### PR TITLE
Ignore leading shebang lines in the lexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ console.log(`Your order total: $${total.toFixed(2)}`);
 printf "const x = 2 + 2; x;" | ./build/ScriptLoader
 ```
 
+Script files may start with a Unix shebang line like `#!/usr/bin/env goccia`; GocciaScript ignores that first line during lexing.
+
 ### Run via Bytecode
 
 GocciaScript includes a bytecode execution backend. The public bytecode artifact is `.gbc`, and WASM emission is not supported.

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -69,6 +69,8 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader
 printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner
 ```
 
+Leading Unix shebang lines such as `#!/usr/bin/env goccia` are treated as comments by the lexer, so executable scripts can be run directly without preprocessing.
+
 ### Compile and Test
 
 ```bash

--- a/tests/language/shebang.js
+++ b/tests/language/shebang.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env goccia
+
+test("leading shebang lines are ignored", () => {
+  expect(8 / 2).toBe(4);
+  expect(/ab/.test("zabz")).toBe(true);
+});

--- a/units/Goccia.Lexer.Test.pas
+++ b/units/Goccia.Lexer.Test.pas
@@ -16,6 +16,8 @@ uses
 type
   TLexerTests = class(TTestSuite)
   private
+    procedure AssertIgnoresLeadingHashbang(const ALineBreak: string);
+    procedure AssertPreservesLineNumbersAfterHashbang(const ALineBreak: string);
     procedure TestIgnoresLeadingHashbang;
     procedure TestPreservesLineNumbersAfterHashbang;
   public
@@ -28,12 +30,12 @@ begin
   Test('Preserves line numbers after hashbang', TestPreservesLineNumbersAfterHashbang);
 end;
 
-procedure TLexerTests.TestIgnoresLeadingHashbang;
+procedure TLexerTests.AssertIgnoresLeadingHashbang(const ALineBreak: string);
 var
   Lexer: TGocciaLexer;
   Tokens: TObjectList<TGocciaToken>;
 begin
-  Lexer := TGocciaLexer.Create('#!/usr/bin/env goccia' + sLineBreak + 'const value = 1 / 2;', '<test>');
+  Lexer := TGocciaLexer.Create('#!/usr/bin/env goccia' + ALineBreak + 'const value = 1 / 2;', '<test>');
   try
     Tokens := Lexer.ScanTokens;
     Expect<Integer>(Tokens.Count).ToBe(8);
@@ -46,12 +48,12 @@ begin
   end;
 end;
 
-procedure TLexerTests.TestPreservesLineNumbersAfterHashbang;
+procedure TLexerTests.AssertPreservesLineNumbersAfterHashbang(const ALineBreak: string);
 var
   Lexer: TGocciaLexer;
   Tokens: TObjectList<TGocciaToken>;
 begin
-  Lexer := TGocciaLexer.Create('#!/usr/bin/env goccia' + sLineBreak + 'const value = 1;', '<test>');
+  Lexer := TGocciaLexer.Create('#!/usr/bin/env goccia' + ALineBreak + 'const value = 1;', '<test>');
   try
     Tokens := Lexer.ScanTokens;
     Expect<Integer>(Tokens[0].Line).ToBe(2);
@@ -60,6 +62,22 @@ begin
   finally
     Lexer.Free;
   end;
+end;
+
+procedure TLexerTests.TestIgnoresLeadingHashbang;
+const
+  CRLF = #13#10;
+begin
+  AssertIgnoresLeadingHashbang(sLineBreak);
+  AssertIgnoresLeadingHashbang(CRLF);
+end;
+
+procedure TLexerTests.TestPreservesLineNumbersAfterHashbang;
+const
+  CRLF = #13#10;
+begin
+  AssertPreservesLineNumbersAfterHashbang(sLineBreak);
+  AssertPreservesLineNumbersAfterHashbang(CRLF);
 end;
 
 begin

--- a/units/Goccia.Lexer.Test.pas
+++ b/units/Goccia.Lexer.Test.pas
@@ -1,0 +1,74 @@
+program Goccia.Lexer.Test;
+
+{$I Goccia.inc}
+
+uses
+  Generics.Collections,
+  SysUtils,
+
+  GarbageCollector.Generic,
+  TestRunner,
+
+  Goccia.Lexer,
+  Goccia.TestSetup,
+  Goccia.Token;
+
+type
+  TLexerTests = class(TTestSuite)
+  private
+    procedure TestIgnoresLeadingHashbang;
+    procedure TestPreservesLineNumbersAfterHashbang;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TLexerTests.SetupTests;
+begin
+  Test('Ignores leading hashbang', TestIgnoresLeadingHashbang);
+  Test('Preserves line numbers after hashbang', TestPreservesLineNumbersAfterHashbang);
+end;
+
+procedure TLexerTests.TestIgnoresLeadingHashbang;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+begin
+  Lexer := TGocciaLexer.Create('#!/usr/bin/env goccia' + sLineBreak + 'const value = 1 / 2;', '<test>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Expect<Integer>(Tokens.Count).ToBe(8);
+    Expect<TGocciaTokenType>(Tokens[0].TokenType).ToBe(gttConst);
+    Expect<TGocciaTokenType>(Tokens[1].TokenType).ToBe(gttIdentifier);
+    Expect<string>(Tokens[1].Lexeme).ToBe('value');
+    Expect<TGocciaTokenType>(Tokens[4].TokenType).ToBe(gttSlash);
+  finally
+    Lexer.Free;
+  end;
+end;
+
+procedure TLexerTests.TestPreservesLineNumbersAfterHashbang;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+begin
+  Lexer := TGocciaLexer.Create('#!/usr/bin/env goccia' + sLineBreak + 'const value = 1;', '<test>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Expect<Integer>(Tokens[0].Line).ToBe(2);
+    Expect<Integer>(Tokens[0].Column).ToBe(1);
+    Expect<Integer>(Tokens[1].Line).ToBe(2);
+  finally
+    Lexer.Free;
+  end;
+end;
+
+begin
+  TGarbageCollector.Initialize;
+  try
+    TestRunnerProgram.AddSuite(TLexerTests.Create('Lexer'));
+    TestRunnerProgram.Run;
+    ExitCode := TestResultToExitCode;
+  finally
+    TGarbageCollector.Shutdown;
+  end;
+end.

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -57,6 +57,7 @@ type
     procedure PushParenRegexContext(const AAllowsRegexAfter: Boolean);
     function PopParenRegexContext: Boolean;
     procedure SkipWhitespace;
+    procedure SkipHashbang;
     procedure SkipComment;
     procedure SkipBlockComment;
   public
@@ -184,6 +185,15 @@ begin
       Break;
     end;
   end;
+end;
+
+procedure TGocciaLexer.SkipHashbang;
+begin
+  if (FCurrent <> 1) or (Length(FSource) < 2) or (Copy(FSource, 1, 2) <> '#!') then
+    Exit;
+
+  while not IsAtEnd and not CharInSet(Peek, [#10, #13]) do
+    Advance;
 end;
 
 procedure TGocciaLexer.SkipComment;
@@ -867,6 +877,7 @@ end;
 
 function TGocciaLexer.ScanTokens: TObjectList<TGocciaToken>;
 begin
+  SkipHashbang;
   while not IsAtEnd do
   begin
     SkipWhitespace;


### PR DESCRIPTION
## Summary
- Teach the lexer to skip an initial Unix shebang line (`#!...`) before tokenization starts.
- Preserve line and column tracking so subsequent tokens still report the correct source location.
- Add regression coverage in both JavaScript end-to-end tests and native lexer tests.
- Document the shebang behavior in the README and build-system guide.

## Testing
- Added `tests/language/shebang.js` to verify scripts with a leading shebang execute normally.
- Added `units/Goccia.Lexer.Test.pas` coverage for skipping the hashbang and preserving line numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GocciaScript now accepts Unix shebang lines (e.g., `#!/usr/bin/env goccia`) at the start of source files; they are ignored during parsing so scripts can be executable.

* **Documentation**
  * README and build docs updated to explain shebang handling and runtime behavior for executable scripts.

* **Tests**
  * Added tests verifying shebangs are ignored and that line/column tracking remains correct after a shebang.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->