### PR TITLE
Add numeric separator support in number literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -884,6 +884,47 @@ jobs:
           test "$error_status_bc" -eq 1
           printf '%s\n' "$error_output_bc" | grep -q 'SyntaxError'
 
+      - name: Check numeric separator rejection
+        run: |
+          # Trailing separator
+          set +e; out="$(printf '1_000_;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+          printf '%s\n' "$out" | grep -q 'Numeric separator must be between digits'
+
+          # Leading separator after hex prefix
+          set +e; out="$(printf '0x_FF;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Leading separator after binary prefix
+          set +e; out="$(printf '0b_10;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Leading separator after octal prefix
+          set +e; out="$(printf '0o_77;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Consecutive separators
+          set +e; out="$(printf '1__000;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+          printf '%s\n' "$out" | grep -q 'Numeric separator must be between digits'
+
+          # Separator after leading 0
+          set +e; out="$(printf '0_1;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+          printf '%s\n' "$out" | grep -q 'Numeric separator cannot be used after leading 0'
+
+          # Separator before decimal point
+          set +e; out="$(printf '1_.5;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Separator after decimal point
+          set +e; out="$(printf '1._5;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Separator after exponent indicator
+          set +e; out="$(printf '1e_10;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
   artifacts:
     needs: [test, toml-compliance, json5-compliance, benchmark, examples]
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -418,6 +418,47 @@ jobs:
           test "$error_status_bc" -eq 1
           printf '%s\n' "$error_output_bc" | grep -q 'SyntaxError'
 
+      - name: Check numeric separator rejection
+        run: |
+          # Trailing separator
+          set +e; out="$(printf '1_000_;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+          printf '%s\n' "$out" | grep -q 'Numeric separator must be between digits'
+
+          # Leading separator after hex prefix
+          set +e; out="$(printf '0x_FF;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Leading separator after binary prefix
+          set +e; out="$(printf '0b_10;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Leading separator after octal prefix
+          set +e; out="$(printf '0o_77;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Consecutive separators
+          set +e; out="$(printf '1__000;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+          printf '%s\n' "$out" | grep -q 'Numeric separator must be between digits'
+
+          # Separator after leading 0
+          set +e; out="$(printf '0_1;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+          printf '%s\n' "$out" | grep -q 'Numeric separator cannot be used after leading 0'
+
+          # Separator before decimal point
+          set +e; out="$(printf '1_.5;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Separator after decimal point
+          set +e; out="$(printf '1._5;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
+          # Separator after exponent indicator
+          set +e; out="$(printf '1e_10;\n' | ./build/ScriptLoader 2>&1)"; st=$?; set -e
+          test "$st" -eq 1
+
   benchmark-comment:
     needs: benchmark
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,7 +455,7 @@ See [docs/build-system.md](docs/build-system.md) for build system details.
 - Auto-formatter: `./format.pas` — auto-fixes uses clause ordering, PascalCase naming, parameter prefixes
 - Pre-commit hook: [Lefthook](https://github.com/evilmartians/lefthook) (`lefthook.yml`)
 - CI: `ci.yml` (main + tags, full matrix) and `pr.yml` (PRs, ubuntu-latest x64 only, with benchmark comparison)
-- Changelog: `CHANGELOG.md` is auto-generated via [git-cliff](https://git-cliff.org/) (`cliff.toml`). Run `git-cliff -o CHANGELOG.md` to regenerate.
+- Changelog: `CHANGELOG.md` is auto-generated via [git-cliff](https://git-cliff.org/) (`cliff.toml`). Run `git-cliff -o CHANGELOG.md` to regenerate. **Do not edit `CHANGELOG.md` manually — it will be overwritten.**
 
 ## Documentation Index
 

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -157,6 +157,7 @@ C[Symbol.metadata].decorated; // true
 - Optional chaining (`?.` for property access, computed access, and method calls).
 - Bitwise operators (`&`, `|`, `^`, `<<`, `>>`, `>>>`).
 - Ternary operator (`? :`).
+- Numeric literals: decimal, hex (`0x`), binary (`0b`), octal (`0o`), scientific notation, and numeric separators (`1_000_000`, `0xFF_FF`, `0b1010_0001`, `0o77_77`, `1.5e1_0`).
 - Template literals with interpolation.
 - Destructuring (array and object patterns).
 - Spread operator (`...`).

--- a/tests/language/expressions/numeric-separators.js
+++ b/tests/language/expressions/numeric-separators.js
@@ -74,10 +74,6 @@ describe("numeric separators", () => {
     expect(typeof 0o77_77).toBe("number");
   });
 
-  test("separator with zero prefix decimal", () => {
-    expect(0_1).toBe(1);
-  });
-
   test("separator in negative expressions", () => {
     expect(-1_000).toBe(-1000);
     expect(-0xFF_FF).toBe(-65535);
@@ -96,6 +92,7 @@ describe("numeric separators", () => {
   //   printf '1_000_' | ./build/ScriptLoader   → SyntaxError
   //   printf '0x_FF'  | ./build/ScriptLoader   → SyntaxError
   //   printf '1__000' | ./build/ScriptLoader   → SyntaxError
+  //   printf '0_1'    | ./build/ScriptLoader   → SyntaxError
   //   printf '1_.5'   | ./build/ScriptLoader   → SyntaxError
   //   printf '1._5'   | ./build/ScriptLoader   → SyntaxError
   //   printf '1e_10'  | ./build/ScriptLoader   → SyntaxError

--- a/tests/language/expressions/numeric-separators.js
+++ b/tests/language/expressions/numeric-separators.js
@@ -1,0 +1,112 @@
+/*---
+description: Numeric separators (underscores) in numeric literals
+features: [numeric-separators]
+---*/
+
+describe("numeric separators", () => {
+  test("decimal integer separators", () => {
+    expect(1_000).toBe(1000);
+    expect(1_000_000).toBe(1000000);
+    expect(1_2_3).toBe(123);
+    expect(10_00).toBe(1000);
+  });
+
+  test("decimal with fractional separators", () => {
+    expect(1_000.5).toBe(1000.5);
+    expect(1_000.00_1).toBe(1000.001);
+    expect(3.141_592).toBe(3.141592);
+    expect(1_0.1_0).toBe(10.10);
+  });
+
+  test("scientific notation separators", () => {
+    expect(1_000e2).toBe(100000);
+    expect(1e1_0).toBe(10000000000);
+    expect(1_0e1_0).toBe(100000000000);
+    expect(1.5e1_0).toBe(15000000000);
+  });
+
+  test("hexadecimal separators", () => {
+    expect(0xFF_FF).toBe(65535);
+    expect(0xA0_B0_C0).toBe(10531008);
+    expect(0x00_FF).toBe(255);
+    expect(0xDEAD_BEEF).toBe(3735928559);
+  });
+
+  test("binary separators", () => {
+    expect(0b1010_0001).toBe(161);
+    expect(0b1111_0000).toBe(240);
+    expect(0b1_0).toBe(2);
+    expect(0b1111_1111).toBe(255);
+  });
+
+  test("octal separators", () => {
+    expect(0o77_77).toBe(4095);
+    expect(0o1_0).toBe(8);
+    expect(0o755_644).toBe(252836);
+    expect(0o123_456).toBe(42798);
+  });
+
+  test("single separator between each digit group", () => {
+    expect(1_2).toBe(12);
+    expect(0xFF_FF_FF).toBe(16777215);
+    expect(0b1_0_1_0).toBe(10);
+    expect(0o7_7_7).toBe(511);
+  });
+
+  test("separators preserve numeric identity", () => {
+    expect(1_000 === 1000).toBe(true);
+    expect(0xFF_FF === 0xFFFF).toBe(true);
+    expect(0b1010_0001 === 0b10100001).toBe(true);
+    expect(0o77_77 === 0o7777).toBe(true);
+  });
+
+  test("separators in arithmetic expressions", () => {
+    expect(1_000 + 2_000).toBe(3000);
+    expect(1_000_000 / 1_000).toBe(1000);
+    expect(1_0 * 1_0).toBe(100);
+    expect(0xFF_00 - 0x00_FF).toBe(65025);
+  });
+
+  test("typeof returns number", () => {
+    expect(typeof 1_000).toBe("number");
+    expect(typeof 0xFF_FF).toBe("number");
+    expect(typeof 0b1010_0001).toBe("number");
+    expect(typeof 0o77_77).toBe("number");
+  });
+
+  test("separator with zero prefix decimal", () => {
+    expect(0_1).toBe(1);
+  });
+
+  test("separator in negative expressions", () => {
+    expect(-1_000).toBe(-1000);
+    expect(-0xFF_FF).toBe(-65535);
+  });
+
+  test("separator with scientific notation and sign", () => {
+    expect(1e+1_0).toBe(10000000000);
+    expect(1e-1_0).toBe(1e-10);
+  });
+
+  test("invalid: trailing separator is a syntax error", () => {
+    expect(() => eval("1_000_")).toThrow();
+  });
+
+  test("invalid: leading separator after prefix is a syntax error", () => {
+    expect(() => eval("0x_FF")).toThrow();
+    expect(() => eval("0b_10")).toThrow();
+    expect(() => eval("0o_77")).toThrow();
+  });
+
+  test("invalid: consecutive separators is a syntax error", () => {
+    expect(() => eval("1__000")).toThrow();
+  });
+
+  test("invalid: separator adjacent to decimal point is a syntax error", () => {
+    expect(() => eval("1_.5")).toThrow();
+  });
+
+  test("invalid: separator after exponent indicator is a syntax error", () => {
+    expect(() => eval("1e_10")).toThrow();
+  });
+});

--- a/tests/language/expressions/numeric-separators.js
+++ b/tests/language/expressions/numeric-separators.js
@@ -88,25 +88,14 @@ describe("numeric separators", () => {
     expect(1e-1_0).toBe(1e-10);
   });
 
-  test("invalid: trailing separator is a syntax error", () => {
-    expect(() => eval("1_000_")).toThrow();
-  });
-
-  test("invalid: leading separator after prefix is a syntax error", () => {
-    expect(() => eval("0x_FF")).toThrow();
-    expect(() => eval("0b_10")).toThrow();
-    expect(() => eval("0o_77")).toThrow();
-  });
-
-  test("invalid: consecutive separators is a syntax error", () => {
-    expect(() => eval("1__000")).toThrow();
-  });
-
-  test("invalid: separator adjacent to decimal point is a syntax error", () => {
-    expect(() => eval("1_.5")).toThrow();
-  });
-
-  test("invalid: separator after exponent indicator is a syntax error", () => {
-    expect(() => eval("1e_10")).toThrow();
-  });
+  // Invalid separator placement (trailing, leading, consecutive, adjacent to
+  // decimal point or exponent) is rejected at lex time, before any JS code
+  // executes. These cases cannot be tested from within JS because `eval` is
+  // excluded in GocciaScript and any file containing the invalid literal would
+  // fail to parse entirely. Lex-level rejection is verified via ScriptLoader:
+  //   printf '1_000_' | ./build/ScriptLoader   → SyntaxError
+  //   printf '0x_FF'  | ./build/ScriptLoader   → SyntaxError
+  //   printf '1__000' | ./build/ScriptLoader   → SyntaxError
+  //   printf '1_.5'   | ./build/ScriptLoader   → SyntaxError
+  //   printf '1e_10'  | ./build/ScriptLoader   → SyntaxError
 });

--- a/tests/language/expressions/numeric-separators.js
+++ b/tests/language/expressions/numeric-separators.js
@@ -97,5 +97,6 @@ describe("numeric separators", () => {
   //   printf '0x_FF'  | ./build/ScriptLoader   → SyntaxError
   //   printf '1__000' | ./build/ScriptLoader   → SyntaxError
   //   printf '1_.5'   | ./build/ScriptLoader   → SyntaxError
+  //   printf '1._5'   | ./build/ScriptLoader   → SyntaxError
   //   printf '1e_10'  | ./build/ScriptLoader   → SyntaxError
 });

--- a/tests/language/expressions/numeric-separators.js
+++ b/tests/language/expressions/numeric-separators.js
@@ -85,15 +85,6 @@ describe("numeric separators", () => {
   });
 
   // Invalid separator placement (trailing, leading, consecutive, adjacent to
-  // decimal point or exponent) is rejected at lex time, before any JS code
-  // executes. These cases cannot be tested from within JS because `eval` is
-  // excluded in GocciaScript and any file containing the invalid literal would
-  // fail to parse entirely. Lex-level rejection is verified via ScriptLoader:
-  //   printf '1_000_' | ./build/ScriptLoader   → SyntaxError
-  //   printf '0x_FF'  | ./build/ScriptLoader   → SyntaxError
-  //   printf '1__000' | ./build/ScriptLoader   → SyntaxError
-  //   printf '0_1'    | ./build/ScriptLoader   → SyntaxError
-  //   printf '1_.5'   | ./build/ScriptLoader   → SyntaxError
-  //   printf '1._5'   | ./build/ScriptLoader   → SyntaxError
-  //   printf '1e_10'  | ./build/ScriptLoader   → SyntaxError
+  // decimal point or exponent) is rejected at lex time. These are tested via
+  // the "Check numeric separator rejection" CI step in ci.yml and pr.yml.
 });

--- a/units/Goccia.Error.Suggestions.pas
+++ b/units/Goccia.Error.Suggestions.pas
@@ -119,7 +119,7 @@ resourcestring
   SSuggestSwitchCaseOrDefault = 'Switch bodies contain case/default labels: case value: ... or default: ...';
   SSuggestMissingCatchOrFinally = 'Add catch (e) { ... } or finally { ... } after the try block';
   SSuggestDeclarePrivateField = 'Declare the private field in the class body, or move this code inside the class';
-  SSuggestNumberFormatValid = 'Valid formats: integers (123), decimals (1.23), hex (0xFF), binary (0b101), octal (0o777)';
+  SSuggestNumberFormatValid = 'Valid formats: integers (123), decimals (1.23), hex (0xFF), binary (0b101), octal (0o777). Numeric separators allowed (1_000)';
 
   // Lexer errors — strings, templates, regex
   SSuggestCloseBlockComment = 'Add "*/" to close the block comment';
@@ -135,6 +135,7 @@ resourcestring
   SSuggestBinaryNumberFormat = 'Binary numbers start with 0b followed by 0 or 1 (e.g., 0b1010)';
   SSuggestOctalNumberFormat = 'Octal numbers start with 0o followed by digits 0-7 (e.g., 0o755)';
   SSuggestScientificNotation = 'Scientific notation needs digits after e (e.g., 1e10 or 3.14e-2)';
+  SSuggestNumericSeparator = 'Numeric separators (_) must be placed between digits (e.g., 1_000, 0xFF_FF)';
 
   // Lexer errors — escapes and characters
   SSuggestUnicodeEscapeFormat = 'Unicode escapes use \uXXXX (4 hex digits) or \u{XXXXXX} (1-6 hex digits)';

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -699,7 +699,10 @@ begin
     end;
   end;
 
-  if (Peek = '.') and CharInSet(PeekNext, ['0'..'9']) then
+  if (Peek = '.') and (PeekNext = '_') then
+    raise TGocciaLexerError.Create('Numeric separator must be between digits',
+      FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator)
+  else if (Peek = '.') and CharInSet(PeekNext, ['0'..'9']) then
   begin
     Advance;
     while CharInSet(Peek, ['0'..'9', '_']) do

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -667,19 +667,13 @@ begin
     end
     else
     begin
-      while CharInSet(Peek, ['0'..'9', '_']) do
-      begin
-        if Peek = '_' then
-        begin
-          HasSeparator := True;
-          Advance;
-          if not CharInSet(Peek, ['0'..'9']) then
-            raise TGocciaLexerError.Create('Numeric separator must be between digits',
-              FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
-        end
-        else
-          Advance;
-      end;
+      // ES2021 §12.9.3: numeric separators are not allowed after a leading 0
+      // in DecimalIntegerLiteral (0 is a standalone production).
+      if Peek = '_' then
+        raise TGocciaLexerError.Create('Numeric separator cannot be used after leading 0',
+          FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+      while CharInSet(Peek, ['0'..'9']) do
+        Advance;
     end;
   end
   else

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -590,7 +590,7 @@ begin
   AddToken(gttRegex, PatternBuffer.ToString + REGEX_SEPARATOR + Flags);
 end;
 
-// ES2021 §12.9.3 NumericLiteral
+// ES2026 §12.9.3 NumericLiteral
 procedure TGocciaLexer.ScanNumber;
 var
   Ch: Char;

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -590,10 +590,14 @@ begin
   AddToken(gttRegex, PatternBuffer.ToString + REGEX_SEPARATOR + Flags);
 end;
 
+// ES2021 §12.9.3 NumericLiteral
 procedure TGocciaLexer.ScanNumber;
 var
   Ch: Char;
+  HasSeparator: Boolean;
+  Lexeme: string;
 begin
+  HasSeparator := False;
   Ch := Peek;
 
   if Ch = '0' then
@@ -607,8 +611,19 @@ begin
       if not CharInSet(Peek, ['0'..'9', 'a'..'f', 'A'..'F']) then
         raise TGocciaLexerError.Create('Invalid hexadecimal number', FLine, FColumn, FFileName, GetSourceLines,
           SSuggestHexNumberFormat);
-      while CharInSet(Peek, ['0'..'9', 'a'..'f', 'A'..'F']) do
-        Advance;
+      while CharInSet(Peek, ['0'..'9', 'a'..'f', 'A'..'F', '_']) do
+      begin
+        if Peek = '_' then
+        begin
+          HasSeparator := True;
+          Advance;
+          if not CharInSet(Peek, ['0'..'9', 'a'..'f', 'A'..'F']) then
+            raise TGocciaLexerError.Create('Numeric separator must be between digits',
+              FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+        end
+        else
+          Advance;
+      end;
     end
     else if (Ch = 'b') or (Ch = 'B') then
     begin
@@ -616,8 +631,19 @@ begin
       if not CharInSet(Peek, ['0', '1']) then
         raise TGocciaLexerError.Create('Invalid binary number', FLine, FColumn, FFileName, GetSourceLines,
           SSuggestBinaryNumberFormat);
-      while CharInSet(Peek, ['0', '1']) do
-        Advance;
+      while CharInSet(Peek, ['0', '1', '_']) do
+      begin
+        if Peek = '_' then
+        begin
+          HasSeparator := True;
+          Advance;
+          if not CharInSet(Peek, ['0', '1']) then
+            raise TGocciaLexerError.Create('Numeric separator must be between digits',
+              FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+        end
+        else
+          Advance;
+      end;
     end
     else if (Ch = 'o') or (Ch = 'O') then
     begin
@@ -625,26 +651,70 @@ begin
       if not CharInSet(Peek, ['0'..'7']) then
         raise TGocciaLexerError.Create('Invalid octal number', FLine, FColumn, FFileName, GetSourceLines,
           SSuggestOctalNumberFormat);
-      while CharInSet(Peek, ['0'..'7']) do
-        Advance;
+      while CharInSet(Peek, ['0'..'7', '_']) do
+      begin
+        if Peek = '_' then
+        begin
+          HasSeparator := True;
+          Advance;
+          if not CharInSet(Peek, ['0'..'7']) then
+            raise TGocciaLexerError.Create('Numeric separator must be between digits',
+              FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+        end
+        else
+          Advance;
+      end;
     end
     else
     begin
-      while CharInSet(Peek, ['0'..'9']) do
-        Advance;
+      while CharInSet(Peek, ['0'..'9', '_']) do
+      begin
+        if Peek = '_' then
+        begin
+          HasSeparator := True;
+          Advance;
+          if not CharInSet(Peek, ['0'..'9']) then
+            raise TGocciaLexerError.Create('Numeric separator must be between digits',
+              FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+        end
+        else
+          Advance;
+      end;
     end;
   end
   else
   begin
-    while CharInSet(Peek, ['0'..'9']) do
-      Advance;
+    while CharInSet(Peek, ['0'..'9', '_']) do
+    begin
+      if Peek = '_' then
+      begin
+        HasSeparator := True;
+        Advance;
+        if not CharInSet(Peek, ['0'..'9']) then
+          raise TGocciaLexerError.Create('Numeric separator must be between digits',
+            FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+      end
+      else
+        Advance;
+    end;
   end;
 
   if (Peek = '.') and CharInSet(PeekNext, ['0'..'9']) then
   begin
     Advance;
-    while CharInSet(Peek, ['0'..'9']) do
-      Advance;
+    while CharInSet(Peek, ['0'..'9', '_']) do
+    begin
+      if Peek = '_' then
+      begin
+        HasSeparator := True;
+        Advance;
+        if not CharInSet(Peek, ['0'..'9']) then
+          raise TGocciaLexerError.Create('Numeric separator must be between digits',
+            FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+      end
+      else
+        Advance;
+    end;
   end;
 
   if CharInSet(Peek, ['e', 'E']) then
@@ -655,11 +725,25 @@ begin
     if not CharInSet(Peek, ['0'..'9']) then
       raise TGocciaLexerError.Create('Invalid scientific notation', FLine, FColumn, FFileName, GetSourceLines,
         SSuggestScientificNotation);
-    while CharInSet(Peek, ['0'..'9']) do
-      Advance;
+    while CharInSet(Peek, ['0'..'9', '_']) do
+    begin
+      if Peek = '_' then
+      begin
+        HasSeparator := True;
+        Advance;
+        if not CharInSet(Peek, ['0'..'9']) then
+          raise TGocciaLexerError.Create('Numeric separator must be between digits',
+            FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+      end
+      else
+        Advance;
+    end;
   end;
 
-  AddToken(gttNumber, Copy(FSource, FStart, FCurrent - FStart));
+  Lexeme := Copy(FSource, FStart, FCurrent - FStart);
+  if HasSeparator then
+    Lexeme := StringReplace(Lexeme, '_', '', [rfReplaceAll]);
+  AddToken(gttNumber, Lexeme);
 end;
 
 function TGocciaLexer.IsValidIdentifierChar(const C: Char): Boolean;


### PR DESCRIPTION
## Summary
- Added lexer support for numeric separators in decimal, hex, binary, octal, and scientific-notation literals.
- Normalized separator-bearing lexemes before emitting number tokens, so runtime numeric values preserve existing behavior.
- Expanded diagnostics and suggestions for invalid numeric literal forms to mention separator placement rules.
- Added JavaScript coverage for valid separator cases and syntax-error cases.
- Updated language restrictions docs to list numeric separators as supported syntax.

## Testing
- Not run.
- Expected verification: `./build.pas testrunner && ./build/TestRunner tests`
- Expected verification for lexer changes: run the numeric separator test file under `tests/language/expressions/numeric-separators.js`.