### PR TITLE
Implement TC39 Template Literal Revision for tagged templates

### DIFF
--- a/docs/language-restrictions.md
+++ b/docs/language-restrictions.md
@@ -160,7 +160,7 @@ C[Symbol.metadata].decorated; // true
 - Bitwise operators (`&`, `|`, `^`, `<<`, `>>`, `>>>`).
 - Ternary operator (`? :`).
 - Numeric literals: decimal, hex (`0x`), binary (`0b`), octal (`0o`), scientific notation, and numeric separators (`1_000_000`, `0xFF_FF`, `0b1010_0001`, `0o77_77`, `1.5e1_0`).
-- Template literals with interpolation and tagged templates (`tag\`...\``, `String.raw`).
+- Template literals with interpolation and tagged templates (`tag\`...\``, `String.raw`). Tagged templates support the TC39 Template Literal Revision (ES2018): malformed escape sequences (e.g., `\u{`, `\xG1`) set the cooked segment to `undefined` while preserving the raw source text; untagged templates still throw `SyntaxError` for invalid escapes.
 - Destructuring (array and object patterns).
 - Spread operator (`...`).
 - `typeof`, `instanceof`, `in`, `delete`.

--- a/tests/language/expressions/string/tagged-templates.js
+++ b/tests/language/expressions/string/tagged-templates.js
@@ -281,4 +281,130 @@ describe("tagged templates", () => {
     const b = tag`hello`;
     expect(a).not.toBe(b);
   });
+
+  // TC39 Template Literal Revision (ES2018): tagged templates tolerate malformed
+  // escape sequences by setting the cooked value to undefined while preserving
+  // the raw source text.
+
+  test("malformed \\xG1 hex escape sets cooked to undefined", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`\xG1`;
+    expect(cooked).toBe(undefined);
+    expect(raw).toBe("\\xG1");
+  });
+
+  test("malformed \\u{ sets cooked to undefined", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`\u{`;
+    expect(cooked).toBe(undefined);
+    expect(raw).toBe("\\u{");
+  });
+
+  test("malformed \\u{ZZZZ} sets cooked to undefined", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`\u{ZZZZ}`;
+    expect(cooked).toBe(undefined);
+    expect(raw).toBe("\\u{ZZZZ}");
+  });
+
+  test("malformed \\u00 (incomplete unicode) sets cooked to undefined", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`\u00`;
+    expect(cooked).toBe(undefined);
+    expect(raw).toBe("\\u00");
+  });
+
+  test("malformed \\x (no digits) sets cooked to undefined", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`\xQQ`;
+    expect(cooked).toBe(undefined);
+    expect(raw).toBe("\\xQQ");
+  });
+
+  test("valid segment alongside invalid segment in tagged template", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings; raw = strings.raw; };
+    tag`valid${"expr"}\xG1`;
+    // First segment is valid
+    expect(cooked[0]).toBe("valid");
+    expect(raw[0]).toBe("valid");
+    // Second segment has malformed escape → cooked is undefined
+    expect(cooked[1]).toBe(undefined);
+    expect(raw[1]).toBe("\\xG1");
+  });
+
+  test("malformed escape with mixed valid text in same segment", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`hello\xG1world`;
+    expect(cooked).toBe(undefined);
+    expect(raw).toBe("hello\\xG1world");
+  });
+
+  test("template object with undefined cooked segments is still frozen", () => {
+    let templateObj;
+    const tag = (strings) => { templateObj = strings; return strings; };
+    tag`\xG1`;
+    expect(Object.isFrozen(templateObj)).toBe(true);
+    expect(Object.isFrozen(templateObj.raw)).toBe(true);
+  });
+
+  test("malformed escape does not affect expression evaluation", () => {
+    const values = [];
+    const tag = (strings, ...vals) => { values.push(...vals); return strings; };
+    const x = 42;
+    const result = tag`\xG1${x}end`;
+    expect(values[0]).toBe(42);
+    expect(result[0]).toBe(undefined);
+    expect(result[1]).toBe("end");
+    expect(result.raw[0]).toBe("\\xG1");
+    expect(result.raw[1]).toBe("end");
+  });
+
+  test("call site identity preserved with malformed escapes", () => {
+    const tag = (strings) => strings;
+    const callSite = () => tag`\xG1`;
+    const a = callSite();
+    const b = callSite();
+    expect(a).toBe(b);
+  });
+
+  test("malformed \\u{110000} (code point too large) sets cooked to undefined", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`\u{110000}`;
+    expect(cooked).toBe(undefined);
+    expect(raw).toBe("\\u{110000}");
+  });
+
+  test("valid unicode escape in tagged template still works", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`\u0041`;
+    expect(cooked).toBe("A");
+    expect(raw).toBe("\\u0041");
+  });
+
+  test("valid hex escape in tagged template still works", () => {
+    let cooked;
+    let raw;
+    const tag = (strings) => { cooked = strings[0]; raw = strings.raw[0]; };
+    tag`\x41`;
+    expect(cooked).toBe("A");
+    expect(raw).toBe("\\x41");
+  });
 });

--- a/tests/language/expressions/string/template-string.js
+++ b/tests/language/expressions/string/template-string.js
@@ -43,3 +43,4 @@ test("triple backslash before dollar-brace is literal backslash plus literal dol
   const x = 42;
   expect(`\\\${x}`).toBe("\\${x}");
 });
+

--- a/units/Goccia.AST.Expressions.pas
+++ b/units/Goccia.AST.Expressions.pas
@@ -77,18 +77,24 @@ type
   end;
 
   TGocciaTemplateStrings = array of string;
+  // TC39 Template Literal Revision: per-segment validity flags for cooked strings.
+  // True means the cooked value is valid; False means the escape was malformed
+  // and the cooked value should be undefined.
+  TGocciaTemplateCookedValid = array of Boolean;
 
   TGocciaTaggedTemplateExpression = class(TGocciaExpression)
   private
     FTag: TGocciaExpression;
     FCookedStrings: TGocciaTemplateStrings;
     FRawStrings: TGocciaTemplateStrings;
+    FCookedValid: TGocciaTemplateCookedValid;
     FExpressions: TObjectList<TGocciaExpression>;
     // ES2026 §13.2.8.3: cached per-call-site template object (nil until first evaluation)
     FTemplateObject: TGocciaValue;
   public
     constructor Create(const ATag: TGocciaExpression;
       const ACookedStrings, ARawStrings: TGocciaTemplateStrings;
+      const ACookedValid: TGocciaTemplateCookedValid;
       const AExpressions: TObjectList<TGocciaExpression>;
       const ALine, AColumn: Integer);
     destructor Destroy; override;
@@ -100,6 +106,7 @@ type
     property Tag: TGocciaExpression read FTag;
     property CookedStrings: TGocciaTemplateStrings read FCookedStrings;
     property RawStrings: TGocciaTemplateStrings read FRawStrings;
+    property CookedValid: TGocciaTemplateCookedValid read FCookedValid;
     property Expressions: TObjectList<TGocciaExpression> read FExpressions;
     property TemplateObject: TGocciaValue read FTemplateObject;
   end;
@@ -664,6 +671,7 @@ end;
 
 constructor TGocciaTaggedTemplateExpression.Create(const ATag: TGocciaExpression;
   const ACookedStrings, ARawStrings: TGocciaTemplateStrings;
+  const ACookedValid: TGocciaTemplateCookedValid;
   const AExpressions: TObjectList<TGocciaExpression>;
   const ALine, AColumn: Integer);
 begin
@@ -671,6 +679,7 @@ begin
   FTag := ATag;
   FCookedStrings := ACookedStrings;
   FRawStrings := ARawStrings;
+  FCookedValid := ACookedValid;
   FExpressions := AExpressions;
 end;
 

--- a/units/Goccia.Bytecode.Binary.pas
+++ b/units/Goccia.Bytecode.Binary.pas
@@ -161,6 +161,9 @@ begin
         WriteUInt16(UInt16(Length(Constant.RawStrings)));
         for J := 0 to Length(Constant.RawStrings) - 1 do
           WriteString(Constant.RawStrings[J]);
+        // TC39 Template Literal Revision: per-segment cooked validity flags
+        for J := 0 to Length(Constant.CookedValid) - 1 do
+          WriteBoolean(Constant.CookedValid[J]);
       end;
     end;
   end;
@@ -325,6 +328,7 @@ var
   SourceFile: string;
   LineMapCount, LocalCount: UInt32;
   CookedStrings, RawStrings: TGocciaBytecodeStringArray;
+  CookedValid: TGocciaBytecodeTemplateCookedValid;
 begin
   Name := ReadString;
   MaxRegs := ReadUInt8;
@@ -365,7 +369,11 @@ begin
         SetLength(RawStrings, StrCount);
         for J := 0 to StrCount - 1 do
           RawStrings[J] := ReadString;
-        Result.AddConstantTemplateObject(CookedStrings, RawStrings);
+        // TC39 Template Literal Revision: per-segment cooked validity flags
+        SetLength(CookedValid, Length(CookedStrings));
+        for J := 0 to Length(CookedStrings) - 1 do
+          CookedValid[J] := ReadBoolean;
+        Result.AddConstantTemplateObject(CookedStrings, RawStrings, CookedValid);
       end;
     end;
   end;

--- a/units/Goccia.Bytecode.Chunk.pas
+++ b/units/Goccia.Bytecode.Chunk.pas
@@ -28,14 +28,17 @@ type
   );
 
   TGocciaBytecodeStringArray = array of string;
+  // TC39 Template Literal Revision: per-segment validity flags for cooked strings.
+  TGocciaBytecodeTemplateCookedValid = array of Boolean;
 
   TGocciaBytecodeConstant = record
     Kind: TGocciaBytecodeConstantKind;
     IntValue: Int64;
     FloatValue: Double;
     StringValue: string;
-    CookedStrings: TGocciaBytecodeStringArray;  // for bckTemplateObject
-    RawStrings: TGocciaBytecodeStringArray;     // for bckTemplateObject
+    CookedStrings: TGocciaBytecodeStringArray;          // for bckTemplateObject
+    RawStrings: TGocciaBytecodeStringArray;             // for bckTemplateObject
+    CookedValid: TGocciaBytecodeTemplateCookedValid;    // for bckTemplateObject
   end;
 
   TGocciaUpvalueDescriptor = record
@@ -104,7 +107,8 @@ type
     // ES2026 §13.2.8.3: add a bckTemplateObject constant that the VM will lazily
     // build and cache on first execution.  Each call site gets its own entry;
     // no deduplication is performed.
-    function AddConstantTemplateObject(const ACookedStrings, ARawStrings: array of string): UInt16;
+    function AddConstantTemplateObject(const ACookedStrings, ARawStrings: array of string;
+      const ACookedValid: array of Boolean): UInt16;
     function GetTemplateObjectCache(const ASlot: Integer): TObject;
     procedure SetTemplateObjectCache(const ASlot: Integer; const AValue: TObject);
     function AddFunction(const AFunction: TGocciaFunctionTemplate): UInt16;
@@ -318,7 +322,8 @@ end;
 
 // ES2026 §13.2.8.3 GetTemplateObject(templateLiteral)
 function TGocciaFunctionTemplate.AddConstantTemplateObject(
-  const ACookedStrings, ARawStrings: array of string): UInt16;
+  const ACookedStrings, ARawStrings: array of string;
+  const ACookedValid: array of Boolean): UInt16;
 var
   K: Integer;
 begin
@@ -338,6 +343,10 @@ begin
   SetLength(FConstants[FConstantCount].RawStrings, Length(ARawStrings));
   for K := 0 to High(ARawStrings) do
     FConstants[FConstantCount].RawStrings[K] := ARawStrings[K];
+  // TC39 Template Literal Revision: per-segment cooked validity flags
+  SetLength(FConstants[FConstantCount].CookedValid, Length(ACookedValid));
+  for K := 0 to High(ACookedValid) do
+    FConstants[FConstantCount].CookedValid[K] := ACookedValid[K];
   // Grow the runtime cache; the new slot starts nil (built on first VM execution)
   if FTemplateObjectCacheCount >= Length(FTemplateObjectCaches) then
     SetLength(FTemplateObjectCaches, FTemplateObjectCacheCount * 2 + 4);

--- a/units/Goccia.Compiler.Expressions.pas
+++ b/units/Goccia.Compiler.Expressions.pas
@@ -1726,7 +1726,8 @@ begin
   // satisfying the per-Parse-Node identity requirement without a new opcode.
   Arg0Reg := ACtx.Scope.AllocateRegister;
   EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, Arg0Reg,
-    ACtx.Template.AddConstantTemplateObject(AExpr.CookedStrings, AExpr.RawStrings)));
+    ACtx.Template.AddConstantTemplateObject(AExpr.CookedStrings, AExpr.RawStrings,
+      AExpr.CookedValid)));
 
   // ES2026 §13.3.11 step 3: evaluate substitutions into argument registers
   for I := 0 to AExpr.Expressions.Count - 1 do

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -2959,8 +2959,15 @@ begin
       CookedArray := TGocciaArrayValue.Create;
       TGarbageCollector.Instance.AddTempRoot(CookedArray);
       try
+        // TC39 Template Literal Revision: segments with malformed escapes get
+        // cooked=undefined; valid segments get the resolved string value.
         for I := 0 to Length(ATaggedTemplateExpression.CookedStrings) - 1 do
-          CookedArray.Elements.Add(TGocciaStringLiteralValue.Create(ATaggedTemplateExpression.CookedStrings[I]));
+        begin
+          if ATaggedTemplateExpression.CookedValid[I] then
+            CookedArray.Elements.Add(TGocciaStringLiteralValue.Create(ATaggedTemplateExpression.CookedStrings[I]))
+          else
+            CookedArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+        end;
         // ES2026 §13.2.8.3 step 8: Define raw as non-enumerable, non-writable, non-configurable
         CookedArray.DefineProperty(PROP_RAW,
           TGocciaPropertyDescriptorData.Create(RawArray, []));

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -391,6 +391,7 @@ end;
 function TGocciaLexer.ScanUnicodeEscapeForTemplate(var ASB: TStringBuffer): Boolean;
 var
   CodePoint, LowSurrogate: Cardinal;
+  CodePointValue: QWord;
   HexStr: string;
   I, HexStart, SavedCurrent, SavedColumn: Integer;
 begin
@@ -413,9 +414,12 @@ begin
     if not IsValidHexString(HexStr) then
       Exit(False);
     Advance; // consume '}'
-    CodePoint := StrToInt('$' + HexStr);
-    if CodePoint > $10FFFF then
+    // Use TryStrToQWord to safely handle arbitrarily long hex payloads
+    // without raising on overflow (e.g. \u{FFFFFFFF}).
+    if not TryStrToQWord('$' + HexStr, CodePointValue) or
+       (CodePointValue > $10FFFF) then
       Exit(False);
+    CodePoint := Cardinal(CodePointValue);
   end
   else
   begin

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -432,7 +432,9 @@ begin
     CodePoint := StrToInt('$' + HexStr);
   end;
 
-  // ES2026 §12.9.4: Combine UTF-16 surrogate pairs into a single code point
+  // ES2026 §12.9.4: Combine UTF-16 surrogate pairs into a single code point.
+  // Guard against scanning past the closing backtick when the low surrogate
+  // probe is incomplete or malformed — restore the cursor on every failure path.
   if (CodePoint >= $D800) and (CodePoint <= $DBFF) and (Peek = '\') and (PeekNext = 'u') then
   begin
     SavedCurrent := FCurrent;
@@ -442,7 +444,7 @@ begin
     HexStart := FCurrent;
     for I := 1 to 4 do
     begin
-      if IsAtEnd then
+      if IsAtEnd or (Peek = '`') then
       begin
         FCurrent := SavedCurrent;
         FColumn := SavedColumn;
@@ -461,6 +463,11 @@ begin
         FCurrent := SavedCurrent;
         FColumn := SavedColumn;
       end;
+    end
+    else
+    begin
+      FCurrent := SavedCurrent;
+      FColumn := SavedColumn;
     end;
   end;
 

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -53,6 +53,12 @@ type
     function ScanUnicodeEscape: string;
     function ScanHexEscape: string;
     procedure ProcessEscapeSequence(var ASB: TStringBuffer);
+    // TC39 Template Literal Revision — template-aware variants that return
+    // False on malformed escapes instead of raising, allowing tagged templates
+    // to set cooked=undefined while preserving the raw source text.
+    function ScanUnicodeEscapeForTemplate(var ASB: TStringBuffer): Boolean;
+    function ScanHexEscapeForTemplate(var ASB: TStringBuffer): Boolean;
+    procedure ProcessTemplateEscapeSequence(var ASB: TStringBuffer; var ASegmentValid: Boolean);
     procedure UpdateRegexContext(const ATokenType: TGocciaTokenType);
     procedure PushParenRegexContext(const AAllowsRegexAfter: Boolean);
     function PopParenRegexContext: Boolean;
@@ -378,6 +384,168 @@ begin
   end;
 end;
 
+// TC39 Template Literal Revision — template-aware Unicode escape scanner.
+// Returns True on success (resolved value appended to ASB), False on malformed
+// escape (cursor advanced past the consumed characters, nothing appended).
+// Does not raise TGocciaLexerError — the caller marks the segment as invalid.
+function TGocciaLexer.ScanUnicodeEscapeForTemplate(var ASB: TStringBuffer): Boolean;
+var
+  CodePoint, LowSurrogate: Cardinal;
+  HexStr: string;
+  I, HexStart, SavedCurrent, SavedColumn: Integer;
+begin
+  // Called after consuming '\u', Peek is the next character
+  if Peek = '{' then
+  begin
+    Advance; // consume '{'
+    HexStart := FCurrent;
+    // Scan hex digits, stopping at '}', backtick, or EOF.
+    // Non-hex characters also stop the scan (invalid escape).
+    while (Peek <> '}') and (Peek <> '`') and not IsAtEnd do
+    begin
+      if not CharInSet(Peek, ['0'..'9', 'a'..'f', 'A'..'F']) then
+        Break;
+      Advance;
+    end;
+    HexStr := Copy(FSource, HexStart, FCurrent - HexStart);
+    if (Peek <> '}') or (HexStr = '') then
+      Exit(False); // unterminated or empty
+    if not IsValidHexString(HexStr) then
+      Exit(False);
+    Advance; // consume '}'
+    CodePoint := StrToInt('$' + HexStr);
+    if CodePoint > $10FFFF then
+      Exit(False);
+  end
+  else
+  begin
+    HexStart := FCurrent;
+    for I := 1 to 4 do
+    begin
+      if IsAtEnd or (Peek = '`') then
+        Exit(False);
+      Advance;
+    end;
+    HexStr := Copy(FSource, HexStart, FCurrent - HexStart);
+    if not IsValidHexString(HexStr) then
+      Exit(False);
+    CodePoint := StrToInt('$' + HexStr);
+  end;
+
+  // ES2026 §12.9.4: Combine UTF-16 surrogate pairs into a single code point
+  if (CodePoint >= $D800) and (CodePoint <= $DBFF) and (Peek = '\') and (PeekNext = 'u') then
+  begin
+    SavedCurrent := FCurrent;
+    SavedColumn := FColumn;
+    Advance; // consume '\'
+    Advance; // consume 'u'
+    HexStart := FCurrent;
+    for I := 1 to 4 do
+    begin
+      if IsAtEnd then
+      begin
+        FCurrent := SavedCurrent;
+        FColumn := SavedColumn;
+        Break;
+      end;
+      Advance;
+    end;
+    HexStr := Copy(FSource, HexStart, FCurrent - HexStart);
+    if (Length(HexStr) = 4) and IsValidHexString(HexStr) then
+    begin
+      LowSurrogate := StrToInt('$' + HexStr);
+      if (LowSurrogate >= $DC00) and (LowSurrogate <= $DFFF) then
+        CodePoint := $10000 + ((CodePoint - $D800) shl 10) + (LowSurrogate - $DC00)
+      else
+      begin
+        FCurrent := SavedCurrent;
+        FColumn := SavedColumn;
+      end;
+    end;
+  end;
+
+  // Convert code point to UTF-8
+  if CodePoint <= $7F then
+    ASB.AppendChar(Chr(CodePoint))
+  else if CodePoint <= $7FF then
+  begin
+    ASB.AppendChar(Chr($C0 or (CodePoint shr 6)));
+    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
+  end
+  else if CodePoint <= $FFFF then
+  begin
+    ASB.AppendChar(Chr($E0 or (CodePoint shr 12)));
+    ASB.AppendChar(Chr($80 or ((CodePoint shr 6) and $3F)));
+    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
+  end
+  else if CodePoint <= $10FFFF then
+  begin
+    ASB.AppendChar(Chr($F0 or (CodePoint shr 18)));
+    ASB.AppendChar(Chr($80 or ((CodePoint shr 12) and $3F)));
+    ASB.AppendChar(Chr($80 or ((CodePoint shr 6) and $3F)));
+    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
+  end
+  else
+    Exit(False);
+  Result := True;
+end;
+
+// TC39 Template Literal Revision — template-aware hex escape scanner.
+// Returns True on success (resolved character appended to ASB), False on
+// malformed escape (cursor advanced past consumed characters).
+function TGocciaLexer.ScanHexEscapeForTemplate(var ASB: TStringBuffer): Boolean;
+var
+  HexStr: string;
+  HexStart: Integer;
+  CodePoint: Cardinal;
+begin
+  // Called after consuming '\x', Peek is the first hex digit
+  if IsAtEnd or (Peek = '`') then
+    Exit(False);
+  HexStart := FCurrent;
+  Advance;
+  if IsAtEnd or (Peek = '`') then
+    Exit(False);
+  Advance;
+  HexStr := Copy(FSource, HexStart, 2);
+  if not IsValidHexString(HexStr) then
+    Exit(False);
+
+  CodePoint := StrToInt('$' + HexStr);
+  ASB.AppendChar(Chr(CodePoint));
+  Result := True;
+end;
+
+// TC39 Template Literal Revision — process an escape sequence in template
+// context. On valid escapes, appends the resolved value to ASB. On invalid
+// \u or \x escapes, sets ASegmentValid to False and does not append to ASB.
+procedure TGocciaLexer.ProcessTemplateEscapeSequence(var ASB: TStringBuffer;
+  var ASegmentValid: Boolean);
+begin
+  case Peek of
+    'n': begin ASB.AppendChar(#10); Advance; end;
+    'r': begin ASB.AppendChar(#13); Advance; end;
+    't': begin ASB.AppendChar(#9); Advance; end;
+    '\': begin ASB.AppendChar('\'); Advance; end;
+    '0': begin ASB.AppendChar(#0); Advance; end;
+    'u':
+    begin
+      Advance;
+      if not ScanUnicodeEscapeForTemplate(ASB) then
+        ASegmentValid := False;
+    end;
+    'x':
+    begin
+      Advance;
+      if not ScanHexEscapeForTemplate(ASB) then
+        ASegmentValid := False;
+    end;
+  else
+    ASB.AppendChar(Peek);
+    Advance;
+  end;
+end;
+
 procedure TGocciaLexer.PushParenRegexContext(const AAllowsRegexAfter: Boolean);
 begin
   if FParenRegexContextCount >= Length(FParenRegexContext) then
@@ -469,17 +637,26 @@ begin
   AddToken(gttString, SB.ToString);
 end;
 
+// TC39 Template Literal Revision: template scanning tolerates malformed escape
+// sequences.  When an invalid \u or \x escape is encountered, the segment is
+// flagged and the token separator changes from #1 to #2 so the parser can
+// detect that cooked values must be re-derived per-segment from the raw string.
 procedure TGocciaLexer.ScanTemplate;
 const
   TEMPLATE_RAW_SEPARATOR = #1;
+  TEMPLATE_INVALID_ESCAPE_SEPARATOR = #2;
 var
   SB: TStringBuffer;
   RawSB: TStringBuffer;
   C: Char;
   RawStart, J: Integer;
+  SegmentValid, HasInvalidEscape: Boolean;
+  Separator: Char;
 begin
   SB := TStringBuffer.Create;
   RawSB := TStringBuffer.Create;
+  HasInvalidEscape := False;
+  SegmentValid := True;
   while (Peek <> '`') and not IsAtEnd do
   begin
     if Peek = #13 then
@@ -523,10 +700,13 @@ begin
           end;
         else
           begin
-            // Capture raw escape sequence by tracking source positions
+            // Capture raw escape sequence by tracking source positions.
+            // Use the template-aware variant that tolerates malformed escapes.
             RawSB.AppendChar('\');
             RawStart := FCurrent;
-            ProcessEscapeSequence(SB);
+            ProcessTemplateEscapeSequence(SB, SegmentValid);
+            if not SegmentValid then
+              HasInvalidEscape := True;
             // Copy the raw source text consumed by the escape sequence
             for J := RawStart to FCurrent - 1 do
               RawSB.AppendChar(FSource[J]);
@@ -547,7 +727,13 @@ begin
       FFileName, GetSourceLines, SSuggestCloseTemplate);
 
   Advance; // Closing backtick
-  AddToken(gttTemplate, SB.ToString + TEMPLATE_RAW_SEPARATOR + RawSB.ToString);
+  // TC39 Template Literal Revision: use #2 separator when the template contains
+  // invalid escape sequences, signalling the parser to re-cook from raw.
+  if HasInvalidEscape then
+    Separator := TEMPLATE_INVALID_ESCAPE_SEPARATOR
+  else
+    Separator := TEMPLATE_RAW_SEPARATOR;
+  AddToken(gttTemplate, SB.ToString + Separator + RawSB.ToString);
 end;
 
 procedure TGocciaLexer.ScanRegexLiteral;

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -1159,6 +1159,27 @@ begin
   ARawSegments[SegmentCount] := Copy(ARawFull, StartRaw, RawI - StartRaw);
 end;
 
+// Convert a Unicode code point to its UTF-8 string representation.
+// Returns empty string for code points above U+10FFFF.
+function CodePointToUTF8(const ACodePoint: Cardinal): string;
+begin
+  if ACodePoint <= $7F then
+    Result := Chr(ACodePoint)
+  else if ACodePoint <= $7FF then
+    Result := Chr($C0 or (ACodePoint shr 6)) + Chr($80 or (ACodePoint and $3F))
+  else if ACodePoint <= $FFFF then
+    Result := Chr($E0 or (ACodePoint shr 12)) +
+              Chr($80 or ((ACodePoint shr 6) and $3F)) +
+              Chr($80 or (ACodePoint and $3F))
+  else if ACodePoint <= $10FFFF then
+    Result := Chr($F0 or (ACodePoint shr 18)) +
+              Chr($80 or ((ACodePoint shr 12) and $3F)) +
+              Chr($80 or ((ACodePoint shr 6) and $3F)) +
+              Chr($80 or (ACodePoint and $3F))
+  else
+    Result := '';
+end;
+
 // TC39 Template Literal Revision — cook a Unicode escape from a raw segment.
 // AStr is the raw text, APos is the current position (after 'u' has been
 // consumed). On success, appends the resolved character(s) to ASB and advances
@@ -1231,30 +1252,10 @@ begin
       APos := SavedPos;
   end;
 
-  // Convert code point to UTF-8
-  if CodePoint <= $7F then
-    ASB.AppendChar(Chr(CodePoint))
-  else if CodePoint <= $7FF then
-  begin
-    ASB.AppendChar(Chr($C0 or (CodePoint shr 6)));
-    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
-  end
-  else if CodePoint <= $FFFF then
-  begin
-    ASB.AppendChar(Chr($E0 or (CodePoint shr 12)));
-    ASB.AppendChar(Chr($80 or ((CodePoint shr 6) and $3F)));
-    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
-  end
-  else if CodePoint <= $10FFFF then
-  begin
-    ASB.AppendChar(Chr($F0 or (CodePoint shr 18)));
-    ASB.AppendChar(Chr($80 or ((CodePoint shr 12) and $3F)));
-    ASB.AppendChar(Chr($80 or ((CodePoint shr 6) and $3F)));
-    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
-  end
-  else
-    Exit(False);
-  Result := True;
+  // Convert code point to UTF-8 via shared helper
+  Result := CodePoint <= $10FFFF;
+  if Result then
+    ASB.Append(CodePointToUTF8(CodePoint));
 end;
 
 // TC39 Template Literal Revision — cook a hex escape from a raw segment.

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -1167,6 +1167,7 @@ function CookUnicodeEscape(const AStr: string; var APos: Integer;
   var ASB: TStringBuffer): Boolean;
 var
   CodePoint, LowSurrogate: Cardinal;
+  CodePointValue: QWord;
   HexStr: string;
   HexStart, I, SavedPos: Integer;
 begin
@@ -1185,9 +1186,12 @@ begin
     if (HexStr = '') or not IsValidHexString(HexStr) then
       Exit(False);
     Inc(APos); // skip '}'
-    CodePoint := StrToInt('$' + HexStr);
-    if CodePoint > $10FFFF then
+    // Use TryStrToQWord to safely handle arbitrarily long hex payloads
+    // without raising on overflow (e.g. \u{FFFFFFFF}).
+    if not TryStrToQWord('$' + HexStr, CodePointValue) or
+       (CodePointValue > $10FFFF) then
       Exit(False);
+    CodePoint := Cardinal(CodePointValue);
   end
   else
   begin

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -1450,17 +1450,25 @@ begin
   ExtractTemplateParts(AToken.Lexeme, CookedFull, RawFull, HasInvalidEscapes);
 
   // TC39 Template Literal Revision: untagged templates must still reject
-  // malformed escape sequences at parse time.
+  // malformed escape sequences at parse time.  HasInvalidEscapes is set for
+  // the whole flat token (including ${...} bodies), so we split into static
+  // segments first and only reject if a static segment has an invalid escape.
   if HasInvalidEscapes then
-    raise TGocciaSyntaxError.Create('Invalid escape sequence in template literal',
-      AToken.Line, AToken.Column, FFileName, FSourceLines, '');
-
-  SplitTemplateAtBoundaries(CookedFull, RawFull, CookedSegments, RawSegments, ExprTexts);
+  begin
+    SplitRawAtBoundaries(RawFull, RawSegments, ExprTexts);
+    SetLength(CookedSegments, Length(RawSegments));
+    for I := 0 to Length(RawSegments) - 1 do
+      if not CookRawSegment(RawSegments[I], CookedSegments[I]) then
+        raise TGocciaSyntaxError.Create('Invalid escape sequence in template literal',
+          AToken.Line, AToken.Column, FFileName, FSourceLines, '');
+  end
+  else
+    SplitTemplateAtBoundaries(CookedFull, RawFull, CookedSegments, RawSegments, ExprTexts);
 
   // No real interpolations — return a simple template literal
   if Length(ExprTexts) = 0 then
   begin
-    Result := TGocciaTemplateLiteralExpression.Create(CookedFull, AToken.Line, AToken.Column);
+    Result := TGocciaTemplateLiteralExpression.Create(CookedSegments[0], AToken.Line, AToken.Column);
     Exit;
   end;
 

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -196,6 +196,8 @@ implementation
 uses
   SysUtils,
 
+  StringBuffer,
+
   Goccia.Error,
   Goccia.Error.Suggestions,
   Goccia.Keywords.Contextual,
@@ -868,6 +870,19 @@ begin
   end;
 end;
 
+// Validate that all characters in a string are hexadecimal digits.
+function IsValidHexString(const AValue: string): Boolean;
+var
+  I: Integer;
+begin
+  if Length(AValue) = 0 then
+    Exit(False);
+  for I := 1 to Length(AValue) do
+    if not CharInSet(AValue[I], ['0'..'9', 'a'..'f', 'A'..'F']) then
+      Exit(False);
+  Result := True;
+end;
+
 // Compute the UTF-8 byte count for a Unicode code point.
 function UTF8ByteCount(const ACodePoint: Cardinal): Integer; inline;
 begin
@@ -1049,12 +1064,26 @@ begin
 end;
 
 // Extract cooked and raw full strings from a template token lexeme.
-procedure ExtractTemplateParts(const ALexeme: string; out ACookedFull, ARawFull: string);
+// AHasInvalidEscapes is True when the lexer used the #2 separator to signal
+// that the template contains at least one malformed escape sequence.
+procedure ExtractTemplateParts(const ALexeme: string;
+  out ACookedFull, ARawFull: string; out AHasInvalidEscapes: Boolean);
 const
   TEMPLATE_RAW_SEPARATOR = #1;
+  TEMPLATE_INVALID_ESCAPE_SEPARATOR = #2;
 var
   SepPos: Integer;
 begin
+  AHasInvalidEscapes := False;
+  // Check for the invalid-escape separator first
+  SepPos := Pos(TEMPLATE_INVALID_ESCAPE_SEPARATOR, ALexeme);
+  if SepPos > 0 then
+  begin
+    AHasInvalidEscapes := True;
+    ACookedFull := Copy(ALexeme, 1, SepPos - 1);
+    ARawFull := Copy(ALexeme, SepPos + 1, MaxInt);
+    Exit;
+  end;
   SepPos := Pos(TEMPLATE_RAW_SEPARATOR, ALexeme);
   if SepPos > 0 then
   begin
@@ -1066,6 +1095,249 @@ begin
     ACookedFull := ALexeme;
     ARawFull := ALexeme;
   end;
+end;
+
+// TC39 Template Literal Revision — split a raw template string at real ${...}
+// interpolation boundaries.  Uses only the raw string (no cooked tracking).
+// For boundary detection, skipping \ + 1 char is sufficient because \$ in
+// raw is two characters and never matches the ${ boundary pattern.
+procedure SplitRawAtBoundaries(const ARawFull: string;
+  out ARawSegments, AExpressionTexts: TGocciaTemplateStrings);
+var
+  RawI, StartRaw, SegmentCount, ExprCount, ExprStartRaw, BraceCount: Integer;
+begin
+  SetLength(ARawSegments, 0);
+  SetLength(AExpressionTexts, 0);
+  SegmentCount := 0;
+  ExprCount := 0;
+  RawI := 1;
+  StartRaw := 1;
+
+  while RawI <= Length(ARawFull) do
+  begin
+    if ARawFull[RawI] = '\' then
+    begin
+      // Skip \ and the next character (handles \$, \\, \n, etc.)
+      Inc(RawI, 2);
+    end
+    else if (ARawFull[RawI] = '$') and (RawI < Length(ARawFull)) and
+            (ARawFull[RawI + 1] = '{') then
+    begin
+      // Real interpolation boundary
+      SetLength(ARawSegments, SegmentCount + 1);
+      ARawSegments[SegmentCount] := Copy(ARawFull, StartRaw, RawI - StartRaw);
+      Inc(SegmentCount);
+
+      Inc(RawI, 2); // skip ${
+      ExprStartRaw := RawI;
+
+      // Find matching } by brace counting
+      BraceCount := 1;
+      while (RawI <= Length(ARawFull)) and (BraceCount > 0) do
+      begin
+        if ARawFull[RawI] = '{' then
+          Inc(BraceCount)
+        else if ARawFull[RawI] = '}' then
+          Dec(BraceCount);
+        if BraceCount > 0 then
+          Inc(RawI);
+      end;
+
+      SetLength(AExpressionTexts, ExprCount + 1);
+      AExpressionTexts[ExprCount] := Trim(Copy(ARawFull, ExprStartRaw, RawI - ExprStartRaw));
+      Inc(ExprCount);
+
+      Inc(RawI); // skip closing }
+      StartRaw := RawI;
+    end
+    else
+      Inc(RawI);
+  end;
+
+  // Final segment
+  SetLength(ARawSegments, SegmentCount + 1);
+  ARawSegments[SegmentCount] := Copy(ARawFull, StartRaw, RawI - StartRaw);
+end;
+
+// TC39 Template Literal Revision — cook a Unicode escape from a raw segment.
+// AStr is the raw text, APos is the current position (after 'u' has been
+// consumed). On success, appends the resolved character(s) to ASB and advances
+// APos. Returns False on malformed escape.
+function CookUnicodeEscape(const AStr: string; var APos: Integer;
+  var ASB: TStringBuffer): Boolean;
+var
+  CodePoint, LowSurrogate: Cardinal;
+  HexStr: string;
+  HexStart, I, SavedPos: Integer;
+begin
+  if APos > Length(AStr) then
+    Exit(False);
+
+  if AStr[APos] = '{' then
+  begin
+    Inc(APos); // skip '{'
+    HexStart := APos;
+    while (APos <= Length(AStr)) and (AStr[APos] <> '}') do
+      Inc(APos);
+    if APos > Length(AStr) then
+      Exit(False); // unterminated
+    HexStr := Copy(AStr, HexStart, APos - HexStart);
+    if (HexStr = '') or not IsValidHexString(HexStr) then
+      Exit(False);
+    Inc(APos); // skip '}'
+    CodePoint := StrToInt('$' + HexStr);
+    if CodePoint > $10FFFF then
+      Exit(False);
+  end
+  else
+  begin
+    HexStart := APos;
+    for I := 1 to 4 do
+    begin
+      if APos > Length(AStr) then
+        Exit(False);
+      Inc(APos);
+    end;
+    HexStr := Copy(AStr, HexStart, 4);
+    if not IsValidHexString(HexStr) then
+      Exit(False);
+    CodePoint := StrToInt('$' + HexStr);
+  end;
+
+  // ES2026 §12.9.4: Combine UTF-16 surrogate pairs
+  if (CodePoint >= $D800) and (CodePoint <= $DBFF) and
+     (APos + 5 <= Length(AStr)) and
+     (AStr[APos] = '\') and (AStr[APos + 1] = 'u') then
+  begin
+    SavedPos := APos;
+    Inc(APos, 2); // skip \u
+    HexStr := Copy(AStr, APos, 4);
+    if (Length(HexStr) = 4) and IsValidHexString(HexStr) then
+    begin
+      LowSurrogate := StrToInt('$' + HexStr);
+      if (LowSurrogate >= $DC00) and (LowSurrogate <= $DFFF) then
+      begin
+        CodePoint := $10000 + ((CodePoint - $D800) shl 10) + (LowSurrogate - $DC00);
+        Inc(APos, 4);
+      end
+      else
+        APos := SavedPos; // not a surrogate pair, restore
+    end
+    else
+      APos := SavedPos;
+  end;
+
+  // Convert code point to UTF-8
+  if CodePoint <= $7F then
+    ASB.AppendChar(Chr(CodePoint))
+  else if CodePoint <= $7FF then
+  begin
+    ASB.AppendChar(Chr($C0 or (CodePoint shr 6)));
+    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
+  end
+  else if CodePoint <= $FFFF then
+  begin
+    ASB.AppendChar(Chr($E0 or (CodePoint shr 12)));
+    ASB.AppendChar(Chr($80 or ((CodePoint shr 6) and $3F)));
+    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
+  end
+  else if CodePoint <= $10FFFF then
+  begin
+    ASB.AppendChar(Chr($F0 or (CodePoint shr 18)));
+    ASB.AppendChar(Chr($80 or ((CodePoint shr 12) and $3F)));
+    ASB.AppendChar(Chr($80 or ((CodePoint shr 6) and $3F)));
+    ASB.AppendChar(Chr($80 or (CodePoint and $3F)));
+  end
+  else
+    Exit(False);
+  Result := True;
+end;
+
+// TC39 Template Literal Revision — cook a hex escape from a raw segment.
+// AStr is the raw text, APos is the current position (after 'x' has been
+// consumed). On success, appends the resolved character to ASB and advances
+// APos. Returns False on malformed escape.
+function CookHexEscape(const AStr: string; var APos: Integer;
+  var ASB: TStringBuffer): Boolean;
+var
+  HexStr: string;
+  CodePoint: Cardinal;
+begin
+  if APos + 1 > Length(AStr) then
+    Exit(False);
+  HexStr := Copy(AStr, APos, 2);
+  if not IsValidHexString(HexStr) then
+    Exit(False);
+  Inc(APos, 2);
+  CodePoint := StrToInt('$' + HexStr);
+  ASB.AppendChar(Chr(CodePoint));
+  Result := True;
+end;
+
+// TC39 Template Literal Revision — cook a raw template segment into its
+// cooked string value by resolving escape sequences.  Returns True if all
+// escapes are valid (ACooked receives the cooked value).  Returns False if
+// any escape is malformed (the segment's cooked value should be undefined).
+function CookRawSegment(const ARawSegment: string; out ACooked: string): Boolean;
+var
+  SB: TStringBuffer;
+  I: Integer;
+begin
+  SB := TStringBuffer.Create;
+  Result := True;
+  I := 1;
+  while I <= Length(ARawSegment) do
+  begin
+    if ARawSegment[I] = '\' then
+    begin
+      Inc(I); // skip '\'
+      if I > Length(ARawSegment) then
+      begin
+        Result := False;
+        Break;
+      end;
+      case ARawSegment[I] of
+        'n': begin SB.AppendChar(#10); Inc(I); end;
+        'r': begin SB.AppendChar(#13); Inc(I); end;
+        't': begin SB.AppendChar(#9); Inc(I); end;
+        '\': begin SB.AppendChar('\'); Inc(I); end;
+        '0': begin SB.AppendChar(#0); Inc(I); end;
+        '`': begin SB.AppendChar('`'); Inc(I); end;
+        '$': begin SB.AppendChar('$'); Inc(I); end;
+        'u':
+        begin
+          Inc(I); // skip 'u'
+          if not CookUnicodeEscape(ARawSegment, I, SB) then
+          begin
+            Result := False;
+            Break;
+          end;
+        end;
+        'x':
+        begin
+          Inc(I); // skip 'x'
+          if not CookHexEscape(ARawSegment, I, SB) then
+          begin
+            Result := False;
+            Break;
+          end;
+        end;
+      else
+        SB.AppendChar(ARawSegment[I]);
+        Inc(I);
+      end;
+    end
+    else
+    begin
+      SB.AppendChar(ARawSegment[I]);
+      Inc(I);
+    end;
+  end;
+
+  if Result then
+    ACooked := SB.ToString
+  else
+    ACooked := '';
 end;
 
 // Parse a template interpolation expression text into an AST expression node.
@@ -1111,20 +1383,42 @@ begin
 end;
 
 // ES2026 §13.3.11 Tagged Templates
+// TC39 Template Literal Revision: when the template contains malformed escapes,
+// split from the raw string and re-cook each segment individually, marking
+// invalid segments so the evaluator emits undefined for their cooked values.
 function TGocciaParser.ParseTaggedTemplate(const ATag: TGocciaExpression;
   const ATemplateToken: TGocciaToken;
   const ALine, AColumn: Integer): TGocciaTaggedTemplateExpression;
 var
   CookedFull, RawFull: string;
   CookedStrings, RawStrings, ExprTexts: TGocciaTemplateStrings;
+  CookedValid: TGocciaTemplateCookedValid;
   Expressions: TObjectList<TGocciaExpression>;
   ParsedExpr: TGocciaExpression;
+  HasInvalidEscapes: Boolean;
   I: Integer;
 begin
-  ExtractTemplateParts(ATemplateToken.Lexeme, CookedFull, RawFull);
+  ExtractTemplateParts(ATemplateToken.Lexeme, CookedFull, RawFull, HasInvalidEscapes);
 
-  // Split at real interpolation boundaries using raw string for detection
-  SplitTemplateAtBoundaries(CookedFull, RawFull, CookedStrings, RawStrings, ExprTexts);
+  if HasInvalidEscapes then
+  begin
+    // TC39 Template Literal Revision: the cooked string from the lexer is
+    // unreliable because invalid escapes were skipped.  Split using the raw
+    // string only and re-cook each segment individually.
+    SplitRawAtBoundaries(RawFull, RawStrings, ExprTexts);
+    SetLength(CookedStrings, Length(RawStrings));
+    SetLength(CookedValid, Length(RawStrings));
+    for I := 0 to Length(RawStrings) - 1 do
+      CookedValid[I] := CookRawSegment(RawStrings[I], CookedStrings[I]);
+  end
+  else
+  begin
+    // No invalid escapes — use the existing dual-tracking split
+    SplitTemplateAtBoundaries(CookedFull, RawFull, CookedStrings, RawStrings, ExprTexts);
+    SetLength(CookedValid, Length(CookedStrings));
+    for I := 0 to Length(CookedStrings) - 1 do
+      CookedValid[I] := True;
+  end;
 
   // Parse each interpolation expression into an AST node
   Expressions := TObjectList<TGocciaExpression>.Create(True);
@@ -1136,21 +1430,31 @@ begin
   end;
 
   Result := TGocciaTaggedTemplateExpression.Create(ATag, CookedStrings, RawStrings,
-    Expressions, ALine, AColumn);
+    CookedValid, Expressions, ALine, AColumn);
 end;
 
 // ES2026 §13.2.8 Template Literals — pre-segment non-tagged templates at parse
 // time using raw-string boundary detection, so that escaped dollar signs (\$)
 // are never mistaken for interpolation boundaries at evaluation time.
+// TC39 Template Literal Revision: untagged templates with malformed escape
+// sequences raise SyntaxError at parse time (preserving existing behavior).
 function TGocciaParser.ParseTemplateLiteral(const AToken: TGocciaToken): TGocciaExpression;
 var
   CookedFull, RawFull: string;
+  HasInvalidEscapes: Boolean;
   CookedSegments, RawSegments, ExprTexts: TGocciaTemplateStrings;
   Parts: TObjectList<TGocciaExpression>;
   ParsedExpr: TGocciaExpression;
   I: Integer;
 begin
-  ExtractTemplateParts(AToken.Lexeme, CookedFull, RawFull);
+  ExtractTemplateParts(AToken.Lexeme, CookedFull, RawFull, HasInvalidEscapes);
+
+  // TC39 Template Literal Revision: untagged templates must still reject
+  // malformed escape sequences at parse time.
+  if HasInvalidEscapes then
+    raise TGocciaSyntaxError.Create('Invalid escape sequence in template literal',
+      AToken.Line, AToken.Column, FFileName, FSourceLines, '');
+
   SplitTemplateAtBoundaries(CookedFull, RawFull, CookedSegments, RawSegments, ExprTexts);
 
   // No real interpolations — return a simple template literal

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -1741,8 +1741,15 @@ begin
     CookedArray := TGocciaArrayValue.Create;
     TGarbageCollector.Instance.AddTempRoot(CookedArray);
     try
+      // TC39 Template Literal Revision: segments with malformed escapes get
+      // cooked=undefined; valid segments get the resolved string value.
       for I := 0 to Length(Constant.CookedStrings) - 1 do
-        CookedArray.Elements.Add(TGocciaStringLiteralValue.Create(Constant.CookedStrings[I]));
+      begin
+        if (I < Length(Constant.CookedValid)) and not Constant.CookedValid[I] then
+          CookedArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue)
+        else
+          CookedArray.Elements.Add(TGocciaStringLiteralValue.Create(Constant.CookedStrings[I]));
+      end;
       // ES2026 §13.2.8.3 step 8: raw is non-enumerable, non-writable, non-configurable
       CookedArray.DefineProperty(PROP_RAW,
         TGocciaPropertyDescriptorData.Create(RawArray, []));


### PR DESCRIPTION
## Summary
- Implement the [TC39 Template Literal Revision](https://tc39.es/proposal-template-literal-revision/) (ES2018): tagged template literals now tolerate malformed escape sequences (`\u{`, `\xG1`, incomplete `\u` escapes, code points > U+10FFFF) by setting the cooked segment to `undefined` while preserving the raw source text in `strings.raw`.
- Untagged template literals continue to throw `SyntaxError` for the same invalid escapes, preserving existing behavior.
- The implementation spans the full pipeline: lexer (template-aware escape scanners), parser (per-segment re-cooking from raw), AST (`CookedValid` flags), evaluator, compiler, bytecode serialization (`.gbc`), and VM.
- Closes #269

## Testing
- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - 13 new test cases in `tagged-templates.js` covering `\xG1`, `\u{`, `\u{ZZZZ}`, `\u00`, `\xQQ`, mixed valid/invalid segments, frozen objects, expression evaluation, call-site identity, code point > U+10FFFF, and valid escapes still working
  - All 48 string expression tests pass in both interpreted and bytecode modes
  - Full test suite (3602 tests) passes with no new regressions
  - `.gbc` serialization round-trip verified for templates with invalid escapes
- [x] Updated documentation
  - `docs/language-restrictions.md` updated to document TC39 Template Literal Revision support

🤖 Generated with [Claude Code](https://claude.com/claude-code)