### PR TITLE
Deduplicate JSON string escaping helpers

### DIFF
--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -25,6 +25,7 @@ uses
   Goccia.Error.Detail,
   Goccia.FileExtensions,
   Goccia.GarbageCollector,
+  Goccia.JSON.Utils,
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.Parser,
@@ -127,15 +128,6 @@ begin
   AResult.AssignProperty('failed', TGocciaNumberLiteralValue.Create(1));
   TGocciaArrayValue(AResult.GetProperty('failedTests')).Elements.Add(
     TGocciaStringLiteralValue.Create(AFileName + ': ' + AMessage));
-end;
-
-function EscapeJSONString(const S: string): string;
-begin
-  Result := StringReplace(S, '\', '\\', [rfReplaceAll]);
-  Result := StringReplace(Result, '"', '\"', [rfReplaceAll]);
-  Result := StringReplace(Result, #10, '\n', [rfReplaceAll]);
-  Result := StringReplace(Result, #13, '\r', [rfReplaceAll]);
-  Result := StringReplace(Result, #9, '\t', [rfReplaceAll]);
 end;
 
 { TTestRunnerApp }

--- a/scripts/GocciaJSON5Check.dpr
+++ b/scripts/GocciaJSON5Check.dpr
@@ -10,45 +10,12 @@ uses
   StringBuffer,
 
   Goccia.GarbageCollector,
+  Goccia.JSON.Utils,
   Goccia.JSON5,
   Goccia.TextFiles,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
-
-function EscapeJSONString(const AValue: string): string;
-var
-  C: Char;
-begin
-  Result := '';
-  for C in AValue do
-    case C of
-      '"':
-        Result := Result + '\"';
-      '\':
-        Result := Result + '\\';
-      #8:
-        Result := Result + '\b';
-      #9:
-        Result := Result + '\t';
-      #10:
-        Result := Result + '\n';
-      #12:
-        Result := Result + '\f';
-      #13:
-        Result := Result + '\r';
-    else
-      if Ord(C) < 32 then
-        Result := Result + '\u' + IntToHex(Ord(C), 4)
-      else
-        Result := Result + C;
-    end;
-end;
-
-function QuoteJSONString(const AValue: string): string;
-begin
-  Result := '"' + EscapeJSONString(AValue) + '"';
-end;
 
 function SameDoubleBits(const ALeft, ARight: Double): Boolean;
 var

--- a/scripts/GocciaTOMLCheck.dpr
+++ b/scripts/GocciaTOMLCheck.dpr
@@ -9,43 +9,10 @@ uses
   StringBuffer,
 
   Goccia.GarbageCollector,
+  Goccia.JSON.Utils,
   Goccia.TextFiles,
   Goccia.TOML,
   Goccia.Values.Primitives;
-
-function EscapeJSONString(const AValue: string): string;
-var
-  Buffer: TStringBuffer;
-  Ch: Char;
-  I: Integer;
-begin
-  Buffer := TStringBuffer.Create(Length(AValue));
-  for I := 1 to Length(AValue) do
-  begin
-    Ch := AValue[I];
-    case Ch of
-      '"': Buffer.Append('\"');
-      '\': Buffer.Append('\\');
-      '/': Buffer.Append('\/');
-      #8: Buffer.Append('\b');
-      #9: Buffer.Append('\t');
-      #10: Buffer.Append('\n');
-      #12: Buffer.Append('\f');
-      #13: Buffer.Append('\r');
-    else
-      if Ord(Ch) < 32 then
-        Buffer.Append('\u' + IntToHex(Ord(Ch), 4))
-      else
-        Buffer.AppendChar(Ch);
-    end;
-  end;
-  Result := Buffer.ToString;
-end;
-
-function QuoteJSONString(const AValue: string): string;
-begin
-  Result := '"' + EscapeJSONString(AValue) + '"';
-end;
 
 function ScalarKindName(const AKind: TGocciaTOMLScalarKind): string;
 begin

--- a/units/Goccia.JSON.Utils.Test.pas
+++ b/units/Goccia.JSON.Utils.Test.pas
@@ -94,10 +94,15 @@ end;
 procedure TJSONUtilsTests.TestPreservesMultibyteUTF8;
 var
   EAcute: string;
+  Grinning: string;
 begin
   EAcute := #$C3#$A9; // UTF-8 for U+00E9 (e with acute accent)
   Expect<string>(EscapeJSONString(EAcute)).ToBe(EAcute);
   Expect<string>(EscapeJSONString('caf' + EAcute)).ToBe('caf' + EAcute);
+
+  Grinning := #$F0#$9F#$98#$80; // UTF-8 for U+1F600 (grinning face emoji)
+  Expect<string>(EscapeJSONString(Grinning)).ToBe(Grinning);
+  Expect<string>(EscapeJSONString('face' + Grinning)).ToBe('face' + Grinning);
 end;
 
 // QuoteJSONString should wrap the escaped body in literal double-quote chars

--- a/units/Goccia.JSON.Utils.Test.pas
+++ b/units/Goccia.JSON.Utils.Test.pas
@@ -1,0 +1,123 @@
+program Goccia.JSON.Utils.Test;
+
+{$I Goccia.inc}
+
+uses
+  SysUtils,
+
+  TestRunner,
+
+  Goccia.JSON.Utils;
+
+type
+  TJSONUtilsTests = class(TTestSuite)
+  private
+    procedure TestEscapesDoubleQuote;
+    procedure TestEscapesBackslash;
+    procedure TestEscapesSolidus;
+    procedure TestEscapesNul;
+    procedure TestEscapesUnitSeparator;
+    procedure TestShortEscapes;
+    procedure TestCombinedSpecialChars;
+    procedure TestPreservesMultibyteUTF8;
+    procedure TestQuoteJSONStringWraps;
+    procedure TestPlainASCIIPassthrough;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TJSONUtilsTests.SetupTests;
+begin
+  Test('Escapes double quote as \"', TestEscapesDoubleQuote);
+  Test('Escapes backslash as \\', TestEscapesBackslash);
+  Test('Escapes solidus as \/', TestEscapesSolidus);
+  Test('Escapes NUL (#0) as \u0000', TestEscapesNul);
+  Test('Escapes unit separator (#31) as \u001F', TestEscapesUnitSeparator);
+  Test('Uses short escapes for \b \t \n \f \r', TestShortEscapes);
+  Test('Handles multiple special chars in one string', TestCombinedSpecialChars);
+  Test('Preserves non-control multibyte UTF-8 characters', TestPreservesMultibyteUTF8);
+  Test('QuoteJSONString wraps escaped result in double quotes', TestQuoteJSONStringWraps);
+  Test('Plain ASCII passes through unchanged', TestPlainASCIIPassthrough);
+end;
+
+procedure TJSONUtilsTests.TestEscapesDoubleQuote;
+begin
+  Expect<string>(EscapeJSONString('"')).ToBe('\"');
+  Expect<string>(EscapeJSONString('say "hello"')).ToBe('say \"hello\"');
+end;
+
+procedure TJSONUtilsTests.TestEscapesBackslash;
+begin
+  Expect<string>(EscapeJSONString('\')).ToBe('\\');
+  Expect<string>(EscapeJSONString('a\b')).ToBe('a\\b');
+end;
+
+procedure TJSONUtilsTests.TestEscapesSolidus;
+begin
+  Expect<string>(EscapeJSONString('/')).ToBe('\/');
+  Expect<string>(EscapeJSONString('</script>')).ToBe('<\/script>');
+end;
+
+// #0 (U+0000) is a C0 control char with no short escape
+procedure TJSONUtilsTests.TestEscapesNul;
+begin
+  Expect<string>(EscapeJSONString(#0)).ToBe('\u0000');
+end;
+
+// #31 (U+001F) is the last C0 control char, no short escape
+procedure TJSONUtilsTests.TestEscapesUnitSeparator;
+begin
+  Expect<string>(EscapeJSONString(#31)).ToBe('\u001F');
+end;
+
+// All five named short escapes: \b \t \n \f \r
+procedure TJSONUtilsTests.TestShortEscapes;
+begin
+  Expect<string>(EscapeJSONString(#8)).ToBe('\b');
+  Expect<string>(EscapeJSONString(#9)).ToBe('\t');
+  Expect<string>(EscapeJSONString(#10)).ToBe('\n');
+  Expect<string>(EscapeJSONString(#12)).ToBe('\f');
+  Expect<string>(EscapeJSONString(#13)).ToBe('\r');
+end;
+
+// Mix of quote, backslash, control chars, and a hex-escaped control char
+// to exercise buffering across multiple escape types
+procedure TJSONUtilsTests.TestCombinedSpecialChars;
+begin
+  Expect<string>(EscapeJSONString('"' + '\' + #10 + #0 + 'ok')).ToBe('\"\\' + '\n' + '\u0000ok');
+  Expect<string>(EscapeJSONString(#9 + '/' + #31)).ToBe('\t' + '\/' + '\u001F');
+end;
+
+// Non-ASCII characters above U+001F must pass through unescaped.
+// U+00E9 (e-acute) is the two-byte UTF-8 sequence #$C3#$A9.
+// U+1F600 (grinning face emoji) is a four-byte UTF-8 sequence.
+procedure TJSONUtilsTests.TestPreservesMultibyteUTF8;
+var
+  EAcute: string;
+begin
+  EAcute := #$C3#$A9; // UTF-8 for U+00E9 (e with acute accent)
+  Expect<string>(EscapeJSONString(EAcute)).ToBe(EAcute);
+  Expect<string>(EscapeJSONString('caf' + EAcute)).ToBe('caf' + EAcute);
+end;
+
+// QuoteJSONString should wrap the escaped body in literal double-quote chars
+procedure TJSONUtilsTests.TestQuoteJSONStringWraps;
+begin
+  Expect<string>(QuoteJSONString('hello')).ToBe('"hello"');
+  Expect<string>(QuoteJSONString('say "hi"')).ToBe('"say \"hi\""');
+  Expect<string>(QuoteJSONString(#10)).ToBe('"\n"');
+  Expect<string>(QuoteJSONString(#0)).ToBe('"\u0000"');
+end;
+
+// Ordinary printable ASCII is never escaped
+procedure TJSONUtilsTests.TestPlainASCIIPassthrough;
+begin
+  Expect<string>(EscapeJSONString('')).ToBe('');
+  Expect<string>(EscapeJSONString('abc 123 !@#$%')).ToBe('abc 123 !@#$%');
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TJSONUtilsTests.Create('JSON Utils'));
+  TestRunnerProgram.Run;
+  ExitCode := TestResultToExitCode;
+end.

--- a/units/Goccia.JSON.Utils.pas
+++ b/units/Goccia.JSON.Utils.pas
@@ -1,0 +1,63 @@
+unit Goccia.JSON.Utils;
+
+{$I Goccia.inc}
+
+interface
+
+/// Escape a string for embedding inside a JSON string literal.
+///
+/// All C0 control characters (U+0000-U+001F) are escaped:
+///   - Known short escapes: \b (#8), \t (#9), \n (#10), \f (#12), \r (#13)
+///   - Remaining control characters: \u00XX hex escapes
+///
+/// Backslash, double-quote and solidus are also escaped.
+function EscapeJSONString(const AValue: string): string;
+
+/// Wrap a value in escaped double quotes: "…"
+function QuoteJSONString(const AValue: string): string;
+
+implementation
+
+uses
+  SysUtils,
+
+  StringBuffer;
+
+function EscapeJSONString(const AValue: string): string;
+var
+  Buffer: TStringBuffer;
+  I: Integer;
+  Ch: Char;
+begin
+  Buffer := TStringBuffer.Create(Length(AValue));
+  for I := 1 to Length(AValue) do
+  begin
+    Ch := AValue[I];
+    case Ch of
+      '"': Buffer.Append('\"');
+      '\': Buffer.Append('\\');
+      '/': Buffer.Append('\/');
+      #8: Buffer.Append('\b');
+      #9: Buffer.Append('\t');
+      #10: Buffer.Append('\n');
+      #12: Buffer.Append('\f');
+      #13: Buffer.Append('\r');
+    else
+      if Ord(Ch) < 32 then
+      begin
+        Buffer.Append('\u');
+        Buffer.Append(IntToHex(Ord(Ch), 4));
+      end
+      else
+        Buffer.AppendChar(Ch);
+    end;
+  end;
+  Result := Buffer.ToString;
+end;
+
+function QuoteJSONString(const AValue: string): string;
+begin
+  Result := '"' + EscapeJSONString(AValue) + '"';
+end;
+
+end.

--- a/units/Goccia.JSON.pas
+++ b/units/Goccia.JSON.pas
@@ -42,7 +42,6 @@ type
     function ApplyToJSON(const AValue: TGocciaValue; const AKey: string): TGocciaValue;
     function ChooseQuoteChar(const AStr: string): Char;
     function CircularErrorName: string;
-    function EscapeJSONString(const AStr: string): string;
     function EscapeJSON5String(const AStr: string; const AQuote: Char): string;
     function IsJSON5IdentifierKey(const AKey: string): Boolean;
     function ShouldOmitObjectProperty(const AValue: TGocciaValue): Boolean;
@@ -67,6 +66,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.Constants.PropertyNames,
+  Goccia.JSON.Utils,
   Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
@@ -683,41 +683,6 @@ begin
     Result := ''''
   else
     Result := '"';
-end;
-
-function TGocciaJSONStringifier.EscapeJSONString(const AStr: string): string;
-var
-  Ch: Char;
-  I: Integer;
-  SB: TStringBuffer;
-begin
-  SB := TStringBuffer.Create(Length(AStr));
-  try
-    for I := 1 to Length(AStr) do
-    begin
-      Ch := AStr[I];
-      case Ch of
-        '"': SB.Append('\"');
-        '\': SB.Append('\\');
-        '/': SB.Append('\/');
-        #8: AppendEscapedChar(SB, 'b');
-        #12: AppendEscapedChar(SB, 'f');
-        #10: AppendEscapedChar(SB, 'n');
-        #13: AppendEscapedChar(SB, 'r');
-        #9: AppendEscapedChar(SB, 't');
-      else
-        if Ord(Ch) < 32 then
-        begin
-          SB.Append('\u');
-          SB.Append(IntToHex(Ord(Ch), 4));
-        end
-        else
-          SB.AppendChar(Ch);
-      end;
-    end;
-    Result := SB.ToString;
-  finally
-  end;
 end;
 
 function TGocciaJSONStringifier.EscapeJSON5String(const AStr: string;

--- a/units/Goccia.Profiler.Report.pas
+++ b/units/Goccia.Profiler.Report.pas
@@ -27,7 +27,8 @@ uses
   StringBuffer,
   TimingUtils,
 
-  Goccia.Bytecode.OpCodeNames;
+  Goccia.Bytecode.OpCodeNames,
+  Goccia.JSON.Utils;
 
 const
   MAX_OPCODE_PAIRS_DISPLAYED = 20;
@@ -75,33 +76,6 @@ begin
   if Lo < AHigh then QuickSortPairs(AEntries, Lo, AHigh);
 end;
 
-function EscapeJSONString(const AValue: string): string;
-var
-  Buf: TStringBuffer;
-  I: Integer;
-  Ch: Char;
-begin
-  Buf := TStringBuffer.Create(Length(AValue) + 16);
-  for I := 1 to Length(AValue) do
-  begin
-    Ch := AValue[I];
-    case Ch of
-      '\': Buf.Append('\\');
-      '"': Buf.Append('\"');
-      #8:  Buf.Append('\b');
-      #9:  Buf.Append('\t');
-      #10: Buf.Append('\n');
-      #12: Buf.Append('\f');
-      #13: Buf.Append('\r');
-    else
-      if Ord(Ch) < 32 then
-        Buf.Append('\u00' + IntToHex(Ord(Ch), 2))
-      else
-        Buf.AppendChar(AnsiChar(Ch));
-    end;
-  end;
-  Result := Buf.ToString;
-end;
 
 { Console: Opcode Profile }
 

--- a/units/Goccia.ScriptLoader.JSON.pas
+++ b/units/Goccia.ScriptLoader.JSON.pas
@@ -44,48 +44,12 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error,
   Goccia.JSON,
+  Goccia.JSON.Utils,
   Goccia.Timeout,
   Goccia.Values.Error,
   Goccia.Values.FunctionBase,
   Goccia.Values.ObjectValue,
   Goccia.VM.Exception;
-
-function EscapeJSONString(const AValue: string): string;
-var
-  I: Integer;
-  Ch: Char;
-  Buffer: TStringBuffer;
-begin
-  Buffer := TStringBuffer.Create(Length(AValue));
-  for I := 1 to Length(AValue) do
-  begin
-    Ch := AValue[I];
-    case Ch of
-      '"': Buffer.Append('\"');
-      '\': Buffer.Append('\\');
-      '/': Buffer.Append('\/');
-      #8: Buffer.Append('\b');
-      #9: Buffer.Append('\t');
-      #10: Buffer.Append('\n');
-      #12: Buffer.Append('\f');
-      #13: Buffer.Append('\r');
-    else
-      if Ord(Ch) < 32 then
-      begin
-        Buffer.Append('\u');
-        Buffer.Append(IntToHex(Ord(Ch), 4));
-      end
-      else
-        Buffer.AppendChar(Ch);
-    end;
-  end;
-  Result := Buffer.ToString;
-end;
-
-function QuoteJSONString(const AValue: string): string;
-begin
-  Result := '"' + EscapeJSONString(AValue) + '"';
-end;
 
 function NanosecondsToMillisecondsText(const ANanoseconds: Int64): string;
 begin

--- a/units/Goccia.SourceMap.pas
+++ b/units/Goccia.SourceMap.pas
@@ -41,7 +41,6 @@ type
     procedure GrowSegments;
     function FindLineStart(const AGeneratedLine: Integer): Integer;
     function EncodeMappings: string;
-    function EscapeJSONString(const AValue: string): string;
   public
     constructor Create(const AFile: string = '');
     destructor Destroy; override;
@@ -76,6 +75,7 @@ uses
   StringBuffer,
 
   Goccia.Base64,
+  Goccia.JSON.Utils,
   Goccia.SourceMap.VLQ;
 
 { TGocciaSourceMap }
@@ -244,38 +244,6 @@ begin
   ASourceLine := FSegments[BestIndex].SourceLine + 1;
   ASourceColumn := FSegments[BestIndex].SourceColumn + (AColumn - FSegments[BestIndex].GeneratedColumn);
   Result := True;
-end;
-
-function TGocciaSourceMap.EscapeJSONString(const AValue: string): string;
-var
-  Buffer: TStringBuffer;
-  I: Integer;
-  Ch: Char;
-begin
-  Buffer := TStringBuffer.Create(Length(AValue));
-  for I := 1 to Length(AValue) do
-  begin
-    Ch := AValue[I];
-    case Ch of
-      '"':  Buffer.Append('\"');
-      '\':  Buffer.Append('\\');
-      '/':  Buffer.Append('\/');
-      #8:   Buffer.Append('\b');
-      #9:   Buffer.Append('\t');
-      #10:  Buffer.Append('\n');
-      #12:  Buffer.Append('\f');
-      #13:  Buffer.Append('\r');
-    else
-      if Ord(Ch) < 32 then
-      begin
-        Buffer.Append('\u');
-        Buffer.Append(IntToHex(Ord(Ch), 4));
-      end
-      else
-        Buffer.AppendChar(Ch);
-    end;
-  end;
-  Result := Buffer.ToString;
 end;
 
 // TC39 Source Map Spec — Mappings encoding


### PR DESCRIPTION
## Summary
- Added `Goccia.JSON.Utils` to centralize JSON string escaping and quoting helpers.
- Replaced duplicated `EscapeJSONString`/`QuoteJSONString` implementations in the test runner, JSON5/TOML checks, script loader JSON, profiler report, source map, and core JSON code.
- Kept escaping behavior consistent across call sites while reducing maintenance overhead.

Fixes #303 

## Testing
- Not run (not requested).
- Concrete check: reviewed the updated call sites to confirm they now import `Goccia.JSON.Utils` and no longer define local escaping helpers.
- Concrete check: verified the new unit preserves escaping for quotes, backslashes, solidus, control characters, and `\uXXXX` fallback for other C0 controls.