### PR TITLE
Environment specific test failure

### DIFF
--- a/units/Goccia.Builtins.GlobalNumber.pas
+++ b/units/Goccia.Builtins.GlobalNumber.pas
@@ -28,6 +28,7 @@ type
 implementation
 
 uses
+  Math,
   SysUtils,
 
   Goccia.Arguments.Validator,
@@ -62,6 +63,7 @@ function TGocciaGlobalNumber.NumberParseInt(const AArgs: TGocciaArgumentsCollect
 var
   InputStr: string;
   Radix: Integer;
+  RadixNum: Double;
   I, StartPos: Integer;
   C: Char;
   Sign: Integer;
@@ -81,8 +83,15 @@ begin
   end;
 
   // Step 5: Let R be ? ToInt32(radix)
+  // ES2026 §7.1.6 ToInt32: NaN, +0, -0, +Infinity, -Infinity all map to +0
   if AArgs.Length > 1 then
-    Radix := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value)
+  begin
+    RadixNum := AArgs.GetElement(1).ToNumberLiteral.Value;
+    if Math.IsNaN(RadixNum) or Math.IsInfinite(RadixNum) then
+      Radix := 0
+    else
+      Radix := Trunc(RadixNum);
+  end
   else
     Radix := 0;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix `Number.parseInt` crashing on Linux when radix is `NaN` or `undefined`.

`Trunc(NaN)` raises an `EInvalidOp` exception on Linux x86_64, whereas it silently returns `0` on macOS ARM64. This caused `Number.parseInt("10", undefined)` to crash on Linux, violating the ES spec which requires `ToInt32(NaN)` to return `+0`. The fix adds checks for `NaN` and `Infinity` before calling `Trunc`, defaulting the radix to `0` as per spec.

---
<p><a href="https://cursor.com/agents/bc-d3cbe52c-e317-4735-8964-0c2f9d139811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3cbe52c-e317-4735-8964-0c2f9d139811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->