### PR TITLE
Add logical assignment operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It's based on the thought "What if we implement ECMAScript today, but without th
 | Computed property names | `{ [expr]: value }` |
 | Nullish coalescing | `a ?? b` |
 | Nullish coalescing assignment | `a ??= b` |
+| Logical assignment | `a &&= b`, `a \|\|= b` |
 | Optional chaining | `obj?.prop?.method?.()` |
 | Arrow functions | `(x) => x + 1` |
 | Rest parameters | `(...args) => args` |

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -154,6 +154,7 @@ C[Symbol.metadata].decorated; // true
 - Logical operators (`&&`, `||`, `!`).
 - Nullish coalescing (`??`).
 - Nullish coalescing assignment (`??=`).
+- Logical assignment (`&&=`, `||=`).
 - Optional chaining (`?.` for property access, computed access, and method calls).
 - Bitwise operators (`&`, `|`, `^`, `<<`, `>>`, `>>>`).
 - Ternary operator (`? :`).

--- a/tests/language/expressions/logical/logical-and-assignment.js
+++ b/tests/language/expressions/logical/logical-and-assignment.js
@@ -1,0 +1,120 @@
+/*---
+description: Logical AND assignment operator (&&=) assigns only when the left-hand side is truthy
+features: [logical-assignment]
+---*/
+
+test("logical AND assignment assigns when the left-hand side is truthy", () => {
+  let truthy = 1;
+  expect(truthy &&= 99).toBe(99);
+  expect(truthy).toBe(99);
+
+  let str = "hello";
+  expect(str &&= "world").toBe("world");
+  expect(str).toBe("world");
+
+  let flag = true;
+  expect(flag &&= false).toBe(false);
+  expect(flag).toBe(false);
+});
+
+test("logical AND assignment short-circuits when the left-hand side is falsy", () => {
+  let zero = 0;
+  expect(zero &&= 5).toBe(0);
+  expect(zero).toBe(0);
+
+  let empty = "";
+  expect(empty &&= "value").toBe("");
+  expect(empty).toBe("");
+
+  let no = false;
+  expect(no &&= true).toBe(false);
+  expect(no).toBe(false);
+
+  let nul = null;
+  expect(nul &&= 1).toBe(null);
+  expect(nul).toBe(null);
+
+  let undef = undefined;
+  expect(undef &&= 1).toBe(undefined);
+  expect(undef).toBe(undefined);
+});
+
+test("logical AND assignment does not evaluate the right-hand side when short-circuited", () => {
+  let calls = 0;
+  const compute = () => {
+    calls += 1;
+    return 42;
+  };
+
+  let falsy = 0;
+  expect(falsy &&= compute()).toBe(0);
+  expect(calls).toBe(0);
+
+  let truthy = 1;
+  expect(truthy &&= compute()).toBe(42);
+  expect(calls).toBe(1);
+});
+
+test("logical AND assignment works for properties", () => {
+  const obj = { truthy: 1, falsy: 0 };
+
+  expect(obj.truthy &&= 42).toBe(42);
+  expect(obj.truthy).toBe(42);
+
+  expect(obj.falsy &&= 99).toBe(0);
+  expect(obj.falsy).toBe(0);
+
+  expect(obj.missing &&= 3).toBe(undefined);
+  expect(obj.missing).toBe(undefined);
+});
+
+test("logical AND assignment works for computed properties", () => {
+  const obj = { a: 1, b: 0 };
+  let keyCalls = 0;
+  const key = (k) => {
+    keyCalls += 1;
+    return k;
+  };
+
+  expect(obj[key("a")] &&= 9).toBe(9);
+  expect(obj.a).toBe(9);
+  expect(keyCalls).toBe(1);
+
+  expect(obj[key("b")] &&= 9).toBe(0);
+  expect(obj.b).toBe(0);
+  expect(keyCalls).toBe(2);
+});
+
+test("logical AND assignment works for private fields", () => {
+  class Box {
+    #value = 1;
+
+    read() {
+      return this.#value;
+    }
+
+    update(value) {
+      return this.#value &&= value;
+    }
+  }
+
+  const box = new Box();
+  expect(box.update("replaced")).toBe("replaced");
+  expect(box.read()).toBe("replaced");
+});
+
+test("logical AND assignment only throws for const bindings when an assignment is needed", () => {
+  const falsy = 0;
+  expect(falsy &&= 2).toBe(0);
+
+  const truthy = 1;
+  expect(() => {
+    truthy &&= 2;
+  }).toThrow(TypeError);
+});
+
+test("logical AND assignment throws for unresolved identifiers", () => {
+  expect(() => {
+    missingAndValue &&= 1;
+  }).toThrow(ReferenceError);
+});

--- a/tests/language/expressions/logical/logical-and-assignment.js
+++ b/tests/language/expressions/logical/logical-and-assignment.js
@@ -118,3 +118,39 @@ test("logical AND assignment throws for unresolved identifiers", () => {
     missingAndValue &&= 1;
   }).toThrow(ReferenceError);
 });
+
+test("logical AND assignment uses private accessors and throws for getter-only fields", () => {
+  class GetterOnly {
+    #storage = 10;
+
+    get #value() {
+      return this.#storage;
+    }
+
+    update(value) {
+      return this.#value &&= value;
+    }
+  }
+
+  const obj = new GetterOnly();
+  expect(() => {
+    obj.update(99);
+  }).toThrow(TypeError);
+});
+
+test("logical AND assignment short-circuits getter-only private accessors when falsy", () => {
+  class GetterOnly {
+    #storage = 0;
+
+    get #value() {
+      return this.#storage;
+    }
+
+    update(value) {
+      return this.#value &&= value;
+    }
+  }
+
+  const obj = new GetterOnly();
+  expect(obj.update(99)).toBe(0);
+});

--- a/tests/language/expressions/logical/logical-or-assignment.js
+++ b/tests/language/expressions/logical/logical-or-assignment.js
@@ -1,0 +1,122 @@
+/*---
+description: Logical OR assignment operator (||=) assigns only when the left-hand side is falsy
+features: [logical-assignment]
+---*/
+
+test("logical OR assignment assigns when the left-hand side is falsy", () => {
+  let zero = 0;
+  expect(zero ||= 5).toBe(5);
+  expect(zero).toBe(5);
+
+  let empty = "";
+  expect(empty ||= "default").toBe("default");
+  expect(empty).toBe("default");
+
+  let no = false;
+  expect(no ||= true).toBe(true);
+  expect(no).toBe(true);
+
+  let nul = null;
+  expect(nul ||= "filled").toBe("filled");
+  expect(nul).toBe("filled");
+
+  let undef = undefined;
+  expect(undef ||= 99).toBe(99);
+  expect(undef).toBe(99);
+});
+
+test("logical OR assignment short-circuits when the left-hand side is truthy", () => {
+  let truthy = 1;
+  expect(truthy ||= 5).toBe(1);
+  expect(truthy).toBe(1);
+
+  let str = "hello";
+  expect(str ||= "world").toBe("hello");
+  expect(str).toBe("hello");
+
+  let flag = true;
+  expect(flag ||= false).toBe(true);
+  expect(flag).toBe(true);
+});
+
+test("logical OR assignment does not evaluate the right-hand side when short-circuited", () => {
+  let calls = 0;
+  const compute = () => {
+    calls += 1;
+    return 42;
+  };
+
+  let truthy = "present";
+  expect(truthy ||= compute()).toBe("present");
+  expect(calls).toBe(0);
+
+  let falsy = 0;
+  expect(falsy ||= compute()).toBe(42);
+  expect(calls).toBe(1);
+});
+
+test("logical OR assignment works for properties", () => {
+  const obj = { present: 1, missing: 0 };
+
+  expect(obj.present ||= 99).toBe(1);
+  expect(obj.present).toBe(1);
+
+  expect(obj.missing ||= 99).toBe(99);
+  expect(obj.missing).toBe(99);
+
+  expect(obj.absent ||= 3).toBe(3);
+  expect(obj.absent).toBe(3);
+});
+
+test("logical OR assignment works for computed properties", () => {
+  const obj = { a: 1, b: 0 };
+  let keyCalls = 0;
+  const key = (k) => {
+    keyCalls += 1;
+    return k;
+  };
+
+  expect(obj[key("a")] ||= 9).toBe(1);
+  expect(obj.a).toBe(1);
+  expect(keyCalls).toBe(1);
+
+  expect(obj[key("b")] ||= 9).toBe(9);
+  expect(obj.b).toBe(9);
+  expect(keyCalls).toBe(2);
+});
+
+test("logical OR assignment works for private fields", () => {
+  class Box {
+    #value;
+
+    read() {
+      return this.#value;
+    }
+
+    initialize(value) {
+      return this.#value ||= value;
+    }
+  }
+
+  const box = new Box();
+  expect(box.initialize(4)).toBe(4);
+  expect(box.read()).toBe(4);
+  expect(box.initialize(8)).toBe(4);
+  expect(box.read()).toBe(4);
+});
+
+test("logical OR assignment only throws for const bindings when an assignment is needed", () => {
+  const truthy = 1;
+  expect(truthy ||= 2).toBe(1);
+
+  const falsy = null;
+  expect(() => {
+    falsy ||= 2;
+  }).toThrow(TypeError);
+});
+
+test("logical OR assignment throws for unresolved identifiers", () => {
+  expect(() => {
+    missingOrValue ||= 1;
+  }).toThrow(ReferenceError);
+});

--- a/tests/language/expressions/logical/logical-or-assignment.js
+++ b/tests/language/expressions/logical/logical-or-assignment.js
@@ -120,3 +120,39 @@ test("logical OR assignment throws for unresolved identifiers", () => {
     missingOrValue ||= 1;
   }).toThrow(ReferenceError);
 });
+
+test("logical OR assignment uses private accessors and throws for getter-only fields", () => {
+  class GetterOnly {
+    #storage = 0;
+
+    get #value() {
+      return this.#storage;
+    }
+
+    update(value) {
+      return this.#value ||= value;
+    }
+  }
+
+  const obj = new GetterOnly();
+  expect(() => {
+    obj.update(99);
+  }).toThrow(TypeError);
+});
+
+test("logical OR assignment short-circuits getter-only private accessors when truthy", () => {
+  class GetterOnly {
+    #storage = 10;
+
+    get #value() {
+      return this.#storage;
+    }
+
+    update(value) {
+      return this.#value ||= value;
+    }
+  }
+
+  const obj = new GetterOnly();
+  expect(obj.update(99)).toBe(10);
+});

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -1122,15 +1122,38 @@ begin
   end;
 end;
 
-// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
+// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
 function TGocciaCompoundAssignmentExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   CurrentValue, RhsValue: TGocciaValue;
 begin
   CurrentValue := AContext.Scope.GetValue(Name);
+  // ES2026 §13.15.2 step 3: ??=
   if Operator = gttNullishCoalescingAssign then
   begin
     if not IsNullishAssignmentValue(CurrentValue) then
+      Exit(CurrentValue);
+
+    Result := Value.Evaluate(AContext);
+    AContext.Scope.AssignLexicalBinding(Name, Result);
+    Exit;
+  end;
+
+  // ES2026 §13.15.2 step 3: &&=
+  if Operator = gttLogicalAndAssign then
+  begin
+    if not CurrentValue.ToBooleanLiteral.Value then
+      Exit(CurrentValue);
+
+    Result := Value.Evaluate(AContext);
+    AContext.Scope.AssignLexicalBinding(Name, Result);
+    Exit;
+  end;
+
+  // ES2026 §13.15.2 step 3: ||=
+  if Operator = gttLogicalOrAssign then
+  begin
+    if CurrentValue.ToBooleanLiteral.Value then
       Exit(CurrentValue);
 
     Result := Value.Evaluate(AContext);
@@ -1144,16 +1167,39 @@ begin
   AContext.Scope.AssignLexicalBinding(Name, Result);
 end;
 
-// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
+// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
 function TGocciaPropertyCompoundAssignmentExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   Obj, CurrentValue, RhsValue: TGocciaValue;
 begin
   Obj := ObjectExpr.Evaluate(AContext);
   CurrentValue := NormalizeAssignmentValue(Obj.GetProperty(PropertyName));
+  // ES2026 §13.15.2 step 3: ??=
   if Operator = gttNullishCoalescingAssign then
   begin
     if not IsNullishAssignmentValue(CurrentValue) then
+      Exit(CurrentValue);
+
+    Result := Value.Evaluate(AContext);
+    AssignProperty(Obj, PropertyName, Result, AContext.OnError, Line, Column);
+    Exit;
+  end;
+
+  // ES2026 §13.15.2 step 3: &&=
+  if Operator = gttLogicalAndAssign then
+  begin
+    if not CurrentValue.ToBooleanLiteral.Value then
+      Exit(CurrentValue);
+
+    Result := Value.Evaluate(AContext);
+    AssignProperty(Obj, PropertyName, Result, AContext.OnError, Line, Column);
+    Exit;
+  end;
+
+  // ES2026 §13.15.2 step 3: ||=
+  if Operator = gttLogicalOrAssign then
+  begin
+    if CurrentValue.ToBooleanLiteral.Value then
       Exit(CurrentValue);
 
     Result := Value.Evaluate(AContext);
@@ -1166,11 +1212,28 @@ begin
   Result := NormalizeAssignmentValue(Obj.GetProperty(PropertyName));
 end;
 
-// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
+// ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
 function TGocciaComputedPropertyCompoundAssignmentExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   Obj, PropertyKeyValue, CurrentValue, RhsValue: TGocciaValue;
   PropName: string;
+
+  function ShortCircuits: Boolean; inline;
+  begin
+    case Operator of
+      gttNullishCoalescingAssign: Result := not IsNullishAssignmentValue(CurrentValue);
+      gttLogicalAndAssign: Result := not CurrentValue.ToBooleanLiteral.Value;
+      gttLogicalOrAssign: Result := CurrentValue.ToBooleanLiteral.Value;
+    else
+      Result := False;
+    end;
+  end;
+
+  function IsShortCircuitOperator: Boolean; inline;
+  begin
+    Result := Operator in [gttNullishCoalescingAssign, gttLogicalAndAssign, gttLogicalOrAssign];
+  end;
+
 begin
   Obj := ObjectExpr.Evaluate(AContext);
   PropertyKeyValue := PropertyExpression.Evaluate(AContext);
@@ -1183,9 +1246,9 @@ begin
       CurrentValue := NormalizeAssignmentValue(
         TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue)));
 
-    if Operator = gttNullishCoalescingAssign then
+    if IsShortCircuitOperator then
     begin
-      if not IsNullishAssignmentValue(CurrentValue) then
+      if ShortCircuits then
         Exit(CurrentValue);
 
       Result := Value.Evaluate(AContext);
@@ -1209,9 +1272,9 @@ begin
 
   PropName := PropertyKeyValue.ToStringLiteral.Value;
   CurrentValue := NormalizeAssignmentValue(Obj.GetProperty(PropName));
-  if Operator = gttNullishCoalescingAssign then
+  if IsShortCircuitOperator then
   begin
-    if not IsNullishAssignmentValue(CurrentValue) then
+    if ShortCircuits then
       Exit(CurrentValue);
 
     Result := Value.Evaluate(AContext);

--- a/units/Goccia.Compiler.Context.pas
+++ b/units/Goccia.Compiler.Context.pas
@@ -54,6 +54,10 @@ function TokenTypeToRuntimeOp(
   const ATokenType: TGocciaTokenType): TGocciaOpCode;
 function CompoundOpToRuntimeOp(
   const ATokenType: TGocciaTokenType): TGocciaOpCode;
+function IsShortCircuitAssignment(
+  const ATokenType: TGocciaTokenType): Boolean; inline;
+function ShortCircuitJumpOp(
+  const ATokenType: TGocciaTokenType): TGocciaOpCode; inline;
 
 implementation
 
@@ -179,6 +183,25 @@ begin
     gttUnsignedRightShiftAssign: Result := OP_USHR;
   else
     Result := OP_ADD;
+  end;
+end;
+
+function IsShortCircuitAssignment(
+  const ATokenType: TGocciaTokenType): Boolean;
+begin
+  Result := ATokenType in [gttNullishCoalescingAssign,
+    gttLogicalAndAssign, gttLogicalOrAssign];
+end;
+
+function ShortCircuitJumpOp(
+  const ATokenType: TGocciaTokenType): TGocciaOpCode;
+begin
+  case ATokenType of
+    gttNullishCoalescingAssign: Result := OP_JUMP_IF_NOT_NULLISH;
+    gttLogicalAndAssign:        Result := OP_JUMP_IF_FALSE;
+    gttLogicalOrAssign:         Result := OP_JUMP_IF_TRUE;
+  else
+    Result := OP_JUMP_IF_NOT_NULLISH;
   end;
 end;
 

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -1839,9 +1839,10 @@ var
   ArithOp: TGocciaTokenType;
   JumpIdx, OkJump: Integer;
 begin
-  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
-  if AExpr.Operator = gttNullishCoalescingAssign then
+  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??=/&&=/||= AssignmentExpression
+  if IsShortCircuitAssignment(AExpr.Operator) then
   begin
+    Op := ShortCircuitJumpOp(AExpr.Operator);
     LocalIdx := ACtx.Scope.ResolveLocal(AExpr.Name);
     if LocalIdx >= 0 then
     begin
@@ -1849,7 +1850,7 @@ begin
       begin
         EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, ADest,
           ACtx.Template.AddConstantString(AExpr.Name)));
-        JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
+        JumpIdx := EmitJumpInstruction(ACtx, Op, ADest);
         if ACtx.Scope.GetLocal(LocalIdx).IsConst then
         begin
           MsgIdx := ACtx.Template.AddConstantString(
@@ -1871,7 +1872,7 @@ begin
       Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
       if ADest <> Slot then
         EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));
-      JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
+      JumpIdx := EmitJumpInstruction(ACtx, Op, ADest);
       if ACtx.Scope.GetLocal(LocalIdx).IsConst then
       begin
         MsgIdx := ACtx.Template.AddConstantString(
@@ -1900,7 +1901,7 @@ begin
     if UpvalIdx >= 0 then
     begin
       EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, ADest, UInt16(UpvalIdx)));
-      JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
+      JumpIdx := EmitJumpInstruction(ACtx, Op, ADest);
       if ACtx.Scope.GetUpvalue(UpvalIdx).IsConst then
       begin
         MsgIdx := ACtx.Template.AddConstantString(
@@ -1939,7 +1940,7 @@ begin
     ACtx.Scope.FreeRegister;
 
     EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, ADest, NameIdx));
-    JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, ADest);
+    JumpIdx := EmitJumpInstruction(ACtx, Op, ADest);
     ACtx.CompileExpression(AExpr.Value, ADest);
     EmitInstruction(ACtx, EncodeABx(OP_SET_GLOBAL, ADest, NameIdx));
     PatchJumpTarget(ACtx, JumpIdx);
@@ -2029,8 +2030,8 @@ var
   PropIdx: UInt16;
   JumpIdx: Integer;
 begin
-  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
-  if AExpr.Operator = gttNullishCoalescingAssign then
+  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??=/&&=/||= AssignmentExpression
+  if IsShortCircuitAssignment(AExpr.Operator) then
   begin
     ObjReg := ACtx.Scope.AllocateRegister;
     CurReg := ACtx.Scope.AllocateRegister;
@@ -2041,7 +2042,7 @@ begin
       raise Exception.Create('Constant pool overflow: property name index exceeds 255');
     EmitInstruction(ACtx, EncodeABC(OP_GET_PROP_CONST, CurReg, ObjReg,
       UInt8(PropIdx)));
-    JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, CurReg);
+    JumpIdx := EmitJumpInstruction(ACtx, ShortCircuitJumpOp(AExpr.Operator), CurReg);
     ACtx.CompileExpression(AExpr.Value, CurReg);
     EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ObjReg, UInt8(PropIdx),
       CurReg));
@@ -2088,8 +2089,8 @@ var
   Op: TGocciaOpCode;
   JumpIdx: Integer;
 begin
-  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
-  if AExpr.Operator = gttNullishCoalescingAssign then
+  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??=/&&=/||= AssignmentExpression
+  if IsShortCircuitAssignment(AExpr.Operator) then
   begin
     ObjReg := ACtx.Scope.AllocateRegister;
     KeyReg := ACtx.Scope.AllocateRegister;
@@ -2098,7 +2099,7 @@ begin
     ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
     ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
     EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
-    JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, CurReg);
+    JumpIdx := EmitJumpInstruction(ACtx, ShortCircuitJumpOp(AExpr.Operator), CurReg);
     ACtx.CompileExpression(AExpr.Value, CurReg);
     EmitInstruction(ACtx, EncodeABC(OP_ARRAY_SET, ObjReg, KeyReg, CurReg));
     PatchJumpTarget(ACtx, JumpIdx);
@@ -2353,8 +2354,8 @@ var
   PropIdx: UInt16;
   JumpIdx: Integer;
 begin
-  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??= AssignmentExpression
-  if AExpr.Operator = gttNullishCoalescingAssign then
+  // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??=/&&=/||= AssignmentExpression
+  if IsShortCircuitAssignment(AExpr.Operator) then
   begin
     ObjReg := ACtx.Scope.AllocateRegister;
     CurReg := ACtx.Scope.AllocateRegister;
@@ -2364,7 +2365,7 @@ begin
     if PropIdx > High(UInt8) then
       raise Exception.Create('Constant pool overflow: private property name index exceeds 255');
     EmitInstruction(ACtx, EncodeABC(OP_GET_PROP_CONST, CurReg, ObjReg, UInt8(PropIdx)));
-    JumpIdx := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH, CurReg);
+    JumpIdx := EmitJumpInstruction(ACtx, ShortCircuitJumpOp(AExpr.Operator), CurReg);
     ACtx.CompileExpression(AExpr.Value, CurReg);
     EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ObjReg, UInt8(PropIdx), CurReg));
     PatchJumpTarget(ACtx, JumpIdx);

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -2652,13 +2652,30 @@ begin
     Exit;
   end;
 
-  if APrivatePropertyCompoundAssignmentExpression.Operator = gttNullishCoalescingAssign then
+  // ES2026 §13.15.2 step 3: short-circuit logical/nullish assignment
+  if APrivatePropertyCompoundAssignmentExpression.Operator in
+     [gttNullishCoalescingAssign, gttLogicalAndAssign, gttLogicalOrAssign] then
   begin
-    if not ((CurrentValue is TGocciaUndefinedLiteralValue) or
-            (CurrentValue is TGocciaNullLiteralValue)) then
-    begin
-      Result := CurrentValue;
-      Exit;
+    case APrivatePropertyCompoundAssignmentExpression.Operator of
+      gttNullishCoalescingAssign:
+        if not ((CurrentValue is TGocciaUndefinedLiteralValue) or
+                (CurrentValue is TGocciaNullLiteralValue)) then
+        begin
+          Result := CurrentValue;
+          Exit;
+        end;
+      gttLogicalAndAssign:
+        if not CurrentValue.ToBooleanLiteral.Value then
+        begin
+          Result := CurrentValue;
+          Exit;
+        end;
+      gttLogicalOrAssign:
+        if CurrentValue.ToBooleanLiteral.Value then
+        begin
+          Result := CurrentValue;
+          Exit;
+        end;
     end;
 
     Value := EvaluateExpression(APrivatePropertyCompoundAssignmentExpression.Value, AContext);

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -2694,6 +2694,8 @@ begin
           SetterArgs.Free;
         end;
       end
+      else if AccessClass.HasPrivateGetter(APrivatePropertyCompoundAssignmentExpression.PrivateName) then
+        ThrowPrivateSetterMissingError(APrivatePropertyCompoundAssignmentExpression.PrivateName)
       else
         Instance.SetPrivateProperty(APrivatePropertyCompoundAssignmentExpression.PrivateName, Result, AccessClass);
     end

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -857,14 +857,24 @@ begin
         AddToken(gttGreater);
     '&':
       if Match('&') then
-        AddToken(gttAnd)
+      begin
+        if Match('=') then
+          AddToken(gttLogicalAndAssign)
+        else
+          AddToken(gttAnd);
+      end
       else if Match('=') then
         AddToken(gttBitwiseAndAssign)
       else
         AddToken(gttBitwiseAnd);
     '|':
       if Match('|') then
-        AddToken(gttOr)
+      begin
+        if Match('=') then
+          AddToken(gttLogicalOrAssign)
+        else
+          AddToken(gttOr);
+      end
       else if Match('=') then
         AddToken(gttBitwiseOrAssign)
       else

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -642,6 +642,7 @@ begin
         gttPlus, gttMinus, gttStar, gttSlash, gttPercent, gttPower,
         gttEqual, gttNotEqual,
         gttAssign, gttPlusAssign, gttMinusAssign, gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign, gttNullishCoalescingAssign,
+        gttLogicalAndAssign, gttLogicalOrAssign,
         gttInstanceof, gttIn]);
   end;
 end;
@@ -1578,6 +1579,7 @@ var
 begin
   Left := Conditional;
   if Match([gttAssign, gttPlusAssign, gttMinusAssign, gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign, gttNullishCoalescingAssign,
+             gttLogicalAndAssign, gttLogicalOrAssign,
              gttBitwiseAndAssign, gttBitwiseOrAssign, gttBitwiseXorAssign, gttLeftShiftAssign, gttRightShiftAssign, gttUnsignedRightShiftAssign]) then
   begin
     Operator := Previous.TokenType;

--- a/units/Goccia.Token.pas
+++ b/units/Goccia.Token.pas
@@ -20,7 +20,7 @@ type
     gttPlus, gttMinus, gttStar, gttSlash, gttPercent, gttPower,
     gttEqual, gttNotEqual, gttLooseEqual, gttLooseNotEqual, gttLess, gttGreater, gttLessEqual, gttGreaterEqual,
     gttAnd, gttOr, gttNullishCoalescing, gttNot, gttTypeof, gttInstanceof, gttIn, gttDelete, gttAssign, gttPlusAssign, gttMinusAssign,
-    gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign, gttNullishCoalescingAssign,
+    gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign, gttNullishCoalescingAssign, gttLogicalAndAssign, gttLogicalOrAssign,
     gttIncrement, gttDecrement,
     gttQuestion, gttColon, gttOptionalChaining,
     // Bitwise operators


### PR DESCRIPTION
## Summary
- Adds support for logical assignment operators `&&=` and `||=` across lexer, parser, evaluator, and bytecode compiler.
- Preserves short-circuit behavior for identifiers, properties, computed properties, and private fields.
- Adds end-to-end language coverage for truthy/falsy cases, short-circuiting, unresolved identifiers, and const binding behavior.
- Updates README and language restrictions docs to reflect the expanded operator set.

## Testing
- Not run.
- New JS coverage added under `tests/language/expressions/logical/` for `&&=` and `||=`.
- Compiler and evaluator paths updated to use short-circuit jumps for both operators.