### PR TITLE
Update unsupported CPU target case in CI workflow

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -280,6 +280,10 @@ jobs:
                 cross_fpc="$PREFIX/lib/fpc/${FPC_VERSION}/ppca64"
                 wrapper="$PREFIX/bin/ppca64-wrapper"
                 ;;
+              *)
+                echo "::error::Unsupported CPU target: ${cpu}"
+                exit 1
+                ;;
             esac
 
             # Extract cross-compilation flags from extra_opts for manual


### PR DESCRIPTION
## Summary

- Replace the manually maintained package allowlist in `toolchain.yml` (rtl-objpas, rtl-generics, fcl-process + source copies of fcl-base and regexpr) with FPC's `make packages`, which builds **all** standard packages for each cross target
- Simplify `ci.yml` to use a single `-Fu"${UNITS_DIR}/*"` wildcard instead of 6 separate `-Fu` paths per compilation command
- Bump cache version to `v31` to trigger a fresh toolchain build

## Motivation

Fixes #170 — the curated package approach meant every new standard FPC dependency (like `Base64` from `fcl-base`) risked a CI failure requiring per-package CI edits. The new approach installs compiled units into the standard `units/$TARGET/*` tree so any shipped FPC/FCL package is automatically available.

## What changed

| File | Change |
|------|--------|
| `toolchain.yml` | `build_target()` reduced from ~80 lines of manual per-unit compilation to `make packages` + install loop (~15 lines). Removed source copies of fcl-base/regexpr. |
| `ci.yml` | 6 package path variables → 1 `UNITS_DIR`. Per-package `-Fu` chains → single `-Fu"${UNITS_DIR}/*"` wildcard. |
| `docs/build-system.md` | Updated cross-compilation documentation to reflect the new approach. |

## Test plan

- [ ] Verify the toolchain cache rebuilds successfully with `make packages` for all 5 cross targets
- [ ] Verify all 6 platform builds succeed in CI with the wildcard `-Fu` path
- [ ] Verify JavaScript tests, Pascal unit tests, TOML/JSON5 compliance, benchmarks, and examples all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)