### PR TITLE
Add bytecode REPL timing mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,9 @@ GocciaScript is a subset of ECMAScript implemented in FreePascal. It provides a 
 ./build/ScriptLoader example.js --emit --output=out.gbc   # Custom output path
 ./build/ScriptLoader out.gbc                     # Load and execute .gbc bytecode
 printf "const x = 2 + 2; x;" | ./build/ScriptLoader        # Execute stdin source
-./build/REPL                                      # Start interactive REPL
+./build/REPL                                      # Start interactive REPL (interpreted)
+./build/REPL --mode=bytecode                      # Start the REPL via bytecode VM
+./build/REPL --mode=bytecode --timing             # Bytecode REPL with per-line timing
 ./build/REPL --import-map=imports.json            # Start the REPL with an explicit import map
 ./build/TestRunner tests/                                                      # Run all JavaScript tests
 ./build/TestRunner tests --import-map=imports.json                             # Run tests with an explicit import map

--- a/REPL.dpr
+++ b/REPL.dpr
@@ -151,8 +151,12 @@ begin
         Source.Clear;
         Source.Add(Line);
 
+        StartTime := GetNanoseconds;
+        LexEnd := StartTime;
+        ParseEnd := StartTime;
+        CompileEnd := StartTime;
+        ExecEnd := StartTime;
         try
-          StartTime := GetNanoseconds;
           SourceText := StringListToLFText(Source);
 
           if ggJSX in TGocciaEngine.DefaultGlobals then
@@ -185,14 +189,6 @@ begin
 
                   if ResultValue <> nil then
                     WriteLn(FormatREPLValue(ResultValue));
-                  if ShowTiming then
-                    WriteLn(SysUtils.Format(
-                      '  Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
-                      [FormatDuration(LexEnd - StartTime),
-                       FormatDuration(ParseEnd - LexEnd),
-                       FormatDuration(CompileEnd - ParseEnd),
-                       FormatDuration(ExecEnd - CompileEnd),
-                       FormatDuration(ExecEnd - StartTime)]));
                 finally
                   if Assigned(TGocciaMicrotaskQueue.Instance) then
                     TGocciaMicrotaskQueue.Instance.ClearQueue;
@@ -209,8 +205,19 @@ begin
           end;
         except
           on E: Exception do
+          begin
+            ExecEnd := GetNanoseconds;
             WriteLn('Error: ', E.Message);
+          end;
         end;
+        if ShowTiming then
+          WriteLn(SysUtils.Format(
+            '  Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
+            [FormatDuration(LexEnd - StartTime),
+             FormatDuration(ParseEnd - LexEnd),
+             FormatDuration(CompileEnd - ParseEnd),
+             FormatDuration(ExecEnd - CompileEnd),
+             FormatDuration(ExecEnd - StartTime)]));
       end;
     finally
       LiveModules.Free;
@@ -245,17 +252,17 @@ begin
           ScriptResult := Engine.Execute;
           if ScriptResult.Result <> nil then
             WriteLn(FormatREPLValue(ScriptResult.Result));
-          if ShowTiming then
-            WriteLn(SysUtils.Format(
-              '  Lex: %s | Parse: %s | Execute: %s | Total: %s',
-              [FormatDuration(ScriptResult.LexTimeNanoseconds),
-               FormatDuration(ScriptResult.ParseTimeNanoseconds),
-               FormatDuration(ScriptResult.ExecuteTimeNanoseconds),
-               FormatDuration(ScriptResult.TotalTimeNanoseconds)]));
         except
           on E: Exception do
             WriteLn('Error: ', E.Message);
         end;
+        if ShowTiming then
+          WriteLn(SysUtils.Format(
+            '  Lex: %s | Parse: %s | Execute: %s | Total: %s',
+            [FormatDuration(Engine.LastTiming.LexTimeNanoseconds),
+             FormatDuration(Engine.LastTiming.ParseTimeNanoseconds),
+             FormatDuration(Engine.LastTiming.ExecuteTimeNanoseconds),
+             FormatDuration(Engine.LastTiming.TotalTimeNanoseconds)]));
       end;
     finally
       Editor.Free;

--- a/REPL.dpr
+++ b/REPL.dpr
@@ -7,6 +7,7 @@ uses
   Generics.Collections,
   SysUtils,
 
+  GarbageCollector.Generic,
   TimingUtils,
 
   Goccia.AST.Node,
@@ -183,12 +184,19 @@ begin
 
                 try
                   ResultValue := Backend.RunModule(Module);
-                  if Assigned(TGocciaMicrotaskQueue.Instance) then
-                    TGocciaMicrotaskQueue.Instance.DrainQueue;
-                  ExecEnd := GetNanoseconds;
+                  if Assigned(ResultValue) then
+                    TGarbageCollector.Instance.AddTempRoot(ResultValue);
+                  try
+                    if Assigned(TGocciaMicrotaskQueue.Instance) then
+                      TGocciaMicrotaskQueue.Instance.DrainQueue;
+                    ExecEnd := GetNanoseconds;
 
-                  if ResultValue <> nil then
-                    WriteLn(FormatREPLValue(ResultValue));
+                    if ResultValue <> nil then
+                      WriteLn(FormatREPLValue(ResultValue));
+                  finally
+                    if Assigned(ResultValue) then
+                      TGarbageCollector.Instance.RemoveTempRoot(ResultValue);
+                  end;
                 finally
                   if Assigned(TGocciaMicrotaskQueue.Instance) then
                     TGocciaMicrotaskQueue.Instance.ClearQueue;

--- a/REPL.dpr
+++ b/REPL.dpr
@@ -4,32 +4,62 @@ program REPL;
 
 uses
   Classes,
+  Generics.Collections,
   SysUtils,
 
   TimingUtils,
 
+  Goccia.AST.Node,
+  Goccia.Bytecode.Module,
   Goccia.Engine,
+  Goccia.Engine.Backend,
+  Goccia.JSX.Transformer,
+  Goccia.Lexer,
+  Goccia.MicrotaskQueue,
   Goccia.Modules.Configuration,
+  Goccia.Parser,
   Goccia.REPL.Formatter,
   Goccia.REPL.LineEditor,
+  Goccia.TextFiles,
+  Goccia.Token,
   Goccia.Values.Primitives,
   Goccia.Version;
 
+const
+  REPL_FILE_NAME = 'REPL';
+
 var
-  Arg: string;
+  Arg, ModeStr: string;
   ImportMapPath: string;
   InlineAliases: TStringList;
   Line: string;
-  Engine: TGocciaEngine;
   Source: TStringList;
-  ScriptResult: TGocciaScriptResult;
   ShowTiming: Boolean;
+  IsBytecodeMode: Boolean;
   I: Integer;
   Editor: TLineEditor;
   ReadResult: TLineReadResult;
 
+  { Interpreted mode }
+  Engine: TGocciaEngine;
+  ScriptResult: TGocciaScriptResult;
+
+  { Bytecode mode }
+  Backend: TGocciaBytecodeBackend;
+  LiveModules: TObjectList<TGocciaBytecodeModule>;
+  ResultValue: TGocciaValue;
+  SourceText: string;
+  JSXResult: TGocciaJSXTransformResult;
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+  Parser: TGocciaParser;
+  ProgramNode: TGocciaProgram;
+  Module: TGocciaBytecodeModule;
+  StartTime, LexEnd, ParseEnd, CompileEnd, ExecEnd: Int64;
+
 begin
   ShowTiming := False;
+  IsBytecodeMode := False;
   ImportMapPath := '';
   InlineAliases := TStringList.Create;
   I := 1;
@@ -37,8 +67,22 @@ begin
   begin
     Arg := ParamStr(I);
     if Arg = '--timing' then
-      ShowTiming := True;
-    if Copy(Arg, 1, 13) = '--import-map=' then
+      ShowTiming := True
+    else if Copy(Arg, 1, 7) = '--mode=' then
+    begin
+      ModeStr := Copy(Arg, 8, MaxInt);
+      if ModeStr = 'interpreted' then
+        IsBytecodeMode := False
+      else if ModeStr = 'bytecode' then
+        IsBytecodeMode := True
+      else
+      begin
+        WriteLn('Error: Unknown mode "', ModeStr, '". Use "interpreted" or "bytecode".');
+        ExitCode := 1;
+        Exit;
+      end;
+    end
+    else if Copy(Arg, 1, 13) = '--import-map=' then
     begin
       ImportMapPath := Copy(Arg, 14, MaxInt);
       if ImportMapPath = '' then
@@ -72,49 +116,152 @@ begin
 
   if FindCmdLineSwitch('help', ['-'], True) or FindCmdLineSwitch('h', ['-'], False) then
   begin
-    WriteLn('Usage: REPL [--timing] [--import-map=file] [--alias key=value]');
+    WriteLn('Usage: REPL [--timing] [--mode=interpreted|bytecode] [--import-map=file] [--alias key=value]');
     Exit;
   end;
 
-  WriteLn('Goccia REPL v' + GetVersion);
+  if IsBytecodeMode then
+    WriteLn('Goccia REPL v' + GetVersion + ' (bytecode)')
+  else
+    WriteLn('Goccia REPL v' + GetVersion + ' (interpreted)');
 
   Source := TStringList.Create;
-  Engine := TGocciaEngine.Create('REPL', Source, TGocciaEngine.DefaultGlobals);
   Editor := TLineEditor.Create;
-  try
-    ConfigureModuleResolver(Engine.Resolver, 'REPL', ImportMapPath,
-      InlineAliases);
-    while True do
-    begin
-      ReadResult := Editor.ReadLine('> ', Line);
-      if ReadResult = lrExit then
-        Break;
-      if Line = 'exit' then
-        Break;
-      if Line = '' then
-        Continue;
 
-      Editor.AddToHistory(Line);
-      Source.Clear;
-      Source.Add(Line);
+  if IsBytecodeMode then
+  begin
+    Backend := TGocciaBytecodeBackend.Create(REPL_FILE_NAME);
+    LiveModules := TObjectList<TGocciaBytecodeModule>.Create(True);
+    try
+      Backend.RegisterBuiltIns(TGocciaEngine.DefaultGlobals);
+      Backend.GlobalBackedTopLevel := True;
+      ConfigureModuleResolver(Backend.ModuleResolver, REPL_FILE_NAME,
+        ImportMapPath, InlineAliases);
+      while True do
+      begin
+        ReadResult := Editor.ReadLine('> ', Line);
+        if ReadResult = lrExit then
+          Break;
+        if Line = 'exit' then
+          Break;
+        if Line = '' then
+          Continue;
 
-      try
-        ScriptResult := Engine.Execute;
-        if ScriptResult.Result <> nil then
-          WriteLn(FormatREPLValue(ScriptResult.Result));
-        if ShowTiming then
-          WriteLn(SysUtils.Format('  [%s lex | %s parse | %s exec | %s total]',
-            [FormatDuration(ScriptResult.LexTimeNanoseconds), FormatDuration(ScriptResult.ParseTimeNanoseconds),
-             FormatDuration(ScriptResult.ExecuteTimeNanoseconds), FormatDuration(ScriptResult.TotalTimeNanoseconds)]));
-      except
-        on E: Exception do
-          WriteLn('Error: ', E.Message);
+        Editor.AddToHistory(Line);
+        Source.Clear;
+        Source.Add(Line);
+
+        try
+          StartTime := GetNanoseconds;
+          SourceText := StringListToLFText(Source);
+
+          if ggJSX in TGocciaEngine.DefaultGlobals then
+          begin
+            JSXResult := TGocciaJSXTransformer.Transform(SourceText);
+            SourceText := JSXResult.Source;
+            JSXResult.SourceMap.Free;
+          end;
+
+          Lexer := TGocciaLexer.Create(SourceText, REPL_FILE_NAME);
+          try
+            Tokens := Lexer.ScanTokens;
+            LexEnd := GetNanoseconds;
+
+            Parser := TGocciaParser.Create(Tokens, REPL_FILE_NAME,
+              Lexer.SourceLines);
+            try
+              ProgramNode := Parser.Parse;
+              ParseEnd := GetNanoseconds;
+
+              try
+                Module := Backend.CompileToModule(ProgramNode);
+                CompileEnd := GetNanoseconds;
+
+                try
+                  ResultValue := Backend.RunModule(Module);
+                  if Assigned(TGocciaMicrotaskQueue.Instance) then
+                    TGocciaMicrotaskQueue.Instance.DrainQueue;
+                  ExecEnd := GetNanoseconds;
+
+                  if ResultValue <> nil then
+                    WriteLn(FormatREPLValue(ResultValue));
+                  if ShowTiming then
+                    WriteLn(SysUtils.Format(
+                      '  Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
+                      [FormatDuration(LexEnd - StartTime),
+                       FormatDuration(ParseEnd - LexEnd),
+                       FormatDuration(CompileEnd - ParseEnd),
+                       FormatDuration(ExecEnd - CompileEnd),
+                       FormatDuration(ExecEnd - StartTime)]));
+                finally
+                  if Assigned(TGocciaMicrotaskQueue.Instance) then
+                    TGocciaMicrotaskQueue.Instance.ClearQueue;
+                  LiveModules.Add(Module);
+                end;
+              finally
+                ProgramNode.Free;
+              end;
+            finally
+              Parser.Free;
+            end;
+          finally
+            Lexer.Free;
+          end;
+        except
+          on E: Exception do
+            WriteLn('Error: ', E.Message);
+        end;
       end;
+    finally
+      LiveModules.Free;
+      Backend.Free;
+      Editor.Free;
+      Source.Free;
+      InlineAliases.Free;
     end;
-  finally
-    Editor.Free;
-    Engine.Free;
-    Source.Free;
-    InlineAliases.Free;
+  end
+  else
+  begin
+    Engine := TGocciaEngine.Create(REPL_FILE_NAME, Source,
+      TGocciaEngine.DefaultGlobals);
+    try
+      ConfigureModuleResolver(Engine.Resolver, REPL_FILE_NAME, ImportMapPath,
+        InlineAliases);
+      while True do
+      begin
+        ReadResult := Editor.ReadLine('> ', Line);
+        if ReadResult = lrExit then
+          Break;
+        if Line = 'exit' then
+          Break;
+        if Line = '' then
+          Continue;
+
+        Editor.AddToHistory(Line);
+        Source.Clear;
+        Source.Add(Line);
+
+        try
+          ScriptResult := Engine.Execute;
+          if ScriptResult.Result <> nil then
+            WriteLn(FormatREPLValue(ScriptResult.Result));
+          if ShowTiming then
+            WriteLn(SysUtils.Format(
+              '  Lex: %s | Parse: %s | Execute: %s | Total: %s',
+              [FormatDuration(ScriptResult.LexTimeNanoseconds),
+               FormatDuration(ScriptResult.ParseTimeNanoseconds),
+               FormatDuration(ScriptResult.ExecuteTimeNanoseconds),
+               FormatDuration(ScriptResult.TotalTimeNanoseconds)]));
+        except
+          on E: Exception do
+            WriteLn('Error: ', E.Message);
+        end;
+      end;
+    finally
+      Editor.Free;
+      Engine.Free;
+      Source.Free;
+      InlineAliases.Free;
+    end;
   end;
 end.

--- a/units/Goccia.Compiler.Context.pas
+++ b/units/Goccia.Compiler.Context.pas
@@ -33,6 +33,7 @@ type
     Scope: TGocciaCompilerScope;
     SourcePath: string;
     FormalParameterCounts: TFormalParameterCountMap;
+    GlobalBackedTopLevel: Boolean;
     CompileExpression: TCompileExpressionProc;
     CompileStatement: TCompileStatementProc;
     CompileFunctionBody: TCompileFunctionBodyProc;

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -1698,9 +1698,7 @@ procedure CompileNewExpression(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaNewExpression; const ADest: UInt8);
 var
   CtorReg: UInt8;
-  NameIdx: UInt16;
   ArgCount, I: Integer;
-  Local: TGocciaCompilerLocal;
 begin
   CtorReg := ACtx.Scope.AllocateRegister;
   ACtx.CompileExpression(AExpr.Callee, CtorReg);
@@ -1716,19 +1714,6 @@ begin
   for I := 0 to ArgCount - 1 do
     ACtx.Scope.FreeRegister;
   ACtx.Scope.FreeRegister;
-
-  for I := 0 to ACtx.Scope.LocalCount - 1 do
-  begin
-    Local := ACtx.Scope.GetLocal(I);
-    if Local.IsGlobalBacked then
-    begin
-      NameIdx := ACtx.Template.AddConstantString(Local.Name);
-      if NameIdx > High(UInt8) then
-        raise Exception.Create('Constant pool overflow: global name index exceeds 255');
-      EmitInstruction(ACtx, EncodeABC(OP_DEFINE_GLOBAL_CONST, Local.Slot,
-        0, UInt8(NameIdx)));
-    end;
-  end;
 end;
 
 procedure CompileComputedPropertyAssignment(const ACtx: TGocciaCompilationContext;

--- a/units/Goccia.Compiler.Statements.pas
+++ b/units/Goccia.Compiler.Statements.pas
@@ -437,6 +437,32 @@ begin
   end;
 end;
 
+{ B field encodes the declaration mode for OP_DEFINE_GLOBAL_CONST:
+  0 = upsert (existing behavior from CompileNewExpression)
+  1 = let declaration (throws on re-declaration)
+  2 = const declaration (throws on re-declaration, non-writable) }
+const
+  GLOBAL_DEFINE_UPSERT = 0;
+  GLOBAL_DEFINE_LET = 1;
+  GLOBAL_DEFINE_CONST = 2;
+
+procedure EmitGlobalDefine(const ACtx: TGocciaCompilationContext;
+  const ASlot: UInt8; const AName: string; const AIsConst: Boolean);
+var
+  NameIdx: UInt16;
+  DeclMode: UInt8;
+begin
+  if AIsConst then
+    DeclMode := GLOBAL_DEFINE_CONST
+  else
+    DeclMode := GLOBAL_DEFINE_LET;
+  NameIdx := ACtx.Template.AddConstantString(AName);
+  if NameIdx > High(UInt8) then
+    raise Exception.Create('Constant pool overflow: global name index exceeds 255');
+  EmitInstruction(ACtx, EncodeABC(OP_DEFINE_GLOBAL_CONST, ASlot,
+    DeclMode, UInt8(NameIdx)));
+end;
+
 procedure CompileVariableDeclaration(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaVariableDeclaration);
 var
@@ -445,12 +471,21 @@ var
   Slot: UInt8;
   InferredTemplate: TGocciaFunctionTemplate;
   TypeHint, AnnotationType: TGocciaLocalType;
-  IsStrict, HasRealInitializer: Boolean;
+  IsStrict, HasRealInitializer, IsTopLevelGlobalBacked: Boolean;
 begin
   for I := 0 to High(AStmt.Variables) do
   begin
     Info := AStmt.Variables[I];
     Slot := ACtx.Scope.DeclareLocal(Info.Name, AStmt.IsConst);
+
+    IsTopLevelGlobalBacked := ACtx.GlobalBackedTopLevel and
+      (ACtx.Scope.Depth = 0);
+    if IsTopLevelGlobalBacked then
+    begin
+      LocalIdx := ACtx.Scope.ResolveLocal(Info.Name);
+      if LocalIdx >= 0 then
+        ACtx.Scope.MarkGlobalBacked(LocalIdx);
+    end;
 
     HasRealInitializer := Assigned(Info.Initializer) and
                           not IsUndefinedInitializer(Info.Initializer);
@@ -532,6 +567,9 @@ begin
     end
     else
       EmitInstruction(ACtx, EncodeABC(OP_LOAD_UNDEFINED, Slot, 0, 0));
+
+    if IsTopLevelGlobalBacked then
+      EmitGlobalDefine(ACtx, Slot, Info.Name, AStmt.IsConst);
   end;
 end;
 
@@ -1906,6 +1944,12 @@ begin
   ACtx.Scope.PrivatePrefix := PrivPrefix;
 
   ClassReg := ACtx.Scope.DeclareLocal(ClassDef.Name, True);
+  if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) then
+  begin
+    LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.Name);
+    if LocalIdx >= 0 then
+      ACtx.Scope.MarkGlobalBacked(LocalIdx);
+  end;
   NameIdx := ACtx.Template.AddConstantString(ClassDef.Name);
   EmitInstruction(ACtx, EncodeABx(OP_NEW_CLASS, ClassReg, NameIdx));
 
@@ -2026,6 +2070,9 @@ begin
     CompileDecoratorAndAccessorPass(ACtx, ClassReg, ClassDef, SuperReg)
   else
     CompileDecoratorAndAccessorPass(ACtx, ClassReg, ClassDef, -1);
+
+  if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) then
+    EmitGlobalDefine(ACtx, ClassReg, ClassDef.Name, True);
 
   ACtx.Scope.PrivatePrefix := '';
 end;
@@ -2204,13 +2251,31 @@ procedure CompileDestructuringDeclaration(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaDestructuringDeclaration);
 var
   SrcReg: UInt8;
+  IsTopLevelGlobalBacked: Boolean;
+  LocalCountBefore, I: Integer;
+  Local: TGocciaCompilerLocal;
 begin
+  IsTopLevelGlobalBacked := ACtx.GlobalBackedTopLevel and
+    (ACtx.Scope.Depth = 0);
+  LocalCountBefore := ACtx.Scope.LocalCount;
+
   CollectDestructuringBindings(AStmt.Pattern, ACtx.Scope, AStmt.IsConst);
+
+  if IsTopLevelGlobalBacked then
+    for I := LocalCountBefore to ACtx.Scope.LocalCount - 1 do
+      ACtx.Scope.MarkGlobalBacked(I);
 
   SrcReg := ACtx.Scope.AllocateRegister;
   ACtx.CompileExpression(AStmt.Initializer, SrcReg);
   EmitDestructuring(ACtx, AStmt.Pattern, SrcReg);
   ACtx.Scope.FreeRegister;
+
+  if IsTopLevelGlobalBacked then
+    for I := LocalCountBefore to ACtx.Scope.LocalCount - 1 do
+    begin
+      Local := ACtx.Scope.GetLocal(I);
+      EmitGlobalDefine(ACtx, Local.Slot, Local.Name, AStmt.IsConst);
+    end;
 end;
 
 procedure CompileEnumDeclaration(const ACtx: TGocciaCompilationContext;
@@ -2221,8 +2286,15 @@ var
   KeyIdx: UInt16;
   ClosedLocals: array[0..255] of UInt8;
   ClosedCount, J: Integer;
+  LocalIdx: Integer;
 begin
   EnumSlot := ACtx.Scope.DeclareLocal(AStmt.Name, False);
+  if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) then
+  begin
+    LocalIdx := ACtx.Scope.ResolveLocal(AStmt.Name);
+    if LocalIdx >= 0 then
+      ACtx.Scope.MarkGlobalBacked(LocalIdx);
+  end;
   EmitInstruction(ACtx, EncodeABx(OP_NEW_OBJECT, EnumSlot,
     Length(AStmt.Members)));
 
@@ -2250,6 +2322,9 @@ begin
   ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
   for J := 0 to ClosedCount - 1 do
     EmitInstruction(ACtx, EncodeABx(OP_CLOSE_UPVALUE, ClosedLocals[J], 0));
+
+  if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) then
+    EmitGlobalDefine(ACtx, EnumSlot, AStmt.Name, False);
 end;
 
 procedure CompileExportEnumDeclaration(const ACtx: TGocciaCompilationContext;

--- a/units/Goccia.Compiler.Statements.pas
+++ b/units/Goccia.Compiler.Statements.pas
@@ -438,11 +438,9 @@ begin
 end;
 
 { B field encodes the declaration mode for OP_DEFINE_GLOBAL_CONST:
-  0 = upsert (existing behavior from CompileNewExpression)
   1 = let declaration (throws on re-declaration)
   2 = const declaration (throws on re-declaration, non-writable) }
 const
-  GLOBAL_DEFINE_UPSERT = 0;
   GLOBAL_DEFINE_LET = 1;
   GLOBAL_DEFINE_CONST = 2;
 

--- a/units/Goccia.Compiler.pas
+++ b/units/Goccia.Compiler.pas
@@ -21,6 +21,7 @@ type
     FCurrentScope: TGocciaCompilerScope;
     FSourcePath: string;
     FFormalParameterCounts: TFormalParameterCountMap;
+    FGlobalBackedTopLevel: Boolean;
     procedure DoCompileExpression(const AExpr: TGocciaExpression;
       const ADest: UInt8);
     procedure DoCompileStatement(const AStmt: TGocciaStatement);
@@ -35,6 +36,8 @@ type
     function Compile(const AProgram: TGocciaProgram): TGocciaBytecodeModule;
     property FormalParameterCounts: TFormalParameterCountMap
       read FFormalParameterCounts;
+    property GlobalBackedTopLevel: Boolean read FGlobalBackedTopLevel
+      write FGlobalBackedTopLevel;
   end;
 
 const
@@ -75,6 +78,7 @@ begin
   Result.Scope := FCurrentScope;
   Result.SourcePath := FSourcePath;
   Result.FormalParameterCounts := FFormalParameterCounts;
+  Result.GlobalBackedTopLevel := FGlobalBackedTopLevel;
   Result.CompileExpression := DoCompileExpression;
   Result.CompileStatement := DoCompileStatement;
   Result.CompileFunctionBody := DoCompileFunctionBody;

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -81,103 +81,15 @@ uses
 
   GarbageCollector.Generic,
 
-  Goccia.AST.Expressions,
-  Goccia.AST.Statements,
   Goccia.CallStack,
   Goccia.Constants.PropertyNames,
   Goccia.Error,
   Goccia.Scope,
   Goccia.Scope.BindingMap,
+  Goccia.Scope.Redeclaration,
   Goccia.Values.ArrayValue,
   Goccia.Values.Error,
   Goccia.Values.ObjectValue;
-
-procedure CollectDestructuringPatternNames(
-  const APattern: TGocciaDestructuringPattern;
-  const AScope: TGocciaScope; const ASourcePath: string);
-var
-  ObjPat: TGocciaObjectDestructuringPattern;
-  ArrPat: TGocciaArrayDestructuringPattern;
-  I: Integer;
-begin
-  if APattern is TGocciaIdentifierDestructuringPattern then
-  begin
-    if AScope.ContainsOwnLexicalBinding(
-         TGocciaIdentifierDestructuringPattern(APattern).Name) then
-      raise TGocciaSyntaxError.Create(
-        SysUtils.Format('Identifier ''%s'' has already been declared',
-          [TGocciaIdentifierDestructuringPattern(APattern).Name]),
-        0, 0, ASourcePath, nil);
-  end
-  else if APattern is TGocciaObjectDestructuringPattern then
-  begin
-    ObjPat := TGocciaObjectDestructuringPattern(APattern);
-    for I := 0 to ObjPat.Properties.Count - 1 do
-      CollectDestructuringPatternNames(ObjPat.Properties[I].Pattern,
-        AScope, ASourcePath);
-  end
-  else if APattern is TGocciaArrayDestructuringPattern then
-  begin
-    ArrPat := TGocciaArrayDestructuringPattern(APattern);
-    for I := 0 to ArrPat.Elements.Count - 1 do
-      if Assigned(ArrPat.Elements[I]) then
-        CollectDestructuringPatternNames(ArrPat.Elements[I],
-          AScope, ASourcePath);
-  end
-  else if APattern is TGocciaAssignmentDestructuringPattern then
-    CollectDestructuringPatternNames(
-      TGocciaAssignmentDestructuringPattern(APattern).Left,
-      AScope, ASourcePath)
-  else if APattern is TGocciaRestDestructuringPattern then
-    CollectDestructuringPatternNames(
-      TGocciaRestDestructuringPattern(APattern).Argument,
-      AScope, ASourcePath);
-end;
-
-procedure CheckTopLevelRedeclarations(const AProgram: TGocciaProgram;
-  const AScope: TGocciaScope; const ASourcePath: string);
-var
-  I, J: Integer;
-  Stmt: TGocciaStatement;
-  VarDecl: TGocciaVariableDeclaration;
-  DeclName: string;
-begin
-  for I := 0 to AProgram.Body.Count - 1 do
-  begin
-    Stmt := AProgram.Body[I];
-    if Stmt is TGocciaVariableDeclaration then
-    begin
-      VarDecl := TGocciaVariableDeclaration(Stmt);
-      for J := 0 to High(VarDecl.Variables) do
-      begin
-        DeclName := VarDecl.Variables[J].Name;
-        if AScope.ContainsOwnLexicalBinding(DeclName) then
-          raise TGocciaSyntaxError.Create(
-            SysUtils.Format('Identifier ''%s'' has already been declared',
-              [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
-      end;
-    end
-    else if Stmt is TGocciaClassDeclaration then
-    begin
-      DeclName := TGocciaClassDeclaration(Stmt).ClassDefinition.Name;
-      if AScope.ContainsOwnLexicalBinding(DeclName) then
-        raise TGocciaSyntaxError.Create(
-          SysUtils.Format('Identifier ''%s'' has already been declared',
-            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
-    end
-    else if Stmt is TGocciaDestructuringDeclaration then
-      CollectDestructuringPatternNames(
-        TGocciaDestructuringDeclaration(Stmt).Pattern, AScope, ASourcePath)
-    else if Stmt is TGocciaEnumDeclaration then
-    begin
-      DeclName := TGocciaEnumDeclaration(Stmt).Name;
-      if AScope.ContainsOwnLexicalBinding(DeclName) then
-        raise TGocciaSyntaxError.Create(
-          SysUtils.Format('Identifier ''%s'' has already been declared',
-            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
-    end;
-  end;
-end;
 
 { TGocciaBytecodeBackend }
 

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -81,6 +81,8 @@ uses
 
   GarbageCollector.Generic,
 
+  Goccia.AST.Expressions,
+  Goccia.AST.Statements,
   Goccia.CallStack,
   Goccia.Constants.PropertyNames,
   Goccia.Error,
@@ -89,6 +91,93 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.Error,
   Goccia.Values.ObjectValue;
+
+procedure CollectDestructuringPatternNames(
+  const APattern: TGocciaDestructuringPattern;
+  const AScope: TGocciaScope; const ASourcePath: string);
+var
+  ObjPat: TGocciaObjectDestructuringPattern;
+  ArrPat: TGocciaArrayDestructuringPattern;
+  I: Integer;
+begin
+  if APattern is TGocciaIdentifierDestructuringPattern then
+  begin
+    if AScope.ContainsOwnLexicalBinding(
+         TGocciaIdentifierDestructuringPattern(APattern).Name) then
+      raise TGocciaSyntaxError.Create(
+        SysUtils.Format('Identifier ''%s'' has already been declared',
+          [TGocciaIdentifierDestructuringPattern(APattern).Name]),
+        0, 0, ASourcePath, nil);
+  end
+  else if APattern is TGocciaObjectDestructuringPattern then
+  begin
+    ObjPat := TGocciaObjectDestructuringPattern(APattern);
+    for I := 0 to ObjPat.Properties.Count - 1 do
+      CollectDestructuringPatternNames(ObjPat.Properties[I].Pattern,
+        AScope, ASourcePath);
+  end
+  else if APattern is TGocciaArrayDestructuringPattern then
+  begin
+    ArrPat := TGocciaArrayDestructuringPattern(APattern);
+    for I := 0 to ArrPat.Elements.Count - 1 do
+      if Assigned(ArrPat.Elements[I]) then
+        CollectDestructuringPatternNames(ArrPat.Elements[I],
+          AScope, ASourcePath);
+  end
+  else if APattern is TGocciaAssignmentDestructuringPattern then
+    CollectDestructuringPatternNames(
+      TGocciaAssignmentDestructuringPattern(APattern).Left,
+      AScope, ASourcePath)
+  else if APattern is TGocciaRestDestructuringPattern then
+    CollectDestructuringPatternNames(
+      TGocciaRestDestructuringPattern(APattern).Argument,
+      AScope, ASourcePath);
+end;
+
+procedure CheckTopLevelRedeclarations(const AProgram: TGocciaProgram;
+  const AScope: TGocciaScope; const ASourcePath: string);
+var
+  I, J: Integer;
+  Stmt: TGocciaStatement;
+  VarDecl: TGocciaVariableDeclaration;
+  DeclName: string;
+begin
+  for I := 0 to AProgram.Body.Count - 1 do
+  begin
+    Stmt := AProgram.Body[I];
+    if Stmt is TGocciaVariableDeclaration then
+    begin
+      VarDecl := TGocciaVariableDeclaration(Stmt);
+      for J := 0 to High(VarDecl.Variables) do
+      begin
+        DeclName := VarDecl.Variables[J].Name;
+        if AScope.ContainsOwnLexicalBinding(DeclName) then
+          raise TGocciaSyntaxError.Create(
+            SysUtils.Format('Identifier ''%s'' has already been declared',
+              [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+      end;
+    end
+    else if Stmt is TGocciaClassDeclaration then
+    begin
+      DeclName := TGocciaClassDeclaration(Stmt).ClassDefinition.Name;
+      if AScope.ContainsOwnLexicalBinding(DeclName) then
+        raise TGocciaSyntaxError.Create(
+          SysUtils.Format('Identifier ''%s'' has already been declared',
+            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+    end
+    else if Stmt is TGocciaDestructuringDeclaration then
+      CollectDestructuringPatternNames(
+        TGocciaDestructuringDeclaration(Stmt).Pattern, AScope, ASourcePath)
+    else if Stmt is TGocciaEnumDeclaration then
+    begin
+      DeclName := TGocciaEnumDeclaration(Stmt).Name;
+      if AScope.ContainsOwnLexicalBinding(DeclName) then
+        raise TGocciaSyntaxError.Create(
+          SysUtils.Format('Identifier ''%s'' has already been declared',
+            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+    end;
+  end;
+end;
 
 { TGocciaBytecodeBackend }
 
@@ -168,6 +257,10 @@ function TGocciaBytecodeBackend.CompileToModule(
 var
   Compiler: TGocciaCompiler;
 begin
+  if FGlobalBackedTopLevel and Assigned(FInterpreter) then
+    CheckTopLevelRedeclarations(AProgram, FInterpreter.GlobalScope,
+      FSourcePath);
+
   Compiler := TGocciaCompiler.Create(FSourcePath);
   try
     Compiler.GlobalBackedTopLevel := FGlobalBackedTopLevel;

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -41,6 +41,7 @@ type
     FBootstrapSource: TStringList;
     FOwnsModuleLoader: Boolean;
     FInjectedGlobals: TStringList;
+    FGlobalBackedTopLevel: Boolean;
     function GetContentProvider: TGocciaModuleContentProvider;
     function GetModuleResolver: TGocciaModuleResolver;
     procedure RequireGlobalsBootstrapReady;
@@ -67,6 +68,8 @@ type
     property Interpreter: TGocciaInterpreter read FInterpreter;
     property Bootstrap: TGocciaRuntimeBootstrap read FBootstrap;
     property ContentProvider: TGocciaModuleContentProvider read GetContentProvider;
+    property GlobalBackedTopLevel: Boolean read FGlobalBackedTopLevel
+      write FGlobalBackedTopLevel;
     property ModuleLoader: TGocciaModuleLoader read FModuleLoader;
     property ModuleResolver: TGocciaModuleResolver read GetModuleResolver;
   end;
@@ -167,6 +170,7 @@ var
 begin
   Compiler := TGocciaCompiler.Create(FSourcePath);
   try
+    Compiler.GlobalBackedTopLevel := FGlobalBackedTopLevel;
     Result := Compiler.Compile(AProgram);
   finally
     Compiler.Free;

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -128,6 +128,7 @@ type
     FBuiltinArrayBuffer: TGocciaGlobalArrayBuffer;
     FPreviousExceptionMask: TFPUExceptionMask;
     FSuppressWarnings: Boolean;
+    FLastTiming: TGocciaScriptResult;
 
     procedure PinSingletons;
     procedure RegisterBuiltIns;
@@ -192,6 +193,7 @@ type
     property BuiltinTemporal: TGocciaTemporalBuiltin read FBuiltinTemporal;
     property BuiltinArrayBuffer: TGocciaGlobalArrayBuffer read FBuiltinArrayBuffer;
     property SuppressWarnings: Boolean read FSuppressWarnings write FSuppressWarnings;
+    property LastTiming: TGocciaScriptResult read FLastTiming;
   end;
 
 
@@ -810,7 +812,8 @@ var
   SourceMap: TGocciaSourceMap;
   OrigLine, OrigCol: Integer;
 begin
-  Result.FileName := FFileName;
+  FillChar(FLastTiming, SizeOf(FLastTiming), 0);
+  FLastTiming.FileName := FFileName;
   StartTime := GetNanoseconds;
 
   if Assigned(FSourceLines) then
@@ -834,23 +837,23 @@ begin
       try
         Tokens := Lexer.ScanTokens;
         LexEnd := GetNanoseconds;
-        Result.LexTimeNanoseconds := LexEnd - StartTime;
+        FLastTiming.LexTimeNanoseconds := LexEnd - StartTime;
 
         Parser := TGocciaParser.Create(Tokens, FFileName, Lexer.SourceLines);
         try
           ProgramNode := Parser.Parse;
           PrintParserWarnings(Parser, SourceMap);
           ParseEnd := GetNanoseconds;
-          Result.ParseTimeNanoseconds := ParseEnd - LexEnd;
+          FLastTiming.ParseTimeNanoseconds := ParseEnd - LexEnd;
 
           try
-            Result.CompileTimeNanoseconds := 0;
-            Result.Result := FInterpreter.Execute(ProgramNode);
+            FLastTiming.CompileTimeNanoseconds := 0;
+            FLastTiming.Result := FInterpreter.Execute(ProgramNode);
             if Assigned(TGocciaMicrotaskQueue.Instance) then
               TGocciaMicrotaskQueue.Instance.DrainQueue;
             ExecEnd := GetNanoseconds;
-            Result.ExecuteTimeNanoseconds := ExecEnd - ParseEnd;
-            Result.TotalTimeNanoseconds := ExecEnd - StartTime;
+            FLastTiming.ExecuteTimeNanoseconds := ExecEnd - ParseEnd;
+            FLastTiming.TotalTimeNanoseconds := ExecEnd - StartTime;
           finally
             if Assigned(TGocciaMicrotaskQueue.Instance) then
               TGocciaMicrotaskQueue.Instance.ClearQueue;
@@ -872,8 +875,12 @@ begin
       end;
     end;
   finally
+    if FLastTiming.TotalTimeNanoseconds = 0 then
+      FLastTiming.TotalTimeNanoseconds := GetNanoseconds - StartTime;
     SourceMap.Free;
   end;
+
+  Result := FLastTiming;
 end;
 
 function TGocciaEngine.ExecuteProgram(const AProgram: TGocciaProgram): TGocciaValue;

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -208,8 +208,6 @@ uses
   GarbageCollector.Generic,
   TimingUtils,
 
-  Goccia.AST.Expressions,
-  Goccia.AST.Statements,
   Goccia.CallStack,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
@@ -218,6 +216,7 @@ uses
   Goccia.Lexer,
   Goccia.MicrotaskQueue,
   Goccia.Scope,
+  Goccia.Scope.Redeclaration,
   Goccia.Token,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
@@ -232,93 +231,6 @@ uses
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Version;
-
-procedure CollectPatternRedeclarations(
-  const APattern: TGocciaDestructuringPattern;
-  const AScope: TGocciaScope; const ASourcePath: string);
-var
-  ObjPat: TGocciaObjectDestructuringPattern;
-  ArrPat: TGocciaArrayDestructuringPattern;
-  I: Integer;
-begin
-  if APattern is TGocciaIdentifierDestructuringPattern then
-  begin
-    if AScope.ContainsOwnLexicalBinding(
-         TGocciaIdentifierDestructuringPattern(APattern).Name) then
-      raise TGocciaSyntaxError.Create(
-        SysUtils.Format('Identifier ''%s'' has already been declared',
-          [TGocciaIdentifierDestructuringPattern(APattern).Name]),
-        0, 0, ASourcePath, nil);
-  end
-  else if APattern is TGocciaObjectDestructuringPattern then
-  begin
-    ObjPat := TGocciaObjectDestructuringPattern(APattern);
-    for I := 0 to ObjPat.Properties.Count - 1 do
-      CollectPatternRedeclarations(ObjPat.Properties[I].Pattern,
-        AScope, ASourcePath);
-  end
-  else if APattern is TGocciaArrayDestructuringPattern then
-  begin
-    ArrPat := TGocciaArrayDestructuringPattern(APattern);
-    for I := 0 to ArrPat.Elements.Count - 1 do
-      if Assigned(ArrPat.Elements[I]) then
-        CollectPatternRedeclarations(ArrPat.Elements[I],
-          AScope, ASourcePath);
-  end
-  else if APattern is TGocciaAssignmentDestructuringPattern then
-    CollectPatternRedeclarations(
-      TGocciaAssignmentDestructuringPattern(APattern).Left,
-      AScope, ASourcePath)
-  else if APattern is TGocciaRestDestructuringPattern then
-    CollectPatternRedeclarations(
-      TGocciaRestDestructuringPattern(APattern).Argument,
-      AScope, ASourcePath);
-end;
-
-procedure CheckRedeclarations(const AProgram: TGocciaProgram;
-  const AScope: TGocciaScope; const ASourcePath: string);
-var
-  I, J: Integer;
-  Stmt: TGocciaStatement;
-  VarDecl: TGocciaVariableDeclaration;
-  DeclName: string;
-begin
-  for I := 0 to AProgram.Body.Count - 1 do
-  begin
-    Stmt := AProgram.Body[I];
-    if Stmt is TGocciaVariableDeclaration then
-    begin
-      VarDecl := TGocciaVariableDeclaration(Stmt);
-      for J := 0 to High(VarDecl.Variables) do
-      begin
-        DeclName := VarDecl.Variables[J].Name;
-        if AScope.ContainsOwnLexicalBinding(DeclName) then
-          raise TGocciaSyntaxError.Create(
-            SysUtils.Format('Identifier ''%s'' has already been declared',
-              [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
-      end;
-    end
-    else if Stmt is TGocciaClassDeclaration then
-    begin
-      DeclName := TGocciaClassDeclaration(Stmt).ClassDefinition.Name;
-      if AScope.ContainsOwnLexicalBinding(DeclName) then
-        raise TGocciaSyntaxError.Create(
-          SysUtils.Format('Identifier ''%s'' has already been declared',
-            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
-    end
-    else if Stmt is TGocciaDestructuringDeclaration then
-      CollectPatternRedeclarations(
-        TGocciaDestructuringDeclaration(Stmt).Pattern, AScope, ASourcePath)
-    else if Stmt is TGocciaEnumDeclaration then
-    begin
-      DeclName := TGocciaEnumDeclaration(Stmt).Name;
-      if AScope.ContainsOwnLexicalBinding(DeclName) then
-        raise TGocciaSyntaxError.Create(
-          SysUtils.Format('Identifier ''%s'' has already been declared',
-            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
-    end;
-  end;
-end;
 
 constructor TGocciaEngine.Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins);
 begin
@@ -936,8 +848,8 @@ begin
           FLastTiming.ParseTimeNanoseconds := ParseEnd - LexEnd;
 
           try
-            CheckRedeclarations(ProgramNode, FInterpreter.GlobalScope,
-              FFileName);
+            CheckTopLevelRedeclarations(ProgramNode,
+              FInterpreter.GlobalScope, FFileName);
             FLastTiming.CompileTimeNanoseconds := 0;
             FLastTiming.Result := FInterpreter.Execute(ProgramNode);
             if Assigned(TGocciaMicrotaskQueue.Instance) then

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -208,6 +208,8 @@ uses
   GarbageCollector.Generic,
   TimingUtils,
 
+  Goccia.AST.Expressions,
+  Goccia.AST.Statements,
   Goccia.CallStack,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
@@ -230,6 +232,93 @@ uses
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Version;
+
+procedure CollectPatternRedeclarations(
+  const APattern: TGocciaDestructuringPattern;
+  const AScope: TGocciaScope; const ASourcePath: string);
+var
+  ObjPat: TGocciaObjectDestructuringPattern;
+  ArrPat: TGocciaArrayDestructuringPattern;
+  I: Integer;
+begin
+  if APattern is TGocciaIdentifierDestructuringPattern then
+  begin
+    if AScope.ContainsOwnLexicalBinding(
+         TGocciaIdentifierDestructuringPattern(APattern).Name) then
+      raise TGocciaSyntaxError.Create(
+        SysUtils.Format('Identifier ''%s'' has already been declared',
+          [TGocciaIdentifierDestructuringPattern(APattern).Name]),
+        0, 0, ASourcePath, nil);
+  end
+  else if APattern is TGocciaObjectDestructuringPattern then
+  begin
+    ObjPat := TGocciaObjectDestructuringPattern(APattern);
+    for I := 0 to ObjPat.Properties.Count - 1 do
+      CollectPatternRedeclarations(ObjPat.Properties[I].Pattern,
+        AScope, ASourcePath);
+  end
+  else if APattern is TGocciaArrayDestructuringPattern then
+  begin
+    ArrPat := TGocciaArrayDestructuringPattern(APattern);
+    for I := 0 to ArrPat.Elements.Count - 1 do
+      if Assigned(ArrPat.Elements[I]) then
+        CollectPatternRedeclarations(ArrPat.Elements[I],
+          AScope, ASourcePath);
+  end
+  else if APattern is TGocciaAssignmentDestructuringPattern then
+    CollectPatternRedeclarations(
+      TGocciaAssignmentDestructuringPattern(APattern).Left,
+      AScope, ASourcePath)
+  else if APattern is TGocciaRestDestructuringPattern then
+    CollectPatternRedeclarations(
+      TGocciaRestDestructuringPattern(APattern).Argument,
+      AScope, ASourcePath);
+end;
+
+procedure CheckRedeclarations(const AProgram: TGocciaProgram;
+  const AScope: TGocciaScope; const ASourcePath: string);
+var
+  I, J: Integer;
+  Stmt: TGocciaStatement;
+  VarDecl: TGocciaVariableDeclaration;
+  DeclName: string;
+begin
+  for I := 0 to AProgram.Body.Count - 1 do
+  begin
+    Stmt := AProgram.Body[I];
+    if Stmt is TGocciaVariableDeclaration then
+    begin
+      VarDecl := TGocciaVariableDeclaration(Stmt);
+      for J := 0 to High(VarDecl.Variables) do
+      begin
+        DeclName := VarDecl.Variables[J].Name;
+        if AScope.ContainsOwnLexicalBinding(DeclName) then
+          raise TGocciaSyntaxError.Create(
+            SysUtils.Format('Identifier ''%s'' has already been declared',
+              [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+      end;
+    end
+    else if Stmt is TGocciaClassDeclaration then
+    begin
+      DeclName := TGocciaClassDeclaration(Stmt).ClassDefinition.Name;
+      if AScope.ContainsOwnLexicalBinding(DeclName) then
+        raise TGocciaSyntaxError.Create(
+          SysUtils.Format('Identifier ''%s'' has already been declared',
+            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+    end
+    else if Stmt is TGocciaDestructuringDeclaration then
+      CollectPatternRedeclarations(
+        TGocciaDestructuringDeclaration(Stmt).Pattern, AScope, ASourcePath)
+    else if Stmt is TGocciaEnumDeclaration then
+    begin
+      DeclName := TGocciaEnumDeclaration(Stmt).Name;
+      if AScope.ContainsOwnLexicalBinding(DeclName) then
+        raise TGocciaSyntaxError.Create(
+          SysUtils.Format('Identifier ''%s'' has already been declared',
+            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+    end;
+  end;
+end;
 
 constructor TGocciaEngine.Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins);
 begin
@@ -847,6 +936,8 @@ begin
           FLastTiming.ParseTimeNanoseconds := ParseEnd - LexEnd;
 
           try
+            CheckRedeclarations(ProgramNode, FInterpreter.GlobalScope,
+              FFileName);
             FLastTiming.CompileTimeNanoseconds := 0;
             FLastTiming.Result := FInterpreter.Execute(ProgramNode);
             if Assigned(TGocciaMicrotaskQueue.Instance) then

--- a/units/Goccia.Scope.Redeclaration.pas
+++ b/units/Goccia.Scope.Redeclaration.pas
@@ -1,0 +1,110 @@
+unit Goccia.Scope.Redeclaration;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.AST.Node,
+  Goccia.Scope;
+
+procedure CheckTopLevelRedeclarations(const AProgram: TGocciaProgram;
+  const AScope: TGocciaScope; const ASourcePath: string);
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.AST.Expressions,
+  Goccia.AST.Statements,
+  Goccia.Error;
+
+procedure CheckPatternRedeclarations(
+  const APattern: TGocciaDestructuringPattern;
+  const AScope: TGocciaScope; const ASourcePath: string);
+var
+  ObjPat: TGocciaObjectDestructuringPattern;
+  ArrPat: TGocciaArrayDestructuringPattern;
+  I: Integer;
+begin
+  if APattern is TGocciaIdentifierDestructuringPattern then
+  begin
+    if AScope.ContainsOwnLexicalBinding(
+         TGocciaIdentifierDestructuringPattern(APattern).Name) then
+      raise TGocciaSyntaxError.Create(
+        SysUtils.Format('Identifier ''%s'' has already been declared',
+          [TGocciaIdentifierDestructuringPattern(APattern).Name]),
+        0, 0, ASourcePath, nil);
+  end
+  else if APattern is TGocciaObjectDestructuringPattern then
+  begin
+    ObjPat := TGocciaObjectDestructuringPattern(APattern);
+    for I := 0 to ObjPat.Properties.Count - 1 do
+      CheckPatternRedeclarations(ObjPat.Properties[I].Pattern,
+        AScope, ASourcePath);
+  end
+  else if APattern is TGocciaArrayDestructuringPattern then
+  begin
+    ArrPat := TGocciaArrayDestructuringPattern(APattern);
+    for I := 0 to ArrPat.Elements.Count - 1 do
+      if Assigned(ArrPat.Elements[I]) then
+        CheckPatternRedeclarations(ArrPat.Elements[I],
+          AScope, ASourcePath);
+  end
+  else if APattern is TGocciaAssignmentDestructuringPattern then
+    CheckPatternRedeclarations(
+      TGocciaAssignmentDestructuringPattern(APattern).Left,
+      AScope, ASourcePath)
+  else if APattern is TGocciaRestDestructuringPattern then
+    CheckPatternRedeclarations(
+      TGocciaRestDestructuringPattern(APattern).Argument,
+      AScope, ASourcePath);
+end;
+
+procedure CheckTopLevelRedeclarations(const AProgram: TGocciaProgram;
+  const AScope: TGocciaScope; const ASourcePath: string);
+var
+  I, J: Integer;
+  Stmt: TGocciaStatement;
+  VarDecl: TGocciaVariableDeclaration;
+  DeclName: string;
+begin
+  for I := 0 to AProgram.Body.Count - 1 do
+  begin
+    Stmt := AProgram.Body[I];
+    if Stmt is TGocciaVariableDeclaration then
+    begin
+      VarDecl := TGocciaVariableDeclaration(Stmt);
+      for J := 0 to High(VarDecl.Variables) do
+      begin
+        DeclName := VarDecl.Variables[J].Name;
+        if AScope.ContainsOwnLexicalBinding(DeclName) then
+          raise TGocciaSyntaxError.Create(
+            SysUtils.Format('Identifier ''%s'' has already been declared',
+              [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+      end;
+    end
+    else if Stmt is TGocciaClassDeclaration then
+    begin
+      DeclName := TGocciaClassDeclaration(Stmt).ClassDefinition.Name;
+      if AScope.ContainsOwnLexicalBinding(DeclName) then
+        raise TGocciaSyntaxError.Create(
+          SysUtils.Format('Identifier ''%s'' has already been declared',
+            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+    end
+    else if Stmt is TGocciaDestructuringDeclaration then
+      CheckPatternRedeclarations(
+        TGocciaDestructuringDeclaration(Stmt).Pattern, AScope, ASourcePath)
+    else if Stmt is TGocciaEnumDeclaration then
+    begin
+      DeclName := TGocciaEnumDeclaration(Stmt).Name;
+      if AScope.ContainsOwnLexicalBinding(DeclName) then
+        raise TGocciaSyntaxError.Create(
+          SysUtils.Format('Identifier ''%s'' has already been declared',
+            [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+    end;
+  end;
+end;
+
+end.

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -4938,6 +4938,21 @@ begin
             raise EGocciaBytecodeThrow.Create(
               CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
         end;
+        on E: TGocciaSyntaxError do
+        begin
+          if (not FHandlerStack.IsEmpty) and
+             (FHandlerStack.Peek.FrameDepth = FFrameDepth) then
+          begin
+            Handler := FHandlerStack.Peek;
+            FHandlerStack.Pop;
+            Frame.IP := Handler.CatchIP;
+            SetRegister(Handler.CatchRegister,
+              CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+          end
+          else
+            raise EGocciaBytecodeThrow.Create(
+              CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+        end;
         on E: TGocciaRuntimeError do
         begin
           if (not FHandlerStack.IsEmpty) and

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -15,6 +15,7 @@ uses
   Goccia.Interpreter,
   Goccia.Modules,
   Goccia.Scope,
+  Goccia.Scope.BindingMap,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -118,6 +119,9 @@ type
     procedure DefineStaticGetterPropertyByKey(const ATarget, AKey, AGetter: TGocciaValue);
     procedure DefineStaticSetterPropertyByKey(const ATarget, AKey, ASetter: TGocciaValue);
     procedure DefineGlobalValue(const AName: string; const AValue: TGocciaValue);
+    procedure DefineGlobalBinding(const AName: string;
+      const AValue: TGocciaValue;
+      const ADeclarationType: TGocciaDeclarationType);
     function FinalizeEnumValue(const AValue: TGocciaValue; const AName: string): TGocciaValue;
     procedure SetupAutoAccessorValue(const AName: string);
     procedure RunClassInitializers(const AClassValue: TGocciaClassValue;
@@ -187,7 +191,6 @@ uses
   Goccia.Error,
   Goccia.Evaluator,
   Goccia.Evaluator.Decorators,
-  Goccia.Scope.BindingMap,
   Goccia.Timeout,
   Goccia.Values.ClassHelper,
   Goccia.Values.EnumValue,
@@ -2425,6 +2428,14 @@ begin
     FGlobalScope.AssignLexicalBinding(AName, AValue)
   else
     FGlobalScope.DefineLexicalBinding(AName, AValue, dtLet);
+end;
+
+procedure TGocciaVM.DefineGlobalBinding(const AName: string;
+  const AValue: TGocciaValue;
+  const ADeclarationType: TGocciaDeclarationType);
+begin
+  if Assigned(FGlobalScope) then
+    FGlobalScope.DefineLexicalBinding(AName, AValue, ADeclarationType);
 end;
 
 function TGocciaVM.FinalizeEnumValue(const AValue: TGocciaValue;
@@ -4858,7 +4869,15 @@ begin
         ThrowTypeError(Template.GetConstantUnchecked(C).StringValue);
 
       OP_DEFINE_GLOBAL_CONST:
-        DefineGlobalValue(Template.GetConstantUnchecked(C).StringValue, GetRegister(A));
+      begin
+        GlobalName := Template.GetConstantUnchecked(C).StringValue;
+        case B of
+          1: DefineGlobalBinding(GlobalName, GetRegister(A), dtLet);
+          2: DefineGlobalBinding(GlobalName, GetRegister(A), dtConst);
+        else
+          DefineGlobalValue(GlobalName, GetRegister(A));
+        end;
+      end;
 
       OP_FINALIZE_ENUM:
         SetRegister(A, FinalizeEnumValue(GetRegister(A),

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -118,7 +118,6 @@ type
     procedure DefineSetterPropertyByKey(const ATarget, AKey, ASetter: TGocciaValue);
     procedure DefineStaticGetterPropertyByKey(const ATarget, AKey, AGetter: TGocciaValue);
     procedure DefineStaticSetterPropertyByKey(const ATarget, AKey, ASetter: TGocciaValue);
-    procedure DefineGlobalValue(const AName: string; const AValue: TGocciaValue);
     procedure DefineGlobalBinding(const AName: string;
       const AValue: TGocciaValue;
       const ADeclarationType: TGocciaDeclarationType);
@@ -2417,17 +2416,6 @@ begin
   end;
 
   DefineStaticSetterProperty(ATarget, AKey.ToStringLiteral.Value, ASetter);
-end;
-
-procedure TGocciaVM.DefineGlobalValue(const AName: string; const AValue: TGocciaValue);
-begin
-  if not Assigned(FGlobalScope) then
-    Exit;
-
-  if FGlobalScope.Contains(AName) then
-    FGlobalScope.AssignLexicalBinding(AName, AValue)
-  else
-    FGlobalScope.DefineLexicalBinding(AName, AValue, dtLet);
 end;
 
 procedure TGocciaVM.DefineGlobalBinding(const AName: string;
@@ -4871,12 +4859,10 @@ begin
       OP_DEFINE_GLOBAL_CONST:
       begin
         GlobalName := Template.GetConstantUnchecked(C).StringValue;
-        case B of
-          1: DefineGlobalBinding(GlobalName, GetRegister(A), dtLet);
-          2: DefineGlobalBinding(GlobalName, GetRegister(A), dtConst);
+        if B = 2 then
+          DefineGlobalBinding(GlobalName, GetRegister(A), dtConst)
         else
-          DefineGlobalValue(GlobalName, GetRegister(A));
-        end;
+          DefineGlobalBinding(GlobalName, GetRegister(A), dtLet);
       end;
 
       OP_FINALIZE_ENUM:


### PR DESCRIPTION
## Summary
- Added `--mode=bytecode` to the REPL so it can run through the bytecode VM instead of the interpreter.
- Added optional `--timing` output for bytecode REPL runs, reporting lex, parse, compile, execute, and total durations per line.
- Wired the bytecode pipeline into the REPL loop, including JSX transform, parsing, compilation, module execution, and microtask draining.
- Propagated top-level global-backed declarations through the compiler and VM so REPL bytecode execution can preserve `let`/`const` semantics for top-level bindings.
- Updated the REPL usage text and AGENTS notes to document the new bytecode and timing modes.

## Testing
- Suggested check: `./build.pas REPL`
- Suggested check: `./build/REPL --mode=bytecode --timing`
- Suggested check: `./build.pas testrunner && ./build/TestRunner tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REPL adds selectable modes (interpreted | bytecode) with an optional bytecode per-line timing; engine exposes detailed per-run timing.

* **Bug Fixes / Behavior**
  * Top-level redeclaration validation now surfaces duplicate-declaration errors.
  * Global-backed top-level declarations affect bytecode/global-definition behavior.

* **Documentation**
  * Command docs updated to document modes and timing option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->