### PR TITLE
Implement import.meta support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | Proxy | `Goccia.Values.ProxyValue.pas` | ES2026 Proxy with all 13 handler traps and invariant enforcement |
 | Uint8Array encoding | `Goccia.Values.Uint8ArrayEncoding.pas` | Uint8Array Base64/Hex: `toBase64`, `fromBase64`, `toHex`, `fromHex`, `setFromBase64`, `setFromHex` |
 | FFI | `Goccia.FFI*.pas`, `Goccia.Values.FFI*.pas` | Foreign Function Interface for native shared libraries |
+| import.meta | `Goccia.ImportMeta.pas` | Per-module metadata object with `url` and `resolve()` (ES2026 §13.3.12) |
 
 **Bytecode design rules:**
 
@@ -443,7 +444,7 @@ See [docs/testing.md](docs/testing.md) for the complete testing guide.
 - **Secondary:** Pascal unit tests in `units/*.Test.pas`
 - **JS test framework:** `describe`/`test`/`expect` with async support, `.resolves`/`.rejects`, mock functions (`mock()`/`spyOn()`), lifecycle hooks, and Vitest-compatible matchers
 - **Key matchers:** `.toBe`, `.toEqual`, `.toContain`, `.toMatch`, `.toThrow(ErrorType)`, `.toHaveBeenCalledWith(...)`, plus `.not` negation
-- **Test directories:** Organized by feature under `tests/language/` (includes `async-await/` with top-level await, `for-of/` with top-level for-await-of) and `tests/built-ins/` (includes `Proxy/` with all 13 trap test files, `FFI/` with library loading and binding tests)
+- **Test directories:** Organized by feature under `tests/language/` (includes `async-await/` with top-level await, `for-of/` with top-level for-await-of, `modules/` with import.meta tests) and `tests/built-ins/` (includes `Proxy/` with all 13 trap test files, `FFI/` with library loading and binding tests)
 - **Pascal test framework:** Generic `Expect<T>(...).ToBe(...)` assertions. NaN checks: use `Value.ToNumberLiteral.IsNaN` (not `Math.IsNaN`)
 
 ## Build System

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -61,7 +61,7 @@ In the current VM:
 
 - core instructions cover hot execution paths such as locals, arithmetic, comparisons, property/index access, calls, construction, iteration, and class/object setup
 - semantic instructions already include generic arithmetic and bitwise operations in `128..140`
-- module and async orchestration currently starts at `167` (`IMPORT`, `EXPORT`, `AWAIT`)
+- module and async orchestration currently starts at `167` (`IMPORT`, `EXPORT`, `AWAIT`, `IMPORT_META`)
 
 The current encoding helpers are defined in `Goccia.Bytecode.pas`:
 
@@ -86,7 +86,7 @@ Current instruction families:
 - object and array operations
 - class construction and member definition
 - calls, construction, iteration, globals, and string coercion
-- semantic-only imports/exports and await
+- semantic-only imports/exports, import.meta, and await
 
 Some opcode families intentionally use flags or mode operands instead of one opcode per syntax form. For example:
 

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -264,6 +264,19 @@ Warning: Wildcard re-exports (export * from ...) are not supported in GocciaScri
   --> script.js:2:1
 ```
 
+`import.meta` (ES2026 §13.3.12) is supported and provides per-module metadata. The `import.meta` object has a null prototype and is identity-stable — the same object is returned on every access within the same module. Two host-defined properties are available:
+
+- **`import.meta.url`** — a `file://` URL string for the current module's absolute path (e.g., `file:///Users/me/project/src/main.js`).
+- **`import.meta.resolve(specifier)`** — a synchronous function that resolves a module specifier relative to the current module's directory and returns the resolved `file://` URL string. Throws `TypeError` if called without arguments.
+
+```javascript
+// Access the current module's URL
+const currentUrl = import.meta.url;
+
+// Resolve a sibling module's path
+const helperUrl = import.meta.resolve("./helpers/math.js");
+```
+
 Dynamic `import()` is parsed as a normal call expression. Because there is no global `import` binding in GocciaScript, calling it currently fails at runtime with `ReferenceError` unless user code defines its own `import` identifier.
 
 ### Data Structures

--- a/tests/language/modules/helpers/import-meta-child.js
+++ b/tests/language/modules/helpers/import-meta-child.js
@@ -1,0 +1,2 @@
+export const childUrl = import.meta.url;
+export const childMeta = import.meta;

--- a/tests/language/modules/helpers/import-meta-function.js
+++ b/tests/language/modules/helpers/import-meta-function.js
@@ -1,0 +1,1 @@
+export const getUrl = () => import.meta.url;

--- a/tests/language/modules/import-meta.js
+++ b/tests/language/modules/import-meta.js
@@ -66,6 +66,16 @@ describe("import.meta", () => {
     expect(resolved).toBe("file:///absolute/path/file.js");
   });
 
+  test("import.meta.resolve percent-encodes special characters", () => {
+    const resolved = import.meta.resolve("/path with spaces/file#1.js");
+    expect(resolved).toBe("file:///path%20with%20spaces/file%231.js");
+  });
+
+  test("import.meta.url percent-encodes spaces in the path", () => {
+    // The URL should not contain raw spaces
+    expect(import.meta.url.includes(" ")).toBe(false);
+  });
+
   test("import.meta.resolve throws without arguments", () => {
     expect(() => import.meta.resolve()).toThrow(TypeError);
   });

--- a/tests/language/modules/import-meta.js
+++ b/tests/language/modules/import-meta.js
@@ -61,6 +61,11 @@ describe("import.meta", () => {
     expect(resolved.includes("helpers/math.js")).toBe(true);
   });
 
+  test("import.meta.resolve handles absolute paths", () => {
+    const resolved = import.meta.resolve("/absolute/path/file.js");
+    expect(resolved).toBe("file:///absolute/path/file.js");
+  });
+
   test("import.meta.resolve throws without arguments", () => {
     expect(() => import.meta.resolve()).toThrow(TypeError);
   });

--- a/tests/language/modules/import-meta.js
+++ b/tests/language/modules/import-meta.js
@@ -1,0 +1,89 @@
+import { childUrl, childMeta } from "./helpers/import-meta-child.js";
+
+describe("import.meta", () => {
+  test("import.meta is an object", () => {
+    expect(typeof import.meta).toBe("object");
+  });
+
+  test("import.meta has null prototype", () => {
+    expect(Object.getPrototypeOf(import.meta)).toBe(null);
+  });
+
+  test("import.meta.url is a string", () => {
+    expect(typeof import.meta.url).toBe("string");
+  });
+
+  test("import.meta.url starts with file://", () => {
+    expect(import.meta.url.startsWith("file://")).toBe(true);
+  });
+
+  test("import.meta.url contains the current file name", () => {
+    expect(import.meta.url.includes("import-meta.js")).toBe(true);
+  });
+
+  test("import.meta.url is an absolute path", () => {
+    // file:// URLs have at least three slashes
+    expect(import.meta.url.startsWith("file:///")).toBe(true);
+  });
+
+  test("import.meta is identity-stable", () => {
+    const a = import.meta;
+    const b = import.meta;
+    expect(a === b).toBe(true);
+  });
+
+  test("import.meta properties are writable", () => {
+    // Per spec, import.meta properties are configurable and writable
+    import.meta.custom = "test";
+    expect(import.meta.custom).toBe("test");
+  });
+
+  test("import.meta.resolve is a function", () => {
+    expect(typeof import.meta.resolve).toBe("function");
+  });
+
+  test("import.meta.resolve returns a file:// URL", () => {
+    const resolved = import.meta.resolve("./helpers/math.js");
+    expect(typeof resolved).toBe("string");
+    expect(resolved.startsWith("file://")).toBe(true);
+  });
+
+  test("import.meta.resolve resolves relative paths", () => {
+    const resolved = import.meta.resolve("./helpers/math.js");
+    expect(resolved.includes("helpers/math.js")).toBe(true);
+    // Should not contain ./ in the resolved path
+    expect(resolved.includes("./")).toBe(false);
+  });
+
+  test("import.meta.resolve resolves parent directory paths", () => {
+    const resolved = import.meta.resolve("../modules/helpers/math.js");
+    expect(resolved.includes("helpers/math.js")).toBe(true);
+  });
+
+  test("import.meta.resolve throws without arguments", () => {
+    expect(() => import.meta.resolve()).toThrow(TypeError);
+  });
+
+  test("import.meta can be stored in a variable", () => {
+    const meta = import.meta;
+    expect(meta.url).toBe(import.meta.url);
+  });
+
+  test("import.meta.url in nested expression", () => {
+    const parts = import.meta.url.split("/");
+    expect(parts[parts.length - 1]).toBe("import-meta.js");
+  });
+
+  test("child module has different import.meta.url", () => {
+    expect(childUrl).not.toBe(import.meta.url);
+    expect(childUrl.includes("import-meta-child.js")).toBe(true);
+  });
+
+  test("child module import.meta is a different object", () => {
+    expect(childMeta).not.toBe(import.meta);
+  });
+
+  test("child module import.meta.url starts with file://", () => {
+    expect(childUrl.startsWith("file://")).toBe(true);
+  });
+});

--- a/tests/language/modules/import-meta.js
+++ b/tests/language/modules/import-meta.js
@@ -1,4 +1,5 @@
 import { childUrl, childMeta } from "./helpers/import-meta-child.js";
+import { getUrl } from "./helpers/import-meta-function.js";
 
 describe("import.meta", () => {
   test("import.meta is an object", () => {
@@ -85,5 +86,13 @@ describe("import.meta", () => {
 
   test("child module import.meta.url starts with file://", () => {
     expect(childUrl.startsWith("file://")).toBe(true);
+  });
+
+  test("exported function preserves lexical import.meta binding", () => {
+    // import.meta binds lexically: an exported function should report
+    // the defining module's URL, not the calling module's URL
+    const fnUrl = getUrl();
+    expect(fnUrl.includes("import-meta-function.js")).toBe(true);
+    expect(fnUrl).not.toBe(import.meta.url);
   });
 });

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -1439,7 +1439,7 @@ begin
   end;
 end;
 
-// ES2026 §13.3.12.1 Runtime Semantics: Evaluation — ImportMeta
+// ES2026 §13.3.12.1 ImportMeta : import . meta
 function TGocciaImportMetaExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 begin
   Result := GetOrCreateImportMeta(AContext.CurrentFilePath);

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -382,6 +382,11 @@ type
     function Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue; override;
   end;
 
+  TGocciaImportMetaExpression = class(TGocciaExpression)
+  public
+    function Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue; override;
+  end;
+
   TGocciaHoleExpression = class(TGocciaExpression)
   public
     constructor Create(const ALine, AColumn: Integer);
@@ -553,6 +558,7 @@ uses
   Goccia.Evaluator.Arithmetic,
   Goccia.Evaluator.Assignment,
   Goccia.GarbageCollector,
+  Goccia.ImportMeta,
   Goccia.RegExp.Runtime,
   Goccia.Values.ClassValue,
   Goccia.Values.ObjectValue,
@@ -1431,6 +1437,12 @@ begin
     AContext.OnError('super can only be used in a class method', Line, Column);
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
+end;
+
+// ES2026 §13.3.12.1 Runtime Semantics: Evaluation — ImportMeta
+function TGocciaImportMetaExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
+begin
+  Result := GetOrCreateImportMeta(AContext.CurrentFilePath);
 end;
 
 function TGocciaHoleExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;

--- a/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/units/Goccia.Bytecode.OpCodeNames.pas
@@ -141,6 +141,7 @@ begin
     OP_IMPORT:                         Result := 'OP_IMPORT';
     OP_EXPORT:                         Result := 'OP_EXPORT';
     OP_AWAIT:                          Result := 'OP_AWAIT';
+    OP_IMPORT_META:                    Result := 'OP_IMPORT_META';
   else
     Result := Format('OP_UNKNOWN_%d', [AOp]);
   end;

--- a/units/Goccia.Bytecode.pas
+++ b/units/Goccia.Bytecode.pas
@@ -5,7 +5,7 @@ unit Goccia.Bytecode;
 interface
 
 const
-  GOCCIA_FORMAT_VERSION = 9;
+  GOCCIA_FORMAT_VERSION = 10;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;
@@ -150,7 +150,8 @@ type
     OP_USHR          = 140,
     OP_IMPORT        = 167,
     OP_EXPORT        = 168,
-    OP_AWAIT         = 169
+    OP_AWAIT         = 169,
+    OP_IMPORT_META   = 170
   );
 
 function EncodeABC(const AOp: TGocciaOpCode; const A, B, C: UInt8): UInt32; inline;

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -74,6 +74,8 @@ procedure CompileThis(const ACtx: TGocciaCompilationContext;
   const ADest: UInt8);
 procedure CompileSuperAccess(const ACtx: TGocciaCompilationContext;
   const ADest: UInt8);
+procedure CompileImportMeta(const ACtx: TGocciaCompilationContext;
+  const ADest: UInt8);
 
 procedure EmitDefaultParameters(const ACtx: TGocciaCompilationContext;
   const AParams: TGocciaParameterArray);
@@ -2444,6 +2446,12 @@ begin
   end;
 
   EmitInstruction(ACtx, EncodeABC(OP_LOAD_UNDEFINED, ADest, 0, 0));
+end;
+
+procedure CompileImportMeta(const ACtx: TGocciaCompilationContext;
+  const ADest: UInt8);
+begin
+  EmitInstruction(ACtx, EncodeABC(OP_IMPORT_META, ADest, 0, 0));
 end;
 
 end.

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -2448,6 +2448,7 @@ begin
   EmitInstruction(ACtx, EncodeABC(OP_LOAD_UNDEFINED, ADest, 0, 0));
 end;
 
+// ES2026 §13.3.12 MetaProperty — import.meta
 procedure CompileImportMeta(const ACtx: TGocciaCompilationContext;
   const ADest: UInt8);
 begin

--- a/units/Goccia.Compiler.pas
+++ b/units/Goccia.Compiler.pas
@@ -152,6 +152,8 @@ begin
   begin
     Goccia.Compiler.Expressions.CompileSuperAccess(Ctx, ADest);
   end
+  else if AExpr is TGocciaImportMetaExpression then
+    Goccia.Compiler.Expressions.CompileImportMeta(Ctx, ADest)
   else if AExpr is TGocciaPrivatePropertyCompoundAssignmentExpression then
     Goccia.Compiler.Expressions.CompilePrivatePropertyCompoundAssignment(Ctx,
       TGocciaPrivatePropertyCompoundAssignmentExpression(AExpr), ADest)

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -61,6 +61,8 @@ const
   PROP_BYTES_PER_ELEMENT = 'BYTES_PER_ELEMENT';
   PROP_FROM             = 'from';
   PROP_OF               = 'of';
+  PROP_URL              = 'url';
+  PROP_RESOLVE          = 'resolve';
   PROP_HAS_OWN_PROPERTY       = 'hasOwnProperty';
   PROP_IS_PROTOTYPE_OF        = 'isPrototypeOf';
   PROP_PROPERTY_IS_ENUMERABLE = 'propertyIsEnumerable';

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -229,6 +229,7 @@ uses
   Goccia.Coverage,
   Goccia.Error,
   Goccia.GarbageCollector,
+  Goccia.ImportMeta,
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.MicrotaskQueue,
@@ -332,6 +333,7 @@ begin
     FBuiltinProxy.Free;
     FBuiltinFFI.Free;
     FBuiltinReflect.Free;
+    ClearImportMetaCache;
     FInjectedGlobals.Free;
     FInterpreter.Free;
     if FOwnsModuleLoader then

--- a/units/Goccia.Error.Suggestions.pas
+++ b/units/Goccia.Error.Suggestions.pas
@@ -105,6 +105,7 @@ resourcestring
   SSuggestComputedPropertyNeedsValue = 'Add '': value'' after the computed property (e.g., [key]: value)';
 
   // Imports and exports
+  SSuggestImportMetaSyntax = 'Use import.meta to access module metadata (e.g., import.meta.url)';
   SSuggestStringImportAs = 'Use: import { "name" as localName } from "module"';
   SSuggestStringExportAs = 'Use: export { localName as "export-name" }';
   SSuggestDestructuringExportDeclareFirst = 'Declare first, then export: const x = ...; export { x };';

--- a/units/Goccia.ImportMeta.pas
+++ b/units/Goccia.ImportMeta.pas
@@ -90,7 +90,7 @@ begin
   FModuleFilePath := AModuleFilePath;
 end;
 
-// ES2026 §13.3.12.1.1 HostGetImportMetaProperties — resolve(specifier)
+// ES2026 §13.3.12.1.1 HostGetImportMetaProperties(moduleRecord)
 function TGocciaImportMetaResolveHelper.Resolve(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
@@ -116,7 +116,7 @@ end;
 
 { Cache functions }
 
-// ES2026 §13.3.12.1 Runtime Semantics: Evaluation — ImportMeta
+// ES2026 §13.3.12.1 ImportMeta : import . meta
 function GetOrCreateImportMeta(const AFilePath: string): TGocciaObjectValue;
 var
   MetaObject: TGocciaObjectValue;
@@ -135,11 +135,11 @@ begin
   // ES2026 §13.3.12.1 step 4a: OrdinaryObjectCreate(null)
   MetaObject := TGocciaObjectValue.Create(nil);
 
-  // ES2026 §13.3.12.1.1 HostGetImportMetaProperties — url
+  // ES2026 §13.3.12.1.1 HostGetImportMetaProperties step: url
   MetaObject.AssignProperty(PROP_URL,
     TGocciaStringLiteralValue.Create(FilePathToUrl(CanonicalPath)));
 
-  // ES2026 §13.3.12.1.1 HostGetImportMetaProperties — resolve
+  // ES2026 §13.3.12.1.1 HostGetImportMetaProperties step: resolve
   ResolveHelper := TGocciaImportMetaResolveHelper.Create(CanonicalPath);
   ResolveFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
     ResolveHelper.Resolve, PROP_RESOLVE, 1);

--- a/units/Goccia.ImportMeta.pas
+++ b/units/Goccia.ImportMeta.pas
@@ -1,0 +1,135 @@
+unit Goccia.ImportMeta;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.GarbageCollector,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaImportMetaResolveHelper = class(TGCManagedObject)
+  private
+    FModuleFilePath: string;
+  public
+    constructor Create(const AModuleFilePath: string);
+    function Resolve(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+function GetOrCreateImportMeta(const AFilePath: string): TGocciaObjectValue;
+function FilePathToUrl(const AFilePath: string): string;
+procedure ClearImportMetaCache;
+
+implementation
+
+uses
+  SysUtils,
+
+  OrderedStringMap,
+
+  Goccia.Constants.PropertyNames,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.NativeFunction;
+
+var
+  ImportMetaCache: TOrderedStringMap<TGocciaObjectValue>;
+
+function FilePathToUrl(const AFilePath: string): string;
+var
+  AbsolutePath: string;
+begin
+  AbsolutePath := ExpandFileName(AFilePath);
+  {$IFDEF MSWINDOWS}
+  AbsolutePath := StringReplace(AbsolutePath, '\', '/', [rfReplaceAll]);
+  Result := 'file:///' + AbsolutePath;
+  {$ELSE}
+  Result := 'file://' + AbsolutePath;
+  {$ENDIF}
+end;
+
+{ TGocciaImportMetaResolveHelper }
+
+constructor TGocciaImportMetaResolveHelper.Create(const AModuleFilePath: string);
+begin
+  inherited Create;
+  FModuleFilePath := AModuleFilePath;
+end;
+
+// ES2026 §13.3.12.1.1 HostGetImportMetaProperties — resolve(specifier)
+function TGocciaImportMetaResolveHelper.Resolve(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Specifier, BaseDirectory, ResolvedPath: string;
+begin
+  if AArgs.Length = 0 then
+    ThrowTypeError('import.meta.resolve requires a specifier argument');
+
+  Specifier := AArgs.GetElement(0).ToStringLiteral.Value;
+  BaseDirectory := ExtractFilePath(ExpandFileName(FModuleFilePath));
+  ResolvedPath := ExpandFileName(BaseDirectory + Specifier);
+  Result := TGocciaStringLiteralValue.Create(FilePathToUrl(ResolvedPath));
+end;
+
+{ Cache functions }
+
+// ES2026 §13.3.12.1 Runtime Semantics: Evaluation — ImportMeta
+function GetOrCreateImportMeta(const AFilePath: string): TGocciaObjectValue;
+var
+  MetaObject: TGocciaObjectValue;
+  ResolveHelper: TGocciaImportMetaResolveHelper;
+  ResolveFunction: TGocciaValue;
+  CanonicalPath: string;
+begin
+  CanonicalPath := ExpandFileName(AFilePath);
+
+  if not Assigned(ImportMetaCache) then
+    ImportMetaCache := TOrderedStringMap<TGocciaObjectValue>.Create;
+
+  if ImportMetaCache.TryGetValue(CanonicalPath, Result) then
+    Exit;
+
+  // ES2026 §13.3.12.1 step 4a: OrdinaryObjectCreate(null)
+  MetaObject := TGocciaObjectValue.Create(nil);
+
+  // ES2026 §13.3.12.1.1 HostGetImportMetaProperties — url
+  MetaObject.AssignProperty(PROP_URL,
+    TGocciaStringLiteralValue.Create(FilePathToUrl(CanonicalPath)));
+
+  // ES2026 §13.3.12.1.1 HostGetImportMetaProperties — resolve
+  ResolveHelper := TGocciaImportMetaResolveHelper.Create(CanonicalPath);
+  ResolveFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    ResolveHelper.Resolve, PROP_RESOLVE, 1);
+  MetaObject.AssignProperty(PROP_RESOLVE, ResolveFunction);
+
+  // Pin the meta object and its dependencies so the GC does not collect them
+  if Assigned(TGarbageCollector.Instance) then
+  begin
+    TGarbageCollector.Instance.PinObject(MetaObject);
+    TGarbageCollector.Instance.PinObject(ResolveHelper);
+    TGarbageCollector.Instance.PinObject(TGCManagedObject(ResolveFunction));
+  end;
+
+  // ES2026 §13.3.12.1 step 4e: cache on module record
+  ImportMetaCache.Add(CanonicalPath, MetaObject);
+  Result := MetaObject;
+end;
+
+procedure ClearImportMetaCache;
+var
+  Pair: TOrderedStringMap<TGocciaObjectValue>.TKeyValuePair;
+begin
+  if Assigned(ImportMetaCache) then
+  begin
+    if Assigned(TGarbageCollector.Instance) then
+      for Pair in ImportMetaCache do
+        TGarbageCollector.Instance.UnpinObject(Pair.Value);
+    FreeAndNil(ImportMetaCache);
+  end;
+end;
+
+end.

--- a/units/Goccia.ImportMeta.pas
+++ b/units/Goccia.ImportMeta.pas
@@ -35,6 +35,10 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction;
 
+const
+  PINNED_OBJECTS_PER_MODULE = 3;
+  PINNED_INITIAL_CAPACITY = 8;
+
 var
   ImportMetaCache: TOrderedStringMap<TGocciaObjectValue>;
   PinnedObjects: array of TGCManagedObject;
@@ -72,8 +76,16 @@ begin
     ThrowTypeError('import.meta.resolve requires a specifier argument');
 
   Specifier := AArgs.GetElement(0).ToStringLiteral.Value;
-  BaseDirectory := ExtractFilePath(ExpandFileName(FModuleFilePath));
-  ResolvedPath := ExpandFileName(BaseDirectory + Specifier);
+
+  // Absolute specifiers resolve directly; relative ones resolve against the module directory
+  if (Length(Specifier) > 0) and ((Specifier[1] = '/') or
+     (Length(Specifier) >= 2) and (Specifier[2] = ':')) then
+    ResolvedPath := ExpandFileName(Specifier)
+  else
+  begin
+    BaseDirectory := ExtractFilePath(ExpandFileName(FModuleFilePath));
+    ResolvedPath := ExpandFileName(IncludeTrailingPathDelimiter(BaseDirectory) + Specifier);
+  end;
   Result := TGocciaStringLiteralValue.Create(FilePathToUrl(ResolvedPath));
 end;
 
@@ -115,12 +127,12 @@ begin
     TGarbageCollector.Instance.PinObject(ResolveHelper);
     TGarbageCollector.Instance.PinObject(TGCManagedObject(ResolveFunction));
 
-    if PinnedCount + 3 > Length(PinnedObjects) then
-      SetLength(PinnedObjects, PinnedCount * 2 + 8);
+    if PinnedCount + PINNED_OBJECTS_PER_MODULE > Length(PinnedObjects) then
+      SetLength(PinnedObjects, PinnedCount * 2 + PINNED_INITIAL_CAPACITY);
     PinnedObjects[PinnedCount] := MetaObject;
     PinnedObjects[PinnedCount + 1] := ResolveHelper;
     PinnedObjects[PinnedCount + 2] := TGCManagedObject(ResolveFunction);
-    Inc(PinnedCount, 3);
+    Inc(PinnedCount, PINNED_OBJECTS_PER_MODULE);
   end;
 
   // ES2026 §13.3.12.1 step 4e: cache on module record

--- a/units/Goccia.ImportMeta.pas
+++ b/units/Goccia.ImportMeta.pas
@@ -37,6 +37,8 @@ uses
 
 var
   ImportMetaCache: TOrderedStringMap<TGocciaObjectValue>;
+  PinnedObjects: array of TGCManagedObject;
+  PinnedCount: Integer;
 
 function FilePathToUrl(const AFilePath: string): string;
 var
@@ -112,6 +114,13 @@ begin
     TGarbageCollector.Instance.PinObject(MetaObject);
     TGarbageCollector.Instance.PinObject(ResolveHelper);
     TGarbageCollector.Instance.PinObject(TGCManagedObject(ResolveFunction));
+
+    if PinnedCount + 3 > Length(PinnedObjects) then
+      SetLength(PinnedObjects, PinnedCount * 2 + 8);
+    PinnedObjects[PinnedCount] := MetaObject;
+    PinnedObjects[PinnedCount + 1] := ResolveHelper;
+    PinnedObjects[PinnedCount + 2] := TGCManagedObject(ResolveFunction);
+    Inc(PinnedCount, 3);
   end;
 
   // ES2026 §13.3.12.1 step 4e: cache on module record
@@ -121,13 +130,15 @@ end;
 
 procedure ClearImportMetaCache;
 var
-  Pair: TOrderedStringMap<TGocciaObjectValue>.TKeyValuePair;
+  I: Integer;
 begin
   if Assigned(ImportMetaCache) then
   begin
     if Assigned(TGarbageCollector.Instance) then
-      for Pair in ImportMetaCache do
-        TGarbageCollector.Instance.UnpinObject(Pair.Value);
+      for I := 0 to PinnedCount - 1 do
+        TGarbageCollector.Instance.UnpinObject(PinnedObjects[I]);
+    SetLength(PinnedObjects, 0);
+    PinnedCount := 0;
     FreeAndNil(ImportMetaCache);
   end;
 end;

--- a/units/Goccia.ImportMeta.pas
+++ b/units/Goccia.ImportMeta.pas
@@ -37,12 +37,33 @@ uses
 
 const
   PINNED_OBJECTS_PER_MODULE = 3;
+  PINNED_GROWTH_MULTIPLIER = 2;
   PINNED_INITIAL_CAPACITY = 8;
 
 var
   ImportMetaCache: TOrderedStringMap<TGocciaObjectValue>;
   PinnedObjects: array of TGCManagedObject;
   PinnedCount: Integer;
+
+// RFC 3986 §2.3 — percent-encode path characters that are not unreserved or '/'
+function PercentEncodePath(const APath: string): string;
+var
+  I: Integer;
+  Ch: Char;
+begin
+  Result := '';
+  for I := 1 to Length(APath) do
+  begin
+    Ch := APath[I];
+    case Ch of
+      'A'..'Z', 'a'..'z', '0'..'9', '-', '.', '_', '~', '/',
+      ':', '@', '!', '$', '&', '''', '(', ')', '*', '+', ',', ';', '=':
+        Result := Result + Ch;
+    else
+      Result := Result + '%' + IntToHex(Ord(Ch), 2);
+    end;
+  end;
+end;
 
 function FilePathToUrl(const AFilePath: string): string;
 var
@@ -51,9 +72,9 @@ begin
   AbsolutePath := ExpandFileName(AFilePath);
   {$IFDEF MSWINDOWS}
   AbsolutePath := StringReplace(AbsolutePath, '\', '/', [rfReplaceAll]);
-  Result := 'file:///' + AbsolutePath;
+  Result := 'file:///' + PercentEncodePath(AbsolutePath);
   {$ELSE}
-  Result := 'file://' + AbsolutePath;
+  Result := 'file://' + PercentEncodePath(AbsolutePath);
   {$ENDIF}
 end;
 
@@ -128,7 +149,7 @@ begin
     TGarbageCollector.Instance.PinObject(TGCManagedObject(ResolveFunction));
 
     if PinnedCount + PINNED_OBJECTS_PER_MODULE > Length(PinnedObjects) then
-      SetLength(PinnedObjects, PinnedCount * 2 + PINNED_INITIAL_CAPACITY);
+      SetLength(PinnedObjects, PinnedCount * PINNED_GROWTH_MULTIPLIER + PINNED_INITIAL_CAPACITY);
     PinnedObjects[PinnedCount] := MetaObject;
     PinnedObjects[PinnedCount + 1] := ResolveHelper;
     PinnedObjects[PinnedCount + 2] := TGCManagedObject(ResolveFunction);

--- a/units/Goccia.ImportMeta.pas
+++ b/units/Goccia.ImportMeta.pas
@@ -72,7 +72,11 @@ begin
   AbsolutePath := ExpandFileName(AFilePath);
   {$IFDEF MSWINDOWS}
   AbsolutePath := StringReplace(AbsolutePath, '\', '/', [rfReplaceAll]);
-  Result := 'file:///' + PercentEncodePath(AbsolutePath);
+  // RFC 8089 §2 — UNC paths map to file://server/share/..., not file:///
+  if (Length(AbsolutePath) >= 2) and (AbsolutePath[1] = '/') and (AbsolutePath[2] = '/') then
+    Result := 'file:' + PercentEncodePath(AbsolutePath)
+  else
+    Result := 'file:///' + PercentEncodePath(AbsolutePath);
   {$ELSE}
   Result := 'file://' + PercentEncodePath(AbsolutePath);
   {$ENDIF}
@@ -99,8 +103,8 @@ begin
   Specifier := AArgs.GetElement(0).ToStringLiteral.Value;
 
   // Absolute specifiers resolve directly; relative ones resolve against the module directory
-  if (Length(Specifier) > 0) and ((Specifier[1] = '/') or
-     (Length(Specifier) >= 2) and (Specifier[2] = ':')) then
+  if (Length(Specifier) > 0) and ((Specifier[1] = '/') or (Specifier[1] = '\') or
+     ((Length(Specifier) >= 2) and (Specifier[2] = ':'))) then
     ResolvedPath := ExpandFileName(Specifier)
   else
   begin

--- a/units/Goccia.Keywords.Contextual.pas
+++ b/units/Goccia.Keywords.Contextual.pas
@@ -8,6 +8,7 @@ const
   // Module system
   KEYWORD_AS           = 'as';
   KEYWORD_FROM         = 'from';
+  KEYWORD_META         = 'meta';
 
   // Class bodies
   KEYWORD_STATIC       = 'static';

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -925,6 +925,23 @@ begin
     Token := Previous;
     Result := TGocciaSuperExpression.Create(Token.Line, Token.Column);
   end
+  else if Match(gttImport) then
+  begin
+    // ES2026 §13.3.12 MetaProperty — import.meta
+    Token := Previous;
+    Consume(gttDot, 'Expected "." after "import" in expression context',
+      SSuggestImportMetaSyntax);
+    if Check(gttIdentifier) and (Peek.Lexeme = KEYWORD_META) then
+    begin
+      Advance;
+      Result := TGocciaImportMetaExpression.Create(Token.Line, Token.Column);
+    end
+    else
+      raise TGocciaSyntaxError.Create(
+        'The only valid meta property for import is "import.meta"',
+        Peek.Line, Peek.Column, FFileName, FSourceLines,
+        SSuggestImportMetaSyntax);
+  end
   else if Match(gttClass) then
   begin
     Token := Previous;
@@ -1727,6 +1744,8 @@ begin
     Result := ClassDeclaration
   else if Match(gttEnum) then
     Result := EnumDeclaration
+  else if Check(gttImport) and CheckNext(gttDot) then
+    Result := ExpressionStatement
   else if Match(gttImport) then
     Result := ImportDeclaration
   else if Match(gttExport) then

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -204,6 +204,7 @@ uses
   Goccia.Evaluator,
   Goccia.Evaluator.Decorators,
   Goccia.GarbageCollector,
+  Goccia.ImportMeta,
   Goccia.Profiler,
   Goccia.Timeout,
   Goccia.Values.ClassHelper,
@@ -5119,6 +5120,9 @@ begin
         ExportBindingValue(
           Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue,
           GetRegister(A));
+
+      OP_IMPORT_META:
+        SetRegister(A, GetOrCreateImportMeta(FCurrentModuleSourcePath));
 
       OP_THROW:
         raise EGocciaBytecodeThrow.Create(GetRegister(A));

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -5121,8 +5121,12 @@ begin
           Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue,
           GetRegister(A));
 
+      // ES2026 §13.3.12.1 — import.meta binds lexically to the defining module
       OP_IMPORT_META:
-        SetRegister(A, GetOrCreateImportMeta(FCurrentModuleSourcePath));
+        if Assigned(Template.DebugInfo) and (Template.DebugInfo.SourceFile <> '') then
+          SetRegister(A, GetOrCreateImportMeta(Template.DebugInfo.SourceFile))
+        else
+          SetRegister(A, GetOrCreateImportMeta(FCurrentModuleSourcePath));
 
       OP_THROW:
         raise EGocciaBytecodeThrow.Create(GetRegister(A));


### PR DESCRIPTION
## Summary
- Added parser, AST, evaluator, compiler, and VM support for `import.meta` expressions.
- Introduced per-module metadata objects with stable `import.meta.url` and `import.meta.resolve()` behavior.
- Added module tests covering object shape, URL resolution, identity stability, and nested-module behavior.
- Documented `import.meta` in the language restrictions and bytecode VM docs, and updated the import/meta suggestion text.

## Testing
- Not run (PR content generated from the diff only).
- Existing test coverage added in `tests/language/modules/import-meta.js` and `tests/language/modules/helpers/import-meta-child.js`.
- The change also bumps the bytecode format version, so bytecode compatibility should be exercised in the normal build/test pipeline.