### PR TITLE
Allow to suppress console output on native tests

### DIFF
--- a/units/Goccia.Builtins.TestAssertions.Test.pas
+++ b/units/Goccia.Builtins.TestAssertions.Test.pas
@@ -188,6 +188,7 @@ procedure TTestExpectationMatchers.BeforeAll;
 begin
   FScope := TGocciaGlobalScope.Create;
   FAssertions := TGocciaTestAssertions.Create('test', FScope, DummyThrowError);
+  FAssertions.SuppressOutput := True;
 end;
 
 procedure TTestExpectationMatchers.AfterAll;
@@ -1203,6 +1204,7 @@ procedure TTestSkipAndConditionalAPIs.BeforeEach;
 begin
   FScope := TGocciaGlobalScope.Create;
   FAssertions := TGocciaTestAssertions.Create('test', FScope, DummyThrowError);
+  FAssertions.SuppressOutput := True;
 end;
 
 procedure TTestSkipAndConditionalAPIs.AfterEach;

--- a/units/Goccia.Builtins.TestAssertions.pas
+++ b/units/Goccia.Builtins.TestAssertions.pas
@@ -100,6 +100,7 @@ type
     FCurrentSuiteIsSkipped: Boolean;
     FSkipNextDescribe: Boolean;
     FSkipNextTest: Boolean;
+    FSuppressOutput: Boolean;
 
     procedure RunCallbacks(const ACallbacks: TGocciaArgumentsCollection);
     procedure AssertionPassed(const ATestName: string);
@@ -137,6 +138,7 @@ type
 
     // Exposed for native Pascal unit tests
     property CurrentTestHasFailures: Boolean read FTestStats.CurrentTestHasFailures;
+    property SuppressOutput: Boolean read FSuppressOutput write FSuppressOutput;
     procedure ResetCurrentTestState;
   end;
 
@@ -1302,7 +1304,9 @@ begin
   Inc(FTestStats.TotalAssertionCount);
   FTestStats.CurrentTestHasFailures := True;
 
-  // Track the failure details for reporting
+  if FSuppressOutput then
+    Exit;
+
   if FTestStats.CurrentSuiteName <> '' then
     WriteLn('    ❌ ', FTestStats.CurrentTestName, ' in ', FTestStats.CurrentSuiteName, ': ', AMessage)
   else
@@ -1603,7 +1607,8 @@ begin
       except
         on E: Exception do
         begin
-          WriteLn('Error in describe block "', Suite.Name, '": ', E.Message);
+          if not FSuppressOutput then
+            WriteLn('Error in describe block "', Suite.Name, '": ', E.Message);
           FailedTestDetails.Add('Describe "' + Suite.Name + '": ' + E.Message);
         end;
       end;
@@ -1627,12 +1632,14 @@ begin
       // Check if test is skipped
       if TestCase.IsSkipped then
       begin
-        // Mark test as skipped and don't execute it
         FTestStats.CurrentTestIsSkipped := True;
-        if TestCase.SuiteName <> '' then
-          WriteLn('    ⏸️ ', TestCase.Name, ' in ', TestCase.SuiteName, ': SKIPPED')
-        else
-          WriteLn('    ⏸️ ', TestCase.Name, ': SKIPPED');
+        if not FSuppressOutput then
+        begin
+          if TestCase.SuiteName <> '' then
+            WriteLn('    ⏸️ ', TestCase.Name, ' in ', TestCase.SuiteName, ': SKIPPED')
+          else
+            WriteLn('    ⏸️ ', TestCase.Name, ': SKIPPED');
+        end;
       end
       else
       begin
@@ -1736,8 +1743,7 @@ begin
   ResultObj.AssignProperty('failedTests', FailedTestDetailsArray);
   ResultObj.AssignProperty('summary', TGocciaStringLiteralValue.Create(Summary));
 
-  // Print the summary to console for visibility
-  if ShowTestResults then
+  if ShowTestResults and not FSuppressOutput then
   begin
     WriteLn('');
     WriteLn('=== Test Results ===');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `SuppressOutput` property to `TGocciaTestAssertions` to clean up native Pascal test output.

The native Pascal test suite intentionally triggers failures to verify matcher behavior, which previously resulted in noisy output. This change silences these expected failure messages and internal `RunTests` output, ensuring only actual test results are displayed.

---
<p><a href="https://cursor.com/agents/bc-80ebe7c4-f74b-4509-98d6-ff7f606344de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80ebe7c4-f74b-4509-98d6-ff7f606344de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->