### PR TITLE
Benchmark tests regression

### DIFF
--- a/souffle/Souffle.Bytecode.Chunk.pas
+++ b/souffle/Souffle.Bytecode.Chunk.pas
@@ -126,7 +126,9 @@ const
 implementation
 
 uses
-  SysUtils;
+  SysUtils,
+
+  GarbageCollector.Generic;
 
 function FloatBitsAreNaN(const AValue: Double): Boolean; inline;
 var
@@ -157,7 +159,16 @@ begin
 end;
 
 destructor TSouffleFunctionTemplate.Destroy;
+var
+  GC: TGarbageCollector;
+  I: Integer;
 begin
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) then
+    for I := 0 to Length(FMaterializedConstants) - 1 do
+      if (FMaterializedConstants[I].Kind = svkReference) and
+         Assigned(FMaterializedConstants[I].AsReference) then
+        GC.UnpinObject(FMaterializedConstants[I].AsReference);
   FStringConstantIndex.Free;
   FFunctions.Free;
   FDebugInfo.Free;
@@ -411,9 +422,11 @@ end;
 procedure TSouffleFunctionTemplate.MaterializeConstants;
 var
   I: Integer;
+  GC: TGarbageCollector;
 begin
   if FConstantCount > Length(FMaterializedConstants) then
   begin
+    GC := TGarbageCollector.Instance;
     SetLength(FMaterializedConstants, FConstantCount);
     for I := 0 to FConstantCount - 1 do
       case FConstants[I].Kind of
@@ -422,7 +435,13 @@ begin
         bckFalse:   FMaterializedConstants[I] := SouffleBoolean(False);
         bckInteger: FMaterializedConstants[I] := SouffleInteger(FConstants[I].IntValue);
         bckFloat:   FMaterializedConstants[I] := SouffleFloat(FConstants[I].FloatValue);
-        bckString:  FMaterializedConstants[I] := SouffleString(FConstants[I].StringValue);
+        bckString:
+        begin
+          FMaterializedConstants[I] := SouffleString(FConstants[I].StringValue);
+          if (FMaterializedConstants[I].Kind = svkReference) and
+             Assigned(FMaterializedConstants[I].AsReference) and Assigned(GC) then
+            GC.PinObject(FMaterializedConstants[I].AsReference);
+        end;
       end;
   end;
   for I := 0 to FFunctions.Count - 1 do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pin heap-allocated string constants during bytecode execution to prevent premature garbage collection and fix benchmark crashes.

The previous commit 14f8d36 pre-materialized constants into a `TSouffleValue` array. For strings exceeding the inline threshold, `SouffleString` creates `TSouffleHeapString` objects on the heap. Since `TSouffleFunctionTemplate` is not GC-managed, these heap strings were not reachable from GC roots and were prematurely collected by `GC.Collect`, leading to dereferencing freed memory during subsequent constant loads in bytecode benchmarks.

<div><a href="https://cursor.com/agents/bc-dbf1e52f-9e92-4782-ac75-5bc21c0902fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbf1e52f-9e92-4782-ac75-5bc21c0902fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved memory management and garbage collection procedures for enhanced resource cleanup and system stability. These internal optimizations ensure more efficient resource utilization during application operations and better handling of system resources throughout the application lifecycle. The result is improved overall application performance, reliability, responsiveness, and system efficiency during runtime execution and normal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->