### PR TITLE
Support reading ScriptLoader source from stdin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,22 @@ jobs:
       - name: Run example scripts
         run: ./build/ScriptLoader examples
 
+      - name: Run stdin smoke tests
+        run: |
+          script_output="$(printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader)"
+          printf '%s\n' "$script_output" | grep -q 'Result: 4'
+
+          script_output_bytecode="$(printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader - --mode=bytecode)"
+          printf '%s\n' "$script_output_bytecode" | grep -q 'Result: 4'
+
+          printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
+            ./build/BenchmarkRunner --no-progress --format=json --output=benchmark-stdin.json
+          grep -q '"name": "sum"' benchmark-stdin.json
+
+          printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
+            ./build/BenchmarkRunner - --mode=bytecode --no-progress --format=json --output=benchmark-stdin-bytecode.json
+          grep -q '"name": "sum"' benchmark-stdin-bytecode.json
+
   artifacts:
     needs: [test, benchmark, examples]
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -125,6 +125,45 @@ jobs:
           retention-days: 1
           path: benchmark-${{ matrix.mode }}.json
 
+  examples:
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Download build
+        uses: actions/download-artifact@v5
+        with:
+          name: build-pr
+          path: build/
+
+      - name: Make binaries executable
+        run: chmod +x build/*
+
+      - name: Run example scripts
+        run: ./build/ScriptLoader examples
+
+      - name: Run stdin smoke tests
+        run: |
+          script_output="$(printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader)"
+          printf '%s\n' "$script_output" | grep -q 'Result: 4'
+
+          script_output_bytecode="$(printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader - --mode=bytecode)"
+          printf '%s\n' "$script_output_bytecode" | grep -q 'Result: 4'
+
+          printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
+            ./build/BenchmarkRunner --no-progress --format=json --output=benchmark-stdin.json
+          grep -q '"name": "sum"' benchmark-stdin.json
+
+          printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
+            ./build/BenchmarkRunner - --mode=bytecode --no-progress --format=json --output=benchmark-stdin-bytecode.json
+          grep -q '"name": "sum"' benchmark-stdin-bytecode.json
+
   benchmark-comment:
     needs: benchmark
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ GocciaScript is a subset of ECMAScript implemented in FreePascal. It provides a 
 ./build/ScriptLoader example.js --emit=bytecode  # Compile to .gbc (explicit)
 ./build/ScriptLoader example.js --emit --output=out.gbc   # Custom output path
 ./build/ScriptLoader out.gbc                     # Load and execute .gbc bytecode
+printf "const x = 2 + 2; x;" | ./build/ScriptLoader        # Execute stdin source
 ./build/REPL                                      # Start interactive REPL
 ./build/TestRunner tests/                                                      # Run all JavaScript tests
 ./build/TestRunner tests/language/expressions/                                 # Run a test category
@@ -41,6 +42,7 @@ GocciaScript is a subset of ECMAScript implemented in FreePascal. It provides a 
 ./build/TestRunner tests --mode=bytecode                                       # Run tests via the Goccia bytecode VM
 ./build/BenchmarkRunner benchmarks/                                               # Run all benchmarks
 ./build/BenchmarkRunner benchmarks/fibonacci.js                                   # Run a specific benchmark
+printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner # Run benchmark source from stdin
 ./build/BenchmarkRunner benchmarks --format=json --output=out.json                # Export as JSON
 ./build/BenchmarkRunner benchmarks --format=console --format=json --output=out.json # Console + JSON
 ./build/BenchmarkRunner benchmarks --no-progress                                  # Suppress progress (CI)
@@ -521,7 +523,7 @@ See [docs/build-system.md](docs/build-system.md) for build system details.
 - Shared path config: `config.cfg`
 - Shared directives: `units/Goccia.inc` (overflow/range checks conditional on `PRODUCTION` define)
 - Output directory: `build/`
-- CI: Two workflow files — `ci.yml` (main + tags, full matrix, all checks + release) and `pr.yml` (PRs, ubuntu-latest x64 only, JS tests + benchmark comparison comment). All matrix strategies use `fail-fast: false`. Post-build jobs (`test`, `benchmark`, `examples`) are independent. Windows artifacts are labeled x86 (FPC produces i386-win32 binaries on the x64 runner).
+- CI: Two workflow files — `ci.yml` (main + tags, full matrix, all checks + release) and `pr.yml` (PRs, ubuntu-latest x64 only, JS tests, examples, and benchmark comparison comment). All matrix strategies use `fail-fast: false`. Post-build jobs (`test`, `benchmark`, `examples`) are independent. The `examples` jobs also smoke-test stdin execution for `ScriptLoader` and `BenchmarkRunner`. Windows artifacts are labeled x86 (FPC produces i386-win32 binaries on the x64 runner).
 - Auto-formatter: `./format.pas` (instantfpc script, no build step) — auto-fixes uses clause ordering, PascalCase function names, and parameter `A` prefix naming
 - Pre-commit hook: [Lefthook](https://github.com/evilmartians/lefthook) (`lefthook.yml`) — requires `lefthook install` after cloning
 - Editor setup: `.vscode/settings.json` (format-on-save) + `.vscode/extensions.json` (recommended extensions)

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -23,6 +23,7 @@ uses
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.Parser,
+  Goccia.ScriptLoader.Input,
   Goccia.Token,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
@@ -31,6 +32,11 @@ uses
   FileUtils in 'units/FileUtils.pas';
 
 type
+  TReportSpec = record
+    Format: TBenchmarkReportFormat;
+    OutputFile: string;
+  end;
+
   TBenchmarkProgress = class
     class procedure OnProgress(const ASuiteName, ABenchName: string; const AIndex, ATotal: Integer);
   end;
@@ -311,11 +317,188 @@ begin
   end;
 end;
 
-type
-  TReportSpec = record
-    Format: TBenchmarkReportFormat;
-    OutputFile: string;
+procedure CollectBenchmarkSourceInterpreted(const ASource: TStringList;
+  const AFileName: string; const AReporter: TBenchmarkReporter);
+var
+  Engine: TGocciaEngine;
+  GC: TGarbageCollector;
+  BenchGlobals: TGocciaGlobalBuiltins;
+  EngineResult: TGocciaScriptResult;
+  ScriptResult: TGocciaObjectValue;
+  FileResult: TBenchmarkFileResult;
+begin
+  BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
+  ASource.Add('runBenchmarks();');
+
+  try
+    Engine := TGocciaEngine.Create(AFileName, ASource, BenchGlobals);
+    try
+      if GShowProgress and Assigned(Engine.BuiltinBenchmark) then
+        Engine.BuiltinBenchmark.OnProgress := TBenchmarkProgress.OnProgress;
+
+      EngineResult := Engine.Execute;
+      FileResult.FileName := AFileName;
+      FileResult.LexTimeNanoseconds := EngineResult.LexTimeNanoseconds;
+      FileResult.ParseTimeNanoseconds := EngineResult.ParseTimeNanoseconds;
+      FileResult.CompileTimeNanoseconds := 0;
+      FileResult.ExecuteTimeNanoseconds := EngineResult.ExecuteTimeNanoseconds;
+
+      GC := TGarbageCollector.Instance;
+      ScriptResult := nil;
+      if EngineResult.Result is TGocciaObjectValue then
+        ScriptResult := TGocciaObjectValue(EngineResult.Result);
+
+      if Assigned(ScriptResult) and Assigned(GC) then
+        GC.AddTempRoot(ScriptResult);
+      try
+        PopulateFileResult(FileResult, ScriptResult, AReporter);
+      finally
+        if Assigned(ScriptResult) and Assigned(GC) then
+          GC.RemoveTempRoot(ScriptResult);
+      end;
+    finally
+      Engine.Free;
+    end;
+  except
+    on E: Exception do
+      MakeErrorFileResult(AFileName, E.Message, AReporter);
   end;
+end;
+
+procedure CollectBenchmarkSourceBytecode(const ASource: TStringList;
+  const AFileName: string; const AReporter: TBenchmarkReporter);
+var
+  SourceText: string;
+  JSXResult: TGocciaJSXTransformResult;
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+  Parser: TGocciaParser;
+  ProgramNode: TGocciaProgram;
+  Module: TGocciaBytecodeModule;
+  Backend: TGocciaBytecodeBackend;
+  GC: TGarbageCollector;
+  ResultValue: TGocciaValue;
+  FileResult: TBenchmarkFileResult;
+  ScriptResult: TGocciaObjectValue;
+  BenchGlobals: TGocciaGlobalBuiltins;
+  CompileStart, CompileEnd, ExecEnd: Int64;
+begin
+  BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
+  ASource.Add('runBenchmarks();');
+
+  SourceText := ASource.Text;
+  if ggJSX in BenchGlobals then
+  begin
+    JSXResult := TGocciaJSXTransformer.Transform(SourceText);
+    SourceText := JSXResult.Source;
+    JSXResult.SourceMap.Free;
+  end;
+
+  try
+    CompileStart := GetNanoseconds;
+
+    Backend := TGocciaBytecodeBackend.Create(AFileName);
+    try
+      Backend.RegisterBuiltIns(BenchGlobals);
+
+      Lexer := TGocciaLexer.Create(SourceText, AFileName);
+      try
+        Tokens := Lexer.ScanTokens;
+        Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
+        try
+          ProgramNode := Parser.Parse;
+          try
+            Module := Backend.CompileToModule(ProgramNode);
+          finally
+            ProgramNode.Free;
+          end;
+        finally
+          Parser.Free;
+        end;
+      finally
+        Lexer.Free;
+      end;
+
+      CompileEnd := GetNanoseconds;
+
+      if GShowProgress and Assigned(Backend.Bootstrap) and
+         Assigned(Backend.Bootstrap.BuiltinBenchmark) then
+        Backend.Bootstrap.BuiltinBenchmark.OnProgress := TBenchmarkProgress.OnProgress;
+      if Assigned(Backend.Bootstrap) and Assigned(Backend.Bootstrap.BuiltinBenchmark) then
+        Backend.Bootstrap.BuiltinBenchmark.OnBeforeMeasurement := Backend.ClearTransientCaches;
+
+      try
+        ResultValue := Backend.RunModule(Module);
+        ExecEnd := GetNanoseconds;
+
+        FileResult.FileName := AFileName;
+        FileResult.LexTimeNanoseconds := 0;
+        FileResult.ParseTimeNanoseconds := 0;
+        FileResult.CompileTimeNanoseconds := CompileEnd - CompileStart;
+        FileResult.ExecuteTimeNanoseconds := ExecEnd - CompileEnd;
+
+        GC := TGarbageCollector.Instance;
+        if Assigned(ResultValue) and Assigned(GC) then
+          GC.AddTempRoot(ResultValue);
+
+        ScriptResult := nil;
+        if ResultValue is TGocciaObjectValue then
+          ScriptResult := TGocciaObjectValue(ResultValue);
+        try
+          PopulateFileResult(FileResult, ScriptResult, AReporter);
+        finally
+          if Assigned(ResultValue) and Assigned(GC) then
+            GC.RemoveTempRoot(ResultValue);
+        end;
+      finally
+        Module.Free;
+      end;
+    finally
+      Backend.Free;
+    end;
+  except
+    on E: Exception do
+      MakeErrorFileResult(AFileName, E.Message, AReporter);
+  end;
+end;
+
+procedure CollectBenchmarkSource(const ASource: TStringList;
+  const AFileName: string; const AReporter: TBenchmarkReporter);
+begin
+  case GMode of
+    ebTreeWalk: CollectBenchmarkSourceInterpreted(ASource, AFileName, AReporter);
+    ebBytecode: CollectBenchmarkSourceBytecode(ASource, AFileName, AReporter);
+  else
+    raise Exception.CreateFmt('Unsupported execution backend: %d', [Ord(GMode)]);
+  end;
+end;
+
+procedure RunBenchmarksFromStdin(const AReports: array of TReportSpec);
+var
+  Source: TStringList;
+  Reporter: TBenchmarkReporter;
+  J: Integer;
+begin
+  Source := ReadSourceFromText(Input);
+  Reporter := TBenchmarkReporter.Create;
+  try
+    CollectBenchmarkSource(Source, STDIN_FILE_NAME, Reporter);
+    for J := 0 to Length(AReports) - 1 do
+    begin
+      Reporter.Render(AReports[J].Format);
+      if AReports[J].OutputFile <> '' then
+        Reporter.WriteToFile(AReports[J].OutputFile)
+      else
+        Reporter.WriteToStdOut;
+    end;
+
+    if Reporter.HasFailures then
+      ExitCode := 1;
+  finally
+    Reporter.Free;
+    Source.Free;
+  end;
+end;
 
 procedure RunBenchmarks(const APaths: TStringList; const AReports: array of TReportSpec);
 var
@@ -409,6 +592,13 @@ begin
         GMode := ebTreeWalk
       else if ParamStr(I) = '--mode=bytecode' then
         GMode := ebBytecode
+      else if (ParamStr(I) = '--help') or (ParamStr(I) = '-h') then
+      begin
+        WriteLn('Usage: BenchmarkRunner [path...|-] [--format=console|text|csv|json [--output=file]] ... [--no-progress] [--mode=interpreted|bytecode]');
+        WriteLn('  -                       Read benchmark source from stdin');
+        WriteLn('  (omitted path)          Read benchmark source from stdin');
+        Exit;
+      end
       else if Copy(ParamStr(I), 1, 7) = '--mode=' then
       begin
         WriteLn('Error: Unknown mode "', Copy(ParamStr(I), 8, MaxInt), '". Use "interpreted" or "bytecode".');
@@ -416,7 +606,13 @@ begin
         Exit;
       end
       else if Copy(ParamStr(I), 1, 2) <> '--' then
-        Paths.Add(ParamStr(I));
+        Paths.Add(ParamStr(I))
+      else
+      begin
+        WriteLn('Error: Unknown option "', ParamStr(I), '".');
+        ExitCode := 1;
+        Exit;
+      end;
     end;
 
     if ReportCount = 0 then
@@ -427,12 +623,14 @@ begin
     end;
 
     if Paths.Count = 0 then
-    begin
-      WriteLn('Usage: BenchmarkRunner <path...> [--format=console|text|csv|json [--output=file]] ... [--no-progress] [--mode=interpreted|bytecode]');
-      ExitCode := 1;
-    end
+      RunBenchmarksFromStdin(Reports)
     else
-      RunBenchmarks(Paths, Reports);
+    begin
+      if (Paths.Count = 1) and IsStdinPath(Paths[0]) then
+        RunBenchmarksFromStdin(Reports)
+      else
+        RunBenchmarks(Paths, Reports);
+    end;
   finally
     Paths.Free;
   end;

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ npx vitest run
 # Run a specific benchmark
 ./build/BenchmarkRunner benchmarks/fibonacci.js
 
+# Run a benchmark from stdin
+printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner
+
 # Export as JSON or CSV
 ./build/BenchmarkRunner benchmarks --format=json --output=results.json
 ./build/BenchmarkRunner benchmarks --format=csv --output=results.csv

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ console.log(`Your order total: $${total.toFixed(2)}`);
 
 ```bash
 ./build.pas loader && ./build/ScriptLoader example.js
+printf "const x = 2 + 2; x;" | ./build/ScriptLoader
 ```
 
 ### Run via Bytecode
@@ -156,12 +157,14 @@ GocciaScript includes a bytecode execution backend. The public bytecode artifact
 ```bash
 # Compile and execute via bytecode
 ./build/ScriptLoader example.js --mode=bytecode
+printf "const x = 2 + 2; x;" | ./build/ScriptLoader --mode=bytecode
 
 # Compile to .gbc bytecode file (no execution)
 ./build/ScriptLoader example.js --emit
 
 # Custom output path
 ./build/ScriptLoader example.js --emit --output=out.gbc
+printf "const x = 2 + 2; x;" | ./build/ScriptLoader --emit --output=out.gbc
 
 # Load and execute a pre-compiled .gbc file
 ./build/ScriptLoader example.gbc

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -21,6 +21,7 @@ uses
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.Parser,
+  Goccia.ScriptLoader.Input,
   Goccia.Token,
   Goccia.Values.Primitives,
 
@@ -34,9 +35,9 @@ var
   GOutputPath: string = '';
   GEmitOnly: Boolean = False;
 
-function ParseSourceFile(const AFileName: string; const AGlobals: TGocciaGlobalBuiltins): TGocciaProgram;
+function ParseSource(const ASource: TStringList; const AFileName: string;
+  const AGlobals: TGocciaGlobalBuiltins): TGocciaProgram;
 var
-  Source: TStringList;
   SourceText: string;
   JSXResult: TGocciaJSXTransformResult;
   SourceMap: TGocciaSourceMap;
@@ -46,58 +47,65 @@ var
   Warning: TGocciaParserWarning;
   OrigLine, OrigCol, I: Integer;
 begin
+  SourceText := ASource.Text;
+
+  SourceMap := nil;
+  if ggJSX in AGlobals then
+  begin
+    JSXResult := TGocciaJSXTransformer.Transform(SourceText);
+    SourceText := JSXResult.Source;
+    SourceMap := JSXResult.SourceMap;
+  end;
+
+  try
+    Lexer := TGocciaLexer.Create(SourceText, AFileName);
+    try
+      Tokens := Lexer.ScanTokens;
+      Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
+      try
+        Result := Parser.Parse;
+        for I := 0 to Parser.WarningCount - 1 do
+        begin
+          Warning := Parser.GetWarning(I);
+          WriteLn(SysUtils.Format('Warning: %s', [Warning.Message]));
+          if Warning.Suggestion <> '' then
+            WriteLn(SysUtils.Format('  Suggestion: %s', [Warning.Suggestion]));
+          if Assigned(SourceMap) and SourceMap.Translate(Warning.Line, Warning.Column, OrigLine, OrigCol) then
+            WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, OrigLine, OrigCol]))
+          else
+            WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, Warning.Line, Warning.Column]));
+        end;
+      finally
+        Parser.Free;
+      end;
+    finally
+      Lexer.Free;
+    end;
+  finally
+    SourceMap.Free;
+  end;
+end;
+
+function ParseSourceFile(const AFileName: string; const AGlobals: TGocciaGlobalBuiltins): TGocciaProgram;
+var
+  Source: TStringList;
+begin
   Source := TStringList.Create;
   try
     Source.LoadFromFile(AFileName);
-    SourceText := Source.Text;
-
-    SourceMap := nil;
-    if ggJSX in AGlobals then
-    begin
-      JSXResult := TGocciaJSXTransformer.Transform(SourceText);
-      SourceText := JSXResult.Source;
-      SourceMap := JSXResult.SourceMap;
-    end;
-
-    try
-      Lexer := TGocciaLexer.Create(SourceText, AFileName);
-      try
-        Tokens := Lexer.ScanTokens;
-        Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
-        try
-          Result := Parser.Parse;
-          for I := 0 to Parser.WarningCount - 1 do
-          begin
-            Warning := Parser.GetWarning(I);
-            WriteLn(SysUtils.Format('Warning: %s', [Warning.Message]));
-            if Warning.Suggestion <> '' then
-              WriteLn(SysUtils.Format('  Suggestion: %s', [Warning.Suggestion]));
-            if Assigned(SourceMap) and SourceMap.Translate(Warning.Line, Warning.Column, OrigLine, OrigCol) then
-              WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, OrigLine, OrigCol]))
-            else
-              WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, Warning.Line, Warning.Column]));
-          end;
-        finally
-          Parser.Free;
-        end;
-      finally
-        Lexer.Free;
-      end;
-    finally
-      SourceMap.Free;
-    end;
+    Result := ParseSource(Source, AFileName, AGlobals);
   finally
     Source.Free;
   end;
 end;
 
-function CompileSourceFile(const AFileName: string;
+function CompileSource(const ASource: TStringList; const AFileName: string;
   const AGlobals: TGocciaGlobalBuiltins): TGocciaBytecodeModule;
 var
   ProgramNode: TGocciaProgram;
   Compiler: TGocciaCompiler;
 begin
-  ProgramNode := ParseSourceFile(AFileName, AGlobals);
+  ProgramNode := ParseSource(ASource, AFileName, AGlobals);
   try
     Compiler := TGocciaCompiler.Create(AFileName);
     try
@@ -110,19 +118,33 @@ begin
   end;
 end;
 
-procedure RunInterpreted(const AFileName: string);
+function CompileSourceFile(const AFileName: string;
+  const AGlobals: TGocciaGlobalBuiltins): TGocciaBytecodeModule;
+var
+  Source: TStringList;
+begin
+  Source := TStringList.Create;
+  try
+    Source.LoadFromFile(AFileName);
+    Result := CompileSource(Source, AFileName, AGlobals);
+  finally
+    Source.Free;
+  end;
+end;
+
+procedure RunInterpreted(const ASource: TStringList; const AFileName: string);
 var
   ScriptResult: TGocciaScriptResult;
 begin
   WriteLn('Running script (interpreted): ', AFileName);
-  ScriptResult := TGocciaEngine.RunScriptFromFile(AFileName, TGocciaEngine.DefaultGlobals);
+  ScriptResult := TGocciaEngine.RunScriptFromStringList(ASource, AFileName, TGocciaEngine.DefaultGlobals);
   WriteLn(SysUtils.Format('  Lex: %s | Parse: %s | Execute: %s | Total: %s',
     [FormatDuration(ScriptResult.LexTimeNanoseconds), FormatDuration(ScriptResult.ParseTimeNanoseconds),
      FormatDuration(ScriptResult.ExecuteTimeNanoseconds), FormatDuration(ScriptResult.TotalTimeNanoseconds)]));
   Writeln('Result: ', ScriptResult.Result.ToStringLiteral.Value);
 end;
 
-procedure RunBytecodeFromSource(const AFileName: string);
+procedure RunBytecodeFromSource(const ASource: TStringList; const AFileName: string);
 var
   ProgramNode: TGocciaProgram;
   Module: TGocciaBytecodeModule;
@@ -137,7 +159,7 @@ begin
   try
     Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
 
-    ProgramNode := ParseSourceFile(AFileName, TGocciaEngine.DefaultGlobals);
+    ProgramNode := ParseSource(ASource, AFileName, TGocciaEngine.DefaultGlobals);
     try
       Module := Backend.CompileToModule(ProgramNode);
     finally
@@ -191,7 +213,7 @@ begin
   end;
 end;
 
-procedure EmitBytecode(const AFileName, AOutputPath: string);
+procedure EmitBytecode(const ASource: TStringList; const AFileName, AOutputPath: string);
 var
   Module: TGocciaBytecodeModule;
   StartTime, EndTime: Int64;
@@ -201,7 +223,7 @@ begin
 
   TGarbageCollector.Initialize;
   try
-    Module := CompileSourceFile(AFileName, TGocciaEngine.DefaultGlobals);
+    Module := CompileSource(ASource, AFileName, TGocciaEngine.DefaultGlobals);
     try
       Goccia.Bytecode.Binary.SaveModuleToFile(Module, AOutputPath);
       EndTime := GetNanoseconds;
@@ -215,7 +237,7 @@ begin
   end;
 end;
 
-procedure RunScriptFromFile(const AFileName: string);
+procedure RunSource(const ASource: TStringList; const AFileName: string);
 var
   Ext, OutputPath: string;
 begin
@@ -232,15 +254,21 @@ begin
     begin
       if GOutputPath <> '' then
         OutputPath := GOutputPath
+      else if AFileName = STDIN_FILE_NAME then
+      begin
+        WriteLn('Error: --output=<path> is required when emitting bytecode from stdin.');
+        ExitCode := 1;
+        Exit;
+      end
       else
         OutputPath := ChangeFileExt(AFileName, EXT_GBC);
-      EmitBytecode(AFileName, OutputPath);
+      EmitBytecode(ASource, AFileName, OutputPath);
       Exit;
     end;
 
     case GMode of
-      emInterpreted: RunInterpreted(AFileName);
-      emBytecode:    RunBytecodeFromSource(AFileName);
+      emInterpreted: RunInterpreted(ASource, AFileName);
+      emBytecode:    RunBytecodeFromSource(ASource, AFileName);
     end;
   except
     on E: Exception do
@@ -251,11 +279,42 @@ begin
   end;
 end;
 
+procedure RunScriptFromFile(const AFileName: string);
+var
+  Source: TStringList;
+begin
+  Source := TStringList.Create;
+  try
+    Source.LoadFromFile(AFileName);
+    RunSource(Source, AFileName);
+  finally
+    Source.Free;
+  end;
+end;
+
+procedure RunScriptFromStdin;
+var
+  Source: TStringList;
+begin
+  Source := ReadSourceFromText(Input);
+  try
+    RunSource(Source, STDIN_FILE_NAME);
+  finally
+    Source.Free;
+  end;
+end;
+
 procedure RunScripts(const APath: string);
 var
   Files: TStringList;
   I: Integer;
 begin
+  if IsStdinPath(APath) then
+  begin
+    RunScriptFromStdin;
+    Exit;
+  end;
+
   if DirectoryExists(APath) then
   begin
     Files := FindAllFiles(APath, ScriptExtensions);
@@ -280,10 +339,12 @@ end;
 
 procedure PrintUsage;
 begin
-  WriteLn('Usage: ScriptLoader <file|directory> [options]');
+  WriteLn('Usage: ScriptLoader [file|directory|-] [options]');
   WriteLn;
   WriteLn('  <file>                  Script (.js, .jsx, .ts, .tsx, .mjs) or bytecode (.gbc)');
   WriteLn('  <directory>             Run all scripts in directory');
+  WriteLn('  -                       Read source from stdin');
+  WriteLn('  (omitted path)          Read source from stdin');
   WriteLn;
   WriteLn('Options:');
   WriteLn('  --mode=interpreted      Tree-walk interpreter (default)');
@@ -346,17 +407,13 @@ begin
     end;
 
     if Paths.Count = 0 then
-    begin
-      PrintUsage;
-      ExitCode := 1;
-      Exit;
-    end;
-
-    for I := 0 to Paths.Count - 1 do
-    begin
-      if I > 0 then WriteLn;
-      RunScripts(Paths[I]);
-    end;
+      RunScriptFromStdin
+    else
+      for I := 0 to Paths.Count - 1 do
+      begin
+        if I > 0 then WriteLn;
+        RunScripts(Paths[I]);
+      end;
   finally
     Paths.Free;
   end;

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -400,10 +400,22 @@ begin
       end
       else if Arg = '--emit' then
         GEmitOnly := True
+      else if (Arg = '--help') or (Arg = '-h') then
+      begin
+        PrintUsage;
+        Exit;
+      end
       else if Copy(Arg, 1, 9) = '--output=' then
         GOutputPath := Copy(Arg, 10, MaxInt)
       else if Copy(Arg, 1, 2) <> '--' then
-        Paths.Add(Arg);
+        Paths.Add(Arg)
+      else
+      begin
+        WriteLn('Error: Unknown option "', Arg, '".');
+        PrintUsage;
+        ExitCode := 1;
+        Exit;
+      end;
     end;
 
     if Paths.Count = 0 then

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -281,8 +281,16 @@ end;
 
 procedure RunScriptFromFile(const AFileName: string);
 var
+  Ext: string;
   Source: TStringList;
 begin
+  Ext := LowerCase(ExtractFileExt(AFileName));
+  if Ext = EXT_GBC then
+  begin
+    RunBytecodeFromFile(AFileName);
+    Exit;
+  end;
+
   Source := TStringList.Create;
   try
     Source.LoadFromFile(AFileName);

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -16,11 +16,17 @@ GocciaScript includes a benchmark runner for measuring execution performance. Be
 # Run a specific benchmark
 ./build/BenchmarkRunner benchmarks/fibonacci.js
 
+# Run a benchmark from stdin
+printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner
+printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner - --mode=bytecode
+
 # Export results in different formats
 ./build/BenchmarkRunner benchmarks --format=json --output=results.json
 ./build/BenchmarkRunner benchmarks --format=csv --output=results.csv
 ./build/BenchmarkRunner benchmarks --format=text
 ```
+
+When no path is provided, `BenchmarkRunner` reads benchmark source from stdin. Use `-` explicitly when you want stdin alongside other CLI flags and still make the input source obvious.
 
 ## Output Formats
 
@@ -105,7 +111,7 @@ setup() → [return value] → warmup(run × N) → calibrate(run × N) → meas
 
 The `BenchmarkRunner` program:
 
-1. Parses CLI arguments (`--format`, `--output`, and the benchmark path).
+1. Parses CLI arguments (`--format`, `--output`, and the benchmark path or stdin marker).
 2. Scans the provided path for `.js` files.
 3. For each file, creates a `TGocciaEngine` with `DefaultGlobals + [ggBenchmark]`.
 4. Loads the source and appends a `runBenchmarks()` call.

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -65,6 +65,7 @@ A full build (no specific targets) automatically cleans first.
 
 ```bash
 ./build.pas loader && ./build/ScriptLoader ./example.js
+printf "const x = 2 + 2; x;" | ./build/ScriptLoader
 ```
 
 ### Compile and Test
@@ -80,10 +81,12 @@ All execution tools support `--mode=bytecode` to compile and run via the Goccia 
 ```bash
 # Execute via bytecode VM
 ./build/ScriptLoader example.js --mode=bytecode
+printf "const x = 2 + 2; x;" | ./build/ScriptLoader --mode=bytecode
 
 # Emit bytecode to .gbc file (no execution)
 ./build/ScriptLoader example.js --emit
 ./build/ScriptLoader example.js --output=output.gbc
+printf "const x = 2 + 2; x;" | ./build/ScriptLoader --emit --output=output.gbc
 
 # Load and execute a pre-compiled .gbc file
 ./build/ScriptLoader output.gbc
@@ -104,7 +107,7 @@ All compiled binaries go to the `build/` directory:
 | Binary | Source | Description |
 |--------|--------|-------------|
 | `build/REPL` | `REPL.dpr` | Interactive read-eval-print loop |
-| `build/ScriptLoader` | `ScriptLoader.dpr` | Execute `.js` files |
+| `build/ScriptLoader` | `ScriptLoader.dpr` | Execute `.js` files or stdin input |
 | `build/TestRunner` | `TestRunner.dpr` | JavaScript test runner |
 | `build/BenchmarkRunner` | `BenchmarkRunner.dpr` | Performance benchmark runner |
 | `build/Goccia.Values.Primitives.Test` | `*.Test.pas` | Pascal unit test binaries |

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -66,6 +66,7 @@ A full build (no specific targets) automatically cleans first.
 ```bash
 ./build.pas loader && ./build/ScriptLoader ./example.js
 printf "const x = 2 + 2; x;" | ./build/ScriptLoader
+printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner
 ```
 
 ### Compile and Test
@@ -96,6 +97,7 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader --emit --output=output.gbc
 
 # Run benchmarks via bytecode VM
 ./build/BenchmarkRunner benchmarks --mode=bytecode
+printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner - --mode=bytecode
 ```
 
 See [bytecode-vm.md](bytecode-vm.md) for the bytecode VM architecture and binary format.
@@ -109,7 +111,7 @@ All compiled binaries go to the `build/` directory:
 | `build/REPL` | `REPL.dpr` | Interactive read-eval-print loop |
 | `build/ScriptLoader` | `ScriptLoader.dpr` | Execute `.js` files or stdin input |
 | `build/TestRunner` | `TestRunner.dpr` | JavaScript test runner |
-| `build/BenchmarkRunner` | `BenchmarkRunner.dpr` | Performance benchmark runner |
+| `build/BenchmarkRunner` | `BenchmarkRunner.dpr` | Performance benchmark runner for files or stdin input |
 | `build/Goccia.Values.Primitives.Test` | `*.Test.pas` | Pascal unit test binaries |
 
 Intermediate files (`.o`, `.ppu`) also go to `build/` to keep the source tree clean.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -517,7 +517,7 @@ The repository includes four embedding examples:
 
 | Program | File | Description |
 |---------|------|-------------|
-| `ScriptLoader` | `ScriptLoader.dpr` | Executes script files (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`) from disk (one-shot) |
+| `ScriptLoader` | `ScriptLoader.dpr` | Executes script files (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`) from disk or stdin (one-shot) |
 | `REPL` | `REPL.dpr` | Interactive read-eval-print loop (long-lived engine) |
 | `TestRunner` | `TestRunner.dpr` | Runs test suites with `ggTestAssertions` enabled |
 | `BenchmarkRunner` | `BenchmarkRunner.dpr` | Runs benchmarks with `ggBenchmark` enabled |

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -520,7 +520,7 @@ The repository includes four embedding examples:
 | `ScriptLoader` | `ScriptLoader.dpr` | Executes script files (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`) from disk or stdin (one-shot) |
 | `REPL` | `REPL.dpr` | Interactive read-eval-print loop (long-lived engine) |
 | `TestRunner` | `TestRunner.dpr` | Runs test suites with `ggTestAssertions` enabled |
-| `BenchmarkRunner` | `BenchmarkRunner.dpr` | Runs benchmarks with `ggBenchmark` enabled |
+| `BenchmarkRunner` | `BenchmarkRunner.dpr` | Runs benchmarks with `ggBenchmark` enabled from files or stdin |
 
 These serve as reference implementations for the patterns described above.
 

--- a/units/Goccia.ScriptLoader.Input.Test.pas
+++ b/units/Goccia.ScriptLoader.Input.Test.pas
@@ -34,15 +34,16 @@ var
   TempFileName: string;
   InputFile: Text;
   Source: TStringList;
+  RawSource: TFileStream;
+  Text: string;
 begin
   TempFileName := GetTempFileName;
-  with TStringList.Create do
+  Text := 'const x = 2 + 2;' + sLineBreak + 'x;';
+  RawSource := TFileStream.Create(TempFileName, fmCreate);
   try
-    Add('const x = 2 + 2;');
-    Add('x;');
-    SaveToFile(TempFileName);
+    RawSource.WriteBuffer(Pointer(Text)^, Length(Text));
   finally
-    Free;
+    RawSource.Free;
   end;
 
   AssignFile(InputFile, TempFileName);

--- a/units/Goccia.ScriptLoader.Input.Test.pas
+++ b/units/Goccia.ScriptLoader.Input.Test.pas
@@ -1,0 +1,113 @@
+program Goccia.ScriptLoader.Input.Test;
+
+{$I Goccia.inc}
+
+uses
+  Classes,
+  SysUtils,
+
+  GarbageCollector.Generic,
+  TestRunner,
+
+  Goccia.ScriptLoader.Input,
+  Goccia.TestSetup;
+
+type
+  TScriptLoaderInputTests = class(TTestSuite)
+  private
+    procedure TestReadSourceFromTextPreservesLines;
+    procedure TestReadSourceFromTextHandlesEmptyInput;
+    procedure TestIsStdinPath;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TScriptLoaderInputTests.SetupTests;
+begin
+  Test('Read source from text preserves lines', TestReadSourceFromTextPreservesLines);
+  Test('Read source from text handles empty input', TestReadSourceFromTextHandlesEmptyInput);
+  Test('Is stdin path', TestIsStdinPath);
+end;
+
+procedure TScriptLoaderInputTests.TestReadSourceFromTextPreservesLines;
+var
+  TempFileName: string;
+  InputFile: Text;
+  Source: TStringList;
+begin
+  TempFileName := GetTempFileName;
+  with TStringList.Create do
+  try
+    Add('const x = 2 + 2;');
+    Add('x;');
+    SaveToFile(TempFileName);
+  finally
+    Free;
+  end;
+
+  AssignFile(InputFile, TempFileName);
+  Reset(InputFile);
+  try
+    Source := ReadSourceFromText(InputFile);
+    try
+      Expect<Integer>(Source.Count).ToBe(2);
+      Expect<string>(Source[0]).ToBe('const x = 2 + 2;');
+      Expect<string>(Source[1]).ToBe('x;');
+      Expect<string>(Source.Text).ToBe('const x = 2 + 2;' + sLineBreak + 'x;' + sLineBreak);
+    finally
+      Source.Free;
+    end;
+  finally
+    CloseFile(InputFile);
+    DeleteFile(TempFileName);
+  end;
+end;
+
+procedure TScriptLoaderInputTests.TestReadSourceFromTextHandlesEmptyInput;
+var
+  TempFileName: string;
+  InputFile: Text;
+  Source: TStringList;
+  EmptySource: TStringList;
+begin
+  TempFileName := GetTempFileName;
+  EmptySource := TStringList.Create;
+  try
+    EmptySource.SaveToFile(TempFileName);
+  finally
+    EmptySource.Free;
+  end;
+
+  AssignFile(InputFile, TempFileName);
+  Reset(InputFile);
+  try
+    Source := ReadSourceFromText(InputFile);
+    try
+      Expect<Integer>(Source.Count).ToBe(0);
+      Expect<string>(Source.Text).ToBe('');
+    finally
+      Source.Free;
+    end;
+  finally
+    CloseFile(InputFile);
+    DeleteFile(TempFileName);
+  end;
+end;
+
+procedure TScriptLoaderInputTests.TestIsStdinPath;
+begin
+  Expect<Boolean>(IsStdinPath('-')).ToBe(True);
+  Expect<Boolean>(IsStdinPath(' - ')).ToBe(True);
+  Expect<Boolean>(IsStdinPath('script.js')).ToBe(False);
+end;
+
+begin
+  TGarbageCollector.Initialize;
+  try
+    TestRunnerProgram.AddSuite(TScriptLoaderInputTests.Create('ScriptLoader Input'));
+    TestRunnerProgram.Run;
+    ExitCode := TestResultToExitCode;
+  finally
+    TGarbageCollector.Shutdown;
+  end;
+end.

--- a/units/Goccia.ScriptLoader.Input.pas
+++ b/units/Goccia.ScriptLoader.Input.pas
@@ -1,0 +1,39 @@
+unit Goccia.ScriptLoader.Input;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Classes;
+
+const
+  STDIN_FILE_NAME = '<stdin>';
+  STDIN_PATH_MARKER = '-';
+
+function IsStdinPath(const APath: string): Boolean;
+function ReadSourceFromText(var AInput: Text): TStringList;
+
+implementation
+
+uses
+  SysUtils;
+
+function IsStdinPath(const APath: string): Boolean;
+begin
+  Result := Trim(APath) = STDIN_PATH_MARKER;
+end;
+
+function ReadSourceFromText(var AInput: Text): TStringList;
+var
+  Line: string;
+begin
+  Result := TStringList.Create;
+  while not EOF(AInput) do
+  begin
+    ReadLn(AInput, Line);
+    Result.Add(Line);
+  end;
+end;
+
+end.


### PR DESCRIPTION
## Summary
- read ScriptLoader source from stdin when no path is provided or when  is used explicitly
- support stdin across interpreted execution, bytecode execution, and bytecode emit flows
- document the new CLI usage and cover stdin input parsing with a native regression test

## Testing
- ./build.pas loader tests
- ./build/Goccia.ScriptLoader.Input.Test
- printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader
- printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader -
- printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader --mode=bytecode
- printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader --emit --output=/tmp/goccia-stdin-test.gbc

Closes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ScriptLoader and BenchmarkRunner accept stdin (pipe) as input; "-" or no path reads from stdin. CLI adds --help, treats unknown options as errors, and requires explicit --output when emitting bytecode from stdin.

* **Documentation**
  * README and docs updated with stdin examples for interpreted, bytecode and benchmark usage.

* **Tests / CI**
  * Added unit tests for stdin handling and CI smoke tests covering stdin for interpreter and bytecode paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->