### PR TITLE
Switch to microsecond timing and improve benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,12 @@ jobs:
         run: chmod +x build/*
 
       - name: Run benchmarks
-        run: ./build/BenchmarkRunner benchmarks
+        if: "!(github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64')"
+        run: ./build/BenchmarkRunner benchmarks --no-progress
 
-      - name: Save benchmark baseline
+      - name: Run benchmarks and save baseline
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
-        run: |
-          ./build/BenchmarkRunner benchmarks --format=json --output=benchmark-results.json
+        run: ./build/BenchmarkRunner benchmarks --no-progress --format=console --format=json --output=benchmark-results.json
 
       - name: Cache benchmark baseline
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Run benchmarks
-        run: ./build/BenchmarkRunner benchmarks --format=json --output=benchmark-results.json
+        run: ./build/BenchmarkRunner benchmarks --no-progress --format=json --output=benchmark-results.json
 
       - name: Compare benchmarks and comment
         uses: actions/github-script@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const THRESHOLD = 7; // % change considered significant
 
             const current = JSON.parse(fs.readFileSync('benchmark-results.json', 'utf8'));
 
@@ -110,63 +111,125 @@ jobs:
               }
             }
 
-            const flatten = (data) => {
-              const map = {};
-              for (const file of data.files) {
-                for (const bench of file.benchmarks) {
-                  if (!bench.error) {
-                    map[`${bench.suite} > ${bench.name}`] = bench.opsPerSec;
-                  }
-                }
-              }
-              return map;
-            };
+            const fmtOps = (n) => Math.round(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
-            const fmtOps = (n) => {
-              return Math.round(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-            };
-
-            const currentMap = flatten(current);
-
-            let body = '## Benchmark Results\n\n';
-
+            const baselineByFile = {};
             if (baseline) {
-              const baselineMap = flatten(baseline);
-
-              body += '| Benchmark | Base (ops/sec) | PR (ops/sec) | Change |\n';
-              body += '|-----------|---------------|-------------|--------|\n';
-
-              const names = Object.keys(currentMap).sort();
-              for (const name of names) {
-                const ops = currentMap[name];
-                const baseOps = baselineMap[name];
-
-                if (baseOps && baseOps > 0) {
-                  const change = ((ops - baseOps) / baseOps) * 100;
-                  let indicator;
-                  if (change > 2) {
-                    indicator = `🟢 +${change.toFixed(1)}%`;
-                  } else if (change < -2) {
-                    indicator = `🔴 ${change.toFixed(1)}%`;
-                  } else {
-                    indicator = `${change >= 0 ? '+' : ''}${change.toFixed(1)}%`;
-                  }
-                  body += `| ${name} | ${fmtOps(baseOps)} | ${fmtOps(ops)} | ${indicator} |\n`;
-                } else {
-                  body += `| ${name} | — | ${fmtOps(ops)} | 🆕 new |\n`;
+              for (const file of baseline.files) {
+                const map = {};
+                for (const bench of file.benchmarks) {
+                  if (!bench.error) map[`${bench.suite} > ${bench.name}`] = bench.opsPerSec;
                 }
-              }
-            } else {
-              body += '> No baseline benchmark data found for `main`. Comparison skipped.\n\n';
-              body += '| Benchmark | ops/sec |\n';
-              body += '|-----------|--------|\n';
-              const names = Object.keys(currentMap).sort();
-              for (const name of names) {
-                body += `| ${name} | ${fmtOps(currentMap[name])} |\n`;
+                baselineByFile[file.file] = map;
               }
             }
 
-            body += `\n<sub>Measured on ubuntu-latest x64. Results may vary by ±2-3% due to CI environment noise.</sub>`;
+            const fmtAvg = (changes) => {
+              if (changes.length === 0) return '';
+              const avg = changes.reduce((a, b) => a + b, 0) / changes.length;
+              const sign = avg >= 0 ? '+' : '';
+              return ` · avg ${sign}${avg.toFixed(1)}%`;
+            };
+
+            let body = '## Benchmark Results\n\n';
+            let totalBenchmarks = 0;
+            let totalImproved = 0;
+            let totalRegressed = 0;
+            let totalNew = 0;
+            let totalUnchanged = 0;
+            const allChanges = [];
+
+            const fileBlocks = [];
+
+            for (const file of current.files) {
+              const fileName = file.file;
+              const baseMap = baselineByFile[fileName] || {};
+              const hasBaseline = baseline && Object.keys(baseMap).length > 0;
+
+              let fileImproved = 0;
+              let fileRegressed = 0;
+              let fileNew = 0;
+              let fileUnchanged = 0;
+              let fileRows = '';
+              const fileChanges = [];
+
+              const benches = file.benchmarks.filter(b => !b.error);
+              totalBenchmarks += benches.length;
+
+              if (hasBaseline) {
+                fileRows += '| Benchmark | Base (ops/sec) | PR (ops/sec) | Change |\n';
+                fileRows += '|-----------|---------------|-------------|--------|\n';
+
+                for (const bench of benches) {
+                  const key = `${bench.suite} > ${bench.name}`;
+                  const ops = bench.opsPerSec;
+                  const baseOps = baseMap[key];
+
+                  if (baseOps && baseOps > 0) {
+                    const change = ((ops - baseOps) / baseOps) * 100;
+                    fileChanges.push(change);
+                    allChanges.push(change);
+                    let indicator;
+                    if (change > THRESHOLD) {
+                      indicator = `🟢 +${change.toFixed(1)}%`;
+                      fileImproved++;
+                    } else if (change < -THRESHOLD) {
+                      indicator = `🔴 ${change.toFixed(1)}%`;
+                      fileRegressed++;
+                    } else {
+                      indicator = `${change >= 0 ? '+' : ''}${change.toFixed(1)}%`;
+                      fileUnchanged++;
+                    }
+                    fileRows += `| ${bench.name} | ${fmtOps(baseOps)} | ${fmtOps(ops)} | ${indicator} |\n`;
+                  } else {
+                    fileRows += `| ${bench.name} | — | ${fmtOps(ops)} | 🆕 new |\n`;
+                    fileNew++;
+                  }
+                }
+              } else {
+                fileRows += '| Benchmark | ops/sec |\n';
+                fileRows += '|-----------|--------|\n';
+                for (const bench of benches) {
+                  fileRows += `| ${bench.name} | ${fmtOps(bench.opsPerSec)} |\n`;
+                  fileNew++;
+                }
+              }
+
+              totalImproved += fileImproved;
+              totalRegressed += fileRegressed;
+              totalNew += fileNew;
+              totalUnchanged += fileUnchanged;
+
+              const parts = [];
+              if (fileImproved > 0) parts.push(`🟢 ${fileImproved} improved`);
+              if (fileRegressed > 0) parts.push(`🔴 ${fileRegressed} regressed`);
+              if (fileNew > 0) parts.push(`🆕 ${fileNew} new`);
+              if (fileUnchanged > 0) parts.push(`${fileUnchanged} unchanged`);
+              const fileSummary = (parts.length > 0 ? parts.join(', ') : `${benches.length} benchmarks`) + fmtAvg(fileChanges);
+
+              fileBlocks.push({ fileName, fileSummary, fileRows, hasSignificant: fileImproved > 0 || fileRegressed > 0 });
+            }
+
+            // Overall summary
+            const summaryParts = [];
+            summaryParts.push(`**${totalBenchmarks}** benchmarks`);
+            if (totalImproved > 0) summaryParts.push(`🟢 ${totalImproved} improved`);
+            if (totalRegressed > 0) summaryParts.push(`🔴 ${totalRegressed} regressed`);
+            if (totalNew > 0) summaryParts.push(`🆕 ${totalNew} new`);
+            if (totalUnchanged > 0) summaryParts.push(`${totalUnchanged} unchanged`);
+            body += summaryParts.join(' · ') + fmtAvg(allChanges) + '\n\n';
+
+            // File sections as collapsible details
+            for (const block of fileBlocks) {
+              const shortName = block.fileName.replace(/^benchmarks\//, '');
+              const open = block.hasSignificant ? ' open' : '';
+              body += `<details${open}>\n`;
+              body += `<summary><strong>${shortName}</strong> — ${block.fileSummary}</summary>\n\n`;
+              body += block.fileRows;
+              body += `\n</details>\n\n`;
+            }
+
+            body += `<sub>Measured on ubuntu-latest x64. Changes within ±${THRESHOLD}% are considered insignificant.</sub>`;
 
             const marker = '<!-- benchmark-comparison -->';
             body = marker + '\n' + body;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,11 @@ GocciaScript is a subset of ECMAScript 2020 implemented in FreePascal. It provid
 ./build/REPL                                      # Start interactive REPL
 ./build/TestRunner tests/                         # Run all JavaScript tests
 ./build/TestRunner tests/language/expressions/    # Run a test category
-./build/BenchmarkRunner benchmarks/                                # Run all benchmarks
-./build/BenchmarkRunner benchmarks/fibonacci.js                    # Run a specific benchmark
-./build/BenchmarkRunner benchmarks --format=json --output=out.json # Export as JSON
-./build/BenchmarkRunner benchmarks --format=csv --output=out.csv   # Export as CSV
+./build/BenchmarkRunner benchmarks/                                               # Run all benchmarks
+./build/BenchmarkRunner benchmarks/fibonacci.js                                   # Run a specific benchmark
+./build/BenchmarkRunner benchmarks --format=json --output=out.json                # Export as JSON
+./build/BenchmarkRunner benchmarks --format=console --format=json --output=out.json # Console + JSON
+./build/BenchmarkRunner benchmarks --no-progress                                  # Suppress progress (CI)
 ```
 
 ### Compile and Run (Common Workflows)
@@ -236,7 +237,7 @@ DefaultGlobals = [ggConsole, ggMath, ggGlobalObject, ggGlobalArray,
 ```
 
 The TestRunner adds `ggTestAssertions` for the test framework (`describe`, `test`, `expect`).
-The BenchmarkRunner adds `ggBenchmark` for the benchmark framework (`suite`, `bench`, `runBenchmarks`). It supports `--format=console|text|csv|json` and `--output=file` for exporting results. Benchmark calibration parameters are configurable via environment variables (`GOCCIA_BENCH_CALIBRATION_MS`, `GOCCIA_BENCH_ROUNDS`, etc.).
+The BenchmarkRunner adds `ggBenchmark` for the benchmark framework (`suite`, `bench`, `runBenchmarks`). It supports multiple `--format=console|text|csv|json` flags in a single command (each optionally followed by `--output=file`), `--no-progress` for CI builds, and benchmark calibration via environment variables (`GOCCIA_BENCH_CALIBRATION_MS`, `GOCCIA_BENCH_ROUNDS`, etc.).
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | Evaluator | `Goccia.Evaluator.pas` | Pure AST evaluation (+ sub-modules) |
 | Scope | `Goccia.Scope.pas` | Lexical scoping, variable bindings, TDZ, VMT-based chain-walking |
 | Keywords | `Goccia.Keywords.pas` | Centralized JavaScript keyword string constants |
+| Timing Utilities | `TimingUtils.pas` | Cross-platform microsecond timing (`GetMicroseconds`) and duration formatting (`FormatDuration`) |
 | Garbage Collector | `Goccia.GarbageCollector.pas` | Mark-and-sweep memory management for runtime values |
 
 ## Development Workflow

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -3,29 +3,19 @@ program ScriptLoader;
 {$I Goccia.inc}
 
 uses
-  Classes, SysUtils, Generics.Collections, Goccia.Values.Primitives, Goccia.Engine, Goccia.Error, FileUtils in 'units/FileUtils.pas';
-
-function RunGocciaScript(const FileName: string): TGocciaValue;
-var
-  Source: TStringList;
-begin
-  Source := TStringList.Create;
-  try
-    Source.LoadFromFile(FileName);
-    Result := TGocciaEngine.RunScriptFromStringList(Source, FileName, TGocciaEngine.DefaultGlobals);
-  finally
-    Source.Free;
-  end;
-end;
+  Classes, SysUtils, Generics.Collections, Goccia.Values.Primitives, Goccia.Engine, TimingUtils, Goccia.Error, FileUtils in 'units/FileUtils.pas';
 
 procedure RunScriptFromFile(const FileName: string);
 var
-  ScriptResult: TGocciaValue;
+  ScriptResult: TGocciaScriptResult;
 begin
   try
     WriteLn('Running script: ', FileName);
-    ScriptResult := RunGocciaScript(FileName);
-    Writeln('Result: ', ScriptResult.ToStringLiteral.Value);
+    ScriptResult := TGocciaEngine.RunScriptFromFile(FileName, TGocciaEngine.DefaultGlobals);
+    WriteLn(SysUtils.Format('  Lex: %s | Parse: %s | Execute: %s | Total: %s',
+      [FormatDuration(ScriptResult.LexTimeMicroseconds), FormatDuration(ScriptResult.ParseTimeMicroseconds),
+       FormatDuration(ScriptResult.ExecuteTimeMicroseconds), FormatDuration(ScriptResult.TotalTimeMicroseconds)]));
+    Writeln('Result: ', ScriptResult.Result.ToStringLiteral.Value);
   except
     on E: Exception do
     begin

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -71,6 +71,12 @@ begin
       begin
         WriteLn('Fatal error: ', E.Message);
         Result.TestResult := ScriptResult;
+        Result.Timing.Result := nil;
+        Result.Timing.LexTimeMicroseconds := 0;
+        Result.Timing.ParseTimeMicroseconds := 0;
+        Result.Timing.ExecuteTimeMicroseconds := 0;
+        Result.Timing.TotalTimeMicroseconds := 0;
+        Result.Timing.FileName := '';
       end;
     end;
   finally

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -33,8 +33,24 @@ begin
   ScriptResult.AssignProperty('failedTests', TGocciaArrayValue.Create);
 
   Source := TStringList.Create;
-  try  
-    Source.LoadFromFile(FileName);
+  try
+    try
+      Source.LoadFromFile(FileName);
+    except
+      on E: EStreamError do
+      begin
+        WriteLn('Error loading test file: ', E.Message);
+        Result.TestResult := ScriptResult;
+        Result.Timing.Result := nil;
+        Result.Timing.LexTimeMicroseconds := 0;
+        Result.Timing.ParseTimeMicroseconds := 0;
+        Result.Timing.ExecuteTimeMicroseconds := 0;
+        Result.Timing.TotalTimeMicroseconds := 0;
+        Result.Timing.FileName := '';
+        Exit;
+      end;
+    end;
+
     Source.Add('runTests({ exitOnFirstFailure: false, showTestResults: false, silent: true });');
 
     try
@@ -80,7 +96,7 @@ begin
       end;
     end;
   finally
-    Source.Free; 
+    Source.Free;
   end;
 end;
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,15 @@ A recursive descent parser that builds an AST from the token stream. Implements:
 
 A dependency-free unit that centralizes all 32 JavaScript keyword string constants (`KEYWORD_THIS`, `KEYWORD_SUPER`, `KEYWORD_UNDEFINED`, etc.). Used by the evaluator, scope, and other units to avoid hardcoded string literals and ensure consistent keyword references. Has no `uses` clause dependencies, so it can be imported by any unit without introducing circular references.
 
+### Timing Utilities (`TimingUtils.pas`)
+
+A cross-platform microsecond-precision timing unit providing two functions:
+
+- **`GetMicroseconds`** — Returns the current timestamp in microseconds. Uses `fpGetTimeOfDay` on Unix (native μs resolution) and `QueryPerformanceCounter`/`QueryPerformanceFrequency` on Windows (sub-μs hardware counter, converted to μs). Falls back to `GetTickCount64 * 1000` on other platforms.
+- **`FormatDuration(Microseconds)`** — Auto-formats a duration with two-decimal precision: values below 0.5ms display as `μs` (e.g., `287μs`), values up to 10s as `ms` (e.g., `1.39ms`), and larger values as `s` (e.g., `12.34s`).
+
+Used by the engine (lex/parse/execute phase timing in `TGocciaScriptResult`), the test assertions framework (test execution duration), and the benchmark runner (calibration and measurement). Has no Goccia-specific dependencies, making it reusable outside the engine.
+
 ### AST (`Goccia.AST.Node.pas`, `Goccia.AST.Expressions.pas`, `Goccia.AST.Statements.pas`)
 
 The Abstract Syntax Tree is structured into three layers:

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -212,7 +212,7 @@ Runs on **ubuntu-latest x64 only** (single runner, no matrix).
 
 **`test`** (needs build) — Runs all JavaScript tests. No native tests.
 
-**`benchmark`** (needs build) — Restores the cached benchmark baseline from main, runs all benchmarks with JSON output, and posts a comparison comment on the PR with per-benchmark percentage changes (green for improvements > 2%, red for regressions > 2%). If no baseline exists, shows results without percentages.
+**`benchmark`** (needs build) — Restores the cached benchmark baseline from main, runs all benchmarks with JSON output, and posts a collapsible comparison comment on the PR grouped by file. Each file section shows per-benchmark ops/sec with percentage changes (🟢 for improvements > 7%, 🔴 for regressions > 7%), plus a per-file and overall average percentage. Files with significant changes are auto-expanded. If no baseline exists, shows results without comparison.
 
 FPC is only installed once per platform in the `build` job. Test, benchmark, and example jobs run in parallel, using pre-built binaries.
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -32,7 +32,7 @@ The build script supports two modes via `--dev` (default) and `--prod` flags:
 ./build.pas --prod    # Production build of all components
 ```
 
-Builds all components in order: tests, loader, testrunner, benchmarkrunner, repl.
+Runs a clean (removes stale `.ppu`, `.o`, `.res` from `build/`), then builds all components in order: tests, loader, testrunner, benchmarkrunner, repl.
 
 ### Build Specific Components
 
@@ -49,6 +49,15 @@ Multiple components can be specified:
 ```bash
 ./build.pas loader repl
 ```
+
+### Clean Build Artifacts
+
+```bash
+./build.pas clean              # Remove stale .ppu, .o, .res from build/
+./build.pas clean loader       # Clean then build loader
+```
+
+A full build (no specific targets) automatically cleans first.
 
 ### Compile and Run
 
@@ -95,7 +104,7 @@ These path flags are shared by both build modes. Mode-specific flags are added b
 |------|----------------------|----------------------|
 | Optimization | `-O-` (disabled) | `-O4` (aggressive) |
 | Debug info | `-gw -godwarfsets` (DWARF) | — (none) |
-| Heap trace | `-gh -gl` (leak detection) | — |
+| Line info | `-gl` (debug line numbers) | — |
 | Stack checking | `-Ct` | — |
 | Range checking | `-Cr` | — |
 | Assertions | `-Sa` | — |
@@ -149,6 +158,7 @@ GocciaScript/
 ├── BenchmarkRunner.dpr   # Benchmark runner program source
 ├── units/
 │   ├── Goccia.inc     # Shared compiler directives
+│   ├── TimingUtils.pas # Cross-platform microsecond timing and duration formatting
 │   ├── *.pas          # All unit source files
 │   └── *.Test.pas     # Pascal unit test programs
 └── build/             # All output (gitignored)

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -75,13 +75,13 @@ The `TStringList` is passed by reference — update its contents and call `Execu
 
 ```pascal
 var
-  Timing: TGocciaTimingResult;
+  ScriptResult: TGocciaScriptResult;
 begin
-  Timing := TGocciaEngine.RunScriptWithTiming(Source, 'bench.js', TGocciaEngine.DefaultGlobals);
-  WriteLn('Lex: ', Timing.LexTimeMs, 'ms');
-  WriteLn('Parse: ', Timing.ParseTimeMs, 'ms');
-  WriteLn('Execute: ', Timing.ExecuteTimeMs, 'ms');
-  WriteLn('Total: ', Timing.TotalTimeMs, 'ms');
+  ScriptResult := TGocciaEngine.RunScript(Source, 'bench.js', TGocciaEngine.DefaultGlobals);
+  WriteLn('Lex: ', FormatDuration(ScriptResult.LexTimeMicroseconds));
+  WriteLn('Parse: ', FormatDuration(ScriptResult.ParseTimeMicroseconds));
+  WriteLn('Execute: ', FormatDuration(ScriptResult.ExecuteTimeMicroseconds));
+  WriteLn('Total: ', FormatDuration(ScriptResult.TotalTimeMicroseconds));
 end;
 ```
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -34,9 +34,7 @@ These are convenience methods that create an engine, execute, and clean up in a 
 | `RunScriptFromFile(FileName, Globals)` | Execute a file with custom globals |
 | `RunScriptFromStringList(Source, FileName)` | Execute from a `TStringList` with default globals |
 | `RunScriptFromStringList(Source, FileName, Globals)` | Execute from a `TStringList` with custom globals |
-| `RunScriptWithTiming(Source, FileName, Globals)` | Execute and return timing breakdown |
-
-All methods return `TGocciaValue` — the result of the last expression evaluated.
+All methods return `TGocciaScriptResult` — a record containing the result value, per-phase timing (in microseconds), and the filename.
 
 ### Instance Usage (Long-Lived Engine)
 
@@ -71,9 +69,11 @@ The `TStringList` is passed by reference — update its contents and call `Execu
 
 ### Timing
 
-`ExecuteWithTiming` and `RunScriptWithTiming` return a `TGocciaTimingResult` record with per-phase timing:
+All `RunScript*` methods and the `Execute` method return a `TGocciaScriptResult` record that includes microsecond-precision timing for each pipeline phase:
 
 ```pascal
+uses Goccia.Engine, TimingUtils;
+
 var
   ScriptResult: TGocciaScriptResult;
 begin
@@ -84,6 +84,10 @@ begin
   WriteLn('Total: ', FormatDuration(ScriptResult.TotalTimeMicroseconds));
 end;
 ```
+
+`FormatDuration` (from `TimingUtils`) automatically selects the appropriate unit: `μs` for values below 0.5ms, `ms` with two decimal places for values up to 10s, and `s` above that.
+
+Timing uses `fpGetTimeOfDay` on Unix (native microsecond resolution) and `QueryPerformanceCounter` on Windows (sub-microsecond hardware counter).
 
 ## Controlling Built-ins
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -488,3 +488,21 @@ build → test       → artifacts
 **`artifacts`** (needs test + benchmark, push only) — Uploads release binaries after both test and benchmark pass.
 
 The `test` and `benchmark` jobs run in parallel since they both depend only on `build`. FPC is installed once per platform, not repeated. Both run across Linux, macOS, and Windows (x64 + ARM where applicable), so platform-specific regressions are caught in both tests and benchmarks.
+
+### PR Workflow (`.github/workflows/pr.yml`)
+
+Runs on pull requests targeting `main`, on **ubuntu-latest x64 only** (single runner, no matrix):
+
+```
+build → test
+      → benchmark → PR comment
+```
+
+**`benchmark`** — Restores the cached benchmark baseline from main, runs all benchmarks with JSON output, and posts a collapsible comparison comment on the PR:
+
+- Results are **grouped by file**, each in a collapsible `<details>` section
+- Files with significant changes (improvements or regressions) are auto-expanded
+- Each file summary shows the count of improved/regressed/unchanged benchmarks and an **average percentage change**
+- The **overall PR summary** at the top shows totals across all files with an average percentage
+- Changes within **±7%** are considered insignificant (shown without color indicators) — this threshold accounts for CI environment noise during active development
+- 🟢 marks improvements > 7%, 🔴 marks regressions > 7%, 🆕 marks new benchmarks with no baseline

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -419,11 +419,11 @@ The `BenchmarkRunner` program:
 2. Scans the provided path for `.js` files.
 3. For each file, creates a `TGocciaEngine` with `DefaultGlobals + [ggBenchmark]`.
 4. Loads the source and appends a `runBenchmarks()` call.
-5. Executes the script via `ExecuteWithTiming` — which measures lex, parse, and execute phases separately.
+5. Executes the script — the engine measures lex, parse, and execute phases separately with microsecond precision via `TimingUtils.GetMicroseconds`.
 6. `suite()` calls execute immediately, registering `bench()` entries.
 7. `runBenchmarks()` runs each registered benchmark:
    - **Warmup:** Configurable iterations to stabilize (default 3).
-   - **Calibrate:** Scales batch size until it runs for at least the target calibration time (default 300ms). Uses microsecond-resolution timing (`fpGetTimeOfDay`) for precision.
+   - **Calibrate:** Scales batch size until it runs for at least the target calibration time (default 300ms). Uses microsecond-resolution timing via `TimingUtils` (`fpGetTimeOfDay` on Unix, `QueryPerformanceCounter` on Windows).
    - **Measure:** Runs multiple measurement rounds (default 3), computes the coefficient of variation (CV%) from the unsorted ops/sec data, then reports the median values.
 8. Collects all results into a `TBenchmarkReporter`, which renders the chosen output format.
 
@@ -454,7 +454,7 @@ The `BenchmarkRunner` program:
 Console format (default):
 
 ```
-  Lex: 0ms | Parse: 0ms | Execute: 7207ms
+  Lex: 287μs | Parse: 0.58ms | Execute: 7207.31ms | Total: 7208.18ms
 
   fibonacci
     recursive fib(15)                        201 ops/sec  ± 0.42%      4.9843 ms/op  (60 iterations)
@@ -463,8 +463,10 @@ Console format (default):
 
 Benchmark Summary
   Total benchmarks: 3
-  Total duration: 7.2s
+  Total duration: 7.21s
 ```
+
+Durations are auto-formatted by `FormatDuration` from `TimingUtils`: values below 0.5ms display as `μs`, values up to 10s as `ms` with two decimal places, and larger values as `s`.
 
 The `±X.XX%` column shows the coefficient of variation across measurement rounds. It is omitted when variance is zero (e.g., with a single measurement round).
 

--- a/units/FileUtils.pas
+++ b/units/FileUtils.pas
@@ -44,6 +44,7 @@ begin
     until FindNext(SearchRec) <> 0;
   end;
   FindClose(SearchRec);
+  Files.Sort;
   Result := Files;
 end;
 

--- a/units/Goccia.Builtins.Benchmark.pas
+++ b/units/Goccia.Builtins.Benchmark.pas
@@ -17,11 +17,13 @@ uses
   Generics.Collections,
   Classes,
   SysUtils,
-  {$IFDEF UNIX}Unix,{$ENDIF}
+  TimingUtils,
   Math;
 
 type
   TGocciaBenchmark = class;
+
+  TBenchmarkProgressEvent = procedure(const SuiteName, BenchName: string; Index, Total: Integer) of object;
 
   TBenchmarkCase = class
   public
@@ -46,6 +48,7 @@ type
     FRegisteredSuites: TStringList;
     FRegisteredBenchmarks: TObjectList<TBenchmarkCase>;
     FCurrentSuiteName: string;
+    FOnProgress: TBenchmarkProgressEvent;
 
     function RunSingleBenchmark(BenchCase: TBenchmarkCase): TBenchmarkResult;
     function CalibrateIterations(BenchCase: TBenchmarkCase): Int64;
@@ -56,6 +59,8 @@ type
     function Suite(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
     function Bench(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
     function RunBenchmarks(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
+
+    property OnProgress: TBenchmarkProgressEvent read FOnProgress write FOnProgress;
   end;
 
 implementation
@@ -182,54 +187,40 @@ begin
   FRegisteredBenchmarks.Add(TBenchmarkCase.Create(BenchName, BenchFunction, FCurrentSuiteName));
 end;
 
-function GetMicroseconds: Int64;
-{$IFDEF UNIX}
-var
-  tv: TTimeVal;
-begin
-  fpGetTimeOfDay(@tv, nil);
-  Result := Int64(tv.tv_sec) * 1000000 + Int64(tv.tv_usec);
-end;
-{$ELSE}
-begin
-  Result := GetTickCount64 * 1000;
-end;
-{$ENDIF}
-
 function TGocciaBenchmark.CalibrateIterations(BenchCase: TBenchmarkCase): Int64;
 var
   EmptyArgs: TGocciaArgumentsCollection;
   BatchSize: Int64;
-  StartUs, ElapsedUs, TargetUs: Int64;
+  StartMicroseconds, ElapsedMicroseconds, TargetMicroseconds: Int64;
   I: Int64;
 begin
-  TargetUs := Int64(MIN_CALIBRATION_MS) * 1000;
+  TargetMicroseconds := Int64(MIN_CALIBRATION_MS) * 1000;
   BatchSize := CALIBRATION_BATCH;
 
   EmptyArgs := TGocciaArgumentsCollection.Create;
   try
     while True do
     begin
-      StartUs := GetMicroseconds;
+      StartMicroseconds := GetMicroseconds;
       I := 0;
       while I < BatchSize do
       begin
         BenchCase.BenchFunction.Call(EmptyArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
         Inc(I);
       end;
-      ElapsedUs := GetMicroseconds - StartUs;
+      ElapsedMicroseconds := GetMicroseconds - StartMicroseconds;
 
-      if ElapsedUs >= TargetUs then
+      if ElapsedMicroseconds >= TargetMicroseconds then
       begin
         Result := (BatchSize div 10) * 10;
         if Result < 10 then Result := 10;
         Exit;
       end;
 
-      if ElapsedUs = 0 then
+      if ElapsedMicroseconds = 0 then
         BatchSize := BatchSize * 10
       else
-        BatchSize := BatchSize * (TargetUs div ElapsedUs + 1);
+        BatchSize := BatchSize * (TargetMicroseconds div ElapsedMicroseconds + 1);
 
       if BatchSize > 10000000 then
       begin
@@ -246,7 +237,7 @@ function TGocciaBenchmark.RunSingleBenchmark(BenchCase: TBenchmarkCase): TBenchm
 var
   EmptyArgs: TGocciaArgumentsCollection;
   Iterations: Int64;
-  StartUs, RoundUs: Int64;
+  StartMicroseconds, RoundMicroseconds: Int64;
   I: Int64;
   Round, J, K: Integer;
   OpsRounds: array[0..4] of Double;   // Max 5 rounds
@@ -271,19 +262,19 @@ begin
       if Assigned(TGocciaGC.Instance) then
         TGocciaGC.Instance.Collect;
 
-      StartUs := GetMicroseconds;
+      StartMicroseconds := GetMicroseconds;
       I := 0;
       while I < Iterations do
       begin
         BenchCase.BenchFunction.Call(EmptyArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
         Inc(I);
       end;
-      RoundUs := GetMicroseconds - StartUs;
+      RoundMicroseconds := GetMicroseconds - StartMicroseconds;
 
-      if RoundUs > 0 then
+      if RoundMicroseconds > 0 then
       begin
-        OpsRounds[Round] := (Iterations / RoundUs) * 1000000;
-        MeanRounds[Round] := (RoundUs / 1000) / Iterations;
+        OpsRounds[Round] := (Iterations / RoundMicroseconds) * 1000000;
+        MeanRounds[Round] := (RoundMicroseconds / 1000) / Iterations;
       end
       else
       begin
@@ -350,9 +341,9 @@ var
   ResultObj: TGocciaObjectValue;
   ResultsArray: TGocciaArrayValue;
   SingleResult: TGocciaObjectValue;
-  StartUs, TotalDurationMs: Int64;
+  StartMicroseconds, TotalDurationMicroseconds: Int64;
 begin
-  StartUs := GetMicroseconds;
+  StartMicroseconds := GetMicroseconds;
 
   // Protect ALL benchmark functions from GC before running any benchmarks.
   // These are held by Pascal TBenchmarkCase objects, not in GocciaScript scopes,
@@ -370,6 +361,9 @@ begin
     for I := 0 to FRegisteredBenchmarks.Count - 1 do
     begin
       BenchCase := FRegisteredBenchmarks[I];
+
+      if Assigned(FOnProgress) then
+        FOnProgress(BenchCase.SuiteName, BenchCase.Name, I + 1, FRegisteredBenchmarks.Count);
 
       try
         BenchResult := RunSingleBenchmark(BenchCase);
@@ -397,12 +391,12 @@ begin
       end;
     end;
 
-    TotalDurationMs := (GetMicroseconds - StartUs) div 1000;
+    TotalDurationMicroseconds := GetMicroseconds - StartMicroseconds;
 
     ResultObj := TGocciaObjectValue.Create;
     ResultObj.AssignProperty('totalBenchmarks', TGocciaNumberLiteralValue.Create(FRegisteredBenchmarks.Count));
     ResultObj.AssignProperty('results', ResultsArray);
-    ResultObj.AssignProperty('duration', TGocciaNumberLiteralValue.Create(TotalDurationMs));
+    ResultObj.AssignProperty('durationMicroseconds', TGocciaNumberLiteralValue.Create(TotalDurationMicroseconds));
 
     Result := ResultObj;
   finally

--- a/units/Goccia.Builtins.TestAssertions.pas
+++ b/units/Goccia.Builtins.TestAssertions.pas
@@ -126,7 +126,8 @@ implementation
 
 uses
   Goccia.Values.ClassValue, Goccia.Evaluator, Goccia.Evaluator.Comparison,
-  Goccia.Values.ObjectPropertyDescriptor, Goccia.Values.Error, Goccia.Values.ClassHelper;
+  Goccia.Values.ObjectPropertyDescriptor, Goccia.Values.Error, Goccia.Values.ClassHelper,
+  TimingUtils;
 
 { TTestSuite }
 
@@ -1245,7 +1246,7 @@ begin
   // Reset test statistics and clear any previously registered tests from describe blocks
   ResetTestStats;
 
-  StartTime := GetTickCount64;
+  StartTime := GetMicroseconds;
 
   // Clear tests that were registered from previous describe executions
   // Keep standalone tests that were registered during script execution
@@ -1405,7 +1406,7 @@ begin
   ResultObj.AssignProperty('failed', TGocciaNumberLiteralValue.Create(FTestStats.FailedTests));
   ResultObj.AssignProperty('skipped', TGocciaNumberLiteralValue.Create(FTestStats.SkippedTests));
   ResultObj.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(FTestStats.TotalAssertionCount));
-  ResultObj.AssignProperty('duration', TGocciaNumberLiteralValue.Create(GetTickCount64 - StartTime));
+  ResultObj.AssignProperty('duration', TGocciaNumberLiteralValue.Create(GetMicroseconds - StartTime));
   ResultObj.AssignProperty('failedTests', FailedTestDetailsArray);
   ResultObj.AssignProperty('summary', TGocciaStringLiteralValue.Create(Summary));
 

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -33,14 +33,16 @@ type
 
   TGocciaGlobalBuiltins = set of TGocciaGlobalBuiltin;
 
-  TGocciaTimingResult = record
+  TGocciaScriptResult = record
     Result: TGocciaValue;
-    LexTimeMs: Int64;
-    ParseTimeMs: Int64;
-    ExecuteTimeMs: Int64;
-    TotalTimeMs: Int64;
+    LexTimeMicroseconds: Int64;
+    ParseTimeMicroseconds: Int64;
+    ExecuteTimeMicroseconds: Int64;
+    TotalTimeMicroseconds: Int64;
+    FileName: string;
   end;
 
+type
   TGocciaEngine = class
   public
     const DefaultGlobals: TGocciaGlobalBuiltins = [ggConsole, ggMath, ggGlobalObject, ggGlobalArray, ggGlobalNumber, ggPromise, ggJSON, ggSymbol, ggSet, ggMap];
@@ -72,17 +74,15 @@ type
     constructor Create(const AFileName: string; ASourceLines: TStringList; AGlobals: TGocciaGlobalBuiltins);
     destructor Destroy; override;
 
-    function Execute: TGocciaValue;
-    function ExecuteWithTiming: TGocciaTimingResult;
+    function Execute: TGocciaScriptResult;
     function ExecuteProgram(AProgram: TGocciaProgram): TGocciaValue;
 
-    class function RunScript(const Source: string; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaValue; overload;
-    class function RunScript(const Source: string; const FileName: string = 'inline.goccia'): TGocciaValue; overload;
-    class function RunScriptFromFile(const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaValue; overload;
-    class function RunScriptFromFile(const FileName: string): TGocciaValue; overload;
-    class function RunScriptFromStringList(const Source: TStringList; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaValue; overload;
-    class function RunScriptFromStringList(const Source: TStringList; const FileName: string): TGocciaValue; overload;
-    class function RunScriptWithTiming(const Source: TStringList; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaTimingResult;
+    class function RunScript(const Source: string; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaScriptResult; overload;
+    class function RunScript(const Source: string; const FileName: string = 'inline.goccia'): TGocciaScriptResult; overload;
+    class function RunScriptFromFile(const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaScriptResult; overload;
+    class function RunScriptFromFile(const FileName: string): TGocciaScriptResult; overload;
+    class function RunScriptFromStringList(const Source: TStringList; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaScriptResult; overload;
+    class function RunScriptFromStringList(const Source: TStringList; const FileName: string): TGocciaScriptResult; overload;
 
     property Interpreter: TGocciaInterpreter read FInterpreter;
     property BuiltinConsole: TGocciaConsole read FBuiltinConsole;
@@ -101,6 +101,9 @@ type
 
 
 implementation
+
+uses
+  TimingUtils, Math;
 
 constructor TGocciaEngine.Create(const AFileName: string; ASourceLines: TStringList; AGlobals: TGocciaGlobalBuiltins);
 var
@@ -261,34 +264,7 @@ begin
   FInterpreter.GlobalScope.DefineLexicalBinding('Function', FunctionConstructor, dtConst);
 end;
 
-function TGocciaEngine.Execute: TGocciaValue;
-var
-  Lexer: TGocciaLexer;
-  Parser: TGocciaParser;
-  ProgramNode: TGocciaProgram;
-  Tokens: TObjectList<TGocciaToken>;
-begin
-  Lexer := TGocciaLexer.Create(FSourceLines.Text, FFileName);
-  try
-    Tokens := Lexer.ScanTokens;
-    Parser := TGocciaParser.Create(Tokens, FFileName, Lexer.SourceLines);
-    try
-      ProgramNode := Parser.Parse;
-      try
-        Result := FInterpreter.Execute(ProgramNode);
-      finally
-        ProgramNode.Free;
-      end;
-    finally
-      Parser.Free;
-      // Don't free Tokens - the lexer owns them and will free them
-    end;
-  finally
-    Lexer.Free;
-  end;
-end;
-
-function TGocciaEngine.ExecuteWithTiming: TGocciaTimingResult;
+function TGocciaEngine.Execute: TGocciaScriptResult;
 var
   Lexer: TGocciaLexer;
   Parser: TGocciaParser;
@@ -296,25 +272,26 @@ var
   Tokens: TObjectList<TGocciaToken>;
   StartTime, LexEnd, ParseEnd, ExecEnd: Int64;
 begin
-  StartTime := GetTickCount64;
+  Result.FileName := FFileName;
+  StartTime := GetMicroseconds;
 
   Lexer := TGocciaLexer.Create(FSourceLines.Text, FFileName);
   try
     Tokens := Lexer.ScanTokens;
-    LexEnd := GetTickCount64;
-    Result.LexTimeMs := LexEnd - StartTime;
+    LexEnd := GetMicroseconds;
+    Result.LexTimeMicroseconds := LexEnd - StartTime;
 
     Parser := TGocciaParser.Create(Tokens, FFileName, Lexer.SourceLines);
     try
       ProgramNode := Parser.Parse;
-      ParseEnd := GetTickCount64;
-      Result.ParseTimeMs := ParseEnd - LexEnd;
+      ParseEnd := GetMicroseconds;
+      Result.ParseTimeMicroseconds := ParseEnd - LexEnd;
 
       try
         Result.Result := FInterpreter.Execute(ProgramNode);
-        ExecEnd := GetTickCount64;
-        Result.ExecuteTimeMs := ExecEnd - ParseEnd;
-        Result.TotalTimeMs := ExecEnd - StartTime;
+        ExecEnd := GetMicroseconds;
+        Result.ExecuteTimeMicroseconds := ExecEnd - ParseEnd;
+        Result.TotalTimeMicroseconds := ExecEnd - StartTime;
       finally
         ProgramNode.Free;
       end;
@@ -331,7 +308,7 @@ begin
   Result := FInterpreter.Execute(AProgram);
 end;
 
-class function TGocciaEngine.RunScript(const Source: string; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaValue;
+class function TGocciaEngine.RunScript(const Source: string; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaScriptResult;
 var
   SourceList: TStringList;
 begin
@@ -344,12 +321,12 @@ begin
   end;
 end;
 
-class function TGocciaEngine.RunScript(const Source: string; const FileName: string): TGocciaValue;
+class function TGocciaEngine.RunScript(const Source: string; const FileName: string): TGocciaScriptResult;
 begin
   Result := RunScript(Source, FileName, TGocciaEngine.DefaultGlobals);
 end;
 
-class function TGocciaEngine.RunScriptFromFile(const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaValue;
+class function TGocciaEngine.RunScriptFromFile(const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaScriptResult;
 var
   Source: TStringList;
 begin
@@ -362,12 +339,12 @@ begin
   end;
 end;
 
-class function TGocciaEngine.RunScriptFromFile(const FileName: string): TGocciaValue;
+class function TGocciaEngine.RunScriptFromFile(const FileName: string): TGocciaScriptResult;
 begin
   Result := RunScriptFromFile(FileName, TGocciaEngine.DefaultGlobals);
 end;
 
-class function TGocciaEngine.RunScriptFromStringList(const Source: TStringList; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaValue;
+class function TGocciaEngine.RunScriptFromStringList(const Source: TStringList; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaScriptResult;
 var
   Engine: TGocciaEngine;
 begin
@@ -379,21 +356,9 @@ begin
   end;
 end;
 
-class function TGocciaEngine.RunScriptFromStringList(const Source: TStringList; const FileName: string): TGocciaValue;
+class function TGocciaEngine.RunScriptFromStringList(const Source: TStringList; const FileName: string): TGocciaScriptResult;
 begin
   Result := RunScriptFromStringList(Source, FileName, TGocciaEngine.DefaultGlobals);
-end;
-
-class function TGocciaEngine.RunScriptWithTiming(const Source: TStringList; const FileName: string; AGlobals: TGocciaGlobalBuiltins): TGocciaTimingResult;
-var
-  Engine: TGocciaEngine;
-begin
-  Engine := TGocciaEngine.Create(FileName, Source, AGlobals);
-  try
-    Result := Engine.ExecuteWithTiming;
-  finally
-    Engine.Free;
-  end;
 end;
 
 procedure TGocciaEngine.ThrowError(const Message: string; Line, Column: Integer);

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -103,7 +103,7 @@ type
 implementation
 
 uses
-  TimingUtils, Math;
+  TimingUtils;
 
 constructor TGocciaEngine.Create(const AFileName: string; ASourceLines: TStringList; AGlobals: TGocciaGlobalBuiltins);
 var

--- a/units/TimingUtils.pas
+++ b/units/TimingUtils.pas
@@ -30,10 +30,12 @@ end;
 {$ELSE}
 {$IFDEF WINDOWS}
 var
-  Counter: Int64;
+  Counter, Whole, Remainder: Int64;
 begin
   QueryPerformanceCounter(Counter);
-  Result := (Counter * 1000000) div QPCFrequency;
+  Whole := Counter div QPCFrequency;
+  Remainder := Counter mod QPCFrequency;
+  Result := Whole * 1000000 + (Remainder * 1000000) div QPCFrequency;
 end;
 {$ELSE}
 begin

--- a/units/TimingUtils.pas
+++ b/units/TimingUtils.pas
@@ -1,0 +1,65 @@
+unit TimingUtils;
+
+{$I Goccia.inc}
+
+interface
+
+function GetMicroseconds: Int64;
+function FormatDuration(Microseconds: Int64): string;
+
+implementation
+
+uses
+  SysUtils
+  {$IFDEF UNIX}, Unix{$ENDIF}
+  {$IFDEF WINDOWS}, Windows{$ENDIF};
+
+{$IFDEF WINDOWS}
+var
+  QPCFrequency: Int64;
+{$ENDIF}
+
+function GetMicroseconds: Int64;
+{$IFDEF UNIX}
+var
+  tv: TTimeVal;
+begin
+  fpGetTimeOfDay(@tv, nil);
+  Result := Int64(tv.tv_sec) * 1000000 + Int64(tv.tv_usec);
+end;
+{$ELSE}
+{$IFDEF WINDOWS}
+var
+  Counter: Int64;
+begin
+  QueryPerformanceCounter(Counter);
+  Result := (Counter * 1000000) div QPCFrequency;
+end;
+{$ELSE}
+begin
+  Result := GetTickCount64 * 1000;
+end;
+{$ENDIF}
+{$ENDIF}
+
+function FormatDuration(Microseconds: Int64): string;
+var
+  Ms: Double;
+  S: Double;
+begin
+  Ms := Microseconds / 1000.0;
+  S := Ms / 1000.0;
+  if S >= 10.0 then
+    Result := SysUtils.Format('%.2fs', [S])
+  else if Ms >= 0.5 then
+    Result := SysUtils.Format('%.2fms', [Ms])
+  else
+    Result := SysUtils.Format('%d' + #$C2#$B5 + 's', [Microseconds]);
+end;
+
+{$IFDEF WINDOWS}
+initialization
+  QueryPerformanceFrequency(QPCFrequency);
+{$ENDIF}
+
+end.


### PR DESCRIPTION
Replace millisecond timing with microseconds across the engine and tooling, adding a new TimingUtils unit (GetMicroseconds, FormatDuration). TGocciaEngine now returns TGocciaScriptResult with microsecond timing fields; callers (BenchmarkRunner, TestRunner, REPL, ScriptLoader, reporter, docs) updated to use and display the new timings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution API (`TGocciaEngine.Execute`/`RunScript*`) and timing plumbing across runners and built-ins; behavior should be unchanged but signature/format changes could break integrations or CI benchmarking output.
> 
> **Overview**
> Switches the engine’s public execution API from returning a raw `TGocciaValue` to returning `TGocciaScriptResult` with **microsecond-precision** phase timings, backed by a new cross-platform `TimingUtils` (`GetMicroseconds`, `FormatDuration`). All CLI tools (`ScriptLoader`, `REPL`, `TestRunner`, `BenchmarkRunner`) and built-ins that report duration are updated to use the new result record and display formatted durations.
> 
> Upgrades benchmarking UX and CI integration: `BenchmarkRunner` gains `--no-progress`, supports multiple `--format` outputs in one run, emits microsecond timing fields in JSON, and sorts discovered benchmark files deterministically. PR benchmarking comments are revamped to group results by file with collapsible sections, a ±7% significance threshold, and overall/per-file summaries; `ci.yml`/`pr.yml` are updated to use `--no-progress` and to save a main-branch JSON baseline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d93cb37c8f1a106a900f719cb9262de01e8b8e54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->