### PR TITLE
Harden OrderedStringMap tombstone compaction

### DIFF
--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -177,7 +177,7 @@ The codebase provides purpose-built hash maps that replace `TDictionary` on hot 
 
 | Use case | Map type | Notes |
 |----------|----------|-------|
-| String keys, insertion order | `TOrderedStringMap<V>` | 4–6× faster inserts than `TDictionary` at N=20–100; `static inline` DJB2 hash/equality |
+| String keys, insertion order | `TOrderedStringMap<V>` | 4–6× faster inserts than `TDictionary` at N=20–100; `static inline` DJB2 hash/equality; tracks deleted buckets and compacts after delete-heavy phases to bound probe chains |
 | Generic keys, insertion order | `TOrderedMap<K,V>` | Virtual `HashKey`/`KeysEqual`; default: DJB2 over raw key bytes |
 | Any key, unordered | `THashMap<K,V>` | Backshift deletion (no tombstones); `static inline` hash/equality; 2× faster inserts for pointer keys |
 | Scope bindings | `TOrderedStringMap<V>` | Hash-based O(1) lookup per scope level; chain walking in `TGocciaScope` |

--- a/units/Goccia.OrderedStringMap.Test.pas
+++ b/units/Goccia.OrderedStringMap.Test.pas
@@ -1,0 +1,87 @@
+program Goccia.OrderedStringMap.Test;
+
+{$I Goccia.inc}
+
+uses
+  SysUtils,
+
+  OrderedStringMap,
+  TestRunner,
+
+  Goccia.TestSetup;
+
+type
+  TTestOrderedStringMap = class(TTestSuite)
+  public
+    procedure SetupTests; override;
+
+    procedure TestReuseDeletedBucketClearsDeletedCount;
+    procedure TestDeleteHeavyInsertCompactsTombstones;
+  end;
+
+procedure TTestOrderedStringMap.SetupTests;
+begin
+  Test('Reuse deleted bucket clears deleted count',
+    TestReuseDeletedBucketClearsDeletedCount);
+  Test('Delete-heavy insert compacts tombstones',
+    TestDeleteHeavyInsertCompactsTombstones);
+end;
+
+procedure TTestOrderedStringMap.TestReuseDeletedBucketClearsDeletedCount;
+var
+  Map: TOrderedStringMap<Integer>;
+begin
+  Map := TOrderedStringMap<Integer>.Create(16);
+  try
+    Map.Add('a', 1);
+    Map.Add('b', 2);
+
+    Expect<Boolean>(Map.Remove('a')).ToBe(True);
+    Expect<Integer>(Map.DeletedCount).ToBe(1);
+
+    // "q" hashes to the same initial bucket as "a" in a 16-slot table.
+    Map.Add('q', 3);
+
+    Expect<Integer>(Map.DeletedCount).ToBe(0);
+    Expect<Integer>(Map.Count).ToBe(2);
+    Expect<Boolean>(Map.ContainsKey('b')).ToBe(True);
+    Expect<Boolean>(Map.ContainsKey('q')).ToBe(True);
+  finally
+    Map.Free;
+  end;
+end;
+
+procedure TTestOrderedStringMap.TestDeleteHeavyInsertCompactsTombstones;
+var
+  Map: TOrderedStringMap<Integer>;
+  I: Integer;
+begin
+  Map := TOrderedStringMap<Integer>.Create(16);
+  try
+    for I := 0 to 9 do
+      Map.Add('key' + IntToStr(I), I);
+
+    for I := 0 to 8 do
+      Expect<Boolean>(Map.Remove('key' + IntToStr(I))).ToBe(True);
+
+    Expect<Integer>(Map.Count).ToBe(1);
+    Expect<Integer>(Map.DeletedCount).ToBe(9);
+
+    Map.Add('new-key', 99);
+
+    Expect<Integer>(Map.Capacity).ToBe(16);
+    Expect<Integer>(Map.Count).ToBe(2);
+    Expect<Integer>(Map.DeletedCount).ToBe(0);
+    Expect<string>(Map.EntryAt(0).Key).ToBe('key9');
+    Expect<string>(Map.EntryAt(1).Key).ToBe('new-key');
+  finally
+    Map.Free;
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TTestOrderedStringMap.Create('OrderedStringMap'));
+  TestRunnerProgram.Run;
+
+  ExitCode := TestResultToExitCode;
+end.

--- a/units/OrderedStringMap.pas
+++ b/units/OrderedStringMap.pas
@@ -55,12 +55,14 @@ type
     FEntries: TEntryArray;
     FBuckets: array of Int32;
     FCount: Integer;
+    FDeletedCount: Integer;
     FEntryCount: Integer;
     FBucketCount: Integer;
 
     class function HashKey(const AKey: string): Cardinal; static; inline;
     class function KeysEqual(const A, B: string): Boolean; static; inline;
 
+    function DeletedSlotsNeedCompaction: Boolean; inline;
     function FindBucket(const AKey: string; AHash: Cardinal;
       out ABucketIdx: Integer): Boolean;
     procedure Grow;
@@ -89,6 +91,7 @@ type
     function EntryAt(AIndex: Integer): TBaseMap<string, TValue>.TKeyValuePair;
 
     property Capacity: Integer read FBucketCount;
+    property DeletedCount: Integer read FDeletedCount;
   end;
 
   TStringStringMap = TOrderedStringMap<string>;
@@ -111,6 +114,11 @@ end;
 class function TOrderedStringMap<TValue>.KeysEqual(const A, B: string): Boolean;
 begin
   Result := A = B;
+end;
+
+function TOrderedStringMap<TValue>.DeletedSlotsNeedCompaction: Boolean;
+begin
+  Result := FDeletedCount > FCount;
 end;
 
 { Probe }
@@ -184,6 +192,8 @@ begin
         Idx := (Idx + 1) and (FBucketCount - 1);
       FBuckets[Idx] := I;
     end;
+
+  FDeletedCount := 0;
 end;
 
 procedure TOrderedStringMap<TValue>.Compact;
@@ -217,6 +227,7 @@ var
 begin
   inherited Create;
   FCount := 0;
+  FDeletedCount := 0;
   FEntryCount := 0;
 
   if AInitialCapacity <= 0 then
@@ -268,6 +279,12 @@ begin
     FindBucket(AKey, Hash, BucketIdx);
   end;
 
+  if DeletedSlotsNeedCompaction then
+  begin
+    Compact;
+    FindBucket(AKey, Hash, BucketIdx);
+  end;
+
   EntryIdx := FEntryCount;
   Inc(FEntryCount);
   if FEntryCount > Length(FEntries) then
@@ -278,6 +295,8 @@ begin
   FEntries[EntryIdx].Hash := Hash;
   FEntries[EntryIdx].Active := True;
 
+  if FBuckets[BucketIdx] = DELETED_SLOT then
+    Dec(FDeletedCount);
   FBuckets[BucketIdx] := EntryIdx;
   Inc(FCount);
 end;
@@ -336,6 +355,7 @@ begin
   FEntries[EntryIdx].Key := '';
   FEntries[EntryIdx].Value := Default(TValue);
   FBuckets[BucketIdx] := DELETED_SLOT;
+  Inc(FDeletedCount);
   Dec(FCount);
 end;
 
@@ -347,6 +367,7 @@ begin
     FBuckets[I] := EMPTY_SLOT;
   SetLength(FEntries, 0);
   FCount := 0;
+  FDeletedCount := 0;
   FEntryCount := 0;
 end;
 


### PR DESCRIPTION
## Summary
- track deleted buckets in `TOrderedStringMap` and reset the counter on rebuild paths
- compact the table after delete-heavy phases to keep probe sequences bounded and decrement the counter when a tombstone slot is reused
- add Pascal unit coverage for tombstone reuse and delete-heavy compaction, and document the behavior

## Testing
- ./format.pas
- ./build.pas clean tests testrunner
- for t in build/Goccia.*.Test; do ""; done
- ./build/TestRunner tests --no-progress

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OrderedStringMap performance with automatic compaction after heavy deletion operations, ensuring efficient probe chain management.

* **Tests**
  * Added comprehensive test suite covering deletion and reinsertion scenarios.

* **Documentation**
  * Updated documentation to reflect deletion tracking and compaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->