### PR TITLE
Unify newline handling for text file inputs

### DIFF
--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -25,6 +25,7 @@ uses
   Goccia.Modules.Configuration,
   Goccia.Parser,
   Goccia.ScriptLoader.Input,
+  Goccia.TextFiles,
   Goccia.Token,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
@@ -157,9 +158,8 @@ var
 begin
   BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
 
-  Source := TStringList.Create;
+  Source := ReadUTF8FileLines(AFileName);
   try
-    Source.LoadFromFile(AFileName);
     Source.Add('runBenchmarks();');
 
     try
@@ -225,12 +225,11 @@ var
 begin
   BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
 
-  Source := TStringList.Create;
+  Source := ReadUTF8FileLines(AFileName);
   try
-    Source.LoadFromFile(AFileName);
     Source.Add('runBenchmarks();');
 
-    SourceText := Source.Text;
+    SourceText := StringListToLFText(Source);
     if ggJSX in BenchGlobals then
     begin
       JSXResult := TGocciaJSXTransformer.Transform(SourceText);
@@ -395,7 +394,7 @@ begin
   BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
   ASource.Add('runBenchmarks();');
 
-  SourceText := ASource.Text;
+  SourceText := StringListToLFText(ASource);
   if ggJSX in BenchGlobals then
   begin
     JSXResult := TGocciaJSXTransformer.Transform(SourceText);

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -27,6 +27,7 @@ uses
   Goccia.ScriptLoader.Globals,
   Goccia.ScriptLoader.Input,
   Goccia.ScriptLoader.JSON,
+  Goccia.TextFiles,
   Goccia.Timeout,
   Goccia.Token,
   Goccia.Values.Primitives,
@@ -68,7 +69,7 @@ var
   OrigLine, OrigCol, I: Integer;
 begin
   StartTime := GetNanoseconds;
-  SourceText := ASource.Text;
+  SourceText := StringListToLFText(ASource);
 
   SourceMap := nil;
   if ggJSX in AGlobals then
@@ -496,9 +497,8 @@ begin
     Exit;
   end;
 
-  Source := TStringList.Create;
+  Source := ReadUTF8FileLines(AFileName);
   try
-    Source.LoadFromFile(AFileName);
     RunSource(Source, AFileName);
   finally
     Source.Free;

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -23,6 +23,7 @@ uses
   Goccia.Lexer,
   Goccia.Modules.Configuration,
   Goccia.Parser,
+  Goccia.TextFiles,
   Goccia.Token,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
@@ -109,10 +110,10 @@ begin
   TestGlobals := TGocciaEngine.DefaultGlobals + [ggTestAssertions];
   ScriptResult := CreateDefaultScriptResult;
 
-  Source := TStringList.Create;
+  Source := nil;
   try
     try
-      Source.LoadFromFile(AFileName);
+      Source := ReadUTF8FileLines(AFileName);
     except
       on E: EStreamError do
       begin
@@ -183,10 +184,10 @@ begin
   TestGlobals := TGocciaEngine.DefaultGlobals + [ggTestAssertions];
   ScriptResult := CreateDefaultScriptResult;
 
-  Source := TStringList.Create;
+  Source := nil;
   try
     try
-      Source.LoadFromFile(AFileName);
+      Source := ReadUTF8FileLines(AFileName);
     except
       on E: EStreamError do
       begin
@@ -200,7 +201,7 @@ begin
     Source.Add(Format('runTests({ exitOnFirstFailure: %s, showTestResults: false });',
       [BoolToStr(GExitOnFirstFailure, 'true', 'false')]));
 
-    SourceText := Source.Text;
+    SourceText := StringListToLFText(Source);
     SourceMap := nil;
     if ggJSX in TestGlobals then
     begin

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -313,7 +313,7 @@ When a parser implements a format with spec-defined newline semantics, test the 
 - Do not treat `LineEnding` / `sLineBreak` as the expected runtime result for parsed data just because the test is running on Windows.
 - Prefer explicit `\r\n` or `#13#10` fixtures when adding regression tests for multiline parsing, folding, or block-scalar behavior.
 - Assert the format-defined canonical result. Example: TOML multiline strings normalize recognized newlines to LF (`\n`) even when the source text uses CRLF.
-- For parser inputs that come from files, read UTF-8 bytes with the shared helper instead of `TStringList.LoadFromFile` or `string(UTF8String(...))`. Keep the text as `UTF8String` until parser entry, then add at least one regression that hits the real file-loading path with non-ASCII data.
+- For parser inputs that come from files, use the shared `Goccia.TextFiles` helpers (`ReadUTF8FileText`, `ReadUTF8FileLines`, `StringListToLFText`) instead of `TStringList.LoadFromFile` or `string(UTF8String(...))`. Keep the text as `UTF8String` until parser entry, canonicalize parser-facing source text to LF through the shared helpers, and add at least one regression that hits the real file-loading path with non-ASCII data.
 - When code needs a “10 characters” or “first identifier code point” style rule on UTF-8 text, do not use raw `Length`, `Copy`, or byte indexing on `string`/`UTF8String`; those operate on bytes under our FPC settings.
 - Keep one public-surface regression in `tests/` and, when the parser exposes a reusable native utility like `TGocciaTOMLParser`, add a focused Pascal regression alongside it as well.
 

--- a/scripts/GocciaJSON5Check.dpr
+++ b/scripts/GocciaJSON5Check.dpr
@@ -11,6 +11,7 @@ uses
   StringBuffer,
 
   Goccia.JSON5,
+  Goccia.TextFiles,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
@@ -209,7 +210,7 @@ end;
 var
   ParsedValue: TGocciaValue;
   Parser: TGocciaJSON5Parser;
-  Source: TStringList;
+  SourceText: UTF8String;
 begin
   if ParamCount <> 1 then
     Halt(2);
@@ -217,12 +218,11 @@ begin
   TGarbageCollector.Initialize;
   PinPrimitiveSingletons;
 
-  Source := TStringList.Create;
   Parser := TGocciaJSON5Parser.Create;
   try
     try
-      Source.LoadFromFile(ParamStr(1));
-      ParsedValue := Parser.Parse(Source.Text);
+      SourceText := ReadUTF8FileText(ParamStr(1));
+      ParsedValue := Parser.Parse(SourceText);
       TGarbageCollector.Instance.AddTempRoot(ParsedValue);
       try
         WriteLn(EncodeValue(ParsedValue));
@@ -238,7 +238,6 @@ begin
     end;
   finally
     Parser.Free;
-    Source.Free;
     TGarbageCollector.Shutdown;
   end;
 end.

--- a/tests/language/modules/helpers/unicode-config.yaml
+++ b/tests/language/modules/helpers/unicode-config.yaml
@@ -1,0 +1,4 @@
+name: José
+"déjà": vu
+nested:
+  city: Zürich

--- a/tests/language/modules/helpers/unicode-events.jsonl
+++ b/tests/language/modules/helpers/unicode-events.jsonl
@@ -1,0 +1,2 @@
+{"name":"José","city":"Zürich"}
+"Café déjà vu"

--- a/tests/language/modules/jsonl-import.js
+++ b/tests/language/modules/jsonl-import.js
@@ -13,6 +13,10 @@ import {
   firstRecord as reExportedFirstRecord,
   labels as reExportedLabels,
 } from "./helpers/jsonl-re-exporter.js";
+import {
+  "0" as unicodeFirstRecord,
+  "1" as unicodeMessage,
+} from "./helpers/unicode-events.jsonl";
 
 describe("JSONL module imports", () => {
   test("imports each record by string index", () => {
@@ -36,5 +40,11 @@ describe("JSONL module imports", () => {
     expect(blankLineLabels.length).toBe(2);
     expect(blankLineLabels[0]).toBe("x");
     expect(blankLineLabels[1]).toBe("y");
+  });
+
+  test("preserves UTF-8 text in file-backed JSONL modules", () => {
+    expect(unicodeFirstRecord.name).toBe("Jos\u00e9");
+    expect(unicodeFirstRecord.city).toBe("Z\u00fcrich");
+    expect(unicodeMessage).toBe("Caf\u00e9 d\u00e9j\u00e0 vu");
   });
 });

--- a/tests/language/modules/yaml-import.js
+++ b/tests/language/modules/yaml-import.js
@@ -1,5 +1,6 @@
 import { name, version, debug, maxRetries, tags, database } from "./helpers/config.yaml";
 import { count, pi, empty, active, greeting } from "./helpers/simple-values.yml";
+import * as unicodeConfig from "./helpers/unicode-config.yaml";
 
 describe("YAML import", () => {
   test("string values", () => {
@@ -44,5 +45,11 @@ describe("YAML import", () => {
 
   test("string with spaces", () => {
     expect(greeting).toBe("hello world");
+  });
+
+  test("preserves UTF-8 text in file-backed YAML modules", () => {
+    expect(unicodeConfig.name).toBe("Jos\u00e9");
+    expect(unicodeConfig["d\u00e9j\u00e0"]).toBe("vu");
+    expect(unicodeConfig.nested.city).toBe("Z\u00fcrich");
   });
 });

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -101,6 +101,7 @@ uses
   Goccia.Keywords.Reserved,
   Goccia.Lexer,
   Goccia.Parser,
+  Goccia.TextFiles,
   Goccia.Token,
   Goccia.Values.Primitives;
 
@@ -1593,9 +1594,8 @@ begin
         Lexer := TGocciaLexer.Create('(' + ExprText + ');', ACtx.SourcePath);
         try
           Tokens := Lexer.ScanTokens;
-          SourceLines := TStringList.Create;
+          SourceLines := CreateUTF8StringList(ExprText);
           try
-            SourceLines.Text := ExprText;
             Parser := TGocciaParser.Create(Tokens, ACtx.SourcePath, SourceLines);
             try
               ProgramNode := Parser.ParseUnchecked;

--- a/units/Goccia.Compiler.Test.pas
+++ b/units/Goccia.Compiler.Test.pas
@@ -24,6 +24,7 @@ uses
   Goccia.Lexer,
   Goccia.Parser,
   Goccia.TestSetup,
+  Goccia.TextFiles,
   Goccia.Token,
   Goccia.Values.Primitives;
 
@@ -70,8 +71,7 @@ var
 begin
   Lexer := TGocciaLexer.Create(ASource, '<test>');
   Tokens := Lexer.ScanTokens;
-  SourceLines := TStringList.Create;
-  SourceLines.Text := ASource;
+  SourceLines := CreateUTF8StringList(ASource);
   Parser := TGocciaParser.Create(Tokens, '<test>', SourceLines);
   ProgramNode := Parser.Parse;
 

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -813,7 +813,7 @@ begin
   StartTime := GetNanoseconds;
 
   if Assigned(FSourceLines) then
-    SourceText := FSourceLines.Text
+    SourceText := StringListToLFText(FSourceLines)
   else
     SourceText := '';
   SourceMap := nil;
@@ -907,7 +907,7 @@ class function TGocciaEngine.RunScriptFromFile(const AFileName: string; const AG
 var
   Source: TStringList;
 begin
-  Source := CreateUTF8StringList(ReadUTF8FileText(AFileName));
+  Source := CreateUTF8FileTextLines(ReadUTF8FileText(AFileName));
   try
     Result := RunScriptFromStringList(Source, AFileName, AGlobals);
   finally

--- a/units/Goccia.JSONL.pas
+++ b/units/Goccia.JSONL.pas
@@ -8,6 +8,7 @@ uses
   SysUtils,
 
   Goccia.JSON,
+  Goccia.TextFiles,
   Goccia.Values.ArrayValue,
   Goccia.Values.Primitives;
 
@@ -46,6 +47,7 @@ type
     constructor Create;
     destructor Destroy; override;
 
+    function Parse(const AText: UTF8String): TGocciaArrayValue; overload;
     function Parse(const AText: string): TGocciaArrayValue; overload;
     function Parse(const ABytes: TBytes): TGocciaArrayValue; overload;
     function ParseChunk(const AText: string; const AStart: Integer = 0;
@@ -200,6 +202,11 @@ begin
       Result := False;
     end;
   end;
+end;
+
+function TGocciaJSONLParser.Parse(const AText: UTF8String): TGocciaArrayValue;
+begin
+  Result := Parse(RetagUTF8Text(RawByteString(AText)));
 end;
 
 function TGocciaJSONLParser.Parse(const AText: string): TGocciaArrayValue;

--- a/units/Goccia.JSX.Transformer.pas
+++ b/units/Goccia.JSX.Transformer.pas
@@ -12,7 +12,8 @@ uses
 
   Goccia.JSX.SourceMap,
   Goccia.Keywords.Contextual,
-  Goccia.Keywords.Reserved;
+  Goccia.Keywords.Reserved,
+  Goccia.TextFiles;
 
 type
   TGocciaJSXTransformResult = record
@@ -533,10 +534,9 @@ begin
   if not HasNewline then
     Exit(AText);
 
-  Lines := TStringList.Create;
+  Lines := CreateUTF8StringList(AText);
   try
     SB := TStringBuffer.Create;
-    Lines.Text := AText;
     First := True;
 
     for I := 0 to Lines.Count - 1 do

--- a/units/Goccia.Modules.ContentProvider.Test.pas
+++ b/units/Goccia.Modules.ContentProvider.Test.pas
@@ -16,6 +16,7 @@ uses
   Goccia.Engine,
   Goccia.Engine.Backend,
   Goccia.Interpreter,
+  Goccia.JSONL,
   Goccia.Lexer,
   Goccia.Modules,
   Goccia.Modules.ContentProvider,
@@ -26,8 +27,10 @@ uses
   Goccia.TextFiles,
   Goccia.Token,
   Goccia.TOML,
+  Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
-  Goccia.Values.Primitives;
+  Goccia.Values.Primitives,
+  Goccia.YAML;
 
 type
   TInMemoryModuleResolver = class(TGocciaModuleResolver)
@@ -71,7 +74,9 @@ type
     procedure TestEngineRetriesModuleAfterFailedLoad;
     procedure TestEngineReportsJSONLModuleLineNumbers;
     procedure TestEngineReportsTOMLModuleSyntaxErrors;
+    procedure TestFileSystemContentProviderPreservesUTF8JSONLText;
     procedure TestFileSystemContentProviderPreservesUTF8TOMLText;
+    procedure TestFileSystemContentProviderPreservesUTF8YAMLText;
     procedure TestEngineLoadsUTF8TextAssetModule;
     procedure TestEngineNormalizesCRLFTextAssetModulesToLF;
     procedure TestModuleLoaderRejectsRebindingAcrossRuntimes;
@@ -159,8 +164,12 @@ begin
     TestEngineReportsJSONLModuleLineNumbers);
   Test('Engine reports TOML module syntax errors',
     TestEngineReportsTOMLModuleSyntaxErrors);
+  Test('File system content provider preserves UTF-8 JSONL text',
+    TestFileSystemContentProviderPreservesUTF8JSONLText);
   Test('File system content provider preserves UTF-8 TOML text',
     TestFileSystemContentProviderPreservesUTF8TOMLText);
+  Test('File system content provider preserves UTF-8 YAML text',
+    TestFileSystemContentProviderPreservesUTF8YAMLText);
   Test('Engine loads UTF-8 text asset modules',
     TestEngineLoadsUTF8TextAssetModule);
   Test('Engine normalizes CRLF text asset modules to LF',
@@ -594,6 +603,59 @@ begin
   end;
 end;
 
+procedure TModuleContentProviderTests.TestFileSystemContentProviderPreservesUTF8JSONLText;
+var
+  CityValue: UTF8String;
+  Content: TGocciaModuleContent;
+  ContentProvider: TGocciaFileSystemModuleContentProvider;
+  MessageValue: UTF8String;
+  NameValue: UTF8String;
+  Parser: TGocciaJSONLParser;
+  Records: TGocciaArrayValue;
+  TempDirectory: string;
+  JSONLPath: string;
+  JSONLText: UTF8String;
+begin
+  TempDirectory := CreateTempDirectory;
+  JSONLPath := IncludeTrailingPathDelimiter(TempDirectory) + 'unicode.jsonl';
+  NameValue := 'Jos' + #$C3#$A9;
+  CityValue := 'Z' + #$C3#$BC + 'rich';
+  MessageValue := 'Caf' + #$C3#$A9 + ' d' + #$C3#$A9 + 'j' + #$C3#$A0 + ' vu';
+  JSONLText :=
+    '{"name":"' + NameValue + '","city":"' + CityValue + '"}' + #10 +
+    '"' + MessageValue + '"' + #10;
+  WriteUTF8File(JSONLPath, JSONLText);
+
+  ContentProvider := TGocciaFileSystemModuleContentProvider.Create;
+  try
+    Content := ContentProvider.LoadContent(JSONLPath);
+    try
+      Parser := TGocciaJSONLParser.Create;
+      try
+        Records := Parser.Parse(Content.Text);
+      finally
+        Parser.Free;
+      end;
+
+      try
+        Expect<Integer>(Records.Elements.Count).ToBe(2);
+        Expect<string>(TGocciaObjectValue(Records.Elements[0])
+          .GetProperty('name').ToStringLiteral.Value).ToBe(NameValue);
+        Expect<string>(TGocciaObjectValue(Records.Elements[0])
+          .GetProperty('city').ToStringLiteral.Value).ToBe(CityValue);
+        Expect<string>(Records.Elements[1].ToStringLiteral.Value)
+          .ToBe(MessageValue);
+      finally
+        Records.Free;
+      end;
+    finally
+      Content.Free;
+    end;
+  finally
+    ContentProvider.Free;
+  end;
+end;
+
 procedure TModuleContentProviderTests.TestFileSystemContentProviderPreservesUTF8TOMLText;
 var
   CityValue: UTF8String;
@@ -639,6 +701,64 @@ begin
       Expect<string>(TGocciaObjectValue(Obj.GetProperty('nested'))
         .GetProperty('city').ToStringLiteral.Value)
         .ToBe(CityValue);
+    finally
+      Content.Free;
+    end;
+  finally
+    ContentProvider.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestFileSystemContentProviderPreservesUTF8YAMLText;
+var
+  CityValue: UTF8String;
+  Content: TGocciaModuleContent;
+  ContentProvider: TGocciaFileSystemModuleContentProvider;
+  Documents: TGocciaArrayValue;
+  NameValue: UTF8String;
+  Obj: TGocciaObjectValue;
+  Parser: TGocciaYAMLParser;
+  QuotedKey: UTF8String;
+  TempDirectory: string;
+  YAMLPath: string;
+  YAMLText: UTF8String;
+begin
+  TempDirectory := CreateTempDirectory;
+  YAMLPath := IncludeTrailingPathDelimiter(TempDirectory) + 'unicode.yaml';
+  NameValue := 'Jos' + #$C3#$A9;
+  QuotedKey := 'd' + #$C3#$A9 + 'j' + #$C3#$A0;
+  CityValue := 'Z' + #$C3#$BC + 'rich';
+  YAMLText :=
+    'name: ' + NameValue + #10 +
+    '"' + QuotedKey + '": vu' + #10 +
+    'nested:' + #10 +
+    '  city: ' + CityValue + #10;
+  WriteUTF8File(YAMLPath, YAMLText);
+
+  ContentProvider := TGocciaFileSystemModuleContentProvider.Create;
+  try
+    Content := ContentProvider.LoadContent(YAMLPath);
+    try
+      Parser := TGocciaYAMLParser.Create;
+      try
+        Documents := Parser.ParseDocuments(Content.Text);
+      finally
+        Parser.Free;
+      end;
+
+      try
+        Expect<Integer>(Documents.Elements.Count).ToBe(1);
+        Obj := TGocciaObjectValue(Documents.Elements[0]);
+        Expect<string>(Obj.GetProperty('name').ToStringLiteral.Value)
+          .ToBe(NameValue);
+        Expect<string>(Obj.GetProperty(QuotedKey).ToStringLiteral.Value)
+          .ToBe('vu');
+        Expect<string>(TGocciaObjectValue(Obj.GetProperty('nested'))
+          .GetProperty('city').ToStringLiteral.Value)
+          .ToBe(CityValue);
+      finally
+        Documents.Free;
+      end;
     finally
       Content.Free;
     end;

--- a/units/Goccia.Modules.ContentProvider.Test.pas
+++ b/units/Goccia.Modules.ContentProvider.Test.pas
@@ -23,6 +23,7 @@ uses
   Goccia.Modules.Resolver,
   Goccia.Parser,
   Goccia.TestSetup,
+  Goccia.TextFiles,
   Goccia.Token,
   Goccia.TOML,
   Goccia.Values.ObjectValue,
@@ -198,9 +199,8 @@ begin
   Lexer := TGocciaLexer.Create(ASource, AFileName);
   try
     Tokens := Lexer.ScanTokens;
-    SourceLines := TStringList.Create;
+    SourceLines := CreateUTF8StringList(ASource);
     try
-      SourceLines.Text := ASource;
       Parser := TGocciaParser.Create(Tokens, AFileName, SourceLines);
       try
         Result := Parser.Parse;

--- a/units/Goccia.Modules.ContentProvider.pas
+++ b/units/Goccia.Modules.ContentProvider.pas
@@ -66,7 +66,7 @@ begin
   inherited Create;
   FLastModified := ALastModified;
   FText := AText;
-  FSourceLines := CreateUTF8StringList(FText);
+  FSourceLines := CreateUTF8FileTextLines(FText);
 end;
 
 destructor TGocciaModuleContent.Destroy;

--- a/units/Goccia.Modules.Loader.pas
+++ b/units/Goccia.Modules.Loader.pas
@@ -217,7 +217,7 @@ begin
 
   Content := FContentProvider.LoadContent(ResolvedPath);
   try
-    SourceText := Content.Text;
+    SourceText := NormalizeUTF8NewlinesToLF(Content.Text);
     JSXSourceMap := nil;
     if FJSXEnabled then
     begin

--- a/units/Goccia.Modules.Loader.pas
+++ b/units/Goccia.Modules.Loader.pas
@@ -171,7 +171,7 @@ var
   ReExportDecl: TGocciaReExportDeclaration;
   ResolvedPath: string;
   SourceModule: TGocciaModule;
-  SourceText: string;
+  SourceText: UTF8String;
   Stmt: TGocciaStatement;
   Value: TGocciaValue;
   VarInfo: TGocciaVariableInfo;
@@ -221,8 +221,8 @@ begin
     JSXSourceMap := nil;
     if FJSXEnabled then
     begin
-      JSXResult := TGocciaJSXTransformer.Transform(SourceText);
-      SourceText := JSXResult.Source;
+      JSXResult := TGocciaJSXTransformer.Transform(string(SourceText));
+      SourceText := UTF8String(JSXResult.Source);
       JSXSourceMap := JSXResult.SourceMap;
       if Assigned(JSXSourceMap) then
         WarnIfJSXExtensionMismatch(ResolvedPath);
@@ -230,7 +230,7 @@ begin
 
     try
       try
-        Lexer := TGocciaLexer.Create(SourceText, ResolvedPath);
+        Lexer := TGocciaLexer.Create(string(SourceText), ResolvedPath);
         try
           Parser := TGocciaParser.Create(Lexer.ScanTokens, ResolvedPath,
             Lexer.SourceLines);

--- a/units/Goccia.Modules.Loader.pas
+++ b/units/Goccia.Modules.Loader.pas
@@ -396,7 +396,7 @@ begin
     try
       Module.ExportsTable.AddOrSetValue(PROP_METADATA, Metadata);
       Module.ExportsTable.AddOrSetValue(PROP_CONTENT,
-        TGocciaStringLiteralValue.Create(NormalizedText));
+        TGocciaStringLiteralValue.FromUTF8(NormalizedText));
       FModules.Add(AResolvedPath, Module);
       Result := Module;
       LoadSucceeded := True;

--- a/units/Goccia.TextFiles.Test.pas
+++ b/units/Goccia.TextFiles.Test.pas
@@ -1,0 +1,108 @@
+program Goccia.TextFiles.Test;
+
+{$I Goccia.inc}
+
+uses
+  Classes,
+  SysUtils,
+
+  TestRunner,
+
+  Goccia.TestSetup,
+  Goccia.TextFiles;
+
+type
+  TTextFilesTests = class(TTestSuite)
+  private
+    procedure TestCreateUTF8StringListSplitsMixedNewlines;
+    procedure TestReadUTF8FileLinesCanonicalizesParserTextToLF;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure WriteUTF8File(const APath: string; const AText: UTF8String);
+var
+  Stream: TFileStream;
+begin
+  Stream := TFileStream.Create(APath, fmCreate);
+  try
+    if Length(AText) > 0 then
+      Stream.WriteBuffer(Pointer(AText)^, Length(AText));
+  finally
+    Stream.Free;
+  end;
+end;
+
+procedure TTextFilesTests.SetupTests;
+begin
+  Test('CreateUTF8StringList splits mixed newlines',
+    TestCreateUTF8StringListSplitsMixedNewlines);
+  Test('ReadUTF8FileLines canonicalizes parser text to LF',
+    TestReadUTF8FileLinesCanonicalizesParserTextToLF);
+end;
+
+procedure TTextFilesTests.TestCreateUTF8StringListSplitsMixedNewlines;
+var
+  Lines: TStringList;
+begin
+  Lines := CreateUTF8StringList('alpha' + #13#10 + 'beta' + #10 + 'gamma' +
+    #13 + 'delta');
+  try
+    Expect<Integer>(Lines.Count).ToBe(4);
+    Expect<string>(Lines[0]).ToBe('alpha');
+    Expect<string>(Lines[1]).ToBe('beta');
+    Expect<string>(Lines[2]).ToBe('gamma');
+    Expect<string>(Lines[3]).ToBe('delta');
+    Expect<string>(StringListToLFText(Lines)).ToBe(
+      'alpha' + #10 +
+      'beta' + #10 +
+      'gamma' + #10 +
+      'delta' + #10);
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure TTextFilesTests.TestReadUTF8FileLinesCanonicalizesParserTextToLF;
+const
+  UTF8_WORD_BYTES = 'na' + #$C3#$AF + 've';
+var
+  FilePath: string;
+  FileText: RawByteString;
+  I: Integer;
+  JoinedText: string;
+  Lines: TStringList;
+begin
+  FilePath := GetTempFileName;
+  FileText := RawByteString('cafe' + #13#10 + UTF8_WORD_BYTES + #13#10);
+  SetCodePage(FileText, CP_UTF8, False);
+  WriteUTF8File(FilePath, UTF8String(FileText));
+  try
+    Lines := ReadUTF8FileLines(FilePath);
+    try
+      Expect<Integer>(Lines.Count).ToBe(3);
+      Expect<string>(Lines[0]).ToBe('cafe');
+      Expect<Integer>(Length(Lines[1])).ToBe(Length(UTF8_WORD_BYTES));
+      for I := 1 to Length(UTF8_WORD_BYTES) do
+        Expect<Integer>(Ord(Lines[1][I])).ToBe(Ord(UTF8_WORD_BYTES[I]));
+      Expect<string>(Lines[2]).ToBe('');
+      JoinedText := StringListToLFText(Lines);
+      Expect<Integer>(Length(JoinedText)).ToBe(
+        Length('cafe' + #10 + UTF8_WORD_BYTES + #10 + #10));
+      for I := 1 to Length(JoinedText) do
+        Expect<Integer>(Ord(JoinedText[I])).ToBe(
+          Ord(('cafe' + #10 + UTF8_WORD_BYTES + #10 + #10)[I]));
+    finally
+      Lines.Free;
+    end;
+  finally
+    DeleteFile(FilePath);
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TTextFilesTests.Create('TextFiles'));
+  TestRunnerProgram.Run;
+
+  ExitCode := TestResultToExitCode;
+end.

--- a/units/Goccia.TextFiles.Test.pas
+++ b/units/Goccia.TextFiles.Test.pas
@@ -15,6 +15,7 @@ type
   TTextFilesTests = class(TTestSuite)
   private
     procedure TestCreateUTF8StringListSplitsMixedNewlines;
+    procedure TestNormalizeUTF8NewlinesToLFPreservesUTF8Bytes;
     procedure TestReadUTF8FileLinesCanonicalizesParserTextToLF;
   public
     procedure SetupTests; override;
@@ -37,6 +38,8 @@ procedure TTextFilesTests.SetupTests;
 begin
   Test('CreateUTF8StringList splits mixed newlines',
     TestCreateUTF8StringListSplitsMixedNewlines);
+  Test('NormalizeUTF8NewlinesToLF preserves UTF-8 bytes',
+    TestNormalizeUTF8NewlinesToLFPreservesUTF8Bytes);
   Test('ReadUTF8FileLines canonicalizes parser text to LF',
     TestReadUTF8FileLinesCanonicalizesParserTextToLF);
 end;
@@ -57,10 +60,30 @@ begin
       'alpha' + #10 +
       'beta' + #10 +
       'gamma' + #10 +
-      'delta' + #10);
+      'delta');
   finally
     Lines.Free;
   end;
+end;
+
+procedure TTextFilesTests.TestNormalizeUTF8NewlinesToLFPreservesUTF8Bytes;
+const
+  UTF8_WORD_BYTES = 'na' + #$C3#$AF + 've';
+var
+  I: Integer;
+  InputText: RawByteString;
+  NormalizedText: UTF8String;
+begin
+  InputText := RawByteString('first' + #13#10 + UTF8_WORD_BYTES + #13);
+  SetCodePage(InputText, CP_UTF8, False);
+
+  NormalizedText := NormalizeUTF8NewlinesToLF(UTF8String(InputText));
+
+  Expect<Integer>(Length(NormalizedText)).ToBe(
+    Length('first' + #10 + UTF8_WORD_BYTES + #10));
+  for I := 1 to Length(NormalizedText) do
+    Expect<Integer>(Ord(NormalizedText[I])).ToBe(
+      Ord(('first' + #10 + UTF8_WORD_BYTES + #10)[I]));
 end;
 
 procedure TTextFilesTests.TestReadUTF8FileLinesCanonicalizesParserTextToLF;
@@ -88,10 +111,10 @@ begin
       Expect<string>(Lines[2]).ToBe('');
       JoinedText := StringListToLFText(Lines);
       Expect<Integer>(Length(JoinedText)).ToBe(
-        Length('cafe' + #10 + UTF8_WORD_BYTES + #10 + #10));
+        Length('cafe' + #10 + UTF8_WORD_BYTES + #10));
       for I := 1 to Length(JoinedText) do
         Expect<Integer>(Ord(JoinedText[I])).ToBe(
-          Ord(('cafe' + #10 + UTF8_WORD_BYTES + #10 + #10)[I]));
+          Ord(('cafe' + #10 + UTF8_WORD_BYTES + #10)[I]));
     finally
       Lines.Free;
     end;

--- a/units/Goccia.TextFiles.pas
+++ b/units/Goccia.TextFiles.pas
@@ -9,13 +9,19 @@ uses
 
 function RetagUTF8Text(const ABytes: RawByteString): string;
 function CreateUTF8StringList(const AText: string): TStringList;
+function CreateUTF8FileTextLines(const AText: UTF8String): TStringList;
+function NormalizeNewlinesToLF(const AText: string): string;
 function NormalizeUTF8NewlinesToLF(const AText: UTF8String): UTF8String;
 function ReadUTF8FileText(const APath: string): UTF8String;
+function ReadUTF8FileLines(const APath: string): TStringList;
+function StringListToLFText(const ALines: TStrings): string;
 
 implementation
 
 uses
-  SysUtils;
+  SysUtils,
+
+  StringBuffer;
 
 function RetagUTF8Text(const ABytes: RawByteString): string;
 var
@@ -59,10 +65,54 @@ begin
     Result.Add('');
 end;
 
-function NormalizeUTF8NewlinesToLF(const AText: UTF8String): UTF8String;
+function CreateUTF8FileTextLines(const AText: UTF8String): TStringList;
+var
+  LineText: UTF8String;
+  LineStart: Integer;
+  TextIndex: Integer;
+begin
+  Result := TStringList.Create;
+  LineStart := 1;
+  TextIndex := 1;
+
+  while TextIndex <= Length(AText) do
+  begin
+    if AText[TextIndex] = #13 then
+    begin
+      LineText := Copy(AText, LineStart, TextIndex - LineStart);
+      Result.Add(string(LineText));
+      if (TextIndex < Length(AText)) and (AText[TextIndex + 1] = #10) then
+        Inc(TextIndex);
+      LineStart := TextIndex + 1;
+    end
+    else if AText[TextIndex] = #10 then
+    begin
+      LineText := Copy(AText, LineStart, TextIndex - LineStart);
+      Result.Add(string(LineText));
+      LineStart := TextIndex + 1;
+    end;
+    Inc(TextIndex);
+  end;
+
+  if LineStart <= Length(AText) then
+  begin
+    LineText := Copy(AText, LineStart, Length(AText) - LineStart + 1);
+    Result.Add(string(LineText));
+  end
+  else if (Length(AText) > 0) and ((AText[Length(AText)] = #10) or
+    (AText[Length(AText)] = #13)) then
+    Result.Add('');
+end;
+
+function NormalizeNewlinesToLF(const AText: string): string;
 begin
   Result := StringReplace(AText, #13#10, #10, [rfReplaceAll]);
   Result := StringReplace(Result, #13, #10, [rfReplaceAll]);
+end;
+
+function NormalizeUTF8NewlinesToLF(const AText: UTF8String): UTF8String;
+begin
+  Result := UTF8String(NormalizeNewlinesToLF(string(AText)));
 end;
 
 function ReadUTF8FileText(const APath: string): UTF8String;
@@ -79,7 +129,31 @@ begin
     Stream.Free;
   end;
 
-  Result := UTF8String(RetagUTF8Text(SourceText));
+  SetCodePage(SourceText, CP_UTF8, False);
+  Result := UTF8String(SourceText);
+end;
+
+function ReadUTF8FileLines(const APath: string): TStringList;
+begin
+  Result := CreateUTF8FileTextLines(ReadUTF8FileText(APath));
+end;
+
+function StringListToLFText(const ALines: TStrings): string;
+var
+  Buffer: TStringBuffer;
+  I: Integer;
+begin
+  if not Assigned(ALines) then
+    Exit('');
+
+  Buffer := TStringBuffer.Create;
+  for I := 0 to ALines.Count - 1 do
+  begin
+    Buffer.Append(ALines[I]);
+    Buffer.AppendChar(#10);
+  end;
+
+  Result := Buffer.ToString;
 end;
 
 initialization

--- a/units/Goccia.TextFiles.pas
+++ b/units/Goccia.TextFiles.pas
@@ -110,9 +110,19 @@ begin
   Result := StringReplace(Result, #13, #10, [rfReplaceAll]);
 end;
 
-function NormalizeUTF8NewlinesToLF(const AText: UTF8String): UTF8String;
+function NormalizeRawNewlinesToLF(const AText: RawByteString): RawByteString;
 begin
-  Result := UTF8String(NormalizeNewlinesToLF(string(AText)));
+  Result := StringReplace(AText, #13#10, #10, [rfReplaceAll]);
+  Result := StringReplace(Result, #13, #10, [rfReplaceAll]);
+end;
+
+function NormalizeUTF8NewlinesToLF(const AText: UTF8String): UTF8String;
+var
+  NormalizedBytes: RawByteString;
+begin
+  NormalizedBytes := NormalizeRawNewlinesToLF(RawByteString(AText));
+  SetCodePage(NormalizedBytes, CP_UTF8, False);
+  Result := UTF8String(NormalizedBytes);
 end;
 
 function ReadUTF8FileText(const APath: string): UTF8String;
@@ -149,8 +159,9 @@ begin
   Buffer := TStringBuffer.Create;
   for I := 0 to ALines.Count - 1 do
   begin
+    if I > 0 then
+      Buffer.AppendChar(#10);
     Buffer.Append(ALines[I]);
-    Buffer.AppendChar(#10);
   end;
 
   Result := Buffer.ToString;

--- a/units/Goccia.Values.Primitives.Test.pas
+++ b/units/Goccia.Values.Primitives.Test.pas
@@ -18,6 +18,7 @@ type
     procedure TestStringValueContent;
     procedure TestStringValueEmpty;
     procedure TestStringValueNumber;
+    procedure TestStringValueFromUTF8;
     procedure TestNumberValue;
     procedure TestNumberValueNaN;
     procedure TestNumberValueInfinity;
@@ -36,6 +37,7 @@ begin
   Test('String value with content', TestStringValueContent);
   Test('String value with empty content', TestStringValueEmpty);
   Test('String value with number content', TestStringValueNumber);
+  Test('String value from UTF-8 text', TestStringValueFromUTF8);
   Test('Number value', TestNumberValue);
   Test('NaN value', TestNumberValueNaN);
   Test('Infinity value', TestNumberValueInfinity);
@@ -87,6 +89,19 @@ begin
   Expect<string>(Value.ToStringLiteral.Value).ToBe('123.456');
   Expect<Boolean>(Value.ToBooleanLiteral.Value).ToBe(True);
   Expect<Double>(Value.ToNumberLiteral.Value).ToBe(123.456);
+  Expect<string>(Value.TypeName).ToBe('string');
+end;
+
+procedure TTestPrimitives.TestStringValueFromUTF8;
+var
+  UTF8Bytes: RawByteString;
+  Value: TGocciaStringLiteralValue;
+begin
+  UTF8Bytes := 'Caf' + #$C3#$A9 + ' d' + #$C3#$A9 + 'j' + #$C3#$A0 + ' vu';
+  SetCodePage(UTF8Bytes, CP_UTF8, False);
+  Value := TGocciaStringLiteralValue.FromUTF8(UTF8String(UTF8Bytes));
+  Expect<string>(Value.ToStringLiteral.Value).ToBe('Café déjà vu');
+  Expect<Boolean>(Value.ToBooleanLiteral.Value).ToBe(True);
   Expect<string>(Value.TypeName).ToBe('string');
 end;
 

--- a/units/Goccia.Values.Primitives.pas
+++ b/units/Goccia.Values.Primitives.pas
@@ -141,6 +141,7 @@ type
     FValue: string;
   public
     constructor Create(const AValue: string);
+    class function FromUTF8(const AValue: UTF8String): TGocciaStringLiteralValue;
 
     function IsPrimitive: Boolean; override;
     function TypeName: string; override;
@@ -167,6 +168,7 @@ uses
 
   Goccia.Constants,
   Goccia.Constants.TypeNames,
+  Goccia.TextFiles,
   Goccia.Values.ClassHelper;
 
 { TGocciaValue }
@@ -541,6 +543,15 @@ end;
 constructor TGocciaStringLiteralValue.Create(const AValue: string);
 begin
   FValue := AValue;
+end;
+
+class function TGocciaStringLiteralValue.FromUTF8(
+  const AValue: UTF8String): TGocciaStringLiteralValue;
+var
+  UTF8Bytes: RawByteString;
+begin
+  UTF8Bytes := AValue;
+  Result := TGocciaStringLiteralValue.Create(RetagUTF8Text(UTF8Bytes));
 end;
 
 function TGocciaStringLiteralValue.TypeName: string;

--- a/units/Goccia.YAML.pas
+++ b/units/Goccia.YAML.pas
@@ -115,8 +115,10 @@ type
     constructor Create;
     destructor Destroy; override;
 
-    function Parse(const AText: string): TGocciaValue;
-    function ParseDocuments(const AText: string): TGocciaArrayValue;
+    function Parse(const AText: string): TGocciaValue; overload;
+    function Parse(const AText: UTF8String): TGocciaValue; overload;
+    function ParseDocuments(const AText: string): TGocciaArrayValue; overload;
+    function ParseDocuments(const AText: UTF8String): TGocciaArrayValue; overload;
   end;
 
 implementation
@@ -2172,6 +2174,11 @@ begin
   end;
 end;
 
+function TGocciaYAMLParser.Parse(const AText: UTF8String): TGocciaValue;
+begin
+  Result := Parse(RetagUTF8Text(RawByteString(AText)));
+end;
+
 function TGocciaYAMLParser.ParseDocuments(const AText: string): TGocciaArrayValue;
 var
   DocumentIndex: Integer;
@@ -2185,6 +2192,12 @@ begin
   finally
     DocumentText.Free;
   end;
+end;
+
+function TGocciaYAMLParser.ParseDocuments(
+  const AText: UTF8String): TGocciaArrayValue;
+begin
+  Result := ParseDocuments(RetagUTF8Text(RawByteString(AText)));
 end;
 
 function TGocciaYAMLParser.ParseNode(const AIndent: Integer): TGocciaValue;

--- a/units/Goccia.YAML.pas
+++ b/units/Goccia.YAML.pas
@@ -128,7 +128,8 @@ uses
   base64,
 
   Goccia.Constants.PropertyNames,
-  Goccia.Temporal.Utils;
+  Goccia.Temporal.Utils,
+  Goccia.TextFiles;
 
 type
   TGocciaYAMLTaggedValue = class(TGocciaValue)
@@ -1253,7 +1254,7 @@ var
   procedure FlushCurrentDocument(const AForce: Boolean);
   begin
     if AForce or HasContent then
-      Result.Add(CurrentDocument.Text);
+      Result.Add(StringListToLFText(CurrentDocument));
     CurrentDocument.Clear;
     DocumentOpen := False;
     HasContent := False;
@@ -1261,14 +1262,13 @@ var
 
 begin
   Result := TStringList.Create;
-  Source := TStringList.Create;
+  Source := CreateUTF8StringList(AText);
   CurrentDocument := TStringList.Create;
   try
     DocumentOpen := False;
     HasContent := False;
     InBlockScalar := False;
     BlockScalarIndent := 0;
-    Source.Text := AText;
 
     for I := 0 to Source.Count - 1 do
     begin
@@ -1352,9 +1352,8 @@ var
   LineText: string;
   Source: TStringList;
 begin
-  Source := TStringList.Create;
+  Source := CreateUTF8StringList(AText);
   try
-    Source.Text := AText;
     InBlockScalar := False;
     BlockScalarIndent := 0;
     for I := 0 to Source.Count - 1 do
@@ -2074,9 +2073,8 @@ var
   Source: TStringList;
 begin
   Reset;
-  Source := TStringList.Create;
+  Source := CreateUTF8StringList(AText);
   try
-    Source.Text := AText;
     SeenContent := False;
     for I := 0 to Source.Count - 1 do
     begin


### PR DESCRIPTION
## Summary
- Standardized file-backed text loading through `Goccia.TextFiles` helpers so parser and tooling paths normalize source text to LF consistently.
- Replaced ad hoc `TStringList.LoadFromFile` / `.Text` usage in loader, engine, benchmark, JSX, YAML, and JSON5 paths with UTF-8-aware helpers.
- Added focused regression coverage for mixed newline handling and real file input parsing, including non-ASCII content.
- Updated testing guidance to document the canonical helper-based workflow for parser inputs.

## Testing
- Added/updated Pascal regressions in `units/Goccia.TextFiles.Test.pas` and related unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UTF‑8 text utilities for reliable file reading and LF newline normalization.

* **Tests**
  * Added a test suite validating UTF‑8 line splitting, normalization, and file read behavior with mixed newlines.

* **Refactor**
  * Standardized text handling across the codebase to use the new UTF‑8 helpers and produce canonical LF line endings.

* **Documentation**
  * Updated testing guidance to require UTF‑8 helpers and LF canonicalization for parser inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->