### PR TITLE
Remove dead decorator class bridge code

### DIFF
--- a/units/Goccia.Compiler.ExtOps.pas
+++ b/units/Goccia.Compiler.ExtOps.pas
@@ -13,7 +13,6 @@ const
   GOCCIA_EXT_DEF_STATIC_GETTER   = 6;  // A=target, C=name constant, R[A+1]=closure
   GOCCIA_EXT_DEF_STATIC_SETTER   = 7;  // A=target, C=name constant, R[A+1]=closure
   GOCCIA_EXT_REQUIRE_OBJECT      = 8;  // A=value (throws if null/undefined)
-  GOCCIA_EXT_EVAL_CLASS          = 9;  // A=dest, C=class index
   GOCCIA_EXT_THROW_TYPE_ERROR    = 10; // C=message constant
   GOCCIA_EXT_SUPER_GET           = 11; // A=dest, C=prop constant, R[A+1]=super blueprint
   GOCCIA_EXT_SPREAD              = 12; // A=target array, C=source reg

--- a/units/Goccia.Compiler.Statements.pas
+++ b/units/Goccia.Compiler.Statements.pas
@@ -50,13 +50,10 @@ procedure CompileDestructuringDeclaration(const ACtx: TGocciaCompilationContext;
 procedure CompileEnumDeclaration(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaEnumDeclaration);
 
-function IsSimpleClass(const AClassDef: TGocciaClassDefinition): Boolean;
 procedure CompileClassDeclaration(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaClassDeclaration);
 procedure CompileClassExpression(const ACtx: TGocciaCompilationContext;
   const AClassDef: TGocciaClassDefinition; const ADest: UInt8);
-procedure CompileComplexClassDeclaration(const ACtx: TGocciaCompilationContext;
-  const AStmt: TGocciaClassDeclaration; const APendingIndex: Integer);
 
 function TypeAnnotationToLocalType(const AAnnotation: string): TSouffleLocalType;
 function IsArrayTypeAnnotation(const AAnnotation: string): Boolean;
@@ -1228,11 +1225,6 @@ begin
   GBreakJumps.Add(EmitJumpInstruction(ACtx, OP_JUMP, 0));
 end;
 
-function IsSimpleClass(const AClassDef: TGocciaClassDefinition): Boolean;
-begin
-  Result := True;
-end;
-
 procedure CompileMethodBody(const ACtx: TGocciaCompilationContext;
   const AClassReg: UInt8; const AMethodName: string;
   const AMethod: TGocciaClassMethod; const AStoreOpcode: TSouffleOpCode);
@@ -2169,58 +2161,6 @@ begin
   end;
 
   ACtx.Scope.PrivatePrefix := '';
-end;
-
-procedure CompileComplexClassDeclaration(const ACtx: TGocciaCompilationContext;
-  const AStmt: TGocciaClassDeclaration; const APendingIndex: Integer);
-var
-  ClassDef: TGocciaClassDefinition;
-  ClassReg: UInt8;
-  NameIdx: UInt16;
-  I: Integer;
-  Local: TGocciaCompilerLocal;
-begin
-  ClassDef := AStmt.ClassDefinition;
-
-  for I := 0 to ACtx.Scope.LocalCount - 1 do
-  begin
-    Local := ACtx.Scope.GetLocal(I);
-    if (Local.Name <> '') and (Local.Name <> '__receiver') and
-       (Local.Name <> KEYWORD_THIS) then
-    begin
-      ACtx.Scope.MarkGlobalBacked(I);
-      NameIdx := ACtx.Template.AddConstantString(Local.Name);
-      if NameIdx > High(UInt8) then
-        raise Exception.Create('Constant pool overflow: global name index exceeds 255');
-      EmitInstruction(ACtx, EncodeABC(OP_RT_EXT, Local.Slot,
-        GOCCIA_EXT_DEFINE_GLOBAL, UInt8(NameIdx)));
-    end;
-  end;
-
-  ClassReg := ACtx.Scope.DeclareLocal(ClassDef.Name, True);
-  if APendingIndex > High(UInt8) then
-    raise Exception.Create('Compiler error: pending class index exceeds 255');
-  EmitInstruction(ACtx, EncodeABC(OP_RT_EXT, ClassReg,
-    GOCCIA_EXT_EVAL_CLASS, UInt8(APendingIndex)));
-
-  NameIdx := ACtx.Template.AddConstantString(ClassDef.Name);
-  if NameIdx > High(UInt8) then
-    raise Exception.Create('Constant pool overflow: global name index exceeds 255');
-  EmitInstruction(ACtx, EncodeABC(OP_RT_EXT, ClassReg,
-    GOCCIA_EXT_DEFINE_GLOBAL, UInt8(NameIdx)));
-
-  for I := 0 to ACtx.Scope.LocalCount - 1 do
-  begin
-    Local := ACtx.Scope.GetLocal(I);
-    if Local.IsGlobalBacked then
-    begin
-      NameIdx := ACtx.Template.AddConstantString(Local.Name);
-      if NameIdx > High(UInt8) then
-        raise Exception.Create('Constant pool overflow: global name index exceeds 255');
-      EmitInstruction(ACtx, EncodeABC(OP_RT_EXT, Local.Slot,
-        GOCCIA_EXT_DEFINE_GLOBAL, UInt8(NameIdx)));
-    end;
-  end;
 end;
 
 procedure CompileDestructuringDeclaration(const ACtx: TGocciaCompilationContext;

--- a/units/Goccia.Compiler.pas
+++ b/units/Goccia.Compiler.pas
@@ -17,12 +17,6 @@ uses
   Goccia.Compiler.Scope;
 
 type
-  TGocciaCompilerClassEntry = record
-    ClassDeclaration: TGocciaClassDeclaration;
-    Line: Integer;
-    Column: Integer;
-  end;
-
   TGocciaCompiler = class
   private
     FModule: TSouffleBytecodeModule;
@@ -30,12 +24,6 @@ type
     FCurrentScope: TGocciaCompilerScope;
     FSourcePath: string;
     FFormalParameterCounts: TFormalParameterCountMap;
-    FPendingClasses: array of TGocciaCompilerClassEntry;
-    FPendingClassNames: TDictionary<string, Boolean>;
-
-    function ShouldDeferClass(
-      const AClassDef: TGocciaClassDefinition): Boolean;
-
     procedure DoCompileExpression(const AExpr: TGocciaExpression;
       const ADest: UInt8);
     procedure DoCompileStatement(const AStmt: TGocciaStatement);
@@ -48,8 +36,6 @@ type
     destructor Destroy; override;
 
     function Compile(const AProgram: TGocciaProgram): TSouffleBytecodeModule;
-    function PendingClassCount: Integer;
-    function GetPendingClass(const AIndex: Integer): TGocciaCompilerClassEntry;
     property FormalParameterCounts: TFormalParameterCountMap
       read FFormalParameterCounts;
   end;
@@ -76,7 +62,6 @@ begin
   inherited Create;
   FSourcePath := ASourcePath;
   FFormalParameterCounts := TFormalParameterCountMap.Create;
-  FPendingClassNames := TDictionary<string, Boolean>.Create;
   FModule := nil;
   FCurrentTemplate := nil;
   FCurrentScope := nil;
@@ -84,20 +69,8 @@ end;
 
 destructor TGocciaCompiler.Destroy;
 begin
-  FPendingClassNames.Free;
   FFormalParameterCounts.Free;
   inherited;
-end;
-
-function TGocciaCompiler.ShouldDeferClass(
-  const AClassDef: TGocciaClassDefinition): Boolean;
-begin
-  if not Goccia.Compiler.Statements.IsSimpleClass(AClassDef) then
-    Exit(True);
-  if (AClassDef.SuperClass <> '') and
-     FPendingClassNames.ContainsKey(AClassDef.SuperClass) then
-    Exit(True);
-  Result := False;
 end;
 
 function TGocciaCompiler.BuildContext: TGocciaCompilationContext;
@@ -191,13 +164,8 @@ begin
     Goccia.Compiler.Expressions.CompileDestructuringAssignment(Ctx,
       TGocciaDestructuringAssignmentExpression(AExpr), ADest)
   else if AExpr is TGocciaClassExpression then
-  begin
-    if not ShouldDeferClass(TGocciaClassExpression(AExpr).ClassDefinition) then
-      Goccia.Compiler.Statements.CompileClassExpression(Ctx,
-        TGocciaClassExpression(AExpr).ClassDefinition, ADest)
-    else
-      EmitInstruction(Ctx, EncodeABC(OP_LOAD_NIL, ADest, 0, 0));
-  end
+    Goccia.Compiler.Statements.CompileClassExpression(Ctx,
+      TGocciaClassExpression(AExpr).ClassDefinition, ADest)
   else if AExpr is TGocciaAwaitExpression then
   begin
     DoCompileExpression(TGocciaAwaitExpression(AExpr).Operand, ADest);
@@ -235,23 +203,8 @@ begin
   else if AStmt is TGocciaForOfStatement then
     Goccia.Compiler.Statements.CompileForOfStatement(Ctx, TGocciaForOfStatement(AStmt))
   else if AStmt is TGocciaClassDeclaration then
-  begin
-    if not ShouldDeferClass(TGocciaClassDeclaration(AStmt).ClassDefinition) then
-      Goccia.Compiler.Statements.CompileClassDeclaration(Ctx,
-        TGocciaClassDeclaration(AStmt))
-    else
-    begin
-      FPendingClassNames.AddOrSetValue(
-        TGocciaClassDeclaration(AStmt).ClassDefinition.Name, True);
-      SetLength(FPendingClasses, Length(FPendingClasses) + 1);
-      FPendingClasses[High(FPendingClasses)].ClassDeclaration :=
-        TGocciaClassDeclaration(AStmt);
-      FPendingClasses[High(FPendingClasses)].Line := AStmt.Line;
-      FPendingClasses[High(FPendingClasses)].Column := AStmt.Column;
-      Goccia.Compiler.Statements.CompileComplexClassDeclaration(Ctx,
-        TGocciaClassDeclaration(AStmt), High(FPendingClasses));
-    end;
-  end
+    Goccia.Compiler.Statements.CompileClassDeclaration(Ctx,
+      TGocciaClassDeclaration(AStmt))
   else if AStmt is TGocciaSwitchStatement then
     Goccia.Compiler.Statements.CompileSwitchStatement(Ctx, TGocciaSwitchStatement(AStmt))
   else if AStmt is TGocciaBreakStatement then
@@ -367,17 +320,6 @@ begin
       FreeAndNil(FModule);
     end;
   end;
-end;
-
-function TGocciaCompiler.PendingClassCount: Integer;
-begin
-  Result := Length(FPendingClasses);
-end;
-
-function TGocciaCompiler.GetPendingClass(
-  const AIndex: Integer): TGocciaCompilerClassEntry;
-begin
-  Result := FPendingClasses[AIndex];
 end;
 
 end.

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -102,8 +102,6 @@ function TGocciaSouffleBackend.CompileToModule(
   const AProgram: TGocciaProgram): TSouffleBytecodeModule;
 var
   Compiler: TGocciaCompiler;
-  I: Integer;
-  Entry: TGocciaCompilerClassEntry;
   Template: TSouffleFunctionTemplate;
 begin
   Compiler := TGocciaCompiler.Create(FSourcePath);
@@ -113,14 +111,6 @@ begin
     for Template in Compiler.FormalParameterCounts.Keys do
       FRuntime.RegisterFormalParameterCount(
         Template, Compiler.FormalParameterCounts[Template]);
-
-    for I := 0 to Compiler.PendingClassCount - 1 do
-    begin
-      Entry := Compiler.GetPendingClass(I);
-      FRuntime.AddPendingClassDef(
-        Entry.ClassDeclaration.ClassDefinition,
-        Entry.Line, Entry.Column);
-    end;
   finally
     Compiler.Free;
   end;

--- a/units/Goccia.Runtime.Operations.pas
+++ b/units/Goccia.Runtime.Operations.pas
@@ -58,8 +58,6 @@ type
     IteratorNextCount: Int64;
     AwaitValueCount: Int64;
     ImportModuleCount: Int64;
-    EvaluateClassCount: Int64;
-
     ArrayCacheHit: Int64;
     ArrayCacheMiss: Int64;
     ClosureCacheHit: Int64;
@@ -91,11 +89,6 @@ type
     destructor Destroy; override;
   end;
 
-  TGocciaPendingClassEntry = record
-    ClassDefinition: TGocciaClassDefinition;
-    Line: Integer;
-    Column: Integer;
-  end;
 
   TGocciaWrappedValue = class(TSouffleHeapObject)
   private
@@ -194,8 +187,6 @@ type
     FBlueprintBridgeCache: TDictionary<TObject, TObject>;
     FBlueprintSuperValues: TDictionary<TObject, TSouffleValue>;
     FFormalParameterCounts: TDictionary<TSouffleFunctionTemplate, Integer>;
-    FPendingClasses: array of TGocciaPendingClassEntry;
-    FPendingClassCount: Integer;
     FClassDefinitionScopes: TDictionary<TObject, TObject>;
     FWrappedValues: TList;
     FBridgeCallDepth: Integer;
@@ -326,8 +317,6 @@ type
     procedure ThrowTypeErrorMessage(
       const AMessage: string);
 
-    function EvaluateClassByIndex(
-      const AIndex: Integer): TSouffleValue;
     function FinalizeEnum(const ARecord: TSouffleValue;
       const AName: string): TSouffleValue;
 
@@ -347,9 +336,6 @@ type
     procedure CheckLocalType(const AValue: TSouffleValue;
       const AExpectedType: TSouffleLocalType); override;
 
-    function AddPendingClassDef(
-      const AClassDef: TGocciaClassDefinition;
-      const ALine, AColumn: Integer): Integer;
 
     function TryInvokeGetter(const AGetterVal, AReceiver: TSouffleValue;
       out AResult: TSouffleValue): Boolean;
@@ -1289,7 +1275,6 @@ begin
   W('IteratorNext', IteratorNextCount);
   W('AwaitValue', AwaitValueCount);
   W('ImportModule', ImportModuleCount);
-  W('EvaluateClassByIndex', EvaluateClassCount);
   WriteLn(StdErr, 'Bridge caches:');
   W('Array cache hit', ArrayCacheHit);
   W('Array cache miss', ArrayCacheMiss);
@@ -1491,8 +1476,6 @@ procedure SyncArraysBack(const ARuntime: TGocciaRuntimeOperations;
 procedure SyncScopeToGlobals(const ARuntime: TGocciaRuntimeOperations;
   const AScope: TGocciaScope); forward;
 
-procedure SyncDefinitionScopesBack(
-  const ARuntime: TGocciaRuntimeOperations); forward;
 
 function BlueprintToClassValue(const ABlueprint: TSouffleBlueprint;
   const ARuntime: TGocciaRuntimeOperations): TGocciaClassValue; forward;
@@ -7764,19 +7747,6 @@ begin
   end;
 end;
 
-function TGocciaRuntimeOperations.AddPendingClassDef(
-  const AClassDef: TGocciaClassDefinition;
-  const ALine, AColumn: Integer): Integer;
-begin
-  Result := FPendingClassCount;
-  if FPendingClassCount >= Length(FPendingClasses) then
-    SetLength(FPendingClasses, FPendingClassCount * 2 + 4);
-  FPendingClasses[FPendingClassCount].ClassDefinition := AClassDef;
-  FPendingClasses[FPendingClassCount].Line := ALine;
-  FPendingClasses[FPendingClassCount].Column := AColumn;
-  Inc(FPendingClassCount);
-end;
-
 function BlueprintToClassValue(const ABlueprint: TSouffleBlueprint;
   const ARuntime: TGocciaRuntimeOperations): TGocciaClassValue;
 var
@@ -7915,65 +7885,6 @@ begin
     GocciaVal := AScope.GetValue(GlobalPair.Key);
     ARuntime.FGlobals.AddOrSetValue(
       GlobalPair.Key, ARuntime.ToSouffleValue(GocciaVal));
-  end;
-end;
-
-procedure SyncDefinitionScopesBack(
-  const ARuntime: TGocciaRuntimeOperations);
-var
-  ScopePair: TPair<TObject, TObject>;
-begin
-  for ScopePair in ARuntime.FClassDefinitionScopes do
-    SyncScopeToGlobals(ARuntime, TGocciaScope(ScopePair.Value));
-end;
-
-function TGocciaRuntimeOperations.EvaluateClassByIndex(
-  const AIndex: Integer): TSouffleValue;
-var
-  Entry: TGocciaPendingClassEntry;
-  Context: TGocciaEvaluationContext;
-  EvalScope: TGocciaScope;
-  ClassValue: TGocciaClassValue;
-  GocciaValue: TGocciaValue;
-  Pair: TPair<string, TSouffleValue>;
-begin
-  {$IFDEF BRIDGE_METRICS}
-  Inc(GBridgeMetrics.EvaluateClassCount);
-  {$ENDIF}
-  Result := SouffleNilWithFlags(GOCCIA_NIL_UNDEFINED);
-  if (AIndex < 0) or (AIndex >= FPendingClassCount) then
-    Exit;
-
-  Entry := FPendingClasses[AIndex];
-  Context := CreateBridgedContext(Self);
-  EvalScope := Context.Scope;
-
-  try
-    ClassValue := EvaluateClassDefinition(
-      Entry.ClassDefinition, Context, Entry.Line, Entry.Column);
-  except
-    on E: TGocciaThrowValue do
-      RethrowAsVM(E);
-  end;
-
-  SyncArraysBack(Self, EvalScope);
-  FArrayBridgeCache.Clear;
-
-  if Assigned(ClassValue) then
-  begin
-    FClassDefinitionScopes.AddOrSetValue(ClassValue, EvalScope);
-    TGarbageCollector.Instance.AddTempRoot(ClassValue);
-    try
-      Result := ToSouffleValue(ClassValue);
-      FGlobals.AddOrSetValue(Entry.ClassDefinition.Name, Result);
-      if EvalScope.ContainsOwnLexicalBinding(Entry.ClassDefinition.Name) then
-        EvalScope.AssignLexicalBinding(Entry.ClassDefinition.Name, ClassValue)
-      else
-        EvalScope.DefineLexicalBinding(
-          Entry.ClassDefinition.Name, ClassValue, dtLet);
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(ClassValue);
-    end;
   end;
 end;
 
@@ -8669,8 +8580,6 @@ begin
       DefineStaticSetter(ADest, ATemplate.GetConstant(AOperandIndex).StringValue, AExtra);
     8: // GOCCIA_EXT_REQUIRE_OBJECT
       RequireObjectCoercible(ADest);
-    9: // GOCCIA_EXT_EVAL_CLASS
-      ADest := EvaluateClassByIndex(AOperandIndex);
     10: // GOCCIA_EXT_THROW_TYPE_ERROR
       ThrowTypeErrorMessage(ATemplate.GetConstant(AOperandIndex).StringValue);
     11: // GOCCIA_EXT_SUPER_GET


### PR DESCRIPTION
## Summary
- Removes the entire `GOCCIA_EXT_EVAL_CLASS` / `EvaluateClassByIndex` code path, which was dead code since `IsSimpleClass` always returned `True`.
- All decorated classes are already compiled natively via `GOCCIA_EXT_BEGIN_DECORATORS` / `APPLY_ELEMENT_DECORATOR` / `FINISH_DECORATORS`.
- ~220 lines of dead code removed across 5 files: compiler, compiler statements, runtime operations, engine backend, and extension opcodes.
- `FClassDefinitionScopes` and `CreateBridgedContext` are preserved — they have other live callers.

## Test plan
- [x] All JS tests pass in interpreter mode
- [x] All JS tests pass in bytecode mode

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified class compilation by consolidating deferred processing mechanisms into streamlined single-pass compilation.
  * Removed intermediate class tracking infrastructure and related internal mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->