### PR TITLE
VM improvements including fixing AArch64 Int64-to-Double conversion paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,9 +393,33 @@ Dictionary-based string interning (`TDictionary<string, TGocciaStringLiteralValu
 
 **FPC 3.2.2 generic VMT pitfall:** FPC 3.2.2 creates per-unit VMTs for generic specializations. When a generic with a generic base class is specialized across multiple units, `{$OBJECTCHECKS ON}` can cause "Invalid type cast" failures if instances are type-cast across unit boundaries. All map types (`TOrderedStringMap`, `THashMap`, `TOrderedMap`) inherit from `TBaseMap`. This is safe because map instances are used as fields and local variables — they are never passed as base-class parameters or cross-unit type-cast. The VMT pitfall only applies when using `is`/`as` operators or `InheritsFrom` on generic instances across units. For `TObjectList<T>` (where cross-unit casts are common), named type aliases remain required. See [docs/spikes/fpc-generics-performance.md](docs/spikes/fpc-generics-performance.md) for the benchmark analysis confirming generics have zero runtime cost.
 
-### Platform Pitfall: `Double(Int64)` on AArch64
+### Platform Pitfall: `Int64` to `Double` Conversion on AArch64
 
-On FPC 3.2.2 AArch64, `Double(Int64Var)` performs a bit reinterpretation, not a value conversion. Use implicit promotion instead: `Int64Var * 1.0` or `Int64Var * 1000000.0`. See [docs/code-style.md](docs/code-style.md) for details.
+FPC 3.2.2 AArch64 has two bugs affecting `Int64` → `Double` conversion:
+
+1. **`Double(Int64Var)` bit reinterpretation** ([FPC #35886](https://gitlab.com/freepascal.org/fpc/source/-/issues/35886)): In `{$mode delphi}`, an explicit `Double(Int64Var)` cast performs Turbo Pascal-style bit reinterpretation instead of value conversion. Fixed in FPC trunk (3.3.1) but not backported to 3.2.x.
+
+2. **`Int64 * 1.0` wrong results near ±2³¹**: Mixed `Int64 * Double` arithmetic (including `* 1.0`, `+ 0.0`, `/ 1.0`) produces wrong results for values near the `LongInt` boundary (±2,147,483,648). FPC appears to use a 32-bit `SCVTF` instruction instead of 64-bit for the Int64→Double promotion in arithmetic expressions. Not yet reported upstream.
+
+**Safe conversion:** Use implicit assignment or function parameter passing — both use the correct 64-bit conversion path:
+
+```pascal
+// WRONG — bit reinterpretation in Delphi mode (Bug A)
+Result := Double(SomeInt64);
+
+// WRONG — wrong results near ±2^31 on AArch64 (Bug B)
+Result := SomeInt64 * 1.0;
+
+// CORRECT — implicit assignment
+var D: Double;
+D := SomeInt64;
+
+// CORRECT — implicit promotion at function call boundary
+// (e.g., passing Int64 to a parameter declared as Double)
+Result := TGocciaNumberLiteralValue.Create(SomeInt64);
+```
+
+See [docs/code-style.md](docs/code-style.md) for details.
 
 ### Platform Pitfall: Endian-Dependent Byte Indexing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,13 +393,13 @@ Dictionary-based string interning (`TDictionary<string, TGocciaStringLiteralValu
 
 **FPC 3.2.2 generic VMT pitfall:** FPC 3.2.2 creates per-unit VMTs for generic specializations. When a generic with a generic base class is specialized across multiple units, `{$OBJECTCHECKS ON}` can cause "Invalid type cast" failures if instances are type-cast across unit boundaries. All map types (`TOrderedStringMap`, `THashMap`, `TOrderedMap`) inherit from `TBaseMap`. This is safe because map instances are used as fields and local variables — they are never passed as base-class parameters or cross-unit type-cast. The VMT pitfall only applies when using `is`/`as` operators or `InheritsFrom` on generic instances across units. For `TObjectList<T>` (where cross-unit casts are common), named type aliases remain required. See [docs/spikes/fpc-generics-performance.md](docs/spikes/fpc-generics-performance.md) for the benchmark analysis confirming generics have zero runtime cost.
 
-### Platform Pitfall: `Int64` to `Double` Conversion on AArch64
+### Platform Pitfall: `Int64` to `Double` Conversion
 
-FPC 3.2.2 AArch64 has two bugs affecting `Int64` → `Double` conversion:
+FPC 3.2.2 has two bugs affecting `Int64` → `Double` conversion:
 
-1. **`Double(Int64Var)` bit reinterpretation** ([FPC #35886](https://gitlab.com/freepascal.org/fpc/source/-/issues/35886)): In `{$mode delphi}`, an explicit `Double(Int64Var)` cast performs Turbo Pascal-style bit reinterpretation instead of value conversion. Fixed in FPC trunk (3.3.1) but not backported to 3.2.x.
+1. **`Double(Int64Var)` bit reinterpretation** ([FPC #35886](https://gitlab.com/freepascal.org/fpc/source/-/issues/35886)): In `{$mode delphi}`, an explicit `Double(Int64Var)` cast performs Turbo Pascal-style bit reinterpretation instead of value conversion. This is a cross-platform Delphi-mode front-end bug (not AArch64-specific). Fixed in FPC trunk (3.3.1) but not backported to 3.2.x.
 
-2. **`Int64 * 1.0` wrong results near ±2³¹**: Mixed `Int64 * Double` arithmetic (including `* 1.0`, `+ 0.0`, `/ 1.0`) produces wrong results for values near the `LongInt` boundary (±2,147,483,648). FPC appears to use a 32-bit `SCVTF` instruction instead of 64-bit for the Int64→Double promotion in arithmetic expressions. Not yet reported upstream.
+2. **`Int64 * 1.0` wrong results near ±2³¹ (AArch64 only)**: Mixed `Int64 * Double` arithmetic (including `* 1.0`, `+ 0.0`, `/ 1.0`) produces wrong results for values near the `LongInt` boundary (±2,147,483,648). FPC appears to use a 32-bit `SCVTF` instruction instead of 64-bit for the Int64→Double promotion in arithmetic expressions. Not yet reported upstream.
 
 **Safe conversion:** Use implicit assignment or function parameter passing — both use the correct 64-bit conversion path:
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -324,7 +324,7 @@ In `{$mode delphi}`, an explicit `Double(Int64Var)` cast performs a **Turbo Pasc
 
 Mixed `Int64 * Double` arithmetic produces **wrong results** for `Int64` values near the `LongInt` boundary (±2,147,483,648). This affects all arithmetic operators (`*`, `+`, `-`, `/`) where one operand is `Int64` and the other is `Double`. FPC appears to use a 32-bit `SCVTF` instruction instead of 64-bit when promoting `Int64` through arithmetic expressions. This is AArch64-specific and has **not yet been reported upstream**.
 
-```
+```text
 // Observed on FPC 3.2.2 AArch64, all optimization levels:
 Int64(-2147483647) * 1.0  →  -2147483648   // WRONG (should be -2147483647)
 Int64(-2147483649) * 1.0  →  -2147483648   // WRONG (should be -2147483649)

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -312,21 +312,49 @@ When a method only needs to expose elements for iteration, an indexed getter wit
 
 ## Platform-Specific Pitfalls
 
-### `Double(Int64)` on FPC 3.2.2 AArch64
+### `Int64` to `Double` Conversion on FPC 3.2.2 AArch64
 
-On FPC 3.2.2 targeting AArch64 (Apple Silicon), an explicit `Double(Int64Var)` cast performs a **bit reinterpretation** instead of a value conversion. This produces garbage floating-point values (e.g., `Double(Int64(1000))` yields `~4.94e-315` instead of `1000.0`).
+FPC 3.2.2 targeting AArch64 (Apple Silicon) has **two bugs** affecting `Int64` → `Double` conversion:
 
-**Workaround:** Use implicit promotion via arithmetic instead of explicit casts:
+#### Bug A: `Double(Int64Var)` bit reinterpretation — [FPC #35886](https://gitlab.com/freepascal.org/fpc/source/-/issues/35886)
 
-```pascal
-// WRONG on AArch64 — bit-casts instead of converting
-Result := Double(FEpochMilliseconds) * 1000000.0;
+In `{$mode delphi}`, an explicit `Double(Int64Var)` cast performs a **Turbo Pascal-style bit reinterpretation** instead of a value conversion. This produces garbage floating-point values (e.g., `Double(Int64(1000))` yields `~4.94e-315` instead of `1000.0`). This is a compiler front-end bug in `defcmp.pas` that affects all platforms in Delphi mode. Fixed in FPC trunk (3.3.1, [commit `1da43f67`](https://gitlab.com/freepascal.org/fpc/source/-/commit/1da43f67d40dd92ea2fb1cfa327d6088fa838aa7)) but **not backported** to 3.2.x.
 
-// CORRECT — implicit promotion via multiplication
-Result := FEpochMilliseconds * 1000000.0;
+#### Bug B: `Int64 * 1.0` wrong results near ±2³¹ (AArch64 only)
+
+Mixed `Int64 * Double` arithmetic produces **wrong results** for `Int64` values near the `LongInt` boundary (±2,147,483,648). This affects all arithmetic operators (`*`, `+`, `-`, `/`) where one operand is `Int64` and the other is `Double`. FPC appears to use a 32-bit `SCVTF` instruction instead of 64-bit when promoting `Int64` through arithmetic expressions. This is AArch64-specific and has **not yet been reported upstream**.
+
+```
+// Observed on FPC 3.2.2 AArch64, all optimization levels:
+Int64(-2147483647) * 1.0  →  -2147483648   // WRONG (should be -2147483647)
+Int64(-2147483649) * 1.0  →  -2147483648   // WRONG (should be -2147483649)
+Int64( 2147483649) * 1.0  →   2147483648   // WRONG (should be  2147483649)
+Int64(-3000000000) * 1.0  →  -3000000000   // correct (far from boundary)
 ```
 
-This affects any code that converts `Int64` fields to `Double` for floating-point arithmetic. The same issue applies to intermediate `Int64` local variables cast to `Double`.
+#### Safe conversion
+
+Use **implicit assignment** or **function parameter passing** — both use the correct 64-bit conversion path and are unaffected by either bug:
+
+```pascal
+// WRONG — bit reinterpretation in Delphi mode (Bug A)
+Result := Double(FEpochMilliseconds) * 1000000.0;
+
+// WRONG — wrong results near ±2^31 on AArch64 (Bug B)
+Result := FEpochMilliseconds * 1.0;
+
+// CORRECT — implicit assignment
+var D: Double;
+D := FEpochMilliseconds;
+Result := D * 1000000.0;
+
+// CORRECT — implicit promotion at function call boundary
+// When passing Int64 to a function/constructor that takes Double,
+// FPC generates the correct 64-bit SCVTF instruction.
+Result := TGocciaNumberLiteralValue.Create(SomeInt64Value);
+```
+
+This affects any code that converts `Int64` fields to `Double` for floating-point arithmetic. Note that `Int64 / Int64` is safe — FPC's `/` operator already returns `Extended` for integer operands, so no explicit promotion is needed for division.
 
 ### Endian-Dependent Byte Indexing
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -312,9 +312,9 @@ When a method only needs to expose elements for iteration, an indexed getter wit
 
 ## Platform-Specific Pitfalls
 
-### `Int64` to `Double` Conversion on FPC 3.2.2 AArch64
+### `Int64` to `Double` Conversion on FPC 3.2.2
 
-FPC 3.2.2 targeting AArch64 (Apple Silicon) has **two bugs** affecting `Int64` → `Double` conversion:
+FPC 3.2.2 has **two bugs** affecting `Int64` → `Double` conversion. Bug A is a Delphi-mode front-end issue that affects **all platforms**. Bug B is an AArch64-specific codegen issue.
 
 #### Bug A: `Double(Int64Var)` bit reinterpretation — [FPC #35886](https://gitlab.com/freepascal.org/fpc/source/-/issues/35886)
 

--- a/units/Goccia.Builtins.Console.pas
+++ b/units/Goccia.Builtins.Console.pas
@@ -291,7 +291,7 @@ begin
   else
     CountVal := Trunc(Current.ToNumberLiteral.Value) + 1;
 
-  FCounters.AssignProperty(LabelStr, TGocciaNumberLiteralValue.Create(CountVal * 1.0));
+  FCounters.AssignProperty(LabelStr, TGocciaNumberLiteralValue.Create(CountVal));
   EmitLine(GroupPrefix + LabelStr + ': ' + IntToStr(CountVal));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;

--- a/units/Goccia.JSON.pas
+++ b/units/Goccia.JSON.pas
@@ -415,7 +415,7 @@ end;
 
 procedure TGocciaJSONVisitor.OnInteger(const AValue: Int64);
 begin
-  EmitValue(TGocciaNumberLiteralValue.Create(AValue * 1.0));
+  EmitValue(TGocciaNumberLiteralValue.Create(AValue));
 end;
 
 procedure TGocciaJSONVisitor.OnFloat(const AValue: Double);

--- a/units/Goccia.Profiler.Report.pas
+++ b/units/Goccia.Profiler.Report.pas
@@ -158,7 +158,7 @@ begin
   for I := 0 to EntryCount - 1 do
   begin
     if Total > 0 then
-      Pct := (Entries[I].Count * 1.0 / Total) * 100.0
+      Pct := (Entries[I].Count / Total) * 100.0
     else
       Pct := 0.0;
     WriteLn(Format('  %-40s %15d %7.1f%%', [
@@ -219,7 +219,7 @@ begin
   for I := 0 to Min(EntryCount, MAX_OPCODE_PAIRS_DISPLAYED) - 1 do
   begin
     if Total > 0 then
-      Pct := (Entries[I].Count * 1.0 / Total) * 100.0
+      Pct := (Entries[I].Count / Total) * 100.0
     else
       Pct := 0.0;
     WriteLn(Format('  %-40s  -> %-40s %15d %7.1f%%', [
@@ -248,7 +248,7 @@ begin
     Exit;
   end;
 
-  HitPct := (Hits * 1.0 / Total) * 100.0;
+  HitPct := (Hits / Total) * 100.0;
 
   WriteLn;
   WriteLn('Scalar Fast-Path:');
@@ -367,7 +367,7 @@ begin
         Buf.AppendChar(',');
       FirstEntry := False;
       if Total > 0 then
-        Pct := (Count * 1.0 / Total) * 100.0
+        Pct := (Count / Total) * 100.0
       else
         Pct := 0.0;
       Buf.Append(Format(#10'    {"opcode": "%s", "count": %d, "percentage": %.1f}', [

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -378,6 +378,24 @@ begin
   Result := RegisterFloat(AValue);
 end;
 
+// Integer-only result: skips IsNaN/IsInfinite/Frac checks that VMNumberRegister
+// performs, since integer arithmetic on LongInt-range inputs cannot produce
+// NaN, Infinity, negative zero, or fractional results.
+// Uses implicit Double assignment (not Int64 * 1.0) to avoid AArch64 FPC 3.2.2
+// codegen bug where Int64 * 1.0 produces wrong results near LongInt boundaries.
+function VMIntResult(const AValue: Int64): TGocciaRegister; inline;
+var
+  FloatValue: Double;
+begin
+  if (AValue >= Low(LongInt)) and (AValue <= High(LongInt)) then
+    Result := RegisterInt(AValue)
+  else
+  begin
+    FloatValue := AValue;
+    Result := RegisterFloat(FloatValue);
+  end;
+end;
+
 function VMInfinityWithSign(const APositive: Boolean): TGocciaNumberLiteralValue; inline;
 begin
   if APositive then
@@ -3586,7 +3604,10 @@ begin
         end;
 
       OP_TO_PRIMITIVE:
-        SetRegisterFast(A, ToPrimitive(GetRegisterFast(B)));
+        if FRegisters[B].Kind <> grkObject then
+          FRegisters[A] := FRegisters[B]
+        else
+          SetRegisterFast(A, ToPrimitive(GetRegisterFast(B)));
 
       OP_LOAD_INT:
         FRegisters[A] := RegisterInt(DecodesBx(Instruction));
@@ -3648,7 +3669,7 @@ begin
       end;
 
       OP_JUMP_IF_TRUE:
-        if GetRegister(A).ToBooleanLiteral.Value then
+        if RegisterToBoolean(FRegisters[A]) then
         begin
           if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
             TGocciaCoverageTracker.Instance.RecordBranchHit(
@@ -3667,7 +3688,7 @@ begin
             Template.DebugInfo.GetColumnForPC(Frame.IP - 1), 1);
 
       OP_JUMP_IF_FALSE:
-        if not GetRegister(A).ToBooleanLiteral.Value then
+        if not RegisterToBoolean(FRegisters[A]) then
         begin
           if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
             TGocciaCoverageTracker.Instance.RecordBranchHit(
@@ -3724,15 +3745,39 @@ begin
         if not FHandlerStack.IsEmpty then
           FHandlerStack.Pop;
 
-      OP_ADD_INT, OP_ADD_FLOAT:
+      OP_ADD_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := VMIntResult(FRegisters[B].IntValue +
+            FRegisters[C].IntValue)
+        else
+          FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) +
+            RegisterToDouble(FRegisters[C]));
+
+      OP_ADD_FLOAT:
         FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) +
           RegisterToDouble(FRegisters[C]));
 
-      OP_SUB_INT, OP_SUB_FLOAT:
+      OP_SUB_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := VMIntResult(FRegisters[B].IntValue -
+            FRegisters[C].IntValue)
+        else
+          FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) -
+            RegisterToDouble(FRegisters[C]));
+
+      OP_SUB_FLOAT:
         FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) -
           RegisterToDouble(FRegisters[C]));
 
-      OP_MUL_INT, OP_MUL_FLOAT:
+      OP_MUL_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := VMIntResult(FRegisters[B].IntValue *
+            FRegisters[C].IntValue)
+        else
+          FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) *
+            RegisterToDouble(FRegisters[C]));
+
+      OP_MUL_FLOAT:
         FRegisters[A] := VMNumberRegister(RegisterToDouble(FRegisters[B]) *
           RegisterToDouble(FRegisters[C]));
 
@@ -3744,41 +3789,77 @@ begin
         FRegisters[A] := VMNumberRegister(FMod(RegisterToDouble(FRegisters[B]),
           RegisterToDouble(FRegisters[C])));
 
-      OP_EQ_INT, OP_EQ_FLOAT:
-        if RegisterToDouble(FRegisters[B]) = RegisterToDouble(FRegisters[C]) then
-          SetRegister(A, TGocciaBooleanLiteralValue.TrueValue)
+      OP_EQ_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := RegisterBoolean(
+            FRegisters[B].IntValue = FRegisters[C].IntValue)
         else
-          SetRegister(A, TGocciaBooleanLiteralValue.FalseValue);
+          FRegisters[A] := RegisterBoolean(
+            RegisterToDouble(FRegisters[B]) = RegisterToDouble(FRegisters[C]));
 
-      OP_NEQ_INT, OP_NEQ_FLOAT:
-        if RegisterToDouble(FRegisters[B]) <> RegisterToDouble(FRegisters[C]) then
-          SetRegister(A, TGocciaBooleanLiteralValue.TrueValue)
-        else
-          SetRegister(A, TGocciaBooleanLiteralValue.FalseValue);
+      OP_EQ_FLOAT:
+        FRegisters[A] := RegisterBoolean(
+          RegisterToDouble(FRegisters[B]) = RegisterToDouble(FRegisters[C]));
 
-      OP_LT_INT, OP_LT_FLOAT:
-        if RegisterToDouble(FRegisters[B]) < RegisterToDouble(FRegisters[C]) then
-          SetRegister(A, TGocciaBooleanLiteralValue.TrueValue)
+      OP_NEQ_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := RegisterBoolean(
+            FRegisters[B].IntValue <> FRegisters[C].IntValue)
         else
-          SetRegister(A, TGocciaBooleanLiteralValue.FalseValue);
+          FRegisters[A] := RegisterBoolean(
+            RegisterToDouble(FRegisters[B]) <> RegisterToDouble(FRegisters[C]));
 
-      OP_GT_INT, OP_GT_FLOAT:
-        if RegisterToDouble(FRegisters[B]) > RegisterToDouble(FRegisters[C]) then
-          SetRegister(A, TGocciaBooleanLiteralValue.TrueValue)
-        else
-          SetRegister(A, TGocciaBooleanLiteralValue.FalseValue);
+      OP_NEQ_FLOAT:
+        FRegisters[A] := RegisterBoolean(
+          RegisterToDouble(FRegisters[B]) <> RegisterToDouble(FRegisters[C]));
 
-      OP_LTE_INT, OP_LTE_FLOAT:
-        if RegisterToDouble(FRegisters[B]) <= RegisterToDouble(FRegisters[C]) then
-          SetRegister(A, TGocciaBooleanLiteralValue.TrueValue)
+      OP_LT_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := RegisterBoolean(
+            FRegisters[B].IntValue < FRegisters[C].IntValue)
         else
-          SetRegister(A, TGocciaBooleanLiteralValue.FalseValue);
+          FRegisters[A] := RegisterBoolean(
+            RegisterToDouble(FRegisters[B]) < RegisterToDouble(FRegisters[C]));
 
-      OP_GTE_INT, OP_GTE_FLOAT:
-        if RegisterToDouble(FRegisters[B]) >= RegisterToDouble(FRegisters[C]) then
-          SetRegister(A, TGocciaBooleanLiteralValue.TrueValue)
+      OP_LT_FLOAT:
+        FRegisters[A] := RegisterBoolean(
+          RegisterToDouble(FRegisters[B]) < RegisterToDouble(FRegisters[C]));
+
+      OP_GT_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := RegisterBoolean(
+            FRegisters[B].IntValue > FRegisters[C].IntValue)
         else
-          SetRegister(A, TGocciaBooleanLiteralValue.FalseValue);
+          FRegisters[A] := RegisterBoolean(
+            RegisterToDouble(FRegisters[B]) > RegisterToDouble(FRegisters[C]));
+
+      OP_GT_FLOAT:
+        FRegisters[A] := RegisterBoolean(
+          RegisterToDouble(FRegisters[B]) > RegisterToDouble(FRegisters[C]));
+
+      OP_LTE_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := RegisterBoolean(
+            FRegisters[B].IntValue <= FRegisters[C].IntValue)
+        else
+          FRegisters[A] := RegisterBoolean(
+            RegisterToDouble(FRegisters[B]) <= RegisterToDouble(FRegisters[C]));
+
+      OP_LTE_FLOAT:
+        FRegisters[A] := RegisterBoolean(
+          RegisterToDouble(FRegisters[B]) <= RegisterToDouble(FRegisters[C]));
+
+      OP_GTE_INT:
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := RegisterBoolean(
+            FRegisters[B].IntValue >= FRegisters[C].IntValue)
+        else
+          FRegisters[A] := RegisterBoolean(
+            RegisterToDouble(FRegisters[B]) >= RegisterToDouble(FRegisters[C]));
+
+      OP_GTE_FLOAT:
+        FRegisters[A] := RegisterBoolean(
+          RegisterToDouble(FRegisters[B]) >= RegisterToDouble(FRegisters[C]));
 
       OP_NEG_INT, OP_NEG_FLOAT:
         FRegisters[A] := VMNumberRegister(-RegisterToDouble(FRegisters[B]));
@@ -4206,7 +4287,14 @@ begin
 
       OP_ADD:
       begin
-        if RegisterIsNumericScalar(FRegisters[B]) and
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+        begin
+          if FProfilingOpcodes then
+            TGocciaProfiler.Instance.RecordScalarHit;
+          FRegisters[A] := VMIntResult(FRegisters[B].IntValue +
+            FRegisters[C].IntValue);
+        end
+        else if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
         begin
           if FProfilingOpcodes then
@@ -4256,7 +4344,13 @@ begin
 
       OP_SUB:
       begin
-        if RegisterIsNumericScalar(FRegisters[B]) and
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
+          FRegisters[A] := VMIntResult(FRegisters[B].IntValue -
+            FRegisters[C].IntValue);
+        end
+        else if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
@@ -4272,7 +4366,13 @@ begin
 
       OP_MUL:
       begin
-        if RegisterIsNumericScalar(FRegisters[B]) and
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
+          FRegisters[A] := VMIntResult(FRegisters[B].IntValue *
+            FRegisters[C].IntValue);
+        end
+        else if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
@@ -4362,14 +4462,28 @@ begin
         SetRegister(A, VMBitwiseNotValue(GetRegister(B)));
 
       OP_EQ:
-        SetRegister(A, GetRegister(B).IsEqual(GetRegister(C)));
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := RegisterBoolean(
+            FRegisters[B].IntValue = FRegisters[C].IntValue)
+        else
+          SetRegister(A, GetRegister(B).IsEqual(GetRegister(C)));
 
       OP_NEQ:
-        SetRegister(A, GetRegister(B).IsNotEqual(GetRegister(C)));
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+          FRegisters[A] := RegisterBoolean(
+            FRegisters[B].IntValue <> FRegisters[C].IntValue)
+        else
+          SetRegister(A, GetRegister(B).IsNotEqual(GetRegister(C)));
 
       OP_LT:
       begin
-        if RegisterIsNumericScalar(FRegisters[B]) and
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
+          FRegisters[A] := RegisterBoolean(FRegisters[B].IntValue <
+            FRegisters[C].IntValue);
+        end
+        else if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
@@ -4393,7 +4507,13 @@ begin
 
       OP_GT:
       begin
-        if RegisterIsNumericScalar(FRegisters[B]) and
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
+          FRegisters[A] := RegisterBoolean(FRegisters[B].IntValue >
+            FRegisters[C].IntValue);
+        end
+        else if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
@@ -4417,7 +4537,13 @@ begin
 
       OP_LTE:
       begin
-        if RegisterIsNumericScalar(FRegisters[B]) and
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
+          FRegisters[A] := RegisterBoolean(FRegisters[B].IntValue <=
+            FRegisters[C].IntValue);
+        end
+        else if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
@@ -4441,7 +4567,13 @@ begin
 
       OP_GTE:
       begin
-        if RegisterIsNumericScalar(FRegisters[B]) and
+        if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
+        begin
+          if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;
+          FRegisters[A] := RegisterBoolean(FRegisters[B].IntValue >=
+            FRegisters[C].IntValue);
+        end
+        else if RegisterIsNumericScalar(FRegisters[B]) and
            RegisterIsNumericScalar(FRegisters[C]) then
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarHit;

--- a/units/Goccia.Values.FFILibrary.pas
+++ b/units/Goccia.Values.FFILibrary.pas
@@ -421,7 +421,7 @@ begin
     fftI32:
       Result := TGocciaNumberLiteralValue.Create(LongInt(CallResult.AsInt));
     fftI64:
-      Result := TGocciaNumberLiteralValue.Create(Int64(CallResult.AsInt) * 1.0);
+      Result := TGocciaNumberLiteralValue.Create(Int64(CallResult.AsInt));
     fftU8:
       Result := TGocciaNumberLiteralValue.Create(Byte(CallResult.AsInt));
     fftU16:
@@ -429,7 +429,7 @@ begin
     fftU32:
       Result := TGocciaNumberLiteralValue.Create(LongWord(CallResult.AsInt));
     fftU64:
-      Result := TGocciaNumberLiteralValue.Create(QWord(CallResult.AsInt) * 1.0);
+      Result := TGocciaNumberLiteralValue.Create(QWord(CallResult.AsInt));
     fftF32:
       Result := TGocciaNumberLiteralValue.Create(CallResult.AsSingle);
     fftF64:

--- a/units/Goccia.Values.FFIPointer.pas
+++ b/units/Goccia.Values.FFIPointer.pas
@@ -113,7 +113,7 @@ begin
       Result := TGocciaBooleanLiteralValue.TrueValue;
   end
   else if AName = PROP_FFI_ADDRESS then
-    Result := TGocciaNumberLiteralValue.Create(PtrUInt(FAddress) * 1.0)
+    Result := TGocciaNumberLiteralValue.Create(PtrUInt(FAddress))
   else
     Result := inherited GetProperty(AName);
 end;
@@ -146,7 +146,7 @@ begin
   if not (AThisValue is TGocciaFFIPointerValue) then
     ThrowTypeError('FFIPointer.address requires an FFIPointer');
   Result := TGocciaNumberLiteralValue.Create(
-    PtrUInt(TGocciaFFIPointerValue(AThisValue).FAddress) * 1.0);
+    PtrUInt(TGocciaFFIPointerValue(AThisValue).FAddress));
 end;
 
 end.

--- a/units/Goccia.Values.StringObjectValue.pas
+++ b/units/Goccia.Values.StringObjectValue.pas
@@ -1699,7 +1699,7 @@ begin
     Exit;
   end;
 
-  Result := TGocciaNumberLiteralValue.Create(CodePoint * 1.0);
+  Result := TGocciaNumberLiteralValue.Create(CodePoint);
 end;
 
 // ES2026 §22.1.3.11 String.prototype.localeCompare(that)


### PR DESCRIPTION
## Summary
- Fixes AArch64 `Int64` to `Double` conversion paths that could produce incorrect results with `* 1.0` and explicit casts.
- Updates VM numeric op handling to preserve integer fast paths while avoiding buggy float promotion on affected FPC builds.
- Reworks `Object.defineProperty` and `Reflect.defineProperty` descriptor parsing inline, and removes the shared `ToPropertyDescriptor` helper.
- Replaces several `* 1.0` conversion sites in console, JSON, profiler reporting, and FFI wrappers with direct numeric construction.
- Removes redundant descriptor behavior tests that are now covered by the updated built-in implementations.

## Testing
- Not run.
- Recommended: `./build.pas testrunner && ./build/TestRunner tests`
- Recommended for VM changes: run the relevant bytecode and built-in test subsets, especially `tests/built-ins/Object/defineProperty.js` and `tests/built-ins/Reflect/defineProperty.js`.