### PR TITLE
Eliminate interpreter bridge for async/await in bytecode mode

### DIFF
--- a/units/Goccia.Runtime.Operations.pas
+++ b/units/Goccia.Runtime.Operations.pas
@@ -4070,6 +4070,7 @@ end;
 function TGocciaRuntimeOperations.AwaitValue(const AValue: TSouffleValue): TSouffleValue;
 var
   GocciaVal, ThenMethod: TGocciaValue;
+  ThenVal: TSouffleValue;
   Promise: TGocciaPromiseValue;
   ThenArgs: TGocciaArgumentsCollection;
   Queue: TGocciaMicrotaskQueue;
@@ -4119,6 +4120,35 @@ begin
     end
     else
       Exit(ToSouffleValue(GocciaVal));
+  end
+  else if AValue.AsReference is TSouffleRecord then
+  begin
+    ThenVal := GetProperty(AValue, 'then');
+    if SouffleIsReference(ThenVal) and Assigned(ThenVal.AsReference) and
+       ((ThenVal.AsReference is TSouffleClosure) or
+        (ThenVal.AsReference is TSouffleNativeFunction) or
+        (ThenVal.AsReference is TGocciaBridgedFunction)) then
+    begin
+      Promise := TGocciaPromiseValue.Create;
+      ThenArgs := TGocciaArgumentsCollection.Create([
+        TGocciaNativeFunctionValue.Create(Promise.DoResolve, 'resolve', 1),
+        TGocciaNativeFunctionValue.Create(Promise.DoReject, 'reject', 1)
+      ]);
+      try
+        try
+          GocciaVal := UnwrapToGocciaValue(ThenVal);
+          TGocciaFunctionBase(GocciaVal).Call(
+            ThenArgs, UnwrapToGocciaValue(AValue));
+        except
+          on E: TGocciaThrowValue do
+            Promise.Reject(E.Value);
+        end;
+      finally
+        ThenArgs.Free;
+      end;
+    end
+    else
+      Exit(AValue);
   end
   else
     Exit(AValue);

--- a/units/Goccia.Runtime.Operations.pas
+++ b/units/Goccia.Runtime.Operations.pas
@@ -4069,44 +4069,91 @@ end;
 
 function TGocciaRuntimeOperations.AwaitValue(const AValue: TSouffleValue): TSouffleValue;
 var
-  GocciaVal, Resolved: TGocciaValue;
+  GocciaVal, ThenMethod: TGocciaValue;
+  Promise: TGocciaPromiseValue;
+  ThenArgs: TGocciaArgumentsCollection;
+  Queue: TGocciaMicrotaskQueue;
 begin
-  {$IFDEF BRIDGE_METRICS}
-  Inc(GBridgeMetrics.AwaitValueCount);
-  {$ENDIF}
   case AValue.Kind of
     svkNil, svkBoolean, svkInteger, svkFloat, svkString:
       Exit(AValue);
   end;
-  if SouffleIsReference(AValue) and Assigned(AValue.AsReference) then
+  if not SouffleIsReference(AValue) or not Assigned(AValue.AsReference) then
+    Exit(AValue);
+  if AValue.AsReference is TSouffleHeapString then
+    Exit(AValue);
+
+  Promise := nil;
+
+  if AValue.AsReference is TGocciaWrappedValue then
   begin
-    if AValue.AsReference is TSouffleHeapString then
-      Exit(AValue);
-    if AValue.AsReference is TGocciaWrappedValue then
+    GocciaVal := TGocciaWrappedValue(AValue.AsReference).Value;
+
+    if GocciaVal is TGocciaPromiseValue then
+      Promise := TGocciaPromiseValue(GocciaVal)
+    else if GocciaVal is TGocciaObjectValue then
     begin
-      GocciaVal := TGocciaWrappedValue(AValue.AsReference).Value;
-      if GocciaVal is TGocciaPromiseValue then
+      ThenMethod := GocciaVal.GetProperty('then');
+      if Assigned(ThenMethod) and
+         not (ThenMethod is TGocciaUndefinedLiteralValue) and
+         ThenMethod.IsCallable then
       begin
-        if TGocciaPromiseValue(GocciaVal).State = gpsFulfilled then
-          Exit(ToSouffleValue(TGocciaPromiseValue(GocciaVal).PromiseResult));
-        if TGocciaPromiseValue(GocciaVal).State = gpsRejected then
-        begin
-          RethrowAsVM(TGocciaThrowValue.Create(
-            TGocciaPromiseValue(GocciaVal).PromiseResult));
-          Exit(SouffleNilWithFlags(GOCCIA_NIL_UNDEFINED));
+        Promise := TGocciaPromiseValue.Create;
+        ThenArgs := TGocciaArgumentsCollection.Create([
+          TGocciaNativeFunctionValue.Create(Promise.DoResolve, 'resolve', 1),
+          TGocciaNativeFunctionValue.Create(Promise.DoReject, 'reject', 1)
+        ]);
+        try
+          try
+            TGocciaFunctionBase(ThenMethod).Call(ThenArgs, GocciaVal);
+          except
+            on E: TGocciaThrowValue do
+              Promise.Reject(E.Value);
+          end;
+        finally
+          ThenArgs.Free;
         end;
       end
-      else if not (GocciaVal is TGocciaObjectValue) then
-        Exit(ToSouffleValue(GocciaVal));
-    end;
-  end;
+      else
+        Exit(AValue);
+    end
+    else
+      Exit(ToSouffleValue(GocciaVal));
+  end
+  else
+    Exit(AValue);
+
+  if not Assigned(Promise) then
+    Exit(AValue);
+
+  if Assigned(TGarbageCollector.Instance) then
+    TGarbageCollector.Instance.AddTempRoot(Promise);
   try
-    GocciaVal := UnwrapToGocciaValue(AValue);
-    Resolved := Goccia.Evaluator.AwaitValue(GocciaVal);
-    Result := ToSouffleValue(Resolved);
-  except
-    on E: TGocciaThrowValue do
-      RethrowAsVM(E);
+    if Promise.State = gpsFulfilled then
+      Exit(ToSouffleValue(Promise.PromiseResult));
+    if Promise.State = gpsRejected then
+    begin
+      RethrowAsVM(TGocciaThrowValue.Create(Promise.PromiseResult));
+      Exit(SouffleNilWithFlags(GOCCIA_NIL_UNDEFINED));
+    end;
+
+    Queue := TGocciaMicrotaskQueue.Instance;
+    if Assigned(Queue) then
+      Queue.DrainQueue;
+
+    if Promise.State = gpsFulfilled then
+      Result := ToSouffleValue(Promise.PromiseResult)
+    else if Promise.State = gpsRejected then
+    begin
+      RethrowAsVM(TGocciaThrowValue.Create(Promise.PromiseResult));
+      Result := SouffleNilWithFlags(GOCCIA_NIL_UNDEFINED);
+    end
+    else
+      raise ESouffleThrow.Create(SouffleString(
+        'await: Promise did not settle after microtask drain'));
+  finally
+    if Assigned(TGarbageCollector.Instance) then
+      TGarbageCollector.Instance.RemoveTempRoot(Promise);
   end;
 end;
 

--- a/units/Goccia.Runtime.Operations.pas
+++ b/units/Goccia.Runtime.Operations.pas
@@ -4074,6 +4074,7 @@ var
   Promise: TGocciaPromiseValue;
   ThenArgs: TGocciaArgumentsCollection;
   Queue: TGocciaMicrotaskQueue;
+  PromiseRooted: Boolean;
 begin
   case AValue.Kind of
     svkNil, svkBoolean, svkInteger, svkFloat, svkString:
@@ -4085,6 +4086,7 @@ begin
     Exit(AValue);
 
   Promise := nil;
+  PromiseRooted := False;
 
   if AValue.AsReference is TGocciaWrappedValue then
   begin
@@ -4094,12 +4096,15 @@ begin
       Promise := TGocciaPromiseValue(GocciaVal)
     else if GocciaVal is TGocciaObjectValue then
     begin
-      ThenMethod := GocciaVal.GetProperty('then');
+      ThenMethod := GocciaVal.GetProperty(PROP_THEN);
       if Assigned(ThenMethod) and
          not (ThenMethod is TGocciaUndefinedLiteralValue) and
          ThenMethod.IsCallable then
       begin
         Promise := TGocciaPromiseValue.Create;
+        if Assigned(TGarbageCollector.Instance) then
+          TGarbageCollector.Instance.AddTempRoot(Promise);
+        PromiseRooted := True;
         ThenArgs := TGocciaArgumentsCollection.Create([
           TGocciaNativeFunctionValue.Create(Promise.DoResolve, 'resolve', 1),
           TGocciaNativeFunctionValue.Create(Promise.DoReject, 'reject', 1)
@@ -4123,20 +4128,22 @@ begin
   end
   else if AValue.AsReference is TSouffleRecord then
   begin
-    ThenVal := GetProperty(AValue, 'then');
-    if SouffleIsReference(ThenVal) and Assigned(ThenVal.AsReference) and
-       ((ThenVal.AsReference is TSouffleClosure) or
-        (ThenVal.AsReference is TSouffleNativeFunction) or
-        (ThenVal.AsReference is TGocciaBridgedFunction)) then
+    ThenVal := GetProperty(AValue, PROP_THEN);
+    GocciaVal := UnwrapToGocciaValue(ThenVal);
+    if Assigned(GocciaVal) and
+       not (GocciaVal is TGocciaUndefinedLiteralValue) and
+       (GocciaVal is TGocciaFunctionBase) then
     begin
       Promise := TGocciaPromiseValue.Create;
+      if Assigned(TGarbageCollector.Instance) then
+        TGarbageCollector.Instance.AddTempRoot(Promise);
+      PromiseRooted := True;
       ThenArgs := TGocciaArgumentsCollection.Create([
         TGocciaNativeFunctionValue.Create(Promise.DoResolve, 'resolve', 1),
         TGocciaNativeFunctionValue.Create(Promise.DoReject, 'reject', 1)
       ]);
       try
         try
-          GocciaVal := UnwrapToGocciaValue(ThenVal);
           TGocciaFunctionBase(GocciaVal).Call(
             ThenArgs, UnwrapToGocciaValue(AValue));
         except
@@ -4156,8 +4163,11 @@ begin
   if not Assigned(Promise) then
     Exit(AValue);
 
-  if Assigned(TGarbageCollector.Instance) then
+  if not PromiseRooted and Assigned(TGarbageCollector.Instance) then
+  begin
     TGarbageCollector.Instance.AddTempRoot(Promise);
+    PromiseRooted := True;
+  end;
   try
     if Promise.State = gpsFulfilled then
       Exit(ToSouffleValue(Promise.PromiseResult));
@@ -4179,10 +4189,10 @@ begin
       Result := SouffleNilWithFlags(GOCCIA_NIL_UNDEFINED);
     end
     else
-      raise ESouffleThrow.Create(SouffleString(
-        'await: Promise did not settle after microtask drain'));
+      ThrowTypeErrorMessage(
+        'await: Promise did not settle after microtask drain');
   finally
-    if Assigned(TGarbageCollector.Instance) then
+    if PromiseRooted and Assigned(TGarbageCollector.Instance) then
       TGarbageCollector.Instance.RemoveTempRoot(Promise);
   end;
 end;


### PR DESCRIPTION
## Summary

- Replace `AwaitValue()` bridge call to `Goccia.Evaluator.AwaitValue()` with a native implementation in the runtime layer
- Handle Promises, thenables, and microtask queue draining directly — no interpreter crossing needed
- Keep the implementation in the runtime layer (not the VM dispatch loop) to avoid the icache pressure that caused PR #88's regression

The native implementation handles:
- **Primitives and heap strings**: return as-is (zero cost)
- **`TGocciaPromiseValue`**: check state directly; if pending, drain microtask queue and re-check; return result or rethrow rejection
- **Thenable objects** (objects with callable `.then`): create Promise, call `.then(resolve, reject)` natively, drain queue, return settled result
- **Non-thenable objects**: return as-is

## Test plan

- [x] Interpreter: 3501 passed, 0 failed, 41 skipped
- [x] Bytecode: 3501 passed, 0 failed, 0 skipped
- [x] Async/await tests (Promise resolution, rejection, chaining, thenable adoption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured async operation handling to improve Promise settlement detection and microtask queue management, enhancing reliability and performance of await operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->