### PR TITLE
Add structured JSON output to ScriptLoader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,21 @@ jobs:
           GOCCIA_BENCH_ROUNDS: 7
         run: ./build/BenchmarkRunner benchmarks ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --no-progress
 
+      - name: Run stdin benchmark smoke test
+        env:
+          GOCCIA_BENCH_CALIBRATION_MS: 100
+          GOCCIA_BENCH_ROUNDS: 7
+        run: |
+          if [ "${{ matrix.mode }}" = "bytecode" ]; then
+            printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
+              ./build/BenchmarkRunner - --mode=bytecode --no-progress --format=json --output=benchmark-stdin-bytecode.json
+            grep -q '"name": "sum"' benchmark-stdin-bytecode.json
+          else
+            printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
+              ./build/BenchmarkRunner --no-progress --format=json --output=benchmark-stdin.json
+            grep -q '"name": "sum"' benchmark-stdin.json
+          fi
+
       - name: Run benchmarks and save baseline
         if: github.ref == 'refs/heads/main' && matrix.target == 'x86_64-linux'
         env:
@@ -336,14 +351,6 @@ jobs:
 
           script_output_bytecode="$(printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader - --mode=bytecode)"
           printf '%s\n' "$script_output_bytecode" | grep -q 'Result: 4'
-
-          printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
-            ./build/BenchmarkRunner --no-progress --format=json --output=benchmark-stdin.json
-          grep -q '"name": "sum"' benchmark-stdin.json
-
-          printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
-            ./build/BenchmarkRunner - --mode=bytecode --no-progress --format=json --output=benchmark-stdin-bytecode.json
-          grep -q '"name": "sum"' benchmark-stdin-bytecode.json
 
   artifacts:
     needs: [test, benchmark, examples]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,13 +199,26 @@ jobs:
       - name: Run all JavaScript tests (bytecode)
         run: ./build/TestRunner tests --mode=bytecode --silent --no-progress --output=test-results-bytecode.json
 
+      - name: Validate TestRunner JSON output
+        run: |
+          grep -q '"mode": "interpreted"' test-results-interpreted.json
+          grep -q '"totalFiles":' test-results-interpreted.json
+          grep -q '"mode": "bytecode"' test-results-bytecode.json
+          grep -q '"totalFiles":' test-results-bytecode.json
+
       - name: Run Pascal unit tests
         run: |
-          ./build/Goccia.Values.Primitives.Test
-          ./build/Goccia.Values.FunctionValue.Test
-          ./build/Goccia.Values.ObjectValue.Test
-          ./build/Goccia.Compiler.Test
-          ./build/Goccia.Builtins.TestAssertions.Test
+          found=0
+          for test_bin in build/Goccia.*.Test build/Goccia.*.Test.exe; do
+            if [ -f "$test_bin" ]; then
+              found=1
+              "$test_bin"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No Pascal unit test binaries found"
+            exit 1
+          fi
 
   benchmark:
     needs: build
@@ -283,10 +296,12 @@ jobs:
           if [ "${{ matrix.mode }}" = "bytecode" ]; then
             printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
               ./build/BenchmarkRunner - --mode=bytecode --no-progress --format=json --output=benchmark-stdin-bytecode.json
+            grep -q '"files": \[' benchmark-stdin-bytecode.json
             grep -q '"name": "sum"' benchmark-stdin-bytecode.json
           else
             printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
               ./build/BenchmarkRunner --no-progress --format=json --output=benchmark-stdin.json
+            grep -q '"files": \[' benchmark-stdin.json
             grep -q '"name": "sum"' benchmark-stdin.json
           fi
 
@@ -296,6 +311,12 @@ jobs:
           GOCCIA_BENCH_CALIBRATION_MS: 100
           GOCCIA_BENCH_ROUNDS: 7
         run: ./build/BenchmarkRunner benchmarks ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --no-progress --format=console --format=json --output=benchmark-${{ matrix.mode }}-results.json
+
+      - name: Validate benchmark JSON output
+        if: github.ref == 'refs/heads/main' && matrix.target == 'x86_64-linux'
+        run: |
+          grep -q '"files": \[' benchmark-${{ matrix.mode }}-results.json
+          grep -q '"totalBenchmarks":' benchmark-${{ matrix.mode }}-results.json
 
       - name: Cache benchmark baseline
         if: github.ref == 'refs/heads/main' && matrix.target == 'x86_64-linux'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,11 +38,8 @@ jobs:
             build/TestRunner
             build/BenchmarkRunner
             build/REPL
-            build/Goccia.Values.Primitives.Test
-            build/Goccia.Values.FunctionValue.Test
-            build/Goccia.Values.ObjectValue.Test
-            build/Goccia.Compiler.Test
-            build/Goccia.Builtins.TestAssertions.Test
+            build/Goccia.*.Test
+            build/Goccia.*.Test.exe
 
   test:
     needs: build
@@ -71,6 +68,11 @@ jobs:
       - name: Run all JavaScript tests
         run: ./build/TestRunner tests ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --silent --no-progress --output=test-results-${{ matrix.mode }}.json
 
+      - name: Validate TestRunner JSON output
+        run: |
+          grep -q '"mode": "${{ matrix.mode }}"' test-results-${{ matrix.mode }}.json
+          grep -q '"totalFiles":' test-results-${{ matrix.mode }}.json
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v5
@@ -82,11 +84,17 @@ jobs:
       - name: Run Pascal unit tests
         if: matrix.mode == 'interpreted'
         run: |
-          ./build/Goccia.Values.Primitives.Test
-          ./build/Goccia.Values.FunctionValue.Test
-          ./build/Goccia.Values.ObjectValue.Test
-          ./build/Goccia.Compiler.Test
-          ./build/Goccia.Builtins.TestAssertions.Test
+          found=0
+          for test_bin in build/Goccia.*.Test build/Goccia.*.Test.exe; do
+            if [ -f "$test_bin" ]; then
+              found=1
+              "$test_bin"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No Pascal unit test binaries found"
+            exit 1
+          fi
 
   benchmark:
     needs: build
@@ -118,6 +126,11 @@ jobs:
           GOCCIA_BENCH_ROUNDS: 7
         run: ./build/BenchmarkRunner benchmarks ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --no-progress --format=json --output=benchmark-${{ matrix.mode }}.json
 
+      - name: Validate benchmark JSON output
+        run: |
+          grep -q '"files": \[' benchmark-${{ matrix.mode }}.json
+          grep -q '"totalBenchmarks":' benchmark-${{ matrix.mode }}.json
+
       - name: Run stdin benchmark smoke test
         env:
           GOCCIA_BENCH_CALIBRATION_MS: 100
@@ -126,10 +139,12 @@ jobs:
           if [ "${{ matrix.mode }}" = "bytecode" ]; then
             printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
               ./build/BenchmarkRunner - --mode=bytecode --no-progress --format=json --output=benchmark-stdin-bytecode.json
+            grep -q '"files": \[' benchmark-stdin-bytecode.json
             grep -q '"name": "sum"' benchmark-stdin-bytecode.json
           else
             printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
               ./build/BenchmarkRunner --no-progress --format=json --output=benchmark-stdin.json
+            grep -q '"files": \[' benchmark-stdin.json
             grep -q '"name": "sum"' benchmark-stdin.json
           fi
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,6 +118,21 @@ jobs:
           GOCCIA_BENCH_ROUNDS: 7
         run: ./build/BenchmarkRunner benchmarks ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --no-progress --format=json --output=benchmark-${{ matrix.mode }}.json
 
+      - name: Run stdin benchmark smoke test
+        env:
+          GOCCIA_BENCH_CALIBRATION_MS: 100
+          GOCCIA_BENCH_ROUNDS: 7
+        run: |
+          if [ "${{ matrix.mode }}" = "bytecode" ]; then
+            printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
+              ./build/BenchmarkRunner - --mode=bytecode --no-progress --format=json --output=benchmark-stdin-bytecode.json
+            grep -q '"name": "sum"' benchmark-stdin-bytecode.json
+          else
+            printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
+              ./build/BenchmarkRunner --no-progress --format=json --output=benchmark-stdin.json
+            grep -q '"name": "sum"' benchmark-stdin.json
+          fi
+
       - name: Upload results
         uses: actions/upload-artifact@v5
         with:
@@ -155,14 +170,6 @@ jobs:
 
           script_output_bytecode="$(printf 'const x = 2 + 2;\nx;\n' | ./build/ScriptLoader - --mode=bytecode)"
           printf '%s\n' "$script_output_bytecode" | grep -q 'Result: 4'
-
-          printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
-            ./build/BenchmarkRunner --no-progress --format=json --output=benchmark-stdin.json
-          grep -q '"name": "sum"' benchmark-stdin.json
-
-          printf 'suite("stdin", () => {\n  bench("sum", {\n    run: () => 1 + 1,\n  });\n});\n' | \
-            ./build/BenchmarkRunner - --mode=bytecode --no-progress --format=json --output=benchmark-stdin-bytecode.json
-          grep -q '"name": "sum"' benchmark-stdin-bytecode.json
 
   benchmark-comment:
     needs: benchmark

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,7 +523,7 @@ See [docs/build-system.md](docs/build-system.md) for build system details.
 - Shared path config: `config.cfg`
 - Shared directives: `units/Goccia.inc` (overflow/range checks conditional on `PRODUCTION` define)
 - Output directory: `build/`
-- CI: Two workflow files — `ci.yml` (main + tags, full matrix, all checks + release) and `pr.yml` (PRs, ubuntu-latest x64 only, JS tests, examples, and benchmark comparison comment). All matrix strategies use `fail-fast: false`. Post-build jobs (`test`, `benchmark`, `examples`) are independent. The `examples` jobs smoke-test stdin execution for `ScriptLoader`, and the `benchmark` jobs smoke-test stdin execution for `BenchmarkRunner`. Windows artifacts are labeled x86 (FPC produces i386-win32 binaries on the x64 runner).
+- CI: Two workflow files — `ci.yml` (main + tags, full matrix, all checks + release) and `pr.yml` (PRs, ubuntu-latest x64 only, JavaScript tests, Pascal unit tests, examples, and benchmark comparison comment). All matrix strategies use `fail-fast: false`. Post-build jobs (`test`, `benchmark`, `examples`) are independent. The `examples` jobs smoke-test stdin execution for `ScriptLoader`, and the `benchmark` jobs smoke-test stdin execution for `BenchmarkRunner`. Windows artifacts are labeled x86 (FPC produces i386-win32 binaries on the x64 runner).
 - Auto-formatter: `./format.pas` (instantfpc script, no build step) — auto-fixes uses clause ordering, PascalCase function names, and parameter `A` prefix naming
 - Pre-commit hook: [Lefthook](https://github.com/evilmartians/lefthook) (`lefthook.yml`) — requires `lefthook install` after cloning
 - Editor setup: `.vscode/settings.json` (format-on-save) + `.vscode/extensions.json` (recommended extensions)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,7 +523,7 @@ See [docs/build-system.md](docs/build-system.md) for build system details.
 - Shared path config: `config.cfg`
 - Shared directives: `units/Goccia.inc` (overflow/range checks conditional on `PRODUCTION` define)
 - Output directory: `build/`
-- CI: Two workflow files — `ci.yml` (main + tags, full matrix, all checks + release) and `pr.yml` (PRs, ubuntu-latest x64 only, JS tests, examples, and benchmark comparison comment). All matrix strategies use `fail-fast: false`. Post-build jobs (`test`, `benchmark`, `examples`) are independent. The `examples` jobs also smoke-test stdin execution for `ScriptLoader` and `BenchmarkRunner`. Windows artifacts are labeled x86 (FPC produces i386-win32 binaries on the x64 runner).
+- CI: Two workflow files — `ci.yml` (main + tags, full matrix, all checks + release) and `pr.yml` (PRs, ubuntu-latest x64 only, JS tests, examples, and benchmark comparison comment). All matrix strategies use `fail-fast: false`. Post-build jobs (`test`, `benchmark`, `examples`) are independent. The `examples` jobs smoke-test stdin execution for `ScriptLoader`, and the `benchmark` jobs smoke-test stdin execution for `BenchmarkRunner`. Windows artifacts are labeled x86 (FPC produces i386-win32 binaries on the x64 runner).
 - Auto-formatter: `./format.pas` (instantfpc script, no build step) — auto-fixes uses clause ordering, PascalCase function names, and parameter `A` prefix naming
 - Pre-commit hook: [Lefthook](https://github.com/evilmartians/lefthook) (`lefthook.yml`) — requires `lefthook install` after cloning
 - Editor setup: `.vscode/settings.json` (format-on-save) + `.vscode/extensions.json` (recommended extensions)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader --emit --output=out.gbc
 
 # Load and execute a pre-compiled .gbc file
 ./build/ScriptLoader example.gbc
+
+# Emit structured JSON for programmatic consumers
+printf "console.log('hi'); 2 + 2;" | ./build/ScriptLoader --output=json
 ```
 
 See [Bytecode VM](docs/bytecode-vm.md) for the current bytecode backend architecture.

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -11,6 +11,7 @@ uses
   TimingUtils,
 
   Goccia.AST.Node,
+  Goccia.Builtins.Console,
   Goccia.Bytecode.Binary,
   Goccia.Bytecode.Module,
   Goccia.Compiler,
@@ -20,8 +21,10 @@ uses
   Goccia.JSX.SourceMap,
   Goccia.JSX.Transformer,
   Goccia.Lexer,
+  Goccia.Logger,
   Goccia.Parser,
   Goccia.ScriptLoader.Input,
+  Goccia.ScriptLoader.JSON,
   Goccia.Token,
   Goccia.Values.Primitives,
 
@@ -30,13 +33,21 @@ uses
 type
   TExecutionMode = (emInterpreted, emBytecode);
 
+  TScriptExecutionReport = record
+    ResultValue: TGocciaValue;
+    Timing: TScriptLoaderTiming;
+  end;
+
 var
   GMode: TExecutionMode = emInterpreted;
   GOutputPath: string = '';
   GEmitOnly: Boolean = False;
+  GJsonOutput: Boolean = False;
+  GSilentConsole: Boolean = False;
 
 function ParseSource(const ASource: TStringList; const AFileName: string;
-  const AGlobals: TGocciaGlobalBuiltins): TGocciaProgram;
+  const AGlobals: TGocciaGlobalBuiltins; const ASuppressWarnings: Boolean;
+  out ALexTimeNanoseconds, AParseTimeNanoseconds: Int64): TGocciaProgram;
 var
   SourceText: string;
   JSXResult: TGocciaJSXTransformResult;
@@ -45,8 +56,10 @@ var
   Tokens: TObjectList<TGocciaToken>;
   Parser: TGocciaParser;
   Warning: TGocciaParserWarning;
+  StartTime, LexEnd, ParseEnd: Int64;
   OrigLine, OrigCol, I: Integer;
 begin
+  StartTime := GetNanoseconds;
   SourceText := ASource.Text;
 
   SourceMap := nil;
@@ -61,20 +74,28 @@ begin
     Lexer := TGocciaLexer.Create(SourceText, AFileName);
     try
       Tokens := Lexer.ScanTokens;
+      LexEnd := GetNanoseconds;
+      ALexTimeNanoseconds := LexEnd - StartTime;
+
       Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
       try
         Result := Parser.Parse;
-        for I := 0 to Parser.WarningCount - 1 do
-        begin
-          Warning := Parser.GetWarning(I);
-          WriteLn(SysUtils.Format('Warning: %s', [Warning.Message]));
-          if Warning.Suggestion <> '' then
-            WriteLn(SysUtils.Format('  Suggestion: %s', [Warning.Suggestion]));
-          if Assigned(SourceMap) and SourceMap.Translate(Warning.Line, Warning.Column, OrigLine, OrigCol) then
-            WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, OrigLine, OrigCol]))
-          else
-            WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, Warning.Line, Warning.Column]));
-        end;
+        ParseEnd := GetNanoseconds;
+        AParseTimeNanoseconds := ParseEnd - LexEnd;
+
+        if not ASuppressWarnings then
+          for I := 0 to Parser.WarningCount - 1 do
+          begin
+            Warning := Parser.GetWarning(I);
+            WriteLn(SysUtils.Format('Warning: %s', [Warning.Message]));
+            if Warning.Suggestion <> '' then
+              WriteLn(SysUtils.Format('  Suggestion: %s', [Warning.Suggestion]));
+            if Assigned(SourceMap) and
+               SourceMap.Translate(Warning.Line, Warning.Column, OrigLine, OrigCol) then
+              WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, OrigLine, OrigCol]))
+            else
+              WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, Warning.Line, Warning.Column]));
+          end;
       finally
         Parser.Free;
       end;
@@ -86,26 +107,15 @@ begin
   end;
 end;
 
-function ParseSourceFile(const AFileName: string; const AGlobals: TGocciaGlobalBuiltins): TGocciaProgram;
-var
-  Source: TStringList;
-begin
-  Source := TStringList.Create;
-  try
-    Source.LoadFromFile(AFileName);
-    Result := ParseSource(Source, AFileName, AGlobals);
-  finally
-    Source.Free;
-  end;
-end;
-
 function CompileSource(const ASource: TStringList; const AFileName: string;
-  const AGlobals: TGocciaGlobalBuiltins): TGocciaBytecodeModule;
+  const AGlobals: TGocciaGlobalBuiltins; const ASuppressWarnings: Boolean = False): TGocciaBytecodeModule;
 var
   ProgramNode: TGocciaProgram;
   Compiler: TGocciaCompiler;
+  LexTimeNanoseconds, ParseTimeNanoseconds: Int64;
 begin
-  ProgramNode := ParseSource(ASource, AFileName, AGlobals);
+  ProgramNode := ParseSource(ASource, AFileName, AGlobals, ASuppressWarnings,
+    LexTimeNanoseconds, ParseTimeNanoseconds);
   try
     Compiler := TGocciaCompiler.Create(AFileName);
     try
@@ -118,62 +128,97 @@ begin
   end;
 end;
 
-function CompileSourceFile(const AFileName: string;
-  const AGlobals: TGocciaGlobalBuiltins): TGocciaBytecodeModule;
-var
-  Source: TStringList;
+procedure ConfigureConsole(const AConsole: TGocciaConsole;
+  const AOutputLines: TStrings);
 begin
-  Source := TStringList.Create;
-  try
-    Source.LoadFromFile(AFileName);
-    Result := CompileSource(Source, AFileName, AGlobals);
-  finally
-    Source.Free;
-  end;
+  if not Assigned(AConsole) then
+    Exit;
+
+  AConsole.Enabled := not GSilentConsole;
+  if GJsonOutput and not GSilentConsole then
+    AConsole.OutputLines := AOutputLines
+  else
+    AConsole.OutputLines := nil;
 end;
 
-procedure RunInterpreted(const ASource: TStringList; const AFileName: string);
+function CapturedOutputText(const AOutputLines: TStrings): string;
+begin
+  if Assigned(AOutputLines) then
+    Result := AOutputLines.Text
+  else
+    Result := '';
+end;
+
+procedure PrintJSONSuccess(const AReport: TScriptExecutionReport;
+  const AOutputLines: TStrings);
+begin
+  WriteLn(BuildSuccessJSON(AReport.ResultValue, CapturedOutputText(AOutputLines),
+    AReport.Timing));
+end;
+
+procedure PrintJSONError(const E: Exception; const AReport: TScriptExecutionReport;
+  const AOutputLines: TStrings; const ADefaultFileName: string);
 var
+  ErrorInfo: TScriptLoaderErrorInfo;
+begin
+  ErrorInfo := ExceptionToScriptLoaderErrorInfo(E);
+  if ErrorInfo.FileName = '' then
+    ErrorInfo.FileName := ADefaultFileName;
+  WriteLn(BuildErrorJSON(CapturedOutputText(AOutputLines), ErrorInfo,
+    AReport.Timing));
+end;
+
+function ExecuteInterpreted(const ASource: TStringList; const AFileName: string;
+  const AOutputLines: TStrings): TScriptExecutionReport;
+var
+  Engine: TGocciaEngine;
   ScriptResult: TGocciaScriptResult;
 begin
-  WriteLn('Running script (interpreted): ', AFileName);
-  ScriptResult := TGocciaEngine.RunScriptFromStringList(ASource, AFileName, TGocciaEngine.DefaultGlobals);
-  WriteLn(SysUtils.Format('  Lex: %s | Parse: %s | Execute: %s | Total: %s',
-    [FormatDuration(ScriptResult.LexTimeNanoseconds), FormatDuration(ScriptResult.ParseTimeNanoseconds),
-     FormatDuration(ScriptResult.ExecuteTimeNanoseconds), FormatDuration(ScriptResult.TotalTimeNanoseconds)]));
-  Writeln('Result: ', ScriptResult.Result.ToStringLiteral.Value);
+  Engine := TGocciaEngine.Create(AFileName, ASource, TGocciaEngine.DefaultGlobals);
+  try
+    Engine.SuppressWarnings := GJsonOutput;
+    ConfigureConsole(Engine.BuiltinConsole, AOutputLines);
+    ScriptResult := Engine.Execute;
+  finally
+    Engine.Free;
+  end;
+
+  Result.ResultValue := ScriptResult.Result;
+  Result.Timing.LexTimeNanoseconds := ScriptResult.LexTimeNanoseconds;
+  Result.Timing.ParseTimeNanoseconds := ScriptResult.ParseTimeNanoseconds;
+  Result.Timing.ExecuteTimeNanoseconds := ScriptResult.ExecuteTimeNanoseconds;
+  Result.Timing.TotalTimeNanoseconds := ScriptResult.TotalTimeNanoseconds;
 end;
 
-procedure RunBytecodeFromSource(const ASource: TStringList; const AFileName: string);
+function ExecuteBytecodeFromSource(const ASource: TStringList; const AFileName: string;
+  const AOutputLines: TStrings): TScriptExecutionReport;
 var
   ProgramNode: TGocciaProgram;
   Module: TGocciaBytecodeModule;
   Backend: TGocciaBytecodeBackend;
-  StartTime, CompileEnd, ExecEnd: Int64;
-  ResultValue: TGocciaValue;
+  StartTime, ExecEnd: Int64;
 begin
-  WriteLn('Running script (bytecode): ', AFileName);
   StartTime := GetNanoseconds;
-
   Backend := TGocciaBytecodeBackend.Create(AFileName);
   try
     Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
+    ConfigureConsole(Backend.Bootstrap.BuiltinConsole, AOutputLines);
 
-    ProgramNode := ParseSource(ASource, AFileName, TGocciaEngine.DefaultGlobals);
+    ProgramNode := ParseSource(ASource, AFileName, TGocciaEngine.DefaultGlobals,
+      GJsonOutput, Result.Timing.LexTimeNanoseconds,
+      Result.Timing.ParseTimeNanoseconds);
     try
       Module := Backend.CompileToModule(ProgramNode);
     finally
       ProgramNode.Free;
     end;
-    CompileEnd := GetNanoseconds;
+
     try
-      ResultValue := Backend.RunModule(Module);
+      Result.ResultValue := Backend.RunModule(Module);
       ExecEnd := GetNanoseconds;
-      WriteLn(SysUtils.Format('  Compile: %s | Execute: %s | Total: %s',
-        [FormatDuration(CompileEnd - StartTime),
-         FormatDuration(ExecEnd - CompileEnd),
-         FormatDuration(ExecEnd - StartTime)]));
-      WriteLn('Result: ', ResultValue.ToStringLiteral.Value);
+      Result.Timing.ExecuteTimeNanoseconds := ExecEnd - StartTime -
+        Result.Timing.LexTimeNanoseconds - Result.Timing.ParseTimeNanoseconds;
+      Result.Timing.TotalTimeNanoseconds := ExecEnd - StartTime;
     finally
       Module.Free;
     end;
@@ -182,29 +227,27 @@ begin
   end;
 end;
 
-procedure RunBytecodeFromFile(const AFileName: string);
+function ExecuteBytecodeFromFile(const AFileName: string;
+  const AOutputLines: TStrings): TScriptExecutionReport;
 var
   Module: TGocciaBytecodeModule;
   Backend: TGocciaBytecodeBackend;
   StartTime, LoadEnd, ExecEnd: Int64;
-  ResultValue: TGocciaValue;
 begin
-  WriteLn('Running bytecode: ', AFileName);
   StartTime := GetNanoseconds;
-
   Module := Goccia.Bytecode.Binary.LoadModuleFromFile(AFileName);
   LoadEnd := GetNanoseconds;
   try
-  Backend := TGocciaBytecodeBackend.Create(AFileName);
-  try
-    Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
-      ResultValue := Backend.RunModule(Module);
+    Backend := TGocciaBytecodeBackend.Create(AFileName);
+    try
+      Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
+      ConfigureConsole(Backend.Bootstrap.BuiltinConsole, AOutputLines);
+      Result.ResultValue := Backend.RunModule(Module);
       ExecEnd := GetNanoseconds;
-      WriteLn(SysUtils.Format('  Load: %s | Execute: %s | Total: %s',
-        [FormatDuration(LoadEnd - StartTime),
-         FormatDuration(ExecEnd - LoadEnd),
-         FormatDuration(ExecEnd - StartTime)]));
-      WriteLn('Result: ', ResultValue.ToStringLiteral.Value);
+      Result.Timing.LexTimeNanoseconds := 0;
+      Result.Timing.ParseTimeNanoseconds := 0;
+      Result.Timing.ExecuteTimeNanoseconds := ExecEnd - LoadEnd;
+      Result.Timing.TotalTimeNanoseconds := ExecEnd - StartTime;
     finally
       Backend.Free;
     end;
@@ -213,7 +256,8 @@ begin
   end;
 end;
 
-procedure EmitBytecode(const ASource: TStringList; const AFileName, AOutputPath: string);
+procedure EmitBytecode(const ASource: TStringList; const AFileName,
+  AOutputPath: string);
 var
   Module: TGocciaBytecodeModule;
   StartTime, EndTime: Int64;
@@ -223,7 +267,8 @@ begin
 
   TGarbageCollector.Initialize;
   try
-    Module := CompileSource(ASource, AFileName, TGocciaEngine.DefaultGlobals);
+    Module := CompileSource(ASource, AFileName, TGocciaEngine.DefaultGlobals,
+      GJsonOutput);
     try
       Goccia.Bytecode.Binary.SaveModuleToFile(Module, AOutputPath);
       EndTime := GetNanoseconds;
@@ -237,57 +282,108 @@ begin
   end;
 end;
 
+procedure PrintHumanReadableResult(const AFileName: string;
+  const AReport: TScriptExecutionReport; const AExtension: string);
+var
+  LoadTimeNanoseconds, FrontEndTimeNanoseconds: Int64;
+begin
+  if AExtension = EXT_GBC then
+  begin
+    LoadTimeNanoseconds := AReport.Timing.TotalTimeNanoseconds -
+      AReport.Timing.ExecuteTimeNanoseconds;
+    WriteLn('Running bytecode: ', AFileName);
+    WriteLn(SysUtils.Format('  Load: %s | Execute: %s | Total: %s',
+      [FormatDuration(LoadTimeNanoseconds),
+       FormatDuration(AReport.Timing.ExecuteTimeNanoseconds),
+       FormatDuration(AReport.Timing.TotalTimeNanoseconds)]));
+  end
+  else if GMode = emBytecode then
+  begin
+    FrontEndTimeNanoseconds := AReport.Timing.TotalTimeNanoseconds -
+      AReport.Timing.ExecuteTimeNanoseconds;
+    WriteLn('Running script (bytecode): ', AFileName);
+    WriteLn(SysUtils.Format('  Compile: %s | Execute: %s | Total: %s',
+      [FormatDuration(FrontEndTimeNanoseconds),
+       FormatDuration(AReport.Timing.ExecuteTimeNanoseconds),
+       FormatDuration(AReport.Timing.TotalTimeNanoseconds)]));
+  end
+  else
+  begin
+    WriteLn('Running script (interpreted): ', AFileName);
+    WriteLn(SysUtils.Format('  Lex: %s | Parse: %s | Execute: %s | Total: %s',
+      [FormatDuration(AReport.Timing.LexTimeNanoseconds),
+       FormatDuration(AReport.Timing.ParseTimeNanoseconds),
+       FormatDuration(AReport.Timing.ExecuteTimeNanoseconds),
+       FormatDuration(AReport.Timing.TotalTimeNanoseconds)]));
+  end;
+
+  WriteLn('Result: ', AReport.ResultValue.ToStringLiteral.Value);
+end;
+
 procedure RunSource(const ASource: TStringList; const AFileName: string);
 var
-  Ext, OutputPath: string;
+  Extension, OutputPath: string;
+  Report: TScriptExecutionReport;
+  OutputLines: TStringList;
+  StartTime: Int64;
 begin
+  FillChar(Report, SizeOf(Report), 0);
+  Report.ResultValue := nil;
+
+  OutputLines := nil;
+  if GJsonOutput then
+    OutputLines := TStringList.Create;
   try
-    Ext := LowerCase(ExtractFileExt(AFileName));
+    StartTime := GetNanoseconds;
+    try
+      Extension := LowerCase(ExtractFileExt(AFileName));
 
-    if Ext = EXT_GBC then
-    begin
-      RunBytecodeFromFile(AFileName);
-      Exit;
-    end;
-
-    if GEmitOnly then
-    begin
-      if GOutputPath <> '' then
-        OutputPath := GOutputPath
-      else if AFileName = STDIN_FILE_NAME then
+      if Extension = EXT_GBC then
+        Report := ExecuteBytecodeFromFile(AFileName, OutputLines)
+      else if GEmitOnly then
       begin
-        WriteLn('Error: --output=<path> is required when emitting bytecode from stdin.');
-        ExitCode := 1;
+        if GOutputPath <> '' then
+          OutputPath := GOutputPath
+        else if AFileName = STDIN_FILE_NAME then
+          raise Exception.Create('--output=<path> is required when emitting bytecode from stdin.')
+        else
+          OutputPath := ChangeFileExt(AFileName, EXT_GBC);
+        EmitBytecode(ASource, AFileName, OutputPath);
         Exit;
       end
       else
-        OutputPath := ChangeFileExt(AFileName, EXT_GBC);
-      EmitBytecode(ASource, AFileName, OutputPath);
-      Exit;
-    end;
+        case GMode of
+          emInterpreted: Report := ExecuteInterpreted(ASource, AFileName, OutputLines);
+          emBytecode:    Report := ExecuteBytecodeFromSource(ASource, AFileName, OutputLines);
+        end;
 
-    case GMode of
-      emInterpreted: RunInterpreted(ASource, AFileName);
-      emBytecode:    RunBytecodeFromSource(ASource, AFileName);
+      if GJsonOutput then
+        PrintJSONSuccess(Report, OutputLines)
+      else
+        PrintHumanReadableResult(AFileName, Report, Extension);
+    except
+      on E: Exception do
+      begin
+        Report.Timing.TotalTimeNanoseconds := GetNanoseconds - StartTime;
+        if GJsonOutput then
+          PrintJSONError(E, Report, OutputLines, AFileName)
+        else
+          WriteLn('Fatal error: ', E.Message);
+        ExitCode := 1;
+      end;
     end;
-  except
-    on E: Exception do
-    begin
-      WriteLn('Fatal error: ', E.Message);
-      ExitCode := 1;
-    end;
+  finally
+    OutputLines.Free;
   end;
 end;
 
 procedure RunScriptFromFile(const AFileName: string);
 var
-  Ext: string;
   Source: TStringList;
 begin
-  Ext := LowerCase(ExtractFileExt(AFileName));
-  if Ext = EXT_GBC then
+  if LowerCase(ExtractFileExt(AFileName)) = EXT_GBC then
   begin
-    RunBytecodeFromFile(AFileName);
+    RunSource(nil, AFileName);
     Exit;
   end;
 
@@ -325,11 +421,15 @@ begin
 
   if DirectoryExists(APath) then
   begin
+    if GJsonOutput then
+      raise Exception.Create('--output=json does not support directory input.');
+
     Files := FindAllFiles(APath, ScriptExtensions);
     try
       for I := 0 to Files.Count - 1 do
       begin
-        if I > 0 then WriteLn;
+        if I > 0 then
+          WriteLn;
         RunScriptFromFile(Files[I]);
       end;
     finally
@@ -339,10 +439,7 @@ begin
   else if FileExists(APath) then
     RunScriptFromFile(APath)
   else
-  begin
-    WriteLn('Error: Path not found: ', APath);
-    ExitCode := 1;
-  end;
+    raise Exception.Create('Path not found: ' + APath);
 end;
 
 procedure PrintUsage;
@@ -359,7 +456,9 @@ begin
   WriteLn('  --mode=bytecode         Compile to bytecode and execute on the Goccia VM');
   WriteLn('  --emit                  Compile to .gbc file (no execution)');
   WriteLn('  --emit=bytecode         Compile to .gbc file (explicit, same as --emit)');
+  WriteLn('  --output=json           Write structured JSON result to stdout');
   WriteLn('  --output=<path>         Output file path (used with --emit)');
+  WriteLn('  --silent                Suppress console output from the script');
 end;
 
 var
@@ -371,6 +470,9 @@ begin
   GMode := emInterpreted;
   GOutputPath := '';
   GEmitOnly := False;
+  GJsonOutput := False;
+  GSilentConsole := False;
+  Logger.Levels := [];
 
   Paths := TStringList.Create;
   try
@@ -395,11 +497,7 @@ begin
       begin
         GEmitOnly := True;
         EmitStr := Copy(Arg, 8, MaxInt);
-        if (EmitStr = 'bytecode') or (EmitStr = '') then
-        begin
-          // Valid.
-        end
-        else
+        if (EmitStr <> 'bytecode') and (EmitStr <> '') then
         begin
           WriteLn('Error: Unknown emit format "', EmitStr, '". Use "bytecode".');
           ExitCode := 1;
@@ -414,7 +512,13 @@ begin
         Exit;
       end
       else if Copy(Arg, 1, 9) = '--output=' then
-        GOutputPath := Copy(Arg, 10, MaxInt)
+      begin
+        GOutputPath := Copy(Arg, 10, MaxInt);
+        if GOutputPath = 'json' then
+          GJsonOutput := True;
+      end
+      else if Arg = '--silent' then
+        GSilentConsole := True
       else if Copy(Arg, 1, 2) <> '--' then
         Paths.Add(Arg)
       else
@@ -426,14 +530,41 @@ begin
       end;
     end;
 
-    if Paths.Count = 0 then
-      RunScriptFromStdin
-    else
-      for I := 0 to Paths.Count - 1 do
+    if GJsonOutput and GEmitOnly then
+    begin
+      WriteLn('Error: --output=json cannot be used with --emit.');
+      ExitCode := 1;
+      Exit;
+    end;
+
+    if GJsonOutput and (Paths.Count > 1) then
+    begin
+      WriteLn('Error: --output=json supports a single input path.');
+      ExitCode := 1;
+      Exit;
+    end;
+
+    try
+      if Paths.Count = 0 then
+        RunScriptFromStdin
+      else
+        for I := 0 to Paths.Count - 1 do
+        begin
+          if I > 0 then
+            WriteLn;
+          RunScripts(Paths[I]);
+        end;
+    except
+      on E: Exception do
       begin
-        if I > 0 then WriteLn;
-        RunScripts(Paths[I]);
+        if GJsonOutput then
+          WriteLn(BuildErrorJSON('', ExceptionToScriptLoaderErrorInfo(E),
+            Default(TScriptLoaderTiming)))
+        else
+          WriteLn('Error: ', E.Message);
+        ExitCode := 1;
       end;
+    end;
   finally
     Paths.Free;
   end;

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -92,6 +92,9 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader --emit --output=output.gbc
 # Load and execute a pre-compiled .gbc file
 ./build/ScriptLoader output.gbc
 
+# Emit structured JSON for programmatic consumers
+printf "console.log('hi'); 2 + 2;" | ./build/ScriptLoader --output=json
+
 # Run tests via bytecode VM
 ./build/TestRunner tests --mode=bytecode
 
@@ -109,7 +112,7 @@ All compiled binaries go to the `build/` directory:
 | Binary | Source | Description |
 |--------|--------|-------------|
 | `build/REPL` | `REPL.dpr` | Interactive read-eval-print loop |
-| `build/ScriptLoader` | `ScriptLoader.dpr` | Execute `.js` files or stdin input |
+| `build/ScriptLoader` | `ScriptLoader.dpr` | Execute `.js` files or stdin input, with optional JSON output |
 | `build/TestRunner` | `TestRunner.dpr` | JavaScript test runner |
 | `build/BenchmarkRunner` | `BenchmarkRunner.dpr` | Performance benchmark runner for files or stdin input |
 | `build/Goccia.Values.Primitives.Test` | `*.Test.pas` | Pascal unit test binaries |

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -9,7 +9,8 @@ GocciaScript is designed to be embedded in FreePascal applications. The `TGoccia
 The simplest way to run a script:
 
 ```pascal
-uses Goccia.Engine;
+uses
+  Goccia.Engine;
 
 TGocciaEngine.RunScript('console.log("hello from GocciaScript");');
 ```
@@ -43,7 +44,11 @@ All methods return `TGocciaScriptResult` — a record containing the result valu
 For interactive sessions (REPL, editor integration) or when you need to execute multiple scripts in the same scope, create an engine instance directly:
 
 ```pascal
-uses Classes, Goccia.Engine, Goccia.Values.Primitives;
+uses
+  Classes,
+
+  Goccia.Engine,
+  Goccia.Values.Primitives;
 
 var
   Engine: TGocciaEngine;
@@ -74,7 +79,10 @@ The `TStringList` is passed by reference — update its contents and call `Execu
 All `RunScript*` methods and the `Execute` method return a `TGocciaScriptResult` record that includes nanosecond-precision timing for each pipeline phase:
 
 ```pascal
-uses Goccia.Engine, TimingUtils;
+uses
+  TimingUtils,
+
+  Goccia.Engine;
 
 var
   ScriptResult: TGocciaScriptResult;
@@ -136,7 +144,8 @@ import { formatDate } from "@/utils/dates";
 For advanced resolution logic (e.g., `node_modules` lookup, URL imports, or in-memory modules), subclass `TGocciaModuleResolver` and override the `Resolve` method:
 
 ```pascal
-uses Goccia.Modules.Resolver;
+uses
+  Goccia.Modules.Resolver;
 
 type
   TMyResolver = class(TGocciaModuleResolver)
@@ -172,7 +181,8 @@ When no custom resolver is provided, the engine creates a default `TGocciaModule
 Global modules are bare-specifier imports that bypass file resolution entirely. They are checked before the resolver runs:
 
 ```pascal
-uses Goccia.Modules;
+uses
+  Goccia.Modules;
 
 var
   Module: TGocciaModule;
@@ -248,7 +258,10 @@ You can inject Pascal functions and values into the script's global scope by wor
 ### Injecting a Value
 
 ```pascal
-uses Goccia.Engine, Goccia.Values.Primitives, Goccia.Scope;
+uses
+  Goccia.Engine,
+  Goccia.Scope,
+  Goccia.Values.Primitives;
 
 var
   Engine: TGocciaEngine;
@@ -277,17 +290,21 @@ end;
 Native functions are Pascal methods exposed to GocciaScript. They receive arguments and a `this` value, and return a `TGocciaValue`.
 
 ```pascal
-uses Goccia.Engine, Goccia.Values.Primitives, Goccia.Values.NativeFunction,
-     Goccia.Arguments.Collection, Goccia.Scope;
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Engine,
+  Goccia.Scope,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.Primitives;
 
 type
   TMyHost = class
-    function GetTimestamp(Args: TGocciaArgumentsCollection;
-      ThisValue: TGocciaValue): TGocciaValue;
+    function GetTimestamp(AArgs: TGocciaArgumentsCollection;
+      AThisValue: TGocciaValue): TGocciaValue;
   end;
 
-function TMyHost.GetTimestamp(Args: TGocciaArgumentsCollection;
-  ThisValue: TGocciaValue): TGocciaValue;
+function TMyHost.GetTimestamp(AArgs: TGocciaArgumentsCollection;
+  AThisValue: TGocciaValue): TGocciaValue;
 begin
   Result := TGocciaNumberLiteralValue.Create(DateTimeToUnix(Now));
 end;
@@ -333,24 +350,29 @@ TGocciaNativeFunctionCallback = function(
 For a more structured API, create a `TGocciaObjectValue` and register native methods on it:
 
 ```pascal
-uses Goccia.Engine, Goccia.Values.Primitives, Goccia.Values.ObjectValue,
-     Goccia.Values.NativeFunction, Goccia.Arguments.Collection, Goccia.Scope;
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Engine,
+  Goccia.Scope,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
 
 type
   TFileSystemAPI = class
-    function ReadFile(Args: TGocciaArgumentsCollection;
-      ThisValue: TGocciaValue): TGocciaValue;
-    function Exists(Args: TGocciaArgumentsCollection;
-      ThisValue: TGocciaValue): TGocciaValue;
+    function ReadFile(AArgs: TGocciaArgumentsCollection;
+      AThisValue: TGocciaValue): TGocciaValue;
+    function Exists(AArgs: TGocciaArgumentsCollection;
+      AThisValue: TGocciaValue): TGocciaValue;
   end;
 
-function TFileSystemAPI.ReadFile(Args: TGocciaArgumentsCollection;
-  ThisValue: TGocciaValue): TGocciaValue;
+function TFileSystemAPI.ReadFile(AArgs: TGocciaArgumentsCollection;
+  AThisValue: TGocciaValue): TGocciaValue;
 var
   Path: string;
   Content: TStringList;
 begin
-  Path := Args.GetElement(0).ToStringLiteral.Value;
+  Path := AArgs.GetElement(0).ToStringLiteral.Value;
   Content := TStringList.Create;
   try
     Content.LoadFromFile(Path);
@@ -360,11 +382,11 @@ begin
   end;
 end;
 
-function TFileSystemAPI.Exists(Args: TGocciaArgumentsCollection;
-  ThisValue: TGocciaValue): TGocciaValue;
+function TFileSystemAPI.Exists(AArgs: TGocciaArgumentsCollection;
+  AThisValue: TGocciaValue): TGocciaValue;
 begin
   Result := TGocciaBooleanLiteralValue.Create(
-    FileExists(Args.GetElement(0).ToStringLiteral.Value)
+    FileExists(AArgs.GetElement(0).ToStringLiteral.Value)
   );
 end;
 
@@ -438,7 +460,9 @@ end;
 GocciaScript errors surface as Pascal exceptions. Wrap execution in `try...except`:
 
 ```pascal
-uses Goccia.Engine, Goccia.Error;
+uses
+  Goccia.Engine,
+  Goccia.Error;
 
 try
   TGocciaEngine.RunScript('undeclaredVariable;');
@@ -495,7 +519,8 @@ The engine initializes a mark-and-sweep garbage collector (`TGarbageCollector`) 
 For long-running engines (REPL-style), the GC runs automatically. If you need to trigger collection manually between script executions:
 
 ```pascal
-uses GarbageCollector.Generic;
+uses
+  GarbageCollector.Generic;
 
 TGarbageCollector.Instance.Collect;
 ```
@@ -517,7 +542,7 @@ The repository includes four embedding examples:
 
 | Program | File | Description |
 |---------|------|-------------|
-| `ScriptLoader` | `ScriptLoader.dpr` | Executes script files (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`) from disk or stdin (one-shot) |
+| `ScriptLoader` | `ScriptLoader.dpr` | Executes script files (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`) from disk or stdin, with optional JSON output for one-shot automation |
 | `REPL` | `REPL.dpr` | Interactive read-eval-print loop (long-lived engine) |
 | `TestRunner` | `TestRunner.dpr` | Runs test suites with `ggTestAssertions` enabled |
 | `BenchmarkRunner` | `BenchmarkRunner.dpr` | Runs benchmarks with `ggBenchmark` enabled from files or stdin |

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -259,6 +259,9 @@ You can inject Pascal functions and values into the script's global scope by wor
 
 ```pascal
 uses
+  Classes,
+  SysUtils,
+
   Goccia.Engine,
   Goccia.Scope,
   Goccia.Values.Primitives;
@@ -291,6 +294,10 @@ Native functions are Pascal methods exposed to GocciaScript. They receive argume
 
 ```pascal
 uses
+  Classes,
+  DateUtils,
+  SysUtils,
+
   Goccia.Arguments.Collection,
   Goccia.Engine,
   Goccia.Scope,
@@ -351,6 +358,9 @@ For a more structured API, create a `TGocciaObjectValue` and register native met
 
 ```pascal
 uses
+  Classes,
+  SysUtils,
+
   Goccia.Arguments.Collection,
   Goccia.Engine,
   Goccia.Scope,
@@ -461,6 +471,8 @@ GocciaScript errors surface as Pascal exceptions. Wrap execution in `try...excep
 
 ```pascal
 uses
+  SysUtils,
+
   Goccia.Engine,
   Goccia.Error;
 

--- a/units/Goccia.Builtins.Console.pas
+++ b/units/Goccia.Builtins.Console.pas
@@ -5,6 +5,8 @@ unit Goccia.Builtins.Console;
 interface
 
 uses
+  Classes,
+
   Goccia.Arguments.Collection,
   Goccia.Builtins.Base,
   Goccia.Error.ThrowErrorCallback,
@@ -20,10 +22,17 @@ type
     FTimers: TGocciaObjectValue;
     FCounters: TGocciaObjectValue;
     FGroupDepth: Integer;
+    FOutputLines: TStrings;
+    FEnabled: Boolean;
 
     function FormatArgs(const AArgs: TGocciaArgumentsCollection): string;
     function GroupPrefix: string;
     function FormatValue(const AValue: TGocciaValue): string;
+    procedure EmitLine(const ALine: string);
+    function GetEnabled: Boolean;
+    procedure SetEnabled(const AValue: Boolean);
+    function GetOutputLines: TStrings;
+    procedure SetOutputLines(const AValue: TStrings);
   protected
   published
     function ConsoleLog(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -45,6 +54,8 @@ type
     function ConsoleTable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
+    property Enabled: Boolean read GetEnabled write SetEnabled;
+    property OutputLines: TStrings read GetOutputLines write SetOutputLines;
   end;
 
 implementation
@@ -66,6 +77,8 @@ begin
   FTimers := TGocciaObjectValue.Create;
   FCounters := TGocciaObjectValue.Create;
   FGroupDepth := 0;
+  FEnabled := True;
+  FOutputLines := nil;
   Members := TGocciaMemberCollection.Create;
   try
     Members.AddMethod(ConsoleLog, -1, gmkStaticMethod);
@@ -92,6 +105,37 @@ begin
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
   AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+end;
+
+procedure TGocciaConsole.EmitLine(const ALine: string);
+begin
+  if not FEnabled then
+    Exit;
+
+  if Assigned(FOutputLines) then
+    FOutputLines.Add(ALine)
+  else
+    WriteLn(ALine);
+end;
+
+function TGocciaConsole.GetEnabled: Boolean;
+begin
+  Result := FEnabled;
+end;
+
+procedure TGocciaConsole.SetEnabled(const AValue: Boolean);
+begin
+  FEnabled := AValue;
+end;
+
+function TGocciaConsole.GetOutputLines: TStrings;
+begin
+  Result := FOutputLines;
+end;
+
+procedure TGocciaConsole.SetOutputLines(const AValue: TStrings);
+begin
+  FOutputLines := AValue;
 end;
 
 function TGocciaConsole.FormatValue(const AValue: TGocciaValue): string;
@@ -165,31 +209,31 @@ end;
 
 function TGocciaConsole.ConsoleLog(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  WriteLn(GroupPrefix + FormatArgs(AArgs));
+  EmitLine(GroupPrefix + FormatArgs(AArgs));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 function TGocciaConsole.ConsoleWarn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  WriteLn(GroupPrefix + 'Warning: ' + FormatArgs(AArgs));
+  EmitLine(GroupPrefix + 'Warning: ' + FormatArgs(AArgs));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 function TGocciaConsole.ConsoleError(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  WriteLn(GroupPrefix + 'Error: ' + FormatArgs(AArgs));
+  EmitLine(GroupPrefix + 'Error: ' + FormatArgs(AArgs));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 function TGocciaConsole.ConsoleInfo(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  WriteLn(GroupPrefix + 'Info: ' + FormatArgs(AArgs));
+  EmitLine(GroupPrefix + 'Info: ' + FormatArgs(AArgs));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 function TGocciaConsole.ConsoleDebug(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  WriteLn(GroupPrefix + 'Debug: ' + FormatArgs(AArgs));
+  EmitLine(GroupPrefix + 'Debug: ' + FormatArgs(AArgs));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
@@ -200,7 +244,7 @@ begin
   if AArgs.Length >= 1 then
   begin
     Value := AArgs.GetElement(0);
-    WriteLn(GroupPrefix + FormatValue(Value));
+    EmitLine(GroupPrefix + FormatValue(Value));
   end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -222,11 +266,11 @@ begin
         for I := 1 to AArgs.Length - 1 do
           Msg := Msg + ' ' + AArgs.GetElement(I).ToStringLiteral.Value;
       end;
-      WriteLn(GroupPrefix + Msg);
+      EmitLine(GroupPrefix + Msg);
     end;
   end
   else
-    WriteLn(GroupPrefix + 'Assertion failed');
+    EmitLine(GroupPrefix + 'Assertion failed');
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
@@ -248,7 +292,7 @@ begin
     CountVal := Trunc(Current.ToNumberLiteral.Value) + 1;
 
   FCounters.AssignProperty(LabelStr, TGocciaNumberLiteralValue.Create(CountVal * 1.0));
-  WriteLn(GroupPrefix + LabelStr + ': ' + IntToStr(CountVal));
+  EmitLine(GroupPrefix + LabelStr + ': ' + IntToStr(CountVal));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
@@ -293,11 +337,11 @@ begin
   if (StartTime <> nil) and not (StartTime is TGocciaUndefinedLiteralValue) then
   begin
     Elapsed := GetMilliseconds - StartTime.ToNumberLiteral.Value;
-    WriteLn(GroupPrefix + LabelStr + ': ' + FormatFloat('0.###', Elapsed) + 'ms');
+    EmitLine(GroupPrefix + LabelStr + ': ' + FormatFloat('0.###', Elapsed) + 'ms');
     FTimers.DeleteProperty(LabelStr);
   end
   else
-    WriteLn(GroupPrefix + 'Timer ''' + LabelStr + ''' does not exist');
+    EmitLine(GroupPrefix + 'Timer ''' + LabelStr + ''' does not exist');
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
@@ -316,10 +360,10 @@ begin
   if (StartTime <> nil) and not (StartTime is TGocciaUndefinedLiteralValue) then
   begin
     Elapsed := GetMilliseconds - StartTime.ToNumberLiteral.Value;
-    WriteLn(GroupPrefix + LabelStr + ': ' + FormatFloat('0.###', Elapsed) + 'ms');
+    EmitLine(GroupPrefix + LabelStr + ': ' + FormatFloat('0.###', Elapsed) + 'ms');
   end
   else
-    WriteLn(GroupPrefix + 'Timer ''' + LabelStr + ''' does not exist');
+    EmitLine(GroupPrefix + 'Timer ''' + LabelStr + ''' does not exist');
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
@@ -331,7 +375,7 @@ end;
 function TGocciaConsole.ConsoleGroup(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if AArgs.Length > 0 then
-    WriteLn(GroupPrefix + FormatArgs(AArgs));
+    EmitLine(GroupPrefix + FormatArgs(AArgs));
   Inc(FGroupDepth);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -346,16 +390,16 @@ end;
 function TGocciaConsole.ConsoleTrace(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if AArgs.Length > 0 then
-    WriteLn(GroupPrefix + 'Trace: ' + FormatArgs(AArgs))
+    EmitLine(GroupPrefix + 'Trace: ' + FormatArgs(AArgs))
   else
-    WriteLn(GroupPrefix + 'Trace');
+    EmitLine(GroupPrefix + 'Trace');
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 function TGocciaConsole.ConsoleTable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if AArgs.Length >= 1 then
-    WriteLn(GroupPrefix + FormatValue(AArgs.GetElement(0)));
+    EmitLine(GroupPrefix + FormatValue(AArgs.GetElement(0)));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 

--- a/units/Goccia.Logger.pas
+++ b/units/Goccia.Logger.pas
@@ -39,18 +39,9 @@ uses
   TypInfo;
 
 constructor TGocciaLogger.Create(const ALevels: TGocciaLogLevels; const ALogFormat: TGocciaLogFormat);
-var
-  Levels: String;
-  Level: TGocciaLogLevel;
 begin
   FLevels := ALevels;
   FLogFormat := ALogFormat;
-
-  Levels := '';
-  for Level in ALevels do
-    Levels := Levels + GetEnumName(TypeInfo(TGocciaLogLevel), Ord(Level)) + ', ';
-
-  WriteLn(Format('[LOGGER] Logger created with levels: %s and format: %s', [Levels, GetEnumName(TypeInfo(TGocciaLogFormat), Ord(FLogFormat))]));
 end;
 
 procedure TGocciaLogger.Trace(const AMessage: string);

--- a/units/Goccia.ScriptLoader.JSON.Test.pas
+++ b/units/Goccia.ScriptLoader.JSON.Test.pas
@@ -11,6 +11,7 @@ uses
   Goccia.Error,
   Goccia.ScriptLoader.JSON,
   Goccia.TestSetup,
+  Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.Primitives;
 
@@ -83,7 +84,7 @@ begin
   try
     ThrowTypeError('Boom');
   except
-    on E: Exception do
+    on E: TGocciaThrowValue do
     begin
       DidThrow := True;
       ErrorInfo := ExceptionToScriptLoaderErrorInfo(E);

--- a/units/Goccia.ScriptLoader.JSON.Test.pas
+++ b/units/Goccia.ScriptLoader.JSON.Test.pas
@@ -1,0 +1,112 @@
+program Goccia.ScriptLoader.JSON.Test;
+
+{$I Goccia.inc}
+
+uses
+  SysUtils,
+
+  GarbageCollector.Generic,
+  TestRunner,
+
+  Goccia.Error,
+  Goccia.ScriptLoader.JSON,
+  Goccia.TestSetup,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.Primitives;
+
+type
+  TScriptLoaderJSONTests = class(TTestSuite)
+  private
+    procedure TestBuildSuccessJSONSerializesOutputAndUndefined;
+    procedure TestExceptionToScriptLoaderErrorInfoUsesGocciaErrorMetadata;
+    procedure TestExceptionToScriptLoaderErrorInfoUsesThrownErrorObject;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TScriptLoaderJSONTests.SetupTests;
+begin
+  Test('Build success JSON serializes output and undefined', TestBuildSuccessJSONSerializesOutputAndUndefined);
+  Test('Exception metadata uses Goccia error metadata', TestExceptionToScriptLoaderErrorInfoUsesGocciaErrorMetadata);
+  Test('Thrown error object metadata is preserved', TestExceptionToScriptLoaderErrorInfoUsesThrownErrorObject);
+end;
+
+procedure TScriptLoaderJSONTests.TestBuildSuccessJSONSerializesOutputAndUndefined;
+var
+  Timing: TScriptLoaderTiming;
+  JSONText: string;
+begin
+  Timing.LexTimeNanoseconds := 1000000;
+  Timing.ParseTimeNanoseconds := 2000000;
+  Timing.ExecuteTimeNanoseconds := 3000000;
+  Timing.TotalTimeNanoseconds := 6000000;
+
+  JSONText := BuildSuccessJSON(TGocciaUndefinedLiteralValue.UndefinedValue, 'hello' + sLineBreak, Timing);
+  Expect<Boolean>(Pos('"ok":true', JSONText) > 0).ToBe(True);
+  Expect<Boolean>(Pos('"value":null', JSONText) > 0).ToBe(True);
+  Expect<Boolean>(Pos('"output":"hello\n"', JSONText) > 0).ToBe(True);
+  Expect<Boolean>(Pos('"lex_ms":1', JSONText) > 0).ToBe(True);
+end;
+
+procedure TScriptLoaderJSONTests.TestExceptionToScriptLoaderErrorInfoUsesGocciaErrorMetadata;
+var
+  ErrorInfo: TScriptLoaderErrorInfo;
+  Error: TGocciaSyntaxError;
+begin
+  Error := TGocciaSyntaxError.Create('Unexpected token', 3, 10, 'script.js', nil);
+  try
+    ErrorInfo := ExceptionToScriptLoaderErrorInfo(Error);
+    Expect<string>(ErrorInfo.ErrorType).ToBe('SyntaxError');
+    Expect<string>(ErrorInfo.Message).ToBe('Unexpected token');
+    Expect<string>(ErrorInfo.FileName).ToBe('script.js');
+    Expect<Integer>(ErrorInfo.Line).ToBe(3);
+    Expect<Integer>(ErrorInfo.Column).ToBe(10);
+  finally
+    Error.Free;
+  end;
+end;
+
+procedure TScriptLoaderJSONTests.TestExceptionToScriptLoaderErrorInfoUsesThrownErrorObject;
+var
+  ErrorInfo: TScriptLoaderErrorInfo;
+  DidThrow: Boolean;
+  ErrorTypeText: string;
+  MessageText: string;
+  ErrorLine: Integer;
+  ErrorColumn: Integer;
+begin
+  DidThrow := False;
+  ErrorTypeText := '';
+  MessageText := '';
+  ErrorLine := 0;
+  ErrorColumn := 0;
+  try
+    ThrowTypeError('Boom');
+  except
+    on E: Exception do
+    begin
+      DidThrow := True;
+      ErrorInfo := ExceptionToScriptLoaderErrorInfo(E);
+      ErrorTypeText := ErrorInfo.ErrorType;
+      MessageText := ErrorInfo.Message;
+      ErrorLine := ErrorInfo.Line;
+      ErrorColumn := ErrorInfo.Column;
+    end;
+  end;
+  Expect<Boolean>(DidThrow).ToBe(True);
+  Expect<string>(ErrorTypeText).ToBe('TypeError');
+  Expect<string>(MessageText).ToBe('Boom');
+  Expect<Integer>(ErrorLine).ToBe(-1);
+  Expect<Integer>(ErrorColumn).ToBe(-1);
+end;
+
+begin
+  TGarbageCollector.Initialize;
+  try
+    TestRunnerProgram.AddSuite(TScriptLoaderJSONTests.Create('ScriptLoader JSON'));
+    TestRunnerProgram.Run;
+    ExitCode := TestResultToExitCode;
+  finally
+    TGarbageCollector.Shutdown;
+  end;
+end.

--- a/units/Goccia.ScriptLoader.JSON.pas
+++ b/units/Goccia.ScriptLoader.JSON.pas
@@ -1,0 +1,268 @@
+unit Goccia.ScriptLoader.JSON;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  SysUtils,
+
+  Goccia.Values.Primitives;
+
+type
+  TScriptLoaderTiming = record
+    LexTimeNanoseconds: Int64;
+    ParseTimeNanoseconds: Int64;
+    ExecuteTimeNanoseconds: Int64;
+    TotalTimeNanoseconds: Int64;
+  end;
+
+  TScriptLoaderErrorInfo = record
+    ErrorType: string;
+    Message: string;
+    FileName: string;
+    Line: Integer;
+    Column: Integer;
+  end;
+
+function DefaultScriptLoaderErrorInfo: TScriptLoaderErrorInfo;
+function ExceptionToScriptLoaderErrorInfo(const E: Exception): TScriptLoaderErrorInfo;
+function BuildSuccessJSON(const AValue: TGocciaValue; const AOutputText: string;
+  const ATiming: TScriptLoaderTiming): string;
+function BuildErrorJSON(const AOutputText: string;
+  const AErrorInfo: TScriptLoaderErrorInfo;
+  const ATiming: TScriptLoaderTiming): string;
+
+implementation
+
+uses
+  Math,
+
+  StringBuffer,
+
+  Goccia.Constants.PropertyNames,
+  Goccia.Error,
+  Goccia.JSON,
+  Goccia.Values.Error,
+  Goccia.Values.FunctionBase,
+  Goccia.Values.ObjectValue,
+  Goccia.VM.Exception;
+
+function EscapeJSONString(const AValue: string): string;
+var
+  I: Integer;
+  Ch: Char;
+  Buffer: TStringBuffer;
+begin
+  Buffer := TStringBuffer.Create(Length(AValue));
+  for I := 1 to Length(AValue) do
+  begin
+    Ch := AValue[I];
+    case Ch of
+      '"': Buffer.Append('\"');
+      '\': Buffer.Append('\\');
+      '/': Buffer.Append('\/');
+      #8: Buffer.Append('\b');
+      #9: Buffer.Append('\t');
+      #10: Buffer.Append('\n');
+      #12: Buffer.Append('\f');
+      #13: Buffer.Append('\r');
+    else
+      if Ord(Ch) < 32 then
+      begin
+        Buffer.Append('\u');
+        Buffer.Append(IntToHex(Ord(Ch), 4));
+      end
+      else
+        Buffer.AppendChar(Ch);
+    end;
+  end;
+  Result := Buffer.ToString;
+end;
+
+function QuoteJSONString(const AValue: string): string;
+begin
+  Result := '"' + EscapeJSONString(AValue) + '"';
+end;
+
+function NanosecondsToMillisecondsText(const ANanoseconds: Int64): string;
+begin
+  Result := FloatToStr(ANanoseconds / 1000000.0, DefaultFormatSettings);
+end;
+
+function SerializeScriptValue(const AValue: TGocciaValue): string;
+var
+  Stringifier: TGocciaJSONStringifier;
+  Serialized: string;
+begin
+  if not Assigned(AValue) or (AValue is TGocciaUndefinedLiteralValue) then
+    Exit('null');
+
+  if AValue.IsCallable then
+    Exit(QuoteJSONString(AValue.ToStringLiteral.Value));
+
+  Stringifier := TGocciaJSONStringifier.Create;
+  try
+    Serialized := Stringifier.Stringify(AValue);
+  finally
+    Stringifier.Free;
+  end;
+
+  if (Serialized = 'null') and
+     not (AValue is TGocciaNullLiteralValue) and
+     not (AValue is TGocciaBooleanLiteralValue) and
+     not (AValue is TGocciaNumberLiteralValue) then
+    Result := QuoteJSONString(AValue.ToStringLiteral.Value)
+  else
+    Result := Serialized;
+end;
+
+function SerializeNullableInteger(const AValue: Integer): string;
+begin
+  if AValue <= 0 then
+    Result := 'null'
+  else
+    Result := IntToStr(AValue);
+end;
+
+function SerializeNullableString(const AValue: string): string;
+begin
+  if AValue = '' then
+    Result := 'null'
+  else
+    Result := QuoteJSONString(AValue);
+end;
+
+function BuildTimingJSON(const ATiming: TScriptLoaderTiming): string;
+begin
+  Result :=
+    '"timing":{' +
+      '"lex_ms":' + NanosecondsToMillisecondsText(ATiming.LexTimeNanoseconds) + ',' +
+      '"parse_ms":' + NanosecondsToMillisecondsText(ATiming.ParseTimeNanoseconds) + ',' +
+      '"exec_ms":' + NanosecondsToMillisecondsText(ATiming.ExecuteTimeNanoseconds) + ',' +
+      '"total_ms":' + NanosecondsToMillisecondsText(ATiming.TotalTimeNanoseconds) +
+    '}';
+end;
+
+function DefaultScriptLoaderErrorInfo: TScriptLoaderErrorInfo;
+begin
+  Result.ErrorType := '';
+  Result.Message := '';
+  Result.FileName := '';
+  Result.Line := -1;
+  Result.Column := -1;
+end;
+
+function TryPopulateErrorInfoFromValue(const AValue: TGocciaValue;
+  var AErrorInfo: TScriptLoaderErrorInfo): Boolean;
+var
+  ErrorObject: TGocciaObjectValue;
+  NameValue, MessageValue: TGocciaValue;
+begin
+  Result := False;
+  if not (AValue is TGocciaObjectValue) then
+    Exit;
+
+  ErrorObject := TGocciaObjectValue(AValue);
+  NameValue := ErrorObject.GetProperty(PROP_NAME);
+  MessageValue := ErrorObject.GetProperty(PROP_MESSAGE);
+
+  if Assigned(NameValue) and not (NameValue is TGocciaUndefinedLiteralValue) then
+    AErrorInfo.ErrorType := NameValue.ToStringLiteral.Value;
+  if Assigned(MessageValue) and not (MessageValue is TGocciaUndefinedLiteralValue) then
+    AErrorInfo.Message := MessageValue.ToStringLiteral.Value;
+
+  Result := (AErrorInfo.ErrorType <> '') or (AErrorInfo.Message <> '');
+end;
+
+function ExceptionClassToErrorType(const E: Exception): string;
+begin
+  if E is TGocciaTypeError then
+    Result := 'TypeError'
+  else if E is TGocciaReferenceError then
+    Result := 'ReferenceError'
+  else if E is TGocciaSyntaxError then
+    Result := 'SyntaxError'
+  else if E is TGocciaRuntimeError then
+    Result := 'RuntimeError'
+  else if E is TGocciaLexerError then
+    Result := 'LexerError'
+  else
+    Result := E.ClassName;
+end;
+
+function ExceptionToScriptLoaderErrorInfo(const E: Exception): TScriptLoaderErrorInfo;
+var
+  GocciaError: TGocciaError;
+begin
+  Result := DefaultScriptLoaderErrorInfo;
+
+  if E is TGocciaThrowValue then
+  begin
+    if not TryPopulateErrorInfoFromValue(TGocciaThrowValue(E).Value, Result) then
+    begin
+      Result.ErrorType := 'Error';
+      Result.Message := TGocciaThrowValue(E).Value.ToStringLiteral.Value;
+    end;
+    Exit;
+  end;
+
+  if E is EGocciaBytecodeThrow then
+  begin
+    if not TryPopulateErrorInfoFromValue(EGocciaBytecodeThrow(E).ThrownValue, Result) then
+    begin
+      Result.ErrorType := 'Error';
+      Result.Message := EGocciaBytecodeThrow(E).Message;
+    end;
+    Exit;
+  end;
+
+  if E is TGocciaError then
+  begin
+    GocciaError := TGocciaError(E);
+    Result.ErrorType := ExceptionClassToErrorType(E);
+    Result.Message := E.Message;
+    Result.FileName := GocciaError.FileName;
+    Result.Line := GocciaError.Line;
+    Result.Column := GocciaError.Column;
+    Exit;
+  end;
+
+  Result.ErrorType := ExceptionClassToErrorType(E);
+  Result.Message := E.Message;
+end;
+
+function BuildSuccessJSON(const AValue: TGocciaValue; const AOutputText: string;
+  const ATiming: TScriptLoaderTiming): string;
+begin
+  Result :=
+    '{' +
+      '"ok":true,' +
+      '"value":' + SerializeScriptValue(AValue) + ',' +
+      '"output":' + QuoteJSONString(AOutputText) + ',' +
+      '"error":null,' +
+      BuildTimingJSON(ATiming) +
+    '}';
+end;
+
+function BuildErrorJSON(const AOutputText: string;
+  const AErrorInfo: TScriptLoaderErrorInfo;
+  const ATiming: TScriptLoaderTiming): string;
+begin
+  Result :=
+    '{' +
+      '"ok":false,' +
+      '"value":null,' +
+      '"output":' + QuoteJSONString(AOutputText) + ',' +
+      '"error":{' +
+        '"type":' + QuoteJSONString(AErrorInfo.ErrorType) + ',' +
+        '"message":' + QuoteJSONString(AErrorInfo.Message) + ',' +
+        '"line":' + SerializeNullableInteger(AErrorInfo.Line) + ',' +
+        '"column":' + SerializeNullableInteger(AErrorInfo.Column) + ',' +
+        '"fileName":' + SerializeNullableString(AErrorInfo.FileName) +
+      '},' +
+      BuildTimingJSON(ATiming) +
+    '}';
+end;
+
+end.


### PR DESCRIPTION
## Summary
- add  to ScriptLoader for structured success and error responses
- capture  output into the JSON payload, with  suppressing it
- keep stdout machine-readable by quieting startup logger noise and routing console output through the builtin console
- add native regression tests for JSON formatting and update user-facing docs

## Testing
- ./build.pas clean loader tests
- ./build/Goccia.ScriptLoader.JSON.Test
- printf 'console.log(hi);\n2 + 2;\n' | ./build/ScriptLoader --output=json
- printf 'console.log(hi);\nmissingValue;\n' | ./build/ScriptLoader --output=json
- printf 'console.log(hi);\n2 + 2;\n' | ./build/ScriptLoader --output=json --silent
- printf 'console.log(hi);\n2 + 2;\n' | ./build/ScriptLoader --output=json --mode=bytecode

Closes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ScriptLoader supports --output=json with structured JSON including timings, captured stdout, result or error details; --silent enables quiet runs
  * Console output can be suppressed or captured programmatically for JSON reporting

* **Documentation**
  * README and build-system docs updated with JSON usage examples and flag details; embedding docs note JSON support

* **Tests**
  * New unit tests validate JSON serialization and error-info conversion

* **CI**
  * CI now validates test/benchmark JSON outputs and discovers/runs Pascal unit tests dynamically
<!-- end of auto-generated comment: release notes by coderabbit.ai -->