### PR TITLE
Replace double-negation unary + with OP_RT_TO_NUMBER

### DIFF
--- a/souffle/Souffle.Bytecode.pas
+++ b/souffle/Souffle.Bytecode.pas
@@ -167,6 +167,7 @@ type
     OP_RT_IS_INSTANCE = 150, // ABC  R[A] := Runtime.IsInstance(R[B], R[C])
     OP_RT_HAS_PROPERTY = 151, // ABC R[A] := Runtime.HasProperty(R[B], R[C])
     OP_RT_TO_BOOLEAN = 152, // AB    R[A] := Runtime.ToBoolean(R[B])
+    OP_RT_TO_NUMBER  = 153, // AB    R[A] := ToNumber(R[B]) — numeric identity, else Runtime.ToNumber
 
     // ── Runtime: Property Access ──
     OP_RT_GET_PROP   = 156, // ABC   R[A] := Runtime.GetProperty(R[B], Constants[C])

--- a/souffle/Souffle.VM.pas
+++ b/souffle/Souffle.VM.pas
@@ -1777,6 +1777,27 @@ begin
       A := DecodeA(AInstruction); B := DecodeB(AInstruction);
       FRegisters[Base + A] := FRuntimeOps.ToBoolean(FRegisters[Base + B]);
     end;
+    OP_RT_TO_NUMBER:
+    begin
+      A := DecodeA(AInstruction); B := DecodeB(AInstruction);
+      case FRegisters[Base + B].Kind of
+        svkInteger, svkFloat:
+          FRegisters[Base + A] := FRegisters[Base + B];
+        svkBoolean:
+          if FRegisters[Base + B].AsBoolean then
+            FRegisters[Base + A] := SouffleInteger(1)
+          else
+            FRegisters[Base + A] := SouffleInteger(0);
+        svkNil:
+          if FRegisters[Base + B].Flags = 0 then
+            FRegisters[Base + A] := SouffleFloat(NaN)
+          else
+            FRegisters[Base + A] := SouffleInteger(0);
+      else
+        FRegisters[Base + A] := FRuntimeOps.Negate(
+          FRuntimeOps.Negate(FRegisters[Base + B]));
+      end;
+    end;
 
     OP_RT_GET_PROP:
     begin

--- a/souffle/Souffle.Wasm.Translator.pas
+++ b/souffle/Souffle.Wasm.Translator.pas
@@ -71,6 +71,7 @@ type
     FRtNot: UInt32;
     FRtTypeOf: UInt32;
     FRtIsInstance: UInt32;
+    FRtToNumber: UInt32;
     FRtHasProperty: UInt32;
     FRtToBooleanVal: UInt32;
 
@@ -395,6 +396,7 @@ begin
   FRtIsInstance := Cond2('rt_is_instance', [OP_RT_IS_INSTANCE]);
   FRtHasProperty := Cond2('rt_has_property', [OP_RT_HAS_PROPERTY]);
   FRtToBooleanVal := Cond1('rt_to_boolean_val', [OP_RT_TO_BOOLEAN]);
+  FRtToNumber := Cond1('rt_to_number', [OP_RT_TO_NUMBER]);
 
   FRtGetProp := CondT('rt_get_prop',
     [WT_EXTERNREF, WT_I32], [WT_EXTERNREF], [OP_RT_GET_PROP]);
@@ -1247,6 +1249,12 @@ begin
     begin
       ABuilder.EmitLocalGet(B);
       ABuilder.EmitCall(FRtToBooleanVal);
+      ABuilder.EmitLocalSet(A);
+    end;
+    OP_RT_TO_NUMBER:
+    begin
+      ABuilder.EmitLocalGet(B);
+      ABuilder.EmitCall(FRtToNumber);
       ABuilder.EmitLocalSet(A);
     end;
 

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -508,11 +508,7 @@ begin
   case AExpr.Operator of
     gttNot:        EmitInstruction(ACtx, EncodeABC(OP_RT_NOT, ADest, RegB, 0));
     gttMinus:      EmitInstruction(ACtx, EncodeABC(OP_RT_NEG, ADest, RegB, 0));
-    gttPlus:
-    begin
-      EmitInstruction(ACtx, EncodeABC(OP_RT_NEG, ADest, RegB, 0));
-      EmitInstruction(ACtx, EncodeABC(OP_RT_NEG, ADest, ADest, 0));
-    end;
+    gttPlus:       EmitInstruction(ACtx, EncodeABC(OP_RT_TO_NUMBER, ADest, RegB, 0));
     gttTypeof:     EmitInstruction(ACtx, EncodeABC(OP_RT_TYPEOF, ADest, RegB, 0));
     gttBitwiseNot: EmitInstruction(ACtx, EncodeABC(OP_RT_BNOT, ADest, RegB, 0));
   else


### PR DESCRIPTION
## Summary
- Adds `OP_RT_TO_NUMBER` (opcode 153) to replace the double-negation pattern for unary `+` (ToNumber coercion).
- Compiler now emits one instruction instead of two for unary `+`.
- VM handler resolves numeric types as identity, boolean/nil inline, and only falls back to `FRuntimeOps.Negate` double-call for strings and references.
- WASM translator updated with dedicated `rt_to_number` import.

## Test plan
- [x] All JS tests pass in interpreter mode
- [x] All JS tests pass in bytecode mode

Made with [Cursor](https://cursor.com)