### PR TITLE
Add `queueMicrotask` functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | Scope | `Goccia.Scope.pas` | Lexical scoping, variable bindings, TDZ, VMT-based chain-walking |
 | Keywords | `Goccia.Keywords.pas` | Centralized JavaScript keyword string constants |
 | Timing Utilities | `TimingUtils.pas` | Cross-platform timing: monotonic (`GetNanoseconds`, `GetMilliseconds`), wall-clock (`GetEpochNanoseconds`), and duration formatting (`FormatDuration`) |
-| Microtask Queue | `Goccia.MicrotaskQueue.pas` | Singleton FIFO queue for deferred Promise reactions, drained after script execution, cleared on exception |
+| Microtask Queue | `Goccia.MicrotaskQueue.pas` | Singleton FIFO queue for Promise reactions and `queueMicrotask` callbacks, drained after script execution, cleared on exception |
 | Garbage Collector | `Goccia.GarbageCollector.pas` | Mark-and-sweep memory management for runtime values |
 | Temporal Utilities | `Goccia.Temporal.Utils.pas` | ISO 8601 date math helpers, parsing, formatting |
 | Temporal Built-in | `Goccia.Builtins.Temporal.pas` | Temporal namespace, constructors, static methods, Temporal.Now |

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -227,9 +227,19 @@ String prototype methods are implemented on string values:
 
 `charAt`, `charCodeAt`, `indexOf`, `lastIndexOf`, `includes`, `startsWith`, `endsWith`, `slice`, `substring`, `toLowerCase`, `toUpperCase`, `trim`, `trimStart`, `trimEnd`, `repeat`, `replace`, `replaceAll`, `split`, `padStart`, `padEnd`, `concat`, `at`
 
-### Global Constants and Error Constructors (`Goccia.Builtins.Globals.pas`)
+### Global Constants, Functions, and Error Constructors (`Goccia.Builtins.Globals.pas`)
+
+These are always registered (not flag-gated).
 
 **Constants:** `undefined`, `NaN`, `Infinity`
+
+**Global functions:**
+
+| Function | Description |
+|----------|-------------|
+| `queueMicrotask(callback)` | Enqueue a callback to run as a microtask. Throws `TypeError` if the argument is not callable. |
+
+`queueMicrotask` shares the same microtask queue used by Promise reactions. Callbacks run after the current synchronous code completes but before the engine returns control. If a callback throws, the error is silently discarded and remaining microtasks still execute.
 
 **Error constructors:** `Error`, `TypeError`, `ReferenceError`, `RangeError`
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -249,6 +249,8 @@ This follows the ECMAScript specification's microtask ordering semantics. Thenab
 | Test framework | After each test callback |
 | Benchmark runner | After warmup, calibration batches, and each measurement round |
 
+**`queueMicrotask`:** The global `queueMicrotask(callback)` function enqueues a user-provided callback into the same microtask queue used by Promise reactions. This matches the [HTML spec](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#microtask-queuing). If a `queueMicrotask` callback throws, the error is silently discarded and the queue keeps draining — remaining microtasks and Promise reactions still run. This matches the observable behavior in Node.js/browsers where uncaught microtask errors don't prevent other microtasks from executing.
+
 **Error safety:** Both `Execute` and `ExecuteProgram` wrap the drain in a `try..finally` that calls `ClearQueue`. If the interpreter throws, stale microtasks are discarded rather than leaking into subsequent executions. After a successful `DrainQueue` the queue is already empty, so `ClearQueue` is a no-op.
 
 **GC safety:** During `DrainQueue`, each microtask's handler, value, and result promise are temp-rooted to prevent collection mid-callback.

--- a/tests/built-ins/queueMicrotask/queueMicrotask.js
+++ b/tests/built-ins/queueMicrotask/queueMicrotask.js
@@ -1,0 +1,108 @@
+/*---
+description: queueMicrotask global function
+features: [queueMicrotask]
+---*/
+
+test("queueMicrotask is a function", () => {
+  expect(typeof queueMicrotask).toBe("function");
+});
+
+test("queueMicrotask returns undefined", () => {
+  const result = queueMicrotask(() => {});
+  expect(result).toBe(undefined);
+});
+
+test("queueMicrotask executes callback asynchronously", () => {
+  const log = [];
+  log.push("before");
+  queueMicrotask(() => {
+    log.push("microtask");
+  });
+  log.push("after");
+
+  return Promise.resolve().then(() => {
+    expect(log).toEqual(["before", "after", "microtask"]);
+  });
+});
+
+test("queueMicrotask callbacks run in order", () => {
+  const log = [];
+  queueMicrotask(() => log.push("first"));
+  queueMicrotask(() => log.push("second"));
+  queueMicrotask(() => log.push("third"));
+
+  return Promise.resolve().then(() => {
+    expect(log).toEqual(["first", "second", "third"]);
+  });
+});
+
+test("queueMicrotask interleaves with promise microtasks", () => {
+  const log = [];
+  Promise.resolve().then(() => log.push("promise-1"));
+  queueMicrotask(() => log.push("microtask-1"));
+  Promise.resolve().then(() => log.push("promise-2"));
+  queueMicrotask(() => log.push("microtask-2"));
+
+  return Promise.resolve().then(() => {
+    return Promise.resolve();
+  }).then(() => {
+    expect(log).toEqual([
+      "promise-1", "microtask-1", "promise-2", "microtask-2"
+    ]);
+  });
+});
+
+test("queueMicrotask callback can enqueue more microtasks", () => {
+  const log = [];
+  queueMicrotask(() => {
+    log.push("outer");
+    queueMicrotask(() => {
+      log.push("inner");
+    });
+  });
+
+  return Promise.resolve().then(() => {
+    return Promise.resolve();
+  }).then(() => {
+    expect(log).toEqual(["outer", "inner"]);
+  });
+});
+
+test("queueMicrotask runs before next promise chain step", () => {
+  const log = [];
+  return Promise.resolve().then(() => {
+    log.push("then-1");
+    queueMicrotask(() => log.push("queued-from-then"));
+  }).then(() => {
+    log.push("then-2");
+    expect(log).toEqual(["then-1", "queued-from-then", "then-2"]);
+  });
+});
+
+test("queueMicrotask with no arguments throws TypeError", () => {
+  expect(() => queueMicrotask()).toThrow(TypeError);
+});
+
+test("queueMicrotask with non-function throws TypeError", () => {
+  expect(() => queueMicrotask(42)).toThrow(TypeError);
+  expect(() => queueMicrotask("string")).toThrow(TypeError);
+  expect(() => queueMicrotask(null)).toThrow(TypeError);
+  expect(() => queueMicrotask(undefined)).toThrow(TypeError);
+  expect(() => queueMicrotask({})).toThrow(TypeError);
+  expect(() => queueMicrotask(true)).toThrow(TypeError);
+});
+
+test("multiple queueMicrotask with promise resolution", () => {
+  const log = [];
+  const p = new Promise((resolve) => {
+    queueMicrotask(() => {
+      log.push("microtask-before-resolve");
+      resolve("done");
+    });
+  });
+
+  return p.then((value) => {
+    log.push("resolved:" + value);
+    expect(log).toEqual(["microtask-before-resolve", "resolved:done"]);
+  });
+});

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -28,7 +28,7 @@ type
 implementation
 
 uses Goccia.Values.ClassHelper, Goccia.Values.ErrorHelper,
-  Goccia.MicrotaskQueue;
+  Goccia.MicrotaskQueue, Goccia.GarbageCollector;
 
 constructor TGocciaGlobals.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
@@ -166,6 +166,8 @@ begin
   Task.Value := TGocciaUndefinedLiteralValue.UndefinedValue;
   Task.ReactionType := prtFulfill;
 
+  if Assigned(TGocciaGC.Instance) then
+    TGocciaGC.Instance.AddTempRoot(Callback);
   TGocciaMicrotaskQueue.Instance.Enqueue(Task);
 
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -16,18 +16,19 @@ type
     FReferenceErrorProto: TGocciaObjectValue;
     FRangeErrorProto: TGocciaObjectValue;
   protected
-    // Error constructors
     function ErrorConstructor(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
     function TypeErrorConstructor(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
     function ReferenceErrorConstructor(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
     function RangeErrorConstructor(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
+    function QueueMicrotaskCallback(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
   end;
 
 implementation
 
-uses Goccia.Values.ClassHelper, Goccia.Values.ErrorHelper;
+uses Goccia.Values.ClassHelper, Goccia.Values.ErrorHelper,
+  Goccia.MicrotaskQueue;
 
 constructor TGocciaGlobals.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
@@ -78,6 +79,10 @@ begin
   AScope.DefineLexicalBinding('TypeError', TypeErrorConstructorFunc, dtConst);
   AScope.DefineLexicalBinding('ReferenceError', ReferenceErrorConstructorFunc, dtConst);
   AScope.DefineLexicalBinding('RangeError', RangeErrorConstructorFunc, dtConst);
+
+  // Global functions
+  AScope.DefineLexicalBinding('queueMicrotask',
+    TGocciaNativeFunctionValue.Create(QueueMicrotaskCallback, 'queueMicrotask', 1), dtConst);
 
   // Note: parseInt, parseFloat, isNaN, isFinite are intentionally NOT registered as globals.
   // They are available only on the Number object (e.g. Number.parseInt, Number.isNaN).
@@ -142,6 +147,28 @@ begin
   ErrorObj := CreateErrorObject('RangeError', Message);
   ErrorObj.Prototype := FRangeErrorProto;
   Result := ErrorObj;
+end;
+
+function TGocciaGlobals.QueueMicrotaskCallback(Args: TGocciaArgumentsCollection; ThisValue: TGocciaValue): TGocciaValue;
+var
+  Callback: TGocciaValue;
+  Task: TGocciaMicrotask;
+begin
+  if Args.Length = 0 then
+    ThrowTypeError('Failed to execute ''queueMicrotask'': 1 argument required, but only 0 present.');
+
+  Callback := Args.GetElement(0);
+  if not Callback.IsCallable then
+    ThrowTypeError('Failed to execute ''queueMicrotask'': parameter 1 is not of type ''Function''.');
+
+  Task.Handler := Callback;
+  Task.ResultPromise := nil;
+  Task.Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Task.ReactionType := prtFulfill;
+
+  TGocciaMicrotaskQueue.Instance.Enqueue(Task);
+
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 end.

--- a/units/Goccia.MicrotaskQueue.pas
+++ b/units/Goccia.MicrotaskQueue.pas
@@ -113,10 +113,13 @@ begin
               Promise.Resolve(HandlerResult);
           except
             on E: TGocciaThrowValue do
-            begin
               if Assigned(Promise) then
                 Promise.Reject(E.Value);
-            end;
+              // TODO: Per HTML spec, queueMicrotask callback errors should be
+              // "reported" (Node.js: uncaughtException, browsers: global error
+              // event). Currently silently discarded because GocciaScript has no
+              // process-level error reporting. Add reporting when/if an error
+              // event mechanism is implemented.
           end;
         finally
           CallArgs.Free;
@@ -149,6 +152,7 @@ begin
   end;
   if I > 0 then
     FQueue.Clear;
+
 end;
 
 procedure TGocciaMicrotaskQueue.ClearQueue;

--- a/units/Goccia.MicrotaskQueue.pas
+++ b/units/Goccia.MicrotaskQueue.pas
@@ -156,7 +156,17 @@ begin
 end;
 
 procedure TGocciaMicrotaskQueue.ClearQueue;
+var
+  I: Integer;
+  Task: TGocciaMicrotask;
 begin
+  if Assigned(TGocciaGC.Instance) then
+    for I := 0 to FQueue.Count - 1 do
+    begin
+      Task := FQueue[I];
+      if Assigned(Task.Handler) then
+        TGocciaGC.Instance.RemoveTempRoot(Task.Handler);
+    end;
   FQueue.Clear;
 end;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `queueMicrotask()` global function for enqueueing callbacks in the microtask queue, sharing the same queue as Promise reactions.

* **Documentation**
  * Updated architecture, built-ins, and design decision documentation to reflect `queueMicrotask()` integration, behavior, and error handling semantics.

* **Tests**
  * Added comprehensive test suite covering functionality, FIFO ordering, Promise interleaving, nesting, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->