### PR TITLE
Fix switch default clause not participating in fallthrough

### DIFF
--- a/tests/language/statements/switch/switch-edge-cases.js
+++ b/tests/language/statements/switch/switch-edge-cases.js
@@ -55,6 +55,81 @@ test("switch with empty case fall-through to default", () => {
   expect(result).toBe("reached default");
 });
 
+test("matched case falls through into default", () => {
+  let result = "";
+  switch (1) {
+    case 1:
+      result += "one";
+    default:
+      result += " default";
+  }
+  expect(result).toBe("one default");
+});
+
+test("matched case falls through default into subsequent case", () => {
+  let result = "";
+  switch (1) {
+    case 1:
+      result += "one";
+    default:
+      result += " default";
+    case 2:
+      result += " two";
+  }
+  expect(result).toBe("one default two");
+});
+
+test("default not reached when match has break", () => {
+  let result = "";
+  switch (1) {
+    case 1:
+      result += "one";
+      break;
+    default:
+      result += " default";
+  }
+  expect(result).toBe("one");
+});
+
+test("default executes when no case matches", () => {
+  let result = "";
+  switch (99) {
+    case 1:
+      result += "one";
+    default:
+      result += "default";
+    case 2:
+      result += " two";
+  }
+  expect(result).toBe("default two");
+});
+
+test("default in middle with match before it", () => {
+  let result = "";
+  switch (1) {
+    case 1:
+      result += "one";
+    default:
+      result += " default";
+    case 3:
+      result += " three";
+  }
+  expect(result).toBe("one default three");
+});
+
+test("default in middle with match after it", () => {
+  let result = "";
+  switch (3) {
+    case 1:
+      result += "one";
+    default:
+      result += "default ";
+    case 3:
+      result += "three";
+  }
+  expect(result).toBe("three");
+});
+
 test("switch with return in arrow function", () => {
   const classify = (n) => {
     switch (true) {

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -1883,9 +1883,9 @@ begin
 
       if not Assigned(CaseClause.Test) then
       begin
-        // Remember default case index for later
         DefaultIndex := I;
-        Continue;
+        if not Matched then
+          Continue;
       end;
 
       if not Matched then


### PR DESCRIPTION
When a prior case matched and fell through, the default clause body was unconditionally skipped because the first-pass loop used Continue for every default clause regardless of match state. Now the default clause is only skipped when no match has been found yet; once Matched = True, it falls through like any other clause.

Fixes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed switch statement default case handling to correctly evaluate subsequent logic after a match has been found.

* **Tests**
  * Added comprehensive test coverage for switch statement fall-through behavior with default cases, including break statement interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->