### PR TITLE
Add `Goccia.build` platform metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,7 +430,7 @@ DefaultGlobals = [ggConsole, ggMath, ggGlobalObject, ggGlobalArray,
 
 The TestRunner adds `ggTestAssertions`; the BenchmarkRunner adds `ggBenchmark`. FFI (`ggFFI`) is available but not in `DefaultGlobals`.
 
-After all flag-gated built-ins, two always-present `const` globals are created: `globalThis` (self-referential global object) and `Goccia` (engine metadata with `version`, `commit`, `builtIns`, `strictTypes`, and `semver`).
+After all flag-gated built-ins, two always-present `const` globals are created: `globalThis` (self-referential global object) and `Goccia` (engine metadata with `version`, `commit`, `builtIns`, `strictTypes`, `build`, and `semver`). `Goccia.build` exposes compile-time platform information (`os` and `arch`), mirroring `Deno.build`.
 
 **JSON/JSON5 source text access (ES2024):** `JSON.parse` and `JSON5.parse` revivers receive `(key, value, context)` where `context` is an object with a `source` property for primitive values (the raw JSON/JSON5 text as written). Objects and arrays get an empty context (no `source` property). Source text collection is implemented via `TAbstractJSONParser.OnValueStart` (position tracking hook in `JSONParser.pas`) and `TGocciaJSONVisitor.RecordSourceText` (captures the raw substring). `TGocciaJSONParser.ParseWithSources` returns both the value tree and a flat source text list consumed in depth-first order by `ApplyReviver`. See [docs/built-ins.md](docs/built-ins.md) for details.
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -435,7 +435,17 @@ A `const` global providing engine metadata and Goccia-owned utility APIs:
 | `commit` | `string` | Short git commit hash (e.g., `"a1b2c3d"`) |
 | `builtIns` | `string[]` | Names of the enabled `TGocciaGlobalBuiltin` flags (e.g., `["Console", "Math", "GlobalObject", ...]`), derived via RTTI at runtime |
 | `strictTypes` | `boolean` | `true` in bytecode mode where strict local type enforcement is active (covering both explicit type annotations and types inferred from literal initializers); `false` in interpreted mode |
+| `build` | `object` | Compile-time platform information (see below) |
 | `semver` | `object` | SemVer 2.0.0 API namespace (see below) |
+
+**`Goccia.build`**
+
+`Goccia.build` exposes compile-time platform information, mirroring `Deno.build`:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `os` | `string` | Operating system: `"darwin"`, `"linux"`, `"windows"`, `"freebsd"`, `"netbsd"`, `"openbsd"`, `"android"`, `"aix"`, `"solaris"`, or `"unknown"` |
+| `arch` | `string` | Processor architecture: `"x86_64"`, `"aarch64"`, `"x86"`, `"arm"`, `"powerpc64"`, `"powerpc"`, or `"unknown"` |
 
 **`Goccia.semver`**
 

--- a/tests/built-ins/Goccia/build.js
+++ b/tests/built-ins/Goccia/build.js
@@ -1,0 +1,81 @@
+/*---
+description: Goccia.build exposes compile-time platform information (os and arch)
+features: [Goccia]
+---*/
+
+const hasGoccia = typeof Goccia !== "undefined";
+
+const KNOWN_OS_VALUES = [
+  "darwin",
+  "linux",
+  "windows",
+  "freebsd",
+  "netbsd",
+  "openbsd",
+  "android",
+  "aix",
+  "solaris",
+];
+
+const KNOWN_ARCH_VALUES = [
+  "x86_64",
+  "aarch64",
+  "x86",
+  "arm",
+  "powerpc64",
+  "powerpc",
+];
+
+describe.runIf(hasGoccia)("Goccia.build", () => {
+  test("build is an object", () => {
+    expect(typeof Goccia.build).toBe("object");
+    expect(Goccia.build !== null).toBe(true);
+  });
+
+  test("build.os is a non-empty string", () => {
+    expect(typeof Goccia.build.os).toBe("string");
+    expect(Goccia.build.os.length > 0).toBe(true);
+  });
+
+  test("build.os is a known value", () => {
+    const os = Goccia.build.os;
+    expect(KNOWN_OS_VALUES.includes(os) || os === "unknown").toBe(true);
+  });
+
+  test("build.arch is a non-empty string", () => {
+    expect(typeof Goccia.build.arch).toBe("string");
+    expect(Goccia.build.arch.length > 0).toBe(true);
+  });
+
+  test("build.arch is a known value", () => {
+    const arch = Goccia.build.arch;
+    expect(KNOWN_ARCH_VALUES.includes(arch) || arch === "unknown").toBe(true);
+  });
+
+  test("build properties are stable across accesses", () => {
+    expect(Goccia.build.os).toBe(Goccia.build.os);
+    expect(Goccia.build.arch).toBe(Goccia.build.arch);
+  });
+
+  test("build.os is read-only", () => {
+    const original = Goccia.build.os;
+    expect(() => { Goccia.build.os = "other"; }).toThrow(TypeError);
+    expect(Goccia.build.os).toBe(original);
+  });
+
+  test("build.arch is read-only", () => {
+    const original = Goccia.build.arch;
+    expect(() => { Goccia.build.arch = "other"; }).toThrow(TypeError);
+    expect(Goccia.build.arch).toBe(original);
+  });
+
+  test("build.os is enumerable", () => {
+    const keys = Object.keys(Goccia.build);
+    expect(keys.includes("os")).toBe(true);
+  });
+
+  test("build.arch is enumerable", () => {
+    const keys = Object.keys(Goccia.build);
+    expect(keys.includes("arch")).toBe(true);
+  });
+});

--- a/units/Goccia.Engine.pas
+++ b/units/Goccia.Engine.pas
@@ -233,6 +233,7 @@ uses
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.MicrotaskQueue,
+  Goccia.Platform,
   Goccia.Scope,
   Goccia.Scope.Redeclaration,
   Goccia.Token,
@@ -666,6 +667,7 @@ const
   PREFIX_LENGTH = 2; // Strip 'gg' prefix from enum names
 var
   GocciaObj: TGocciaObjectValue;
+  BuildObj: TGocciaObjectValue;
   BuiltInsArray: TGocciaArrayValue;
   Flag: TGocciaGlobalBuiltin;
   Name: string;
@@ -677,12 +679,19 @@ begin
     BuiltInsArray.Elements.Add(TGocciaStringLiteralValue.Create(Copy(Name, PREFIX_LENGTH + 1, Length(Name) - PREFIX_LENGTH)));
   end;
 
+  BuildObj := TGocciaObjectValue.Create;
+  BuildObj.DefineProperty('os', TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(GetBuildOS), [pfEnumerable]));
+  BuildObj.DefineProperty('arch', TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(GetBuildArch), [pfEnumerable]));
+
   GocciaObj := TGocciaObjectValue.Create;
   GocciaObj.AssignProperty('version', TGocciaStringLiteralValue.Create(GetVersion));
   GocciaObj.AssignProperty('commit', TGocciaStringLiteralValue.Create(GetCommit));
   GocciaObj.AssignProperty('builtIns', BuiltInsArray);
   GocciaObj.AssignProperty(PROP_STRICT_TYPES, TGocciaBooleanLiteralValue.FalseValue);
   GocciaObj.AssignProperty(SEMVER_NAMESPACE_PROPERTY, CreateSemverNamespace);
+  GocciaObj.AssignProperty('build', BuildObj);
 
   FInterpreter.GlobalScope.DefineLexicalBinding('Goccia', GocciaObj, dtConst);
 end;

--- a/units/Goccia.Platform.pas
+++ b/units/Goccia.Platform.pas
@@ -1,0 +1,61 @@
+unit Goccia.Platform;
+
+{$I Goccia.inc}
+
+interface
+
+function GetBuildOS: string;
+function GetBuildArch: string;
+
+implementation
+
+const
+  {$IF DEFINED(DARWIN)}
+  BUILD_OS = 'darwin';
+  {$ELSEIF DEFINED(ANDROID)}
+  BUILD_OS = 'android';
+  {$ELSEIF DEFINED(LINUX)}
+  BUILD_OS = 'linux';
+  {$ELSEIF DEFINED(MSWINDOWS)}
+  BUILD_OS = 'windows';
+  {$ELSEIF DEFINED(FREEBSD)}
+  BUILD_OS = 'freebsd';
+  {$ELSEIF DEFINED(NETBSD)}
+  BUILD_OS = 'netbsd';
+  {$ELSEIF DEFINED(OPENBSD)}
+  BUILD_OS = 'openbsd';
+  {$ELSEIF DEFINED(AIX)}
+  BUILD_OS = 'aix';
+  {$ELSEIF DEFINED(SOLARIS)}
+  BUILD_OS = 'solaris';
+  {$ELSE}
+  BUILD_OS = 'unknown';
+  {$ENDIF}
+
+  {$IF DEFINED(CPUX86_64)}
+  BUILD_ARCH = 'x86_64';
+  {$ELSEIF DEFINED(CPUAARCH64)}
+  BUILD_ARCH = 'aarch64';
+  {$ELSEIF DEFINED(CPUI386)}
+  BUILD_ARCH = 'x86';
+  {$ELSEIF DEFINED(CPUARM)}
+  BUILD_ARCH = 'arm';
+  {$ELSEIF DEFINED(CPUPOWERPC64)}
+  BUILD_ARCH = 'powerpc64';
+  {$ELSEIF DEFINED(CPUPOWERPC)}
+  BUILD_ARCH = 'powerpc';
+  {$ELSE}
+  BUILD_ARCH = 'unknown';
+  {$ENDIF}
+
+function GetBuildOS: string;
+begin
+  Result := BUILD_OS;
+end;
+
+function GetBuildArch: string;
+begin
+  Result := BUILD_ARCH;
+end;
+
+end.

--- a/units/Goccia.Runtime.Bootstrap.pas
+++ b/units/Goccia.Runtime.Bootstrap.pas
@@ -99,6 +99,7 @@ uses
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.GarbageCollector,
+  Goccia.Platform,
   Goccia.Scope,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
@@ -108,6 +109,7 @@ uses
   Goccia.Values.MapValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.NumberObjectValue,
+  Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
   Goccia.Values.SetValue,
   Goccia.Values.SharedArrayBufferValue,
@@ -477,6 +479,7 @@ const
   PREFIX_LENGTH = 2;
 var
   GocciaObj: TGocciaObjectValue;
+  BuildObj: TGocciaObjectValue;
   BuiltInsArray: TGocciaArrayValue;
   Flag: TGocciaGlobalBuiltin;
   Name: string;
@@ -489,12 +492,19 @@ begin
       Copy(Name, PREFIX_LENGTH + 1, Length(Name) - PREFIX_LENGTH)));
   end;
 
+  BuildObj := TGocciaObjectValue.Create;
+  BuildObj.DefineProperty('os', TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(GetBuildOS), [pfEnumerable]));
+  BuildObj.DefineProperty('arch', TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(GetBuildArch), [pfEnumerable]));
+
   GocciaObj := TGocciaObjectValue.Create;
   GocciaObj.AssignProperty('version', TGocciaStringLiteralValue.Create(GetVersion));
   GocciaObj.AssignProperty('commit', TGocciaStringLiteralValue.Create(GetCommit));
   GocciaObj.AssignProperty('builtIns', BuiltInsArray);
   GocciaObj.AssignProperty(PROP_STRICT_TYPES, TGocciaBooleanLiteralValue.FalseValue);
   GocciaObj.AssignProperty(SEMVER_NAMESPACE_PROPERTY, CreateSemverNamespace);
+  GocciaObj.AssignProperty('build', BuildObj);
 
   FInterpreter.GlobalScope.DefineLexicalBinding('Goccia', GocciaObj, dtConst);
 end;


### PR DESCRIPTION
## Summary
- Add a new `Goccia.build` object with compile-time `os` and `arch` metadata.
- Wire the build metadata into the engine/runtime bootstrap so it is always available on the `Goccia` global.
- Document the new API in `docs/built-ins.md` and add end-to-end coverage in `tests/built-ins/Goccia/build.js`.

## Testing
- Added a dedicated JS test file covering `Goccia.build` shape, value stability, enumerability, and read-only behavior.
- Documentation updated to describe the new `Goccia.build` contract and supported platform values.