### PR TITLE
Fix cross builds for fcl-base units

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,15 @@ jobs:
           OBJPAS_DIR="$PREFIX/lib/fpc/${FPC_VERSION}/units/${TARGET}/rtl-objpas"
           GEN_DIR="$PREFIX/lib/fpc/${FPC_VERSION}/units/${TARGET}/rtl-generics"
           FCL_DIR="$PREFIX/lib/fpc/${FPC_VERSION}/units/${TARGET}/fcl-process"
+          FCL_BASE_SRC="$PREFIX/share/fpcsrc/packages/fcl-base/src"
 
           # Verify RTL units exist
           echo "RTL units: $(ls "$RTL_DIR"/*.ppu 2>/dev/null | wc -l) .ppu files"
           echo "rtl-objpas units: $(ls "$OBJPAS_DIR"/*.ppu 2>/dev/null | wc -l) .ppu files"
           echo "rtl-generics units: $(ls "$GEN_DIR"/*.ppu 2>/dev/null | wc -l) .ppu files"
           echo "fcl-process units: $(ls "$FCL_DIR"/*.ppu 2>/dev/null | wc -l) .ppu files"
+          echo "fcl-base source path: $FCL_BASE_SRC"
+          test -d "$FCL_BASE_SRC"
 
           # Build main binaries
           for src in ScriptLoader.dpr TestRunner.dpr BenchmarkRunner.dpr REPL.dpr; do
@@ -121,7 +124,7 @@ jobs:
             "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
               -Fu./units -Fu./souffle \
               -Fi./units -Fi./souffle \
-              -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" \
+              -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" \
               -FU"build" -FE"build" \
               $EXTRA_FLAGS \
               -dFPC_SOFT_FPUX80 \
@@ -137,7 +140,7 @@ jobs:
             "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
               -Fu./units -Fu./souffle \
               -Fi./units -Fi./souffle \
-              -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" \
+              -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" \
               -FU"build" -FE"build" \
               $EXTRA_FLAGS \
               -dFPC_SOFT_FPUX80 \

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -10,7 +10,7 @@ on:
 env:
   FPC_VERSION: "3.2.2"
   BINUTILS_VERSION: "2.44"
-  CACHE_VERSION: "v28"
+  CACHE_VERSION: "v29"
 
 jobs:
   build:
@@ -97,12 +97,17 @@ jobs:
           PREFIX="$PWD/fpc-cross"
           BREW_FPC_LIB="$(brew --prefix)/lib/fpc/${FPC_VERSION}"
 
-          mkdir -p "$PREFIX/bin" "$PREFIX/lib/fpc/${FPC_VERSION}" "$PREFIX/lib/fpc/etc"
+          mkdir -p "$PREFIX/bin" "$PREFIX/lib/fpc/${FPC_VERSION}" "$PREFIX/lib/fpc/etc" "$PREFIX/share/fpcsrc/packages"
 
           # Copy native compiler and units
           cp "$(which instantfpc)" "$PREFIX/bin/"
           cp "$BREW_FPC_LIB/ppca64" "$PREFIX/lib/fpc/${FPC_VERSION}/"
           cp -r "$BREW_FPC_LIB/units" "$PREFIX/lib/fpc/${FPC_VERSION}/"
+
+          # Keep the official FCL sources available for cross builds. The
+          # cached cross toolchain only prebuilds a minimal package subset, so
+          # source-based lookup is needed for units like Base64 from fcl-base.
+          cp -R "$GITHUB_WORKSPACE/fpc-source/packages/fcl-base" "$PREFIX/share/fpcsrc/packages/"
 
       - name: Compile soft-float units for native RTL
         if: steps.cache-check.outputs.cache-hit != 'true'

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -205,6 +205,8 @@ It:
 6. If the `FPC_TARGET_CPU` environment variable is set, prepends `-P<arch>` to the compiler arguments (used by CI to target x86_64 on Windows where the FPC package defaults to i386).
 7. For the `tests` target, auto-discovers all `*.Test.pas` files in `units/`.
 
+The GitHub Actions cross-compilation workflow uses a reduced cached FPC toolchain rather than a full target-side FCL install. It prebuilds the RTL, `rtl-objpas`, `rtl-generics`, and `fcl-process`, and also caches the official `fcl-base` sources so cross builds can resolve units such as `Base64` on demand from the shipped FCL package.
+
 ## Project Structure for Compilation
 
 ```


### PR DESCRIPTION
## Summary

Fix cross-compilation failures when GocciaScript uses `fcl-base` units such as `Base64`.

The current cross toolchain only prebuilds a curated subset of FPC packages, so `Base64` was unavailable even though it ships with FPC/FCL. This change caches the official `fcl-base` sources in the cross toolchain and adds that package source directory to the cross compiler unit search path.

## Why this change

This is a targeted fix for the current breakage in cross CI.

The broader architectural issue is tracked separately in #170. That issue covers replacing the curated cross-package bootstrap with a proper FPC package installation flow so cross builds stop depending on manual package availability.

## Verification

- verified the root cause: `Base64` resolves from `fcl-base`, not from the currently curated cross-package set
- reproduced that compilation fails without `fcl-base` on the unit path and succeeds once the official `fcl-base` source path is available
- did not run the full GitHub Actions workflow from the local environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added details on cross-compilation workflow optimization and FCL package source handling.

* **Chores**
  * Enhanced CI/CD pipeline to improve cross-compilation support with cached package sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->