### PR TITLE
Add bytecode VM profiling support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader        # Execute stdin sourc
 ./build/ScriptLoader example.js --coverage --coverage-format=lcov --coverage-output=coverage.lcov  # Coverage with lcov output
 ./build/ScriptLoader example.js --coverage --coverage-format=json --coverage-output=coverage.json  # Coverage with JSON output
 ./build/ScriptLoader example.js --asi                              # Execute with automatic semicolon insertion
+./build/ScriptLoader example.js --profile=opcodes                  # Opcode histogram, pair frequency, scalar hit rate (bytecode)
+./build/ScriptLoader example.js --profile=functions                # Function self-time, allocations (bytecode)
+./build/ScriptLoader example.js --profile=all                      # All profiling data (bytecode)
+./build/ScriptLoader example.js --profile=all --profile-output=profile.json  # Profile with JSON export
 ./build/REPL                                      # Start interactive REPL (interpreted)
 ./build/REPL --mode=bytecode                      # Start the REPL via bytecode VM
 ./build/REPL --mode=bytecode --timing             # Bytecode REPL with per-line timing
@@ -116,6 +120,7 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | Runtime bootstrap | `Goccia.Runtime.Bootstrap.pas` | Shared built-in and global initialization |
 | Shared values | `Goccia.Values.*.pas` | Arrays, objects, classes, promises, iterators, primitives |
 | Garbage collector | `GarbageCollector.Generic.pas` | Shared GC for interpreter and bytecode execution |
+| Profiler | `Goccia.Profiler*.pas` | Bytecode opcode/function profiling, pair tracking, allocation counting |
 
 **Bytecode design rules:**
 
@@ -564,6 +569,7 @@ See [docs/build-system.md](docs/build-system.md) for build system details.
 | [docs/built-ins.md](docs/built-ins.md) | Available built-ins, registration system, adding new ones |
 | [docs/adding-built-in-types.md](docs/adding-built-in-types.md) | Step-by-step guide for adding new built-in types |
 | [docs/testing.md](docs/testing.md) | Test organization, writing tests, running tests |
+| [docs/profiling.md](docs/profiling.md) | Bytecode VM profiling: opcodes, pairs, scalar hit rate, function timing, allocations |
 | [docs/benchmarks.md](docs/benchmarks.md) | Benchmark runner, output formats, writing benchmarks, CI comparison |
 | [docs/build-system.md](docs/build-system.md) | Build commands, configuration, CI/CD |
 | [docs/language-restrictions.md](docs/language-restrictions.md) | Supported/excluded features with rationale |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader        # Execute stdin sourc
 ./build/ScriptLoader example.js --profile=functions                # Function self-time, allocations (bytecode)
 ./build/ScriptLoader example.js --profile=all                      # All profiling data (bytecode)
 ./build/ScriptLoader example.js --profile=all --profile-output=profile.json  # Profile with JSON export
+./build/ScriptLoader example.js --profile=functions --profile-format=flamegraph --profile-output=flamegraph.txt  # Flame graph export
 ./build/REPL                                      # Start interactive REPL (interpreted)
 ./build/REPL --mode=bytecode                      # Start the REPL via bytecode VM
 ./build/REPL --mode=bytecode --timing             # Bytecode REPL with per-line timing

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -26,6 +26,8 @@ uses
   Goccia.Lexer,
   Goccia.Modules.Configuration,
   Goccia.Parser,
+  Goccia.Profiler,
+  Goccia.Profiler.Report,
   Goccia.ScriptLoader.Globals,
   Goccia.ScriptLoader.Input,
   Goccia.ScriptLoader.JSON,
@@ -61,6 +63,9 @@ var
   GCoverageJsonEnabled: Boolean = False;
   GCoverageOutputPath: string = '';
   GASIEnabled: Boolean = False;
+  GProfileOpcodes: Boolean = False;
+  GProfileFunctions: Boolean = False;
+  GProfileOutputPath: string = '';
 
 function ParseSource(const ASource: TStringList; const AFileName: string;
   const AGlobals: TGocciaGlobalBuiltins; const ASuppressWarnings: Boolean;
@@ -603,6 +608,8 @@ begin
   WriteLn('  --coverage              Enable line and branch coverage reporting');
   WriteLn('  --coverage-format=lcov|json  Coverage output format (implies --coverage)');
   WriteLn('  --coverage-output=<file>     Coverage output file (paired with --coverage-format)');
+  WriteLn('  --profile=opcodes|functions|all  Enable bytecode profiling (implies --mode=bytecode)');
+  WriteLn('  --profile-output=<file>          Write profile results as JSON');
 end;
 
 var
@@ -739,6 +746,33 @@ begin
         GCoverageOutputPath := Copy(Arg, 19, MaxInt);
         GCoverageEnabled := True;
       end
+      else if Arg = '--profile=opcodes' then
+      begin
+        GProfileOpcodes := True;
+        GMode := emBytecode;
+      end
+      else if Arg = '--profile=functions' then
+      begin
+        GProfileFunctions := True;
+        GMode := emBytecode;
+      end
+      else if Arg = '--profile=all' then
+      begin
+        GProfileOpcodes := True;
+        GProfileFunctions := True;
+        GMode := emBytecode;
+      end
+      else if Copy(Arg, 1, 10) = '--profile=' then
+      begin
+        WriteLn('Error: Unknown profile mode "', Copy(Arg, 11, MaxInt),
+          '". Use "opcodes", "functions", or "all".');
+        ExitCode := 1;
+        Exit;
+      end
+      else if Copy(Arg, 1, 17) = '--profile-output=' then
+      begin
+        GProfileOutputPath := Copy(Arg, 18, MaxInt);
+      end
       else if Copy(Arg, 1, 2) <> '--' then
         Paths.Add(Arg)
       else
@@ -777,6 +811,18 @@ begin
       TGocciaCoverageTracker.Initialize;
       TGocciaCoverageTracker.Instance.Enabled := True;
     end;
+    if GProfileOpcodes or GProfileFunctions then
+    begin
+      TGocciaProfiler.Initialize;
+      TGocciaProfiler.Instance.Enabled := True;
+      TGocciaProfiler.Instance.Mode := [];
+      if GProfileOpcodes then
+        TGocciaProfiler.Instance.Mode :=
+          TGocciaProfiler.Instance.Mode + [pmOpcodes];
+      if GProfileFunctions then
+        TGocciaProfiler.Instance.Mode :=
+          TGocciaProfiler.Instance.Mode + [pmFunctions];
+    end;
     try
       try
         if Paths.Count = 0 then
@@ -813,9 +859,29 @@ begin
         if GCoverageJsonEnabled and (GCoverageOutputPath <> '') then
           WriteCoverageJSON(TGocciaCoverageTracker.Instance, GCoverageOutputPath);
       end;
+
+      if (GProfileOpcodes or GProfileFunctions) and
+         Assigned(TGocciaProfiler.Instance) then
+      begin
+        if not GJsonOutput then
+        begin
+          if GProfileOpcodes then
+          begin
+            PrintOpcodeProfile(TGocciaProfiler.Instance);
+            PrintOpcodePairProfile(TGocciaProfiler.Instance);
+            PrintScalarHitRate(TGocciaProfiler.Instance);
+          end;
+          if GProfileFunctions then
+            PrintFunctionProfile(TGocciaProfiler.Instance);
+        end;
+        if GProfileOutputPath <> '' then
+          WriteProfileJSON(TGocciaProfiler.Instance, GProfileOutputPath);
+      end;
     finally
       if GCoverageEnabled then
         TGocciaCoverageTracker.Shutdown;
+      if GProfileOpcodes or GProfileFunctions then
+        TGocciaProfiler.Shutdown;
     end;
   finally
     Paths.Free;

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -66,6 +66,7 @@ var
   GProfileOpcodes: Boolean = False;
   GProfileFunctions: Boolean = False;
   GProfileOutputPath: string = '';
+  GProfileFormatFlamegraph: Boolean = False;
 
 function ParseSource(const ASource: TStringList; const AFileName: string;
   const AGlobals: TGocciaGlobalBuiltins; const ASuppressWarnings: Boolean;
@@ -610,6 +611,7 @@ begin
   WriteLn('  --coverage-output=<file>     Coverage output file (paired with --coverage-format)');
   WriteLn('  --profile=opcodes|functions|all  Enable bytecode profiling (implies --mode=bytecode)');
   WriteLn('  --profile-output=<file>          Write profile results as JSON');
+  WriteLn('  --profile-format=flamegraph      Write collapsed stack format for flame graph visualization');
 end;
 
 var
@@ -747,20 +749,13 @@ begin
         GCoverageEnabled := True;
       end
       else if Arg = '--profile=opcodes' then
-      begin
-        GProfileOpcodes := True;
-        GMode := emBytecode;
-      end
+        GProfileOpcodes := True
       else if Arg = '--profile=functions' then
-      begin
-        GProfileFunctions := True;
-        GMode := emBytecode;
-      end
+        GProfileFunctions := True
       else if Arg = '--profile=all' then
       begin
         GProfileOpcodes := True;
         GProfileFunctions := True;
-        GMode := emBytecode;
       end
       else if Copy(Arg, 1, 10) = '--profile=' then
       begin
@@ -772,6 +767,21 @@ begin
       else if Copy(Arg, 1, 17) = '--profile-output=' then
       begin
         GProfileOutputPath := Copy(Arg, 18, MaxInt);
+        if GProfileOutputPath = '' then
+        begin
+          WriteLn('Error: --profile-output requires a non-empty path.');
+          ExitCode := 1;
+          Exit;
+        end;
+      end
+      else if Arg = '--profile-format=flamegraph' then
+        GProfileFormatFlamegraph := True
+      else if Copy(Arg, 1, 18) = '--profile-format=' then
+      begin
+        WriteLn('Error: Unknown profile format "', Copy(Arg, 19, MaxInt),
+          '". Use "flamegraph".');
+        ExitCode := 1;
+        Exit;
       end
       else if Copy(Arg, 1, 2) <> '--' then
         Paths.Add(Arg)
@@ -802,6 +812,28 @@ begin
     if GTimeoutMilliseconds < 0 then
     begin
       WriteLn('Error: --timeout must be 0 or greater.');
+      ExitCode := 1;
+      Exit;
+    end;
+
+    // --profile-format implies --profile=functions when no explicit --profile given
+    if GProfileFormatFlamegraph and not (GProfileOpcodes or GProfileFunctions) then
+      GProfileFunctions := True;
+
+    // Profiling requires bytecode mode regardless of --mode flag
+    if GProfileOpcodes or GProfileFunctions then
+      GMode := emBytecode;
+
+    if (GProfileOutputPath <> '') and not (GProfileOpcodes or GProfileFunctions) then
+    begin
+      WriteLn('Error: --profile-output requires --profile=opcodes|functions|all.');
+      ExitCode := 1;
+      Exit;
+    end;
+
+    if GProfileFormatFlamegraph and (GProfileOutputPath = '') then
+    begin
+      WriteLn('Error: --profile-format=flamegraph requires --profile-output=<path>.');
       ExitCode := 1;
       Exit;
     end;
@@ -875,7 +907,12 @@ begin
             PrintFunctionProfile(TGocciaProfiler.Instance);
         end;
         if GProfileOutputPath <> '' then
-          WriteProfileJSON(TGocciaProfiler.Instance, GProfileOutputPath);
+        begin
+          if GProfileFormatFlamegraph then
+            WriteCollapsedStacks(TGocciaProfiler.Instance, GProfileOutputPath)
+          else
+            WriteProfileJSON(TGocciaProfiler.Instance, GProfileOutputPath);
+        end;
       end;
     finally
       if GCoverageEnabled then

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -31,6 +31,8 @@ Public bytecode artifacts use the `.gbc` extension.
 | VM execution | `Goccia.VM.pas` |
 | Frames / closures / upvalues | `Goccia.VM.CallFrame.pas`, `Goccia.VM.Closure.pas`, `Goccia.VM.Upvalue.pas` |
 | Backend entry point | `Goccia.Engine.Backend.pas` |
+| Opcode name lookup | `Goccia.Bytecode.OpCodeNames.pas` |
+| Profiler | `Goccia.Profiler.pas`, `Goccia.Profiler.Report.pas` |
 
 ## Core Design
 
@@ -102,6 +104,17 @@ Recent VM cleanup and optimization work has focused on reducing per-instruction 
 - keep fast register access limited to proven hot/simple paths; local-slot and complex property paths should only move to fast access when they stay correct and measurably improve throughput
 
 The current optimization target is reducing bytecode-mode suite time further without diverging interpreter and bytecode semantics.
+
+## Profiling
+
+The `--profile` flag on ScriptLoader enables language-level profiling of the bytecode VM. See [profiling.md](profiling.md) for the full guide.
+
+- `--profile=opcodes` — opcode frequency histogram, opcode pair frequency (superinstruction candidates), and scalar fast-path hit rate for generic arithmetic/comparison opcodes
+- `--profile=functions` — per-function self-time, total-time, call count, and heap allocation count
+- `--profile=all` — both
+- `--profile-output=path.json` — JSON export
+
+The profiler follows the same singleton-tracker pattern as coverage (`Goccia.Coverage.pas`). Zero overhead when disabled. Opcode counting adds ~1% overhead; function timing adds ~3%.
 
 ## Binary Format
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -110,6 +110,30 @@ Function Profile:
 }
 ```
 
+## Flame Graph Export
+
+`--profile-format=flamegraph --profile-output=flamegraph.txt` writes collapsed stack traces, viewable in [speedscope](https://speedscope.app) (drag and drop) or renderable to SVG via [FlameGraph](https://github.com/brendangregg/FlameGraph):
+
+```bash
+./build/ScriptLoader script.js --profile=functions --profile-format=flamegraph --profile-output=flamegraph.txt
+
+# View in browser
+open https://speedscope.app  # drag flamegraph.txt into the page
+
+# Or render to SVG
+flamegraph.pl flamegraph.txt > flamegraph.svg
+```
+
+Each line is a semicolon-separated call stack with a self-time weight in microseconds:
+
+```
+<module>;fib;fib;fib 4170
+<module>;fib;fib 1
+<module>;fib 1
+```
+
+This shows the JS function call hierarchy that external profilers like `sample` cannot see — `sample` would show all these as the same recursive `ExecuteClosureRegistersInternal` frame.
+
 ## Combining with `sample` (macOS)
 
 The profiler and `sample` are complementary. The profiler sees inside the dispatch loop (opcodes, JS functions, allocations). `sample` sees outside it (FPC runtime overhead, memory management, exception frames).
@@ -150,7 +174,7 @@ The profiler's allocation count per function tells you *which JS function* drive
 | Unit | Role |
 |------|------|
 | `Goccia.Profiler.pas` | Singleton tracker: opcode counts, pair matrix, scalar hit/miss, function profiles with timing stack |
-| `Goccia.Profiler.Report.pas` | Console output and JSON export |
+| `Goccia.Profiler.Report.pas` | Console output, JSON export, and collapsed stack export |
 | `Goccia.Bytecode.OpCodeNames.pas` | Opcode ordinal to human-readable name (cold path, report generation only) |
 
 The profiler follows the same singleton pattern as `Goccia.Coverage.pas`: `Initialize`/`Instance`/`Shutdown`, boolean `Enabled` flag, zero overhead when disabled. Opcode counting and pair tracking use static arrays (no heap allocation in the hot path). Function profiling uses a timing stack for correct self-time calculation across recursive calls. Allocation tracking hooks into `TGocciaValue.AfterConstruction` via a global `GProfilingAllocations` boolean, attributing each allocation to the function on top of the profiler's timing stack.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -43,7 +43,7 @@ Opcode Profile:
   Total                                             284582
 ```
 
-**How to read it:** The percentages show where the VM spends its instruction budget. High `OP_CALL`/`OP_RETURN` percentages indicate call-overhead-bound code. High `OP_TO_PRIMITIVE` suggests the compiler is emitting generic opcodes where typed opcodes would suffice. High `OP_GET_PROP_CONST` points to property-access-heavy code that might benefit from inline caching.
+**How to read it:** The percentages show where the VM spends its instruction budget. A large share of `OP_CALL`/`OP_RETURN` indicates call-overhead-bound code. Elevated `OP_TO_PRIMITIVE` counts suggest the compiler is emitting generic opcodes where typed opcodes would suffice. Frequent `OP_GET_PROP_CONST` points to property-access-heavy code that might benefit from inline caching.
 
 ### Opcode Pair Frequency (`--profile=opcodes`)
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -6,7 +6,7 @@
 
 The `--profile` flag on ScriptLoader enables language-level profiling of the bytecode VM. It operates inside the dispatch loop, providing data that external profilers (like `sample` or `callgrind`) cannot see — which opcodes execute, which JS functions are hot, and where the VM allocates.
 
-Profiling implies `--mode=bytecode` automatically. Zero overhead when not enabled (boolean guard on the dispatch loop, same pattern as `--coverage`).
+Profiling implies `--mode=bytecode` automatically. Near-zero overhead when disabled (boolean guard on the dispatch loop, same pattern as `--coverage`). The guard branches are consistently not-taken and well-predicted, but they are present in the compiled binary.
 
 ## CLI Usage
 
@@ -33,7 +33,7 @@ echo 'const x = 1 + 2; x;' | ./build/ScriptLoader --profile=all
 
 Counts how many times each bytecode opcode executes. Sorted by frequency descending.
 
-```
+```text
 Opcode Profile:
   Opcode                                             Count        %
   OP_GET_LOCAL                                       54728    19.2%
@@ -49,7 +49,7 @@ Opcode Profile:
 
 Counts how often each two-instruction sequence executes. Shows the top 20 pairs.
 
-```
+```text
 Opcode Pairs (top 20):
   Previous                                      Current                                            Count        %
   OP_GET_LOCAL                              -> OP_LOAD_INT                                     87918017    15.4%
@@ -64,7 +64,7 @@ Opcode Pairs (top 20):
 
 For the generic arithmetic and comparison opcodes (`OP_ADD`, `OP_SUB`, `OP_MUL`, `OP_DIV`, `OP_MOD`, `OP_POW`, `OP_LT`, `OP_GT`, `OP_LTE`, `OP_GTE`), tracks how often the `RegisterIsNumericScalar` fast path hits versus falls through to the slow (boxing/polymorphic) path.
 
-```
+```text
 Scalar Fast-Path:
   Hits:      109897525 (100.0%)
   Misses:            0 (  0.0%)
@@ -77,7 +77,7 @@ Scalar Fast-Path:
 
 Per-function breakdown: self-time (exclusive — time in the function minus time in callees), total-time (inclusive), call count, and allocation count (heap-allocated `TGocciaValue` instances created during that function's execution).
 
-```
+```text
 Function Profile:
   Self Time    Total Time      Calls     Allocs  Function                       Location
   19.78s       443.42s      43959011   13584073  fib                            script.js:1
@@ -126,7 +126,7 @@ flamegraph.pl flamegraph.txt > flamegraph.svg
 
 Each line is a semicolon-separated call stack with a self-time weight in microseconds:
 
-```
+```text
 <module>;fib;fib;fib 4170
 <module>;fib;fib 1
 <module>;fib 1

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,156 @@
+# Bytecode Profiling
+
+*For contributors analyzing bytecode VM performance.*
+
+## Overview
+
+The `--profile` flag on ScriptLoader enables language-level profiling of the bytecode VM. It operates inside the dispatch loop, providing data that external profilers (like `sample` or `callgrind`) cannot see — which opcodes execute, which JS functions are hot, and where the VM allocates.
+
+Profiling implies `--mode=bytecode` automatically. Zero overhead when not enabled (boolean guard on the dispatch loop, same pattern as `--coverage`).
+
+## CLI Usage
+
+```bash
+# Opcode profiling: histogram, pair frequency, scalar hit rate
+./build/ScriptLoader script.js --profile=opcodes
+
+# Function profiling: self-time, total-time, call count, allocations
+./build/ScriptLoader script.js --profile=functions
+
+# Both
+./build/ScriptLoader script.js --profile=all
+
+# JSON export (includes all sections regardless of console mode)
+./build/ScriptLoader script.js --profile=all --profile-output=profile.json
+
+# Stdin works too
+echo 'const x = 1 + 2; x;' | ./build/ScriptLoader --profile=all
+```
+
+## Report Sections
+
+### Opcode Histogram (`--profile=opcodes`)
+
+Counts how many times each bytecode opcode executes. Sorted by frequency descending.
+
+```
+Opcode Profile:
+  Opcode                                             Count        %
+  OP_GET_LOCAL                                       54728    19.2%
+  OP_LOAD_INT                                        43782    15.4%
+  OP_RETURN                                          21892     7.7%
+  ...
+  Total                                             284582
+```
+
+**How to read it:** The percentages show where the VM spends its instruction budget. High `OP_CALL`/`OP_RETURN` percentages indicate call-overhead-bound code. High `OP_TO_PRIMITIVE` suggests the compiler is emitting generic opcodes where typed opcodes would suffice. High `OP_GET_PROP_CONST` points to property-access-heavy code that might benefit from inline caching.
+
+### Opcode Pair Frequency (`--profile=opcodes`)
+
+Counts how often each two-instruction sequence executes. Shows the top 20 pairs.
+
+```
+Opcode Pairs (top 20):
+  Previous                                      Current                                            Count        %
+  OP_GET_LOCAL                              -> OP_LOAD_INT                                     87918017    15.4%
+  OP_LOAD_INT                               -> OP_LTE                                          43959011     7.7%
+  OP_LTE                                    -> OP_JUMP_IF_FALSE                                43959011     7.7%
+  ...
+```
+
+**How to read it:** Hot pairs are superinstruction candidates — two opcodes that could be fused into one to eliminate a dispatch. A pair at 7%+ of total is worth fusing. Cross-frame pairs (e.g., `RETURN → MOVE`) cannot be fused because they span call boundaries.
+
+### Scalar Fast-Path Hit Rate (`--profile=opcodes`)
+
+For the generic arithmetic and comparison opcodes (`OP_ADD`, `OP_SUB`, `OP_MUL`, `OP_DIV`, `OP_MOD`, `OP_POW`, `OP_LT`, `OP_GT`, `OP_LTE`, `OP_GTE`), tracks how often the `RegisterIsNumericScalar` fast path hits versus falls through to the slow (boxing/polymorphic) path.
+
+```
+Scalar Fast-Path:
+  Hits:      109897525 (100.0%)
+  Misses:            0 (  0.0%)
+  Total:     109897525
+```
+
+**How to read it:** A high hit rate (>95%) means the compiler should be emitting typed opcodes (`OP_ADD_INT`, `OP_LTE_INT`, etc.) instead of generic ones, since the runtime polymorphism is never exercised. A lower hit rate indicates genuinely mixed-type arithmetic where generic opcodes are necessary.
+
+### Function Profile (`--profile=functions`)
+
+Per-function breakdown: self-time (exclusive — time in the function minus time in callees), total-time (inclusive), call count, and allocation count (heap-allocated `TGocciaValue` instances created during that function's execution).
+
+```
+Function Profile:
+  Self Time    Total Time      Calls     Allocs  Function                       Location
+  19.78s       443.42s      43959011   13584073  fib                            script.js:1
+  91.00µs     19.78s              1         22  <module>                       script.js:1
+  7.00µs      19.78s              5          8  <arrow>                        script.js:2
+```
+
+**How to read it:** Sort by self-time to find the functions where the VM spends the most time. The `Allocs` column shows GC pressure per function — high allocation counts relative to call counts indicate boxing overhead (register values being unnecessarily converted to heap objects). Functions named `<module>` are top-level script code; `<arrow>` and `<anonymous>` are unnamed callbacks.
+
+## JSON Export
+
+`--profile-output=path.json` writes all profiling data as JSON:
+
+```json
+{
+  "opcodes": [
+    {"opcode": "OP_GET_LOCAL", "count": 54728, "percentage": 19.2},
+    ...
+  ],
+  "opcodePairs": [
+    {"prev": "OP_GET_LOCAL", "cur": "OP_LOAD_INT", "count": 87918017},
+    ...
+  ],
+  "scalarFastPath": {"hits": 109897525, "misses": 0, "total": 109897525, "hitRate": 100.0},
+  "functions": [
+    {"name": "fib", "sourceFile": "script.js", "line": 1, "calls": 43959011,
+     "selfTimeNs": 19780000000, "totalTimeNs": 443420000000, "allocations": 13584073},
+    ...
+  ]
+}
+```
+
+## Combining with `sample` (macOS)
+
+The profiler and `sample` are complementary. The profiler sees inside the dispatch loop (opcodes, JS functions, allocations). `sample` sees outside it (FPC runtime overhead, memory management, exception frames).
+
+Run both on the same production binary for the full picture:
+
+```bash
+# Build production
+./build.pas --prod loader
+
+# Profiler run
+./build/ScriptLoader script.js --profile=all
+
+# sample run (no --profile, to avoid measuring profiling overhead)
+./build/ScriptLoader script.js --mode=bytecode &
+PID=$!
+sleep 0.2
+sample "$PID" 10 1 -file sample-output.txt -mayDie
+wait $PID
+```
+
+Look at `sample`'s "Sort by top of stack" section. Typical categories:
+
+| `sample` function | Category |
+|-------------------|----------|
+| `ExecuteClosureRegistersInternal` | Dispatch loop itself |
+| `FPC_DYNARRAY_*` | Register frame allocation/deallocation |
+| `FPC_PUSHEXCEPTADDR`, `FPC_POPADDRSTACK` | try/except per call frame |
+| `TObject.InheritsFrom`, `FPC_DO_IS` | RTTI type checks |
+| `Math.IsNaN`, `Math.IsInfinite` | Number creation guards |
+| `RegisterToValue` | Register→value boxing |
+| `SysGetMem`, `SysFreeMem` | Heap allocator |
+
+The profiler's allocation count per function tells you *which JS function* drives the allocations that `sample` attributes to `SysGetMem`/`RegisterToValue`. The opcode histogram tells you *which operations* are inside the 30% of time `sample` attributes to `ExecuteClosureRegistersInternal`.
+
+## Architecture
+
+| Unit | Role |
+|------|------|
+| `Goccia.Profiler.pas` | Singleton tracker: opcode counts, pair matrix, scalar hit/miss, function profiles with timing stack |
+| `Goccia.Profiler.Report.pas` | Console output and JSON export |
+| `Goccia.Bytecode.OpCodeNames.pas` | Opcode ordinal to human-readable name (cold path, report generation only) |
+
+The profiler follows the same singleton pattern as `Goccia.Coverage.pas`: `Initialize`/`Instance`/`Shutdown`, boolean `Enabled` flag, zero overhead when disabled. Opcode counting and pair tracking use static arrays (no heap allocation in the hot path). Function profiling uses a timing stack for correct self-time calculation across recursive calls. Allocation tracking hooks into `TGocciaValue.AfterConstruction` via a global `GProfilingAllocations` boolean, attributing each allocation to the function on top of the profiler's timing stack.

--- a/units/Goccia.Bytecode.Chunk.pas
+++ b/units/Goccia.Bytecode.Chunk.pas
@@ -73,6 +73,7 @@ type
     FIsAsync: Boolean;
     FIsArrow: Boolean;
     FTypeCheckPreambleSize: UInt8;
+    FProfileIndex: Integer;
     FStringConstantIndex: TOrderedStringMap<UInt16>;
     function GetFunctionCount: Integer;
   public
@@ -122,6 +123,7 @@ type
     property IsAsync: Boolean read FIsAsync write FIsAsync;
     property IsArrow: Boolean read FIsArrow write FIsArrow;
     property TypeCheckPreambleSize: UInt8 read FTypeCheckPreambleSize write FTypeCheckPreambleSize;
+    property ProfileIndex: Integer read FProfileIndex write FProfileIndex;
   end;
 
 implementation
@@ -155,6 +157,7 @@ begin
   FLocalTypeCount := 0;
   FLocalStrictCount := 0;
   FIsArrow := False;
+  FProfileIndex := -1;
 end;
 
 destructor TGocciaFunctionTemplate.Destroy;

--- a/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/units/Goccia.Bytecode.OpCodeNames.pas
@@ -1,0 +1,149 @@
+unit Goccia.Bytecode.OpCodeNames;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Bytecode;
+
+function OpCodeName(const AOp: UInt8): string;
+
+implementation
+
+uses
+  SysUtils;
+
+function OpCodeName(const AOp: UInt8): string;
+begin
+  case TGocciaOpCode(AOp) of
+    OP_LOAD_CONST:                     Result := 'OP_LOAD_CONST';
+    OP_LOAD_TRUE:                      Result := 'OP_LOAD_TRUE';
+    OP_LOAD_FALSE:                     Result := 'OP_LOAD_FALSE';
+    OP_LOAD_INT:                       Result := 'OP_LOAD_INT';
+    OP_MOVE:                           Result := 'OP_MOVE';
+    OP_GET_LOCAL:                      Result := 'OP_GET_LOCAL';
+    OP_SET_LOCAL:                      Result := 'OP_SET_LOCAL';
+    OP_GET_UPVALUE:                    Result := 'OP_GET_UPVALUE';
+    OP_SET_UPVALUE:                    Result := 'OP_SET_UPVALUE';
+    OP_CLOSE_UPVALUE:                  Result := 'OP_CLOSE_UPVALUE';
+    OP_JUMP:                           Result := 'OP_JUMP';
+    OP_JUMP_IF_TRUE:                   Result := 'OP_JUMP_IF_TRUE';
+    OP_JUMP_IF_FALSE:                  Result := 'OP_JUMP_IF_FALSE';
+    OP_JUMP_IF_NULLISH:                Result := 'OP_JUMP_IF_NULLISH';
+    OP_JUMP_IF_NOT_NULLISH:            Result := 'OP_JUMP_IF_NOT_NULLISH';
+    OP_CLOSURE:                        Result := 'OP_CLOSURE';
+    OP_PUSH_HANDLER:                   Result := 'OP_PUSH_HANDLER';
+    OP_POP_HANDLER:                    Result := 'OP_POP_HANDLER';
+    OP_THROW:                          Result := 'OP_THROW';
+    OP_RETURN:                         Result := 'OP_RETURN';
+    OP_LOAD_UNDEFINED:                 Result := 'OP_LOAD_UNDEFINED';
+    OP_ARRAY_POP:                      Result := 'OP_ARRAY_POP';
+    OP_NEW_ARRAY:                      Result := 'OP_NEW_ARRAY';
+    OP_ARRAY_PUSH:                     Result := 'OP_ARRAY_PUSH';
+    OP_ARRAY_GET:                      Result := 'OP_ARRAY_GET';
+    OP_ARRAY_SET:                      Result := 'OP_ARRAY_SET';
+    OP_NEW_OBJECT:                     Result := 'OP_NEW_OBJECT';
+    OP_GET_PROP_CONST:                 Result := 'OP_GET_PROP_CONST';
+    OP_SET_PROP_CONST:                 Result := 'OP_SET_PROP_CONST';
+    OP_DELETE_PROP_CONST:              Result := 'OP_DELETE_PROP_CONST';
+    OP_GET_LENGTH:                     Result := 'OP_GET_LENGTH';
+    OP_ARG_COUNT:                      Result := 'OP_ARG_COUNT';
+    OP_PACK_ARGS:                      Result := 'OP_PACK_ARGS';
+    OP_NOP:                            Result := 'OP_NOP';
+    OP_LINE:                           Result := 'OP_LINE';
+    OP_ADD_INT:                        Result := 'OP_ADD_INT';
+    OP_SUB_INT:                        Result := 'OP_SUB_INT';
+    OP_MUL_INT:                        Result := 'OP_MUL_INT';
+    OP_DIV_INT:                        Result := 'OP_DIV_INT';
+    OP_MOD_INT:                        Result := 'OP_MOD_INT';
+    OP_NEG_INT:                        Result := 'OP_NEG_INT';
+    OP_ADD_FLOAT:                      Result := 'OP_ADD_FLOAT';
+    OP_SUB_FLOAT:                      Result := 'OP_SUB_FLOAT';
+    OP_MUL_FLOAT:                      Result := 'OP_MUL_FLOAT';
+    OP_DIV_FLOAT:                      Result := 'OP_DIV_FLOAT';
+    OP_MOD_FLOAT:                      Result := 'OP_MOD_FLOAT';
+    OP_NEG_FLOAT:                      Result := 'OP_NEG_FLOAT';
+    OP_EQ_INT:                         Result := 'OP_EQ_INT';
+    OP_NEQ_INT:                        Result := 'OP_NEQ_INT';
+    OP_LT_INT:                         Result := 'OP_LT_INT';
+    OP_GT_INT:                         Result := 'OP_GT_INT';
+    OP_LTE_INT:                        Result := 'OP_LTE_INT';
+    OP_GTE_INT:                        Result := 'OP_GTE_INT';
+    OP_CONCAT:                         Result := 'OP_CONCAT';
+    OP_GET_GLOBAL:                     Result := 'OP_GET_GLOBAL';
+    OP_SET_GLOBAL:                     Result := 'OP_SET_GLOBAL';
+    OP_HAS_GLOBAL:                     Result := 'OP_HAS_GLOBAL';
+    OP_CALL:                           Result := 'OP_CALL';
+    OP_CALL_METHOD:                    Result := 'OP_CALL_METHOD';
+    OP_CONSTRUCT:                      Result := 'OP_CONSTRUCT';
+    OP_GET_ITER:                       Result := 'OP_GET_ITER';
+    OP_ITER_NEXT:                      Result := 'OP_ITER_NEXT';
+    OP_TO_STRING:                      Result := 'OP_TO_STRING';
+    OP_NEW_CLASS:                      Result := 'OP_NEW_CLASS';
+    OP_CLASS_SET_SUPER:                Result := 'OP_CLASS_SET_SUPER';
+    OP_CLASS_ADD_METHOD_CONST:         Result := 'OP_CLASS_ADD_METHOD_CONST';
+    OP_CLASS_SET_FIELD_INITIALIZER:    Result := 'OP_CLASS_SET_FIELD_INITIALIZER';
+    OP_CLASS_DECLARE_PRIVATE_STATIC_CONST: Result := 'OP_CLASS_DECLARE_PRIVATE_STATIC_CONST';
+    OP_TO_PRIMITIVE:                   Result := 'OP_TO_PRIMITIVE';
+    OP_UNPACK:                         Result := 'OP_UNPACK';
+    OP_LOAD_NULL:                      Result := 'OP_LOAD_NULL';
+    OP_LOAD_HOLE:                      Result := 'OP_LOAD_HOLE';
+    OP_CHECK_TYPE:                     Result := 'OP_CHECK_TYPE';
+    OP_EQ_FLOAT:                       Result := 'OP_EQ_FLOAT';
+    OP_NEQ_FLOAT:                      Result := 'OP_NEQ_FLOAT';
+    OP_LT_FLOAT:                       Result := 'OP_LT_FLOAT';
+    OP_GT_FLOAT:                       Result := 'OP_GT_FLOAT';
+    OP_LTE_FLOAT:                      Result := 'OP_LTE_FLOAT';
+    OP_GTE_FLOAT:                      Result := 'OP_GTE_FLOAT';
+    OP_NOT:                            Result := 'OP_NOT';
+    OP_TO_BOOL:                        Result := 'OP_TO_BOOL';
+    OP_DEFINE_ACCESSOR_CONST:          Result := 'OP_DEFINE_ACCESSOR_CONST';
+    OP_DEFINE_ACCESSOR_DYNAMIC:        Result := 'OP_DEFINE_ACCESSOR_DYNAMIC';
+    OP_COLLECTION_OP:                  Result := 'OP_COLLECTION_OP';
+    OP_VALIDATE_VALUE:                 Result := 'OP_VALIDATE_VALUE';
+    OP_THROW_TYPE_ERROR_CONST:         Result := 'OP_THROW_TYPE_ERROR_CONST';
+    OP_DEFINE_GLOBAL_CONST:            Result := 'OP_DEFINE_GLOBAL_CONST';
+    OP_FINALIZE_ENUM:                  Result := 'OP_FINALIZE_ENUM';
+    OP_SUPER_GET_CONST:                Result := 'OP_SUPER_GET_CONST';
+    OP_SETUP_AUTO_ACCESSOR_CONST:      Result := 'OP_SETUP_AUTO_ACCESSOR_CONST';
+    OP_BEGIN_DECORATORS:               Result := 'OP_BEGIN_DECORATORS';
+    OP_APPLY_CLASS_DECORATOR:          Result := 'OP_APPLY_CLASS_DECORATOR';
+    OP_FINISH_DECORATORS:              Result := 'OP_FINISH_DECORATORS';
+    OP_APPLY_ELEMENT_DECORATOR_CONST:  Result := 'OP_APPLY_ELEMENT_DECORATOR_CONST';
+    OP_EQ:                             Result := 'OP_EQ';
+    OP_NEQ:                            Result := 'OP_NEQ';
+    OP_LT:                             Result := 'OP_LT';
+    OP_GT:                             Result := 'OP_GT';
+    OP_LTE:                            Result := 'OP_LTE';
+    OP_GTE:                            Result := 'OP_GTE';
+    OP_TYPEOF:                         Result := 'OP_TYPEOF';
+    OP_IS_INSTANCE:                    Result := 'OP_IS_INSTANCE';
+    OP_HAS_PROPERTY:                   Result := 'OP_HAS_PROPERTY';
+    OP_TO_NUMBER:                      Result := 'OP_TO_NUMBER';
+    OP_NEG:                            Result := 'OP_NEG';
+    OP_BNOT:                           Result := 'OP_BNOT';
+    OP_GET_INDEX:                      Result := 'OP_GET_INDEX';
+    OP_SET_INDEX:                      Result := 'OP_SET_INDEX';
+    OP_DEL_INDEX:                      Result := 'OP_DEL_INDEX';
+    OP_ADD:                            Result := 'OP_ADD';
+    OP_SUB:                            Result := 'OP_SUB';
+    OP_MUL:                            Result := 'OP_MUL';
+    OP_DIV:                            Result := 'OP_DIV';
+    OP_MOD:                            Result := 'OP_MOD';
+    OP_POW:                            Result := 'OP_POW';
+    OP_BAND:                           Result := 'OP_BAND';
+    OP_BOR:                            Result := 'OP_BOR';
+    OP_BXOR:                           Result := 'OP_BXOR';
+    OP_SHL:                            Result := 'OP_SHL';
+    OP_SHR:                            Result := 'OP_SHR';
+    OP_USHR:                           Result := 'OP_USHR';
+    OP_IMPORT:                         Result := 'OP_IMPORT';
+    OP_EXPORT:                         Result := 'OP_EXPORT';
+    OP_AWAIT:                          Result := 'OP_AWAIT';
+  else
+    Result := Format('OP_UNKNOWN_%d', [AOp]);
+  end;
+end;
+
+end.

--- a/units/Goccia.Engine.Backend.pas
+++ b/units/Goccia.Engine.Backend.pas
@@ -87,6 +87,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Coverage,
   Goccia.Error,
+  Goccia.Profiler,
   Goccia.Scope,
   Goccia.Scope.BindingMap,
   Goccia.Scope.Redeclaration,
@@ -196,9 +197,17 @@ begin
   GC.Enabled := False;
   FMinimalVM.CoverageEnabled := Assigned(TGocciaCoverageTracker.Instance)
     and TGocciaCoverageTracker.Instance.Enabled;
+  FMinimalVM.ProfilingOpcodes := Assigned(TGocciaProfiler.Instance)
+    and TGocciaProfiler.Instance.Enabled
+    and (pmOpcodes in TGocciaProfiler.Instance.Mode);
+  FMinimalVM.ProfilingFunctions := Assigned(TGocciaProfiler.Instance)
+    and TGocciaProfiler.Instance.Enabled
+    and (pmFunctions in TGocciaProfiler.Instance.Mode);
+  GProfilingAllocations := FMinimalVM.ProfilingFunctions;
   try
     Result := FMinimalVM.ExecuteModule(AModule);
   finally
+    GProfilingAllocations := False;
     GC.Enabled := WasEnabled;
   end;
 end;

--- a/units/Goccia.Profiler.Report.pas
+++ b/units/Goccia.Profiler.Report.pas
@@ -1,0 +1,403 @@
+unit Goccia.Profiler.Report;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Profiler;
+
+procedure PrintOpcodeProfile(const AProfiler: TGocciaProfiler);
+procedure PrintOpcodePairProfile(const AProfiler: TGocciaProfiler);
+procedure PrintScalarHitRate(const AProfiler: TGocciaProfiler);
+procedure PrintFunctionProfile(const AProfiler: TGocciaProfiler);
+procedure WriteProfileJSON(const AProfiler: TGocciaProfiler;
+  const AOutputPath: string);
+
+implementation
+
+uses
+  Classes,
+  Math,
+  SysUtils,
+
+  StringBuffer,
+  TimingUtils,
+
+  Goccia.Bytecode.OpCodeNames;
+
+const
+  MAX_OPCODE_PAIRS_DISPLAYED = 20;
+
+type
+  TOpcodeEntry = record
+    Op: UInt8;
+    Count: Int64;
+  end;
+
+  TOpcodePairEntry = record
+    Prev: UInt8;
+    Cur: UInt8;
+    Count: Int64;
+  end;
+
+  TFunctionEntry = record
+    Index: Integer;
+    SelfTimeNanoseconds: Int64;
+  end;
+
+function EscapeJSONString(const AValue: string): string;
+begin
+  Result := StringReplace(AValue, '\', '\\', [rfReplaceAll]);
+  Result := StringReplace(Result, '"', '\"', [rfReplaceAll]);
+  Result := StringReplace(Result, #10, '\n', [rfReplaceAll]);
+  Result := StringReplace(Result, #13, '\r', [rfReplaceAll]);
+  Result := StringReplace(Result, #9, '\t', [rfReplaceAll]);
+end;
+
+{ Console: Opcode Profile }
+
+procedure PrintOpcodeProfile(const AProfiler: TGocciaProfiler);
+var
+  Entries: array of TOpcodeEntry;
+  EntryCount: Integer;
+  I, J: Integer;
+  Total: Int64;
+  Pct: Double;
+  Temp: TOpcodeEntry;
+  Count: Int64;
+begin
+  EntryCount := 0;
+  SetLength(Entries, 256);
+  Total := 0;
+
+  for I := 0 to MAX_OPCODE_ORDINAL do
+  begin
+    Count := AProfiler.GetOpcodeCount(I);
+    if Count > 0 then
+    begin
+      Entries[EntryCount].Op := I;
+      Entries[EntryCount].Count := Count;
+      Inc(EntryCount);
+      Total := Total + Count;
+    end;
+  end;
+
+  if EntryCount = 0 then
+  begin
+    WriteLn;
+    WriteLn('Opcode Profile: (no instructions executed)');
+    Exit;
+  end;
+
+  // Sort descending by count (insertion sort — small N)
+  for I := 1 to EntryCount - 1 do
+  begin
+    Temp := Entries[I];
+    J := I - 1;
+    while (J >= 0) and (Entries[J].Count < Temp.Count) do
+    begin
+      Entries[J + 1] := Entries[J];
+      Dec(J);
+    end;
+    Entries[J + 1] := Temp;
+  end;
+
+  WriteLn;
+  WriteLn('Opcode Profile:');
+  WriteLn(Format('  %-40s %15s %8s', ['Opcode', 'Count', '%']));
+
+  for I := 0 to EntryCount - 1 do
+  begin
+    if Total > 0 then
+      Pct := (Entries[I].Count * 1.0 / Total) * 100.0
+    else
+      Pct := 0.0;
+    WriteLn(Format('  %-40s %15d %7.1f%%', [
+      OpCodeName(Entries[I].Op),
+      Entries[I].Count,
+      Pct]));
+  end;
+
+  WriteLn(Format('  %-40s %15d', ['Total', Total]));
+end;
+
+{ Console: Opcode Pair Profile }
+
+procedure PrintOpcodePairProfile(const AProfiler: TGocciaProfiler);
+var
+  Entries: array of TOpcodePairEntry;
+  EntryCount: Integer;
+  Prev, Cur: Integer;
+  I, J: Integer;
+  Total: Int64;
+  Pct: Double;
+  Temp: TOpcodePairEntry;
+  Count: Int64;
+begin
+  EntryCount := 0;
+  SetLength(Entries, 65536);
+  Total := 0;
+
+  for Prev := 0 to MAX_OPCODE_ORDINAL do
+    for Cur := 0 to MAX_OPCODE_ORDINAL do
+    begin
+      Count := AProfiler.GetOpcodePairCount(Prev, Cur);
+      if Count > 0 then
+      begin
+        Entries[EntryCount].Prev := Prev;
+        Entries[EntryCount].Cur := Cur;
+        Entries[EntryCount].Count := Count;
+        Inc(EntryCount);
+        Total := Total + Count;
+      end;
+    end;
+
+  if EntryCount = 0 then
+  begin
+    WriteLn;
+    WriteLn('Opcode Pairs: (no data)');
+    Exit;
+  end;
+
+  // Sort descending by count (insertion sort)
+  for I := 1 to EntryCount - 1 do
+  begin
+    Temp := Entries[I];
+    J := I - 1;
+    while (J >= 0) and (Entries[J].Count < Temp.Count) do
+    begin
+      Entries[J + 1] := Entries[J];
+      Dec(J);
+    end;
+    Entries[J + 1] := Temp;
+  end;
+
+  WriteLn;
+  WriteLn('Opcode Pairs (top ', MAX_OPCODE_PAIRS_DISPLAYED, '):');
+  WriteLn(Format('  %-40s %-4s %-40s %15s %8s', [
+    'Previous', '', 'Current', 'Count', '%']));
+
+  for I := 0 to Min(EntryCount, MAX_OPCODE_PAIRS_DISPLAYED) - 1 do
+  begin
+    if Total > 0 then
+      Pct := (Entries[I].Count * 1.0 / Total) * 100.0
+    else
+      Pct := 0.0;
+    WriteLn(Format('  %-40s  -> %-40s %15d %7.1f%%', [
+      OpCodeName(Entries[I].Prev),
+      OpCodeName(Entries[I].Cur),
+      Entries[I].Count,
+      Pct]));
+  end;
+end;
+
+{ Console: Scalar Fast-Path Hit Rate }
+
+procedure PrintScalarHitRate(const AProfiler: TGocciaProfiler);
+var
+  Hits, Misses, Total: Int64;
+  HitPct: Double;
+begin
+  Hits := AProfiler.ScalarHits;
+  Misses := AProfiler.ScalarMisses;
+  Total := Hits + Misses;
+
+  if Total = 0 then
+  begin
+    WriteLn;
+    WriteLn('Scalar Fast-Path: (no generic arithmetic executed)');
+    Exit;
+  end;
+
+  HitPct := (Hits * 1.0 / Total) * 100.0;
+
+  WriteLn;
+  WriteLn('Scalar Fast-Path:');
+  WriteLn(Format('  Hits:   %12d (%5.1f%%)', [Hits, HitPct]));
+  WriteLn(Format('  Misses: %12d (%5.1f%%)', [Misses, 100.0 - HitPct]));
+  WriteLn(Format('  Total:  %12d', [Total]));
+end;
+
+{ Console: Function Profile }
+
+procedure PrintFunctionProfile(const AProfiler: TGocciaProfiler);
+var
+  Entries: array of TFunctionEntry;
+  EntryCount: Integer;
+  I, J: Integer;
+  Profile: TGocciaFunctionProfile;
+  Temp: TFunctionEntry;
+  DisplayName, Location: string;
+begin
+  EntryCount := 0;
+  SetLength(Entries, AProfiler.FunctionProfileCount);
+
+  for I := 0 to AProfiler.FunctionProfileCount - 1 do
+  begin
+    Profile := AProfiler.GetFunctionProfile(I);
+    if Profile.CallCount > 0 then
+    begin
+      Entries[EntryCount].Index := I;
+      Entries[EntryCount].SelfTimeNanoseconds := Profile.SelfTimeNanoseconds;
+      Inc(EntryCount);
+    end;
+  end;
+
+  if EntryCount = 0 then
+  begin
+    WriteLn;
+    WriteLn('Function Profile: (no functions called)');
+    Exit;
+  end;
+
+  // Sort descending by self-time (insertion sort — small N)
+  for I := 1 to EntryCount - 1 do
+  begin
+    Temp := Entries[I];
+    J := I - 1;
+    while (J >= 0) and (Entries[J].SelfTimeNanoseconds < Temp.SelfTimeNanoseconds) do
+    begin
+      Entries[J + 1] := Entries[J];
+      Dec(J);
+    end;
+    Entries[J + 1] := Temp;
+  end;
+
+  WriteLn;
+  WriteLn('Function Profile:');
+  WriteLn(Format('  %-12s %-12s %8s %10s  %-30s %s', [
+    'Self Time', 'Total Time', 'Calls', 'Allocs', 'Function', 'Location']));
+
+  for I := 0 to EntryCount - 1 do
+  begin
+    Profile := AProfiler.GetFunctionProfile(Entries[I].Index);
+    if Profile.TemplateName = '' then
+      DisplayName := '<anonymous>'
+    else
+      DisplayName := Profile.TemplateName;
+    if (Profile.SourceFile <> '') and (Profile.Line > 0) then
+      Location := Format('%s:%d', [Profile.SourceFile, Profile.Line])
+    else if Profile.SourceFile <> '' then
+      Location := Profile.SourceFile
+    else
+      Location := '';
+    WriteLn(Format('  %-12s %-12s %8d %10d  %-30s %s', [
+      FormatDuration(Profile.SelfTimeNanoseconds),
+      FormatDuration(Profile.TotalTimeNanoseconds),
+      Profile.CallCount,
+      Profile.Allocations,
+      DisplayName,
+      Location]));
+  end;
+end;
+
+{ JSON Export }
+
+procedure WriteProfileJSON(const AProfiler: TGocciaProfiler;
+  const AOutputPath: string);
+var
+  Buf: TStringBuffer;
+  I, Prev, Cur: Integer;
+  Count: Int64;
+  Total: Int64;
+  Pct: Double;
+  Profile: TGocciaFunctionProfile;
+  Hits, Misses, ScalarTotal: Int64;
+  FirstEntry: Boolean;
+  Output: TStringList;
+begin
+  Buf := TStringBuffer.Create(8192);
+  Buf.Append('{');
+
+  // Opcodes section
+  Buf.Append(#10'  "opcodes": [');
+  Total := 0;
+  for I := 0 to MAX_OPCODE_ORDINAL do
+    Total := Total + AProfiler.GetOpcodeCount(I);
+
+  FirstEntry := True;
+  for I := 0 to MAX_OPCODE_ORDINAL do
+  begin
+    Count := AProfiler.GetOpcodeCount(I);
+    if Count > 0 then
+    begin
+      if not FirstEntry then
+        Buf.AppendChar(',');
+      FirstEntry := False;
+      if Total > 0 then
+        Pct := (Count * 1.0 / Total) * 100.0
+      else
+        Pct := 0.0;
+      Buf.Append(Format(#10'    {"opcode": "%s", "count": %d, "percentage": %.1f}', [
+        EscapeJSONString(OpCodeName(I)), Count, Pct]));
+    end;
+  end;
+  Buf.Append(#10'  ],');
+
+  // Opcode pairs section
+  Buf.Append(#10'  "opcodePairs": [');
+  FirstEntry := True;
+  for Prev := 0 to MAX_OPCODE_ORDINAL do
+    for Cur := 0 to MAX_OPCODE_ORDINAL do
+    begin
+      Count := AProfiler.GetOpcodePairCount(Prev, Cur);
+      if Count > 0 then
+      begin
+        if not FirstEntry then
+          Buf.AppendChar(',');
+        FirstEntry := False;
+        Buf.Append(Format(#10'    {"prev": "%s", "cur": "%s", "count": %d}', [
+          EscapeJSONString(OpCodeName(Prev)),
+          EscapeJSONString(OpCodeName(Cur)),
+          Count]));
+      end;
+    end;
+  Buf.Append(#10'  ],');
+
+  // Scalar fast-path section
+  Hits := AProfiler.ScalarHits;
+  Misses := AProfiler.ScalarMisses;
+  ScalarTotal := Hits + Misses;
+  Buf.Append(Format(#10'  "scalarFastPath": {"hits": %d, "misses": %d, "total": %d', [
+    Hits, Misses, ScalarTotal]));
+  if ScalarTotal > 0 then
+    Buf.Append(Format(', "hitRate": %.1f', [Hits * 100.0 / ScalarTotal]));
+  Buf.Append('},');
+
+  // Functions section
+  Buf.Append(#10'  "functions": [');
+  FirstEntry := True;
+  for I := 0 to AProfiler.FunctionProfileCount - 1 do
+  begin
+    Profile := AProfiler.GetFunctionProfile(I);
+    if Profile.CallCount > 0 then
+    begin
+      if not FirstEntry then
+        Buf.AppendChar(',');
+      FirstEntry := False;
+      Buf.Append(Format(#10'    {"name": "%s", "sourceFile": "%s", "line": %d, ' +
+        '"calls": %d, "selfTimeNs": %d, "totalTimeNs": %d, "allocations": %d}', [
+        EscapeJSONString(Profile.TemplateName),
+        EscapeJSONString(Profile.SourceFile),
+        Profile.Line,
+        Profile.CallCount,
+        Profile.SelfTimeNanoseconds,
+        Profile.TotalTimeNanoseconds,
+        Profile.Allocations]));
+    end;
+  end;
+  Buf.Append(#10'  ]');
+
+  Buf.Append(#10'}' + #10);
+
+  Output := TStringList.Create;
+  try
+    Output.Text := Buf.ToString;
+    Output.SaveToFile(AOutputPath);
+  finally
+    Output.Free;
+  end;
+end;
+
+end.

--- a/units/Goccia.Profiler.Report.pas
+++ b/units/Goccia.Profiler.Report.pas
@@ -49,13 +49,58 @@ type
     SelfTimeNanoseconds: Int64;
   end;
 
-function EscapeJSONString(const AValue: string): string;
+procedure QuickSortPairs(var AEntries: array of TOpcodePairEntry;
+  const ALow, AHigh: Integer);
+var
+  Lo, Hi: Integer;
+  Pivot: Int64;
+  Temp: TOpcodePairEntry;
 begin
-  Result := StringReplace(AValue, '\', '\\', [rfReplaceAll]);
-  Result := StringReplace(Result, '"', '\"', [rfReplaceAll]);
-  Result := StringReplace(Result, #10, '\n', [rfReplaceAll]);
-  Result := StringReplace(Result, #13, '\r', [rfReplaceAll]);
-  Result := StringReplace(Result, #9, '\t', [rfReplaceAll]);
+  Lo := ALow;
+  Hi := AHigh;
+  Pivot := AEntries[(ALow + AHigh) div 2].Count;
+  repeat
+    while AEntries[Lo].Count > Pivot do Inc(Lo);
+    while AEntries[Hi].Count < Pivot do Dec(Hi);
+    if Lo <= Hi then
+    begin
+      Temp := AEntries[Lo];
+      AEntries[Lo] := AEntries[Hi];
+      AEntries[Hi] := Temp;
+      Inc(Lo);
+      Dec(Hi);
+    end;
+  until Lo > Hi;
+  if ALow < Hi then QuickSortPairs(AEntries, ALow, Hi);
+  if Lo < AHigh then QuickSortPairs(AEntries, Lo, AHigh);
+end;
+
+function EscapeJSONString(const AValue: string): string;
+var
+  Buf: TStringBuffer;
+  I: Integer;
+  Ch: Char;
+begin
+  Buf := TStringBuffer.Create(Length(AValue) + 16);
+  for I := 1 to Length(AValue) do
+  begin
+    Ch := AValue[I];
+    case Ch of
+      '\': Buf.Append('\\');
+      '"': Buf.Append('\"');
+      #8:  Buf.Append('\b');
+      #9:  Buf.Append('\t');
+      #10: Buf.Append('\n');
+      #12: Buf.Append('\f');
+      #13: Buf.Append('\r');
+    else
+      if Ord(Ch) < 32 then
+        Buf.Append('\u00' + IntToHex(Ord(Ch), 2))
+      else
+        Buf.AppendChar(AnsiChar(Ch));
+    end;
+  end;
+  Result := Buf.ToString;
 end;
 
 { Console: Opcode Profile }
@@ -132,10 +177,9 @@ var
   Entries: array of TOpcodePairEntry;
   EntryCount: Integer;
   Prev, Cur: Integer;
-  I, J: Integer;
+  I: Integer;
   Total: Int64;
   Pct: Double;
-  Temp: TOpcodePairEntry;
   Count: Int64;
 begin
   EntryCount := 0;
@@ -163,18 +207,9 @@ begin
     Exit;
   end;
 
-  // Sort descending by count (insertion sort)
-  for I := 1 to EntryCount - 1 do
-  begin
-    Temp := Entries[I];
-    J := I - 1;
-    while (J >= 0) and (Entries[J].Count < Temp.Count) do
-    begin
-      Entries[J + 1] := Entries[J];
-      Dec(J);
-    end;
-    Entries[J + 1] := Temp;
-  end;
+  // Sort descending by count
+  if EntryCount > 1 then
+    QuickSortPairs(Entries, 0, EntryCount - 1);
 
   WriteLn;
   WriteLn('Opcode Pairs (top ', MAX_OPCODE_PAIRS_DISPLAYED, '):');

--- a/units/Goccia.Profiler.Report.pas
+++ b/units/Goccia.Profiler.Report.pas
@@ -13,6 +13,8 @@ procedure PrintScalarHitRate(const AProfiler: TGocciaProfiler);
 procedure PrintFunctionProfile(const AProfiler: TGocciaProfiler);
 procedure WriteProfileJSON(const AProfiler: TGocciaProfiler;
   const AOutputPath: string);
+procedure WriteCollapsedStacks(const AProfiler: TGocciaProfiler;
+  const AOutputPath: string);
 
 implementation
 
@@ -21,6 +23,7 @@ uses
   Math,
   SysUtils,
 
+  BaseMap,
   StringBuffer,
   TimingUtils,
 
@@ -306,7 +309,10 @@ var
   Hits, Misses, ScalarTotal: Int64;
   FirstEntry: Boolean;
   Output: TStringList;
+  InvariantFormat: TFormatSettings;
 begin
+  InvariantFormat := DefaultFormatSettings;
+  InvariantFormat.DecimalSeparator := '.';
   Buf := TStringBuffer.Create(8192);
   Buf.Append('{');
 
@@ -330,7 +336,7 @@ begin
       else
         Pct := 0.0;
       Buf.Append(Format(#10'    {"opcode": "%s", "count": %d, "percentage": %.1f}', [
-        EscapeJSONString(OpCodeName(I)), Count, Pct]));
+        EscapeJSONString(OpCodeName(I)), Count, Pct], InvariantFormat));
     end;
   end;
   Buf.Append(#10'  ],');
@@ -362,7 +368,8 @@ begin
   Buf.Append(Format(#10'  "scalarFastPath": {"hits": %d, "misses": %d, "total": %d', [
     Hits, Misses, ScalarTotal]));
   if ScalarTotal > 0 then
-    Buf.Append(Format(', "hitRate": %.1f', [Hits * 100.0 / ScalarTotal]));
+    Buf.Append(Format(', "hitRate": %.1f', [Hits * 100.0 / ScalarTotal],
+      InvariantFormat));
   Buf.Append('},');
 
   // Functions section
@@ -394,6 +401,24 @@ begin
   Output := TStringList.Create;
   try
     Output.Text := Buf.ToString;
+    Output.SaveToFile(AOutputPath);
+  finally
+    Output.Free;
+  end;
+end;
+
+{ Collapsed Stack Export (Flame Graph) }
+
+procedure WriteCollapsedStacks(const AProfiler: TGocciaProfiler;
+  const AOutputPath: string);
+var
+  Output: TStringList;
+  Pair: TBaseMap<string, Int64>.TKeyValuePair;
+begin
+  Output := TStringList.Create;
+  try
+    for Pair in AProfiler.CollapsedStacks do
+      Output.Add(Pair.Key + ' ' + IntToStr(Pair.Value));
     Output.SaveToFile(AOutputPath);
   finally
     Output.Free;

--- a/units/Goccia.Profiler.Report.pas
+++ b/units/Goccia.Profiler.Report.pas
@@ -449,11 +449,16 @@ procedure WriteCollapsedStacks(const AProfiler: TGocciaProfiler;
 var
   Output: TStringList;
   Pair: TBaseMap<string, Int64>.TKeyValuePair;
+  Microseconds: Int64;
 begin
   Output := TStringList.Create;
   try
     for Pair in AProfiler.CollapsedStacks do
-      Output.Add(Pair.Key + ' ' + IntToStr(Pair.Value));
+    begin
+      Microseconds := Pair.Value div 1000;
+      if Microseconds > 0 then
+        Output.Add(Pair.Key + ' ' + IntToStr(Microseconds));
+    end;
     Output.SaveToFile(AOutputPath);
   finally
     Output.Free;

--- a/units/Goccia.Profiler.pas
+++ b/units/Goccia.Profiler.pas
@@ -4,6 +4,9 @@ unit Goccia.Profiler;
 
 interface
 
+uses
+  OrderedStringMap;
+
 const
   MAX_OPCODE_ORDINAL = 255;
   OPCODE_PAIR_SIZE = 256;
@@ -45,6 +48,7 @@ type
     FMode: TGocciaProfileMode;
     FEnabled: Boolean;
     FOpcodeCount: array[0..MAX_OPCODE_ORDINAL] of Int64;
+    FHasPrevOp: Boolean;
     FPrevOp: UInt8;
     FOpcodePairs: PGocciaOpcodePairArray;
     FScalarHits: Int64;
@@ -53,6 +57,7 @@ type
     FFunctionProfileCount: Integer;
     FTimingStack: array of TGocciaProfilingStackEntry;
     FTimingStackCount: Integer;
+    FCollapsedStacks: TOrderedStringMap<Int64>;
   public
     class function Instance: TGocciaProfiler;
     class procedure Initialize;
@@ -82,6 +87,7 @@ type
     property FunctionProfileCount: Integer read FFunctionProfileCount;
     property ScalarHits: Int64 read FScalarHits;
     property ScalarMisses: Int64 read FScalarMisses;
+    property CollapsedStacks: TOrderedStringMap<Int64> read FCollapsedStacks;
   end;
 
 implementation
@@ -117,6 +123,7 @@ begin
   FMode := [];
   for I := 0 to MAX_OPCODE_ORDINAL do
     FOpcodeCount[I] := 0;
+  FHasPrevOp := False;
   FPrevOp := 0;
   GetMem(FOpcodePairs, SizeOf(TGocciaOpcodePairArray));
   FillChar(FOpcodePairs^, SizeOf(TGocciaOpcodePairArray), 0);
@@ -126,10 +133,12 @@ begin
   SetLength(FFunctionProfiles, INITIAL_FUNCTION_PROFILE_CAPACITY);
   FTimingStackCount := 0;
   SetLength(FTimingStack, INITIAL_TIMING_STACK_CAPACITY);
+  FCollapsedStacks := TOrderedStringMap<Int64>.Create;
 end;
 
 destructor TGocciaProfiler.Destroy;
 begin
+  FCollapsedStacks.Free;
   if Assigned(FOpcodePairs) then
     FreeMem(FOpcodePairs);
   inherited;
@@ -138,8 +147,10 @@ end;
 procedure TGocciaProfiler.RecordOpcode(const AOp: UInt8);
 begin
   Inc(FOpcodeCount[AOp]);
-  Inc(FOpcodePairs^[FPrevOp, AOp]);
+  if FHasPrevOp then
+    Inc(FOpcodePairs^[FPrevOp, AOp]);
   FPrevOp := AOp;
+  FHasPrevOp := True;
 end;
 
 procedure TGocciaProfiler.RecordScalarHit;
@@ -190,7 +201,9 @@ end;
 procedure TGocciaProfiler.PopFunction(const AProfileIndex: Integer;
   const ATimestamp: Int64);
 var
-  Elapsed, SelfTime: Int64;
+  Elapsed, SelfTime, SelfTimeMicroseconds, ExistingValue: Int64;
+  StackPath: string;
+  I: Integer;
 begin
   if FTimingStackCount <= 0 then Exit;
   Dec(FTimingStackCount);
@@ -200,6 +213,33 @@ begin
   Inc(FFunctionProfiles[AProfileIndex].SelfTimeNanoseconds, SelfTime);
   if FTimingStackCount > 0 then
     Inc(FTimingStack[FTimingStackCount - 1].ChildTimeAccumulated, Elapsed);
+
+  // Build collapsed stack path for flame graph export
+  StackPath := '';
+  for I := 0 to FTimingStackCount - 1 do
+  begin
+    if StackPath <> '' then
+      StackPath := StackPath + ';';
+    if FFunctionProfiles[FTimingStack[I].ProfileIndex].TemplateName <> '' then
+      StackPath := StackPath + FFunctionProfiles[FTimingStack[I].ProfileIndex].TemplateName
+    else
+      StackPath := StackPath + '<anonymous>';
+  end;
+  if StackPath <> '' then
+    StackPath := StackPath + ';';
+  if FFunctionProfiles[AProfileIndex].TemplateName <> '' then
+    StackPath := StackPath + FFunctionProfiles[AProfileIndex].TemplateName
+  else
+    StackPath := StackPath + '<anonymous>';
+
+  SelfTimeMicroseconds := SelfTime div 1000;
+  if SelfTimeMicroseconds > 0 then
+  begin
+    if FCollapsedStacks.TryGetValue(StackPath, ExistingValue) then
+      FCollapsedStacks.AddOrSetValue(StackPath, ExistingValue + SelfTimeMicroseconds)
+    else
+      FCollapsedStacks.Add(StackPath, SelfTimeMicroseconds);
+  end;
 end;
 
 function TGocciaProfiler.GetOpcodeCount(const AOp: UInt8): Int64;

--- a/units/Goccia.Profiler.pas
+++ b/units/Goccia.Profiler.pas
@@ -202,18 +202,20 @@ end;
 procedure TGocciaProfiler.PopFunction(const AProfileIndex: Integer;
   const ATimestamp: Int64);
 var
-  Elapsed, SelfTime, SelfTimeMicroseconds: Int64;
+  Elapsed, SelfTime: Int64;
+  PoppedIndex: Integer;
   ExistingValue: Int64;
   StackPath: string;
   I: Integer;
 begin
   if FTimingStackCount <= 0 then Exit;
-  if (AProfileIndex < 0) or (AProfileIndex >= FFunctionProfileCount) then Exit;
   Dec(FTimingStackCount);
+  PoppedIndex := FTimingStack[FTimingStackCount].ProfileIndex;
+  if (PoppedIndex < 0) or (PoppedIndex >= FFunctionProfileCount) then Exit;
   Elapsed := ATimestamp - FTimingStack[FTimingStackCount].EntryTimestamp;
   SelfTime := Elapsed - FTimingStack[FTimingStackCount].ChildTimeAccumulated;
-  Inc(FFunctionProfiles[AProfileIndex].TotalTimeNanoseconds, Elapsed);
-  Inc(FFunctionProfiles[AProfileIndex].SelfTimeNanoseconds, SelfTime);
+  Inc(FFunctionProfiles[PoppedIndex].TotalTimeNanoseconds, Elapsed);
+  Inc(FFunctionProfiles[PoppedIndex].SelfTimeNanoseconds, SelfTime);
   if FTimingStackCount > 0 then
     Inc(FTimingStack[FTimingStackCount - 1].ChildTimeAccumulated, Elapsed);
 
@@ -230,18 +232,18 @@ begin
   end;
   if StackPath <> '' then
     StackPath := StackPath + ';';
-  if FFunctionProfiles[AProfileIndex].TemplateName <> '' then
-    StackPath := StackPath + FFunctionProfiles[AProfileIndex].TemplateName
+  if FFunctionProfiles[PoppedIndex].TemplateName <> '' then
+    StackPath := StackPath + FFunctionProfiles[PoppedIndex].TemplateName
   else
     StackPath := StackPath + '<anonymous>';
 
-  SelfTimeMicroseconds := SelfTime div 1000;
-  if SelfTimeMicroseconds > 0 then
+  // Accumulate self-time in nanoseconds (converted to microseconds at export)
+  if SelfTime > 0 then
   begin
     if FCollapsedStacks.TryGetValue(StackPath, ExistingValue) then
-      FCollapsedStacks.AddOrSetValue(StackPath, ExistingValue + SelfTimeMicroseconds)
+      FCollapsedStacks.AddOrSetValue(StackPath, ExistingValue + SelfTime)
     else
-      FCollapsedStacks.Add(StackPath, SelfTimeMicroseconds);
+      FCollapsedStacks.Add(StackPath, SelfTime);
   end;
 end;
 

--- a/units/Goccia.Profiler.pas
+++ b/units/Goccia.Profiler.pas
@@ -189,6 +189,7 @@ end;
 procedure TGocciaProfiler.PushFunction(const AProfileIndex: Integer;
   const ATimestamp: Int64);
 begin
+  if (AProfileIndex < 0) or (AProfileIndex >= FFunctionProfileCount) then Exit;
   if FTimingStackCount >= Length(FTimingStack) then
     SetLength(FTimingStack, FTimingStackCount * 2 + 16);
   FTimingStack[FTimingStackCount].ProfileIndex := AProfileIndex;
@@ -201,11 +202,13 @@ end;
 procedure TGocciaProfiler.PopFunction(const AProfileIndex: Integer;
   const ATimestamp: Int64);
 var
-  Elapsed, SelfTime, SelfTimeMicroseconds, ExistingValue: Int64;
+  Elapsed, SelfTime, SelfTimeMicroseconds: Int64;
+  ExistingValue: Int64;
   StackPath: string;
   I: Integer;
 begin
   if FTimingStackCount <= 0 then Exit;
+  if (AProfileIndex < 0) or (AProfileIndex >= FFunctionProfileCount) then Exit;
   Dec(FTimingStackCount);
   Elapsed := ATimestamp - FTimingStack[FTimingStackCount].EntryTimestamp;
   SelfTime := Elapsed - FTimingStack[FTimingStackCount].ChildTimeAccumulated;

--- a/units/Goccia.Profiler.pas
+++ b/units/Goccia.Profiler.pas
@@ -1,0 +1,221 @@
+unit Goccia.Profiler;
+
+{$I Goccia.inc}
+
+interface
+
+const
+  MAX_OPCODE_ORDINAL = 255;
+  OPCODE_PAIR_SIZE = 256;
+  INITIAL_FUNCTION_PROFILE_CAPACITY = 64;
+  INITIAL_TIMING_STACK_CAPACITY = 32;
+
+type
+  TGocciaProfileModeItem = (pmOpcodes, pmFunctions);
+  TGocciaProfileMode = set of TGocciaProfileModeItem;
+
+  TGocciaFunctionProfile = record
+    TemplateName: string;
+    SourceFile: string;
+    Line: Integer;
+    CallCount: Int64;
+    SelfTimeNanoseconds: Int64;
+    TotalTimeNanoseconds: Int64;
+    Allocations: Int64;
+  end;
+
+  TGocciaProfilingStackEntry = record
+    ProfileIndex: Integer;
+    EntryTimestamp: Int64;
+    ChildTimeAccumulated: Int64;
+  end;
+
+  TGocciaOpcodePairArray = array[0..OPCODE_PAIR_SIZE - 1,
+    0..OPCODE_PAIR_SIZE - 1] of Int64;
+  PGocciaOpcodePairArray = ^TGocciaOpcodePairArray;
+
+var
+  GProfilingAllocations: Boolean;
+
+type
+  TGocciaProfiler = class
+  private class var
+    FInstance: TGocciaProfiler;
+  private
+    FMode: TGocciaProfileMode;
+    FEnabled: Boolean;
+    FOpcodeCount: array[0..MAX_OPCODE_ORDINAL] of Int64;
+    FPrevOp: UInt8;
+    FOpcodePairs: PGocciaOpcodePairArray;
+    FScalarHits: Int64;
+    FScalarMisses: Int64;
+    FFunctionProfiles: array of TGocciaFunctionProfile;
+    FFunctionProfileCount: Integer;
+    FTimingStack: array of TGocciaProfilingStackEntry;
+    FTimingStackCount: Integer;
+  public
+    class function Instance: TGocciaProfiler;
+    class procedure Initialize;
+    class procedure Shutdown;
+
+    constructor Create;
+    destructor Destroy; override;
+
+    procedure RecordOpcode(const AOp: UInt8); inline;
+    procedure RecordScalarHit; inline;
+    procedure RecordScalarMiss; inline;
+    procedure RecordAllocation; inline;
+
+    function RegisterTemplate(const AName, ASourceFile: string;
+      const ALine: Integer): Integer;
+    procedure PushFunction(const AProfileIndex: Integer;
+      const ATimestamp: Int64);
+    procedure PopFunction(const AProfileIndex: Integer;
+      const ATimestamp: Int64);
+
+    function GetOpcodeCount(const AOp: UInt8): Int64; inline;
+    function GetOpcodePairCount(const APrev, ACur: UInt8): Int64; inline;
+    function GetFunctionProfile(const AIndex: Integer): TGocciaFunctionProfile; inline;
+
+    property Mode: TGocciaProfileMode read FMode write FMode;
+    property Enabled: Boolean read FEnabled write FEnabled;
+    property FunctionProfileCount: Integer read FFunctionProfileCount;
+    property ScalarHits: Int64 read FScalarHits;
+    property ScalarMisses: Int64 read FScalarMisses;
+  end;
+
+implementation
+
+uses
+  SysUtils;
+
+{ TGocciaProfiler }
+
+class function TGocciaProfiler.Instance: TGocciaProfiler;
+begin
+  Result := FInstance;
+end;
+
+class procedure TGocciaProfiler.Initialize;
+begin
+  if not Assigned(FInstance) then
+    FInstance := TGocciaProfiler.Create;
+end;
+
+class procedure TGocciaProfiler.Shutdown;
+begin
+  FreeAndNil(FInstance);
+end;
+
+constructor TGocciaProfiler.Create;
+var
+  I: Integer;
+begin
+  inherited Create;
+  GProfilingAllocations := False;
+  FEnabled := False;
+  FMode := [];
+  for I := 0 to MAX_OPCODE_ORDINAL do
+    FOpcodeCount[I] := 0;
+  FPrevOp := 0;
+  GetMem(FOpcodePairs, SizeOf(TGocciaOpcodePairArray));
+  FillChar(FOpcodePairs^, SizeOf(TGocciaOpcodePairArray), 0);
+  FScalarHits := 0;
+  FScalarMisses := 0;
+  FFunctionProfileCount := 0;
+  SetLength(FFunctionProfiles, INITIAL_FUNCTION_PROFILE_CAPACITY);
+  FTimingStackCount := 0;
+  SetLength(FTimingStack, INITIAL_TIMING_STACK_CAPACITY);
+end;
+
+destructor TGocciaProfiler.Destroy;
+begin
+  if Assigned(FOpcodePairs) then
+    FreeMem(FOpcodePairs);
+  inherited;
+end;
+
+procedure TGocciaProfiler.RecordOpcode(const AOp: UInt8);
+begin
+  Inc(FOpcodeCount[AOp]);
+  Inc(FOpcodePairs^[FPrevOp, AOp]);
+  FPrevOp := AOp;
+end;
+
+procedure TGocciaProfiler.RecordScalarHit;
+begin
+  Inc(FScalarHits);
+end;
+
+procedure TGocciaProfiler.RecordScalarMiss;
+begin
+  Inc(FScalarMisses);
+end;
+
+procedure TGocciaProfiler.RecordAllocation;
+begin
+  if FTimingStackCount > 0 then
+    Inc(FFunctionProfiles[
+      FTimingStack[FTimingStackCount - 1].ProfileIndex].Allocations);
+end;
+
+function TGocciaProfiler.RegisterTemplate(const AName, ASourceFile: string;
+  const ALine: Integer): Integer;
+begin
+  if FFunctionProfileCount >= Length(FFunctionProfiles) then
+    SetLength(FFunctionProfiles, FFunctionProfileCount * 2 + 16);
+  Result := FFunctionProfileCount;
+  FFunctionProfiles[Result].TemplateName := AName;
+  FFunctionProfiles[Result].SourceFile := ASourceFile;
+  FFunctionProfiles[Result].Line := ALine;
+  FFunctionProfiles[Result].CallCount := 0;
+  FFunctionProfiles[Result].SelfTimeNanoseconds := 0;
+  FFunctionProfiles[Result].TotalTimeNanoseconds := 0;
+  FFunctionProfiles[Result].Allocations := 0;
+  Inc(FFunctionProfileCount);
+end;
+
+procedure TGocciaProfiler.PushFunction(const AProfileIndex: Integer;
+  const ATimestamp: Int64);
+begin
+  if FTimingStackCount >= Length(FTimingStack) then
+    SetLength(FTimingStack, FTimingStackCount * 2 + 16);
+  FTimingStack[FTimingStackCount].ProfileIndex := AProfileIndex;
+  FTimingStack[FTimingStackCount].EntryTimestamp := ATimestamp;
+  FTimingStack[FTimingStackCount].ChildTimeAccumulated := 0;
+  Inc(FTimingStackCount);
+  Inc(FFunctionProfiles[AProfileIndex].CallCount);
+end;
+
+procedure TGocciaProfiler.PopFunction(const AProfileIndex: Integer;
+  const ATimestamp: Int64);
+var
+  Elapsed, SelfTime: Int64;
+begin
+  if FTimingStackCount <= 0 then Exit;
+  Dec(FTimingStackCount);
+  Elapsed := ATimestamp - FTimingStack[FTimingStackCount].EntryTimestamp;
+  SelfTime := Elapsed - FTimingStack[FTimingStackCount].ChildTimeAccumulated;
+  Inc(FFunctionProfiles[AProfileIndex].TotalTimeNanoseconds, Elapsed);
+  Inc(FFunctionProfiles[AProfileIndex].SelfTimeNanoseconds, SelfTime);
+  if FTimingStackCount > 0 then
+    Inc(FTimingStack[FTimingStackCount - 1].ChildTimeAccumulated, Elapsed);
+end;
+
+function TGocciaProfiler.GetOpcodeCount(const AOp: UInt8): Int64;
+begin
+  Result := FOpcodeCount[AOp];
+end;
+
+function TGocciaProfiler.GetOpcodePairCount(const APrev, ACur: UInt8): Int64;
+begin
+  Result := FOpcodePairs^[APrev, ACur];
+end;
+
+function TGocciaProfiler.GetFunctionProfile(
+  const AIndex: Integer): TGocciaFunctionProfile;
+begin
+  Result := FFunctionProfiles[AIndex];
+end;
+
+end.

--- a/units/Goccia.Profiler.pas
+++ b/units/Goccia.Profiler.pas
@@ -211,10 +211,6 @@ begin
   if FTimingStackCount <= 0 then Exit;
   Dec(FTimingStackCount);
   PoppedIndex := FTimingStack[FTimingStackCount].ProfileIndex;
-  {$IFDEF DEBUG}
-  Assert(PoppedIndex = AProfileIndex,
-    'PopFunction: caller index does not match popped frame');
-  {$ENDIF}
   if (PoppedIndex < 0) or (PoppedIndex >= FFunctionProfileCount) then Exit;
   Elapsed := ATimestamp - FTimingStack[FTimingStackCount].EntryTimestamp;
   SelfTime := Elapsed - FTimingStack[FTimingStackCount].ChildTimeAccumulated;

--- a/units/Goccia.Profiler.pas
+++ b/units/Goccia.Profiler.pas
@@ -211,6 +211,10 @@ begin
   if FTimingStackCount <= 0 then Exit;
   Dec(FTimingStackCount);
   PoppedIndex := FTimingStack[FTimingStackCount].ProfileIndex;
+  {$IFDEF DEBUG}
+  Assert(PoppedIndex = AProfileIndex,
+    'PopFunction: caller index does not match popped frame');
+  {$ENDIF}
   if (PoppedIndex < 0) or (PoppedIndex >= FFunctionProfileCount) then Exit;
   Elapsed := ATimestamp - FTimingStack[FTimingStackCount].EntryTimestamp;
   SelfTime := Elapsed - FTimingStack[FTimingStackCount].ChildTimeAccumulated;

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -3460,7 +3460,7 @@ begin
         Template.DebugInfo.GetLineMapEntry(0).Line);
 
     // Function profiling: register template and record entry timestamp
-    if FProfilingFunctions then
+    if FProfilingFunctions and Assigned(TGocciaProfiler.Instance) then
     begin
       if Template.ProfileIndex < 0 then
       begin
@@ -5203,7 +5203,8 @@ begin
     end;
     Result := RegisterUndefined;
   finally
-    if FProfilingFunctions and (Template.ProfileIndex >= 0) then
+    if FProfilingFunctions and Assigned(Template) and
+       (Template.ProfileIndex >= 0) then
       TGocciaProfiler.Instance.PopFunction(
         Template.ProfileIndex, GetNanoseconds);
     if Assigned(TGocciaCallStack.Instance) then

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -73,6 +73,8 @@ type
     FCurrentModuleExports: TGocciaValueMap;
     FActiveDecoratorSession: TObject;
     FCoverageEnabled: Boolean;
+    FProfilingOpcodes: Boolean;
+    FProfilingFunctions: Boolean;
     FPreviousExceptionMask: TFPUExceptionMask;
     FArgumentPool: TGocciaArgumentsPoolArray;
     FArgumentPoolCount: Integer;
@@ -181,6 +183,8 @@ type
     property GlobalScope: TGocciaScope read FGlobalScope write FGlobalScope;
     property Interpreter: TGocciaInterpreter read FInterpreter write FInterpreter;
     property CoverageEnabled: Boolean read FCoverageEnabled write FCoverageEnabled;
+    property ProfilingOpcodes: Boolean read FProfilingOpcodes write FProfilingOpcodes;
+    property ProfilingFunctions: Boolean read FProfilingFunctions write FProfilingFunctions;
   end;
 
 implementation
@@ -190,6 +194,7 @@ uses
   SysUtils,
 
   GarbageCollector.Generic,
+  TimingUtils,
 
   Goccia.CallStack,
   Goccia.Constants.ConstructorNames,
@@ -199,6 +204,7 @@ uses
   Goccia.Error,
   Goccia.Evaluator,
   Goccia.Evaluator.Decorators,
+  Goccia.Profiler,
   Goccia.Timeout,
   Goccia.Values.ClassHelper,
   Goccia.Values.EnumValue,
@@ -3419,7 +3425,10 @@ var
   BoundFunction: TGocciaBoundFunctionValue;
   JumpOffset: Integer;
   PrevCovLine, CovLine: UInt32;
+  ProfileEntryTimestamp: Int64;
 begin
+  Template := nil;
+  ProfileEntryTimestamp := 0;
   SavedRegisterBase := FRegisterBase;
   SavedRegisterCount := FRegisterCount;
   SavedLocalCellBase := FLocalCellBase;
@@ -3449,6 +3458,24 @@ begin
       TGocciaCoverageTracker.Instance.RecordLineHit(
         Template.DebugInfo.SourceFile,
         Template.DebugInfo.GetLineMapEntry(0).Line);
+
+    // Function profiling: register template and record entry timestamp
+    if FProfilingFunctions then
+    begin
+      if Template.ProfileIndex < 0 then
+      begin
+        if Assigned(Template.DebugInfo) and (Template.DebugInfo.LineMapCount > 0) then
+          Template.ProfileIndex := TGocciaProfiler.Instance.RegisterTemplate(
+            Template.Name, Template.DebugInfo.SourceFile,
+            Template.DebugInfo.GetLineMapEntry(0).Line)
+        else
+          Template.ProfileIndex := TGocciaProfiler.Instance.RegisterTemplate(
+            Template.Name, '', 0);
+      end;
+      ProfileEntryTimestamp := GetNanoseconds;
+      TGocciaProfiler.Instance.PushFunction(
+        Template.ProfileIndex, ProfileEntryTimestamp);
+    end;
 
     SetLocalRaw(0, AThisValue);
     if AUseFixedArgs then
@@ -3496,6 +3523,8 @@ begin
         end;
 
         Op := DecodeOp(Instruction);
+        if FProfilingOpcodes then
+          TGocciaProfiler.Instance.RecordOpcode(Op);
         A := DecodeA(Instruction);
         B := DecodeB(Instruction);
         C := DecodeC(Instruction);
@@ -4179,9 +4208,16 @@ begin
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then
+            TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) +
-            RegisterToDouble(FRegisters[C]))
-        else if (((FRegisters[B].Kind = grkObject) and
+            RegisterToDouble(FRegisters[C]));
+        end
+        else begin
+          if FProfilingOpcodes then
+            TGocciaProfiler.Instance.RecordScalarMiss;
+          if (((FRegisters[B].Kind = grkObject) and
                   (FRegisters[B].ObjectValue is TGocciaStringLiteralValue)) or
                  ((FRegisters[C].Kind = grkObject) and
                   (FRegisters[C].ObjectValue is TGocciaStringLiteralValue))) and
@@ -4215,56 +4251,87 @@ begin
           else
             SetRegister(A, VMAddValues(LeftValue, RightValue));
         end;
+        end;
       end;
 
       OP_SUB:
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) -
-            RegisterToDouble(FRegisters[C]))
+            RegisterToDouble(FRegisters[C]));
+        end
         else
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           SetRegister(A, VMSubtractValues(GetRegisterFast(B), GetRegisterFast(C)));
+        end;
       end;
 
       OP_MUL:
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) *
-            RegisterToDouble(FRegisters[C]))
+            RegisterToDouble(FRegisters[C]));
+        end
         else
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           SetRegister(A, VMMultiplyValues(GetRegisterFast(B), GetRegisterFast(C)));
+        end;
       end;
 
       OP_DIV:
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) /
-            RegisterToDouble(FRegisters[C]))
+            RegisterToDouble(FRegisters[C]));
+        end
         else
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           SetRegister(A, VMDivideValues(GetRegisterFast(B), GetRegisterFast(C)));
+        end;
       end;
 
       OP_MOD:
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := VMNumberRegister(FMod(RegisterToDouble(FRegisters[B]),
-            RegisterToDouble(FRegisters[C])))
+            RegisterToDouble(FRegisters[C])));
+        end
         else
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           SetRegister(A, VMModuloValues(GetRegisterFast(B), GetRegisterFast(C)));
+        end;
       end;
 
       OP_POW:
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := VMNumberRegister(Power(RegisterToDouble(FRegisters[B]),
-            RegisterToDouble(FRegisters[C])))
+            RegisterToDouble(FRegisters[C])));
+        end
         else
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           SetRegister(A, VMPowerValues(GetRegisterFast(B), GetRegisterFast(C)));
+        end;
       end;
 
       OP_NEG:
@@ -4304,10 +4371,14 @@ begin
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := RegisterBoolean(RegisterToDouble(FRegisters[B]) <
-            RegisterToDouble(FRegisters[C]))
+            RegisterToDouble(FRegisters[C]));
+        end
         else
         begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           LeftValue := GetRegisterFast(B);
           RightValue := GetRegisterFast(C);
           if (LeftValue is TGocciaStringLiteralValue) and
@@ -4324,10 +4395,14 @@ begin
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := RegisterBoolean(RegisterToDouble(FRegisters[B]) >
-            RegisterToDouble(FRegisters[C]))
+            RegisterToDouble(FRegisters[C]));
+        end
         else
         begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           LeftValue := GetRegisterFast(B);
           RightValue := GetRegisterFast(C);
           if (LeftValue is TGocciaStringLiteralValue) and
@@ -4344,10 +4419,14 @@ begin
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := RegisterBoolean(RegisterToDouble(FRegisters[B]) <=
-            RegisterToDouble(FRegisters[C]))
+            RegisterToDouble(FRegisters[C]));
+        end
         else
         begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           LeftValue := GetRegisterFast(B);
           RightValue := GetRegisterFast(C);
           if (LeftValue is TGocciaStringLiteralValue) and
@@ -4364,10 +4443,14 @@ begin
       begin
         if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
           FRegisters[A] := RegisterBoolean(RegisterToDouble(FRegisters[B]) >=
-            RegisterToDouble(FRegisters[C]))
+            RegisterToDouble(FRegisters[C]));
+        end
         else
         begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
           LeftValue := GetRegisterFast(B);
           RightValue := GetRegisterFast(C);
           if (LeftValue is TGocciaStringLiteralValue) and
@@ -5120,6 +5203,9 @@ begin
     end;
     Result := RegisterUndefined;
   finally
+    if FProfilingFunctions and (Template.ProfileIndex >= 0) then
+      TGocciaProfiler.Instance.PopFunction(
+        Template.ProfileIndex, GetNanoseconds);
     if Assigned(TGocciaCallStack.Instance) then
       TGocciaCallStack.Instance.Pop;
     while FHandlerStack.Count > SavedHandlerCount do

--- a/units/Goccia.Values.Primitives.pas
+++ b/units/Goccia.Values.Primitives.pas
@@ -167,6 +167,7 @@ uses
 
   Goccia.Constants,
   Goccia.Constants.TypeNames,
+  Goccia.Profiler,
   Goccia.TextFiles;
 
 { TGocciaValue }
@@ -176,6 +177,8 @@ begin
   inherited;
   if Assigned(TGarbageCollector.Instance) then
     TGarbageCollector.Instance.RegisterObject(Self);
+  if GProfilingAllocations and Assigned(TGocciaProfiler.Instance) then
+    TGocciaProfiler.Instance.RecordAllocation;
 end;
 
 function TGocciaValue.RuntimeCopy: TGocciaValue;


### PR DESCRIPTION
## Summary
- Added a bytecode profiling mode to `ScriptLoader` with `--profile=opcodes|functions|all` and `--profile-output=<file>`.
- Introduced profiler/runtime reporting units for opcode histograms, opcode pair frequency, scalar fast-path hit rate, function timing, and allocation counts.
- Documented the profiling workflow in new and updated docs, including `docs/profiling.md` and `docs/bytecode-vm.md`.

## Testing
- Expected verification path: `./build.pas testrunner && ./build/TestRunner tests`.
- For profiling smoke checks, run `./build/ScriptLoader <script> --profile=all` and `./build/ScriptLoader <script> --profile=all --profile-output=profile.json`.