### PR TITLE
Mark SouffleIsTrue as inline for hot-path branch elimination

### DIFF
--- a/souffle/Souffle.Value.pas
+++ b/souffle/Souffle.Value.pas
@@ -58,7 +58,7 @@ function SouffleIsReference(const AValue: TSouffleValue): Boolean; inline;
 function SouffleIsNumeric(const AValue: TSouffleValue): Boolean; inline;
 function SouffleIsStringValue(const AValue: TSouffleValue): Boolean; inline;
 
-function SouffleIsTrue(const AValue: TSouffleValue): Boolean;
+function SouffleIsTrue(const AValue: TSouffleValue): Boolean; inline;
 function SouffleAsNumber(const AValue: TSouffleValue): Double; inline;
 function SouffleToDouble(const AValue: TSouffleValue): Double; inline;
 function SouffleGetString(const AValue: TSouffleValue): string;


### PR DESCRIPTION
## Summary
- Marks `SouffleIsTrue` as `inline` in `Souffle.Value.pas`, matching the existing `inline` directive on `SouffleToDouble` and other hot-path helpers.
- `SouffleIsTrue` is called on every `OP_JUMP_IF_FALSE` and `OP_JUMP_IF_TRUE` in the main VM dispatch loop. Without `inline`, every conditional branch pays a function call overhead.
- The function is a simple `case` switch on `TSouffleValueKind` — well within FPC's inlining threshold.

## Test plan
- [x] All 3,462 JS tests pass in interpreter mode
- [x] All 3,462 JS tests pass in bytecode mode
- CI benchmark comparison will show impact on branch-heavy workloads

Made with [Cursor](https://cursor.com)