### PR TITLE
Add support for RegExp modifier groups

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -386,6 +386,7 @@ RegExp is available as both `RegExp()` and `new RegExp()`. Regex literals (`/pat
 
 **Behavior notes:**
 
+- **Inline modifier groups** (`(?ims-ims:...)`) are supported per ES2025 RegExp Modifiers. Only `i` (ignoreCase), `m` (multiline), and `s` (dotAll) are valid modifier flags. The colon form is required — bare `(?ims)` without `:` is a `SyntaxError`. Duplicate flags and flags appearing in both enable and disable sections are rejected. Modifiers are scoped to the group body; outer flags are unaffected.
 - **Named capture groups** (`(?<name>...)`) are supported. Match results include a `groups` property (an object with `null` prototype) mapping group names to matched strings. Non-participating named groups are `undefined`. When no named groups exist, `groups` is `undefined`.
 - **Duplicate named capture groups:** the same group name may appear in different alternatives of a disjunction (`|`). For example, `/(?<year>\d{4})-\d{2}|\d{2}-(?<year>\d{4})/`. The `groups` property on the match result returns the value from whichever alternative participated; non-participating duplicates are `undefined`. Using the same name in the same alternative (where both groups could participate) is a `SyntaxError`.
 - **Named backreferences** (`\k<name>`) reference a previously captured named group within the same pattern. With duplicate named capture groups, `\k<name>` resolves to the group with that name in the same alternative branch.

--- a/tests/built-ins/RegExp/modifiers.js
+++ b/tests/built-ins/RegExp/modifiers.js
@@ -218,6 +218,12 @@ test("(?im-ms:...) overlapping flag throws SyntaxError", () => {
   expect(() => { new RegExp("(?im-ms:abc)"); }).toThrow(SyntaxError);
 });
 
+// --- Error cases: empty modifier lists ---
+
+test("(?-:...) empty add and remove throws SyntaxError", () => {
+  expect(() => { new RegExp("(?-:abc)"); }).toThrow(SyntaxError);
+});
+
 // --- Error cases: double dash ---
 
 test("(?i--s:...) double dash throws SyntaxError", () => {

--- a/tests/built-ins/RegExp/modifiers.js
+++ b/tests/built-ins/RegExp/modifiers.js
@@ -1,0 +1,225 @@
+/*---
+description: RegExp Modifiers (?ims-ims:...)
+features: [RegExp Modifiers]
+---*/
+
+// --- Enable modifiers ---
+
+test("(?i:...) enables case-insensitive matching within the group", () => {
+  const re = new RegExp("(?i:abc)def");
+  expect(re.test("ABCdef")).toBe(true);
+  expect(re.test("abcdef")).toBe(true);
+  expect(re.test("ABCDEF")).toBe(false);
+});
+
+test("(?m:...) enables multiline matching within the group", () => {
+  const re = new RegExp("(?m:^abc)");
+  expect(re.test("abc")).toBe(true);
+  expect(re.test("xyz\nabc")).toBe(true);
+});
+
+test("(?s:...) enables dotAll matching within the group", () => {
+  const re = new RegExp("(?s:a.b)");
+  expect(re.test("axb")).toBe(true);
+  expect(re.test("a\nb")).toBe(true);
+});
+
+test("(?s:...) dotAll is scoped to the group", () => {
+  const re = new RegExp("(?s:a.b)c.d");
+  expect(re.test("a\nbc\nd")).toBe(false);
+  expect(re.test("a\nbcxd")).toBe(true);
+});
+
+// --- Disable modifiers ---
+
+test("(?-i:...) disables case-insensitive matching within the group", () => {
+  const re = new RegExp("(?-i:abc)def", "i");
+  expect(re.test("abcDEF")).toBe(true);
+  expect(re.test("abcdef")).toBe(true);
+  expect(re.test("ABCdef")).toBe(false);
+});
+
+test("(?-m:...) disables multiline within the group", () => {
+  const re = new RegExp("(?-m:^abc)", "m");
+  expect(re.test("abc")).toBe(true);
+  expect(re.test("xyz\nabc")).toBe(false);
+});
+
+test("(?-s:...) disables dotAll within the group", () => {
+  const re = new RegExp("(?-s:a.b)", "s");
+  expect(re.test("axb")).toBe(true);
+  expect(re.test("a\nb")).toBe(false);
+});
+
+// --- Combined enable/disable ---
+
+test("(?im:...) enables both ignoreCase and multiline", () => {
+  const re = new RegExp("(?im:^abc)");
+  expect(re.test("xyz\nABC")).toBe(true);
+  expect(re.test("ABC")).toBe(true);
+});
+
+test("(?ims:...) enables all three modifiers", () => {
+  const re = new RegExp("(?ims:^a.b)");
+  expect(re.test("xyz\nA\nB")).toBe(true);
+});
+
+test("(?i-s:...) enables ignoreCase and disables dotAll", () => {
+  const re = new RegExp("(?i-s:a.b)", "s");
+  expect(re.test("AXB")).toBe(true);
+  expect(re.test("A\nB")).toBe(false);
+});
+
+test("(?-ims:...) disables all three modifiers", () => {
+  const re = new RegExp("(?-ims:^a.b$)", "ims");
+  expect(re.test("axb")).toBe(true);
+  expect(re.test("AXB")).toBe(false);
+  expect(re.test("a\nb")).toBe(false);
+});
+
+test("(?is-m:...) enables ignoreCase and dotAll, disables multiline", () => {
+  const re = new RegExp("(?is-m:^A.b)", "m");
+  expect(re.test("a\nb")).toBe(true);
+  expect(re.test("xyz\na\nb")).toBe(false);
+});
+
+// --- Nested modifier groups ---
+
+test("nested modifier groups override outer modifiers", () => {
+  const re = new RegExp("(?i:a(?-i:b)c)");
+  expect(re.test("AbC")).toBe(true);
+  expect(re.test("abc")).toBe(true);
+  expect(re.test("ABC")).toBe(false);
+  expect(re.test("aBc")).toBe(false);
+});
+
+test("deeply nested modifier groups", () => {
+  const re = new RegExp("(?i:a(?-i:b(?i:c)))");
+  expect(re.test("abC")).toBe(true);
+  expect(re.test("abc")).toBe(true);
+  expect(re.test("AbC")).toBe(true);
+  expect(re.test("aBC")).toBe(false);
+  expect(re.test("aBc")).toBe(false);
+});
+
+// --- Modifier groups with captures ---
+
+test("modifier group can contain a capturing group", () => {
+  const re = new RegExp("(?i:(abc))def");
+  const match = re.exec("ABCdef");
+  expect(match[1]).toBe("ABC");
+});
+
+test("modifier group with named capture", () => {
+  const re = new RegExp("(?i:(?<word>[a-z]+))");
+  const match = re.exec("HELLO");
+  expect(match.groups.word).toBe("HELLO");
+});
+
+test("modifier group does not create a capture group itself", () => {
+  const re = new RegExp("(?i:abc)(def)");
+  const match = re.exec("ABCdef");
+  expect(match[0]).toBe("ABCdef");
+  expect(match[1]).toBe("def");
+});
+
+// --- Modifier groups with alternation ---
+
+test("modifier group with alternation", () => {
+  const re = new RegExp("(?i:abc|def)");
+  expect(re.test("ABC")).toBe(true);
+  expect(re.test("DEF")).toBe(true);
+});
+
+// --- Edge cases: patterns that should NOT trigger modifier validation ---
+
+test("(?:...) non-capturing group is not affected", () => {
+  const re = new RegExp("(?:abc)");
+  expect(re.test("abc")).toBe(true);
+  expect(re.test("ABC")).toBe(false);
+});
+
+test("modifier-like syntax inside character class is not validated", () => {
+  const re = new RegExp("[(?i:]");
+  expect(re.test("(")).toBe(true);
+  expect(re.test("i")).toBe(true);
+});
+
+test("escaped parenthesis does not trigger modifier validation", () => {
+  const re = new RegExp("\\(?i:abc\\)");
+  expect(re.test("(?i:abc)")).toBe(true);
+});
+
+// --- source and flags ---
+
+test("source preserves modifier group syntax", () => {
+  const re = new RegExp("(?i:abc)");
+  expect(re.source).toBe("(?i:abc)");
+});
+
+test("toString includes modifier group", () => {
+  const re = new RegExp("(?i:abc)", "g");
+  expect(re.toString()).toBe("/(?i:abc)/g");
+});
+
+// --- Error cases: invalid modifier flags ---
+
+test("(?g:...) throws SyntaxError", () => {
+  expect(() => { new RegExp("(?g:abc)"); }).toThrow(SyntaxError);
+});
+
+test("(?u:...) throws SyntaxError", () => {
+  expect(() => { new RegExp("(?u:abc)"); }).toThrow(SyntaxError);
+});
+
+test("(?v:...) throws SyntaxError", () => {
+  expect(() => { new RegExp("(?v:abc)"); }).toThrow(SyntaxError);
+});
+
+test("(?y:...) throws SyntaxError", () => {
+  expect(() => { new RegExp("(?y:abc)"); }).toThrow(SyntaxError);
+});
+
+test("(?d:...) throws SyntaxError", () => {
+  expect(() => { new RegExp("(?d:abc)"); }).toThrow(SyntaxError);
+});
+
+// --- Error cases: bare modifier without colon ---
+
+test("(?i) bare modifier without colon throws SyntaxError", () => {
+  expect(() => { new RegExp("(?i)"); }).toThrow(SyntaxError);
+});
+
+test("(?ims) bare modifier without colon throws SyntaxError", () => {
+  expect(() => { new RegExp("(?ims)"); }).toThrow(SyntaxError);
+});
+
+test("(?-i) bare disable modifier without colon throws SyntaxError", () => {
+  expect(() => { new RegExp("(?-i)"); }).toThrow(SyntaxError);
+});
+
+// --- Error cases: duplicate flags ---
+
+test("(?ii:...) duplicate enable flag throws SyntaxError", () => {
+  expect(() => { new RegExp("(?ii:abc)"); }).toThrow(SyntaxError);
+});
+
+test("(?-ss:...) duplicate disable flag throws SyntaxError", () => {
+  expect(() => { new RegExp("(?-ss:abc)"); }).toThrow(SyntaxError);
+});
+
+// --- Error cases: flag in both enable and disable ---
+
+test("(?i-i:...) flag in both enable and disable throws SyntaxError", () => {
+  expect(() => { new RegExp("(?i-i:abc)"); }).toThrow(SyntaxError);
+});
+
+test("(?im-ms:...) overlapping flag throws SyntaxError", () => {
+  expect(() => { new RegExp("(?im-ms:abc)"); }).toThrow(SyntaxError);
+});
+
+// --- Error cases: double dash ---
+
+test("(?i--s:...) double dash throws SyntaxError", () => {
+  expect(() => { new RegExp("(?i--s:abc)"); }).toThrow(SyntaxError);
+});

--- a/units/Goccia.RegExp.Engine.pas
+++ b/units/Goccia.RegExp.Engine.pas
@@ -186,6 +186,11 @@ begin
         end;
         Inc(J);
       end;
+      // ES2025 §22.2.1: Both add and remove lists empty is a SyntaxError
+      if (J <= PatternLength) and (APattern[J] = ':') and
+         (EnableFlags = '') and (DisableFlags = '') then
+        raise EConvertError.Create(
+          'Invalid regular expression: modifier group must enable or disable at least one flag');
     end;
     Inc(I);
   end;

--- a/units/Goccia.RegExp.Engine.pas
+++ b/units/Goccia.RegExp.Engine.pas
@@ -96,11 +96,284 @@ begin
     raise EConvertError.Create('Invalid regular expression flags');
 end;
 
+// ES2025 §22.2.1 Static Semantics: Early Errors — RegExp Modifiers
+// Validates inline modifier group syntax (?flags:...) and (?flags-flags:...).
+// Only i, m, s are valid modifier flags. The colon form is required.
+procedure ValidateModifierGroups(const APattern: string);
+var
+  I, J, PatternLength: Integer;
+  InCharClass: Boolean;
+  C: Char;
+  EnableFlags, DisableFlags: string;
+  InDisable: Boolean;
+begin
+  PatternLength := Length(APattern);
+  I := 1;
+  InCharClass := False;
+  while I <= PatternLength do
+  begin
+    if APattern[I] = '\' then
+    begin
+      if I + 1 <= PatternLength then
+        Inc(I, 2)
+      else
+        Inc(I);
+      Continue;
+    end;
+    if APattern[I] = '[' then
+    begin
+      InCharClass := True;
+      Inc(I);
+      Continue;
+    end;
+    if (APattern[I] = ']') and InCharClass then
+    begin
+      InCharClass := False;
+      Inc(I);
+      Continue;
+    end;
+    if InCharClass then
+    begin
+      Inc(I);
+      Continue;
+    end;
+    // ES2025: Check for modifier group prefix (?[ims-]...)
+    if (APattern[I] = '(') and (I + 2 <= PatternLength) and
+       (APattern[I + 1] = '?') and
+       CharInSet(APattern[I + 2], ['i', 'm', 's', '-']) then
+    begin
+      J := I + 2;
+      EnableFlags := '';
+      DisableFlags := '';
+      InDisable := False;
+      while J <= PatternLength do
+      begin
+        C := APattern[J];
+        // ES2025 §22.2.1 step 4: colon terminates modifier prefix
+        if C = ':' then
+          Break;
+        if C = ')' then
+          raise EConvertError.Create(
+            'Invalid regular expression: modifier group must use (?flags:...) syntax');
+        if C = '-' then
+        begin
+          if InDisable then
+            raise EConvertError.Create(
+              'Invalid regular expression: unexpected - in modifier group');
+          InDisable := True;
+          Inc(J);
+          Continue;
+        end;
+        if not CharInSet(C, ['i', 'm', 's']) then
+          raise EConvertError.CreateFmt(
+            'Invalid regular expression: ''%s'' is not a valid modifier flag', [C]);
+        if InDisable then
+        begin
+          if Pos(C, DisableFlags) > 0 then
+            raise EConvertError.CreateFmt(
+              'Invalid regular expression: duplicate modifier flag ''%s''', [C]);
+          if Pos(C, EnableFlags) > 0 then
+            raise EConvertError.CreateFmt(
+              'Invalid regular expression: ''%s'' in both enable and disable', [C]);
+          DisableFlags := DisableFlags + C;
+        end
+        else
+        begin
+          if Pos(C, EnableFlags) > 0 then
+            raise EConvertError.CreateFmt(
+              'Invalid regular expression: duplicate modifier flag ''%s''', [C]);
+          EnableFlags := EnableFlags + C;
+        end;
+        Inc(J);
+      end;
+    end;
+    Inc(I);
+  end;
+end;
+
+// ES2025 §22.2.1 RegExp Modifiers — Transforms inline modifier groups
+// (?flags:...) and (?flags-flags:...) into TRegExpr-compatible syntax.
+// For i and m modifiers: uses (?i)/(?-i)/(?m)/(?-m) toggles inside (?:...)
+// groups (TRegExpr scopes these correctly to groups).
+// For s modifier enable: replaces . with [\s\S] (because TRegExpr's (?s)
+// leaks from groups). For s modifier disable: uses (?-s) toggle (TRegExpr
+// scopes this correctly).
+function PreprocessModifierGroups(const APattern: string): string;
+type
+  TSModifierEntry = record
+    Depth: Integer;
+    PreviousSActive: Boolean;
+  end;
+const
+  DOTALL_REPLACEMENT = '[\s\S]';
+  INITIAL_STACK_SIZE = 32;
+var
+  I, J, PatternLength: Integer;
+  InCharClass: Boolean;
+  GroupDepth: Integer;
+  SStack: array of TSModifierEntry;
+  SStackTop: Integer;
+  CurrentSActive: Boolean;
+  C: Char;
+  EnableFlags, DisableFlags: string;
+  InDisable: Boolean;
+  Toggles: string;
+  NewSActive: Boolean;
+begin
+  PatternLength := Length(APattern);
+  if PatternLength = 0 then
+  begin
+    Result := '';
+    Exit;
+  end;
+  Result := '';
+  I := 1;
+  InCharClass := False;
+  GroupDepth := 0;
+  CurrentSActive := False;
+  SStackTop := -1;
+  SetLength(SStack, INITIAL_STACK_SIZE);
+  while I <= PatternLength do
+  begin
+    // Handle escape sequences
+    if APattern[I] = '\' then
+    begin
+      if I + 1 <= PatternLength then
+      begin
+        Result := Result + APattern[I] + APattern[I + 1];
+        Inc(I, 2);
+      end
+      else
+      begin
+        Result := Result + APattern[I];
+        Inc(I);
+      end;
+      Continue;
+    end;
+    // Handle character classes (copy as-is, no dot transformation)
+    if APattern[I] = '[' then
+    begin
+      InCharClass := True;
+      Result := Result + APattern[I];
+      Inc(I);
+      Continue;
+    end;
+    if (APattern[I] = ']') and InCharClass then
+    begin
+      InCharClass := False;
+      Result := Result + APattern[I];
+      Inc(I);
+      Continue;
+    end;
+    if InCharClass then
+    begin
+      Result := Result + APattern[I];
+      Inc(I);
+      Continue;
+    end;
+    // ES2025: Transform . based on current s modifier state
+    if APattern[I] = '.' then
+    begin
+      if CurrentSActive then
+        Result := Result + DOTALL_REPLACEMENT
+      else
+        Result := Result + '.';
+      Inc(I);
+      Continue;
+    end;
+    // Handle closing paren — pop s state if this closes a modifier group
+    if APattern[I] = ')' then
+    begin
+      if (SStackTop >= 0) and (SStack[SStackTop].Depth = GroupDepth) then
+      begin
+        CurrentSActive := SStack[SStackTop].PreviousSActive;
+        Dec(SStackTop);
+      end;
+      Dec(GroupDepth);
+      Result := Result + ')';
+      Inc(I);
+      Continue;
+    end;
+    // Handle opening paren — check for modifier group prefix
+    if APattern[I] = '(' then
+    begin
+      Inc(GroupDepth);
+      if (I + 1 <= PatternLength) and (APattern[I + 1] = '?') and
+         (I + 2 <= PatternLength) and
+         CharInSet(APattern[I + 2], ['i', 'm', 's', '-']) then
+      begin
+        // Parse modifier flags up to ':'
+        J := I + 2;
+        EnableFlags := '';
+        DisableFlags := '';
+        InDisable := False;
+        while (J <= PatternLength) and (APattern[J] <> ':') and
+              (APattern[J] <> ')') do
+        begin
+          C := APattern[J];
+          if C = '-' then
+          begin
+            InDisable := True;
+            Inc(J);
+            Continue;
+          end;
+          if CharInSet(C, ['i', 'm', 's']) then
+          begin
+            if InDisable then
+              DisableFlags := DisableFlags + C
+            else
+              EnableFlags := EnableFlags + C;
+          end;
+          Inc(J);
+        end;
+        if (J <= PatternLength) and (APattern[J] = ':') then
+        begin
+          // Valid modifier group — transform to TRegExpr-compatible syntax
+          // Build i/m toggles (TRegExpr scopes these correctly to groups)
+          Toggles := '';
+          if Pos('i', EnableFlags) > 0 then Toggles := Toggles + '(?i)';
+          if Pos('m', EnableFlags) > 0 then Toggles := Toggles + '(?m)';
+          if Pos('i', DisableFlags) > 0 then Toggles := Toggles + '(?-i)';
+          if Pos('m', DisableFlags) > 0 then Toggles := Toggles + '(?-m)';
+          // s disable uses TRegExpr toggle (correctly scoped to groups)
+          if Pos('s', DisableFlags) > 0 then Toggles := Toggles + '(?-s)';
+          // Determine new s state (s enable uses dot transformation)
+          NewSActive := CurrentSActive;
+          if Pos('s', EnableFlags) > 0 then NewSActive := True;
+          if Pos('s', DisableFlags) > 0 then NewSActive := False;
+          // Push s state if s modifier changed
+          if NewSActive <> CurrentSActive then
+          begin
+            Inc(SStackTop);
+            if SStackTop >= Length(SStack) then
+              SetLength(SStack, SStackTop * 2 + 4);
+            SStack[SStackTop].Depth := GroupDepth;
+            SStack[SStackTop].PreviousSActive := CurrentSActive;
+            CurrentSActive := NewSActive;
+          end;
+          // Emit non-capturing group with toggles
+          Result := Result + '(?:' + Toggles;
+          I := J + 1;
+          Continue;
+        end;
+      end;
+      // Regular group or non-modifier (?...) — pass through
+      Result := Result + APattern[I];
+      Inc(I);
+      Continue;
+    end;
+    // Default: copy character as-is
+    Result := Result + APattern[I];
+    Inc(I);
+  end;
+end;
+
 // ES2026 §22.2.3.1 RegExp ( pattern, flags ) — validation step
 procedure ValidateRegExpPattern(const APattern, AFlags: string);
 var
   Matcher: TRegExpr;
   NormalizedPattern: string;
+  ExecutablePattern: string;
   ConvertedPattern: string;
   DiscardedGroups: TGocciaRegExpNamedGroups;
   IsUnicode: Boolean;
@@ -109,9 +382,13 @@ begin
   NormalizedPattern := NormalizeRegExpSource(APattern);
   if NormalizedPattern = EMPTY_REGEX then
     Exit;
+  ExecutablePattern := GetExecutableRegExpPattern(NormalizedPattern);
+  // ES2025: Validate inline modifier groups before transformation
+  ValidateModifierGroups(ExecutablePattern);
+  // ES2025: Transform modifier groups into TRegExpr-compatible syntax
+  ExecutablePattern := PreprocessModifierGroups(ExecutablePattern);
   IsUnicode := HasRegExpFlag(AFlags, 'u');
-  ConvertedPattern := PreprocessRegExpPattern(
-    GetExecutableRegExpPattern(NormalizedPattern), DiscardedGroups);
+  ConvertedPattern := PreprocessRegExpPattern(ExecutablePattern, DiscardedGroups);
   // ES2026 §22.2.2.9: Apply Unicode pattern preprocessing when u flag is set
   if IsUnicode then
     ConvertedPattern := PreprocessUnicodePattern(ConvertedPattern);
@@ -563,6 +840,7 @@ function ExecuteRegExp(const APattern, AFlags, AInput: string;
 var
   Matcher: TRegExpr;
   I: Integer;
+  ExecutablePattern: string;
   ConvertedPattern: string;
   NamedGroups: TGocciaRegExpNamedGroups;
   IsUnicode: Boolean;
@@ -589,8 +867,10 @@ begin
     AResult.Groups[0].Value := '';
     Exit(True);
   end;
-  ConvertedPattern := PreprocessRegExpPattern(
-    GetExecutableRegExpPattern(APattern), NamedGroups);
+  // ES2025: Transform modifier groups before named group preprocessing
+  ExecutablePattern := PreprocessModifierGroups(
+    GetExecutableRegExpPattern(APattern));
+  ConvertedPattern := PreprocessRegExpPattern(ExecutablePattern, NamedGroups);
   // ES2026 §22.2.2.9: Apply Unicode pattern preprocessing when u flag is set
   if IsUnicode then
     ConvertedPattern := PreprocessUnicodePattern(ConvertedPattern);

--- a/units/Goccia.Spec.pas
+++ b/units/Goccia.Spec.pas
@@ -159,11 +159,12 @@ const
   // ---------------------------------------------------------------------------
   // ES2025
   // ---------------------------------------------------------------------------
-  ES2025_FEATURES: array[0..9] of TGocciaFeatureEntry = (
+  ES2025_FEATURES: array[0..10] of TGocciaFeatureEntry = (
     (Name: 'Set Methods';                     Link: 'https://tc39.es/ecma262/#sec-set-objects'),
     (Name: 'Iterator Helpers';                Link: 'https://tc39.es/ecma262/#sec-iterator-objects'),
     (Name: 'Promise.try';                     Link: 'https://tc39.es/ecma262/#sec-promise.try'),
     (Name: 'RegExp.escape';                   Link: 'https://tc39.es/ecma262/#sec-regexp.escape'),
+    (Name: 'RegExp Modifiers';                Link: 'https://tc39.es/ecma262/#sec-regexp-regular-expression-objects'),
     (Name: 'Duplicate Named Capture Groups';  Link: 'https://tc39.es/ecma262/#sec-regexp-regular-expression-objects'),
     (Name: 'Error.isError';                   Link: 'https://tc39.es/ecma262/#sec-error.iserror'),
     (Name: 'Float16Array';                    Link: 'https://tc39.es/ecma262/#sec-typedarray-objects'),


### PR DESCRIPTION
## Summary
- Added support for inline RegExp modifier groups `(?ims-ims:...)` in the RegExp engine.
- Enforces ES2025 validation rules for modifier groups, including required colon syntax, allowed flags (`i`, `m`, `s`), and duplicate/overlap checks.
- Updated RegExp preprocessing so modifier scopes are applied correctly during matching, including nested groups and `s` flag handling.
- Added end-to-end coverage for valid, nested, and invalid modifier group cases.
- Documented the new behavior in `docs/built-ins.md` and registered the ES2025 feature in `units/Goccia.Spec.pas`.

## Testing
- Added `tests/built-ins/RegExp/modifiers.js` covering enable/disable combinations, nesting, captures, source/toString behavior, and error cases.
- Not run: `./build.pas testrunner && ./build/TestRunner tests`.
- Not run: native Pascal test suite (`./build.pas clean tests && for t in build/Goccia.*.Test; do "$t"; done`).