### PR TITLE
Add RegExp.escape static method

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -382,6 +382,12 @@ RegExp is available as both `RegExp()` and `new RegExp()`. Regex literals (`/pat
 | `unicodeSets` | `true` when the `v` flag is present |
 | `hasIndices` | `true` when the `d` flag is present |
 
+**Static methods:**
+
+| Method | Description |
+|--------|-------------|
+| `escape(string)` | Returns a string with all regex-significant characters escaped so the result can be safely interpolated into a pattern. Implements the TC39 RegExp Escaping proposal. Syntax characters are backslash-escaped; ClassSet-reserved punctuators, whitespace, and line terminators are hex-encoded (`\xHH` / `\uHHHH`). A leading digit or ASCII letter is also hex-encoded to prevent ambiguity with backreferences. |
+
 **Prototype methods:**
 
 | Method | Description |

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -633,6 +633,7 @@ The transformer generates an internal source map for accurate error line/column 
 - Regex literals: `/pattern/flags`
 - Flags: `d`, `g`, `i`, `m`, `s`, `u`, `v`, `y`
 - RegExp instance properties: `source`, canonicalized `flags`, `lastIndex`, `global`, `ignoreCase`, `multiline`, `dotAll`, `unicode`, `sticky`, `unicodeSets`, `hasIndices`
+- `RegExp.escape()` (TC39 RegExp Escaping proposal)
 - `RegExp.prototype.exec()`, `test()`, `toString()`, and the `Symbol.match`, `Symbol.matchAll`, `Symbol.replace`, `Symbol.search`, and `Symbol.split` hooks
 - String integrations for `replace`, `replaceAll`, `split`, `match`, `matchAll`, and `search`, including custom protocol objects with the corresponding well-known symbol methods
 

--- a/tests/built-ins/RegExp/escape.js
+++ b/tests/built-ins/RegExp/escape.js
@@ -1,0 +1,134 @@
+/*---
+description: RegExp.escape
+features: [RegExp]
+---*/
+
+describe("RegExp.escape", () => {
+  test("is a function with length 1", () => {
+    expect(typeof RegExp.escape).toBe("function");
+    expect(RegExp.escape.length).toBe(1);
+  });
+
+  test("escapes syntax characters with backslash", () => {
+    expect(RegExp.escape("^")).toBe("\\^");
+    expect(RegExp.escape("$")).toBe("\\$");
+    expect(RegExp.escape("\\")).toBe("\\\\");
+    expect(RegExp.escape(".")).toBe("\\.");
+    expect(RegExp.escape("*")).toBe("\\*");
+    expect(RegExp.escape("+")).toBe("\\+");
+    expect(RegExp.escape("?")).toBe("\\?");
+    expect(RegExp.escape("(")).toBe("\\(");
+    expect(RegExp.escape(")")).toBe("\\)");
+    expect(RegExp.escape("[")).toBe("\\[");
+    expect(RegExp.escape("]")).toBe("\\]");
+    expect(RegExp.escape("{")).toBe("\\{");
+    expect(RegExp.escape("}")).toBe("\\}");
+    expect(RegExp.escape("|")).toBe("\\|");
+    expect(RegExp.escape("/")).toBe("\\/");
+  });
+
+  test("hex-encodes the first character when it is a digit", () => {
+    expect(RegExp.escape("1")).toBe("\\x31");
+    expect(RegExp.escape("0")).toBe("\\x30");
+    expect(RegExp.escape("9")).toBe("\\x39");
+    expect(RegExp.escape("5abc")).toBe("\\x35abc");
+  });
+
+  test("hex-encodes the first character when it is an ASCII letter", () => {
+    expect(RegExp.escape("a")).toBe("\\x61");
+    expect(RegExp.escape("z")).toBe("\\x7a");
+    expect(RegExp.escape("A")).toBe("\\x41");
+    expect(RegExp.escape("Z")).toBe("\\x5a");
+    expect(RegExp.escape("hello")).toBe("\\x68ello");
+  });
+
+  test("does not hex-encode digits/letters after the first character", () => {
+    expect(RegExp.escape(".1")).toBe("\\.1");
+    expect(RegExp.escape(".a")).toBe("\\.a");
+    expect(RegExp.escape("^abc123")).toBe("\\^abc123");
+  });
+
+  test("hex-encodes ClassSetReservedPunctuator characters", () => {
+    expect(RegExp.escape("&")).toBe("\\x26");
+    expect(RegExp.escape("-")).toBe("\\x2d");
+    expect(RegExp.escape("!")).toBe("\\x21");
+    expect(RegExp.escape("#")).toBe("\\x23");
+    expect(RegExp.escape("%")).toBe("\\x25");
+    expect(RegExp.escape(",")).toBe("\\x2c");
+    expect(RegExp.escape(":")).toBe("\\x3a");
+    expect(RegExp.escape(";")).toBe("\\x3b");
+    expect(RegExp.escape("<")).toBe("\\x3c");
+    expect(RegExp.escape("=")).toBe("\\x3d");
+    expect(RegExp.escape(">")).toBe("\\x3e");
+    expect(RegExp.escape("@")).toBe("\\x40");
+    expect(RegExp.escape("`")).toBe("\\x60");
+    expect(RegExp.escape("~")).toBe("\\x7e");
+  });
+
+  test("hex-encodes ASCII whitespace and line terminators", () => {
+    expect(RegExp.escape("\t")).toBe("\\x09");
+    expect(RegExp.escape("\n")).toBe("\\x0a");
+    expect(RegExp.escape("\x0b")).toBe("\\x0b");
+    expect(RegExp.escape("\x0c")).toBe("\\x0c");
+    expect(RegExp.escape("\r")).toBe("\\x0d");
+    expect(RegExp.escape(" ")).toBe("\\x20");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(RegExp.escape("")).toBe("");
+  });
+
+  test("passes through normal characters", () => {
+    expect(RegExp.escape("_")).toBe("_");
+    expect(RegExp.escape("'")).toBe("'");
+    expect(RegExp.escape('"')).toBe('"');
+  });
+
+  test("escapes mixed content correctly", () => {
+    expect(RegExp.escape("foo.bar+baz*qux"))
+      .toBe("\\x66oo\\.bar\\+baz\\*qux");
+    expect(RegExp.escape("(test)"))
+      .toBe("\\(test\\)");
+    expect(RegExp.escape("[a-z]"))
+      .toBe("\\[a\\x2dz\\]");
+  });
+
+  test("produces a usable regex pattern", () => {
+    const special = "Hello. How are you? (I'm fine!)";
+    const escaped = RegExp.escape(special);
+    const regex = new RegExp(escaped);
+    expect(regex.test(special)).toBe(true);
+    expect(regex.test("Hello! How are you? (I'm fine!)")).toBe(false);
+  });
+
+  test("escaped string works inside character class context", () => {
+    const input = "a+b";
+    const escaped = RegExp.escape(input);
+    const regex = new RegExp("^" + escaped + "$");
+    expect(regex.test("a+b")).toBe(true);
+    expect(regex.test("ab")).toBe(false);
+    expect(regex.test("aab")).toBe(false);
+  });
+
+  test("throws TypeError for non-string argument", () => {
+    expect(() => { RegExp.escape(42); }).toThrow(TypeError);
+    expect(() => { RegExp.escape(true); }).toThrow(TypeError);
+    expect(() => { RegExp.escape(null); }).toThrow(TypeError);
+    expect(() => { RegExp.escape(undefined); }).toThrow(TypeError);
+    expect(() => { RegExp.escape({}); }).toThrow(TypeError);
+    expect(() => { RegExp.escape(); }).toThrow(TypeError);
+  });
+
+  test("first character encoding does not apply to syntax characters", () => {
+    // Syntax characters as first char use backslash, not hex
+    expect(RegExp.escape("^abc")).toBe("\\^abc");
+    expect(RegExp.escape(".test")).toBe("\\.test");
+    expect(RegExp.escape("*foo")).toBe("\\*foo");
+  });
+
+  test("first character encoding does not apply to ClassSetReservedPunctuators", () => {
+    // ClassSetReservedPunctuators as first char use hex encoding
+    expect(RegExp.escape("&abc")).toBe("\\x26abc");
+    expect(RegExp.escape("-test")).toBe("\\x2dtest");
+  });
+});

--- a/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/units/Goccia.Builtins.GlobalRegExp.pas
@@ -20,10 +20,13 @@ type
     FRegExpConstructor: TGocciaNativeFunctionValue;
     FRegExpPrototype: TGocciaObjectValue;
     class var FPrototypeMembers: array of TGocciaMemberDefinition;
+    class var FStaticMembers: array of TGocciaMemberDefinition;
 
     function RegExpConstructorFn(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
   published
+    function RegExpEscape(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
     function RegExpExec(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     function RegExpTest(const AArgs: TGocciaArgumentsCollection;
@@ -319,7 +322,177 @@ begin
   FRegExpConstructor.AssignProperty(PROP_PROTOTYPE, FRegExpPrototype);
   FRegExpPrototype.AssignProperty(PROP_CONSTRUCTOR, FRegExpConstructor);
 
+  if Length(FStaticMembers) = 0 then
+  begin
+    Members := TGocciaMemberCollection.Create;
+    try
+      Members.AddMethod(RegExpEscape, 1, gmkStaticMethod);
+      FStaticMembers := Members.ToDefinitions;
+    finally
+      Members.Free;
+    end;
+  end;
+  RegisterMemberDefinitions(FRegExpConstructor, FStaticMembers);
+
   AScope.DefineLexicalBinding(AName, FRegExpConstructor, dtConst);
+end;
+
+function IsECMAScriptWhiteSpaceOrLineTerminator(
+  const ACodePoint: Cardinal): Boolean; inline;
+begin
+  case ACodePoint of
+    // ES2026 §12.2 White Space
+    $0009, $000B, $000C, $0020, $00A0, $FEFF,
+    // ES2026 §12.2 White Space — Unicode Zs category
+    $1680, $2000..$200A, $202F, $205F, $3000,
+    // ES2026 §12.3 Line Terminators
+    $000A, $000D, $2028, $2029:
+      Result := True;
+  else
+    Result := False;
+  end;
+end;
+
+function DecodeUTF8CodePoint(const AStr: string; const AIndex: Integer;
+  out ACodePoint: Cardinal): Integer;
+var
+  B1: Byte;
+begin
+  B1 := Ord(AStr[AIndex]);
+
+  // Single byte (ASCII)
+  if B1 < $80 then
+  begin
+    ACodePoint := B1;
+    Result := 1;
+  end
+  // 2-byte sequence
+  else if ((B1 and $E0) = $C0) and (AIndex + 1 <= Length(AStr)) then
+  begin
+    ACodePoint := ((B1 and $1F) shl 6) or
+                  (Ord(AStr[AIndex + 1]) and $3F);
+    Result := 2;
+  end
+  // 3-byte sequence
+  else if ((B1 and $F0) = $E0) and (AIndex + 2 <= Length(AStr)) then
+  begin
+    ACodePoint := ((B1 and $0F) shl 12) or
+                  ((Ord(AStr[AIndex + 1]) and $3F) shl 6) or
+                  (Ord(AStr[AIndex + 2]) and $3F);
+    Result := 3;
+  end
+  // 4-byte sequence
+  else if ((B1 and $F8) = $F0) and (AIndex + 3 <= Length(AStr)) then
+  begin
+    ACodePoint := ((B1 and $07) shl 18) or
+                  ((Ord(AStr[AIndex + 1]) and $3F) shl 12) or
+                  ((Ord(AStr[AIndex + 2]) and $3F) shl 6) or
+                  (Ord(AStr[AIndex + 3]) and $3F);
+    Result := 4;
+  end
+  else
+  begin
+    // Invalid or incomplete sequence — treat as single byte
+    ACodePoint := B1;
+    Result := 1;
+  end;
+end;
+
+// TC39 RegExp Escaping §1.1.1 EncodeForRegExpEscape(c)
+function EncodeForRegExpEscape(const ACodePoint: Cardinal): string;
+var
+  High, Low: Cardinal;
+begin
+  if ACodePoint <= $FF then
+    Result := '\x' + LowerCase(IntToHex(ACodePoint, 2))
+  else if ACodePoint <= $FFFF then
+    Result := '\u' + LowerCase(IntToHex(ACodePoint, 4))
+  else
+  begin
+    // TC39 RegExp Escaping §1.1.1 step 3-7: surrogate pair encoding
+    High := $D800 + ((ACodePoint - $10000) shr 10);
+    Low := $DC00 + ((ACodePoint - $10000) and $3FF);
+    Result := '\u' + LowerCase(IntToHex(High, 4)) +
+              '\u' + LowerCase(IntToHex(Low, 4));
+  end;
+end;
+
+// TC39 RegExp Escaping §1.1 RegExp.escape(string)
+function TGocciaGlobalRegExp.RegExpEscape(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+const
+  SYNTAX_CHARACTERS = ['^', '$', '\', '.', '*', '+', '?',
+    '(', ')', '[', ']', '{', '}', '|', '/'];
+  CLASS_SET_RESERVED_PUNCTUATORS = ['&', '-', '!', '#', '%', ',',
+    ':', ';', '<', '=', '>', '@', '`', '~'];
+var
+  Arg: TGocciaValue;
+  Input, Escaped: string;
+  I, ByteLen: Integer;
+  CodePoint: Cardinal;
+  IsFirst: Boolean;
+begin
+  // TC39 RegExp Escaping §1.1 step 1
+  if AArgs.Length = 0 then
+    ThrowTypeError('RegExp.escape requires a string argument');
+
+  Arg := AArgs.GetElement(0);
+  if not (Arg is TGocciaStringLiteralValue) then
+    ThrowTypeError('First argument to RegExp.escape must be a string');
+
+  Input := Arg.ToStringLiteral.Value;
+  Escaped := '';
+  IsFirst := True;
+  I := 1;
+
+  while I <= Length(Input) do
+  begin
+    ByteLen := DecodeUTF8CodePoint(Input, I, CodePoint);
+
+    // TC39 RegExp Escaping §1.1 step 4a: first code point is digit or letter
+    if IsFirst and (CodePoint < $80) and
+       CharInSet(Chr(CodePoint), ['0'..'9', 'a'..'z', 'A'..'Z']) then
+    begin
+      Escaped := Escaped + EncodeForRegExpEscape(CodePoint);
+      IsFirst := False;
+      Inc(I, ByteLen);
+      Continue;
+    end;
+
+    IsFirst := False;
+
+    // TC39 RegExp Escaping §1.1 step 4b: SyntaxCharacter or solidus
+    if (CodePoint < $80) and CharInSet(Chr(CodePoint), SYNTAX_CHARACTERS) then
+    begin
+      Escaped := Escaped + '\' + Chr(CodePoint);
+      Inc(I, ByteLen);
+      Continue;
+    end;
+
+    // TC39 RegExp Escaping §1.1 step 4c: ClassSetReservedPunctuator
+    if (CodePoint < $80) and
+       CharInSet(Chr(CodePoint), CLASS_SET_RESERVED_PUNCTUATORS) then
+    begin
+      Escaped := Escaped + EncodeForRegExpEscape(CodePoint);
+      Inc(I, ByteLen);
+      Continue;
+    end;
+
+    // TC39 RegExp Escaping §1.1 step 4d: WhiteSpace or LineTerminator
+    if IsECMAScriptWhiteSpaceOrLineTerminator(CodePoint) then
+    begin
+      Escaped := Escaped + EncodeForRegExpEscape(CodePoint);
+      Inc(I, ByteLen);
+      Continue;
+    end;
+
+    // TC39 RegExp Escaping §1.1 step 4e: pass through
+    Escaped := Escaped + Copy(Input, I, ByteLen);
+    Inc(I, ByteLen);
+  end;
+
+  Result := TGocciaStringLiteralValue.Create(Escaped);
 end;
 
 // ES2026 §22.2.3.1 RegExp ( pattern, flags )


### PR DESCRIPTION
## Summary
- Adds `RegExp.escape(string)` as a static `RegExp` method, following the TC39 RegExp Escaping proposal.
- Escapes regex syntax characters, class-set reserved punctuators, whitespace, and line terminators with the correct backslash or hex encodings.
- Hex-encodes a leading ASCII letter or digit to avoid ambiguity with backreferences.
- Updates the built-ins and language-restrictions docs to document the new API.
- Adds end-to-end coverage for escaping behavior, mixed inputs, and regex usability.

## Testing
- Not run: `./build.pas testrunner && ./build/TestRunner tests`
- Not run: targeted inspection of the new `tests/built-ins/RegExp/escape.js` coverage for syntax characters, whitespace, class-set punctuators, and first-character rules
- Not run: native Pascal test suite (`./build.pas clean tests && for t in build/Goccia.*.Test; do "$t"; done`)