### PR TITLE
Expand JSON.stringify error coverage

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -139,7 +139,10 @@ All methods handle `NaN` and `Infinity` edge cases correctly.
 The JSON parser is a recursive descent implementation. Special handling:
 - `NaN` → `null` in stringify
 - `undefined` → omitted in objects, `null` in arrays
-- Functions → omitted
+- Functions → omitted in objects, `null` in arrays
+- Symbols → omitted in objects, `null` in arrays
+- `toJSON()` is called before serializing object values
+- Circular references throw `TypeError`
 
 ### Object (`Goccia.Builtins.GlobalObject.pas`)
 

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -121,3 +121,116 @@ test("JSON.stringify space is capped at 10", () => {
   const lines = result.split("\n");
   expect(lines.length).toBe(3);
 });
+
+test("JSON.stringify throws on circular references", () => {
+  const obj = {};
+  obj.self = obj;
+
+  const arr = [];
+  arr.push(arr);
+
+  const nested = { child: {} };
+  nested.child.parent = nested;
+
+  expect(() => JSON.stringify(obj)).toThrow(TypeError);
+  expect(() => JSON.stringify(arr)).toThrow(TypeError);
+  expect(() => JSON.stringify(nested)).toThrow(TypeError);
+});
+
+test("JSON.stringify calls toJSON during serialization", () => {
+  let rootKey = "unset";
+  let nestedKey = "unset";
+
+  const payload = {
+    value: 5,
+    nested: {
+      toJSON(key) {
+        nestedKey = key;
+        return { ok: true };
+      },
+    },
+    toJSON(key) {
+      rootKey = key;
+      return {
+        doubled: this.value * 2,
+        nested: this.nested,
+      };
+    },
+  };
+
+  const parsed = JSON.parse(JSON.stringify(payload));
+  expect(rootKey).toBe("");
+  expect(nestedKey).toBe("nested");
+  expect(parsed.doubled).toBe(10);
+  expect(parsed.nested.ok).toBeTruthy();
+});
+
+test("JSON.stringify propagates toJSON errors", () => {
+  const value = {
+    toJSON() {
+      throw new RangeError("bad toJSON");
+    },
+  };
+
+  expect(() => JSON.stringify(value)).toThrow(RangeError);
+});
+
+test("JSON.stringify propagates replacer errors", () => {
+  expect(() =>
+    JSON.stringify({ a: 1 }, () => {
+      throw new SyntaxError("bad replacer");
+    }),
+  ).toThrow(SyntaxError);
+});
+
+test("JSON.stringify ignores invalid replacer types", () => {
+  const obj = { a: 1, b: 2 };
+  const expected = '{"a":1,"b":2}';
+
+  expect(JSON.stringify(obj, 123)).toBe(expected);
+  expect(JSON.stringify(obj, "ignored")).toBe(expected);
+  expect(JSON.stringify(obj, { only: ["a"] })).toBe(expected);
+});
+
+test("JSON.stringify omits function values in objects and serializes them as null in arrays", () => {
+  const obj = { keep: 1, fn: () => 1 };
+  const arr = [1, () => 1, 3];
+
+  expect(JSON.stringify(obj)).toBe('{"keep":1}');
+  expect(JSON.stringify(arr)).toBe("[1,null,3]");
+});
+
+test("JSON.stringify omits symbol values in objects and serializes them as null in arrays", () => {
+  const sym = Symbol("x");
+
+  expect(JSON.stringify({ keep: 1, sym })).toBe('{"keep":1}');
+  expect(JSON.stringify([1, sym, 3])).toBe("[1,null,3]");
+});
+
+test("JSON.stringify handles deeply nested objects", () => {
+  const makeNested = (depth) =>
+    depth === 0 ? { leaf: true } : { child: makeNested(depth - 1) };
+  const countDepth = (node) => (node.leaf ? 0 : 1 + countDepth(node.child));
+
+  const parsed = JSON.parse(JSON.stringify(makeNested(25)));
+  expect(countDepth(parsed)).toBe(25);
+  expect(parsed.child.child.child.child.child).toBeTruthy();
+});
+
+test("JSON.stringify ignores invalid space parameters", () => {
+  const obj = { a: 1 };
+
+  expect(JSON.stringify(obj, null, {})).toBe('{"a":1}');
+  expect(JSON.stringify(obj, null, true)).toBe('{"a":1}');
+});
+
+test("JSON.stringify treats non-positive space as no indentation", () => {
+  const obj = { a: 1 };
+
+  expect(JSON.stringify(obj, null, 0)).toBe('{"a":1}');
+  expect(JSON.stringify(obj, null, -4)).toBe('{"a":1}');
+});
+
+test("JSON.stringify serializes sparse array holes as null", () => {
+  expect(JSON.stringify([1, , 3])).toBe("[1,null,3]");
+});

--- a/units/Goccia.Builtins.JSON.pas
+++ b/units/Goccia.Builtins.JSON.pas
@@ -5,6 +5,8 @@ unit Goccia.Builtins.JSON;
 interface
 
 uses
+  Generics.Collections,
+
   Goccia.Arguments.Collection,
   Goccia.Arguments.Validator,
   Goccia.Builtins.Base,
@@ -13,6 +15,7 @@ uses
   Goccia.ObjectModel,
   Goccia.Scope,
   Goccia.Values.ArrayValue,
+  Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
 type
@@ -21,9 +24,11 @@ type
     class var FStaticMembers: array of TGocciaMemberDefinition;
     FParser: TGocciaJSONParser;
     FStringifier: TGocciaJSONStringifier;
+    FReplacerTraversalStack: TList<TGocciaObjectValue>;
 
     function ApplyReviver(const AHolder: TGocciaValue; const AKey: string; const AReviver: TGocciaValue): TGocciaValue;
     function ApplyReplacer(const AHolder: TGocciaValue; const AKey: string; const AValue: TGocciaValue; const AReplacer: TGocciaValue): TGocciaValue;
+    function ApplyToJSON(const AValue: TGocciaValue; const AKey: string): TGocciaValue;
     function ResolveGap(const ASpaceArg: TGocciaValue): string;
     function TransformWithReplacer(const AHolder: TGocciaValue; const AKey: string; const AValue: TGocciaValue; const AReplacer: TGocciaValue): TGocciaValue;
     function StringifyWithReplacer(const AValue: TGocciaValue; const AReplacer: TGocciaValue; const AGap: string): string;
@@ -42,10 +47,11 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Constants.PropertyNames,
   Goccia.Utils,
+  Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
 
 constructor TGocciaJSONBuiltin.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
@@ -56,6 +62,7 @@ begin
 
   FParser := TGocciaJSONParser.Create;
   FStringifier := TGocciaJSONStringifier.Create;
+  FReplacerTraversalStack := TList<TGocciaObjectValue>.Create;
 
   Members := TGocciaMemberCollection.Create;
   try
@@ -78,6 +85,7 @@ destructor TGocciaJSONBuiltin.Destroy;
 begin
   FParser.Free;
   FStringifier.Free;
+  FReplacerTraversalStack.Free;
   inherited;
 end;
 
@@ -202,6 +210,29 @@ begin
   // Step 9: Else let gap be the empty string (already default).
 end;
 
+// ES2026 §25.5.2.2 SerializeJSONProperty ( state, key, holder ) step 1: toJSON hook.
+function TGocciaJSONBuiltin.ApplyToJSON(const AValue: TGocciaValue; const AKey: string): TGocciaValue;
+var
+  ToJSONMethod: TGocciaValue;
+  Args: TGocciaArgumentsCollection;
+begin
+  Result := AValue;
+  if not (AValue is TGocciaObjectValue) then
+    Exit;
+
+  ToJSONMethod := TGocciaObjectValue(AValue).GetProperty(PROP_TO_JSON);
+  if not Assigned(ToJSONMethod) or not ToJSONMethod.IsCallable then
+    Exit;
+
+  Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
+  try
+    Args.Add(TGocciaStringLiteralValue.Create(AKey));
+    Result := InvokeCallable(ToJSONMethod, Args, AValue);
+  finally
+    Args.Free;
+  end;
+end;
+
 // §25.5.2.1 SerializeJSONProperty — Step 2: Call replacer function.
 // Invokes the replacer with (key, value) bound to the holder object.
 function TGocciaJSONBuiltin.ApplyReplacer(const AHolder: TGocciaValue; const AKey: string; const AValue: TGocciaValue; const AReplacer: TGocciaValue): TGocciaValue;
@@ -227,45 +258,64 @@ var
   Key: string;
   I: Integer;
 begin
-  // Step 1: Call the replacer to get the transformed value.
-  Replaced := ApplyReplacer(AHolder, AKey, AValue, AReplacer);
+  // Step 1: Apply a toJSON hook before the replacer sees the value.
+  Replaced := ApplyToJSON(AValue, AKey);
 
-  // Step 2: If replacer returned undefined, signal omission.
+  // Step 2: Call the replacer to get the transformed value.
+  Replaced := ApplyReplacer(AHolder, AKey, Replaced, AReplacer);
+
+  // Step 3: If replacer returned undefined, signal omission.
   if Replaced is TGocciaUndefinedLiteralValue then
   begin
     Result := Replaced;
     Exit;
   end;
 
-  // Step 3: If result is an Array, recursively serialize each element (SerializeJSONArray).
+  // Step 4: If result is an Array, recursively serialize each element (SerializeJSONArray).
   if Replaced is TGocciaArrayValue then
   begin
+    if FReplacerTraversalStack.IndexOf(TGocciaArrayValue(Replaced)) <> -1 then
+      ThrowTypeError('Converting circular structure to JSON');
+
+    FReplacerTraversalStack.Add(TGocciaArrayValue(Replaced));
     Arr := TGocciaArrayValue(Replaced);
     NewArr := TGocciaArrayValue.Create;
-    for I := 0 to Arr.Elements.Count - 1 do
-    begin
-      PropValue := Arr.Elements[I];
-      TransformedProp := TransformWithReplacer(Arr, IntToStr(I), PropValue, AReplacer);
-      NewArr.Elements.Add(TransformedProp);
+    try
+      for I := 0 to Arr.Elements.Count - 1 do
+      begin
+        PropValue := Arr.Elements[I];
+        TransformedProp := TransformWithReplacer(Arr, IntToStr(I), PropValue, AReplacer);
+        NewArr.Elements.Add(TransformedProp);
+      end;
+    finally
+      FReplacerTraversalStack.Delete(FReplacerTraversalStack.Count - 1);
     end;
     Result := NewArr;
   end
-  // Step 4: If result is an Object, recursively serialize each property (SerializeJSONObject).
+  // Step 5: If result is an Object, recursively serialize each property (SerializeJSONObject).
   else if (Replaced is TGocciaObjectValue) and not (Replaced is TGocciaArrayValue) then
   begin
+    if FReplacerTraversalStack.IndexOf(TGocciaObjectValue(Replaced)) <> -1 then
+      ThrowTypeError('Converting circular structure to JSON');
+
+    FReplacerTraversalStack.Add(TGocciaObjectValue(Replaced));
     Obj := TGocciaObjectValue(Replaced);
     NewObj := TGocciaObjectValue.Create;
-    for Key in Obj.GetEnumerablePropertyNames do
-    begin
-      PropValue := Obj.GetProperty(Key);
-      TransformedProp := TransformWithReplacer(Obj, Key, PropValue, AReplacer);
-      // Omit properties whose replacer result is undefined.
-      if not (TransformedProp is TGocciaUndefinedLiteralValue) then
-        NewObj.AssignProperty(Key, TransformedProp);
+    try
+      for Key in Obj.GetEnumerablePropertyNames do
+      begin
+        PropValue := Obj.GetProperty(Key);
+        TransformedProp := TransformWithReplacer(Obj, Key, PropValue, AReplacer);
+        // Omit properties whose replacer result is undefined.
+        if not (TransformedProp is TGocciaUndefinedLiteralValue) then
+          NewObj.AssignProperty(Key, TransformedProp);
+      end;
+    finally
+      FReplacerTraversalStack.Delete(FReplacerTraversalStack.Count - 1);
     end;
     Result := NewObj;
   end
-  // Step 5: Primitive values pass through directly.
+  // Step 6: Primitive values pass through directly.
   else
     Result := Replaced;
 end;
@@ -282,6 +332,7 @@ begin
   // Step 11: Perform ! CreateDataPropertyOrThrow(wrapper, "", value).
   Root.AssignProperty('', AValue);
   // Step 12: Return ? SerializeJSONProperty(state, "", wrapper).
+  FReplacerTraversalStack.Clear;
   Transformed := TransformWithReplacer(Root, '', AValue, AReplacer);
 
   if Transformed is TGocciaUndefinedLiteralValue then
@@ -374,6 +425,8 @@ begin
     // Step 10-12: Create wrapper, set wrapper[""] = value, return SerializeJSONProperty(state, "", wrapper).
     Result := TGocciaStringLiteralValue.Create(FStringifier.Stringify(Value, Gap));
   except
+    on E: TGocciaThrowValue do
+      raise;
     on E: Exception do
       ThrowError('JSON.stringify error: ' + E.Message, 0, 0);
   end;

--- a/units/Goccia.JSON.pas
+++ b/units/Goccia.JSON.pas
@@ -5,6 +5,7 @@ unit Goccia.JSON;
 interface
 
 uses
+  Generics.Collections,
   SysUtils,
 
   Goccia.Values.ArrayValue,
@@ -22,7 +23,11 @@ type
   TGocciaJSONStringifier = class
   private
     FGap: string;
-    function StringifyValue(const AValue: TGocciaValue; const AIndent: Integer = 0): string;
+    FTraversalStack: TList<TGocciaObjectValue>;
+    function ApplyToJSON(const AValue: TGocciaValue; const AKey: string): TGocciaValue;
+    function ShouldOmitObjectProperty(const AValue: TGocciaValue): Boolean;
+    function StringifyPreparedValue(const AValue: TGocciaValue; const AIndent: Integer = 0): string;
+    function StringifyValue(const AValue: TGocciaValue; const AIndent: Integer = 0; const AKey: string = ''): string;
     function StringifyObject(const AObj: TGocciaObjectValue; const AIndent: Integer): string;
     function StringifyArray(const AArr: TGocciaArrayValue; const AIndent: Integer): string;
     function EscapeString(const AStr: string): string;
@@ -35,12 +40,17 @@ implementation
 
 uses
   Classes,
-  Generics.Collections,
 
   JSONParser,
   StringBuffer,
 
-  Goccia.Values.FunctionValue;
+  Goccia.Arguments.Collection,
+  Goccia.Constants.PropertyNames,
+  Goccia.Utils,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionValue,
+  Goccia.Values.HoleValue,
+  Goccia.Values.SymbolValue;
 
 type
   TGocciaJSONVisitor = class(TAbstractJSONParser)
@@ -195,7 +205,13 @@ end;
 function TGocciaJSONStringifier.Stringify(const AValue: TGocciaValue; const AGap: string): string;
 begin
   FGap := AGap;
-  Result := StringifyValue(AValue);
+  FTraversalStack := TList<TGocciaObjectValue>.Create;
+  try
+    Result := StringifyValue(AValue);
+  finally
+    FTraversalStack.Free;
+    FTraversalStack := nil;
+  end;
 end;
 
 function TGocciaJSONStringifier.MakeIndent(const ALevel: Integer): string;
@@ -209,11 +225,50 @@ begin
     Result := Result + FGap;
 end;
 
-function TGocciaJSONStringifier.StringifyValue(const AValue: TGocciaValue; const AIndent: Integer): string;
+// ES2026 §25.5.2.2 SerializeJSONProperty ( state, key, holder )
+function TGocciaJSONStringifier.ApplyToJSON(const AValue: TGocciaValue; const AKey: string): TGocciaValue;
+var
+  ToJSONMethod: TGocciaValue;
+  Args: TGocciaArgumentsCollection;
+begin
+  Result := AValue;
+  if not (AValue is TGocciaObjectValue) then
+    Exit;
+
+  ToJSONMethod := TGocciaObjectValue(AValue).GetProperty(PROP_TO_JSON);
+  if not Assigned(ToJSONMethod) or not ToJSONMethod.IsCallable then
+    Exit;
+
+  Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
+  try
+    Args.Add(TGocciaStringLiteralValue.Create(AKey));
+    Result := InvokeCallable(ToJSONMethod, Args, AValue);
+  finally
+    Args.Free;
+  end;
+end;
+
+function TGocciaJSONStringifier.ShouldOmitObjectProperty(const AValue: TGocciaValue): Boolean;
+begin
+  Result := (AValue is TGocciaUndefinedLiteralValue) or
+            AValue.IsCallable or
+            (AValue is TGocciaSymbolValue);
+end;
+
+function TGocciaJSONStringifier.StringifyValue(const AValue: TGocciaValue;
+  const AIndent: Integer; const AKey: string): string;
+begin
+  Result := StringifyPreparedValue(ApplyToJSON(AValue, AKey), AIndent);
+end;
+
+function TGocciaJSONStringifier.StringifyPreparedValue(const AValue: TGocciaValue;
+  const AIndent: Integer): string;
 begin
   if AValue is TGocciaNullLiteralValue then
     Result := 'null'
   else if AValue is TGocciaUndefinedLiteralValue then
+    Result := 'null'
+  else if AValue is TGocciaHoleValue then
     Result := 'null'
   else if AValue is TGocciaBooleanLiteralValue then
   begin
@@ -233,6 +288,10 @@ begin
   end
   else if AValue is TGocciaStringLiteralValue then
     Result := '"' + EscapeString(AValue.ToStringLiteral.Value) + '"'
+  else if AValue.IsCallable then
+    Result := 'null'
+  else if AValue is TGocciaSymbolValue then
+    Result := 'null'
   else if AValue is TGocciaArrayValue then
     Result := StringifyArray(TGocciaArrayValue(AValue), AIndent)
   else if AValue is TGocciaObjectValue then
@@ -249,29 +308,33 @@ var
   HasProperties: Boolean;
   Separator, ChildIndent, CloseIndent: string;
 begin
+  if FTraversalStack.IndexOf(AObj) <> -1 then
+    ThrowTypeError('Converting circular structure to JSON');
+
+  FTraversalStack.Add(AObj);
   SB := TStringBuffer.Create;
-  HasProperties := False;
+  try
+    HasProperties := False;
 
-  if FGap <> '' then
-  begin
-    Separator := ',' + #10;
-    ChildIndent := MakeIndent(AIndent + 1);
-    CloseIndent := MakeIndent(AIndent);
-  end
-  else
-  begin
-    Separator := ',';
-    ChildIndent := '';
-    CloseIndent := '';
-  end;
-
-  for Key in AObj.GetEnumerablePropertyNames do
-  begin
-    Value := AObj.GetProperty(Key);
-
-    if not (Value is TGocciaUndefinedLiteralValue) and
-       not (Value is TGocciaFunctionValue) then
+    if FGap <> '' then
     begin
+      Separator := ',' + #10;
+      ChildIndent := MakeIndent(AIndent + 1);
+      CloseIndent := MakeIndent(AIndent);
+    end
+    else
+    begin
+      Separator := ',';
+      ChildIndent := '';
+      CloseIndent := '';
+    end;
+
+    for Key in AObj.GetEnumerablePropertyNames do
+    begin
+      Value := ApplyToJSON(AObj.GetProperty(Key), Key);
+      if ShouldOmitObjectProperty(Value) then
+        Continue;
+
       if HasProperties then
         SB.Append(Separator);
       SB.Append(ChildIndent);
@@ -280,56 +343,69 @@ begin
       SB.Append('":');
       if FGap <> '' then
         SB.AppendChar(' ');
-      SB.Append(StringifyValue(Value, AIndent + 1));
+      SB.Append(StringifyPreparedValue(Value, AIndent + 1));
       HasProperties := True;
     end;
-  end;
 
-  if not HasProperties then
-    Result := '{}'
-  else if FGap <> '' then
-    Result := '{' + #10 + SB.ToString + #10 + CloseIndent + '}'
-  else
-    Result := '{' + SB.ToString + '}';
+    if not HasProperties then
+      Result := '{}'
+    else if FGap <> '' then
+      Result := '{' + #10 + SB.ToString + #10 + CloseIndent + '}'
+    else
+      Result := '{' + SB.ToString + '}';
+  finally
+    FTraversalStack.Delete(FTraversalStack.Count - 1);
+  end;
 end;
 
 function TGocciaJSONStringifier.StringifyArray(const AArr: TGocciaArrayValue; const AIndent: Integer): string;
 var
   SB: TStringBuffer;
   I: Integer;
+  Value: TGocciaValue;
   Separator, ChildIndent, CloseIndent: string;
 begin
+  if FTraversalStack.IndexOf(AArr) <> -1 then
+    ThrowTypeError('Converting circular structure to JSON');
+
+  FTraversalStack.Add(AArr);
   if AArr.Elements.Count = 0 then
   begin
     Result := '[]';
+    FTraversalStack.Delete(FTraversalStack.Count - 1);
     Exit;
   end;
 
-  if FGap <> '' then
-  begin
-    Separator := ',' + #10;
-    ChildIndent := MakeIndent(AIndent + 1);
-    CloseIndent := MakeIndent(AIndent);
-  end
-  else
-  begin
-    Separator := ',';
-    ChildIndent := '';
-    CloseIndent := '';
-  end;
+  try
+    if FGap <> '' then
+    begin
+      Separator := ',' + #10;
+      ChildIndent := MakeIndent(AIndent + 1);
+      CloseIndent := MakeIndent(AIndent);
+    end
+    else
+    begin
+      Separator := ',';
+      ChildIndent := '';
+      CloseIndent := '';
+    end;
 
-  SB := TStringBuffer.Create;
-  for I := 0 to AArr.Elements.Count - 1 do
-  begin
-    if I > 0 then
-      SB.Append(Separator);
-    SB.Append(ChildIndent);
-    SB.Append(StringifyValue(AArr.Elements[I], AIndent + 1));
+    SB := TStringBuffer.Create;
+    for I := 0 to AArr.Elements.Count - 1 do
+    begin
+      if I > 0 then
+        SB.Append(Separator);
+      SB.Append(ChildIndent);
+      Value := ApplyToJSON(AArr.Elements[I], IntToStr(I));
+      SB.Append(StringifyPreparedValue(Value, AIndent + 1));
+    end;
+    if FGap <> '' then
+      Result := '[' + #10 + SB.ToString + #10 + CloseIndent + ']'
+    else
+      Result := '[' + SB.ToString + ']';
+  finally
+    FTraversalStack.Delete(FTraversalStack.Count - 1);
   end;
-  if FGap <> '' then
-    Result := '[' + #10 + SB.ToString + #10 + CloseIndent + ']'
-  else
-    Result := '[' + SB.ToString + ']';
 end;
 
 function TGocciaJSONStringifier.EscapeString(const AStr: string): string;


### PR DESCRIPTION
## Summary
- expand `JSON.stringify` coverage for circular references, `toJSON`, thrown errors, invalid replacers/space, symbols, functions, deep nesting, and sparse arrays
- align the runtime JSON serializer with the new edge-case expectations, including cycle detection and `toJSON()` handling
- document the supported `JSON.stringify` special cases in `docs/built-ins.md`

## Testing
- `./build.pas clean loader`
- `./build.pas testrunner`
- `./build/TestRunner tests/built-ins/JSON/stringify.js --no-progress`
- `./build/TestRunner tests --no-progress`

Closes #122.
