### PR TITLE
Add `atob` and `btoa` global functions

### DIFF
--- a/benchmarks/base64.js
+++ b/benchmarks/base64.js
@@ -1,0 +1,77 @@
+/*---
+description: Base64 encoding and decoding benchmarks (btoa/atob)
+---*/
+
+const SHORT_ASCII = "Hello, World!";
+const MEDIUM_ASCII = "The quick brown fox jumps over the lazy dog. ".repeat(10);
+const LATIN1 = String.fromCharCode(0x00, 0x41, 0x80, 0xC0, 0xFF, 0xA9, 0xBE, 0x7F);
+
+const SHORT_B64 = btoa(SHORT_ASCII);
+const MEDIUM_B64 = btoa(MEDIUM_ASCII);
+const LATIN1_B64 = btoa(LATIN1);
+
+suite("btoa", () => {
+  bench("short ASCII (13 chars)", {
+    run: () => {
+      btoa(SHORT_ASCII);
+    },
+  });
+
+  bench("medium ASCII (450 chars)", {
+    run: () => {
+      btoa(MEDIUM_ASCII);
+    },
+  });
+
+  bench("Latin-1 characters", {
+    run: () => {
+      btoa(LATIN1);
+    },
+  });
+});
+
+suite("atob", () => {
+  bench("short base64 (20 chars)", {
+    run: () => {
+      atob(SHORT_B64);
+    },
+  });
+
+  bench("medium base64 (600 chars)", {
+    run: () => {
+      atob(MEDIUM_B64);
+    },
+  });
+
+  bench("Latin-1 output", {
+    run: () => {
+      atob(LATIN1_B64);
+    },
+  });
+
+  bench("forgiving (no padding)", {
+    run: () => {
+      atob("SGVsbG8");
+    },
+  });
+
+  bench("with whitespace", {
+    run: () => {
+      atob("SGVs bG8s\nIFdv\tcmxk IQ==");
+    },
+  });
+});
+
+suite("round-trip", () => {
+  bench("atob(btoa(short))", {
+    run: () => {
+      atob(btoa(SHORT_ASCII));
+    },
+  });
+
+  bench("atob(btoa(medium))", {
+    run: () => {
+      atob(btoa(MEDIUM_ASCII));
+    },
+  });
+});

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -466,10 +466,16 @@ The constructor-backed objects mirror the `node-semver` public fields and core i
 |----------|-------------|
 | `queueMicrotask(callback)` | Enqueue a callback to run as a microtask. Throws `TypeError` if the argument is not callable. |
 | `structuredClone(value)` | Deep-clone a value using the structured clone algorithm. Handles objects, arrays, `Map`, `Set`, and circular references. Throws `DOMException` with name `"DataCloneError"` (code 25) for non-cloneable types (functions, symbols). |
+| `btoa(data)` | Encode a binary string (each character code ≤ U+00FF) to base64. Throws `DOMException` with name `"InvalidCharacterError"` (code 5) if any character code exceeds U+00FF. |
+| `atob(data)` | Decode a base64 string to a binary string. Uses WHATWG forgiving-base64-decode: strips ASCII whitespace, tolerates missing `=` padding. Throws `DOMException` with name `"InvalidCharacterError"` (code 5) for invalid base64 input. |
 
 `queueMicrotask` shares the same microtask queue used by Promise reactions. Callbacks run after the current synchronous code completes but before the engine returns control. If a callback throws, the error is silently discarded and remaining microtasks still execute.
 
 `structuredClone` creates a deep copy following the HTML spec's structured clone algorithm. Primitives are returned as-is. Objects, arrays, Maps, and Sets are recursively cloned. Circular references and shared references within the object graph are preserved (the same cloned object is reused). Non-serializable values (functions, symbols) throw a `DOMException` with `name: "DataCloneError"` and `code: 25`, matching browser and Node.js behavior. Accessor properties (getters/setters) are read via the getter and the resulting value is cloned as a data property on the clone.
+
+`btoa` encodes a string to base64 following the WHATWG HTML spec §8.3. Each character in the input must have a code point ≤ U+00FF (Latin-1 range); characters outside this range throw a `DOMException` with name `"InvalidCharacterError"` and legacy code 5. The input is interpreted as a byte sequence where each code point maps 1:1 to a byte value.
+
+`atob` decodes a base64 string following the WHATWG forgiving-base64-decode algorithm. ASCII whitespace (U+0009, U+000A, U+000C, U+000D, U+0020) is stripped before decoding. Missing `=` padding is tolerated. Invalid characters or an invalid length (length mod 4 = 1 after cleanup) throw a `DOMException` with name `"InvalidCharacterError"` and legacy code 5. The decoded bytes are returned as a string where each byte becomes a character (Latin-1 interpretation).
 
 **Error constructors:** `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `DOMException`
 

--- a/tests/built-ins/atob.js
+++ b/tests/built-ins/atob.js
@@ -1,0 +1,99 @@
+describe("atob", () => {
+  test("typeof atob is function", () => {
+    expect(typeof atob).toBe("function");
+  });
+
+  test("decodes empty string", () => {
+    expect(atob("")).toBe("");
+  });
+
+  test("decodes basic ASCII base64 strings", () => {
+    expect(atob("SGVsbG8=")).toBe("Hello");
+    expect(atob("SGVsbG8sIFdvcmxkIQ==")).toBe("Hello, World!");
+    expect(atob("YWJj")).toBe("abc");
+    expect(atob("YWI=")).toBe("ab");
+    expect(atob("YQ==")).toBe("a");
+  });
+
+  test("decodes without padding (forgiving base64)", () => {
+    // Missing both == padding
+    expect(atob("YQ")).toBe("a");
+    // Missing single = padding
+    expect(atob("YWI")).toBe("ab");
+    // No padding needed (length divisible by 4 content)
+    expect(atob("YWJj")).toBe("abc");
+  });
+
+  test("strips ASCII whitespace before decoding", () => {
+    // Spaces
+    expect(atob("SGVs bG8=")).toBe("Hello");
+    // Tabs
+    expect(atob("SGVs\tbG8=")).toBe("Hello");
+    // Newlines
+    expect(atob("SGVs\nbG8=")).toBe("Hello");
+    // Carriage returns
+    expect(atob("SGVs\rbG8=")).toBe("Hello");
+    // Form feeds
+    expect(atob("SGVs\x0CbG8=")).toBe("Hello");
+    // Mixed whitespace
+    expect(atob(" S G V s b G 8 = ")).toBe("Hello");
+  });
+
+  test("decodes to Latin-1 characters (bytes > 0x7F)", () => {
+    // Base64 for byte 0xC0 (À)
+    expect(atob("wA==")).toBe(String.fromCharCode(0xC0));
+    // Base64 for byte 0xFF (ÿ)
+    expect(atob("/w==")).toBe(String.fromCharCode(0xFF));
+    // Base64 for byte 0x80
+    expect(atob("gA==")).toBe(String.fromCharCode(0x80));
+  });
+
+  test("throws InvalidCharacterError for invalid base64 characters", () => {
+    expect(() => atob("!!!!")).toThrow();
+    expect(() => atob("====")).toThrow();
+    expect(() => atob("abc!")).toThrow();
+  });
+
+  test("throws InvalidCharacterError when length mod 4 = 1 after stripping", () => {
+    // Single valid base64 char after cleanup → mod 4 = 1
+    expect(() => atob("A")).toThrow();
+    expect(() => atob("AAAAA")).toThrow();
+  });
+
+  test("throws TypeError when called with no arguments", () => {
+    expect(() => atob()).toThrow();
+  });
+
+  test("handles only-whitespace input", () => {
+    expect(atob("   ")).toBe("");
+    expect(atob("\t\n")).toBe("");
+  });
+
+  test("decodes standard padding variants", () => {
+    // RFC 4648 test vectors
+    expect(atob("Zg==")).toBe("f");
+    expect(atob("Zm8=")).toBe("fo");
+    expect(atob("Zm9v")).toBe("foo");
+    expect(atob("Zm9vYg==")).toBe("foob");
+    expect(atob("Zm9vYmE=")).toBe("fooba");
+    expect(atob("Zm9vYmFy")).toBe("foobar");
+  });
+
+  test("round-trips with btoa", () => {
+    const inputs = ["", "Hello", "Hello, World!", "abc", "a", "ab", "foobar"];
+    inputs.forEach((input) => {
+      expect(atob(btoa(input))).toBe(input);
+    });
+  });
+
+  test("round-trips binary data", () => {
+    const bytes = [];
+    let i = 0;
+    const step = 1;
+    // Test a range of byte values
+    [0, 1, 127, 128, 200, 255].forEach((b) => {
+      const ch = String.fromCharCode(b);
+      expect(atob(btoa(ch))).toBe(ch);
+    });
+  });
+});

--- a/tests/built-ins/btoa.js
+++ b/tests/built-ins/btoa.js
@@ -36,12 +36,20 @@ describe("btoa", () => {
   });
 
   test("throws InvalidCharacterError for characters > U+00FF", () => {
-    // U+0100 (Latin Extended-A) — first character outside Latin-1 range
-    expect(() => btoa(String.fromCharCode(0x0100))).toThrow();
-    // U+4E2D (Chinese character 中)
-    expect(() => btoa("中")).toThrow();
-    // Mixed: ASCII followed by out-of-range
-    expect(() => btoa("abc" + String.fromCharCode(0x100))).toThrow();
+    const inputs = [
+      String.fromCharCode(0x0100), // U+0100 (Latin Extended-A)
+      "中",                         // U+4E2D (Chinese character)
+      "abc" + String.fromCharCode(0x100), // Mixed: ASCII followed by out-of-range
+    ];
+    inputs.forEach((input) => {
+      try {
+        btoa(input);
+        expect(true).toBe(false); // should not reach here
+      } catch (e) {
+        expect(e.name).toBe("InvalidCharacterError");
+        expect(e.code).toBe(5);
+      }
+    });
   });
 
   test("throws TypeError when called with no arguments", () => {
@@ -49,10 +57,10 @@ describe("btoa", () => {
   });
 
   test("coerces non-string arguments to string", () => {
-    expect(btoa("123")).toBe("MTIz");
-    expect(btoa("true")).toBe("dHJ1ZQ==");
-    expect(btoa("null")).toBe("bnVsbA==");
-    expect(btoa("undefined")).toBe("dW5kZWZpbmVk");
+    expect(btoa(123)).toBe("MTIz");
+    expect(btoa(true)).toBe("dHJ1ZQ==");
+    expect(btoa(null)).toBe("bnVsbA==");
+    expect(btoa(undefined)).toBe("dW5kZWZpbmVk");
   });
 
   test("handles padding correctly for various input lengths", () => {

--- a/tests/built-ins/btoa.js
+++ b/tests/built-ins/btoa.js
@@ -1,0 +1,84 @@
+describe("btoa", () => {
+  test("typeof btoa is function", () => {
+    expect(typeof btoa).toBe("function");
+  });
+
+  test("encodes empty string", () => {
+    expect(btoa("")).toBe("");
+  });
+
+  test("encodes basic ASCII strings", () => {
+    expect(btoa("Hello")).toBe("SGVsbG8=");
+    expect(btoa("Hello, World!")).toBe("SGVsbG8sIFdvcmxkIQ==");
+    expect(btoa("abc")).toBe("YWJj");
+    expect(btoa("ab")).toBe("YWI=");
+    expect(btoa("a")).toBe("YQ==");
+  });
+
+  test("encodes all printable ASCII characters", () => {
+    expect(btoa(" ")).toBe("IA==");
+    expect(btoa("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")).toBe(
+      "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0NTY3ODk="
+    );
+  });
+
+  test("encodes Latin-1 characters (code points 0x80-0xFF)", () => {
+    // \xC0 = 192 (À), \xFF = 255 (ÿ)
+    expect(btoa(String.fromCharCode(0xC0))).toBe("wA==");
+    expect(btoa(String.fromCharCode(0xFF))).toBe("/w==");
+    expect(btoa(String.fromCharCode(0x80))).toBe("gA==");
+    expect(btoa(String.fromCharCode(0xA9))).toBe("qQ==");
+  });
+
+  test("encodes null bytes", () => {
+    expect(btoa(String.fromCharCode(0))).toBe("AA==");
+    expect(btoa(String.fromCharCode(0, 0, 0))).toBe("AAAA");
+  });
+
+  test("throws InvalidCharacterError for characters > U+00FF", () => {
+    // U+0100 (Latin Extended-A) — first character outside Latin-1 range
+    expect(() => btoa(String.fromCharCode(0x0100))).toThrow();
+    // U+4E2D (Chinese character 中)
+    expect(() => btoa("中")).toThrow();
+    // Mixed: ASCII followed by out-of-range
+    expect(() => btoa("abc" + String.fromCharCode(0x100))).toThrow();
+  });
+
+  test("throws TypeError when called with no arguments", () => {
+    expect(() => btoa()).toThrow();
+  });
+
+  test("coerces non-string arguments to string", () => {
+    expect(btoa("123")).toBe("MTIz");
+    expect(btoa("true")).toBe("dHJ1ZQ==");
+    expect(btoa("null")).toBe("bnVsbA==");
+    expect(btoa("undefined")).toBe("dW5kZWZpbmVk");
+  });
+
+  test("handles padding correctly for various input lengths", () => {
+    // Length 1 → 4 output chars with ==
+    expect(btoa("f")).toBe("Zg==");
+    // Length 2 → 4 output chars with =
+    expect(btoa("fo")).toBe("Zm8=");
+    // Length 3 → 4 output chars, no padding
+    expect(btoa("foo")).toBe("Zm9v");
+    // Length 4 → 8 output chars with ==
+    expect(btoa("foob")).toBe("Zm9vYg==");
+    // Length 5 → 8 output chars with =
+    expect(btoa("fooba")).toBe("Zm9vYmE=");
+    // Length 6 → 8 output chars, no padding
+    expect(btoa("foobar")).toBe("Zm9vYmFy");
+  });
+
+  test("round-trips with atob", () => {
+    const inputs = ["", "Hello", "Hello, World!", "abc", "a", "ab"];
+    inputs.forEach((input) => {
+      expect(atob(btoa(input))).toBe(input);
+    });
+  });
+
+  test("round-trips Latin-1 with atob", () => {
+    const input = String.fromCharCode(0x00, 0x7F, 0x80, 0xFF);
+    expect(atob(btoa(input))).toBe(input);
+  });
+});

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -699,7 +699,7 @@ function TGocciaGlobals.AtobCallback(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   Data, Cleaned, Decoded, ResultStr: string;
-  I: Integer;
+  I, CleanedLen, ResultLen: Integer;
   B: Byte;
   Remainder: Integer;
 begin
@@ -711,10 +711,15 @@ begin
   Data := AArgs.GetElement(0).ToStringLiteral.Value;
 
   // Step 3: Remove ASCII whitespace (U+0009, U+000A, U+000C, U+000D, U+0020)
-  Cleaned := '';
+  SetLength(Cleaned, Length(Data));
+  CleanedLen := 0;
   for I := 1 to Length(Data) do
     if not (Data[I] in [#9, #10, #12, #13, ' ']) then
-      Cleaned := Cleaned + Data[I];
+    begin
+      Inc(CleanedLen);
+      Cleaned[CleanedLen] := Data[I];
+    end;
+  SetLength(Cleaned, CleanedLen);
 
   // Step 4: If length mod 4 = 0, remove 1 or 2 trailing '=' characters
   if (Length(Cleaned) > 0) and (Length(Cleaned) mod 4 = 0) then
@@ -752,15 +757,25 @@ begin
 
   // Step 8: Convert decoded bytes to a string (Latin-1 interpretation)
   // Bytes > 0x7F need to be re-encoded as 2-byte UTF-8 sequences
-  ResultStr := '';
+  SetLength(ResultStr, Length(Decoded) * 2);
+  ResultLen := 0;
   for I := 1 to Length(Decoded) do
   begin
     B := Ord(Decoded[I]);
     if B < $80 then
-      ResultStr := ResultStr + Chr(B)
+    begin
+      Inc(ResultLen);
+      ResultStr[ResultLen] := Chr(B);
+    end
     else
-      ResultStr := ResultStr + Chr($C0 or (B shr 6)) + Chr($80 or (B and $3F));
+    begin
+      Inc(ResultLen);
+      ResultStr[ResultLen] := Chr($C0 or (B shr 6));
+      Inc(ResultLen);
+      ResultStr[ResultLen] := Chr($80 or (B and $3F));
+    end;
   end;
+  SetLength(ResultStr, ResultLen);
 
   Result := TGocciaStringLiteralValue.Create(ResultStr);
 end;

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -604,12 +604,24 @@ begin
   end;
 end;
 
+const
+  UNICODE_REPLACEMENT_CHARACTER = $FFFD;
+
+{ Returns True if the byte at AIndex is a valid UTF-8 continuation byte (10xxxxxx). }
+function IsContinuationByte(const AString: string; const AIndex, ALength: Integer): Boolean; inline;
+begin
+  Result := (AIndex <= ALength) and ((Ord(AString[AIndex]) and $C0) = $80);
+end;
+
 { Decode a single UTF-8 code point starting at position AIndex in AUTF8String.
-  Advances AIndex past the decoded sequence. Returns the Unicode code point value. }
+  Advances AIndex past the decoded sequence. Returns the Unicode code point value.
+  Returns U+FFFD for malformed or truncated sequences. }
 function NextUTF8CodePoint(const AUTF8String: string; var AIndex: Integer): Integer;
 var
   B: Byte;
+  Len: Integer;
 begin
+  Len := Length(AUTF8String);
   B := Ord(AUTF8String[AIndex]);
   if B < $80 then
   begin
@@ -618,35 +630,46 @@ begin
   end
   else if (B and $E0) = $C0 then
   begin
-    Result := (B and $1F) shl 6;
     Inc(AIndex);
-    if AIndex <= Length(AUTF8String) then
-      Result := Result or (Ord(AUTF8String[AIndex]) and $3F);
+    if not IsContinuationByte(AUTF8String, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := ((B and $1F) shl 6) or (Ord(AUTF8String[AIndex]) and $3F);
     Inc(AIndex);
   end
   else if (B and $F0) = $E0 then
   begin
+    Inc(AIndex);
+    if not IsContinuationByte(AUTF8String, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
     Result := (B and $0F) shl 12;
+    Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 6);
     Inc(AIndex);
-    if AIndex <= Length(AUTF8String) then
-      Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 6);
+    if not IsContinuationByte(AUTF8String, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := Result or (Ord(AUTF8String[AIndex]) and $3F);
     Inc(AIndex);
-    if AIndex <= Length(AUTF8String) then
-      Result := Result or (Ord(AUTF8String[AIndex]) and $3F);
+  end
+  else if (B and $F8) = $F0 then
+  begin
+    Inc(AIndex);
+    if not IsContinuationByte(AUTF8String, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := (B and $07) shl 18;
+    Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 12);
+    Inc(AIndex);
+    if not IsContinuationByte(AUTF8String, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 6);
+    Inc(AIndex);
+    if not IsContinuationByte(AUTF8String, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := Result or (Ord(AUTF8String[AIndex]) and $3F);
     Inc(AIndex);
   end
   else
   begin
-    Result := (B and $07) shl 18;
-    Inc(AIndex);
-    if AIndex <= Length(AUTF8String) then
-      Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 12);
-    Inc(AIndex);
-    if AIndex <= Length(AUTF8String) then
-      Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 6);
-    Inc(AIndex);
-    if AIndex <= Length(AUTF8String) then
-      Result := Result or (Ord(AUTF8String[AIndex]) and $3F);
+    // Invalid lead byte (bare continuation or 0xFE/0xFF)
+    Result := UNICODE_REPLACEMENT_CHARACTER;
     Inc(AIndex);
   end;
 end;

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -49,6 +49,8 @@ type
     function ErrorIsError(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function QueueMicrotaskCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function StructuredCloneCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function BtoaCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function AtobCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
   end;
@@ -57,7 +59,9 @@ implementation
 
 uses
   Classes,
+  SysUtils,
 
+  base64,
   HashMap,
 
   Goccia.Constants.ErrorNames,
@@ -175,6 +179,12 @@ begin
 
   AScope.DefineLexicalBinding('structuredClone',
     TGocciaNativeFunctionValue.Create(StructuredCloneCallback, 'structuredClone', 1), dtConst);
+
+  AScope.DefineLexicalBinding('btoa',
+    TGocciaNativeFunctionValue.Create(BtoaCallback, 'btoa', 1), dtConst);
+
+  AScope.DefineLexicalBinding('atob',
+    TGocciaNativeFunctionValue.Create(AtobCallback, 'atob', 1), dtConst);
 end;
 
 { NativeError ( message [ , options ] ) — §20.5.6.1.1 (shared by all NativeError constructors)
@@ -354,6 +364,8 @@ function DOMExceptionLegacyCode(const AName: string): Integer;
 begin
   if AName = DATA_CLONE_ERROR_NAME then
     Result := 25
+  else if AName = INVALID_CHARACTER_ERROR_NAME then
+    Result := 5
   else
     Result := 0;
 end;
@@ -590,6 +602,167 @@ begin
     end;
     Memory.Free;
   end;
+end;
+
+{ Decode a single UTF-8 code point starting at position AIndex in AUTF8String.
+  Advances AIndex past the decoded sequence. Returns the Unicode code point value. }
+function NextUTF8CodePoint(const AUTF8String: string; var AIndex: Integer): Integer;
+var
+  B: Byte;
+begin
+  B := Ord(AUTF8String[AIndex]);
+  if B < $80 then
+  begin
+    Result := B;
+    Inc(AIndex);
+  end
+  else if (B and $E0) = $C0 then
+  begin
+    Result := (B and $1F) shl 6;
+    Inc(AIndex);
+    if AIndex <= Length(AUTF8String) then
+      Result := Result or (Ord(AUTF8String[AIndex]) and $3F);
+    Inc(AIndex);
+  end
+  else if (B and $F0) = $E0 then
+  begin
+    Result := (B and $0F) shl 12;
+    Inc(AIndex);
+    if AIndex <= Length(AUTF8String) then
+      Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 6);
+    Inc(AIndex);
+    if AIndex <= Length(AUTF8String) then
+      Result := Result or (Ord(AUTF8String[AIndex]) and $3F);
+    Inc(AIndex);
+  end
+  else
+  begin
+    Result := (B and $07) shl 18;
+    Inc(AIndex);
+    if AIndex <= Length(AUTF8String) then
+      Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 12);
+    Inc(AIndex);
+    if AIndex <= Length(AUTF8String) then
+      Result := Result or ((Ord(AUTF8String[AIndex]) and $3F) shl 6);
+    Inc(AIndex);
+    if AIndex <= Length(AUTF8String) then
+      Result := Result or (Ord(AUTF8String[AIndex]) and $3F);
+    Inc(AIndex);
+  end;
+end;
+
+// WHATWG HTML spec §8.3 btoa(data)
+function TGocciaGlobals.BtoaCallback(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Data, RawBytes: string;
+  I, CodePoint, ByteCount: Integer;
+begin
+  // Step 1: If no argument, throw TypeError
+  if AArgs.Length = 0 then
+    ThrowTypeError('Failed to execute ''btoa'': 1 argument required, but only 0 present.');
+
+  // Step 2: Let data be ToString(argument)
+  Data := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  // Step 3: For each code point in data, if > U+00FF throw InvalidCharacterError
+  // Also collect raw byte values (code points 0x00-0xFF map 1:1 to bytes)
+  SetLength(RawBytes, Length(Data));
+  ByteCount := 0;
+  I := 1;
+  while I <= Length(Data) do
+  begin
+    CodePoint := NextUTF8CodePoint(Data, I);
+    if CodePoint > $FF then
+      ThrowInvalidCharacterError(
+        'Failed to execute ''btoa'': The string to be encoded contains characters outside of the Latin1 range.');
+    Inc(ByteCount);
+    RawBytes[ByteCount] := Chr(CodePoint);
+  end;
+  SetLength(RawBytes, ByteCount);
+
+  // Step 4-5: Base64 encode and return
+  Result := TGocciaStringLiteralValue.Create(EncodeStringBase64(RawBytes));
+end;
+
+{ Returns True if AChar is a valid base64 alphabet character (A-Z, a-z, 0-9, +, /) }
+function IsBase64Char(const AChar: Char): Boolean;
+begin
+  Result := ((AChar >= 'A') and (AChar <= 'Z'))
+    or ((AChar >= 'a') and (AChar <= 'z'))
+    or ((AChar >= '0') and (AChar <= '9'))
+    or (AChar = '+') or (AChar = '/');
+end;
+
+// WHATWG HTML spec §8.3 atob(data) — forgiving-base64-decode
+function TGocciaGlobals.AtobCallback(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Data, Cleaned, Decoded, ResultStr: string;
+  I: Integer;
+  B: Byte;
+  Remainder: Integer;
+begin
+  // Step 1: If no argument, throw TypeError
+  if AArgs.Length = 0 then
+    ThrowTypeError('Failed to execute ''atob'': 1 argument required, but only 0 present.');
+
+  // Step 2: Let data be ToString(argument)
+  Data := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  // Step 3: Remove ASCII whitespace (U+0009, U+000A, U+000C, U+000D, U+0020)
+  Cleaned := '';
+  for I := 1 to Length(Data) do
+    if not (Data[I] in [#9, #10, #12, #13, ' ']) then
+      Cleaned := Cleaned + Data[I];
+
+  // Step 4: If length mod 4 = 0, remove 1 or 2 trailing '=' characters
+  if (Length(Cleaned) > 0) and (Length(Cleaned) mod 4 = 0) then
+  begin
+    if Cleaned[Length(Cleaned)] = '=' then
+    begin
+      SetLength(Cleaned, Length(Cleaned) - 1);
+      if (Length(Cleaned) > 0) and (Cleaned[Length(Cleaned)] = '=') then
+        SetLength(Cleaned, Length(Cleaned) - 1);
+    end;
+  end;
+
+  // Step 5: If length mod 4 = 1, throw InvalidCharacterError
+  Remainder := Length(Cleaned) mod 4;
+  if Remainder = 1 then
+    ThrowInvalidCharacterError(
+      'Failed to execute ''atob'': The string to be decoded is not correctly encoded.');
+
+  // Step 6: If data contains any character not in the base64 alphabet, throw InvalidCharacterError
+  for I := 1 to Length(Cleaned) do
+    if not IsBase64Char(Cleaned[I]) then
+      ThrowInvalidCharacterError(
+        'Failed to execute ''atob'': The string to be decoded is not correctly encoded.');
+
+  // Step 7: Pad to multiple of 4 and decode
+  case Remainder of
+    2: Cleaned := Cleaned + '==';
+    3: Cleaned := Cleaned + '=';
+  end;
+
+  if Cleaned = '' then
+    Exit(TGocciaStringLiteralValue.Create(''));
+
+  Decoded := DecodeStringBase64(Cleaned);
+
+  // Step 8: Convert decoded bytes to a string (Latin-1 interpretation)
+  // Bytes > 0x7F need to be re-encoded as 2-byte UTF-8 sequences
+  ResultStr := '';
+  for I := 1 to Length(Decoded) do
+  begin
+    B := Ord(Decoded[I]);
+    if B < $80 then
+      ResultStr := ResultStr + Chr(B)
+    else
+      ResultStr := ResultStr + Chr($C0 or (B shr 6)) + Chr($80 or (B and $3F));
+  end;
+
+  Result := TGocciaStringLiteralValue.Create(ResultStr);
 end;
 
 end.

--- a/units/Goccia.Constants.ErrorNames.pas
+++ b/units/Goccia.Constants.ErrorNames.pas
@@ -14,6 +14,7 @@ const
   AGGREGATE_ERROR_NAME  = 'AggregateError';
   DOM_EXCEPTION_NAME    = 'DOMException';
   DATA_CLONE_ERROR_NAME = 'DataCloneError';
+  INVALID_CHARACTER_ERROR_NAME = 'InvalidCharacterError';
 
 implementation
 

--- a/units/Goccia.Values.ErrorHelper.pas
+++ b/units/Goccia.Values.ErrorHelper.pas
@@ -26,6 +26,9 @@ procedure ThrowSyntaxError(const AMessage: string);
 { Raises a TGocciaThrowValue with a DataCloneError (DOMException with code 25) }
 procedure ThrowDataCloneError(const AMessage: string);
 
+{ Raises a TGocciaThrowValue with an InvalidCharacterError (DOMException with code 5) }
+procedure ThrowInvalidCharacterError(const AMessage: string);
+
 { Raises a TGocciaThrowValue with a generic Error }
 procedure ThrowError(const AMessage: string);
 
@@ -106,6 +109,18 @@ begin
   ErrorObj := CreateErrorObject(DATA_CLONE_ERROR_NAME, AMessage);
   ErrorObj.HasErrorData := False;
   ErrorObj.AssignProperty(PROP_CODE, TGocciaNumberLiteralValue.Create(25));
+  if Assigned(GDOMExceptionProto) then
+    ErrorObj.Prototype := GDOMExceptionProto;
+  raise TGocciaThrowValue.Create(ErrorObj);
+end;
+
+procedure ThrowInvalidCharacterError(const AMessage: string);
+var
+  ErrorObj: TGocciaObjectValue;
+begin
+  ErrorObj := CreateErrorObject(INVALID_CHARACTER_ERROR_NAME, AMessage);
+  ErrorObj.HasErrorData := False;
+  ErrorObj.AssignProperty(PROP_CODE, TGocciaNumberLiteralValue.Create(5));
   if Assigned(GDOMExceptionProto) then
     ErrorObj.Prototype := GDOMExceptionProto;
   raise TGocciaThrowValue.Create(ErrorObj);


### PR DESCRIPTION
## Summary
- Added global `atob` and `btoa` built-ins with WHATWG-style base64 behavior.
- Implemented `InvalidCharacterError` DOMException support for invalid Latin-1 and base64 input.
- Added end-to-end tests covering encoding, decoding, whitespace handling, padding, Latin-1 edge cases, and error paths.
- Documented the new globals in `docs/built-ins.md`.

## Testing
- Not run: `./build.pas testrunner && ./build/TestRunner tests`
- Not run: targeted built-in tests for `atob` and `btoa`
- Not run: native Pascal test suite