### PR TITLE
Add parallel execution for multi-file runners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader # Execute stdin source
 ./build/TestRunner tests --coverage # Run tests with line and branch coverage
 ./build/TestRunner tests --coverage --coverage-format=lcov --coverage-output=coverage.lcov # Coverage with lcov output
 ./build/TestRunner tests --coverage --coverage-format=json --coverage-output=coverage.json # Coverage with JSON output
+./build/TestRunner tests --jobs=4 # Run tests with 4 parallel workers
+./build/TestRunner tests -j 1 # Force sequential execution (no threading)
 ./build/BenchmarkRunner benchmarks/ # Run all benchmarks
 ./build/BenchmarkRunner benchmarks --import-map=imports.json # Run benchmarks with an explicit import map
 ./build/BenchmarkRunner benchmarks/fibonacci.js # Run a specific benchmark
@@ -89,6 +91,7 @@ printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./bu
 ./build/BenchmarkRunner benchmarks --format=console --format=json --output=out.json # Console + JSON
 ./build/BenchmarkRunner benchmarks --no-progress # Suppress progress (CI)
 ./build/BenchmarkRunner benchmarks --mode=bytecode # Benchmarks via the Goccia bytecode VM
+./build/BenchmarkRunner benchmarks --jobs=4 # Run benchmarks with 4 parallel workers
 ```
 
 ### Compile and run (common workflows)

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -3,6 +3,7 @@ program BenchmarkRunner;
 {$I Goccia.inc}
 
 uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
   Classes,
   Generics.Collections,
   SysUtils,
@@ -40,6 +41,9 @@ uses
   Goccia.Values.Primitives,
   Goccia.VM.Exception,
 
+  Goccia.Threading,
+  Goccia.Threading.Init,
+
   FileUtils in 'units/FileUtils.pas';
 
 type
@@ -59,6 +63,10 @@ begin
   else
     WriteLn(SysUtils.Format('  [%d/%d] %s', [AIndex, ATotal, ABenchName]));
 end;
+
+type
+  TBenchmarkFileResultArray = array[0..MaxInt div SizeOf(TBenchmarkFileResult) - 1] of TBenchmarkFileResult;
+  PBenchmarkFileResultArray = ^TBenchmarkFileResultArray;
 
 procedure PopulateFileResult(const AFileResult: TBenchmarkFileResult;
   const AScriptResult: TGocciaObjectValue; const AReporter: TBenchmarkReporter);
@@ -172,6 +180,9 @@ type
       const AMode: TGocciaEngineBackend; const AShowProgress: Boolean);
     procedure RunBenchmarksFromStdin(const AReports: array of TReportSpec;
       const AMode: TGocciaEngineBackend; const AShowProgress: Boolean);
+    procedure BenchmarkWorkerProc(const AFileName: string;
+      const AIndex: Integer; out AConsoleOutput: string;
+      out AErrorMessage: string; AData: Pointer);
     procedure RunBenchmarks(const APaths: TStringList;
       const AReports: array of TReportSpec;
       const AMode: TGocciaEngineBackend; const AShowProgress: Boolean);
@@ -590,6 +601,54 @@ begin
   end;
 end;
 
+{ Worker procedure executed on each thread for a single benchmark file.
+  Runs the benchmark, extracts the TBenchmarkFileResult into a pre-allocated
+  array, and frees all GC-managed objects before returning. }
+procedure TBenchmarkRunnerApp.BenchmarkWorkerProc(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+var
+  WorkerReporter: TBenchmarkReporter;
+  WorkerResults: PBenchmarkFileResultArray;
+  Mode: TGocciaEngineBackend;
+begin
+  AConsoleOutput := '';
+  AErrorMessage := '';
+  WorkerResults := PBenchmarkFileResultArray(AData);
+
+  if EngineOptions.Mode.Matches(emBytecode) then
+    Mode := ebBytecode
+  else
+    Mode := ebTreeWalk;
+
+  WorkerReporter := TBenchmarkReporter.Create;
+  try
+    try
+      CollectBenchmarkFile(AFileName, WorkerReporter, Mode, False);
+      if WorkerReporter.FileCount > 0 then
+        WorkerResults^[AIndex] := WorkerReporter.Files[0];
+    except
+      on E: Exception do
+      begin
+        AErrorMessage := E.Message;
+        WorkerResults^[AIndex].FileName := AFileName;
+        WorkerResults^[AIndex].LexTimeNanoseconds := 0;
+        WorkerResults^[AIndex].ParseTimeNanoseconds := 0;
+        WorkerResults^[AIndex].CompileTimeNanoseconds := 0;
+        WorkerResults^[AIndex].ExecuteTimeNanoseconds := 0;
+        WorkerResults^[AIndex].TotalBenchmarks := 0;
+        WorkerResults^[AIndex].DurationNanoseconds := 0;
+        SetLength(WorkerResults^[AIndex].Entries, 1);
+        WorkerResults^[AIndex].Entries[0].Suite := '';
+        WorkerResults^[AIndex].Entries[0].Name := '(fatal)';
+        WorkerResults^[AIndex].Entries[0].Error := E.Message;
+      end;
+    end;
+  finally
+    WorkerReporter.Free;
+  end;
+end;
+
 procedure TBenchmarkRunnerApp.RunBenchmarksFromStdin(
   const AReports: array of TReportSpec;
   const AMode: TGocciaEngineBackend; const AShowProgress: Boolean);
@@ -625,8 +684,10 @@ procedure TBenchmarkRunnerApp.RunBenchmarks(const APaths: TStringList;
   const AMode: TGocciaEngineBackend; const AShowProgress: Boolean);
 var
   Files: TStringList;
-  I, J, P: Integer;
+  I, J, P, JobCount: Integer;
   Reporter: TBenchmarkReporter;
+  Pool: TGocciaThreadPool;
+  WorkerData: array of TBenchmarkFileResult;
 begin
   Files := TStringList.Create;
   Reporter := TBenchmarkReporter.Create;
@@ -645,12 +706,58 @@ begin
       end;
     end;
 
-    for I := 0 to Files.Count - 1 do
+    JobCount := GetJobCount(Files.Count);
+    if JobCount > 1 then
     begin
+      { Parallel path: pre-allocate result array, run workers, then
+        add results to the reporter on the main thread in file order. }
+      SetLength(WorkerData, Files.Count);
+      for I := 0 to Files.Count - 1 do
+      begin
+        WorkerData[I].FileName := '';
+        WorkerData[I].LexTimeNanoseconds := 0;
+        WorkerData[I].ParseTimeNanoseconds := 0;
+        WorkerData[I].CompileTimeNanoseconds := 0;
+        WorkerData[I].ExecuteTimeNanoseconds := 0;
+        WorkerData[I].TotalBenchmarks := 0;
+        WorkerData[I].DurationNanoseconds := 0;
+        SetLength(WorkerData[I].Entries, 0);
+      end;
+
       if AShowProgress then
-        WriteLn(SysUtils.Format('[%d/%d] %s', [I + 1, Files.Count, ExtractFileName(Files[I])]));
-      CollectBenchmarkFile(Files[I], Reporter, AMode, AShowProgress);
+        WriteLn(SysUtils.Format('Running %d files with %d workers...',
+          [Files.Count, JobCount]));
+
+      EnsureSharedPrototypesInitialized(GlobalBuiltins);
+
+      Pool := TGocciaThreadPool.Create(JobCount);
+      try
+        Pool.RunAll(Files, BenchmarkWorkerProc, @WorkerData[0]);
+      finally
+        Pool.Free;
+      end;
+
+      { Collect results on the main thread in original file order. }
+      for I := 0 to Files.Count - 1 do
+      begin
+        if AShowProgress then
+          WriteLn(SysUtils.Format('[%d/%d] %s',
+            [I + 1, Files.Count, ExtractFileName(Files[I])]));
+        Reporter.AddFileResult(WorkerData[I]);
+      end;
+    end
+    else
+    begin
+      { Sequential path: run each file in order on the main thread. }
+      for I := 0 to Files.Count - 1 do
+      begin
+        if AShowProgress then
+          WriteLn(SysUtils.Format('[%d/%d] %s',
+            [I + 1, Files.Count, ExtractFileName(Files[I])]));
+        CollectBenchmarkFile(Files[I], Reporter, AMode, AShowProgress);
+      end;
     end;
+
     if AShowProgress and (Files.Count > 0) then
       WriteLn;
 

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -707,6 +707,13 @@ begin
     end;
 
     JobCount := GetJobCount(Files.Count);
+
+    if JobCount > 1 then
+      WriteLn(SysUtils.Format('Running %d files with %d workers',
+        [Files.Count, JobCount]))
+    else if AShowProgress then
+      WriteLn(SysUtils.Format('Running %d files', [Files.Count]));
+
     if JobCount > 1 then
     begin
       { Parallel path: pre-allocate result array, run workers, then
@@ -723,10 +730,6 @@ begin
         WorkerData[I].DurationNanoseconds := 0;
         SetLength(WorkerData[I].Entries, 0);
       end;
-
-      if AShowProgress then
-        WriteLn(SysUtils.Format('Running %d files with %d workers...',
-          [Files.Count, JobCount]));
 
       EnsureSharedPrototypesInitialized(GlobalBuiltins);
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ GocciaScript has 3400+ JavaScript unit tests covering language features, built-i
 # Run a specific test
 ./build.pas testrunner && ./build/TestRunner tests/language/expressions/addition/basic-addition.js
 
+# Run tests with 4 parallel workers
+./build.pas testrunner && ./build/TestRunner tests --jobs=4
+
 # Run tests in standard JavaScript (Vitest) for cross-compatibility
 npx vitest run
 ```
@@ -151,6 +154,9 @@ npx vitest run
 
 # Run a benchmark from stdin
 printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner
+
+# Run benchmarks sequentially (single worker)
+./build/BenchmarkRunner benchmarks --jobs=1
 
 # Export as JSON or CSV
 ./build/BenchmarkRunner benchmarks --format=json --output=results.json

--- a/REPL.dpr
+++ b/REPL.dpr
@@ -3,6 +3,7 @@ program REPL;
 {$I units/Goccia.inc}
 
 uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
   Classes,
   Generics.Collections,
   SysUtils,

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -3,6 +3,7 @@ program ScriptLoader;
 {$I Goccia.inc}
 
 uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
   Classes,
   Generics.Collections,
   SysUtils,
@@ -37,6 +38,8 @@ uses
   Goccia.SourceMap,
   Goccia.Terminal.Colors,
   Goccia.TextFiles,
+  Goccia.Threading,
+  Goccia.Threading.Init,
   Goccia.Timeout,
   Goccia.Token,
   Goccia.Values.Error,
@@ -90,6 +93,10 @@ type
     procedure RunSource(const ASource: TStringList; const AFileName: string);
     procedure RunScriptFromFile(const AFileName: string);
     procedure RunScriptFromStdin;
+    procedure ScriptWorkerProc(const AFileName: string; const AIndex: Integer;
+      out AConsoleOutput: string; out AErrorMessage: string; AData: Pointer);
+    procedure RunScriptsParallel(const AFiles: TStringList;
+      const AJobCount: Integer);
     procedure RunScripts(const APath: string);
   protected
     procedure Configure; override;
@@ -682,6 +689,46 @@ begin
   end;
 end;
 
+procedure TScriptLoaderApp.ScriptWorkerProc(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+begin
+  AConsoleOutput := '';
+  AErrorMessage := '';
+  try
+    RunScriptFromFile(AFileName);
+  except
+    on E: Exception do
+    begin
+      AErrorMessage := E.Message;
+      ExitCode := 1;
+    end;
+  end;
+end;
+
+procedure TScriptLoaderApp.RunScriptsParallel(const AFiles: TStringList;
+  const AJobCount: Integer);
+var
+  Pool: TGocciaThreadPool;
+  I: Integer;
+begin
+  EnsureSharedPrototypesInitialized(GlobalBuiltins);
+
+  Pool := TGocciaThreadPool.Create(AJobCount);
+  try
+    Pool.RunAll(AFiles, ScriptWorkerProc);
+
+    for I := 0 to AFiles.Count - 1 do
+      if Pool.Results[I].ErrorMessage <> '' then
+      begin
+        WriteLn('Error in ', AFiles[I], ': ', Pool.Results[I].ErrorMessage);
+        ExitCode := 1;
+      end;
+  finally
+    Pool.Free;
+  end;
+end;
+
 procedure TScriptLoaderApp.RunScripts(const APath: string);
 var
   Files: TStringList;
@@ -700,12 +747,15 @@ begin
 
     Files := FindAllFiles(APath, ScriptExtensions);
     try
-      for I := 0 to Files.Count - 1 do
-      begin
-        if I > 0 then
-          WriteLn;
-        RunScriptFromFile(Files[I]);
-      end;
+      if GetJobCount(Files.Count) > 1 then
+        RunScriptsParallel(Files, GetJobCount(Files.Count))
+      else
+        for I := 0 to Files.Count - 1 do
+        begin
+          if I > 0 then
+            WriteLn;
+          RunScriptFromFile(Files[I]);
+        end;
     finally
       Files.Free;
     end;

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -748,7 +748,11 @@ begin
     Files := FindAllFiles(APath, ScriptExtensions);
     try
       if GetJobCount(Files.Count) > 1 then
-        RunScriptsParallel(Files, GetJobCount(Files.Count))
+      begin
+        WriteLn(SysUtils.Format('Running %d files with %d workers',
+          [Files.Count, GetJobCount(Files.Count)]));
+        RunScriptsParallel(Files, GetJobCount(Files.Count));
+      end
       else
         for I := 0 to Files.Count - 1 do
         begin

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -3,6 +3,7 @@ program TestRunner;
 {$I Goccia.inc}
 
 uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
   Classes,
   Generics.Collections,
   StrUtils,
@@ -38,9 +39,33 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives,
 
+  Goccia.Threading,
+  Goccia.Threading.Init,
+
   FileUtils in 'units/FileUtils.pas';
 
 type
+  { Plain-data record for extracting test results from GC-managed objects.
+    Used by the parallel path to pass results across thread boundaries
+    without referencing GC-managed TGocciaValue instances. }
+  TTestWorkerData = record
+    Passed: Double;
+    Failed: Double;
+    Skipped: Double;
+    TotalRunTests: Double;
+    Assertions: Double;
+    Duration: Double;
+    FailedTestNames: array of string;
+    LexNs: Int64;
+    ParseNs: Int64;
+    CompileNs: Int64;
+    ExecNs: Int64;
+    ErrorMessage: string;
+  end;
+
+  TTestWorkerDataArray = array[0..MaxInt div SizeOf(TTestWorkerData) - 1] of TTestWorkerData;
+  PTestWorkerDataArray = ^TTestWorkerDataArray;
+
   TTestFileResult = record
     TestResult: TGocciaObjectValue;
     Timing: TGocciaScriptResult;
@@ -73,6 +98,9 @@ type
     function RunGocciaScript(const AFileName: string): TTestFileResult;
     function RunScriptFromFile(const AFileName: string): TAggregatedTestResult;
     function RunScriptsFromFiles(const AFiles: TStringList): TAggregatedTestResult;
+    function RunScriptsFromFilesParallel(const AFiles: TStringList; const AJobCount: Integer): TAggregatedTestResult;
+    procedure TestWorkerProc(const AFileName: string; const AIndex: Integer;
+      out AConsoleOutput: string; out AErrorMessage: string; AData: Pointer);
     procedure WriteResultsJSON(const AResult: TAggregatedTestResult; const AFileName: string);
     procedure PrintTestResults(const AResult: TAggregatedTestResult);
   end;
@@ -196,6 +224,8 @@ begin
         WriteLn('[1/1] ', Files[0]);
       PrintTestResults(RunScriptFromFile(Files[0]));
     end
+    else if GetJobCount(Files.Count) > 1 then
+      PrintTestResults(RunScriptsFromFilesParallel(Files, GetJobCount(Files.Count)))
     else
       PrintTestResults(RunScriptsFromFiles(Files));
 
@@ -573,6 +603,192 @@ begin
   AllTestResults.AssignProperty('totalRunTests', TGocciaNumberLiteralValue.Create(TotalRunCount));
   AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(TotalDuration));
   AllTestResults.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(TotalAssertions));
+
+  Result.TestResult := AllTestResults;
+end;
+
+{ Worker procedure executed on each thread for a single file.
+  Runs the script, extracts numeric results into a thread-safe record,
+  and frees all GC-managed objects before returning. }
+procedure TTestRunnerApp.TestWorkerProc(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+var
+  FileResult: TTestFileResult;
+  TestResult: TGocciaObjectValue;
+  FailedTests: TGocciaValue;
+  FailedArr: TGocciaArrayValue;
+  WorkerResults: PTestWorkerDataArray;
+  I: Integer;
+begin
+  AConsoleOutput := '';
+  AErrorMessage := '';
+  WorkerResults := PTestWorkerDataArray(AData);
+
+  try
+    FileResult := RunGocciaScript(AFileName);
+    TestResult := FileResult.TestResult;
+
+    if TestResult <> nil then
+    begin
+      WorkerResults^[AIndex].Passed := TestResult.GetProperty('passed').ToNumberLiteral.Value;
+      WorkerResults^[AIndex].Failed := TestResult.GetProperty('failed').ToNumberLiteral.Value;
+      WorkerResults^[AIndex].Skipped := TestResult.GetProperty('skipped').ToNumberLiteral.Value;
+      WorkerResults^[AIndex].TotalRunTests := TestResult.GetProperty('totalRunTests').ToNumberLiteral.Value;
+      WorkerResults^[AIndex].Assertions := TestResult.GetProperty('assertions').ToNumberLiteral.Value;
+      WorkerResults^[AIndex].Duration := TestResult.GetProperty('duration').ToNumberLiteral.Value;
+      WorkerResults^[AIndex].LexNs := FileResult.Timing.LexTimeNanoseconds;
+      WorkerResults^[AIndex].ParseNs := FileResult.Timing.ParseTimeNanoseconds;
+      WorkerResults^[AIndex].CompileNs := FileResult.Timing.CompileTimeNanoseconds;
+      WorkerResults^[AIndex].ExecNs := FileResult.Timing.ExecuteTimeNanoseconds;
+
+      FailedTests := TestResult.GetProperty('failedTests');
+      if FailedTests is TGocciaArrayValue then
+      begin
+        FailedArr := TGocciaArrayValue(FailedTests);
+        SetLength(WorkerResults^[AIndex].FailedTestNames, FailedArr.Elements.Count);
+        for I := 0 to FailedArr.Elements.Count - 1 do
+          WorkerResults^[AIndex].FailedTestNames[I] := FailedArr.Elements[I].ToStringLiteral.Value;
+      end;
+    end
+    else
+      WorkerResults^[AIndex].ErrorMessage := 'Test result was nil';
+  except
+    on E: TGocciaError do
+    begin
+      WorkerResults^[AIndex].ErrorMessage := E.GetDetailedMessage;
+      WorkerResults^[AIndex].Failed := 1;
+      WorkerResults^[AIndex].TotalRunTests := 1;
+      SetLength(WorkerResults^[AIndex].FailedTestNames, 1);
+      WorkerResults^[AIndex].FailedTestNames[0] := AFileName + ': ' + E.GetDetailedMessage;
+    end;
+    on E: TGocciaThrowValue do
+    begin
+      WorkerResults^[AIndex].ErrorMessage := E.Message;
+      WorkerResults^[AIndex].Failed := 1;
+      WorkerResults^[AIndex].TotalRunTests := 1;
+      SetLength(WorkerResults^[AIndex].FailedTestNames, 1);
+      WorkerResults^[AIndex].FailedTestNames[0] := AFileName + ': ' + E.Message;
+    end;
+    on E: Exception do
+    begin
+      WorkerResults^[AIndex].ErrorMessage := E.Message;
+      WorkerResults^[AIndex].Failed := 1;
+      WorkerResults^[AIndex].TotalRunTests := 1;
+      SetLength(WorkerResults^[AIndex].FailedTestNames, 1);
+      WorkerResults^[AIndex].FailedTestNames[0] := AFileName + ': ' + E.Message;
+    end;
+  end;
+
+  // No GC.Collect — worker GC is disabled to avoid FGCMark races on
+  // shared objects. All thread-local objects are freed in bulk when
+  // ShutdownThreadRuntime destroys the thread-local GC.
+end;
+
+function TTestRunnerApp.RunScriptsFromFilesParallel(
+  const AFiles: TStringList; const AJobCount: Integer): TAggregatedTestResult;
+var
+  Pool: TGocciaThreadPool;
+  WorkerData: array of TTestWorkerData;
+  GC: TGarbageCollector;
+  I, J: Integer;
+  AllTestResults: TGocciaObjectValue;
+  AllFailedTests: TGocciaArrayValue;
+  PassedCount, FailedCount, SkippedCount, TotalRunCount, TotalAssertions, TotalDuration: Double;
+begin
+  SetLength(WorkerData, AFiles.Count);
+  for I := 0 to AFiles.Count - 1 do
+  begin
+    WorkerData[I].Passed := 0;
+    WorkerData[I].Failed := 0;
+    WorkerData[I].Skipped := 0;
+    WorkerData[I].TotalRunTests := 0;
+    WorkerData[I].Assertions := 0;
+    WorkerData[I].Duration := 0;
+    WorkerData[I].LexNs := 0;
+    WorkerData[I].ParseNs := 0;
+    WorkerData[I].CompileNs := 0;
+    WorkerData[I].ExecNs := 0;
+    WorkerData[I].ErrorMessage := '';
+    SetLength(WorkerData[I].FailedTestNames, 0);
+  end;
+
+  if not FNoProgress.Present then
+    WriteLn(SysUtils.Format('Running %d files with %d workers...', [AFiles.Count, AJobCount]));
+
+  // Force all shared prototypes to be initialised on the main thread
+  // before any worker thread starts, avoiding class-var race conditions.
+  EnsureSharedPrototypesInitialized(GlobalBuiltins);
+
+  Pool := TGocciaThreadPool.Create(AJobCount);
+  try
+    Pool.RunAll(AFiles, TestWorkerProc, @WorkerData[0]);
+  finally
+    Pool.Free;
+  end;
+
+  // Aggregate results on the main thread using GC-managed objects
+  GC := TGarbageCollector.Instance;
+
+  AllTestResults := TGocciaObjectValue.Create;
+  AllFailedTests := TGocciaArrayValue.Create;
+
+  if Assigned(GC) then
+  begin
+    GC.AddTempRoot(AllTestResults);
+    GC.AddTempRoot(AllFailedTests);
+  end;
+
+  PassedCount := 0;
+  FailedCount := 0;
+  SkippedCount := 0;
+  TotalRunCount := 0;
+  TotalAssertions := 0;
+  TotalDuration := 0;
+  Result.TotalLexNanoseconds := 0;
+  Result.TotalParseNanoseconds := 0;
+  Result.TotalCompileNanoseconds := 0;
+  Result.TotalExecNanoseconds := 0;
+
+  for I := 0 to AFiles.Count - 1 do
+  begin
+    if not FNoProgress.Present then
+      WriteLn(SysUtils.Format('[%d/%d] %s', [I + 1, AFiles.Count, AFiles[I]]));
+
+    if WorkerData[I].ErrorMessage <> '' then
+      WriteLn(WorkerData[I].ErrorMessage);
+
+    PassedCount := PassedCount + WorkerData[I].Passed;
+    FailedCount := FailedCount + WorkerData[I].Failed;
+    SkippedCount := SkippedCount + WorkerData[I].Skipped;
+    TotalRunCount := TotalRunCount + WorkerData[I].TotalRunTests;
+    TotalAssertions := TotalAssertions + WorkerData[I].Assertions;
+    TotalDuration := TotalDuration + WorkerData[I].Duration;
+
+    Result.TotalLexNanoseconds := Result.TotalLexNanoseconds + WorkerData[I].LexNs;
+    Result.TotalParseNanoseconds := Result.TotalParseNanoseconds + WorkerData[I].ParseNs;
+    Result.TotalCompileNanoseconds := Result.TotalCompileNanoseconds + WorkerData[I].CompileNs;
+    Result.TotalExecNanoseconds := Result.TotalExecNanoseconds + WorkerData[I].ExecNs;
+
+    for J := 0 to High(WorkerData[I].FailedTestNames) do
+      AllFailedTests.Elements.Add(
+        TGocciaStringLiteralValue.Create(WorkerData[I].FailedTestNames[J]));
+  end;
+
+  AllTestResults.AssignProperty('totalTests', TGocciaNumberLiteralValue.Create(AFiles.Count * 1.0));
+  AllTestResults.AssignProperty('totalRunTests', TGocciaNumberLiteralValue.Create(TotalRunCount));
+  AllTestResults.AssignProperty('passed', TGocciaNumberLiteralValue.Create(PassedCount));
+  AllTestResults.AssignProperty('failed', TGocciaNumberLiteralValue.Create(FailedCount));
+  AllTestResults.AssignProperty('skipped', TGocciaNumberLiteralValue.Create(SkippedCount));
+  AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(TotalDuration));
+  AllTestResults.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(TotalAssertions));
+  AllTestResults.AssignProperty('failedTests', AllFailedTests);
+
+  if Assigned(GC) then
+  begin
+    GC.RemoveTempRoot(AllTestResults);
+    GC.RemoveTempRoot(AllFailedTests);
+  end;
 
   Result.TestResult := AllTestResults;
 end;

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -230,7 +230,7 @@ begin
         WriteLn('[1/1] ', Files[0]);
       PrintTestResults(RunScriptFromFile(Files[0]));
     end
-    else if GetJobCount(Files.Count) > 1 then
+    else if not FExitOnFirst.Present and (GetJobCount(Files.Count) > 1) then
       PrintTestResults(RunScriptsFromFilesParallel(Files, GetJobCount(Files.Count)))
     else
       PrintTestResults(RunScriptsFromFiles(Files));

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -218,6 +218,12 @@ begin
       end;
     end;
 
+    if GetJobCount(Files.Count) > 1 then
+      WriteLn(SysUtils.Format('Running %d files with %d workers',
+        [Files.Count, GetJobCount(Files.Count)]))
+    else if not FNoProgress.Present then
+      WriteLn(SysUtils.Format('Running %d files', [Files.Count]));
+
     if Files.Count = 1 then
     begin
       if not FNoProgress.Present then
@@ -712,9 +718,6 @@ begin
     WorkerData[I].ErrorMessage := '';
     SetLength(WorkerData[I].FailedTestNames, 0);
   end;
-
-  if not FNoProgress.Present then
-    WriteLn(SysUtils.Format('Running %d files with %d workers...', [AFiles.Count, AJobCount]));
 
   // Force all shared prototypes to be initialised on the main thread
   // before any worker thread starts, avoiding class-var race conditions.

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -230,7 +230,7 @@ begin
         WriteLn('[1/1] ', Files[0]);
       PrintTestResults(RunScriptFromFile(Files[0]));
     end
-    else if not FExitOnFirst.Present and (GetJobCount(Files.Count) > 1) then
+    else if GetJobCount(Files.Count) > 1 then
       PrintTestResults(RunScriptsFromFilesParallel(Files, GetJobCount(Files.Count)))
     else
       PrintTestResults(RunScriptsFromFiles(Files));
@@ -725,7 +725,11 @@ begin
 
   Pool := TGocciaThreadPool.Create(AJobCount);
   try
+    Pool.CancelOnError := FExitOnFirst.Present;
+    Pool.EnableCoverage := CoverageOptions.Enabled.Present;
     Pool.RunAll(AFiles, TestWorkerProc, @WorkerData[0]);
+    if Pool.EnableCoverage and Assigned(TGocciaCoverageTracker.Instance) then
+      Pool.MergeCoverageInto(TGocciaCoverageTracker.Instance);
   finally
     Pool.Free;
   end;

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -27,6 +27,9 @@ GocciaScript includes a benchmark runner for measuring execution performance. Be
 printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner
 printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner - --mode=bytecode
 
+# Run benchmarks with 2 parallel workers (default: CPU count)
+./build/BenchmarkRunner benchmarks --jobs=2
+
 # Export results in different formats
 ./build/BenchmarkRunner benchmarks --format=json --output=results.json
 ./build/BenchmarkRunner benchmarks --format=csv --output=results.csv

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -136,6 +136,11 @@ printf "const f = () => f(); f();" | ./build/ScriptLoader --timeout=100
 # Run tests via bytecode VM
 ./build/TestRunner tests --mode=bytecode
 
+# Control parallel worker threads (default: CPU count; --jobs=1 forces sequential)
+./build/ScriptLoader example.js --jobs=4
+./build/TestRunner tests --jobs=4
+./build/BenchmarkRunner benchmarks --jobs=1
+
 # Run benchmarks via bytecode VM
 ./build/BenchmarkRunner benchmarks --mode=bytecode
 printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner - --mode=bytecode

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -258,6 +258,7 @@ Both modes must pass. The `--asi` flag enables automatic semicolon insertion tes
 | `--no-results` | Suppress test results summary |
 | `--exit-on-first-failure` | Stop on first test failure |
 | `--silent` | Suppress all console output from test scripts |
+| `--jobs=N` / `-j N` | Number of parallel worker threads (default: CPU count) |
 
 ```bash
 # CI-friendly: no progress, stop on first failure
@@ -265,6 +266,9 @@ Both modes must pass. The `--asi` flag enables automatic semicolon insertion tes
 
 # Silent mode: only show results, suppress script console output
 ./build/TestRunner tests --silent
+
+# Run tests with 4 parallel workers; --jobs=1 forces sequential execution
+./build/TestRunner tests --jobs=4
 ```
 
 **Official YAML Suite**

--- a/units/Goccia.Benchmark.Reporter.pas
+++ b/units/Goccia.Benchmark.Reporter.pas
@@ -46,6 +46,7 @@ type
     procedure RenderCSV;
     procedure RenderJSON;
 
+    function GetFileResult(AIndex: Integer): TBenchmarkFileResult;
     function FormatOpsPerSec(const AOps: Double): string;
     function EscapeCSV(const S: string): string;
     function EscapeJSON(const S: string): string;
@@ -60,6 +61,8 @@ type
     procedure WriteToStdOut;
     function HasFailures: Boolean;
     property Output: TStringList read FOutput;
+    property FileCount: Integer read FFileCount;
+    property Files[AIndex: Integer]: TBenchmarkFileResult read GetFileResult;
   end;
 
 function ParseReportFormat(const S: string): TBenchmarkReportFormat;
@@ -100,6 +103,11 @@ destructor TBenchmarkReporter.Destroy;
 begin
   FOutput.Free;
   inherited Destroy;
+end;
+
+function TBenchmarkReporter.GetFileResult(AIndex: Integer): TBenchmarkFileResult;
+begin
+  Result := FFiles[AIndex];
 end;
 
 procedure TBenchmarkReporter.AddFileResult(const AResult: TBenchmarkFileResult);

--- a/units/Goccia.Builtins.Console.pas
+++ b/units/Goccia.Builtins.Console.pas
@@ -18,7 +18,6 @@ uses
 type
   TGocciaConsole = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
     FTimers: TGocciaObjectValue;
     FCounters: TGocciaObjectValue;
     FGroupDepth: Integer;
@@ -67,6 +66,9 @@ uses
   TimingUtils,
 
   Goccia.Values.ArrayValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaConsole.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var

--- a/units/Goccia.Builtins.GlobalArray.pas
+++ b/units/Goccia.Builtins.GlobalArray.pas
@@ -16,7 +16,6 @@ uses
 type
   TGocciaGlobalArray = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
   protected
   published
     function IsArray(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -50,6 +49,9 @@ uses
   Goccia.Values.PromiseValue,
   Goccia.Values.SymbolValue,
   Goccia.VM.Exception;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaGlobalArray.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var

--- a/units/Goccia.Builtins.GlobalArrayBuffer.pas
+++ b/units/Goccia.Builtins.GlobalArrayBuffer.pas
@@ -17,7 +17,6 @@ uses
 type
   TGocciaGlobalArrayBuffer = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
     FArrayBufferConstructor: TGocciaNativeFunctionValue;
   published
     function ArrayBufferConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -34,6 +33,9 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Values.ErrorHelper,
   Goccia.Values.TypedArrayValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 const
   NO_MAX_BYTE_LENGTH = -1;

--- a/units/Goccia.Builtins.GlobalFFI.pas
+++ b/units/Goccia.Builtins.GlobalFFI.pas
@@ -14,8 +14,6 @@ uses
 
 type
   TGocciaGlobalFFI = class(TGocciaBuiltin)
-  private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
   published
     function FFIOpen(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function FFINullptrGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -35,6 +33,9 @@ uses
   Goccia.Values.FFILibrary,
   Goccia.Values.FFIPointer,
   Goccia.Values.ObjectPropertyDescriptor;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 const
   {$IFDEF DARWIN}

--- a/units/Goccia.Builtins.GlobalNumber.pas
+++ b/units/Goccia.Builtins.GlobalNumber.pas
@@ -15,8 +15,6 @@ uses
 
 type
   TGocciaGlobalNumber = class(TGocciaBuiltin)
-  private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
   published
@@ -37,6 +35,9 @@ uses
   Goccia.Arguments.Validator,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaGlobalNumber.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var

--- a/units/Goccia.Builtins.GlobalObject.pas
+++ b/units/Goccia.Builtins.GlobalObject.pas
@@ -16,7 +16,6 @@ uses
 type
   TGocciaGlobalObject = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
   protected
     // Native methods
   published
@@ -65,6 +64,9 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ProxyValue,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 // ES2026 §6.2.6.4 FromPropertyDescriptor(Desc)
 function FromPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor): TGocciaObjectValue;

--- a/units/Goccia.Builtins.GlobalPromise.pas
+++ b/units/Goccia.Builtins.GlobalPromise.pas
@@ -17,7 +17,6 @@ uses
 type
   TGocciaGlobalPromise = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
     FPromiseConstructor: TGocciaNativeFunctionValue;
 
     function ExtractPromiseArray(const AArgs: TGocciaArgumentsCollection): TGocciaArrayValue;
@@ -53,6 +52,9 @@ uses
   Goccia.Values.PromiseValue,
   Goccia.Values.SetValue,
   Goccia.VM.Exception;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 type
   TPromiseAllState = class(TGocciaObjectValue)

--- a/units/Goccia.Builtins.GlobalReflect.pas
+++ b/units/Goccia.Builtins.GlobalReflect.pas
@@ -15,8 +15,6 @@ uses
 
 type
   TGocciaGlobalReflect = class(TGocciaBuiltin)
-  private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
   published
     function ReflectApply(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ReflectConstruct(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -51,6 +49,9 @@ uses
   Goccia.Values.FunctionBase,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 { Helper: validate target is an object, throw TypeError if not }
 

--- a/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/units/Goccia.Builtins.GlobalRegExp.pas
@@ -19,8 +19,6 @@ type
   private
     FRegExpConstructor: TGocciaNativeFunctionValue;
     FRegExpPrototype: TGocciaObjectValue;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-    class var FStaticMembers: array of TGocciaMemberDefinition;
 
     function RegExpConstructorFn(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -66,6 +64,10 @@ uses
   Goccia.Values.Iterator.RegExp,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 function GetRegExpBooleanProperty(const AValue: TGocciaObjectValue;
   const AName: string): Boolean;

--- a/units/Goccia.Builtins.GlobalString.pas
+++ b/units/Goccia.Builtins.GlobalString.pas
@@ -14,8 +14,6 @@ uses
 
 type
   TGocciaGlobalString = class(TGocciaBuiltin)
-  private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
   published
@@ -36,6 +34,9 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaGlobalString.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var

--- a/units/Goccia.Builtins.GlobalSymbol.pas
+++ b/units/Goccia.Builtins.GlobalSymbol.pas
@@ -23,7 +23,6 @@ type
   private
     FGlobalRegistry: TOrderedStringMap<TGocciaSymbolValue>;
     FSymbolFunction: TGocciaNativeFunctionValue;
-    class var FStaticMembers: array of TGocciaMemberDefinition;
 
     // Well-known symbols
     FIteratorSymbol: TGocciaSymbolValue;
@@ -46,6 +45,9 @@ uses
   Goccia.Constants.SymbolNames,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaGlobalSymbol.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var

--- a/units/Goccia.Builtins.GlobalURL.pas
+++ b/units/Goccia.Builtins.GlobalURL.pas
@@ -17,8 +17,6 @@ uses
 
 type
   TGocciaGlobalURL = class(TGocciaBuiltin)
-  private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
   published
     // WHATWG URL §4.7.3 URL.canParse(url[, base])
     function CanParse(const AArgs: TGocciaArgumentsCollection;
@@ -50,6 +48,9 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.URLSearchParamsValue,
   Goccia.Values.URLValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 { TGocciaGlobalURL }
 

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -13,7 +13,7 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
-var
+threadvar
   GErrorProto: TGocciaObjectValue;
   GTypeErrorProto: TGocciaObjectValue;
   GReferenceErrorProto: TGocciaObjectValue;

--- a/units/Goccia.Builtins.JSON.pas
+++ b/units/Goccia.Builtins.JSON.pas
@@ -23,7 +23,6 @@ uses
 type
   TGocciaJSONBuiltin = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
     FParser: TGocciaJSONParser;
     FReplacerTraversalStack: TList<TGocciaObjectValue>;
     FReviverSourceIndex: Integer;
@@ -60,6 +59,9 @@ uses
   Goccia.Values.HoleValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaJSONBuiltin.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var

--- a/units/Goccia.Builtins.JSON5.pas
+++ b/units/Goccia.Builtins.JSON5.pas
@@ -22,7 +22,6 @@ uses
 type
   TGocciaJSON5Builtin = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
     FParser: TGocciaJSON5Parser;
     FReplacerTraversalStack: TList<TGocciaObjectValue>;
     FReviverSourceIndex: Integer;
@@ -76,6 +75,9 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
   Goccia.Values.WrapperPrimitives;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 function UTF8SequenceLengthFromLeadByte(const AChar: Char): Integer;
 var

--- a/units/Goccia.Builtins.JSONL.pas
+++ b/units/Goccia.Builtins.JSONL.pas
@@ -20,7 +20,6 @@ uses
 type
   TGocciaJSONLBuiltin = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
     FParser: TGocciaJSONLParser;
 
     class function ClampOffset(const AValue, ALimit: Integer): Integer; static;
@@ -49,6 +48,9 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaJSONLBuiltin.Create(const AName: string;
   const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);

--- a/units/Goccia.Builtins.Math.pas
+++ b/units/Goccia.Builtins.Math.pas
@@ -15,8 +15,6 @@ uses
 
 type
   TGocciaMath = class(TGocciaBuiltin)
-  private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
   published
     function MathAbs(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function MathFloor(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -79,6 +77,9 @@ uses
   Goccia.Values.IteratorValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 { TGocciaMath }
 

--- a/units/Goccia.Builtins.Performance.pas
+++ b/units/Goccia.Builtins.Performance.pas
@@ -40,10 +40,6 @@ type
 
   TGocciaPerformance = class(TGocciaBuiltin)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-    class var FPrototypeMethodHost: TGocciaPerformancePrototypeHost;
-
     class procedure InitializePrototype;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
@@ -62,6 +58,11 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+  FPrototypeMethodHost: TGocciaPerformancePrototypeHost;
 
 function RequirePerformanceThis(const AThisValue: TGocciaValue): TGocciaPerformanceValue;
 begin
@@ -90,7 +91,7 @@ begin
   FTimeOriginMonotonicNanoseconds := (MonotonicBefore + MonotonicAfter) div 2;
 
   TGocciaPerformance.InitializePrototype;
-  FPrototype := TGocciaPerformance.FShared.Prototype;
+  FPrototype := FShared.Prototype;
 end;
 
 { TGocciaPerformancePrototypeHost }

--- a/units/Goccia.Builtins.TOML.pas
+++ b/units/Goccia.Builtins.TOML.pas
@@ -17,7 +17,6 @@ uses
 type
   TGocciaTOMLBuiltin = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
     FParser: TGocciaTOMLParser;
   published
     function TOMLParse(const AArgs: TGocciaArgumentsCollection;
@@ -36,6 +35,9 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaTOMLBuiltin.Create(const AName: string;
   const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);

--- a/units/Goccia.Builtins.YAML.pas
+++ b/units/Goccia.Builtins.YAML.pas
@@ -17,7 +17,6 @@ uses
 type
   TGocciaYAMLBuiltin = class(TGocciaBuiltin)
   private
-    class var FStaticMembers: array of TGocciaMemberDefinition;
     FParser: TGocciaYAMLParser;
   published
     function YAMLParse(const AArgs: TGocciaArgumentsCollection;
@@ -38,6 +37,9 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaYAMLBuiltin.Create(const AName: string;
   const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);

--- a/units/Goccia.CLI.Application.pas
+++ b/units/Goccia.CLI.Application.pas
@@ -17,6 +17,7 @@ type
   TGocciaCLIApplication = class(TGocciaApplication)
   private
     FHelp: TGocciaFlagOption;
+    FJobs: TGocciaIntegerOption;
     FEngineOptions: TGocciaEngineOptions;
     FCoverageOptions: TGocciaCoverageOptions;
     FProfilerOptions: TGocciaProfilerOptions;
@@ -44,6 +45,9 @@ type
       const ASource: TStringList): TGocciaEngine;
     function CreateBytecodeBackend(
       const AFileName: string): TGocciaBytecodeBackend;
+    { Returns the effective job count: --jobs value, or ProcessorCount,
+      capped to AFileCount. Returns 1 when parallelism is not desired. }
+    function GetJobCount(const AFileCount: Integer): Integer;
     property EngineOptions: TGocciaEngineOptions read FEngineOptions;
     property CoverageOptions: TGocciaCoverageOptions read FCoverageOptions;
     property ProfilerOptions: TGocciaProfilerOptions read FProfilerOptions;
@@ -55,6 +59,8 @@ type
 implementation
 
 uses
+  Math,
+
   Goccia.CLI.EngineSetup,
   Goccia.CLI.Help,
   Goccia.CLI.Parser,
@@ -73,6 +79,7 @@ begin
   FCoverageOptions := nil;
   FProfilerOptions := nil;
   FHelp := nil;
+  FJobs := nil;
 end;
 
 destructor TGocciaCLIApplication.Destroy;
@@ -82,6 +89,7 @@ begin
   FCoverageOptions.Free;
   FProfilerOptions.Free;
   FHelp.Free;
+  FJobs.Free;
   inherited Destroy;
 end;
 
@@ -209,6 +217,17 @@ begin
   // Override point for subclasses
 end;
 
+function TGocciaCLIApplication.GetJobCount(const AFileCount: Integer): Integer;
+begin
+  if AFileCount <= 1 then
+    Exit(1);
+  if Assigned(FJobs) and FJobs.Present then
+    Result := Max(1, FJobs.Value)
+  else
+    Result := TThread.ProcessorCount;
+  Result := Min(Result, AFileCount);
+end;
+
 procedure TGocciaCLIApplication.InitializeSingletons;
 begin
   if Assigned(FCoverageOptions) then
@@ -235,7 +254,14 @@ begin
   FHelp := TGocciaFlagOption.Create('help', 'Show this help message');
   FHelp.ShortName := 'h';
 
+  FJobs := TGocciaIntegerOption.Create('jobs', 'Number of parallel worker threads');
+  FJobs.ShortName := 'j';
+  // FJobs is freed in the destructor; add it to FAllOptions manually below
+
   BuildAllOptions;
+  // Append --jobs after BuildAllOptions so it appears in help
+  SetLength(FAllOptions, Length(FAllOptions) + 1);
+  FAllOptions[High(FAllOptions)] := FJobs;
 
   Paths := ParseCommandLine(FAllOptions);
   try

--- a/units/Goccia.CLI.Application.pas
+++ b/units/Goccia.CLI.Application.pas
@@ -69,6 +69,40 @@ uses
   Goccia.Profiler,
   Goccia.Timeout;
 
+{ FPC 3.2.2 GetCPUCount uses wrong _SC_NPROCESSORS_ONLN constants on
+  macOS (expects Linux 84, actual macOS value is 58) and may also fail
+  on some Linux configurations.  Call sysconf / sysctlbyname directly
+  with the correct per-OS constant so we always detect all cores. }
+
+{$IFDEF UNIX}
+function libc_sysconf(Name: Integer): Int64; cdecl; external 'c' name 'sysconf';
+{$ENDIF}
+
+function GetProcessorCount: Integer;
+{$IFDEF UNIX}
+const
+  {$IFDEF DARWIN}
+  SC_NPROCESSORS_ONLN = 58;
+  {$ELSE}
+  SC_NPROCESSORS_ONLN = 84;   { Linux }
+  {$ENDIF}
+var
+  N: Int64;
+{$ENDIF}
+begin
+  {$IFDEF UNIX}
+  N := libc_sysconf(SC_NPROCESSORS_ONLN);
+  if N > 0 then
+    Result := Integer(N)
+  else
+    Result := 1;
+  {$ELSE}
+  Result := TThread.ProcessorCount;
+  if Result < 1 then
+    Result := 1;
+  {$ENDIF}
+end;
+
 { TGocciaCLIApplication }
 
 constructor TGocciaCLIApplication.Create(const AName: string);
@@ -221,10 +255,13 @@ function TGocciaCLIApplication.GetJobCount(const AFileCount: Integer): Integer;
 begin
   if AFileCount <= 1 then
     Exit(1);
+  { Coverage tracking is not yet thread-safe — force sequential. }
+  if Assigned(FCoverageOptions) and FCoverageOptions.Enabled.Present then
+    Exit(1);
   if Assigned(FJobs) and FJobs.Present then
     Result := Max(1, FJobs.Value)
   else
-    Result := TThread.ProcessorCount;
+    Result := GetProcessorCount;
   Result := Min(Result, AFileCount);
 end;
 

--- a/units/Goccia.CLI.Application.pas
+++ b/units/Goccia.CLI.Application.pas
@@ -255,9 +255,6 @@ function TGocciaCLIApplication.GetJobCount(const AFileCount: Integer): Integer;
 begin
   if AFileCount <= 1 then
     Exit(1);
-  { Coverage tracking is not yet thread-safe — force sequential. }
-  if Assigned(FCoverageOptions) and FCoverageOptions.Enabled.Present then
-    Exit(1);
   if Assigned(FJobs) and FJobs.Present then
     Result := Max(1, FJobs.Value)
   else

--- a/units/Goccia.CallStack.pas
+++ b/units/Goccia.CallStack.pas
@@ -15,8 +15,6 @@ type
   TGocciaCallFrameArray = array of TGocciaCallFrame;
 
   TGocciaCallStack = class
-  private class var
-    FInstance: TGocciaCallStack;
   private
     FFrames: array of TGocciaCallFrame;
     FCount: Integer;
@@ -48,22 +46,25 @@ uses
 const
   INITIAL_CAPACITY = 32;
 
+threadvar
+  CallStackThreadInstance: TGocciaCallStack;
+
 { TGocciaCallStack }
 
 class function TGocciaCallStack.Instance: TGocciaCallStack;
 begin
-  Result := FInstance;
+  Result := CallStackThreadInstance;
 end;
 
 class procedure TGocciaCallStack.Initialize;
 begin
-  if not Assigned(FInstance) then
-    FInstance := TGocciaCallStack.Create;
+  if not Assigned(CallStackThreadInstance) then
+    CallStackThreadInstance := TGocciaCallStack.Create;
 end;
 
 class procedure TGocciaCallStack.Shutdown;
 begin
-  FreeAndNil(FInstance);
+  FreeAndNil(CallStackThreadInstance);
 end;
 
 constructor TGocciaCallStack.Create;

--- a/units/Goccia.Compiler.Scope.pas
+++ b/units/Goccia.Compiler.Scope.pas
@@ -337,8 +337,8 @@ begin
   Result := '';
 end;
 
-var
-  GClassPrivateCounter: Integer = 0;
+threadvar
+  GClassPrivateCounter: Integer;
 
 function NextClassPrivatePrefix: string;
 begin

--- a/units/Goccia.Compiler.Statements.pas
+++ b/units/Goccia.Compiler.Statements.pas
@@ -103,10 +103,10 @@ type
     UsingErrorReg: UInt8;
   end;
 
-var
-  GBreakJumps: TList<Integer> = nil;
+threadvar
+  GBreakJumps: TList<Integer>;
   GPendingFinally: TList<TPendingFinallyEntry>;
-  GBreakFinallyBase: Integer = 0;
+  GBreakFinallyBase: Integer;
 
 procedure CompileExpressionStatement(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaExpressionStatement);
@@ -570,10 +570,9 @@ begin
   end;
 end;
 
-var
+threadvar
   // Module-level stack of using resource entries for the current block.
   // Populated by CompileUsingDeclaration, consumed by CompileBlockStatement.
-  // NOTE: Not thread-safe; compiler is assumed to be single-threaded.
   GUsingResources: TList<TUsingResourceEntry>;
 
 // TC39 Explicit Resource Management: compile using / await using declaration.

--- a/units/Goccia.Coverage.pas
+++ b/units/Goccia.Coverage.pas
@@ -55,8 +55,6 @@ type
   TGocciaCoverageFileMap = TOrderedStringMap<TGocciaFileCoverage>;
 
   TGocciaCoverageTracker = class
-  private class var
-    FInstance: TGocciaCoverageTracker;
   private
     FFiles: TGocciaCoverageFileMap;
     FEnabled: Boolean;
@@ -405,20 +403,23 @@ end;
 
 { TGocciaCoverageTracker }
 
+threadvar
+  CoverageTrackerThreadInstance: TGocciaCoverageTracker;
+
 class function TGocciaCoverageTracker.Instance: TGocciaCoverageTracker;
 begin
-  Result := FInstance;
+  Result := CoverageTrackerThreadInstance;
 end;
 
 class procedure TGocciaCoverageTracker.Initialize;
 begin
-  if not Assigned(FInstance) then
-    FInstance := TGocciaCoverageTracker.Create;
+  if not Assigned(CoverageTrackerThreadInstance) then
+    CoverageTrackerThreadInstance := TGocciaCoverageTracker.Create;
 end;
 
 class procedure TGocciaCoverageTracker.Shutdown;
 begin
-  FreeAndNil(FInstance);
+  FreeAndNil(CoverageTrackerThreadInstance);
 end;
 
 constructor TGocciaCoverageTracker.Create;

--- a/units/Goccia.Coverage.pas
+++ b/units/Goccia.Coverage.pas
@@ -78,6 +78,11 @@ type
 
     function GetFileCoverage(const AFilePath: string): TGocciaFileCoverage;
 
+    { Merge all coverage data from ASource into this tracker.
+      Line hits and branch hits are summed. Files present in ASource
+      but not in this tracker are created with 0 executable lines. }
+    procedure MergeFrom(const ASource: TGocciaCoverageTracker);
+
     property Files: TGocciaCoverageFileMap read FFiles;
     property Enabled: Boolean read FEnabled write FEnabled;
   end;
@@ -487,6 +492,41 @@ function TGocciaCoverageTracker.GetFileCoverage(
 begin
   if not FFiles.TryGetValue(AFilePath, Result) then
     Result := nil;
+end;
+
+procedure TGocciaCoverageTracker.MergeFrom(const ASource: TGocciaCoverageTracker);
+var
+  IterState, I: Integer;
+  Key: string;
+  SrcFile, DstFile: TGocciaFileCoverage;
+  Branch: TGocciaCoverageBranch;
+begin
+  if (ASource = nil) or (ASource.Files = nil) then Exit;
+
+  IterState := 0;
+  while ASource.Files.GetNextEntry(IterState, Key, SrcFile) do
+  begin
+    DstFile := GetOrCreateFile(Key);
+    { If the destination was auto-created with 0 executable lines but the
+      source has a proper count, adopt it. }
+    if (DstFile.ExecutableLines = 0) and (SrcFile.ExecutableLines > 0) then
+      DstFile.FExecutableLines := SrcFile.ExecutableLines;
+
+    { Merge line hits — sum counts for each line. }
+    for I := 1 to SrcFile.LineHitCount - 1 do
+      if SrcFile.GetLineHitCount(I) > 0 then
+        DstFile.RecordLineHit(I);
+
+    { Merge branch hits. }
+    for I := 0 to SrcFile.Branches.Count - 1 do
+    begin
+      Branch := SrcFile.Branches[I];
+      if Branch.HitCount > 0 then
+        DstFile.RecordBranchHit(Branch.Line, Branch.Column, Branch.BranchIndex)
+      else
+        DstFile.EnsureBranchExists(Branch.Line, Branch.Column, Branch.BranchIndex);
+    end;
+  end;
 end;
 
 end.

--- a/units/Goccia.GarbageCollector.pas
+++ b/units/Goccia.GarbageCollector.pas
@@ -11,8 +11,6 @@ uses
 
 type
   TGCManagedObject = class
-  private class var
-    FCurrentMark: Cardinal;
   private
     FGCMark: Cardinal;
     FGCIndex: Integer;
@@ -32,8 +30,6 @@ type
   TGCObjectSet = THashMap<TGCManagedObject, Boolean>;
 
   TGarbageCollector = class
-  private class var
-    FInstance: TGarbageCollector;
   private
     FManagedObjects: TGCManagedObjectList;
     FPinnedObjects: TGCObjectSet;
@@ -133,29 +129,33 @@ uses
   TimingUtils{$ENDIF};
 {$ENDIF}
 
+threadvar
+  GCCurrentMark: Cardinal;
+  GCThreadInstance: TGarbageCollector;
+
 { TGCManagedObject }
 
 class procedure TGCManagedObject.AdvanceMark;
 begin
-  Inc(FCurrentMark);
-  if FCurrentMark = 0 then
-    FCurrentMark := 1;
+  Inc(GCCurrentMark);
+  if GCCurrentMark = 0 then
+    GCCurrentMark := 1;
 end;
 
 function TGCManagedObject.GetGCMarked: Boolean;
 begin
-  Result := FGCMark = FCurrentMark;
+  Result := FGCMark = GCCurrentMark;
 end;
 
 procedure TGCManagedObject.SetGCMarked(const AValue: Boolean);
 begin
   if AValue then
-    FGCMark := FCurrentMark;
+    FGCMark := GCCurrentMark;
 end;
 
 procedure TGCManagedObject.MarkReferences;
 begin
-  FGCMark := FCurrentMark;
+  FGCMark := GCCurrentMark;
 end;
 
 procedure TGCManagedObject.Recycle;
@@ -167,19 +167,22 @@ end;
 
 class function TGarbageCollector.Instance: TGarbageCollector;
 begin
-  Result := FInstance;
+  Result := GCThreadInstance;
 end;
 
 class procedure TGarbageCollector.Initialize;
 begin
-  if not Assigned(FInstance) then
-    FInstance := TGarbageCollector.Create;
+  if not Assigned(GCThreadInstance) then
+  begin
+    GCThreadInstance := TGarbageCollector.Create;
+    GCCurrentMark := 1;
+  end;
 end;
 
 class procedure TGarbageCollector.Shutdown;
 begin
-  FInstance.Free;
-  FInstance := nil;
+  GCThreadInstance.Free;
+  GCThreadInstance := nil;
 end;
 
 constructor TGarbageCollector.Create;
@@ -526,6 +529,6 @@ begin
 end;
 
 initialization
-  TGCManagedObject.FCurrentMark := 1;
+  GCCurrentMark := 1;
 
 end.

--- a/units/Goccia.MicrotaskQueue.pas
+++ b/units/Goccia.MicrotaskQueue.pas
@@ -20,8 +20,6 @@ type
   end;
 
   TGocciaMicrotaskQueue = class
-  private class var
-    FInstance: TGocciaMicrotaskQueue;
   private
     FQueue: TList<TGocciaMicrotask>;
   public
@@ -51,20 +49,23 @@ uses
   Goccia.Values.PromiseValue,
   Goccia.VM.Exception;
 
+threadvar
+  MicrotaskQueueThreadInstance: TGocciaMicrotaskQueue;
+
 class function TGocciaMicrotaskQueue.Instance: TGocciaMicrotaskQueue;
 begin
-  Result := FInstance;
+  Result := MicrotaskQueueThreadInstance;
 end;
 
 class procedure TGocciaMicrotaskQueue.Initialize;
 begin
-  if not Assigned(FInstance) then
-    FInstance := TGocciaMicrotaskQueue.Create;
+  if not Assigned(MicrotaskQueueThreadInstance) then
+    MicrotaskQueueThreadInstance := TGocciaMicrotaskQueue.Create;
 end;
 
 class procedure TGocciaMicrotaskQueue.Shutdown;
 begin
-  FreeAndNil(FInstance);
+  FreeAndNil(MicrotaskQueueThreadInstance);
 end;
 
 constructor TGocciaMicrotaskQueue.Create;

--- a/units/Goccia.ObjectModel.Engine.pas
+++ b/units/Goccia.ObjectModel.Engine.pas
@@ -45,7 +45,6 @@ implementation
 
 uses
   Goccia.Constants.PropertyNames,
-  Goccia.SharedPrototype,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -111,8 +110,7 @@ begin
   else if Assigned(ATypeDefinition.PrototypeProvider) then
   begin
     AConstructor.ReplacePrototype(ATypeDefinition.PrototypeProvider());
-    if not AConstructor.Prototype.HasProperty(PROP_CONSTRUCTOR) then
-      AConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
+    AConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
   end
   else
     raise EGocciaObjectModelError.CreateFmt(

--- a/units/Goccia.ObjectModel.Engine.pas
+++ b/units/Goccia.ObjectModel.Engine.pas
@@ -45,6 +45,7 @@ implementation
 
 uses
   Goccia.Constants.PropertyNames,
+  Goccia.SharedPrototype,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -110,7 +111,8 @@ begin
   else if Assigned(ATypeDefinition.PrototypeProvider) then
   begin
     AConstructor.ReplacePrototype(ATypeDefinition.PrototypeProvider());
-    AConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
+    if not AConstructor.Prototype.HasProperty(PROP_CONSTRUCTOR) then
+      AConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
   end
   else
     raise EGocciaObjectModelError.CreateFmt(

--- a/units/Goccia.ObjectModel.pas
+++ b/units/Goccia.ObjectModel.pas
@@ -154,7 +154,7 @@ type
       const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
-var
+threadvar
   GPublishedGetterHosts: TObjectList<TObject>;
 
 function KindToString(const AKind: TGocciaMemberKind): string;
@@ -476,6 +476,8 @@ var
 begin
   GetterHost := TGocciaPublishedGetterHost.Create(
     AInstanceClass, APascalPropertyName, True);
+  if not Assigned(GPublishedGetterHosts) then
+    GPublishedGetterHosts := TObjectList<TObject>.Create(True);
   GPublishedGetterHosts.Add(GetterHost);
   Result := DefineAccessor(AExposedName, GetterHost.Invoke, nil, AFlags, AKind);
 end;
@@ -488,6 +490,8 @@ var
 begin
   GetterHost := TGocciaPublishedGetterHost.Create(
     AMethodHost.ClassType, APascalPropertyName, False, AMethodHost);
+  if not Assigned(GPublishedGetterHosts) then
+    GPublishedGetterHosts := TObjectList<TObject>.Create(True);
   GPublishedGetterHosts.Add(GetterHost);
   Result := DefineAccessor(AExposedName, GetterHost.Invoke, nil, AFlags, AKind);
 end;
@@ -761,8 +765,5 @@ end;
 
 initialization
   GPublishedGetterHosts := TObjectList<TObject>.Create(True);
-
-finalization
-  GPublishedGetterHosts.Free;
 
 end.

--- a/units/Goccia.Profiler.pas
+++ b/units/Goccia.Profiler.pas
@@ -37,13 +37,11 @@ type
     0..OPCODE_PAIR_SIZE - 1] of Int64;
   PGocciaOpcodePairArray = ^TGocciaOpcodePairArray;
 
-var
+threadvar
   GProfilingAllocations: Boolean;
 
 type
   TGocciaProfiler = class
-  private class var
-    FInstance: TGocciaProfiler;
   private
     FMode: TGocciaProfileMode;
     FEnabled: Boolean;
@@ -97,20 +95,23 @@ uses
 
 { TGocciaProfiler }
 
+threadvar
+  ProfilerThreadInstance: TGocciaProfiler;
+
 class function TGocciaProfiler.Instance: TGocciaProfiler;
 begin
-  Result := FInstance;
+  Result := ProfilerThreadInstance;
 end;
 
 class procedure TGocciaProfiler.Initialize;
 begin
-  if not Assigned(FInstance) then
-    FInstance := TGocciaProfiler.Create;
+  if not Assigned(ProfilerThreadInstance) then
+    ProfilerThreadInstance := TGocciaProfiler.Create;
 end;
 
 class procedure TGocciaProfiler.Shutdown;
 begin
-  FreeAndNil(FInstance);
+  FreeAndNil(ProfilerThreadInstance);
 end;
 
 constructor TGocciaProfiler.Create;

--- a/units/Goccia.RegExp.Runtime.pas
+++ b/units/Goccia.RegExp.Runtime.pas
@@ -35,7 +35,7 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
 
-var
+threadvar
   GRegExpPrototype: TGocciaObjectValue;
 
 function GetRegExpPrototype: TGocciaValue;

--- a/units/Goccia.SharedPrototype.pas
+++ b/units/Goccia.SharedPrototype.pas
@@ -5,8 +5,16 @@ unit Goccia.SharedPrototype;
 interface
 
 uses
+  SyncObjs,
+
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
+
+var
+  { Critical section protecting writes to shared prototype objects from
+    concurrent threads. Used by ExposeOnConstructor and the older
+    ExposePrototype class methods (e.g. TGocciaArrayValue). }
+  GSharedPrototypeLock: TCriticalSection;
 
 type
   TGocciaSharedPrototype = class
@@ -46,7 +54,18 @@ begin
     TGocciaClassValue(AConstructor).ReplacePrototype(FPrototype)
   else if AConstructor is TGocciaObjectValue then
     TGocciaObjectValue(AConstructor).AssignProperty(PROP_PROTOTYPE, FPrototype);
-  FPrototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
+  // Only write constructor to the shared prototype if not yet set.
+  // After EnsureSharedPrototypesInitialized runs on the main thread,
+  // this property is already populated. Skipping the write on worker
+  // threads avoids a data race on the prototype's property hash map.
+  if not FPrototype.HasProperty(PROP_CONSTRUCTOR) then
+    FPrototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
 end;
+
+initialization
+  GSharedPrototypeLock := TCriticalSection.Create;
+
+finalization
+  GSharedPrototypeLock.Free;
 
 end.

--- a/units/Goccia.SharedPrototype.pas
+++ b/units/Goccia.SharedPrototype.pas
@@ -5,16 +5,8 @@ unit Goccia.SharedPrototype;
 interface
 
 uses
-  SyncObjs,
-
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
-
-var
-  { Critical section protecting writes to shared prototype objects from
-    concurrent threads. Used by ExposeOnConstructor and the older
-    ExposePrototype class methods (e.g. TGocciaArrayValue). }
-  GSharedPrototypeLock: TCriticalSection;
 
 type
   TGocciaSharedPrototype = class
@@ -54,18 +46,7 @@ begin
     TGocciaClassValue(AConstructor).ReplacePrototype(FPrototype)
   else if AConstructor is TGocciaObjectValue then
     TGocciaObjectValue(AConstructor).AssignProperty(PROP_PROTOTYPE, FPrototype);
-  // Only write constructor to the shared prototype if not yet set.
-  // After EnsureSharedPrototypesInitialized runs on the main thread,
-  // this property is already populated. Skipping the write on worker
-  // threads avoids a data race on the prototype's property hash map.
-  if not FPrototype.HasProperty(PROP_CONSTRUCTOR) then
-    FPrototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
+  FPrototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
 end;
-
-initialization
-  GSharedPrototypeLock := TCriticalSection.Create;
-
-finalization
-  GSharedPrototypeLock.Free;
 
 end.

--- a/units/Goccia.Threading.Init.pas
+++ b/units/Goccia.Threading.Init.pas
@@ -1,0 +1,55 @@
+{ Pre-initialises all shared prototypes and class-level singletons before
+  worker threads are spawned. Must be called once on the main thread.
+
+  The shared prototypes (class var FShared / FSharedArrayPrototype etc.) are
+  lazily created on first object construction. Without pre-initialisation,
+  two worker threads could race to initialise the same prototype, causing
+  data corruption. Calling this procedure forces all lazy init to complete
+  while only the main thread is running. }
+
+unit Goccia.Threading.Init;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Engine;
+
+{ Force-creates a throwaway engine to trigger lazy shared prototype
+  initialisation for every built-in type. Safe to call multiple times
+  (subsequent calls are no-ops once prototypes are populated). }
+procedure EnsureSharedPrototypesInitialized(const ABuiltins: TGocciaGlobalBuiltins);
+
+implementation
+
+uses
+  Classes,
+
+  Goccia.GarbageCollector;
+
+procedure EnsureSharedPrototypesInitialized(const ABuiltins: TGocciaGlobalBuiltins);
+var
+  Source: TStringList;
+  Engine: TGocciaEngine;
+begin
+  Source := TStringList.Create;
+  try
+    // Create a minimal engine. The constructor registers all built-in
+    // types, which triggers lazy shared prototype initialisation for
+    // every value type (Array, Object, Map, Set, Promise, etc.).
+    Engine := TGocciaEngine.Create('<thread-init>', Source, ABuiltins);
+    try
+      // Nothing to execute — we only needed the constructor side-effects.
+    finally
+      Engine.Free;
+    end;
+    // Clean up the throwaway objects.
+    if Assigned(TGarbageCollector.Instance) then
+      TGarbageCollector.Instance.Collect;
+  finally
+    Source.Free;
+  end;
+end;
+
+end.

--- a/units/Goccia.Threading.Test.pas
+++ b/units/Goccia.Threading.Test.pas
@@ -1,0 +1,396 @@
+program Goccia.Threading.Test;
+
+{$I Goccia.inc}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  Classes,
+  SysUtils,
+
+  Goccia.Threading,
+  TestRunner,
+
+  Goccia.TestSetup;
+
+type
+  TTestThreading = class(TTestSuite)
+  public
+    procedure SetupTests; override;
+
+    procedure TestWorkQueueDrainsAllItems;
+    procedure TestWorkQueueReturnsItemsInOrder;
+    procedure TestWorkQueueEmptyReturnsFalse;
+    procedure TestPoolRunsAllFiles;
+    procedure TestPoolResultsInFileOrder;
+    procedure TestPoolCancelSkipsRemaining;
+    procedure TestPoolCancelOnErrorStopsOnFailure;
+    procedure TestPoolResetsCancelledBetweenRuns;
+    procedure TestPoolHandlesEmptyFileList;
+    procedure TestPoolSingleWorker;
+  end;
+
+{ Helpers }
+
+var
+  GWorkerCallCount: Integer;
+  GWorkerFileNames: array of string;
+  GWorkerLock: TRTLCriticalSection;
+
+procedure ResetWorkerState;
+begin
+  GWorkerCallCount := 0;
+  SetLength(GWorkerFileNames, 0);
+end;
+
+type
+  TTestWorkerHost = class
+    procedure CountingWorker(const AFileName: string;
+      const AIndex: Integer; out AConsoleOutput: string;
+      out AErrorMessage: string; AData: Pointer);
+    procedure FailOnSecondWorker(const AFileName: string;
+      const AIndex: Integer; out AConsoleOutput: string;
+      out AErrorMessage: string; AData: Pointer);
+  end;
+
+procedure TTestWorkerHost.CountingWorker(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+begin
+  AConsoleOutput := '';
+  AErrorMessage := '';
+  EnterCriticalSection(GWorkerLock);
+  try
+    Inc(GWorkerCallCount);
+    SetLength(GWorkerFileNames, Length(GWorkerFileNames) + 1);
+    GWorkerFileNames[High(GWorkerFileNames)] := AFileName;
+  finally
+    LeaveCriticalSection(GWorkerLock);
+  end;
+end;
+
+procedure TTestWorkerHost.FailOnSecondWorker(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+begin
+  AConsoleOutput := '';
+  if AFileName = 'fail.js' then
+    AErrorMessage := 'deliberate failure'
+  else
+    AErrorMessage := '';
+end;
+
+{ TTestThreading }
+
+procedure TTestThreading.SetupTests;
+begin
+  Test('WorkQueue drains all items', TestWorkQueueDrainsAllItems);
+  Test('WorkQueue returns items in order', TestWorkQueueReturnsItemsInOrder);
+  Test('WorkQueue empty returns False', TestWorkQueueEmptyReturnsFalse);
+  Test('Pool runs all files', TestPoolRunsAllFiles);
+  Test('Pool results in file order', TestPoolResultsInFileOrder);
+  Test('Pool Cancel skips remaining', TestPoolCancelSkipsRemaining);
+  Test('Pool CancelOnError stops on failure', TestPoolCancelOnErrorStopsOnFailure);
+  Test('Pool resets Cancelled between runs', TestPoolResetsCancelledBetweenRuns);
+  Test('Pool handles empty file list', TestPoolHandlesEmptyFileList);
+  Test('Pool single worker processes all files', TestPoolSingleWorker);
+end;
+
+procedure TTestThreading.TestWorkQueueDrainsAllItems;
+var
+  Items: TGocciaWorkItemArray;
+  Queue: TGocciaWorkQueue;
+  Item: TGocciaWorkItem;
+  Count: Integer;
+begin
+  SetLength(Items, 5);
+  Items[0].FileName := 'a.js'; Items[0].Index := 0;
+  Items[1].FileName := 'b.js'; Items[1].Index := 1;
+  Items[2].FileName := 'c.js'; Items[2].Index := 2;
+  Items[3].FileName := 'd.js'; Items[3].Index := 3;
+  Items[4].FileName := 'e.js'; Items[4].Index := 4;
+
+  Queue := TGocciaWorkQueue.Create(Items);
+  try
+    Count := 0;
+    while Queue.TryDequeue(Item) do
+      Inc(Count);
+    Expect<Integer>(Count).ToBe(5);
+  finally
+    Queue.Free;
+  end;
+end;
+
+procedure TTestThreading.TestWorkQueueReturnsItemsInOrder;
+var
+  Items: TGocciaWorkItemArray;
+  Queue: TGocciaWorkQueue;
+  Item: TGocciaWorkItem;
+begin
+  SetLength(Items, 3);
+  Items[0].FileName := 'first.js';  Items[0].Index := 0;
+  Items[1].FileName := 'second.js'; Items[1].Index := 1;
+  Items[2].FileName := 'third.js';  Items[2].Index := 2;
+
+  Queue := TGocciaWorkQueue.Create(Items);
+  try
+    Queue.TryDequeue(Item);
+    Expect<string>(Item.FileName).ToBe('first.js');
+    Queue.TryDequeue(Item);
+    Expect<string>(Item.FileName).ToBe('second.js');
+    Queue.TryDequeue(Item);
+    Expect<string>(Item.FileName).ToBe('third.js');
+  finally
+    Queue.Free;
+  end;
+end;
+
+procedure TTestThreading.TestWorkQueueEmptyReturnsFalse;
+var
+  Items: TGocciaWorkItemArray;
+  Queue: TGocciaWorkQueue;
+  Item: TGocciaWorkItem;
+begin
+  SetLength(Items, 0);
+  Queue := TGocciaWorkQueue.Create(Items);
+  try
+    Expect<Boolean>(Queue.TryDequeue(Item)).ToBe(False);
+  finally
+    Queue.Free;
+  end;
+end;
+
+procedure TTestThreading.TestPoolRunsAllFiles;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+begin
+  ResetWorkerState;
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    Files.Add('a.js');
+    Files.Add('b.js');
+    Files.Add('c.js');
+    Files.Add('d.js');
+    Files.Add('e.js');
+
+    Pool := TGocciaThreadPool.Create(2);
+    try
+      Pool.RunAll(Files, Host.CountingWorker);
+      Expect<Integer>(GWorkerCallCount).ToBe(5);
+    finally
+      Pool.Free;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+procedure TTestThreading.TestPoolResultsInFileOrder;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+begin
+  ResetWorkerState;
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    Files.Add('alpha.js');
+    Files.Add('beta.js');
+    Files.Add('gamma.js');
+
+    Pool := TGocciaThreadPool.Create(2);
+    try
+      Pool.RunAll(Files, Host.CountingWorker);
+      Expect<Integer>(Length(Pool.Results)).ToBe(3);
+      Expect<string>(Pool.Results[0].FileName).ToBe('alpha.js');
+      Expect<string>(Pool.Results[1].FileName).ToBe('beta.js');
+      Expect<string>(Pool.Results[2].FileName).ToBe('gamma.js');
+      Expect<Boolean>(Pool.Results[0].Success).ToBe(True);
+    finally
+      Pool.Free;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+procedure TTestThreading.TestPoolCancelSkipsRemaining;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+  CancelledCount, I: Integer;
+begin
+  ResetWorkerState;
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    for I := 0 to 99 do
+      Files.Add('file' + IntToStr(I) + '.js');
+
+    Pool := TGocciaThreadPool.Create(2);
+    try
+      Pool.RunAll(Files, Host.CountingWorker);
+      // Cancel after first run completes
+      Pool.Cancel;
+      // All should have completed since Cancel was called after RunAll
+      Expect<Integer>(GWorkerCallCount).ToBe(100);
+    finally
+      Pool.Free;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+procedure TTestThreading.TestPoolCancelOnErrorStopsOnFailure;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+  FailedCount, CancelledCount, I: Integer;
+begin
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    // Put the failure file first so it triggers quickly
+    Files.Add('fail.js');
+    for I := 1 to 99 do
+      Files.Add('ok' + IntToStr(I) + '.js');
+
+    Pool := TGocciaThreadPool.Create(1);
+    try
+      Pool.CancelOnError := True;
+      Pool.RunAll(Files, Host.FailOnSecondWorker);
+
+      // First file should have failed
+      Expect<Boolean>(Pool.Results[0].Success).ToBe(False);
+      Expect<string>(Pool.Results[0].ErrorMessage).ToBe('deliberate failure');
+      Expect<Boolean>(Pool.Cancelled).ToBe(True);
+
+      // Some remaining files should be cancelled (with 1 worker, all after first)
+      CancelledCount := 0;
+      FailedCount := 0;
+      for I := 0 to High(Pool.Results) do
+      begin
+        if Pool.Results[I].ErrorMessage = 'Cancelled' then
+          Inc(CancelledCount);
+        if not Pool.Results[I].Success then
+          Inc(FailedCount);
+      end;
+
+      // At least some files should be cancelled
+      Expect<Boolean>(CancelledCount > 0).ToBe(True);
+    finally
+      Pool.Free;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+procedure TTestThreading.TestPoolResetsCancelledBetweenRuns;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+begin
+  ResetWorkerState;
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    Files.Add('fail.js');
+
+    Pool := TGocciaThreadPool.Create(1);
+    try
+      Pool.CancelOnError := True;
+      // First run: triggers cancel
+      Pool.RunAll(Files, Host.FailOnSecondWorker);
+      Expect<Boolean>(Pool.Cancelled).ToBe(True);
+
+      // Second run: should reset and succeed
+      Files.Clear;
+      Files.Add('ok.js');
+      Pool.CancelOnError := False;
+      Pool.RunAll(Files, Host.CountingWorker);
+      Expect<Boolean>(Pool.Cancelled).ToBe(False);
+      Expect<Boolean>(Pool.Results[0].Success).ToBe(True);
+    finally
+      Pool.Free;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+procedure TTestThreading.TestPoolHandlesEmptyFileList;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+begin
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    Pool := TGocciaThreadPool.Create(4);
+    try
+      Pool.RunAll(Files, Host.CountingWorker);
+      Expect<Integer>(Length(Pool.Results)).ToBe(0);
+    finally
+      Pool.Free;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+procedure TTestThreading.TestPoolSingleWorker;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+begin
+  ResetWorkerState;
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    Files.Add('one.js');
+    Files.Add('two.js');
+    Files.Add('three.js');
+
+    Pool := TGocciaThreadPool.Create(1);
+    try
+      Pool.RunAll(Files, Host.CountingWorker);
+      Expect<Integer>(GWorkerCallCount).ToBe(3);
+      Expect<Integer>(Length(Pool.Results)).ToBe(3);
+      Expect<string>(Pool.Results[0].FileName).ToBe('one.js');
+      Expect<string>(Pool.Results[2].FileName).ToBe('three.js');
+    finally
+      Pool.Free;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+begin
+  InitCriticalSection(GWorkerLock);
+  try
+    TestRunnerProgram.AddSuite(TTestThreading.Create('Threading'));
+    TestRunnerProgram.Run;
+  finally
+    DoneCriticalSection(GWorkerLock);
+  end;
+
+  ExitCode := TestResultToExitCode;
+end.

--- a/units/Goccia.Threading.pas
+++ b/units/Goccia.Threading.pas
@@ -256,7 +256,24 @@ begin
           Exception(Workers[I].FatalException).Message);
       end;
       for ResultIdx := 0 to High(Workers[I].Results) do
-        FResults[Workers[I].Results[ResultIdx].Index] := Workers[I].Results[ResultIdx];
+      begin
+        if Workers[I].Results[ResultIdx].FileName <> '' then
+          FResults[Workers[I].Results[ResultIdx].Index] := Workers[I].Results[ResultIdx]
+        else
+        begin
+          { Worker died before processing this slot — fill from work items. }
+          FResults[WorkItems[I][ResultIdx].Index].Index := WorkItems[I][ResultIdx].Index;
+          FResults[WorkItems[I][ResultIdx].Index].FileName := WorkItems[I][ResultIdx].FileName;
+          FResults[WorkItems[I][ResultIdx].Index].Success := False;
+          if Assigned(Workers[I].FatalException) then
+            FResults[WorkItems[I][ResultIdx].Index].ErrorMessage :=
+              Exception(Workers[I].FatalException).Message
+          else
+            FResults[WorkItems[I][ResultIdx].Index].ErrorMessage := 'Worker terminated unexpectedly';
+          FResults[WorkItems[I][ResultIdx].Index].ConsoleOutput := '';
+          FResults[WorkItems[I][ResultIdx].Index].Data := nil;
+        end;
+      end;
       Workers[I].Free;
     end;
   end;

--- a/units/Goccia.Threading.pas
+++ b/units/Goccia.Threading.pas
@@ -5,6 +5,10 @@
   thread-local runtime (GC, CallStack, MicrotaskQueue) and shuts it down
   on completion, so there is zero shared mutable state between workers.
 
+  Workers pull files from a shared queue so that fast workers naturally
+  pick up more files, keeping all cores busy even when file execution
+  times vary widely.
+
   Results are collected in submission order so callers can print output
   deterministically. }
 
@@ -46,10 +50,24 @@ type
 
   TGocciaWorkItemArray = array of TGocciaWorkItem;
 
+  { Shared work queue — workers pull the next item under a lock. }
+  TGocciaWorkQueue = class
+  private
+    FItems: TGocciaWorkItemArray;
+    FNextIndex: Integer;
+    FLock: TRTLCriticalSection;
+  public
+    constructor Create(const AItems: TGocciaWorkItemArray);
+    destructor Destroy; override;
+    { Returns True and fills AItem if work remains, False when exhausted. }
+    function TryDequeue(out AItem: TGocciaWorkItem): Boolean;
+  end;
+
   TGocciaFileWorker = class(TThread)
   private
-    FWorkItems: TGocciaWorkItemArray;
+    FQueue: TGocciaWorkQueue;
     FResults: TGocciaWorkerResultArray;
+    FResultCount: Integer;
     FWorkerProc: TGocciaWorkerProc;
     FCancelled: PBoolean;
     FCancelOnError: Boolean;
@@ -59,14 +77,15 @@ type
   protected
     procedure Execute; override;
   public
-    constructor Create(const AWorkItems: TGocciaWorkItemArray;
+    constructor Create(AQueue: TGocciaWorkQueue;
       AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean;
       ACancelOnError: Boolean; AEnableCoverage: Boolean; AData: Pointer);
     property Results: TGocciaWorkerResultArray read FResults;
+    property ResultCount: Integer read FResultCount;
     property CoverageTracker: TObject read FCoverageTracker;
   end;
 
-  { Simple thread pool that partitions files across N workers.
+  { Thread pool that dispatches files to workers via a shared queue.
     Call RunAll to execute, then read Results in original file order. }
   TGocciaThreadPool = class
   private
@@ -96,10 +115,9 @@ type
     property WorkerCount: Integer read FWorkerCount;
     property Cancelled: Boolean read FCancelled;
     { When True, the first worker error automatically cancels remaining files. }
-    { When True, the first worker error automatically cancels remaining files. }
     property CancelOnError: Boolean read FCancelOnError write FCancelOnError;
     { When True, each worker initialises a per-thread coverage tracker.
-      After RunAll, use MergeCoverage to collect results. }
+      After RunAll, use MergeCoverageInto to collect results. }
     property EnableCoverage: Boolean read FEnableCoverage write FEnableCoverage;
   end;
 
@@ -155,66 +173,113 @@ begin
   TGarbageCollector.Shutdown;
 end;
 
+{ TGocciaWorkQueue }
+
+constructor TGocciaWorkQueue.Create(const AItems: TGocciaWorkItemArray);
+begin
+  inherited Create;
+  FItems := AItems;
+  FNextIndex := 0;
+  InitCriticalSection(FLock);
+end;
+
+destructor TGocciaWorkQueue.Destroy;
+begin
+  DoneCriticalSection(FLock);
+  inherited;
+end;
+
+function TGocciaWorkQueue.TryDequeue(out AItem: TGocciaWorkItem): Boolean;
+var
+  Idx: Integer;
+begin
+  EnterCriticalSection(FLock);
+  try
+    if FNextIndex < Length(FItems) then
+    begin
+      Idx := FNextIndex;
+      Inc(FNextIndex);
+      AItem := FItems[Idx];
+      Result := True;
+    end
+    else
+      Result := False;
+  finally
+    LeaveCriticalSection(FLock);
+  end;
+end;
+
 { TGocciaFileWorker }
 
-constructor TGocciaFileWorker.Create(const AWorkItems: TGocciaWorkItemArray;
+constructor TGocciaFileWorker.Create(AQueue: TGocciaWorkQueue;
   AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean;
   ACancelOnError: Boolean; AEnableCoverage: Boolean; AData: Pointer);
 begin
   inherited Create(True); // Create suspended
   FreeOnTerminate := False;
-  FWorkItems := AWorkItems;
+  FQueue := AQueue;
   FWorkerProc := AWorkerProc;
   FCancelled := ACancelled;
   FCancelOnError := ACancelOnError;
   FEnableCoverage := AEnableCoverage;
   FCoverageTracker := nil;
   FData := AData;
-  SetLength(FResults, Length(FWorkItems));
+  FResultCount := 0;
+  // Pre-allocate generously; actual count tracked by FResultCount.
+  SetLength(FResults, 0);
 end;
 
 procedure TGocciaFileWorker.Execute;
 var
-  I: Integer;
+  Item: TGocciaWorkItem;
   ConsoleOut, ErrorMsg: string;
+  Idx: Integer;
 begin
   InitThreadRuntime(FEnableCoverage);
   try
-    for I := 0 to High(FWorkItems) do
+    while FQueue.TryDequeue(Item) do
     begin
       if FCancelled^ then
       begin
-        FResults[I].Index := FWorkItems[I].Index;
-        FResults[I].FileName := FWorkItems[I].FileName;
-        FResults[I].Success := False;
-        FResults[I].ErrorMessage := 'Cancelled';
-        FResults[I].ConsoleOutput := '';
-        FResults[I].Data := nil;
+        Idx := FResultCount;
+        Inc(FResultCount);
+        if Idx >= Length(FResults) then
+          SetLength(FResults, Max(8, Length(FResults) * 2));
+        FResults[Idx].Index := Item.Index;
+        FResults[Idx].FileName := Item.FileName;
+        FResults[Idx].Success := False;
+        FResults[Idx].ErrorMessage := 'Cancelled';
+        FResults[Idx].ConsoleOutput := '';
+        FResults[Idx].Data := nil;
         Continue;
       end;
 
       ConsoleOut := '';
       ErrorMsg := '';
-      FResults[I].Index := FWorkItems[I].Index;
-      FResults[I].FileName := FWorkItems[I].FileName;
-      FResults[I].Data := FData;
+      Idx := FResultCount;
+      Inc(FResultCount);
+      if Idx >= Length(FResults) then
+        SetLength(FResults, Max(8, Length(FResults) * 2));
+      FResults[Idx].Index := Item.Index;
+      FResults[Idx].FileName := Item.FileName;
+      FResults[Idx].Data := FData;
       try
-        FWorkerProc(FWorkItems[I].FileName, FWorkItems[I].Index,
+        FWorkerProc(Item.FileName, Item.Index,
           ConsoleOut, ErrorMsg, FData);
-        FResults[I].Success := ErrorMsg = '';
-        FResults[I].ErrorMessage := ErrorMsg;
-        FResults[I].ConsoleOutput := ConsoleOut;
+        FResults[Idx].Success := ErrorMsg = '';
+        FResults[Idx].ErrorMessage := ErrorMsg;
+        FResults[Idx].ConsoleOutput := ConsoleOut;
       except
         on E: Exception do
         begin
-          FResults[I].Success := False;
-          FResults[I].ErrorMessage := E.ClassName + ': ' + E.Message;
-          FResults[I].ConsoleOutput := ConsoleOut;
+          FResults[Idx].Success := False;
+          FResults[Idx].ErrorMessage := E.ClassName + ': ' + E.Message;
+          FResults[Idx].ConsoleOutput := ConsoleOut;
         end;
       end;
 
       { Cancel remaining files across all workers on first error. }
-      if FCancelOnError and (not FResults[I].Success) then
+      if FCancelOnError and (not FResults[Idx].Success) then
         FCancelled^ := True;
     end;
   finally
@@ -240,8 +305,9 @@ end;
 procedure TGocciaThreadPool.RunAll(const AFiles: TStringList;
   AWorkerProc: TGocciaWorkerProc; AData: Pointer);
 var
-  WorkItems: array of TGocciaWorkItemArray;
-  FileCount, I, WorkerIdx, ResultIdx: Integer;
+  AllItems: TGocciaWorkItemArray;
+  Queue: TGocciaWorkQueue;
+  FileCount, I, J: Integer;
 begin
   FileCount := AFiles.Count;
   if FileCount = 0 then
@@ -250,76 +316,61 @@ begin
     Exit;
   end;
 
-  // Partition files round-robin across workers
-  SetLength(WorkItems, FWorkerCount);
-  for I := 0 to FWorkerCount - 1 do
-    SetLength(WorkItems[I], 0);
-
+  // Build the shared work item array
+  SetLength(AllItems, FileCount);
   for I := 0 to FileCount - 1 do
   begin
-    WorkerIdx := I mod FWorkerCount;
-    SetLength(WorkItems[WorkerIdx], Length(WorkItems[WorkerIdx]) + 1);
-    WorkItems[WorkerIdx][High(WorkItems[WorkerIdx])].FileName := AFiles[I];
-    WorkItems[WorkerIdx][High(WorkItems[WorkerIdx])].Index := I;
+    AllItems[I].FileName := AFiles[I];
+    AllItems[I].Index := I;
   end;
 
-  // Create and start workers
-  SetLength(FWorkers, FWorkerCount);
-  for I := 0 to FWorkerCount - 1 do
-  begin
-    if Length(WorkItems[I]) > 0 then
+  Queue := TGocciaWorkQueue.Create(AllItems);
+  try
+    // Create and start workers
+    SetLength(FWorkers, FWorkerCount);
+    for I := 0 to FWorkerCount - 1 do
     begin
-      FWorkers[I] := TGocciaFileWorker.Create(WorkItems[I], AWorkerProc,
+      FWorkers[I] := TGocciaFileWorker.Create(Queue, AWorkerProc,
         @FCancelled, FCancelOnError, FEnableCoverage, AData);
       FWorkers[I].Start;
-    end
-    else
-      FWorkers[I] := nil;
-  end;
+    end;
 
-  // Wait for all workers
-  for I := 0 to FWorkerCount - 1 do
-    if Assigned(FWorkers[I]) then
+    // Wait for all workers
+    for I := 0 to FWorkerCount - 1 do
       FWorkers[I].WaitFor;
+  finally
+    Queue.Free;
+  end;
 
   // Collect results in original file order
   SetLength(FResults, FileCount);
+  // Initialise all slots so we can detect missing results
+  for I := 0 to FileCount - 1 do
+  begin
+    FResults[I].Index := I;
+    FResults[I].FileName := AFiles[I];
+    FResults[I].Success := False;
+    FResults[I].ErrorMessage := '';
+    FResults[I].ConsoleOutput := '';
+    FResults[I].Data := nil;
+  end;
+
   for I := 0 to FWorkerCount - 1 do
   begin
-    if Assigned(FWorkers[I]) then
+    // Check for unhandled exceptions in the worker thread
+    if Assigned(FWorkers[I].FatalException) then
+      WriteLn(StdErr, 'Worker thread ', I, ' fatal: ',
+        Exception(FWorkers[I].FatalException).Message);
+
+    for J := 0 to FWorkers[I].ResultCount - 1 do
+      FResults[FWorkers[I].Results[J].Index] := FWorkers[I].Results[J];
+
+    { Don't free workers yet if coverage is enabled — MergeCoverageInto
+      needs access to their coverage trackers. }
+    if not FEnableCoverage then
     begin
-      // Check for unhandled exceptions in the worker thread
-      if Assigned(FWorkers[I].FatalException) then
-      begin
-        WriteLn(StdErr, 'Worker thread ', I, ' fatal: ',
-          Exception(FWorkers[I].FatalException).Message);
-      end;
-      for ResultIdx := 0 to High(FWorkers[I].Results) do
-      begin
-        if FWorkers[I].Results[ResultIdx].FileName <> '' then
-          FResults[FWorkers[I].Results[ResultIdx].Index] := FWorkers[I].Results[ResultIdx]
-        else
-        begin
-          { Worker died before processing this slot — fill from work items. }
-          FResults[WorkItems[I][ResultIdx].Index].Index := WorkItems[I][ResultIdx].Index;
-          FResults[WorkItems[I][ResultIdx].Index].FileName := WorkItems[I][ResultIdx].FileName;
-          FResults[WorkItems[I][ResultIdx].Index].Success := False;
-          if Assigned(FWorkers[I].FatalException) then
-            FResults[WorkItems[I][ResultIdx].Index].ErrorMessage :=
-              Exception(FWorkers[I].FatalException).Message
-          else
-            FResults[WorkItems[I][ResultIdx].Index].ErrorMessage := 'Worker terminated unexpectedly';
-          FResults[WorkItems[I][ResultIdx].Index].ConsoleOutput := '';
-          FResults[WorkItems[I][ResultIdx].Index].Data := nil;
-        end;
-      end;
-      { Don't free workers yet if coverage is enabled — MergeCoverageInto
-        needs access to their coverage trackers. }
-      if not FEnableCoverage then
-      begin
-        FWorkers[I].Free;
-        FWorkers[I] := nil;
-      end;
+      FWorkers[I].Free;
+      FWorkers[I] := nil;
     end;
   end;
 end;

--- a/units/Goccia.Threading.pas
+++ b/units/Goccia.Threading.pas
@@ -52,14 +52,18 @@ type
     FResults: TGocciaWorkerResultArray;
     FWorkerProc: TGocciaWorkerProc;
     FCancelled: PBoolean;
+    FCancelOnError: Boolean;
+    FEnableCoverage: Boolean;
+    FCoverageTracker: TObject;  // TGocciaCoverageTracker, kept alive for merge
     FData: Pointer;
   protected
     procedure Execute; override;
   public
     constructor Create(const AWorkItems: TGocciaWorkItemArray;
       AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean;
-      AData: Pointer);
+      ACancelOnError: Boolean; AEnableCoverage: Boolean; AData: Pointer);
     property Results: TGocciaWorkerResultArray read FResults;
+    property CoverageTracker: TObject read FCoverageTracker;
   end;
 
   { Simple thread pool that partitions files across N workers.
@@ -68,7 +72,10 @@ type
   private
     FWorkerCount: Integer;
     FResults: TGocciaWorkerResultArray;
+    FWorkers: array of TGocciaFileWorker;
     FCancelled: Boolean;
+    FCancelOnError: Boolean;
+    FEnableCoverage: Boolean;
   public
     constructor Create(AWorkerCount: Integer);
 
@@ -81,14 +88,25 @@ type
     { Signal workers to skip remaining files. }
     procedure Cancel;
 
+    { Merge per-worker coverage into the main thread's tracker.
+      Only meaningful when EnableCoverage is True. }
+    procedure MergeCoverageInto(ATarget: TObject);
+
     property Results: TGocciaWorkerResultArray read FResults;
     property WorkerCount: Integer read FWorkerCount;
     property Cancelled: Boolean read FCancelled;
+    { When True, the first worker error automatically cancels remaining files. }
+    { When True, the first worker error automatically cancels remaining files. }
+    property CancelOnError: Boolean read FCancelOnError write FCancelOnError;
+    { When True, each worker initialises a per-thread coverage tracker.
+      After RunAll, use MergeCoverage to collect results. }
+    property EnableCoverage: Boolean read FEnableCoverage write FEnableCoverage;
   end;
 
   { Initialise the thread-local runtime for the calling thread.
-    Must be called at the start of each worker thread. }
-  procedure InitThreadRuntime;
+    Must be called at the start of each worker thread.
+    Set AEnableCoverage to initialise a per-thread coverage tracker. }
+  procedure InitThreadRuntime(AEnableCoverage: Boolean = False);
 
   { Shut down the thread-local runtime for the calling thread.
     Must be called before the worker thread exits. }
@@ -101,13 +119,14 @@ uses
   SysUtils,
 
   Goccia.CallStack,
+  Goccia.Coverage,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.Values.Primitives;
 
 { Thread runtime lifecycle }
 
-procedure InitThreadRuntime;
+procedure InitThreadRuntime(AEnableCoverage: Boolean);
 begin
   TGarbageCollector.Initialize;
   // Disable automatic GC on worker threads. Shared immutable objects
@@ -120,10 +139,17 @@ begin
   TGocciaCallStack.Initialize;
   TGocciaMicrotaskQueue.Initialize;
   PinPrimitiveSingletons;
+  if AEnableCoverage then
+  begin
+    TGocciaCoverageTracker.Initialize;
+    TGocciaCoverageTracker.Instance.Enabled := True;
+  end;
 end;
 
 procedure ShutdownThreadRuntime;
 begin
+  // Coverage tracker is NOT shut down here — the main thread reads it
+  // after workers complete, then merges into the main tracker.
   TGocciaMicrotaskQueue.Shutdown;
   TGocciaCallStack.Shutdown;
   TGarbageCollector.Shutdown;
@@ -132,13 +158,17 @@ end;
 { TGocciaFileWorker }
 
 constructor TGocciaFileWorker.Create(const AWorkItems: TGocciaWorkItemArray;
-  AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean; AData: Pointer);
+  AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean;
+  ACancelOnError: Boolean; AEnableCoverage: Boolean; AData: Pointer);
 begin
   inherited Create(True); // Create suspended
   FreeOnTerminate := False;
   FWorkItems := AWorkItems;
   FWorkerProc := AWorkerProc;
   FCancelled := ACancelled;
+  FCancelOnError := ACancelOnError;
+  FEnableCoverage := AEnableCoverage;
+  FCoverageTracker := nil;
   FData := AData;
   SetLength(FResults, Length(FWorkItems));
 end;
@@ -148,7 +178,7 @@ var
   I: Integer;
   ConsoleOut, ErrorMsg: string;
 begin
-  InitThreadRuntime;
+  InitThreadRuntime(FEnableCoverage);
   try
     for I := 0 to High(FWorkItems) do
     begin
@@ -182,8 +212,16 @@ begin
           FResults[I].ConsoleOutput := ConsoleOut;
         end;
       end;
+
+      { Cancel remaining files across all workers on first error. }
+      if FCancelOnError and (not FResults[I].Success) then
+        FCancelled^ := True;
     end;
   finally
+    { Detach the coverage tracker before shutting down the runtime so
+      the main thread can read it after the worker completes. }
+    if FEnableCoverage then
+      FCoverageTracker := TGocciaCoverageTracker.Instance;
     ShutdownThreadRuntime;
   end;
 end;
@@ -195,12 +233,13 @@ begin
   inherited Create;
   FWorkerCount := Max(1, AWorkerCount);
   FCancelled := False;
+  FCancelOnError := False;
+  FEnableCoverage := False;
 end;
 
 procedure TGocciaThreadPool.RunAll(const AFiles: TStringList;
   AWorkerProc: TGocciaWorkerProc; AData: Pointer);
 var
-  Workers: array of TGocciaFileWorker;
   WorkItems: array of TGocciaWorkItemArray;
   FileCount, I, WorkerIdx, ResultIdx: Integer;
 begin
@@ -225,56 +264,62 @@ begin
   end;
 
   // Create and start workers
-  SetLength(Workers, FWorkerCount);
+  SetLength(FWorkers, FWorkerCount);
   for I := 0 to FWorkerCount - 1 do
   begin
     if Length(WorkItems[I]) > 0 then
     begin
-      Workers[I] := TGocciaFileWorker.Create(WorkItems[I], AWorkerProc,
-        @FCancelled, AData);
-      Workers[I].Start;
+      FWorkers[I] := TGocciaFileWorker.Create(WorkItems[I], AWorkerProc,
+        @FCancelled, FCancelOnError, FEnableCoverage, AData);
+      FWorkers[I].Start;
     end
     else
-      Workers[I] := nil;
+      FWorkers[I] := nil;
   end;
 
   // Wait for all workers
   for I := 0 to FWorkerCount - 1 do
-    if Assigned(Workers[I]) then
-      Workers[I].WaitFor;
+    if Assigned(FWorkers[I]) then
+      FWorkers[I].WaitFor;
 
   // Collect results in original file order
   SetLength(FResults, FileCount);
   for I := 0 to FWorkerCount - 1 do
   begin
-    if Assigned(Workers[I]) then
+    if Assigned(FWorkers[I]) then
     begin
       // Check for unhandled exceptions in the worker thread
-      if Assigned(Workers[I].FatalException) then
+      if Assigned(FWorkers[I].FatalException) then
       begin
         WriteLn(StdErr, 'Worker thread ', I, ' fatal: ',
-          Exception(Workers[I].FatalException).Message);
+          Exception(FWorkers[I].FatalException).Message);
       end;
-      for ResultIdx := 0 to High(Workers[I].Results) do
+      for ResultIdx := 0 to High(FWorkers[I].Results) do
       begin
-        if Workers[I].Results[ResultIdx].FileName <> '' then
-          FResults[Workers[I].Results[ResultIdx].Index] := Workers[I].Results[ResultIdx]
+        if FWorkers[I].Results[ResultIdx].FileName <> '' then
+          FResults[FWorkers[I].Results[ResultIdx].Index] := FWorkers[I].Results[ResultIdx]
         else
         begin
           { Worker died before processing this slot — fill from work items. }
           FResults[WorkItems[I][ResultIdx].Index].Index := WorkItems[I][ResultIdx].Index;
           FResults[WorkItems[I][ResultIdx].Index].FileName := WorkItems[I][ResultIdx].FileName;
           FResults[WorkItems[I][ResultIdx].Index].Success := False;
-          if Assigned(Workers[I].FatalException) then
+          if Assigned(FWorkers[I].FatalException) then
             FResults[WorkItems[I][ResultIdx].Index].ErrorMessage :=
-              Exception(Workers[I].FatalException).Message
+              Exception(FWorkers[I].FatalException).Message
           else
             FResults[WorkItems[I][ResultIdx].Index].ErrorMessage := 'Worker terminated unexpectedly';
           FResults[WorkItems[I][ResultIdx].Index].ConsoleOutput := '';
           FResults[WorkItems[I][ResultIdx].Index].Data := nil;
         end;
       end;
-      Workers[I].Free;
+      { Don't free workers yet if coverage is enabled — MergeCoverageInto
+        needs access to their coverage trackers. }
+      if not FEnableCoverage then
+      begin
+        FWorkers[I].Free;
+        FWorkers[I] := nil;
+      end;
     end;
   end;
 end;
@@ -282,6 +327,24 @@ end;
 procedure TGocciaThreadPool.Cancel;
 begin
   FCancelled := True;
+end;
+
+procedure TGocciaThreadPool.MergeCoverageInto(ATarget: TObject);
+var
+  I: Integer;
+  WorkerTracker: TGocciaCoverageTracker;
+begin
+  if not FEnableCoverage then Exit;
+  for I := 0 to High(FWorkers) do
+  begin
+    if Assigned(FWorkers[I]) and Assigned(FWorkers[I].CoverageTracker) then
+    begin
+      WorkerTracker := TGocciaCoverageTracker(FWorkers[I].CoverageTracker);
+      TGocciaCoverageTracker(ATarget).MergeFrom(WorkerTracker);
+      WorkerTracker.Free;
+    end;
+    FreeAndNil(FWorkers[I]);
+  end;
 end;
 
 end.

--- a/units/Goccia.Threading.pas
+++ b/units/Goccia.Threading.pas
@@ -1,0 +1,270 @@
+{ Thread pool for parallel file execution.
+
+  Provides TGocciaThreadPool which dispatches file-level work items to a
+  configurable number of worker threads. Each worker initialises its own
+  thread-local runtime (GC, CallStack, MicrotaskQueue) and shuts it down
+  on completion, so there is zero shared mutable state between workers.
+
+  Results are collected in submission order so callers can print output
+  deterministically. }
+
+unit Goccia.Threading;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Classes,
+  SyncObjs;
+
+type
+  { Callback executed on each worker thread for a single file.
+    Implementations must NOT call WriteLn directly — capture output in
+    AConsoleOutput instead. }
+  TGocciaWorkerProc = procedure(const AFileName: string;
+    const AIndex: Integer; out AConsoleOutput: string;
+    out AErrorMessage: string; AData: Pointer) of object;
+
+  { Per-file result collected by the thread pool. }
+  TGocciaWorkerResult = record
+    Index: Integer;
+    FileName: string;
+    Success: Boolean;
+    ErrorMessage: string;
+    ConsoleOutput: string;
+    Data: Pointer;
+  end;
+
+  TGocciaWorkerResultArray = array of TGocciaWorkerResult;
+
+  { Internal work item queued for worker threads. }
+  TGocciaWorkItem = record
+    FileName: string;
+    Index: Integer;
+  end;
+
+  TGocciaWorkItemArray = array of TGocciaWorkItem;
+
+  TGocciaFileWorker = class(TThread)
+  private
+    FWorkItems: TGocciaWorkItemArray;
+    FResults: TGocciaWorkerResultArray;
+    FWorkerProc: TGocciaWorkerProc;
+    FCancelled: PBoolean;
+    FData: Pointer;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(const AWorkItems: TGocciaWorkItemArray;
+      AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean;
+      AData: Pointer);
+    property Results: TGocciaWorkerResultArray read FResults;
+  end;
+
+  { Simple thread pool that partitions files across N workers.
+    Call RunAll to execute, then read Results in original file order. }
+  TGocciaThreadPool = class
+  private
+    FWorkerCount: Integer;
+    FResults: TGocciaWorkerResultArray;
+    FCancelled: Boolean;
+  public
+    constructor Create(AWorkerCount: Integer);
+
+    { Execute AFiles across worker threads. Blocks until all complete.
+      AWorkerProc is called on each worker thread for each file.
+      AData is an opaque pointer passed through to each worker call. }
+    procedure RunAll(const AFiles: TStringList;
+      AWorkerProc: TGocciaWorkerProc; AData: Pointer = nil);
+
+    { Signal workers to skip remaining files. }
+    procedure Cancel;
+
+    property Results: TGocciaWorkerResultArray read FResults;
+    property WorkerCount: Integer read FWorkerCount;
+    property Cancelled: Boolean read FCancelled;
+  end;
+
+  { Initialise the thread-local runtime for the calling thread.
+    Must be called at the start of each worker thread. }
+  procedure InitThreadRuntime;
+
+  { Shut down the thread-local runtime for the calling thread.
+    Must be called before the worker thread exits. }
+  procedure ShutdownThreadRuntime;
+
+implementation
+
+uses
+  Math,
+  SysUtils,
+
+  Goccia.CallStack,
+  Goccia.GarbageCollector,
+  Goccia.MicrotaskQueue,
+  Goccia.Values.Primitives;
+
+{ Thread runtime lifecycle }
+
+procedure InitThreadRuntime;
+begin
+  TGarbageCollector.Initialize;
+  // Disable automatic GC on worker threads. Shared immutable objects
+  // (primitive singletons, shared prototypes) have a single FGCMark field
+  // written by the mark phase — running GC on multiple threads would race
+  // on that field. Each worker runs a single file and then shuts down, so
+  // skipping collection is acceptable: all objects are freed in bulk when
+  // the thread-local GC is destroyed.
+  TGarbageCollector.Instance.Enabled := False;
+  TGocciaCallStack.Initialize;
+  TGocciaMicrotaskQueue.Initialize;
+  PinPrimitiveSingletons;
+end;
+
+procedure ShutdownThreadRuntime;
+begin
+  TGocciaMicrotaskQueue.Shutdown;
+  TGocciaCallStack.Shutdown;
+  TGarbageCollector.Shutdown;
+end;
+
+{ TGocciaFileWorker }
+
+constructor TGocciaFileWorker.Create(const AWorkItems: TGocciaWorkItemArray;
+  AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean; AData: Pointer);
+begin
+  inherited Create(True); // Create suspended
+  FreeOnTerminate := False;
+  FWorkItems := AWorkItems;
+  FWorkerProc := AWorkerProc;
+  FCancelled := ACancelled;
+  FData := AData;
+  SetLength(FResults, Length(FWorkItems));
+end;
+
+procedure TGocciaFileWorker.Execute;
+var
+  I: Integer;
+  ConsoleOut, ErrorMsg: string;
+begin
+  InitThreadRuntime;
+  try
+    for I := 0 to High(FWorkItems) do
+    begin
+      if FCancelled^ then
+      begin
+        FResults[I].Index := FWorkItems[I].Index;
+        FResults[I].FileName := FWorkItems[I].FileName;
+        FResults[I].Success := False;
+        FResults[I].ErrorMessage := 'Cancelled';
+        FResults[I].ConsoleOutput := '';
+        FResults[I].Data := nil;
+        Continue;
+      end;
+
+      ConsoleOut := '';
+      ErrorMsg := '';
+      FResults[I].Index := FWorkItems[I].Index;
+      FResults[I].FileName := FWorkItems[I].FileName;
+      FResults[I].Data := FData;
+      try
+        FWorkerProc(FWorkItems[I].FileName, FWorkItems[I].Index,
+          ConsoleOut, ErrorMsg, FData);
+        FResults[I].Success := ErrorMsg = '';
+        FResults[I].ErrorMessage := ErrorMsg;
+        FResults[I].ConsoleOutput := ConsoleOut;
+      except
+        on E: Exception do
+        begin
+          FResults[I].Success := False;
+          FResults[I].ErrorMessage := E.ClassName + ': ' + E.Message;
+          FResults[I].ConsoleOutput := ConsoleOut;
+        end;
+      end;
+    end;
+  finally
+    ShutdownThreadRuntime;
+  end;
+end;
+
+{ TGocciaThreadPool }
+
+constructor TGocciaThreadPool.Create(AWorkerCount: Integer);
+begin
+  inherited Create;
+  FWorkerCount := Max(1, AWorkerCount);
+  FCancelled := False;
+end;
+
+procedure TGocciaThreadPool.RunAll(const AFiles: TStringList;
+  AWorkerProc: TGocciaWorkerProc; AData: Pointer);
+var
+  Workers: array of TGocciaFileWorker;
+  WorkItems: array of TGocciaWorkItemArray;
+  FileCount, I, WorkerIdx, ResultIdx: Integer;
+begin
+  FileCount := AFiles.Count;
+  if FileCount = 0 then
+  begin
+    SetLength(FResults, 0);
+    Exit;
+  end;
+
+  // Partition files round-robin across workers
+  SetLength(WorkItems, FWorkerCount);
+  for I := 0 to FWorkerCount - 1 do
+    SetLength(WorkItems[I], 0);
+
+  for I := 0 to FileCount - 1 do
+  begin
+    WorkerIdx := I mod FWorkerCount;
+    SetLength(WorkItems[WorkerIdx], Length(WorkItems[WorkerIdx]) + 1);
+    WorkItems[WorkerIdx][High(WorkItems[WorkerIdx])].FileName := AFiles[I];
+    WorkItems[WorkerIdx][High(WorkItems[WorkerIdx])].Index := I;
+  end;
+
+  // Create and start workers
+  SetLength(Workers, FWorkerCount);
+  for I := 0 to FWorkerCount - 1 do
+  begin
+    if Length(WorkItems[I]) > 0 then
+    begin
+      Workers[I] := TGocciaFileWorker.Create(WorkItems[I], AWorkerProc,
+        @FCancelled, AData);
+      Workers[I].Start;
+    end
+    else
+      Workers[I] := nil;
+  end;
+
+  // Wait for all workers
+  for I := 0 to FWorkerCount - 1 do
+    if Assigned(Workers[I]) then
+      Workers[I].WaitFor;
+
+  // Collect results in original file order
+  SetLength(FResults, FileCount);
+  for I := 0 to FWorkerCount - 1 do
+  begin
+    if Assigned(Workers[I]) then
+    begin
+      // Check for unhandled exceptions in the worker thread
+      if Assigned(Workers[I].FatalException) then
+      begin
+        WriteLn(StdErr, 'Worker thread ', I, ' fatal: ',
+          Exception(Workers[I].FatalException).Message);
+      end;
+      for ResultIdx := 0 to High(Workers[I].Results) do
+        FResults[Workers[I].Results[ResultIdx].Index] := Workers[I].Results[ResultIdx];
+      Workers[I].Free;
+    end;
+  end;
+end;
+
+procedure TGocciaThreadPool.Cancel;
+begin
+  FCancelled := True;
+end;
+
+end.

--- a/units/Goccia.Threading.pas
+++ b/units/Goccia.Threading.pas
@@ -309,6 +309,7 @@ var
   Queue: TGocciaWorkQueue;
   FileCount, I, J: Integer;
 begin
+  FCancelled := False;
   FileCount := AFiles.Count;
   if FileCount = 0 then
   begin
@@ -326,19 +327,23 @@ begin
 
   Queue := TGocciaWorkQueue.Create(AllItems);
   try
-    // Create and start workers
+    // Create and start workers. Track how many started so we can
+    // wait/free only those if a later Create/Start raises.
     SetLength(FWorkers, FWorkerCount);
+    for I := 0 to FWorkerCount - 1 do
+      FWorkers[I] := nil;
+
     for I := 0 to FWorkerCount - 1 do
     begin
       FWorkers[I] := TGocciaFileWorker.Create(Queue, AWorkerProc,
         @FCancelled, FCancelOnError, FEnableCoverage, AData);
       FWorkers[I].Start;
     end;
-
-    // Wait for all workers
-    for I := 0 to FWorkerCount - 1 do
-      FWorkers[I].WaitFor;
   finally
+    // Wait for all started workers before freeing the queue
+    for I := 0 to FWorkerCount - 1 do
+      if Assigned(FWorkers[I]) then
+        FWorkers[I].WaitFor;
     Queue.Free;
   end;
 

--- a/units/Goccia.Timeout.pas
+++ b/units/Goccia.Timeout.pas
@@ -23,10 +23,10 @@ const
   TIMEOUT_CHECK_INTERVAL = 1024;
   TIMEOUT_ALWAYS_CHECK_THRESHOLD_MS = 16;
 
-var
-  GTimeoutMilliseconds: Integer = 0;
-  GStartNanoseconds: Int64 = 0;
-  GCheckCounter: Integer = 0;
+threadvar
+  GTimeoutMilliseconds: Integer;
+  GStartNanoseconds: Int64;
+  GCheckCounter: Integer;
 
 procedure StartExecutionTimeout(const ATimeoutMilliseconds: Integer);
 begin

--- a/units/Goccia.Values.ArrayBufferValue.pas
+++ b/units/Goccia.Values.ArrayBufferValue.pas
@@ -17,9 +17,6 @@ uses
 type
   TGocciaArrayBufferValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     const NO_MAX_BYTE_LENGTH = -1;
   private
     FData: TBytes;
@@ -69,6 +66,10 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function RequireArrayBuffer(const AThisValue: TGocciaValue; const AMethodName: string): TGocciaArrayBufferValue;
 begin

--- a/units/Goccia.Values.ArrayValue.pas
+++ b/units/Goccia.Values.ArrayValue.pas
@@ -15,10 +15,6 @@ uses
 type
   TGocciaArrayValue = class(TGocciaInstanceValue)
   private
-    class var FSharedArrayPrototype: TGocciaObjectValue;
-    class var FPrototypeMethodHost: TGocciaArrayValue;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-
     // Helper methods for reducing duplication
     function ValidateArrayMethodCall(const AMethodName: string; const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue; const ARequiresCallback: Boolean = True): TGocciaValue;
@@ -116,6 +112,7 @@ uses
   Goccia.Error,
   Goccia.Evaluator.Comparison,
   Goccia.GarbageCollector,
+  Goccia.SharedPrototype,
   Goccia.Utils,
   Goccia.Utils.Arrays,
   Goccia.Values.ClassHelper,
@@ -125,6 +122,11 @@ uses
   Goccia.Values.Iterator.Concrete,
   Goccia.Values.SymbolValue,
   Goccia.Values.ToPrimitive;
+
+threadvar
+  FSharedArrayPrototype: TGocciaObjectValue;
+  FPrototypeMethodHost: TGocciaArrayValue;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function DefaultCompare(constref A, B: TGocciaValue): Integer;
 var
@@ -330,7 +332,8 @@ begin
     TGocciaClassValue(AConstructor).ReplacePrototype(FSharedArrayPrototype)
   else if AConstructor is TGocciaObjectValue then
     TGocciaObjectValue(AConstructor).AssignProperty(PROP_PROTOTYPE, FSharedArrayPrototype);
-  FSharedArrayPrototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
+  if not FSharedArrayPrototype.HasProperty(PROP_CONSTRUCTOR) then
+    FSharedArrayPrototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
 end;
 
 destructor TGocciaArrayValue.Destroy;

--- a/units/Goccia.Values.ArrayValue.pas
+++ b/units/Goccia.Values.ArrayValue.pas
@@ -112,7 +112,6 @@ uses
   Goccia.Error,
   Goccia.Evaluator.Comparison,
   Goccia.GarbageCollector,
-  Goccia.SharedPrototype,
   Goccia.Utils,
   Goccia.Utils.Arrays,
   Goccia.Values.ClassHelper,
@@ -332,8 +331,7 @@ begin
     TGocciaClassValue(AConstructor).ReplacePrototype(FSharedArrayPrototype)
   else if AConstructor is TGocciaObjectValue then
     TGocciaObjectValue(AConstructor).AssignProperty(PROP_PROTOTYPE, FSharedArrayPrototype);
-  if not FSharedArrayPrototype.HasProperty(PROP_CONSTRUCTOR) then
-    FSharedArrayPrototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
+  FSharedArrayPrototype.AssignProperty(PROP_CONSTRUCTOR, AConstructor);
 end;
 
 destructor TGocciaArrayValue.Destroy;

--- a/units/Goccia.Values.BooleanObjectValue.pas
+++ b/units/Goccia.Values.BooleanObjectValue.pas
@@ -14,10 +14,6 @@ uses
 type
   TGocciaBooleanObjectValue = class(TGocciaInstanceValue)
   private
-    class var FSharedBooleanPrototype: TGocciaObjectValue;
-    class var FPrototypeMethodHost: TGocciaBooleanObjectValue;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FPrimitive: TGocciaBooleanLiteralValue;
   public
     constructor Create(const APrimitive: TGocciaBooleanLiteralValue; const AClass: TGocciaClassValue = nil);
@@ -39,6 +35,11 @@ implementation
 uses
   Goccia.GarbageCollector,
   Goccia.Values.NativeFunction;
+
+threadvar
+  FSharedBooleanPrototype: TGocciaObjectValue;
+  FPrototypeMethodHost: TGocciaBooleanObjectValue;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaBooleanObjectValue.Create(const APrimitive: TGocciaBooleanLiteralValue; const AClass: TGocciaClassValue = nil);
 begin

--- a/units/Goccia.Values.FFILibrary.pas
+++ b/units/Goccia.Values.FFILibrary.pas
@@ -15,9 +15,6 @@ uses
 type
   TGocciaFFILibraryValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FHandle: TGocciaFFILibraryHandle;
 
     procedure InitializePrototype;
@@ -58,6 +55,10 @@ uses
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.TypedArrayValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 const
   FFI_LIBRARY_TAG = 'FFILibrary';

--- a/units/Goccia.Values.FFIPointer.pas
+++ b/units/Goccia.Values.FFIPointer.pas
@@ -18,10 +18,6 @@ uses
 type
   TGocciaFFIPointerValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-    class var FNullPointer: TGocciaFFIPointerValue;
-  private
     FAddress: Pointer;
 
     procedure InitializePrototype;
@@ -49,6 +45,11 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+  FNullPointer: TGocciaFFIPointerValue;
 
 const
   FFI_POINTER_TAG = 'FFIPointer';

--- a/units/Goccia.Values.FunctionBase.pas
+++ b/units/Goccia.Values.FunctionBase.pas
@@ -257,11 +257,16 @@ begin
   // Set the threadvar early to prevent infinite recursion when creating
   // TGocciaNativeFunctionValue instances (which inherit from TGocciaFunctionBase)
   FSharedPrototype := Self;
-
-  Members[0] := DefineNamedMethod('call', FunctionCall, 1);
-  Members[1] := DefineNamedMethod('apply', FunctionApply, 2);
-  Members[2] := DefineNamedMethod('bind', FunctionBind, 1);
-  RegisterMemberDefinitions(Self, Members);
+  try
+    Members[0] := DefineNamedMethod('call', FunctionCall, 1);
+    Members[1] := DefineNamedMethod('apply', FunctionApply, 2);
+    Members[2] := DefineNamedMethod('bind', FunctionBind, 1);
+    RegisterMemberDefinitions(Self, Members);
+  except
+    if FSharedPrototype = Self then
+      FSharedPrototype := nil;
+    raise;
+  end;
 end;
 
 function TGocciaFunctionSharedPrototype.FunctionCall(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/units/Goccia.Values.FunctionBase.pas
+++ b/units/Goccia.Values.FunctionBase.pas
@@ -26,8 +26,6 @@ type
 
   // Base class for all callable functions
   TGocciaFunctionBase = class(TGocciaObjectValue)
-  private class var
-    FSharedPrototype: TGocciaFunctionSharedPrototype;
   protected
     // Subclasses should override these to provide name/length
     function GetFunctionLength: Integer; virtual;
@@ -102,6 +100,9 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction;
+
+threadvar
+  FSharedPrototype: TGocciaFunctionSharedPrototype;
 
 { TGocciaFunctionBase }
 
@@ -253,9 +254,9 @@ var
 begin
   inherited Create;
 
-  // Set the class var early to prevent infinite recursion when creating
+  // Set the threadvar early to prevent infinite recursion when creating
   // TGocciaNativeFunctionValue instances (which inherit from TGocciaFunctionBase)
-  TGocciaFunctionBase.FSharedPrototype := Self;
+  FSharedPrototype := Self;
 
   Members[0] := DefineNamedMethod('call', FunctionCall, 1);
   Members[1] := DefineNamedMethod('apply', FunctionApply, 2);

--- a/units/Goccia.Values.IteratorValue.pas
+++ b/units/Goccia.Values.IteratorValue.pas
@@ -12,12 +12,6 @@ uses
 
 type
   TGocciaIteratorValue = class(TGocciaObjectValue)
-  private
-    class var FSharedIteratorPrototype: TGocciaObjectValue;
-    class var FPrototypeMethodHost: TGocciaIteratorValue;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-    class var FStaticMembers: array of TGocciaMemberDefinition;
-  private
   public
     function IteratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorSelf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -74,6 +68,12 @@ uses
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FSharedIteratorPrototype: TGocciaObjectValue;
+  FPrototypeMethodHost: TGocciaIteratorValue;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 procedure CloseIteratorPreservingError(const AIterator: TGocciaIteratorValue);
 begin

--- a/units/Goccia.Values.MapValue.pas
+++ b/units/Goccia.Values.MapValue.pas
@@ -23,9 +23,6 @@ type
 
   TGocciaMapValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FEntries: TList<TGocciaMapEntry>;
   public
     function MapGet(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -75,6 +72,10 @@ uses
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaMapValue.Create(const AClass: TGocciaClassValue = nil);
 begin

--- a/units/Goccia.Values.NumberObjectValue.pas
+++ b/units/Goccia.Values.NumberObjectValue.pas
@@ -16,10 +16,6 @@ type
   private
     FPrimitive: TGocciaNumberLiteralValue;
 
-    class var FSharedNumberPrototype: TGocciaObjectValue;
-    class var FPrototypeMethodHost: TGocciaNumberObjectValue;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-
     function ExtractPrimitive(const AValue: TGocciaValue): TGocciaNumberLiteralValue;
   public
     constructor Create(const APrimitive: TGocciaNumberLiteralValue; const AClass: TGocciaClassValue = nil);
@@ -51,6 +47,11 @@ uses
   Goccia.GarbageCollector,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction;
+
+threadvar
+  FSharedNumberPrototype: TGocciaObjectValue;
+  FPrototypeMethodHost: TGocciaNumberObjectValue;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function TGocciaNumberObjectValue.ExtractPrimitive(const AValue: TGocciaValue): TGocciaNumberLiteralValue;
 begin

--- a/units/Goccia.Values.ObjectValue.pas
+++ b/units/Goccia.Values.ObjectValue.pas
@@ -20,10 +20,6 @@ type
 
   TGocciaObjectValue = class(TGocciaValue)
   private
-    class var FSharedObjectPrototype: TGocciaObjectValue;
-    class var FPrototypeMethodHost: TGocciaObjectValue;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
   protected
     FProperties: TGocciaPropertyMap;
     FSymbolDescriptors: TSymbolDescriptorMap;
@@ -35,7 +31,9 @@ type
     FHasErrorData: Boolean;
   public
     class procedure InitializeSharedPrototype;
-    class property SharedObjectPrototype: TGocciaObjectValue read FSharedObjectPrototype write FSharedObjectPrototype;
+    class function GetSharedObjectPrototype: TGocciaObjectValue; static;
+    class procedure SetSharedObjectPrototype(const AValue: TGocciaObjectValue); static;
+    class property SharedObjectPrototype: TGocciaObjectValue read GetSharedObjectPrototype write SetSharedObjectPrototype;
     constructor Create(const APrototype: TGocciaObjectValue = nil;
       const APropertyCapacity: Integer = 0);
     destructor Destroy; override;
@@ -121,6 +119,11 @@ uses
   Goccia.Values.FunctionValue,
   Goccia.Values.NativeFunction;
 
+threadvar
+  FSharedObjectPrototype: TGocciaObjectValue;
+  FPrototypeMethodHost: TGocciaObjectValue;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+
 const
   MAX_PROTOTYPE_CHAIN_DEPTH = 256;
 
@@ -130,6 +133,16 @@ begin
 end;
 
 { TGocciaObjectValue }
+
+class function TGocciaObjectValue.GetSharedObjectPrototype: TGocciaObjectValue;
+begin
+  Result := FSharedObjectPrototype;
+end;
+
+class procedure TGocciaObjectValue.SetSharedObjectPrototype(const AValue: TGocciaObjectValue);
+begin
+  FSharedObjectPrototype := AValue;
+end;
 
 constructor TGocciaObjectValue.Create(const APrototype: TGocciaObjectValue = nil;
   const APropertyCapacity: Integer = 0);

--- a/units/Goccia.Values.PromiseValue.pas
+++ b/units/Goccia.Values.PromiseValue.pas
@@ -36,9 +36,6 @@ type
 
   TGocciaPromiseValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FState: TGocciaPromiseState;
     FResult: TGocciaValue;
     FReactions: TList<TGocciaPromiseReaction>;
@@ -89,6 +86,10 @@ uses
   Goccia.Values.FunctionBase,
   Goccia.Values.NativeFunction,
   Goccia.VM.Exception;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 type
   TGocciaFinallyPassthrough = class(TGocciaObjectValue)

--- a/units/Goccia.Values.SetValue.pas
+++ b/units/Goccia.Values.SetValue.pas
@@ -16,9 +16,6 @@ uses
 type
   TGocciaSetValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FItems: TGocciaValueList;
   public
     function SetHas(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -72,6 +69,10 @@ uses
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 constructor TGocciaSetValue.Create(const AClass: TGocciaClassValue = nil);
 begin

--- a/units/Goccia.Values.SharedArrayBufferValue.pas
+++ b/units/Goccia.Values.SharedArrayBufferValue.pas
@@ -17,9 +17,6 @@ uses
 type
   TGocciaSharedArrayBufferValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FData: TBytes;
 
     function GetByteLength: Integer;
@@ -55,6 +52,10 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function TGocciaSharedArrayBufferValue.GetByteLength: Integer;
 begin

--- a/units/Goccia.Values.StringObjectValue.pas
+++ b/units/Goccia.Values.StringObjectValue.pas
@@ -19,10 +19,6 @@ type
   private
     FPrimitive: TGocciaStringLiteralValue;
 
-    class var FSharedStringPrototype: TGocciaObjectValue;
-    class var FPrototypeMethodHost: TGocciaStringObjectValue;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-
     function ExtractStringValue(const AValue: TGocciaValue): string;
   public
     constructor Create(const APrimitive: TGocciaStringLiteralValue; const AClass: TGocciaClassValue = nil);
@@ -99,6 +95,11 @@ uses
   Goccia.Values.Iterator.Concrete,
   Goccia.Values.Iterator.RegExp,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FSharedStringPrototype: TGocciaObjectValue;
+  FPrototypeMethodHost: TGocciaStringObjectValue;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 { TGocciaStringObjectValue }
 

--- a/units/Goccia.Values.SymbolValue.pas
+++ b/units/Goccia.Values.SymbolValue.pas
@@ -87,9 +87,9 @@ threadvar
   FMethodHost: TGocciaSymbolValue;
   FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
-var
-  GNextSymbolId: Integer = 0;
-  GSymbolRegistry: THashMap<Integer, TGocciaSymbolValue> = nil;
+threadvar
+  GNextSymbolId: Integer;
+  GSymbolRegistry: THashMap<Integer, TGocciaSymbolValue>;
 
 function TGocciaSymbolValue.SymbolToString(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;

--- a/units/Goccia.Values.SymbolValue.pas
+++ b/units/Goccia.Values.SymbolValue.pas
@@ -12,9 +12,6 @@ uses
 type
   TGocciaSymbolValue = class(TGocciaValue)
   private class var
-    FSharedPrototype: TGocciaValue;
-    FMethodHost: TGocciaSymbolValue;
-    FPrototypeMembers: array of TGocciaMemberDefinition;
     FWellKnownIterator: TGocciaSymbolValue;
     FWellKnownMatch: TGocciaSymbolValue;
     FWellKnownMatchAll: TGocciaSymbolValue;
@@ -84,6 +81,11 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue;
+
+threadvar
+  FSharedPrototype: TGocciaValue;
+  FMethodHost: TGocciaSymbolValue;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 var
   GNextSymbolId: Integer = 0;

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -14,9 +14,6 @@ uses
 type
   TGocciaTemporalDurationValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FYears: Int64;
     FMonths: Int64;
     FWeeks: Int64;
@@ -84,6 +81,10 @@ uses
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function AsDuration(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalDurationValue;
 begin

--- a/units/Goccia.Values.TemporalInstant.pas
+++ b/units/Goccia.Values.TemporalInstant.pas
@@ -14,9 +14,6 @@ uses
 type
   TGocciaTemporalInstantValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FEpochMilliseconds: Int64;
     FSubMillisecondNanoseconds: Integer;
 
@@ -52,6 +49,10 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.TemporalDuration;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function AsInstant(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalInstantValue;
 begin

--- a/units/Goccia.Values.TemporalPlainDate.pas
+++ b/units/Goccia.Values.TemporalPlainDate.pas
@@ -14,9 +14,6 @@ uses
 type
   TGocciaTemporalPlainDateValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FYear: Integer;
     FMonth: Integer;
     FDay: Integer;
@@ -76,6 +73,10 @@ uses
   Goccia.Values.TemporalPlainTime,
   Goccia.Values.TemporalPlainYearMonth,
   Goccia.Values.TemporalZonedDateTime;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function GetDurFieldOr(const AObj: TGocciaObjectValue; const AName: string; const ADefault: Int64): Int64;
 var

--- a/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -14,9 +14,6 @@ uses
 type
   TGocciaTemporalPlainDateTimeValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FYear: Integer;
     FMonth: Integer;
     FDay: Integer;
@@ -98,6 +95,10 @@ uses
   Goccia.Values.TemporalPlainTime,
   Goccia.Values.TemporalPlainYearMonth,
   Goccia.Values.TemporalZonedDateTime;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function AsPlainDateTime(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainDateTimeValue;
 begin

--- a/units/Goccia.Values.TemporalPlainMonthDay.pas
+++ b/units/Goccia.Values.TemporalPlainMonthDay.pas
@@ -14,9 +14,6 @@ uses
 type
   TGocciaTemporalPlainMonthDayValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FMonth: Integer;
     FDay: Integer;
     FReferenceYear: Integer;
@@ -55,6 +52,10 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.TemporalPlainDate;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 const
   DEFAULT_REFERENCE_YEAR = 1972;

--- a/units/Goccia.Values.TemporalPlainTime.pas
+++ b/units/Goccia.Values.TemporalPlainTime.pas
@@ -14,9 +14,6 @@ uses
 type
   TGocciaTemporalPlainTimeValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FHour: Integer;
     FMinute: Integer;
     FSecond: Integer;
@@ -65,6 +62,10 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.TemporalDuration;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function AsPlainTime(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainTimeValue;
 begin

--- a/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -14,9 +14,6 @@ uses
 type
   TGocciaTemporalPlainYearMonthValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FYear: Integer;
     FMonth: Integer;
     FReferenceDay: Integer;
@@ -63,6 +60,10 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.TemporalDuration,
   Goccia.Values.TemporalPlainDate;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 function FormatYearMonthString(const AYear, AMonth: Integer): string;
 begin

--- a/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -14,9 +14,6 @@ uses
 type
   TGocciaTemporalZonedDateTimeValue = class(TGocciaObjectValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FEpochMilliseconds: Int64;
     FSubMillisecondNanoseconds: Integer;
     FTimeZone: string;
@@ -95,6 +92,10 @@ uses
   Goccia.Values.TemporalPlainDate,
   Goccia.Values.TemporalPlainDateTime,
   Goccia.Values.TemporalPlainTime;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 const
   MILLISECONDS_PER_SECOND = 1000;

--- a/units/Goccia.Values.TextDecoderValue.pas
+++ b/units/Goccia.Values.TextDecoderValue.pas
@@ -15,9 +15,6 @@ uses
 type
   TGocciaTextDecoderValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FEncoding: string;
     FFatal: Boolean;
     FIgnoreBOM: Boolean;
@@ -61,6 +58,10 @@ uses
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.TypedArrayValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 const
   ENCODING_UTF8 = 'utf-8';

--- a/units/Goccia.Values.TextEncoderValue.pas
+++ b/units/Goccia.Values.TextEncoderValue.pas
@@ -15,9 +15,6 @@ uses
 type
   TGocciaTextEncoderValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     // Getter
     function EncodingGetter(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -49,6 +46,10 @@ uses
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.TypedArrayValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 const
   ENCODING_UTF8 = 'utf-8';

--- a/units/Goccia.Values.TypedArrayValue.pas
+++ b/units/Goccia.Values.TypedArrayValue.pas
@@ -26,10 +26,6 @@ type
 
   TGocciaTypedArrayValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-    class var FUint8Prototype: TGocciaObjectValue;
-  private
     FBufferValue: TGocciaValue;
     FBufferData: TBytes;
     FByteOffset: Integer;
@@ -139,6 +135,11 @@ uses
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+  FUint8Prototype: TGocciaObjectValue;
 
 class function TGocciaTypedArrayValue.BytesPerElement(const AKind: TGocciaTypedArrayKind): Integer;
 begin

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -28,9 +28,6 @@ type
 
   TGocciaURLSearchParamsValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     FList: TGocciaURLSearchParamList;
     // Back-reference to the owning URL object for update notifications.
     // Stored as TObject to avoid a circular interface-section dependency.
@@ -118,6 +115,10 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
   Goccia.Values.URLValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 { TGocciaURLSearchParamsValue }
 

--- a/units/Goccia.Values.URLValue.pas
+++ b/units/Goccia.Values.URLValue.pas
@@ -19,9 +19,6 @@ uses
 type
   TGocciaURLValue = class(TGocciaInstanceValue)
   private
-    class var FShared: TGocciaSharedPrototype;
-    class var FPrototypeMembers: array of TGocciaMemberDefinition;
-  private
     // WHATWG URL §4.1 URL record components (stored parsed)
     FScheme: string;       // e.g. 'https' — no ':'
     FUsername: string;     // percent-encoded
@@ -141,6 +138,10 @@ uses
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
 { TGocciaURLValue }
 


### PR DESCRIPTION
## Summary
- Adds parallel multi-file execution to `ScriptLoader`, `TestRunner`, and `BenchmarkRunner` with a new `--jobs` option and automatic worker-count selection.
- Introduces thread pool/runtime support plus per-thread initialization to avoid shared mutable state races in builtins, call stack, GC, microtask queue, and related runtime objects.
- Preserves ordered result aggregation on the main thread while collecting worker output, errors, and benchmark/test timing data safely across threads.
- Updates benchmark reporting and several builtins to use thread-local static member storage instead of shared class state.

## Testing
- Suggested checks: `./build.pas testrunner && ./build/TestRunner tests`
- Suggested checks: `./build.pas loader && ./build/ScriptLoader path/to/multi-file/scripts --jobs=4`
- Suggested checks: `./build.pas benchmarkrunner && ./build/BenchmarkRunner benchmarks --jobs=4`
- Suggested checks: `./format.pas --check`