### PR TITLE
Fix lexically aware template boundaries and line terminators

### DIFF
--- a/tests/language/expressions/string/tagged-templates.js
+++ b/tests/language/expressions/string/tagged-templates.js
@@ -407,4 +407,56 @@ describe("tagged templates", () => {
     expect(cooked).toBe("A");
     expect(raw).toBe("\\x41");
   });
+
+  test("interpolation with string containing } preserves segments", () => {
+    let strings;
+    let values;
+    const tag = (s, ...v) => { strings = s; values = v; };
+    tag`a${"}"}b`;
+    expect(strings[0]).toBe("a");
+    expect(strings[1]).toBe("b");
+    expect(values[0]).toBe("}");
+  });
+
+  test("interpolation with object literal preserves segments", () => {
+    let strings;
+    let values;
+    const tag = (s, ...v) => { strings = s; values = v; };
+    tag`start${{x: 1}}end`;
+    expect(strings[0]).toBe("start");
+    expect(strings[1]).toBe("end");
+    expect(typeof values[0]).toBe("object");
+  });
+
+  test("interpolation with block comment containing } preserves segments", () => {
+    let strings;
+    let values;
+    const tag = (s, ...v) => { strings = s; values = v; };
+    tag`pre${/*}*/42}post`;
+    expect(strings[0]).toBe("pre");
+    expect(strings[1]).toBe("post");
+    expect(values[0]).toBe(42);
+  });
+
+  test("interpolation with nested template preserves segments", () => {
+    let strings;
+    let values;
+    const tag = (s, ...v) => { strings = s; values = v; };
+    tag`outer${`inner`}tail`;
+    expect(strings[0]).toBe("outer");
+    expect(strings[1]).toBe("tail");
+    expect(values[0]).toBe("inner");
+  });
+
+  test("malformed escape with complex interpolation boundary", () => {
+    let cooked;
+    let raw;
+    let values;
+    const tag = (s, ...v) => { cooked = s; raw = s.raw; values = v; };
+    tag`\xGG${"}"}end`;
+    expect(cooked[0]).toBe(undefined);
+    expect(raw[0]).toBe("\\xGG");
+    expect(cooked[1]).toBe("end");
+    expect(values[0]).toBe("}");
+  });
 });

--- a/tests/language/expressions/string/template-interpolation-boundaries.js
+++ b/tests/language/expressions/string/template-interpolation-boundaries.js
@@ -121,4 +121,10 @@ describe("template interpolation boundary detection", () => {
     const x = `${a}|${b}|${c}`;
     expect(x).toBe("[object Object]|}|3");
   });
+
+  test("line comment at end of interpolation expression", () => {
+    const x = `${1 // trailing comment
+}`;
+    expect(x).toBe("1");
+  });
 });

--- a/tests/language/expressions/string/template-interpolation-boundaries.js
+++ b/tests/language/expressions/string/template-interpolation-boundaries.js
@@ -1,0 +1,124 @@
+/*---
+description: Lexically-aware ${...} boundary detection in template literals
+features: [template-literals, interpolation-boundaries]
+---*/
+
+describe("template interpolation boundary detection", () => {
+  test("string literal containing } inside interpolation", () => {
+    const x = `${"}"}`;
+    expect(x).toBe("}");
+  });
+
+  test("string literal containing { inside interpolation", () => {
+    const x = `${"{"}`;
+    expect(x).toBe("{");
+  });
+
+  test("single-quoted string containing } inside interpolation", () => {
+    const x = `${'}'}`;
+    expect(x).toBe("}");
+  });
+
+  test("string with escaped quote and } inside interpolation", () => {
+    const x = `${"\"}\""}`;
+    expect(x).toBe("\"}\"");
+  });
+
+  test("object literal inside interpolation", () => {
+    const x = `${{a: 1}}`;
+    expect(x).toBe("[object Object]");
+  });
+
+  test("nested object literal inside interpolation", () => {
+    const x = `${{a: {b: 2}}}`;
+    expect(x).toBe("[object Object]");
+  });
+
+  test("block comment containing } inside interpolation", () => {
+    const x = `${/*}*/1}`;
+    expect(x).toBe("1");
+  });
+
+  test("block comment containing { inside interpolation", () => {
+    const x = `${/*{*/2}`;
+    expect(x).toBe("2");
+  });
+
+  test("block comment containing multiple braces", () => {
+    const x = `${/*}{}{*/3}`;
+    expect(x).toBe("3");
+  });
+
+  test("line comment containing } inside interpolation", () => {
+    const x = `${
+      1 // }
+      + 2
+    }`;
+    expect(x.trim()).toBe("3");
+  });
+
+  test("nested template literal inside interpolation", () => {
+    const x = `${`nested`}`;
+    expect(x).toBe("nested");
+  });
+
+  test("nested template with its own interpolation", () => {
+    const y = 42;
+    const x = `${`inner ${y}`}`;
+    expect(x).toBe("inner 42");
+  });
+
+  test("nested template containing } in static text", () => {
+    const x = `${`a}b`}`;
+    expect(x).toBe("a}b");
+  });
+
+  test("deeply nested templates", () => {
+    const a = 1;
+    const b = 2;
+    const x = `${`${`${a + b}`}`}`;
+    expect(x).toBe("3");
+  });
+
+  test("mixed: object literal and string with } in same template", () => {
+    const obj = {x: 1};
+    const x = `${obj} and ${"}"}`;
+    expect(x).toBe("[object Object] and }");
+  });
+
+  test("ternary with object literals inside interpolation", () => {
+    const cond = true;
+    const x = `${cond ? {a: 1} : {b: 2}}`;
+    expect(x).toBe("[object Object]");
+  });
+
+  test("arrow function with braces inside interpolation", () => {
+    const fn = (x) => { return x + 1; };
+    const x = `${fn(2)}`;
+    expect(x).toBe("3");
+  });
+
+  test("array with nested objects inside interpolation", () => {
+    const arr = [{a: 1}, {b: 2}];
+    const x = `${arr.length}`;
+    expect(x).toBe("2");
+  });
+
+  test("empty interpolation followed by normal text", () => {
+    const x = `${""}end`;
+    expect(x).toBe("end");
+  });
+
+  test("escaped dollar-brace is not an interpolation boundary", () => {
+    const x = `\${not interpolated}`;
+    expect(x).toBe("${not interpolated}");
+  });
+
+  test("multiple interpolations with complex expressions", () => {
+    const a = {x: 1};
+    const b = "}";
+    const c = /*}*/ 3;
+    const x = `${a}|${b}|${c}`;
+    expect(x).toBe("[object Object]|}|3");
+  });
+});

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -748,6 +748,8 @@ begin
   end;
 end;
 
+// ES2026 §12.9.4 Template Literal Lexical Components
+//
 // Scans a template interpolation expression with full lexical awareness.
 // Called after ${ has been consumed.  Tracks brace depth starting at 1 and
 // stops when the matching } is found WITHOUT consuming it — the caller is
@@ -866,11 +868,11 @@ begin
         begin
           if Peek = '/' then
           begin
-            // Line comment — consume until end of line
+            // Line comment — consume until line terminator (LF, CR, LS, PS)
             C := Advance;
             ASB.AppendChar(C);
             ARawSB.AppendChar(C);
-            while not IsAtEnd and (Peek <> #10) and (Peek <> #13) do
+            while not IsAtEnd and not IsLineTerminator do
             begin
               C := Advance;
               ASB.AppendChar(C);

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -59,6 +59,15 @@ type
     function ScanUnicodeEscapeForTemplate(var ASB: TStringBuffer): Boolean;
     function ScanHexEscapeForTemplate(var ASB: TStringBuffer): Boolean;
     procedure ProcessTemplateEscapeSequence(var ASB: TStringBuffer; var ASegmentValid: Boolean);
+    // Lexically-aware ${...} boundary detection for template literals.
+    // ScanInterpolationExpression scans an expression body after ${ has been
+    // consumed, tracking braces, strings, comments, and nested templates.
+    // Stops without consuming the matching }.
+    procedure ScanInterpolationExpression(var ASB, ARawSB: TStringBuffer);
+    // Scans a nested template literal body within an interpolation expression.
+    // Called after the opening backtick has been consumed and appended.
+    // Handles \`, \$, and nested ${...} via mutual recursion.
+    procedure ScanNestedTemplateInExpression(var ASB, ARawSB: TStringBuffer);
     procedure UpdateRegexContext(const ATokenType: TGocciaTokenType);
     procedure PushParenRegexContext(const AAllowsRegexAfter: Boolean);
     function PopParenRegexContext: Boolean;
@@ -627,6 +636,304 @@ begin
   end;
 end;
 
+// Scans a nested template literal body within an interpolation expression.
+// Called after the opening backtick has been consumed and appended to the
+// buffers.  Consumes characters up to and including the closing backtick,
+// appending all content to both ASB and ARawSB verbatim.  Handles escaped
+// backticks (\`), escaped dollars (\$), and nested ${...} interpolations
+// via mutual recursion with ScanInterpolationExpression.
+procedure TGocciaLexer.ScanNestedTemplateInExpression(var ASB, ARawSB: TStringBuffer);
+var
+  C: Char;
+begin
+  while not IsAtEnd do
+  begin
+    C := Peek;
+    case C of
+      '`':
+      begin
+        // Closing backtick of nested template
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+        Exit;
+      end;
+      '\':
+      begin
+        // Escape sequence — consume \ and next char verbatim
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+        if not IsAtEnd then
+        begin
+          C := Advance;
+          ASB.AppendChar(C);
+          ARawSB.AppendChar(C);
+        end;
+      end;
+      '$':
+      begin
+        if PeekNext = '{' then
+        begin
+          // Nested interpolation within nested template
+          Advance; // consume $
+          ASB.AppendChar('$');
+          ARawSB.AppendChar('$');
+          Advance; // consume {
+          ASB.AppendChar('{');
+          ARawSB.AppendChar('{');
+          ScanInterpolationExpression(ASB, ARawSB);
+          // ScanInterpolationExpression leaves the closing } unconsumed
+          if not IsAtEnd then
+          begin
+            Advance; // consume }
+            ASB.AppendChar('}');
+            ARawSB.AppendChar('}');
+          end;
+        end
+        else
+        begin
+          Advance;
+          ASB.AppendChar(C);
+          ARawSB.AppendChar(C);
+        end;
+      end;
+      #13:
+      begin
+        Advance;
+        if Peek = #10 then
+          Advance;
+        Inc(FLine);
+        FColumn := 0;
+        ASB.AppendChar(#10);
+        ARawSB.AppendChar(#10);
+      end;
+      #10:
+      begin
+        Inc(FLine);
+        FColumn := 0;
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+      end;
+    else
+      begin
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+      end;
+    end;
+  end;
+end;
+
+// Scans a template interpolation expression with full lexical awareness.
+// Called after ${ has been consumed.  Tracks brace depth starting at 1 and
+// stops when the matching } is found WITHOUT consuming it — the caller is
+// responsible for consuming the closing }.  All characters within the
+// expression body are appended verbatim to both ASB and ARawSB.
+//
+// Lexical constructs handled:
+//   - Nested braces {…}
+//   - String literals '…' and "…" (with \ escapes)
+//   - Template literals `…` (with nested ${…} via mutual recursion)
+//   - Line comments //…
+//   - Block comments /*…*/
+//   - Line terminators (CR, CRLF, LF) with line/column tracking
+procedure TGocciaLexer.ScanInterpolationExpression(var ASB, ARawSB: TStringBuffer);
+var
+  BraceCount: Integer;
+  C, Quote: Char;
+begin
+  BraceCount := 1;
+  while (BraceCount > 0) and not IsAtEnd do
+  begin
+    C := Peek;
+    case C of
+      '{':
+      begin
+        Inc(BraceCount);
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+      end;
+      '}':
+      begin
+        Dec(BraceCount);
+        if BraceCount > 0 then
+        begin
+          Advance;
+          ASB.AppendChar(C);
+          ARawSB.AppendChar(C);
+        end;
+        // When BraceCount = 0, leave the closing } unconsumed for the caller
+      end;
+      '''', '"':
+      begin
+        // String literal — scan until matching unescaped quote
+        Quote := C;
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+        while not IsAtEnd do
+        begin
+          C := Peek;
+          if C = '\' then
+          begin
+            // Escape — consume \ and the next character verbatim
+            Advance;
+            ASB.AppendChar(C);
+            ARawSB.AppendChar(C);
+            if not IsAtEnd then
+            begin
+              C := Advance;
+              ASB.AppendChar(C);
+              ARawSB.AppendChar(C);
+            end;
+          end
+          else if C = Quote then
+          begin
+            Advance;
+            ASB.AppendChar(C);
+            ARawSB.AppendChar(C);
+            Break;
+          end
+          else
+          begin
+            // Track line terminators inside strings
+            if C = #13 then
+            begin
+              Advance;
+              if Peek = #10 then
+                Advance;
+              Inc(FLine);
+              FColumn := 0;
+              ASB.AppendChar(#10);
+              ARawSB.AppendChar(#10);
+            end
+            else if C = #10 then
+            begin
+              Inc(FLine);
+              FColumn := 0;
+              Advance;
+              ASB.AppendChar(C);
+              ARawSB.AppendChar(C);
+            end
+            else
+            begin
+              Advance;
+              ASB.AppendChar(C);
+              ARawSB.AppendChar(C);
+            end;
+          end;
+        end;
+      end;
+      '`':
+      begin
+        // Nested template literal — delegate to mutual recursion
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+        ScanNestedTemplateInExpression(ASB, ARawSB);
+      end;
+      '/':
+      begin
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+        if not IsAtEnd then
+        begin
+          if Peek = '/' then
+          begin
+            // Line comment — consume until end of line
+            C := Advance;
+            ASB.AppendChar(C);
+            ARawSB.AppendChar(C);
+            while not IsAtEnd and (Peek <> #10) and (Peek <> #13) do
+            begin
+              C := Advance;
+              ASB.AppendChar(C);
+              ARawSB.AppendChar(C);
+            end;
+          end
+          else if Peek = '*' then
+          begin
+            // Block comment — consume until */
+            C := Advance; // consume *
+            ASB.AppendChar(C);
+            ARawSB.AppendChar(C);
+            while not IsAtEnd do
+            begin
+              C := Peek;
+              if C = '*' then
+              begin
+                Advance;
+                ASB.AppendChar(C);
+                ARawSB.AppendChar(C);
+                if not IsAtEnd and (Peek = '/') then
+                begin
+                  C := Advance;
+                  ASB.AppendChar(C);
+                  ARawSB.AppendChar(C);
+                  Break;
+                end;
+              end
+              else if C = #13 then
+              begin
+                Advance;
+                if Peek = #10 then
+                  Advance;
+                Inc(FLine);
+                FColumn := 0;
+                ASB.AppendChar(#10);
+                ARawSB.AppendChar(#10);
+              end
+              else if C = #10 then
+              begin
+                Inc(FLine);
+                FColumn := 0;
+                Advance;
+                ASB.AppendChar(C);
+                ARawSB.AppendChar(C);
+              end
+              else
+              begin
+                Advance;
+                ASB.AppendChar(C);
+                ARawSB.AppendChar(C);
+              end;
+            end;
+          end;
+          // If neither // nor /*, the / was already appended — continue
+        end;
+      end;
+      #13:
+      begin
+        Advance;
+        if Peek = #10 then
+          Advance;
+        Inc(FLine);
+        FColumn := 0;
+        ASB.AppendChar(#10);
+        ARawSB.AppendChar(#10);
+      end;
+      #10:
+      begin
+        Inc(FLine);
+        FColumn := 0;
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+      end;
+    else
+      begin
+        Advance;
+        ASB.AppendChar(C);
+        ARawSB.AppendChar(C);
+      end;
+    end;
+  end;
+end;
+
 procedure TGocciaLexer.PushParenRegexContext(const AAllowsRegexAfter: Boolean);
 begin
   if FParenRegexContextCount >= Length(FParenRegexContext) then
@@ -726,6 +1033,7 @@ procedure TGocciaLexer.ScanTemplate;
 const
   TEMPLATE_RAW_SEPARATOR = #1;
   TEMPLATE_INVALID_ESCAPE_SEPARATOR = #2;
+  TEMPLATE_EXPRESSION_BOUNDARY = #3;
 var
   SB: TStringBuffer;
   RawSB: TStringBuffer;
@@ -807,6 +1115,22 @@ begin
           end;
         end;
       end;
+    end
+    else if (Peek = '$') and (PeekNext = '{') then
+    begin
+      // Interpolation expression boundary — detect and record with lexical
+      // awareness so braces inside strings, comments, and nested templates
+      // do not confuse the boundary detection.
+      Advance; // consume $
+      Advance; // consume {
+      SB.AppendChar(TEMPLATE_EXPRESSION_BOUNDARY);
+      RawSB.AppendChar(TEMPLATE_EXPRESSION_BOUNDARY);
+      ScanInterpolationExpression(SB, RawSB);
+      // ScanInterpolationExpression leaves the closing } unconsumed
+      if not IsAtEnd then
+        Advance; // consume closing }
+      SB.AppendChar(TEMPLATE_EXPRESSION_BOUNDARY);
+      RawSB.AppendChar(TEMPLATE_EXPRESSION_BOUNDARY);
     end
     else
     begin

--- a/units/Goccia.Lexer.pas
+++ b/units/Goccia.Lexer.pas
@@ -645,6 +645,7 @@ end;
 procedure TGocciaLexer.ScanNestedTemplateInExpression(var ASB, ARawSB: TStringBuffer);
 var
   C: Char;
+  J: Integer;
 begin
   while not IsAtEnd do
   begin
@@ -704,7 +705,7 @@ begin
         if Peek = #10 then
           Advance;
         Inc(FLine);
-        FColumn := 0;
+        FColumn := 1;
         ASB.AppendChar(#10);
         ARawSB.AppendChar(#10);
       end;
@@ -715,6 +716,27 @@ begin
         Advance;
         ASB.AppendChar(C);
         ARawSB.AppendChar(C);
+      end;
+      UTF8_LINE_TERMINATOR_LEAD_BYTE:
+      begin
+        if IsUnicodeLineTerminator then
+        begin
+          for J := 0 to UTF8_LINE_TERMINATOR_BYTE_LENGTH - 1 do
+          begin
+            C := FSource[FCurrent + J];
+            ASB.AppendChar(C);
+            ARawSB.AppendChar(C);
+          end;
+          Inc(FCurrent, UTF8_LINE_TERMINATOR_BYTE_LENGTH);
+          Inc(FLine);
+          FColumn := 1;
+        end
+        else
+        begin
+          Advance;
+          ASB.AppendChar(C);
+          ARawSB.AppendChar(C);
+        end;
       end;
     else
       begin
@@ -738,10 +760,10 @@ end;
 //   - Template literals `…` (with nested ${…} via mutual recursion)
 //   - Line comments //…
 //   - Block comments /*…*/
-//   - Line terminators (CR, CRLF, LF) with line/column tracking
+//   - Line terminators (CR, CRLF, LF, LS, PS) with line/column tracking
 procedure TGocciaLexer.ScanInterpolationExpression(var ASB, ARawSB: TStringBuffer);
 var
-  BraceCount: Integer;
+  BraceCount, J: Integer;
   C, Quote: Char;
 begin
   BraceCount := 1;
@@ -806,7 +828,7 @@ begin
               if Peek = #10 then
                 Advance;
               Inc(FLine);
-              FColumn := 0;
+              FColumn := 1;
               ASB.AppendChar(#10);
               ARawSB.AppendChar(#10);
             end
@@ -883,7 +905,7 @@ begin
                 if Peek = #10 then
                   Advance;
                 Inc(FLine);
-                FColumn := 0;
+                FColumn := 1;
                 ASB.AppendChar(#10);
                 ARawSB.AppendChar(#10);
               end
@@ -912,7 +934,7 @@ begin
         if Peek = #10 then
           Advance;
         Inc(FLine);
-        FColumn := 0;
+        FColumn := 1;
         ASB.AppendChar(#10);
         ARawSB.AppendChar(#10);
       end;
@@ -923,6 +945,27 @@ begin
         Advance;
         ASB.AppendChar(C);
         ARawSB.AppendChar(C);
+      end;
+      UTF8_LINE_TERMINATOR_LEAD_BYTE:
+      begin
+        if IsUnicodeLineTerminator then
+        begin
+          for J := 0 to UTF8_LINE_TERMINATOR_BYTE_LENGTH - 1 do
+          begin
+            C := FSource[FCurrent + J];
+            ASB.AppendChar(C);
+            ARawSB.AppendChar(C);
+          end;
+          Inc(FCurrent, UTF8_LINE_TERMINATOR_BYTE_LENGTH);
+          Inc(FLine);
+          FColumn := 1;
+        end
+        else
+        begin
+          Advance;
+          ASB.AppendChar(C);
+          ARawSB.AppendChar(C);
+        end;
       end;
     else
       begin

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -883,184 +883,83 @@ begin
   Result := True;
 end;
 
-// Compute the UTF-8 byte count for a Unicode code point.
-function UTF8ByteCount(const ACodePoint: Cardinal): Integer; inline;
+
+// Split a string at #3 (TEMPLATE_EXPRESSION_BOUNDARY) markers embedded by the
+// lexer during ScanTemplate.  Returns all parts: even-indexed parts are static
+// template segments, odd-indexed parts are interpolation expression texts.
+procedure SplitOnBoundaryMarker(const AStr: string; out AParts: TGocciaTemplateStrings);
+const
+  TEMPLATE_EXPRESSION_BOUNDARY = #3;
+var
+  I, Start, PartCount: Integer;
 begin
-  if ACodePoint <= $7F then
-    Result := 1
-  else if ACodePoint <= $7FF then
-    Result := 2
-  else if ACodePoint <= $FFFF then
-    Result := 3
-  else
-    Result := 4;
+  SetLength(AParts, 0);
+  PartCount := 0;
+  Start := 1;
+  for I := 1 to Length(AStr) do
+  begin
+    if AStr[I] = TEMPLATE_EXPRESSION_BOUNDARY then
+    begin
+      SetLength(AParts, PartCount + 1);
+      AParts[PartCount] := Copy(AStr, Start, I - Start);
+      Inc(PartCount);
+      Start := I + 1;
+    end;
+  end;
+  // Final part (after last marker, or entire string if no markers)
+  SetLength(AParts, PartCount + 1);
+  AParts[PartCount] := Copy(AStr, Start, Length(AStr) - Start + 1);
 end;
 
-// Parse a hex string into a cardinal, returning 0 on invalid input.
-function SafeHexToCardinal(const AHexStr: string): Cardinal;
-begin
-  if AHexStr = '' then
-    Result := 0
-  else
-    Result := Cardinal(StrToIntDef('$' + AHexStr, 0));
-end;
-
-// Split a template token's cooked and raw strings at real ${...} interpolation
-// boundaries. Uses the raw string for boundary detection (where \$ is preserved
-// as two characters, preventing phantom boundaries from escaped dollar signs).
-// Walks both strings in parallel, tracking how escape sequences map between the
-// two representations.
-//
-// The escape length mapping mirrors Goccia.Lexer.ScanTemplate exactly:
-//   \$ \` \n \r \t \\ \0 \<other>: raw=2, cooked=1
-//   \xHH:                          raw=4, cooked=1
-//   \uHHHH:                        raw=6, cooked=UTF8ByteCount(codepoint)
-//   \uHHHH\uHHHH (surrogate pair): raw=12, cooked=UTF8ByteCount(combined)
-//   \u{H...}:                       raw=4+len(hex), cooked=UTF8ByteCount(codepoint)
+// Split a template token's cooked and raw strings at interpolation boundaries.
+// The lexer embeds #3 boundary markers around expression texts during
+// ScanTemplate with full lexical awareness (strings, comments, nested
+// templates), so this function simply splits on those markers.
+// Even-indexed parts are static segments; odd-indexed parts are expressions.
 procedure SplitTemplateAtBoundaries(const ACookedFull, ARawFull: string;
   out ACookedSegments, ARawSegments: TGocciaTemplateStrings;
   out AExpressionTexts: TGocciaTemplateStrings);
-const
-  HIGH_SURROGATE_MIN = $D800;
-  HIGH_SURROGATE_MAX = $DBFF;
-  LOW_SURROGATE_MIN = $DC00;
-  LOW_SURROGATE_MAX = $DFFF;
-  SURROGATE_OFFSET = $10000;
-  SURROGATE_SHIFT = 10;
 var
-  RawI, CookedI, StartRaw, StartCooked, SegmentCount, ExprCount: Integer;
-  BraceCount, ExprStartRaw: Integer;
-  CodePoint, LowSurrogate: Cardinal;
-  HexStart, HexEnd: Integer;
+  CookedParts, RawParts: TGocciaTemplateStrings;
+  I, StaticCount, ExprCount: Integer;
 begin
-  SetLength(ACookedSegments, 0);
-  SetLength(ARawSegments, 0);
-  SetLength(AExpressionTexts, 0);
-  SegmentCount := 0;
+  SplitOnBoundaryMarker(ACookedFull, CookedParts);
+  SplitOnBoundaryMarker(ARawFull, RawParts);
+
+  // Even-indexed parts are static segments, odd-indexed are expressions
+  StaticCount := 0;
   ExprCount := 0;
-
-  RawI := 1;
-  CookedI := 1;
-  StartRaw := 1;
-  StartCooked := 1;
-
-  while RawI <= Length(ARawFull) do
+  for I := 0 to Length(RawParts) - 1 do
   begin
-    if ARawFull[RawI] = '\' then
-    begin
-      // Escape sequence in raw — advance past it in both strings.
-      // The raw string preserves escape sequences verbatim; the cooked string
-      // has the resolved value (produced by Goccia.Lexer.ScanTemplate).
-      Inc(RawI); // skip '\'
-      if RawI <= Length(ARawFull) then
-      begin
-        case ARawFull[RawI] of
-          'x':
-          begin
-            // \xHH: raw=4 total (\xHH), cooked=1 byte
-            Inc(RawI, 3); // skip 'x', H, H
-            Inc(CookedI);
-          end;
-          'u':
-          begin
-            Inc(RawI); // skip 'u'
-            if (RawI <= Length(ARawFull)) and (ARawFull[RawI] = '{') then
-            begin
-              // \u{H...}: variable raw length, cooked=UTF8ByteCount
-              Inc(RawI); // skip '{'
-              HexStart := RawI;
-              while (RawI <= Length(ARawFull)) and (ARawFull[RawI] <> '}') do
-                Inc(RawI);
-              HexEnd := RawI;
-              CodePoint := SafeHexToCardinal(Copy(ARawFull, HexStart, HexEnd - HexStart));
-              Inc(RawI); // skip '}'
-              Inc(CookedI, UTF8ByteCount(CodePoint));
-            end
-            else
-            begin
-              // \uHHHH: raw=6 total, cooked=UTF8ByteCount. May form surrogate pair.
-              CodePoint := SafeHexToCardinal(Copy(ARawFull, RawI, 4));
-              Inc(RawI, 4); // skip HHHH
-              // ES2026 §12.9.4: check for UTF-16 surrogate pair
-              if (CodePoint >= HIGH_SURROGATE_MIN) and (CodePoint <= HIGH_SURROGATE_MAX) and
-                 (RawI + 5 <= Length(ARawFull)) and
-                 (ARawFull[RawI] = '\') and (ARawFull[RawI + 1] = 'u') then
-              begin
-                LowSurrogate := SafeHexToCardinal(Copy(ARawFull, RawI + 2, 4));
-                if (LowSurrogate >= LOW_SURROGATE_MIN) and (LowSurrogate <= LOW_SURROGATE_MAX) then
-                begin
-                  CodePoint := SURROGATE_OFFSET +
-                    ((CodePoint - HIGH_SURROGATE_MIN) shl SURROGATE_SHIFT) +
-                    (LowSurrogate - LOW_SURROGATE_MIN);
-                  Inc(RawI, 6); // skip \uHHHH of low surrogate
-                end;
-              end;
-              Inc(CookedI, UTF8ByteCount(CodePoint));
-            end;
-          end;
-        else
-          // All other escapes: \n \r \t \\ \0 \$ \` \<other>
-          // raw=2 total (\ + char), cooked=1 byte
-          Inc(RawI); // skip the escaped character
-          Inc(CookedI);
-        end;
-      end;
-    end
-    else if (ARawFull[RawI] = '$') and (RawI < Length(ARawFull)) and
-            (ARawFull[RawI + 1] = '{') then
-    begin
-      // Real interpolation boundary (unescaped $ followed by {)
-      // Record the static text segments up to this point
-      SetLength(ACookedSegments, SegmentCount + 1);
-      ACookedSegments[SegmentCount] := Copy(ACookedFull, StartCooked, CookedI - StartCooked);
-      SetLength(ARawSegments, SegmentCount + 1);
-      ARawSegments[SegmentCount] := Copy(ARawFull, StartRaw, RawI - StartRaw);
-      Inc(SegmentCount);
-
-      // Skip ${ in both strings
-      Inc(RawI, 2);
-      Inc(CookedI, 2);
-      ExprStartRaw := RawI;
-
-      // Find matching } by brace counting (expression text is identical in both)
-      BraceCount := 1;
-      while (RawI <= Length(ARawFull)) and (BraceCount > 0) do
-      begin
-        if ARawFull[RawI] = '{' then
-          Inc(BraceCount)
-        else if ARawFull[RawI] = '}' then
-          Dec(BraceCount);
-        if BraceCount > 0 then
-        begin
-          Inc(RawI);
-          Inc(CookedI);
-        end;
-      end;
-
-      // Record expression text (identical in raw and cooked)
-      SetLength(AExpressionTexts, ExprCount + 1);
-      AExpressionTexts[ExprCount] := Trim(Copy(ARawFull, ExprStartRaw, RawI - ExprStartRaw));
+    if I mod 2 = 0 then
+      Inc(StaticCount)
+    else
       Inc(ExprCount);
+  end;
 
-      // Skip closing }
-      Inc(RawI);
-      Inc(CookedI);
-      StartRaw := RawI;
-      StartCooked := CookedI;
+  SetLength(ACookedSegments, StaticCount);
+  SetLength(ARawSegments, StaticCount);
+  SetLength(AExpressionTexts, ExprCount);
+
+  StaticCount := 0;
+  ExprCount := 0;
+  for I := 0 to Length(RawParts) - 1 do
+  begin
+    if I mod 2 = 0 then
+    begin
+      ARawSegments[StaticCount] := RawParts[I];
+      if I < Length(CookedParts) then
+        ACookedSegments[StaticCount] := CookedParts[I]
+      else
+        ACookedSegments[StaticCount] := '';
+      Inc(StaticCount);
     end
     else
     begin
-      // Normal character — advance both by 1
-      Inc(RawI);
-      Inc(CookedI);
+      AExpressionTexts[ExprCount] := Trim(RawParts[I]);
+      Inc(ExprCount);
     end;
   end;
-
-  // Record the final static text segments
-  SetLength(ACookedSegments, SegmentCount + 1);
-  ACookedSegments[SegmentCount] := Copy(ACookedFull, StartCooked, CookedI - StartCooked);
-  SetLength(ARawSegments, SegmentCount + 1);
-  ARawSegments[SegmentCount] := Copy(ARawFull, StartRaw, RawI - StartRaw);
 end;
 
 // Extract cooked and raw full strings from a template token lexeme.
@@ -1097,66 +996,45 @@ begin
   end;
 end;
 
-// TC39 Template Literal Revision — split a raw template string at real ${...}
-// interpolation boundaries.  Uses only the raw string (no cooked tracking).
-// For boundary detection, skipping \ + 1 char is sufficient because \$ in
-// raw is two characters and never matches the ${ boundary pattern.
+// TC39 Template Literal Revision — split a raw template string at interpolation
+// boundaries.  The lexer embeds #3 boundary markers with full lexical awareness,
+// so this function simply splits on those markers.
 procedure SplitRawAtBoundaries(const ARawFull: string;
   out ARawSegments, AExpressionTexts: TGocciaTemplateStrings);
 var
-  RawI, StartRaw, SegmentCount, ExprCount, ExprStartRaw, BraceCount: Integer;
+  Parts: TGocciaTemplateStrings;
+  I, StaticCount, ExprCount: Integer;
 begin
-  SetLength(ARawSegments, 0);
-  SetLength(AExpressionTexts, 0);
-  SegmentCount := 0;
+  SplitOnBoundaryMarker(ARawFull, Parts);
+
+  StaticCount := 0;
   ExprCount := 0;
-  RawI := 1;
-  StartRaw := 1;
-
-  while RawI <= Length(ARawFull) do
+  for I := 0 to Length(Parts) - 1 do
   begin
-    if ARawFull[RawI] = '\' then
-    begin
-      // Skip \ and the next character (handles \$, \\, \n, etc.)
-      Inc(RawI, 2);
-    end
-    else if (ARawFull[RawI] = '$') and (RawI < Length(ARawFull)) and
-            (ARawFull[RawI + 1] = '{') then
-    begin
-      // Real interpolation boundary
-      SetLength(ARawSegments, SegmentCount + 1);
-      ARawSegments[SegmentCount] := Copy(ARawFull, StartRaw, RawI - StartRaw);
-      Inc(SegmentCount);
-
-      Inc(RawI, 2); // skip ${
-      ExprStartRaw := RawI;
-
-      // Find matching } by brace counting
-      BraceCount := 1;
-      while (RawI <= Length(ARawFull)) and (BraceCount > 0) do
-      begin
-        if ARawFull[RawI] = '{' then
-          Inc(BraceCount)
-        else if ARawFull[RawI] = '}' then
-          Dec(BraceCount);
-        if BraceCount > 0 then
-          Inc(RawI);
-      end;
-
-      SetLength(AExpressionTexts, ExprCount + 1);
-      AExpressionTexts[ExprCount] := Trim(Copy(ARawFull, ExprStartRaw, RawI - ExprStartRaw));
-      Inc(ExprCount);
-
-      Inc(RawI); // skip closing }
-      StartRaw := RawI;
-    end
+    if I mod 2 = 0 then
+      Inc(StaticCount)
     else
-      Inc(RawI);
+      Inc(ExprCount);
   end;
 
-  // Final segment
-  SetLength(ARawSegments, SegmentCount + 1);
-  ARawSegments[SegmentCount] := Copy(ARawFull, StartRaw, RawI - StartRaw);
+  SetLength(ARawSegments, StaticCount);
+  SetLength(AExpressionTexts, ExprCount);
+
+  StaticCount := 0;
+  ExprCount := 0;
+  for I := 0 to Length(Parts) - 1 do
+  begin
+    if I mod 2 = 0 then
+    begin
+      ARawSegments[StaticCount] := Parts[I];
+      Inc(StaticCount);
+    end
+    else
+    begin
+      AExpressionTexts[ExprCount] := Trim(Parts[I]);
+      Inc(ExprCount);
+    end;
+  end;
 end;
 
 // Convert a Unicode code point to its UTF-8 string representation.

--- a/units/Goccia.Parser.pas
+++ b/units/Goccia.Parser.pas
@@ -956,7 +956,7 @@ begin
     end
     else
     begin
-      AExpressionTexts[ExprCount] := Trim(RawParts[I]);
+      AExpressionTexts[ExprCount] := RawParts[I];
       Inc(ExprCount);
     end;
   end;
@@ -1031,7 +1031,7 @@ begin
     end
     else
     begin
-      AExpressionTexts[ExprCount] := Trim(Parts[I]);
+      AExpressionTexts[ExprCount] := Parts[I];
       Inc(ExprCount);
     end;
   end;


### PR DESCRIPTION
## Summary
- Made template interpolation parsing lexically aware so `}` inside strings, comments, objects, and nested templates no longer terminates `${...}` early.
- Extended the lexer to recognize CR, CRLF, LS, and PS as line terminators in whitespace, hashbangs, and comments.
- Removed dynamic `import()` support from the parser/compiler path and updated the related docs and tests accordingly.
- Added lexer and template literal regression coverage for the new boundary and line-terminator behavior.

Fixes #279 

## Testing
- Not run in this turn.
- Added/updated JavaScript coverage under `tests/language/expressions/string/` for template interpolation boundary cases.
- Added lexer unit coverage in `units/Goccia.Lexer.Test.pas` for CR, CRLF, LS, and PS handling.