### PR TITLE
Fix FPC 3.2.2 internal error on CI prod builds

### DIFF
--- a/souffle/Souffle.VM.pas
+++ b/souffle/Souffle.VM.pas
@@ -122,6 +122,13 @@ begin
   if Assigned(FGC) then
     FGC.AllocateObject(TopClosure);
 
+  // WORKAROUND: Do NOT simplify this to ExecuteFunction(TopClosure, [SouffleNil]).
+  // FPC 3.2.2 has a compiler bug (Internal error 2018042601) in its temporary
+  // register allocator that fires when a packed variant record <= 16 bytes
+  // (i.e. TSouffleValue at SOUFFLE_INLINE_STRING_MAX = 13) is passed via an
+  // inline open array constructor at -O2 or higher. Using a stack-allocated
+  // array sidesteps the bug. Safe to revisit if we upgrade past FPC 3.2.2.
+  // See: https://github.com/frostney/GocciaScript/pull/98
   Args[0] := SouffleNil;
   Result := ExecuteFunction(TopClosure, Args);
 end;

--- a/souffle/Souffle.VM.pas
+++ b/souffle/Souffle.VM.pas
@@ -112,6 +112,7 @@ end;
 function TSouffleVM.Execute(const AModule: TSouffleBytecodeModule): TSouffleValue;
 var
   TopClosure: TSouffleClosure;
+  Args: array[0..0] of TSouffleValue;
 begin
   if not Assigned(AModule.TopLevel) then
     Exit(SouffleNil);
@@ -121,7 +122,8 @@ begin
   if Assigned(FGC) then
     FGC.AllocateObject(TopClosure);
 
-  Result := ExecuteFunction(TopClosure, [SouffleNil]);
+  Args[0] := SouffleNil;
+  Result := ExecuteFunction(TopClosure, Args);
 end;
 
 function TSouffleVM.ExecuteFunction(const AClosure: TSouffleClosure;

--- a/souffle/Souffle.VM.pas
+++ b/souffle/Souffle.VM.pas
@@ -126,8 +126,11 @@ begin
   // FPC 3.2.2 has a compiler bug (Internal error 2018042601) in its temporary
   // register allocator that fires when a packed variant record <= 16 bytes
   // (i.e. TSouffleValue at SOUFFLE_INLINE_STRING_MAX = 13) is passed via an
-  // inline open array constructor at -O2 or higher. Using a stack-allocated
-  // array sidesteps the bug. Safe to revisit if we upgrade past FPC 3.2.2.
+  // inline open array constructor at -O2 or higher. The bug is aarch64-specific
+  // — x86_64 builds (including Ubuntu CI) are unaffected because the x64 code
+  // generator uses a different register allocation path for open array temps.
+  // Using a stack-allocated array sidesteps the bug on all targets.
+  // Safe to revisit if we upgrade past FPC 3.2.2.
   // See: https://github.com/frostney/GocciaScript/pull/98
   Args[0] := SouffleNil;
   Result := ExecuteFunction(TopClosure, Args);


### PR DESCRIPTION
## Summary
- FPC 3.2.2 has a compiler bug in its temp register allocator that fires when a packed variant record <= 16 bytes is passed via an inline open array constructor at `-O2` or higher
- After f0257b1 shrank `TSouffleValue` from 26 to 16 bytes, the `[SouffleNil]` call in `Souffle.VM.pas:124` started triggering `Internal error 2018042601` on CI (`-O4`), while local debug builds (`-O-`) were unaffected
- Replace the inline open array with a stack-allocated array variable to sidestep the FPC bug

## Test plan
- [ ] CI prod build passes on aarch64 without `Internal error 2018042601`
- [ ] Existing test suite passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved VM execution stability via an internal change that avoids a known compiler-related issue and includes notes for future review.

* **Bug Fixes**
  * Addressed an intermittent execution problem observed with a specific compiler version by applying a safe workaround to prevent incorrect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->