### PR TITLE
Support array-like arguments for apply and Reflect

### DIFF
--- a/tests/built-ins/Function/prototype/apply.js
+++ b/tests/built-ins/Function/prototype/apply.js
@@ -67,6 +67,18 @@ describe("Function.prototype.apply", () => {
     expect(fn.apply(undefined, arrayLike)).toBe("hello");
   });
 
+  test("treats absent length as zero", () => {
+    const fn = (...args) => args.length;
+    expect(fn.apply(undefined, {})).toBe(0);
+    expect(fn.apply(undefined, { 0: "ignored" })).toBe(0);
+  });
+
+  test("treats non-numeric string length as zero", () => {
+    const fn = (...args) => args.length;
+    expect(fn.apply(undefined, { length: "foo" })).toBe(0);
+    expect(fn.apply(undefined, { 0: "ignored", length: "bar" })).toBe(0);
+  });
+
   test("throws TypeError if argArray is not an object", () => {
     const fn = () => {};
     expect(() => fn.apply(undefined, "not-array")).toThrow(TypeError);

--- a/tests/built-ins/Function/prototype/apply.js
+++ b/tests/built-ins/Function/prototype/apply.js
@@ -79,6 +79,11 @@ describe("Function.prototype.apply", () => {
     expect(fn.apply(undefined, { 0: "ignored", length: "bar" })).toBe(0);
   });
 
+  test("throws RangeError for excessively large array-like length", () => {
+    const fn = () => {};
+    expect(() => fn.apply(undefined, { length: 2000000000 })).toThrow(RangeError);
+  });
+
   test("throws TypeError if argArray is not an object", () => {
     const fn = () => {};
     expect(() => fn.apply(undefined, "not-array")).toThrow(TypeError);

--- a/tests/built-ins/Function/prototype/apply.js
+++ b/tests/built-ins/Function/prototype/apply.js
@@ -1,0 +1,81 @@
+/*---
+description: Function.prototype.apply
+features: [Function]
+---*/
+
+describe("Function.prototype.apply", () => {
+  test("calls a function with the given this and arguments array", () => {
+    const fn = (a, b) => a + b;
+    expect(fn.apply(undefined, [1, 2])).toBe(3);
+  });
+
+  test("passes thisArg correctly", () => {
+    class Obj {
+      constructor(x) {
+        this.x = x;
+      }
+      getX() {
+        return this.x;
+      }
+    }
+    const obj = new Obj(42);
+    expect(obj.getX.apply(obj, [])).toBe(42);
+  });
+
+  test("works with empty arguments array", () => {
+    const fn = () => "hello";
+    expect(fn.apply(undefined, [])).toBe("hello");
+  });
+
+  test("works with no arguments at all", () => {
+    const fn = () => "default";
+    expect(fn.apply(undefined)).toBe("default");
+  });
+
+  test("treats undefined argArray as no arguments", () => {
+    const fn = () => "ok";
+    expect(fn.apply(undefined, undefined)).toBe("ok");
+  });
+
+  test("treats null argArray as no arguments", () => {
+    const fn = () => "ok";
+    expect(fn.apply(undefined, null)).toBe("ok");
+  });
+
+  test("works with array-like objects", () => {
+    const fn = (a, b, c) => a + b + c;
+    const arrayLike = { 0: 10, 1: 20, 2: 30, length: 3 };
+    expect(fn.apply(undefined, arrayLike)).toBe(60);
+  });
+
+  test("works with array-like object with zero length", () => {
+    const fn = () => "no-args";
+    expect(fn.apply(undefined, { length: 0 })).toBe("no-args");
+  });
+
+  test("works with array-like object with missing indices", () => {
+    const fn = (a, b) => [a, b];
+    const arrayLike = { 0: "x", length: 2 };
+    const result = fn.apply(undefined, arrayLike);
+    expect(result[0]).toBe("x");
+    expect(result[1]).toBe(undefined);
+  });
+
+  test("works with array-like object with string length", () => {
+    const fn = (a) => a;
+    const arrayLike = { 0: "hello", length: "1" };
+    expect(fn.apply(undefined, arrayLike)).toBe("hello");
+  });
+
+  test("throws TypeError if argArray is not an object", () => {
+    const fn = () => {};
+    expect(() => fn.apply(undefined, "not-array")).toThrow(TypeError);
+    expect(() => fn.apply(undefined, 42)).toThrow(TypeError);
+    expect(() => fn.apply(undefined, true)).toThrow(TypeError);
+  });
+
+  test("throws TypeError when called on non-function", () => {
+    const obj = { apply: Function.prototype.apply };
+    expect(() => obj.apply(undefined, [])).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Reflect/apply.js
+++ b/tests/built-ins/Reflect/apply.js
@@ -33,8 +33,35 @@ describe("Reflect.apply", () => {
     expect(() => Reflect.apply("string", undefined, [])).toThrow(TypeError);
   });
 
-  test("throws TypeError if argumentsList is not an array", () => {
+  test("works with array-like objects", () => {
+    const fn = (a, b, c) => a + b + c;
+    const arrayLike = { 0: 10, 1: 20, 2: 30, length: 3 };
+    expect(Reflect.apply(fn, undefined, arrayLike)).toBe(60);
+  });
+
+  test("works with array-like object with zero length", () => {
+    const fn = () => "no-args";
+    expect(Reflect.apply(fn, undefined, { length: 0 })).toBe("no-args");
+  });
+
+  test("works with array-like object with missing indices", () => {
+    const fn = (a, b) => [a, b];
+    const arrayLike = { 0: "x", length: 2 };
+    const result = Reflect.apply(fn, undefined, arrayLike);
+    expect(result[0]).toBe("x");
+    expect(result[1]).toBe(undefined);
+  });
+
+  test("works with array-like object with string length", () => {
+    const fn = (a) => a;
+    const arrayLike = { 0: "hello", length: "1" };
+    expect(Reflect.apply(fn, undefined, arrayLike)).toBe("hello");
+  });
+
+  test("throws TypeError if argumentsList is not an object", () => {
     const fn = () => {};
     expect(() => Reflect.apply(fn, undefined, "not-array")).toThrow(TypeError);
+    expect(() => Reflect.apply(fn, undefined, 42)).toThrow(TypeError);
+    expect(() => Reflect.apply(fn, undefined, true)).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Reflect/construct.js
+++ b/tests/built-ins/Reflect/construct.js
@@ -52,9 +52,48 @@ describe("Reflect.construct", () => {
     expect(() => Reflect.construct(Foo, [], () => {})).toThrow(TypeError);
   });
 
-  test("throws TypeError if argumentsList is not an array", () => {
+  test("works with array-like objects", () => {
+    class Point {
+      constructor(x, y) {
+        this.x = x;
+        this.y = y;
+      }
+    }
+    const arrayLike = { 0: 3, 1: 4, length: 2 };
+    const point = Reflect.construct(Point, arrayLike);
+    expect(point.x).toBe(3);
+    expect(point.y).toBe(4);
+    expect(point instanceof Point).toBe(true);
+  });
+
+  test("works with array-like object with zero length", () => {
+    class Empty {
+      constructor() {
+        this.value = "constructed";
+      }
+    }
+    const obj = Reflect.construct(Empty, { length: 0 });
+    expect(obj.value).toBe("constructed");
+  });
+
+  test("works with array-like object with missing indices", () => {
+    class Pair {
+      constructor(a, b) {
+        this.a = a;
+        this.b = b;
+      }
+    }
+    const arrayLike = { 0: "first", length: 2 };
+    const pair = Reflect.construct(Pair, arrayLike);
+    expect(pair.a).toBe("first");
+    expect(pair.b).toBe(undefined);
+  });
+
+  test("throws TypeError if argumentsList is not an object", () => {
     class Foo {}
     expect(() => Reflect.construct(Foo, "not-array")).toThrow(TypeError);
+    expect(() => Reflect.construct(Foo, 42)).toThrow(TypeError);
+    expect(() => Reflect.construct(Foo, true)).toThrow(TypeError);
   });
 
   test("newTarget prototype is visible during constructor execution", () => {

--- a/units/Goccia.Arguments.ArrayLike.pas
+++ b/units/Goccia.Arguments.ArrayLike.pas
@@ -16,6 +16,7 @@ function CreateListFromArrayLike(const AValue: TGocciaValue; const AMethodName: 
 implementation
 
 uses
+  Math,
   SysUtils,
 
   Goccia.Constants.PropertyNames,
@@ -29,6 +30,7 @@ var
   ArrVal: TGocciaArrayValue;
   ArrayObj: TGocciaObjectValue;
   LengthProp: TGocciaValue;
+  LengthValue: Double;
   Len, I: Integer;
   Element: TGocciaValue;
 begin
@@ -48,17 +50,23 @@ begin
 
   // ES2026 §7.3.18 step 2: Let len be ? LengthOfArrayLike(obj)
   // ES2026 §7.3.3 LengthOfArrayLike: ToLength(? Get(obj, "length"))
+  // ES2026 §7.1.22 ToLength: NaN/negative → 0, cap at 2^53−1
   ArrayObj := TGocciaObjectValue(AValue);
   LengthProp := ArrayObj.GetProperty(PROP_LENGTH);
-  if (LengthProp is TGocciaUndefinedLiteralValue) or
+  if not Assigned(LengthProp) or
+     (LengthProp is TGocciaUndefinedLiteralValue) or
      (LengthProp is TGocciaNullLiteralValue) then
     Len := 0
   else
   begin
-    Len := Trunc(LengthProp.ToNumberLiteral.Value);
-    // ES2026 §7.1.22 ToLength step 2: If len <= 0, return +0
-    if Len < 0 then
-      Len := 0;
+    LengthValue := LengthProp.ToNumberLiteral.Value;
+    // Trunc raises EInvalidOp for NaN/Infinity in FPC 3.2.2
+    if IsNan(LengthValue) or (LengthValue <= 0) then
+      Len := 0
+    else if LengthValue >= MaxInt then
+      Len := MaxInt
+    else
+      Len := Trunc(LengthValue);
   end;
 
   // ES2026 §7.3.18 steps 3-5: Iterate and collect elements

--- a/units/Goccia.Arguments.ArrayLike.pas
+++ b/units/Goccia.Arguments.ArrayLike.pas
@@ -24,6 +24,12 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue;
 
+const
+  // Ceiling for array-like argument lists. The ES spec caps ToLength at 2^53−1,
+  // but allocating that many elements is infeasible. This limit prevents
+  // pathological OOM from script-controlled length values like { length: 2e9 }.
+  MAX_ARGUMENTS_LIST_LENGTH = 1048576; // 2^20
+
 // ES2026 §7.3.18 CreateListFromArrayLike(obj [, elementTypes])
 function CreateListFromArrayLike(const AValue: TGocciaValue; const AMethodName: string): TGocciaArgumentsCollection;
 var
@@ -51,7 +57,6 @@ begin
   // ES2026 §7.3.18 step 2: Let len be ? LengthOfArrayLike(obj)
   // ES2026 §7.3.3 LengthOfArrayLike: ToLength(? Get(obj, "length"))
   // ES2026 §7.1.22 ToLength: NaN/negative → 0, spec caps at 2^53−1.
-  // Practical cap: MaxInt (Len is Integer); larger allocations are infeasible.
   ArrayObj := TGocciaObjectValue(AValue);
   LengthProp := ArrayObj.GetProperty(PROP_LENGTH);
   if not Assigned(LengthProp) or
@@ -69,6 +74,11 @@ begin
     else
       Len := Trunc(LengthValue);
   end;
+
+  // Guard against pathological lengths before allocating
+  if Len > MAX_ARGUMENTS_LIST_LENGTH then
+    ThrowRangeError(Format('%s: arguments list length %d exceeds maximum of %d',
+      [AMethodName, Len, MAX_ARGUMENTS_LIST_LENGTH]));
 
   // ES2026 §7.3.18 steps 3-5: Iterate and collect elements
   Result := TGocciaArgumentsCollection.CreateWithCapacity(Len);

--- a/units/Goccia.Arguments.ArrayLike.pas
+++ b/units/Goccia.Arguments.ArrayLike.pas
@@ -50,7 +50,8 @@ begin
 
   // ES2026 §7.3.18 step 2: Let len be ? LengthOfArrayLike(obj)
   // ES2026 §7.3.3 LengthOfArrayLike: ToLength(? Get(obj, "length"))
-  // ES2026 §7.1.22 ToLength: NaN/negative → 0, cap at 2^53−1
+  // ES2026 §7.1.22 ToLength: NaN/negative → 0, spec caps at 2^53−1.
+  // Practical cap: MaxInt (Len is Integer); larger allocations are infeasible.
   ArrayObj := TGocciaObjectValue(AValue);
   LengthProp := ArrayObj.GetProperty(PROP_LENGTH);
   if not Assigned(LengthProp) or

--- a/units/Goccia.Arguments.ArrayLike.pas
+++ b/units/Goccia.Arguments.ArrayLike.pas
@@ -1,0 +1,76 @@
+unit Goccia.Arguments.ArrayLike;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Values.Primitives;
+
+// ES2026 §7.3.18 CreateListFromArrayLike(obj [, elementTypes])
+// Converts an array or array-like object to a TGocciaArgumentsCollection.
+// Throws TypeError if the value is not an object.
+function CreateListFromArrayLike(const AValue: TGocciaValue; const AMethodName: string): TGocciaArgumentsCollection;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Constants.PropertyNames,
+  Goccia.Values.ArrayValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.ObjectValue;
+
+// ES2026 §7.3.18 CreateListFromArrayLike(obj [, elementTypes])
+function CreateListFromArrayLike(const AValue: TGocciaValue; const AMethodName: string): TGocciaArgumentsCollection;
+var
+  ArrVal: TGocciaArrayValue;
+  ArrayObj: TGocciaObjectValue;
+  LengthProp: TGocciaValue;
+  Len, I: Integer;
+  Element: TGocciaValue;
+begin
+  // ES2026 §7.3.18 step 1: If obj is not an Object, throw a TypeError exception
+  if not (AValue is TGocciaObjectValue) then
+    ThrowTypeError(Format('%s: argumentsList must be an array-like object', [AMethodName]));
+
+  // Fast path: TGocciaArrayValue — direct element access
+  if AValue is TGocciaArrayValue then
+  begin
+    ArrVal := TGocciaArrayValue(AValue);
+    Result := TGocciaArgumentsCollection.CreateWithCapacity(ArrVal.Elements.Count);
+    for I := 0 to ArrVal.Elements.Count - 1 do
+      Result.Add(ArrVal.Elements[I]);
+    Exit;
+  end;
+
+  // ES2026 §7.3.18 step 2: Let len be ? LengthOfArrayLike(obj)
+  // ES2026 §7.3.3 LengthOfArrayLike: ToLength(? Get(obj, "length"))
+  ArrayObj := TGocciaObjectValue(AValue);
+  LengthProp := ArrayObj.GetProperty(PROP_LENGTH);
+  if (LengthProp is TGocciaUndefinedLiteralValue) or
+     (LengthProp is TGocciaNullLiteralValue) then
+    Len := 0
+  else
+  begin
+    Len := Trunc(LengthProp.ToNumberLiteral.Value);
+    // ES2026 §7.1.22 ToLength step 2: If len <= 0, return +0
+    if Len < 0 then
+      Len := 0;
+  end;
+
+  // ES2026 §7.3.18 steps 3-5: Iterate and collect elements
+  Result := TGocciaArgumentsCollection.CreateWithCapacity(Len);
+  for I := 0 to Len - 1 do
+  begin
+    // ES2026 §7.3.18 step 5a: Let next be ? Get(obj, indexName)
+    Element := ArrayObj.GetProperty(IntToStr(I));
+    if not Assigned(Element) then
+      Element := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Result.Add(Element);
+  end;
+end;
+
+end.

--- a/units/Goccia.Builtins.GlobalReflect.pas
+++ b/units/Goccia.Builtins.GlobalReflect.pas
@@ -40,6 +40,7 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Arguments.ArrayLike,
   Goccia.Arguments.Validator,
   Goccia.Constants.PropertyNames,
   Goccia.Utils,
@@ -100,9 +101,7 @@ function TGocciaGlobalReflect.ReflectApply(const AArgs: TGocciaArgumentsCollecti
 var
   Target, ThisArg: TGocciaValue;
   ArgsList: TGocciaValue;
-  ArgsArray: TGocciaArrayValue;
   CallArgs: TGocciaArgumentsCollection;
-  I: Integer;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 3, 'Reflect.apply', ThrowError);
 
@@ -115,15 +114,8 @@ begin
     ThrowTypeError('Reflect.apply: target must be a function');
 
   // Step 2: Let args be ? CreateListFromArrayLike(argumentsList)
-  if not (ArgsList is TGocciaArrayValue) then
-    ThrowTypeError('Reflect.apply: argumentsList must be an array');
-
-  ArgsArray := TGocciaArrayValue(ArgsList);
-  CallArgs := TGocciaArgumentsCollection.Create;
+  CallArgs := CreateListFromArrayLike(ArgsList, 'Reflect.apply');
   try
-    for I := 0 to ArgsArray.Elements.Count - 1 do
-      CallArgs.Add(ArgsArray.Elements[I]);
-
     // Step 3: Return ? Call(target, thisArgument, args)
     Result := TGocciaFunctionBase(Target).Call(CallArgs, ThisArg);
   finally
@@ -137,10 +129,7 @@ var
   Target: TGocciaValue;
   ArgsList: TGocciaValue;
   NewTarget: TGocciaValue;
-  ArgsArray: TGocciaArrayValue;
   CallArgs: TGocciaArgumentsCollection;
-  Instance: TGocciaValue;
-  I: Integer;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Reflect.construct', ThrowError);
 
@@ -152,36 +141,27 @@ begin
     ThrowTypeError('Reflect.construct: target must be a constructor');
 
   // Step 2: Let args be ? CreateListFromArrayLike(argumentsList)
-  if not (ArgsList is TGocciaArrayValue) then
-    ThrowTypeError('Reflect.construct: argumentsList must be an array');
-
-  // Step 3: If IsConstructor(newTarget) is false, throw a TypeError exception
-  if AArgs.Length >= 3 then
-  begin
-    NewTarget := AArgs.GetElement(2);
-    if not (NewTarget is TGocciaClassValue) then
-      ThrowTypeError('Reflect.construct: newTarget must be a constructor');
-  end
-  else
-    NewTarget := Target;
-
-  ArgsArray := TGocciaArrayValue(ArgsList);
-  CallArgs := TGocciaArgumentsCollection.Create;
+  CallArgs := CreateListFromArrayLike(ArgsList, 'Reflect.construct');
   try
-    for I := 0 to ArgsArray.Elements.Count - 1 do
-      CallArgs.Add(ArgsArray.Elements[I]);
+    // Step 3: If IsConstructor(newTarget) is false, throw a TypeError exception
+    if AArgs.Length >= 3 then
+    begin
+      NewTarget := AArgs.GetElement(2);
+      if not (NewTarget is TGocciaClassValue) then
+        ThrowTypeError('Reflect.construct: newTarget must be a constructor');
+    end
+    else
+      NewTarget := Target;
 
     // Step 4: Return ? Construct(target, args, newTarget)
     // Pass newTarget so the instance prototype is set before the constructor runs
     if NewTarget <> Target then
-      Instance := TGocciaClassValue(Target).Instantiate(CallArgs, TGocciaClassValue(NewTarget))
+      Result := TGocciaClassValue(Target).Instantiate(CallArgs, TGocciaClassValue(NewTarget))
     else
-      Instance := TGocciaClassValue(Target).Instantiate(CallArgs);
+      Result := TGocciaClassValue(Target).Instantiate(CallArgs);
   finally
     CallArgs.Free;
   end;
-
-  Result := Instance;
 end;
 
 // ES2026 §28.1.3 Reflect.defineProperty(target, propertyKey, attributes)

--- a/units/Goccia.Values.FunctionBase.pas
+++ b/units/Goccia.Values.FunctionBase.pas
@@ -94,11 +94,13 @@ uses
 
   GarbageCollector.Generic,
 
+  Goccia.Arguments.ArrayLike,
   Goccia.Constants.PropertyNames,
   Goccia.Constants.TypeNames,
   Goccia.Error,
   Goccia.ObjectModel,
   Goccia.Values.ArrayValue,
+  Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction;
 
 { TGocciaFunctionBase }
@@ -297,74 +299,58 @@ begin
   end;
 end;
 
+// ES2026 §20.2.3.1 Function.prototype.apply(thisArg, argArray)
 function TGocciaFunctionSharedPrototype.FunctionApply(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   CallArgs: TGocciaArgumentsCollection;
   NewThisValue: TGocciaValue;
-  I: Integer;
+  ArgArray: TGocciaValue;
   ArrVal: TGocciaArrayValue;
-  ArrayObj: TGocciaObjectValue;
-  LengthProp: TGocciaValue;
-  ArrayLength: Integer;
 begin
+  // Step 1: Perform ? RequireObjectCoercible(this)
   if not AThisValue.IsCallable then
-    raise TGocciaError.Create('Function.prototype.apply called on non-function', 0, 0, '', nil);
+    ThrowTypeError('Function.prototype.apply called on non-function');
 
+  // thisArg
   if AArgs.Length > 0 then
     NewThisValue := AArgs.GetElement(0)
   else
     NewThisValue := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  CallArgs := nil;
-  try
-    if AArgs.Length > 1 then
-    begin
-      // Fast path: direct element access for TGocciaArrayValue
-      if AArgs.GetElement(1) is TGocciaArrayValue then
-      begin
-        ArrVal := TGocciaArrayValue(AArgs.GetElement(1));
-        case ArrVal.Elements.Count of
-          0:
-            Exit(TGocciaFunctionBase(AThisValue).CallNoArgs(NewThisValue));
-          1:
-            Exit(TGocciaFunctionBase(AThisValue).CallOneArg(ArrVal.Elements[0], NewThisValue));
-          2:
-            Exit(TGocciaFunctionBase(AThisValue).CallTwoArgs(ArrVal.Elements[0],
-              ArrVal.Elements[1], NewThisValue));
-          3:
-            Exit(TGocciaFunctionBase(AThisValue).CallThreeArgs(ArrVal.Elements[0],
-              ArrVal.Elements[1], ArrVal.Elements[2], NewThisValue));
-        end;
-        CallArgs := TGocciaArgumentsCollection.CreateWithCapacity(ArrVal.Elements.Count);
-        for I := 0 to ArrVal.Elements.Count - 1 do
-          CallArgs.Add(ArrVal.Elements[I]);
-      end
-      // Generic path: array-like objects with length + numeric indices
-      else if AArgs.GetElement(1) is TGocciaObjectValue then
-      begin
-        ArrayObj := TGocciaObjectValue(AArgs.GetElement(1));
-        LengthProp := ArrayObj.GetProperty(PROP_LENGTH);
-        if not (LengthProp is TGocciaUndefinedLiteralValue) then
-        begin
-          ArrayLength := Trunc((LengthProp as TGocciaNumberLiteralValue).Value);
-          CallArgs := TGocciaArgumentsCollection.CreateWithCapacity(ArrayLength);
-          for I := 0 to ArrayLength - 1 do
-            CallArgs.Add(ArrayObj.GetProperty(IntToStr(I)));
-        end;
-      end
-      else if not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) and not (AArgs.GetElement(1) is TGocciaNullLiteralValue) then
-      begin
-        raise TGocciaError.Create('Function.prototype.apply: second argument must be an array', 0, 0, '', nil);
-      end;
+  // Step 2: If argArray is undefined or null, return F.[[Call]](thisArg, <<>>)
+  if AArgs.Length <= 1 then
+    Exit(TGocciaFunctionBase(AThisValue).CallNoArgs(NewThisValue));
+
+  ArgArray := AArgs.GetElement(1);
+  if (ArgArray is TGocciaUndefinedLiteralValue) or
+     (ArgArray is TGocciaNullLiteralValue) then
+    Exit(TGocciaFunctionBase(AThisValue).CallNoArgs(NewThisValue));
+
+  // Fast path: small arrays use specialized call methods
+  if ArgArray is TGocciaArrayValue then
+  begin
+    ArrVal := TGocciaArrayValue(ArgArray);
+    case ArrVal.Elements.Count of
+      0:
+        Exit(TGocciaFunctionBase(AThisValue).CallNoArgs(NewThisValue));
+      1:
+        Exit(TGocciaFunctionBase(AThisValue).CallOneArg(ArrVal.Elements[0], NewThisValue));
+      2:
+        Exit(TGocciaFunctionBase(AThisValue).CallTwoArgs(ArrVal.Elements[0],
+          ArrVal.Elements[1], NewThisValue));
+      3:
+        Exit(TGocciaFunctionBase(AThisValue).CallThreeArgs(ArrVal.Elements[0],
+          ArrVal.Elements[1], ArrVal.Elements[2], NewThisValue));
     end;
+  end;
 
-    if not Assigned(CallArgs) then
-      CallArgs := TGocciaArgumentsCollection.CreateWithCapacity(0);
-
+  // Step 3: Let argList be ? CreateListFromArrayLike(argArray)
+  CallArgs := CreateListFromArrayLike(ArgArray, 'Function.prototype.apply');
+  try
+    // Step 4: Return ? Call(func, thisArg, argList)
     Result := TGocciaFunctionBase(AThisValue).Call(CallArgs, NewThisValue);
   finally
-    if Assigned(CallArgs) then
-      CallArgs.Free;
+    CallArgs.Free;
   end;
 end;
 


### PR DESCRIPTION
## Summary
- Added a shared `CreateListFromArrayLike` helper to convert arrays and array-like objects into argument lists.
- Updated `Function.prototype.apply`, `Reflect.apply`, and `Reflect.construct` to accept array-like `argumentsList` values.
- Preserved fast paths for small arrays while extending the general path to handle object-like inputs and missing indices.
- Added coverage for empty inputs, sparse array-like objects, string `length` values, and invalid non-object arguments.

Fixes #231 

## Testing
- Added JavaScript tests under `tests/built-ins/Function/prototype/apply.js`.
- Extended JavaScript tests under `tests/built-ins/Reflect/apply.js`.
- Extended JavaScript tests under `tests/built-ins/Reflect/construct.js`.