### PR TITLE
Remove obsolete `multihelpers` mode switch

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -186,7 +186,6 @@ Shared compiler directives included by all units:
   {$rangechecks on}               // Runtime array bounds checking
 {$ENDIF}
 {$modeswitch advancedrecords}     // Records with methods
-{$modeswitch multihelpers}        // Multiple class helpers for same type
 ```
 
 Under the current project settings, FreePascal behaves like this:

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -22,7 +22,6 @@ Which sets:
 {$overflowchecks on}     // Runtime overflow checking
 {$rangechecks on}        // Runtime range checking
 {$modeswitch advancedrecords}   // Records with methods
-{$modeswitch multihelpers}      // Multiple class helpers
 ```
 
 Overflow and range checks are **enabled** — correctness is prioritized over raw performance.

--- a/units/Goccia.inc
+++ b/units/Goccia.inc
@@ -15,7 +15,6 @@
   {$C+}
 {$ENDIF}
 {$modeswitch advancedrecords}
-{$modeswitch multihelpers}
 
 { Uncomment to enable bridge-crossing metrics on the GocciaScript runtime.
   When enabled, TGocciaRuntimeOperations tracks per-operation counts and


### PR DESCRIPTION
## Summary
- Removed the unused `{$modeswitch multihelpers}` directive from the shared Pascal include file.
- Updated build-system and code-style docs to match the current compiler settings.
- Kept the change scoped to documentation and compiler configuration only.

## Testing
- Not run (documentation and configuration-only change).
- Not run: build or test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a compiler directive from the build configuration

* **Documentation**
  * Updated documentation to reflect compiler directive changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->