### PR TITLE
Add default GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -14,6 +14,7 @@ Why is this needed?
 
 ## Current behavior
 What happens today?
+Optional for bugs: include reproduction steps and environment details (OS, versions, flags, or config).
 
 ## Expected behavior
 What should happen instead?

--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,22 @@
+---
+name: Issue
+about: Propose a feature, fix, or scoped change
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Summary
+What should change?
+
+## Why
+Why is this needed?
+
+## Current behavior
+What happens today?
+
+## Expected behavior
+What should happen instead?
+
+## Scope notes
+Constraints, non-goals, related issues, or implementation notes.


### PR DESCRIPTION
## Summary
- Added a default GitHub issue template at `.github/ISSUE_TEMPLATE/default.md`.
- The template prompts reporters to describe the change, rationale, current behavior, expected behavior, and scope notes.
- Includes frontmatter fields for name, about, title, labels, and assignees.

## Testing
- Not run (documentation-only change).
- Verified the new template file was added with the expected issue sections and frontmatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a standardized GitHub issue template to streamline issue submissions. The template includes predefined sections for Summary, rationale, current behavior, expected behavior, and scope, helping contributors provide comprehensive information when reporting issues or requesting features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->