### PR TITLE
Add decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's based on the thought "What if we implement ECMAScript today, but without th
 
 - **Variables**: `let` and `const` declarations (no `var`)
 - **Functions**: Arrow functions only (no `function` keyword)
-- **Classes**: Full class support with private fields (`#field`), static methods, getters/setters, and inheritance
+- **Classes**: Full class support with private fields (`#field`), static methods, getters/setters, inheritance, and decorators
 - **Equality**: Strict equality only (`===` / `!==`)
 - **Strict Mode**: Implicit — all code runs in strict mode
 - **Template Literals**: String interpolation with `${expression}`
@@ -65,6 +65,8 @@ GocciaScript implements several active TC39 proposals:
 
 | Proposal | Stage | Description |
 |----------|-------|-------------|
+| [Decorators](https://github.com/tc39/proposal-decorators) | 3 | Class, method, field, getter/setter, auto-accessor decorators with `addInitializer` |
+| [Decorator Metadata](https://github.com/tc39/proposal-decorator-metadata) | 3 | `Symbol.metadata` for decorator-attached class metadata with inheritance |
 | [Types as Comments](https://tc39.es/proposal-type-annotations/) | 1 | TypeScript-style type annotations parsed and ignored at runtime |
 | [Enum Declarations](https://github.com/tc39/proposal-enum) | 0 | Frozen, null-prototype enum objects with `Symbol.iterator` |
 | [Temporal](https://tc39.es/proposal-temporal/) | 3 | Modern date/time API (`Temporal.PlainDate`, `Temporal.Duration`, `Temporal.Instant`, etc.) |

--- a/benchmarks/destructuring.js
+++ b/benchmarks/destructuring.js
@@ -83,3 +83,46 @@ suite("parameter destructuring", () => {
     const values = data.map(({ id, value }) => id + value);
   });
 });
+
+suite("callback destructuring", () => {
+  bench("forEach with array destructuring", () => {
+    const pairs = [[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]];
+    let sum = 0;
+    pairs.forEach(([k, v]) => { sum = sum + k + v; });
+  });
+
+  bench("map with array destructuring", () => {
+    const pairs = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]];
+    const sums = pairs.map(([a, b]) => a + b);
+  });
+
+  bench("filter with array destructuring", () => {
+    const entries = [[1, 10], [2, 5], [3, 20], [4, 3], [5, 15]];
+    const big = entries.filter(([, val]) => val > 8);
+  });
+
+  bench("reduce with array destructuring", () => {
+    const entries = [[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]];
+    const total = entries.reduce((acc, [, v]) => acc + v, 0);
+  });
+
+  bench("map with object destructuring", () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ id: i, name: "item", value: i * 10 }));
+    const ids = items.map(({ id }) => id);
+  });
+
+  bench("map with nested destructuring", () => {
+    const data = Array.from({ length: 10 }, (_, i) => ({ user: { name: "u" + i }, score: i }));
+    const names = data.map(({ user: { name } }) => name);
+  });
+
+  bench("map with rest in destructuring", () => {
+    const rows = Array.from({ length: 10 }, (_, i) => [i, i + 1, i + 2, i + 3]);
+    const firsts = rows.map(([first, ...rest]) => first + rest.length);
+  });
+
+  bench("map with defaults in destructuring", () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ x: i }));
+    const ys = items.map(({ x, y = 0 }) => x + y);
+  });
+});

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -109,7 +109,7 @@ The `BenchmarkRunner` program:
 | `benchmarks/closures.js` | Closure capture, higher-order functions, call/apply/bind, recursion |
 | `benchmarks/collections.js` | Set add/has/delete/forEach, Map set/get/has/delete/forEach/keys/values |
 | `benchmarks/json.js` | JSON.parse, JSON.stringify, roundtrip with nested and mixed data |
-| `benchmarks/destructuring.js` | Array/object/parameter destructuring, rest, defaults, nesting |
+| `benchmarks/destructuring.js` | Array/object/parameter/callback destructuring, rest, defaults, nesting |
 | `benchmarks/promises.js` | Promise.resolve/reject, then chains, catch/finally, all/race/allSettled/any |
 
 ## Sample Output

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -105,7 +105,7 @@ The `BenchmarkRunner` program:
 | `benchmarks/arrays.js` | Array.from, map, filter, reduce, forEach, find, sort, flat, flatMap |
 | `benchmarks/objects.js` | Object creation, property access, Object.keys/entries, spread |
 | `benchmarks/strings.js` | Concatenation, template literals, split/join, indexOf, trim, replace, pad |
-| `benchmarks/classes.js` | Instantiation, method dispatch, single/multi-level inheritance, private fields, getters/setters |
+| `benchmarks/classes.js` | Instantiation, method dispatch, inheritance, private fields, getters/setters, decorators (class, method, field, getter/setter, static, private, auto-accessor, metadata) |
 | `benchmarks/closures.js` | Closure capture, higher-order functions, call/apply/bind, recursion |
 | `benchmarks/collections.js` | Set add/has/delete/forEach, Map set/get/has/delete/forEach/keys/values |
 | `benchmarks/json.js` | JSON.parse, JSON.stringify, roundtrip with nested and mixed data |

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -389,6 +389,7 @@ Symbols are unique, immutable primitive values used as property keys.
 | `Symbol.toPrimitive` | Well-known symbol for type conversion |
 | `Symbol.toStringTag` | Well-known symbol for Object.prototype.toString |
 | `Symbol.isConcatSpreadable` | Well-known symbol for Array.prototype.concat |
+| `Symbol.metadata` | Well-known symbol for decorator metadata (TC39 proposal-decorator-metadata) |
 | `symbol.toString()` | Returns `"Symbol(description)"` |
 | `symbol.description` | The description string, or `undefined` |
 

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -45,6 +45,7 @@ add.length; // 2
 - Private fields and methods (`#field`).
 - Static properties.
 - Inheritance with `extends` and `super`.
+- Decorators (see [Decorators](#decorators) below).
 
 ```javascript
 class Counter {
@@ -53,6 +54,52 @@ class Counter {
   get value() { return this.#count; }
 }
 ```
+
+### Decorators
+
+TC39 Stage 3 decorators ([proposal-decorators](https://github.com/tc39/proposal-decorators)) and decorator metadata ([proposal-decorator-metadata](https://github.com/tc39/proposal-decorator-metadata)) are fully supported.
+
+**Supported decorator targets:**
+- Class declarations (`@decorator class C {}`)
+- Instance and static methods (`@decorator method() {}`)
+- Getters and setters (`@decorator get x() {}`, `@decorator set x(v) {}`)
+- Class fields (`@decorator field = value;`)
+- Auto-accessors (`@decorator accessor prop = value;`)
+- Private elements (`@decorator #method() {}`)
+
+**Decorator context object properties:** `kind`, `name`, `access` (with `get`/`set`), `static`, `private`, `addInitializer`, `metadata`.
+
+**Decorator expressions:** Identifiers (`@log`), member access (`@decorators.log`), call expressions (`@factory(arg)`), and parenthesized expressions (`@(expr)`).
+
+**Auto-accessors:** The `accessor` keyword creates a property backed by a private storage slot with generated getter/setter methods:
+
+```javascript
+class C {
+  accessor name = "default";
+}
+// Equivalent to a private #name field with get name() / set name(v)
+```
+
+**`addInitializer`:** Decorators can register initialization callbacks via `context.addInitializer()`. Timing depends on decorator kind:
+- Class decorators: after the class is fully defined and static fields are assigned.
+- Static method/getter/setter: during class definition, after static methods are placed.
+- Non-static method/getter/setter: during class construction, before field initialization.
+- Field/accessor: during construction, immediately after the decorated element is initialized.
+
+**`Symbol.metadata`:** Each decorated class receives a `[Symbol.metadata]` property containing a null-prototype object. Metadata objects inherit from the parent class's metadata via prototype chain.
+
+```javascript
+const meta = (value, context) => {
+  context.metadata.decorated = true;
+};
+
+@meta
+class C {}
+
+C[Symbol.metadata].decorated; // true
+```
+
+**Not supported:** Parameter decorators.
 
 ### Expressions
 
@@ -384,7 +431,6 @@ enum Tokens { Alpha = Symbol("alpha") }
 - Namespaces (`namespace Foo { ... }`).
 - Parameter properties in constructors (`constructor(public x: number)`).
 - Angle-bracket type assertions (`<string>value`) — use `value as string` instead.
-- Decorators (`@decorator`).
 
 ### JSX (Opt-in)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,13 +46,15 @@ tests/
 └── language/               # Core language feature tests
     ├── classes/            # Class declarations, inheritance, private fields/methods/getters/setters
     ├── declarations/       # let, const
-    ├── expressions/        # Arithmetic, comparison, logical, destructuring, etc.
+    ├── decorators/         # TC39 Stage 3 decorators and decorator metadata
+    ├── expressions/        # Arithmetic, comparison, logical, destructuring, trailing commas, etc.
     │   ├── addition/       # Addition with ToPrimitive
     │   ├── arithmetic/     # Division (IEEE-754 signed zeros, Infinity), exponentiation (Infinity edge cases)
     │   ├── bitwise/        # Bitwise OR, AND, XOR, NOT, shifts
     │   ├── modulo/         # Floating-point modulo
     │   ├── conditional/    # Ternary precedence
     │   ├── optional-chaining/  # Optional chaining (?.) edge cases
+    │   ├── trailing-commas.js  # Trailing commas in calls, parameters, constructors
     │   └── ...
     ├── functions/          # Arrow functions, closures, higher-order, recursion
     │   └── function-length-name.js  # Function.length and Function.name
@@ -188,6 +190,7 @@ expect(value).toBeInstanceOf(ClassName);
 // Errors
 expect(() => throwingFn()).toThrow();
 expect(() => throwingFn()).toThrow(TypeError);  // Check error constructor
+expect(() => throwingFn()).toThrow(RangeError);
 
 // Negation
 expect(value).not.toBe(wrong);
@@ -343,6 +346,20 @@ expect([...set.values()]).toEqual([1, 2, 3]);
 5. **Edge cases matter** — Tests should cover `NaN`, `undefined`, `null`, empty arrays, negative numbers, boundary conditions, and type coercion scenarios.
 
 6. **Readable as specification** — Test names should describe the expected behavior. A passing test suite serves as living documentation of what GocciaScript supports.
+
+7. **Always pass an error constructor to `.toThrow()`** — When testing that code throws, pass the expected error constructor (`TypeError`, `RangeError`, `SyntaxError`, `Error`, etc.) to `.toThrow()` rather than calling it bare. This ensures the test verifies the correct error type, not just that *something* throws.
+
+```javascript
+// Preferred — verifies the error type
+expect(() => null.foo).toThrow(TypeError);
+expect(() => new Array(-1)).toThrow(RangeError);
+
+// Acceptable for cases where the error type is implementation-defined
+expect(() => riskyOp()).toThrow();
+
+// Avoid — doesn't verify the error type
+expect(() => null.foo).toThrow();  // passes even if the wrong error is thrown
+```
 
 ## How the TestRunner Works
 

--- a/tests/built-ins/Map/prototype/getOrInsertComputed.js
+++ b/tests/built-ins/Map/prototype/getOrInsertComputed.js
@@ -37,10 +37,12 @@ describe.runIf(isGocciaScript)("Map.prototype.getOrInsertComputed", () => {
 
   test("throws TypeError for non-callable callback", () => {
     const map = new Map();
-    expect(() => map.getOrInsertComputed("key", "not a function")).toThrow();
-    expect(() => map.getOrInsertComputed("key", 42)).toThrow();
-    expect(() => map.getOrInsertComputed("key", null)).toThrow();
-    expect(() => map.getOrInsertComputed("key", undefined)).toThrow();
+    expect(() => map.getOrInsertComputed("key", "not a function")).toThrow(
+      TypeError,
+    );
+    expect(() => map.getOrInsertComputed("key", 42)).toThrow(TypeError);
+    expect(() => map.getOrInsertComputed("key", null)).toThrow(TypeError);
+    expect(() => map.getOrInsertComputed("key", undefined)).toThrow(TypeError);
   });
 
   test("works with NaN key", () => {

--- a/tests/built-ins/structuredClone/errors.js
+++ b/tests/built-ins/structuredClone/errors.js
@@ -29,7 +29,7 @@ test("throws DOMException with DataCloneError on symbol", () => {
 });
 
 test("throws when no arguments provided", () => {
-  expect(() => structuredClone()).toThrow();
+  expect(() => structuredClone()).toThrow(TypeError);
 });
 
 test("throws DOMException with DataCloneError on object containing a function", () => {

--- a/tests/language/decorators/add-initializer.js
+++ b/tests/language/decorators/add-initializer.js
@@ -1,0 +1,42 @@
+/*---
+description: addInitializer on decorator context runs callbacks at the correct time
+features: [decorators]
+---*/
+
+describe("addInitializer", () => {
+  test("class addInitializer runs after class definition", () => {
+    let initialized = false;
+
+    const init = (cls, context) => {
+      context.addInitializer(() => {
+        initialized = true;
+      });
+    };
+
+    expect(initialized).toBe(false);
+
+    @init
+    class C {}
+
+    expect(initialized).toBe(true);
+  });
+
+  test("method addInitializer runs during construction", () => {
+    let initCalled = false;
+
+    const dec = (method, context) => {
+      context.addInitializer(() => {
+        initCalled = true;
+      });
+    };
+
+    class C {
+      @dec
+      foo() {}
+    }
+
+    expect(initCalled).toBe(false);
+    const c = new C();
+    expect(initCalled).toBe(true);
+  });
+});

--- a/tests/language/decorators/auto-accessor-decorator.js
+++ b/tests/language/decorators/auto-accessor-decorator.js
@@ -1,0 +1,25 @@
+/*---
+description: Auto-accessor decorators receive {get, set} and can return {get?, set?, init?}
+features: [decorators, auto-accessor]
+---*/
+
+describe("auto-accessor decorators", () => {
+  test("accessor decorator receives get/set object and context", () => {
+    let receivedValue;
+    let receivedContext;
+
+    const log = (value, context) => {
+      receivedValue = value;
+      receivedContext = context;
+    };
+
+    class C {
+      @log
+      accessor x = 42;
+    }
+
+    expect(receivedContext.kind).toBe("accessor");
+    expect(receivedContext.name).toBe("x");
+    expect(typeof receivedValue).toBe("object");
+  });
+});

--- a/tests/language/decorators/auto-accessor.js
+++ b/tests/language/decorators/auto-accessor.js
@@ -1,0 +1,34 @@
+/*---
+description: Auto-accessor class elements create getter/setter pairs with a backing field
+features: [decorators, auto-accessor]
+---*/
+
+describe("auto-accessor", () => {
+  test("basic auto-accessor with initializer", () => {
+    class C {
+      accessor x = 42;
+    }
+
+    const c = new C();
+    expect(c.x).toBe(42);
+  });
+
+  test("auto-accessor can be set", () => {
+    class C {
+      accessor x = 0;
+    }
+
+    const c = new C();
+    c.x = 100;
+    expect(c.x).toBe(100);
+  });
+
+  test("auto-accessor without initializer", () => {
+    class C {
+      accessor x;
+    }
+
+    const c = new C();
+    expect(c.x).toBe(undefined);
+  });
+});

--- a/tests/language/decorators/basic-class-decorator.js
+++ b/tests/language/decorators/basic-class-decorator.js
@@ -1,0 +1,59 @@
+/*---
+description: Class decorators receive the class and can wrap or replace it
+features: [decorators]
+---*/
+
+describe("class decorators", () => {
+  test("decorator receives class and context", () => {
+    let receivedClass;
+    let receivedContext;
+
+    const log = (cls, context) => {
+      receivedClass = cls;
+      receivedContext = context;
+    };
+
+    @log
+    class MyClass {
+      value = 42;
+    }
+
+    expect(receivedContext.kind).toBe("class");
+    expect(receivedContext.name).toBe("MyClass");
+  });
+
+  test("decorator returning undefined keeps original class", () => {
+    const noop = (cls, context) => {
+      return undefined;
+    };
+
+    @noop
+    class C {
+      greet() {
+        return "hello";
+      }
+    }
+
+    const c = new C();
+    expect(c.greet()).toBe("hello");
+  });
+
+  test("multiple class decorators applied bottom-up", () => {
+    const calls = [];
+
+    const first = (cls, context) => {
+      calls.push("first");
+    };
+
+    const second = (cls, context) => {
+      calls.push("second");
+    };
+
+    @first
+    @second
+    class C {}
+
+    expect(calls[0]).toBe("second");
+    expect(calls[1]).toBe("first");
+  });
+});

--- a/tests/language/decorators/basic-field-decorator.js
+++ b/tests/language/decorators/basic-field-decorator.js
@@ -1,0 +1,57 @@
+/*---
+description: Field decorators receive undefined as value and can return initializer functions
+features: [decorators]
+---*/
+
+describe("field decorators", () => {
+  test("decorator receives undefined and context", () => {
+    let receivedValue;
+    let receivedContext;
+
+    const log = (value, context) => {
+      receivedValue = value;
+      receivedContext = context;
+    };
+
+    class C {
+      @log
+      x = 42;
+    }
+
+    expect(receivedValue).toBe(undefined);
+    expect(receivedContext.kind).toBe("field");
+    expect(receivedContext.name).toBe("x");
+    expect(receivedContext.static).toBe(false);
+    expect(receivedContext.private).toBe(false);
+  });
+
+  test("decorator can return initializer function", () => {
+    const doubleInit = (value, context) => {
+      return (initialValue) => {
+        return initialValue * 2;
+      };
+    };
+
+    class C {
+      @doubleInit
+      x = 21;
+    }
+
+    const c = new C();
+    expect(c.x).toBe(42);
+  });
+
+  test("decorator returning undefined keeps original initializer", () => {
+    const noop = (value, context) => {
+      return undefined;
+    };
+
+    class C {
+      @noop
+      x = 42;
+    }
+
+    const c = new C();
+    expect(c.x).toBe(42);
+  });
+});

--- a/tests/language/decorators/basic-field-decorator.js
+++ b/tests/language/decorators/basic-field-decorator.js
@@ -54,4 +54,51 @@ describe("field decorators", () => {
     const c = new C();
     expect(c.x).toBe(42);
   });
+
+  test("decorator context for static field", () => {
+    let ctx;
+    const capture = (value, context) => {
+      ctx = context;
+    };
+
+    class C {
+      @capture
+      static x = 1;
+    }
+
+    expect(ctx.kind).toBe("field");
+    expect(ctx.name).toBe("x");
+    expect(ctx.static).toBe(true);
+    expect(ctx.private).toBe(false);
+  });
+
+  test("decorator context for private field", () => {
+    let ctx;
+    const capture = (value, context) => {
+      ctx = context;
+    };
+
+    class C {
+      @capture
+      #secret = 1;
+    }
+
+    expect(ctx.kind).toBe("field");
+    expect(ctx.name).toBe("#secret");
+    expect(ctx.static).toBe(false);
+    expect(ctx.private).toBe(true);
+  });
+
+  test("decorator that throws propagates error", () => {
+    const bomb = (value, context) => {
+      throw new Error("decorator failed");
+    };
+
+    expect(() => {
+      class C {
+        @bomb
+        x = 1;
+      }
+    }).toThrow(Error);
+  });
 });

--- a/tests/language/decorators/basic-getter-setter-decorator.js
+++ b/tests/language/decorators/basic-getter-setter-decorator.js
@@ -1,0 +1,48 @@
+/*---
+description: Getter and setter decorators can wrap accessor functions
+features: [decorators]
+---*/
+
+describe("getter and setter decorators", () => {
+  test("getter decorator receives function and context", () => {
+    let receivedContext;
+
+    const log = (fn, context) => {
+      receivedContext = context;
+      return fn;
+    };
+
+    class C {
+      #value = 42;
+
+      @log
+      get value() {
+        return this.#value;
+      }
+    }
+
+    expect(receivedContext.kind).toBe("getter");
+    expect(receivedContext.name).toBe("value");
+  });
+
+  test("setter decorator receives function and context", () => {
+    let receivedContext;
+
+    const log = (fn, context) => {
+      receivedContext = context;
+      return fn;
+    };
+
+    class C {
+      #value = 0;
+
+      @log
+      set value(v) {
+        this.#value = v;
+      }
+    }
+
+    expect(receivedContext.kind).toBe("setter");
+    expect(receivedContext.name).toBe("value");
+  });
+});

--- a/tests/language/decorators/basic-method-decorator.js
+++ b/tests/language/decorators/basic-method-decorator.js
@@ -1,0 +1,89 @@
+/*---
+description: Method decorators can wrap and replace class methods
+features: [decorators]
+---*/
+
+describe("method decorators", () => {
+  test("decorator receives method and context", () => {
+    let receivedContext;
+
+    const log = (method, context) => {
+      receivedContext = context;
+      return method;
+    };
+
+    class C {
+      @log
+      greet() {
+        return "hello";
+      }
+    }
+
+    const c = new C();
+    expect(c.greet()).toBe("hello");
+    expect(receivedContext.kind).toBe("method");
+    expect(receivedContext.name).toBe("greet");
+    expect(receivedContext.static).toBe(false);
+    expect(receivedContext.private).toBe(false);
+  });
+
+  test("decorator can replace method", () => {
+    const double = (method, context) => {
+      return (/* ...args */) => {
+        const result = method.call(this);
+        return result * 2;
+      };
+    };
+
+    class Calculator {
+      @double
+      value() {
+        return 21;
+      }
+    }
+
+    const calc = new Calculator();
+    expect(calc.value()).toBe(42);
+  });
+
+  test("decorator returning undefined keeps original", () => {
+    const noop = (method, context) => {
+      return undefined;
+    };
+
+    class C {
+      @noop
+      greet() {
+        return "hello";
+      }
+    }
+
+    const c = new C();
+    expect(c.greet()).toBe("hello");
+  });
+
+  test("multiple decorators applied bottom-up", () => {
+    const calls = [];
+
+    const first = (method, context) => {
+      calls.push("first");
+      return method;
+    };
+
+    const second = (method, context) => {
+      calls.push("second");
+      return method;
+    };
+
+    class C {
+      @first
+      @second
+      greet() {
+        return "hello";
+      }
+    }
+
+    expect(calls[0]).toBe("second");
+    expect(calls[1]).toBe("first");
+  });
+});

--- a/tests/language/decorators/decorator-context.js
+++ b/tests/language/decorators/decorator-context.js
@@ -1,0 +1,80 @@
+/*---
+description: Decorator context object has correct properties for each element kind
+features: [decorators]
+---*/
+
+describe("decorator context properties", () => {
+  test("method context has correct properties", () => {
+    let ctx;
+    const capture = (v, c) => { ctx = c; };
+
+    class C {
+      @capture
+      foo() {}
+    }
+
+    expect(ctx.kind).toBe("method");
+    expect(ctx.name).toBe("foo");
+    expect(ctx.static).toBe(false);
+    expect(ctx.private).toBe(false);
+    expect(typeof ctx.addInitializer).toBe("function");
+    expect(typeof ctx.metadata).toBe("object");
+  });
+
+  test("static method context", () => {
+    let ctx;
+    const capture = (v, c) => { ctx = c; };
+
+    class C {
+      @capture
+      static bar() {}
+    }
+
+    expect(ctx.kind).toBe("method");
+    expect(ctx.name).toBe("bar");
+    expect(ctx.static).toBe(true);
+    expect(ctx.private).toBe(false);
+  });
+
+  test("field context has correct properties", () => {
+    let ctx;
+    const capture = (v, c) => { ctx = c; };
+
+    class C {
+      @capture
+      x = 1;
+    }
+
+    expect(ctx.kind).toBe("field");
+    expect(ctx.name).toBe("x");
+    expect(ctx.static).toBe(false);
+    expect(ctx.private).toBe(false);
+  });
+
+  test("static field context", () => {
+    let ctx;
+    const capture = (v, c) => { ctx = c; };
+
+    class C {
+      @capture
+      static y = 2;
+    }
+
+    expect(ctx.kind).toBe("field");
+    expect(ctx.name).toBe("y");
+    expect(ctx.static).toBe(true);
+  });
+
+  test("class decorator context has correct properties", () => {
+    let ctx;
+    const capture = (cls, c) => { ctx = c; };
+
+    @capture
+    class MyClass {}
+
+    expect(ctx.kind).toBe("class");
+    expect(ctx.name).toBe("MyClass");
+    expect(typeof ctx.addInitializer).toBe("function");
+    expect(typeof ctx.metadata).toBe("object");
+  });
+});

--- a/tests/language/decorators/decorator-errors.js
+++ b/tests/language/decorators/decorator-errors.js
@@ -5,15 +5,11 @@ features: [decorators]
 
 describe("decorator errors", () => {
   test("non-callable decorator throws", () => {
-    let threw = false;
-    try {
+    expect(() => {
       const notAFunction = 42;
 
       @notAFunction
       class C {}
-    } catch (e) {
-      threw = true;
-    }
-    expect(threw).toBe(true);
+    }).toThrow(TypeError);
   });
 });

--- a/tests/language/decorators/decorator-errors.js
+++ b/tests/language/decorators/decorator-errors.js
@@ -1,0 +1,19 @@
+/*---
+description: Decorator error cases throw appropriate errors
+features: [decorators]
+---*/
+
+describe("decorator errors", () => {
+  test("non-callable decorator throws", () => {
+    let threw = false;
+    try {
+      const notAFunction = 42;
+
+      @notAFunction
+      class C {}
+    } catch (e) {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+  });
+});

--- a/tests/language/decorators/decorator-expressions.js
+++ b/tests/language/decorators/decorator-expressions.js
@@ -1,0 +1,68 @@
+/*---
+description: Decorator expressions support property access and calls
+features: [decorators]
+---*/
+
+describe("decorator expressions", () => {
+  test("@identifier", () => {
+    let called = false;
+    const dec = (value, context) => { called = true; };
+
+    class C {
+      @dec
+      foo() {}
+    }
+
+    expect(called).toBe(true);
+  });
+
+  test("@obj.property", () => {
+    let called = false;
+    const decorators = {
+      log: (value, context) => { called = true; },
+    };
+
+    class C {
+      @decorators.log
+      foo() {}
+    }
+
+    expect(called).toBe(true);
+  });
+
+  test("@factory(arg)", () => {
+    let receivedArg;
+
+    const withTag = (tag) => {
+      return (value, context) => {
+        receivedArg = tag;
+      };
+    };
+
+    class C {
+      @withTag("important")
+      foo() {}
+    }
+
+    expect(receivedArg).toBe("important");
+  });
+
+  test("@obj.factory(arg)", () => {
+    let receivedArg;
+
+    const decorators = {
+      withTag: (tag) => {
+        return (value, context) => {
+          receivedArg = tag;
+        };
+      },
+    };
+
+    class C {
+      @decorators.withTag("test")
+      foo() {}
+    }
+
+    expect(receivedArg).toBe("test");
+  });
+});

--- a/tests/language/decorators/decorator-metadata.js
+++ b/tests/language/decorators/decorator-metadata.js
@@ -1,0 +1,60 @@
+/*---
+description: Symbol.metadata is assigned on decorated classes with prototype chain inheritance
+features: [decorators, decorator-metadata]
+---*/
+
+describe("decorator metadata", () => {
+  test("Symbol.metadata exists on decorated class", () => {
+    const track = (value, context) => {
+      context.metadata.tracked = true;
+    };
+
+    @track
+    class C {}
+
+    const meta = C[Symbol.metadata];
+    expect(meta).not.toBe(undefined);
+    expect(meta.tracked).toBe(true);
+  });
+
+  test("metadata is shared across decorators on same class", () => {
+    const first = (value, context) => {
+      context.metadata.first = true;
+    };
+
+    const second = (value, context) => {
+      context.metadata.second = true;
+    };
+
+    class C {
+      @first
+      foo() {}
+
+      @second
+      bar() {}
+    }
+
+    const meta = C[Symbol.metadata];
+    expect(meta.first).toBe(true);
+    expect(meta.second).toBe(true);
+  });
+
+  test("metadata object is provided to all element decorators", () => {
+    const collected = [];
+
+    const track = (value, context) => {
+      collected.push(context.metadata);
+    };
+
+    class C {
+      @track
+      a() {}
+
+      @track
+      b() {}
+    }
+
+    expect(collected.length).toBe(2);
+    expect(collected[0] === collected[1]).toBe(true);
+  });
+});

--- a/tests/language/decorators/decorator-metadata.js
+++ b/tests/language/decorators/decorator-metadata.js
@@ -57,4 +57,24 @@ describe("decorator metadata", () => {
     expect(collected.length).toBe(2);
     expect(collected[0] === collected[1]).toBe(true);
   });
+
+  test("subclass metadata inherits from superclass metadata", () => {
+    const tag = (key, val) => (value, context) => {
+      context.metadata[key] = val;
+    };
+
+    @tag('base', true)
+    class Base {}
+
+    @tag('child', true)
+    class Child extends Base {}
+
+    const baseMeta = Base[Symbol.metadata];
+    const childMeta = Child[Symbol.metadata];
+
+    expect(baseMeta.base).toBe(true);
+    expect(childMeta.child).toBe(true);
+    expect(childMeta.base).toBe(true);
+    expect(baseMeta.child).toBe(undefined);
+  });
 });

--- a/tests/language/decorators/decorator-order.js
+++ b/tests/language/decorators/decorator-order.js
@@ -4,7 +4,7 @@ features: [decorators]
 ---*/
 
 describe("decorator ordering", () => {
-  test("decorators evaluated top-to-bottom", () => {
+  test("decorators applied bottom-to-top", () => {
     const order = [];
 
     const first = (value, context) => { order.push("first-call"); };

--- a/tests/language/decorators/decorator-order.js
+++ b/tests/language/decorators/decorator-order.js
@@ -1,0 +1,43 @@
+/*---
+description: Decorator evaluation and application order follows the spec
+features: [decorators]
+---*/
+
+describe("decorator ordering", () => {
+  test("decorators evaluated top-to-bottom", () => {
+    const order = [];
+
+    const first = (value, context) => { order.push("first-call"); };
+    const second = (value, context) => { order.push("second-call"); };
+
+    class C {
+      @first
+      @second
+      foo() {}
+    }
+
+    expect(order[0]).toBe("second-call");
+    expect(order[1]).toBe("first-call");
+  });
+
+  test("element decorators called before class decorator", () => {
+    const order = [];
+
+    const classDecorator = (cls, context) => {
+      order.push("class");
+    };
+
+    const methodDecorator = (method, context) => {
+      order.push("method");
+    };
+
+    @classDecorator
+    class C {
+      @methodDecorator
+      foo() {}
+    }
+
+    expect(order[0]).toBe("method");
+    expect(order[1]).toBe("class");
+  });
+});

--- a/tests/language/decorators/private-decorators.js
+++ b/tests/language/decorators/private-decorators.js
@@ -1,0 +1,32 @@
+/*---
+description: Decorators work on private class elements
+features: [decorators]
+---*/
+
+describe("private element decorators", () => {
+  test("private method decorator reports private name", () => {
+    let receivedContext;
+
+    const log = (method, context) => {
+      receivedContext = context;
+      return method;
+    };
+
+    class C {
+      @log
+      #greet() {
+        return "hello";
+      }
+
+      callGreet() {
+        return this.#greet();
+      }
+    }
+
+    const c = new C();
+    expect(c.callGreet()).toBe("hello");
+    expect(receivedContext.kind).toBe("method");
+    expect(receivedContext.name).toBe("#greet");
+    expect(receivedContext.private).toBe(true);
+  });
+});

--- a/tests/language/decorators/static-decorators.js
+++ b/tests/language/decorators/static-decorators.js
@@ -1,0 +1,44 @@
+/*---
+description: Decorators work on static class elements
+features: [decorators]
+---*/
+
+describe("static element decorators", () => {
+  test("static method decorator", () => {
+    let receivedContext;
+
+    const log = (method, context) => {
+      receivedContext = context;
+      return method;
+    };
+
+    class C {
+      @log
+      static greet() {
+        return "hello";
+      }
+    }
+
+    expect(receivedContext.kind).toBe("method");
+    expect(receivedContext.name).toBe("greet");
+    expect(receivedContext.static).toBe(true);
+    expect(C.greet()).toBe("hello");
+  });
+
+  test("static field decorator", () => {
+    let receivedContext;
+
+    const log = (value, context) => {
+      receivedContext = context;
+    };
+
+    class C {
+      @log
+      static x = 42;
+    }
+
+    expect(receivedContext.kind).toBe("field");
+    expect(receivedContext.name).toBe("x");
+    expect(receivedContext.static).toBe(true);
+  });
+});

--- a/tests/language/decorators/symbol-metadata.js
+++ b/tests/language/decorators/symbol-metadata.js
@@ -1,0 +1,18 @@
+/*---
+description: Symbol.metadata is available as a well-known symbol
+features: [decorators, decorator-metadata]
+---*/
+
+describe("Symbol.metadata", () => {
+  test("Symbol.metadata is a symbol", () => {
+    expect(typeof Symbol.metadata).toBe("symbol");
+  });
+
+  test("Symbol.metadata is always the same instance", () => {
+    expect(Symbol.metadata === Symbol.metadata).toBe(true);
+  });
+
+  test("Symbol.metadata description", () => {
+    expect(Symbol.metadata.toString()).toBe("Symbol(Symbol.metadata)");
+  });
+});

--- a/tests/language/expressions/destructuring/parameters.js
+++ b/tests/language/expressions/destructuring/parameters.js
@@ -1,0 +1,135 @@
+/*---
+description: Destructuring in function and callback parameters
+features: [destructuring, arrow-functions]
+---*/
+
+describe("destructuring parameters", () => {
+  describe("array destructuring in parameters", () => {
+    test("basic array parameter", () => {
+      const sum = ([a, b]) => a + b;
+      expect(sum([1, 2])).toBe(3);
+    });
+
+    test("with rest element", () => {
+      const headAndTail = ([head, ...tail]) => ({ head, tail });
+      const result = headAndTail([1, 2, 3, 4]);
+      expect(result.head).toBe(1);
+      expect(result.tail).toEqual([2, 3, 4]);
+    });
+
+    test("with default values", () => {
+      const f = ([a, b = 10, c = 20]) => a + b + c;
+      expect(f([1])).toBe(31);
+      expect(f([1, 2])).toBe(23);
+      expect(f([1, 2, 3])).toBe(6);
+    });
+
+    test("skipping elements", () => {
+      const third = ([, , c]) => c;
+      expect(third([1, 2, 3])).toBe(3);
+    });
+
+    test("nested array destructuring", () => {
+      const f = ([[a, b], [c, d]]) => a + b + c + d;
+      expect(f([[1, 2], [3, 4]])).toBe(10);
+    });
+
+    test("multiple destructured params", () => {
+      const f = ([a, b], [c, d]) => a + b + c + d;
+      expect(f([1, 2], [3, 4])).toBe(10);
+    });
+  });
+
+  describe("object destructuring in parameters", () => {
+    test("basic object parameter", () => {
+      const greet = ({ name }) => "hello " + name;
+      expect(greet({ name: "Alice" })).toBe("hello Alice");
+    });
+
+    test("multiple properties", () => {
+      const area = ({ width, height }) => width * height;
+      expect(area({ width: 3, height: 4 })).toBe(12);
+    });
+
+    test("with defaults", () => {
+      const f = ({ x = 0, y = 0 }) => x + y;
+      expect(f({})).toBe(0);
+      expect(f({ x: 5 })).toBe(5);
+      expect(f({ x: 3, y: 7 })).toBe(10);
+    });
+
+    test("with renaming", () => {
+      const f = ({ firstName: first, lastName: last }) => first + " " + last;
+      expect(f({ firstName: "Alice", lastName: "Smith" })).toBe("Alice Smith");
+    });
+
+    test("nested object destructuring", () => {
+      const city = ({ address: { city } }) => city;
+      expect(city({ address: { city: "NYC" } })).toBe("NYC");
+    });
+
+    test("with rest properties", () => {
+      const f = ({ a, ...rest }) => Object.keys(rest).length;
+      expect(f({ a: 1, b: 2, c: 3 })).toBe(2);
+    });
+  });
+
+  describe("callback parameters with destructuring", () => {
+    test("forEach with array destructuring", () => {
+      const data = [["a", 1], ["b", 2], ["c", 3]];
+      let result = "";
+      data.forEach(([key, val]) => {
+        result = result + key + val;
+      });
+      expect(result).toBe("a1b2c3");
+    });
+
+    test("map with array destructuring", () => {
+      const pairs = [[1, 2], [3, 4], [5, 6]];
+      const sums = pairs.map(([a, b]) => a + b);
+      expect(sums).toEqual([3, 7, 11]);
+    });
+
+    test("map with object destructuring", () => {
+      const items = [{ name: "a", value: 1 }, { name: "b", value: 2 }];
+      const names = items.map(({ name }) => name);
+      expect(names).toEqual(["a", "b"]);
+    });
+
+    test("filter with destructuring", () => {
+      const entries = [["x", 10], ["y", 5], ["z", 20]];
+      const big = entries.filter(([, val]) => val > 8);
+      expect(big.length).toBe(2);
+    });
+
+    test("reduce with destructuring", () => {
+      const entries = [["a", 1], ["b", 2], ["c", 3]];
+      const sum = entries.reduce((acc, [, val]) => acc + val, 0);
+      expect(sum).toBe(6);
+    });
+
+    test("nested destructuring in callback", () => {
+      const data = [{ user: { name: "Alice" } }, { user: { name: "Bob" } }];
+      const names = data.map(({ user: { name } }) => name);
+      expect(names).toEqual(["Alice", "Bob"]);
+    });
+
+    test("rest in array destructuring callback", () => {
+      const rows = [[1, 2, 3, 4], [5, 6, 7, 8]];
+      const firsts = rows.map(([first, ...rest]) => first);
+      expect(firsts).toEqual([1, 5]);
+    });
+
+    test("default values in destructuring callback", () => {
+      const items = [{ x: 1 }, { x: 2, y: 10 }];
+      const ys = items.map(({ y = 0 }) => y);
+      expect(ys).toEqual([0, 10]);
+    });
+
+    test("mixed destructuring and regular params in callback", () => {
+      const data = [[10, 20], [30, 40]];
+      const result = data.map(([a, b], index) => a + b + index);
+      expect(result).toEqual([30, 71]);
+    });
+  });
+});

--- a/tests/language/expressions/trailing-commas.js
+++ b/tests/language/expressions/trailing-commas.js
@@ -1,0 +1,158 @@
+/*---
+description: Trailing commas in function calls, parameters, constructors, arrays, and objects
+features: [trailing-commas]
+---*/
+
+describe("trailing commas", () => {
+  describe("function call arguments", () => {
+    test("single argument with trailing comma", () => {
+      const f = (x) => x * 2;
+      expect(f(3,)).toBe(6);
+    });
+
+    test("multiple arguments with trailing comma", () => {
+      const f = (a, b, c) => a + b + c;
+      expect(f(1, 2, 3,)).toBe(6);
+    });
+
+    test("method call with trailing comma", () => {
+      const arr = [1, 2, 3];
+      expect(arr.indexOf(2,)).toBe(1);
+    });
+
+    test("nested calls with trailing commas", () => {
+      const add = (a, b) => a + b;
+      expect(add(add(1, 2,), 3,)).toBe(6);
+    });
+
+    test("spread argument with trailing comma", () => {
+      const f = (...args) => args.length;
+      expect(f(...[1, 2, 3],)).toBe(3);
+    });
+
+    test("multiline argument list with trailing comma", () => {
+      const f = (a, b) => a + b;
+      expect(f(
+        1,
+        2,
+      )).toBe(3);
+    });
+  });
+
+  describe("function parameter definitions", () => {
+    test("single parameter with trailing comma", () => {
+      const f = (x,) => x;
+      expect(f(42)).toBe(42);
+    });
+
+    test("multiple parameters with trailing comma", () => {
+      const f = (a, b, c,) => a + b + c;
+      expect(f(1, 2, 3)).toBe(6);
+    });
+
+    test("destructuring parameter with trailing comma", () => {
+      const f = ({ x, y },) => x + y;
+      expect(f({ x: 1, y: 2 })).toBe(3);
+    });
+
+    test("array destructuring parameter with trailing comma", () => {
+      const f = ([a, b],) => a + b;
+      expect(f([10, 20])).toBe(30);
+    });
+
+    test("default parameter with trailing comma", () => {
+      const f = (a, b = 5,) => a + b;
+      expect(f(1)).toBe(6);
+    });
+  });
+
+  describe("constructor calls", () => {
+    test("new expression with trailing comma", () => {
+      const m = new Map([["a", 1],]);
+      expect(m.get("a")).toBe(1);
+    });
+
+    test("new expression multiple args with trailing comma", () => {
+      class Point {
+        constructor(x, y) {
+          this.x = x;
+          this.y = y;
+        }
+      }
+      const p = new Point(1, 2,);
+      expect(p.x).toBe(1);
+      expect(p.y).toBe(2);
+    });
+  });
+
+  describe("array literals", () => {
+    test("single element with trailing comma", () => {
+      const arr = [1,];
+      expect(arr.length).toBe(1);
+      expect(arr[0]).toBe(1);
+    });
+
+    test("multiple elements with trailing comma", () => {
+      const arr = [1, 2, 3,];
+      expect(arr.length).toBe(3);
+    });
+
+    test("nested arrays with trailing commas", () => {
+      const arr = [[1, 2,], [3, 4,],];
+      expect(arr.length).toBe(2);
+      expect(arr[0]).toEqual([1, 2]);
+    });
+  });
+
+  describe("object literals", () => {
+    test("single property with trailing comma", () => {
+      const obj = { x: 1, };
+      expect(obj.x).toBe(1);
+    });
+
+    test("multiple properties with trailing comma", () => {
+      const obj = { a: 1, b: 2, c: 3, };
+      expect(obj.a).toBe(1);
+      expect(obj.b).toBe(2);
+      expect(obj.c).toBe(3);
+    });
+
+    test("shorthand properties with trailing comma", () => {
+      const x = 1;
+      const y = 2;
+      const obj = { x, y, };
+      expect(obj.x).toBe(1);
+      expect(obj.y).toBe(2);
+    });
+
+    test("computed properties with trailing comma", () => {
+      const key = "name";
+      const obj = { [key]: "Alice", };
+      expect(obj.name).toBe("Alice");
+    });
+
+    test("method shorthand with trailing comma", () => {
+      const obj = {
+        greet() { return "hello"; },
+      };
+      expect(obj.greet()).toBe("hello");
+    });
+
+    test("nested objects with trailing commas", () => {
+      const obj = {
+        inner: {
+          a: 1,
+          b: 2,
+        },
+      };
+      expect(obj.inner.a).toBe(1);
+    });
+
+    test("getter/setter with trailing comma", () => {
+      const obj = {
+        get value() { return 42; },
+      };
+      expect(obj.value).toBe(42);
+    });
+  });
+});

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -471,6 +471,8 @@ type
     property Value: TGocciaExpression read FValue;
   end;
 
+  TGocciaDecoratorList = array of TGocciaExpression;
+
 implementation
 
 uses

--- a/units/Goccia.AST.Statements.pas
+++ b/units/Goccia.AST.Statements.pas
@@ -8,6 +8,8 @@ uses
   Classes,
   Generics.Collections,
 
+  OrderedMap,
+
   Goccia.AST.Expressions,
   Goccia.AST.Node;
 
@@ -202,10 +204,8 @@ type
     FStaticSetters: TDictionary<string, TGocciaSetterExpression>;
     FComputedStaticGetters: array of TGocciaComputedStaticAccessorEntry;
     FStaticProperties: TDictionary<string, TGocciaExpression>;
-    FInstanceProperties: TDictionary<string, TGocciaExpression>;
-    FInstancePropertyOrder: TStringList;
-    FPrivateInstanceProperties: TDictionary<string, TGocciaExpression>;
-    FPrivateInstancePropertyOrder: TStringList;
+    FInstanceProperties: TOrderedMap<TGocciaExpression>;
+    FPrivateInstanceProperties: TOrderedMap<TGocciaExpression>;
     FPrivateStaticProperties: TDictionary<string, TGocciaExpression>;
     FPrivateMethods: TDictionary<string, TGocciaClassMethod>;
     FGenericParams: string;
@@ -219,8 +219,8 @@ type
       const AGetters: TDictionary<string, TGocciaGetterExpression>;
       const ASetters: TDictionary<string, TGocciaSetterExpression>;
       const AStaticProperties: TDictionary<string, TGocciaExpression>;
-      const AInstanceProperties: TDictionary<string, TGocciaExpression>;
-      const APrivateInstanceProperties: TDictionary<string, TGocciaExpression> = nil;
+      const AInstanceProperties: TOrderedMap<TGocciaExpression>;
+      const APrivateInstanceProperties: TOrderedMap<TGocciaExpression>;
       const APrivateMethods: TDictionary<string, TGocciaClassMethod> = nil;
       const APrivateStaticProperties: TDictionary<string, TGocciaExpression> = nil);
     destructor Destroy; override;
@@ -232,10 +232,8 @@ type
     property StaticGetters: TDictionary<string, TGocciaGetterExpression> read FStaticGetters;
     property StaticSetters: TDictionary<string, TGocciaSetterExpression> read FStaticSetters;
     property StaticProperties: TDictionary<string, TGocciaExpression> read FStaticProperties;
-    property InstanceProperties: TDictionary<string, TGocciaExpression> read FInstanceProperties;
-    property InstancePropertyOrder: TStringList read FInstancePropertyOrder;
-    property PrivateInstanceProperties: TDictionary<string, TGocciaExpression> read FPrivateInstanceProperties;
-    property PrivateInstancePropertyOrder: TStringList read FPrivateInstancePropertyOrder;
+    property InstanceProperties: TOrderedMap<TGocciaExpression> read FInstanceProperties;
+    property PrivateInstanceProperties: TOrderedMap<TGocciaExpression> read FPrivateInstanceProperties;
     property PrivateStaticProperties: TDictionary<string, TGocciaExpression> read FPrivateStaticProperties;
     property PrivateMethods: TDictionary<string, TGocciaClassMethod> read FPrivateMethods;
     property GenericParams: string read FGenericParams write FGenericParams;
@@ -411,8 +409,8 @@ uses
     const AGetters: TDictionary<string, TGocciaGetterExpression>;
     const ASetters: TDictionary<string, TGocciaSetterExpression>;
     const AStaticProperties: TDictionary<string, TGocciaExpression>;
-    const AInstanceProperties: TDictionary<string, TGocciaExpression>;
-    const APrivateInstanceProperties: TDictionary<string, TGocciaExpression> = nil;
+    const AInstanceProperties: TOrderedMap<TGocciaExpression>;
+    const APrivateInstanceProperties: TOrderedMap<TGocciaExpression>;
     const APrivateMethods: TDictionary<string, TGocciaClassMethod> = nil;
     const APrivateStaticProperties: TDictionary<string, TGocciaExpression> = nil);
   begin
@@ -426,13 +424,7 @@ uses
     SetLength(FComputedStaticGetters, 0);
     FStaticProperties := AStaticProperties;
     FInstanceProperties := AInstanceProperties;
-    FInstancePropertyOrder := TStringList.Create;
-    FPrivateInstancePropertyOrder := TStringList.Create;
-
-    if Assigned(APrivateInstanceProperties) then
-      FPrivateInstanceProperties := APrivateInstanceProperties
-    else
-      FPrivateInstanceProperties := TDictionary<string, TGocciaExpression>.Create;
+    FPrivateInstanceProperties := APrivateInstanceProperties;
 
     if Assigned(APrivateMethods) then
       FPrivateMethods := APrivateMethods
@@ -456,11 +448,8 @@ uses
     FStaticSetters.Free;
     FStaticProperties.Free;
     FInstanceProperties.Free;
-    FInstancePropertyOrder.Free;
-    FPrivateInstancePropertyOrder.Free;
+    FPrivateInstanceProperties.Free;
     FInstancePropertyTypes.Free;
-    if Assigned(FPrivateInstanceProperties) then
-      FPrivateInstanceProperties.Free;
     if Assigned(FPrivateMethods) then
       FPrivateMethods.Free;
     if Assigned(FPrivateStaticProperties) then

--- a/units/Goccia.AST.Statements.pas
+++ b/units/Goccia.AST.Statements.pas
@@ -165,6 +165,31 @@ type
     GetterExpression: TGocciaGetterExpression;
   end;
 
+  // TC39 proposal-decorators: class element kinds
+  TGocciaClassElementKind = (
+    cekMethod,
+    cekGetter,
+    cekSetter,
+    cekField,
+    cekAccessor
+  );
+
+  // TC39 proposal-decorators: unified class element with optional decorators
+  TGocciaClassElement = record
+    Kind: TGocciaClassElementKind;
+    Name: string;
+    IsStatic: Boolean;
+    IsPrivate: Boolean;
+    IsComputed: Boolean;
+    ComputedKeyExpression: TGocciaExpression;
+    Decorators: TGocciaDecoratorList;
+    MethodNode: TGocciaClassMethod;
+    GetterNode: TGocciaGetterExpression;
+    SetterNode: TGocciaSetterExpression;
+    FieldInitializer: TGocciaExpression;
+    TypeAnnotation: string;
+  end;
+
   // Shared class definition structure
   TGocciaClassDefinition = class
   public
@@ -178,14 +203,16 @@ type
     FComputedStaticGetters: array of TGocciaComputedStaticAccessorEntry;
     FStaticProperties: TDictionary<string, TGocciaExpression>;
     FInstanceProperties: TDictionary<string, TGocciaExpression>;
-    FInstancePropertyOrder: TStringList; // Preserves declaration order
+    FInstancePropertyOrder: TStringList;
     FPrivateInstanceProperties: TDictionary<string, TGocciaExpression>;
-    FPrivateInstancePropertyOrder: TStringList; // Preserves declaration order
+    FPrivateInstancePropertyOrder: TStringList;
     FPrivateStaticProperties: TDictionary<string, TGocciaExpression>;
     FPrivateMethods: TDictionary<string, TGocciaClassMethod>;
     FGenericParams: string;
     FImplementsClause: string;
     FInstancePropertyTypes: TDictionary<string, string>;
+    FDecorators: TGocciaDecoratorList;
+    FElements: array of TGocciaClassElement;
 
     constructor Create(const AName, ASuperClass: string;
       const AMethods: TDictionary<string, TGocciaClassMethod>;
@@ -214,6 +241,7 @@ type
     property GenericParams: string read FGenericParams write FGenericParams;
     property ImplementsClause: string read FImplementsClause write FImplementsClause;
     property InstancePropertyTypes: TDictionary<string, string> read FInstancePropertyTypes;
+    property Decorators: TGocciaDecoratorList read FDecorators write FDecorators;
   end;
 
   TGocciaClassDeclaration = class(TGocciaStatement)

--- a/units/Goccia.Builtins.GlobalSymbol.pas
+++ b/units/Goccia.Builtins.GlobalSymbol.pas
@@ -72,6 +72,7 @@ begin
   FSymbolFunction.RegisterConstant('toPrimitive', TGocciaSymbolValue.WellKnownToPrimitive);
   FSymbolFunction.RegisterConstant('toStringTag', TGocciaSymbolValue.WellKnownToStringTag);
   FSymbolFunction.RegisterConstant('isConcatSpreadable', TGocciaSymbolValue.WellKnownIsConcatSpreadable);
+  FSymbolFunction.RegisterConstant('metadata', TGocciaSymbolValue.WellKnownMetadata);
 
   // Expose Symbol.prototype (ECMAScript compatible)
   FSymbolFunction.AssignProperty(PROP_PROTOTYPE, TGocciaSymbolValue.SharedPrototype);

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -26,6 +26,13 @@ const
   PROP_CONFIGURABLE = 'configurable';
   PROP_GET          = 'get';
   PROP_SET          = 'set';
+  PROP_INIT         = 'init';
+  PROP_KIND         = 'kind';
+  PROP_STATIC       = 'static';
+  PROP_PRIVATE      = 'private';
+  PROP_ACCESS       = 'access';
+  PROP_METADATA     = 'metadata';
+  PROP_ADD_INITIALIZER = 'addInitializer';
 
 implementation
 

--- a/units/Goccia.Evaluator.Decorators.pas
+++ b/units/Goccia.Evaluator.Decorators.pas
@@ -1,0 +1,96 @@
+unit Goccia.Evaluator.Decorators;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Values.NativeFunctionCallback,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaInitializerCollector = class
+  private
+    FInitializers: array of TGocciaValue;
+  public
+    function AddInitializer(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function GetInitializers: TArray<TGocciaValue>;
+  end;
+
+  TGocciaAccessGetter = class
+  private
+    FTarget: TGocciaValue;
+    FPropertyName: string;
+  public
+    constructor Create(const ATarget: TGocciaValue; const APropertyName: string);
+    function Get(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+  TGocciaAccessSetter = class
+  private
+    FPropertyName: string;
+  public
+    constructor Create(const APropertyName: string);
+    function SetValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+implementation
+
+uses
+  Goccia.Values.ObjectValue;
+
+{ TGocciaInitializerCollector }
+
+function TGocciaInitializerCollector.AddInitializer(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable then
+  begin
+    SetLength(FInitializers, Length(FInitializers) + 1);
+    FInitializers[High(FInitializers)] := AArgs.GetElement(0);
+  end;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaInitializerCollector.GetInitializers: TArray<TGocciaValue>;
+var
+  I: Integer;
+begin
+  SetLength(Result, Length(FInitializers));
+  for I := 0 to High(FInitializers) do
+    Result[I] := FInitializers[I];
+end;
+
+{ TGocciaAccessGetter }
+
+constructor TGocciaAccessGetter.Create(const ATarget: TGocciaValue; const APropertyName: string);
+begin
+  FTarget := ATarget;
+  FPropertyName := APropertyName;
+end;
+
+function TGocciaAccessGetter.Get(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if Assigned(AThisValue) and (AThisValue is TGocciaObjectValue) then
+    Result := AThisValue.GetProperty(FPropertyName)
+  else if Assigned(FTarget) then
+    Result := FTarget.GetProperty(FPropertyName)
+  else
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+{ TGocciaAccessSetter }
+
+constructor TGocciaAccessSetter.Create(const APropertyName: string);
+begin
+  FPropertyName := APropertyName;
+end;
+
+function TGocciaAccessSetter.SetValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if Assigned(AThisValue) and (AThisValue is TGocciaObjectValue) then
+    TGocciaObjectValue(AThisValue).AssignProperty(FPropertyName, AArgs.GetElement(0));
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+end.

--- a/units/Goccia.Keywords.Contextual.pas
+++ b/units/Goccia.Keywords.Contextual.pas
@@ -13,6 +13,7 @@ const
   KEYWORD_STATIC       = 'static';
   KEYWORD_GET          = 'get';
   KEYWORD_SET          = 'set';
+  KEYWORD_ACCESSOR     = 'accessor';
 
   // Async/generators
   KEYWORD_AWAIT        = 'await';

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -716,6 +716,7 @@ begin
       else
         AddToken(gttDot);
     '#': AddToken(gttHash);
+    '@': AddToken(gttAt);
     '`':
       ScanTemplate;
     '''', '"':

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -413,7 +413,7 @@ begin
           else
             Arg := Expression;
           Arguments.Add(Arg);
-        until not Match([gttComma]);
+        until not Match([gttComma]) or Check(gttRightParen);
       end;
 
       Consume(gttRightParen, 'Expected ")" after arguments');
@@ -454,7 +454,7 @@ begin
               else
                 Arg := Expression;
               Arguments.Add(Arg);
-            until not Match([gttComma]);
+            until not Match([gttComma]) or Check(gttRightParen);
           end;
           Consume(gttRightParen, 'Expected ")" after arguments');
           // Wrap call in optional chaining by wrapping the callee in an optional member
@@ -598,7 +598,7 @@ begin
             Args.Add(TGocciaSpreadExpression.Create(Expression, Previous.Line, Previous.Column))
           else
             Args.Add(Expression);
-        until not Match([gttComma]);
+        until not Match([gttComma]) or Check(gttRightParen);
       end;
       Consume(gttRightParen, 'Expected ")" after constructor arguments');
       Result := TGocciaNewExpression.Create(Expr, Args, Token.Line, Token.Column);
@@ -974,7 +974,7 @@ begin
       end;
 
       Inc(ParamCount);
-    until not Match([gttComma]);
+    until not Match([gttComma]) or Check(gttRightParen);
   end;
 
   SetLength(Result, ParamCount);
@@ -1749,7 +1749,7 @@ begin
             else
               Arg := Expression;
             Arguments.Add(Arg);
-          until not Match([gttComma]);
+          until not Match([gttComma]) or Check(gttRightParen);
         end;
         Consume(gttRightParen, 'Expected ")" after arguments');
         Result := TGocciaCallExpression.Create(Result, Arguments, Line, Column);

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -141,6 +141,8 @@ implementation
 uses
   SysUtils,
 
+  OrderedMap,
+
   Goccia.Error,
   Goccia.Keywords.Contextual,
   Goccia.Keywords.Reserved,
@@ -2031,12 +2033,10 @@ var
   Getters: TDictionary<string, TGocciaGetterExpression>;
   Setters: TDictionary<string, TGocciaSetterExpression>;
   StaticProperties: TDictionary<string, TGocciaExpression>;
-  InstanceProperties: TDictionary<string, TGocciaExpression>;
-  PrivateInstanceProperties: TDictionary<string, TGocciaExpression>;
+  InstanceProperties: TOrderedMap<TGocciaExpression>;
+  PrivateInstanceProperties: TOrderedMap<TGocciaExpression>;
   PrivateStaticProperties: TDictionary<string, TGocciaExpression>;
   PrivateMethods: TDictionary<string, TGocciaClassMethod>;
-  InstancePropertyOrder: TStringList;
-  PrivateInstancePropertyOrder: TStringList;
   MemberName: string;
   Method: TGocciaClassMethod;
   Getter: TGocciaGetterExpression;
@@ -2081,12 +2081,10 @@ begin
   Getters := TDictionary<string, TGocciaGetterExpression>.Create;
   Setters := TDictionary<string, TGocciaSetterExpression>.Create;
   StaticProperties := TDictionary<string, TGocciaExpression>.Create;
-  InstanceProperties := TDictionary<string, TGocciaExpression>.Create;
-  PrivateInstanceProperties := TDictionary<string, TGocciaExpression>.Create;
+  InstanceProperties := TOrderedMap<TGocciaExpression>.Create;
+  PrivateInstanceProperties := TOrderedMap<TGocciaExpression>.Create;
   PrivateStaticProperties := TDictionary<string, TGocciaExpression>.Create;
   PrivateMethods := TDictionary<string, TGocciaClassMethod>.Create;
-  InstancePropertyOrder := TStringList.Create;
-  PrivateInstancePropertyOrder := TStringList.Create;
   InstancePropertyTypes := TDictionary<string, string>.Create;
   StaticGetters := TDictionary<string, TGocciaGetterExpression>.Create;
   StaticSetters := TDictionary<string, TGocciaSetterExpression>.Create;
@@ -2222,16 +2220,12 @@ begin
       if IsPrivate and IsStatic then
         PrivateStaticProperties.Add(MemberName, PropertyValue)
       else if IsPrivate then
-      begin
-        PrivateInstanceProperties.Add(MemberName, PropertyValue);
-        PrivateInstancePropertyOrder.Add(MemberName);
-      end
+        PrivateInstanceProperties.Add(MemberName, PropertyValue)
       else if IsStatic then
         StaticProperties.Add(MemberName, PropertyValue)
       else
       begin
         InstanceProperties.Add(MemberName, PropertyValue);
-        InstancePropertyOrder.Add(MemberName);
         if FieldType <> '' then
           InstancePropertyTypes.Add(MemberName, FieldType);
       end;
@@ -2258,16 +2252,12 @@ begin
       if IsPrivate and IsStatic then
         PrivateStaticProperties.Add(MemberName, PropertyValue)
       else if IsPrivate then
-      begin
-        PrivateInstanceProperties.Add(MemberName, PropertyValue);
-        PrivateInstancePropertyOrder.Add(MemberName);
-      end
+        PrivateInstanceProperties.Add(MemberName, PropertyValue)
       else if IsStatic then
         StaticProperties.Add(MemberName, PropertyValue)
       else
       begin
         InstanceProperties.Add(MemberName, PropertyValue);
-        InstancePropertyOrder.Add(MemberName);
         if FieldType <> '' then
           InstancePropertyTypes.Add(MemberName, FieldType);
       end;
@@ -2361,12 +2351,9 @@ begin
   Result := TGocciaClassDefinition.Create(AClassName, SuperClass, Methods, Getters, Setters, StaticProperties, InstanceProperties, PrivateInstanceProperties, PrivateMethods, PrivateStaticProperties);
   Result.GenericParams := ClassGenericParams;
   Result.ImplementsClause := ClassImplementsClause;
-  Result.FInstancePropertyOrder.Assign(InstancePropertyOrder);
-  Result.FPrivateInstancePropertyOrder.Assign(PrivateInstancePropertyOrder);
   for MemberName in InstancePropertyTypes.Keys do
     Result.FInstancePropertyTypes.Add(MemberName, InstancePropertyTypes[MemberName]);
 
-  // Transfer static getters/setters
   Result.FStaticGetters.Free;
   Result.FStaticGetters := StaticGetters;
   Result.FStaticSetters.Free;
@@ -2374,8 +2361,6 @@ begin
   Result.FComputedStaticGetters := ComputedStaticGetters;
   Result.FElements := Elements;
 
-  InstancePropertyOrder.Free;
-  PrivateInstancePropertyOrder.Free;
   InstancePropertyTypes.Free;
 end;
 

--- a/units/Goccia.Token.pas
+++ b/units/Goccia.Token.pas
@@ -31,7 +31,7 @@ type
     // Punctuation
     gttLeftParen, gttRightParen, gttLeftBrace, gttRightBrace,
     gttLeftBracket, gttRightBracket, gttComma, gttDot, gttSemicolon,
-    gttArrow, gttSpread, gttHash,
+    gttArrow, gttSpread, gttHash, gttAt,
     // Special
     gttEOF, gttNewLine
   );

--- a/units/Goccia.Values.AutoAccessor.pas
+++ b/units/Goccia.Values.AutoAccessor.pas
@@ -1,0 +1,62 @@
+unit Goccia.Values.AutoAccessor;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaAutoAccessorGetter = class
+  private
+    FBackingName: string;
+  public
+    constructor Create(const ABackingName: string);
+    function Get(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+  TGocciaAutoAccessorSetter = class
+  private
+    FBackingName: string;
+  public
+    constructor Create(const ABackingName: string);
+    function SetValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+implementation
+
+uses
+  Goccia.Values.ObjectValue;
+
+{ TGocciaAutoAccessorGetter }
+
+constructor TGocciaAutoAccessorGetter.Create(const ABackingName: string);
+begin
+  FBackingName := ABackingName;
+end;
+
+function TGocciaAutoAccessorGetter.Get(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if Assigned(AThisValue) and (AThisValue is TGocciaObjectValue) then
+    Result := TGocciaObjectValue(AThisValue).GetProperty(FBackingName)
+  else
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+{ TGocciaAutoAccessorSetter }
+
+constructor TGocciaAutoAccessorSetter.Create(const ABackingName: string);
+begin
+  FBackingName := ABackingName;
+end;
+
+function TGocciaAutoAccessorSetter.SetValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if Assigned(AThisValue) and (AThisValue is TGocciaObjectValue) then
+    TGocciaObjectValue(AThisValue).AssignProperty(FBackingName, AArgs.GetElement(0));
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+end.

--- a/units/Goccia.Values.ClassValue.pas
+++ b/units/Goccia.Values.ClassValue.pas
@@ -231,6 +231,7 @@ var
   ValuePair: TPair<string, TGocciaValue>;
   SymPair: TPair<TGocciaSymbolValue, TGocciaPropertyDescriptor>;
   Accessor: TGocciaPropertyDescriptorAccessor;
+  I: Integer;
 begin
   if GCMarked then Exit;
   inherited; // Sets mark
@@ -301,6 +302,17 @@ begin
         Accessor.Setter.MarkReferences;
     end;
   end;
+
+  // Mark decorator initializer arrays
+  for I := 0 to High(FMethodInitializers) do
+    if Assigned(FMethodInitializers[I]) then
+      FMethodInitializers[I].MarkReferences;
+  for I := 0 to High(FFieldInitializers) do
+    if Assigned(FFieldInitializers[I]) then
+      FFieldInitializers[I].MarkReferences;
+  for I := 0 to High(FDecoratorFieldInitializers) do
+    if Assigned(FDecoratorFieldInitializers[I].Initializer) then
+      FDecoratorFieldInitializers[I].Initializer.MarkReferences;
 end;
 
 function TGocciaClassValue.IsCallable: Boolean;

--- a/units/Goccia.Values.SymbolValue.pas
+++ b/units/Goccia.Values.SymbolValue.pas
@@ -180,7 +180,7 @@ begin
   Result := FWellKnownIsConcatSpreadable;
 end;
 
-// TC39 proposal-decorator-metadata
+// TC39 proposal-decorator-metadata §2 Symbol.metadata
 class function TGocciaSymbolValue.WellKnownMetadata: TGocciaSymbolValue;
 begin
   if not Assigned(FWellKnownMetadata) then

--- a/units/Goccia.Values.SymbolValue.pas
+++ b/units/Goccia.Values.SymbolValue.pas
@@ -19,6 +19,7 @@ type
     FWellKnownToPrimitive: TGocciaSymbolValue;
     FWellKnownToStringTag: TGocciaSymbolValue;
     FWellKnownIsConcatSpreadable: TGocciaSymbolValue;
+    FWellKnownMetadata: TGocciaSymbolValue;
   private
     FDescription: string;
     FId: Integer;
@@ -38,6 +39,7 @@ type
     class function WellKnownToPrimitive: TGocciaSymbolValue;
     class function WellKnownToStringTag: TGocciaSymbolValue;
     class function WellKnownIsConcatSpreadable: TGocciaSymbolValue;
+    class function WellKnownMetadata: TGocciaSymbolValue;
 
     function TypeName: string; override;
     function TypeOf: string; override;
@@ -176,6 +178,18 @@ begin
       TGocciaGarbageCollector.Instance.PinValue(FWellKnownIsConcatSpreadable);
   end;
   Result := FWellKnownIsConcatSpreadable;
+end;
+
+// TC39 proposal-decorator-metadata
+class function TGocciaSymbolValue.WellKnownMetadata: TGocciaSymbolValue;
+begin
+  if not Assigned(FWellKnownMetadata) then
+  begin
+    FWellKnownMetadata := TGocciaSymbolValue.Create('Symbol.metadata');
+    if Assigned(TGocciaGarbageCollector.Instance) then
+      TGocciaGarbageCollector.Instance.PinValue(FWellKnownMetadata);
+  end;
+  Result := FWellKnownMetadata;
 end;
 
 constructor TGocciaSymbolValue.Create(const ADescription: string);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full TC39 Stage 3 decorators support for classes, methods, fields, getters/setters, and auto-accessors
  * Added `Symbol.metadata` for decorator metadata handling
  * Added auto-accessor syntax for class properties
  * Added `addInitializer` context method for decorators

* **Documentation**
  * Updated language reference with decorators and auto-accessor capabilities
  * Updated built-ins documentation to include `Symbol.metadata`
  * Added decorator benchmarks to performance testing suite

* **Tests**
  * Added comprehensive test coverage for decorator features, metadata, and auto-accessors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->