### PR TITLE
Add stack property for errors

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,6 +85,15 @@ A dependency-free unit that centralizes all 33 reserved JavaScript keyword strin
 
 A dependency-free unit that centralizes all 12 contextual keyword string constants (`KEYWORD_GET`, `KEYWORD_SET`, `KEYWORD_TYPE`, `KEYWORD_INTERFACE`, `KEYWORD_IMPLEMENTS`, etc.). Contextual keywords have special meaning only in specific syntactic positions but are otherwise valid identifiers. Used by the lexer and parser.
 
+### Call Stack (`Goccia.CallStack.pas`)
+
+A singleton call frame stack that tracks the active function call chain for `Error.stack` trace generation. Key design:
+
+- **Singleton** — `TGocciaCallStack.Initialize` / `TGocciaCallStack.Instance`, mirroring the `TGocciaGarbageCollector` pattern.
+- **Push/Pop** — `EvaluateCall` and `EvaluateNewExpression` in the evaluator push a frame (function name, file path, line, column) before dispatching to the callee and pop after return (via `try/finally`). Each frame records the call-site position from the AST node and the callee's name.
+- **CaptureStackTrace** — Called by error constructors and `CreateErrorObject` to snapshot the current stack as a formatted string. Accepts a `SkipTop` parameter to omit the Error constructor frame when errors are created via `new Error()`.
+- **Pre-allocated** — Uses a fixed-capacity dynamic array (initial size 32) with doubling growth, avoiding per-frame heap allocation.
+
 ### Microtask Queue (`Goccia.MicrotaskQueue.pas`)
 
 A singleton microtask queue used by Promises and `queueMicrotask()` to defer callbacks per the ECMAScript specification. Key design:

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -319,7 +319,7 @@ A `const` global providing engine metadata:
 
 All error constructors accept an optional second argument `options` with a `cause` property. `AggregateError` takes `(errors, message, options?)` where `errors` is an array of error objects.
 
-Each creates a `TGocciaError` with the appropriate `Name` and `Message`.
+Each creates an error object with `name`, `message`, and `stack` properties. The `stack` property is a formatted string containing the error name/message on the first line, followed by `    at functionName (filePath:line:col)` entries for each frame in the call stack at the point of construction. Runtime errors thrown by the engine (e.g., `TypeError` from accessing a property on `undefined`) also receive a `stack` property.
 
 ### Iterator (`Goccia.Values.IteratorValue.pas`, `Iterator.Concrete.pas`, `Iterator.Lazy.pas`, `Iterator.Generic.pas`)
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -319,7 +319,15 @@ A `const` global providing engine metadata:
 
 All error constructors accept an optional second argument `options` with a `cause` property. `AggregateError` takes `(errors, message, options?)` where `errors` is an array of error objects.
 
-Each creates an error object with `name`, `message`, and `stack` properties. The `stack` property is a formatted string containing the error name/message on the first line, followed by `    at functionName (filePath:line:col)` entries for each frame in the call stack at the point of construction. Runtime errors thrown by the engine (e.g., `TypeError` from accessing a property on `undefined`) also receive a `stack` property.
+Each creates an error object with `name`, `message`, and `stack` properties. The `stack` property is a formatted string with the following structure:
+
+```
+ErrorName: message
+    at functionName (filePath:line:col)
+    at outerFunction (filePath:line:col)
+```
+
+Runtime errors thrown by the engine (e.g., `TypeError` from accessing a property on `undefined`) also receive a `stack` property.
 
 ### Iterator (`Goccia.Values.IteratorValue.pas`, `Iterator.Concrete.pas`, `Iterator.Lazy.pas`, `Iterator.Generic.pas`)
 

--- a/tests/built-ins/Error/error-stack.js
+++ b/tests/built-ins/Error/error-stack.js
@@ -1,0 +1,103 @@
+/*---
+description: Error objects have a stack property with a formatted stack trace
+features: [Error, stack]
+---*/
+
+test("Error has stack property", () => {
+  const error = new Error("test message");
+  expect(typeof error.stack).toBe("string");
+});
+
+test("stack starts with error name and message", () => {
+  const error = new Error("something went wrong");
+  expect(error.stack.startsWith("Error: something went wrong")).toBe(true);
+});
+
+test("TypeError stack starts with TypeError", () => {
+  const error = new TypeError("bad type");
+  expect(error.stack.startsWith("TypeError: bad type")).toBe(true);
+});
+
+test("RangeError stack starts with RangeError", () => {
+  const error = new RangeError("out of range");
+  expect(error.stack.startsWith("RangeError: out of range")).toBe(true);
+});
+
+test("ReferenceError stack starts with ReferenceError", () => {
+  const error = new ReferenceError("not defined");
+  expect(error.stack.startsWith("ReferenceError: not defined")).toBe(true);
+});
+
+test("SyntaxError stack starts with SyntaxError", () => {
+  const error = new SyntaxError("unexpected token");
+  expect(error.stack.startsWith("SyntaxError: unexpected token")).toBe(true);
+});
+
+test("Error with empty message shows just the name", () => {
+  const error = new Error();
+  expect(error.stack.startsWith("Error")).toBe(true);
+});
+
+test("stack contains 'at' lines for call chain", () => {
+  const makeError = () => new Error("inside function");
+  const error = makeError();
+  expect(error.stack.includes("at")).toBe(true);
+});
+
+test("stack traces through nested function calls", () => {
+  const inner = () => new Error("deep");
+  const middle = () => inner();
+  const outer = () => middle();
+  const error = outer();
+  const lines = error.stack.split("\n");
+  expect(lines.length >= 4).toBe(true);
+  expect(lines[0]).toBe("Error: deep");
+});
+
+test("stack includes function names", () => {
+  const namedFunction = () => new Error("named");
+  const error = namedFunction();
+  expect(error.stack.includes("namedFunction")).toBe(true);
+});
+
+test("stack from caught runtime error has trace", () => {
+  let stack = "";
+  try {
+    const obj = undefined;
+    obj.property;
+  } catch (e) {
+    stack = e.stack;
+  }
+  expect(typeof stack).toBe("string");
+  expect(stack.includes("Error")).toBe(true);
+});
+
+test("stack trace shows caller chain", () => {
+  const a = () => new Error("trace");
+  const b = () => a();
+  const c = () => b();
+  const error = c();
+  expect(error.stack.includes("a")).toBe(true);
+  expect(error.stack.includes("b")).toBe(true);
+  expect(error.stack.includes("c")).toBe(true);
+});
+
+test("AggregateError has stack property", () => {
+  const error = new AggregateError([], "aggregate");
+  expect(typeof error.stack).toBe("string");
+  expect(error.stack.startsWith("AggregateError: aggregate")).toBe(true);
+});
+
+test("thrown and caught error preserves stack", () => {
+  const thrower = () => {
+    throw new Error("thrown");
+  };
+  let caughtStack = "";
+  try {
+    thrower();
+  } catch (e) {
+    caughtStack = e.stack;
+  }
+  expect(caughtStack.startsWith("Error: thrown")).toBe(true);
+  expect(caughtStack.includes("thrower")).toBe(true);
+});

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -40,6 +40,7 @@ type
 implementation
 
 uses
+  Goccia.CallStack,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.Values.ArrayValue,
@@ -144,6 +145,12 @@ begin
   { Step 2: Let O = OrdinaryCreateFromConstructor with prototype }
   Result := CreateErrorObject(AName, Message);
   Result.Prototype := AProto;
+
+  { Capture stack trace at construction site, skipping the Error constructor frame }
+  if Assigned(TGocciaCallStack.Instance) then
+    Result.AssignProperty('stack',
+      TGocciaStringLiteralValue.Create(
+        TGocciaCallStack.Instance.CaptureStackTrace(AName, Message, 1)));
 
   { Step 4: InstallErrorCause(O, options) }
   OptionsIndex := 1;

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -40,7 +40,6 @@ type
 implementation
 
 uses
-  Goccia.CallStack,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.Values.ArrayValue,
@@ -143,14 +142,8 @@ begin
     Message := '';
 
   { Step 2: Let O = OrdinaryCreateFromConstructor with prototype }
-  Result := CreateErrorObject(AName, Message);
+  Result := CreateErrorObject(AName, Message, 1);
   Result.Prototype := AProto;
-
-  { Capture stack trace at construction site, skipping the Error constructor frame }
-  if Assigned(TGocciaCallStack.Instance) then
-    Result.AssignProperty('stack',
-      TGocciaStringLiteralValue.Create(
-        TGocciaCallStack.Instance.CaptureStackTrace(AName, Message, 1)));
 
   { Step 4: InstallErrorCause(O, options) }
   OptionsIndex := 1;

--- a/units/Goccia.CallStack.pas
+++ b/units/Goccia.CallStack.pas
@@ -1,0 +1,129 @@
+unit Goccia.CallStack;
+
+{$I Goccia.inc}
+
+interface
+
+type
+  TGocciaCallFrame = record
+    FunctionName: string;
+    FilePath: string;
+    Line: Integer;
+    Column: Integer;
+  end;
+
+  TGocciaCallStack = class
+  private class var
+    FInstance: TGocciaCallStack;
+  private
+    FFrames: array of TGocciaCallFrame;
+    FCount: Integer;
+    FCapacity: Integer;
+    procedure Grow;
+  public
+    class function Instance: TGocciaCallStack;
+    class procedure Initialize;
+    class procedure Shutdown;
+
+    constructor Create;
+
+    procedure Push(const AFunctionName, AFilePath: string; const ALine, AColumn: Integer);
+    procedure Pop;
+
+    { Captures the current call stack as a formatted string.
+      AErrorName and AMessage form the first line: "ErrorName: message".
+      ASkipTop omits the topmost N frames (e.g. 1 to skip the Error constructor). }
+    function CaptureStackTrace(const AErrorName, AMessage: string; const ASkipTop: Integer = 0): string;
+
+    property Count: Integer read FCount;
+  end;
+
+implementation
+
+uses
+  SysUtils;
+
+const
+  INITIAL_CAPACITY = 32;
+
+{ TGocciaCallStack }
+
+class function TGocciaCallStack.Instance: TGocciaCallStack;
+begin
+  Result := FInstance;
+end;
+
+class procedure TGocciaCallStack.Initialize;
+begin
+  if not Assigned(FInstance) then
+    FInstance := TGocciaCallStack.Create;
+end;
+
+class procedure TGocciaCallStack.Shutdown;
+begin
+  FreeAndNil(FInstance);
+end;
+
+constructor TGocciaCallStack.Create;
+begin
+  FCount := 0;
+  FCapacity := INITIAL_CAPACITY;
+  SetLength(FFrames, FCapacity);
+end;
+
+procedure TGocciaCallStack.Grow;
+begin
+  FCapacity := FCapacity * 2;
+  SetLength(FFrames, FCapacity);
+end;
+
+procedure TGocciaCallStack.Push(const AFunctionName, AFilePath: string; const ALine, AColumn: Integer);
+begin
+  if FCount >= FCapacity then
+    Grow;
+  FFrames[FCount].FunctionName := AFunctionName;
+  FFrames[FCount].FilePath := AFilePath;
+  FFrames[FCount].Line := ALine;
+  FFrames[FCount].Column := AColumn;
+  Inc(FCount);
+end;
+
+procedure TGocciaCallStack.Pop;
+begin
+  if FCount > 0 then
+    Dec(FCount);
+end;
+
+function TGocciaCallStack.CaptureStackTrace(const AErrorName, AMessage: string; const ASkipTop: Integer = 0): string;
+var
+  I, EffectiveCount: Integer;
+  Frame: TGocciaCallFrame;
+  FuncName, Location: string;
+begin
+  if AMessage <> '' then
+    Result := AErrorName + ': ' + AMessage
+  else
+    Result := AErrorName;
+
+  EffectiveCount := FCount - ASkipTop;
+  if EffectiveCount < 0 then
+    EffectiveCount := 0;
+
+  for I := EffectiveCount - 1 downto 0 do
+  begin
+    Frame := FFrames[I];
+    if Frame.FunctionName <> '' then
+      FuncName := Frame.FunctionName
+    else
+      FuncName := '<anonymous>';
+
+    if Frame.FilePath <> '' then
+      Location := Format('%s:%d:%d', [Frame.FilePath, Frame.Line, Frame.Column])
+    else
+      Location := Format('<unknown>:%d:%d', [Frame.Line, Frame.Column]);
+
+    Result := Result + sLineBreak + '    at ' + FuncName + ' (' + Location + ')';
+  end;
+end;
+
+end.

--- a/units/Goccia.CallStack.pas
+++ b/units/Goccia.CallStack.pas
@@ -105,7 +105,10 @@ begin
   else
     Result := AErrorName;
 
-  EffectiveCount := FCount - ASkipTop;
+  if ASkipTop > 0 then
+    EffectiveCount := FCount - ASkipTop
+  else
+    EffectiveCount := FCount;
   if EffectiveCount < 0 then
     EffectiveCount := 0;
 

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -144,6 +144,7 @@ uses
 
   TimingUtils,
 
+  Goccia.CallStack,
   Goccia.Error,
   Goccia.GarbageCollector,
   Goccia.JSX.Transformer,
@@ -187,6 +188,7 @@ begin
   end;
 
   TGocciaGarbageCollector.Initialize;
+  TGocciaCallStack.Initialize;
   TGocciaMicrotaskQueue.Initialize;
 
   FInterpreter := TGocciaInterpreter.Create(AFileName, ASourceLines);

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -83,6 +83,7 @@ uses
   SysUtils,
 
   Goccia.Arguments.Collection,
+  Goccia.CallStack,
   Goccia.Error,
   Goccia.Evaluator.Arithmetic,
   Goccia.Evaluator.Assignment,
@@ -832,6 +833,7 @@ var
   SuperClass: TGocciaClassValue;
   MemberExpr: TGocciaMemberExpression;
   SpreadValue: TGocciaValue;
+  CalleeName: string;
   I: Integer;
 begin
 
@@ -921,17 +923,34 @@ begin
     end;
 
     if Callee is TGocciaNativeFunctionValue then
-      Result := TGocciaNativeFunctionValue(Callee).Call(Arguments, ThisValue)
+      CalleeName := TGocciaNativeFunctionValue(Callee).Name
     else if Callee is TGocciaFunctionValue then
-      Result := TGocciaFunctionValue(Callee).Call(Arguments, ThisValue)
-    else if Callee is TGocciaBoundFunctionValue then
-      Result := TGocciaBoundFunctionValue(Callee).Call(Arguments, ThisValue)
+      CalleeName := TGocciaFunctionValue(Callee).Name
     else if Callee is TGocciaClassValue then
-      Result := TGocciaClassValue(Callee).Call(Arguments, ThisValue)
+      CalleeName := TGocciaClassValue(Callee).Name
     else
-    begin
-      SafeOnError(AContext, Format('%s is not a function', [Callee.TypeName]), ACallExpression.Line, ACallExpression.Column);
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+      CalleeName := '';
+
+    if Assigned(TGocciaCallStack.Instance) then
+      TGocciaCallStack.Instance.Push(CalleeName, AContext.CurrentFilePath,
+        ACallExpression.Line, ACallExpression.Column);
+    try
+      if Callee is TGocciaNativeFunctionValue then
+        Result := TGocciaNativeFunctionValue(Callee).Call(Arguments, ThisValue)
+      else if Callee is TGocciaFunctionValue then
+        Result := TGocciaFunctionValue(Callee).Call(Arguments, ThisValue)
+      else if Callee is TGocciaBoundFunctionValue then
+        Result := TGocciaBoundFunctionValue(Callee).Call(Arguments, ThisValue)
+      else if Callee is TGocciaClassValue then
+        Result := TGocciaClassValue(Callee).Call(Arguments, ThisValue)
+      else
+      begin
+        SafeOnError(AContext, Format('%s is not a function', [Callee.TypeName]), ACallExpression.Line, ACallExpression.Column);
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+      end;
+    finally
+      if Assigned(TGocciaCallStack.Instance) then
+        TGocciaCallStack.Instance.Pop;
     end;
 
   finally
@@ -1540,6 +1559,7 @@ var
   Callee: TGocciaValue;
   Arguments: TGocciaArgumentsCollection;
   SpreadValue: TGocciaValue;
+  CalleeName: string;
   I: Integer;
   Instance: TGocciaInstanceValue;
   NativeInstance: TGocciaObjectValue;
@@ -1563,92 +1583,105 @@ begin
     end;
 
     if Callee is TGocciaClassValue then
-    begin
-      ClassValue := TGocciaClassValue(Callee);
+      CalleeName := TGocciaClassValue(Callee).Name
+    else if Callee is TGocciaNativeFunctionValue then
+      CalleeName := TGocciaNativeFunctionValue(Callee).Name
+    else
+      CalleeName := '';
 
-      NativeInstance := nil;
-      WalkClass := ClassValue;
-      while Assigned(WalkClass) do
+    if Assigned(TGocciaCallStack.Instance) then
+      TGocciaCallStack.Instance.Push(CalleeName, AContext.CurrentFilePath,
+        ANewExpression.Line, ANewExpression.Column);
+    try
+      if Callee is TGocciaClassValue then
       begin
-        NativeInstance := WalkClass.CreateNativeInstance(Arguments);
-        if Assigned(NativeInstance) then
-          Break;
-        WalkClass := WalkClass.SuperClass;
-      end;
+        ClassValue := TGocciaClassValue(Callee);
 
-      if Assigned(NativeInstance) then
-      begin
-        NativeInstance.Prototype := ClassValue.Prototype;
-        if NativeInstance is TGocciaInstanceValue then
-          TGocciaInstanceValue(NativeInstance).ClassValue := ClassValue;
-
-        InitContext := AContext;
-        InitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue);
-        InitScope.ThisValue := NativeInstance;
-        InitContext.Scope := InitScope;
-
-        InitializeInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue, InitContext);
-
-        if Assigned(ClassValue.SuperClass) then
+        NativeInstance := nil;
+        WalkClass := ClassValue;
+        while Assigned(WalkClass) do
         begin
-          SuperInitContext := AContext;
-          SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue.SuperClass);
-          SuperInitScope.ThisValue := NativeInstance;
-          SuperInitContext.Scope := SuperInitScope;
-          InitializePrivateInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue.SuperClass, SuperInitContext);
+          NativeInstance := WalkClass.CreateNativeInstance(Arguments);
+          if Assigned(NativeInstance) then
+            Break;
+          WalkClass := WalkClass.SuperClass;
         end;
 
-        InitializePrivateInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue, InitContext);
+        if Assigned(NativeInstance) then
+        begin
+          NativeInstance.Prototype := ClassValue.Prototype;
+          if NativeInstance is TGocciaInstanceValue then
+            TGocciaInstanceValue(NativeInstance).ClassValue := ClassValue;
 
-        if Assigned(ClassValue.ConstructorMethod) then
-          ClassValue.ConstructorMethod.Call(Arguments, NativeInstance)
-        else if Assigned(ClassValue.SuperClass) and Assigned(ClassValue.SuperClass.ConstructorMethod) then
-          ClassValue.SuperClass.ConstructorMethod.Call(Arguments, NativeInstance)
+          InitContext := AContext;
+          InitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue);
+          InitScope.ThisValue := NativeInstance;
+          InitContext.Scope := InitScope;
+
+          InitializeInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue, InitContext);
+
+          if Assigned(ClassValue.SuperClass) then
+          begin
+            SuperInitContext := AContext;
+            SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue.SuperClass);
+            SuperInitScope.ThisValue := NativeInstance;
+            SuperInitContext.Scope := SuperInitScope;
+            InitializePrivateInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue.SuperClass, SuperInitContext);
+          end;
+
+          InitializePrivateInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue, InitContext);
+
+          if Assigned(ClassValue.ConstructorMethod) then
+            ClassValue.ConstructorMethod.Call(Arguments, NativeInstance)
+          else if Assigned(ClassValue.SuperClass) and Assigned(ClassValue.SuperClass.ConstructorMethod) then
+            ClassValue.SuperClass.ConstructorMethod.Call(Arguments, NativeInstance)
+          else
+            TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(Arguments);
+
+          Result := NativeInstance;
+        end
         else
-          TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(Arguments);
+        begin
+          Instance := TGocciaInstanceValue.Create(ClassValue);
+          Instance.Prototype := ClassValue.Prototype;
 
-        Result := NativeInstance;
+          InitContext := AContext;
+          InitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue);
+          InitScope.ThisValue := Instance;
+          InitContext.Scope := InitScope;
+
+          InitializeInstanceProperties(Instance, ClassValue, InitContext);
+
+          if Assigned(ClassValue.SuperClass) then
+          begin
+            SuperInitContext := AContext;
+            SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue.SuperClass);
+            SuperInitScope.ThisValue := Instance;
+            SuperInitContext.Scope := SuperInitScope;
+            InitializePrivateInstanceProperties(Instance, ClassValue.SuperClass, SuperInitContext);
+          end;
+
+          InitializePrivateInstanceProperties(Instance, ClassValue, InitContext);
+
+          if Assigned(ClassValue.ConstructorMethod) then
+            ClassValue.ConstructorMethod.Call(Arguments, Instance)
+          else if Assigned(ClassValue.SuperClass) and Assigned(ClassValue.SuperClass.ConstructorMethod) then
+            ClassValue.SuperClass.ConstructorMethod.Call(Arguments, Instance);
+
+          Result := Instance;
+        end;
+      end
+      else if Callee is TGocciaNativeFunctionValue then
+      begin
+        Result := TGocciaNativeFunctionValue(Callee).Call(Arguments, TGocciaUndefinedLiteralValue.UndefinedValue);
       end
       else
       begin
-        Instance := TGocciaInstanceValue.Create(ClassValue);
-        Instance.Prototype := ClassValue.Prototype;
-
-        InitContext := AContext;
-        InitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue);
-        InitScope.ThisValue := Instance;
-        InitContext.Scope := InitScope;
-
-        InitializeInstanceProperties(Instance, ClassValue, InitContext);
-
-        if Assigned(ClassValue.SuperClass) then
-        begin
-          SuperInitContext := AContext;
-          SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue.SuperClass);
-          SuperInitScope.ThisValue := Instance;
-          SuperInitContext.Scope := SuperInitScope;
-          InitializePrivateInstanceProperties(Instance, ClassValue.SuperClass, SuperInitContext);
-        end;
-
-        InitializePrivateInstanceProperties(Instance, ClassValue, InitContext);
-
-        if Assigned(ClassValue.ConstructorMethod) then
-          ClassValue.ConstructorMethod.Call(Arguments, Instance)
-        else if Assigned(ClassValue.SuperClass) and Assigned(ClassValue.SuperClass.ConstructorMethod) then
-          ClassValue.SuperClass.ConstructorMethod.Call(Arguments, Instance);
-
-        Result := Instance;
+        ThrowTypeError(Callee.TypeName + ' is not a constructor');
       end;
-    end
-    else if Callee is TGocciaNativeFunctionValue then
-    begin
-      // Native function constructors (e.g. Error, TypeError, etc.)
-      Result := TGocciaNativeFunctionValue(Callee).Call(Arguments, TGocciaUndefinedLiteralValue.UndefinedValue);
-    end
-    else
-    begin
-      // Throw proper TypeError for non-constructors
-      ThrowTypeError(Callee.TypeName + ' is not a constructor');
+    finally
+      if Assigned(TGocciaCallStack.Instance) then
+        TGocciaCallStack.Instance.Pop;
     end;
   finally
     Arguments.Free;

--- a/units/Goccia.Values.ErrorHelper.pas
+++ b/units/Goccia.Values.ErrorHelper.pas
@@ -28,6 +28,7 @@ procedure ThrowError(const AMessage: string);
 implementation
 
 uses
+  Goccia.CallStack,
   Goccia.Values.Error,
   Goccia.Values.Primitives;
 
@@ -36,6 +37,11 @@ begin
   Result := TGocciaObjectValue.Create;
   Result.AssignProperty('name', TGocciaStringLiteralValue.Create(AName));
   Result.AssignProperty('message', TGocciaStringLiteralValue.Create(AMessage));
+
+  if Assigned(TGocciaCallStack.Instance) then
+    Result.AssignProperty('stack',
+      TGocciaStringLiteralValue.Create(
+        TGocciaCallStack.Instance.CaptureStackTrace(AName, AMessage)));
 end;
 
 procedure ThrowTypeError(const AMessage: string);

--- a/units/Goccia.Values.ErrorHelper.pas
+++ b/units/Goccia.Values.ErrorHelper.pas
@@ -7,8 +7,9 @@ interface
 uses
   Goccia.Values.ObjectValue;
 
-{ Creates a JavaScript error object with the given name and message }
-function CreateErrorObject(const AName, AMessage: string): TGocciaObjectValue;
+{ Creates a JavaScript error object with the given name and message.
+  ASkipTop controls how many frames to skip from the top of the call stack. }
+function CreateErrorObject(const AName, AMessage: string; const ASkipTop: Integer = 0): TGocciaObjectValue;
 
 { Raises a TGocciaThrowValue with a TypeError }
 procedure ThrowTypeError(const AMessage: string);
@@ -32,7 +33,7 @@ uses
   Goccia.Values.Error,
   Goccia.Values.Primitives;
 
-function CreateErrorObject(const AName, AMessage: string): TGocciaObjectValue;
+function CreateErrorObject(const AName, AMessage: string; const ASkipTop: Integer = 0): TGocciaObjectValue;
 begin
   Result := TGocciaObjectValue.Create;
   Result.AssignProperty('name', TGocciaStringLiteralValue.Create(AName));
@@ -41,7 +42,7 @@ begin
   if Assigned(TGocciaCallStack.Instance) then
     Result.AssignProperty('stack',
       TGocciaStringLiteralValue.Create(
-        TGocciaCallStack.Instance.CaptureStackTrace(AName, AMessage)));
+        TGocciaCallStack.Instance.CaptureStackTrace(AName, AMessage, ASkipTop)));
 end;
 
 procedure ThrowTypeError(const AMessage: string);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error objects now include formatted stack traces showing the error header and call-site lines; stacks are preserved for thrown and runtime errors.
  * Symbol and iterator semantics clarified: Symbol.iterator behavior, lazy well-known symbols, and Symbol.species support for controlling derived constructors.
  * Microtask/Promise execution model and microtask queue behavior documented.

* **Documentation**
  * Expanded docs describing call-stack and microtask behaviors and public-facing symbol/iterator semantics.

* **Tests**
  * Added comprehensive tests validating error stack contents and formatting across error types and call patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->