### PR TITLE
Use shared Temporal property names in PlainDate parsing

### DIFF
--- a/units/Goccia.Values.TemporalPlainDate.pas
+++ b/units/Goccia.Values.TemporalPlainDate.pas
@@ -107,6 +107,7 @@ var
   TimeRec: TTemporalTimeRecord;
   Obj: TGocciaObjectValue;
   V, VMonth, VDay: TGocciaValue;
+  RequiredFieldsMsg: string;
 begin
   if AValue is TGocciaTemporalPlainDateValue then
     Result := TGocciaTemporalPlainDateValue(AValue)
@@ -126,15 +127,16 @@ begin
   else if AValue is TGocciaObjectValue then
   begin
     Obj := TGocciaObjectValue(AValue);
+    RequiredFieldsMsg := Format('%s requires %s, %s, %s properties', [AMethod, PROP_YEAR, PROP_MONTH, PROP_DAY]);
     V := Obj.GetProperty(PROP_YEAR);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(Format('%s requires %s, %s, %s properties', [AMethod, PROP_YEAR, PROP_MONTH, PROP_DAY]), SSuggestTemporalFromArg);
+      ThrowTypeError(RequiredFieldsMsg, SSuggestTemporalFromArg);
     VMonth := Obj.GetProperty(PROP_MONTH);
     if (VMonth = nil) or (VMonth is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(Format('%s requires %s, %s, %s properties', [AMethod, PROP_YEAR, PROP_MONTH, PROP_DAY]), SSuggestTemporalFromArg);
+      ThrowTypeError(RequiredFieldsMsg, SSuggestTemporalFromArg);
     VDay := Obj.GetProperty(PROP_DAY);
     if (VDay = nil) or (VDay is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(Format('%s requires %s, %s, %s properties', [AMethod, PROP_YEAR, PROP_MONTH, PROP_DAY]), SSuggestTemporalFromArg);
+      ThrowTypeError(RequiredFieldsMsg, SSuggestTemporalFromArg);
     Result := TGocciaTemporalPlainDateValue.Create(
       Trunc(V.ToNumberLiteral.Value),
       Trunc(VMonth.ToNumberLiteral.Value),

--- a/units/Goccia.Values.TemporalPlainDate.pas
+++ b/units/Goccia.Values.TemporalPlainDate.pas
@@ -64,6 +64,7 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
@@ -125,15 +126,15 @@ begin
   else if AValue is TGocciaObjectValue then
   begin
     Obj := TGocciaObjectValue(AValue);
-    V := Obj.GetProperty('year');
+    V := Obj.GetProperty(PROP_YEAR);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires year, month, day properties', SSuggestTemporalFromArg);
-    VMonth := Obj.GetProperty('month');
+      ThrowTypeError(Format('%s requires %s, %s, %s properties', [AMethod, PROP_YEAR, PROP_MONTH, PROP_DAY]), SSuggestTemporalFromArg);
+    VMonth := Obj.GetProperty(PROP_MONTH);
     if (VMonth = nil) or (VMonth is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires year, month, day properties', SSuggestTemporalFromArg);
-    VDay := Obj.GetProperty('day');
+      ThrowTypeError(Format('%s requires %s, %s, %s properties', [AMethod, PROP_YEAR, PROP_MONTH, PROP_DAY]), SSuggestTemporalFromArg);
+    VDay := Obj.GetProperty(PROP_DAY);
     if (VDay = nil) or (VDay is TGocciaUndefinedLiteralValue) then
-      ThrowTypeError(AMethod + ' requires year, month, day properties', SSuggestTemporalFromArg);
+      ThrowTypeError(Format('%s requires %s, %s, %s properties', [AMethod, PROP_YEAR, PROP_MONTH, PROP_DAY]), SSuggestTemporalFromArg);
     Result := TGocciaTemporalPlainDateValue.Create(
       Trunc(V.ToNumberLiteral.Value),
       Trunc(VMonth.ToNumberLiteral.Value),


### PR DESCRIPTION
## Summary
- Replaced hard-coded `year`, `month`, and `day` property lookups with shared property name constants.
- Updated the missing-property type error to format the field names from the same constants, keeping the message aligned with the lookup keys.
- Added the shared property names unit to the implementation uses list.

Fixes #309 