### PR TITLE
Add TextEncoder and TextDecoder built-ins

### DIFF
--- a/tests/built-ins/TextDecoder/constructor.js
+++ b/tests/built-ins/TextDecoder/constructor.js
@@ -1,0 +1,69 @@
+describe("TextDecoder constructor", () => {
+  test("creates an instance with no arguments", () => {
+    const dec = new TextDecoder();
+    expect(dec instanceof TextDecoder).toBe(true);
+  });
+
+  test("defaults to utf-8 encoding", () => {
+    const dec = new TextDecoder();
+    expect(dec.encoding).toBe("utf-8");
+  });
+
+  test("accepts 'utf-8' label explicitly", () => {
+    const dec = new TextDecoder("utf-8");
+    expect(dec.encoding).toBe("utf-8");
+  });
+
+  test("accepts 'utf8' alias", () => {
+    const dec = new TextDecoder("utf8");
+    expect(dec.encoding).toBe("utf-8");
+  });
+
+  test("accepts 'UTF-8' (case-insensitive)", () => {
+    const dec = new TextDecoder("UTF-8");
+    expect(dec.encoding).toBe("utf-8");
+  });
+
+  test("accepts unicode-1-1-utf-8 alias", () => {
+    const dec = new TextDecoder("unicode-1-1-utf-8");
+    expect(dec.encoding).toBe("utf-8");
+  });
+
+  test("fatal defaults to false", () => {
+    const dec = new TextDecoder();
+    expect(dec.fatal).toBe(false);
+  });
+
+  test("ignoreBOM defaults to false", () => {
+    const dec = new TextDecoder();
+    expect(dec.ignoreBOM).toBe(false);
+  });
+
+  test("accepts fatal option", () => {
+    const dec = new TextDecoder("utf-8", { fatal: true });
+    expect(dec.fatal).toBe(true);
+  });
+
+  test("accepts ignoreBOM option", () => {
+    const dec = new TextDecoder("utf-8", { ignoreBOM: true });
+    expect(dec.ignoreBOM).toBe(true);
+  });
+
+  test("throws RangeError for unknown encoding label", () => {
+    expect(() => new TextDecoder("latin1")).toThrow(RangeError);
+  });
+
+  test("throws RangeError for completely invalid label", () => {
+    expect(() => new TextDecoder("not-an-encoding")).toThrow(RangeError);
+  });
+
+  test("has decode method", () => {
+    const dec = new TextDecoder();
+    expect(typeof dec.decode).toBe("function");
+  });
+
+  test("prototype has correct toStringTag", () => {
+    const dec = new TextDecoder();
+    expect(Object.prototype.toString.call(dec)).toBe("[object TextDecoder]");
+  });
+});

--- a/tests/built-ins/TextDecoder/prototype/decode.js
+++ b/tests/built-ins/TextDecoder/prototype/decode.js
@@ -62,11 +62,25 @@ describe("TextDecoder.prototype.decode", () => {
     expect(dec.decode(bytes)).toBe("\u0000");
   });
 
-  test("non-fatal mode returns a string for invalid bytes (no throw)", () => {
-    // Non-fatal mode — result may be garbled but must produce a string.
-    const bytes = new Uint8Array([0xFF]);
-    const result = dec.decode(bytes);
-    expect(typeof result).toBe("string");
+  test("non-fatal mode replaces 0xFF with U+FFFD", () => {
+    // Per WHATWG Encoding §4.1: ill-formed bytes become U+FFFD.
+    expect(dec.decode(new Uint8Array([0xFF]))).toBe("\uFFFD");
+  });
+
+  test("non-fatal mode replaces truncated 2-byte sequence with U+FFFD", () => {
+    expect(dec.decode(new Uint8Array([0xC3]))).toBe("\uFFFD");
+  });
+
+  test("non-fatal mode replaces surrogate bytes (ED A0 80) with three U+FFFDs", () => {
+    // ED is rejected at its second byte (A0 > 9F for the ED leading byte);
+    // then A0 and 80 are orphaned continuation bytes → three replacements.
+    // Matches WHATWG spec and browser behaviour.
+    expect(dec.decode(new Uint8Array([0xED, 0xA0, 0x80]))).toBe("\uFFFD\uFFFD\uFFFD");
+  });
+
+  test("non-fatal mode preserves valid sequences between invalid bytes", () => {
+    // 'H' (0x48) + invalid 0xFF + 'i' (0x69) → H + U+FFFD + i
+    expect(dec.decode(new Uint8Array([0x48, 0xFF, 0x69]))).toBe("H\uFFFDi");
   });
 
   test("fatal mode throws TypeError for invalid UTF-8 byte sequence", () => {

--- a/tests/built-ins/TextDecoder/prototype/decode.js
+++ b/tests/built-ins/TextDecoder/prototype/decode.js
@@ -81,6 +81,29 @@ describe("TextDecoder.prototype.decode", () => {
     expect(() => fatalDec.decode(bad)).toThrow(TypeError);
   });
 
+  test("fatal mode rejects overlong 3-byte sequence (E0 80 80)", () => {
+    // E0 must be followed by A0-BF; 80 is overlong.
+    const fatalDec = new TextDecoder("utf-8", { fatal: true });
+    expect(() => fatalDec.decode(new Uint8Array([0xE0, 0x80, 0x80]))).toThrow(TypeError);
+  });
+
+  test("fatal mode rejects UTF-16 surrogate pair (ED A0 80 = U+D800)", () => {
+    const fatalDec = new TextDecoder("utf-8", { fatal: true });
+    expect(() => fatalDec.decode(new Uint8Array([0xED, 0xA0, 0x80]))).toThrow(TypeError);
+  });
+
+  test("fatal mode rejects overlong 4-byte sequence (F0 80 80 80)", () => {
+    // F0 must be followed by 90-BF; 80 is overlong.
+    const fatalDec = new TextDecoder("utf-8", { fatal: true });
+    expect(() => fatalDec.decode(new Uint8Array([0xF0, 0x80, 0x80, 0x80]))).toThrow(TypeError);
+  });
+
+  test("fatal mode rejects code point above U+10FFFF (F4 90 80 80)", () => {
+    // F4 must be followed by 80-8F; 90 exceeds U+10FFFF.
+    const fatalDec = new TextDecoder("utf-8", { fatal: true });
+    expect(() => fatalDec.decode(new Uint8Array([0xF4, 0x90, 0x80, 0x80]))).toThrow(TypeError);
+  });
+
   test("fatal mode accepts valid UTF-8 without throwing", () => {
     const fatalDec = new TextDecoder("utf-8", { fatal: true });
     const bytes = new Uint8Array([72, 101, 108, 108, 111]);

--- a/tests/built-ins/TextDecoder/prototype/decode.js
+++ b/tests/built-ins/TextDecoder/prototype/decode.js
@@ -1,0 +1,106 @@
+describe("TextDecoder.prototype.decode", () => {
+  const dec = new TextDecoder();
+
+  test("returns empty string when called with no arguments", () => {
+    expect(dec.decode()).toBe("");
+  });
+
+  test("returns empty string for undefined input", () => {
+    expect(dec.decode(undefined)).toBe("");
+  });
+
+  test("decodes an empty Uint8Array to an empty string", () => {
+    expect(dec.decode(new Uint8Array(0))).toBe("");
+  });
+
+  test("decodes ASCII bytes from a Uint8Array", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]); // Hello
+    expect(dec.decode(bytes)).toBe("Hello");
+  });
+
+  test("decodes a 2-byte UTF-8 sequence (é, U+00E9)", () => {
+    const bytes = new Uint8Array([0xC3, 0xA9]);
+    expect(dec.decode(bytes)).toBe("\u00E9");
+  });
+
+  test("decodes a 3-byte UTF-8 sequence (中, U+4E2D)", () => {
+    const bytes = new Uint8Array([0xE4, 0xB8, 0xAD]);
+    expect(dec.decode(bytes)).toBe("\u4E2D");
+  });
+
+  test("decodes a 4-byte UTF-8 sequence (😀, U+1F600)", () => {
+    const bytes = new Uint8Array([0xF0, 0x9F, 0x98, 0x80]);
+    expect(dec.decode(bytes)).toBe("\uD83D\uDE00");
+  });
+
+  test("decodes a mixed ASCII and multibyte string", () => {
+    const bytes = new Uint8Array([97, 0xC3, 0xA9, 98]); // a + é + b
+    expect(dec.decode(bytes)).toBe("a\u00E9b");
+  });
+
+  test("decodes an ArrayBuffer directly", () => {
+    const buf = new ArrayBuffer(5);
+    const view = new Uint8Array(buf);
+    view[0] = 72; view[1] = 101; view[2] = 108; view[3] = 108; view[4] = 111;
+    expect(dec.decode(buf)).toBe("Hello");
+  });
+
+  test("strips UTF-8 BOM (EF BB BF) by default", () => {
+    const bytes = new Uint8Array([0xEF, 0xBB, 0xBF, 72, 105]); // BOM + Hi
+    expect(dec.decode(bytes)).toBe("Hi");
+  });
+
+  test("preserves BOM when ignoreBOM is true", () => {
+    const decIgnore = new TextDecoder("utf-8", { ignoreBOM: true });
+    const bytes = new Uint8Array([0xEF, 0xBB, 0xBF, 72, 105]); // BOM + Hi
+    // BOM decoded as U+FEFF
+    expect(decIgnore.decode(bytes)).toBe("\uFEFFHi");
+  });
+
+  test("decodes a null byte (U+0000)", () => {
+    const bytes = new Uint8Array([0x00]);
+    expect(dec.decode(bytes)).toBe("\u0000");
+  });
+
+  test("non-fatal mode returns a string for invalid bytes (no throw)", () => {
+    // Non-fatal mode — result may be garbled but must produce a string.
+    const bytes = new Uint8Array([0xFF]);
+    const result = dec.decode(bytes);
+    expect(typeof result).toBe("string");
+  });
+
+  test("fatal mode throws TypeError for invalid UTF-8 byte sequence", () => {
+    const fatalDec = new TextDecoder("utf-8", { fatal: true });
+    const bad = new Uint8Array([0xFF]); // invalid leading byte
+    expect(() => fatalDec.decode(bad)).toThrow(TypeError);
+  });
+
+  test("fatal mode throws TypeError for truncated multi-byte sequence", () => {
+    const fatalDec = new TextDecoder("utf-8", { fatal: true });
+    const bad = new Uint8Array([0xC3]); // 2-byte start with no continuation
+    expect(() => fatalDec.decode(bad)).toThrow(TypeError);
+  });
+
+  test("fatal mode accepts valid UTF-8 without throwing", () => {
+    const fatalDec = new TextDecoder("utf-8", { fatal: true });
+    const bytes = new Uint8Array([72, 101, 108, 108, 111]);
+    expect(fatalDec.decode(bytes)).toBe("Hello");
+  });
+
+  test("throws TypeError for non-buffer-source input", () => {
+    expect(() => dec.decode("not a buffer")).toThrow(TypeError);
+  });
+
+  test("decodes a typed array backed by an offset into a shared buffer", () => {
+    const buf = new ArrayBuffer(6);
+    const view = new Uint8Array(buf);
+    view[0] = 0; view[1] = 72; view[2] = 105; // 0, H, i
+    const slice = new Uint8Array(buf, 1, 2); // H, i
+    expect(dec.decode(slice)).toBe("Hi");
+  });
+
+  test("decodes Int8Array containing ASCII bytes", () => {
+    const bytes = new Int8Array([72, 101, 108, 108, 111]); // Hello
+    expect(dec.decode(bytes)).toBe("Hello");
+  });
+});

--- a/tests/built-ins/TextDecoder/prototype/encoding.js
+++ b/tests/built-ins/TextDecoder/prototype/encoding.js
@@ -1,0 +1,14 @@
+describe("TextDecoder.prototype.encoding", () => {
+  test("returns the normalised label", () => {
+    expect(new TextDecoder("utf-8").encoding).toBe("utf-8");
+    expect(new TextDecoder("utf8").encoding).toBe("utf-8");
+    expect(new TextDecoder("UTF-8").encoding).toBe("utf-8");
+  });
+
+  test("is a getter-only accessor (no setter defined)", () => {
+    const desc = Object.getOwnPropertyDescriptor(TextDecoder.prototype, "encoding");
+    expect(typeof desc.get).toBe("function");
+    expect(desc.set).toBe(undefined);
+    expect(desc.configurable).toBe(true);
+  });
+});

--- a/tests/built-ins/TextDecoder/prototype/fatal.js
+++ b/tests/built-ins/TextDecoder/prototype/fatal.js
@@ -1,0 +1,20 @@
+describe("TextDecoder.prototype.fatal", () => {
+  test("is false by default", () => {
+    expect(new TextDecoder().fatal).toBe(false);
+  });
+
+  test("is true when fatal: true is passed", () => {
+    expect(new TextDecoder("utf-8", { fatal: true }).fatal).toBe(true);
+  });
+
+  test("is false when fatal: false is passed explicitly", () => {
+    expect(new TextDecoder("utf-8", { fatal: false }).fatal).toBe(false);
+  });
+
+  test("is a getter-only accessor (no setter defined)", () => {
+    const desc = Object.getOwnPropertyDescriptor(TextDecoder.prototype, "fatal");
+    expect(typeof desc.get).toBe("function");
+    expect(desc.set).toBe(undefined);
+    expect(desc.configurable).toBe(true);
+  });
+});

--- a/tests/built-ins/TextDecoder/prototype/ignoreBOM.js
+++ b/tests/built-ins/TextDecoder/prototype/ignoreBOM.js
@@ -1,0 +1,20 @@
+describe("TextDecoder.prototype.ignoreBOM", () => {
+  test("is false by default", () => {
+    expect(new TextDecoder().ignoreBOM).toBe(false);
+  });
+
+  test("is true when ignoreBOM: true is passed", () => {
+    expect(new TextDecoder("utf-8", { ignoreBOM: true }).ignoreBOM).toBe(true);
+  });
+
+  test("is false when ignoreBOM: false is passed explicitly", () => {
+    expect(new TextDecoder("utf-8", { ignoreBOM: false }).ignoreBOM).toBe(false);
+  });
+
+  test("is a getter-only accessor (no setter defined)", () => {
+    const desc = Object.getOwnPropertyDescriptor(TextDecoder.prototype, "ignoreBOM");
+    expect(typeof desc.get).toBe("function");
+    expect(desc.set).toBe(undefined);
+    expect(desc.configurable).toBe(true);
+  });
+});

--- a/tests/built-ins/TextEncoder/constructor.js
+++ b/tests/built-ins/TextEncoder/constructor.js
@@ -1,0 +1,26 @@
+describe("TextEncoder constructor", () => {
+  test("creates an instance with no arguments", () => {
+    const enc = new TextEncoder();
+    expect(enc instanceof TextEncoder).toBe(true);
+  });
+
+  test("encoding property is utf-8", () => {
+    const enc = new TextEncoder();
+    expect(enc.encoding).toBe("utf-8");
+  });
+
+  test("has encode method", () => {
+    const enc = new TextEncoder();
+    expect(typeof enc.encode).toBe("function");
+  });
+
+  test("has encodeInto method", () => {
+    const enc = new TextEncoder();
+    expect(typeof enc.encodeInto).toBe("function");
+  });
+
+  test("prototype has correct toStringTag", () => {
+    const enc = new TextEncoder();
+    expect(Object.prototype.toString.call(enc)).toBe("[object TextEncoder]");
+  });
+});

--- a/tests/built-ins/TextEncoder/prototype/encode.js
+++ b/tests/built-ins/TextEncoder/prototype/encode.js
@@ -99,4 +99,8 @@ describe("TextEncoder.prototype.encode", () => {
     expect(result[1]).toBe(0xBF);
     expect(result[2]).toBe(0xBD);
   });
+
+  test("throws TypeError when called on a non-TextEncoder receiver", () => {
+    expect(() => TextEncoder.prototype.encode.call({}, "x")).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/TextEncoder/prototype/encode.js
+++ b/tests/built-ins/TextEncoder/prototype/encode.js
@@ -1,0 +1,85 @@
+describe("TextEncoder.prototype.encode", () => {
+  const enc = new TextEncoder();
+
+  test("encodes an empty string to an empty Uint8Array", () => {
+    const result = enc.encode("");
+    expect(result instanceof Uint8Array).toBe(true);
+    expect(result.length).toBe(0);
+  });
+
+  test("returns a new Uint8Array on each call", () => {
+    const a = enc.encode("hi");
+    const b = enc.encode("hi");
+    expect(a === b).toBe(false);
+  });
+
+  test("encodes ASCII characters as single bytes", () => {
+    const result = enc.encode("ABC");
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(65);
+    expect(result[1]).toBe(66);
+    expect(result[2]).toBe(67);
+  });
+
+  test("encodes a simple ASCII string", () => {
+    const result = enc.encode("Hello");
+    expect(result.length).toBe(5);
+    expect(result[0]).toBe(72);  // H
+    expect(result[1]).toBe(101); // e
+    expect(result[2]).toBe(108); // l
+    expect(result[3]).toBe(108); // l
+    expect(result[4]).toBe(111); // o
+  });
+
+  test("encodes a 2-byte UTF-8 character (U+00E9, é)", () => {
+    const result = enc.encode("\u00E9");
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe(0xC3);
+    expect(result[1]).toBe(0xA9);
+  });
+
+  test("encodes a 3-byte UTF-8 character (U+4E2D, 中)", () => {
+    const result = enc.encode("\u4E2D");
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(0xE4);
+    expect(result[1]).toBe(0xB8);
+    expect(result[2]).toBe(0xAD);
+  });
+
+  test("encodes a 4-byte UTF-8 character (U+1F600, 😀)", () => {
+    const result = enc.encode("\uD83D\uDE00");
+    expect(result.length).toBe(4);
+    expect(result[0]).toBe(0xF0);
+    expect(result[1]).toBe(0x9F);
+    expect(result[2]).toBe(0x98);
+    expect(result[3]).toBe(0x80);
+  });
+
+  test("encodes a mixed ASCII and multibyte string", () => {
+    const result = enc.encode("a\u00E9b");
+    // a = 1 byte, é = 2 bytes, b = 1 byte → total 4
+    expect(result.length).toBe(4);
+    expect(result[0]).toBe(97);   // a
+    expect(result[1]).toBe(0xC3); // é high
+    expect(result[2]).toBe(0xA9); // é low
+    expect(result[3]).toBe(98);   // b
+  });
+
+  test("undefined input is treated as empty string", () => {
+    const result = enc.encode(undefined);
+    expect(result.length).toBe(0);
+  });
+
+  test("encodes a null byte (U+0000)", () => {
+    const result = enc.encode("\u0000");
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(0);
+  });
+
+  test("encodes U+0080 as a 2-byte sequence", () => {
+    const result = enc.encode("\u0080");
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe(0xC2);
+    expect(result[1]).toBe(0x80);
+  });
+});

--- a/tests/built-ins/TextEncoder/prototype/encode.js
+++ b/tests/built-ins/TextEncoder/prototype/encode.js
@@ -82,4 +82,21 @@ describe("TextEncoder.prototype.encode", () => {
     expect(result[0]).toBe(0xC2);
     expect(result[1]).toBe(0x80);
   });
+
+  test("lone high surrogate (\\uD800) is encoded as U+FFFD (EF BF BD)", () => {
+    // Per WHATWG Encoding §8.3.2: TextEncoder normalises lone surrogates to U+FFFD.
+    const result = enc.encode("\uD800");
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(0xEF);
+    expect(result[1]).toBe(0xBF);
+    expect(result[2]).toBe(0xBD);
+  });
+
+  test("lone low surrogate (\\uDFFF) is encoded as U+FFFD (EF BF BD)", () => {
+    const result = enc.encode("\uDFFF");
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(0xEF);
+    expect(result[1]).toBe(0xBF);
+    expect(result[2]).toBe(0xBD);
+  });
 });

--- a/tests/built-ins/TextEncoder/prototype/encodeInto.js
+++ b/tests/built-ins/TextEncoder/prototype/encodeInto.js
@@ -1,0 +1,64 @@
+describe("TextEncoder.prototype.encodeInto", () => {
+  const enc = new TextEncoder();
+
+  test("encodes ASCII into a Uint8Array that is large enough", () => {
+    const dest = new Uint8Array(10);
+    const result = enc.encodeInto("Hello", dest);
+    expect(result.read).toBe(5);
+    expect(result.written).toBe(5);
+    expect(dest[0]).toBe(72);  // H
+    expect(dest[4]).toBe(111); // o
+  });
+
+  test("stops when destination is full (ASCII)", () => {
+    const dest = new Uint8Array(3);
+    const result = enc.encodeInto("ABCDE", dest);
+    expect(result.read).toBe(3);
+    expect(result.written).toBe(3);
+    expect(dest[0]).toBe(65); // A
+    expect(dest[2]).toBe(67); // C
+  });
+
+  test("does not split a multibyte sequence across the boundary", () => {
+    // é is 2 bytes (C3 A9). A 1-byte destination cannot hold it.
+    const dest = new Uint8Array(1);
+    const result = enc.encodeInto("\u00E9", dest);
+    expect(result.read).toBe(0);
+    expect(result.written).toBe(0);
+  });
+
+  test("encodes a 2-byte character when space is available", () => {
+    const dest = new Uint8Array(2);
+    const result = enc.encodeInto("\u00E9", dest);
+    expect(result.read).toBe(1);
+    expect(result.written).toBe(2);
+    expect(dest[0]).toBe(0xC3);
+    expect(dest[1]).toBe(0xA9);
+  });
+
+  test("returns {read:0, written:0} for empty source", () => {
+    const dest = new Uint8Array(10);
+    const result = enc.encodeInto("", dest);
+    expect(result.read).toBe(0);
+    expect(result.written).toBe(0);
+  });
+
+  test("a 4-byte emoji counts as 2 UTF-16 code units in read", () => {
+    const dest = new Uint8Array(4);
+    // U+1F600 is encoded as a surrogate pair in UTF-16: \uD83D\uDE00 = 2 code units
+    const result = enc.encodeInto("\uD83D\uDE00", dest);
+    expect(result.read).toBe(2);
+    expect(result.written).toBe(4);
+  });
+
+  test("result object has read and written properties", () => {
+    const dest = new Uint8Array(5);
+    const result = enc.encodeInto("abc", dest);
+    expect(typeof result.read).toBe("number");
+    expect(typeof result.written).toBe("number");
+  });
+
+  test("throws TypeError when destination is not a Uint8Array", () => {
+    expect(() => enc.encodeInto("hi", new Int8Array(10))).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/TextEncoder/prototype/encoding.js
+++ b/tests/built-ins/TextEncoder/prototype/encoding.js
@@ -10,4 +10,10 @@ describe("TextEncoder.prototype.encoding", () => {
     expect(desc.set).toBe(undefined);
     expect(desc.configurable).toBe(true);
   });
+
+  test("throws TypeError when called on a non-TextEncoder receiver", () => {
+    expect(() =>
+      Object.getOwnPropertyDescriptor(TextEncoder.prototype, "encoding").get.call({})
+    ).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/TextEncoder/prototype/encoding.js
+++ b/tests/built-ins/TextEncoder/prototype/encoding.js
@@ -1,0 +1,13 @@
+describe("TextEncoder.prototype.encoding", () => {
+  test("returns utf-8", () => {
+    const enc = new TextEncoder();
+    expect(enc.encoding).toBe("utf-8");
+  });
+
+  test("is a getter-only accessor (no setter defined)", () => {
+    const desc = Object.getOwnPropertyDescriptor(TextEncoder.prototype, "encoding");
+    expect(typeof desc.get).toBe("function");
+    expect(desc.set).toBe(undefined);
+    expect(desc.configurable).toBe(true);
+  });
+});

--- a/units/Goccia.Builtins.GlobalTextDecoder.pas
+++ b/units/Goccia.Builtins.GlobalTextDecoder.pas
@@ -1,0 +1,51 @@
+unit Goccia.Builtins.GlobalTextDecoder;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Builtins.Base,
+  Goccia.Error.ThrowErrorCallback,
+  Goccia.Scope,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.Primitives,
+  Goccia.Values.TextDecoderValue;
+
+type
+  TGocciaGlobalTextDecoder = class(TGocciaBuiltin)
+  private
+    FTextDecoderConstructor: TGocciaNativeFunctionValue;
+
+    function TextDecoderConstructorFn(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AName: string; const AScope: TGocciaScope;
+      const AThrowError: TGocciaThrowErrorCallback);
+  end;
+
+implementation
+
+// WHATWG Encoding §8.2 new TextDecoder([label [, options]])
+constructor TGocciaGlobalTextDecoder.Create(const AName: string;
+  const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
+begin
+  inherited Create(AName, AScope, AThrowError);
+  FTextDecoderConstructor := TGocciaNativeFunctionValue.Create(
+    TextDecoderConstructorFn, 'TextDecoder', 0);
+  TGocciaTextDecoderValue.ExposePrototype(FTextDecoderConstructor);
+end;
+
+function TGocciaGlobalTextDecoder.TextDecoderConstructorFn(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Decoder: TGocciaTextDecoderValue;
+begin
+  Decoder := TGocciaTextDecoderValue.Create;
+  Decoder.InitializeNativeFromArguments(AArgs);
+  Result := Decoder;
+end;
+
+end.

--- a/units/Goccia.Builtins.GlobalTextDecoder.pas
+++ b/units/Goccia.Builtins.GlobalTextDecoder.pas
@@ -7,6 +7,7 @@ interface
 uses
   Goccia.Arguments.Collection,
   Goccia.Builtins.Base,
+  Goccia.Constants.ConstructorNames,
   Goccia.Error.ThrowErrorCallback,
   Goccia.Scope,
   Goccia.Values.NativeFunction,
@@ -33,7 +34,7 @@ constructor TGocciaGlobalTextDecoder.Create(const AName: string;
 begin
   inherited Create(AName, AScope, AThrowError);
   FTextDecoderConstructor := TGocciaNativeFunctionValue.Create(
-    TextDecoderConstructorFn, 'TextDecoder', 0);
+    TextDecoderConstructorFn, CONSTRUCTOR_TEXT_DECODER, 0);
   TGocciaTextDecoderValue.ExposePrototype(FTextDecoderConstructor);
 end;
 

--- a/units/Goccia.Builtins.GlobalTextEncoder.pas
+++ b/units/Goccia.Builtins.GlobalTextEncoder.pas
@@ -1,0 +1,48 @@
+unit Goccia.Builtins.GlobalTextEncoder;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Builtins.Base,
+  Goccia.Error.ThrowErrorCallback,
+  Goccia.Scope,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.Primitives,
+  Goccia.Values.TextEncoderValue;
+
+type
+  TGocciaGlobalTextEncoder = class(TGocciaBuiltin)
+  private
+    FTextEncoderConstructor: TGocciaNativeFunctionValue;
+
+    function TextEncoderConstructorFn(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AName: string; const AScope: TGocciaScope;
+      const AThrowError: TGocciaThrowErrorCallback);
+  end;
+
+implementation
+
+// WHATWG Encoding §8.3 new TextEncoder()
+constructor TGocciaGlobalTextEncoder.Create(const AName: string;
+  const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
+begin
+  inherited Create(AName, AScope, AThrowError);
+  FTextEncoderConstructor := TGocciaNativeFunctionValue.Create(
+    TextEncoderConstructorFn, 'TextEncoder', 0);
+  TGocciaTextEncoderValue.ExposePrototype(FTextEncoderConstructor);
+end;
+
+function TGocciaGlobalTextEncoder.TextEncoderConstructorFn(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  // TextEncoder takes no arguments.
+  Result := TGocciaTextEncoderValue.Create;
+end;
+
+end.

--- a/units/Goccia.Builtins.GlobalTextEncoder.pas
+++ b/units/Goccia.Builtins.GlobalTextEncoder.pas
@@ -7,6 +7,7 @@ interface
 uses
   Goccia.Arguments.Collection,
   Goccia.Builtins.Base,
+  Goccia.Constants.ConstructorNames,
   Goccia.Error.ThrowErrorCallback,
   Goccia.Scope,
   Goccia.Values.NativeFunction,
@@ -33,7 +34,7 @@ constructor TGocciaGlobalTextEncoder.Create(const AName: string;
 begin
   inherited Create(AName, AScope, AThrowError);
   FTextEncoderConstructor := TGocciaNativeFunctionValue.Create(
-    TextEncoderConstructorFn, 'TextEncoder', 0);
+    TextEncoderConstructorFn, CONSTRUCTOR_TEXT_ENCODER, 0);
   TGocciaTextEncoderValue.ExposePrototype(FTextEncoderConstructor);
 end;
 

--- a/units/Goccia.Constants.ConstructorNames.pas
+++ b/units/Goccia.Constants.ConstructorNames.pas
@@ -37,6 +37,9 @@ const
 
   CONSTRUCTOR_FFI                  = 'FFI';
 
+  CONSTRUCTOR_TEXT_ENCODER = 'TextEncoder';
+  CONSTRUCTOR_TEXT_DECODER = 'TextDecoder';
+
 implementation
 
 end.

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -109,6 +109,9 @@ const
   PROP_ENCODING               = 'encoding';
   PROP_FATAL                  = 'fatal';
   PROP_IGNORE_BOM             = 'ignoreBOM';
+  PROP_ENCODE                 = 'encode';
+  PROP_ENCODE_INTO            = 'encodeInto';
+  PROP_DECODE                 = 'decode';
 
   // Proxy handler trap names
   PROP_HAS                       = 'has';

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -106,6 +106,9 @@ const
   PROP_SET_FROM_BASE64        = 'setFromBase64';
   PROP_SET_FROM_HEX           = 'setFromHex';
   PROP_RAW                    = 'raw';
+  PROP_ENCODING               = 'encoding';
+  PROP_FATAL                  = 'fatal';
+  PROP_IGNORE_BOM             = 'ignoreBOM';
 
   // Proxy handler trap names
   PROP_HAS                       = 'has';

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -26,6 +26,8 @@ uses
   Goccia.Builtins.GlobalSet,
   Goccia.Builtins.GlobalString,
   Goccia.Builtins.GlobalSymbol,
+  Goccia.Builtins.GlobalTextDecoder,
+  Goccia.Builtins.GlobalTextEncoder,
   Goccia.Builtins.JSON,
   Goccia.Builtins.JSON5,
   Goccia.Builtins.JSONL,
@@ -82,7 +84,9 @@ type
     ggArrayBuffer,
     ggProxy,
     ggFFI,
-    ggReflect
+    ggReflect,
+    ggTextEncoder,
+    ggTextDecoder
   );
 
   TGocciaGlobalBuiltins = set of TGocciaGlobalBuiltin;
@@ -100,7 +104,7 @@ type
 type
   TGocciaEngine = class
   public
-    const DefaultGlobals: TGocciaGlobalBuiltins = [ggConsole, ggMath, ggGlobalObject, ggGlobalArray, ggGlobalNumber, ggPromise, ggJSON, ggJSON5, ggJSONL, ggTOML, ggYAML, ggSymbol, ggSet, ggMap, ggPerformance, ggTemporal, ggJSX, ggArrayBuffer, ggProxy, ggReflect];
+    const DefaultGlobals: TGocciaGlobalBuiltins = [ggConsole, ggMath, ggGlobalObject, ggGlobalArray, ggGlobalNumber, ggPromise, ggJSON, ggJSON5, ggJSONL, ggTOML, ggYAML, ggSymbol, ggSet, ggMap, ggPerformance, ggTemporal, ggJSX, ggArrayBuffer, ggProxy, ggReflect, ggTextEncoder, ggTextDecoder];
   private
     FInterpreter: TGocciaInterpreter;
     FFileName: string;
@@ -136,6 +140,8 @@ type
     FBuiltinProxy: TGocciaGlobalProxy;
     FBuiltinFFI: TGocciaGlobalFFI;
     FBuiltinReflect: TGocciaGlobalReflect;
+    FBuiltinTextEncoder: TGocciaGlobalTextEncoder;
+    FBuiltinTextDecoder: TGocciaGlobalTextDecoder;
     FPreviousExceptionMask: TFPUExceptionMask;
     FASIEnabled: Boolean;
     FSuppressWarnings: Boolean;
@@ -248,6 +254,8 @@ uses
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.TextDecoderValue,
+  Goccia.Values.TextEncoderValue,
   Goccia.Values.Uint8ArrayEncoding,
   Goccia.Version;
 
@@ -333,6 +341,8 @@ begin
     FBuiltinProxy.Free;
     FBuiltinFFI.Free;
     FBuiltinReflect.Free;
+    FBuiltinTextEncoder.Free;
+    FBuiltinTextDecoder.Free;
     ClearImportMetaCache;
     FInjectedGlobals.Free;
     FInterpreter.Free;
@@ -402,6 +412,12 @@ begin
     FBuiltinFFI := TGocciaGlobalFFI.Create(CONSTRUCTOR_FFI, Scope, ThrowError);
   if ggReflect in FGlobals then
     FBuiltinReflect := TGocciaGlobalReflect.Create('Reflect', Scope, ThrowError);
+  if ggTextEncoder in FGlobals then
+    FBuiltinTextEncoder := TGocciaGlobalTextEncoder.Create(
+      CONSTRUCTOR_TEXT_ENCODER, Scope, ThrowError);
+  if ggTextDecoder in FGlobals then
+    FBuiltinTextDecoder := TGocciaGlobalTextDecoder.Create(
+      CONSTRUCTOR_TEXT_DECODER, Scope, ThrowError);
 
   // Always-registered built-ins
   FBuiltinGlobalString := TGocciaGlobalString.Create(CONSTRUCTOR_STRING, Scope, ThrowError);
@@ -451,6 +467,16 @@ end;
 procedure ExposeSetPrototype(const AConstructor: TGocciaValue);
 begin
   TGocciaSetValue.ExposePrototype(AConstructor);
+end;
+
+procedure ExposeTextEncoderPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaTextEncoderValue.ExposePrototype(AConstructor);
+end;
+
+procedure ExposeTextDecoderPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaTextDecoderValue.ExposePrototype(AConstructor);
 end;
 
 procedure TGocciaEngine.RegisterBuiltinConstructors;
@@ -517,6 +543,32 @@ begin
     TypeDef.AddSpeciesGetter := True;
     RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
     SetConstructor := TGocciaSetClassValue(GenericConstructor);
+  end;
+
+  if ggTextEncoder in FGlobals then
+  begin
+    TypeDef.ConstructorName := CONSTRUCTOR_TEXT_ENCODER;
+    TypeDef.Kind := gtdkNativeInstanceType;
+    TypeDef.ClassValueClass := TGocciaTextEncoderClassValue;
+    TypeDef.ExposePrototype := @ExposeTextEncoderPrototype;
+    TypeDef.PrototypeProvider := nil;
+    TypeDef.StaticSource := nil;
+    TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+    TypeDef.AddSpeciesGetter := False;
+    RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
+  end;
+
+  if ggTextDecoder in FGlobals then
+  begin
+    TypeDef.ConstructorName := CONSTRUCTOR_TEXT_DECODER;
+    TypeDef.Kind := gtdkNativeInstanceType;
+    TypeDef.ClassValueClass := TGocciaTextDecoderClassValue;
+    TypeDef.ExposePrototype := @ExposeTextDecoderPrototype;
+    TypeDef.PrototypeProvider := nil;
+    TypeDef.StaticSource := nil;
+    TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+    TypeDef.AddSpeciesGetter := False;
+    RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
   end;
 
   if ggArrayBuffer in FGlobals then

--- a/units/Goccia.Runtime.Bootstrap.pas
+++ b/units/Goccia.Runtime.Bootstrap.pas
@@ -25,6 +25,8 @@ uses
   Goccia.Builtins.GlobalSet,
   Goccia.Builtins.GlobalString,
   Goccia.Builtins.GlobalSymbol,
+  Goccia.Builtins.GlobalTextDecoder,
+  Goccia.Builtins.GlobalTextEncoder,
   Goccia.Builtins.JSON,
   Goccia.Builtins.JSON5,
   Goccia.Builtins.JSONL,
@@ -76,6 +78,8 @@ type
     FBuiltinFFI: TGocciaGlobalFFI;
     FBuiltinProxy: TGocciaGlobalProxy;
     FBuiltinReflect: TGocciaGlobalReflect;
+    FBuiltinTextEncoder: TGocciaGlobalTextEncoder;
+    FBuiltinTextDecoder: TGocciaGlobalTextDecoder;
 
     procedure PinSingletons;
     procedure RegisterBuiltIns;
@@ -113,6 +117,8 @@ uses
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.TextDecoderValue,
+  Goccia.Values.TextEncoderValue,
   Goccia.Values.Uint8ArrayEncoding,
   Goccia.Version;
 
@@ -159,6 +165,16 @@ begin
   TGocciaSetValue.ExposePrototype(AConstructor);
 end;
 
+procedure ExposeTextEncoderPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaTextEncoderValue.ExposePrototype(AConstructor);
+end;
+
+procedure ExposeTextDecoderPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaTextDecoderValue.ExposePrototype(AConstructor);
+end;
+
 constructor TGocciaRuntimeBootstrap.Create(const AInterpreter: TGocciaInterpreter;
   const AGlobals: TGocciaGlobalBuiltins; const AThrowError: TGocciaThrowErrorCallback);
 begin
@@ -197,6 +213,8 @@ begin
   FBuiltinFFI.Free;
   FBuiltinProxy.Free;
   FBuiltinReflect.Free;
+  FBuiltinTextEncoder.Free;
+  FBuiltinTextDecoder.Free;
   inherited;
 end;
 
@@ -256,6 +274,12 @@ begin
     FBuiltinProxy := TGocciaGlobalProxy.Create(Scope);
   if ggReflect in FGlobals then
     FBuiltinReflect := TGocciaGlobalReflect.Create('Reflect', Scope, FThrowError);
+  if ggTextEncoder in FGlobals then
+    FBuiltinTextEncoder := TGocciaGlobalTextEncoder.Create(
+      CONSTRUCTOR_TEXT_ENCODER, Scope, FThrowError);
+  if ggTextDecoder in FGlobals then
+    FBuiltinTextDecoder := TGocciaGlobalTextDecoder.Create(
+      CONSTRUCTOR_TEXT_DECODER, Scope, FThrowError);
 
   FBuiltinGlobalString := TGocciaGlobalString.Create(CONSTRUCTOR_STRING, Scope, FThrowError);
   FBuiltinGlobals := TGocciaGlobals.Create('Globals', Scope, FThrowError);
@@ -327,6 +351,32 @@ begin
     TypeDef.AddSpeciesGetter := True;
     RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
     SetConstructor := TGocciaSetClassValue(GenericConstructor);
+  end;
+
+  if ggTextEncoder in FGlobals then
+  begin
+    TypeDef.ConstructorName := CONSTRUCTOR_TEXT_ENCODER;
+    TypeDef.Kind := gtdkNativeInstanceType;
+    TypeDef.ClassValueClass := TGocciaTextEncoderClassValue;
+    TypeDef.ExposePrototype := @ExposeTextEncoderPrototype;
+    TypeDef.PrototypeProvider := nil;
+    TypeDef.StaticSource := nil;
+    TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+    TypeDef.AddSpeciesGetter := False;
+    RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
+  end;
+
+  if ggTextDecoder in FGlobals then
+  begin
+    TypeDef.ConstructorName := CONSTRUCTOR_TEXT_DECODER;
+    TypeDef.Kind := gtdkNativeInstanceType;
+    TypeDef.ClassValueClass := TGocciaTextDecoderClassValue;
+    TypeDef.ExposePrototype := @ExposeTextDecoderPrototype;
+    TypeDef.PrototypeProvider := nil;
+    TypeDef.StaticSource := nil;
+    TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+    TypeDef.AddSpeciesGetter := False;
+    RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
   end;
 
   if ggArrayBuffer in FGlobals then

--- a/units/Goccia.Values.ClassValue.pas
+++ b/units/Goccia.Values.ClassValue.pas
@@ -173,6 +173,14 @@ type
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
   end;
 
+  TGocciaTextEncoderClassValue = class(TGocciaClassValue)
+    function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+  end;
+
+  TGocciaTextDecoderClassValue = class(TGocciaClassValue)
+    function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+  end;
+
   TGocciaInstanceValue = class(TGocciaObjectValue)
   private
     FClass: TGocciaClassValue;
@@ -217,7 +225,9 @@ uses
   Goccia.Values.MapValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.SetValue,
-  Goccia.Values.SharedArrayBufferValue;
+  Goccia.Values.SharedArrayBufferValue,
+  Goccia.Values.TextDecoderValue,
+  Goccia.Values.TextEncoderValue;
 
 constructor TGocciaClassValue.Create(const AName: string; const ASuperClass: TGocciaClassValue);
 begin
@@ -1063,6 +1073,20 @@ end;
 function TGocciaSharedArrayBufferClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
 begin
   Result := TGocciaSharedArrayBufferValue.Create(nil);
+end;
+
+{ TGocciaTextEncoderClassValue }
+
+function TGocciaTextEncoderClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
+begin
+  Result := TGocciaTextEncoderValue.Create;
+end;
+
+{ TGocciaTextDecoderClassValue }
+
+function TGocciaTextDecoderClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
+begin
+  Result := TGocciaTextDecoderValue.Create;
 end;
 
 { TGocciaStringClassValue }

--- a/units/Goccia.Values.TextDecoderValue.pas
+++ b/units/Goccia.Values.TextDecoderValue.pas
@@ -158,6 +158,126 @@ begin
   end;
 end;
 
+// WHATWG Encoding §4.1: decode UTF-8 bytes with replacement semantics.
+// Each ill-formed byte (invalid leading byte, truncated sequence, overlong,
+// surrogate, or out-of-range code point) emits U+FFFD (EF BF BD) and advances
+// the cursor by one byte.
+function DecodeUTF8WithReplacement(const AData: TBytes;
+  const AOffset, ALength: Integer): string;
+const
+  FFFD_0 = $EF;
+  FFFD_1 = $BF;
+  FFFD_2 = $BD;
+var
+  OutBytes: array of Byte;
+  OutPos, I, SeqLen, K: Integer;
+  B, NextByte: Byte;
+  Valid: Boolean;
+  U8: UTF8String;
+begin
+  if ALength = 0 then
+  begin
+    Result := '';
+    Exit;
+  end;
+  // Worst case: every input byte becomes 3 bytes of U+FFFD.
+  SetLength(OutBytes, ALength * 3);
+  OutPos := 0;
+  I := AOffset;
+  while I < AOffset + ALength do
+  begin
+    B := AData[I];
+    // Determine the expected sequence length from the leading byte.
+    if B and $80 = 0 then
+      SeqLen := 1
+    else if (B and $E0 = $C0) and (B >= $C2) then
+      SeqLen := 2
+    else if B and $F0 = $E0 then
+      SeqLen := 3
+    else if (B and $F8 = $F0) and (B <= $F4) then
+      SeqLen := 4
+    else
+      SeqLen := 0;
+
+    if SeqLen = 0 then
+    begin
+      // Invalid leading byte ($80-$BF, $C0, $C1, $F5-$FF).
+      OutBytes[OutPos]     := FFFD_0;
+      OutBytes[OutPos + 1] := FFFD_1;
+      OutBytes[OutPos + 2] := FFFD_2;
+      Inc(OutPos, 3);
+      Inc(I);
+    end
+    else if I + SeqLen > AOffset + ALength then
+    begin
+      // Truncated sequence — not enough bytes remain.
+      OutBytes[OutPos]     := FFFD_0;
+      OutBytes[OutPos + 1] := FFFD_1;
+      OutBytes[OutPos + 2] := FFFD_2;
+      Inc(OutPos, 3);
+      Inc(I);
+    end
+    else if SeqLen = 1 then
+    begin
+      // ASCII — always valid, pass through directly.
+      OutBytes[OutPos] := B;
+      Inc(OutPos);
+      Inc(I);
+    end
+    else
+    begin
+      // Multi-byte: validate all continuation bytes (must be 10xxxxxx).
+      Valid := True;
+      for K := 1 to SeqLen - 1 do
+        if (AData[I + K] and $C0) <> $80 then
+        begin
+          Valid := False;
+          Break;
+        end;
+
+      // Second-byte range guards (same constraints as IsValidUTF8).
+      if Valid then
+      begin
+        NextByte := AData[I + 1];
+        case SeqLen of
+          3:
+          begin
+            if (B = $E0) and (NextByte < $A0) then Valid := False; // overlong
+            if (B = $ED) and (NextByte > $9F) then Valid := False; // surrogate
+          end;
+          4:
+          begin
+            if (B = $F0) and (NextByte < $90) then Valid := False; // overlong
+            if (B = $F4) and (NextByte > $8F) then Valid := False; // > U+10FFFF
+          end;
+        end;
+      end;
+
+      if Valid then
+      begin
+        for K := 0 to SeqLen - 1 do
+          OutBytes[OutPos + K] := AData[I + K];
+        Inc(OutPos, SeqLen);
+        Inc(I, SeqLen);
+      end
+      else
+      begin
+        // Invalid sequence — emit U+FFFD and retreat to next byte.
+        OutBytes[OutPos]     := FFFD_0;
+        OutBytes[OutPos + 1] := FFFD_1;
+        OutBytes[OutPos + 2] := FFFD_2;
+        Inc(OutPos, 3);
+        Inc(I);
+      end;
+    end;
+  end;
+
+  SetLength(U8, OutPos);
+  if OutPos > 0 then
+    Move(OutBytes[0], U8[1], OutPos);
+  Result := string(U8);
+end;
+
 { TGocciaTextDecoderValue }
 
 constructor TGocciaTextDecoderValue.Create(const AClass: TGocciaClassValue = nil);
@@ -352,16 +472,23 @@ begin
     Dec(DataLen, MIN_BOM_LENGTH);
   end;
 
-  // Fatal mode: validate UTF-8 before decoding.
-  // Per WHATWG Encoding §8.2.4 step 5: throw a TypeError on failure.
-  if Obj.FFatal and not IsValidUTF8(Data, Offset, DataLen) then
-    ThrowTypeError('TextDecoder.prototype.decode: invalid UTF-8 byte sequence');
-
-  // Decode: treat the raw bytes as a UTF-8 string.
-  SetLength(U8, DataLen);
-  if DataLen > 0 then
-    Move(Data[Offset], U8[1], DataLen);
-  Result := TGocciaStringLiteralValue.Create(string(U8));
+  // WHATWG Encoding §8.2.4 step 5: fatal vs. replacement decoding.
+  if Obj.FFatal then
+  begin
+    // Fatal mode: reject any ill-formed byte sequence with a TypeError.
+    if not IsValidUTF8(Data, Offset, DataLen) then
+      ThrowTypeError(
+        'TextDecoder.prototype.decode: invalid UTF-8 byte sequence');
+    // All bytes are well-formed — raw copy is safe.
+    SetLength(U8, DataLen);
+    if DataLen > 0 then
+      Move(Data[Offset], U8[1], DataLen);
+    Result := TGocciaStringLiteralValue.Create(string(U8));
+  end
+  else
+    // Non-fatal mode: replace each ill-formed sequence with U+FFFD.
+    Result := TGocciaStringLiteralValue.Create(
+      DecodeUTF8WithReplacement(Data, Offset, DataLen));
 end;
 
 end.

--- a/units/Goccia.Values.TextDecoderValue.pas
+++ b/units/Goccia.Values.TextDecoderValue.pas
@@ -125,6 +125,27 @@ begin
       Exit;
     end;
 
+    // Second-byte range checks required by RFC 3629 to reject overlong
+    // sequences, UTF-16 surrogate pairs, and code points above U+10FFFF.
+    if SeqLen = 3 then
+    begin
+      case B of
+        $E0: // Overlong: second byte must be A0-BF (U+0800 minimum).
+          if AData[I + 1] < $A0 then begin Result := False; Exit; end;
+        $ED: // Surrogate range U+D800-U+DFFF: second byte must be 80-9F.
+          if AData[I + 1] > $9F then begin Result := False; Exit; end;
+      end;
+    end
+    else if SeqLen = 4 then
+    begin
+      case B of
+        $F0: // Overlong: second byte must be 90-BF (U+10000 minimum).
+          if AData[I + 1] < $90 then begin Result := False; Exit; end;
+        $F4: // Limit to U+10FFFF: second byte must be 80-8F.
+          if AData[I + 1] > $8F then begin Result := False; Exit; end;
+      end;
+    end;
+
     // Validate each continuation byte (must be 10xxxxxx).
     for J := 1 to SeqLen - 1 do
       if (AData[I + J] and $C0) <> $80 then
@@ -206,7 +227,7 @@ begin
       Members.AddAccessor(PROP_ENCODING, EncodingGetter, nil, [pfConfigurable]);
       Members.AddAccessor(PROP_FATAL, FatalGetter, nil, [pfConfigurable]);
       Members.AddAccessor(PROP_IGNORE_BOM, IgnoreBOMGetter, nil, [pfConfigurable]);
-      Members.AddNamedMethod('decode', Decode, 1, gmkPrototypeMethod,
+      Members.AddNamedMethod(PROP_DECODE, Decode, 1, gmkPrototypeMethod,
         [gmfNoFunctionPrototype]);
       FPrototypeMembers := Members.ToDefinitions;
     finally

--- a/units/Goccia.Values.TextDecoderValue.pas
+++ b/units/Goccia.Values.TextDecoderValue.pas
@@ -1,0 +1,346 @@
+unit Goccia.Values.TextDecoderValue;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.ObjectModel,
+  Goccia.SharedPrototype,
+  Goccia.Values.ClassValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaTextDecoderValue = class(TGocciaInstanceValue)
+  private
+    class var FShared: TGocciaSharedPrototype;
+    class var FPrototypeMembers: array of TGocciaMemberDefinition;
+  private
+    FEncoding: string;
+    FFatal: Boolean;
+    FIgnoreBOM: Boolean;
+
+    // Getters
+    function EncodingGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function FatalGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function IgnoreBOMGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    // Methods
+    function Decode(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+
+    procedure InitializePrototype;
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil);
+
+    procedure InitializeNativeFromArguments(
+      const AArguments: TGocciaArgumentsCollection); override;
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+
+    property Encoding: string read FEncoding;
+    property Fatal: Boolean read FFatal;
+    property IgnoreBOM: Boolean read FIgnoreBOM;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.Values.ArrayBufferValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.TypedArrayValue;
+
+const
+  ENCODING_UTF8 = 'utf-8';
+
+  // UTF-8 BOM bytes (EF BB BF).
+  UTF8_BOM_BYTE0 = $EF;
+  UTF8_BOM_BYTE1 = $BB;
+  UTF8_BOM_BYTE2 = $BF;
+
+  MIN_BOM_LENGTH = 3;
+
+// Map a label string to the WHATWG canonical encoding name.
+// Returns an empty string when the label is not supported.
+// Per WHATWG Encoding §4.2 — UTF-8 labels only for now; everything else is a
+// RangeError at construction time.
+function NormalizeEncodingLabel(const ALabel: string): string;
+var
+  Lower: string;
+begin
+  Lower := LowerCase(Trim(ALabel));
+  if (Lower = 'utf-8') or (Lower = 'utf8') or
+     (Lower = 'unicode-1-1-utf-8') or (Lower = 'unicode11utf8') or
+     (Lower = 'unicode20utf8') or (Lower = 'x-unicode20utf8') then
+    Result := ENCODING_UTF8
+  else
+    Result := '';
+end;
+
+// Validate that AData[AOffset .. AOffset+ALength-1] is well-formed UTF-8.
+// Checks leading byte range, continuation bytes, and overlong/surrogate
+// sequences per RFC 3629.
+function IsValidUTF8(const AData: TBytes; const AOffset, ALength: Integer): Boolean;
+var
+  I, SeqLen, J: Integer;
+  B: Byte;
+begin
+  Result := True;
+  I := AOffset;
+  while I < AOffset + ALength do
+  begin
+    B := AData[I];
+    if B and $80 = 0 then
+      SeqLen := 1
+    else if (B and $E0 = $C0) and (B >= $C2) then
+      // $C0/$C1 are overlong encodings of U+0000-U+007F — reject them.
+      SeqLen := 2
+    else if B and $F0 = $E0 then
+      SeqLen := 3
+    else if (B and $F8 = $F0) and (B <= $F4) then
+      // Limit to U+10FFFF ($F4 80 80 80); $F5-$FF are out of range.
+      SeqLen := 4
+    else
+    begin
+      Result := False;
+      Exit;
+    end;
+
+    // Make sure all continuation bytes are present.
+    if I + SeqLen > AOffset + ALength then
+    begin
+      Result := False;
+      Exit;
+    end;
+
+    // Validate each continuation byte (must be 10xxxxxx).
+    for J := 1 to SeqLen - 1 do
+      if (AData[I + J] and $C0) <> $80 then
+      begin
+        Result := False;
+        Exit;
+      end;
+
+    Inc(I, SeqLen);
+  end;
+end;
+
+{ TGocciaTextDecoderValue }
+
+constructor TGocciaTextDecoderValue.Create(const AClass: TGocciaClassValue = nil);
+begin
+  inherited Create(AClass);
+  FEncoding := ENCODING_UTF8;
+  FFatal := False;
+  FIgnoreBOM := False;
+  InitializePrototype;
+  if not Assigned(AClass) and Assigned(FShared) then
+    FPrototype := FShared.Prototype;
+end;
+
+// WHATWG Encoding §8.1 new TextDecoder([label [, options]])
+procedure TGocciaTextDecoderValue.InitializeNativeFromArguments(
+  const AArguments: TGocciaArgumentsCollection);
+var
+  LabelArg, OptionsArg, FatalOpt, IgnoreBOMOpt: TGocciaValue;
+  Normalized: string;
+begin
+  // Step 1: If label is provided and not undefined, normalise it.
+  if AArguments.Length > 0 then
+  begin
+    LabelArg := AArguments.GetElement(0);
+    if not (LabelArg is TGocciaUndefinedLiteralValue) then
+    begin
+      Normalized := NormalizeEncodingLabel(LabelArg.ToStringLiteral.Value);
+      if Normalized = '' then
+        ThrowRangeError('TextDecoder: The encoding label provided (' +
+          LabelArg.ToStringLiteral.Value + ') is invalid.');
+      FEncoding := Normalized;
+    end;
+  end;
+
+  // Step 2: If options are provided, extract fatal and ignoreBOM flags.
+  if AArguments.Length > 1 then
+  begin
+    OptionsArg := AArguments.GetElement(1);
+    if not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    begin
+      if not (OptionsArg is TGocciaObjectValue) then
+        ThrowTypeError('TextDecoder: options must be an object or undefined');
+
+      FatalOpt := TGocciaObjectValue(OptionsArg).GetProperty(PROP_FATAL);
+      if Assigned(FatalOpt) and not (FatalOpt is TGocciaUndefinedLiteralValue) then
+        FFatal := FatalOpt.ToBooleanLiteral.Value;
+
+      IgnoreBOMOpt := TGocciaObjectValue(OptionsArg).GetProperty(PROP_IGNORE_BOM);
+      if Assigned(IgnoreBOMOpt) and
+         not (IgnoreBOMOpt is TGocciaUndefinedLiteralValue) then
+        FIgnoreBOM := IgnoreBOMOpt.ToBooleanLiteral.Value;
+    end;
+  end;
+end;
+
+procedure TGocciaTextDecoderValue.InitializePrototype;
+var
+  Members: TGocciaMemberCollection;
+begin
+  if Assigned(FShared) then Exit;
+
+  FShared := TGocciaSharedPrototype.Create(Self);
+  if Length(FPrototypeMembers) = 0 then
+  begin
+    Members := TGocciaMemberCollection.Create;
+    try
+      Members.AddAccessor(PROP_ENCODING, EncodingGetter, nil, [pfConfigurable]);
+      Members.AddAccessor(PROP_FATAL, FatalGetter, nil, [pfConfigurable]);
+      Members.AddAccessor(PROP_IGNORE_BOM, IgnoreBOMGetter, nil, [pfConfigurable]);
+      Members.AddNamedMethod('decode', Decode, 1, gmkPrototypeMethod,
+        [gmfNoFunctionPrototype]);
+      FPrototypeMembers := Members.ToDefinitions;
+    finally
+      Members.Free;
+    end;
+  end;
+  RegisterMemberDefinitions(FShared.Prototype, FPrototypeMembers);
+end;
+
+class procedure TGocciaTextDecoderValue.ExposePrototype(const AConstructor: TGocciaValue);
+begin
+  if not Assigned(FShared) then
+    TGocciaTextDecoderValue.Create;
+  ExposeSharedPrototypeOnConstructor(FShared, AConstructor);
+end;
+
+function TGocciaTextDecoderValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_TEXT_DECODER;
+end;
+
+procedure TGocciaTextDecoderValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  // No additional TGocciaValue fields — FEncoding is a plain Pascal string.
+end;
+
+// WHATWG Encoding §8.2.1 get TextDecoder.prototype.encoding
+function TGocciaTextDecoderValue.EncodingGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Obj: TGocciaTextDecoderValue;
+begin
+  if not (AThisValue is TGocciaTextDecoderValue) then
+    ThrowTypeError('TextDecoder.prototype.encoding: illegal invocation');
+  Obj := TGocciaTextDecoderValue(AThisValue);
+  Result := TGocciaStringLiteralValue.Create(Obj.FEncoding);
+end;
+
+// WHATWG Encoding §8.2.2 get TextDecoder.prototype.fatal
+function TGocciaTextDecoderValue.FatalGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Obj: TGocciaTextDecoderValue;
+begin
+  if not (AThisValue is TGocciaTextDecoderValue) then
+    ThrowTypeError('TextDecoder.prototype.fatal: illegal invocation');
+  Obj := TGocciaTextDecoderValue(AThisValue);
+  if Obj.FFatal then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// WHATWG Encoding §8.2.3 get TextDecoder.prototype.ignoreBOM
+function TGocciaTextDecoderValue.IgnoreBOMGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Obj: TGocciaTextDecoderValue;
+begin
+  if not (AThisValue is TGocciaTextDecoderValue) then
+    ThrowTypeError('TextDecoder.prototype.ignoreBOM: illegal invocation');
+  Obj := TGocciaTextDecoderValue(AThisValue);
+  if Obj.FIgnoreBOM then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// WHATWG Encoding §8.2.4 TextDecoder.prototype.decode([input [, options]])
+function TGocciaTextDecoderValue.Decode(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Obj: TGocciaTextDecoderValue;
+  InputArg: TGocciaValue;
+  Data: TBytes;
+  Offset, DataLen: Integer;
+  U8: UTF8String;
+begin
+  if not (AThisValue is TGocciaTextDecoderValue) then
+    ThrowTypeError('TextDecoder.prototype.decode: illegal invocation');
+  Obj := TGocciaTextDecoderValue(AThisValue);
+
+  // No input or undefined input — return empty string.
+  if (AArgs.Length = 0) or (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
+  begin
+    Result := TGocciaStringLiteralValue.Create('');
+    Exit;
+  end;
+
+  InputArg := AArgs.GetElement(0);
+  Offset := 0;
+  DataLen := 0;
+
+  // Extract raw bytes and byte-range from the buffer source.
+  if InputArg is TGocciaTypedArrayValue then
+  begin
+    Data := TGocciaTypedArrayValue(InputArg).BufferData;
+    Offset := TGocciaTypedArrayValue(InputArg).ByteOffset;
+    DataLen := TGocciaTypedArrayValue(InputArg).Length *
+      TGocciaTypedArrayValue.BytesPerElement(
+        TGocciaTypedArrayValue(InputArg).Kind);
+  end
+  else if InputArg is TGocciaArrayBufferValue then
+  begin
+    Data := TGocciaArrayBufferValue(InputArg).Data;
+    Offset := 0;
+    DataLen := Length(Data);
+  end
+  else
+    ThrowTypeError(
+      'TextDecoder.prototype.decode: input must be an ArrayBuffer or ArrayBufferView');
+
+  // Strip the UTF-8 BOM (EF BB BF) unless ignoreBOM is true.
+  if not Obj.FIgnoreBOM and (DataLen >= MIN_BOM_LENGTH) and
+     (Data[Offset] = UTF8_BOM_BYTE0) and
+     (Data[Offset + 1] = UTF8_BOM_BYTE1) and
+     (Data[Offset + 2] = UTF8_BOM_BYTE2) then
+  begin
+    Inc(Offset, MIN_BOM_LENGTH);
+    Dec(DataLen, MIN_BOM_LENGTH);
+  end;
+
+  // Fatal mode: validate UTF-8 before decoding.
+  // Per WHATWG Encoding §8.2.4 step 5: throw a TypeError on failure.
+  if Obj.FFatal and not IsValidUTF8(Data, Offset, DataLen) then
+    ThrowTypeError('TextDecoder.prototype.decode: invalid UTF-8 byte sequence');
+
+  // Decode: treat the raw bytes as a UTF-8 string.
+  SetLength(U8, DataLen);
+  if DataLen > 0 then
+    Move(Data[Offset], U8[1], DataLen);
+  Result := TGocciaStringLiteralValue.Create(string(U8));
+end;
+
+end.

--- a/units/Goccia.Values.TextEncoderValue.pas
+++ b/units/Goccia.Values.TextEncoderValue.pas
@@ -53,15 +53,61 @@ uses
 const
   ENCODING_UTF8 = 'utf-8';
 
-// Convert an FPC string (stored as UTF-8) to a raw byte array of UTF-8 octets.
+  // UTF-8 encoding of U+FFFD REPLACEMENT CHARACTER (EF BF BD).
+  REPLACEMENT_BYTE0 = $EF;
+  REPLACEMENT_BYTE1 = $BF;
+  REPLACEMENT_BYTE2 = $BD;
+
+// Convert an FPC string (stored as UTF-8) to a raw byte array of UTF-8 octets,
+// normalising lone surrogate code points (U+D800-U+DFFF) to U+FFFD per the
+// WHATWG USVString requirement (Encoding §8.3.2 encode).
+//
+// Surrogates appear as the three-byte sequence ED A0-BF 80-BF in CESU-8/WTF-8
+// style storage.  Since U+FFFD also encodes to exactly 3 bytes (EF BF BD),
+// the replacement can be done in-place without resizing the output buffer.
 function StringToUTF8Bytes(const AStr: string): TBytes;
 var
   U8: UTF8String;
+  Len, I: Integer;
+  B: Byte;
 begin
   U8 := UTF8String(AStr);
-  SetLength(Result, Length(U8));
-  if Length(U8) > 0 then
-    Move(U8[1], Result[0], Length(U8));
+  Len := Length(U8);
+  SetLength(Result, Len);
+  if Len > 0 then
+    Move(U8[1], Result[0], Len);
+
+  // Scan for 3-byte sequences in the surrogate range (ED A0 xx .. ED BF xx)
+  // and replace each with the U+FFFD replacement character (EF BF BD).
+  I := 0;
+  while I < Len do
+  begin
+    B := Result[I];
+    if B and $80 = 0 then
+      // ASCII — 1 byte
+      Inc(I)
+    else if (B and $E0 = $C0) and (I + 1 < Len) then
+      // 2-byte sequence
+      Inc(I, 2)
+    else if (B and $F0 = $E0) and (I + 2 < Len) then
+    begin
+      // 3-byte sequence — check for surrogate range (ED A0-BF continuation)
+      if (B = $ED) and (Result[I + 1] >= $A0) then
+      begin
+        // Lone surrogate: replace in-place with U+FFFD.
+        Result[I]     := REPLACEMENT_BYTE0;
+        Result[I + 1] := REPLACEMENT_BYTE1;
+        Result[I + 2] := REPLACEMENT_BYTE2;
+      end;
+      Inc(I, 3);
+    end
+    else if (B and $F8 = $F0) and (I + 3 < Len) then
+      // 4-byte sequence
+      Inc(I, 4)
+    else
+      // Invalid leading byte — step one byte to avoid infinite loop.
+      Inc(I);
+  end;
 end;
 
 // Return the byte-length of the UTF-8 sequence that starts with AByte.
@@ -102,9 +148,9 @@ begin
     Members := TGocciaMemberCollection.Create;
     try
       Members.AddAccessor(PROP_ENCODING, EncodingGetter, nil, [pfConfigurable]);
-      Members.AddNamedMethod('encode', Encode, 1, gmkPrototypeMethod,
+      Members.AddNamedMethod(PROP_ENCODE, Encode, 1, gmkPrototypeMethod,
         [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('encodeInto', EncodeInto, 2, gmkPrototypeMethod,
+      Members.AddNamedMethod(PROP_ENCODE_INTO, EncodeInto, 2, gmkPrototypeMethod,
         [gmfNoFunctionPrototype]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
@@ -155,7 +201,8 @@ begin
   if (AArgs.Length > 0) and not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
     Input := AArgs.GetElement(0).ToStringLiteral.Value;
 
-  // Step 3: Run UTF-8 encode on input and return the resulting Uint8Array.
+  // Step 3: Run UTF-8 encode on the USVString (lone surrogates → U+FFFD)
+  // and return the resulting Uint8Array.
   Bytes := StringToUTF8Bytes(Input);
   NewTA := TGocciaTypedArrayValue.Create(takUint8, Length(Bytes));
   for I := 0 to Length(Bytes) - 1 do
@@ -190,7 +237,7 @@ begin
     ThrowTypeError(
       'TextEncoder.prototype.encodeInto: destination must be a Uint8Array');
 
-  // Convert source to UTF-8 bytes in a temporary buffer.
+  // Convert source to USVString bytes (lone surrogates normalized to U+FFFD).
   Bytes := StringToUTF8Bytes(Source);
   DestLen := Dest.Length;
   Written := 0;

--- a/units/Goccia.Values.TextEncoderValue.pas
+++ b/units/Goccia.Values.TextEncoderValue.pas
@@ -182,6 +182,8 @@ end;
 function TGocciaTextEncoderValue.EncodingGetter(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
+  if not (AThisValue is TGocciaTextEncoderValue) then
+    ThrowTypeError('TextEncoder.prototype.encoding: illegal invocation');
   // TextEncoder always uses UTF-8 — no instance state required.
   Result := TGocciaStringLiteralValue.Create(ENCODING_UTF8);
 end;
@@ -195,6 +197,8 @@ var
   NewTA: TGocciaTypedArrayValue;
   I: Integer;
 begin
+  if not (AThisValue is TGocciaTextEncoderValue) then
+    ThrowTypeError('TextEncoder.prototype.encode: illegal invocation');
   // Step 1: Let input be the empty string.
   Input := '';
   // Step 2: If input is given, convert to a scalar-value string.
@@ -220,6 +224,8 @@ var
   I, J, SeqLen, Written, Read, DestLen: Integer;
   ResultObj: TGocciaObjectValue;
 begin
+  if not (AThisValue is TGocciaTextEncoderValue) then
+    ThrowTypeError('TextEncoder.prototype.encodeInto: illegal invocation');
   if AArgs.Length < 2 then
     ThrowTypeError(
       'TextEncoder.prototype.encodeInto requires source and destination arguments');

--- a/units/Goccia.Values.TextEncoderValue.pas
+++ b/units/Goccia.Values.TextEncoderValue.pas
@@ -1,0 +1,231 @@
+unit Goccia.Values.TextEncoderValue;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.ObjectModel,
+  Goccia.SharedPrototype,
+  Goccia.Values.ClassValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaTextEncoderValue = class(TGocciaInstanceValue)
+  private
+    class var FShared: TGocciaSharedPrototype;
+    class var FPrototypeMembers: array of TGocciaMemberDefinition;
+  private
+    // Getter
+    function EncodingGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    // Methods
+    function Encode(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function EncodeInto(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+
+    procedure InitializePrototype;
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil);
+
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+  end;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.GarbageCollector,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.TypedArrayValue;
+
+const
+  ENCODING_UTF8 = 'utf-8';
+
+// Convert an FPC string (stored as UTF-8) to a raw byte array of UTF-8 octets.
+function StringToUTF8Bytes(const AStr: string): TBytes;
+var
+  U8: UTF8String;
+begin
+  U8 := UTF8String(AStr);
+  SetLength(Result, Length(U8));
+  if Length(U8) > 0 then
+    Move(U8[1], Result[0], Length(U8));
+end;
+
+// Return the byte-length of the UTF-8 sequence that starts with AByte.
+// Returns 1 for invalid leading bytes so the encoder can skip them gracefully.
+function UTF8SeqLen(const AByte: Byte): Integer;
+begin
+  if AByte and $80 = 0 then
+    Result := 1
+  else if AByte and $E0 = $C0 then
+    Result := 2
+  else if AByte and $F0 = $E0 then
+    Result := 3
+  else if AByte and $F8 = $F0 then
+    Result := 4
+  else
+    Result := 1;
+end;
+
+{ TGocciaTextEncoderValue }
+
+constructor TGocciaTextEncoderValue.Create(const AClass: TGocciaClassValue = nil);
+begin
+  inherited Create(AClass);
+  InitializePrototype;
+  if not Assigned(AClass) and Assigned(FShared) then
+    FPrototype := FShared.Prototype;
+end;
+
+procedure TGocciaTextEncoderValue.InitializePrototype;
+var
+  Members: TGocciaMemberCollection;
+begin
+  if Assigned(FShared) then Exit;
+
+  FShared := TGocciaSharedPrototype.Create(Self);
+  if Length(FPrototypeMembers) = 0 then
+  begin
+    Members := TGocciaMemberCollection.Create;
+    try
+      Members.AddAccessor(PROP_ENCODING, EncodingGetter, nil, [pfConfigurable]);
+      Members.AddNamedMethod('encode', Encode, 1, gmkPrototypeMethod,
+        [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('encodeInto', EncodeInto, 2, gmkPrototypeMethod,
+        [gmfNoFunctionPrototype]);
+      FPrototypeMembers := Members.ToDefinitions;
+    finally
+      Members.Free;
+    end;
+  end;
+  RegisterMemberDefinitions(FShared.Prototype, FPrototypeMembers);
+end;
+
+class procedure TGocciaTextEncoderValue.ExposePrototype(const AConstructor: TGocciaValue);
+begin
+  if not Assigned(FShared) then
+    TGocciaTextEncoderValue.Create;
+  ExposeSharedPrototypeOnConstructor(FShared, AConstructor);
+end;
+
+function TGocciaTextEncoderValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_TEXT_ENCODER;
+end;
+
+procedure TGocciaTextEncoderValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+end;
+
+// WHATWG Encoding §8.3.1 get TextEncoder.prototype.encoding
+function TGocciaTextEncoderValue.EncodingGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  // TextEncoder always uses UTF-8 — no instance state required.
+  Result := TGocciaStringLiteralValue.Create(ENCODING_UTF8);
+end;
+
+// WHATWG Encoding §8.3.2 TextEncoder.prototype.encode(input = '')
+function TGocciaTextEncoderValue.Encode(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Input: string;
+  Bytes: TBytes;
+  NewTA: TGocciaTypedArrayValue;
+  I: Integer;
+begin
+  // Step 1: Let input be the empty string.
+  Input := '';
+  // Step 2: If input is given, convert to a scalar-value string.
+  if (AArgs.Length > 0) and not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
+    Input := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  // Step 3: Run UTF-8 encode on input and return the resulting Uint8Array.
+  Bytes := StringToUTF8Bytes(Input);
+  NewTA := TGocciaTypedArrayValue.Create(takUint8, Length(Bytes));
+  for I := 0 to Length(Bytes) - 1 do
+    NewTA.BufferData[NewTA.ByteOffset + I] := Bytes[I];
+  Result := NewTA;
+end;
+
+// WHATWG Encoding §8.3.3 TextEncoder.prototype.encodeInto(source, destination)
+function TGocciaTextEncoderValue.EncodeInto(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Source: string;
+  Dest: TGocciaTypedArrayValue;
+  Bytes: TBytes;
+  I, J, SeqLen, Written, Read, DestLen: Integer;
+  ResultObj: TGocciaObjectValue;
+begin
+  if AArgs.Length < 2 then
+    ThrowTypeError(
+      'TextEncoder.prototype.encodeInto requires source and destination arguments');
+
+  if AArgs.GetElement(0) is TGocciaUndefinedLiteralValue then
+    Source := ''
+  else
+    Source := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  if not (AArgs.GetElement(1) is TGocciaTypedArrayValue) then
+    ThrowTypeError(
+      'TextEncoder.prototype.encodeInto: destination must be a Uint8Array');
+  Dest := TGocciaTypedArrayValue(AArgs.GetElement(1));
+  if Dest.Kind <> takUint8 then
+    ThrowTypeError(
+      'TextEncoder.prototype.encodeInto: destination must be a Uint8Array');
+
+  // Convert source to UTF-8 bytes in a temporary buffer.
+  Bytes := StringToUTF8Bytes(Source);
+  DestLen := Dest.Length;
+  Written := 0;
+  Read := 0;
+  I := 0;
+
+  while I < Length(Bytes) do
+  begin
+    SeqLen := UTF8SeqLen(Bytes[I]);
+    // Stop before writing a sequence that would overflow the destination.
+    if Written + SeqLen > DestLen then Break;
+
+    for J := 0 to SeqLen - 1 do
+      Dest.BufferData[Dest.ByteOffset + Written + J] := Bytes[I + J];
+
+    Inc(Written, SeqLen);
+    Inc(I, SeqLen);
+    // Supplementary-plane code points (4-byte sequences) count as 2 UTF-16
+    // code units; everything else counts as 1.
+    if SeqLen = 4 then
+      Inc(Read, 2)
+    else
+      Inc(Read);
+  end;
+
+  // Return { read, written }.
+  ResultObj := TGocciaObjectValue.Create;
+  TGarbageCollector.Instance.AddTempRoot(ResultObj);
+  try
+    ResultObj.AssignProperty(PROP_READ, TGocciaNumberLiteralValue.Create(Read));
+    ResultObj.AssignProperty(PROP_WRITTEN, TGocciaNumberLiteralValue.Create(Written));
+    Result := ResultObj;
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(ResultObj);
+  end;
+end;
+
+end.


### PR DESCRIPTION
## Summary
- Added `TextEncoder` and `TextDecoder` globals with native constructors, prototype exposure, and `toStringTag` support.
- Implemented `TextEncoder.prototype.encode`, `TextEncoder.prototype.encodeInto`, and `TextDecoder.prototype.decode` with UTF-8 handling and BOM/fatal option support.
- Registered the new constructor/property names in the shared constants and wired both built-ins into engine initialization.
- Added end-to-end tests covering constructor behavior, encoding/decoding paths, options, and error cases.

## Testing
- Existing test coverage added for `tests/built-ins/TextEncoder/**` and `tests/built-ins/TextDecoder/**`.
- Manual checks implied by the diff: constructor creation, UTF-8 encoding/decoding, `encodeInto` boundary handling, BOM stripping, and fatal-mode errors.