### PR TITLE
Add encodeURI / decodeURI / encodeURIComponent / decodeURIComponent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | Proxy | `Goccia.Values.ProxyValue.pas` | ES2026 Proxy with all 13 handler traps and invariant enforcement |
 | Uint8Array encoding | `Goccia.Values.Uint8ArrayEncoding.pas` | Uint8Array Base64/Hex: `toBase64`, `fromBase64`, `toHex`, `fromHex`, `setFromBase64`, `setFromHex` |
 | FFI | `Goccia.FFI*.pas`, `Goccia.Values.FFI*.pas` | Foreign Function Interface for native shared libraries |
+| URI encoding | `Goccia.URI.pas` | Shared `encodeURI`/`decodeURI`/`encodeURIComponent`/`decodeURIComponent` and `PercentEncodePath` |
 | import.meta | `Goccia.ImportMeta.pas` | Per-module metadata object with `url` and `resolve()` (ES2026 §13.3.12) |
 
 **Bytecode design rules:**

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -482,6 +482,10 @@ The constructor-backed objects mirror the `node-semver` public fields and core i
 | `structuredClone(value)` | Deep-clone a value using the structured clone algorithm. Handles objects, arrays, `Map`, `Set`, and circular references. Throws `DOMException` with name `"DataCloneError"` (code 25) for non-cloneable types (functions, symbols). |
 | `btoa(data)` | Encode a binary string (each character code ≤ U+00FF) to base64. Throws `DOMException` with name `"InvalidCharacterError"` (code 5) if any character code exceeds U+00FF. |
 | `atob(data)` | Decode a base64 string to a binary string. Uses WHATWG forgiving-base64-decode: strips ASCII whitespace, tolerates missing `=` padding. Throws `DOMException` with name `"InvalidCharacterError"` (code 5) for invalid base64 input. |
+| `encodeURI(uriString)` | Encode a complete URI, preserving reserved characters (`;/?:@&=+$,#`) and unreserved characters. Multi-byte characters are UTF-8 encoded. Throws `URIError` for lone surrogates. |
+| `decodeURI(encodedURI)` | Decode a percent-encoded URI. Does **not** decode reserved characters (`%3B`, `%2F`, etc.). Throws `URIError` for malformed percent sequences or invalid UTF-8. |
+| `encodeURIComponent(uriComponent)` | Encode a URI component. Only unreserved characters (`A-Z a-z 0-9 - _ . ! ~ * ' ( )`) are preserved. Throws `URIError` for lone surrogates. |
+| `decodeURIComponent(encodedURIComponent)` | Decode a percent-encoded URI component. Decodes all percent sequences including reserved characters. Throws `URIError` for malformed percent sequences or invalid UTF-8. |
 
 `queueMicrotask` shares the same microtask queue used by Promise reactions. Callbacks run after the current synchronous code completes but before the engine returns control. If a callback throws, the error is silently discarded and remaining microtasks still execute.
 
@@ -490,6 +494,8 @@ The constructor-backed objects mirror the `node-semver` public fields and core i
 `btoa` encodes a string to base64 following the WHATWG HTML spec §8.3. Each character in the input must have a code point ≤ U+00FF (Latin-1 range); characters outside this range throw a `DOMException` with name `"InvalidCharacterError"` and legacy code 5. The input is interpreted as a byte sequence where each code point maps 1:1 to a byte value.
 
 `atob` decodes a base64 string following the WHATWG forgiving-base64-decode algorithm. ASCII whitespace (U+0009, U+000A, U+000C, U+000D, U+0020) is stripped before decoding. Missing `=` padding is tolerated. Invalid characters or an invalid length (length mod 4 = 1 after cleanup) throw a `DOMException` with name `"InvalidCharacterError"` and legacy code 5. The decoded bytes are returned as a string where each byte becomes a character (Latin-1 interpretation).
+
+`encodeURI` / `decodeURI` / `encodeURIComponent` / `decodeURIComponent` implement ES2026 §19.2.6. The shared encoding/decoding logic lives in `Goccia.URI.pas` and is also used by `import.meta.url` for file-path percent-encoding. Multi-byte Unicode characters are encoded as UTF-8 octets, each percent-encoded individually (e.g., `encodeURIComponent("中")` → `%E4%B8%AD`). Lone surrogates (U+D800–U+DFFF) throw `URIError`. Decoding validates UTF-8 well-formedness: overlong encodings, truncated sequences, and code points above U+10FFFF all throw `URIError`. `decodeURI` re-emits reserved characters as uppercase percent-encoded sequences even when the input uses lowercase hex digits (e.g., `%2f` → `%2F`).
 
 **Error constructors:** `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `DOMException`
 

--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -512,8 +512,6 @@ Labels exist primarily for `break`/`continue` targets in nested loops. Since Goc
 The following standard ECMAScript built-ins are **not yet implemented** and may be added in future versions:
 
 - **WeakMap / WeakSet / WeakRef / FinalizationRegistry** — Weak reference collections and finalizers. These require tight GC integration. Deferred until demand warrants the complexity.
-- **URI functions** (`encodeURI`, `decodeURI`, `encodeURIComponent`, `decodeURIComponent`) — URL encoding/decoding.
-- **atob / btoa** — Base64 encoding/decoding.
 
 ## Types as Comments
 

--- a/tests/built-ins/decodeURI.js
+++ b/tests/built-ins/decodeURI.js
@@ -42,11 +42,13 @@ describe("decodeURI", () => {
     expect(decodeURI("%23")).toBe("%23"); // #
   });
 
-  test("normalizes lowercase reserved hex to uppercase", () => {
-    // When a reserved char is percent-encoded, decodeURI re-emits it with uppercase hex
-    expect(decodeURI("%3b")).toBe("%3B"); // ;
-    expect(decodeURI("%2f")).toBe("%2F"); // /
-    expect(decodeURI("%3f")).toBe("%3F"); // ?
+  test("preserves original hex case for reserved characters", () => {
+    // ES2026 §19.2.6.2: reserved escapes are preserved verbatim, not normalized
+    expect(decodeURI("%3b")).toBe("%3b"); // ;
+    expect(decodeURI("%2f")).toBe("%2f"); // /
+    expect(decodeURI("%3f")).toBe("%3f"); // ?
+    expect(decodeURI("%3B")).toBe("%3B"); // ; (uppercase stays uppercase)
+    expect(decodeURI("%2F")).toBe("%2F"); // / (uppercase stays uppercase)
   });
 
   test("decodes multi-byte UTF-8 sequences", () => {

--- a/tests/built-ins/decodeURI.js
+++ b/tests/built-ins/decodeURI.js
@@ -1,0 +1,118 @@
+describe("decodeURI", () => {
+  test("typeof decodeURI is function", () => {
+    expect(typeof decodeURI).toBe("function");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(decodeURI("")).toBe("");
+  });
+
+  test("passes through unencoded characters unchanged", () => {
+    expect(decodeURI("hello")).toBe("hello");
+    expect(decodeURI("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")).toBe(
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    );
+  });
+
+  test("decodes non-reserved percent-encoded characters", () => {
+    expect(decodeURI("%20")).toBe(" ");
+    expect(decodeURI("%3C")).toBe("<");
+    expect(decodeURI("%3E")).toBe(">");
+    expect(decodeURI("%22")).toBe('"');
+    expect(decodeURI("%7B")).toBe("{");
+    expect(decodeURI("%7D")).toBe("}");
+    expect(decodeURI("%7C")).toBe("|");
+    expect(decodeURI("%5C")).toBe("\\");
+    expect(decodeURI("%5E")).toBe("^");
+    expect(decodeURI("%60")).toBe("`");
+    expect(decodeURI("%25")).toBe("%");
+  });
+
+  test("does NOT decode reserved URI characters (;/?:@&=+$,#)", () => {
+    expect(decodeURI("%3B")).toBe("%3B"); // ;
+    expect(decodeURI("%2F")).toBe("%2F"); // /
+    expect(decodeURI("%3F")).toBe("%3F"); // ?
+    expect(decodeURI("%3A")).toBe("%3A"); // :
+    expect(decodeURI("%40")).toBe("%40"); // @
+    expect(decodeURI("%26")).toBe("%26"); // &
+    expect(decodeURI("%3D")).toBe("%3D"); // =
+    expect(decodeURI("%2B")).toBe("%2B"); // +
+    expect(decodeURI("%24")).toBe("%24"); // $
+    expect(decodeURI("%2C")).toBe("%2C"); // ,
+    expect(decodeURI("%23")).toBe("%23"); // #
+  });
+
+  test("normalizes lowercase reserved hex to uppercase", () => {
+    // When a reserved char is percent-encoded, decodeURI re-emits it with uppercase hex
+    expect(decodeURI("%3b")).toBe("%3B"); // ;
+    expect(decodeURI("%2f")).toBe("%2F"); // /
+    expect(decodeURI("%3f")).toBe("%3F"); // ?
+  });
+
+  test("decodes multi-byte UTF-8 sequences", () => {
+    // 2-byte: U+00E9 (é) → %C3%A9
+    expect(decodeURI("%C3%A9")).toBe("\u00E9");
+    // 3-byte: U+4E2D (中) → %E4%B8%AD
+    expect(decodeURI("%E4%B8%AD")).toBe("\u4E2D");
+  });
+
+  test("preserves complete URIs while decoding unreserved characters", () => {
+    expect(decodeURI("https://example.com/hello%20world?q=1&b=2#frag")).toBe(
+      "https://example.com/hello world?q=1&b=2#frag"
+    );
+  });
+
+  test("throws URIError for incomplete percent sequence", () => {
+    expect(() => decodeURI("%")).toThrow(URIError);
+    expect(() => decodeURI("%2")).toThrow(URIError);
+    expect(() => decodeURI("abc%")).toThrow(URIError);
+  });
+
+  test("throws URIError for invalid hex digits", () => {
+    expect(() => decodeURI("%GG")).toThrow(URIError);
+    expect(() => decodeURI("%ZZ")).toThrow(URIError);
+  });
+
+  test("throws URIError for invalid UTF-8 sequences", () => {
+    // Invalid continuation byte
+    expect(() => decodeURI("%C3%00")).toThrow(URIError);
+    // Truncated multi-byte sequence
+    expect(() => decodeURI("%E4%B8")).toThrow(URIError);
+    // Invalid lead byte (bare continuation byte)
+    expect(() => decodeURI("%80")).toThrow(URIError);
+  });
+
+  test("throws URIError for overlong UTF-8 encodings", () => {
+    // Overlong 2-byte encoding of U+0000
+    expect(() => decodeURI("%C0%80")).toThrow(URIError);
+  });
+
+  test("coerces non-string arguments to string", () => {
+    expect(decodeURI(123)).toBe("123");
+    expect(decodeURI(true)).toBe("true");
+    expect(decodeURI(null)).toBe("null");
+  });
+
+  test("decodes undefined when called with no arguments", () => {
+    expect(decodeURI()).toBe("undefined");
+  });
+
+  test("round-trips with encodeURI", () => {
+    const inputs = [
+      "https://example.com/path?query=value&other=123#fragment",
+      "https://example.com/hello world",
+      "https://example.com/\u00E9",
+      "https://example.com/\u4E2D\u6587",
+    ];
+    inputs.forEach((input) => {
+      expect(decodeURI(encodeURI(input))).toBe(input);
+    });
+  });
+
+  test("difference from decodeURIComponent: preserves reserved character encoding", () => {
+    // decodeURI does NOT decode %2F (/)
+    expect(decodeURI("%2F")).toBe("%2F");
+    // decodeURIComponent DOES decode %2F (/)
+    expect(decodeURIComponent("%2F")).toBe("/");
+  });
+});

--- a/tests/built-ins/decodeURIComponent.js
+++ b/tests/built-ins/decodeURIComponent.js
@@ -1,0 +1,102 @@
+describe("decodeURIComponent", () => {
+  test("typeof decodeURIComponent is function", () => {
+    expect(typeof decodeURIComponent).toBe("function");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(decodeURIComponent("")).toBe("");
+  });
+
+  test("passes through unencoded characters unchanged", () => {
+    expect(decodeURIComponent("hello")).toBe("hello");
+    expect(decodeURIComponent("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")).toBe(
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    );
+  });
+
+  test("decodes percent-encoded ASCII characters", () => {
+    expect(decodeURIComponent("%20")).toBe(" ");
+    expect(decodeURIComponent("%3B")).toBe(";");
+    expect(decodeURIComponent("%2F")).toBe("/");
+    expect(decodeURIComponent("%3F")).toBe("?");
+    expect(decodeURIComponent("%3A")).toBe(":");
+    expect(decodeURIComponent("%40")).toBe("@");
+    expect(decodeURIComponent("%26")).toBe("&");
+    expect(decodeURIComponent("%3D")).toBe("=");
+    expect(decodeURIComponent("%2B")).toBe("+");
+    expect(decodeURIComponent("%24")).toBe("$");
+    expect(decodeURIComponent("%2C")).toBe(",");
+    expect(decodeURIComponent("%23")).toBe("#");
+    expect(decodeURIComponent("%25")).toBe("%");
+  });
+
+  test("decodes lowercase hex digits", () => {
+    expect(decodeURIComponent("%2f")).toBe("/");
+    expect(decodeURIComponent("%3a")).toBe(":");
+    expect(decodeURIComponent("%2b")).toBe("+");
+  });
+
+  test("decodes multi-byte UTF-8 sequences", () => {
+    // 2-byte: U+00E9 (é) → %C3%A9
+    expect(decodeURIComponent("%C3%A9")).toBe("\u00E9");
+    // 3-byte: U+4E2D (中) → %E4%B8%AD
+    expect(decodeURIComponent("%E4%B8%AD")).toBe("\u4E2D");
+  });
+
+  test("decodes mixed encoded and plain text", () => {
+    expect(decodeURIComponent("hello%20world")).toBe("hello world");
+    expect(decodeURIComponent("key%3Dvalue%26foo%3Dbar")).toBe("key=value&foo=bar");
+    expect(decodeURIComponent("path%2Fto%2Ffile")).toBe("path/to/file");
+  });
+
+  test("throws URIError for incomplete percent sequence", () => {
+    expect(() => decodeURIComponent("%")).toThrow(URIError);
+    expect(() => decodeURIComponent("%2")).toThrow(URIError);
+    expect(() => decodeURIComponent("abc%")).toThrow(URIError);
+    expect(() => decodeURIComponent("abc%2")).toThrow(URIError);
+  });
+
+  test("throws URIError for invalid hex digits", () => {
+    expect(() => decodeURIComponent("%GG")).toThrow(URIError);
+    expect(() => decodeURIComponent("%ZZ")).toThrow(URIError);
+    expect(() => decodeURIComponent("%0G")).toThrow(URIError);
+  });
+
+  test("throws URIError for invalid UTF-8 sequences", () => {
+    // Invalid continuation byte
+    expect(() => decodeURIComponent("%C3%00")).toThrow(URIError);
+    // Truncated multi-byte sequence: 3-byte lead with only 1 continuation
+    expect(() => decodeURIComponent("%E4%B8")).toThrow(URIError);
+    // Invalid lead byte (bare continuation byte)
+    expect(() => decodeURIComponent("%80")).toThrow(URIError);
+  });
+
+  test("throws URIError for overlong UTF-8 encodings", () => {
+    // Overlong 2-byte encoding of U+0000 (should be 1 byte)
+    expect(() => decodeURIComponent("%C0%80")).toThrow(URIError);
+  });
+
+  test("coerces non-string arguments to string", () => {
+    expect(decodeURIComponent(123)).toBe("123");
+    expect(decodeURIComponent(true)).toBe("true");
+    expect(decodeURIComponent(null)).toBe("null");
+  });
+
+  test("decodes undefined when called with no arguments", () => {
+    expect(decodeURIComponent()).toBe("undefined");
+  });
+
+  test("round-trips with encodeURIComponent", () => {
+    const inputs = [
+      "hello world",
+      "key=value&foo=bar",
+      "path/to/file?q=search#hash",
+      "\u00E9",
+      "\u4E2D\u6587",
+      "-_.!~*'()",
+    ];
+    inputs.forEach((input) => {
+      expect(decodeURIComponent(encodeURIComponent(input))).toBe(input);
+    });
+  });
+});

--- a/tests/built-ins/encodeURI.js
+++ b/tests/built-ins/encodeURI.js
@@ -1,0 +1,114 @@
+describe("encodeURI", () => {
+  test("typeof encodeURI is function", () => {
+    expect(typeof encodeURI).toBe("function");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(encodeURI("")).toBe("");
+  });
+
+  test("does not encode unreserved characters (A-Z a-z 0-9)", () => {
+    expect(encodeURI("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")).toBe(
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    );
+  });
+
+  test("does not encode URI mark characters (- _ . ! ~ * ' ( ))", () => {
+    expect(encodeURI("-_.!~*'()")).toBe("-_.!~*'()");
+  });
+
+  test("does not encode reserved URI characters (;/?:@&=+$,#)", () => {
+    expect(encodeURI(";")).toBe(";");
+    expect(encodeURI("/")).toBe("/");
+    expect(encodeURI("?")).toBe("?");
+    expect(encodeURI(":")).toBe(":");
+    expect(encodeURI("@")).toBe("@");
+    expect(encodeURI("&")).toBe("&");
+    expect(encodeURI("=")).toBe("=");
+    expect(encodeURI("+")).toBe("+");
+    expect(encodeURI("$")).toBe("$");
+    expect(encodeURI(",")).toBe(",");
+    expect(encodeURI("#")).toBe("#");
+  });
+
+  test("encodes spaces and non-reserved characters", () => {
+    expect(encodeURI(" ")).toBe("%20");
+    expect(encodeURI("<")).toBe("%3C");
+    expect(encodeURI(">")).toBe("%3E");
+    expect(encodeURI('"')).toBe("%22");
+    expect(encodeURI("{")).toBe("%7B");
+    expect(encodeURI("}")).toBe("%7D");
+    expect(encodeURI("|")).toBe("%7C");
+    expect(encodeURI("\\")).toBe("%5C");
+    expect(encodeURI("^")).toBe("%5E");
+    expect(encodeURI("`")).toBe("%60");
+  });
+
+  test("preserves complete URIs", () => {
+    expect(encodeURI("https://example.com/path?query=value&other=123#fragment")).toBe(
+      "https://example.com/path?query=value&other=123#fragment"
+    );
+    expect(encodeURI("http://user:pass@host.com:8080/p/a/t/h?q=1")).toBe(
+      "http://user:pass@host.com:8080/p/a/t/h?q=1"
+    );
+  });
+
+  test("encodes spaces in URIs", () => {
+    expect(encodeURI("https://example.com/hello world")).toBe(
+      "https://example.com/hello%20world"
+    );
+  });
+
+  test("encodes multi-byte UTF-8 characters in URIs", () => {
+    // 2-byte UTF-8: U+00E9 (é) → %C3%A9
+    expect(encodeURI("\u00E9")).toBe("%C3%A9");
+    // 3-byte UTF-8: U+4E2D (中) → %E4%B8%AD
+    expect(encodeURI("\u4E2D")).toBe("%E4%B8%AD");
+    // Real-world example: Japanese characters in a URL
+    expect(encodeURI("https://example.com/\u4E2D\u6587")).toBe(
+      "https://example.com/%E4%B8%AD%E6%96%87"
+    );
+  });
+
+  test("encodes percent sign itself", () => {
+    expect(encodeURI("%")).toBe("%25");
+  });
+
+  test("coerces non-string arguments to string", () => {
+    expect(encodeURI(123)).toBe("123");
+    expect(encodeURI(true)).toBe("true");
+    expect(encodeURI(null)).toBe("null");
+  });
+
+  test("encodes undefined when called with no arguments", () => {
+    expect(encodeURI()).toBe("undefined");
+  });
+
+  test("round-trips with decodeURI", () => {
+    const inputs = [
+      "https://example.com/path?query=value&other=123#fragment",
+      "https://example.com/hello world",
+      "https://example.com/\u00E9",
+      "https://example.com/\u4E2D\u6587",
+    ];
+    inputs.forEach((input) => {
+      expect(decodeURI(encodeURI(input))).toBe(input);
+    });
+  });
+
+  test("difference from encodeURIComponent: preserves reserved characters", () => {
+    const uri = "https://example.com/path?q=hello world#frag";
+    const encoded = encodeURI(uri);
+    // encodeURI preserves :, /, ?, #, etc.
+    expect(encoded).toContain("://");
+    expect(encoded).toContain("?");
+    expect(encoded).toContain("#");
+    expect(encoded).toContain("%20");
+    // encodeURIComponent would encode all of those
+    const component = encodeURIComponent(uri);
+    expect(component).toContain("%3A");
+    expect(component).toContain("%2F");
+    expect(component).toContain("%3F");
+    expect(component).toContain("%23");
+  });
+});

--- a/tests/built-ins/encodeURI.js
+++ b/tests/built-ins/encodeURI.js
@@ -84,6 +84,13 @@ describe("encodeURI", () => {
     expect(encodeURI()).toBe("undefined");
   });
 
+  test("throws URIError for lone surrogate input", () => {
+    expect(() => encodeURI("\uD800")).toThrow(URIError);
+    expect(() => encodeURI("\uDFFF")).toThrow(URIError);
+    expect(() => encodeURI("abc\uD800")).toThrow(URIError);
+    expect(() => encodeURI("\uDC00xyz")).toThrow(URIError);
+  });
+
   test("round-trips with decodeURI", () => {
     const inputs = [
       "https://example.com/path?query=value&other=123#fragment",

--- a/tests/built-ins/encodeURIComponent.js
+++ b/tests/built-ins/encodeURIComponent.js
@@ -73,6 +73,13 @@ describe("encodeURIComponent", () => {
     expect(encodeURIComponent()).toBe("undefined");
   });
 
+  test("throws URIError for lone surrogate input", () => {
+    expect(() => encodeURIComponent("\uD800")).toThrow(URIError);
+    expect(() => encodeURIComponent("\uDFFF")).toThrow(URIError);
+    expect(() => encodeURIComponent("abc\uD800")).toThrow(URIError);
+    expect(() => encodeURIComponent("\uDC00xyz")).toThrow(URIError);
+  });
+
   test("round-trips with decodeURIComponent", () => {
     const inputs = [
       "hello world",

--- a/tests/built-ins/encodeURIComponent.js
+++ b/tests/built-ins/encodeURIComponent.js
@@ -1,0 +1,88 @@
+describe("encodeURIComponent", () => {
+  test("typeof encodeURIComponent is function", () => {
+    expect(typeof encodeURIComponent).toBe("function");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(encodeURIComponent("")).toBe("");
+  });
+
+  test("does not encode unreserved characters (A-Z a-z 0-9 - _ . ! ~ * ' ( ))", () => {
+    expect(encodeURIComponent("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")).toBe(
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    );
+    expect(encodeURIComponent("-_.!~*'()")).toBe("-_.!~*'()");
+  });
+
+  test("encodes reserved URI characters", () => {
+    expect(encodeURIComponent(";")).toBe("%3B");
+    expect(encodeURIComponent("/")).toBe("%2F");
+    expect(encodeURIComponent("?")).toBe("%3F");
+    expect(encodeURIComponent(":")).toBe("%3A");
+    expect(encodeURIComponent("@")).toBe("%40");
+    expect(encodeURIComponent("&")).toBe("%26");
+    expect(encodeURIComponent("=")).toBe("%3D");
+    expect(encodeURIComponent("+")).toBe("%2B");
+    expect(encodeURIComponent("$")).toBe("%24");
+    expect(encodeURIComponent(",")).toBe("%2C");
+    expect(encodeURIComponent("#")).toBe("%23");
+  });
+
+  test("encodes spaces", () => {
+    expect(encodeURIComponent(" ")).toBe("%20");
+    expect(encodeURIComponent("hello world")).toBe("hello%20world");
+  });
+
+  test("encodes special characters", () => {
+    expect(encodeURIComponent("<")).toBe("%3C");
+    expect(encodeURIComponent(">")).toBe("%3E");
+    expect(encodeURIComponent('"')).toBe("%22");
+    expect(encodeURIComponent("{")).toBe("%7B");
+    expect(encodeURIComponent("}")).toBe("%7D");
+    expect(encodeURIComponent("|")).toBe("%7C");
+    expect(encodeURIComponent("\\")).toBe("%5C");
+    expect(encodeURIComponent("^")).toBe("%5E");
+    expect(encodeURIComponent("`")).toBe("%60");
+  });
+
+  test("encodes multi-byte UTF-8 characters", () => {
+    // 2-byte UTF-8: U+00E9 (é) → %C3%A9
+    expect(encodeURIComponent("\u00E9")).toBe("%C3%A9");
+    // 3-byte UTF-8: U+4E2D (中) → %E4%B8%AD
+    expect(encodeURIComponent("\u4E2D")).toBe("%E4%B8%AD");
+  });
+
+  test("encodes percent sign itself", () => {
+    expect(encodeURIComponent("%")).toBe("%25");
+  });
+
+  test("encodes practical URI component values", () => {
+    expect(encodeURIComponent("key=value&foo=bar")).toBe("key%3Dvalue%26foo%3Dbar");
+    expect(encodeURIComponent("hello world!")).toBe("hello%20world!");
+    expect(encodeURIComponent("path/to/file")).toBe("path%2Fto%2Ffile");
+  });
+
+  test("coerces non-string arguments to string", () => {
+    expect(encodeURIComponent(123)).toBe("123");
+    expect(encodeURIComponent(true)).toBe("true");
+    expect(encodeURIComponent(null)).toBe("null");
+    expect(encodeURIComponent(undefined)).toBe("undefined");
+  });
+
+  test("encodes undefined when called with no arguments", () => {
+    expect(encodeURIComponent()).toBe("undefined");
+  });
+
+  test("round-trips with decodeURIComponent", () => {
+    const inputs = [
+      "hello world",
+      "key=value&foo=bar",
+      "path/to/file?q=search#hash",
+      "\u00E9",
+      "\u4E2D\u6587",
+    ];
+    inputs.forEach((input) => {
+      expect(decodeURIComponent(encodeURIComponent(input))).toBe(input);
+    });
+  });
+});

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -51,6 +51,10 @@ type
     function StructuredCloneCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function BtoaCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function AtobCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function EncodeURICallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DecodeURICallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function EncodeURIComponentCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DecodeURIComponentCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
   end;
@@ -68,6 +72,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
+  Goccia.URI,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -185,6 +190,18 @@ begin
 
   AScope.DefineLexicalBinding('atob',
     TGocciaNativeFunctionValue.Create(AtobCallback, 'atob', 1), dtConst);
+
+  AScope.DefineLexicalBinding('encodeURI',
+    TGocciaNativeFunctionValue.Create(EncodeURICallback, 'encodeURI', 1), dtConst);
+
+  AScope.DefineLexicalBinding('decodeURI',
+    TGocciaNativeFunctionValue.Create(DecodeURICallback, 'decodeURI', 1), dtConst);
+
+  AScope.DefineLexicalBinding('encodeURIComponent',
+    TGocciaNativeFunctionValue.Create(EncodeURIComponentCallback, 'encodeURIComponent', 1), dtConst);
+
+  AScope.DefineLexicalBinding('decodeURIComponent',
+    TGocciaNativeFunctionValue.Create(DecodeURIComponentCallback, 'decodeURIComponent', 1), dtConst);
 end;
 
 { NativeError ( message [ , options ] ) — §20.5.6.1.1 (shared by all NativeError constructors)
@@ -801,6 +818,74 @@ begin
   SetLength(ResultStr, ResultLen);
 
   Result := TGocciaStringLiteralValue.Create(ResultStr);
+end;
+
+// ES2026 §19.2.6.2 encodeURI(uriString)
+function TGocciaGlobals.EncodeURICallback(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  URIString: string;
+begin
+  // Step 1: Let uriString be ? ToString(uriString)
+  if AArgs.Length = 0 then
+    URIString := 'undefined'
+  else
+    URIString := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  // Step 2: Let unescapedURISet be uriReserved + uriUnescaped + "#"
+  // Step 3: Return ? Encode(uriString, unescapedURISet)
+  Result := TGocciaStringLiteralValue.Create(EncodeURI(URIString));
+end;
+
+// ES2026 §19.2.6.3 decodeURI(encodedURI)
+function TGocciaGlobals.DecodeURICallback(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EncodedURI: string;
+begin
+  // Step 1: Let encodedURI be ? ToString(encodedURI)
+  if AArgs.Length = 0 then
+    EncodedURI := 'undefined'
+  else
+    EncodedURI := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  // Step 2: Let reservedURISet be uriReserved + "#"
+  // Step 3: Return ? Decode(encodedURI, reservedURISet)
+  Result := TGocciaStringLiteralValue.Create(DecodeURI(EncodedURI));
+end;
+
+// ES2026 §19.2.6.4 encodeURIComponent(uriComponent)
+function TGocciaGlobals.EncodeURIComponentCallback(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  ComponentString: string;
+begin
+  // Step 1: Let componentString be ? ToString(uriComponent)
+  if AArgs.Length = 0 then
+    ComponentString := 'undefined'
+  else
+    ComponentString := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  // Step 2: Let unescapedURIComponentSet be uriUnescaped
+  // Step 3: Return ? Encode(componentString, unescapedURIComponentSet)
+  Result := TGocciaStringLiteralValue.Create(EncodeURIComponent(ComponentString));
+end;
+
+// ES2026 §19.2.6.5 decodeURIComponent(encodedURIComponent)
+function TGocciaGlobals.DecodeURIComponentCallback(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  ComponentString: string;
+begin
+  // Step 1: Let componentString be ? ToString(encodedURIComponent)
+  if AArgs.Length = 0 then
+    ComponentString := 'undefined'
+  else
+    ComponentString := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  // Step 2: Let reservedURIComponentSet be the empty String
+  // Step 3: Return ? Decode(componentString, reservedURIComponentSet)
+  Result := TGocciaStringLiteralValue.Create(DecodeURIComponent(ComponentString));
 end;
 
 end.

--- a/units/Goccia.ImportMeta.pas
+++ b/units/Goccia.ImportMeta.pas
@@ -32,6 +32,7 @@ uses
   OrderedStringMap,
 
   Goccia.Constants.PropertyNames,
+  Goccia.URI,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction;
 
@@ -44,26 +45,6 @@ var
   ImportMetaCache: TOrderedStringMap<TGocciaObjectValue>;
   PinnedObjects: array of TGCManagedObject;
   PinnedCount: Integer;
-
-// RFC 3986 §2.3 — percent-encode path characters that are not unreserved or '/'
-function PercentEncodePath(const APath: string): string;
-var
-  I: Integer;
-  Ch: Char;
-begin
-  Result := '';
-  for I := 1 to Length(APath) do
-  begin
-    Ch := APath[I];
-    case Ch of
-      'A'..'Z', 'a'..'z', '0'..'9', '-', '.', '_', '~', '/',
-      ':', '@', '!', '$', '&', '''', '(', ')', '*', '+', ',', ';', '=':
-        Result := Result + Ch;
-    else
-      Result := Result + '%' + IntToHex(Ord(Ch), 2);
-    end;
-  end;
-end;
 
 function FilePathToUrl(const AFilePath: string): string;
 var

--- a/units/Goccia.URI.pas
+++ b/units/Goccia.URI.pas
@@ -273,7 +273,7 @@ end;
 function Decode(const AString: string; const AReservedSet: TSysCharSet): string;
 var
   Buffer: TStringBuffer;
-  I, Len, ByteCount, J: Integer;
+  I, Len, ByteCount, J, EscapeStart: Integer;
   B, B2: Byte;
   CodePoint: Integer;
   UTF8Bytes: array[0..3] of Byte;
@@ -294,6 +294,9 @@ begin
     end
     else
     begin
+      // ES2026 §19.2.6.2 step 4b: capture start position of the escape
+      EscapeStart := I;
+
       // Decode the first percent-encoded byte
       B := DecodePercentByte(AString, I, Len);
 
@@ -303,8 +306,8 @@ begin
         DecodedChar := Chr(B);
         if DecodedChar in AReservedSet then
         begin
-          // Reserved characters are re-emitted as percent-encoded (uppercase)
-          Buffer.Append(PercentEncodeByte(B));
+          // ES2026 §19.2.6.2 step 4b.ii.1: preserve original escape verbatim
+          Buffer.Append(Copy(AString, EscapeStart, 3));
         end
         else
           Buffer.Append(DecodedChar);

--- a/units/Goccia.URI.pas
+++ b/units/Goccia.URI.pas
@@ -1,0 +1,422 @@
+unit Goccia.URI;
+
+// ES2026 §19.2.6 URI Handling Functions
+// Shared URI encoding and decoding used by encodeURI, encodeURIComponent,
+// decodeURI, decodeURIComponent, and import.meta path encoding.
+
+{$I Goccia.inc}
+
+interface
+
+{ ES2026 §19.2.6.2 encodeURI(uriString) — encode a complete URI }
+function EncodeURI(const AString: string): string;
+
+{ ES2026 §19.2.6.4 encodeURIComponent(uriComponent) — encode a URI component }
+function EncodeURIComponent(const AString: string): string;
+
+{ ES2026 §19.2.6.3 decodeURI(encodedURI) — decode a complete URI }
+function DecodeURI(const AString: string): string;
+
+{ ES2026 §19.2.6.5 decodeURIComponent(encodedURIComponent) — decode a URI component }
+function DecodeURIComponent(const AString: string): string;
+
+{ RFC 3986 §2.3 — percent-encode file-path characters for file:// URLs.
+  Preserves unreserved characters plus sub-delims and '/', ':', '@'. }
+function PercentEncodePath(const APath: string): string;
+
+implementation
+
+uses
+  SysUtils,
+
+  StringBuffer,
+
+  Goccia.Values.ErrorHelper;
+
+const
+  HEX_DIGITS = '0123456789ABCDEF';
+
+  // ES2026 §19.2.6.2 step 4: uriReserved + uriUnescaped + '#'
+  // uriReserved = ; / ? : @ & = + $ ,
+  // uriUnescaped = A-Z a-z 0-9 - _ . ! ~ * ' ( )
+  // '#' is also unescaped for encodeURI
+  ENCODE_URI_UNESCAPED = [
+    'A'..'Z', 'a'..'z', '0'..'9',
+    '-', '_', '.', '!', '~', '*', '''', '(', ')',
+    ';', '/', '?', ':', '@', '&', '=', '+', '$', ',', '#'
+  ];
+
+  // ES2026 §19.2.6.4 step 4: uriUnescaped
+  // uriUnescaped = A-Z a-z 0-9 - _ . ! ~ * ' ( )
+  ENCODE_URI_COMPONENT_UNESCAPED = [
+    'A'..'Z', 'a'..'z', '0'..'9',
+    '-', '_', '.', '!', '~', '*', '''', '(', ')'
+  ];
+
+  // ES2026 §19.2.6.3 step 4: uriReserved + '#'
+  // Characters that decodeURI does NOT decode even when percent-encoded
+  DECODE_URI_RESERVED = [
+    ';', '/', '?', ':', '@', '&', '=', '+', '$', ',', '#'
+  ];
+
+  // RFC 3986 §2.3 unreserved characters plus sub-delimiters and path characters
+  PERCENT_ENCODE_PATH_UNESCAPED = [
+    'A'..'Z', 'a'..'z', '0'..'9',
+    '-', '.', '_', '~', '/',
+    ':', '@', '!', '$', '&', '''', '(', ')', '*', '+', ',', ';', '='
+  ];
+
+  UNICODE_REPLACEMENT_CHARACTER = $FFFD;
+
+{ Returns True if the byte at AIndex is a valid UTF-8 continuation byte (10xxxxxx). }
+function IsContinuationByte(const AString: string; const AIndex, ALength: Integer): Boolean; inline;
+begin
+  Result := (AIndex <= ALength) and ((Ord(AString[AIndex]) and $C0) = $80);
+end;
+
+{ Decode a single UTF-8 code point starting at position AIndex.
+  Advances AIndex past the decoded sequence. Returns the Unicode code point.
+  Returns -1 for lone surrogates (U+D800..U+DFFF) which are invalid. }
+function NextUTF8CodePoint(const AString: string; var AIndex: Integer): Integer;
+var
+  B: Byte;
+  Len: Integer;
+begin
+  Len := Length(AString);
+  B := Ord(AString[AIndex]);
+  if B < $80 then
+  begin
+    Result := B;
+    Inc(AIndex);
+  end
+  else if (B and $E0) = $C0 then
+  begin
+    Inc(AIndex);
+    if not IsContinuationByte(AString, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := ((B and $1F) shl 6) or (Ord(AString[AIndex]) and $3F);
+    Inc(AIndex);
+  end
+  else if (B and $F0) = $E0 then
+  begin
+    Inc(AIndex);
+    if not IsContinuationByte(AString, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := (B and $0F) shl 12;
+    Result := Result or ((Ord(AString[AIndex]) and $3F) shl 6);
+    Inc(AIndex);
+    if not IsContinuationByte(AString, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := Result or (Ord(AString[AIndex]) and $3F);
+    Inc(AIndex);
+  end
+  else if (B and $F8) = $F0 then
+  begin
+    Inc(AIndex);
+    if not IsContinuationByte(AString, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := (B and $07) shl 18;
+    Result := Result or ((Ord(AString[AIndex]) and $3F) shl 12);
+    Inc(AIndex);
+    if not IsContinuationByte(AString, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := Result or ((Ord(AString[AIndex]) and $3F) shl 6);
+    Inc(AIndex);
+    if not IsContinuationByte(AString, AIndex, Len) then
+      Exit(UNICODE_REPLACEMENT_CHARACTER);
+    Result := Result or (Ord(AString[AIndex]) and $3F);
+    Inc(AIndex);
+  end
+  else
+  begin
+    Result := UNICODE_REPLACEMENT_CHARACTER;
+    Inc(AIndex);
+  end;
+end;
+
+{ Percent-encode a single byte as %XX (uppercase hex). }
+function PercentEncodeByte(const AByte: Byte): string; inline;
+begin
+  Result := '%' + HEX_DIGITS[(AByte shr 4) + 1] + HEX_DIGITS[(AByte and $0F) + 1];
+end;
+
+{ Append the UTF-8 bytes of a code point to ABuffer, percent-encoding each byte. }
+procedure AppendPercentEncodedCodePoint(var ABuffer: TStringBuffer; const ACodePoint: Integer);
+begin
+  if ACodePoint < $80 then
+    ABuffer.Append(PercentEncodeByte(ACodePoint))
+  else if ACodePoint < $800 then
+  begin
+    ABuffer.Append(PercentEncodeByte($C0 or (ACodePoint shr 6)));
+    ABuffer.Append(PercentEncodeByte($80 or (ACodePoint and $3F)));
+  end
+  else if ACodePoint < $10000 then
+  begin
+    ABuffer.Append(PercentEncodeByte($E0 or (ACodePoint shr 12)));
+    ABuffer.Append(PercentEncodeByte($80 or ((ACodePoint shr 6) and $3F)));
+    ABuffer.Append(PercentEncodeByte($80 or (ACodePoint and $3F)));
+  end
+  else
+  begin
+    ABuffer.Append(PercentEncodeByte($F0 or (ACodePoint shr 18)));
+    ABuffer.Append(PercentEncodeByte($80 or ((ACodePoint shr 12) and $3F)));
+    ABuffer.Append(PercentEncodeByte($80 or ((ACodePoint shr 6) and $3F)));
+    ABuffer.Append(PercentEncodeByte($80 or (ACodePoint and $3F)));
+  end;
+end;
+
+{ Returns True if ACodePoint is a UTF-16 surrogate (U+D800..U+DFFF). }
+function IsSurrogate(const ACodePoint: Integer): Boolean; inline;
+begin
+  Result := (ACodePoint >= $D800) and (ACodePoint <= $DFFF);
+end;
+
+{ Returns True if ACodePoint is a high surrogate (U+D800..U+DBFF). }
+function IsHighSurrogate(const ACodePoint: Integer): Boolean; inline;
+begin
+  Result := (ACodePoint >= $D800) and (ACodePoint <= $DBFF);
+end;
+
+{ Returns True if ACodePoint is a low surrogate (U+DC00..U+DFFF). }
+function IsLowSurrogate(const ACodePoint: Integer): Boolean; inline;
+begin
+  Result := (ACodePoint >= $DC00) and (ACodePoint <= $DFFF);
+end;
+
+// ES2026 §19.2.6.1 Encode(string, unescapedSet)
+function Encode(const AString: string; const AUnescapedSet: TSysCharSet): string;
+var
+  Buffer: TStringBuffer;
+  I, Len, CodePoint, NextCP: Integer;
+begin
+  Len := Length(AString);
+  if Len = 0 then
+    Exit('');
+
+  Buffer := TStringBuffer.Create(Len);
+  I := 1;
+  while I <= Len do
+  begin
+    CodePoint := NextUTF8CodePoint(AString, I);
+
+    // ES2026 §19.2.6.1 step 4c: if the code point is in unescapedSet, pass it through
+    if (CodePoint < 128) and (Chr(CodePoint) in AUnescapedSet) then
+      Buffer.Append(Chr(CodePoint))
+    else
+    begin
+      // ES2026 §19.2.6.1 step 4d: lone surrogates throw URIError
+      if IsSurrogate(CodePoint) then
+      begin
+        // Check for surrogate pair — FPC stores UTF-8 internally, but the
+        // JavaScript string model is UTF-16. A code point in the surrogate
+        // range that appears in our internal UTF-8 string means a lone
+        // surrogate in the JS source. Supplementary code points (>= U+10000)
+        // are already decoded as full code points by NextUTF8CodePoint, so
+        // they never appear here.
+        if IsHighSurrogate(CodePoint) and (I <= Len) then
+        begin
+          NextCP := NextUTF8CodePoint(AString, I);
+          if IsLowSurrogate(NextCP) then
+          begin
+            // Surrogate pair — combine to supplementary code point
+            CodePoint := $10000 + ((CodePoint - $D800) shl 10) + (NextCP - $DC00);
+            AppendPercentEncodedCodePoint(Buffer, CodePoint);
+            Continue;
+          end
+          else
+            ThrowURIError('URI malformed');
+        end
+        else
+          ThrowURIError('URI malformed');
+      end;
+
+      // ES2026 §19.2.6.1 step 4d.vi: percent-encode UTF-8 octets
+      AppendPercentEncodedCodePoint(Buffer, CodePoint);
+    end;
+  end;
+  Result := Buffer.ToString;
+end;
+
+{ Returns True if C is an ASCII hex digit. }
+function IsASCIIHexDigit(const C: Char): Boolean; inline;
+begin
+  Result := (C in ['0'..'9', 'A'..'F', 'a'..'f']);
+end;
+
+{ Parse a hex digit character to its numeric value. }
+function HexVal(const C: Char): Byte; inline;
+begin
+  case C of
+    '0'..'9': Result := Ord(C) - Ord('0');
+    'A'..'F': Result := Ord(C) - Ord('A') + 10;
+    'a'..'f': Result := Ord(C) - Ord('a') + 10;
+  else
+    Result := 0;
+  end;
+end;
+
+{ Decode a single percent-encoded byte (%XX) at position AIndex.
+  AIndex must point to the '%'. Advances AIndex by 3 on success.
+  Throws URIError if the hex digits are invalid. }
+function DecodePercentByte(const AString: string; var AIndex: Integer;
+  const ALength: Integer): Byte;
+begin
+  if (AIndex + 2 > ALength) or
+     not IsASCIIHexDigit(AString[AIndex + 1]) or
+     not IsASCIIHexDigit(AString[AIndex + 2]) then
+    ThrowURIError('URI malformed');
+  Result := (HexVal(AString[AIndex + 1]) shl 4) or HexVal(AString[AIndex + 2]);
+  Inc(AIndex, 3);
+end;
+
+// ES2026 §19.2.6.2 Decode(string, reservedSet)
+function Decode(const AString: string; const AReservedSet: TSysCharSet): string;
+var
+  Buffer: TStringBuffer;
+  I, Len, ByteCount, J: Integer;
+  B, B2: Byte;
+  CodePoint: Integer;
+  UTF8Bytes: array[0..3] of Byte;
+  DecodedChar: Char;
+begin
+  Len := Length(AString);
+  if Len = 0 then
+    Exit('');
+
+  Buffer := TStringBuffer.Create(Len);
+  I := 1;
+  while I <= Len do
+  begin
+    if AString[I] <> '%' then
+    begin
+      Buffer.Append(AString[I]);
+      Inc(I);
+    end
+    else
+    begin
+      // Decode the first percent-encoded byte
+      B := DecodePercentByte(AString, I, Len);
+
+      if B < $80 then
+      begin
+        // ES2026 §19.2.6.2 step 4b.ii: single-byte character
+        DecodedChar := Chr(B);
+        if DecodedChar in AReservedSet then
+        begin
+          // Reserved characters are re-emitted as percent-encoded (uppercase)
+          Buffer.Append(PercentEncodeByte(B));
+        end
+        else
+          Buffer.Append(DecodedChar);
+      end
+      else
+      begin
+        // ES2026 §19.2.6.2 step 4b.v: multi-byte UTF-8 sequence
+        // Determine expected byte count from lead byte
+        if (B and $E0) = $C0 then
+          ByteCount := 2
+        else if (B and $F0) = $E0 then
+          ByteCount := 3
+        else if (B and $F8) = $F0 then
+          ByteCount := 4
+        else
+          ThrowURIError('URI malformed');
+
+        UTF8Bytes[0] := B;
+
+        // Decode continuation bytes
+        for J := 1 to ByteCount - 1 do
+        begin
+          if (I > Len) or (AString[I] <> '%') then
+            ThrowURIError('URI malformed');
+          B2 := DecodePercentByte(AString, I, Len);
+          if (B2 and $C0) <> $80 then
+            ThrowURIError('URI malformed');
+          UTF8Bytes[J] := B2;
+        end;
+
+        // Reconstruct the code point
+        case ByteCount of
+          2: CodePoint := ((UTF8Bytes[0] and $1F) shl 6) or
+                           (UTF8Bytes[1] and $3F);
+          3: CodePoint := ((UTF8Bytes[0] and $0F) shl 12) or
+                          ((UTF8Bytes[1] and $3F) shl 6) or
+                           (UTF8Bytes[2] and $3F);
+          4: CodePoint := ((UTF8Bytes[0] and $07) shl 18) or
+                          ((UTF8Bytes[1] and $3F) shl 12) or
+                          ((UTF8Bytes[2] and $3F) shl 6) or
+                           (UTF8Bytes[3] and $3F);
+        else
+          CodePoint := UNICODE_REPLACEMENT_CHARACTER;
+        end;
+
+        // Lone surrogates are invalid
+        if IsSurrogate(CodePoint) then
+          ThrowURIError('URI malformed');
+
+        // Overlong encodings are invalid
+        if ((ByteCount = 2) and (CodePoint < $80)) or
+           ((ByteCount = 3) and (CodePoint < $800)) or
+           ((ByteCount = 4) and (CodePoint < $10000)) then
+          ThrowURIError('URI malformed');
+
+        // Code points above U+10FFFF are invalid
+        if CodePoint > $10FFFF then
+          ThrowURIError('URI malformed');
+
+        // Append the decoded UTF-8 bytes directly
+        for J := 0 to ByteCount - 1 do
+          Buffer.Append(Chr(UTF8Bytes[J]));
+      end;
+    end;
+  end;
+  Result := Buffer.ToString;
+end;
+
+// ES2026 §19.2.6.2 encodeURI(uriString)
+function EncodeURI(const AString: string): string;
+begin
+  Result := Encode(AString, ENCODE_URI_UNESCAPED);
+end;
+
+// ES2026 §19.2.6.4 encodeURIComponent(uriComponent)
+function EncodeURIComponent(const AString: string): string;
+begin
+  Result := Encode(AString, ENCODE_URI_COMPONENT_UNESCAPED);
+end;
+
+// ES2026 §19.2.6.3 decodeURI(encodedURI)
+function DecodeURI(const AString: string): string;
+begin
+  Result := Decode(AString, DECODE_URI_RESERVED);
+end;
+
+// ES2026 §19.2.6.5 decodeURIComponent(encodedURIComponent)
+function DecodeURIComponent(const AString: string): string;
+begin
+  Result := Decode(AString, []);
+end;
+
+// RFC 3986 §2.3 — percent-encode path characters that are not unreserved or '/'
+function PercentEncodePath(const APath: string): string;
+var
+  Buffer: TStringBuffer;
+  I: Integer;
+  Ch: Char;
+begin
+  if Length(APath) = 0 then
+    Exit('');
+
+  Buffer := TStringBuffer.Create(Length(APath));
+  for I := 1 to Length(APath) do
+  begin
+    Ch := APath[I];
+    if Ch in PERCENT_ENCODE_PATH_UNESCAPED then
+      Buffer.Append(Ch)
+    else
+      Buffer.Append(PercentEncodeByte(Ord(Ch)));
+  end;
+  Result := Buffer.ToString;
+end;
+
+end.

--- a/units/Goccia.Values.ErrorHelper.pas
+++ b/units/Goccia.Values.ErrorHelper.pas
@@ -29,6 +29,9 @@ procedure ThrowDataCloneError(const AMessage: string);
 { Raises a TGocciaThrowValue with an InvalidCharacterError (DOMException with code 5) }
 procedure ThrowInvalidCharacterError(const AMessage: string);
 
+{ Raises a TGocciaThrowValue with a URIError }
+procedure ThrowURIError(const AMessage: string);
+
 { Raises a TGocciaThrowValue with a generic Error }
 procedure ThrowError(const AMessage: string);
 
@@ -124,6 +127,11 @@ begin
   if Assigned(GDOMExceptionProto) then
     ErrorObj.Prototype := GDOMExceptionProto;
   raise TGocciaThrowValue.Create(ErrorObj);
+end;
+
+procedure ThrowURIError(const AMessage: string);
+begin
+  raise TGocciaThrowValue.Create(CreateErrorObject(URI_ERROR_NAME, AMessage));
 end;
 
 procedure ThrowError(const AMessage: string);


### PR DESCRIPTION
## Summary
- Implements `encodeURI`, `decodeURI`, `encodeURIComponent`, and `decodeURIComponent` as global functions per ES2026 §19.2.6.
- New shared `Goccia.URI.pas` unit with the `Encode`/`Decode` core algorithms, UTF-8 multi-byte support, surrogate validation, and overlong-encoding rejection. Also exposes `PercentEncodePath` for file-URL percent-encoding.
- **Unifies URI encoding**: `Goccia.ImportMeta.pas` now uses the shared `PercentEncodePath` from `Goccia.URI` instead of its own private copy.
- Adds `ThrowURIError` to `Goccia.Values.ErrorHelper.pas` (the `URIError` constructor and prototype already existed).
- No Windows-specific edge cases for the URI functions themselves (pure string operations). The `import.meta` path-separator conversion (`\` → `/`) remains unchanged and runs before the shared encoder.
- Removes URI functions and atob/btoa from the "Deferred Built-ins" list in `docs/language-restrictions.md`.

## Testing
- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - 56 new tests across 4 files (`encodeURIComponent.js`, `decodeURIComponent.js`, `encodeURI.js`, `decodeURI.js`), all passing in both interpreted and bytecode modes
  - Full suite: 4954 passed, 12 failed (all pre-existing FFI/ASI failures), 41 skipped — zero new regressions
  - `import.meta` tests (22/22) continue to pass after the `PercentEncodePath` unification
- [x] Updated documentation
  - `CLAUDE.md`: added `Goccia.URI.pas` to architecture table
  - `docs/built-ins.md`: documented all 4 functions with behavior details
  - `docs/language-restrictions.md`: removed from deferred list
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change