### PR TITLE
Add JSONC support for structured module globals

### DIFF
--- a/tests/language/modules/helpers/config.jsonc
+++ b/tests/language/modules/helpers/config.jsonc
@@ -1,0 +1,12 @@
+{
+  // JSONC: JSON with Comments
+  "name": "goccia-jsonc",
+  "version": "2.0.0",
+  "debug": false,
+  "maxRetries": 5,
+  "tags": ["stable", "release"],
+  "database": {
+    "host": "db.example.com",
+    "port": 3306
+  }
+}

--- a/tests/language/modules/jsonc-import.js
+++ b/tests/language/modules/jsonc-import.js
@@ -21,4 +21,8 @@ describe("JSONC import", () => {
     expect(database.host).toBe("db.example.com");
     expect(database.port).toBe(3306);
   });
+
+  test("fails on malformed JSONC", () => {
+    expect(() => JSON5.parse('{ "key": }')).toThrow(SyntaxError);
+  });
 });

--- a/tests/language/modules/jsonc-import.js
+++ b/tests/language/modules/jsonc-import.js
@@ -1,0 +1,24 @@
+import {
+  name,
+  version,
+  debug,
+  maxRetries,
+  tags,
+  database,
+} from "./helpers/config.jsonc";
+
+describe("JSONC import", () => {
+  test("exports top-level scalar values", () => {
+    expect(name).toBe("goccia-jsonc");
+    expect(version).toBe("2.0.0");
+    expect(debug).toBe(false);
+    expect(maxRetries).toBe(5);
+  });
+
+  test("exports arrays and nested objects", () => {
+    expect(tags.length).toBe(2);
+    expect(tags[0]).toBe("stable");
+    expect(database.host).toBe("db.example.com");
+    expect(database.port).toBe(3306);
+  });
+});

--- a/units/Goccia.FileExtensions.pas
+++ b/units/Goccia.FileExtensions.pas
@@ -12,6 +12,7 @@ const
   EXT_MJS  = '.mjs';
   EXT_JSON = '.json';
   EXT_JSON5 = '.json5';
+  EXT_JSONC = '.jsonc';
   EXT_JSONL = '.jsonl';
   EXT_TOML = '.toml';
   EXT_YAML = '.yaml';
@@ -29,9 +30,9 @@ const
     EXT_JSX, EXT_TSX
   );
 
-  ModuleImportExtensions: array[0..12] of string = (
+  ModuleImportExtensions: array[0..13] of string = (
     EXT_JS, EXT_JSX, EXT_TS, EXT_TSX, EXT_MJS,
-    EXT_JSON, EXT_JSON5, EXT_JSONL, EXT_TOML, EXT_YAML, EXT_YML,
+    EXT_JSON, EXT_JSON5, EXT_JSONC, EXT_JSONL, EXT_TOML, EXT_YAML, EXT_YML,
     EXT_TXT, EXT_MD
   );
 
@@ -87,7 +88,7 @@ var
   Ext: string;
 begin
   Ext := LowerCase(AExtension);
-  Result := Ext = EXT_JSON5;
+  Result := (Ext = EXT_JSON5) or (Ext = EXT_JSONC);
 end;
 
 function IsYAMLExtension(const AExtension: string): Boolean;

--- a/units/Goccia.ScriptLoader.Globals.Test.pas
+++ b/units/Goccia.ScriptLoader.Globals.Test.pas
@@ -57,6 +57,8 @@ procedure TScriptLoaderGlobalsTests.TestDetectsStructuredGlobalsFilesByExtension
 begin
   Expect<Boolean>(IsStructuredGlobalsFile('config.json5')).ToBe(True);
   Expect<Boolean>(IsJSON5GlobalsFile('config.json5')).ToBe(True);
+  Expect<Boolean>(IsStructuredGlobalsFile('config.jsonc')).ToBe(True);
+  Expect<Boolean>(IsJSON5GlobalsFile('config.jsonc')).ToBe(True);
   Expect<Boolean>(IsStructuredGlobalsFile('config.toml')).ToBe(True);
   Expect<Boolean>(IsTOMLGlobalsFile('config.toml')).ToBe(True);
   Expect<Boolean>(IsYAMLGlobalsFile('config.toml')).ToBe(False);


### PR DESCRIPTION
## Summary
- Treat `.jsonc` files as structured module globals alongside `.json5`.
- Update extension detection so JSONC is recognized as a JSON5-style structured globals format.
- Add coverage for importing JSONC module globals and validating exported scalar, array, and nested object values.

## Testing
- Added unit coverage in `Goccia.ScriptLoader.Globals.Test.pas` for `config.jsonc` detection.
- Added module import test in `tests/language/modules/jsonc-import.js` using `tests/language/modules/helpers/config.jsonc`.
- Not run