### PR TITLE
Set prototype.constructor on native blueprint construct path

### DIFF
--- a/tests/language/classes/basic-class-declaration.js
+++ b/tests/language/classes/basic-class-declaration.js
@@ -15,6 +15,38 @@ test("simple class creation", () => {
   expect(person instanceof Person).toBeTruthy();
 });
 
+test("instance.constructor points to class", () => {
+  class Foo {
+    constructor() {
+      this.name = "foo";
+    }
+  }
+
+  const f = new Foo();
+  expect(f.constructor === Foo).toBe(true);
+});
+
+test("instance.constructor follows inheritance chain", () => {
+  class Base {
+    constructor() {
+      this.base = true;
+    }
+  }
+
+  class Child extends Base {
+    constructor() {
+      super();
+      this.child = true;
+    }
+  }
+
+  const b = new Base();
+  const c = new Child();
+  expect(b.constructor === Base).toBe(true);
+  expect(c.constructor === Child).toBe(true);
+  expect(c.constructor === Base).toBe(false);
+});
+
 test("class reference preserves instanceof", () => {
   class MyClass {
     constructor(x) {

--- a/units/Goccia.Runtime.Operations.pas
+++ b/units/Goccia.Runtime.Operations.pas
@@ -3311,6 +3311,8 @@ begin
             else if Assigned(FVM) then
               WalkBp.Methods.Delegate := FVM.RecordDelegate;
           end;
+          if not WalkBp.Prototype.Get(PROP_CONSTRUCTOR, CtorMethod) then
+            WalkBp.Prototype.Put(PROP_CONSTRUCTOR, SouffleReference(WalkBp));
           WalkBp := WalkBp.SuperBlueprint;
         end;
       end;


### PR DESCRIPTION
## Summary

- Sets the `constructor` property on each blueprint's prototype during the delegate chain walk in the native construct path, so `instance.constructor === Class` returns `true` in bytecode mode
- Guarded by `Get(PROP_CONSTRUCTOR)` to avoid redundant writes on repeated constructions of the same class
- Adds two test cases to `basic-class-declaration.js`: single class and inheritance chain

## Test plan

- [x] `instance.constructor === Foo` passes in both interpreter and bytecode modes
- [x] Inheritance chain: `child.constructor === Child` is `true`, `child.constructor === Base` is `false`
- [x] Full test suite (3,501 tests) passes in both modes with zero failures

Closes #101

Made with [Cursor](https://cursor.com)