### PR TITLE
Add nullish coalescing assignment operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It's based on the thought "What if we implement ECMAScript today, but without th
 | Object shorthand properties and methods | `{ x, y, method() {} }` |
 | Computed property names | `{ [expr]: value }` |
 | Nullish coalescing | `a ?? b` |
+| Nullish coalescing assignment | `a ??= b` |
 | Optional chaining | `obj?.prop?.method?.()` |
 | Arrow functions | `(x) => x + 1` |
 | Rest parameters | `(...args) => args` |

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -401,7 +401,7 @@ The trade-off is that arithmetic fast paths need to be built on top of shared Go
 
 Language features are compiled into compact bytecode instruction sequences rather than expanding the opcode surface unnecessarily:
 
-- **Nullish coalescing (`??`)** — The compiler emits `OP_JUMP_IF_NOT_NULLISH` in its nullish-match mode, so `undefined`, `null`, and internal hole values all follow the same short-circuit path without extra comparison instructions.
+- **Nullish coalescing (`??`) and nullish coalescing assignment (`??=`)** — The compiler emits `OP_JUMP_IF_NOT_NULLISH` in its nullish-match mode, so `undefined`, `null`, and internal hole values all follow the same short-circuit path without extra comparison instructions.
 - **Template literals** — The compiler parses interpolations at compile time, emits string constants and `OP_TO_STRING` for expression parts, then chains `OP_CONCAT` instructions.
 - **Object spread** — The compiler emits dedicated Goccia bytecode rather than routing through a generic extension dispatcher.
 

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -145,6 +145,7 @@ C[Symbol.metadata].decorated; // true
 - All comparison operators (`===`, `!==`, `<`, `>`, `<=`, `>=`).
 - Logical operators (`&&`, `||`, `!`).
 - Nullish coalescing (`??`).
+- Nullish coalescing assignment (`??=`).
 - Optional chaining (`?.` for property access, computed access, and method calls).
 - Bitwise operators (`&`, `|`, `^`, `<<`, `>>`, `>>>`).
 - Ternary operator (`? :`).

--- a/tests/language/expressions/nullish-coalescing/assignment.js
+++ b/tests/language/expressions/nullish-coalescing/assignment.js
@@ -86,3 +86,43 @@ test("nullish coalescing assignment only throws for const bindings when an assig
     missing ??= 2;
   }).toThrow(TypeError);
 });
+
+test("nullish coalescing assignment throws for unresolved identifiers", () => {
+  expect(() => {
+    missingValue ??= 1;
+  }).toThrow(ReferenceError);
+});
+
+test("nullish coalescing assignment uses private accessors for the nullish check", () => {
+  class AccessorBox {
+    #storage = 10;
+
+    get #value() {
+      if (this.#storage === 10) {
+        return null;
+      }
+      return this.#storage;
+    }
+
+    set #value(value) {
+      this.#storage = value;
+    }
+
+    initialize(value) {
+      return this.#value ??= value;
+    }
+
+    read() {
+      return this.#storage;
+    }
+  }
+
+  const first = new AccessorBox();
+  expect(first.initialize(6)).toBe(6);
+  expect(first.read()).toBe(6);
+
+  const second = new AccessorBox();
+  second.initialize(4);
+  expect(second.initialize(9)).toBe(4);
+  expect(second.read()).toBe(4);
+});

--- a/tests/language/expressions/nullish-coalescing/assignment.js
+++ b/tests/language/expressions/nullish-coalescing/assignment.js
@@ -1,0 +1,88 @@
+/*---
+description: Nullish coalescing assignment operator (??=) assigns only for null and undefined
+features: [nullish-coalescing-assignment]
+---*/
+
+test("nullish coalescing assignment works for identifiers", () => {
+  let missing = undefined;
+  expect(missing ??= 5).toBe(5);
+  expect(missing).toBe(5);
+
+  let empty = null;
+  expect(empty ??= 7).toBe(7);
+  expect(empty).toBe(7);
+
+  let zero = 0;
+  expect(zero ??= 9).toBe(0);
+  expect(zero).toBe(0);
+});
+
+test("nullish coalescing assignment short-circuits the right-hand side", () => {
+  let calls = 0;
+  const compute = () => {
+    calls += 1;
+    return 11;
+  };
+
+  let present = "value";
+  expect(present ??= compute()).toBe("value");
+  expect(calls).toBe(0);
+
+  let absent = undefined;
+  expect(absent ??= compute()).toBe(11);
+  expect(calls).toBe(1);
+});
+
+test("nullish coalescing assignment works for properties", () => {
+  const obj = { present: false };
+
+  expect(obj.present ??= true).toBe(false);
+  expect(obj.present).toBe(false);
+
+  expect(obj.missing ??= 3).toBe(3);
+  expect(obj.missing).toBe(3);
+});
+
+test("nullish coalescing assignment works for computed properties and evaluates the key once", () => {
+  const obj = {};
+  let keyCalls = 0;
+  const key = () => {
+    keyCalls += 1;
+    return "dynamic";
+  };
+
+  expect(obj[key()] ??= 9).toBe(9);
+  expect(obj.dynamic).toBe(9);
+  expect(keyCalls).toBe(1);
+});
+
+test("nullish coalescing assignment works for private fields", () => {
+  class Counter {
+    #value;
+
+    read() {
+      return this.#value;
+    }
+
+    initialize(value) {
+      return this.#value ??= value;
+    }
+  }
+
+  const counter = new Counter();
+
+  expect(counter.initialize(4)).toBe(4);
+  expect(counter.read()).toBe(4);
+  expect(counter.initialize(8)).toBe(4);
+  expect(counter.read()).toBe(4);
+});
+
+test("nullish coalescing assignment only throws for const bindings when an assignment is needed", () => {
+  const keep = 1;
+  expect(keep ??= 2).toBe(1);
+
+  const missing = null;
+  expect(() => {
+    missing ??= 2;
+  }).toThrow(TypeError);
+});

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -546,6 +546,21 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
 
+function IsNullishAssignmentValue(const AValue: TGocciaValue): Boolean; inline;
+begin
+  Result := not Assigned(AValue) or
+            (AValue is TGocciaUndefinedLiteralValue) or
+            (AValue is TGocciaNullLiteralValue);
+end;
+
+function NormalizeAssignmentValue(const AValue: TGocciaValue): TGocciaValue; inline;
+begin
+  if Assigned(AValue) then
+    Result := AValue
+  else
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
 { TGocciaLiteralExpression }
 
 constructor TGocciaLiteralExpression.Create(const AValue: TGocciaValue;
@@ -1079,52 +1094,106 @@ begin
   end;
 end;
 
+// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
 function TGocciaCompoundAssignmentExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
-  RhsValue: TGocciaValue;
+  CurrentValue, RhsValue: TGocciaValue;
 begin
-  Result := AContext.Scope.GetValue(Name);
+  CurrentValue := AContext.Scope.GetValue(Name);
+  if Operator = gttNullishCoalescingAssign then
+  begin
+    if not IsNullishAssignmentValue(CurrentValue) then
+      Exit(CurrentValue);
+
+    Result := Value.Evaluate(AContext);
+    AContext.Scope.AssignLexicalBinding(Name, Result);
+    Exit;
+  end;
+
+  Result := CurrentValue;
   RhsValue := Value.Evaluate(AContext);
   Result := PerformCompoundOperation(Result, RhsValue, Operator);
   AContext.Scope.AssignLexicalBinding(Name, Result);
 end;
 
+// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
 function TGocciaPropertyCompoundAssignmentExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
-  Obj, RhsValue: TGocciaValue;
+  Obj, CurrentValue, RhsValue: TGocciaValue;
 begin
   Obj := ObjectExpr.Evaluate(AContext);
+  CurrentValue := NormalizeAssignmentValue(Obj.GetProperty(PropertyName));
+  if Operator = gttNullishCoalescingAssign then
+  begin
+    if not IsNullishAssignmentValue(CurrentValue) then
+      Exit(CurrentValue);
+
+    Result := Value.Evaluate(AContext);
+    AssignProperty(Obj, PropertyName, Result, AContext.OnError, Line, Column);
+    Exit;
+  end;
+
   RhsValue := Value.Evaluate(AContext);
   PerformPropertyCompoundAssignment(Obj, PropertyName, RhsValue, Operator, AContext.OnError, Line, Column);
-  Result := Obj.GetProperty(PropertyName);
-  if Result = nil then
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Result := NormalizeAssignmentValue(Obj.GetProperty(PropertyName));
 end;
 
+// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
 function TGocciaComputedPropertyCompoundAssignmentExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
-  Obj, PropertyKeyValue, RhsValue: TGocciaValue;
+  Obj, PropertyKeyValue, CurrentValue, RhsValue: TGocciaValue;
   PropName: string;
 begin
   Obj := ObjectExpr.Evaluate(AContext);
   PropertyKeyValue := PropertyExpression.Evaluate(AContext);
-  RhsValue := Value.Evaluate(AContext);
   if (PropertyKeyValue is TGocciaSymbolValue) and ((Obj is TGocciaClassValue) or (Obj is TGocciaObjectValue)) then
   begin
+    if Obj is TGocciaClassValue then
+      CurrentValue := NormalizeAssignmentValue(
+        TGocciaClassValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue)))
+    else
+      CurrentValue := NormalizeAssignmentValue(
+        TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue)));
+
+    if Operator = gttNullishCoalescingAssign then
+    begin
+      if not IsNullishAssignmentValue(CurrentValue) then
+        Exit(CurrentValue);
+
+      Result := Value.Evaluate(AContext);
+      if Obj is TGocciaClassValue then
+        TGocciaClassValue(Obj).AssignSymbolProperty(TGocciaSymbolValue(PropertyKeyValue), Result)
+      else
+        TGocciaObjectValue(Obj).AssignSymbolProperty(TGocciaSymbolValue(PropertyKeyValue), Result);
+      Exit;
+    end;
+
+    RhsValue := Value.Evaluate(AContext);
     PerformSymbolPropertyCompoundAssignment(Obj, TGocciaSymbolValue(PropertyKeyValue), RhsValue, Operator, AContext.OnError, Line, Column);
     if Obj is TGocciaClassValue then
-      Result := TGocciaClassValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue))
+      Result := NormalizeAssignmentValue(
+        TGocciaClassValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue)))
     else
-      Result := TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue));
-  end
-  else
-  begin
-    PropName := PropertyKeyValue.ToStringLiteral.Value;
-    PerformPropertyCompoundAssignment(Obj, PropName, RhsValue, Operator, AContext.OnError, Line, Column);
-    Result := Obj.GetProperty(PropName);
+      Result := NormalizeAssignmentValue(
+        TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue)));
+    Exit;
   end;
-  if Result = nil then
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  PropName := PropertyKeyValue.ToStringLiteral.Value;
+  CurrentValue := NormalizeAssignmentValue(Obj.GetProperty(PropName));
+  if Operator = gttNullishCoalescingAssign then
+  begin
+    if not IsNullishAssignmentValue(CurrentValue) then
+      Exit(CurrentValue);
+
+    Result := Value.Evaluate(AContext);
+    AssignProperty(Obj, PropName, Result, AContext.OnError, Line, Column);
+    Exit;
+  end;
+
+  RhsValue := Value.Evaluate(AContext);
+  PerformPropertyCompoundAssignment(Obj, PropName, RhsValue, Operator, AContext.OnError, Line, Column);
+  Result := NormalizeAssignmentValue(Obj.GetProperty(PropName));
 end;
 
 function TGocciaIncrementExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -1803,12 +1803,12 @@ procedure CompileCompoundAssignment(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaCompoundAssignmentExpression; const ADest: UInt8);
 var
   LocalIdx, UpvalIdx: Integer;
-  Slot, RegVal, RegResult: UInt8;
-  MsgIdx: UInt16;
+  Slot, RegVal, RegResult, CondReg, ArgReg: UInt8;
+  MsgIdx, NameIdx: UInt16;
   Op, FloatOp: TGocciaOpCode;
   LocalType, ValType: TGocciaLocalType;
   ArithOp: TGocciaTokenType;
-  JumpIdx: Integer;
+  JumpIdx, OkJump: Integer;
 begin
   // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
   if AExpr.Operator = gttNullishCoalescingAssign then
@@ -1894,12 +1894,25 @@ begin
       Exit;
     end;
 
-    EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, ADest,
-      ACtx.Template.AddConstantString(AExpr.Name)));
+    NameIdx := ACtx.Template.AddConstantString(AExpr.Name);
+    CondReg := ACtx.Scope.AllocateRegister;
+    ArgReg := ACtx.Scope.AllocateRegister;
+    EmitInstruction(ACtx, EncodeABx(OP_HAS_GLOBAL, CondReg, NameIdx));
+    OkJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, CondReg);
+    EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, CondReg,
+      ACtx.Template.AddConstantString(REFERENCE_ERROR_NAME)));
+    EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, ArgReg,
+      ACtx.Template.AddConstantString(AExpr.Name + ' is not defined')));
+    EmitInstruction(ACtx, EncodeABC(OP_CONSTRUCT, CondReg, CondReg, 1));
+    EmitInstruction(ACtx, EncodeABC(OP_THROW, CondReg, 0, 0));
+    PatchJumpTarget(ACtx, OkJump);
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+
+    EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, ADest, NameIdx));
     JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
     ACtx.CompileExpression(AExpr.Value, ADest);
-    EmitInstruction(ACtx, EncodeABx(OP_SET_GLOBAL, ADest,
-      ACtx.Template.AddConstantString(AExpr.Name)));
+    EmitInstruction(ACtx, EncodeABx(OP_SET_GLOBAL, ADest, NameIdx));
     PatchJumpTarget(ACtx, JumpIdx);
     Exit;
   end;

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -1808,7 +1808,102 @@ var
   Op, FloatOp: TGocciaOpCode;
   LocalType, ValType: TGocciaLocalType;
   ArithOp: TGocciaTokenType;
+  JumpIdx: Integer;
 begin
+  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
+  if AExpr.Operator = gttNullishCoalescingAssign then
+  begin
+    LocalIdx := ACtx.Scope.ResolveLocal(AExpr.Name);
+    if LocalIdx >= 0 then
+    begin
+      if ACtx.Scope.GetLocal(LocalIdx).IsGlobalBacked then
+      begin
+        EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, ADest,
+          ACtx.Template.AddConstantString(AExpr.Name)));
+        JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
+        if ACtx.Scope.GetLocal(LocalIdx).IsConst then
+        begin
+          MsgIdx := ACtx.Template.AddConstantString(
+            'Assignment to constant variable.');
+          if MsgIdx > High(UInt8) then
+            raise Exception.Create('Constant pool overflow: error message index exceeds 255');
+          EmitInstruction(ACtx, EncodeABC(OP_THROW_TYPE_ERROR_CONST, 0, 0, UInt8(MsgIdx)));
+        end
+        else
+        begin
+          ACtx.CompileExpression(AExpr.Value, ADest);
+          EmitInstruction(ACtx, EncodeABx(OP_SET_GLOBAL, ADest,
+            ACtx.Template.AddConstantString(AExpr.Name)));
+        end;
+        PatchJumpTarget(ACtx, JumpIdx);
+        Exit;
+      end;
+
+      Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
+      if ADest <> Slot then
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));
+      JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
+      if ACtx.Scope.GetLocal(LocalIdx).IsConst then
+      begin
+        MsgIdx := ACtx.Template.AddConstantString(
+          'Assignment to constant variable.');
+        if MsgIdx > High(UInt8) then
+          raise Exception.Create('Constant pool overflow: error message index exceeds 255');
+        EmitInstruction(ACtx, EncodeABC(OP_THROW_TYPE_ERROR_CONST, 0, 0, UInt8(MsgIdx)));
+      end
+      else
+      begin
+        ACtx.CompileExpression(AExpr.Value, ADest);
+        LocalType := ACtx.Scope.GetLocal(LocalIdx).TypeHint;
+        if ACtx.Scope.GetLocal(LocalIdx).IsStrictlyTyped and
+           (LocalType <> sltUntyped) and
+           not TypesAreCompatible(InferLocalType(AExpr.Value), LocalType) then
+          EmitInstruction(ACtx, EncodeABC(OP_CHECK_TYPE, ADest,
+            UInt8(Ord(LocalType)), 0));
+        if ADest <> Slot then
+          EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, ADest, Slot));
+      end;
+      PatchJumpTarget(ACtx, JumpIdx);
+      Exit;
+    end;
+
+    UpvalIdx := ACtx.Scope.ResolveUpvalue(AExpr.Name);
+    if UpvalIdx >= 0 then
+    begin
+      EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, ADest, UInt16(UpvalIdx)));
+      JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
+      if ACtx.Scope.GetUpvalue(UpvalIdx).IsConst then
+      begin
+        MsgIdx := ACtx.Template.AddConstantString(
+          'Assignment to constant variable.');
+        if MsgIdx > High(UInt8) then
+          raise Exception.Create('Constant pool overflow: error message index exceeds 255');
+        EmitInstruction(ACtx, EncodeABC(OP_THROW_TYPE_ERROR_CONST, 0, 0, UInt8(MsgIdx)));
+      end
+      else
+      begin
+        ACtx.CompileExpression(AExpr.Value, ADest);
+        if ACtx.Scope.GetUpvalue(UpvalIdx).IsStrictlyTyped and
+           not TypesAreCompatible(InferLocalType(AExpr.Value),
+             ACtx.Scope.GetUpvalue(UpvalIdx).TypeHint) then
+          EmitInstruction(ACtx, EncodeABC(OP_CHECK_TYPE, ADest,
+            UInt8(Ord(ACtx.Scope.GetUpvalue(UpvalIdx).TypeHint)), 0));
+        EmitInstruction(ACtx, EncodeABx(OP_SET_UPVALUE, ADest, UInt16(UpvalIdx)));
+      end;
+      PatchJumpTarget(ACtx, JumpIdx);
+      Exit;
+    end;
+
+    EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, ADest,
+      ACtx.Template.AddConstantString(AExpr.Name)));
+    JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
+    ACtx.CompileExpression(AExpr.Value, ADest);
+    EmitInstruction(ACtx, EncodeABx(OP_SET_GLOBAL, ADest,
+      ACtx.Template.AddConstantString(AExpr.Name)));
+    PatchJumpTarget(ACtx, JumpIdx);
+    Exit;
+  end;
+
   Op := CompoundOpToRuntimeOp(AExpr.Operator);
 
   LocalIdx := ACtx.Scope.ResolveLocal(AExpr.Name);
@@ -1890,7 +1985,34 @@ var
   ObjReg, CurReg, ValReg: UInt8;
   Op: TGocciaOpCode;
   PropIdx: UInt16;
+  JumpIdx: Integer;
 begin
+  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
+  if AExpr.Operator = gttNullishCoalescingAssign then
+  begin
+    ObjReg := ACtx.Scope.AllocateRegister;
+    CurReg := ACtx.Scope.AllocateRegister;
+
+    ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
+    PropIdx := ACtx.Template.AddConstantString(AExpr.PropertyName);
+    if PropIdx > High(UInt8) then
+      raise Exception.Create('Constant pool overflow: property name index exceeds 255');
+    EmitInstruction(ACtx, EncodeABC(OP_GET_PROP_CONST, CurReg, ObjReg,
+      UInt8(PropIdx)));
+    JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, CurReg);
+    ACtx.CompileExpression(AExpr.Value, CurReg);
+    EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ObjReg, UInt8(PropIdx),
+      CurReg));
+    PatchJumpTarget(ACtx, JumpIdx);
+
+    if ADest <> CurReg then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   Op := CompoundOpToRuntimeOp(AExpr.Operator);
   ObjReg := ACtx.Scope.AllocateRegister;
   CurReg := ACtx.Scope.AllocateRegister;
@@ -1922,7 +2044,32 @@ procedure CompileComputedPropertyCompoundAssignment(
 var
   ObjReg, KeyReg, CurReg, ValReg: UInt8;
   Op: TGocciaOpCode;
+  JumpIdx: Integer;
 begin
+  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
+  if AExpr.Operator = gttNullishCoalescingAssign then
+  begin
+    ObjReg := ACtx.Scope.AllocateRegister;
+    KeyReg := ACtx.Scope.AllocateRegister;
+    CurReg := ACtx.Scope.AllocateRegister;
+
+    ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
+    ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
+    EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
+    JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, CurReg);
+    ACtx.CompileExpression(AExpr.Value, CurReg);
+    EmitInstruction(ACtx, EncodeABC(OP_ARRAY_SET, ObjReg, KeyReg, CurReg));
+    PatchJumpTarget(ACtx, JumpIdx);
+
+    if ADest <> CurReg then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   Op := CompoundOpToRuntimeOp(AExpr.Operator);
   ObjReg := ACtx.Scope.AllocateRegister;
   KeyReg := ACtx.Scope.AllocateRegister;
@@ -2162,7 +2309,30 @@ var
   ObjReg, CurReg, ValReg: UInt8;
   Op: TGocciaOpCode;
   PropIdx: UInt16;
+  JumpIdx: Integer;
 begin
+  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
+  if AExpr.Operator = gttNullishCoalescingAssign then
+  begin
+    ObjReg := ACtx.Scope.AllocateRegister;
+    CurReg := ACtx.Scope.AllocateRegister;
+    ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
+    PropIdx := ACtx.Template.AddConstantString(
+      PrivateKey(ACtx.Scope, AExpr.PrivateName));
+    if PropIdx > High(UInt8) then
+      raise Exception.Create('Constant pool overflow: private property name index exceeds 255');
+    EmitInstruction(ACtx, EncodeABC(OP_GET_PROP_CONST, CurReg, ObjReg, UInt8(PropIdx)));
+    JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, CurReg);
+    ACtx.CompileExpression(AExpr.Value, CurReg);
+    EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ObjReg, UInt8(PropIdx), CurReg));
+    PatchJumpTarget(ACtx, JumpIdx);
+    if ADest <> CurReg then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   Op := CompoundOpToRuntimeOp(AExpr.Operator);
   ObjReg := ACtx.Scope.AllocateRegister;
   CurReg := ACtx.Scope.AllocateRegister;

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -2411,20 +2411,20 @@ begin
   Result := Value;
 end;
 
+// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
 function EvaluatePrivatePropertyCompoundAssignment(const APrivatePropertyCompoundAssignmentExpression: TGocciaPrivatePropertyCompoundAssignmentExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   ObjectValue: TGocciaValue;
   Instance: TGocciaInstanceValue;
   ClassValue: TGocciaClassValue;
   AccessClass: TGocciaClassValue;
-  Value: TGocciaValue;
   CurrentValue: TGocciaValue;
+  Value: TGocciaValue;
+  SetterFn: TGocciaFunctionBase;
+  SetterArgs: TGocciaArgumentsCollection;
 begin
   // Evaluate the object expression
   ObjectValue := EvaluateExpression(APrivatePropertyCompoundAssignmentExpression.ObjectExpr, AContext);
-
-  // Evaluate the value to operate with
-  Value := EvaluateExpression(APrivatePropertyCompoundAssignmentExpression.Value, AContext);
 
   if ObjectValue is TGocciaInstanceValue then
   begin
@@ -2452,6 +2452,42 @@ begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
+
+  if APrivatePropertyCompoundAssignmentExpression.Operator = gttNullishCoalescingAssign then
+  begin
+    if not ((CurrentValue is TGocciaUndefinedLiteralValue) or
+            (CurrentValue is TGocciaNullLiteralValue)) then
+    begin
+      Result := CurrentValue;
+      Exit;
+    end;
+
+    Value := EvaluateExpression(APrivatePropertyCompoundAssignmentExpression.Value, AContext);
+    Result := Value;
+
+    if ObjectValue is TGocciaInstanceValue then
+    begin
+      if AccessClass.HasPrivateSetter(APrivatePropertyCompoundAssignmentExpression.PrivateName) then
+      begin
+        SetterFn := AccessClass.PrivatePropertySetter[APrivatePropertyCompoundAssignmentExpression.PrivateName];
+        SetterArgs := TGocciaArgumentsCollection.Create;
+        try
+          SetterArgs.Add(Value);
+          SetterFn.Call(SetterArgs, Instance);
+        finally
+          SetterArgs.Free;
+        end;
+      end
+      else
+        Instance.SetPrivateProperty(APrivatePropertyCompoundAssignmentExpression.PrivateName, Result, AccessClass);
+    end
+    else if ObjectValue is TGocciaClassValue then
+      ClassValue.AddPrivateStaticProperty(APrivatePropertyCompoundAssignmentExpression.PrivateName, Result);
+    Exit;
+  end;
+
+  // Evaluate the value to operate with
+  Value := EvaluateExpression(APrivatePropertyCompoundAssignmentExpression.Value, AContext);
 
   // Use shared compound operation function
   Result := PerformCompoundOperation(CurrentValue, Value, APrivatePropertyCompoundAssignmentExpression.Operator);

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -2434,8 +2434,16 @@ begin
     // Determine the access class from the owning class of the current method
     AccessClass := ResolveOwningClass(Instance, AContext);
 
-    // Get the current value of the private property
-    CurrentValue := Instance.GetPrivateProperty(APrivatePropertyCompoundAssignmentExpression.PrivateName, AccessClass);
+    // Use the accessor-visible read path so private getters participate in ??=
+    if AccessClass.HasPrivateGetter(APrivatePropertyCompoundAssignmentExpression.PrivateName) then
+      CurrentValue := EvaluatePrivateMemberOnInstance(
+        Instance,
+        APrivatePropertyCompoundAssignmentExpression.PrivateName,
+        AContext)
+    else
+      CurrentValue := Instance.GetPrivateProperty(
+        APrivatePropertyCompoundAssignmentExpression.PrivateName,
+        AccessClass);
   end
   else if ObjectValue is TGocciaClassValue then
   begin

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -579,7 +579,12 @@ begin
     ';': AddToken(gttSemicolon);
     '?':
       if Match('?') then
-        AddToken(gttNullishCoalescing)
+      begin
+        if Match('=') then
+          AddToken(gttNullishCoalescingAssign)
+        else
+          AddToken(gttNullishCoalescing);
+      end
       else if Match('.') then
         AddToken(gttOptionalChaining)
       else

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -340,7 +340,7 @@ begin
         gttAnd, gttOr, gttNullishCoalescing,
         gttPlus, gttMinus, gttStar, gttSlash, gttPercent, gttPower,
         gttEqual, gttNotEqual,
-        gttAssign, gttPlusAssign, gttMinusAssign, gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign,
+        gttAssign, gttPlusAssign, gttMinusAssign, gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign, gttNullishCoalescingAssign,
         gttInstanceof, gttIn]);
   end;
 end;
@@ -1198,7 +1198,7 @@ var
   Pattern: TGocciaDestructuringPattern;
 begin
   Left := Conditional;
-  if Match([gttAssign, gttPlusAssign, gttMinusAssign, gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign,
+  if Match([gttAssign, gttPlusAssign, gttMinusAssign, gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign, gttNullishCoalescingAssign,
              gttBitwiseAndAssign, gttBitwiseOrAssign, gttBitwiseXorAssign, gttLeftShiftAssign, gttRightShiftAssign, gttUnsignedRightShiftAssign]) then
   begin
     Operator := Previous.TokenType;

--- a/units/Goccia.Token.pas
+++ b/units/Goccia.Token.pas
@@ -20,7 +20,7 @@ type
     gttPlus, gttMinus, gttStar, gttSlash, gttPercent, gttPower,
     gttEqual, gttNotEqual, gttLooseEqual, gttLooseNotEqual, gttLess, gttGreater, gttLessEqual, gttGreaterEqual,
     gttAnd, gttOr, gttNullishCoalescing, gttNot, gttTypeof, gttInstanceof, gttIn, gttDelete, gttAssign, gttPlusAssign, gttMinusAssign,
-    gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign,
+    gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign, gttNullishCoalescingAssign,
     gttIncrement, gttDecrement,
     gttQuestion, gttColon, gttOptionalChaining,
     // Bitwise operators


### PR DESCRIPTION
## Summary
- add support for the nullish coalescing assignment operator (`??=`)
- implement short-circuit semantics in both interpreter and bytecode mode
- add JavaScript coverage for identifiers, properties, computed properties, private fields, and const behavior
- update the language docs to include `??=`

## Testing
- ./build/TestRunner tests --no-progress --silent
- ./build/TestRunner tests --mode=bytecode --no-progress --silent
- ./build/TestRunner tests/language/expressions/nullish-coalescing/assignment.js --no-progress --silent
- ./build/TestRunner tests/language/expressions/nullish-coalescing/assignment.js --mode=bytecode --no-progress --silent

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the nullish coalescing assignment operator (`??=`): assigns RHS only when LHS is nullish and short-circuits (RHS not evaluated) when LHS is already non-nullish.

* **Documentation**
  * Updated README and design/language docs to describe `??=` behavior and examples.

* **Tests**
  * Added comprehensive tests covering identifiers, properties, computed keys, private fields/accessors, short-circuiting, and expected error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->