### PR TITLE
Fix increment/decrement for computed member expressions 

### DIFF
--- a/tests/language/expressions/arithmetic/decrement.js
+++ b/tests/language/expressions/arithmetic/decrement.js
@@ -68,3 +68,19 @@ test("decrement on computed member with string key", () => {
   --obj["y"];
   expect(obj.y).toBe(199);
 });
+
+test("decrement on computed member with symbol key", () => {
+  const sym = Symbol("counter");
+  const obj = { [sym]: 10 };
+  obj[sym]--;
+  expect(obj[sym]).toBe(9);
+  --obj[sym];
+  expect(obj[sym]).toBe(8);
+});
+
+test("post-decrement on non-writable property throws", () => {
+  const obj = {};
+  Object.defineProperty(obj, "x", { value: 5, writable: false });
+  expect(() => obj.x--).toThrow(TypeError);
+  expect(obj.x).toBe(5);
+});

--- a/tests/language/expressions/arithmetic/decrement.js
+++ b/tests/language/expressions/arithmetic/decrement.js
@@ -24,3 +24,47 @@ test("decrement preserves fractional part", () => {
   --y;
   expect(y).toBe(-0.5);
 });
+
+test("post-decrement on property access", () => {
+  const obj = { count: 10 };
+  expect(obj.count--).toBe(10);
+  expect(obj.count).toBe(9);
+});
+
+test("pre-decrement on property access", () => {
+  const obj = { count: 10 };
+  expect(--obj.count).toBe(9);
+  expect(obj.count).toBe(9);
+});
+
+test("post-decrement on computed member (array index)", () => {
+  const arr = [5, 10, 15];
+  expect(arr[0]--).toBe(5);
+  expect(arr[0]).toBe(4);
+  expect(arr[2]--).toBe(15);
+  expect(arr[2]).toBe(14);
+});
+
+test("pre-decrement on computed member (array index)", () => {
+  const arr = [5, 10, 15];
+  expect(--arr[0]).toBe(4);
+  expect(arr[0]).toBe(4);
+  expect(--arr[1]).toBe(9);
+  expect(arr[1]).toBe(9);
+});
+
+test("decrement on computed member with variable key", () => {
+  const arr = [10, 20, 30];
+  let i = 2;
+  arr[i]--;
+  expect(arr[2]).toBe(29);
+});
+
+test("decrement on computed member with string key", () => {
+  const obj = { x: 100, y: 200 };
+  const key = "x";
+  obj[key]--;
+  expect(obj.x).toBe(99);
+  --obj["y"];
+  expect(obj.y).toBe(199);
+});

--- a/tests/language/expressions/arithmetic/increment.js
+++ b/tests/language/expressions/arithmetic/increment.js
@@ -70,3 +70,19 @@ test("increment on computed member with string key", () => {
   ++obj["b"];
   expect(obj.b).toBe(11);
 });
+
+test("increment on computed member with symbol key", () => {
+  const sym = Symbol("counter");
+  const obj = { [sym]: 5 };
+  obj[sym]++;
+  expect(obj[sym]).toBe(6);
+  ++obj[sym];
+  expect(obj[sym]).toBe(7);
+});
+
+test("post-increment on non-writable property throws", () => {
+  const obj = {};
+  Object.defineProperty(obj, "x", { value: 1, writable: false });
+  expect(() => obj.x++).toThrow(TypeError);
+  expect(obj.x).toBe(1);
+});

--- a/tests/language/expressions/arithmetic/increment.js
+++ b/tests/language/expressions/arithmetic/increment.js
@@ -26,3 +26,47 @@ test("increment preserves fractional part", () => {
   ++y;
   expect(y).toBe(0.5);
 });
+
+test("post-increment on property access", () => {
+  const obj = { count: 10 };
+  expect(obj.count++).toBe(10);
+  expect(obj.count).toBe(11);
+});
+
+test("pre-increment on property access", () => {
+  const obj = { count: 10 };
+  expect(++obj.count).toBe(11);
+  expect(obj.count).toBe(11);
+});
+
+test("post-increment on computed member (array index)", () => {
+  const arr = [1, 2, 3];
+  expect(arr[0]++).toBe(1);
+  expect(arr[0]).toBe(2);
+  expect(arr[1]++).toBe(2);
+  expect(arr[1]).toBe(3);
+});
+
+test("pre-increment on computed member (array index)", () => {
+  const arr = [1, 2, 3];
+  expect(++arr[0]).toBe(2);
+  expect(arr[0]).toBe(2);
+  expect(++arr[2]).toBe(4);
+  expect(arr[2]).toBe(4);
+});
+
+test("increment on computed member with variable key", () => {
+  const arr = [10, 20, 30];
+  let i = 1;
+  arr[i]++;
+  expect(arr[1]).toBe(21);
+});
+
+test("increment on computed member with string key", () => {
+  const obj = { a: 5, b: 10 };
+  const key = "a";
+  obj[key]++;
+  expect(obj.a).toBe(6);
+  ++obj["b"];
+  expect(obj.b).toBe(11);
+});

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -1123,7 +1123,7 @@ end;
 
 function TGocciaIncrementExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
-  Obj, OldValue, NewValue: TGocciaValue;
+  Obj, OldValue, NewValue, PropertyKeyValue: TGocciaValue;
   MemberExpr: TGocciaMemberExpression;
   PropName: string;
 begin
@@ -1143,7 +1143,29 @@ begin
     MemberExpr := TGocciaMemberExpression(Operand);
     Obj := MemberExpr.ObjectExpr.Evaluate(AContext);
     if MemberExpr.Computed then
-      PropName := MemberExpr.PropertyExpression.Evaluate(AContext).ToStringLiteral.Value
+    begin
+      PropertyKeyValue := MemberExpr.PropertyExpression.Evaluate(AContext);
+      if (PropertyKeyValue is TGocciaSymbolValue) and ((Obj is TGocciaClassValue) or (Obj is TGocciaObjectValue)) then
+      begin
+        if Obj is TGocciaClassValue then
+          OldValue := TGocciaClassValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue))
+        else
+          OldValue := TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue));
+        if OldValue = nil then
+          OldValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+        NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
+        if Obj is TGocciaClassValue then
+          TGocciaClassValue(Obj).AssignSymbolProperty(TGocciaSymbolValue(PropertyKeyValue), NewValue)
+        else
+          TGocciaObjectValue(Obj).AssignSymbolProperty(TGocciaSymbolValue(PropertyKeyValue), NewValue);
+        if IsPrefix then
+          Result := NewValue
+        else
+          Result := OldValue;
+        Exit;
+      end;
+      PropName := PropertyKeyValue.ToStringLiteral.Value;
+    end
     else
       PropName := MemberExpr.PropertyName;
     OldValue := Obj.GetProperty(PropName);

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -1124,6 +1124,7 @@ end;
 function TGocciaIncrementExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   Obj, OldValue, NewValue: TGocciaValue;
+  MemberExpr: TGocciaMemberExpression;
   PropName: string;
 begin
   if Operand is TGocciaIdentifierExpression then
@@ -1139,8 +1140,12 @@ begin
   end
   else if Operand is TGocciaMemberExpression then
   begin
-    Obj := TGocciaMemberExpression(Operand).ObjectExpr.Evaluate(AContext);
-    PropName := TGocciaMemberExpression(Operand).PropertyName;
+    MemberExpr := TGocciaMemberExpression(Operand);
+    Obj := MemberExpr.ObjectExpr.Evaluate(AContext);
+    if MemberExpr.Computed then
+      PropName := MemberExpr.PropertyExpression.Evaluate(AContext).ToStringLiteral.Value
+    else
+      PropName := MemberExpr.PropertyName;
     OldValue := Obj.GetProperty(PropName);
     if OldValue = nil then
     begin
@@ -1149,7 +1154,7 @@ begin
       Exit;
     end;
     NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
-    DefinePropertyOnValue(Obj, PropName, NewValue);
+    AssignProperty(Obj, PropName, NewValue, AContext.OnError, Line, Column);
     if IsPrefix then
       Result := NewValue
     else

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -1939,6 +1939,63 @@ begin
   ACtx.Scope.FreeRegister;
 end;
 
+procedure CompileIncrementMember(const ACtx: TGocciaCompilationContext;
+  const AExpr: TGocciaIncrementExpression; const AMember: TGocciaMemberExpression;
+  const ADest: UInt8; const AOp: TSouffleOpCode);
+var
+  ObjReg, CurReg, RegOne: UInt8;
+  PropIdx: UInt16;
+begin
+  ObjReg := ACtx.Scope.AllocateRegister;
+  CurReg := ACtx.Scope.AllocateRegister;
+  RegOne := ACtx.Scope.AllocateRegister;
+
+  ACtx.CompileExpression(AMember.ObjectExpr, ObjReg);
+  PropIdx := ACtx.Template.AddConstantString(AMember.PropertyName);
+  if PropIdx > High(UInt8) then
+    raise Exception.Create('Constant pool overflow: property name index exceeds 255');
+  EmitInstruction(ACtx, EncodeABC(OP_RT_GET_PROP, CurReg, ObjReg, UInt8(PropIdx)));
+  EmitInstruction(ACtx, EncodeAsBx(OP_LOAD_INT, RegOne, 1));
+  if not AExpr.IsPrefix then
+    EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+  EmitInstruction(ACtx, EncodeABC(AOp, CurReg, CurReg, RegOne));
+  EmitInstruction(ACtx, EncodeABC(OP_RT_SET_PROP, ObjReg, UInt8(PropIdx), CurReg));
+  if AExpr.IsPrefix then
+    EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+
+  ACtx.Scope.FreeRegister;
+  ACtx.Scope.FreeRegister;
+  ACtx.Scope.FreeRegister;
+end;
+
+procedure CompileIncrementComputedMember(const ACtx: TGocciaCompilationContext;
+  const AExpr: TGocciaIncrementExpression; const AMember: TGocciaMemberExpression;
+  const ADest: UInt8; const AOp: TSouffleOpCode);
+var
+  ObjReg, KeyReg, CurReg, RegOne: UInt8;
+begin
+  ObjReg := ACtx.Scope.AllocateRegister;
+  KeyReg := ACtx.Scope.AllocateRegister;
+  CurReg := ACtx.Scope.AllocateRegister;
+  RegOne := ACtx.Scope.AllocateRegister;
+
+  ACtx.CompileExpression(AMember.ObjectExpr, ObjReg);
+  ACtx.CompileExpression(AMember.PropertyExpression, KeyReg);
+  EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
+  EmitInstruction(ACtx, EncodeAsBx(OP_LOAD_INT, RegOne, 1));
+  if not AExpr.IsPrefix then
+    EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+  EmitInstruction(ACtx, EncodeABC(AOp, CurReg, CurReg, RegOne));
+  EmitInstruction(ACtx, EncodeABC(OP_ARRAY_SET, ObjReg, KeyReg, CurReg));
+  if AExpr.IsPrefix then
+    EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+
+  ACtx.Scope.FreeRegister;
+  ACtx.Scope.FreeRegister;
+  ACtx.Scope.FreeRegister;
+  ACtx.Scope.FreeRegister;
+end;
+
 procedure CompileIncrement(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaIncrementExpression; const ADest: UInt8);
 var
@@ -1947,11 +2004,22 @@ var
   MsgIdx: UInt16;
   Op: TSouffleOpCode;
   Ident: TGocciaIdentifierExpression;
+  MemberExpr: TGocciaMemberExpression;
 begin
   if AExpr.Operator = gttIncrement then
     Op := OP_RT_ADD
   else
     Op := OP_RT_SUB;
+
+  if AExpr.Operand is TGocciaMemberExpression then
+  begin
+    MemberExpr := TGocciaMemberExpression(AExpr.Operand);
+    if MemberExpr.Computed then
+      CompileIncrementComputedMember(ACtx, AExpr, MemberExpr, ADest, Op)
+    else
+      CompileIncrementMember(ACtx, AExpr, MemberExpr, ADest, Op);
+    Exit;
+  end;
 
   if not (AExpr.Operand is TGocciaIdentifierExpression) then
   begin


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix increment/decrement for computed member expressions and array elements.

This PR addresses issue #52 by ensuring that increment/decrement operations on computed member expressions (e.g., `arr[i]++`, `obj[key]--`) correctly mutate values in both interpreter and bytecode modes. It also fixes a latent bug where `DefinePropertyOnValue` incorrectly handled array updates, now using `AssignProperty` to dispatch to the virtual `SetProperty` method.

---
<p><a href="https://cursor.com/agents/bc-3f1c7ec1-0b27-4063-82d0-c1d665337cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f1c7ec1-0b27-4063-82d0-c1d665337cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed increment and decrement operators on object properties and computed array indices to properly return values and update the target location.

* **Tests**
  * Added comprehensive test coverage for pre- and post-increment/decrement operations on object properties, array indices, and computed member access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->