### PR TITLE
Add Iterator.concat support

### DIFF
--- a/benchmarks/iterators.js
+++ b/benchmarks/iterators.js
@@ -184,6 +184,62 @@ suite("iterator helpers — user-defined source", () => {
   });
 });
 
+suite("Iterator.concat", () => {
+  const arr10 = Array.from({ length: 10 }, (_, i) => i);
+  const arr20 = Array.from({ length: 20 }, (_, i) => i);
+
+  bench("concat 2 arrays (10 + 10 elements)", {
+    run: () => {
+      const result = Iterator.concat(arr10, arr10).toArray();
+    },
+  });
+
+  bench("concat 5 arrays (10 elements each)", {
+    run: () => {
+      const result = Iterator.concat(arr10, arr10, arr10, arr10, arr10).toArray();
+    },
+  });
+
+  bench("concat 2 arrays (20 + 20 elements)", {
+    run: () => {
+      const result = Iterator.concat(arr20, arr20).toArray();
+    },
+  });
+
+  bench("concat + filter + toArray (20 + 20 elements)", {
+    run: () => {
+      const result = Iterator.concat(arr20, arr20)
+        .filter((x) => x % 2 === 0)
+        .toArray();
+    },
+  });
+
+  bench("concat + map + take (20 + 20 elements, take 10)", {
+    run: () => {
+      const result = Iterator.concat(arr20, arr20)
+        .map((x) => x * 3)
+        .take(10)
+        .toArray();
+    },
+  });
+
+  bench("concat Sets (15 + 15 elements)", {
+    setup: () => ({
+      a: new Set(Array.from({ length: 15 }, (_, i) => i)),
+      b: new Set(Array.from({ length: 15 }, (_, i) => i + 15)),
+    }),
+    run: (ctx) => {
+      const result = Iterator.concat(ctx.a, ctx.b).toArray();
+    },
+  });
+
+  bench("concat strings (13 + 13 characters)", {
+    run: () => {
+      const result = Iterator.concat("abcdefghijklm", "nopqrstuvwxyz").toArray();
+    },
+  });
+});
+
 suite("built-in iterator helpers", () => {
   const arr50 = Array.from({ length: 50 }, (_, i) => i);
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -500,7 +500,7 @@ ErrorName: message
     at outerFunction (filePath:line:col)
 ```
 
-### Iterator (`Goccia.Values.IteratorValue.pas`, `Iterator.Concrete.pas`, `Iterator.Lazy.pas`, `Iterator.Generic.pas`)
+### Iterator (`Goccia.Values.IteratorValue.pas`, `Iterator.Concrete.pas`, `Iterator.Lazy.pas`, `Iterator.Concat.pas`, `Iterator.Generic.pas`)
 
 All built-in iterators (Array, String, Map, Set) share a common `Iterator.prototype` with helper methods per the ECMAScript Iterator Helpers proposal:
 
@@ -526,11 +526,12 @@ Iterators are consumed once — calling `next()` past the end returns `{value: u
 
 **User-defined iterables:** Objects with a `[Symbol.iterator]()` method that returns a plain `{next()}` object are fully supported. They work with spread, destructuring, `Array.from()`, and `Iterator.from()`.
 
-**Static method:**
+**Static methods:**
 
 | Method | Description |
 |--------|-------------|
 | `Iterator.from(value)` | Wrap an iterable, iterator, or `{next()}` object as a proper Iterator with helper methods |
+| `Iterator.concat(...items)` | Concatenate multiple iterables into a single lazy iterator (TC39 Iterator Sequencing). All arguments are validated upfront as iterables; iterators are opened lazily as each iterable is consumed. |
 | `Iterator.prototype` | The shared iterator prototype (accessible for inspection) |
 
 ### Symbol (`Goccia.Builtins.GlobalSymbol.pas`)

--- a/tests/built-ins/Iterator/concat.js
+++ b/tests/built-ins/Iterator/concat.js
@@ -1,0 +1,172 @@
+/*---
+description: Iterator.concat() concatenates multiple iterables into a single iterator
+features: [Iterator, Iterator.concat]
+---*/
+
+describe("Iterator.concat()", () => {
+  test("concatenates two arrays", () => {
+    const result = Iterator.concat([1, 2], [3, 4]).toArray();
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+
+  test("concatenates three arrays", () => {
+    const result = Iterator.concat([1], [2, 3], [4, 5, 6]).toArray();
+    expect(result).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  test("concatenates zero arguments (empty)", () => {
+    const result = Iterator.concat().toArray();
+    expect(result).toEqual([]);
+  });
+
+  test("concatenates a single array", () => {
+    const result = Iterator.concat([10, 20, 30]).toArray();
+    expect(result).toEqual([10, 20, 30]);
+  });
+
+  test("concatenates empty arrays", () => {
+    const result = Iterator.concat([], [1, 2], [], [3], []).toArray();
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  test("concatenates Sets", () => {
+    const a = new Set([1, 2]);
+    const b = new Set([3, 4]);
+    const result = Iterator.concat(a, b).toArray();
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+
+  test("concatenates Maps (yields entries)", () => {
+    const a = new Map([["x", 1]]);
+    const b = new Map([["y", 2]]);
+    const result = Iterator.concat(a, b).toArray();
+    expect(result[0][0]).toBe("x");
+    expect(result[0][1]).toBe(1);
+    expect(result[1][0]).toBe("y");
+    expect(result[1][1]).toBe(2);
+  });
+
+  test("concatenates mixed iterable types", () => {
+    const arr = [1, 2];
+    const set = new Set([3, 4]);
+    const result = Iterator.concat(arr, set).toArray();
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+
+  test("concatenates strings (character iteration)", () => {
+    const result = Iterator.concat("ab", "cd").toArray();
+    expect(result).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("concatenates string with array", () => {
+    const result = Iterator.concat("hi", [1, 2]).toArray();
+    expect(result).toEqual(["h", "i", 1, 2]);
+  });
+
+  test("is lazy — does not consume iterables until next() is called", () => {
+    let opened = 0;
+    const iterable1 = {
+      [Symbol.iterator]() {
+        opened = opened + 1;
+        return [1, 2].values();
+      },
+    };
+    const iterable2 = {
+      [Symbol.iterator]() {
+        opened = opened + 1;
+        return [3, 4].values();
+      },
+    };
+
+    const iter = Iterator.concat(iterable1, iterable2);
+    expect(opened).toBe(0);
+
+    expect(iter.next().value).toBe(1);
+    expect(opened).toBe(1);
+
+    expect(iter.next().value).toBe(2);
+    expect(opened).toBe(1);
+
+    expect(iter.next().value).toBe(3);
+    expect(opened).toBe(2);
+
+    expect(iter.next().value).toBe(4);
+    expect(opened).toBe(2);
+
+    expect(iter.next().done).toBe(true);
+  });
+
+  test("returns done after exhaustion", () => {
+    const iter = Iterator.concat([1]);
+    expect(iter.next()).toEqual({ value: 1, done: false });
+    expect(iter.next()).toEqual({ value: undefined, done: true });
+    expect(iter.next()).toEqual({ value: undefined, done: true });
+  });
+
+  test("result is an iterator (has next and Symbol.iterator)", () => {
+    const iter = Iterator.concat([1]);
+    expect(typeof iter.next).toBe("function");
+    expect(iter[Symbol.iterator]()).toBe(iter);
+  });
+
+  test("result works with iterator helper methods", () => {
+    const result = Iterator.concat([1, 2, 3], [4, 5, 6])
+      .filter((x) => x % 2 === 0)
+      .map((x) => x * 10)
+      .toArray();
+    expect(result).toEqual([20, 40, 60]);
+  });
+
+  test("validates all arguments upfront before iterating", () => {
+    expect(() => Iterator.concat([1], 42, [3])).toThrow(TypeError);
+    expect(() => Iterator.concat([1], null)).toThrow(TypeError);
+    expect(() => Iterator.concat(undefined)).toThrow(TypeError);
+    expect(() => Iterator.concat([1], true)).toThrow(TypeError);
+  });
+
+  test("throws TypeError for object without Symbol.iterator", () => {
+    expect(() => Iterator.concat({ a: 1 })).toThrow(TypeError);
+  });
+
+  test("concatenates user-defined iterables", () => {
+    const range = (start, end) => ({
+      [Symbol.iterator]() {
+        let i = start;
+        return {
+          next() {
+            if (i <= end) {
+              const v = i;
+              i = i + 1;
+              return { value: v, done: false };
+            }
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    });
+
+    const result = Iterator.concat(range(1, 3), range(10, 12)).toArray();
+    expect(result).toEqual([1, 2, 3, 10, 11, 12]);
+  });
+
+  test("closes inner iterator on early termination via take", () => {
+    const result = Iterator.concat([1, 2, 3], [4, 5, 6]).take(4).toArray();
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+
+  test("works with for-of", () => {
+    const result = [];
+    const iter = Iterator.concat([1, 2], [3]);
+    for (const v of iter) {
+      result.push(v);
+    }
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  test("handles large number of iterables", () => {
+    const arrays = Array.from({ length: 100 }, (_, i) => [i]);
+    const expected = Array.from({ length: 100 }, (_, i) => i);
+    const result = Iterator.concat(...arrays).toArray();
+    expect(result).toEqual(expected);
+  });
+});

--- a/units/Goccia.Values.Iterator.Concat.pas
+++ b/units/Goccia.Values.Iterator.Concat.pas
@@ -1,0 +1,213 @@
+unit Goccia.Values.Iterator.Concat;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.IteratorValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaConcatIterableRecord = record
+    Iterable: TGocciaValue;
+    IteratorMethod: TGocciaValue; // nil for string iterables (handled specially)
+  end;
+
+  TGocciaConcatIteratorValue = class(TGocciaIteratorValue)
+  private
+    FIterables: array of TGocciaConcatIterableRecord;
+    FCurrentIndex: Integer;
+    FCurrentIterator: TGocciaIteratorValue;
+    function OpenNextIterator: Boolean;
+  public
+    constructor Create(const AIterables: array of TGocciaConcatIterableRecord);
+    function AdvanceNext: TGocciaObjectValue; override;
+    function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    procedure Close; override;
+    procedure MarkReferences; override;
+  end;
+
+implementation
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Constants.PropertyNames,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
+  Goccia.Values.Iterator.Concrete,
+  Goccia.Values.Iterator.Generic;
+
+procedure CloseIteratorPreservingOriginalError(const AIterator: TGocciaIteratorValue);
+begin
+  if not Assigned(AIterator) then
+    Exit;
+  try
+    AIterator.Close;
+  except
+    // Preserve the original abrupt-completion error when cleanup also throws.
+  end;
+end;
+
+{ TGocciaConcatIteratorValue }
+
+constructor TGocciaConcatIteratorValue.Create(const AIterables: array of TGocciaConcatIterableRecord);
+var
+  I: Integer;
+begin
+  inherited Create;
+  SetLength(FIterables, Length(AIterables));
+  for I := 0 to High(AIterables) do
+    FIterables[I] := AIterables[I];
+  FCurrentIndex := 0;
+  FCurrentIterator := nil;
+end;
+
+// TC39 Iterator Sequencing §1 step 3.a: Open the next iterable's iterator
+function TGocciaConcatIteratorValue.OpenNextIterator: Boolean;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  IteratorObj: TGocciaValue;
+begin
+  Result := False;
+  if FCurrentIndex >= Length(FIterables) then
+    Exit;
+
+  if not Assigned(FIterables[FCurrentIndex].IteratorMethod) then
+  begin
+    // String iterable — create string iterator directly
+    FCurrentIterator := TGocciaStringIteratorValue.Create(FIterables[FCurrentIndex].Iterable);
+  end
+  else
+  begin
+    // TC39 Iterator Sequencing §1 step 3.a.i: Call(method, iterable)
+    CallArgs := TGocciaArgumentsCollection.Create;
+    try
+      IteratorObj := TGocciaFunctionBase(FIterables[FCurrentIndex].IteratorMethod).Call(
+        CallArgs, FIterables[FCurrentIndex].Iterable);
+    finally
+      CallArgs.Free;
+    end;
+
+    // TC39 Iterator Sequencing §1 step 3.a.ii: If iter is not an Object, throw TypeError
+    if not (IteratorObj is TGocciaObjectValue) then
+      ThrowTypeError('Iterator.concat: [Symbol.iterator]() must return an object');
+
+    if IteratorObj is TGocciaIteratorValue then
+      FCurrentIterator := TGocciaIteratorValue(IteratorObj)
+    else
+      FCurrentIterator := TGocciaGenericIteratorValue.Create(IteratorObj);
+  end;
+
+  Inc(FCurrentIndex);
+  Result := True;
+end;
+
+// TC39 Iterator Sequencing §1 step 3.a.v: Yield values from each iterable in sequence
+function TGocciaConcatIteratorValue.AdvanceNext: TGocciaObjectValue;
+var
+  InnerResult: TGocciaObjectValue;
+begin
+  if FDone then
+  begin
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+
+  repeat
+    if Assigned(FCurrentIterator) then
+    begin
+      try
+        InnerResult := FCurrentIterator.AdvanceNext;
+      except
+        CloseIteratorPreservingOriginalError(FCurrentIterator);
+        FCurrentIterator := nil;
+        FDone := True;
+        raise;
+      end;
+      if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
+      begin
+        Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
+        Exit;
+      end;
+      FCurrentIterator := nil;
+    end;
+
+    if not OpenNextIterator then
+    begin
+      FDone := True;
+      Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+      Exit;
+    end;
+  until False;
+end;
+
+// TC39 Iterator Sequencing §1 step 3.a.v: DirectNext variant for performance
+function TGocciaConcatIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+var
+  InnerDone: Boolean;
+  InnerValue: TGocciaValue;
+begin
+  if FDone then
+  begin
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  repeat
+    if Assigned(FCurrentIterator) then
+    begin
+      try
+        InnerValue := FCurrentIterator.DirectNext(InnerDone);
+      except
+        CloseIteratorPreservingOriginalError(FCurrentIterator);
+        FCurrentIterator := nil;
+        FDone := True;
+        raise;
+      end;
+      if not InnerDone then
+      begin
+        ADone := False;
+        Result := InnerValue;
+        Exit;
+      end;
+      FCurrentIterator := nil;
+    end;
+
+    if not OpenNextIterator then
+    begin
+      FDone := True;
+      ADone := True;
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Exit;
+    end;
+  until False;
+end;
+
+procedure TGocciaConcatIteratorValue.Close;
+begin
+  inherited;
+  if Assigned(FCurrentIterator) then
+    FCurrentIterator.Close;
+end;
+
+procedure TGocciaConcatIteratorValue.MarkReferences;
+var
+  I: Integer;
+begin
+  if GCMarked then Exit;
+  inherited;
+  for I := 0 to High(FIterables) do
+  begin
+    if Assigned(FIterables[I].Iterable) then
+      FIterables[I].Iterable.MarkReferences;
+    if Assigned(FIterables[I].IteratorMethod) then
+      FIterables[I].IteratorMethod.MarkReferences;
+  end;
+  if Assigned(FCurrentIterator) then
+    FCurrentIterator.MarkReferences;
+end;
+
+end.

--- a/units/Goccia.Values.Iterator.Concat.pas
+++ b/units/Goccia.Values.Iterator.Concat.pas
@@ -64,7 +64,7 @@ begin
   FCurrentIterator := nil;
 end;
 
-// TC39 Iterator Sequencing §1 step 3.a: Open the next iterable's iterator
+// TC39 Iterator Sequencing §1 Iterator.concat ( ...items ) — steps 3.a.i-iii
 function TGocciaConcatIteratorValue.OpenNextIterator: Boolean;
 var
   CallArgs: TGocciaArgumentsCollection;
@@ -104,7 +104,7 @@ begin
   Result := True;
 end;
 
-// TC39 Iterator Sequencing §1 step 3.a.v: Yield values from each iterable in sequence
+// TC39 Iterator Sequencing §1 Iterator.concat ( ...items ) — step 3.a.iv-v
 function TGocciaConcatIteratorValue.AdvanceNext: TGocciaObjectValue;
 var
   InnerResult: TGocciaObjectValue;
@@ -134,16 +134,21 @@ begin
       FCurrentIterator := nil;
     end;
 
-    if not OpenNextIterator then
-    begin
+    try
+      if not OpenNextIterator then
+      begin
+        FDone := True;
+        Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+        Exit;
+      end;
+    except
       FDone := True;
-      Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-      Exit;
+      raise;
     end;
   until False;
 end;
 
-// TC39 Iterator Sequencing §1 step 3.a.v: DirectNext variant for performance
+// TC39 Iterator Sequencing §1 Iterator.concat ( ...items ) — step 3.a.iv-v (DirectNext)
 function TGocciaConcatIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
 var
   InnerDone: Boolean;
@@ -176,12 +181,17 @@ begin
       FCurrentIterator := nil;
     end;
 
-    if not OpenNextIterator then
-    begin
+    try
+      if not OpenNextIterator then
+      begin
+        FDone := True;
+        ADone := True;
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Exit;
+      end;
+    except
       FDone := True;
-      ADone := True;
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Exit;
+      raise;
     end;
   until False;
 end;

--- a/units/Goccia.Values.Iterator.Concat.pas
+++ b/units/Goccia.Values.Iterator.Concat.pas
@@ -190,7 +190,10 @@ procedure TGocciaConcatIteratorValue.Close;
 begin
   inherited;
   if Assigned(FCurrentIterator) then
+  begin
     FCurrentIterator.Close;
+    FCurrentIterator := nil;
+  end;
 end;
 
 procedure TGocciaConcatIteratorValue.MarkReferences;

--- a/units/Goccia.Values.IteratorValue.pas
+++ b/units/Goccia.Values.IteratorValue.pas
@@ -34,6 +34,7 @@ type
     function IteratorFind(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorFlatMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorFrom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorConcat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     class procedure EnsurePrototypeInitialized;
     procedure InitializePrototype;
@@ -64,6 +65,7 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
+  Goccia.Values.Iterator.Concat,
   Goccia.Values.Iterator.Concrete,
   Goccia.Values.Iterator.Generic,
   Goccia.Values.Iterator.Lazy,
@@ -191,6 +193,7 @@ begin
     Members := TGocciaMemberCollection.Create;
     try
       Members.AddNamedMethod('from', FPrototypeMethodHost.IteratorFrom, 1, gmkStaticMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('concat', FPrototypeMethodHost.IteratorConcat, 0, gmkStaticMethod, [gmfNoFunctionPrototype]);
       FStaticMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -608,6 +611,48 @@ begin
 
   ThrowTypeError('Iterator.from requires an iterable or iterator-like object');
   Result := nil;
+end;
+
+{ Iterator.concat() }
+
+// TC39 Iterator Sequencing §1 Iterator.concat ( ...items )
+function TGocciaIteratorValue.IteratorConcat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  I: Integer;
+  Item, IteratorMethod: TGocciaValue;
+  Iterables: array of TGocciaConcatIterableRecord;
+begin
+  // TC39 Iterator Sequencing §1 step 1: Let iterables be a new empty List.
+  SetLength(Iterables, AArgs.Length);
+
+  // TC39 Iterator Sequencing §1 step 2: For each element item of items
+  for I := 0 to AArgs.Length - 1 do
+  begin
+    Item := AArgs.GetElement(I);
+
+    if Item is TGocciaStringLiteralValue then
+    begin
+      // Strings are iterable primitives — handle specially
+      Iterables[I].Iterable := Item;
+      Iterables[I].IteratorMethod := nil;
+    end
+    else if Item is TGocciaObjectValue then
+    begin
+      // TC39 Iterator Sequencing §1 step 2b: Let method be GetMethod(item, @@iterator)
+      IteratorMethod := TGocciaObjectValue(Item).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
+      // TC39 Iterator Sequencing §1 step 2c: If method is undefined, throw TypeError
+      if not Assigned(IteratorMethod) or (IteratorMethod is TGocciaUndefinedLiteralValue) or not IteratorMethod.IsCallable then
+        ThrowTypeError('Iterator.concat requires all arguments to be iterable');
+      Iterables[I].Iterable := Item;
+      Iterables[I].IteratorMethod := IteratorMethod;
+    end
+    else
+      // TC39 Iterator Sequencing §1 step 2a: If item is not an Object, throw TypeError
+      ThrowTypeError('Iterator.concat requires all arguments to be iterable');
+  end;
+
+  // TC39 Iterator Sequencing §1 steps 3-6: Create iterator from closure
+  Result := TGocciaConcatIteratorValue.Create(Iterables);
 end;
 
 end.


### PR DESCRIPTION
## Summary
- Adds `Iterator.concat(...items)` as a new static iterator helper for lazy concatenation of multiple iterables.
- Implements a dedicated concat iterator value in Pascal, including iterator opening, cleanup, GC marking, and direct `next()` support.
- Expands JavaScript coverage with happy-path, laziness, validation, and interop tests for arrays, sets, maps, strings, and user-defined iterables.
- Updates iterator documentation and adds benchmark coverage for concat workloads.

## Testing
- Not run (changes were reviewed from the patch only).
- Expected verification: `./build.pas testrunner && ./build/TestRunner tests`
- Expected verification for iterator-specific coverage: `./build/TestRunner tests/built-ins/Iterator/concat.js`
- Expected verification for benchmark sanity: `./build/BenchmarkRunner benchmarks/iterators.js`