### PR TITLE
Support iterable inputs in Map.groupBy

### DIFF
--- a/tests/built-ins/Map/groupBy.js
+++ b/tests/built-ins/Map/groupBy.js
@@ -81,9 +81,9 @@ describe("Map.groupBy", () => {
   });
 
   test("throws TypeError for non-iterable", () => {
-    expect(() => Map.groupBy(42, () => "a")).toThrow();
-    expect(() => Map.groupBy(true, () => "a")).toThrow();
-    expect(() => Map.groupBy(null, () => "a")).toThrow();
+    expect(() => Map.groupBy(42, () => "a")).toThrow(TypeError);
+    expect(() => Map.groupBy(true, () => "a")).toThrow(TypeError);
+    expect(() => Map.groupBy(null, () => "a")).toThrow(TypeError);
   });
 
   test("empty iterable returns empty Map", () => {

--- a/tests/built-ins/Map/groupBy.js
+++ b/tests/built-ins/Map/groupBy.js
@@ -28,4 +28,66 @@ describe("Map.groupBy", () => {
     });
     expect(indices).toEqual([0, 1]);
   });
+
+  test("accepts a Set", () => {
+    const result = Map.groupBy(new Set([1, 2, 3, 4]), (n) => n % 2 === 0 ? "even" : "odd");
+    expect(result.get("odd")).toEqual([1, 3]);
+    expect(result.get("even")).toEqual([2, 4]);
+  });
+
+  test("accepts a Map", () => {
+    const source = new Map([["a", 1], ["b", 2], ["c", 3]]);
+    const result = Map.groupBy(source, ([key, value]) => value > 1 ? "big" : "small");
+    expect(result.get("small")).toEqual([["a", 1]]);
+    expect(result.get("big")).toEqual([["b", 2], ["c", 3]]);
+  });
+
+  test("accepts a string", () => {
+    const result = Map.groupBy("aabbc", (ch) => ch);
+    expect(result.get("a")).toEqual(["a", "a"]);
+    expect(result.get("b")).toEqual(["b", "b"]);
+    expect(result.get("c")).toEqual(["c"]);
+  });
+
+  test("accepts a custom iterable with Symbol.iterator", () => {
+    const iterable = {
+      [Symbol.iterator]() {
+        let i = 0;
+        const values = [5, 10, 15, 20];
+        return {
+          next() {
+            if (i < values.length) {
+              const val = values[i];
+              i = i + 1;
+              return { value: val, done: false };
+            }
+            return { value: undefined, done: true };
+          }
+        };
+      }
+    };
+    const result = Map.groupBy(iterable, (n) => n >= 15 ? "high" : "low");
+    expect(result.get("low")).toEqual([5, 10]);
+    expect(result.get("high")).toEqual([15, 20]);
+  });
+
+  test("callback receives correct index for iterables", () => {
+    const indices = [];
+    Map.groupBy(new Set(["x", "y", "z"]), (el, idx) => {
+      indices.push(idx);
+      return "group";
+    });
+    expect(indices).toEqual([0, 1, 2]);
+  });
+
+  test("throws TypeError for non-iterable", () => {
+    expect(() => Map.groupBy(42, () => "a")).toThrow();
+    expect(() => Map.groupBy(true, () => "a")).toThrow();
+    expect(() => Map.groupBy(null, () => "a")).toThrow();
+  });
+
+  test("empty iterable returns empty Map", () => {
+    const result = Map.groupBy(new Set(), () => "a");
+    expect(result.size).toBe(0);
+  });
 });

--- a/units/Goccia.Builtins.GlobalMap.pas
+++ b/units/Goccia.Builtins.GlobalMap.pas
@@ -22,13 +22,21 @@ type
 implementation
 
 uses
+  Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.GarbageCollector,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
+  Goccia.Values.Iterator.Concrete,
+  Goccia.Values.Iterator.Generic,
+  Goccia.Values.IteratorValue,
   Goccia.Values.MapValue,
-  Goccia.Values.NativeFunction;
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.SymbolValue;
 
 constructor TGocciaGlobalMap.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 begin
@@ -40,71 +48,156 @@ end;
 // ES2026 §24.1.2.1 Map.groupBy(items, callbackfn)
 function TGocciaGlobalMap.MapGroupBy(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Items: TGocciaArrayValue;
+  Source: TGocciaValue;
+  SourceArray: TGocciaArrayValue;
   Callback: TGocciaValue;
   ResultMap: TGocciaMapValue;
   GroupKey: TGocciaValue;
   GroupArray: TGocciaArrayValue;
   CallArgs: TGocciaArgumentsCollection;
+  IteratorMethod, IteratorObj, NextMethod, CurrentValue: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
+  Done: Boolean;
   I, J: Integer;
   Found: Boolean;
-begin
-  // Step 1: Let groups be GroupBy(items, callbackfn, zero)
-  // (Validate arguments first)
-  if not (AArgs.GetElement(0) is TGocciaArrayValue) then
-    ThrowTypeError(SErrorMapGroupByRequiresIterable, SSuggestNotIterable);
-  if not AArgs.GetElement(1).IsCallable then
-    ThrowTypeError(SErrorMapGroupByRequiresCallback, SSuggestCallbackRequired);
 
-  Items := TGocciaArrayValue(AArgs.GetElement(0));
-  Callback := AArgs.GetElement(1);
-  // Step 2: Let map be a new empty Map
-  ResultMap := TGocciaMapValue.Create;
-
-  // GroupBy abstract operation: iterate items, call callbackfn for each element
-  I := 0;
-  while I < Items.Elements.Count do
+  procedure AddToGroup(const AValue: TGocciaValue; const AIndex: Integer);
+  var
+    K: Integer;
   begin
-    // Step 1a (GroupBy): Let value be items[k]
-    // Step 1b (GroupBy): Let key be Call(callbackfn, undefined, « value, k »)
     CallArgs := TGocciaArgumentsCollection.Create;
     try
-      CallArgs.Add(Items.Elements[I]);
-      CallArgs.Add(TGocciaNumberLiteralValue.Create(I));
+      CallArgs.Add(AValue);
+      CallArgs.Add(TGocciaNumberLiteralValue.Create(AIndex));
       GroupKey := InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
     finally
       CallArgs.Free;
     end;
 
-    // Step 1c (GroupBy): If key matches an existing group, use that group
+    // If key matches an existing group, use that group
     Found := False;
-    for J := 0 to ResultMap.Entries.Count - 1 do
+    for K := 0 to ResultMap.Entries.Count - 1 do
     begin
-      if ResultMap.Entries[J].Key.ToStringLiteral.Value = GroupKey.ToStringLiteral.Value then
+      if ResultMap.Entries[K].Key.ToStringLiteral.Value = GroupKey.ToStringLiteral.Value then
       begin
-        GroupArray := TGocciaArrayValue(ResultMap.Entries[J].Value);
+        GroupArray := TGocciaArrayValue(ResultMap.Entries[K].Value);
         Found := True;
         Break;
       end;
     end;
 
-    // Step 1d (GroupBy): Otherwise, create a new group for this key
+    // Otherwise, create a new group for this key
     if not Found then
     begin
       GroupArray := TGocciaArrayValue.Create;
       ResultMap.SetEntry(GroupKey, GroupArray);
     end;
 
-    // Step 1e (GroupBy): Append value to the group's elements list
-    GroupArray.Elements.Add(Items.Elements[I]);
-    Inc(I);
+    // Append value to the group's elements list
+    GroupArray.Elements.Add(AValue);
   end;
 
-  // Step 3: For each Record { [[Key]], [[Elements]] } g of groups, do
-  //   Perform ! CreateDataPropertyOrThrow(map, g.[[Key]], CreateArrayFromList(g.[[Elements]]))
-  //   (Already done inline above via SetEntry)
-  // Step 4: Return map
-  Result := ResultMap;
+begin
+  // Step 1: Let groups be GroupBy(items, callbackfn, zero)
+  // (Validate arguments first)
+  if not AArgs.GetElement(1).IsCallable then
+    ThrowTypeError(SErrorMapGroupByRequiresCallback, SSuggestCallbackRequired);
+
+  Source := AArgs.GetElement(0);
+  Callback := AArgs.GetElement(1);
+
+  // Step 2: Let map be a new empty Map
+  ResultMap := TGocciaMapValue.Create;
+
+  // Fast path: source is an array (avoids iterator overhead)
+  if Source is TGocciaArrayValue then
+  begin
+    SourceArray := TGocciaArrayValue(Source);
+    I := 0;
+    while I < SourceArray.Elements.Count do
+    begin
+      AddToGroup(SourceArray.Elements[I], I);
+      Inc(I);
+    end;
+    Result := ResultMap;
+    Exit;
+  end;
+
+  // Iterator path: strings via string iterator
+  if Source is TGocciaStringLiteralValue then
+  begin
+    Iterator := TGocciaStringIteratorValue.Create(Source);
+    TGarbageCollector.Instance.AddTempRoot(Iterator);
+    TGarbageCollector.Instance.AddTempRoot(ResultMap);
+    try
+      I := 0;
+      CurrentValue := Iterator.DirectNext(Done);
+      while not Done do
+      begin
+        AddToGroup(CurrentValue, I);
+        Inc(I);
+        CurrentValue := Iterator.DirectNext(Done);
+      end;
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(ResultMap);
+      TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+    end;
+    Result := ResultMap;
+    Exit;
+  end;
+
+  // Iterator path: objects with [Symbol.iterator]
+  if Source is TGocciaObjectValue then
+  begin
+    IteratorMethod := TGocciaObjectValue(Source).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
+    if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
+    begin
+      CallArgs := TGocciaArgumentsCollection.Create;
+      try
+        IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, Source);
+      finally
+        CallArgs.Free;
+      end;
+
+      if IteratorObj is TGocciaIteratorValue then
+        Iterator := TGocciaIteratorValue(IteratorObj)
+      else if IteratorObj is TGocciaObjectValue then
+      begin
+        NextMethod := IteratorObj.GetProperty(PROP_NEXT);
+        if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
+          Iterator := TGocciaGenericIteratorValue.Create(IteratorObj)
+        else
+          Iterator := nil;
+      end
+      else
+        Iterator := nil;
+
+      if not Assigned(Iterator) then
+        ThrowTypeError(SErrorMapGroupByRequiresIterable, SSuggestNotIterable);
+
+      TGarbageCollector.Instance.AddTempRoot(Iterator);
+      TGarbageCollector.Instance.AddTempRoot(ResultMap);
+      try
+        I := 0;
+        CurrentValue := Iterator.DirectNext(Done);
+        while not Done do
+        begin
+          AddToGroup(CurrentValue, I);
+          Inc(I);
+          CurrentValue := Iterator.DirectNext(Done);
+        end;
+      finally
+        TGarbageCollector.Instance.RemoveTempRoot(ResultMap);
+        TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+      end;
+      Result := ResultMap;
+      Exit;
+    end;
+  end;
+
+  // Non-iterable: throw TypeError
+  ThrowTypeError(SErrorMapGroupByRequiresIterable, SSuggestNotIterable);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 end.

--- a/units/Goccia.Builtins.GlobalMap.pas
+++ b/units/Goccia.Builtins.GlobalMap.pas
@@ -147,43 +147,48 @@ begin
     IteratorMethod := TGocciaObjectValue(Source).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
     if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
     begin
-      CallArgs := TGocciaArgumentsCollection.Create;
-      try
-        IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, Source);
-      finally
-        CallArgs.Free;
-      end;
-
-      if IteratorObj is TGocciaIteratorValue then
-        Iterator := TGocciaIteratorValue(IteratorObj)
-      else if IteratorObj is TGocciaObjectValue then
-      begin
-        NextMethod := IteratorObj.GetProperty(PROP_NEXT);
-        if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
-          Iterator := TGocciaGenericIteratorValue.Create(IteratorObj)
-        else
-          Iterator := nil;
-      end
-      else
-        Iterator := nil;
-
-      if not Assigned(Iterator) then
-        ThrowTypeError(SErrorMapGroupByRequiresIterable, SSuggestNotIterable);
-
-      TGarbageCollector.Instance.AddTempRoot(Iterator);
+      // Root ResultMap before calling [Symbol.iterator]() — that call
+      // executes user code and may trigger GC.
       TGarbageCollector.Instance.AddTempRoot(ResultMap);
       try
-        I := 0;
-        CurrentValue := Iterator.DirectNext(Done);
-        while not Done do
+        CallArgs := TGocciaArgumentsCollection.Create;
+        try
+          IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, Source);
+        finally
+          CallArgs.Free;
+        end;
+
+        if IteratorObj is TGocciaIteratorValue then
+          Iterator := TGocciaIteratorValue(IteratorObj)
+        else if IteratorObj is TGocciaObjectValue then
         begin
-          AddToGroup(CurrentValue, I);
-          Inc(I);
+          NextMethod := IteratorObj.GetProperty(PROP_NEXT);
+          if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
+            Iterator := TGocciaGenericIteratorValue.Create(IteratorObj)
+          else
+            Iterator := nil;
+        end
+        else
+          Iterator := nil;
+
+        if not Assigned(Iterator) then
+          ThrowTypeError(SErrorMapGroupByRequiresIterable, SSuggestNotIterable);
+
+        TGarbageCollector.Instance.AddTempRoot(Iterator);
+        try
+          I := 0;
           CurrentValue := Iterator.DirectNext(Done);
+          while not Done do
+          begin
+            AddToGroup(CurrentValue, I);
+            Inc(I);
+            CurrentValue := Iterator.DirectNext(Done);
+          end;
+        finally
+          TGarbageCollector.Instance.RemoveTempRoot(Iterator);
         end;
       finally
         TGarbageCollector.Instance.RemoveTempRoot(ResultMap);
-        TGarbageCollector.Instance.RemoveTempRoot(Iterator);
       end;
       Result := ResultMap;
       Exit;

--- a/units/Goccia.Builtins.GlobalMap.pas
+++ b/units/Goccia.Builtins.GlobalMap.pas
@@ -58,12 +58,11 @@ var
   IteratorMethod, IteratorObj, NextMethod, CurrentValue: TGocciaValue;
   Iterator: TGocciaIteratorValue;
   Done: Boolean;
-  I, J: Integer;
-  Found: Boolean;
+  I: Integer;
 
   procedure AddToGroup(const AValue: TGocciaValue; const AIndex: Integer);
   var
-    K: Integer;
+    EntryIndex: Integer;
   begin
     CallArgs := TGocciaArgumentsCollection.Create;
     try
@@ -74,20 +73,11 @@ var
       CallArgs.Free;
     end;
 
-    // If key matches an existing group, use that group
-    Found := False;
-    for K := 0 to ResultMap.Entries.Count - 1 do
-    begin
-      if ResultMap.Entries[K].Key.ToStringLiteral.Value = GroupKey.ToStringLiteral.Value then
-      begin
-        GroupArray := TGocciaArrayValue(ResultMap.Entries[K].Value);
-        Found := True;
-        Break;
-      end;
-    end;
-
-    // Otherwise, create a new group for this key
-    if not Found then
+    // Use Map's SameValueZero lookup to preserve key identity (1 vs "1", etc.)
+    EntryIndex := ResultMap.FindEntry(GroupKey);
+    if EntryIndex >= 0 then
+      GroupArray := TGocciaArrayValue(ResultMap.Entries[EntryIndex].Value)
+    else
     begin
       GroupArray := TGocciaArrayValue.Create;
       ResultMap.SetEntry(GroupKey, GroupArray);
@@ -113,11 +103,16 @@ begin
   if Source is TGocciaArrayValue then
   begin
     SourceArray := TGocciaArrayValue(Source);
-    I := 0;
-    while I < SourceArray.Elements.Count do
-    begin
-      AddToGroup(SourceArray.Elements[I], I);
-      Inc(I);
+    TGarbageCollector.Instance.AddTempRoot(ResultMap);
+    try
+      I := 0;
+      while I < SourceArray.Elements.Count do
+      begin
+        AddToGroup(SourceArray.Elements[I], I);
+        Inc(I);
+      end;
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(ResultMap);
     end;
     Result := ResultMap;
     Exit;


### PR DESCRIPTION
## Summary
- Expanded `Map.groupBy` to accept iterable sources, including arrays, sets, maps, strings, and custom iterables.
- Preserved the array fast path while adding iterator-based handling for non-array inputs.
- Added coverage for iterable sources, callback indices, empty iterables, and non-iterable TypeError cases.

Fixes #310 