### PR TITLE
Handle mixed type-only imports and exports

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -367,6 +367,9 @@ GocciaScript implements the [TC39 Types as Comments](https://tc39.es/proposal-ty
 | `interface X { ... }` | Skipped → `TGocciaEmptyStatement` |
 | `import type { ... }` | Skipped → `TGocciaEmptyStatement` |
 | `export type { ... }` | Skipped → `TGocciaEmptyStatement` |
+| `import { value, type T } from ...` | Value binding kept; type-only binding skipped |
+| `export { value, type T }` | Value export kept; type-only binding skipped |
+| `export interface X { ... }` | Skipped → `TGocciaEmptyStatement` |
 
 ## String Interning — Attempted and Rejected
 

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -496,6 +496,15 @@ interface Animal { name: string; speak(): string; }
 import type { Foo } from './types.js';
 export type { Bar };
 
+// Mixed type/value named bindings keep runtime imports/exports for value bindings
+import { parseSourceFile, type SourceFile } from "./parser.js";
+export { value, type ValueShape };
+
+// export interface declarations are skipped entirely
+export interface Serializable {
+  toJSON(): string;
+}
+
 // as Type and as const assertions
 const x = 42 as number;
 const colors = ["red", "green"] as const;

--- a/tests/language/types-as-comments/helpers/exported-interface.js
+++ b/tests/language/types-as-comments/helpers/exported-interface.js
@@ -1,0 +1,5 @@
+export interface Person {
+  name: string;
+}
+
+export const answer = 42;

--- a/tests/language/types-as-comments/helpers/mixed-type-export.js
+++ b/tests/language/types-as-comments/helpers/mixed-type-export.js
@@ -1,0 +1,3 @@
+const value = 1;
+
+export { value, type MissingType };

--- a/tests/language/types-as-comments/helpers/type-only-only-side-effect.js
+++ b/tests/language/types-as-comments/helpers/type-only-only-side-effect.js
@@ -1,0 +1,7 @@
+if (globalThis.__typeOnlyNamedImportLoaded === undefined) {
+  globalThis.__typeOnlyNamedImportLoaded = 0;
+}
+
+globalThis.__typeOnlyNamedImportLoaded = globalThis.__typeOnlyNamedImportLoaded + 1;
+
+export const sentinel = 11;

--- a/tests/language/types-as-comments/helpers/type-only-side-effect.js
+++ b/tests/language/types-as-comments/helpers/type-only-side-effect.js
@@ -1,0 +1,7 @@
+if (globalThis.__typeOnlyImportLoaded === undefined) {
+  globalThis.__typeOnlyImportLoaded = 0;
+}
+
+globalThis.__typeOnlyImportLoaded = globalThis.__typeOnlyImportLoaded + 1;
+
+export const runtimeValue = 7;

--- a/tests/language/types-as-comments/helpers/type-renamed-export.js
+++ b/tests/language/types-as-comments/helpers/type-renamed-export.js
@@ -1,0 +1,3 @@
+const type = 9;
+
+export { type as kind };

--- a/tests/language/types-as-comments/helpers/type-value-export.js
+++ b/tests/language/types-as-comments/helpers/type-value-export.js
@@ -1,0 +1,1 @@
+export const type = 7;

--- a/tests/language/types-as-comments/import-export-type.js
+++ b/tests/language/types-as-comments/import-export-type.js
@@ -5,7 +5,9 @@ features: [types-as-comments]
 
 import { runtimeValue, type MissingValueType } from "./helpers/type-only-side-effect.js";
 import { type PhantomType } from "./helpers/type-only-only-side-effect.js";
+import { type as kind } from "./helpers/type-value-export.js";
 import { value } from "./helpers/mixed-type-export.js";
+import { kind as exportedKind } from "./helpers/type-renamed-export.js";
 import { answer } from "./helpers/exported-interface.js";
 
 test("import type is skipped", () => {
@@ -30,6 +32,14 @@ test("type-only named import still loads the module at runtime", () => {
 
 test("mixed export keeps value exports and skips type-only bindings", () => {
   expect(value).toBe(1);
+});
+
+test("type named binding can still be imported as a value", () => {
+  expect(kind).toBe(7);
+});
+
+test("type named export can still be re-exported as a value binding", () => {
+  expect(exportedKind).toBe(9);
 });
 
 test("export interface is skipped while value exports remain available", () => {

--- a/tests/language/types-as-comments/import-export-type.js
+++ b/tests/language/types-as-comments/import-export-type.js
@@ -1,7 +1,12 @@
 /*---
-description: import type and export type declarations are parsed and ignored at runtime
+description: type-only module syntax is parsed correctly and preserves runtime behavior
 features: [types-as-comments]
 ---*/
+
+import { runtimeValue, type MissingValueType } from "./helpers/type-only-side-effect.js";
+import { type PhantomType } from "./helpers/type-only-only-side-effect.js";
+import { value } from "./helpers/mixed-type-export.js";
+import { answer } from "./helpers/exported-interface.js";
 
 test("import type is skipped", () => {
   import type { Foo } from './nonexistent.js';
@@ -13,4 +18,20 @@ test("export type is skipped", () => {
   export type { Bar };
   const y = "hello";
   expect(y).toBe("hello");
+});
+
+test("mixed import keeps runtime bindings and skips type-only bindings", () => {
+  expect(runtimeValue).toBe(7);
+});
+
+test("type-only named import still loads the module at runtime", () => {
+  expect(globalThis.__typeOnlyNamedImportLoaded).toBe(1);
+});
+
+test("mixed export keeps value exports and skips type-only bindings", () => {
+  expect(value).toBe(1);
+});
+
+test("export interface is skipped while value exports remain available", () => {
+  expect(answer).toBe(42);
 });

--- a/tests/language/types-as-comments/unsupported-function-annotations.js
+++ b/tests/language/types-as-comments/unsupported-function-annotations.js
@@ -15,9 +15,29 @@ test("typed function declaration is skipped", () => {
   expect(typeof foo).toBe("undefined");
 });
 
+test("typed function declaration with object return type is skipped", () => {
+  let x = 1;
+
+  function foo(): { value: number } {
+    x = 99;
+    return { value: 1 };
+  }
+
+  expect(x).toBe(1);
+  expect(typeof foo).toBe("undefined");
+});
+
 test("typed function expression evaluates to undefined", () => {
   const fn = function <T>(value: T): T {
     return value;
+  };
+
+  expect(fn).toBe(undefined);
+});
+
+test("typed function expression with object return type evaluates to undefined", () => {
+  const fn = function (): { value: number } {
+    return { value: 1 };
   };
 
   expect(fn).toBe(undefined);

--- a/tests/language/types-as-comments/unsupported-function-annotations.js
+++ b/tests/language/types-as-comments/unsupported-function-annotations.js
@@ -1,0 +1,24 @@
+/*---
+description: typed annotations on unsupported function syntax still follow GocciaScript's graceful function fallback
+features: [types-as-comments, parser-warnings, unsupported-features]
+---*/
+
+test("typed function declaration is skipped", () => {
+  let x = 1;
+
+  function foo<T>(value: T): T {
+    x = 99;
+    return value;
+  }
+
+  expect(x).toBe(1);
+  expect(typeof foo).toBe("undefined");
+});
+
+test("typed function expression evaluates to undefined", () => {
+  const fn = function <T>(value: T): T {
+    return value;
+  };
+
+  expect(fn).toBe(undefined);
+});

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -116,6 +116,7 @@ type
     procedure SkipBalancedParens;
     procedure SkipStatementOrBlock;
     procedure SkipUnsupportedFunctionSignature;
+    function IsTypeOnlySpecifierModifier: Boolean;
     procedure SkipInterfaceDeclaration;
     function IsTypeDeclaration: Boolean;
 
@@ -1914,6 +1915,13 @@ begin
     Advance;
 end;
 
+function TGocciaParser.IsTypeOnlySpecifierModifier: Boolean;
+begin
+  Result := Check(gttIdentifier) and (Peek.Lexeme = KEYWORD_TYPE) and
+    (FCurrent + 1 < FTokens.Count) and
+    (FTokens[FCurrent + 1].TokenType in [gttIdentifier, gttString]);
+end;
+
 function TGocciaParser.VarStatement: TGocciaStatement;
 var
   Line, Column: Integer;
@@ -2437,7 +2445,7 @@ begin
 
   while not Check(gttRightBrace) and not IsAtEnd do
   begin
-    IsTypeOnlyBinding := Check(gttIdentifier) and (Peek.Lexeme = KEYWORD_TYPE);
+    IsTypeOnlyBinding := IsTypeOnlySpecifierModifier;
     if IsTypeOnlyBinding then
       Advance;
 
@@ -2577,7 +2585,7 @@ begin
 
   while not Check(gttRightBrace) and not IsAtEnd do
   begin
-    IsTypeOnlyBinding := Check(gttIdentifier) and (Peek.Lexeme = KEYWORD_TYPE);
+    IsTypeOnlyBinding := IsTypeOnlySpecifierModifier;
     if IsTypeOnlyBinding then
       Advance;
 

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -115,6 +115,7 @@ type
     procedure SkipBlock;
     procedure SkipBalancedParens;
     procedure SkipStatementOrBlock;
+    procedure SkipUnsupportedFunctionSignature;
     procedure SkipInterfaceDeclaration;
     function IsTypeDeclaration: Boolean;
 
@@ -964,10 +965,7 @@ begin
     AddWarning('''function'' expressions are not supported in GocciaScript',
       'Use arrow functions instead: const name = (...) => { ... }',
       Token.Line, Token.Column);
-    if Check(gttStar) then Advance;
-    if Check(gttIdentifier) then Advance;
-    SkipBalancedParens;
-    SkipBlock;
+    SkipUnsupportedFunctionSignature;
     Result := TGocciaLiteralExpression.Create(
       TGocciaUndefinedLiteralValue.UndefinedValue, Token.Line, Token.Column);
   end
@@ -1792,6 +1790,30 @@ begin
     SkipUntilSemicolon;
 end;
 
+procedure TGocciaParser.SkipUnsupportedFunctionSignature;
+begin
+  if Check(gttStar) then
+    Advance;
+  if Check(gttIdentifier) then
+    Advance;
+
+  CollectGenericParameters;
+
+  if Check(gttLeftParen) then
+    SkipBalancedParens;
+
+  if Check(gttColon) then
+  begin
+    Advance;
+    CollectTypeAnnotation([gttLeftBrace, gttSemicolon]);
+  end;
+
+  if Check(gttLeftBrace) then
+    SkipBlock
+  else if Check(gttSemicolon) then
+    Advance;
+end;
+
 function TGocciaParser.VarStatement: TGocciaStatement;
 var
   Line, Column: Integer;
@@ -1972,10 +1994,7 @@ begin
     'Use arrow functions instead: const name = (...) => { ... }',
     Line, Column);
 
-  if Check(gttStar) then Advance;
-  if Check(gttIdentifier) then Advance;
-  SkipBalancedParens;
-  SkipBlock;
+  SkipUnsupportedFunctionSignature;
 
   Result := TGocciaEmptyStatement.Create(Line, Column);
 end;
@@ -2265,6 +2284,7 @@ var
   ImportedName, LocalName, ModulePath, NamespaceName: string;
   ImportedNameToken: TGocciaToken;
   Line, Column: Integer;
+  IsTypeOnlyBinding: Boolean;
 begin
   Line := Previous.Line;
   Column := Previous.Column;
@@ -2317,6 +2337,10 @@ begin
 
   while not Check(gttRightBrace) and not IsAtEnd do
   begin
+    IsTypeOnlyBinding := Check(gttIdentifier) and (Peek.Lexeme = KEYWORD_TYPE);
+    if IsTypeOnlyBinding then
+      Advance;
+
     ImportedNameToken := ConsumeModuleExportName('Expected import name');
     ImportedName := ImportedNameToken.Lexeme;
 
@@ -2330,7 +2354,8 @@ begin
     else
       LocalName := ImportedName;
 
-    Imports.Add(LocalName, ImportedName);
+    if not IsTypeOnlyBinding then
+      Imports.Add(LocalName, ImportedName);
 
     if not Match(gttComma) then
       Break;
@@ -2359,6 +2384,7 @@ var
   SpecifierCount: Integer;
   NameToken: TGocciaToken;
   IsReExport: Boolean;
+  IsTypeOnlyBinding: Boolean;
   I: Integer;
 
   function HasFromClauseAfterNamedExports: Boolean;
@@ -2384,6 +2410,15 @@ begin
     Exit;
   end;
 
+  if Check(gttIdentifier) and (Peek.Lexeme = KEYWORD_INTERFACE) and IsTypeDeclaration then
+  begin
+    Advance;
+    Advance;
+    SkipInterfaceDeclaration;
+    Result := TGocciaEmptyStatement.Create(Line, Column);
+    Exit;
+  end;
+
   if Check(gttDefault) then
   begin
     AddWarning('Default exports are not supported in GocciaScript',
@@ -2399,10 +2434,7 @@ begin
     else if Check(gttFunction) then
     begin
       Advance;
-      if Check(gttStar) then Advance;
-      if Check(gttIdentifier) then Advance;
-      SkipBalancedParens;
-      SkipBlock;
+      SkipUnsupportedFunctionSignature;
     end
     else
       SkipUntilSemicolon;
@@ -2445,6 +2477,10 @@ begin
 
   while not Check(gttRightBrace) and not IsAtEnd do
   begin
+    IsTypeOnlyBinding := Check(gttIdentifier) and (Peek.Lexeme = KEYWORD_TYPE);
+    if IsTypeOnlyBinding then
+      Advance;
+
     NameToken := ConsumeModuleExportName('Expected export name');
     LocalName := NameToken.Lexeme;
 
@@ -2454,17 +2490,20 @@ begin
     else
       ExportedName := LocalName;
 
-    SetLength(LocalNames, SpecifierCount + 1);
-    SetLength(ExportedNames, SpecifierCount + 1);
-    SetLength(LocalNameTokenTypes, SpecifierCount + 1);
-    SetLength(LocalNameLines, SpecifierCount + 1);
-    SetLength(LocalNameColumns, SpecifierCount + 1);
-    LocalNames[SpecifierCount] := LocalName;
-    ExportedNames[SpecifierCount] := ExportedName;
-    LocalNameTokenTypes[SpecifierCount] := NameToken.TokenType;
-    LocalNameLines[SpecifierCount] := NameToken.Line;
-    LocalNameColumns[SpecifierCount] := NameToken.Column;
-    Inc(SpecifierCount);
+    if not IsTypeOnlyBinding then
+    begin
+      SetLength(LocalNames, SpecifierCount + 1);
+      SetLength(ExportedNames, SpecifierCount + 1);
+      SetLength(LocalNameTokenTypes, SpecifierCount + 1);
+      SetLength(LocalNameLines, SpecifierCount + 1);
+      SetLength(LocalNameColumns, SpecifierCount + 1);
+      LocalNames[SpecifierCount] := LocalName;
+      ExportedNames[SpecifierCount] := ExportedName;
+      LocalNameTokenTypes[SpecifierCount] := NameToken.TokenType;
+      LocalNameLines[SpecifierCount] := NameToken.Line;
+      LocalNameColumns[SpecifierCount] := NameToken.Column;
+      Inc(SpecifierCount);
+    end;
 
     if not Match(gttComma) then
       Break;

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -1791,6 +1791,63 @@ begin
 end;
 
 procedure TGocciaParser.SkipUnsupportedFunctionSignature;
+  function TokenAfterBalancedBraces: TGocciaToken;
+  var
+    Depth: Integer;
+    ScanIndex: Integer;
+  begin
+    ScanIndex := FCurrent;
+    Depth := 0;
+
+    while ScanIndex < FTokens.Count do
+    begin
+      case FTokens[ScanIndex].TokenType of
+        gttLeftBrace:
+          Inc(Depth);
+        gttRightBrace:
+          begin
+            Dec(Depth);
+            if Depth = 0 then
+            begin
+              Inc(ScanIndex);
+              Break;
+            end;
+          end;
+      end;
+      Inc(ScanIndex);
+    end;
+
+    if ScanIndex < FTokens.Count then
+      Result := FTokens[ScanIndex]
+    else
+      Result := FTokens[FTokens.Count - 1];
+  end;
+
+  function IsReturnTypeContinuationToken(const AToken: TGocciaToken): Boolean;
+  begin
+    case AToken.TokenType of
+      gttBitwiseAnd,
+      gttBitwiseOr,
+      gttQuestion,
+      gttLeftBracket,
+      gttLess,
+      gttGreater,
+      gttRightShift,
+      gttUnsignedRightShift:
+        Exit(True);
+    end;
+
+    if (AToken.TokenType = gttIdentifier) and
+      ((AToken.Lexeme = KEYWORD_AS) or
+       (AToken.Lexeme = KEYWORD_EXTENDS)) then
+      Exit(True);
+
+    Result := False;
+  end;
+
+var
+  NestingDepth: Integer;
+  FollowingToken: TGocciaToken;
 begin
   if Check(gttStar) then
     Advance;
@@ -1805,7 +1862,50 @@ begin
   if Check(gttColon) then
   begin
     Advance;
-    CollectTypeAnnotation([gttLeftBrace, gttSemicolon]);
+
+    NestingDepth := 0;
+    while not IsAtEnd do
+    begin
+      if (NestingDepth = 0) and Check(gttSemicolon) then
+        Break;
+
+      if Check(gttLeftBrace) then
+      begin
+        FollowingToken := TokenAfterBalancedBraces;
+        if (NestingDepth > 0) or
+          (FollowingToken.TokenType = gttLeftBrace) or
+          IsReturnTypeContinuationToken(FollowingToken) then
+        begin
+          SkipBlock;
+          Continue;
+        end;
+        Break;
+      end;
+
+      case Peek.TokenType of
+        gttLeftParen,
+        gttLeftBracket,
+        gttLess:
+          Inc(NestingDepth);
+        gttRightParen,
+        gttRightBracket,
+        gttGreater:
+          if NestingDepth > 0 then
+            Dec(NestingDepth);
+        gttRightShift:
+          if NestingDepth > 0 then
+          begin
+            Dec(NestingDepth);
+            if NestingDepth > 0 then
+              Dec(NestingDepth);
+          end;
+        gttUnsignedRightShift:
+          while NestingDepth > 0 do
+            Dec(NestingDepth);
+      end;
+
+      Advance;
+    end;
   end;
 
   if Check(gttLeftBrace) then


### PR DESCRIPTION
## Summary
- Teach the parser to skip `type`-only specifiers inside mixed `import { ... }` and `export { ... }` lists while preserving runtime value bindings.
- Add support for skipping `export interface` declarations as type-only syntax.
- Extend unsupported function-syntax handling so typed/generic signatures are skipped cleanly.
- Add regression coverage for mixed type/value module bindings, type-only import side effects, and typed unsupported function syntax.
- Update the language restrictions and design-decision docs to reflect the new behavior.

## Testing
- Added/updated JavaScript regression tests under `tests/language/types-as-comments/` for mixed imports/exports and `export interface` handling.
- Added parser coverage for typed unsupported function declarations and expressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated guidance on handling type declarations and mixed import/export syntax
  * Clarified behavior when type-only declarations are used alongside value exports

* **Improvements**
  * Enhanced parsing of type-only imports and exports
  * Improved handling of unsupported function syntax with type annotations

* **Tests**
  * Added comprehensive test coverage for type-only and mixed declaration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->