### PR TITLE
De-couple control flow from exception flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,8 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | Lexer | `Goccia.Lexer.pas` | Source → tokens |
 | Parser | `Goccia.Parser.pas` | Tokens → AST (including `TGocciaForOfStatement`, `TGocciaForAwaitOfStatement` in `Goccia.AST.Statements.pas`) |
 | Interpreter | `Goccia.Interpreter.pas` | AST execution, module loading, scope ownership |
-| Evaluator | `Goccia.Evaluator.pas` | Pure AST evaluation (+ sub-modules: Arithmetic, Bitwise, Comparison, Assignment, TypeOperations) |
+| Evaluator | `Goccia.Evaluator.pas` | Pure AST evaluation (+ sub-modules: Arithmetic, Bitwise, Comparison, Assignment, TypeOperations). Statement-level functions (`Evaluate`, `EvaluateStatement`, `EvaluateStatements`, `EvaluateBlock`, `EvaluateIf`, `EvaluateTry`, `EvaluateSwitch`, `EvaluateForOf`, `EvaluateForAwaitOf`) return `TGocciaControlFlow` records |
+| Control Flow | `Goccia.ControlFlow.pas` | `TGocciaControlFlow` result record (`cfkNormal`, `cfkReturn`, `cfkBreak`) for exception-free propagation of `return` and `break` signals through the interpreter |
 | Scope | `Goccia.Scope.pas` | Lexical scoping, variable bindings, TDZ, VMT-based chain-walking |
 | Reserved Keywords | `Goccia.Keywords.Reserved.pas` | Reserved JavaScript keyword string constants (`break`, `class`, `const`, `this`, etc.) |
 | Contextual Keywords | `Goccia.Keywords.Contextual.pas` | Contextual keyword string constants (`async`, `get`, `set`, `type`, `interface`, `implements`, etc.) |
@@ -439,7 +440,7 @@ This pattern is used in `TGocciaNumberLiteralValue.GetIsNegativeZero` and `IsNeg
 - **Parser combinator** for binary expressions (`ParseBinaryExpression` shared helper)
 - **Recursive descent** for parsing
 - **Mark-and-sweep** for garbage collection (`TGocciaGarbageCollector`)
-- **Shared helpers** for evaluator deduplication (`EvaluateStatementsSafe`, `SpreadIterableInto`, `EvaluateSimpleNumericBinaryOp`)
+- **Shared helpers** for evaluator deduplication (`EvaluateStatements`, `SpreadIterableInto`, `EvaluateSimpleNumericBinaryOp`)
 
 ## Value System
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,7 +197,7 @@ The largest component. Implements the actual semantics of the language as **pure
 
 | Module | Responsibility |
 |--------|---------------|
-| `Goccia.Evaluator.pas` | Core dispatch, expressions, statements, classes, function name inference, `EvaluateStatementsSafe`, spread helpers |
+| `Goccia.Evaluator.pas` | Core dispatch, expressions, statements, classes, function name inference, `EvaluateStatements`, spread helpers |
 | `Goccia.Evaluator.Arithmetic.pas` | `+` (uses `ToPrimitive`), `-`, `*`, `**`, `/`, `%` (float), compound assignment dispatch. Division and exponentiation use `IsActualZero` and special-value enum checks for IEEE-754 correctness with `NaN`/`±Infinity`/`-0` |
 | `Goccia.Evaluator.Bitwise.pas` | `&`, `\|`, `^`, `<<`, `>>`, `>>>` |
 | `Goccia.Evaluator.Comparison.pas` | `===`, `!==`, `<`, `>`, `<=`, `>=` |
@@ -208,7 +208,7 @@ The largest component. Implements the actual semantics of the language as **pure
 
 Shared helper functions reduce duplication across the evaluator:
 
-- **`EvaluateStatementsSafe`** — Executes a list of AST nodes with standardized exception handling: re-raises GocciaScript signals (`TGocciaReturnValue`, `TGocciaThrowValue`, `TGocciaBreakSignal`, type/reference/runtime errors) and wraps unexpected Pascal exceptions. Used by `EvaluateBlock`, `EvaluateTry` (try/catch/finally blocks), and other statement-list contexts.
+- **`EvaluateStatements`** — Executes a list of AST nodes, returning `TGocciaControlFlow`. Propagates `cfkReturn` and `cfkBreak` signals by exiting early when `Result.Kind <> cfkNormal`. `TGocciaThrowValue` exceptions propagate naturally without interception. Used by `EvaluateBlock`, `EvaluateTry` (try/catch/finally blocks), and other statement-list contexts.
 - **`SpreadIterableInto` / `SpreadIterableIntoArgs`** — Shared spread expansion logic for array, string, Set, and Map values. Used by `EvaluateCall`, `EvaluateArray`, and `EvaluateObject` to handle `...spread` expressions uniformly.
 - **`CopyStatementList`** — Creates a non-owning copy of an AST statement list (used by getters, setters, arrow functions, and class methods to avoid ownership conflicts).
 - **`DefinePropertyOnValue`** — Defines a property with a full descriptor on objects, falling back to `SetProperty` for non-objects.

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -96,7 +96,7 @@ end;
 // TC39 Set Methods §2.1 Set.prototype.union(other)
 ```
 
-**What not to annotate:** Internal GocciaScript helpers that don't correspond to a spec algorithm (e.g., `EvaluateStatementsSafe`, `SpreadIterableInto`, Pascal-specific utilities).
+**What not to annotate:** Internal GocciaScript helpers that don't correspond to a spec algorithm (e.g., `EvaluateStatements`, `SpreadIterableInto`, Pascal-specific utilities).
 
 ### No Abbreviations
 
@@ -435,7 +435,7 @@ Methods that return `Self` for chaining (e.g., `Set.add`, `Map.set`) must return
 
 ### Evaluator Helper Patterns
 
-**`EvaluateStatementsSafe`** — Wraps statement list execution with standardized exception handling (re-raises GocciaScript signals, wraps unexpected exceptions). Used wherever a list of AST nodes is evaluated in sequence.
+**`EvaluateStatements`** — Evaluates a list of AST nodes in sequence, returning `TGocciaControlFlow`. Exits early when `Result.Kind <> cfkNormal` to propagate `return` and `break` signals. `TGocciaThrowValue` exceptions propagate naturally without interception.
 
 **`SpreadIterableInto` / `SpreadIterableIntoArgs`** — Unified spread expansion for arrays, strings, sets, and maps. Used by `EvaluateCall`, `EvaluateArray`, and `EvaluateObject`.
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -211,11 +211,11 @@ GocciaScript uses a layered error approach:
 2. **Runtime errors** use a callback pattern (`OnError` in `TGocciaEvaluationContext`) — this keeps evaluator functions pure.
 3. **JavaScript-level errors** use `TGocciaThrowValue` for `throw` statements and `try/catch` — these flow through the evaluator's return path.
 4. **`try-finally` without `catch`** — The evaluator wraps the Pascal `try...except` in a Pascal `try...finally` to guarantee the JS `finally` block runs before exceptions propagate, even when no `catch` clause exists.
-5. **`break` in `switch`** — Uses `TGocciaBreakSignal` (a Pascal exception) to exit `switch` cases. The `EvaluateSwitch` function catches this signal to implement JavaScript's fall-through-until-break semantics.
+5. **`break` and `return`** — Use `TGocciaControlFlow` result records (`cfkBreak`, `cfkReturn`) instead of Pascal exceptions. Statement-level evaluator functions return `TGocciaControlFlow`, and callers check `Result.Kind` to propagate signals. This eliminates `FPC_SETJMP` overhead from the interpreter's hot path (function calls, loop iterations, switch statements). `EvaluateSwitch` checks `CF.Kind = cfkBreak` after each case statement to implement JavaScript's fall-through-until-break semantics.
 
 **Centralized error construction** — `Goccia.Values.ErrorHelper.pas` provides `ThrowTypeError`, `ThrowRangeError`, `ThrowReferenceError`, and `CreateErrorObject` helpers. All error throw sites across the codebase use these helpers instead of manually building error objects, reducing duplication and ensuring consistent error formatting.
 
-**Why not exceptions everywhere?** Pascal exceptions disrupt the pure-function model of the evaluator. The callback pattern allows the evaluator to signal errors without unwinding the call stack, making control flow explicit. The exceptions to this rule (`TGocciaThrowValue`, `TGocciaReturnValue`, `TGocciaBreakSignal`) are used only for non-local exits where unwinding is the intended behavior.
+**Why not exceptions everywhere?** Pascal exceptions disrupt the pure-function model of the evaluator. The callback pattern allows the evaluator to signal errors without unwinding the call stack, making control flow explicit. `TGocciaThrowValue` is the only exception used for non-local exits — it propagates naturally through the call stack to `EvaluateTry` (JS `try...catch`) or the top-level handler. `return` and `break` use lightweight `TGocciaControlFlow` records instead of exceptions, avoiding `setjmp`/`longjmp` overhead on every function call and loop iteration.
 
 ## Mark-and-Sweep Garbage Collector
 

--- a/units/Goccia.ControlFlow.pas
+++ b/units/Goccia.ControlFlow.pas
@@ -1,0 +1,41 @@
+unit Goccia.ControlFlow;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.Primitives;
+
+type
+  TGocciaControlFlowKind = (cfkNormal, cfkReturn, cfkBreak);
+
+  TGocciaControlFlow = record
+    Kind: TGocciaControlFlowKind;
+    Value: TGocciaValue;
+    class function Normal(const AValue: TGocciaValue): TGocciaControlFlow; static; inline;
+    class function Return(const AValue: TGocciaValue): TGocciaControlFlow; static; inline;
+    class function Break: TGocciaControlFlow; static; inline;
+  end;
+
+implementation
+
+class function TGocciaControlFlow.Normal(const AValue: TGocciaValue): TGocciaControlFlow;
+begin
+  Result.Kind := cfkNormal;
+  Result.Value := AValue;
+end;
+
+class function TGocciaControlFlow.Return(const AValue: TGocciaValue): TGocciaControlFlow;
+begin
+  Result.Kind := cfkReturn;
+  Result.Value := AValue;
+end;
+
+class function TGocciaControlFlow.Break: TGocciaControlFlow;
+begin
+  Result.Kind := cfkBreak;
+  Result.Value := nil;
+end;
+
+end.

--- a/units/Goccia.ControlFlow.pas
+++ b/units/Goccia.ControlFlow.pas
@@ -10,32 +10,49 @@ uses
 type
   TGocciaControlFlowKind = (cfkNormal, cfkReturn, cfkBreak);
 
+  // Tagged-pointer representation: the control flow kind is encoded in the low
+  // 2 bits of the value pointer. TGocciaValue instances are always 16-byte
+  // aligned on 64-bit platforms, so the low 4 bits are guaranteed to be zero.
+  // This makes the record 8 bytes (single register) with zero overhead for the
+  // Normal case — Normal(value) is just the raw pointer, no bit manipulation.
   TGocciaControlFlow = record
-    Kind: TGocciaControlFlowKind;
-    Value: TGocciaValue;
+  private
+    FBits: PtrUInt;
+    function GetKind: TGocciaControlFlowKind; inline;
+    function GetValue: TGocciaValue; inline;
+  public
     class function Normal(const AValue: TGocciaValue): TGocciaControlFlow; static; inline;
     class function Return(const AValue: TGocciaValue): TGocciaControlFlow; static; inline;
     class function Break: TGocciaControlFlow; static; inline;
+    property Kind: TGocciaControlFlowKind read GetKind;
+    property Value: TGocciaValue read GetValue;
   end;
 
 implementation
 
+function TGocciaControlFlow.GetKind: TGocciaControlFlowKind;
+begin
+  Result := TGocciaControlFlowKind(FBits and 3);
+end;
+
+function TGocciaControlFlow.GetValue: TGocciaValue;
+begin
+  Result := TGocciaValue(FBits and not PtrUInt(3));
+end;
+
 class function TGocciaControlFlow.Normal(const AValue: TGocciaValue): TGocciaControlFlow;
 begin
-  Result.Kind := cfkNormal;
-  Result.Value := AValue;
+  Result.FBits := PtrUInt(AValue);
 end;
 
 class function TGocciaControlFlow.Return(const AValue: TGocciaValue): TGocciaControlFlow;
 begin
-  Result.Kind := cfkReturn;
-  Result.Value := AValue;
+  Result.FBits := PtrUInt(AValue) or 1;
 end;
 
 class function TGocciaControlFlow.Break: TGocciaControlFlow;
 begin
-  Result.Kind := cfkBreak;
-  Result.Value := nil;
+  Result.FBits := 2;
 end;
 
 end.

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -150,10 +150,16 @@ function EvaluateStatements(const ANodes: TObjectList<TGocciaASTNode>; const ACo
 var
   I: Integer;
 begin
+  if Assigned(AContext.OnError) and not Assigned(AContext.Scope.OnError) then
+    AContext.Scope.OnError := AContext.OnError;
+
   Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
   for I := 0 to ANodes.Count - 1 do
   begin
-    Result := Evaluate(ANodes[I], AContext);
+    if ANodes[I] is TGocciaExpression then
+      Result := TGocciaControlFlow.Normal(EvaluateExpression(TGocciaExpression(ANodes[I]), AContext))
+    else
+      Result := EvaluateStatement(TGocciaStatement(ANodes[I]), AContext);
     if Result.Kind <> cfkNormal then Exit;
   end;
 end;
@@ -1419,7 +1425,7 @@ begin
       else
         IterScope.DefineLexicalBinding(AForOfStatement.BindingName, CurrentValue, DeclarationType);
 
-      CF := Evaluate(AForOfStatement.Body, IterContext);
+      CF := EvaluateStatement(AForOfStatement.Body, IterContext);
       if CF.Kind = cfkBreak then Break;
       if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
 
@@ -1500,7 +1506,7 @@ begin
           else
             IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
 
-          CF := Evaluate(AForAwaitOfStatement.Body, IterContext);
+          CF := EvaluateStatement(AForAwaitOfStatement.Body, IterContext);
           if CF.Kind = cfkBreak then Break;
           if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
         end;
@@ -1536,7 +1542,7 @@ begin
         else
           IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
 
-        CF := Evaluate(AForAwaitOfStatement.Body, IterContext);
+        CF := EvaluateStatement(AForAwaitOfStatement.Body, IterContext);
         if CF.Kind = cfkBreak then Break;
         if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
 
@@ -1907,7 +1913,7 @@ begin
     begin
       for J := 0 to CaseClause.Consequent.Count - 1 do
       begin
-        CF := Evaluate(CaseClause.Consequent[J], AContext);
+        CF := EvaluateStatement(CaseClause.Consequent[J], AContext);
         if CF.Kind = cfkBreak then begin Done := True; Break; end;
         if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
         Result := CF;
@@ -1923,7 +1929,7 @@ begin
       CaseClause := ASwitchStatement.Cases[I];
       for J := 0 to CaseClause.Consequent.Count - 1 do
       begin
-        CF := Evaluate(CaseClause.Consequent[J], AContext);
+        CF := EvaluateStatement(CaseClause.Consequent[J], AContext);
         if CF.Kind = cfkBreak then begin Done := True; Break; end;
         if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
         Result := CF;

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -1724,14 +1724,21 @@ begin
   // Phase 2: Execute finally block (always runs)
   if Assigned(ATryStatement.FinallyBlock) then
   begin
-    FinallyCF := EvaluateStatements(ATryStatement.FinallyBlock.Nodes, AContext);
-    // Per JS semantics: finally's control flow overrides try/catch result AND pending throw
-    if FinallyCF.Kind <> cfkNormal then
-    begin
-      Result := FinallyCF;
-      Exit;
+    if HasUnhandledThrow and Assigned(TGocciaGarbageCollector.Instance) then
+      TGocciaGarbageCollector.Instance.AddTempRoot(ThrownValue);
+    try
+      FinallyCF := EvaluateStatements(ATryStatement.FinallyBlock.Nodes, AContext);
+      // Per JS semantics: finally's control flow overrides try/catch result AND pending throw
+      if FinallyCF.Kind <> cfkNormal then
+      begin
+        Result := FinallyCF;
+        Exit;
+      end;
+      // If finally throws (TGocciaThrowValue), it propagates naturally and overrides everything
+    finally
+      if HasUnhandledThrow and Assigned(TGocciaGarbageCollector.Instance) then
+        TGocciaGarbageCollector.Instance.RemoveTempRoot(ThrownValue);
     end;
-    // If finally throws (TGocciaThrowValue), it propagates naturally and overrides everything
   end;
 
   // Phase 3: Re-raise unhandled throw (if not overridden by finally)

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -11,6 +11,7 @@ uses
   Goccia.AST.Expressions,
   Goccia.AST.Node,
   Goccia.AST.Statements,
+  Goccia.ControlFlow,
   Goccia.Error.ThrowErrorCallback,
   Goccia.Modules,
   Goccia.Scope,
@@ -29,10 +30,10 @@ type
     CurrentFilePath: string;
   end;
 
-function Evaluate(const ANode: TGocciaASTNode; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function Evaluate(const ANode: TGocciaASTNode; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 function EvaluateExpression(const AExpression: TGocciaExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
-function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
-function EvaluateStatementsSafe(const ANodes: TObjectList<TGocciaASTNode>; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+function EvaluateStatements(const ANodes: TObjectList<TGocciaASTNode>; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 function EvaluateBinary(const ABinaryExpression: TGocciaBinaryExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateUnary(const AUnaryExpression: TGocciaUnaryExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateDelete(const AOperand: TGocciaExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
@@ -45,10 +46,10 @@ function EvaluateGetter(const AGetterExpression: TGocciaGetterExpression; const 
 function EvaluateSetter(const ASetterExpression: TGocciaSetterExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateArrowFunction(const AArrowFunctionExpression: TGocciaArrowFunctionExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateMethodExpression(const AMethodExpression: TGocciaMethodExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
-function EvaluateBlock(const ABlockStatement: TGocciaBlockStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
-function EvaluateIf(const AIfStatement: TGocciaIfStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
-function EvaluateTry(const ATryStatement: TGocciaTryStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
-function EvaluateSwitch(const ASwitchStatement: TGocciaSwitchStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateBlock(const ABlockStatement: TGocciaBlockStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+function EvaluateIf(const AIfStatement: TGocciaIfStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+function EvaluateTry(const ATryStatement: TGocciaTryStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+function EvaluateSwitch(const ASwitchStatement: TGocciaSwitchStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 function EvaluateClassMethod(const AClassMethod: TGocciaClassMethod; const AContext: TGocciaEvaluationContext; const ASuperClass: TGocciaValue = nil): TGocciaValue;
 function EvaluateClass(const AClassDeclaration: TGocciaClassDeclaration; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateClassExpression(const AClassExpression: TGocciaClassExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
@@ -65,8 +66,8 @@ function EvaluateTemplateLiteral(const ATemplateLiteralExpression: TGocciaTempla
 function EvaluateTemplateExpression(const AExpressionText: string; const AContext: TGocciaEvaluationContext; const ALine, AColumn: Integer): TGocciaValue;
 function EvaluateAwait(const AAwaitExpression: TGocciaAwaitExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function AwaitValue(const AValue: TGocciaValue): TGocciaValue;
-function EvaluateForOf(const AForOfStatement: TGocciaForOfStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
-function EvaluateForAwaitOf(const AForAwaitOfStatement: TGocciaForAwaitOfStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateForOf(const AForOfStatement: TGocciaForOfStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+function EvaluateForAwaitOf(const AForAwaitOfStatement: TGocciaForAwaitOfStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 
 // Destructuring pattern assignment procedures
 procedure AssignPattern(const APattern: TGocciaDestructuringPattern; const AValue: TGocciaValue; const AContext: TGocciaEvaluationContext; const AIsDeclaration: Boolean = False; const ADeclarationType: TGocciaDeclarationType = dtLet);
@@ -145,25 +146,15 @@ begin
     Result.Add(ASource[I]);
 end;
 
-function EvaluateStatementsSafe(const ANodes: TObjectList<TGocciaASTNode>; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateStatements(const ANodes: TObjectList<TGocciaASTNode>; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   I: Integer;
 begin
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
   for I := 0 to ANodes.Count - 1 do
   begin
-    try
-      Result := Evaluate(ANodes[I], AContext);
-    except
-      on E: TGocciaReturnValue do raise;
-      on E: TGocciaThrowValue do raise;
-      on E: TGocciaBreakSignal do raise;
-      on E: TGocciaTypeError do raise;
-      on E: TGocciaReferenceError do raise;
-      on E: TGocciaRuntimeError do raise;
-      on E: Exception do
-        raise TGocciaError.Create('Error executing statement: ' + E.Message, 0, 0, '', nil);
-    end;
+    Result := Evaluate(ANodes[I], AContext);
+    if Result.Kind <> cfkNormal then Exit;
   end;
 end;
 
@@ -271,24 +262,18 @@ begin
   SpreadIterableInto(ASpreadValue, AArgs.Items);
 end;
 
-function Evaluate(const ANode: TGocciaASTNode; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function Evaluate(const ANode: TGocciaASTNode; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 begin
   // Propagate OnError onto the scope so closures inherit it
   if Assigned(AContext.OnError) and not Assigned(AContext.Scope.OnError) then
     AContext.Scope.OnError := AContext.OnError;
 
   if ANode is TGocciaExpression then
-  begin
-    Result := EvaluateExpression(TGocciaExpression(ANode), AContext);
-  end
+    Result := TGocciaControlFlow.Normal(EvaluateExpression(TGocciaExpression(ANode), AContext))
   else if ANode is TGocciaStatement then
-  begin
-    Result := EvaluateStatement(TGocciaStatement(ANode), AContext);
-  end
+    Result := EvaluateStatement(TGocciaStatement(ANode), AContext)
   else
-  begin
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  end;
+    Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
 end;
 
 function EvaluateExpression(const AExpression: TGocciaExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
@@ -536,7 +521,7 @@ begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
-function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   Decl: TGocciaVariableDeclaration;
   ImportDecl: TGocciaImportDeclaration;
@@ -546,11 +531,11 @@ var
   I: Integer;
 begin
 
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
 
   if AStatement is TGocciaExpressionStatement then
   begin
-    Result := EvaluateExpression(TGocciaExpressionStatement(AStatement).Expression, AContext);
+    Result := TGocciaControlFlow.Normal(EvaluateExpression(TGocciaExpressionStatement(AStatement).Expression, AContext));
   end
       else if AStatement is TGocciaVariableDeclaration then
   begin
@@ -576,7 +561,7 @@ begin
   end
   else if AStatement is TGocciaDestructuringDeclaration then
   begin
-    Result := EvaluateDestructuringDeclaration(TGocciaDestructuringDeclaration(AStatement), AContext);
+    Result := TGocciaControlFlow.Normal(EvaluateDestructuringDeclaration(TGocciaDestructuringDeclaration(AStatement), AContext));
   end
   else if AStatement is TGocciaBlockStatement then
   begin
@@ -592,7 +577,7 @@ begin
   end
   else if AStatement is TGocciaBreakStatement then
   begin
-    raise TGocciaBreakSignal.Create;
+    Result := TGocciaControlFlow.Break;
   end
   else if AStatement is TGocciaReturnStatement then
   begin
@@ -600,15 +585,11 @@ begin
     begin
       Value := EvaluateExpression(TGocciaReturnStatement(AStatement).Value, AContext);
       if Value = nil then
-      begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-      end;
     end
     else
-    begin
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-    end;
-    raise TGocciaReturnValue.Create(Value);
+    Result := TGocciaControlFlow.Return(Value);
   end
   else if AStatement is TGocciaThrowStatement then
   begin
@@ -621,15 +602,15 @@ begin
   end
   else if AStatement is TGocciaClassDeclaration then
   begin
-    Result := EvaluateClass(TGocciaClassDeclaration(AStatement), AContext);
+    Result := TGocciaControlFlow.Normal(EvaluateClass(TGocciaClassDeclaration(AStatement), AContext));
   end
   else if AStatement is TGocciaEnumDeclaration then
   begin
-    Result := EvaluateEnumDeclaration(TGocciaEnumDeclaration(AStatement), AContext);
+    Result := TGocciaControlFlow.Normal(EvaluateEnumDeclaration(TGocciaEnumDeclaration(AStatement), AContext));
   end
   else if AStatement is TGocciaExportEnumDeclaration then
   begin
-    Result := EvaluateEnumDeclaration(TGocciaExportEnumDeclaration(AStatement).Declaration, AContext);
+    Result := TGocciaControlFlow.Normal(EvaluateEnumDeclaration(TGocciaExportEnumDeclaration(AStatement).Declaration, AContext));
   end
   else if AStatement is TGocciaImportDeclaration then
   begin
@@ -655,7 +636,7 @@ begin
   end
   else if AStatement is TGocciaReExportDeclaration then
   begin
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
   end
   else if AStatement is TGocciaForAwaitOfStatement then
   begin
@@ -667,7 +648,7 @@ begin
   end
   else if AStatement is TGocciaEmptyStatement then
   begin
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
   end;
 
 end;
@@ -1398,17 +1379,18 @@ begin
 end;
 
 // ES2026 §14.7.5.6 ForIn/OfBodyEvaluation(lhs, stmt, iteratorRecord, iterationKind, lhsKind)
-function EvaluateForOf(const AForOfStatement: TGocciaForOfStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateForOf(const AForOfStatement: TGocciaForOfStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   IterableValue: TGocciaValue;
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
   CurrentValue: TGocciaValue;
+  CF: TGocciaControlFlow;
   IterScope: TGocciaScope;
   IterContext: TGocciaEvaluationContext;
   DeclarationType: TGocciaDeclarationType;
 begin
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
 
   IterableValue := EvaluateExpression(AForOfStatement.Iterable, AContext);
   Iterator := GetIteratorFromValue(IterableValue);
@@ -1423,33 +1405,25 @@ begin
   if Assigned(TGocciaGarbageCollector.Instance) then
     TGocciaGarbageCollector.Instance.AddTempRoot(Iterator);
   try
-    try
+    IterResult := Iterator.AdvanceNext;
+    while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
+    begin
+      CurrentValue := IterResult.GetProperty(PROP_VALUE);
+
+      IterScope := AContext.Scope.CreateChild(skBlock);
+      IterContext := AContext;
+      IterContext.Scope := IterScope;
+
+      if AForOfStatement.BindingPattern <> nil then
+        AssignPattern(AForOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
+      else
+        IterScope.DefineLexicalBinding(AForOfStatement.BindingName, CurrentValue, DeclarationType);
+
+      CF := Evaluate(AForOfStatement.Body, IterContext);
+      if CF.Kind = cfkBreak then Break;
+      if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
+
       IterResult := Iterator.AdvanceNext;
-      while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
-      begin
-        CurrentValue := IterResult.GetProperty(PROP_VALUE);
-
-        IterScope := AContext.Scope.CreateChild(skBlock);
-        IterContext := AContext;
-        IterContext.Scope := IterScope;
-
-        if AForOfStatement.BindingPattern <> nil then
-          AssignPattern(AForOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
-        else
-          IterScope.DefineLexicalBinding(AForOfStatement.BindingName, CurrentValue, DeclarationType);
-
-        try
-          Evaluate(AForOfStatement.Body, IterContext);
-        except
-          on E: TGocciaBreakSignal do
-            Exit;
-        end;
-
-        IterResult := Iterator.AdvanceNext;
-      end;
-    except
-      on E: TGocciaBreakSignal do
-        ;
     end;
   finally
     if Assigned(TGocciaGarbageCollector.Instance) then
@@ -1458,17 +1432,18 @@ begin
 end;
 
 // ES2026 §14.7.5.6 ForIn/OfBodyEvaluation — for-await-of variant
-function EvaluateForAwaitOf(const AForAwaitOfStatement: TGocciaForAwaitOfStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateForAwaitOf(const AForAwaitOfStatement: TGocciaForAwaitOfStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   IterableValue, IteratorMethod, IteratorObj, NextMethod, NextResult, DoneValue, CurrentValue: TGocciaValue;
   Iterator: TGocciaIteratorValue;
   GenericNextResult: TGocciaObjectValue;
+  CF: TGocciaControlFlow;
   IterScope: TGocciaScope;
   IterContext: TGocciaEvaluationContext;
   DeclarationType: TGocciaDeclarationType;
   EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
 
   IterableValue := EvaluateExpression(AForAwaitOfStatement.Iterable, AContext);
 
@@ -1499,16 +1474,16 @@ begin
         if not Assigned(NextMethod) or not NextMethod.IsCallable then
           ThrowTypeError('Async iterator .next is not callable');
 
-          while True do
-          begin
-            NextResult := TGocciaFunctionBase(NextMethod).Call(EmptyArgs, IteratorObj);
-            NextResult := AwaitValue(NextResult);
+        while True do
+        begin
+          NextResult := TGocciaFunctionBase(NextMethod).Call(EmptyArgs, IteratorObj);
+          NextResult := AwaitValue(NextResult);
 
-            // ES2026 §7.4.2 step 5: If nextResult is not an Object, throw a TypeError
-            if NextResult.IsPrimitive then
-              ThrowTypeError('Iterator result ' + NextResult.ToStringLiteral.Value + ' is not an object');
+          // ES2026 §7.4.2 step 5: If nextResult is not an Object, throw a TypeError
+          if NextResult.IsPrimitive then
+            ThrowTypeError('Iterator result ' + NextResult.ToStringLiteral.Value + ' is not an object');
 
-            DoneValue := NextResult.GetProperty(PROP_DONE);
+          DoneValue := NextResult.GetProperty(PROP_DONE);
           if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
             Break;
 
@@ -1525,12 +1500,9 @@ begin
           else
             IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
 
-          try
-            Evaluate(AForAwaitOfStatement.Body, IterContext);
-          except
-            on E: TGocciaBreakSignal do
-              Exit;
-          end;
+          CF := Evaluate(AForAwaitOfStatement.Body, IterContext);
+          if CF.Kind = cfkBreak then Break;
+          if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
         end;
       finally
         EmptyArgs.Free;
@@ -1549,34 +1521,26 @@ begin
     if Assigned(TGocciaGarbageCollector.Instance) then
       TGocciaGarbageCollector.Instance.AddTempRoot(Iterator);
     try
-      try
+      GenericNextResult := Iterator.AdvanceNext;
+      while not GenericNextResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
+      begin
+        CurrentValue := GenericNextResult.GetProperty(PROP_VALUE);
+        CurrentValue := AwaitValue(CurrentValue);
+
+        IterScope := AContext.Scope.CreateChild(skBlock);
+        IterContext := AContext;
+        IterContext.Scope := IterScope;
+
+        if AForAwaitOfStatement.BindingPattern <> nil then
+          AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
+        else
+          IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
+
+        CF := Evaluate(AForAwaitOfStatement.Body, IterContext);
+        if CF.Kind = cfkBreak then Break;
+        if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
+
         GenericNextResult := Iterator.AdvanceNext;
-        while not GenericNextResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
-        begin
-          CurrentValue := GenericNextResult.GetProperty(PROP_VALUE);
-          CurrentValue := AwaitValue(CurrentValue);
-
-          IterScope := AContext.Scope.CreateChild(skBlock);
-          IterContext := AContext;
-          IterContext.Scope := IterScope;
-
-          if AForAwaitOfStatement.BindingPattern <> nil then
-            AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
-          else
-            IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
-
-          try
-            Evaluate(AForAwaitOfStatement.Body, IterContext);
-          except
-            on E: TGocciaBreakSignal do
-              Exit;
-          end;
-
-          GenericNextResult := Iterator.AdvanceNext;
-        end;
-      except
-        on E: TGocciaBreakSignal do
-          ;
       end;
     finally
       if Assigned(TGocciaGarbageCollector.Instance) then
@@ -1623,14 +1587,12 @@ begin
     Result := TGocciaFunctionValue.Create(AMethodExpression.Parameters, Statements, AContext.Scope.CreateChild);
 end;
 
-function EvaluateBlock(const ABlockStatement: TGocciaBlockStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateBlock(const ABlockStatement: TGocciaBlockStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   I: Integer;
-  LastValue: TGocciaValue;
   BlockContext: TGocciaEvaluationContext;
   NeedsChildScope: Boolean;
 begin
-  // Check if we need a child scope (only if there are variable declarations)
   NeedsChildScope := False;
   for I := 0 to ABlockStatement.Nodes.Count - 1 do
   begin
@@ -1646,31 +1608,29 @@ begin
   if NeedsChildScope then
     BlockContext.Scope := AContext.Scope.CreateChild(skBlock, 'BlockScope')
   else
-    BlockContext.Scope := AContext.Scope; // Use same scope - no isolation needed
+    BlockContext.Scope := AContext.Scope;
 
   try
-    LastValue := EvaluateStatementsSafe(ABlockStatement.Nodes, BlockContext);
-    if LastValue = nil then
-      LastValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Result := LastValue;
+    Result := EvaluateStatements(ABlockStatement.Nodes, BlockContext);
+    if (Result.Kind = cfkNormal) and (Result.Value = nil) then
+      Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
   finally
-    // Only free the scope if we created a child scope
     if NeedsChildScope then
       BlockContext.Scope.Free;
   end;
 end;
 
-function EvaluateIf(const AIfStatement: TGocciaIfStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateIf(const AIfStatement: TGocciaIfStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 begin
   if EvaluateExpression(AIfStatement.Condition, AContext).ToBooleanLiteral.Value then
     Result := EvaluateStatement(AIfStatement.Consequent, AContext)
   else if Assigned(AIfStatement.Alternate) then
     Result := EvaluateStatement(AIfStatement.Alternate, AContext)
   else
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
 end;
 
-function ExecuteCatchBlock(const ATryStatement: TGocciaTryStatement; const AErrorValue: TGocciaValue; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function ExecuteCatchBlock(const ATryStatement: TGocciaTryStatement; const AErrorValue: TGocciaValue; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   CatchScope: TGocciaScope;
   CatchContext: TGocciaEvaluationContext;
@@ -1682,13 +1642,13 @@ begin
       CatchScope.DefineLexicalBinding(ATryStatement.CatchParam, AErrorValue, dtParameter);
       CatchContext := AContext;
       CatchContext.Scope := CatchScope;
-      Result := EvaluateStatementsSafe(ATryStatement.CatchBlock.Nodes, CatchContext);
+      Result := EvaluateStatements(ATryStatement.CatchBlock.Nodes, CatchContext);
     finally
       CatchScope.Free;
     end;
   end
   else
-    Result := EvaluateStatementsSafe(ATryStatement.CatchBlock.Nodes, AContext);
+    Result := EvaluateStatements(ATryStatement.CatchBlock.Nodes, AContext);
 end;
 
 function PascalExceptionToErrorObject(const E: Exception): TGocciaValue;
@@ -1705,35 +1665,78 @@ begin
     Result := CreateErrorObject(ERROR_NAME, E.Message);
 end;
 
-function EvaluateTry(const ATryStatement: TGocciaTryStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateTry(const ATryStatement: TGocciaTryStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+var
+  ThrownValue: TGocciaValue;
+  HasUnhandledThrow: Boolean;
+  FinallyCF: TGocciaControlFlow;
 begin
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  HasUnhandledThrow := False;
+  ThrownValue := nil;
+  Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
 
+  // Phase 1: Execute try block, capturing throws
   try
-    try
-      Result := EvaluateStatementsSafe(ATryStatement.Block.Nodes, AContext);
-    except
-      on E: TGocciaThrowValue do
+    Result := EvaluateStatements(ATryStatement.Block.Nodes, AContext);
+  except
+    on E: TGocciaThrowValue do
+    begin
+      if Assigned(ATryStatement.CatchBlock) then
       begin
-        if Assigned(ATryStatement.CatchBlock) then
-          Result := ExecuteCatchBlock(ATryStatement, E.Value, AContext)
-        else
-          raise;
-      end;
-      on E: TGocciaReturnValue do raise;
-      on E: TGocciaBreakSignal do raise;
-      on E: Exception do
+        try
+          Result := ExecuteCatchBlock(ATryStatement, E.Value, AContext);
+        except
+          on E2: TGocciaThrowValue do
+          begin
+            HasUnhandledThrow := True;
+            ThrownValue := E2.Value;
+          end;
+        end;
+      end
+      else
       begin
-        if Assigned(ATryStatement.CatchBlock) then
-          Result := ExecuteCatchBlock(ATryStatement, PascalExceptionToErrorObject(E), AContext)
-        else
-          raise TGocciaThrowValue.Create(PascalExceptionToErrorObject(E));
+        HasUnhandledThrow := True;
+        ThrownValue := E.Value;
       end;
     end;
-  finally
-    if Assigned(ATryStatement.FinallyBlock) then
-      EvaluateStatementsSafe(ATryStatement.FinallyBlock.Nodes, AContext);
+    on E: Exception do
+    begin
+      if Assigned(ATryStatement.CatchBlock) then
+      begin
+        try
+          Result := ExecuteCatchBlock(ATryStatement, PascalExceptionToErrorObject(E), AContext);
+        except
+          on E2: TGocciaThrowValue do
+          begin
+            HasUnhandledThrow := True;
+            ThrownValue := E2.Value;
+          end;
+        end;
+      end
+      else
+      begin
+        HasUnhandledThrow := True;
+        ThrownValue := PascalExceptionToErrorObject(E);
+      end;
+    end;
   end;
+
+  // Phase 2: Execute finally block (always runs)
+  if Assigned(ATryStatement.FinallyBlock) then
+  begin
+    FinallyCF := EvaluateStatements(ATryStatement.FinallyBlock.Nodes, AContext);
+    // Per JS semantics: finally's control flow overrides try/catch result AND pending throw
+    if FinallyCF.Kind <> cfkNormal then
+    begin
+      Result := FinallyCF;
+      Exit;
+    end;
+    // If finally throws (TGocciaThrowValue), it propagates naturally and overrides everything
+  end;
+
+  // Phase 3: Re-raise unhandled throw (if not overridden by finally)
+  if HasUnhandledThrow then
+    raise TGocciaThrowValue.Create(ThrownValue);
 end;
 
 function EvaluateClassMethod(const AClassMethod: TGocciaClassMethod; const AContext: TGocciaEvaluationContext; const ASuperClass: TGocciaValue = nil): TGocciaValue;
@@ -1858,68 +1861,69 @@ begin
   end;
 end;
 
-function EvaluateSwitch(const ASwitchStatement: TGocciaSwitchStatement; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateSwitch(const ASwitchStatement: TGocciaSwitchStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   Discriminant: TGocciaValue;
   CaseClause: TGocciaCaseClause;
   CaseTest: TGocciaValue;
+  CF: TGocciaControlFlow;
   I, J: Integer;
   Matched: Boolean;
   DefaultIndex: Integer;
+  Done: Boolean;
 begin
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-
-  // Evaluate the discriminant expression
+  Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
   Discriminant := EvaluateExpression(ASwitchStatement.Discriminant, AContext);
 
   Matched := False;
   DefaultIndex := -1;
+  Done := False;
 
-  try
-    // First pass: find matching case or default
-    for I := 0 to ASwitchStatement.Cases.Count - 1 do
+  for I := 0 to ASwitchStatement.Cases.Count - 1 do
+  begin
+    CaseClause := ASwitchStatement.Cases[I];
+
+    if not Assigned(CaseClause.Test) then
     begin
-      CaseClause := ASwitchStatement.Cases[I];
-
-      if not Assigned(CaseClause.Test) then
-      begin
-        // Remember default case index for later
-        DefaultIndex := I;
-        Continue;
-      end;
-
-      if not Matched then
-      begin
-        CaseTest := EvaluateExpression(CaseClause.Test, AContext);
-        if IsStrictEqual(Discriminant, CaseTest) then
-          Matched := True;
-      end;
-
-      // Once matched, execute this case's statements (fall-through)
-      if Matched then
-      begin
-        for J := 0 to CaseClause.Consequent.Count - 1 do
-          Result := Evaluate(CaseClause.Consequent[J], AContext);
-      end;
+      DefaultIndex := I;
+      Continue;
     end;
 
-    // If no case matched, execute from default and fall through
-    if not Matched and (DefaultIndex >= 0) then
+    if not Matched then
     begin
-      for I := DefaultIndex to ASwitchStatement.Cases.Count - 1 do
-      begin
-        CaseClause := ASwitchStatement.Cases[I];
-        for J := 0 to CaseClause.Consequent.Count - 1 do
-          Result := Evaluate(CaseClause.Consequent[J], AContext);
-      end;
+      CaseTest := EvaluateExpression(CaseClause.Test, AContext);
+      if IsStrictEqual(Discriminant, CaseTest) then
+        Matched := True;
     end;
-  except
-    on E: TGocciaBreakSignal do
+
+    if Matched then
     begin
-      // Break exits the switch — swallow the signal
+      for J := 0 to CaseClause.Consequent.Count - 1 do
+      begin
+        CF := Evaluate(CaseClause.Consequent[J], AContext);
+        if CF.Kind = cfkBreak then begin Done := True; Break; end;
+        if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
+        Result := CF;
+      end;
+      if Done then Break;
     end;
   end;
 
+  if not Matched and not Done and (DefaultIndex >= 0) then
+  begin
+    for I := DefaultIndex to ASwitchStatement.Cases.Count - 1 do
+    begin
+      CaseClause := ASwitchStatement.Cases[I];
+      for J := 0 to CaseClause.Consequent.Count - 1 do
+      begin
+        CF := Evaluate(CaseClause.Consequent[J], AContext);
+        if CF.Kind = cfkBreak then begin Done := True; Break; end;
+        if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
+        Result := CF;
+      end;
+      if Done then Break;
+    end;
+  end;
 end;
 
 function EvaluateNewExpression(const ANewExpression: TGocciaNewExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;

--- a/units/Goccia.Interpreter.pas
+++ b/units/Goccia.Interpreter.pas
@@ -13,6 +13,7 @@ uses
   Goccia.AST.Expressions,
   Goccia.AST.Node,
   Goccia.AST.Statements,
+  Goccia.ControlFlow,
   Goccia.Error,
   Goccia.Evaluator,
   Goccia.Lexer,
@@ -105,13 +106,18 @@ end;
 function TGocciaInterpreter.Execute(const AProgram: TGocciaProgram): TGocciaValue;
 var
   I: Integer;
+  CF: TGocciaControlFlow;
   Context: TGocciaEvaluationContext;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   Context := CreateEvaluationContext;
 
   for I := 0 to AProgram.Body.Count - 1 do
-    Result := EvaluateStatement(AProgram.Body[I], Context);
+  begin
+    CF := EvaluateStatement(AProgram.Body[I], Context);
+    Result := CF.Value;
+    if CF.Kind = cfkReturn then Exit;
+  end;
 end;
 
 function TGocciaInterpreter.LoadModule(const AModulePath, AImportingFilePath: string): TGocciaModule;
@@ -202,7 +208,7 @@ begin
                 Context.CurrentFilePath := ResolvedPath;
 
                 for I := 0 to ProgramNode.Body.Count - 1 do
-                  EvaluateStatement(ProgramNode.Body[I], Context);
+                  EvaluateStatement(ProgramNode.Body[I], Context);  // .Value discarded at module level
 
                 for I := 0 to ProgramNode.Body.Count - 1 do
                 begin

--- a/units/Goccia.Values.Error.pas
+++ b/units/Goccia.Values.Error.pas
@@ -10,16 +10,10 @@ uses
   Goccia.Values.Primitives;
 
 type
-  // These are flow-control exceptions (return/throw), distinct from the compilation
-  // and runtime errors in Goccia.Error. Kept separate intentionally.
-  TGocciaReturnValue = class(Exception)
-  private
-    FValue: TGocciaValue;
-  public
-    constructor Create(const AValue: TGocciaValue);
-    property Value: TGocciaValue read FValue;
-  end;
-
+  // TGocciaThrowValue is the exception type for JS throw statements and runtime
+  // errors (ThrowTypeError, ThrowRangeError, etc.). It propagates naturally through
+  // the call stack and is caught by EvaluateTry (JS try/catch), async wrappers, or
+  // the top-level engine. Return and break use TGocciaControlFlow records instead.
   TGocciaThrowValue = class(Exception)
   private
     FValue: TGocciaValue;
@@ -28,20 +22,7 @@ type
     property Value: TGocciaValue read FValue;
   end;
 
-  TGocciaBreakSignal = class(Exception)
-  public
-    constructor Create;
-  end;
-
 implementation
-
-{ TGocciaReturnValue }
-
-constructor TGocciaReturnValue.Create(const AValue: TGocciaValue);
-begin
-  inherited Create('');
-  FValue := AValue;
-end;
 
 { TGocciaThrowValue }
 
@@ -49,13 +30,6 @@ constructor TGocciaThrowValue.Create(const AValue: TGocciaValue);
 begin
   inherited Create('');
   FValue := AValue;
-end;
-
-{ TGocciaBreakSignal }
-
-constructor TGocciaBreakSignal.Create;
-begin
-  inherited Create('break');
 end;
 
 end.

--- a/units/Goccia.Values.FunctionValue.Test.pas
+++ b/units/Goccia.Values.FunctionValue.Test.pas
@@ -13,6 +13,7 @@ uses
   Goccia.AST.Expressions,
   Goccia.AST.Node,
   Goccia.AST.Statements,
+  Goccia.ControlFlow,
   Goccia.Evaluator,
   Goccia.Scope,
   Goccia.TestSetup,
@@ -526,7 +527,7 @@ type
     LastValue := TGocciaUndefinedLiteralValue.UndefinedValue;
 
     for I := 0 to Statements.Count - 1 do
-      LastValue := Evaluate(Statements[I], Context);
+      LastValue := Evaluate(Statements[I], Context).Value;
 
     Expect<Double>(LastValue.ToNumberLiteral.Value).ToBe(1);
 
@@ -556,7 +557,7 @@ type
     LastValue := TGocciaUndefinedLiteralValue.UndefinedValue;
 
     for I := 0 to Statements.Count - 1 do
-      LastValue := Evaluate(Statements[I], Context);
+      LastValue := Evaluate(Statements[I], Context).Value;
 
     Expect<Double>(LastValue.ToNumberLiteral.Value).ToBe(3);
 

--- a/units/Goccia.Values.FunctionValue.pas
+++ b/units/Goccia.Values.FunctionValue.pas
@@ -221,13 +221,18 @@ begin
     Exit;
   end;
 
-  // Block body: check control flow records instead of catching exceptions
   Context.Scope := ACallScope;
+  if Assigned(Context.OnError) and not Assigned(ACallScope.OnError) then
+    ACallScope.OnError := Context.OnError;
+
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   for I := 0 to FBodyStatements.Count - 1 do
   begin
-    CF := Evaluate(FBodyStatements[I], Context);
+    if FBodyStatements[I] is TGocciaExpression then
+      CF := TGocciaControlFlow.Normal(EvaluateExpression(TGocciaExpression(FBodyStatements[I]), Context))
+    else
+      CF := EvaluateStatement(TGocciaStatement(FBodyStatements[I]), Context);
     if CF.Kind = cfkReturn then
     begin
       if CF.Value = nil then

--- a/units/Goccia.Values.FunctionValue.pas
+++ b/units/Goccia.Values.FunctionValue.pas
@@ -201,10 +201,13 @@ begin
     end;
   end;
 
+  Context.Scope := ACallScope;
+  if Assigned(Context.OnError) and not Assigned(ACallScope.OnError) then
+    ACallScope.OnError := Context.OnError;
+
   // Expression-body fast path: expression bodies cannot contain return/break
   if FIsExpressionBody and (FBodyStatements.Count = 1) then
   begin
-    Context.Scope := ACallScope;
     Result := EvaluateExpression(TGocciaExpression(FBodyStatements[0]), Context);
     Exit;
   end;
@@ -213,17 +216,12 @@ begin
   // expression directly, bypassing the statement loop
   if (FBodyStatements.Count = 1) and (FBodyStatements[0] is TGocciaReturnStatement) then
   begin
-    Context.Scope := ACallScope;
     if TGocciaReturnStatement(FBodyStatements[0]).Value <> nil then
       Result := EvaluateExpression(TGocciaExpression(TGocciaReturnStatement(FBodyStatements[0]).Value), Context)
     else
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
-
-  Context.Scope := ACallScope;
-  if Assigned(Context.OnError) and not Assigned(ACallScope.OnError) then
-    ACallScope.OnError := Context.OnError;
 
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 

--- a/units/Goccia.Values.FunctionValue.pas
+++ b/units/Goccia.Values.FunctionValue.pas
@@ -237,7 +237,7 @@ begin
       Exit;
     end;
     if CF.Kind = cfkBreak then
-      Exit;
+      ThrowSyntaxError('Illegal break statement');
   end;
 end;
 

--- a/units/Goccia.Values.FunctionValue.pas
+++ b/units/Goccia.Values.FunctionValue.pas
@@ -70,13 +70,13 @@ uses
   SysUtils,
 
   Goccia.AST.Statements,
+  Goccia.ControlFlow,
   Goccia.Error,
   Goccia.Evaluator,
   Goccia.GarbageCollector,
   Goccia.Logger,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassHelper,
-  Goccia.Values.Error,
   Goccia.Values.ErrorHelper;
 
 { TGocciaFunctionValue }
@@ -135,6 +135,7 @@ function TGocciaFunctionValue.ExecuteBody(const ACallScope: TGocciaScope; const 
 var
   I, J: Integer;
   ReturnValue: TGocciaValue;
+  CF: TGocciaControlFlow;
   Context: TGocciaEvaluationContext;
 begin
   // Set up evaluation context — inherit OnError from the closure scope
@@ -200,69 +201,43 @@ begin
     end;
   end;
 
-  // Expression-body fast path: skip try/except entirely since expression bodies
-  // cannot contain return/break statements — exceptions propagate naturally
+  // Expression-body fast path: expression bodies cannot contain return/break
   if FIsExpressionBody and (FBodyStatements.Count = 1) then
   begin
     Context.Scope := ACallScope;
-    Result := Evaluate(FBodyStatements[0], Context);
+    Result := EvaluateExpression(TGocciaExpression(FBodyStatements[0]), Context);
     Exit;
   end;
 
   // Single-return fast path: (x) => { return expr; } — evaluate the return
-  // expression directly, bypassing try/except and TGocciaReturnValue exception
+  // expression directly, bypassing the statement loop
   if (FBodyStatements.Count = 1) and (FBodyStatements[0] is TGocciaReturnStatement) then
   begin
     Context.Scope := ACallScope;
     if TGocciaReturnStatement(FBodyStatements[0]).Value <> nil then
-      Result := Evaluate(TGocciaReturnStatement(FBodyStatements[0]).Value, Context)
+      Result := EvaluateExpression(TGocciaExpression(TGocciaReturnStatement(FBodyStatements[0]).Value), Context)
     else
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
 
-  // Block body: full execution with exception handling for return/break signals
-  try
-    Context.Scope := ACallScope;
-    ReturnValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+  // Block body: check control flow records instead of catching exceptions
+  Context.Scope := ACallScope;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-    for I := 0 to FBodyStatements.Count - 1 do
+  for I := 0 to FBodyStatements.Count - 1 do
+  begin
+    CF := Evaluate(FBodyStatements[I], Context);
+    if CF.Kind = cfkReturn then
     begin
-      try
-        ReturnValue := Evaluate(FBodyStatements[I], Context);
-      except
-        on E: TGocciaReturnValue do raise;
-        on E: TGocciaThrowValue do raise;
-        on E: TGocciaBreakSignal do raise;
-        on E: TGocciaTypeError do raise;
-        on E: TGocciaReferenceError do raise;
-        on E: TGocciaRuntimeError do raise;
-        on E: TGocciaError do raise;
-        on E: Exception do
-          ThrowError('Error executing statement: ' + E.Message);
-      end;
-    end;
-
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  except
-    on E: TGocciaReturnValue do
-    begin
-      if E.Value = nil then
+      if CF.Value = nil then
         Result := TGocciaUndefinedLiteralValue.UndefinedValue
       else
-        Result := E.Value;
+        Result := CF.Value;
+      Exit;
     end;
-    on E: TGocciaThrowValue do raise;
-    on E: TGocciaBreakSignal do raise;
-    on E: TGocciaTypeError do raise;
-    on E: TGocciaReferenceError do raise;
-    on E: TGocciaRuntimeError do raise;
-    on E: TGocciaError do raise;
-    on E: Exception do
-    begin
-      Logger.Error('FunctionValue.Call: Caught unexpected exception: %s', [E.Message]);
-      raise;
-    end;
+    if CF.Kind = cfkBreak then
+      Exit;
   end;
 end;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked control-flow so return/break use lightweight in-memory signals instead of exception objects, improving runtime efficiency on hot paths.
  * Statement/block evaluation now propagates these signals by early exit while preserving existing semantics (including try/catch/finally behavior).
  * Internal test adjustments to read values from the new control-flow wrapper where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->