### PR TITLE
Fix YAML harness cleanup on parse failure

### DIFF
--- a/scripts/run_yaml_test_suite.py
+++ b/scripts/run_yaml_test_suite.py
@@ -42,21 +42,22 @@ begin
   Source := TStringList.Create;
   Parser := TGocciaYAMLParser.Create;
   try
-    Source.LoadFromFile(ParamStr(1));
-    Documents := Parser.ParseDocuments(Source.Text);
-    Documents.Free;
-    Halt(0);
-  except
-    on E: Exception do
-    begin
-      Writeln(E.Message);
-      Halt(1);
+    try
+      Source.LoadFromFile(ParamStr(1));
+      Documents := Parser.ParseDocuments(Source.Text);
+      Documents.Free;
+    except
+      on E: Exception do
+      begin
+        Writeln(E.Message);
+        Halt(1);
+      end;
     end;
+  finally
+    Parser.Free;
+    Source.Free;
+    TGarbageCollector.Shutdown;
   end;
-
-  Parser.Free;
-  Source.Free;
-  TGarbageCollector.Shutdown;
 end.
 """
 

--- a/scripts/run_yaml_test_suite.py
+++ b/scripts/run_yaml_test_suite.py
@@ -29,6 +29,7 @@ uses
   Goccia.YAML;
 
 var
+  ExitCode: Integer;
   Documents: TGocciaArrayValue;
   Parser: TGocciaYAMLParser;
   Source: TStringList;
@@ -36,6 +37,7 @@ begin
   if ParamCount <> 1 then
     Halt(2);
 
+  ExitCode := 0;
   TGarbageCollector.Initialize;
   PinPrimitiveSingletons;
 
@@ -50,7 +52,7 @@ begin
       on E: Exception do
       begin
         Writeln(E.Message);
-        Halt(1);
+        ExitCode := 1;
       end;
     end;
   finally
@@ -58,6 +60,8 @@ begin
     Source.Free;
     TGarbageCollector.Shutdown;
   end;
+
+  Halt(ExitCode);
 end.
 """
 


### PR DESCRIPTION
## Summary
- Move parser and source cleanup into a `finally` block so they always run.
- Ensure `TGarbageCollector.Shutdown` executes even when YAML loading or parsing raises an exception.
- Preserve the existing exit status and error message behavior for failures.

Fixes #167 