### PR TITLE
Add reviver source context to JSON.parse and JSON5.parse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,6 +430,8 @@ The TestRunner adds `ggTestAssertions`; the BenchmarkRunner adds `ggBenchmark`. 
 
 After all flag-gated built-ins, two always-present `const` globals are created: `globalThis` (self-referential global object) and `Goccia` (engine metadata with `version`, `commit`, `builtIns`, `strictTypes`, and `semver`).
 
+**JSON/JSON5 source text access (ES2024):** `JSON.parse` and `JSON5.parse` revivers receive `(key, value, context)` where `context` is an object with a `source` property for primitive values (the raw JSON/JSON5 text as written). Objects and arrays get an empty context (no `source` property). Source text collection is implemented via `TAbstractJSONParser.OnValueStart` (position tracking hook in `JSONParser.pas`) and `TGocciaJSONVisitor.RecordSourceText` (captures the raw substring). `TGocciaJSONParser.ParseWithSources` returns both the value tree and a flat source text list consumed in depth-first order by `ApplyReviver`. See [docs/built-ins.md](docs/built-ins.md) for details.
+
 **JSX:** Opt-in pre-pass transformer (`Goccia.JSX.Transformer.pas`) converts JSX to `createElement` calls. Users provide their own `createElement`/`Fragment`. Custom factory via `@jsxFactory`/`@jsxFragment` pragmas. See [docs/language-restrictions.md](docs/language-restrictions.md#jsx-opt-in).
 
 ## Testing

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -147,8 +147,10 @@ All methods handle `NaN` and `Infinity` edge cases correctly.
 
 | Method | Description |
 |--------|-------------|
-| `JSON.parse(text, reviver?)` | Parse JSON string to value, with optional reviver function |
+| `JSON.parse(text, reviver?)` | Parse JSON string to value, with optional reviver function that receives source text access |
 | `JSON.stringify(value, replacer?, space?)` | Convert value to JSON string, with optional replacer (function or array) and indentation |
+
+**Source text access (ES2024):** When a reviver is provided, it receives three arguments: `(key, value, context)`. The `context` parameter is an object. For primitive JSON values (numbers, strings, booleans, `null`), the context contains a `source` property with the raw JSON text that produced the value — including quotes for strings, exact numeric notation, and escape sequences as written. For objects and arrays, the context object has no `source` property. This enables lossless round-tripping of numeric precision and format-aware value reconstruction.
 
 The JSON parser is a recursive descent implementation. Special handling:
 - `NaN` → `null` in stringify
@@ -163,10 +165,10 @@ The JSON parser is a recursive descent implementation. Special handling:
 
 | Method | Description |
 |--------|-------------|
-| `JSON5.parse(text, reviver?)` | Parse JSON5 text to a value, with optional reviver function |
+| `JSON5.parse(text, reviver?)` | Parse JSON5 text to a value, with optional reviver function that receives source text access |
 | `JSON5.stringify(value, replacerOrOptions?, space?)` | Serialize a value with JSON5 syntax, including special numeric values and optional `quote` override |
 
-`JSON5.parse` delegates to the standalone `TGocciaJSON5Parser` utility in `Goccia.JSON5`. The JSON5 parser shares the same core capability-driven parser engine as strict JSON, so `JSON.parse(...)` stays strict while `JSON5.parse(...)` opts into comments, trailing commas, single-quoted strings, unquoted identifier keys, hexadecimal numbers, signed numbers, `Infinity`, `NaN`, line continuations, and ECMAScript whitespace extensions.
+`JSON5.parse` delegates to the standalone `TGocciaJSON5Parser` utility in `Goccia.JSON5`. The JSON5 parser shares the same core capability-driven parser engine as strict JSON, so `JSON.parse(...)` stays strict while `JSON5.parse(...)` opts into comments, trailing commas, single-quoted strings, unquoted identifier keys, hexadecimal numbers, signed numbers, `Infinity`, `NaN`, line continuations, and ECMAScript whitespace extensions. Source text access works identically to `JSON.parse`: the reviver receives `(key, value, context)` where `context.source` preserves the raw JSON5 text for primitives (including extended literals like `Infinity`, `NaN`, `0xFF`, and `+1`).
 
 `JSON5.stringify` delegates to `TGocciaJSON5Stringifier`, which reuses the same shared serialization core as strict JSON but switches to JSON5 formatting rules. That means unquoted identifier keys, single- or double-quoted strings (with optional `{ quote: "'" | '"' }` override), preserved `Infinity` / `-Infinity` / `NaN`, trailing commas when pretty-printing, `toJSON5()` preference over `toJSON()`, and the same replacer / space semantics as JSON plus the upstream JSON5 options-object form `{ replacer, space, quote }`.
 

--- a/tests/built-ins/JSON/parse.js
+++ b/tests/built-ins/JSON/parse.js
@@ -318,3 +318,22 @@ test("JSON.parse reviver source with negative numbers", () => {
   });
   expect(src).toBe("-42");
 });
+
+test("JSON.parse reviver source text is reentrant", () => {
+  const outerSources = [];
+  const result = JSON.parse('{"a":1,"b":2}', (key, value, context) => {
+    if (key !== "") {
+      outerSources.push(context.source);
+      // Nested JSON.parse with its own reviver must not clobber outer state.
+      const inner = JSON.parse('"nested"', (k, v, ctx) => {
+        expect(ctx.source).toBe('"nested"');
+        return v;
+      });
+      expect(inner).toBe("nested");
+    }
+    return value;
+  });
+  expect(outerSources).toEqual(["1", "2"]);
+  expect(result.a).toBe(1);
+  expect(result.b).toBe(2);
+});

--- a/tests/built-ins/JSON/parse.js
+++ b/tests/built-ins/JSON/parse.js
@@ -197,3 +197,124 @@ test("JSON.parse reviver visits nested properties before parents", () => {
 
   expect(keys).toEqual(["inner", "outer", "0", "list", ""]);
 });
+
+test("JSON.parse reviver receives context with source for number", () => {
+  let receivedSource;
+  JSON.parse("42", (key, value, context) => {
+    if (key === "") {
+      receivedSource = context.source;
+    }
+    return value;
+  });
+  expect(receivedSource).toBe("42");
+});
+
+test("JSON.parse reviver receives context with source for string", () => {
+  let receivedSource;
+  JSON.parse('"hello"', (key, value, context) => {
+    if (key === "") {
+      receivedSource = context.source;
+    }
+    return value;
+  });
+  expect(receivedSource).toBe('"hello"');
+});
+
+test("JSON.parse reviver receives context with source for boolean and null", () => {
+  const sources = [];
+  JSON.parse("[true, false, null]", (key, value, context) => {
+    if (key !== "") {
+      sources.push(context.source);
+    }
+    return value;
+  });
+  expect(sources).toEqual(["true", "false", "null"]);
+});
+
+test("JSON.parse reviver context has no source for objects and arrays", () => {
+  const contextHasSource = [];
+  JSON.parse('{"a":{"b":1},"c":[2]}', (key, value, context) => {
+    if (key !== "") {
+      contextHasSource.push({ key, has: "source" in context });
+    }
+    return value;
+  });
+  expect(contextHasSource).toEqual([
+    { key: "b", has: true },
+    { key: "a", has: false },
+    { key: "0", has: true },
+    { key: "c", has: false },
+  ]);
+});
+
+test("JSON.parse reviver source preserves raw JSON text", () => {
+  const sources = {};
+  JSON.parse('{"a":"caf\\u00e9","b":1e2,"c":-0}', (key, value, context) => {
+    if (key !== "" && context.source !== undefined) {
+      sources[key] = context.source;
+    }
+    return value;
+  });
+  expect(sources.a).toBe('"caf\\u00e9"');
+  expect(sources.b).toBe("1e2");
+  expect(sources.c).toBe("-0");
+});
+
+test("JSON.parse reviver source for nested array primitives", () => {
+  const sources = [];
+  JSON.parse("[[1, 2], [3]]", (key, value, context) => {
+    if (context.source !== undefined) {
+      sources.push(context.source);
+    }
+    return value;
+  });
+  expect(sources).toEqual(["1", "2", "3"]);
+});
+
+test("JSON.parse reviver source for root primitive", () => {
+  const rootSources = [];
+  const check = (json) => {
+    JSON.parse(json, (key, value, context) => {
+      if (key === "") {
+        rootSources.push(context.source);
+      }
+      return value;
+    });
+  };
+  check("42");
+  check('"text"');
+  check("true");
+  check("null");
+  expect(rootSources).toEqual(["42", '"text"', "true", "null"]);
+});
+
+test("JSON.parse reviver context is always an object", () => {
+  const contextTypes = [];
+  JSON.parse('{"a":1}', (key, value, context) => {
+    contextTypes.push(typeof context);
+    return value;
+  });
+  expect(contextTypes).toEqual(["object", "object"]);
+});
+
+test("JSON.parse reviver source with decimal numbers", () => {
+  let src;
+  JSON.parse("3.14", (key, value, context) => {
+    if (key === "") {
+      src = context.source;
+    }
+    return value;
+  });
+  expect(src).toBe("3.14");
+});
+
+test("JSON.parse reviver source with negative numbers", () => {
+  let src;
+  JSON.parse("-42", (key, value, context) => {
+    if (key === "") {
+      src = context.source;
+    }
+    return value;
+  });
+  expect(src).toBe("-42");
+});

--- a/tests/built-ins/JSON5/parse.js
+++ b/tests/built-ins/JSON5/parse.js
@@ -102,4 +102,48 @@ No \\\\n's!",
     expect(() => JSON5.parse("{\\u00A0: 1}")).toThrow(SyntaxError);
     expect(() => JSON5.parse("/*")).toThrow(SyntaxError);
   });
+
+  test("reviver receives context with source for primitives", () => {
+    const sources = {};
+    JSON5.parse("{a: 42, b: 'hello', c: true, d: null}", (key, value, context) => {
+      if (key !== "" && context.source !== undefined) {
+        sources[key] = context.source;
+      }
+      return value;
+    });
+    expect(sources.a).toBe("42");
+    expect(sources.b).toBe("'hello'");
+    expect(sources.c).toBe("true");
+    expect(sources.d).toBe("null");
+  });
+
+  test("reviver context has no source for objects and arrays", () => {
+    const results = [];
+    JSON5.parse("{obj: {x: 1}, arr: [2]}", (key, value, context) => {
+      if (key !== "") {
+        results.push({ key, has: "source" in context });
+      }
+      return value;
+    });
+    expect(results).toEqual([
+      { key: "x", has: true },
+      { key: "obj", has: false },
+      { key: "0", has: true },
+      { key: "arr", has: false },
+    ]);
+  });
+
+  test("reviver source preserves raw JSON5 text", () => {
+    const sources = {};
+    JSON5.parse("{a: Infinity, b: NaN, c: 0xFF, d: +1}", (key, value, context) => {
+      if (key !== "" && context.source !== undefined) {
+        sources[key] = context.source;
+      }
+      return value;
+    });
+    expect(sources.a).toBe("Infinity");
+    expect(sources.b).toBe("NaN");
+    expect(sources.c).toBe("0xFF");
+    expect(sources.d).toBe("+1");
+  });
 });

--- a/units/Goccia.Builtins.JSON.pas
+++ b/units/Goccia.Builtins.JSON.pas
@@ -168,6 +168,8 @@ end;
 function TGocciaJSONBuiltin.JSONParse(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   HasReviver: Boolean;
+  PreviousSourceIndex: Integer;
+  PreviousSourceTexts: TStringList;
   Reviver: TGocciaValue;
   Root: TGocciaObjectValue;
   SourceTexts: TStringList;
@@ -199,13 +201,16 @@ begin
       Root := TGocciaObjectValue.Create;
       Root.AssignProperty('', Result);
 
+      // Save/restore for reentrancy (reviver may call JSON.parse).
+      PreviousSourceTexts := FReviverSourceTexts;
+      PreviousSourceIndex := FReviverSourceIndex;
       FReviverSourceTexts := SourceTexts;
       FReviverSourceIndex := 0;
       try
         Result := ApplyReviver(Root, '', Reviver);
       finally
-        FReviverSourceTexts := nil;
-        FReviverSourceIndex := 0;
+        FReviverSourceTexts := PreviousSourceTexts;
+        FReviverSourceIndex := PreviousSourceIndex;
       end;
     finally
       SourceTexts.Free;

--- a/units/Goccia.Builtins.JSON.pas
+++ b/units/Goccia.Builtins.JSON.pas
@@ -5,6 +5,7 @@ unit Goccia.Builtins.JSON;
 interface
 
 uses
+  Classes,
   Generics.Collections,
 
   Goccia.Arguments.Collection,
@@ -23,8 +24,10 @@ type
   private
     class var FStaticMembers: array of TGocciaMemberDefinition;
     FParser: TGocciaJSONParser;
-    FStringifier: TGocciaJSONStringifier;
     FReplacerTraversalStack: TList<TGocciaObjectValue>;
+    FReviverSourceIndex: Integer;
+    FReviverSourceTexts: TStringList;
+    FStringifier: TGocciaJSONStringifier;
 
     function ApplyReviver(const AHolder: TGocciaValue; const AKey: string; const AReviver: TGocciaValue): TGocciaValue;
     function ApplyReplacer(const AHolder: TGocciaValue; const AKey: string; const AValue: TGocciaValue; const AReplacer: TGocciaValue): TGocciaValue;
@@ -90,7 +93,7 @@ begin
   inherited;
 end;
 
-// §25.5.1.1 InternalizeJSONProperty ( holder, name, reviver )
+// ES2026 §25.5.1.1 InternalizeJSONProperty ( holder, name, reviver )
 function TGocciaJSONBuiltin.ApplyReviver(const AHolder: TGocciaValue; const AKey: string; const AReviver: TGocciaValue): TGocciaValue;
 var
   Value, NewValue: TGocciaValue;
@@ -99,6 +102,7 @@ var
   I: Integer;
   PropKey: string;
   Args: TGocciaArgumentsCollection;
+  Context: TGocciaObjectValue;
 begin
   // Step 1: Let val be ? Get(holder, name).
   Value := AHolder.GetProperty(AKey);
@@ -138,18 +142,31 @@ begin
     end;
   end;
 
-  // Step 3: Return ? Call(reviver, holder, « name, val »).
-  Args := TGocciaArgumentsCollection.Create;
+  // ES2026 §25.5.1.1 step 3: Build the context object for source text access.
+  Context := TGocciaObjectValue.Create;
+  if not (Value is TGocciaObjectValue) and Assigned(FReviverSourceTexts) and
+    (FReviverSourceIndex < FReviverSourceTexts.Count) then
+  begin
+    Context.AssignProperty(PROP_SOURCE,
+      TGocciaStringLiteralValue.Create(FReviverSourceTexts[FReviverSourceIndex]));
+    Inc(FReviverSourceIndex);
+  end;
+
+  // Step 4: Return ? Call(reviver, holder, « name, val, context »).
+  Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
   Args.Add(TGocciaStringLiteralValue.Create(AKey));
   Args.Add(Value);
+  Args.Add(Context);
   Result := InvokeCallable(AReviver, Args, AHolder);
 end;
 
-// §25.5.1 JSON.parse ( text [ , reviver ] )
+// ES2026 §25.5.1 JSON.parse ( text [ , reviver ] )
 function TGocciaJSONBuiltin.JSONParse(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
+  HasReviver: Boolean;
   Reviver: TGocciaValue;
   Root: TGocciaObjectValue;
+  SourceTexts: TStringList;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON.parse', ThrowError);
 
@@ -157,30 +174,49 @@ begin
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
     ThrowError('JSON.parse: argument must be a string', 0, 0);
 
-  // Step 2: Parse jsonString as a JSON text (throw SyntaxError on failure).
-  // Let unfiltered be the result.
-  try
-    Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
-  except
-    on E: Exception do
-      ThrowSyntaxError(E.Message);
-  end;
+  // Step 2-3: Parse and optionally apply the reviver with source text access.
+  HasReviver := (AArgs.Length >= 2) and AArgs.GetElement(1).IsCallable;
 
-  // Step 3: If reviver is callable, wrap in root object and apply InternalizeJSONProperty.
-  if AArgs.Length >= 2 then
+  if HasReviver then
   begin
     Reviver := AArgs.GetElement(1);
-    if Reviver.IsCallable then
-    begin
-      // Step 3a: Let root be OrdinaryObjectCreate(null).
+    SourceTexts := TStringList.Create;
+    try
+      // Step 2: Parse with source text tracking for the reviver context.
+      try
+        FParser.ParseWithSources(
+          AArgs.GetElement(0).ToStringLiteral.Value, Result, SourceTexts);
+      except
+        on E: Exception do
+          ThrowSyntaxError(E.Message);
+      end;
+
+      // Step 3: Wrap in root object and apply InternalizeJSONProperty.
       Root := TGocciaObjectValue.Create;
-      // Step 3b: Perform ! CreateDataPropertyOrThrow(root, "", unfiltered).
       Root.AssignProperty('', Result);
-      // Step 3c: Return ? InternalizeJSONProperty(root, "", reviver).
-      Result := ApplyReviver(Root, '', Reviver);
+
+      FReviverSourceTexts := SourceTexts;
+      FReviverSourceIndex := 0;
+      try
+        Result := ApplyReviver(Root, '', Reviver);
+      finally
+        FReviverSourceTexts := nil;
+        FReviverSourceIndex := 0;
+      end;
+    finally
+      SourceTexts.Free;
+    end;
+  end
+  else
+  begin
+    // No reviver — parse without source text collection.
+    try
+      Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
+    except
+      on E: Exception do
+        ThrowSyntaxError(E.Message);
     end;
   end;
-  // Step 4: Else return unfiltered.
 end;
 
 // §25.5.2 steps 7-8: Resolve the gap (indentation) string from the space argument.

--- a/units/Goccia.Builtins.JSON.pas
+++ b/units/Goccia.Builtins.JSON.pas
@@ -154,10 +154,14 @@ begin
 
   // Step 4: Return ? Call(reviver, holder, « name, val, context »).
   Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
-  Args.Add(TGocciaStringLiteralValue.Create(AKey));
-  Args.Add(Value);
-  Args.Add(Context);
-  Result := InvokeCallable(AReviver, Args, AHolder);
+  try
+    Args.Add(TGocciaStringLiteralValue.Create(AKey));
+    Args.Add(Value);
+    Args.Add(Context);
+    Result := InvokeCallable(AReviver, Args, AHolder);
+  finally
+    Args.Free;
+  end;
 end;
 
 // ES2026 §25.5.1 JSON.parse ( text [ , reviver ] )

--- a/units/Goccia.Builtins.JSON5.pas
+++ b/units/Goccia.Builtins.JSON5.pas
@@ -205,10 +205,14 @@ begin
   end;
 
   Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
-  Args.Add(TGocciaStringLiteralValue.Create(AKey));
-  Args.Add(Value);
-  Args.Add(Context);
-  Result := InvokeCallable(AReviver, Args, AHolder);
+  try
+    Args.Add(TGocciaStringLiteralValue.Create(AKey));
+    Args.Add(Value);
+    Args.Add(Context);
+    Result := InvokeCallable(AReviver, Args, AHolder);
+  finally
+    Args.Free;
+  end;
 end;
 
 function TGocciaJSON5Builtin.ApplyToJSON(const AValue: TGocciaValue;

--- a/units/Goccia.Builtins.JSON5.pas
+++ b/units/Goccia.Builtins.JSON5.pas
@@ -5,6 +5,7 @@ unit Goccia.Builtins.JSON5;
 interface
 
 uses
+  Classes,
   Generics.Collections,
 
   Goccia.Arguments.Collection,
@@ -23,8 +24,10 @@ type
   private
     class var FStaticMembers: array of TGocciaMemberDefinition;
     FParser: TGocciaJSON5Parser;
-    FStringifier: TGocciaJSON5Stringifier;
     FReplacerTraversalStack: TList<TGocciaObjectValue>;
+    FReviverSourceIndex: Integer;
+    FReviverSourceTexts: TStringList;
+    FStringifier: TGocciaJSON5Stringifier;
 
     function ApplyReviver(const AHolder: TGocciaValue; const AKey: string;
       const AReviver: TGocciaValue): TGocciaValue;
@@ -148,11 +151,13 @@ begin
   inherited;
 end;
 
+// ES2026 §25.5.1.1 InternalizeJSONProperty ( holder, name, reviver )
 function TGocciaJSON5Builtin.ApplyReviver(const AHolder: TGocciaValue;
   const AKey: string; const AReviver: TGocciaValue): TGocciaValue;
 var
   Args: TGocciaArgumentsCollection;
   Arr: TGocciaArrayValue;
+  Context: TGocciaObjectValue;
   I: Integer;
   NewValue: TGocciaValue;
   Obj: TGocciaObjectValue;
@@ -189,14 +194,21 @@ begin
     end;
   end;
 
-  Args := TGocciaArgumentsCollection.Create;
-  try
-    Args.Add(TGocciaStringLiteralValue.Create(AKey));
-    Args.Add(Value);
-    Result := InvokeCallable(AReviver, Args, AHolder);
-  finally
-    Args.Free;
+  // Build the context object for source text access.
+  Context := TGocciaObjectValue.Create;
+  if not (Value is TGocciaObjectValue) and Assigned(FReviverSourceTexts) and
+    (FReviverSourceIndex < FReviverSourceTexts.Count) then
+  begin
+    Context.AssignProperty(PROP_SOURCE,
+      TGocciaStringLiteralValue.Create(FReviverSourceTexts[FReviverSourceIndex]));
+    Inc(FReviverSourceIndex);
   end;
+
+  Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
+  Args.Add(TGocciaStringLiteralValue.Create(AKey));
+  Args.Add(Value);
+  Args.Add(Context);
+  Result := InvokeCallable(AReviver, Args, AHolder);
 end;
 
 function TGocciaJSON5Builtin.ApplyToJSON(const AValue: TGocciaValue;
@@ -524,29 +536,53 @@ function TGocciaJSON5Builtin.JSON5Parse(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
+  HasReviver: Boolean;
   Reviver: TGocciaValue;
   Root: TGocciaObjectValue;
+  SourceTexts: TStringList;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON5.parse', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
     ThrowError('JSON5.parse: argument must be a string', 0, 0);
 
-  try
-    Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
-  except
-    on E: Exception do
-      ThrowSyntaxError(E.Message);
-  end;
+  HasReviver := (AArgs.Length >= 2) and AArgs.GetElement(1).IsCallable;
 
-  if AArgs.Length >= 2 then
+  if HasReviver then
   begin
     Reviver := AArgs.GetElement(1);
-    if Reviver.IsCallable then
-    begin
+    SourceTexts := TStringList.Create;
+    try
+      try
+        FParser.ParseWithSources(
+          AArgs.GetElement(0).ToStringLiteral.Value, Result, SourceTexts);
+      except
+        on E: Exception do
+          ThrowSyntaxError(E.Message);
+      end;
+
       Root := TGocciaObjectValue.Create;
       Root.AssignProperty('', Result);
-      Result := ApplyReviver(Root, '', Reviver);
+
+      FReviverSourceTexts := SourceTexts;
+      FReviverSourceIndex := 0;
+      try
+        Result := ApplyReviver(Root, '', Reviver);
+      finally
+        FReviverSourceTexts := nil;
+        FReviverSourceIndex := 0;
+      end;
+    finally
+      SourceTexts.Free;
+    end;
+  end
+  else
+  begin
+    try
+      Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
+    except
+      on E: Exception do
+        ThrowSyntaxError(E.Message);
     end;
   end;
 end;

--- a/units/Goccia.Builtins.JSON5.pas
+++ b/units/Goccia.Builtins.JSON5.pas
@@ -541,6 +541,8 @@ function TGocciaJSON5Builtin.JSON5Parse(
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   HasReviver: Boolean;
+  PreviousSourceIndex: Integer;
+  PreviousSourceTexts: TStringList;
   Reviver: TGocciaValue;
   Root: TGocciaObjectValue;
   SourceTexts: TStringList;
@@ -568,13 +570,16 @@ begin
       Root := TGocciaObjectValue.Create;
       Root.AssignProperty('', Result);
 
+      // Save/restore for reentrancy (reviver may call JSON5.parse).
+      PreviousSourceTexts := FReviverSourceTexts;
+      PreviousSourceIndex := FReviverSourceIndex;
       FReviverSourceTexts := SourceTexts;
       FReviverSourceIndex := 0;
       try
         Result := ApplyReviver(Root, '', Reviver);
       finally
-        FReviverSourceTexts := nil;
-        FReviverSourceIndex := 0;
+        FReviverSourceTexts := PreviousSourceTexts;
+        FReviverSourceIndex := PreviousSourceIndex;
       end;
     finally
       SourceTexts.Free;

--- a/units/Goccia.JSON.pas
+++ b/units/Goccia.JSON.pas
@@ -5,6 +5,7 @@ unit Goccia.JSON;
 interface
 
 uses
+  Classes,
   Generics.Collections,
   SysUtils,
 
@@ -26,6 +27,8 @@ type
     constructor Create(
       const ACapabilities: TJSONParserCapabilities); overload;
     function Parse(const AText: UTF8String): TGocciaValue; virtual;
+    procedure ParseWithSources(const AText: UTF8String;
+      out AValue: TGocciaValue; const ASourceTexts: TStringList);
   end;
 
   TGocciaJSONStringifier = class
@@ -60,8 +63,6 @@ type
 implementation
 
 uses
-  Classes,
-
   StringBuffer,
 
   Goccia.Arguments.Collection,
@@ -76,9 +77,13 @@ uses
 type
   TGocciaJSONVisitor = class(TAbstractJSONParser)
   private
-    FStack: TList<TGocciaValue>;
+    FCollectSources: Boolean;
     FKeyStack: TStringList;
     FResult: TGocciaValue;
+    FSourceTexts: TStringList;
+    FStack: TList<TGocciaValue>;
+    FValueStartPosition: Integer;
+    procedure RecordSourceText;
   protected
     procedure OnNull; override;
     procedure OnBoolean(const AValue: Boolean); override;
@@ -90,6 +95,7 @@ type
     procedure OnEndObject; override;
     procedure OnBeginArray; override;
     procedure OnEndArray; override;
+    procedure OnValueStart; override;
     procedure EmitValue(const AValue: TGocciaValue);
   public
     constructor Create;
@@ -97,6 +103,8 @@ type
       const ACapabilities: TJSONParserCapabilities);
     destructor Destroy; override;
     function Parse(const AText: UTF8String): TGocciaValue;
+    property CollectSources: Boolean read FCollectSources write FCollectSources;
+    property SourceTexts: TStringList read FSourceTexts;
   end;
 
 const
@@ -345,6 +353,26 @@ begin
   end;
 end;
 
+procedure TGocciaJSONParser.ParseWithSources(const AText: UTF8String;
+  out AValue: TGocciaValue; const ASourceTexts: TStringList);
+var
+  Visitor: TGocciaJSONVisitor;
+begin
+  Visitor := TGocciaJSONVisitor.Create(FCapabilities);
+  try
+    Visitor.CollectSources := True;
+    try
+      AValue := Visitor.Parse(AText);
+      ASourceTexts.Assign(Visitor.SourceTexts);
+    except
+      on E: EJSONParseError do
+        raise EGocciaJSONParseError.Create(E.Message);
+    end;
+  finally
+    Visitor.Free;
+  end;
+end;
+
 { TGocciaJSONVisitor }
 
 constructor TGocciaJSONVisitor.Create;
@@ -358,13 +386,16 @@ begin
   inherited Create(ACapabilities);
   FStack := TList<TGocciaValue>.Create;
   FKeyStack := TStringList.Create;
+  FSourceTexts := TStringList.Create;
   FResult := nil;
+  FCollectSources := False;
 end;
 
 destructor TGocciaJSONVisitor.Destroy;
 begin
   FStack.Free;
   FKeyStack.Free;
+  FSourceTexts.Free;
   inherited;
 end;
 
@@ -372,6 +403,18 @@ function TGocciaJSONVisitor.Parse(const AText: UTF8String): TGocciaValue;
 begin
   DoParse(AText);
   Result := FResult;
+end;
+
+procedure TGocciaJSONVisitor.OnValueStart;
+begin
+  FValueStartPosition := CurrentPosition;
+end;
+
+procedure TGocciaJSONVisitor.RecordSourceText;
+begin
+  if FCollectSources then
+    FSourceTexts.Add(Copy(string(SourceTextData), FValueStartPosition,
+      CurrentPosition - FValueStartPosition));
 end;
 
 procedure TGocciaJSONVisitor.EmitValue(const AValue: TGocciaValue);
@@ -397,11 +440,13 @@ end;
 
 procedure TGocciaJSONVisitor.OnNull;
 begin
+  RecordSourceText;
   EmitValue(TGocciaNullLiteralValue.NullValue);
 end;
 
 procedure TGocciaJSONVisitor.OnBoolean(const AValue: Boolean);
 begin
+  RecordSourceText;
   if AValue then
     EmitValue(TGocciaBooleanLiteralValue.TrueValue)
   else
@@ -410,16 +455,19 @@ end;
 
 procedure TGocciaJSONVisitor.OnString(const AValue: string);
 begin
+  RecordSourceText;
   EmitValue(TGocciaStringLiteralValue.Create(AValue));
 end;
 
 procedure TGocciaJSONVisitor.OnInteger(const AValue: Int64);
 begin
+  RecordSourceText;
   EmitValue(TGocciaNumberLiteralValue.Create(AValue));
 end;
 
 procedure TGocciaJSONVisitor.OnFloat(const AValue: Double);
 begin
+  RecordSourceText;
   EmitValue(TGocciaNumberLiteralValue.Create(AValue));
 end;
 

--- a/units/JSONParser.pas
+++ b/units/JSONParser.pas
@@ -109,6 +109,10 @@ type
     procedure OnEndObject; virtual; abstract;
     procedure OnBeginArray; virtual; abstract;
     procedure OnEndArray; virtual; abstract;
+    procedure OnValueStart; virtual;
+
+    property CurrentPosition: Integer read FPosition;
+    property SourceTextData: UTF8String read FText;
   public
     constructor Create; overload; virtual;
     constructor Create(
@@ -363,6 +367,11 @@ begin
     Inc(FPosition, Length(Result));
 end;
 
+procedure TAbstractJSONParser.OnValueStart;
+begin
+  // No-op by default. Subclasses override to track value source positions.
+end;
+
 procedure TAbstractJSONParser.DoParseValue;
 var
   Ch: Char;
@@ -370,6 +379,8 @@ begin
   SkipWhitespace;
   if IsAtEnd then
     RaiseParseError('Unexpected end of JSON input');
+
+  OnValueStart;
 
   Ch := PeekChar;
   case Ch of


### PR DESCRIPTION
## Summary
- Adds `context.source` support to `JSON.parse` and `JSON5.parse` revivers for primitive values.
- Preserves raw source text for numbers, strings, booleans, null, and JSON5-specific literals such as `Infinity`, `NaN`, and hex numbers.
- Keeps object and array reviver contexts without a `source` field.
- Extends the parser layer to record source spans when reviver source tracking is enabled.

## Testing
- Added end-to-end coverage for `JSON.parse` reviver source behavior in `tests/built-ins/JSON/parse.js`.
- Added end-to-end coverage for `JSON5.parse` reviver source behavior in `tests/built-ins/JSON5/parse.js`.
- Not run: `./build.pas testrunner && ./build/TestRunner tests`.