### PR TITLE
Add coverage reporting to ScriptLoader and TestRunner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,33 @@ jobs:
           grep -q '"mode": "bytecode"' test-results-bytecode.json
           grep -q '"totalFiles":' test-results-bytecode.json
 
+      - name: Check TestRunner coverage CLI
+        run: |
+          cov_output="$(./build/TestRunner tests/built-ins/Array/array-creation.js --coverage 2>&1)"
+          printf '%s\n' "$cov_output" | grep -q 'Coverage Summary:'
+          printf '%s\n' "$cov_output" | grep -q 'array-creation.js'
+
+          ./build/TestRunner tests/built-ins/Array/array-creation.js --coverage --coverage-format=lcov --coverage-output=cov.lcov
+          grep -q '^SF:' cov.lcov
+          grep -q '^DA:' cov.lcov
+          grep -q '^end_of_record' cov.lcov
+          rm cov.lcov
+
+          ./build/TestRunner tests/built-ins/Array/array-creation.js --coverage --coverage-format=json --coverage-output=cov.json
+          grep -q '"path":' cov.json
+          grep -q '"statementMap":' cov.json
+          rm cov.json
+
+          ./build/TestRunner tests/built-ins/Array/array-creation.js --coverage --coverage-output=cov2.lcov --coverage-format=lcov
+          grep -q '^DA:' cov2.lcov
+          rm cov2.lcov
+
+          detail_output="$(./build/TestRunner tests/built-ins/Array/array-creation.js --coverage 2>&1)"
+          printf '%s\n' "$detail_output" | grep -Eq '[0-9]+x \|'
+
+          bytecode_cov="$(./build/TestRunner tests/built-ins/Array/array-creation.js --mode=bytecode --coverage 2>&1)"
+          printf '%s\n' "$bytecode_cov" | grep -q 'Coverage Summary:'
+
       - name: Run Pascal unit tests
         run: |
           found=0
@@ -746,6 +773,27 @@ jobs:
           printf '%s\n' "$error_output" | grep -q '"ok":false'
           printf '%s\n' "$error_output" | grep -q '"type":"TypeError"'
           printf '%s\n' "$error_output" | grep -q '"message":"boom"'
+
+      - name: Check ScriptLoader coverage CLI
+        run: |
+          cov_output="$(printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage 2>&1)"
+          printf '%s\n' "$cov_output" | grep -q 'Coverage Summary:'
+
+          json_cov_output="$(printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --output=json --coverage 2>&1)"
+          printf '%s\n' "$json_cov_output" | head -1 | grep -q '^{'
+
+          printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage --coverage-format=lcov --coverage-output=sl-cov.lcov
+          grep -q '^SF:' sl-cov.lcov
+          grep -q '^DA:' sl-cov.lcov
+          rm sl-cov.lcov
+
+          printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage --coverage-format=json --coverage-output=sl-cov.json
+          grep -q '"path":' sl-cov.json
+          rm sl-cov.json
+
+          printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage-output=sl-cov2.lcov --coverage-format=lcov
+          grep -q '^DA:' sl-cov2.lcov
+          rm sl-cov2.lcov
 
   artifacts:
     needs: [test, toml-compliance, json5-compliance, benchmark, examples]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,17 @@ jobs:
           bytecode_cov="$(./build/TestRunner tests/built-ins/Array/array-creation.js --mode=bytecode --coverage 2>&1)"
           printf '%s\n' "$bytecode_cov" | grep -q 'Coverage Summary:'
 
+          ./build/TestRunner tests/language/statements/if/if-else-statements.js --coverage --coverage-format=lcov --coverage-output=branch-cov.lcov
+          grep -q '^BRDA:' branch-cov.lcov
+          grep -q '^BRF:' branch-cov.lcov
+          grep -q '^BRH:' branch-cov.lcov
+          rm branch-cov.lcov
+
+          ./build/TestRunner tests/language/statements/if/if-else-statements.js --coverage --coverage-format=json --coverage-output=branch-cov.json
+          grep -q '"branchMap":' branch-cov.json
+          grep -q '"b":' branch-cov.json
+          rm branch-cov.json
+
       - name: Run Pascal unit tests
         run: |
           found=0
@@ -794,6 +805,9 @@ jobs:
           printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage-output=sl-cov2.lcov --coverage-format=lcov
           grep -q '^DA:' sl-cov2.lcov
           rm sl-cov2.lcov
+
+          bytecode_cov="$(printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --mode=bytecode --coverage 2>&1)"
+          printf '%s\n' "$bytecode_cov" | grep -q 'Coverage Summary:'
 
   artifacts:
     needs: [test, toml-compliance, json5-compliance, benchmark, examples]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,6 +70,35 @@ jobs:
           grep -q '"mode": "${{ matrix.mode }}"' test-results-${{ matrix.mode }}.json
           grep -q '"totalFiles":' test-results-${{ matrix.mode }}.json
 
+      - name: Check TestRunner coverage CLI
+        run: |
+          # --coverage prints a summary to stdout
+          cov_output="$(./build/TestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage 2>&1)"
+          printf '%s\n' "$cov_output" | grep -q 'Coverage Summary:'
+          printf '%s\n' "$cov_output" | grep -q 'array-creation.js'
+
+          # --coverage-format=lcov --coverage-output writes an lcov file
+          ./build/TestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage --coverage-format=lcov --coverage-output=cov.lcov
+          grep -q '^SF:' cov.lcov
+          grep -q '^DA:' cov.lcov
+          grep -q '^end_of_record' cov.lcov
+          rm cov.lcov
+
+          # --coverage-format=json --coverage-output writes a JSON file
+          ./build/TestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage --coverage-format=json --coverage-output=cov.json
+          grep -q '"path":' cov.json
+          grep -q '"statementMap":' cov.json
+          rm cov.json
+
+          # order-independent: --coverage-output before --coverage-format
+          ./build/TestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage --coverage-output=cov2.lcov --coverage-format=lcov
+          grep -q '^DA:' cov2.lcov
+          rm cov2.lcov
+
+          # single-file detail view shows line annotations
+          detail_output="$(./build/TestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage 2>&1)"
+          printf '%s\n' "$detail_output" | grep -Eq '[0-9]+x \|'
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v5
@@ -306,6 +335,32 @@ jobs:
           printf '%s\n' "$error_output" | grep -q '"ok":false'
           printf '%s\n' "$error_output" | grep -q '"type":"TypeError"'
           printf '%s\n' "$error_output" | grep -q '"message":"boom"'
+
+      - name: Check ScriptLoader coverage CLI
+        run: |
+          # --coverage prints summary
+          cov_output="$(printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage 2>&1)"
+          printf '%s\n' "$cov_output" | grep -q 'Coverage Summary:'
+
+          # --coverage with --output=json does NOT corrupt JSON stdout
+          json_cov_output="$(printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --output=json --coverage 2>&1)"
+          printf '%s\n' "$json_cov_output" | head -1 | grep -q '^{'
+
+          # lcov file output
+          printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage --coverage-format=lcov --coverage-output=sl-cov.lcov
+          grep -q '^SF:' sl-cov.lcov
+          grep -q '^DA:' sl-cov.lcov
+          rm sl-cov.lcov
+
+          # json file output
+          printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage --coverage-format=json --coverage-output=sl-cov.json
+          grep -q '"path":' sl-cov.json
+          rm sl-cov.json
+
+          # order-independent flags
+          printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage-output=sl-cov2.lcov --coverage-format=lcov
+          grep -q '^DA:' sl-cov2.lcov
+          rm sl-cov2.lcov
 
   benchmark-comment:
     needs: benchmark

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,6 +99,19 @@ jobs:
           detail_output="$(./build/TestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage 2>&1)"
           printf '%s\n' "$detail_output" | grep -Eq '[0-9]+x \|'
 
+          # branch coverage: lcov contains BRDA/BRF entries for branching code
+          ./build/TestRunner tests/language/statements/if/if-else-statements.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage --coverage-format=lcov --coverage-output=branch-cov.lcov
+          grep -q '^BRDA:' branch-cov.lcov
+          grep -q '^BRF:' branch-cov.lcov
+          grep -q '^BRH:' branch-cov.lcov
+          rm branch-cov.lcov
+
+          # branch coverage: JSON contains branchMap and b entries
+          ./build/TestRunner tests/language/statements/if/if-else-statements.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage --coverage-format=json --coverage-output=branch-cov.json
+          grep -q '"branchMap":' branch-cov.json
+          grep -q '"b":' branch-cov.json
+          rm branch-cov.json
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v5
@@ -361,6 +374,10 @@ jobs:
           printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --coverage-output=sl-cov2.lcov --coverage-format=lcov
           grep -q '^DA:' sl-cov2.lcov
           rm sl-cov2.lcov
+
+          # bytecode mode coverage
+          bytecode_cov="$(printf 'const x = 5;\nx;\n' | ./build/ScriptLoader --mode=bytecode --coverage 2>&1)"
+          printf '%s\n' "$bytecode_cov" | grep -q 'Coverage Summary:'
 
   benchmark-comment:
     needs: benchmark

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ GocciaScript is a subset of ECMAScript implemented in FreePascal. It provides a 
 ./build/ScriptLoader out.gbc                     # Load and execute .gbc bytecode
 printf "const x = 2 + 2; x;" | ./build/ScriptLoader        # Execute stdin source
 ./build/ScriptLoader example.js --coverage                 # Execute with line and branch coverage
+./build/ScriptLoader example.js --coverage --coverage-format=lcov --coverage-output=coverage.lcov  # Coverage with lcov output
+./build/ScriptLoader example.js --coverage --coverage-format=json --coverage-output=coverage.json  # Coverage with JSON output
 ./build/REPL                                      # Start interactive REPL (interpreted)
 ./build/REPL --mode=bytecode                      # Start the REPL via bytecode VM
 ./build/REPL --mode=bytecode --timing             # Bytecode REPL with per-line timing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ GocciaScript is a subset of ECMAScript implemented in FreePascal. It provides a 
 ./build/ScriptLoader example.js --emit --output=out.gbc   # Custom output path
 ./build/ScriptLoader out.gbc                     # Load and execute .gbc bytecode
 printf "const x = 2 + 2; x;" | ./build/ScriptLoader        # Execute stdin source
+./build/ScriptLoader example.js --coverage                 # Execute with line and branch coverage
 ./build/REPL                                      # Start interactive REPL (interpreted)
 ./build/REPL --mode=bytecode                      # Start the REPL via bytecode VM
 ./build/REPL --mode=bytecode --timing             # Bytecode REPL with per-line timing
@@ -46,6 +47,9 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader        # Execute stdin sourc
 ./build/TestRunner tests --silent                                              # Suppress all console output
 ./build/TestRunner tests --output=results.json                                 # Write test results as JSON
 ./build/TestRunner tests --mode=bytecode                                       # Run tests via the Goccia bytecode VM
+./build/TestRunner tests --coverage                                            # Run tests with line and branch coverage
+./build/TestRunner tests --coverage --coverage-format=lcov --coverage-output=coverage.lcov  # Coverage with lcov output
+./build/TestRunner tests --coverage --coverage-format=json --coverage-output=coverage.json  # Coverage with JSON output
 ./build/BenchmarkRunner benchmarks/                                               # Run all benchmarks
 ./build/BenchmarkRunner benchmarks --import-map=imports.json                      # Run benchmarks with an explicit import map
 ./build/BenchmarkRunner benchmarks/fibonacci.js                                   # Run a specific benchmark

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -56,8 +56,9 @@ var
   GInlineGlobals: TStringList = nil;
   GInlineAliases: TStringList = nil;
   GCoverageEnabled: Boolean = False;
-  GCoverageLcovFile: string = '';
-  GCoverageJsonFile: string = '';
+  GCoverageLcovEnabled: Boolean = False;
+  GCoverageJsonEnabled: Boolean = False;
+  GCoverageOutputPath: string = '';
 
 function ParseSource(const ASource: TStringList; const AFileName: string;
   const AGlobals: TGocciaGlobalBuiltins; const ASuppressWarnings: Boolean;
@@ -707,41 +708,25 @@ begin
         GSilentConsole := True
       else if Arg = '--coverage' then
         GCoverageEnabled := True
+      else if Arg = '--coverage-format=lcov' then
+      begin
+        GCoverageLcovEnabled := True;
+        GCoverageEnabled := True;
+      end
+      else if Arg = '--coverage-format=json' then
+      begin
+        GCoverageJsonEnabled := True;
+        GCoverageEnabled := True;
+      end
       else if Copy(Arg, 1, 18) = '--coverage-format=' then
       begin
-        if Copy(Arg, 19, MaxInt) = 'lcov' then
-        begin
-          if I < ParamCount then
-          begin
-            Inc(I);
-            if Copy(ParamStr(I), 1, 18) = '--coverage-output=' then
-              GCoverageLcovFile := Copy(ParamStr(I), 19, MaxInt)
-            else
-              Dec(I);
-          end;
-        end
-        else if Copy(Arg, 19, MaxInt) = 'json' then
-        begin
-          if I < ParamCount then
-          begin
-            Inc(I);
-            if Copy(ParamStr(I), 1, 18) = '--coverage-output=' then
-              GCoverageJsonFile := Copy(ParamStr(I), 19, MaxInt)
-            else
-              Dec(I);
-          end;
-        end
-        else
-        begin
-          WriteLn('Error: Unknown coverage format "', Copy(Arg, 19, MaxInt), '". Use "lcov" or "json".');
-          ExitCode := 1;
-          Exit;
-        end;
-        GCoverageEnabled := True;
+        WriteLn('Error: Unknown coverage format "', Copy(Arg, 19, MaxInt), '". Use "lcov" or "json".');
+        ExitCode := 1;
+        Exit;
       end
       else if Copy(Arg, 1, 18) = '--coverage-output=' then
       begin
-        GCoverageLcovFile := Copy(Arg, 19, MaxInt);
+        GCoverageOutputPath := Copy(Arg, 19, MaxInt);
         GCoverageEnabled := True;
       end
       else if Copy(Arg, 1, 2) <> '--' then
@@ -807,13 +792,16 @@ begin
 
       if GCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
       begin
-        PrintCoverageSummary(TGocciaCoverageTracker.Instance);
-        if (Paths.Count = 1) and FileExists(Paths[0]) then
-          PrintCoverageDetail(TGocciaCoverageTracker.Instance, Paths[0]);
-        if GCoverageLcovFile <> '' then
-          WriteCoverageLcov(TGocciaCoverageTracker.Instance, GCoverageLcovFile);
-        if GCoverageJsonFile <> '' then
-          WriteCoverageJSON(TGocciaCoverageTracker.Instance, GCoverageJsonFile);
+        if not GJsonOutput then
+        begin
+          PrintCoverageSummary(TGocciaCoverageTracker.Instance);
+          if (Paths.Count = 1) and FileExists(Paths[0]) then
+            PrintCoverageDetail(TGocciaCoverageTracker.Instance, Paths[0]);
+        end;
+        if GCoverageLcovEnabled and (GCoverageOutputPath <> '') then
+          WriteCoverageLcov(TGocciaCoverageTracker.Instance, GCoverageOutputPath);
+        if GCoverageJsonEnabled and (GCoverageOutputPath <> '') then
+          WriteCoverageJSON(TGocciaCoverageTracker.Instance, GCoverageOutputPath);
       end;
     finally
       if GCoverageEnabled then

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -15,6 +15,8 @@ uses
   Goccia.Bytecode.Binary,
   Goccia.Bytecode.Module,
   Goccia.Compiler,
+  Goccia.Coverage,
+  Goccia.Coverage.Report,
   Goccia.Engine,
   Goccia.Engine.BytecodeBackend,
   Goccia.FileExtensions,
@@ -53,6 +55,9 @@ var
   GGlobalsFiles: TStringList = nil;
   GInlineGlobals: TStringList = nil;
   GInlineAliases: TStringList = nil;
+  GCoverageEnabled: Boolean = False;
+  GCoverageLcovFile: string = '';
+  GCoverageJsonFile: string = '';
 
 function ParseSource(const ASource: TStringList; const AFileName: string;
   const AGlobals: TGocciaGlobalBuiltins; const ASuppressWarnings: Boolean;
@@ -297,6 +302,12 @@ begin
     ProgramNode := ParseSource(ASource, AFileName, TGocciaEngine.DefaultGlobals,
       GJsonOutput, Result.Timing.LexTimeNanoseconds,
       Result.Timing.ParseTimeNanoseconds);
+
+    if Assigned(TGocciaCoverageTracker.Instance) and
+       TGocciaCoverageTracker.Instance.Enabled and Assigned(ASource) then
+      TGocciaCoverageTracker.Instance.RegisterSourceFile(
+        AFileName, CountExecutableLines(ASource));
+
     try
       CompileStart := GetNanoseconds;
       Module := Backend.CompileToModule(ProgramNode);
@@ -579,6 +590,9 @@ begin
   WriteLn('  --output=json           Write structured JSON result to stdout');
   WriteLn('  --output=<path>         Output file path (used with --emit)');
   WriteLn('  --silent                Suppress console output from the script');
+  WriteLn('  --coverage              Enable line and branch coverage reporting');
+  WriteLn('  --coverage-format=lcov|json  Coverage output format (implies --coverage)');
+  WriteLn('  --coverage-output=<file>     Coverage output file (paired with --coverage-format)');
 end;
 
 var
@@ -691,6 +705,45 @@ begin
       end
       else if Arg = '--silent' then
         GSilentConsole := True
+      else if Arg = '--coverage' then
+        GCoverageEnabled := True
+      else if Copy(Arg, 1, 18) = '--coverage-format=' then
+      begin
+        if Copy(Arg, 19, MaxInt) = 'lcov' then
+        begin
+          if I < ParamCount then
+          begin
+            Inc(I);
+            if Copy(ParamStr(I), 1, 18) = '--coverage-output=' then
+              GCoverageLcovFile := Copy(ParamStr(I), 19, MaxInt)
+            else
+              Dec(I);
+          end;
+        end
+        else if Copy(Arg, 19, MaxInt) = 'json' then
+        begin
+          if I < ParamCount then
+          begin
+            Inc(I);
+            if Copy(ParamStr(I), 1, 18) = '--coverage-output=' then
+              GCoverageJsonFile := Copy(ParamStr(I), 19, MaxInt)
+            else
+              Dec(I);
+          end;
+        end
+        else
+        begin
+          WriteLn('Error: Unknown coverage format "', Copy(Arg, 19, MaxInt), '". Use "lcov" or "json".');
+          ExitCode := 1;
+          Exit;
+        end;
+        GCoverageEnabled := True;
+      end
+      else if Copy(Arg, 1, 18) = '--coverage-output=' then
+      begin
+        GCoverageLcovFile := Copy(Arg, 19, MaxInt);
+        GCoverageEnabled := True;
+      end
       else if Copy(Arg, 1, 2) <> '--' then
         Paths.Add(Arg)
       else
@@ -724,26 +777,47 @@ begin
       Exit;
     end;
 
+    if GCoverageEnabled then
+    begin
+      TGocciaCoverageTracker.Initialize;
+      TGocciaCoverageTracker.Instance.Enabled := True;
+    end;
     try
-      if Paths.Count = 0 then
-        RunScriptFromStdin
-      else
-        for I := 0 to Paths.Count - 1 do
-        begin
-          if I > 0 then
-            WriteLn;
-          RunScripts(Paths[I]);
-        end;
-    except
-      on E: Exception do
-      begin
-        if GJsonOutput then
-          WriteLn(BuildErrorJSON('', ExceptionToScriptLoaderErrorInfo(E),
-            Default(TScriptLoaderTiming)))
+      try
+        if Paths.Count = 0 then
+          RunScriptFromStdin
         else
-          WriteLn('Error: ', E.Message);
-        ExitCode := 1;
+          for I := 0 to Paths.Count - 1 do
+          begin
+            if I > 0 then
+              WriteLn;
+            RunScripts(Paths[I]);
+          end;
+      except
+        on E: Exception do
+        begin
+          if GJsonOutput then
+            WriteLn(BuildErrorJSON('', ExceptionToScriptLoaderErrorInfo(E),
+              Default(TScriptLoaderTiming)))
+          else
+            WriteLn('Error: ', E.Message);
+          ExitCode := 1;
+        end;
       end;
+
+      if GCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+      begin
+        PrintCoverageSummary(TGocciaCoverageTracker.Instance);
+        if (Paths.Count = 1) and FileExists(Paths[0]) then
+          PrintCoverageDetail(TGocciaCoverageTracker.Instance, Paths[0]);
+        if GCoverageLcovFile <> '' then
+          WriteCoverageLcov(TGocciaCoverageTracker.Instance, GCoverageLcovFile);
+        if GCoverageJsonFile <> '' then
+          WriteCoverageJSON(TGocciaCoverageTracker.Instance, GCoverageJsonFile);
+      end;
+    finally
+      if GCoverageEnabled then
+        TGocciaCoverageTracker.Shutdown;
     end;
   finally
     Paths.Free;

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -15,6 +15,8 @@ uses
   Goccia.Builtins.TestConsole,
   Goccia.Bytecode.Module,
   Goccia.Compiler,
+  Goccia.Coverage,
+  Goccia.Coverage.Report,
   Goccia.Engine,
   Goccia.Engine.BytecodeBackend,
   Goccia.FileExtensions,
@@ -40,6 +42,9 @@ var
   GImportMapPath: string = '';
   GInlineAliases: TStringList = nil;
   GMode: TGocciaEngineBackend = ebTreeWalk;
+  GCoverageEnabled: Boolean = False;
+  GCoverageLcovFile: string = '';
+  GCoverageJsonFile: string = '';
 
 type
   TTestFileResult = record
@@ -228,6 +233,11 @@ begin
           try
             ProgramNode := Parser.Parse;
             ParseEnd := GetNanoseconds;
+
+            if Assigned(TGocciaCoverageTracker.Instance) and
+               TGocciaCoverageTracker.Instance.Enabled then
+              TGocciaCoverageTracker.Instance.RegisterSourceFile(
+                AFileName, CountExecutableLines(Lexer.SourceLines));
 
             if not GSilentConsole then
               for I := 0 to Parser.WarningCount - 1 do
@@ -606,6 +616,46 @@ begin
         ExitCode := 1;
         Exit;
       end
+      else if Arg = '--coverage' then
+        GCoverageEnabled := True
+      else if Copy(Arg, 1, 18) = '--coverage-format=' then
+      begin
+        if Copy(Arg, 19, MaxInt) = 'lcov' then
+        begin
+          if I < ParamCount then
+          begin
+            Inc(I);
+            if Copy(ParamStr(I), 1, 18) = '--coverage-output=' then
+              GCoverageLcovFile := Copy(ParamStr(I), 19, MaxInt)
+            else
+              Dec(I);
+          end;
+        end
+        else if Copy(Arg, 19, MaxInt) = 'json' then
+        begin
+          if I < ParamCount then
+          begin
+            Inc(I);
+            if Copy(ParamStr(I), 1, 18) = '--coverage-output=' then
+              GCoverageJsonFile := Copy(ParamStr(I), 19, MaxInt)
+            else
+              Dec(I);
+          end;
+        end
+        else
+        begin
+          WriteLn('Error: Unknown coverage format "', Copy(Arg, 19, MaxInt), '". Use "lcov" or "json".');
+          ExitCode := 1;
+          Exit;
+        end;
+        GCoverageEnabled := True;
+      end
+      else if Copy(Arg, 1, 18) = '--coverage-output=' then
+      begin
+        // Standalone --coverage-output= (default to lcov)
+        GCoverageLcovFile := Copy(Arg, 19, MaxInt);
+        GCoverageEnabled := True;
+      end
       else if Copy(Arg, 1, 2) = '--' then
       begin
         WriteLn('Error: Unknown option "', Arg, '"');
@@ -629,36 +679,60 @@ begin
       WriteLn('  --alias key=value       Add an inline import-map-style alias');
       WriteLn('  --output=<file>         Write test results as JSON to file');
       WriteLn('  --mode=interpreted|bytecode  Execution backend (default: interpreted)');
+      WriteLn('  --coverage              Enable line and branch coverage reporting');
+      WriteLn('  --coverage-format=lcov|json  Coverage output format (implies --coverage)');
+      WriteLn('  --coverage-output=<file>     Coverage output file (paired with --coverage-format)');
       ExitCode := 1;
     end
     else
     begin
-      Files := TStringList.Create;
+      if GCoverageEnabled then
+      begin
+        TGocciaCoverageTracker.Initialize;
+        TGocciaCoverageTracker.Instance.Enabled := True;
+      end;
       try
-        for I := 0 to Paths.Count - 1 do
-        begin
-          if DirectoryExists(Paths[I]) then
-            Files.AddStrings(FindAllFiles(Paths[I], ScriptExtensions))
-          else if FileExists(Paths[I]) then
-            Files.Add(Paths[I])
-          else
+        Files := TStringList.Create;
+        try
+          for I := 0 to Paths.Count - 1 do
           begin
-            WriteLn('Error: Path not found: ', Paths[I]);
-            ExitCode := 1;
-            Exit;
+            if DirectoryExists(Paths[I]) then
+              Files.AddStrings(FindAllFiles(Paths[I], ScriptExtensions))
+            else if FileExists(Paths[I]) then
+              Files.Add(Paths[I])
+            else
+            begin
+              WriteLn('Error: Path not found: ', Paths[I]);
+              ExitCode := 1;
+              Exit;
+            end;
           end;
-        end;
 
-        if Files.Count = 1 then
-        begin
-          if GShowProgress then
-            WriteLn('[1/1] ', Files[0]);
-          PrintTestResults(RunScriptFromFile(Files[0]));
-        end
-        else
-          PrintTestResults(RunScriptsFromFiles(Files));
+          if Files.Count = 1 then
+          begin
+            if GShowProgress then
+              WriteLn('[1/1] ', Files[0]);
+            PrintTestResults(RunScriptFromFile(Files[0]));
+          end
+          else
+            PrintTestResults(RunScriptsFromFiles(Files));
+
+          if GCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+          begin
+            PrintCoverageSummary(TGocciaCoverageTracker.Instance);
+            if Files.Count = 1 then
+              PrintCoverageDetail(TGocciaCoverageTracker.Instance, Files[0]);
+            if GCoverageLcovFile <> '' then
+              WriteCoverageLcov(TGocciaCoverageTracker.Instance, GCoverageLcovFile);
+            if GCoverageJsonFile <> '' then
+              WriteCoverageJSON(TGocciaCoverageTracker.Instance, GCoverageJsonFile);
+          end;
+        finally
+          Files.Free;
+        end;
       finally
-        Files.Free;
+        if GCoverageEnabled then
+          TGocciaCoverageTracker.Shutdown;
       end;
     end;
   finally

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -43,8 +43,9 @@ var
   GInlineAliases: TStringList = nil;
   GMode: TGocciaEngineBackend = ebTreeWalk;
   GCoverageEnabled: Boolean = False;
-  GCoverageLcovFile: string = '';
-  GCoverageJsonFile: string = '';
+  GCoverageLcovEnabled: Boolean = False;
+  GCoverageJsonEnabled: Boolean = False;
+  GCoverageOutputPath: string = '';
 
 type
   TTestFileResult = record
@@ -618,42 +619,25 @@ begin
       end
       else if Arg = '--coverage' then
         GCoverageEnabled := True
+      else if Arg = '--coverage-format=lcov' then
+      begin
+        GCoverageLcovEnabled := True;
+        GCoverageEnabled := True;
+      end
+      else if Arg = '--coverage-format=json' then
+      begin
+        GCoverageJsonEnabled := True;
+        GCoverageEnabled := True;
+      end
       else if Copy(Arg, 1, 18) = '--coverage-format=' then
       begin
-        if Copy(Arg, 19, MaxInt) = 'lcov' then
-        begin
-          if I < ParamCount then
-          begin
-            Inc(I);
-            if Copy(ParamStr(I), 1, 18) = '--coverage-output=' then
-              GCoverageLcovFile := Copy(ParamStr(I), 19, MaxInt)
-            else
-              Dec(I);
-          end;
-        end
-        else if Copy(Arg, 19, MaxInt) = 'json' then
-        begin
-          if I < ParamCount then
-          begin
-            Inc(I);
-            if Copy(ParamStr(I), 1, 18) = '--coverage-output=' then
-              GCoverageJsonFile := Copy(ParamStr(I), 19, MaxInt)
-            else
-              Dec(I);
-          end;
-        end
-        else
-        begin
-          WriteLn('Error: Unknown coverage format "', Copy(Arg, 19, MaxInt), '". Use "lcov" or "json".');
-          ExitCode := 1;
-          Exit;
-        end;
-        GCoverageEnabled := True;
+        WriteLn('Error: Unknown coverage format "', Copy(Arg, 19, MaxInt), '". Use "lcov" or "json".');
+        ExitCode := 1;
+        Exit;
       end
       else if Copy(Arg, 1, 18) = '--coverage-output=' then
       begin
-        // Standalone --coverage-output= (default to lcov)
-        GCoverageLcovFile := Copy(Arg, 19, MaxInt);
+        GCoverageOutputPath := Copy(Arg, 19, MaxInt);
         GCoverageEnabled := True;
       end
       else if Copy(Arg, 1, 2) = '--' then
@@ -722,10 +706,10 @@ begin
             PrintCoverageSummary(TGocciaCoverageTracker.Instance);
             if Files.Count = 1 then
               PrintCoverageDetail(TGocciaCoverageTracker.Instance, Files[0]);
-            if GCoverageLcovFile <> '' then
-              WriteCoverageLcov(TGocciaCoverageTracker.Instance, GCoverageLcovFile);
-            if GCoverageJsonFile <> '' then
-              WriteCoverageJSON(TGocciaCoverageTracker.Instance, GCoverageJsonFile);
+            if GCoverageLcovEnabled and (GCoverageOutputPath <> '') then
+              WriteCoverageLcov(TGocciaCoverageTracker.Instance, GCoverageOutputPath);
+            if GCoverageJsonEnabled and (GCoverageOutputPath <> '') then
+              WriteCoverageJSON(TGocciaCoverageTracker.Instance, GCoverageOutputPath);
           end;
         finally
           Files.Free;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -796,3 +796,47 @@ build → test
 ```
 
 The benchmark comparison comment includes a **Suite Timing** section showing test execution and benchmark duration for both modes. See [benchmarks.md](benchmarks.md#pr-benchmark-comparison) for details on the comparison format.
+
+## Coverage
+
+The TestRunner and ScriptLoader support JavaScript source-level coverage reporting via the `--coverage` flag. Coverage tracks which lines and branches of JavaScript source code are executed at runtime.
+
+### Usage
+
+```bash
+# Console summary (printed after test results)
+./build/TestRunner tests --coverage
+
+# lcov output (for Codecov, Coveralls, or genhtml)
+./build/TestRunner tests --coverage --coverage-format=lcov --coverage-output=coverage.lcov
+
+# JSON output (Istanbul-compatible)
+./build/TestRunner tests --coverage --coverage-format=json --coverage-output=coverage.json
+
+# ScriptLoader also supports coverage
+./build/ScriptLoader example.js --coverage
+```
+
+### What is Tracked
+
+**Line coverage:** Which source lines were executed and how many times. Instrumented in both the tree-walk interpreter (`EvaluateStatement`/`EvaluateExpression`) and the bytecode VM (main dispatch loop with line-change deduplication).
+
+**Branch coverage:** Which branch arms were taken at:
+- `if`/`else` statements (branch 0 = consequent, branch 1 = alternate)
+- Ternary expressions (`? :`)
+- Short-circuit operators (`&&`, `||`, `??`)
+- `switch` statement case clauses
+
+### Output Formats
+
+| Format | Flag | Description |
+|--------|------|-------------|
+| Console | `--coverage` | Summary table printed to stdout after test results |
+| lcov | `--coverage-format=lcov --coverage-output=<file>` | Standard lcov tracefile with `DA:` and `BRDA:` entries |
+| JSON | `--coverage-format=json --coverage-output=<file>` | Istanbul-compatible JSON for tooling integration |
+
+### Architecture
+
+Coverage uses a runtime boolean check (`CoverageEnabled` on `TGocciaEvaluationContext` for the interpreter, `FCoverageEnabled` on `TGocciaVM` for bytecode). When `--coverage` is not passed, the boolean is `False` and branch prediction makes the check effectively free — no separate build is needed.
+
+Data is collected by the `TGocciaCoverageTracker` singleton (`Goccia.Coverage.pas`), which follows the same Initialize/Shutdown pattern as `TGarbageCollector` and `TGocciaCallStack`. Output formatting is in `Goccia.Coverage.Report.pas`.

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -550,6 +550,7 @@ implementation
 uses
   GarbageCollector.Generic,
 
+  Goccia.Coverage,
   Goccia.Evaluator,
   Goccia.Evaluator.Arithmetic,
   Goccia.Evaluator.Assignment,
@@ -1331,8 +1332,20 @@ begin
 end;
 
 function TGocciaConditionalExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
+var
+  ConditionResult: Boolean;
 begin
-  if Condition.Evaluate(AContext).ToBooleanLiteral.Value then
+  ConditionResult := Condition.Evaluate(AContext).ToBooleanLiteral.Value;
+  if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+  begin
+    if ConditionResult then
+      TGocciaCoverageTracker.Instance.RecordBranchHit(
+        AContext.CurrentFilePath, Line, Column, 0)
+    else
+      TGocciaCoverageTracker.Instance.RecordBranchHit(
+        AContext.CurrentFilePath, Line, Column, 1);
+  end;
+  if ConditionResult then
     Result := Consequent.Evaluate(AContext)
   else
     Result := Alternate.Evaluate(AContext);

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -1398,6 +1398,7 @@ begin
 
   ACtx.SwapState(ChildTemplate, ChildScope);
   try
+    EmitLineMapping(ACtx, AGetter.Line, AGetter.Column);
     ACtx.CompileFunctionBody(AGetter.Body);
     ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
 
@@ -1447,6 +1448,7 @@ begin
 
   ACtx.SwapState(ChildTemplate, ChildScope);
   try
+    EmitLineMapping(ACtx, ASetter.Line, ASetter.Column);
     ACtx.CompileFunctionBody(ASetter.Body);
     ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
 

--- a/units/Goccia.Compiler.Statements.pas
+++ b/units/Goccia.Compiler.Statements.pas
@@ -1318,6 +1318,7 @@ begin
     ACtx.FormalParameterCounts.AddOrSetValue(ChildTemplate, FormalCount);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
+  EmitLineMapping(ACtx, AMethod.Line, AMethod.Column);
 
   ChildCtx := ACtx;
   ChildCtx.Template := ChildTemplate;
@@ -1378,6 +1379,7 @@ begin
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
+  EmitLineMapping(ACtx, AGetter.Line, AGetter.Column);
   ACtx.CompileFunctionBody(AGetter.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
 
@@ -1427,6 +1429,7 @@ begin
   ChildScope.DeclareLocal(ASetter.Parameter, False);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
+  EmitLineMapping(ACtx, ASetter.Line, ASetter.Column);
   ACtx.CompileFunctionBody(ASetter.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
 

--- a/units/Goccia.Compiler.Statements.pas
+++ b/units/Goccia.Compiler.Statements.pas
@@ -1477,6 +1477,7 @@ begin
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
+  EmitLineMapping(ACtx, AGetter.Line, AGetter.Column);
   ACtx.CompileFunctionBody(AGetter.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
 
@@ -1533,6 +1534,7 @@ begin
   ChildScope.DeclareLocal(ASetter.Parameter, False);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
+  EmitLineMapping(ACtx, ASetter.Line, ASetter.Column);
   ACtx.CompileFunctionBody(ASetter.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
 

--- a/units/Goccia.Coverage.Report.pas
+++ b/units/Goccia.Coverage.Report.pas
@@ -1,0 +1,391 @@
+unit Goccia.Coverage.Report;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Coverage;
+
+procedure PrintCoverageSummary(const ATracker: TGocciaCoverageTracker);
+procedure PrintCoverageDetail(const ATracker: TGocciaCoverageTracker;
+  const AFilePath: string);
+procedure WriteCoverageLcov(const ATracker: TGocciaCoverageTracker;
+  const AOutputPath: string);
+procedure WriteCoverageJSON(const ATracker: TGocciaCoverageTracker;
+  const AOutputPath: string);
+
+implementation
+
+uses
+  Classes,
+  SysUtils,
+
+  BaseMap,
+  OrderedStringMap,
+  StringBuffer;
+
+type
+  TFileCovPair = TBaseMap<string, TGocciaFileCoverage>.TKeyValuePair;
+
+{ Console Summary }
+
+procedure PrintCoverageSummary(const ATracker: TGocciaCoverageTracker);
+var
+  Pair: TFileCovPair;
+  FileCov: TGocciaFileCoverage;
+  LinesHit, LinesTotal, BranchesHit, BranchesTotal: Integer;
+  TotalLinesHit, TotalLinesTotal, TotalBranchesHit, TotalBranchesTotal: Integer;
+  LinePct, BranchPct: Double;
+begin
+  TotalLinesHit := 0;
+  TotalLinesTotal := 0;
+  TotalBranchesHit := 0;
+  TotalBranchesTotal := 0;
+
+  WriteLn;
+  WriteLn('Coverage Summary:');
+  WriteLn(Format('  %-60s %-18s %s', ['File', 'Lines', 'Branches']));
+
+  for Pair in ATracker.Files do
+  begin
+    FileCov := Pair.Value;
+    LinesHit := FileCov.LinesHit;
+    LinesTotal := LinesHit;
+    if FileCov.ExecutableLines > LinesTotal then
+      LinesTotal := FileCov.ExecutableLines;
+    BranchesHit := FileCov.BranchesHit;
+    BranchesTotal := FileCov.BranchesFound;
+
+    if LinesTotal > 0 then
+      LinePct := (LinesHit / LinesTotal) * 100.0
+    else
+      LinePct := 100.0;
+
+    if BranchesTotal > 0 then
+      BranchPct := (BranchesHit / BranchesTotal) * 100.0
+    else
+      BranchPct := 100.0;
+
+    WriteLn(Format('  %-60s %d/%d (%5.1f%%)  %d/%d (%5.1f%%)',
+      [FileCov.FileName, LinesHit, LinesTotal, LinePct,
+       BranchesHit, BranchesTotal, BranchPct]));
+
+    TotalLinesHit := TotalLinesHit + LinesHit;
+    TotalLinesTotal := TotalLinesTotal + LinesTotal;
+    TotalBranchesHit := TotalBranchesHit + BranchesHit;
+    TotalBranchesTotal := TotalBranchesTotal + BranchesTotal;
+  end;
+
+  if TotalLinesTotal > 0 then
+    LinePct := (TotalLinesHit / TotalLinesTotal) * 100.0
+  else
+    LinePct := 100.0;
+  if TotalBranchesTotal > 0 then
+    BranchPct := (TotalBranchesHit / TotalBranchesTotal) * 100.0
+  else
+    BranchPct := 100.0;
+
+  WriteLn(Format('  %-60s %-18s %s', [
+    '----------------------------------------------------------------',
+    '------------------', '------------------']));
+  WriteLn(Format('  %-60s %d/%d (%5.1f%%)  %d/%d (%5.1f%%)',
+    ['Total', TotalLinesHit, TotalLinesTotal, LinePct,
+     TotalBranchesHit, TotalBranchesTotal, BranchPct]));
+end;
+
+{ Line-by-Line Detail }
+
+procedure PrintCoverageDetail(const ATracker: TGocciaCoverageTracker;
+  const AFilePath: string);
+var
+  FileCov: TGocciaFileCoverage;
+  SourceLines: TStringList;
+  ExecutableFlags: array of Boolean;
+  I, HitCount, LineWidth: Integer;
+  Gutter: string;
+begin
+  FileCov := ATracker.GetFileCoverage(AFilePath);
+  if not Assigned(FileCov) then Exit;
+  if not FileExists(AFilePath) then Exit;
+
+  SourceLines := TStringList.Create;
+  try
+    SourceLines.LoadFromFile(AFilePath);
+    if SourceLines.Count = 0 then Exit;
+
+    // Build per-line executable flags using the shared scanner
+    SetLength(ExecutableFlags, SourceLines.Count);
+    BuildExecutableLineFlags(SourceLines, ExecutableFlags);
+
+    // Determine gutter width from line count
+    LineWidth := Length(IntToStr(SourceLines.Count));
+    if LineWidth < 3 then
+      LineWidth := 3;
+
+    WriteLn;
+    WriteLn(AFilePath + ':');
+
+    for I := 0 to SourceLines.Count - 1 do
+    begin
+      HitCount := FileCov.GetLineHitCount(I + 1);
+
+      if HitCount > 0 then
+        Gutter := Format('%*dx', [LineWidth + 3, HitCount])
+      else if ExecutableFlags[I] then
+        Gutter := Format('%*s', [LineWidth + 2, '']) + '!!'
+      else
+        Gutter := Format('%*s', [LineWidth + 4, '']);
+      WriteLn(Format('  %s | %*d | %s',
+        [Gutter, LineWidth, I + 1, SourceLines[I]]));
+    end;
+  finally
+    SourceLines.Free;
+  end;
+end;
+
+{ lcov Format }
+
+procedure WriteCoverageLcov(const ATracker: TGocciaCoverageTracker;
+  const AOutputPath: string);
+var
+  Output: TStringList;
+  Pair: TFileCovPair;
+  FileCov: TGocciaFileCoverage;
+  I, HitCount, LineCount, BranchCount, BranchHitCount: Integer;
+  Branch: TGocciaCoverageBranch;
+  BranchBlockIndex: Integer;
+  PrevLine, PrevColumn: Integer;
+begin
+  Output := TStringList.Create;
+  try
+    Output.Add('TN:');
+
+    for Pair in ATracker.Files do
+    begin
+      FileCov := Pair.Value;
+      Output.Add('SF:' + FileCov.FileName);
+
+      // Line coverage data
+      LineCount := 0;
+      for I := 1 to FileCov.LineHitCount - 1 do
+      begin
+        HitCount := FileCov.GetLineHitCount(I);
+        if HitCount > 0 then
+        begin
+          Output.Add(Format('DA:%d,%d', [I, HitCount]));
+          Inc(LineCount);
+        end;
+      end;
+
+      // Branch coverage data
+      // BRDA format: BRDA:line,block,branch,hit_count
+      BranchCount := 0;
+      BranchHitCount := 0;
+      BranchBlockIndex := 0;
+      PrevLine := -1;
+      PrevColumn := -1;
+      for I := 0 to FileCov.Branches.Count - 1 do
+      begin
+        Branch := FileCov.Branches[I];
+        if (Branch.Line <> PrevLine) or (Branch.Column <> PrevColumn) then
+        begin
+          Inc(BranchBlockIndex);
+          PrevLine := Branch.Line;
+          PrevColumn := Branch.Column;
+        end;
+        if Branch.HitCount > 0 then
+          Output.Add(Format('BRDA:%d,%d,%d,%d',
+            [Branch.Line, BranchBlockIndex, Branch.BranchIndex,
+             Branch.HitCount]))
+        else
+          Output.Add(Format('BRDA:%d,%d,%d,-',
+            [Branch.Line, BranchBlockIndex, Branch.BranchIndex]));
+        Inc(BranchCount);
+        if Branch.HitCount > 0 then
+          Inc(BranchHitCount);
+      end;
+
+      Output.Add(Format('BRF:%d', [BranchCount]));
+      Output.Add(Format('BRH:%d', [BranchHitCount]));
+      Output.Add(Format('LF:%d', [LineCount]));
+      Output.Add(Format('LH:%d', [FileCov.LinesHit]));
+      Output.Add('end_of_record');
+    end;
+
+    Output.SaveToFile(AOutputPath);
+  finally
+    Output.Free;
+  end;
+end;
+
+{ JSON Format (Istanbul-compatible) }
+
+function EscapeJSONStr(const S: string): string;
+begin
+  Result := StringReplace(S, '\', '\\', [rfReplaceAll]);
+  Result := StringReplace(Result, '"', '\"', [rfReplaceAll]);
+  Result := StringReplace(Result, #10, '\n', [rfReplaceAll]);
+  Result := StringReplace(Result, #13, '\r', [rfReplaceAll]);
+  Result := StringReplace(Result, #9, '\t', [rfReplaceAll]);
+end;
+
+procedure WriteCoverageJSON(const ATracker: TGocciaCoverageTracker;
+  const AOutputPath: string);
+var
+  Buf: TStringBuffer;
+  Pair: TFileCovPair;
+  FileCov: TGocciaFileCoverage;
+  I, HitCount, StatementIndex, BranchBlockIndex: Integer;
+  Branch: TGocciaCoverageBranch;
+  PrevLine, PrevColumn: Integer;
+  FirstFile, FirstEntry: Boolean;
+  Output: TStringList;
+begin
+  Buf := TStringBuffer.Create(4096);
+  Buf.Append('{');
+
+  FirstFile := True;
+  for Pair in ATracker.Files do
+  begin
+    FileCov := Pair.Value;
+    if not FirstFile then
+      Buf.AppendChar(',');
+    FirstFile := False;
+
+    Buf.Append(#10'  "');
+    Buf.Append(EscapeJSONStr(FileCov.FileName));
+    Buf.Append('": {');
+
+    // path
+    Buf.Append(#10'    "path": "');
+    Buf.Append(EscapeJSONStr(FileCov.FileName));
+    Buf.Append('",');
+
+    // s (statement hit counts)
+    Buf.Append(#10'    "s": {');
+    StatementIndex := 0;
+    FirstEntry := True;
+    for I := 1 to FileCov.LineHitCount - 1 do
+    begin
+      HitCount := FileCov.GetLineHitCount(I);
+      if HitCount > 0 then
+      begin
+        if not FirstEntry then
+          Buf.AppendChar(',');
+        FirstEntry := False;
+        Inc(StatementIndex);
+        Buf.Append(Format('"%d":%d', [StatementIndex, HitCount]));
+      end;
+    end;
+    Buf.Append('},');
+
+    // statementMap
+    Buf.Append(#10'    "statementMap": {');
+    StatementIndex := 0;
+    FirstEntry := True;
+    for I := 1 to FileCov.LineHitCount - 1 do
+    begin
+      HitCount := FileCov.GetLineHitCount(I);
+      if HitCount > 0 then
+      begin
+        if not FirstEntry then
+          Buf.AppendChar(',');
+        FirstEntry := False;
+        Inc(StatementIndex);
+        Buf.Append(Format('"%d":{"start":{"line":%d,"column":0},"end":{"line":%d,"column":0}}',
+          [StatementIndex, I, I]));
+      end;
+    end;
+    Buf.Append('},');
+
+    // b (branch hit counts)
+    Buf.Append(#10'    "b": {');
+    BranchBlockIndex := 0;
+    PrevLine := -1;
+    PrevColumn := -1;
+    FirstEntry := True;
+    I := 0;
+    while I < FileCov.Branches.Count do
+    begin
+      Branch := FileCov.Branches[I];
+      if (Branch.Line <> PrevLine) or (Branch.Column <> PrevColumn) then
+      begin
+        if not FirstEntry then
+          Buf.AppendChar(']');
+        if BranchBlockIndex > 0 then
+          Buf.AppendChar(',');
+        Inc(BranchBlockIndex);
+        PrevLine := Branch.Line;
+        PrevColumn := Branch.Column;
+        FirstEntry := False;
+        Buf.Append(Format('"%d":[', [BranchBlockIndex]));
+        Buf.Append(Format('%d', [Branch.HitCount]));
+      end
+      else
+      begin
+        Buf.AppendChar(',');
+        Buf.Append(Format('%d', [Branch.HitCount]));
+      end;
+      Inc(I);
+    end;
+    if not FirstEntry then
+      Buf.AppendChar(']');
+    Buf.Append('},');
+
+    // branchMap
+    Buf.Append(#10'    "branchMap": {');
+    BranchBlockIndex := 0;
+    PrevLine := -1;
+    PrevColumn := -1;
+    I := 0;
+    while I < FileCov.Branches.Count do
+    begin
+      Branch := FileCov.Branches[I];
+      if (Branch.Line <> PrevLine) or (Branch.Column <> PrevColumn) then
+      begin
+        if BranchBlockIndex > 0 then
+          Buf.AppendChar(',');
+        Inc(BranchBlockIndex);
+        PrevLine := Branch.Line;
+        PrevColumn := Branch.Column;
+        Buf.Append(Format('"%d":{"type":"branch","loc":{"start":{"line":%d,"column":%d},"end":{"line":%d,"column":%d}},"locations":[',
+          [BranchBlockIndex, Branch.Line, Branch.Column,
+           Branch.Line, Branch.Column]));
+        Buf.Append(Format('{"start":{"line":%d,"column":%d},"end":{"line":%d,"column":%d}}',
+          [Branch.Line, Branch.Column, Branch.Line, Branch.Column]));
+      end
+      else
+      begin
+        Buf.AppendChar(',');
+        Buf.Append(Format('{"start":{"line":%d,"column":%d},"end":{"line":%d,"column":%d}}',
+          [Branch.Line, Branch.Column, Branch.Line, Branch.Column]));
+      end;
+      // Check if next branch is same block
+      if (I + 1 >= FileCov.Branches.Count) or
+         (FileCov.Branches[I + 1].Line <> PrevLine) or
+         (FileCov.Branches[I + 1].Column <> PrevColumn) then
+        Buf.Append(']}');
+      Inc(I);
+    end;
+    Buf.Append('},');
+
+    // f and fnMap (function coverage — not tracked yet, emit empty)
+    Buf.Append(#10'    "f": {},');
+    Buf.Append(#10'    "fnMap": {}');
+
+    Buf.Append(#10'  }');
+  end;
+
+  Buf.Append(#10'}' + #10);
+
+  Output := TStringList.Create;
+  try
+    Output.Text := Buf.ToString;
+    Output.SaveToFile(AOutputPath);
+  finally
+    Output.Free;
+  end;
+end;
+
+end.

--- a/units/Goccia.Coverage.pas
+++ b/units/Goccia.Coverage.pas
@@ -1,0 +1,466 @@
+unit Goccia.Coverage;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Classes,
+  Generics.Collections,
+
+  OrderedStringMap;
+
+function CountExecutableLines(const ASourceLines: TStrings): Integer;
+procedure BuildExecutableLineFlags(const ASourceLines: TStrings;
+  var AFlags: array of Boolean);
+function IsStructuralOnly(const ATrimmed: string): Boolean;
+function StartsWithWord(const ALine, AWord: string): Boolean;
+
+type
+  TGocciaCoverageBranch = record
+    Line: Integer;
+    Column: Integer;
+    BranchIndex: Integer;
+    HitCount: Integer;
+  end;
+
+  TGocciaCoverageBranchList = TList<TGocciaCoverageBranch>;
+
+  TGocciaFileCoverage = class
+  private
+    FFileName: string;
+    FLineHits: array of Integer;
+    FExecutableLines: Integer;
+    FBranches: TGocciaCoverageBranchList;
+  public
+    constructor Create(const AFileName: string; const AExecutableLines: Integer);
+    destructor Destroy; override;
+
+    procedure RecordLineHit(const ALine: Integer); inline;
+    procedure RecordBranchHit(const ALine, AColumn, ABranchIndex: Integer);
+
+    function LinesHit: Integer;
+    function BranchesFound: Integer;
+    function BranchesHit: Integer;
+
+    function LineHitCount: Integer;
+
+    property FileName: string read FFileName;
+    property ExecutableLines: Integer read FExecutableLines;
+    property Branches: TGocciaCoverageBranchList read FBranches;
+    function GetLineHitCount(const ALine: Integer): Integer; inline;
+  end;
+
+  TGocciaCoverageFileMap = TOrderedStringMap<TGocciaFileCoverage>;
+
+  TGocciaCoverageTracker = class
+  private class var
+    FInstance: TGocciaCoverageTracker;
+  private
+    FFiles: TGocciaCoverageFileMap;
+    FEnabled: Boolean;
+    FLastHitFile: string;
+    FLastHitLine: Integer;
+    function GetOrCreateFile(const AFilePath: string): TGocciaFileCoverage;
+  public
+    class function Instance: TGocciaCoverageTracker;
+    class procedure Initialize;
+    class procedure Shutdown;
+
+    constructor Create;
+    destructor Destroy; override;
+
+    procedure RegisterSourceFile(const AFilePath: string;
+      const AExecutableLines: Integer);
+    procedure RecordLineHit(const AFilePath: string;
+      const ALine: Integer); inline;
+    procedure RecordBranchHit(const AFilePath: string;
+      const ALine, AColumn, ABranchIndex: Integer);
+
+    function GetFileCoverage(const AFilePath: string): TGocciaFileCoverage;
+
+    property Files: TGocciaCoverageFileMap read FFiles;
+    property Enabled: Boolean read FEnabled write FEnabled;
+  end;
+
+implementation
+
+uses
+  SysUtils;
+
+const
+  DEFAULT_LINE_CAPACITY = 256;
+
+function IsStructuralOnly(const ATrimmed: string): Boolean;
+var
+  I: Integer;
+begin
+  // Returns True if the line contains only braces, brackets, parens,
+  // semicolons, commas, and whitespace — e.g., });  }  );  ],  ]);
+  for I := 1 to Length(ATrimmed) do
+    if not (ATrimmed[I] in ['}', ')', ']', ';', ',', '{', '(', '[', ' ', #9]) then
+      Exit(False);
+  Result := True;
+end;
+
+function StartsWithWord(const ALine, AWord: string): Boolean;
+var
+  WordLen: Integer;
+begin
+  WordLen := Length(AWord);
+  Result := (Length(ALine) > WordLen) and
+            (Copy(ALine, 1, WordLen) = AWord) and
+            (ALine[WordLen + 1] in [' ', '(', '<', '{', #9]);
+end;
+
+function CountUnescapedBackticks(const ALine: string): Integer;
+var
+  J, Len: Integer;
+begin
+  Result := 0;
+  Len := Length(ALine);
+  J := 1;
+  while J <= Len do
+  begin
+    if (ALine[J] = '\') then
+    begin
+      Inc(J, 2); // skip escaped character
+      Continue;
+    end;
+    if ALine[J] = '`' then
+      Inc(Result);
+    Inc(J);
+  end;
+end;
+
+function IsSkippedTestLine(const ATrimmed: string): Boolean;
+begin
+  Result := (Pos('test.skip(', ATrimmed) > 0) or
+            (Pos('describe.skip(', ATrimmed) > 0) or
+            (Pos('.skipIf(', ATrimmed) > 0);
+end;
+
+procedure BuildExecutableLineFlags(const ASourceLines: TStrings;
+  var AFlags: array of Boolean);
+var
+  I, J, Len: Integer;
+  Trimmed: string;
+  InBlockComment: Boolean;
+  InTemplateLiteral: Boolean;
+  TypeBodyDepth: Integer;
+  SkipBodyDepth: Integer;
+begin
+  InBlockComment := False;
+  InTemplateLiteral := False;
+  TypeBodyDepth := 0;
+  SkipBodyDepth := 0;
+
+  for I := 0 to ASourceLines.Count - 1 do
+  begin
+    AFlags[I] := False;
+    Trimmed := Trim(ASourceLines[I]);
+    Len := Length(Trimmed);
+
+    // Empty line
+    if Len = 0 then Continue;
+
+    // Template literal continuation — lines inside backtick strings are data
+    if InTemplateLiteral then
+    begin
+      if Odd(CountUnescapedBackticks(Trimmed)) then
+        InTemplateLiteral := False;
+      Continue;
+    end;
+
+    // Track block comment state
+    if InBlockComment then
+    begin
+      if Pos('*/', Trimmed) > 0 then
+        InBlockComment := False;
+      Continue;
+    end;
+
+    // Single-line comment
+    if (Len >= 2) and (Trimmed[1] = '/') and (Trimmed[2] = '/') then Continue;
+
+    // Block comment opening — check if it also closes on same line
+    if (Len >= 2) and (Trimmed[1] = '/') and (Trimmed[2] = '*') then
+    begin
+      if Pos('*/', Trimmed) > 2 then
+        { Single-line block comment like /* ... */ — skip the whole line }
+      else
+        InBlockComment := True;
+      Continue;
+    end;
+
+    // Check for template literal opening on this line (odd number of backticks
+    // means the line ends inside a template)
+    if Odd(CountUnescapedBackticks(Trimmed)) then
+      InTemplateLiteral := True;
+
+    // Track skipped test/describe body depth — lines inside are intentionally unexecuted
+    if SkipBodyDepth > 0 then
+    begin
+      for J := 1 to Len do
+      begin
+        if Trimmed[J] = '(' then Inc(SkipBodyDepth)
+        else if Trimmed[J] = ')' then Dec(SkipBodyDepth);
+      end;
+      Continue;
+    end;
+
+    // Detect test.skip/describe.skip/skipIf/runIf — body is intentionally skipped
+    if IsSkippedTestLine(Trimmed) then
+    begin
+      SkipBodyDepth := 0;
+      for J := 1 to Len do
+      begin
+        if Trimmed[J] = '(' then Inc(SkipBodyDepth)
+        else if Trimmed[J] = ')' then Dec(SkipBodyDepth);
+      end;
+      AFlags[I] := True; // The skip line itself is executable (it gets evaluated)
+      Continue;
+    end;
+
+    // Track interface body depth — lines inside are type-only
+    if TypeBodyDepth > 0 then
+    begin
+      for J := 1 to Len do
+      begin
+        if Trimmed[J] = '{' then Inc(TypeBodyDepth)
+        else if Trimmed[J] = '}' then Dec(TypeBodyDepth);
+      end;
+      Continue;
+    end;
+
+    // Detect interface block openings:
+    //   interface Foo {         → opening line is executable, body is not
+    //   interface Foo extends X {
+    if StartsWithWord(Trimmed, 'interface') and (Pos('{', Trimmed) > 0) then
+    begin
+      TypeBodyDepth := 1;
+      for J := Pos('{', Trimmed) + 1 to Len do
+      begin
+        if Trimmed[J] = '{' then Inc(TypeBodyDepth)
+        else if Trimmed[J] = '}' then Dec(TypeBodyDepth);
+      end;
+      AFlags[I] := True; // The opening line itself is executable
+      Continue;
+    end;
+
+    // Pure structural lines: only closing braces/parens/semicolons
+    if IsStructuralOnly(Trimmed) then Continue;
+
+    AFlags[I] := True;
+  end;
+end;
+
+function CountExecutableLines(const ASourceLines: TStrings): Integer;
+var
+  Flags: array of Boolean;
+  I: Integer;
+begin
+  SetLength(Flags, ASourceLines.Count);
+  BuildExecutableLineFlags(ASourceLines, Flags);
+  Result := 0;
+  for I := 0 to High(Flags) do
+    if Flags[I] then
+      Inc(Result);
+end;
+
+{ TGocciaFileCoverage }
+
+constructor TGocciaFileCoverage.Create(const AFileName: string;
+  const AExecutableLines: Integer);
+var
+  I, Capacity: Integer;
+begin
+  inherited Create;
+  FFileName := AFileName;
+  FExecutableLines := AExecutableLines;
+  if AExecutableLines > 0 then
+    Capacity := AExecutableLines + 1
+  else
+    Capacity := DEFAULT_LINE_CAPACITY;
+  SetLength(FLineHits, Capacity);
+  for I := 0 to High(FLineHits) do
+    FLineHits[I] := 0;
+  FBranches := TGocciaCoverageBranchList.Create;
+end;
+
+destructor TGocciaFileCoverage.Destroy;
+begin
+  FBranches.Free;
+  inherited;
+end;
+
+procedure TGocciaFileCoverage.RecordLineHit(const ALine: Integer);
+var
+  NewLength, I: Integer;
+begin
+  if ALine <= 0 then Exit;
+  if ALine >= Length(FLineHits) then
+  begin
+    NewLength := Length(FLineHits);
+    if NewLength < 16 then
+      NewLength := 16;
+    while NewLength <= ALine do
+      NewLength := NewLength * 2;
+    I := Length(FLineHits);
+    SetLength(FLineHits, NewLength);
+    while I < NewLength do
+    begin
+      FLineHits[I] := 0;
+      Inc(I);
+    end;
+  end;
+  Inc(FLineHits[ALine]);
+end;
+
+procedure TGocciaFileCoverage.RecordBranchHit(const ALine, AColumn,
+  ABranchIndex: Integer);
+var
+  I: Integer;
+  Branch: TGocciaCoverageBranch;
+begin
+  for I := 0 to FBranches.Count - 1 do
+    if (FBranches[I].Line = ALine) and (FBranches[I].Column = AColumn) and
+       (FBranches[I].BranchIndex = ABranchIndex) then
+    begin
+      Branch := FBranches[I];
+      Inc(Branch.HitCount);
+      FBranches[I] := Branch;
+      Exit;
+    end;
+
+  Branch.Line := ALine;
+  Branch.Column := AColumn;
+  Branch.BranchIndex := ABranchIndex;
+  Branch.HitCount := 1;
+  FBranches.Add(Branch);
+end;
+
+function TGocciaFileCoverage.LinesHit: Integer;
+var
+  I: Integer;
+begin
+  Result := 0;
+  for I := 1 to High(FLineHits) do
+    if FLineHits[I] > 0 then
+      Inc(Result);
+end;
+
+function TGocciaFileCoverage.BranchesFound: Integer;
+begin
+  Result := FBranches.Count;
+end;
+
+function TGocciaFileCoverage.BranchesHit: Integer;
+var
+  I: Integer;
+begin
+  Result := 0;
+  for I := 0 to FBranches.Count - 1 do
+    if FBranches[I].HitCount > 0 then
+      Inc(Result);
+end;
+
+function TGocciaFileCoverage.LineHitCount: Integer;
+begin
+  Result := Length(FLineHits);
+end;
+
+function TGocciaFileCoverage.GetLineHitCount(const ALine: Integer): Integer;
+begin
+  if (ALine >= 0) and (ALine < Length(FLineHits)) then
+    Result := FLineHits[ALine]
+  else
+    Result := 0;
+end;
+
+{ TGocciaCoverageTracker }
+
+class function TGocciaCoverageTracker.Instance: TGocciaCoverageTracker;
+begin
+  Result := FInstance;
+end;
+
+class procedure TGocciaCoverageTracker.Initialize;
+begin
+  if not Assigned(FInstance) then
+    FInstance := TGocciaCoverageTracker.Create;
+end;
+
+class procedure TGocciaCoverageTracker.Shutdown;
+begin
+  FreeAndNil(FInstance);
+end;
+
+constructor TGocciaCoverageTracker.Create;
+begin
+  inherited Create;
+  FFiles := TGocciaCoverageFileMap.Create;
+  FEnabled := False;
+end;
+
+destructor TGocciaCoverageTracker.Destroy;
+var
+  IterState: Integer;
+  Key: string;
+  Value: TGocciaFileCoverage;
+begin
+  if Assigned(FFiles) then
+  begin
+    IterState := 0;
+    while FFiles.GetNextEntry(IterState, Key, Value) do
+      Value.Free;
+    FFiles.Free;
+  end;
+  inherited;
+end;
+
+function TGocciaCoverageTracker.GetOrCreateFile(
+  const AFilePath: string): TGocciaFileCoverage;
+begin
+  if not FFiles.TryGetValue(AFilePath, Result) then
+  begin
+    Result := TGocciaFileCoverage.Create(AFilePath, 0);
+    FFiles.Add(AFilePath, Result);
+  end;
+end;
+
+procedure TGocciaCoverageTracker.RegisterSourceFile(const AFilePath: string;
+  const AExecutableLines: Integer);
+var
+  FileCov: TGocciaFileCoverage;
+begin
+  if not FFiles.TryGetValue(AFilePath, FileCov) then
+  begin
+    FileCov := TGocciaFileCoverage.Create(AFilePath, AExecutableLines);
+    FFiles.Add(AFilePath, FileCov);
+  end;
+end;
+
+procedure TGocciaCoverageTracker.RecordLineHit(const AFilePath: string;
+  const ALine: Integer);
+begin
+  if (ALine = FLastHitLine) and (AFilePath = FLastHitFile) then Exit;
+  FLastHitLine := ALine;
+  FLastHitFile := AFilePath;
+  GetOrCreateFile(AFilePath).RecordLineHit(ALine);
+end;
+
+procedure TGocciaCoverageTracker.RecordBranchHit(const AFilePath: string;
+  const ALine, AColumn, ABranchIndex: Integer);
+begin
+  GetOrCreateFile(AFilePath).RecordBranchHit(ALine, AColumn, ABranchIndex);
+end;
+
+function TGocciaCoverageTracker.GetFileCoverage(
+  const AFilePath: string): TGocciaFileCoverage;
+begin
+  if not FFiles.TryGetValue(AFilePath, Result) then
+    Result := nil;
+end;
+
+end.

--- a/units/Goccia.Coverage.pas
+++ b/units/Goccia.Coverage.pas
@@ -38,6 +38,7 @@ type
 
     procedure RecordLineHit(const ALine: Integer); inline;
     procedure RecordBranchHit(const ALine, AColumn, ABranchIndex: Integer);
+    procedure EnsureBranchExists(const ALine, AColumn, ABranchIndex: Integer);
 
     function LinesHit: Integer;
     function BranchesFound: Integer;
@@ -136,8 +137,7 @@ end;
 function IsSkippedTestLine(const ATrimmed: string): Boolean;
 begin
   Result := (Pos('test.skip(', ATrimmed) > 0) or
-            (Pos('describe.skip(', ATrimmed) > 0) or
-            (Pos('.skipIf(', ATrimmed) > 0);
+            (Pos('describe.skip(', ATrimmed) > 0);
 end;
 
 procedure BuildExecutableLineFlags(const ASourceLines: TStrings;
@@ -330,6 +330,9 @@ begin
       Branch := FBranches[I];
       Inc(Branch.HitCount);
       FBranches[I] := Branch;
+      // Ensure the opposite arm exists for binary branches (if/ternary/short-circuit)
+      if ABranchIndex <= 1 then
+        EnsureBranchExists(ALine, AColumn, 1 - ABranchIndex);
       Exit;
     end;
 
@@ -337,6 +340,28 @@ begin
   Branch.Column := AColumn;
   Branch.BranchIndex := ABranchIndex;
   Branch.HitCount := 1;
+  FBranches.Add(Branch);
+
+  // Ensure the opposite arm exists for binary branches
+  if ABranchIndex <= 1 then
+    EnsureBranchExists(ALine, AColumn, 1 - ABranchIndex);
+end;
+
+procedure TGocciaFileCoverage.EnsureBranchExists(const ALine, AColumn,
+  ABranchIndex: Integer);
+var
+  I: Integer;
+  Branch: TGocciaCoverageBranch;
+begin
+  for I := 0 to FBranches.Count - 1 do
+    if (FBranches[I].Line = ALine) and (FBranches[I].Column = AColumn) and
+       (FBranches[I].BranchIndex = ABranchIndex) then
+      Exit;
+
+  Branch.Line := ALine;
+  Branch.Column := AColumn;
+  Branch.BranchIndex := ABranchIndex;
+  Branch.HitCount := 0;
   FBranches.Add(Branch);
 end;
 

--- a/units/Goccia.Coverage.pas
+++ b/units/Goccia.Coverage.pas
@@ -209,7 +209,7 @@ begin
       Continue;
     end;
 
-    // Detect test.skip/describe.skip/skipIf/runIf — body is intentionally skipped
+    // Detect test.skip/describe.skip — body is unconditionally skipped
     if IsSkippedTestLine(Trimmed) then
     begin
       SkipBodyDepth := 0;

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -83,6 +83,7 @@ uses
 
   Goccia.CallStack,
   Goccia.Constants.PropertyNames,
+  Goccia.Coverage,
   Goccia.Error,
   Goccia.Scope,
   Goccia.Scope.BindingMap,
@@ -191,6 +192,8 @@ begin
   GC := TGarbageCollector.Instance;
   WasEnabled := GC.Enabled;
   GC.Enabled := False;
+  FMinimalVM.CoverageEnabled := Assigned(TGocciaCoverageTracker.Instance)
+    and TGocciaCoverageTracker.Instance.Enabled;
   try
     Result := FMinimalVM.ExecuteModule(AModule);
   finally

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -212,6 +212,7 @@ uses
   Goccia.CallStack,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Coverage,
   Goccia.Error,
   Goccia.JSX.Transformer,
   Goccia.Lexer,
@@ -852,6 +853,11 @@ begin
           PrintParserWarnings(Parser, SourceMap);
           ParseEnd := GetNanoseconds;
           FLastTiming.ParseTimeNanoseconds := ParseEnd - LexEnd;
+
+          if Assigned(TGocciaCoverageTracker.Instance) and
+             TGocciaCoverageTracker.Instance.Enabled then
+            TGocciaCoverageTracker.Instance.RegisterSourceFile(
+              FFileName, CountExecutableLines(Lexer.SourceLines));
 
           try
             CheckTopLevelRedeclarations(ProgramNode,

--- a/units/Goccia.Evaluator.Context.pas
+++ b/units/Goccia.Evaluator.Context.pas
@@ -15,6 +15,7 @@ type
     OnError: TGocciaThrowErrorCallback;
     LoadModule: TLoadModuleCallback;
     CurrentFilePath: string;
+    CoverageEnabled: Boolean;
   end;
 
 implementation

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -94,6 +94,7 @@ uses
   Goccia.Constants,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Coverage,
   Goccia.Error,
   Goccia.Evaluator.Arithmetic,
   Goccia.Evaluator.Assignment,
@@ -281,11 +282,17 @@ end;
 
 function EvaluateExpression(const AExpression: TGocciaExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 begin
+  if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+    TGocciaCoverageTracker.Instance.RecordLineHit(
+      AContext.CurrentFilePath, AExpression.Line);
   Result := AExpression.Evaluate(AContext);
 end;
 
 function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 begin
+  if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+    TGocciaCoverageTracker.Instance.RecordLineHit(
+      AContext.CurrentFilePath, AStatement.Line);
   Result := AStatement.Execute(AContext);
 end;
 
@@ -298,9 +305,19 @@ begin
   begin
     Left := EvaluateExpression(ABinaryExpression.Left, AContext);
     if not Left.ToBooleanLiteral.Value then
+    begin
+      if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+        TGocciaCoverageTracker.Instance.RecordBranchHit(
+          AContext.CurrentFilePath, ABinaryExpression.Line,
+          ABinaryExpression.Column, 0);
       Result := Left  // Short-circuit: return left operand if falsy
+    end
     else
     begin
+      if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+        TGocciaCoverageTracker.Instance.RecordBranchHit(
+          AContext.CurrentFilePath, ABinaryExpression.Line,
+          ABinaryExpression.Column, 1);
       Right := EvaluateExpression(ABinaryExpression.Right, AContext);
       Result := Right;  // Return right operand
     end;
@@ -310,9 +327,19 @@ begin
   begin
     Left := EvaluateExpression(ABinaryExpression.Left, AContext);
     if Left.ToBooleanLiteral.Value then
+    begin
+      if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+        TGocciaCoverageTracker.Instance.RecordBranchHit(
+          AContext.CurrentFilePath, ABinaryExpression.Line,
+          ABinaryExpression.Column, 0);
       Result := Left  // Short-circuit: return left operand if truthy
+    end
     else
     begin
+      if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+        TGocciaCoverageTracker.Instance.RecordBranchHit(
+          AContext.CurrentFilePath, ABinaryExpression.Line,
+          ABinaryExpression.Column, 1);
       Right := EvaluateExpression(ABinaryExpression.Right, AContext);
       Result := Right;  // Return right operand
     end;
@@ -324,11 +351,21 @@ begin
     // Return right operand only if left is null or undefined
     if (Left is TGocciaNullLiteralValue) or (Left is TGocciaUndefinedLiteralValue) then
     begin
+      if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+        TGocciaCoverageTracker.Instance.RecordBranchHit(
+          AContext.CurrentFilePath, ABinaryExpression.Line,
+          ABinaryExpression.Column, 0);
       Right := EvaluateExpression(ABinaryExpression.Right, AContext);
       Result := Right;
     end
     else
+    begin
+      if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+        TGocciaCoverageTracker.Instance.RecordBranchHit(
+          AContext.CurrentFilePath, ABinaryExpression.Line,
+          ABinaryExpression.Column, 1);
       Result := Left;  // Return left operand for all other values (including falsy ones)
+    end;
     Exit;
   end;
 
@@ -926,6 +963,8 @@ begin
 
   // Create function with closure scope
   Result := TGocciaFunctionValue.Create(EmptyParameters, Statements, AContext.Scope.CreateChild);
+  TGocciaFunctionValue(Result).SourceFilePath := AContext.CurrentFilePath;
+  TGocciaFunctionValue(Result).SourceLine := AGetterExpression.Line;
 end;
 
 function EvaluateSetter(const ASetterExpression: TGocciaSetterExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
@@ -942,6 +981,8 @@ begin
 
   // Create function with closure scope
   Result := TGocciaFunctionValue.Create(Parameters, Statements, AContext.Scope.CreateChild);
+  TGocciaFunctionValue(Result).SourceFilePath := AContext.CurrentFilePath;
+  TGocciaFunctionValue(Result).SourceLine := ASetterExpression.Line;
 end;
 
 // ES2026 §27.7.5.3 Await(value)
@@ -1218,6 +1259,8 @@ begin
   else
     Result := TGocciaArrowFunctionValue.Create(AArrowFunctionExpression.Parameters, Statements, AContext.Scope.CreateChild);
   TGocciaFunctionValue(Result).IsExpressionBody := not (AArrowFunctionExpression.Body is TGocciaBlockStatement);
+  TGocciaFunctionValue(Result).SourceFilePath := AContext.CurrentFilePath;
+  TGocciaFunctionValue(Result).SourceLine := AArrowFunctionExpression.Line;
 end;
 
 function EvaluateMethodExpression(const AMethodExpression: TGocciaMethodExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
@@ -1236,6 +1279,8 @@ begin
     Result := TGocciaAsyncFunctionValue.Create(AMethodExpression.Parameters, Statements, AContext.Scope.CreateChild)
   else
     Result := TGocciaFunctionValue.Create(AMethodExpression.Parameters, Statements, AContext.Scope.CreateChild);
+  TGocciaFunctionValue(Result).SourceFilePath := AContext.CurrentFilePath;
+  TGocciaFunctionValue(Result).SourceLine := AMethodExpression.Line;
 end;
 
 function EvaluateBlock(const ABlockStatement: TGocciaBlockStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
@@ -1272,8 +1317,21 @@ begin
 end;
 
 function EvaluateIf(const AIfStatement: TGocciaIfStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+var
+  ConditionResult: Boolean;
 begin
-  if EvaluateExpression(AIfStatement.Condition, AContext).ToBooleanLiteral.Value then
+  ConditionResult := EvaluateExpression(AIfStatement.Condition, AContext)
+    .ToBooleanLiteral.Value;
+  if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+  begin
+    if ConditionResult then
+      TGocciaCoverageTracker.Instance.RecordBranchHit(
+        AContext.CurrentFilePath, AIfStatement.Line, AIfStatement.Column, 0)
+    else
+      TGocciaCoverageTracker.Instance.RecordBranchHit(
+        AContext.CurrentFilePath, AIfStatement.Line, AIfStatement.Column, 1);
+  end;
+  if ConditionResult then
     Result := EvaluateStatement(AIfStatement.Consequent, AContext)
   else if Assigned(AIfStatement.Alternate) then
     Result := EvaluateStatement(AIfStatement.Alternate, AContext)
@@ -1409,6 +1467,8 @@ begin
     Result := TGocciaAsyncMethodValue.Create(AClassMethod.Parameters, Statements, AContext.Scope.CreateChild, AClassMethod.Name, ASuperClass)
   else
     Result := TGocciaMethodValue.Create(AClassMethod.Parameters, Statements, AContext.Scope.CreateChild, AClassMethod.Name, ASuperClass);
+  TGocciaFunctionValue(Result).SourceFilePath := AContext.CurrentFilePath;
+  TGocciaFunctionValue(Result).SourceLine := AClassMethod.Line;
 end;
 
 function EvaluateClass(const AClassDeclaration: TGocciaClassDeclaration; const AContext: TGocciaEvaluationContext): TGocciaValue;
@@ -1554,7 +1614,13 @@ begin
     begin
       CaseTest := EvaluateExpression(CaseClause.Test, AContext);
       if IsStrictEqual(Discriminant, CaseTest) then
+      begin
         Matched := True;
+        if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+          TGocciaCoverageTracker.Instance.RecordBranchHit(
+            AContext.CurrentFilePath, ASwitchStatement.Line,
+            ASwitchStatement.Column, I);
+      end;
     end;
 
     if Matched then

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -1638,6 +1638,10 @@ begin
 
   if not Matched and not Done and (DefaultIndex >= 0) then
   begin
+    if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+      TGocciaCoverageTracker.Instance.RecordBranchHit(
+        AContext.CurrentFilePath, ASwitchStatement.Line,
+        ASwitchStatement.Column, DefaultIndex);
     for I := DefaultIndex to ASwitchStatement.Cases.Count - 1 do
     begin
       CaseClause := ASwitchStatement.Cases[I];

--- a/units/Goccia.Interpreter.pas
+++ b/units/Goccia.Interpreter.pas
@@ -71,7 +71,9 @@ type
 implementation
 
 uses
-  GarbageCollector.Generic;
+  GarbageCollector.Generic,
+
+  Goccia.Coverage;
 
 { TGocciaInterpreter }
 
@@ -118,6 +120,8 @@ begin
   Result.OnError := ThrowError;
   Result.LoadModule := LoadModule;
   Result.CurrentFilePath := FFileName;
+  Result.CoverageEnabled := Assigned(TGocciaCoverageTracker.Instance)
+    and TGocciaCoverageTracker.Instance.Enabled;
 end;
 
 function TGocciaInterpreter.Execute(const AProgram: TGocciaProgram): TGocciaValue;

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -3395,7 +3395,11 @@ begin
       for I := 0 to High(AArguments) do
         SetLocalRaw(I + 1, AArguments[I]);
 
-    PrevCovLine := 0;
+    if FCoverageEnabled and Assigned(Template.DebugInfo) and
+       (Template.DebugInfo.LineMapCount > 0) then
+      PrevCovLine := Template.DebugInfo.GetLineMapEntry(0).Line
+    else
+      PrevCovLine := 0;
     Running := True;
     while Running and (Frame.IP < Template.CodeCount) do
     begin

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -64,6 +64,7 @@ type
     FCurrentModuleSourcePath: string;
     FCurrentModuleExports: TGocciaValueMap;
     FActiveDecoratorSession: TObject;
+    FCoverageEnabled: Boolean;
     FPreviousExceptionMask: TFPUExceptionMask;
     FArgumentPool: TGocciaArgumentsPoolArray;
     FArgumentPoolCount: Integer;
@@ -173,6 +174,7 @@ type
     function ExecuteModule(const AModule: TGocciaBytecodeModule): TGocciaValue;
     property GlobalScope: TGocciaScope read FGlobalScope write FGlobalScope;
     property Interpreter: TGocciaInterpreter read FInterpreter write FInterpreter;
+    property CoverageEnabled: Boolean read FCoverageEnabled write FCoverageEnabled;
   end;
 
 implementation
@@ -187,6 +189,7 @@ uses
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Coverage,
   Goccia.Error,
   Goccia.Evaluator,
   Goccia.Evaluator.Decorators,
@@ -3341,6 +3344,7 @@ var
   BytecodeFunction: TGocciaBytecodeFunctionValue;
   BoundFunction: TGocciaBoundFunctionValue;
   JumpOffset: Integer;
+  PrevCovLine, CovLine: UInt32;
 begin
   SavedRegisters := FRegisters;
   SavedLocalCells := FLocalCells;
@@ -3363,6 +3367,13 @@ begin
     Template := AClosure.Template;
     Frame.Template := Template;
 
+    // Record coverage hit on the function declaration line
+    if FCoverageEnabled and Assigned(Template.DebugInfo) and
+       (Template.DebugInfo.LineMapCount > 0) then
+      TGocciaCoverageTracker.Instance.RecordLineHit(
+        Template.DebugInfo.SourceFile,
+        Template.DebugInfo.GetLineMapEntry(0).Line);
+
     SetLocalRaw(0, AThisValue);
     if AUseFixedArgs then
       case AArgCount of
@@ -3384,12 +3395,24 @@ begin
       for I := 0 to High(AArguments) do
         SetLocalRaw(I + 1, AArguments[I]);
 
+    PrevCovLine := 0;
     Running := True;
     while Running and (Frame.IP < Template.CodeCount) do
     begin
       try
         Instruction := Template.GetInstructionUnchecked(Frame.IP);
         Inc(Frame.IP);
+
+        if FCoverageEnabled and Assigned(Template.DebugInfo) then
+        begin
+          CovLine := Template.DebugInfo.GetLineForPC(Frame.IP - 1);
+          if (CovLine <> 0) and (CovLine <> PrevCovLine) then
+          begin
+            TGocciaCoverageTracker.Instance.RecordLineHit(
+              Template.DebugInfo.SourceFile, CovLine);
+            PrevCovLine := CovLine;
+          end;
+        end;
 
         Op := DecodeOp(Instruction);
         A := DecodeA(Instruction);
@@ -3517,28 +3540,72 @@ begin
       OP_JUMP_IF_TRUE:
         if GetRegister(A).ToBooleanLiteral.Value then
         begin
+          if FCoverageEnabled and Assigned(Template.DebugInfo) then
+            TGocciaCoverageTracker.Instance.RecordBranchHit(
+              Template.DebugInfo.SourceFile,
+              Template.DebugInfo.GetLineForPC(Frame.IP - 1),
+              Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 0);
           JumpOffset := DecodesBx(Instruction);
           Inc(Frame.IP, JumpOffset);
           if JumpOffset < 0 then
             CheckExecutionTimeout;
-        end;
+        end
+        else if FCoverageEnabled and Assigned(Template.DebugInfo) then
+          TGocciaCoverageTracker.Instance.RecordBranchHit(
+            Template.DebugInfo.SourceFile,
+            Template.DebugInfo.GetLineForPC(Frame.IP - 1),
+            Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 1);
 
       OP_JUMP_IF_FALSE:
         if not GetRegister(A).ToBooleanLiteral.Value then
         begin
+          if FCoverageEnabled and Assigned(Template.DebugInfo) then
+            TGocciaCoverageTracker.Instance.RecordBranchHit(
+              Template.DebugInfo.SourceFile,
+              Template.DebugInfo.GetLineForPC(Frame.IP - 1),
+              Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 0);
           JumpOffset := DecodesBx(Instruction);
           Inc(Frame.IP, JumpOffset);
           if JumpOffset < 0 then
             CheckExecutionTimeout;
-        end;
+        end
+        else if FCoverageEnabled and Assigned(Template.DebugInfo) then
+          TGocciaCoverageTracker.Instance.RecordBranchHit(
+            Template.DebugInfo.SourceFile,
+            Template.DebugInfo.GetLineForPC(Frame.IP - 1),
+            Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 1);
 
       OP_JUMP_IF_NULLISH:
         if RegisterMatchesNullishKind(FRegisters[A], B) then
+        begin
+          if FCoverageEnabled and Assigned(Template.DebugInfo) then
+            TGocciaCoverageTracker.Instance.RecordBranchHit(
+              Template.DebugInfo.SourceFile,
+              Template.DebugInfo.GetLineForPC(Frame.IP - 1),
+              Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 0);
           Inc(Frame.IP, C);
+        end
+        else if FCoverageEnabled and Assigned(Template.DebugInfo) then
+          TGocciaCoverageTracker.Instance.RecordBranchHit(
+            Template.DebugInfo.SourceFile,
+            Template.DebugInfo.GetLineForPC(Frame.IP - 1),
+            Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 1);
 
       OP_JUMP_IF_NOT_NULLISH:
         if not RegisterMatchesNullishKind(FRegisters[A], B) then
+        begin
+          if FCoverageEnabled and Assigned(Template.DebugInfo) then
+            TGocciaCoverageTracker.Instance.RecordBranchHit(
+              Template.DebugInfo.SourceFile,
+              Template.DebugInfo.GetLineForPC(Frame.IP - 1),
+              Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 0);
           Inc(Frame.IP, C);
+        end
+        else if FCoverageEnabled and Assigned(Template.DebugInfo) then
+          TGocciaCoverageTracker.Instance.RecordBranchHit(
+            Template.DebugInfo.SourceFile,
+            Template.DebugInfo.GetLineForPC(Frame.IP - 1),
+            Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 1);
 
       OP_PUSH_HANDLER:
         FHandlerStack.Push(Frame.IP + DecodeBx(Instruction), A, FFrameDepth);

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -3368,8 +3368,8 @@ begin
     Frame.Template := Template;
 
     // Record coverage hit on the function declaration line
-    if FCoverageEnabled and Assigned(Template.DebugInfo) and
-       (Template.DebugInfo.LineMapCount > 0) then
+    if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and
+       Assigned(Template.DebugInfo) and (Template.DebugInfo.LineMapCount > 0) then
       TGocciaCoverageTracker.Instance.RecordLineHit(
         Template.DebugInfo.SourceFile,
         Template.DebugInfo.GetLineMapEntry(0).Line);
@@ -3407,7 +3407,8 @@ begin
         Instruction := Template.GetInstructionUnchecked(Frame.IP);
         Inc(Frame.IP);
 
-        if FCoverageEnabled and Assigned(Template.DebugInfo) then
+        if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and
+           Assigned(Template.DebugInfo) then
         begin
           CovLine := Template.DebugInfo.GetLineForPC(Frame.IP - 1);
           if (CovLine <> 0) and (CovLine <> PrevCovLine) then
@@ -3544,7 +3545,7 @@ begin
       OP_JUMP_IF_TRUE:
         if GetRegister(A).ToBooleanLiteral.Value then
         begin
-          if FCoverageEnabled and Assigned(Template.DebugInfo) then
+          if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
             TGocciaCoverageTracker.Instance.RecordBranchHit(
               Template.DebugInfo.SourceFile,
               Template.DebugInfo.GetLineForPC(Frame.IP - 1),
@@ -3554,7 +3555,7 @@ begin
           if JumpOffset < 0 then
             CheckExecutionTimeout;
         end
-        else if FCoverageEnabled and Assigned(Template.DebugInfo) then
+        else if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
           TGocciaCoverageTracker.Instance.RecordBranchHit(
             Template.DebugInfo.SourceFile,
             Template.DebugInfo.GetLineForPC(Frame.IP - 1),
@@ -3563,7 +3564,7 @@ begin
       OP_JUMP_IF_FALSE:
         if not GetRegister(A).ToBooleanLiteral.Value then
         begin
-          if FCoverageEnabled and Assigned(Template.DebugInfo) then
+          if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
             TGocciaCoverageTracker.Instance.RecordBranchHit(
               Template.DebugInfo.SourceFile,
               Template.DebugInfo.GetLineForPC(Frame.IP - 1),
@@ -3573,7 +3574,7 @@ begin
           if JumpOffset < 0 then
             CheckExecutionTimeout;
         end
-        else if FCoverageEnabled and Assigned(Template.DebugInfo) then
+        else if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
           TGocciaCoverageTracker.Instance.RecordBranchHit(
             Template.DebugInfo.SourceFile,
             Template.DebugInfo.GetLineForPC(Frame.IP - 1),
@@ -3582,14 +3583,14 @@ begin
       OP_JUMP_IF_NULLISH:
         if RegisterMatchesNullishKind(FRegisters[A], B) then
         begin
-          if FCoverageEnabled and Assigned(Template.DebugInfo) then
+          if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
             TGocciaCoverageTracker.Instance.RecordBranchHit(
               Template.DebugInfo.SourceFile,
               Template.DebugInfo.GetLineForPC(Frame.IP - 1),
               Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 0);
           Inc(Frame.IP, C);
         end
-        else if FCoverageEnabled and Assigned(Template.DebugInfo) then
+        else if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
           TGocciaCoverageTracker.Instance.RecordBranchHit(
             Template.DebugInfo.SourceFile,
             Template.DebugInfo.GetLineForPC(Frame.IP - 1),
@@ -3598,14 +3599,14 @@ begin
       OP_JUMP_IF_NOT_NULLISH:
         if not RegisterMatchesNullishKind(FRegisters[A], B) then
         begin
-          if FCoverageEnabled and Assigned(Template.DebugInfo) then
+          if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
             TGocciaCoverageTracker.Instance.RecordBranchHit(
               Template.DebugInfo.SourceFile,
               Template.DebugInfo.GetLineForPC(Frame.IP - 1),
               Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 0);
           Inc(Frame.IP, C);
         end
-        else if FCoverageEnabled and Assigned(Template.DebugInfo) then
+        else if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
           TGocciaCoverageTracker.Instance.RecordBranchHit(
             Template.DebugInfo.SourceFile,
             Template.DebugInfo.GetLineForPC(Frame.IP - 1),

--- a/units/Goccia.Values.FunctionValue.pas
+++ b/units/Goccia.Values.FunctionValue.pas
@@ -24,6 +24,8 @@ type
     FParameters: TGocciaParameterArray;
     FBodyStatements: TObjectList<TGocciaASTNode>;
     FClosure: TGocciaScope;
+    FSourceFilePath: string;
+    FSourceLine: Integer;
     FIsExpressionBody: Boolean;
     FIsSimpleParams: Boolean;
     function GetFunctionLength: Integer; override;
@@ -43,6 +45,8 @@ type
     property Closure: TGocciaScope read FClosure;
     property Name: string read FName write FName;
     property IsExpressionBody: Boolean read FIsExpressionBody write FIsExpressionBody;
+    property SourceFilePath: string read FSourceFilePath write FSourceFilePath;
+    property SourceLine: Integer read FSourceLine write FSourceLine;
   end;
 
   TGocciaArrowFunctionValue = class(TGocciaFunctionValue)
@@ -73,6 +77,7 @@ uses
 
   Goccia.AST.Statements,
   Goccia.ControlFlow,
+  Goccia.Coverage,
   Goccia.Error,
   Goccia.Evaluator,
   Goccia.Evaluator.Context,
@@ -144,6 +149,13 @@ begin
   Context.Scope := FClosure;
   Context.OnError := FClosure.OnError;
   Context.LoadModule := nil;
+  Context.CurrentFilePath := FSourceFilePath;
+  Context.CoverageEnabled := Assigned(TGocciaCoverageTracker.Instance)
+    and TGocciaCoverageTracker.Instance.Enabled;
+
+  // Record coverage hit on the declaration line (get/set/constructor/method)
+  if Context.CoverageEnabled and (FSourceLine > 0) and (FSourceFilePath <> '') then
+    TGocciaCoverageTracker.Instance.RecordLineHit(FSourceFilePath, FSourceLine);
 
   // Bind this via virtual dispatch (arrow vs non-arrow)
   BindThis(ACallScope, AThisValue);


### PR DESCRIPTION
## Summary
- Added runtime coverage tracking for interpreted and bytecode execution, including line and branch hits.
- Added `--coverage`, `--coverage-format=lcov|json`, and `--coverage-output=<file>` support to `ScriptLoader` and `TestRunner`.
- Added coverage summary and detail reporting, plus lcov and JSON export helpers.
- Updated compiler line mapping so coverage data is available for function bodies and branch locations.
- Documented the new coverage workflow in `docs/testing.md` and the top-level command references.

## Testing
- Expected validation: `./build.pas testrunner && ./build/TestRunner tests`
- Expected validation: `./build/ScriptLoader example.js --coverage`
- Expected validation: `./build/TestRunner tests --coverage --coverage-format=lcov --coverage-output=coverage.lcov`
- Expected validation: `./build/TestRunner tests --coverage --coverage-format=json --coverage-output=coverage.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-level coverage reporting (line and branch) with console summaries, per-file detail, and report export (lcov/json) for both the test runner and script loader; new CLI flags to enable coverage, choose format, and set output file.

* **Documentation**
  * Added a Coverage section with usage examples, tracked metrics, and format guidance.

* **Tests**
  * CI steps added to validate coverage output (summary, lcov, and JSON) for both executables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->