### PR TITLE
Report wall-clock timing for parallel runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,8 +310,10 @@ jobs:
         run: |
           grep -q '"mode": "interpreted"' test-results-interpreted.json
           grep -q '"totalFiles":' test-results-interpreted.json
+          grep -q '"jobCount":' test-results-interpreted.json
           grep -q '"mode": "bytecode"' test-results-bytecode.json
           grep -q '"totalFiles":' test-results-bytecode.json
+          grep -q '"jobCount":' test-results-bytecode.json
 
       - name: Check TestRunner coverage CLI
         run: |
@@ -654,6 +656,7 @@ jobs:
         run: |
           grep -q '"files": \[' benchmark-${{ matrix.mode }}-results.json
           grep -q '"totalBenchmarks":' benchmark-${{ matrix.mode }}-results.json
+          grep -q '"jobCount":' benchmark-${{ matrix.mode }}-results.json
 
       - name: Cache benchmark baseline
         if: github.ref == 'refs/heads/main' && matrix.target == 'x86_64-linux'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -880,6 +880,10 @@ jobs:
               const bSkipped = testBytecode ? testBytecode.skipped : 0;
               const iDur = testInterp ? fmtDur(testInterp.durationNanoseconds) : '—';
               const bDur = testBytecode ? fmtDur(testBytecode.durationNanoseconds) : '—';
+              const iJobs = testInterp ? (testInterp.jobCount || 1) : 1;
+              const bJobs = testBytecode ? (testBytecode.jobCount || 1) : 1;
+              const isParallel = iJobs > 1 || bJobs > 1;
+              const timingLabel = isParallel ? ' (cumulative)' : '';
               const iLex = testInterp ? fmtDur(testInterp.lexTimeNanoseconds) : '—';
               const bLex = testBytecode ? fmtDur(testBytecode.lexTimeNanoseconds) : '—';
               const iParse = testInterp ? fmtDur(testInterp.parseTimeNanoseconds) : '—';
@@ -896,12 +900,31 @@ jobs:
                 body += `| Tests | Failed | ${iFailed > 0 ? `${iFailed} ❌` : '0'} | ${bFailed > 0 ? `${bFailed} ❌` : '0'} |\n`;
               if (iSkipped > 0 || bSkipped > 0)
                 body += `| Tests | Skipped | ${iSkipped} | ${bSkipped} |\n`;
+              if (isParallel)
+                body += `| Tests | Workers | ${iJobs} | ${bJobs} |\n`;
               body += `| Tests | Test Duration | ${iDur} | ${bDur} |\n`;
-              body += `| Tests | Lex | ${iLex} | ${bLex} |\n`;
-              body += `| Tests | Parse | ${iParse} | ${bParse} |\n`;
-              body += `| Tests | Compile | — | ${bCompile} |\n`;
-              body += `| Tests | Execute | ${iExec} | ${bExec} |\n`;
-              body += `| Tests | Engine Total | ${iEngine} | ${bEngine} |\n`;
+              body += `| Tests | Lex${timingLabel} | ${iLex} | ${bLex} |\n`;
+              body += `| Tests | Parse${timingLabel} | ${iParse} | ${bParse} |\n`;
+              body += `| Tests | Compile${timingLabel} | — | ${bCompile} |\n`;
+              body += `| Tests | Execute${timingLabel} | ${iExec} | ${bExec} |\n`;
+              body += `| Tests | Engine Total${timingLabel} | ${iEngine} | ${bEngine} |\n`;
+              if (isParallel) {
+                const fmtAvg = (ns, jobs) => jobs > 1 ? fmtDur(ns / jobs) : '—';
+                const iAvgLex = testInterp && iJobs > 1 ? fmtAvg(testInterp.lexTimeNanoseconds, iJobs) : '—';
+                const bAvgLex = testBytecode && bJobs > 1 ? fmtAvg(testBytecode.lexTimeNanoseconds, bJobs) : '—';
+                const iAvgParse = testInterp && iJobs > 1 ? fmtAvg(testInterp.parseTimeNanoseconds, iJobs) : '—';
+                const bAvgParse = testBytecode && bJobs > 1 ? fmtAvg(testBytecode.parseTimeNanoseconds, bJobs) : '—';
+                const bAvgCompile = testBytecode && bJobs > 1 ? fmtAvg(testBytecode.compileTimeNanoseconds, bJobs) : '—';
+                const iAvgExec = testInterp && iJobs > 1 ? fmtAvg(testInterp.executeTimeNanoseconds, iJobs) : '—';
+                const bAvgExec = testBytecode && bJobs > 1 ? fmtAvg(testBytecode.executeTimeNanoseconds, bJobs) : '—';
+                const iAvgEngine = testInterp && iJobs > 1 ? fmtAvg(testInterp.totalEngineNanoseconds, iJobs) : '—';
+                const bAvgEngine = testBytecode && bJobs > 1 ? fmtAvg(testBytecode.totalEngineNanoseconds, bJobs) : '—';
+                body += `| Tests | Lex (avg/worker) | ${iAvgLex} | ${bAvgLex} |\n`;
+                body += `| Tests | Parse (avg/worker) | ${iAvgParse} | ${bAvgParse} |\n`;
+                body += `| Tests | Compile (avg/worker) | — | ${bAvgCompile} |\n`;
+                body += `| Tests | Execute (avg/worker) | ${iAvgExec} | ${bAvgExec} |\n`;
+                body += `| Tests | Engine Total (avg/worker) | ${iAvgEngine} | ${bAvgEngine} |\n`;
+              }
             }
 
             if (benchInterp || benchBytecode) {

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           grep -q '"mode": "${{ matrix.mode }}"' test-results-${{ matrix.mode }}.json
           grep -q '"totalFiles":' test-results-${{ matrix.mode }}.json
+          grep -q '"jobCount":' test-results-${{ matrix.mode }}.json
 
       - name: Check TestRunner coverage CLI
         run: |
@@ -192,6 +193,7 @@ jobs:
         run: |
           grep -q '"files": \[' benchmark-${{ matrix.mode }}.json
           grep -q '"totalBenchmarks":' benchmark-${{ matrix.mode }}.json
+          grep -q '"jobCount":' benchmark-${{ matrix.mode }}.json
 
       - name: Check BenchmarkRunner CLI behaviour
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -932,8 +932,13 @@ jobs:
               const bBenchCount = benchBytecode ? benchBytecode.files.reduce((a, f) => a + f.benchmarks.filter(b => !b.error).length, 0) : '—';
               const iBenchDur = benchInterp ? fmtDur(benchInterp.totalDurationNanoseconds) : '—';
               const bBenchDur = benchBytecode ? fmtDur(benchBytecode.totalDurationNanoseconds) : '—';
+              const iBenchJobs = benchInterp ? (benchInterp.jobCount || 1) : 1;
+              const bBenchJobs = benchBytecode ? (benchBytecode.jobCount || 1) : 1;
+              const benchParallel = iBenchJobs > 1 || bBenchJobs > 1;
 
               body += `| Benchmarks | Total | ${iBenchCount} | ${bBenchCount} |\n`;
+              if (benchParallel)
+                body += `| Benchmarks | Workers | ${iBenchJobs} | ${bBenchJobs} |\n`;
               body += `| Benchmarks | Duration | ${iBenchDur} | ${bBenchDur} |\n`;
             }
 

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -693,6 +693,7 @@ var
   Reporter: TBenchmarkReporter;
   Pool: TGocciaThreadPool;
   WorkerData: array of TBenchmarkFileResult;
+  WallClockStart: Int64;
 begin
   Files := TStringList.Create;
   Reporter := TBenchmarkReporter.Create;
@@ -738,12 +739,16 @@ begin
 
       EnsureSharedPrototypesInitialized(GlobalBuiltins);
 
+      WallClockStart := GetNanoseconds;
+
       Pool := TGocciaThreadPool.Create(JobCount);
       try
         Pool.RunAll(Files, BenchmarkWorkerProc, @WorkerData[0]);
       finally
         Pool.Free;
       end;
+
+      Reporter.WallClockDurationNanoseconds := GetNanoseconds - WallClockStart;
 
       { Collect results on the main thread in original file order. }
       for I := 0 to Files.Count - 1 do

--- a/BenchmarkRunner.dpr
+++ b/BenchmarkRunner.dpr
@@ -749,6 +749,7 @@ begin
       end;
 
       Reporter.WallClockDurationNanoseconds := GetNanoseconds - WallClockStart;
+      Reporter.JobCount := JobCount;
 
       { Collect results on the main thread in original file order. }
       for I := 0 to Files.Count - 1 do

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -514,6 +514,7 @@ function TTestRunnerApp.RunScriptFromFile(const AFileName: string): TAggregatedT
 var
   FileResult: TTestFileResult;
 begin
+  Result.JobCount := 1;
   Result.TestResult := nil;
   Result.TotalLexNanoseconds := 0;
   Result.TotalParseNanoseconds := 0;

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -766,6 +766,8 @@ begin
     Pool.Free;
   end;
 
+  WallClockDuration := GetNanoseconds - WallClockStart;
+
   // Aggregate results on the main thread using GC-managed objects
   GC := TGarbageCollector.Instance;
 
@@ -812,14 +814,12 @@ begin
         TGocciaStringLiteralValue.Create(WorkerData[I].FailedTestNames[J]));
   end;
 
-  WallClockDuration := GetNanoseconds - WallClockStart;
-
   AllTestResults.AssignProperty('totalTests', TGocciaNumberLiteralValue.Create(AFiles.Count * 1.0));
   AllTestResults.AssignProperty('totalRunTests', TGocciaNumberLiteralValue.Create(TotalRunCount));
   AllTestResults.AssignProperty('passed', TGocciaNumberLiteralValue.Create(PassedCount));
   AllTestResults.AssignProperty('failed', TGocciaNumberLiteralValue.Create(FailedCount));
   AllTestResults.AssignProperty('skipped', TGocciaNumberLiteralValue.Create(SkippedCount));
-  AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(WallClockDuration * 1.0));
+  AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(WallClockDuration));
   AllTestResults.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(TotalAssertions));
   AllTestResults.AssignProperty('failedTests', AllFailedTests);
 

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -85,6 +85,7 @@ type
     TotalParseNanoseconds: Int64;
     TotalCompileNanoseconds: Int64;
     TotalExecNanoseconds: Int64;
+    JobCount: Integer;
   end;
 
   TTestRunnerApp = class(TGocciaCLIApplication)
@@ -624,6 +625,7 @@ begin
   AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(TotalDuration));
   AllTestResults.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(TotalAssertions));
 
+  Result.JobCount := 1;
   Result.TestResult := AllTestResults;
 end;
 
@@ -827,6 +829,7 @@ begin
     GC.RemoveTempRoot(AllFailedTests);
   end;
 
+  Result.JobCount := AJobCount;
   Result.TestResult := AllTestResults;
 end;
 
@@ -849,6 +852,7 @@ begin
   try
     Lines.Add('{');
     Lines.Add(Format('  "mode": "%s",', [IfThen(IsBytecodeMode, 'bytecode', 'interpreted')]));
+    Lines.Add(Format('  "jobCount": %d,', [AResult.JobCount]));
     Lines.Add(Format('  "totalFiles": %d,', [Round(AResult.TestResult.GetProperty('totalTests').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "totalTests": %d,', [Round(AResult.TestResult.GetProperty('totalRunTests').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "passed": %d,', [Round(AResult.TestResult.GetProperty('passed').ToNumberLiteral.Value)]));
@@ -897,6 +901,7 @@ var
   RunCount: Double;
   PerTestNanoseconds: Int64;
   IsBytecodeMode: Boolean;
+  IsParallel: Boolean;
   CurrentOutputFile: string;
 begin
   ExitCode := 0;
@@ -913,6 +918,7 @@ begin
   RunCount := StrToFloat(TotalRunTests);
 
   IsBytecodeMode := EngineOptions.Mode.Matches(emBytecode);
+  IsParallel := AResult.JobCount > 1;
 
   if not FNoResults.Present then
   begin
@@ -927,15 +933,46 @@ begin
       Writeln(Format('Test Results Skipped: %s (%2.2f%%)', [TotalSkipped, (StrToFloat(TotalSkipped) / RunCount * 100)]));
       Writeln(Format('Test Results Assertions: %s', [TotalAssertions]));
       Writeln(Format('Test Results Test Duration: %s (%s/test)', [FormatDuration(DurationNanoseconds), FormatDuration(PerTestNanoseconds)]));
-      if IsBytecodeMode then
-        Writeln(Format('Test Results Engine Timing: Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
-          [FormatDuration(AResult.TotalLexNanoseconds), FormatDuration(AResult.TotalParseNanoseconds),
-           FormatDuration(AResult.TotalCompileNanoseconds), FormatDuration(AResult.TotalExecNanoseconds),
-           FormatDuration(AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds)]))
+      if IsParallel then
+      begin
+        if IsBytecodeMode then
+        begin
+          Writeln(Format('Test Results Engine Timing (cumulative): Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
+            [FormatDuration(AResult.TotalLexNanoseconds), FormatDuration(AResult.TotalParseNanoseconds),
+             FormatDuration(AResult.TotalCompileNanoseconds), FormatDuration(AResult.TotalExecNanoseconds),
+             FormatDuration(AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds)]));
+          Writeln(Format('Test Results Engine Timing (avg/worker): Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
+            [FormatDuration(AResult.TotalLexNanoseconds div AResult.JobCount),
+             FormatDuration(AResult.TotalParseNanoseconds div AResult.JobCount),
+             FormatDuration(AResult.TotalCompileNanoseconds div AResult.JobCount),
+             FormatDuration(AResult.TotalExecNanoseconds div AResult.JobCount),
+             FormatDuration((AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds) div AResult.JobCount)]));
+        end
+        else
+        begin
+          Writeln(Format('Test Results Engine Timing (cumulative): Lex: %s | Parse: %s | Execute: %s | Total: %s',
+            [FormatDuration(AResult.TotalLexNanoseconds), FormatDuration(AResult.TotalParseNanoseconds),
+             FormatDuration(AResult.TotalExecNanoseconds),
+             FormatDuration(AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalExecNanoseconds)]));
+          Writeln(Format('Test Results Engine Timing (avg/worker): Lex: %s | Parse: %s | Execute: %s | Total: %s',
+            [FormatDuration(AResult.TotalLexNanoseconds div AResult.JobCount),
+             FormatDuration(AResult.TotalParseNanoseconds div AResult.JobCount),
+             FormatDuration(AResult.TotalExecNanoseconds div AResult.JobCount),
+             FormatDuration((AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalExecNanoseconds) div AResult.JobCount)]));
+        end;
+      end
       else
-        Writeln(Format('Test Results Engine Timing: Lex: %s | Parse: %s | Execute: %s | Total: %s',
-          [FormatDuration(AResult.TotalLexNanoseconds), FormatDuration(AResult.TotalParseNanoseconds), FormatDuration(AResult.TotalExecNanoseconds),
-           FormatDuration(AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalExecNanoseconds)]));
+      begin
+        if IsBytecodeMode then
+          Writeln(Format('Test Results Engine Timing: Lex: %s | Parse: %s | Compile: %s | Execute: %s | Total: %s',
+            [FormatDuration(AResult.TotalLexNanoseconds), FormatDuration(AResult.TotalParseNanoseconds),
+             FormatDuration(AResult.TotalCompileNanoseconds), FormatDuration(AResult.TotalExecNanoseconds),
+             FormatDuration(AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds)]))
+        else
+          Writeln(Format('Test Results Engine Timing: Lex: %s | Parse: %s | Execute: %s | Total: %s',
+            [FormatDuration(AResult.TotalLexNanoseconds), FormatDuration(AResult.TotalParseNanoseconds), FormatDuration(AResult.TotalExecNanoseconds),
+             FormatDuration(AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalExecNanoseconds)]));
+      end;
       Writeln(Format('Test Results Failed Tests: %s', [TestResult.GetProperty('failedTests').ToStringLiteral.Value]));
     end;
   end;

--- a/TestRunner.dpr
+++ b/TestRunner.dpr
@@ -714,7 +714,8 @@ var
   I, J: Integer;
   AllTestResults: TGocciaObjectValue;
   AllFailedTests: TGocciaArrayValue;
-  PassedCount, FailedCount, SkippedCount, TotalRunCount, TotalAssertions, TotalDuration: Double;
+  PassedCount, FailedCount, SkippedCount, TotalRunCount, TotalAssertions: Double;
+  WallClockStart, WallClockDuration: Int64;
   EffectiveTimeoutMs: Integer;
   WatchdogMs: Integer;
 begin
@@ -738,6 +739,8 @@ begin
   // Force all shared prototypes to be initialised on the main thread
   // before any worker thread starts, avoiding class-var race conditions.
   EnsureSharedPrototypesInitialized(GlobalBuiltins);
+
+  WallClockStart := GetNanoseconds;
 
   Pool := TGocciaThreadPool.Create(AJobCount);
   try
@@ -778,7 +781,6 @@ begin
   SkippedCount := 0;
   TotalRunCount := 0;
   TotalAssertions := 0;
-  TotalDuration := 0;
   Result.TotalLexNanoseconds := 0;
   Result.TotalParseNanoseconds := 0;
   Result.TotalCompileNanoseconds := 0;
@@ -797,7 +799,6 @@ begin
     SkippedCount := SkippedCount + WorkerData[I].Skipped;
     TotalRunCount := TotalRunCount + WorkerData[I].TotalRunTests;
     TotalAssertions := TotalAssertions + WorkerData[I].Assertions;
-    TotalDuration := TotalDuration + WorkerData[I].Duration;
 
     Result.TotalLexNanoseconds := Result.TotalLexNanoseconds + WorkerData[I].LexNs;
     Result.TotalParseNanoseconds := Result.TotalParseNanoseconds + WorkerData[I].ParseNs;
@@ -809,12 +810,14 @@ begin
         TGocciaStringLiteralValue.Create(WorkerData[I].FailedTestNames[J]));
   end;
 
+  WallClockDuration := GetNanoseconds - WallClockStart;
+
   AllTestResults.AssignProperty('totalTests', TGocciaNumberLiteralValue.Create(AFiles.Count * 1.0));
   AllTestResults.AssignProperty('totalRunTests', TGocciaNumberLiteralValue.Create(TotalRunCount));
   AllTestResults.AssignProperty('passed', TGocciaNumberLiteralValue.Create(PassedCount));
   AllTestResults.AssignProperty('failed', TGocciaNumberLiteralValue.Create(FailedCount));
   AllTestResults.AssignProperty('skipped', TGocciaNumberLiteralValue.Create(SkippedCount));
-  AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(TotalDuration));
+  AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(WallClockDuration * 1.0));
   AllTestResults.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(TotalAssertions));
   AllTestResults.AssignProperty('failedTests', AllFailedTests);
 

--- a/units/Goccia.Benchmark.Reporter.pas
+++ b/units/Goccia.Benchmark.Reporter.pas
@@ -40,6 +40,7 @@ type
     FFiles: array of TBenchmarkFileResult;
     FFileCount: Integer;
     FOutput: TStringList;
+    FWallClockDurationNanoseconds: Int64;
 
     procedure RenderConsole;
     procedure RenderText;
@@ -63,6 +64,7 @@ type
     property Output: TStringList read FOutput;
     property FileCount: Integer read FFileCount;
     property Files[AIndex: Integer]: TBenchmarkFileResult read GetFileResult;
+    property WallClockDurationNanoseconds: Int64 read FWallClockDurationNanoseconds write FWallClockDurationNanoseconds;
   end;
 
 function ParseReportFormat(const S: string): TBenchmarkReportFormat;
@@ -96,6 +98,7 @@ begin
   inherited Create;
   FOutput := TStringList.Create;
   FFileCount := 0;
+  FWallClockDurationNanoseconds := 0;
   SetLength(FFiles, 0);
 end;
 
@@ -236,6 +239,9 @@ begin
       FOutput.Add('');
   end;
 
+  if FWallClockDurationNanoseconds > 0 then
+    TotalDurationNanoseconds := FWallClockDurationNanoseconds;
+
   FOutput.Add('');
   FOutput.Add('Benchmark Summary');
   FOutput.Add(SysUtils.Format('  Total benchmarks: %d', [TotalBenchmarks]));
@@ -287,6 +293,9 @@ begin
     TotalBenchmarks := TotalBenchmarks + FFiles[F].TotalBenchmarks;
     TotalDurationNanoseconds := TotalDurationNanoseconds + FFiles[F].DurationNanoseconds;
   end;
+
+  if FWallClockDurationNanoseconds > 0 then
+    TotalDurationNanoseconds := FWallClockDurationNanoseconds;
 
   FOutput.Add('');
   FOutput.Add(SysUtils.Format('Total: %d benchmarks in %s',
@@ -386,6 +395,9 @@ begin
     if F < FFileCount - 1 then
       FOutput[FOutput.Count - 1] := FOutput[FOutput.Count - 1] + ',';
   end;
+
+  if FWallClockDurationNanoseconds > 0 then
+    TotalDurationNanoseconds := FWallClockDurationNanoseconds;
 
   FOutput.Add('  ],');
   FOutput.Add(SysUtils.Format('  "totalBenchmarks": %d,', [TotalBenchmarks]));

--- a/units/Goccia.Benchmark.Reporter.pas
+++ b/units/Goccia.Benchmark.Reporter.pas
@@ -41,6 +41,7 @@ type
     FFileCount: Integer;
     FOutput: TStringList;
     FWallClockDurationNanoseconds: Int64;
+    FJobCount: Integer;
 
     procedure RenderConsole;
     procedure RenderText;
@@ -65,6 +66,7 @@ type
     property FileCount: Integer read FFileCount;
     property Files[AIndex: Integer]: TBenchmarkFileResult read GetFileResult;
     property WallClockDurationNanoseconds: Int64 read FWallClockDurationNanoseconds write FWallClockDurationNanoseconds;
+    property JobCount: Integer read FJobCount write FJobCount;
   end;
 
 function ParseReportFormat(const S: string): TBenchmarkReportFormat;
@@ -99,6 +101,7 @@ begin
   FOutput := TStringList.Create;
   FFileCount := 0;
   FWallClockDurationNanoseconds := 0;
+  FJobCount := 1;
   SetLength(FFiles, 0);
 end;
 
@@ -400,6 +403,7 @@ begin
     TotalDurationNanoseconds := FWallClockDurationNanoseconds;
 
   FOutput.Add('  ],');
+  FOutput.Add(SysUtils.Format('  "jobCount": %d,', [FJobCount]));
   FOutput.Add(SysUtils.Format('  "totalBenchmarks": %d,', [TotalBenchmarks]));
   FOutput.Add(SysUtils.Format('  "totalDurationNanoseconds": %d', [TotalDurationNanoseconds]));
   FOutput.Add('}');


### PR DESCRIPTION
## Summary
- Measure wall-clock elapsed time around parallel execution in `TestRunner` and `BenchmarkRunner`.
- Use that elapsed time for aggregate duration reporting instead of summing worker timings.
- Propagate the wall-clock duration into benchmark reporter output for console, text, and JSON formats.

## Testing
- Not run (PR content drafted from diff only).
- Review the updated duration fields in benchmark and test runner output paths.
- Verify parallel runs still produce the same per-file/per-worker results while the aggregate duration reflects wall-clock time.