### PR TITLE
Fix class expression super() bytecode crash in decorator wrapping benchmark

### DIFF
--- a/tests/language/classes/class-expression-extends.js
+++ b/tests/language/classes/class-expression-extends.js
@@ -1,0 +1,99 @@
+/*---
+description: Class expressions extending dynamic values with super() calls
+features: [classes]
+---*/
+
+describe("class expression extends dynamic value", () => {
+  test("class expression extends parameter with constructor calling super()", () => {
+    const makeWrapper = (Base) => {
+      return class extends Base {
+        constructor() {
+          super();
+          this.wrapped = true;
+        }
+      };
+    };
+
+    class Original {
+      constructor() { this.x = 1; }
+    }
+    const Wrapped = makeWrapper(Original);
+    const w = new Wrapped();
+    expect(w.x).toBe(1);
+    expect(w.wrapped).toBe(true);
+    expect(w instanceof Wrapped).toBe(true);
+    expect(w instanceof Original).toBe(true);
+  });
+
+  test("class expression extends parameter with spread args in super()", () => {
+    const makeWrapper = (Base) => {
+      return class extends Base {
+        constructor(...args) {
+          super(...args);
+          this.wrapped = true;
+        }
+      };
+    };
+
+    class Original {
+      constructor(a, b) { this.a = a; this.b = b; }
+    }
+    const Wrapped = makeWrapper(Original);
+    const w = new Wrapped(10, 20);
+    expect(w.a).toBe(10);
+    expect(w.b).toBe(20);
+    expect(w.wrapped).toBe(true);
+  });
+
+  test("class expression extends parameter without constructor (implicit super)", () => {
+    const makeWrapper = (Base) => {
+      return class extends Base {};
+    };
+
+    class Original {
+      constructor() { this.x = 42; }
+    }
+    const Wrapped = makeWrapper(Original);
+    const w = new Wrapped();
+    expect(w.x).toBe(42);
+    expect(w instanceof Original).toBe(true);
+  });
+
+  test("class expression extends parameter with methods", () => {
+    const addGreeting = (Base) => {
+      return class extends Base {
+        constructor(name) {
+          super(name);
+        }
+        greet() { return "Hello, " + this.name; }
+      };
+    };
+
+    class Person {
+      constructor(name) { this.name = name; }
+    }
+    const Greeter = addGreeting(Person);
+    const g = new Greeter("Alice");
+    expect(g.name).toBe("Alice");
+    expect(g.greet()).toBe("Hello, Alice");
+  });
+
+  test("class decorator wrapping with constructor and super()", () => {
+    const wrap = (cls, context) => {
+      return class extends cls {
+        constructor(...args) {
+          super(...args);
+          this.wrapped = true;
+        }
+      };
+    };
+
+    @wrap
+    class C {
+      constructor() { this.x = 1; }
+    }
+    const c = new C();
+    expect(c.x).toBe(1);
+    expect(c.wrapped).toBe(true);
+  });
+});

--- a/units/Goccia.Compiler.Statements.pas
+++ b/units/Goccia.Compiler.Statements.pas
@@ -1803,7 +1803,7 @@ begin
 
   if HasSuper then
   begin
-    SuperReg := ACtx.Scope.AllocateRegister;
+    SuperReg := ACtx.Scope.DeclareLocal('__super__', False);
 
     LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.SuperClass);
     if LocalIdx >= 0 then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix a fatal error in bytecode mode for class expressions extending dynamic values with `super()` calls.

The `CompileClassExpression` incorrectly used `AllocateRegister()` for the super register, preventing `__super__` from being resolved via upvalue capture in constructors, leading to a crash and the "class decorator (wrapping)" benchmark reporting 0 ops/sec.

---
<p><a href="https://cursor.com/agents/bc-b0a8411f-e0d9-4ef8-8474-62f6b96f0340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0a8411f-e0d9-4ef8-8474-62f6b96f0340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for class expressions extending dynamic base classes, covering constructor super() calls, argument spreading, implicit super behavior, method inheritance patterns, and decorator-like wrapping functionality for enhanced validation.

* **Refactor**
  * Optimized internal storage mechanism for superclass references in class declarations and expressions to improve memory efficiency without affecting external behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->