### PR TITLE
Allow Windows CRLF in ScriptLoader CLI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,12 +388,12 @@ jobs:
           json_output="$(printf '%s\n' "console.log('hi');" '2 + 2;' | ./build/ScriptLoader --output=json)"
           printf '%s\n' "$json_output" | grep -q '"ok":true'
           printf '%s\n' "$json_output" | grep -q '"value":4'
-          printf '%s\n' "$json_output" | grep -q '"output":"hi\\n"'
+          printf '%s\n' "$json_output" | grep -Eq '"output":"hi(\\r)?\\n"'
 
           json_output_bytecode="$(printf '%s\n' "console.log('hi');" '2 + 2;' | ./build/ScriptLoader - --mode=bytecode --output=json)"
           printf '%s\n' "$json_output_bytecode" | grep -q '"ok":true'
           printf '%s\n' "$json_output_bytecode" | grep -q '"value":4'
-          printf '%s\n' "$json_output_bytecode" | grep -q '"output":"hi\\n"'
+          printf '%s\n' "$json_output_bytecode" | grep -Eq '"output":"hi(\\r)?\\n"'
 
           set +e
           error_output="$(printf '%s\n' "throw new TypeError('boom');" | ./build/ScriptLoader --output=json)"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -201,12 +201,12 @@ jobs:
           json_output="$(printf '%s\n' "console.log('hi');" '2 + 2;' | ./build/ScriptLoader --output=json)"
           printf '%s\n' "$json_output" | grep -q '"ok":true'
           printf '%s\n' "$json_output" | grep -q '"value":4'
-          printf '%s\n' "$json_output" | grep -q '"output":"hi\\n"'
+          printf '%s\n' "$json_output" | grep -Eq '"output":"hi(\\r)?\\n"'
 
           json_output_bytecode="$(printf '%s\n' "console.log('hi');" '2 + 2;' | ./build/ScriptLoader - --mode=bytecode --output=json)"
           printf '%s\n' "$json_output_bytecode" | grep -q '"ok":true'
           printf '%s\n' "$json_output_bytecode" | grep -q '"value":4'
-          printf '%s\n' "$json_output_bytecode" | grep -q '"output":"hi\\n"'
+          printf '%s\n' "$json_output_bytecode" | grep -Eq '"output":"hi(\\r)?\\n"'
 
           set +e
           error_output="$(printf '%s\n' "throw new TypeError('boom');" | ./build/ScriptLoader --output=json)"


### PR DESCRIPTION
## Summary
- make the ScriptLoader CLI behaviour checks accept both  and  in the JSON output field
- keep the existing command-level assertions otherwise unchanged
- apply the fix in both  and 

## Verification
- ./format.pas --check
- local ScriptLoader JSON output checks with the updated regex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability across Windows and Unix-like systems by updating workflow assertions to handle different line ending formats in test output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->