### PR TITLE
Add bytecode and vm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,15 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | GocciaScript Backend | `Goccia.Engine.Backend.pas` | `TGocciaSouffleBackend` — bridges GocciaScript engine to Souffle VM |
 | GocciaScript Compiler | `Goccia.Compiler.pas` | `TGocciaCompiler` — AST → Souffle bytecode compilation |
 | GocciaScript Runtime | `Goccia.Runtime.Operations.pas` | `TGocciaRuntimeOperations` — GocciaScript semantics for Souffle VM |
+| Compiler Scope | `Goccia.Compiler.Scope.pas` | `TGocciaCompilerScope` — lexical scope tracking, local/upvalue resolution for the bytecode compiler |
+
+**Souffle VM known limitations:** Iteration (`GetIterator`, `IteratorNext`, `SpreadInto`), module imports (`ImportModule`), and async/await (`AwaitValue`) are currently stubbed in `TGocciaRuntimeOperations`. Closure receiver binding is accepted but not stored into the frame. `.sbc` binary format uses native endianness (not yet portable). ABC-encoded instructions limit constant pool references to 255 per prototype. See [docs/souffle-vm.md § Known Limitations](docs/souffle-vm.md#known-limitations) for the full list.
+
+**Souffle VM design rules:**
+- The `souffle/` directory must not import `Goccia.*` units — all GocciaScript dependencies live in the bridge files (`Goccia.Engine.Backend.pas`, `Goccia.Runtime.Operations.pas`, `Goccia.Compiler.pas`).
+- NaN handling in the Souffle layer uses raw IEEE 754 bit-pattern checks (`FloatBitsAreNaN`), not FPC's `Math.IsNaN`, to avoid language-runtime dependencies and AArch64 pitfalls.
+- New Tier 2 opcodes should only be added when no combination of existing opcodes can express the semantics efficiently. Language-specific features should be desugared by the compiler.
+- The `TSouffleRuntimeOperations` abstract class defines the contract between the VM and any language frontend. GocciaScript's `TGocciaRuntimeOperations` is one implementation; future frontends provide their own.
 
 ## Development Workflow
 

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -269,6 +269,8 @@ begin
   case GMode of
     ebTreeWalk:  Result := CollectBenchmarkFileInterpreted(AFileName, AReporter);
     ebSouffleVM: Result := CollectBenchmarkFileBytecode(AFileName, AReporter);
+  else
+    raise Exception.CreateFmt('Unsupported execution backend: %d', [Ord(GMode)]);
   end;
 end;
 

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -4,13 +4,23 @@ program BenchmarkRunner;
 
 uses
   Classes,
+  Generics.Collections,
   SysUtils,
 
+  Souffle.Bytecode.Module,
+  TimingUtils,
+
+  Goccia.AST.Node,
   Goccia.Benchmark.Reporter,
   Goccia.Builtins.Benchmark,
+  Goccia.Compiler,
   Goccia.Constants.PropertyNames,
   Goccia.Engine,
+  Goccia.Engine.Backend,
   Goccia.FileExtensions,
+  Goccia.Lexer,
+  Goccia.Parser,
+  Goccia.Token,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives,
@@ -32,8 +42,104 @@ end;
 
 var
   GShowProgress: Boolean = True;
+  GMode: TGocciaEngineBackend = ebTreeWalk;
 
-function CollectBenchmarkFile(const AFileName: string;
+procedure PopulateFileResult(const AFileResult: TBenchmarkFileResult;
+  const AScriptResult: TGocciaObjectValue; const AReporter: TBenchmarkReporter;
+  out AResultObj: TGocciaObjectValue);
+var
+  ResultsArray: TGocciaArrayValue;
+  SingleResult: TGocciaObjectValue;
+  MutableFileResult: TBenchmarkFileResult;
+  Entry: TBenchmarkEntry;
+  ErrorMsg: string;
+  I, EntryCount: Integer;
+begin
+  MutableFileResult := AFileResult;
+
+  if AScriptResult <> nil then
+  begin
+    MutableFileResult.TotalBenchmarks := Round(AScriptResult.GetProperty('totalBenchmarks').ToNumberLiteral.Value);
+    MutableFileResult.DurationNanoseconds := Round(AScriptResult.GetProperty('durationNanoseconds').ToNumberLiteral.Value);
+
+    if AScriptResult.GetProperty('results') is TGocciaArrayValue then
+    begin
+      ResultsArray := TGocciaArrayValue(AScriptResult.GetProperty('results'));
+      EntryCount := ResultsArray.GetLength;
+      SetLength(MutableFileResult.Entries, EntryCount);
+
+      for I := 0 to EntryCount - 1 do
+      begin
+        SingleResult := TGocciaObjectValue(ResultsArray.GetElement(I));
+
+        Entry.Suite := SingleResult.GetProperty('suite').ToStringLiteral.Value;
+        Entry.Name := SingleResult.GetProperty(PROP_NAME).ToStringLiteral.Value;
+
+        ErrorMsg := SingleResult.GetProperty('error').ToStringLiteral.Value;
+        if ErrorMsg <> 'undefined' then
+        begin
+          Entry.Error := ErrorMsg;
+          Entry.OpsPerSec := 0;
+          Entry.MeanMs := 0;
+          Entry.Iterations := 0;
+          Entry.VariancePercentage := 0;
+          Entry.SetupMs := 0;
+          Entry.TeardownMs := 0;
+        end
+        else
+        begin
+          Entry.Error := '';
+          Entry.OpsPerSec := SingleResult.GetProperty('opsPerSec').ToNumberLiteral.Value;
+          Entry.MeanMs := SingleResult.GetProperty('meanMs').ToNumberLiteral.Value;
+          Entry.Iterations := Round(SingleResult.GetProperty('iterations').ToNumberLiteral.Value);
+          Entry.VariancePercentage := SingleResult.GetProperty('variancePercentage').ToNumberLiteral.Value;
+          Entry.SetupMs := SingleResult.GetProperty('setupMs').ToNumberLiteral.Value;
+          Entry.TeardownMs := SingleResult.GetProperty('teardownMs').ToNumberLiteral.Value;
+        end;
+
+        MutableFileResult.Entries[I] := Entry;
+      end;
+    end;
+
+    AReporter.AddFileResult(MutableFileResult);
+    AResultObj := AScriptResult;
+  end
+  else
+  begin
+    MutableFileResult.TotalBenchmarks := 0;
+    MutableFileResult.DurationNanoseconds := 0;
+    SetLength(MutableFileResult.Entries, 0);
+    AReporter.AddFileResult(MutableFileResult);
+
+    AResultObj := TGocciaObjectValue.Create;
+    AResultObj.AssignProperty('totalBenchmarks', TGocciaNumberLiteralValue.ZeroValue);
+    AResultObj.AssignProperty('duration', TGocciaNumberLiteralValue.ZeroValue);
+  end;
+end;
+
+function MakeErrorFileResult(const AFileName, AMessage: string;
+  const AReporter: TBenchmarkReporter): TGocciaObjectValue;
+var
+  FileResult: TBenchmarkFileResult;
+begin
+  FileResult.FileName := AFileName;
+  FileResult.LexTimeNanoseconds := 0;
+  FileResult.ParseTimeNanoseconds := 0;
+  FileResult.ExecuteTimeNanoseconds := 0;
+  FileResult.TotalBenchmarks := 0;
+  FileResult.DurationNanoseconds := 0;
+  SetLength(FileResult.Entries, 1);
+  FileResult.Entries[0].Suite := '';
+  FileResult.Entries[0].Name := '(fatal)';
+  FileResult.Entries[0].Error := AMessage;
+  AReporter.AddFileResult(FileResult);
+
+  Result := TGocciaObjectValue.Create;
+  Result.AssignProperty('totalBenchmarks', TGocciaNumberLiteralValue.ZeroValue);
+  Result.AssignProperty('duration', TGocciaNumberLiteralValue.ZeroValue);
+end;
+
+function CollectBenchmarkFileInterpreted(const AFileName: string;
   const AReporter: TBenchmarkReporter): TGocciaObjectValue;
 var
   Source: TStringList;
@@ -41,12 +147,7 @@ var
   BenchGlobals: TGocciaGlobalBuiltins;
   EngineResult: TGocciaScriptResult;
   ScriptResult: TGocciaObjectValue;
-  ResultsArray: TGocciaArrayValue;
-  SingleResult: TGocciaObjectValue;
   FileResult: TBenchmarkFileResult;
-  Entry: TBenchmarkEntry;
-  ErrorMsg: string;
-  I, EntryCount: Integer;
 begin
   BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
 
@@ -71,88 +172,103 @@ begin
       FileResult.ParseTimeNanoseconds := EngineResult.ParseTimeNanoseconds;
       FileResult.ExecuteTimeNanoseconds := EngineResult.ExecuteTimeNanoseconds;
 
+      ScriptResult := nil;
       if EngineResult.Result is TGocciaObjectValue then
-      begin
         ScriptResult := TGocciaObjectValue(EngineResult.Result);
 
-        FileResult.TotalBenchmarks := Round(ScriptResult.GetProperty('totalBenchmarks').ToNumberLiteral.Value);
-        FileResult.DurationNanoseconds := Round(ScriptResult.GetProperty('durationNanoseconds').ToNumberLiteral.Value);
-
-        if ScriptResult.GetProperty('results') is TGocciaArrayValue then
-        begin
-          ResultsArray := TGocciaArrayValue(ScriptResult.GetProperty('results'));
-          EntryCount := ResultsArray.GetLength;
-          SetLength(FileResult.Entries, EntryCount);
-
-          for I := 0 to EntryCount - 1 do
-          begin
-            SingleResult := TGocciaObjectValue(ResultsArray.GetElement(I));
-
-            Entry.Suite := SingleResult.GetProperty('suite').ToStringLiteral.Value;
-            Entry.Name := SingleResult.GetProperty(PROP_NAME).ToStringLiteral.Value;
-
-            ErrorMsg := SingleResult.GetProperty('error').ToStringLiteral.Value;
-            if ErrorMsg <> 'undefined' then
-            begin
-              Entry.Error := ErrorMsg;
-              Entry.OpsPerSec := 0;
-              Entry.MeanMs := 0;
-              Entry.Iterations := 0;
-              Entry.VariancePercentage := 0;
-              Entry.SetupMs := 0;
-              Entry.TeardownMs := 0;
-            end
-            else
-            begin
-              Entry.Error := '';
-              Entry.OpsPerSec := SingleResult.GetProperty('opsPerSec').ToNumberLiteral.Value;
-              Entry.MeanMs := SingleResult.GetProperty('meanMs').ToNumberLiteral.Value;
-              Entry.Iterations := Round(SingleResult.GetProperty('iterations').ToNumberLiteral.Value);
-              Entry.VariancePercentage := SingleResult.GetProperty('variancePercentage').ToNumberLiteral.Value;
-              Entry.SetupMs := SingleResult.GetProperty('setupMs').ToNumberLiteral.Value;
-              Entry.TeardownMs := SingleResult.GetProperty('teardownMs').ToNumberLiteral.Value;
-            end;
-
-            FileResult.Entries[I] := Entry;
-          end;
-        end;
-
-        AReporter.AddFileResult(FileResult);
-        Result := ScriptResult;
-      end
-      else
-      begin
-        FileResult.TotalBenchmarks := 0;
-        FileResult.DurationNanoseconds := 0;
-        SetLength(FileResult.Entries, 0);
-        AReporter.AddFileResult(FileResult);
-
-        Result := TGocciaObjectValue.Create;
-        Result.AssignProperty('totalBenchmarks', TGocciaNumberLiteralValue.ZeroValue);
-        Result.AssignProperty('duration', TGocciaNumberLiteralValue.ZeroValue);
-      end;
+      PopulateFileResult(FileResult, ScriptResult, AReporter, Result);
     except
       on E: Exception do
-      begin
-        FileResult.FileName := AFileName;
-        FileResult.LexTimeNanoseconds := 0;
-        FileResult.ParseTimeNanoseconds := 0;
-        FileResult.ExecuteTimeNanoseconds := 0;
-        FileResult.TotalBenchmarks := 0;
-        FileResult.DurationNanoseconds := 0;
-        SetLength(FileResult.Entries, 1);
-        FileResult.Entries[0].Suite := '';
-        FileResult.Entries[0].Name := '(fatal)';
-        FileResult.Entries[0].Error := E.Message;
-        AReporter.AddFileResult(FileResult);
-
-        Result := TGocciaObjectValue.Create;
-        Result.AssignProperty('totalBenchmarks', TGocciaNumberLiteralValue.ZeroValue);
-        Result.AssignProperty('duration', TGocciaNumberLiteralValue.ZeroValue);
-      end;
+        Result := MakeErrorFileResult(AFileName, E.Message, AReporter);
     end;
   finally
     Source.Free;
+  end;
+end;
+
+function CollectBenchmarkFileBytecode(const AFileName: string;
+  const AReporter: TBenchmarkReporter): TGocciaObjectValue;
+var
+  Source: TStringList;
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+  Parser: TGocciaParser;
+  ProgramNode: TGocciaProgram;
+  Module: TSouffleBytecodeModule;
+  Backend: TGocciaSouffleBackend;
+  ResultValue: TGocciaValue;
+  FileResult: TBenchmarkFileResult;
+  ScriptResult: TGocciaObjectValue;
+  BenchGlobals: TGocciaGlobalBuiltins;
+  StartTime, EndTime: Int64;
+begin
+  BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
+
+  Source := TStringList.Create;
+  try
+    Source.LoadFromFile(AFileName);
+    Source.Add('runBenchmarks();');
+
+    try
+      StartTime := GetNanoseconds;
+
+      Backend := TGocciaSouffleBackend.Create(AFileName);
+      try
+        Backend.RegisterBuiltIns(BenchGlobals);
+
+        Lexer := TGocciaLexer.Create(Source.Text, AFileName);
+        try
+          Tokens := Lexer.ScanTokens;
+          Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
+          try
+            ProgramNode := Parser.Parse;
+            try
+              Module := Backend.CompileToModule(ProgramNode);
+            finally
+              ProgramNode.Free;
+            end;
+          finally
+            Parser.Free;
+          end;
+        finally
+          Lexer.Free;
+        end;
+
+        try
+          ResultValue := Backend.RunModule(Module);
+          EndTime := GetNanoseconds;
+
+          FileResult.FileName := AFileName;
+          FileResult.LexTimeNanoseconds := 0;
+          FileResult.ParseTimeNanoseconds := 0;
+          FileResult.ExecuteTimeNanoseconds := EndTime - StartTime;
+
+          ScriptResult := nil;
+          if ResultValue is TGocciaObjectValue then
+            ScriptResult := TGocciaObjectValue(ResultValue);
+
+          PopulateFileResult(FileResult, ScriptResult, AReporter, Result);
+        finally
+          Module.Free;
+        end;
+      finally
+        Backend.Free;
+      end;
+    except
+      on E: Exception do
+        Result := MakeErrorFileResult(AFileName, E.Message, AReporter);
+    end;
+  finally
+    Source.Free;
+  end;
+end;
+
+function CollectBenchmarkFile(const AFileName: string;
+  const AReporter: TBenchmarkReporter): TGocciaObjectValue;
+begin
+  case GMode of
+    ebTreeWalk:  Result := CollectBenchmarkFileInterpreted(AFileName, AReporter);
+    ebSouffleVM: Result := CollectBenchmarkFileBytecode(AFileName, AReporter);
   end;
 end;
 
@@ -218,6 +334,7 @@ var
 begin
   ReportCount := 0;
   GShowProgress := True;
+  GMode := ebTreeWalk;
   SetLength(Reports, 0);
 
   Paths := TStringList.Create;
@@ -246,6 +363,16 @@ begin
       end
       else if ParamStr(I) = '--no-progress' then
         GShowProgress := False
+      else if ParamStr(I) = '--mode=interpreted' then
+        GMode := ebTreeWalk
+      else if ParamStr(I) = '--mode=bytecode' then
+        GMode := ebSouffleVM
+      else if Copy(ParamStr(I), 1, 7) = '--mode=' then
+      begin
+        WriteLn('Error: Unknown mode "', Copy(ParamStr(I), 8, MaxInt), '". Use "interpreted" or "bytecode".');
+        ExitCode := 1;
+        Exit;
+      end
       else if Copy(ParamStr(I), 1, 2) <> '--' then
         Paths.Add(ParamStr(I));
     end;
@@ -259,7 +386,7 @@ begin
 
     if Paths.Count = 0 then
     begin
-      WriteLn('Usage: BenchmarkRunner <path...> [--format=console|text|csv|json [--output=file]] ... [--no-progress]');
+      WriteLn('Usage: BenchmarkRunner <path...> [--format=console|text|csv|json [--output=file]] ... [--no-progress] [--mode=interpreted|bytecode]');
       ExitCode := 1;
     end
     else

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ console.log(`Your order total: $${total.toFixed(2)}`);
 
 ### Run via Souffle VM (Bytecode)
 
-GocciaScript includes an alternative bytecode execution backend — the **Souffle VM** — a general-purpose register-based virtual machine:
+GocciaScript includes an alternative bytecode execution backend — the **Souffle VM** — a general-purpose register-based virtual machine. The bytecode backend supports variables, closures, classes, property access, and invocation. Iteration, modules, and async/await are not yet implemented (see [Known Limitations](docs/souffle-vm.md#known-limitations)).
 
 ```bash
 # Compile and execute via Souffle VM

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -197,7 +197,10 @@ begin
 
     if GEmitOnly then
     begin
-      EmitBytecode(AFileName, GEmitPath);
+      if GEmitPath <> '' then
+        EmitBytecode(AFileName, GEmitPath)
+      else
+        EmitBytecode(AFileName, ChangeFileExt(AFileName, EXT_SBC));
       Exit;
     end;
 

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -4,27 +4,207 @@ program ScriptLoader;
 
 uses
   Classes,
+  Generics.Collections,
   SysUtils,
 
+  Souffle.Bytecode.Binary,
+  Souffle.Bytecode.Module,
   TimingUtils,
 
+  Goccia.AST.Node,
+  Goccia.Compiler,
   Goccia.Engine,
+  Goccia.Engine.Backend,
   Goccia.FileExtensions,
+  Goccia.GarbageCollector,
+  Goccia.Lexer,
+  Goccia.Parser,
+  Goccia.Token,
   Goccia.Values.Primitives,
 
   FileUtils in 'units/FileUtils.pas';
 
-procedure RunScriptFromFile(const AFileName: string);
+type
+  TExecutionMode = (emInterpreted, emBytecode);
+
+var
+  GMode: TExecutionMode = emInterpreted;
+  GEmitPath: string = '';
+  GEmitOnly: Boolean = False;
+
+function ParseSourceFile(const AFileName: string): TGocciaProgram;
+var
+  Source: TStringList;
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+  Parser: TGocciaParser;
+begin
+  Source := TStringList.Create;
+  try
+    Source.LoadFromFile(AFileName);
+    Lexer := TGocciaLexer.Create(Source.Text, AFileName);
+    try
+      Tokens := Lexer.ScanTokens;
+      Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
+      try
+        Result := Parser.Parse;
+      finally
+        Parser.Free;
+      end;
+    finally
+      Lexer.Free;
+    end;
+  finally
+    Source.Free;
+  end;
+end;
+
+function CompileSourceFile(const AFileName: string): TSouffleBytecodeModule;
+var
+  ProgramNode: TGocciaProgram;
+  Compiler: TGocciaCompiler;
+begin
+  ProgramNode := ParseSourceFile(AFileName);
+  try
+    Compiler := TGocciaCompiler.Create(AFileName);
+    try
+      Result := Compiler.Compile(ProgramNode);
+    finally
+      Compiler.Free;
+    end;
+  finally
+    ProgramNode.Free;
+  end;
+end;
+
+procedure RunInterpreted(const AFileName: string);
 var
   ScriptResult: TGocciaScriptResult;
 begin
+  WriteLn('Running script (interpreted): ', AFileName);
+  ScriptResult := TGocciaEngine.RunScriptFromFile(AFileName, TGocciaEngine.DefaultGlobals);
+  WriteLn(SysUtils.Format('  Lex: %s | Parse: %s | Execute: %s | Total: %s',
+    [FormatDuration(ScriptResult.LexTimeNanoseconds), FormatDuration(ScriptResult.ParseTimeNanoseconds),
+     FormatDuration(ScriptResult.ExecuteTimeNanoseconds), FormatDuration(ScriptResult.TotalTimeNanoseconds)]));
+  Writeln('Result: ', ScriptResult.Result.ToStringLiteral.Value);
+end;
+
+procedure RunBytecodeFromSource(const AFileName: string);
+var
+  ProgramNode: TGocciaProgram;
+  Module: TSouffleBytecodeModule;
+  Backend: TGocciaSouffleBackend;
+  StartTime, CompileEnd, ExecEnd: Int64;
+  ResultValue: TGocciaValue;
+begin
+  WriteLn('Running script (bytecode): ', AFileName);
+  StartTime := GetNanoseconds;
+
+  Backend := TGocciaSouffleBackend.Create(AFileName);
   try
-    WriteLn('Running script: ', AFileName);
-    ScriptResult := TGocciaEngine.RunScriptFromFile(AFileName, TGocciaEngine.DefaultGlobals);
-    WriteLn(SysUtils.Format('  Lex: %s | Parse: %s | Execute: %s | Total: %s',
-      [FormatDuration(ScriptResult.LexTimeNanoseconds), FormatDuration(ScriptResult.ParseTimeNanoseconds),
-       FormatDuration(ScriptResult.ExecuteTimeNanoseconds), FormatDuration(ScriptResult.TotalTimeNanoseconds)]));
-    Writeln('Result: ', ScriptResult.Result.ToStringLiteral.Value);
+    Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
+
+    ProgramNode := ParseSourceFile(AFileName);
+    try
+      Module := Backend.CompileToModule(ProgramNode);
+    finally
+      ProgramNode.Free;
+    end;
+    CompileEnd := GetNanoseconds;
+    try
+      ResultValue := Backend.RunModule(Module);
+      ExecEnd := GetNanoseconds;
+      WriteLn(SysUtils.Format('  Compile: %s | Execute: %s | Total: %s',
+        [FormatDuration(CompileEnd - StartTime),
+         FormatDuration(ExecEnd - CompileEnd),
+         FormatDuration(ExecEnd - StartTime)]));
+      WriteLn('Result: ', ResultValue.ToStringLiteral.Value);
+    finally
+      Module.Free;
+    end;
+  finally
+    Backend.Free;
+  end;
+end;
+
+procedure RunBytecodeFromFile(const AFileName: string);
+var
+  Module: TSouffleBytecodeModule;
+  Backend: TGocciaSouffleBackend;
+  StartTime, LoadEnd, ExecEnd: Int64;
+  ResultValue: TGocciaValue;
+begin
+  WriteLn('Running bytecode: ', AFileName);
+  StartTime := GetNanoseconds;
+
+  Module := LoadModuleFromFile(AFileName);
+  LoadEnd := GetNanoseconds;
+  try
+    Backend := TGocciaSouffleBackend.Create(AFileName);
+    try
+      Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
+      ResultValue := Backend.RunModule(Module);
+      ExecEnd := GetNanoseconds;
+      WriteLn(SysUtils.Format('  Load: %s | Execute: %s | Total: %s',
+        [FormatDuration(LoadEnd - StartTime),
+         FormatDuration(ExecEnd - LoadEnd),
+         FormatDuration(ExecEnd - StartTime)]));
+      WriteLn('Result: ', ResultValue.ToStringLiteral.Value);
+    finally
+      Backend.Free;
+    end;
+  finally
+    Module.Free;
+  end;
+end;
+
+procedure EmitBytecode(const AFileName, AOutputPath: string);
+var
+  Module: TSouffleBytecodeModule;
+  StartTime, EndTime: Int64;
+begin
+  WriteLn('Compiling: ', AFileName);
+  StartTime := GetNanoseconds;
+
+  TGocciaGarbageCollector.Initialize;
+  try
+    Module := CompileSourceFile(AFileName);
+    try
+      SaveModuleToFile(Module, AOutputPath);
+      EndTime := GetNanoseconds;
+      WriteLn(SysUtils.Format('  Compiled to %s (%s)',
+        [AOutputPath, FormatDuration(EndTime - StartTime)]));
+    finally
+      Module.Free;
+    end;
+  finally
+    TGocciaGarbageCollector.Shutdown;
+  end;
+end;
+
+procedure RunScriptFromFile(const AFileName: string);
+var
+  Ext: string;
+begin
+  try
+    Ext := LowerCase(ExtractFileExt(AFileName));
+
+    if Ext = EXT_SBC then
+    begin
+      RunBytecodeFromFile(AFileName);
+      Exit;
+    end;
+
+    if GEmitOnly then
+    begin
+      EmitBytecode(AFileName, GEmitPath);
+      Exit;
+    end;
+
+    case GMode of
+      emInterpreted: RunInterpreted(AFileName);
+      emBytecode:    RunBytecodeFromSource(AFileName);
+    end;
   except
     on E: Exception do
     begin
@@ -61,14 +241,78 @@ begin
   end;
 end;
 
+procedure PrintUsage;
 begin
-  if ParamCount < 1 then
-  begin
-    WriteLn('Usage: ScriptLoader <filename.js|.jsx|.ts|.tsx|.mjs>');
-    WriteLn('or');
-    WriteLn('Usage: ScriptLoader <directory>');
-    ExitCode := 1;
-  end
-  else
-    RunScripts(ParamStr(1));
+  WriteLn('Usage: ScriptLoader <file|directory> [options]');
+  WriteLn;
+  WriteLn('  <file>                  Script (.js, .jsx, .ts, .tsx, .mjs) or bytecode (.sbc)');
+  WriteLn('  <directory>             Run all scripts in directory');
+  WriteLn;
+  WriteLn('Options:');
+  WriteLn('  --mode=interpreted      Tree-walk interpreter (default)');
+  WriteLn('  --mode=bytecode         Compile to bytecode and execute on Souffle VM');
+  WriteLn('  --emit[=output.sbc]     Compile to .sbc file (no execution)');
+end;
+
+var
+  Paths: TStringList;
+  I: Integer;
+  Arg, ModeStr: string;
+
+begin
+  GMode := emInterpreted;
+  GEmitPath := '';
+  GEmitOnly := False;
+
+  Paths := TStringList.Create;
+  try
+    for I := 1 to ParamCount do
+    begin
+      Arg := ParamStr(I);
+      if Copy(Arg, 1, 7) = '--mode=' then
+      begin
+        ModeStr := Copy(Arg, 8, MaxInt);
+        if ModeStr = 'interpreted' then
+          GMode := emInterpreted
+        else if ModeStr = 'bytecode' then
+          GMode := emBytecode
+        else
+        begin
+          WriteLn('Error: Unknown mode "', ModeStr, '". Use "interpreted" or "bytecode".');
+          ExitCode := 1;
+          Exit;
+        end;
+      end
+      else if Copy(Arg, 1, 7) = '--emit=' then
+      begin
+        GEmitOnly := True;
+        GEmitPath := Copy(Arg, 8, MaxInt);
+      end
+      else if Arg = '--emit' then
+      begin
+        GEmitOnly := True;
+        GEmitPath := '';
+      end
+      else if Copy(Arg, 1, 2) <> '--' then
+        Paths.Add(Arg);
+    end;
+
+    if Paths.Count = 0 then
+    begin
+      PrintUsage;
+      ExitCode := 1;
+      Exit;
+    end;
+
+    if GEmitOnly and (GEmitPath = '') then
+      GEmitPath := ChangeFileExt(Paths[0], EXT_SBC);
+
+    for I := 0 to Paths.Count - 1 do
+    begin
+      if I > 0 then WriteLn;
+      RunScripts(Paths[I]);
+    end;
+  finally
+    Paths.Free;
+  end;
 end.

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -437,7 +437,13 @@ begin
         ExitCode := 1;
         Exit;
       end
-      else if Copy(ParamStr(I), 1, 2) <> '--' then
+      else if Copy(ParamStr(I), 1, 2) = '--' then
+      begin
+        WriteLn('Error: Unknown option "', ParamStr(I), '"');
+        ExitCode := 1;
+        Exit;
+      end
+      else
         Paths.Add(ParamStr(I));
     end;
 

--- a/config.cfg
+++ b/config.cfg
@@ -1,4 +1,6 @@
 -Fu./units
+-Fu./souffle
 -Fi./units
+-Fi./souffle
 -FUbuild
 -FEbuild

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -71,6 +71,30 @@ A full build (no specific targets) automatically cleans first.
 ./build.pas testrunner && ./build/TestRunner tests
 ```
 
+### Bytecode Mode
+
+All execution tools support `--mode=bytecode` to compile and run via the Souffle VM instead of the tree-walk interpreter:
+
+```bash
+# Execute via Souffle VM
+./build/ScriptLoader example.js --mode=bytecode
+
+# Emit bytecode to .sbc file (no execution)
+./build/ScriptLoader example.js --emit
+./build/ScriptLoader example.js --emit=output.sbc
+
+# Load and execute a pre-compiled .sbc file
+./build/ScriptLoader output.sbc
+
+# Run tests via Souffle VM
+./build/TestRunner tests --mode=bytecode
+
+# Run benchmarks via Souffle VM
+./build/BenchmarkRunner benchmarks --mode=bytecode
+```
+
+See [souffle-vm.md](souffle-vm.md) for the full Souffle VM architecture and binary format.
+
 ## Build Output
 
 All compiled binaries go to the `build/` directory:
@@ -162,6 +186,12 @@ GocciaScript/
 │   ├── TimingUtils.pas # Cross-platform microsecond timing and duration formatting
 │   ├── *.pas          # All unit source files
 │   └── *.Test.pas     # Pascal unit test programs
+├── souffle/           # Souffle VM (general-purpose bytecode VM)
+│   ├── Souffle.inc    # Shared compiler directives for Souffle units
+│   ├── Souffle.VM.pas # Core VM: dispatch loop, register file, execution
+│   ├── Souffle.Bytecode.pas # Opcode definitions, instruction encoding
+│   ├── Souffle.Value.pas    # Tagged union value system
+│   └── *.pas          # Other Souffle units (heap, GC, closures, etc.)
 └── build/             # All output (gitignored)
     ├── *.o            # Object files
     ├── *.ppu          # Compiled unit files

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -405,6 +405,23 @@ Language-specific features are compiled into sequences of generic VM instruction
 
 This keeps the VM general-purpose: new language features are expressed through existing operations.
 
+### Deferred Runtime Operations
+
+Several runtime operations are currently stubbed in `TGocciaRuntimeOperations` and will need full implementations before the corresponding GocciaScript features work in bytecode mode:
+
+- **Iteration** (`GetIterator`, `IteratorNext`, `SpreadInto`) — Not yet wired to GocciaScript's iterator protocol. Blocks `for...of`, spread syntax, and destructuring in bytecode mode.
+- **Module imports** (`ImportModule`) — Returns nil. Blocks `import`/`export` in bytecode mode.
+- **Async/await** (`AwaitValue`) — Returns the value unchanged. Blocks async function execution in bytecode mode.
+
+These stubs exist because the core execution pipeline (variables, closures, classes, property access, invocation) was prioritized first. Each stub has a clear contract defined by the abstract `TSouffleRuntimeOperations` base class.
+
+### Rejected Findings
+
+During code review, the following findings were investigated and determined to be non-issues:
+
+- **`SBIAS_24` (Souffle.Bytecode.pas)** — The 24-bit signed bias constant 8388607 is correct. The 24-bit unsigned range 0..16777215 centered at 8388607 gives a signed range of −8388607..+8388608. This is standard Lua-style bias encoding.
+- **Token list leak in `Goccia.Compiler.Test.pas`** — `Lexer.ScanTokens` returns the lexer's own `FTokens` list (freed in the lexer's destructor). Adding manual `Tokens.Free` causes a double-free crash.
+
 ## Testing Strategy
 
 JavaScript end-to-end tests are the **primary** testing mechanism. Every new feature or bug fix must include JavaScript tests that validate the behavior through the full pipeline (lexer → parser → evaluator).

--- a/docs/souffle-vm.md
+++ b/docs/souffle-vm.md
@@ -1,0 +1,491 @@
+# Souffle VM
+
+Souffle is a general-purpose bytecode virtual machine designed for extensibility, maintainability, and performance. It serves as an alternative execution backend for GocciaScript and is architected to support multiple programming language frontends and future WASM 3.0 output.
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    subgraph frontends ["Frontend Layer (per language)"]
+        GS["GocciaScript<br/>Lexer → Parser → AST"]
+        FL["Future Language<br/>Lexer → Parser → AST"]
+    end
+
+    subgraph compiler ["Compiler (per language)"]
+        GSC["GocciaScript Compiler<br/>AST → Souffle Bytecode"]
+        FLC["Future Compiler<br/>AST → Souffle Bytecode"]
+    end
+
+    subgraph bytecodeLayer ["Souffle Bytecode Layer (shared format)"]
+        BC["TSouffleBytecodeModule<br/>Instructions + Constants + Debug"]
+        BIN[".sbc Binary<br/>Serialized module"]
+    end
+
+    subgraph execution ["Souffle Execution Layer"]
+        VM["TSouffleVM<br/>Dispatch, Registers, Frames, GC"]
+        VALS["TSouffleValue<br/>Tagged union: Nil, Bool, Int, Float, Ref"]
+        RTJS["Goccia Runtime Ops<br/>JS semantics"]
+        RTOTHER["Future Runtime Ops<br/>other language semantics"]
+        WASM["WASM 3.0 Backend (future)<br/>Bytecode → .wasm"]
+    end
+
+    GS --> GSC
+    FL --> FLC
+    GSC --> BC
+    FLC --> BC
+    BC <-->|"serialize / deserialize"| BIN
+    BC --> VM
+    BC --> WASM
+    VM --> VALS
+    VM -->|"Tier 2 opcodes"| RTJS
+    VM -->|"Tier 2 opcodes"| RTOTHER
+```
+
+The key architectural principle is the **separation of language semantics from VM mechanics**. The VM itself knows nothing about JavaScript, prototype chains, or any language-specific behavior. All language semantics are injected through the pluggable runtime operations interface.
+
+## Execution Pipeline
+
+```
+Source file --[Lexer]--> Tokens --[Parser]--> AST --[Compiler]--> Module --[VM]--> Result
+                                                       |
+                                              --emit-> .sbc file
+                                                       |
+.sbc file ----[LoadModuleFromFile]-----------> Module --[VM]--> Result
+```
+
+## Two-Tier Instruction Set Architecture
+
+The opcode space is split into two tiers with distinct responsibilities:
+
+### Tier 1 (opcodes 0–127): VM-Intrinsic Operations
+
+Fixed semantics implemented directly in the dispatch loop. These are universal operations that every language needs:
+
+| Category | Opcodes | Description |
+|----------|---------|-------------|
+| Load/Store | `OP_LOAD_CONST`, `OP_LOAD_NIL`, `OP_LOAD_TRUE`, `OP_LOAD_FALSE`, `OP_LOAD_INT`, `OP_MOVE` | Register manipulation and constant loading |
+| Variables | `OP_GET_LOCAL`, `OP_SET_LOCAL`, `OP_GET_UPVALUE`, `OP_SET_UPVALUE`, `OP_CLOSE_UPVALUE` | Local and upvalue access |
+| Control Flow | `OP_JUMP`, `OP_JUMP_IF_TRUE`, `OP_JUMP_IF_FALSE`, `OP_JUMP_IF_NIL`, `OP_JUMP_IF_NOT_NIL` | Branching and conditional jumps |
+| Closures | `OP_CLOSURE` | Closure creation from function prototypes |
+| Exceptions | `OP_PUSH_HANDLER`, `OP_POP_HANDLER`, `OP_THROW` | Handler-table exception model |
+| Return | `OP_RETURN`, `OP_RETURN_NIL` | Function return |
+| Debug | `OP_NOP`, `OP_LINE` | No-ops and source line annotations |
+
+### Tier 2 (opcodes 128–255): Runtime-Dispatched Operations
+
+Language-specific semantics dispatched through `TSouffleRuntimeOperations`, an abstract class that each language frontend provides:
+
+| Category | Opcodes | Description |
+|----------|---------|-------------|
+| Arithmetic | `OP_RT_ADD` through `OP_RT_NEG` | Polymorphic arithmetic (addition, subtraction, etc.) |
+| Bitwise | `OP_RT_BAND` through `OP_RT_BNOT` | Polymorphic bitwise operations |
+| Comparison | `OP_RT_EQ` through `OP_RT_GTE` | Polymorphic comparison |
+| Logical/Type | `OP_RT_NOT`, `OP_RT_TYPEOF`, `OP_RT_IS_INSTANCE`, `OP_RT_HAS_PROPERTY`, `OP_RT_TO_BOOLEAN` | Type checks and logical operations |
+| Compound | `OP_RT_NEW_COMPOUND`, `OP_RT_INIT_FIELD`, `OP_RT_INIT_INDEX` | Object/array creation |
+| Property Access | `OP_RT_GET_PROP`, `OP_RT_SET_PROP`, `OP_RT_GET_INDEX`, `OP_RT_SET_INDEX`, `OP_RT_DEL_PROP` | Property read/write/delete |
+| Invocation | `OP_RT_CALL`, `OP_RT_CALL_METHOD`, `OP_RT_CONSTRUCT` | Function calls and construction |
+| Iteration | `OP_RT_GET_ITER`, `OP_RT_ITER_NEXT`, `OP_RT_SPREAD` | Iterator protocol |
+| Modules | `OP_RT_IMPORT`, `OP_RT_EXPORT` | Module system |
+| Async | `OP_RT_AWAIT` | Async/await support |
+| Globals | `OP_RT_GET_GLOBAL`, `OP_RT_SET_GLOBAL` | Global variable access |
+
+The VM doesn't know what "get property" means. It calls `RuntimeOps.GetProperty(obj, key)`. GocciaScript's runtime walks prototype chains. A future Python runtime would do MRO + `__getattr__`. A future Lua runtime would check metatables. Same opcodes, completely different semantics — the **compiler** makes those choices, not the VM.
+
+### Why Two Tiers?
+
+Language-specific concepts like property access, arithmetic on polymorphic values, and `instanceof` have fundamentally different semantics across languages:
+
+- **JavaScript/GocciaScript**: Prototype chain walking, `typeof` operator, `===` strict equality
+- **Python**: MRO-based attribute lookup, `type()` builtin, `__eq__` dunder method
+- **Lua**: Metatable lookups, `type()` function, raw equality
+
+By routing these through an abstract interface, the VM remains language-agnostic. Adding a new language frontend requires implementing `TSouffleRuntimeOperations` — zero VM changes.
+
+### Classes as a Compiler Concern
+
+There is no `CLASS` opcode. Classes are syntactic sugar that the **compiler** desugars into generic operations:
+
+```
+; class Foo extends Bar { constructor(x) { this.x = x; } greet() { return "hi"; } }
+
+CLOSURE      r0, <constructor_proto>     ; constructor function
+CLOSURE      r1, <greet_proto>           ; method
+RT_NEW_COMPOUND r2                        ; create prototype object
+RT_SET_PROP  r2, "greet", r1             ; prototype.greet = greet
+RT_SET_PROP  r0, "prototype", r2         ; Foo.prototype = proto
+RT_LINK_PARENT r0, r_bar                 ; inheritance (runtime-specific semantics)
+```
+
+Every language compiles its "class" concept differently, but all use the same generic opcodes. JavaScript does prototype chains, Python does metaclass invocation + MRO, Lua does metatables.
+
+## Instruction Encoding
+
+Fixed 32-bit instructions with an 8-bit opcode and 24-bit operand space. Four encoding formats:
+
+| Format | Layout | Use |
+|--------|--------|-----|
+| ABC | `[op:8][A:8][B:8][C:8]` | Three 8-bit operands (arithmetic, comparison, property access) |
+| ABx | `[op:8][A:8][Bx:16]` | One 8-bit + one 16-bit unsigned (constant/function index) |
+| AsBx | `[op:8][A:8][sBx:16]` | One 8-bit + one 16-bit signed via bias (conditional jumps) |
+| Ax | `[op:8][Ax:24]` | One 24-bit signed via bias (unconditional jumps) |
+
+Signed operands use bias encoding: `sBx` is stored as `sBx + 32767`, `Ax` is stored as `Ax + 8388607`.
+
+## Register-Based VM
+
+Souffle uses a register-based architecture (like Lua 5, LuaJIT, and Dalvik) rather than a stack-based one.
+
+```
+ Register File (array of TSouffleValue, 16 bytes each):
+ ┌──────────────────┬─────────────────┬─────────────────┬─────┐
+ │ Frame 0 (global) │ Frame 1 (fn A)  │ Frame 2 (fn B)  │ ... │
+ │ R[0]..R[15]      │ R[0]..R[8]      │ R[0]..R[5]      │     │
+ └──────────────────┴─────────────────┴─────────────────┴─────┘
+   ^                  ^                  ^
+   Base=0             Base=16            Base=25
+```
+
+- Up to 65,536 registers in a flat array
+- Each call frame has a base offset; register operands are relative to the frame base
+- Fewer instructions than stack-based VMs (no redundant push/pop)
+- Cache-friendly flat array of 16-byte values with no indirection for primitives
+
+### Call Frames
+
+Each function call pushes a `TSouffleVMCallFrame` onto the call stack:
+
+- `Closure` — the executing closure (provides code, constants, upvalues)
+- `IP` — instruction pointer (index into the closure's code array)
+- `Base` — absolute register offset for this frame
+- `ReturnRegister` — absolute register index where the return value should be stored
+
+The VM supports re-entrant execution: when a runtime operation (e.g., a closure bridge) needs to call back into the VM, `ExecuteFunction` saves and restores `FBaseFrameCount` to correctly handle nested dispatch loops.
+
+## Tagged Union Value System
+
+The VM has its own value system, completely independent of `TGocciaValue`:
+
+```
+TSouffleValue (16 bytes):
+┌──────────────────┬────────────────────────────────┐
+│ Kind: UInt8 (1B) │ padding (7B)                   │
+├──────────────────┴────────────────────────────────┤
+│ Data (8B): Int64 / Double / Pointer               │
+└───────────────────────────────────────────────────┘
+```
+
+### Five Value Kinds
+
+| Kind | In-Value Data | Heap? | Description |
+|------|--------------|-------|-------------|
+| `svkNil` | — | No | Absence of value |
+| `svkBoolean` | `AsBoolean: Boolean` | No | True or false |
+| `svkInteger` | `AsInteger: Int64` | No | 64-bit integer |
+| `svkFloat` | `AsFloat: Double` | No | 64-bit float |
+| `svkReference` | `AsReference: TSouffleHeapObject` | Yes | Pointer to heap object |
+
+Primitives are inline — zero heap allocation, zero GC pressure. All complex types (strings, objects, closures) are `svkReference` pointing to `TSouffleHeapObject` subclasses. The VM never inspects what kind of reference it is — that's the runtime's job.
+
+### Why Only 5 Kinds?
+
+The VM does **not** distinguish between strings, objects, arrays, closures, classes, etc. Those are all `svkReference` — a pointer to a heap object. The heap object carries its own type tag (`HeapKind: UInt8`) that the **runtime** interprets.
+
+This means:
+
+- The VM is truly language-agnostic — it doesn't know what "a string" or "an object" is
+- Adding new heap types requires zero VM changes
+- The register file is a flat array of 16-byte values — cache-friendly, no indirection for primitives
+
+### Truthiness Semantics
+
+`IsTrue` is the one Tier 1 operation that touches value kinds. It has universal behavior: Nil is falsy, Boolean checks the flag, Integer 0 is falsy, Float 0.0/NaN is falsy, all References are truthy. Languages that need different truthiness (e.g., Python where empty list is falsy) can use `RT_TO_BOOLEAN` instead of `JUMP_IF_TRUE`.
+
+### Heap Objects
+
+All heap-allocated values inherit from `TSouffleHeapObject`:
+
+| Heap Kind | Constant | Class | Description |
+|-----------|----------|-------|-------------|
+| 0 | `SOUFFLE_HEAP_STRING` | `TSouffleString` | Immutable string value |
+| 1 | `SOUFFLE_HEAP_CLOSURE` | `TSouffleClosure` | Function prototype + captured upvalues |
+| 2 | `SOUFFLE_HEAP_UPVALUE` | `TSouffleUpvalue` | Open or closed upvalue |
+| 128 | `SOUFFLE_HEAP_RUNTIME` | `TGocciaWrappedValue` | Language-specific wrapped value |
+
+Kind 128+ is reserved for runtime-specific heap types. GocciaScript uses `TGocciaWrappedValue` to wrap `TGocciaValue` instances as Souffle heap objects, enabling GocciaScript's rich type system (arrays, objects, classes, promises, etc.) to be referenced from VM registers.
+
+## Closures and Upvalues
+
+Souffle uses a Lua-style upvalue model for lexical closures:
+
+- **`TSouffleClosure`** — Pairs a `TSouffleFunctionPrototype` (code + constants) with an array of `TSouffleUpvalue` references
+- **`TSouffleUpvalue`** — Either *open* (pointing to a live register) or *closed* (holding a captured value)
+- **`OP_CLOSURE`** — Creates a closure from a nested function prototype, capturing upvalues as described by the prototype's `UpvalueDescriptors`
+- **`OP_GET_UPVALUE` / `OP_SET_UPVALUE`** — Read/write through upvalue indirection
+- **`OP_CLOSE_UPVALUE`** — Migrates an open upvalue's register value into the upvalue's `Closed` field
+
+Open upvalues are linked in a sorted list (`FOpenUpvalues`) for efficient closing when a scope exits. When a function returns, all upvalues pointing to registers at or above the frame's base are closed.
+
+## Exception Handling
+
+Souffle uses a handler-table approach (not try/catch blocks in bytecode):
+
+Each function prototype contains an array of `TSouffleExceptionHandler` records:
+
+```
+TSouffleExceptionHandler:
+  TryStart: UInt32     — first PC of the try range
+  TryEnd: UInt32       — last PC of the try range
+  CatchTarget: UInt32  — PC to jump to on exception
+  FinallyTarget: UInt32 — PC for finally block ($FFFFFFFF if none)
+  CatchRegister: UInt8 — register to store the caught value
+```
+
+At runtime, `OP_PUSH_HANDLER` pushes a handler entry; `OP_POP_HANDLER` removes it. When `OP_THROW` fires, the VM searches the handler stack for a matching handler and jumps to `CatchTarget`, storing the thrown value in `CatchRegister`.
+
+## Garbage Collection
+
+Souffle has its own mark-and-sweep garbage collector (`Souffle.GarbageCollector.pas`), independent of GocciaScript's GC:
+
+- **Singleton** — `TSouffleGarbageCollector.Initialize` / `TSouffleGarbageCollector.Instance`
+- **Managed objects** — All `TSouffleHeapObject` instances registered via `AllocateObject`
+- **Pinned objects** — Long-lived objects protected from collection via `PinObject` / `UnpinObject`
+- **Temp roots** — Short-lived references protected during operations via `AddTempRoot` / `RemoveTempRoot`
+- **External root marker** — The VM registers `MarkVMRoots` to mark all values in the register file and call stack during collection
+- **Threshold-based collection** — `CollectIfNeeded` triggers after a configurable number of allocations (default: 10,000)
+- **O(1) membership** — Pinned objects and temp roots use `TDictionary<TSouffleHeapObject, Boolean>` for hash-set semantics
+
+## Bytecode Module Structure
+
+```
+TSouffleBytecodeModule
+  ├── FormatVersion: UInt16
+  ├── RuntimeTag: string                              (e.g., "goccia-js", "goccia-py")
+  ├── TopLevel: TSouffleFunctionPrototype
+  ├── SourcePath: string
+  ├── Imports: array of TSouffleModuleImport
+  │     ├── ModulePath: string
+  │     └── Bindings: array of (ExportName, LocalSlot)
+  └── Exports: array of TSouffleModuleExport
+        ├── Name: string
+        └── LocalSlot: UInt16
+```
+
+### Function Prototype
+
+```
+TSouffleFunctionPrototype
+  ├── Name: string
+  ├── Code: array of UInt32                         (instruction words)
+  ├── Constants: array of TSouffleBytecodeConstant   (typed constant pool)
+  ├── Functions: array of TSouffleFunctionPrototype   (nested closures)
+  ├── MaxRegisters: UInt8                            (register window size)
+  ├── ParameterCount: UInt8
+  ├── UpvalueCount: UInt8
+  ├── UpvalueDescriptors: array of TSouffleUpvalueDescriptor
+  │     ├── IsLocal: Boolean
+  │     └── Index: UInt8
+  ├── ExceptionHandlers: array of TSouffleExceptionHandler
+  │     ├── TryStart, TryEnd: UInt32
+  │     ├── CatchTarget: UInt32
+  │     ├── FinallyTarget: UInt32 ($FFFFFFFF if none)
+  │     └── CatchRegister: UInt8
+  └── DebugInfo: TSouffleDebugInfo (optional)
+        ├── SourceFile: string
+        ├── LineMap: array of (PC, Line, Column)
+        └── LocalNames: array of (Slot, Name, StartPC, EndPC)
+```
+
+### Constant Pool
+
+Six constant kinds are supported:
+
+| Kind | Tag | Data |
+|------|-----|------|
+| `bckNil` | 0 | — |
+| `bckTrue` | 1 | — |
+| `bckFalse` | 2 | — |
+| `bckInteger` | 3 | `Int64` |
+| `bckFloat` | 4 | `Double` |
+| `bckString` | 5 | Length-prefixed UTF-8 |
+
+Constants are deduplicated within each prototype — adding a duplicate returns the existing index.
+
+## Binary Format (`.sbc`)
+
+The `.sbc` (Souffle ByteCode) binary format enables ahead-of-time compilation and module distribution:
+
+```
+.sbc Binary:
+┌──────────────────────────────────────┐
+│ Header                               │
+│   Magic: "SBC\x00" (4 bytes)        │
+│   FormatVersion: UInt16              │
+├──────────────────────────────────────┤
+│ Metadata                             │
+│   RuntimeTag: len-prefixed UTF-8     │
+│   SourcePath: len-prefixed UTF-8     │
+│   HasDebugInfo: UInt8 (boolean)      │
+├──────────────────────────────────────┤
+│ Import Table                         │
+│   Count: UInt16                      │
+│   Per import:                        │
+│     ModulePath: len-prefixed UTF-8   │
+│     BindingCount: UInt16             │
+│     Per binding:                     │
+│       ExportName: len-prefixed UTF-8 │
+│       LocalSlot: UInt16              │
+├──────────────────────────────────────┤
+│ Export Table                         │
+│   Count: UInt16                      │
+│   Per export:                        │
+│     Name: len-prefixed UTF-8         │
+│     LocalSlot: UInt16                │
+├──────────────────────────────────────┤
+│ Function Prototype (recursive)       │
+│   Name: len-prefixed UTF-8           │
+│   MaxRegisters: UInt8                │
+│   ParameterCount: UInt8              │
+│   UpvalueCount: UInt8                │
+│   CodeLength: UInt32                 │
+│   Code: CodeLength × UInt32          │
+│   ConstantCount: UInt16              │
+│   Per constant:                      │
+│     Tag: UInt8 (0=nil..5=string)     │
+│     Data varies by tag               │
+│   Per upvalue:                       │
+│     IsLocal: UInt8                   │
+│     Index: UInt8                     │
+│   HandlerCount: UInt16               │
+│   Per handler:                       │
+│     TryStart/End: UInt32             │
+│     CatchTarget: UInt32              │
+│     FinallyTarget: UInt32            │
+│     CatchRegister: UInt8             │
+│   SubFunctionCount: UInt16           │
+│   Per sub: (recursive prototype)     │
+│   HasDebug: UInt8 (boolean)          │
+│   [if debug:]                        │
+│     DebugInfo block                  │
+└──────────────────────────────────────┘
+```
+
+The `RuntimeTag` field (e.g., `"goccia-js"`) identifies which runtime operations implementation is needed to execute the module. A loader can reject modules compiled for an incompatible runtime.
+
+## CLI Integration
+
+The `ScriptLoader`, `TestRunner`, and `BenchmarkRunner` all support switching between execution modes:
+
+```bash
+# Interpreted mode (default)
+./build/ScriptLoader example.js
+./build/ScriptLoader example.js --mode=interpreted
+
+# Bytecode mode (compile and execute via Souffle VM)
+./build/ScriptLoader example.js --mode=bytecode
+
+# Emit bytecode to .sbc file (no execution)
+./build/ScriptLoader example.js --emit
+./build/ScriptLoader example.js --emit=output.sbc
+
+# Load and execute a pre-compiled .sbc file
+./build/ScriptLoader output.sbc
+```
+
+When `--emit` is used without a path, the output filename is derived from the input (e.g., `example.js` → `example.sbc`).
+
+## GocciaScript Runtime Bridge
+
+`TGocciaSouffleBackend` (`Goccia.Engine.Backend.pas`) bridges GocciaScript to the Souffle VM:
+
+1. **`RegisterBuiltIns`** — Creates a `TGocciaEngine` instance to bootstrap all GocciaScript globals (`console`, `Math`, `JSON`, `Object`, `Array`, etc.), then registers each global scope binding with the Souffle runtime operations as a wrapped `TSouffleValue`.
+
+2. **`CompileToModule`** — Compiles a `TGocciaProgram` AST to a `TSouffleBytecodeModule`, then evaluates any pending class definitions using the GocciaScript evaluator to produce proper `TGocciaClassValue` objects registered as globals.
+
+3. **`RunModule`** — Executes a module on the VM and unwraps the result back to a `TGocciaValue`.
+
+`TGocciaRuntimeOperations` (`Goccia.Runtime.Operations.pas`) implements `TSouffleRuntimeOperations` with GocciaScript semantics. It bridges between `TSouffleValue` and `TGocciaValue` at the runtime boundary:
+
+- **`ToSouffleValue`** / **`UnwrapToGocciaValue`** — Convert between value systems
+- **`TGocciaWrappedValue`** — Wraps a `TGocciaValue` as a `TSouffleHeapObject` for VM register storage
+- **`TGocciaSouffleClosureBridge`** — Wraps a `TSouffleClosure` as a `TGocciaFunctionBase`, enabling Souffle closures to be called by GocciaScript built-in methods (e.g., `Array.prototype.map` callbacks)
+- **Auto-boxing** — `GetProperty` performs primitive boxing when a direct property lookup returns `nil`, enabling prototype methods on primitives (e.g., `(42).toFixed(2)`)
+
+## File Organization
+
+All Souffle VM source files live in the `souffle/` directory with `Souffle.` prefix naming:
+
+| File | Description |
+|------|-------------|
+| `Souffle.Value.pas` | `TSouffleValue` tagged union, constructors, type checks, truthiness |
+| `Souffle.Heap.pas` | `TSouffleHeapObject` base class, `TSouffleString` |
+| `Souffle.Bytecode.pas` | Opcode definitions, instruction encoding/decoding helpers |
+| `Souffle.Bytecode.Chunk.pas` | `TSouffleFunctionPrototype`, constant pool, upvalue descriptors |
+| `Souffle.Bytecode.Module.pas` | `TSouffleBytecodeModule`, import/export tables |
+| `Souffle.Bytecode.Binary.pas` | `.sbc` serialization/deserialization |
+| `Souffle.Bytecode.Debug.pas` | `TSouffleDebugInfo`, source line mapping, local variable info |
+| `Souffle.VM.pas` | Core VM: dispatch loop, register file, execution |
+| `Souffle.VM.CallFrame.pas` | `TSouffleVMCallFrame`, `TSouffleCallStack` |
+| `Souffle.VM.Closure.pas` | `TSouffleClosure` (prototype + upvalue array) |
+| `Souffle.VM.Upvalue.pas` | `TSouffleUpvalue` (open/closed variable capture) |
+| `Souffle.VM.Exception.pas` | `TSouffleHandlerStack`, `ESouffleThrow` |
+| `Souffle.VM.RuntimeOperations.pas` | `TSouffleRuntimeOperations` abstract interface |
+| `Souffle.GarbageCollector.pas` | Mark-and-sweep GC for `TSouffleHeapObject` |
+
+GocciaScript-specific bridge files in `units/`:
+
+| File | Description |
+|------|-------------|
+| `Goccia.Engine.Backend.pas` | `TGocciaSouffleBackend` — orchestration, built-in registration |
+| `Goccia.Compiler.pas` | `TGocciaCompiler` — AST to Souffle bytecode |
+| `Goccia.Runtime.Operations.pas` | `TGocciaRuntimeOperations` — GocciaScript runtime semantics |
+
+## WASM 3.0 Alignment
+
+The architecture is designed to make a future WASM 3.0 backend a natural fit:
+
+| Souffle Concept | WASM 3.0 Feature |
+|-----------------|-------------------|
+| `TSouffleValue` tagged union | `anyref` hierarchy (`i31ref` for small ints/bools, GC structs for boxed values) |
+| `TSouffleHeapObject` | GC struct types with subtyping (`ref.cast`, `ref.test`) |
+| `TSouffleClosure` | GC struct with `funcref` field + upvalue array |
+| `TSouffleUpvalue` | Mutable GC struct field |
+| Handler-table exception model | `try_table` / `throw` / `throw_ref` / `exnref` |
+| Register file | WASM locals (lowered via register-to-stack translation) |
+| Constant pool | WASM data segments + global constants |
+| Module imports/exports | WASM module imports/exports |
+| `.sbc` binary format | Infrastructure for emitting `.wasm` binary |
+
+### Value Mapping
+
+| Souffle Value | WASM 3.0 Representation |
+|---------------|------------------------|
+| `svkNil` | `ref.null none` |
+| `svkBoolean` (true/false) | `i31ref` (unboxed: 1 or 0) |
+| `svkInteger` (fits 31 bits) | `i31ref` (unboxed, no allocation) |
+| `svkInteger` (large) | `(ref $boxed_i64)` GC struct with `i64` field |
+| `svkFloat` | `(ref $boxed_f64)` GC struct with `f64` field |
+| `svkReference` → String | `(ref $string)` GC array of `i8` |
+| `svkReference` → Object | `(ref $object)` GC struct |
+| `svkReference` → Closure | `(ref $closure)` GC struct with `funcref` + upvalue array |
+
+Key WASM 3.0 features this leverages:
+
+- **`i31ref`** — Unboxed 31-bit tagged integers: small ints and booleans need zero heap allocation in WASM too
+- **GC structs** — `struct.new`, `struct.get`, `struct.set`: our heap objects map directly
+- **GC arrays** — `array.new`, `array.get`, `array.set`: strings and array-like values
+- **Subtyping** — `ref.cast`, `ref.test`, `br_on_cast`: heap kind dispatch without tables
+- **Exception handling** — `try_table`, `throw`, `throw_ref`: direct mapping from our handler-table model
+
+A WASM backend would read `TSouffleBytecodeModule` and emit a `.wasm` binary. The Souffle bytecode layer, VM, and compiler would require zero changes.
+
+## Design Principles
+
+1. **Language-agnostic VM** — The VM knows about 5 value kinds and generic operations. All language semantics live in the runtime operations layer.
+
+2. **Compiler-side desugaring** — Language-specific features (classes, nullish coalescing, template literals) are compiled into sequences of generic VM instructions. The compiler makes semantic choices, not the VM.
+
+3. **Self-contained value system** — `TSouffleValue` is independent of `TGocciaValue`. Bridge conversions happen at the runtime operations boundary, keeping the VM free of GocciaScript dependencies.
+
+4. **Minimal opcode surface** — New language features should be expressible using existing Tier 1 + Tier 2 opcodes. Adding a new Tier 2 opcode is acceptable only when no combination of existing operations can express the semantics efficiently.
+
+5. **Zero-overhead abstraction boundary** — The runtime tag on modules ensures type safety (a module compiled for one runtime cannot be loaded by another), but the actual dispatch is a single virtual method call per Tier 2 instruction.

--- a/souffle/Souffle.Bytecode.Binary.pas
+++ b/souffle/Souffle.Bytecode.Binary.pas
@@ -1,0 +1,457 @@
+unit Souffle.Bytecode.Binary;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Classes,
+
+  Souffle.Bytecode.Chunk,
+  Souffle.Bytecode.Module;
+
+type
+  TSouffleBytecodeWriter = class
+  private
+    FStream: TStream;
+    procedure WriteUInt8(const AValue: UInt8);
+    procedure WriteUInt16(const AValue: UInt16);
+    procedure WriteUInt32(const AValue: UInt32);
+    procedure WriteInt64(const AValue: Int64);
+    procedure WriteDouble(const AValue: Double);
+    procedure WriteString(const AValue: string);
+    procedure WriteBoolean(const AValue: Boolean);
+    procedure WriteFunctionPrototype(const AProto: TSouffleFunctionPrototype);
+  public
+    constructor Create(const AStream: TStream);
+    procedure WriteModule(const AModule: TSouffleBytecodeModule);
+  end;
+
+  TSouffleBytecodeReader = class
+  private
+    FStream: TStream;
+    function ReadUInt8: UInt8;
+    function ReadUInt16: UInt16;
+    function ReadUInt32: UInt32;
+    function ReadInt64: Int64;
+    function ReadDouble: Double;
+    function ReadString: string;
+    function ReadBoolean: Boolean;
+    function ReadFunctionPrototype: TSouffleFunctionPrototype;
+  public
+    constructor Create(const AStream: TStream);
+    function ReadModule: TSouffleBytecodeModule;
+  end;
+
+procedure SaveModuleToFile(const AModule: TSouffleBytecodeModule;
+  const AFileName: string);
+function LoadModuleFromFile(const AFileName: string): TSouffleBytecodeModule;
+
+implementation
+
+uses
+  SysUtils,
+
+  Souffle.Bytecode,
+  Souffle.Bytecode.Debug;
+
+{ TSouffleBytecodeWriter }
+
+constructor TSouffleBytecodeWriter.Create(const AStream: TStream);
+begin
+  inherited Create;
+  FStream := AStream;
+end;
+
+procedure TSouffleBytecodeWriter.WriteUInt8(const AValue: UInt8);
+begin
+  FStream.WriteBuffer(AValue, SizeOf(UInt8));
+end;
+
+procedure TSouffleBytecodeWriter.WriteUInt16(const AValue: UInt16);
+begin
+  FStream.WriteBuffer(AValue, SizeOf(UInt16));
+end;
+
+procedure TSouffleBytecodeWriter.WriteUInt32(const AValue: UInt32);
+begin
+  FStream.WriteBuffer(AValue, SizeOf(UInt32));
+end;
+
+procedure TSouffleBytecodeWriter.WriteInt64(const AValue: Int64);
+begin
+  FStream.WriteBuffer(AValue, SizeOf(Int64));
+end;
+
+procedure TSouffleBytecodeWriter.WriteDouble(const AValue: Double);
+begin
+  FStream.WriteBuffer(AValue, SizeOf(Double));
+end;
+
+procedure TSouffleBytecodeWriter.WriteString(const AValue: string);
+var
+  Len: UInt32;
+  UTF8Str: UTF8String;
+begin
+  UTF8Str := UTF8String(AValue);
+  Len := Length(UTF8Str);
+  WriteUInt32(Len);
+  if Len > 0 then
+    FStream.WriteBuffer(UTF8Str[1], Len);
+end;
+
+procedure TSouffleBytecodeWriter.WriteBoolean(const AValue: Boolean);
+begin
+  if AValue then
+    WriteUInt8(1)
+  else
+    WriteUInt8(0);
+end;
+
+procedure TSouffleBytecodeWriter.WriteFunctionPrototype(
+  const AProto: TSouffleFunctionPrototype);
+var
+  I: Integer;
+  Constant: TSouffleBytecodeConstant;
+  Descriptor: TSouffleUpvalueDescriptor;
+  Handler: TSouffleExceptionHandler;
+begin
+  WriteString(AProto.Name);
+  WriteUInt8(AProto.MaxRegisters);
+  WriteUInt8(AProto.ParameterCount);
+  WriteUInt8(AProto.UpvalueCount);
+
+  // Code
+  WriteUInt32(UInt32(AProto.CodeCount));
+  for I := 0 to AProto.CodeCount - 1 do
+    WriteUInt32(AProto.GetInstruction(I));
+
+  // Constants
+  WriteUInt16(UInt16(AProto.ConstantCount));
+  for I := 0 to AProto.ConstantCount - 1 do
+  begin
+    Constant := AProto.GetConstant(I);
+    WriteUInt8(Ord(Constant.Kind));
+    case Constant.Kind of
+      bckNil, bckTrue, bckFalse:
+        ; // Tag only
+      bckInteger:
+        WriteInt64(Constant.IntValue);
+      bckFloat:
+        WriteDouble(Constant.FloatValue);
+      bckString:
+        WriteString(Constant.StringValue);
+    end;
+  end;
+
+  // Upvalue descriptors
+  for I := 0 to AProto.UpvalueCount - 1 do
+  begin
+    Descriptor := AProto.GetUpvalueDescriptor(I);
+    WriteBoolean(Descriptor.IsLocal);
+    WriteUInt8(Descriptor.Index);
+  end;
+
+  // Exception handlers
+  WriteUInt16(UInt16(AProto.ExceptionHandlerCount));
+  for I := 0 to AProto.ExceptionHandlerCount - 1 do
+  begin
+    Handler := AProto.GetExceptionHandler(I);
+    WriteUInt32(Handler.TryStart);
+    WriteUInt32(Handler.TryEnd);
+    WriteUInt32(Handler.CatchTarget);
+    WriteUInt32(Handler.FinallyTarget);
+    WriteUInt8(Handler.CatchRegister);
+  end;
+
+  // Nested functions
+  WriteUInt16(UInt16(AProto.FunctionCount));
+  for I := 0 to AProto.FunctionCount - 1 do
+    WriteFunctionPrototype(AProto.GetFunction(I));
+
+  // Debug info
+  WriteBoolean(Assigned(AProto.DebugInfo));
+  if Assigned(AProto.DebugInfo) then
+  begin
+    WriteString(AProto.DebugInfo.SourceFile);
+    WriteUInt32(UInt32(AProto.DebugInfo.LineMapCount));
+    for I := 0 to AProto.DebugInfo.LineMapCount - 1 do
+    begin
+      WriteUInt32(AProto.DebugInfo.GetLineMapEntry(I).PC);
+      WriteUInt32(AProto.DebugInfo.GetLineMapEntry(I).Line);
+      WriteUInt16(AProto.DebugInfo.GetLineMapEntry(I).Column);
+    end;
+    WriteUInt32(UInt32(AProto.DebugInfo.LocalCount));
+    for I := 0 to AProto.DebugInfo.LocalCount - 1 do
+    begin
+      WriteString(AProto.DebugInfo.GetLocalInfo(I).Name);
+      WriteUInt8(AProto.DebugInfo.GetLocalInfo(I).Slot);
+      WriteUInt32(AProto.DebugInfo.GetLocalInfo(I).StartPC);
+      WriteUInt32(AProto.DebugInfo.GetLocalInfo(I).EndPC);
+    end;
+  end;
+end;
+
+procedure TSouffleBytecodeWriter.WriteModule(
+  const AModule: TSouffleBytecodeModule);
+var
+  I, J: Integer;
+  Import: TSouffleModuleImport;
+  Export_: TSouffleModuleExport;
+begin
+  // Header: magic + version
+  FStream.WriteBuffer(SOUFFLE_BINARY_MAGIC, 4);
+  WriteUInt16(AModule.FormatVersion);
+
+  // Metadata
+  WriteString(AModule.RuntimeTag);
+  WriteString(AModule.SourcePath);
+  WriteBoolean(AModule.HasDebugInfo);
+
+  // Imports
+  WriteUInt16(UInt16(AModule.ImportCount));
+  for I := 0 to AModule.ImportCount - 1 do
+  begin
+    Import := AModule.GetImport(I);
+    WriteString(Import.ModulePath);
+    WriteUInt16(UInt16(Length(Import.Bindings)));
+    for J := 0 to High(Import.Bindings) do
+    begin
+      WriteString(Import.Bindings[J].ExportName);
+      WriteUInt16(Import.Bindings[J].LocalSlot);
+    end;
+  end;
+
+  // Exports
+  WriteUInt16(UInt16(AModule.ExportCount));
+  for I := 0 to AModule.ExportCount - 1 do
+  begin
+    Export_ := AModule.GetExport(I);
+    WriteString(Export_.Name);
+    WriteUInt16(Export_.LocalSlot);
+  end;
+
+  // Top-level function
+  WriteFunctionPrototype(AModule.TopLevel);
+end;
+
+{ TSouffleBytecodeReader }
+
+constructor TSouffleBytecodeReader.Create(const AStream: TStream);
+begin
+  inherited Create;
+  FStream := AStream;
+end;
+
+function TSouffleBytecodeReader.ReadUInt8: UInt8;
+begin
+  FStream.ReadBuffer(Result, SizeOf(UInt8));
+end;
+
+function TSouffleBytecodeReader.ReadUInt16: UInt16;
+begin
+  FStream.ReadBuffer(Result, SizeOf(UInt16));
+end;
+
+function TSouffleBytecodeReader.ReadUInt32: UInt32;
+begin
+  FStream.ReadBuffer(Result, SizeOf(UInt32));
+end;
+
+function TSouffleBytecodeReader.ReadInt64: Int64;
+begin
+  FStream.ReadBuffer(Result, SizeOf(Int64));
+end;
+
+function TSouffleBytecodeReader.ReadDouble: Double;
+begin
+  FStream.ReadBuffer(Result, SizeOf(Double));
+end;
+
+function TSouffleBytecodeReader.ReadString: string;
+var
+  Len: UInt32;
+  UTF8Str: UTF8String;
+begin
+  Len := ReadUInt32;
+  if Len = 0 then
+    Exit('');
+  SetLength(UTF8Str, Len);
+  FStream.ReadBuffer(UTF8Str[1], Len);
+  Result := string(UTF8Str);
+end;
+
+function TSouffleBytecodeReader.ReadBoolean: Boolean;
+begin
+  Result := ReadUInt8 <> 0;
+end;
+
+function TSouffleBytecodeReader.ReadFunctionPrototype: TSouffleFunctionPrototype;
+var
+  Name: string;
+  MaxRegs, ParamCount, UpvalueCount: UInt8;
+  CodeCount: UInt32;
+  ConstCount, FuncCount, HandlerCount: UInt16;
+  I: Integer;
+  ConstKind: UInt8;
+  HasDebug: Boolean;
+  DebugInfo: TSouffleDebugInfo;
+  SourceFile: string;
+  LineMapCount, LocalCount: UInt32;
+begin
+  Name := ReadString;
+  MaxRegs := ReadUInt8;
+  ParamCount := ReadUInt8;
+  UpvalueCount := ReadUInt8;
+
+  Result := TSouffleFunctionPrototype.Create(Name);
+  Result.MaxRegisters := MaxRegs;
+  Result.ParameterCount := ParamCount;
+
+  // Code
+  CodeCount := ReadUInt32;
+  for I := 0 to CodeCount - 1 do
+    Result.EmitInstruction(ReadUInt32);
+
+  // Constants
+  ConstCount := ReadUInt16;
+  for I := 0 to ConstCount - 1 do
+  begin
+    ConstKind := ReadUInt8;
+    case TSouffleBytecodeConstantKind(ConstKind) of
+      bckNil:     Result.AddConstantNil;
+      bckTrue:    Result.AddConstantBoolean(True);
+      bckFalse:   Result.AddConstantBoolean(False);
+      bckInteger: Result.AddConstantInteger(ReadInt64);
+      bckFloat:   Result.AddConstantFloat(ReadDouble);
+      bckString:  Result.AddConstantString(ReadString);
+    end;
+  end;
+
+  // Upvalue descriptors
+  for I := 0 to UpvalueCount - 1 do
+    Result.AddUpvalueDescriptor(ReadBoolean, ReadUInt8);
+
+  // Exception handlers
+  HandlerCount := ReadUInt16;
+  for I := 0 to HandlerCount - 1 do
+    Result.AddExceptionHandler(ReadUInt32, ReadUInt32, ReadUInt32,
+      ReadUInt32, ReadUInt8);
+
+  // Nested functions
+  FuncCount := ReadUInt16;
+  for I := 0 to FuncCount - 1 do
+    Result.AddFunction(ReadFunctionPrototype);
+
+  // Debug info
+  HasDebug := ReadBoolean;
+  if HasDebug then
+  begin
+    SourceFile := ReadString;
+    DebugInfo := TSouffleDebugInfo.Create(SourceFile);
+
+    LineMapCount := ReadUInt32;
+    for I := 0 to LineMapCount - 1 do
+      DebugInfo.AddLineMapping(ReadUInt32, ReadUInt32, ReadUInt16);
+
+    LocalCount := ReadUInt32;
+    for I := 0 to LocalCount - 1 do
+      DebugInfo.AddLocal(ReadString, ReadUInt8, ReadUInt32, ReadUInt32);
+
+    Result.DebugInfo := DebugInfo;
+  end;
+end;
+
+function TSouffleBytecodeReader.ReadModule: TSouffleBytecodeModule;
+var
+  Magic: array[0..3] of Byte;
+  Version: UInt16;
+  RuntimeTag, SourcePath: string;
+  HasDebug: Boolean;
+  ImportCount, ExportCount: UInt16;
+  I, J: Integer;
+  ModulePath: string;
+  BindingCount: UInt16;
+  Bindings: array of TSouffleModuleBinding;
+begin
+  FStream.ReadBuffer(Magic, 4);
+  if (Magic[0] <> SOUFFLE_BINARY_MAGIC[0]) or (Magic[1] <> SOUFFLE_BINARY_MAGIC[1]) or
+     (Magic[2] <> SOUFFLE_BINARY_MAGIC[2]) or (Magic[3] <> SOUFFLE_BINARY_MAGIC[3]) then
+    raise Exception.Create('Invalid Souffle bytecode file: bad magic');
+
+  Version := ReadUInt16;
+  if Version <> SOUFFLE_FORMAT_VERSION then
+    raise Exception.CreateFmt('Unsupported bytecode format version: %d (expected %d)',
+      [Version, SOUFFLE_FORMAT_VERSION]);
+
+  RuntimeTag := ReadString;
+  SourcePath := ReadString;
+  HasDebug := ReadBoolean;
+
+  Result := TSouffleBytecodeModule.Create(RuntimeTag, SourcePath);
+  Result.HasDebugInfo := HasDebug;
+
+  // Imports
+  ImportCount := ReadUInt16;
+  for I := 0 to ImportCount - 1 do
+  begin
+    ModulePath := ReadString;
+    BindingCount := ReadUInt16;
+    SetLength(Bindings, BindingCount);
+    for J := 0 to BindingCount - 1 do
+    begin
+      Bindings[J].ExportName := ReadString;
+      Bindings[J].LocalSlot := ReadUInt16;
+    end;
+    Result.AddImport(ModulePath, Bindings);
+  end;
+
+  // Exports
+  ExportCount := ReadUInt16;
+  for I := 0 to ExportCount - 1 do
+    Result.AddExport(ReadString, ReadUInt16);
+
+  // Top-level function
+  Result.TopLevel := ReadFunctionPrototype;
+end;
+
+{ File I/O helpers }
+
+procedure SaveModuleToFile(const AModule: TSouffleBytecodeModule;
+  const AFileName: string);
+var
+  Stream: TFileStream;
+  Writer: TSouffleBytecodeWriter;
+begin
+  Stream := TFileStream.Create(AFileName, fmCreate);
+  try
+    Writer := TSouffleBytecodeWriter.Create(Stream);
+    try
+      Writer.WriteModule(AModule);
+    finally
+      Writer.Free;
+    end;
+  finally
+    Stream.Free;
+  end;
+end;
+
+function LoadModuleFromFile(const AFileName: string): TSouffleBytecodeModule;
+var
+  Stream: TFileStream;
+  Reader: TSouffleBytecodeReader;
+begin
+  Stream := TFileStream.Create(AFileName, fmOpenRead);
+  try
+    Reader := TSouffleBytecodeReader.Create(Stream);
+    try
+      Result := Reader.ReadModule;
+    finally
+      Reader.Free;
+    end;
+  finally
+    Stream.Free;
+  end;
+end;
+
+end.

--- a/souffle/Souffle.Bytecode.Chunk.pas
+++ b/souffle/Souffle.Bytecode.Chunk.pas
@@ -1,0 +1,289 @@
+unit Souffle.Bytecode.Chunk;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Generics.Collections,
+
+  Souffle.Bytecode.Debug;
+
+type
+  TSouffleBytecodeConstantKind = (
+    bckNil,
+    bckTrue,
+    bckFalse,
+    bckInteger,
+    bckFloat,
+    bckString
+  );
+
+  TSouffleBytecodeConstant = record
+    Kind: TSouffleBytecodeConstantKind;
+    IntValue: Int64;
+    FloatValue: Double;
+    StringValue: string;
+  end;
+
+  TSouffleUpvalueDescriptor = record
+    IsLocal: Boolean;
+    Index: UInt8;
+  end;
+
+  TSouffleExceptionHandler = record
+    TryStart: UInt32;
+    TryEnd: UInt32;
+    CatchTarget: UInt32;
+    FinallyTarget: UInt32;
+    CatchRegister: UInt8;
+  end;
+
+  TSouffleFunctionPrototype = class
+  private
+    FName: string;
+    FCode: array of UInt32;
+    FCodeCount: Integer;
+    FConstants: array of TSouffleBytecodeConstant;
+    FConstantCount: Integer;
+    FFunctions: TObjectList<TSouffleFunctionPrototype>;
+    FUpvalueDescriptors: array of TSouffleUpvalueDescriptor;
+    FExceptionHandlers: array of TSouffleExceptionHandler;
+    FExceptionHandlerCount: Integer;
+    FMaxRegisters: UInt8;
+    FParameterCount: UInt8;
+    FUpvalueCount: UInt8;
+    FDebugInfo: TSouffleDebugInfo;
+    function GetFunctionCount: Integer;
+  public
+    constructor Create(const AName: string);
+    destructor Destroy; override;
+
+    function EmitInstruction(const AInstruction: UInt32): Integer;
+    procedure PatchInstruction(const AIndex: Integer; const AInstruction: UInt32);
+    function AddConstantNil: UInt16;
+    function AddConstantBoolean(const AValue: Boolean): UInt16;
+    function AddConstantInteger(const AValue: Int64): UInt16;
+    function AddConstantFloat(const AValue: Double): UInt16;
+    function AddConstantString(const AValue: string): UInt16;
+    function AddFunction(const AFunction: TSouffleFunctionPrototype): UInt16;
+    procedure AddUpvalueDescriptor(const AIsLocal: Boolean; const AIndex: UInt8);
+    procedure AddExceptionHandler(const ATryStart, ATryEnd, ACatchTarget,
+      AFinallyTarget: UInt32; const ACatchRegister: UInt8);
+
+    function GetInstruction(const AIndex: Integer): UInt32;
+    function GetConstant(const AIndex: Integer): TSouffleBytecodeConstant;
+    function GetFunction(const AIndex: Integer): TSouffleFunctionPrototype;
+    function GetUpvalueDescriptor(const AIndex: Integer): TSouffleUpvalueDescriptor;
+    function GetExceptionHandler(const AIndex: Integer): TSouffleExceptionHandler;
+
+    property Name: string read FName;
+    property CodeCount: Integer read FCodeCount;
+    property ConstantCount: Integer read FConstantCount;
+    property FunctionCount: Integer read GetFunctionCount;
+    property ExceptionHandlerCount: Integer read FExceptionHandlerCount;
+    property MaxRegisters: UInt8 read FMaxRegisters write FMaxRegisters;
+    property ParameterCount: UInt8 read FParameterCount write FParameterCount;
+    property UpvalueCount: UInt8 read FUpvalueCount;
+    property DebugInfo: TSouffleDebugInfo read FDebugInfo write FDebugInfo;
+  end;
+
+const
+  NO_FINALLY: UInt32 = $FFFFFFFF;
+
+implementation
+
+{ TSouffleFunctionPrototype }
+
+constructor TSouffleFunctionPrototype.Create(const AName: string);
+begin
+  inherited Create;
+  FName := AName;
+  FCodeCount := 0;
+  FConstantCount := 0;
+  FFunctions := TObjectList<TSouffleFunctionPrototype>.Create(True);
+  FExceptionHandlerCount := 0;
+  FMaxRegisters := 0;
+  FParameterCount := 0;
+  FUpvalueCount := 0;
+  FDebugInfo := nil;
+end;
+
+destructor TSouffleFunctionPrototype.Destroy;
+begin
+  FFunctions.Free;
+  FDebugInfo.Free;
+  inherited;
+end;
+
+function TSouffleFunctionPrototype.EmitInstruction(
+  const AInstruction: UInt32): Integer;
+begin
+  if FCodeCount >= Length(FCode) then
+    SetLength(FCode, FCodeCount * 2 + 16);
+  FCode[FCodeCount] := AInstruction;
+  Result := FCodeCount;
+  Inc(FCodeCount);
+end;
+
+procedure TSouffleFunctionPrototype.PatchInstruction(const AIndex: Integer;
+  const AInstruction: UInt32);
+begin
+  FCode[AIndex] := AInstruction;
+end;
+
+function TSouffleFunctionPrototype.AddConstantNil: UInt16;
+var
+  I: Integer;
+begin
+  for I := 0 to FConstantCount - 1 do
+    if FConstants[I].Kind = bckNil then
+      Exit(UInt16(I));
+
+  if FConstantCount >= Length(FConstants) then
+    SetLength(FConstants, FConstantCount * 2 + 8);
+  FConstants[FConstantCount].Kind := bckNil;
+  Result := UInt16(FConstantCount);
+  Inc(FConstantCount);
+end;
+
+function TSouffleFunctionPrototype.AddConstantBoolean(
+  const AValue: Boolean): UInt16;
+var
+  I: Integer;
+  Target: TSouffleBytecodeConstantKind;
+begin
+  if AValue then
+    Target := bckTrue
+  else
+    Target := bckFalse;
+
+  for I := 0 to FConstantCount - 1 do
+    if FConstants[I].Kind = Target then
+      Exit(UInt16(I));
+
+  if FConstantCount >= Length(FConstants) then
+    SetLength(FConstants, FConstantCount * 2 + 8);
+  FConstants[FConstantCount].Kind := Target;
+  Result := UInt16(FConstantCount);
+  Inc(FConstantCount);
+end;
+
+function TSouffleFunctionPrototype.AddConstantInteger(
+  const AValue: Int64): UInt16;
+var
+  I: Integer;
+begin
+  for I := 0 to FConstantCount - 1 do
+    if (FConstants[I].Kind = bckInteger) and (FConstants[I].IntValue = AValue) then
+      Exit(UInt16(I));
+
+  if FConstantCount >= Length(FConstants) then
+    SetLength(FConstants, FConstantCount * 2 + 8);
+  FConstants[FConstantCount].Kind := bckInteger;
+  FConstants[FConstantCount].IntValue := AValue;
+  Result := UInt16(FConstantCount);
+  Inc(FConstantCount);
+end;
+
+function TSouffleFunctionPrototype.AddConstantFloat(
+  const AValue: Double): UInt16;
+var
+  I: Integer;
+begin
+  for I := 0 to FConstantCount - 1 do
+    if (FConstants[I].Kind = bckFloat) and (FConstants[I].FloatValue = AValue) then
+      Exit(UInt16(I));
+
+  if FConstantCount >= Length(FConstants) then
+    SetLength(FConstants, FConstantCount * 2 + 8);
+  FConstants[FConstantCount].Kind := bckFloat;
+  FConstants[FConstantCount].FloatValue := AValue;
+  Result := UInt16(FConstantCount);
+  Inc(FConstantCount);
+end;
+
+function TSouffleFunctionPrototype.AddConstantString(
+  const AValue: string): UInt16;
+var
+  I: Integer;
+begin
+  for I := 0 to FConstantCount - 1 do
+    if (FConstants[I].Kind = bckString) and (FConstants[I].StringValue = AValue) then
+      Exit(UInt16(I));
+
+  if FConstantCount >= Length(FConstants) then
+    SetLength(FConstants, FConstantCount * 2 + 8);
+  FConstants[FConstantCount].Kind := bckString;
+  FConstants[FConstantCount].StringValue := AValue;
+  Result := UInt16(FConstantCount);
+  Inc(FConstantCount);
+end;
+
+function TSouffleFunctionPrototype.AddFunction(
+  const AFunction: TSouffleFunctionPrototype): UInt16;
+begin
+  Result := UInt16(FFunctions.Count);
+  FFunctions.Add(AFunction);
+end;
+
+procedure TSouffleFunctionPrototype.AddUpvalueDescriptor(
+  const AIsLocal: Boolean; const AIndex: UInt8);
+begin
+  if FUpvalueCount >= Length(FUpvalueDescriptors) then
+    SetLength(FUpvalueDescriptors, FUpvalueCount * 2 + 4);
+  FUpvalueDescriptors[FUpvalueCount].IsLocal := AIsLocal;
+  FUpvalueDescriptors[FUpvalueCount].Index := AIndex;
+  Inc(FUpvalueCount);
+end;
+
+procedure TSouffleFunctionPrototype.AddExceptionHandler(
+  const ATryStart, ATryEnd, ACatchTarget, AFinallyTarget: UInt32;
+  const ACatchRegister: UInt8);
+begin
+  if FExceptionHandlerCount >= Length(FExceptionHandlers) then
+    SetLength(FExceptionHandlers, FExceptionHandlerCount * 2 + 4);
+  FExceptionHandlers[FExceptionHandlerCount].TryStart := ATryStart;
+  FExceptionHandlers[FExceptionHandlerCount].TryEnd := ATryEnd;
+  FExceptionHandlers[FExceptionHandlerCount].CatchTarget := ACatchTarget;
+  FExceptionHandlers[FExceptionHandlerCount].FinallyTarget := AFinallyTarget;
+  FExceptionHandlers[FExceptionHandlerCount].CatchRegister := ACatchRegister;
+  Inc(FExceptionHandlerCount);
+end;
+
+function TSouffleFunctionPrototype.GetInstruction(
+  const AIndex: Integer): UInt32;
+begin
+  Result := FCode[AIndex];
+end;
+
+function TSouffleFunctionPrototype.GetConstant(
+  const AIndex: Integer): TSouffleBytecodeConstant;
+begin
+  Result := FConstants[AIndex];
+end;
+
+function TSouffleFunctionPrototype.GetFunction(
+  const AIndex: Integer): TSouffleFunctionPrototype;
+begin
+  Result := FFunctions[AIndex];
+end;
+
+function TSouffleFunctionPrototype.GetUpvalueDescriptor(
+  const AIndex: Integer): TSouffleUpvalueDescriptor;
+begin
+  Result := FUpvalueDescriptors[AIndex];
+end;
+
+function TSouffleFunctionPrototype.GetFunctionCount: Integer;
+begin
+  Result := FFunctions.Count;
+end;
+
+function TSouffleFunctionPrototype.GetExceptionHandler(
+  const AIndex: Integer): TSouffleExceptionHandler;
+begin
+  Result := FExceptionHandlers[AIndex];
+end;
+
+end.

--- a/souffle/Souffle.Bytecode.Chunk.pas
+++ b/souffle/Souffle.Bytecode.Chunk.pas
@@ -93,6 +93,15 @@ const
 
 implementation
 
+function FloatBitsAreNaN(const AValue: Double): Boolean; inline;
+var
+  Bits: UInt64;
+begin
+  Move(AValue, Bits, SizeOf(Double));
+  Result := ((Bits and $7FF0000000000000) = $7FF0000000000000) and
+            ((Bits and $000FFFFFFFFFFFFF) <> 0);
+end;
+
 { TSouffleFunctionPrototype }
 
 constructor TSouffleFunctionPrototype.Create(const AName: string);
@@ -192,7 +201,9 @@ var
   I: Integer;
 begin
   for I := 0 to FConstantCount - 1 do
-    if (FConstants[I].Kind = bckFloat) and (FConstants[I].FloatValue = AValue) then
+    if (FConstants[I].Kind = bckFloat) and
+       ((FConstants[I].FloatValue = AValue) or
+        (FloatBitsAreNaN(FConstants[I].FloatValue) and FloatBitsAreNaN(AValue))) then
       Exit(UInt16(I));
 
   if FConstantCount >= Length(FConstants) then

--- a/souffle/Souffle.Bytecode.Chunk.pas
+++ b/souffle/Souffle.Bytecode.Chunk.pas
@@ -93,6 +93,9 @@ const
 
 implementation
 
+uses
+  SysUtils;
+
 function FloatBitsAreNaN(const AValue: Double): Boolean; inline;
 var
   Bits: UInt64;
@@ -138,6 +141,8 @@ end;
 procedure TSouffleFunctionPrototype.PatchInstruction(const AIndex: Integer;
   const AInstruction: UInt32);
 begin
+  if (AIndex < 0) or (AIndex >= FCodeCount) then
+    raise ERangeError.CreateFmt('PatchInstruction: index %d out of range 0..%d', [AIndex, FCodeCount - 1]);
   FCode[AIndex] := AInstruction;
 end;
 
@@ -149,6 +154,8 @@ begin
     if FConstants[I].Kind = bckNil then
       Exit(UInt16(I));
 
+  if FConstantCount > High(UInt16) then
+    raise Exception.Create('Constant pool overflow: exceeds 65535 entries');
   if FConstantCount >= Length(FConstants) then
     SetLength(FConstants, FConstantCount * 2 + 8);
   FConstants[FConstantCount].Kind := bckNil;
@@ -171,6 +178,8 @@ begin
     if FConstants[I].Kind = Target then
       Exit(UInt16(I));
 
+  if FConstantCount > High(UInt16) then
+    raise Exception.Create('Constant pool overflow: exceeds 65535 entries');
   if FConstantCount >= Length(FConstants) then
     SetLength(FConstants, FConstantCount * 2 + 8);
   FConstants[FConstantCount].Kind := Target;
@@ -187,6 +196,8 @@ begin
     if (FConstants[I].Kind = bckInteger) and (FConstants[I].IntValue = AValue) then
       Exit(UInt16(I));
 
+  if FConstantCount > High(UInt16) then
+    raise Exception.Create('Constant pool overflow: exceeds 65535 entries');
   if FConstantCount >= Length(FConstants) then
     SetLength(FConstants, FConstantCount * 2 + 8);
   FConstants[FConstantCount].Kind := bckInteger;
@@ -206,6 +217,8 @@ begin
         (FloatBitsAreNaN(FConstants[I].FloatValue) and FloatBitsAreNaN(AValue))) then
       Exit(UInt16(I));
 
+  if FConstantCount > High(UInt16) then
+    raise Exception.Create('Constant pool overflow: exceeds 65535 entries');
   if FConstantCount >= Length(FConstants) then
     SetLength(FConstants, FConstantCount * 2 + 8);
   FConstants[FConstantCount].Kind := bckFloat;
@@ -223,6 +236,8 @@ begin
     if (FConstants[I].Kind = bckString) and (FConstants[I].StringValue = AValue) then
       Exit(UInt16(I));
 
+  if FConstantCount > High(UInt16) then
+    raise Exception.Create('Constant pool overflow: exceeds 65535 entries');
   if FConstantCount >= Length(FConstants) then
     SetLength(FConstants, FConstantCount * 2 + 8);
   FConstants[FConstantCount].Kind := bckString;
@@ -241,6 +256,8 @@ end;
 procedure TSouffleFunctionPrototype.AddUpvalueDescriptor(
   const AIsLocal: Boolean; const AIndex: UInt8);
 begin
+  if FUpvalueCount >= High(UInt8) then
+    raise Exception.Create('Upvalue descriptor overflow: exceeds 255 entries');
   if FUpvalueCount >= Length(FUpvalueDescriptors) then
     SetLength(FUpvalueDescriptors, FUpvalueCount * 2 + 4);
   FUpvalueDescriptors[FUpvalueCount].IsLocal := AIsLocal;
@@ -265,24 +282,40 @@ end;
 function TSouffleFunctionPrototype.GetInstruction(
   const AIndex: Integer): UInt32;
 begin
+  {$IFDEF DEBUG}
+  if (AIndex < 0) or (AIndex >= FCodeCount) then
+    raise ERangeError.CreateFmt('GetInstruction: index %d out of range 0..%d', [AIndex, FCodeCount - 1]);
+  {$ENDIF}
   Result := FCode[AIndex];
 end;
 
 function TSouffleFunctionPrototype.GetConstant(
   const AIndex: Integer): TSouffleBytecodeConstant;
 begin
+  {$IFDEF DEBUG}
+  if (AIndex < 0) or (AIndex >= FConstantCount) then
+    raise ERangeError.CreateFmt('GetConstant: index %d out of range 0..%d', [AIndex, FConstantCount - 1]);
+  {$ENDIF}
   Result := FConstants[AIndex];
 end;
 
 function TSouffleFunctionPrototype.GetFunction(
   const AIndex: Integer): TSouffleFunctionPrototype;
 begin
+  {$IFDEF DEBUG}
+  if (AIndex < 0) or (AIndex >= FFunctions.Count) then
+    raise ERangeError.CreateFmt('GetFunction: index %d out of range 0..%d', [AIndex, FFunctions.Count - 1]);
+  {$ENDIF}
   Result := FFunctions[AIndex];
 end;
 
 function TSouffleFunctionPrototype.GetUpvalueDescriptor(
   const AIndex: Integer): TSouffleUpvalueDescriptor;
 begin
+  {$IFDEF DEBUG}
+  if (AIndex < 0) or (AIndex >= FUpvalueCount) then
+    raise ERangeError.CreateFmt('GetUpvalueDescriptor: index %d out of range 0..%d', [AIndex, FUpvalueCount - 1]);
+  {$ENDIF}
   Result := FUpvalueDescriptors[AIndex];
 end;
 

--- a/souffle/Souffle.Bytecode.Chunk.pas
+++ b/souffle/Souffle.Bytecode.Chunk.pas
@@ -249,6 +249,8 @@ end;
 function TSouffleFunctionPrototype.AddFunction(
   const AFunction: TSouffleFunctionPrototype): UInt16;
 begin
+  if FFunctions.Count > High(UInt16) then
+    raise Exception.Create('Function pool overflow: exceeds 65535 entries');
   Result := UInt16(FFunctions.Count);
   FFunctions.Add(AFunction);
 end;
@@ -327,6 +329,10 @@ end;
 function TSouffleFunctionPrototype.GetExceptionHandler(
   const AIndex: Integer): TSouffleExceptionHandler;
 begin
+  {$IFDEF DEBUG}
+  if (AIndex < 0) or (AIndex >= FExceptionHandlerCount) then
+    raise ERangeError.CreateFmt('GetExceptionHandler: index %d out of range 0..%d', [AIndex, FExceptionHandlerCount - 1]);
+  {$ENDIF}
   Result := FExceptionHandlers[AIndex];
 end;
 

--- a/souffle/Souffle.Bytecode.Debug.pas
+++ b/souffle/Souffle.Bytecode.Debug.pas
@@ -1,0 +1,125 @@
+unit Souffle.Bytecode.Debug;
+
+{$I Souffle.inc}
+
+interface
+
+type
+  TSouffleLineMapEntry = record
+    PC: UInt32;
+    Line: UInt32;
+    Column: UInt16;
+  end;
+
+  TSouffleLocalInfo = record
+    Name: string;
+    Slot: UInt8;
+    StartPC: UInt32;
+    EndPC: UInt32;
+  end;
+
+  TSouffleDebugInfo = class
+  private
+    FSourceFile: string;
+    FLineMap: array of TSouffleLineMapEntry;
+    FLineMapCount: Integer;
+    FLocals: array of TSouffleLocalInfo;
+    FLocalCount: Integer;
+  public
+    constructor Create(const ASourceFile: string);
+
+    procedure AddLineMapping(const APC: UInt32; const ALine: UInt32;
+      const AColumn: UInt16);
+    procedure AddLocal(const AName: string; const ASlot: UInt8;
+      const AStartPC, AEndPC: UInt32);
+
+    function GetLineForPC(const APC: UInt32): UInt32;
+    function GetColumnForPC(const APC: UInt32): UInt16;
+    function GetLocalName(const ASlot: UInt8; const APC: UInt32): string;
+
+    function GetLineMapEntry(const AIndex: Integer): TSouffleLineMapEntry;
+    function GetLocalInfo(const AIndex: Integer): TSouffleLocalInfo;
+
+    property SourceFile: string read FSourceFile;
+    property LineMapCount: Integer read FLineMapCount;
+    property LocalCount: Integer read FLocalCount;
+  end;
+
+implementation
+
+{ TSouffleDebugInfo }
+
+constructor TSouffleDebugInfo.Create(const ASourceFile: string);
+begin
+  inherited Create;
+  FSourceFile := ASourceFile;
+  FLineMapCount := 0;
+  FLocalCount := 0;
+end;
+
+procedure TSouffleDebugInfo.AddLineMapping(const APC: UInt32;
+  const ALine: UInt32; const AColumn: UInt16);
+begin
+  if FLineMapCount >= Length(FLineMap) then
+    SetLength(FLineMap, FLineMapCount * 2 + 8);
+  FLineMap[FLineMapCount].PC := APC;
+  FLineMap[FLineMapCount].Line := ALine;
+  FLineMap[FLineMapCount].Column := AColumn;
+  Inc(FLineMapCount);
+end;
+
+procedure TSouffleDebugInfo.AddLocal(const AName: string; const ASlot: UInt8;
+  const AStartPC, AEndPC: UInt32);
+begin
+  if FLocalCount >= Length(FLocals) then
+    SetLength(FLocals, FLocalCount * 2 + 4);
+  FLocals[FLocalCount].Name := AName;
+  FLocals[FLocalCount].Slot := ASlot;
+  FLocals[FLocalCount].StartPC := AStartPC;
+  FLocals[FLocalCount].EndPC := AEndPC;
+  Inc(FLocalCount);
+end;
+
+function TSouffleDebugInfo.GetLineForPC(const APC: UInt32): UInt32;
+var
+  I: Integer;
+begin
+  Result := 0;
+  for I := FLineMapCount - 1 downto 0 do
+    if FLineMap[I].PC <= APC then
+      Exit(FLineMap[I].Line);
+end;
+
+function TSouffleDebugInfo.GetColumnForPC(const APC: UInt32): UInt16;
+var
+  I: Integer;
+begin
+  Result := 0;
+  for I := FLineMapCount - 1 downto 0 do
+    if FLineMap[I].PC <= APC then
+      Exit(FLineMap[I].Column);
+end;
+
+function TSouffleDebugInfo.GetLocalName(const ASlot: UInt8;
+  const APC: UInt32): string;
+var
+  I: Integer;
+begin
+  Result := '';
+  for I := 0 to FLocalCount - 1 do
+    if (FLocals[I].Slot = ASlot) and (APC >= FLocals[I].StartPC) and
+       (APC <= FLocals[I].EndPC) then
+      Exit(FLocals[I].Name);
+end;
+
+function TSouffleDebugInfo.GetLineMapEntry(const AIndex: Integer): TSouffleLineMapEntry;
+begin
+  Result := FLineMap[AIndex];
+end;
+
+function TSouffleDebugInfo.GetLocalInfo(const AIndex: Integer): TSouffleLocalInfo;
+begin
+  Result := FLocals[AIndex];
+end;
+
+end.

--- a/souffle/Souffle.Bytecode.Module.pas
+++ b/souffle/Souffle.Bytecode.Module.pas
@@ -1,0 +1,118 @@
+unit Souffle.Bytecode.Module;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Souffle.Bytecode.Chunk;
+
+type
+  TSouffleModuleBinding = record
+    ExportName: string;
+    LocalSlot: UInt16;
+  end;
+
+  TSouffleModuleImport = record
+    ModulePath: string;
+    Bindings: array of TSouffleModuleBinding;
+  end;
+
+  TSouffleModuleExport = record
+    Name: string;
+    LocalSlot: UInt16;
+  end;
+
+  TSouffleBytecodeModule = class
+  private
+    FFormatVersion: UInt16;
+    FRuntimeTag: string;
+    FSourcePath: string;
+    FTopLevel: TSouffleFunctionPrototype;
+    FImports: array of TSouffleModuleImport;
+    FImportCount: Integer;
+    FExports: array of TSouffleModuleExport;
+    FExportCount: Integer;
+    FHasDebugInfo: Boolean;
+  public
+    constructor Create(const ARuntimeTag, ASourcePath: string);
+    destructor Destroy; override;
+
+    procedure AddImport(const AModulePath: string;
+      const ABindings: array of TSouffleModuleBinding);
+    procedure AddExport(const AName: string; const ALocalSlot: UInt16);
+
+    function GetImport(const AIndex: Integer): TSouffleModuleImport;
+    function GetExport(const AIndex: Integer): TSouffleModuleExport;
+
+    property FormatVersion: UInt16 read FFormatVersion;
+    property RuntimeTag: string read FRuntimeTag;
+    property SourcePath: string read FSourcePath;
+    property TopLevel: TSouffleFunctionPrototype read FTopLevel write FTopLevel;
+    property ImportCount: Integer read FImportCount;
+    property ExportCount: Integer read FExportCount;
+    property HasDebugInfo: Boolean read FHasDebugInfo write FHasDebugInfo;
+  end;
+
+implementation
+
+uses
+  Souffle.Bytecode;
+
+{ TSouffleBytecodeModule }
+
+constructor TSouffleBytecodeModule.Create(const ARuntimeTag, ASourcePath: string);
+begin
+  inherited Create;
+  FFormatVersion := SOUFFLE_FORMAT_VERSION;
+  FRuntimeTag := ARuntimeTag;
+  FSourcePath := ASourcePath;
+  FTopLevel := nil;
+  FImportCount := 0;
+  FExportCount := 0;
+  FHasDebugInfo := True;
+end;
+
+destructor TSouffleBytecodeModule.Destroy;
+begin
+  FTopLevel.Free;
+  inherited;
+end;
+
+procedure TSouffleBytecodeModule.AddImport(const AModulePath: string;
+  const ABindings: array of TSouffleModuleBinding);
+var
+  I: Integer;
+begin
+  if FImportCount >= Length(FImports) then
+    SetLength(FImports, FImportCount * 2 + 4);
+  FImports[FImportCount].ModulePath := AModulePath;
+  SetLength(FImports[FImportCount].Bindings, Length(ABindings));
+  for I := 0 to High(ABindings) do
+    FImports[FImportCount].Bindings[I] := ABindings[I];
+  Inc(FImportCount);
+end;
+
+procedure TSouffleBytecodeModule.AddExport(const AName: string;
+  const ALocalSlot: UInt16);
+begin
+  if FExportCount >= Length(FExports) then
+    SetLength(FExports, FExportCount * 2 + 4);
+  FExports[FExportCount].Name := AName;
+  FExports[FExportCount].LocalSlot := ALocalSlot;
+  Inc(FExportCount);
+end;
+
+function TSouffleBytecodeModule.GetImport(
+  const AIndex: Integer): TSouffleModuleImport;
+begin
+  Result := FImports[AIndex];
+end;
+
+function TSouffleBytecodeModule.GetExport(
+  const AIndex: Integer): TSouffleModuleExport;
+begin
+  Result := FExports[AIndex];
+end;
+
+end.

--- a/souffle/Souffle.Bytecode.pas
+++ b/souffle/Souffle.Bytecode.pas
@@ -1,0 +1,223 @@
+unit Souffle.Bytecode;
+
+{$I Souffle.inc}
+
+interface
+
+const
+  SOUFFLE_FORMAT_VERSION = 1;
+  SOUFFLE_BINARY_MAGIC: array[0..3] of Byte = (Ord('S'), Ord('B'), Ord('C'), 0);
+
+  OP_RT_FIRST = 128;
+
+type
+  { Tier 1: Core operations (VM-intrinsic, fixed semantics) — opcodes 0..127 }
+  { Tier 2: Runtime operations (pluggable semantics) — opcodes 128..255 }
+  TSouffleOpCode = (
+    // ── Tier 1: Load / Store / Move ──
+    OP_LOAD_CONST    = 0,   // ABx   R[A] := Constants[Bx]
+    OP_LOAD_NIL      = 1,   // A     R[A] := Nil
+    OP_LOAD_TRUE     = 2,   // A     R[A] := Boolean(true)
+    OP_LOAD_FALSE    = 3,   // A     R[A] := Boolean(false)
+    OP_LOAD_INT      = 4,   // AsBx  R[A] := Integer(sBx)
+    OP_MOVE          = 5,   // AB    R[A] := R[B]
+
+    // ── Tier 1: Variables ──
+    OP_GET_LOCAL     = 6,   // ABx   R[A] := Locals[Bx]
+    OP_SET_LOCAL     = 7,   // ABx   Locals[Bx] := R[A]
+    OP_GET_UPVALUE   = 8,   // ABx   R[A] := Upvalues[Bx]
+    OP_SET_UPVALUE   = 9,   // ABx   Upvalues[Bx] := R[A]
+    OP_CLOSE_UPVALUE = 10,  // A     Close upvalue for R[A]
+
+    // ── Tier 1: Control Flow ──
+    OP_JUMP          = 11,  // Ax    PC += Ax (signed 24-bit)
+    OP_JUMP_IF_TRUE  = 12,  // AsBx  if IsTrue(R[A]): PC += sBx
+    OP_JUMP_IF_FALSE = 13,  // AsBx  if not IsTrue(R[A]): PC += sBx
+    OP_JUMP_IF_NIL   = 14,  // AsBx  if R[A].Kind = svkNil: PC += sBx
+    OP_JUMP_IF_NOT_NIL = 15, // AsBx if R[A].Kind <> svkNil: PC += sBx
+
+    // ── Tier 1: Closures ──
+    OP_CLOSURE       = 16,  // ABx   R[A] := Closure(FunctionPrototypes[Bx])
+
+    // ── Tier 1: Exception Handling ──
+    OP_PUSH_HANDLER  = 17,  // ABx   Push handler: catch at PC+Bx, value in R[A]
+    OP_POP_HANDLER   = 18,  //       Pop innermost handler
+    OP_THROW         = 19,  // A     Throw R[A]
+
+    // ── Tier 1: Return ──
+    OP_RETURN        = 20,  // A     Return R[A] to caller
+    OP_RETURN_NIL    = 21,  //       Return Nil to caller
+
+    // ── Tier 1: Debug ──
+    OP_NOP           = 22,  //       No operation
+    OP_LINE          = 23,  // Bx    Source line annotation
+
+    // ── Tier 2: Polymorphic Arithmetic ──
+    OP_RT_ADD        = 128, // ABC   R[A] := Runtime.Add(R[B], R[C])
+    OP_RT_SUB        = 129, // ABC   R[A] := Runtime.Subtract(R[B], R[C])
+    OP_RT_MUL        = 130, // ABC   R[A] := Runtime.Multiply(R[B], R[C])
+    OP_RT_DIV        = 131, // ABC   R[A] := Runtime.Divide(R[B], R[C])
+    OP_RT_MOD        = 132, // ABC   R[A] := Runtime.Modulo(R[B], R[C])
+    OP_RT_POW        = 133, // ABC   R[A] := Runtime.Power(R[B], R[C])
+    OP_RT_NEG        = 134, // AB    R[A] := Runtime.Negate(R[B])
+
+    // ── Tier 2: Polymorphic Bitwise ──
+    OP_RT_BAND       = 135, // ABC   R[A] := Runtime.BitwiseAnd(R[B], R[C])
+    OP_RT_BOR        = 136, // ABC   R[A] := Runtime.BitwiseOr(R[B], R[C])
+    OP_RT_BXOR       = 137, // ABC   R[A] := Runtime.BitwiseXor(R[B], R[C])
+    OP_RT_SHL        = 138, // ABC   R[A] := Runtime.ShiftLeft(R[B], R[C])
+    OP_RT_SHR        = 139, // ABC   R[A] := Runtime.ShiftRight(R[B], R[C])
+    OP_RT_USHR       = 140, // ABC   R[A] := Runtime.UnsignedShiftRight(R[B], R[C])
+    OP_RT_BNOT       = 141, // AB    R[A] := Runtime.BitwiseNot(R[B])
+
+    // ── Tier 2: Polymorphic Comparison ──
+    OP_RT_EQ         = 142, // ABC   R[A] := Runtime.Equal(R[B], R[C])
+    OP_RT_NEQ        = 143, // ABC   R[A] := Runtime.NotEqual(R[B], R[C])
+    OP_RT_LT         = 144, // ABC   R[A] := Runtime.LessThan(R[B], R[C])
+    OP_RT_GT         = 145, // ABC   R[A] := Runtime.GreaterThan(R[B], R[C])
+    OP_RT_LTE        = 146, // ABC   R[A] := Runtime.LessThanOrEqual(R[B], R[C])
+    OP_RT_GTE        = 147, // ABC   R[A] := Runtime.GreaterThanOrEqual(R[B], R[C])
+
+    // ── Tier 2: Logical / Type ──
+    OP_RT_NOT        = 148, // AB    R[A] := Runtime.LogicalNot(R[B])
+    OP_RT_TYPEOF     = 149, // AB    R[A] := Runtime.TypeOf(R[B])
+    OP_RT_IS_INSTANCE = 150, // ABC  R[A] := Runtime.IsInstance(R[B], R[C])
+    OP_RT_HAS_PROPERTY = 151, // ABC R[A] := Runtime.HasProperty(R[B], R[C])
+    OP_RT_TO_BOOLEAN = 152, // AB    R[A] := Runtime.ToBoolean(R[B])
+
+    // ── Tier 2: Compound Creation ──
+    OP_RT_NEW_COMPOUND = 153, // AB  R[A] := Runtime.CreateCompound(B)
+    OP_RT_INIT_FIELD = 154, // ABC   Runtime.InitField(R[A], Constants[B], R[C])
+    OP_RT_INIT_INDEX = 155, // ABC   Runtime.InitIndex(R[A], R[B], R[C])
+
+    // ── Tier 2: Property Access ──
+    OP_RT_GET_PROP   = 156, // ABC   R[A] := Runtime.GetProperty(R[B], Constants[C])
+    OP_RT_SET_PROP   = 157, // ABC   Runtime.SetProperty(R[A], Constants[B], R[C])
+    OP_RT_GET_INDEX  = 158, // ABC   R[A] := Runtime.GetIndex(R[B], R[C])
+    OP_RT_SET_INDEX  = 159, // ABC   Runtime.SetIndex(R[A], R[B], R[C])
+    OP_RT_DEL_PROP   = 160, // ABC   R[A] := Runtime.DeleteProperty(R[B], Constants[C])
+
+    // ── Tier 2: Invocation ──
+    OP_RT_CALL       = 161, // ABC   R[A] := Runtime.Invoke(R[A], args, B=argc, C=flags)
+    OP_RT_CALL_METHOD = 162, // ABC  Like RT_CALL but receiver = R[A-1]
+    OP_RT_CONSTRUCT  = 163, // ABC   R[A] := Runtime.Construct(R[B], args, C=argc)
+
+    // ── Tier 2: Iteration ──
+    OP_RT_GET_ITER   = 164, // AB    R[A] := Runtime.GetIterator(R[B])
+    OP_RT_ITER_NEXT  = 165, // ABC   (R[A], R[B]) := Runtime.IteratorNext(R[C])
+    OP_RT_SPREAD     = 166, // AB    Runtime.SpreadInto(R[A], R[B])
+
+    // ── Tier 2: Modules ──
+    OP_RT_IMPORT     = 167, // ABx   R[A] := Runtime.ImportModule(Constants[Bx])
+    OP_RT_EXPORT     = 168, // ABx   Runtime.ExportBinding(R[A], Constants[Bx])
+
+    // ── Tier 2: Async ──
+    OP_RT_AWAIT      = 169, // AB    R[A] := Runtime.Await(R[B])
+
+    // ── Tier 2: Globals ──
+    OP_RT_GET_GLOBAL = 170, // ABx   R[A] := Runtime.GetGlobal(Constants[Bx])
+    OP_RT_SET_GLOBAL = 171  // ABx   Runtime.SetGlobal(Constants[Bx], R[A])
+  );
+
+{ Instruction encoding/decoding helpers }
+
+{ Encoding: pack opcode + operands into a 32-bit instruction word }
+function EncodeABC(const AOp: TSouffleOpCode; const A, B, C: UInt8): UInt32; inline;
+function EncodeABx(const AOp: TSouffleOpCode; const A: UInt8; const ABx: UInt16): UInt32; inline;
+function EncodeAsBx(const AOp: TSouffleOpCode; const A: UInt8; const AAsBx: Int16): UInt32; inline;
+function EncodeAx(const AOp: TSouffleOpCode; const AAx: Int32): UInt32; inline;
+
+{ Decoding: extract fields from a 32-bit instruction word }
+function DecodeOp(const AInstruction: UInt32): UInt8; inline;
+function DecodeA(const AInstruction: UInt32): UInt8; inline;
+function DecodeB(const AInstruction: UInt32): UInt8; inline;
+function DecodeC(const AInstruction: UInt32): UInt8; inline;
+function DecodeBx(const AInstruction: UInt32): UInt16; inline;
+function DecodesBx(const AInstruction: UInt32): Int16; inline;
+function DecodeAx(const AInstruction: UInt32): Int32; inline;
+
+function IsRuntimeOp(const AInstruction: UInt32): Boolean; inline;
+
+implementation
+
+{ Instruction layout:
+    ABC:  [op:8][A:8][B:8][C:8]
+    ABx:  [op:8][A:8][Bx:16]
+    AsBx: [op:8][A:8][sBx:16]  (sBx is signed via bias: stored as sBx + 32767)
+    Ax:   [op:8][Ax:24]        (Ax is signed via bias: stored as Ax + 8388607) }
+
+const
+  SBIAS_16 = 32767;
+  SBIAS_24 = 8388607;
+
+{ Encoding }
+
+function EncodeABC(const AOp: TSouffleOpCode; const A, B, C: UInt8): UInt32;
+begin
+  Result := UInt32(Ord(AOp)) or (UInt32(A) shl 8) or (UInt32(B) shl 16) or (UInt32(C) shl 24);
+end;
+
+function EncodeABx(const AOp: TSouffleOpCode; const A: UInt8; const ABx: UInt16): UInt32;
+begin
+  Result := UInt32(Ord(AOp)) or (UInt32(A) shl 8) or (UInt32(ABx) shl 16);
+end;
+
+function EncodeAsBx(const AOp: TSouffleOpCode; const A: UInt8; const AAsBx: Int16): UInt32;
+var
+  Biased: UInt16;
+begin
+  Biased := UInt16(Integer(AAsBx) + SBIAS_16);
+  Result := UInt32(Ord(AOp)) or (UInt32(A) shl 8) or (UInt32(Biased) shl 16);
+end;
+
+function EncodeAx(const AOp: TSouffleOpCode; const AAx: Int32): UInt32;
+var
+  Biased: UInt32;
+begin
+  Biased := UInt32(AAx + SBIAS_24) and $FFFFFF;
+  Result := UInt32(Ord(AOp)) or (Biased shl 8);
+end;
+
+{ Decoding }
+
+function DecodeOp(const AInstruction: UInt32): UInt8;
+begin
+  Result := UInt8(AInstruction and $FF);
+end;
+
+function DecodeA(const AInstruction: UInt32): UInt8;
+begin
+  Result := UInt8((AInstruction shr 8) and $FF);
+end;
+
+function DecodeB(const AInstruction: UInt32): UInt8;
+begin
+  Result := UInt8((AInstruction shr 16) and $FF);
+end;
+
+function DecodeC(const AInstruction: UInt32): UInt8;
+begin
+  Result := UInt8((AInstruction shr 24) and $FF);
+end;
+
+function DecodeBx(const AInstruction: UInt32): UInt16;
+begin
+  Result := UInt16((AInstruction shr 16) and $FFFF);
+end;
+
+function DecodesBx(const AInstruction: UInt32): Int16;
+begin
+  Result := Int16(Integer(DecodeBx(AInstruction)) - SBIAS_16);
+end;
+
+function DecodeAx(const AInstruction: UInt32): Int32;
+begin
+  Result := Int32((AInstruction shr 8) and $FFFFFF) - SBIAS_24;
+end;
+
+function IsRuntimeOp(const AInstruction: UInt32): Boolean;
+begin
+  Result := (AInstruction and $FF) >= OP_RT_FIRST;
+end;
+
+end.

--- a/souffle/Souffle.GarbageCollector.pas
+++ b/souffle/Souffle.GarbageCollector.pas
@@ -1,0 +1,219 @@
+unit Souffle.GarbageCollector;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Generics.Collections,
+
+  Souffle.Heap;
+
+type
+  TSouffleHeapObjectList = TObjectList<TSouffleHeapObject>;
+  TSouffleGCRootMarker = procedure of object;
+
+  TSouffleGarbageCollector = class
+  private class var
+    FInstance: TSouffleGarbageCollector;
+  private
+    FManagedObjects: TSouffleHeapObjectList;
+    FPinnedObjects: TDictionary<TSouffleHeapObject, Boolean>;
+    FTempRoots: TDictionary<TSouffleHeapObject, Boolean>;
+
+    FAllocationsSinceLastGC: Integer;
+    FGCThreshold: Integer;
+    FEnabled: Boolean;
+    FCollecting: Boolean;
+    FTotalCollected: Int64;
+    FTotalCollections: Integer;
+
+    FExternalRootMarker: TSouffleGCRootMarker;
+
+    procedure MarkPhase;
+    procedure SweepPhase;
+    function GetManagedObjectCount: Integer;
+  public
+    class function Instance: TSouffleGarbageCollector;
+    class procedure Initialize;
+    class procedure Shutdown;
+
+    constructor Create;
+    destructor Destroy; override;
+
+    function AllocateObject(const AObject: TSouffleHeapObject): TSouffleHeapObject;
+    procedure PinObject(const AObject: TSouffleHeapObject);
+    procedure UnpinObject(const AObject: TSouffleHeapObject);
+    procedure AddTempRoot(const AObject: TSouffleHeapObject);
+    procedure RemoveTempRoot(const AObject: TSouffleHeapObject);
+
+    procedure SetExternalRootMarker(const AMarker: TSouffleGCRootMarker);
+
+    procedure Collect;
+    procedure CollectIfNeeded;
+
+    property Enabled: Boolean read FEnabled write FEnabled;
+    property Threshold: Integer read FGCThreshold write FGCThreshold;
+    property TotalCollected: Int64 read FTotalCollected;
+    property TotalCollections: Integer read FTotalCollections;
+    property ManagedObjectCount: Integer read GetManagedObjectCount;
+  end;
+
+implementation
+
+uses
+  SysUtils;
+
+const
+  DEFAULT_GC_THRESHOLD = 10000;
+
+{ TSouffleGarbageCollector }
+
+class function TSouffleGarbageCollector.Instance: TSouffleGarbageCollector;
+begin
+  Result := FInstance;
+end;
+
+class procedure TSouffleGarbageCollector.Initialize;
+begin
+  if not Assigned(FInstance) then
+    FInstance := TSouffleGarbageCollector.Create;
+end;
+
+class procedure TSouffleGarbageCollector.Shutdown;
+begin
+  FreeAndNil(FInstance);
+end;
+
+constructor TSouffleGarbageCollector.Create;
+begin
+  FManagedObjects := TSouffleHeapObjectList.Create(False);
+  FPinnedObjects := TDictionary<TSouffleHeapObject, Boolean>.Create;
+  FTempRoots := TDictionary<TSouffleHeapObject, Boolean>.Create;
+  FAllocationsSinceLastGC := 0;
+  FGCThreshold := DEFAULT_GC_THRESHOLD;
+  FEnabled := True;
+  FCollecting := False;
+  FTotalCollected := 0;
+  FTotalCollections := 0;
+  FExternalRootMarker := nil;
+end;
+
+destructor TSouffleGarbageCollector.Destroy;
+begin
+  FManagedObjects.Free;
+  FPinnedObjects.Free;
+  FTempRoots.Free;
+  inherited;
+end;
+
+function TSouffleGarbageCollector.AllocateObject(
+  const AObject: TSouffleHeapObject): TSouffleHeapObject;
+begin
+  FManagedObjects.Add(AObject);
+  Inc(FAllocationsSinceLastGC);
+  Result := AObject;
+end;
+
+procedure TSouffleGarbageCollector.PinObject(
+  const AObject: TSouffleHeapObject);
+begin
+  if Assigned(AObject) and not FPinnedObjects.ContainsKey(AObject) then
+    FPinnedObjects.Add(AObject, True);
+end;
+
+procedure TSouffleGarbageCollector.UnpinObject(
+  const AObject: TSouffleHeapObject);
+begin
+  FPinnedObjects.Remove(AObject);
+end;
+
+procedure TSouffleGarbageCollector.AddTempRoot(
+  const AObject: TSouffleHeapObject);
+begin
+  if Assigned(AObject) and not FTempRoots.ContainsKey(AObject) then
+    FTempRoots.Add(AObject, True);
+end;
+
+procedure TSouffleGarbageCollector.RemoveTempRoot(
+  const AObject: TSouffleHeapObject);
+begin
+  FTempRoots.Remove(AObject);
+end;
+
+procedure TSouffleGarbageCollector.SetExternalRootMarker(
+  const AMarker: TSouffleGCRootMarker);
+begin
+  FExternalRootMarker := AMarker;
+end;
+
+procedure TSouffleGarbageCollector.MarkPhase;
+var
+  I: Integer;
+  Obj: TSouffleHeapObject;
+begin
+  for I := 0 to FManagedObjects.Count - 1 do
+    FManagedObjects[I].GCMarked := False;
+
+  for Obj in FPinnedObjects.Keys do
+    Obj.MarkReferences;
+
+  for Obj in FTempRoots.Keys do
+    Obj.MarkReferences;
+
+  if Assigned(FExternalRootMarker) then
+    FExternalRootMarker();
+end;
+
+procedure TSouffleGarbageCollector.SweepPhase;
+var
+  I, WriteIdx: Integer;
+  Collected: Integer;
+begin
+  Collected := 0;
+  WriteIdx := 0;
+
+  for I := 0 to FManagedObjects.Count - 1 do
+  begin
+    if FManagedObjects[I].GCMarked then
+    begin
+      FManagedObjects[WriteIdx] := FManagedObjects[I];
+      Inc(WriteIdx);
+    end
+    else
+    begin
+      FManagedObjects[I].Free;
+      Inc(Collected);
+    end;
+  end;
+
+  FManagedObjects.Count := WriteIdx;
+  FTotalCollected := FTotalCollected + Collected;
+end;
+
+procedure TSouffleGarbageCollector.Collect;
+begin
+  if FCollecting then Exit;
+  FCollecting := True;
+  try
+    MarkPhase;
+    SweepPhase;
+    FAllocationsSinceLastGC := 0;
+    Inc(FTotalCollections);
+  finally
+    FCollecting := False;
+  end;
+end;
+
+procedure TSouffleGarbageCollector.CollectIfNeeded;
+begin
+  if FEnabled and (FAllocationsSinceLastGC >= FGCThreshold) and not FCollecting then
+    Collect;
+end;
+
+function TSouffleGarbageCollector.GetManagedObjectCount: Integer;
+begin
+  Result := FManagedObjects.Count;
+end;
+
+end.

--- a/souffle/Souffle.GarbageCollector.pas
+++ b/souffle/Souffle.GarbageCollector.pas
@@ -100,7 +100,11 @@ begin
 end;
 
 destructor TSouffleGarbageCollector.Destroy;
+var
+  I: Integer;
 begin
+  for I := 0 to FManagedObjects.Count - 1 do
+    FManagedObjects[I].Free;
   FManagedObjects.Free;
   FPinnedObjects.Free;
   FTempRoots.Free;

--- a/souffle/Souffle.Heap.pas
+++ b/souffle/Souffle.Heap.pas
@@ -1,0 +1,76 @@
+unit Souffle.Heap;
+
+{$I Souffle.inc}
+
+interface
+
+type
+  TSouffleHeapObject = class
+  private
+    FGCMarked: Boolean;
+    FHeapKind: UInt8;
+  public
+    constructor Create(const AHeapKind: UInt8);
+
+    procedure MarkReferences; virtual;
+    function DebugString: string; virtual;
+
+    property GCMarked: Boolean read FGCMarked write FGCMarked;
+    property HeapKind: UInt8 read FHeapKind;
+  end;
+
+  TSouffleString = class(TSouffleHeapObject)
+  private
+    FValue: string;
+  public
+    constructor Create(const AValue: string);
+
+    function DebugString: string; override;
+
+    property Value: string read FValue;
+  end;
+
+const
+  SOUFFLE_HEAP_STRING   = 0;
+  SOUFFLE_HEAP_CLOSURE  = 1;
+  SOUFFLE_HEAP_UPVALUE  = 2;
+  SOUFFLE_HEAP_RUNTIME  = 128;
+
+implementation
+
+uses
+  SysUtils;
+
+{ TSouffleHeapObject }
+
+constructor TSouffleHeapObject.Create(const AHeapKind: UInt8);
+begin
+  inherited Create;
+  FGCMarked := False;
+  FHeapKind := AHeapKind;
+end;
+
+procedure TSouffleHeapObject.MarkReferences;
+begin
+  FGCMarked := True;
+end;
+
+function TSouffleHeapObject.DebugString: string;
+begin
+  Result := '<heap:' + IntToStr(FHeapKind) + '>';
+end;
+
+{ TSouffleString }
+
+constructor TSouffleString.Create(const AValue: string);
+begin
+  inherited Create(SOUFFLE_HEAP_STRING);
+  FValue := AValue;
+end;
+
+function TSouffleString.DebugString: string;
+begin
+  Result := '"' + FValue + '"';
+end;
+
+end.

--- a/souffle/Souffle.VM.CallFrame.pas
+++ b/souffle/Souffle.VM.CallFrame.pas
@@ -81,6 +81,11 @@ end;
 
 function TSouffleCallStack.Peek: PSouffleVMCallFrame;
 begin
+  {$IFDEF DEBUG}
+  Assert(FCount > 0, 'TSouffleCallStack.Peek called on empty stack');
+  {$ENDIF}
+  if FCount = 0 then
+    Exit(nil);
   Result := @FFrames[FCount - 1];
 end;
 

--- a/souffle/Souffle.VM.CallFrame.pas
+++ b/souffle/Souffle.VM.CallFrame.pas
@@ -1,0 +1,92 @@
+unit Souffle.VM.CallFrame;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Souffle.Bytecode.Chunk,
+  Souffle.VM.Closure;
+
+type
+  PSouffleVMCallFrame = ^TSouffleVMCallFrame;
+
+  TSouffleVMCallFrame = record
+    Prototype: TSouffleFunctionPrototype;
+    Closure: TSouffleClosure;
+    IP: Integer;
+    BaseRegister: Integer;
+    HandlerDepth: Integer;
+    ReturnRegister: Integer;
+  end;
+
+  TSouffleCallStack = class
+  private
+    FFrames: array of TSouffleVMCallFrame;
+    FCount: Integer;
+    FCapacity: Integer;
+  public
+    constructor Create(const AInitialCapacity: Integer = 64);
+
+    function Push(const APrototype: TSouffleFunctionPrototype;
+      const AClosure: TSouffleClosure;
+      const ABaseRegister: Integer;
+      const AReturnRegister: Integer;
+      const AHandlerDepth: Integer): PSouffleVMCallFrame;
+    procedure Pop;
+    function Peek: PSouffleVMCallFrame; inline;
+    function IsEmpty: Boolean; inline;
+
+    property Count: Integer read FCount;
+  end;
+
+implementation
+
+{ TSouffleCallStack }
+
+constructor TSouffleCallStack.Create(const AInitialCapacity: Integer);
+begin
+  inherited Create;
+  FCapacity := AInitialCapacity;
+  SetLength(FFrames, FCapacity);
+  FCount := 0;
+end;
+
+function TSouffleCallStack.Push(const APrototype: TSouffleFunctionPrototype;
+  const AClosure: TSouffleClosure;
+  const ABaseRegister: Integer;
+  const AReturnRegister: Integer;
+  const AHandlerDepth: Integer): PSouffleVMCallFrame;
+begin
+  if FCount >= FCapacity then
+  begin
+    FCapacity := FCapacity * 2;
+    SetLength(FFrames, FCapacity);
+  end;
+  FFrames[FCount].Prototype := APrototype;
+  FFrames[FCount].Closure := AClosure;
+  FFrames[FCount].IP := 0;
+  FFrames[FCount].BaseRegister := ABaseRegister;
+  FFrames[FCount].ReturnRegister := AReturnRegister;
+  FFrames[FCount].HandlerDepth := AHandlerDepth;
+  Result := @FFrames[FCount];
+  Inc(FCount);
+end;
+
+procedure TSouffleCallStack.Pop;
+begin
+  if FCount > 0 then
+    Dec(FCount);
+end;
+
+function TSouffleCallStack.Peek: PSouffleVMCallFrame;
+begin
+  Result := @FFrames[FCount - 1];
+end;
+
+function TSouffleCallStack.IsEmpty: Boolean;
+begin
+  Result := FCount = 0;
+end;
+
+end.

--- a/souffle/Souffle.VM.CallFrame.pas
+++ b/souffle/Souffle.VM.CallFrame.pas
@@ -35,6 +35,7 @@ type
       const AHandlerDepth: Integer): PSouffleVMCallFrame;
     procedure Pop;
     function Peek: PSouffleVMCallFrame; inline;
+    function GetFrame(const AIndex: Integer): PSouffleVMCallFrame; inline;
     function IsEmpty: Boolean; inline;
 
     property Count: Integer read FCount;
@@ -87,6 +88,11 @@ begin
   if FCount = 0 then
     Exit(nil);
   Result := @FFrames[FCount - 1];
+end;
+
+function TSouffleCallStack.GetFrame(const AIndex: Integer): PSouffleVMCallFrame;
+begin
+  Result := @FFrames[AIndex];
 end;
 
 function TSouffleCallStack.IsEmpty: Boolean;

--- a/souffle/Souffle.VM.Closure.pas
+++ b/souffle/Souffle.VM.Closure.pas
@@ -1,0 +1,69 @@
+unit Souffle.VM.Closure;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Souffle.Bytecode.Chunk,
+  Souffle.Heap,
+  Souffle.VM.Upvalue;
+
+type
+  TSouffleClosure = class(TSouffleHeapObject)
+  private
+    FPrototype: TSouffleFunctionPrototype;
+    FUpvalues: array of TSouffleUpvalue;
+    FUpvalueCount: Integer;
+  public
+    constructor Create(const APrototype: TSouffleFunctionPrototype);
+
+    function GetUpvalue(const AIndex: Integer): TSouffleUpvalue; inline;
+    procedure SetUpvalue(const AIndex: Integer; const AUpvalue: TSouffleUpvalue); inline;
+
+    procedure MarkReferences; override;
+    function DebugString: string; override;
+
+    property Prototype: TSouffleFunctionPrototype read FPrototype;
+    property UpvalueCount: Integer read FUpvalueCount;
+  end;
+
+implementation
+
+{ TSouffleClosure }
+
+constructor TSouffleClosure.Create(const APrototype: TSouffleFunctionPrototype);
+begin
+  inherited Create(SOUFFLE_HEAP_CLOSURE);
+  FPrototype := APrototype;
+  FUpvalueCount := APrototype.UpvalueCount;
+  SetLength(FUpvalues, FUpvalueCount);
+end;
+
+function TSouffleClosure.GetUpvalue(const AIndex: Integer): TSouffleUpvalue;
+begin
+  Result := FUpvalues[AIndex];
+end;
+
+procedure TSouffleClosure.SetUpvalue(const AIndex: Integer;
+  const AUpvalue: TSouffleUpvalue);
+begin
+  FUpvalues[AIndex] := AUpvalue;
+end;
+
+procedure TSouffleClosure.MarkReferences;
+var
+  I: Integer;
+begin
+  inherited;
+  for I := 0 to FUpvalueCount - 1 do
+    if Assigned(FUpvalues[I]) then
+      FUpvalues[I].MarkReferences;
+end;
+
+function TSouffleClosure.DebugString: string;
+begin
+  Result := '<closure:' + FPrototype.Name + '>';
+end;
+
+end.

--- a/souffle/Souffle.VM.Exception.pas
+++ b/souffle/Souffle.VM.Exception.pas
@@ -51,7 +51,10 @@ implementation
 constructor TSouffleHandlerStack.Create(const AInitialCapacity: Integer);
 begin
   inherited Create;
-  FCapacity := AInitialCapacity;
+  if AInitialCapacity < 1 then
+    FCapacity := 1
+  else
+    FCapacity := AInitialCapacity;
   SetLength(FEntries, FCapacity);
   FCount := 0;
 end;
@@ -62,7 +65,10 @@ procedure TSouffleHandlerStack.Push(const ACatchIP, AFinallyIP: Integer;
 begin
   if FCount >= FCapacity then
   begin
-    FCapacity := FCapacity * 2;
+    if FCapacity < 1 then
+      FCapacity := 1
+    else
+      FCapacity := FCapacity * 2;
     SetLength(FEntries, FCapacity);
   end;
   FEntries[FCount].CatchIP := ACatchIP;
@@ -81,6 +87,11 @@ end;
 
 function TSouffleHandlerStack.Peek: TSouffleHandlerEntry;
 begin
+  {$IFDEF DEBUG}
+  Assert(FCount > 0, 'TSouffleHandlerStack.Peek called on empty stack');
+  {$ENDIF}
+  if FCount = 0 then
+    raise Exception.Create('TSouffleHandlerStack.Peek: stack is empty');
   Result := FEntries[FCount - 1];
 end;
 

--- a/souffle/Souffle.VM.Exception.pas
+++ b/souffle/Souffle.VM.Exception.pas
@@ -1,0 +1,100 @@
+unit Souffle.VM.Exception;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  SysUtils,
+
+  Souffle.Value;
+
+type
+  TSouffleHandlerEntry = record
+    CatchIP: Integer;
+    FinallyIP: Integer;
+    CatchRegister: UInt8;
+    FrameIndex: Integer;
+    BaseRegister: Integer;
+  end;
+
+  TSouffleHandlerStack = class
+  private
+    FEntries: array of TSouffleHandlerEntry;
+    FCount: Integer;
+    FCapacity: Integer;
+  public
+    constructor Create(const AInitialCapacity: Integer = 16);
+
+    procedure Push(const ACatchIP, AFinallyIP: Integer;
+      const ACatchRegister: UInt8;
+      const AFrameIndex, ABaseRegister: Integer);
+    procedure Pop;
+    function Peek: TSouffleHandlerEntry; inline;
+    function IsEmpty: Boolean; inline;
+
+    property Count: Integer read FCount;
+  end;
+
+  ESouffleThrow = class(Exception)
+  private
+    FThrownValue: TSouffleValue;
+  public
+    constructor Create(const AValue: TSouffleValue);
+    property ThrownValue: TSouffleValue read FThrownValue;
+  end;
+
+implementation
+
+{ TSouffleHandlerStack }
+
+constructor TSouffleHandlerStack.Create(const AInitialCapacity: Integer);
+begin
+  inherited Create;
+  FCapacity := AInitialCapacity;
+  SetLength(FEntries, FCapacity);
+  FCount := 0;
+end;
+
+procedure TSouffleHandlerStack.Push(const ACatchIP, AFinallyIP: Integer;
+  const ACatchRegister: UInt8;
+  const AFrameIndex, ABaseRegister: Integer);
+begin
+  if FCount >= FCapacity then
+  begin
+    FCapacity := FCapacity * 2;
+    SetLength(FEntries, FCapacity);
+  end;
+  FEntries[FCount].CatchIP := ACatchIP;
+  FEntries[FCount].FinallyIP := AFinallyIP;
+  FEntries[FCount].CatchRegister := ACatchRegister;
+  FEntries[FCount].FrameIndex := AFrameIndex;
+  FEntries[FCount].BaseRegister := ABaseRegister;
+  Inc(FCount);
+end;
+
+procedure TSouffleHandlerStack.Pop;
+begin
+  if FCount > 0 then
+    Dec(FCount);
+end;
+
+function TSouffleHandlerStack.Peek: TSouffleHandlerEntry;
+begin
+  Result := FEntries[FCount - 1];
+end;
+
+function TSouffleHandlerStack.IsEmpty: Boolean;
+begin
+  Result := FCount = 0;
+end;
+
+{ ESouffleThrow }
+
+constructor ESouffleThrow.Create(const AValue: TSouffleValue);
+begin
+  inherited Create('Souffle throw');
+  FThrownValue := AValue;
+end;
+
+end.

--- a/souffle/Souffle.VM.RuntimeOperations.pas
+++ b/souffle/Souffle.VM.RuntimeOperations.pas
@@ -1,0 +1,93 @@
+unit Souffle.VM.RuntimeOperations;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Souffle.Value;
+
+type
+  TSouffleRuntimeOperations = class abstract
+  public
+    // Arithmetic
+    function Add(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function Subtract(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function Multiply(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function Divide(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function Modulo(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function Power(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function Negate(const A: TSouffleValue): TSouffleValue; virtual; abstract;
+
+    // Bitwise
+    function BitwiseAnd(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function BitwiseOr(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function BitwiseXor(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function ShiftLeft(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function ShiftRight(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function UnsignedShiftRight(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function BitwiseNot(const A: TSouffleValue): TSouffleValue; virtual; abstract;
+
+    // Comparison
+    function Equal(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function NotEqual(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function LessThan(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function GreaterThan(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function LessThanOrEqual(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function GreaterThanOrEqual(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+
+    // Logical / Type
+    function LogicalNot(const A: TSouffleValue): TSouffleValue; virtual; abstract;
+    function TypeOf(const A: TSouffleValue): TSouffleValue; virtual; abstract;
+    function IsInstance(const A, B: TSouffleValue): TSouffleValue; virtual; abstract;
+    function HasProperty(const AObject, AKey: TSouffleValue): TSouffleValue; virtual; abstract;
+    function ToBoolean(const A: TSouffleValue): TSouffleValue; virtual; abstract;
+
+    // Compound creation
+    function CreateCompound(const ATypeTag: UInt8): TSouffleValue; virtual; abstract;
+    procedure InitField(const ACompound: TSouffleValue; const AKey: string;
+      const AValue: TSouffleValue); virtual; abstract;
+    procedure InitIndex(const ACompound: TSouffleValue; const AIndex: TSouffleValue;
+      const AValue: TSouffleValue); virtual; abstract;
+
+    // Property access
+    function GetProperty(const AObject: TSouffleValue;
+      const AKey: string): TSouffleValue; virtual; abstract;
+    procedure SetProperty(const AObject: TSouffleValue; const AKey: string;
+      const AValue: TSouffleValue); virtual; abstract;
+    function GetIndex(const AObject, AKey: TSouffleValue): TSouffleValue; virtual; abstract;
+    procedure SetIndex(const AObject: TSouffleValue;
+      const AKey, AValue: TSouffleValue); virtual; abstract;
+    function DeleteProperty(const AObject: TSouffleValue;
+      const AKey: string): TSouffleValue; virtual; abstract;
+
+    // Invocation
+    function Invoke(const ACallee: TSouffleValue; const AArgs: PSouffleValue;
+      const AArgCount: Integer; const AReceiver: TSouffleValue): TSouffleValue; virtual; abstract;
+    function Construct(const AConstructor: TSouffleValue; const AArgs: PSouffleValue;
+      const AArgCount: Integer): TSouffleValue; virtual; abstract;
+
+    // Iteration
+    function GetIterator(const AIterable: TSouffleValue): TSouffleValue; virtual; abstract;
+    function IteratorNext(const AIterator: TSouffleValue;
+      out ADone: Boolean): TSouffleValue; virtual; abstract;
+    procedure SpreadInto(const ATarget, ASource: TSouffleValue); virtual; abstract;
+
+    // Modules
+    function ImportModule(const APath: string): TSouffleValue; virtual; abstract;
+    procedure ExportBinding(const AValue: TSouffleValue;
+      const AName: string); virtual; abstract;
+
+    // Async
+    function AwaitValue(const AValue: TSouffleValue): TSouffleValue; virtual; abstract;
+
+    // Globals
+    function GetGlobal(const AName: string): TSouffleValue; virtual; abstract;
+    procedure SetGlobal(const AName: string;
+      const AValue: TSouffleValue); virtual; abstract;
+
+  end;
+
+implementation
+
+end.

--- a/souffle/Souffle.VM.Upvalue.pas
+++ b/souffle/Souffle.VM.Upvalue.pas
@@ -1,0 +1,71 @@
+unit Souffle.VM.Upvalue;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Souffle.Heap,
+  Souffle.Value;
+
+type
+  TSouffleUpvalue = class(TSouffleHeapObject)
+  private
+    FIsOpen: Boolean;
+    FRegisterIndex: Integer;
+    FClosed: TSouffleValue;
+    FNext: TSouffleUpvalue;
+  public
+    constructor Create(const ARegisterIndex: Integer);
+
+    procedure Close(const AValue: TSouffleValue);
+    procedure MarkReferences; override;
+    function DebugString: string; override;
+
+    property IsOpen: Boolean read FIsOpen;
+    property RegisterIndex: Integer read FRegisterIndex;
+    property Closed: TSouffleValue read FClosed write FClosed;
+    property Next: TSouffleUpvalue read FNext write FNext;
+  end;
+
+implementation
+
+uses
+  SysUtils;
+
+{ TSouffleUpvalue }
+
+constructor TSouffleUpvalue.Create(const ARegisterIndex: Integer);
+begin
+  inherited Create(SOUFFLE_HEAP_UPVALUE);
+  FIsOpen := True;
+  FRegisterIndex := ARegisterIndex;
+  FClosed := SouffleNil;
+  FNext := nil;
+end;
+
+procedure TSouffleUpvalue.Close(const AValue: TSouffleValue);
+begin
+  FClosed := AValue;
+  FIsOpen := False;
+end;
+
+procedure TSouffleUpvalue.MarkReferences;
+begin
+  inherited;
+  if not FIsOpen and SouffleIsReference(FClosed) and
+     Assigned(FClosed.AsReference) then
+    FClosed.AsReference.MarkReferences;
+  if Assigned(FNext) then
+    FNext.MarkReferences;
+end;
+
+function TSouffleUpvalue.DebugString: string;
+begin
+  if FIsOpen then
+    Result := '<upvalue:open:R[' + IntToStr(FRegisterIndex) + ']>'
+  else
+    Result := '<upvalue:closed:' + SouffleValueToString(FClosed) + '>';
+end;
+
+end.

--- a/souffle/Souffle.VM.pas
+++ b/souffle/Souffle.VM.pas
@@ -1,0 +1,801 @@
+unit Souffle.VM;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Souffle.Bytecode,
+  Souffle.Bytecode.Chunk,
+  Souffle.Bytecode.Module,
+  Souffle.GarbageCollector,
+  Souffle.Heap,
+  Souffle.Value,
+  Souffle.VM.CallFrame,
+  Souffle.VM.Closure,
+  Souffle.VM.Exception,
+  Souffle.VM.RuntimeOperations,
+  Souffle.VM.Upvalue;
+
+type
+  TSouffleVM = class
+  private const
+    MAX_REGISTERS  = 65536;
+    INITIAL_FRAMES = 64;
+  private
+    FRegisters: array of TSouffleValue;
+    FCallStack: TSouffleCallStack;
+    FHandlerStack: TSouffleHandlerStack;
+    FOpenUpvalues: TSouffleUpvalue;
+    FRuntimeOps: TSouffleRuntimeOperations;
+    FGC: TSouffleGarbageCollector;
+    FBaseFrameCount: Integer;
+
+    function CaptureUpvalue(const ARegisterIndex: Integer): TSouffleUpvalue;
+    procedure CloseUpvalues(const ALastRegister: Integer);
+    procedure MarkVMRoots;
+    procedure CallClosure(const AClosure: TSouffleClosure;
+      const AArgBase, AArgCount, AReturnAbsolute: Integer;
+      const AReceiver: TSouffleValue);
+
+    procedure ExecuteLoop;
+    procedure ExecuteTier1(const AFrame: PSouffleVMCallFrame;
+      const AInstruction: UInt32; const AOp: UInt8);
+    procedure ExecuteTier2(const AFrame: PSouffleVMCallFrame;
+      const AInstruction: UInt32; const AOp: UInt8);
+
+    function MaterializeConstant(
+      const AConstant: TSouffleBytecodeConstant): TSouffleValue;
+  public
+    constructor Create(const ARuntimeOps: TSouffleRuntimeOperations);
+    destructor Destroy; override;
+
+    function Execute(const AModule: TSouffleBytecodeModule): TSouffleValue;
+    function ExecuteFunction(const AClosure: TSouffleClosure;
+      const AArgs: array of TSouffleValue): TSouffleValue;
+  end;
+
+implementation
+
+uses
+  SysUtils;
+
+{ TSouffleVM }
+
+constructor TSouffleVM.Create(const ARuntimeOps: TSouffleRuntimeOperations);
+begin
+  inherited Create;
+  SetLength(FRegisters, MAX_REGISTERS);
+  FCallStack := TSouffleCallStack.Create(INITIAL_FRAMES);
+  FHandlerStack := TSouffleHandlerStack.Create;
+  FOpenUpvalues := nil;
+  FRuntimeOps := ARuntimeOps;
+
+  FGC := TSouffleGarbageCollector.Instance;
+  if Assigned(FGC) then
+    FGC.SetExternalRootMarker(MarkVMRoots);
+end;
+
+destructor TSouffleVM.Destroy;
+begin
+  FCallStack.Free;
+  FHandlerStack.Free;
+  inherited;
+end;
+
+function TSouffleVM.Execute(const AModule: TSouffleBytecodeModule): TSouffleValue;
+var
+  TopClosure: TSouffleClosure;
+begin
+  if not Assigned(AModule.TopLevel) then
+    Exit(SouffleNil);
+
+  TopClosure := TSouffleClosure.Create(AModule.TopLevel);
+  if Assigned(FGC) then
+    FGC.AllocateObject(TopClosure);
+
+  Result := ExecuteFunction(TopClosure, []);
+end;
+
+function TSouffleVM.ExecuteFunction(const AClosure: TSouffleClosure;
+  const AArgs: array of TSouffleValue): TSouffleValue;
+var
+  Frame: PSouffleVMCallFrame;
+  I, Base, SavedBaseFrameCount: Integer;
+begin
+  Base := 0;
+  if not FCallStack.IsEmpty then
+    Base := FCallStack.Peek^.BaseRegister + FCallStack.Peek^.Prototype.MaxRegisters;
+
+  Frame := FCallStack.Push(AClosure.Prototype, AClosure, Base, Base, FHandlerStack.Count);
+
+  for I := 0 to High(AArgs) do
+    FRegisters[Base + I] := AArgs[I];
+  for I := Length(AArgs) to AClosure.Prototype.MaxRegisters - 1 do
+    FRegisters[Base + I] := SouffleNil;
+
+  SavedBaseFrameCount := FBaseFrameCount;
+  FBaseFrameCount := FCallStack.Count;
+
+  try
+    ExecuteLoop;
+  except
+    on E: ESouffleThrow do
+    begin
+      while FCallStack.Count >= FBaseFrameCount do
+        FCallStack.Pop;
+      FBaseFrameCount := SavedBaseFrameCount;
+      Result := SouffleNil;
+      Exit;
+    end;
+  end;
+
+  FBaseFrameCount := SavedBaseFrameCount;
+  Result := FRegisters[Base];
+end;
+
+procedure TSouffleVM.ExecuteLoop;
+var
+  Frame: PSouffleVMCallFrame;
+  Instruction: UInt32;
+  Op: UInt8;
+begin
+  while FCallStack.Count >= FBaseFrameCount do
+  begin
+    Frame := FCallStack.Peek;
+
+    if Frame^.IP >= Frame^.Prototype.CodeCount then
+    begin
+      CloseUpvalues(Frame^.BaseRegister);
+      FRegisters[Frame^.ReturnRegister] := SouffleNil;
+      FCallStack.Pop;
+      Continue;
+    end;
+
+    Instruction := Frame^.Prototype.GetInstruction(Frame^.IP);
+    Inc(Frame^.IP);
+    Op := DecodeOp(Instruction);
+
+    if Op < OP_RT_FIRST then
+      ExecuteTier1(Frame, Instruction, Op)
+    else
+      ExecuteTier2(Frame, Instruction, Op);
+  end;
+end;
+
+procedure TSouffleVM.CallClosure(const AClosure: TSouffleClosure;
+  const AArgBase, AArgCount, AReturnAbsolute: Integer;
+  const AReceiver: TSouffleValue);
+var
+  NewBase, I: Integer;
+  Frame: PSouffleVMCallFrame;
+begin
+  NewBase := FCallStack.Peek^.BaseRegister + FCallStack.Peek^.Prototype.MaxRegisters;
+  if NewBase + AClosure.Prototype.MaxRegisters > MAX_REGISTERS then
+    raise Exception.Create('Stack overflow');
+
+  for I := 0 to AArgCount - 1 do
+    FRegisters[NewBase + I] := FRegisters[AArgBase + I];
+  for I := AArgCount to AClosure.Prototype.MaxRegisters - 1 do
+    FRegisters[NewBase + I] := SouffleNil;
+
+  Frame := FCallStack.Push(AClosure.Prototype, AClosure, NewBase,
+    AReturnAbsolute, FHandlerStack.Count);
+end;
+
+procedure TSouffleVM.ExecuteTier1(const AFrame: PSouffleVMCallFrame;
+  const AInstruction: UInt32; const AOp: UInt8);
+var
+  A, B: UInt8;
+  Bx: UInt16;
+  sBx: Int16;
+  Ax: Int32;
+  Base: Integer;
+  Closure: TSouffleClosure;
+  Upval: TSouffleUpvalue;
+  Proto: TSouffleFunctionPrototype;
+  Desc: TSouffleUpvalueDescriptor;
+  I: Integer;
+  Handler: TSouffleHandlerEntry;
+begin
+  Base := AFrame^.BaseRegister;
+
+  case TSouffleOpCode(AOp) of
+    OP_LOAD_CONST:
+    begin
+      A := DecodeA(AInstruction);
+      Bx := DecodeBx(AInstruction);
+      FRegisters[Base + A] := MaterializeConstant(
+        AFrame^.Prototype.GetConstant(Bx));
+    end;
+
+    OP_LOAD_NIL:
+    begin
+      A := DecodeA(AInstruction);
+      FRegisters[Base + A] := SouffleNil;
+    end;
+
+    OP_LOAD_TRUE:
+    begin
+      A := DecodeA(AInstruction);
+      FRegisters[Base + A] := SouffleBoolean(True);
+    end;
+
+    OP_LOAD_FALSE:
+    begin
+      A := DecodeA(AInstruction);
+      FRegisters[Base + A] := SouffleBoolean(False);
+    end;
+
+    OP_LOAD_INT:
+    begin
+      A := DecodeA(AInstruction);
+      sBx := DecodesBx(AInstruction);
+      FRegisters[Base + A] := SouffleInteger(sBx);
+    end;
+
+    OP_MOVE:
+    begin
+      A := DecodeA(AInstruction);
+      B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRegisters[Base + B];
+    end;
+
+    OP_GET_LOCAL:
+    begin
+      A := DecodeA(AInstruction);
+      Bx := DecodeBx(AInstruction);
+      FRegisters[Base + A] := FRegisters[Base + Bx];
+    end;
+
+    OP_SET_LOCAL:
+    begin
+      A := DecodeA(AInstruction);
+      Bx := DecodeBx(AInstruction);
+      FRegisters[Base + Bx] := FRegisters[Base + A];
+    end;
+
+    OP_GET_UPVALUE:
+    begin
+      A := DecodeA(AInstruction);
+      Bx := DecodeBx(AInstruction);
+      if Assigned(AFrame^.Closure) then
+      begin
+        Upval := AFrame^.Closure.GetUpvalue(Bx);
+        if Assigned(Upval) then
+        begin
+          if Upval.IsOpen then
+            FRegisters[Base + A] := FRegisters[Upval.RegisterIndex]
+          else
+            FRegisters[Base + A] := Upval.Closed;
+        end
+        else
+          FRegisters[Base + A] := SouffleNil;
+      end
+      else
+        FRegisters[Base + A] := SouffleNil;
+    end;
+
+    OP_SET_UPVALUE:
+    begin
+      A := DecodeA(AInstruction);
+      Bx := DecodeBx(AInstruction);
+      if Assigned(AFrame^.Closure) then
+      begin
+        Upval := AFrame^.Closure.GetUpvalue(Bx);
+        if Assigned(Upval) then
+        begin
+          if Upval.IsOpen then
+            FRegisters[Upval.RegisterIndex] := FRegisters[Base + A]
+          else
+            Upval.Closed := FRegisters[Base + A];
+        end;
+      end;
+    end;
+
+    OP_CLOSE_UPVALUE:
+    begin
+      A := DecodeA(AInstruction);
+      CloseUpvalues(Base + A);
+    end;
+
+    OP_JUMP:
+    begin
+      Ax := DecodeAx(AInstruction);
+      AFrame^.IP := AFrame^.IP + Ax;
+      if Assigned(FGC) and (Ax < 0) then
+        FGC.CollectIfNeeded;
+    end;
+
+    OP_JUMP_IF_TRUE:
+    begin
+      A := DecodeA(AInstruction);
+      sBx := DecodesBx(AInstruction);
+      if SouffleIsTrue(FRegisters[Base + A]) then
+        AFrame^.IP := AFrame^.IP + sBx;
+    end;
+
+    OP_JUMP_IF_FALSE:
+    begin
+      A := DecodeA(AInstruction);
+      sBx := DecodesBx(AInstruction);
+      if not SouffleIsTrue(FRegisters[Base + A]) then
+        AFrame^.IP := AFrame^.IP + sBx;
+    end;
+
+    OP_JUMP_IF_NIL:
+    begin
+      A := DecodeA(AInstruction);
+      sBx := DecodesBx(AInstruction);
+      if SouffleIsNil(FRegisters[Base + A]) then
+        AFrame^.IP := AFrame^.IP + sBx;
+    end;
+
+    OP_JUMP_IF_NOT_NIL:
+    begin
+      A := DecodeA(AInstruction);
+      sBx := DecodesBx(AInstruction);
+      if not SouffleIsNil(FRegisters[Base + A]) then
+        AFrame^.IP := AFrame^.IP + sBx;
+    end;
+
+    OP_CLOSURE:
+    begin
+      A := DecodeA(AInstruction);
+      Bx := DecodeBx(AInstruction);
+      Proto := AFrame^.Prototype.GetFunction(Bx);
+      Closure := TSouffleClosure.Create(Proto);
+      if Assigned(FGC) then
+        FGC.AllocateObject(Closure);
+
+      for I := 0 to Proto.UpvalueCount - 1 do
+      begin
+        Desc := Proto.GetUpvalueDescriptor(I);
+        if Desc.IsLocal then
+          Upval := CaptureUpvalue(Base + Desc.Index)
+        else if Assigned(AFrame^.Closure) then
+          Upval := AFrame^.Closure.GetUpvalue(Desc.Index)
+        else
+          Upval := nil;
+        Closure.SetUpvalue(I, Upval);
+      end;
+
+      FRegisters[Base + A] := SouffleReference(Closure);
+    end;
+
+    OP_PUSH_HANDLER:
+    begin
+      A := DecodeA(AInstruction);
+      Bx := DecodeBx(AInstruction);
+      FHandlerStack.Push(
+        AFrame^.IP + Bx,
+        -1,
+        A,
+        FCallStack.Count - 1,
+        Base);
+    end;
+
+    OP_POP_HANDLER:
+    begin
+      if not FHandlerStack.IsEmpty then
+        FHandlerStack.Pop;
+    end;
+
+    OP_THROW:
+    begin
+      A := DecodeA(AInstruction);
+      if FHandlerStack.IsEmpty then
+        raise ESouffleThrow.Create(FRegisters[Base + A]);
+
+      Handler := FHandlerStack.Peek;
+      FHandlerStack.Pop;
+
+      while FCallStack.Count - 1 > Handler.FrameIndex do
+        FCallStack.Pop;
+
+      AFrame^.IP := Handler.CatchIP;
+      FRegisters[Handler.BaseRegister + Handler.CatchRegister] :=
+        FRegisters[Base + A];
+    end;
+
+    OP_RETURN:
+    begin
+      A := DecodeA(AInstruction);
+      CloseUpvalues(Base);
+      FRegisters[AFrame^.ReturnRegister] := FRegisters[Base + A];
+      FCallStack.Pop;
+    end;
+
+    OP_RETURN_NIL:
+    begin
+      CloseUpvalues(Base);
+      FRegisters[AFrame^.ReturnRegister] := SouffleNil;
+      FCallStack.Pop;
+    end;
+
+    OP_NOP:;
+
+    OP_LINE:;
+  end;
+end;
+
+procedure TSouffleVM.ExecuteTier2(const AFrame: PSouffleVMCallFrame;
+  const AInstruction: UInt32; const AOp: UInt8);
+var
+  A, B, C: UInt8;
+  Bx: UInt16;
+  Base: Integer;
+  Done: Boolean;
+begin
+  Base := AFrame^.BaseRegister;
+
+  case TSouffleOpCode(AOp) of
+    // Arithmetic
+    OP_RT_ADD:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Add(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_SUB:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Subtract(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_MUL:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Multiply(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_DIV:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Divide(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_MOD:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Modulo(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_POW:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Power(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_NEG:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Negate(FRegisters[Base + B]);
+    end;
+
+    // Bitwise
+    OP_RT_BAND:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.BitwiseAnd(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_BOR:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.BitwiseOr(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_BXOR:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.BitwiseXor(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_SHL:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.ShiftLeft(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_SHR:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.ShiftRight(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_USHR:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.UnsignedShiftRight(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_BNOT:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.BitwiseNot(FRegisters[Base + B]);
+    end;
+
+    // Comparison
+    OP_RT_EQ:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Equal(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_NEQ:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.NotEqual(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_LT:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.LessThan(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_GT:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.GreaterThan(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_LTE:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.LessThanOrEqual(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_GTE:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.GreaterThanOrEqual(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+
+    // Logical / Type
+    OP_RT_NOT:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.LogicalNot(FRegisters[Base + B]);
+    end;
+    OP_RT_TYPEOF:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.TypeOf(FRegisters[Base + B]);
+    end;
+    OP_RT_IS_INSTANCE:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.IsInstance(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_HAS_PROPERTY:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.HasProperty(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_TO_BOOLEAN:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.ToBoolean(FRegisters[Base + B]);
+    end;
+
+    // Compound creation
+    OP_RT_NEW_COMPOUND:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.CreateCompound(B);
+    end;
+    OP_RT_INIT_FIELD:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRuntimeOps.InitField(FRegisters[Base + A],
+        AFrame^.Prototype.GetConstant(B).StringValue,
+        FRegisters[Base + C]);
+    end;
+    OP_RT_INIT_INDEX:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRuntimeOps.InitIndex(FRegisters[Base + A],
+        FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+
+    // Property access
+    OP_RT_GET_PROP:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.GetProperty(FRegisters[Base + B],
+        AFrame^.Prototype.GetConstant(C).StringValue);
+    end;
+    OP_RT_SET_PROP:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRuntimeOps.SetProperty(FRegisters[Base + A],
+        AFrame^.Prototype.GetConstant(B).StringValue,
+        FRegisters[Base + C]);
+    end;
+    OP_RT_GET_INDEX:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.GetIndex(FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_SET_INDEX:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRuntimeOps.SetIndex(FRegisters[Base + A], FRegisters[Base + B], FRegisters[Base + C]);
+    end;
+    OP_RT_DEL_PROP:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.DeleteProperty(FRegisters[Base + B],
+        AFrame^.Prototype.GetConstant(C).StringValue);
+    end;
+
+    // Invocation
+    OP_RT_CALL:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      if SouffleIsReference(FRegisters[Base + A]) and
+         (FRegisters[Base + A].AsReference is TSouffleClosure) then
+        CallClosure(TSouffleClosure(FRegisters[Base + A].AsReference),
+          Base + A + 1, B, Base + A, SouffleNil)
+      else
+      begin
+        FRegisters[Base + A] := FRuntimeOps.Invoke(
+          FRegisters[Base + A],
+          @FRegisters[Base + A + 1],
+          B,
+          SouffleNil);
+      end;
+      if Assigned(FGC) then
+        FGC.CollectIfNeeded;
+    end;
+    OP_RT_CALL_METHOD:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      if SouffleIsReference(FRegisters[Base + A]) and
+         (FRegisters[Base + A].AsReference is TSouffleClosure) then
+        CallClosure(TSouffleClosure(FRegisters[Base + A].AsReference),
+          Base + A + 1, B, Base + A, FRegisters[Base + A - 1])
+      else
+      begin
+        FRegisters[Base + A] := FRuntimeOps.Invoke(
+          FRegisters[Base + A],
+          @FRegisters[Base + A + 1],
+          B,
+          FRegisters[Base + A - 1]);
+      end;
+      if Assigned(FGC) then
+        FGC.CollectIfNeeded;
+    end;
+    OP_RT_CONSTRUCT:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.Construct(
+        FRegisters[Base + B],
+        @FRegisters[Base + B + 1],
+        C);
+      if Assigned(FGC) then
+        FGC.CollectIfNeeded;
+    end;
+
+    // Iteration
+    OP_RT_GET_ITER:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.GetIterator(FRegisters[Base + B]);
+    end;
+    OP_RT_ITER_NEXT:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction); C := DecodeC(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.IteratorNext(FRegisters[Base + C], Done);
+      FRegisters[Base + B] := SouffleBoolean(Done);
+    end;
+    OP_RT_SPREAD:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRuntimeOps.SpreadInto(FRegisters[Base + A], FRegisters[Base + B]);
+    end;
+
+    // Modules
+    OP_RT_IMPORT:
+    begin
+      A := DecodeA(AInstruction); Bx := DecodeBx(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.ImportModule(
+        AFrame^.Prototype.GetConstant(Bx).StringValue);
+    end;
+    OP_RT_EXPORT:
+    begin
+      A := DecodeA(AInstruction); Bx := DecodeBx(AInstruction);
+      FRuntimeOps.ExportBinding(FRegisters[Base + A],
+        AFrame^.Prototype.GetConstant(Bx).StringValue);
+    end;
+
+    // Async
+    OP_RT_AWAIT:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.AwaitValue(FRegisters[Base + B]);
+    end;
+
+    // Globals
+    OP_RT_GET_GLOBAL:
+    begin
+      A := DecodeA(AInstruction); Bx := DecodeBx(AInstruction);
+      FRegisters[Base + A] := FRuntimeOps.GetGlobal(
+        AFrame^.Prototype.GetConstant(Bx).StringValue);
+    end;
+    OP_RT_SET_GLOBAL:
+    begin
+      A := DecodeA(AInstruction); Bx := DecodeBx(AInstruction);
+      FRuntimeOps.SetGlobal(
+        AFrame^.Prototype.GetConstant(Bx).StringValue,
+        FRegisters[Base + A]);
+    end;
+
+  end;
+end;
+
+function TSouffleVM.CaptureUpvalue(const ARegisterIndex: Integer): TSouffleUpvalue;
+var
+  Current, Prev: TSouffleUpvalue;
+begin
+  Prev := nil;
+  Current := FOpenUpvalues;
+
+  while Assigned(Current) and (Current.RegisterIndex > ARegisterIndex) do
+  begin
+    Prev := Current;
+    Current := Current.Next;
+  end;
+
+  if Assigned(Current) and (Current.RegisterIndex = ARegisterIndex) then
+    Exit(Current);
+
+  Result := TSouffleUpvalue.Create(ARegisterIndex);
+  if Assigned(FGC) then
+    FGC.AllocateObject(Result);
+  Result.Next := Current;
+
+  if Assigned(Prev) then
+    Prev.Next := Result
+  else
+    FOpenUpvalues := Result;
+end;
+
+procedure TSouffleVM.CloseUpvalues(const ALastRegister: Integer);
+var
+  Upval: TSouffleUpvalue;
+begin
+  while Assigned(FOpenUpvalues) and (FOpenUpvalues.RegisterIndex >= ALastRegister) do
+  begin
+    Upval := FOpenUpvalues;
+    Upval.Close(FRegisters[Upval.RegisterIndex]);
+    FOpenUpvalues := Upval.Next;
+  end;
+end;
+
+procedure TSouffleVM.MarkVMRoots;
+var
+  I: Integer;
+  HighWater: Integer;
+begin
+  if FCallStack.IsEmpty then
+    Exit;
+
+  HighWater := FCallStack.Peek^.BaseRegister + FCallStack.Peek^.Prototype.MaxRegisters;
+  for I := 0 to HighWater - 1 do
+    if SouffleIsReference(FRegisters[I]) and Assigned(FRegisters[I].AsReference) then
+      FRegisters[I].AsReference.MarkReferences;
+
+  if Assigned(FOpenUpvalues) then
+    FOpenUpvalues.MarkReferences;
+end;
+
+function TSouffleVM.MaterializeConstant(
+  const AConstant: TSouffleBytecodeConstant): TSouffleValue;
+var
+  Str: TSouffleString;
+begin
+  case AConstant.Kind of
+    bckNil:     Result := SouffleNil;
+    bckTrue:    Result := SouffleBoolean(True);
+    bckFalse:   Result := SouffleBoolean(False);
+    bckInteger: Result := SouffleInteger(AConstant.IntValue);
+    bckFloat:   Result := SouffleFloat(AConstant.FloatValue);
+    bckString:
+    begin
+      Str := TSouffleString.Create(AConstant.StringValue);
+      if Assigned(FGC) then
+        FGC.AllocateObject(Str);
+      Result := SouffleReference(Str);
+    end;
+  else
+    Result := SouffleNil;
+  end;
+end;
+
+end.

--- a/souffle/Souffle.Value.pas
+++ b/souffle/Souffle.Value.pas
@@ -1,0 +1,212 @@
+unit Souffle.Value;
+
+{$I Souffle.inc}
+
+interface
+
+uses
+  Souffle.Heap;
+
+type
+  TSouffleValueKind = (
+    svkNil,
+    svkBoolean,
+    svkInteger,
+    svkFloat,
+    svkReference
+  );
+
+  PSouffleValue = ^TSouffleValue;
+
+  TSouffleValue = record
+    Kind: TSouffleValueKind;
+    case TSouffleValueKind of
+      svkNil:       ();
+      svkBoolean:   (AsBoolean: Boolean);
+      svkInteger:   (AsInteger: Int64);
+      svkFloat:     (AsFloat: Double);
+      svkReference: (AsReference: TSouffleHeapObject);
+  end;
+
+  TSouffleValueArray = array of TSouffleValue;
+  PSouffleValueArray = ^TSouffleValueArray;
+
+function SouffleNil: TSouffleValue; inline;
+function SouffleBoolean(const AValue: Boolean): TSouffleValue; inline;
+function SouffleInteger(const AValue: Int64): TSouffleValue; inline;
+function SouffleFloat(const AValue: Double): TSouffleValue; inline;
+function SouffleReference(const AObject: TSouffleHeapObject): TSouffleValue; inline;
+
+function SouffleIsNil(const AValue: TSouffleValue): Boolean; inline;
+function SouffleIsBoolean(const AValue: TSouffleValue): Boolean; inline;
+function SouffleIsInteger(const AValue: TSouffleValue): Boolean; inline;
+function SouffleIsFloat(const AValue: TSouffleValue): Boolean; inline;
+function SouffleIsReference(const AValue: TSouffleValue): Boolean; inline;
+function SouffleIsNumeric(const AValue: TSouffleValue): Boolean; inline;
+
+function SouffleIsTrue(const AValue: TSouffleValue): Boolean; inline;
+function SouffleAsNumber(const AValue: TSouffleValue): Double; inline;
+
+function SouffleValuesEqual(const A, B: TSouffleValue): Boolean;
+function SouffleValueToString(const AValue: TSouffleValue): string;
+
+implementation
+
+uses
+  Math,
+  SysUtils;
+
+{ Value constructors }
+
+function SouffleNil: TSouffleValue;
+begin
+  Result.Kind := svkNil;
+  Result.AsInteger := 0;
+end;
+
+function SouffleBoolean(const AValue: Boolean): TSouffleValue;
+begin
+  Result.Kind := svkBoolean;
+  Result.AsInteger := 0;
+  Result.AsBoolean := AValue;
+end;
+
+function SouffleInteger(const AValue: Int64): TSouffleValue;
+begin
+  Result.Kind := svkInteger;
+  Result.AsInteger := AValue;
+end;
+
+function SouffleFloat(const AValue: Double): TSouffleValue;
+begin
+  Result.Kind := svkFloat;
+  Result.AsFloat := AValue;
+end;
+
+function SouffleReference(const AObject: TSouffleHeapObject): TSouffleValue;
+begin
+  Result.Kind := svkReference;
+  Result.AsReference := AObject;
+end;
+
+{ Type checks }
+
+function SouffleIsNil(const AValue: TSouffleValue): Boolean;
+begin
+  Result := AValue.Kind = svkNil;
+end;
+
+function SouffleIsBoolean(const AValue: TSouffleValue): Boolean;
+begin
+  Result := AValue.Kind = svkBoolean;
+end;
+
+function SouffleIsInteger(const AValue: TSouffleValue): Boolean;
+begin
+  Result := AValue.Kind = svkInteger;
+end;
+
+function SouffleIsFloat(const AValue: TSouffleValue): Boolean;
+begin
+  Result := AValue.Kind = svkFloat;
+end;
+
+function SouffleIsReference(const AValue: TSouffleValue): Boolean;
+begin
+  Result := AValue.Kind = svkReference;
+end;
+
+function SouffleIsNumeric(const AValue: TSouffleValue): Boolean;
+begin
+  Result := (AValue.Kind = svkInteger) or (AValue.Kind = svkFloat);
+end;
+
+{ Truthiness -- universal semantics used by JUMP_IF_TRUE/JUMP_IF_FALSE }
+
+function SouffleIsTrue(const AValue: TSouffleValue): Boolean;
+begin
+  case AValue.Kind of
+    svkNil:
+      Result := False;
+    svkBoolean:
+      Result := AValue.AsBoolean;
+    svkInteger:
+      Result := AValue.AsInteger <> 0;
+    svkFloat:
+      Result := (AValue.AsFloat <> 0.0) and not IsNaN(AValue.AsFloat);
+    svkReference:
+      Result := Assigned(AValue.AsReference);
+  else
+    Result := False;
+  end;
+end;
+
+{ Numeric coercion for VM-level arithmetic fast paths }
+
+function SouffleAsNumber(const AValue: TSouffleValue): Double;
+begin
+  case AValue.Kind of
+    svkInteger:
+      Result := AValue.AsInteger * 1.0;
+    svkFloat:
+      Result := AValue.AsFloat;
+  else
+    Result := NaN;
+  end;
+end;
+
+{ Identity equality for Tier 1 operations }
+
+function SouffleValuesEqual(const A, B: TSouffleValue): Boolean;
+begin
+  if A.Kind <> B.Kind then
+    Exit(False);
+
+  case A.Kind of
+    svkNil:
+      Result := True;
+    svkBoolean:
+      Result := A.AsBoolean = B.AsBoolean;
+    svkInteger:
+      Result := A.AsInteger = B.AsInteger;
+    svkFloat:
+      Result := A.AsFloat = B.AsFloat;
+    svkReference:
+      Result := A.AsReference = B.AsReference;
+  else
+    Result := False;
+  end;
+end;
+
+{ Debug string representation }
+
+function SouffleValueToString(const AValue: TSouffleValue): string;
+begin
+  case AValue.Kind of
+    svkNil:
+      Result := 'nil';
+    svkBoolean:
+      if AValue.AsBoolean then
+        Result := 'true'
+      else
+        Result := 'false';
+    svkInteger:
+      Result := IntToStr(AValue.AsInteger);
+    svkFloat:
+      Result := FloatToStr(AValue.AsFloat);
+    svkReference:
+      if Assigned(AValue.AsReference) then
+      begin
+        if AValue.AsReference is TSouffleString then
+          Result := TSouffleString(AValue.AsReference).Value
+        else
+          Result := AValue.AsReference.DebugString;
+      end
+      else
+        Result := 'nil';
+  else
+    Result := '<unknown>';
+  end;
+end;
+
+end.

--- a/souffle/Souffle.inc
+++ b/souffle/Souffle.inc
@@ -1,0 +1,15 @@
+{$mode delphi} {H+}
+{$IFDEF PRODUCTION}
+  {$overflowchecks off}
+  {$rangechecks off}
+  {$S-}
+  {$OBJECTCHECKS OFF}
+  {$C-}
+{$ELSE}
+  {$overflowchecks on}
+  {$rangechecks on}
+  {$S+}
+  {$OBJECTCHECKS ON}
+  {$C+}
+{$ENDIF}
+{$modeswitch advancedrecords}

--- a/units/Goccia.Compiler.Scope.pas
+++ b/units/Goccia.Compiler.Scope.pas
@@ -1,0 +1,203 @@
+unit Goccia.Compiler.Scope;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Generics.Collections;
+
+type
+  TGocciaCompilerVariableKind = (cvkLocal, cvkUpvalue, cvkGlobal);
+
+  TGocciaCompilerLocal = record
+    Name: string;
+    Slot: UInt8;
+    Depth: Integer;
+    IsCaptured: Boolean;
+    IsConst: Boolean;
+  end;
+
+  TGocciaCompilerUpvalue = record
+    Index: UInt8;
+    IsLocal: Boolean;
+  end;
+
+  TGocciaCompilerScope = class
+  private
+    FParent: TGocciaCompilerScope;
+    FLocals: array of TGocciaCompilerLocal;
+    FLocalCount: Integer;
+    FUpvalues: array of TGocciaCompilerUpvalue;
+    FUpvalueCount: Integer;
+    FDepth: Integer;
+    FNextSlot: UInt8;
+    FMaxSlot: UInt8;
+  public
+    constructor Create(const AParent: TGocciaCompilerScope;
+      const ADepth: Integer);
+
+    function DeclareLocal(const AName: string;
+      const AIsConst: Boolean): UInt8;
+    function ResolveLocal(const AName: string): Integer;
+    function ResolveUpvalue(const AName: string): Integer;
+    function AddUpvalue(const AIndex: UInt8;
+      const AIsLocal: Boolean): Integer;
+
+    function AllocateRegister: UInt8;
+    procedure FreeRegister;
+    procedure BeginScope;
+    procedure EndScope(out AClosedLocals: array of UInt8;
+      out AClosedCount: Integer);
+
+    property Parent: TGocciaCompilerScope read FParent;
+    property LocalCount: Integer read FLocalCount;
+    property UpvalueCount: Integer read FUpvalueCount;
+    property Depth: Integer read FDepth;
+    property MaxSlot: UInt8 read FMaxSlot;
+    property NextSlot: UInt8 read FNextSlot;
+
+    function GetLocal(const AIndex: Integer): TGocciaCompilerLocal;
+    function GetUpvalue(const AIndex: Integer): TGocciaCompilerUpvalue;
+    procedure MarkCaptured(const AIndex: Integer);
+  end;
+
+implementation
+
+{ TGocciaCompilerScope }
+
+constructor TGocciaCompilerScope.Create(const AParent: TGocciaCompilerScope;
+  const ADepth: Integer);
+begin
+  inherited Create;
+  FParent := AParent;
+  FLocalCount := 0;
+  FUpvalueCount := 0;
+  FDepth := ADepth;
+  FNextSlot := 0;
+  FMaxSlot := 0;
+end;
+
+function TGocciaCompilerScope.DeclareLocal(const AName: string;
+  const AIsConst: Boolean): UInt8;
+begin
+  if FLocalCount >= Length(FLocals) then
+    SetLength(FLocals, FLocalCount * 2 + 8);
+  FLocals[FLocalCount].Name := AName;
+  FLocals[FLocalCount].Slot := FNextSlot;
+  FLocals[FLocalCount].Depth := FDepth;
+  FLocals[FLocalCount].IsCaptured := False;
+  FLocals[FLocalCount].IsConst := AIsConst;
+  Result := FNextSlot;
+  Inc(FLocalCount);
+  Inc(FNextSlot);
+  if FNextSlot > FMaxSlot then
+    FMaxSlot := FNextSlot;
+end;
+
+function TGocciaCompilerScope.ResolveLocal(const AName: string): Integer;
+var
+  I: Integer;
+begin
+  for I := FLocalCount - 1 downto 0 do
+    if FLocals[I].Name = AName then
+      Exit(I);
+  Result := -1;
+end;
+
+function TGocciaCompilerScope.ResolveUpvalue(const AName: string): Integer;
+var
+  LocalIdx: Integer;
+  UpvalueIdx: Integer;
+begin
+  if not Assigned(FParent) then
+    Exit(-1);
+
+  LocalIdx := FParent.ResolveLocal(AName);
+  if LocalIdx >= 0 then
+  begin
+    FParent.MarkCaptured(LocalIdx);
+    Exit(AddUpvalue(FParent.FLocals[LocalIdx].Slot, True));
+  end;
+
+  UpvalueIdx := FParent.ResolveUpvalue(AName);
+  if UpvalueIdx >= 0 then
+    Exit(AddUpvalue(UInt8(UpvalueIdx), False));
+
+  Result := -1;
+end;
+
+function TGocciaCompilerScope.AddUpvalue(const AIndex: UInt8;
+  const AIsLocal: Boolean): Integer;
+var
+  I: Integer;
+begin
+  for I := 0 to FUpvalueCount - 1 do
+    if (FUpvalues[I].Index = AIndex) and (FUpvalues[I].IsLocal = AIsLocal) then
+      Exit(I);
+
+  if FUpvalueCount >= Length(FUpvalues) then
+    SetLength(FUpvalues, FUpvalueCount * 2 + 4);
+  FUpvalues[FUpvalueCount].Index := AIndex;
+  FUpvalues[FUpvalueCount].IsLocal := AIsLocal;
+  Result := FUpvalueCount;
+  Inc(FUpvalueCount);
+end;
+
+function TGocciaCompilerScope.AllocateRegister: UInt8;
+begin
+  Result := FNextSlot;
+  Inc(FNextSlot);
+  if FNextSlot > FMaxSlot then
+    FMaxSlot := FNextSlot;
+end;
+
+procedure TGocciaCompilerScope.FreeRegister;
+begin
+  if FNextSlot > 0 then
+    Dec(FNextSlot);
+end;
+
+procedure TGocciaCompilerScope.BeginScope;
+begin
+  Inc(FDepth);
+end;
+
+procedure TGocciaCompilerScope.EndScope(out AClosedLocals: array of UInt8;
+  out AClosedCount: Integer);
+begin
+  AClosedCount := 0;
+  while (FLocalCount > 0) and (FLocals[FLocalCount - 1].Depth = FDepth) do
+  begin
+    Dec(FLocalCount);
+    if FLocals[FLocalCount].IsCaptured then
+    begin
+      if AClosedCount < Length(AClosedLocals) then
+      begin
+        AClosedLocals[AClosedCount] := FLocals[FLocalCount].Slot;
+        Inc(AClosedCount);
+      end;
+    end;
+    Dec(FNextSlot);
+  end;
+  Dec(FDepth);
+end;
+
+function TGocciaCompilerScope.GetLocal(
+  const AIndex: Integer): TGocciaCompilerLocal;
+begin
+  Result := FLocals[AIndex];
+end;
+
+function TGocciaCompilerScope.GetUpvalue(
+  const AIndex: Integer): TGocciaCompilerUpvalue;
+begin
+  Result := FUpvalues[AIndex];
+end;
+
+procedure TGocciaCompilerScope.MarkCaptured(const AIndex: Integer);
+begin
+  FLocals[AIndex].IsCaptured := True;
+end;
+
+end.

--- a/units/Goccia.Compiler.Scope.pas
+++ b/units/Goccia.Compiler.Scope.pas
@@ -145,6 +145,8 @@ begin
     if (FUpvalues[I].Index = AIndex) and (FUpvalues[I].IsLocal = AIsLocal) then
       Exit(I);
 
+  if FUpvalueCount >= High(UInt8) then
+    raise Exception.Create('Compiler error: upvalue count overflow (>255)');
   if FUpvalueCount >= Length(FUpvalues) then
     SetLength(FUpvalues, FUpvalueCount * 2 + 4);
   FUpvalues[FUpvalueCount].Index := AIndex;
@@ -155,6 +157,8 @@ end;
 
 function TGocciaCompilerScope.AllocateRegister: UInt8;
 begin
+  if FNextSlot >= High(UInt8) then
+    raise Exception.Create('Compiler error: register slot overflow (>255)');
   Result := FNextSlot;
   Inc(FNextSlot);
   if FNextSlot > FMaxSlot then

--- a/units/Goccia.Compiler.Test.pas
+++ b/units/Goccia.Compiler.Test.pas
@@ -1,0 +1,168 @@
+program Goccia.Compiler.Test;
+
+{$I Goccia.inc}
+
+uses
+  Classes,
+  Generics.Collections,
+  SysUtils,
+
+  Souffle.Bytecode,
+  Souffle.Bytecode.Binary,
+  Souffle.Bytecode.Chunk,
+  Souffle.Bytecode.Debug,
+  Souffle.Bytecode.Module,
+  TestRunner,
+
+  Goccia.AST.Expressions,
+  Goccia.AST.Node,
+  Goccia.AST.Statements,
+  Goccia.Compiler,
+  Goccia.Compiler.Scope,
+  Goccia.GarbageCollector,
+  Goccia.Lexer,
+  Goccia.Parser,
+  Goccia.Token,
+  Goccia.Values.Primitives;
+
+type
+  TTestCompiler = class(TTestSuite)
+  private
+    function CompileSource(const ASource: string): TSouffleBytecodeModule;
+
+    procedure TestCompileLiteral;
+    procedure TestCompileArithmetic;
+    procedure TestCompileVariable;
+    procedure TestCompileFunction;
+    procedure TestBinaryRoundTrip;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TTestCompiler.SetupTests;
+begin
+  Test('Compile literal', TestCompileLiteral);
+  Test('Compile arithmetic', TestCompileArithmetic);
+  Test('Compile variable', TestCompileVariable);
+  Test('Compile function', TestCompileFunction);
+  Test('Binary round-trip', TestBinaryRoundTrip);
+end;
+
+function TTestCompiler.CompileSource(
+  const ASource: string): TSouffleBytecodeModule;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+  Parser: TGocciaParser;
+  ProgramNode: TGocciaProgram;
+  Compiler: TGocciaCompiler;
+  SourceLines: TStringList;
+begin
+  Lexer := TGocciaLexer.Create(ASource, '<test>');
+  Tokens := Lexer.ScanTokens;
+  SourceLines := TStringList.Create;
+  SourceLines.Text := ASource;
+  Parser := TGocciaParser.Create(Tokens, '<test>', SourceLines);
+  ProgramNode := Parser.Parse;
+
+  Compiler := TGocciaCompiler.Create('<test>');
+  try
+    Result := Compiler.Compile(ProgramNode);
+  finally
+    Compiler.Free;
+    ProgramNode.Free;
+    Parser.Free;
+    SourceLines.Free;
+    Lexer.Free;
+  end;
+end;
+
+procedure TTestCompiler.TestCompileLiteral;
+var
+  Module: TSouffleBytecodeModule;
+begin
+  Module := CompileSource('const x = 42;');
+  try
+    Expect<Boolean>(Assigned(Module)).ToBe(True);
+    Expect<Boolean>(Assigned(Module.TopLevel)).ToBe(True);
+    Expect<Boolean>(Module.TopLevel.CodeCount > 0).ToBe(True);
+  finally
+    Module.Free;
+  end;
+end;
+
+procedure TTestCompiler.TestCompileArithmetic;
+var
+  Module: TSouffleBytecodeModule;
+begin
+  Module := CompileSource('const result = 1 + 2 * 3;');
+  try
+    Expect<Boolean>(Assigned(Module)).ToBe(True);
+    Expect<Boolean>(Module.TopLevel.CodeCount > 3).ToBe(True);
+  finally
+    Module.Free;
+  end;
+end;
+
+procedure TTestCompiler.TestCompileVariable;
+var
+  Module: TSouffleBytecodeModule;
+begin
+  Module := CompileSource('let a = 10; let b = a;');
+  try
+    Expect<Boolean>(Assigned(Module)).ToBe(True);
+    Expect<Boolean>(Module.TopLevel.CodeCount > 2).ToBe(True);
+  finally
+    Module.Free;
+  end;
+end;
+
+procedure TTestCompiler.TestCompileFunction;
+var
+  Module: TSouffleBytecodeModule;
+begin
+  Module := CompileSource('const add = (a, b) => a + b;');
+  try
+    Expect<Boolean>(Assigned(Module)).ToBe(True);
+    Expect<Boolean>(Module.TopLevel.FunctionCount > 0).ToBe(True);
+  finally
+    Module.Free;
+  end;
+end;
+
+procedure TTestCompiler.TestBinaryRoundTrip;
+var
+  Original, Loaded: TSouffleBytecodeModule;
+  TempFile: string;
+begin
+  Original := CompileSource('const x = 42; const y = "hello";');
+  TempFile := GetTempFileName + '.sbc';
+  try
+    SaveModuleToFile(Original, TempFile);
+    Loaded := LoadModuleFromFile(TempFile);
+    try
+      Expect<string>(Loaded.RuntimeTag).ToBe(Original.RuntimeTag);
+      Expect<string>(Loaded.SourcePath).ToBe(Original.SourcePath);
+      Expect<Integer>(Loaded.TopLevel.CodeCount).ToBe(Original.TopLevel.CodeCount);
+      Expect<Integer>(Loaded.TopLevel.ConstantCount).ToBe(Original.TopLevel.ConstantCount);
+      Expect<Integer>(Loaded.TopLevel.FunctionCount).ToBe(Original.TopLevel.FunctionCount);
+    finally
+      Loaded.Free;
+    end;
+  finally
+    Original.Free;
+    DeleteFile(TempFile);
+  end;
+end;
+
+begin
+  TGocciaGarbageCollector.Initialize;
+  try
+    TestRunnerProgram.AddSuite(TTestCompiler.Create('GocciaScript Compiler'));
+    TestRunnerProgram.Run;
+
+    ExitCode := TestResultToExitCode;
+  finally
+    TGocciaGarbageCollector.Shutdown;
+  end;
+end.

--- a/units/Goccia.Compiler.pas
+++ b/units/Goccia.Compiler.pas
@@ -1,0 +1,1141 @@
+unit Goccia.Compiler;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Classes,
+  Generics.Collections,
+
+  Souffle.Bytecode,
+  Souffle.Bytecode.Chunk,
+  Souffle.Bytecode.Debug,
+  Souffle.Bytecode.Module,
+
+  Goccia.AST.Expressions,
+  Goccia.AST.Node,
+  Goccia.AST.Statements,
+  Goccia.Compiler.Scope,
+  Goccia.Token,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaCompilerClassEntry = record
+    ClassDeclaration: TGocciaClassDeclaration;
+    Line: Integer;
+    Column: Integer;
+  end;
+
+  TGocciaCompiler = class
+  private
+    FModule: TSouffleBytecodeModule;
+    FCurrentPrototype: TSouffleFunctionPrototype;
+    FCurrentScope: TGocciaCompilerScope;
+    FSourcePath: string;
+    FPendingClasses: array of TGocciaCompilerClassEntry;
+
+    procedure CompileExpression(const AExpr: TGocciaExpression; const ADest: UInt8);
+    procedure CompileStatement(const AStmt: TGocciaStatement);
+
+    procedure CompileLiteral(const AExpr: TGocciaLiteralExpression; const ADest: UInt8);
+    procedure CompileIdentifier(const AExpr: TGocciaIdentifierExpression; const ADest: UInt8);
+    procedure CompileBinary(const AExpr: TGocciaBinaryExpression; const ADest: UInt8);
+    procedure CompileUnary(const AExpr: TGocciaUnaryExpression; const ADest: UInt8);
+    procedure CompileAssignment(const AExpr: TGocciaAssignmentExpression; const ADest: UInt8);
+    procedure CompilePropertyAssignment(const AExpr: TGocciaPropertyAssignmentExpression; const ADest: UInt8);
+    procedure CompileArrowFunction(const AExpr: TGocciaArrowFunctionExpression; const ADest: UInt8);
+    procedure CompileCall(const AExpr: TGocciaCallExpression; const ADest: UInt8);
+    procedure CompileMember(const AExpr: TGocciaMemberExpression; const ADest: UInt8);
+    procedure CompileConditional(const AExpr: TGocciaConditionalExpression; const ADest: UInt8);
+    procedure CompileArray(const AExpr: TGocciaArrayExpression; const ADest: UInt8);
+    procedure CompileObject(const AExpr: TGocciaObjectExpression; const ADest: UInt8);
+    procedure CompileTemplateLiteral(const AExpr: TGocciaTemplateLiteralExpression; const ADest: UInt8);
+    procedure CompileTemplateWithInterpolation(const AExpr: TGocciaTemplateWithInterpolationExpression; const ADest: UInt8);
+    procedure CompileNewExpression(const AExpr: TGocciaNewExpression; const ADest: UInt8);
+
+    procedure CompileExpressionStatement(const AStmt: TGocciaExpressionStatement);
+    procedure CompileVariableDeclaration(const AStmt: TGocciaVariableDeclaration);
+    procedure CompileBlockStatement(const AStmt: TGocciaBlockStatement);
+    procedure CompileIfStatement(const AStmt: TGocciaIfStatement);
+    procedure CompileReturnStatement(const AStmt: TGocciaReturnStatement);
+    procedure CompileThrowStatement(const AStmt: TGocciaThrowStatement);
+    procedure CompileTryStatement(const AStmt: TGocciaTryStatement);
+    procedure CompileForOfStatement(const AStmt: TGocciaForOfStatement);
+    procedure CompileImportDeclaration(const AStmt: TGocciaImportDeclaration);
+    procedure CompileExportDeclaration(const AStmt: TGocciaExportDeclaration);
+
+    function Emit(const AInstruction: UInt32): Integer;
+    procedure EmitLine(const ALine, AColumn: Integer);
+    function EmitJump(const AOp: TSouffleOpCode; const AReg: UInt8): Integer;
+    procedure PatchJump(const AIndex: Integer);
+    function CurrentCodeCount: Integer;
+
+    procedure CompileFunctionBody(const ABody: TGocciaASTNode);
+    function TokenTypeToRTOp(const ATokenType: TGocciaTokenType): TSouffleOpCode;
+  public
+    constructor Create(const ASourcePath: string);
+    destructor Destroy; override;
+
+    function Compile(const AProgram: TGocciaProgram): TSouffleBytecodeModule;
+    function PendingClassCount: Integer;
+    function GetPendingClass(const AIndex: Integer): TGocciaCompilerClassEntry;
+  end;
+
+const
+  GOCCIA_RUNTIME_TAG = 'goccia-js';
+  COMPOUND_TAG_OBJECT = 0;
+  COMPOUND_TAG_ARRAY  = 1;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Lexer,
+  Goccia.Parser;
+
+{ TGocciaCompiler }
+
+constructor TGocciaCompiler.Create(const ASourcePath: string);
+begin
+  inherited Create;
+  FSourcePath := ASourcePath;
+  FModule := nil;
+  FCurrentPrototype := nil;
+  FCurrentScope := nil;
+end;
+
+destructor TGocciaCompiler.Destroy;
+begin
+  inherited;
+end;
+
+function TGocciaCompiler.Compile(
+  const AProgram: TGocciaProgram): TSouffleBytecodeModule;
+var
+  I: Integer;
+begin
+  FModule := TSouffleBytecodeModule.Create(GOCCIA_RUNTIME_TAG, FSourcePath);
+  FCurrentPrototype := TSouffleFunctionPrototype.Create('<module>');
+  FCurrentPrototype.DebugInfo := TSouffleDebugInfo.Create(FSourcePath);
+  FCurrentScope := TGocciaCompilerScope.Create(nil, 0);
+
+  for I := 0 to AProgram.Body.Count - 1 do
+    CompileStatement(AProgram.Body[I]);
+
+  Emit(EncodeABC(OP_RETURN_NIL, 0, 0, 0));
+
+  FCurrentPrototype.MaxRegisters := FCurrentScope.MaxSlot;
+  FModule.TopLevel := FCurrentPrototype;
+
+  FCurrentScope.Free;
+  FCurrentScope := nil;
+  FCurrentPrototype := nil;
+
+  Result := FModule;
+  FModule := nil;
+end;
+
+{ Expression dispatch }
+
+procedure TGocciaCompiler.CompileExpression(const AExpr: TGocciaExpression;
+  const ADest: UInt8);
+begin
+  EmitLine(AExpr.Line, AExpr.Column);
+
+  if AExpr is TGocciaLiteralExpression then
+    CompileLiteral(TGocciaLiteralExpression(AExpr), ADest)
+  else if AExpr is TGocciaIdentifierExpression then
+    CompileIdentifier(TGocciaIdentifierExpression(AExpr), ADest)
+  else if AExpr is TGocciaBinaryExpression then
+    CompileBinary(TGocciaBinaryExpression(AExpr), ADest)
+  else if AExpr is TGocciaUnaryExpression then
+    CompileUnary(TGocciaUnaryExpression(AExpr), ADest)
+  else if AExpr is TGocciaAssignmentExpression then
+    CompileAssignment(TGocciaAssignmentExpression(AExpr), ADest)
+  else if AExpr is TGocciaPropertyAssignmentExpression then
+    CompilePropertyAssignment(TGocciaPropertyAssignmentExpression(AExpr), ADest)
+  else if AExpr is TGocciaArrowFunctionExpression then
+    CompileArrowFunction(TGocciaArrowFunctionExpression(AExpr), ADest)
+  else if AExpr is TGocciaCallExpression then
+    CompileCall(TGocciaCallExpression(AExpr), ADest)
+  else if AExpr is TGocciaMemberExpression then
+    CompileMember(TGocciaMemberExpression(AExpr), ADest)
+  else if AExpr is TGocciaConditionalExpression then
+    CompileConditional(TGocciaConditionalExpression(AExpr), ADest)
+  else if AExpr is TGocciaArrayExpression then
+    CompileArray(TGocciaArrayExpression(AExpr), ADest)
+  else if AExpr is TGocciaObjectExpression then
+    CompileObject(TGocciaObjectExpression(AExpr), ADest)
+  else if AExpr is TGocciaTemplateWithInterpolationExpression then
+    CompileTemplateWithInterpolation(TGocciaTemplateWithInterpolationExpression(AExpr), ADest)
+  else if AExpr is TGocciaTemplateLiteralExpression then
+    CompileTemplateLiteral(TGocciaTemplateLiteralExpression(AExpr), ADest)
+  else if AExpr is TGocciaNewExpression then
+    CompileNewExpression(TGocciaNewExpression(AExpr), ADest)
+  else
+    Emit(EncodeABC(OP_LOAD_NIL, ADest, 0, 0));
+end;
+
+{ Statement dispatch }
+
+procedure TGocciaCompiler.CompileStatement(const AStmt: TGocciaStatement);
+begin
+  EmitLine(AStmt.Line, AStmt.Column);
+
+  if AStmt is TGocciaExpressionStatement then
+    CompileExpressionStatement(TGocciaExpressionStatement(AStmt))
+  else if AStmt is TGocciaVariableDeclaration then
+    CompileVariableDeclaration(TGocciaVariableDeclaration(AStmt))
+  else if AStmt is TGocciaBlockStatement then
+    CompileBlockStatement(TGocciaBlockStatement(AStmt))
+  else if AStmt is TGocciaIfStatement then
+    CompileIfStatement(TGocciaIfStatement(AStmt))
+  else if AStmt is TGocciaReturnStatement then
+    CompileReturnStatement(TGocciaReturnStatement(AStmt))
+  else if AStmt is TGocciaThrowStatement then
+    CompileThrowStatement(TGocciaThrowStatement(AStmt))
+  else if AStmt is TGocciaTryStatement then
+    CompileTryStatement(TGocciaTryStatement(AStmt))
+  else if AStmt is TGocciaForOfStatement then
+    CompileForOfStatement(TGocciaForOfStatement(AStmt))
+  else if AStmt is TGocciaClassDeclaration then
+  begin
+    SetLength(FPendingClasses, Length(FPendingClasses) + 1);
+    FPendingClasses[High(FPendingClasses)].ClassDeclaration :=
+      TGocciaClassDeclaration(AStmt);
+    FPendingClasses[High(FPendingClasses)].Line := AStmt.Line;
+    FPendingClasses[High(FPendingClasses)].Column := AStmt.Column;
+  end
+  else if AStmt is TGocciaImportDeclaration then
+    CompileImportDeclaration(TGocciaImportDeclaration(AStmt))
+  else if AStmt is TGocciaExportDeclaration then
+    CompileExportDeclaration(TGocciaExportDeclaration(AStmt));
+end;
+
+{ Expression compilation }
+
+procedure TGocciaCompiler.CompileLiteral(
+  const AExpr: TGocciaLiteralExpression; const ADest: UInt8);
+var
+  Value: TGocciaValue;
+  Idx: UInt16;
+begin
+  Value := AExpr.Value;
+
+  if Value is TGocciaUndefinedLiteralValue then
+    Emit(EncodeABC(OP_LOAD_NIL, ADest, 0, 0))
+  else if Value is TGocciaNullLiteralValue then
+    Emit(EncodeABx(OP_RT_GET_GLOBAL, ADest,
+      FCurrentPrototype.AddConstantString('null')))
+  else if Value is TGocciaBooleanLiteralValue then
+  begin
+    if TGocciaBooleanLiteralValue(Value).Value then
+      Emit(EncodeABC(OP_LOAD_TRUE, ADest, 0, 0))
+    else
+      Emit(EncodeABC(OP_LOAD_FALSE, ADest, 0, 0));
+  end
+  else if Value is TGocciaNumberLiteralValue then
+  begin
+    if not TGocciaNumberLiteralValue(Value).IsNaN
+       and not TGocciaNumberLiteralValue(Value).IsInfinite
+       and (Frac(TGocciaNumberLiteralValue(Value).Value) = 0.0)
+       and (TGocciaNumberLiteralValue(Value).Value >= -32768)
+       and (TGocciaNumberLiteralValue(Value).Value <= 32767) then
+      Emit(EncodeAsBx(OP_LOAD_INT, ADest,
+        Int16(Trunc(TGocciaNumberLiteralValue(Value).Value))))
+    else
+    begin
+      Idx := FCurrentPrototype.AddConstantFloat(
+        TGocciaNumberLiteralValue(Value).Value);
+      Emit(EncodeABx(OP_LOAD_CONST, ADest, Idx));
+    end;
+  end
+  else if Value is TGocciaStringLiteralValue then
+  begin
+    Idx := FCurrentPrototype.AddConstantString(
+      TGocciaStringLiteralValue(Value).Value);
+    Emit(EncodeABx(OP_LOAD_CONST, ADest, Idx));
+  end
+  else
+    Emit(EncodeABC(OP_LOAD_NIL, ADest, 0, 0));
+end;
+
+procedure TGocciaCompiler.CompileIdentifier(
+  const AExpr: TGocciaIdentifierExpression; const ADest: UInt8);
+var
+  LocalIdx, UpvalIdx: Integer;
+  Slot: UInt8;
+begin
+  LocalIdx := FCurrentScope.ResolveLocal(AExpr.Name);
+  if LocalIdx >= 0 then
+  begin
+    Slot := FCurrentScope.GetLocal(LocalIdx).Slot;
+    if Slot <> ADest then
+      Emit(EncodeABC(OP_MOVE, ADest, Slot, 0));
+    Exit;
+  end;
+
+  UpvalIdx := FCurrentScope.ResolveUpvalue(AExpr.Name);
+  if UpvalIdx >= 0 then
+  begin
+    Emit(EncodeABx(OP_GET_UPVALUE, ADest, UInt16(UpvalIdx)));
+    Exit;
+  end;
+
+  Emit(EncodeABx(OP_RT_GET_GLOBAL, ADest,
+    FCurrentPrototype.AddConstantString(AExpr.Name)));
+end;
+
+procedure TGocciaCompiler.CompileBinary(
+  const AExpr: TGocciaBinaryExpression; const ADest: UInt8);
+var
+  RegB, RegC: UInt8;
+  Op: TSouffleOpCode;
+  JumpIdx, JumpIdx2: Integer;
+begin
+  if AExpr.Operator = gttAnd then
+  begin
+    CompileExpression(AExpr.Left, ADest);
+    JumpIdx := EmitJump(OP_JUMP_IF_FALSE, ADest);
+    CompileExpression(AExpr.Right, ADest);
+    PatchJump(JumpIdx);
+    Exit;
+  end;
+
+  if AExpr.Operator = gttOr then
+  begin
+    CompileExpression(AExpr.Left, ADest);
+    JumpIdx := EmitJump(OP_JUMP_IF_TRUE, ADest);
+    CompileExpression(AExpr.Right, ADest);
+    PatchJump(JumpIdx);
+    Exit;
+  end;
+
+  if AExpr.Operator = gttNullishCoalescing then
+  begin
+    CompileExpression(AExpr.Left, ADest);
+
+    JumpIdx := EmitJump(OP_JUMP_IF_NOT_NIL, ADest);
+    JumpIdx2 := EmitJump(OP_JUMP, 0);
+
+    PatchJump(JumpIdx);
+    RegB := FCurrentScope.AllocateRegister;
+    RegC := FCurrentScope.AllocateRegister;
+    Emit(EncodeABx(OP_RT_GET_GLOBAL, RegB,
+      FCurrentPrototype.AddConstantString('null')));
+    Emit(EncodeABC(OP_RT_EQ, RegC, ADest, RegB));
+    FCurrentScope.FreeRegister;
+    FCurrentScope.FreeRegister;
+    JumpIdx := EmitJump(OP_JUMP_IF_FALSE, RegC);
+
+    PatchJump(JumpIdx2);
+    CompileExpression(AExpr.Right, ADest);
+
+    PatchJump(JumpIdx);
+    Exit;
+  end;
+
+  RegB := FCurrentScope.AllocateRegister;
+  RegC := FCurrentScope.AllocateRegister;
+
+  CompileExpression(AExpr.Left, RegB);
+  CompileExpression(AExpr.Right, RegC);
+
+  Op := TokenTypeToRTOp(AExpr.Operator);
+  Emit(EncodeABC(Op, ADest, RegB, RegC));
+
+  FCurrentScope.FreeRegister;
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileUnary(
+  const AExpr: TGocciaUnaryExpression; const ADest: UInt8);
+var
+  RegB: UInt8;
+begin
+  RegB := FCurrentScope.AllocateRegister;
+  CompileExpression(AExpr.Operand, RegB);
+
+  case AExpr.Operator of
+    gttNot:        Emit(EncodeABC(OP_RT_NOT, ADest, RegB, 0));
+    gttMinus:      Emit(EncodeABC(OP_RT_NEG, ADest, RegB, 0));
+    gttTypeof:     Emit(EncodeABC(OP_RT_TYPEOF, ADest, RegB, 0));
+    gttBitwiseNot: Emit(EncodeABC(OP_RT_BNOT, ADest, RegB, 0));
+  else
+    Emit(EncodeABC(OP_LOAD_NIL, ADest, 0, 0));
+  end;
+
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileAssignment(
+  const AExpr: TGocciaAssignmentExpression; const ADest: UInt8);
+var
+  LocalIdx, UpvalIdx: Integer;
+  Slot: UInt8;
+begin
+  CompileExpression(AExpr.Value, ADest);
+
+  LocalIdx := FCurrentScope.ResolveLocal(AExpr.Name);
+  if LocalIdx >= 0 then
+  begin
+    Slot := FCurrentScope.GetLocal(LocalIdx).Slot;
+    if ADest <> Slot then
+      Emit(EncodeABC(OP_MOVE, Slot, ADest, 0));
+    Exit;
+  end;
+
+  UpvalIdx := FCurrentScope.ResolveUpvalue(AExpr.Name);
+  if UpvalIdx >= 0 then
+  begin
+    Emit(EncodeABx(OP_SET_UPVALUE, ADest, UInt16(UpvalIdx)));
+    Exit;
+  end;
+
+  Emit(EncodeABx(OP_RT_SET_GLOBAL, ADest,
+    FCurrentPrototype.AddConstantString(AExpr.Name)));
+end;
+
+procedure TGocciaCompiler.CompilePropertyAssignment(
+  const AExpr: TGocciaPropertyAssignmentExpression; const ADest: UInt8);
+var
+  ObjReg, ValReg: UInt8;
+  KeyIdx: UInt8;
+begin
+  ObjReg := FCurrentScope.AllocateRegister;
+  ValReg := FCurrentScope.AllocateRegister;
+
+  CompileExpression(AExpr.ObjectExpr, ObjReg);
+  CompileExpression(AExpr.Value, ValReg);
+
+  KeyIdx := UInt8(FCurrentPrototype.AddConstantString(AExpr.PropertyName) and $FF);
+  Emit(EncodeABC(OP_RT_SET_PROP, ObjReg, KeyIdx, ValReg));
+
+  if ADest <> ValReg then
+    Emit(EncodeABC(OP_MOVE, ADest, ValReg, 0));
+
+  FCurrentScope.FreeRegister;
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileArrowFunction(
+  const AExpr: TGocciaArrowFunctionExpression; const ADest: UInt8);
+var
+  OldProto: TSouffleFunctionPrototype;
+  OldScope: TGocciaCompilerScope;
+  ChildProto: TSouffleFunctionPrototype;
+  ChildScope: TGocciaCompilerScope;
+  FuncIdx: UInt16;
+  I: Integer;
+begin
+  OldProto := FCurrentPrototype;
+  OldScope := FCurrentScope;
+
+  ChildProto := TSouffleFunctionPrototype.Create('<arrow>');
+  ChildProto.DebugInfo := TSouffleDebugInfo.Create(FSourcePath);
+  ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+
+  ChildProto.ParameterCount := Length(AExpr.Parameters);
+  for I := 0 to High(AExpr.Parameters) do
+    if not AExpr.Parameters[I].IsPattern then
+      ChildScope.DeclareLocal(AExpr.Parameters[I].Name, False);
+
+  FCurrentPrototype := ChildProto;
+  FCurrentScope := ChildScope;
+
+  CompileFunctionBody(AExpr.Body);
+
+  ChildProto.MaxRegisters := ChildScope.MaxSlot;
+
+  for I := 0 to ChildScope.UpvalueCount - 1 do
+    ChildProto.AddUpvalueDescriptor(
+      ChildScope.GetUpvalue(I).IsLocal,
+      ChildScope.GetUpvalue(I).Index);
+
+  FCurrentPrototype := OldProto;
+  FCurrentScope := OldScope;
+  ChildScope.Free;
+
+  FuncIdx := FCurrentPrototype.AddFunction(ChildProto);
+  Emit(EncodeABx(OP_CLOSURE, ADest, FuncIdx));
+end;
+
+procedure TGocciaCompiler.CompileFunctionBody(const ABody: TGocciaASTNode);
+var
+  Block: TGocciaBlockStatement;
+  I: Integer;
+  Node: TGocciaASTNode;
+  Reg: UInt8;
+begin
+  if ABody is TGocciaBlockStatement then
+  begin
+    Block := TGocciaBlockStatement(ABody);
+    for I := 0 to Block.Nodes.Count - 1 do
+    begin
+      Node := Block.Nodes[I];
+      if Node is TGocciaStatement then
+        CompileStatement(TGocciaStatement(Node))
+      else if Node is TGocciaExpression then
+      begin
+        Reg := FCurrentScope.AllocateRegister;
+        CompileExpression(TGocciaExpression(Node), Reg);
+        FCurrentScope.FreeRegister;
+      end;
+    end;
+    Emit(EncodeABC(OP_RETURN_NIL, 0, 0, 0));
+  end
+  else if ABody is TGocciaExpression then
+  begin
+    Reg := FCurrentScope.AllocateRegister;
+    CompileExpression(TGocciaExpression(ABody), Reg);
+    Emit(EncodeABC(OP_RETURN, Reg, 0, 0));
+    FCurrentScope.FreeRegister;
+  end
+  else
+    Emit(EncodeABC(OP_RETURN_NIL, 0, 0, 0));
+end;
+
+procedure TGocciaCompiler.CompileCall(
+  const AExpr: TGocciaCallExpression; const ADest: UInt8);
+var
+  ArgCount, I: Integer;
+  BaseReg, ObjReg: UInt8;
+  MemberExpr: TGocciaMemberExpression;
+  PropIdx: UInt16;
+begin
+  ArgCount := AExpr.Arguments.Count;
+
+  if AExpr.Callee is TGocciaMemberExpression then
+  begin
+    MemberExpr := TGocciaMemberExpression(AExpr.Callee);
+    ObjReg := FCurrentScope.AllocateRegister;
+    BaseReg := FCurrentScope.AllocateRegister;
+
+    CompileExpression(MemberExpr.ObjectExpr, ObjReg);
+
+    if MemberExpr.Computed then
+    begin
+      CompileExpression(MemberExpr.PropertyExpression, BaseReg);
+      Emit(EncodeABC(OP_RT_GET_INDEX, BaseReg, ObjReg, BaseReg));
+    end
+    else
+    begin
+      PropIdx := FCurrentPrototype.AddConstantString(MemberExpr.PropertyName);
+      Emit(EncodeABC(OP_RT_GET_PROP, BaseReg, ObjReg,
+        UInt8(PropIdx and $FF)));
+    end;
+
+    for I := 0 to ArgCount - 1 do
+      CompileExpression(AExpr.Arguments[I], FCurrentScope.AllocateRegister);
+
+    Emit(EncodeABC(OP_RT_CALL_METHOD, BaseReg, UInt8(ArgCount), 0));
+
+    for I := 0 to ArgCount - 1 do
+      FCurrentScope.FreeRegister;
+
+    if ADest <> BaseReg then
+      Emit(EncodeABC(OP_MOVE, ADest, BaseReg, 0));
+
+    FCurrentScope.FreeRegister;
+    FCurrentScope.FreeRegister;
+  end
+  else
+  begin
+    BaseReg := FCurrentScope.AllocateRegister;
+
+    CompileExpression(AExpr.Callee, BaseReg);
+
+    for I := 0 to ArgCount - 1 do
+      CompileExpression(AExpr.Arguments[I], FCurrentScope.AllocateRegister);
+
+    Emit(EncodeABC(OP_RT_CALL, BaseReg, UInt8(ArgCount), 0));
+
+    for I := 0 to ArgCount - 1 do
+      FCurrentScope.FreeRegister;
+
+    if ADest <> BaseReg then
+      Emit(EncodeABC(OP_MOVE, ADest, BaseReg, 0));
+
+    FCurrentScope.FreeRegister;
+  end;
+end;
+
+procedure TGocciaCompiler.CompileMember(
+  const AExpr: TGocciaMemberExpression; const ADest: UInt8);
+var
+  ObjReg: UInt8;
+  PropIdx: UInt16;
+begin
+  ObjReg := FCurrentScope.AllocateRegister;
+  CompileExpression(AExpr.ObjectExpr, ObjReg);
+
+  if AExpr.Computed then
+  begin
+    CompileExpression(AExpr.PropertyExpression, ADest);
+    Emit(EncodeABC(OP_RT_GET_INDEX, ADest, ObjReg, ADest));
+  end
+  else
+  begin
+    PropIdx := FCurrentPrototype.AddConstantString(AExpr.PropertyName);
+    Emit(EncodeABC(OP_RT_GET_PROP, ADest, ObjReg, UInt8(PropIdx and $FF)));
+  end;
+
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileConditional(
+  const AExpr: TGocciaConditionalExpression; const ADest: UInt8);
+var
+  ElseJump, EndJump: Integer;
+begin
+  CompileExpression(AExpr.Condition, ADest);
+  ElseJump := EmitJump(OP_JUMP_IF_FALSE, ADest);
+  CompileExpression(AExpr.Consequent, ADest);
+  EndJump := EmitJump(OP_JUMP, 0);
+  PatchJump(ElseJump);
+  CompileExpression(AExpr.Alternate, ADest);
+  PatchJump(EndJump);
+end;
+
+procedure TGocciaCompiler.CompileArray(
+  const AExpr: TGocciaArrayExpression; const ADest: UInt8);
+var
+  I: Integer;
+  ElemReg, IdxReg: UInt8;
+begin
+  Emit(EncodeABC(OP_RT_NEW_COMPOUND, ADest, COMPOUND_TAG_ARRAY, 0));
+
+  for I := 0 to AExpr.Elements.Count - 1 do
+  begin
+    ElemReg := FCurrentScope.AllocateRegister;
+    IdxReg := FCurrentScope.AllocateRegister;
+    CompileExpression(AExpr.Elements[I], ElemReg);
+    Emit(EncodeAsBx(OP_LOAD_INT, IdxReg, Int16(I)));
+    Emit(EncodeABC(OP_RT_INIT_INDEX, ADest, IdxReg, ElemReg));
+    FCurrentScope.FreeRegister;
+    FCurrentScope.FreeRegister;
+  end;
+end;
+
+procedure TGocciaCompiler.CompileObject(
+  const AExpr: TGocciaObjectExpression; const ADest: UInt8);
+var
+  I: Integer;
+  Key: string;
+  ValExpr: TGocciaExpression;
+  ValReg: UInt8;
+  KeyIdx: UInt8;
+  Names: TStringList;
+begin
+  Emit(EncodeABC(OP_RT_NEW_COMPOUND, ADest, COMPOUND_TAG_OBJECT, 0));
+
+  Names := AExpr.GetPropertyNamesInOrder;
+  for I := 0 to Names.Count - 1 do
+  begin
+    Key := Names[I];
+    if AExpr.Properties.TryGetValue(Key, ValExpr) then
+    begin
+      ValReg := FCurrentScope.AllocateRegister;
+      CompileExpression(ValExpr, ValReg);
+      KeyIdx := UInt8(FCurrentPrototype.AddConstantString(Key) and $FF);
+      Emit(EncodeABC(OP_RT_INIT_FIELD, ADest, KeyIdx, ValReg));
+      FCurrentScope.FreeRegister;
+    end;
+  end;
+end;
+
+procedure TGocciaCompiler.CompileTemplateLiteral(
+  const AExpr: TGocciaTemplateLiteralExpression; const ADest: UInt8);
+var
+  Template: string;
+  I, Start, BraceCount: Integer;
+  ExprText, StaticPart: string;
+  PartReg: UInt8;
+  HasParts: Boolean;
+  Lexer: TGocciaLexer;
+  Parser: TGocciaParser;
+  ProgramNode: TGocciaProgram;
+  Tokens: TObjectList<TGocciaToken>;
+  SourceLines: TStringList;
+  ParsedExpr: TGocciaExpression;
+begin
+  Template := AExpr.Value;
+
+  if Pos('${', Template) = 0 then
+  begin
+    Emit(EncodeABx(OP_LOAD_CONST, ADest,
+      FCurrentPrototype.AddConstantString(Template)));
+    Exit;
+  end;
+
+  HasParts := False;
+  I := 1;
+  while I <= Length(Template) do
+  begin
+    if (I < Length(Template)) and (Template[I] = '$') and (Template[I + 1] = '{') then
+    begin
+      Inc(I, 2);
+      Start := I;
+      BraceCount := 1;
+      while (I <= Length(Template)) and (BraceCount > 0) do
+      begin
+        if Template[I] = '{' then
+          Inc(BraceCount)
+        else if Template[I] = '}' then
+          Dec(BraceCount);
+        if BraceCount > 0 then
+          Inc(I);
+      end;
+
+      ExprText := Trim(Copy(Template, Start, I - Start));
+      Inc(I);
+
+      if ExprText <> '' then
+      begin
+        Lexer := TGocciaLexer.Create(ExprText + ';', FSourcePath);
+        try
+          Tokens := Lexer.ScanTokens;
+          SourceLines := TStringList.Create;
+          try
+            SourceLines.Text := ExprText;
+            Parser := TGocciaParser.Create(Tokens, FSourcePath, SourceLines);
+            try
+              ProgramNode := Parser.Parse;
+              try
+                ParsedExpr := nil;
+                if (ProgramNode.Body.Count > 0) and
+                   (ProgramNode.Body[0] is TGocciaExpressionStatement) then
+                  ParsedExpr := TGocciaExpressionStatement(
+                    ProgramNode.Body[0]).Expression;
+
+                if Assigned(ParsedExpr) then
+                begin
+                  if not HasParts then
+                  begin
+                    CompileExpression(ParsedExpr, ADest);
+                    HasParts := True;
+                  end
+                  else
+                  begin
+                    PartReg := FCurrentScope.AllocateRegister;
+                    CompileExpression(ParsedExpr, PartReg);
+                    Emit(EncodeABC(OP_RT_ADD, ADest, ADest, PartReg));
+                    FCurrentScope.FreeRegister;
+                  end;
+                end;
+              finally
+                ProgramNode.Free;
+              end;
+            finally
+              Parser.Free;
+            end;
+          finally
+            SourceLines.Free;
+          end;
+        finally
+          Lexer.Free;
+        end;
+      end;
+    end
+    else
+    begin
+      Start := I;
+      while (I <= Length(Template)) and
+        not ((I < Length(Template)) and (Template[I] = '$') and (Template[I + 1] = '{')) do
+        Inc(I);
+
+      StaticPart := Copy(Template, Start, I - Start);
+      if StaticPart <> '' then
+      begin
+        if not HasParts then
+        begin
+          Emit(EncodeABx(OP_LOAD_CONST, ADest,
+            FCurrentPrototype.AddConstantString(StaticPart)));
+          HasParts := True;
+        end
+        else
+        begin
+          PartReg := FCurrentScope.AllocateRegister;
+          Emit(EncodeABx(OP_LOAD_CONST, PartReg,
+            FCurrentPrototype.AddConstantString(StaticPart)));
+          Emit(EncodeABC(OP_RT_ADD, ADest, ADest, PartReg));
+          FCurrentScope.FreeRegister;
+        end;
+      end;
+    end;
+  end;
+
+  if not HasParts then
+    Emit(EncodeABx(OP_LOAD_CONST, ADest,
+      FCurrentPrototype.AddConstantString('')));
+end;
+
+procedure TGocciaCompiler.CompileTemplateWithInterpolation(
+  const AExpr: TGocciaTemplateWithInterpolationExpression; const ADest: UInt8);
+var
+  I: Integer;
+  PartReg: UInt8;
+begin
+  if AExpr.Parts.Count = 0 then
+  begin
+    Emit(EncodeABx(OP_LOAD_CONST, ADest,
+      FCurrentPrototype.AddConstantString('')));
+    Exit;
+  end;
+
+  CompileExpression(AExpr.Parts[0], ADest);
+
+  for I := 1 to AExpr.Parts.Count - 1 do
+  begin
+    PartReg := FCurrentScope.AllocateRegister;
+    CompileExpression(AExpr.Parts[I], PartReg);
+    Emit(EncodeABC(OP_RT_ADD, ADest, ADest, PartReg));
+    FCurrentScope.FreeRegister;
+  end;
+end;
+
+procedure TGocciaCompiler.CompileNewExpression(
+  const AExpr: TGocciaNewExpression; const ADest: UInt8);
+var
+  CtorReg: UInt8;
+  ArgCount, I: Integer;
+begin
+  CtorReg := FCurrentScope.AllocateRegister;
+  CompileExpression(AExpr.Callee, CtorReg);
+
+  ArgCount := AExpr.Arguments.Count;
+  for I := 0 to ArgCount - 1 do
+    CompileExpression(AExpr.Arguments[I], FCurrentScope.AllocateRegister);
+
+  Emit(EncodeABC(OP_RT_CONSTRUCT, ADest, CtorReg, UInt8(ArgCount)));
+
+  for I := 0 to ArgCount - 1 do
+    FCurrentScope.FreeRegister;
+  FCurrentScope.FreeRegister;
+end;
+
+{ Statement compilation }
+
+procedure TGocciaCompiler.CompileExpressionStatement(
+  const AStmt: TGocciaExpressionStatement);
+var
+  Reg: UInt8;
+begin
+  Reg := FCurrentScope.AllocateRegister;
+  CompileExpression(AStmt.Expression, Reg);
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileVariableDeclaration(
+  const AStmt: TGocciaVariableDeclaration);
+var
+  I: Integer;
+  Info: TGocciaVariableInfo;
+  Slot: UInt8;
+begin
+  for I := 0 to High(AStmt.Variables) do
+  begin
+    Info := AStmt.Variables[I];
+    Slot := FCurrentScope.DeclareLocal(Info.Name, AStmt.IsConst);
+    if Assigned(Info.Initializer) then
+      CompileExpression(Info.Initializer, Slot)
+    else
+      Emit(EncodeABC(OP_LOAD_NIL, Slot, 0, 0));
+  end;
+end;
+
+procedure TGocciaCompiler.CompileBlockStatement(
+  const AStmt: TGocciaBlockStatement);
+var
+  I: Integer;
+  ClosedLocals: array[0..255] of UInt8;
+  ClosedCount: Integer;
+  Node: TGocciaASTNode;
+  Reg: UInt8;
+begin
+  FCurrentScope.BeginScope;
+
+  for I := 0 to AStmt.Nodes.Count - 1 do
+  begin
+    Node := AStmt.Nodes[I];
+    if Node is TGocciaStatement then
+      CompileStatement(TGocciaStatement(Node))
+    else if Node is TGocciaExpression then
+    begin
+      Reg := FCurrentScope.AllocateRegister;
+      CompileExpression(TGocciaExpression(Node), Reg);
+      FCurrentScope.FreeRegister;
+    end;
+  end;
+
+  FCurrentScope.EndScope(ClosedLocals, ClosedCount);
+  for I := 0 to ClosedCount - 1 do
+    Emit(EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+end;
+
+procedure TGocciaCompiler.CompileIfStatement(
+  const AStmt: TGocciaIfStatement);
+var
+  CondReg: UInt8;
+  ElseJump, EndJump: Integer;
+begin
+  CondReg := FCurrentScope.AllocateRegister;
+  CompileExpression(AStmt.Condition, CondReg);
+  FCurrentScope.FreeRegister;
+
+  ElseJump := EmitJump(OP_JUMP_IF_FALSE, CondReg);
+  CompileStatement(AStmt.Consequent);
+
+  if Assigned(AStmt.Alternate) then
+  begin
+    EndJump := EmitJump(OP_JUMP, 0);
+    PatchJump(ElseJump);
+    CompileStatement(AStmt.Alternate);
+    PatchJump(EndJump);
+  end
+  else
+    PatchJump(ElseJump);
+end;
+
+procedure TGocciaCompiler.CompileReturnStatement(
+  const AStmt: TGocciaReturnStatement);
+var
+  Reg: UInt8;
+begin
+  if Assigned(AStmt.Value) then
+  begin
+    Reg := FCurrentScope.AllocateRegister;
+    CompileExpression(AStmt.Value, Reg);
+    Emit(EncodeABC(OP_RETURN, Reg, 0, 0));
+    FCurrentScope.FreeRegister;
+  end
+  else
+    Emit(EncodeABC(OP_RETURN_NIL, 0, 0, 0));
+end;
+
+procedure TGocciaCompiler.CompileThrowStatement(
+  const AStmt: TGocciaThrowStatement);
+var
+  Reg: UInt8;
+begin
+  Reg := FCurrentScope.AllocateRegister;
+  CompileExpression(AStmt.Value, Reg);
+  Emit(EncodeABC(OP_THROW, Reg, 0, 0));
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileTryStatement(
+  const AStmt: TGocciaTryStatement);
+var
+  CatchReg: UInt8;
+  HandlerJump, EndJump: Integer;
+  ClosedLocals: array[0..255] of UInt8;
+  ClosedCount: Integer;
+begin
+  CatchReg := FCurrentScope.AllocateRegister;
+  HandlerJump := EmitJump(OP_PUSH_HANDLER, CatchReg);
+
+  CompileBlockStatement(AStmt.Block);
+
+  Emit(EncodeABC(OP_POP_HANDLER, 0, 0, 0));
+  EndJump := EmitJump(OP_JUMP, 0);
+
+  PatchJump(HandlerJump);
+
+  if AStmt.CatchParam <> '' then
+  begin
+    FCurrentScope.BeginScope;
+    FCurrentScope.DeclareLocal(AStmt.CatchParam, False);
+    Emit(EncodeABC(OP_MOVE, FCurrentScope.NextSlot - 1, CatchReg, 0));
+  end;
+
+  if Assigned(AStmt.CatchBlock) then
+    CompileBlockStatement(AStmt.CatchBlock);
+
+  if AStmt.CatchParam <> '' then
+    FCurrentScope.EndScope(ClosedLocals, ClosedCount);
+
+  PatchJump(EndJump);
+
+  if Assigned(AStmt.FinallyBlock) then
+    CompileBlockStatement(AStmt.FinallyBlock);
+
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileForOfStatement(
+  const AStmt: TGocciaForOfStatement);
+var
+  IterReg, ValueReg, DoneReg: UInt8;
+  LoopStart, ExitJump: Integer;
+  Slot: UInt8;
+  ClosedLocals: array[0..255] of UInt8;
+  ClosedCount: Integer;
+begin
+  IterReg := FCurrentScope.AllocateRegister;
+  ValueReg := FCurrentScope.AllocateRegister;
+  DoneReg := FCurrentScope.AllocateRegister;
+
+  CompileExpression(AStmt.Iterable, IterReg);
+  Emit(EncodeABC(OP_RT_GET_ITER, IterReg, IterReg, 0));
+
+  LoopStart := CurrentCodeCount;
+
+  Emit(EncodeABC(OP_RT_ITER_NEXT, ValueReg, DoneReg, IterReg));
+  ExitJump := EmitJump(OP_JUMP_IF_TRUE, DoneReg);
+
+  FCurrentScope.BeginScope;
+
+  if AStmt.BindingName <> '' then
+  begin
+    Slot := FCurrentScope.DeclareLocal(AStmt.BindingName, AStmt.IsConst);
+    Emit(EncodeABC(OP_MOVE, Slot, ValueReg, 0));
+  end;
+
+  CompileStatement(AStmt.Body);
+
+  FCurrentScope.EndScope(ClosedLocals, ClosedCount);
+
+  Emit(EncodeAx(OP_JUMP, LoopStart - CurrentCodeCount - 1));
+
+  PatchJump(ExitJump);
+
+  FCurrentScope.FreeRegister;
+  FCurrentScope.FreeRegister;
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileImportDeclaration(
+  const AStmt: TGocciaImportDeclaration);
+var
+  ModReg: UInt8;
+  PathIdx, NameIdx: UInt16;
+  Pair: TPair<string, string>;
+  Slot: UInt8;
+begin
+  ModReg := FCurrentScope.AllocateRegister;
+  PathIdx := FCurrentPrototype.AddConstantString(AStmt.ModulePath);
+  Emit(EncodeABx(OP_RT_IMPORT, ModReg, PathIdx));
+
+  for Pair in AStmt.Imports do
+  begin
+    Slot := FCurrentScope.DeclareLocal(Pair.Key, True);
+    NameIdx := FCurrentPrototype.AddConstantString(Pair.Value);
+    Emit(EncodeABC(OP_RT_GET_PROP, Slot, ModReg, UInt8(NameIdx and $FF)));
+  end;
+
+  FCurrentScope.FreeRegister;
+end;
+
+procedure TGocciaCompiler.CompileExportDeclaration(
+  const AStmt: TGocciaExportDeclaration);
+var
+  Pair: TPair<string, string>;
+  LocalIdx: Integer;
+  Reg: UInt8;
+  NameIdx: UInt16;
+begin
+  for Pair in AStmt.ExportsTable do
+  begin
+    LocalIdx := FCurrentScope.ResolveLocal(Pair.Value);
+    if LocalIdx >= 0 then
+    begin
+      Reg := FCurrentScope.GetLocal(LocalIdx).Slot;
+      NameIdx := FCurrentPrototype.AddConstantString(Pair.Key);
+      Emit(EncodeABx(OP_RT_EXPORT, Reg, NameIdx));
+    end;
+  end;
+end;
+
+{ Helpers }
+
+function TGocciaCompiler.Emit(const AInstruction: UInt32): Integer;
+begin
+  Result := FCurrentPrototype.EmitInstruction(AInstruction);
+end;
+
+procedure TGocciaCompiler.EmitLine(const ALine, AColumn: Integer);
+begin
+  if Assigned(FCurrentPrototype.DebugInfo) then
+    FCurrentPrototype.DebugInfo.AddLineMapping(
+      UInt32(FCurrentPrototype.CodeCount), UInt32(ALine), UInt16(AColumn));
+end;
+
+function TGocciaCompiler.EmitJump(const AOp: TSouffleOpCode;
+  const AReg: UInt8): Integer;
+begin
+  if AOp = OP_JUMP then
+    Result := Emit(EncodeAx(AOp, 0))
+  else
+    Result := Emit(EncodeAsBx(AOp, AReg, 0));
+end;
+
+procedure TGocciaCompiler.PatchJump(const AIndex: Integer);
+var
+  Offset: Integer;
+  Instruction: UInt32;
+  Op: UInt8;
+  A: UInt8;
+begin
+  Offset := CurrentCodeCount - AIndex - 1;
+  Instruction := FCurrentPrototype.GetInstruction(AIndex);
+  Op := DecodeOp(Instruction);
+
+  if TSouffleOpCode(Op) = OP_JUMP then
+    FCurrentPrototype.PatchInstruction(AIndex, EncodeAx(OP_JUMP, Offset))
+  else
+  begin
+    A := DecodeA(Instruction);
+    FCurrentPrototype.PatchInstruction(AIndex,
+      EncodeAsBx(TSouffleOpCode(Op), A, Int16(Offset)));
+  end;
+end;
+
+function TGocciaCompiler.CurrentCodeCount: Integer;
+begin
+  Result := FCurrentPrototype.CodeCount;
+end;
+
+function TGocciaCompiler.PendingClassCount: Integer;
+begin
+  Result := Length(FPendingClasses);
+end;
+
+function TGocciaCompiler.GetPendingClass(
+  const AIndex: Integer): TGocciaCompilerClassEntry;
+begin
+  Result := FPendingClasses[AIndex];
+end;
+
+function TGocciaCompiler.TokenTypeToRTOp(
+  const ATokenType: TGocciaTokenType): TSouffleOpCode;
+begin
+  case ATokenType of
+    gttPlus:               Result := OP_RT_ADD;
+    gttMinus:              Result := OP_RT_SUB;
+    gttStar:               Result := OP_RT_MUL;
+    gttSlash:              Result := OP_RT_DIV;
+    gttPercent:            Result := OP_RT_MOD;
+    gttPower:              Result := OP_RT_POW;
+    gttEqual:              Result := OP_RT_EQ;
+    gttNotEqual:           Result := OP_RT_NEQ;
+    gttLess:               Result := OP_RT_LT;
+    gttGreater:            Result := OP_RT_GT;
+    gttLessEqual:          Result := OP_RT_LTE;
+    gttGreaterEqual:       Result := OP_RT_GTE;
+    gttInstanceof:         Result := OP_RT_IS_INSTANCE;
+    gttIn:                 Result := OP_RT_HAS_PROPERTY;
+    gttBitwiseAnd:         Result := OP_RT_BAND;
+    gttBitwiseOr:          Result := OP_RT_BOR;
+    gttBitwiseXor:         Result := OP_RT_BXOR;
+    gttLeftShift:          Result := OP_RT_SHL;
+    gttRightShift:         Result := OP_RT_SHR;
+    gttUnsignedRightShift: Result := OP_RT_USHR;
+  else
+    Result := OP_RT_ADD;
+  end;
+end;
+
+end.

--- a/units/Goccia.Compiler.pas
+++ b/units/Goccia.Compiler.pas
@@ -525,8 +525,9 @@ begin
     else
     begin
       PropIdx := FCurrentPrototype.AddConstantString(MemberExpr.PropertyName);
-      Emit(EncodeABC(OP_RT_GET_PROP, BaseReg, ObjReg,
-        UInt8(PropIdx and $FF)));
+      if PropIdx > High(UInt8) then
+        raise Exception.Create('Constant pool overflow: property name index exceeds 255');
+      Emit(EncodeABC(OP_RT_GET_PROP, BaseReg, ObjReg, UInt8(PropIdx)));
     end;
 
     for I := 0 to ArgCount - 1 do
@@ -581,7 +582,9 @@ begin
   else
   begin
     PropIdx := FCurrentPrototype.AddConstantString(AExpr.PropertyName);
-    Emit(EncodeABC(OP_RT_GET_PROP, ADest, ObjReg, UInt8(PropIdx and $FF)));
+    if PropIdx > High(UInt8) then
+      raise Exception.Create('Constant pool overflow: property name index exceeds 255');
+    Emit(EncodeABC(OP_RT_GET_PROP, ADest, ObjReg, UInt8(PropIdx)));
   end;
 
   FCurrentScope.FreeRegister;
@@ -1031,7 +1034,9 @@ begin
   begin
     Slot := FCurrentScope.DeclareLocal(Pair.Key, True);
     NameIdx := FCurrentPrototype.AddConstantString(Pair.Value);
-    Emit(EncodeABC(OP_RT_GET_PROP, Slot, ModReg, UInt8(NameIdx and $FF)));
+    if NameIdx > High(UInt8) then
+      raise Exception.Create('Constant pool overflow: import name index exceeds 255');
+    Emit(EncodeABC(OP_RT_GET_PROP, Slot, ModReg, UInt8(NameIdx)));
   end;
 
   FCurrentScope.FreeRegister;

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -54,6 +54,7 @@ uses
 
   Goccia.AST.Statements,
   Goccia.Evaluator,
+  Goccia.GarbageCollector,
   Goccia.Interpreter,
   Goccia.Scope,
   Goccia.Scope.BindingMap;
@@ -116,9 +117,14 @@ begin
           Context, Entry.Line, Entry.Column);
         if Assigned(ClassValue) then
         begin
-          RegisterGlobal(Entry.ClassDeclaration.ClassDefinition.Name, ClassValue);
-          Context.Scope.DefineLexicalBinding(
-            Entry.ClassDeclaration.ClassDefinition.Name, ClassValue, dtConst);
+          TGocciaGarbageCollector.Instance.AddTempRoot(ClassValue);
+          try
+            RegisterGlobal(Entry.ClassDeclaration.ClassDefinition.Name, ClassValue);
+            Context.Scope.DefineLexicalBinding(
+              Entry.ClassDeclaration.ClassDefinition.Name, ClassValue, dtConst);
+          finally
+            TGocciaGarbageCollector.Instance.RemoveTempRoot(ClassValue);
+          end;
         end;
       end;
     end;

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -1,0 +1,167 @@
+unit Goccia.Engine.Backend;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Souffle.Bytecode.Module,
+  Souffle.VM,
+  Souffle.VM.RuntimeOperations,
+
+  Goccia.AST.Node,
+  Goccia.Compiler,
+  Goccia.Engine,
+  Goccia.Runtime.Operations,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaEngineBackend = (
+    ebTreeWalk,
+    ebSouffleVM
+  );
+
+  TGocciaSouffleBackend = class
+  private
+    FVM: TSouffleVM;
+    FRuntime: TGocciaRuntimeOperations;
+    FSourcePath: string;
+    FEngine: TGocciaEngine;
+  public
+    constructor Create(const ASourcePath: string);
+    destructor Destroy; override;
+
+    function CompileAndRun(const AProgram: TGocciaProgram): TGocciaValue;
+    function CompileToModule(const AProgram: TGocciaProgram): TSouffleBytecodeModule;
+    function RunModule(const AModule: TSouffleBytecodeModule): TGocciaValue;
+
+    procedure RegisterGlobal(const AName: string; const AValue: TGocciaValue);
+    procedure RegisterBuiltIns(const AGlobals: TGocciaGlobalBuiltins);
+
+    property Runtime: TGocciaRuntimeOperations read FRuntime;
+    property VM: TSouffleVM read FVM;
+    property Engine: TGocciaEngine read FEngine;
+  end;
+
+implementation
+
+uses
+  Classes,
+
+  Souffle.Heap,
+  Souffle.Value,
+
+  Goccia.AST.Statements,
+  Goccia.Evaluator,
+  Goccia.Interpreter,
+  Goccia.Scope,
+  Goccia.Scope.BindingMap;
+
+{ TGocciaSouffleBackend }
+
+constructor TGocciaSouffleBackend.Create(const ASourcePath: string);
+begin
+  inherited Create;
+  FSourcePath := ASourcePath;
+  FRuntime := TGocciaRuntimeOperations.Create;
+  FVM := TSouffleVM.Create(FRuntime);
+  FRuntime.VM := FVM;
+  FRuntime.Engine := nil;
+  FEngine := nil;
+end;
+
+destructor TGocciaSouffleBackend.Destroy;
+begin
+  FVM.Free;
+  FRuntime.Free;
+  FEngine.Free;
+  inherited;
+end;
+
+function TGocciaSouffleBackend.CompileAndRun(
+  const AProgram: TGocciaProgram): TGocciaValue;
+var
+  Module: TSouffleBytecodeModule;
+begin
+  Module := CompileToModule(AProgram);
+  try
+    Result := RunModule(Module);
+  finally
+    Module.Free;
+  end;
+end;
+
+function TGocciaSouffleBackend.CompileToModule(
+  const AProgram: TGocciaProgram): TSouffleBytecodeModule;
+var
+  Compiler: TGocciaCompiler;
+  I: Integer;
+  Entry: TGocciaCompilerClassEntry;
+  Context: TGocciaEvaluationContext;
+  ClassValue: TGocciaValue;
+begin
+  Compiler := TGocciaCompiler.Create(FSourcePath);
+  try
+    Result := Compiler.Compile(AProgram);
+
+    if Assigned(FEngine) and (Compiler.PendingClassCount > 0) then
+    begin
+      Context := FEngine.Interpreter.CreateEvaluationContext;
+      for I := 0 to Compiler.PendingClassCount - 1 do
+      begin
+        Entry := Compiler.GetPendingClass(I);
+        ClassValue := EvaluateClassDefinition(
+          Entry.ClassDeclaration.ClassDefinition,
+          Context, Entry.Line, Entry.Column);
+        if Assigned(ClassValue) then
+        begin
+          RegisterGlobal(Entry.ClassDeclaration.ClassDefinition.Name, ClassValue);
+          Context.Scope.DefineLexicalBinding(
+            Entry.ClassDeclaration.ClassDefinition.Name, ClassValue, dtConst);
+        end;
+      end;
+    end;
+  finally
+    Compiler.Free;
+  end;
+end;
+
+function TGocciaSouffleBackend.RunModule(
+  const AModule: TSouffleBytecodeModule): TGocciaValue;
+var
+  SouffleResult: TSouffleValue;
+begin
+  SouffleResult := FVM.Execute(AModule);
+  Result := FRuntime.UnwrapToGocciaValue(SouffleResult);
+end;
+
+procedure TGocciaSouffleBackend.RegisterGlobal(const AName: string;
+  const AValue: TGocciaValue);
+begin
+  FRuntime.RegisterGlobal(AName, FRuntime.ToSouffleValue(AValue));
+end;
+
+procedure TGocciaSouffleBackend.RegisterBuiltIns(
+  const AGlobals: TGocciaGlobalBuiltins);
+var
+  EmptySource: TStringList;
+  GlobalScope: TGocciaScope;
+  Names: TGocciaStringArray;
+  I: Integer;
+begin
+  EmptySource := TStringList.Create;
+  try
+    FEngine := TGocciaEngine.Create(FSourcePath, EmptySource, AGlobals);
+  finally
+    EmptySource.Free;
+  end;
+
+  FRuntime.Engine := FEngine;
+
+  GlobalScope := FEngine.Interpreter.GlobalScope;
+  Names := GlobalScope.GetOwnBindingNames;
+  for I := 0 to Length(Names) - 1 do
+    RegisterGlobal(Names[I], GlobalScope.GetValue(Names[I]));
+end;
+
+end.

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -157,6 +157,7 @@ var
   I: Integer;
 begin
   FreeAndNil(FEngine);
+  FRuntime.Engine := nil;
 
   EmptySource := TStringList.Create;
   try

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -47,6 +47,7 @@ implementation
 
 uses
   Classes,
+  SysUtils,
 
   Souffle.Heap,
   Souffle.Value,
@@ -149,6 +150,8 @@ var
   Names: TGocciaStringArray;
   I: Integer;
 begin
+  FreeAndNil(FEngine);
+
   EmptySource := TStringList.Create;
   try
     FEngine := TGocciaEngine.Create(FSourcePath, EmptySource, AGlobals);

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -2825,13 +2825,15 @@ begin
     begin
       InitializeInstanceProperties(TGocciaInstanceValue(Instance), AClassValue, InitContext);
 
-      if Assigned(AClassValue.SuperClass) then
+      WalkClass := AClassValue.SuperClass;
+      while Assigned(WalkClass) do
       begin
         SuperInitContext := AContext;
-        SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue.SuperClass);
+        SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, WalkClass);
         SuperInitScope.ThisValue := Instance;
         SuperInitContext.Scope := SuperInitScope;
-        InitializePrivateInstanceProperties(TGocciaInstanceValue(Instance), AClassValue.SuperClass, SuperInitContext);
+        InitializePrivateInstanceProperties(TGocciaInstanceValue(Instance), WalkClass, SuperInitContext);
+        WalkClass := WalkClass.SuperClass;
       end;
 
       InitializePrivateInstanceProperties(TGocciaInstanceValue(Instance), AClassValue, InitContext);

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -7,6 +7,7 @@ interface
 uses
   Generics.Collections,
 
+  Goccia.Arguments.Collection,
   Goccia.AST.Expressions,
   Goccia.AST.Node,
   Goccia.AST.Statements,
@@ -76,6 +77,7 @@ procedure AssignAssignmentPattern(const APattern: TGocciaAssignmentDestructuring
 procedure AssignRestPattern(const APattern: TGocciaRestDestructuringPattern; const AValue: TGocciaValue; const AContext: TGocciaEvaluationContext; const AIsDeclaration: Boolean = False; const ADeclarationType: TGocciaDeclarationType = dtLet);
 procedure InitializeInstanceProperties(const AInstance: TGocciaInstanceValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 procedure InitializePrivateInstanceProperties(const AInstance: TGocciaInstanceValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
+function InstantiateClass(const AClassValue: TGocciaClassValue; const AArguments: TGocciaArgumentsCollection; const AContext: TGocciaEvaluationContext): TGocciaValue;
 
 function IsObjectInstanceOfClass(const AObj: TGocciaObjectValue; const AClassValue: TGocciaClassValue): Boolean;
 
@@ -90,7 +92,6 @@ uses
 
   OrderedMap,
 
-  Goccia.Arguments.Collection,
   Goccia.CallStack,
   Goccia.Constants,
   Goccia.Constants.ErrorNames,
@@ -1931,89 +1932,7 @@ begin
     try
       if Callee is TGocciaClassValue then
       begin
-        ClassValue := TGocciaClassValue(Callee);
-
-        NativeInstance := nil;
-        WalkClass := ClassValue;
-        while Assigned(WalkClass) do
-        begin
-          NativeInstance := WalkClass.CreateNativeInstance(Arguments);
-          if Assigned(NativeInstance) then
-            Break;
-          WalkClass := WalkClass.SuperClass;
-        end;
-
-        if Assigned(NativeInstance) then
-        begin
-          NativeInstance.Prototype := ClassValue.Prototype;
-          if NativeInstance is TGocciaInstanceValue then
-            TGocciaInstanceValue(NativeInstance).ClassValue := ClassValue;
-
-          InitContext := AContext;
-          InitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue);
-          InitScope.ThisValue := NativeInstance;
-          InitContext.Scope := InitScope;
-
-          InitializeInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue, InitContext);
-
-          if Assigned(ClassValue.SuperClass) then
-          begin
-            SuperInitContext := AContext;
-            SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue.SuperClass);
-            SuperInitScope.ThisValue := NativeInstance;
-            SuperInitContext.Scope := SuperInitScope;
-            InitializePrivateInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue.SuperClass, SuperInitContext);
-          end;
-
-          InitializePrivateInstanceProperties(TGocciaInstanceValue(NativeInstance), ClassValue, InitContext);
-
-          ClassValue.RunMethodInitializers(NativeInstance);
-          ClassValue.RunFieldInitializers(NativeInstance);
-          ClassValue.RunDecoratorFieldInitializers(NativeInstance);
-
-          if Assigned(ClassValue.ConstructorMethod) then
-            ClassValue.ConstructorMethod.Call(Arguments, NativeInstance)
-          else if Assigned(ClassValue.SuperClass) and Assigned(ClassValue.SuperClass.ConstructorMethod) then
-            ClassValue.SuperClass.ConstructorMethod.Call(Arguments, NativeInstance)
-          else
-            TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(Arguments);
-
-          Result := NativeInstance;
-        end
-        else
-        begin
-          Instance := TGocciaInstanceValue.Create(ClassValue);
-          Instance.Prototype := ClassValue.Prototype;
-
-          InitContext := AContext;
-          InitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue);
-          InitScope.ThisValue := Instance;
-          InitContext.Scope := InitScope;
-
-          InitializeInstanceProperties(Instance, ClassValue, InitContext);
-
-          if Assigned(ClassValue.SuperClass) then
-          begin
-            SuperInitContext := AContext;
-            SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, ClassValue.SuperClass);
-            SuperInitScope.ThisValue := Instance;
-            SuperInitContext.Scope := SuperInitScope;
-            InitializePrivateInstanceProperties(Instance, ClassValue.SuperClass, SuperInitContext);
-          end;
-
-          InitializePrivateInstanceProperties(Instance, ClassValue, InitContext);
-
-          ClassValue.RunMethodInitializers(Instance);
-          ClassValue.RunFieldInitializers(Instance);
-          ClassValue.RunDecoratorFieldInitializers(Instance);
-
-          if Assigned(ClassValue.ConstructorMethod) then
-            ClassValue.ConstructorMethod.Call(Arguments, Instance)
-          else if Assigned(ClassValue.SuperClass) and Assigned(ClassValue.SuperClass.ConstructorMethod) then
-            ClassValue.SuperClass.ConstructorMethod.Call(Arguments, Instance);
-
-          Result := Instance;
-        end;
+        Result := InstantiateClass(TGocciaClassValue(Callee), Arguments, AContext);
       end
       else if Callee is TGocciaNativeFunctionValue then
       begin
@@ -2860,6 +2779,79 @@ begin
     PropertyValue := EvaluateExpression(Entry.Value, AContext);
     AInstance.SetPrivateProperty(Entry.Key, PropertyValue, AClassValue);
   end;
+end;
+
+function InstantiateClass(const AClassValue: TGocciaClassValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const AContext: TGocciaEvaluationContext): TGocciaValue;
+var
+  Instance: TGocciaObjectValue;
+  WalkClass: TGocciaClassValue;
+  NativeInstance: TGocciaObjectValue;
+  InitContext, SuperInitContext: TGocciaEvaluationContext;
+  InitScope, SuperInitScope: TGocciaScope;
+begin
+  NativeInstance := nil;
+  WalkClass := AClassValue;
+  while Assigned(WalkClass) do
+  begin
+    NativeInstance := WalkClass.CreateNativeInstance(AArguments);
+    if Assigned(NativeInstance) then
+      Break;
+    WalkClass := WalkClass.SuperClass;
+  end;
+
+  if Assigned(NativeInstance) then
+  begin
+    Instance := NativeInstance;
+    Instance.Prototype := AClassValue.Prototype;
+    if NativeInstance is TGocciaInstanceValue then
+      TGocciaInstanceValue(NativeInstance).ClassValue := AClassValue;
+  end
+  else
+  begin
+    Instance := TGocciaInstanceValue.Create(AClassValue);
+    Instance.Prototype := AClassValue.Prototype;
+  end;
+
+  TGocciaGarbageCollector.Instance.AddTempRoot(Instance);
+  try
+    InitContext := AContext;
+    InitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue);
+    InitScope.ThisValue := Instance;
+    InitContext.Scope := InitScope;
+
+    if Instance is TGocciaInstanceValue then
+    begin
+      InitializeInstanceProperties(TGocciaInstanceValue(Instance), AClassValue, InitContext);
+
+      if Assigned(AClassValue.SuperClass) then
+      begin
+        SuperInitContext := AContext;
+        SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue.SuperClass);
+        SuperInitScope.ThisValue := Instance;
+        SuperInitContext.Scope := SuperInitScope;
+        InitializePrivateInstanceProperties(TGocciaInstanceValue(Instance), AClassValue.SuperClass, SuperInitContext);
+      end;
+
+      InitializePrivateInstanceProperties(TGocciaInstanceValue(Instance), AClassValue, InitContext);
+    end;
+
+    AClassValue.RunMethodInitializers(Instance);
+    AClassValue.RunFieldInitializers(Instance);
+    AClassValue.RunDecoratorFieldInitializers(Instance);
+
+    if Assigned(AClassValue.ConstructorMethod) then
+      AClassValue.ConstructorMethod.Call(AArguments, Instance)
+    else if Assigned(AClassValue.SuperClass) and Assigned(AClassValue.SuperClass.ConstructorMethod) then
+      AClassValue.SuperClass.ConstructorMethod.Call(AArguments, Instance)
+    else if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then
+      TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+  finally
+    TGocciaGarbageCollector.Instance.RemoveTempRoot(Instance);
+  end;
+
+  Result := Instance;
 end;
 
 function EvaluateTemplateLiteral(const ATemplateLiteralExpression: TGocciaTemplateLiteralExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;

--- a/units/Goccia.FileExtensions.pas
+++ b/units/Goccia.FileExtensions.pas
@@ -11,6 +11,7 @@ const
   EXT_TSX  = '.tsx';
   EXT_MJS  = '.mjs';
   EXT_JSON = '.json';
+  EXT_SBC  = '.sbc';
 
   ScriptExtensions: array[0..4] of string = (
     EXT_JS, EXT_JSX, EXT_TS, EXT_TSX, EXT_MJS

--- a/units/Goccia.Interpreter.pas
+++ b/units/Goccia.Interpreter.pas
@@ -44,9 +44,9 @@ type
     FResolver: TGocciaModuleResolver;
 
     procedure ThrowError(const AMessage: string; const ALine, AColumn: Integer);
-    function CreateEvaluationContext: TGocciaEvaluationContext;
     function LoadJsonModule(const AResolvedPath: string): TGocciaModule;
   public
+    function CreateEvaluationContext: TGocciaEvaluationContext;
     constructor Create(const AFileName: string; const ASourceLines: TStringList);
     destructor Destroy; override;
     function Execute(const AProgram: TGocciaProgram): TGocciaValue;

--- a/units/Goccia.Runtime.Operations.pas
+++ b/units/Goccia.Runtime.Operations.pas
@@ -1,0 +1,771 @@
+unit Goccia.Runtime.Operations;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Generics.Collections,
+
+  Souffle.Heap,
+  Souffle.Value,
+  Souffle.VM,
+  Souffle.VM.Closure,
+  Souffle.VM.RuntimeOperations,
+
+  Goccia.Values.Primitives;
+
+const
+  GOCCIA_HEAP_WRAPPED = 128;
+
+type
+  TGocciaRuntimeOperations = class;
+
+  TGocciaWrappedValue = class(TSouffleHeapObject)
+  private
+    FValue: TGocciaValue;
+  public
+    constructor Create(const AValue: TGocciaValue);
+    procedure MarkReferences; override;
+    function DebugString: string; override;
+    property Value: TGocciaValue read FValue;
+  end;
+
+  TGocciaRuntimeOperations = class(TSouffleRuntimeOperations)
+  private
+    FGlobals: TDictionary<string, TSouffleValue>;
+    FExports: TDictionary<string, TSouffleValue>;
+    FVM: TSouffleVM;
+    FEngine: TObject;
+
+    function WrapGocciaValue(const AValue: TGocciaValue): TSouffleValue;
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    function Add(const A, B: TSouffleValue): TSouffleValue; override;
+    function Subtract(const A, B: TSouffleValue): TSouffleValue; override;
+    function Multiply(const A, B: TSouffleValue): TSouffleValue; override;
+    function Divide(const A, B: TSouffleValue): TSouffleValue; override;
+    function Modulo(const A, B: TSouffleValue): TSouffleValue; override;
+    function Power(const A, B: TSouffleValue): TSouffleValue; override;
+    function Negate(const A: TSouffleValue): TSouffleValue; override;
+
+    function BitwiseAnd(const A, B: TSouffleValue): TSouffleValue; override;
+    function BitwiseOr(const A, B: TSouffleValue): TSouffleValue; override;
+    function BitwiseXor(const A, B: TSouffleValue): TSouffleValue; override;
+    function ShiftLeft(const A, B: TSouffleValue): TSouffleValue; override;
+    function ShiftRight(const A, B: TSouffleValue): TSouffleValue; override;
+    function UnsignedShiftRight(const A, B: TSouffleValue): TSouffleValue; override;
+    function BitwiseNot(const A: TSouffleValue): TSouffleValue; override;
+
+    function Equal(const A, B: TSouffleValue): TSouffleValue; override;
+    function NotEqual(const A, B: TSouffleValue): TSouffleValue; override;
+    function LessThan(const A, B: TSouffleValue): TSouffleValue; override;
+    function GreaterThan(const A, B: TSouffleValue): TSouffleValue; override;
+    function LessThanOrEqual(const A, B: TSouffleValue): TSouffleValue; override;
+    function GreaterThanOrEqual(const A, B: TSouffleValue): TSouffleValue; override;
+
+    function LogicalNot(const A: TSouffleValue): TSouffleValue; override;
+    function TypeOf(const A: TSouffleValue): TSouffleValue; override;
+    function IsInstance(const A, B: TSouffleValue): TSouffleValue; override;
+    function HasProperty(const AObject, AKey: TSouffleValue): TSouffleValue; override;
+    function ToBoolean(const A: TSouffleValue): TSouffleValue; override;
+
+    function CreateCompound(const ATypeTag: UInt8): TSouffleValue; override;
+    procedure InitField(const ACompound: TSouffleValue; const AKey: string;
+      const AValue: TSouffleValue); override;
+    procedure InitIndex(const ACompound: TSouffleValue; const AIndex: TSouffleValue;
+      const AValue: TSouffleValue); override;
+
+    function GetProperty(const AObject: TSouffleValue;
+      const AKey: string): TSouffleValue; override;
+    procedure SetProperty(const AObject: TSouffleValue; const AKey: string;
+      const AValue: TSouffleValue); override;
+    function GetIndex(const AObject, AKey: TSouffleValue): TSouffleValue; override;
+    procedure SetIndex(const AObject: TSouffleValue;
+      const AKey, AValue: TSouffleValue); override;
+    function DeleteProperty(const AObject: TSouffleValue;
+      const AKey: string): TSouffleValue; override;
+
+    function Invoke(const ACallee: TSouffleValue; const AArgs: PSouffleValue;
+      const AArgCount: Integer; const AReceiver: TSouffleValue): TSouffleValue; override;
+    function Construct(const AConstructor: TSouffleValue; const AArgs: PSouffleValue;
+      const AArgCount: Integer): TSouffleValue; override;
+
+    function GetIterator(const AIterable: TSouffleValue): TSouffleValue; override;
+    function IteratorNext(const AIterator: TSouffleValue;
+      out ADone: Boolean): TSouffleValue; override;
+    procedure SpreadInto(const ATarget, ASource: TSouffleValue); override;
+
+    function ImportModule(const APath: string): TSouffleValue; override;
+    procedure ExportBinding(const AValue: TSouffleValue;
+      const AName: string); override;
+
+    function AwaitValue(const AValue: TSouffleValue): TSouffleValue; override;
+
+    function GetGlobal(const AName: string): TSouffleValue; override;
+    procedure SetGlobal(const AName: string;
+      const AValue: TSouffleValue); override;
+
+    function UnwrapToGocciaValue(const AValue: TSouffleValue): TGocciaValue;
+    function ToSouffleValue(const AValue: TGocciaValue): TSouffleValue;
+
+    procedure RegisterGlobal(const AName: string; const AValue: TSouffleValue);
+    property ModuleExports: TDictionary<string, TSouffleValue> read FExports;
+    property VM: TSouffleVM read FVM write FVM;
+    property Engine: TObject read FEngine write FEngine;
+  end;
+
+implementation
+
+uses
+  Math,
+  SysUtils,
+
+  Goccia.Arguments.Collection,
+  Goccia.Engine,
+  Goccia.Evaluator,
+  Goccia.Interpreter,
+  Goccia.Values.ArrayValue,
+  Goccia.Values.ClassHelper,
+  Goccia.Values.ClassValue,
+  Goccia.Values.FunctionBase,
+  Goccia.Values.ObjectValue;
+
+type
+  TGocciaSouffleClosureBridge = class(TGocciaFunctionBase)
+  private
+    FClosure: TSouffleClosure;
+    FRuntime: TGocciaRuntimeOperations;
+  protected
+    function GetFunctionLength: Integer; override;
+    function GetFunctionName: string; override;
+  public
+    constructor Create(const AClosure: TSouffleClosure;
+      const ARuntime: TGocciaRuntimeOperations);
+    function Call(const AArguments: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
+  end;
+
+{ TGocciaSouffleClosureBridge }
+
+constructor TGocciaSouffleClosureBridge.Create(
+  const AClosure: TSouffleClosure;
+  const ARuntime: TGocciaRuntimeOperations);
+begin
+  inherited Create;
+  FClosure := AClosure;
+  FRuntime := ARuntime;
+end;
+
+function TGocciaSouffleClosureBridge.GetFunctionLength: Integer;
+begin
+  Result := FClosure.Prototype.ParameterCount;
+end;
+
+function TGocciaSouffleClosureBridge.GetFunctionName: string;
+begin
+  Result := FClosure.Prototype.Name;
+end;
+
+function TGocciaSouffleClosureBridge.Call(
+  const AArguments: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Args: array of TSouffleValue;
+  I: Integer;
+  SouffleResult: TSouffleValue;
+begin
+  SetLength(Args, AArguments.Length);
+  for I := 0 to AArguments.Length - 1 do
+    Args[I] := FRuntime.ToSouffleValue(AArguments.GetElement(I));
+
+  SouffleResult := FRuntime.VM.ExecuteFunction(FClosure, Args);
+  Result := FRuntime.UnwrapToGocciaValue(SouffleResult);
+end;
+
+{ TGocciaWrappedValue }
+
+constructor TGocciaWrappedValue.Create(const AValue: TGocciaValue);
+begin
+  inherited Create(GOCCIA_HEAP_WRAPPED);
+  FValue := AValue;
+end;
+
+procedure TGocciaWrappedValue.MarkReferences;
+begin
+  // Wrapped GocciaValue is managed by Goccia's own GC
+end;
+
+function TGocciaWrappedValue.DebugString: string;
+begin
+  if Assigned(FValue) then
+    Result := '[Wrapped: ' + FValue.ToStringLiteral.Value + ']'
+  else
+    Result := '[Wrapped: nil]';
+end;
+
+{ TGocciaRuntimeOperations }
+
+constructor TGocciaRuntimeOperations.Create;
+begin
+  inherited Create;
+  FGlobals := TDictionary<string, TSouffleValue>.Create;
+  FExports := TDictionary<string, TSouffleValue>.Create;
+  FVM := nil;
+  FGlobals.AddOrSetValue('null',
+    WrapGocciaValue(TGocciaNullLiteralValue.Create));
+end;
+
+destructor TGocciaRuntimeOperations.Destroy;
+begin
+  FGlobals.Free;
+  FExports.Free;
+  inherited;
+end;
+
+function TGocciaRuntimeOperations.WrapGocciaValue(
+  const AValue: TGocciaValue): TSouffleValue;
+begin
+  Result := SouffleReference(TGocciaWrappedValue.Create(AValue));
+end;
+
+function TGocciaRuntimeOperations.UnwrapToGocciaValue(
+  const AValue: TSouffleValue): TGocciaValue;
+begin
+  case AValue.Kind of
+    svkNil:
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    svkBoolean:
+      if AValue.AsBoolean then
+        Result := TGocciaBooleanLiteralValue.TrueValue
+      else
+        Result := TGocciaBooleanLiteralValue.FalseValue;
+    svkInteger:
+      Result := TGocciaNumberLiteralValue.Create(AValue.AsInteger * 1.0);
+    svkFloat:
+      Result := TGocciaNumberLiteralValue.Create(AValue.AsFloat);
+    svkReference:
+      if AValue.AsReference is TGocciaWrappedValue then
+        Result := TGocciaWrappedValue(AValue.AsReference).Value
+      else if AValue.AsReference is TSouffleString then
+        Result := TGocciaStringLiteralValue.Create(
+          TSouffleString(AValue.AsReference).Value)
+      else if (AValue.AsReference is TSouffleClosure) and Assigned(FVM) then
+        Result := TGocciaSouffleClosureBridge.Create(
+          TSouffleClosure(AValue.AsReference), Self)
+      else
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  else
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  end;
+end;
+
+function TGocciaRuntimeOperations.ToSouffleValue(
+  const AValue: TGocciaValue): TSouffleValue;
+var
+  NumVal: TGocciaNumberLiteralValue;
+begin
+  if AValue is TGocciaUndefinedLiteralValue then
+    Result := SouffleNil
+  else if AValue is TGocciaNullLiteralValue then
+    Result := SouffleNil
+  else if AValue is TGocciaBooleanLiteralValue then
+    Result := SouffleBoolean(TGocciaBooleanLiteralValue(AValue).Value)
+  else if AValue is TGocciaNumberLiteralValue then
+  begin
+    NumVal := TGocciaNumberLiteralValue(AValue);
+    if NumVal.IsNaN then
+      Result := SouffleFloat(NaN)
+    else if NumVal.IsInfinite then
+    begin
+      if NumVal.IsNegativeInfinity then
+        Result := SouffleFloat(NegInfinity)
+      else
+        Result := SouffleFloat(Infinity);
+    end
+    else if (Frac(NumVal.Value) = 0.0)
+       and (NumVal.Value >= Low(Int64) * 1.0)
+       and (NumVal.Value <= High(Int64) * 1.0) then
+      Result := SouffleInteger(Trunc(NumVal.Value))
+    else
+      Result := SouffleFloat(NumVal.Value);
+  end
+  else if AValue is TGocciaStringLiteralValue then
+    Result := SouffleReference(
+      TSouffleString.Create(TGocciaStringLiteralValue(AValue).Value))
+  else
+    Result := WrapGocciaValue(AValue);
+end;
+
+{ Arithmetic }
+
+function TGocciaRuntimeOperations.Add(const A, B: TSouffleValue): TSouffleValue;
+begin
+  if SouffleIsInteger(A) and SouffleIsInteger(B) then
+    Result := SouffleInteger(A.AsInteger + B.AsInteger)
+  else if SouffleIsNumeric(A) and SouffleIsNumeric(B) then
+    Result := SouffleFloat(SouffleAsNumber(A) + SouffleAsNumber(B))
+  else if (A.Kind = svkReference) and (A.AsReference is TSouffleString) then
+    Result := SouffleReference(TSouffleString.Create(
+      TSouffleString(A.AsReference).Value + SouffleValueToString(B)))
+  else if (B.Kind = svkReference) and (B.AsReference is TSouffleString) then
+    Result := SouffleReference(TSouffleString.Create(
+      SouffleValueToString(A) + TSouffleString(B.AsReference).Value))
+  else
+    Result := SouffleFloat(SouffleAsNumber(A) + SouffleAsNumber(B));
+end;
+
+function TGocciaRuntimeOperations.Subtract(const A, B: TSouffleValue): TSouffleValue;
+begin
+  if SouffleIsInteger(A) and SouffleIsInteger(B) then
+    Result := SouffleInteger(A.AsInteger - B.AsInteger)
+  else
+    Result := SouffleFloat(SouffleAsNumber(A) - SouffleAsNumber(B));
+end;
+
+function TGocciaRuntimeOperations.Multiply(const A, B: TSouffleValue): TSouffleValue;
+begin
+  if SouffleIsInteger(A) and SouffleIsInteger(B) then
+    Result := SouffleInteger(A.AsInteger * B.AsInteger)
+  else
+    Result := SouffleFloat(SouffleAsNumber(A) * SouffleAsNumber(B));
+end;
+
+function TGocciaRuntimeOperations.Divide(const A, B: TSouffleValue): TSouffleValue;
+var
+  Divisor: Double;
+begin
+  Divisor := SouffleAsNumber(B);
+  if Divisor = 0.0 then
+  begin
+    if SouffleAsNumber(A) = 0.0 then
+      Result := SouffleFloat(NaN)
+    else if SouffleAsNumber(A) > 0 then
+      Result := SouffleFloat(Infinity)
+    else
+      Result := SouffleFloat(NegInfinity);
+  end
+  else
+    Result := SouffleFloat(SouffleAsNumber(A) / Divisor);
+end;
+
+function TGocciaRuntimeOperations.Modulo(const A, B: TSouffleValue): TSouffleValue;
+var
+  Divisor: Double;
+begin
+  if SouffleIsInteger(A) and SouffleIsInteger(B) and (B.AsInteger <> 0) then
+    Result := SouffleInteger(A.AsInteger mod B.AsInteger)
+  else
+  begin
+    Divisor := SouffleAsNumber(B);
+    if Divisor = 0.0 then
+      Result := SouffleFloat(NaN)
+    else
+      Result := SouffleFloat(FMod(SouffleAsNumber(A), Divisor));
+  end;
+end;
+
+function TGocciaRuntimeOperations.Power(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleFloat(Math.Power(SouffleAsNumber(A), SouffleAsNumber(B)));
+end;
+
+function TGocciaRuntimeOperations.Negate(const A: TSouffleValue): TSouffleValue;
+begin
+  if SouffleIsInteger(A) then
+    Result := SouffleInteger(-A.AsInteger)
+  else
+    Result := SouffleFloat(-SouffleAsNumber(A));
+end;
+
+{ Bitwise }
+
+function TGocciaRuntimeOperations.BitwiseAnd(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleInteger(Int32(Trunc(SouffleAsNumber(A))) and
+    Int32(Trunc(SouffleAsNumber(B))));
+end;
+
+function TGocciaRuntimeOperations.BitwiseOr(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleInteger(Int32(Trunc(SouffleAsNumber(A))) or
+    Int32(Trunc(SouffleAsNumber(B))));
+end;
+
+function TGocciaRuntimeOperations.BitwiseXor(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleInteger(Int32(Trunc(SouffleAsNumber(A))) xor
+    Int32(Trunc(SouffleAsNumber(B))));
+end;
+
+function TGocciaRuntimeOperations.ShiftLeft(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleInteger(Int32(Trunc(SouffleAsNumber(A))) shl
+    (Int32(Trunc(SouffleAsNumber(B))) and $1F));
+end;
+
+function TGocciaRuntimeOperations.ShiftRight(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleInteger(Int32(Trunc(SouffleAsNumber(A))) shr
+    (Int32(Trunc(SouffleAsNumber(B))) and $1F));
+end;
+
+function TGocciaRuntimeOperations.UnsignedShiftRight(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleInteger(Int64(UInt32(Trunc(SouffleAsNumber(A))) shr
+    (Int32(Trunc(SouffleAsNumber(B))) and $1F)));
+end;
+
+function TGocciaRuntimeOperations.BitwiseNot(const A: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleInteger(not Int32(Trunc(SouffleAsNumber(A))));
+end;
+
+{ Comparison }
+
+function TGocciaRuntimeOperations.Equal(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleBoolean(SouffleValuesEqual(A, B));
+end;
+
+function TGocciaRuntimeOperations.NotEqual(const A, B: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleBoolean(not SouffleValuesEqual(A, B));
+end;
+
+function TGocciaRuntimeOperations.LessThan(const A, B: TSouffleValue): TSouffleValue;
+begin
+  if SouffleIsNumeric(A) and SouffleIsNumeric(B) then
+    Result := SouffleBoolean(SouffleAsNumber(A) < SouffleAsNumber(B))
+  else
+    Result := SouffleBoolean(SouffleValueToString(A) < SouffleValueToString(B));
+end;
+
+function TGocciaRuntimeOperations.GreaterThan(const A, B: TSouffleValue): TSouffleValue;
+begin
+  if SouffleIsNumeric(A) and SouffleIsNumeric(B) then
+    Result := SouffleBoolean(SouffleAsNumber(A) > SouffleAsNumber(B))
+  else
+    Result := SouffleBoolean(SouffleValueToString(A) > SouffleValueToString(B));
+end;
+
+function TGocciaRuntimeOperations.LessThanOrEqual(const A, B: TSouffleValue): TSouffleValue;
+begin
+  if SouffleIsNumeric(A) and SouffleIsNumeric(B) then
+    Result := SouffleBoolean(SouffleAsNumber(A) <= SouffleAsNumber(B))
+  else
+    Result := SouffleBoolean(SouffleValueToString(A) <= SouffleValueToString(B));
+end;
+
+function TGocciaRuntimeOperations.GreaterThanOrEqual(const A, B: TSouffleValue): TSouffleValue;
+begin
+  if SouffleIsNumeric(A) and SouffleIsNumeric(B) then
+    Result := SouffleBoolean(SouffleAsNumber(A) >= SouffleAsNumber(B))
+  else
+    Result := SouffleBoolean(SouffleValueToString(A) >= SouffleValueToString(B));
+end;
+
+{ Logical / Type }
+
+function TGocciaRuntimeOperations.LogicalNot(const A: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleBoolean(not SouffleIsTrue(A));
+end;
+
+function TGocciaRuntimeOperations.TypeOf(const A: TSouffleValue): TSouffleValue;
+var
+  GocciaVal: TGocciaValue;
+  TypeStr: string;
+begin
+  GocciaVal := UnwrapToGocciaValue(A);
+  TypeStr := GocciaVal.TypeOf;
+  Result := SouffleReference(TSouffleString.Create(TypeStr));
+end;
+
+function TGocciaRuntimeOperations.IsInstance(const A, B: TSouffleValue): TSouffleValue;
+var
+  GocciaObj, GocciaClass: TGocciaValue;
+begin
+  GocciaObj := UnwrapToGocciaValue(A);
+  GocciaClass := UnwrapToGocciaValue(B);
+  if (GocciaObj is TGocciaInstanceValue) and (GocciaClass is TGocciaClassValue) then
+    Result := SouffleBoolean(
+      TGocciaInstanceValue(GocciaObj).IsInstanceOf(TGocciaClassValue(GocciaClass)))
+  else
+    Result := SouffleBoolean(False);
+end;
+
+function TGocciaRuntimeOperations.HasProperty(
+  const AObject, AKey: TSouffleValue): TSouffleValue;
+var
+  KeyStr: string;
+  Prop: TGocciaValue;
+begin
+  KeyStr := SouffleValueToString(AKey);
+  if SouffleIsReference(AObject) and
+     (AObject.AsReference is TGocciaWrappedValue) then
+  begin
+    Prop := TGocciaWrappedValue(AObject.AsReference).Value.GetProperty(KeyStr);
+    Result := SouffleBoolean(Assigned(Prop) and
+      not (Prop is TGocciaUndefinedLiteralValue));
+  end
+  else
+    Result := SouffleBoolean(False);
+end;
+
+function TGocciaRuntimeOperations.ToBoolean(const A: TSouffleValue): TSouffleValue;
+begin
+  Result := SouffleBoolean(SouffleIsTrue(A));
+end;
+
+{ Compound creation }
+
+function TGocciaRuntimeOperations.CreateCompound(const ATypeTag: UInt8): TSouffleValue;
+var
+  GocciaVal: TGocciaValue;
+begin
+  case ATypeTag of
+    1: GocciaVal := TGocciaArrayValue.Create;
+  else
+    GocciaVal := TGocciaObjectValue.Create;
+  end;
+  Result := WrapGocciaValue(GocciaVal);
+end;
+
+procedure TGocciaRuntimeOperations.InitField(const ACompound: TSouffleValue;
+  const AKey: string; const AValue: TSouffleValue);
+var
+  Wrapped: TGocciaValue;
+  Val: TGocciaValue;
+begin
+  if SouffleIsReference(ACompound) and
+     (ACompound.AsReference is TGocciaWrappedValue) then
+  begin
+    Wrapped := TGocciaWrappedValue(ACompound.AsReference).Value;
+    Val := UnwrapToGocciaValue(AValue);
+    Wrapped.SetProperty(AKey, Val);
+  end;
+end;
+
+procedure TGocciaRuntimeOperations.InitIndex(const ACompound: TSouffleValue;
+  const AIndex: TSouffleValue; const AValue: TSouffleValue);
+var
+  Wrapped: TGocciaValue;
+  Val: TGocciaValue;
+begin
+  if SouffleIsReference(ACompound) and
+     (ACompound.AsReference is TGocciaWrappedValue) then
+  begin
+    Wrapped := TGocciaWrappedValue(ACompound.AsReference).Value;
+    Val := UnwrapToGocciaValue(AValue);
+    if Wrapped is TGocciaArrayValue then
+      TGocciaArrayValue(Wrapped).Elements.Add(Val)
+    else
+      Wrapped.SetProperty(SouffleValueToString(AIndex), Val);
+  end;
+end;
+
+{ Property access }
+
+function TGocciaRuntimeOperations.GetProperty(const AObject: TSouffleValue;
+  const AKey: string): TSouffleValue;
+var
+  GocciaObj, Prop: TGocciaValue;
+  Boxed: TGocciaObjectValue;
+begin
+  GocciaObj := UnwrapToGocciaValue(AObject);
+  Prop := GocciaObj.GetProperty(AKey);
+
+  if not Assigned(Prop) then
+  begin
+    Boxed := GocciaObj.Box;
+    if Assigned(Boxed) then
+      Prop := Boxed.GetProperty(AKey);
+  end;
+
+  if Assigned(Prop) then
+    Result := ToSouffleValue(Prop)
+  else
+    Result := SouffleNil;
+end;
+
+procedure TGocciaRuntimeOperations.SetProperty(const AObject: TSouffleValue;
+  const AKey: string; const AValue: TSouffleValue);
+var
+  GocciaObj, Val: TGocciaValue;
+begin
+  if SouffleIsReference(AObject) and
+     (AObject.AsReference is TGocciaWrappedValue) then
+  begin
+    GocciaObj := TGocciaWrappedValue(AObject.AsReference).Value;
+    Val := UnwrapToGocciaValue(AValue);
+    GocciaObj.SetProperty(AKey, Val);
+  end;
+end;
+
+function TGocciaRuntimeOperations.GetIndex(
+  const AObject, AKey: TSouffleValue): TSouffleValue;
+begin
+  Result := GetProperty(AObject, SouffleValueToString(AKey));
+end;
+
+procedure TGocciaRuntimeOperations.SetIndex(const AObject: TSouffleValue;
+  const AKey, AValue: TSouffleValue);
+begin
+  SetProperty(AObject, SouffleValueToString(AKey), AValue);
+end;
+
+function TGocciaRuntimeOperations.DeleteProperty(const AObject: TSouffleValue;
+  const AKey: string): TSouffleValue;
+begin
+  Result := SouffleBoolean(True);
+end;
+
+{ Invocation -- delegates to GocciaScript's existing call mechanism }
+
+function TGocciaRuntimeOperations.Invoke(const ACallee: TSouffleValue;
+  const AArgs: PSouffleValue; const AArgCount: Integer;
+  const AReceiver: TSouffleValue): TSouffleValue;
+var
+  GocciaCallee, GocciaReceiver, GocciaResult: TGocciaValue;
+  Args: TGocciaArgumentsCollection;
+  I: Integer;
+begin
+  GocciaCallee := UnwrapToGocciaValue(ACallee);
+  if not GocciaCallee.IsCallable then
+  begin
+    Result := SouffleNil;
+    Exit;
+  end;
+
+  Args := TGocciaArgumentsCollection.Create;
+  try
+    for I := 0 to AArgCount - 1 do
+      Args.Add(UnwrapToGocciaValue(PSouffleValue(PByte(AArgs) + I * SizeOf(TSouffleValue))^));
+
+    GocciaReceiver := UnwrapToGocciaValue(AReceiver);
+    if GocciaCallee is TGocciaFunctionBase then
+      GocciaResult := TGocciaFunctionBase(GocciaCallee).Call(Args, GocciaReceiver)
+    else if GocciaCallee is TGocciaClassValue then
+      GocciaResult := TGocciaClassValue(GocciaCallee).Call(Args, GocciaReceiver)
+    else
+      GocciaResult := nil;
+
+    if Assigned(GocciaResult) then
+      Result := ToSouffleValue(GocciaResult)
+    else
+      Result := SouffleNil;
+  finally
+    Args.Free;
+  end;
+end;
+
+function TGocciaRuntimeOperations.Construct(const AConstructor: TSouffleValue;
+  const AArgs: PSouffleValue; const AArgCount: Integer): TSouffleValue;
+var
+  GocciaConstructor, GocciaResult: TGocciaValue;
+  Args: TGocciaArgumentsCollection;
+  Context: TGocciaEvaluationContext;
+  I: Integer;
+begin
+  GocciaConstructor := UnwrapToGocciaValue(AConstructor);
+
+  if not GocciaConstructor.IsCallable then
+  begin
+    Result := SouffleNil;
+    Exit;
+  end;
+
+  Args := TGocciaArgumentsCollection.Create;
+  try
+    for I := 0 to AArgCount - 1 do
+      Args.Add(UnwrapToGocciaValue(PSouffleValue(PByte(AArgs) + I * SizeOf(TSouffleValue))^));
+
+    if (GocciaConstructor is TGocciaClassValue) and Assigned(FEngine) then
+    begin
+      Context := TGocciaEngine(FEngine).Interpreter.CreateEvaluationContext;
+      GocciaResult := InstantiateClass(
+        TGocciaClassValue(GocciaConstructor), Args, Context);
+    end
+    else if GocciaConstructor is TGocciaFunctionBase then
+      GocciaResult := TGocciaFunctionBase(GocciaConstructor).Call(Args, nil)
+    else
+      GocciaResult := nil;
+
+    if Assigned(GocciaResult) then
+      Result := ToSouffleValue(GocciaResult)
+    else
+      Result := SouffleNil;
+  finally
+    Args.Free;
+  end;
+end;
+
+{ Iteration }
+
+function TGocciaRuntimeOperations.GetIterator(
+  const AIterable: TSouffleValue): TSouffleValue;
+begin
+  Result := AIterable;
+end;
+
+function TGocciaRuntimeOperations.IteratorNext(const AIterator: TSouffleValue;
+  out ADone: Boolean): TSouffleValue;
+begin
+  ADone := True;
+  Result := SouffleNil;
+end;
+
+procedure TGocciaRuntimeOperations.SpreadInto(
+  const ATarget, ASource: TSouffleValue);
+begin
+  // Placeholder for spread implementation
+end;
+
+{ Modules }
+
+function TGocciaRuntimeOperations.ImportModule(const APath: string): TSouffleValue;
+begin
+  Result := SouffleNil;
+end;
+
+procedure TGocciaRuntimeOperations.ExportBinding(const AValue: TSouffleValue;
+  const AName: string);
+begin
+  FExports.AddOrSetValue(AName, AValue);
+end;
+
+{ Async }
+
+function TGocciaRuntimeOperations.AwaitValue(const AValue: TSouffleValue): TSouffleValue;
+begin
+  Result := AValue;
+end;
+
+{ Globals }
+
+function TGocciaRuntimeOperations.GetGlobal(const AName: string): TSouffleValue;
+var
+  Value: TSouffleValue;
+begin
+  if FGlobals.TryGetValue(AName, Value) then
+    Result := Value
+  else
+    Result := SouffleNil;
+end;
+
+procedure TGocciaRuntimeOperations.SetGlobal(const AName: string;
+  const AValue: TSouffleValue);
+begin
+  FGlobals.AddOrSetValue(AName, AValue);
+end;
+
+procedure TGocciaRuntimeOperations.RegisterGlobal(const AName: string;
+  const AValue: TSouffleValue);
+begin
+  FGlobals.AddOrSetValue(AName, AValue);
+end;
+
+end.

--- a/units/Goccia.Runtime.Operations.pas
+++ b/units/Goccia.Runtime.Operations.pas
@@ -195,7 +195,9 @@ end;
 
 procedure TGocciaWrappedValue.MarkReferences;
 begin
-  // Wrapped GocciaValue is managed by Goccia's own GC
+  inherited;
+  if Assigned(FValue) then
+    FValue.MarkReferences;
 end;
 
 function TGocciaWrappedValue.DebugString: string;
@@ -619,8 +621,21 @@ end;
 
 function TGocciaRuntimeOperations.DeleteProperty(const AObject: TSouffleValue;
   const AKey: string): TSouffleValue;
+var
+  GocciaObj: TGocciaValue;
 begin
-  Result := SouffleBoolean(True);
+  if SouffleIsReference(AObject) and Assigned(AObject.AsReference) and
+     (AObject.AsReference is TGocciaWrappedValue) then
+  begin
+    GocciaObj := TGocciaWrappedValue(AObject.AsReference).Value;
+    if GocciaObj is TGocciaObjectValue then
+    begin
+      TGocciaObjectValue(GocciaObj).DeleteProperty(AKey);
+      Result := SouffleBoolean(True);
+      Exit;
+    end;
+  end;
+  Result := SouffleBoolean(False);
 end;
 
 { Invocation -- delegates to GocciaScript's existing call mechanism }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Souffle VM bytecode backend with --mode=bytecode, .sbc execution, and --emit to write bytecode files; script/test/benchmark runners support interpreted or bytecode modes and mode-specific CLI options.
  * Recognizes .sbc as a supported bytecode extension.

* **Documentation**
  * Added comprehensive Souffle VM docs and updated README, architecture, build-system, and design-decision docs.

* **Tests**
  * Added compiler and bytecode tests including serialization round‑trip checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->