### PR TITLE
Add `Map#getOrInsert[Computed]`, `Error.isError`, `Math.sumPrecise`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ GocciaScript implements several active TC39 proposals:
 | [Enum Declarations](https://github.com/tc39/proposal-enum) | 0 | Frozen, null-prototype enum objects with `Symbol.iterator` |
 | [Temporal](https://tc39.es/proposal-temporal/) | 3 | Modern date/time API (`Temporal.PlainDate`, `Temporal.Duration`, `Temporal.Instant`, etc.) |
 | [`Math.clamp`](https://github.com/tc39/proposal-math-clamp) | 3 | Clamp a value to a range |
+| [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) | 3 | Precise summation of iterables using compensated algorithm |
+| [`Map.prototype.getOrInsert`](https://github.com/tc39/proposal-upsert) | 3 | Get existing value or insert a default / computed value |
+| [`Error.isError`](https://github.com/tc39/proposal-is-error) | 4 | Reliable brand check for error objects via `[[ErrorData]]` |
 
 See [Language Restrictions](docs/language-restrictions.md) for details on supported syntax.
 
@@ -147,7 +150,7 @@ console.log(`Your order total: $${total.toFixed(2)}`);
 
 ### Run Tests
 
-GocciaScript has 2300+ JavaScript unit tests covering language features, built-in objects, and edge cases.
+GocciaScript has 2400+ JavaScript unit tests covering language features, built-in objects, and edge cases.
 
 ```bash
 # Run all tests (GocciaScript TestRunner)
@@ -244,19 +247,6 @@ lefthook install
 ```
 
 See [Code Style](docs/code-style.md) for conventions, editor configuration, and [AGENTS.md](AGENTS.md) for the full development workflow.
-
-## Roadmap
-
-- [x] Promises (constructor, `.then`/`.catch`/`.finally`, `Promise.all`/`allSettled`/`race`/`any`, microtask queue)
-- [x] Iterator Helpers (`map`, `filter`, `take`, `drop`, `flatMap`, `forEach`, `reduce`, `toArray`, `some`, `every`, `find`)
-- [x] Temporal API (`Temporal.PlainDate`, `Temporal.PlainTime`, `Temporal.PlainDateTime`, `Temporal.Instant`, `Temporal.Duration`, `Temporal.Now`)
-- [x] Types as Comments (TC39 proposal-type-annotations)
-- [x] Enum declarations (TC39 proposal-enum)
-- [x] Set methods (`union`, `intersection`, `difference`, `symmetricDifference`, `isSubsetOf`, `isSupersetOf`, `isDisjointFrom`)
-- [ ] Async/await syntax
-- [ ] Regular expressions
-- [ ] Generator functions (`function*`)
-- [ ] Pre-compiled binary releases
 
 ## License
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -143,7 +143,7 @@ end;
 
 All methods handle `NaN` and `Infinity` edge cases correctly.
 
-`Math.sumPrecise` takes an iterable of numbers and returns their sum using Kahan-Babuska-Neumaier compensated summation, avoiding floating-point precision loss from naive addition. Non-number values in the iterable throw `TypeError`. An empty iterable returns `-0`. If any element is `NaN`, returns `NaN`. Mixed `+Infinity` and `-Infinity` returns `NaN`.
+`Math.sumPrecise(iterable)` takes an iterable of numbers and returns their sum using Kahan-Babuska-Neumaier compensated summation, avoiding floating-point precision loss from naive addition. Throws `TypeError` if the argument is not iterable (e.g., `null`, `undefined`, numbers, plain objects without `[Symbol.iterator]`). Non-number values in the iterable also throw `TypeError`. An empty iterable returns `-0`. If any element is `NaN`, returns `NaN`. Mixed `+Infinity` and `-Infinity` returns `NaN`.
 
 ### JSON (`Goccia.Builtins.JSON.pas`)
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -139,8 +139,11 @@ end;
 | `Math.log1p(x)` | ln(1 + x) (precise for small x) |
 | `Math.log2(x)` | Base-2 logarithm |
 | `Math.clz32(x)` | Count leading zeros (32-bit) |
+| `Math.sumPrecise(iterable)` | Precise sum of iterable of numbers (TC39 proposal) |
 
 All methods handle `NaN` and `Infinity` edge cases correctly.
+
+`Math.sumPrecise` takes an iterable of numbers and returns their sum using Kahan-Babuska-Neumaier compensated summation, avoiding floating-point precision loss from naive addition. Non-number values in the iterable throw `TypeError`. An empty iterable returns `-0`. If any element is `NaN`, returns `NaN`. Mixed `+Infinity` and `-Infinity` returns `NaN`.
 
 ### JSON (`Goccia.Builtins.JSON.pas`)
 
@@ -320,6 +323,12 @@ A `const` global providing engine metadata:
 
 **Error constructors:** `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `DOMException`
 
+**Static methods:**
+
+| Method | Description |
+|--------|-------------|
+| `Error.isError(arg)` | Returns `true` if `arg` is an Error instance (prototype chain includes `Error.prototype`), `false` otherwise (ES2026) |
+
 All error constructors accept an optional second argument `options` with a `cause` property. `AggregateError` takes `(errors, message, options?)` where `errors` is an array of error objects. `DOMException` takes `(message?, name?)` where `name` defaults to `"Error"` — the `code` property is automatically set from the legacy error code mapping (e.g., `"DataCloneError"` → 25).
 
 Each creates an error object with `name`, `message`, and `stack` properties. The `stack` property is a formatted string with the following structure:
@@ -442,6 +451,8 @@ A collection of key-value pairs with insertion-order iteration. Any value (inclu
 | `map.values()` | Returns an iterator over values |
 | `map.entries()` | Returns an iterator over `[key, value]` pairs |
 | `map[Symbol.iterator]()` | Returns an entries iterator (same as `entries()`) |
+| `map.getOrInsert(key, default)` | Return value for key if present; otherwise insert default and return it (TC39 proposal-upsert) |
+| `map.getOrInsertComputed(key, cb)` | Return value for key if present; otherwise call `cb(key)`, insert result, and return it (TC39 proposal-upsert) |
 
 **Static methods:**
 

--- a/tests/built-ins/Error/isError.js
+++ b/tests/built-ins/Error/isError.js
@@ -1,0 +1,87 @@
+/*---
+description: Error.isError returns true for Error instances and false for non-errors
+features: [Error.isError]
+---*/
+
+describe("Error.isError", () => {
+  test("returns true for Error", () => {
+    expect(Error.isError(new Error())).toBe(true);
+    expect(Error.isError(new Error("message"))).toBe(true);
+  });
+
+  test("returns true for TypeError", () => {
+    expect(Error.isError(new TypeError())).toBe(true);
+    expect(Error.isError(new TypeError("msg"))).toBe(true);
+  });
+
+  test("returns true for RangeError", () => {
+    expect(Error.isError(new RangeError())).toBe(true);
+  });
+
+  test("returns true for ReferenceError", () => {
+    expect(Error.isError(new ReferenceError())).toBe(true);
+  });
+
+  test("returns true for SyntaxError", () => {
+    expect(Error.isError(new SyntaxError())).toBe(true);
+  });
+
+  test("returns true for URIError", () => {
+    expect(Error.isError(new URIError())).toBe(true);
+  });
+
+  test("returns true for AggregateError", () => {
+    expect(Error.isError(new AggregateError([]))).toBe(true);
+    expect(Error.isError(new AggregateError([], "msg"))).toBe(true);
+  });
+
+  test("returns false for DOMException", () => {
+    expect(Error.isError(new DOMException("msg"))).toBe(false);
+  });
+
+  test("returns false for null and undefined", () => {
+    expect(Error.isError(null)).toBe(false);
+    expect(Error.isError(undefined)).toBe(false);
+  });
+
+  test("returns false for primitives", () => {
+    expect(Error.isError(42)).toBe(false);
+    expect(Error.isError("error")).toBe(false);
+    expect(Error.isError(true)).toBe(false);
+    expect(Error.isError(false)).toBe(false);
+  });
+
+  test("returns false for plain objects", () => {
+    expect(Error.isError({})).toBe(false);
+    expect(Error.isError({ name: "Error", message: "fake" })).toBe(false);
+  });
+
+  test("returns false for arrays", () => {
+    expect(Error.isError([])).toBe(false);
+    expect(Error.isError([new Error()])).toBe(false);
+  });
+
+  test("returns false for functions", () => {
+    expect(Error.isError(() => {})).toBe(false);
+  });
+
+  test("returns false with no arguments", () => {
+    expect(Error.isError()).toBe(false);
+  });
+
+  test("returns true for caught errors", () => {
+    let caught;
+    try {
+      throw new TypeError("test");
+    } catch (e) {
+      caught = e;
+    }
+    expect(Error.isError(caught)).toBe(true);
+  });
+
+  test("returns true for error with cause", () => {
+    const err = new Error("outer", { cause: new Error("inner") });
+    expect(Error.isError(err)).toBe(true);
+    expect(Error.isError(err.cause)).toBe(true);
+  });
+});

--- a/tests/built-ins/Map/prototype/getOrInsert.js
+++ b/tests/built-ins/Map/prototype/getOrInsert.js
@@ -1,0 +1,83 @@
+/*---
+description: Map.prototype.getOrInsert returns existing value or inserts default
+features: [Map.prototype.getOrInsert]
+---*/
+
+const isGocciaScript = typeof GocciaScript !== "undefined";
+
+describe.runIf(isGocciaScript)("Map.prototype.getOrInsert", () => {
+  test("returns existing value without overwriting", () => {
+    const map = new Map([["key", "original"]]);
+    const result = map.getOrInsert("key", "replacement");
+    expect(result).toBe("original");
+    expect(map.get("key")).toBe("original");
+  });
+
+  test("inserts and returns default value when key is absent", () => {
+    const map = new Map();
+    const result = map.getOrInsert("key", "default");
+    expect(result).toBe("default");
+    expect(map.get("key")).toBe("default");
+    expect(map.size).toBe(1);
+  });
+
+  test("works with numeric keys", () => {
+    const map = new Map([[1, "one"]]);
+    expect(map.getOrInsert(1, "replacement")).toBe("one");
+    expect(map.getOrInsert(2, "two")).toBe("two");
+    expect(map.size).toBe(2);
+  });
+
+  test("works with NaN key", () => {
+    const map = new Map();
+    map.getOrInsert(NaN, "nan-value");
+    expect(map.get(NaN)).toBe("nan-value");
+    expect(map.getOrInsert(NaN, "other")).toBe("nan-value");
+  });
+
+  test("works with null and undefined keys", () => {
+    const map = new Map();
+    expect(map.getOrInsert(null, "null-val")).toBe("null-val");
+    expect(map.getOrInsert(undefined, "undef-val")).toBe("undef-val");
+    expect(map.size).toBe(2);
+    expect(map.getOrInsert(null, "other")).toBe("null-val");
+  });
+
+  test("works with object keys using reference equality", () => {
+    const key = { id: 1 };
+    const map = new Map();
+    map.getOrInsert(key, "found");
+    expect(map.get(key)).toBe("found");
+    expect(map.getOrInsert({ id: 1 }, "other")).toBe("other");
+    expect(map.size).toBe(2);
+  });
+
+  test("default value can be any type", () => {
+    const map = new Map();
+    const arr = [];
+    expect(map.getOrInsert("arr", arr)).toBe(arr);
+    expect(map.getOrInsert("num", 42)).toBe(42);
+    expect(map.getOrInsert("bool", false)).toBe(false);
+    expect(map.getOrInsert("null", null)).toBe(null);
+  });
+
+  test("handles default values for grouping pattern", () => {
+    const map = new Map();
+    map.getOrInsert("a", []).push(1);
+    map.getOrInsert("a", []).push(2);
+    map.getOrInsert("b", []).push(3);
+    expect(map.get("a").length).toBe(2);
+    expect(map.get("b").length).toBe(1);
+  });
+
+  test("handles counter pattern", () => {
+    const map = new Map();
+    const keys = ["a", "b", "a", "c", "b", "a"];
+    keys.forEach((key) => {
+      map.set(key, map.getOrInsert(key, 0) + 1);
+    });
+    expect(map.get("a")).toBe(3);
+    expect(map.get("b")).toBe(2);
+    expect(map.get("c")).toBe(1);
+  });
+});

--- a/tests/built-ins/Map/prototype/getOrInsertComputed.js
+++ b/tests/built-ins/Map/prototype/getOrInsertComputed.js
@@ -1,0 +1,86 @@
+/*---
+description: Map.prototype.getOrInsertComputed returns existing value or computes and inserts
+features: [Map.prototype.getOrInsertComputed]
+---*/
+
+const isGocciaScript = typeof GocciaScript !== "undefined";
+
+describe.runIf(isGocciaScript)("Map.prototype.getOrInsertComputed", () => {
+  test("returns existing value without calling callback", () => {
+    const map = new Map([["key", "original"]]);
+    let called = false;
+    const result = map.getOrInsertComputed("key", () => {
+      called = true;
+      return "computed";
+    });
+    expect(result).toBe("original");
+    expect(called).toBe(false);
+  });
+
+  test("calls callback and inserts when key is absent", () => {
+    const map = new Map();
+    const result = map.getOrInsertComputed("key", () => "computed");
+    expect(result).toBe("computed");
+    expect(map.get("key")).toBe("computed");
+    expect(map.size).toBe(1);
+  });
+
+  test("callback receives the key as argument", () => {
+    const map = new Map();
+    let receivedKey;
+    map.getOrInsertComputed("myKey", (key) => {
+      receivedKey = key;
+      return "value";
+    });
+    expect(receivedKey).toBe("myKey");
+  });
+
+  test("throws TypeError for non-callable callback", () => {
+    const map = new Map();
+    expect(() => map.getOrInsertComputed("key", "not a function")).toThrow();
+    expect(() => map.getOrInsertComputed("key", 42)).toThrow();
+    expect(() => map.getOrInsertComputed("key", null)).toThrow();
+    expect(() => map.getOrInsertComputed("key", undefined)).toThrow();
+  });
+
+  test("works with NaN key", () => {
+    const map = new Map();
+    map.getOrInsertComputed(NaN, () => "nan-value");
+    expect(map.get(NaN)).toBe("nan-value");
+    expect(map.getOrInsertComputed(NaN, () => "other")).toBe("nan-value");
+  });
+
+  test("works with object keys", () => {
+    const key = { id: 1 };
+    const map = new Map();
+    map.getOrInsertComputed(key, () => "found");
+    expect(map.get(key)).toBe("found");
+  });
+
+  test("lazy computation avoids expensive operations", () => {
+    const map = new Map([["cached", 42]]);
+    let computeCount = 0;
+    const compute = (key) => {
+      computeCount = computeCount + 1;
+      return key.length;
+    };
+    map.getOrInsertComputed("cached", compute);
+    map.getOrInsertComputed("cached", compute);
+    map.getOrInsertComputed("new", compute);
+    expect(computeCount).toBe(1);
+  });
+
+  test("handles grouping pattern with computed", () => {
+    const map = new Map();
+    const data = [
+      ["a", 1],
+      ["b", 2],
+      ["a", 3],
+    ];
+    data.forEach(([key, val]) => {
+      map.getOrInsertComputed(key, () => []).push(val);
+    });
+    expect(map.get("a").length).toBe(2);
+    expect(map.get("b").length).toBe(1);
+  });
+});

--- a/tests/built-ins/Math/sumPrecise.js
+++ b/tests/built-ins/Math/sumPrecise.js
@@ -1,0 +1,73 @@
+/*---
+description: Math.sumPrecise returns a precise sum of iterable elements
+features: [Math.sumPrecise]
+---*/
+
+const isGocciaScript = typeof GocciaScript !== "undefined";
+
+describe.runIf(isGocciaScript)("Math.sumPrecise", () => {
+  test("basic summation", () => {
+    expect(Math.sumPrecise([1, 2, 3])).toBe(6);
+    expect(Math.sumPrecise([10, 20, 30])).toBe(60);
+    expect(Math.sumPrecise([0.1, 0.2])).toBe(0.30000000000000004);
+  });
+
+  test("precise summation avoids floating point error", () => {
+    const result = Math.sumPrecise([1e20, 0.1, -1e20]);
+    expect(result).toBe(0.1);
+  });
+
+  test("single element", () => {
+    expect(Math.sumPrecise([42])).toBe(42);
+    expect(Math.sumPrecise([-5])).toBe(-5);
+  });
+
+  test("empty iterable returns negative zero", () => {
+    const result = Math.sumPrecise([]);
+    expect(Object.is(result, -0)).toBe(true);
+  });
+
+  test("NaN propagation", () => {
+    expect(Number.isNaN(Math.sumPrecise([1, NaN, 3]))).toBe(true);
+    expect(Number.isNaN(Math.sumPrecise([NaN]))).toBe(true);
+  });
+
+  test("positive Infinity", () => {
+    expect(Math.sumPrecise([1, Infinity, 3])).toBe(Infinity);
+    expect(Math.sumPrecise([Infinity])).toBe(Infinity);
+    expect(Math.sumPrecise([Infinity, Infinity])).toBe(Infinity);
+  });
+
+  test("negative Infinity", () => {
+    expect(Math.sumPrecise([1, -Infinity, 3])).toBe(-Infinity);
+    expect(Math.sumPrecise([-Infinity])).toBe(-Infinity);
+  });
+
+  test("mixed Infinity returns NaN", () => {
+    expect(Number.isNaN(Math.sumPrecise([Infinity, -Infinity]))).toBe(true);
+    expect(Number.isNaN(Math.sumPrecise([1, Infinity, -Infinity, 2]))).toBe(true);
+  });
+
+  test("works with Set iterable", () => {
+    const s = new Set([1, 2, 3]);
+    expect(Math.sumPrecise(s)).toBe(6);
+  });
+
+  test("throws TypeError for non-number elements", () => {
+    expect(() => Math.sumPrecise([1, "2", 3])).toThrow();
+    expect(() => Math.sumPrecise([true])).toThrow();
+    expect(() => Math.sumPrecise([null])).toThrow();
+    expect(() => Math.sumPrecise([undefined])).toThrow();
+    expect(() => Math.sumPrecise([{}])).toThrow();
+  });
+
+  test("throws TypeError for non-iterable argument", () => {
+    expect(() => Math.sumPrecise(42)).toThrow();
+    expect(() => Math.sumPrecise(null)).toThrow();
+  });
+
+  test("sum of many values", () => {
+    expect(Math.sumPrecise([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBe(55);
+    expect(Math.sumPrecise([100, 200, 300, 400])).toBe(1000);
+  });
+});

--- a/tests/built-ins/Math/sumPrecise.js
+++ b/tests/built-ins/Math/sumPrecise.js
@@ -54,16 +54,16 @@ describe.runIf(isGocciaScript)("Math.sumPrecise", () => {
   });
 
   test("throws TypeError for non-number elements", () => {
-    expect(() => Math.sumPrecise([1, "2", 3])).toThrow();
-    expect(() => Math.sumPrecise([true])).toThrow();
-    expect(() => Math.sumPrecise([null])).toThrow();
-    expect(() => Math.sumPrecise([undefined])).toThrow();
-    expect(() => Math.sumPrecise([{}])).toThrow();
+    expect(() => Math.sumPrecise([1, "2", 3])).toThrow(TypeError);
+    expect(() => Math.sumPrecise([true])).toThrow(TypeError);
+    expect(() => Math.sumPrecise([null])).toThrow(TypeError);
+    expect(() => Math.sumPrecise([undefined])).toThrow(TypeError);
+    expect(() => Math.sumPrecise([{}])).toThrow(TypeError);
   });
 
   test("throws TypeError for non-iterable argument", () => {
-    expect(() => Math.sumPrecise(42)).toThrow();
-    expect(() => Math.sumPrecise(null)).toThrow();
+    expect(() => Math.sumPrecise(42)).toThrow(TypeError);
+    expect(() => Math.sumPrecise(null)).toThrow(TypeError);
   });
 
   test("sum of many values", () => {

--- a/units/Goccia.Values.ErrorHelper.pas
+++ b/units/Goccia.Values.ErrorHelper.pas
@@ -39,9 +39,11 @@ uses
   Goccia.Values.Error,
   Goccia.Values.Primitives;
 
+// ES2026 §10.4.4.4 [[ErrorData]]
 function CreateErrorObject(const AName, AMessage: string; const ASkipTop: Integer = 0): TGocciaObjectValue;
 begin
   Result := TGocciaObjectValue.Create;
+  Result.HasErrorData := True;
   Result.AssignProperty(PROP_NAME, TGocciaStringLiteralValue.Create(AName));
   Result.AssignProperty(PROP_MESSAGE, TGocciaStringLiteralValue.Create(AMessage));
 
@@ -76,6 +78,7 @@ var
   ErrorObj: TGocciaObjectValue;
 begin
   ErrorObj := CreateErrorObject(DATA_CLONE_ERROR_NAME, AMessage);
+  ErrorObj.HasErrorData := False;
   ErrorObj.AssignProperty(PROP_CODE, TGocciaNumberLiteralValue.Create(25));
   if Assigned(GDOMExceptionProto) then
     ErrorObj.Prototype := GDOMExceptionProto;

--- a/units/Goccia.Values.ObjectValue.pas
+++ b/units/Goccia.Values.ObjectValue.pas
@@ -22,6 +22,7 @@ type
     FFrozen: Boolean;
     FSealed: Boolean;
     FExtensible: Boolean;
+    FHasErrorData: Boolean;
   public
     constructor Create(const APrototype: TGocciaObjectValue = nil);
     destructor Destroy; override;
@@ -79,6 +80,7 @@ type
     property Frozen: Boolean read FFrozen;
     property Sealed: Boolean read FSealed;
     property Extensible: Boolean read FExtensible;
+    property HasErrorData: Boolean read FHasErrorData write FHasErrorData;
   end;
 
 


### PR DESCRIPTION
…ath.sumPrecise`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Math.sumPrecise(): high-precision compensated summation
  * Error.isError(): static utility to detect Error instances
  * Map.prototype.getOrInsert() and getOrInsertComputed(): upsert APIs with eager/default and lazy-computed insertion

* **Tests**
  * Comprehensive test suites added covering all new behaviors and edge cases

* **Documentation**
  * Docs updated to document the new Math, Error, and Map APIs and test coverage counts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->