### PR TITLE
Add command-line flags to TestRunner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: chmod +x build/*
 
       - name: Run all JavaScript tests
-        run: ./build/TestRunner tests
+        run: ./build/TestRunner tests --silent --no-progress
 
       - name: Run Pascal unit tests
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,7 +60,7 @@ jobs:
         run: chmod +x build/*
 
       - name: Run all JavaScript tests
-        run: ./build/TestRunner tests
+        run: ./build/TestRunner tests --silent --no-progress
 
   benchmark:
     needs: build

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -309,8 +309,14 @@ begin
         begin
           if DirectoryExists(Paths[I]) then
             Files.AddStrings(FindAllFiles(Paths[I], ScriptExtensions))
+          else if FileExists(Paths[I]) then
+            Files.Add(Paths[I])
           else
-            Files.Add(Paths[I]);
+          begin
+            WriteLn('Error: Path not found: ', Paths[I]);
+            ExitCode := 1;
+            Exit;
+          end;
         end;
 
         if Files.Count = 1 then

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -205,6 +205,9 @@ begin
     TotalRunCount := TotalRunCount + FileResult.TestResult.GetProperty('totalRunTests').ToNumberLiteral.Value;
     TotalDuration := TotalDuration + FileResult.TestResult.GetProperty('duration').ToNumberLiteral.Value;
     TotalAssertions := TotalAssertions + FileResult.TestResult.GetProperty('assertions').ToNumberLiteral.Value;
+
+    if GExitOnFirstFailure and (FailedCount > 0) then
+      Break;
   end;
   
   AllTestResults.AssignProperty('passed', TGocciaNumberLiteralValue.Create(PassedCount));

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -109,9 +109,6 @@ begin
           ScriptResult.AssignProperty('duration', FileResult.GetProperty('duration'));
         if FileResult.GetProperty('failedTests').ToStringLiteral.Value <> 'undefined' then
           ScriptResult.AssignProperty('failedTests', FileResult.GetProperty('failedTests'));
-      end else
-      begin
-        ScriptResult := FileResult;
       end;
 
       Result.TestResult := ScriptResult;

--- a/units/Goccia.Builtins.TestAssertions.pas
+++ b/units/Goccia.Builtins.TestAssertions.pas
@@ -1114,8 +1114,6 @@ begin
           begin
             // Route callback exceptions through proper assertion failure mechanism
             AssertionFailed('callback execution', 'Callback threw an exception: ' + E.Message);
-            // Also log for debugging
-            WriteLn('Warning: Error in callback: ', E.Message);
           end;
         end;
       end;
@@ -1162,7 +1160,6 @@ begin
   FTestStats.CurrentTestHasFailures := True;
 
   // Track the failure details for reporting
-  // This is called during test execution, so we know the current test context
   if FTestStats.CurrentSuiteName <> '' then
     WriteLn('    ❌ ', FTestStats.CurrentTestName, ' in ', FTestStats.CurrentSuiteName, ': ', AMessage)
   else
@@ -1396,7 +1393,6 @@ var
   ResultObj: TGocciaObjectValue;
   ExitOnFirstFailure: Boolean = False;
   ShowTestResults: Boolean = True;
-  Silent: Boolean = False;
   Summary: string;
   PreviousSuiteName: string;
   PreviousSuiteIsSkipped: Boolean;
@@ -1433,16 +1429,11 @@ begin
         ShowTestResults := TestParams.GetProperty('showTestResults').ToBooleanLiteral.Value
       else
         ShowTestResults := True;
-      if TestParams.HasProperty('silent') then
-        Silent := TestParams.GetProperty('silent').ToBooleanLiteral.Value
-      else
-        Silent := False;
     end
     else
     begin
       ExitOnFirstFailure := False;
       ShowTestResults := True;
-      Silent := False;
     end;
   end;
 
@@ -1467,8 +1458,7 @@ begin
       except
         on E: Exception do
         begin
-          if not Silent then
-            WriteLn('Error in describe block "', Suite.Name, '": ', E.Message);
+          WriteLn('Error in describe block "', Suite.Name, '": ', E.Message);
           FailedTestDetails.Add('Describe "' + Suite.Name + '": ' + E.Message);
         end;
       end;
@@ -1494,13 +1484,10 @@ begin
       begin
         // Mark test as skipped and don't execute it
         FTestStats.CurrentTestIsSkipped := True;
-        if not Silent then
-        begin
-          if TestCase.SuiteName <> '' then
-            WriteLn('    ⏸️ ', TestCase.Name, ' in ', TestCase.SuiteName, ': SKIPPED')
-          else
-            WriteLn('    ⏸️ ', TestCase.Name, ': SKIPPED');
-        end;
+        if TestCase.SuiteName <> '' then
+          WriteLn('    ⏸️ ', TestCase.Name, ' in ', TestCase.SuiteName, ': SKIPPED')
+        else
+          WriteLn('    ⏸️ ', TestCase.Name, ': SKIPPED');
       end
       else
       begin

--- a/units/Goccia.Builtins.TestConsole.pas
+++ b/units/Goccia.Builtins.TestConsole.pas
@@ -1,0 +1,51 @@
+unit Goccia.Builtins.TestConsole;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaTestConsole = class
+  private
+    function NoOp(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    procedure Silence(const AConsoleObject: TGocciaObjectValue);
+  end;
+
+implementation
+
+uses
+  Goccia.Values.NativeFunction;
+
+function TGocciaTestConsole.NoOp(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+procedure TGocciaTestConsole.Silence(const AConsoleObject: TGocciaObjectValue);
+begin
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'log', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'warn', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'error', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'info', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'debug', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'dir', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'assert', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'count', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'countReset', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'time', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'timeEnd', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'timeLog', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'clear', 0));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'group', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'groupEnd', 0));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'trace', -1));
+  AConsoleObject.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NoOp, 'table', -1));
+end;
+
+end.

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -89,6 +89,7 @@ type
     FBuiltinTestAssertions: TGocciaTestAssertions;
     FBuiltinBenchmark: TGocciaBenchmark;
     FBuiltinTemporal: TGocciaTemporalBuiltin;
+    FSuppressWarnings: Boolean;
 
     procedure PinSingletons;
     procedure RegisterBuiltIns;
@@ -132,6 +133,7 @@ type
     property BuiltinTestAssertions: TGocciaTestAssertions read FBuiltinTestAssertions;
     property BuiltinBenchmark: TGocciaBenchmark read FBuiltinBenchmark;
     property BuiltinTemporal: TGocciaTemporalBuiltin read FBuiltinTemporal;
+    property SuppressWarnings: Boolean read FSuppressWarnings write FSuppressWarnings;
   end;
 
 
@@ -579,6 +581,8 @@ var
   Warning: TGocciaParserWarning;
   I, OrigLine, OrigCol: Integer;
 begin
+  if FSuppressWarnings then
+    Exit;
   for I := 0 to AParser.WarningCount - 1 do
   begin
     Warning := AParser.GetWarning(I);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New test CLI options: --silent, --no-progress, --no-results, --exit-on-first-failure
  * Tests can silence console methods and suppress parser warnings
  * Benchmark runner accepts multiple paths and aggregates inputs

* **Behavior Changes**
  * Test output verbosity and progress reporting adjusted; per-file timing and aggregated summaries added
  * Describe-block errors and skipped tests are now always printed

* **Chores**
  * CI/PR workflows run tests with reduced verbosity by default
<!-- end of auto-generated comment: release notes by coderabbit.ai -->