### PR TITLE
Add Object.getOwnPropertyDescriptors support

### DIFF
--- a/tests/built-ins/Object/getOwnPropertyDescriptors.js
+++ b/tests/built-ins/Object/getOwnPropertyDescriptors.js
@@ -205,6 +205,12 @@ describe("Object.getOwnPropertyDescriptors", () => {
     expect(descs.a.configurable).toBe(false);
   });
 
+  test("ignores extra arguments", () => {
+    const obj = { a: 1 };
+    const descs = Object.getOwnPropertyDescriptors(obj, "extra", 123);
+    expect(descs.a.value).toBe(1);
+  });
+
   test("can be used with Object.defineProperties for shallow clone", () => {
     const original = { x: 1, y: 2 };
     Object.defineProperty(original, "z", {

--- a/tests/built-ins/Object/getOwnPropertyDescriptors.js
+++ b/tests/built-ins/Object/getOwnPropertyDescriptors.js
@@ -1,0 +1,225 @@
+describe("Object.getOwnPropertyDescriptors", () => {
+  test("returns descriptors for all own string-keyed data properties", () => {
+    const obj = { a: 1, b: 2 };
+    const descs = Object.getOwnPropertyDescriptors(obj);
+
+    expect(descs.a).toEqual({
+      value: 1,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    expect(descs.b).toEqual({
+      value: 2,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+
+  test("returns descriptors for non-enumerable properties", () => {
+    const obj = {};
+    Object.defineProperty(obj, "hidden", {
+      value: 42,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(descs.hidden).toEqual({
+      value: 42,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  });
+
+  test("returns descriptors for accessor properties", () => {
+    const obj = {};
+    let value = 10;
+    const getter = () => value;
+    const setter = (v) => { value = v; };
+    Object.defineProperty(obj, "prop", {
+      get: getter,
+      set: setter,
+      enumerable: true,
+      configurable: true,
+    });
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(descs.prop.get).toBe(getter);
+    expect(descs.prop.set).toBe(setter);
+    expect(descs.prop.enumerable).toBe(true);
+    expect(descs.prop.configurable).toBe(true);
+    expect(descs.prop.value).toBeUndefined();
+    expect(descs.prop.writable).toBeUndefined();
+  });
+
+  test("returns descriptors for getter-only accessor", () => {
+    const obj = {};
+    const getter = () => 99;
+    Object.defineProperty(obj, "readOnly", {
+      get: getter,
+      enumerable: false,
+      configurable: true,
+    });
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(descs.readOnly.get).toBe(getter);
+    expect(descs.readOnly.set).toBeUndefined();
+    expect(descs.readOnly.enumerable).toBe(false);
+    expect(descs.readOnly.configurable).toBe(true);
+  });
+
+  test("returns descriptors for setter-only accessor", () => {
+    const obj = {};
+    let stored;
+    const setter = (v) => { stored = v; };
+    Object.defineProperty(obj, "writeOnly", {
+      set: setter,
+      enumerable: true,
+      configurable: false,
+    });
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(descs.writeOnly.get).toBeUndefined();
+    expect(descs.writeOnly.set).toBe(setter);
+    expect(descs.writeOnly.enumerable).toBe(true);
+    expect(descs.writeOnly.configurable).toBe(false);
+  });
+
+  test("returns descriptors for symbol-keyed properties", () => {
+    const sym = Symbol("mySymbol");
+    const obj = {};
+    obj[sym] = "symbolValue";
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(descs[sym]).toEqual({
+      value: "symbolValue",
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+
+  test("returns descriptors for both string and symbol keys", () => {
+    const sym = Symbol("s");
+    const obj = { name: "test" };
+    obj[sym] = 42;
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(descs.name.value).toBe("test");
+    expect(descs[sym].value).toBe(42);
+  });
+
+  test("returns empty object for object with no own properties", () => {
+    const obj = Object.create({ inherited: true });
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(Object.keys(descs).length).toBe(0);
+  });
+
+  test("does not include inherited properties", () => {
+    const parent = { parentProp: 1 };
+    const child = Object.create(parent);
+    child.childProp = 2;
+
+    const descs = Object.getOwnPropertyDescriptors(child);
+    expect(descs.childProp).toEqual({
+      value: 2,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    expect(descs.parentProp).toBeUndefined();
+  });
+
+  test("handles mixed data and accessor properties", () => {
+    const obj = { x: 1 };
+    Object.defineProperty(obj, "y", {
+      get: () => 2,
+      enumerable: true,
+      configurable: true,
+    });
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+
+    expect(descs.x.value).toBe(1);
+    expect(descs.x.writable).toBe(true);
+
+    expect(descs.y.get).toBeDefined();
+    expect(descs.y.value).toBeUndefined();
+  });
+
+  test("preserves all descriptor attributes from defineProperty", () => {
+    const obj = {};
+    Object.defineProperty(obj, "a", {
+      value: 1,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+    Object.defineProperty(obj, "b", {
+      value: 2,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+
+    expect(descs.a.writable).toBe(true);
+    expect(descs.a.enumerable).toBe(false);
+    expect(descs.a.configurable).toBe(true);
+
+    expect(descs.b.writable).toBe(false);
+    expect(descs.b.enumerable).toBe(true);
+    expect(descs.b.configurable).toBe(false);
+  });
+
+  test("throws TypeError for non-object argument", () => {
+    expect(() => Object.getOwnPropertyDescriptors(42)).toThrow();
+    expect(() => Object.getOwnPropertyDescriptors("str")).toThrow();
+    expect(() => Object.getOwnPropertyDescriptors(true)).toThrow();
+    expect(() => Object.getOwnPropertyDescriptors(null)).toThrow();
+    expect(() => Object.getOwnPropertyDescriptors(undefined)).toThrow();
+  });
+
+  test("works with frozen objects", () => {
+    const obj = { a: 1 };
+    Object.freeze(obj);
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(descs.a.value).toBe(1);
+    expect(descs.a.writable).toBe(false);
+    expect(descs.a.configurable).toBe(false);
+  });
+
+  test("works with sealed objects", () => {
+    const obj = { a: 1 };
+    Object.seal(obj);
+
+    const descs = Object.getOwnPropertyDescriptors(obj);
+    expect(descs.a.value).toBe(1);
+    expect(descs.a.writable).toBe(true);
+    expect(descs.a.configurable).toBe(false);
+  });
+
+  test("can be used with Object.defineProperties for shallow clone", () => {
+    const original = { x: 1, y: 2 };
+    Object.defineProperty(original, "z", {
+      value: 3,
+      enumerable: false,
+    });
+
+    const clone = Object.create(Object.getPrototypeOf(original));
+    Object.defineProperties(clone, Object.getOwnPropertyDescriptors(original));
+
+    expect(clone.x).toBe(1);
+    expect(clone.y).toBe(2);
+    expect(clone.z).toBe(3);
+
+    const cloneDescs = Object.getOwnPropertyDescriptors(clone);
+    expect(cloneDescs.z.enumerable).toBe(false);
+  });
+});

--- a/units/Goccia.Builtins.GlobalObject.pas
+++ b/units/Goccia.Builtins.GlobalObject.pas
@@ -29,6 +29,7 @@ type
     function ObjectHasOwn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectGetOwnPropertyNames(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectGetOwnPropertyDescriptor(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ObjectGetOwnPropertyDescriptors(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectDefineProperty(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectDefineProperties(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectGetOwnPropertySymbols(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -79,6 +80,7 @@ begin
     Members.AddMethod(ObjectHasOwn, 2, gmkStaticMethod);
     Members.AddMethod(ObjectGetOwnPropertyNames, 1, gmkStaticMethod);
     Members.AddMethod(ObjectGetOwnPropertyDescriptor, 2, gmkStaticMethod);
+    Members.AddMethod(ObjectGetOwnPropertyDescriptors, 1, gmkStaticMethod);
     Members.AddMethod(ObjectDefineProperty, 3, gmkStaticMethod);
     Members.AddMethod(ObjectDefineProperties, 2, gmkStaticMethod);
     Members.AddMethod(ObjectGetOwnPropertySymbols, 1, gmkStaticMethod);
@@ -383,6 +385,85 @@ begin
 
     Result := DescriptorObj;
   end;
+end;
+
+// ES2026 §20.1.2.7 Object.getOwnPropertyDescriptors(O)
+function TGocciaGlobalObject.ObjectGetOwnPropertyDescriptors(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+
+  function FromPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor): TGocciaObjectValue;
+  begin
+    Result := TGocciaObjectValue.Create;
+    if ADescriptor.Enumerable then
+      Result.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      Result.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
+    if ADescriptor.Configurable then
+      Result.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      Result.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
+
+    if ADescriptor is TGocciaPropertyDescriptorData then
+    begin
+      Result.AssignProperty(PROP_VALUE, TGocciaPropertyDescriptorData(ADescriptor).Value);
+      if ADescriptor.Writable then
+        Result.AssignProperty(PROP_WRITABLE, TGocciaBooleanLiteralValue.TrueValue)
+      else
+        Result.AssignProperty(PROP_WRITABLE, TGocciaBooleanLiteralValue.FalseValue);
+    end
+    else if ADescriptor is TGocciaPropertyDescriptorAccessor then
+    begin
+      if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Getter) then
+        Result.AssignProperty(PROP_GET, TGocciaPropertyDescriptorAccessor(ADescriptor).Getter)
+      else
+        Result.AssignProperty(PROP_GET, TGocciaUndefinedLiteralValue.UndefinedValue);
+
+      if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Setter) then
+        Result.AssignProperty(PROP_SET, TGocciaPropertyDescriptorAccessor(ADescriptor).Setter)
+      else
+        Result.AssignProperty(PROP_SET, TGocciaUndefinedLiteralValue.UndefinedValue);
+    end;
+  end;
+
+var
+  Obj, Descriptors: TGocciaObjectValue;
+  PropertyNames: TArray<string>;
+  OwnSymbols: TArray<TGocciaSymbolValue>;
+  Descriptor: TGocciaPropertyDescriptor;
+  I: Integer;
+begin
+  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.getOwnPropertyDescriptors', ThrowError);
+
+  // Step 1: Let obj be ? ToObject(O)
+  if not (AArgs.GetElement(0) is TGocciaObjectValue) then
+    ThrowError('Object.getOwnPropertyDescriptors called on non-object', 0, 0);
+
+  Obj := TGocciaObjectValue(AArgs.GetElement(0));
+  // Step 2: Let ownKeys be ? obj.[[OwnPropertyKeys]]()
+  // Step 3: Let descriptors be OrdinaryObjectCreate(%Object.prototype%)
+  Descriptors := TGocciaObjectValue.Create;
+
+  // Step 4: For each element key of ownKeys (string keys)
+  PropertyNames := Obj.GetAllPropertyNames;
+  for I := 0 to High(PropertyNames) do
+  begin
+    // Step 4a: Let desc be ? obj.[[GetOwnProperty]](key)
+    Descriptor := Obj.GetOwnPropertyDescriptor(PropertyNames[I]);
+    // Step 4b-c: Let descriptor be FromPropertyDescriptor(desc) and add to result
+    if Descriptor <> nil then
+      Descriptors.AssignProperty(PropertyNames[I], FromPropertyDescriptor(Descriptor));
+  end;
+
+  // Step 4 continued: For each element key of ownKeys (symbol keys)
+  OwnSymbols := Obj.GetOwnSymbols;
+  for I := 0 to High(OwnSymbols) do
+  begin
+    Descriptor := Obj.GetOwnSymbolPropertyDescriptor(OwnSymbols[I]);
+    if Descriptor <> nil then
+      Descriptors.AssignSymbolProperty(OwnSymbols[I], FromPropertyDescriptor(Descriptor));
+  end;
+
+  // Step 5: Return descriptors
+  Result := Descriptors;
 end;
 
 // ES2026 §20.1.2.3 Object.defineProperty(O, P, Attributes)

--- a/units/Goccia.Builtins.GlobalObject.pas
+++ b/units/Goccia.Builtins.GlobalObject.pas
@@ -63,6 +63,41 @@ uses
   Goccia.Values.ProxyValue,
   Goccia.Values.SymbolValue;
 
+// ES2026 §6.2.6.4 FromPropertyDescriptor(Desc)
+function FromPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor): TGocciaObjectValue;
+begin
+  Result := TGocciaObjectValue.Create;
+  if ADescriptor.Enumerable then
+    Result.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
+  else
+    Result.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
+  if ADescriptor.Configurable then
+    Result.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
+  else
+    Result.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
+
+  if ADescriptor is TGocciaPropertyDescriptorData then
+  begin
+    Result.AssignProperty(PROP_VALUE, TGocciaPropertyDescriptorData(ADescriptor).Value);
+    if ADescriptor.Writable then
+      Result.AssignProperty(PROP_WRITABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      Result.AssignProperty(PROP_WRITABLE, TGocciaBooleanLiteralValue.FalseValue);
+  end
+  else if ADescriptor is TGocciaPropertyDescriptorAccessor then
+  begin
+    if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Getter) then
+      Result.AssignProperty(PROP_GET, TGocciaPropertyDescriptorAccessor(ADescriptor).Getter)
+    else
+      Result.AssignProperty(PROP_GET, TGocciaUndefinedLiteralValue.UndefinedValue);
+
+    if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Setter) then
+      Result.AssignProperty(PROP_SET, TGocciaPropertyDescriptorAccessor(ADescriptor).Setter)
+    else
+      Result.AssignProperty(PROP_SET, TGocciaUndefinedLiteralValue.UndefinedValue);
+  end;
+end;
+
 constructor TGocciaGlobalObject.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
   Members: TGocciaMemberCollection;
@@ -327,7 +362,7 @@ end;
 // ES2026 §20.1.2.6 Object.getOwnPropertyDescriptor(O, P)
 function TGocciaGlobalObject.ObjectGetOwnPropertyDescriptor(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Obj, DescriptorObj: TGocciaObjectValue;
+  Obj: TGocciaObjectValue;
   Descriptor: TGocciaPropertyDescriptor;
   PropertyName: string;
 begin
@@ -349,81 +384,13 @@ begin
   end;
   // Step 4: Return FromPropertyDescriptor(desc)
   if Descriptor = nil then
-  begin
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  end else begin
-    DescriptorObj := TGocciaObjectValue.Create;
-    if Descriptor.Enumerable then
-      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
-    if Descriptor.Configurable then
-      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
-
-    if Descriptor is TGocciaPropertyDescriptorData then
-    begin
-      DescriptorObj.AssignProperty(PROP_VALUE, TGocciaPropertyDescriptorData(Descriptor).Value);
-      if Descriptor.Writable then
-        DescriptorObj.AssignProperty(PROP_WRITABLE, TGocciaBooleanLiteralValue.TrueValue)
-      else
-        DescriptorObj.AssignProperty(PROP_WRITABLE, TGocciaBooleanLiteralValue.FalseValue);
-    end
-    else if Descriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      if Assigned(TGocciaPropertyDescriptorAccessor(Descriptor).Getter) then
-        DescriptorObj.AssignProperty(PROP_GET, TGocciaPropertyDescriptorAccessor(Descriptor).Getter)
-      else
-        DescriptorObj.AssignProperty(PROP_GET, TGocciaUndefinedLiteralValue.UndefinedValue);
-
-      if Assigned(TGocciaPropertyDescriptorAccessor(Descriptor).Setter) then
-        DescriptorObj.AssignProperty(PROP_SET, TGocciaPropertyDescriptorAccessor(Descriptor).Setter)
-      else
-        DescriptorObj.AssignProperty(PROP_SET, TGocciaUndefinedLiteralValue.UndefinedValue);
-    end;
-
-    Result := DescriptorObj;
-  end;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue
+  else
+    Result := FromPropertyDescriptor(Descriptor);
 end;
 
 // ES2026 §20.1.2.7 Object.getOwnPropertyDescriptors(O)
 function TGocciaGlobalObject.ObjectGetOwnPropertyDescriptors(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-
-  function FromPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor): TGocciaObjectValue;
-  begin
-    Result := TGocciaObjectValue.Create;
-    if ADescriptor.Enumerable then
-      Result.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      Result.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
-    if ADescriptor.Configurable then
-      Result.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      Result.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
-
-    if ADescriptor is TGocciaPropertyDescriptorData then
-    begin
-      Result.AssignProperty(PROP_VALUE, TGocciaPropertyDescriptorData(ADescriptor).Value);
-      if ADescriptor.Writable then
-        Result.AssignProperty(PROP_WRITABLE, TGocciaBooleanLiteralValue.TrueValue)
-      else
-        Result.AssignProperty(PROP_WRITABLE, TGocciaBooleanLiteralValue.FalseValue);
-    end
-    else if ADescriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Getter) then
-        Result.AssignProperty(PROP_GET, TGocciaPropertyDescriptorAccessor(ADescriptor).Getter)
-      else
-        Result.AssignProperty(PROP_GET, TGocciaUndefinedLiteralValue.UndefinedValue);
-
-      if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Setter) then
-        Result.AssignProperty(PROP_SET, TGocciaPropertyDescriptorAccessor(ADescriptor).Setter)
-      else
-        Result.AssignProperty(PROP_SET, TGocciaUndefinedLiteralValue.UndefinedValue);
-    end;
-  end;
-
 var
   Obj, Descriptors: TGocciaObjectValue;
   PropertyNames: TArray<string>;
@@ -431,7 +398,7 @@ var
   Descriptor: TGocciaPropertyDescriptor;
   I: Integer;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.getOwnPropertyDescriptors', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.getOwnPropertyDescriptors', ThrowError);
 
   // Step 1: Let obj be ? ToObject(O)
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then


### PR DESCRIPTION
## Summary
- Add `Object.getOwnPropertyDescriptors` to the global object implementation.
- Return full property descriptor maps for both string and symbol own properties, including data and accessor descriptors.
- Add end-to-end coverage for enumerable, non-enumerable, accessor, symbol-keyed, frozen, sealed, and error cases.

## Testing
- Not run: `./build.pas testrunner && ./build/TestRunner tests`
- Not run: targeted verification of `tests/built-ins/Object/getOwnPropertyDescriptors.js`