### PR TITLE
Add JSON.rawJSON and JSON.isRawJSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture deep-
 | Temporal types | `Goccia.Values.TemporalPlainYearMonth.pas`, `Goccia.Values.TemporalPlainMonthDay.pas`, `Goccia.Values.TemporalZonedDateTime.pas` | PlainYearMonth, PlainMonthDay, and ZonedDateTime Temporal types |
 | Temporal timezone | `Goccia.Temporal.TimeZone.pas` | IANA timezone resolution, TZif parsing, UTC offset calculation |
 | Temporal options | `Goccia.Temporal.Options.pas` | Shared options bag parsing: rounding modes, overflow, units, fractional digits |
+| Raw JSON | `Goccia.Values.RawJSON.pas` | `JSON.rawJSON()` frozen value with `[[IsRawJSON]]` internal slot |
 | Spec | `Goccia.Spec.pas` | Spec/proposal feature data and factory functions |
 | Preprocessors | `Goccia.Engine.pas` | `TGocciaPreprocessor = (ppJSX)` and `TGocciaPreprocessors` — pre-processing system |
 | Compatibility | `Goccia.Engine.pas` | `TGocciaCompatibility = (cfASI)` and `TGocciaCompatibilityFlags` — compatibility layer |
@@ -326,7 +327,7 @@ See [docs/code-style.md](docs/code-style.md) for the complete style guide.
 - **No abbreviations:** Use full words in class, function, method, and type names (e.g., `TGarbageCollector` not `TGC`). Exceptions: `AST`, `JSON`, `REPL`, `ISO`, `Utils`.
 - **File extension constants:** Use `Goccia.FileExtensions` constants (`EXT_JS`, `EXT_JSX`, `EXT_TS`, `EXT_TSX`, `EXT_MJS`, `EXT_JSON`, `EXT_JSON5`, `EXT_JSONL`, `EXT_TOML`, `EXT_YAML`, `EXT_YML`, `EXT_TXT`, `EXT_MD`, `EXT_GBC`) instead of hardcoded string literals. Use the shared extension arrays/helpers (`ScriptExtensions`, `ModuleImportExtensions`, `IsScriptExtension`, `IsTextAssetExtension`, `IsJSXNativeExtension`, etc.) instead of duplicating extension lists or ad-hoc checks.
 - **Runtime constants:** Use the split constant units instead of hardcoded string literals for property names, type names, error names, constructor names, and symbol names:
-  - `Goccia.Constants.PropertyNames` — `PROP_LENGTH`, `PROP_NAME`, `PROP_CONSTRUCTOR`, `PROP_PROTOTYPE`, `PROP_GET`, `PROP_SET`, `PROP_KIND`, `PROP_STATIC`, `PROP_PRIVATE`, `PROP_METADATA`, `PROP_ACCESS`, `PROP_INIT`, `PROP_ADD_INITIALIZER`, `PROP_STRICT_TYPES`, etc.
+  - `Goccia.Constants.PropertyNames` — `PROP_LENGTH`, `PROP_NAME`, `PROP_CONSTRUCTOR`, `PROP_PROTOTYPE`, `PROP_GET`, `PROP_SET`, `PROP_KIND`, `PROP_STATIC`, `PROP_PRIVATE`, `PROP_METADATA`, `PROP_ACCESS`, `PROP_INIT`, `PROP_ADD_INITIALIZER`, `PROP_STRICT_TYPES`, `PROP_RAW_JSON`, etc.
   - `Goccia.Constants.TypeNames` — `OBJECT_TYPE_NAME`, `STRING_TYPE_NAME`, `FUNCTION_TYPE_NAME`, etc.
   - `Goccia.Constants.ErrorNames` — `ERROR_NAME`, `TYPE_ERROR_NAME`, `RANGE_ERROR_NAME`, etc.
   - `Goccia.Constants.ConstructorNames` — `CONSTRUCTOR_OBJECT`, `CONSTRUCTOR_ARRAY`, `CONSTRUCTOR_STRING`, `CONSTRUCTOR_MAP`, etc.
@@ -440,6 +441,8 @@ The TestRunner adds `ggTestAssertions`; the BenchmarkRunner adds `ggBenchmark`. 
 After all built-ins, two always-present `const` globals are created: `globalThis` (self-referential global object) and `Goccia` (engine metadata with `version`, `commit`, `strictTypes`, `semver`, `build`, `spec`, `proposal`, and `shims`). `Goccia.build` exposes compile-time platform information (`os` and `arch`), mirroring `Deno.build`. `Goccia.spec` and `Goccia.proposal` expose spec and proposal feature data; `Goccia.shims` lists active shims. `strictTypes` is configurable at engine creation.
 
 **JSON/JSON5 source text access (ES2024):** `JSON.parse` and `JSON5.parse` revivers receive `(key, value, context)` where `context` is an object with a `source` property for primitive values (the raw JSON/JSON5 text as written). Objects and arrays get an empty context (no `source` property). Source text collection is implemented via `TAbstractJSONParser.OnValueStart` (position tracking hook in `JSONParser.pas`) and `TGocciaJSONVisitor.RecordSourceText` (captures the raw substring). `TGocciaJSONParser.ParseWithSources` returns both the value tree and a flat source text list consumed in depth-first order by `ApplyReviver`. See [docs/built-ins.md](docs/built-ins.md) for details.
+
+**JSON.rawJSON / JSON.isRawJSON (ES2026):** `JSON.rawJSON(text)` creates a frozen, null-prototype `TGocciaRawJSONValue` with a `rawJSON` property. The `[[IsRawJSON]]` internal slot is modeled by the class identity (`is TGocciaRawJSONValue`). During `JSON.stringify`, `StringifyPreparedValue` checks for `TGocciaRawJSONValue` and emits the raw text verbatim. `TransformWithReplacer` passes raw JSON values through without recursion. The input must be valid JSON representing a primitive (string, number, boolean, or null); objects, arrays, empty strings, and leading/trailing whitespace throw `SyntaxError`.
 
 **JSX:** Enabled by default via `DefaultPreprocessors`. The JSX transformer (`Goccia.JSX.Transformer.pas`) converts JSX to `createElement` calls as a pre-pass. Users provide their own `createElement`/`Fragment`. Custom factory via `@jsxFactory`/`@jsxFragment` pragmas. Embedders can disable via `Engine.Preprocessors := []`. See [docs/language-restrictions.md](docs/language-restrictions.md#jsx).
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -125,6 +125,10 @@ All methods handle `NaN` and `Infinity` edge cases correctly.
 |--------|-------------|
 | `JSON.parse(text, reviver?)` | Parse JSON string to value, with optional reviver function that receives source text access |
 | `JSON.stringify(value, replacer?, space?)` | Convert value to JSON string, with optional replacer (function or array) and indentation |
+| `JSON.rawJSON(text)` | Create a raw JSON value object for verbatim serialization (ES2026 §25.5.2.4) |
+| `JSON.isRawJSON(value)` | Return `true` if the value was created by `JSON.rawJSON()` (ES2026 §25.5.2.3) |
+
+**Raw JSON (ES2026):** `JSON.rawJSON(text)` creates a frozen, null-prototype object with a `rawJSON` property containing the original text. The input must be valid JSON representing a primitive value (string, number, boolean, or null) — objects and arrays are rejected. Leading/trailing whitespace and empty strings throw `SyntaxError`. During `JSON.stringify`, raw JSON values are emitted verbatim without re-serialization, enabling lossless round-tripping of values like large integers (`9007199254740993`) that exceed IEEE-754 `Number` precision. Replacer functions can return `JSON.rawJSON()` values. `JSON.isRawJSON(value)` checks for the internal `[[IsRawJSON]]` slot — objects that merely mimic the structure (e.g., `{ rawJSON: "123" }`) return `false`.
 
 **Source text access (ES2024):** When a reviver is provided, it receives three arguments: `(key, value, context)`. The `context` parameter is an object. For primitive JSON values (numbers, strings, booleans, `null`), the context contains a `source` property with the raw JSON text that produced the value — including quotes for strings, exact numeric notation, and escape sequences as written. For objects and arrays, the context object has no `source` property. This enables lossless round-tripping of numeric precision and format-aware value reconstruction.
 

--- a/tests/built-ins/JSON/isRawJSON.js
+++ b/tests/built-ins/JSON/isRawJSON.js
@@ -1,0 +1,39 @@
+/*---
+description: JSON.isRawJSON checks whether a value was created by JSON.rawJSON
+features: [JSON.isRawJSON, JSON.rawJSON]
+---*/
+
+test("JSON.isRawJSON returns true for raw JSON values", () => {
+  expect(JSON.isRawJSON(JSON.rawJSON("123"))).toBe(true);
+  expect(JSON.isRawJSON(JSON.rawJSON('"hello"'))).toBe(true);
+  expect(JSON.isRawJSON(JSON.rawJSON("true"))).toBe(true);
+  expect(JSON.isRawJSON(JSON.rawJSON("false"))).toBe(true);
+  expect(JSON.isRawJSON(JSON.rawJSON("null"))).toBe(true);
+});
+
+test("JSON.isRawJSON returns false for primitives", () => {
+  expect(JSON.isRawJSON(123)).toBe(false);
+  expect(JSON.isRawJSON("hello")).toBe(false);
+  expect(JSON.isRawJSON(true)).toBe(false);
+  expect(JSON.isRawJSON(false)).toBe(false);
+  expect(JSON.isRawJSON(null)).toBe(false);
+  expect(JSON.isRawJSON(undefined)).toBe(false);
+});
+
+test("JSON.isRawJSON returns false for regular objects", () => {
+  expect(JSON.isRawJSON({})).toBe(false);
+  expect(JSON.isRawJSON([])).toBe(false);
+  expect(JSON.isRawJSON({ rawJSON: "123" })).toBe(false);
+});
+
+test("JSON.isRawJSON returns false for objects mimicking raw JSON structure", () => {
+  const fake = Object.create(null);
+  fake.rawJSON = "123";
+  Object.freeze(fake);
+  expect(JSON.isRawJSON(fake)).toBe(false);
+});
+
+test("JSON.isRawJSON returns false for symbols and functions", () => {
+  expect(JSON.isRawJSON(Symbol("test"))).toBe(false);
+  expect(JSON.isRawJSON(() => {})).toBe(false);
+});

--- a/tests/built-ins/JSON/isRawJSON.js
+++ b/tests/built-ins/JSON/isRawJSON.js
@@ -37,3 +37,7 @@ test("JSON.isRawJSON returns false for symbols and functions", () => {
   expect(JSON.isRawJSON(Symbol("test"))).toBe(false);
   expect(JSON.isRawJSON(() => {})).toBe(false);
 });
+
+test("JSON.isRawJSON returns false when called with no arguments", () => {
+  expect(JSON.isRawJSON()).toBe(false);
+});

--- a/tests/built-ins/JSON/rawJSON.js
+++ b/tests/built-ins/JSON/rawJSON.js
@@ -120,8 +120,7 @@ test("JSON.stringify with replacer function returning raw JSON", () => {
 test("JSON.stringify with indentation and raw JSON", () => {
   const obj = { a: JSON.rawJSON("123"), b: "text" };
   const result = JSON.stringify(obj, null, 2);
-  expect(result).toContain("123");
-  expect(result).toContain('"text"');
+  expect(result).toBe('{\n  "a": 123,\n  "b": "text"\n}');
 });
 
 test("JSON.rawJSON objects are frozen and cannot be modified", () => {

--- a/tests/built-ins/JSON/rawJSON.js
+++ b/tests/built-ins/JSON/rawJSON.js
@@ -63,6 +63,11 @@ test("JSON.rawJSON throws SyntaxError for invalid JSON", () => {
   expect(() => JSON.rawJSON("{invalid}")).toThrow(SyntaxError);
 });
 
+test("JSON.rawJSON with no arguments proceeds with undefined and throws SyntaxError", () => {
+  // Per spec: ToString(undefined) = "undefined", which is invalid JSON.
+  expect(() => JSON.rawJSON()).toThrow(SyntaxError);
+});
+
 test("JSON.rawJSON throws SyntaxError for object values", () => {
   expect(() => JSON.rawJSON("{}")).toThrow(SyntaxError);
   expect(() => JSON.rawJSON('{"a":1}')).toThrow(SyntaxError);

--- a/tests/built-ins/JSON/rawJSON.js
+++ b/tests/built-ins/JSON/rawJSON.js
@@ -1,0 +1,142 @@
+/*---
+description: JSON.rawJSON creates frozen raw JSON value objects
+features: [JSON.rawJSON, JSON.isRawJSON]
+---*/
+
+test("JSON.rawJSON returns a frozen object with null prototype", () => {
+  const raw = JSON.rawJSON("123");
+
+  expect(typeof raw).toBe("object");
+  expect(Object.isFrozen(raw)).toBe(true);
+  expect(Object.getPrototypeOf(raw)).toBeNull();
+});
+
+test("JSON.rawJSON sets the rawJSON property to the input string", () => {
+  expect(JSON.rawJSON("123").rawJSON).toBe("123");
+  expect(JSON.rawJSON('"hello"').rawJSON).toBe('"hello"');
+  expect(JSON.rawJSON("true").rawJSON).toBe("true");
+  expect(JSON.rawJSON("false").rawJSON).toBe("false");
+  expect(JSON.rawJSON("null").rawJSON).toBe("null");
+});
+
+test("JSON.rawJSON accepts number values", () => {
+  expect(JSON.rawJSON("0").rawJSON).toBe("0");
+  expect(JSON.rawJSON("-1").rawJSON).toBe("-1");
+  expect(JSON.rawJSON("3.14").rawJSON).toBe("3.14");
+  expect(JSON.rawJSON("1e100").rawJSON).toBe("1e100");
+  expect(JSON.rawJSON("9007199254740993").rawJSON).toBe("9007199254740993");
+});
+
+test("JSON.rawJSON accepts string values", () => {
+  expect(JSON.rawJSON('"abc"').rawJSON).toBe('"abc"');
+  expect(JSON.rawJSON('""').rawJSON).toBe('""');
+  expect(JSON.rawJSON('"hello\\nworld"').rawJSON).toBe('"hello\\nworld"');
+});
+
+test("JSON.rawJSON accepts boolean and null values", () => {
+  expect(JSON.rawJSON("true").rawJSON).toBe("true");
+  expect(JSON.rawJSON("false").rawJSON).toBe("false");
+  expect(JSON.rawJSON("null").rawJSON).toBe("null");
+});
+
+test("JSON.rawJSON throws SyntaxError for empty string", () => {
+  expect(() => JSON.rawJSON("")).toThrow(SyntaxError);
+});
+
+test("JSON.rawJSON throws SyntaxError for leading whitespace", () => {
+  expect(() => JSON.rawJSON(" 123")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("\t123")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("\n123")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("\r123")).toThrow(SyntaxError);
+});
+
+test("JSON.rawJSON throws SyntaxError for trailing whitespace", () => {
+  expect(() => JSON.rawJSON("123 ")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("123\t")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("123\n")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("123\r")).toThrow(SyntaxError);
+});
+
+test("JSON.rawJSON throws SyntaxError for invalid JSON", () => {
+  expect(() => JSON.rawJSON("abc")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("undefined")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("{invalid}")).toThrow(SyntaxError);
+});
+
+test("JSON.rawJSON throws SyntaxError for object values", () => {
+  expect(() => JSON.rawJSON("{}")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON('{"a":1}')).toThrow(SyntaxError);
+});
+
+test("JSON.rawJSON throws SyntaxError for array values", () => {
+  expect(() => JSON.rawJSON("[]")).toThrow(SyntaxError);
+  expect(() => JSON.rawJSON("[1,2,3]")).toThrow(SyntaxError);
+});
+
+test("JSON.stringify emits raw JSON text verbatim", () => {
+  const raw = JSON.rawJSON("9007199254740993");
+  expect(JSON.stringify(raw)).toBe("9007199254740993");
+});
+
+test("JSON.stringify emits raw JSON inside objects", () => {
+  const obj = { bigNum: JSON.rawJSON("9007199254740993") };
+  expect(JSON.stringify(obj)).toBe('{"bigNum":9007199254740993}');
+});
+
+test("JSON.stringify emits raw JSON inside arrays", () => {
+  const arr = [1, JSON.rawJSON("9007199254740993"), 3];
+  expect(JSON.stringify(arr)).toBe("[1,9007199254740993,3]");
+});
+
+test("JSON.stringify emits raw JSON string values without double-quoting", () => {
+  const obj = { greeting: JSON.rawJSON('"hello"') };
+  expect(JSON.stringify(obj)).toBe('{"greeting":"hello"}');
+});
+
+test("JSON.stringify emits raw JSON boolean and null values", () => {
+  const obj = {
+    a: JSON.rawJSON("true"),
+    b: JSON.rawJSON("false"),
+    c: JSON.rawJSON("null"),
+  };
+  expect(JSON.stringify(obj)).toBe('{"a":true,"b":false,"c":null}');
+});
+
+test("JSON.stringify with replacer function returning raw JSON", () => {
+  const result = JSON.stringify({ n: 42 }, (key, value) => {
+    if (key === "n") {
+      return JSON.rawJSON("9007199254740993");
+    }
+    return value;
+  });
+  expect(result).toBe('{"n":9007199254740993}');
+});
+
+test("JSON.stringify with indentation and raw JSON", () => {
+  const obj = { a: JSON.rawJSON("123"), b: "text" };
+  const result = JSON.stringify(obj, null, 2);
+  expect(result).toContain("123");
+  expect(result).toContain('"text"');
+});
+
+test("JSON.rawJSON objects are frozen and cannot be modified", () => {
+  const raw = JSON.rawJSON("123");
+  expect(() => { raw.rawJSON = "456"; }).toThrow(TypeError);
+  expect(() => { raw.extra = true; }).toThrow(TypeError);
+  expect(raw.rawJSON).toBe("123");
+});
+
+test("JSON.rawJSON preserves exact numeric representation", () => {
+  const values = [
+    "1e100",
+    "-0",
+    "1.0000000000000001",
+    "9007199254740993",
+    "0.1",
+  ];
+  values.forEach((v) => {
+    const obj = { v: JSON.rawJSON(v) };
+    const result = JSON.stringify(obj);
+    expect(result).toBe('{"v":' + v + "}");
+  });
+});

--- a/units/Goccia.Builtins.JSON.pas
+++ b/units/Goccia.Builtins.JSON.pas
@@ -174,9 +174,11 @@ function TGocciaJSONBuiltin.JSONIsRawJSON(const AArgs: TGocciaArgumentsCollectio
 var
   Value: TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON.isRawJSON', ThrowError);
-
-  Value := AArgs.GetElement(0);
+  // No arity enforcement per spec — missing argument is treated as undefined.
+  if AArgs.Length >= 1 then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
   // Step 1: If Type(O) is Object and O has an [[IsRawJSON]] internal slot, return true.
   // Step 2: Return false.
   if Value is TGocciaRawJSONValue then
@@ -257,14 +259,18 @@ const
   JSON_WHITESPACE_CR = #13;
   JSON_WHITESPACE_SPACE = #32;
 var
+  TextValue: TGocciaValue;
   JSONString: string;
   Parsed: TGocciaValue;
   FirstChar, LastChar: Char;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON.rawJSON', ThrowError);
-
   // Step 1: Let jsonString be ? ToString(text).
-  JSONString := AArgs.GetElement(0).ToStringLiteral.Value;
+  // No arity enforcement per spec — missing argument is treated as undefined.
+  if AArgs.Length >= 1 then
+    TextValue := AArgs.GetElement(0)
+  else
+    TextValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+  JSONString := TextValue.ToStringLiteral.Value;
 
   // Step 2: Throw a SyntaxError if jsonString is the empty string.
   if JSONString = '' then

--- a/units/Goccia.Builtins.JSON.pas
+++ b/units/Goccia.Builtins.JSON.pas
@@ -17,7 +17,8 @@ uses
   Goccia.Scope,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
-  Goccia.Values.Primitives;
+  Goccia.Values.Primitives,
+  Goccia.Values.RawJSON;
 
 type
   TGocciaJSONBuiltin = class(TGocciaBuiltin)
@@ -38,7 +39,9 @@ type
     function StringifyWithAllowList(const AValue: TGocciaValue; const AAllowList: TGocciaArrayValue; const AGap: string): string;
   protected
   published
+    function JSONIsRawJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function JSONParse(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function JSONRawJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function JSONStringify(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
@@ -70,7 +73,9 @@ begin
 
   Members := TGocciaMemberCollection.Create;
   try
+    Members.AddMethod(JSONIsRawJSON, 1, gmkStaticMethod);
     Members.AddMethod(JSONParse, 1, gmkStaticMethod);
+    Members.AddMethod(JSONRawJSON, 1, gmkStaticMethod);
     Members.AddMethod(JSONStringify, 1, gmkStaticMethod);
     Members.AddSymbolDataProperty(
       TGocciaSymbolValue.WellKnownToStringTag,
@@ -164,6 +169,22 @@ begin
   end;
 end;
 
+// ES2026 §25.5.2.3 JSON.isRawJSON ( O )
+function TGocciaJSONBuiltin.JSONIsRawJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Value: TGocciaValue;
+begin
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON.isRawJSON', ThrowError);
+
+  Value := AArgs.GetElement(0);
+  // Step 1: If Type(O) is Object and O has an [[IsRawJSON]] internal slot, return true.
+  // Step 2: Return false.
+  if Value is TGocciaRawJSONValue then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
 // ES2026 §25.5.1 JSON.parse ( text [ , reviver ] )
 function TGocciaJSONBuiltin.JSONParse(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
@@ -226,6 +247,53 @@ begin
         ThrowSyntaxError(E.Message);
     end;
   end;
+end;
+
+// ES2026 §25.5.2.4 JSON.rawJSON ( text )
+function TGocciaJSONBuiltin.JSONRawJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+const
+  JSON_WHITESPACE_TAB = #9;
+  JSON_WHITESPACE_LF = #10;
+  JSON_WHITESPACE_CR = #13;
+  JSON_WHITESPACE_SPACE = #32;
+var
+  JSONString: string;
+  Parsed: TGocciaValue;
+  FirstChar, LastChar: Char;
+begin
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON.rawJSON', ThrowError);
+
+  // Step 1: Let jsonString be ? ToString(text).
+  JSONString := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  // Step 2: Throw a SyntaxError if jsonString is the empty string.
+  if JSONString = '' then
+    ThrowSyntaxError('JSON.rawJSON: empty string is not valid JSON');
+
+  // Step 2 (continued): Throw a SyntaxError if the first or last code unit is whitespace.
+  FirstChar := JSONString[1];
+  LastChar := JSONString[Length(JSONString)];
+  if (FirstChar = JSON_WHITESPACE_TAB) or (FirstChar = JSON_WHITESPACE_LF) or
+    (FirstChar = JSON_WHITESPACE_CR) or (FirstChar = JSON_WHITESPACE_SPACE) then
+    ThrowSyntaxError('JSON.rawJSON: input must not have leading whitespace');
+  if (LastChar = JSON_WHITESPACE_TAB) or (LastChar = JSON_WHITESPACE_LF) or
+    (LastChar = JSON_WHITESPACE_CR) or (LastChar = JSON_WHITESPACE_SPACE) then
+    ThrowSyntaxError('JSON.rawJSON: input must not have trailing whitespace');
+
+  // Step 3: Parse jsonString as a JSON text. Throw SyntaxError if invalid.
+  try
+    Parsed := FParser.Parse(UTF8String(JSONString));
+  except
+    on E: Exception do
+      ThrowSyntaxError('JSON.rawJSON: ' + E.Message);
+  end;
+
+  // Step 3 (continued): Throw SyntaxError if outermost value is object or array.
+  if (Parsed is TGocciaObjectValue) then
+    ThrowSyntaxError('JSON.rawJSON: value must be a JSON primitive (not an object or array)');
+
+  // Steps 4-7: Create frozen object with null prototype, [[IsRawJSON]], and "rawJSON" property.
+  Result := TGocciaRawJSONValue.Create(JSONString);
 end;
 
 // §25.5.2 steps 7-8: Resolve the gap (indentation) string from the space argument.
@@ -312,6 +380,13 @@ begin
 
   // Step 3: If replacer returned undefined, signal omission.
   if Replaced is TGocciaUndefinedLiteralValue then
+  begin
+    Result := Replaced;
+    Exit;
+  end;
+
+  // ES2026 §25.5.2.2 step 4a: If result has [[IsRawJSON]], pass through directly.
+  if Replaced is TGocciaRawJSONValue then
   begin
     Result := Replaced;
     Exit;

--- a/units/Goccia.Constants.PropertyNames.pas
+++ b/units/Goccia.Constants.PropertyNames.pas
@@ -106,6 +106,7 @@ const
   PROP_SET_FROM_BASE64        = 'setFromBase64';
   PROP_SET_FROM_HEX           = 'setFromHex';
   PROP_RAW                    = 'raw';
+  PROP_RAW_JSON               = 'rawJSON';
   PROP_ENCODING               = 'encoding';
   PROP_FATAL                  = 'fatal';
   PROP_IGNORE_BOM             = 'ignoreBOM';

--- a/units/Goccia.JSON.pas
+++ b/units/Goccia.JSON.pas
@@ -70,6 +70,7 @@ uses
   Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
+  Goccia.Values.RawJSON,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.WrapperPrimitives;
@@ -819,6 +820,10 @@ function TGocciaJSONStringifier.StringifyPreparedValue(const AValue: TGocciaValu
 var
   EffectiveValue: TGocciaValue;
 begin
+  // ES2026 §25.5.2.2 step 4a: If value has [[IsRawJSON]], return its raw text verbatim.
+  if AValue is TGocciaRawJSONValue then
+    Exit(TGocciaRawJSONValue(AValue).RawText);
+
   EffectiveValue := UnboxWrappedPrimitive(AValue);
 
   if EffectiveValue is TGocciaNullLiteralValue then

--- a/units/Goccia.Values.RawJSON.pas
+++ b/units/Goccia.Values.RawJSON.pas
@@ -1,0 +1,45 @@
+unit Goccia.Values.RawJSON;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  // ES2026 §25.5.2.2 step 4a: Represents a raw JSON value created by JSON.rawJSON().
+  // The [[IsRawJSON]] internal slot is modeled by the class identity (is TGocciaRawJSONValue).
+  // The object has a null prototype, a single "rawJSON" property, and is frozen.
+  TGocciaRawJSONValue = class(TGocciaObjectValue)
+  private
+    FRawText: string;
+  public
+    constructor Create(const ARawText: string);
+
+    property RawText: string read FRawText;
+  end;
+
+implementation
+
+uses
+  Goccia.Constants.PropertyNames,
+  Goccia.Values.ObjectPropertyDescriptor;
+
+constructor TGocciaRawJSONValue.Create(const ARawText: string);
+begin
+  // ES2026 §25.5.2.4 step 5: OrdinaryObjectCreate(null, << [[IsRawJSON]] >>)
+  inherited Create(nil, 1);
+  FRawText := ARawText;
+
+  // ES2026 §25.5.2.4 step 6: CreateDataPropertyOrThrow(obj, "rawJSON", jsonString)
+  DefineProperty(PROP_RAW_JSON, TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(ARawText),
+    [pfWritable, pfEnumerable, pfConfigurable]));
+
+  // ES2026 §25.5.2.4 step 7: SetIntegrityLevel(obj, frozen)
+  Freeze;
+end;
+
+end.


### PR DESCRIPTION
## Summary
- Adds `JSON.rawJSON(text)` to create frozen raw JSON wrapper objects with null prototypes and a `rawJSON` data property.
- Adds `JSON.isRawJSON(value)` to detect values created by `JSON.rawJSON()`.
- Updates `JSON.stringify` to emit raw JSON values verbatim, including through replacer functions and nested object/array positions.
- Documents the new ES2026 JSON raw value behavior and adds end-to-end coverage for valid inputs, invalid inputs, and serialization behavior.

## Testing
- Not run in this branch review context.
- Added JavaScript tests covering `JSON.rawJSON`, `JSON.isRawJSON`, and `JSON.stringify` integration.
- No Pascal/native test run was included in the provided diff.