### PR TITLE
Extract standalone module loader for module content providers

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -180,6 +180,83 @@ end;
 
 When no custom resolver is provided, the engine creates a default `TGocciaModuleResolver` whose base directory is the entry script's directory.
 
+### Custom Content Provider
+
+Resolution and content loading are separate concerns. A custom resolver decides **which** module path to load; a custom content provider decides **how** the module text or JSON is retrieved once that path is resolved.
+
+Use `TGocciaModuleContentProvider` when your modules come from memory, an archive, a database, or some other non-filesystem source:
+
+```pascal
+uses
+  Classes,
+  SysUtils,
+
+  Goccia.Engine,
+  Goccia.Modules.ContentProvider,
+  Goccia.Modules.Resolver;
+
+type
+  TMemoryResolver = class(TGocciaModuleResolver)
+  public
+    function Resolve(const AModulePath, AImportingFilePath: string): string; override;
+  end;
+
+  TMemoryContentProvider = class(TGocciaModuleContentProvider)
+  public
+    function Exists(const APath: string): Boolean; override;
+    function LoadContent(const APath: string): TGocciaModuleContent; override;
+    function TryGetLastModified(const APath: string;
+      out ALastModified: TDateTime): Boolean; override;
+  end;
+
+function TMemoryResolver.Resolve(const AModulePath,
+  AImportingFilePath: string): string;
+begin
+  Result := AModulePath;
+end;
+
+function TMemoryContentProvider.Exists(const APath: string): Boolean;
+begin
+  Result := APath = 'memory:/dep.js';
+end;
+
+function TMemoryContentProvider.LoadContent(
+  const APath: string): TGocciaModuleContent;
+begin
+  if APath = 'memory:/dep.js' then
+    Exit(TGocciaModuleContent.Create('export const value = 42;', 0));
+
+  raise Exception.Create('Module content not found: ' + APath);
+end;
+
+function TMemoryContentProvider.TryGetLastModified(const APath: string;
+  out ALastModified: TDateTime): Boolean;
+begin
+  ALastModified := 0;
+  Result := False;
+end;
+
+var
+  Engine: TGocciaEngine;
+  Resolver: TMemoryResolver;
+  Provider: TMemoryContentProvider;
+begin
+  Resolver := TMemoryResolver.Create;
+  Provider := TMemoryContentProvider.Create;
+  Engine := TGocciaEngine.Create('memory:/app.js', Source,
+    TGocciaEngine.DefaultGlobals, Resolver, Provider);
+  try
+    Engine.Execute;
+  finally
+    Engine.Free;
+    Provider.Free;  // caller owns injected providers
+    Resolver.Free;
+  end;
+end;
+```
+
+`TGocciaInterpreter` and `TGocciaBytecodeBackend` also accept injected content providers. When no provider is supplied, they create a `TGocciaFileSystemModuleContentProvider` automatically, preserving the current filesystem-backed behavior.
+
 ### Global Modules
 
 Global modules are bare-specifier imports that bypass file resolution entirely. They are checked before the resolver runs:

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -193,6 +193,7 @@ uses
 
   Goccia.Engine,
   Goccia.Modules.ContentProvider,
+  Goccia.Modules.Loader,
   Goccia.Modules.Resolver;
 
 type
@@ -238,24 +239,34 @@ end;
 
 var
   Engine: TGocciaEngine;
+  ModuleLoader: TGocciaModuleLoader;
   Resolver: TMemoryResolver;
   Provider: TMemoryContentProvider;
 begin
   Resolver := TMemoryResolver.Create;
   Provider := TMemoryContentProvider.Create;
-  Engine := TGocciaEngine.Create('memory:/app.js', Source,
-    TGocciaEngine.DefaultGlobals, Resolver, Provider);
   try
-    Engine.Execute;
+    ModuleLoader := TGocciaModuleLoader.Create('memory:/app.js', Resolver,
+      Provider);
+    try
+      Engine := TGocciaEngine.Create('memory:/app.js', Source,
+        TGocciaEngine.DefaultGlobals, ModuleLoader);
+      try
+        Engine.Execute;
+      finally
+        Engine.Free;
+      end;
+    finally
+      ModuleLoader.Free;  // caller owns injected module loaders
+    end;
   finally
-    Engine.Free;
     Provider.Free;  // caller owns injected providers
     Resolver.Free;
   end;
 end;
 ```
 
-`TGocciaInterpreter` and `TGocciaBytecodeBackend` also accept injected content providers. When no provider is supplied, they create a `TGocciaFileSystemModuleContentProvider` automatically, preserving the current filesystem-backed behavior.
+`TGocciaInterpreter` and `TGocciaBytecodeBackend` also accept injected module loaders. When no loader is supplied, they create a default `TGocciaModuleLoader`, which in turn uses a `TGocciaFileSystemModuleContentProvider` and the standard filesystem-backed resolver.
 
 ### Global Modules
 

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -16,6 +16,7 @@ uses
   Goccia.MicrotaskQueue,
   Goccia.Modules,
   Goccia.Modules.ContentProvider,
+  Goccia.Modules.Loader,
   Goccia.Modules.Resolver,
   Goccia.Runtime.Bootstrap,
   Goccia.Values.Primitives,
@@ -33,15 +34,17 @@ type
     FSourcePath: string;
     FInterpreter: TGocciaInterpreter;
     FBootstrap: TGocciaRuntimeBootstrap;
-    FModuleResolver: TGocciaModuleResolver;
+    FModuleLoader: TGocciaModuleLoader;
     FBootstrapSource: TStringList;
-    FContentProvider: TGocciaModuleContentProvider;
+    FOwnsModuleLoader: Boolean;
     FInjectedGlobals: TStringList;
+    function GetContentProvider: TGocciaModuleContentProvider;
+    function GetModuleResolver: TGocciaModuleResolver;
     procedure ThrowError(const AMessage: string; const ALine, AColumn: Integer);
   public
     constructor Create(const ASourcePath: string); overload;
     constructor Create(const ASourcePath: string;
-      const AContentProvider: TGocciaModuleContentProvider); overload;
+      const AModuleLoader: TGocciaModuleLoader); overload;
     destructor Destroy; override;
 
     function CompileAndRun(const AProgram: TGocciaProgram): TGocciaValue;
@@ -56,8 +59,9 @@ type
 
     property Interpreter: TGocciaInterpreter read FInterpreter;
     property Bootstrap: TGocciaRuntimeBootstrap read FBootstrap;
-    property ContentProvider: TGocciaModuleContentProvider read FContentProvider;
-    property ModuleResolver: TGocciaModuleResolver read FModuleResolver;
+    property ContentProvider: TGocciaModuleContentProvider read GetContentProvider;
+    property ModuleLoader: TGocciaModuleLoader read FModuleLoader;
+    property ModuleResolver: TGocciaModuleResolver read GetModuleResolver;
   end;
 
 implementation
@@ -66,8 +70,6 @@ uses
   SysUtils,
 
   GarbageCollector.Generic,
-  ModuleResolver,
-  OrderedStringMap,
 
   Goccia.CallStack,
   Goccia.Constants.PropertyNames,
@@ -81,24 +83,39 @@ uses
 
 constructor TGocciaBytecodeBackend.Create(const ASourcePath: string);
 begin
-  Create(ASourcePath, nil);
+  inherited Create;
+  TGarbageCollector.Initialize;
+  TGocciaCallStack.Initialize;
+  TGocciaMicrotaskQueue.Initialize;
+  FSourcePath := ASourcePath;
+  FModuleLoader := TGocciaModuleLoader.Create(ASourcePath);
+  FOwnsModuleLoader := True;
+  FMinimalVM := TGocciaVM.Create;
+  FInterpreter := nil;
+  FBootstrap := nil;
+  FBootstrapSource := nil;
+  FInjectedGlobals := TStringList.Create;
 end;
 
 constructor TGocciaBytecodeBackend.Create(const ASourcePath: string;
-  const AContentProvider: TGocciaModuleContentProvider);
+  const AModuleLoader: TGocciaModuleLoader);
 begin
   inherited Create;
   TGarbageCollector.Initialize;
   TGocciaCallStack.Initialize;
   TGocciaMicrotaskQueue.Initialize;
   FSourcePath := ASourcePath;
-  FModuleResolver := TGocciaModuleResolver.Create(
-    ExtractFilePath(ExpandFileName(ASourcePath)));
+  FModuleLoader := AModuleLoader;
+  FOwnsModuleLoader := False;
+  if not Assigned(FModuleLoader) then
+  begin
+    FModuleLoader := TGocciaModuleLoader.Create(ASourcePath);
+    FOwnsModuleLoader := True;
+  end;
   FMinimalVM := TGocciaVM.Create;
   FInterpreter := nil;
   FBootstrap := nil;
   FBootstrapSource := nil;
-  FContentProvider := AContentProvider;
   FInjectedGlobals := TStringList.Create;
 end;
 
@@ -111,7 +128,8 @@ begin
   FInterpreter.Free;
   FBootstrapSource.Free;
   FInjectedGlobals.Free;
-  FModuleResolver.Free;
+  if FOwnsModuleLoader then
+    FModuleLoader.Free;
   inherited;
 end;
 
@@ -228,7 +246,6 @@ procedure TGocciaBytecodeBackend.RegisterBuiltIns(
   const AGlobals: TGocciaGlobalBuiltins);
 var
   EmptySource: TStringList;
-  AliasPair: TOrderedStringMap<string>.TKeyValuePair;
 begin
   FreeAndNil(FBootstrap);
   if Assigned(TGarbageCollector.Instance) and Assigned(FInterpreter) then
@@ -240,22 +257,27 @@ begin
   EmptySource.Text := '';
   FBootstrapSource := EmptySource;
   FInterpreter := TGocciaInterpreter.Create(FSourcePath, FBootstrapSource,
-    FContentProvider);
+    FModuleLoader);
   FInterpreter.JSXEnabled := ggJSX in AGlobals;
-  FInterpreter.Resolver := FModuleResolver;
   TGarbageCollector.Instance.AddRootObject(FInterpreter.GlobalScope);
   FBootstrap := TGocciaRuntimeBootstrap.Create(FInterpreter, AGlobals, ThrowError);
 
   FMinimalVM.GlobalScope := FInterpreter.GlobalScope;
   FMinimalVM.Interpreter := FInterpreter;
 
-  if Assigned(FInterpreter.Resolver) then
-    for AliasPair in FInterpreter.Resolver.Aliases do
-      FModuleResolver.AddAlias(AliasPair.Key, AliasPair.Value);
-
   if FInterpreter.GlobalScope.GetValue('GocciaScript') is TGocciaObjectValue then
     TGocciaObjectValue(FInterpreter.GlobalScope.GetValue('GocciaScript'))
       .AssignProperty(PROP_STRICT_TYPES, TGocciaBooleanLiteralValue.TrueValue);
+end;
+
+function TGocciaBytecodeBackend.GetContentProvider: TGocciaModuleContentProvider;
+begin
+  Result := FModuleLoader.ContentProvider;
+end;
+
+function TGocciaBytecodeBackend.GetModuleResolver: TGocciaModuleResolver;
+begin
+  Result := FModuleLoader.Resolver;
 end;
 
 procedure TGocciaBytecodeBackend.ClearTransientCaches;

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -15,6 +15,7 @@ uses
   Goccia.JSON,
   Goccia.MicrotaskQueue,
   Goccia.Modules,
+  Goccia.Modules.ContentProvider,
   Goccia.Modules.Resolver,
   Goccia.Runtime.Bootstrap,
   Goccia.Values.Primitives,
@@ -34,10 +35,13 @@ type
     FBootstrap: TGocciaRuntimeBootstrap;
     FModuleResolver: TGocciaModuleResolver;
     FBootstrapSource: TStringList;
+    FContentProvider: TGocciaModuleContentProvider;
     FInjectedGlobals: TStringList;
     procedure ThrowError(const AMessage: string; const ALine, AColumn: Integer);
   public
-    constructor Create(const ASourcePath: string);
+    constructor Create(const ASourcePath: string); overload;
+    constructor Create(const ASourcePath: string;
+      const AContentProvider: TGocciaModuleContentProvider); overload;
     destructor Destroy; override;
 
     function CompileAndRun(const AProgram: TGocciaProgram): TGocciaValue;
@@ -52,6 +56,7 @@ type
 
     property Interpreter: TGocciaInterpreter read FInterpreter;
     property Bootstrap: TGocciaRuntimeBootstrap read FBootstrap;
+    property ContentProvider: TGocciaModuleContentProvider read FContentProvider;
     property ModuleResolver: TGocciaModuleResolver read FModuleResolver;
   end;
 
@@ -76,6 +81,12 @@ uses
 
 constructor TGocciaBytecodeBackend.Create(const ASourcePath: string);
 begin
+  Create(ASourcePath, nil);
+end;
+
+constructor TGocciaBytecodeBackend.Create(const ASourcePath: string;
+  const AContentProvider: TGocciaModuleContentProvider);
+begin
   inherited Create;
   TGarbageCollector.Initialize;
   TGocciaCallStack.Initialize;
@@ -87,6 +98,7 @@ begin
   FInterpreter := nil;
   FBootstrap := nil;
   FBootstrapSource := nil;
+  FContentProvider := AContentProvider;
   FInjectedGlobals := TStringList.Create;
 end;
 
@@ -227,7 +239,8 @@ begin
   EmptySource := TStringList.Create;
   EmptySource.Text := '';
   FBootstrapSource := EmptySource;
-  FInterpreter := TGocciaInterpreter.Create(FSourcePath, FBootstrapSource);
+  FInterpreter := TGocciaInterpreter.Create(FSourcePath, FBootstrapSource,
+    FContentProvider);
   FInterpreter.JSXEnabled := ggJSX in AGlobals;
   FInterpreter.Resolver := FModuleResolver;
   TGarbageCollector.Instance.AddRootObject(FInterpreter.GlobalScope);

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -31,6 +31,7 @@ uses
   Goccia.JSON,
   Goccia.JSX.SourceMap,
   Goccia.Modules,
+  Goccia.Modules.ContentProvider,
   Goccia.Modules.Resolver,
   Goccia.ObjectModel,
   Goccia.ObjectModel.Engine,
@@ -113,12 +114,15 @@ type
     procedure RegisterTypedArrayConstructor(const AName: string; const AKind: TGocciaTypedArrayKind; const AObjectConstructor: TGocciaClassValue);
     procedure RegisterGlobalThis;
     procedure RegisterGocciaScriptGlobal;
+    function GetContentProvider: TGocciaModuleContentProvider;
     function SpeciesGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure PrintParserWarnings(const AParser: TGocciaParser; const ASourceMap: TGocciaSourceMap = nil);
     procedure ThrowError(const AMessage: string; const ALine, AColumn: Integer);
   public
     constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins); overload;
     constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AResolver: TGocciaModuleResolver); overload;
+    constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AContentProvider: TGocciaModuleContentProvider); overload;
+    constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AResolver: TGocciaModuleResolver; const AContentProvider: TGocciaModuleContentProvider); overload;
     destructor Destroy; override;
 
     function Execute: TGocciaScriptResult;
@@ -139,6 +143,7 @@ type
 
     property Interpreter: TGocciaInterpreter read FInterpreter;
     property Resolver: TGocciaModuleResolver read FResolver;
+    property ContentProvider: TGocciaModuleContentProvider read GetContentProvider;
     property BuiltinConsole: TGocciaConsole read FBuiltinConsole;
     property BuiltinMath: TGocciaMath read FBuiltinMath;
     property BuiltinGlobalObject: TGocciaGlobalObject read FBuiltinGlobalObject;
@@ -195,10 +200,25 @@ uses
 
 constructor TGocciaEngine.Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins);
 begin
-  Create(AFileName, ASourceLines, AGlobals, nil);
+  Create(AFileName, ASourceLines, AGlobals, nil, nil);
 end;
 
 constructor TGocciaEngine.Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AResolver: TGocciaModuleResolver);
+begin
+  Create(AFileName, ASourceLines, AGlobals, AResolver, nil);
+end;
+
+constructor TGocciaEngine.Create(const AFileName: string;
+  const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins;
+  const AContentProvider: TGocciaModuleContentProvider);
+begin
+  Create(AFileName, ASourceLines, AGlobals, nil, AContentProvider);
+end;
+
+constructor TGocciaEngine.Create(const AFileName: string;
+  const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins;
+  const AResolver: TGocciaModuleResolver;
+  const AContentProvider: TGocciaModuleContentProvider);
 begin
   FPreviousExceptionMask := GetExceptionMask;
   SetExceptionMask([exInvalidOp, exDenormalized, exZeroDivide, exOverflow, exUnderflow, exPrecision]);
@@ -221,7 +241,8 @@ begin
   TGocciaCallStack.Initialize;
   TGocciaMicrotaskQueue.Initialize;
 
-  FInterpreter := TGocciaInterpreter.Create(AFileName, ASourceLines);
+  FInterpreter := TGocciaInterpreter.Create(AFileName, ASourceLines,
+    AContentProvider);
   FInterpreter.JSXEnabled := ggJSX in FGlobals;
   FInterpreter.Resolver := FResolver;
 
@@ -562,6 +583,11 @@ begin
   GocciaObj.AssignProperty(PROP_STRICT_TYPES, TGocciaBooleanLiteralValue.FalseValue);
 
   FInterpreter.GlobalScope.DefineLexicalBinding('GocciaScript', GocciaObj, dtConst);
+end;
+
+function TGocciaEngine.GetContentProvider: TGocciaModuleContentProvider;
+begin
+  Result := FInterpreter.ContentProvider;
 end;
 
 procedure TGocciaEngine.AddAlias(const APattern, AReplacement: string);

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -32,6 +32,7 @@ uses
   Goccia.JSX.SourceMap,
   Goccia.Modules,
   Goccia.Modules.ContentProvider,
+  Goccia.Modules.Loader,
   Goccia.Modules.Resolver,
   Goccia.ObjectModel,
   Goccia.ObjectModel.Engine,
@@ -80,12 +81,12 @@ type
     const DefaultGlobals: TGocciaGlobalBuiltins = [ggConsole, ggMath, ggGlobalObject, ggGlobalArray, ggGlobalNumber, ggPromise, ggJSON, ggSymbol, ggSet, ggMap, ggPerformance, ggTemporal, ggJSX, ggArrayBuffer];
   private
     FInterpreter: TGocciaInterpreter;
-    FResolver: TGocciaModuleResolver;
-    FOwnsResolver: Boolean;
     FFileName: string;
     FSourceLines: TStringList;
     FInjectedGlobals: TStringList;
     FGlobals: TGocciaGlobalBuiltins;
+    FModuleLoader: TGocciaModuleLoader;
+    FOwnsModuleLoader: Boolean;
 
     // Built-in objects
     FBuiltinConsole: TGocciaConsole;
@@ -114,15 +115,18 @@ type
     procedure RegisterTypedArrayConstructor(const AName: string; const AKind: TGocciaTypedArrayKind; const AObjectConstructor: TGocciaClassValue);
     procedure RegisterGlobalThis;
     procedure RegisterGocciaScriptGlobal;
+    procedure Initialize(const AFileName: string; const ASourceLines: TStringList;
+      const AGlobals: TGocciaGlobalBuiltins; const AModuleLoader: TGocciaModuleLoader;
+      const AOwnsModuleLoader: Boolean);
     function GetContentProvider: TGocciaModuleContentProvider;
+    function GetResolver: TGocciaModuleResolver;
     function SpeciesGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure PrintParserWarnings(const AParser: TGocciaParser; const ASourceMap: TGocciaSourceMap = nil);
     procedure ThrowError(const AMessage: string; const ALine, AColumn: Integer);
   public
     constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins); overload;
     constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AResolver: TGocciaModuleResolver); overload;
-    constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AContentProvider: TGocciaModuleContentProvider); overload;
-    constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AResolver: TGocciaModuleResolver; const AContentProvider: TGocciaModuleContentProvider); overload;
+    constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AModuleLoader: TGocciaModuleLoader); overload;
     destructor Destroy; override;
 
     function Execute: TGocciaScriptResult;
@@ -142,7 +146,7 @@ type
     class function RunScriptFromStringList(const ASource: TStringList; const AFileName: string): TGocciaScriptResult; overload;
 
     property Interpreter: TGocciaInterpreter read FInterpreter;
-    property Resolver: TGocciaModuleResolver read FResolver;
+    property Resolver: TGocciaModuleResolver read GetResolver;
     property ContentProvider: TGocciaModuleContentProvider read GetContentProvider;
     property BuiltinConsole: TGocciaConsole read FBuiltinConsole;
     property BuiltinMath: TGocciaMath read FBuiltinMath;
@@ -200,41 +204,38 @@ uses
 
 constructor TGocciaEngine.Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins);
 begin
-  Create(AFileName, ASourceLines, AGlobals, nil, nil);
+  Initialize(AFileName, ASourceLines, AGlobals,
+    TGocciaModuleLoader.Create(AFileName), True);
 end;
 
 constructor TGocciaEngine.Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AResolver: TGocciaModuleResolver);
 begin
-  Create(AFileName, ASourceLines, AGlobals, AResolver, nil);
+  Initialize(AFileName, ASourceLines, AGlobals,
+    TGocciaModuleLoader.Create(AFileName, AResolver), True);
 end;
 
 constructor TGocciaEngine.Create(const AFileName: string;
   const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins;
-  const AContentProvider: TGocciaModuleContentProvider);
+  const AModuleLoader: TGocciaModuleLoader);
 begin
-  Create(AFileName, ASourceLines, AGlobals, nil, AContentProvider);
+  Initialize(AFileName, ASourceLines, AGlobals, AModuleLoader, False);
 end;
 
-constructor TGocciaEngine.Create(const AFileName: string;
+procedure TGocciaEngine.Initialize(const AFileName: string;
   const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins;
-  const AResolver: TGocciaModuleResolver;
-  const AContentProvider: TGocciaModuleContentProvider);
+  const AModuleLoader: TGocciaModuleLoader; const AOwnsModuleLoader: Boolean);
 begin
   FPreviousExceptionMask := GetExceptionMask;
   SetExceptionMask([exInvalidOp, exDenormalized, exZeroDivide, exOverflow, exUnderflow, exPrecision]);
   FFileName := AFileName;
   FSourceLines := ASourceLines;
   FGlobals := AGlobals;
-
-  if Assigned(AResolver) then
+  FModuleLoader := AModuleLoader;
+  FOwnsModuleLoader := AOwnsModuleLoader;
+  if not Assigned(FModuleLoader) then
   begin
-    FResolver := AResolver;
-    FOwnsResolver := False;
-  end
-  else
-  begin
-    FResolver := TGocciaModuleResolver.Create(ExtractFilePath(ExpandFileName(AFileName)));
-    FOwnsResolver := True;
+    FModuleLoader := TGocciaModuleLoader.Create(AFileName);
+    FOwnsModuleLoader := True;
   end;
 
   TGarbageCollector.Initialize;
@@ -242,9 +243,8 @@ begin
   TGocciaMicrotaskQueue.Initialize;
 
   FInterpreter := TGocciaInterpreter.Create(AFileName, ASourceLines,
-    AContentProvider);
+    FModuleLoader);
   FInterpreter.JSXEnabled := ggJSX in FGlobals;
-  FInterpreter.Resolver := FResolver;
 
   TGarbageCollector.Instance.AddRootObject(FInterpreter.GlobalScope);
 
@@ -277,10 +277,9 @@ begin
     FBuiltinTemporal.Free;
     FBuiltinArrayBuffer.Free;
     FInjectedGlobals.Free;
-
     FInterpreter.Free;
-    if FOwnsResolver then
-      FResolver.Free;
+    if FOwnsModuleLoader then
+      FModuleLoader.Free;
   finally
     SetExceptionMask(FPreviousExceptionMask);
   end;
@@ -587,12 +586,17 @@ end;
 
 function TGocciaEngine.GetContentProvider: TGocciaModuleContentProvider;
 begin
-  Result := FInterpreter.ContentProvider;
+  Result := FModuleLoader.ContentProvider;
+end;
+
+function TGocciaEngine.GetResolver: TGocciaModuleResolver;
+begin
+  Result := FModuleLoader.Resolver;
 end;
 
 procedure TGocciaEngine.AddAlias(const APattern, AReplacement: string);
 begin
-  FResolver.AddAlias(APattern, AReplacement);
+  Resolver.AddAlias(APattern, AReplacement);
 end;
 
 procedure TGocciaEngine.InjectGlobal(const AKey: string; const AValue: TGocciaValue);

--- a/units/Goccia.Interpreter.pas
+++ b/units/Goccia.Interpreter.pas
@@ -21,6 +21,7 @@ uses
   Goccia.Lexer,
   Goccia.Logger,
   Goccia.Modules,
+  Goccia.Modules.ContentProvider,
   Goccia.Modules.Resolver,
   Goccia.Parser,
   Goccia.Scope,
@@ -44,13 +45,17 @@ type
     FFileName: string;
     FSourceLines: TStringList;
     FJSXEnabled: Boolean;
+    FContentProvider: TGocciaModuleContentProvider;
+    FOwnsContentProvider: Boolean;
     FResolver: TGocciaModuleResolver;
 
     procedure ThrowError(const AMessage: string; const ALine, AColumn: Integer);
     function LoadJsonModule(const AResolvedPath: string): TGocciaModule;
   public
     function CreateEvaluationContext: TGocciaEvaluationContext;
-    constructor Create(const AFileName: string; const ASourceLines: TStringList);
+    constructor Create(const AFileName: string; const ASourceLines: TStringList); overload;
+    constructor Create(const AFileName: string; const ASourceLines: TStringList;
+      const AContentProvider: TGocciaModuleContentProvider); overload;
     destructor Destroy; override;
     function Execute(const AProgram: TGocciaProgram): TGocciaValue;
     function LoadModule(const AModulePath, AImportingFilePath: string): TGocciaModule;
@@ -58,6 +63,7 @@ type
 
     property GlobalScope: TGocciaGlobalScope read FGlobalScope;
     property JSXEnabled: Boolean read FJSXEnabled write FJSXEnabled;
+    property ContentProvider: TGocciaModuleContentProvider read FContentProvider;
     property Resolver: TGocciaModuleResolver read FResolver write FResolver;
     property GlobalModules: TOrderedStringMap<TGocciaModule> read FGlobalModules;
   end;
@@ -78,12 +84,29 @@ uses
 constructor TGocciaInterpreter.Create(const AFileName: string;
   const ASourceLines: TStringList);
 begin
+  Create(AFileName, ASourceLines, nil);
+end;
+
+constructor TGocciaInterpreter.Create(const AFileName: string;
+  const ASourceLines: TStringList;
+  const AContentProvider: TGocciaModuleContentProvider);
+begin
   FFileName := AFileName;
   FSourceLines := ASourceLines;
   FGlobalScope := TGocciaGlobalScope.Create;
   FModules := TOrderedStringMap<TGocciaModule>.Create;
   FLoadingModules := TOrderedStringMap<Boolean>.Create;
   FGlobalModules := TOrderedStringMap<TGocciaModule>.Create;
+  if Assigned(AContentProvider) then
+  begin
+    FContentProvider := AContentProvider;
+    FOwnsContentProvider := False;
+  end
+  else
+  begin
+    FContentProvider := TGocciaFileSystemModuleContentProvider.Create;
+    FOwnsContentProvider := True;
+  end;
 end;
 
 destructor TGocciaInterpreter.Destroy;
@@ -93,6 +116,8 @@ begin
   FModules.Free;
   FLoadingModules.Free;
   FGlobalModules.Free;
+  if FOwnsContentProvider then
+    FContentProvider.Free;
 
   inherited;
 end;
@@ -126,7 +151,7 @@ end;
 function TGocciaInterpreter.LoadModule(const AModulePath, AImportingFilePath: string): TGocciaModule;
 var
   ResolvedPath: string;
-  Source: TStringList;
+  Content: TGocciaModuleContent;
   SourceText: string;
   JSXResult: TGocciaJSXTransformResult;
   JSXSourceMap: TGocciaSourceMap;
@@ -176,11 +201,9 @@ begin
     Exit;
   end;
 
-  Source := TStringList.Create;
+  Content := FContentProvider.LoadContent(ResolvedPath);
   try
-    Source.LoadFromFile(ResolvedPath);
-
-    SourceText := Source.Text;
+    SourceText := Content.Text;
     JSXSourceMap := nil;
     if FJSXEnabled then
     begin
@@ -200,7 +223,7 @@ begin
             ProgramNode := Parser.Parse;
             try
               Module := TGocciaModule.Create(ResolvedPath);
-              Module.LastModified := FileDateToDateTime(FileAge(ResolvedPath));
+              Module.LastModified := Content.LastModified;
               FModules.Add(ResolvedPath, Module);
               FLoadingModules.Add(ResolvedPath, True);
               try
@@ -273,7 +296,7 @@ begin
         begin
           if Assigned(JSXSourceMap) and
              JSXSourceMap.Translate(E.Line, E.Column, OrigLine, OrigCol) then
-            E.TranslatePosition(OrigLine, OrigCol, Source);
+            E.TranslatePosition(OrigLine, OrigCol, Content.SourceLines);
           raise;
         end;
       end;
@@ -281,7 +304,7 @@ begin
       JSXSourceMap.Free;
     end;
   finally
-    Source.Free;
+    Content.Free;
   end;
 end;
 
@@ -289,7 +312,9 @@ procedure TGocciaInterpreter.CheckForModuleReload(const AModule: TGocciaModule);
 var
   CurrentModified: TDateTime;
 begin
-  CurrentModified := FileDateToDateTime(FileAge(AModule.Path));
+  if not FContentProvider.TryGetLastModified(AModule.Path, CurrentModified) then
+    Exit;
+
   if CurrentModified > AModule.LastModified then
   begin
     AModule.ExportsTable.Clear;
@@ -300,21 +325,19 @@ end;
 
 function TGocciaInterpreter.LoadJsonModule(const AResolvedPath: string): TGocciaModule;
 var
-  Source: TStringList;
+  Content: TGocciaModuleContent;
   Parser: TGocciaJSONParser;
   ParsedValue: TGocciaValue;
   Obj: TGocciaObjectValue;
   Key: string;
   Module: TGocciaModule;
 begin
-  Source := TStringList.Create;
+  Content := FContentProvider.LoadContent(AResolvedPath);
   try
-    Source.LoadFromFile(AResolvedPath);
-
     Parser := TGocciaJSONParser.Create;
     try
       try
-        ParsedValue := Parser.Parse(Source.Text);
+        ParsedValue := Parser.Parse(Content.Text);
       except
         on E: EGocciaJSONParseError do
           raise TGocciaRuntimeError.Create(
@@ -323,7 +346,7 @@ begin
       end;
 
       Module := TGocciaModule.Create(AResolvedPath);
-      Module.LastModified := FileDateToDateTime(FileAge(AResolvedPath));
+      Module.LastModified := Content.LastModified;
 
       if ParsedValue is TGocciaObjectValue then
       begin
@@ -338,7 +361,7 @@ begin
       Parser.Free;
     end;
   finally
-    Source.Free;
+    Content.Free;
   end;
 end;
 

--- a/units/Goccia.Interpreter.pas
+++ b/units/Goccia.Interpreter.pas
@@ -18,14 +18,12 @@ uses
   Goccia.Error,
   Goccia.Evaluator,
   Goccia.Evaluator.Context,
-  Goccia.Lexer,
   Goccia.Logger,
   Goccia.Modules,
   Goccia.Modules.ContentProvider,
+  Goccia.Modules.Loader,
   Goccia.Modules.Resolver,
-  Goccia.Parser,
   Goccia.Scope,
-  Goccia.Token,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
@@ -39,45 +37,41 @@ type
   TGocciaInterpreter = class
   private
     FGlobalScope: TGocciaGlobalScope;
-    FModules: TOrderedStringMap<TGocciaModule>;
-    FLoadingModules: TOrderedStringMap<Boolean>;
-    FGlobalModules: TOrderedStringMap<TGocciaModule>;
     FFileName: string;
     FSourceLines: TStringList;
     FJSXEnabled: Boolean;
-    FContentProvider: TGocciaModuleContentProvider;
-    FOwnsContentProvider: Boolean;
-    FResolver: TGocciaModuleResolver;
+    FModuleLoader: TGocciaModuleLoader;
+    FOwnsModuleLoader: Boolean;
 
     procedure ThrowError(const AMessage: string; const ALine, AColumn: Integer);
-    function LoadJsonModule(const AResolvedPath: string): TGocciaModule;
+    function GetContentProvider: TGocciaModuleContentProvider;
+    function GetGlobalModules: TOrderedStringMap<TGocciaModule>;
+    function GetResolver: TGocciaModuleResolver;
+    procedure SetJSXEnabled(const AValue: Boolean);
+    procedure SetResolver(const AValue: TGocciaModuleResolver);
   public
     function CreateEvaluationContext: TGocciaEvaluationContext;
     constructor Create(const AFileName: string; const ASourceLines: TStringList); overload;
     constructor Create(const AFileName: string; const ASourceLines: TStringList;
-      const AContentProvider: TGocciaModuleContentProvider); overload;
+      const AModuleLoader: TGocciaModuleLoader); overload;
     destructor Destroy; override;
     function Execute(const AProgram: TGocciaProgram): TGocciaValue;
     function LoadModule(const AModulePath, AImportingFilePath: string): TGocciaModule;
     procedure CheckForModuleReload(const AModule: TGocciaModule);
 
     property GlobalScope: TGocciaGlobalScope read FGlobalScope;
-    property JSXEnabled: Boolean read FJSXEnabled write FJSXEnabled;
-    property ContentProvider: TGocciaModuleContentProvider read FContentProvider;
-    property Resolver: TGocciaModuleResolver read FResolver write FResolver;
-    property GlobalModules: TOrderedStringMap<TGocciaModule> read FGlobalModules;
+    property JSXEnabled: Boolean read FJSXEnabled write SetJSXEnabled;
+    property ContentProvider: TGocciaModuleContentProvider read GetContentProvider;
+    property ModuleLoader: TGocciaModuleLoader read FModuleLoader;
+    property Resolver: TGocciaModuleResolver read GetResolver write SetResolver;
+    property GlobalModules: TOrderedStringMap<TGocciaModule> read GetGlobalModules;
   end;
 
 
 implementation
 
 uses
-  GarbageCollector.Generic,
-
-  Goccia.FileExtensions,
-  Goccia.JSON,
-  Goccia.JSX.SourceMap,
-  Goccia.JSX.Transformer;
+  GarbageCollector.Generic;
 
 { TGocciaInterpreter }
 
@@ -89,35 +83,30 @@ end;
 
 constructor TGocciaInterpreter.Create(const AFileName: string;
   const ASourceLines: TStringList;
-  const AContentProvider: TGocciaModuleContentProvider);
+  const AModuleLoader: TGocciaModuleLoader);
 begin
   FFileName := AFileName;
   FSourceLines := ASourceLines;
   FGlobalScope := TGocciaGlobalScope.Create;
-  FModules := TOrderedStringMap<TGocciaModule>.Create;
-  FLoadingModules := TOrderedStringMap<Boolean>.Create;
-  FGlobalModules := TOrderedStringMap<TGocciaModule>.Create;
-  if Assigned(AContentProvider) then
+  if Assigned(AModuleLoader) then
   begin
-    FContentProvider := AContentProvider;
-    FOwnsContentProvider := False;
+    FModuleLoader := AModuleLoader;
+    FOwnsModuleLoader := False;
   end
   else
   begin
-    FContentProvider := TGocciaFileSystemModuleContentProvider.Create;
-    FOwnsContentProvider := True;
+    FModuleLoader := TGocciaModuleLoader.Create(AFileName);
+    FOwnsModuleLoader := True;
   end;
+  FModuleLoader.BindRuntime(FGlobalScope, ThrowError);
 end;
 
 destructor TGocciaInterpreter.Destroy;
 begin
   if not Assigned(TGarbageCollector.Instance) then
     FGlobalScope.Free;
-  FModules.Free;
-  FLoadingModules.Free;
-  FGlobalModules.Free;
-  if FOwnsContentProvider then
-    FContentProvider.Free;
+  if FOwnsModuleLoader then
+    FModuleLoader.Free;
 
   inherited;
 end;
@@ -149,220 +138,42 @@ begin
 end;
 
 function TGocciaInterpreter.LoadModule(const AModulePath, AImportingFilePath: string): TGocciaModule;
-var
-  ResolvedPath: string;
-  Content: TGocciaModuleContent;
-  SourceText: string;
-  JSXResult: TGocciaJSXTransformResult;
-  JSXSourceMap: TGocciaSourceMap;
-  OrigLine, OrigCol: Integer;
-  Lexer: TGocciaLexer;
-  Parser: TGocciaParser;
-  ProgramNode: TGocciaProgram;
-  Module: TGocciaModule;
-  ModuleScope: TGocciaScope;
-  I: Integer;
-  Stmt: TGocciaStatement;
-  ExportDecl: TGocciaExportDeclaration;
-  ExportVarDecl: TGocciaExportVariableDeclaration;
-  ReExportDecl: TGocciaReExportDeclaration;
-  ExportPair: TStringStringMap.TKeyValuePair;
-  Value: TGocciaValue;
-  Context: TGocciaEvaluationContext;
-  SourceModule: TGocciaModule;
-  VarInfo: TGocciaVariableInfo;
 begin
-  if FGlobalModules.TryGetValue(AModulePath, Result) then
-    Exit;
-
-  try
-    if Assigned(FResolver) then
-      ResolvedPath := FResolver.Resolve(AModulePath, AImportingFilePath)
-    else
-      raise EGocciaModuleNotFound.CreateFmt(
-        'No module resolver configured and cannot resolve "%s"', [AModulePath]);
-  except
-    on E: TGocciaRuntimeError do
-      raise;
-    on E: Exception do
-      raise TGocciaRuntimeError.Create(E.Message, 0, 0, AImportingFilePath, nil);
-  end;
-
-  if FModules.TryGetValue(ResolvedPath, Result) then
-  begin
-    if not FLoadingModules.ContainsKey(ResolvedPath) then
-      CheckForModuleReload(Result);
-    Exit;
-  end;
-
-  if LowerCase(ExtractFileExt(ResolvedPath)) = EXT_JSON then
-  begin
-    Result := LoadJsonModule(ResolvedPath);
-    Exit;
-  end;
-
-  Content := FContentProvider.LoadContent(ResolvedPath);
-  try
-    SourceText := Content.Text;
-    JSXSourceMap := nil;
-    if FJSXEnabled then
-    begin
-      JSXResult := TGocciaJSXTransformer.Transform(SourceText);
-      SourceText := JSXResult.Source;
-      JSXSourceMap := JSXResult.SourceMap;
-      if Assigned(JSXSourceMap) then
-        WarnIfJSXExtensionMismatch(ResolvedPath);
-    end;
-
-    try
-      try
-        Lexer := TGocciaLexer.Create(SourceText, ResolvedPath);
-        try
-          Parser := TGocciaParser.Create(Lexer.ScanTokens, ResolvedPath, Lexer.SourceLines);
-          try
-            ProgramNode := Parser.Parse;
-            try
-              Module := TGocciaModule.Create(ResolvedPath);
-              Module.LastModified := Content.LastModified;
-              FModules.Add(ResolvedPath, Module);
-              FLoadingModules.Add(ResolvedPath, True);
-              try
-                ModuleScope := FGlobalScope.CreateChild(skModule, 'Module:' + ResolvedPath);
-                Context.Scope := ModuleScope;
-                Context.OnError := ThrowError;
-                Context.LoadModule := LoadModule;
-                Context.CurrentFilePath := ResolvedPath;
-
-                for I := 0 to ProgramNode.Body.Count - 1 do
-                  EvaluateStatement(ProgramNode.Body[I], Context);  // .Value discarded at module level
-
-                for I := 0 to ProgramNode.Body.Count - 1 do
-                begin
-                  Stmt := ProgramNode.Body[I];
-
-                  if Stmt is TGocciaExportDeclaration then
-                  begin
-                    ExportDecl := TGocciaExportDeclaration(Stmt);
-                    for ExportPair in ExportDecl.ExportsTable do
-                    begin
-                      Value := ModuleScope.GetValue(ExportPair.Value);
-                      if Assigned(Value) then
-                        Module.ExportsTable.AddOrSetValue(ExportPair.Key, Value);
-                    end;
-                  end
-                  else if Stmt is TGocciaExportVariableDeclaration then
-                  begin
-                    ExportVarDecl := TGocciaExportVariableDeclaration(Stmt);
-                    for VarInfo in ExportVarDecl.Declaration.Variables do
-                    begin
-                      Value := ModuleScope.GetValue(VarInfo.Name);
-                      if Assigned(Value) then
-                        Module.ExportsTable.AddOrSetValue(VarInfo.Name, Value);
-                    end;
-                  end
-                  else if Stmt is TGocciaExportEnumDeclaration then
-                  begin
-                    Value := ModuleScope.GetValue(TGocciaExportEnumDeclaration(Stmt).Declaration.Name);
-                    if Assigned(Value) then
-                      Module.ExportsTable.AddOrSetValue(TGocciaExportEnumDeclaration(Stmt).Declaration.Name, Value);
-                  end
-                  else if Stmt is TGocciaReExportDeclaration then
-                  begin
-                    ReExportDecl := TGocciaReExportDeclaration(Stmt);
-                    SourceModule := LoadModule(ReExportDecl.ModulePath, ResolvedPath);
-                    for ExportPair in ReExportDecl.ExportsTable do
-                    begin
-                      if SourceModule.ExportsTable.TryGetValue(ExportPair.Value, Value) then
-                        Module.ExportsTable.AddOrSetValue(ExportPair.Key, Value);
-                    end;
-                  end;
-                end;
-
-                Result := Module;
-              finally
-                FLoadingModules.Remove(ResolvedPath);
-              end;
-            finally
-              ProgramNode.Free;
-            end;
-          finally
-            Parser.Free;
-          end;
-        finally
-          Lexer.Free;
-        end;
-      except
-        on E: TGocciaError do
-        begin
-          if Assigned(JSXSourceMap) and
-             JSXSourceMap.Translate(E.Line, E.Column, OrigLine, OrigCol) then
-            E.TranslatePosition(OrigLine, OrigCol, Content.SourceLines);
-          raise;
-        end;
-      end;
-    finally
-      JSXSourceMap.Free;
-    end;
-  finally
-    Content.Free;
-  end;
+  Result := FModuleLoader.LoadModule(AModulePath, AImportingFilePath);
 end;
 
 procedure TGocciaInterpreter.CheckForModuleReload(const AModule: TGocciaModule);
-var
-  CurrentModified: TDateTime;
 begin
-  if not FContentProvider.TryGetLastModified(AModule.Path, CurrentModified) then
-    Exit;
-
-  if CurrentModified > AModule.LastModified then
-  begin
-    AModule.ExportsTable.Clear;
-    AModule.LastModified := CurrentModified;
-    LoadModule(AModule.Path, AModule.Path);
-  end;
+  FModuleLoader.CheckForModuleReload(AModule);
 end;
 
-function TGocciaInterpreter.LoadJsonModule(const AResolvedPath: string): TGocciaModule;
-var
-  Content: TGocciaModuleContent;
-  Parser: TGocciaJSONParser;
-  ParsedValue: TGocciaValue;
-  Obj: TGocciaObjectValue;
-  Key: string;
-  Module: TGocciaModule;
+function TGocciaInterpreter.GetContentProvider: TGocciaModuleContentProvider;
 begin
-  Content := FContentProvider.LoadContent(AResolvedPath);
-  try
-    Parser := TGocciaJSONParser.Create;
-    try
-      try
-        ParsedValue := Parser.Parse(Content.Text);
-      except
-        on E: EGocciaJSONParseError do
-          raise TGocciaRuntimeError.Create(
-            Format('Failed to parse JSON module "%s": %s', [AResolvedPath, E.Message]),
-            0, 0, AResolvedPath, nil);
-      end;
+  Result := FModuleLoader.ContentProvider;
+end;
 
-      Module := TGocciaModule.Create(AResolvedPath);
-      Module.LastModified := Content.LastModified;
+function TGocciaInterpreter.GetGlobalModules: TOrderedStringMap<TGocciaModule>;
+begin
+  Result := FModuleLoader.GlobalModules;
+end;
 
-      if ParsedValue is TGocciaObjectValue then
-      begin
-        Obj := TGocciaObjectValue(ParsedValue);
-        for Key in Obj.GetOwnPropertyKeys do
-          Module.ExportsTable.AddOrSetValue(Key, Obj.GetProperty(Key));
-      end;
+function TGocciaInterpreter.GetResolver: TGocciaModuleResolver;
+begin
+  Result := FModuleLoader.Resolver;
+end;
 
-      FModules.Add(AResolvedPath, Module);
-      Result := Module;
-    finally
-      Parser.Free;
-    end;
-  finally
-    Content.Free;
-  end;
+procedure TGocciaInterpreter.SetJSXEnabled(const AValue: Boolean);
+begin
+  FJSXEnabled := AValue;
+  FModuleLoader.JSXEnabled := AValue;
+end;
+
+procedure TGocciaInterpreter.SetResolver(const AValue: TGocciaModuleResolver);
+begin
+  if Assigned(AValue) and (AValue <> FModuleLoader.Resolver) then
+    raise Exception.Create(
+      'TGocciaInterpreter resolver is owned by the module loader. ' +
+      'Create the interpreter with a configured TGocciaModuleLoader instead.');
 end;
 
 procedure TGocciaInterpreter.ThrowError(const AMessage: string; const ALine, AColumn: Integer);

--- a/units/Goccia.Modules.ContentProvider.Test.pas
+++ b/units/Goccia.Modules.ContentProvider.Test.pas
@@ -17,6 +17,7 @@ uses
   Goccia.Interpreter,
   Goccia.Lexer,
   Goccia.Modules.ContentProvider,
+  Goccia.Modules.Loader,
   Goccia.Modules.Resolver,
   Goccia.Parser,
   Goccia.TestSetup,
@@ -233,6 +234,7 @@ const
   MODULE_PATH = 'memory:/dep.js';
 var
   Engine: TGocciaEngine;
+  ModuleLoader: TGocciaModuleLoader;
   Provider: TMemoryModuleContentProvider;
   Resolver: TInMemoryModuleResolver;
   Source: TStringList;
@@ -246,12 +248,17 @@ begin
     Source.Text := 'import { value } from "' + MODULE_PATH + '";' + LineEnding +
       'value;';
 
-    Engine := TGocciaEngine.Create(ENTRY_PATH, Source,
-      TGocciaEngine.DefaultGlobals, Resolver, Provider);
+    ModuleLoader := TGocciaModuleLoader.Create(ENTRY_PATH, Resolver, Provider);
     try
-      ScriptResult := Engine.Execute;
+      Engine := TGocciaEngine.Create(ENTRY_PATH, Source,
+        TGocciaEngine.DefaultGlobals, ModuleLoader);
+      try
+        ScriptResult := Engine.Execute;
+      finally
+        Engine.Free;
+      end;
     finally
-      Engine.Free;
+      ModuleLoader.Free;
     end;
 
     Expect<Boolean>(ScriptResult.Result is TGocciaNumberLiteralValue).ToBe(True);
@@ -266,6 +273,7 @@ end;
 procedure TModuleContentProviderTests.TestBytecodeBackendUsesInjectedContentProvider;
 var
   Backend: TGocciaBytecodeBackend;
+  ModuleLoader: TGocciaModuleLoader;
   Module: TGocciaBytecodeModule;
   ProgramNode: TGocciaProgram;
   Provider: TMemoryModuleContentProvider;
@@ -283,27 +291,32 @@ begin
   Provider := TMemoryModuleContentProvider.Create;
   Provider.AddModule(DepPath, 'export const value = 42;');
 
-  Backend := TGocciaBytecodeBackend.Create(EntryPath, Provider);
+  ModuleLoader := TGocciaModuleLoader.Create(EntryPath, nil, Provider);
   try
-    Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
-    ProgramNode := CreateProgram(
-      'import { value } from "./dep.js";' + LineEnding + 'value;',
-      EntryPath);
+    Backend := TGocciaBytecodeBackend.Create(EntryPath, ModuleLoader);
     try
-      Module := Backend.CompileToModule(ProgramNode);
-    finally
-      ProgramNode.Free;
-    end;
+      Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
+      ProgramNode := CreateProgram(
+        'import { value } from "./dep.js";' + LineEnding + 'value;',
+        EntryPath);
+      try
+        Module := Backend.CompileToModule(ProgramNode);
+      finally
+        ProgramNode.Free;
+      end;
 
-    try
-      ResultValue := Backend.RunModule(Module);
-      Expect<Boolean>(ResultValue is TGocciaNumberLiteralValue).ToBe(True);
-      Expect<Double>(TGocciaNumberLiteralValue(ResultValue).Value).ToBe(42);
+      try
+        ResultValue := Backend.RunModule(Module);
+        Expect<Boolean>(ResultValue is TGocciaNumberLiteralValue).ToBe(True);
+        Expect<Double>(TGocciaNumberLiteralValue(ResultValue).Value).ToBe(42);
+      finally
+        Module.Free;
+      end;
     finally
-      Module.Free;
+      Backend.Free;
     end;
   finally
-    Backend.Free;
+    ModuleLoader.Free;
     Provider.Free;
   end;
 end;

--- a/units/Goccia.Modules.ContentProvider.Test.pas
+++ b/units/Goccia.Modules.ContentProvider.Test.pas
@@ -1,0 +1,316 @@
+program Goccia.Modules.ContentProvider.Test;
+
+{$I Goccia.inc}
+
+uses
+  Classes,
+  Generics.Collections,
+  SysUtils,
+
+  OrderedStringMap,
+  TestRunner,
+
+  Goccia.AST.Node,
+  Goccia.Bytecode.Module,
+  Goccia.Engine,
+  Goccia.Engine.Backend,
+  Goccia.Interpreter,
+  Goccia.Lexer,
+  Goccia.Modules.ContentProvider,
+  Goccia.Modules.Resolver,
+  Goccia.Parser,
+  Goccia.TestSetup,
+  Goccia.Token,
+  Goccia.Values.Primitives;
+
+type
+  TInMemoryModuleResolver = class(TGocciaModuleResolver)
+  public
+    function Resolve(const AModulePath, AImportingFilePath: string): string; override;
+  end;
+
+  TMemoryModuleEntry = record
+    HasLastModified: Boolean;
+    LastModified: TDateTime;
+    Text: string;
+  end;
+
+  TMemoryModuleContentProvider = class(TGocciaModuleContentProvider)
+  private
+    FEntries: TOrderedStringMap<TMemoryModuleEntry>;
+  public
+    constructor Create;
+    destructor Destroy; override;
+
+    procedure AddModule(const APath, AText: string);
+    function Exists(const APath: string): Boolean; override;
+    function LoadContent(const APath: string): TGocciaModuleContent; override;
+    function TryGetLastModified(const APath: string;
+      out ALastModified: TDateTime): Boolean; override;
+  end;
+
+  TModuleContentProviderTests = class(TTestSuite)
+  private
+    FTempDirectories: TStringList;
+
+    function CreateProgram(const ASource, AFileName: string): TGocciaProgram;
+    function CreateTempDirectory: string;
+    procedure DeleteDirectoryTree(const APath: string);
+    procedure WriteTextFile(const APath, AText: string);
+
+    procedure TestEngineLoadsInMemoryModuleWithCustomProvider;
+    procedure TestBytecodeBackendUsesInjectedContentProvider;
+  protected
+    procedure BeforeAll; override;
+    procedure AfterAll; override;
+  public
+    procedure SetupTests; override;
+  end;
+
+function TInMemoryModuleResolver.Resolve(const AModulePath,
+  AImportingFilePath: string): string;
+begin
+  Result := AModulePath;
+end;
+
+constructor TMemoryModuleContentProvider.Create;
+begin
+  inherited Create;
+  FEntries := TOrderedStringMap<TMemoryModuleEntry>.Create;
+end;
+
+destructor TMemoryModuleContentProvider.Destroy;
+begin
+  FEntries.Free;
+  inherited;
+end;
+
+procedure TMemoryModuleContentProvider.AddModule(const APath, AText: string);
+var
+  Entry: TMemoryModuleEntry;
+begin
+  Entry.Text := AText;
+  Entry.HasLastModified := False;
+  Entry.LastModified := 0;
+  FEntries.AddOrSetValue(APath, Entry);
+end;
+
+function TMemoryModuleContentProvider.Exists(const APath: string): Boolean;
+var
+  Entry: TMemoryModuleEntry;
+begin
+  Result := FEntries.TryGetValue(APath, Entry);
+end;
+
+function TMemoryModuleContentProvider.LoadContent(
+  const APath: string): TGocciaModuleContent;
+var
+  Entry: TMemoryModuleEntry;
+begin
+  if not FEntries.TryGetValue(APath, Entry) then
+    raise Exception.Create('Module content not found: ' + APath);
+
+  Result := TGocciaModuleContent.Create(Entry.Text, Entry.LastModified);
+end;
+
+function TMemoryModuleContentProvider.TryGetLastModified(const APath: string;
+  out ALastModified: TDateTime): Boolean;
+var
+  Entry: TMemoryModuleEntry;
+begin
+  Result := FEntries.TryGetValue(APath, Entry) and Entry.HasLastModified;
+  if Result then
+    ALastModified := Entry.LastModified
+  else
+    ALastModified := 0;
+end;
+
+procedure TModuleContentProviderTests.SetupTests;
+begin
+  Test('Engine loads in-memory module with custom provider',
+    TestEngineLoadsInMemoryModuleWithCustomProvider);
+  Test('Bytecode backend uses injected content provider',
+    TestBytecodeBackendUsesInjectedContentProvider);
+end;
+
+procedure TModuleContentProviderTests.BeforeAll;
+begin
+  inherited BeforeAll;
+  Randomize;
+  FTempDirectories := TStringList.Create;
+end;
+
+procedure TModuleContentProviderTests.AfterAll;
+var
+  I: Integer;
+begin
+  for I := 0 to FTempDirectories.Count - 1 do
+    DeleteDirectoryTree(FTempDirectories[I]);
+  FTempDirectories.Free;
+  inherited AfterAll;
+end;
+
+function TModuleContentProviderTests.CreateProgram(const ASource,
+  AFileName: string): TGocciaProgram;
+var
+  Lexer: TGocciaLexer;
+  Parser: TGocciaParser;
+  SourceLines: TStringList;
+  Tokens: TObjectList<TGocciaToken>;
+begin
+  Lexer := TGocciaLexer.Create(ASource, AFileName);
+  try
+    Tokens := Lexer.ScanTokens;
+    SourceLines := TStringList.Create;
+    try
+      SourceLines.Text := ASource;
+      Parser := TGocciaParser.Create(Tokens, AFileName, SourceLines);
+      try
+        Result := Parser.Parse;
+      finally
+        Parser.Free;
+      end;
+    finally
+      SourceLines.Free;
+    end;
+  finally
+    Lexer.Free;
+  end;
+end;
+
+function TModuleContentProviderTests.CreateTempDirectory: string;
+begin
+  Result := IncludeTrailingPathDelimiter(GetTempDir(False)) +
+    'goccia-content-provider-' + IntToStr(Random(MaxInt));
+  ForceDirectories(Result);
+  FTempDirectories.Add(Result);
+end;
+
+procedure TModuleContentProviderTests.DeleteDirectoryTree(const APath: string);
+var
+  EntryPath: string;
+  SearchRec: TSearchRec;
+begin
+  if not DirectoryExists(APath) then
+    Exit;
+
+  if FindFirst(IncludeTrailingPathDelimiter(APath) + '*', faAnyFile,
+    SearchRec) = 0 then
+  begin
+    repeat
+      if (SearchRec.Name = '.') or (SearchRec.Name = '..') then
+        Continue;
+
+      EntryPath := IncludeTrailingPathDelimiter(APath) + SearchRec.Name;
+      if (SearchRec.Attr and faDirectory) = faDirectory then
+        DeleteDirectoryTree(EntryPath)
+      else
+        DeleteFile(EntryPath);
+    until FindNext(SearchRec) <> 0;
+    FindClose(SearchRec);
+  end;
+
+  RemoveDir(APath);
+end;
+
+procedure TModuleContentProviderTests.WriteTextFile(const APath, AText: string);
+var
+  Source: TStringList;
+begin
+  ForceDirectories(ExtractFileDir(APath));
+  Source := TStringList.Create;
+  try
+    Source.Text := AText;
+    Source.SaveToFile(APath);
+  finally
+    Source.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestEngineLoadsInMemoryModuleWithCustomProvider;
+const
+  ENTRY_PATH = 'memory:/app.js';
+  MODULE_PATH = 'memory:/dep.js';
+var
+  Engine: TGocciaEngine;
+  Provider: TMemoryModuleContentProvider;
+  Resolver: TInMemoryModuleResolver;
+  Source: TStringList;
+  ScriptResult: TGocciaScriptResult;
+begin
+  Provider := TMemoryModuleContentProvider.Create;
+  Resolver := TInMemoryModuleResolver.Create;
+  Source := TStringList.Create;
+  try
+    Provider.AddModule(MODULE_PATH, 'export const value = 42;');
+    Source.Text := 'import { value } from "' + MODULE_PATH + '";' + LineEnding +
+      'value;';
+
+    Engine := TGocciaEngine.Create(ENTRY_PATH, Source,
+      TGocciaEngine.DefaultGlobals, Resolver, Provider);
+    try
+      ScriptResult := Engine.Execute;
+    finally
+      Engine.Free;
+    end;
+
+    Expect<Boolean>(ScriptResult.Result is TGocciaNumberLiteralValue).ToBe(True);
+    Expect<Double>(TGocciaNumberLiteralValue(ScriptResult.Result).Value).ToBe(42);
+  finally
+    Source.Free;
+    Resolver.Free;
+    Provider.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestBytecodeBackendUsesInjectedContentProvider;
+var
+  Backend: TGocciaBytecodeBackend;
+  Module: TGocciaBytecodeModule;
+  ProgramNode: TGocciaProgram;
+  Provider: TMemoryModuleContentProvider;
+  ResultValue: TGocciaValue;
+  TempDirectory: string;
+  DepPath: string;
+  EntryPath: string;
+begin
+  TempDirectory := CreateTempDirectory;
+  EntryPath := IncludeTrailingPathDelimiter(TempDirectory) + 'app.js';
+  DepPath := IncludeTrailingPathDelimiter(TempDirectory) + 'dep.js';
+
+  WriteTextFile(DepPath, 'export const value = 7;');
+
+  Provider := TMemoryModuleContentProvider.Create;
+  Provider.AddModule(DepPath, 'export const value = 42;');
+
+  Backend := TGocciaBytecodeBackend.Create(EntryPath, Provider);
+  try
+    Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
+    ProgramNode := CreateProgram(
+      'import { value } from "./dep.js";' + LineEnding + 'value;',
+      EntryPath);
+    try
+      Module := Backend.CompileToModule(ProgramNode);
+    finally
+      ProgramNode.Free;
+    end;
+
+    try
+      ResultValue := Backend.RunModule(Module);
+      Expect<Boolean>(ResultValue is TGocciaNumberLiteralValue).ToBe(True);
+      Expect<Double>(TGocciaNumberLiteralValue(ResultValue).Value).ToBe(42);
+    finally
+      Module.Free;
+    end;
+  finally
+    Backend.Free;
+    Provider.Free;
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(
+    TModuleContentProviderTests.Create('Module Content Provider'));
+  TestRunnerProgram.Run;
+  ExitCode := TestResultToExitCode;
+end.

--- a/units/Goccia.Modules.ContentProvider.Test.pas
+++ b/units/Goccia.Modules.ContentProvider.Test.pas
@@ -16,6 +16,7 @@ uses
   Goccia.Engine.Backend,
   Goccia.Interpreter,
   Goccia.Lexer,
+  Goccia.Modules,
   Goccia.Modules.ContentProvider,
   Goccia.Modules.Loader,
   Goccia.Modules.Resolver,
@@ -44,6 +45,8 @@ type
     destructor Destroy; override;
 
     procedure AddModule(const APath, AText: string);
+    procedure SetModule(const APath, AText: string;
+      const ALastModified: TDateTime; const AHasLastModified: Boolean = True);
     function Exists(const APath: string): Boolean; override;
     function LoadContent(const APath: string): TGocciaModuleContent; override;
     function TryGetLastModified(const APath: string;
@@ -60,6 +63,9 @@ type
     procedure WriteTextFile(const APath, AText: string);
 
     procedure TestEngineLoadsInMemoryModuleWithCustomProvider;
+    procedure TestEngineReloadsModifiedInMemoryModule;
+    procedure TestEngineRetriesModuleAfterFailedLoad;
+    procedure TestModuleLoaderRejectsRebindingAcrossRuntimes;
     procedure TestBytecodeBackendUsesInjectedContentProvider;
   protected
     procedure BeforeAll; override;
@@ -87,12 +93,18 @@ begin
 end;
 
 procedure TMemoryModuleContentProvider.AddModule(const APath, AText: string);
+begin
+  SetModule(APath, AText, 0, False);
+end;
+
+procedure TMemoryModuleContentProvider.SetModule(const APath, AText: string;
+  const ALastModified: TDateTime; const AHasLastModified: Boolean);
 var
   Entry: TMemoryModuleEntry;
 begin
   Entry.Text := AText;
-  Entry.HasLastModified := False;
-  Entry.LastModified := 0;
+  Entry.HasLastModified := AHasLastModified;
+  Entry.LastModified := ALastModified;
   FEntries.AddOrSetValue(APath, Entry);
 end;
 
@@ -130,6 +142,12 @@ procedure TModuleContentProviderTests.SetupTests;
 begin
   Test('Engine loads in-memory module with custom provider',
     TestEngineLoadsInMemoryModuleWithCustomProvider);
+  Test('Engine reloads modified in-memory module',
+    TestEngineReloadsModifiedInMemoryModule);
+  Test('Engine retries module load after previous failure',
+    TestEngineRetriesModuleAfterFailedLoad);
+  Test('Module loader rejects rebinding across runtimes',
+    TestModuleLoaderRejectsRebindingAcrossRuntimes);
   Test('Bytecode backend uses injected content provider',
     TestBytecodeBackendUsesInjectedContentProvider);
 end;
@@ -317,6 +335,158 @@ begin
     end;
   finally
     ModuleLoader.Free;
+    Provider.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestEngineReloadsModifiedInMemoryModule;
+const
+  ENTRY_PATH = 'memory:/app.js';
+  MODULE_PATH = 'memory:/dep.js';
+var
+  Interpreter: TGocciaInterpreter;
+  ModuleLoader: TGocciaModuleLoader;
+  ModuleValue: TGocciaModule;
+  Provider: TMemoryModuleContentProvider;
+  Resolver: TInMemoryModuleResolver;
+  Source: TStringList;
+begin
+  Provider := TMemoryModuleContentProvider.Create;
+  Resolver := TInMemoryModuleResolver.Create;
+  Source := TStringList.Create;
+  try
+    Provider.SetModule(MODULE_PATH, 'export const value = 1;', 1);
+    Source.Text := 'import { value } from "' + MODULE_PATH + '";' + LineEnding +
+      'value;';
+
+    ModuleLoader := TGocciaModuleLoader.Create(ENTRY_PATH, Resolver, Provider);
+    try
+      Interpreter := TGocciaInterpreter.Create(ENTRY_PATH, Source, ModuleLoader);
+      try
+        ModuleValue := Interpreter.LoadModule(MODULE_PATH, ENTRY_PATH);
+        Expect<Boolean>(ModuleValue.ExportsTable['value'] is TGocciaNumberLiteralValue).ToBe(True);
+        Expect<Double>(TGocciaNumberLiteralValue(ModuleValue.ExportsTable['value']).Value).ToBe(1);
+
+        Provider.SetModule(MODULE_PATH, 'export const value = 2;', 2);
+        ModuleValue := Interpreter.LoadModule(MODULE_PATH, ENTRY_PATH);
+        Expect<Boolean>(ModuleValue.ExportsTable['value'] is TGocciaNumberLiteralValue).ToBe(True);
+        Expect<Double>(TGocciaNumberLiteralValue(ModuleValue.ExportsTable['value']).Value).ToBe(2);
+      finally
+        Interpreter.Free;
+      end;
+    finally
+      ModuleLoader.Free;
+    end;
+  finally
+    Source.Free;
+    Resolver.Free;
+    Provider.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestEngineRetriesModuleAfterFailedLoad;
+const
+  ENTRY_PATH = 'memory:/app.js';
+  MODULE_PATH = 'memory:/dep.js';
+var
+  Engine: TGocciaEngine;
+  ModuleLoader: TGocciaModuleLoader;
+  Provider: TMemoryModuleContentProvider;
+  Resolver: TInMemoryModuleResolver;
+  ScriptResult: TGocciaScriptResult;
+  Source: TStringList;
+begin
+  Provider := TMemoryModuleContentProvider.Create;
+  Resolver := TInMemoryModuleResolver.Create;
+  Source := TStringList.Create;
+  try
+    Provider.AddModule(MODULE_PATH, 'export const value = ;');
+    Source.Text := 'import { value } from "' + MODULE_PATH + '";' + LineEnding +
+      'value;';
+
+    ModuleLoader := TGocciaModuleLoader.Create(ENTRY_PATH, Resolver, Provider);
+    try
+      Engine := TGocciaEngine.Create(ENTRY_PATH, Source,
+        TGocciaEngine.DefaultGlobals, ModuleLoader);
+      try
+        try
+          Engine.Execute;
+          Fail('Expected invalid module source to raise an exception.');
+        except
+          on E: Exception do
+          begin
+            // Expected parse failure; retry after fixing the module source.
+          end;
+        end;
+
+        Provider.AddModule(MODULE_PATH, 'export const value = 42;');
+        ScriptResult := Engine.Execute;
+        Expect<Boolean>(ScriptResult.Result is TGocciaNumberLiteralValue).ToBe(True);
+        Expect<Double>(TGocciaNumberLiteralValue(ScriptResult.Result).Value).ToBe(42);
+      finally
+        Engine.Free;
+      end;
+    finally
+      ModuleLoader.Free;
+    end;
+  finally
+    Source.Free;
+    Resolver.Free;
+    Provider.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestModuleLoaderRejectsRebindingAcrossRuntimes;
+const
+  ENTRY_PATH = 'memory:/app.js';
+var
+  EngineA: TGocciaEngine;
+  EngineB: TGocciaEngine;
+  RaisedExpected: Boolean;
+  HasExpectedMessage: Boolean;
+  ModuleLoader: TGocciaModuleLoader;
+  Provider: TMemoryModuleContentProvider;
+  Resolver: TInMemoryModuleResolver;
+  SourceA: TStringList;
+  SourceB: TStringList;
+begin
+  Provider := TMemoryModuleContentProvider.Create;
+  Resolver := TInMemoryModuleResolver.Create;
+  ModuleLoader := TGocciaModuleLoader.Create(ENTRY_PATH, Resolver, Provider);
+  SourceA := TStringList.Create;
+  SourceB := TStringList.Create;
+  EngineB := nil;
+  RaisedExpected := False;
+  try
+    SourceA.Text := '1;';
+    SourceB.Text := '2;';
+    EngineA := TGocciaEngine.Create(ENTRY_PATH, SourceA,
+      TGocciaEngine.DefaultGlobals, ModuleLoader);
+    try
+      try
+        EngineB := TGocciaEngine.Create(ENTRY_PATH, SourceB,
+          TGocciaEngine.DefaultGlobals, ModuleLoader);
+        Fail('Expected module loader rebinding to raise an exception.');
+      except
+        on E: Exception do
+        begin
+          RaisedExpected := True;
+          HasExpectedMessage := Pos('single-runtime', E.Message) > 0;
+          if not HasExpectedMessage then
+            Fail('Expected single-runtime error message.');
+        end;
+      end;
+      Expect<Boolean>(RaisedExpected).ToBe(True);
+    finally
+      EngineA.Free;
+      if Assigned(EngineB) then
+        EngineB.Free;
+    end;
+  finally
+    SourceA.Free;
+    SourceB.Free;
+    ModuleLoader.Free;
+    Resolver.Free;
     Provider.Free;
   end;
 end;

--- a/units/Goccia.Modules.ContentProvider.pas
+++ b/units/Goccia.Modules.ContentProvider.pas
@@ -1,0 +1,110 @@
+unit Goccia.Modules.ContentProvider;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Classes,
+  SysUtils;
+
+type
+  TGocciaModuleContent = class
+  private
+    FLastModified: TDateTime;
+    FSourceLines: TStringList;
+    function GetText: string;
+  public
+    constructor Create(const AText: string; const ALastModified: TDateTime);
+    destructor Destroy; override;
+
+    property LastModified: TDateTime read FLastModified;
+    property SourceLines: TStringList read FSourceLines;
+    property Text: string read GetText;
+  end;
+
+  TGocciaModuleContentProvider = class
+  public
+    function Exists(const APath: string): Boolean; virtual; abstract;
+    function LoadContent(const APath: string): TGocciaModuleContent; virtual; abstract;
+    function TryGetLastModified(const APath: string;
+      out ALastModified: TDateTime): Boolean; virtual; abstract;
+  end;
+
+  TGocciaFileSystemModuleContentProvider = class(TGocciaModuleContentProvider)
+  public
+    function Exists(const APath: string): Boolean; override;
+    function LoadContent(const APath: string): TGocciaModuleContent; override;
+    function TryGetLastModified(const APath: string;
+      out ALastModified: TDateTime): Boolean; override;
+  end;
+
+implementation
+
+function TryGetFileLastModified(const APath: string;
+  out ALastModified: TDateTime): Boolean;
+var
+  FileAgeValue: LongInt;
+begin
+  FileAgeValue := FileAge(APath);
+  Result := FileAgeValue <> -1;
+  if Result then
+    ALastModified := FileDateToDateTime(FileAgeValue)
+  else
+    ALastModified := 0;
+end;
+
+{ TGocciaModuleContent }
+
+constructor TGocciaModuleContent.Create(const AText: string;
+  const ALastModified: TDateTime);
+begin
+  inherited Create;
+  FLastModified := ALastModified;
+  FSourceLines := TStringList.Create;
+  FSourceLines.Text := AText;
+end;
+
+destructor TGocciaModuleContent.Destroy;
+begin
+  FSourceLines.Free;
+  inherited;
+end;
+
+function TGocciaModuleContent.GetText: string;
+begin
+  Result := FSourceLines.Text;
+end;
+
+{ TGocciaFileSystemModuleContentProvider }
+
+function TGocciaFileSystemModuleContentProvider.Exists(
+  const APath: string): Boolean;
+begin
+  Result := FileExists(APath);
+end;
+
+function TGocciaFileSystemModuleContentProvider.LoadContent(
+  const APath: string): TGocciaModuleContent;
+var
+  LastModified: TDateTime;
+  Source: TStringList;
+begin
+  Source := TStringList.Create;
+  try
+    Source.LoadFromFile(APath);
+    if not TryGetFileLastModified(APath, LastModified) then
+      LastModified := 0;
+    Result := TGocciaModuleContent.Create(Source.Text, LastModified);
+  finally
+    Source.Free;
+  end;
+end;
+
+function TGocciaFileSystemModuleContentProvider.TryGetLastModified(
+  const APath: string; out ALastModified: TDateTime): Boolean;
+begin
+  Result := TryGetFileLastModified(APath, ALastModified);
+end;
+
+end.

--- a/units/Goccia.Modules.Loader.pas
+++ b/units/Goccia.Modules.Loader.pas
@@ -30,6 +30,8 @@ type
     FOwnsResolver: Boolean;
     FResolver: TGocciaModuleResolver;
 
+    procedure CopyModuleContents(const ASourceModule,
+      ATargetModule: TGocciaModule);
     function LoadJsonModule(const AResolvedPath: string): TGocciaModule;
   public
     constructor Create(const AEntryFileName: string;
@@ -118,8 +120,22 @@ end;
 procedure TGocciaModuleLoader.BindRuntime(const AGlobalScope: TGocciaGlobalScope;
   const AOnError: TGocciaThrowErrorCallback);
 begin
+  if Assigned(FGlobalScope) and (FGlobalScope <> AGlobalScope) then
+    raise Exception.Create(
+      'TGocciaModuleLoader instances are single-runtime; create a new loader per engine/backend.');
   FGlobalScope := AGlobalScope;
   FOnError := AOnError;
+end;
+
+procedure TGocciaModuleLoader.CopyModuleContents(const ASourceModule,
+  ATargetModule: TGocciaModule);
+var
+  ExportPair: TGocciaValueMap.TKeyValuePair;
+begin
+  ATargetModule.ExportsTable.Clear;
+  for ExportPair in ASourceModule.ExportsTable do
+    ATargetModule.ExportsTable.AddOrSetValue(ExportPair.Key, ExportPair.Value);
+  ATargetModule.LastModified := ASourceModule.LastModified;
 end;
 
 function TGocciaModuleLoader.LoadModule(const AModulePath,
@@ -147,6 +163,7 @@ var
   Stmt: TGocciaStatement;
   Value: TGocciaValue;
   VarInfo: TGocciaVariableInfo;
+  LoadSucceeded: Boolean;
 begin
   if not Assigned(FGlobalScope) then
     raise Exception.Create('Module loader runtime is not bound.');
@@ -206,6 +223,7 @@ begin
               Module.LastModified := Content.LastModified;
               FModules.Add(ResolvedPath, Module);
               FLoadingModules.Add(ResolvedPath, True);
+              LoadSucceeded := False;
               try
                 ModuleScope := FGlobalScope.CreateChild(skModule,
                   'Module:' + ResolvedPath);
@@ -265,8 +283,14 @@ begin
                 end;
 
                 Result := Module;
+                LoadSucceeded := True;
               finally
                 FLoadingModules.Remove(ResolvedPath);
+                if not LoadSucceeded then
+                begin
+                  FModules.Remove(ResolvedPath);
+                  Module.Free;
+                end;
               end;
             finally
               ProgramNode.Free;
@@ -297,15 +321,31 @@ end;
 procedure TGocciaModuleLoader.CheckForModuleReload(const AModule: TGocciaModule);
 var
   CurrentModified: TDateTime;
+  ReloadedModule: TGocciaModule;
 begin
   if not FContentProvider.TryGetLastModified(AModule.Path, CurrentModified) then
     Exit;
 
   if CurrentModified > AModule.LastModified then
   begin
-    AModule.ExportsTable.Clear;
-    AModule.LastModified := CurrentModified;
-    LoadModule(AModule.Path, AModule.Path);
+    FModules.Remove(AModule.Path);
+    try
+      ReloadedModule := LoadModule(AModule.Path, AModule.Path);
+    except
+      FModules.AddOrSetValue(AModule.Path, AModule);
+      raise;
+    end;
+
+    if ReloadedModule <> AModule then
+    begin
+      try
+        CopyModuleContents(ReloadedModule, AModule);
+      finally
+        FModules.Remove(AModule.Path);
+        FModules.AddOrSetValue(AModule.Path, AModule);
+        ReloadedModule.Free;
+      end;
+    end;
   end;
 end;
 
@@ -318,6 +358,7 @@ var
   Obj: TGocciaObjectValue;
   ParsedValue: TGocciaValue;
   Parser: TGocciaJSONParser;
+  LoadSucceeded: Boolean;
 begin
   Content := FContentProvider.LoadContent(AResolvedPath);
   try
@@ -335,16 +376,22 @@ begin
 
       Module := TGocciaModule.Create(AResolvedPath);
       Module.LastModified := Content.LastModified;
+      LoadSucceeded := False;
+      try
+        if ParsedValue is TGocciaObjectValue then
+        begin
+          Obj := TGocciaObjectValue(ParsedValue);
+          for Key in Obj.GetOwnPropertyKeys do
+            Module.ExportsTable.AddOrSetValue(Key, Obj.GetProperty(Key));
+        end;
 
-      if ParsedValue is TGocciaObjectValue then
-      begin
-        Obj := TGocciaObjectValue(ParsedValue);
-        for Key in Obj.GetOwnPropertyKeys do
-          Module.ExportsTable.AddOrSetValue(Key, Obj.GetProperty(Key));
+        FModules.Add(AResolvedPath, Module);
+        Result := Module;
+        LoadSucceeded := True;
+      finally
+        if not LoadSucceeded then
+          Module.Free;
       end;
-
-      FModules.Add(AResolvedPath, Module);
-      Result := Module;
     finally
       Parser.Free;
     end;

--- a/units/Goccia.Modules.Loader.pas
+++ b/units/Goccia.Modules.Loader.pas
@@ -1,0 +1,356 @@
+unit Goccia.Modules.Loader;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  SysUtils,
+
+  OrderedStringMap,
+
+  Goccia.Error.ThrowErrorCallback,
+  Goccia.Modules,
+  Goccia.Modules.ContentProvider,
+  Goccia.Modules.Resolver,
+  Goccia.Scope;
+
+type
+  TGocciaModuleLoader = class
+  private
+    FContentProvider: TGocciaModuleContentProvider;
+    FEntryFileName: string;
+    FGlobalModules: TOrderedStringMap<TGocciaModule>;
+    FGlobalScope: TGocciaGlobalScope;
+    FJSXEnabled: Boolean;
+    FLoadingModules: TOrderedStringMap<Boolean>;
+    FModules: TOrderedStringMap<TGocciaModule>;
+    FOnError: TGocciaThrowErrorCallback;
+    FOwnsContentProvider: Boolean;
+    FOwnsResolver: Boolean;
+    FResolver: TGocciaModuleResolver;
+
+    function LoadJsonModule(const AResolvedPath: string): TGocciaModule;
+  public
+    constructor Create(const AEntryFileName: string;
+      const AResolver: TGocciaModuleResolver = nil;
+      const AContentProvider: TGocciaModuleContentProvider = nil);
+    destructor Destroy; override;
+
+    procedure BindRuntime(const AGlobalScope: TGocciaGlobalScope;
+      const AOnError: TGocciaThrowErrorCallback);
+    procedure CheckForModuleReload(const AModule: TGocciaModule);
+    function LoadModule(const AModulePath,
+      AImportingFilePath: string): TGocciaModule;
+
+    property ContentProvider: TGocciaModuleContentProvider
+      read FContentProvider;
+    property GlobalModules: TOrderedStringMap<TGocciaModule>
+      read FGlobalModules;
+    property JSXEnabled: Boolean read FJSXEnabled write FJSXEnabled;
+    property Resolver: TGocciaModuleResolver read FResolver;
+  end;
+
+implementation
+
+uses
+  Goccia.AST.Expressions,
+  Goccia.AST.Node,
+  Goccia.AST.Statements,
+  Goccia.Error,
+  Goccia.Evaluator,
+  Goccia.Evaluator.Context,
+  Goccia.FileExtensions,
+  Goccia.JSON,
+  Goccia.JSX.SourceMap,
+  Goccia.JSX.Transformer,
+  Goccia.Lexer,
+  Goccia.Parser,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+constructor TGocciaModuleLoader.Create(const AEntryFileName: string;
+  const AResolver: TGocciaModuleResolver;
+  const AContentProvider: TGocciaModuleContentProvider);
+begin
+  inherited Create;
+  FEntryFileName := AEntryFileName;
+  FModules := TOrderedStringMap<TGocciaModule>.Create;
+  FLoadingModules := TOrderedStringMap<Boolean>.Create;
+  FGlobalModules := TOrderedStringMap<TGocciaModule>.Create;
+
+  if Assigned(AResolver) then
+  begin
+    FResolver := AResolver;
+    FOwnsResolver := False;
+  end
+  else
+  begin
+    FResolver := TGocciaModuleResolver.Create(
+      ExtractFilePath(ExpandFileName(AEntryFileName)));
+    FOwnsResolver := True;
+  end;
+
+  if Assigned(AContentProvider) then
+  begin
+    FContentProvider := AContentProvider;
+    FOwnsContentProvider := False;
+  end
+  else
+  begin
+    FContentProvider := TGocciaFileSystemModuleContentProvider.Create;
+    FOwnsContentProvider := True;
+  end;
+end;
+
+destructor TGocciaModuleLoader.Destroy;
+begin
+  FModules.Free;
+  FLoadingModules.Free;
+  FGlobalModules.Free;
+  if FOwnsResolver then
+    FResolver.Free;
+  if FOwnsContentProvider then
+    FContentProvider.Free;
+  inherited;
+end;
+
+procedure TGocciaModuleLoader.BindRuntime(const AGlobalScope: TGocciaGlobalScope;
+  const AOnError: TGocciaThrowErrorCallback);
+begin
+  FGlobalScope := AGlobalScope;
+  FOnError := AOnError;
+end;
+
+function TGocciaModuleLoader.LoadModule(const AModulePath,
+  AImportingFilePath: string): TGocciaModule;
+var
+  Content: TGocciaModuleContent;
+  Context: TGocciaEvaluationContext;
+  ExportDecl: TGocciaExportDeclaration;
+  ExportPair: TStringStringMap.TKeyValuePair;
+  ExportVarDecl: TGocciaExportVariableDeclaration;
+  I: Integer;
+  JSXResult: TGocciaJSXTransformResult;
+  JSXSourceMap: TGocciaSourceMap;
+  Lexer: TGocciaLexer;
+  Module: TGocciaModule;
+  ModuleScope: TGocciaScope;
+  OrigLine: Integer;
+  OrigCol: Integer;
+  Parser: TGocciaParser;
+  ProgramNode: TGocciaProgram;
+  ReExportDecl: TGocciaReExportDeclaration;
+  ResolvedPath: string;
+  SourceModule: TGocciaModule;
+  SourceText: string;
+  Stmt: TGocciaStatement;
+  Value: TGocciaValue;
+  VarInfo: TGocciaVariableInfo;
+begin
+  if not Assigned(FGlobalScope) then
+    raise Exception.Create('Module loader runtime is not bound.');
+
+  if FGlobalModules.TryGetValue(AModulePath, Result) then
+    Exit;
+
+  try
+    if Assigned(FResolver) then
+      ResolvedPath := FResolver.Resolve(AModulePath, AImportingFilePath)
+    else
+      raise EGocciaModuleNotFound.CreateFmt(
+        'No module resolver configured and cannot resolve "%s"', [AModulePath]);
+  except
+    on E: TGocciaRuntimeError do
+      raise;
+    on E: Exception do
+      raise TGocciaRuntimeError.Create(E.Message, 0, 0, AImportingFilePath, nil);
+  end;
+
+  if FModules.TryGetValue(ResolvedPath, Result) then
+  begin
+    if not FLoadingModules.ContainsKey(ResolvedPath) then
+      CheckForModuleReload(Result);
+    Exit;
+  end;
+
+  if LowerCase(ExtractFileExt(ResolvedPath)) = EXT_JSON then
+  begin
+    Result := LoadJsonModule(ResolvedPath);
+    Exit;
+  end;
+
+  Content := FContentProvider.LoadContent(ResolvedPath);
+  try
+    SourceText := Content.Text;
+    JSXSourceMap := nil;
+    if FJSXEnabled then
+    begin
+      JSXResult := TGocciaJSXTransformer.Transform(SourceText);
+      SourceText := JSXResult.Source;
+      JSXSourceMap := JSXResult.SourceMap;
+      if Assigned(JSXSourceMap) then
+        WarnIfJSXExtensionMismatch(ResolvedPath);
+    end;
+
+    try
+      try
+        Lexer := TGocciaLexer.Create(SourceText, ResolvedPath);
+        try
+          Parser := TGocciaParser.Create(Lexer.ScanTokens, ResolvedPath,
+            Lexer.SourceLines);
+          try
+            ProgramNode := Parser.Parse;
+            try
+              Module := TGocciaModule.Create(ResolvedPath);
+              Module.LastModified := Content.LastModified;
+              FModules.Add(ResolvedPath, Module);
+              FLoadingModules.Add(ResolvedPath, True);
+              try
+                ModuleScope := FGlobalScope.CreateChild(skModule,
+                  'Module:' + ResolvedPath);
+                Context.Scope := ModuleScope;
+                Context.OnError := FOnError;
+                Context.LoadModule := LoadModule;
+                Context.CurrentFilePath := ResolvedPath;
+
+                for I := 0 to ProgramNode.Body.Count - 1 do
+                  EvaluateStatement(ProgramNode.Body[I], Context);
+
+                for I := 0 to ProgramNode.Body.Count - 1 do
+                begin
+                  Stmt := ProgramNode.Body[I];
+
+                  if Stmt is TGocciaExportDeclaration then
+                  begin
+                    ExportDecl := TGocciaExportDeclaration(Stmt);
+                    for ExportPair in ExportDecl.ExportsTable do
+                    begin
+                      Value := ModuleScope.GetValue(ExportPair.Value);
+                      if Assigned(Value) then
+                        Module.ExportsTable.AddOrSetValue(ExportPair.Key, Value);
+                    end;
+                  end
+                  else if Stmt is TGocciaExportVariableDeclaration then
+                  begin
+                    ExportVarDecl := TGocciaExportVariableDeclaration(Stmt);
+                    for VarInfo in ExportVarDecl.Declaration.Variables do
+                    begin
+                      Value := ModuleScope.GetValue(VarInfo.Name);
+                      if Assigned(Value) then
+                        Module.ExportsTable.AddOrSetValue(VarInfo.Name, Value);
+                    end;
+                  end
+                  else if Stmt is TGocciaExportEnumDeclaration then
+                  begin
+                    Value := ModuleScope.GetValue(
+                      TGocciaExportEnumDeclaration(Stmt).Declaration.Name);
+                    if Assigned(Value) then
+                      Module.ExportsTable.AddOrSetValue(
+                        TGocciaExportEnumDeclaration(Stmt).Declaration.Name,
+                        Value);
+                  end
+                  else if Stmt is TGocciaReExportDeclaration then
+                  begin
+                    ReExportDecl := TGocciaReExportDeclaration(Stmt);
+                    SourceModule := LoadModule(ReExportDecl.ModulePath,
+                      ResolvedPath);
+                    for ExportPair in ReExportDecl.ExportsTable do
+                    begin
+                      if SourceModule.ExportsTable.TryGetValue(ExportPair.Value,
+                        Value) then
+                        Module.ExportsTable.AddOrSetValue(ExportPair.Key, Value);
+                    end;
+                  end;
+                end;
+
+                Result := Module;
+              finally
+                FLoadingModules.Remove(ResolvedPath);
+              end;
+            finally
+              ProgramNode.Free;
+            end;
+          finally
+            Parser.Free;
+          end;
+        finally
+          Lexer.Free;
+        end;
+      except
+        on E: TGocciaError do
+        begin
+          if Assigned(JSXSourceMap) and
+             JSXSourceMap.Translate(E.Line, E.Column, OrigLine, OrigCol) then
+            E.TranslatePosition(OrigLine, OrigCol, Content.SourceLines);
+          raise;
+        end;
+      end;
+    finally
+      JSXSourceMap.Free;
+    end;
+  finally
+    Content.Free;
+  end;
+end;
+
+procedure TGocciaModuleLoader.CheckForModuleReload(const AModule: TGocciaModule);
+var
+  CurrentModified: TDateTime;
+begin
+  if not FContentProvider.TryGetLastModified(AModule.Path, CurrentModified) then
+    Exit;
+
+  if CurrentModified > AModule.LastModified then
+  begin
+    AModule.ExportsTable.Clear;
+    AModule.LastModified := CurrentModified;
+    LoadModule(AModule.Path, AModule.Path);
+  end;
+end;
+
+function TGocciaModuleLoader.LoadJsonModule(
+  const AResolvedPath: string): TGocciaModule;
+var
+  Content: TGocciaModuleContent;
+  Key: string;
+  Module: TGocciaModule;
+  Obj: TGocciaObjectValue;
+  ParsedValue: TGocciaValue;
+  Parser: TGocciaJSONParser;
+begin
+  Content := FContentProvider.LoadContent(AResolvedPath);
+  try
+    Parser := TGocciaJSONParser.Create;
+    try
+      try
+        ParsedValue := Parser.Parse(Content.Text);
+      except
+        on E: EGocciaJSONParseError do
+          raise TGocciaRuntimeError.Create(
+            Format('Failed to parse JSON module "%s": %s',
+              [AResolvedPath, E.Message]),
+            0, 0, AResolvedPath, nil);
+      end;
+
+      Module := TGocciaModule.Create(AResolvedPath);
+      Module.LastModified := Content.LastModified;
+
+      if ParsedValue is TGocciaObjectValue then
+      begin
+        Obj := TGocciaObjectValue(ParsedValue);
+        for Key in Obj.GetOwnPropertyKeys do
+          Module.ExportsTable.AddOrSetValue(Key, Obj.GetProperty(Key));
+      end;
+
+      FModules.Add(AResolvedPath, Module);
+      Result := Module;
+    finally
+      Parser.Free;
+    end;
+  finally
+    Content.Free;
+  end;
+end;
+
+end.


### PR DESCRIPTION
## Summary
- add `TGocciaModuleContentProvider` and the default filesystem-backed implementation
- introduce `TGocciaModuleLoader` as the standalone owner of module resolution, content loading, cache state, and runtime binding
- refactor `TGocciaInterpreter` to consume a module loader instead of owning module loading directly
- update `TGocciaEngine` and `TGocciaBytecodeBackend` to compose around a shared module loader service
- add native tests for in-memory module loading through injected module loaders
- document custom module loader composition in the embedding guide

Closes #152.

## Testing
- `./build.pas clean tests`
- `for t in build/Goccia.*.Test; do "$t"; done`
- `./build.pas testrunner`
- `./build/TestRunner tests`
- `./build.pas loader`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable module loader/content-provider allowing in-memory or alternative module loading; filesystem remains the default.
  * Engine, interpreter, and backend can accept injected module loaders/content providers for flexible integration.

* **Documentation**
  * Added guide demonstrating custom content provider and resolver wiring with examples.

* **Tests**
  * Added test suite validating in-memory content-provider behavior, reloads, error recovery, single-runtime binding, and bytecode backend integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->