### PR TITLE
Add Uint8Array Base64 and Hex APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | Garbage collector | `Goccia.GarbageCollector.pas` | Unified mark-and-sweep GC for interpreter and bytecode execution |
 | Profiler | `Goccia.Profiler*.pas` | Bytecode opcode/function profiling, pair tracking, allocation counting |
 | Proxy | `Goccia.Values.ProxyValue.pas` | ES2026 Proxy with all 13 handler traps and invariant enforcement |
+| Uint8Array encoding | `Goccia.Values.Uint8ArrayEncoding.pas` | Uint8Array Base64/Hex: `toBase64`, `fromBase64`, `toHex`, `fromHex`, `setFromBase64`, `setFromHex` |
 | FFI | `Goccia.FFI*.pas`, `Goccia.Values.FFI*.pas` | Foreign Function Interface for native shared libraries |
 
 **Bytecode design rules:**

--- a/benchmarks/uint8array-encoding.js
+++ b/benchmarks/uint8array-encoding.js
@@ -1,0 +1,141 @@
+/*---
+description: Uint8Array Base64 and Hex encoding/decoding benchmarks
+---*/
+
+const SHORT_BYTES = new Uint8Array([72, 101, 108, 108, 111]);
+const MEDIUM_BYTES = new Uint8Array(450);
+const LARGE_BYTES = new Uint8Array(4096);
+
+// Fill with varied data
+for (const i of Array(450).keys()) MEDIUM_BYTES[i] = i % 256;
+for (const i of Array(4096).keys()) LARGE_BYTES[i] = (i * 7 + 13) % 256;
+
+const SHORT_B64 = SHORT_BYTES.toBase64();
+const MEDIUM_B64 = MEDIUM_BYTES.toBase64();
+const LARGE_B64 = LARGE_BYTES.toBase64();
+
+const SHORT_HEX = SHORT_BYTES.toHex();
+const MEDIUM_HEX = MEDIUM_BYTES.toHex();
+const LARGE_HEX = LARGE_BYTES.toHex();
+
+suite("Uint8Array.prototype.toBase64", () => {
+  bench("short (5 bytes)", {
+    run: () => {
+      SHORT_BYTES.toBase64();
+    },
+  });
+
+  bench("medium (450 bytes)", {
+    run: () => {
+      MEDIUM_BYTES.toBase64();
+    },
+  });
+
+  bench("large (4096 bytes)", {
+    run: () => {
+      LARGE_BYTES.toBase64();
+    },
+  });
+
+  bench("base64url alphabet", {
+    run: () => {
+      MEDIUM_BYTES.toBase64({ alphabet: "base64url" });
+    },
+  });
+
+  bench("omitPadding", {
+    run: () => {
+      SHORT_BYTES.toBase64({ omitPadding: true });
+    },
+  });
+});
+
+suite("Uint8Array.fromBase64", () => {
+  bench("short (8 chars)", {
+    run: () => {
+      Uint8Array.fromBase64(SHORT_B64);
+    },
+  });
+
+  bench("medium (600 chars)", {
+    run: () => {
+      Uint8Array.fromBase64(MEDIUM_B64);
+    },
+  });
+
+  bench("large (5464 chars)", {
+    run: () => {
+      Uint8Array.fromBase64(LARGE_B64);
+    },
+  });
+});
+
+suite("Uint8Array.prototype.toHex", () => {
+  bench("short (5 bytes)", {
+    run: () => {
+      SHORT_BYTES.toHex();
+    },
+  });
+
+  bench("medium (450 bytes)", {
+    run: () => {
+      MEDIUM_BYTES.toHex();
+    },
+  });
+
+  bench("large (4096 bytes)", {
+    run: () => {
+      LARGE_BYTES.toHex();
+    },
+  });
+});
+
+suite("Uint8Array.fromHex", () => {
+  bench("short (10 chars)", {
+    run: () => {
+      Uint8Array.fromHex(SHORT_HEX);
+    },
+  });
+
+  bench("medium (900 chars)", {
+    run: () => {
+      Uint8Array.fromHex(MEDIUM_HEX);
+    },
+  });
+
+  bench("large (8192 chars)", {
+    run: () => {
+      Uint8Array.fromHex(LARGE_HEX);
+    },
+  });
+});
+
+suite("Uint8Array setFrom* (in-place)", () => {
+  bench("setFromBase64 (450 bytes)", {
+    setup: () => new Uint8Array(450),
+    run: (target) => {
+      target.setFromBase64(MEDIUM_B64);
+    },
+  });
+
+  bench("setFromHex (450 bytes)", {
+    setup: () => new Uint8Array(450),
+    run: (target) => {
+      target.setFromHex(MEDIUM_HEX);
+    },
+  });
+});
+
+suite("round-trip", () => {
+  bench("toBase64 → fromBase64 (450 bytes)", {
+    run: () => {
+      Uint8Array.fromBase64(MEDIUM_BYTES.toBase64());
+    },
+  });
+
+  bench("toHex → fromHex (450 bytes)", {
+    run: () => {
+      Uint8Array.fromHex(MEDIUM_BYTES.toHex());
+    },
+  });
+});

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -1019,6 +1019,22 @@ TypedArrays provide array-like views over ArrayBuffer data with fixed element ty
 | `ta.entries()` | Iterator over [index, value] pairs |
 | `ta[Symbol.iterator]()` | Same as `values()` |
 
+**Uint8Array Base64/Hex encoding** (TC39 Uint8Array Base64, `Goccia.Values.Uint8ArrayEncoding.pas`):
+
+These methods are available only on `Uint8Array`, not on other TypedArray types.
+
+| Static method | Description |
+|--------|-------------|
+| `Uint8Array.fromBase64(string [, options])` | Decode a base64 string to a new Uint8Array. Options: `alphabet` (`"base64"` or `"base64url"`), `lastChunkHandling` (`"loose"`, `"strict"`, or `"stop-before-partial"`) |
+| `Uint8Array.fromHex(string)` | Decode a hex string (case-insensitive) to a new Uint8Array. Throws `SyntaxError` on odd length or invalid characters |
+
+| Prototype method | Description |
+|--------|-------------|
+| `u8.toBase64([options])` | Encode bytes as a base64 string. Options: `alphabet` (`"base64"` or `"base64url"`), `omitPadding` (boolean, default `false`) |
+| `u8.toHex()` | Encode bytes as a lowercase hex string |
+| `u8.setFromBase64(string [, options])` | Decode base64 into this array. Returns `{ read, written }`. Same options as `fromBase64` |
+| `u8.setFromHex(string)` | Decode hex into this array. Returns `{ read, written }` |
+
 **Value encoding:** Integer types use fixed-width truncation (overflow wraps). `Uint8ClampedArray` clamps to [0, 255] with half-to-even rounding. `Float32Array` rounds to IEEE 754 single precision. `Float64Array` preserves full double precision. NaN is stored as 0 in integer types and as NaN in float types.
 
 **Not supported:** `BigInt64Array`, `BigUint64Array` (BigInt types), `DataView`.

--- a/tests/built-ins/TypedArray/fromBase64.js
+++ b/tests/built-ins/TypedArray/fromBase64.js
@@ -1,0 +1,114 @@
+describe("Uint8Array.fromBase64", () => {
+  test("decodes standard base64 string", () => {
+    const result = Uint8Array.fromBase64("SGVsbG8=");
+    expect(result.length).toBe(5);
+    expect(result[0]).toBe(72);
+    expect(result[1]).toBe(101);
+    expect(result[4]).toBe(111);
+  });
+
+  test("decodes base64 without padding (loose mode)", () => {
+    const result = Uint8Array.fromBase64("SGVsbG8");
+    expect(result.length).toBe(5);
+    expect(result[0]).toBe(72);
+  });
+
+  test("decodes empty string", () => {
+    const result = Uint8Array.fromBase64("");
+    expect(result.length).toBe(0);
+  });
+
+  test("decodes base64url alphabet", () => {
+    const result = Uint8Array.fromBase64("-__-", { alphabet: "base64url" });
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(251);
+    expect(result[1]).toBe(255);
+    expect(result[2]).toBe(254);
+  });
+
+  test("skips ASCII whitespace", () => {
+    const result = Uint8Array.fromBase64("S G V s\nb G 8 =");
+    expect(result.length).toBe(5);
+    expect(result[0]).toBe(72);
+  });
+
+  test("returns a Uint8Array instance", () => {
+    const result = Uint8Array.fromBase64("QUJD");
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(65);
+    expect(result[1]).toBe(66);
+    expect(result[2]).toBe(67);
+  });
+
+  test("throws TypeError when argument is not a string", () => {
+    expect(() => Uint8Array.fromBase64(123)).toThrow(TypeError);
+    expect(() => Uint8Array.fromBase64(null)).toThrow(TypeError);
+  });
+
+  test("throws TypeError with no arguments", () => {
+    expect(() => Uint8Array.fromBase64()).toThrow(TypeError);
+  });
+
+  test("throws SyntaxError for invalid characters", () => {
+    expect(() => Uint8Array.fromBase64("!!!")).toThrow(SyntaxError);
+    expect(() => Uint8Array.fromBase64("AB@D")).toThrow(SyntaxError);
+  });
+
+  test("throws SyntaxError for single trailing character", () => {
+    expect(() => Uint8Array.fromBase64("QUJDA")).toThrow(SyntaxError);
+  });
+
+  test("strict mode requires proper padding", () => {
+    expect(() => Uint8Array.fromBase64("SGVsbG8", {
+      lastChunkHandling: "strict"
+    })).toThrow(SyntaxError);
+  });
+
+  test("strict mode accepts properly padded input", () => {
+    const result = Uint8Array.fromBase64("SGVsbG8=", {
+      lastChunkHandling: "strict"
+    });
+    expect(result.length).toBe(5);
+  });
+
+  test("strict mode rejects non-zero padding bits", () => {
+    // "AR==" has non-zero padding bits (the R encodes 0x11, trailing bits are non-zero)
+    expect(() => Uint8Array.fromBase64("AR==", {
+      lastChunkHandling: "strict"
+    })).toThrow(SyntaxError);
+  });
+
+  test("stop-before-partial ignores incomplete final chunk", () => {
+    const result = Uint8Array.fromBase64("QUJDQQ", {
+      lastChunkHandling: "stop-before-partial"
+    });
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(65);
+    expect(result[1]).toBe(66);
+    expect(result[2]).toBe(67);
+  });
+
+  test("throws TypeError for invalid alphabet option", () => {
+    expect(() => Uint8Array.fromBase64("AA==", { alphabet: "invalid" })).toThrow(TypeError);
+  });
+
+  test("throws TypeError for invalid lastChunkHandling option", () => {
+    expect(() => Uint8Array.fromBase64("AA==", { lastChunkHandling: "invalid" })).toThrow(TypeError);
+  });
+
+  test("decodes all zeros", () => {
+    const result = Uint8Array.fromBase64("AAAA");
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(0);
+    expect(result[2]).toBe(0);
+  });
+
+  test("decodes all 255s", () => {
+    const result = Uint8Array.fromBase64("////");
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(255);
+    expect(result[1]).toBe(255);
+    expect(result[2]).toBe(255);
+  });
+});

--- a/tests/built-ins/TypedArray/fromHex.js
+++ b/tests/built-ins/TypedArray/fromHex.js
@@ -1,0 +1,81 @@
+describe("Uint8Array.fromHex", () => {
+  test("decodes hex string to Uint8Array", () => {
+    const result = Uint8Array.fromHex("48656c6c6f");
+    expect(result.length).toBe(5);
+    expect(result[0]).toBe(72);
+    expect(result[1]).toBe(101);
+    expect(result[4]).toBe(111);
+  });
+
+  test("decodes empty string", () => {
+    const result = Uint8Array.fromHex("");
+    expect(result.length).toBe(0);
+  });
+
+  test("accepts lowercase hex", () => {
+    const result = Uint8Array.fromHex("aabbcc");
+    expect(result[0]).toBe(0xAA);
+    expect(result[1]).toBe(0xBB);
+    expect(result[2]).toBe(0xCC);
+  });
+
+  test("accepts uppercase hex", () => {
+    const result = Uint8Array.fromHex("AABBCC");
+    expect(result[0]).toBe(0xAA);
+    expect(result[1]).toBe(0xBB);
+    expect(result[2]).toBe(0xCC);
+  });
+
+  test("accepts mixed case hex", () => {
+    const result = Uint8Array.fromHex("aAbBcC");
+    expect(result[0]).toBe(0xAA);
+    expect(result[1]).toBe(0xBB);
+    expect(result[2]).toBe(0xCC);
+  });
+
+  test("decodes boundary values", () => {
+    const result = Uint8Array.fromHex("007f80ff");
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(127);
+    expect(result[2]).toBe(128);
+    expect(result[3]).toBe(255);
+  });
+
+  test("returns Uint8Array instance", () => {
+    const result = Uint8Array.fromHex("ff");
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(255);
+  });
+
+  test("throws TypeError when argument is not a string", () => {
+    expect(() => Uint8Array.fromHex(123)).toThrow(TypeError);
+    expect(() => Uint8Array.fromHex(null)).toThrow(TypeError);
+  });
+
+  test("throws TypeError with no arguments", () => {
+    expect(() => Uint8Array.fromHex()).toThrow(TypeError);
+  });
+
+  test("throws SyntaxError for odd-length string", () => {
+    expect(() => Uint8Array.fromHex("a")).toThrow(SyntaxError);
+    expect(() => Uint8Array.fromHex("abc")).toThrow(SyntaxError);
+    expect(() => Uint8Array.fromHex("abcde")).toThrow(SyntaxError);
+  });
+
+  test("throws SyntaxError for invalid hex characters", () => {
+    expect(() => Uint8Array.fromHex("zz")).toThrow(SyntaxError);
+    expect(() => Uint8Array.fromHex("gg")).toThrow(SyntaxError);
+    expect(() => Uint8Array.fromHex("0x")).toThrow(SyntaxError);
+  });
+
+  test("round-trips with toHex", () => {
+    const original = new Uint8Array([0, 42, 128, 255]);
+    const hex = original.toHex();
+    const decoded = Uint8Array.fromHex(hex);
+    expect(decoded.length).toBe(original.length);
+    expect(decoded[0]).toBe(0);
+    expect(decoded[1]).toBe(42);
+    expect(decoded[2]).toBe(128);
+    expect(decoded[3]).toBe(255);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/setFromBase64.js
+++ b/tests/built-ins/TypedArray/prototype/setFromBase64.js
@@ -1,0 +1,74 @@
+describe("Uint8Array.prototype.setFromBase64", () => {
+  test("decodes base64 into existing array", () => {
+    const target = new Uint8Array(5);
+    const result = target.setFromBase64("SGVsbG8=");
+    expect(result.read).toBe(8);
+    expect(result.written).toBe(5);
+    expect(target[0]).toBe(72);
+    expect(target[4]).toBe(111);
+  });
+
+  test("returns { read, written } object", () => {
+    const target = new Uint8Array(3);
+    const result = target.setFromBase64("QUJD");
+    expect(result.read).toBe(4);
+    expect(result.written).toBe(3);
+  });
+
+  test("stops writing when target is full", () => {
+    const target = new Uint8Array(2);
+    const result = target.setFromBase64("QUJD");
+    expect(result.written).toBe(2);
+    expect(target[0]).toBe(65);
+    expect(target[1]).toBe(66);
+  });
+
+  test("handles empty input", () => {
+    const target = new Uint8Array(5);
+    const result = target.setFromBase64("");
+    expect(result.read).toBe(0);
+    expect(result.written).toBe(0);
+  });
+
+  test("handles base64url alphabet", () => {
+    const target = new Uint8Array(3);
+    const result = target.setFromBase64("-__-", { alphabet: "base64url" });
+    expect(result.written).toBe(3);
+    expect(target[0]).toBe(251);
+    expect(target[1]).toBe(255);
+    expect(target[2]).toBe(254);
+  });
+
+  test("skips whitespace in input", () => {
+    const target = new Uint8Array(5);
+    const result = target.setFromBase64("S G V s b G 8 =");
+    expect(result.written).toBe(5);
+    expect(target[0]).toBe(72);
+  });
+
+  test("throws TypeError when called on non-Uint8Array", () => {
+    const fn = Uint8Array.prototype.setFromBase64;
+    expect(() => fn.call(new Int8Array(1), "AA==")).toThrow(TypeError);
+  });
+
+  test("throws TypeError when first argument is not a string", () => {
+    const target = new Uint8Array(5);
+    expect(() => target.setFromBase64(123)).toThrow(TypeError);
+  });
+
+  test("throws SyntaxError for invalid base64 characters", () => {
+    const target = new Uint8Array(5);
+    expect(() => target.setFromBase64("!!!")).toThrow(SyntaxError);
+  });
+
+  test("loose mode decodes partial last chunk", () => {
+    const target = new Uint8Array(5);
+    const result = target.setFromBase64("SGVsbG8");
+    expect(result.written).toBe(5);
+  });
+
+  test("strict mode rejects incomplete chunk without padding", () => {
+    const target = new Uint8Array(5);
+    expect(() => target.setFromBase64("SGVsbG8", { lastChunkHandling: "strict" })).toThrow(SyntaxError);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/setFromBase64.js
+++ b/tests/built-ins/TypedArray/prototype/setFromBase64.js
@@ -15,12 +15,25 @@ describe("Uint8Array.prototype.setFromBase64", () => {
     expect(result.written).toBe(3);
   });
 
-  test("stops writing when target is full", () => {
+  test("does not consume chunk when output would overflow target", () => {
+    // "QUJD" decodes to 3 bytes (ABC) but target only has 2 bytes
+    // A full 4-char chunk produces 3 bytes atomically — can't partially write it
     const target = new Uint8Array(2);
     const result = target.setFromBase64("QUJD");
-    expect(result.written).toBe(2);
+    expect(result.read).toBe(0);
+    expect(result.written).toBe(0);
+  });
+
+  test("consumes only chunks that fully fit in target", () => {
+    // "QUJDREVG" = "QUJD" (ABC, 3 bytes) + "REVG" (DEF, 3 bytes)
+    // Target has 4 bytes: first chunk (3 bytes) fits, second chunk (3 bytes) does not
+    const target = new Uint8Array(4);
+    const result = target.setFromBase64("QUJDREVG");
+    expect(result.read).toBe(4);
+    expect(result.written).toBe(3);
     expect(target[0]).toBe(65);
     expect(target[1]).toBe(66);
+    expect(target[2]).toBe(67);
   });
 
   test("handles empty input", () => {

--- a/tests/built-ins/TypedArray/prototype/setFromHex.js
+++ b/tests/built-ins/TypedArray/prototype/setFromHex.js
@@ -1,0 +1,69 @@
+describe("Uint8Array.prototype.setFromHex", () => {
+  test("decodes hex into existing array", () => {
+    const target = new Uint8Array(5);
+    const result = target.setFromHex("48656c6c6f");
+    expect(result.read).toBe(10);
+    expect(result.written).toBe(5);
+    expect(target[0]).toBe(72);
+    expect(target[4]).toBe(111);
+  });
+
+  test("returns { read, written } object", () => {
+    const target = new Uint8Array(3);
+    const result = target.setFromHex("414243");
+    expect(result.read).toBe(6);
+    expect(result.written).toBe(3);
+  });
+
+  test("stops writing when target is full", () => {
+    const target = new Uint8Array(2);
+    const result = target.setFromHex("414243");
+    expect(result.written).toBe(2);
+    expect(result.read).toBe(4);
+    expect(target[0]).toBe(65);
+    expect(target[1]).toBe(66);
+  });
+
+  test("handles empty input", () => {
+    const target = new Uint8Array(5);
+    const result = target.setFromHex("");
+    expect(result.read).toBe(0);
+    expect(result.written).toBe(0);
+  });
+
+  test("accepts uppercase hex", () => {
+    const target = new Uint8Array(3);
+    const result = target.setFromHex("AABBCC");
+    expect(result.written).toBe(3);
+    expect(target[0]).toBe(0xAA);
+    expect(target[1]).toBe(0xBB);
+    expect(target[2]).toBe(0xCC);
+  });
+
+  test("accepts mixed case hex", () => {
+    const target = new Uint8Array(2);
+    const result = target.setFromHex("aAbB");
+    expect(target[0]).toBe(0xAA);
+    expect(target[1]).toBe(0xBB);
+  });
+
+  test("throws TypeError when called on non-Uint8Array", () => {
+    const fn = Uint8Array.prototype.setFromHex;
+    expect(() => fn.call(new Int8Array(1), "ff")).toThrow(TypeError);
+  });
+
+  test("throws TypeError when first argument is not a string", () => {
+    const target = new Uint8Array(5);
+    expect(() => target.setFromHex(123)).toThrow(TypeError);
+  });
+
+  test("throws SyntaxError for odd-length hex string", () => {
+    const target = new Uint8Array(5);
+    expect(() => target.setFromHex("abc")).toThrow(SyntaxError);
+  });
+
+  test("throws SyntaxError for invalid hex characters", () => {
+    const target = new Uint8Array(5);
+    expect(() => target.setFromHex("zzzz")).toThrow(SyntaxError);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/toBase64.js
+++ b/tests/built-ins/TypedArray/prototype/toBase64.js
@@ -1,0 +1,81 @@
+describe("Uint8Array.prototype.toBase64", () => {
+  test("encodes bytes to base64 with padding", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+    expect(bytes.toBase64()).toBe("SGVsbG8=");
+  });
+
+  test("encodes bytes that produce no padding", () => {
+    const bytes = new Uint8Array([72, 101, 108]);
+    expect(bytes.toBase64()).toBe("SGVs");
+  });
+
+  test("encodes bytes that produce double padding", () => {
+    const bytes = new Uint8Array([72]);
+    expect(bytes.toBase64()).toBe("SA==");
+  });
+
+  test("returns empty string for empty array", () => {
+    expect(new Uint8Array(0).toBase64()).toBe("");
+  });
+
+  test("omitPadding option removes trailing =", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+    expect(bytes.toBase64({ omitPadding: true })).toBe("SGVsbG8");
+  });
+
+  test("omitPadding with double padding", () => {
+    const bytes = new Uint8Array([72]);
+    expect(bytes.toBase64({ omitPadding: true })).toBe("SA");
+  });
+
+  test("omitPadding false is default", () => {
+    const bytes = new Uint8Array([72]);
+    expect(bytes.toBase64({ omitPadding: false })).toBe("SA==");
+  });
+
+  test("base64url alphabet uses - and _ instead of + and /", () => {
+    const bytes = new Uint8Array([251, 255, 254]);
+    expect(bytes.toBase64()).toBe("+//+");
+    expect(bytes.toBase64({ alphabet: "base64url" })).toBe("-__-");
+  });
+
+  test("base64url with omitPadding", () => {
+    const bytes = new Uint8Array([72]);
+    expect(bytes.toBase64({ alphabet: "base64url", omitPadding: true })).toBe("SA");
+  });
+
+  test("throws TypeError for invalid alphabet option", () => {
+    const bytes = new Uint8Array([1]);
+    expect(() => bytes.toBase64({ alphabet: "invalid" })).toThrow(TypeError);
+  });
+
+  test("throws TypeError when called on non-Uint8Array", () => {
+    const fn = Uint8Array.prototype.toBase64;
+    expect(() => fn.call(new Int8Array(1))).toThrow(TypeError);
+  });
+
+  test("throws TypeError when options is not an object", () => {
+    const bytes = new Uint8Array([1]);
+    expect(() => bytes.toBase64("bad")).toThrow(TypeError);
+  });
+
+  test("works with buffer offset", () => {
+    const buffer = new ArrayBuffer(8);
+    const full = new Uint8Array(buffer);
+    full[3] = 65;
+    full[4] = 66;
+    full[5] = 67;
+    const view = new Uint8Array(buffer, 3, 3);
+    expect(view.toBase64()).toBe("QUJD");
+  });
+
+  test("encodes all zero bytes", () => {
+    const bytes = new Uint8Array([0, 0, 0]);
+    expect(bytes.toBase64()).toBe("AAAA");
+  });
+
+  test("encodes all 255 bytes", () => {
+    const bytes = new Uint8Array([255, 255, 255]);
+    expect(bytes.toBase64()).toBe("////");
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/toHex.js
+++ b/tests/built-ins/TypedArray/prototype/toHex.js
@@ -1,0 +1,42 @@
+describe("Uint8Array.prototype.toHex", () => {
+  test("encodes bytes as lowercase hex pairs", () => {
+    const bytes = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]);
+    expect(bytes.toHex()).toBe("48656c6c6f");
+  });
+
+  test("encodes single byte", () => {
+    expect(new Uint8Array([0xff]).toHex()).toBe("ff");
+    expect(new Uint8Array([0x00]).toHex()).toBe("00");
+    expect(new Uint8Array([0x0a]).toHex()).toBe("0a");
+  });
+
+  test("returns empty string for empty array", () => {
+    expect(new Uint8Array(0).toHex()).toBe("");
+  });
+
+  test("always produces lowercase hex", () => {
+    const bytes = new Uint8Array([0xAB, 0xCD, 0xEF]);
+    expect(bytes.toHex()).toBe("abcdef");
+  });
+
+  test("encodes all byte values", () => {
+    const bytes = new Uint8Array([0, 127, 128, 255]);
+    expect(bytes.toHex()).toBe("007f80ff");
+  });
+
+  test("throws TypeError when called on non-Uint8Array", () => {
+    const fn = Uint8Array.prototype.toHex;
+    expect(() => fn.call(new Int8Array(1))).toThrow(TypeError);
+    expect(() => fn.call(new Int32Array(1))).toThrow(TypeError);
+  });
+
+  test("works with buffer offset", () => {
+    const buffer = new ArrayBuffer(8);
+    const full = new Uint8Array(buffer);
+    full[2] = 0xAA;
+    full[3] = 0xBB;
+    full[4] = 0xCC;
+    const view = new Uint8Array(buffer, 2, 3);
+    expect(view.toHex()).toBe("aabbcc");
+  });
+});

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -87,6 +87,16 @@ const
   PROP_OPEN                   = 'open';
   PROP_NULLPTR                = 'nullptr';
   PROP_SUFFIX                 = 'suffix';
+  PROP_ALPHABET               = 'alphabet';
+  PROP_OMIT_PADDING           = 'omitPadding';
+  PROP_LAST_CHUNK_HANDLING    = 'lastChunkHandling';
+  PROP_WRITTEN                = 'written';
+  PROP_TO_BASE64              = 'toBase64';
+  PROP_TO_HEX                 = 'toHex';
+  PROP_FROM_BASE64            = 'fromBase64';
+  PROP_FROM_HEX               = 'fromHex';
+  PROP_SET_FROM_BASE64        = 'setFromBase64';
+  PROP_SET_FROM_HEX           = 'setFromHex';
 
   // Proxy handler trap names
   PROP_HAS                       = 'has';

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -247,6 +247,7 @@ uses
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.Uint8ArrayEncoding,
   Goccia.Version;
 
 constructor TGocciaEngine.Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins);
@@ -597,6 +598,7 @@ var
   TAConstructor: TGocciaTypedArrayClassValue;
   BPE: TGocciaNumberLiteralValue;
   FromFn, OfFn: TGocciaTypedArrayStaticFrom;
+  Encoding: TGocciaUint8ArrayEncoding;
 begin
   TAConstructor := TGocciaTypedArrayClassValue.Create(AName, nil, AKind);
   TGocciaTypedArrayValue.ExposePrototype(TAConstructor);
@@ -611,6 +613,31 @@ begin
   OfFn := TGocciaTypedArrayStaticFrom.Create(AKind);
   TAConstructor.SetProperty(PROP_OF,
     TGocciaNativeFunctionValue.CreateWithoutPrototype(OfFn.TypedArrayOf, 'of', 0));
+
+  // Uint8Array-only: Base64/Hex encoding methods (TC39 Uint8Array Base64)
+  if AKind = takUint8 then
+  begin
+    Encoding := TGocciaUint8ArrayEncoding.Create;
+
+    // Static methods on Uint8Array constructor
+    TAConstructor.SetProperty(PROP_FROM_BASE64,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.FromBase64, 'fromBase64', 1));
+    TAConstructor.SetProperty(PROP_FROM_HEX,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.FromHex, 'fromHex', 1));
+
+    // Prototype methods on Uint8Array.prototype
+    TAConstructor.Prototype.AssignProperty(PROP_TO_BASE64,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.ToBase64, 'toBase64', 0));
+    TAConstructor.Prototype.AssignProperty(PROP_TO_HEX,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.ToHex, 'toHex', 0));
+    TAConstructor.Prototype.AssignProperty(PROP_SET_FROM_BASE64,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.SetFromBase64, 'setFromBase64', 1));
+    TAConstructor.Prototype.AssignProperty(PROP_SET_FROM_HEX,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.SetFromHex, 'setFromHex', 1));
+
+    // Uint8Array instances use constructor's prototype (encoding methods + shared chain)
+    TGocciaTypedArrayValue.SetUint8Prototype(TAConstructor.Prototype);
+  end;
 
   FInterpreter.GlobalScope.DefineLexicalBinding(AName, TAConstructor, dtConst);
 end;

--- a/units/Goccia.Runtime.Bootstrap.pas
+++ b/units/Goccia.Runtime.Bootstrap.pas
@@ -113,6 +113,7 @@ uses
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.Uint8ArrayEncoding,
   Goccia.Version;
 
 function ObjectPrototypeProvider: TGocciaObjectValue;
@@ -410,6 +411,7 @@ var
   TAConstructor: TGocciaTypedArrayClassValue;
   BPE: TGocciaNumberLiteralValue;
   FromFn, OfFn: TGocciaTypedArrayStaticFrom;
+  Encoding: TGocciaUint8ArrayEncoding;
 begin
   TAConstructor := TGocciaTypedArrayClassValue.Create(AName, nil, AKind);
   TGocciaTypedArrayValue.ExposePrototype(TAConstructor);
@@ -424,6 +426,31 @@ begin
   OfFn := TGocciaTypedArrayStaticFrom.Create(AKind);
   TAConstructor.SetProperty(PROP_OF,
     TGocciaNativeFunctionValue.CreateWithoutPrototype(OfFn.TypedArrayOf, 'of', 0));
+
+  // Uint8Array-only: Base64/Hex encoding methods (TC39 Uint8Array Base64)
+  if AKind = takUint8 then
+  begin
+    Encoding := TGocciaUint8ArrayEncoding.Create;
+
+    // Static methods on Uint8Array constructor
+    TAConstructor.SetProperty(PROP_FROM_BASE64,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.FromBase64, 'fromBase64', 1));
+    TAConstructor.SetProperty(PROP_FROM_HEX,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.FromHex, 'fromHex', 1));
+
+    // Prototype methods on Uint8Array.prototype
+    TAConstructor.Prototype.AssignProperty(PROP_TO_BASE64,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.ToBase64, 'toBase64', 0));
+    TAConstructor.Prototype.AssignProperty(PROP_TO_HEX,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.ToHex, 'toHex', 0));
+    TAConstructor.Prototype.AssignProperty(PROP_SET_FROM_BASE64,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.SetFromBase64, 'setFromBase64', 1));
+    TAConstructor.Prototype.AssignProperty(PROP_SET_FROM_HEX,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.SetFromHex, 'setFromHex', 1));
+
+    // Uint8Array instances use constructor's prototype (encoding methods + shared chain)
+    TGocciaTypedArrayValue.SetUint8Prototype(TAConstructor.Prototype);
+  end;
 
   FInterpreter.GlobalScope.DefineLexicalBinding(AName, TAConstructor, dtConst);
 end;

--- a/units/Goccia.Values.TypedArrayValue.pas
+++ b/units/Goccia.Values.TypedArrayValue.pas
@@ -28,6 +28,7 @@ type
   private
     class var FShared: TGocciaSharedPrototype;
     class var FPrototypeMembers: array of TGocciaMemberDefinition;
+    class var FUint8Prototype: TGocciaObjectValue;
   private
     FBufferValue: TGocciaValue;
     FBufferData: TBytes;
@@ -59,6 +60,7 @@ type
     class function KindName(const AKind: TGocciaTypedArrayKind): string;
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
     class procedure SetSharedPrototypeParent(const AParent: TGocciaObjectValue);
+    class procedure SetUint8Prototype(const APrototype: TGocciaObjectValue);
 
     property BufferValue: TGocciaValue read FBufferValue;
     property BufferData: TBytes read FBufferData;
@@ -375,7 +377,9 @@ begin
   FBufferValue := Buf;
   FBufferData := Buf.Data;
   InitializePrototype;
-  if Assigned(FShared) then
+  if (AKind = takUint8) and Assigned(FUint8Prototype) then
+    FPrototype := FUint8Prototype
+  else if Assigned(FShared) then
     FPrototype := FShared.Prototype;
 end;
 
@@ -397,7 +401,9 @@ begin
     FLength := (System.Length(ABuffer.Data) - AByteOffset) div BPE;
 
   InitializePrototype;
-  if Assigned(FShared) then
+  if (AKind = takUint8) and Assigned(FUint8Prototype) then
+    FPrototype := FUint8Prototype
+  else if Assigned(FShared) then
     FPrototype := FShared.Prototype;
 end;
 
@@ -419,7 +425,9 @@ begin
     FLength := (System.Length(ASharedBuffer.Data) - AByteOffset) div BPE;
 
   InitializePrototype;
-  if Assigned(FShared) then
+  if (AKind = takUint8) and Assigned(FUint8Prototype) then
+    FPrototype := FUint8Prototype
+  else if Assigned(FShared) then
     FPrototype := FShared.Prototype;
 end;
 
@@ -499,6 +507,11 @@ class procedure TGocciaTypedArrayValue.SetSharedPrototypeParent(const AParent: T
 begin
   if Assigned(FShared) and not Assigned(FShared.Prototype.Prototype) then
     FShared.Prototype.Prototype := AParent;
+end;
+
+class procedure TGocciaTypedArrayValue.SetUint8Prototype(const APrototype: TGocciaObjectValue);
+begin
+  FUint8Prototype := APrototype;
 end;
 
 { Property access — indexed elements }

--- a/units/Goccia.Values.Uint8ArrayEncoding.pas
+++ b/units/Goccia.Values.Uint8ArrayEncoding.pas
@@ -1,0 +1,693 @@
+unit Goccia.Values.Uint8ArrayEncoding;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaUint8ArrayEncoding = class
+  public
+    { Prototype methods — called with this = Uint8Array instance }
+    function ToBase64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ToHex(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function SetFromBase64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function SetFromHex(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+
+    { Static methods — called on Uint8Array constructor }
+    function FromBase64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function FromHex(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Constants.PropertyNames,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.TypedArrayValue;
+
+type
+  TBase64Alphabet = array[0..63] of Char;
+  TBase64DecodeTable = array[0..127] of Byte;
+
+const
+  ALPHABET_BASE64    = 'base64';
+  ALPHABET_BASE64URL = 'base64url';
+
+  LAST_CHUNK_LOOSE            = 'loose';
+  LAST_CHUNK_STRICT           = 'strict';
+  LAST_CHUNK_STOP_BEFORE_PARTIAL = 'stop-before-partial';
+
+  HEX_CHARS: array[0..15] of Char = (
+    '0', '1', '2', '3', '4', '5', '6', '7',
+    '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+  );
+
+  BASE64_STANDARD: TBase64Alphabet = (
+    'A','B','C','D','E','F','G','H','I','J','K','L','M',
+    'N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
+    'a','b','c','d','e','f','g','h','i','j','k','l','m',
+    'n','o','p','q','r','s','t','u','v','w','x','y','z',
+    '0','1','2','3','4','5','6','7','8','9','+','/'
+  );
+
+  BASE64_URL_SAFE: TBase64Alphabet = (
+    'A','B','C','D','E','F','G','H','I','J','K','L','M',
+    'N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
+    'a','b','c','d','e','f','g','h','i','j','k','l','m',
+    'n','o','p','q','r','s','t','u','v','w','x','y','z',
+    '0','1','2','3','4','5','6','7','8','9','-','_'
+  );
+
+  INVALID_BASE64_VALUE = 255;
+  BASE64_PAD_CHAR      = '=';
+
+{ Decoding lookup tables initialized once }
+
+var
+  Base64StandardDecode: TBase64DecodeTable;
+  Base64UrlDecode: TBase64DecodeTable;
+  TablesInitialized: Boolean = False;
+
+procedure InitDecodeTables;
+var
+  I: Integer;
+begin
+  if TablesInitialized then Exit;
+  for I := 0 to 127 do
+  begin
+    Base64StandardDecode[I] := INVALID_BASE64_VALUE;
+    Base64UrlDecode[I] := INVALID_BASE64_VALUE;
+  end;
+  for I := 0 to 63 do
+  begin
+    Base64StandardDecode[Ord(BASE64_STANDARD[I])] := Byte(I);
+    Base64UrlDecode[Ord(BASE64_URL_SAFE[I])] := Byte(I);
+  end;
+  TablesInitialized := True;
+end;
+
+function IsAsciiWhitespace(const ACh: Char): Boolean; inline;
+begin
+  Result := (ACh = #9) or (ACh = #10) or (ACh = #12) or (ACh = #13) or (ACh = ' ');
+end;
+
+function RequireUint8Array(const AThisValue: TGocciaValue; const AMethod: string): TGocciaTypedArrayValue;
+begin
+  if not (AThisValue is TGocciaTypedArrayValue) or
+     (TGocciaTypedArrayValue(AThisValue).Kind <> takUint8) then
+    ThrowTypeError(AMethod + ' requires that |this| be a Uint8Array');
+  Result := TGocciaTypedArrayValue(AThisValue);
+end;
+
+function ReadAlphabetOption(const AOptions: TGocciaValue): string;
+var
+  AlphabetVal: TGocciaValue;
+begin
+  Result := ALPHABET_BASE64;
+  if (AOptions is TGocciaObjectValue) then
+  begin
+    AlphabetVal := TGocciaObjectValue(AOptions).GetProperty(PROP_ALPHABET);
+    if Assigned(AlphabetVal) and not (AlphabetVal is TGocciaUndefinedLiteralValue) then
+    begin
+      Result := AlphabetVal.ToStringLiteral.Value;
+      if (Result <> ALPHABET_BASE64) and (Result <> ALPHABET_BASE64URL) then
+        ThrowTypeError('Invalid alphabet: expected "base64" or "base64url"');
+    end;
+  end;
+end;
+
+function ReadOmitPaddingOption(const AOptions: TGocciaValue): Boolean;
+var
+  Val: TGocciaValue;
+begin
+  Result := False;
+  if (AOptions is TGocciaObjectValue) then
+  begin
+    Val := TGocciaObjectValue(AOptions).GetProperty(PROP_OMIT_PADDING);
+    if Assigned(Val) and not (Val is TGocciaUndefinedLiteralValue) then
+      Result := Val.ToBooleanLiteral.Value;
+  end;
+end;
+
+function ReadLastChunkHandlingOption(const AOptions: TGocciaValue): string;
+var
+  Val: TGocciaValue;
+begin
+  Result := LAST_CHUNK_LOOSE;
+  if (AOptions is TGocciaObjectValue) then
+  begin
+    Val := TGocciaObjectValue(AOptions).GetProperty(PROP_LAST_CHUNK_HANDLING);
+    if Assigned(Val) and not (Val is TGocciaUndefinedLiteralValue) then
+    begin
+      Result := Val.ToStringLiteral.Value;
+      if (Result <> LAST_CHUNK_LOOSE) and (Result <> LAST_CHUNK_STRICT) and
+         (Result <> LAST_CHUNK_STOP_BEFORE_PARTIAL) then
+        ThrowTypeError('Invalid lastChunkHandling: expected "loose", "strict", or "stop-before-partial"');
+    end;
+  end;
+end;
+
+{ ---- Hex helpers ---- }
+
+function HexCharToNibble(const ACh: Char): Integer; inline;
+begin
+  case ACh of
+    '0'..'9': Result := Ord(ACh) - Ord('0');
+    'a'..'f': Result := 10 + Ord(ACh) - Ord('a');
+    'A'..'F': Result := 10 + Ord(ACh) - Ord('A');
+  else
+    Result := -1;
+  end;
+end;
+
+{ ---- Base64 encoding ---- }
+
+function EncodeBase64(const AData: TBytes; const AOffset, ALength: Integer;
+  const AAlphabet: string; const AOmitPadding: Boolean): string;
+var
+  Table: TBase64Alphabet;
+  I, Groups, Remainder, OutLen, Pos: Integer;
+  B0, B1, B2: Byte;
+begin
+  if AAlphabet = ALPHABET_BASE64URL then
+    Table := BASE64_URL_SAFE
+  else
+    Table := BASE64_STANDARD;
+
+  Groups := ALength div 3;
+  Remainder := ALength mod 3;
+  if AOmitPadding then
+  begin
+    case Remainder of
+      0: OutLen := Groups * 4;
+      1: OutLen := Groups * 4 + 2;
+      2: OutLen := Groups * 4 + 3;
+    else
+      OutLen := Groups * 4;
+    end;
+  end
+  else
+  begin
+    if Remainder > 0 then
+      OutLen := (Groups + 1) * 4
+    else
+      OutLen := Groups * 4;
+  end;
+
+  SetLength(Result, OutLen);
+  Pos := 1;
+
+  for I := 0 to Groups - 1 do
+  begin
+    B0 := AData[AOffset + I * 3];
+    B1 := AData[AOffset + I * 3 + 1];
+    B2 := AData[AOffset + I * 3 + 2];
+    Result[Pos]     := Table[(B0 shr 2) and $3F];
+    Result[Pos + 1] := Table[((B0 and $03) shl 4) or ((B1 shr 4) and $0F)];
+    Result[Pos + 2] := Table[((B1 and $0F) shl 2) or ((B2 shr 6) and $03)];
+    Result[Pos + 3] := Table[B2 and $3F];
+    Inc(Pos, 4);
+  end;
+
+  case Remainder of
+    1:
+    begin
+      B0 := AData[AOffset + Groups * 3];
+      Result[Pos]     := Table[(B0 shr 2) and $3F];
+      Result[Pos + 1] := Table[(B0 and $03) shl 4];
+      if not AOmitPadding then
+      begin
+        Result[Pos + 2] := BASE64_PAD_CHAR;
+        Result[Pos + 3] := BASE64_PAD_CHAR;
+      end;
+    end;
+    2:
+    begin
+      B0 := AData[AOffset + Groups * 3];
+      B1 := AData[AOffset + Groups * 3 + 1];
+      Result[Pos]     := Table[(B0 shr 2) and $3F];
+      Result[Pos + 1] := Table[((B0 and $03) shl 4) or ((B1 shr 4) and $0F)];
+      Result[Pos + 2] := Table[(B1 and $0F) shl 2];
+      if not AOmitPadding then
+        Result[Pos + 3] := BASE64_PAD_CHAR;
+    end;
+  end;
+end;
+
+{ ---- Base64 decoding ---- }
+
+type
+  TBase64DecodeResult = record
+    Bytes: TBytes;
+    ByteLength: Integer;
+    CharsRead: Integer;
+  end;
+
+function DecodeBase64(const AInput: string; const AAlphabet: string;
+  const ALastChunkHandling: string; const AMaxBytes: Integer): TBase64DecodeResult;
+var
+  DecodeTable: TBase64DecodeTable;
+  Cleaned: string;
+  CleanedLen, I, ChunkLen: Integer;
+  Ch: Char;
+  HasPadding: Boolean;
+  PadStart, FullChunks, Remainder: Integer;
+  Pos, OutPos: Integer;
+  V0, V1, V2, V3: Byte;
+  CharsConsumed: Integer;
+
+  { Map cleaned index back to original input index }
+  CleanedToOriginal: array of Integer;
+begin
+  InitDecodeTables;
+  if AAlphabet = ALPHABET_BASE64URL then
+    DecodeTable := Base64UrlDecode
+  else
+    DecodeTable := Base64StandardDecode;
+
+  // Step 1: Strip ASCII whitespace and track original positions
+  SetLength(Cleaned, Length(AInput));
+  SetLength(CleanedToOriginal, Length(AInput) + 1);
+  CleanedLen := 0;
+  for I := 1 to Length(AInput) do
+  begin
+    Ch := AInput[I];
+    if not IsAsciiWhitespace(Ch) then
+    begin
+      Inc(CleanedLen);
+      Cleaned[CleanedLen] := Ch;
+      CleanedToOriginal[CleanedLen] := I;
+    end;
+  end;
+  SetLength(Cleaned, CleanedLen);
+
+  // Step 2: Handle padding — remove trailing '=' and record
+  HasPadding := False;
+  PadStart := CleanedLen;
+  if (CleanedLen >= 1) and (Cleaned[CleanedLen] = BASE64_PAD_CHAR) then
+  begin
+    HasPadding := True;
+    Dec(PadStart);
+    if (PadStart >= 1) and (Cleaned[PadStart] = BASE64_PAD_CHAR) then
+      Dec(PadStart);
+  end;
+
+  if HasPadding then
+    ChunkLen := PadStart
+  else
+    ChunkLen := CleanedLen;
+
+  // Step 3: Validate all non-padding characters
+  for I := 1 to ChunkLen do
+  begin
+    Ch := Cleaned[I];
+    if (Ord(Ch) > 127) or (DecodeTable[Ord(Ch)] = INVALID_BASE64_VALUE) then
+      ThrowSyntaxError('Invalid character in base64 string');
+  end;
+
+  // Step 4: Compute full chunks and remainder
+  FullChunks := ChunkLen div 4;
+  Remainder := ChunkLen mod 4;
+
+  // Step 5: Handle last chunk based on mode
+  if Remainder = 1 then
+  begin
+    // A single trailing character is never valid
+    if ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL then
+    begin
+      // Just ignore the last char, treat only full chunks
+      Dec(ChunkLen, 1);
+      Remainder := 0;
+    end
+    else
+      ThrowSyntaxError('Invalid base64 string: incomplete chunk');
+  end;
+
+  if Remainder > 0 then
+  begin
+    if ALastChunkHandling = LAST_CHUNK_STRICT then
+    begin
+      if HasPadding then
+      begin
+        // In strict mode with padding, the padded chunk must be exactly 4 chars
+        // Check that the padding makes it a complete 4-char chunk
+        if (Remainder = 2) and (CleanedLen - PadStart = 2) then
+        begin
+          // 2 data + 2 pad = 4: OK, check overflow bits
+          V0 := DecodeTable[Ord(Cleaned[PadStart - 1])];
+          V1 := DecodeTable[Ord(Cleaned[PadStart])];
+          if (V1 and $0F) <> 0 then
+            ThrowSyntaxError('Invalid base64 string: non-zero padding bits');
+        end
+        else if (Remainder = 3) and (CleanedLen - PadStart = 1) then
+        begin
+          // 3 data + 1 pad = 4: OK, check overflow bits
+          V0 := DecodeTable[Ord(Cleaned[PadStart])];
+          if (V0 and $03) <> 0 then
+            ThrowSyntaxError('Invalid base64 string: non-zero padding bits');
+        end
+        else
+          ThrowSyntaxError('Invalid base64 string: malformed padding');
+      end
+      else
+      begin
+        // In strict mode without padding, partial chunks are invalid
+        ThrowSyntaxError('Invalid base64 string: incomplete chunk in strict mode');
+      end;
+    end
+    else if ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL then
+    begin
+      // Don't decode the partial last chunk
+      Dec(ChunkLen, Remainder);
+      Remainder := 0;
+      FullChunks := ChunkLen div 4;
+    end;
+    // 'loose' mode: decode the partial chunk normally
+  end
+  else if HasPadding and (ALastChunkHandling = LAST_CHUNK_STRICT) then
+  begin
+    // Padding present but no remainder means the padding was part of a complete chunk
+    // Validate the padding makes sense
+    // (This case occurs when e.g., "AAAA==" — the padding overflows a complete chunk)
+    // Actually if Remainder = 0 and HasPadding, the padding was stripped from a complete set
+    // which means padding was erroneous
+    if PadStart <> CleanedLen then
+      ThrowSyntaxError('Invalid base64 string: unexpected padding');
+  end;
+
+  // Step 6: Compute output size
+  Result.ByteLength := FullChunks * 3;
+  case Remainder of
+    2: Inc(Result.ByteLength, 1);
+    3: Inc(Result.ByteLength, 2);
+  end;
+
+  if (AMaxBytes >= 0) and (Result.ByteLength > AMaxBytes) then
+    Result.ByteLength := AMaxBytes;
+
+  SetLength(Result.Bytes, Result.ByteLength);
+
+  // Step 7: Decode full 4-char chunks
+  Pos := 1;
+  OutPos := 0;
+  for I := 0 to FullChunks - 1 do
+  begin
+    if OutPos >= Result.ByteLength then Break;
+    V0 := DecodeTable[Ord(Cleaned[Pos])];
+    V1 := DecodeTable[Ord(Cleaned[Pos + 1])];
+    V2 := DecodeTable[Ord(Cleaned[Pos + 2])];
+    V3 := DecodeTable[Ord(Cleaned[Pos + 3])];
+    if OutPos < Result.ByteLength then
+    begin
+      Result.Bytes[OutPos] := (V0 shl 2) or (V1 shr 4);
+      Inc(OutPos);
+    end;
+    if OutPos < Result.ByteLength then
+    begin
+      Result.Bytes[OutPos] := ((V1 and $0F) shl 4) or (V2 shr 2);
+      Inc(OutPos);
+    end;
+    if OutPos < Result.ByteLength then
+    begin
+      Result.Bytes[OutPos] := ((V2 and $03) shl 6) or V3;
+      Inc(OutPos);
+    end;
+    Inc(Pos, 4);
+  end;
+
+  // Step 8: Decode remainder
+  if (Remainder >= 2) and (OutPos < Result.ByteLength) then
+  begin
+    V0 := DecodeTable[Ord(Cleaned[Pos])];
+    V1 := DecodeTable[Ord(Cleaned[Pos + 1])];
+    Result.Bytes[OutPos] := (V0 shl 2) or (V1 shr 4);
+    Inc(OutPos);
+    if (Remainder >= 3) and (OutPos < Result.ByteLength) then
+    begin
+      V2 := DecodeTable[Ord(Cleaned[Pos + 2])];
+      Result.Bytes[OutPos] := ((V1 and $0F) shl 4) or (V2 shr 2);
+      Inc(OutPos);
+    end;
+    Inc(Pos, Remainder);
+  end;
+
+  Result.ByteLength := OutPos;
+  SetLength(Result.Bytes, Result.ByteLength);
+
+  // Compute characters read from the original input
+  // After successful decode, all characters (including padding) were consumed
+  if (Pos > ChunkLen) then
+  begin
+    // All data chars were decoded — consumed everything including padding
+    if CleanedLen > 0 then
+      CharsConsumed := CleanedToOriginal[CleanedLen]
+    else
+      CharsConsumed := 0;
+  end
+  else if Pos > 1 then
+    CharsConsumed := CleanedToOriginal[Pos - 1]
+  else
+    CharsConsumed := 0;
+
+  // For stop-before-partial, report only up to the chars that were actually decoded
+  if (ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL) and (ChunkLen < PadStart) then
+  begin
+    if ChunkLen > 0 then
+      CharsConsumed := CleanedToOriginal[ChunkLen]
+    else
+      CharsConsumed := 0;
+  end;
+
+  Result.CharsRead := CharsConsumed;
+end;
+
+{ ---- Public methods ---- }
+
+// ES2026 §5.1.1 Uint8Array.prototype.toBase64([options])
+function TGocciaUint8ArrayEncoding.ToBase64(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  TA: TGocciaTypedArrayValue;
+  Alphabet: string;
+  OmitPadding: Boolean;
+  Options: TGocciaValue;
+  Encoded: string;
+begin
+  TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.toBase64');
+
+  Alphabet := ALPHABET_BASE64;
+  OmitPadding := False;
+  if AArgs.Length > 0 then
+  begin
+    Options := AArgs.GetElement(0);
+    if not (Options is TGocciaUndefinedLiteralValue) then
+    begin
+      if not (Options is TGocciaObjectValue) then
+        ThrowTypeError('Uint8Array.prototype.toBase64: options must be an object');
+      Alphabet := ReadAlphabetOption(Options);
+      OmitPadding := ReadOmitPaddingOption(Options);
+    end;
+  end;
+
+  Encoded := EncodeBase64(TA.BufferData, TA.ByteOffset, TA.Length, Alphabet, OmitPadding);
+  Result := TGocciaStringLiteralValue.Create(Encoded);
+end;
+
+// ES2026 §5.1.2 Uint8Array.prototype.toHex()
+function TGocciaUint8ArrayEncoding.ToHex(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  TA: TGocciaTypedArrayValue;
+  I, Offset: Integer;
+  Hex: string;
+  B: Byte;
+begin
+  TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.toHex');
+
+  SetLength(Hex, TA.Length * 2);
+  Offset := TA.ByteOffset;
+  for I := 0 to TA.Length - 1 do
+  begin
+    B := TA.BufferData[Offset + I];
+    Hex[I * 2 + 1] := HEX_CHARS[B shr 4];
+    Hex[I * 2 + 2] := HEX_CHARS[B and $0F];
+  end;
+  Result := TGocciaStringLiteralValue.Create(Hex);
+end;
+
+// ES2026 §5.1.3 Uint8Array.prototype.setFromBase64(string [, options])
+function TGocciaUint8ArrayEncoding.SetFromBase64(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  TA: TGocciaTypedArrayValue;
+  Input, Alphabet, LastChunkHandling: string;
+  Options: TGocciaValue;
+  DecResult: TBase64DecodeResult;
+  Written, I: Integer;
+  ResultObj: TGocciaObjectValue;
+begin
+  TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.setFromBase64');
+
+  if AArgs.Length = 0 then
+    ThrowTypeError('Uint8Array.prototype.setFromBase64 requires a string argument');
+  if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
+    ThrowTypeError('Uint8Array.prototype.setFromBase64: first argument must be a string');
+
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  Alphabet := ALPHABET_BASE64;
+  LastChunkHandling := LAST_CHUNK_LOOSE;
+  if AArgs.Length > 1 then
+  begin
+    Options := AArgs.GetElement(1);
+    if not (Options is TGocciaUndefinedLiteralValue) then
+    begin
+      if not (Options is TGocciaObjectValue) then
+        ThrowTypeError('Uint8Array.prototype.setFromBase64: options must be an object');
+      Alphabet := ReadAlphabetOption(Options);
+      LastChunkHandling := ReadLastChunkHandlingOption(Options);
+    end;
+  end;
+
+  DecResult := DecodeBase64(Input, Alphabet, LastChunkHandling, TA.Length);
+
+  Written := DecResult.ByteLength;
+  if Written > TA.Length then
+    Written := TA.Length;
+
+  for I := 0 to Written - 1 do
+    TA.BufferData[TA.ByteOffset + I] := DecResult.Bytes[I];
+
+  ResultObj := TGocciaObjectValue.Create;
+  ResultObj.AssignProperty(PROP_READ, TGocciaNumberLiteralValue.Create(DecResult.CharsRead));
+  ResultObj.AssignProperty(PROP_WRITTEN, TGocciaNumberLiteralValue.Create(Written));
+  Result := ResultObj;
+end;
+
+// ES2026 §5.1.4 Uint8Array.prototype.setFromHex(string)
+function TGocciaUint8ArrayEncoding.SetFromHex(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  TA: TGocciaTypedArrayValue;
+  Input: string;
+  I, Written, Hi, Lo: Integer;
+  ResultObj: TGocciaObjectValue;
+  CharsRead: Integer;
+begin
+  TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.setFromHex');
+
+  if AArgs.Length = 0 then
+    ThrowTypeError('Uint8Array.prototype.setFromHex requires a string argument');
+  if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
+    ThrowTypeError('Uint8Array.prototype.setFromHex: first argument must be a string');
+
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  if (Length(Input) mod 2) <> 0 then
+    ThrowSyntaxError('Invalid hex string: odd length');
+
+  Written := 0;
+  CharsRead := 0;
+  I := 1;
+  while (I + 1 <= Length(Input)) and (Written < TA.Length) do
+  begin
+    Hi := HexCharToNibble(Input[I]);
+    Lo := HexCharToNibble(Input[I + 1]);
+    if (Hi < 0) or (Lo < 0) then
+      ThrowSyntaxError('Invalid character in hex string');
+    TA.BufferData[TA.ByteOffset + Written] := Byte((Hi shl 4) or Lo);
+    Inc(Written);
+    Inc(I, 2);
+    CharsRead := I - 1;
+  end;
+
+  if Written = 0 then
+    CharsRead := 0;
+
+  ResultObj := TGocciaObjectValue.Create;
+  ResultObj.AssignProperty(PROP_READ, TGocciaNumberLiteralValue.Create(CharsRead));
+  ResultObj.AssignProperty(PROP_WRITTEN, TGocciaNumberLiteralValue.Create(Written));
+  Result := ResultObj;
+end;
+
+// ES2026 §5.2.1 Uint8Array.fromBase64(string [, options])
+function TGocciaUint8ArrayEncoding.FromBase64(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Input, Alphabet, LastChunkHandling: string;
+  Options: TGocciaValue;
+  DecResult: TBase64DecodeResult;
+  NewTA: TGocciaTypedArrayValue;
+  I: Integer;
+begin
+  if AArgs.Length = 0 then
+    ThrowTypeError('Uint8Array.fromBase64 requires a string argument');
+  if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
+    ThrowTypeError('Uint8Array.fromBase64: first argument must be a string');
+
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  Alphabet := ALPHABET_BASE64;
+  LastChunkHandling := LAST_CHUNK_LOOSE;
+  if AArgs.Length > 1 then
+  begin
+    Options := AArgs.GetElement(1);
+    if not (Options is TGocciaUndefinedLiteralValue) then
+    begin
+      if not (Options is TGocciaObjectValue) then
+        ThrowTypeError('Uint8Array.fromBase64: options must be an object');
+      Alphabet := ReadAlphabetOption(Options);
+      LastChunkHandling := ReadLastChunkHandlingOption(Options);
+    end;
+  end;
+
+  DecResult := DecodeBase64(Input, Alphabet, LastChunkHandling, -1);
+
+  NewTA := TGocciaTypedArrayValue.Create(takUint8, DecResult.ByteLength);
+  for I := 0 to DecResult.ByteLength - 1 do
+    NewTA.BufferData[NewTA.ByteOffset + I] := DecResult.Bytes[I];
+
+  Result := NewTA;
+end;
+
+// ES2026 §5.2.2 Uint8Array.fromHex(string)
+function TGocciaUint8ArrayEncoding.FromHex(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Input: string;
+  I, ByteLen, Hi, Lo: Integer;
+  NewTA: TGocciaTypedArrayValue;
+begin
+  if AArgs.Length = 0 then
+    ThrowTypeError('Uint8Array.fromHex requires a string argument');
+  if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
+    ThrowTypeError('Uint8Array.fromHex: first argument must be a string');
+
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  if (Length(Input) mod 2) <> 0 then
+    ThrowSyntaxError('Invalid hex string: odd length');
+
+  ByteLen := Length(Input) div 2;
+  NewTA := TGocciaTypedArrayValue.Create(takUint8, ByteLen);
+
+  for I := 0 to ByteLen - 1 do
+  begin
+    Hi := HexCharToNibble(Input[I * 2 + 1]);
+    Lo := HexCharToNibble(Input[I * 2 + 2]);
+    if (Hi < 0) or (Lo < 0) then
+      ThrowSyntaxError('Invalid character in hex string');
+    NewTA.BufferData[NewTA.ByteOffset + I] := Byte((Hi shl 4) or Lo);
+  end;
+
+  Result := NewTA;
+end;
+
+end.

--- a/units/Goccia.Values.Uint8ArrayEncoding.pas
+++ b/units/Goccia.Values.Uint8ArrayEncoding.pas
@@ -28,6 +28,7 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.GarbageCollector,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue,
   Goccia.Values.TypedArrayValue;
@@ -394,42 +395,32 @@ begin
 
   SetLength(Result.Bytes, Result.ByteLength);
 
-  // Step 7: Decode full 4-char chunks
+  // Step 7: Decode full 4-char chunks — only consume when all 3 output bytes fit
   Pos := 1;
   OutPos := 0;
   for I := 0 to FullChunks - 1 do
   begin
-    if OutPos >= Result.ByteLength then Break;
+    if OutPos + 3 > Result.ByteLength then Break;
     V0 := DecodeTable[Ord(Cleaned[Pos])];
     V1 := DecodeTable[Ord(Cleaned[Pos + 1])];
     V2 := DecodeTable[Ord(Cleaned[Pos + 2])];
     V3 := DecodeTable[Ord(Cleaned[Pos + 3])];
-    if OutPos < Result.ByteLength then
-    begin
-      Result.Bytes[OutPos] := (V0 shl 2) or (V1 shr 4);
-      Inc(OutPos);
-    end;
-    if OutPos < Result.ByteLength then
-    begin
-      Result.Bytes[OutPos] := ((V1 and $0F) shl 4) or (V2 shr 2);
-      Inc(OutPos);
-    end;
-    if OutPos < Result.ByteLength then
-    begin
-      Result.Bytes[OutPos] := ((V2 and $03) shl 6) or V3;
-      Inc(OutPos);
-    end;
+    Result.Bytes[OutPos]     := (V0 shl 2) or (V1 shr 4);
+    Result.Bytes[OutPos + 1] := ((V1 and $0F) shl 4) or (V2 shr 2);
+    Result.Bytes[OutPos + 2] := ((V2 and $03) shl 6) or V3;
+    Inc(OutPos, 3);
     Inc(Pos, 4);
   end;
 
-  // Step 8: Decode remainder
-  if (Remainder >= 2) and (OutPos < Result.ByteLength) then
+  // Step 8: Decode remainder — only consume when all output bytes fit
+  // 2 trailing chars → 1 byte; 3 trailing chars → 2 bytes
+  if (Remainder >= 2) and (OutPos + (Remainder - 1) <= Result.ByteLength) then
   begin
     V0 := DecodeTable[Ord(Cleaned[Pos])];
     V1 := DecodeTable[Ord(Cleaned[Pos + 1])];
     Result.Bytes[OutPos] := (V0 shl 2) or (V1 shr 4);
     Inc(OutPos);
-    if (Remainder >= 3) and (OutPos < Result.ByteLength) then
+    if Remainder >= 3 then
     begin
       V2 := DecodeTable[Ord(Cleaned[Pos + 2])];
       Result.Bytes[OutPos] := ((V1 and $0F) shl 4) or (V2 shr 2);
@@ -566,9 +557,14 @@ begin
     TA.BufferData[TA.ByteOffset + I] := DecResult.Bytes[I];
 
   ResultObj := TGocciaObjectValue.Create;
-  ResultObj.AssignProperty(PROP_READ, TGocciaNumberLiteralValue.Create(DecResult.CharsRead));
-  ResultObj.AssignProperty(PROP_WRITTEN, TGocciaNumberLiteralValue.Create(Written));
-  Result := ResultObj;
+  TGarbageCollector.Instance.AddTempRoot(ResultObj);
+  try
+    ResultObj.AssignProperty(PROP_READ, TGocciaNumberLiteralValue.Create(DecResult.CharsRead));
+    ResultObj.AssignProperty(PROP_WRITTEN, TGocciaNumberLiteralValue.Create(Written));
+    Result := ResultObj;
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(ResultObj);
+  end;
 end;
 
 // ES2026 §5.1.4 Uint8Array.prototype.setFromHex(string)
@@ -612,9 +608,14 @@ begin
     CharsRead := 0;
 
   ResultObj := TGocciaObjectValue.Create;
-  ResultObj.AssignProperty(PROP_READ, TGocciaNumberLiteralValue.Create(CharsRead));
-  ResultObj.AssignProperty(PROP_WRITTEN, TGocciaNumberLiteralValue.Create(Written));
-  Result := ResultObj;
+  TGarbageCollector.Instance.AddTempRoot(ResultObj);
+  try
+    ResultObj.AssignProperty(PROP_READ, TGocciaNumberLiteralValue.Create(CharsRead));
+    ResultObj.AssignProperty(PROP_WRITTEN, TGocciaNumberLiteralValue.Create(Written));
+    Result := ResultObj;
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(ResultObj);
+  end;
 end;
 
 // ES2026 §5.2.1 Uint8Array.fromBase64(string [, options])


### PR DESCRIPTION
## Summary
- Adds `Uint8Array.fromBase64`, `Uint8Array.fromHex`, `Uint8Array.prototype.toBase64`, `Uint8Array.prototype.toHex`, `Uint8Array.prototype.setFromBase64`, and `Uint8Array.prototype.setFromHex`.
- Limits the new encoding APIs to `Uint8Array` and wires them into engine/runtime bootstrap and typed array prototype setup.
- Extends the built-ins documentation and adds coverage for decoding, encoding, option handling, whitespace handling, and error cases.

## Testing
- Not run in this environment.
- Added JavaScript tests under `tests/built-ins/TypedArray/` for `fromBase64`, `fromHex`, `toBase64`, `toHex`, `setFromBase64`, and `setFromHex`.
- Coverage includes standard and URL-safe base64 alphabets, padding behavior, partial chunks, invalid input, and non-`Uint8Array` receiver checks.