### PR TITLE
Add Iterator.zip and zipKeyed helpers

### DIFF
--- a/benchmarks/iterators.js
+++ b/benchmarks/iterators.js
@@ -240,6 +240,139 @@ suite("Iterator.concat", () => {
   });
 });
 
+suite("Iterator.zip", () => {
+  const arr10 = Array.from({ length: 10 }, (_, i) => i);
+  const arr20 = Array.from({ length: 20 }, (_, i) => i);
+  const arr50 = Array.from({ length: 50 }, (_, i) => i);
+
+  bench("zip 2 arrays (10 + 10 elements)", {
+    run: () => {
+      const result = Iterator.zip([arr10, arr10]).toArray();
+    },
+  });
+
+  bench("zip 3 arrays (10 elements each)", {
+    run: () => {
+      const result = Iterator.zip([arr10, arr10, arr10]).toArray();
+    },
+  });
+
+  bench("zip 2 arrays (20 + 20 elements)", {
+    run: () => {
+      const result = Iterator.zip([arr20, arr20]).toArray();
+    },
+  });
+
+  bench("zip 2 arrays (50 + 50 elements)", {
+    run: () => {
+      const result = Iterator.zip([arr50, arr50]).toArray();
+    },
+  });
+
+  bench("zip shortest mode (20 + 10 elements)", {
+    run: () => {
+      const result = Iterator.zip([arr20, arr10]).toArray();
+    },
+  });
+
+  bench("zip longest mode (10 + 20 elements)", {
+    run: () => {
+      const result = Iterator.zip([arr10, arr20], { mode: "longest", padding: [0, 0] }).toArray();
+    },
+  });
+
+  bench("zip strict mode (20 + 20 elements)", {
+    run: () => {
+      const result = Iterator.zip([arr20, arr20], { mode: "strict" }).toArray();
+    },
+  });
+
+  bench("zip + map + toArray (20 + 20 elements)", {
+    run: () => {
+      const result = Iterator.zip([arr20, arr20])
+        .map(([a, b]) => a + b)
+        .toArray();
+    },
+  });
+
+  bench("zip + filter + toArray (20 + 20 elements)", {
+    run: () => {
+      const result = Iterator.zip([arr20, arr20])
+        .filter(([a, b]) => a % 2 === 0)
+        .toArray();
+    },
+  });
+
+  bench("zip Sets (15 + 15 elements)", {
+    setup: () => ({
+      a: new Set(Array.from({ length: 15 }, (_, i) => i)),
+      b: new Set(Array.from({ length: 15 }, (_, i) => i + 15)),
+    }),
+    run: (ctx) => {
+      const result = Iterator.zip([ctx.a, ctx.b]).toArray();
+    },
+  });
+});
+
+suite("Iterator.zipKeyed", () => {
+  bench("zipKeyed 2 keys (10 elements each)", {
+    setup: () => ({
+      x: Array.from({ length: 10 }, (_, i) => i),
+      y: Array.from({ length: 10 }, (_, i) => i * 2),
+    }),
+    run: (data) => {
+      const result = Iterator.zipKeyed(data).toArray();
+    },
+  });
+
+  bench("zipKeyed 3 keys (20 elements each)", {
+    setup: () => ({
+      name: Array.from({ length: 20 }, (_, i) => "item" + i),
+      value: Array.from({ length: 20 }, (_, i) => i * 10),
+      flag: Array.from({ length: 20 }, (_, i) => i % 2 === 0),
+    }),
+    run: (data) => {
+      const result = Iterator.zipKeyed(data).toArray();
+    },
+  });
+
+  bench("zipKeyed longest mode (10 + 20 elements)", {
+    setup: () => ({
+      short: Array.from({ length: 10 }, (_, i) => i),
+      long: Array.from({ length: 20 }, (_, i) => i),
+    }),
+    run: (data) => {
+      const result = Iterator.zipKeyed(data, {
+        mode: "longest",
+        padding: { short: 0, long: 0 },
+      }).toArray();
+    },
+  });
+
+  bench("zipKeyed strict mode (20 + 20 elements)", {
+    setup: () => ({
+      a: Array.from({ length: 20 }, (_, i) => i),
+      b: Array.from({ length: 20 }, (_, i) => i * 3),
+    }),
+    run: (data) => {
+      const result = Iterator.zipKeyed(data, { mode: "strict" }).toArray();
+    },
+  });
+
+  bench("zipKeyed + filter + map (20 elements)", {
+    setup: () => ({
+      x: Array.from({ length: 20 }, (_, i) => i),
+      y: Array.from({ length: 20 }, (_, i) => i * 5),
+    }),
+    run: (data) => {
+      const result = Iterator.zipKeyed(data)
+        .filter(({ x }) => x > 10)
+        .map(({ x, y }) => x + y)
+        .toArray();
+    },
+  });
+});
+
 suite("built-in iterator helpers", () => {
   const arr50 = Array.from({ length: 50 }, (_, i) => i);
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -532,6 +532,8 @@ Iterators are consumed once — calling `next()` past the end returns `{value: u
 |--------|-------------|
 | `Iterator.from(value)` | Wrap an iterable, iterator, or `{next()}` object as a proper Iterator with helper methods |
 | `Iterator.concat(...items)` | Concatenate multiple iterables into a single lazy iterator (TC39 Iterator Sequencing). All arguments are validated upfront as iterables; iterators are opened lazily as each iterable is consumed. |
+| `Iterator.zip(iterables, options?)` | Combine multiple iterables into an iterator of arrays (TC39 Joint Iteration). `iterables` is an iterable of iterables. `options.mode` can be `"shortest"` (default), `"longest"`, or `"strict"`. In `"longest"` mode, `options.padding` (an iterable) provides fill values for exhausted iterables. |
+| `Iterator.zipKeyed(iterables, options?)` | Combine keyed iterables into an iterator of objects (TC39 Joint Iteration). `iterables` is an object whose values are iterables. Each yielded object has the same keys as the input. Same `mode`/`padding` options as `zip`, but `padding` is an object with matching keys. |
 | `Iterator.prototype` | The shared iterator prototype (accessible for inspection) |
 
 ### Symbol (`Goccia.Builtins.GlobalSymbol.pas`)

--- a/tests/built-ins/Iterator/zip.js
+++ b/tests/built-ins/Iterator/zip.js
@@ -1,0 +1,254 @@
+/*---
+description: Iterator.zip() combines multiple iterables into an iterator of arrays
+features: [Iterator, Iterator.zip]
+---*/
+
+describe("Iterator.zip()", () => {
+  test("zips two arrays of equal length", () => {
+    const result = Iterator.zip([[1, 2, 3], ["a", "b", "c"]]).toArray();
+    expect(result).toEqual([[1, "a"], [2, "b"], [3, "c"]]);
+  });
+
+  test("zips three arrays of equal length", () => {
+    const result = Iterator.zip([[1, 2], ["a", "b"], [true, false]]).toArray();
+    expect(result).toEqual([[1, "a", true], [2, "b", false]]);
+  });
+
+  test("zips a single array", () => {
+    const result = Iterator.zip([[1, 2, 3]]).toArray();
+    expect(result).toEqual([[1], [2], [3]]);
+  });
+
+  test("zips empty iterables yields nothing", () => {
+    const result = Iterator.zip([]).toArray();
+    expect(result).toEqual([]);
+  });
+
+  test("zips empty arrays", () => {
+    const result = Iterator.zip([[], []]).toArray();
+    expect(result).toEqual([]);
+  });
+
+  test("default mode is shortest — stops at shortest iterable", () => {
+    const result = Iterator.zip([[1, 2, 3], ["a", "b"]]).toArray();
+    expect(result).toEqual([[1, "a"], [2, "b"]]);
+  });
+
+  test("explicit shortest mode", () => {
+    const result = Iterator.zip([[1, 2, 3], ["x"]], { mode: "shortest" }).toArray();
+    expect(result).toEqual([[1, "x"]]);
+  });
+
+  test("zips Sets", () => {
+    const a = new Set([1, 2]);
+    const b = new Set([3, 4]);
+    const result = Iterator.zip([a, b]).toArray();
+    expect(result).toEqual([[1, 3], [2, 4]]);
+  });
+
+  test("zips Maps (yields entries)", () => {
+    const a = new Map([["x", 1]]);
+    const b = new Map([["y", 2]]);
+    const result = Iterator.zip([a, b]).toArray();
+    expect(result[0][0][0]).toBe("x");
+    expect(result[0][0][1]).toBe(1);
+    expect(result[0][1][0]).toBe("y");
+    expect(result[0][1][1]).toBe(2);
+  });
+
+  test("zips mixed iterable types", () => {
+    const arr = [1, 2];
+    const set = new Set(["a", "b"]);
+    const result = Iterator.zip([arr, set]).toArray();
+    expect(result).toEqual([[1, "a"], [2, "b"]]);
+  });
+
+  test("zips strings (character iteration)", () => {
+    const result = Iterator.zip(["ab", "cd"]).toArray();
+    expect(result).toEqual([["a", "c"], ["b", "d"]]);
+  });
+
+  test("result is an iterator (has next and Symbol.iterator)", () => {
+    const iter = Iterator.zip([[1], [2]]);
+    expect(typeof iter.next).toBe("function");
+    expect(iter[Symbol.iterator]()).toBe(iter);
+  });
+
+  test("returns done after exhaustion", () => {
+    const iter = Iterator.zip([[1], [2]]);
+    expect(iter.next()).toEqual({ value: [1, 2], done: false });
+    expect(iter.next()).toEqual({ value: undefined, done: true });
+    expect(iter.next()).toEqual({ value: undefined, done: true });
+  });
+
+  test("works with for-of", () => {
+    const result = [];
+    for (const pair of Iterator.zip([[1, 2], ["a", "b"]])) {
+      result.push(pair);
+    }
+    expect(result).toEqual([[1, "a"], [2, "b"]]);
+  });
+
+  test("works with destructuring in for-of", () => {
+    const names = [];
+    const ages = [];
+    for (const [name, age] of Iterator.zip([["Alice", "Bob"], [30, 25]])) {
+      names.push(name);
+      ages.push(age);
+    }
+    expect(names).toEqual(["Alice", "Bob"]);
+    expect(ages).toEqual([30, 25]);
+  });
+
+  test("result works with iterator helper methods", () => {
+    const result = Iterator.zip([[1, 2, 3], [10, 20, 30]])
+      .map(([a, b]) => a + b)
+      .toArray();
+    expect(result).toEqual([11, 22, 33]);
+  });
+
+  test("zips user-defined iterables", () => {
+    const range = (start, end) => ({
+      [Symbol.iterator]() {
+        let i = start;
+        return {
+          next() {
+            if (i <= end) {
+              const v = i;
+              i = i + 1;
+              return { value: v, done: false };
+            }
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    });
+
+    const result = Iterator.zip([range(1, 3), range(10, 12)]).toArray();
+    expect(result).toEqual([[1, 10], [2, 11], [3, 12]]);
+  });
+
+  test("throws TypeError for non-iterable first argument", () => {
+    expect(() => Iterator.zip(42)).toThrow(TypeError);
+    expect(() => Iterator.zip(true)).toThrow(TypeError);
+    expect(() => Iterator.zip(null)).toThrow(TypeError);
+  });
+
+  test("throws TypeError for non-iterable item in iterables", () => {
+    expect(() => Iterator.zip([[1, 2], 42]).toArray()).toThrow(TypeError);
+    expect(() => Iterator.zip([[1], null]).toArray()).toThrow(TypeError);
+  });
+
+  test("throws TypeError with no arguments", () => {
+    expect(() => Iterator.zip()).toThrow(TypeError);
+  });
+
+  test("throws RangeError for invalid mode", () => {
+    expect(() => Iterator.zip([[1]], { mode: "invalid" })).toThrow(RangeError);
+  });
+
+  test("ignores options if undefined", () => {
+    const result = Iterator.zip([[1, 2], [3, 4]], undefined).toArray();
+    expect(result).toEqual([[1, 3], [2, 4]]);
+  });
+});
+
+describe("Iterator.zip() — longest mode", () => {
+  test("continues until all iterables are exhausted", () => {
+    const result = Iterator.zip([[1, 2], ["a", "b", "c"]], { mode: "longest" }).toArray();
+    expect(result).toEqual([[1, "a"], [2, "b"], [undefined, "c"]]);
+  });
+
+  test("fills with undefined when no padding provided", () => {
+    const result = Iterator.zip([[1], ["a", "b", "c"]], { mode: "longest" }).toArray();
+    expect(result).toEqual([[1, "a"], [undefined, "b"], [undefined, "c"]]);
+  });
+
+  test("fills with padding values", () => {
+    const result = Iterator.zip(
+      [[1, 2], ["a", "b", "c", "d"]],
+      { mode: "longest", padding: [0, "?"] }
+    ).toArray();
+    expect(result).toEqual([[1, "a"], [2, "b"], [0, "c"], [0, "d"]]);
+  });
+
+  test("padding shorter than iterables count uses undefined for extra positions", () => {
+    const result = Iterator.zip(
+      [[1], [2], [3, 4]],
+      { mode: "longest", padding: [0] }
+    ).toArray();
+    expect(result).toEqual([[1, 2, 3], [0, undefined, 4]]);
+  });
+
+  test("all same length behaves like shortest mode", () => {
+    const result = Iterator.zip(
+      [[1, 2], [3, 4]],
+      { mode: "longest" }
+    ).toArray();
+    expect(result).toEqual([[1, 3], [2, 4]]);
+  });
+
+  test("empty iterables with longest mode yield nothing", () => {
+    const result = Iterator.zip([[], []], { mode: "longest" }).toArray();
+    expect(result).toEqual([]);
+  });
+
+  test("one empty and one non-empty with padding", () => {
+    const result = Iterator.zip(
+      [[], [1, 2]],
+      { mode: "longest", padding: [99, 0] }
+    ).toArray();
+    expect(result).toEqual([[99, 1], [99, 2]]);
+  });
+});
+
+describe("Iterator.zip() — strict mode", () => {
+  test("works when all iterables have same length", () => {
+    const result = Iterator.zip(
+      [[1, 2, 3], ["a", "b", "c"]],
+      { mode: "strict" }
+    ).toArray();
+    expect(result).toEqual([[1, "a"], [2, "b"], [3, "c"]]);
+  });
+
+  test("throws TypeError when iterables have different lengths", () => {
+    expect(() => {
+      Iterator.zip([[1, 2], ["a", "b", "c"]], { mode: "strict" }).toArray();
+    }).toThrow(TypeError);
+  });
+
+  test("throws TypeError when first is shorter", () => {
+    expect(() => {
+      Iterator.zip([[1], [2, 3]], { mode: "strict" }).toArray();
+    }).toThrow(TypeError);
+  });
+
+  test("throws TypeError when second is shorter", () => {
+    expect(() => {
+      Iterator.zip([[1, 2], [3]], { mode: "strict" }).toArray();
+    }).toThrow(TypeError);
+  });
+
+  test("empty iterables in strict mode are fine", () => {
+    const result = Iterator.zip([[], []], { mode: "strict" }).toArray();
+    expect(result).toEqual([]);
+  });
+
+  test("single element strict mode", () => {
+    const result = Iterator.zip([[42], [99]], { mode: "strict" }).toArray();
+    expect(result).toEqual([[42, 99]]);
+  });
+});
+
+describe("Iterator.zip() — creating Map from two arrays", () => {
+  test("creates a Map from keys and values arrays", () => {
+    const keys = ["Mon", "Tue", "Wed"];
+    const vals = [22, 21, 23];
+    const entries = Iterator.zip([keys, vals]).toArray();
+    const map = new Map(entries);
+    expect(map.get("Mon")).toBe(22);
+    expect(map.get("Tue")).toBe(21);
+    expect(map.get("Wed")).toBe(23);
+    expect(map.size).toBe(3);
+  });
+});

--- a/tests/built-ins/Iterator/zipKeyed.js
+++ b/tests/built-ins/Iterator/zipKeyed.js
@@ -1,0 +1,265 @@
+/*---
+description: Iterator.zipKeyed() combines keyed iterables into an iterator of objects
+features: [Iterator, Iterator.zipKeyed]
+---*/
+
+describe("Iterator.zipKeyed()", () => {
+  test("zips keyed object with array values", () => {
+    const result = Iterator.zipKeyed({
+      name: ["Alice", "Bob", "Carol"],
+      age: [30, 25, 35],
+    }).toArray();
+    expect(result).toEqual([
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 25 },
+      { name: "Carol", age: 35 },
+    ]);
+  });
+
+  test("zips a single key", () => {
+    const result = Iterator.zipKeyed({ x: [1, 2, 3] }).toArray();
+    expect(result).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }]);
+  });
+
+  test("zips empty object yields nothing", () => {
+    const result = Iterator.zipKeyed({}).toArray();
+    expect(result).toEqual([]);
+  });
+
+  test("default mode is shortest — stops at shortest iterable", () => {
+    const result = Iterator.zipKeyed({
+      x: [1, 2, 3],
+      y: ["a", "b"],
+    }).toArray();
+    expect(result).toEqual([
+      { x: 1, y: "a" },
+      { x: 2, y: "b" },
+    ]);
+  });
+
+  test("explicit shortest mode", () => {
+    const result = Iterator.zipKeyed(
+      { a: [1, 2, 3], b: ["x"] },
+      { mode: "shortest" }
+    ).toArray();
+    expect(result).toEqual([{ a: 1, b: "x" }]);
+  });
+
+  test("zips with Set values", () => {
+    const result = Iterator.zipKeyed({
+      nums: new Set([1, 2]),
+      letters: new Set(["a", "b"]),
+    }).toArray();
+    expect(result).toEqual([
+      { nums: 1, letters: "a" },
+      { nums: 2, letters: "b" },
+    ]);
+  });
+
+  test("result is an iterator (has next and Symbol.iterator)", () => {
+    const iter = Iterator.zipKeyed({ x: [1] });
+    expect(typeof iter.next).toBe("function");
+    expect(iter[Symbol.iterator]()).toBe(iter);
+  });
+
+  test("returns done after exhaustion", () => {
+    const iter = Iterator.zipKeyed({ x: [1], y: [2] });
+    expect(iter.next()).toEqual({ value: { x: 1, y: 2 }, done: false });
+    expect(iter.next()).toEqual({ value: undefined, done: true });
+    expect(iter.next()).toEqual({ value: undefined, done: true });
+  });
+
+  test("works with for-of", () => {
+    const result = [];
+    for (const obj of Iterator.zipKeyed({ a: [1, 2], b: [3, 4] })) {
+      result.push(obj);
+    }
+    expect(result).toEqual([{ a: 1, b: 3 }, { a: 2, b: 4 }]);
+  });
+
+  test("works with destructuring in for-of", () => {
+    const names = [];
+    const cities = [];
+    for (const { name, city } of Iterator.zipKeyed({
+      name: ["Alice", "Bob"],
+      city: ["NYC", "London"],
+    })) {
+      names.push(name);
+      cities.push(city);
+    }
+    expect(names).toEqual(["Alice", "Bob"]);
+    expect(cities).toEqual(["NYC", "London"]);
+  });
+
+  test("result works with iterator helper methods", () => {
+    const result = Iterator.zipKeyed({
+      x: [1, 2, 3, 4],
+      y: [10, 20, 30, 40],
+    })
+      .filter(({ x }) => x > 2)
+      .map(({ x, y }) => x + y)
+      .toArray();
+    expect(result).toEqual([33, 44]);
+  });
+
+  test("zips with string values (character iteration)", () => {
+    const result = Iterator.zipKeyed({
+      first: "ab",
+      second: "cd",
+    }).toArray();
+    expect(result).toEqual([
+      { first: "a", second: "c" },
+      { first: "b", second: "d" },
+    ]);
+  });
+
+  test("throws TypeError for non-object first argument", () => {
+    expect(() => Iterator.zipKeyed(42)).toThrow(TypeError);
+    expect(() => Iterator.zipKeyed(true)).toThrow(TypeError);
+    expect(() => Iterator.zipKeyed(null)).toThrow(TypeError);
+    expect(() => Iterator.zipKeyed("hello")).toThrow(TypeError);
+  });
+
+  test("throws TypeError for non-iterable property value", () => {
+    expect(() => Iterator.zipKeyed({ x: 42 }).toArray()).toThrow(TypeError);
+    expect(() => Iterator.zipKeyed({ x: [1], y: null }).toArray()).toThrow(TypeError);
+  });
+
+  test("throws TypeError with no arguments", () => {
+    expect(() => Iterator.zipKeyed()).toThrow(TypeError);
+  });
+
+  test("throws RangeError for invalid mode", () => {
+    expect(() => Iterator.zipKeyed({ x: [1] }, { mode: "bad" })).toThrow(RangeError);
+  });
+
+  test("ignores options if undefined", () => {
+    const result = Iterator.zipKeyed({ x: [1], y: [2] }, undefined).toArray();
+    expect(result).toEqual([{ x: 1, y: 2 }]);
+  });
+});
+
+describe("Iterator.zipKeyed() — longest mode", () => {
+  test("continues until all iterables are exhausted", () => {
+    const result = Iterator.zipKeyed(
+      { x: [1, 2], y: ["a", "b", "c"] },
+      { mode: "longest" }
+    ).toArray();
+    expect(result).toEqual([
+      { x: 1, y: "a" },
+      { x: 2, y: "b" },
+      { x: undefined, y: "c" },
+    ]);
+  });
+
+  test("fills with undefined when no padding provided", () => {
+    const result = Iterator.zipKeyed(
+      { x: [1], y: ["a", "b", "c"] },
+      { mode: "longest" }
+    ).toArray();
+    expect(result).toEqual([
+      { x: 1, y: "a" },
+      { x: undefined, y: "b" },
+      { x: undefined, y: "c" },
+    ]);
+  });
+
+  test("fills with padding values from object", () => {
+    const result = Iterator.zipKeyed(
+      { x: [1, 2], y: ["a", "b", "c", "d"] },
+      { mode: "longest", padding: { x: 0, y: "?" } }
+    ).toArray();
+    expect(result).toEqual([
+      { x: 1, y: "a" },
+      { x: 2, y: "b" },
+      { x: 0, y: "c" },
+      { x: 0, y: "d" },
+    ]);
+  });
+
+  test("padding missing keys use undefined", () => {
+    const result = Iterator.zipKeyed(
+      { x: [1], y: [2], z: [3, 4] },
+      { mode: "longest", padding: { x: 0 } }
+    ).toArray();
+    expect(result).toEqual([
+      { x: 1, y: 2, z: 3 },
+      { x: 0, y: undefined, z: 4 },
+    ]);
+  });
+
+  test("all same length behaves like shortest mode", () => {
+    const result = Iterator.zipKeyed(
+      { a: [1, 2], b: [3, 4] },
+      { mode: "longest" }
+    ).toArray();
+    expect(result).toEqual([{ a: 1, b: 3 }, { a: 2, b: 4 }]);
+  });
+
+  test("empty iterables with longest mode yield nothing", () => {
+    const result = Iterator.zipKeyed(
+      { x: [], y: [] },
+      { mode: "longest" }
+    ).toArray();
+    expect(result).toEqual([]);
+  });
+});
+
+describe("Iterator.zipKeyed() — strict mode", () => {
+  test("works when all iterables have same length", () => {
+    const result = Iterator.zipKeyed(
+      { name: ["Alice", "Bob"], age: [30, 25] },
+      { mode: "strict" }
+    ).toArray();
+    expect(result).toEqual([
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 25 },
+    ]);
+  });
+
+  test("throws TypeError when iterables have different lengths", () => {
+    expect(() => {
+      Iterator.zipKeyed(
+        { x: [1, 2], y: [3, 4, 5] },
+        { mode: "strict" }
+      ).toArray();
+    }).toThrow(TypeError);
+  });
+
+  test("throws TypeError when first is shorter", () => {
+    expect(() => {
+      Iterator.zipKeyed(
+        { a: [1], b: [2, 3] },
+        { mode: "strict" }
+      ).toArray();
+    }).toThrow(TypeError);
+  });
+
+  test("empty iterables in strict mode are fine", () => {
+    const result = Iterator.zipKeyed(
+      { x: [], y: [] },
+      { mode: "strict" }
+    ).toArray();
+    expect(result).toEqual([]);
+  });
+});
+
+describe("Iterator.zipKeyed() — table data example", () => {
+  test("processes tabular data", () => {
+    const table = {
+      name: ["Caroline", "Danielle", "Evelyn"],
+      age: [30, 25, 35],
+      city: ["New York", "London", "Hong Kong"],
+    };
+
+    const result = [];
+    for (const { name, age, city } of Iterator.zipKeyed(table)) {
+      result.push(name + " (" + age + ", " + city + ")");
+    }
+    expect(result).toEqual([
+      "Caroline (30, New York)",
+      "Danielle (25, London)",
+      "Evelyn (35, Hong Kong)",
+    ]);
+  });
+});

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -87,6 +87,8 @@ const
   PROP_OPEN                   = 'open';
   PROP_NULLPTR                = 'nullptr';
   PROP_SUFFIX                 = 'suffix';
+  PROP_MODE                   = 'mode';
+  PROP_PADDING                = 'padding';
 
   // Proxy handler trap names
   PROP_HAS                       = 'has';

--- a/units/Goccia.Values.Iterator.Zip.pas
+++ b/units/Goccia.Values.Iterator.Zip.pas
@@ -52,6 +52,7 @@ implementation
 
 uses
   Goccia.Arguments.Collection,
+  Goccia.GarbageCollector,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -182,96 +183,101 @@ begin
   end;
 
   ResultArray := TGocciaArrayValue.Create;
-  AnyDone := False;
-  AllDone := True;
+  TGarbageCollector.Instance.AddTempRoot(ResultArray);
+  try
+    AnyDone := False;
+    AllDone := True;
 
-  // TC39 Joint Iteration §1.1 step 6.a: For each iteratorRecord of iteratorRecords
-  for I := 0 to High(FIterators) do
-  begin
-    if FExhausted[I] then
+    // TC39 Joint Iteration §1.1 step 6.a: For each iteratorRecord of iteratorRecords
+    for I := 0 to High(FIterators) do
     begin
-      // Already exhausted — use padding (only relevant for longest mode)
-      if I < Length(FPadding) then
-        ResultArray.Elements.Add(FPadding[I])
+      if FExhausted[I] then
+      begin
+        // Already exhausted — use padding (only relevant for longest mode)
+        if I < Length(FPadding) then
+          ResultArray.Elements.Add(FPadding[I])
+        else
+          ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+        AnyDone := True;
+        Continue;
+      end;
+
+      try
+        InnerValue := FIterators[I].DirectNext(InnerDone);
+      except
+        CloseAllIterators;
+        FDone := True;
+        raise;
+      end;
+
+      if InnerDone then
+      begin
+        FExhausted[I] := True;
+        AnyDone := True;
+        if I < Length(FPadding) then
+          ResultArray.Elements.Add(FPadding[I])
+        else
+          ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+      end
       else
-        ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
-      AnyDone := True;
-      Continue;
+      begin
+        AllDone := False;
+        ResultArray.Elements.Add(InnerValue);
+      end;
     end;
 
-    try
-      InnerValue := FIterators[I].DirectNext(InnerDone);
-    except
-      CloseAllIterators;
-      FDone := True;
-      raise;
-    end;
-
-    if InnerDone then
-    begin
-      FExhausted[I] := True;
-      AnyDone := True;
-      if I < Length(FPadding) then
-        ResultArray.Elements.Add(FPadding[I])
-      else
-        ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
-    end
-    else
-    begin
+    if not AnyDone then
       AllDone := False;
-      ResultArray.Elements.Add(InnerValue);
+
+    case FMode of
+      zmShortest:
+      begin
+        // TC39 Joint Iteration §1.1 step 6.a.ii: If mode is "shortest", close remaining
+        if AnyDone then
+        begin
+          CloseAllIterators;
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+      end;
+      zmLongest:
+      begin
+        // TC39 Joint Iteration §1.1: If all are done, complete
+        if AllDone then
+        begin
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+        // Otherwise yield the array with padding values for exhausted iterators
+      end;
+      zmStrict:
+      begin
+        // TC39 Joint Iteration §1.1: In strict mode, all must finish together
+        if AnyDone and not AllDone then
+        begin
+          CloseAllIterators;
+          FDone := True;
+          ThrowTypeError('Iterator.zip: iterables have different lengths in strict mode');
+        end;
+        if AllDone then
+        begin
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+      end;
     end;
+
+    ADone := False;
+    Result := ResultArray;
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(ResultArray);
   end;
-
-  if not AnyDone then
-    AllDone := False;
-
-  case FMode of
-    zmShortest:
-    begin
-      // TC39 Joint Iteration §1.1 step 6.a.ii: If mode is "shortest", close remaining
-      if AnyDone then
-      begin
-        CloseAllIterators;
-        FDone := True;
-        ADone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
-    end;
-    zmLongest:
-    begin
-      // TC39 Joint Iteration §1.1: If all are done, complete
-      if AllDone then
-      begin
-        FDone := True;
-        ADone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
-      // Otherwise yield the array with padding values for exhausted iterators
-    end;
-    zmStrict:
-    begin
-      // TC39 Joint Iteration §1.1: In strict mode, all must finish together
-      if AnyDone and not AllDone then
-      begin
-        CloseAllIterators;
-        FDone := True;
-        ThrowTypeError('Iterator.zip: iterables have different lengths in strict mode');
-      end;
-      if AllDone then
-      begin
-        FDone := True;
-        ADone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
-    end;
-  end;
-
-  ADone := False;
-  Result := ResultArray;
 end;
 
 procedure TGocciaZipIteratorValue.Close;
@@ -369,91 +375,96 @@ begin
   end;
 
   ResultObj := TGocciaObjectValue.Create;
-  AnyDone := False;
-  AllDone := True;
+  TGarbageCollector.Instance.AddTempRoot(ResultObj);
+  try
+    AnyDone := False;
+    AllDone := True;
 
-  // TC39 Joint Iteration §1.2 step 6.a: For each key of keys
-  for I := 0 to High(FIterators) do
-  begin
-    if FExhausted[I] then
+    // TC39 Joint Iteration §1.2 step 6.a: For each key of keys
+    for I := 0 to High(FIterators) do
     begin
-      if I < Length(FPadding) then
-        ResultObj.AssignProperty(FKeys[I], FPadding[I])
+      if FExhausted[I] then
+      begin
+        if I < Length(FPadding) then
+          ResultObj.AssignProperty(FKeys[I], FPadding[I])
+        else
+          ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
+        AnyDone := True;
+        Continue;
+      end;
+
+      try
+        InnerValue := FIterators[I].DirectNext(InnerDone);
+      except
+        CloseAllIterators;
+        FDone := True;
+        raise;
+      end;
+
+      if InnerDone then
+      begin
+        FExhausted[I] := True;
+        AnyDone := True;
+        if I < Length(FPadding) then
+          ResultObj.AssignProperty(FKeys[I], FPadding[I])
+        else
+          ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
+      end
       else
-        ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
-      AnyDone := True;
-      Continue;
+      begin
+        AllDone := False;
+        ResultObj.AssignProperty(FKeys[I], InnerValue);
+      end;
     end;
 
-    try
-      InnerValue := FIterators[I].DirectNext(InnerDone);
-    except
-      CloseAllIterators;
-      FDone := True;
-      raise;
-    end;
-
-    if InnerDone then
-    begin
-      FExhausted[I] := True;
-      AnyDone := True;
-      if I < Length(FPadding) then
-        ResultObj.AssignProperty(FKeys[I], FPadding[I])
-      else
-        ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
-    end
-    else
-    begin
+    if not AnyDone then
       AllDone := False;
-      ResultObj.AssignProperty(FKeys[I], InnerValue);
+
+    case FMode of
+      zmShortest:
+      begin
+        if AnyDone then
+        begin
+          CloseAllIterators;
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+      end;
+      zmLongest:
+      begin
+        if AllDone then
+        begin
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+      end;
+      zmStrict:
+      begin
+        if AnyDone and not AllDone then
+        begin
+          CloseAllIterators;
+          FDone := True;
+          ThrowTypeError('Iterator.zipKeyed: iterables have different lengths in strict mode');
+        end;
+        if AllDone then
+        begin
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+      end;
     end;
+
+    ADone := False;
+    Result := ResultObj;
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(ResultObj);
   end;
-
-  if not AnyDone then
-    AllDone := False;
-
-  case FMode of
-    zmShortest:
-    begin
-      if AnyDone then
-      begin
-        CloseAllIterators;
-        FDone := True;
-        ADone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
-    end;
-    zmLongest:
-    begin
-      if AllDone then
-      begin
-        FDone := True;
-        ADone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
-    end;
-    zmStrict:
-    begin
-      if AnyDone and not AllDone then
-      begin
-        CloseAllIterators;
-        FDone := True;
-        ThrowTypeError('Iterator.zipKeyed: iterables have different lengths in strict mode');
-      end;
-      if AllDone then
-      begin
-        FDone := True;
-        ADone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
-    end;
-  end;
-
-  ADone := False;
-  Result := ResultObj;
 end;
 
 procedure TGocciaZipKeyedIteratorValue.Close;

--- a/units/Goccia.Values.Iterator.Zip.pas
+++ b/units/Goccia.Values.Iterator.Zip.pas
@@ -1,0 +1,484 @@
+unit Goccia.Values.Iterator.Zip;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.IteratorValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaZipMode = (zmShortest, zmLongest, zmStrict);
+
+  TGocciaZipIteratorValue = class(TGocciaIteratorValue)
+  private
+    FIterators: array of TGocciaIteratorValue;
+    FPadding: array of TGocciaValue;
+    FMode: TGocciaZipMode;
+    FExhausted: array of Boolean;
+    procedure CloseAllIterators;
+  public
+    constructor Create(const AIterators: array of TGocciaIteratorValue;
+      const APadding: array of TGocciaValue; const AMode: TGocciaZipMode);
+    function AdvanceNext: TGocciaObjectValue; override;
+    function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    procedure Close; override;
+    procedure MarkReferences; override;
+  end;
+
+  TGocciaZipKeyedIteratorValue = class(TGocciaIteratorValue)
+  private
+    FKeys: array of string;
+    FIterators: array of TGocciaIteratorValue;
+    FPadding: array of TGocciaValue;
+    FMode: TGocciaZipMode;
+    FExhausted: array of Boolean;
+    procedure CloseAllIterators;
+  public
+    constructor Create(const AKeys: array of string;
+      const AIterators: array of TGocciaIteratorValue;
+      const APadding: array of TGocciaValue; const AMode: TGocciaZipMode);
+    function AdvanceNext: TGocciaObjectValue; override;
+    function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    procedure Close; override;
+    procedure MarkReferences; override;
+  end;
+
+function GetIteratorFromIterable(const AValue: TGocciaValue): TGocciaIteratorValue;
+
+implementation
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Values.ArrayValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
+  Goccia.Values.Iterator.Concrete,
+  Goccia.Values.Iterator.Generic,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue;
+
+procedure CloseIteratorPreservingOriginalError(const AIterator: TGocciaIteratorValue);
+begin
+  if not Assigned(AIterator) then
+    Exit;
+  try
+    AIterator.Close;
+  except
+    // Preserve the original abrupt-completion error when cleanup also throws.
+  end;
+end;
+
+// TC39 Joint Iteration §2.1.1 GetIteratorFlattenable(obj, primitiveHandling)
+function GetIteratorFromIterable(const AValue: TGocciaValue): TGocciaIteratorValue;
+var
+  IteratorMethod, IteratorObj: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
+begin
+  Result := nil;
+
+  if AValue is TGocciaIteratorValue then
+  begin
+    Result := TGocciaIteratorValue(AValue);
+    Exit;
+  end;
+
+  if AValue is TGocciaStringLiteralValue then
+  begin
+    Result := TGocciaStringIteratorValue.Create(AValue);
+    Exit;
+  end;
+
+  if AValue is TGocciaObjectValue then
+  begin
+    IteratorMethod := TGocciaObjectValue(AValue).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
+    if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
+    begin
+      CallArgs := TGocciaArgumentsCollection.Create;
+      try
+        IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, AValue);
+      finally
+        CallArgs.Free;
+      end;
+      if IteratorObj is TGocciaIteratorValue then
+      begin
+        Result := TGocciaIteratorValue(IteratorObj);
+        Exit;
+      end;
+      if IteratorObj is TGocciaObjectValue then
+      begin
+        Result := TGocciaGenericIteratorValue.Create(IteratorObj);
+        Exit;
+      end;
+    end;
+  end;
+end;
+
+{ TGocciaZipIteratorValue }
+
+constructor TGocciaZipIteratorValue.Create(const AIterators: array of TGocciaIteratorValue;
+  const APadding: array of TGocciaValue; const AMode: TGocciaZipMode);
+var
+  I: Integer;
+begin
+  inherited Create;
+  SetLength(FIterators, Length(AIterators));
+  for I := 0 to High(AIterators) do
+    FIterators[I] := AIterators[I];
+  SetLength(FPadding, Length(APadding));
+  for I := 0 to High(APadding) do
+    FPadding[I] := APadding[I];
+  FMode := AMode;
+  SetLength(FExhausted, Length(AIterators));
+  for I := 0 to High(FExhausted) do
+    FExhausted[I] := False;
+end;
+
+procedure TGocciaZipIteratorValue.CloseAllIterators;
+var
+  I: Integer;
+begin
+  for I := 0 to High(FIterators) do
+  begin
+    if not FExhausted[I] then
+      CloseIteratorPreservingOriginalError(FIterators[I]);
+  end;
+end;
+
+// TC39 Joint Iteration §1.1 Iterator.zip(iterables [, options])
+function TGocciaZipIteratorValue.AdvanceNext: TGocciaObjectValue;
+var
+  Value: TGocciaValue;
+  Done: Boolean;
+begin
+  Value := DirectNext(Done);
+  Result := CreateIteratorResult(Value, Done);
+end;
+
+// TC39 Joint Iteration §1.1 Iterator.zip(iterables [, options]) — yield step
+function TGocciaZipIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+var
+  ResultArray: TGocciaArrayValue;
+  I: Integer;
+  InnerValue: TGocciaValue;
+  InnerDone: Boolean;
+  AnyDone, AllDone: Boolean;
+begin
+  if FDone then
+  begin
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  if Length(FIterators) = 0 then
+  begin
+    FDone := True;
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  ResultArray := TGocciaArrayValue.Create;
+  AnyDone := False;
+  AllDone := True;
+
+  // TC39 Joint Iteration §1.1 step 6.a: For each iteratorRecord of iteratorRecords
+  for I := 0 to High(FIterators) do
+  begin
+    if FExhausted[I] then
+    begin
+      // Already exhausted — use padding (only relevant for longest mode)
+      if I < Length(FPadding) then
+        ResultArray.Elements.Add(FPadding[I])
+      else
+        ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+      AnyDone := True;
+      Continue;
+    end;
+
+    try
+      InnerValue := FIterators[I].DirectNext(InnerDone);
+    except
+      CloseAllIterators;
+      FDone := True;
+      raise;
+    end;
+
+    if InnerDone then
+    begin
+      FExhausted[I] := True;
+      AnyDone := True;
+      if I < Length(FPadding) then
+        ResultArray.Elements.Add(FPadding[I])
+      else
+        ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+    end
+    else
+    begin
+      AllDone := False;
+      ResultArray.Elements.Add(InnerValue);
+    end;
+  end;
+
+  if not AnyDone then
+    AllDone := False;
+
+  case FMode of
+    zmShortest:
+    begin
+      // TC39 Joint Iteration §1.1 step 6.a.ii: If mode is "shortest", close remaining
+      if AnyDone then
+      begin
+        CloseAllIterators;
+        FDone := True;
+        ADone := True;
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Exit;
+      end;
+    end;
+    zmLongest:
+    begin
+      // TC39 Joint Iteration §1.1: If all are done, complete
+      if AllDone then
+      begin
+        FDone := True;
+        ADone := True;
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Exit;
+      end;
+      // Otherwise yield the array with padding values for exhausted iterators
+    end;
+    zmStrict:
+    begin
+      // TC39 Joint Iteration §1.1: In strict mode, all must finish together
+      if AnyDone and not AllDone then
+      begin
+        CloseAllIterators;
+        FDone := True;
+        ThrowTypeError('Iterator.zip: iterables have different lengths in strict mode');
+      end;
+      if AllDone then
+      begin
+        FDone := True;
+        ADone := True;
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Exit;
+      end;
+    end;
+  end;
+
+  ADone := False;
+  Result := ResultArray;
+end;
+
+procedure TGocciaZipIteratorValue.Close;
+begin
+  if FDone then Exit;
+  FDone := True;
+  CloseAllIterators;
+end;
+
+procedure TGocciaZipIteratorValue.MarkReferences;
+var
+  I: Integer;
+begin
+  if GCMarked then Exit;
+  inherited;
+  for I := 0 to High(FIterators) do
+  begin
+    if Assigned(FIterators[I]) then
+      FIterators[I].MarkReferences;
+  end;
+  for I := 0 to High(FPadding) do
+  begin
+    if Assigned(FPadding[I]) then
+      FPadding[I].MarkReferences;
+  end;
+end;
+
+{ TGocciaZipKeyedIteratorValue }
+
+constructor TGocciaZipKeyedIteratorValue.Create(const AKeys: array of string;
+  const AIterators: array of TGocciaIteratorValue;
+  const APadding: array of TGocciaValue; const AMode: TGocciaZipMode);
+var
+  I: Integer;
+begin
+  inherited Create;
+  SetLength(FKeys, Length(AKeys));
+  for I := 0 to High(AKeys) do
+    FKeys[I] := AKeys[I];
+  SetLength(FIterators, Length(AIterators));
+  for I := 0 to High(AIterators) do
+    FIterators[I] := AIterators[I];
+  SetLength(FPadding, Length(APadding));
+  for I := 0 to High(APadding) do
+    FPadding[I] := APadding[I];
+  FMode := AMode;
+  SetLength(FExhausted, Length(AIterators));
+  for I := 0 to High(FExhausted) do
+    FExhausted[I] := False;
+end;
+
+procedure TGocciaZipKeyedIteratorValue.CloseAllIterators;
+var
+  I: Integer;
+begin
+  for I := 0 to High(FIterators) do
+  begin
+    if not FExhausted[I] then
+      CloseIteratorPreservingOriginalError(FIterators[I]);
+  end;
+end;
+
+// TC39 Joint Iteration §1.2 Iterator.zipKeyed(iterables [, options])
+function TGocciaZipKeyedIteratorValue.AdvanceNext: TGocciaObjectValue;
+var
+  Value: TGocciaValue;
+  Done: Boolean;
+begin
+  Value := DirectNext(Done);
+  Result := CreateIteratorResult(Value, Done);
+end;
+
+// TC39 Joint Iteration §1.2 Iterator.zipKeyed(iterables [, options]) — yield step
+function TGocciaZipKeyedIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+var
+  ResultObj: TGocciaObjectValue;
+  I: Integer;
+  InnerValue: TGocciaValue;
+  InnerDone: Boolean;
+  AnyDone, AllDone: Boolean;
+begin
+  if FDone then
+  begin
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  if Length(FIterators) = 0 then
+  begin
+    FDone := True;
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  ResultObj := TGocciaObjectValue.Create;
+  AnyDone := False;
+  AllDone := True;
+
+  // TC39 Joint Iteration §1.2 step 6.a: For each key of keys
+  for I := 0 to High(FIterators) do
+  begin
+    if FExhausted[I] then
+    begin
+      if I < Length(FPadding) then
+        ResultObj.AssignProperty(FKeys[I], FPadding[I])
+      else
+        ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
+      AnyDone := True;
+      Continue;
+    end;
+
+    try
+      InnerValue := FIterators[I].DirectNext(InnerDone);
+    except
+      CloseAllIterators;
+      FDone := True;
+      raise;
+    end;
+
+    if InnerDone then
+    begin
+      FExhausted[I] := True;
+      AnyDone := True;
+      if I < Length(FPadding) then
+        ResultObj.AssignProperty(FKeys[I], FPadding[I])
+      else
+        ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
+    end
+    else
+    begin
+      AllDone := False;
+      ResultObj.AssignProperty(FKeys[I], InnerValue);
+    end;
+  end;
+
+  if not AnyDone then
+    AllDone := False;
+
+  case FMode of
+    zmShortest:
+    begin
+      if AnyDone then
+      begin
+        CloseAllIterators;
+        FDone := True;
+        ADone := True;
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Exit;
+      end;
+    end;
+    zmLongest:
+    begin
+      if AllDone then
+      begin
+        FDone := True;
+        ADone := True;
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Exit;
+      end;
+    end;
+    zmStrict:
+    begin
+      if AnyDone and not AllDone then
+      begin
+        CloseAllIterators;
+        FDone := True;
+        ThrowTypeError('Iterator.zipKeyed: iterables have different lengths in strict mode');
+      end;
+      if AllDone then
+      begin
+        FDone := True;
+        ADone := True;
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Exit;
+      end;
+    end;
+  end;
+
+  ADone := False;
+  Result := ResultObj;
+end;
+
+procedure TGocciaZipKeyedIteratorValue.Close;
+begin
+  if FDone then Exit;
+  FDone := True;
+  CloseAllIterators;
+end;
+
+procedure TGocciaZipKeyedIteratorValue.MarkReferences;
+var
+  I: Integer;
+begin
+  if GCMarked then Exit;
+  inherited;
+  for I := 0 to High(FIterators) do
+  begin
+    if Assigned(FIterators[I]) then
+      FIterators[I].MarkReferences;
+  end;
+  for I := 0 to High(FPadding) do
+  begin
+    if Assigned(FPadding[I]) then
+      FPadding[I].MarkReferences;
+  end;
+end;
+
+end.

--- a/units/Goccia.Values.IteratorValue.pas
+++ b/units/Goccia.Values.IteratorValue.pas
@@ -690,6 +690,7 @@ var
   I, J, Count, Acquired: Integer;
   ModeStr: string;
   GC: TGarbageCollector;
+  Success: Boolean;
 begin
   // TC39 Joint Iteration §1.1 step 1: If iterables is not an Object, throw TypeError
   if AArgs.Length < 1 then
@@ -752,6 +753,7 @@ begin
   for I := 0 to Count - 1 do
     Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
 
+  Success := False;
   try
     if AArgs.Length >= 2 then
     begin
@@ -809,7 +811,14 @@ begin
     end;
 
     Result := TGocciaZipIteratorValue.Create(Iterators, Padding, Mode);
+    Success := True;
   finally
+    // On error, close all iterators so generator finally blocks run
+    if not Success then
+    begin
+      for I := 0 to Count - 1 do
+        CloseIteratorPreservingError(Iterators[I]);
+    end;
     // Unroot iterators — the zip iterator now owns them via MarkReferences
     for I := 0 to Count - 1 do
       GC.RemoveTempRoot(Iterators[I]);
@@ -834,6 +843,7 @@ var
   I, J, Count, Acquired: Integer;
   ModeStr: string;
   GC: TGarbageCollector;
+  Success: Boolean;
 begin
   // TC39 Joint Iteration §1.2 step 1: If iterables is not an Object, throw TypeError
   if AArgs.Length < 1 then
@@ -879,6 +889,7 @@ begin
   for I := 0 to Count - 1 do
     Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
 
+  Success := False;
   try
     if AArgs.Length >= 2 then
     begin
@@ -925,7 +936,14 @@ begin
     end;
 
     Result := TGocciaZipKeyedIteratorValue.Create(Keys, Iterators, Padding, Mode);
+    Success := True;
   finally
+    // On error, close all iterators so generator finally blocks run
+    if not Success then
+    begin
+      for I := 0 to Count - 1 do
+        CloseIteratorPreservingError(Iterators[I]);
+    end;
     // Unroot iterators — the zipKeyed iterator now owns them via MarkReferences
     for I := 0 to Count - 1 do
       GC.RemoveTempRoot(Iterators[I]);

--- a/units/Goccia.Values.IteratorValue.pas
+++ b/units/Goccia.Values.IteratorValue.pas
@@ -35,6 +35,8 @@ type
     function IteratorFlatMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorFrom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorConcat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorZip(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorZipKeyed(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     class procedure EnsurePrototypeInitialized;
     procedure InitializePrototype;
@@ -68,6 +70,7 @@ uses
   Goccia.Values.Iterator.Concrete,
   Goccia.Values.Iterator.Generic,
   Goccia.Values.Iterator.Lazy,
+  Goccia.Values.Iterator.Zip,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
@@ -193,6 +196,8 @@ begin
     try
       Members.AddNamedMethod('from', FPrototypeMethodHost.IteratorFrom, 1, gmkStaticMethod, [gmfNoFunctionPrototype]);
       Members.AddNamedMethod('concat', FPrototypeMethodHost.IteratorConcat, 0, gmkStaticMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('zip', FPrototypeMethodHost.IteratorZip, 1, gmkStaticMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('zipKeyed', FPrototypeMethodHost.IteratorZipKeyed, 1, gmkStaticMethod, [gmfNoFunctionPrototype]);
       FStaticMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -652,6 +657,220 @@ begin
 
   // TC39 Iterator Sequencing §1 steps 3-6: Create iterator from closure
   Result := TGocciaConcatIteratorValue.Create(Iterables);
+end;
+
+{ Iterator.zip() }
+
+// TC39 Joint Iteration §1.1 Iterator.zip(iterables [, options])
+function TGocciaIteratorValue.IteratorZip(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+const
+  ZIP_MODE_SHORTEST = 'shortest';
+  ZIP_MODE_LONGEST = 'longest';
+  ZIP_MODE_STRICT = 'strict';
+var
+  IterablesArg, OptionsArg, Item, ModeVal, PaddingVal, PaddingItem: TGocciaValue;
+  OuterIterator, InnerIterator, PaddingIterator: TGocciaIteratorValue;
+  OuterDone, PaddingDone: Boolean;
+  Iterators: array of TGocciaIteratorValue;
+  Padding: array of TGocciaValue;
+  Mode: TGocciaZipMode;
+  Items: TGocciaValueList;
+  PaddingItems: TGocciaValueList;
+  I, Count: Integer;
+  ModeStr: string;
+begin
+  // TC39 Joint Iteration §1.1 step 1: If iterables is not an Object, throw TypeError
+  if AArgs.Length < 1 then
+    ThrowTypeError('Iterator.zip requires an argument');
+
+  IterablesArg := AArgs.GetElement(0);
+
+  // TC39 Joint Iteration §1.1 step 2: Get iterator from iterables
+  OuterIterator := GetIteratorFromIterable(IterablesArg);
+  if OuterIterator = nil then
+    ThrowTypeError('Iterator.zip: first argument must be iterable');
+
+  // TC39 Joint Iteration §1.1 step 3: Collect all inner iterables
+  Items := TGocciaValueList.Create(False);
+  try
+    Item := OuterIterator.DirectNext(OuterDone);
+    while not OuterDone do
+    begin
+      Items.Add(Item);
+      Item := OuterIterator.DirectNext(OuterDone);
+    end;
+
+    Count := Items.Count;
+    SetLength(Iterators, Count);
+
+    // TC39 Joint Iteration §1.1 step 4: Get iterators from each iterable
+    for I := 0 to Count - 1 do
+    begin
+      InnerIterator := GetIteratorFromIterable(Items[I]);
+      if InnerIterator = nil then
+        ThrowTypeError('Iterator.zip: all items in iterables must be iterable');
+      Iterators[I] := InnerIterator;
+    end;
+  finally
+    Items.Free;
+  end;
+
+  // TC39 Joint Iteration §1.1 step 5: Parse options
+  Mode := zmShortest;
+  SetLength(Padding, Count);
+  for I := 0 to Count - 1 do
+    Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  if AArgs.Length >= 2 then
+  begin
+    OptionsArg := AArgs.GetElement(1);
+    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    begin
+      if not (OptionsArg is TGocciaObjectValue) then
+        ThrowTypeError('Iterator.zip: options must be an object');
+
+      // TC39 Joint Iteration §1.1 step 5a: Get mode
+      ModeVal := OptionsArg.GetProperty(PROP_MODE);
+      if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
+      begin
+        if not (ModeVal is TGocciaStringLiteralValue) then
+          ThrowTypeError('Iterator.zip: mode must be a string');
+        ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
+        if ModeStr = ZIP_MODE_SHORTEST then
+          Mode := zmShortest
+        else if ModeStr = ZIP_MODE_LONGEST then
+          Mode := zmLongest
+        else if ModeStr = ZIP_MODE_STRICT then
+          Mode := zmStrict
+        else
+          ThrowRangeError('Iterator.zip: invalid mode "' + ModeStr + '"');
+      end;
+
+      // TC39 Joint Iteration §1.1 step 5b: Get padding (only for longest mode)
+      if Mode = zmLongest then
+      begin
+        PaddingVal := OptionsArg.GetProperty(PROP_PADDING);
+        if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
+        begin
+          PaddingIterator := GetIteratorFromIterable(PaddingVal);
+          if PaddingIterator = nil then
+            ThrowTypeError('Iterator.zip: padding must be iterable');
+          PaddingItems := TGocciaValueList.Create(False);
+          try
+            PaddingItem := PaddingIterator.DirectNext(PaddingDone);
+            while not PaddingDone do
+            begin
+              PaddingItems.Add(PaddingItem);
+              PaddingItem := PaddingIterator.DirectNext(PaddingDone);
+            end;
+            for I := 0 to Count - 1 do
+            begin
+              if I < PaddingItems.Count then
+                Padding[I] := PaddingItems[I];
+            end;
+          finally
+            PaddingItems.Free;
+          end;
+        end;
+      end;
+    end;
+  end;
+
+  Result := TGocciaZipIteratorValue.Create(Iterators, Padding, Mode);
+end;
+
+{ Iterator.zipKeyed() }
+
+// TC39 Joint Iteration §1.2 Iterator.zipKeyed(iterables [, options])
+function TGocciaIteratorValue.IteratorZipKeyed(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+const
+  ZIP_MODE_SHORTEST = 'shortest';
+  ZIP_MODE_LONGEST = 'longest';
+  ZIP_MODE_STRICT = 'strict';
+var
+  IterablesArg, OptionsArg, ModeVal, PaddingVal, PropValue: TGocciaValue;
+  InnerIterator: TGocciaIteratorValue;
+  Keys: TArray<string>;
+  Iterators: array of TGocciaIteratorValue;
+  Padding: array of TGocciaValue;
+  Mode: TGocciaZipMode;
+  I, Count: Integer;
+  ModeStr: string;
+begin
+  // TC39 Joint Iteration §1.2 step 1: If iterables is not an Object, throw TypeError
+  if AArgs.Length < 1 then
+    ThrowTypeError('Iterator.zipKeyed requires an argument');
+
+  IterablesArg := AArgs.GetElement(0);
+  if not (IterablesArg is TGocciaObjectValue) then
+    ThrowTypeError('Iterator.zipKeyed: first argument must be an object');
+
+  // TC39 Joint Iteration §1.2 step 2: Get own enumerable property keys
+  Keys := TGocciaObjectValue(IterablesArg).GetEnumerablePropertyNames;
+  Count := Length(Keys);
+
+  // TC39 Joint Iteration §1.2 step 3: Get iterators from each property value
+  SetLength(Iterators, Count);
+  for I := 0 to Count - 1 do
+  begin
+    PropValue := IterablesArg.GetProperty(Keys[I]);
+    InnerIterator := GetIteratorFromIterable(PropValue);
+    if InnerIterator = nil then
+      ThrowTypeError('Iterator.zipKeyed: property "' + Keys[I] + '" value must be iterable');
+    Iterators[I] := InnerIterator;
+  end;
+
+  // TC39 Joint Iteration §1.2 step 4: Parse options
+  Mode := zmShortest;
+  SetLength(Padding, Count);
+  for I := 0 to Count - 1 do
+    Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  if AArgs.Length >= 2 then
+  begin
+    OptionsArg := AArgs.GetElement(1);
+    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    begin
+      if not (OptionsArg is TGocciaObjectValue) then
+        ThrowTypeError('Iterator.zipKeyed: options must be an object');
+
+      // TC39 Joint Iteration §1.2 step 4a: Get mode
+      ModeVal := OptionsArg.GetProperty(PROP_MODE);
+      if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
+      begin
+        if not (ModeVal is TGocciaStringLiteralValue) then
+          ThrowTypeError('Iterator.zipKeyed: mode must be a string');
+        ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
+        if ModeStr = ZIP_MODE_SHORTEST then
+          Mode := zmShortest
+        else if ModeStr = ZIP_MODE_LONGEST then
+          Mode := zmLongest
+        else if ModeStr = ZIP_MODE_STRICT then
+          Mode := zmStrict
+        else
+          ThrowRangeError('Iterator.zipKeyed: invalid mode "' + ModeStr + '"');
+      end;
+
+      // TC39 Joint Iteration §1.2 step 4b: Get padding (only for longest mode)
+      if Mode = zmLongest then
+      begin
+        PaddingVal := OptionsArg.GetProperty(PROP_PADDING);
+        if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
+        begin
+          if not (PaddingVal is TGocciaObjectValue) then
+            ThrowTypeError('Iterator.zipKeyed: padding must be an object');
+          for I := 0 to Count - 1 do
+          begin
+            PropValue := PaddingVal.GetProperty(Keys[I]);
+            if Assigned(PropValue) and not (PropValue is TGocciaUndefinedLiteralValue) then
+              Padding[I] := PropValue;
+          end;
+        end;
+      end;
+    end;
+  end;
+
+  Result := TGocciaZipKeyedIteratorValue.Create(Keys, Iterators, Padding, Mode);
 end;
 
 end.

--- a/units/Goccia.Values.IteratorValue.pas
+++ b/units/Goccia.Values.IteratorValue.pas
@@ -789,6 +789,7 @@ begin
             PaddingIterator := GetIteratorFromIterable(PaddingVal);
             if PaddingIterator = nil then
               ThrowTypeError('Iterator.zip: padding must be iterable');
+            GC.AddTempRoot(PaddingIterator);
             PaddingItems := TGocciaValueList.Create(False);
             try
               PaddingItem := PaddingIterator.DirectNext(PaddingDone);
@@ -804,6 +805,7 @@ begin
               end;
             finally
               PaddingItems.Free;
+              GC.RemoveTempRoot(PaddingIterator);
             end;
           end;
         end;

--- a/units/Goccia.Values.IteratorValue.pas
+++ b/units/Goccia.Values.IteratorValue.pas
@@ -75,6 +75,17 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
+procedure CloseIteratorPreservingError(const AIterator: TGocciaIteratorValue);
+begin
+  if not Assigned(AIterator) then
+    Exit;
+  try
+    AIterator.Close;
+  except
+    // Preserve the original abrupt-completion error when cleanup also throws.
+  end;
+end;
+
 function CreateIteratorResult(const AValue: TGocciaValue; const ADone: Boolean): TGocciaObjectValue;
 begin
   Result := TGocciaObjectValue.Create;
@@ -676,43 +687,63 @@ var
   Mode: TGocciaZipMode;
   Items: TGocciaValueList;
   PaddingItems: TGocciaValueList;
-  I, Count: Integer;
+  I, J, Count, Acquired: Integer;
   ModeStr: string;
+  GC: TGarbageCollector;
 begin
   // TC39 Joint Iteration §1.1 step 1: If iterables is not an Object, throw TypeError
   if AArgs.Length < 1 then
     ThrowTypeError('Iterator.zip requires an argument');
 
   IterablesArg := AArgs.GetElement(0);
+  GC := TGarbageCollector.Instance;
 
   // TC39 Joint Iteration §1.1 step 2: Get iterator from iterables
   OuterIterator := GetIteratorFromIterable(IterablesArg);
   if OuterIterator = nil then
     ThrowTypeError('Iterator.zip: first argument must be iterable');
 
-  // TC39 Joint Iteration §1.1 step 3: Collect all inner iterables
-  Items := TGocciaValueList.Create(False);
+  GC.AddTempRoot(OuterIterator);
   try
-    Item := OuterIterator.DirectNext(OuterDone);
-    while not OuterDone do
-    begin
-      Items.Add(Item);
+    // TC39 Joint Iteration §1.1 step 3: Collect all inner iterables
+    Items := TGocciaValueList.Create(False);
+    try
       Item := OuterIterator.DirectNext(OuterDone);
-    end;
+      while not OuterDone do
+      begin
+        Items.Add(Item);
+        Item := OuterIterator.DirectNext(OuterDone);
+      end;
 
-    Count := Items.Count;
-    SetLength(Iterators, Count);
+      Count := Items.Count;
+      SetLength(Iterators, Count);
+      Acquired := 0;
 
-    // TC39 Joint Iteration §1.1 step 4: Get iterators from each iterable
-    for I := 0 to Count - 1 do
-    begin
-      InnerIterator := GetIteratorFromIterable(Items[I]);
-      if InnerIterator = nil then
-        ThrowTypeError('Iterator.zip: all items in iterables must be iterable');
-      Iterators[I] := InnerIterator;
+      // TC39 Joint Iteration §1.1 step 4: Get iterators from each iterable
+      try
+        for I := 0 to Count - 1 do
+        begin
+          InnerIterator := GetIteratorFromIterable(Items[I]);
+          if InnerIterator = nil then
+            ThrowTypeError('Iterator.zip: all items in iterables must be iterable');
+          Iterators[I] := InnerIterator;
+          GC.AddTempRoot(InnerIterator);
+          Acquired := I + 1;
+        end;
+      except
+        // Close and unroot already-acquired iterators before re-raising
+        for J := 0 to Acquired - 1 do
+        begin
+          CloseIteratorPreservingError(Iterators[J]);
+          GC.RemoveTempRoot(Iterators[J]);
+        end;
+        raise;
+      end;
+    finally
+      Items.Free;
     end;
   finally
-    Items.Free;
+    GC.RemoveTempRoot(OuterIterator);
   end;
 
   // TC39 Joint Iteration §1.1 step 5: Parse options
@@ -721,62 +752,68 @@ begin
   for I := 0 to Count - 1 do
     Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  if AArgs.Length >= 2 then
-  begin
-    OptionsArg := AArgs.GetElement(1);
-    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+  try
+    if AArgs.Length >= 2 then
     begin
-      if not (OptionsArg is TGocciaObjectValue) then
-        ThrowTypeError('Iterator.zip: options must be an object');
-
-      // TC39 Joint Iteration §1.1 step 5a: Get mode
-      ModeVal := OptionsArg.GetProperty(PROP_MODE);
-      if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
+      OptionsArg := AArgs.GetElement(1);
+      if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
       begin
-        if not (ModeVal is TGocciaStringLiteralValue) then
-          ThrowTypeError('Iterator.zip: mode must be a string');
-        ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
-        if ModeStr = ZIP_MODE_SHORTEST then
-          Mode := zmShortest
-        else if ModeStr = ZIP_MODE_LONGEST then
-          Mode := zmLongest
-        else if ModeStr = ZIP_MODE_STRICT then
-          Mode := zmStrict
-        else
-          ThrowRangeError('Iterator.zip: invalid mode "' + ModeStr + '"');
-      end;
+        if not (OptionsArg is TGocciaObjectValue) then
+          ThrowTypeError('Iterator.zip: options must be an object');
 
-      // TC39 Joint Iteration §1.1 step 5b: Get padding (only for longest mode)
-      if Mode = zmLongest then
-      begin
-        PaddingVal := OptionsArg.GetProperty(PROP_PADDING);
-        if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
+        // TC39 Joint Iteration §1.1 step 5a: Get mode
+        ModeVal := OptionsArg.GetProperty(PROP_MODE);
+        if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
         begin
-          PaddingIterator := GetIteratorFromIterable(PaddingVal);
-          if PaddingIterator = nil then
-            ThrowTypeError('Iterator.zip: padding must be iterable');
-          PaddingItems := TGocciaValueList.Create(False);
-          try
-            PaddingItem := PaddingIterator.DirectNext(PaddingDone);
-            while not PaddingDone do
-            begin
-              PaddingItems.Add(PaddingItem);
+          if not (ModeVal is TGocciaStringLiteralValue) then
+            ThrowTypeError('Iterator.zip: mode must be a string');
+          ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
+          if ModeStr = ZIP_MODE_SHORTEST then
+            Mode := zmShortest
+          else if ModeStr = ZIP_MODE_LONGEST then
+            Mode := zmLongest
+          else if ModeStr = ZIP_MODE_STRICT then
+            Mode := zmStrict
+          else
+            ThrowRangeError('Iterator.zip: invalid mode "' + ModeStr + '"');
+        end;
+
+        // TC39 Joint Iteration §1.1 step 5b: Get padding (only for longest mode)
+        if Mode = zmLongest then
+        begin
+          PaddingVal := OptionsArg.GetProperty(PROP_PADDING);
+          if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
+          begin
+            PaddingIterator := GetIteratorFromIterable(PaddingVal);
+            if PaddingIterator = nil then
+              ThrowTypeError('Iterator.zip: padding must be iterable');
+            PaddingItems := TGocciaValueList.Create(False);
+            try
               PaddingItem := PaddingIterator.DirectNext(PaddingDone);
+              while not PaddingDone do
+              begin
+                PaddingItems.Add(PaddingItem);
+                PaddingItem := PaddingIterator.DirectNext(PaddingDone);
+              end;
+              for I := 0 to Count - 1 do
+              begin
+                if I < PaddingItems.Count then
+                  Padding[I] := PaddingItems[I];
+              end;
+            finally
+              PaddingItems.Free;
             end;
-            for I := 0 to Count - 1 do
-            begin
-              if I < PaddingItems.Count then
-                Padding[I] := PaddingItems[I];
-            end;
-          finally
-            PaddingItems.Free;
           end;
         end;
       end;
     end;
-  end;
 
-  Result := TGocciaZipIteratorValue.Create(Iterators, Padding, Mode);
+    Result := TGocciaZipIteratorValue.Create(Iterators, Padding, Mode);
+  finally
+    // Unroot iterators — the zip iterator now owns them via MarkReferences
+    for I := 0 to Count - 1 do
+      GC.RemoveTempRoot(Iterators[I]);
+  end;
 end;
 
 { Iterator.zipKeyed() }
@@ -794,8 +831,9 @@ var
   Iterators: array of TGocciaIteratorValue;
   Padding: array of TGocciaValue;
   Mode: TGocciaZipMode;
-  I, Count: Integer;
+  I, J, Count, Acquired: Integer;
   ModeStr: string;
+  GC: TGarbageCollector;
 begin
   // TC39 Joint Iteration §1.2 step 1: If iterables is not an Object, throw TypeError
   if AArgs.Length < 1 then
@@ -805,19 +843,34 @@ begin
   if not (IterablesArg is TGocciaObjectValue) then
     ThrowTypeError('Iterator.zipKeyed: first argument must be an object');
 
+  GC := TGarbageCollector.Instance;
+
   // TC39 Joint Iteration §1.2 step 2: Get own enumerable property keys
   Keys := TGocciaObjectValue(IterablesArg).GetEnumerablePropertyNames;
   Count := Length(Keys);
 
   // TC39 Joint Iteration §1.2 step 3: Get iterators from each property value
   SetLength(Iterators, Count);
-  for I := 0 to Count - 1 do
-  begin
-    PropValue := IterablesArg.GetProperty(Keys[I]);
-    InnerIterator := GetIteratorFromIterable(PropValue);
-    if InnerIterator = nil then
-      ThrowTypeError('Iterator.zipKeyed: property "' + Keys[I] + '" value must be iterable');
-    Iterators[I] := InnerIterator;
+  Acquired := 0;
+  try
+    for I := 0 to Count - 1 do
+    begin
+      PropValue := IterablesArg.GetProperty(Keys[I]);
+      InnerIterator := GetIteratorFromIterable(PropValue);
+      if InnerIterator = nil then
+        ThrowTypeError('Iterator.zipKeyed: property "' + Keys[I] + '" value must be iterable');
+      Iterators[I] := InnerIterator;
+      GC.AddTempRoot(InnerIterator);
+      Acquired := I + 1;
+    end;
+  except
+    // Close and unroot already-acquired iterators before re-raising
+    for J := 0 to Acquired - 1 do
+    begin
+      CloseIteratorPreservingError(Iterators[J]);
+      GC.RemoveTempRoot(Iterators[J]);
+    end;
+    raise;
   end;
 
   // TC39 Joint Iteration §1.2 step 4: Parse options
@@ -826,51 +879,57 @@ begin
   for I := 0 to Count - 1 do
     Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  if AArgs.Length >= 2 then
-  begin
-    OptionsArg := AArgs.GetElement(1);
-    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+  try
+    if AArgs.Length >= 2 then
     begin
-      if not (OptionsArg is TGocciaObjectValue) then
-        ThrowTypeError('Iterator.zipKeyed: options must be an object');
-
-      // TC39 Joint Iteration §1.2 step 4a: Get mode
-      ModeVal := OptionsArg.GetProperty(PROP_MODE);
-      if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
+      OptionsArg := AArgs.GetElement(1);
+      if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
       begin
-        if not (ModeVal is TGocciaStringLiteralValue) then
-          ThrowTypeError('Iterator.zipKeyed: mode must be a string');
-        ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
-        if ModeStr = ZIP_MODE_SHORTEST then
-          Mode := zmShortest
-        else if ModeStr = ZIP_MODE_LONGEST then
-          Mode := zmLongest
-        else if ModeStr = ZIP_MODE_STRICT then
-          Mode := zmStrict
-        else
-          ThrowRangeError('Iterator.zipKeyed: invalid mode "' + ModeStr + '"');
-      end;
+        if not (OptionsArg is TGocciaObjectValue) then
+          ThrowTypeError('Iterator.zipKeyed: options must be an object');
 
-      // TC39 Joint Iteration §1.2 step 4b: Get padding (only for longest mode)
-      if Mode = zmLongest then
-      begin
-        PaddingVal := OptionsArg.GetProperty(PROP_PADDING);
-        if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
+        // TC39 Joint Iteration §1.2 step 4a: Get mode
+        ModeVal := OptionsArg.GetProperty(PROP_MODE);
+        if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
         begin
-          if not (PaddingVal is TGocciaObjectValue) then
-            ThrowTypeError('Iterator.zipKeyed: padding must be an object');
-          for I := 0 to Count - 1 do
+          if not (ModeVal is TGocciaStringLiteralValue) then
+            ThrowTypeError('Iterator.zipKeyed: mode must be a string');
+          ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
+          if ModeStr = ZIP_MODE_SHORTEST then
+            Mode := zmShortest
+          else if ModeStr = ZIP_MODE_LONGEST then
+            Mode := zmLongest
+          else if ModeStr = ZIP_MODE_STRICT then
+            Mode := zmStrict
+          else
+            ThrowRangeError('Iterator.zipKeyed: invalid mode "' + ModeStr + '"');
+        end;
+
+        // TC39 Joint Iteration §1.2 step 4b: Get padding (only for longest mode)
+        if Mode = zmLongest then
+        begin
+          PaddingVal := OptionsArg.GetProperty(PROP_PADDING);
+          if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
           begin
-            PropValue := PaddingVal.GetProperty(Keys[I]);
-            if Assigned(PropValue) and not (PropValue is TGocciaUndefinedLiteralValue) then
-              Padding[I] := PropValue;
+            if not (PaddingVal is TGocciaObjectValue) then
+              ThrowTypeError('Iterator.zipKeyed: padding must be an object');
+            for I := 0 to Count - 1 do
+            begin
+              PropValue := PaddingVal.GetProperty(Keys[I]);
+              if Assigned(PropValue) and not (PropValue is TGocciaUndefinedLiteralValue) then
+                Padding[I] := PropValue;
+            end;
           end;
         end;
       end;
     end;
-  end;
 
-  Result := TGocciaZipKeyedIteratorValue.Create(Keys, Iterators, Padding, Mode);
+    Result := TGocciaZipKeyedIteratorValue.Create(Keys, Iterators, Padding, Mode);
+  finally
+    // Unroot iterators — the zipKeyed iterator now owns them via MarkReferences
+    for I := 0 to Count - 1 do
+      GC.RemoveTempRoot(Iterators[I]);
+  end;
 end;
 
 end.


### PR DESCRIPTION
## Summary
- Added `Iterator.zip` and `Iterator.zipKeyed` built-ins for joint iteration over positional and keyed inputs.
- Implemented `shortest`, `longest`, and `strict` modes, including padding support and iterator cleanup behavior.
- Added JavaScript coverage for happy paths, edge cases, and error handling, plus benchmark entries and built-in docs updates.

## Testing
- Not run
- Expected validation path: `./build.pas testrunner && ./build/TestRunner tests`
- Recommended follow-up for iterator/runtime changes: `./build.pas clean tests && for t in build/Goccia.*.Test; do "$t"; done`