### PR TITLE
Add resizable ArrayBuffer support and transfer APIs

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -913,7 +913,7 @@ A raw binary data buffer. Supports both fixed-length and resizable modes. Intern
 |--------|-------------|
 | `buf.slice(begin?, end?)` | Returns a new ArrayBuffer containing bytes from `begin` (inclusive) to `end` (exclusive). Supports negative indices (count from end). Clamps out-of-range indices. Defaults: `begin` = 0, `end` = `byteLength`. Throws `TypeError` if detached. |
 | `buf.resize(newLength)` | Resizes a resizable buffer to `newLength` bytes. Preserves existing data up to `min(old, new)` length; zero-fills growth. Throws `TypeError` if fixed-length or detached. Throws `RangeError` if `newLength > maxByteLength`. Returns `undefined`. |
-| `buf.transfer([newLength])` | Copies data into a new buffer and detaches the original. `newLength` defaults to current `byteLength`. Preserves resizability: if the source was resizable, the new buffer's `maxByteLength` is `max(newLength, originalMaxByteLength)`. Throws `TypeError` if detached. |
+| `buf.transfer([newLength])` | Copies data into a new buffer and detaches the original. `newLength` defaults to current `byteLength`. Preserves resizability: if the source was resizable, the new buffer keeps the original `maxByteLength`. Throws `RangeError` if `newLength` exceeds that cap, and `TypeError` if detached. |
 | `buf.transferToFixedLength([newLength])` | Like `transfer`, but always produces a fixed-length (non-resizable) result. `newLength` defaults to current `byteLength`. Throws `TypeError` if detached. |
 
 **structuredClone:** ArrayBuffer instances are cloneable. The byte contents are copied into a new buffer.

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -882,13 +882,14 @@ Provides current time in various representations.
 
 ### ArrayBuffer (`Goccia.Builtins.GlobalArrayBuffer.pas`, `Goccia.Values.ArrayBufferValue.pas`)
 
-A fixed-length raw binary data buffer. Internally backed by a zero-initialized `TBytes` array.
+A raw binary data buffer. Supports both fixed-length and resizable modes. Internally backed by a zero-initialized `TBytes` array. Resizable buffers are created by passing `{ maxByteLength }` in the options argument. Buffers can be transferred (moving ownership to a new buffer and detaching the original).
 
 **Constructor:**
 
 | Constructor | Description |
 |-------------|-------------|
-| `new ArrayBuffer(length)` | Create a buffer with the given byte length (must be a non-negative integer). Throws `RangeError` for negative, fractional, NaN, or Infinity values. |
+| `new ArrayBuffer(length)` | Create a fixed-length buffer with the given byte length (must be a non-negative integer). Throws `RangeError` for negative, fractional, NaN, or Infinity values. |
+| `new ArrayBuffer(length, { maxByteLength })` | Create a resizable buffer with the given initial byte length and maximum capacity. Throws `RangeError` if `length > maxByteLength`. |
 
 **Static methods:**
 
@@ -900,14 +901,20 @@ A fixed-length raw binary data buffer. Internally backed by a zero-initialized `
 
 | Property | Description |
 |----------|-------------|
-| `buf.byteLength` | The size, in bytes, of the ArrayBuffer (read-only getter) |
+| `buf.byteLength` | The current size in bytes. Returns 0 for detached buffers. |
+| `buf.maxByteLength` | Maximum byte length for resizable buffers; equals `byteLength` for fixed-length buffers. Returns 0 for detached buffers. |
+| `buf.resizable` | `true` if the buffer was created with `maxByteLength`, `false` otherwise. Preserved after detachment. |
+| `buf.detached` | `true` if the buffer has been detached (via `transfer` or `transferToFixedLength`), `false` otherwise. |
 | `buf[Symbol.toStringTag]` | `"ArrayBuffer"` |
 
 **Prototype methods:**
 
 | Method | Description |
 |--------|-------------|
-| `buf.slice(begin?, end?)` | Returns a new ArrayBuffer containing bytes from `begin` (inclusive) to `end` (exclusive). Supports negative indices (count from end). Clamps out-of-range indices. Defaults: `begin` = 0, `end` = `byteLength`. |
+| `buf.slice(begin?, end?)` | Returns a new ArrayBuffer containing bytes from `begin` (inclusive) to `end` (exclusive). Supports negative indices (count from end). Clamps out-of-range indices. Defaults: `begin` = 0, `end` = `byteLength`. Throws `TypeError` if detached. |
+| `buf.resize(newLength)` | Resizes a resizable buffer to `newLength` bytes. Preserves existing data up to `min(old, new)` length; zero-fills growth. Throws `TypeError` if fixed-length or detached. Throws `RangeError` if `newLength > maxByteLength`. Returns `undefined`. |
+| `buf.transfer([newLength])` | Copies data into a new buffer and detaches the original. `newLength` defaults to current `byteLength`. Preserves resizability: if the source was resizable, the new buffer's `maxByteLength` is `max(newLength, originalMaxByteLength)`. Throws `TypeError` if detached. |
+| `buf.transferToFixedLength([newLength])` | Like `transfer`, but always produces a fixed-length (non-resizable) result. `newLength` defaults to current `byteLength`. Throws `TypeError` if detached. |
 
 **structuredClone:** ArrayBuffer instances are cloneable. The byte contents are copied into a new buffer.
 

--- a/tests/built-ins/ArrayBuffer/constructor-options.js
+++ b/tests/built-ins/ArrayBuffer/constructor-options.js
@@ -1,0 +1,68 @@
+/*---
+description: ArrayBuffer constructor with options (maxByteLength)
+features: [ArrayBuffer, resizable-arraybuffer]
+---*/
+
+describe("ArrayBuffer constructor with maxByteLength option", () => {
+  test("creates a resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(buf.byteLength).toBe(4);
+    expect(buf.maxByteLength).toBe(16);
+    expect(buf.resizable).toBe(true);
+  });
+
+  test("maxByteLength equal to byteLength", () => {
+    const buf = new ArrayBuffer(8, { maxByteLength: 8 });
+    expect(buf.byteLength).toBe(8);
+    expect(buf.maxByteLength).toBe(8);
+    expect(buf.resizable).toBe(true);
+  });
+
+  test("maxByteLength of 0 with byteLength of 0", () => {
+    const buf = new ArrayBuffer(0, { maxByteLength: 0 });
+    expect(buf.byteLength).toBe(0);
+    expect(buf.maxByteLength).toBe(0);
+    expect(buf.resizable).toBe(true);
+  });
+
+  test("zero initial length with positive maxByteLength", () => {
+    const buf = new ArrayBuffer(0, { maxByteLength: 64 });
+    expect(buf.byteLength).toBe(0);
+    expect(buf.maxByteLength).toBe(64);
+    expect(buf.resizable).toBe(true);
+  });
+
+  test("without options produces fixed-length buffer", () => {
+    const buf = new ArrayBuffer(8);
+    expect(buf.resizable).toBe(false);
+    expect(buf.maxByteLength).toBe(8);
+  });
+
+  test("throws RangeError when byteLength > maxByteLength", () => {
+    expect(() => new ArrayBuffer(16, { maxByteLength: 8 })).toThrow(RangeError);
+  });
+
+  test("undefined maxByteLength in options creates fixed-length", () => {
+    const buf = new ArrayBuffer(8, { maxByteLength: undefined });
+    expect(buf.resizable).toBe(false);
+  });
+
+  test("empty options object creates fixed-length", () => {
+    const buf = new ArrayBuffer(8, {});
+    expect(buf.resizable).toBe(false);
+  });
+
+  test("undefined options creates fixed-length", () => {
+    const buf = new ArrayBuffer(8, undefined);
+    expect(buf.resizable).toBe(false);
+  });
+
+  test("detached is false for newly created resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(buf.detached).toBe(false);
+  });
+
+  test("throws RangeError for negative maxByteLength", () => {
+    expect(() => new ArrayBuffer(0, { maxByteLength: -1 })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/ArrayBuffer/constructor-options.js
+++ b/tests/built-ins/ArrayBuffer/constructor-options.js
@@ -65,4 +65,32 @@ describe("ArrayBuffer constructor with maxByteLength option", () => {
   test("throws RangeError for negative maxByteLength", () => {
     expect(() => new ArrayBuffer(0, { maxByteLength: -1 })).toThrow(RangeError);
   });
+
+  test("primitive options are silently ignored per spec", () => {
+    // ES2026 §25.1.3.7: If options is not an Object, return empty
+    const buf1 = new ArrayBuffer(8, 42);
+    expect(buf1.resizable).toBe(false);
+    expect(buf1.byteLength).toBe(8);
+
+    const buf2 = new ArrayBuffer(8, "hello");
+    expect(buf2.resizable).toBe(false);
+
+    const buf3 = new ArrayBuffer(8, true);
+    expect(buf3.resizable).toBe(false);
+
+    const buf4 = new ArrayBuffer(8, null);
+    expect(buf4.resizable).toBe(false);
+  });
+
+  test("NaN maxByteLength is coerced to 0 via ToIndex", () => {
+    const buf = new ArrayBuffer(0, { maxByteLength: NaN });
+    expect(buf.resizable).toBe(true);
+    expect(buf.maxByteLength).toBe(0);
+  });
+
+  test("fractional maxByteLength is truncated via ToIndex", () => {
+    const buf = new ArrayBuffer(0, { maxByteLength: 8.9 });
+    expect(buf.resizable).toBe(true);
+    expect(buf.maxByteLength).toBe(8);
+  });
 });

--- a/tests/built-ins/ArrayBuffer/prototype/detached.js
+++ b/tests/built-ins/ArrayBuffer/prototype/detached.js
@@ -1,0 +1,44 @@
+/*---
+description: ArrayBuffer.prototype.detached
+features: [ArrayBuffer, arraybuffer-transfer]
+---*/
+
+describe("get ArrayBuffer.prototype.detached", () => {
+  test("returns false for a new buffer", () => {
+    const buf = new ArrayBuffer(8);
+    expect(buf.detached).toBe(false);
+  });
+
+  test("returns false for a zero-length buffer", () => {
+    const buf = new ArrayBuffer(0);
+    expect(buf.detached).toBe(false);
+  });
+
+  test("returns true after transfer()", () => {
+    const buf = new ArrayBuffer(8);
+    buf.transfer();
+    expect(buf.detached).toBe(true);
+  });
+
+  test("returns true after transferToFixedLength()", () => {
+    const buf = new ArrayBuffer(8);
+    buf.transferToFixedLength();
+    expect(buf.detached).toBe(true);
+  });
+
+  test("returns false for resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(buf.detached).toBe(false);
+  });
+
+  test("returns true for detached resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    buf.transfer();
+    expect(buf.detached).toBe(true);
+  });
+
+  test("throws TypeError when called on non-ArrayBuffer", () => {
+    const getter = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "detached").get;
+    expect(() => getter.call({})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/ArrayBuffer/prototype/maxByteLength.js
+++ b/tests/built-ins/ArrayBuffer/prototype/maxByteLength.js
@@ -1,0 +1,51 @@
+/*---
+description: ArrayBuffer.prototype.maxByteLength
+features: [ArrayBuffer, resizable-arraybuffer]
+---*/
+
+describe("get ArrayBuffer.prototype.maxByteLength", () => {
+  test("returns byteLength for fixed-length buffer", () => {
+    const buf = new ArrayBuffer(8);
+    expect(buf.maxByteLength).toBe(8);
+  });
+
+  test("returns maxByteLength for resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(buf.maxByteLength).toBe(16);
+  });
+
+  test("returns 0 for zero-length fixed buffer", () => {
+    const buf = new ArrayBuffer(0);
+    expect(buf.maxByteLength).toBe(0);
+  });
+
+  test("returns 0 for detached buffer", () => {
+    const buf = new ArrayBuffer(8);
+    buf.transfer();
+    expect(buf.maxByteLength).toBe(0);
+  });
+
+  test("returns 0 for detached resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    buf.transfer();
+    expect(buf.maxByteLength).toBe(0);
+  });
+
+  test("reflects current byteLength for fixed after resize attempt", () => {
+    const buf = new ArrayBuffer(8);
+    expect(buf.maxByteLength).toBe(8);
+  });
+
+  test("does not change after resize", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    buf.resize(8);
+    expect(buf.maxByteLength).toBe(16);
+    buf.resize(2);
+    expect(buf.maxByteLength).toBe(16);
+  });
+
+  test("throws TypeError when called on non-ArrayBuffer", () => {
+    const getter = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "maxByteLength").get;
+    expect(() => getter.call({})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/ArrayBuffer/prototype/maxByteLength.js
+++ b/tests/built-ins/ArrayBuffer/prototype/maxByteLength.js
@@ -31,7 +31,7 @@ describe("get ArrayBuffer.prototype.maxByteLength", () => {
     expect(buf.maxByteLength).toBe(0);
   });
 
-  test("reflects current byteLength for fixed after resize attempt", () => {
+  test("reflects current byteLength for fixed buffers", () => {
     const buf = new ArrayBuffer(8);
     expect(buf.maxByteLength).toBe(8);
   });

--- a/tests/built-ins/ArrayBuffer/prototype/resizable.js
+++ b/tests/built-ins/ArrayBuffer/prototype/resizable.js
@@ -1,0 +1,43 @@
+/*---
+description: ArrayBuffer.prototype.resizable
+features: [ArrayBuffer, resizable-arraybuffer]
+---*/
+
+describe("get ArrayBuffer.prototype.resizable", () => {
+  test("returns false for a fixed-length buffer", () => {
+    const buf = new ArrayBuffer(8);
+    expect(buf.resizable).toBe(false);
+  });
+
+  test("returns true for a resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(buf.resizable).toBe(true);
+  });
+
+  test("returns false for zero-length fixed buffer", () => {
+    const buf = new ArrayBuffer(0);
+    expect(buf.resizable).toBe(false);
+  });
+
+  test("returns true for resizable buffer with zero initial length", () => {
+    const buf = new ArrayBuffer(0, { maxByteLength: 16 });
+    expect(buf.resizable).toBe(true);
+  });
+
+  test("returns false for detached fixed-length buffer", () => {
+    const buf = new ArrayBuffer(8);
+    buf.transfer();
+    expect(buf.resizable).toBe(false);
+  });
+
+  test("returns true for detached resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    buf.transfer();
+    expect(buf.resizable).toBe(true);
+  });
+
+  test("throws TypeError when called on non-ArrayBuffer", () => {
+    const getter = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "resizable").get;
+    expect(() => getter.call({})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/ArrayBuffer/prototype/resize.js
+++ b/tests/built-ins/ArrayBuffer/prototype/resize.js
@@ -1,0 +1,116 @@
+/*---
+description: ArrayBuffer.prototype.resize
+features: [ArrayBuffer, resizable-arraybuffer]
+---*/
+
+describe("ArrayBuffer.prototype.resize", () => {
+  test("resize grows a resizable buffer", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(buf.byteLength).toBe(4);
+    buf.resize(8);
+    expect(buf.byteLength).toBe(8);
+  });
+
+  test("resize shrinks a resizable buffer", () => {
+    const buf = new ArrayBuffer(8, { maxByteLength: 16 });
+    buf.resize(4);
+    expect(buf.byteLength).toBe(4);
+  });
+
+  test("resize to 0", () => {
+    const buf = new ArrayBuffer(8, { maxByteLength: 16 });
+    buf.resize(0);
+    expect(buf.byteLength).toBe(0);
+  });
+
+  test("resize to maxByteLength", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    buf.resize(16);
+    expect(buf.byteLength).toBe(16);
+  });
+
+  test("resize to same size is a no-op", () => {
+    const buf = new ArrayBuffer(8, { maxByteLength: 16 });
+    buf.resize(8);
+    expect(buf.byteLength).toBe(8);
+  });
+
+  test("resize returns undefined", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    const result = buf.resize(8);
+    expect(result).toBe(undefined);
+  });
+
+  test("resize preserves existing data when growing", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    const view = new Uint8Array(buf);
+    view[0] = 1;
+    view[1] = 2;
+    view[2] = 3;
+    view[3] = 4;
+
+    buf.resize(8);
+    const newView = new Uint8Array(buf);
+    expect(newView[0]).toBe(1);
+    expect(newView[1]).toBe(2);
+    expect(newView[2]).toBe(3);
+    expect(newView[3]).toBe(4);
+  });
+
+  test("resize zero-fills new bytes when growing", () => {
+    const buf = new ArrayBuffer(2, { maxByteLength: 8 });
+    const view = new Uint8Array(buf);
+    view[0] = 255;
+    view[1] = 128;
+
+    buf.resize(6);
+    const newView = new Uint8Array(buf);
+    expect(newView[0]).toBe(255);
+    expect(newView[1]).toBe(128);
+    expect(newView[2]).toBe(0);
+    expect(newView[3]).toBe(0);
+    expect(newView[4]).toBe(0);
+    expect(newView[5]).toBe(0);
+  });
+
+  test("resize truncates data when shrinking", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 8 });
+    const view = new Uint8Array(buf);
+    view[0] = 10;
+    view[1] = 20;
+    view[2] = 30;
+    view[3] = 40;
+
+    buf.resize(2);
+    const newView = new Uint8Array(buf);
+    expect(newView.length).toBe(2);
+    expect(newView[0]).toBe(10);
+    expect(newView[1]).toBe(20);
+  });
+
+  test("throws TypeError for non-resizable buffer", () => {
+    const buf = new ArrayBuffer(8);
+    expect(() => buf.resize(4)).toThrow(TypeError);
+  });
+
+  test("throws TypeError for detached buffer", () => {
+    const buf = new ArrayBuffer(8, { maxByteLength: 16 });
+    buf.transfer();
+    expect(() => buf.resize(4)).toThrow(TypeError);
+  });
+
+  test("throws RangeError when newLength exceeds maxByteLength", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(() => buf.resize(17)).toThrow(RangeError);
+  });
+
+  test("throws RangeError for negative newLength", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(() => buf.resize(-1)).toThrow(RangeError);
+  });
+
+  test("throws TypeError when called on non-ArrayBuffer", () => {
+    const resize = ArrayBuffer.prototype.resize;
+    expect(() => resize.call({}, 0)).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/ArrayBuffer/prototype/transfer.js
+++ b/tests/built-ins/ArrayBuffer/prototype/transfer.js
@@ -80,13 +80,17 @@ describe("ArrayBuffer.prototype.transfer", () => {
     expect(newBuf.maxByteLength).toBe(16);
   });
 
-  test("transfer of resizable with larger size updates maxByteLength", () => {
+  test("transfer of resizable with larger size throws RangeError", () => {
     const buf = new ArrayBuffer(4, { maxByteLength: 8 });
-    const newBuf = buf.transfer(12);
+    expect(() => buf.transfer(12)).toThrow(RangeError);
+  });
+
+  test("transfer of resizable preserves original maxByteLength", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    const newBuf = buf.transfer(8);
     expect(newBuf.resizable).toBe(true);
-    expect(newBuf.byteLength).toBe(12);
-    // maxByteLength = max(newLength, originalMaxByteLength)
-    expect(newBuf.maxByteLength).toBe(12);
+    expect(newBuf.byteLength).toBe(8);
+    expect(newBuf.maxByteLength).toBe(16);
   });
 
   test("transfer of fixed-length buffer returns fixed-length", () => {

--- a/tests/built-ins/ArrayBuffer/prototype/transfer.js
+++ b/tests/built-ins/ArrayBuffer/prototype/transfer.js
@@ -1,0 +1,127 @@
+/*---
+description: ArrayBuffer.prototype.transfer
+features: [ArrayBuffer, arraybuffer-transfer]
+---*/
+
+describe("ArrayBuffer.prototype.transfer", () => {
+  test("transfers data to a new buffer", () => {
+    const buf = new ArrayBuffer(8);
+    const view = new Uint8Array(buf);
+    view[0] = 1;
+    view[1] = 2;
+    view[2] = 3;
+
+    const newBuf = buf.transfer();
+    const newView = new Uint8Array(newBuf);
+    expect(newView[0]).toBe(1);
+    expect(newView[1]).toBe(2);
+    expect(newView[2]).toBe(3);
+  });
+
+  test("detaches the original buffer", () => {
+    const buf = new ArrayBuffer(8);
+    buf.transfer();
+    expect(buf.detached).toBe(true);
+    expect(buf.byteLength).toBe(0);
+  });
+
+  test("new buffer has same byteLength when no argument", () => {
+    const buf = new ArrayBuffer(16);
+    const newBuf = buf.transfer();
+    expect(newBuf.byteLength).toBe(16);
+  });
+
+  test("transfer with larger size zero-fills new bytes", () => {
+    const buf = new ArrayBuffer(4);
+    const view = new Uint8Array(buf);
+    view[0] = 10;
+    view[1] = 20;
+
+    const newBuf = buf.transfer(8);
+    expect(newBuf.byteLength).toBe(8);
+
+    const newView = new Uint8Array(newBuf);
+    expect(newView[0]).toBe(10);
+    expect(newView[1]).toBe(20);
+    expect(newView[4]).toBe(0);
+    expect(newView[7]).toBe(0);
+  });
+
+  test("transfer with smaller size truncates", () => {
+    const buf = new ArrayBuffer(8);
+    const view = new Uint8Array(buf);
+    view[0] = 1;
+    view[1] = 2;
+    view[2] = 3;
+    view[3] = 4;
+
+    const newBuf = buf.transfer(2);
+    expect(newBuf.byteLength).toBe(2);
+
+    const newView = new Uint8Array(newBuf);
+    expect(newView[0]).toBe(1);
+    expect(newView[1]).toBe(2);
+  });
+
+  test("transfer with 0 creates empty buffer and detaches", () => {
+    const buf = new ArrayBuffer(8);
+    const newBuf = buf.transfer(0);
+    expect(newBuf.byteLength).toBe(0);
+    expect(buf.detached).toBe(true);
+  });
+
+  test("transfer preserves resizability", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(buf.resizable).toBe(true);
+
+    const newBuf = buf.transfer();
+    expect(newBuf.resizable).toBe(true);
+    expect(newBuf.byteLength).toBe(4);
+    expect(newBuf.maxByteLength).toBe(16);
+  });
+
+  test("transfer of resizable with larger size updates maxByteLength", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 8 });
+    const newBuf = buf.transfer(12);
+    expect(newBuf.resizable).toBe(true);
+    expect(newBuf.byteLength).toBe(12);
+    // maxByteLength = max(newLength, originalMaxByteLength)
+    expect(newBuf.maxByteLength).toBe(12);
+  });
+
+  test("transfer of fixed-length buffer returns fixed-length", () => {
+    const buf = new ArrayBuffer(8);
+    const newBuf = buf.transfer();
+    expect(newBuf.resizable).toBe(false);
+    expect(newBuf.maxByteLength).toBe(8);
+  });
+
+  test("new buffer is a distinct object", () => {
+    const buf = new ArrayBuffer(8);
+    const newBuf = buf.transfer();
+    expect(newBuf).not.toBe(buf);
+  });
+
+  test("new buffer is instanceof ArrayBuffer", () => {
+    const buf = new ArrayBuffer(8);
+    const newBuf = buf.transfer();
+    expect(newBuf instanceof ArrayBuffer).toBe(true);
+  });
+
+  test("throws TypeError on detached buffer", () => {
+    const buf = new ArrayBuffer(8);
+    buf.transfer();
+    expect(() => buf.transfer()).toThrow(TypeError);
+  });
+
+  test("throws TypeError when called on non-ArrayBuffer", () => {
+    const transfer = ArrayBuffer.prototype.transfer;
+    expect(() => transfer.call({})).toThrow(TypeError);
+  });
+
+  test("transfer with undefined newLength uses current byteLength", () => {
+    const buf = new ArrayBuffer(10);
+    const newBuf = buf.transfer(undefined);
+    expect(newBuf.byteLength).toBe(10);
+  });
+});

--- a/tests/built-ins/ArrayBuffer/prototype/transferToFixedLength.js
+++ b/tests/built-ins/ArrayBuffer/prototype/transferToFixedLength.js
@@ -1,0 +1,96 @@
+/*---
+description: ArrayBuffer.prototype.transferToFixedLength
+features: [ArrayBuffer, arraybuffer-transfer]
+---*/
+
+describe("ArrayBuffer.prototype.transferToFixedLength", () => {
+  test("transfers data to a new fixed-length buffer", () => {
+    const buf = new ArrayBuffer(8);
+    const view = new Uint8Array(buf);
+    view[0] = 42;
+    view[7] = 99;
+
+    const newBuf = buf.transferToFixedLength();
+    const newView = new Uint8Array(newBuf);
+    expect(newView[0]).toBe(42);
+    expect(newView[7]).toBe(99);
+  });
+
+  test("detaches the original buffer", () => {
+    const buf = new ArrayBuffer(8);
+    buf.transferToFixedLength();
+    expect(buf.detached).toBe(true);
+    expect(buf.byteLength).toBe(0);
+  });
+
+  test("new buffer has same byteLength when no argument", () => {
+    const buf = new ArrayBuffer(16);
+    const newBuf = buf.transferToFixedLength();
+    expect(newBuf.byteLength).toBe(16);
+  });
+
+  test("always produces a non-resizable buffer from resizable source", () => {
+    const buf = new ArrayBuffer(4, { maxByteLength: 16 });
+    expect(buf.resizable).toBe(true);
+
+    const newBuf = buf.transferToFixedLength();
+    expect(newBuf.resizable).toBe(false);
+    expect(newBuf.byteLength).toBe(4);
+    expect(newBuf.maxByteLength).toBe(4);
+  });
+
+  test("transferToFixedLength with larger size zero-fills", () => {
+    const buf = new ArrayBuffer(4);
+    const view = new Uint8Array(buf);
+    view[0] = 1;
+    view[1] = 2;
+
+    const newBuf = buf.transferToFixedLength(8);
+    expect(newBuf.byteLength).toBe(8);
+
+    const newView = new Uint8Array(newBuf);
+    expect(newView[0]).toBe(1);
+    expect(newView[1]).toBe(2);
+    expect(newView[4]).toBe(0);
+    expect(newView[7]).toBe(0);
+  });
+
+  test("transferToFixedLength with smaller size truncates", () => {
+    const buf = new ArrayBuffer(8);
+    const view = new Uint8Array(buf);
+    view[0] = 10;
+    view[1] = 20;
+    view[2] = 30;
+
+    const newBuf = buf.transferToFixedLength(2);
+    expect(newBuf.byteLength).toBe(2);
+
+    const newView = new Uint8Array(newBuf);
+    expect(newView[0]).toBe(10);
+    expect(newView[1]).toBe(20);
+  });
+
+  test("transferToFixedLength with 0", () => {
+    const buf = new ArrayBuffer(8);
+    const newBuf = buf.transferToFixedLength(0);
+    expect(newBuf.byteLength).toBe(0);
+    expect(buf.detached).toBe(true);
+  });
+
+  test("new buffer is instanceof ArrayBuffer", () => {
+    const buf = new ArrayBuffer(8);
+    const newBuf = buf.transferToFixedLength();
+    expect(newBuf instanceof ArrayBuffer).toBe(true);
+  });
+
+  test("throws TypeError on detached buffer", () => {
+    const buf = new ArrayBuffer(8);
+    buf.transfer();
+    expect(() => buf.transferToFixedLength()).toThrow(TypeError);
+  });
+
+  test("throws TypeError when called on non-ArrayBuffer", () => {
+    const transferToFixedLength = ArrayBuffer.prototype.transferToFixedLength;
+    expect(() => transferToFixedLength.call({})).toThrow(TypeError);
+  });
+});

--- a/units/Goccia.Builtins.GlobalArrayBuffer.pas
+++ b/units/Goccia.Builtins.GlobalArrayBuffer.pas
@@ -31,8 +31,12 @@ implementation
 uses
   Math,
 
+  Goccia.Constants.PropertyNames,
   Goccia.Values.ErrorHelper,
   Goccia.Values.TypedArrayValue;
+
+const
+  NO_MAX_BYTE_LENGTH = -1;
 
 constructor TGocciaGlobalArrayBuffer.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
@@ -53,11 +57,14 @@ begin
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 end;
 
-// ES2026 §25.1.4.1 ArrayBuffer(length) — ToIndex(undefined) returns 0
+// ES2026 §25.1.4.1 ArrayBuffer(length [, options])
 function TGocciaGlobalArrayBuffer.ArrayBufferConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Num: TGocciaNumberLiteralValue;
   Len: Integer;
+  OptionsArg, MaxByteLengthValue: TGocciaValue;
+  RequestedMaxByteLength: Integer;
+  MaxNum: TGocciaNumberLiteralValue;
 begin
   if AArgs.Length = 0 then
   begin
@@ -71,7 +78,32 @@ begin
     ThrowRangeError('Invalid array buffer length');
 
   Len := Trunc(Num.Value);
-  Result := TGocciaArrayBufferValue.Create(Len);
+
+  // ES2026 §25.1.4.1 step 3: GetArrayBufferMaxByteLengthOption(options)
+  RequestedMaxByteLength := NO_MAX_BYTE_LENGTH;
+  if AArgs.Length > 1 then
+  begin
+    OptionsArg := AArgs.GetElement(1);
+    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    begin
+      if OptionsArg.IsPrimitive then
+        ThrowTypeError('Options argument must be an object');
+
+      MaxByteLengthValue := OptionsArg.GetProperty(PROP_MAX_BYTE_LENGTH);
+      if Assigned(MaxByteLengthValue) and not (MaxByteLengthValue is TGocciaUndefinedLiteralValue) then
+      begin
+        MaxNum := MaxByteLengthValue.ToNumberLiteral;
+        if MaxNum.IsNaN or MaxNum.IsInfinite or (MaxNum.Value < 0) or (MaxNum.Value <> Trunc(MaxNum.Value)) then
+          ThrowRangeError('Invalid maxByteLength');
+        RequestedMaxByteLength := Trunc(MaxNum.Value);
+      end;
+    end;
+  end;
+
+  if RequestedMaxByteLength >= 0 then
+    Result := TGocciaArrayBufferValue.Create(Len, RequestedMaxByteLength)
+  else
+    Result := TGocciaArrayBufferValue.Create(Len);
 end;
 
 // ES2026 §25.1.5.1 ArrayBuffer.isView(arg)

--- a/units/Goccia.Builtins.GlobalArrayBuffer.pas
+++ b/units/Goccia.Builtins.GlobalArrayBuffer.pas
@@ -57,6 +57,38 @@ begin
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 end;
 
+// ES2026 §6.2.4.2 ToIndex(value) — local implementation for constructor path
+function ConstructorToIndex(const AValue: TGocciaValue): Integer;
+const
+  MAX_ECMA_INDEX = 9007199254740991.0;
+var
+  Num: TGocciaNumberLiteralValue;
+  IntegerIndex: Double;
+begin
+  if (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue) then
+  begin
+    Result := 0;
+    Exit;
+  end;
+
+  Num := AValue.ToNumberLiteral;
+  if Num.IsNaN then
+    IntegerIndex := 0
+  else if Num.IsInfinite then
+  begin
+    ThrowRangeError('Invalid array buffer length');
+    Exit(0);
+  end
+  else
+    IntegerIndex := Trunc(Num.Value);
+
+  if (IntegerIndex < 0) or (IntegerIndex > MAX_ECMA_INDEX) or
+     (IntegerIndex > High(Integer)) then
+    ThrowRangeError('Invalid array buffer length');
+
+  Result := Trunc(IntegerIndex);
+end;
+
 // ES2026 §25.1.4.1 ArrayBuffer(length [, options])
 function TGocciaGlobalArrayBuffer.ArrayBufferConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
@@ -64,7 +96,6 @@ var
   Len: Integer;
   OptionsArg, MaxByteLengthValue: TGocciaValue;
   RequestedMaxByteLength: Integer;
-  MaxNum: TGocciaNumberLiteralValue;
 begin
   if AArgs.Length = 0 then
   begin
@@ -80,23 +111,17 @@ begin
   Len := Trunc(Num.Value);
 
   // ES2026 §25.1.4.1 step 3: GetArrayBufferMaxByteLengthOption(options)
+  // ES2026 §25.1.3.7 step 2: If options is not an Object, return empty
   RequestedMaxByteLength := NO_MAX_BYTE_LENGTH;
   if AArgs.Length > 1 then
   begin
     OptionsArg := AArgs.GetElement(1);
-    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) and
+       not OptionsArg.IsPrimitive then
     begin
-      if OptionsArg.IsPrimitive then
-        ThrowTypeError('Options argument must be an object');
-
       MaxByteLengthValue := OptionsArg.GetProperty(PROP_MAX_BYTE_LENGTH);
       if Assigned(MaxByteLengthValue) and not (MaxByteLengthValue is TGocciaUndefinedLiteralValue) then
-      begin
-        MaxNum := MaxByteLengthValue.ToNumberLiteral;
-        if MaxNum.IsNaN or MaxNum.IsInfinite or (MaxNum.Value < 0) or (MaxNum.Value <> Trunc(MaxNum.Value)) then
-          ThrowRangeError('Invalid maxByteLength');
-        RequestedMaxByteLength := Trunc(MaxNum.Value);
-      end;
+        RequestedMaxByteLength := ConstructorToIndex(MaxByteLengthValue);
     end;
   end;
 

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -55,9 +55,12 @@ const
   PROP_THEN         = 'then';
   PROP_RESOLVES     = 'resolves';
   PROP_REJECTS      = 'rejects';
-  PROP_BYTE_LENGTH  = 'byteLength';
-  PROP_BYTE_OFFSET  = 'byteOffset';
-  PROP_BUFFER       = 'buffer';
+  PROP_BYTE_LENGTH      = 'byteLength';
+  PROP_BYTE_OFFSET      = 'byteOffset';
+  PROP_BUFFER           = 'buffer';
+  PROP_MAX_BYTE_LENGTH  = 'maxByteLength';
+  PROP_RESIZABLE        = 'resizable';
+  PROP_DETACHED         = 'detached';
   PROP_BYTES_PER_ELEMENT = 'BYTES_PER_ELEMENT';
   PROP_FROM             = 'from';
   PROP_OF               = 'of';

--- a/units/Goccia.Values.ArrayBufferValue.pas
+++ b/units/Goccia.Values.ArrayBufferValue.pas
@@ -20,13 +20,18 @@ type
     class var FShared: TGocciaSharedPrototype;
     class var FPrototypeMembers: array of TGocciaMemberDefinition;
   private
+    const NO_MAX_BYTE_LENGTH = -1;
+  private
     FData: TBytes;
+    FDetached: Boolean;
+    FMaxByteLength: Integer;
 
     function GetByteLength: Integer;
 
     procedure InitializePrototype;
   public
     constructor Create(const AByteLength: Integer = 0); overload;
+    constructor Create(const AByteLength: Integer; const AMaxByteLength: Integer); overload;
     constructor Create(const AClass: TGocciaClassValue); overload;
 
     function GetProperty(const AName: string): TGocciaValue; override;
@@ -35,14 +40,23 @@ type
 
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
     procedure MarkReferences; override;
+    procedure Detach;
 
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
 
     property Data: TBytes read FData write FData;
+    property Detached: Boolean read FDetached;
+    property MaxByteLength: Integer read FMaxByteLength;
   published
     property ByteLength: Integer read GetByteLength;
     function ArrayBufferSlice(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayBufferResize(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayBufferTransfer(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayBufferTransferToFixedLength(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayBufferMaxByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayBufferResizableGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayBufferDetachedGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
 implementation
@@ -56,14 +70,75 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
+function RequireArrayBuffer(const AThisValue: TGocciaValue; const AMethodName: string): TGocciaArrayBufferValue;
+begin
+  if not (AThisValue is TGocciaArrayBufferValue) then
+    ThrowTypeError(AMethodName + ' requires an ArrayBuffer');
+  Result := TGocciaArrayBufferValue(AThisValue);
+end;
+
+// ES2026 §6.2.4.2 ToIndex(value)
+function ToIndex(const AValue: TGocciaValue): Integer;
+var
+  Num: TGocciaNumberLiteralValue;
+  IntegerIndex: Double;
+begin
+  if (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue) then
+  begin
+    Result := 0;
+    Exit;
+  end;
+
+  Num := AValue.ToNumberLiteral;
+  if Num.IsNaN then
+    IntegerIndex := 0
+  else if Num.IsInfinite then
+  begin
+    ThrowRangeError('Invalid array buffer length');
+    Exit(0);
+  end
+  else
+    IntegerIndex := Trunc(Num.Value);
+
+  if (IntegerIndex < 0) or (IntegerIndex > 9007199254740991) then
+    ThrowRangeError('Invalid array buffer length');
+
+  Result := Trunc(IntegerIndex);
+end;
+
 function TGocciaArrayBufferValue.GetByteLength: Integer;
 begin
-  Result := Length(FData);
+  if FDetached then
+    Result := 0
+  else
+    Result := Length(FData);
 end;
 
 constructor TGocciaArrayBufferValue.Create(const AByteLength: Integer);
 begin
   inherited Create(nil);
+  FDetached := False;
+  FMaxByteLength := NO_MAX_BYTE_LENGTH;
+  SetLength(FData, AByteLength);
+  if AByteLength > 0 then
+    FillChar(FData[0], AByteLength, 0);
+  InitializePrototype;
+  if Assigned(FShared) then
+    FPrototype := FShared.Prototype;
+end;
+
+constructor TGocciaArrayBufferValue.Create(const AByteLength: Integer; const AMaxByteLength: Integer);
+begin
+  inherited Create(nil);
+  FDetached := False;
+  if AMaxByteLength >= 0 then
+  begin
+    if AByteLength > AMaxByteLength then
+      ThrowRangeError('ArrayBuffer byte length must not exceed maxByteLength');
+    FMaxByteLength := AMaxByteLength;
+  end
+  else
+    FMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, AByteLength);
   if AByteLength > 0 then
     FillChar(FData[0], AByteLength, 0);
@@ -75,6 +150,8 @@ end;
 constructor TGocciaArrayBufferValue.Create(const AClass: TGocciaClassValue);
 begin
   inherited Create(AClass);
+  FDetached := False;
+  FMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, 0);
   InitializePrototype;
   if not Assigned(AClass) and Assigned(FShared) then
@@ -93,8 +170,13 @@ begin
     Members := TGocciaMemberCollection.Create;
     try
       Members.AddMethod(ArrayBufferSlice, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddPublishedGetter(
-        TGocciaArrayBufferValue, 'ByteLength', PROP_BYTE_LENGTH, [pfConfigurable]);
+      Members.AddMethod(ArrayBufferResize, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(ArrayBufferTransfer, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(ArrayBufferTransferToFixedLength, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddAccessor(PROP_BYTE_LENGTH, ArrayBufferByteLengthGetter, nil, [pfConfigurable]);
+      Members.AddAccessor(PROP_MAX_BYTE_LENGTH, ArrayBufferMaxByteLengthGetter, nil, [pfConfigurable]);
+      Members.AddAccessor(PROP_RESIZABLE, ArrayBufferResizableGetter, nil, [pfConfigurable]);
+      Members.AddAccessor(PROP_DETACHED, ArrayBufferDetachedGetter, nil, [pfConfigurable]);
       Members.AddSymbolDataProperty(
         TGocciaSymbolValue.WellKnownToStringTag,
         TGocciaStringLiteralValue.Create(CONSTRUCTOR_ARRAY_BUFFER),
@@ -117,47 +199,51 @@ end;
 // ES2026 §25.1.4.1 ArrayBuffer(length [, options])
 procedure TGocciaArrayBufferValue.InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
 var
-  LengthArg: TGocciaValue;
-  Num: TGocciaNumberLiteralValue;
-  IntegerIndex: Double;
   Len: Integer;
+  OptionsArg, MaxByteLengthValue: TGocciaValue;
+  RequestedMaxByteLength: Integer;
 begin
   // ES2026 §6.2.4.2 ToIndex(value)
-  // Step 1: If value is undefined, let integerIndex be 0
   if AArguments.Length = 0 then
+    Len := 0
+  else
+    Len := ToIndex(AArguments.GetElement(0));
+
+  // ES2026 §25.1.4.1 step 3: GetArrayBufferMaxByteLengthOption(options)
+  RequestedMaxByteLength := NO_MAX_BYTE_LENGTH;
+  if AArguments.Length > 1 then
   begin
-    SetLength(FData, 0);
-    Exit;
+    OptionsArg := AArguments.GetElement(1);
+    if not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    begin
+      if OptionsArg.IsPrimitive then
+        ThrowTypeError('Options argument must be an object');
+
+      MaxByteLengthValue := OptionsArg.GetProperty(PROP_MAX_BYTE_LENGTH);
+      if Assigned(MaxByteLengthValue) and not (MaxByteLengthValue is TGocciaUndefinedLiteralValue) then
+        RequestedMaxByteLength := ToIndex(MaxByteLengthValue);
+    end;
   end;
 
-  LengthArg := AArguments.GetElement(0);
-  if LengthArg is TGocciaUndefinedLiteralValue then
+  // ES2026 §25.1.2.1 AllocateArrayBuffer step 4: If maxByteLength is present
+  if RequestedMaxByteLength >= 0 then
   begin
-    SetLength(FData, 0);
-    Exit;
-  end;
-
-  // Step 2: Let integerIndex be ToIntegerOrInfinity(value) (ES2026 §7.1.5)
-  Num := LengthArg.ToNumberLiteral;
-  if Num.IsNaN then
-    IntegerIndex := 0
-  else if Num.IsInfinite then
-  begin
-    // +/-Infinity is not in [0, 2^53-1]
-    ThrowRangeError('Invalid array buffer length');
-    Exit;
+    if Len > RequestedMaxByteLength then
+      ThrowRangeError('ArrayBuffer byte length must not exceed maxByteLength');
+    FMaxByteLength := RequestedMaxByteLength;
   end
   else
-    IntegerIndex := Trunc(Num.Value);
+    FMaxByteLength := NO_MAX_BYTE_LENGTH;
 
-  // Step 3: If integerIndex is not in [0, 2^53-1], throw RangeError
-  if (IntegerIndex < 0) or (IntegerIndex > 9007199254740991) then
-    ThrowRangeError('Invalid array buffer length');
-
-  Len := Trunc(IntegerIndex);
   SetLength(FData, Len);
   if Len > 0 then
     FillChar(FData[0], Len, 0);
+end;
+
+procedure TGocciaArrayBufferValue.Detach;
+begin
+  FDetached := True;
+  SetLength(FData, 0);
 end;
 
 procedure TGocciaArrayBufferValue.MarkReferences;
@@ -174,7 +260,35 @@ end;
 function TGocciaArrayBufferValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 begin
   if AName = PROP_BYTE_LENGTH then
-    Result := TGocciaNumberLiteralValue.Create(Length(FData))
+  begin
+    if FDetached then
+      Result := TGocciaNumberLiteralValue.ZeroValue
+    else
+      Result := TGocciaNumberLiteralValue.Create(Length(FData));
+  end
+  else if AName = PROP_MAX_BYTE_LENGTH then
+  begin
+    if FDetached then
+      Result := TGocciaNumberLiteralValue.ZeroValue
+    else if FMaxByteLength >= 0 then
+      Result := TGocciaNumberLiteralValue.Create(FMaxByteLength)
+    else
+      Result := TGocciaNumberLiteralValue.Create(Length(FData));
+  end
+  else if AName = PROP_RESIZABLE then
+  begin
+    if FMaxByteLength >= 0 then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+  end
+  else if AName = PROP_DETACHED then
+  begin
+    if FDetached then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+  end
   else
     Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
@@ -186,13 +300,174 @@ end;
 
 // ES2026 §25.1.6.1 get ArrayBuffer.prototype.byteLength
 function TGocciaArrayBufferValue.ArrayBufferByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
 begin
-  if not (AThisValue is TGocciaArrayBufferValue) then
-    ThrowTypeError('ArrayBuffer.prototype.byteLength requires an ArrayBuffer');
-  Result := TGocciaNumberLiteralValue.Create(Length(TGocciaArrayBufferValue(AThisValue).FData));
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.byteLength');
+  // ES2026 §25.1.6.1 step 4: If IsDetachedBuffer(O) is true, return +0
+  if Buf.FDetached then
+    Result := TGocciaNumberLiteralValue.ZeroValue
+  else
+    Result := TGocciaNumberLiteralValue.Create(Length(Buf.FData));
 end;
 
-// ES2026 §25.1.6.3 ArrayBuffer.prototype.slice(start, end)
+// ES2026 §25.1.6.2 get ArrayBuffer.prototype.detached
+function TGocciaArrayBufferValue.ArrayBufferDetachedGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
+begin
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.detached');
+  // ES2026 §25.1.6.2 step 4: Return IsDetachedBuffer(O)
+  if Buf.FDetached then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// ES2026 §25.1.6.3 get ArrayBuffer.prototype.maxByteLength
+function TGocciaArrayBufferValue.ArrayBufferMaxByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
+begin
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.maxByteLength');
+  // ES2026 §25.1.6.3 step 4: If IsDetachedBuffer(O) is true, return +0
+  if Buf.FDetached then
+    Result := TGocciaNumberLiteralValue.ZeroValue
+  // ES2026 §25.1.6.3 step 5: If IsFixedLengthArrayBuffer(O), return byteLength
+  else if Buf.FMaxByteLength < 0 then
+    Result := TGocciaNumberLiteralValue.Create(Length(Buf.FData))
+  // ES2026 §25.1.6.3 step 6: Return maxByteLength
+  else
+    Result := TGocciaNumberLiteralValue.Create(Buf.FMaxByteLength);
+end;
+
+// ES2026 §25.1.6.4 get ArrayBuffer.prototype.resizable
+function TGocciaArrayBufferValue.ArrayBufferResizableGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
+begin
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.resizable');
+  // ES2026 §25.1.6.4 step 4-5: Return !IsFixedLengthArrayBuffer(O)
+  if Buf.FMaxByteLength >= 0 then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// ES2026 §25.1.6.5 ArrayBuffer.prototype.resize(newLength)
+function TGocciaArrayBufferValue.ArrayBufferResize(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
+  NewByteLength, OldByteLength, CopyLength: Integer;
+  NewData: TBytes;
+begin
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.resize');
+
+  // ES2026 §25.1.6.5 step 4: If IsDetachedBuffer(O), throw TypeError
+  if Buf.FDetached then
+    ThrowTypeError('Cannot resize a detached ArrayBuffer');
+
+  // ES2026 §25.1.6.5 step 5: If IsFixedLengthArrayBuffer(O), throw TypeError
+  if Buf.FMaxByteLength < 0 then
+    ThrowTypeError('Cannot resize a fixed-length ArrayBuffer');
+
+  // ES2026 §25.1.6.5 step 6: Let newByteLength be ToIndex(newLength)
+  if AArgs.Length > 0 then
+    NewByteLength := ToIndex(AArgs.GetElement(0))
+  else
+    NewByteLength := 0;
+
+  // ES2026 §25.1.6.5 step 7: If newByteLength > maxByteLength, throw RangeError
+  if NewByteLength > Buf.FMaxByteLength then
+    ThrowRangeError('ArrayBuffer resize exceeds maxByteLength');
+
+  // ES2026 §25.1.6.5 steps 10-16: Create new data block and copy
+  OldByteLength := Length(Buf.FData);
+  CopyLength := Min(NewByteLength, OldByteLength);
+
+  SetLength(NewData, NewByteLength);
+  if NewByteLength > 0 then
+    FillChar(NewData[0], NewByteLength, 0);
+  if CopyLength > 0 then
+    Move(Buf.FData[0], NewData[0], CopyLength);
+
+  Buf.FData := NewData;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+// ES2026 §25.1.2.4 ArrayBufferCopyAndDetach(O, newLength, preserveResizability)
+function ArrayBufferCopyAndDetach(const ABuf: TGocciaArrayBufferValue;
+  const ANewLength: Integer; const APreserveResizability: Boolean): TGocciaArrayBufferValue;
+var
+  NewMaxByteLength, CopyLength: Integer;
+begin
+  // ES2026 §25.1.2.4 steps 5-6: Determine new maxByteLength
+  if APreserveResizability and (ABuf.FMaxByteLength >= 0) then
+    NewMaxByteLength := Max(ANewLength, ABuf.FMaxByteLength)
+  else
+    NewMaxByteLength := ABuf.NO_MAX_BYTE_LENGTH;
+
+  // ES2026 §25.1.2.4 step 8: Allocate new ArrayBuffer
+  if NewMaxByteLength >= 0 then
+    Result := TGocciaArrayBufferValue.Create(ANewLength, NewMaxByteLength)
+  else
+    Result := TGocciaArrayBufferValue.Create(ANewLength);
+
+  // ES2026 §25.1.2.4 step 9: copyLength = min(newLength, oldByteLength)
+  CopyLength := Min(ANewLength, Length(ABuf.FData));
+  // ES2026 §25.1.2.4 step 12: CopyDataBlockBytes
+  if CopyLength > 0 then
+    Move(ABuf.FData[0], Result.FData[0], CopyLength);
+
+  // ES2026 §25.1.2.4 step 14: DetachArrayBuffer(O)
+  ABuf.Detach;
+end;
+
+// ES2026 §25.1.6.6 ArrayBuffer.prototype.transfer([newLength])
+function TGocciaArrayBufferValue.ArrayBufferTransfer(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
+  NewByteLength: Integer;
+begin
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.transfer');
+
+  // ES2026 §25.1.6.6 step 2: If IsDetachedBuffer(O), throw TypeError
+  if Buf.FDetached then
+    ThrowTypeError('Cannot transfer a detached ArrayBuffer');
+
+  // ES2026 §25.1.6.6 step 1: newLength defaults to current byteLength
+  if (AArgs.Length = 0) or (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
+    NewByteLength := Length(Buf.FData)
+  else
+    NewByteLength := ToIndex(AArgs.GetElement(0));
+
+  // ES2026 §25.1.6.6 step 3: ArrayBufferCopyAndDetach(O, newLength, PRESERVE-RESIZABILITY)
+  Result := ArrayBufferCopyAndDetach(Buf, NewByteLength, True);
+end;
+
+// ES2026 §25.1.6.7 ArrayBuffer.prototype.transferToFixedLength([newLength])
+function TGocciaArrayBufferValue.ArrayBufferTransferToFixedLength(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
+  NewByteLength: Integer;
+begin
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.transferToFixedLength');
+
+  // ES2026 §25.1.6.7 step 2: If IsDetachedBuffer(O), throw TypeError
+  if Buf.FDetached then
+    ThrowTypeError('Cannot transfer a detached ArrayBuffer');
+
+  // ES2026 §25.1.6.7 step 1: newLength defaults to current byteLength
+  if (AArgs.Length = 0) or (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
+    NewByteLength := Length(Buf.FData)
+  else
+    NewByteLength := ToIndex(AArgs.GetElement(0));
+
+  // ES2026 §25.1.6.7 step 3: ArrayBufferCopyAndDetach(O, newLength, FIXED-LENGTH)
+  Result := ArrayBufferCopyAndDetach(Buf, NewByteLength, False);
+end;
+
+// ES2026 §25.1.6.8 ArrayBuffer.prototype.slice(start, end)
 function TGocciaArrayBufferValue.ArrayBufferSlice(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Buf: TGocciaArrayBufferValue;
@@ -200,10 +475,12 @@ var
   StartNum, EndNum: TGocciaNumberLiteralValue;
   NewBuf: TGocciaArrayBufferValue;
 begin
-  if not (AThisValue is TGocciaArrayBufferValue) then
-    ThrowTypeError('ArrayBuffer.prototype.slice requires an ArrayBuffer');
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.slice');
 
-  Buf := TGocciaArrayBufferValue(AThisValue);
+  // ES2026 §25.1.6.8 step 4: If IsDetachedBuffer(O), throw TypeError
+  if Buf.FDetached then
+    ThrowTypeError('Cannot slice a detached ArrayBuffer');
+
   Len := Length(Buf.FData);
 
   // Step 7: Let relativeStart be ToIntegerOrInfinity(start)
@@ -224,7 +501,7 @@ begin
   else
     First := Min(First, Len);
 
-  // ES2026 §25.1.6.3 step 11: If end is undefined, let relativeEnd be len
+  // ES2026 §25.1.6.8 step 11: If end is undefined, let relativeEnd be len
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
   begin
     EndNum := AArgs.GetElement(1).ToNumberLiteral;

--- a/units/Goccia.Values.ArrayBufferValue.pas
+++ b/units/Goccia.Values.ArrayBufferValue.pas
@@ -79,6 +79,8 @@ end;
 
 // ES2026 §6.2.4.2 ToIndex(value)
 function ToIndex(const AValue: TGocciaValue): Integer;
+const
+  MAX_ECMA_INDEX = 9007199254740991.0;
 var
   Num: TGocciaNumberLiteralValue;
   IntegerIndex: Double;
@@ -100,7 +102,8 @@ begin
   else
     IntegerIndex := Trunc(Num.Value);
 
-  if (IntegerIndex < 0) or (IntegerIndex > 9007199254740991) then
+  if (IntegerIndex < 0) or (IntegerIndex > MAX_ECMA_INDEX) or
+     (IntegerIndex > High(Integer)) then
     ThrowRangeError('Invalid array buffer length');
 
   Result := Trunc(IntegerIndex);
@@ -214,11 +217,11 @@ begin
   if AArguments.Length > 1 then
   begin
     OptionsArg := AArguments.GetElement(1);
-    if not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    // ES2026 §25.1.3.7 GetArrayBufferMaxByteLengthOption step 2:
+    // If options is not an Object, return empty
+    if not (OptionsArg is TGocciaUndefinedLiteralValue) and
+       not OptionsArg.IsPrimitive then
     begin
-      if OptionsArg.IsPrimitive then
-        ThrowTypeError('Options argument must be an object');
-
       MaxByteLengthValue := OptionsArg.GetProperty(PROP_MAX_BYTE_LENGTH);
       if Assigned(MaxByteLengthValue) and not (MaxByteLengthValue is TGocciaUndefinedLiteralValue) then
         RequestedMaxByteLength := ToIndex(MaxByteLengthValue);
@@ -402,8 +405,10 @@ var
   NewMaxByteLength, CopyLength: Integer;
 begin
   // ES2026 §25.1.2.4 steps 5-6: Determine new maxByteLength
+  // Preserve the original maxByteLength; AllocateArrayBuffer throws RangeError
+  // if newByteLength > newMaxByteLength
   if APreserveResizability and (ABuf.FMaxByteLength >= 0) then
-    NewMaxByteLength := Max(ANewLength, ABuf.FMaxByteLength)
+    NewMaxByteLength := ABuf.FMaxByteLength
   else
     NewMaxByteLength := ABuf.NO_MAX_BYTE_LENGTH;
 


### PR DESCRIPTION
## Summary
- Adds resizable `ArrayBuffer` construction via `{ maxByteLength }` and exposes `byteLength`, `maxByteLength`, `resizable`, and `detached` on the prototype.
- Implements `ArrayBuffer.prototype.resize()`, `transfer()`, and `transferToFixedLength()` with detachment, copying, truncation, and zero-fill behavior.
- Updates built-in documentation to describe fixed-length versus resizable buffers and the new transfer semantics.
- Adds end-to-end tests covering constructor options, getters, resize behavior, transfer behavior, and error cases.

## Testing
- Not run (PR content only).
- Added JavaScript coverage for resizable constructor options and all new `ArrayBuffer` prototype members.
- Added checks for fixed-length buffers, detached buffers, range errors, type errors, growth, shrinkage, and zero-fill behavior.