### PR TITLE
Thread optional receiver through Reflect.get and Reflect.set

### DIFF
--- a/tests/built-ins/Reflect/get.js
+++ b/tests/built-ins/Reflect/get.js
@@ -38,4 +38,54 @@ describe("Reflect.get", () => {
     expect(() => Reflect.get(null, "x")).toThrow(TypeError);
     expect(() => Reflect.get(undefined, "x")).toThrow(TypeError);
   });
+
+  test("receiver defaults to target for data properties", () => {
+    const obj = { x: 10 };
+    // When receiver is omitted, should behave identically
+    expect(Reflect.get(obj, "x")).toBe(10);
+    // Explicitly passing target as receiver
+    expect(Reflect.get(obj, "x", obj)).toBe(10);
+  });
+
+  test("receiver is passed as this to getter", () => {
+    const target = {};
+    Object.defineProperty(target, "value", {
+      get() { return this.x; },
+      configurable: true,
+    });
+    const receiver = { x: 42 };
+    // Without receiver: this === target, target.x is undefined
+    expect(Reflect.get(target, "value")).toBe(undefined);
+    // With receiver: this === receiver, receiver.x is 42
+    expect(Reflect.get(target, "value", receiver)).toBe(42);
+  });
+
+  test("receiver is threaded through prototype chain getters", () => {
+    const proto = {};
+    Object.defineProperty(proto, "name", {
+      get() { return this.label; },
+      configurable: true,
+    });
+    const target = Object.create(proto);
+    const receiver = { label: "from-receiver" };
+    expect(Reflect.get(target, "name", receiver)).toBe("from-receiver");
+  });
+
+  test("receiver with symbol-keyed getter", () => {
+    const sym = Symbol("val");
+    const target = {};
+    Object.defineProperty(target, sym, {
+      get() { return this.data; },
+      configurable: true,
+    });
+    const receiver = { data: "symbol-receiver" };
+    expect(Reflect.get(target, sym, receiver)).toBe("symbol-receiver");
+  });
+
+  test("receiver does not affect data properties", () => {
+    const target = { x: 100 };
+    const receiver = { x: 999 };
+    // Data properties return the target's value regardless of receiver
+    expect(Reflect.get(target, "x", receiver)).toBe(100);
+  });
 });

--- a/tests/built-ins/Reflect/set.js
+++ b/tests/built-ins/Reflect/set.js
@@ -35,4 +35,129 @@ describe("Reflect.set", () => {
     expect(() => Reflect.set("str", "x", 1)).toThrow(TypeError);
     expect(() => Reflect.set(null, "x", 1)).toThrow(TypeError);
   });
+
+  test("receiver is passed as this to setter", () => {
+    let setterThis = null;
+    const target = {};
+    Object.defineProperty(target, "value", {
+      set(v) { setterThis = this; },
+      configurable: true,
+    });
+    const receiver = { id: "receiver-obj" };
+    Reflect.set(target, "value", 42, receiver);
+    expect(setterThis).toBe(receiver);
+  });
+
+  test("setter receives value with correct receiver this", () => {
+    let captured = {};
+    const target = {};
+    Object.defineProperty(target, "x", {
+      set(v) {
+        captured.thisId = this.id;
+        captured.value = v;
+      },
+      configurable: true,
+    });
+    const receiver = { id: "recv" };
+    Reflect.set(target, "x", 99, receiver);
+    expect(captured.thisId).toBe("recv");
+    expect(captured.value).toBe(99);
+  });
+
+  test("data property write lands on receiver, not target", () => {
+    const target = { x: 1 };
+    const receiver = {};
+    const result = Reflect.set(target, "x", 42, receiver);
+    expect(result).toBe(true);
+    // Value should be written to receiver, not target
+    expect(receiver.x).toBe(42);
+    // Target should be unchanged
+    expect(target.x).toBe(1);
+  });
+
+  test("inherited setter invoked with receiver as this", () => {
+    let setterThis = null;
+    const proto = {};
+    Object.defineProperty(proto, "prop", {
+      set(v) { setterThis = this; },
+      configurable: true,
+    });
+    const target = Object.create(proto);
+    const receiver = { id: "the-receiver" };
+    Reflect.set(target, "prop", "val", receiver);
+    expect(setterThis).toBe(receiver);
+  });
+
+  test("returns false for non-writable data property", () => {
+    const target = {};
+    Object.defineProperty(target, "x", {
+      value: 10,
+      writable: false,
+      configurable: true,
+    });
+    const result = Reflect.set(target, "x", 99);
+    expect(result).toBe(false);
+  });
+
+  test("returns false when receiver has accessor for data property key", () => {
+    const target = { x: 1 };
+    const receiver = {};
+    Object.defineProperty(receiver, "x", {
+      get() { return 0; },
+      configurable: true,
+    });
+    // Target has data property, but receiver has an accessor for same key
+    const result = Reflect.set(target, "x", 42, receiver);
+    expect(result).toBe(false);
+  });
+
+  test("returns false when receiver has non-writable own property", () => {
+    const target = { x: 1 };
+    const receiver = {};
+    Object.defineProperty(receiver, "x", {
+      value: 0,
+      writable: false,
+      configurable: true,
+    });
+    const result = Reflect.set(target, "x", 42, receiver);
+    expect(result).toBe(false);
+  });
+
+  test("creates new property on receiver when absent", () => {
+    const proto = { x: 10 };
+    const target = Object.create(proto);
+    const receiver = {};
+    const result = Reflect.set(target, "x", 42, receiver);
+    expect(result).toBe(true);
+    expect(receiver.x).toBe(42);
+    // Proto should be unchanged
+    expect(proto.x).toBe(10);
+  });
+
+  test("receiver defaults to target when omitted", () => {
+    const obj = {};
+    Reflect.set(obj, "x", 42);
+    expect(obj.x).toBe(42);
+  });
+
+  test("receiver with symbol-keyed setter", () => {
+    let setterThis = null;
+    const sym = Symbol("val");
+    const target = {};
+    Object.defineProperty(target, sym, {
+      set(v) { setterThis = this; },
+      configurable: true,
+    });
+    const receiver = { tag: "sym-receiver" };
+    Reflect.set(target, sym, 99, receiver);
+    expect(setterThis).toBe(receiver);
+  });
+
+  test("returns false for non-extensible receiver when creating property", () => {
+    const target = {};
+    const receiver = {};
+    Object.preventExtensions(receiver);
+    const result = Reflect.set(target, "newProp", 42, receiver);
+    expect(result).toBe(false);
+  });
 });

--- a/units/Goccia.Builtins.GlobalReflect.pas
+++ b/units/Goccia.Builtins.GlobalReflect.pas
@@ -287,7 +287,7 @@ end;
 // ES2026 §28.1.5 Reflect.get(target, propertyKey [, receiver])
 function TGocciaGlobalReflect.ReflectGet(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Target, PropKey: TGocciaValue;
+  Target, PropKey, Receiver: TGocciaValue;
   PropertyName: string;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Reflect.get', ThrowError);
@@ -298,10 +298,18 @@ begin
   // Step 1: If target is not an Object, throw a TypeError exception
   RequireObjectTarget(Target, 'Reflect.get');
 
+  // Step 3: If receiver is not present, set receiver to target
+  if AArgs.Length >= 3 then
+    Receiver := AArgs.GetElement(2)
+  else
+    Receiver := Target;
+
   // Step 2: Let key be ? ToPropertyKey(propertyKey)
+  // Step 4: Return ? target.[[Get]](key, receiver)
   if PropKey is TGocciaSymbolValue then
   begin
-    Result := TGocciaObjectValue(Target).GetSymbolProperty(TGocciaSymbolValue(PropKey));
+    Result := TGocciaObjectValue(Target).GetSymbolPropertyWithReceiver(
+      TGocciaSymbolValue(PropKey), Receiver);
     if Result = nil then
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
@@ -309,8 +317,13 @@ begin
 
   PropertyName := PropKey.ToStringLiteral.Value;
 
-  // Step 3-4: Return ? target.[[Get]](key, receiver)
-  Result := TGocciaObjectValue(Target).GetProperty(PropertyName);
+  // When an explicit receiver is provided, use GetPropertyWithContext to thread
+  // the receiver through to accessor getters. Otherwise use virtual GetProperty
+  // for correct dispatch on subclasses (arrays handle length/indices specially).
+  if AArgs.Length >= 3 then
+    Result := TGocciaObjectValue(Target).GetPropertyWithContext(PropertyName, Receiver)
+  else
+    Result := TGocciaObjectValue(Target).GetProperty(PropertyName);
 end;
 
 // ES2026 §28.1.6 Reflect.getOwnPropertyDescriptor(target, propertyKey)
@@ -509,8 +522,9 @@ end;
 // ES2026 §28.1.12 Reflect.set(target, propertyKey, V [, receiver])
 function TGocciaGlobalReflect.ReflectSet(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Target, PropKey, Value: TGocciaValue;
+  Target, PropKey, Value, Receiver: TGocciaValue;
   PropertyName: string;
+  Success: Boolean;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 3, 'Reflect.set', ThrowError);
 
@@ -521,22 +535,28 @@ begin
   // Step 1: If target is not an Object, throw a TypeError exception
   RequireObjectTarget(Target, 'Reflect.set');
 
+  // Step 4: If receiver is not present, set receiver to target
+  if AArgs.Length >= 4 then
+    Receiver := AArgs.GetElement(3)
+  else
+    Receiver := Target;
+
   // Step 2: Let key be ? ToPropertyKey(propertyKey)
-  // Step 3-4: Return ? target.[[Set]](key, V, receiver)
-  try
-    if PropKey is TGocciaSymbolValue then
-      TGocciaObjectValue(Target).AssignSymbolProperty(
-        TGocciaSymbolValue(PropKey), Value)
-    else
-    begin
-      PropertyName := PropKey.ToStringLiteral.Value;
-      TGocciaObjectValue(Target).AssignProperty(PropertyName, Value);
-    end;
-    Result := TGocciaBooleanLiteralValue.TrueValue;
-  except
-    on TGocciaThrowValue do
-      Result := TGocciaBooleanLiteralValue.FalseValue;
+  // Step 3, 5: Return ? target.[[Set]](key, V, receiver)
+  if PropKey is TGocciaSymbolValue then
+    Success := TGocciaObjectValue(Target).AssignSymbolPropertyWithReceiver(
+      TGocciaSymbolValue(PropKey), Value, Receiver)
+  else
+  begin
+    PropertyName := PropKey.ToStringLiteral.Value;
+    Success := TGocciaObjectValue(Target).AssignPropertyWithReceiver(
+      PropertyName, Value, Receiver);
   end;
+
+  if Success then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
 end;
 
 // ES2026 §28.1.13 Reflect.setPrototypeOf(target, proto)

--- a/units/Goccia.Builtins.GlobalReflect.pas
+++ b/units/Goccia.Builtins.GlobalReflect.pas
@@ -317,13 +317,8 @@ begin
 
   PropertyName := PropKey.ToStringLiteral.Value;
 
-  // When an explicit receiver is provided, use GetPropertyWithContext to thread
-  // the receiver through to accessor getters. Otherwise use virtual GetProperty
-  // for correct dispatch on subclasses (arrays handle length/indices specially).
-  if AArgs.Length >= 3 then
-    Result := TGocciaObjectValue(Target).GetPropertyWithContext(PropertyName, Receiver)
-  else
-    Result := TGocciaObjectValue(Target).GetProperty(PropertyName);
+  // Step 4: Return ? target.[[Get]](key, receiver)
+  Result := TGocciaObjectValue(Target).GetPropertyWithContext(PropertyName, Receiver);
 end;
 
 // ES2026 §28.1.6 Reflect.getOwnPropertyDescriptor(target, propertyKey)

--- a/units/Goccia.Values.ArrayBufferValue.pas
+++ b/units/Goccia.Values.ArrayBufferValue.pas
@@ -30,6 +30,7 @@ type
     constructor Create(const AClass: TGocciaClassValue); overload;
 
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToStringTag: string; override;
 
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
@@ -167,10 +168,15 @@ end;
 
 function TGocciaArrayBufferValue.GetProperty(const AName: string): TGocciaValue;
 begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaArrayBufferValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
   if AName = PROP_BYTE_LENGTH then
     Result := TGocciaNumberLiteralValue.Create(Length(FData))
   else
-    Result := inherited GetProperty(AName);
+    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaArrayBufferValue.ToStringTag: string;

--- a/units/Goccia.Values.ArrayValue.pas
+++ b/units/Goccia.Values.ArrayValue.pas
@@ -47,6 +47,7 @@ type
     function SetElement(const AIndex: Integer; const AValue: TGocciaValue): Boolean;
     function TypeName: string; override;
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); override;
     function HasOwnProperty(const AName: string): Boolean; override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
@@ -1664,6 +1665,11 @@ begin
 end;
 
 function TGocciaArrayValue.GetProperty(const AName: string): TGocciaValue;
+begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaArrayValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 var
   Index: Integer;
 begin
@@ -1689,7 +1695,7 @@ begin
   else
   begin
     // Fall back to regular object property lookup
-    Result := inherited GetProperty(AName);
+    Result := inherited GetPropertyWithContext(AName, AThisContext);
   end;
 end;
 

--- a/units/Goccia.Values.BooleanObjectValue.pas
+++ b/units/Goccia.Values.BooleanObjectValue.pas
@@ -23,6 +23,7 @@ type
     constructor Create(const APrimitive: TGocciaBooleanLiteralValue; const AClass: TGocciaClassValue = nil);
     procedure InitializePrototype;
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     procedure MarkReferences; override;
 
     class function GetSharedPrototype: TGocciaObjectValue;
@@ -79,12 +80,17 @@ end;
 
 function TGocciaBooleanObjectValue.GetProperty(const AName: string): TGocciaValue;
 begin
-  Result := inherited GetProperty(AName);
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaBooleanObjectValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
+  Result := inherited GetPropertyWithContext(AName, AThisContext);
   if not (Result is TGocciaUndefinedLiteralValue) then
     Exit;
 
   if Assigned(FSharedBooleanPrototype) then
-    Result := FSharedBooleanPrototype.GetPropertyWithContext(AName, Self);
+    Result := FSharedBooleanPrototype.GetPropertyWithContext(AName, AThisContext);
 end;
 
 class function TGocciaBooleanObjectValue.GetSharedPrototype: TGocciaObjectValue;

--- a/units/Goccia.Values.ClassValue.pas
+++ b/units/Goccia.Values.ClassValue.pas
@@ -184,6 +184,7 @@ type
     function TypeName: string; override;
     function ToStringLiteral: TGocciaStringLiteralValue; override;
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     procedure AssignProperty(const AName: string; const AValue: TGocciaValue; const ACanCreate: Boolean = True); override;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); override;
     function GetPrivateProperty(const AName: string; const AAccessClass: TGocciaClassValue): TGocciaValue;
@@ -1130,6 +1131,11 @@ begin
 end;
 
 function TGocciaInstanceValue.GetProperty(const AName: string): TGocciaValue;
+begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaInstanceValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 var
   Descriptor: TGocciaPropertyDescriptor;
   Args: TGocciaArgumentsCollection;
@@ -1147,7 +1153,7 @@ begin
         Args := TGocciaArgumentsCollection.CreateWithCapacity(0);
         try
           Result := TGocciaFunctionBase(TGocciaPropertyDescriptorAccessor(Descriptor).Getter)
-            .Call(Args, Self);
+            .Call(Args, AThisContext);
         finally
           Args.Free;
         end;
@@ -1160,10 +1166,10 @@ begin
     Exit;
   end;
 
-  // Check for getters/setters on the prototype with this instance as context
+  // Check for getters/setters on the prototype with the receiver as context
   if Assigned(FPrototype) then
   begin
-    Result := FPrototype.GetPropertyWithContext(AName, Self);
+    Result := FPrototype.GetPropertyWithContext(AName, AThisContext);
     if not (Result is TGocciaUndefinedLiteralValue) then
       Exit;
   end;

--- a/units/Goccia.Values.FFILibrary.pas
+++ b/units/Goccia.Values.FFILibrary.pas
@@ -32,6 +32,7 @@ type
     destructor Destroy; override;
 
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToStringTag: string; override;
     procedure MarkReferences; override;
 
@@ -502,6 +503,11 @@ end;
 
 function TGocciaFFILibraryValue.GetProperty(const AName: string): TGocciaValue;
 begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaFFILibraryValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
   if AName = PROP_FFI_PATH then
     Result := TGocciaStringLiteralValue.Create(FHandle.Path)
   else if AName = PROP_FFI_CLOSED then
@@ -512,7 +518,7 @@ begin
       Result := TGocciaBooleanLiteralValue.FalseValue;
   end
   else
-    Result := inherited GetProperty(AName);
+    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaFFILibraryValue.ToStringTag: string;

--- a/units/Goccia.Values.FFIPointer.pas
+++ b/units/Goccia.Values.FFIPointer.pas
@@ -32,6 +32,7 @@ type
     constructor Create(const AAddress: Pointer);
 
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToStringTag: string; override;
     procedure MarkReferences; override;
 
@@ -105,6 +106,11 @@ end;
 
 function TGocciaFFIPointerValue.GetProperty(const AName: string): TGocciaValue;
 begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaFFIPointerValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
   if AName = PROP_IS_NULL then
   begin
     if Assigned(FAddress) then
@@ -115,7 +121,7 @@ begin
   else if AName = PROP_FFI_ADDRESS then
     Result := TGocciaNumberLiteralValue.Create(PtrUInt(FAddress) * 1.0)
   else
-    Result := inherited GetProperty(AName);
+    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaFFIPointerValue.ToStringTag: string;

--- a/units/Goccia.Values.FunctionBase.pas
+++ b/units/Goccia.Values.FunctionBase.pas
@@ -38,6 +38,7 @@ type
 
     // Override GetProperty to provide call, apply, bind methods and length/name
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
 
     // Abstract method that subclasses must implement
     function Call(const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; virtual;
@@ -120,6 +121,11 @@ end;
 
 function TGocciaFunctionBase.GetProperty(const AName: string): TGocciaValue;
 begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaFunctionBase.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
   // ECMAScript: Function.length and Function.name
   if AName = PROP_LENGTH then
   begin
@@ -131,7 +137,7 @@ begin
     Result := TGocciaStringLiteralValue.Create(GetFunctionName);
     Exit;
   end;
-  Result := inherited GetProperty(AName);
+  Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaFunctionBase.GetFunctionLength: Integer;

--- a/units/Goccia.Values.MapValue.pas
+++ b/units/Goccia.Values.MapValue.pas
@@ -49,6 +49,7 @@ type
     procedure SetEntry(const AKey, AValue: TGocciaValue);
 
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToArray: TGocciaArrayValue;
     function ToStringTag: string; override;
 
@@ -208,10 +209,15 @@ end;
 
 function TGocciaMapValue.GetProperty(const AName: string): TGocciaValue;
 begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaMapValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
   if AName = PROP_SIZE then
     Result := TGocciaNumberLiteralValue.Create(FEntries.Count)
   else
-    Result := inherited GetProperty(AName);
+    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaMapValue.ToArray: TGocciaArrayValue;

--- a/units/Goccia.Values.NumberObjectValue.pas
+++ b/units/Goccia.Values.NumberObjectValue.pas
@@ -24,6 +24,7 @@ type
   public
     constructor Create(const APrimitive: TGocciaNumberLiteralValue; const AClass: TGocciaClassValue = nil);
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     procedure InitializePrototype;
     procedure MarkReferences; override;
 
@@ -73,12 +74,17 @@ end;
 
 function TGocciaNumberObjectValue.GetProperty(const AName: string): TGocciaValue;
 begin
-  Result := inherited GetProperty(AName);
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaNumberObjectValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
+  Result := inherited GetPropertyWithContext(AName, AThisContext);
   if not (Result is TGocciaUndefinedLiteralValue) then
     Exit;
 
   if Assigned(FSharedNumberPrototype) then
-    Result := FSharedNumberPrototype.GetPropertyWithContext(AName, Self);
+    Result := FSharedNumberPrototype.GetPropertyWithContext(AName, AThisContext);
 end;
 
 procedure TGocciaNumberObjectValue.InitializePrototype;

--- a/units/Goccia.Values.ObjectValue.pas
+++ b/units/Goccia.Values.ObjectValue.pas
@@ -50,14 +50,14 @@ type
 
     procedure DefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor); virtual;
     procedure AssignProperty(const AName: string; const AValue: TGocciaValue; const ACanCreate: Boolean = True); virtual;
-    function AssignPropertyWithReceiver(const AName: string; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean;
+    function AssignPropertyWithReceiver(const AName: string; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean; virtual;
 
     procedure RegisterNativeMethod(const AMethod: TGocciaValue);
     procedure RegisterConstant(const AName: string; const AValue: TGocciaValue);
 
     function GetProperty(const AName: string): TGocciaValue; override;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); override;
-    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; virtual;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; virtual;
     function HasProperty(const AName: string): Boolean;
     function HasOwnProperty(const AName: string): Boolean; virtual;
@@ -72,9 +72,9 @@ type
 
     procedure DefineSymbolProperty(const ASymbol: TGocciaSymbolValue; const ADescriptor: TGocciaPropertyDescriptor);
     procedure AssignSymbolProperty(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue);
-    function AssignSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean;
+    function AssignSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean; virtual;
     function GetSymbolProperty(const ASymbol: TGocciaSymbolValue): TGocciaValue; virtual;
-    function GetSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AReceiver: TGocciaValue): TGocciaValue;
+    function GetSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AReceiver: TGocciaValue): TGocciaValue; virtual;
     function GetOwnSymbolPropertyDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor;
     function HasSymbolProperty(const ASymbol: TGocciaSymbolValue): Boolean; virtual;
     function DeleteSymbolProperty(const ASymbol: TGocciaSymbolValue): Boolean;

--- a/units/Goccia.Values.ObjectValue.pas
+++ b/units/Goccia.Values.ObjectValue.pas
@@ -50,6 +50,7 @@ type
 
     procedure DefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor); virtual;
     procedure AssignProperty(const AName: string; const AValue: TGocciaValue; const ACanCreate: Boolean = True); virtual;
+    function AssignPropertyWithReceiver(const AName: string; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean;
 
     procedure RegisterNativeMethod(const AMethod: TGocciaValue);
     procedure RegisterConstant(const AName: string; const AValue: TGocciaValue);
@@ -71,6 +72,7 @@ type
 
     procedure DefineSymbolProperty(const ASymbol: TGocciaSymbolValue; const ADescriptor: TGocciaPropertyDescriptor);
     procedure AssignSymbolProperty(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue);
+    function AssignSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean;
     function GetSymbolProperty(const ASymbol: TGocciaSymbolValue): TGocciaValue; virtual;
     function GetSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AReceiver: TGocciaValue): TGocciaValue;
     function GetOwnSymbolPropertyDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor;
@@ -583,6 +585,84 @@ begin
     [pfEnumerable, pfConfigurable, pfWritable]));
 end;
 
+// ES2026 §10.1.9.2 OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc)
+function TGocciaObjectValue.AssignPropertyWithReceiver(const AName: string; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean;
+var
+  OwnDesc, ReceiverDesc: TGocciaPropertyDescriptor;
+  Accessor: TGocciaPropertyDescriptorAccessor;
+  Args: TGocciaArgumentsCollection;
+  ReceiverObj: TGocciaObjectValue;
+begin
+  // Step 1: Let ownDesc be O.[[GetOwnProperty]](P)
+  OwnDesc := GetOwnPropertyDescriptor(AName);
+
+  if OwnDesc = nil then
+  begin
+    // Step 1a-b: Walk prototype chain
+    if Assigned(FPrototype) then
+      Exit(FPrototype.AssignPropertyWithReceiver(AName, AValue, AReceiver));
+    // Step 1c: No prototype — treat as absent, create on receiver
+    if not (AReceiver is TGocciaObjectValue) then
+      Exit(False);
+    ReceiverObj := TGocciaObjectValue(AReceiver);
+    if not ReceiverObj.Extensible then
+      Exit(False);
+    ReceiverObj.DefineProperty(AName, TGocciaPropertyDescriptorData.Create(AValue,
+      [pfEnumerable, pfConfigurable, pfWritable]));
+    Exit(True);
+  end;
+
+  if OwnDesc is TGocciaPropertyDescriptorData then
+  begin
+    // Step 2a: If ownDesc.[[Writable]] is false, return false
+    if not OwnDesc.Writable then
+      Exit(False);
+    // Step 2b: If Receiver is not an Object, return false
+    if not (AReceiver is TGocciaObjectValue) then
+      Exit(False);
+    ReceiverObj := TGocciaObjectValue(AReceiver);
+    // Step 2c: Let existingDescriptor be Receiver.[[GetOwnProperty]](P)
+    ReceiverDesc := ReceiverObj.GetOwnPropertyDescriptor(AName);
+    if Assigned(ReceiverDesc) then
+    begin
+      // Step 2d.i: If IsAccessorDescriptor(existingDescriptor), return false
+      if ReceiverDesc is TGocciaPropertyDescriptorAccessor then
+        Exit(False);
+      // Step 2d.ii: If existingDescriptor.[[Writable]] is false, return false
+      if not ReceiverDesc.Writable then
+        Exit(False);
+      // Step 2d.iii-iv: Update value on receiver
+      TGocciaPropertyDescriptorData(ReceiverDesc).Value := AValue;
+      Exit(True);
+    end
+    else
+    begin
+      // Step 2e: CreateDataProperty(Receiver, P, V)
+      if not ReceiverObj.Extensible then
+        Exit(False);
+      ReceiverObj.DefineProperty(AName, TGocciaPropertyDescriptorData.Create(AValue,
+        [pfEnumerable, pfConfigurable, pfWritable]));
+      Exit(True);
+    end;
+  end;
+
+  // Step 3-7: Accessor descriptor
+  Accessor := TGocciaPropertyDescriptorAccessor(OwnDesc);
+  // Step 4-5: If setter is undefined, return false
+  if not Assigned(Accessor.Setter) or not Accessor.Setter.IsCallable then
+    Exit(False);
+  // Step 6: Call(setter, Receiver, « V »)
+  Args := TGocciaArgumentsCollection.Create;
+  try
+    Args.Add(AValue);
+    TGocciaFunctionBase(Accessor.Setter).Call(Args, AReceiver);
+  finally
+    Args.Free;
+  end;
+  // Step 7: Return true
+  Result := True;
+end;
+
 procedure TGocciaObjectValue.DefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor);
 var
   ExistingDescriptor: TGocciaPropertyDescriptor;
@@ -909,6 +989,84 @@ begin
     ThrowTypeError('Cannot add symbol property, object is not extensible');
 
   DefineSymbolProperty(ASymbol, TGocciaPropertyDescriptorData.Create(AValue, [pfEnumerable, pfConfigurable, pfWritable]));
+end;
+
+// ES2026 §10.1.9.2 OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc) — symbol variant
+function TGocciaObjectValue.AssignSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean;
+var
+  OwnDesc, ReceiverDesc: TGocciaPropertyDescriptor;
+  Accessor: TGocciaPropertyDescriptorAccessor;
+  Args: TGocciaArgumentsCollection;
+  ReceiverObj: TGocciaObjectValue;
+begin
+  // Step 1: Let ownDesc be O.[[GetOwnProperty]](P)
+  OwnDesc := GetOwnSymbolPropertyDescriptor(ASymbol);
+
+  if OwnDesc = nil then
+  begin
+    // Step 1a-b: Walk prototype chain
+    if Assigned(FPrototype) then
+      Exit(FPrototype.AssignSymbolPropertyWithReceiver(ASymbol, AValue, AReceiver));
+    // Step 1c: No prototype — treat as absent, create on receiver
+    if not (AReceiver is TGocciaObjectValue) then
+      Exit(False);
+    ReceiverObj := TGocciaObjectValue(AReceiver);
+    if not ReceiverObj.Extensible then
+      Exit(False);
+    ReceiverObj.DefineSymbolProperty(ASymbol, TGocciaPropertyDescriptorData.Create(AValue,
+      [pfEnumerable, pfConfigurable, pfWritable]));
+    Exit(True);
+  end;
+
+  if OwnDesc is TGocciaPropertyDescriptorData then
+  begin
+    // Step 2a: If ownDesc.[[Writable]] is false, return false
+    if not OwnDesc.Writable then
+      Exit(False);
+    // Step 2b: If Receiver is not an Object, return false
+    if not (AReceiver is TGocciaObjectValue) then
+      Exit(False);
+    ReceiverObj := TGocciaObjectValue(AReceiver);
+    // Step 2c: Let existingDescriptor be Receiver.[[GetOwnProperty]](P)
+    ReceiverDesc := ReceiverObj.GetOwnSymbolPropertyDescriptor(ASymbol);
+    if Assigned(ReceiverDesc) then
+    begin
+      // Step 2d.i: If IsAccessorDescriptor(existingDescriptor), return false
+      if ReceiverDesc is TGocciaPropertyDescriptorAccessor then
+        Exit(False);
+      // Step 2d.ii: If existingDescriptor.[[Writable]] is false, return false
+      if not ReceiverDesc.Writable then
+        Exit(False);
+      // Step 2d.iii-iv: Update value on receiver
+      TGocciaPropertyDescriptorData(ReceiverDesc).Value := AValue;
+      Exit(True);
+    end
+    else
+    begin
+      // Step 2e: CreateDataProperty(Receiver, P, V)
+      if not ReceiverObj.Extensible then
+        Exit(False);
+      ReceiverObj.DefineSymbolProperty(ASymbol, TGocciaPropertyDescriptorData.Create(AValue,
+        [pfEnumerable, pfConfigurable, pfWritable]));
+      Exit(True);
+    end;
+  end;
+
+  // Step 3-7: Accessor descriptor
+  Accessor := TGocciaPropertyDescriptorAccessor(OwnDesc);
+  // Step 4-5: If setter is undefined, return false
+  if not Assigned(Accessor.Setter) or not Accessor.Setter.IsCallable then
+    Exit(False);
+  // Step 6: Call(setter, Receiver, « V »)
+  Args := TGocciaArgumentsCollection.Create;
+  try
+    Args.Add(AValue);
+    TGocciaFunctionBase(Accessor.Setter).Call(Args, AReceiver);
+  finally
+    Args.Free;
+  end;
+  // Step 7: Return true
+  Result := True;
 end;
 
 function TGocciaObjectValue.GetSymbolProperty(const ASymbol: TGocciaSymbolValue): TGocciaValue;

--- a/units/Goccia.Values.ObjectValue.pas
+++ b/units/Goccia.Values.ObjectValue.pas
@@ -601,10 +601,22 @@ begin
     // Step 1a-b: Walk prototype chain
     if Assigned(FPrototype) then
       Exit(FPrototype.AssignPropertyWithReceiver(AName, AValue, AReceiver));
-    // Step 1c: No prototype — treat as absent, create on receiver
+    // Step 1c: No prototype — ownDesc defaults to writable data descriptor,
+    // fall through to step 2 which consults Receiver.[[GetOwnProperty]](P)
     if not (AReceiver is TGocciaObjectValue) then
       Exit(False);
     ReceiverObj := TGocciaObjectValue(AReceiver);
+    ReceiverDesc := ReceiverObj.GetOwnPropertyDescriptor(AName);
+    if Assigned(ReceiverDesc) then
+    begin
+      // Step 2d: Receiver already has own property P
+      if (ReceiverDesc is TGocciaPropertyDescriptorAccessor) or
+         (not ReceiverDesc.Writable) then
+        Exit(False);
+      TGocciaPropertyDescriptorData(ReceiverDesc).Value := AValue;
+      Exit(True);
+    end;
+    // Step 2e: CreateDataProperty(Receiver, P, V)
     if not ReceiverObj.Extensible then
       Exit(False);
     ReceiverObj.DefineProperty(AName, TGocciaPropertyDescriptorData.Create(AValue,
@@ -1007,10 +1019,22 @@ begin
     // Step 1a-b: Walk prototype chain
     if Assigned(FPrototype) then
       Exit(FPrototype.AssignSymbolPropertyWithReceiver(ASymbol, AValue, AReceiver));
-    // Step 1c: No prototype — treat as absent, create on receiver
+    // Step 1c: No prototype — ownDesc defaults to writable data descriptor,
+    // fall through to step 2 which consults Receiver.[[GetOwnProperty]](P)
     if not (AReceiver is TGocciaObjectValue) then
       Exit(False);
     ReceiverObj := TGocciaObjectValue(AReceiver);
+    ReceiverDesc := ReceiverObj.GetOwnSymbolPropertyDescriptor(ASymbol);
+    if Assigned(ReceiverDesc) then
+    begin
+      // Step 2d: Receiver already has own property P
+      if (ReceiverDesc is TGocciaPropertyDescriptorAccessor) or
+         (not ReceiverDesc.Writable) then
+        Exit(False);
+      TGocciaPropertyDescriptorData(ReceiverDesc).Value := AValue;
+      Exit(True);
+    end;
+    // Step 2e: CreateDataProperty(Receiver, P, V)
     if not ReceiverObj.Extensible then
       Exit(False);
     ReceiverObj.DefineSymbolProperty(ASymbol, TGocciaPropertyDescriptorData.Create(AValue,

--- a/units/Goccia.Values.PromiseValue.pas
+++ b/units/Goccia.Values.PromiseValue.pas
@@ -58,6 +58,7 @@ type
     function DoReject(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToStringTag: string; override;
 
     procedure MarkReferences; override;
@@ -626,7 +627,12 @@ end;
 
 function TGocciaPromiseValue.GetProperty(const AName: string): TGocciaValue;
 begin
-  Result := inherited GetProperty(AName);
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaPromiseValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
+  Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaPromiseValue.ToStringTag: string;

--- a/units/Goccia.Values.ProxyValue.pas
+++ b/units/Goccia.Values.ProxyValue.pas
@@ -28,6 +28,7 @@ type
 
     // ES2026 §28.1.1 [[Get]](P, Receiver)
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
 
     // ES2026 §28.1.1 [[Set]](P, V, Receiver)
     procedure AssignProperty(const AName: string; const AValue: TGocciaValue;
@@ -180,6 +181,11 @@ end;
 
 // ES2026 §28.1.1 [[Get]](P, Receiver)
 function TGocciaProxyValue.GetProperty(const AName: string): TGocciaValue;
+begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaProxyValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 var
   Trap: TGocciaValue;
   Args: TGocciaArgumentsCollection;

--- a/units/Goccia.Values.ProxyValue.pas
+++ b/units/Goccia.Values.ProxyValue.pas
@@ -199,13 +199,14 @@ begin
     try
       Args.Add(FTarget);
       Args.Add(TGocciaStringLiteralValue.Create(AName));
-      Args.Add(Self);
+      // ES2026 §10.5.8 step 7: Pass the receiver, not the proxy itself
+      Args.Add(AThisContext);
       Result := InvokeTrap(Trap, Args);
     finally
       Args.Free;
     end;
 
-    // ES2026 §28.1.1 step 8-9: Invariant validation.
+    // ES2026 §10.5.8 step 8-9: Invariant validation.
     if FTarget is TGocciaObjectValue then
     begin
       TargetDesc := TGocciaObjectValue(FTarget).GetOwnPropertyDescriptor(AName);
@@ -224,6 +225,9 @@ begin
       end;
     end;
   end
+  else if FTarget is TGocciaObjectValue then
+    // ES2026 §10.5.8 step 10: Return ? target.[[Get]](P, Receiver)
+    Result := TGocciaObjectValue(FTarget).GetPropertyWithContext(AName, AThisContext)
   else
     Result := FTarget.GetProperty(AName);
 end;

--- a/units/Goccia.Values.ProxyValue.pas
+++ b/units/Goccia.Values.ProxyValue.pas
@@ -56,11 +56,22 @@ type
     function GetAllPropertyNames: TArray<string>; override;
     function HasOwnProperty(const AName: string): Boolean; override;
 
+    // ES2026 §10.5.9 [[Set]](P, V, Receiver) — receiver-aware
+    function AssignPropertyWithReceiver(const AName: string;
+      const AValue: TGocciaValue;
+      const AReceiver: TGocciaValue): Boolean; override;
+
     // Symbol-keyed property access via get/has traps
     function GetSymbolProperty(
       const ASymbol: TGocciaSymbolValue): TGocciaValue; override;
+    function GetSymbolPropertyWithReceiver(
+      const ASymbol: TGocciaSymbolValue;
+      const AReceiver: TGocciaValue): TGocciaValue; override;
     function HasSymbolProperty(
       const ASymbol: TGocciaSymbolValue): Boolean; override;
+    function AssignSymbolPropertyWithReceiver(
+      const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue;
+      const AReceiver: TGocciaValue): Boolean; override;
 
     // ES2026 §28.1.1 [[GetPrototypeOf]]()
     function GetPrototypeTrap: TGocciaValue;
@@ -281,6 +292,62 @@ begin
     FTarget.SetProperty(AName, AValue);
 end;
 
+// ES2026 §10.5.9 [[Set]](P, V, Receiver) — receiver-aware, returns Boolean
+function TGocciaProxyValue.AssignPropertyWithReceiver(const AName: string;
+  const AValue: TGocciaValue;
+  const AReceiver: TGocciaValue): Boolean;
+var
+  Trap: TGocciaValue;
+  Args: TGocciaArgumentsCollection;
+  TrapResult: TGocciaValue;
+  TargetDesc: TGocciaPropertyDescriptor;
+begin
+  CheckRevoked;
+  Trap := GetTrap(PROP_SET);
+  if Assigned(Trap) then
+  begin
+    Args := TGocciaArgumentsCollection.Create;
+    try
+      Args.Add(FTarget);
+      Args.Add(TGocciaStringLiteralValue.Create(AName));
+      Args.Add(AValue);
+      Args.Add(AReceiver);
+      TrapResult := InvokeTrap(Trap, Args);
+      if not TrapResult.ToBooleanLiteral.Value then
+        Exit(False);
+    finally
+      Args.Free;
+    end;
+
+    // ES2026 §10.5.9 step 11-12: Invariant validation after truthy result.
+    if FTarget is TGocciaObjectValue then
+    begin
+      TargetDesc := TGocciaObjectValue(FTarget).GetOwnPropertyDescriptor(AName);
+      if Assigned(TargetDesc) and not TargetDesc.Configurable then
+      begin
+        // Non-configurable, non-writable data property: value must match
+        if (TargetDesc is TGocciaPropertyDescriptorData) and
+           not TargetDesc.Writable and
+           not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, AValue) then
+          ThrowTypeError('Proxy set: cannot change value of non-configurable, non-writable property ''' + AName + '''');
+        // Non-configurable accessor without setter
+        if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
+           not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Setter) then
+          ThrowTypeError('Proxy set: cannot set non-configurable accessor property ''' + AName + ''' without a setter');
+      end;
+    end;
+
+    Result := True;
+  end
+  else
+  begin
+    if FTarget is TGocciaObjectValue then
+      Result := TGocciaObjectValue(FTarget).AssignPropertyWithReceiver(AName, AValue, AReceiver)
+    else
+      Result := False;
+  end;
+end;
+
 // ES2026 §28.1.1 [[HasProperty]](P)
 function TGocciaProxyValue.HasTrap(const AName: string): Boolean;
 var
@@ -422,6 +489,111 @@ begin
       Result := TGocciaObjectValue(FTarget).GetSymbolProperty(ASymbol)
     else
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  end;
+end;
+
+// ES2026 §10.5.8 [[Get]](P, Receiver) — symbol key, receiver-aware
+function TGocciaProxyValue.GetSymbolPropertyWithReceiver(
+  const ASymbol: TGocciaSymbolValue;
+  const AReceiver: TGocciaValue): TGocciaValue;
+var
+  Trap: TGocciaValue;
+  Args: TGocciaArgumentsCollection;
+  TargetDesc: TGocciaPropertyDescriptor;
+begin
+  CheckRevoked;
+  Trap := GetTrap(PROP_GET);
+  if Assigned(Trap) then
+  begin
+    Args := TGocciaArgumentsCollection.Create;
+    try
+      Args.Add(FTarget);
+      Args.Add(ASymbol);
+      Args.Add(AReceiver);
+      Result := InvokeTrap(Trap, Args);
+    finally
+      Args.Free;
+    end;
+
+    // ES2026 §10.5.8 step 8-9: Invariant validation for symbol keys.
+    if FTarget is TGocciaObjectValue then
+    begin
+      TargetDesc := TGocciaObjectValue(FTarget).GetOwnSymbolPropertyDescriptor(ASymbol);
+      if Assigned(TargetDesc) and not TargetDesc.Configurable then
+      begin
+        if (TargetDesc is TGocciaPropertyDescriptorData) and
+           not TargetDesc.Writable and
+           not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, Result) then
+          ThrowTypeError('Proxy get: value mismatch for non-configurable, non-writable symbol property');
+        if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
+           not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Getter) and
+           not (Result is TGocciaUndefinedLiteralValue) then
+          ThrowTypeError('Proxy get: must return undefined for non-configurable accessor without getter');
+      end;
+    end;
+  end
+  else
+  begin
+    if FTarget is TGocciaObjectValue then
+      Result := TGocciaObjectValue(FTarget).GetSymbolPropertyWithReceiver(ASymbol, AReceiver)
+    else
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  end;
+end;
+
+// ES2026 §10.5.9 [[Set]](P, V, Receiver) — symbol key, receiver-aware
+function TGocciaProxyValue.AssignSymbolPropertyWithReceiver(
+  const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue;
+  const AReceiver: TGocciaValue): Boolean;
+var
+  Trap: TGocciaValue;
+  Args: TGocciaArgumentsCollection;
+  TrapResult: TGocciaValue;
+  TargetDesc: TGocciaPropertyDescriptor;
+begin
+  CheckRevoked;
+  Trap := GetTrap(PROP_SET);
+  if Assigned(Trap) then
+  begin
+    Args := TGocciaArgumentsCollection.Create;
+    try
+      Args.Add(FTarget);
+      Args.Add(ASymbol);
+      Args.Add(AValue);
+      Args.Add(AReceiver);
+      TrapResult := InvokeTrap(Trap, Args);
+      if not TrapResult.ToBooleanLiteral.Value then
+        Exit(False);
+    finally
+      Args.Free;
+    end;
+
+    // ES2026 §10.5.9 step 11-12: Invariant validation after truthy result.
+    if FTarget is TGocciaObjectValue then
+    begin
+      TargetDesc := TGocciaObjectValue(FTarget).GetOwnSymbolPropertyDescriptor(ASymbol);
+      if Assigned(TargetDesc) and not TargetDesc.Configurable then
+      begin
+        // Non-configurable, non-writable data property: value must match
+        if (TargetDesc is TGocciaPropertyDescriptorData) and
+           not TargetDesc.Writable and
+           not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, AValue) then
+          ThrowTypeError('Proxy set: cannot change value of non-configurable, non-writable symbol property');
+        // Non-configurable accessor without setter
+        if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
+           not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Setter) then
+          ThrowTypeError('Proxy set: cannot set non-configurable accessor symbol property without a setter');
+      end;
+    end;
+
+    Result := True;
+  end
+  else
+  begin
+    if FTarget is TGocciaObjectValue then
+      Result := TGocciaObjectValue(FTarget).AssignSymbolPropertyWithReceiver(ASymbol, AValue, AReceiver)
+    else
+      Result := False;
   end;
 end;
 

--- a/units/Goccia.Values.SetValue.pas
+++ b/units/Goccia.Values.SetValue.pas
@@ -47,6 +47,7 @@ type
     procedure AddItem(const AValue: TGocciaValue);
 
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToArray: TGocciaArrayValue;
     function ToStringTag: string; override;
 
@@ -195,10 +196,15 @@ end;
 
 function TGocciaSetValue.GetProperty(const AName: string): TGocciaValue;
 begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaSetValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
   if AName = PROP_SIZE then
     Result := TGocciaNumberLiteralValue.Create(FItems.Count)
   else
-    Result := inherited GetProperty(AName);
+    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaSetValue.ToArray: TGocciaArrayValue;

--- a/units/Goccia.Values.SharedArrayBufferValue.pas
+++ b/units/Goccia.Values.SharedArrayBufferValue.pas
@@ -30,6 +30,7 @@ type
     constructor Create(const AClass: TGocciaClassValue); overload;
 
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToStringTag: string; override;
 
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
@@ -166,10 +167,15 @@ end;
 
 function TGocciaSharedArrayBufferValue.GetProperty(const AName: string): TGocciaValue;
 begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaSharedArrayBufferValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
   if AName = PROP_BYTE_LENGTH then
     Result := TGocciaNumberLiteralValue.Create(Length(FData))
   else
-    Result := inherited GetProperty(AName);
+    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaSharedArrayBufferValue.ToStringTag: string;

--- a/units/Goccia.Values.StringObjectValue.pas
+++ b/units/Goccia.Values.StringObjectValue.pas
@@ -26,6 +26,7 @@ type
     destructor Destroy; override;
     function TypeName: string; override;
     function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
 
     procedure InitializePrototype;
     procedure MarkReferences; override;
@@ -280,6 +281,11 @@ begin
 end;
 
 function TGocciaStringObjectValue.GetProperty(const AName: string): TGocciaValue;
+begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaStringObjectValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 var
   Index: Integer;
   StringValue: string;
@@ -295,12 +301,12 @@ begin
     Exit;
   end;
 
-  Result := inherited GetProperty(AName);
+  Result := inherited GetPropertyWithContext(AName, AThisContext);
   if not (Result is TGocciaUndefinedLiteralValue) then
     Exit;
 
   if Assigned(FSharedStringPrototype) then
-    Result := FSharedStringPrototype.GetPropertyWithContext(AName, Self);
+    Result := FSharedStringPrototype.GetPropertyWithContext(AName, AThisContext);
 end;
 
 procedure TGocciaStringObjectValue.InitializePrototype;


### PR DESCRIPTION
## Summary

- **`Reflect.get`**: passes the optional `receiver` argument to getter calls via `GetPropertyWithContext` (string keys) and `GetSymbolPropertyWithReceiver` (symbol keys), so accessor getters observe the correct `this` (ES2026 §28.1.5)
- **`Reflect.set`**: adds `AssignPropertyWithReceiver` / `AssignSymbolPropertyWithReceiver` implementing the full `OrdinarySetWithOwnDescriptor` algorithm (ES2026 §10.1.9.2) — accessor setters receive `receiver` as `this`, and data property writes land on `receiver` rather than `target`
- Adds 16 new tests covering receiver threading for getters, setters, inherited accessors, symbol keys, data-property-on-receiver writes, and edge cases (non-writable, accessor conflicts, non-extensible receiver)

Closes #230

## Test plan

- [x] All 86 Reflect tests pass (70 existing + 16 new)
- [x] Full test suite passes (4027 tests, 0 new failures)
- [x] Object.defineProperty tests pass (191 tests)
- [x] Formatter check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)