### PR TITLE
Pre-materialize constant pool into TSouffleValue array on template load

### DIFF
--- a/souffle/Souffle.Bytecode.Chunk.pas
+++ b/souffle/Souffle.Bytecode.Chunk.pas
@@ -7,7 +7,8 @@ interface
 uses
   Generics.Collections,
 
-  Souffle.Bytecode.Debug;
+  Souffle.Bytecode.Debug,
+  Souffle.Value;
 
 type
   TSouffleBytecodeConstantKind = (
@@ -69,6 +70,7 @@ type
     FLocalStrictCount: UInt8;
     FIsAsync: Boolean;
     FTypeCheckPreambleSize: UInt8;
+    FMaterializedConstants: array of TSouffleValue;
     FStringConstantIndex: TDictionary<string, UInt16>;
     function GetFunctionCount: Integer;
   public
@@ -92,6 +94,9 @@ type
     function GetFunction(const AIndex: Integer): TSouffleFunctionTemplate;
     function GetUpvalueDescriptor(const AIndex: Integer): TSouffleUpvalueDescriptor;
     function GetExceptionHandler(const AIndex: Integer): TSouffleExceptionHandler;
+
+    procedure MaterializeConstants;
+    function GetMaterializedConstant(const AIndex: Integer): TSouffleValue; inline;
 
     property Name: string read FName write FName;
     property CodeCount: Integer read FCodeCount;
@@ -401,6 +406,39 @@ begin
     Result := FLocalStrictFlags[ASlot]
   else
     Result := False;
+end;
+
+procedure TSouffleFunctionTemplate.MaterializeConstants;
+var
+  I: Integer;
+begin
+  if FConstantCount > Length(FMaterializedConstants) then
+  begin
+    SetLength(FMaterializedConstants, FConstantCount);
+    for I := 0 to FConstantCount - 1 do
+      case FConstants[I].Kind of
+        bckNil:     FMaterializedConstants[I] := SouffleNil;
+        bckTrue:    FMaterializedConstants[I] := SouffleBoolean(True);
+        bckFalse:   FMaterializedConstants[I] := SouffleBoolean(False);
+        bckInteger: FMaterializedConstants[I] := SouffleInteger(FConstants[I].IntValue);
+        bckFloat:   FMaterializedConstants[I] := SouffleFloat(FConstants[I].FloatValue);
+        bckString:  FMaterializedConstants[I] := SouffleString(FConstants[I].StringValue);
+      end;
+  end;
+  for I := 0 to FFunctions.Count - 1 do
+    FFunctions[I].MaterializeConstants;
+end;
+
+function TSouffleFunctionTemplate.GetMaterializedConstant(
+  const AIndex: Integer): TSouffleValue;
+begin
+  {$IFDEF DEBUG}
+  if (AIndex < 0) or (AIndex >= Length(FMaterializedConstants)) then
+    raise ERangeError.CreateFmt(
+      'GetMaterializedConstant: index %d out of range 0..%d',
+      [AIndex, Length(FMaterializedConstants) - 1]);
+  {$ENDIF}
+  Result := FMaterializedConstants[AIndex];
 end;
 
 end.

--- a/souffle/Souffle.VM.pas
+++ b/souffle/Souffle.VM.pas
@@ -116,6 +116,7 @@ begin
   if not Assigned(AModule.TopLevel) then
     Exit(SouffleNil);
 
+  AModule.TopLevel.MaterializeConstants;
   TopClosure := TSouffleClosure.Create(AModule.TopLevel);
   if Assigned(FGC) then
     FGC.AllocateObject(TopClosure);
@@ -279,8 +280,7 @@ begin
           begin
             A := UInt8((Instruction shr 8) and $FF);
             Bx := UInt16((Instruction shr 16) and $FFFF);
-            FRegisters[Base + A] :=
-              MaterializeConstant(Frame^.Template.GetConstant(Bx));
+            FRegisters[Base + A] := Frame^.Template.GetMaterializedConstant(Bx);
           end;
 
           OP_LOAD_TRUE:
@@ -657,8 +657,7 @@ begin
     begin
       A := DecodeA(AInstruction);
       Bx := DecodeBx(AInstruction);
-      FRegisters[Base + A] := MaterializeConstant(
-        AFrame^.Template.GetConstant(Bx));
+      FRegisters[Base + A] := AFrame^.Template.GetMaterializedConstant(Bx);
     end;
 
     OP_LOAD_NIL:


### PR DESCRIPTION
## Summary
- Pre-materializes the constant pool into a \`TSouffleValue\` array when a module is loaded, before VM execution begins.
- \`OP_LOAD_CONST\` becomes a single array index lookup (\`GetMaterializedConstant\`) with no branching on constant kind or heap string allocation per instruction.
- \`MaterializeConstants\` is recursive — covers all sub-templates (closures, methods) in one pass.
- String heap objects are allocated once during materialization and reused across all constant loads.

## Test plan
- [x] All JS tests pass in interpreter mode
- [x] All JS tests pass in bytecode mode

Made with [Cursor](https://cursor.com)