### PR TITLE
Experiment: SOUFFLE_INLINE_STRING_MAX = 7

### DIFF
--- a/souffle/Souffle.Value.pas
+++ b/souffle/Souffle.Value.pas
@@ -268,7 +268,12 @@ begin
     svkString:
       Result := A.AsInlineString = B.AsInlineString;
     svkReference:
-      Result := A.AsReference = B.AsReference;
+      if (A.AsReference is TSouffleHeapString) and
+         (B.AsReference is TSouffleHeapString) then
+        Result := TSouffleHeapString(A.AsReference).Value =
+          TSouffleHeapString(B.AsReference).Value
+      else
+        Result := A.AsReference = B.AsReference;
   else
     Result := False;
   end;

--- a/units/Goccia.Runtime.Operations.pas
+++ b/units/Goccia.Runtime.Operations.pas
@@ -1530,7 +1530,7 @@ begin
       .Invoke(ASelf, nil, 0)
   else
     Exit;
-  Result := APrimitive.Kind <> svkReference;
+  Result := (APrimitive.Kind <> svkReference) or SouffleIsStringValue(APrimitive);
 end;
 
 function FindRecordMethod(const ARec: TSouffleRecord;


### PR DESCRIPTION
## Experiment

Reduces `SOUFFLE_INLINE_STRING_MAX` from 23 to 7, shrinking `TSouffleValue` from 26 bytes to 10 bytes (variant arm now matches `Int64` at 8 bytes). Strings longer than 7 chars spill to `TSouffleHeapString` on the GC heap.

**Hypothesis:** Smaller record size improves cache density in the VM register file (`FRegisters`), reducing cache misses in the dispatch loop. Trade-off: more heap allocations for medium-length strings (8-23 chars).

**Known:** 6 bytecode test failures in string-heavy operations (toString, split, template literals) where strings >7 chars were previously inline. This is a benchmarking experiment, not intended for merge.

## Test plan
- [x] Interpreter: 3422 passed, 0 failed, 41 skipped
- [x] Bytecode: 3452 passed, 6 failed, 5 skipped
- [ ] CI benchmarks for performance comparison


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted string storage behavior to improve memory efficiency for short strings.

* **Bug Fixes**
  * Fixed string comparison to correctly compare underlying string values when needed.
  * Broadened acceptance of primitive invocation results to allow string values wrapped as references, reducing erroneous failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->