### PR TITLE
Make String.prototype.matchAll return a lazy iterator

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -387,7 +387,7 @@ RegExp is available as both `RegExp()` and `new RegExp()`. Regex literals (`/pat
 
 - Replacement strings in regex-backed `replace()` and `replaceAll()` support `$$`, `$&`, the pre-match token `$` followed by a backtick, `$'`, and numeric captures such as `$1`.
 - `String.prototype.match`, `matchAll`, `replace`, `replaceAll`, `search`, and `split` dispatch through the corresponding well-known symbol hooks, so custom protocol objects work as expected.
-- `matchAll()` currently returns an eager iterator over precomputed matches rather than a fully lazy spec-style iterator.
+- `matchAll()` returns a lazy iterator that advances matches on demand per the ES2026 spec.
 - The `u` flag is accepted and exposed through `.flags` and `.unicode`, but full ECMAScript Unicode regexp semantics are not implemented yet.
 - Named capture groups, `d` / indices, and Unicode sets (`v`) are not implemented yet.
 

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -612,7 +612,6 @@ Current gaps from full ECMAScript RegExp semantics:
 
 - The `u` flag is accepted and exposed, but matching still does not implement full ECMAScript Unicode semantics.
 - Named capture groups, indices (`d`), and Unicode sets (`v`) are not supported.
-- `String.prototype.matchAll()` uses an eager array-backed iterator rather than a lazy spec-style iterator.
 
 ## Intentional Divergences from ECMAScript
 

--- a/tests/built-ins/RegExp/prototype/symbol-matchAll.js
+++ b/tests/built-ins/RegExp/prototype/symbol-matchAll.js
@@ -55,3 +55,33 @@ test("Symbol.replace respects sticky lastIndex and updates it", () => {
   expect("ba".replace(regex, "x")).toBe("bx");
   expect(regex.lastIndex).toBe(2);
 });
+
+test("Symbol.matchAll returns a lazy iterator", () => {
+  const regex = /a/g;
+  const iter = regex[Symbol.matchAll]("aaa");
+
+  const first = iter.next();
+  expect(first.done).toBe(false);
+  expect(first.value[0]).toBe("a");
+  expect(first.value.index).toBe(0);
+
+  const second = iter.next();
+  expect(second.done).toBe(false);
+  expect(second.value.index).toBe(1);
+
+  const third = iter.next();
+  expect(third.done).toBe(false);
+  expect(third.value.index).toBe(2);
+
+  const fourth = iter.next();
+  expect(fourth.done).toBe(true);
+});
+
+test("Symbol.matchAll with sticky flag", () => {
+  const regex = /a/gy;
+  const matches = [...regex[Symbol.matchAll]("aab")];
+
+  expect(matches.length).toBe(2);
+  expect(matches[0][0]).toBe("a");
+  expect(matches[1][0]).toBe("a");
+});

--- a/tests/built-ins/RegExp/prototype/symbol-matchAll.js
+++ b/tests/built-ins/RegExp/prototype/symbol-matchAll.js
@@ -77,11 +77,36 @@ test("Symbol.matchAll returns a lazy iterator", () => {
   expect(fourth.done).toBe(true);
 });
 
-test("Symbol.matchAll with sticky flag", () => {
+test("Symbol.matchAll with global and sticky flags iterates all matches", () => {
   const regex = /a/gy;
   const matches = [...regex[Symbol.matchAll]("aab")];
 
   expect(matches.length).toBe(2);
   expect(matches[0][0]).toBe("a");
   expect(matches[1][0]).toBe("a");
+});
+
+test("Symbol.matchAll with sticky-only yields a single match", () => {
+  const regex = /a/y;
+  const matches = [...regex[Symbol.matchAll]("aaa")];
+
+  // Sticky without global: iterator yields one match then stops
+  expect(matches.length).toBe(1);
+  expect(matches[0][0]).toBe("a");
+  expect(matches[0].index).toBe(0);
+});
+
+test("Symbol.matchAll preserves lastIndex from cloned regex", () => {
+  const regex = /a/g;
+  regex.lastIndex = 1;
+
+  const matches = [...regex[Symbol.matchAll]("aaa")];
+
+  // Iterator starts from cloned lastIndex (1), so first match is at index 1
+  expect(matches.length).toBe(2);
+  expect(matches[0].index).toBe(1);
+  expect(matches[1].index).toBe(2);
+
+  // Original regex lastIndex is not mutated
+  expect(regex.lastIndex).toBe(1);
 });

--- a/tests/built-ins/String/prototype/matchAll.js
+++ b/tests/built-ins/String/prototype/matchAll.js
@@ -55,3 +55,70 @@ test("matchAll dispatches through Symbol.matchAll", () => {
 
   expect("abc".matchAll(matcher)).toEqual(["custom matchAll"]);
 });
+
+test("matchAll is lazy - partial consumption does not compute all matches", () => {
+  const iter = "aaa".matchAll(/a/g);
+  const first = iter.next();
+  expect(first.done).toBe(false);
+  expect(first.value[0]).toBe("a");
+  expect(first.value.index).toBe(0);
+
+  const second = iter.next();
+  expect(second.done).toBe(false);
+  expect(second.value.index).toBe(1);
+});
+
+test("matchAll iterator returns done after all matches consumed", () => {
+  const iter = "ab".matchAll(/a/g);
+  const first = iter.next();
+  expect(first.done).toBe(false);
+  expect(first.value[0]).toBe("a");
+
+  const second = iter.next();
+  expect(second.done).toBe(true);
+  expect(second.value).toBe(undefined);
+});
+
+test("matchAll iterator works with spread", () => {
+  const matches = [...("hello".matchAll(/l/g))];
+  expect(matches.length).toBe(2);
+  expect(matches[0][0]).toBe("l");
+  expect(matches[0].index).toBe(2);
+  expect(matches[1].index).toBe(3);
+});
+
+test("matchAll iterator works with for-of", () => {
+  const indices = [];
+  for (const match of "abab".matchAll(/a/g)) {
+    indices.push(match.index);
+  }
+  expect(indices).toEqual([0, 2]);
+});
+
+test("matchAll with capture groups in lazy iteration", () => {
+  const iter = "a1b2".matchAll(/([a-z])(\d)/g);
+
+  const first = iter.next();
+  expect(first.value[0]).toBe("a1");
+  expect(first.value[1]).toBe("a");
+  expect(first.value[2]).toBe("1");
+
+  const second = iter.next();
+  expect(second.value[0]).toBe("b2");
+  expect(second.value[1]).toBe("b");
+  expect(second.value[2]).toBe("2");
+
+  const third = iter.next();
+  expect(third.done).toBe(true);
+});
+
+test("matchAll iterator does not mutate the original regex", () => {
+  const regex = /a/g;
+  regex.lastIndex = 2;
+
+  const iter = "aaa".matchAll(regex);
+  iter.next();
+  iter.next();
+
+  expect(regex.lastIndex).toBe(2);
+});

--- a/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/units/Goccia.Builtins.GlobalRegExp.pas
@@ -49,6 +49,7 @@ type
 implementation
 
 uses
+  StrUtils,
   SysUtils,
 
   GarbageCollector.Generic,
@@ -60,7 +61,7 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
-  Goccia.Values.Iterator.Concrete,
+  Goccia.Values.Iterator.RegExp,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -429,11 +430,8 @@ function TGocciaGlobalRegExp.RegExpSymbolMatchAll(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Input: string;
-  RegexValue: TGocciaObjectValue;
-  MatchesArray: TGocciaArrayValue;
-  MatchValue: TGocciaValue;
-  MatchArray: TGocciaObjectValue;
-  MatchIndex, MatchEnd, NextIndex: Integer;
+  RegexClone: TGocciaObjectValue;
+  IsGlobal: Boolean;
 begin
   if not IsRegExpValue(AThisValue) then
     ThrowTypeError('RegExp.prototype[Symbol.matchAll] called on non-RegExp object');
@@ -443,29 +441,10 @@ begin
   else
     Input := TGocciaUndefinedLiteralValue.UndefinedValue.ToStringLiteral.Value;
 
-  RegexValue := TGocciaObjectValue(CloneRegExpObject(AThisValue));
-  TGarbageCollector.Instance.AddTempRoot(RegexValue);
-  try
-    MatchesArray := TGocciaArrayValue.Create;
-    TGarbageCollector.Instance.AddTempRoot(MatchesArray);
-    try
-      if GetRegExpBooleanProperty(RegexValue, PROP_GLOBAL) or
-         GetRegExpBooleanProperty(RegexValue, PROP_STICKY) then
-      begin
-        while MatchRegExpObjectOnce(RegexValue, Input, MatchValue) do
-          MatchesArray.Elements.Add(MatchValue);
-      end
-      else if MatchRegExpObjectValue(RegexValue, Input, 0, False, False,
-        MatchArray, MatchIndex, MatchEnd, NextIndex) then
-        MatchesArray.Elements.Add(MatchArray);
-
-      Result := TGocciaArrayIteratorValue.Create(MatchesArray, akValues);
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(MatchesArray);
-    end;
-  finally
-    TGarbageCollector.Instance.RemoveTempRoot(RegexValue);
-  end;
+  RegexClone := TGocciaObjectValue(CloneRegExpObject(AThisValue));
+  IsGlobal := GetRegExpBooleanProperty(RegexClone, PROP_GLOBAL) or
+    GetRegExpBooleanProperty(RegexClone, PROP_STICKY);
+  Result := TGocciaRegExpMatchAllIteratorValue.Create(RegexClone, Input, IsGlobal);
 end;
 
 // ES2026 §22.2.6.11 RegExp.prototype [ @@replace ] ( string, replaceValue )

--- a/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/units/Goccia.Builtins.GlobalRegExp.pas
@@ -441,9 +441,11 @@ begin
   else
     Input := TGocciaUndefinedLiteralValue.UndefinedValue.ToStringLiteral.Value;
 
+  // ES2026 §22.2.6.9 step 4: Let matcher be a clone of R
   RegexClone := TGocciaObjectValue(CloneRegExpObject(AThisValue));
-  IsGlobal := GetRegExpBooleanProperty(RegexClone, PROP_GLOBAL) or
-    GetRegExpBooleanProperty(RegexClone, PROP_STICKY);
+  // ES2026 §22.2.6.9 step 5: global is true iff flags contains "g"
+  // Sticky (y) affects match positioning but does not enable repeated iteration
+  IsGlobal := GetRegExpBooleanProperty(RegexClone, PROP_GLOBAL);
   Result := TGocciaRegExpMatchAllIteratorValue.Create(RegexClone, Input, IsGlobal);
 end;
 

--- a/units/Goccia.Values.Iterator.RegExp.pas
+++ b/units/Goccia.Values.Iterator.RegExp.pas
@@ -29,6 +29,8 @@ type
 implementation
 
 uses
+  Math,
+
   Goccia.Constants.PropertyNames,
   Goccia.RegExp.Runtime;
 
@@ -44,7 +46,10 @@ begin
   inherited Create;
   FRegExp := ARegExp;
   FInput := AInput;
-  FSearchIndex := 0;
+  // ES2026 §22.2.6.9 step 6: matcher.lastIndex = ToLength(rx.lastIndex)
+  // CloneRegExpObject preserves lastIndex; honour it for global/sticky regexes
+  FSearchIndex := Max(0, Trunc(
+    ARegExp.GetProperty(PROP_LAST_INDEX).ToNumberLiteral.Value));
   FGlobal := AGlobal;
   FSingleMatchReturned := False;
 end;

--- a/units/Goccia.Values.Iterator.RegExp.pas
+++ b/units/Goccia.Values.Iterator.RegExp.pas
@@ -1,0 +1,142 @@
+unit Goccia.Values.Iterator.RegExp;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.IteratorValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaRegExpMatchAllIteratorValue = class(TGocciaIteratorValue)
+  private
+    FRegExp: TGocciaObjectValue;
+    FInput: string;
+    FSearchIndex: Integer;
+    FGlobal: Boolean;
+    FSingleMatchReturned: Boolean;
+  public
+    constructor Create(const ARegExp: TGocciaObjectValue; const AInput: string;
+      const AGlobal: Boolean);
+    function AdvanceNext: TGocciaObjectValue; override;
+    function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+  end;
+
+implementation
+
+uses
+  Goccia.Constants.PropertyNames,
+  Goccia.RegExp.Runtime;
+
+const
+  REGEXP_STRING_ITERATOR_TAG = 'RegExp String Iterator';
+
+{ TGocciaRegExpMatchAllIteratorValue }
+
+constructor TGocciaRegExpMatchAllIteratorValue.Create(
+  const ARegExp: TGocciaObjectValue; const AInput: string;
+  const AGlobal: Boolean);
+begin
+  inherited Create;
+  FRegExp := ARegExp;
+  FInput := AInput;
+  FSearchIndex := 0;
+  FGlobal := AGlobal;
+  FSingleMatchReturned := False;
+end;
+
+// ES2026 §22.2.9.1.1 %RegExpStringIteratorPrototype%.next()
+function TGocciaRegExpMatchAllIteratorValue.AdvanceNext: TGocciaObjectValue;
+var
+  MatchValue: TGocciaValue;
+  MatchIndex, MatchEnd, NextIndex: Integer;
+begin
+  if FDone then
+  begin
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+
+  if not FGlobal and FSingleMatchReturned then
+  begin
+    FDone := True;
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+
+  if not MatchRegExpObject(FRegExp, FInput, FSearchIndex, False, False,
+    MatchValue, MatchIndex, MatchEnd, NextIndex) then
+  begin
+    FDone := True;
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+
+  FSearchIndex := NextIndex;
+  if not FGlobal then
+    FSingleMatchReturned := True;
+
+  if FSearchIndex > Length(FInput) then
+    FDone := True;
+
+  Result := CreateIteratorResult(MatchValue, False);
+end;
+
+function TGocciaRegExpMatchAllIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+var
+  MatchValue: TGocciaValue;
+  MatchIndex, MatchEnd, NextIndex: Integer;
+begin
+  if FDone then
+  begin
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  if not FGlobal and FSingleMatchReturned then
+  begin
+    FDone := True;
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  if not MatchRegExpObject(FRegExp, FInput, FSearchIndex, False, False,
+    MatchValue, MatchIndex, MatchEnd, NextIndex) then
+  begin
+    FDone := True;
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  FSearchIndex := NextIndex;
+  if not FGlobal then
+    FSingleMatchReturned := True;
+
+  if FSearchIndex > Length(FInput) then
+    FDone := True;
+
+  ADone := False;
+  Result := MatchValue;
+end;
+
+function TGocciaRegExpMatchAllIteratorValue.ToStringTag: string;
+begin
+  Result := REGEXP_STRING_ITERATOR_TAG;
+end;
+
+procedure TGocciaRegExpMatchAllIteratorValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FRegExp) then
+    FRegExp.MarkReferences;
+end;
+
+end.

--- a/units/Goccia.Values.StringObjectValue.pas
+++ b/units/Goccia.Values.StringObjectValue.pas
@@ -88,6 +88,7 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.Iterator.Concrete,
+  Goccia.Values.Iterator.RegExp,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -1355,9 +1356,6 @@ var
   MatchAllMethod: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
   RegexValue: TGocciaObjectValue;
-  MatchesArray: TGocciaArrayValue;
-  MatchArray: TGocciaObjectValue;
-  MatchIndex, MatchEnd, NextIndex, SearchIndex: Integer;
 begin
   StringValue := ExtractStringValue(AThisValue);
   if (AArgs.Length > 0) and IsRegExpValue(AArgs.GetElement(0)) and
@@ -1391,31 +1389,7 @@ begin
     RegexValue := CoerceRegExpValue(TGocciaUndefinedLiteralValue.UndefinedValue,
       'g');
 
-  TGarbageCollector.Instance.AddTempRoot(RegexValue);
-  try
-    if not GetRegExpBooleanProperty(RegexValue, PROP_GLOBAL) then
-      ThrowTypeError('String.prototype.matchAll requires a global RegExp');
-
-    MatchesArray := TGocciaArrayValue.Create;
-    TGarbageCollector.Instance.AddTempRoot(MatchesArray);
-    try
-      SearchIndex := 0;
-      while MatchRegExpObjectValue(RegexValue, StringValue, SearchIndex,
-        False,
-        False, MatchArray, MatchIndex, MatchEnd, NextIndex) do
-      begin
-        MatchesArray.Elements.Add(MatchArray);
-        SearchIndex := NextIndex;
-        if SearchIndex > Length(StringValue) then
-          Break;
-      end;
-      Result := TGocciaArrayIteratorValue.Create(MatchesArray, akValues);
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(MatchesArray);
-    end;
-  finally
-    TGarbageCollector.Instance.RemoveTempRoot(RegexValue);
-  end;
+  Result := TGocciaRegExpMatchAllIteratorValue.Create(RegexValue, StringValue, True);
 end;
 
 // ES2026 §22.1.3.27 String.prototype.search(regexp)


### PR DESCRIPTION
## Summary
- Replace eager array-backed matchAll iterator with a lazy `TGocciaRegExpMatchAllIteratorValue` that computes one match per `.next()` call, aligning with ES2026 §22.2.6.9 spec behavior.
- Both `RegExp.prototype[Symbol.matchAll]` and the `String.prototype.matchAll` fallback path now return the lazy iterator.
- New unit `Goccia.Values.Iterator.RegExp.pas` follows the established lazy iterator pattern (same as `TGocciaLazyMapIteratorValue` etc.), with proper GC `MarkReferences`, `ToStringTag`, and support for both global and non-global modes.

Closes #175

## Testing
- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `String.prototype.matchAll()` returns a lazy iterator computing matches on demand per ES2026 specification.

* **Tests**
  * Added comprehensive test coverage for lazy iterator behavior, including partial iteration, completion checks, and compatibility with spread operators and `for..of` loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->