### PR TITLE
Normalize TOML multiline strings to LF across platforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,7 @@ JavaScript end-to-end tests are the **primary** way of testing GocciaScript. Whe
 - **One method per file** — each test file focuses on a single method or operation. Never bundle multiple methods into one file (no `prototype-methods.js` or `static-methods.js`).
 - **Prototype methods go in `prototype/`** — instance methods live in `BuiltIn/prototype/methodName.js`. Static methods and constructor tests live directly in the `BuiltIn/` folder. See `tests/built-ins/Array/prototype/` for the canonical example.
 - **Edge cases are co-located** — edge case tests (NaN, Infinity, negative indices, clamping, empty collections, boundary conditions) belong in the **same file** as the happy-path tests for that method. Do **not** create separate `edge-cases.js` files.
+- **Format-defined newline semantics are not host-dependent** — when a file format specifies newline normalization (for example TOML multiline strings or YAML folding/block-scalar rules), implement that behavior explicitly and do **not** emit `LineEnding`/`sLineBreak` just because the host OS is Windows. Add regression coverage with explicit `#13#10` / `\r\n` inputs and assert the format-defined canonical result so Windows CI cannot drift from Linux/macOS behavior.
 - Always verify changes by running: `./build.pas testrunner && ./build/TestRunner tests`
 
 **When adding a new language feature:**

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -180,7 +180,7 @@ Compatibility goal: GocciaScript is targeting full YAML 1.2 support over time wh
 |--------|-------------|
 | `TOML.parse(text)` | Parse TOML 1.1.0 text into Goccia values |
 
-`TOML.parse` delegates to the standalone `TGocciaTOMLParser` utility in `Goccia.TOML`, mirroring the JSON and YAML split between parser utility and runtime surface. The current TOML surface supports strings (basic, literal, and multiline variants), integers, floats, booleans, arrays, inline tables, regular tables, arrays of tables, dotted keys, and TOML 1.1.0 date/time values.
+`TOML.parse` delegates to the standalone `TGocciaTOMLParser` utility in `Goccia.TOML`, mirroring the JSON and YAML split between parser utility and runtime surface. The current TOML surface supports strings (basic, literal, and multiline variants), integers, floats, booleans, arrays, inline tables, regular tables, arrays of tables, dotted keys, and TOML 1.1.0 date/time values. TOML multiline strings normalize recognized source newlines to LF (`\n`) regardless of the host platform, so the parsed value is stable across Linux, macOS, and Windows.
 
 TOML date/time values currently map to validated string scalars rather than Temporal values. This keeps the runtime and module-import behavior stable for v1 while leaving room for future Temporal-aware interop.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -291,6 +291,15 @@ describe("Feature Name", () => {
 
 Nested `describe` blocks compose their suite names with ` > ` separators. In the example above, the nested test's suite name would be `"Feature Name > sub-feature"`.
 
+### Cross-Platform Newline Rules for Data Format Parsers
+
+When a parser implements a format with spec-defined newline semantics, test the format semantics directly instead of inheriting the host OS newline convention.
+
+- Do not treat `LineEnding` / `sLineBreak` as the expected runtime result for parsed data just because the test is running on Windows.
+- Prefer explicit `\r\n` or `#13#10` fixtures when adding regression tests for multiline parsing, folding, or block-scalar behavior.
+- Assert the format-defined canonical result. Example: TOML multiline strings normalize recognized newlines to LF (`\n`) even when the source text uses CRLF.
+- Keep one public-surface regression in `tests/` and, when the parser exposes a reusable native utility like `TGocciaTOMLParser`, add a focused Pascal regression alongside it as well.
+
 ### Test Metadata (Optional)
 
 Test files can include JSDoc-style metadata:

--- a/tests/built-ins/TOML/parse.js
+++ b/tests/built-ins/TOML/parse.js
@@ -79,6 +79,16 @@ point = { x = 1, y = 2, meta = { label = "origin" } }
     expect(value.literal).toBe("C:\\Users\\nodejs\\templates\nLine two\n");
   });
 
+  test("normalizes CRLF multiline strings to LF", () => {
+    const value = TOML.parse(
+      'basic = """\r\nRoses are red\r\nViolets are blue\r\n"""\r\n' +
+      "literal = '''\r\nC:\\Users\\nodejs\\templates\r\nLine two\r\n'''\r\n"
+    );
+
+    expect(value.basic).toBe("Roses are red\nViolets are blue\n");
+    expect(value.literal).toBe("C:\\Users\\nodejs\\templates\nLine two\n");
+  });
+
   test("parses integer bases and special floats", () => {
     const value = TOML.parse(`
 decimal = 1_000

--- a/units/Goccia.TOML.Test.pas
+++ b/units/Goccia.TOML.Test.pas
@@ -15,6 +15,7 @@ type
   private
     function GetChildOrFail(const AParent: TGocciaTOMLNode;
       const AKey: string): TGocciaTOMLNode;
+    procedure TestParseDocumentNormalizesCRLFInMultilineStrings;
     procedure TestParseDocumentTracksScalarKinds;
     procedure TestParseDocumentTracksArrayElementKinds;
   public
@@ -27,6 +28,8 @@ begin
     TestParseDocumentTracksScalarKinds);
   Test('ParseDocument tracks array element kinds',
     TestParseDocumentTracksArrayElementKinds);
+  Test('ParseDocument normalizes CRLF in multiline strings',
+    TestParseDocumentNormalizesCRLFInMultilineStrings);
 end;
 
 function TTOMLParserTests.GetChildOrFail(const AParent: TGocciaTOMLNode;
@@ -105,6 +108,40 @@ begin
       NestedNode := GetChildOrFail(ItemsNode.Items[3], 'nested');
       Expect<Integer>(Ord(NestedNode.ScalarKind)).ToBe(Ord(tskBool));
       Expect<string>(NestedNode.CanonicalValue).ToBe('true');
+    finally
+      Root.Free;
+    end;
+  finally
+    Parser.Free;
+  end;
+end;
+
+procedure TTOMLParserTests.TestParseDocumentNormalizesCRLFInMultilineStrings;
+var
+  BasicNode: TGocciaTOMLNode;
+  LiteralNode: TGocciaTOMLNode;
+  Parser: TGocciaTOMLParser;
+  Root: TGocciaTOMLNode;
+begin
+  Parser := TGocciaTOMLParser.Create;
+  try
+    Root := Parser.ParseDocument(
+      'basic = """' + #13#10 +
+      'Roses are red' + #13#10 +
+      'Violets are blue' + #13#10 +
+      '"""' + #13#10 +
+      'literal = ''''''' + #13#10 +
+      'C:\Users\nodejs\templates' + #13#10 +
+      'Line two' + #13#10 +
+      '''''''' + #13#10);
+    try
+      BasicNode := GetChildOrFail(Root, 'basic');
+      LiteralNode := GetChildOrFail(Root, 'literal');
+
+      Expect<string>(BasicNode.CanonicalValue).ToBe(
+        'Roses are red' + #10 + 'Violets are blue' + #10);
+      Expect<string>(LiteralNode.CanonicalValue).ToBe(
+        'C:\Users\nodejs\templates' + #10 + 'Line two' + #10);
     finally
       Root.Free;
     end;

--- a/units/Goccia.TOML.pas
+++ b/units/Goccia.TOML.pas
@@ -189,6 +189,8 @@ begin
 end;
 
 function NormalizeMultilineNewline(const AText: string; var AIndex: Integer): string;
+const
+  TOML_MULTILINE_NEWLINE = #10;
 begin
   if (AIndex <= Length(AText)) and (AText[AIndex] = #13) then
   begin
@@ -200,7 +202,7 @@ begin
   end
   else
     Inc(AIndex);
-  Result := LineEnding;
+  Result := TOML_MULTILINE_NEWLINE;
 end;
 
 function JoinPath(const APath: TArray<string>): string;


### PR DESCRIPTION
## Summary
- normalize TOML multiline basic and literal strings to LF instead of host `LineEnding`
- add CRLF regression coverage for `TOML.parse` and `TGocciaTOMLParser.ParseDocument`
- document the cross-platform newline rule for data format parsers so future parser work does not regress on Windows

## Verification
- `./build/TestRunner tests/built-ins/TOML/parse.js`
- `./build/Goccia.TOML.Test`
- `python3 scripts/run_toml_test_suite.py`
- `./build/TestRunner tests --no-progress --exit-on-first-failure`
- `for t in build/Goccia.*.Test; do "$t"; done`
- `./format.pas --check`

## Context
This fixes the Windows TOML multiline-string regression introduced after TOML support landed and makes the newline-normalization expectation explicit in the contributor docs.