### PR TITLE
Align error suggestions across builtins and runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ build/ScriptLoader
 build/TestRunner
 build/BenchmarkRunner
 build/*.Test
+build/ppas.sh
+build/ppas.bat
 
 # Mac OS files
 .DS_Store

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -252,9 +252,9 @@ begin
       on E: TGocciaThrowValue do
       begin
         if not GIsWorkerThread then
-          WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, Source, IsColorTerminal));
+          WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, Source, IsColorTerminal, E.Suggestion));
         MakeErrorFileResult(AFileName,
-          FormatThrowDetail(E.Value, AFileName, Source, False), AReporter);
+          FormatThrowDetail(E.Value, AFileName, Source, False, E.Suggestion), AReporter);
       end;
       on E: Exception do
         MakeErrorFileResult(AFileName, E.Message, AReporter);
@@ -375,9 +375,9 @@ begin
       on E: TGocciaThrowValue do
       begin
         if not GIsWorkerThread then
-          WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, Source, IsColorTerminal));
+          WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, Source, IsColorTerminal, E.Suggestion));
         MakeErrorFileResult(AFileName,
-          FormatThrowDetail(E.Value, AFileName, Source, False), AReporter);
+          FormatThrowDetail(E.Value, AFileName, Source, False, E.Suggestion), AReporter);
       end;
       on E: EGocciaBytecodeThrow do
       begin
@@ -464,9 +464,9 @@ begin
     end;
     on E: TGocciaThrowValue do
     begin
-      WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal));
+      WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal, E.Suggestion));
       MakeErrorFileResult(AFileName,
-        FormatThrowDetail(E.Value, AFileName, ASource, False), AReporter);
+        FormatThrowDetail(E.Value, AFileName, ASource, False, E.Suggestion), AReporter);
     end;
     on E: Exception do
       MakeErrorFileResult(AFileName, E.Message, AReporter);
@@ -577,9 +577,9 @@ begin
     end;
     on E: TGocciaThrowValue do
     begin
-      WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal));
+      WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal, E.Suggestion));
       MakeErrorFileResult(AFileName,
-        FormatThrowDetail(E.Value, AFileName, ASource, False), AReporter);
+        FormatThrowDetail(E.Value, AFileName, ASource, False, E.Suggestion), AReporter);
     end;
     on E: EGocciaBytecodeThrow do
     begin

--- a/REPL.dpr
+++ b/REPL.dpr
@@ -203,7 +203,8 @@ begin
                       WriteLn(TGocciaError(E).GetDetailedMessage(IsColorTerminal))
                     else if E is TGocciaThrowValue then
                       WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value,
-                        REPL_FILE_NAME, Source, IsColorTerminal))
+                        REPL_FILE_NAME, Source, IsColorTerminal,
+                        TGocciaThrowValue(E).Suggestion))
                     else
                       WriteLn('Error: ', E.Message);
                   end;
@@ -256,7 +257,8 @@ begin
                       WriteLn(TGocciaError(E).GetDetailedMessage(IsColorTerminal))
                     else if E is TGocciaThrowValue then
                       WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value,
-                        REPL_FILE_NAME, Source, IsColorTerminal))
+                        REPL_FILE_NAME, Source, IsColorTerminal,
+                        TGocciaThrowValue(E).Suggestion))
                     else
                       WriteLn('Error: ', E.Message);
                   end;

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -651,7 +651,7 @@ begin
           else if E is TGocciaError then
             WriteLn(TGocciaError(E).GetDetailedMessage(IsColorTerminal))
           else if E is TGocciaThrowValue then
-            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, ASource, IsColorTerminal))
+            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, ASource, IsColorTerminal, TGocciaThrowValue(E).Suggestion))
           else if E is EGocciaBytecodeThrow then
             WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName, ASource, IsColorTerminal))
           else

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -325,9 +325,9 @@ begin
         else if E is TGocciaThrowValue then
         begin
           if not GIsWorkerThread then
-            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, IsColorTerminal));
+            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, IsColorTerminal, TGocciaThrowValue(E).Suggestion));
           MarkLoadError(ScriptResult, AFileName,
-            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, False));
+            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, False, TGocciaThrowValue(E).Suggestion));
         end
         else
         begin
@@ -473,9 +473,9 @@ begin
         else if E is TGocciaThrowValue then
         begin
           if not GIsWorkerThread then
-            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, IsColorTerminal));
+            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, IsColorTerminal, TGocciaThrowValue(E).Suggestion));
           MarkLoadError(ScriptResult, AFileName,
-            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, False));
+            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, False, TGocciaThrowValue(E).Suggestion));
         end
         else
         begin

--- a/units/Goccia.Application.pas
+++ b/units/Goccia.Application.pas
@@ -55,7 +55,7 @@ begin
   if AException is TGocciaError then
     WriteLn(TGocciaError(AException).GetDetailedMessage(UseColor))
   else if AException is TGocciaThrowValue then
-    WriteLn(FormatThrowDetail(TGocciaThrowValue(AException).Value, '', nil, UseColor))
+    WriteLn(FormatThrowDetail(TGocciaThrowValue(AException).Value, '', nil, UseColor, TGocciaThrowValue(AException).Suggestion))
   else if AException is EGocciaBytecodeThrow then
     WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(AException).ThrownValue, '', nil, UseColor))
   else

--- a/units/Goccia.Builtins.DisposableStack.pas
+++ b/units/Goccia.Builtins.DisposableStack.pas
@@ -51,6 +51,8 @@ uses
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.DisposalTracker,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Scope.BindingMap,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
@@ -85,16 +87,16 @@ var
   Obj: TGocciaObjectValue;
 begin
   if not (AThisValue is TGocciaObjectValue) then
-    ThrowTypeError('DisposableStack method called on incompatible receiver');
+    ThrowTypeError(SErrorDisposableStackIncompatibleReceiver, SSuggestDisposableStackThisType);
   Obj := TGocciaObjectValue(AThisValue);
   if not Assigned(GSlotMap) or not GSlotMap.TryGetValue(Obj, Result) then
-    ThrowTypeError('DisposableStack method called on incompatible receiver');
+    ThrowTypeError(SErrorDisposableStackIncompatibleReceiver, SSuggestDisposableStackThisType);
 end;
 
 procedure RequireNotDisposed(const ASlot: PDisposableStackSlot);
 begin
   if ASlot^.Disposed then
-    ThrowReferenceError('DisposableStack has already been disposed');
+    ThrowReferenceError(SErrorDisposableStackAlreadyDisposed, SSuggestDisposableStackAlreadyDisposed);
 end;
 
 // TC39 Explicit Resource Management §3.4.3.2 DisposableStack.prototype.use(value)
@@ -121,7 +123,7 @@ begin
 
   DisposeMethod := GetDisposeMethod(Value, dhSyncDispose);
   if not Assigned(DisposeMethod) then
-    ThrowTypeError('The value is not disposable (missing [Symbol.dispose])');
+    ThrowTypeError(SErrorValueNotDisposable, SSuggestDisposable);
 
   Slot^.Tracker.AddResource(Value, DisposeMethod, dhSyncDispose);
   Result := Value;
@@ -151,7 +153,7 @@ begin
 
   DisposeMethod := GetDisposeMethod(Value, dhAsyncDispose);
   if not Assigned(DisposeMethod) then
-    ThrowTypeError('The value is not disposable (missing [Symbol.asyncDispose] and [Symbol.dispose])');
+    ThrowTypeError(SErrorValueNotAsyncDisposable, SSuggestDisposable);
 
   Slot^.Tracker.AddResource(Value, DisposeMethod, dhAsyncDispose);
   Result := Value;
@@ -178,7 +180,7 @@ begin
     OnDispose := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   if not OnDispose.IsCallable then
-    ThrowTypeError('The onDispose argument must be a function');
+    ThrowTypeError(SErrorOnDisposeMustBeFunction, SSuggestNotFunctionType);
 
   Slot^.Tracker.AddResource(Value, OnDispose, dhSyncDispose);
   Result := Value;
@@ -200,7 +202,7 @@ begin
     OnDispose := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   if not OnDispose.IsCallable then
-    ThrowTypeError('The onDispose argument must be a function');
+    ThrowTypeError(SErrorOnDisposeMustBeFunction, SSuggestNotFunctionType);
 
   Slot^.Tracker.AddResource(TGocciaUndefinedLiteralValue.UndefinedValue, OnDispose, dhSyncDispose);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;

--- a/units/Goccia.Builtins.GlobalArray.pas
+++ b/units/Goccia.Builtins.GlobalArray.pas
@@ -33,6 +33,8 @@ uses
 
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator,
   Goccia.GarbageCollector,
   Goccia.Utils,
@@ -155,7 +157,8 @@ begin
     begin
       // Step 3a: If IsCallable(mapfn) is false, throw TypeError
       if not MapCallback.IsCallable then
-        ThrowTypeError('Array.from: when provided, the second argument must be a function');
+        ThrowTypeError(SErrorArrayFromMapFn,
+          SSuggestArrayFromMapFn);
       // Step 3b: Let mapping be true
       Mapping := True;
       if AArgs.Length > 2 then
@@ -251,7 +254,7 @@ begin
           Iterator := nil;
 
         if not Assigned(Iterator) then
-          ThrowTypeError('[Symbol.iterator] did not return a valid iterator');
+          ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
 
         // Step 5a-b: If IsConstructor(C), Construct(C, « »); else ArrayCreate(0)
         ResultObj := ConstructOrCreate(0);
@@ -366,7 +369,7 @@ var
       CloseResult := TGocciaFunctionBase(ReturnMethod).Call(CloseArgs, AIterator);
       CloseResult := AwaitValue(CloseResult);
       if not (CloseResult is TGocciaObjectValue) then
-        ThrowTypeError('Iterator return() must return an object');
+        ThrowTypeError(SErrorIteratorReturnObject, SSuggestIteratorProtocol);
     finally
       CloseArgs.Free;
     end;
@@ -457,7 +460,7 @@ begin
           try
             NextMethod := IteratorObj.GetProperty(PROP_NEXT);
             if not Assigned(NextMethod) or not NextMethod.IsCallable then
-              ThrowTypeError('Async iterator .next is not callable');
+              ThrowTypeError(SErrorAsyncIteratorNextNotCallable, SSuggestIteratorProtocol);
 
             K := 0;
             EmptyArgs := TGocciaArgumentsCollection.Create;
@@ -472,7 +475,8 @@ begin
 
                   // ES2026 §7.4.2 step 5: If nextResult is not an Object, throw a TypeError
                   if NextResult.IsPrimitive then
-                    ThrowTypeError('Iterator result ' + NextResult.ToStringLiteral.Value + ' is not an object');
+                    ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.ToStringLiteral.Value]),
+                      SSuggestIteratorResultObject);
 
                   // TC39 Array.fromAsync §2.1.1.1 step 4.b.iii: IteratorComplete(next)
                   DoneValue := NextResult.GetProperty(PROP_DONE);

--- a/units/Goccia.Builtins.GlobalArrayBuffer.pas
+++ b/units/Goccia.Builtins.GlobalArrayBuffer.pas
@@ -31,6 +31,8 @@ uses
   Math,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.TypedArrayValue;
 
@@ -78,7 +80,7 @@ begin
     IntegerIndex := 0
   else if Num.IsInfinite then
   begin
-    ThrowRangeError('Invalid array buffer length');
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
     Exit(0);
   end
   else
@@ -86,7 +88,7 @@ begin
 
   if (IntegerIndex < 0) or (IntegerIndex > MAX_ECMA_INDEX) or
      (IntegerIndex > High(Integer)) then
-    ThrowRangeError('Invalid array buffer length');
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
 
   Result := Trunc(IntegerIndex);
 end;
@@ -108,7 +110,7 @@ begin
   Num := AArgs.GetElement(0).ToNumberLiteral;
 
   if Num.IsNaN or Num.IsInfinite or (Num.Value < 0) or (Num.Value <> Trunc(Num.Value)) then
-    ThrowRangeError('Invalid array buffer length');
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
 
   Len := Trunc(Num.Value);
 

--- a/units/Goccia.Builtins.GlobalFFI.pas
+++ b/units/Goccia.Builtins.GlobalFFI.pas
@@ -28,6 +28,8 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.FFI.DynamicLibrary,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FFILibrary,
@@ -74,7 +76,7 @@ var
   Handle: TGocciaFFILibraryHandle;
 begin
   if AArgs.Length < 1 then
-    ThrowTypeError('FFI.open requires a library path');
+    ThrowTypeError(SErrorFFIOpenRequiresPath, SSuggestFFILibraryOpen);
 
   LibPath := AArgs.GetElement(0).ToStringLiteral.Value;
 
@@ -82,7 +84,7 @@ begin
     Handle := TGocciaFFILibraryHandle.Create(LibPath);
   except
     on E: Exception do
-      ThrowTypeError(E.Message);
+      ThrowTypeError(E.Message, SSuggestFFILibraryOpen);
   end;
 
   try

--- a/units/Goccia.Builtins.GlobalMap.pas
+++ b/units/Goccia.Builtins.GlobalMap.pas
@@ -22,8 +22,11 @@ type
 implementation
 
 uses
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
+  Goccia.Values.ErrorHelper,
   Goccia.Values.MapValue,
   Goccia.Values.NativeFunction;
 
@@ -49,9 +52,9 @@ begin
   // Step 1: Let groups be GroupBy(items, callbackfn, zero)
   // (Validate arguments first)
   if not (AArgs.GetElement(0) is TGocciaArrayValue) then
-    ThrowError('Map.groupBy requires an iterable as first argument', 0, 0);
+    ThrowTypeError(SErrorMapGroupByRequiresIterable, SSuggestNotIterable);
   if not AArgs.GetElement(1).IsCallable then
-    ThrowError('Map.groupBy requires a callback function as second argument', 0, 0);
+    ThrowTypeError(SErrorMapGroupByRequiresCallback, SSuggestCallbackRequired);
 
   Items := TGocciaArrayValue(AArgs.GetElement(0));
   Callback := AArgs.GetElement(1);

--- a/units/Goccia.Builtins.GlobalObject.pas
+++ b/units/Goccia.Builtins.GlobalObject.pas
@@ -53,6 +53,8 @@ uses
 
   Goccia.Arguments.Validator,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator.Comparison,
   Goccia.GarbageCollector,
   Goccia.Utils,
@@ -109,7 +111,7 @@ var
   Boxed: TGocciaObjectValue;
 begin
   if (AValue is TGocciaUndefinedLiteralValue) or (AValue is TGocciaNullLiteralValue) then
-    ThrowTypeError('Cannot convert undefined or null to object');
+    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
 
   if AValue is TGocciaObjectValue then
   begin
@@ -126,7 +128,7 @@ begin
   end;
 
   // Symbol and other non-coercible types
-  ThrowTypeError('Cannot convert value to object');
+  ThrowTypeError(SErrorCannotConvertValueToObject, SSuggestObjectArgType);
   Result := nil;
 end;
 
@@ -340,7 +342,7 @@ begin
 
   // Step 1: If Type(O) is neither Object nor Null, throw a TypeError exception
   if not (ProtoArg is TGocciaObjectValue) and not (ProtoArg is TGocciaNullLiteralValue) then
-    ThrowError('Object.create called on non-object', 0, 0);
+    ThrowTypeError(SErrorObjectCreateCalledOnNonObject, SSuggestObjectArgType);
 
   // Step 2: Let obj be OrdinaryObjectCreate(O)
   if ProtoArg is TGocciaObjectValue then
@@ -348,7 +350,7 @@ begin
   else if ProtoArg is TGocciaNullLiteralValue then
     Result := TGocciaObjectValue.Create(nil)
   else
-    ThrowError('Object.create called on non-object', 0, 0);
+    ThrowTypeError(SErrorObjectCreateCalledOnNonObject, SSuggestObjectArgType);
   // Step 3: If Properties is not undefined, perform ObjectDefineProperties(obj, Properties)
   // Step 4: Return obj
 end;
@@ -547,10 +549,10 @@ begin
 
   // Step 1: If Type(O) is not Object, throw a TypeError exception
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
-    ThrowError('Object.defineProperty called on non-object', 0, 0);
+    ThrowTypeError(SErrorObjectDefinePropertyCalledOnNonObject, SSuggestObjectArgType);
 
   if not (AArgs.GetElement(2) is TGocciaObjectValue) then
-    ThrowError('Object.defineProperty: descriptor must be an object', 0, 0);
+    ThrowTypeError(SErrorObjectDefinePropertyDescriptorMustBeObject, SSuggestObjectArgType);
 
   Obj := TGocciaObjectValue(AArgs.GetElement(0));
   DescriptorObject := TGocciaObjectValue(AArgs.GetElement(2));
@@ -604,11 +606,11 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.defineProperties', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
-    ThrowError('Object.defineProperties called on non-object', 0, 0);
+    ThrowTypeError(SErrorObjectDefinePropertiesCalledOnNonObject, SSuggestObjectArgType);
 
   // Step 1: Let props be ? ToObject(Properties)
   if not (AArgs.GetElement(1) is TGocciaObjectValue) then
-    ThrowError('Object.defineProperties: properties must be an object', 0, 0);
+    ThrowTypeError(SErrorObjectDefinePropertiesMustBeObject, SSuggestObjectArgType);
 
   Obj := TGocciaObjectValue(AArgs.GetElement(0));
   PropertiesDescriptor := TGocciaObjectValue(AArgs.GetElement(1));
@@ -746,7 +748,7 @@ begin
 
   // Step 1: Perform ? RequireObjectCoercible(iterable)
   if not (AArgs.GetElement(0) is TGocciaArrayValue) then
-    ThrowError('Object.fromEntries requires an iterable of key-value pairs', 0, 0);
+    ThrowTypeError(SErrorObjectFromEntriesRequiresIterable, SSuggestNotIterable);
 
   Entries := TGocciaArrayValue(AArgs.GetElement(0));
   // Step 2: Let obj be OrdinaryObjectCreate(%Object.prototype%)
@@ -756,11 +758,11 @@ begin
   for I := 0 to Entries.Elements.Count - 1 do
   begin
     if not (Entries.Elements[I] is TGocciaArrayValue) then
-      ThrowError('Object.fromEntries requires an iterable of key-value pairs', 0, 0);
+      ThrowTypeError(SErrorObjectFromEntriesRequiresIterable, SSuggestNotIterable);
 
     Entry := TGocciaArrayValue(Entries.Elements[I]);
     if Entry.Elements.Count < 2 then
-      ThrowError('Object.fromEntries requires each entry to have at least 2 elements', 0, 0);
+      ThrowTypeError(SErrorObjectFromEntriesRequiresPairs, SSuggestNotIterable);
 
     // Step 3a: Let key be entry[0], let value be entry[1]
     Key := Entry.Elements[0].ToStringLiteral.Value;
@@ -867,12 +869,12 @@ begin
   // Step 1: Perform ? RequireObjectCoercible(O) — throws for undefined/null
   if (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) or
      (AArgs.GetElement(0) is TGocciaNullLiteralValue) then
-    ThrowTypeError('Cannot convert undefined or null to object');
+    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
 
   // Step 2: If Type(proto) is neither Object nor Null, throw a TypeError exception
   ProtoArg := AArgs.GetElement(1);
   if not (ProtoArg is TGocciaObjectValue) and not (ProtoArg is TGocciaNullLiteralValue) then
-    ThrowTypeError('Object prototype may only be an Object or null');
+    ThrowTypeError(SErrorObjectPrototypeMustBeObjectOrNull, SSuggestObjectArgType);
 
   // Step 3: If Type(O) is not Object, return O (primitives are immutable)
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
@@ -885,14 +887,14 @@ begin
   if AArgs.GetElement(0) is TGocciaProxyValue then
   begin
     if not TGocciaProxyValue(AArgs.GetElement(0)).SetPrototypeTrap(ProtoArg) then
-      ThrowError('setPrototypeOf trap returned false', 0, 0);
+      ThrowTypeError(SErrorSetPrototypeOfTrapReturnedFalse, SSuggestObjectArgType);
     Result := AArgs.GetElement(0);
     Exit;
   end;
 
   // Step 3: If Type(O) is not Object, return O (handled above via throw)
   if not TGocciaObjectValue(AArgs.GetElement(0)).Extensible then
-    ThrowError('Object.setPrototypeOf called on non-extensible object', 0, 0);
+    ThrowTypeError(SErrorSetPrototypeOfNonExtensible, SSuggestObjectNotExtensible);
 
   // Step 4: Let status be ? O.[[SetPrototypeOf]](proto)
   if ProtoArg is TGocciaNullLiteralValue then
@@ -919,9 +921,9 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.groupBy', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaArrayValue) then
-    ThrowError('Object.groupBy requires an iterable as first argument', 0, 0);
+    ThrowTypeError(SErrorObjectGroupByRequiresIterable, SSuggestNotIterable);
   if not AArgs.GetElement(1).IsCallable then
-    ThrowError('Object.groupBy requires a callback function as second argument', 0, 0);
+    ThrowTypeError(SErrorObjectGroupByRequiresCallback, SSuggestCallbackRequired);
 
   // Step 1: Let groups be ? GroupBy(items, callbackfn, property)
   Items := TGocciaArrayValue(AArgs.GetElement(0));

--- a/units/Goccia.Builtins.GlobalPromise.pas
+++ b/units/Goccia.Builtins.GlobalPromise.pas
@@ -41,6 +41,8 @@ uses
 
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.Utils,
@@ -422,7 +424,7 @@ begin
   begin
     FState.Settled := True;
     ErrorObj := Goccia.Values.ErrorHelper.CreateErrorObject(AGGREGATE_ERROR_NAME,
-      'All promises were rejected');
+      SErrorAllPromisesRejected);
     ErrorObj.AssignProperty(PROP_ERRORS, FState.Errors);
     FState.ResultPromise.Reject(ErrorObj);
   end;
@@ -489,11 +491,11 @@ var
 begin
   { Step 2: If IsCallable(executor) is false, throw a TypeError }
   if AArgs.Length = 0 then
-    Goccia.Values.ErrorHelper.ThrowTypeError('Promise resolver undefined is not a function');
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseResolverUndefinedNotFunction, SSuggestPromiseResolver);
 
   Executor := AArgs.GetElement(0);
   if not Executor.IsCallable then
-    Goccia.Values.ErrorHelper.ThrowTypeError('Promise resolver is not a function');
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseResolverNotFunction, SSuggestPromiseResolver);
 
   { Steps 3-4: Let promise = OrdinaryCreateFromConstructor; set state to pending }
   Promise := TGocciaPromiseValue.Create;
@@ -611,7 +613,7 @@ begin
   else
   begin
     Goccia.Values.ErrorHelper.ThrowTypeError(
-      Iterable.ToStringLiteral.Value + ' is not iterable');
+      Iterable.ToStringLiteral.Value + ' is not iterable', SSuggestNotIterable);
     Result := nil;
   end;
 end;
@@ -868,7 +870,7 @@ begin
   if InputArray.Elements.Count = 0 then
   begin
     ErrorObj := Goccia.Values.ErrorHelper.CreateErrorObject(AGGREGATE_ERROR_NAME,
-      'All promises were rejected');
+      SErrorAllPromisesRejected);
     ErrorObj.AssignProperty(PROP_ERRORS, TGocciaArrayValue.Create);
     ResultPromise.Reject(ErrorObj);
     Result := ResultPromise;
@@ -952,11 +954,11 @@ begin
 
   { Step 2: If IsCallable(callbackfn) is false, throw a TypeError }
   if AArgs.Length = 0 then
-    Goccia.Values.ErrorHelper.ThrowTypeError('Promise.try requires a callback function');
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseTryRequiresCallback, SSuggestCallbackRequired);
 
   Callback := AArgs.GetElement(0);
   if not Callback.IsCallable then
-    Goccia.Values.ErrorHelper.ThrowTypeError('Promise.try requires a callback function');
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseTryRequiresCallback, SSuggestCallbackRequired);
 
   { Step 4: Let status = Call(callbackfn, undefined) }
   try

--- a/units/Goccia.Builtins.GlobalProxy.pas
+++ b/units/Goccia.Builtins.GlobalProxy.pas
@@ -29,6 +29,8 @@ implementation
 uses
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
   Goccia.Values.NativeFunction,
@@ -58,24 +60,24 @@ var
 begin
   // Proxy must be called with new
   if not (AThisValue is TGocciaHoleValue) then
-    ThrowTypeError('Constructor Proxy requires ''new''');
+    ThrowTypeError(SErrorProxyRequiresNew, SSuggestRequiresNew);
 
   if AArgs.Length < 2 then
-    ThrowTypeError('Cannot create proxy with a non-object as target or handler');
+    ThrowTypeError(SErrorProxyNonObjectTargetOrHandler, SSuggestProxyTargetType);
 
   TargetArg := AArgs.GetElement(0);
   HandlerArg := AArgs.GetElement(1);
 
   // Target must be an object (or function)
   if TargetArg.IsPrimitive then
-    ThrowTypeError('Cannot create proxy with a non-object as target or handler');
+    ThrowTypeError(SErrorProxyNonObjectTargetOrHandler, SSuggestProxyTargetType);
 
   // Handler must be an object
   if HandlerArg.IsPrimitive then
-    ThrowTypeError('Cannot create proxy with a non-object as target or handler');
+    ThrowTypeError(SErrorProxyNonObjectTargetOrHandler, SSuggestProxyTargetType);
 
   if not (HandlerArg is TGocciaObjectValue) then
-    ThrowTypeError('Cannot create proxy with a non-object as target or handler');
+    ThrowTypeError(SErrorProxyNonObjectTargetOrHandler, SSuggestProxyTargetType);
 
   Result := TGocciaProxyValue.Create(TargetArg,
     TGocciaObjectValue(HandlerArg));
@@ -92,21 +94,21 @@ var
   ResultObj: TGocciaObjectValue;
 begin
   if AArgs.Length < 2 then
-    ThrowTypeError('Cannot create proxy with a non-object as target or handler');
+    ThrowTypeError(SErrorProxyNonObjectTargetOrHandler, SSuggestProxyTargetType);
 
   TargetArg := AArgs.GetElement(0);
   HandlerArg := AArgs.GetElement(1);
 
   // Target must be an object (or function)
   if TargetArg.IsPrimitive then
-    ThrowTypeError('Cannot create proxy with a non-object as target or handler');
+    ThrowTypeError(SErrorProxyNonObjectTargetOrHandler, SSuggestProxyTargetType);
 
   // Handler must be an object
   if HandlerArg.IsPrimitive then
-    ThrowTypeError('Cannot create proxy with a non-object as target or handler');
+    ThrowTypeError(SErrorProxyNonObjectTargetOrHandler, SSuggestProxyTargetType);
 
   if not (HandlerArg is TGocciaObjectValue) then
-    ThrowTypeError('Cannot create proxy with a non-object as target or handler');
+    ThrowTypeError(SErrorProxyNonObjectTargetOrHandler, SSuggestProxyTargetType);
 
   ProxyInstance := TGocciaProxyValue.Create(TargetArg,
     TGocciaObjectValue(HandlerArg));

--- a/units/Goccia.Builtins.GlobalReflect.pas
+++ b/units/Goccia.Builtins.GlobalReflect.pas
@@ -41,6 +41,8 @@ uses
   Goccia.Arguments.ArrayLike,
   Goccia.Arguments.Validator,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
@@ -58,7 +60,7 @@ threadvar
 procedure RequireObjectTarget(const ATarget: TGocciaValue; const AMethodName: string);
 begin
   if not (ATarget is TGocciaObjectValue) then
-    ThrowTypeError(Format('%s: target must be an object', [AMethodName]));
+    ThrowTypeError(Format(SErrorReflectTargetMustBeObject, [AMethodName]), SSuggestReflectObjectArg);
 end;
 
 { TGocciaGlobalReflect }
@@ -112,7 +114,7 @@ begin
 
   // Step 1: If IsCallable(target) is false, throw a TypeError exception
   if not (Target is TGocciaFunctionBase) then
-    ThrowTypeError('Reflect.apply: target must be a function');
+    ThrowTypeError(SErrorReflectApplyTargetMustBeFunction, SSuggestNotFunctionType);
 
   // Step 2: Let args be ? CreateListFromArrayLike(argumentsList)
   CallArgs := CreateListFromArrayLike(ArgsList, 'Reflect.apply');
@@ -139,7 +141,7 @@ begin
 
   // Step 1: If IsConstructor(target) is false, throw a TypeError exception
   if not (Target is TGocciaClassValue) then
-    ThrowTypeError('Reflect.construct: target must be a constructor');
+    ThrowTypeError(SErrorReflectConstructTargetMustBeConstructor, SSuggestNotConstructorType);
 
   // Step 2: Let args be ? CreateListFromArrayLike(argumentsList)
   CallArgs := CreateListFromArrayLike(ArgsList, 'Reflect.construct');
@@ -149,7 +151,7 @@ begin
     begin
       NewTarget := AArgs.GetElement(2);
       if not (NewTarget is TGocciaClassValue) then
-        ThrowTypeError('Reflect.construct: newTarget must be a constructor');
+        ThrowTypeError(SErrorReflectConstructNewTargetMustBeConstructor, SSuggestNotConstructorType);
     end
     else
       NewTarget := Target;
@@ -187,7 +189,7 @@ begin
   RequireObjectTarget(Target, 'Reflect.defineProperty');
 
   if not (Attrs is TGocciaObjectValue) then
-    ThrowTypeError('Reflect.defineProperty: attributes must be an object');
+    ThrowTypeError(SErrorReflectDefinePropertyAttrsMustBeObject, SSuggestPropertyDescriptorObject);
 
   Obj := TGocciaObjectValue(Target);
   DescriptorObject := TGocciaObjectValue(Attrs);
@@ -551,7 +553,7 @@ begin
 
   // Step 2: If Type(proto) is neither Object nor Null, throw a TypeError exception
   if not (ProtoArg is TGocciaObjectValue) and not (ProtoArg is TGocciaNullLiteralValue) then
-    ThrowTypeError('Reflect.setPrototypeOf: proto must be an object or null');
+    ThrowTypeError(SErrorReflectSetPrototypeOfProtoType, SSuggestReflectObjectArg);
 
   // Step 3: Return ? target.[[SetPrototypeOf]](proto)
   // ES2026 §10.1.2 OrdinarySetPrototypeOf step 2: If SameValue(V, current) return true

--- a/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/units/Goccia.Builtins.GlobalRegExp.pas
@@ -55,6 +55,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.RegExp.Runtime,
   Goccia.Utils,
@@ -436,11 +438,11 @@ var
 begin
   // TC39 RegExp Escaping §1.1 step 1
   if AArgs.Length = 0 then
-    ThrowTypeError('RegExp.escape requires a string argument');
+    ThrowTypeError(SErrorRegExpEscapeRequiresString, SSuggestRegExpEscapeString);
 
   Arg := AArgs.GetElement(0);
   if not (Arg is TGocciaStringLiteralValue) then
-    ThrowTypeError('First argument to RegExp.escape must be a string');
+    ThrowTypeError(SErrorRegExpEscapeArgMustBeString, SSuggestRegExpEscapeString);
 
   Input := Arg.ToStringLiteral.Value;
   Escaped := '';
@@ -548,7 +550,7 @@ var
   MatchValue: TGocciaValue;
 begin
   if not IsRegExpValue(AThisValue) then
-    ThrowTypeError('RegExp.prototype.exec called on non-RegExp object');
+    ThrowTypeError(SErrorRegExpExecNonRegExp, SSuggestRegExpThisType);
 
   if AArgs.Length > 0 then
     Input := AArgs.GetElement(0).ToStringLiteral.Value
@@ -569,7 +571,7 @@ var
   MatchValue: TGocciaValue;
 begin
   if not IsRegExpValue(AThisValue) then
-    ThrowTypeError('RegExp.prototype.test called on non-RegExp object');
+    ThrowTypeError(SErrorRegExpTestNonRegExp, SSuggestRegExpThisType);
 
   if AArgs.Length > 0 then
     Input := AArgs.GetElement(0).ToStringLiteral.Value
@@ -586,7 +588,7 @@ function TGocciaGlobalRegExp.RegExpToStringMethod(
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not IsRegExpValue(AThisValue) then
-    ThrowTypeError('RegExp.prototype.toString called on non-RegExp object');
+    ThrowTypeError(SErrorRegExpToStringNonRegExp, SSuggestRegExpThisType);
 
   Result := TGocciaStringLiteralValue.Create(RegExpObjectToString(AThisValue));
 end;
@@ -603,7 +605,7 @@ var
   MatchIndex, MatchEnd, NextIndex: Integer;
 begin
   if not IsRegExpValue(AThisValue) then
-    ThrowTypeError('RegExp.prototype[Symbol.match] called on non-RegExp object');
+    ThrowTypeError(SErrorRegExpMatchNonRegExp, SSuggestRegExpThisType);
 
   if AArgs.Length > 0 then
     Input := AArgs.GetElement(0).ToStringLiteral.Value
@@ -643,7 +645,7 @@ var
   IsGlobal: Boolean;
 begin
   if not IsRegExpValue(AThisValue) then
-    ThrowTypeError('RegExp.prototype[Symbol.matchAll] called on non-RegExp object');
+    ThrowTypeError(SErrorRegExpMatchAllNonRegExp, SSuggestRegExpThisType);
 
   if AArgs.Length > 0 then
     Input := AArgs.GetElement(0).ToStringLiteral.Value
@@ -670,7 +672,7 @@ var
   MatchIndex, MatchEnd, NextIndex, SearchIndex, OutputIndex: Integer;
 begin
   if not IsRegExpValue(AThisValue) then
-    ThrowTypeError('RegExp.prototype[Symbol.replace] called on non-RegExp object');
+    ThrowTypeError(SErrorRegExpReplaceNonRegExp, SSuggestRegExpThisType);
 
   if AArgs.Length > 0 then
     Input := AArgs.GetElement(0).ToStringLiteral.Value
@@ -735,7 +737,7 @@ var
   MatchIndex, MatchEnd, NextIndex: Integer;
 begin
   if not IsRegExpValue(AThisValue) then
-    ThrowTypeError('RegExp.prototype[Symbol.search] called on non-RegExp object');
+    ThrowTypeError(SErrorRegExpSearchNonRegExp, SSuggestRegExpThisType);
 
   if AArgs.Length > 0 then
     Input := AArgs.GetElement(0).ToStringLiteral.Value
@@ -766,7 +768,7 @@ var
   I: Integer;
 begin
   if not IsRegExpValue(AThisValue) then
-    ThrowTypeError('RegExp.prototype[Symbol.split] called on non-RegExp object');
+    ThrowTypeError(SErrorRegExpSplitNonRegExp, SSuggestRegExpThisType);
 
   if AArgs.Length > 0 then
     Input := AArgs.GetElement(0).ToStringLiteral.Value

--- a/units/Goccia.Builtins.GlobalString.pas
+++ b/units/Goccia.Builtins.GlobalString.pas
@@ -30,6 +30,8 @@ uses
   StringBuffer,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -94,10 +96,10 @@ begin
   begin
     NumArg := AArgs.GetElement(I).ToNumberLiteral;
     if NumArg.IsNaN or NumArg.IsInfinity or NumArg.IsNegativeInfinity then
-      ThrowRangeError('Invalid code point');
+      ThrowRangeError(SErrorInvalidCodePoint, SSuggestCodePointRange);
     RawValue := NumArg.Value;
     if (RawValue < 0) or (RawValue > $10FFFF) or (RawValue <> Trunc(RawValue)) then
-      ThrowRangeError(FloatToStr(RawValue) + ' is not a valid code point');
+      ThrowRangeError(Format(SErrorNotValidCodePoint, [FloatToStr(RawValue)]), SSuggestCodePointRange);
     CodePoint := Trunc(RawValue);
 
     if CodePoint < $80 then
@@ -124,17 +126,19 @@ var
   NextSub: TGocciaValue;
 begin
   if AArgs.Length = 0 then
-    ThrowTypeError('Cannot convert undefined to object');
+    ThrowTypeError(Format(SErrorCannotConvertToObject, ['undefined']), SSuggestCheckNullBeforeAccess);
 
   // ES2026 §22.1.2.4 step 1-2: Let cooked be ToObject(template)
   TemplateObj := AArgs.GetElement(0);
   if (TemplateObj is TGocciaUndefinedLiteralValue) or (TemplateObj is TGocciaNullLiteralValue) then
-    ThrowTypeError('Cannot convert ' + TemplateObj.TypeName + ' to object');
+    ThrowTypeError(Format(SErrorCannotConvertToObject, [TemplateObj.TypeName]), SSuggestCheckNullBeforeAccess);
 
   // ES2026 §22.1.2.4 step 3: Let raw be ToObject(Get(cooked, "raw"))
   RawValue := TemplateObj.GetProperty(PROP_RAW);
-  if not Assigned(RawValue) or (RawValue is TGocciaUndefinedLiteralValue) or (RawValue is TGocciaNullLiteralValue) then
-    ThrowTypeError('Cannot convert ' + 'undefined' + ' to object');
+  if not Assigned(RawValue) or (RawValue is TGocciaUndefinedLiteralValue) then
+    ThrowTypeError(Format(SErrorCannotConvertToObject, ['undefined']), SSuggestCheckNullBeforeAccess)
+  else if RawValue is TGocciaNullLiteralValue then
+    ThrowTypeError(Format(SErrorCannotConvertToObject, ['null']), SSuggestCheckNullBeforeAccess);
   RawObj := RawValue;
 
   // ES2026 §22.1.2.4 step 4: Let literalSegments be LengthOfArrayLike(raw)

--- a/units/Goccia.Builtins.GlobalSymbol.pas
+++ b/units/Goccia.Builtins.GlobalSymbol.pas
@@ -43,6 +43,8 @@ implementation
 uses
   Goccia.Constants.PropertyNames,
   Goccia.Constants.SymbolNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue;
 
@@ -175,7 +177,7 @@ begin
 
   { Step 1: If Type(sym) is not Symbol, throw a TypeError }
   if not (Arg is TGocciaSymbolValue) then
-    ThrowTypeError('Symbol.keyFor requires that the first argument be a symbol');
+    ThrowTypeError(SErrorSymbolKeyForRequiresSymbol, SSuggestSymbolKeyForArg);
 
   { Step 2: Search GlobalSymbolRegistry for matching symbol }
   for Pair in FGlobalRegistry do

--- a/units/Goccia.Builtins.Globals.pas
+++ b/units/Goccia.Builtins.Globals.pas
@@ -73,6 +73,8 @@ uses
 
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.URI,
@@ -497,11 +499,11 @@ var
 begin
   { Step 1: If IsCallable(callback) is false, throw a TypeError }
   if AArgs.Length = 0 then
-    ThrowTypeError('Failed to execute ''queueMicrotask'': 1 argument required, but only 0 present.');
+    ThrowTypeError(SErrorQueueMicrotaskArgRequired, SSuggestCallbackRequired);
 
   Callback := AArgs.GetElement(0);
   if not Callback.IsCallable then
-    ThrowTypeError('Failed to execute ''queueMicrotask'': parameter 1 is not of type ''Function''.');
+    ThrowTypeError(SErrorQueueMicrotaskNotFunction, SSuggestCallbackRequired);
 
   { Step 2: HostEnqueueMicrotask(callback) }
   Task.Handler := Callback;
@@ -650,10 +652,10 @@ begin
     Exit(AValue);
 
   if AValue is TGocciaSymbolValue then
-    ThrowDataCloneError(AValue.ToStringLiteral.Value + ' could not be cloned.');
+    ThrowDataCloneError(Format(SErrorStructuredCloneNotCloneable, [AValue.ToStringLiteral.Value]), SSuggestStructuredClone);
 
   if AValue.IsCallable then
-    ThrowDataCloneError(AValue.ToStringLiteral.Value + ' could not be cloned.');
+    ThrowDataCloneError(Format(SErrorStructuredCloneNotCloneable, [AValue.ToStringLiteral.Value]), SSuggestStructuredClone);
 
   if AMemory.TryGetValue(AValue, Existing) then
     Exit(Existing);
@@ -671,7 +673,7 @@ begin
   else if AValue is TGocciaObjectValue then
     Result := CloneObject(TGocciaObjectValue(AValue), AMemory)
   else
-    ThrowDataCloneError('value could not be cloned.');
+    ThrowDataCloneError(SErrorStructuredCloneValueNotCloneable, SSuggestStructuredClone);
 end;
 
 function TGocciaGlobals.StructuredCloneCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -681,7 +683,7 @@ var
   I: Integer;
 begin
   if AArgs.Length = 0 then
-    ThrowTypeError('Failed to execute ''structuredClone'': 1 argument required, but only 0 present.');
+    ThrowTypeError(SErrorStructuredCloneArgRequired, SSuggestObjectArgType);
 
   Memory := THashMap<TGocciaValue, TGocciaValue>.Create;
   try
@@ -776,7 +778,7 @@ var
 begin
   // Step 1: If no argument, throw TypeError
   if AArgs.Length = 0 then
-    ThrowTypeError('Failed to execute ''btoa'': 1 argument required, but only 0 present.');
+    ThrowTypeError(SErrorBtoaRequiresArg, SSuggestStringArgRequired);
 
   // Step 2: Let data be ToString(argument)
   Data := AArgs.GetElement(0).ToStringLiteral.Value;
@@ -821,7 +823,7 @@ var
 begin
   // Step 1: If no argument, throw TypeError
   if AArgs.Length = 0 then
-    ThrowTypeError('Failed to execute ''atob'': 1 argument required, but only 0 present.');
+    ThrowTypeError(SErrorAtobRequiresArg, SSuggestStringArgRequired);
 
   // Step 2: Let data be ToString(argument)
   Data := AArgs.GetElement(0).ToStringLiteral.Value;

--- a/units/Goccia.Builtins.JSON.pas
+++ b/units/Goccia.Builtins.JSON.pas
@@ -53,6 +53,8 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Utils,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
@@ -203,7 +205,7 @@ begin
 
   // Step 1: Let jsonString be ? ToString(text).
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowError('JSON.parse: argument must be a string', 0, 0);
+    ThrowTypeError(SErrorJSONParseArgMustBeString, SSuggestStringArgRequired);
 
   // Step 2-3: Parse and optionally apply the reviver with source text access.
   HasReviver := (AArgs.Length >= 2) and AArgs.GetElement(1).IsCallable;
@@ -219,7 +221,7 @@ begin
           AArgs.GetElement(0).ToStringLiteral.Value, Result, SourceTexts);
       except
         on E: Exception do
-          ThrowSyntaxError(E.Message);
+          ThrowSyntaxError(E.Message, SSuggestJSONFormat);
       end;
 
       // Step 3: Wrap in root object and apply InternalizeJSONProperty.
@@ -248,7 +250,7 @@ begin
       Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
     except
       on E: Exception do
-        ThrowSyntaxError(E.Message);
+        ThrowSyntaxError(E.Message, SSuggestJSONFormat);
     end;
   end;
 end;
@@ -276,29 +278,29 @@ begin
 
   // Step 2: Throw a SyntaxError if jsonString is the empty string.
   if JSONString = '' then
-    ThrowSyntaxError('JSON.rawJSON: empty string is not valid JSON');
+    ThrowSyntaxError(SErrorJSONRawJSONEmptyString, SSuggestJSONFormat);
 
   // Step 2 (continued): Throw a SyntaxError if the first or last code unit is whitespace.
   FirstChar := JSONString[1];
   LastChar := JSONString[Length(JSONString)];
   if (FirstChar = JSON_WHITESPACE_TAB) or (FirstChar = JSON_WHITESPACE_LF) or
     (FirstChar = JSON_WHITESPACE_CR) or (FirstChar = JSON_WHITESPACE_SPACE) then
-    ThrowSyntaxError('JSON.rawJSON: input must not have leading whitespace');
+    ThrowSyntaxError(SErrorJSONRawJSONLeadingWhitespace, SSuggestJSONFormat);
   if (LastChar = JSON_WHITESPACE_TAB) or (LastChar = JSON_WHITESPACE_LF) or
     (LastChar = JSON_WHITESPACE_CR) or (LastChar = JSON_WHITESPACE_SPACE) then
-    ThrowSyntaxError('JSON.rawJSON: input must not have trailing whitespace');
+    ThrowSyntaxError(SErrorJSONRawJSONTrailingWhitespace, SSuggestJSONFormat);
 
   // Step 3: Parse jsonString as a JSON text. Throw SyntaxError if invalid.
   try
     Parsed := FParser.Parse(UTF8String(JSONString));
   except
     on E: Exception do
-      ThrowSyntaxError('JSON.rawJSON: ' + E.Message);
+      ThrowSyntaxError(Format(SErrorJSONRawJSONInvalid, [E.Message]), SSuggestJSONFormat);
   end;
 
   // Step 3 (continued): Throw SyntaxError if outermost value is object or array.
   if (Parsed is TGocciaObjectValue) then
-    ThrowSyntaxError('JSON.rawJSON: value must be a JSON primitive (not an object or array)');
+    ThrowSyntaxError(SErrorJSONRawJSONMustBePrimitive, SSuggestJSONFormat);
 
   // Steps 4-7: Create frozen object with null prototype, [[IsRawJSON]], and "rawJSON" property.
   Result := TGocciaRawJSONValue.Create(JSONString);
@@ -404,7 +406,7 @@ begin
   if Replaced is TGocciaArrayValue then
   begin
     if FReplacerTraversalStack.IndexOf(TGocciaArrayValue(Replaced)) <> -1 then
-      ThrowTypeError('Converting circular structure to JSON');
+      ThrowTypeError(SErrorJSONCircularStructure, SSuggestJSONFormat);
 
     FReplacerTraversalStack.Add(TGocciaArrayValue(Replaced));
     Arr := TGocciaArrayValue(Replaced);
@@ -425,7 +427,7 @@ begin
   else if (Replaced is TGocciaObjectValue) and not (Replaced is TGocciaArrayValue) then
   begin
     if FReplacerTraversalStack.IndexOf(TGocciaObjectValue(Replaced)) <> -1 then
-      ThrowTypeError('Converting circular structure to JSON');
+      ThrowTypeError(SErrorJSONCircularStructure, SSuggestJSONFormat);
 
     FReplacerTraversalStack.Add(TGocciaObjectValue(Replaced));
     Obj := TGocciaObjectValue(Replaced);
@@ -557,7 +559,7 @@ begin
     on E: TGocciaThrowValue do
       raise;
     on E: Exception do
-      ThrowError('JSON.stringify error: ' + E.Message, 0, 0);
+      ThrowTypeError(Format(SErrorJSONStringifyError, [E.Message]), SSuggestJSONFormat);
   end;
 end;
 

--- a/units/Goccia.Builtins.JSON5.pas
+++ b/units/Goccia.Builtins.JSON5.pas
@@ -68,6 +68,8 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Utils,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
@@ -291,7 +293,7 @@ begin
   if Replaced is TGocciaArrayValue then
   begin
     if FReplacerTraversalStack.IndexOf(TGocciaArrayValue(Replaced)) <> -1 then
-      ThrowTypeError('Converting circular structure to JSON5');
+      ThrowTypeError(SErrorCircularStructureToJSON5, SSuggestJSONFormat);
 
     FReplacerTraversalStack.Add(TGocciaArrayValue(Replaced));
     Arr := TGocciaArrayValue(Replaced);
@@ -313,7 +315,7 @@ begin
     not (Replaced is TGocciaArrayValue) then
   begin
     if FReplacerTraversalStack.IndexOf(TGocciaObjectValue(Replaced)) <> -1 then
-      ThrowTypeError('Converting circular structure to JSON5');
+      ThrowTypeError(SErrorCircularStructureToJSON5, SSuggestJSONFormat);
 
     FReplacerTraversalStack.Add(TGocciaObjectValue(Replaced));
     Obj := TGocciaObjectValue(Replaced);
@@ -489,7 +491,7 @@ begin
   if TransformedValue is TGocciaArrayValue then
   begin
     if FReplacerTraversalStack.IndexOf(TGocciaArrayValue(TransformedValue)) <> -1 then
-      ThrowTypeError('Converting circular structure to JSON5');
+      ThrowTypeError(SErrorCircularStructureToJSON5, SSuggestJSONFormat);
 
     FReplacerTraversalStack.Add(TGocciaArrayValue(TransformedValue));
     Arr := TGocciaArrayValue(TransformedValue);
@@ -512,7 +514,7 @@ begin
     not (TransformedValue is TGocciaArrayValue) then
   begin
     if FReplacerTraversalStack.IndexOf(TGocciaObjectValue(TransformedValue)) <> -1 then
-      ThrowTypeError('Converting circular structure to JSON5');
+      ThrowTypeError(SErrorCircularStructureToJSON5, SSuggestJSONFormat);
 
     FReplacerTraversalStack.Add(TGocciaObjectValue(TransformedValue));
     Obj := TGocciaObjectValue(TransformedValue);
@@ -552,7 +554,7 @@ begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON5.parse', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowError('JSON5.parse: argument must be a string', 0, 0);
+    ThrowTypeError(SErrorJSON5ParseArgMustBeString, SSuggestStringArgRequired);
 
   HasReviver := (AArgs.Length >= 2) and AArgs.GetElement(1).IsCallable;
 
@@ -566,7 +568,7 @@ begin
           AArgs.GetElement(0).ToStringLiteral.Value, Result, SourceTexts);
       except
         on E: Exception do
-          ThrowSyntaxError(E.Message);
+          ThrowSyntaxError(E.Message, SSuggestJSONFormat);
       end;
 
       Root := TGocciaObjectValue.Create;
@@ -593,7 +595,7 @@ begin
       Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
     except
       on E: Exception do
-        ThrowSyntaxError(E.Message);
+        ThrowSyntaxError(E.Message, SSuggestJSONFormat);
     end;
   end;
 end;
@@ -678,7 +680,7 @@ begin
     on E: TGocciaThrowValue do
       raise;
     on E: Exception do
-      ThrowError('JSON5.stringify error: ' + E.Message, 0, 0);
+      ThrowTypeError(Format(SErrorJSON5StringifyError, [E.Message]), SSuggestJSONFormat);
   end;
 end;
 

--- a/units/Goccia.Builtins.JSONL.pas
+++ b/units/Goccia.Builtins.JSONL.pas
@@ -44,6 +44,7 @@ implementation
 uses
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
@@ -145,7 +146,7 @@ begin
       Result := FParser.Parse(Bytes);
     end
     else
-      ThrowTypeError('JSONL.parse: argument must be a string or Uint8Array');
+      ThrowTypeError(SErrorJSONLParseArgType);
   except
     on E: EGocciaJSONLInvalidInputError do
       ThrowTypeError(E.Message);
@@ -242,7 +243,7 @@ begin
       Exit;
     end;
 
-    ThrowTypeError('JSONL.parseChunk: argument must be a string or Uint8Array');
+    ThrowTypeError(SErrorJSONLParseChunkArgType);
   except
     on E: EGocciaJSONLInvalidInputError do
       ThrowTypeError(E.Message);

--- a/units/Goccia.Builtins.Math.pas
+++ b/units/Goccia.Builtins.Math.pas
@@ -67,6 +67,8 @@ uses
   Goccia.Arguments.Converter,
   Goccia.Arguments.Validator,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Float16,
   Goccia.GarbageCollector,
   Goccia.Values.ArrayValue,
@@ -382,7 +384,7 @@ begin
   // Step 5: If lower > upper, throw a RangeError.
   if MinVal.IsGreaterThan(MaxVal).Value then
   begin
-    ThrowError('RangeError: Invalid range in Math.clamp', 0, 0);
+    ThrowRangeError(SErrorMathClampInvalidRange, SSuggestNumberRange);
     Exit;
   end;
 
@@ -1019,7 +1021,7 @@ function TGocciaMath.MathSumPrecise(const AArgs: TGocciaArgumentsCollection; con
     T: Double;
   begin
     if not (AElement is TGocciaNumberLiteralValue) then
-      Goccia.Values.ErrorHelper.ThrowTypeError('Math.sumPrecise: element is not a number');
+      Goccia.Values.ErrorHelper.ThrowTypeError(SErrorMathSumPreciseNotNumber, SSuggestNumberRange);
     NumVal := TGocciaNumberLiteralValue(AElement);
     AHasAnyValue := True;
     if NumVal.IsNaN then
@@ -1102,7 +1104,7 @@ begin
     end;
 
     if not Assigned(Iterator) then
-      Goccia.Values.ErrorHelper.ThrowTypeError('Math.sumPrecise: argument is not iterable');
+      Goccia.Values.ErrorHelper.ThrowTypeError(SErrorMathSumPreciseNotIterable, SSuggestNotIterable);
 
     TGarbageCollector.Instance.AddTempRoot(Iterator);
     try

--- a/units/Goccia.Builtins.Performance.pas
+++ b/units/Goccia.Builtins.Performance.pas
@@ -55,6 +55,8 @@ uses
 
   TimingUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
@@ -67,7 +69,7 @@ threadvar
 function RequirePerformanceThis(const AThisValue: TGocciaValue): TGocciaPerformanceValue;
 begin
   if not (AThisValue is TGocciaPerformanceValue) then
-    ThrowTypeError('Method Performance called on incompatible receiver');
+    ThrowTypeError(SErrorPerformanceIncompatibleReceiver, SSuggestPerformanceThisType);
   Result := TGocciaPerformanceValue(AThisValue);
 end;
 
@@ -99,7 +101,7 @@ end;
 function TGocciaPerformancePrototypeHost.PerformanceConstructorCall(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Illegal constructor');
+  ThrowTypeError(SErrorIllegalConstructor, SSuggestIllegalConstructor);
 end;
 
 // High Resolution Time Level 3 §7.1 Performance.now()

--- a/units/Goccia.Builtins.Semver.pas
+++ b/units/Goccia.Builtins.Semver.pas
@@ -21,6 +21,8 @@ uses
   Goccia.Arguments.Collection,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.ObjectModel,
   Goccia.Semver,
   Goccia.Values.ArrayValue,
@@ -326,7 +328,7 @@ var
   I: Integer;
 begin
   if not (AValue is TGocciaArrayValue) then
-    ThrowTypeError('Expected an array of versions');
+    ThrowTypeError(SErrorExpectedArrayOfVersions, SSuggestSemverUsage);
   ArrayValue := TGocciaArrayValue(AValue);
   SetLength(Result, ArrayValue.Elements.Count);
   for I := 0 to ArrayValue.Elements.Count - 1 do
@@ -455,9 +457,9 @@ function TGocciaSemverNamespaceHost.HandleSemverException(
   const E: Exception): TGocciaValue;
 begin
   if E is EGocciaSemverTypeError then
-    ThrowTypeError(E.Message)
+    ThrowTypeError(E.Message, SSuggestSemverUsage)
   else if E is EGocciaSemverError then
-    ThrowError(E.Message)
+    ThrowError(E.Message, SSuggestSemverUsage)
   else
     raise E;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -468,7 +470,7 @@ function TGocciaSemverNamespaceHost.RequireStringArgument(
   const AMethodName: string): string;
 begin
   if AArgs.Length <= AIndex then
-    ThrowTypeError(AMethodName + ' requires a string argument');
+    ThrowTypeError(AMethodName + ' requires a string argument', SSuggestStringArgRequired);
   Result := AArgs.GetElement(AIndex).ToStringLiteral.Value;
 end;
 
@@ -688,7 +690,7 @@ begin
       Identifier := '';
     if not TryIncrement(ThisSemver.Version, AArgs.GetElement(0).ToStringLiteral.Value,
       ThisSemver.Options, Identifier, False, False, Updated) then
-      ThrowError('invalid increment');
+      ThrowError(SErrorSemverInvalidIncrement, SSuggestSemverUsage);
     UpdatedSemver := MustParseSemver(Updated, ThisSemver.Options);
     WriteSemverProperties(TGocciaObjectValue(AThisValue), UpdatedSemver);
     Result := AThisValue;

--- a/units/Goccia.Builtins.TOML.pas
+++ b/units/Goccia.Builtins.TOML.pas
@@ -32,6 +32,8 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
@@ -76,13 +78,13 @@ function TGocciaTOMLBuiltin.TOMLParse(
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'TOML.parse', ThrowError);
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowError('TOML.parse: argument must be a string', 0, 0);
+    ThrowTypeError(SErrorTOMLParseArgMustBeString, SSuggestStringArgRequired);
 
   try
     Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
   except
     on E: EGocciaTOMLParseError do
-      ThrowSyntaxError(E.Message);
+      ThrowSyntaxError(E.Message, SSuggestTOMLSyntax);
   end;
 end;
 

--- a/units/Goccia.Builtins.Temporal.pas
+++ b/units/Goccia.Builtins.Temporal.pas
@@ -90,6 +90,8 @@ uses
   TimingUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
@@ -222,7 +224,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowRangeError('Invalid ISO duration string');
+      ThrowRangeError(SErrorInvalidISODuration, SSuggestTemporalDurationArg);
     Result := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -239,7 +241,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('Temporal.Duration.from requires a string, Duration, or object');
+    ThrowTypeError(SErrorTemporalDurationFromArg, SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -259,7 +261,7 @@ var
     else if AArg is TGocciaStringLiteralValue then
     begin
       if not TryParseISODuration(TGocciaStringLiteralValue(AArg).Value, DurRec) then
-        ThrowRangeError('Invalid ISO duration string');
+        ThrowRangeError(SErrorInvalidISODuration, SSuggestTemporalDurationArg);
       Result := TGocciaTemporalDurationValue.Create(
         DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
         DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -267,7 +269,7 @@ var
     end
     else
     begin
-      ThrowTypeError('Temporal.Duration.compare requires Duration arguments');
+      ThrowTypeError(SErrorTemporalDurationCompareArg, SSuggestTemporalCompareArg);
       Result := nil;
     end;
   end;
@@ -318,7 +320,7 @@ var
   SubMs: Integer;
 begin
   if AArgs.Length < 1 then
-    ThrowTypeError('Temporal.Instant requires epochNanoseconds argument');
+    ThrowTypeError(SErrorTemporalInstantRequiresEpoch, SSuggestTemporalFromArg);
 
   EpochNs := AArgs.GetElement(0).ToNumberLiteral.Value;
   Ms := Trunc(EpochNs / 1000000);
@@ -348,7 +350,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODateTime(TGocciaStringLiteralValue(Arg).Value, DateRec, TimeRec) then
-      ThrowTypeError('Invalid ISO instant string');
+      ThrowTypeError(SErrorInvalidISOInstant, SSuggestTemporalISOFormat);
     EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * Int64(86400000) +
                Int64(TimeRec.Hour) * 3600000 + Int64(TimeRec.Minute) * 60000 +
                Int64(TimeRec.Second) * 1000 + TimeRec.Millisecond;
@@ -357,7 +359,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('Temporal.Instant.from requires a string or Instant');
+    ThrowTypeError(SErrorTemporalInstantFromArg, SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -365,7 +367,7 @@ end;
 function TGocciaTemporalBuiltin.InstantFromEpochMilliseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if AArgs.Length < 1 then
-    ThrowTypeError('Temporal.Instant.fromEpochMilliseconds requires an argument');
+    ThrowTypeError(SErrorTemporalInstantFromEpochMillis, SSuggestTemporalFromArg);
   Result := TGocciaTemporalInstantValue.Create(
     Trunc(AArgs.GetElement(0).ToNumberLiteral.Value), 0);
 end;
@@ -377,7 +379,7 @@ var
   SubMs: Integer;
 begin
   if AArgs.Length < 1 then
-    ThrowTypeError('Temporal.Instant.fromEpochNanoseconds requires an argument');
+    ThrowTypeError(SErrorTemporalInstantFromEpochNanos, SSuggestTemporalFromArg);
   EpochNs := AArgs.GetElement(0).ToNumberLiteral.Value;
   Ms := Trunc(EpochNs / 1000000);
   // Safe Int64 → Double conversion (FPC 3.2.2 AArch64 bug: Int64 * Double gives wrong results)
@@ -402,7 +404,7 @@ var
     else if AArg is TGocciaStringLiteralValue then
     begin
       if not TryParseISODateTime(TGocciaStringLiteralValue(AArg).Value, DateRec, TimeRec) then
-        ThrowTypeError('Invalid ISO instant string');
+        ThrowTypeError(SErrorInvalidISOInstant, SSuggestTemporalISOFormat);
       EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * Int64(86400000) +
                  Int64(TimeRec.Hour) * 3600000 + Int64(TimeRec.Minute) * 60000 +
                  Int64(TimeRec.Second) * 1000 + TimeRec.Millisecond;
@@ -411,7 +413,7 @@ var
     end
     else
     begin
-      ThrowTypeError('Temporal.Instant.compare requires Instant arguments');
+      ThrowTypeError(SErrorTemporalInstantCompareArg, SSuggestTemporalCompareArg);
       Result := nil;
     end;
   end;
@@ -450,7 +452,7 @@ end;
 function TGocciaTemporalBuiltin.PlainDateConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if AArgs.Length < 3 then
-    ThrowTypeError('Temporal.PlainDate requires year, month, day arguments');
+    ThrowTypeError(SErrorTemporalPlainDateArgs, SSuggestTemporalDateRange);
 
   Result := TGocciaTemporalPlainDateValue.Create(
     Trunc(AArgs.GetElement(0).ToNumberLiteral.Value),
@@ -491,23 +493,23 @@ begin
     else if TryParseISODateTime(TGocciaStringLiteralValue(Arg).Value, DateRec, TimeRec) then
       Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day)
     else
-      ThrowTypeError('Invalid ISO date string');
+      ThrowTypeError(SErrorInvalidISODate, SSuggestTemporalISOFormat);
   end
   else if Arg is TGocciaObjectValue then
   begin
     Obj := TGocciaObjectValue(Arg);
     V := Obj.GetProperty(PROP_YEAR);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError('Temporal.PlainDate.from requires year, month, day properties');
+      ThrowTypeError(SErrorTemporalPlainDateFromProps, SSuggestTemporalFromArg);
     Y := Trunc(V.ToNumberLiteral.Value);
     V := Obj.GetProperty(PROP_MONTH);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError('Temporal.PlainDate.from requires year, month, day properties');
+      ThrowTypeError(SErrorTemporalPlainDateFromProps, SSuggestTemporalFromArg);
     Mo := Trunc(V.ToNumberLiteral.Value);
     if (Mo < 1) or (Mo > 12) then
     begin
       if Overflow = toReject then
-        ThrowRangeError('Month ' + IntToStr(Mo) + ' out of range');
+        ThrowRangeError(Format(SErrorTemporalMonthOutOfRange, [Mo]), SSuggestTemporalDateRange);
       if Mo < 1 then
         Mo := 1
       else
@@ -515,12 +517,12 @@ begin
     end;
     V := Obj.GetProperty(PROP_DAY);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError('Temporal.PlainDate.from requires year, month, day properties');
+      ThrowTypeError(SErrorTemporalPlainDateFromProps, SSuggestTemporalFromArg);
     Dy := Trunc(V.ToNumberLiteral.Value);
     if Dy < 1 then
     begin
       if Overflow = toReject then
-        ThrowRangeError('Day ' + IntToStr(Dy) + ' out of range');
+        ThrowRangeError(Format(SErrorTemporalDayOutOfRange, [Dy]), SSuggestTemporalDateRange);
       Dy := 1;
     end;
 
@@ -528,7 +530,7 @@ begin
     if Dy > MaxDay then
     begin
       if Overflow = toReject then
-        ThrowRangeError('Day ' + IntToStr(Dy) + ' out of range for month ' + IntToStr(Mo));
+        ThrowRangeError(Format(SErrorTemporalDayOutOfRangeForMonth, [Dy, Mo]), SSuggestTemporalDateRange);
       Dy := MaxDay;
     end;
 
@@ -536,7 +538,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('Temporal.PlainDate.from requires a string, PlainDate, or object');
+    ThrowTypeError(SErrorTemporalPlainDateFromArg, SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -560,13 +562,13 @@ var
         Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day)
       else
       begin
-        ThrowTypeError('Invalid ISO date string');
+        ThrowTypeError(SErrorInvalidISODate, SSuggestTemporalISOFormat);
         Result := nil;
       end;
     end
     else
     begin
-      ThrowTypeError('Temporal.PlainDate.compare requires PlainDate arguments');
+      ThrowTypeError(SErrorTemporalPlainDateCompareArg, SSuggestTemporalCompareArg);
       Result := nil;
     end;
   end;
@@ -638,7 +640,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
-      ThrowTypeError('Invalid ISO time string');
+      ThrowTypeError(SErrorInvalidISOTime, SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainTimeValue.Create(
       TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
       TimeRec.Millisecond, TimeRec.Microsecond, TimeRec.Nanosecond);
@@ -663,7 +665,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('Temporal.PlainTime.from requires a string, PlainTime, or object');
+    ThrowTypeError(SErrorTemporalPlainTimeFromArg, SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -682,7 +684,7 @@ var
     begin
       if not TryParseISOTime(TGocciaStringLiteralValue(AArg).Value, TimeRec) then
       begin
-        ThrowTypeError('Invalid ISO time string');
+        ThrowTypeError(SErrorInvalidISOTime, SSuggestTemporalISOFormat);
         Result := nil;
       end
       else
@@ -692,7 +694,7 @@ var
     end
     else
     begin
-      ThrowTypeError('Temporal.PlainTime.compare requires PlainTime arguments');
+      ThrowTypeError(SErrorTemporalPlainTimeCompareArg, SSuggestTemporalCompareArg);
       Result := nil;
     end;
   end;
@@ -741,7 +743,7 @@ function TGocciaTemporalBuiltin.PlainDateTimeConstructorFn(const AArgs: TGocciaA
 
 begin
   if AArgs.Length < 3 then
-    ThrowTypeError('Temporal.PlainDateTime requires at least year, month, day arguments');
+    ThrowTypeError(SErrorTemporalPlainDateTimeArgs, SSuggestTemporalDateRange);
 
   Result := TGocciaTemporalPlainDateTimeValue.Create(
     GetArgOr(0, 0), GetArgOr(1, 0), GetArgOr(2, 0),
@@ -770,7 +772,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODateTime(TGocciaStringLiteralValue(Arg).Value, DateRec, TimeRec) then
-      ThrowTypeError('Invalid ISO date-time string');
+      ThrowTypeError(SErrorInvalidISODateTime, SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainDateTimeValue.Create(
       DateRec.Year, DateRec.Month, DateRec.Day,
       TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
@@ -793,7 +795,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('Temporal.PlainDateTime.from requires a string, PlainDateTime, or object');
+    ThrowTypeError(SErrorTemporalPlainDateTimeFromArg, SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -814,7 +816,7 @@ var
     begin
       if not TryParseISODateTime(TGocciaStringLiteralValue(AArg).Value, DateRec, TimeRec) then
       begin
-        ThrowTypeError('Invalid ISO date-time string');
+        ThrowTypeError(SErrorInvalidISODateTime, SSuggestTemporalISOFormat);
         Result := nil;
       end
       else
@@ -825,7 +827,7 @@ var
     end
     else
     begin
-      ThrowTypeError('Temporal.PlainDateTime.compare requires PlainDateTime arguments');
+      ThrowTypeError(SErrorTemporalPlainDateTimeCompareArg, SSuggestTemporalCompareArg);
       Result := nil;
     end;
   end;
@@ -863,7 +865,7 @@ var
   RefDay: Integer;
 begin
   if AArgs.Length < 2 then
-    ThrowTypeError('Temporal.PlainYearMonth requires year, month arguments');
+    ThrowTypeError(SErrorTemporalPlainYearMonthArgs, SSuggestTemporalDateRange);
 
   RefDay := 1;
   if (AArgs.Length >= 3) and not (AArgs.GetElement(2) is TGocciaUndefinedLiteralValue) then
@@ -894,7 +896,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISOYearMonth(TGocciaStringLiteralValue(Arg).Value, Y, M) then
-      ThrowRangeError('Invalid ISO year-month string');
+      ThrowRangeError(SErrorInvalidISOYearMonth, SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainYearMonthValue.Create(Y, M);
   end
   else if Arg is TGocciaObjectValue then
@@ -902,7 +904,7 @@ begin
     Obj := TGocciaObjectValue(Arg);
     V := Obj.GetProperty(PROP_YEAR);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError('Temporal.PlainYearMonth.from requires year property');
+      ThrowTypeError(SErrorTemporalPlainYearMonthFromYear, SSuggestTemporalFromArg);
     Y := Trunc(V.ToNumberLiteral.Value);
     // Support both monthCode and month, consistent with PlainMonthDay.from
     VMonthCode := Obj.GetProperty(PROP_MONTH_CODE);
@@ -911,30 +913,30 @@ begin
       MonthCodeStr := VMonthCode.ToStringLiteral.Value;
       if (Length(MonthCodeStr) <> 3) or (MonthCodeStr[1] <> 'M') or
          not (MonthCodeStr[2] in ['0'..'9']) or not (MonthCodeStr[3] in ['0'..'9']) then
-        ThrowTypeError('Invalid monthCode for Temporal.PlainYearMonth.from');
+        ThrowTypeError(SErrorInvalidMonthCodeYearMonth, SSuggestTemporalMonthCode);
       if not TryStrToInt(Copy(MonthCodeStr, 2, 2), MonthPart) then
-        ThrowTypeError('Invalid monthCode for Temporal.PlainYearMonth.from');
+        ThrowTypeError(SErrorInvalidMonthCodeYearMonth, SSuggestTemporalMonthCode);
       if (MonthPart < 1) or (MonthPart > 12) then
-        ThrowRangeError('monthCode month out of range in Temporal.PlainYearMonth.from');
+        ThrowRangeError(SErrorMonthCodeOutOfRange, SSuggestTemporalMonthCode);
       // Check consistency if both month and monthCode are provided
       V := Obj.GetProperty(PROP_MONTH);
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
         if Trunc(V.ToNumberLiteral.Value) <> MonthPart then
-          ThrowRangeError('month and monthCode must match in Temporal.PlainYearMonth.from');
+          ThrowRangeError(SErrorMonthCodeMismatch, SSuggestTemporalMonthCode);
       M := MonthPart;
     end
     else
     begin
       V := Obj.GetProperty(PROP_MONTH);
       if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-        ThrowTypeError('Temporal.PlainYearMonth.from requires monthCode or month property');
+        ThrowTypeError(SErrorTemporalPlainYearMonthFromMonth, SSuggestTemporalFromArg);
       M := Trunc(V.ToNumberLiteral.Value);
     end;
     Result := TGocciaTemporalPlainYearMonthValue.Create(Y, M);
   end
   else
   begin
-    ThrowTypeError('Temporal.PlainYearMonth.from requires a string, PlainYearMonth, or object');
+    ThrowTypeError(SErrorTemporalPlainYearMonthFromArg, SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -954,7 +956,7 @@ var
     begin
       if not TryParseISOYearMonth(TGocciaStringLiteralValue(AArg).Value, Y, M) then
       begin
-        ThrowRangeError('Invalid ISO year-month string');
+        ThrowRangeError(SErrorInvalidISOYearMonth, SSuggestTemporalISOFormat);
         Result := nil;
       end
       else
@@ -962,7 +964,7 @@ var
     end
     else
     begin
-      ThrowTypeError('Temporal.PlainYearMonth.compare requires PlainYearMonth arguments');
+      ThrowTypeError(SErrorTemporalPlainYearMonthCompareArg, SSuggestTemporalCompareArg);
       Result := nil;
     end;
   end;
@@ -1002,7 +1004,7 @@ function TGocciaTemporalBuiltin.PlainMonthDayConstructorFn(const AArgs: TGocciaA
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if AArgs.Length < 2 then
-    ThrowTypeError('Temporal.PlainMonthDay requires month, day arguments');
+    ThrowTypeError(SErrorTemporalPlainMonthDayArgs, SSuggestTemporalDateRange);
 
   Result := TGocciaTemporalPlainMonthDayValue.Create(
     Trunc(AArgs.GetElement(0).ToNumberLiteral.Value),
@@ -1028,7 +1030,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISOMonthDay(TGocciaStringLiteralValue(Arg).Value, M, D) then
-      ThrowRangeError('Invalid ISO month-day string');
+      ThrowRangeError(SErrorInvalidISOMonthDay, SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainMonthDayValue.Create(M, D);
   end
   else if Arg is TGocciaObjectValue then
@@ -1036,7 +1038,7 @@ begin
     Obj := TGocciaObjectValue(Arg);
     V := Obj.GetProperty(PROP_DAY);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError('Temporal.PlainMonthDay.from requires day property');
+      ThrowTypeError(SErrorTemporalPlainMonthDayFromDay, SSuggestTemporalFromArg);
     D := Trunc(V.ToNumberLiteral.Value);
     // Support both monthCode (e.g., "M07") and month (numeric)
     V := Obj.GetProperty(PROP_MONTH_CODE);
@@ -1046,9 +1048,9 @@ begin
       MonthCodeStr := V.ToStringLiteral.Value;
       if (Length(MonthCodeStr) <> 3) or (MonthCodeStr[1] <> 'M') or
          not (MonthCodeStr[2] in ['0'..'9']) or not (MonthCodeStr[3] in ['0'..'9']) then
-        ThrowTypeError('Invalid monthCode for Temporal.PlainMonthDay.from');
+        ThrowTypeError(SErrorInvalidMonthCodeMonthDay, SSuggestTemporalMonthCode);
       if not TryStrToInt(Copy(MonthCodeStr, 2, 2), M) then
-        ThrowTypeError('Invalid monthCode for Temporal.PlainMonthDay.from');
+        ThrowTypeError(SErrorInvalidMonthCodeMonthDay, SSuggestTemporalMonthCode);
     end
     else
     begin
@@ -1059,12 +1061,12 @@ begin
         M := 0;
     end;
     if (M < 1) or (M > 12) then
-      ThrowTypeError('Temporal.PlainMonthDay.from requires a valid month property');
+      ThrowTypeError(SErrorTemporalPlainMonthDayFromMonth, SSuggestTemporalDateRange);
     Result := TGocciaTemporalPlainMonthDayValue.Create(M, D);
   end
   else
   begin
-    ThrowTypeError('Temporal.PlainMonthDay.from requires a string, PlainMonthDay, or object');
+    ThrowTypeError(SErrorTemporalPlainMonthDayFromArg, SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -1084,7 +1086,7 @@ var
     begin
       if not TryParseISOMonthDay(TGocciaStringLiteralValue(AArg).Value, M, D) then
       begin
-        ThrowRangeError('Invalid ISO month-day string');
+        ThrowRangeError(SErrorInvalidISOMonthDay, SSuggestTemporalISOFormat);
         Result := nil;
       end
       else
@@ -1092,7 +1094,7 @@ var
     end
     else
     begin
-      ThrowTypeError('Temporal.PlainMonthDay.compare requires PlainMonthDay arguments');
+      ThrowTypeError(SErrorTemporalPlainMonthDayCompareArg, SSuggestTemporalCompareArg);
       Result := nil;
     end;
   end;
@@ -1138,7 +1140,7 @@ var
   TZ: string;
 begin
   if AArgs.Length < 2 then
-    ThrowTypeError('Temporal.ZonedDateTime requires epochNanoseconds and timeZone arguments');
+    ThrowTypeError(SErrorTemporalZonedDateTimeArgs, SSuggestTemporalTimezone);
 
   EpochNs := AArgs.GetElement(0).ToNumberLiteral.Value;
   Ms := Trunc(EpochNs / 1000000);
@@ -1173,7 +1175,7 @@ begin
   begin
     if not TryParseISODateTimeWithOffset(TGocciaStringLiteralValue(Arg).Value,
         DateRec, TimeRec, OffsetSeconds, TZ) then
-      ThrowRangeError('Invalid ISO zoned date-time string');
+      ThrowRangeError(SErrorInvalidISOZonedDateTime, SSuggestTemporalISOFormat);
 
     // Compute UTC epoch from wall-clock time
     EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * Int64(86400000) +
@@ -1185,13 +1187,13 @@ begin
     EpochMs := EpochMs - Int64(OffsetSeconds) * 1000;
 
     if TZ = '' then
-      ThrowRangeError('Temporal.ZonedDateTime.from requires a timezone annotation (e.g., [UTC])');
+      ThrowRangeError(SErrorTemporalZonedDateTimeRequiresTZ, SSuggestTemporalTimezone);
 
     Result := TGocciaTemporalZonedDateTimeValue.Create(EpochMs, SubMs, TZ);
   end
   else
   begin
-    ThrowTypeError('Temporal.ZonedDateTime.from requires a string or ZonedDateTime');
+    ThrowTypeError(SErrorTemporalZonedDateTimeFromArg, SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -1216,7 +1218,7 @@ var
     begin
       if not TryParseISODateTimeWithOffset(TGocciaStringLiteralValue(AArg).Value,
           CoerceDateRec, CoerceTimeRec, CoerceOffsetSeconds, CoerceTZ) then
-        ThrowRangeError('Invalid ISO zoned date-time string');
+        ThrowRangeError(SErrorInvalidISOZonedDateTime, SSuggestTemporalISOFormat);
 
       CoerceEpochMs := DateToEpochDays(CoerceDateRec.Year, CoerceDateRec.Month, CoerceDateRec.Day) * Int64(86400000) +
                        Int64(CoerceTimeRec.Hour) * 3600000 + Int64(CoerceTimeRec.Minute) * 60000 +
@@ -1225,13 +1227,13 @@ var
       CoerceEpochMs := CoerceEpochMs - Int64(CoerceOffsetSeconds) * 1000;
 
       if CoerceTZ = '' then
-        ThrowRangeError('Temporal.ZonedDateTime.compare requires a timezone annotation (e.g., [UTC])');
+        ThrowRangeError(SErrorTemporalZonedDateTimeCompareTZ, SSuggestTemporalTimezone);
 
       Result := TGocciaTemporalZonedDateTimeValue.Create(CoerceEpochMs, CoerceSubMs, CoerceTZ);
     end
     else
     begin
-      ThrowTypeError('Temporal.ZonedDateTime.compare requires ZonedDateTime or string arguments');
+      ThrowTypeError(SErrorTemporalZonedDateTimeCompareArg, SSuggestTemporalCompareArg);
       Result := nil;
     end;
   end;

--- a/units/Goccia.Builtins.TestAssertions.pas
+++ b/units/Goccia.Builtins.TestAssertions.pas
@@ -277,6 +277,8 @@ uses
 
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator,
   Goccia.Evaluator.Comparison,
   Goccia.GarbageCollector,
@@ -285,6 +287,7 @@ uses
   Goccia.Values.ClassHelper,
   Goccia.Values.ClassValue,
   Goccia.Values.Error,
+  Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.PromiseValue,
   Goccia.Values.SetValue;
@@ -535,16 +538,16 @@ begin
     FTestAssertions.ThrowError);
 
   if not (AArguments.GetElement(0) is TGocciaStringLiteralValue) then
-    FTestAssertions.ThrowError(GetFunctionName +
-      ' expects first argument to be a string', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsStringFirst,
+      [GetFunctionName]), SSuggestTestUsage);
 
   if not (AArguments.GetElement(1) is TGocciaFunctionBase) then
-    FTestAssertions.ThrowError(GetFunctionName +
-      ' expects second argument to be a function', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsFunctionSecond,
+      [GetFunctionName]), SSuggestTestUsage);
 
   if not (FTable is TGocciaArrayValue) then
-    FTestAssertions.ThrowError(GetFunctionName +
-      '.each expects a table array', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsTableArray,
+      [GetFunctionName]), SSuggestTestUsage);
 
   BaseName := AArguments.GetElement(0).ToStringLiteral.Value;
   Callback := TGocciaFunctionBase(AArguments.GetElement(1));
@@ -1490,7 +1493,7 @@ begin
       Exit;
     end;
 
-    FTestAssertions.ThrowError('toThrow expects actual value to be a function', 0, 0);
+    ThrowTypeError(SErrorToThrowExpectsFunction, SSuggestTestUsage);
     Exit;
   end;
 
@@ -1750,8 +1753,8 @@ begin
   NumVal := AArgs.GetElement(0).ToNumberLiteral;
   if NumVal.IsNaN or NumVal.IsInfinity or NumVal.IsNegativeInfinity or
      (NumVal.Value < 0) or (NumVal.Value > High(Integer)) or (Frac(NumVal.Value) <> 0) then
-    TGocciaTestAssertions(FTestAssertions).ThrowError(
-      'toHaveBeenCalledTimes expects a non-negative integer', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(
+      SErrorToHaveBeenCalledTimesExpectsInt, SSuggestTestUsage);
   ExpectedTimes := Trunc(NumVal.Value);
   Matches := MockFn.MockCalls.Count = ExpectedTimes;
 
@@ -1906,8 +1909,8 @@ begin
 
   if AArgs.Length < 1 then
   begin
-    TGocciaTestAssertions(FTestAssertions).ThrowError(
-      'toHaveBeenNthCalledWith requires at least 1 argument (call index)', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(
+      SErrorToHaveBeenNthCalledWithRequiresArg, SSuggestTestUsage);
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
   end;
 
@@ -1915,8 +1918,8 @@ begin
   NumVal := AArgs.GetElement(0).ToNumberLiteral;
   if NumVal.IsNaN or NumVal.IsInfinity or NumVal.IsNegativeInfinity or
      (NumVal.Value < 1) or (NumVal.Value > High(Integer)) or (Frac(NumVal.Value) <> 0) then
-    TGocciaTestAssertions(FTestAssertions).ThrowError(
-      'toHaveBeenNthCalledWith expects a positive integer index', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(
+      SErrorToHaveBeenNthCalledWithExpectsInt, SSuggestTestUsage);
   N := Trunc(NumVal.Value);
 
   if (N < 1) or (N > MockFn.MockCalls.Count) then
@@ -2032,8 +2035,8 @@ begin
   NumVal := AArgs.GetElement(0).ToNumberLiteral;
   if NumVal.IsNaN or NumVal.IsInfinity or NumVal.IsNegativeInfinity or
      (NumVal.Value < 0) or (NumVal.Value > High(Integer)) or (Frac(NumVal.Value) <> 0) then
-    TGocciaTestAssertions(FTestAssertions).ThrowError(
-      'toHaveReturnedTimes expects a non-negative integer', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(
+      SErrorToHaveReturnedTimesExpectsInt, SSuggestTestUsage);
   ExpectedTimes := Trunc(NumVal.Value);
   ActualCount := 0;
 
@@ -2203,8 +2206,8 @@ begin
   NumVal := AArgs.GetElement(0).ToNumberLiteral;
   if NumVal.IsNaN or NumVal.IsInfinity or NumVal.IsNegativeInfinity or
      (NumVal.Value < 1) or (NumVal.Value > High(Integer)) or (Frac(NumVal.Value) <> 0) then
-    TGocciaTestAssertions(FTestAssertions).ThrowError(
-      'toHaveNthReturnedWith expects a positive integer index', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(
+      SErrorToHaveNthReturnedWithExpectsInt, SSuggestTestUsage);
   N := Trunc(NumVal.Value);
   Expected := AArgs.GetElement(1);
 
@@ -2462,11 +2465,10 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 2, AFunctionName, ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowError(AFunctionName + ' expects first argument to be a string', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsStringFirst, [AFunctionName]), SSuggestTestUsage);
 
   if not (AArgs.GetElement(1) is TGocciaFunctionBase) then
-    ThrowError(AFunctionName + ' expects second argument to be a function', 0,
-      0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsFunctionSecond, [AFunctionName]), SSuggestTestUsage);
 
   ASuiteName := AArgs.GetElement(0).ToStringLiteral.Value;
   ASuiteFunction := TGocciaFunctionBase(AArgs.GetElement(1));
@@ -2480,11 +2482,10 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 2, AFunctionName, ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowError(AFunctionName + ' expects first argument to be a string', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsStringFirst, [AFunctionName]), SSuggestTestUsage);
 
   if not (AArgs.GetElement(1) is TGocciaFunctionBase) then
-    ThrowError(AFunctionName + ' expects second argument to be a function', 0,
-      0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsFunctionSecond, [AFunctionName]), SSuggestTestUsage);
 
   ATestName := AArgs.GetElement(0).ToStringLiteral.Value;
   ATestFunction := TGocciaFunctionBase(AArgs.GetElement(1));
@@ -2498,7 +2499,7 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, AHookName, ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaFunctionBase) then
-    ThrowError(AHookName + ' expects a function argument', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsFunctionArg, [AHookName]), SSuggestTestUsage);
 
   GetCurrentRegistrationSuite.AddHook(TGocciaFunctionBase(AArgs.GetElement(0)),
     APhase);
@@ -3150,7 +3151,7 @@ begin
   begin
     if not (AArgs.GetElement(0) is TGocciaFunctionBase) then
     begin
-      ThrowError('mock() expects a function argument or no arguments', 0, 0);
+      Goccia.Values.ErrorHelper.ThrowTypeError(SErrorMockExpectsFunctionOrNoArgs, SSuggestTestUsage);
       Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
     end;
     Impl := AArgs.GetElement(0);
@@ -3171,13 +3172,13 @@ begin
 
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
   begin
-    ThrowError('spyOn expects first argument to be an object', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorSpyOnExpectsObject, SSuggestTestUsage);
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
   end;
 
   if not (AArgs.GetElement(1) is TGocciaStringLiteralValue) then
   begin
-    ThrowError('spyOn expects second argument to be a string (method name)', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorSpyOnExpectsString, SSuggestTestUsage);
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
   end;
 
@@ -3186,14 +3187,14 @@ begin
 
   if not Target.HasProperty(MethodName) then
   begin
-    ThrowError('spyOn: cannot spy on non-existent property "' + MethodName + '"', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorSpyOnNonExistentProperty, [MethodName]), SSuggestTestUsage);
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
   end;
 
   ExistingValue := Target.GetProperty(MethodName);
   if not Assigned(ExistingValue) or not (ExistingValue is TGocciaFunctionBase) then
   begin
-    ThrowError('spyOn: property "' + MethodName + '" is not a function', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorSpyOnPropertyNotFunction, [MethodName]), SSuggestTestUsage);
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
   end;
 
@@ -3255,7 +3256,7 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'describe.each', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaArrayValue) then
-    ThrowError('describe.each expects a table array', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsTableArray, ['describe.each']), SSuggestTestUsage);
 
   Result := TGocciaParameterizedRegistrationFunction.Create(Self,
     AArgs.GetElement(0), prtDescribe);
@@ -3336,7 +3337,7 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'test.each', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaArrayValue) then
-    ThrowError('test.each expects a table array', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(Format(SErrorFunctionExpectsTableArray, ['test.each']), SSuggestTestUsage);
 
   Result := TGocciaParameterizedRegistrationFunction.Create(Self,
     AArgs.GetElement(0), prtTest);
@@ -3347,7 +3348,7 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'test.todo', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowError('test.todo expects first argument to be a string', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorTestTodoExpectsString, SSuggestTestUsage);
 
   RegisterTestEntry(AArgs.GetElement(0).ToStringLiteral.Value, nil, nil, False,
     False, True);
@@ -3396,7 +3397,7 @@ begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'onTestFinished', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaFunctionBase) then
-    ThrowError('onTestFinished expects a function argument', 0, 0);
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorOnTestFinishedExpectsFunction, SSuggestTestUsage);
 
   AddTempRootIfNeeded(AArgs.GetElement(0));
   FOnTestFinishedCallbacks.Add(AArgs.GetElement(0));

--- a/units/Goccia.Builtins.YAML.pas
+++ b/units/Goccia.Builtins.YAML.pas
@@ -34,6 +34,8 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
@@ -79,13 +81,13 @@ function TGocciaYAMLBuiltin.YAMLParse(
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'YAML.parse', ThrowError);
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowError('YAML.parse: argument must be a string', 0, 0);
+    ThrowTypeError(SErrorYAMLParseArgMustBeString, SSuggestStringArgRequired);
 
   try
     Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
   except
     on E: Exception do
-      ThrowSyntaxError(E.Message);
+      ThrowSyntaxError(E.Message, SSuggestYAMLSyntax);
   end;
 end;
 
@@ -95,13 +97,13 @@ function TGocciaYAMLBuiltin.YAMLParseDocuments(
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'YAML.parseDocuments', ThrowError);
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowError('YAML.parseDocuments: argument must be a string', 0, 0);
+    ThrowTypeError(SErrorYAMLParseDocumentsArgMustBeString, SSuggestStringArgRequired);
 
   try
     Result := FParser.ParseDocuments(AArgs.GetElement(0).ToStringLiteral.Value);
   except
     on E: Exception do
-      ThrowSyntaxError(E.Message);
+      ThrowSyntaxError(E.Message, SSuggestYAMLSyntax);
   end;
 end;
 

--- a/units/Goccia.DisposalTracker.pas
+++ b/units/Goccia.DisposalTracker.pas
@@ -57,6 +57,8 @@ uses
   Goccia.CallStack,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -180,7 +182,7 @@ begin
     if Assigned(Method) and not (Method is TGocciaUndefinedLiteralValue) then
     begin
       if not Method.IsCallable then
-        ThrowTypeError('Property [Symbol.asyncDispose] is not a function');
+        ThrowTypeError(Format(SErrorDisposePropertyNotFunction, ['asyncDispose']), SSuggestDisposable);
       Result := Method;
       Exit;
     end;
@@ -191,7 +193,7 @@ begin
     if Assigned(Method) and not (Method is TGocciaUndefinedLiteralValue) then
     begin
       if not Method.IsCallable then
-        ThrowTypeError('Property [Symbol.dispose] is not a function');
+        ThrowTypeError(Format(SErrorDisposePropertyNotFunction, ['dispose']), SSuggestDisposable);
       Result := Method;
       Exit;
     end;
@@ -206,7 +208,7 @@ begin
     if Assigned(Method) and not (Method is TGocciaUndefinedLiteralValue) then
     begin
       if not Method.IsCallable then
-        ThrowTypeError('Property [Symbol.dispose] is not a function');
+        ThrowTypeError(Format(SErrorDisposePropertyNotFunction, ['dispose']), SSuggestDisposable);
       Result := Method;
       Exit;
     end;

--- a/units/Goccia.Error.Detail.pas
+++ b/units/Goccia.Error.Detail.pas
@@ -20,7 +20,7 @@ function ExtractThrowLocation(const AThrown: TGocciaValue;
   Falls back to the stack trace or bare message when context is unavailable. }
 function FormatThrowDetail(const AThrown: TGocciaValue;
   const AFileName: string; const ASourceLines: TStringList;
-  const AUseColor: Boolean): string;
+  const AUseColor: Boolean; const ASuggestion: string = ''): string;
 
 implementation
 
@@ -97,7 +97,7 @@ end;
 
 function FormatThrowDetail(const AThrown: TGocciaValue;
   const AFileName: string; const ASourceLines: TStringList;
-  const AUseColor: Boolean): string;
+  const AUseColor: Boolean; const ASuggestion: string = ''): string;
 var
   ErrorName, ErrorMessage, FrameFileName: string;
   Line, Col: Integer;
@@ -111,8 +111,10 @@ begin
       EffectiveFileName := FrameFileName
     else
       EffectiveFileName := AFileName;
+
     Result := FormatErrorWithSourceContext(
-      ErrorName, ErrorMessage, EffectiveFileName, Line, Col, ASourceLines, AUseColor);
+      ErrorName, ErrorMessage, EffectiveFileName, Line, Col, ASourceLines,
+      AUseColor, ASuggestion);
   end
   else
   begin

--- a/units/Goccia.Error.Messages.pas
+++ b/units/Goccia.Error.Messages.pas
@@ -1,0 +1,683 @@
+unit Goccia.Error.Messages;
+
+{$I Goccia.inc}
+
+interface
+
+resourcestring
+  // Scope errors
+  SErrorIdentifierAlreadyDeclared = 'Identifier ''%s'' has already been declared';
+  SErrorCannotAccessBeforeInit = 'Cannot access ''%s'' before initialization';
+  SErrorAssignToConstant = 'Assignment to constant variable ''%s''';
+  SErrorUndefinedVariable = 'Undefined variable: %s';
+
+  // Type errors — function calls
+  SErrorMemberNotFunction = '%s.%s is not a function';
+  SErrorNotFunction = '''%s'' is not a function';
+  SErrorValueNotFunction = '%s is not a function';
+  SErrorSymbolToNumber = 'Cannot convert a Symbol value to a number';
+  SErrorSymbolToString = 'Cannot convert a Symbol value to a string';
+
+  // Type errors — property access
+  SErrorCannotReadPropertyOf = 'Cannot read property ''%s'' of %s';
+  SErrorCannotReadPropertiesOf = 'Cannot read properties of %s (reading ''%s'')';
+
+  // Type errors — constructors
+  SErrorNotConstructor = '''%s'' is not a constructor';
+  SErrorValueNotConstructor = '%s is not a constructor';
+
+  // Type errors — iterables and spread
+  SErrorSpreadRequiresIterable = 'Spread syntax requires an iterable';
+  SErrorNotIterable = '''%s'' is not iterable';
+
+  // Type errors — iterator protocol
+  SErrorIteratorResultNotObject = 'Iterator result %s is not an object';
+
+  // Type errors — destructuring
+  SErrorCannotDestructure = 'Cannot destructure %s';
+  SErrorCannotDestructureType = 'Cannot destructure value of type ''%s''';
+
+  // Type errors — classes, decorators, private fields
+  SErrorDecoratorMustBeFunction = 'Decorator must be a function';
+  SErrorPrivateGetterMissing = 'Private accessor #%s was defined without a getter';
+  SErrorPrivateSetterMissing = 'Private accessor #%s was defined without a setter';
+  SErrorPrivateFieldInaccessible = 'Private field #%s is not accessible';
+  SErrorEnumInitializer = 'Enum member initializer must evaluate to a Number, String, or Symbol value';
+
+  // Type errors — async, disposal, tagged templates
+  SErrorAwaitPromiseUnsettled = 'await: Promise did not settle after microtask drain';
+  SErrorUsingOutsideBlock = 'using declaration outside of a block scope';
+  SErrorNotDisposable = 'Value is not disposable (missing [Symbol.dispose])';
+  SErrorNotAsyncDisposable = 'Value is not disposable (missing [Symbol.asyncDispose] and [Symbol.dispose])';
+
+  // Type errors — delete
+  SErrorCannotDeletePropertyOf = 'Cannot delete property ''%s'' of %s';
+
+  // Array errors
+  SErrorSpeciesNotConstructor = 'Species is not a constructor';
+  SErrorInvalidArrayLength = 'Invalid array length';
+  SErrorReduceEmptyArray = 'Reduce of empty array with no initial value';
+  SErrorInvalidArrayWithIndex = 'Invalid index for Array.with';
+
+  // Iterator helper errors — protocol
+  SErrorIteratorNextNonIterator = 'Iterator.prototype.next called on non-iterator';
+  SErrorIteratorMapNonIterator = 'Iterator.prototype.map called on non-iterator';
+  SErrorIteratorFilterNonIterator = 'Iterator.prototype.filter called on non-iterator';
+  SErrorIteratorTakeNonIterator = 'Iterator.prototype.take called on non-iterator';
+  SErrorIteratorDropNonIterator = 'Iterator.prototype.drop called on non-iterator';
+  SErrorIteratorFlatMapNonIterator = 'Iterator.prototype.flatMap called on non-iterator';
+  SErrorIteratorForEachNonIterator = 'Iterator.prototype.forEach called on non-iterator';
+  SErrorIteratorReduceNonIterator = 'Iterator.prototype.reduce called on non-iterator';
+  SErrorIteratorToArrayNonIterator = 'Iterator.prototype.toArray called on non-iterator';
+  SErrorIteratorSomeNonIterator = 'Iterator.prototype.some called on non-iterator';
+  SErrorIteratorEveryNonIterator = 'Iterator.prototype.every called on non-iterator';
+  SErrorIteratorFindNonIterator = 'Iterator.prototype.find called on non-iterator';
+
+  // Iterator helper errors — argument validation
+  SErrorIteratorMapCallable = 'Iterator.prototype.map requires a callable argument';
+  SErrorIteratorFilterCallable = 'Iterator.prototype.filter requires a callable argument';
+  SErrorIteratorFlatMapCallable = 'Iterator.prototype.flatMap requires a callable argument';
+  SErrorIteratorForEachCallable = 'Iterator.prototype.forEach requires a callable argument';
+  SErrorIteratorReduceCallable = 'Iterator.prototype.reduce requires a callable argument';
+  SErrorIteratorSomeCallable = 'Iterator.prototype.some requires a callable argument';
+  SErrorIteratorEveryCallable = 'Iterator.prototype.every requires a callable argument';
+  SErrorIteratorFindCallable = 'Iterator.prototype.find requires a callable argument';
+  SErrorIteratorTakeRequiresArg = 'Iterator.prototype.take requires an argument';
+  SErrorIteratorDropRequiresArg = 'Iterator.prototype.drop requires an argument';
+  SErrorIteratorTakeNonNegative = 'Iterator.prototype.take argument must be non-negative';
+  SErrorIteratorDropNonNegative = 'Iterator.prototype.drop argument must be non-negative';
+  SErrorReduceEmptyIterator = 'Reduce of empty iterator with no initial value';
+
+  // Iterator.from / Iterator.concat / Iterator.zip / Iterator.zipKeyed
+  SErrorIteratorZipInvalidMode = 'Iterator.zip: invalid mode "%s"';
+  SErrorIteratorZipKeyedPropertyNotIterable = 'Iterator.zipKeyed: property "%s" value must be iterable';
+  SErrorIteratorZipKeyedInvalidMode = 'Iterator.zipKeyed: invalid mode "%s"';
+  SErrorIteratorFromRequiresArg = 'Iterator.from requires an argument';
+  SErrorIteratorFromRequiresIterable = 'Iterator.from requires an iterable or iterator-like object';
+  SErrorIteratorConcatNotIterable = 'Iterator.concat requires all arguments to be iterable';
+  SErrorIteratorZipRequiresArg = 'Iterator.zip requires an argument';
+  SErrorIteratorZipFirstIterable = 'Iterator.zip: first argument must be iterable';
+  SErrorIteratorZipItemIterable = 'Iterator.zip: all items in iterables must be iterable';
+  SErrorIteratorZipOptionsObject = 'Iterator.zip: options must be an object';
+  SErrorIteratorZipModeString = 'Iterator.zip: mode must be a string';
+  SErrorIteratorZipPaddingIterable = 'Iterator.zip: padding must be iterable';
+  SErrorIteratorZipKeyedRequiresArg = 'Iterator.zipKeyed requires an argument';
+  SErrorIteratorZipKeyedFirstObject = 'Iterator.zipKeyed: first argument must be an object';
+  SErrorIteratorZipKeyedOptionsObject = 'Iterator.zipKeyed: options must be an object';
+  SErrorIteratorZipKeyedModeString = 'Iterator.zipKeyed: mode must be a string';
+  SErrorIteratorZipKeyedPaddingObject = 'Iterator.zipKeyed: padding must be an object';
+
+  // Global array errors
+  SErrorArrayFromMapFn = 'Array.from: when provided, the second argument must be a function';
+  SErrorIteratorInvalid = '[Symbol.iterator] did not return a valid iterator';
+  SErrorIteratorReturnObject = 'Iterator return() must return an object';
+  SErrorAsyncIteratorNextNotCallable = 'Async iterator .next is not callable';
+
+  // Temporal API errors — Duration
+  SErrorTemporalDurationFromArg = 'Temporal.Duration.from requires a string, Duration, or object';
+  SErrorTemporalDurationCompareArg = 'Temporal.Duration.compare requires Duration arguments';
+  SErrorInvalidISODuration = 'Invalid ISO duration string';
+
+  // Temporal API errors — Instant
+  SErrorTemporalInstantRequiresEpoch = 'Temporal.Instant requires epochNanoseconds argument';
+  SErrorInvalidISOInstant = 'Invalid ISO instant string';
+  SErrorTemporalInstantFromArg = 'Temporal.Instant.from requires a string or Instant';
+  SErrorTemporalInstantFromEpochMillis = 'Temporal.Instant.fromEpochMilliseconds requires an argument';
+  SErrorTemporalInstantFromEpochNanos = 'Temporal.Instant.fromEpochNanoseconds requires an argument';
+  SErrorTemporalInstantCompareArg = 'Temporal.Instant.compare requires Instant arguments';
+
+  // Temporal API errors — PlainDate
+  SErrorTemporalPlainDateArgs = 'Temporal.PlainDate requires year, month, day arguments';
+  SErrorInvalidISODate = 'Invalid ISO date string';
+  SErrorTemporalPlainDateFromProps = 'Temporal.PlainDate.from requires year, month, day properties';
+  SErrorTemporalPlainDateFromArg = 'Temporal.PlainDate.from requires a string, PlainDate, or object';
+  SErrorTemporalPlainDateCompareArg = 'Temporal.PlainDate.compare requires PlainDate arguments';
+
+  // Temporal API errors — PlainTime
+  SErrorInvalidISOTime = 'Invalid ISO time string';
+  SErrorTemporalPlainTimeFromArg = 'Temporal.PlainTime.from requires a string, PlainTime, or object';
+  SErrorTemporalPlainTimeCompareArg = 'Temporal.PlainTime.compare requires PlainTime arguments';
+
+  // Temporal API errors — PlainDateTime
+  SErrorTemporalPlainDateTimeArgs = 'Temporal.PlainDateTime requires at least year, month, day arguments';
+  SErrorInvalidISODateTime = 'Invalid ISO date-time string';
+  SErrorTemporalPlainDateTimeFromArg = 'Temporal.PlainDateTime.from requires a string, PlainDateTime, or object';
+  SErrorTemporalPlainDateTimeCompareArg = 'Temporal.PlainDateTime.compare requires PlainDateTime arguments';
+
+  // Temporal API errors — PlainYearMonth
+  SErrorTemporalPlainYearMonthArgs = 'Temporal.PlainYearMonth requires year, month arguments';
+  SErrorTemporalPlainYearMonthFromYear = 'Temporal.PlainYearMonth.from requires year property';
+  SErrorInvalidMonthCodeYearMonth = 'Invalid monthCode for Temporal.PlainYearMonth.from';
+  SErrorTemporalPlainYearMonthFromMonth = 'Temporal.PlainYearMonth.from requires monthCode or month property';
+  SErrorTemporalPlainYearMonthFromArg = 'Temporal.PlainYearMonth.from requires a string, PlainYearMonth, or object';
+  SErrorTemporalPlainYearMonthCompareArg = 'Temporal.PlainYearMonth.compare requires PlainYearMonth arguments';
+  SErrorInvalidISOYearMonth = 'Invalid ISO year-month string';
+  SErrorMonthCodeOutOfRange = 'monthCode month out of range in Temporal.PlainYearMonth.from';
+  SErrorMonthCodeMismatch = 'month and monthCode must match in Temporal.PlainYearMonth.from';
+
+  // Temporal API errors — PlainMonthDay
+  SErrorTemporalPlainMonthDayArgs = 'Temporal.PlainMonthDay requires month, day arguments';
+  SErrorTemporalPlainMonthDayFromDay = 'Temporal.PlainMonthDay.from requires day property';
+  SErrorInvalidMonthCodeMonthDay = 'Invalid monthCode for Temporal.PlainMonthDay.from';
+  SErrorTemporalPlainMonthDayFromMonth = 'Temporal.PlainMonthDay.from requires a valid month property';
+  SErrorTemporalPlainMonthDayFromArg = 'Temporal.PlainMonthDay.from requires a string, PlainMonthDay, or object';
+  SErrorTemporalPlainMonthDayCompareArg = 'Temporal.PlainMonthDay.compare requires PlainMonthDay arguments';
+  SErrorInvalidISOMonthDay = 'Invalid ISO month-day string';
+
+  // Temporal API errors — ZonedDateTime
+  SErrorTemporalZonedDateTimeArgs = 'Temporal.ZonedDateTime requires epochNanoseconds and timeZone arguments';
+  SErrorTemporalZonedDateTimeFromArg = 'Temporal.ZonedDateTime.from requires a string or ZonedDateTime';
+  SErrorTemporalZonedDateTimeCompareArg = 'Temporal.ZonedDateTime.compare requires ZonedDateTime or string arguments';
+  SErrorInvalidISOZonedDateTime = 'Invalid ISO zoned date-time string';
+  SErrorTemporalZonedDateTimeRequiresTZ = 'Temporal.ZonedDateTime.from requires a timezone annotation (e.g., [UTC])';
+  SErrorTemporalZonedDateTimeCompareTZ = 'Temporal.ZonedDateTime.compare requires a timezone annotation (e.g., [UTC])';
+
+  // Temporal API errors — range
+  SErrorTemporalMonthOutOfRange = 'Month %d out of range';
+  SErrorTemporalDayOutOfRange = 'Day %d out of range';
+  SErrorTemporalDayOutOfRangeForMonth = 'Day %d out of range for month %d';
+
+  // Temporal prototype errors — shared
+  SErrorInvalidDurationString = 'Invalid duration string';
+  SErrorInvalidTimeString = 'Invalid time string';
+  SErrorTemporalValueOf = 'Temporal.%s.prototype.valueOf cannot be used; use %s instead';
+  SErrorTemporalWithRequiresObject = '%s.prototype.with requires an object argument';
+  SErrorTemporalAddRequiresDuration = '%s.prototype.add requires a Duration or string';
+  SErrorTemporalSubtractRequiresDuration = '%s.prototype.subtract requires a Duration or string';
+  SErrorTemporalRoundRequiresStringOrOptions = '%s.prototype.round requires a string or options object';
+  SErrorTemporalRoundRequiresSmallestUnit = 'round() requires a smallestUnit option';
+  SErrorTemporalInvalidUnitFor = 'Invalid unit for %s: %s';
+  SErrorTemporalInvalidISOStringFor = 'Invalid ISO %s string for %s';
+
+  // Temporal prototype errors — Duration
+  SErrorDurationMixedSigns = 'Duration fields must not have mixed signs';
+  SErrorDurationRoundRequiresUnit = 'round() requires at least a smallestUnit or largestUnit';
+  SErrorDurationRoundRequiresRelativeTo = 'Duration with years or months requires relativeTo for round()';
+  SErrorDurationTotalRequiresUnit = 'total() requires a unit option';
+  SErrorDurationTotalRequiresRelativeTo = 'Duration with years or months requires relativeTo for total()';
+  SErrorDurationTotalRelativeToUnsupported = 'relativeTo for Duration.prototype.total is not yet supported';
+  SErrorDurationTotalRequiresStringOrOptions = 'Duration.prototype.total requires a string or options object';
+  SErrorInvalidDurationAddArg = 'Invalid argument to Duration.prototype.add';
+  SErrorInvalidDurationSubtractArg = 'Invalid argument to Duration.prototype.subtract';
+
+  // Temporal prototype errors — Instant
+  SErrorInstantAddNoCalendar = 'Instant.prototype.add does not support years, months, or weeks';
+  SErrorInstantSubtractNoCalendar = 'Instant.prototype.subtract does not support years, months, or weeks';
+
+  // Temporal prototype errors — PlainDate
+  SErrorInvalidDate = 'Invalid date: %s';
+  SErrorPlainDateToZonedRequiresTZ = 'PlainDate.prototype.toZonedDateTime requires a timeZone';
+  SErrorPlainDateToZonedRequiresStringOrOptions = 'PlainDate.prototype.toZonedDateTime requires a timezone string or options object';
+
+  // Temporal prototype errors — PlainTime
+  SErrorInvalidTime = 'Invalid time';
+
+  // Temporal prototype errors — PlainDateTime
+  SErrorInvalidDateInPlainDateTime = 'Invalid date in PlainDateTime';
+  SErrorInvalidTimeInPlainDateTime = 'Invalid time in PlainDateTime';
+  SErrorPlainDateTimeToZonedRequiresTZ = 'PlainDateTime.prototype.toZonedDateTime requires a timeZone';
+  SErrorPlainDateTimeToZonedRequiresStringOrOptions = 'PlainDateTime.prototype.toZonedDateTime requires a timezone string or options object';
+  SErrorPlainDateTimeToZonedUnknownTZ = 'PlainDateTime.prototype.toZonedDateTime: unknown timezone %s';
+  SErrorPlainDateTimeWithPlainTimeArg = 'PlainDateTime.prototype.withPlainTime requires a PlainTime or string';
+
+  // Temporal prototype errors — PlainYearMonth
+  SErrorInvalidMonth = 'Invalid month: %s';
+  SErrorInvalidYearMonthStringFor = 'Invalid year-month string for %s';
+  SErrorPlainYearMonthToPlainDateRequiresDay = 'PlainYearMonth.prototype.toPlainDate requires an object with a day property';
+  SErrorMonthCodeOutOfRangeIn = 'monthCode month out of range in %s';
+  SErrorMonthCodeMismatchIn = 'month and monthCode must match in %s';
+
+  // Temporal prototype errors — PlainMonthDay
+  SErrorInvalidMonthDay = 'Invalid month-day: %s';
+  SErrorInvalidMonthDayStringFor = 'Invalid month-day string for %s';
+  SErrorInvalidMonthCodeFor = 'Invalid monthCode for %s';
+  SErrorPlainMonthDayToPlainDateRequiresYear = 'PlainMonthDay.prototype.toPlainDate requires an object with a year property';
+
+  // Temporal prototype errors — ZonedDateTime
+  SErrorZonedDateTimeRequiresTZ = 'ZonedDateTime requires a timezone';
+  SErrorUnknownTimezone = 'Unknown timezone: %s';
+  SErrorZonedDateTimeRequiresTZAnnotation = 'ZonedDateTime requires a timezone annotation in the string';
+  SErrorInvalidDateStringForZDT = 'Invalid date string for ZonedDateTime.prototype.withPlainDate';
+  SErrorZDTWithPlainDateArg = 'ZonedDateTime.prototype.withPlainDate requires a PlainDate or string';
+  SErrorInvalidTimeStringForZDT = 'Invalid time string for ZonedDateTime.prototype.withPlainTime';
+  SErrorZDTWithPlainTimeArg = 'ZonedDateTime.prototype.withPlainTime requires a PlainTime or string';
+  SErrorZDTWithTimeZoneArg = 'ZonedDateTime.prototype.withTimeZone requires a timezone argument';
+  SErrorZDTWithTimeZoneNonEmpty = 'ZonedDateTime.prototype.withTimeZone requires a non-empty timezone';
+  SErrorInvalidZDTRoundUnit = 'Invalid unit for ZonedDateTime.prototype.round';
+
+  // Temporal options errors
+  SErrorInvalidSmallestUnit = 'Invalid smallestUnit: %s';
+  SErrorInvalidLargestUnit = 'Invalid largestUnit: %s';
+  SErrorInvalidRoundingMode = 'Invalid roundingMode: %s';
+  SErrorRoundingIncrementMin = 'roundingIncrement must be >= 1';
+  SErrorInvalidOverflow = 'Invalid overflow option: %s';
+  SErrorInvalidFractionalDigits = 'Invalid fractionalSecondDigits: %s';
+  SErrorFractionalDigitsRange = 'fractionalSecondDigits must be 0-9 or "auto"';
+  SErrorCannotConvertCalendarUnit = 'Cannot convert calendar unit to nanoseconds';
+
+  // TypedArray errors
+  SErrorTypedArrayRequiresTypedArray = '%s requires a TypedArray';
+  SErrorTypedArraySetRequiresArg = 'TypedArray.prototype.set requires at least one argument';
+  SErrorTypedArraySetOffsetNonNegative = 'TypedArray.prototype.set offset must be >= 0';
+  SErrorTypedArraySetArgType = 'TypedArray.prototype.set argument must be an array or typed array';
+  SErrorTypedArraySourceTooLarge = 'Source is too large';
+  SErrorTypedArrayFindCallable = 'TypedArray.prototype.find requires a callable argument';
+  SErrorTypedArrayFindIndexCallable = 'TypedArray.prototype.findIndex requires a callable argument';
+  SErrorTypedArrayFindLastCallable = 'TypedArray.prototype.findLast requires a callable argument';
+  SErrorTypedArrayFindLastIndexCallable = 'TypedArray.prototype.findLastIndex requires a callable argument';
+  SErrorTypedArrayEveryCallable = 'TypedArray.prototype.every requires a callable argument';
+  SErrorTypedArraySomeCallable = 'TypedArray.prototype.some requires a callable argument';
+  SErrorTypedArrayForEachCallable = 'TypedArray.prototype.forEach requires a callable argument';
+  SErrorTypedArrayMapCallable = 'TypedArray.prototype.map requires a callable argument';
+  SErrorTypedArrayFilterCallable = 'TypedArray.prototype.filter requires a callable argument';
+  SErrorTypedArrayReduceCallable = 'TypedArray.prototype.reduce requires a callable argument';
+  SErrorTypedArrayReduceRightCallable = 'TypedArray.prototype.reduceRight requires a callable argument';
+  SErrorReduceEmptyTypedArray = 'Reduce of empty typed array with no initial value';
+  SErrorTypedArrayFromRequiresArg = 'TypedArray.from requires at least one argument';
+  SErrorTypedArrayFromMapFn = 'TypedArray.from mapfn must be a function';
+  SErrorTypedArrayFromSource = 'TypedArray.from requires an array-like or iterable source';
+  SErrorInvalidTypedArrayIndex = 'Invalid index';
+  SErrorInvalidTypedArrayLength = 'Invalid typed array length';
+  SErrorTypedArrayStartOffsetNonNegative = 'Start offset of %s must be non-negative';
+  SErrorTypedArrayStartOffsetMultiple = 'Start offset of %s should be a multiple of %d';
+  SErrorTypedArrayStartOffsetBounds = 'Start offset is outside the bounds of the buffer';
+  SErrorTypedArrayByteLengthMultiple = 'Byte length of %s should be a multiple of %d';
+
+  // Proxy trap errors
+  SErrorProxyRevoked = 'Cannot perform operation on a revoked proxy';
+  SErrorProxyTrapNotFunction = 'Proxy handler trap ''%s'' is not a function';
+  SErrorProxyTrapNotCallable = 'Proxy trap is not callable';
+  SErrorProxyGetNonConfigurableValue = 'Proxy get: value mismatch for non-configurable, non-writable property ''%s''';
+  SErrorProxyGetNoGetter = 'Proxy get: must return undefined for non-configurable accessor without getter ''%s''';
+  SErrorProxySetReturnedFalse = 'Proxy set handler returned false for property ''%s''';
+  SErrorProxySetNonConfigurableValue = 'Proxy set: cannot change value of non-configurable, non-writable property ''%s''';
+  SErrorProxySetNoSetter = 'Proxy set: cannot set non-configurable accessor property ''%s'' without a setter';
+  SErrorProxyHasNonConfigurable = 'Proxy has trap returned false for non-configurable property ''%s''';
+  SErrorProxyHasNonExtensible = 'Proxy has trap returned false for property on non-extensible target';
+  SErrorProxyHasSymbolNonConfigurable = 'Proxy has trap returned false for non-configurable symbol property';
+  SErrorProxyHasSymbolNonExtensible = 'Proxy has trap returned false for symbol property on non-extensible target';
+  SErrorProxyGetSymbolNonConfigurable = 'Proxy get: value mismatch for non-configurable, non-writable symbol property';
+  SErrorProxyGetSymbolNoGetter = 'Proxy get: must return undefined for non-configurable accessor without getter';
+  SErrorProxySetSymbolNonConfigurable = 'Proxy set: cannot change value of non-configurable, non-writable symbol property';
+  SErrorProxySetSymbolNoSetter = 'Proxy set: cannot set non-configurable accessor symbol property without a setter';
+  SErrorProxyDeleteNonConfigurable = 'Proxy deleteProperty trap returned true for non-configurable property ''%s''';
+  SErrorProxyDeleteNonExtensible = 'Proxy deleteProperty trap returned true for property on non-extensible target';
+  SErrorProxyGetOwnNonConfigurable = 'Proxy getOwnPropertyDescriptor returned undefined for non-configurable property ''%s''';
+  SErrorProxyGetOwnNonExtensible = 'Proxy getOwnPropertyDescriptor returned undefined for property on non-extensible target';
+  SErrorProxyGetOwnReturnType = 'Proxy getOwnPropertyDescriptor must return an object or undefined';
+  SErrorProxyDefineReturnedFalse = 'Proxy defineProperty handler returned false for property ''%s''';
+  SErrorProxyDefineNonObject = 'Cannot define property on non-object target';
+  SErrorProxyOwnKeysArray = 'Proxy ownKeys must return an array';
+  SErrorProxyOwnKeysTypes = 'Proxy ownKeys trap result must contain only strings and symbols';
+  SErrorProxyOwnKeysMissing = 'Proxy ownKeys trap result must include non-configurable property ''%s''';
+  SErrorProxyGetProtoReturnType = 'Proxy getPrototypeOf trap must return an object or null';
+  SErrorProxyGetProtoMismatch = 'Proxy getPrototypeOf trap result does not match non-extensible target prototype';
+  SErrorProxySetProtoNonExtensible = 'Proxy setPrototypeOf trap returned true but target is non-extensible';
+  SErrorProxyIsExtensibleMismatch = 'Proxy isExtensible trap result does not match target extensibility';
+  SErrorProxyPreventExtensionsFalse = 'Proxy preventExtensions handler returned false';
+  SErrorProxyPreventExtensionsStillExtensible = 'Proxy preventExtensions trap returned true but target is still extensible';
+  SErrorProxyApplyNonFunction = 'Proxy apply trap called on non-function target';
+  SErrorProxyTargetNotCallable = 'Proxy target is not callable';
+  SErrorProxyTargetNotConstructor = 'Proxy target is not a constructor';
+  SErrorProxyConstructReturnType = 'Proxy construct handler must return an object';
+
+  // FFI errors
+  SErrorFFIFuncArgCount = 'FFI function %s expects %d arguments, got %d';
+  SErrorFFIArgMustBeBufferOrNull = 'FFI argument %d must be an ArrayBuffer, TypedArray, FFIPointer, or null';
+  SErrorFFIBindRequiresNameAndSig = 'bind requires a function name and a signature object';
+  SErrorFFIBindSigObject = 'bind second argument must be a signature object { args: [...], returns: "..." }';
+  SErrorFFIUnknownType = 'Unknown FFI type: %s';
+  SErrorFFIVoidNotValidArg = 'void is not a valid argument type';
+  SErrorFFISigArgsMustBeArray = 'signature args must be an array of type strings';
+  SErrorFFIUnknownReturnType = 'Unknown FFI return type: %s';
+  SErrorFFISigReturnsMustBeString = 'signature returns must be a type string';
+  SErrorFFIBindRequiresLibrary = 'bind requires an FFILibrary';
+  SErrorFFIBindLibraryClosed = 'Cannot bind from a closed library';
+  SErrorFFISymbolRequiresLibrary = 'symbol requires an FFILibrary';
+  SErrorFFISymbolLibraryClosed = 'Cannot look up symbol in a closed library';
+  SErrorFFISymbolRequiresName = 'symbol requires a symbol name';
+  SErrorFFICloseRequiresLibrary = 'close requires an FFILibrary';
+  SErrorFFIPathRequiresLibrary = 'FFILibrary.path requires an FFILibrary';
+  SErrorFFIClosedRequiresLibrary = 'FFILibrary.closed requires an FFILibrary';
+
+  // URLSearchParams errors
+  SErrorURLSearchParamsNotSequence = 'Failed to construct URLSearchParams: The provided value cannot be converted to a sequence';
+  SErrorURLSearchParamsPairSize = 'Failed to construct URLSearchParams: Sequence initializer must contain pairs with exactly two items';
+  SErrorURLSearchParamsAppendNotInstance = 'URLSearchParams.prototype.append: not a URLSearchParams';
+  SErrorURLSearchParamsDeleteNotInstance = 'URLSearchParams.prototype.delete: not a URLSearchParams';
+  SErrorURLSearchParamsGetNotInstance = 'URLSearchParams.prototype.get: not a URLSearchParams';
+  SErrorURLSearchParamsGetAllNotInstance = 'URLSearchParams.prototype.getAll: not a URLSearchParams';
+  SErrorURLSearchParamsHasNotInstance = 'URLSearchParams.prototype.has: not a URLSearchParams';
+  SErrorURLSearchParamsSetNotInstance = 'URLSearchParams.prototype.set: not a URLSearchParams';
+  SErrorURLSearchParamsSortNotInstance = 'URLSearchParams.prototype.sort: not a URLSearchParams';
+  SErrorURLSearchParamsToStringNotInstance = 'URLSearchParams.prototype.toString: not a URLSearchParams';
+  SErrorURLSearchParamsKeysNotInstance = 'URLSearchParams.prototype.keys: not a URLSearchParams';
+  SErrorURLSearchParamsValuesNotInstance = 'URLSearchParams.prototype.values: not a URLSearchParams';
+  SErrorURLSearchParamsEntriesNotInstance = 'URLSearchParams.prototype.entries: not a URLSearchParams';
+  SErrorURLSearchParamsForEachNotInstance = 'URLSearchParams.prototype.forEach: not a URLSearchParams';
+  SErrorURLSearchParamsForEachNotCallable = 'URLSearchParams.prototype.forEach: callback is not a function';
+  SErrorURLSearchParamsSizeNotInstance = 'URLSearchParams size getter: not a URLSearchParams';
+  SErrorURLSearchParamsIteratorNotInstance = 'URLSearchParams[Symbol.iterator]: not a URLSearchParams';
+
+  // URL errors
+  SErrorURLNotURL = 'URL %s: not a URL';
+  SErrorURLConstructorRequiresArg = 'URL constructor: 1 argument required';
+  SErrorInvalidBaseURL = 'Invalid base URL: %s';
+  SErrorInvalidURL = 'Invalid URL: %s';
+
+  // String method errors
+  SErrorSymbolReplaceNotCallable = '@@replace is not callable';
+  SErrorReplaceAllRequiresGlobalRegExp = 'String.prototype.replaceAll requires a global RegExp';
+  SErrorSymbolSplitNotCallable = '@@split is not callable';
+  SErrorSymbolMatchNotCallable = '@@match is not callable';
+  SErrorMatchAllRequiresGlobalRegExp = 'String.prototype.matchAll requires a global RegExp';
+  SErrorSymbolMatchAllNotCallable = '@@matchAll is not callable';
+  SErrorSymbolSearchNotCallable = '@@search is not callable';
+  SErrorInvalidRepeatCount = 'Invalid count value: %s';
+  SErrorInvalidNormalizationForm = 'The normalization form should be one of NFC, NFD, NFKC, NFKD';
+  SErrorIsWellFormedRequiresNonNullish = 'String.prototype.isWellFormed requires that ''this'' not be null or undefined';
+  SErrorToWellFormedRequiresNonNullish = 'String.prototype.toWellFormed requires that ''this'' not be null or undefined';
+
+  // ArrayBuffer errors
+  SErrorRequiresArrayBuffer = '%s requires an ArrayBuffer';
+  SErrorInvalidArrayBufferLength = 'Invalid array buffer length';
+  SErrorArrayBufferExceedsMaxByteLength = 'ArrayBuffer byte length must not exceed maxByteLength';
+  SErrorCannotResizeDetachedArrayBuffer = 'Cannot resize a detached ArrayBuffer';
+  SErrorCannotResizeFixedLengthArrayBuffer = 'Cannot resize a fixed-length ArrayBuffer';
+  SErrorArrayBufferResizeExceedsMax = 'ArrayBuffer resize exceeds maxByteLength';
+  SErrorCannotTransferDetachedArrayBuffer = 'Cannot transfer a detached ArrayBuffer';
+  SErrorCannotSliceDetachedArrayBuffer = 'Cannot slice a detached ArrayBuffer';
+
+  // RegExp errors
+  SErrorRegExpEscapeRequiresString = 'RegExp.escape requires a string argument';
+  SErrorRegExpEscapeArgMustBeString = 'First argument to RegExp.escape must be a string';
+  SErrorRegExpExecNonRegExp = 'RegExp.prototype.exec called on non-RegExp object';
+  SErrorRegExpTestNonRegExp = 'RegExp.prototype.test called on non-RegExp object';
+  SErrorRegExpToStringNonRegExp = 'RegExp.prototype.toString called on non-RegExp object';
+  SErrorRegExpMatchNonRegExp = 'RegExp.prototype[Symbol.match] called on non-RegExp object';
+  SErrorRegExpMatchAllNonRegExp = 'RegExp.prototype[Symbol.matchAll] called on non-RegExp object';
+  SErrorRegExpReplaceNonRegExp = 'RegExp.prototype[Symbol.replace] called on non-RegExp object';
+  SErrorRegExpSearchNonRegExp = 'RegExp.prototype[Symbol.search] called on non-RegExp object';
+  SErrorRegExpSplitNonRegExp = 'RegExp.prototype[Symbol.split] called on non-RegExp object';
+
+  // VM runtime errors
+  SErrorCannotAssignReadOnly = 'Cannot assign to read only property ''%s''';
+  SErrorTypeNotAssignable = 'Type ''%s'' is not assignable to type ''%s''';
+  SErrorModuleNotAvailableInVM = 'Module loading is not available in TGocciaVM';
+  SErrorEnumMemberType = 'Enum member ''%s'' must be a number, string, or symbol';
+  SErrorClassDecoratorReturn = 'Class decorator must return a class or undefined';
+  SErrorMethodDecoratorReturn = 'Method decorator must return a function or undefined';
+  SErrorGetterDecoratorReturn = 'Getter decorator must return a function or undefined';
+  SErrorSetterDecoratorReturn = 'Setter decorator must return a function or undefined';
+  SErrorFieldDecoratorReturn = 'Field decorator must return a function or undefined';
+  SErrorAccessorDecoratorReturn = 'Accessor decorator must return an object or undefined';
+  SErrorCannotReadPropertiesOfNull = 'Cannot read properties of null (reading ''%s'')';
+  SErrorCannotReadPropertiesOfUndefined = 'Cannot read properties of undefined (reading ''%s'')';
+  SErrorCannotSetPropertiesOfNull = 'Cannot set properties of null (setting ''%s'')';
+  SErrorCannotSetPropertiesOfUndefined = 'Cannot set properties of undefined (setting ''%s'')';
+  SErrorPrivateAccessorNoGetter = 'Private accessor %s was defined without a getter';
+  SErrorPrivateAccessorNoSetter = 'Private accessor %s was defined without a setter';
+  SErrorPrivateFieldNotAccessible = 'Private field %s is not accessible';
+  SErrorCannotUseInOperator = 'Cannot use ''in'' operator to search for ''%s'' in %s';
+  SErrorCannotDestructureNotObject = 'Cannot destructure %s as it is not an object';
+
+  // Uint8Array encoding errors
+  SErrorRequiresUint8Array = '%s requires that |this| be a Uint8Array';
+  SErrorInvalidAlphabet = 'Invalid alphabet: expected "base64" or "base64url"';
+  SErrorInvalidLastChunkHandling = 'Invalid lastChunkHandling: expected "loose", "strict", or "stop-before-partial"';
+  SErrorInvalidBase64Character = 'Invalid character in base64 string';
+  SErrorBase64IncompleteChunk = 'Invalid base64 string: incomplete chunk';
+  SErrorBase64NonZeroPaddingBits = 'Invalid base64 string: non-zero padding bits';
+  SErrorBase64MalformedPadding = 'Invalid base64 string: malformed padding';
+  SErrorBase64IncompleteChunkStrict = 'Invalid base64 string: incomplete chunk in strict mode';
+  SErrorBase64UnexpectedPadding = 'Invalid base64 string: unexpected padding';
+  SErrorToBase64OptionsNotObject = 'Uint8Array.prototype.toBase64: options must be an object';
+  SErrorSetFromBase64RequiresString = 'Uint8Array.prototype.setFromBase64 requires a string argument';
+  SErrorSetFromBase64FirstArgString = 'Uint8Array.prototype.setFromBase64: first argument must be a string';
+  SErrorSetFromBase64OptionsNotObject = 'Uint8Array.prototype.setFromBase64: options must be an object';
+  SErrorSetFromHexRequiresString = 'Uint8Array.prototype.setFromHex requires a string argument';
+  SErrorSetFromHexFirstArgString = 'Uint8Array.prototype.setFromHex: first argument must be a string';
+  SErrorInvalidHexOddLength = 'Invalid hex string: odd length';
+  SErrorInvalidHexCharacter = 'Invalid character in hex string';
+  SErrorFromBase64RequiresString = 'Uint8Array.fromBase64 requires a string argument';
+  SErrorFromBase64FirstArgString = 'Uint8Array.fromBase64: first argument must be a string';
+  SErrorFromBase64OptionsNotObject = 'Uint8Array.fromBase64: options must be an object';
+  SErrorFromHexRequiresString = 'Uint8Array.fromHex requires a string argument';
+  SErrorFromHexFirstArgString = 'Uint8Array.fromHex: first argument must be a string';
+
+  // TextDecoder errors
+  SErrorTextDecoderInvalidEncoding = 'TextDecoder: The encoding label provided (%s) is invalid.';
+  SErrorTextDecoderOptionsMustBeObject = 'TextDecoder: options must be an object or undefined';
+  SErrorTextDecoderEncodingIllegalInvocation = 'TextDecoder.prototype.encoding: illegal invocation';
+  SErrorTextDecoderFatalIllegalInvocation = 'TextDecoder.prototype.fatal: illegal invocation';
+  SErrorTextDecoderIgnoreBOMIllegalInvocation = 'TextDecoder.prototype.ignoreBOM: illegal invocation';
+  SErrorTextDecoderDecodeIllegalInvocation = 'TextDecoder.prototype.decode: illegal invocation';
+  SErrorTextDecoderDecodeInputType = 'TextDecoder.prototype.decode: input must be an ArrayBuffer or ArrayBufferView';
+  SErrorTextDecoderDecodeInvalidUTF8 = 'TextDecoder.prototype.decode: invalid UTF-8 byte sequence';
+
+  // SharedArrayBuffer errors
+  SErrorInvalidSharedArrayBufferLength = 'Invalid shared array buffer length';
+  SErrorRequiresSharedArrayBuffer = '%s requires a SharedArrayBuffer';
+  SErrorSharedArrayBufferSpeciesReturnedThis = 'SharedArrayBuffer subclass returned this from species constructor';
+
+  // Reflect errors
+  SErrorReflectTargetMustBeObject = '%s: target must be an object';
+  SErrorReflectApplyTargetMustBeFunction = 'Reflect.apply: target must be a function';
+  SErrorReflectConstructTargetMustBeConstructor = 'Reflect.construct: target must be a constructor';
+  SErrorReflectConstructNewTargetMustBeConstructor = 'Reflect.construct: newTarget must be a constructor';
+  SErrorReflectDefinePropertyAttrsMustBeObject = 'Reflect.defineProperty: attributes must be an object';
+  SErrorReflectSetPrototypeOfProtoType = 'Reflect.setPrototypeOf: proto must be an object or null';
+
+  // URI errors
+  SErrorURIMalformed = 'URI malformed';
+
+  // Proxy constructor errors
+  SErrorProxyRequiresNew = 'Constructor Proxy requires ''new''';
+  SErrorProxyNonObjectTargetOrHandler = 'Cannot create proxy with a non-object as target or handler';
+
+  // Class errors
+  SErrorClassSetterOnlyAccessor = 'Cannot set property on class with getter-only accessor';
+  SErrorClassConstructorRequiresNew = 'Class constructor %s cannot be invoked without ''new''';
+
+  // JSON errors
+  SErrorJSONParseArgMustBeString = 'JSON.parse: argument must be a string';
+  SErrorJSONRawJSONEmptyString = 'JSON.rawJSON: empty string is not valid JSON';
+  SErrorJSONRawJSONLeadingWhitespace = 'JSON.rawJSON: input must not have leading whitespace';
+  SErrorJSONRawJSONTrailingWhitespace = 'JSON.rawJSON: input must not have trailing whitespace';
+  SErrorJSONRawJSONInvalid = 'JSON.rawJSON: %s';
+  SErrorJSONRawJSONMustBePrimitive = 'JSON.rawJSON: value must be a JSON primitive (not an object or array)';
+  SErrorJSONCircularStructure = 'Converting circular structure to JSON';
+  SErrorJSONStringifyError = 'JSON.stringify error: %s';
+
+  // DisposableStack errors
+  SErrorDisposableStackIncompatibleReceiver = 'DisposableStack method called on incompatible receiver';
+  SErrorDisposableStackAlreadyDisposed = 'DisposableStack has already been disposed';
+  SErrorValueNotDisposable = 'The value is not disposable (missing [Symbol.dispose])';
+  SErrorValueNotAsyncDisposable = 'The value is not disposable (missing [Symbol.asyncDispose] and [Symbol.dispose])';
+  SErrorOnDisposeMustBeFunction = 'The onDispose argument must be a function';
+
+  // Global function errors — queueMicrotask
+  SErrorQueueMicrotaskArgRequired = 'Failed to execute ''queueMicrotask'': 1 argument required, but only 0 present.';
+  SErrorQueueMicrotaskNotFunction = 'Failed to execute ''queueMicrotask'': parameter 1 is not of type ''Function''.';
+
+  // Global function errors — structuredClone
+  SErrorStructuredCloneArgRequired = 'Failed to execute ''structuredClone'': 1 argument required, but only 0 present.';
+  SErrorStructuredCloneNotCloneable = '%s could not be cloned.';
+  SErrorStructuredCloneValueNotCloneable = 'value could not be cloned.';
+
+  // Property descriptor errors
+  SErrorPropertyDescriptorMustBeObject = 'property descriptor must be an object';
+  SErrorGetterMustBeFunctionOrUndefined = 'getter must be a function or undefined';
+  SErrorSetterMustBeFunctionOrUndefined = 'setter must be a function or undefined';
+  SErrorDescriptorMixedAccessorData = 'descriptor cannot have both accessor and data properties';
+
+  // JSON5 errors
+  SErrorCircularStructureToJSON5 = 'Converting circular structure to JSON5';
+  SErrorJSON5ParseArgMustBeString = 'JSON5.parse: argument must be a string';
+
+  // String static method errors
+  SErrorInvalidCodePoint = 'Invalid code point';
+  SErrorNotValidCodePoint = '%s is not a valid code point';
+  SErrorCannotConvertToObject = 'Cannot convert %s to object';
+
+  // Promise errors
+  SErrorPromiseResolverUndefinedNotFunction = 'Promise resolver undefined is not a function';
+  SErrorPromiseResolverNotFunction = 'Promise resolver is not a function';
+  SErrorPromiseTryRequiresCallback = 'Promise.try requires a callback function';
+  SErrorAllPromisesRejected = 'All promises were rejected';
+
+  // Object static method errors
+  SErrorCannotConvertValueToObject = 'Cannot convert value to object';
+  SErrorObjectPrototypeMustBeObjectOrNull = 'Object prototype may only be an Object or null';
+
+  // Object property errors
+  SErrorCannotConvertNullOrUndefined = 'Cannot convert undefined or null to object';
+  SErrorReadOnlyPropertyFrozen = 'Cannot assign to read only property ''%s'' of frozen object';
+  SErrorSetPropertyOnlyGetter = 'Cannot set property %s of #<%s> which has only a getter';
+  SErrorProtoChainDepthExceeded = 'Prototype chain depth exceeded safety limit while setting ''%s''';
+  SErrorCannotAssignNonExistent = 'Cannot assign to non-existent property ''%s''';
+  SErrorCannotAddPropertyNotExtensible = 'Cannot add property ''%s'', object is not extensible';
+  SErrorCannotRedefineNonConfigurable = 'Cannot redefine non-configurable property ''%s''';
+  SErrorCannotAssignFrozenObject = 'Cannot assign to property of frozen object';
+  SErrorSetSymbolOnlyGetter = 'Cannot set property which has only a getter';
+  SErrorReadOnlySymbolProperty = 'Cannot assign to read only symbol property';
+  SErrorCannotAddSymbolNotExtensible = 'Cannot add symbol property, object is not extensible';
+
+  // TextEncoder errors
+  SErrorTextEncoderIllegalInvocation = '%s: illegal invocation';
+  SErrorTextEncoderEncodeIntoArgs = 'TextEncoder.prototype.encodeInto requires source and destination arguments';
+  SErrorTextEncoderEncodeIntoDestType = 'TextEncoder.prototype.encodeInto: destination must be a Uint8Array';
+
+  // Promise prototype errors
+  SErrorPromiseThenNonPromise = 'Promise.prototype.then called on non-Promise';
+  SErrorPromiseFinallyNonPromise = 'Promise.prototype.finally called on non-Promise';
+  SErrorThenNotFunction = 'then is not a function';
+  SErrorPromiseChainingCycle = 'Chaining cycle detected for promise';
+
+  // Disposal method errors
+  SErrorDisposePropertyNotFunction = 'Property [Symbol.%s] is not a function';
+
+  // Symbol prototype errors
+  SErrorSymbolProtoToStringRequiresSymbol = 'Symbol.prototype.toString requires that ''this'' be a Symbol';
+  SErrorSymbolProtoDescriptionRequiresSymbol = 'Symbol.prototype.description requires that ''this'' be a Symbol';
+
+  // Iterator zip strict errors
+  SErrorIteratorZipStrictLengthMismatch = 'Iterator.zip: iterables have different lengths in strict mode';
+  SErrorIteratorZipKeyedStrictLengthMismatch = 'Iterator.zipKeyed: iterables have different lengths in strict mode';
+
+  // Iterator lazy errors
+  SErrorIteratorFlatMapMustReturnIterable = 'Iterator.prototype.flatMap callback must return an iterable';
+
+  // Generic iterator errors
+  SErrorIteratorReturnMustBeCallable = 'Iterator return property must be callable';
+
+  // Iterator concat errors
+  SErrorIteratorConcatMustReturnObject = 'Iterator.concat: [Symbol.iterator]() must return an object';
+
+  // FFIPointer errors
+  SErrorFFIPointerRequiresFFIPointer = 'FFIPointer.%s requires an FFIPointer';
+
+  // Performance errors
+  SErrorPerformanceIncompatibleReceiver = 'Method Performance called on incompatible receiver';
+  SErrorIllegalConstructor = 'Illegal constructor';
+
+  // Math.sumPrecise errors
+  SErrorMathSumPreciseNotNumber = 'Math.sumPrecise: element is not a number';
+  SErrorMathSumPreciseNotIterable = 'Math.sumPrecise: argument is not iterable';
+
+  // JSONL errors
+  SErrorJSONLParseArgType = 'JSONL.parse: argument must be a string or Uint8Array';
+  SErrorJSONLParseChunkArgType = 'JSONL.parseChunk: argument must be a string or Uint8Array';
+
+  // ToPrimitive errors
+  SErrorCannotConvertToPrimitive = 'Cannot convert object to primitive value';
+
+  // Number method errors
+  SErrorToExponentialArgRange = 'toExponential() argument must be between 0 and 100';
+
+  // Map upsert errors
+  SErrorMapGetOrInsertComputedNotCallable = 'Map.getOrInsertComputed: callbackfn is not a function';
+
+  // Function body errors
+  SErrorIllegalBreakStatement = 'Illegal break statement';
+
+  // Function.prototype errors
+  SErrorFunctionApplyNonFunction = 'Function.prototype.apply called on non-function';
+
+  // Array utility errors
+  SErrorInvalidArrayIndexFmt = 'Invalid array index: %d';
+
+  // import.meta errors
+  SErrorImportMetaResolveRequiresArg = 'import.meta.resolve requires a specifier argument';
+
+  // Property assignment errors
+  SErrorCannotSetPropertyOnNonObject = 'Cannot set property on non-object';
+
+  // Semver errors
+  SErrorExpectedArrayOfVersions = 'Expected an array of versions';
+
+  // Symbol.keyFor errors
+  SErrorSymbolKeyForRequiresSymbol = 'Symbol.keyFor requires that the first argument be a symbol';
+
+  // FFI.open errors
+  SErrorFFIOpenRequiresPath = 'FFI.open requires a library path';
+
+  // btoa/atob errors
+  SErrorBtoaRequiresArg = 'Failed to execute ''btoa'': 1 argument required, but only 0 present.';
+  SErrorAtobRequiresArg = 'Failed to execute ''atob'': 1 argument required, but only 0 present.';
+
+  // Array method errors
+  SErrorArrayMethodCalledOnNonArray = 'Array.%s called on non-array';
+  SErrorArrayMethodExpectsCallback = 'Array.%s expects callback function';
+  SErrorCallbackMustBeFunction = 'Callback must be a function';
+  SErrorCallbackMustNotBeUndefined = 'Callback must not be undefined';
+  SErrorArrayFlatExpectsNumber = 'Array.flat expects depth argument to be a number';
+  SErrorArrayWithRequiresArgs = 'Array.with requires index and value arguments';
+  SErrorArrayCopyWithinRequiresTarget = 'Array.copyWithin requires a target argument';
+  SErrorCustomSortMustBeFunction = 'Custom sort function must be a function';
+
+  // Object static method errors — Object.create / defineProperty / defineProperties
+  SErrorObjectCreateCalledOnNonObject = 'Object.create called on non-object';
+  SErrorObjectDefinePropertyCalledOnNonObject = 'Object.defineProperty called on non-object';
+  SErrorObjectDefinePropertyDescriptorMustBeObject = 'Object.defineProperty: descriptor must be an object';
+  SErrorObjectDefinePropertiesCalledOnNonObject = 'Object.defineProperties called on non-object';
+  SErrorObjectDefinePropertiesMustBeObject = 'Object.defineProperties: properties must be an object';
+  SErrorObjectFromEntriesRequiresIterable = 'Object.fromEntries requires an iterable of key-value pairs';
+  SErrorObjectFromEntriesRequiresPairs = 'Object.fromEntries requires each entry to have at least 2 elements';
+  SErrorObjectGroupByRequiresIterable = 'Object.groupBy requires an iterable as first argument';
+  SErrorObjectGroupByRequiresCallback = 'Object.groupBy requires a callback function as second argument';
+  SErrorSetPrototypeOfTrapReturnedFalse = 'setPrototypeOf trap returned false';
+  SErrorSetPrototypeOfNonExtensible = 'Object.setPrototypeOf called on non-extensible object';
+
+  // Test assertion errors
+  SErrorFunctionExpectsStringFirst = '%s expects first argument to be a string';
+  SErrorFunctionExpectsFunctionSecond = '%s expects second argument to be a function';
+  SErrorFunctionExpectsTableArray = '%s expects a table array';
+  SErrorFunctionExpectsFunctionArg = '%s expects a function argument';
+  SErrorToThrowExpectsFunction = 'toThrow expects actual value to be a function';
+  SErrorToHaveBeenCalledTimesExpectsInt = 'toHaveBeenCalledTimes expects a non-negative integer';
+  SErrorToHaveBeenNthCalledWithRequiresArg = 'toHaveBeenNthCalledWith requires at least 1 argument (call index)';
+  SErrorToHaveBeenNthCalledWithExpectsInt = 'toHaveBeenNthCalledWith expects a positive integer index';
+  SErrorToHaveReturnedTimesExpectsInt = 'toHaveReturnedTimes expects a non-negative integer';
+  SErrorToHaveNthReturnedWithExpectsInt = 'toHaveNthReturnedWith expects a positive integer index';
+  SErrorMockExpectsFunctionOrNoArgs = 'mock() expects a function argument or no arguments';
+  SErrorSpyOnExpectsObject = 'spyOn expects first argument to be an object';
+  SErrorSpyOnExpectsString = 'spyOn expects second argument to be a string (method name)';
+  SErrorSpyOnNonExistentProperty = 'spyOn: cannot spy on non-existent property "%s"';
+  SErrorSpyOnPropertyNotFunction = 'spyOn: property "%s" is not a function';
+  SErrorTestTodoExpectsString = 'test.todo expects first argument to be a string';
+  SErrorOnTestFinishedExpectsFunction = 'onTestFinished expects a function argument';
+
+  // Other builtin errors — YAML / TOML / Map / Math / Semver / JSON5
+  SErrorYAMLParseArgMustBeString = 'YAML.parse: argument must be a string';
+  SErrorYAMLParseDocumentsArgMustBeString = 'YAML.parseDocuments: argument must be a string';
+  SErrorTOMLParseArgMustBeString = 'TOML.parse: argument must be a string';
+  SErrorMapGroupByRequiresIterable = 'Map.groupBy requires an iterable as first argument';
+  SErrorMapGroupByRequiresCallback = 'Map.groupBy requires a callback function as second argument';
+  SErrorMathClampInvalidRange = 'Invalid range in Math.clamp';
+  SErrorSemverInvalidIncrement = 'invalid increment';
+  SErrorJSON5StringifyError = 'JSON5.stringify error: %s';
+
+implementation
+
+end.

--- a/units/Goccia.Error.Suggestions.pas
+++ b/units/Goccia.Error.Suggestions.pas
@@ -148,6 +148,207 @@ resourcestring
   SSuggestInvalidCharacter = 'This character is not valid in GocciaScript. Check for typos';
   SSuggestInvalidDoubleDot = 'Did you mean "..." (spread operator)? Two dots is not valid syntax';
 
+  // Runtime errors — scope
+  SSuggestTemporalDeadZone = 'the variable is in the temporal dead zone until its declaration is evaluated';
+  SSuggestDeclareBeforeUse = 'check the spelling or declare the variable with const, let, or var before use';
+  SSuggestUseLetNotConst = 'declare with ''let'' instead of ''const'' if it needs to be reassigned';
+  SSuggestAlreadyDeclared = 'the variable was already declared with let or const in this scope';
+
+  // Runtime errors — type and call
+  SSuggestSymbolNoImplicitConversion = 'use String(symbol) or symbol.toString() for explicit conversion';
+  SSuggestDecoratorFunction = 'decorators must be expressions that evaluate to a function';
+  SSuggestDisposable = 'the value must have a [Symbol.dispose] method to be used with ''using''';
+  SSuggestNotFunctionType = 'the value is not callable — only functions can be invoked';
+  SSuggestNotConstructorType = 'only classes and constructor functions can be used with ''new''';
+  SSuggestPropertyOfNullish = 'the value is null or undefined and has no properties';
+  SSuggestNotIterable = 'only arrays, strings, sets, maps, and objects with Symbol.iterator can be iterated';
+  SSuggestSpreadRequiresIterable = 'only arrays, strings, sets, maps, and objects with Symbol.iterator can be spread';
+  SSuggestTaggedTemplateCallable = 'tagged template literals require the tag to be a callable function';
+  SSuggestDestructureRequiresIterable = 'array destructuring requires an iterable value';
+  SSuggestDestructureRequiresObject = 'object destructuring requires an object value';
+  SSuggestIteratorProtocol = 'the value does not implement the iterator protocol';
+  SSuggestCheckNullBeforeAccess = 'check that the value is not null or undefined before accessing properties';
+  SSuggestCannotDeleteNonConfigurable = 'non-configurable properties cannot be deleted';
+  SSuggestPrivateFieldAccess = 'private fields and accessors are only accessible within the class that defines them';
+  SSuggestRequiresNew = 'class constructors must be called with ''new''';
+  SSuggestEnumValueType = 'enum member values must be number, string, or symbol literals';
+  SSuggestUsingInsideBlock = '''using'' declarations must be inside a block (e.g., { using x = ...; })';
+  SSuggestAwaitMicrotaskDrain = 'the promise did not resolve during the microtask queue drain cycle';
+  SSuggestAsyncIteratorProtocol = 'the async iterator must have a callable next() method';
+  SSuggestIteratorResultObject = 'iterator next() must return an object with ''done'' and ''value'' properties';
+  SSuggestTypeEnforcement = 'the value type does not match the declared type';
+
+  // Runtime errors — array
+  SSuggestSpeciesConstructor = 'Symbol.species must return a constructor function';
+  SSuggestArrayLengthRange = 'array length must be a non-negative integer less than 2^32';
+  SSuggestReduceInitialValue = 'provide an initial value as the second argument to reduce()';
+
+  // Runtime errors — promises
+  SSuggestPromiseThisType = 'Promise prototype methods must be called on a Promise object';
+  SSuggestPromiseResolver = 'pass a function to the Promise constructor: new Promise((resolve, reject) => { ... })';
+  SSuggestPromiseAnyRejected = 'Promise.any() requires at least one promise to fulfill';
+  SSuggestCallbackRequired = 'pass a function as the argument';
+
+  // Runtime errors — ArrayBuffer
+  SSuggestArrayBufferThisType = 'ArrayBuffer methods must be called on an ArrayBuffer instance';
+  SSuggestArrayBufferDetached = 'the ArrayBuffer has been detached (transferred) and can no longer be used';
+  SSuggestArrayBufferResizable = 'create a resizable ArrayBuffer with: new ArrayBuffer(length, { maxByteLength: ... })';
+
+  // Runtime errors — DisposableStack
+  SSuggestDisposableStackThisType = 'DisposableStack methods must be called on a DisposableStack instance';
+  SSuggestDisposableStackAlreadyDisposed = 'the DisposableStack has already been disposed and cannot be used again';
+
+  // Runtime errors — iterator helpers
+  SSuggestIteratorThisType = 'iterator helper methods must be called on an iterator object';
+  SSuggestIteratorZipMode = 'valid modes are "shortest", "longest", or "strict"';
+  SSuggestIteratorCallable = 'pass a function as the first argument';
+  SSuggestIteratorFlatMapCallable = 'pass a function that returns an iterable';
+  SSuggestIteratorNonNegative = 'pass a non-negative integer as the argument';
+  SSuggestIteratorFromArg = 'pass an array, string, set, map, or object with Symbol.iterator or a next() method';
+  SSuggestIteratorZipOptions = 'pass an options object with mode and/or padding properties';
+  SSuggestIteratorZipKeyedArg = 'pass an object whose values are iterables';
+  SSuggestIteratorZipKeyedPadding = 'pass an object whose keys match the iterable keys';
+  SSuggestArrayFromMapFn = 'usage: Array.from(iterable [, mapFn [, thisArg]])';
+
+  // Runtime errors — object property constraints
+  SSuggestPropertyHasOnlyGetter = 'the property has only a getter and no setter defined';
+  SSuggestObjectNotExtensible = 'the object has been frozen, sealed, or marked non-extensible with Object.preventExtensions()';
+  SSuggestPrototypeChainTooDeep = 'check for circular prototype chains';
+  SSuggestPropertyDescriptorObject = 'pass an object with writable, enumerable, configurable, value, get, or set properties';
+
+  // Runtime errors — string
+  SSuggestWellKnownSymbolCallable = 'the well-known Symbol method must be a function on the object';
+  SSuggestReplaceAllGlobalFlag = 'add the ''g'' flag to the RegExp: /pattern/g';
+  SSuggestRepeatCountRange = 'the count must be a non-negative finite integer';
+  SSuggestNormalizationForm = 'valid forms are NFC, NFD, NFKC, or NFKD';
+
+  // Runtime errors — regexp
+  SSuggestRegExpEscapeString = 'pass a string to escape special regex characters';
+  SSuggestRegExpThisType = 'RegExp prototype methods must be called on a RegExp object';
+
+  // Runtime errors — code points
+  SSuggestCodePointRange = 'code points must be integers between 0 and 0x10FFFF';
+
+  // Runtime errors — Temporal
+  SSuggestTemporalISOFormat = 'provide a valid ISO 8601 string (e.g., "2024-01-15", "2024-01-15T10:30:00")';
+  SSuggestTemporalFromArg = 'pass a string in ISO 8601 format, an existing Temporal object, or a property bag';
+  SSuggestTemporalCompareArg = 'both arguments must be the same Temporal type or valid ISO strings';
+  SSuggestTemporalWithObject = 'pass an object with the date/time fields to update (e.g., { year: 2025 })';
+  SSuggestTemporalDurationArg = 'pass a Temporal.Duration, a duration string (e.g., "P1Y2M"), or a duration-like object';
+  SSuggestTemporalRoundArg = 'pass a unit string (e.g., "hour") or an options object with smallestUnit';
+  SSuggestTemporalNoValueOf = 'Temporal objects cannot be implicitly converted; use toString() or compare() instead';
+  SSuggestTemporalValidUnits = 'valid units are: year, month, week, day, hour, minute, second, millisecond, microsecond, nanosecond';
+  SSuggestTemporalDurationSigns = 'all duration fields must have the same sign (all positive or all negative)';
+  SSuggestTemporalRelativeTo = 'pass a relativeTo option with a PlainDate or ZonedDateTime for calendar-sensitive operations';
+  SSuggestTemporalOverflow = 'valid overflow options are "constrain" or "reject"';
+  SSuggestTemporalRoundingMode = 'valid modes: ceil, floor, expand, trunc, halfCeil, halfFloor, halfExpand, halfTrunc, halfEven';
+  SSuggestTemporalTimezone = 'provide a timezone string (e.g., "UTC", "America/New_York") or a Temporal.TimeZone';
+  SSuggestTemporalDateRange = 'check that month is 1-12 and day is valid for the month';
+  SSuggestTemporalMonthCode = 'valid monthCodes are M01 through M12';
+  SSuggestTemporalThisType = 'this method must be called on a Temporal object of the correct type';
+  SSuggestTemporalToPlainDateYear = 'pass an object with a year property (e.g., { year: 2024 })';
+
+  // Runtime errors — Proxy
+  SSuggestProxyRevoked = 'the proxy has been revoked and can no longer be used';
+  SSuggestProxyTrapInvariant = 'proxy trap must respect the invariants of the target object''s property configuration';
+  SSuggestProxyTrapReturnType = 'the proxy trap must return the correct type for the operation';
+  SSuggestProxyTargetType = 'Proxy requires both target and handler to be objects';
+
+  // Runtime errors — TypedArray
+  SSuggestTypedArrayThisType = 'TypedArray methods must be called on a TypedArray instance';
+  SSuggestTypedArrayCallable = 'pass a function as the callback argument';
+  SSuggestTypedArraySetSource = 'pass an Array or TypedArray as the source';
+  SSuggestTypedArrayLength = 'the length or offset is outside the valid range for this buffer';
+  SSuggestTypedArrayAlignment = 'the byte offset must be aligned to the element size of the TypedArray';
+
+  // Runtime errors — URL
+  SSuggestURLThisType = 'URL prototype methods must be called on a URL object';
+  SSuggestURLFormat = 'provide a valid URL string (e.g., "https://example.com/path")';
+
+  // Runtime errors — URLSearchParams
+  SSuggestURLSearchParamsThisType = 'URLSearchParams methods must be called on a URLSearchParams instance';
+  SSuggestURLSearchParamsInit = 'pass a string, array of pairs, or object to construct URLSearchParams';
+
+  // Runtime errors — array methods
+  SSuggestArrayThisType = 'Array prototype methods must be called on an Array';
+
+  // Runtime errors — Uint8Array encoding
+  SSuggestBase64Format = 'provide a valid base64 string using the standard or base64url alphabet';
+  SSuggestHexFormat = 'provide a valid hex string with an even number of hex digits (0-9, a-f)';
+  SSuggestUint8ArrayThisType = 'Uint8Array encoding methods must be called on a Uint8Array instance';
+
+  // Runtime errors — FFI
+  SSuggestFFIUsage = 'check the FFI function signature and argument types';
+  SSuggestFFILibraryOpen = 'open a library first with FFI.open("path/to/library")';
+
+  // Runtime errors — test framework
+  SSuggestTestUsage = 'check the test framework API documentation for correct usage';
+
+  // Runtime errors — Object.*
+  SSuggestObjectArgType = 'pass an object as the argument';
+
+  // Runtime errors — JSON/JSON5/JSONL
+  SSuggestJSONFormat = 'ensure the string contains valid JSON';
+
+  // Runtime errors — URI encoding
+  SSuggestURIEncoding = 'check that the URI string contains only valid percent-encoded sequences';
+
+  // Runtime errors — TextDecoder/TextEncoder
+  SSuggestTextDecoderThisType = 'TextDecoder methods must be called on a TextDecoder instance';
+  SSuggestTextEncoderThisType = 'TextEncoder methods must be called on a TextEncoder instance';
+
+  // Runtime errors — SharedArrayBuffer
+  SSuggestSharedArrayBufferThisType = 'SharedArrayBuffer methods must be called on a SharedArrayBuffer instance';
+
+  // Runtime errors — Reflect
+  SSuggestReflectObjectArg = 'Reflect methods require the target to be an object';
+
+  // Runtime errors — Symbol
+  SSuggestSymbolThisType = 'Symbol prototype methods must be called on a Symbol';
+  SSuggestSymbolKeyForArg = 'pass a Symbol value to Symbol.keyFor (e.g., Symbol.for("key"))';
+
+  // Runtime errors — Performance
+  SSuggestPerformanceThisType = 'Performance methods must be called on a Performance instance';
+
+  // Runtime errors — string argument required
+  SSuggestStringArgRequired = 'pass a string as the argument';
+
+  // Runtime errors — Semver
+  SSuggestSemverUsage = 'check the semver API documentation for correct usage';
+
+  // Runtime errors — import.meta
+  SSuggestImportMetaUsage = 'import.meta.resolve() requires a string specifier argument';
+
+  // Runtime errors — Map
+  SSuggestMapCallbackRequired = 'pass a function as the callback argument';
+
+  // Runtime errors — Number
+  SSuggestNumberRange = 'the argument must be within the valid range';
+
+  // Runtime errors — ToPrimitive
+  SSuggestToPrimitive = 'define a valueOf() or toString() method on the object';
+
+  // Runtime errors — Function
+  SSuggestFunctionApply = 'Function.prototype.apply requires a callable this value';
+
+  // Runtime errors — illegal constructor
+  SSuggestIllegalConstructor = 'this constructor cannot be called directly';
+
+  // Runtime errors — structuredClone
+  SSuggestStructuredClone = 'only plain objects, arrays, primitives, and built-in types can be cloned';
+
+  // Runtime errors — TOML
+  SSuggestTOMLSyntax = 'check that the input is valid TOML syntax';
+
+  // Runtime errors — YAML
+  SSuggestYAMLSyntax = 'check that the input is valid YAML syntax';
+
+  // Runtime errors — TextEncoder
+  SSuggestTextEncoderEncodeIntoArgs = 'encodeInto requires a string source and a Uint8Array destination';
+
+  // Runtime errors — read-only property
+  SSuggestReadOnlyProperty = 'the property is read-only and cannot be assigned to';
+
 implementation
 
 end.

--- a/units/Goccia.Evaluator.Arithmetic.pas
+++ b/units/Goccia.Evaluator.Arithmetic.pas
@@ -21,6 +21,8 @@ implementation
 uses
   Math,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator.Bitwise,
   Goccia.Values.ErrorHelper,
   Goccia.Values.SymbolValue,
@@ -38,7 +40,7 @@ function ToNumericPair(const ALeft, ARight: TGocciaValue;
   out ALeftNum, ARightNum: TGocciaNumberLiteralValue): Boolean;
 begin
   if (ALeft is TGocciaSymbolValue) or (ARight is TGocciaSymbolValue) then
-    ThrowTypeError('Cannot convert a Symbol value to a number');
+    ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
   ALeftNum := ALeft.ToNumberLiteral;
   ARightNum := ARight.ToNumberLiteral;
   Result := not (ALeftNum.IsNaN or ARightNum.IsNaN);
@@ -53,7 +55,7 @@ begin
   PrimRight := ToPrimitive(ARight);
 
   if (PrimLeft is TGocciaSymbolValue) or (PrimRight is TGocciaSymbolValue) then
-    ThrowTypeError('Cannot convert a Symbol value to a string');
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
 
   if (PrimLeft is TGocciaStringLiteralValue) or (PrimRight is TGocciaStringLiteralValue) then
   begin

--- a/units/Goccia.Evaluator.Assignment.pas
+++ b/units/Goccia.Evaluator.Assignment.pas
@@ -23,6 +23,8 @@ function PerformIncrement(const AOldValue: TGocciaValue; const AIsIncrement: Boo
 implementation
 
 uses
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator.Arithmetic,
   Goccia.Values.ClassValue,
   Goccia.Values.ErrorHelper,
@@ -38,7 +40,7 @@ begin
     // a JavaScript-level TypeError (TGocciaThrowValue), not an interpreter-level
     // runtime error (TGocciaRuntimeError) which is what AOnError produces.
     // The Assigned check guards against raising in contexts without error handling.
-    ThrowTypeError('Cannot set property on non-object');
+    ThrowTypeError(SErrorCannotSetPropertyOnNonObject, SSuggestCheckNullBeforeAccess);
 end;
 
 procedure PerformPropertyCompoundAssignment(const AObj: TGocciaValue; const APropertyName: string; const AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer);

--- a/units/Goccia.Evaluator.TypeOperations.pas
+++ b/units/Goccia.Evaluator.TypeOperations.pas
@@ -23,6 +23,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Keywords.Reserved,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -150,8 +152,9 @@ var
 begin
   // ECMAScript: right operand must be an object, not a primitive
   if ARight.IsPrimitive then
-    ThrowTypeError('Cannot use ''' + KEYWORD_IN + ''' operator to search for ''' +
-      ALeft.ToStringLiteral.Value + ''' in ' + ARight.ToStringLiteral.Value);
+    ThrowTypeError(Format(SErrorCannotUseInOperator,
+      [ALeft.ToStringLiteral.Value, ARight.ToStringLiteral.Value]),
+      SSuggestCheckNullBeforeAccess);
 
   if ALeft is TGocciaSymbolValue then
   begin

--- a/units/Goccia.Evaluator.pas
+++ b/units/Goccia.Evaluator.pas
@@ -95,6 +95,8 @@ uses
   Goccia.Coverage,
   Goccia.DisposalTracker,
   Goccia.Error,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator.Arithmetic,
   Goccia.Evaluator.Assignment,
   Goccia.Evaluator.Bitwise,
@@ -251,9 +253,9 @@ begin
       end;
     end
     else
-      ThrowTypeError(Format(
-        'Spread syntax requires an iterable — ''%s'' is not iterable. Only arrays, strings, sets, maps, and objects with Symbol.iterator can be spread',
-        [ASpreadValue.TypeName]));
+      ThrowTypeError(
+        SErrorSpreadRequiresIterable,
+        SSuggestSpreadRequiresIterable);
   end;
 end;
 
@@ -452,7 +454,7 @@ begin
     gttMinus:
       begin
         if Operand is TGocciaSymbolValue then
-          ThrowTypeError('Cannot convert a Symbol value to a number');
+          ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
         if (Operand is TGocciaNumberLiteralValue) then
         begin
           if TGocciaNumberLiteralValue(Operand).IsInfinity then
@@ -476,7 +478,7 @@ begin
     gttPlus:
     begin
       if Operand is TGocciaSymbolValue then
-        ThrowTypeError('Cannot convert a Symbol value to a number');
+        ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
       Result := Operand.ToNumberLiteral;
     end;
     gttTypeof:
@@ -624,22 +626,30 @@ begin
           MemberExpr := TGocciaMemberExpression(ACallExpression.Callee);
 
         if Assigned(MemberExpr) and (MemberExpr.ObjectExpr is TGocciaIdentifierExpression) then
-          ThrowTypeError(Format('%s.%s is not a function — ''%s'' is of type ''%s'' which does not have method ''%s''',
-            [TGocciaIdentifierExpression(MemberExpr.ObjectExpr).Name,
-             MemberExpr.PropertyName,
-             TGocciaIdentifierExpression(MemberExpr.ObjectExpr).Name,
-             ThisValue.TypeName,
-             MemberExpr.PropertyName]))
+          ThrowTypeError(
+            Format(SErrorMemberNotFunction,
+              [TGocciaIdentifierExpression(MemberExpr.ObjectExpr).Name,
+               MemberExpr.PropertyName]),
+            Format('''%s'' is of type ''%s'' which does not have method ''%s''',
+              [TGocciaIdentifierExpression(MemberExpr.ObjectExpr).Name,
+               ThisValue.TypeName,
+               MemberExpr.PropertyName]))
         else if Assigned(MemberExpr) then
-          ThrowTypeError(Format('''%s'' is of type ''%s'' which does not have method ''%s''',
-            [ThisValue.TypeName, ThisValue.TypeName, MemberExpr.PropertyName]))
+          ThrowTypeError(
+            Format(SErrorMemberNotFunction,
+              [ThisValue.TypeName, MemberExpr.PropertyName]),
+            Format('''%s'' is of type ''%s'' which does not have method ''%s''',
+              [ThisValue.TypeName, ThisValue.TypeName, MemberExpr.PropertyName]))
         else if ACallExpression.Callee is TGocciaIdentifierExpression then
-          ThrowTypeError(Format('''%s'' is not a function — ''%s'' is of type ''%s'' and cannot be called as a function',
-            [TGocciaIdentifierExpression(ACallExpression.Callee).Name,
-             TGocciaIdentifierExpression(ACallExpression.Callee).Name,
-             Callee.TypeName]))
+          ThrowTypeError(
+            Format(SErrorNotFunction,
+              [TGocciaIdentifierExpression(ACallExpression.Callee).Name]),
+            Format('''%s'' is of type ''%s'' and cannot be called as a function',
+              [TGocciaIdentifierExpression(ACallExpression.Callee).Name,
+               Callee.TypeName]))
         else
-          ThrowTypeError(Format('%s is not a function', [Callee.TypeName]));
+          ThrowTypeError(Format(SErrorValueNotFunction, [Callee.TypeName]),
+            SSuggestNotFunctionType);
       end;
     finally
       if Assigned(TGocciaCallStack.Instance) then
@@ -750,7 +760,8 @@ begin
     if PropertyValue is TGocciaSymbolValue then
     begin
       if (Obj is TGocciaNullLiteralValue) or (Obj is TGocciaUndefinedLiteralValue) then
-        ThrowTypeError('Cannot read properties of ' + Obj.ToStringLiteral.Value + ' (reading ''Symbol()'')');
+        ThrowTypeError(Format(SErrorCannotReadPropertiesOf, [Obj.ToStringLiteral.Value, 'Symbol()']),
+          SSuggestCheckNullBeforeAccess);
 
       if Obj is TGocciaClassValue then
       begin
@@ -795,21 +806,24 @@ begin
     else if (Obj is TGocciaNullLiteralValue) or (Obj is TGocciaUndefinedLiteralValue) then
     begin
       if AMemberExpression.ObjectExpr is TGocciaMemberExpression then
-        ThrowTypeError(Format(
-          'Cannot read property ''%s'' of %s — ''%s'' evaluated to %s and does not have property ''%s''',
-          [PropertyName, Obj.ToStringLiteral.Value,
-           TGocciaMemberExpression(AMemberExpression.ObjectExpr).PropertyName,
-           Obj.ToStringLiteral.Value, PropertyName]))
+        ThrowTypeError(
+          Format(SErrorCannotReadPropertyOf,
+            [PropertyName, Obj.ToStringLiteral.Value]),
+          Format('''%s'' evaluated to %s and does not have property ''%s''',
+            [TGocciaMemberExpression(AMemberExpression.ObjectExpr).PropertyName,
+             Obj.ToStringLiteral.Value, PropertyName]))
       else if AMemberExpression.ObjectExpr is TGocciaIdentifierExpression then
-        ThrowTypeError(Format(
-          'Cannot read property ''%s'' of %s — ''%s'' is %s and does not have property ''%s''',
-          [PropertyName, Obj.ToStringLiteral.Value,
-           TGocciaIdentifierExpression(AMemberExpression.ObjectExpr).Name,
-           Obj.ToStringLiteral.Value, PropertyName]))
+        ThrowTypeError(
+          Format(SErrorCannotReadPropertyOf,
+            [PropertyName, Obj.ToStringLiteral.Value]),
+          Format('''%s'' is %s and does not have property ''%s''',
+            [TGocciaIdentifierExpression(AMemberExpression.ObjectExpr).Name,
+             Obj.ToStringLiteral.Value, PropertyName]))
       else
         ThrowTypeError(Format(
-          'Cannot read property ''%s'' of %s',
-          [PropertyName, Obj.ToStringLiteral.Value]));
+          SErrorCannotReadPropertyOf,
+          [PropertyName, Obj.ToStringLiteral.Value]),
+          SSuggestCheckNullBeforeAccess);
     end
     else
     begin
@@ -1101,7 +1115,7 @@ begin
     else if Promise.State = gpsRejected then
       raise TGocciaThrowValue.Create(Promise.PromiseResult)
     else
-      ThrowTypeError('await: Promise did not settle after microtask drain');
+      ThrowTypeError(SErrorAwaitPromiseUnsettled, SSuggestAwaitMicrotaskDrain);
   finally
     if Assigned(TGarbageCollector.Instance) then
       TGarbageCollector.Instance.RemoveTempRoot(Promise);
@@ -1133,13 +1147,16 @@ begin
   if Iterator = nil then
   begin
     if AForOfStatement.Iterable is TGocciaIdentifierExpression then
-      ThrowTypeError(Format('''%s'' is not iterable — ''%s'' is of type ''%s'' which does not implement the iterator protocol',
-        [TGocciaIdentifierExpression(AForOfStatement.Iterable).Name,
-         TGocciaIdentifierExpression(AForOfStatement.Iterable).Name,
-         IterableValue.TypeName]))
+      ThrowTypeError(
+        Format(SErrorNotIterable,
+          [TGocciaIdentifierExpression(AForOfStatement.Iterable).Name]),
+        Format('''%s'' is of type ''%s'' which does not implement the iterator protocol',
+          [TGocciaIdentifierExpression(AForOfStatement.Iterable).Name,
+           IterableValue.TypeName]))
     else
-      ThrowTypeError(Format('''%s'' is not iterable — values of type ''%s'' do not implement the iterator protocol',
-        [IterableValue.TypeName, IterableValue.TypeName]));
+      ThrowTypeError(
+        Format(SErrorNotIterable, [IterableValue.TypeName]),
+        SSuggestIteratorProtocol);
   end;
 
   if AForOfStatement.IsConst then
@@ -1218,7 +1235,7 @@ begin
       try
         NextMethod := IteratorObj.GetProperty(PROP_NEXT);
         if not Assigned(NextMethod) or not NextMethod.IsCallable then
-          ThrowTypeError('Async iterator .next is not callable');
+          ThrowTypeError(SErrorAsyncIteratorNextNotCallable, SSuggestAsyncIteratorProtocol);
 
         while True do
         begin
@@ -1228,7 +1245,8 @@ begin
 
           // ES2026 §7.4.2 step 5: If nextResult is not an Object, throw a TypeError
           if NextResult.IsPrimitive then
-            ThrowTypeError('Iterator result ' + NextResult.ToStringLiteral.Value + ' is not an object');
+            ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.ToStringLiteral.Value]),
+              SSuggestIteratorResultObject);
 
           DoneValue := NextResult.GetProperty(PROP_DONE);
           if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
@@ -1263,9 +1281,9 @@ begin
   begin
     Iterator := GetIteratorFromValue(IterableValue);
     if Iterator = nil then
-      ThrowTypeError(Format(
-        '''%s'' is not iterable — values of type ''%s'' do not implement the iterator protocol',
-        [IterableValue.TypeName, IterableValue.TypeName]));
+      ThrowTypeError(
+        Format(SErrorNotIterable, [IterableValue.TypeName]),
+        SSuggestIteratorProtocol);
 
     if Assigned(TGarbageCollector.Instance) then
       TGarbageCollector.Instance.AddTempRoot(Iterator);
@@ -1562,7 +1580,7 @@ begin
   // The disposal tracker should have been set by EvaluateBlock
   if (AContext.DisposalTracker = nil) or
      not (AContext.DisposalTracker is TGocciaDisposalTracker) then
-    ThrowTypeError('using declaration outside of a block scope');
+    ThrowTypeError(SErrorUsingOutsideBlock, SSuggestUsingInsideBlock);
   Tracker := TGocciaDisposalTracker(AContext.DisposalTracker);
 
   if AUsingDeclaration.IsAwait then
@@ -1592,9 +1610,9 @@ begin
       if not Assigned(DisposeMethod) then
       begin
         if Hint = dhAsyncDispose then
-          ThrowTypeError('Value is not disposable (missing [Symbol.asyncDispose] and [Symbol.dispose])')
+          ThrowTypeError(SErrorNotAsyncDisposable, SSuggestDisposable)
         else
-          ThrowTypeError('Value is not disposable (missing [Symbol.dispose])');
+          ThrowTypeError(SErrorNotDisposable, SSuggestDisposable);
       end;
 
       // Bind the variable as const (using bindings are not reassignable)
@@ -1801,7 +1819,7 @@ begin
       if not ((MemberValue is TGocciaNumberLiteralValue) or
               (MemberValue is TGocciaStringLiteralValue) or
               (MemberValue is TGocciaSymbolValue)) then
-        ThrowTypeError('Enum member initializer must evaluate to a Number, String, or Symbol value');
+        ThrowTypeError(SErrorEnumInitializer, SSuggestEnumValueType);
 
       EnumValue.DefineProperty(AEnumDeclaration.Members[I].Name,
         TGocciaPropertyDescriptorData.Create(MemberValue, [pfEnumerable]));
@@ -2003,13 +2021,17 @@ begin
       else
       begin
         if ANewExpression.Callee is TGocciaIdentifierExpression then
-          ThrowTypeError(Format('''%s'' is not a constructor — ''%s'' is of type ''%s'' and cannot be used with ''new''',
-            [TGocciaIdentifierExpression(ANewExpression.Callee).Name,
-             TGocciaIdentifierExpression(ANewExpression.Callee).Name,
-             Callee.TypeName]))
+          ThrowTypeError(
+            Format(SErrorNotConstructor,
+              [TGocciaIdentifierExpression(ANewExpression.Callee).Name]),
+            Format('''%s'' is of type ''%s'' and cannot be used with ''new''',
+              [TGocciaIdentifierExpression(ANewExpression.Callee).Name,
+               Callee.TypeName]))
         else
-          ThrowTypeError(Format('%s is not a constructor — values of type ''%s'' cannot be used with ''new''',
-            [Callee.TypeName, Callee.TypeName]));
+          ThrowTypeError(
+            Format(SErrorValueNotConstructor, [Callee.TypeName]),
+            Format('values of type ''%s'' cannot be used with ''new''',
+              [Callee.TypeName]));
       end;
     finally
       if Assigned(TGocciaCallStack.Instance) then
@@ -2410,7 +2432,7 @@ begin
       begin
         DecoratorFn := EvaluatedElementDecorators[I][J];
         if not DecoratorFn.IsCallable then
-          ThrowTypeError('Decorator must be a function');
+          ThrowTypeError(SErrorDecoratorMustBeFunction, SSuggestDecoratorFunction);
 
         // Build context object
         ContextObject := TGocciaObjectValue.Create;
@@ -2624,7 +2646,7 @@ begin
     begin
       DecoratorFn := EvaluatedClassDecorators[I];
       if not DecoratorFn.IsCallable then
-        ThrowTypeError('Decorator must be a function');
+        ThrowTypeError(SErrorDecoratorMustBeFunction, SSuggestDecoratorFunction);
 
       ContextObject := TGocciaObjectValue.Create;
       ContextObject.AssignProperty(PROP_KIND, TGocciaStringLiteralValue.Create('class'));
@@ -2740,19 +2762,20 @@ end;
 
 procedure ThrowPrivateGetterMissingError(const APrivateName: string);
 begin
-  ThrowTypeError(Format('Private accessor #%s was defined without a getter',
-    [APrivateName]));
+  ThrowTypeError(Format(SErrorPrivateGetterMissing,
+    [APrivateName]), SSuggestPrivateFieldAccess);
 end;
 
 procedure ThrowPrivateSetterMissingError(const APrivateName: string);
 begin
-  ThrowTypeError(Format('Private accessor #%s was defined without a setter',
-    [APrivateName]));
+  ThrowTypeError(Format(SErrorPrivateSetterMissing,
+    [APrivateName]), SSuggestPrivateFieldAccess);
 end;
 
 procedure ThrowPrivateBrandError(const APrivateName: string);
 begin
-  ThrowTypeError(Format('Private field #%s is not accessible', [APrivateName]));
+  ThrowTypeError(Format(SErrorPrivateFieldInaccessible, [APrivateName]),
+    SSuggestPrivateFieldAccess);
 end;
 
 procedure EnsurePrivateStaticBrand(const AReceiver,
@@ -3235,7 +3258,7 @@ begin
     else
     begin
       if PartValue is TGocciaSymbolValue then
-        ThrowTypeError('Cannot convert a Symbol value to a string');
+        ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
       // ES2026 §13.15.5.1 step 5e: ToString(value) on each substitution
       SB.Append(ToECMAString(PartValue).Value);
     end;
@@ -3344,9 +3367,9 @@ begin
       else if Callee is TGocciaFunctionBase then
         Result := TGocciaFunctionBase(Callee).Call(Arguments, ThisValue)
       else
-        ThrowTypeError(Format(
-          '%s is not a function — tagged template literals require the tag to be a callable function',
-          [Callee.TypeName]));
+        ThrowTypeError(
+          Format(SErrorValueNotFunction, [Callee.TypeName]),
+          SSuggestTaggedTemplateCallable);
     finally
       if Assigned(TGocciaCallStack.Instance) then
         TGocciaCallStack.Instance.Pop;
@@ -3494,7 +3517,7 @@ begin
         if (LeftVal <> nil) and (RightVal <> nil) then
         begin
           if (LeftVal is TGocciaSymbolValue) or (RightVal is TGocciaSymbolValue) then
-            ThrowTypeError('Cannot convert a Symbol value to a string');
+            ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
           if (LeftVal is TGocciaStringLiteralValue) or (RightVal is TGocciaStringLiteralValue) then
             Result := TGocciaStringLiteralValue.Create(LeftVal.ToStringLiteral.Value + RightVal.ToStringLiteral.Value)
           else
@@ -3686,9 +3709,9 @@ var
   J: Integer;
 begin
   if (AValue is TGocciaNullLiteralValue) or (AValue is TGocciaUndefinedLiteralValue) then
-    ThrowTypeError(Format(
-      'Cannot destructure %s — array destructuring requires an iterable value',
-      [AValue.ToStringLiteral.Value]));
+    ThrowTypeError(
+      Format(SErrorCannotDestructure, [AValue.ToStringLiteral.Value]),
+      SSuggestDestructureRequiresIterable);
 
   if AValue is TGocciaArrayValue then
   begin
@@ -3753,9 +3776,9 @@ begin
   begin
     Iterator := GetIteratorFromValue(AValue);
     if not Assigned(Iterator) then
-      ThrowTypeError(Format(
-        '''%s'' is not iterable — array destructuring requires an iterable value (array, string, set, map, or object with Symbol.iterator)',
-        [AValue.TypeName]));
+      ThrowTypeError(
+        Format(SErrorNotIterable, [AValue.TypeName]),
+        SSuggestDestructureRequiresIterable);
 
     TGarbageCollector.Instance.AddTempRoot(Iterator);
     try
@@ -3811,13 +3834,13 @@ begin
   if not (AValue is TGocciaObjectValue) then
   begin
     if (AValue is TGocciaNullLiteralValue) or (AValue is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(Format(
-        'Cannot destructure %s — object destructuring requires an object value',
-        [AValue.ToStringLiteral.Value]))
+      ThrowTypeError(
+        Format(SErrorCannotDestructure, [AValue.ToStringLiteral.Value]),
+        SSuggestDestructureRequiresObject)
     else
-      ThrowTypeError(Format(
-        'Cannot destructure value of type ''%s'' — object destructuring requires an object value',
-        [AValue.TypeName]));
+      ThrowTypeError(
+        Format(SErrorCannotDestructureType, [AValue.TypeName]),
+        SSuggestDestructureRequiresObject);
   end;
 
   ObjectValue := TGocciaObjectValue(AValue);
@@ -3957,7 +3980,8 @@ begin
       else
       begin
         if not ArrayValue.DeleteProperty(PropertyName) then
-          ThrowTypeError('Cannot delete property ''' + PropertyName + ''' of [object Array]');
+          ThrowTypeError(Format(SErrorCannotDeletePropertyOf, [PropertyName, '[object Array]']),
+            SSuggestCannotDeleteNonConfigurable);
         Result := TGocciaBooleanLiteralValue.TrueValue;
       end;
     end
@@ -3965,7 +3989,8 @@ begin
     begin
       ObjectValue := TGocciaObjectValue(ObjValue);
       if not ObjectValue.DeleteProperty(PropertyName) then
-        ThrowTypeError('Cannot delete property ''' + PropertyName + ''' of [object Object]');
+        ThrowTypeError(Format(SErrorCannotDeletePropertyOf, [PropertyName, '[object Object]']),
+          SSuggestCannotDeleteNonConfigurable);
       Result := TGocciaBooleanLiteralValue.TrueValue;
     end
     else

--- a/units/Goccia.ImportMeta.pas
+++ b/units/Goccia.ImportMeta.pas
@@ -32,6 +32,8 @@ uses
   OrderedStringMap,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.URI,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction;
@@ -79,7 +81,7 @@ var
   Specifier, BaseDirectory, ResolvedPath: string;
 begin
   if AArgs.Length = 0 then
-    ThrowTypeError('import.meta.resolve requires a specifier argument');
+    ThrowTypeError(SErrorImportMetaResolveRequiresArg, SSuggestImportMetaUsage);
 
   Specifier := AArgs.GetElement(0).ToStringLiteral.Value;
 

--- a/units/Goccia.Scope.pas
+++ b/units/Goccia.Scope.pas
@@ -136,6 +136,8 @@ uses
   SysUtils,
 
   Goccia.Error,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Keywords.Reserved;
 
 { TGocciaScope }
@@ -226,6 +228,7 @@ procedure TGocciaScope.DefineLexicalBinding(const AName: string; const AValue: T
 var
   LexicalBinding: TLexicalBinding;
   ExistingLexicalBinding: TLexicalBinding;
+  Error: TGocciaSyntaxError;
 begin
   // Check for redeclaration errors
   if FLexicalBindings.TryGetValue(AName, ExistingLexicalBinding) then
@@ -234,8 +237,9 @@ begin
     case ADeclarationType of
       dtLet, dtConst:
         begin
-          // let/const cannot be redeclared
-          raise TGocciaSyntaxError.Create(Format('Identifier ''%s'' has already been declared', [AName]), ALine, AColumn, '', nil);
+          Error := TGocciaSyntaxError.Create(Format(SErrorIdentifierAlreadyDeclared, [AName]), ALine, AColumn, '', nil);
+          Error.Suggestion := SSuggestAlreadyDeclared;
+          raise Error;
         end;
     end;
   end;
@@ -288,11 +292,17 @@ begin
   begin
     // Check if variable is initialized (temporal dead zone for let/const)
     if not LexicalBinding.IsAccessible then
-      raise TGocciaReferenceError.Create(Format('Cannot access ''%s'' before initialization', [AName]), ALine, AColumn, '', nil);
+      raise TGocciaReferenceError.Create(
+        Format(SErrorCannotAccessBeforeInit, [AName]),
+        ALine, AColumn, '', nil,
+        SSuggestTemporalDeadZone);
 
     // Check if variable is writable
     if not LexicalBinding.Writable then
-      raise TGocciaTypeError.Create(Format('Assignment to constant variable ''%s''', [AName]), ALine, AColumn, '', nil);
+      raise TGocciaTypeError.Create(
+        Format(SErrorAssignToConstant, [AName]),
+        ALine, AColumn, '', nil,
+        SSuggestUseLetNotConst);
 
     // Update the value and mark as initialized
     LexicalBinding.Value := AValue;
@@ -309,7 +319,10 @@ begin
   end;
 
   // Variable not found in any scope - strict mode always throws
-  raise TGocciaReferenceError.Create(Format('Undefined variable: %s', [AName]), ALine, AColumn, '', nil);
+  raise TGocciaReferenceError.Create(
+    Format(SErrorUndefinedVariable, [AName]),
+    ALine, AColumn, '', nil,
+    SSuggestDeclareBeforeUse);
 end;
 
 function TGocciaScope.GetLexicalBinding(const AName: string; const ALine: Integer = 0; const AColumn: Integer = 0): TLexicalBinding;
@@ -319,13 +332,19 @@ begin
   if FLexicalBindings.TryGetValue(AName, LexicalBinding) then
   begin
     if not LexicalBinding.IsAccessible then
-      raise TGocciaReferenceError.Create(Format('Cannot access ''%s'' before initialization', [AName]), ALine, AColumn, '', nil);
+      raise TGocciaReferenceError.Create(
+        Format(SErrorCannotAccessBeforeInit, [AName]),
+        ALine, AColumn, '', nil,
+        SSuggestTemporalDeadZone);
     Result := LexicalBinding;
   end
   else if Assigned(FParent) then
     Result := FParent.GetLexicalBinding(AName, ALine, AColumn)
   else
-    raise TGocciaReferenceError.Create(Format('Undefined variable: %s', [AName]), ALine, AColumn, '', nil);
+    raise TGocciaReferenceError.Create(
+      Format(SErrorUndefinedVariable, [AName]),
+      ALine, AColumn, '', nil,
+      SSuggestDeclareBeforeUse);
 end;
 
 function TGocciaScope.GetValue(const AName: string): TGocciaValue;

--- a/units/Goccia.Temporal.Options.pas
+++ b/units/Goccia.Temporal.Options.pas
@@ -67,6 +67,8 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper;
 
@@ -146,7 +148,7 @@ begin
     Exit;
   end;
   if not GetTemporalUnitFromString(S, Result) then
-    ThrowRangeError('Invalid smallestUnit: ' + S);
+    ThrowRangeError(Format(SErrorInvalidSmallestUnit, [S]), SSuggestTemporalValidUnits);
 end;
 
 function GetLargestUnit(const AOptions: TGocciaObjectValue; const ADefault: TTemporalUnit): TTemporalUnit;
@@ -160,7 +162,7 @@ begin
     Exit;
   end;
   if not GetTemporalUnitFromString(S, Result) then
-    ThrowRangeError('Invalid largestUnit: ' + S);
+    ThrowRangeError(Format(SErrorInvalidLargestUnit, [S]), SSuggestTemporalValidUnits);
 end;
 
 function GetRoundingMode(const AOptions: TGocciaObjectValue; const ADefault: TTemporalRoundingMode): TTemporalRoundingMode;
@@ -174,14 +176,14 @@ begin
     Exit;
   end;
   if not GetRoundingModeFromString(S, Result) then
-    ThrowRangeError('Invalid roundingMode: ' + S);
+    ThrowRangeError(Format(SErrorInvalidRoundingMode, [S]), SSuggestTemporalRoundingMode);
 end;
 
 function GetRoundingIncrement(const AOptions: TGocciaObjectValue; const ADefault: Integer): Integer;
 begin
   Result := GetOptionInteger(AOptions, 'roundingIncrement', ADefault);
   if Result < 1 then
-    ThrowRangeError('roundingIncrement must be >= 1');
+    ThrowRangeError(SErrorRoundingIncrementMin, SSuggestTemporalRoundArg);
 end;
 
 function GetOverflowOption(const AOptions: TGocciaObjectValue): TTemporalOverflow;
@@ -194,7 +196,7 @@ begin
   else if S = 'reject' then
     Result := toReject
   else
-    ThrowRangeError('Invalid overflow option: ' + S);
+    ThrowRangeError(Format(SErrorInvalidOverflow, [S]), SSuggestTemporalOverflow);
 end;
 
 function GetFractionalSecondDigits(const AOptions: TGocciaObjectValue): Integer;
@@ -219,13 +221,13 @@ begin
     if S = 'auto' then
       Result := -1
     else
-      ThrowRangeError('Invalid fractionalSecondDigits: ' + S);
+      ThrowRangeError(Format(SErrorInvalidFractionalDigits, [S]), SSuggestTemporalRoundArg);
   end
   else
   begin
     Result := Trunc(V.ToNumberLiteral.Value);
     if (Result < 0) or (Result > 9) then
-      ThrowRangeError('fractionalSecondDigits must be 0-9 or "auto"');
+      ThrowRangeError(SErrorFractionalDigitsRange, SSuggestTemporalRoundArg);
   end;
 end;
 
@@ -240,7 +242,7 @@ begin
     tuNanosecond: Result := 1;
     tuDay: Result := NANOSECONDS_PER_DAY;
   else
-    ThrowRangeError('Cannot convert calendar unit to nanoseconds');
+    ThrowRangeError(SErrorCannotConvertCalendarUnit, SSuggestTemporalValidUnits);
     Result := 1;
   end;
 end;

--- a/units/Goccia.URI.pas
+++ b/units/Goccia.URI.pas
@@ -31,6 +31,8 @@ uses
 
   StringBuffer,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper;
 
 const
@@ -224,10 +226,10 @@ begin
             Continue;
           end
           else
-            ThrowURIError('URI malformed');
+            ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
         end
         else
-          ThrowURIError('URI malformed');
+          ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
       end;
 
       // ES2026 §19.2.6.1 step 4d.vi: percent-encode UTF-8 octets
@@ -264,7 +266,7 @@ begin
   if (AIndex + 2 > ALength) or
      not IsASCIIHexDigit(AString[AIndex + 1]) or
      not IsASCIIHexDigit(AString[AIndex + 2]) then
-    ThrowURIError('URI malformed');
+    ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
   Result := (HexVal(AString[AIndex + 1]) shl 4) or HexVal(AString[AIndex + 2]);
   Inc(AIndex, 3);
 end;
@@ -323,7 +325,7 @@ begin
         else if (B and $F8) = $F0 then
           ByteCount := 4
         else
-          ThrowURIError('URI malformed');
+          ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
 
         UTF8Bytes[0] := B;
 
@@ -331,10 +333,10 @@ begin
         for J := 1 to ByteCount - 1 do
         begin
           if (I > Len) or (AString[I] <> '%') then
-            ThrowURIError('URI malformed');
+            ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
           B2 := DecodePercentByte(AString, I, Len);
           if (B2 and $C0) <> $80 then
-            ThrowURIError('URI malformed');
+            ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
           UTF8Bytes[J] := B2;
         end;
 
@@ -355,17 +357,17 @@ begin
 
         // Lone surrogates are invalid
         if IsSurrogate(CodePoint) then
-          ThrowURIError('URI malformed');
+          ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
 
         // Overlong encodings are invalid
         if ((ByteCount = 2) and (CodePoint < $80)) or
            ((ByteCount = 3) and (CodePoint < $800)) or
            ((ByteCount = 4) and (CodePoint < $10000)) then
-          ThrowURIError('URI malformed');
+          ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
 
         // Code points above U+10FFFF are invalid
         if CodePoint > $10FFFF then
-          ThrowURIError('URI malformed');
+          ThrowURIError(SErrorURIMalformed, SSuggestURIEncoding);
 
         // Append the decoded UTF-8 bytes directly
         for J := 0 to ByteCount - 1 do

--- a/units/Goccia.Utils.Arrays.pas
+++ b/units/Goccia.Utils.Arrays.pas
@@ -17,13 +17,15 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue;
 
 procedure ArrayCreateDataProperty(const AArray: TGocciaArrayValue; const AIndex: Integer; const AValue: TGocciaValue);
 begin
   if AIndex < 0 then
-    ThrowRangeError('Invalid array index: ' + IntToStr(AIndex));
+    ThrowRangeError(Format(SErrorInvalidArrayIndexFmt, [AIndex]), SSuggestArrayLengthRange);
   if AIndex < AArray.Elements.Count then
     AArray.Elements[AIndex] := AValue
   else

--- a/units/Goccia.VM.pas
+++ b/units/Goccia.VM.pas
@@ -207,6 +207,8 @@ uses
   Goccia.Coverage,
   Goccia.DisposalTracker,
   Goccia.Error,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator,
   Goccia.Evaluator.Decorators,
   Goccia.GarbageCollector,
@@ -340,7 +342,8 @@ begin
   if not Result then
     Exit;
   if not TGocciaPropertyDescriptorData(Descriptor).Writable then
-    ThrowTypeError('Cannot assign to read only property ''' + AName + '''');
+    ThrowTypeError(Format(SErrorCannotAssignReadOnly, [AName]),
+      SSuggestReadOnlyProperty);
   TGocciaPropertyDescriptorData(Descriptor).Value := AValue;
 end;
 
@@ -397,32 +400,32 @@ begin
            AValue.ToNumberLiteral.IsNaN or
            AValue.ToNumberLiteral.IsInfinite or
            (Frac(AValue.ToNumberLiteral.Value) <> 0.0) then
-          ThrowTypeError('Type ''' + AValue.TypeName +
-            ''' is not assignable to type ''' + INTEGER_TYPE_NAME + '''');
+          ThrowTypeError(Format(SErrorTypeNotAssignable, [AValue.TypeName, INTEGER_TYPE_NAME]),
+            SSuggestTypeEnforcement);
       end;
     sltFloat:
       begin
         if not (AValue is TGocciaNumberLiteralValue) then
-          ThrowTypeError('Type ''' + AValue.TypeName +
-            ''' is not assignable to type ''' + NUMBER_TYPE_NAME + '''');
+          ThrowTypeError(Format(SErrorTypeNotAssignable, [AValue.TypeName, NUMBER_TYPE_NAME]),
+            SSuggestTypeEnforcement);
       end;
     sltBoolean:
       begin
         if not (AValue is TGocciaBooleanLiteralValue) then
-          ThrowTypeError('Type ''' + AValue.TypeName +
-            ''' is not assignable to type ''' + BOOLEAN_TYPE_NAME + '''');
+          ThrowTypeError(Format(SErrorTypeNotAssignable, [AValue.TypeName, BOOLEAN_TYPE_NAME]),
+            SSuggestTypeEnforcement);
       end;
     sltString:
       begin
         if not (AValue is TGocciaStringLiteralValue) then
-          ThrowTypeError('Type ''' + AValue.TypeName +
-            ''' is not assignable to type ''' + STRING_TYPE_NAME + '''');
+          ThrowTypeError(Format(SErrorTypeNotAssignable, [AValue.TypeName, STRING_TYPE_NAME]),
+            SSuggestTypeEnforcement);
       end;
     sltReference:
       begin
         if AValue.IsPrimitive then
-          ThrowTypeError('Type ''' + AValue.TypeName +
-            ''' is not assignable to type ''' + OBJECT_TYPE_NAME + '''');
+          ThrowTypeError(Format(SErrorTypeNotAssignable, [AValue.TypeName, OBJECT_TYPE_NAME]),
+            SSuggestTypeEnforcement);
       end;
   else
     // sltUntyped: no runtime check
@@ -459,7 +462,7 @@ function VMToNumericPair(const ALeft, ARight: TGocciaValue;
   out ALeftNum, ARightNum: TGocciaNumberLiteralValue): Boolean; inline;
 begin
   if (ALeft is TGocciaSymbolValue) or (ARight is TGocciaSymbolValue) then
-    ThrowTypeError('Cannot convert a Symbol value to a number');
+    ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
   ALeftNum := ALeft.ToNumberLiteral;
   ARightNum := ARight.ToNumberLiteral;
   Result := not (ALeftNum.IsNaN or ARightNum.IsNaN);
@@ -578,14 +581,14 @@ begin
     Exit(TGocciaStringLiteralValue(AValue));
 
   if AValue is TGocciaSymbolValue then
-    ThrowTypeError('Cannot convert a Symbol value to a string');
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
 
   if AValue.IsPrimitive then
     Exit(AValue.ToStringLiteral);
 
   PrimitiveValue := ToPrimitive(AValue, tphString);
   if PrimitiveValue is TGocciaSymbolValue then
-    ThrowTypeError('Cannot convert a Symbol value to a string');
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
   Result := PrimitiveValue.ToStringLiteral;
 end;
 
@@ -613,7 +616,7 @@ begin
         if AValue.ObjectValue is TGocciaStringLiteralValue then
           Exit(TGocciaStringLiteralValue(AValue.ObjectValue));
         if AValue.ObjectValue is TGocciaSymbolValue then
-          ThrowTypeError('Cannot convert a Symbol value to a string');
+          ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
         if Assigned(AValue.ObjectValue) then
           Exit(VMToECMAStringFast(AValue.ObjectValue));
       end;
@@ -749,7 +752,7 @@ begin
   PrimRight := ToPrimitive(ARight);
 
   if (PrimLeft is TGocciaSymbolValue) or (PrimRight is TGocciaSymbolValue) then
-    ThrowTypeError('Cannot convert a Symbol value to a string');
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
 
   if (PrimLeft is TGocciaStringLiteralValue) or (PrimRight is TGocciaStringLiteralValue) then
     Exit(TGocciaStringLiteralValue.Create(
@@ -2166,8 +2169,8 @@ begin
       end;
       NextResult := AwaitValue(NextResult);
       if NextResult.IsPrimitive then
-        ThrowTypeError('Iterator result ' + NextResult.ToStringLiteral.Value +
-          ' is not an object');
+        ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.ToStringLiteral.Value]),
+          SSuggestIteratorResultObject);
       DoneValue := NextResult.GetProperty(PROP_DONE);
       DoneFlag := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
       if not DoneFlag then
@@ -2326,7 +2329,8 @@ begin
     end;
   end;
 
-  ThrowTypeError(AIterable.TypeName + ' is not iterable');
+  ThrowTypeError(Format(SErrorNotIterable, [AIterable.TypeName]),
+    SSuggestNotIterable);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
@@ -2375,8 +2379,9 @@ begin
   if AConstructor is TGocciaBytecodeFunctionValue then
   begin
     if TGocciaBytecodeFunctionValue(AConstructor).FClosure.Template.IsArrow then
-      ThrowTypeError(TGocciaBytecodeFunctionValue(AConstructor).GetProperty(PROP_NAME)
-        .ToStringLiteral.Value + ' is not a constructor');
+      ThrowTypeError(Format(SErrorNotConstructor, [TGocciaBytecodeFunctionValue(AConstructor).GetProperty(PROP_NAME)
+        .ToStringLiteral.Value]),
+        SSuggestNotConstructorType);
   end;
 
   if AConstructor is TGocciaFunctionBase then
@@ -2395,7 +2400,8 @@ begin
     Exit;
   end;
 
-  ThrowTypeError(AConstructor.TypeName + ' is not a constructor');
+  ThrowTypeError(Format(SErrorValueNotConstructor, [AConstructor.TypeName]),
+    SSuggestNotConstructorType);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
@@ -2404,7 +2410,7 @@ var
   Module: TGocciaModule;
 begin
   if not Assigned(FInterpreter) then
-    ThrowTypeError('Module loading is not available in TGocciaVM');
+    ThrowTypeError(SErrorModuleNotAvailableInVM);
 
   Module := FInterpreter.LoadModule(APath, FCurrentModuleSourcePath);
   Result := CreateModuleNamespaceObject(Module);
@@ -2415,7 +2421,7 @@ var
   Module: TGocciaModule;
 begin
   if not Assigned(FInterpreter) then
-    ThrowTypeError('Module loading is not available in TGocciaVM');
+    ThrowTypeError(SErrorModuleNotAvailableInVM);
 
   Module := FInterpreter.LoadModule(APath, AReferrer);
   Result := CreateModuleNamespaceObject(Module);
@@ -2663,8 +2669,8 @@ begin
     if not (MemberValue is TGocciaNumberLiteralValue) and
        not (MemberValue is TGocciaStringLiteralValue) and
        not (MemberValue is TGocciaSymbolValue) then
-      ThrowTypeError('Enum member ''' + Key +
-        ''' must be a number, string, or symbol');
+      ThrowTypeError(Format(SErrorEnumMemberType, [Key]),
+        SSuggestEnumValueType);
 
     EnumObj.DefineProperty(Key,
       TGocciaPropertyDescriptorData.Create(MemberValue, [pfEnumerable]));
@@ -2860,7 +2866,7 @@ begin
   if not (ClassVal is TGocciaClassValue) then
     Exit;
   if not ADecoratorFn.IsCallable then
-    ThrowTypeError('Decorator must be a function');
+    ThrowTypeError(SErrorDecoratorMustBeFunction, SSuggestDecoratorFunction);
 
   ContextObject := TGocciaObjectValue.Create;
   ContextObject.AssignProperty(PROP_KIND,
@@ -2886,7 +2892,7 @@ begin
      not (DecoratorResult is TGocciaUndefinedLiteralValue) then
   begin
     if not (DecoratorResult is TGocciaClassValue) then
-      ThrowTypeError('Class decorator must return a class or undefined');
+      ThrowTypeError(SErrorClassDecoratorReturn, SSuggestDecoratorFunction);
     Session.ClassValue := DecoratorResult;
   end;
 end;
@@ -2917,7 +2923,7 @@ begin
   if not (ClassVal is TGocciaClassValue) then
     Exit;
   if not ADecoratorFn.IsCallable then
-    ThrowTypeError('Decorator must be a function');
+    ThrowTypeError(SErrorDecoratorMustBeFunction, SSuggestDecoratorFunction);
 
   ParseElementDescriptor(ADescriptor, Kind, Name, Flags);
   IsStatic := (Flags and 1) <> 0;
@@ -3058,7 +3064,7 @@ begin
     'm':
       begin
         if not DecoratorResult.IsCallable then
-          ThrowTypeError('Method decorator must return a function or undefined');
+          ThrowTypeError(SErrorMethodDecoratorReturn, SSuggestDecoratorFunction);
         if IsPrivate then
           TGocciaClassValue(ClassVal).Prototype.AssignProperty(
             '#' + Name, DecoratorResult)
@@ -3071,7 +3077,7 @@ begin
     'g':
       begin
         if not DecoratorResult.IsCallable then
-          ThrowTypeError('Getter decorator must return a function or undefined');
+          ThrowTypeError(SErrorGetterDecoratorReturn, SSuggestDecoratorFunction);
         if IsStatic then
           TGocciaClassValue(ClassVal).AddStaticGetter(
             Name, TGocciaFunctionValue(DecoratorResult))
@@ -3091,7 +3097,7 @@ begin
     's':
       begin
         if not DecoratorResult.IsCallable then
-          ThrowTypeError('Setter decorator must return a function or undefined');
+          ThrowTypeError(SErrorSetterDecoratorReturn, SSuggestDecoratorFunction);
         if IsStatic then
           TGocciaClassValue(ClassVal).AddStaticSetter(
             Name, TGocciaFunctionValue(DecoratorResult))
@@ -3111,14 +3117,14 @@ begin
     'f':
       begin
         if not DecoratorResult.IsCallable then
-          ThrowTypeError('Field decorator must return a function or undefined');
+          ThrowTypeError(SErrorFieldDecoratorReturn, SSuggestDecoratorFunction);
         TGocciaClassValue(ClassVal).AddFieldInitializer(
           Name, DecoratorResult, IsPrivate, IsStatic);
       end;
     'a':
       begin
         if not (DecoratorResult is TGocciaObjectValue) then
-          ThrowTypeError('Accessor decorator must return an object or undefined');
+          ThrowTypeError(SErrorAccessorDecoratorReturn, SSuggestDecoratorFunction);
         DecResultObj := TGocciaObjectValue(DecoratorResult);
         NewGetter := DecResultObj.GetProperty(PROP_GET);
         NewSetter := DecResultObj.GetProperty(PROP_SET);
@@ -3242,9 +3248,11 @@ var
   EmptyArgs: TGocciaArgumentsCollection;
 begin
   if AObject is TGocciaNullLiteralValue then
-    ThrowTypeError('Cannot read properties of null (reading ''' + AKey + ''')');
+    ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull, [AKey]),
+      SSuggestCheckNullBeforeAccess);
   if AObject is TGocciaUndefinedLiteralValue then
-    ThrowTypeError('Cannot read properties of undefined (reading ''' + AKey + ''')');
+    ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined, [AKey]),
+      SSuggestCheckNullBeforeAccess);
 
   if (AKey <> '') and (AKey[1] = '#') then
   begin
@@ -3263,10 +3271,12 @@ begin
         end;
       end;
       if TGocciaClassValue(AObject).HasOwnPrivateSetter(PrivateName) then
-        ThrowTypeError('Private accessor ' + AKey + ' was defined without a getter');
+        ThrowTypeError(Format(SErrorPrivateAccessorNoGetter, [AKey]),
+          SSuggestPrivateFieldAccess);
       if TryGetRawPrivateValue(AObject, AKey, Result) then
         Exit;
-      ThrowTypeError('Private field ' + AKey + ' is not accessible');
+      ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
+        SSuggestPrivateFieldAccess);
     end;
 
     if AObject is TGocciaObjectValue then
@@ -3279,7 +3289,8 @@ begin
         begin
           if Assigned(TGocciaPropertyDescriptorAccessor(Descriptor).Getter) then
             Exit(AObject.GetProperty(AKey));
-          ThrowTypeError('Private accessor ' + AKey + ' was defined without a getter');
+          ThrowTypeError(Format(SErrorPrivateAccessorNoGetter, [AKey]),
+            SSuggestPrivateFieldAccess);
         end;
         Current := Current.Prototype;
       end;
@@ -3311,9 +3322,11 @@ var
   PrivateName: string;
 begin
   if AObject is TGocciaNullLiteralValue then
-    ThrowTypeError('Cannot set properties of null (setting ''' + AKey + ''')');
+    ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, [AKey]),
+      SSuggestCheckNullBeforeAccess);
   if AObject is TGocciaUndefinedLiteralValue then
-    ThrowTypeError('Cannot set properties of undefined (setting ''' + AKey + ''')');
+    ThrowTypeError(Format(SErrorCannotSetPropertiesOfUndefined, [AKey]),
+      SSuggestCheckNullBeforeAccess);
   if (AKey <> '') and (AKey[1] = '#') then
   begin
     PrivateName := Copy(AKey, 2, MaxInt);
@@ -3332,13 +3345,15 @@ begin
         Exit;
       end;
       if TGocciaClassValue(AObject).HasOwnPrivateGetter(PrivateName) then
-        ThrowTypeError('Private accessor ' + AKey + ' was defined without a setter');
+        ThrowTypeError(Format(SErrorPrivateAccessorNoSetter, [AKey]),
+          SSuggestPrivateFieldAccess);
       if TGocciaClassValue(AObject).HasOwnPrivateStaticProperty(AKey) then
       begin
         TGocciaClassValue(AObject).AddPrivateStaticProperty(AKey, AValue);
         Exit;
       end;
-      ThrowTypeError('Private field ' + AKey + ' is not accessible');
+      ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
+        SSuggestPrivateFieldAccess);
     end;
 
     if AObject is TGocciaObjectValue then
@@ -3354,7 +3369,8 @@ begin
           Exit;
         end;
         if Descriptor is TGocciaPropertyDescriptorAccessor then
-          ThrowTypeError('Private accessor ' + AKey + ' was defined without a setter');
+          ThrowTypeError(Format(SErrorPrivateAccessorNoSetter, [AKey]),
+            SSuggestPrivateFieldAccess);
         Current := Current.Prototype;
       end;
     end;
@@ -3417,8 +3433,8 @@ begin
      (AObject is TGocciaBooleanLiteralValue) or
      (AObject is TGocciaNumberLiteralValue) or
      (AObject is TGocciaStringLiteralValue) then
-    ThrowTypeError('Cannot use ''in'' operator to search for ''' +
-      AKey.ToStringLiteral.Value + ''' in ' + AObject.ToStringLiteral.Value);
+    ThrowTypeError(Format(SErrorCannotUseInOperator, [AKey.ToStringLiteral.Value, AObject.ToStringLiteral.Value]),
+      SSuggestCheckNullBeforeAccess);
 
   if (AKey is TGocciaSymbolValue) and (AObject is TGocciaObjectValue) then
   begin
@@ -3492,7 +3508,8 @@ begin
     CalleeDesc := ACallee.TypeName
   else
     CalleeDesc := 'undefined';
-  ThrowTypeError(CalleeDesc + ' is not a function');
+  ThrowTypeError(Format(SErrorValueNotFunction, [CalleeDesc]),
+    SSuggestNotFunctionType);
 end;
 
 function TGocciaVM.ExecuteClosureRegisters(const AClosure: TGocciaBytecodeClosure;
@@ -4269,9 +4286,8 @@ begin
             Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue) then
             FRegisters[A] := RegisterBoolean(True)
           else
-            ThrowTypeError('Cannot delete property ''' +
-              Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue +
-              ''' of [object Object]');
+            ThrowTypeError(Format(SErrorCannotDeletePropertyOf, [Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue, '[object Object]']),
+              SSuggestCannotDeleteNonConfigurable);
         end
         else
           FRegisters[A] := RegisterBoolean(True);
@@ -5151,8 +5167,8 @@ begin
 
             IterResult := AwaitValue(IterResult);
             if IterResult.IsPrimitive then
-              ThrowTypeError('Iterator result ' +
-                IterResult.ToStringLiteral.Value + ' is not an object');
+              ThrowTypeError(Format(SErrorIteratorResultNotObject, [IterResult.ToStringLiteral.Value]),
+                SSuggestIteratorResultObject);
 
             DoneValue := IterResult.GetProperty(PROP_DONE);
             if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
@@ -5475,9 +5491,8 @@ begin
           VALIDATE_OP_REQUIRE_OBJECT:
             begin
               if FRegisters[A].Kind in [grkNull, grkUndefined] then
-                ThrowTypeError('Cannot destructure ' +
-                  RegisterToValue(FRegisters[A]).ToStringLiteral.Value +
-                  ' as it is not an object');
+                ThrowTypeError(Format(SErrorCannotDestructureNotObject, [RegisterToValue(FRegisters[A]).ToStringLiteral.Value]),
+                  SSuggestDestructureRequiresObject);
             end;
 
           VALIDATE_OP_REQUIRE_ITERABLE:

--- a/units/Goccia.Values.ArrayBufferValue.pas
+++ b/units/Goccia.Values.ArrayBufferValue.pas
@@ -63,6 +63,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
@@ -74,7 +76,7 @@ threadvar
 function RequireArrayBuffer(const AThisValue: TGocciaValue; const AMethodName: string): TGocciaArrayBufferValue;
 begin
   if not (AThisValue is TGocciaArrayBufferValue) then
-    ThrowTypeError(AMethodName + ' requires an ArrayBuffer');
+    ThrowTypeError(Format(SErrorRequiresArrayBuffer, [AMethodName]), SSuggestArrayBufferThisType);
   Result := TGocciaArrayBufferValue(AThisValue);
 end;
 
@@ -97,7 +99,7 @@ begin
     IntegerIndex := 0
   else if Num.IsInfinite then
   begin
-    ThrowRangeError('Invalid array buffer length');
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
     Exit(0);
   end
   else
@@ -105,7 +107,7 @@ begin
 
   if (IntegerIndex < 0) or (IntegerIndex > MAX_ECMA_INDEX) or
      (IntegerIndex > High(Integer)) then
-    ThrowRangeError('Invalid array buffer length');
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
 
   Result := Trunc(IntegerIndex);
 end;
@@ -138,7 +140,7 @@ begin
   if AMaxByteLength >= 0 then
   begin
     if AByteLength > AMaxByteLength then
-      ThrowRangeError('ArrayBuffer byte length must not exceed maxByteLength');
+      ThrowRangeError(SErrorArrayBufferExceedsMaxByteLength, SSuggestArrayBufferResizable);
     FMaxByteLength := AMaxByteLength;
   end
   else
@@ -233,7 +235,7 @@ begin
   if RequestedMaxByteLength >= 0 then
   begin
     if Len > RequestedMaxByteLength then
-      ThrowRangeError('ArrayBuffer byte length must not exceed maxByteLength');
+      ThrowRangeError(SErrorArrayBufferExceedsMaxByteLength, SSuggestArrayBufferResizable);
     FMaxByteLength := RequestedMaxByteLength;
   end
   else
@@ -369,11 +371,11 @@ begin
 
   // ES2026 §25.1.6.5 step 4: If IsDetachedBuffer(O), throw TypeError
   if Buf.FDetached then
-    ThrowTypeError('Cannot resize a detached ArrayBuffer');
+    ThrowTypeError(SErrorCannotResizeDetachedArrayBuffer, SSuggestArrayBufferDetached);
 
   // ES2026 §25.1.6.5 step 5: If IsFixedLengthArrayBuffer(O), throw TypeError
   if Buf.FMaxByteLength < 0 then
-    ThrowTypeError('Cannot resize a fixed-length ArrayBuffer');
+    ThrowTypeError(SErrorCannotResizeFixedLengthArrayBuffer, SSuggestArrayBufferResizable);
 
   // ES2026 §25.1.6.5 step 6: Let newByteLength be ToIndex(newLength)
   if AArgs.Length > 0 then
@@ -383,7 +385,7 @@ begin
 
   // ES2026 §25.1.6.5 step 7: If newByteLength > maxByteLength, throw RangeError
   if NewByteLength > Buf.FMaxByteLength then
-    ThrowRangeError('ArrayBuffer resize exceeds maxByteLength');
+    ThrowRangeError(SErrorArrayBufferResizeExceedsMax, SSuggestArrayBufferResizable);
 
   // ES2026 §25.1.6.5 steps 10-16: Create new data block and copy
   OldByteLength := Length(Buf.FData);
@@ -439,7 +441,7 @@ begin
 
   // ES2026 §25.1.6.6 step 2: If IsDetachedBuffer(O), throw TypeError
   if Buf.FDetached then
-    ThrowTypeError('Cannot transfer a detached ArrayBuffer');
+    ThrowTypeError(SErrorCannotTransferDetachedArrayBuffer, SSuggestArrayBufferDetached);
 
   // ES2026 §25.1.6.6 step 1: newLength defaults to current byteLength
   if (AArgs.Length = 0) or (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
@@ -461,7 +463,7 @@ begin
 
   // ES2026 §25.1.6.7 step 2: If IsDetachedBuffer(O), throw TypeError
   if Buf.FDetached then
-    ThrowTypeError('Cannot transfer a detached ArrayBuffer');
+    ThrowTypeError(SErrorCannotTransferDetachedArrayBuffer, SSuggestArrayBufferDetached);
 
   // ES2026 §25.1.6.7 step 1: newLength defaults to current byteLength
   if (AArgs.Length = 0) or (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
@@ -485,7 +487,7 @@ begin
 
   // ES2026 §25.1.6.8 step 4: If IsDetachedBuffer(O), throw TypeError
   if Buf.FDetached then
-    ThrowTypeError('Cannot slice a detached ArrayBuffer');
+    ThrowTypeError(SErrorCannotSliceDetachedArrayBuffer, SSuggestArrayBufferDetached);
 
   Len := Length(Buf.FData);
 

--- a/units/Goccia.Values.ArrayValue.pas
+++ b/units/Goccia.Values.ArrayValue.pas
@@ -23,6 +23,7 @@ type
     procedure FlattenInto(const ATarget: TGocciaArrayValue; const ADepth: Integer);
     procedure ThrowError(const AMessage: string; const AArgs: array of const); overload; inline;
     procedure ThrowError(const AMessage: string); overload; inline;
+    procedure ThrowError(const AMessage: string; const AArgs: array of const; const ASuggestion: string); overload; inline;
   protected
     FElements: TGocciaValueList;
   public
@@ -110,6 +111,8 @@ uses
   Goccia.Arguments.Callbacks,
   Goccia.Constants.PropertyNames,
   Goccia.Error,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator.Comparison,
   Goccia.GarbageCollector,
   Goccia.Utils,
@@ -167,7 +170,8 @@ begin
 
     // Step 7: If IsConstructor(C) is false, throw TypeError
     if not (Species is TGocciaClassValue) then
-      ThrowTypeError('Species is not a constructor');
+      ThrowTypeError(SErrorSpeciesNotConstructor,
+        SSuggestSpeciesConstructor);
 
     // Step 8: Return Construct(C, « length »)
     SpeciesClass := TGocciaClassValue(Species);
@@ -356,7 +360,8 @@ begin
     begin
       Len := TGocciaNumberLiteralValue(LenArg).Value;
       if (Len <> Trunc(Len)) or (Len < 0) or (Len > 4294967295) then
-        ThrowRangeError('Invalid array length');
+        ThrowRangeError(SErrorInvalidArrayLength,
+          SSuggestArrayLengthRange);
       for I := 0 to Trunc(Len) - 1 do
         FElements.Add(TGocciaHoleValue.HoleValue);
     end
@@ -400,6 +405,11 @@ begin
   ThrowError(AMessage, []);
 end;
 
+procedure TGocciaArrayValue.ThrowError(const AMessage: string; const AArgs: array of const; const ASuggestion: string);
+begin
+  raise TGocciaError.Create(Format(AMessage, AArgs), 0, 0, '', nil, ASuggestion);
+end;
+
 function TGocciaArrayValue.GetLengthProperty(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   Result := TGocciaNumberLiteralValue.Create(TGocciaArrayValue(AThisValue).Elements.Count);
@@ -439,22 +449,22 @@ function TGocciaArrayValue.ValidateArrayMethodCall(const AMethodName: string; co
   const AThisValue: TGocciaValue; const ARequiresCallback: Boolean = True): TGocciaValue;
 begin
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.%s called on non-array', [AMethodName]);
+    ThrowError(SErrorArrayMethodCalledOnNonArray, [AMethodName], SSuggestArrayThisType);
 
   if AArgs.Length < 1 then
-    ThrowError('Array.%s expects callback function', [AMethodName]);
+    ThrowError(SErrorArrayMethodExpectsCallback, [AMethodName], SSuggestIteratorCallable);
 
   Result := AArgs.GetElement(0);
 
   if ARequiresCallback then
   begin
     if not Result.IsCallable then
-      ThrowError('Callback must be a function');
+      ThrowError(SErrorCallbackMustBeFunction, [], SSuggestIteratorCallable);
   end
   else
   begin
     if Result is TGocciaUndefinedLiteralValue then
-      ThrowError('Callback must not be undefined');
+      ThrowError(SErrorCallbackMustNotBeUndefined, [], SSuggestIteratorCallable);
   end;
 end;
 
@@ -565,7 +575,8 @@ begin
   else
   begin
     if Arr.Elements.Count = 0 then
-      ThrowTypeError('Reduce of empty array with no initial value');
+      ThrowTypeError(SErrorReduceEmptyArray,
+        SSuggestReduceInitialValue);
     Accumulator := Arr.Elements[0];
     StartIndex := 1;
   end;
@@ -643,7 +654,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.join called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['join'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -697,7 +708,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.includes called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['includes'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -839,7 +850,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.flat called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['flat'], SSuggestArrayThisType);
 
   // Step 2: Let sourceLen be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -850,7 +861,7 @@ begin
   if AArgs.Length > 0 then
   begin
     if not (AArgs.GetElement(0) is TGocciaNumberLiteralValue) then
-      ThrowError('Array.flat expects depth argument to be a number');
+      ThrowError(SErrorArrayFlatExpectsNumber, [], SSuggestArrayThisType);
 
     DepthNum := AArgs.GetElement(0).ToNumberLiteral;
     if DepthNum.IsNaN then
@@ -978,7 +989,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.slice called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['slice'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1200,13 +1211,13 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.with called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['with'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
 
   if AArgs.Length < 2 then
-    ThrowError('Array.with requires index and value arguments');
+    ThrowError(SErrorArrayWithRequiresArgs, [], SSuggestArrayThisType);
 
   // Step 3: Let relativeIndex be ToIntegerOrInfinity(index)
   Index := ToIntegerFromArgs(AArgs);
@@ -1221,7 +1232,8 @@ begin
 
   // Step 6: If actualIndex >= len or actualIndex < 0, throw RangeError
   if (ActualIndex < 0) or (ActualIndex >= Arr.Elements.Count) then
-    ThrowRangeError('Invalid index for Array.with');
+    ThrowRangeError(SErrorInvalidArrayWithIndex,
+      Format('index must be between %d and %d', [-Arr.Elements.Count, Arr.Elements.Count - 1]));
 
   // Step 7: Let A be ArrayCreate(len)
   ResultArray := TGocciaArrayValue.Create;
@@ -1248,14 +1260,14 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.copyWithin called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['copyWithin'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
   Len := Arr.Elements.Count;
 
   if AArgs.Length < 1 then
-    ThrowError('Array.copyWithin requires a target argument');
+    ThrowError(SErrorArrayCopyWithinRequiresTarget, [], SSuggestArrayThisType);
 
   // Step 3: Let relativeTarget be ToIntegerOrInfinity(target)
   Target := ToIntegerFromArgs(AArgs);
@@ -1300,7 +1312,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.indexOf called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['indexOf'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1350,7 +1362,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.lastIndexOf called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['lastIndexOf'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1401,7 +1413,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.concat called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['concat'], SSuggestArrayThisType);
 
   // Step 2: Let A be ArraySpeciesCreate(O, 0)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1440,7 +1452,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.reverse called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['reverse'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1471,7 +1483,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.toReversed called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['toReversed'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1498,7 +1510,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.toSorted called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['toSorted'], SSuggestArrayThisType);
 
   // Step 2: If comparefn is not undefined and IsCallable(comparefn) is false, throw TypeError
   // Step 3: Let len be LengthOfArrayLike(O)
@@ -1515,7 +1527,7 @@ begin
     CustomSortFunction := AArgs.GetElement(0);
 
     if not CustomSortFunction.IsCallable then
-      ThrowError('Custom sort function must be a function');
+      ThrowError(SErrorCustomSortMustBeFunction, [], SSuggestCallbackRequired);
 
     CallArgs := TGocciaArgumentsCollection.Create([nil, nil]);
     try
@@ -1541,7 +1553,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.toSpliced called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['toSpliced'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1759,7 +1771,7 @@ var
   CallArgs: TGocciaArgumentsCollection;
 begin
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.sort called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['sort'], SSuggestArrayThisType);
 
   Arr := TGocciaArrayValue(AThisValue);
 
@@ -1768,7 +1780,7 @@ begin
     CustomSortFunction := AArgs.GetElement(0);
 
     if not CustomSortFunction.IsCallable then
-      ThrowError('Custom sort function must be a function');
+      ThrowError(SErrorCustomSortMustBeFunction, [], SSuggestCallbackRequired);
 
     CallArgs := TGocciaArgumentsCollection.Create([nil, nil]);
     try
@@ -1792,7 +1804,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.splice called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['splice'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1847,7 +1859,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.shift called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['shift'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1873,7 +1885,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.unshift called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['unshift'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1896,7 +1908,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.fill called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['fill'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1934,7 +1946,7 @@ var
 begin
   // Step 1: Let O be ToObject(this value)
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.at called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['at'], SSuggestArrayThisType);
 
   // Step 2: Let len be LengthOfArrayLike(O)
   Arr := TGocciaArrayValue(AThisValue);
@@ -1964,7 +1976,7 @@ end;
 function TGocciaArrayValue.ArrayValues(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.values called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['values'], SSuggestArrayThisType);
   // Step 1: Let O be ToObject(this value)
   // Step 2: Return CreateArrayIterator(O, value)
   Result := TGocciaArrayIteratorValue.Create(AThisValue, akValues);
@@ -1974,7 +1986,7 @@ end;
 function TGocciaArrayValue.ArrayKeys(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.keys called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['keys'], SSuggestArrayThisType);
   // Step 1: Let O be ToObject(this value)
   // Step 2: Return CreateArrayIterator(O, key)
   Result := TGocciaArrayIteratorValue.Create(AThisValue, akKeys);
@@ -1984,7 +1996,7 @@ end;
 function TGocciaArrayValue.ArrayEntries(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('Array.entries called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['entries'], SSuggestArrayThisType);
   // Step 1: Let O be ToObject(this value)
   // Step 2: Return CreateArrayIterator(O, key+value)
   Result := TGocciaArrayIteratorValue.Create(AThisValue, akEntries);
@@ -1994,7 +2006,7 @@ end;
 function TGocciaArrayValue.ArraySymbolIterator(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaArrayValue) then
-    ThrowError('[Symbol.iterator] called on non-array');
+    ThrowError(SErrorArrayMethodCalledOnNonArray, ['[Symbol.iterator]'], SSuggestArrayThisType);
   // Step 1: Return the result of calling Array.prototype.values
   Result := TGocciaArrayIteratorValue.Create(AThisValue, akValues);
 end;

--- a/units/Goccia.Values.ClassValue.pas
+++ b/units/Goccia.Values.ClassValue.pas
@@ -224,6 +224,8 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Constants.TypeNames,
   Goccia.Error,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
@@ -961,7 +963,7 @@ begin
         Exit;
         end
         else
-          ThrowTypeError('Cannot set property on class with getter-only accessor');
+          ThrowTypeError(SErrorClassSetterOnlyAccessor, SSuggestPropertyHasOnlyGetter);
       end;
       Break;
     end;
@@ -1047,7 +1049,7 @@ begin
   else if (FName = CONSTRUCTOR_ARRAY) or (FName = CONSTRUCTOR_OBJECT) then
     Result := Instantiate(AArguments)
   else
-    ThrowTypeError('Class constructor ' + FName + ' cannot be invoked without ''new''');
+    ThrowTypeError(Format(SErrorClassConstructorRequiresNew, [FName]), SSuggestRequiresNew);
 end;
 
 { TGocciaArrayClassValue }
@@ -1244,7 +1246,7 @@ begin
      (Descriptor is TGocciaPropertyDescriptorData) then
   begin
     if not TGocciaPropertyDescriptorData(Descriptor).Writable then
-      ThrowTypeError('Cannot assign to read only property ''' + AName + '''');
+      ThrowTypeError(Format(SErrorCannotAssignReadOnly, [AName]), SSuggestCannotDeleteNonConfigurable);
     TGocciaPropertyDescriptorData(Descriptor).Value := AValue;
     Exit;
   end;
@@ -1270,21 +1272,20 @@ begin
       end
       else if Descriptor is TGocciaPropertyDescriptorAccessor then
       begin
-        ThrowTypeError('Cannot set property ' + AName + ' of #<' + ToStringTag +
-          '> which has only a getter');
+        ThrowTypeError(Format(SErrorSetPropertyOnlyGetter, [AName, ToStringTag]), SSuggestPropertyHasOnlyGetter);
       end
       else if (Descriptor is TGocciaPropertyDescriptorData) and
               (not TGocciaPropertyDescriptorData(Descriptor).Writable) then
-        ThrowTypeError('Cannot assign to read only property ''' + AName + '''');
+        ThrowTypeError(Format(SErrorCannotAssignReadOnly, [AName]), SSuggestCannotDeleteNonConfigurable);
     end;
     Proto := Proto.Prototype;
   end;
 
   if not ACanCreate then
-    ThrowTypeError('Cannot assign to non-existent property ''' + AName + '''');
+    ThrowTypeError(Format(SErrorCannotAssignNonExistent, [AName]), SSuggestCannotDeleteNonConfigurable);
 
   if not FExtensible then
-    ThrowTypeError('Cannot add property ''' + AName + ''', object is not extensible');
+    ThrowTypeError(Format(SErrorCannotAddPropertyNotExtensible, [AName]), SSuggestObjectNotExtensible);
 
   DefineProperty(AName, TGocciaPropertyDescriptorData.Create(AValue,
     [pfEnumerable, pfConfigurable, pfWritable]));

--- a/units/Goccia.Values.Error.pas
+++ b/units/Goccia.Values.Error.pas
@@ -17,9 +17,13 @@ type
   TGocciaThrowValue = class(Exception)
   private
     FValue: TGocciaValue;
+    FSuggestion: string;
   public
-    constructor Create(const AValue: TGocciaValue);
+    constructor Create(const AValue: TGocciaValue); overload;
+    constructor Create(const AValue: TGocciaValue;
+      const ASuggestion: string); overload;
     property Value: TGocciaValue read FValue;
+    property Suggestion: string read FSuggestion;
   end;
 
 implementation
@@ -30,6 +34,15 @@ constructor TGocciaThrowValue.Create(const AValue: TGocciaValue);
 begin
   inherited Create('');
   FValue := AValue;
+  FSuggestion := '';
+end;
+
+constructor TGocciaThrowValue.Create(const AValue: TGocciaValue;
+  const ASuggestion: string);
+begin
+  inherited Create('');
+  FValue := AValue;
+  FSuggestion := ASuggestion;
 end;
 
 end.

--- a/units/Goccia.Values.ErrorHelper.pas
+++ b/units/Goccia.Values.ErrorHelper.pas
@@ -12,28 +12,35 @@ uses
 function CreateErrorObject(const AName, AMessage: string; const ASkipTop: Integer = 0): TGocciaObjectValue;
 
 { Raises a TGocciaThrowValue with a TypeError }
-procedure ThrowTypeError(const AMessage: string);
+procedure ThrowTypeError(const AMessage: string); overload;
+procedure ThrowTypeError(const AMessage, ASuggestion: string); overload;
 
 { Raises a TGocciaThrowValue with a RangeError }
-procedure ThrowRangeError(const AMessage: string);
+procedure ThrowRangeError(const AMessage: string); overload;
+procedure ThrowRangeError(const AMessage, ASuggestion: string); overload;
 
 { Raises a TGocciaThrowValue with a ReferenceError }
-procedure ThrowReferenceError(const AMessage: string);
+procedure ThrowReferenceError(const AMessage: string); overload;
+procedure ThrowReferenceError(const AMessage, ASuggestion: string); overload;
 
 { Raises a TGocciaThrowValue with a SyntaxError }
-procedure ThrowSyntaxError(const AMessage: string);
+procedure ThrowSyntaxError(const AMessage: string); overload;
+procedure ThrowSyntaxError(const AMessage, ASuggestion: string); overload;
 
 { Raises a TGocciaThrowValue with a DataCloneError (DOMException with code 25) }
-procedure ThrowDataCloneError(const AMessage: string);
+procedure ThrowDataCloneError(const AMessage: string); overload;
+procedure ThrowDataCloneError(const AMessage, ASuggestion: string); overload;
 
 { Raises a TGocciaThrowValue with an InvalidCharacterError (DOMException with code 5) }
 procedure ThrowInvalidCharacterError(const AMessage: string);
 
 { Raises a TGocciaThrowValue with a URIError }
-procedure ThrowURIError(const AMessage: string);
+procedure ThrowURIError(const AMessage: string); overload;
+procedure ThrowURIError(const AMessage, ASuggestion: string); overload;
 
 { Raises a TGocciaThrowValue with a generic Error }
-procedure ThrowError(const AMessage: string);
+procedure ThrowError(const AMessage: string); overload;
+procedure ThrowError(const AMessage, ASuggestion: string); overload;
 
 implementation
 
@@ -87,9 +94,21 @@ begin
         TGocciaCallStack.Instance.CaptureStackTrace(AName, AMessage, ASkipTop)));
 end;
 
+{ Shared raise helper — creates the error object and raises with optional suggestion }
+procedure RaiseNativeError(const AErrorName, AMessage, ASuggestion: string);
+begin
+  raise TGocciaThrowValue.Create(
+    CreateErrorObject(AErrorName, AMessage), ASuggestion);
+end;
+
 procedure ThrowTypeError(const AMessage: string);
 begin
   raise TGocciaThrowValue.Create(CreateErrorObject(TYPE_ERROR_NAME, AMessage));
+end;
+
+procedure ThrowTypeError(const AMessage, ASuggestion: string);
+begin
+  RaiseNativeError(TYPE_ERROR_NAME, AMessage, ASuggestion);
 end;
 
 procedure ThrowRangeError(const AMessage: string);
@@ -97,14 +116,29 @@ begin
   raise TGocciaThrowValue.Create(CreateErrorObject(RANGE_ERROR_NAME, AMessage));
 end;
 
+procedure ThrowRangeError(const AMessage, ASuggestion: string);
+begin
+  RaiseNativeError(RANGE_ERROR_NAME, AMessage, ASuggestion);
+end;
+
 procedure ThrowReferenceError(const AMessage: string);
 begin
   raise TGocciaThrowValue.Create(CreateErrorObject(REFERENCE_ERROR_NAME, AMessage));
 end;
 
+procedure ThrowReferenceError(const AMessage, ASuggestion: string);
+begin
+  RaiseNativeError(REFERENCE_ERROR_NAME, AMessage, ASuggestion);
+end;
+
 procedure ThrowSyntaxError(const AMessage: string);
 begin
   raise TGocciaThrowValue.Create(CreateErrorObject(SYNTAX_ERROR_NAME, AMessage));
+end;
+
+procedure ThrowSyntaxError(const AMessage, ASuggestion: string);
+begin
+  RaiseNativeError(SYNTAX_ERROR_NAME, AMessage, ASuggestion);
 end;
 
 procedure ThrowDataCloneError(const AMessage: string);
@@ -117,6 +151,18 @@ begin
   if Assigned(GDOMExceptionProto) then
     ErrorObj.Prototype := GDOMExceptionProto;
   raise TGocciaThrowValue.Create(ErrorObj);
+end;
+
+procedure ThrowDataCloneError(const AMessage, ASuggestion: string);
+var
+  ErrorObj: TGocciaObjectValue;
+begin
+  ErrorObj := CreateErrorObject(DATA_CLONE_ERROR_NAME, AMessage);
+  ErrorObj.HasErrorData := False;
+  ErrorObj.AssignProperty(PROP_CODE, TGocciaNumberLiteralValue.Create(25));
+  if Assigned(GDOMExceptionProto) then
+    ErrorObj.Prototype := GDOMExceptionProto;
+  raise TGocciaThrowValue.Create(ErrorObj, ASuggestion);
 end;
 
 procedure ThrowInvalidCharacterError(const AMessage: string);
@@ -136,9 +182,19 @@ begin
   raise TGocciaThrowValue.Create(CreateErrorObject(URI_ERROR_NAME, AMessage));
 end;
 
+procedure ThrowURIError(const AMessage, ASuggestion: string);
+begin
+  RaiseNativeError(URI_ERROR_NAME, AMessage, ASuggestion);
+end;
+
 procedure ThrowError(const AMessage: string);
 begin
   raise TGocciaThrowValue.Create(CreateErrorObject(ERROR_NAME, AMessage));
+end;
+
+procedure ThrowError(const AMessage, ASuggestion: string);
+begin
+  RaiseNativeError(ERROR_NAME, AMessage, ASuggestion);
 end;
 
 end.

--- a/units/Goccia.Values.FFILibrary.pas
+++ b/units/Goccia.Values.FFILibrary.pas
@@ -43,6 +43,8 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.FFI.Call,
   Goccia.FFI.Types,
   Goccia.GarbageCollector,
@@ -111,9 +113,9 @@ var
 begin
   // Validate arg count
   if AArgs.Length < FSignature.ArgCount then
-    ThrowTypeError('FFI function ' + FName + ' expects ' +
-      IntToStr(FSignature.ArgCount) + ' arguments, got ' +
-      IntToStr(AArgs.Length));
+    ThrowTypeError(Format(SErrorFFIFuncArgCount,
+      [FName, FSignature.ArgCount, AArgs.Length]),
+      SSuggestFFIUsage);
 
   // Marshal arguments into native arrays
   SetLength(IntArgs, 0);
@@ -184,8 +186,8 @@ begin
             else if ArgValue is TGocciaNullLiteralValue then
               IntArgs[I] := 0
             else
-              ThrowTypeError('FFI argument ' + IntToStr(I) +
-                ' must be an ArrayBuffer, TypedArray, FFIPointer, or null');
+              ThrowTypeError(Format(SErrorFFIArgMustBeBufferOrNull, [I]),
+                SSuggestFFIUsage);
           end;
           fftCString:
           begin
@@ -298,8 +300,8 @@ begin
               else if ArgValue is TGocciaNullLiteralValue then
                 {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := 0
               else
-                ThrowTypeError('FFI argument ' + IntToStr(I) +
-                  ' must be an ArrayBuffer, TypedArray, FFIPointer, or null');
+                ThrowTypeError(Format(SErrorFFIArgMustBeBufferOrNull, [I]),
+                SSuggestFFIUsage);
             end;
             fftCString:
             begin
@@ -377,8 +379,8 @@ begin
               else if ArgValue is TGocciaNullLiteralValue then
                 IntVal := 0
               else
-                ThrowTypeError('FFI argument ' + IntToStr(I) +
-                  ' must be an ArrayBuffer, TypedArray, FFIPointer, or null');
+                ThrowTypeError(Format(SErrorFFIArgMustBeBufferOrNull, [I]),
+                SSuggestFFIUsage);
             end;
             fftCString:
             begin
@@ -545,10 +547,10 @@ var
   ValidationError: string;
 begin
   if AArgs.Length < 2 then
-    ThrowTypeError('bind requires a function name and a signature object');
+    ThrowTypeError(SErrorFFIBindRequiresNameAndSig, SSuggestFFIUsage);
 
   if not (AArgs.GetElement(1) is TGocciaObjectValue) then
-    ThrowTypeError('bind second argument must be a signature object { args: [...], returns: "..." }');
+    ThrowTypeError(SErrorFFIBindSigObject, SSuggestFFIUsage);
 
   SigObj := TGocciaObjectValue(AArgs.GetElement(1));
 
@@ -564,9 +566,9 @@ begin
       TypeName := ArgsArray.Elements[I].ToStringLiteral.Value;
       Result.ArgTypes[I] := ParseFFIType(TypeName);
       if (Result.ArgTypes[I] = fftVoid) and (TypeName <> FFI_TYPE_VOID) then
-        ThrowTypeError('Unknown FFI type: ' + TypeName);
+        ThrowTypeError(Format(SErrorFFIUnknownType, [TypeName]), SSuggestFFIUsage);
       if Result.ArgTypes[I] = fftVoid then
-        ThrowTypeError('void is not a valid argument type');
+        ThrowTypeError(SErrorFFIVoidNotValidArg, SSuggestFFIUsage);
     end;
   end
   else if (ArgsField = nil) or (ArgsField is TGocciaUndefinedLiteralValue) then
@@ -575,7 +577,7 @@ begin
     SetLength(Result.ArgTypes, 0);
   end
   else
-    ThrowTypeError('signature args must be an array of type strings');
+    ThrowTypeError(SErrorFFISigArgsMustBeArray, SSuggestFFIUsage);
 
   // Parse return type
   ReturnsField := SigObj.GetProperty('returns');
@@ -584,17 +586,17 @@ begin
     ReturnStr := TGocciaStringLiteralValue(ReturnsField).Value;
     Result.ReturnType := ParseFFIType(ReturnStr);
     if (Result.ReturnType = fftVoid) and (ReturnStr <> FFI_TYPE_VOID) then
-      ThrowTypeError('Unknown FFI return type: ' + ReturnStr);
+      ThrowTypeError(Format(SErrorFFIUnknownReturnType, [ReturnStr]), SSuggestFFIUsage);
   end
   else if (ReturnsField = nil) or (ReturnsField is TGocciaUndefinedLiteralValue) then
     Result.ReturnType := fftVoid
   else
-    ThrowTypeError('signature returns must be a type string');
+    ThrowTypeError(SErrorFFISigReturnsMustBeString, SSuggestFFIUsage);
 
   // Validate
   ValidationError := ValidateSignature(Result);
   if ValidationError <> '' then
-    ThrowTypeError(ValidationError);
+    ThrowTypeError(ValidationError, SSuggestFFIUsage);
 end;
 
 function TGocciaFFILibraryValue.Bind(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -606,11 +608,11 @@ var
   BoundFunc: TGocciaFFIBoundFunction;
 begin
   if not (AThisValue is TGocciaFFILibraryValue) then
-    ThrowTypeError('bind requires an FFILibrary');
+    ThrowTypeError(SErrorFFIBindRequiresLibrary, SSuggestFFILibraryOpen);
   Lib := TGocciaFFILibraryValue(AThisValue);
 
   if Lib.FHandle.IsClosed then
-    ThrowTypeError('Cannot bind from a closed library');
+    ThrowTypeError(SErrorFFIBindLibraryClosed, SSuggestFFILibraryOpen);
 
   FuncName := AArgs.GetElement(0).ToStringLiteral.Value;
   Sig := ParseSignatureFromArgs(AArgs, FuncName);
@@ -619,7 +621,7 @@ begin
     SymbolPtr := Lib.FHandle.FindSymbol(FuncName);
   except
     on E: Exception do
-      ThrowTypeError(E.Message);
+      ThrowTypeError(E.Message, SSuggestFFIUsage);
   end;
   BoundFunc := TGocciaFFIBoundFunction.Create(SymbolPtr, Sig, FuncName);
   Result := TGocciaNativeFunctionValue.CreateWithoutPrototype(
@@ -633,21 +635,21 @@ var
   SymPtr: CodePointer;
 begin
   if not (AThisValue is TGocciaFFILibraryValue) then
-    ThrowTypeError('symbol requires an FFILibrary');
+    ThrowTypeError(SErrorFFISymbolRequiresLibrary, SSuggestFFILibraryOpen);
   Lib := TGocciaFFILibraryValue(AThisValue);
 
   if Lib.FHandle.IsClosed then
-    ThrowTypeError('Cannot look up symbol in a closed library');
+    ThrowTypeError(SErrorFFISymbolLibraryClosed, SSuggestFFILibraryOpen);
 
   if AArgs.Length < 1 then
-    ThrowTypeError('symbol requires a symbol name');
+    ThrowTypeError(SErrorFFISymbolRequiresName, SSuggestFFIUsage);
 
   SymName := AArgs.GetElement(0).ToStringLiteral.Value;
   try
     SymPtr := Lib.FHandle.FindSymbol(SymName);
   except
     on E: Exception do
-      ThrowTypeError(E.Message);
+      ThrowTypeError(E.Message, SSuggestFFIUsage);
   end;
   Result := TGocciaFFIPointerValue.Create(Pointer(SymPtr));
 end;
@@ -657,7 +659,7 @@ var
   Lib: TGocciaFFILibraryValue;
 begin
   if not (AThisValue is TGocciaFFILibraryValue) then
-    ThrowTypeError('close requires an FFILibrary');
+    ThrowTypeError(SErrorFFICloseRequiresLibrary, SSuggestFFILibraryOpen);
   Lib := TGocciaFFILibraryValue(AThisValue);
   Lib.FHandle.Close;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -666,7 +668,7 @@ end;
 function TGocciaFFILibraryValue.PathGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaFFILibraryValue) then
-    ThrowTypeError('FFILibrary.path requires an FFILibrary');
+    ThrowTypeError(SErrorFFIPathRequiresLibrary, SSuggestFFILibraryOpen);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaFFILibraryValue(AThisValue).FHandle.Path);
 end;
@@ -674,7 +676,7 @@ end;
 function TGocciaFFILibraryValue.ClosedGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaFFILibraryValue) then
-    ThrowTypeError('FFILibrary.closed requires an FFILibrary');
+    ThrowTypeError(SErrorFFIClosedRequiresLibrary, SSuggestFFILibraryOpen);
   if TGocciaFFILibraryValue(AThisValue).FHandle.IsClosed then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else

--- a/units/Goccia.Values.FFIPointer.pas
+++ b/units/Goccia.Values.FFIPointer.pas
@@ -41,6 +41,10 @@ type
 implementation
 
 uses
+  SysUtils,
+
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -140,7 +144,7 @@ end;
 function TGocciaFFIPointerValue.IsNullGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaFFIPointerValue) then
-    ThrowTypeError('FFIPointer.isNull requires an FFIPointer');
+    ThrowTypeError(Format(SErrorFFIPointerRequiresFFIPointer, [PROP_IS_NULL]), SSuggestFFIUsage);
   if Assigned(TGocciaFFIPointerValue(AThisValue).FAddress) then
     Result := TGocciaBooleanLiteralValue.FalseValue
   else
@@ -150,7 +154,7 @@ end;
 function TGocciaFFIPointerValue.AddressGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaFFIPointerValue) then
-    ThrowTypeError('FFIPointer.address requires an FFIPointer');
+    ThrowTypeError(Format(SErrorFFIPointerRequiresFFIPointer, [PROP_FFI_ADDRESS]), SSuggestFFIUsage);
   Result := TGocciaNumberLiteralValue.Create(
     PtrUInt(TGocciaFFIPointerValue(AThisValue).FAddress));
 end;

--- a/units/Goccia.Values.FunctionBase.pas
+++ b/units/Goccia.Values.FunctionBase.pas
@@ -95,6 +95,8 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Constants.TypeNames,
   Goccia.Error,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.ObjectModel,
   Goccia.Values.ArrayValue,
@@ -320,7 +322,7 @@ var
 begin
   // Step 1: Perform ? RequireObjectCoercible(this)
   if not AThisValue.IsCallable then
-    ThrowTypeError('Function.prototype.apply called on non-function');
+    ThrowTypeError(SErrorFunctionApplyNonFunction, SSuggestFunctionApply);
 
   // thisArg
   if AArgs.Length > 0 then

--- a/units/Goccia.Values.FunctionValue.pas
+++ b/units/Goccia.Values.FunctionValue.pas
@@ -76,6 +76,8 @@ uses
   Goccia.AST.Statements,
   Goccia.ControlFlow,
   Goccia.Coverage,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator,
   Goccia.Evaluator.Context,
   Goccia.GarbageCollector,
@@ -251,7 +253,7 @@ begin
       Exit;
     end;
     if CF.Kind = cfkBreak then
-      ThrowSyntaxError('Illegal break statement');
+      ThrowSyntaxError(SErrorIllegalBreakStatement, SSuggestExpressionExpected);
   end;
 end;
 

--- a/units/Goccia.Values.Iterator.Concat.pas
+++ b/units/Goccia.Values.Iterator.Concat.pas
@@ -34,6 +34,8 @@ implementation
 uses
   Goccia.Arguments.Collection,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.Iterator.Concrete,
@@ -92,7 +94,7 @@ begin
 
     // TC39 Iterator Sequencing §1 step 3.a.ii: If iter is not an Object, throw TypeError
     if not (IteratorObj is TGocciaObjectValue) then
-      ThrowTypeError('Iterator.concat: [Symbol.iterator]() must return an object');
+      ThrowTypeError(SErrorIteratorConcatMustReturnObject, SSuggestIteratorProtocol);
 
     if IteratorObj is TGocciaIteratorValue then
       FCurrentIterator := TGocciaIteratorValue(IteratorObj)

--- a/units/Goccia.Values.Iterator.Generic.pas
+++ b/units/Goccia.Values.Iterator.Generic.pas
@@ -26,6 +26,8 @@ implementation
 uses
   Goccia.Arguments.Collection,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase;
 
@@ -161,13 +163,13 @@ begin
      (ReturnMethod is TGocciaNullLiteralValue) then
     Exit;
   if not ReturnMethod.IsCallable then
-    ThrowTypeError('Iterator return property must be callable');
+    ThrowTypeError(SErrorIteratorReturnMustBeCallable, SSuggestIteratorProtocol);
 
   CallArgs := TGocciaArgumentsCollection.Create;
   try
     ReturnResult := TGocciaFunctionBase(ReturnMethod).Call(CallArgs, FSource);
     if not (ReturnResult is TGocciaObjectValue) then
-      ThrowTypeError('Iterator return() must return an object');
+      ThrowTypeError(SErrorIteratorReturnObject, SSuggestIteratorResultObject);
   finally
     CallArgs.Free;
   end;

--- a/units/Goccia.Values.Iterator.Lazy.pas
+++ b/units/Goccia.Values.Iterator.Lazy.pas
@@ -82,6 +82,8 @@ implementation
 uses
   Goccia.Arguments.Collection,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -551,7 +553,7 @@ begin
     if not Assigned(FInnerIterator) then
     begin
       FSourceIterator.Close;
-      ThrowTypeError('Iterator.prototype.flatMap callback must return an iterable');
+      ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
     end;
 
     InnerResult := FInnerIterator.AdvanceNext;
@@ -611,7 +613,7 @@ begin
     if not Assigned(FInnerIterator) then
     begin
       FSourceIterator.Close;
-      ThrowTypeError('Iterator.prototype.flatMap callback must return an iterable');
+      ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
     end;
 
     InnerValue := FInnerIterator.DirectNext(InnerDone);

--- a/units/Goccia.Values.Iterator.Zip.pas
+++ b/units/Goccia.Values.Iterator.Zip.pas
@@ -52,6 +52,8 @@ implementation
 
 uses
   Goccia.Arguments.Collection,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -261,7 +263,7 @@ begin
         begin
           CloseAllIterators;
           FDone := True;
-          ThrowTypeError('Iterator.zip: iterables have different lengths in strict mode');
+          ThrowTypeError(SErrorIteratorZipStrictLengthMismatch, SSuggestIteratorZipMode);
         end;
         if AllDone then
         begin
@@ -448,7 +450,7 @@ begin
         begin
           CloseAllIterators;
           FDone := True;
-          ThrowTypeError('Iterator.zipKeyed: iterables have different lengths in strict mode');
+          ThrowTypeError(SErrorIteratorZipKeyedStrictLengthMismatch, SSuggestIteratorZipMode);
         end;
         if AllDone then
         begin

--- a/units/Goccia.Values.IteratorValue.pas
+++ b/units/Goccia.Values.IteratorValue.pas
@@ -56,6 +56,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -223,7 +225,7 @@ end;
 function TGocciaIteratorValue.IteratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.next called on non-iterator');
+    ThrowTypeError(SErrorIteratorNextNonIterator, SSuggestIteratorThisType);
   Result := TGocciaIteratorValue(AThisValue).AdvanceNext;
 end;
 
@@ -237,9 +239,10 @@ end;
 function TGocciaIteratorValue.IteratorMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.map called on non-iterator');
+    ThrowTypeError(SErrorIteratorMapNonIterator, SSuggestIteratorThisType);
   if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('Iterator.prototype.map requires a callable argument');
+    ThrowTypeError(SErrorIteratorMapCallable,
+      SSuggestIteratorCallable);
 
   Result := TGocciaLazyMapIteratorValue.Create(
     TGocciaIteratorValue(AThisValue), AArgs.GetElement(0)
@@ -249,9 +252,10 @@ end;
 function TGocciaIteratorValue.IteratorFilter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.filter called on non-iterator');
+    ThrowTypeError(SErrorIteratorFilterNonIterator, SSuggestIteratorThisType);
   if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('Iterator.prototype.filter requires a callable argument');
+    ThrowTypeError(SErrorIteratorFilterCallable,
+      SSuggestIteratorCallable);
 
   Result := TGocciaLazyFilterIteratorValue.Create(
     TGocciaIteratorValue(AThisValue), AArgs.GetElement(0)
@@ -263,13 +267,14 @@ var
   Limit: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.take called on non-iterator');
+    ThrowTypeError(SErrorIteratorTakeNonIterator, SSuggestIteratorThisType);
   if AArgs.Length < 1 then
-    ThrowRangeError('Iterator.prototype.take requires an argument');
+    ThrowRangeError(SErrorIteratorTakeRequiresArg, SSuggestIteratorNonNegative);
 
   Limit := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
   if Limit < 0 then
-    ThrowRangeError('Iterator.prototype.take argument must be non-negative');
+    ThrowRangeError(SErrorIteratorTakeNonNegative,
+      SSuggestIteratorNonNegative);
 
   Result := TGocciaLazyTakeIteratorValue.Create(
     TGocciaIteratorValue(AThisValue), Limit
@@ -281,13 +286,14 @@ var
   DropCount: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.drop called on non-iterator');
+    ThrowTypeError(SErrorIteratorDropNonIterator, SSuggestIteratorThisType);
   if AArgs.Length < 1 then
-    ThrowRangeError('Iterator.prototype.drop requires an argument');
+    ThrowRangeError(SErrorIteratorDropRequiresArg, SSuggestIteratorNonNegative);
 
   DropCount := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
   if DropCount < 0 then
-    ThrowRangeError('Iterator.prototype.drop argument must be non-negative');
+    ThrowRangeError(SErrorIteratorDropNonNegative,
+      SSuggestIteratorNonNegative);
 
   Result := TGocciaLazyDropIteratorValue.Create(
     TGocciaIteratorValue(AThisValue), DropCount
@@ -297,9 +303,10 @@ end;
 function TGocciaIteratorValue.IteratorFlatMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.flatMap called on non-iterator');
+    ThrowTypeError(SErrorIteratorFlatMapNonIterator, SSuggestIteratorThisType);
   if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('Iterator.prototype.flatMap requires a callable argument');
+    ThrowTypeError(SErrorIteratorFlatMapCallable,
+      SSuggestIteratorFlatMapCallable);
 
   Result := TGocciaLazyFlatMapIteratorValue.Create(
     TGocciaIteratorValue(AThisValue), AArgs.GetElement(0)
@@ -316,9 +323,10 @@ var
   Index: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.forEach called on non-iterator');
+    ThrowTypeError(SErrorIteratorForEachNonIterator, SSuggestIteratorThisType);
   if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('Iterator.prototype.forEach requires a callable argument');
+    ThrowTypeError(SErrorIteratorForEachCallable,
+      SSuggestIteratorCallable);
 
   Iterator := TGocciaIteratorValue(AThisValue);
   Callback := AArgs.GetElement(0);
@@ -355,9 +363,10 @@ var
   Index: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.reduce called on non-iterator');
+    ThrowTypeError(SErrorIteratorReduceNonIterator, SSuggestIteratorThisType);
   if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('Iterator.prototype.reduce requires a callable argument');
+    ThrowTypeError(SErrorIteratorReduceCallable,
+      SSuggestIteratorCallable);
 
   Iterator := TGocciaIteratorValue(AThisValue);
   Callback := AArgs.GetElement(0);
@@ -374,7 +383,8 @@ begin
       begin
         Accumulator := Iterator.DirectNext(Done);
         if Done then
-          ThrowTypeError('Reduce of empty iterator with no initial value');
+          ThrowTypeError(SErrorReduceEmptyIterator,
+            SSuggestReduceInitialValue);
         Index := 1;
       end;
 
@@ -417,7 +427,7 @@ var
   Done: Boolean;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.toArray called on non-iterator');
+    ThrowTypeError(SErrorIteratorToArrayNonIterator, SSuggestIteratorThisType);
 
   Iterator := TGocciaIteratorValue(AThisValue);
   ResultArray := TGocciaArrayValue.Create;
@@ -447,9 +457,10 @@ var
   Index: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.some called on non-iterator');
+    ThrowTypeError(SErrorIteratorSomeNonIterator, SSuggestIteratorThisType);
   if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('Iterator.prototype.some requires a callable argument');
+    ThrowTypeError(SErrorIteratorSomeCallable,
+      SSuggestIteratorCallable);
 
   Iterator := TGocciaIteratorValue(AThisValue);
   Callback := AArgs.GetElement(0);
@@ -489,9 +500,10 @@ var
   Index: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.every called on non-iterator');
+    ThrowTypeError(SErrorIteratorEveryNonIterator, SSuggestIteratorThisType);
   if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('Iterator.prototype.every requires a callable argument');
+    ThrowTypeError(SErrorIteratorEveryCallable,
+      SSuggestIteratorCallable);
 
   Iterator := TGocciaIteratorValue(AThisValue);
   Callback := AArgs.GetElement(0);
@@ -531,9 +543,10 @@ var
   Index: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
-    ThrowTypeError('Iterator.prototype.find called on non-iterator');
+    ThrowTypeError(SErrorIteratorFindNonIterator, SSuggestIteratorThisType);
   if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('Iterator.prototype.find requires a callable argument');
+    ThrowTypeError(SErrorIteratorFindCallable,
+      SSuggestIteratorCallable);
 
   Iterator := TGocciaIteratorValue(AThisValue);
   Callback := AArgs.GetElement(0);
@@ -573,7 +586,7 @@ var
   CallArgs: TGocciaArgumentsCollection;
 begin
   if AArgs.Length < 1 then
-    ThrowTypeError('Iterator.from requires an argument');
+    ThrowTypeError(SErrorIteratorFromRequiresArg, SSuggestIteratorFromArg);
 
   Value := AArgs.GetElement(0);
 
@@ -624,7 +637,8 @@ begin
     Exit;
   end;
 
-  ThrowTypeError('Iterator.from requires an iterable or iterator-like object');
+  ThrowTypeError(SErrorIteratorFromRequiresIterable,
+    SSuggestIteratorFromArg);
   Result := nil;
 end;
 
@@ -657,13 +671,13 @@ begin
       IteratorMethod := TGocciaObjectValue(Item).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
       // TC39 Iterator Sequencing §1 step 2c: If method is undefined, throw TypeError
       if not Assigned(IteratorMethod) or (IteratorMethod is TGocciaUndefinedLiteralValue) or not IteratorMethod.IsCallable then
-        ThrowTypeError('Iterator.concat requires all arguments to be iterable');
+        ThrowTypeError(SErrorIteratorConcatNotIterable, SSuggestNotIterable);
       Iterables[I].Iterable := Item;
       Iterables[I].IteratorMethod := IteratorMethod;
     end
     else
       // TC39 Iterator Sequencing §1 step 2a: If item is not an Object, throw TypeError
-      ThrowTypeError('Iterator.concat requires all arguments to be iterable');
+      ThrowTypeError(SErrorIteratorConcatNotIterable, SSuggestNotIterable);
   end;
 
   // TC39 Iterator Sequencing §1 steps 3-6: Create iterator from closure
@@ -694,7 +708,7 @@ var
 begin
   // TC39 Joint Iteration §1.1 step 1: If iterables is not an Object, throw TypeError
   if AArgs.Length < 1 then
-    ThrowTypeError('Iterator.zip requires an argument');
+    ThrowTypeError(SErrorIteratorZipRequiresArg, SSuggestNotIterable);
 
   IterablesArg := AArgs.GetElement(0);
   GC := TGarbageCollector.Instance;
@@ -702,7 +716,7 @@ begin
   // TC39 Joint Iteration §1.1 step 2: Get iterator from iterables
   OuterIterator := GetIteratorFromIterable(IterablesArg);
   if OuterIterator = nil then
-    ThrowTypeError('Iterator.zip: first argument must be iterable');
+    ThrowTypeError(SErrorIteratorZipFirstIterable, SSuggestNotIterable);
 
   GC.AddTempRoot(OuterIterator);
   try
@@ -726,7 +740,7 @@ begin
         begin
           InnerIterator := GetIteratorFromIterable(Items[I]);
           if InnerIterator = nil then
-            ThrowTypeError('Iterator.zip: all items in iterables must be iterable');
+            ThrowTypeError(SErrorIteratorZipItemIterable, SSuggestNotIterable);
           Iterators[I] := InnerIterator;
           GC.AddTempRoot(InnerIterator);
           Acquired := I + 1;
@@ -761,14 +775,14 @@ begin
       if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
       begin
         if not (OptionsArg is TGocciaObjectValue) then
-          ThrowTypeError('Iterator.zip: options must be an object');
+          ThrowTypeError(SErrorIteratorZipOptionsObject, SSuggestIteratorZipOptions);
 
         // TC39 Joint Iteration §1.1 step 5a: Get mode
         ModeVal := OptionsArg.GetProperty(PROP_MODE);
         if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
         begin
           if not (ModeVal is TGocciaStringLiteralValue) then
-            ThrowTypeError('Iterator.zip: mode must be a string');
+            ThrowTypeError(SErrorIteratorZipModeString, SSuggestIteratorZipMode);
           ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
           if ModeStr = ZIP_MODE_SHORTEST then
             Mode := zmShortest
@@ -777,7 +791,7 @@ begin
           else if ModeStr = ZIP_MODE_STRICT then
             Mode := zmStrict
           else
-            ThrowRangeError('Iterator.zip: invalid mode "' + ModeStr + '"');
+            ThrowRangeError(Format(SErrorIteratorZipInvalidMode, [ModeStr]), SSuggestIteratorZipMode);
         end;
 
         // TC39 Joint Iteration §1.1 step 5b: Get padding (only for longest mode)
@@ -788,7 +802,7 @@ begin
           begin
             PaddingIterator := GetIteratorFromIterable(PaddingVal);
             if PaddingIterator = nil then
-              ThrowTypeError('Iterator.zip: padding must be iterable');
+              ThrowTypeError(SErrorIteratorZipPaddingIterable, SSuggestNotIterable);
             GC.AddTempRoot(PaddingIterator);
             PaddingItems := TGocciaValueList.Create(False);
             try
@@ -849,11 +863,11 @@ var
 begin
   // TC39 Joint Iteration §1.2 step 1: If iterables is not an Object, throw TypeError
   if AArgs.Length < 1 then
-    ThrowTypeError('Iterator.zipKeyed requires an argument');
+    ThrowTypeError(SErrorIteratorZipKeyedRequiresArg, SSuggestNotIterable);
 
   IterablesArg := AArgs.GetElement(0);
   if not (IterablesArg is TGocciaObjectValue) then
-    ThrowTypeError('Iterator.zipKeyed: first argument must be an object');
+    ThrowTypeError(SErrorIteratorZipKeyedFirstObject, SSuggestIteratorZipKeyedArg);
 
   GC := TGarbageCollector.Instance;
 
@@ -870,7 +884,7 @@ begin
       PropValue := IterablesArg.GetProperty(Keys[I]);
       InnerIterator := GetIteratorFromIterable(PropValue);
       if InnerIterator = nil then
-        ThrowTypeError('Iterator.zipKeyed: property "' + Keys[I] + '" value must be iterable');
+        ThrowTypeError(Format(SErrorIteratorZipKeyedPropertyNotIterable, [Keys[I]]), SSuggestNotIterable);
       Iterators[I] := InnerIterator;
       GC.AddTempRoot(InnerIterator);
       Acquired := I + 1;
@@ -899,14 +913,14 @@ begin
       if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
       begin
         if not (OptionsArg is TGocciaObjectValue) then
-          ThrowTypeError('Iterator.zipKeyed: options must be an object');
+          ThrowTypeError(SErrorIteratorZipKeyedOptionsObject, SSuggestIteratorZipOptions);
 
         // TC39 Joint Iteration §1.2 step 4a: Get mode
         ModeVal := OptionsArg.GetProperty(PROP_MODE);
         if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
         begin
           if not (ModeVal is TGocciaStringLiteralValue) then
-            ThrowTypeError('Iterator.zipKeyed: mode must be a string');
+            ThrowTypeError(SErrorIteratorZipKeyedModeString, SSuggestIteratorZipMode);
           ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
           if ModeStr = ZIP_MODE_SHORTEST then
             Mode := zmShortest
@@ -915,7 +929,7 @@ begin
           else if ModeStr = ZIP_MODE_STRICT then
             Mode := zmStrict
           else
-            ThrowRangeError('Iterator.zipKeyed: invalid mode "' + ModeStr + '"');
+            ThrowRangeError(Format(SErrorIteratorZipKeyedInvalidMode, [ModeStr]), SSuggestIteratorZipMode);
         end;
 
         // TC39 Joint Iteration §1.2 step 4b: Get padding (only for longest mode)
@@ -925,7 +939,7 @@ begin
           if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
           begin
             if not (PaddingVal is TGocciaObjectValue) then
-              ThrowTypeError('Iterator.zipKeyed: padding must be an object');
+              ThrowTypeError(SErrorIteratorZipKeyedPaddingObject, SSuggestIteratorZipKeyedPadding);
             for I := 0 to Count - 1 do
             begin
               PropValue := PaddingVal.GetProperty(Keys[I]);

--- a/units/Goccia.Values.MapValue.pas
+++ b/units/Goccia.Values.MapValue.pas
@@ -63,6 +63,8 @@ implementation
 uses
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator.Comparison,
   Goccia.GarbageCollector,
   Goccia.Utils,
@@ -469,7 +471,7 @@ begin
   else
     CallbackArg := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not CallbackArg.IsCallable then
-    ThrowTypeError('Map.getOrInsertComputed: callbackfn is not a function');
+    ThrowTypeError(SErrorMapGetOrInsertComputedNotCallable, SSuggestMapCallbackRequired);
 
   // Step 4: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
   //   If SameValueZero(p.[[Key]], key) is true, return p.[[Value]]

--- a/units/Goccia.Values.NumberObjectValue.pas
+++ b/units/Goccia.Values.NumberObjectValue.pas
@@ -44,6 +44,8 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction;
@@ -295,7 +297,7 @@ begin
     FractionDigits := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
     // Step 5: If f < 0 or f > 100, throw a RangeError exception
     if (FractionDigits < 0) or (FractionDigits > 100) then
-      ThrowRangeError('toExponential() argument must be between 0 and 100');
+      ThrowRangeError(SErrorToExponentialArgRange, SSuggestNumberRange);
   end
   else
     FractionDigits := -1;

--- a/units/Goccia.Values.ObjectPropertyDescriptor.pas
+++ b/units/Goccia.Values.ObjectPropertyDescriptor.pas
@@ -66,6 +66,8 @@ implementation
 
 uses
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue;
 
@@ -140,7 +142,7 @@ var
 begin
   // ES2026 §6.2.5.5 step 1: If Desc is not an Object, throw a TypeError
   if not (ADescriptorObject is TGocciaObjectValue) then
-    ThrowTypeError('property descriptor must be an object');
+    ThrowTypeError(SErrorPropertyDescriptorMustBeObject, SSuggestPropertyDescriptorObject);
 
   DescObj := TGocciaObjectValue(ADescriptorObject);
 
@@ -188,7 +190,7 @@ begin
   begin
     Getter := DescObj.GetProperty(PROP_GET);
     if not (Getter is TGocciaUndefinedLiteralValue) and not Getter.IsCallable then
-      ThrowTypeError('getter must be a function or undefined');
+      ThrowTypeError(SErrorGetterMustBeFunctionOrUndefined, SSuggestNotFunctionType);
     if Getter is TGocciaUndefinedLiteralValue then
       Getter := nil;
   end;
@@ -198,14 +200,14 @@ begin
   begin
     Setter := DescObj.GetProperty(PROP_SET);
     if not (Setter is TGocciaUndefinedLiteralValue) and not Setter.IsCallable then
-      ThrowTypeError('setter must be a function or undefined');
+      ThrowTypeError(SErrorSetterMustBeFunctionOrUndefined, SSuggestNotFunctionType);
     if Setter is TGocciaUndefinedLiteralValue then
       Setter := nil;
   end;
 
   // ES2026 §6.2.5.5 step 10: mixed data+accessor is invalid
   if (HasValue or HasWritable) and (HasGet or HasSet) then
-    ThrowTypeError('descriptor cannot have both accessor and data properties');
+    ThrowTypeError(SErrorDescriptorMixedAccessorData, SSuggestPropertyDescriptorObject);
 
   // Build flags
   PropertyFlags := [];

--- a/units/Goccia.Values.ObjectValue.pas
+++ b/units/Goccia.Values.ObjectValue.pas
@@ -112,6 +112,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.ObjectModel,
   Goccia.Values.ErrorHelper,
@@ -202,7 +204,7 @@ var
 begin
   // Step 2: Let O be ? ToObject(this value)
   if (AThisValue is TGocciaUndefinedLiteralValue) or (AThisValue is TGocciaNullLiteralValue) then
-    ThrowTypeError('Cannot convert undefined or null to object');
+    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
 
   if not (AThisValue is TGocciaObjectValue) then
     Exit(TGocciaBooleanLiteralValue.FalseValue);
@@ -243,7 +245,7 @@ begin
 
   // Step 2: Let O be ? ToObject(this value)
   if (AThisValue is TGocciaUndefinedLiteralValue) or (AThisValue is TGocciaNullLiteralValue) then
-    ThrowTypeError('Cannot convert undefined or null to object');
+    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
   if not (AThisValue is TGocciaObjectValue) then
     Exit(TGocciaBooleanLiteralValue.FalseValue);
 
@@ -271,7 +273,7 @@ var
 begin
   // Step 2: Let O be ? ToObject(this value)
   if (AThisValue is TGocciaUndefinedLiteralValue) or (AThisValue is TGocciaNullLiteralValue) then
-    ThrowTypeError('Cannot convert undefined or null to object');
+    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
 
   if not (AThisValue is TGocciaObjectValue) then
     Exit(TGocciaBooleanLiteralValue.FalseValue);
@@ -516,7 +518,7 @@ var
   ChainDepth: Integer;
 begin
   if FFrozen then
-    ThrowTypeError('Cannot assign to read only property ''' + AName + ''' of frozen object');
+    ThrowTypeError(Format(SErrorReadOnlyPropertyFrozen, [AName]), SSuggestCannotDeleteNonConfigurable);
 
   if FProperties.TryGetValue(AName, Descriptor) then
   begin
@@ -534,7 +536,7 @@ begin
         end;
         Exit;
       end;
-      ThrowTypeError('Cannot set property ' + AName + ' of #<' + ToStringTag + '> which has only a getter');
+      ThrowTypeError(Format(SErrorSetPropertyOnlyGetter, [AName, ToStringTag]), SSuggestPropertyHasOnlyGetter);
     end
     else if Descriptor is TGocciaPropertyDescriptorData then
     begin
@@ -543,7 +545,7 @@ begin
         TGocciaPropertyDescriptorData(Descriptor).Value := AValue;
         Exit;
       end;
-      ThrowTypeError('Cannot assign to read only property ''' + AName + '''');
+      ThrowTypeError(Format(SErrorCannotAssignReadOnly, [AName]), SSuggestCannotDeleteNonConfigurable);
     end;
   end;
 
@@ -554,7 +556,7 @@ begin
   begin
     Inc(ChainDepth);
     if ChainDepth > MAX_PROTOTYPE_CHAIN_DEPTH then
-      ThrowTypeError('Prototype chain depth exceeded safety limit while setting ''' + AName + '''');
+      ThrowTypeError(Format(SErrorProtoChainDepthExceeded, [AName]), SSuggestPrototypeChainTooDeep);
     if Proto.FProperties.TryGetValue(AName, Descriptor) then
     begin
       if Descriptor is TGocciaPropertyDescriptorAccessor then
@@ -571,12 +573,12 @@ begin
           end;
           Exit;
         end;
-        ThrowTypeError('Cannot set property ' + AName + ' of #<' + ToStringTag + '> which has only a getter');
+        ThrowTypeError(Format(SErrorSetPropertyOnlyGetter, [AName, ToStringTag]), SSuggestPropertyHasOnlyGetter);
       end
       else if Descriptor is TGocciaPropertyDescriptorData then
       begin
         if not TGocciaPropertyDescriptorData(Descriptor).Writable then
-          ThrowTypeError('Cannot assign to read only property ''' + AName + '''');
+          ThrowTypeError(Format(SErrorCannotAssignReadOnly, [AName]), SSuggestCannotDeleteNonConfigurable);
         Break;
       end;
     end;
@@ -584,10 +586,10 @@ begin
   end;
 
   if not ACanCreate then
-    ThrowTypeError('Cannot assign to non-existent property ''' + AName + '''');
+    ThrowTypeError(Format(SErrorCannotAssignNonExistent, [AName]), SSuggestCannotDeleteNonConfigurable);
 
   if not FExtensible then
-    ThrowTypeError('Cannot add property ''' + AName + ''', object is not extensible');
+    ThrowTypeError(Format(SErrorCannotAddPropertyNotExtensible, [AName]), SSuggestObjectNotExtensible);
 
   DefineProperty(AName, TGocciaPropertyDescriptorData.Create(AValue,
     [pfEnumerable, pfConfigurable, pfWritable]));
@@ -687,7 +689,7 @@ begin
   if FProperties.TryGetValue(AName, ExistingDescriptor) then
   begin
     if not ExistingDescriptor.Configurable then
-      ThrowTypeError('Cannot redefine non-configurable property ''' + AName + '''');
+      ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [AName]), SSuggestCannotDeleteNonConfigurable);
     ExistingDescriptor.Free;
   end;
 
@@ -955,7 +957,7 @@ begin
   if FSymbolDescriptors.TryGetValue(ASymbol, ExistingDescriptor) then
   begin
     if not ExistingDescriptor.Configurable then
-      ThrowTypeError('Cannot redefine non-configurable property ''' + ASymbol.ToStringLiteral.Value + '''');
+      ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [ASymbol.ToStringLiteral.Value]), SSuggestCannotDeleteNonConfigurable);
     ExistingDescriptor.Free;
   end
   else
@@ -1009,7 +1011,7 @@ var
   Current: TGocciaObjectValue;
 begin
   if FFrozen then
-    ThrowTypeError('Cannot assign to property of frozen object');
+    ThrowTypeError(SErrorCannotAssignFrozenObject, SSuggestCannotDeleteNonConfigurable);
 
   if FSymbolDescriptors.TryGetValue(ASymbol, Descriptor) then
   begin
@@ -1028,7 +1030,7 @@ begin
         end;
         Exit;
       end;
-      ThrowTypeError('Cannot set property which has only a getter');
+      ThrowTypeError(SErrorSetSymbolOnlyGetter, SSuggestPropertyHasOnlyGetter);
     end
     else if Descriptor is TGocciaPropertyDescriptorData then
     begin
@@ -1038,7 +1040,7 @@ begin
         Descriptor.Free;
         Exit;
       end;
-      ThrowTypeError('Cannot assign to read only symbol property');
+      ThrowTypeError(SErrorReadOnlySymbolProperty, SSuggestCannotDeleteNonConfigurable);
     end;
   end;
 
@@ -1062,12 +1064,12 @@ begin
           end;
           Exit;
         end;
-        ThrowTypeError('Cannot set property which has only a getter');
+        ThrowTypeError(SErrorSetSymbolOnlyGetter, SSuggestPropertyHasOnlyGetter);
       end
       else if Descriptor is TGocciaPropertyDescriptorData then
       begin
         if not TGocciaPropertyDescriptorData(Descriptor).Writable then
-          ThrowTypeError('Cannot assign to read only symbol property');
+          ThrowTypeError(SErrorReadOnlySymbolProperty, SSuggestCannotDeleteNonConfigurable);
         Break;
       end;
     end;
@@ -1075,7 +1077,7 @@ begin
   end;
 
   if not FExtensible then
-    ThrowTypeError('Cannot add symbol property, object is not extensible');
+    ThrowTypeError(SErrorCannotAddSymbolNotExtensible, SSuggestObjectNotExtensible);
 
   DefineSymbolProperty(ASymbol, TGocciaPropertyDescriptorData.Create(AValue, [pfEnumerable, pfConfigurable, pfWritable]));
 end;

--- a/units/Goccia.Values.PromiseValue.pas
+++ b/units/Goccia.Values.PromiseValue.pas
@@ -78,6 +78,8 @@ implementation
 uses
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.Values.ClassValue,
@@ -297,7 +299,7 @@ begin
   begin
     FState := gpsRejected;
     FResult := Goccia.Values.ErrorHelper.CreateErrorObject(TYPE_ERROR_NAME,
-      'Chaining cycle detected for promise');
+      SErrorPromiseChainingCycle);
     TriggerReactions;
     Exit;
   end;
@@ -356,7 +358,7 @@ begin
             else if ThenMethod is TGocciaClassValue then
               TGocciaClassValue(ThenMethod).Call(ThenArgs, AValue)
             else
-              Goccia.Values.ErrorHelper.ThrowTypeError('then is not a function');
+              Goccia.Values.ErrorHelper.ThrowTypeError(SErrorThenNotFunction, SSuggestPromiseThisType);
           except
             on E: EGocciaBytecodeThrow do
             begin
@@ -580,7 +582,7 @@ var
   OnFulfilled, OnRejected: TGocciaValue;
 begin
   if not (AThisValue is TGocciaPromiseValue) then
-    Goccia.Values.ErrorHelper.ThrowTypeError('Promise.prototype.then called on non-Promise');
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseThenNonPromise, SSuggestPromiseThisType);
 
   P := TGocciaPromiseValue(AThisValue);
 
@@ -616,7 +618,7 @@ var
   OnFinally: TGocciaValue;
 begin
   if not (AThisValue is TGocciaPromiseValue) then
-    Goccia.Values.ErrorHelper.ThrowTypeError('Promise.prototype.finally called on non-Promise');
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseFinallyNonPromise, SSuggestPromiseThisType);
 
   OnFinally := nil;
   if (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable then

--- a/units/Goccia.Values.ProxyValue.pas
+++ b/units/Goccia.Values.ProxyValue.pas
@@ -140,6 +140,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator.Comparison,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
@@ -162,7 +164,7 @@ end;
 procedure TGocciaProxyValue.CheckRevoked;
 begin
   if FRevoked then
-    ThrowTypeError('Cannot perform operation on a revoked proxy');
+    ThrowTypeError(SErrorProxyRevoked, SSuggestProxyRevoked);
 end;
 
 function TGocciaProxyValue.GetTrap(const ATrapName: string): TGocciaValue;
@@ -174,7 +176,7 @@ begin
      (TrapValue is TGocciaNullLiteralValue) then
     Result := nil
   else if not TrapValue.IsCallable then
-    ThrowTypeError('Proxy handler trap ''' + ATrapName + ''' is not a function')
+    ThrowTypeError(Format(SErrorProxyTrapNotFunction, [ATrapName]), SSuggestProxyTargetType)
   else
     Result := TrapValue;
 end;
@@ -191,7 +193,7 @@ begin
   else if ATrap is TGocciaClassValue then
     Result := TGocciaClassValue(ATrap).Call(AArgs, FHandler)
   else
-    ThrowTypeError('Proxy trap is not callable');
+    ThrowTypeError(SErrorProxyTrapNotCallable, SSuggestProxyTargetType);
 end;
 
 // ES2026 §28.1.1 [[Get]](P, Receiver)
@@ -231,12 +233,12 @@ begin
         if (TargetDesc is TGocciaPropertyDescriptorData) and
            not TargetDesc.Writable and
            not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, Result) then
-          ThrowTypeError('Proxy get: value mismatch for non-configurable, non-writable property ''' + AName + '''');
+          ThrowTypeError(Format(SErrorProxyGetNonConfigurableValue, [AName]), SSuggestProxyTrapInvariant);
         // Non-configurable accessor without getter: result must be undefined
         if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
            not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Getter) and
            not (Result is TGocciaUndefinedLiteralValue) then
-          ThrowTypeError('Proxy get: must return undefined for non-configurable accessor without getter ''' + AName + '''');
+          ThrowTypeError(Format(SErrorProxyGetNoGetter, [AName]), SSuggestProxyTrapInvariant);
       end;
     end;
   end
@@ -268,8 +270,7 @@ begin
       Args.Add(Self);
       TrapResult := InvokeTrap(Trap, Args);
       if not TrapResult.ToBooleanLiteral.Value then
-        ThrowTypeError('Proxy set handler returned false for property ''' +
-          AName + '''');
+        ThrowTypeError(Format(SErrorProxySetReturnedFalse, [AName]), SSuggestProxyTrapInvariant);
     finally
       Args.Free;
     end;
@@ -284,11 +285,11 @@ begin
         if (TargetDesc is TGocciaPropertyDescriptorData) and
            not TargetDesc.Writable and
            not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, AValue) then
-          ThrowTypeError('Proxy set: cannot change value of non-configurable, non-writable property ''' + AName + '''');
+          ThrowTypeError(Format(SErrorProxySetNonConfigurableValue, [AName]), SSuggestProxyTrapInvariant);
         // Non-configurable accessor without setter
         if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
            not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Setter) then
-          ThrowTypeError('Proxy set: cannot set non-configurable accessor property ''' + AName + ''' without a setter');
+          ThrowTypeError(Format(SErrorProxySetNoSetter, [AName]), SSuggestProxyTrapInvariant);
       end;
     end;
   end
@@ -333,11 +334,11 @@ begin
         if (TargetDesc is TGocciaPropertyDescriptorData) and
            not TargetDesc.Writable and
            not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, AValue) then
-          ThrowTypeError('Proxy set: cannot change value of non-configurable, non-writable property ''' + AName + '''');
+          ThrowTypeError(Format(SErrorProxySetNonConfigurableValue, [AName]), SSuggestProxyTrapInvariant);
         // Non-configurable accessor without setter
         if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
            not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Setter) then
-          ThrowTypeError('Proxy set: cannot set non-configurable accessor property ''' + AName + ''' without a setter');
+          ThrowTypeError(Format(SErrorProxySetNoSetter, [AName]), SSuggestProxyTrapInvariant);
       end;
     end;
 
@@ -380,10 +381,10 @@ begin
       TargetDesc := TGocciaObjectValue(FTarget).GetOwnPropertyDescriptor(AName);
       // Cannot hide non-configurable own property
       if Assigned(TargetDesc) and not TargetDesc.Configurable then
-        ThrowTypeError('Proxy has trap returned false for non-configurable property ''' + AName + '''');
+        ThrowTypeError(Format(SErrorProxyHasNonConfigurable, [AName]), SSuggestProxyTrapInvariant);
       // Cannot hide own property on non-extensible target
       if Assigned(TargetDesc) and not TGocciaObjectValue(FTarget).Extensible then
-        ThrowTypeError('Proxy has trap returned false for property on non-extensible target');
+        ThrowTypeError(SErrorProxyHasNonExtensible, SSuggestProxyTrapInvariant);
     end;
   end
   else
@@ -423,9 +424,9 @@ begin
     begin
       TargetDesc := TGocciaObjectValue(FTarget).GetOwnSymbolPropertyDescriptor(ASymbol);
       if Assigned(TargetDesc) and not TargetDesc.Configurable then
-        ThrowTypeError('Proxy has trap returned false for non-configurable symbol property');
+        ThrowTypeError(SErrorProxyHasSymbolNonConfigurable, SSuggestProxyTrapInvariant);
       if Assigned(TargetDesc) and not TGocciaObjectValue(FTarget).Extensible then
-        ThrowTypeError('Proxy has trap returned false for symbol property on non-extensible target');
+        ThrowTypeError(SErrorProxyHasSymbolNonExtensible, SSuggestProxyTrapInvariant);
     end;
   end
   else
@@ -479,11 +480,11 @@ begin
         if (TargetDesc is TGocciaPropertyDescriptorData) and
            not TargetDesc.Writable and
            not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, Result) then
-          ThrowTypeError('Proxy get: value mismatch for non-configurable, non-writable symbol property');
+          ThrowTypeError(SErrorProxyGetSymbolNonConfigurable, SSuggestProxyTrapInvariant);
         if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
            not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Getter) and
            not (Result is TGocciaUndefinedLiteralValue) then
-          ThrowTypeError('Proxy get: must return undefined for non-configurable accessor without getter');
+          ThrowTypeError(SErrorProxyGetSymbolNoGetter, SSuggestProxyTrapInvariant);
       end;
     end;
   end
@@ -528,11 +529,11 @@ begin
         if (TargetDesc is TGocciaPropertyDescriptorData) and
            not TargetDesc.Writable and
            not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, Result) then
-          ThrowTypeError('Proxy get: value mismatch for non-configurable, non-writable symbol property');
+          ThrowTypeError(SErrorProxyGetSymbolNonConfigurable, SSuggestProxyTrapInvariant);
         if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
            not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Getter) and
            not (Result is TGocciaUndefinedLiteralValue) then
-          ThrowTypeError('Proxy get: must return undefined for non-configurable accessor without getter');
+          ThrowTypeError(SErrorProxyGetSymbolNoGetter, SSuggestProxyTrapInvariant);
       end;
     end;
   end
@@ -582,11 +583,11 @@ begin
         if (TargetDesc is TGocciaPropertyDescriptorData) and
            not TargetDesc.Writable and
            not IsSameValue(TGocciaPropertyDescriptorData(TargetDesc).Value, AValue) then
-          ThrowTypeError('Proxy set: cannot change value of non-configurable, non-writable symbol property');
+          ThrowTypeError(SErrorProxySetSymbolNonConfigurable, SSuggestProxyTrapInvariant);
         // Non-configurable accessor without setter
         if (TargetDesc is TGocciaPropertyDescriptorAccessor) and
            not Assigned(TGocciaPropertyDescriptorAccessor(TargetDesc).Setter) then
-          ThrowTypeError('Proxy set: cannot set non-configurable accessor symbol property without a setter');
+          ThrowTypeError(SErrorProxySetSymbolNoSetter, SSuggestProxyTrapInvariant);
       end;
     end;
 
@@ -636,10 +637,10 @@ begin
       TargetDesc := TGocciaObjectValue(FTarget).GetOwnPropertyDescriptor(AName);
       // Cannot delete non-configurable own property
       if Assigned(TargetDesc) and not TargetDesc.Configurable then
-        ThrowTypeError('Proxy deleteProperty trap returned true for non-configurable property ''' + AName + '''');
+        ThrowTypeError(Format(SErrorProxyDeleteNonConfigurable, [AName]), SSuggestProxyTrapInvariant);
       // Cannot delete own property on non-extensible target (property still exists)
       if Assigned(TargetDesc) and not TGocciaObjectValue(FTarget).Extensible then
-        ThrowTypeError('Proxy deleteProperty trap returned true for property on non-extensible target');
+        ThrowTypeError(SErrorProxyDeleteNonExtensible, SSuggestProxyTrapInvariant);
     end;
   end
   else
@@ -686,15 +687,15 @@ begin
       begin
         TargetDesc := TGocciaObjectValue(FTarget).GetOwnPropertyDescriptor(AName);
         if Assigned(TargetDesc) and not TargetDesc.Configurable then
-          ThrowTypeError('Proxy getOwnPropertyDescriptor returned undefined for non-configurable property ''' + AName + '''');
+          ThrowTypeError(Format(SErrorProxyGetOwnNonConfigurable, [AName]), SSuggestProxyTrapInvariant);
         if Assigned(TargetDesc) and not TGocciaObjectValue(FTarget).Extensible then
-          ThrowTypeError('Proxy getOwnPropertyDescriptor returned undefined for property on non-extensible target');
+          ThrowTypeError(SErrorProxyGetOwnNonExtensible, SSuggestProxyTrapInvariant);
       end;
       Exit(nil);
     end;
 
     if not (TrapResult is TGocciaObjectValue) then
-      ThrowTypeError('Proxy getOwnPropertyDescriptor must return an object or undefined');
+      ThrowTypeError(SErrorProxyGetOwnReturnType, SSuggestProxyTrapReturnType);
 
     ResultObj := TGocciaObjectValue(TrapResult);
     Flags := [];
@@ -783,9 +784,7 @@ begin
       Args.Add(DescObj);
       TrapResult := InvokeTrap(Trap, Args);
       if not TrapResult.ToBooleanLiteral.Value then
-        ThrowTypeError(
-          'Proxy defineProperty handler returned false for property ''' +
-          AName + '''');
+        ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [AName]), SSuggestProxyTrapInvariant);
     finally
       Args.Free;
     end;
@@ -795,7 +794,7 @@ begin
     if FTarget is TGocciaObjectValue then
       TGocciaObjectValue(FTarget).DefineProperty(AName, ADescriptor)
     else
-      ThrowTypeError('Cannot define property on non-object target');
+      ThrowTypeError(SErrorProxyDefineNonObject, SSuggestProxyTargetType);
   end;
 end;
 
@@ -944,7 +943,7 @@ begin
     end;
 
     if not (TrapResult is TGocciaArrayValue) then
-      ThrowTypeError('Proxy ownKeys must return an array');
+      ThrowTypeError(SErrorProxyOwnKeysArray, SSuggestProxyTrapReturnType);
 
     ResultArray := TGocciaArrayValue(TrapResult);
     SetLength(Keys, ResultArray.Elements.Count);
@@ -954,7 +953,7 @@ begin
       // ES2026 §28.1.1 step 8: Each element must be a String or Symbol.
       if not (Element is TGocciaStringLiteralValue) and
          not (Element is TGocciaSymbolValue) then
-        ThrowTypeError('Proxy ownKeys trap result must contain only strings and symbols');
+        ThrowTypeError(SErrorProxyOwnKeysTypes, SSuggestProxyTrapReturnType);
       Keys[I] := Element.ToStringLiteral.Value;
     end;
 
@@ -972,7 +971,7 @@ begin
           for J := 0 to Length(Keys) - 1 do
             if Keys[J] = TargetKeys[I] then begin Found := True; Break; end;
           if not Found then
-            ThrowTypeError('Proxy ownKeys trap result must include non-configurable property ''' + TargetKeys[I] + '''');
+            ThrowTypeError(Format(SErrorProxyOwnKeysMissing, [TargetKeys[I]]), SSuggestProxyTrapInvariant);
         end;
       end;
     end;
@@ -1043,7 +1042,7 @@ begin
     // ES2026 §10.5.1 step 5: Result must be an Object or null.
     if not (Result is TGocciaObjectValue) and
        not (Result is TGocciaNullLiteralValue) then
-      ThrowTypeError('Proxy getPrototypeOf trap must return an object or null');
+      ThrowTypeError(SErrorProxyGetProtoReturnType, SSuggestProxyTrapReturnType);
 
     // ES2026 §28.1.1 step 8: If target is non-extensible, trap result
     // must be the same as the target's actual prototype.
@@ -1055,8 +1054,7 @@ begin
       else
         TargetProto := TGocciaNullLiteralValue.NullValue;
       if Result <> TargetProto then
-        ThrowTypeError(
-          'Proxy getPrototypeOf trap result does not match non-extensible target prototype');
+        ThrowTypeError(SErrorProxyGetProtoMismatch, SSuggestProxyTrapInvariant);
     end;
   end
   else
@@ -1103,12 +1101,12 @@ begin
       if AProto is TGocciaObjectValue then
       begin
         if TGocciaObjectValue(FTarget).Prototype <> TGocciaObjectValue(AProto) then
-          ThrowTypeError('Proxy setPrototypeOf trap returned true but target is non-extensible');
+          ThrowTypeError(SErrorProxySetProtoNonExtensible, SSuggestProxyTrapInvariant);
       end
       else if AProto is TGocciaNullLiteralValue then
       begin
         if Assigned(TGocciaObjectValue(FTarget).Prototype) then
-          ThrowTypeError('Proxy setPrototypeOf trap returned true but target is non-extensible');
+          ThrowTypeError(SErrorProxySetProtoNonExtensible, SSuggestProxyTrapInvariant);
       end;
     end;
   end
@@ -1168,8 +1166,7 @@ begin
     else
       TargetExtensible := False;
     if Result <> TargetExtensible then
-      ThrowTypeError(
-        'Proxy isExtensible trap result does not match target extensibility');
+      ThrowTypeError(SErrorProxyIsExtensibleMismatch, SSuggestProxyTrapInvariant);
   end
   else
   begin
@@ -1196,7 +1193,7 @@ begin
       Args.Add(FTarget);
       TrapResult := InvokeTrap(Trap, Args);
       if not TrapResult.ToBooleanLiteral.Value then
-        ThrowTypeError('Proxy preventExtensions handler returned false');
+        ThrowTypeError(SErrorProxyPreventExtensionsFalse, SSuggestProxyTrapInvariant);
     finally
       Args.Free;
     end;
@@ -1205,8 +1202,7 @@ begin
     // must actually be non-extensible now.
     if (FTarget is TGocciaObjectValue) and
        TGocciaObjectValue(FTarget).Extensible then
-      ThrowTypeError(
-        'Proxy preventExtensions trap returned true but target is still extensible');
+      ThrowTypeError(SErrorProxyPreventExtensionsStillExtensible, SSuggestProxyTrapInvariant);
   end
   else
   begin
@@ -1228,7 +1224,7 @@ begin
   CheckRevoked;
 
   if not FTarget.IsCallable then
-    ThrowTypeError('Proxy apply trap called on non-function target');
+    ThrowTypeError(SErrorProxyApplyNonFunction, SSuggestProxyTargetType);
 
   Trap := GetTrap(PROP_APPLY);
   if Assigned(Trap) then
@@ -1258,7 +1254,7 @@ begin
     else if FTarget is TGocciaClassValue then
       Result := TGocciaClassValue(FTarget).Call(AArguments, AThisValue)
     else
-      ThrowTypeError('Proxy target is not callable');
+      ThrowTypeError(SErrorProxyTargetNotCallable, SSuggestProxyTargetType);
   end;
 end;
 
@@ -1279,7 +1275,7 @@ begin
           (FTarget is TGocciaClassValue) or
           (FTarget is TGocciaNativeFunctionValue) or
           (FTarget is TGocciaFunctionBase)) then
-    ThrowTypeError('Proxy target is not a constructor');
+    ThrowTypeError(SErrorProxyTargetNotConstructor, SSuggestProxyTargetType);
 
   Trap := GetTrap(PROP_CONSTRUCT);
   if Assigned(Trap) then
@@ -1296,7 +1292,7 @@ begin
       Args.Add(Self);
       Result := InvokeTrap(Trap, Args);
       if Result.IsPrimitive then
-        ThrowTypeError('Proxy construct handler must return an object');
+        ThrowTypeError(SErrorProxyConstructReturnType, SSuggestProxyTrapReturnType);
     finally
       Args.Free;
     end;
@@ -1317,7 +1313,7 @@ begin
       Result := TGocciaFunctionBase(FTarget).Call(AArguments,
         TGocciaHoleValue.HoleValue)
     else
-      ThrowTypeError('Proxy target is not a constructor');
+      ThrowTypeError(SErrorProxyTargetNotConstructor, SSuggestProxyTargetType);
   end;
 end;
 

--- a/units/Goccia.Values.SharedArrayBufferValue.pas
+++ b/units/Goccia.Values.SharedArrayBufferValue.pas
@@ -49,6 +49,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
@@ -144,7 +146,7 @@ begin
     IntegerIndex := 0
   else if Num.IsInfinite then
   begin
-    ThrowRangeError('Invalid shared array buffer length');
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
     Exit;
   end
   else
@@ -152,7 +154,7 @@ begin
 
   // Step 3: If integerIndex is not in [0, 2^53-1], throw RangeError
   if (IntegerIndex < 0) or (IntegerIndex > 9007199254740991) then
-    ThrowRangeError('Invalid shared array buffer length');
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
 
   Len := Trunc(IntegerIndex);
   SetLength(FData, Len);
@@ -188,7 +190,9 @@ end;
 function TGocciaSharedArrayBufferValue.SharedArrayBufferByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaSharedArrayBufferValue) then
-    ThrowTypeError('SharedArrayBuffer.prototype.byteLength requires a SharedArrayBuffer');
+    ThrowTypeError(Format(SErrorRequiresSharedArrayBuffer,
+      ['SharedArrayBuffer.prototype.byteLength']),
+      SSuggestSharedArrayBufferThisType);
   Result := TGocciaNumberLiteralValue.Create(Length(TGocciaSharedArrayBufferValue(AThisValue).FData));
 end;
 
@@ -201,7 +205,9 @@ var
   NewBuf: TGocciaSharedArrayBufferValue;
 begin
   if not (AThisValue is TGocciaSharedArrayBufferValue) then
-    ThrowTypeError('SharedArrayBuffer.prototype.slice requires a SharedArrayBuffer');
+    ThrowTypeError(Format(SErrorRequiresSharedArrayBuffer,
+      ['SharedArrayBuffer.prototype.slice']),
+      SSuggestSharedArrayBufferThisType);
 
   Buf := TGocciaSharedArrayBufferValue(AThisValue);
   Len := Length(Buf.FData);
@@ -245,7 +251,7 @@ begin
 
   // ES2026 §25.2.5.6 step 11: If new.[[ArrayBufferData]] is O.[[ArrayBufferData]], throw TypeError
   if Pointer(NewBuf.FData) = Pointer(Buf.FData) then
-    ThrowTypeError('SharedArrayBuffer subclass returned this from species constructor');
+    ThrowTypeError(SErrorSharedArrayBufferSpeciesReturnedThis, SSuggestSpeciesConstructor);
 
   if NewLen > 0 then
     Move(Buf.FData[First], NewBuf.FData[0], NewLen);

--- a/units/Goccia.Values.StringObjectValue.pas
+++ b/units/Goccia.Values.StringObjectValue.pas
@@ -87,6 +87,8 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.RegExp.Runtime,
   Goccia.Utils,
@@ -255,7 +257,7 @@ begin
   else if AValue is TGocciaStringObjectValue then
     Result := TGocciaStringObjectValue(AValue).Primitive.Value
   else if AValue is TGocciaSymbolValue then
-    ThrowTypeError('Cannot convert a Symbol value to a string')
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion)
   else
     Result := AValue.ToStringLiteral.Value;
 end;
@@ -1026,7 +1028,7 @@ begin
   if not (ReplaceMethod is TGocciaUndefinedLiteralValue) then
   begin
     if not ReplaceMethod.IsCallable then
-      ThrowTypeError('@@replace is not callable');
+      ThrowTypeError(SErrorSymbolReplaceNotCallable, SSuggestWellKnownSymbolCallable);
     CallArgs := TGocciaArgumentsCollection.Create([
       TGocciaStringLiteralValue.Create(StringValue),
       ReplaceArg
@@ -1151,14 +1153,14 @@ begin
 
   if IsRegExpValue(SearchArg) and
      not GetRegExpBooleanProperty(TGocciaObjectValue(SearchArg), PROP_GLOBAL) then
-    ThrowTypeError('String.prototype.replaceAll requires a global RegExp');
+    ThrowTypeError(SErrorReplaceAllRequiresGlobalRegExp, SSuggestReplaceAllGlobalFlag);
 
   ReplaceMethod := GetMethodBySymbol(SearchArg,
     TGocciaSymbolValue.WellKnownReplace);
   if not (ReplaceMethod is TGocciaUndefinedLiteralValue) then
   begin
     if not ReplaceMethod.IsCallable then
-      ThrowTypeError('@@replace is not callable');
+      ThrowTypeError(SErrorSymbolReplaceNotCallable, SSuggestWellKnownSymbolCallable);
     CallArgs := TGocciaArgumentsCollection.Create([
       TGocciaStringLiteralValue.Create(StringValue),
       ReplaceArg
@@ -1301,7 +1303,7 @@ begin
     if not (SplitMethod is TGocciaUndefinedLiteralValue) then
     begin
       if not SplitMethod.IsCallable then
-        ThrowTypeError('@@split is not callable');
+        ThrowTypeError(SErrorSymbolSplitNotCallable, SSuggestWellKnownSymbolCallable);
       if HasLimit then
         CallArgs := TGocciaArgumentsCollection.Create([
           TGocciaStringLiteralValue.Create(StringValue),
@@ -1437,7 +1439,7 @@ begin
     if not (MatchMethod is TGocciaUndefinedLiteralValue) then
     begin
       if not MatchMethod.IsCallable then
-        ThrowTypeError('@@match is not callable');
+        ThrowTypeError(SErrorSymbolMatchNotCallable, SSuggestWellKnownSymbolCallable);
       CallArgs := TGocciaArgumentsCollection.Create([
         TGocciaStringLiteralValue.Create(StringValue)
       ]);
@@ -1502,7 +1504,7 @@ begin
   if (AArgs.Length > 0) and IsRegExpValue(AArgs.GetElement(0)) and
      not GetRegExpBooleanProperty(TGocciaObjectValue(AArgs.GetElement(0)),
        PROP_GLOBAL) then
-    ThrowTypeError('String.prototype.matchAll requires a global RegExp');
+    ThrowTypeError(SErrorMatchAllRequiresGlobalRegExp, SSuggestReplaceAllGlobalFlag);
 
   if AArgs.Length > 0 then
   begin
@@ -1511,7 +1513,7 @@ begin
     if not (MatchAllMethod is TGocciaUndefinedLiteralValue) then
     begin
       if not MatchAllMethod.IsCallable then
-        ThrowTypeError('@@matchAll is not callable');
+        ThrowTypeError(SErrorSymbolMatchAllNotCallable, SSuggestWellKnownSymbolCallable);
       CallArgs := TGocciaArgumentsCollection.Create([
         TGocciaStringLiteralValue.Create(StringValue)
       ]);
@@ -1551,7 +1553,7 @@ begin
     if not (SearchMethod is TGocciaUndefinedLiteralValue) then
     begin
       if not SearchMethod.IsCallable then
-        ThrowTypeError('@@search is not callable');
+        ThrowTypeError(SErrorSymbolSearchNotCallable, SSuggestWellKnownSymbolCallable);
       CallArgs := TGocciaArgumentsCollection.Create([
         TGocciaStringLiteralValue.Create(StringValue)
       ]);
@@ -1608,7 +1610,7 @@ begin
 
   // Step 4: If n < 0 or n = +∞, throw a RangeError exception
   if CountValue.IsInfinity or CountValue.IsNegativeInfinity or (CountValue.Value < 0) then
-    ThrowRangeError('Invalid count value: ' + CountValue.ToStringLiteral.Value);
+    ThrowRangeError(Format(SErrorInvalidRepeatCount, [CountValue.ToStringLiteral.Value]), SSuggestRepeatCountRange);
 
   // Step 5: If n = 0, return ""
   // Step 6: Return S repeated n times
@@ -1718,7 +1720,7 @@ begin
   for I := 0 to AArgs.Length - 1 do
   begin
     if AArgs.GetElement(I) is TGocciaSymbolValue then
-      ThrowTypeError('Cannot convert a Symbol value to a string');
+      ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
     StringValue := StringValue + AArgs.GetElement(I).ToStringLiteral.Value;
   end;
 
@@ -1884,7 +1886,7 @@ begin
 
   // Step 4: If f is not one of "NFC", "NFD", "NFKC", "NFKD", throw a RangeError
   if (Form <> 'NFC') and (Form <> 'NFD') and (Form <> 'NFKC') and (Form <> 'NFKD') then
-    ThrowRangeError('The normalization form should be one of NFC, NFD, NFKC, NFKD');
+    ThrowRangeError(SErrorInvalidNormalizationForm, SSuggestNormalizationForm);
 
   // Step 5: Return the Unicode Normalization Form f of S
   Result := TGocciaStringLiteralValue.Create(StringValue);
@@ -1899,7 +1901,7 @@ var
 begin
   // ES2026 §22.1.3.8 step 1: Let O be RequireObjectCoercible(this value)
   if (AThisValue is TGocciaUndefinedLiteralValue) or (AThisValue is TGocciaNullLiteralValue) then
-    ThrowTypeError('String.prototype.isWellFormed requires that ''this'' not be null or undefined');
+    ThrowTypeError(SErrorIsWellFormedRequiresNonNullish, SSuggestCheckNullBeforeAccess);
   // Step 2: Let S be ToString(O)
   StringValue := ExtractStringValue(AThisValue);
   // Step 3: Return IsStringWellFormedUnicode(S)
@@ -1960,7 +1962,7 @@ var
 begin
   // ES2026 §22.1.3.33 step 1: Let O be RequireObjectCoercible(this value)
   if (AThisValue is TGocciaUndefinedLiteralValue) or (AThisValue is TGocciaNullLiteralValue) then
-    ThrowTypeError('String.prototype.toWellFormed requires that ''this'' not be null or undefined');
+    ThrowTypeError(SErrorToWellFormedRequiresNonNullish, SSuggestCheckNullBeforeAccess);
   // Step 2: Let S be ToString(O)
   StringValue := ExtractStringValue(AThisValue);
   // Step 3: Let result be ""

--- a/units/Goccia.Values.SymbolValue.pas
+++ b/units/Goccia.Values.SymbolValue.pas
@@ -76,6 +76,8 @@ uses
 
   Goccia.Constants.PropertyNames,
   Goccia.Constants.TypeNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.ObjectModel,
   Goccia.Values.ErrorHelper,
@@ -95,7 +97,7 @@ function TGocciaSymbolValue.SymbolToString(const AArgs: TGocciaArgumentsCollecti
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaSymbolValue) then
-    ThrowTypeError('Symbol.prototype.toString requires that ''this'' be a Symbol');
+    ThrowTypeError(SErrorSymbolProtoToStringRequiresSymbol, SSuggestSymbolThisType);
   Result := AThisValue.ToStringLiteral;
 end;
 
@@ -103,7 +105,7 @@ function TGocciaSymbolValue.GetDescription(const AArgs: TGocciaArgumentsCollecti
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaSymbolValue) then
-    ThrowTypeError('Symbol.prototype.description requires that ''this'' be a Symbol');
+    ThrowTypeError(SErrorSymbolProtoDescriptionRequiresSymbol, SSuggestSymbolThisType);
   if TGocciaSymbolValue(AThisValue).FDescription <> '' then
     Result := TGocciaStringLiteralValue.Create(TGocciaSymbolValue(AThisValue).FDescription)
   else
@@ -356,7 +358,7 @@ end;
 
 function TGocciaSymbolValue.ToNumberLiteral: TGocciaNumberLiteralValue;
 begin
-  ThrowTypeError('Cannot convert a Symbol value to a number');
+  ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
   Result := nil;
 end;
 

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -77,6 +77,8 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
@@ -89,7 +91,7 @@ threadvar
 function AsDuration(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalDurationValue;
 begin
   if not (AValue is TGocciaTemporalDurationValue) then
-    ThrowTypeError(AMethod + ' called on non-Duration');
+    ThrowTypeError(AMethod + ' called on non-Duration', SSuggestTemporalThisType);
   Result := TGocciaTemporalDurationValue(AValue);
 end;
 
@@ -148,7 +150,7 @@ begin
                  (AHours < 0) or (AMinutes < 0) or (ASeconds < 0) or
                  (AMilliseconds < 0) or (AMicroseconds < 0) or (ANanoseconds < 0);
   if HasPositive and HasNegative then
-    ThrowRangeError('Duration fields must not have mixed signs');
+    ThrowRangeError(SErrorDurationMixedSigns, SSuggestTemporalDurationSigns);
 
   InitializePrototype;
   if Assigned(FShared) then
@@ -395,13 +397,13 @@ begin
         DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
         DurRec.Milliseconds, DurRec.Microseconds, DurRec.Nanoseconds)
     else
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
   end
   else if Arg is TGocciaObjectValue then
     Other := DurationFromObject(TGocciaObjectValue(Arg))
   else
   begin
-    ThrowTypeError('Invalid argument to Duration.prototype.add');
+    ThrowTypeError(SErrorInvalidDurationAddArg, SSuggestTemporalDurationArg);
     Other := nil;
   end;
 
@@ -433,13 +435,13 @@ begin
         DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
         DurRec.Milliseconds, DurRec.Microseconds, DurRec.Nanoseconds)
     else
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
   end
   else if Arg is TGocciaObjectValue then
     Other := DurationFromObject(TGocciaObjectValue(Arg))
   else
   begin
-    ThrowTypeError('Invalid argument to Duration.prototype.subtract');
+    ThrowTypeError(SErrorInvalidDurationSubtractArg, SSuggestTemporalDurationArg);
     Other := nil;
   end;
 
@@ -474,7 +476,7 @@ begin
   D := AsDuration(AThisValue, 'Duration.prototype.with');
   V := AArgs.GetElement(0);
   if not (V is TGocciaObjectValue) then
-    ThrowTypeError('Duration.prototype.with requires an object argument');
+    ThrowTypeError(Format(SErrorTemporalWithRequiresObject, ['Duration']), SSuggestTemporalWithObject);
   Obj := TGocciaObjectValue(V);
 
   Result := TGocciaTemporalDurationValue.Create(
@@ -508,7 +510,7 @@ begin
   Arg := AArgs.GetElement(0);
 
   if (D.FYears <> 0) or (D.FMonths <> 0) then
-    ThrowRangeError('Duration with years or months requires relativeTo for round()');
+    ThrowRangeError(SErrorDurationRoundRequiresRelativeTo, SSuggestTemporalRelativeTo);
 
   SmallestUnit := tuNone;
   LargestUnit := tuNone;
@@ -518,7 +520,7 @@ begin
   if Arg is TGocciaStringLiteralValue then
   begin
     if not GetTemporalUnitFromString(TGocciaStringLiteralValue(Arg).Value, SmallestUnit) then
-      ThrowRangeError('Invalid unit for Duration.prototype.round: ' + TGocciaStringLiteralValue(Arg).Value);
+      ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Duration.prototype.round', TGocciaStringLiteralValue(Arg).Value]), SSuggestTemporalValidUnits);
   end
   else if Arg is TGocciaObjectValue then
   begin
@@ -529,11 +531,11 @@ begin
     Increment := GetRoundingIncrement(OptionsObj, 1);
   end
   else
-    ThrowTypeError('Duration.prototype.round requires a string or options object');
+    ThrowTypeError(Format(SErrorTemporalRoundRequiresStringOrOptions, ['Duration']), SSuggestTemporalRoundArg);
 
   // If only largestUnit is specified, rebalance without rounding
   if (SmallestUnit = tuNone) and (LargestUnit = tuNone) then
-    ThrowRangeError('round() requires at least a smallestUnit or largestUnit');
+    ThrowRangeError(SErrorDurationRoundRequiresUnit, SSuggestTemporalRoundArg);
   if SmallestUnit = tuNone then
     SmallestUnit := tuNanosecond;
   if LargestUnit = tuNone then
@@ -645,7 +647,7 @@ begin
 
     Arg := OptionsObj.GetProperty('unit');
     if (Arg = nil) or (Arg is TGocciaUndefinedLiteralValue) then
-      ThrowRangeError('total() requires a unit option');
+      ThrowRangeError(SErrorDurationTotalRequiresUnit, SSuggestTemporalValidUnits);
     UnitStr := Arg.ToStringLiteral.Value;
 
     RelToArg := OptionsObj.GetProperty('relativeTo');
@@ -653,16 +655,16 @@ begin
   end
   else
   begin
-    ThrowTypeError('Duration.prototype.total requires a string or options object');
+    ThrowTypeError(SErrorDurationTotalRequiresStringOrOptions, SSuggestTemporalValidUnits);
     UnitStr := '';
   end;
 
   if (D.FYears <> 0) or (D.FMonths <> 0) then
   begin
     if HasRelativeTo then
-      ThrowRangeError('relativeTo for Duration.prototype.total is not yet supported')
+      ThrowRangeError(SErrorDurationTotalRelativeToUnsupported, SSuggestTemporalRelativeTo)
     else
-      ThrowRangeError('Duration with years or months requires relativeTo for total()');
+      ThrowRangeError(SErrorDurationTotalRequiresRelativeTo, SSuggestTemporalRelativeTo);
   end;
 
   TotalNs := D.FNanoseconds +
@@ -692,7 +694,7 @@ begin
     Result := TGocciaNumberLiteralValue.Create(TotalNs / 6.048e14)
   else
   begin
-    ThrowRangeError('Invalid unit for Duration.prototype.total: ' + UnitStr);
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Duration.prototype.total', UnitStr]), SSuggestTemporalValidUnits);
     Result := nil;
   end;
 end;
@@ -711,7 +713,7 @@ end;
 
 function TGocciaTemporalDurationValue.DurationValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Temporal.Duration.prototype.valueOf cannot be used; use toString or compare instead');
+  ThrowTypeError(Format(SErrorTemporalValueOf, ['Duration', 'toString or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
 end;
 

--- a/units/Goccia.Values.TemporalInstant.pas
+++ b/units/Goccia.Values.TemporalInstant.pas
@@ -44,6 +44,10 @@ type
 implementation
 
 uses
+  SysUtils,
+
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
@@ -57,7 +61,7 @@ threadvar
 function AsInstant(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalInstantValue;
 begin
   if not (AValue is TGocciaTemporalInstantValue) then
-    ThrowTypeError(AMethod + ' called on non-Instant');
+    ThrowTypeError(AMethod + ' called on non-Instant', SSuggestTemporalThisType);
   Result := TGocciaTemporalInstantValue(AValue);
 end;
 
@@ -74,7 +78,7 @@ begin
   begin
     // Parse as ISO date-time and convert to epoch
     if not TryParseISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
-      ThrowTypeError('Invalid ISO instant string for ' + AMethod);
+      ThrowTypeError(Format(SErrorTemporalInvalidISOStringFor, ['instant', AMethod]), SSuggestTemporalISOFormat);
     EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * Int64(86400000) +
                Int64(TimeRec.Hour) * 3600000 + Int64(TimeRec.Minute) * 60000 +
                Int64(TimeRec.Second) * 1000 + TimeRec.Millisecond;
@@ -83,7 +87,7 @@ begin
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires an Instant or string');
+    ThrowTypeError(AMethod + ' requires an Instant or string', SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -202,20 +206,20 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(0, 0, 0, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
       DurRec.Milliseconds, DurRec.Microseconds, DurRec.Nanoseconds);
   end
   else
   begin
-    ThrowTypeError('Instant.prototype.add requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalAddRequiresDuration, ['Instant']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
   // Instant only supports time-based duration
   if (Dur.Years <> 0) or (Dur.Months <> 0) or (Dur.Weeks <> 0) then
-    ThrowRangeError('Instant.prototype.add does not support years, months, or weeks');
+    ThrowRangeError(SErrorInstantAddNoCalendar, SSuggestTemporalDurationArg);
 
   NewMs := Inst.FEpochMilliseconds +
            Dur.Days * Int64(86400000) +
@@ -246,19 +250,19 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(0, 0, 0, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
       DurRec.Milliseconds, DurRec.Microseconds, DurRec.Nanoseconds);
   end
   else
   begin
-    ThrowTypeError('Instant.prototype.subtract requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalSubtractRequiresDuration, ['Instant']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
   if (Dur.Years <> 0) or (Dur.Months <> 0) or (Dur.Weeks <> 0) then
-    ThrowRangeError('Instant.prototype.subtract does not support years, months, or weeks');
+    ThrowRangeError(SErrorInstantSubtractNoCalendar, SSuggestTemporalDurationArg);
 
   NewMs := Inst.FEpochMilliseconds -
            Dur.Days * Int64(86400000) -
@@ -343,20 +347,20 @@ begin
   begin
     UnitStr := TGocciaStringLiteralValue(Arg).Value;
     if not GetTemporalUnitFromString(UnitStr, SmallestUnit) then
-      ThrowRangeError('Invalid unit for Instant.prototype.round: ' + UnitStr);
+      ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.round', UnitStr]), SSuggestTemporalValidUnits);
   end
   else if Arg is TGocciaObjectValue then
   begin
     OptionsObj := TGocciaObjectValue(Arg);
     SmallestUnit := GetSmallestUnit(OptionsObj, tuNone);
     if SmallestUnit = tuNone then
-      ThrowRangeError('round() requires a smallestUnit option');
+      ThrowRangeError(SErrorTemporalRoundRequiresSmallestUnit, SSuggestTemporalRoundArg);
     Mode := GetRoundingMode(OptionsObj, rmHalfExpand);
     Increment := GetRoundingIncrement(OptionsObj, 1);
   end
   else
   begin
-    ThrowTypeError('Instant.prototype.round requires a string or options object');
+    ThrowTypeError(Format(SErrorTemporalRoundRequiresStringOrOptions, ['Instant']), SSuggestTemporalRoundArg);
     SmallestUnit := tuNanosecond;
   end;
 
@@ -432,7 +436,7 @@ end;
 
 function TGocciaTemporalInstantValue.InstantValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Temporal.Instant.prototype.valueOf cannot be used; use epochMilliseconds, epochNanoseconds, or compare instead');
+  ThrowTypeError(Format(SErrorTemporalValueOf, ['Instant', 'epochMilliseconds, epochNanoseconds, or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
 end;
 

--- a/units/Goccia.Values.TemporalPlainDate.pas
+++ b/units/Goccia.Values.TemporalPlainDate.pas
@@ -62,6 +62,10 @@ type
 implementation
 
 uses
+  SysUtils,
+
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
@@ -92,7 +96,7 @@ end;
 function AsPlainDate(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainDateValue;
 begin
   if not (AValue is TGocciaTemporalPlainDateValue) then
-    ThrowTypeError(AMethod + ' called on non-PlainDate');
+    ThrowTypeError(AMethod + ' called on non-PlainDate', SSuggestTemporalThisType);
   Result := TGocciaTemporalPlainDateValue(AValue);
 end;
 
@@ -113,7 +117,7 @@ begin
       if TryParseISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
         Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day)
       else
-        ThrowTypeError('Invalid ISO date string for ' + AMethod);
+        ThrowTypeError(Format(SErrorTemporalInvalidISOStringFor, ['date', AMethod]), SSuggestTemporalISOFormat);
     end
     else
       Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day);
@@ -123,13 +127,13 @@ begin
     Obj := TGocciaObjectValue(AValue);
     V := Obj.GetProperty('year');
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires year, month, day properties');
+      ThrowTypeError(AMethod + ' requires year, month, day properties', SSuggestTemporalFromArg);
     VMonth := Obj.GetProperty('month');
     if (VMonth = nil) or (VMonth is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires year, month, day properties');
+      ThrowTypeError(AMethod + ' requires year, month, day properties', SSuggestTemporalFromArg);
     VDay := Obj.GetProperty('day');
     if (VDay = nil) or (VDay is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires year, month, day properties');
+      ThrowTypeError(AMethod + ' requires year, month, day properties', SSuggestTemporalFromArg);
     Result := TGocciaTemporalPlainDateValue.Create(
       Trunc(V.ToNumberLiteral.Value),
       Trunc(VMonth.ToNumberLiteral.Value),
@@ -137,7 +141,7 @@ begin
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires a PlainDate, string, or object');
+    ThrowTypeError(AMethod + ' requires a PlainDate, string, or object', SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -148,7 +152,7 @@ constructor TGocciaTemporalPlainDateValue.Create(const AYear, AMonth, ADay: Inte
 begin
   inherited Create(nil);
   if not IsValidDate(AYear, AMonth, ADay) then
-    ThrowRangeError('Invalid date: ' + FormatDateString(AYear, AMonth, ADay));
+    ThrowRangeError(Format(SErrorInvalidDate, [FormatDateString(AYear, AMonth, ADay)]), SSuggestTemporalDateRange);
   FYear := AYear;
   FMonth := AMonth;
   FDay := ADay;
@@ -334,7 +338,7 @@ begin
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.with');
   V := AArgs.GetElement(0);
   if not (V is TGocciaObjectValue) then
-    ThrowTypeError('PlainDate.prototype.with requires an object argument');
+    ThrowTypeError(Format(SErrorTemporalWithRequiresObject, ['PlainDate']), SSuggestTemporalWithObject);
   Obj := TGocciaObjectValue(V);
 
   NewYear := GetFieldOr('year', D.FYear);
@@ -361,7 +365,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -379,7 +383,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('PlainDate.prototype.add requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalAddRequiresDuration, ['PlainDate']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
@@ -428,7 +432,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -446,7 +450,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('PlainDate.prototype.subtract requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalSubtractRequiresDuration, ['PlainDate']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
@@ -527,7 +531,7 @@ end;
 
 function TGocciaTemporalPlainDateValue.DateValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Temporal.PlainDate.prototype.valueOf cannot be used; use toString or compare instead');
+  ThrowTypeError(Format(SErrorTemporalValueOf, ['PlainDate', 'toString or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
 end;
 
@@ -614,12 +618,12 @@ begin
   begin
     Arg := TGocciaObjectValue(Arg).GetProperty('timeZone');
     if (Arg = nil) or (Arg is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError('PlainDate.prototype.toZonedDateTime requires a timeZone');
+      ThrowTypeError(SErrorPlainDateToZonedRequiresTZ, SSuggestTemporalTimezone);
     TimeZoneStr := Arg.ToStringLiteral.Value;
   end
   else
   begin
-    ThrowTypeError('PlainDate.prototype.toZonedDateTime requires a timezone string or options object');
+    ThrowTypeError(SErrorPlainDateToZonedRequiresStringOrOptions, SSuggestTemporalTimezone);
     TimeZoneStr := '';
   end;
 

--- a/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -84,6 +84,10 @@ type
 implementation
 
 uses
+  SysUtils,
+
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
@@ -103,7 +107,7 @@ threadvar
 function AsPlainDateTime(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainDateTimeValue;
 begin
   if not (AValue is TGocciaTemporalPlainDateTimeValue) then
-    ThrowTypeError(AMethod + ' called on non-PlainDateTime');
+    ThrowTypeError(AMethod + ' called on non-PlainDateTime', SSuggestTemporalThisType);
   Result := TGocciaTemporalPlainDateTimeValue(AValue);
 end;
 
@@ -119,7 +123,7 @@ var
   begin
     V := Obj.GetProperty(AName);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires ' + AName + ' property');
+      ThrowTypeError(AMethod + ' requires ' + AName + ' property', SSuggestTemporalFromArg);
     Result := Trunc(V.ToNumberLiteral.Value);
   end;
 
@@ -138,7 +142,7 @@ begin
   else if AValue is TGocciaStringLiteralValue then
   begin
     if not TryParseISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
-      ThrowTypeError('Invalid ISO date-time string for ' + AMethod);
+      ThrowTypeError(Format(SErrorTemporalInvalidISOStringFor, ['date-time', AMethod]), SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainDateTimeValue.Create(
       DateRec.Year, DateRec.Month, DateRec.Day,
       TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
@@ -158,7 +162,7 @@ begin
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires a PlainDateTime, string, or object');
+    ThrowTypeError(AMethod + ' requires a PlainDateTime, string, or object', SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -170,9 +174,9 @@ constructor TGocciaTemporalPlainDateTimeValue.Create(const AYear, AMonth, ADay, 
 begin
   inherited Create(nil);
   if not IsValidDate(AYear, AMonth, ADay) then
-    ThrowRangeError('Invalid date in PlainDateTime');
+    ThrowRangeError(SErrorInvalidDateInPlainDateTime, SSuggestTemporalDateRange);
   if not IsValidTime(AHour, AMinute, ASecond, AMillisecond, AMicrosecond, ANanosecond) then
-    ThrowRangeError('Invalid time in PlainDateTime');
+    ThrowRangeError(SErrorInvalidTimeInPlainDateTime, SSuggestTemporalDateRange);
   FYear := AYear;
   FMonth := AMonth;
   FDay := ADay;
@@ -402,7 +406,7 @@ begin
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.with');
   V := AArgs.GetElement(0);
   if not (V is TGocciaObjectValue) then
-    ThrowTypeError('PlainDateTime.prototype.with requires an object argument');
+    ThrowTypeError(Format(SErrorTemporalWithRequiresObject, ['PlainDateTime']), SSuggestTemporalWithObject);
   Obj := TGocciaObjectValue(V);
 
   Result := TGocciaTemporalPlainDateTimeValue.Create(
@@ -435,10 +439,12 @@ begin
     else if Arg is TGocciaStringLiteralValue then
     begin
       if not TryParseISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
-        ThrowTypeError('Invalid time string');
+        ThrowTypeError(SErrorInvalidTimeString, SSuggestTemporalISOFormat);
       H := TimeRec.Hour; Mi := TimeRec.Minute; S := TimeRec.Second;
       Ms := TimeRec.Millisecond; Us := TimeRec.Microsecond; Ns := TimeRec.Nanosecond;
-    end;
+    end
+    else
+      ThrowTypeError(SErrorPlainDateTimeWithPlainTimeArg, SSuggestTemporalFromArg);
   end;
 
   Result := TGocciaTemporalPlainDateTimeValue.Create(D.FYear, D.FMonth, D.FDay, H, Mi, S, Ms, Us, Ns);
@@ -466,7 +472,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -490,7 +496,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('PlainDateTime.prototype.add requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalAddRequiresDuration, ['PlainDateTime']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
@@ -535,7 +541,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -559,7 +565,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('PlainDateTime.prototype.subtract requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalSubtractRequiresDuration, ['PlainDateTime']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
@@ -660,20 +666,20 @@ begin
   begin
     UnitStr := TGocciaStringLiteralValue(Arg).Value;
     if not GetTemporalUnitFromString(UnitStr, SmallestUnit) then
-      ThrowRangeError('Invalid unit for PlainDateTime.prototype.round: ' + UnitStr);
+      ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDateTime.prototype.round', UnitStr]), SSuggestTemporalValidUnits);
   end
   else if Arg is TGocciaObjectValue then
   begin
     OptionsObj := TGocciaObjectValue(Arg);
     SmallestUnit := GetSmallestUnit(OptionsObj, tuNone);
     if SmallestUnit = tuNone then
-      ThrowRangeError('round() requires a smallestUnit option');
+      ThrowRangeError(SErrorTemporalRoundRequiresSmallestUnit, SSuggestTemporalRoundArg);
     Mode := GetRoundingMode(OptionsObj, rmHalfExpand);
     Increment := GetRoundingIncrement(OptionsObj, 1);
   end
   else
   begin
-    ThrowTypeError('PlainDateTime.prototype.round requires a string or options object');
+    ThrowTypeError(Format(SErrorTemporalRoundRequiresStringOrOptions, ['PlainDateTime']), SSuggestTemporalRoundArg);
     SmallestUnit := tuNanosecond;
   end;
 
@@ -740,7 +746,7 @@ end;
 
 function TGocciaTemporalPlainDateTimeValue.DateTimeValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Temporal.PlainDateTime.prototype.valueOf cannot be used; use toString or compare instead');
+  ThrowTypeError(Format(SErrorTemporalValueOf, ['PlainDateTime', 'toString or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
 end;
 
@@ -794,17 +800,17 @@ begin
   begin
     Arg := TGocciaObjectValue(Arg).GetProperty('timeZone');
     if (Arg = nil) or (Arg is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError('PlainDateTime.prototype.toZonedDateTime requires a timeZone');
+      ThrowTypeError(SErrorPlainDateTimeToZonedRequiresTZ, SSuggestTemporalTimezone);
     TimeZoneStr := Arg.ToStringLiteral.Value;
   end
   else
   begin
-    ThrowTypeError('PlainDateTime.prototype.toZonedDateTime requires a timezone string or options object');
+    ThrowTypeError(SErrorPlainDateTimeToZonedRequiresStringOrOptions, SSuggestTemporalTimezone);
     TimeZoneStr := '';
   end;
 
   if not IsValidTimeZone(TimeZoneStr) then
-    ThrowRangeError('PlainDateTime.prototype.toZonedDateTime: unknown timezone ' + TimeZoneStr);
+    ThrowRangeError(Format(SErrorPlainDateTimeToZonedUnknownTZ, [TimeZoneStr]), SSuggestTemporalTimezone);
 
   // Compute epoch ms from local components
   EpochMs := DateToEpochDays(D.FYear, D.FMonth, D.FDay) * Int64(86400000) +

--- a/units/Goccia.Values.TemporalPlainMonthDay.pas
+++ b/units/Goccia.Values.TemporalPlainMonthDay.pas
@@ -48,6 +48,8 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -63,7 +65,7 @@ const
 function AsPlainMonthDay(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainMonthDayValue;
 begin
   if not (AValue is TGocciaTemporalPlainMonthDayValue) then
-    ThrowTypeError(AMethod + ' called on non-PlainMonthDay');
+    ThrowTypeError(AMethod + ' called on non-PlainMonthDay', SSuggestTemporalThisType);
   Result := TGocciaTemporalPlainMonthDayValue(AValue);
 end;
 
@@ -86,11 +88,11 @@ begin
     S := TGocciaStringLiteralValue(AValue).Value;
     DashPos := Pos('-', S);
     if (DashPos < 2) or (DashPos >= Length(S)) then
-      ThrowTypeError('Invalid month-day string for ' + AMethod);
+      ThrowTypeError(Format(SErrorInvalidMonthDayStringFor, [AMethod]), SSuggestTemporalISOFormat);
     if not TryStrToInt(Copy(S, 1, DashPos - 1), MonthPart) then
-      ThrowTypeError('Invalid month-day string for ' + AMethod);
+      ThrowTypeError(Format(SErrorInvalidMonthDayStringFor, [AMethod]), SSuggestTemporalISOFormat);
     if not TryStrToInt(Copy(S, DashPos + 1, Length(S) - DashPos), DayPart) then
-      ThrowTypeError('Invalid month-day string for ' + AMethod);
+      ThrowTypeError(Format(SErrorInvalidMonthDayStringFor, [AMethod]), SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainMonthDayValue.Create(MonthPart, DayPart);
   end
   else if AValue is TGocciaObjectValue then
@@ -98,23 +100,23 @@ begin
     Obj := TGocciaObjectValue(AValue);
     VDay := Obj.GetProperty(PROP_DAY);
     if (VDay = nil) or (VDay is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires day property');
+      ThrowTypeError(AMethod + ' requires day property', SSuggestTemporalFromArg);
     VMonthCode := Obj.GetProperty(PROP_MONTH_CODE);
     if Assigned(VMonthCode) and not (VMonthCode is TGocciaUndefinedLiteralValue) then
     begin
       MonthCodeStr := VMonthCode.ToStringLiteral.Value;
       if (Length(MonthCodeStr) <> 3) or (MonthCodeStr[1] <> 'M') or
          not (MonthCodeStr[2] in ['0'..'9']) or not (MonthCodeStr[3] in ['0'..'9']) then
-        ThrowTypeError('Invalid monthCode for ' + AMethod);
+        ThrowTypeError(Format(SErrorInvalidMonthCodeFor, [AMethod]), SSuggestTemporalMonthCode);
       if not TryStrToInt(Copy(MonthCodeStr, 2, 2), MonthPart) then
-        ThrowTypeError('Invalid monthCode for ' + AMethod);
+        ThrowTypeError(Format(SErrorInvalidMonthCodeFor, [AMethod]), SSuggestTemporalMonthCode);
       if (MonthPart < 1) or (MonthPart > 12) then
-        ThrowRangeError('monthCode month out of range in ' + AMethod);
+        ThrowRangeError(Format(SErrorMonthCodeOutOfRangeIn, [AMethod]), SSuggestTemporalMonthCode);
       // Validate month/monthCode consistency when both are provided
       V := Obj.GetProperty(PROP_MONTH);
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
         if Trunc(V.ToNumberLiteral.Value) <> MonthPart then
-          ThrowRangeError('month and monthCode must match in ' + AMethod);
+          ThrowRangeError(Format(SErrorMonthCodeMismatchIn, [AMethod]), SSuggestTemporalMonthCode);
     end
     else
     begin
@@ -122,14 +124,14 @@ begin
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
         MonthPart := Trunc(V.ToNumberLiteral.Value)
       else
-        ThrowTypeError(AMethod + ' requires monthCode or month property');
+        ThrowTypeError(AMethod + ' requires monthCode or month property', SSuggestTemporalFromArg);
     end;
     Result := TGocciaTemporalPlainMonthDayValue.Create(
       MonthPart, Trunc(VDay.ToNumberLiteral.Value));
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires a PlainMonthDay, string, or object');
+    ThrowTypeError(AMethod + ' requires a PlainMonthDay, string, or object', SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -145,7 +147,7 @@ constructor TGocciaTemporalPlainMonthDayValue.Create(const AMonth, ADay, ARefere
 begin
   inherited Create(nil);
   if not IsValidDate(AReferenceYear, AMonth, ADay) then
-    ThrowRangeError('Invalid month-day: ' + PadTwo(AMonth) + '-' + PadTwo(ADay));
+    ThrowRangeError(Format(SErrorInvalidMonthDay, [PadTwo(AMonth) + '-' + PadTwo(ADay)]), SSuggestTemporalDateRange);
   FMonth := AMonth;
   FDay := ADay;
   FReferenceYear := AReferenceYear;
@@ -240,7 +242,7 @@ begin
   MD := AsPlainMonthDay(AThisValue, 'PlainMonthDay.prototype.with');
   V := AArgs.GetElement(0);
   if not (V is TGocciaObjectValue) then
-    ThrowTypeError('PlainMonthDay.prototype.with requires an object argument');
+    ThrowTypeError(Format(SErrorTemporalWithRequiresObject, ['PlainMonthDay']), SSuggestTemporalWithObject);
   Obj := TGocciaObjectValue(V);
 
   NewMonth := MD.FMonth;
@@ -250,16 +252,16 @@ begin
     MonthCodeStr := V.ToStringLiteral.Value;
     if (Length(MonthCodeStr) <> 3) or (MonthCodeStr[1] <> 'M') or
        not (MonthCodeStr[2] in ['0'..'9']) or not (MonthCodeStr[3] in ['0'..'9']) then
-      ThrowTypeError('Invalid monthCode in PlainMonthDay.prototype.with');
+      ThrowTypeError(Format(SErrorInvalidMonthCodeFor, ['PlainMonthDay.prototype.with']), SSuggestTemporalMonthCode);
     if not TryStrToInt(Copy(MonthCodeStr, 2, 2), NewMonth) then
-      ThrowTypeError('Invalid monthCode in PlainMonthDay.prototype.with');
+      ThrowTypeError(Format(SErrorInvalidMonthCodeFor, ['PlainMonthDay.prototype.with']), SSuggestTemporalMonthCode);
     if (NewMonth < 1) or (NewMonth > 12) then
-      ThrowRangeError('monthCode month out of range in PlainMonthDay.prototype.with');
+      ThrowRangeError(Format(SErrorMonthCodeOutOfRangeIn, ['PlainMonthDay.prototype.with']), SSuggestTemporalMonthCode);
     // Validate month/monthCode consistency when both are provided
     V := Obj.GetProperty(PROP_MONTH);
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
       if Trunc(V.ToNumberLiteral.Value) <> NewMonth then
-        ThrowRangeError('month and monthCode must match in PlainMonthDay.prototype.with');
+        ThrowRangeError(Format(SErrorMonthCodeMismatchIn, ['PlainMonthDay.prototype.with']), SSuggestTemporalMonthCode);
   end
   else
   begin
@@ -307,7 +309,7 @@ end;
 // TC39 Temporal §11.3.10 Temporal.PlainMonthDay.prototype.valueOf()
 function TGocciaTemporalPlainMonthDayValue.MonthDayValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Temporal.PlainMonthDay.prototype.valueOf cannot be used; use toString or compare instead');
+  ThrowTypeError(Format(SErrorTemporalValueOf, ['PlainMonthDay', 'toString or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
 end;
 
@@ -323,11 +325,11 @@ begin
   Arg := AArgs.GetElement(0);
 
   if not (Arg is TGocciaObjectValue) then
-    ThrowTypeError('PlainMonthDay.prototype.toPlainDate requires an object with a year property');
+    ThrowTypeError(SErrorPlainMonthDayToPlainDateRequiresYear, SSuggestTemporalToPlainDateYear);
   Obj := TGocciaObjectValue(Arg);
   V := Obj.GetProperty(PROP_YEAR);
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-    ThrowTypeError('PlainMonthDay.prototype.toPlainDate requires an object with a year property');
+    ThrowTypeError(SErrorPlainMonthDayToPlainDateRequiresYear, SSuggestTemporalToPlainDateYear);
 
   YearValue := Trunc(V.ToNumberLiteral.Value);
   Result := TGocciaTemporalPlainDateValue.Create(YearValue, MD.FMonth, MD.FDay);

--- a/units/Goccia.Values.TemporalPlainTime.pas
+++ b/units/Goccia.Values.TemporalPlainTime.pas
@@ -57,6 +57,10 @@ type
 implementation
 
 uses
+  SysUtils,
+
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
@@ -70,7 +74,7 @@ threadvar
 function AsPlainTime(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainTimeValue;
 begin
   if not (AValue is TGocciaTemporalPlainTimeValue) then
-    ThrowTypeError(AMethod + ' called on non-PlainTime');
+    ThrowTypeError(AMethod + ' called on non-PlainTime', SSuggestTemporalThisType);
   Result := TGocciaTemporalPlainTimeValue(AValue);
 end;
 
@@ -86,7 +90,7 @@ begin
   else if AValue is TGocciaStringLiteralValue then
   begin
     if not TryParseISOTime(TGocciaStringLiteralValue(AValue).Value, TimeRec) then
-      ThrowTypeError('Invalid ISO time string for ' + AMethod);
+      ThrowTypeError(Format(SErrorTemporalInvalidISOStringFor, ['time', AMethod]), SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainTimeValue.Create(
       TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
       TimeRec.Millisecond, TimeRec.Microsecond, TimeRec.Nanosecond);
@@ -111,7 +115,7 @@ begin
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires a PlainTime, string, or object');
+    ThrowTypeError(AMethod + ' requires a PlainTime, string, or object', SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -132,7 +136,7 @@ constructor TGocciaTemporalPlainTimeValue.Create(const AHour, AMinute, ASecond, 
 begin
   inherited Create(nil);
   if not IsValidTime(AHour, AMinute, ASecond, AMillisecond, AMicrosecond, ANanosecond) then
-    ThrowRangeError('Invalid time');
+    ThrowRangeError(SErrorInvalidTime, SSuggestTemporalDateRange);
   FHour := AHour;
   FMinute := AMinute;
   FSecond := ASecond;
@@ -245,7 +249,7 @@ begin
   T := AsPlainTime(AThisValue, 'PlainTime.prototype.with');
   V := AArgs.GetElement(0);
   if not (V is TGocciaObjectValue) then
-    ThrowTypeError('PlainTime.prototype.with requires an object argument');
+    ThrowTypeError(Format(SErrorTemporalWithRequiresObject, ['PlainTime']), SSuggestTemporalWithObject);
   Obj := TGocciaObjectValue(V);
 
   Result := TGocciaTemporalPlainTimeValue.Create(
@@ -277,7 +281,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -303,7 +307,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('PlainTime.prototype.add requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalAddRequiresDuration, ['PlainTime']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
@@ -341,7 +345,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -367,7 +371,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('PlainTime.prototype.subtract requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalSubtractRequiresDuration, ['PlainTime']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
@@ -446,20 +450,20 @@ begin
   begin
     UnitStr := TGocciaStringLiteralValue(Arg).Value;
     if not GetTemporalUnitFromString(UnitStr, SmallestUnit) then
-      ThrowRangeError('Invalid unit for PlainTime.prototype.round: ' + UnitStr);
+      ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.round', UnitStr]), SSuggestTemporalValidUnits);
   end
   else if Arg is TGocciaObjectValue then
   begin
     OptionsObj := TGocciaObjectValue(Arg);
     SmallestUnit := GetSmallestUnit(OptionsObj, tuNone);
     if SmallestUnit = tuNone then
-      ThrowRangeError('round() requires a smallestUnit option');
+      ThrowRangeError(SErrorTemporalRoundRequiresSmallestUnit, SSuggestTemporalRoundArg);
     Mode := GetRoundingMode(OptionsObj, rmHalfExpand);
     Increment := GetRoundingIncrement(OptionsObj, 1);
   end
   else
   begin
-    ThrowTypeError('PlainTime.prototype.round requires a string or options object');
+    ThrowTypeError(Format(SErrorTemporalRoundRequiresStringOrOptions, ['PlainTime']), SSuggestTemporalRoundArg);
     SmallestUnit := tuNanosecond;
   end;
 
@@ -517,7 +521,7 @@ end;
 
 function TGocciaTemporalPlainTimeValue.TimeValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Temporal.PlainTime.prototype.valueOf cannot be used; use toString or compare instead');
+  ThrowTypeError(Format(SErrorTemporalValueOf, ['PlainTime', 'toString or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
 end;
 

--- a/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -55,6 +55,8 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -98,7 +100,7 @@ end;
 function AsPlainYearMonth(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainYearMonthValue;
 begin
   if not (AValue is TGocciaTemporalPlainYearMonthValue) then
-    ThrowTypeError(AMethod + ' called on non-PlainYearMonth');
+    ThrowTypeError(AMethod + ' called on non-PlainYearMonth', SSuggestTemporalThisType);
   Result := TGocciaTemporalPlainYearMonthValue(AValue);
 end;
 
@@ -122,32 +124,32 @@ begin
     begin
       Inc(Pos);
       if not TryParseYearMonthDigits(S, Pos, 6, Year) then
-        ThrowTypeError('Invalid year-month string for ' + AMethod);
+        ThrowTypeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
     end
     else if (Pos <= Length(S)) and (S[Pos] = '-') then
     begin
       Inc(Pos);
       Sign := -1;
       if not TryParseYearMonthDigits(S, Pos, 6, Year) then
-        ThrowTypeError('Invalid year-month string for ' + AMethod);
+        ThrowTypeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
     end
     else
     begin
       if not TryParseYearMonthDigits(S, Pos, 4, Year) then
-        ThrowTypeError('Invalid year-month string for ' + AMethod);
+        ThrowTypeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
     end;
 
     Year := Year * Sign;
 
     if (Pos > Length(S)) or (S[Pos] <> '-') then
-      ThrowTypeError('Invalid year-month string for ' + AMethod);
+      ThrowTypeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
     Inc(Pos);
 
     if not TryParseYearMonthDigits(S, Pos, 2, Month) then
-      ThrowTypeError('Invalid year-month string for ' + AMethod);
+      ThrowTypeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
 
     if Pos <= Length(S) then
-      ThrowTypeError('Invalid year-month string for ' + AMethod);
+      ThrowTypeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
 
     Result := TGocciaTemporalPlainYearMonthValue.Create(Year, Month);
   end
@@ -156,17 +158,17 @@ begin
     Obj := TGocciaObjectValue(AValue);
     V := Obj.GetProperty('year');
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires year and month properties');
+      ThrowTypeError(AMethod + ' requires year and month properties', SSuggestTemporalFromArg);
     VMonth := Obj.GetProperty('month');
     if (VMonth = nil) or (VMonth is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires year and month properties');
+      ThrowTypeError(AMethod + ' requires year and month properties', SSuggestTemporalFromArg);
     Result := TGocciaTemporalPlainYearMonthValue.Create(
       Trunc(V.ToNumberLiteral.Value),
       Trunc(VMonth.ToNumberLiteral.Value));
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires a PlainYearMonth, string, or object');
+    ThrowTypeError(AMethod + ' requires a PlainYearMonth, string, or object', SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -179,7 +181,7 @@ var
 begin
   inherited Create(nil);
   if (AMonth < 1) or (AMonth > 12) then
-    ThrowRangeError('Invalid month: ' + IntToStr(AMonth));
+    ThrowRangeError(Format(SErrorInvalidMonth, [IntToStr(AMonth)]), SSuggestTemporalDateRange);
   FYear := AYear;
   FMonth := AMonth;
   MaxDay := Goccia.Temporal.Utils.DaysInMonth(AYear, AMonth);
@@ -328,7 +330,7 @@ begin
   YM := AsPlainYearMonth(AThisValue, 'PlainYearMonth.prototype.with');
   V := AArgs.GetElement(0);
   if not (V is TGocciaObjectValue) then
-    ThrowTypeError('PlainYearMonth.prototype.with requires an object argument');
+    ThrowTypeError(Format(SErrorTemporalWithRequiresObject, ['PlainYearMonth']), SSuggestTemporalWithObject);
   Obj := TGocciaObjectValue(V);
 
   NewYear := GetFieldOr('year', YM.FYear);
@@ -366,7 +368,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -382,7 +384,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('PlainYearMonth.prototype.add requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalAddRequiresDuration, ['PlainYearMonth']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
@@ -434,7 +436,7 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(Arg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string');
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Dur := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -450,7 +452,7 @@ begin
   end
   else
   begin
-    ThrowTypeError('PlainYearMonth.prototype.subtract requires a Duration or string');
+    ThrowTypeError(Format(SErrorTemporalSubtractRequiresDuration, ['PlainYearMonth']), SSuggestTemporalDurationArg);
     Dur := nil;
   end;
 
@@ -542,7 +544,7 @@ end;
 // TC39 Temporal §10.3.19 Temporal.PlainYearMonth.prototype.valueOf()
 function TGocciaTemporalPlainYearMonthValue.YearMonthValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Temporal.PlainYearMonth.prototype.valueOf cannot be used; use toString or compare instead');
+  ThrowTypeError(Format(SErrorTemporalValueOf, ['PlainYearMonth', 'toString or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
 end;
 
@@ -558,12 +560,12 @@ begin
   Arg := AArgs.GetElement(0);
 
   if not (Arg is TGocciaObjectValue) then
-    ThrowTypeError('PlainYearMonth.prototype.toPlainDate requires an object with a day property');
+    ThrowTypeError(SErrorPlainYearMonthToPlainDateRequiresDay, SSuggestTemporalFromArg);
   Obj := TGocciaObjectValue(Arg);
 
   V := Obj.GetProperty('day');
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-    ThrowTypeError('PlainYearMonth.prototype.toPlainDate requires a day property');
+    ThrowTypeError(SErrorPlainYearMonthToPlainDateRequiresDay, SSuggestTemporalFromArg);
 
   Day := Trunc(V.ToNumberLiteral.Value);
   Result := TGocciaTemporalPlainDateValue.Create(YM.FYear, YM.FMonth, Day);

--- a/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -82,6 +82,8 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
@@ -110,7 +112,7 @@ const
 function AsZonedDateTime(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalZonedDateTimeValue;
 begin
   if not (AValue is TGocciaTemporalZonedDateTimeValue) then
-    ThrowTypeError(AMethod + ' called on non-ZonedDateTime');
+    ThrowTypeError(AMethod + ' called on non-ZonedDateTime', SSuggestTemporalThisType);
   Result := TGocciaTemporalZonedDateTimeValue(AValue);
 end;
 
@@ -130,9 +132,9 @@ begin
     // Parse ISO with timezone annotation: 2024-03-15T13:45:30+05:30[Asia/Kolkata]
     if not TryParseISODateTimeWithOffset(TGocciaStringLiteralValue(AValue).Value,
       DateRec, TimeRec, OffsetSeconds, TimeZoneStr) then
-      ThrowTypeError('Invalid ISO ZonedDateTime string for ' + AMethod);
+      ThrowTypeError(Format(SErrorTemporalInvalidISOStringFor, ['ZonedDateTime', AMethod]), SSuggestTemporalISOFormat);
     if TimeZoneStr = '' then
-      ThrowTypeError(AMethod + ' requires a timezone annotation in the string');
+      ThrowTypeError(SErrorZonedDateTimeRequiresTZAnnotation, SSuggestTemporalTimezone);
 
     // Convert parsed local time to epoch ms using the parsed offset
     EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * MILLISECONDS_PER_DAY +
@@ -147,7 +149,7 @@ begin
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires a ZonedDateTime or string');
+    ThrowTypeError(AMethod + ' requires a ZonedDateTime or string', SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -234,7 +236,7 @@ begin
   else if AArg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODuration(TGocciaStringLiteralValue(AArg).Value, DurRec) then
-      ThrowTypeError('Invalid duration string for ' + AMethod);
+      ThrowTypeError(SErrorInvalidDurationString, SSuggestTemporalDurationArg);
     Result := TGocciaTemporalDurationValue.Create(
       DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
       DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
@@ -258,7 +260,7 @@ begin
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires a Duration, string, or object');
+    ThrowTypeError(AMethod + ' requires a Duration, string, or object', SSuggestTemporalDurationArg);
     Result := nil;
   end;
 end;
@@ -270,9 +272,9 @@ constructor TGocciaTemporalZonedDateTimeValue.Create(const AEpochMilliseconds: I
 begin
   inherited Create(nil);
   if ATimeZone = '' then
-    ThrowRangeError('ZonedDateTime requires a timezone');
+    ThrowRangeError(SErrorZonedDateTimeRequiresTZ, SSuggestTemporalTimezone);
   if not IsValidTimeZone(ATimeZone) then
-    ThrowRangeError('Unknown timezone: ' + ATimeZone);
+    ThrowRangeError(Format(SErrorUnknownTimezone, [ATimeZone]), SSuggestTemporalTimezone);
 
   FEpochMilliseconds := AEpochMilliseconds;
   FSubMillisecondNanoseconds := ASubMillisecondNanoseconds;
@@ -649,7 +651,7 @@ begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.with');
   V := AArgs.GetElement(0);
   if not (V is TGocciaObjectValue) then
-    ThrowTypeError('ZonedDateTime.prototype.with requires an object argument');
+    ThrowTypeError(Format(SErrorTemporalWithRequiresObject, ['ZonedDateTime']), SSuggestTemporalWithObject);
   Obj := TGocciaObjectValue(V);
 
   ComputeLocalComponents(Zdt, LYear, LMonth, LDay, LHour, LMinute, LSecond, LMs, LUs, LNs);
@@ -686,12 +688,12 @@ begin
   else if Arg is TGocciaStringLiteralValue then
   begin
     if not TryParseISODate(TGocciaStringLiteralValue(Arg).Value, DateRec) then
-      ThrowTypeError('Invalid date string for ZonedDateTime.prototype.withPlainDate');
+      ThrowTypeError(SErrorInvalidDateStringForZDT, SSuggestTemporalISOFormat);
     PlainDate := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day);
   end
   else
   begin
-    ThrowTypeError('ZonedDateTime.prototype.withPlainDate requires a PlainDate or string');
+    ThrowTypeError(SErrorZDTWithPlainDateArg, SSuggestTemporalFromArg);
     PlainDate := nil;
   end;
 
@@ -731,12 +733,12 @@ begin
     else if Arg is TGocciaStringLiteralValue then
     begin
       if not TryParseISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
-        ThrowTypeError('Invalid time string for ZonedDateTime.prototype.withPlainTime');
+        ThrowTypeError(SErrorInvalidTimeStringForZDT, SSuggestTemporalISOFormat);
       NewHour := TimeRec.Hour; NewMinute := TimeRec.Minute; NewSecond := TimeRec.Second;
       NewMs := TimeRec.Millisecond; NewUs := TimeRec.Microsecond; NewNs := TimeRec.Nanosecond;
     end
     else
-      ThrowTypeError('ZonedDateTime.prototype.withPlainTime requires a PlainTime or string');
+      ThrowTypeError(SErrorZDTWithPlainTimeArg, SSuggestTemporalFromArg);
   end;
 
   NewEpochMs := LocalToEpochMs(LYear, LMonth, LDay, NewHour, NewMinute, NewSecond, NewMs, Zdt.FTimeZone);
@@ -754,11 +756,11 @@ begin
   Arg := AArgs.GetElement(0);
 
   if (Arg = nil) or (Arg is TGocciaUndefinedLiteralValue) then
-    ThrowTypeError('ZonedDateTime.prototype.withTimeZone requires a timezone argument');
+    ThrowTypeError(SErrorZDTWithTimeZoneArg, SSuggestTemporalTimezone);
 
   NewTimeZone := Arg.ToStringLiteral.Value;
   if NewTimeZone = '' then
-    ThrowTypeError('ZonedDateTime.prototype.withTimeZone requires a non-empty timezone');
+    ThrowTypeError(SErrorZDTWithTimeZoneNonEmpty, SSuggestTemporalTimezone);
 
   // Keep the same epoch instant, just change the timezone
   Result := TGocciaTemporalZonedDateTimeValue.Create(
@@ -915,7 +917,7 @@ begin
     OptionsObj := TGocciaObjectValue(Arg);
     SmallestUnit := GetSmallestUnit(OptionsObj, tuNone);
     if SmallestUnit = tuNone then
-      ThrowRangeError('round() requires a smallestUnit option');
+      ThrowRangeError(SErrorTemporalRoundRequiresSmallestUnit, SSuggestTemporalRoundArg);
     Mode := GetRoundingMode(OptionsObj, rmHalfExpand);
     Increment := GetRoundingIncrement(OptionsObj, 1);
     // Convert unit enum to string for the existing unit dispatch
@@ -928,13 +930,13 @@ begin
       tuMicrosecond: UnitStr := 'microsecond';
       tuNanosecond: UnitStr := 'nanosecond';
     else
-      ThrowRangeError('Invalid unit for ZonedDateTime.prototype.round');
+      ThrowRangeError(SErrorInvalidZDTRoundUnit, SSuggestTemporalValidUnits);
       UnitStr := '';
     end;
   end
   else
   begin
-    ThrowTypeError('ZonedDateTime.prototype.round requires a string or options object');
+    ThrowTypeError(Format(SErrorTemporalRoundRequiresStringOrOptions, ['ZonedDateTime']), SSuggestTemporalRoundArg);
     UnitStr := '';
   end;
 
@@ -986,7 +988,7 @@ begin
   else if UnitStr = 'nanosecond' then Divisor := 1
   else
   begin
-    ThrowRangeError('Invalid unit for ZonedDateTime.prototype.round: ' + UnitStr);
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['ZonedDateTime.prototype.round', UnitStr]), SSuggestTemporalValidUnits);
     Divisor := 1;
   end;
 
@@ -1105,7 +1107,7 @@ end;
 // TC39 Temporal §6.3.40 Temporal.ZonedDateTime.prototype.valueOf()
 function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  ThrowTypeError('Temporal.ZonedDateTime.prototype.valueOf cannot be used; use epochMilliseconds, epochNanoseconds, or compare instead');
+  ThrowTypeError(Format(SErrorTemporalValueOf, ['ZonedDateTime', 'epochMilliseconds, epochNanoseconds, or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
 end;
 

--- a/units/Goccia.Values.TextDecoderValue.pas
+++ b/units/Goccia.Values.TextDecoderValue.pas
@@ -53,6 +53,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -307,8 +309,9 @@ begin
     begin
       Normalized := NormalizeEncodingLabel(LabelArg.ToStringLiteral.Value);
       if Normalized = '' then
-        ThrowRangeError('TextDecoder: The encoding label provided (' +
-          LabelArg.ToStringLiteral.Value + ') is invalid.');
+        ThrowRangeError(Format(SErrorTextDecoderInvalidEncoding,
+          [LabelArg.ToStringLiteral.Value]),
+          SSuggestTextDecoderThisType);
       FEncoding := Normalized;
     end;
   end;
@@ -320,7 +323,7 @@ begin
     if not (OptionsArg is TGocciaUndefinedLiteralValue) then
     begin
       if not (OptionsArg is TGocciaObjectValue) then
-        ThrowTypeError('TextDecoder: options must be an object or undefined');
+        ThrowTypeError(SErrorTextDecoderOptionsMustBeObject, SSuggestTextDecoderThisType);
 
       FatalOpt := TGocciaObjectValue(OptionsArg).GetProperty(PROP_FATAL);
       if Assigned(FatalOpt) and not (FatalOpt is TGocciaUndefinedLiteralValue) then
@@ -384,7 +387,7 @@ var
   Obj: TGocciaTextDecoderValue;
 begin
   if not (AThisValue is TGocciaTextDecoderValue) then
-    ThrowTypeError('TextDecoder.prototype.encoding: illegal invocation');
+    ThrowTypeError(SErrorTextDecoderEncodingIllegalInvocation, SSuggestTextDecoderThisType);
   Obj := TGocciaTextDecoderValue(AThisValue);
   Result := TGocciaStringLiteralValue.Create(Obj.FEncoding);
 end;
@@ -396,7 +399,7 @@ var
   Obj: TGocciaTextDecoderValue;
 begin
   if not (AThisValue is TGocciaTextDecoderValue) then
-    ThrowTypeError('TextDecoder.prototype.fatal: illegal invocation');
+    ThrowTypeError(SErrorTextDecoderFatalIllegalInvocation, SSuggestTextDecoderThisType);
   Obj := TGocciaTextDecoderValue(AThisValue);
   if Obj.FFatal then
     Result := TGocciaBooleanLiteralValue.TrueValue
@@ -411,7 +414,7 @@ var
   Obj: TGocciaTextDecoderValue;
 begin
   if not (AThisValue is TGocciaTextDecoderValue) then
-    ThrowTypeError('TextDecoder.prototype.ignoreBOM: illegal invocation');
+    ThrowTypeError(SErrorTextDecoderIgnoreBOMIllegalInvocation, SSuggestTextDecoderThisType);
   Obj := TGocciaTextDecoderValue(AThisValue);
   if Obj.FIgnoreBOM then
     Result := TGocciaBooleanLiteralValue.TrueValue
@@ -430,7 +433,7 @@ var
   U8: UTF8String;
 begin
   if not (AThisValue is TGocciaTextDecoderValue) then
-    ThrowTypeError('TextDecoder.prototype.decode: illegal invocation');
+    ThrowTypeError(SErrorTextDecoderDecodeIllegalInvocation, SSuggestTextDecoderThisType);
   Obj := TGocciaTextDecoderValue(AThisValue);
 
   // No input or undefined input — return empty string.
@@ -460,8 +463,7 @@ begin
     DataLen := Length(Data);
   end
   else
-    ThrowTypeError(
-      'TextDecoder.prototype.decode: input must be an ArrayBuffer or ArrayBufferView');
+    ThrowTypeError(SErrorTextDecoderDecodeInputType, SSuggestTextDecoderThisType);
 
   // Strip the UTF-8 BOM (EF BB BF) unless ignoreBOM is true.
   if not Obj.FIgnoreBOM and (DataLen >= MIN_BOM_LENGTH) and
@@ -478,8 +480,7 @@ begin
   begin
     // Fatal mode: reject any ill-formed byte sequence with a TypeError.
     if not IsValidUTF8(Data, Offset, DataLen) then
-      ThrowTypeError(
-        'TextDecoder.prototype.decode: invalid UTF-8 byte sequence');
+      ThrowTypeError(SErrorTextDecoderDecodeInvalidUTF8, SSuggestTextDecoderThisType);
     // All bytes are well-formed — raw copy is safe.
     SetLength(U8, DataLen);
     if DataLen > 0 then

--- a/units/Goccia.Values.TextEncoderValue.pas
+++ b/units/Goccia.Values.TextEncoderValue.pas
@@ -41,6 +41,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -184,7 +186,9 @@ function TGocciaTextEncoderValue.EncodingGetter(const AArgs: TGocciaArgumentsCol
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaTextEncoderValue) then
-    ThrowTypeError('TextEncoder.prototype.encoding: illegal invocation');
+    ThrowTypeError(Format(SErrorTextEncoderIllegalInvocation,
+      ['TextEncoder.prototype.encoding']),
+      SSuggestTextEncoderThisType);
   // TextEncoder always uses UTF-8 — no instance state required.
   Result := TGocciaStringLiteralValue.Create(ENCODING_UTF8);
 end;
@@ -199,7 +203,9 @@ var
   I: Integer;
 begin
   if not (AThisValue is TGocciaTextEncoderValue) then
-    ThrowTypeError('TextEncoder.prototype.encode: illegal invocation');
+    ThrowTypeError(Format(SErrorTextEncoderIllegalInvocation,
+      ['TextEncoder.prototype.encode']),
+      SSuggestTextEncoderThisType);
   // Step 1: Let input be the empty string.
   Input := '';
   // Step 2: If input is given, convert to a scalar-value string.
@@ -226,10 +232,11 @@ var
   ResultObj: TGocciaObjectValue;
 begin
   if not (AThisValue is TGocciaTextEncoderValue) then
-    ThrowTypeError('TextEncoder.prototype.encodeInto: illegal invocation');
+    ThrowTypeError(Format(SErrorTextEncoderIllegalInvocation,
+      ['TextEncoder.prototype.encodeInto']),
+      SSuggestTextEncoderThisType);
   if AArgs.Length < 2 then
-    ThrowTypeError(
-      'TextEncoder.prototype.encodeInto requires source and destination arguments');
+    ThrowTypeError(SErrorTextEncoderEncodeIntoArgs, SSuggestTextEncoderEncodeIntoArgs);
 
   if AArgs.GetElement(0) is TGocciaUndefinedLiteralValue then
     Source := ''
@@ -237,12 +244,10 @@ begin
     Source := AArgs.GetElement(0).ToStringLiteral.Value;
 
   if not (AArgs.GetElement(1) is TGocciaTypedArrayValue) then
-    ThrowTypeError(
-      'TextEncoder.prototype.encodeInto: destination must be a Uint8Array');
+    ThrowTypeError(SErrorTextEncoderEncodeIntoDestType, SSuggestTextEncoderEncodeIntoArgs);
   Dest := TGocciaTypedArrayValue(AArgs.GetElement(1));
   if Dest.Kind <> takUint8 then
-    ThrowTypeError(
-      'TextEncoder.prototype.encodeInto: destination must be a Uint8Array');
+    ThrowTypeError(SErrorTextEncoderEncodeIntoDestType, SSuggestTextEncoderEncodeIntoArgs);
 
   // Convert source to USVString bytes (lone surrogates normalized to U+FFFD).
   Bytes := StringToUTF8Bytes(Source);

--- a/units/Goccia.Values.ToPrimitive.pas
+++ b/units/Goccia.Values.ToPrimitive.pas
@@ -21,6 +21,8 @@ implementation
 uses
   Goccia.Arguments.Collection,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -82,7 +84,7 @@ begin
     end;
 
     // ES2026 §7.1.1 step 3e: Throw TypeError if no method returned a primitive
-    ThrowTypeError('Cannot convert object to primitive value');
+    ThrowTypeError(SErrorCannotConvertToPrimitive, SSuggestToPrimitive);
   end;
 
   Result := AValue;
@@ -100,7 +102,7 @@ begin
   end;
 
   if AValue is TGocciaSymbolValue then
-    ThrowTypeError('Cannot convert a Symbol value to a string');
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
 
   if AValue.IsPrimitive then
   begin
@@ -111,7 +113,7 @@ begin
   // ES2026 §7.1.17 step 1: ToPrimitive(argument, string)
   Prim := ToPrimitive(AValue, tphString);
   if Prim is TGocciaSymbolValue then
-    ThrowTypeError('Cannot convert a Symbol value to a string');
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
   Result := Prim.ToStringLiteral;
 end;
 

--- a/units/Goccia.Values.TypedArrayValue.pas
+++ b/units/Goccia.Values.TypedArrayValue.pas
@@ -127,6 +127,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Float16,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -609,7 +611,7 @@ end;
 function RequireTypedArray(const AThisValue: TGocciaValue; const AMethod: string): TGocciaTypedArrayValue;
 begin
   if not (AThisValue is TGocciaTypedArrayValue) then
-    ThrowTypeError(AMethod + ' requires a TypedArray');
+    ThrowTypeError(Format(SErrorTypedArrayRequiresTypedArray, [AMethod]), SSuggestTypedArrayThisType);
   Result := TGocciaTypedArrayValue(AThisValue);
 end;
 
@@ -843,13 +845,13 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.set');
   if AArgs.Length = 0 then
-    ThrowTypeError('TypedArray.prototype.set requires at least one argument');
+    ThrowTypeError(SErrorTypedArraySetRequiresArg, SSuggestTypedArraySetSource);
 
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
   begin
     TargetOffset := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value);
     if TargetOffset < 0 then
-      ThrowRangeError('TypedArray.prototype.set offset must be >= 0');
+      ThrowRangeError(SErrorTypedArraySetOffsetNonNegative, SSuggestTypedArrayLength);
   end
   else
     TargetOffset := 0;
@@ -858,7 +860,7 @@ begin
   begin
     SrcTA := TGocciaTypedArrayValue(AArgs.GetElement(0));
     if TargetOffset + SrcTA.FLength > TA.FLength then
-      ThrowRangeError('Source is too large');
+      ThrowRangeError(SErrorTypedArraySourceTooLarge, SSuggestTypedArrayLength);
     for I := 0 to SrcTA.FLength - 1 do
       TA.WriteElement(TargetOffset + I, SrcTA.ReadElement(I));
   end
@@ -866,12 +868,12 @@ begin
   begin
     SrcArray := TGocciaArrayValue(AArgs.GetElement(0));
     if TargetOffset + SrcArray.Elements.Count > TA.FLength then
-      ThrowRangeError('Source is too large');
+      ThrowRangeError(SErrorTypedArraySourceTooLarge, SSuggestTypedArrayLength);
     for I := 0 to SrcArray.Elements.Count - 1 do
       TA.WriteNumberLiteral(TargetOffset + I, SrcArray.Elements[I].ToNumberLiteral);
   end
   else
-    ThrowTypeError('TypedArray.prototype.set argument must be an array or typed array');
+    ThrowTypeError(SErrorTypedArraySetArgType, SSuggestTypedArraySetSource);
 
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -1106,7 +1108,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.find');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.find requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayFindCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1130,7 +1132,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.findIndex');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.findIndex requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayFindIndexCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1154,7 +1156,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.findLast');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.findLast requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayFindLastCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1178,7 +1180,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.findLastIndex');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.findLastIndex requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayFindLastIndexCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1202,7 +1204,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.every');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.every requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayEveryCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1227,7 +1229,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.some');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.some requires a callable argument');
+    ThrowTypeError(SErrorTypedArraySomeCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1252,7 +1254,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.forEach');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.forEach requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayForEachCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1273,7 +1275,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.map');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.map requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayMapCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1300,7 +1302,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.filter');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.filter requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayFilterCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
@@ -1337,7 +1339,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.reduce');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.reduce requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayReduceCallable, SSuggestTypedArrayCallable);
 
   if AArgs.Length >= 2 then
   begin
@@ -1347,7 +1349,7 @@ begin
   else
   begin
     if TA.FLength = 0 then
-      ThrowTypeError('Reduce of empty typed array with no initial value');
+      ThrowTypeError(SErrorReduceEmptyTypedArray, SSuggestReduceInitialValue);
     Accumulator := TGocciaNumberLiteralValue.Create(TA.ReadElement(0));
     I := 1;
   end;
@@ -1379,7 +1381,7 @@ var
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.reduceRight');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError('TypedArray.prototype.reduceRight requires a callable argument');
+    ThrowTypeError(SErrorTypedArrayReduceRightCallable, SSuggestTypedArrayCallable);
 
   if AArgs.Length >= 2 then
   begin
@@ -1389,7 +1391,7 @@ begin
   else
   begin
     if TA.FLength = 0 then
-      ThrowTypeError('Reduce of empty typed array with no initial value');
+      ThrowTypeError(SErrorReduceEmptyTypedArray, SSuggestReduceInitialValue);
     Accumulator := TGocciaNumberLiteralValue.Create(TA.ReadElement(TA.FLength - 1));
     I := TA.FLength - 2;
   end;
@@ -1490,7 +1492,7 @@ begin
   if ActualIndex < 0 then
     ActualIndex := TA.FLength + ActualIndex;
   if (ActualIndex < 0) or (ActualIndex >= TA.FLength) then
-    ThrowRangeError('Invalid index');
+    ThrowRangeError(SErrorInvalidTypedArrayIndex, SSuggestTypedArrayLength);
   // ES2026 §23.2.3.36 step 7: Let numericValue be ? ToNumber(value)
   if AArgs.Length > 1 then
     NewNum := AArgs.GetElement(1).ToNumberLiteral
@@ -1602,27 +1604,27 @@ begin
       ByteOff := 0;
 
     if ByteOff < 0 then
-      ThrowRangeError('Start offset of ' + TGocciaTypedArrayValue.KindName(FKind) + ' must be non-negative');
+      ThrowRangeError(Format(SErrorTypedArrayStartOffsetNonNegative, [TGocciaTypedArrayValue.KindName(FKind)]), SSuggestTypedArrayLength);
     if (ByteOff mod BPE) <> 0 then
-      ThrowRangeError('Start offset of ' + TGocciaTypedArrayValue.KindName(FKind) + ' should be a multiple of ' + IntToStr(BPE));
+      ThrowRangeError(Format(SErrorTypedArrayStartOffsetMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
     if ByteOff > System.Length(Buf.Data) then
-      ThrowRangeError('Start offset is outside the bounds of the buffer');
+      ThrowRangeError(SErrorTypedArrayStartOffsetBounds, SSuggestTypedArrayLength);
 
     if AArguments.Length > 2 then
     begin
       ElemLen := Trunc(AArguments.GetElement(2).ToNumberLiteral.Value);
       if ElemLen < 0 then
-        ThrowRangeError('Invalid typed array length');
+        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
       if Int64(ByteOff) + Int64(ElemLen) * Int64(BPE) > Int64(System.Length(Buf.Data)) then
-        ThrowRangeError('Invalid typed array length');
+        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     end
     else
     begin
       if ((Int64(System.Length(Buf.Data)) - Int64(ByteOff)) mod Int64(BPE)) <> 0 then
-        ThrowRangeError('Byte length of ' + TGocciaTypedArrayValue.KindName(FKind) + ' should be a multiple of ' + IntToStr(BPE));
+        ThrowRangeError(Format(SErrorTypedArrayByteLengthMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
       ElemLen := Integer((Int64(System.Length(Buf.Data)) - Int64(ByteOff)) div Int64(BPE));
       if ElemLen < 0 then
-        ThrowRangeError('Invalid typed array length');
+        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     end;
 
     Exit(TGocciaTypedArrayValue.Create(FKind, Buf, ByteOff, ElemLen));
@@ -1638,27 +1640,27 @@ begin
       ByteOff := 0;
 
     if ByteOff < 0 then
-      ThrowRangeError('Start offset of ' + TGocciaTypedArrayValue.KindName(FKind) + ' must be non-negative');
+      ThrowRangeError(Format(SErrorTypedArrayStartOffsetNonNegative, [TGocciaTypedArrayValue.KindName(FKind)]), SSuggestTypedArrayLength);
     if (ByteOff mod BPE) <> 0 then
-      ThrowRangeError('Start offset of ' + TGocciaTypedArrayValue.KindName(FKind) + ' should be a multiple of ' + IntToStr(BPE));
+      ThrowRangeError(Format(SErrorTypedArrayStartOffsetMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
     if ByteOff > System.Length(SAB.Data) then
-      ThrowRangeError('Start offset is outside the bounds of the buffer');
+      ThrowRangeError(SErrorTypedArrayStartOffsetBounds, SSuggestTypedArrayLength);
 
     if AArguments.Length > 2 then
     begin
       ElemLen := Trunc(AArguments.GetElement(2).ToNumberLiteral.Value);
       if ElemLen < 0 then
-        ThrowRangeError('Invalid typed array length');
+        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
       if Int64(ByteOff) + Int64(ElemLen) * Int64(BPE) > Int64(System.Length(SAB.Data)) then
-        ThrowRangeError('Invalid typed array length');
+        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     end
     else
     begin
       if ((Int64(System.Length(SAB.Data)) - Int64(ByteOff)) mod Int64(BPE)) <> 0 then
-        ThrowRangeError('Byte length of ' + TGocciaTypedArrayValue.KindName(FKind) + ' should be a multiple of ' + IntToStr(BPE));
+        ThrowRangeError(Format(SErrorTypedArrayByteLengthMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
       ElemLen := Integer((Int64(System.Length(SAB.Data)) - Int64(ByteOff)) div Int64(BPE));
       if ElemLen < 0 then
-        ThrowRangeError('Invalid typed array length');
+        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     end;
 
     Exit(TGocciaTypedArrayValue.Create(FKind, SAB, ByteOff, ElemLen));
@@ -1682,7 +1684,7 @@ begin
   begin
     Len := Trunc(Num.Value);
     if Len < 0 then
-      ThrowRangeError('Invalid typed array length');
+      ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
   end;
   Result := TGocciaTypedArrayValue.Create(FKind, Len);
 end;
@@ -1711,7 +1713,7 @@ var
   MapArgs: TGocciaArgumentsCollection;
 begin
   if AArgs.Length = 0 then
-    ThrowTypeError('TypedArray.from requires at least one argument');
+    ThrowTypeError(SErrorTypedArrayFromRequiresArg, SSuggestTypedArraySetSource);
   Source := AArgs.GetElement(0);
   HasMapFn := False;
   MapFn := nil;
@@ -1719,7 +1721,7 @@ begin
   begin
     MapFnArg := AArgs.GetElement(1);
     if not MapFnArg.IsCallable then
-      ThrowTypeError('TypedArray.from mapfn must be a function');
+      ThrowTypeError(SErrorTypedArrayFromMapFn, SSuggestTypedArrayCallable);
     HasMapFn := True;
     MapFn := TGocciaFunctionBase(MapFnArg);
   end;
@@ -1774,7 +1776,7 @@ begin
     Exit(NewTA);
   end;
 
-  ThrowTypeError('TypedArray.from requires an array-like or iterable source');
+  ThrowTypeError(SErrorTypedArrayFromSource, SSuggestTypedArraySetSource);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 

--- a/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/units/Goccia.Values.URLSearchParamsValue.pas
@@ -104,6 +104,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.URL.Parser,
   Goccia.Utils,
@@ -279,11 +281,11 @@ begin
   for I := 0 to Outer.Elements.Count - 1 do
   begin
     if not Assigned(Outer.Elements[I]) or not (Outer.Elements[I] is TGocciaArrayValue) then
-      ThrowTypeError('Failed to construct URLSearchParams: The provided value cannot be converted to a sequence');
+      ThrowTypeError(SErrorURLSearchParamsNotSequence, SSuggestURLSearchParamsInit);
     Inner := TGocciaArrayValue(Outer.Elements[I]);
     // WHATWG URL §5.2: each pair must contain exactly two items
     if Inner.Elements.Count <> 2 then
-      ThrowTypeError('Failed to construct URLSearchParams: Sequence initializer must contain pairs with exactly two items');
+      ThrowTypeError(SErrorURLSearchParamsPairSize, SSuggestURLSearchParamsInit);
     Param.Name := '';
     Param.Value := '';
     if Assigned(Inner.Elements[0]) then
@@ -315,7 +317,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.append: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsAppendNotInstance, SSuggestURLSearchParamsThisType);
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
   if AArgs.Length < 2 then Exit;
   Param.Name := AArgs.GetElement(0).ToStringLiteral.Value;
@@ -336,7 +338,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.delete: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsDeleteNotInstance, SSuggestURLSearchParamsThisType);
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
   if AArgs.Length = 0 then Exit;
   Name := AArgs.GetElement(0).ToStringLiteral.Value;
@@ -374,7 +376,7 @@ var
   I: Integer;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.get: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsGetNotInstance, SSuggestURLSearchParamsThisType);
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
   if AArgs.Length = 0 then
   begin
@@ -402,7 +404,7 @@ var
   I: Integer;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.getAll: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsGetAllNotInstance, SSuggestURLSearchParamsThisType);
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
   Arr := TGocciaArrayValue.Create;
   if AArgs.Length > 0 then
@@ -426,7 +428,7 @@ var
   I: Integer;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.has: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsHasNotInstance, SSuggestURLSearchParamsThisType);
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
   if AArgs.Length = 0 then
   begin
@@ -465,7 +467,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.set: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsSetNotInstance, SSuggestURLSearchParamsThisType);
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
   if AArgs.Length < 2 then Exit;
   Name := AArgs.GetElement(0).ToStringLiteral.Value;
@@ -512,7 +514,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.sort: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsSortNotInstance, SSuggestURLSearchParamsThisType);
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
 
   // Stable sort by name (Unicode code unit order) — insertion sort
@@ -536,7 +538,7 @@ function TGocciaURLSearchParamsValue.URLSearchParamsToString(
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.toString: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsToStringNotInstance, SSuggestURLSearchParamsThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLSearchParamsValue(AThisValue).Serialize);
 end;
@@ -547,7 +549,7 @@ function TGocciaURLSearchParamsValue.URLSearchParamsKeys(
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.keys: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsKeysNotInstance, SSuggestURLSearchParamsThisType);
   Result := TGocciaURLSearchParamsIteratorValue.Create(AThisValue, spikKeys);
 end;
 
@@ -557,7 +559,7 @@ function TGocciaURLSearchParamsValue.URLSearchParamsValues(
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.values: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsValuesNotInstance, SSuggestURLSearchParamsThisType);
   Result := TGocciaURLSearchParamsIteratorValue.Create(AThisValue, spikValues);
 end;
 
@@ -567,7 +569,7 @@ function TGocciaURLSearchParamsValue.URLSearchParamsEntries(
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.entries: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsEntriesNotInstance, SSuggestURLSearchParamsThisType);
   Result := TGocciaURLSearchParamsIteratorValue.Create(AThisValue, spikEntries);
 end;
 
@@ -584,14 +586,14 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams.prototype.forEach: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsForEachNotInstance, SSuggestURLSearchParamsThisType);
   Self_ := TGocciaURLSearchParamsValue(AThisValue);
   // §6.2: callbackFn is required; GetElement(0) returns undefined when absent,
   // which then fails the IsCallable check and throws TypeError as required.
   Callback := AArgs.GetElement(0);
   // §6.2 step 3: if callbackFn is not callable, throw TypeError
   if not Callback.IsCallable then
-    ThrowTypeError('URLSearchParams.prototype.forEach: callback is not a function');
+    ThrowTypeError(SErrorURLSearchParamsForEachNotCallable, SSuggestCallbackRequired);
 
   // §6.2 step 4: optional thisArg (second argument)
   if AArgs.Length >= 2 then
@@ -625,7 +627,7 @@ function TGocciaURLSearchParamsValue.URLSearchParamsSizeGetter(
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams size getter: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsSizeNotInstance, SSuggestURLSearchParamsThisType);
   Result := TGocciaNumberLiteralValue.Create(
     TGocciaURLSearchParamsValue(AThisValue).FList.Count);
 end;
@@ -636,7 +638,7 @@ function TGocciaURLSearchParamsValue.URLSearchParamsSymbolIterator(
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLSearchParamsValue) then
-    ThrowTypeError('URLSearchParams[Symbol.iterator]: not a URLSearchParams');
+    ThrowTypeError(SErrorURLSearchParamsIteratorNotInstance, SSuggestURLSearchParamsThisType);
   Result := TGocciaURLSearchParamsIteratorValue.Create(AThisValue, spikEntries);
 end;
 

--- a/units/Goccia.Values.URLValue.pas
+++ b/units/Goccia.Values.URLValue.pas
@@ -131,6 +131,8 @@ uses
 
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.URL.Parser,
   Goccia.Values.ArrayValue,
@@ -342,7 +344,7 @@ function TGocciaURLValue.URLHrefGetter(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL href getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['href getter']), SSuggestURLThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLValue(AThisValue).ComputeHref);
 end;
@@ -354,7 +356,7 @@ var
   URLRec: TGocciaURLRecord;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL origin getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['origin getter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   FillChar(URLRec, SizeOf(URLRec), 0);
   URLRec.Scheme := U.FScheme;
@@ -368,7 +370,7 @@ function TGocciaURLValue.URLProtocolGetter(const AArgs: TGocciaArgumentsCollecti
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL protocol getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['protocol getter']), SSuggestURLThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLValue(AThisValue).FScheme + ':');
 end;
@@ -377,7 +379,7 @@ function TGocciaURLValue.URLUsernameGetter(const AArgs: TGocciaArgumentsCollecti
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL username getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['username getter']), SSuggestURLThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLValue(AThisValue).FUsername);
 end;
@@ -386,7 +388,7 @@ function TGocciaURLValue.URLPasswordGetter(const AArgs: TGocciaArgumentsCollecti
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL password getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['password getter']), SSuggestURLThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLValue(AThisValue).FPassword);
 end;
@@ -398,7 +400,7 @@ var
   H: string;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL host getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['host getter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   H := U.FHost;
   if U.FPort <> URL_NULL_PORT then
@@ -410,7 +412,7 @@ function TGocciaURLValue.URLHostnameGetter(const AArgs: TGocciaArgumentsCollecti
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL hostname getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['hostname getter']), SSuggestURLThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLValue(AThisValue).FHost);
 end;
@@ -421,7 +423,7 @@ var
   U: TGocciaURLValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL port getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['port getter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if U.FPort = URL_NULL_PORT then
     Result := TGocciaStringLiteralValue.Create('')
@@ -433,7 +435,7 @@ function TGocciaURLValue.URLPathnameGetter(const AArgs: TGocciaArgumentsCollecti
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL pathname getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['pathname getter']), SSuggestURLThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLValue(AThisValue).FPathname);
 end;
@@ -444,7 +446,7 @@ var
   U: TGocciaURLValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL search getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['search getter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if U.FHasNullQuery or (U.FQuery = '') then
     Result := TGocciaStringLiteralValue.Create('')
@@ -459,7 +461,7 @@ var
   U: TGocciaURLValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL searchParams getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['searchParams getter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
 
   // Lazy initialization of the search params object
@@ -480,7 +482,7 @@ var
   U: TGocciaURLValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL hash getter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['hash getter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if U.FHasNullFragment or (U.FFragment = '') then
     Result := TGocciaStringLiteralValue.Create('')
@@ -502,13 +504,13 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL href setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['href setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if AArgs.Length = 0 then Exit;
   NewHref := AArgs.GetElement(0).ToStringLiteral.Value;
   Parsed := ParseURL(NewHref);
   if not Parsed.IsValid then
-    ThrowTypeError('Invalid URL: ' + NewHref);
+    ThrowTypeError(Format(SErrorInvalidURL, [NewHref]), SSuggestURLFormat);
   U.FScheme := Parsed.Scheme;
   U.FUsername := Parsed.Username;
   U.FPassword := Parsed.Password;
@@ -534,7 +536,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL protocol setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['protocol setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if AArgs.Length = 0 then Exit;
   Input := AArgs.GetElement(0).ToStringLiteral.Value;
@@ -570,7 +572,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL username setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['username setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   // Cannot set credentials on a URL with no host or file: scheme
   if U.FHasNullHost or (U.FScheme = 'file') then Exit;
@@ -586,7 +588,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL password setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['password setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if U.FHasNullHost or (U.FScheme = 'file') then Exit;
   if AArgs.Length = 0 then Exit;
@@ -604,7 +606,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL host setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['host setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if U.FHasOpaquePath then Exit;
   if AArgs.Length = 0 then Exit;
@@ -631,7 +633,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL hostname setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['hostname setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if U.FHasOpaquePath then Exit;
   if AArgs.Length = 0 then Exit;
@@ -657,7 +659,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL port setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['port setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if U.FHasNullHost or (U.FScheme = 'file') then Exit;
   if AArgs.Length = 0 then Exit;
@@ -686,7 +688,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL pathname setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['pathname setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if U.FHasOpaquePath then Exit;
   if AArgs.Length = 0 then Exit;
@@ -716,7 +718,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL search setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['search setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if AArgs.Length = 0 then Exit;
   Input := AArgs.GetElement(0).ToStringLiteral.Value;
@@ -745,7 +747,7 @@ var
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL hash setter: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['hash setter']), SSuggestURLThisType);
   U := TGocciaURLValue(AThisValue);
   if AArgs.Length = 0 then Exit;
   Input := AArgs.GetElement(0).ToStringLiteral.Value;
@@ -772,7 +774,7 @@ function TGocciaURLValue.URLToString(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL.prototype.toString: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['prototype.toString']), SSuggestURLThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLValue(AThisValue).ComputeHref);
 end;
@@ -782,7 +784,7 @@ function TGocciaURLValue.URLToJSON(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if not (AThisValue is TGocciaURLValue) then
-    ThrowTypeError('URL.prototype.toJSON: not a URL');
+    ThrowTypeError(Format(SErrorURLNotURL, ['prototype.toJSON']), SSuggestURLThisType);
   Result := TGocciaStringLiteralValue.Create(
     TGocciaURLValue(AThisValue).ComputeHref);
 end;
@@ -819,7 +821,7 @@ var
   Parsed, BaseParsed: TGocciaURLRecord;
 begin
   if AArguments.Length = 0 then
-    ThrowTypeError('URL constructor: 1 argument required');
+    ThrowTypeError(SErrorURLConstructorRequiresArg, SSuggestURLFormat);
 
   URLStr := AArguments.GetElement(0).ToStringLiteral.Value;
 
@@ -829,14 +831,14 @@ begin
     BaseStr := AArguments.GetElement(1).ToStringLiteral.Value;
     BaseParsed := ParseURL(BaseStr);
     if not BaseParsed.IsValid then
-      ThrowTypeError('Invalid base URL: ' + BaseStr);
+      ThrowTypeError(Format(SErrorInvalidBaseURL, [BaseStr]), SSuggestURLFormat);
     Parsed := ParseURLWithBase(URLStr, BaseParsed);
   end
   else
     Parsed := ParseURL(URLStr);
 
   if not Parsed.IsValid then
-    ThrowTypeError('Invalid URL: ' + URLStr);
+    ThrowTypeError(Format(SErrorInvalidURL, [URLStr]), SSuggestURLFormat);
 
   FScheme := Parsed.Scheme;
   FUsername := Parsed.Username;

--- a/units/Goccia.Values.Uint8ArrayEncoding.pas
+++ b/units/Goccia.Values.Uint8ArrayEncoding.pas
@@ -28,6 +28,8 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue,
@@ -103,7 +105,8 @@ function RequireUint8Array(const AThisValue: TGocciaValue; const AMethod: string
 begin
   if not (AThisValue is TGocciaTypedArrayValue) or
      (TGocciaTypedArrayValue(AThisValue).Kind <> takUint8) then
-    ThrowTypeError(AMethod + ' requires that |this| be a Uint8Array');
+    ThrowTypeError(Format(SErrorRequiresUint8Array, [AMethod]),
+      SSuggestUint8ArrayThisType);
   Result := TGocciaTypedArrayValue(AThisValue);
 end;
 
@@ -119,7 +122,7 @@ begin
     begin
       Result := AlphabetVal.ToStringLiteral.Value;
       if (Result <> ALPHABET_BASE64) and (Result <> ALPHABET_BASE64URL) then
-        ThrowTypeError('Invalid alphabet: expected "base64" or "base64url"');
+        ThrowTypeError(SErrorInvalidAlphabet, SSuggestBase64Format);
     end;
   end;
 end;
@@ -150,7 +153,7 @@ begin
       Result := Val.ToStringLiteral.Value;
       if (Result <> LAST_CHUNK_LOOSE) and (Result <> LAST_CHUNK_STRICT) and
          (Result <> LAST_CHUNK_STOP_BEFORE_PARTIAL) then
-        ThrowTypeError('Invalid lastChunkHandling: expected "loose", "strict", or "stop-before-partial"');
+        ThrowTypeError(SErrorInvalidLastChunkHandling, SSuggestBase64Format);
     end;
   end;
 end;
@@ -310,7 +313,7 @@ begin
   begin
     Ch := Cleaned[I];
     if (Ord(Ch) > 127) or (DecodeTable[Ord(Ch)] = INVALID_BASE64_VALUE) then
-      ThrowSyntaxError('Invalid character in base64 string');
+      ThrowSyntaxError(SErrorInvalidBase64Character, SSuggestBase64Format);
   end;
 
   // Step 4: Compute full chunks and remainder
@@ -328,7 +331,7 @@ begin
       Remainder := 0;
     end
     else
-      ThrowSyntaxError('Invalid base64 string: incomplete chunk');
+      ThrowSyntaxError(SErrorBase64IncompleteChunk, SSuggestBase64Format);
   end;
 
   if Remainder > 0 then
@@ -345,22 +348,22 @@ begin
           V0 := DecodeTable[Ord(Cleaned[PadStart - 1])];
           V1 := DecodeTable[Ord(Cleaned[PadStart])];
           if (V1 and $0F) <> 0 then
-            ThrowSyntaxError('Invalid base64 string: non-zero padding bits');
+            ThrowSyntaxError(SErrorBase64NonZeroPaddingBits, SSuggestBase64Format);
         end
         else if (Remainder = 3) and (CleanedLen - PadStart = 1) then
         begin
           // 3 data + 1 pad = 4: OK, check overflow bits
           V0 := DecodeTable[Ord(Cleaned[PadStart])];
           if (V0 and $03) <> 0 then
-            ThrowSyntaxError('Invalid base64 string: non-zero padding bits');
+            ThrowSyntaxError(SErrorBase64NonZeroPaddingBits, SSuggestBase64Format);
         end
         else
-          ThrowSyntaxError('Invalid base64 string: malformed padding');
+          ThrowSyntaxError(SErrorBase64MalformedPadding, SSuggestBase64Format);
       end
       else
       begin
         // In strict mode without padding, partial chunks are invalid
-        ThrowSyntaxError('Invalid base64 string: incomplete chunk in strict mode');
+        ThrowSyntaxError(SErrorBase64IncompleteChunkStrict, SSuggestBase64Format);
       end;
     end
     else if ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL then
@@ -380,7 +383,7 @@ begin
     // Actually if Remainder = 0 and HasPadding, the padding was stripped from a complete set
     // which means padding was erroneous
     if PadStart <> CleanedLen then
-      ThrowSyntaxError('Invalid base64 string: unexpected padding');
+      ThrowSyntaxError(SErrorBase64UnexpectedPadding, SSuggestBase64Format);
   end;
 
   // Step 6: Compute output size
@@ -481,7 +484,7 @@ begin
     if not (Options is TGocciaUndefinedLiteralValue) then
     begin
       if not (Options is TGocciaObjectValue) then
-        ThrowTypeError('Uint8Array.prototype.toBase64: options must be an object');
+        ThrowTypeError(SErrorToBase64OptionsNotObject, SSuggestBase64Format);
       Alphabet := ReadAlphabetOption(Options);
       OmitPadding := ReadOmitPaddingOption(Options);
     end;
@@ -527,9 +530,9 @@ begin
   TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.setFromBase64');
 
   if AArgs.Length = 0 then
-    ThrowTypeError('Uint8Array.prototype.setFromBase64 requires a string argument');
+    ThrowTypeError(SErrorSetFromBase64RequiresString, SSuggestStringArgRequired);
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowTypeError('Uint8Array.prototype.setFromBase64: first argument must be a string');
+    ThrowTypeError(SErrorSetFromBase64FirstArgString, SSuggestStringArgRequired);
 
   Input := AArgs.GetElement(0).ToStringLiteral.Value;
 
@@ -541,7 +544,7 @@ begin
     if not (Options is TGocciaUndefinedLiteralValue) then
     begin
       if not (Options is TGocciaObjectValue) then
-        ThrowTypeError('Uint8Array.prototype.setFromBase64: options must be an object');
+        ThrowTypeError(SErrorSetFromBase64OptionsNotObject, SSuggestBase64Format);
       Alphabet := ReadAlphabetOption(Options);
       LastChunkHandling := ReadLastChunkHandlingOption(Options);
     end;
@@ -580,14 +583,14 @@ begin
   TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.setFromHex');
 
   if AArgs.Length = 0 then
-    ThrowTypeError('Uint8Array.prototype.setFromHex requires a string argument');
+    ThrowTypeError(SErrorSetFromHexRequiresString, SSuggestStringArgRequired);
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowTypeError('Uint8Array.prototype.setFromHex: first argument must be a string');
+    ThrowTypeError(SErrorSetFromHexFirstArgString, SSuggestStringArgRequired);
 
   Input := AArgs.GetElement(0).ToStringLiteral.Value;
 
   if (Length(Input) mod 2) <> 0 then
-    ThrowSyntaxError('Invalid hex string: odd length');
+    ThrowSyntaxError(SErrorInvalidHexOddLength, SSuggestHexFormat);
 
   Written := 0;
   CharsRead := 0;
@@ -597,7 +600,7 @@ begin
     Hi := HexCharToNibble(Input[I]);
     Lo := HexCharToNibble(Input[I + 1]);
     if (Hi < 0) or (Lo < 0) then
-      ThrowSyntaxError('Invalid character in hex string');
+      ThrowSyntaxError(SErrorInvalidHexCharacter, SSuggestHexFormat);
     TA.BufferData[TA.ByteOffset + Written] := Byte((Hi shl 4) or Lo);
     Inc(Written);
     Inc(I, 2);
@@ -629,9 +632,9 @@ var
   I: Integer;
 begin
   if AArgs.Length = 0 then
-    ThrowTypeError('Uint8Array.fromBase64 requires a string argument');
+    ThrowTypeError(SErrorFromBase64RequiresString, SSuggestStringArgRequired);
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowTypeError('Uint8Array.fromBase64: first argument must be a string');
+    ThrowTypeError(SErrorFromBase64FirstArgString, SSuggestStringArgRequired);
 
   Input := AArgs.GetElement(0).ToStringLiteral.Value;
 
@@ -643,7 +646,7 @@ begin
     if not (Options is TGocciaUndefinedLiteralValue) then
     begin
       if not (Options is TGocciaObjectValue) then
-        ThrowTypeError('Uint8Array.fromBase64: options must be an object');
+        ThrowTypeError(SErrorFromBase64OptionsNotObject, SSuggestBase64Format);
       Alphabet := ReadAlphabetOption(Options);
       LastChunkHandling := ReadLastChunkHandlingOption(Options);
     end;
@@ -667,14 +670,14 @@ var
   NewTA: TGocciaTypedArrayValue;
 begin
   if AArgs.Length = 0 then
-    ThrowTypeError('Uint8Array.fromHex requires a string argument');
+    ThrowTypeError(SErrorFromHexRequiresString, SSuggestStringArgRequired);
   if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
-    ThrowTypeError('Uint8Array.fromHex: first argument must be a string');
+    ThrowTypeError(SErrorFromHexFirstArgString, SSuggestStringArgRequired);
 
   Input := AArgs.GetElement(0).ToStringLiteral.Value;
 
   if (Length(Input) mod 2) <> 0 then
-    ThrowSyntaxError('Invalid hex string: odd length');
+    ThrowSyntaxError(SErrorInvalidHexOddLength, SSuggestHexFormat);
 
   ByteLen := Length(Input) div 2;
   NewTA := TGocciaTypedArrayValue.Create(takUint8, ByteLen);
@@ -684,7 +687,7 @@ begin
     Hi := HexCharToNibble(Input[I * 2 + 1]);
     Lo := HexCharToNibble(Input[I * 2 + 2]);
     if (Hi < 0) or (Lo < 0) then
-      ThrowSyntaxError('Invalid character in hex string');
+      ThrowSyntaxError(SErrorInvalidHexCharacter, SSuggestHexFormat);
     NewTA.BufferData[NewTA.ByteOffset + I] := Byte((Hi shl 4) or Lo);
   end;
 


### PR DESCRIPTION
## Summary
- Added suggestion-aware error formatting throughout the runners, REPL, application entrypoint, and VM exception paths so thrown values now surface consistent hints.
- Replaced many ad hoc builtin error strings with centralized error message and suggestion constants across core objects, collections, promises, proxies, temporal APIs, and utility types.
- Introduced shared error message and suggestion modules to standardize diagnostics and reduce divergence between call sites.
- Added `build/ppas.sh` to support assembling and linking the generated Pascal artifacts on macOS.

## Testing
- Concrete check: verify affected runners still compile with `./build.pas testrunner && ./build.pas loader && ./build.pas repl && ./build.pas benchmarkrunner`.
- Concrete check: run the test suite with `./build/TestRunner tests` and confirm suggestion text appears in thrown-value error output where expected.