### PR TITLE
Report bytecode timing phases separately

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -650,6 +650,13 @@ jobs:
               const bSkipped = testBytecode ? testBytecode.skipped : 0;
               const iDur = testInterp ? fmtDur(testInterp.durationNanoseconds) : '—';
               const bDur = testBytecode ? fmtDur(testBytecode.durationNanoseconds) : '—';
+              const iLex = testInterp ? fmtDur(testInterp.lexTimeNanoseconds) : '—';
+              const bLex = testBytecode ? fmtDur(testBytecode.lexTimeNanoseconds) : '—';
+              const iParse = testInterp ? fmtDur(testInterp.parseTimeNanoseconds) : '—';
+              const bParse = testBytecode ? fmtDur(testBytecode.parseTimeNanoseconds) : '—';
+              const bCompile = testBytecode ? fmtDur(testBytecode.compileTimeNanoseconds) : '—';
+              const iExec = testInterp ? fmtDur(testInterp.executeTimeNanoseconds) : '—';
+              const bExec = testBytecode ? fmtDur(testBytecode.executeTimeNanoseconds) : '—';
               const iEngine = testInterp ? fmtDur(testInterp.totalEngineNanoseconds) : '—';
               const bEngine = testBytecode ? fmtDur(testBytecode.totalEngineNanoseconds) : '—';
 
@@ -659,8 +666,12 @@ jobs:
                 body += `| Tests | Failed | ${iFailed > 0 ? `${iFailed} ❌` : '0'} | ${bFailed > 0 ? `${bFailed} ❌` : '0'} |\n`;
               if (iSkipped > 0 || bSkipped > 0)
                 body += `| Tests | Skipped | ${iSkipped} | ${bSkipped} |\n`;
-              body += `| Tests | Execution | ${iDur} | ${bDur} |\n`;
-              body += `| Tests | Engine | ${iEngine} | ${bEngine} |\n`;
+              body += `| Tests | Test Duration | ${iDur} | ${bDur} |\n`;
+              body += `| Tests | Lex | ${iLex} | ${bLex} |\n`;
+              body += `| Tests | Parse | ${iParse} | ${bParse} |\n`;
+              body += `| Tests | Compile | — | ${bCompile} |\n`;
+              body += `| Tests | Execute | ${iExec} | ${bExec} |\n`;
+              body += `| Tests | Engine Total | ${iEngine} | ${bEngine} |\n`;
             }
 
             if (benchInterp || benchBytecode) {

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -221,7 +221,7 @@ var
   FileResult: TBenchmarkFileResult;
   ScriptResult: TGocciaObjectValue;
   BenchGlobals: TGocciaGlobalBuiltins;
-  CompileStart, CompileEnd, ExecEnd: Int64;
+  LexStart, LexEnd, ParseEnd, CompileEnd, ExecEnd: Int64;
 begin
   BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
 
@@ -238,22 +238,26 @@ begin
     end;
 
     try
-      CompileStart := GetNanoseconds;
-
       Backend := TGocciaBytecodeBackend.Create(AFileName);
       try
         Backend.RegisterBuiltIns(BenchGlobals);
         ConfigureModuleResolver(Backend.ModuleResolver, AFileName,
           GImportMapPath, GInlineAliases);
 
+        LexStart := GetNanoseconds;
         Lexer := TGocciaLexer.Create(SourceText, AFileName);
         try
           Tokens := Lexer.ScanTokens;
+          LexEnd := GetNanoseconds;
+
           Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
           try
             ProgramNode := Parser.Parse;
+            ParseEnd := GetNanoseconds;
+
             try
               Module := Backend.CompileToModule(ProgramNode);
+              CompileEnd := GetNanoseconds;
             finally
               ProgramNode.Free;
             end;
@@ -263,8 +267,6 @@ begin
         finally
           Lexer.Free;
         end;
-
-        CompileEnd := GetNanoseconds;
 
         if GShowProgress and Assigned(Backend.Bootstrap) and
            Assigned(Backend.Bootstrap.BuiltinBenchmark) then
@@ -277,9 +279,9 @@ begin
           ExecEnd := GetNanoseconds;
 
           FileResult.FileName := AFileName;
-          FileResult.LexTimeNanoseconds := 0;
-          FileResult.ParseTimeNanoseconds := 0;
-          FileResult.CompileTimeNanoseconds := CompileEnd - CompileStart;
+          FileResult.LexTimeNanoseconds := LexEnd - LexStart;
+          FileResult.ParseTimeNanoseconds := ParseEnd - LexEnd;
+          FileResult.CompileTimeNanoseconds := CompileEnd - ParseEnd;
           FileResult.ExecuteTimeNanoseconds := ExecEnd - CompileEnd;
 
           GC := TGarbageCollector.Instance;
@@ -389,7 +391,7 @@ var
   FileResult: TBenchmarkFileResult;
   ScriptResult: TGocciaObjectValue;
   BenchGlobals: TGocciaGlobalBuiltins;
-  CompileStart, CompileEnd, ExecEnd: Int64;
+  LexStart, LexEnd, ParseEnd, CompileEnd, ExecEnd: Int64;
 begin
   BenchGlobals := TGocciaEngine.DefaultGlobals + [ggBenchmark];
   ASource.Add('runBenchmarks();');
@@ -403,22 +405,26 @@ begin
   end;
 
   try
-    CompileStart := GetNanoseconds;
-
     Backend := TGocciaBytecodeBackend.Create(AFileName);
     try
       Backend.RegisterBuiltIns(BenchGlobals);
       ConfigureModuleResolver(Backend.ModuleResolver, AFileName,
         GImportMapPath, GInlineAliases);
 
+      LexStart := GetNanoseconds;
       Lexer := TGocciaLexer.Create(SourceText, AFileName);
       try
         Tokens := Lexer.ScanTokens;
+        LexEnd := GetNanoseconds;
+
         Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
         try
           ProgramNode := Parser.Parse;
+          ParseEnd := GetNanoseconds;
+
           try
             Module := Backend.CompileToModule(ProgramNode);
+            CompileEnd := GetNanoseconds;
           finally
             ProgramNode.Free;
           end;
@@ -428,8 +434,6 @@ begin
       finally
         Lexer.Free;
       end;
-
-      CompileEnd := GetNanoseconds;
 
       if GShowProgress and Assigned(Backend.Bootstrap) and
          Assigned(Backend.Bootstrap.BuiltinBenchmark) then
@@ -442,9 +446,9 @@ begin
         ExecEnd := GetNanoseconds;
 
         FileResult.FileName := AFileName;
-        FileResult.LexTimeNanoseconds := 0;
-        FileResult.ParseTimeNanoseconds := 0;
-        FileResult.CompileTimeNanoseconds := CompileEnd - CompileStart;
+        FileResult.LexTimeNanoseconds := LexEnd - LexStart;
+        FileResult.ParseTimeNanoseconds := ParseEnd - LexEnd;
+        FileResult.CompileTimeNanoseconds := CompileEnd - ParseEnd;
         FileResult.ExecuteTimeNanoseconds := ExecEnd - CompileEnd;
 
         GC := TGarbageCollector.Instance;

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -282,10 +282,10 @@ var
   ProgramNode: TGocciaProgram;
   Module: TGocciaBytecodeModule;
   Backend: TGocciaBytecodeBackend;
-  StartTime, ExecEnd: Int64;
+  StartTime, CompileStart, CompileEnd, ExecEnd: Int64;
 begin
   StartTime := GetNanoseconds;
-    Backend := TGocciaBytecodeBackend.Create(AFileName);
+  Backend := TGocciaBytecodeBackend.Create(AFileName);
   try
     Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
     ConfigureConsole(Backend.Bootstrap.BuiltinConsole, AOutputLines);
@@ -297,7 +297,10 @@ begin
       GJsonOutput, Result.Timing.LexTimeNanoseconds,
       Result.Timing.ParseTimeNanoseconds);
     try
+      CompileStart := GetNanoseconds;
       Module := Backend.CompileToModule(ProgramNode);
+      CompileEnd := GetNanoseconds;
+      Result.Timing.CompileTimeNanoseconds := CompileEnd - CompileStart;
     finally
       ProgramNode.Free;
     end;
@@ -311,8 +314,7 @@ begin
         ClearExecutionTimeout;
       end;
       ExecEnd := GetNanoseconds;
-      Result.Timing.ExecuteTimeNanoseconds := ExecEnd - StartTime -
-        Result.Timing.LexTimeNanoseconds - Result.Timing.ParseTimeNanoseconds;
+      Result.Timing.ExecuteTimeNanoseconds := ExecEnd - CompileEnd;
       Result.Timing.TotalTimeNanoseconds := ExecEnd - StartTime;
     finally
       Module.Free;
@@ -389,7 +391,7 @@ end;
 procedure PrintHumanReadableResult(const AFileName: string;
   const AReport: TScriptExecutionReport; const AExtension: string);
 var
-  LoadTimeNanoseconds, FrontEndTimeNanoseconds: Int64;
+  LoadTimeNanoseconds: Int64;
 begin
   if AExtension = EXT_GBC then
   begin
@@ -403,11 +405,11 @@ begin
   end
   else if GMode = emBytecode then
   begin
-    FrontEndTimeNanoseconds := AReport.Timing.TotalTimeNanoseconds -
-      AReport.Timing.ExecuteTimeNanoseconds;
     WriteLn('Running script (bytecode): ', AFileName);
-    WriteLn(SysUtils.Format('  Compile: %s | Execute: %s | Total: %s',
-      [FormatDuration(FrontEndTimeNanoseconds),
+    WriteLn(SysUtils.Format('  Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
+      [FormatDuration(AReport.Timing.LexTimeNanoseconds),
+       FormatDuration(AReport.Timing.ParseTimeNanoseconds),
+       FormatDuration(AReport.Timing.CompileTimeNanoseconds),
        FormatDuration(AReport.Timing.ExecuteTimeNanoseconds),
        FormatDuration(AReport.Timing.TotalTimeNanoseconds)]));
   end

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -353,6 +353,7 @@ begin
       ExecEnd := GetNanoseconds;
       Result.Timing.LexTimeNanoseconds := 0;
       Result.Timing.ParseTimeNanoseconds := 0;
+      Result.Timing.CompileTimeNanoseconds := 0;
       Result.Timing.ExecuteTimeNanoseconds := ExecEnd - LoadEnd;
       Result.Timing.TotalTimeNanoseconds := ExecEnd - StartTime;
     finally
@@ -473,11 +474,13 @@ begin
       begin
         Report.Timing.TotalTimeNanoseconds := GetNanoseconds - StartTime;
         if Report.Timing.TotalTimeNanoseconds >
-           Report.Timing.LexTimeNanoseconds + Report.Timing.ParseTimeNanoseconds then
+           Report.Timing.LexTimeNanoseconds + Report.Timing.ParseTimeNanoseconds +
+           Report.Timing.CompileTimeNanoseconds then
           Report.Timing.ExecuteTimeNanoseconds :=
             Report.Timing.TotalTimeNanoseconds -
             Report.Timing.LexTimeNanoseconds -
-            Report.Timing.ParseTimeNanoseconds;
+            Report.Timing.ParseTimeNanoseconds -
+            Report.Timing.CompileTimeNanoseconds;
         if GJsonOutput then
           PrintJSONError(E, Report, OutputLines, AFileName)
         else

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -272,6 +272,7 @@ begin
   Result.ResultValue := ScriptResult.Result;
   Result.Timing.LexTimeNanoseconds := ScriptResult.LexTimeNanoseconds;
   Result.Timing.ParseTimeNanoseconds := ScriptResult.ParseTimeNanoseconds;
+  Result.Timing.CompileTimeNanoseconds := 0;
   Result.Timing.ExecuteTimeNanoseconds := ScriptResult.ExecuteTimeNanoseconds;
   Result.Timing.TotalTimeNanoseconds := ScriptResult.TotalTimeNanoseconds;
 end;

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -53,6 +53,7 @@ begin
   Result.Timing.Result := nil;
   Result.Timing.LexTimeNanoseconds := 0;
   Result.Timing.ParseTimeNanoseconds := 0;
+  Result.Timing.CompileTimeNanoseconds := 0;
   Result.Timing.ExecuteTimeNanoseconds := 0;
   Result.Timing.TotalTimeNanoseconds := 0;
   Result.Timing.FileName := '';
@@ -179,7 +180,7 @@ var
   ResultValue: TGocciaValue;
   TestGlobals: TGocciaGlobalBuiltins;
   OrigLine, OrigCol, I: Integer;
-  CompileStart, CompileEnd, ExecEnd: Int64;
+  LexStart, LexEnd, ParseEnd, CompileEnd, ExecEnd: Int64;
 begin
   TestGlobals := TGocciaEngine.DefaultGlobals + [ggTestAssertions];
   ScriptResult := CreateDefaultScriptResult;
@@ -211,20 +212,23 @@ begin
     end;
 
     try try
-      CompileStart := GetNanoseconds;
-
       Backend := TGocciaBytecodeBackend.Create(AFileName);
       try
         Backend.RegisterBuiltIns(TestGlobals);
         ConfigureModuleResolver(Backend.ModuleResolver, AFileName,
           GImportMapPath, GInlineAliases);
 
+        LexStart := GetNanoseconds;
         Lexer := TGocciaLexer.Create(SourceText, AFileName);
         try
           Tokens := Lexer.ScanTokens;
+          LexEnd := GetNanoseconds;
+
           Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
           try
             ProgramNode := Parser.Parse;
+            ParseEnd := GetNanoseconds;
+
             if not GSilentConsole then
               for I := 0 to Parser.WarningCount - 1 do
               begin
@@ -239,6 +243,7 @@ begin
               end;
             try
               Module := Backend.CompileToModule(ProgramNode);
+              CompileEnd := GetNanoseconds;
             finally
               ProgramNode.Free;
             end;
@@ -249,8 +254,6 @@ begin
           Lexer.Free;
         end;
 
-        CompileEnd := GetNanoseconds;
-
         try
           ResultValue := Backend.RunModule(Module);
           ExecEnd := GetNanoseconds;
@@ -260,10 +263,11 @@ begin
 
           Result.TestResult := ScriptResult;
           Result.Timing.Result := ResultValue;
-          Result.Timing.LexTimeNanoseconds := CompileEnd - CompileStart;
-          Result.Timing.ParseTimeNanoseconds := 0;
+          Result.Timing.LexTimeNanoseconds := LexEnd - LexStart;
+          Result.Timing.ParseTimeNanoseconds := ParseEnd - LexEnd;
+          Result.Timing.CompileTimeNanoseconds := CompileEnd - ParseEnd;
           Result.Timing.ExecuteTimeNanoseconds := ExecEnd - CompileEnd;
-          Result.Timing.TotalTimeNanoseconds := ExecEnd - CompileStart;
+          Result.Timing.TotalTimeNanoseconds := ExecEnd - LexStart;
           Result.Timing.FileName := AFileName;
         finally
           Module.Free;
@@ -318,7 +322,7 @@ begin
     Result.TestResult := FileResult.TestResult;
     Result.TotalLexNanoseconds := FileResult.Timing.LexTimeNanoseconds;
     Result.TotalParseNanoseconds := FileResult.Timing.ParseTimeNanoseconds;
-    Result.TotalCompileNanoseconds := FileResult.Timing.LexTimeNanoseconds;
+    Result.TotalCompileNanoseconds := FileResult.Timing.CompileTimeNanoseconds;
     Result.TotalExecNanoseconds := FileResult.Timing.ExecuteTimeNanoseconds;
   except
     on E: Exception do
@@ -437,7 +441,7 @@ var
   I: Integer;
 begin
   if GMode = ebBytecode then
-    TotalNanoseconds := AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds
+    TotalNanoseconds := AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds
   else
     TotalNanoseconds := AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalExecNanoseconds;
 
@@ -452,17 +456,11 @@ begin
     Lines.Add(Format('  "skipped": %d,', [Round(AResult.TestResult.GetProperty('skipped').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "assertions": %d,', [Round(AResult.TestResult.GetProperty('assertions').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "durationNanoseconds": %d,', [Round(AResult.TestResult.GetProperty('duration').ToNumberLiteral.Value)]));
+    Lines.Add(Format('  "lexTimeNanoseconds": %d,', [AResult.TotalLexNanoseconds]));
+    Lines.Add(Format('  "parseTimeNanoseconds": %d,', [AResult.TotalParseNanoseconds]));
     if GMode = ebBytecode then
-    begin
       Lines.Add(Format('  "compileTimeNanoseconds": %d,', [AResult.TotalCompileNanoseconds]));
-      Lines.Add(Format('  "executeTimeNanoseconds": %d,', [AResult.TotalExecNanoseconds]));
-    end
-    else
-    begin
-      Lines.Add(Format('  "lexTimeNanoseconds": %d,', [AResult.TotalLexNanoseconds]));
-      Lines.Add(Format('  "parseTimeNanoseconds": %d,', [AResult.TotalParseNanoseconds]));
-      Lines.Add(Format('  "executeTimeNanoseconds": %d,', [AResult.TotalExecNanoseconds]));
-    end;
+    Lines.Add(Format('  "executeTimeNanoseconds": %d,', [AResult.TotalExecNanoseconds]));
     Lines.Add(Format('  "totalEngineNanoseconds": %d,', [TotalNanoseconds]));
 
     FailedTests := AResult.TestResult.GetProperty('failedTests');
@@ -524,11 +522,12 @@ begin
       Writeln(Format('Test Results Failed: %s (%2.2f%%)', [TotalFailed, (StrToFloat(TotalFailed) / RunCount * 100)]));
       Writeln(Format('Test Results Skipped: %s (%2.2f%%)', [TotalSkipped, (StrToFloat(TotalSkipped) / RunCount * 100)]));
       Writeln(Format('Test Results Assertions: %s', [TotalAssertions]));
-      Writeln(Format('Test Results Test Execution: %s (%s/test)', [FormatDuration(DurationNanoseconds), FormatDuration(PerTestNanoseconds)]));
+      Writeln(Format('Test Results Test Duration: %s (%s/test)', [FormatDuration(DurationNanoseconds), FormatDuration(PerTestNanoseconds)]));
       if GMode = ebBytecode then
-        Writeln(Format('Test Results Engine Timing: Compile: %s | Execute: %s | Total: %s',
-          [FormatDuration(AResult.TotalCompileNanoseconds), FormatDuration(AResult.TotalExecNanoseconds),
-           FormatDuration(AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds)]))
+        Writeln(Format('Test Results Engine Timing: Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
+          [FormatDuration(AResult.TotalLexNanoseconds), FormatDuration(AResult.TotalParseNanoseconds),
+           FormatDuration(AResult.TotalCompileNanoseconds), FormatDuration(AResult.TotalExecNanoseconds),
+           FormatDuration(AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds)]))
       else
         Writeln(Format('Test Results Engine Timing: Lex: %s | Parse: %s | Execute: %s | Total: %s',
           [FormatDuration(AResult.TotalLexNanoseconds), FormatDuration(AResult.TotalParseNanoseconds), FormatDuration(AResult.TotalExecNanoseconds),

--- a/units/Goccia.Benchmark.Reporter.pas
+++ b/units/Goccia.Benchmark.Reporter.pas
@@ -174,9 +174,10 @@ begin
       FOutput.Add('Running benchmark: ' + FFiles[F].FileName);
 
     if FFiles[F].CompileTimeNanoseconds > 0 then
-      FOutput.Add(SysUtils.Format('  Compile: %s | Execute: %s | Total: %s',
-        [FormatDuration(FFiles[F].CompileTimeNanoseconds), FormatDuration(FFiles[F].ExecuteTimeNanoseconds),
-         FormatDuration(FFiles[F].CompileTimeNanoseconds + FFiles[F].ExecuteTimeNanoseconds)]))
+      FOutput.Add(SysUtils.Format('  Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
+        [FormatDuration(FFiles[F].LexTimeNanoseconds), FormatDuration(FFiles[F].ParseTimeNanoseconds),
+         FormatDuration(FFiles[F].CompileTimeNanoseconds), FormatDuration(FFiles[F].ExecuteTimeNanoseconds),
+         FormatDuration(FFiles[F].LexTimeNanoseconds + FFiles[F].ParseTimeNanoseconds + FFiles[F].CompileTimeNanoseconds + FFiles[F].ExecuteTimeNanoseconds)]))
     else
       FOutput.Add(SysUtils.Format('  Lex: %s | Parse: %s | Execute: %s | Total: %s',
         [FormatDuration(FFiles[F].LexTimeNanoseconds), FormatDuration(FFiles[F].ParseTimeNanoseconds), FormatDuration(FFiles[F].ExecuteTimeNanoseconds),
@@ -329,13 +330,10 @@ begin
   begin
     FOutput.Add('    {');
     FOutput.Add(SysUtils.Format('      "file": "%s",', [EscapeJSON(FFiles[F].FileName)]));
+    FOutput.Add(SysUtils.Format('      "lexTimeNanoseconds": %d,', [FFiles[F].LexTimeNanoseconds]));
+    FOutput.Add(SysUtils.Format('      "parseTimeNanoseconds": %d,', [FFiles[F].ParseTimeNanoseconds]));
     if FFiles[F].CompileTimeNanoseconds > 0 then
-      FOutput.Add(SysUtils.Format('      "compileTimeNanoseconds": %d,', [FFiles[F].CompileTimeNanoseconds]))
-    else
-    begin
-      FOutput.Add(SysUtils.Format('      "lexTimeNanoseconds": %d,', [FFiles[F].LexTimeNanoseconds]));
-      FOutput.Add(SysUtils.Format('      "parseTimeNanoseconds": %d,', [FFiles[F].ParseTimeNanoseconds]));
-    end;
+      FOutput.Add(SysUtils.Format('      "compileTimeNanoseconds": %d,', [FFiles[F].CompileTimeNanoseconds]));
     FOutput.Add(SysUtils.Format('      "executeTimeNanoseconds": %d,', [FFiles[F].ExecuteTimeNanoseconds]));
     FOutput.Add('      "benchmarks": [');
 

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -844,6 +844,7 @@ begin
           Result.ParseTimeNanoseconds := ParseEnd - LexEnd;
 
           try
+            Result.CompileTimeNanoseconds := 0;
             Result.Result := FInterpreter.Execute(ProgramNode);
             if Assigned(TGocciaMicrotaskQueue.Instance) then
               TGocciaMicrotaskQueue.Instance.DrainQueue;

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -84,6 +84,7 @@ type
     Result: TGocciaValue;
     LexTimeNanoseconds: Int64;
     ParseTimeNanoseconds: Int64;
+    CompileTimeNanoseconds: Int64;
     ExecuteTimeNanoseconds: Int64;
     TotalTimeNanoseconds: Int64;
     FileName: string;

--- a/units/Goccia.ScriptLoader.JSON.pas
+++ b/units/Goccia.ScriptLoader.JSON.pas
@@ -13,6 +13,7 @@ type
   TScriptLoaderTiming = record
     LexTimeNanoseconds: Int64;
     ParseTimeNanoseconds: Int64;
+    CompileTimeNanoseconds: Int64;
     ExecuteTimeNanoseconds: Int64;
     TotalTimeNanoseconds: Int64;
   end;
@@ -140,6 +141,7 @@ begin
     '"timing":{' +
       '"lex_ms":' + NanosecondsToMillisecondsText(ATiming.LexTimeNanoseconds) + ',' +
       '"parse_ms":' + NanosecondsToMillisecondsText(ATiming.ParseTimeNanoseconds) + ',' +
+      '"compile_ms":' + NanosecondsToMillisecondsText(ATiming.CompileTimeNanoseconds) + ',' +
       '"exec_ms":' + NanosecondsToMillisecondsText(ATiming.ExecuteTimeNanoseconds) + ',' +
       '"total_ms":' + NanosecondsToMillisecondsText(ATiming.TotalTimeNanoseconds) +
     '}';


### PR DESCRIPTION
## Summary
- Split bytecode timing into distinct lex, parse, compile, and execute phases across the loader, test runner, and benchmark runner.
- Added `CompileTimeNanoseconds` to shared timing records and surfaced it in JSON output and human-readable reports.
- Updated PR workflow reporting to show the new timing breakdown in test results.

## Testing
- Concrete checks expected: run `./build.pas testrunner && ./build/TestRunner tests`.
- Concrete checks expected: run `./build.pas benchmarkrunner && ./build/BenchmarkRunner benchmarks --format=json` to verify the new timing fields.
- Concrete checks expected: run `./build.pas loader && ./build/ScriptLoader example.js --mode=bytecode` to confirm bytecode timing output includes lex/parse/compile/execute phases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds finer-grained timing metrics (lex, parse, compile, execute) to console and JSON test/benchmark outputs.
  * Console output now shows a per-test breakdown: Lex | Parse | Compile | Execute | Total when available.

* **Improvements**
  * Renamed summary labels for clarity ("Test Duration" and "Engine Total").
  * More accurate and consistent timing calculations across modes and aggregate reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->