### PR TITLE
Add standalone GocciaBundler build target and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -960,12 +960,6 @@ jobs:
           check_map_json /tmp/custom.map
           rm /tmp/custom.map
 
-          # --source-map with --emit
-          ./build/ScriptLoader /tmp/sm-test.jsx --emit --source-map
-          test -f /tmp/sm-test.jsx.map
-          check_map_json /tmp/sm-test.jsx.map
-          rm /tmp/sm-test.jsx.map /tmp/sm-test.gbc
-
           # --source-map in interpreted mode
           ./build/ScriptLoader /tmp/sm-test.jsx --source-map
           test -f /tmp/sm-test.jsx.map
@@ -985,6 +979,60 @@ jobs:
           printf '%s\n' "$out" | grep -q 'required when reading source from stdin'
 
           rm /tmp/sm-test.jsx
+
+      - name: Check GocciaBundler source map CLI
+        run: |
+          check_map_json() {
+            python3 - "$1" <<'PY'
+          import json, sys
+          with open(sys.argv[1], 'r', encoding='utf-8') as f:
+              data = json.load(f)
+          assert data.get('version') == 3, f"bad version: {data.get('version')}"
+          assert isinstance(data.get('sources'), list) and len(data['sources']) > 0, "missing sources"
+          assert isinstance(data.get('mappings'), str) and data['mappings'] != '', "missing mappings"
+          PY
+          }
+
+          # Create a JSX test file
+          cat > /tmp/bundler-sm.jsx << 'JSXEOF'
+          const createElement = (t, p, ...c) => ({ t, p, c });
+          const el = <div id="test">hello</div>;
+          el;
+          JSXEOF
+
+          # --source-map writes .map file alongside .gbc
+          ./build/GocciaBundler /tmp/bundler-sm.jsx --source-map
+          test -f /tmp/bundler-sm.gbc
+          test -f /tmp/bundler-sm.jsx.map
+          check_map_json /tmp/bundler-sm.jsx.map
+          rm /tmp/bundler-sm.gbc /tmp/bundler-sm.jsx.map
+
+          # --source-map=<path> writes to custom path
+          ./build/GocciaBundler /tmp/bundler-sm.jsx --source-map=/tmp/bundler-custom.map
+          test -f /tmp/bundler-sm.gbc
+          test -f /tmp/bundler-custom.map
+          check_map_json /tmp/bundler-custom.map
+          rm /tmp/bundler-sm.gbc /tmp/bundler-custom.map
+
+          # No .map file without --source-map
+          ./build/GocciaBundler /tmp/bundler-sm.jsx
+          test -f /tmp/bundler-sm.gbc
+          test ! -f /tmp/bundler-sm.jsx.map
+          rm /tmp/bundler-sm.gbc
+
+          # --source-map from stdin derives map path from --output
+          cat > /tmp/bundler-stdin-sm.jsx << 'JSXEOF'
+          const createElement = (t, p, ...c) => ({ t, p, c });
+          const el = <div id="test">hello</div>;
+          el;
+          JSXEOF
+          cat /tmp/bundler-stdin-sm.jsx | ./build/GocciaBundler --output=/tmp/sm-stdin.gbc --source-map
+          test -f /tmp/sm-stdin.gbc
+          test -f /tmp/sm-stdin.gbc.map
+          check_map_json /tmp/sm-stdin.gbc.map
+          rm /tmp/sm-stdin.gbc /tmp/sm-stdin.gbc.map /tmp/bundler-stdin-sm.jsx
+
+          rm /tmp/bundler-sm.jsx
 
   artifacts:
     needs: [test, toml-compliance, json5-compliance, benchmark, examples]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -539,6 +539,132 @@ jobs:
 
           rm /tmp/sm-test.jsx
 
+      - name: Check GocciaBundler CLI behaviour
+        run: |
+          # Single file compilation
+          printf 'const x = 2 + 2;\nx;\n' > /tmp/bundler-test.js
+          bundler_output="$(./build/GocciaBundler /tmp/bundler-test.js 2>&1)"
+          test -f /tmp/bundler-test.gbc
+          printf '%s\n' "$bundler_output" | grep -q 'Compiling: /tmp/bundler-test.js'
+          printf '%s\n' "$bundler_output" | grep -q 'Compiled to /tmp/bundler-test.gbc'
+
+          # Roundtrip: GocciaBundler emits, ScriptLoader runs
+          roundtrip_output="$(./build/ScriptLoader /tmp/bundler-test.gbc 2>&1)"
+          printf '%s\n' "$roundtrip_output" | grep -q 'Result: 4'
+          rm /tmp/bundler-test.gbc
+
+          # Custom --output path
+          ./build/GocciaBundler /tmp/bundler-test.js --output=/tmp/custom-output.gbc
+          test -f /tmp/custom-output.gbc
+          rm /tmp/custom-output.gbc
+
+          # Stdin compilation (--output required)
+          printf 'const y = 10;\ny;\n' | ./build/GocciaBundler --output=/tmp/stdin-out.gbc
+          test -f /tmp/stdin-out.gbc
+          stdin_roundtrip="$(./build/ScriptLoader /tmp/stdin-out.gbc 2>&1)"
+          printf '%s\n' "$stdin_roundtrip" | grep -q 'Result: 10'
+          rm /tmp/stdin-out.gbc
+
+          # Stdin without --output should fail
+          set +e
+          printf 'const z = 1;\n' | ./build/GocciaBundler 2>&1
+          stdin_no_output_status=$?
+          set -e
+          test "$stdin_no_output_status" -eq 1
+
+          # Directory compilation
+          mkdir -p /tmp/bundler-dir
+          printf 'const a = 1;\n' > /tmp/bundler-dir/a.js
+          printf 'const b = 2;\n' > /tmp/bundler-dir/b.js
+          ./build/GocciaBundler /tmp/bundler-dir
+          test -f /tmp/bundler-dir/a.gbc
+          test -f /tmp/bundler-dir/b.gbc
+          rm -r /tmp/bundler-dir
+
+          # Directory with --output to output directory
+          mkdir -p /tmp/bundler-src /tmp/bundler-dist
+          printf 'const c = 3;\n' > /tmp/bundler-src/c.js
+          ./build/GocciaBundler /tmp/bundler-src --output=/tmp/bundler-dist
+          test -f /tmp/bundler-dist/c.gbc
+          rm -r /tmp/bundler-src /tmp/bundler-dist
+
+          # Multiple positional files
+          printf 'const p = 1;\n' > /tmp/p.js
+          printf 'const q = 2;\n' > /tmp/q.js
+          ./build/GocciaBundler /tmp/p.js /tmp/q.js
+          test -f /tmp/p.gbc
+          test -f /tmp/q.gbc
+          rm /tmp/p.js /tmp/q.js /tmp/p.gbc /tmp/q.gbc
+
+          # .gbc input should be rejected
+          printf 'const r = 1;\n' > /tmp/reject.js
+          ./build/GocciaBundler /tmp/reject.js
+          set +e
+          ./build/GocciaBundler /tmp/reject.gbc 2>&1
+          gbc_status=$?
+          set -e
+          test "$gbc_status" -eq 1
+          rm /tmp/reject.js /tmp/reject.gbc
+
+          # --help
+          help_output="$(./build/GocciaBundler --help 2>&1)"
+          printf '%s\n' "$help_output" | grep -q '\-\-output'
+          printf '%s\n' "$help_output" | grep -q '\-\-source-map'
+          printf '%s\n' "$help_output" | grep -q '\-\-asi'
+          printf '%s\n' "$help_output" | grep -q '\-\-jobs'
+
+          rm /tmp/bundler-test.js
+
+      - name: Check GocciaBundler source map CLI
+        run: |
+          check_map_json() {
+            python3 - "$1" <<'PY'
+          import json, sys
+          with open(sys.argv[1], 'r', encoding='utf-8') as f:
+              data = json.load(f)
+          assert data.get('version') == 3, f"bad version: {data.get('version')}"
+          assert isinstance(data.get('sources'), list) and len(data['sources']) > 0, "missing sources"
+          assert isinstance(data.get('mappings'), str) and data['mappings'] != '', "missing mappings"
+          PY
+          }
+
+          # Create a JSX test file
+          cat > /tmp/bundler-sm.jsx << 'JSXEOF'
+          const createElement = (t, p, ...c) => ({ t, p, c });
+          const el = <div id="test">hello</div>;
+          el;
+          JSXEOF
+
+          # --source-map writes .map file alongside .gbc
+          ./build/GocciaBundler /tmp/bundler-sm.jsx --source-map
+          test -f /tmp/bundler-sm.gbc
+          test -f /tmp/bundler-sm.jsx.map
+          check_map_json /tmp/bundler-sm.jsx.map
+          rm /tmp/bundler-sm.gbc /tmp/bundler-sm.jsx.map
+
+          # --source-map=<path> writes to custom path
+          ./build/GocciaBundler /tmp/bundler-sm.jsx --source-map=/tmp/bundler-custom.map
+          test -f /tmp/bundler-sm.gbc
+          test -f /tmp/bundler-custom.map
+          check_map_json /tmp/bundler-custom.map
+          rm /tmp/bundler-sm.gbc /tmp/bundler-custom.map
+
+          # No .map file without --source-map
+          ./build/GocciaBundler /tmp/bundler-sm.jsx
+          test -f /tmp/bundler-sm.gbc
+          test ! -f /tmp/bundler-sm.jsx.map
+          rm /tmp/bundler-sm.gbc
+
+          # --source-map without explicit path rejects stdin
+          set +e
+          out="$(printf 'const x = 1;\n' | ./build/GocciaBundler --output=/tmp/sm-stdin.gbc --source-map 2>&1)"
+          st=$?
+          set -e
+          test "$st" -eq 1
+          printf '%s\n' "$out" | grep -q 'required when reading source from stdin'
+
+          rm /tmp/bundler-sm.jsx
+
   benchmark-comment:
     needs: benchmark
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -513,12 +513,6 @@ jobs:
           check_map_json /tmp/custom.map
           rm /tmp/custom.map
 
-          # --source-map with --emit
-          ./build/ScriptLoader /tmp/sm-test.jsx --emit --source-map
-          test -f /tmp/sm-test.jsx.map
-          check_map_json /tmp/sm-test.jsx.map
-          rm /tmp/sm-test.jsx.map /tmp/sm-test.gbc
-
           # --source-map in interpreted mode
           ./build/ScriptLoader /tmp/sm-test.jsx --source-map
           test -f /tmp/sm-test.jsx.map
@@ -655,13 +649,17 @@ jobs:
           test ! -f /tmp/bundler-sm.jsx.map
           rm /tmp/bundler-sm.gbc
 
-          # --source-map without explicit path rejects stdin
-          set +e
-          out="$(printf 'const x = 1;\n' | ./build/GocciaBundler --output=/tmp/sm-stdin.gbc --source-map 2>&1)"
-          st=$?
-          set -e
-          test "$st" -eq 1
-          printf '%s\n' "$out" | grep -q 'required when reading source from stdin'
+          # --source-map from stdin derives map path from --output
+          cat > /tmp/bundler-stdin-sm.jsx << 'JSXEOF'
+          const createElement = (t, p, ...c) => ({ t, p, c });
+          const el = <div id="test">hello</div>;
+          el;
+          JSXEOF
+          cat /tmp/bundler-stdin-sm.jsx | ./build/GocciaBundler --output=/tmp/sm-stdin.gbc --source-map
+          test -f /tmp/sm-stdin.gbc
+          test -f /tmp/sm-stdin.gbc.map
+          check_map_json /tmp/sm-stdin.gbc.map
+          rm /tmp/sm-stdin.gbc /tmp/sm-stdin.gbc.map /tmp/bundler-stdin-sm.jsx
 
           rm /tmp/bundler-sm.jsx
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/REPL
 build/ScriptLoader
 build/TestRunner
 build/BenchmarkRunner
+build/GocciaBundler
 build/*.Test
 build/ppas.sh
 build/ppas.bat

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ Assistants should treat CONTRIBUTING as authoritative for contribution requireme
 ## Quick checks
 
 ```bash
-./build.pas testrunner && ./build/TestRunner tests   # after substantive changes
+./build.pas testrunner && ./build/TestRunner tests       # after substantive changes
+./build.pas bundler && ./build/GocciaBundler example.js  # build and run the bundler
 ./format.pas --check # before push / PR
 ```
 
@@ -37,6 +38,7 @@ Assistants should treat CONTRIBUTING as authoritative for contribution requireme
 ./build.pas loader # Dev build (--dev is the default)
 ./build.pas testrunner # Dev build of TestRunner
 ./build.pas benchmarkrunner # Dev build of BenchmarkRunner
+./build.pas bundler # Dev build of GocciaBundler
 ./build.pas tests # Dev build of Pascal unit tests
 ./build.pas clean # Clean stale artifacts only (no build)
 ./build.pas clean loader # Clean, then dev build of ScriptLoader
@@ -92,6 +94,14 @@ printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./bu
 ./build/BenchmarkRunner benchmarks --no-progress # Suppress progress (CI)
 ./build/BenchmarkRunner benchmarks --mode=bytecode # Benchmarks via the Goccia bytecode VM
 ./build/BenchmarkRunner benchmarks --jobs=4 # Run benchmarks with 4 parallel workers
+./build/GocciaBundler example.js # Compile to .gbc (no execution)
+./build/GocciaBundler example.js --output=out.gbc # Custom output path
+./build/GocciaBundler src/ # Compile all scripts in a directory
+./build/GocciaBundler src/ --output=dist/ # Compile directory to output directory
+./build/GocciaBundler example.js --source-map # Write .map source map alongside .gbc
+printf "const x = 2 + 2; x;" | ./build/GocciaBundler --output=out.gbc # Compile stdin to .gbc
+./build/GocciaBundler src/ --jobs=4 # Compile with 4 parallel workers
+./build/GocciaBundler example.js --asi # Compile with automatic semicolon insertion
 ```
 
 ### Compile and run (common workflows)
@@ -120,6 +130,7 @@ fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- REPL.dpr
 fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- ScriptLoader.dpr
 fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- TestRunner.dpr
 fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- BenchmarkRunner.dpr
+fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- GocciaBundler.dpr
 ```
 
 ## Where to go next

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,6 @@ Assistants should treat CONTRIBUTING as authoritative for contribution requireme
 ./build/ScriptLoader example.js --mode=bytecode # Execute via bytecode VM
 ./build/ScriptLoader example.js --import-map=imports.json # Execute with an explicit import map
 ./build/ScriptLoader example.js --alias @/=./src/ --alias config=./config/default.js # One-off import-map-style aliases
-./build/ScriptLoader example.js --emit # Compile to .gbc (no execution)
-./build/ScriptLoader example.js --emit=bytecode # Compile to .gbc (explicit)
-./build/ScriptLoader example.js --emit --output=out.gbc # Custom output path
 ./build/ScriptLoader out.gbc # Load and execute .gbc bytecode
 printf "const x = 2 + 2; x;" | ./build/ScriptLoader # Execute stdin source
 ./build/ScriptLoader example.js --coverage # Execute with line and branch coverage
@@ -66,7 +63,6 @@ printf "const x = 2 + 2; x;" | ./build/ScriptLoader # Execute stdin source
 ./build/ScriptLoader example.js --profile=all --profile-output=profile.json # Profile with JSON export
 ./build/ScriptLoader example.js --profile=functions --profile-format=flamegraph --profile-output=flamegraph.txt # Flame graph export
 ./build/ScriptLoader example.jsx --source-map --mode=bytecode # Write .map source map alongside execution
-./build/ScriptLoader example.jsx --source-map=out.map --emit # Write source map to specific path with bytecode emit
 ./build/REPL # Start interactive REPL (interpreted)
 ./build/REPL --mode=bytecode # Start the REPL via bytecode VM
 ./build/REPL --mode=bytecode --timing # Bytecode REPL with per-line timing

--- a/GocciaBundler.dpr
+++ b/GocciaBundler.dpr
@@ -158,7 +158,7 @@ end;
 procedure TBundlerApp.WriteSourceMapIfEnabled(
   const ASourceMap: TGocciaSourceMap; const AFileName: string);
 var
-  MapOutputPath: string;
+  MapOutputPath, SourceName: string;
 begin
   if not FSourceMap.Present then
     Exit;
@@ -166,9 +166,17 @@ begin
     Exit;
   MapOutputPath := FSourceMap.ValueOr('');
   if MapOutputPath = '' then
-    MapOutputPath := AFileName + EXT_MAP;
-  ASourceMap.FileName := ExtractFileName(AFileName);
-  ASourceMap.SetSourcePath(0, ExtractFileName(AFileName));
+  begin
+    if AFileName = STDIN_FILE_NAME then
+      MapOutputPath := ResolveOutputPath(AFileName) + EXT_MAP
+    else
+      MapOutputPath := AFileName + EXT_MAP;
+  end;
+  SourceName := AFileName;
+  if (SourceName = STDIN_FILE_NAME) and FOutputPath.Present then
+    SourceName := FOutputPath.Value;
+  ASourceMap.FileName := ExtractFileName(SourceName);
+  ASourceMap.SetSourcePath(0, ExtractFileName(SourceName));
   ASourceMap.SaveToFile(MapOutputPath);
   if not GIsWorkerThread then
     WriteLn(SysUtils.Format('  Source map written to %s', [MapOutputPath]));
@@ -363,12 +371,6 @@ begin
       ((APaths.Count = 1) and DirectoryExists(APaths[0]))) then
     raise TGocciaParseError.Create(
       '--output must be a directory when compiling multiple files.');
-
-  if FSourceMap.Present and (FSourceMap.ValueOr('') = '') and
-     ((APaths.Count = 0) or
-      ((APaths.Count = 1) and IsStdinPath(APaths[0]))) then
-    raise TGocciaParseError.Create(
-      '--source-map=<file> is required when reading source from stdin.');
 
   if (FSourceMap.ValueOr('') <> '') and
      ((APaths.Count > 1) or

--- a/GocciaBundler.dpr
+++ b/GocciaBundler.dpr
@@ -1,0 +1,398 @@
+program GocciaBundler;
+
+{$I Goccia.inc}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  Classes,
+  Generics.Collections,
+  SysUtils,
+
+  TimingUtils,
+
+  Goccia.Application,
+  Goccia.AST.Node,
+  Goccia.Bytecode.Binary,
+  Goccia.Bytecode.Module,
+  Goccia.CLI.Application,
+  Goccia.CLI.Options,
+  Goccia.Compiler,
+  Goccia.Engine,
+  Goccia.FileExtensions,
+  Goccia.JSX.Transformer,
+  Goccia.Lexer,
+  Goccia.Parser,
+  Goccia.ScriptLoader.Input,
+  Goccia.SourceMap,
+  Goccia.TextFiles,
+  Goccia.Threading,
+  Goccia.Threading.Init,
+  Goccia.Token,
+
+  FileUtils in 'units/FileUtils.pas';
+
+type
+  TBundlerApp = class(TGocciaCLIApplication)
+  private
+    FOutputPath: TGocciaStringOption;
+    FSourceMap: TGocciaStringOption;
+    FASI: TGocciaFlagOption;
+
+    function ParseSource(const ASource: TStringList; const AFileName: string;
+      out ALexTimeNanoseconds, AParseTimeNanoseconds: Int64;
+      out ASourceMap: TGocciaSourceMap): TGocciaProgram;
+    function CompileSource(const ASource: TStringList;
+      const AFileName: string): TGocciaBytecodeModule;
+    procedure WriteSourceMapIfEnabled(const ASourceMap: TGocciaSourceMap;
+      const AFileName: string);
+    procedure EmitBytecode(const ASource: TStringList; const AFileName,
+      AOutputPath: string);
+    function ResolveOutputPath(const AInputFile: string): string;
+    procedure EmitFromFile(const AFileName: string);
+    procedure EmitFromStdin;
+    procedure EmitWorkerProc(const AFileName: string; const AIndex: Integer;
+      out AConsoleOutput: string; out AErrorMessage: string; AData: Pointer);
+    procedure EmitParallel(const AFiles: TStringList;
+      const AJobCount: Integer);
+    procedure EmitPath(const APath: string);
+  protected
+    procedure Configure; override;
+    function UsageLine: string; override;
+    procedure Validate; override;
+    procedure ExecuteWithPaths(const APaths: TStringList); override;
+  end;
+
+{ TBundlerApp - Configure }
+
+function TBundlerApp.UsageLine: string;
+begin
+  Result := '[file|directory|-] [options]';
+end;
+
+procedure TBundlerApp.Configure;
+begin
+  FASI := AddFlag('asi', 'Enable automatic semicolon insertion');
+  FOutputPath := AddString('output',
+    'Output path (single file) or output directory (multiple files)');
+  FSourceMap := AddString('source-map',
+    'Write a .map source map file (optional: explicit path)');
+end;
+
+{ TBundlerApp - Validate }
+
+procedure TBundlerApp.Validate;
+begin
+  inherited Validate;
+end;
+
+{ TBundlerApp - Core logic }
+
+function TBundlerApp.ParseSource(const ASource: TStringList;
+  const AFileName: string;
+  out ALexTimeNanoseconds, AParseTimeNanoseconds: Int64;
+  out ASourceMap: TGocciaSourceMap): TGocciaProgram;
+var
+  SourceText: string;
+  JSXResult: TGocciaJSXTransformResult;
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+  Parser: TGocciaParser;
+  Warning: TGocciaParserWarning;
+  StartTime, LexEnd, ParseEnd: Int64;
+  OrigLine, OrigCol, I: Integer;
+begin
+  StartTime := GetNanoseconds;
+  SourceText := StringListToLFText(ASource);
+
+  ASourceMap := nil;
+  if ppJSX in TGocciaEngine.DefaultPreprocessors then
+  begin
+    JSXResult := TGocciaJSXTransformer.Transform(SourceText);
+    SourceText := JSXResult.Source;
+    ASourceMap := JSXResult.SourceMap;
+    if Assigned(ASourceMap) then
+      ASourceMap.SetSourceContent(0, StringListToLFText(ASource));
+  end;
+
+  try
+    Lexer := TGocciaLexer.Create(SourceText, AFileName);
+    try
+      Tokens := Lexer.ScanTokens;
+      LexEnd := GetNanoseconds;
+      ALexTimeNanoseconds := LexEnd - StartTime;
+
+      Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
+      Parser.AutomaticSemicolonInsertion := FASI.Present;
+      try
+        Result := Parser.Parse;
+        ParseEnd := GetNanoseconds;
+        AParseTimeNanoseconds := ParseEnd - LexEnd;
+
+        if not GIsWorkerThread then
+          for I := 0 to Parser.WarningCount - 1 do
+          begin
+            Warning := Parser.GetWarning(I);
+            WriteLn(SysUtils.Format('Warning: %s', [Warning.Message]));
+            if Warning.Suggestion <> '' then
+              WriteLn(SysUtils.Format('  Suggestion: %s', [Warning.Suggestion]));
+            if Assigned(ASourceMap) and
+               ASourceMap.Translate(Warning.Line, Warning.Column, OrigLine, OrigCol) then
+              WriteLn(SysUtils.Format('  --> %s:%d:%d', [AFileName, OrigLine, OrigCol]))
+            else
+              WriteLn(SysUtils.Format('  --> %s:%d:%d',
+                [AFileName, Warning.Line, Warning.Column]));
+          end;
+      finally
+        Parser.Free;
+      end;
+    finally
+      Lexer.Free;
+    end;
+  except
+    ASourceMap.Free;
+    ASourceMap := nil;
+    raise;
+  end;
+end;
+
+procedure TBundlerApp.WriteSourceMapIfEnabled(
+  const ASourceMap: TGocciaSourceMap; const AFileName: string);
+var
+  MapOutputPath: string;
+begin
+  if not FSourceMap.Present then
+    Exit;
+  if not Assigned(ASourceMap) then
+    Exit;
+  MapOutputPath := FSourceMap.ValueOr('');
+  if MapOutputPath = '' then
+    MapOutputPath := AFileName + EXT_MAP;
+  ASourceMap.FileName := ExtractFileName(AFileName);
+  ASourceMap.SetSourcePath(0, ExtractFileName(AFileName));
+  ASourceMap.SaveToFile(MapOutputPath);
+  if not GIsWorkerThread then
+    WriteLn(SysUtils.Format('  Source map written to %s', [MapOutputPath]));
+end;
+
+function TBundlerApp.CompileSource(const ASource: TStringList;
+  const AFileName: string): TGocciaBytecodeModule;
+var
+  ProgramNode: TGocciaProgram;
+  Compiler: TGocciaCompiler;
+  CompiledModule: TGocciaBytecodeModule;
+  LexTimeNanoseconds, ParseTimeNanoseconds: Int64;
+  SourceMap: TGocciaSourceMap;
+begin
+  CompiledModule := nil;
+  ProgramNode := ParseSource(ASource, AFileName,
+    LexTimeNanoseconds, ParseTimeNanoseconds, SourceMap);
+  try
+    Compiler := TGocciaCompiler.Create(AFileName);
+    try
+      CompiledModule := Compiler.Compile(ProgramNode);
+      WriteSourceMapIfEnabled(SourceMap, AFileName);
+      Result := CompiledModule;
+      CompiledModule := nil;
+    finally
+      Compiler.Free;
+    end;
+  finally
+    ProgramNode.Free;
+    SourceMap.Free;
+    CompiledModule.Free;
+  end;
+end;
+
+procedure TBundlerApp.EmitBytecode(const ASource: TStringList;
+  const AFileName, AOutputPath: string);
+var
+  Module: TGocciaBytecodeModule;
+  StartTime, EndTime: Int64;
+begin
+  if not GIsWorkerThread then
+    WriteLn('Compiling: ', AFileName);
+  StartTime := GetNanoseconds;
+
+  Module := CompileSource(ASource, AFileName);
+  try
+    Goccia.Bytecode.Binary.SaveModuleToFile(Module, AOutputPath);
+    EndTime := GetNanoseconds;
+    if not GIsWorkerThread then
+      WriteLn(SysUtils.Format('  Compiled to %s (%s)',
+        [AOutputPath, FormatDuration(EndTime - StartTime)]));
+  finally
+    Module.Free;
+  end;
+end;
+
+function TBundlerApp.ResolveOutputPath(const AInputFile: string): string;
+begin
+  if FOutputPath.Present then
+  begin
+    if DirectoryExists(FOutputPath.Value) then
+      Result := IncludeTrailingPathDelimiter(FOutputPath.Value) +
+        ChangeFileExt(ExtractFileName(AInputFile), EXT_GBC)
+    else
+      Result := FOutputPath.Value;
+  end
+  else
+    Result := ChangeFileExt(AInputFile, EXT_GBC);
+end;
+
+procedure TBundlerApp.EmitFromFile(const AFileName: string);
+var
+  Source: TStringList;
+  OutputPath: string;
+begin
+  if LowerCase(ExtractFileExt(AFileName)) = EXT_GBC then
+    raise Exception.CreateFmt('Cannot compile bytecode file: %s', [AFileName]);
+
+  OutputPath := ResolveOutputPath(AFileName);
+
+  Source := ReadUTF8FileLines(AFileName);
+  try
+    EmitBytecode(Source, AFileName, OutputPath);
+  finally
+    Source.Free;
+  end;
+end;
+
+procedure TBundlerApp.EmitFromStdin;
+var
+  Source: TStringList;
+begin
+  if not FOutputPath.Present then
+    raise TGocciaParseError.Create(
+      '--output=<path> is required when compiling from stdin.');
+
+  Source := ReadSourceFromText(Input);
+  try
+    EmitBytecode(Source, STDIN_FILE_NAME, FOutputPath.Value);
+  finally
+    Source.Free;
+  end;
+end;
+
+procedure TBundlerApp.EmitWorkerProc(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+begin
+  AConsoleOutput := '';
+  AErrorMessage := '';
+  try
+    EmitFromFile(AFileName);
+  except
+    on E: Exception do
+    begin
+      AErrorMessage := E.Message;
+      ExitCode := 1;
+    end;
+  end;
+end;
+
+procedure TBundlerApp.EmitParallel(const AFiles: TStringList;
+  const AJobCount: Integer);
+var
+  Pool: TGocciaThreadPool;
+  I: Integer;
+begin
+  EnsureSharedPrototypesInitialized(GlobalBuiltins);
+
+  Pool := TGocciaThreadPool.Create(AJobCount);
+  try
+    Pool.RunAll(AFiles, EmitWorkerProc);
+
+    for I := 0 to AFiles.Count - 1 do
+      if Pool.Results[I].ErrorMessage <> '' then
+      begin
+        WriteLn('Error in ', AFiles[I], ': ', Pool.Results[I].ErrorMessage);
+        ExitCode := 1;
+      end;
+  finally
+    Pool.Free;
+  end;
+end;
+
+procedure TBundlerApp.EmitPath(const APath: string);
+var
+  Files: TStringList;
+  I: Integer;
+begin
+  if IsStdinPath(APath) then
+  begin
+    EmitFromStdin;
+    Exit;
+  end;
+
+  if DirectoryExists(APath) then
+  begin
+    Files := FindAllFiles(APath, ScriptExtensions);
+    try
+      if GetJobCount(Files.Count) > 1 then
+      begin
+        WriteLn(SysUtils.Format('Compiling %d files with %d workers',
+          [Files.Count, GetJobCount(Files.Count)]));
+        EmitParallel(Files, GetJobCount(Files.Count));
+      end
+      else
+        for I := 0 to Files.Count - 1 do
+        begin
+          if I > 0 then
+            WriteLn;
+          EmitFromFile(Files[I]);
+        end;
+    finally
+      Files.Free;
+    end;
+  end
+  else if FileExists(APath) then
+    EmitFromFile(APath)
+  else
+    raise Exception.Create('Path not found: ' + APath);
+end;
+
+{ TBundlerApp - ExecuteWithPaths }
+
+procedure TBundlerApp.ExecuteWithPaths(const APaths: TStringList);
+var
+  I: Integer;
+begin
+  if FOutputPath.Present and (FOutputPath.Value <> '') and
+     not DirectoryExists(FOutputPath.Value) and
+     ((APaths.Count > 1) or
+      ((APaths.Count = 1) and DirectoryExists(APaths[0]))) then
+    raise TGocciaParseError.Create(
+      '--output must be a directory when compiling multiple files.');
+
+  if FSourceMap.Present and (FSourceMap.ValueOr('') = '') and
+     ((APaths.Count = 0) or
+      ((APaths.Count = 1) and IsStdinPath(APaths[0]))) then
+    raise TGocciaParseError.Create(
+      '--source-map=<file> is required when reading source from stdin.');
+
+  if (FSourceMap.ValueOr('') <> '') and
+     ((APaths.Count > 1) or
+      ((APaths.Count = 1) and DirectoryExists(APaths[0]))) then
+    raise TGocciaParseError.Create(
+      '--source-map=<file> supports a single input file or stdin.');
+
+  if APaths.Count = 0 then
+    EmitFromStdin
+  else
+    for I := 0 to APaths.Count - 1 do
+    begin
+      if I > 0 then
+        WriteLn;
+      EmitPath(APaths[I]);
+    end;
+end;
+
+{ Entry point }
+
+var
+  RunResult: Integer;
+begin
+  RunResult := TGocciaApplication.RunApplication(TBundlerApp, 'GocciaBundler');
+  if RunResult <> 0 then
+    ExitCode := RunResult;
+end.

--- a/GocciaBundler.dpr
+++ b/GocciaBundler.dpr
@@ -314,7 +314,7 @@ begin
     for I := 0 to AFiles.Count - 1 do
       if Pool.Results[I].ErrorMessage <> '' then
       begin
-        WriteLn('Error in ', AFiles[I], ': ', Pool.Results[I].ErrorMessage);
+        WriteLn('Error in ', Pool.Results[I].FileName, ': ', Pool.Results[I].ErrorMessage);
         ExitCode := 1;
       end;
   finally

--- a/GocciaBundler.dpr
+++ b/GocciaBundler.dpr
@@ -273,6 +273,10 @@ begin
     raise TGocciaParseError.Create(
       '--output=<path> is required when compiling from stdin.');
 
+  if DirectoryExists(FOutputPath.Value) then
+    raise TGocciaParseError.Create(
+      '--output must be a file when compiling from stdin.');
+
   Source := ReadSourceFromText(Input);
   try
     EmitBytecode(Source, STDIN_FILE_NAME, FOutputPath.Value);
@@ -291,10 +295,7 @@ begin
     EmitFromFile(AFileName);
   except
     on E: Exception do
-    begin
       AErrorMessage := E.Message;
-      ExitCode := 1;
-    end;
   end;
 end;
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,9 @@ GocciaScript includes a bytecode execution backend. The public bytecode artifact
 ./build/ScriptLoader example.js --mode=bytecode
 printf "const x = 2 + 2; x;" | ./build/ScriptLoader --mode=bytecode
 
-# Compile to .gbc bytecode file (no execution)
-./build/ScriptLoader example.js --emit
-
-# Custom output path
-./build/ScriptLoader example.js --emit --output=out.gbc
-printf "const x = 2 + 2; x;" | ./build/ScriptLoader --emit --output=out.gbc
+# Compile to .gbc bytecode file (no execution) — use GocciaBundler
+./build/GocciaBundler example.js
+./build/GocciaBundler example.js --output=out.gbc
 
 # Load and execute a pre-compiled .gbc file
 ./build/ScriptLoader example.gbc

--- a/ScriptLoader.dpr
+++ b/ScriptLoader.dpr
@@ -17,7 +17,6 @@ uses
   Goccia.Bytecode.Module,
   Goccia.CLI.Application,
   Goccia.CLI.Options,
-  Goccia.Compiler,
   Goccia.Constants.PropertyNames,
   Goccia.Coverage,
   Goccia.Coverage.Report,
@@ -57,7 +56,6 @@ type
 
   TScriptLoaderApp = class(TGocciaCLIApplication)
   private
-    FEmit: TGocciaStringOption;
     FOutputPath: TGocciaStringOption;
     FSilent: TGocciaFlagOption;
     FSourceMap: TGocciaStringOption;
@@ -69,9 +67,6 @@ type
       const APreprocessors: TGocciaPreprocessors; const ASuppressWarnings: Boolean;
       out ALexTimeNanoseconds, AParseTimeNanoseconds: Int64;
       out ASourceMap: TGocciaSourceMap): TGocciaProgram;
-    function CompileSource(const ASource: TStringList; const AFileName: string;
-      const APreprocessors: TGocciaPreprocessors;
-      const ASuppressWarnings: Boolean = False): TGocciaBytecodeModule;
     procedure WriteSourceMapIfEnabled(const ASourceMap: TGocciaSourceMap;
       const AFileName: string);
     procedure ConfigureConsole(const AConsole: TGocciaConsole;
@@ -86,8 +81,6 @@ type
       const AOutputLines: TStrings): TScriptExecutionReport;
     function ExecuteBytecodeFromFile(const AFileName: string;
       const AOutputLines: TStrings): TScriptExecutionReport;
-    procedure EmitBytecode(const ASource: TStringList; const AFileName,
-      AOutputPath: string);
     procedure PrintHumanReadableResult(const AFileName: string;
       const AReport: TScriptExecutionReport; const AExtension: string);
     procedure RunSource(const ASource: TStringList; const AFileName: string);
@@ -120,10 +113,8 @@ begin
   AddCoverageOptions;
   AddProfilerOptions;
 
-  FEmit := AddString('emit',
-    'Compile to .gbc file (no execution); optional value: bytecode');
   FOutputPath := AddString('output',
-    'Output path (used with --emit) or "json" for structured JSON output');
+    '"json" for structured JSON output');
   FSilent := AddFlag('silent', 'Suppress console output from the script');
   FSourceMap := AddString('source-map',
     'Write a .map source map file (optional: explicit path)');
@@ -138,16 +129,6 @@ end;
 procedure TScriptLoaderApp.Validate;
 begin
   inherited Validate;
-
-  if FEmit.Present then
-  begin
-    if (FEmit.Value <> '') and (FEmit.Value <> 'bytecode') then
-      raise TGocciaParseError.CreateFmt(
-        'Unknown emit format "%s". Use "bytecode".', [FEmit.Value]);
-  end;
-
-  if (FOutputPath.Present and (FOutputPath.Value = 'json')) and FEmit.Present then
-    raise TGocciaParseError.Create('--output=json cannot be used with --emit.');
 
   if EngineOptions.Timeout.Present and (EngineOptions.Timeout.Value < 0) then
     raise TGocciaParseError.Create('--timeout must be 0 or greater.');
@@ -257,36 +238,6 @@ begin
   ASourceMap.SaveToFile(MapOutputPath);
   if not (FOutputPath.Present and (FOutputPath.Value = 'json')) then
     WriteLn(SysUtils.Format('  Source map written to %s', [MapOutputPath]));
-end;
-
-function TScriptLoaderApp.CompileSource(const ASource: TStringList;
-  const AFileName: string; const APreprocessors: TGocciaPreprocessors;
-  const ASuppressWarnings: Boolean): TGocciaBytecodeModule;
-var
-  ProgramNode: TGocciaProgram;
-  Compiler: TGocciaCompiler;
-  CompiledModule: TGocciaBytecodeModule;
-  LexTimeNanoseconds, ParseTimeNanoseconds: Int64;
-  SourceMap: TGocciaSourceMap;
-begin
-  CompiledModule := nil;
-  ProgramNode := ParseSource(ASource, AFileName, APreprocessors, ASuppressWarnings,
-    LexTimeNanoseconds, ParseTimeNanoseconds, SourceMap);
-  try
-    Compiler := TGocciaCompiler.Create(AFileName);
-    try
-      CompiledModule := Compiler.Compile(ProgramNode);
-      WriteSourceMapIfEnabled(SourceMap, AFileName);
-      Result := CompiledModule;
-      CompiledModule := nil;
-    finally
-      Compiler.Free;
-    end;
-  finally
-    ProgramNode.Free;
-    SourceMap.Free;
-    CompiledModule.Free;
-  end;
 end;
 
 procedure TScriptLoaderApp.ConfigureConsole(const AConsole: TGocciaConsole;
@@ -529,27 +480,6 @@ begin
   end;
 end;
 
-procedure TScriptLoaderApp.EmitBytecode(const ASource: TStringList;
-  const AFileName, AOutputPath: string);
-var
-  Module: TGocciaBytecodeModule;
-  StartTime, EndTime: Int64;
-begin
-  WriteLn('Compiling: ', AFileName);
-  StartTime := GetNanoseconds;
-
-  Module := CompileSource(ASource, AFileName, TGocciaEngine.DefaultPreprocessors,
-    (FOutputPath.Present and (FOutputPath.Value = 'json')));
-  try
-    Goccia.Bytecode.Binary.SaveModuleToFile(Module, AOutputPath);
-    EndTime := GetNanoseconds;
-    WriteLn(SysUtils.Format('  Compiled to %s (%s)',
-      [AOutputPath, FormatDuration(EndTime - StartTime)]));
-  finally
-    Module.Free;
-  end;
-end;
-
 procedure TScriptLoaderApp.PrintHumanReadableResult(const AFileName: string;
   const AReport: TScriptExecutionReport; const AExtension: string);
 var
@@ -593,7 +523,7 @@ end;
 procedure TScriptLoaderApp.RunSource(const ASource: TStringList;
   const AFileName: string);
 var
-  Extension, EmitOutputPath: string;
+  Extension: string;
   Report: TScriptExecutionReport;
   OutputLines: TStringList;
   StartTime: Int64;
@@ -611,17 +541,6 @@ begin
 
       if Extension = EXT_GBC then
         Report := ExecuteBytecodeFromFile(AFileName, OutputLines)
-      else if FEmit.Present then
-      begin
-        if FOutputPath.Present and (FOutputPath.Value <> 'json') then
-          EmitOutputPath := FOutputPath.Value
-        else if AFileName = STDIN_FILE_NAME then
-          raise Exception.Create('--output=<path> is required when emitting bytecode from stdin.')
-        else
-          EmitOutputPath := ChangeFileExt(AFileName, EXT_GBC);
-        EmitBytecode(ASource, AFileName, EmitOutputPath);
-        Exit;
-      end
       else
         case EngineOptions.Mode.ValueOr(emInterpreted) of
           emInterpreted: Report := ExecuteInterpreted(ASource, AFileName, OutputLines);

--- a/build.pas
+++ b/build.pas
@@ -360,6 +360,21 @@ begin
   WriteLn('BenchmarkRunner built successfully');
 end;
 
+procedure BuildGocciaBundler;
+var
+  Output: string;
+begin
+  WriteLn('Building GocciaBundler...');
+  if not RunCommand('fpc', FPCArgs('GocciaBundler.dpr'), Output) then
+  begin
+    WriteLn(Output);
+    WriteLn('GocciaBundler build failed');
+    Halt(1);
+  end;
+  WriteLn(Output);
+  WriteLn('GocciaBundler built successfully');
+end;
+
 procedure Clean;
 var
   Files: TStringList;
@@ -400,7 +415,9 @@ begin
   else if ATrigger = 'testrunner' then
     BuildTestRunner
   else if ATrigger = 'benchmarkrunner' then
-    BuildBenchmarkRunner;
+    BuildBenchmarkRunner
+  else if ATrigger = 'bundler' then
+    BuildGocciaBundler;
 end;
 
 begin
@@ -438,6 +455,7 @@ begin
     BuildTriggers.Add('loader');
     BuildTriggers.Add('testrunner');
     BuildTriggers.Add('benchmarkrunner');
+    BuildTriggers.Add('bundler');
     BuildTriggers.Add('repl');
   end;
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -91,11 +91,6 @@ All execution tools support `--mode=bytecode` to compile and run via the Goccia 
 ./build/ScriptLoader example.js --mode=bytecode
 printf "const x = 2 + 2; x;" | ./build/ScriptLoader --mode=bytecode
 
-# Emit bytecode to .gbc file (no execution)
-./build/ScriptLoader example.js --emit
-./build/ScriptLoader example.js --output=output.gbc
-printf "const x = 2 + 2; x;" | ./build/ScriptLoader --emit --output=output.gbc
-
 # Load and execute a pre-compiled .gbc file
 ./build/ScriptLoader output.gbc
 
@@ -130,9 +125,6 @@ printf "const f = () => f(); f();" | ./build/ScriptLoader --timeout=100
 
 # Write .map source map alongside execution
 ./build/ScriptLoader example.jsx --source-map --mode=bytecode
-
-# Write source map to specific path with bytecode emit
-./build/ScriptLoader example.jsx --source-map=out.map --emit
 
 # Run tests via bytecode VM
 ./build/TestRunner tests --mode=bytecode

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -38,7 +38,7 @@ The build script supports two modes via `--dev` (default) and `--prod` flags:
 ./build.pas --prod    # Production build of all components
 ```
 
-Runs a clean (removes stale `.ppu`, `.o`, `.res` from `build/`), then builds all components in order: tests, loader, testrunner, benchmarkrunner, repl.
+Runs a clean (removes stale `.ppu`, `.o`, `.res` from `build/`), then builds all components in order: tests, loader, testrunner, benchmarkrunner, bundler, repl.
 
 ### Build Specific Components
 
@@ -47,6 +47,7 @@ Runs a clean (removes stale `.ppu`, `.o`, `.res` from `build/`), then builds all
 ./build.pas loader           # Script file executor
 ./build.pas testrunner       # JavaScript test runner
 ./build.pas benchmarkrunner  # Performance benchmark runner
+./build.pas bundler          # Bytecode bundler (compile to .gbc)
 ./build.pas tests            # Pascal unit tests
 ```
 
@@ -146,6 +147,42 @@ printf "const f = () => f(); f();" | ./build/ScriptLoader --timeout=100
 printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/BenchmarkRunner - --mode=bytecode
 ```
 
+### GocciaBundler (Standalone Bytecode Compiler)
+
+GocciaBundler is a dedicated tool for compiling source files to `.gbc` bytecode without executing them. It accepts the same input modes as ScriptLoader (file, multiple files, directory, stdin):
+
+```bash
+# Compile a single file (output: example.gbc alongside the source)
+./build/GocciaBundler example.js
+
+# Custom output path
+./build/GocciaBundler example.js --output=dist/example.gbc
+
+# Compile all scripts in a directory (1:1 .gbc output alongside each source)
+./build/GocciaBundler src/
+
+# Compile a directory to a specific output directory
+./build/GocciaBundler src/ --output=dist/
+
+# Compile from stdin (--output required)
+printf "const x = 2 + 2; x;" | ./build/GocciaBundler --output=out.gbc
+
+# Multiple positional files
+./build/GocciaBundler a.js b.js c.js
+
+# Write source map alongside .gbc
+./build/GocciaBundler example.jsx --source-map
+
+# Explicit source map path (single file only)
+./build/GocciaBundler example.jsx --source-map=out.map
+
+# Enable automatic semicolon insertion during parsing
+./build/GocciaBundler example.js --asi
+
+# Parallel compilation (default: CPU count)
+./build/GocciaBundler src/ --jobs=4
+```
+
 See [bytecode-vm.md](bytecode-vm.md) for the bytecode VM architecture and binary format.
 
 ## Build Output
@@ -158,6 +195,7 @@ All compiled binaries go to the `build/` directory:
 | `build/ScriptLoader` | `ScriptLoader.dpr` | Execute `.js` files or stdin input, with optional JSON output |
 | `build/TestRunner` | `TestRunner.dpr` | JavaScript test runner |
 | `build/BenchmarkRunner` | `BenchmarkRunner.dpr` | Performance benchmark runner for files or stdin input |
+| `build/GocciaBundler` | `GocciaBundler.dpr` | Standalone bytecode compiler (source to `.gbc`) |
 | `build/Goccia.Values.Primitives.Test` | `*.Test.pas` | Pascal unit test binaries |
 
 Intermediate files (`.o`, `.ppu`) also go to `build/` to keep the source tree clean.
@@ -244,6 +282,7 @@ GocciaScript/
 ├── ScriptLoader.dpr      # Script loader program source
 ├── TestRunner.dpr        # Test runner program source
 ├── BenchmarkRunner.dpr   # Benchmark runner program source
+├── GocciaBundler.dpr     # Standalone bytecode compiler
 ├── units/
 │   ├── Goccia.inc     # Shared compiler directives
 │   ├── TimingUtils.pas # Cross-platform microsecond timing and duration formatting
@@ -404,6 +443,7 @@ fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- REPL.dpr
 fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- ScriptLoader.dpr
 fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- TestRunner.dpr
 fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- BenchmarkRunner.dpr
+fpc @config.cfg -vw-n-h-i-l-d-u-t-p-c-x- GocciaBundler.dpr
 ```
 
 The `-v` flags suppress verbose output to keep the build clean. Use `fpc @config.cfg REPL.dpr` for full verbose output during debugging.


### PR DESCRIPTION
## Summary
- Added `GocciaBundler` as a standalone Pascal entrypoint for compiling JavaScript/JSX sources to `.gbc` bytecode without execution.
- Wired `build.pas` to build the new bundler target and added `bundler` to the default build flow.
- Documented the new build target and CLI usage in `docs/build-system.md` and updated repo agent guidance.
- Added CI coverage for bundler compilation, stdin handling, output paths, directory mode, multi-file mode, source maps, and error cases.

## Testing
- Added GitHub Actions checks for single-file, stdin, directory, and multi-file compilation flows.
- Added checks that `./build/GocciaBundler` emits `.gbc` files and that `ScriptLoader` can execute the result.
- Added checks for `--output`, `--source-map`, `--asi`, and `--help` behavior.
- Not run locally in this environment.