### PR TITLE
Add URL and URLSearchParams built-ins

### DIFF
--- a/tests/built-ins/URL/canParse.js
+++ b/tests/built-ins/URL/canParse.js
@@ -1,0 +1,47 @@
+/*---
+description: URL.canParse static method
+features: [URL]
+---*/
+
+describe("URL.canParse", () => {
+  test("returns true for a valid absolute URL", () => {
+    expect(URL.canParse("https://example.com")).toBe(true);
+  });
+
+  test("returns true for URL with all components", () => {
+    expect(URL.canParse("https://user:pass@example.com:8080/path?q=1#hash")).toBe(true);
+  });
+
+  test("returns false for an invalid URL without base", () => {
+    expect(URL.canParse("not-a-url")).toBe(false);
+  });
+
+  test("returns false for empty string", () => {
+    expect(URL.canParse("")).toBe(false);
+  });
+
+  test("returns true for valid relative URL with base", () => {
+    expect(URL.canParse("/path", "https://example.com")).toBe(true);
+  });
+
+  test("returns true for relative URL with base URL object", () => {
+    const base = new URL("https://example.com/foo/");
+    expect(URL.canParse("bar", base)).toBe(true);
+  });
+
+  test("returns false for relative URL with invalid base string", () => {
+    expect(URL.canParse("/path", "not-valid")).toBe(false);
+  });
+
+  test("returns false for relative path without base", () => {
+    expect(URL.canParse("/path")).toBe(false);
+  });
+
+  test("returns true for http URL", () => {
+    expect(URL.canParse("http://example.com/page")).toBe(true);
+  });
+
+  test("returns true for file URL", () => {
+    expect(URL.canParse("file:///home/user/file.txt")).toBe(true);
+  });
+});

--- a/tests/built-ins/URL/constructor.js
+++ b/tests/built-ins/URL/constructor.js
@@ -1,0 +1,61 @@
+/*---
+description: URL constructor with absolute and relative URLs
+features: [URL]
+---*/
+
+describe("URL constructor", () => {
+  test("basic absolute URL normalizes href", () => {
+    const url = new URL("https://example.com");
+    expect(url.href).toBe("https://example.com/");
+  });
+
+  test("URL with all components", () => {
+    const url = new URL("https://user:pass@example.com:8080/path?q=1#hash");
+    expect(url.protocol).toBe("https:");
+    expect(url.username).toBe("user");
+    expect(url.password).toBe("pass");
+    expect(url.hostname).toBe("example.com");
+    expect(url.port).toBe("8080");
+    expect(url.pathname).toBe("/path");
+    expect(url.search).toBe("?q=1");
+    expect(url.hash).toBe("#hash");
+  });
+
+  test("relative URL with string base", () => {
+    const url = new URL("/path", "https://example.com");
+    expect(url.href).toBe("https://example.com/path");
+  });
+
+  test("relative URL with base URL object", () => {
+    const base = new URL("https://example.com/foo/baz");
+    const url = new URL("../bar", base);
+    expect(url.href).toBe("https://example.com/bar");
+  });
+
+  test("relative path resolves against base", () => {
+    const url = new URL("page.html", "https://example.com/dir/");
+    expect(url.href).toBe("https://example.com/dir/page.html");
+  });
+
+  test("throws TypeError for invalid URL without base", () => {
+    expect(() => new URL("not-a-url")).toThrow(TypeError);
+  });
+
+  test("throws TypeError for invalid base", () => {
+    expect(() => new URL("/path", "not-valid")).toThrow(TypeError);
+  });
+
+  test("throws TypeError with no arguments", () => {
+    expect(() => new URL()).toThrow(TypeError);
+  });
+
+  test("URL preserves trailing slash", () => {
+    const url = new URL("https://example.com/path/");
+    expect(url.pathname).toBe("/path/");
+  });
+
+  test("URL without path gets slash added", () => {
+    const url = new URL("https://example.com");
+    expect(url.pathname).toBe("/");
+  });
+});

--- a/tests/built-ins/URL/parse.js
+++ b/tests/built-ins/URL/parse.js
@@ -1,0 +1,52 @@
+/*---
+description: URL.parse static method
+features: [URL]
+---*/
+
+describe("URL.parse", () => {
+  test("returns a URL object for a valid absolute URL", () => {
+    const url = URL.parse("https://example.com/path");
+    expect(url).not.toBe(null);
+    expect(url.href).toBe("https://example.com/path");
+  });
+
+  test("returns null for an invalid URL", () => {
+    const result = URL.parse("not-a-url");
+    expect(result).toBe(null);
+  });
+
+  test("returns null for empty string", () => {
+    expect(URL.parse("")).toBe(null);
+  });
+
+  test("returns null for relative URL without base", () => {
+    expect(URL.parse("/path")).toBe(null);
+  });
+
+  test("works with a string base URL", () => {
+    const url = URL.parse("/path", "https://example.com");
+    expect(url).not.toBe(null);
+    expect(url.href).toBe("https://example.com/path");
+  });
+
+  test("works with a URL object as base", () => {
+    const base = new URL("https://example.com/dir/");
+    const url = URL.parse("file.html", base);
+    expect(url).not.toBe(null);
+    expect(url.href).toBe("https://example.com/dir/file.html");
+  });
+
+  test("returns null when base is invalid", () => {
+    const result = URL.parse("/path", "not-valid");
+    expect(result).toBe(null);
+  });
+
+  test("returned object has correct components", () => {
+    const url = URL.parse("https://example.com:9000/search?q=hello#section");
+    expect(url.hostname).toBe("example.com");
+    expect(url.port).toBe("9000");
+    expect(url.pathname).toBe("/search");
+    expect(url.search).toBe("?q=hello");
+    expect(url.hash).toBe("#section");
+  });
+});

--- a/tests/built-ins/URL/prototype/hash.js
+++ b/tests/built-ins/URL/prototype/hash.js
@@ -1,0 +1,51 @@
+/*---
+description: URL.prototype.hash getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.hash", () => {
+  test("getter returns fragment with leading hash", () => {
+    const url = new URL("https://example.com/path#section");
+    expect(url.hash).toBe("#section");
+  });
+
+  test("getter returns empty string when no fragment", () => {
+    const url = new URL("https://example.com/path");
+    expect(url.hash).toBe("");
+  });
+
+  test("getter returns empty string when no fragment but search present", () => {
+    const url = new URL("https://example.com/path?q=1");
+    expect(url.hash).toBe("");
+  });
+
+  test("setter updates the fragment", () => {
+    const url = new URL("https://example.com/path");
+    url.hash = "#newfrag";
+    expect(url.hash).toBe("#newfrag");
+  });
+
+  test("setter adds hash prefix if omitted", () => {
+    const url = new URL("https://example.com/path");
+    url.hash = "section2";
+    expect(url.hash).toBe("#section2");
+  });
+
+  test("setter with empty string clears fragment", () => {
+    const url = new URL("https://example.com/path#section");
+    url.hash = "";
+    expect(url.hash).toBe("");
+  });
+
+  test("href reflects updated hash", () => {
+    const url = new URL("https://example.com/path?q=1");
+    url.hash = "bottom";
+    expect(url.href).toBe("https://example.com/path?q=1#bottom");
+  });
+
+  test("clearing hash removes it from href", () => {
+    const url = new URL("https://example.com/path#top");
+    url.hash = "";
+    expect(url.href).toBe("https://example.com/path");
+  });
+});

--- a/tests/built-ins/URL/prototype/host.js
+++ b/tests/built-ins/URL/prototype/host.js
@@ -1,0 +1,46 @@
+/*---
+description: URL.prototype.host getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.host", () => {
+  test("getter returns hostname without port when no port", () => {
+    const url = new URL("https://example.com/path");
+    expect(url.host).toBe("example.com");
+  });
+
+  test("getter returns hostname:port when port is present", () => {
+    const url = new URL("https://example.com:8080/path");
+    expect(url.host).toBe("example.com:8080");
+  });
+
+  test("getter omits default https port 443", () => {
+    const url = new URL("https://example.com:443/path");
+    expect(url.host).toBe("example.com");
+  });
+
+  test("getter omits default http port 80", () => {
+    const url = new URL("http://example.com:80/path");
+    expect(url.host).toBe("example.com");
+  });
+
+  test("setter updates hostname", () => {
+    const url = new URL("https://example.com/path");
+    url.host = "other.org";
+    expect(url.hostname).toBe("other.org");
+    expect(url.port).toBe("");
+  });
+
+  test("setter updates hostname and port together", () => {
+    const url = new URL("https://example.com/path");
+    url.host = "other.org:9000";
+    expect(url.hostname).toBe("other.org");
+    expect(url.port).toBe("9000");
+  });
+
+  test("href reflects updated host", () => {
+    const url = new URL("https://example.com/path");
+    url.host = "newhost.com:3000";
+    expect(url.href).toBe("https://newhost.com:3000/path");
+  });
+});

--- a/tests/built-ins/URL/prototype/hostname.js
+++ b/tests/built-ins/URL/prototype/hostname.js
@@ -1,0 +1,47 @@
+/*---
+description: URL.prototype.hostname getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.hostname", () => {
+  test("getter returns hostname without port", () => {
+    const url = new URL("https://example.com:8080/path");
+    expect(url.hostname).toBe("example.com");
+  });
+
+  test("getter returns hostname for URL without port", () => {
+    const url = new URL("https://example.com/path");
+    expect(url.hostname).toBe("example.com");
+  });
+
+  test("getter returns IP address hostname", () => {
+    const url = new URL("https://192.168.1.1/path");
+    expect(url.hostname).toBe("192.168.1.1");
+  });
+
+  test("setter updates only the hostname, not port", () => {
+    const url = new URL("https://example.com:8080/path");
+    url.hostname = "other.org";
+    expect(url.hostname).toBe("other.org");
+    expect(url.port).toBe("8080");
+  });
+
+  test("setter does not accept port in hostname", () => {
+    const url = new URL("https://example.com/path");
+    url.hostname = "other.org:9000";
+    // port embedded in hostname string is ignored
+    expect(url.hostname).toBe("other.org");
+  });
+
+  test("href reflects updated hostname", () => {
+    const url = new URL("https://example.com/path");
+    url.hostname = "newhost.com";
+    expect(url.href).toBe("https://newhost.com/path");
+  });
+
+  test("href with port reflects updated hostname", () => {
+    const url = new URL("https://example.com:3000/path");
+    url.hostname = "other.org";
+    expect(url.href).toBe("https://other.org:3000/path");
+  });
+});

--- a/tests/built-ins/URL/prototype/href.js
+++ b/tests/built-ins/URL/prototype/href.js
@@ -1,0 +1,45 @@
+/*---
+description: URL.prototype.href getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.href", () => {
+  test("getter returns the full serialized URL", () => {
+    const url = new URL("https://example.com/path?q=1#hash");
+    expect(url.href).toBe("https://example.com/path?q=1#hash");
+  });
+
+  test("getter includes trailing slash for bare origin", () => {
+    const url = new URL("https://example.com");
+    expect(url.href).toBe("https://example.com/");
+  });
+
+  test("setter updates the entire URL", () => {
+    const url = new URL("https://example.com/old");
+    url.href = "https://other.org/new?x=2#frag";
+    expect(url.href).toBe("https://other.org/new?x=2#frag");
+    expect(url.hostname).toBe("other.org");
+    expect(url.pathname).toBe("/new");
+    expect(url.search).toBe("?x=2");
+    expect(url.hash).toBe("#frag");
+  });
+
+  test("setter with just a different path updates href", () => {
+    const url = new URL("https://example.com/old");
+    url.href = "https://example.com/new";
+    expect(url.pathname).toBe("/new");
+  });
+
+  test("setter throws TypeError for invalid URL", () => {
+    const url = new URL("https://example.com");
+    expect(() => {
+      url.href = "not-a-url";
+    }).toThrow(TypeError);
+  });
+
+  test("href reflects changes made via other setters", () => {
+    const url = new URL("https://example.com/path");
+    url.pathname = "/updated";
+    expect(url.href).toBe("https://example.com/updated");
+  });
+});

--- a/tests/built-ins/URL/prototype/href.js
+++ b/tests/built-ins/URL/prototype/href.js
@@ -27,7 +27,7 @@ describe("URL.prototype.href", () => {
   test("setter with just a different path updates href", () => {
     const url = new URL("https://example.com/old");
     url.href = "https://example.com/new";
-    expect(url.pathname).toBe("/new");
+    expect(url.href).toBe("https://example.com/new");
   });
 
   test("setter throws TypeError for invalid URL", () => {

--- a/tests/built-ins/URL/prototype/origin.js
+++ b/tests/built-ins/URL/prototype/origin.js
@@ -1,0 +1,46 @@
+/*---
+description: URL.prototype.origin getter
+features: [URL]
+---*/
+
+describe("URL.prototype.origin", () => {
+  test("https URL origin is scheme + host", () => {
+    const url = new URL("https://example.com/path");
+    expect(url.origin).toBe("https://example.com");
+  });
+
+  test("https URL with non-default port includes port", () => {
+    const url = new URL("https://example.com:8080/path");
+    expect(url.origin).toBe("https://example.com:8080");
+  });
+
+  test("https URL on default port 443 omits port", () => {
+    const url = new URL("https://example.com:443/path");
+    expect(url.origin).toBe("https://example.com");
+  });
+
+  test("http URL origin is scheme + host", () => {
+    const url = new URL("http://example.com/path");
+    expect(url.origin).toBe("http://example.com");
+  });
+
+  test("http URL on default port 80 omits port", () => {
+    const url = new URL("http://example.com:80/path");
+    expect(url.origin).toBe("http://example.com");
+  });
+
+  test("http URL with non-default port includes port", () => {
+    const url = new URL("http://example.com:8080/path");
+    expect(url.origin).toBe("http://example.com:8080");
+  });
+
+  test("file URL has opaque origin of null", () => {
+    const url = new URL("file:///home/user/file.txt");
+    expect(url.origin).toBe("null");
+  });
+
+  test("data URL has opaque origin of null", () => {
+    const url = new URL("data:text/plain,hello");
+    expect(url.origin).toBe("null");
+  });
+});

--- a/tests/built-ins/URL/prototype/password.js
+++ b/tests/built-ins/URL/prototype/password.js
@@ -1,0 +1,45 @@
+/*---
+description: URL.prototype.password getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.password", () => {
+  test("getter returns password from URL", () => {
+    const url = new URL("https://user:pass@example.com");
+    expect(url.password).toBe("pass");
+  });
+
+  test("getter returns empty string when no password", () => {
+    const url = new URL("https://example.com");
+    expect(url.password).toBe("");
+  });
+
+  test("getter returns empty string when only username is present", () => {
+    const url = new URL("https://user@example.com");
+    expect(url.password).toBe("");
+  });
+
+  test("setter updates the password", () => {
+    const url = new URL("https://user@example.com");
+    url.password = "secret";
+    expect(url.password).toBe("secret");
+  });
+
+  test("setter encodes special characters in password", () => {
+    const url = new URL("https://user@example.com");
+    url.password = "p@ss word";
+    expect(url.password).toBe("p%40ss%20word");
+  });
+
+  test("setter with empty string clears password", () => {
+    const url = new URL("https://user:pass@example.com");
+    url.password = "";
+    expect(url.password).toBe("");
+  });
+
+  test("href reflects updated password", () => {
+    const url = new URL("https://user@example.com/path");
+    url.password = "newpass";
+    expect(url.href).toBe("https://user:newpass@example.com/path");
+  });
+});

--- a/tests/built-ins/URL/prototype/pathname.js
+++ b/tests/built-ins/URL/prototype/pathname.js
@@ -42,7 +42,7 @@ describe("URL.prototype.pathname", () => {
     expect(url.href).toBe("https://example.com/new?q=1");
   });
 
-  test("setting empty pathname results in slash", () => {
+  test("setting pathname to '/' results in slash", () => {
     const url = new URL("https://example.com/path");
     url.pathname = "/";
     expect(url.pathname).toBe("/");

--- a/tests/built-ins/URL/prototype/pathname.js
+++ b/tests/built-ins/URL/prototype/pathname.js
@@ -1,0 +1,50 @@
+/*---
+description: URL.prototype.pathname getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.pathname", () => {
+  test("getter returns the path", () => {
+    const url = new URL("https://example.com/foo/bar");
+    expect(url.pathname).toBe("/foo/bar");
+  });
+
+  test("getter returns slash for bare origin URL", () => {
+    const url = new URL("https://example.com");
+    expect(url.pathname).toBe("/");
+  });
+
+  test("getter returns path with trailing slash", () => {
+    const url = new URL("https://example.com/path/");
+    expect(url.pathname).toBe("/path/");
+  });
+
+  test("getter does not include search or hash", () => {
+    const url = new URL("https://example.com/path?q=1#hash");
+    expect(url.pathname).toBe("/path");
+  });
+
+  test("setter updates the path", () => {
+    const url = new URL("https://example.com/old");
+    url.pathname = "/new/path";
+    expect(url.pathname).toBe("/new/path");
+  });
+
+  test("setter adds leading slash if omitted", () => {
+    const url = new URL("https://example.com/old");
+    url.pathname = "new/path";
+    expect(url.pathname).toBe("/new/path");
+  });
+
+  test("href reflects updated pathname", () => {
+    const url = new URL("https://example.com/old?q=1");
+    url.pathname = "/new";
+    expect(url.href).toBe("https://example.com/new?q=1");
+  });
+
+  test("setting empty pathname results in slash", () => {
+    const url = new URL("https://example.com/path");
+    url.pathname = "/";
+    expect(url.pathname).toBe("/");
+  });
+});

--- a/tests/built-ins/URL/prototype/port.js
+++ b/tests/built-ins/URL/prototype/port.js
@@ -51,5 +51,6 @@ describe("URL.prototype.port", () => {
     const url = new URL("https://example.com:8080/path");
     url.port = "443";
     expect(url.port).toBe("");
+    expect(url.href).toBe("https://example.com/path");
   });
 });

--- a/tests/built-ins/URL/prototype/port.js
+++ b/tests/built-ins/URL/prototype/port.js
@@ -1,0 +1,55 @@
+/*---
+description: URL.prototype.port getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.port", () => {
+  test("getter returns port string when port is present", () => {
+    const url = new URL("https://example.com:8080/path");
+    expect(url.port).toBe("8080");
+  });
+
+  test("getter returns empty string when no port specified", () => {
+    const url = new URL("https://example.com/path");
+    expect(url.port).toBe("");
+  });
+
+  test("default https port 443 returns empty string", () => {
+    const url = new URL("https://example.com:443/path");
+    expect(url.port).toBe("");
+  });
+
+  test("default http port 80 returns empty string", () => {
+    const url = new URL("http://example.com:80/path");
+    expect(url.port).toBe("");
+  });
+
+  test("non-default port on http is returned", () => {
+    const url = new URL("http://example.com:8080/path");
+    expect(url.port).toBe("8080");
+  });
+
+  test("setter updates the port", () => {
+    const url = new URL("https://example.com/path");
+    url.port = "3000";
+    expect(url.port).toBe("3000");
+  });
+
+  test("setter with empty string clears port", () => {
+    const url = new URL("https://example.com:8080/path");
+    url.port = "";
+    expect(url.port).toBe("");
+  });
+
+  test("href reflects updated port", () => {
+    const url = new URL("https://example.com/path");
+    url.port = "9090";
+    expect(url.href).toBe("https://example.com:9090/path");
+  });
+
+  test("setting default port clears it from href", () => {
+    const url = new URL("https://example.com:8080/path");
+    url.port = "443";
+    expect(url.port).toBe("");
+  });
+});

--- a/tests/built-ins/URL/prototype/protocol.js
+++ b/tests/built-ins/URL/prototype/protocol.js
@@ -1,0 +1,40 @@
+/*---
+description: URL.prototype.protocol getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.protocol", () => {
+  test("getter returns scheme with colon for https", () => {
+    const url = new URL("https://example.com");
+    expect(url.protocol).toBe("https:");
+  });
+
+  test("getter returns scheme with colon for http", () => {
+    const url = new URL("http://example.com");
+    expect(url.protocol).toBe("http:");
+  });
+
+  test("getter returns scheme with colon for ftp", () => {
+    const url = new URL("ftp://example.com/file");
+    expect(url.protocol).toBe("ftp:");
+  });
+
+  test("setter updates the scheme", () => {
+    const url = new URL("https://example.com/path");
+    url.protocol = "http:";
+    expect(url.protocol).toBe("http:");
+    expect(url.href).toBe("http://example.com/path");
+  });
+
+  test("setter accepts scheme without colon", () => {
+    const url = new URL("https://example.com/path");
+    url.protocol = "http";
+    expect(url.protocol).toBe("http:");
+  });
+
+  test("setter updates origin when protocol changes", () => {
+    const url = new URL("https://example.com");
+    url.protocol = "http:";
+    expect(url.origin).toBe("http://example.com");
+  });
+});

--- a/tests/built-ins/URL/prototype/search.js
+++ b/tests/built-ins/URL/prototype/search.js
@@ -1,0 +1,51 @@
+/*---
+description: URL.prototype.search getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.search", () => {
+  test("getter returns query string with leading question mark", () => {
+    const url = new URL("https://example.com/path?q=1&r=2");
+    expect(url.search).toBe("?q=1&r=2");
+  });
+
+  test("getter returns empty string when no query", () => {
+    const url = new URL("https://example.com/path");
+    expect(url.search).toBe("");
+  });
+
+  test("getter does not include the hash fragment", () => {
+    const url = new URL("https://example.com/path?q=1#hash");
+    expect(url.search).toBe("?q=1");
+  });
+
+  test("setter updates the search string", () => {
+    const url = new URL("https://example.com/path");
+    url.search = "?key=value";
+    expect(url.search).toBe("?key=value");
+  });
+
+  test("setter with string without leading question mark adds it", () => {
+    const url = new URL("https://example.com/path");
+    url.search = "key=value";
+    expect(url.search).toBe("?key=value");
+  });
+
+  test("setter with empty string clears the query", () => {
+    const url = new URL("https://example.com/path?q=1");
+    url.search = "";
+    expect(url.search).toBe("");
+  });
+
+  test("href reflects updated search", () => {
+    const url = new URL("https://example.com/path?old=1");
+    url.search = "new=2";
+    expect(url.href).toBe("https://example.com/path?new=2");
+  });
+
+  test("clearing search removes question mark from href", () => {
+    const url = new URL("https://example.com/path?q=1");
+    url.search = "";
+    expect(url.href).toBe("https://example.com/path");
+  });
+});

--- a/tests/built-ins/URL/prototype/searchParams.js
+++ b/tests/built-ins/URL/prototype/searchParams.js
@@ -1,0 +1,55 @@
+/*---
+description: URL.prototype.searchParams getter
+features: [URL, URLSearchParams]
+---*/
+
+describe("URL.prototype.searchParams", () => {
+  test("returns a URLSearchParams object", () => {
+    const url = new URL("https://example.com/path?a=1&b=2");
+    const params = url.searchParams;
+    expect(params instanceof URLSearchParams).toBe(true);
+  });
+
+  test("searchParams reflects existing query string", () => {
+    const url = new URL("https://example.com/path?a=1&b=2");
+    expect(url.searchParams.get("a")).toBe("1");
+    expect(url.searchParams.get("b")).toBe("2");
+  });
+
+  test("empty query gives empty searchParams", () => {
+    const url = new URL("https://example.com/path");
+    expect(url.searchParams.get("a")).toBe(null);
+  });
+
+  test("modifying searchParams updates url.search", () => {
+    const url = new URL("https://example.com/path?a=1");
+    url.searchParams.set("a", "2");
+    expect(url.search).toBe("?a=2");
+  });
+
+  test("appending to searchParams updates url.search", () => {
+    const url = new URL("https://example.com/path");
+    url.searchParams.append("x", "hello");
+    expect(url.search).toBe("?x=hello");
+  });
+
+  test("deleting from searchParams updates url.search", () => {
+    const url = new URL("https://example.com/path?a=1&b=2");
+    url.searchParams.delete("a");
+    expect(url.search).toBe("?b=2");
+  });
+
+  test("setting url.search updates searchParams", () => {
+    const url = new URL("https://example.com/path?a=1");
+    url.search = "?b=99";
+    expect(url.searchParams.get("b")).toBe("99");
+    expect(url.searchParams.get("a")).toBe(null);
+  });
+
+  test("returns same object on repeated access", () => {
+    const url = new URL("https://example.com/path?a=1");
+    const p1 = url.searchParams;
+    const p2 = url.searchParams;
+    expect(p1).toBe(p2);
+  });
+});

--- a/tests/built-ins/URL/prototype/toJSON.js
+++ b/tests/built-ins/URL/prototype/toJSON.js
@@ -1,0 +1,35 @@
+/*---
+description: URL.prototype.toJSON
+features: [URL]
+---*/
+
+describe("URL.prototype.toJSON", () => {
+  test("toJSON returns the same value as href", () => {
+    const url = new URL("https://example.com/path?q=1#hash");
+    expect(url.toJSON()).toBe(url.href);
+  });
+
+  test("toJSON for bare origin URL", () => {
+    const url = new URL("https://example.com");
+    expect(url.toJSON()).toBe("https://example.com/");
+  });
+
+  test("toJSON equals toString", () => {
+    const url = new URL("https://example.com/path?q=1");
+    expect(url.toJSON()).toBe(url.toString());
+  });
+
+  test("toJSON after modifying the URL", () => {
+    const url = new URL("https://example.com/old");
+    url.pathname = "/new";
+    url.search = "updated=true";
+    expect(url.toJSON()).toBe(url.href);
+  });
+
+  test("JSON.stringify uses toJSON", () => {
+    const url = new URL("https://example.com/path");
+    const obj = { url };
+    const parsed = JSON.parse(JSON.stringify(obj));
+    expect(parsed.url).toBe(url.href);
+  });
+});

--- a/tests/built-ins/URL/prototype/toString.js
+++ b/tests/built-ins/URL/prototype/toString.js
@@ -1,0 +1,39 @@
+/*---
+description: URL.prototype.toString
+features: [URL]
+---*/
+
+describe("URL.prototype.toString", () => {
+  test("toString returns the same value as href", () => {
+    const url = new URL("https://example.com/path?q=1#hash");
+    expect(url.toString()).toBe(url.href);
+  });
+
+  test("toString for bare origin URL", () => {
+    const url = new URL("https://example.com");
+    expect(url.toString()).toBe("https://example.com/");
+  });
+
+  test("toString after modifying pathname", () => {
+    const url = new URL("https://example.com/old");
+    url.pathname = "/new";
+    expect(url.toString()).toBe(url.href);
+  });
+
+  test("toString after modifying search", () => {
+    const url = new URL("https://example.com/path");
+    url.search = "x=1";
+    expect(url.toString()).toBe(url.href);
+  });
+
+  test("toString after modifying hash", () => {
+    const url = new URL("https://example.com/path");
+    url.hash = "section";
+    expect(url.toString()).toBe(url.href);
+  });
+
+  test("toString reflects full URL with credentials", () => {
+    const url = new URL("https://user:pass@example.com/path");
+    expect(url.toString()).toBe(url.href);
+  });
+});

--- a/tests/built-ins/URL/prototype/username.js
+++ b/tests/built-ins/URL/prototype/username.js
@@ -1,0 +1,45 @@
+/*---
+description: URL.prototype.username getter and setter
+features: [URL]
+---*/
+
+describe("URL.prototype.username", () => {
+  test("getter returns username from URL", () => {
+    const url = new URL("https://user@example.com");
+    expect(url.username).toBe("user");
+  });
+
+  test("getter returns empty string when no username", () => {
+    const url = new URL("https://example.com");
+    expect(url.username).toBe("");
+  });
+
+  test("getter returns username when both username and password are present", () => {
+    const url = new URL("https://user:pass@example.com");
+    expect(url.username).toBe("user");
+  });
+
+  test("setter updates the username", () => {
+    const url = new URL("https://example.com");
+    url.username = "newuser";
+    expect(url.username).toBe("newuser");
+  });
+
+  test("setter encodes special characters in username", () => {
+    const url = new URL("https://example.com");
+    url.username = "user name";
+    expect(url.username).toBe("user%20name");
+  });
+
+  test("setter with empty string clears username", () => {
+    const url = new URL("https://user@example.com");
+    url.username = "";
+    expect(url.username).toBe("");
+  });
+
+  test("href reflects updated username", () => {
+    const url = new URL("https://example.com/path");
+    url.username = "admin";
+    expect(url.href).toBe("https://admin@example.com/path");
+  });
+});

--- a/tests/built-ins/URLSearchParams/constructor.js
+++ b/tests/built-ins/URLSearchParams/constructor.js
@@ -85,4 +85,10 @@ describe("URLSearchParams constructor", () => {
     // "123" (no "=") parses as key "123" with empty value → "123="
     expect(params.toString()).toBe("123=");
   });
+
+  test("explicit undefined init creates empty params", () => {
+    const params = new URLSearchParams(undefined);
+    expect(params.size).toBe(0);
+    expect(params.toString()).toBe("");
+  });
 });

--- a/tests/built-ins/URLSearchParams/constructor.js
+++ b/tests/built-ins/URLSearchParams/constructor.js
@@ -72,4 +72,10 @@ describe("URLSearchParams constructor", () => {
       new URLSearchParams([[]]);
     }).toThrow(TypeError);
   });
+
+  test("malformed pair with more than 2 elements throws", () => {
+    expect(() => {
+      new URLSearchParams([["a", "1", "extra"]]);
+    }).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/URLSearchParams/constructor.js
+++ b/tests/built-ins/URLSearchParams/constructor.js
@@ -78,4 +78,11 @@ describe("URLSearchParams constructor", () => {
       new URLSearchParams([["a", "1", "extra"]]);
     }).toThrow(TypeError);
   });
+
+  test("numeric argument is coerced to string and parsed", () => {
+    // URLSearchParams(123) coerces 123 to "123" then parses as form-encoded
+    const params = new URLSearchParams(123);
+    // "123" (no "=") parses as key "123" with empty value → "123="
+    expect(params.toString()).toBe("123=");
+  });
 });

--- a/tests/built-ins/URLSearchParams/constructor.js
+++ b/tests/built-ins/URLSearchParams/constructor.js
@@ -60,4 +60,16 @@ describe("URLSearchParams constructor", () => {
     const params = new URLSearchParams("a=hello+world");
     expect(params.get("a")).toBe("hello world");
   });
+
+  test("malformed pair with fewer than 2 elements throws", () => {
+    expect(() => {
+      new URLSearchParams([["only-name"]]);
+    }).toThrow(TypeError);
+  });
+
+  test("malformed pair with no elements throws", () => {
+    expect(() => {
+      new URLSearchParams([[]]);
+    }).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/URLSearchParams/constructor.js
+++ b/tests/built-ins/URLSearchParams/constructor.js
@@ -1,0 +1,63 @@
+/*---
+description: URLSearchParams constructor
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams constructor", () => {
+  test("no arguments creates empty params", () => {
+    const params = new URLSearchParams();
+    expect(params.size).toBe(0);
+  });
+
+  test("string argument parses key=value pairs", () => {
+    const params = new URLSearchParams("a=1&b=2");
+    expect(params.get("a")).toBe("1");
+    expect(params.get("b")).toBe("2");
+    expect(params.size).toBe(2);
+  });
+
+  test("string with leading question mark strips it", () => {
+    const params = new URLSearchParams("?a=1&b=2");
+    expect(params.get("a")).toBe("1");
+    expect(params.get("b")).toBe("2");
+  });
+
+  test("array of pairs initializes params", () => {
+    const params = new URLSearchParams([["a", "1"], ["b", "2"]]);
+    expect(params.get("a")).toBe("1");
+    expect(params.get("b")).toBe("2");
+  });
+
+  test("array allows duplicate keys", () => {
+    const params = new URLSearchParams([["a", "1"], ["a", "2"]]);
+    expect(params.getAll("a")).toEqual(["1", "2"]);
+  });
+
+  test("object initializes params from own enumerable properties", () => {
+    const params = new URLSearchParams({ a: "1", b: "2" });
+    expect(params.get("a")).toBe("1");
+    expect(params.get("b")).toBe("2");
+  });
+
+  test("copy from another URLSearchParams", () => {
+    const source = new URLSearchParams("x=10&y=20");
+    const copy = new URLSearchParams(source);
+    expect(copy.get("x")).toBe("10");
+    expect(copy.get("y")).toBe("20");
+  });
+
+  test("empty string creates empty params", () => {
+    const params = new URLSearchParams("");
+    expect(params.size).toBe(0);
+  });
+
+  test("string with encoded characters is decoded", () => {
+    const params = new URLSearchParams("a=hello%20world");
+    expect(params.get("a")).toBe("hello world");
+  });
+
+  test("plus sign in string is decoded as space", () => {
+    const params = new URLSearchParams("a=hello+world");
+    expect(params.get("a")).toBe("hello world");
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/append.js
+++ b/tests/built-ins/URLSearchParams/prototype/append.js
@@ -1,0 +1,53 @@
+/*---
+description: URLSearchParams.prototype.append
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.append", () => {
+  test("appends a new key-value pair", () => {
+    const params = new URLSearchParams();
+    params.append("a", "1");
+    expect(params.get("a")).toBe("1");
+  });
+
+  test("appending to existing key adds another entry", () => {
+    const params = new URLSearchParams("a=1");
+    params.append("a", "2");
+    expect(params.getAll("a")).toEqual(["1", "2"]);
+  });
+
+  test("size increases with each append", () => {
+    const params = new URLSearchParams();
+    params.append("a", "1");
+    params.append("b", "2");
+    expect(params.size).toBe(2);
+  });
+
+  test("appending duplicate key does not remove first", () => {
+    const params = new URLSearchParams("a=1");
+    params.append("a", "2");
+    expect(params.size).toBe(2);
+    expect(params.get("a")).toBe("1");
+  });
+
+  test("appended value is accessible via getAll", () => {
+    const params = new URLSearchParams();
+    params.append("color", "red");
+    params.append("color", "blue");
+    params.append("color", "green");
+    expect(params.getAll("color")).toEqual(["red", "blue", "green"]);
+  });
+
+  test("append encodes special characters", () => {
+    const params = new URLSearchParams();
+    params.append("q", "hello world");
+    expect(params.get("q")).toBe("hello world");
+    expect(params.toString()).toContain("q=hello+world");
+  });
+
+  test("append with empty string value", () => {
+    const params = new URLSearchParams();
+    params.append("key", "");
+    expect(params.get("key")).toBe("");
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/delete.js
+++ b/tests/built-ins/URLSearchParams/prototype/delete.js
@@ -1,0 +1,51 @@
+/*---
+description: URLSearchParams.prototype.delete
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.delete", () => {
+  test("deletes all entries with the given name", () => {
+    const params = new URLSearchParams("a=1&b=2&a=3");
+    params.delete("a");
+    expect(params.has("a")).toBe(false);
+    expect(params.get("b")).toBe("2");
+  });
+
+  test("deleting nonexistent key does nothing", () => {
+    const params = new URLSearchParams("a=1");
+    params.delete("z");
+    expect(params.size).toBe(1);
+  });
+
+  test("size decreases after delete", () => {
+    const params = new URLSearchParams("a=1&b=2");
+    params.delete("a");
+    expect(params.size).toBe(1);
+  });
+
+  test("delete with value removes only matching entry", () => {
+    const params = new URLSearchParams("a=1&a=2&a=3");
+    params.delete("a", "2");
+    expect(params.getAll("a")).toEqual(["1", "3"]);
+  });
+
+  test("delete with value does nothing if value not found", () => {
+    const params = new URLSearchParams("a=1&a=2");
+    params.delete("a", "99");
+    expect(params.getAll("a")).toEqual(["1", "2"]);
+  });
+
+  test("delete with value removes all matching pairs", () => {
+    const params = new URLSearchParams("a=1&a=1&b=2");
+    params.delete("a", "1");
+    expect(params.getAll("a")).toEqual([]);
+    expect(params.size).toBe(1);
+  });
+
+  test("delete last entry results in empty params", () => {
+    const params = new URLSearchParams("a=1");
+    params.delete("a");
+    expect(params.size).toBe(0);
+    expect(params.toString()).toBe("");
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/delete.js
+++ b/tests/built-ins/URLSearchParams/prototype/delete.js
@@ -4,6 +4,12 @@ features: [URLSearchParams]
 ---*/
 
 describe("URLSearchParams.prototype.delete", () => {
+  test("deleting via url.searchParams updates url.search", () => {
+    const url = new URL("https://example.com/?a=1&a=2&b=3");
+    url.searchParams.delete("a");
+    expect(url.search).toBe("?b=3");
+  });
+
   test("deletes all entries with the given name", () => {
     const params = new URLSearchParams("a=1&b=2&a=3");
     params.delete("a");

--- a/tests/built-ins/URLSearchParams/prototype/entries.js
+++ b/tests/built-ins/URLSearchParams/prototype/entries.js
@@ -1,0 +1,63 @@
+/*---
+description: URLSearchParams.prototype.entries
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.entries", () => {
+  test("returns an iterator of [name, value] pairs", () => {
+    const params = new URLSearchParams("a=1&b=2");
+    const entries = [];
+    for (const entry of params.entries()) {
+      entries.push(entry);
+    }
+    expect(entries).toEqual([["a", "1"], ["b", "2"]]);
+  });
+
+  test("duplicate keys produce separate entries", () => {
+    const params = new URLSearchParams("a=1&a=2");
+    const entries = [];
+    for (const entry of params.entries()) {
+      entries.push(entry);
+    }
+    expect(entries).toEqual([["a", "1"], ["a", "2"]]);
+  });
+
+  test("returns empty iterator for empty params", () => {
+    const params = new URLSearchParams();
+    const entries = [];
+    for (const entry of params.entries()) {
+      entries.push(entry);
+    }
+    expect(entries).toEqual([]);
+  });
+
+  test("each entry is a two-element array", () => {
+    const params = new URLSearchParams("key=val");
+    for (const entry of params.entries()) {
+      expect(entry.length).toBe(2);
+      expect(entry[0]).toBe("key");
+      expect(entry[1]).toBe("val");
+    }
+  });
+
+  test("entries can be spread into an array", () => {
+    const params = new URLSearchParams("x=10&y=20");
+    const entries = [...params.entries()];
+    expect(entries).toEqual([["x", "10"], ["y", "20"]]);
+  });
+
+  test("entries values are decoded", () => {
+    const params = new URLSearchParams("a=hello+world");
+    const entries = [...params.entries()];
+    expect(entries[0]).toEqual(["a", "hello world"]);
+  });
+
+  test("URLSearchParams is itself iterable and yields entries", () => {
+    const params = new URLSearchParams("a=1&b=2");
+    const entries = [];
+    for (const entry of params) {
+      entries.push(entry);
+    }
+    expect(entries).toEqual([["a", "1"], ["b", "2"]]);
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/forEach.js
+++ b/tests/built-ins/URLSearchParams/prototype/forEach.js
@@ -57,4 +57,14 @@ describe("URLSearchParams.prototype.forEach", () => {
     });
     expect(count).toBe(3);
   });
+
+  test("throws TypeError when callback is not callable", () => {
+    const params = new URLSearchParams("a=1");
+    expect(() => {
+      params.forEach(null);
+    }).toThrow(TypeError);
+    expect(() => {
+      params.forEach(42);
+    }).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/URLSearchParams/prototype/forEach.js
+++ b/tests/built-ins/URLSearchParams/prototype/forEach.js
@@ -1,0 +1,60 @@
+/*---
+description: URLSearchParams.prototype.forEach
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.forEach", () => {
+  test("iterates over all key-value entries", () => {
+    const params = new URLSearchParams("a=1&b=2&c=3");
+    const collected = [];
+    params.forEach((value, name) => {
+      collected.push([name, value]);
+    });
+    expect(collected).toEqual([["a", "1"], ["b", "2"], ["c", "3"]]);
+  });
+
+  test("callback receives value as first argument, name as second", () => {
+    const params = new URLSearchParams("key=val");
+    params.forEach((value, name) => {
+      expect(name).toBe("key");
+      expect(value).toBe("val");
+    });
+  });
+
+  test("callback receives URLSearchParams as third argument", () => {
+    const params = new URLSearchParams("a=1");
+    params.forEach((value, name, searchParams) => {
+      expect(searchParams).toBe(params);
+    });
+  });
+
+  test("iterates duplicate keys in order", () => {
+    const params = new URLSearchParams("a=1&a=2&b=3");
+    const names = [];
+    const values = [];
+    params.forEach((value, name) => {
+      names.push(name);
+      values.push(value);
+    });
+    expect(names).toEqual(["a", "a", "b"]);
+    expect(values).toEqual(["1", "2", "3"]);
+  });
+
+  test("callback not called for empty params", () => {
+    const params = new URLSearchParams();
+    let called = false;
+    params.forEach(() => {
+      called = true;
+    });
+    expect(called).toBe(false);
+  });
+
+  test("call count matches number of entries", () => {
+    const params = new URLSearchParams("a=1&b=2&c=3");
+    let count = 0;
+    params.forEach(() => {
+      count++;
+    });
+    expect(count).toBe(3);
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/forEach.js
+++ b/tests/built-ins/URLSearchParams/prototype/forEach.js
@@ -67,4 +67,11 @@ describe("URLSearchParams.prototype.forEach", () => {
       params.forEach(42);
     }).toThrow(TypeError);
   });
+
+  test("throws TypeError when called with no arguments", () => {
+    const params = new URLSearchParams("a=1");
+    expect(() => {
+      params.forEach();
+    }).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/URLSearchParams/prototype/get.js
+++ b/tests/built-ins/URLSearchParams/prototype/get.js
@@ -1,0 +1,47 @@
+/*---
+description: URLSearchParams.prototype.get
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.get", () => {
+  test("returns the value for the given name", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.get("a")).toBe("1");
+  });
+
+  test("returns null for a nonexistent name", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.get("b")).toBe(null);
+  });
+
+  test("returns the first value when multiple exist", () => {
+    const params = new URLSearchParams("a=1&a=2&a=3");
+    expect(params.get("a")).toBe("1");
+  });
+
+  test("returns empty string for key with empty value", () => {
+    const params = new URLSearchParams("a=");
+    expect(params.get("a")).toBe("");
+  });
+
+  test("returns decoded value", () => {
+    const params = new URLSearchParams("a=hello%20world");
+    expect(params.get("a")).toBe("hello world");
+  });
+
+  test("returns decoded plus-as-space", () => {
+    const params = new URLSearchParams("a=hello+world");
+    expect(params.get("a")).toBe("hello world");
+  });
+
+  test("returns null on empty params", () => {
+    const params = new URLSearchParams();
+    expect(params.get("anything")).toBe(null);
+  });
+
+  test("key is case-sensitive", () => {
+    const params = new URLSearchParams("Key=value");
+    expect(params.get("Key")).toBe("value");
+    expect(params.get("key")).toBe(null);
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/getAll.js
+++ b/tests/built-ins/URLSearchParams/prototype/getAll.js
@@ -1,0 +1,45 @@
+/*---
+description: URLSearchParams.prototype.getAll
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.getAll", () => {
+  test("returns array with single value", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.getAll("a")).toEqual(["1"]);
+  });
+
+  test("returns all values for duplicate keys", () => {
+    const params = new URLSearchParams("a=1&a=2&a=3");
+    expect(params.getAll("a")).toEqual(["1", "2", "3"]);
+  });
+
+  test("returns empty array for nonexistent key", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.getAll("b")).toEqual([]);
+  });
+
+  test("returns values in insertion order", () => {
+    const params = new URLSearchParams();
+    params.append("x", "c");
+    params.append("x", "a");
+    params.append("x", "b");
+    expect(params.getAll("x")).toEqual(["c", "a", "b"]);
+  });
+
+  test("returns decoded values", () => {
+    const params = new URLSearchParams("a=hello+world&a=foo%20bar");
+    expect(params.getAll("a")).toEqual(["hello world", "foo bar"]);
+  });
+
+  test("returns empty array on empty params", () => {
+    const params = new URLSearchParams();
+    expect(params.getAll("a")).toEqual([]);
+  });
+
+  test("only returns values for the specified key", () => {
+    const params = new URLSearchParams("a=1&b=2&a=3&b=4");
+    expect(params.getAll("a")).toEqual(["1", "3"]);
+    expect(params.getAll("b")).toEqual(["2", "4"]);
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/has.js
+++ b/tests/built-ins/URLSearchParams/prototype/has.js
@@ -1,0 +1,60 @@
+/*---
+description: URLSearchParams.prototype.has
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.has", () => {
+  test("returns true for an existing key", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.has("a")).toBe(true);
+  });
+
+  test("returns false for a nonexistent key", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.has("b")).toBe(false);
+  });
+
+  test("returns false for empty params", () => {
+    const params = new URLSearchParams();
+    expect(params.has("a")).toBe(false);
+  });
+
+  test("is case-sensitive", () => {
+    const params = new URLSearchParams("Key=value");
+    expect(params.has("Key")).toBe(true);
+    expect(params.has("key")).toBe(false);
+  });
+
+  test("has with value returns true when name and value match", () => {
+    const params = new URLSearchParams("a=1&a=2");
+    expect(params.has("a", "1")).toBe(true);
+    expect(params.has("a", "2")).toBe(true);
+  });
+
+  test("has with value returns false when value does not match", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.has("a", "99")).toBe(false);
+  });
+
+  test("has with value returns false for nonexistent key", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.has("b", "1")).toBe(false);
+  });
+
+  test("returns true when key has empty string value and checked with empty string", () => {
+    const params = new URLSearchParams("a=");
+    expect(params.has("a", "")).toBe(true);
+  });
+
+  test("returns true after appending key", () => {
+    const params = new URLSearchParams();
+    params.append("x", "y");
+    expect(params.has("x")).toBe(true);
+  });
+
+  test("returns false after deleting key", () => {
+    const params = new URLSearchParams("a=1");
+    params.delete("a");
+    expect(params.has("a")).toBe(false);
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/keys.js
+++ b/tests/built-ins/URLSearchParams/prototype/keys.js
@@ -1,0 +1,51 @@
+/*---
+description: URLSearchParams.prototype.keys
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.keys", () => {
+  test("returns an iterator of all keys", () => {
+    const params = new URLSearchParams("a=1&b=2&c=3");
+    const keys = [];
+    for (const key of params.keys()) {
+      keys.push(key);
+    }
+    expect(keys).toEqual(["a", "b", "c"]);
+  });
+
+  test("duplicate keys appear multiple times", () => {
+    const params = new URLSearchParams("a=1&a=2&b=3");
+    const keys = [];
+    for (const key of params.keys()) {
+      keys.push(key);
+    }
+    expect(keys).toEqual(["a", "a", "b"]);
+  });
+
+  test("returns empty iterator for empty params", () => {
+    const params = new URLSearchParams();
+    const keys = [];
+    for (const key of params.keys()) {
+      keys.push(key);
+    }
+    expect(keys).toEqual([]);
+  });
+
+  test("iterator is in insertion order", () => {
+    const params = new URLSearchParams();
+    params.append("z", "1");
+    params.append("a", "2");
+    params.append("m", "3");
+    const keys = [];
+    for (const key of params.keys()) {
+      keys.push(key);
+    }
+    expect(keys).toEqual(["z", "a", "m"]);
+  });
+
+  test("keys iterator can be spread into an array", () => {
+    const params = new URLSearchParams("x=1&y=2");
+    const keys = [...params.keys()];
+    expect(keys).toEqual(["x", "y"]);
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/set.js
+++ b/tests/built-ins/URLSearchParams/prototype/set.js
@@ -4,6 +4,12 @@ features: [URLSearchParams]
 ---*/
 
 describe("URLSearchParams.prototype.set", () => {
+  test("setting via url.searchParams updates url.search", () => {
+    const url = new URL("https://example.com/?a=1&b=2");
+    url.searchParams.set("a", "99");
+    expect(url.search).toBe("?a=99&b=2");
+  });
+
   test("sets a new key-value pair", () => {
     const params = new URLSearchParams();
     params.set("a", "1");

--- a/tests/built-ins/URLSearchParams/prototype/set.js
+++ b/tests/built-ins/URLSearchParams/prototype/set.js
@@ -1,0 +1,54 @@
+/*---
+description: URLSearchParams.prototype.set
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.set", () => {
+  test("sets a new key-value pair", () => {
+    const params = new URLSearchParams();
+    params.set("a", "1");
+    expect(params.get("a")).toBe("1");
+  });
+
+  test("updates the first occurrence of an existing key", () => {
+    const params = new URLSearchParams("a=old");
+    params.set("a", "new");
+    expect(params.get("a")).toBe("new");
+  });
+
+  test("removes duplicates, leaving only the updated first occurrence", () => {
+    const params = new URLSearchParams("a=1&b=x&a=2&a=3");
+    params.set("a", "99");
+    expect(params.getAll("a")).toEqual(["99"]);
+  });
+
+  test("position of the first occurrence is preserved", () => {
+    const params = new URLSearchParams("a=1&b=2&a=3");
+    params.set("a", "99");
+    const keys = [];
+    for (const [k] of params.entries()) {
+      keys.push(k);
+    }
+    expect(keys[0]).toBe("a");
+    expect(keys[1]).toBe("b");
+  });
+
+  test("size is correct after set removes duplicates", () => {
+    const params = new URLSearchParams("a=1&a=2&a=3");
+    params.set("a", "x");
+    expect(params.size).toBe(1);
+  });
+
+  test("set with empty string value", () => {
+    const params = new URLSearchParams("a=1");
+    params.set("a", "");
+    expect(params.get("a")).toBe("");
+  });
+
+  test("set encodes value with special characters", () => {
+    const params = new URLSearchParams();
+    params.set("q", "hello world");
+    expect(params.get("q")).toBe("hello world");
+    expect(params.toString()).toContain("q=hello+world");
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/size.js
+++ b/tests/built-ins/URLSearchParams/prototype/size.js
@@ -31,7 +31,7 @@ describe("URLSearchParams.prototype.size", () => {
     expect(params.size).toBe(1);
   });
 
-  test("unchanged after set that replaces duplicates", () => {
+  test("decreases when set removes duplicate entries", () => {
     const params = new URLSearchParams("a=1&a=2&a=3");
     params.set("a", "x");
     expect(params.size).toBe(1);

--- a/tests/built-ins/URLSearchParams/prototype/size.js
+++ b/tests/built-ins/URLSearchParams/prototype/size.js
@@ -1,0 +1,51 @@
+/*---
+description: URLSearchParams.prototype.size
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.size", () => {
+  test("is 0 for empty params", () => {
+    const params = new URLSearchParams();
+    expect(params.size).toBe(0);
+  });
+
+  test("returns number of entries", () => {
+    const params = new URLSearchParams("a=1&b=2&c=3");
+    expect(params.size).toBe(3);
+  });
+
+  test("counts duplicate keys as separate entries", () => {
+    const params = new URLSearchParams("a=1&a=2&a=3");
+    expect(params.size).toBe(3);
+  });
+
+  test("increases after append", () => {
+    const params = new URLSearchParams("a=1");
+    params.append("b", "2");
+    expect(params.size).toBe(2);
+  });
+
+  test("decreases after delete (removes all with that key)", () => {
+    const params = new URLSearchParams("a=1&a=2&b=3");
+    params.delete("a");
+    expect(params.size).toBe(1);
+  });
+
+  test("unchanged after set that replaces duplicates", () => {
+    const params = new URLSearchParams("a=1&a=2&a=3");
+    params.set("a", "x");
+    expect(params.size).toBe(1);
+  });
+
+  test("is 0 after deleting all entries", () => {
+    const params = new URLSearchParams("a=1&b=2");
+    params.delete("a");
+    params.delete("b");
+    expect(params.size).toBe(0);
+  });
+
+  test("counts entries from array constructor", () => {
+    const params = new URLSearchParams([["a", "1"], ["a", "2"], ["b", "3"]]);
+    expect(params.size).toBe(3);
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/sort.js
+++ b/tests/built-ins/URLSearchParams/prototype/sort.js
@@ -4,6 +4,12 @@ features: [URLSearchParams]
 ---*/
 
 describe("URLSearchParams.prototype.sort", () => {
+  test("sorting url.searchParams updates url.search", () => {
+    const url = new URL("https://example.com/path?b=2&a=1");
+    url.searchParams.sort();
+    expect(url.search).toBe("?a=1&b=2");
+  });
+
   test("sorts params by name in ascending order", () => {
     const params = new URLSearchParams("c=3&a=1&b=2");
     params.sort();

--- a/tests/built-ins/URLSearchParams/prototype/sort.js
+++ b/tests/built-ins/URLSearchParams/prototype/sort.js
@@ -1,0 +1,61 @@
+/*---
+description: URLSearchParams.prototype.sort
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.sort", () => {
+  test("sorts params by name in ascending order", () => {
+    const params = new URLSearchParams("c=3&a=1&b=2");
+    params.sort();
+    const keys = [];
+    for (const [k] of params.entries()) {
+      keys.push(k);
+    }
+    expect(keys).toEqual(["a", "b", "c"]);
+  });
+
+  test("sort is stable: duplicate keys preserve relative order", () => {
+    const params = new URLSearchParams("b=2&a=first&a=second&b=1");
+    params.sort();
+    expect(params.getAll("a")).toEqual(["first", "second"]);
+    expect(params.getAll("b")).toEqual(["2", "1"]);
+  });
+
+  test("keys are in sorted order after sort", () => {
+    const params = new URLSearchParams("z=last&m=mid&a=first");
+    params.sort();
+    const entries = [];
+    for (const entry of params.entries()) {
+      entries.push(entry);
+    }
+    expect(entries[0][0]).toBe("a");
+    expect(entries[1][0]).toBe("m");
+    expect(entries[2][0]).toBe("z");
+  });
+
+  test("sort does not change values", () => {
+    const params = new URLSearchParams("c=30&a=10&b=20");
+    params.sort();
+    expect(params.get("a")).toBe("10");
+    expect(params.get("b")).toBe("20");
+    expect(params.get("c")).toBe("30");
+  });
+
+  test("sort on already sorted params is a no-op", () => {
+    const params = new URLSearchParams("a=1&b=2&c=3");
+    params.sort();
+    expect(params.toString()).toBe("a=1&b=2&c=3");
+  });
+
+  test("sort on empty params does not throw", () => {
+    const params = new URLSearchParams();
+    params.sort();
+    expect(params.size).toBe(0);
+  });
+
+  test("sort on single entry does not throw", () => {
+    const params = new URLSearchParams("z=1");
+    params.sort();
+    expect(params.get("z")).toBe("1");
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/toString.js
+++ b/tests/built-ins/URLSearchParams/prototype/toString.js
@@ -1,0 +1,58 @@
+/*---
+description: URLSearchParams.prototype.toString
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.toString", () => {
+  test("serializes a single key-value pair", () => {
+    const params = new URLSearchParams("a=1");
+    expect(params.toString()).toBe("a=1");
+  });
+
+  test("serializes multiple pairs with ampersand separator", () => {
+    const params = new URLSearchParams("a=1&b=2&c=3");
+    expect(params.toString()).toBe("a=1&b=2&c=3");
+  });
+
+  test("returns empty string for empty params", () => {
+    const params = new URLSearchParams();
+    expect(params.toString()).toBe("");
+  });
+
+  test("spaces are encoded as plus signs", () => {
+    const params = new URLSearchParams();
+    params.set("q", "hello world");
+    expect(params.toString()).toBe("q=hello+world");
+  });
+
+  test("special characters are percent-encoded", () => {
+    const params = new URLSearchParams();
+    params.set("key", "a=b&c");
+    const str = params.toString();
+    expect(str).not.toContain("a=b&c");
+    expect(str).toContain("key=");
+  });
+
+  test("at sign is percent-encoded", () => {
+    const params = new URLSearchParams();
+    params.set("email", "user@example.com");
+    expect(params.toString()).toContain("user%40example.com");
+  });
+
+  test("round-trips through parse and stringify", () => {
+    const original = "a=1&b=hello+world&c=3";
+    const params = new URLSearchParams(original);
+    expect(params.get("b")).toBe("hello world");
+    expect(params.toString()).toBe(original);
+  });
+
+  test("duplicate keys are both included in output", () => {
+    const params = new URLSearchParams("a=1&a=2");
+    expect(params.toString()).toBe("a=1&a=2");
+  });
+
+  test("leading question mark is not included", () => {
+    const params = new URLSearchParams("?a=1");
+    expect(params.toString()).toBe("a=1");
+  });
+});

--- a/tests/built-ins/URLSearchParams/prototype/values.js
+++ b/tests/built-ins/URLSearchParams/prototype/values.js
@@ -1,0 +1,56 @@
+/*---
+description: URLSearchParams.prototype.values
+features: [URLSearchParams]
+---*/
+
+describe("URLSearchParams.prototype.values", () => {
+  test("returns an iterator of all values", () => {
+    const params = new URLSearchParams("a=1&b=2&c=3");
+    const values = [];
+    for (const value of params.values()) {
+      values.push(value);
+    }
+    expect(values).toEqual(["1", "2", "3"]);
+  });
+
+  test("duplicate keys produce multiple values", () => {
+    const params = new URLSearchParams("a=1&a=2&b=3");
+    const values = [];
+    for (const value of params.values()) {
+      values.push(value);
+    }
+    expect(values).toEqual(["1", "2", "3"]);
+  });
+
+  test("returns empty iterator for empty params", () => {
+    const params = new URLSearchParams();
+    const values = [];
+    for (const value of params.values()) {
+      values.push(value);
+    }
+    expect(values).toEqual([]);
+  });
+
+  test("values are decoded", () => {
+    const params = new URLSearchParams("a=hello+world&b=foo%20bar");
+    const values = [];
+    for (const value of params.values()) {
+      values.push(value);
+    }
+    expect(values).toEqual(["hello world", "foo bar"]);
+  });
+
+  test("values iterator can be spread into an array", () => {
+    const params = new URLSearchParams("x=10&y=20");
+    const values = [...params.values()];
+    expect(values).toEqual(["10", "20"]);
+  });
+
+  test("values in insertion order", () => {
+    const params = new URLSearchParams();
+    params.append("a", "first");
+    params.append("a", "second");
+    const values = [...params.values()];
+    expect(values).toEqual(["first", "second"]);
+  });
+});

--- a/units/Goccia.Builtins.GlobalURL.pas
+++ b/units/Goccia.Builtins.GlobalURL.pas
@@ -1,0 +1,166 @@
+unit Goccia.Builtins.GlobalURL;
+
+// WHATWG URL Standard §4 URL / §6 URLSearchParams — engine registration
+// https://url.spec.whatwg.org/
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Builtins.Base,
+  Goccia.Error.ThrowErrorCallback,
+  Goccia.ObjectModel,
+  Goccia.Scope,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaGlobalURL = class(TGocciaBuiltin)
+  private
+    class var FStaticMembers: array of TGocciaMemberDefinition;
+  published
+    // WHATWG URL §4.7.3 URL.canParse(url[, base])
+    function CanParse(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+
+    // WHATWG URL §4.7.2 URL.parse(url[, base])
+    function Parse(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AName: string; const AScope: TGocciaScope;
+      const AThrowError: TGocciaThrowErrorCallback);
+  end;
+
+  TGocciaGlobalURLSearchParams = class(TGocciaBuiltin)
+  public
+    constructor Create(const AName: string; const AScope: TGocciaScope;
+      const AThrowError: TGocciaThrowErrorCallback);
+  end;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.URL.Parser,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.URLSearchParamsValue,
+  Goccia.Values.URLValue;
+
+{ TGocciaGlobalURL }
+
+constructor TGocciaGlobalURL.Create(const AName: string;
+  const AScope: TGocciaScope;
+  const AThrowError: TGocciaThrowErrorCallback);
+var
+  Members: TGocciaMemberCollection;
+begin
+  inherited Create(AName, AScope, AThrowError);
+
+  // Initialize the shared URL prototype lazily
+  TGocciaURLValue.ExposePrototype(FBuiltinObject);
+
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddNamedMethod('canParse', CanParse, 1, gmkStaticMethod);
+    Members.AddNamedMethod('parse', Parse, 1, gmkStaticMethod);
+    FStaticMembers := Members.ToDefinitions;
+  finally
+    Members.Free;
+  end;
+  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
+end;
+
+// WHATWG URL §4.7.3 URL.canParse(url[, base]) -> boolean
+function TGocciaGlobalURL.CanParse(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  URLStr, BaseStr: string;
+  Parsed, BaseParsed: TGocciaURLRecord;
+begin
+  if AArgs.Length = 0 then
+  begin
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+  URLStr := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  if AArgs.Length >= 2 then
+  begin
+    BaseStr := AArgs.GetElement(1).ToStringLiteral.Value;
+    BaseParsed := ParseURL(BaseStr);
+    if not BaseParsed.IsValid then
+    begin
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+      Exit;
+    end;
+    Parsed := ParseURLWithBase(URLStr, BaseParsed);
+  end
+  else
+    Parsed := ParseURL(URLStr);
+
+  if Parsed.IsValid then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// WHATWG URL §4.7.2 URL.parse(url[, base]) -> URL or null
+function TGocciaGlobalURL.Parse(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  URLStr, BaseStr: string;
+  Parsed, BaseParsed: TGocciaURLRecord;
+  URLObj: TGocciaURLValue;
+begin
+  if AArgs.Length = 0 then
+  begin
+    Result := TGocciaNullLiteralValue.NullValue;
+    Exit;
+  end;
+  URLStr := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  if AArgs.Length >= 2 then
+  begin
+    BaseStr := AArgs.GetElement(1).ToStringLiteral.Value;
+    BaseParsed := ParseURL(BaseStr);
+    if not BaseParsed.IsValid then
+    begin
+      Result := TGocciaNullLiteralValue.NullValue;
+      Exit;
+    end;
+    Parsed := ParseURLWithBase(URLStr, BaseParsed);
+  end
+  else
+    Parsed := ParseURL(URLStr);
+
+  if not Parsed.IsValid then
+  begin
+    Result := TGocciaNullLiteralValue.NullValue;
+    Exit;
+  end;
+
+  URLObj := TGocciaURLValue.Create;
+  URLObj.InitFromRecord(
+    Parsed.Scheme, Parsed.Username, Parsed.Password,
+    Parsed.Host, Parsed.HasNullHost, Parsed.Port,
+    SerializePath(Parsed),
+    Parsed.HasNullQuery, Parsed.Query,
+    Parsed.HasNullFragment, Parsed.Fragment,
+    Parsed.HasOpaquePath);
+  Result := URLObj;
+end;
+
+{ TGocciaGlobalURLSearchParams }
+
+constructor TGocciaGlobalURLSearchParams.Create(const AName: string;
+  const AScope: TGocciaScope;
+  const AThrowError: TGocciaThrowErrorCallback);
+begin
+  inherited Create(AName, AScope, AThrowError);
+  // Initialize the shared URLSearchParams prototype lazily
+  TGocciaURLSearchParamsValue.ExposePrototype(FBuiltinObject);
+end;
+
+end.

--- a/units/Goccia.Builtins.GlobalURL.pas
+++ b/units/Goccia.Builtins.GlobalURL.pas
@@ -44,6 +44,7 @@ uses
   SysUtils,
 
   Goccia.Arguments.Validator,
+  Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.URL.Parser,
   Goccia.Values.ErrorHelper,
@@ -81,7 +82,7 @@ var
   URLStr, BaseStr: string;
   Parsed, BaseParsed: TGocciaURLRecord;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'URL.canParse', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, CONSTRUCTOR_URL + '.' + PROP_CAN_PARSE, ThrowError);
   URLStr := AArgs.GetElement(0).ToStringLiteral.Value;
 
   if AArgs.Length >= 2 then
@@ -112,7 +113,7 @@ var
   Parsed, BaseParsed: TGocciaURLRecord;
   URLObj: TGocciaURLValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'URL.parse', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, CONSTRUCTOR_URL + '.' + PROP_PARSE, ThrowError);
   URLStr := AArgs.GetElement(0).ToStringLiteral.Value;
 
   if AArgs.Length >= 2 then

--- a/units/Goccia.Builtins.GlobalURL.pas
+++ b/units/Goccia.Builtins.GlobalURL.pas
@@ -43,6 +43,8 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Arguments.Validator,
+  Goccia.Constants.PropertyNames,
   Goccia.URL.Parser,
   Goccia.Values.ErrorHelper,
   Goccia.Values.URLSearchParamsValue,
@@ -63,8 +65,8 @@ begin
 
   Members := TGocciaMemberCollection.Create;
   try
-    Members.AddNamedMethod('canParse', CanParse, 1, gmkStaticMethod);
-    Members.AddNamedMethod('parse', Parse, 1, gmkStaticMethod);
+    Members.AddNamedMethod(PROP_CAN_PARSE, CanParse, 1, gmkStaticMethod);
+    Members.AddNamedMethod(PROP_PARSE, Parse, 1, gmkStaticMethod);
     FStaticMembers := Members.ToDefinitions;
   finally
     Members.Free;
@@ -79,11 +81,7 @@ var
   URLStr, BaseStr: string;
   Parsed, BaseParsed: TGocciaURLRecord;
 begin
-  if AArgs.Length = 0 then
-  begin
-    Result := TGocciaBooleanLiteralValue.FalseValue;
-    Exit;
-  end;
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'URL.canParse', ThrowError);
   URLStr := AArgs.GetElement(0).ToStringLiteral.Value;
 
   if AArgs.Length >= 2 then
@@ -114,11 +112,7 @@ var
   Parsed, BaseParsed: TGocciaURLRecord;
   URLObj: TGocciaURLValue;
 begin
-  if AArgs.Length = 0 then
-  begin
-    Result := TGocciaNullLiteralValue.NullValue;
-    Exit;
-  end;
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'URL.parse', ThrowError);
   URLStr := AArgs.GetElement(0).ToStringLiteral.Value;
 
   if AArgs.Length >= 2 then

--- a/units/Goccia.Constants.ConstructorNames.pas
+++ b/units/Goccia.Constants.ConstructorNames.pas
@@ -36,6 +36,8 @@ const
   CONSTRUCTOR_FLOAT64_ARRAY        = 'Float64Array';
 
   CONSTRUCTOR_FFI                  = 'FFI';
+  CONSTRUCTOR_URL                  = 'URL';
+  CONSTRUCTOR_URL_SEARCH_PARAMS    = 'URLSearchParams';
 
 implementation
 

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -129,6 +129,15 @@ const
   PROP_PARSE            = 'parse';
   PROP_CAN_PARSE        = 'canParse';
 
+  // URLSearchParams prototype method names
+  PROP_APPEND    = 'append';
+  PROP_DELETE    = 'delete';
+  PROP_GET_ALL   = 'getAll';
+  PROP_SORT      = 'sort';
+  PROP_KEYS      = 'keys';
+  PROP_ENTRIES   = 'entries';
+  PROP_FOR_EACH  = 'forEach';
+
   // Proxy handler trap names
   PROP_HAS                       = 'has';
   PROP_DELETE_PROPERTY            = 'deleteProperty';

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -120,6 +120,7 @@ const
   PROP_SEARCH           = 'search';
   PROP_SEARCH_PARAMS    = 'searchParams';
   PROP_HASH             = 'hash';
+  PROP_PARSE            = 'parse';
   PROP_CAN_PARSE        = 'canParse';
 
   // Proxy handler trap names

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -107,6 +107,21 @@ const
   PROP_SET_FROM_HEX           = 'setFromHex';
   PROP_RAW                    = 'raw';
 
+  // URL and URLSearchParams properties
+  PROP_HREF             = 'href';
+  PROP_ORIGIN           = 'origin';
+  PROP_PROTOCOL         = 'protocol';
+  PROP_USERNAME         = 'username';
+  PROP_PASSWORD         = 'password';
+  PROP_HOST             = 'host';
+  PROP_HOSTNAME         = 'hostname';
+  PROP_PORT             = 'port';
+  PROP_PATHNAME         = 'pathname';
+  PROP_SEARCH           = 'search';
+  PROP_SEARCH_PARAMS    = 'searchParams';
+  PROP_HASH             = 'hash';
+  PROP_CAN_PARSE        = 'canParse';
+
   // Proxy handler trap names
   PROP_HAS                       = 'has';
   PROP_DELETE_PROPERTY            = 'deleteProperty';

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -26,6 +26,7 @@ uses
   Goccia.Builtins.GlobalSet,
   Goccia.Builtins.GlobalString,
   Goccia.Builtins.GlobalSymbol,
+  Goccia.Builtins.GlobalURL,
   Goccia.Builtins.JSON,
   Goccia.Builtins.JSON5,
   Goccia.Builtins.JSONL,
@@ -82,7 +83,8 @@ type
     ggArrayBuffer,
     ggProxy,
     ggFFI,
-    ggReflect
+    ggReflect,
+    ggURL
   );
 
   TGocciaGlobalBuiltins = set of TGocciaGlobalBuiltin;
@@ -100,7 +102,7 @@ type
 type
   TGocciaEngine = class
   public
-    const DefaultGlobals: TGocciaGlobalBuiltins = [ggConsole, ggMath, ggGlobalObject, ggGlobalArray, ggGlobalNumber, ggPromise, ggJSON, ggJSON5, ggJSONL, ggTOML, ggYAML, ggSymbol, ggSet, ggMap, ggPerformance, ggTemporal, ggJSX, ggArrayBuffer, ggProxy, ggReflect];
+    const DefaultGlobals: TGocciaGlobalBuiltins = [ggConsole, ggMath, ggGlobalObject, ggGlobalArray, ggGlobalNumber, ggPromise, ggJSON, ggJSON5, ggJSONL, ggTOML, ggYAML, ggSymbol, ggSet, ggMap, ggPerformance, ggTemporal, ggJSX, ggArrayBuffer, ggProxy, ggReflect, ggURL];
   private
     FInterpreter: TGocciaInterpreter;
     FFileName: string;
@@ -136,6 +138,8 @@ type
     FBuiltinProxy: TGocciaGlobalProxy;
     FBuiltinFFI: TGocciaGlobalFFI;
     FBuiltinReflect: TGocciaGlobalReflect;
+    FBuiltinURL: TGocciaGlobalURL;
+    FBuiltinURLSearchParams: TGocciaGlobalURLSearchParams;
     FPreviousExceptionMask: TFPUExceptionMask;
     FASIEnabled: Boolean;
     FSuppressWarnings: Boolean;
@@ -208,6 +212,8 @@ type
     property ASIEnabled: Boolean read FASIEnabled write SetASIEnabled;
     property BuiltinFFI: TGocciaGlobalFFI read FBuiltinFFI;
     property BuiltinReflect: TGocciaGlobalReflect read FBuiltinReflect;
+    property BuiltinURL: TGocciaGlobalURL read FBuiltinURL;
+    property BuiltinURLSearchParams: TGocciaGlobalURLSearchParams read FBuiltinURLSearchParams;
     property SuppressWarnings: Boolean read FSuppressWarnings write FSuppressWarnings;
     property LastTiming: TGocciaScriptResult read FLastTiming;
   end;
@@ -249,6 +255,8 @@ uses
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.Uint8ArrayEncoding,
+  Goccia.Values.URLSearchParamsValue,
+  Goccia.Values.URLValue,
   Goccia.Version;
 
 constructor TGocciaEngine.Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins);
@@ -333,6 +341,8 @@ begin
     FBuiltinProxy.Free;
     FBuiltinFFI.Free;
     FBuiltinReflect.Free;
+    FBuiltinURL.Free;
+    FBuiltinURLSearchParams.Free;
     ClearImportMetaCache;
     FInjectedGlobals.Free;
     FInterpreter.Free;
@@ -402,6 +412,12 @@ begin
     FBuiltinFFI := TGocciaGlobalFFI.Create(CONSTRUCTOR_FFI, Scope, ThrowError);
   if ggReflect in FGlobals then
     FBuiltinReflect := TGocciaGlobalReflect.Create('Reflect', Scope, ThrowError);
+  if ggURL in FGlobals then
+  begin
+    FBuiltinURL := TGocciaGlobalURL.Create(CONSTRUCTOR_URL, Scope, ThrowError);
+    FBuiltinURLSearchParams := TGocciaGlobalURLSearchParams.Create(
+      CONSTRUCTOR_URL_SEARCH_PARAMS, Scope, ThrowError);
+  end;
 
   // Always-registered built-ins
   FBuiltinGlobalString := TGocciaGlobalString.Create(CONSTRUCTOR_STRING, Scope, ThrowError);
@@ -453,6 +469,16 @@ begin
   TGocciaSetValue.ExposePrototype(AConstructor);
 end;
 
+procedure ExposeURLPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaURLValue.ExposePrototype(AConstructor);
+end;
+
+procedure ExposeURLSearchParamsPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaURLSearchParamsValue.ExposePrototype(AConstructor);
+end;
+
 procedure TGocciaEngine.RegisterBuiltinConstructors;
 var
   Key: string;
@@ -467,6 +493,8 @@ var
   NumberConstructor: TGocciaNumberClassValue;
   BooleanConstructor: TGocciaBooleanClassValue;
   PerformanceConstructor: TGocciaNativeFunctionValue;
+  URLConstructor: TGocciaURLClassValue;
+  URLSearchParamsConstructor: TGocciaURLSearchParamsClassValue;
   TypeDef: TGocciaTypeDefinition;
 begin
   TGocciaObjectValue.InitializeSharedPrototype;
@@ -517,6 +545,31 @@ begin
     TypeDef.AddSpeciesGetter := True;
     RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
     SetConstructor := TGocciaSetClassValue(GenericConstructor);
+  end;
+
+  if ggURL in FGlobals then
+  begin
+    TypeDef.ConstructorName := CONSTRUCTOR_URL;
+    TypeDef.Kind := gtdkCollectionLikeNativeType;
+    TypeDef.ClassValueClass := TGocciaURLClassValue;
+    TypeDef.ExposePrototype := @ExposeURLPrototype;
+    TypeDef.PrototypeProvider := nil;
+    TypeDef.StaticSource := BuiltinObjectOrNil(FBuiltinURL);
+    TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+    TypeDef.AddSpeciesGetter := False;
+    RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
+    URLConstructor := TGocciaURLClassValue(GenericConstructor);
+
+    TypeDef.ConstructorName := CONSTRUCTOR_URL_SEARCH_PARAMS;
+    TypeDef.Kind := gtdkCollectionLikeNativeType;
+    TypeDef.ClassValueClass := TGocciaURLSearchParamsClassValue;
+    TypeDef.ExposePrototype := @ExposeURLSearchParamsPrototype;
+    TypeDef.PrototypeProvider := nil;
+    TypeDef.StaticSource := BuiltinObjectOrNil(FBuiltinURLSearchParams);
+    TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+    TypeDef.AddSpeciesGetter := False;
+    RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
+    URLSearchParamsConstructor := TGocciaURLSearchParamsClassValue(GenericConstructor);
   end;
 
   if ggArrayBuffer in FGlobals then

--- a/units/Goccia.Runtime.Bootstrap.pas
+++ b/units/Goccia.Runtime.Bootstrap.pas
@@ -25,6 +25,7 @@ uses
   Goccia.Builtins.GlobalSet,
   Goccia.Builtins.GlobalString,
   Goccia.Builtins.GlobalSymbol,
+  Goccia.Builtins.GlobalURL,
   Goccia.Builtins.JSON,
   Goccia.Builtins.JSON5,
   Goccia.Builtins.JSONL,
@@ -76,6 +77,8 @@ type
     FBuiltinFFI: TGocciaGlobalFFI;
     FBuiltinProxy: TGocciaGlobalProxy;
     FBuiltinReflect: TGocciaGlobalReflect;
+    FBuiltinURL: TGocciaGlobalURL;
+    FBuiltinURLSearchParams: TGocciaGlobalURLSearchParams;
 
     procedure PinSingletons;
     procedure RegisterBuiltIns;
@@ -114,6 +117,8 @@ uses
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.Uint8ArrayEncoding,
+  Goccia.Values.URLSearchParamsValue,
+  Goccia.Values.URLValue,
   Goccia.Version;
 
 function ObjectPrototypeProvider: TGocciaObjectValue;
@@ -159,6 +164,16 @@ begin
   TGocciaSetValue.ExposePrototype(AConstructor);
 end;
 
+procedure ExposeURLPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaURLValue.ExposePrototype(AConstructor);
+end;
+
+procedure ExposeURLSearchParamsPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaURLSearchParamsValue.ExposePrototype(AConstructor);
+end;
+
 constructor TGocciaRuntimeBootstrap.Create(const AInterpreter: TGocciaInterpreter;
   const AGlobals: TGocciaGlobalBuiltins; const AThrowError: TGocciaThrowErrorCallback);
 begin
@@ -197,6 +212,8 @@ begin
   FBuiltinFFI.Free;
   FBuiltinProxy.Free;
   FBuiltinReflect.Free;
+  FBuiltinURL.Free;
+  FBuiltinURLSearchParams.Free;
   inherited;
 end;
 
@@ -256,6 +273,12 @@ begin
     FBuiltinProxy := TGocciaGlobalProxy.Create(Scope);
   if ggReflect in FGlobals then
     FBuiltinReflect := TGocciaGlobalReflect.Create('Reflect', Scope, FThrowError);
+  if ggURL in FGlobals then
+  begin
+    FBuiltinURL := TGocciaGlobalURL.Create(CONSTRUCTOR_URL, Scope, FThrowError);
+    FBuiltinURLSearchParams := TGocciaGlobalURLSearchParams.Create(
+      CONSTRUCTOR_URL_SEARCH_PARAMS, Scope, FThrowError);
+  end;
 
   FBuiltinGlobalString := TGocciaGlobalString.Create(CONSTRUCTOR_STRING, Scope, FThrowError);
   FBuiltinGlobals := TGocciaGlobals.Create('Globals', Scope, FThrowError);
@@ -277,6 +300,8 @@ var
   NumberConstructor: TGocciaNumberClassValue;
   BooleanConstructor: TGocciaBooleanClassValue;
   PerformanceConstructor: TGocciaNativeFunctionValue;
+  URLConstructor: TGocciaURLClassValue;
+  URLSearchParamsConstructor: TGocciaURLSearchParamsClassValue;
   TypeDef: TGocciaTypeDefinition;
 begin
   TGocciaObjectValue.InitializeSharedPrototype;
@@ -327,6 +352,31 @@ begin
     TypeDef.AddSpeciesGetter := True;
     RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
     SetConstructor := TGocciaSetClassValue(GenericConstructor);
+  end;
+
+  if ggURL in FGlobals then
+  begin
+    TypeDef.ConstructorName := CONSTRUCTOR_URL;
+    TypeDef.Kind := gtdkCollectionLikeNativeType;
+    TypeDef.ClassValueClass := TGocciaURLClassValue;
+    TypeDef.ExposePrototype := @ExposeURLPrototype;
+    TypeDef.PrototypeProvider := nil;
+    TypeDef.StaticSource := BuiltinObjectOrNil(FBuiltinURL);
+    TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+    TypeDef.AddSpeciesGetter := False;
+    RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
+    URLConstructor := TGocciaURLClassValue(GenericConstructor);
+
+    TypeDef.ConstructorName := CONSTRUCTOR_URL_SEARCH_PARAMS;
+    TypeDef.Kind := gtdkCollectionLikeNativeType;
+    TypeDef.ClassValueClass := TGocciaURLSearchParamsClassValue;
+    TypeDef.ExposePrototype := @ExposeURLSearchParamsPrototype;
+    TypeDef.PrototypeProvider := nil;
+    TypeDef.StaticSource := BuiltinObjectOrNil(FBuiltinURLSearchParams);
+    TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+    TypeDef.AddSpeciesGetter := False;
+    RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
+    URLSearchParamsConstructor := TGocciaURLSearchParamsClassValue(GenericConstructor);
   end;
 
   if ggArrayBuffer in FGlobals then

--- a/units/Goccia.URL.Parser.pas
+++ b/units/Goccia.URL.Parser.pas
@@ -1,0 +1,1537 @@
+unit Goccia.URL.Parser;
+
+// WHATWG URL Standard §4 URLs
+// https://url.spec.whatwg.org/
+
+{$I Goccia.inc}
+
+interface
+
+const
+  // Sentinel value meaning the port component is null
+  URL_NULL_PORT = -1;
+
+type
+  // WHATWG URL Standard §4.1 URL representation
+  // The path is stored as segments for normal URLs, or as an opaque string
+  TGocciaURLPathSegments = array of string;
+
+  TGocciaURLRecord = record
+    Scheme: string;                      // e.g. 'https' — lowercased, no ':'
+    Username: string;                    // percent-encoded
+    Password: string;                    // percent-encoded
+    Host: string;                        // serialized host: domain, IP, empty string
+    HasNullHost: Boolean;               // true = host is null (no authority component)
+    Port: Integer;                       // URL_NULL_PORT = null
+    PathSegments: TGocciaURLPathSegments;// path segments for non-opaque paths
+    HasOpaquePath: Boolean;              // true for non-special no-authority URLs
+    OpaquePath: string;                  // opaque path when HasOpaquePath is true
+    Query: string;                       // without leading '?', '' means empty query
+    HasNullQuery: Boolean;              // true = query is null
+    Fragment: string;                    // without leading '#', '' means empty fragment
+    HasNullFragment: Boolean;           // true = fragment is null
+    IsValid: Boolean;                    // false if parsing failed
+  end;
+
+// WHATWG URL Standard §4.4 URL parsing
+function ParseURL(const AInput: string): TGocciaURLRecord; overload;
+function ParseURLWithBase(const AInput: string;
+  const ABase: TGocciaURLRecord): TGocciaURLRecord;
+
+// WHATWG URL Standard §4.5 URL serializing
+function SerializeURL(const AURL: TGocciaURLRecord;
+  const AExcludeFragment: Boolean = False): string;
+function SerializePath(const AURL: TGocciaURLRecord): string;
+
+// WHATWG URL Standard §4.6 URL origin
+function SerializeOrigin(const AURL: TGocciaURLRecord): string;
+
+// Scheme utilities
+function IsSpecialScheme(const AScheme: string): Boolean;
+function DefaultPortForScheme(const AScheme: string): Integer;
+function URLHasCredentials(const AURL: TGocciaURLRecord): Boolean;
+
+// Percent-encode/decode
+function PercentEncodeForUserinfo(const AInput: string): string;
+function PercentEncodeForPath(const AInput: string): string;
+function PercentEncodeForQuery(const AInput: string;
+  const AIsSpecial: Boolean): string;
+function PercentEncodeForFragment(const AInput: string): string;
+function PercentDecodeString(const AInput: string): string;
+
+// application/x-www-form-urlencoded serialization
+function SerializeFormEncoded(const AName, AValue: string): string;
+function ParseFormEncoded(const AInput: string;
+  out ANames: TArray<string>; out AValues: TArray<string>): Boolean;
+
+implementation
+
+uses
+  SysUtils;
+
+// ---------------------------------------------------------------------------
+// Character helpers
+// ---------------------------------------------------------------------------
+
+function IsASCIIAlpha(const C: Char): Boolean; inline;
+begin
+  Result := (C in ['A'..'Z', 'a'..'z']);
+end;
+
+function IsASCIIDigit(const C: Char): Boolean; inline;
+begin
+  Result := (C in ['0'..'9']);
+end;
+
+function IsASCIIAlphanumeric(const C: Char): Boolean; inline;
+begin
+  Result := (C in ['A'..'Z', 'a'..'z', '0'..'9']);
+end;
+
+function IsASCIIHexDigit(const C: Char): Boolean; inline;
+begin
+  Result := (C in ['0'..'9', 'A'..'F', 'a'..'f']);
+end;
+
+function IsASCIIWhitespace(const C: Char): Boolean; inline;
+begin
+  // ASCII tab, LF, CR, space
+  Result := (C = #9) or (C = #10) or (C = #13) or (C = ' ');
+end;
+
+function ASCIILower(const C: Char): Char; inline;
+begin
+  if C in ['A'..'Z'] then
+    Result := Chr(Ord(C) + 32)
+  else
+    Result := C;
+end;
+
+function ASCIILowerString(const S: string): string;
+var
+  I: Integer;
+begin
+  Result := S;
+  for I := 1 to Length(Result) do
+    if Result[I] in ['A'..'Z'] then
+      Result[I] := Chr(Ord(Result[I]) + 32);
+end;
+
+function HexVal(const C: Char): Byte; inline;
+begin
+  case C of
+    '0'..'9': Result := Ord(C) - Ord('0');
+    'A'..'F': Result := Ord(C) - Ord('A') + 10;
+    'a'..'f': Result := Ord(C) - Ord('a') + 10;
+  else
+    Result := 0;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// WHATWG URL Standard §1.3 Percent-encode/decode
+// ---------------------------------------------------------------------------
+
+const
+  HEX_DIGITS = '0123456789ABCDEF';
+
+// §1.3.1 percent-encode after encoding
+function PercentEncode(const AByte: Byte): string; inline;
+begin
+  Result := '%' + HEX_DIGITS[(AByte shr 4) + 1] + HEX_DIGITS[(AByte and $0F) + 1];
+end;
+
+// §1.3.2 percent-decode
+function PercentDecodeString(const AInput: string): string;
+var
+  I: Integer;
+  B: Byte;
+begin
+  Result := '';
+  I := 1;
+  while I <= Length(AInput) do
+  begin
+    if (AInput[I] = '%') and (I + 2 <= Length(AInput)) and
+       IsASCIIHexDigit(AInput[I + 1]) and IsASCIIHexDigit(AInput[I + 2]) then
+    begin
+      B := (HexVal(AInput[I + 1]) shl 4) or HexVal(AInput[I + 2]);
+      Result := Result + Chr(B);
+      Inc(I, 3);
+    end
+    else
+    begin
+      Result := Result + AInput[I];
+      Inc(I);
+    end;
+  end;
+end;
+
+// WHATWG URL Standard §4.1 Percent-encode sets
+
+// C0 percent-encode set: U+0000–U+001F and > U+007E
+function InC0PercentEncodeSet(const B: Byte): Boolean; inline;
+begin
+  Result := (B < $21) or (B > $7E);
+end;
+
+// Fragment percent-encode set: C0 + {space U+0020, " U+0022, < U+003C, > U+003E, ` U+0060}
+function InFragmentPercentEncodeSet(const B: Byte): Boolean; inline;
+begin
+  Result := InC0PercentEncodeSet(B) or
+            (B = $20) or (B = $22) or (B = $3C) or (B = $3E) or (B = $60);
+end;
+
+// Query percent-encode set: C0 + {space, ", #, <, >}
+function InQueryPercentEncodeSet(const B: Byte): Boolean; inline;
+begin
+  Result := InC0PercentEncodeSet(B) or
+            (B = $20) or (B = $22) or (B = $23) or (B = $3C) or (B = $3E);
+end;
+
+// Special-query percent-encode set: query + {'}
+function InSpecialQueryPercentEncodeSet(const B: Byte): Boolean; inline;
+begin
+  Result := InQueryPercentEncodeSet(B) or (B = $27);
+end;
+
+// Path percent-encode set: query + {?, `, {, }}
+function InPathPercentEncodeSet(const B: Byte): Boolean; inline;
+begin
+  Result := InQueryPercentEncodeSet(B) or
+            (B = $3F) or (B = $60) or (B = $7B) or (B = $7D);
+end;
+
+// Userinfo percent-encode set: path + {/, :, ;, =, @, [, \, ], ^, |}
+function InUserinfoPercentEncodeSet(const B: Byte): Boolean; inline;
+begin
+  Result := InPathPercentEncodeSet(B) or
+            (B = $2F) or (B = $3A) or (B = $3B) or (B = $3D) or
+            (B = $40) or (B = $5B) or (B = $5C) or (B = $5D) or
+            (B = $5E) or (B = $7C);
+end;
+
+// application/x-www-form-urlencoded percent-encode set (for form data)
+function InFormPercentEncodeSet(const B: Byte): Boolean; inline;
+begin
+  // Everything except: * - . 0-9 A-Z _ a-z
+  Result := not (
+    (B = $2A) or (B = $2D) or (B = $2E) or
+    (B >= $30) and (B <= $39) or
+    (B >= $41) and (B <= $5A) or
+    (B = $5F) or
+    (B >= $61) and (B <= $7A)
+  );
+end;
+
+function PercentEncodeForUserinfo(const AInput: string): string;
+var
+  I: Integer;
+  B: Byte;
+begin
+  Result := '';
+  for I := 1 to Length(AInput) do
+  begin
+    B := Ord(AInput[I]);
+    if (B > $7F) or InUserinfoPercentEncodeSet(B) then
+      Result := Result + PercentEncode(B)
+    else
+      Result := Result + AInput[I];
+  end;
+end;
+
+function PercentEncodeForPath(const AInput: string): string;
+var
+  I: Integer;
+  B: Byte;
+begin
+  Result := '';
+  for I := 1 to Length(AInput) do
+  begin
+    B := Ord(AInput[I]);
+    if (B > $7F) or InPathPercentEncodeSet(B) then
+      Result := Result + PercentEncode(B)
+    else
+      Result := Result + AInput[I];
+  end;
+end;
+
+function PercentEncodeForQuery(const AInput: string;
+  const AIsSpecial: Boolean): string;
+var
+  I: Integer;
+  B: Byte;
+begin
+  Result := '';
+  for I := 1 to Length(AInput) do
+  begin
+    B := Ord(AInput[I]);
+    if AIsSpecial then
+    begin
+      if (B > $7F) or InSpecialQueryPercentEncodeSet(B) then
+        Result := Result + PercentEncode(B)
+      else
+        Result := Result + AInput[I];
+    end
+    else
+    begin
+      if (B > $7F) or InQueryPercentEncodeSet(B) then
+        Result := Result + PercentEncode(B)
+      else
+        Result := Result + AInput[I];
+    end;
+  end;
+end;
+
+function PercentEncodeForFragment(const AInput: string): string;
+var
+  I: Integer;
+  B: Byte;
+begin
+  Result := '';
+  for I := 1 to Length(AInput) do
+  begin
+    B := Ord(AInput[I]);
+    if (B > $7F) or InFragmentPercentEncodeSet(B) then
+      Result := Result + PercentEncode(B)
+    else
+      Result := Result + AInput[I];
+  end;
+end;
+
+// application/x-www-form-urlencoded encoding
+function EncodeFormComponent(const AInput: string): string;
+var
+  I: Integer;
+  B: Byte;
+begin
+  Result := '';
+  for I := 1 to Length(AInput) do
+  begin
+    B := Ord(AInput[I]);
+    if B = $20 then
+      Result := Result + '+'         // space -> +
+    else if (B > $7F) or InFormPercentEncodeSet(B) then
+      Result := Result + PercentEncode(B)
+    else
+      Result := Result + AInput[I];
+  end;
+end;
+
+function DecodeFormComponent(const AInput: string): string;
+var
+  I: Integer;
+  B: Byte;
+begin
+  Result := '';
+  I := 1;
+  while I <= Length(AInput) do
+  begin
+    if AInput[I] = '+' then
+    begin
+      Result := Result + ' ';
+      Inc(I);
+    end
+    else if (AInput[I] = '%') and (I + 2 <= Length(AInput)) and
+            IsASCIIHexDigit(AInput[I + 1]) and IsASCIIHexDigit(AInput[I + 2]) then
+    begin
+      B := (HexVal(AInput[I + 1]) shl 4) or HexVal(AInput[I + 2]);
+      Result := Result + Chr(B);
+      Inc(I, 3);
+    end
+    else
+    begin
+      Result := Result + AInput[I];
+      Inc(I);
+    end;
+  end;
+end;
+
+// WHATWG URL Standard §5.1 application/x-www-form-urlencoded serializing
+function SerializeFormEncoded(const AName, AValue: string): string;
+begin
+  Result := EncodeFormComponent(AName) + '=' + EncodeFormComponent(AValue);
+end;
+
+// WHATWG URL Standard §5.2 application/x-www-form-urlencoded parsing
+function ParseFormEncoded(const AInput: string;
+  out ANames: TArray<string>; out AValues: TArray<string>): Boolean;
+var
+  Sequences, Pair: TArray<string>;
+  I, EqPos: Integer;
+  S, Name, Value: string;
+begin
+  SetLength(ANames, 0);
+  SetLength(AValues, 0);
+
+  // Split by '&'
+  if AInput = '' then
+  begin
+    Result := True;
+    Exit;
+  end;
+
+  // Split on '&' separator
+  SetLength(Sequences, 0);
+  S := '';
+  for I := 1 to Length(AInput) do
+  begin
+    if AInput[I] = '&' then
+    begin
+      SetLength(Sequences, Length(Sequences) + 1);
+      Sequences[High(Sequences)] := S;
+      S := '';
+    end
+    else
+      S := S + AInput[I];
+  end;
+  SetLength(Sequences, Length(Sequences) + 1);
+  Sequences[High(Sequences)] := S;
+
+  for I := 0 to High(Sequences) do
+  begin
+    S := Sequences[I];
+    if S = '' then Continue;
+    // Split on first '='
+    EqPos := Pos('=', S);
+    if EqPos > 0 then
+    begin
+      Name := Copy(S, 1, EqPos - 1);
+      Value := Copy(S, EqPos + 1, Length(S) - EqPos);
+    end
+    else
+    begin
+      Name := S;
+      Value := '';
+    end;
+    Name := DecodeFormComponent(Name);
+    Value := DecodeFormComponent(Value);
+    SetLength(ANames, Length(ANames) + 1);
+    SetLength(AValues, Length(AValues) + 1);
+    ANames[High(ANames)] := Name;
+    AValues[High(AValues)] := Value;
+  end;
+  Result := True;
+end;
+
+// ---------------------------------------------------------------------------
+// WHATWG URL Standard §3 Hosts
+// ---------------------------------------------------------------------------
+
+// Check if a string is a valid Windows drive letter (e.g. "C:" or "C|")
+function IsWindowsDriveLetter(const S: string): Boolean;
+begin
+  Result := (Length(S) = 2) and IsASCIIAlpha(S[1]) and ((S[2] = ':') or (S[2] = '|'));
+end;
+
+// Check if a string is a normalized Windows drive letter (e.g. "C:")
+function IsNormalizedWindowsDriveLetter(const S: string): Boolean;
+begin
+  Result := (Length(S) = 2) and IsASCIIAlpha(S[1]) and (S[2] = ':');
+end;
+
+// Normalize a Windows drive letter: replace '|' with ':'
+function NormalizeWindowsDriveLetter(const S: string): string;
+begin
+  Result := S;
+  if (Length(Result) = 2) and (Result[2] = '|') then
+    Result[2] := ':';
+end;
+
+// WHATWG §3.5 host parsing (simplified: no IDNA/Punycode)
+// Returns false if the host is invalid
+function ParseHost(const AInput: string; const AIsSpecial: Boolean;
+  out AHost: string): Boolean;
+var
+  I: Integer;
+  S: string;
+begin
+  AHost := '';
+  if AInput = '' then
+  begin
+    Result := not AIsSpecial; // empty host allowed for non-special only
+    Exit;
+  end;
+
+  // IPv6 address
+  if (Length(AInput) > 0) and (AInput[1] = '[') then
+  begin
+    if (Length(AInput) < 2) or (AInput[Length(AInput)] <> ']') then
+    begin
+      Result := False;
+      Exit;
+    end;
+    // For now, keep IPv6 as-is (simplified)
+    AHost := AInput;
+    Result := True;
+    Exit;
+  end;
+
+  // Opaque host (for non-special schemes): just validate no forbidden chars
+  if not AIsSpecial then
+  begin
+    for I := 1 to Length(AInput) do
+    begin
+      if AInput[I] in [#0, ' ', '#', '/', ':', '<', '>', '?', '@', '[', '\', ']', '^', '|'] then
+      begin
+        Result := False;
+        Exit;
+      end;
+    end;
+    // Percent-decode and keep
+    AHost := AInput;
+    Result := True;
+    Exit;
+  end;
+
+  // Domain: percent-decode and lowercase
+  S := PercentDecodeString(AInput);
+  AHost := ASCIILowerString(S);
+
+  // Validate: no forbidden host code points
+  for I := 1 to Length(AHost) do
+  begin
+    if AHost[I] in [#0, #9, #10, #13, ' ', '#', '/', '<', '>', '?', '@', '[', '\', ']', '^', '|'] then
+    begin
+      Result := False;
+      Exit;
+    end;
+  end;
+
+  Result := AHost <> '';
+end;
+
+// ---------------------------------------------------------------------------
+// WHATWG URL Standard §4 special schemes
+// ---------------------------------------------------------------------------
+
+// WHATWG URL §4.1 special scheme list
+function IsSpecialScheme(const AScheme: string): Boolean;
+begin
+  Result := (AScheme = 'ftp') or (AScheme = 'file') or
+            (AScheme = 'http') or (AScheme = 'https') or
+            (AScheme = 'ws') or (AScheme = 'wss');
+end;
+
+// WHATWG URL §4.1 default port
+function DefaultPortForScheme(const AScheme: string): Integer;
+begin
+  if AScheme = 'ftp' then Result := 21
+  else if (AScheme = 'http') or (AScheme = 'ws') then Result := 80
+  else if (AScheme = 'https') or (AScheme = 'wss') then Result := 443
+  else Result := URL_NULL_PORT;
+end;
+
+function URLHasCredentials(const AURL: TGocciaURLRecord): Boolean;
+begin
+  Result := (AURL.Username <> '') or (AURL.Password <> '');
+end;
+
+// ---------------------------------------------------------------------------
+// WHATWG URL Standard §4.5 URL serializing
+// ---------------------------------------------------------------------------
+
+// WHATWG URL §4.5.1 URL path serializing
+function SerializePath(const AURL: TGocciaURLRecord): string;
+var
+  I: Integer;
+begin
+  if AURL.HasOpaquePath then
+  begin
+    Result := AURL.OpaquePath;
+    Exit;
+  end;
+  Result := '';
+  for I := 0 to High(AURL.PathSegments) do
+    Result := Result + '/' + AURL.PathSegments[I];
+  if Length(AURL.PathSegments) = 0 then
+    Result := '';
+end;
+
+// WHATWG URL §4.5 URL serializer
+function SerializeURL(const AURL: TGocciaURLRecord;
+  const AExcludeFragment: Boolean): string;
+begin
+  // Step 1: output = url.scheme + ':'
+  Result := AURL.Scheme + ':';
+
+  // Step 2: if host is not null
+  if not AURL.HasNullHost then
+  begin
+    Result := Result + '//';
+    // If url includes credentials
+    if URLHasCredentials(AURL) then
+    begin
+      Result := Result + AURL.Username;
+      if AURL.Password <> '' then
+        Result := Result + ':' + AURL.Password;
+      Result := Result + '@';
+    end;
+    // Host
+    Result := Result + AURL.Host;
+    // Port
+    if AURL.Port <> URL_NULL_PORT then
+      Result := Result + ':' + IntToStr(AURL.Port);
+  end
+  // Step 3: file with null host → '//'
+  else if AURL.Scheme = 'file' then
+    Result := Result + '//';
+
+  // Step 4/5: path
+  if AURL.HasOpaquePath then
+    Result := Result + AURL.OpaquePath
+  else
+  begin
+    // If url.host is null, path has more than one segment, first is ''
+    if AURL.HasNullHost and (Length(AURL.PathSegments) > 1) and
+       (AURL.PathSegments[0] = '') then
+      Result := Result + '/.';
+    Result := Result + SerializePath(AURL);
+  end;
+
+  // Step 6: query
+  if not AURL.HasNullQuery then
+    Result := Result + '?' + AURL.Query;
+
+  // Step 7: fragment
+  if not AExcludeFragment and not AURL.HasNullFragment then
+    Result := Result + '#' + AURL.Fragment;
+end;
+
+// WHATWG URL §4.6 URL origin
+function SerializeOrigin(const AURL: TGocciaURLRecord): string;
+begin
+  // Tuple origins for special schemes (except file)
+  if (AURL.Scheme = 'http') or (AURL.Scheme = 'https') or
+     (AURL.Scheme = 'ftp') or (AURL.Scheme = 'ws') or (AURL.Scheme = 'wss') then
+  begin
+    Result := AURL.Scheme + '://' + AURL.Host;
+    if AURL.Port <> URL_NULL_PORT then
+      Result := Result + ':' + IntToStr(AURL.Port);
+    Exit;
+  end;
+  // Opaque origin
+  Result := 'null';
+end;
+
+// ---------------------------------------------------------------------------
+// WHATWG URL Standard §4.4 URL parsing — state machine
+// ---------------------------------------------------------------------------
+
+type
+  TURLParserState = (
+    upsSchemeStart, upsScheme, upsNoScheme, upsSpecialRelativeOrAuthority,
+    upsPathOrAuthority, upsRelative, upsRelativeSlash, upsSpecialAuthoritySlashes,
+    upsSpecialAuthorityIgnoreSlashes, upsAuthority, upsHost, upsHostname,
+    upsPort, upsFile, upsFileSlash, upsFileHost, upsPathStart, upsPath,
+    upsOpaquePath, upsQuery, upsFragment, upsDone, upsFailure
+  );
+
+// Shorten a URL's path: WHATWG §4.5.4 shorten a URL's path
+procedure ShortenPath(const AScheme: string; var APath: TGocciaURLPathSegments);
+var
+  N: Integer;
+begin
+  N := Length(APath);
+  if N = 0 then Exit;
+
+  // For 'file' with a normalized Windows drive letter at path[0], keep it
+  if (AScheme = 'file') and (N = 1) and IsNormalizedWindowsDriveLetter(APath[0]) then
+    Exit;
+
+  // Remove last path segment
+  SetLength(APath, N - 1);
+end;
+
+// Append a string to the path segments
+procedure AppendPathSegment(var APath: TGocciaURLPathSegments;
+  const ASegment: string);
+var
+  N: Integer;
+begin
+  N := Length(APath);
+  SetLength(APath, N + 1);
+  APath[N] := ASegment;
+end;
+
+// Check if a string starts with a Windows drive letter followed by / \ ? #
+function StartsWithWindowsDriveLetter(const S: string): Boolean;
+begin
+  Result := (Length(S) >= 2) and IsASCIIAlpha(S[1]) and
+            ((S[2] = ':') or (S[2] = '|')) and
+            ((Length(S) = 2) or (S[3] in ['/', '\', '?', '#']));
+end;
+
+const
+  // Sentinel for EOF
+  EOF_CHAR = #0;
+
+function ParseURLInternal(const AInput: string; const AHasBase: Boolean;
+  const ABase: TGocciaURLRecord; const AStateOverride: TURLParserState;
+  const AHasStateOverride: Boolean): TGocciaURLRecord;
+var
+  Input: string;
+  URL: TGocciaURLRecord;
+  State: TURLParserState;
+  I, Len: Integer;
+  C: Char;
+  Buffer: string;
+  AtSignSeen, InsideBrackets, PasswordTokenSeen: Boolean;
+  IsSpecial: Boolean;
+  PortNum: Integer;
+  Host: string;
+  Segment: string;
+  J: Integer;
+
+  function Peek(const AOffset: Integer): Char;
+  begin
+    if (I + AOffset >= 1) and (I + AOffset <= Len) then
+      Result := Input[I + AOffset]
+    else
+      Result := EOF_CHAR;
+  end;
+
+  function CurrentChar: Char;
+  begin
+    if (I >= 1) and (I <= Len) then
+      Result := Input[I]
+    else
+      Result := EOF_CHAR;
+  end;
+
+  function RemainingStartsWith(const S: string): Boolean;
+  var
+    K: Integer;
+  begin
+    Result := False;
+    if I + Length(S) - 1 > Len then Exit;
+    for K := 1 to Length(S) do
+      if Input[I + K - 1] <> S[K] then Exit;
+    Result := True;
+  end;
+
+begin
+  // Initialize the URL record
+  FillChar(URL, SizeOf(URL), 0);
+  URL.HasNullHost := True;
+  URL.HasNullQuery := True;
+  URL.HasNullFragment := True;
+  URL.Port := URL_NULL_PORT;
+
+  // §4.4 step 1: strip leading/trailing ASCII whitespace
+  Input := AInput;
+  while (Length(Input) > 0) and IsASCIIWhitespace(Input[1]) do
+    Delete(Input, 1, 1);
+  while (Length(Input) > 0) and IsASCIIWhitespace(Input[Length(Input)]) do
+    SetLength(Input, Length(Input) - 1);
+
+  // §4.4 step 2: remove ASCII tabs and newlines
+  J := 1;
+  while J <= Length(Input) do
+  begin
+    if Input[J] in [#9, #10, #13] then
+      Delete(Input, J, 1)
+    else
+      Inc(J);
+  end;
+
+  Len := Length(Input);
+
+  State := AStateOverride;
+  if not AHasStateOverride then
+    State := upsSchemeStart;
+
+  Buffer := '';
+  AtSignSeen := False;
+  InsideBrackets := False;
+  PasswordTokenSeen := False;
+  I := 1;
+  IsSpecial := False;
+
+  // Main state machine loop
+  while State <> upsDone do
+  begin
+    C := CurrentChar;
+    // EOF is represented as a sentinel EOF_CHAR when I > Len
+
+    case State of
+      // §4.4.1 scheme start state
+      upsSchemeStart:
+      begin
+        if IsASCIIAlpha(C) then
+        begin
+          Buffer := Buffer + ASCIILower(C);
+          State := upsScheme;
+          Inc(I);
+        end
+        else if not AHasStateOverride then
+        begin
+          State := upsNoScheme;
+          // Do not advance pointer
+        end
+        else
+        begin
+          State := upsFailure;
+        end;
+      end;
+
+      // §4.4.2 scheme state
+      upsScheme:
+      begin
+        if IsASCIIAlphanumeric(C) or (C = '+') or (C = '-') or (C = '.') then
+        begin
+          Buffer := Buffer + ASCIILower(C);
+          Inc(I);
+        end
+        else if C = ':' then
+        begin
+          URL.Scheme := Buffer;
+          Buffer := '';
+          IsSpecial := IsSpecialScheme(URL.Scheme);
+
+          if AHasStateOverride then
+          begin
+            // State override: just update scheme and return
+            // (simplified — skip full state override logic for setters)
+            State := upsDone;
+          end
+          else if URL.Scheme = 'file' then
+          begin
+            State := upsFile;
+            Inc(I);
+          end
+          else if IsSpecial and AHasBase and (ABase.Scheme = URL.Scheme) then
+          begin
+            State := upsSpecialRelativeOrAuthority;
+            Inc(I);
+          end
+          else if IsSpecial then
+          begin
+            State := upsSpecialAuthoritySlashes;
+            Inc(I);
+          end
+          else if (I < Len) and (Input[I + 1] = '/') then
+          begin
+            State := upsPathOrAuthority;
+            Inc(I, 2);
+          end
+          else
+          begin
+            URL.HasOpaquePath := True;
+            State := upsOpaquePath;
+            Inc(I);
+          end;
+        end
+        else if not AHasStateOverride then
+        begin
+          // No colon found — rewind and treat as no scheme
+          Buffer := '';
+          URL.Scheme := '';
+          State := upsNoScheme;
+          I := 1;
+        end
+        else
+        begin
+          State := upsFailure;
+        end;
+      end;
+
+      // §4.4.3 no scheme state
+      upsNoScheme:
+      begin
+        if not AHasBase then
+        begin
+          State := upsFailure;
+        end
+        else if ABase.HasOpaquePath then
+        begin
+          if C <> '#' then
+          begin
+            State := upsFailure;
+          end
+          else
+          begin
+            // Copy base path and query, set fragment
+            URL.Scheme := ABase.Scheme;
+            URL.HasOpaquePath := True;
+            URL.OpaquePath := ABase.OpaquePath;
+            URL.Query := ABase.Query;
+            URL.HasNullQuery := ABase.HasNullQuery;
+            URL.Fragment := '';
+            URL.HasNullFragment := False;
+            State := upsFragment;
+            Inc(I);
+          end;
+        end
+        else if ABase.Scheme <> 'file' then
+        begin
+          State := upsRelative;
+        end
+        else
+        begin
+          State := upsFile;
+        end;
+      end;
+
+      // §4.4.4 special relative or authority state
+      upsSpecialRelativeOrAuthority:
+      begin
+        if (C = '/') and (Peek(1) = '/') then
+        begin
+          State := upsSpecialAuthorityIgnoreSlashes;
+          Inc(I, 2);
+        end
+        else
+        begin
+          State := upsRelative;
+          // Do not advance
+        end;
+      end;
+
+      // §4.4.5 path or authority state
+      upsPathOrAuthority:
+      begin
+        if C = '/' then
+        begin
+          State := upsAuthority;
+          Inc(I);
+        end
+        else
+        begin
+          State := upsPath;
+          // Do not advance
+        end;
+      end;
+
+      // §4.4.6 relative state
+      upsRelative:
+      begin
+        // Copy base scheme
+        URL.Scheme := ABase.Scheme;
+        IsSpecial := IsSpecialScheme(URL.Scheme);
+
+        if C = '/' then
+        begin
+          State := upsRelativeSlash;
+          Inc(I);
+        end
+        else if IsSpecial and (C = '\') then
+        begin
+          State := upsRelativeSlash;
+          Inc(I);
+        end
+        else
+        begin
+          // Copy base URL components
+          URL.Username := ABase.Username;
+          URL.Password := ABase.Password;
+          URL.Host := ABase.Host;
+          URL.HasNullHost := ABase.HasNullHost;
+          URL.Port := ABase.Port;
+          URL.PathSegments := Copy(ABase.PathSegments);
+          URL.Query := ABase.Query;
+          URL.HasNullQuery := ABase.HasNullQuery;
+
+          if C = '?' then
+          begin
+            URL.Query := '';
+            URL.HasNullQuery := False;
+            State := upsQuery;
+            Inc(I);
+          end
+          else if C = '#' then
+          begin
+            URL.Fragment := '';
+            URL.HasNullFragment := False;
+            State := upsFragment;
+            Inc(I);
+          end
+          else if C <> EOF_CHAR then
+          begin
+            URL.Query := '';
+            URL.HasNullQuery := True;
+            ShortenPath(URL.Scheme, URL.PathSegments);
+            State := upsPath;
+            // Do not advance
+          end
+          else
+          begin
+            State := upsDone;
+          end;
+        end;
+      end;
+
+      // §4.4.7 relative slash state
+      upsRelativeSlash:
+      begin
+        if IsSpecial and ((C = '/') or (C = '\')) then
+        begin
+          State := upsSpecialAuthorityIgnoreSlashes;
+          Inc(I);
+        end
+        else if C = '/' then
+        begin
+          State := upsAuthority;
+          Inc(I);
+        end
+        else
+        begin
+          URL.Username := ABase.Username;
+          URL.Password := ABase.Password;
+          URL.Host := ABase.Host;
+          URL.HasNullHost := ABase.HasNullHost;
+          URL.Port := ABase.Port;
+          State := upsPath;
+          // Do not advance
+        end;
+      end;
+
+      // §4.4.8 special authority slashes state
+      upsSpecialAuthoritySlashes:
+      begin
+        if (C = '/') and (Peek(1) = '/') then
+        begin
+          State := upsSpecialAuthorityIgnoreSlashes;
+          Inc(I, 2);
+        end
+        else
+        begin
+          State := upsSpecialAuthorityIgnoreSlashes;
+          // Do not advance
+        end;
+      end;
+
+      // §4.4.9 special authority ignore slashes state
+      upsSpecialAuthorityIgnoreSlashes:
+      begin
+        if (C = '/') or (C = '\') then
+          Inc(I)
+        else
+          State := upsAuthority;
+        // Do not advance in the else case
+      end;
+
+      // §4.4.10 authority state
+      upsAuthority:
+      begin
+        if C = '@' then
+        begin
+          // If we already saw a '@', the current buffer should be prefixed with %40
+          if AtSignSeen then
+            Buffer := '%40' + Buffer;
+          AtSignSeen := True;
+
+          // §4.4.10 step 2: parse buffer as credentials (username[:password])
+          URL.Username := '';
+          URL.Password := '';
+          PasswordTokenSeen := False;
+          for J := 1 to Length(Buffer) do
+          begin
+            if (Buffer[J] = ':') and not PasswordTokenSeen then
+              PasswordTokenSeen := True
+            else if PasswordTokenSeen then
+              URL.Password := URL.Password + PercentEncodeForUserinfo(Buffer[J])
+            else
+              URL.Username := URL.Username + PercentEncodeForUserinfo(Buffer[J]);
+          end;
+
+          Buffer := '';
+          Inc(I);
+        end
+        else if (C in [EOF_CHAR, '/', '?', '#']) or (IsSpecial and (C = '\')) then
+        begin
+          // End of authority — buffer contains host[:port] accumulated since last '@'
+          if AtSignSeen and (Buffer = '') then
+          begin
+            State := upsFailure;
+          end
+          else
+          begin
+            // Rewind so host state re-reads the buffer content from the input stream.
+            // The buffer was accumulated character by character; moving I back by
+            // buffer.length positions it at the first character of the host.
+            Dec(I, Length(Buffer));
+            Buffer := '';
+            State := upsHost;
+          end;
+        end
+        else
+        begin
+          Buffer := Buffer + C;
+          Inc(I);
+        end;
+      end;
+
+      // §4.4.11 host state / §4.4.12 hostname state
+      upsHost, upsHostname:
+      begin
+        if (C = ':') and not InsideBrackets then
+        begin
+          if IsSpecial and (Buffer = '') then
+          begin
+            State := upsFailure;
+          end
+          else if AHasStateOverride and (State = upsHostname) then
+          begin
+            State := upsDone;
+          end
+          else
+          begin
+            if not ParseHost(Buffer, IsSpecial, Host) then
+            begin
+              State := upsFailure;
+            end
+            else
+            begin
+              URL.Host := Host;
+              URL.HasNullHost := False;
+              Buffer := '';
+              State := upsPort;
+              Inc(I);
+            end;
+          end;
+        end
+        else if (C in [EOF_CHAR, '/', '?', '#']) or (IsSpecial and (C = '\')) then
+        begin
+          if IsSpecial and (Buffer = '') then
+          begin
+            State := upsFailure;
+          end
+          else if AHasStateOverride and (Buffer = '') and
+                  (URLHasCredentials(URL) or (URL.Port <> URL_NULL_PORT)) then
+          begin
+            State := upsDone;
+          end
+          else
+          begin
+            if not ParseHost(Buffer, IsSpecial, Host) then
+            begin
+              State := upsFailure;
+            end
+            else
+            begin
+              URL.Host := Host;
+              URL.HasNullHost := False;
+              Buffer := '';
+              State := upsPathStart;
+              // Do not advance
+            end;
+          end;
+        end
+        else
+        begin
+          if C = '[' then InsideBrackets := True;
+          if C = ']' then InsideBrackets := False;
+          Buffer := Buffer + C;
+          Inc(I);
+        end;
+      end;
+
+      // §4.4.13 port state
+      upsPort:
+      begin
+        if IsASCIIDigit(C) then
+        begin
+          Buffer := Buffer + C;
+          Inc(I);
+        end
+        else if (C in [EOF_CHAR, '/', '?', '#']) or (IsSpecial and (C = '\')) or
+                AHasStateOverride then
+        begin
+          if Buffer <> '' then
+          begin
+            PortNum := StrToIntDef(Buffer, -1);
+            if (PortNum < 0) or (PortNum > 65535) then
+            begin
+              State := upsFailure;
+            end
+            else
+            begin
+              Buffer := '';
+              // Set port (null if default for scheme)
+              if PortNum = DefaultPortForScheme(URL.Scheme) then
+                URL.Port := URL_NULL_PORT
+              else
+                URL.Port := PortNum;
+            end;
+          end;
+          if State <> upsFailure then
+          begin
+            if AHasStateOverride then
+              State := upsDone
+            else
+              State := upsPathStart;
+            // Do not advance
+          end;
+        end
+        else
+        begin
+          State := upsFailure;
+        end;
+      end;
+
+      // §4.4.14 file state
+      upsFile:
+      begin
+        URL.Scheme := 'file';
+        IsSpecial := True;
+        URL.Host := '';
+        URL.HasNullHost := False; // file has a host (empty string)
+
+        if (C = '/') or (C = '\') then
+        begin
+          State := upsFileSlash;
+          Inc(I);
+        end
+        else if AHasBase and (ABase.Scheme = 'file') then
+        begin
+          // Copy base
+          URL.Host := ABase.Host;
+          URL.HasNullHost := ABase.HasNullHost;
+          URL.PathSegments := Copy(ABase.PathSegments);
+          URL.Query := ABase.Query;
+          URL.HasNullQuery := ABase.HasNullQuery;
+
+          if C = '?' then
+          begin
+            URL.Query := '';
+            URL.HasNullQuery := False;
+            State := upsQuery;
+            Inc(I);
+          end
+          else if C = '#' then
+          begin
+            URL.Fragment := '';
+            URL.HasNullFragment := False;
+            State := upsFragment;
+            Inc(I);
+          end
+          else if C <> EOF_CHAR then
+          begin
+            URL.Query := '';
+            URL.HasNullQuery := True;
+            // If input does not start with windows drive letter
+            if not StartsWithWindowsDriveLetter(Copy(Input, I, Length(Input))) then
+              ShortenPath(URL.Scheme, URL.PathSegments);
+            State := upsPath;
+            // Do not advance
+          end
+          else
+          begin
+            State := upsDone;
+          end;
+        end
+        else
+        begin
+          State := upsPath;
+          // Do not advance
+        end;
+      end;
+
+      // §4.4.15 file slash state
+      upsFileSlash:
+      begin
+        if (C = '/') or (C = '\') then
+        begin
+          State := upsFileHost;
+          Inc(I);
+        end
+        else
+        begin
+          if AHasBase and (ABase.Scheme = 'file') then
+          begin
+            // Copy base host
+            URL.Host := ABase.Host;
+            URL.HasNullHost := ABase.HasNullHost;
+            // If base has Windows drive letter, keep it
+            if (Length(ABase.PathSegments) > 0) and
+               IsNormalizedWindowsDriveLetter(ABase.PathSegments[0]) then
+              AppendPathSegment(URL.PathSegments, ABase.PathSegments[0]);
+          end;
+          State := upsPath;
+          // Do not advance
+        end;
+      end;
+
+      // §4.4.16 file host state
+      upsFileHost:
+      begin
+        if (C in [EOF_CHAR, '/', '\', '?', '#']) then
+        begin
+          // end of host
+          if IsWindowsDriveLetter(Buffer) then
+          begin
+            // Buffer looks like a drive letter — treat as path
+            State := upsPath;
+            // Do not advance (keep buffer for path processing)
+          end
+          else if Buffer = '' then
+          begin
+            URL.Host := '';
+            URL.HasNullHost := False; // empty string host, not null
+            if AHasStateOverride then
+              State := upsDone
+            else
+              State := upsPathStart;
+            // Do not advance
+          end
+          else
+          begin
+            if not ParseHost(Buffer, IsSpecial, Host) then
+            begin
+              State := upsFailure;
+            end
+            else
+            begin
+              if Host = 'localhost' then Host := '';
+              URL.Host := Host;
+              URL.HasNullHost := False;
+              Buffer := '';
+              if AHasStateOverride then
+                State := upsDone
+              else
+                State := upsPathStart;
+              // Do not advance
+            end;
+          end;
+        end
+        else
+        begin
+          Buffer := Buffer + C;
+          Inc(I);
+        end;
+      end;
+
+      // §4.4.17 path start state
+      upsPathStart:
+      begin
+        if IsSpecial then
+        begin
+          // Special URLs: '/' or '\' → path state, otherwise path state
+          if C = '\' then
+            Inc(I)  // ignore backslash for special
+          else if C <> '/' then
+          begin
+            // Don't advance — path state handles adding slash
+          end;
+          State := upsPath;
+          if C = '/' then Inc(I);
+        end
+        else if not AHasStateOverride and (C = '?') then
+        begin
+          URL.Query := '';
+          URL.HasNullQuery := False;
+          State := upsQuery;
+          Inc(I);
+        end
+        else if not AHasStateOverride and (C = '#') then
+        begin
+          URL.Fragment := '';
+          URL.HasNullFragment := False;
+          State := upsFragment;
+          Inc(I);
+        end
+        else if C <> EOF_CHAR then
+        begin
+          State := upsPath;
+          if C <> '/' then
+          begin
+            // Do not advance
+          end
+          else
+            Inc(I);
+        end
+        else
+          State := upsDone;
+      end;
+
+      // §4.4.18 path state
+      upsPath:
+      begin
+        if (C = EOF_CHAR) or (C = '/') or (IsSpecial and (C = '\')) or
+           (not AHasStateOverride and ((C = '?') or (C = '#'))) then
+        begin
+          // Process buffer as a path segment
+          if (ASCIILowerString(Buffer) = '..') or
+             (Buffer = '.%2e') or (Buffer = '.%2E') or
+             (Buffer = '%2e.') or (Buffer = '%2E.') or
+             (Buffer = '%2e%2e') or (Buffer = '%2E%2E') or
+             (Buffer = '%2E%2e') or (Buffer = '%2e%2E') then
+          begin
+            // Double dot: go up
+            ShortenPath(URL.Scheme, URL.PathSegments);
+            if (C <> '/') and not (IsSpecial and (C = '\')) then
+              AppendPathSegment(URL.PathSegments, '');
+          end
+          else if (Buffer = '.') or (Buffer = '%2e') or (Buffer = '%2E') then
+          begin
+            // Single dot: stay (but add empty segment if at end)
+            if (C <> '/') and not (IsSpecial and (C = '\')) then
+              AppendPathSegment(URL.PathSegments, '');
+          end
+          else
+          begin
+            // Special case: file scheme with Windows drive letter
+            if (URL.Scheme = 'file') and (Length(URL.PathSegments) = 0) and
+               IsWindowsDriveLetter(Buffer) then
+              Buffer := Buffer[1] + ':'; // normalize | to :
+            AppendPathSegment(URL.PathSegments, Buffer);
+          end;
+          Buffer := '';
+
+          if C = '?' then
+          begin
+            URL.Query := '';
+            URL.HasNullQuery := False;
+            State := upsQuery;
+            Inc(I);
+          end
+          else if C = '#' then
+          begin
+            URL.Fragment := '';
+            URL.HasNullFragment := False;
+            State := upsFragment;
+            Inc(I);
+          end
+          else if C = EOF_CHAR then
+          begin
+            State := upsDone;
+          end
+          else
+          begin
+            // '/' or special '\': continue in path state
+            Inc(I);
+          end;
+        end
+        else
+        begin
+          // Add encoded character to buffer
+          Buffer := Buffer + PercentEncodeForPath(C);
+          Inc(I);
+        end;
+      end;
+
+      // §4.4.19 opaque path state
+      upsOpaquePath:
+      begin
+        if C = '?' then
+        begin
+          URL.Query := '';
+          URL.HasNullQuery := False;
+          State := upsQuery;
+          Inc(I);
+        end
+        else if C = '#' then
+        begin
+          URL.Fragment := '';
+          URL.HasNullFragment := False;
+          State := upsFragment;
+          Inc(I);
+        end
+        else if C = EOF_CHAR then
+        begin
+          State := upsDone;
+        end
+        else
+        begin
+          URL.OpaquePath := URL.OpaquePath + PercentEncodeForPath(C);
+          Inc(I);
+        end;
+      end;
+
+      // §4.4.20 query state
+      upsQuery:
+      begin
+        if C = '#' then
+        begin
+          // Encode query up to this point
+          URL.Query := URL.Query + PercentEncodeForQuery(Buffer, IsSpecial);
+          Buffer := '';
+          URL.Fragment := '';
+          URL.HasNullFragment := False;
+          State := upsFragment;
+          Inc(I);
+        end
+        else if C = EOF_CHAR then
+        begin
+          URL.Query := URL.Query + PercentEncodeForQuery(Buffer, IsSpecial);
+          Buffer := '';
+          State := upsDone;
+        end
+        else
+        begin
+          Buffer := Buffer + C;
+          Inc(I);
+        end;
+      end;
+
+      // §4.4.21 fragment state
+      upsFragment:
+      begin
+        if C = EOF_CHAR then
+        begin
+          URL.Fragment := URL.Fragment + PercentEncodeForFragment(Buffer);
+          Buffer := '';
+          State := upsDone;
+        end
+        else
+        begin
+          Buffer := Buffer + C;
+          Inc(I);
+        end;
+      end;
+
+      upsFailure:
+      begin
+        URL.IsValid := False;
+        Exit(URL);
+      end;
+
+      upsDone:
+        Break;
+    end; // case
+
+    // Safety: if we're past the end and not done, go to done
+    if (I > Len + 1) then
+      State := upsDone;
+  end; // while
+
+  // Handle remaining buffer in query/fragment states
+  if Buffer <> '' then
+  begin
+    case State of
+      upsQuery:
+        URL.Query := URL.Query + PercentEncodeForQuery(Buffer, IsSpecial);
+      upsFragment:
+        URL.Fragment := URL.Fragment + PercentEncodeForFragment(Buffer);
+    end;
+  end;
+
+  // For special schemes, ensure path is non-empty (add '' segment = '/')
+  if IsSpecial and (Length(URL.PathSegments) = 0) then
+    AppendPathSegment(URL.PathSegments, '');
+
+  URL.IsValid := True;
+  Result := URL;
+end;
+
+// ---------------------------------------------------------------------------
+// Public parsing functions
+// ---------------------------------------------------------------------------
+
+// WHATWG URL §4.4 basic URL parser — no base URL
+function ParseURL(const AInput: string): TGocciaURLRecord;
+var
+  DummyBase: TGocciaURLRecord;
+begin
+  FillChar(DummyBase, SizeOf(DummyBase), 0);
+  Result := ParseURLInternal(AInput, False, DummyBase, upsSchemeStart, False);
+end;
+
+// WHATWG URL §4.4 basic URL parser — with base URL
+function ParseURLWithBase(const AInput: string;
+  const ABase: TGocciaURLRecord): TGocciaURLRecord;
+begin
+  Result := ParseURLInternal(AInput, True, ABase, upsSchemeStart, False);
+end;
+
+end.

--- a/units/Goccia.URL.Parser.pas
+++ b/units/Goccia.URL.Parser.pas
@@ -67,7 +67,9 @@ function ParseFormEncoded(const AInput: string;
 implementation
 
 uses
-  SysUtils;
+  SysUtils,
+
+  StringBuffer;
 
 // ---------------------------------------------------------------------------
 // Character helpers
@@ -227,32 +229,36 @@ function PercentEncodeForUserinfo(const AInput: string): string;
 var
   I: Integer;
   B: Byte;
+  Buffer: TStringBuffer;
 begin
-  Result := '';
+  Buffer := TStringBuffer.Create(Length(AInput) * 2);
   for I := 1 to Length(AInput) do
   begin
     B := Ord(AInput[I]);
     if (B > $7F) or InUserinfoPercentEncodeSet(B) then
-      Result := Result + PercentEncode(B)
+      Buffer.Append(PercentEncode(B))
     else
-      Result := Result + AInput[I];
+      Buffer.AppendChar(AInput[I]);
   end;
+  Result := Buffer.ToString;
 end;
 
 function PercentEncodeForPath(const AInput: string): string;
 var
   I: Integer;
   B: Byte;
+  Buffer: TStringBuffer;
 begin
-  Result := '';
+  Buffer := TStringBuffer.Create(Length(AInput) * 2);
   for I := 1 to Length(AInput) do
   begin
     B := Ord(AInput[I]);
     if (B > $7F) or InPathPercentEncodeSet(B) then
-      Result := Result + PercentEncode(B)
+      Buffer.Append(PercentEncode(B))
     else
-      Result := Result + AInput[I];
+      Buffer.AppendChar(AInput[I]);
   end;
+  Result := Buffer.ToString;
 end;
 
 function PercentEncodeForQuery(const AInput: string;
@@ -260,42 +266,46 @@ function PercentEncodeForQuery(const AInput: string;
 var
   I: Integer;
   B: Byte;
+  Buffer: TStringBuffer;
 begin
-  Result := '';
+  Buffer := TStringBuffer.Create(Length(AInput) * 2);
   for I := 1 to Length(AInput) do
   begin
     B := Ord(AInput[I]);
     if AIsSpecial then
     begin
       if (B > $7F) or InSpecialQueryPercentEncodeSet(B) then
-        Result := Result + PercentEncode(B)
+        Buffer.Append(PercentEncode(B))
       else
-        Result := Result + AInput[I];
+        Buffer.AppendChar(AInput[I]);
     end
     else
     begin
       if (B > $7F) or InQueryPercentEncodeSet(B) then
-        Result := Result + PercentEncode(B)
+        Buffer.Append(PercentEncode(B))
       else
-        Result := Result + AInput[I];
+        Buffer.AppendChar(AInput[I]);
     end;
   end;
+  Result := Buffer.ToString;
 end;
 
 function PercentEncodeForFragment(const AInput: string): string;
 var
   I: Integer;
   B: Byte;
+  Buffer: TStringBuffer;
 begin
-  Result := '';
+  Buffer := TStringBuffer.Create(Length(AInput) * 2);
   for I := 1 to Length(AInput) do
   begin
     B := Ord(AInput[I]);
     if (B > $7F) or InFragmentPercentEncodeSet(B) then
-      Result := Result + PercentEncode(B)
+      Buffer.Append(PercentEncode(B))
     else
-      Result := Result + AInput[I];
+      Buffer.AppendChar(AInput[I]);
   end;
+  Result := Buffer.ToString;
 end;
 
 // application/x-www-form-urlencoded encoding

--- a/units/Goccia.Values.ClassValue.pas
+++ b/units/Goccia.Values.ClassValue.pas
@@ -173,6 +173,14 @@ type
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
   end;
 
+  TGocciaURLClassValue = class(TGocciaClassValue)
+    function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+  end;
+
+  TGocciaURLSearchParamsClassValue = class(TGocciaClassValue)
+    function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+  end;
+
   TGocciaInstanceValue = class(TGocciaObjectValue)
   private
     FClass: TGocciaClassValue;
@@ -217,7 +225,9 @@ uses
   Goccia.Values.MapValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.SetValue,
-  Goccia.Values.SharedArrayBufferValue;
+  Goccia.Values.SharedArrayBufferValue,
+  Goccia.Values.URLSearchParamsValue,
+  Goccia.Values.URLValue;
 
 constructor TGocciaClassValue.Create(const AName: string; const ASuperClass: TGocciaClassValue);
 begin
@@ -1063,6 +1073,20 @@ end;
 function TGocciaSharedArrayBufferClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
 begin
   Result := TGocciaSharedArrayBufferValue.Create(nil);
+end;
+
+{ TGocciaURLClassValue }
+
+function TGocciaURLClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
+begin
+  Result := TGocciaURLValue.Create(nil);
+end;
+
+{ TGocciaURLSearchParamsClassValue }
+
+function TGocciaURLSearchParamsClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
+begin
+  Result := TGocciaURLSearchParamsValue.Create(nil);
 end;
 
 { TGocciaStringClassValue }

--- a/units/Goccia.Values.Iterator.Concrete.pas
+++ b/units/Goccia.Values.Iterator.Concrete.pas
@@ -67,13 +67,30 @@ type
     procedure MarkReferences; override;
   end;
 
+  TGocciaURLSearchParamsIteratorKind = (spikKeys, spikValues, spikEntries);
+
+  TGocciaURLSearchParamsIteratorValue = class(TGocciaIteratorValue)
+  private
+    FSource: TGocciaValue;
+    FIndex: Integer;
+    FKind: TGocciaURLSearchParamsIteratorKind;
+  public
+    constructor Create(const ASource: TGocciaValue;
+      const AKind: TGocciaURLSearchParamsIteratorKind);
+    function AdvanceNext: TGocciaObjectValue; override;
+    function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+  end;
+
 implementation
 
 uses
   Goccia.Values.ArrayValue,
   Goccia.Values.HoleValue,
   Goccia.Values.MapValue,
-  Goccia.Values.SetValue;
+  Goccia.Values.SetValue,
+  Goccia.Values.URLSearchParamsValue;
 
 { TGocciaArrayIteratorValue }
 
@@ -430,6 +447,109 @@ begin
 end;
 
 procedure TGocciaSetIteratorValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FSource) then
+    FSource.MarkReferences;
+end;
+
+{ TGocciaURLSearchParamsIteratorValue }
+
+constructor TGocciaURLSearchParamsIteratorValue.Create(const ASource: TGocciaValue;
+  const AKind: TGocciaURLSearchParamsIteratorKind);
+begin
+  inherited Create;
+  FSource := ASource;
+  FIndex := 0;
+  FKind := AKind;
+end;
+
+function TGocciaURLSearchParamsIteratorValue.AdvanceNext: TGocciaObjectValue;
+var
+  Params: TGocciaURLSearchParamsValue;
+  EntryArray: TGocciaArrayValue;
+begin
+  if FDone then
+  begin
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+
+  Params := TGocciaURLSearchParamsValue(FSource);
+  if FIndex >= Params.List.Count then
+  begin
+    FDone := True;
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+
+  case FKind of
+    spikKeys:
+      Result := CreateIteratorResult(
+        TGocciaStringLiteralValue.Create(Params.List[FIndex].Name), False);
+    spikValues:
+      Result := CreateIteratorResult(
+        TGocciaStringLiteralValue.Create(Params.List[FIndex].Value), False);
+    spikEntries:
+    begin
+      EntryArray := TGocciaArrayValue.Create;
+      EntryArray.Elements.Add(
+        TGocciaStringLiteralValue.Create(Params.List[FIndex].Name));
+      EntryArray.Elements.Add(
+        TGocciaStringLiteralValue.Create(Params.List[FIndex].Value));
+      Result := CreateIteratorResult(EntryArray, False);
+    end;
+  end;
+  Inc(FIndex);
+end;
+
+function TGocciaURLSearchParamsIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+var
+  Params: TGocciaURLSearchParamsValue;
+  EntryArray: TGocciaArrayValue;
+begin
+  if FDone then
+  begin
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  Params := TGocciaURLSearchParamsValue(FSource);
+  if FIndex >= Params.List.Count then
+  begin
+    FDone := True;
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  ADone := False;
+  case FKind of
+    spikKeys:
+      Result := TGocciaStringLiteralValue.Create(Params.List[FIndex].Name);
+    spikValues:
+      Result := TGocciaStringLiteralValue.Create(Params.List[FIndex].Value);
+    spikEntries:
+    begin
+      EntryArray := TGocciaArrayValue.Create;
+      EntryArray.Elements.Add(
+        TGocciaStringLiteralValue.Create(Params.List[FIndex].Name));
+      EntryArray.Elements.Add(
+        TGocciaStringLiteralValue.Create(Params.List[FIndex].Value));
+      Result := EntryArray;
+    end;
+  end;
+  Inc(FIndex);
+end;
+
+function TGocciaURLSearchParamsIteratorValue.ToStringTag: string;
+begin
+  Result := 'URLSearchParams Iterator';
+end;
+
+procedure TGocciaURLSearchParamsIteratorValue.MarkReferences;
 begin
   if GCMarked then Exit;
   inherited;

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -104,6 +104,7 @@ uses
   SysUtils,
 
   Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
   Goccia.GarbageCollector,
   Goccia.URL.Parser,
   Goccia.Utils,
@@ -145,31 +146,31 @@ begin
   begin
     Members := TGocciaMemberCollection.Create;
     try
-      Members.AddNamedMethod('append', URLSearchParamsAppend, 2,
+      Members.AddNamedMethod(PROP_APPEND, URLSearchParamsAppend, 2,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('delete', URLSearchParamsDelete, 1,
+      Members.AddNamedMethod(PROP_DELETE, URLSearchParamsDelete, 1,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('get', URLSearchParamsGet, 1,
+      Members.AddNamedMethod(PROP_GET, URLSearchParamsGet, 1,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('getAll', URLSearchParamsGetAll, 1,
+      Members.AddNamedMethod(PROP_GET_ALL, URLSearchParamsGetAll, 1,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('has', URLSearchParamsHas, 1,
+      Members.AddNamedMethod(PROP_HAS, URLSearchParamsHas, 1,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('set', URLSearchParamsSet, 2,
+      Members.AddNamedMethod(PROP_SET, URLSearchParamsSet, 2,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('sort', URLSearchParamsSort, 0,
+      Members.AddNamedMethod(PROP_SORT, URLSearchParamsSort, 0,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('toString', URLSearchParamsToString, 0,
+      Members.AddNamedMethod(PROP_TO_STRING, URLSearchParamsToString, 0,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('keys', URLSearchParamsKeys, 0,
+      Members.AddNamedMethod(PROP_KEYS, URLSearchParamsKeys, 0,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('values', URLSearchParamsValues, 0,
+      Members.AddNamedMethod(PROP_VALUES, URLSearchParamsValues, 0,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('entries', URLSearchParamsEntries, 0,
+      Members.AddNamedMethod(PROP_ENTRIES, URLSearchParamsEntries, 0,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddNamedMethod('forEach', URLSearchParamsForEach, 1,
+      Members.AddNamedMethod(PROP_FOR_EACH, URLSearchParamsForEach, 1,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddAccessor('size',
+      Members.AddAccessor(PROP_SIZE,
         URLSearchParamsSizeGetter, nil,
         [pfConfigurable, pfEnumerable]);
       Members.AddSymbolMethod(
@@ -573,7 +574,8 @@ begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
     ThrowTypeError('URLSearchParams.prototype.forEach: not a URLSearchParams');
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
-  if AArgs.Length = 0 then Exit;
+  // §6.2: callbackFn is required; GetElement(0) returns undefined when absent,
+  // which then fails the IsCallable check and throws TypeError as required.
   Callback := AArgs.GetElement(0);
   // §6.2 step 3: if callbackFn is not callable, throw TypeError
   if not Callback.IsCallable then
@@ -658,7 +660,12 @@ begin
   else if Init is TGocciaArrayValue then
     ParseFromArray(Init)
   else if Init is TGocciaObjectValue then
-    ParseFromObject(TGocciaObjectValue(Init));
+    ParseFromObject(TGocciaObjectValue(Init))
+  else
+  begin
+    // §5.2: coerce non-object, non-string, non-array init to USVString (e.g. numbers)
+    ParseFromString(Init.ToStringLiteral.Value);
+  end;
 end;
 
 procedure TGocciaURLSearchParamsValue.MarkReferences;

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -269,8 +269,9 @@ begin
     if not Assigned(Outer.Elements[I]) or not (Outer.Elements[I] is TGocciaArrayValue) then
       ThrowTypeError('Failed to construct URLSearchParams: The provided value cannot be converted to a sequence');
     Inner := TGocciaArrayValue(Outer.Elements[I]);
-    if Inner.Elements.Count < 2 then
-      ThrowTypeError('Failed to construct URLSearchParams: Sequence initializer must contain pairs');
+    // WHATWG URL §5.2: each pair must contain exactly two items
+    if Inner.Elements.Count <> 2 then
+      ThrowTypeError('Failed to construct URLSearchParams: Sequence initializer must contain pairs with exactly two items');
     Param.Name := '';
     Param.Value := '';
     if Assigned(Inner.Elements[0]) then

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -1,0 +1,663 @@
+unit Goccia.Values.URLSearchParamsValue;
+
+// WHATWG URL Standard §6 URLSearchParams
+// https://url.spec.whatwg.org/#interface-urlsearchparams
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Generics.Collections,
+
+  Goccia.Arguments.Collection,
+  Goccia.ObjectModel,
+  Goccia.SharedPrototype,
+  Goccia.Values.ClassValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  // A single name=value pair in URLSearchParams
+  TGocciaURLSearchParam = record
+    Name: string;
+    Value: string;
+  end;
+
+  TGocciaURLSearchParamList = TList<TGocciaURLSearchParam>;
+
+  TGocciaURLSearchParamsValue = class(TGocciaInstanceValue)
+  private
+    class var FShared: TGocciaSharedPrototype;
+    class var FPrototypeMembers: array of TGocciaMemberDefinition;
+  private
+    FList: TGocciaURLSearchParamList;
+    // Back-reference to the owning URL object for update notifications.
+    // Stored as TObject to avoid a circular interface-section dependency.
+    // In practice this is a TGocciaURLValue; cast in the implementation.
+    FURLRef: TObject;
+  private
+    procedure InitializePrototype;
+    procedure UpdateURL;
+  public
+    function URLSearchParamsAppend(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsDelete(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsGet(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsGetAll(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsHas(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsSet(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsSort(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsToString(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsKeys(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsValues(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsEntries(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsForEach(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsSymbolIterator(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsSizeGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil);
+    destructor Destroy; override;
+
+    // Initialize from a query string (without or with leading '?')
+    procedure ParseFromString(const AQuery: string);
+    // Initialize from an object's own enumerable properties
+    procedure ParseFromObject(const AObj: TGocciaObjectValue);
+    // Initialize from an array of [name, value] pairs
+    procedure ParseFromArray(const AArr: TGocciaValue);
+
+    // Serialize to application/x-www-form-urlencoded
+    function Serialize: string;
+
+    function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string;
+      const AThisContext: TGocciaValue): TGocciaValue; override;
+    function ToStringTag: string; override;
+
+    procedure InitializeNativeFromArguments(
+      const AArguments: TGocciaArgumentsCollection); override;
+    procedure MarkReferences; override;
+
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+
+    property List: TGocciaURLSearchParamList read FList;
+    // Set to a TGocciaURLValue to receive mutation notifications
+    property URLRef: TObject read FURLRef write FURLRef;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Constants.ConstructorNames,
+  Goccia.GarbageCollector,
+  Goccia.URL.Parser,
+  Goccia.Utils,
+  Goccia.Values.ArrayValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
+  Goccia.Values.Iterator.Concrete,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
+  Goccia.Values.URLValue;
+
+{ TGocciaURLSearchParamsValue }
+
+constructor TGocciaURLSearchParamsValue.Create(const AClass: TGocciaClassValue);
+begin
+  inherited Create(AClass);
+  FList := TGocciaURLSearchParamList.Create;
+  FURLRef := nil;
+  InitializePrototype;
+  if not Assigned(AClass) and Assigned(FShared) then
+    FPrototype := FShared.Prototype;
+end;
+
+destructor TGocciaURLSearchParamsValue.Destroy;
+begin
+  FList.Free;
+  inherited;
+end;
+
+procedure TGocciaURLSearchParamsValue.InitializePrototype;
+var
+  Members: TGocciaMemberCollection;
+begin
+  if Assigned(FShared) then Exit;
+
+  FShared := TGocciaSharedPrototype.Create(Self);
+  if Length(FPrototypeMembers) = 0 then
+  begin
+    Members := TGocciaMemberCollection.Create;
+    try
+      Members.AddNamedMethod('append', URLSearchParamsAppend, 2,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('delete', URLSearchParamsDelete, 1,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('get', URLSearchParamsGet, 1,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('getAll', URLSearchParamsGetAll, 1,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('has', URLSearchParamsHas, 1,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('set', URLSearchParamsSet, 2,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('sort', URLSearchParamsSort, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('toString', URLSearchParamsToString, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('keys', URLSearchParamsKeys, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('values', URLSearchParamsValues, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('entries', URLSearchParamsEntries, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('forEach', URLSearchParamsForEach, 1,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddAccessor('size',
+        URLSearchParamsSizeGetter, nil,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddSymbolMethod(
+        TGocciaSymbolValue.WellKnownIterator,
+        '[Symbol.iterator]',
+        URLSearchParamsSymbolIterator,
+        0,
+        [pfConfigurable, pfWritable]);
+      FPrototypeMembers := Members.ToDefinitions;
+    finally
+      Members.Free;
+    end;
+  end;
+  RegisterMemberDefinitions(FShared.Prototype, FPrototypeMembers);
+end;
+
+class procedure TGocciaURLSearchParamsValue.ExposePrototype(
+  const AConstructor: TGocciaValue);
+begin
+  if not Assigned(FShared) then
+    TGocciaURLSearchParamsValue.Create;
+  ExposeSharedPrototypeOnConstructor(FShared, AConstructor);
+end;
+
+// ---------------------------------------------------------------------------
+// Serialization / parsing
+// ---------------------------------------------------------------------------
+
+// WHATWG URL §5.1 application/x-www-form-urlencoded serializer
+function TGocciaURLSearchParamsValue.Serialize: string;
+var
+  I: Integer;
+begin
+  Result := '';
+  for I := 0 to FList.Count - 1 do
+  begin
+    if I > 0 then Result := Result + '&';
+    Result := Result + SerializeFormEncoded(FList[I].Name, FList[I].Value);
+  end;
+end;
+
+// WHATWG URL §5.2 application/x-www-form-urlencoded parser
+procedure TGocciaURLSearchParamsValue.ParseFromString(const AQuery: string);
+var
+  Names, Values: TArray<string>;
+  I: Integer;
+  Param: TGocciaURLSearchParam;
+  Input: string;
+begin
+  FList.Clear;
+  Input := AQuery;
+  // Strip leading '?'
+  if (Length(Input) > 0) and (Input[1] = '?') then
+    Delete(Input, 1, 1);
+
+  ParseFormEncoded(Input, Names, Values);
+  for I := 0 to High(Names) do
+  begin
+    Param.Name := Names[I];
+    Param.Value := Values[I];
+    FList.Add(Param);
+  end;
+end;
+
+procedure TGocciaURLSearchParamsValue.ParseFromObject(
+  const AObj: TGocciaObjectValue);
+var
+  Key: string;
+  Param: TGocciaURLSearchParam;
+  Val: TGocciaValue;
+begin
+  FList.Clear;
+  for Key in AObj.GetOwnPropertyKeys do
+  begin
+    Val := AObj.GetProperty(Key);
+    Param.Name := Key;
+    if Assigned(Val) then
+      Param.Value := Val.ToStringLiteral.Value
+    else
+      Param.Value := '';
+    FList.Add(Param);
+  end;
+end;
+
+procedure TGocciaURLSearchParamsValue.ParseFromArray(const AArr: TGocciaValue);
+var
+  Outer, Inner: TGocciaArrayValue;
+  I: Integer;
+  Param: TGocciaURLSearchParam;
+begin
+  FList.Clear;
+  if not (AArr is TGocciaArrayValue) then Exit;
+  Outer := TGocciaArrayValue(AArr);
+  for I := 0 to Outer.Elements.Count - 1 do
+  begin
+    if Assigned(Outer.Elements[I]) and (Outer.Elements[I] is TGocciaArrayValue) then
+    begin
+      Inner := TGocciaArrayValue(Outer.Elements[I]);
+      if Inner.Elements.Count >= 2 then
+      begin
+        Param.Name := '';
+        Param.Value := '';
+        if Assigned(Inner.Elements[0]) then
+          Param.Name := Inner.Elements[0].ToStringLiteral.Value;
+        if Assigned(Inner.Elements[1]) then
+          Param.Value := Inner.Elements[1].ToStringLiteral.Value;
+        FList.Add(Param);
+      end;
+    end;
+  end;
+end;
+
+// Notify the owning URL that our params have changed
+procedure TGocciaURLSearchParamsValue.UpdateURL;
+begin
+  if Assigned(FURLRef) then
+    TGocciaURLValue(FURLRef).SetSearchFromParams(Self);
+end;
+
+// ---------------------------------------------------------------------------
+// Prototype methods
+// ---------------------------------------------------------------------------
+
+// WHATWG URL §6.2 URLSearchParams.prototype.append(name, value)
+function TGocciaURLSearchParamsValue.URLSearchParamsAppend(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Self_: TGocciaURLSearchParamsValue;
+  Param: TGocciaURLSearchParam;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.append: not a URLSearchParams');
+  Self_ := TGocciaURLSearchParamsValue(AThisValue);
+  if AArgs.Length < 2 then Exit;
+  Param.Name := AArgs.GetElement(0).ToStringLiteral.Value;
+  Param.Value := AArgs.GetElement(1).ToStringLiteral.Value;
+  Self_.FList.Add(Param);
+  Self_.UpdateURL;
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.delete(name[, value])
+function TGocciaURLSearchParamsValue.URLSearchParamsDelete(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Self_: TGocciaURLSearchParamsValue;
+  Name, Value: string;
+  HasValue: Boolean;
+  I: Integer;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.delete: not a URLSearchParams');
+  Self_ := TGocciaURLSearchParamsValue(AThisValue);
+  if AArgs.Length = 0 then Exit;
+  Name := AArgs.GetElement(0).ToStringLiteral.Value;
+  HasValue := AArgs.Length >= 2;
+  if HasValue then
+    Value := AArgs.GetElement(1).ToStringLiteral.Value
+  else
+    Value := '';
+
+  I := 0;
+  while I < Self_.FList.Count do
+  begin
+    if Self_.FList[I].Name = Name then
+    begin
+      if HasValue and (Self_.FList[I].Value <> Value) then
+      begin
+        Inc(I);
+        Continue;
+      end;
+      Self_.FList.Delete(I);
+    end
+    else
+      Inc(I);
+  end;
+  Self_.UpdateURL;
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.get(name) → string or null
+function TGocciaURLSearchParamsValue.URLSearchParamsGet(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Self_: TGocciaURLSearchParamsValue;
+  Name: string;
+  I: Integer;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.get: not a URLSearchParams');
+  Self_ := TGocciaURLSearchParamsValue(AThisValue);
+  if AArgs.Length = 0 then
+  begin
+    Result := TGocciaNullLiteralValue.NullValue;
+    Exit;
+  end;
+  Name := AArgs.GetElement(0).ToStringLiteral.Value;
+  for I := 0 to Self_.FList.Count - 1 do
+    if Self_.FList[I].Name = Name then
+    begin
+      Result := TGocciaStringLiteralValue.Create(Self_.FList[I].Value);
+      Exit;
+    end;
+  Result := TGocciaNullLiteralValue.NullValue;
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.getAll(name) → string[]
+function TGocciaURLSearchParamsValue.URLSearchParamsGetAll(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Self_: TGocciaURLSearchParamsValue;
+  Name: string;
+  Arr: TGocciaArrayValue;
+  I: Integer;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.getAll: not a URLSearchParams');
+  Self_ := TGocciaURLSearchParamsValue(AThisValue);
+  Arr := TGocciaArrayValue.Create;
+  if AArgs.Length > 0 then
+  begin
+    Name := AArgs.GetElement(0).ToStringLiteral.Value;
+    for I := 0 to Self_.FList.Count - 1 do
+      if Self_.FList[I].Name = Name then
+        Arr.Elements.Add(TGocciaStringLiteralValue.Create(Self_.FList[I].Value));
+  end;
+  Result := Arr;
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.has(name[, value]) → boolean
+function TGocciaURLSearchParamsValue.URLSearchParamsHas(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Self_: TGocciaURLSearchParamsValue;
+  Name, Value: string;
+  HasValue: Boolean;
+  I: Integer;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.has: not a URLSearchParams');
+  Self_ := TGocciaURLSearchParamsValue(AThisValue);
+  if AArgs.Length = 0 then
+  begin
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+  Name := AArgs.GetElement(0).ToStringLiteral.Value;
+  HasValue := AArgs.Length >= 2;
+  if HasValue then
+    Value := AArgs.GetElement(1).ToStringLiteral.Value
+  else
+    Value := '';
+
+  for I := 0 to Self_.FList.Count - 1 do
+    if Self_.FList[I].Name = Name then
+    begin
+      if not HasValue or (Self_.FList[I].Value = Value) then
+      begin
+        Result := TGocciaBooleanLiteralValue.TrueValue;
+        Exit;
+      end;
+    end;
+  Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.set(name, value)
+function TGocciaURLSearchParamsValue.URLSearchParamsSet(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Self_: TGocciaURLSearchParamsValue;
+  Name, Value: string;
+  Found: Boolean;
+  Param: TGocciaURLSearchParam;
+  I: Integer;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.set: not a URLSearchParams');
+  Self_ := TGocciaURLSearchParamsValue(AThisValue);
+  if AArgs.Length < 2 then Exit;
+  Name := AArgs.GetElement(0).ToStringLiteral.Value;
+  Value := AArgs.GetElement(1).ToStringLiteral.Value;
+
+  Found := False;
+  I := 0;
+  while I < Self_.FList.Count do
+  begin
+    if Self_.FList[I].Name = Name then
+    begin
+      if not Found then
+      begin
+        Param := Self_.FList[I];
+        Param.Value := Value;
+        Self_.FList[I] := Param;
+        Found := True;
+        Inc(I);
+      end
+      else
+        Self_.FList.Delete(I);
+    end
+    else
+      Inc(I);
+  end;
+
+  if not Found then
+  begin
+    Param.Name := Name;
+    Param.Value := Value;
+    Self_.FList.Add(Param);
+  end;
+  Self_.UpdateURL;
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.sort()
+function TGocciaURLSearchParamsValue.URLSearchParamsSort(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Self_: TGocciaURLSearchParamsValue;
+  I, J: Integer;
+  Temp: TGocciaURLSearchParam;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.sort: not a URLSearchParams');
+  Self_ := TGocciaURLSearchParamsValue(AThisValue);
+
+  // Stable sort by name (Unicode code unit order) — insertion sort
+  for I := 1 to Self_.FList.Count - 1 do
+  begin
+    Temp := Self_.FList[I];
+    J := I - 1;
+    while (J >= 0) and (Self_.FList[J].Name > Temp.Name) do
+    begin
+      Self_.FList[J + 1] := Self_.FList[J];
+      Dec(J);
+    end;
+    Self_.FList[J + 1] := Temp;
+  end;
+  Self_.UpdateURL;
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.toString()
+function TGocciaURLSearchParamsValue.URLSearchParamsToString(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.toString: not a URLSearchParams');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLSearchParamsValue(AThisValue).Serialize);
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.keys()
+function TGocciaURLSearchParamsValue.URLSearchParamsKeys(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.keys: not a URLSearchParams');
+  Result := TGocciaURLSearchParamsIteratorValue.Create(AThisValue, spikKeys);
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.values()
+function TGocciaURLSearchParamsValue.URLSearchParamsValues(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.values: not a URLSearchParams');
+  Result := TGocciaURLSearchParamsIteratorValue.Create(AThisValue, spikValues);
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.entries()
+function TGocciaURLSearchParamsValue.URLSearchParamsEntries(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.entries: not a URLSearchParams');
+  Result := TGocciaURLSearchParamsIteratorValue.Create(AThisValue, spikEntries);
+end;
+
+// WHATWG URL §6.2 URLSearchParams.prototype.forEach(callbackFn[, thisArg])
+function TGocciaURLSearchParamsValue.URLSearchParamsForEach(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Self_: TGocciaURLSearchParamsValue;
+  Callback: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
+  I: Integer;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams.prototype.forEach: not a URLSearchParams');
+  Self_ := TGocciaURLSearchParamsValue(AThisValue);
+  if AArgs.Length = 0 then Exit;
+  Callback := AArgs.GetElement(0);
+  if not Callback.IsCallable then Exit;
+
+  for I := 0 to Self_.FList.Count - 1 do
+  begin
+    CallArgs := TGocciaArgumentsCollection.Create([
+      TGocciaStringLiteralValue.Create(Self_.FList[I].Value),
+      TGocciaStringLiteralValue.Create(Self_.FList[I].Name),
+      AThisValue]);
+    try
+      InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+    finally
+      CallArgs.Free;
+    end;
+  end;
+end;
+
+// WHATWG URL §6.2 size getter
+function TGocciaURLSearchParamsValue.URLSearchParamsSizeGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams size getter: not a URLSearchParams');
+  Result := TGocciaNumberLiteralValue.Create(
+    TGocciaURLSearchParamsValue(AThisValue).FList.Count);
+end;
+
+// [Symbol.iterator] → same as entries()
+function TGocciaURLSearchParamsValue.URLSearchParamsSymbolIterator(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLSearchParamsValue) then
+    ThrowTypeError('URLSearchParams[Symbol.iterator]: not a URLSearchParams');
+  Result := TGocciaURLSearchParamsIteratorValue.Create(AThisValue, spikEntries);
+end;
+
+// ---------------------------------------------------------------------------
+// Property access
+// ---------------------------------------------------------------------------
+
+function TGocciaURLSearchParamsValue.GetProperty(
+  const AName: string): TGocciaValue;
+begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaURLSearchParamsValue.GetPropertyWithContext(const AName: string;
+  const AThisContext: TGocciaValue): TGocciaValue;
+begin
+  Result := inherited GetPropertyWithContext(AName, AThisContext);
+end;
+
+function TGocciaURLSearchParamsValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_URL_SEARCH_PARAMS;
+end;
+
+procedure TGocciaURLSearchParamsValue.InitializeNativeFromArguments(
+  const AArguments: TGocciaArgumentsCollection);
+var
+  Init: TGocciaValue;
+begin
+  if AArguments.Length = 0 then Exit;
+  Init := AArguments.GetElement(0);
+  if Init is TGocciaStringLiteralValue then
+    ParseFromString(TGocciaStringLiteralValue(Init).Value)
+  else if Init is TGocciaURLSearchParamsValue then
+  begin
+    // Copy from existing URLSearchParams
+    FList.AddRange(TGocciaURLSearchParamsValue(Init).FList);
+  end
+  else if Init is TGocciaArrayValue then
+    ParseFromArray(Init)
+  else if Init is TGocciaObjectValue then
+    ParseFromObject(TGocciaObjectValue(Init));
+end;
+
+procedure TGocciaURLSearchParamsValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  // FURLRef is a non-owning back-reference; the URL object marks us
+end;
+
+end.

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -296,7 +296,7 @@ end;
 // Notify the owning URL that our params have changed
 procedure TGocciaURLSearchParamsValue.UpdateURL;
 begin
-  if Assigned(FURLRef) then
+  if Assigned(FURLRef) and (FURLRef is TGocciaURLValue) then
     TGocciaURLValue(FURLRef).SetSearchFromParams(Self);
 end;
 
@@ -578,6 +578,7 @@ var
   Self_: TGocciaURLSearchParamsValue;
   Callback, ThisArg: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
+  Pair: TGocciaURLSearchParam;
   I: Integer;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -597,17 +598,23 @@ begin
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  for I := 0 to Self_.FList.Count - 1 do
+  // §6.2: snapshot each pair before invoking the callback so that
+  // mutations to FList during the callback (append/delete/set) do not
+  // cause out-of-bounds access on a now-shorter list.
+  I := 0;
+  while I < Self_.FList.Count do
   begin
+    Pair := Self_.FList[I];
     CallArgs := TGocciaArgumentsCollection.Create([
-      TGocciaStringLiteralValue.Create(Self_.FList[I].Value),
-      TGocciaStringLiteralValue.Create(Self_.FList[I].Name),
+      TGocciaStringLiteralValue.Create(Pair.Value),
+      TGocciaStringLiteralValue.Create(Pair.Name),
       AThisValue]);
     try
       InvokeCallable(Callback, CallArgs, ThisArg);
     finally
       CallArgs.Free;
     end;
+    Inc(I);
   end;
 end;
 
@@ -685,7 +692,7 @@ begin
   // Mark the owning URL so it stays live as long as this URLSearchParams is
   // reachable, preventing use-after-free when the user holds only a direct
   // reference to a url.searchParams object.
-  if Assigned(FURLRef) then
+  if Assigned(FURLRef) and (FURLRef is TGocciaURLValue) then
     TGocciaURLValue(FURLRef).MarkReferences;
 end;
 

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -170,9 +170,10 @@ begin
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddNamedMethod(PROP_FOR_EACH, URLSearchParamsForEach, 1,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      // WHATWG URLSearchParams: size is a non-enumerable prototype accessor
       Members.AddAccessor(PROP_SIZE,
         URLSearchParamsSizeGetter, nil,
-        [pfConfigurable, pfEnumerable]);
+        [pfConfigurable]);
       Members.AddSymbolMethod(
         TGocciaSymbolValue.WellKnownIterator,
         '[Symbol.iterator]',

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -263,22 +263,21 @@ begin
   FList.Clear;
   if not (AArr is TGocciaArrayValue) then Exit;
   Outer := TGocciaArrayValue(AArr);
+  // WHATWG URL §5.2: each pair must contain exactly 2 elements per sequence<sequence<USVString>>
   for I := 0 to Outer.Elements.Count - 1 do
   begin
-    if Assigned(Outer.Elements[I]) and (Outer.Elements[I] is TGocciaArrayValue) then
-    begin
-      Inner := TGocciaArrayValue(Outer.Elements[I]);
-      if Inner.Elements.Count >= 2 then
-      begin
-        Param.Name := '';
-        Param.Value := '';
-        if Assigned(Inner.Elements[0]) then
-          Param.Name := Inner.Elements[0].ToStringLiteral.Value;
-        if Assigned(Inner.Elements[1]) then
-          Param.Value := Inner.Elements[1].ToStringLiteral.Value;
-        FList.Add(Param);
-      end;
-    end;
+    if not Assigned(Outer.Elements[I]) or not (Outer.Elements[I] is TGocciaArrayValue) then
+      ThrowTypeError('Failed to construct URLSearchParams: The provided value cannot be converted to a sequence');
+    Inner := TGocciaArrayValue(Outer.Elements[I]);
+    if Inner.Elements.Count < 2 then
+      ThrowTypeError('Failed to construct URLSearchParams: Sequence initializer must contain pairs');
+    Param.Name := '';
+    Param.Value := '';
+    if Assigned(Inner.Elements[0]) then
+      Param.Name := Inner.Elements[0].ToStringLiteral.Value;
+    if Assigned(Inner.Elements[1]) then
+      Param.Value := Inner.Elements[1].ToStringLiteral.Value;
+    FList.Add(Param);
   end;
 end;
 
@@ -565,7 +564,7 @@ function TGocciaURLSearchParamsValue.URLSearchParamsForEach(
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   Self_: TGocciaURLSearchParamsValue;
-  Callback: TGocciaValue;
+  Callback, ThisArg: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
 begin
@@ -575,7 +574,15 @@ begin
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
   if AArgs.Length = 0 then Exit;
   Callback := AArgs.GetElement(0);
-  if not Callback.IsCallable then Exit;
+  // §6.2 step 3: if callbackFn is not callable, throw TypeError
+  if not Callback.IsCallable then
+    ThrowTypeError('URLSearchParams.prototype.forEach: callback is not a function');
+
+  // §6.2 step 4: optional thisArg (second argument)
+  if AArgs.Length >= 2 then
+    ThisArg := AArgs.GetElement(1)
+  else
+    ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   for I := 0 to Self_.FList.Count - 1 do
   begin
@@ -584,7 +591,7 @@ begin
       TGocciaStringLiteralValue.Create(Self_.FList[I].Name),
       AThisValue]);
     try
-      InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+      InvokeCallable(Callback, CallArgs, ThisArg);
     finally
       CallArgs.Free;
     end;
@@ -657,7 +664,11 @@ procedure TGocciaURLSearchParamsValue.MarkReferences;
 begin
   if GCMarked then Exit;
   inherited;
-  // FURLRef is a non-owning back-reference; the URL object marks us
+  // Mark the owning URL so it stays live as long as this URLSearchParams is
+  // reachable, preventing use-after-free when the user holds only a direct
+  // reference to a url.searchParams object.
+  if Assigned(FURLRef) then
+    TGocciaURLValue(FURLRef).MarkReferences;
 end;
 
 end.

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -103,6 +103,8 @@ implementation
 uses
   SysUtils,
 
+  StringBuffer,
+
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.GarbageCollector,
@@ -204,13 +206,20 @@ end;
 function TGocciaURLSearchParamsValue.Serialize: string;
 var
   I: Integer;
+  Buffer: TStringBuffer;
 begin
-  Result := '';
+  if FList.Count = 0 then
+  begin
+    Result := '';
+    Exit;
+  end;
+  Buffer := TStringBuffer.Create(FList.Count * 16);
   for I := 0 to FList.Count - 1 do
   begin
-    if I > 0 then Result := Result + '&';
-    Result := Result + SerializeFormEncoded(FList[I].Name, FList[I].Value);
+    if I > 0 then Buffer.AppendChar('&');
+    Buffer.Append(SerializeFormEncoded(FList[I].Name, FList[I].Value));
   end;
+  Result := Buffer.ToString;
 end;
 
 // WHATWG URL §5.2 application/x-www-form-urlencoded parser

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -667,6 +667,9 @@ var
 begin
   if AArguments.Length = 0 then Exit;
   Init := AArguments.GetElement(0);
+  // WHATWG Web IDL: explicit undefined receives the default value (empty string),
+  // producing an empty list — same as calling the constructor with no argument.
+  if Init is TGocciaUndefinedLiteralValue then Exit;
   if Init is TGocciaStringLiteralValue then
     ParseFromString(TGocciaStringLiteralValue(Init).Value)
   else if Init is TGocciaURLSearchParamsValue then

--- a/units/Goccia.Values.URLValue.pas
+++ b/units/Goccia.Values.URLValue.pas
@@ -1,0 +1,863 @@
+unit Goccia.Values.URLValue;
+
+// WHATWG URL Standard §4 URL class
+// https://url.spec.whatwg.org/#url-class
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.ObjectModel,
+  Goccia.SharedPrototype,
+  Goccia.Values.ClassValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives,
+  Goccia.Values.URLSearchParamsValue;
+
+type
+  TGocciaURLValue = class(TGocciaInstanceValue)
+  private
+    class var FShared: TGocciaSharedPrototype;
+    class var FPrototypeMembers: array of TGocciaMemberDefinition;
+  private
+    // WHATWG URL §4.1 URL record components (stored parsed)
+    FScheme: string;       // e.g. 'https' — no ':'
+    FUsername: string;     // percent-encoded
+    FPassword: string;     // percent-encoded
+    FHost: string;         // serialized hostname
+    FHasNullHost: Boolean; // true = no authority component (null host)
+    FPort: Integer;        // -1 = null port
+    FPathname: string;     // serialized path including leading '/'
+    FHasNullQuery: Boolean;
+    FQuery: string;        // without leading '?'
+    FHasNullFragment: Boolean;
+    FFragment: string;     // without leading '#'
+    FHasOpaquePath: Boolean;
+
+    // Cached URLSearchParams — lazily created
+    FSearchParams: TGocciaURLSearchParamsValue;
+    // True = URL is invalid (parse failure)
+    FIsValid: Boolean;
+
+    procedure InitializePrototype;
+    procedure SyncSearchParamsFromQuery;
+  private
+    // Getters
+    function URLHrefGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLOriginGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLProtocolGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLUsernameGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLPasswordGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLHostGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLHostnameGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLPortGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLPathnameGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchParamsGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLHashGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    // Setters
+    function URLHrefSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLProtocolSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLUsernameSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLPasswordSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLHostSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLHostnameSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLPortSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLPathnameSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLSearchSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLHashSetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    // Methods
+    function URLToString(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function URLToJSON(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil);
+    destructor Destroy; override;
+
+    // Initialize from a parsed URL record
+    procedure InitFromRecord(const AScheme, AUsername, APassword, AHost: string;
+      const AHasNullHost: Boolean; const APort: Integer;
+      const APathname: string; const AHasNullQuery: Boolean;
+      const AQuery: string; const AHasNullFragment: Boolean;
+      const AFragment: string; const AHasOpaquePath: Boolean);
+
+    // Called by URLSearchParams when params change
+    procedure SetSearchFromParams(const AParams: TGocciaURLSearchParamsValue);
+
+    // Compute the href string
+    function ComputeHref: string;
+
+    function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string;
+      const AThisContext: TGocciaValue): TGocciaValue; override;
+    function ToStringLiteral: TGocciaStringLiteralValue; override;
+    function ToStringTag: string; override;
+
+    procedure InitializeNativeFromArguments(
+      const AArguments: TGocciaArgumentsCollection); override;
+    procedure MarkReferences; override;
+
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+
+    property IsValid: Boolean read FIsValid;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.GarbageCollector,
+  Goccia.URL.Parser,
+  Goccia.Values.ArrayValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue;
+
+{ TGocciaURLValue }
+
+constructor TGocciaURLValue.Create(const AClass: TGocciaClassValue);
+begin
+  inherited Create(AClass);
+  FPort := URL_NULL_PORT;
+  FHasNullHost := True;
+  FHasNullQuery := True;
+  FHasNullFragment := True;
+  FIsValid := False;
+  FSearchParams := nil;
+  InitializePrototype;
+  if not Assigned(AClass) and Assigned(FShared) then
+    FPrototype := FShared.Prototype;
+end;
+
+destructor TGocciaURLValue.Destroy;
+begin
+  inherited;
+end;
+
+procedure TGocciaURLValue.InitializePrototype;
+var
+  Members: TGocciaMemberCollection;
+begin
+  if Assigned(FShared) then Exit;
+
+  FShared := TGocciaSharedPrototype.Create(Self);
+  if Length(FPrototypeMembers) = 0 then
+  begin
+    Members := TGocciaMemberCollection.Create;
+    try
+      // Accessor properties (getter + setter pairs)
+      Members.AddAccessor(PROP_HREF,
+        URLHrefGetter, URLHrefSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_ORIGIN,
+        URLOriginGetter, nil,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_PROTOCOL,
+        URLProtocolGetter, URLProtocolSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_USERNAME,
+        URLUsernameGetter, URLUsernameSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_PASSWORD,
+        URLPasswordGetter, URLPasswordSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_HOST,
+        URLHostGetter, URLHostSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_HOSTNAME,
+        URLHostnameGetter, URLHostnameSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_PORT,
+        URLPortGetter, URLPortSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_PATHNAME,
+        URLPathnameGetter, URLPathnameSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_SEARCH,
+        URLSearchGetter, URLSearchSetter,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_SEARCH_PARAMS,
+        URLSearchParamsGetter, nil,
+        [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_HASH,
+        URLHashGetter, URLHashSetter,
+        [pfConfigurable, pfEnumerable]);
+      // Methods
+      Members.AddNamedMethod('toString', URLToString, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod('toJSON', URLToJSON, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      FPrototypeMembers := Members.ToDefinitions;
+    finally
+      Members.Free;
+    end;
+  end;
+  RegisterMemberDefinitions(FShared.Prototype, FPrototypeMembers);
+end;
+
+class procedure TGocciaURLValue.ExposePrototype(
+  const AConstructor: TGocciaValue);
+begin
+  if not Assigned(FShared) then
+    TGocciaURLValue.Create;
+  ExposeSharedPrototypeOnConstructor(FShared, AConstructor);
+end;
+
+// ---------------------------------------------------------------------------
+// Initialization helpers
+// ---------------------------------------------------------------------------
+
+procedure TGocciaURLValue.InitFromRecord(const AScheme, AUsername, APassword,
+  AHost: string; const AHasNullHost: Boolean; const APort: Integer;
+  const APathname: string; const AHasNullQuery: Boolean;
+  const AQuery: string; const AHasNullFragment: Boolean;
+  const AFragment: string; const AHasOpaquePath: Boolean);
+begin
+  FScheme := AScheme;
+  FUsername := AUsername;
+  FPassword := APassword;
+  FHost := AHost;
+  FHasNullHost := AHasNullHost;
+  FPort := APort;
+  FPathname := APathname;
+  FHasNullQuery := AHasNullQuery;
+  FQuery := AQuery;
+  FHasNullFragment := AHasNullFragment;
+  FFragment := AFragment;
+  FHasOpaquePath := AHasOpaquePath;
+  FIsValid := True;
+
+  // Reset cached search params
+  FSearchParams := nil;
+end;
+
+// Serialize the URL to its href string directly from stored fields.
+// This avoids needing to split FPathname back into segments.
+function TGocciaURLValue.ComputeHref: string;
+var
+  HasCredentials: Boolean;
+begin
+  // scheme:
+  Result := FScheme + ':';
+
+  // //authority
+  if not FHasNullHost then
+  begin
+    Result := Result + '//';
+    HasCredentials := (FUsername <> '') or (FPassword <> '');
+    if HasCredentials then
+    begin
+      Result := Result + FUsername;
+      if FPassword <> '' then
+        Result := Result + ':' + FPassword;
+      Result := Result + '@';
+    end;
+    Result := Result + FHost;
+    if FPort <> URL_NULL_PORT then
+      Result := Result + ':' + IntToStr(FPort);
+  end
+  else if FScheme = 'file' then
+    Result := Result + '//';
+
+  // path
+  Result := Result + FPathname;
+
+  // ?query
+  if not FHasNullQuery then
+    Result := Result + '?' + FQuery;
+
+  // #fragment
+  if not FHasNullFragment then
+    Result := Result + '#' + FFragment;
+end;
+
+procedure TGocciaURLValue.SyncSearchParamsFromQuery;
+begin
+  if Assigned(FSearchParams) then
+  begin
+    // Temporarily remove URL ref to avoid re-entrancy
+    FSearchParams.URLRef := nil;
+    if FHasNullQuery then
+      FSearchParams.ParseFromString('')
+    else
+      FSearchParams.ParseFromString(FQuery);
+    FSearchParams.URLRef := Self;
+  end;
+end;
+
+// Called by URLSearchParams when its contents change
+procedure TGocciaURLValue.SetSearchFromParams(
+  const AParams: TGocciaURLSearchParamsValue);
+var
+  S: string;
+begin
+  S := AParams.Serialize;
+  if S = '' then
+  begin
+    FHasNullQuery := True;
+    FQuery := '';
+  end
+  else
+  begin
+    FHasNullQuery := False;
+    FQuery := S;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+function TGocciaURLValue.URLHrefGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL href getter: not a URL');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLValue(AThisValue).ComputeHref);
+end;
+
+function TGocciaURLValue.URLOriginGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  URLRec: TGocciaURLRecord;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL origin getter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  FillChar(URLRec, SizeOf(URLRec), 0);
+  URLRec.Scheme := U.FScheme;
+  URLRec.Host := U.FHost;
+  URLRec.HasNullHost := U.FHasNullHost;
+  URLRec.Port := U.FPort;
+  Result := TGocciaStringLiteralValue.Create(SerializeOrigin(URLRec));
+end;
+
+function TGocciaURLValue.URLProtocolGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL protocol getter: not a URL');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLValue(AThisValue).FScheme + ':');
+end;
+
+function TGocciaURLValue.URLUsernameGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL username getter: not a URL');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLValue(AThisValue).FUsername);
+end;
+
+function TGocciaURLValue.URLPasswordGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL password getter: not a URL');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLValue(AThisValue).FPassword);
+end;
+
+function TGocciaURLValue.URLHostGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  H: string;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL host getter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  H := U.FHost;
+  if U.FPort <> URL_NULL_PORT then
+    H := H + ':' + IntToStr(U.FPort);
+  Result := TGocciaStringLiteralValue.Create(H);
+end;
+
+function TGocciaURLValue.URLHostnameGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL hostname getter: not a URL');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLValue(AThisValue).FHost);
+end;
+
+function TGocciaURLValue.URLPortGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL port getter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if U.FPort = URL_NULL_PORT then
+    Result := TGocciaStringLiteralValue.Create('')
+  else
+    Result := TGocciaStringLiteralValue.Create(IntToStr(U.FPort));
+end;
+
+function TGocciaURLValue.URLPathnameGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL pathname getter: not a URL');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLValue(AThisValue).FPathname);
+end;
+
+function TGocciaURLValue.URLSearchGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL search getter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if U.FHasNullQuery or (U.FQuery = '') then
+    Result := TGocciaStringLiteralValue.Create('')
+  else
+    Result := TGocciaStringLiteralValue.Create('?' + U.FQuery);
+end;
+
+function TGocciaURLValue.URLSearchParamsGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL searchParams getter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+
+  // Lazy initialization of the search params object
+  if not Assigned(U.FSearchParams) then
+  begin
+    U.FSearchParams := TGocciaURLSearchParamsValue.Create;
+    U.FSearchParams.URLRef := U;
+    if not U.FHasNullQuery then
+      U.FSearchParams.ParseFromString(U.FQuery);
+  end;
+
+  Result := U.FSearchParams;
+end;
+
+function TGocciaURLValue.URLHashGetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL hash getter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if U.FHasNullFragment or (U.FFragment = '') then
+    Result := TGocciaStringLiteralValue.Create('')
+  else
+    Result := TGocciaStringLiteralValue.Create('#' + U.FFragment);
+end;
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+// WHATWG URL §7.1 href setter: full re-parse
+function TGocciaURLValue.URLHrefSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  NewHref: string;
+  Parsed: TGocciaURLRecord;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL href setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if AArgs.Length = 0 then Exit;
+  NewHref := AArgs.GetElement(0).ToStringLiteral.Value;
+  Parsed := ParseURL(NewHref);
+  if not Parsed.IsValid then
+    ThrowTypeError('Invalid URL: ' + NewHref);
+  U.FScheme := Parsed.Scheme;
+  U.FUsername := Parsed.Username;
+  U.FPassword := Parsed.Password;
+  U.FHost := Parsed.Host;
+  U.FHasNullHost := Parsed.HasNullHost;
+  U.FPort := Parsed.Port;
+  U.FPathname := SerializePath(Parsed);
+  U.FHasNullQuery := Parsed.HasNullQuery;
+  U.FQuery := Parsed.Query;
+  U.FHasNullFragment := Parsed.HasNullFragment;
+  U.FFragment := Parsed.Fragment;
+  U.FHasOpaquePath := Parsed.HasOpaquePath;
+  U.SyncSearchParamsFromQuery;
+end;
+
+// WHATWG URL §7.1 protocol setter
+function TGocciaURLValue.URLProtocolSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  Input, S: string;
+  I: Integer;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL protocol setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if AArgs.Length = 0 then Exit;
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+  // Strip trailing ':' and anything after
+  S := '';
+  for I := 1 to Length(Input) do
+  begin
+    if Input[I] = ':' then Break;
+    S := S + Input[I];
+  end;
+  // lowercase
+  S := LowerCase(S);
+  // Validate: must be valid scheme chars
+  if S = '' then Exit;
+  if not (S[1] in ['a'..'z']) then Exit;
+  for I := 1 to Length(S) do
+    if not (S[I] in ['a'..'z', '0'..'9', '+', '-', '.']) then Exit;
+  // Cannot change a special scheme to non-special or vice-versa
+  if IsSpecialScheme(U.FScheme) <> IsSpecialScheme(S) then Exit;
+  // Cannot change to/from 'file'
+  if (U.FScheme = 'file') <> (S = 'file') then Exit;
+  U.FScheme := S;
+  // Clear port if it matches new scheme's default
+  if U.FPort = DefaultPortForScheme(U.FScheme) then
+    U.FPort := URL_NULL_PORT;
+end;
+
+// WHATWG URL §7.1 username setter
+function TGocciaURLValue.URLUsernameSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL username setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  // Cannot set credentials on a URL with no host or file: scheme
+  if U.FHasNullHost or (U.FScheme = 'file') then Exit;
+  if AArgs.Length = 0 then Exit;
+  U.FUsername := PercentEncodeForUserinfo(AArgs.GetElement(0).ToStringLiteral.Value);
+end;
+
+// WHATWG URL §7.1 password setter
+function TGocciaURLValue.URLPasswordSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL password setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if U.FHasNullHost or (U.FScheme = 'file') then Exit;
+  if AArgs.Length = 0 then Exit;
+  U.FPassword := PercentEncodeForUserinfo(AArgs.GetElement(0).ToStringLiteral.Value);
+end;
+
+// WHATWG URL §7.1 host setter
+function TGocciaURLValue.URLHostSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  Input: string;
+  Parsed: TGocciaURLRecord;
+  Temp: string;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL host setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if U.FHasOpaquePath then Exit;
+  if AArgs.Length = 0 then Exit;
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+  // Re-parse using a temporary URL prefix to get host + port
+  Temp := U.FScheme + '://' + Input + '/';
+  Parsed := ParseURL(Temp);
+  if Parsed.IsValid and not Parsed.HasNullHost then
+  begin
+    U.FHost := Parsed.Host;
+    U.FHasNullHost := False;
+    U.FPort := Parsed.Port;
+  end;
+end;
+
+// WHATWG URL §7.1 hostname setter
+function TGocciaURLValue.URLHostnameSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  Input: string;
+  Parsed: TGocciaURLRecord;
+  Temp: string;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL hostname setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if U.FHasOpaquePath then Exit;
+  if AArgs.Length = 0 then Exit;
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+  // Parse just the hostname (no port)
+  Temp := U.FScheme + '://' + Input + '/';
+  Parsed := ParseURL(Temp);
+  if Parsed.IsValid and not Parsed.HasNullHost then
+  begin
+    U.FHost := Parsed.Host;
+    U.FHasNullHost := False;
+    // Do not update port for hostname setter
+  end;
+end;
+
+// WHATWG URL §7.1 port setter
+function TGocciaURLValue.URLPortSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  Input: string;
+  PortNum: Integer;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL port setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if U.FHasNullHost or (U.FScheme = 'file') then Exit;
+  if AArgs.Length = 0 then Exit;
+  Input := Trim(AArgs.GetElement(0).ToStringLiteral.Value);
+  if Input = '' then
+  begin
+    U.FPort := URL_NULL_PORT;
+    Exit;
+  end;
+  PortNum := StrToIntDef(Input, -2);
+  if (PortNum < 0) or (PortNum > 65535) then Exit;
+  if PortNum = DefaultPortForScheme(U.FScheme) then
+    U.FPort := URL_NULL_PORT
+  else
+    U.FPort := PortNum;
+end;
+
+// WHATWG URL §7.1 pathname setter
+function TGocciaURLValue.URLPathnameSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  Input: string;
+  Parsed: TGocciaURLRecord;
+  Temp: string;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL pathname setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if U.FHasOpaquePath then Exit;
+  if AArgs.Length = 0 then Exit;
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+  // WHATWG URL §7.1: pathname must begin with '/' for URLs with authority
+  if not U.FHasOpaquePath and not U.FHasNullHost and
+     (Length(Input) > 0) and (Input[1] <> '/') then
+    Input := '/' + Input
+  else if U.FHasNullHost and (Length(Input) > 0) and (Input[1] <> '/') then
+    Input := '/' + Input;
+  // Re-parse path via a temporary URL to apply normalization
+  if U.FHasNullHost then
+    Temp := U.FScheme + ':' + Input
+  else
+    Temp := U.FScheme + '://' + U.FHost + Input;
+  Parsed := ParseURL(Temp);
+  if Parsed.IsValid then
+    U.FPathname := SerializePath(Parsed);
+end;
+
+// WHATWG URL §7.1 search setter
+function TGocciaURLValue.URLSearchSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  Input: string;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL search setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if AArgs.Length = 0 then Exit;
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+  if Input = '' then
+  begin
+    U.FHasNullQuery := True;
+    U.FQuery := '';
+  end
+  else
+  begin
+    // Strip leading '?'
+    if (Length(Input) > 0) and (Input[1] = '?') then
+      Delete(Input, 1, 1);
+    U.FHasNullQuery := False;
+    U.FQuery := PercentEncodeForQuery(Input, IsSpecialScheme(U.FScheme));
+  end;
+  U.SyncSearchParamsFromQuery;
+end;
+
+// WHATWG URL §7.1 hash setter
+function TGocciaURLValue.URLHashSetter(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  U: TGocciaURLValue;
+  Input: string;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL hash setter: not a URL');
+  U := TGocciaURLValue(AThisValue);
+  if AArgs.Length = 0 then Exit;
+  Input := AArgs.GetElement(0).ToStringLiteral.Value;
+  if Input = '' then
+  begin
+    U.FHasNullFragment := True;
+    U.FFragment := '';
+  end
+  else
+  begin
+    if (Length(Input) > 0) and (Input[1] = '#') then
+      Delete(Input, 1, 1);
+    U.FHasNullFragment := False;
+    U.FFragment := PercentEncodeForFragment(Input);
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// Methods
+// ---------------------------------------------------------------------------
+
+// WHATWG URL §7.1 toString() → same as href
+function TGocciaURLValue.URLToString(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL.prototype.toString: not a URL');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLValue(AThisValue).ComputeHref);
+end;
+
+// WHATWG URL §7.1 toJSON() → same as href
+function TGocciaURLValue.URLToJSON(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaURLValue) then
+    ThrowTypeError('URL.prototype.toJSON: not a URL');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaURLValue(AThisValue).ComputeHref);
+end;
+
+// ---------------------------------------------------------------------------
+// Property access, GC, and constructor
+// ---------------------------------------------------------------------------
+
+function TGocciaURLValue.GetProperty(const AName: string): TGocciaValue;
+begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaURLValue.GetPropertyWithContext(const AName: string;
+  const AThisContext: TGocciaValue): TGocciaValue;
+begin
+  Result := inherited GetPropertyWithContext(AName, AThisContext);
+end;
+
+function TGocciaURLValue.ToStringLiteral: TGocciaStringLiteralValue;
+begin
+  Result := TGocciaStringLiteralValue.Create(ComputeHref);
+end;
+
+function TGocciaURLValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_URL;
+end;
+
+procedure TGocciaURLValue.InitializeNativeFromArguments(
+  const AArguments: TGocciaArgumentsCollection);
+var
+  URLStr, BaseStr: string;
+  Parsed, BaseParsed: TGocciaURLRecord;
+begin
+  if AArguments.Length = 0 then
+    ThrowTypeError('URL constructor: 1 argument required');
+
+  URLStr := AArguments.GetElement(0).ToStringLiteral.Value;
+
+  if AArguments.Length >= 2 then
+  begin
+    // Parse with base
+    BaseStr := AArguments.GetElement(1).ToStringLiteral.Value;
+    BaseParsed := ParseURL(BaseStr);
+    if not BaseParsed.IsValid then
+      ThrowTypeError('Invalid base URL: ' + BaseStr);
+    Parsed := ParseURLWithBase(URLStr, BaseParsed);
+  end
+  else
+    Parsed := ParseURL(URLStr);
+
+  if not Parsed.IsValid then
+    ThrowTypeError('Invalid URL: ' + URLStr);
+
+  FScheme := Parsed.Scheme;
+  FUsername := Parsed.Username;
+  FPassword := Parsed.Password;
+  FHost := Parsed.Host;
+  FHasNullHost := Parsed.HasNullHost;
+  FPort := Parsed.Port;
+  FPathname := SerializePath(Parsed);
+  FHasNullQuery := Parsed.HasNullQuery;
+  FQuery := Parsed.Query;
+  FHasNullFragment := Parsed.HasNullFragment;
+  FFragment := Parsed.Fragment;
+  FHasOpaquePath := Parsed.HasOpaquePath;
+  FIsValid := True;
+end;
+
+procedure TGocciaURLValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FSearchParams) then
+    FSearchParams.MarkReferences;
+end;
+
+end.


### PR DESCRIPTION
## Summary
- Adds WHATWG `URL` and `URLSearchParams` built-ins to the runtime.
- Implements URL parsing, serialization, component accessors, and static helpers like `URL.parse` and `URL.canParse`.
- Adds `URLSearchParams` construction, mutation, iteration, and serialization behavior.
- Wires the new globals into engine bootstrap and constructor/property name constants.
- Expands JavaScript coverage with per-method tests for `URL` and `URLSearchParams`.

## Testing
- New test coverage added under `tests/built-ins/URL/` and `tests/built-ins/URLSearchParams/`.