### PR TITLE
Pull 70 compiler error

### DIFF
--- a/build.pas
+++ b/build.pas
@@ -219,6 +219,7 @@ begin
       Args.Add('-Xs');
       Args.Add('-CX');
       Args.Add('-XX');
+      Args.Add('-B');
     end else
     begin
       Args.Add('-O-');

--- a/souffle/Souffle.inc
+++ b/souffle/Souffle.inc
@@ -1,5 +1,6 @@
 {$mode delphi} {H+}
 {$IFDEF PRODUCTION}
+  {$optimization autoInline}
   {$overflowchecks off}
   {$rangechecks off}
   {$S-}

--- a/units/Goccia.inc
+++ b/units/Goccia.inc
@@ -1,5 +1,6 @@
 {$mode delphi} {H+}
 {$IFDEF PRODUCTION}
+  {$optimization autoInline}
   {$overflowchecks off}
   {$rangechecks off}
   {$S-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes FPC 3.2.2 compiler error when `autoInline` is enabled by adding `-B` to production builds.

`{$optimization autoInline}` in FPC 3.2.2 creates corrupt inline data in PPU files that cause `EListError` when reused across compilation targets. Adding the `-B` (build all) flag forces FPC to recompile all units for each target, preventing the reuse of these corrupt PPUs and resolving the internal compiler error.

<div><a href="https://cursor.com/agents/bc-9edf7c07-adbe-42a8-9a5d-c3cb1db1e7da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edf7c07-adbe-42a8-9a5d-c3cb1db1e7da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->