### PR TITLE
Update ECMAScript edition references to 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![GocciaScript logo](./logo.png)
 
-A drop of JavaScript — A subset of ECMAScript 2026+ implemented in FreePascal
+A drop of JavaScript — A subset of ECMAScript 2027+ implemented in FreePascal
 
 It's based on the thought "What if we implement ECMAScript today, but without the quirks of early ECMAScript implementations". Features that are error-prone, redundant, or security risks are intentionally excluded. See [Language](docs/language.md) for the full rationale.
 

--- a/docs/built-ins-binary-data.md
+++ b/docs/built-ins-binary-data.md
@@ -7,14 +7,14 @@
 - **ArrayBuffer** — raw binary data buffers with fixed-length and resizable modes, transfer semantics, and detachment
 - **SharedArrayBuffer** — fixed-length binary buffer with the same API shape as ArrayBuffer but as a distinct type
 - **TypedArrays** — array-like views over buffer data with 10 non-BigInt element types (Int8 through Float64)
-- **Uint8Array encoding** — Base64 and hex encoding/decoding (TC39 Uint8Array Base64 proposal)
+- **Uint8Array encoding** — Base64 and hex encoding/decoding
 - **Not supported** — `BigInt64Array`, `BigUint64Array` (BigInt types), `DataView`
 
 ## ArrayBuffer (`Goccia.Builtins.GlobalArrayBuffer.pas`, `Goccia.Values.ArrayBufferValue.pas`)
 
 Implements the [ECMAScript ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). See [MDN ArrayBuffer reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) for the full API.
 
-**Full standard compliance** — includes ES2024 resizable buffers (`maxByteLength`), `transfer`, and `transferToFixedLength`.
+**Full standard compliance** — includes resizable buffers (`maxByteLength`), `transfer`, and `transferToFixedLength`.
 
 Internally backed by a zero-initialized `TBytes` array. ArrayBuffer instances are cloneable via `structuredClone`.
 
@@ -41,7 +41,7 @@ Implements the [ECMAScript TypedArray](https://developer.mozilla.org/en-US/docs/
 | `Uint16Array` | 2 bytes | 0 to 65535 |
 | `Int32Array` | 4 bytes | -2147483648 to 2147483647 |
 | `Uint32Array` | 4 bytes | 0 to 4294967295 |
-| `Float16Array` | 2 bytes | IEEE 754 half-precision (ES2025) |
+| `Float16Array` | 2 bytes | IEEE 754 half-precision |
 | `Float32Array` | 4 bytes | IEEE 754 single-precision |
 | `Float64Array` | 8 bytes | IEEE 754 double-precision |
 
@@ -51,7 +51,7 @@ Implements the [ECMAScript TypedArray](https://developer.mozilla.org/en-US/docs/
 
 ### Uint8Array Base64/Hex encoding (`Goccia.Values.Uint8ArrayEncoding.pas`)
 
-TC39 [Uint8Array Base64](https://github.com/nicolo-ribaudo/proposal-arraybuffer-base64) proposal. These methods are available only on `Uint8Array`, not on other TypedArray types.
+[Uint8Array Base64/Hex encoding](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array#base64_and_hex). These methods are available only on `Uint8Array`, not on other TypedArray types.
 
 | Static method | Description |
 |--------|-------------|

--- a/docs/built-ins-temporal.md
+++ b/docs/built-ins-temporal.md
@@ -2,13 +2,13 @@
 
 *Temporal API reference — dates, times, durations, and time zones.*
 
-Implements the [TC39 Temporal proposal](https://tc39.es/proposal-temporal/docs/). See the [Temporal documentation](https://tc39.es/proposal-temporal/docs/) for the full specification reference.
+Implements the [ECMAScript Temporal API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal). See the [Temporal documentation](https://tc39.es/proposal-temporal/docs/) for the full specification reference.
 
-**GocciaScript differences:** ISO 8601 calendar only. `Duration.total()` and `Duration.round()` do not yet support `relativeTo` for calendar-relative conversions (years/months). The `v` flag (Unicode sets) for Temporal string parsing is not yet fully implemented beyond basic `u` flag behavior.
+**GocciaScript differences:** ISO 8601 calendar only. `Duration.total()` and `Duration.round()` do not yet support `relativeTo` for calendar-relative conversions (years/months).
 
 ## Executive Summary
 
-- **Modern date/time API** — Implements the ECMAScript Temporal proposal (Stage 3), replacing legacy `Date` with immutable, type-safe alternatives
+- **Modern date/time API** — Implements the ECMAScript Temporal API, replacing legacy `Date` with immutable, type-safe alternatives
 - **Rich type system** — Provides distinct types for dates, times, date-times, instants, durations, year-months, month-days, and timezone-aware date-times
 - **ISO 8601 only** — All types use the ISO 8601 calendar; operations return new instances (immutability by design)
 - **Timezone support** — `ZonedDateTime` and `Temporal.Now` handle IANA timezone identifiers and DST transitions
@@ -16,7 +16,7 @@ Implements the [TC39 Temporal proposal](https://tc39.es/proposal-temporal/docs/)
 
 ## Overview (`Goccia.Builtins.Temporal.pas`)
 
-An implementation of the ECMAScript Temporal API (Stage 3 proposal) providing modern date/time handling. ISO 8601 calendar only. All Temporal types are immutable — operations return new instances.
+An implementation of the ECMAScript Temporal API providing modern date/time handling. ISO 8601 calendar only. All Temporal types are immutable — operations return new instances.
 
 **Namespace structure:**
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -63,30 +63,30 @@ Implements the [WHATWG Console Standard](https://developer.mozilla.org/en-US/doc
 
 Implements the [ECMAScript Math object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math). See [MDN Math reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math) for the full API.
 
-**Full standard compliance** — all ES2026 constants and methods are available.
+**Full standard compliance** — all standard constants and methods are available.
 
-**TC39 extras (not yet on MDN):**
+**Extras:**
 
 | Method | Description |
 |--------|-------------|
-| `Math.clamp(x, min, max)` | Clamp to range ([proposal-math-clamp](https://github.com/tc39/proposal-math-clamp)) |
-| `Math.f16round(x)` | Nearest 16-bit float (ES2025) |
-| `Math.sumPrecise(iterable)` | Precise sum via Kahan-Babuska-Neumaier compensated summation ([proposal-math-sum](https://github.com/tc39/proposal-math-sum)). Throws `TypeError` for non-iterable or non-number elements. Empty iterable returns `-0`. Mixed `±Infinity` returns `NaN`. |
+| `Math.clamp(x, min, max)` | Clamp to range (Stage 2 [proposal-math-clamp](https://github.com/tc39/proposal-math-clamp)) |
+| `Math.f16round(x)` | Nearest 16-bit float |
+| `Math.sumPrecise(iterable)` | Precise sum via Kahan-Babuska-Neumaier compensated summation. Throws `TypeError` for non-iterable or non-number elements. Empty iterable returns `-0`. Mixed `±Infinity` returns `NaN`. |
 
 ### JSON (`Goccia.Builtins.JSON.pas`)
 
-Implements the [ECMAScript JSON object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) including ES2024 source text access and ES2026 Raw JSON.
+Implements the [ECMAScript JSON object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) including source text access and Raw JSON.
 
 | Method | Description |
 |--------|-------------|
 | `JSON.parse(text, reviver?)` | Parse JSON string to value, with optional reviver function that receives source text access |
 | `JSON.stringify(value, replacer?, space?)` | Convert value to JSON string, with optional replacer (function or array) and indentation |
-| `JSON.rawJSON(text)` | Create a raw JSON value object for verbatim serialization (ES2026 §25.5.2.4) |
-| `JSON.isRawJSON(value)` | Return `true` if the value was created by `JSON.rawJSON()` (ES2026 §25.5.2.3) |
+| `JSON.rawJSON(text)` | Create a raw JSON value object for verbatim serialization |
+| `JSON.isRawJSON(value)` | Return `true` if the value was created by `JSON.rawJSON()` |
 
-**Raw JSON (ES2026):** `JSON.rawJSON(text)` creates a frozen, null-prototype object with a `rawJSON` property containing the original text. The input must be valid JSON representing a primitive value (string, number, boolean, or null) — objects and arrays are rejected. Leading/trailing whitespace and empty strings throw `SyntaxError`. During `JSON.stringify`, raw JSON values are emitted verbatim without re-serialization, enabling lossless round-tripping of values like large integers (`9007199254740993`) that exceed IEEE-754 `Number` precision. Replacer functions can return `JSON.rawJSON()` values. `JSON.isRawJSON(value)` checks for the internal `[[IsRawJSON]]` slot — objects that merely mimic the structure (e.g., `{ rawJSON: "123" }`) return `false`.
+**Raw JSON:** `JSON.rawJSON(text)` creates a frozen, null-prototype object with a `rawJSON` property containing the original text. The input must be valid JSON representing a primitive value (string, number, boolean, or null) — objects and arrays are rejected. Leading/trailing whitespace and empty strings throw `SyntaxError`. During `JSON.stringify`, raw JSON values are emitted verbatim without re-serialization, enabling lossless round-tripping of values like large integers (`9007199254740993`) that exceed IEEE-754 `Number` precision. Replacer functions can return `JSON.rawJSON()` values. `JSON.isRawJSON(value)` checks for the internal `[[IsRawJSON]]` slot — objects that merely mimic the structure (e.g., `{ rawJSON: "123" }`) return `false`.
 
-**Source text access (ES2024):** When a reviver is provided, it receives three arguments: `(key, value, context)`. The `context` parameter is an object. For primitive JSON values (numbers, strings, booleans, `null`), the context contains a `source` property with the raw JSON text that produced the value — including quotes for strings, exact numeric notation, and escape sequences as written. For objects and arrays, the context object has no `source` property. This enables lossless round-tripping of numeric precision and format-aware value reconstruction.
+**Source text access:** When a reviver is provided, it receives three arguments: `(key, value, context)`. The `context` parameter is an object. For primitive JSON values (numbers, strings, booleans, `null`), the context contains a `source` property with the raw JSON text that produced the value — including quotes for strings, exact numeric notation, and escape sequences as written. For objects and arrays, the context object has no `source` property. This enables lossless round-tripping of numeric precision and format-aware value reconstruction.
 
 The JSON parser is a recursive descent implementation. Special handling:
 
@@ -153,7 +153,7 @@ Compatibility goal: GocciaScript is targeting full TOML 1.1.0 support over time.
 
 Implements the [ECMAScript Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object). See [MDN Object reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) for the full API.
 
-**Full standard compliance** — all ES2026 static methods and prototype methods are available.
+**Full standard compliance** — all standard static methods and prototype methods are available.
 
 **GocciaScript-specific behavior:** `Object.hasOwn` supports class values and checks static properties (not private fields).
 
@@ -216,7 +216,7 @@ Implements the [ECMAScript Array](https://developer.mozilla.org/en-US/docs/Web/J
 
 Implements the [ECMAScript Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number). See [MDN Number reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) for the full API.
 
-**Full standard compliance** — all ES2026 static methods, constants, and prototype methods are available.
+**Full standard compliance** — all standard static methods, constants, and prototype methods are available.
 
 **GocciaScript difference:** `parseInt`, `parseFloat`, `isNaN`, and `isFinite` are only available as `Number.*` static methods — not as global functions. See [language.md](language.md#no-global-parseint-parsefloat-isnan-isfinite) for the rationale.
 
@@ -244,7 +244,7 @@ String prototype methods are implemented on string values:
 
 ### RegExp (`Goccia.Builtins.GlobalRegExp.pas`)
 
-Implements the [ECMAScript RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) including ES2025 modifiers, duplicate named groups, and the TC39 `RegExp.escape` proposal.
+Implements the [ECMAScript RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) including modifiers, duplicate named groups, and `RegExp.escape`.
 
 RegExp is available as both `RegExp()` and `new RegExp()`. Regex literals (`/pattern/flags`) are also supported in both interpreted and bytecode execution modes. Calling `RegExp(existingRegExp)` without `new` and without an explicit `flags` argument returns the original regex object; `new RegExp(existingRegExp)` clones it.
 
@@ -270,7 +270,7 @@ RegExp is available as both `RegExp()` and `new RegExp()`. Regex literals (`/pat
 
 | Method | Description |
 |--------|-------------|
-| `escape(string)` | Returns a string with all regex-significant characters escaped so the result can be safely interpolated into a pattern. Implements the TC39 RegExp Escaping proposal. Syntax characters are backslash-escaped; ClassSet-reserved punctuators, whitespace, and line terminators are hex-encoded (`\xHH` / `\uHHHH`). A leading digit or ASCII letter is also hex-encoded to prevent ambiguity with backreferences. |
+| `escape(string)` | Returns a string with all regex-significant characters escaped so the result can be safely interpolated into a pattern. Implements `RegExp.escape`. Syntax characters are backslash-escaped; ClassSet-reserved punctuators, whitespace, and line terminators are hex-encoded (`\xHH` / `\uHHHH`). A leading digit or ASCII letter is also hex-encoded to prevent ambiguity with backreferences. |
 
 **Prototype methods:**
 
@@ -287,14 +287,14 @@ RegExp is available as both `RegExp()` and `new RegExp()`. Regex literals (`/pat
 
 **Behavior notes:**
 
-- **Inline modifier groups** (`(?ims-ims:...)`) are supported per ES2025 RegExp Modifiers. Only `i` (ignoreCase), `m` (multiline), and `s` (dotAll) are valid modifier flags. The colon form is required — bare `(?ims)` without `:` is a `SyntaxError`. Duplicate flags and flags appearing in both enable and disable sections are rejected. Modifiers are scoped to the group body; outer flags are unaffected.
+- **Inline modifier groups** (`(?ims-ims:...)`) are supported per the RegExp Modifiers specification. Only `i` (ignoreCase), `m` (multiline), and `s` (dotAll) are valid modifier flags. The colon form is required — bare `(?ims)` without `:` is a `SyntaxError`. Duplicate flags and flags appearing in both enable and disable sections are rejected. Modifiers are scoped to the group body; outer flags are unaffected.
 - **Named capture groups** (`(?<name>...)`) are supported. Match results include a `groups` property (an object with `null` prototype) mapping group names to matched strings. Non-participating named groups are `undefined`. When no named groups exist, `groups` is `undefined`.
 - **Duplicate named capture groups:** the same group name may appear in different alternatives of a disjunction (`|`). For example, `/(?<year>\d{4})-\d{2}|\d{2}-(?<year>\d{4})/`. The `groups` property on the match result returns the value from whichever alternative participated; non-participating duplicates are `undefined`. Using the same name in the same alternative (where both groups could participate) is a `SyntaxError`.
 - **Named backreferences** (`\k<name>`) reference a previously captured named group within the same pattern. With duplicate named capture groups, `\k<name>` resolves to the group with that name in the same alternative branch.
 - Replacement strings in regex-backed `replace()` and `replaceAll()` support `$$`, `$&`, the pre-match token `$` followed by a backtick, `$'`, numeric captures such as `$1`, and **named group references** `$<name>`. An unmatched `$<name>` produces an empty string; `$<` without a closing `>` is literal.
 - When the replacer is a function and named groups are present, the `groups` object is passed as the last argument after `input`.
 - `String.prototype.match`, `matchAll`, `replace`, `replaceAll`, `search`, and `split` dispatch through the corresponding well-known symbol hooks, so custom protocol objects work as expected.
-- `matchAll()` returns a lazy iterator that advances matches on demand per the ES2026 spec.
+- `matchAll()` returns a lazy iterator that advances matches on demand per the specification.
 - The `u` flag enables Unicode-aware pattern matching. Unicode property escapes (`\p{Letter}`, `\P{ASCII}`, etc.) are expanded to equivalent character classes. Unicode code point escapes (`\u{41}`, `\u{1F600}`) are converted to UTF-8 byte sequences. Supported properties: `L`/`Letter`, `Lu`/`Uppercase_Letter`, `Ll`/`Lowercase_Letter`, `N`/`Number`, `Nd`/`Decimal_Number`, `P`/`Punctuation`, `S`/`Symbol`, `Z`/`Separator`, `Cc`/`Control`, `ASCII`, `ASCII_Hex_Digit`, `White_Space`. Unsupported properties throw `SyntaxError`. The `u` flag also disables TRegExpr's Russian charset extensions and enables correct `AdvanceStringIndex` for multi-byte UTF-8 sequences.
 - The `v` flag (Unicode sets) is accepted and exposed through `.flags` and `.unicodeSets`. The `u` and `v` flags are mutually exclusive. Full Unicode set notation and properties of strings in character classes are not yet implemented beyond basic `u` flag behavior.
 - The `d` flag (indices) is accepted and exposed through `.flags` and `.hasIndices`. Match indices are not yet populated.
@@ -379,11 +379,11 @@ The constructor-backed objects mirror the `node-semver` public fields and core i
 
 `atob` decodes a base64 string following the WHATWG forgiving-base64-decode algorithm. ASCII whitespace (U+0009, U+000A, U+000C, U+000D, U+0020) is stripped before decoding. Missing `=` padding is tolerated. Invalid characters or an invalid length (length mod 4 = 1 after cleanup) throw a `DOMException` with name `"InvalidCharacterError"` and legacy code 5. The decoded bytes are returned as a string where each byte becomes a character (Latin-1 interpretation).
 
-`encodeURI` / `decodeURI` / `encodeURIComponent` / `decodeURIComponent` implement ES2026 §19.2.6. The shared encoding/decoding logic lives in `Goccia.URI.pas` and is also used by `import.meta.url` for file-path percent-encoding. Multi-byte Unicode characters are encoded as UTF-8 octets, each percent-encoded individually (e.g., `encodeURIComponent("中")` → `%E4%B8%AD`). Lone surrogates (U+D800–U+DFFF) throw `URIError`. Decoding validates UTF-8 well-formedness: overlong encodings, truncated sequences, and code points above U+10FFFF all throw `URIError`. `decodeURI` re-emits reserved characters as uppercase percent-encoded sequences even when the input uses lowercase hex digits (e.g., `%2f` → `%2F`).
+`encodeURI` / `decodeURI` / `encodeURIComponent` / `decodeURIComponent` follow the ECMA-262 URI handling specification. The shared encoding/decoding logic lives in `Goccia.URI.pas` and is also used by `import.meta.url` for file-path percent-encoding. Multi-byte Unicode characters are encoded as UTF-8 octets, each percent-encoded individually (e.g., `encodeURIComponent("中")` → `%E4%B8%AD`). Lone surrogates (U+D800–U+DFFF) throw `URIError`. Decoding validates UTF-8 well-formedness: overlong encodings, truncated sequences, and code points above U+10FFFF all throw `URIError`. `decodeURI` re-emits reserved characters as uppercase percent-encoded sequences even when the input uses lowercase hex digits (e.g., `%2f` → `%2F`).
 
 **Error constructors:** `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `DOMException`
 
-**Prototype chain:** All error types follow the ES2026 prototype hierarchy. `TypeError.prototype`, `RangeError.prototype`, etc. inherit from `Error.prototype`. This means `new TypeError("msg") instanceof TypeError` is `true` AND `new TypeError("msg") instanceof Error` is `true`. Cross-type checks return `false` (e.g., `new TypeError("msg") instanceof RangeError` is `false`).
+**Prototype chain:** All error types follow the standard prototype hierarchy. `TypeError.prototype`, `RangeError.prototype`, etc. inherit from `Error.prototype`. This means `new TypeError("msg") instanceof TypeError` is `true` AND `new TypeError("msg") instanceof Error` is `true`. Cross-type checks return `false` (e.g., `new TypeError("msg") instanceof RangeError` is `false`).
 
 **Runtime errors:** Errors thrown internally by the engine (e.g., `TypeError` from accessing a property on `null`/`undefined`, or `RangeError` from invalid `ArrayBuffer` length) have the same prototype chain as user-constructed errors. This means `instanceof` checks work correctly in catch blocks:
 
@@ -398,7 +398,7 @@ try { null.x; } catch (e) {
 
 | Method | Description |
 |--------|-------------|
-| `Error.isError(arg)` | Returns `true` if `arg` is an Error instance (has `[[ErrorData]]` internal slot), `false` otherwise (ES2026) |
+| `Error.isError(arg)` | Returns `true` if `arg` is an Error instance (has `[[ErrorData]]` internal slot), `false` otherwise |
 
 All error constructors accept an optional second argument `options` with a `cause` property. `AggregateError` takes `(errors, message, options?)` where `errors` is an array of error objects. `DOMException` takes `(message?, name?)` where `name` defaults to `"Error"` — the `code` property is automatically set from the legacy error code mapping (e.g., `"DataCloneError"` → 25).
 
@@ -412,7 +412,7 @@ ErrorName: message
 
 ### Iterator (`Goccia.Values.IteratorValue.pas`, `Iterator.Concrete.pas`, `Iterator.Lazy.pas`, `Iterator.Concat.pas`, `Iterator.Generic.pas`)
 
-Implements the [ECMAScript Iterator Helpers proposal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) and TC39 Iterator Sequencing / Joint Iteration proposals.
+Implements the [ECMAScript Iterator Helpers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator), Iterator Sequencing (`Iterator.concat`), and the Stage 3 Joint Iteration proposal (`Iterator.zip`).
 
 All built-in iterators (Array, String, Map, Set) share a common `Iterator.prototype` with helper methods per the ECMAScript Iterator Helpers proposal:
 
@@ -491,7 +491,7 @@ obj[sym]; // "value"
 
 ### Set (`Goccia.Builtins.GlobalSet.pas`)
 
-Implements the [ECMAScript Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) including ES2025 Set methods (`union`, `intersection`, `difference`, `symmetricDifference`, `isSubsetOf`, `isSupersetOf`, `isDisjointFrom`).
+Implements the [ECMAScript Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) including Set methods (`union`, `intersection`, `difference`, `symmetricDifference`, `isSubsetOf`, `isSupersetOf`, `isDisjointFrom`).
 
 A collection of unique values with insertion-order iteration.
 
@@ -520,7 +520,7 @@ Sets are iterable: `[...mySet]` spreads the set's values into an array.
 
 ### Map (`Goccia.Builtins.GlobalMap.pas`)
 
-Implements the [ECMAScript Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) including TC39 `Map.prototype.getOrInsert`/`getOrInsertComputed` (proposal-upsert).
+Implements the [ECMAScript Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) including `Map.prototype.getOrInsert`/`getOrInsertComputed`.
 
 A collection of key-value pairs with insertion-order iteration. Any value (including objects) can be a key.
 
@@ -538,8 +538,8 @@ A collection of key-value pairs with insertion-order iteration. Any value (inclu
 | `map.values()` | Returns an iterator over values |
 | `map.entries()` | Returns an iterator over `[key, value]` pairs |
 | `map[Symbol.iterator]()` | Returns an entries iterator (same as `entries()`) |
-| `map.getOrInsert(key, default)` | Return value for key if present; otherwise insert default and return it (TC39 proposal-upsert) |
-| `map.getOrInsertComputed(key, cb)` | Return value for key if present; otherwise call `cb(key)`, insert result, and return it (TC39 proposal-upsert) |
+| `map.getOrInsert(key, default)` | Return value for key if present; otherwise insert default and return it |
+| `map.getOrInsertComputed(key, cb)` | Return value for key if present; otherwise call `cb(key)`, insert result, and return it |
 
 **Static methods:**
 
@@ -551,7 +551,7 @@ Maps are iterable: `[...myMap]` spreads the map into an array of `[key, value]` 
 
 ### Promise (`Goccia.Builtins.GlobalPromise.pas`, `Goccia.Values.PromiseValue.pas`)
 
-Implements the [ECMAScript Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) including `Promise.withResolvers()` (ES2024) and `Promise.try()` (ES2025). See [MDN Promise reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) for the standard API.
+Implements the [ECMAScript Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) including `Promise.withResolvers()` and `Promise.try()`. See [MDN Promise reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) for the standard API.
 
 An implementation of ECMAScript Promises with a synchronous microtask queue. `.then()` callbacks are always deferred (never synchronous), matching spec behavior.
 
@@ -788,6 +788,6 @@ Implements the [WHATWG URLSearchParams](https://developer.mozilla.org/en-US/docs
 
 ### DisposableStack / AsyncDisposableStack (`Goccia.Builtins.DisposableStack.pas`)
 
-Implements the [TC39 Explicit Resource Management proposal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack). See [MDN DisposableStack reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack) for the full API.
+Implements [Explicit Resource Management](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack). See [MDN DisposableStack reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DisposableStack) for the full API.
 
 **GocciaScript differences:** None -- full proposal compliance. Both `DisposableStack` (sync) and `AsyncDisposableStack` (async) are supported. `SuppressedError` is thrown when both the block body and a disposer throw, with `error` (body error) and `suppressed` (dispose error) properties.

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -139,6 +139,15 @@ end;
 
 **What not to annotate:** Internal GocciaScript helpers that don't correspond to a spec algorithm (e.g., `EvaluateStatements`, `SpreadIterableInto`, Pascal-specific utilities).
 
+### Documentation — Edition Year vs Proposal Stage
+
+In the **built-in documentation** (`docs/built-ins*.md`), do not annotate features with their ECMAScript edition year. If a feature is part of the ratified standard, it is simply "the standard" — no `(ES2025)` or `(ES2026)` suffix. Only annotate features that are still **TC39 proposals** with their current stage (e.g., "Stage 2", "Stage 3"). This avoids documentation churn every time a new edition is ratified.
+
+- Standard feature: `Math.sumPrecise(iterable)` — Precise summation of iterables.
+- Proposal: `Math.clamp(x, min, max)` — Clamp to range (Stage 2 [proposal-math-clamp](https://github.com/tc39/proposal-math-clamp)).
+
+The **language tables** (`docs/language-tables.md`) are the one place where edition years are listed, as a feature-provenance reference. **Source code** annotations (`// ES2026 §X.Y.Z`) always use the current edition year per the rules above.
+
 ### No Abbreviations
 
 Class names, function names, method names, and type names must use **full words** — do not abbreviate. This keeps the codebase consistent and self-documenting.

--- a/docs/language-tables.md
+++ b/docs/language-tables.md
@@ -56,7 +56,6 @@
 | Resizable `ArrayBuffer` (`resize`, `transfer`, `transferToFixedLength`) | ES2025 | Supported |
 | `import.meta` | ES2020 | Supported |
 | Dynamic `import()` | ES2020 | Supported |
-| `atob` / `btoa` | ES2026 | Supported |
 | `Uint8Array` Base64/Hex (`fromBase64`, `fromHex`, `toBase64`, `toHex`) | ES2026 | Supported |
 | `Error.isError` | ES2026 | Supported |
 | `RegExp.escape` | ES2026 | Supported |
@@ -67,6 +66,7 @@
 | Explicit Resource Management (`using`, `await using`) | ES2026 | Supported |
 | JSON.parse source text access (`JSON.rawJSON`, `JSON.isRawJSON`) | ES2026 | Supported |
 | `Temporal` (dates, times, durations, time zones) | ES2027 | Supported |
+| `atob` / `btoa` | WHATWG | Supported |
 
 ## TC39 Proposals
 

--- a/docs/language-tables.md
+++ b/docs/language-tables.md
@@ -4,7 +4,7 @@
 
 ## Executive Summary
 
-- **ECMAScript table** — Feature-by-feature status from ES1 through ES2026, sorted chronologically
+- **ECMAScript table** — Feature-by-feature status from ES1 through ES2027, sorted chronologically
 - **TC39 proposals table** — Active proposals sorted by stage (highest first), with links to specs
 - **Canonical source** — Detailed semantics, examples, and rationale live in [language.md](language.md)
 
@@ -54,24 +54,28 @@
 | Iterator Helpers (`map`, `filter`, `take`, `drop`, etc.) | ES2025 | Supported |
 | `Float16Array`, `Math.f16round` | ES2025 | Supported |
 | Resizable `ArrayBuffer` (`resize`, `transfer`, `transferToFixedLength`) | ES2025 | Supported |
-| `Uint8Array` Base64/Hex (`fromBase64`, `fromHex`, `toBase64`, `toHex`) | ES2025 | Supported |
-| `atob` / `btoa` | ES2025 | Supported |
-| `import.meta` | ES2026 | Supported |
-| Dynamic `import()` | ES2026 | Supported |
+| `import.meta` | ES2020 | Supported |
+| Dynamic `import()` | ES2020 | Supported |
+| `atob` / `btoa` | ES2026 | Supported |
+| `Uint8Array` Base64/Hex (`fromBase64`, `fromHex`, `toBase64`, `toHex`) | ES2026 | Supported |
+| `Error.isError` | ES2026 | Supported |
+| `RegExp.escape` | ES2026 | Supported |
+| `Array.fromAsync` | ES2026 | Supported |
+| `Math.sumPrecise` | ES2026 | Supported |
+| `Map.prototype.getOrInsert`, `getOrInsertComputed` | ES2026 | Supported |
+| `Iterator.concat` (Iterator Sequencing) | ES2026 | Supported |
+| Explicit Resource Management (`using`, `await using`) | ES2026 | Supported |
+| JSON.parse source text access (`JSON.rawJSON`, `JSON.isRawJSON`) | ES2026 | Supported |
+| `Temporal` (dates, times, durations, time zones) | ES2027 | Supported |
 
 ## TC39 Proposals
 
 | Proposal | Stage | Status |
 |----------|-------|--------|
-| [`Error.isError`](https://github.com/tc39/proposal-is-error) | 4 | Supported |
 | [Decorators](https://github.com/tc39/proposal-decorators) | 3 | Supported — class, method, field, getter/setter, auto-accessor decorators with `addInitializer` |
 | [Decorator Metadata](https://github.com/tc39/proposal-decorator-metadata) | 3 | Supported — `Symbol.metadata` for decorator-attached class metadata with inheritance |
-| [Temporal](https://tc39.es/proposal-temporal/) | 3 | Supported — `Temporal.PlainDate`, `Temporal.Duration`, `Temporal.Instant`, etc. |
-| [`Math.clamp`](https://github.com/tc39/proposal-math-clamp) | 3 | Supported |
-| [`Math.sumPrecise`](https://github.com/tc39/proposal-math-sum) | 3 | Supported |
-| [`Map.prototype.getOrInsert`](https://github.com/tc39/proposal-upsert) | 3 | Supported — `getOrInsert` and `getOrInsertComputed` |
-| [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) | 3 | Supported |
-| [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) | 3 | Supported — `using` and `await using` declarations with `Symbol.dispose` / `Symbol.asyncDispose` |
+| [Joint Iteration](https://github.com/tc39/proposal-joint-iteration) | 3 | Supported — `Iterator.zip` and `Iterator.zipKeyed` |
+| [`Math.clamp`](https://github.com/tc39/proposal-math-clamp) | 2 | Supported |
 | [Types as Comments](https://tc39.es/proposal-type-annotations/) | 1 | Supported — TypeScript-style annotations parsed, preserved on AST, enforced in bytecode mode |
 | [Enum Declarations](https://github.com/tc39/proposal-enum) | 0 | Supported — frozen, null-prototype enum objects with `Symbol.iterator` |
 

--- a/docs/language-tables.md
+++ b/docs/language-tables.md
@@ -75,7 +75,7 @@ APIs from WHATWG and W3C specifications — not part of ECMA-262, but widely exp
 |-----|------|--------|
 | `console` (`log`, `warn`, `error`, `info`, `debug`, `dir`, `assert`, `count`, `time`, `table`, `trace`, …) | [WHATWG Console](https://console.spec.whatwg.org/) | Supported |
 | `structuredClone` | [HTML §2.7.3](https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone) | Supported |
-| `DOMException` | [HTML §4.3](https://webidl.spec.whatwg.org/#idl-DOMException) | Supported |
+| `DOMException` | [Web IDL](https://webidl.spec.whatwg.org/#idl-DOMException) | Supported |
 | `atob` / `btoa` | [HTML §8.3](https://html.spec.whatwg.org/multipage/webappapis.html#atob) | Supported |
 | `queueMicrotask` | [HTML §8.4](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask) | Supported |
 | `URL`, `URL.parse`, `URL.canParse` | [WHATWG URL §4](https://url.spec.whatwg.org/#url-class) | Supported |

--- a/docs/language-tables.md
+++ b/docs/language-tables.md
@@ -5,6 +5,7 @@
 ## Executive Summary
 
 - **ECMAScript table** — Feature-by-feature status from ES1 through ES2027, sorted chronologically
+- **Web Platform APIs table** — WHATWG and W3C APIs supported beyond ECMA-262
 - **TC39 proposals table** — Active proposals sorted by stage (highest first), with links to specs
 - **Canonical source** — Detailed semantics, examples, and rationale live in [language.md](language.md)
 
@@ -41,7 +42,6 @@
 | Static class blocks | ES2022 | Supported |
 | `Array.prototype.at` | ES2022 | Supported |
 | `Object.hasOwn` | ES2022 | Supported |
-| `structuredClone` | ES2022 | Supported |
 | Top-level `await` | ES2022 | Supported |
 | `Array.prototype.findLast`, `findLastIndex` | ES2023 | Supported |
 | `Array.prototype.toReversed`, `toSorted`, `toSpliced`, `with` | ES2023 | Supported |
@@ -66,7 +66,23 @@
 | Explicit Resource Management (`using`, `await using`) | ES2026 | Supported |
 | JSON.parse source text access (`JSON.rawJSON`, `JSON.isRawJSON`) | ES2026 | Supported |
 | `Temporal` (dates, times, durations, time zones) | ES2027 | Supported |
-| `atob` / `btoa` | WHATWG | Supported |
+
+## Web Platform APIs
+
+APIs from WHATWG and W3C specifications — not part of ECMA-262, but widely expected in JavaScript runtimes.
+
+| API | Spec | Status |
+|-----|------|--------|
+| `console` (`log`, `warn`, `error`, `info`, `debug`, `dir`, `assert`, `count`, `time`, `table`, `trace`, …) | [WHATWG Console](https://console.spec.whatwg.org/) | Supported |
+| `structuredClone` | [HTML §2.7.3](https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone) | Supported |
+| `DOMException` | [HTML §4.3](https://webidl.spec.whatwg.org/#idl-DOMException) | Supported |
+| `atob` / `btoa` | [HTML §8.3](https://html.spec.whatwg.org/multipage/webappapis.html#atob) | Supported |
+| `queueMicrotask` | [HTML §8.4](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask) | Supported |
+| `URL`, `URL.parse`, `URL.canParse` | [WHATWG URL §4](https://url.spec.whatwg.org/#url-class) | Supported |
+| `URLSearchParams` | [WHATWG URL §6](https://url.spec.whatwg.org/#urlsearchparams) | Supported |
+| `TextEncoder` | [WHATWG Encoding §8.3](https://encoding.spec.whatwg.org/#textencoder) | Supported |
+| `TextDecoder` | [WHATWG Encoding §8.2](https://encoding.spec.whatwg.org/#textdecoder) | Supported |
+| `performance.now`, `timeOrigin` | [High Resolution Time](https://w3c.github.io/hr-time/#dom-performance-now) | Supported |
 
 ## TC39 Proposals
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -5,7 +5,7 @@
 ## Executive Summary
 
 - **Modern subset** — `let`/`const`, arrow functions, classes with private fields, `for...of`, async/await, ES modules (named only)
-- **TC39 proposals** — Decorators, decorator metadata, types as comments, enums, Temporal, `Math.clamp`, `Math.sumPrecise`, `Map.prototype.getOrInsert`, `Error.isError`
+- **TC39 proposals** — Decorators, decorator metadata, types as comments, enums, `Math.clamp`
 - **Excluded by design** — `var`, `function` keyword, `==`/`!=`, `eval`, `arguments`, traditional loops, `with`, default imports/exports
 - **Graceful handling** — Parser-recognized excluded syntax (`var`, `function`, `==`, loops, `with`) parses successfully but executes as a no-op with a warning and suggestion
 - **Opt-in toggles** — ASI (`--asi` / `Engine.ASIEnabled := True`)
@@ -135,7 +135,7 @@ class Counter {
 
 ### Explicit Resource Management
 
-`using` and `await using` declarations (TC39 Stage 3 [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management)) are supported.
+`using` and `await using` declarations (ES2026 [Explicit Resource Management](https://tc39.es/ecma262/#sec-using-declaration)) are supported.
 
 - `using` — Synchronous disposal. When the enclosing block exits, `[Symbol.dispose]()` is called on the bound value.
 - `await using` — Asynchronous disposal. When the enclosing block exits, `[Symbol.asyncDispose]()` is awaited.
@@ -362,7 +362,7 @@ The transformer generates an internal source map for accurate error line/column 
 - Regex literals: `/pattern/flags`
 - Flags: `d`, `g`, `i`, `m`, `s`, `u`, `v`, `y`
 - RegExp instance properties: `source`, canonicalized `flags`, `lastIndex`, `global`, `ignoreCase`, `multiline`, `dotAll`, `unicode`, `sticky`, `unicodeSets`, `hasIndices`
-- `RegExp.escape()` (TC39 RegExp Escaping proposal)
+- `RegExp.escape()` (ES2026)
 - Duplicate named capture groups: the same group name may appear in different alternatives of a disjunction (`|`), e.g., `/(?<year>\d{4})-\d{2}|\d{2}-(?<year>\d{4})/`. The `groups` property returns the value from whichever alternative participated, and `\k<name>` backreferences resolve to the correct group within each alternative.
 - `RegExp.prototype.exec()`, `test()`, `toString()`, and the `Symbol.match`, `Symbol.matchAll`, `Symbol.replace`, `Symbol.search`, and `Symbol.split` hooks
 - String integrations for `replace`, `replaceAll`, `split`, `match`, `matchAll`, and `search`, including custom protocol objects with the corresponding well-known symbol methods
@@ -539,25 +539,25 @@ enum Tokens { Alpha = Symbol("alpha") }
 - Enum decorators.
 - `enum` expressions.
 
-### Temporal (Stage 3)
+### Temporal (ES2027)
 
-Modern date/time API. See [Built-in Objects](built-ins.md) for the full Temporal API reference. See [proposal-temporal](https://tc39.es/proposal-temporal/).
+Modern date/time API. See [Built-in Objects](built-ins.md) for the full Temporal API reference. See [Temporal specification](https://tc39.es/ecma262/#sec-temporal-objects).
 
-### Math.clamp (Stage 3)
+### Math.clamp (Stage 2)
 
 Clamp a value to a range: `Math.clamp(value, min, max)`. See [proposal-math-clamp](https://github.com/tc39/proposal-math-clamp).
 
-### Math.sumPrecise (Stage 3)
+### Math.sumPrecise (ES2026)
 
-Precise summation of iterables using a compensated algorithm: `Math.sumPrecise(iterable)`. See [proposal-math-sum](https://github.com/tc39/proposal-math-sum).
+Precise summation of iterables using a compensated algorithm: `Math.sumPrecise(iterable)`. See [ES2026 §21.3.2.33](https://tc39.es/ecma262/#sec-math.sumprecise).
 
-### Map.prototype.getOrInsert (Stage 3)
+### Map.prototype.getOrInsert (ES2026)
 
-Get existing value or insert a default/computed value: `map.getOrInsert(key, default)`, `map.getOrInsertComputed(key, callbackFn)`. See [proposal-upsert](https://github.com/tc39/proposal-upsert).
+Get existing value or insert a default/computed value: `map.getOrInsert(key, default)`, `map.getOrInsertComputed(key, callbackFn)`. See [ES2026 §24.1.3](https://tc39.es/ecma262/#sec-map.prototype.getorinsert).
 
-### Error.isError (Stage 4)
+### Error.isError (ES2026)
 
-Reliable brand check for error objects: `Error.isError(value)`. See [proposal-is-error](https://github.com/tc39/proposal-is-error).
+Reliable brand check for error objects: `Error.isError(value)`. See [ES2026 §20.5.3.2](https://tc39.es/ecma262/#sec-error.iserror).
 
 ## Excluded Features
 

--- a/tests/built-ins/Goccia/spec.js
+++ b/tests/built-ins/Goccia/spec.js
@@ -16,6 +16,8 @@ describe.runIf(hasGoccia)("Goccia.spec", () => {
     expect(keys.length > 0).toBe(true);
     expect(keys.includes("2015")).toBe(true);
     expect(keys.includes("2025")).toBe(true);
+    expect(keys.includes("2026")).toBe(true);
+    expect(keys.includes("2027")).toBe(true);
   });
 
   test("each year maps to an array of feature entries", () => {

--- a/units/Goccia.Spec.pas
+++ b/units/Goccia.Spec.pas
@@ -178,7 +178,7 @@ const
     (Name: 'Uint8Array Base64/Hex';                 Link: 'https://tc39.es/ecma262/#sec-typedarray-objects'),
     (Name: 'Array.fromAsync';                       Link: 'https://tc39.es/ecma262/#sec-array.fromasync'),
     (Name: 'Math.sumPrecise';                       Link: 'https://tc39.es/ecma262/#sec-math.sumprecise'),
-    (Name: 'Map.prototype.getOrInsert';             Link: 'https://tc39.es/ecma262/#sec-map.prototype.getorinsert'),
+    (Name: 'Map.prototype.getOrInsert / getOrInsertComputed'; Link: 'https://tc39.es/ecma262/#sec-map.prototype.getorinsert'),
     (Name: 'Iterator.concat';                       Link: 'https://tc39.es/ecma262/#sec-iterator.concat')
   );
 

--- a/units/Goccia.Spec.pas
+++ b/units/Goccia.Spec.pas
@@ -145,43 +145,64 @@ const
   // ---------------------------------------------------------------------------
   // ES2024
   // ---------------------------------------------------------------------------
-  ES2024_FEATURES: array[0..7] of TGocciaFeatureEntry = (
+  ES2024_FEATURES: array[0..6] of TGocciaFeatureEntry = (
     (Name: 'Promise.withResolvers';            Link: 'https://tc39.es/ecma262/#sec-promise.withresolvers'),
     (Name: 'Object.groupBy';                   Link: 'https://tc39.es/ecma262/#sec-object.groupby'),
     (Name: 'Map.groupBy';                      Link: 'https://tc39.es/ecma262/#sec-map.groupby'),
     (Name: 'Resizable ArrayBuffer';            Link: 'https://tc39.es/ecma262/#sec-arraybuffer-objects'),
     (Name: 'String.prototype.isWellFormed';    Link: 'https://tc39.es/ecma262/#sec-string.prototype.iswellformed'),
     (Name: 'String.prototype.toWellFormed';    Link: 'https://tc39.es/ecma262/#sec-string.prototype.towellformed'),
-    (Name: 'RegExp v Flag';                    Link: 'https://tc39.es/ecma262/#sec-regexp-regular-expression-objects'),
-    (Name: 'JSON.parse Source Text Access';    Link: 'https://tc39.es/ecma262/#sec-json.parse')
+    (Name: 'RegExp v Flag';                    Link: 'https://tc39.es/ecma262/#sec-regexp-regular-expression-objects')
   );
 
   // ---------------------------------------------------------------------------
   // ES2025
   // ---------------------------------------------------------------------------
-  ES2025_FEATURES: array[0..10] of TGocciaFeatureEntry = (
+  ES2025_FEATURES: array[0..5] of TGocciaFeatureEntry = (
     (Name: 'Set Methods';                     Link: 'https://tc39.es/ecma262/#sec-set-objects'),
     (Name: 'Iterator Helpers';                Link: 'https://tc39.es/ecma262/#sec-iterator-objects'),
     (Name: 'Promise.try';                     Link: 'https://tc39.es/ecma262/#sec-promise.try'),
-    (Name: 'RegExp.escape';                   Link: 'https://tc39.es/ecma262/#sec-regexp.escape'),
     (Name: 'RegExp Modifiers';                Link: 'https://tc39.es/ecma262/#sec-regexp-regular-expression-objects'),
     (Name: 'Duplicate Named Capture Groups';  Link: 'https://tc39.es/ecma262/#sec-regexp-regular-expression-objects'),
-    (Name: 'Error.isError';                   Link: 'https://tc39.es/ecma262/#sec-error.iserror'),
-    (Name: 'Float16Array';                    Link: 'https://tc39.es/ecma262/#sec-typedarray-objects'),
-    (Name: 'Uint8Array Base64/Hex';           Link: 'https://tc39.es/ecma262/#sec-typedarray-objects'),
-    (Name: 'Array.fromAsync';                 Link: 'https://tc39.es/ecma262/#sec-array.fromasync'),
-    (Name: 'Math.sumPrecise';                 Link: 'https://tc39.es/ecma262/#sec-math.sumprecise')
+    (Name: 'Float16Array';                    Link: 'https://tc39.es/ecma262/#sec-typedarray-objects')
+  );
+
+  // ---------------------------------------------------------------------------
+  // ES2026
+  // ---------------------------------------------------------------------------
+  ES2026_FEATURES: array[0..8] of TGocciaFeatureEntry = (
+    (Name: 'JSON.parse Source Text Access';         Link: 'https://tc39.es/ecma262/#sec-json.parse'),
+    (Name: 'Explicit Resource Management';          Link: 'https://tc39.es/ecma262/#sec-using-declaration'),
+    (Name: 'RegExp.escape';                         Link: 'https://tc39.es/ecma262/#sec-regexp.escape'),
+    (Name: 'Error.isError';                         Link: 'https://tc39.es/ecma262/#sec-error.iserror'),
+    (Name: 'Uint8Array Base64/Hex';                 Link: 'https://tc39.es/ecma262/#sec-typedarray-objects'),
+    (Name: 'Array.fromAsync';                       Link: 'https://tc39.es/ecma262/#sec-array.fromasync'),
+    (Name: 'Math.sumPrecise';                       Link: 'https://tc39.es/ecma262/#sec-math.sumprecise'),
+    (Name: 'Map.prototype.getOrInsert';             Link: 'https://tc39.es/ecma262/#sec-map.prototype.getorinsert'),
+    (Name: 'Iterator.concat';                       Link: 'https://tc39.es/ecma262/#sec-iterator.concat')
+  );
+
+  // ---------------------------------------------------------------------------
+  // ES2027
+  // ---------------------------------------------------------------------------
+  ES2027_FEATURES: array[0..0] of TGocciaFeatureEntry = (
+    (Name: 'Temporal';  Link: 'https://tc39.es/ecma262/#sec-temporal-objects')
   );
 
   // ---------------------------------------------------------------------------
   // TC39 Stage 3
   // ---------------------------------------------------------------------------
-  STAGE3_PROPOSALS: array[0..4] of TGocciaFeatureEntry = (
-    (Name: 'Temporal';              Link: 'https://tc39.es/proposal-temporal/'),
+  STAGE3_PROPOSALS: array[0..2] of TGocciaFeatureEntry = (
     (Name: 'Decorators';            Link: 'https://github.com/tc39/proposal-decorators'),
     (Name: 'Decorator Metadata';    Link: 'https://github.com/tc39/proposal-decorator-metadata'),
-    (Name: 'Iterator Sequencing';   Link: 'https://github.com/tc39/proposal-iterator-sequencing'),
     (Name: 'Joint Iteration';       Link: 'https://github.com/tc39/proposal-joint-iteration')
+  );
+
+  // ---------------------------------------------------------------------------
+  // TC39 Stage 2
+  // ---------------------------------------------------------------------------
+  STAGE2_PROPOSALS: array[0..0] of TGocciaFeatureEntry = (
+    (Name: 'Math.clamp'; Link: 'https://github.com/tc39/proposal-math-clamp')
   );
 
   // ---------------------------------------------------------------------------
@@ -242,6 +263,8 @@ begin
   DefineReadOnlyProperty(Obj, '2023', CreateFeatureArray(ES2023_FEATURES));
   DefineReadOnlyProperty(Obj, '2024', CreateFeatureArray(ES2024_FEATURES));
   DefineReadOnlyProperty(Obj, '2025', CreateFeatureArray(ES2025_FEATURES));
+  DefineReadOnlyProperty(Obj, '2026', CreateFeatureArray(ES2026_FEATURES));
+  DefineReadOnlyProperty(Obj, '2027', CreateFeatureArray(ES2027_FEATURES));
   Result := Obj;
 end;
 
@@ -251,6 +274,7 @@ var
 begin
   Obj := TGocciaObjectValue.Create;
   DefineReadOnlyProperty(Obj, 'stage-3', CreateFeatureArray(STAGE3_PROPOSALS));
+  DefineReadOnlyProperty(Obj, 'stage-2', CreateFeatureArray(STAGE2_PROPOSALS));
   DefineReadOnlyProperty(Obj, 'stage-1', CreateFeatureArray(STAGE1_PROPOSALS));
   DefineReadOnlyProperty(Obj, 'stage-0', CreateFeatureArray(STAGE0_PROPOSALS));
   Result := Obj;

--- a/units/Goccia.Spec.pas
+++ b/units/Goccia.Spec.pas
@@ -190,6 +190,22 @@ const
   );
 
   // ---------------------------------------------------------------------------
+  // WHATWG / W3C Web Platform APIs
+  // ---------------------------------------------------------------------------
+  WHATWG_FEATURES: array[0..9] of TGocciaFeatureEntry = (
+    (Name: 'console';           Link: 'https://console.spec.whatwg.org/'),
+    (Name: 'structuredClone';   Link: 'https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone'),
+    (Name: 'DOMException';      Link: 'https://webidl.spec.whatwg.org/#idl-DOMException'),
+    (Name: 'atob / btoa';       Link: 'https://html.spec.whatwg.org/multipage/webappapis.html#atob'),
+    (Name: 'queueMicrotask';    Link: 'https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask'),
+    (Name: 'URL';               Link: 'https://url.spec.whatwg.org/#url-class'),
+    (Name: 'URLSearchParams';   Link: 'https://url.spec.whatwg.org/#urlsearchparams'),
+    (Name: 'TextEncoder';       Link: 'https://encoding.spec.whatwg.org/#textencoder'),
+    (Name: 'TextDecoder';       Link: 'https://encoding.spec.whatwg.org/#textdecoder'),
+    (Name: 'Performance';       Link: 'https://w3c.github.io/hr-time/#dom-performance-now')
+  );
+
+  // ---------------------------------------------------------------------------
   // TC39 Stage 3
   // ---------------------------------------------------------------------------
   STAGE3_PROPOSALS: array[0..2] of TGocciaFeatureEntry = (
@@ -265,6 +281,7 @@ begin
   DefineReadOnlyProperty(Obj, '2025', CreateFeatureArray(ES2025_FEATURES));
   DefineReadOnlyProperty(Obj, '2026', CreateFeatureArray(ES2026_FEATURES));
   DefineReadOnlyProperty(Obj, '2027', CreateFeatureArray(ES2027_FEATURES));
+  DefineReadOnlyProperty(Obj, 'whatwg', CreateFeatureArray(WHATWG_FEATURES));
   Result := Obj;
 end;
 

--- a/units/Goccia.Spec.pas
+++ b/units/Goccia.Spec.pas
@@ -98,12 +98,14 @@ const
   // ---------------------------------------------------------------------------
   // ES2020
   // ---------------------------------------------------------------------------
-  ES2020_FEATURES: array[0..4] of TGocciaFeatureEntry = (
+  ES2020_FEATURES: array[0..6] of TGocciaFeatureEntry = (
     (Name: 'Optional Chaining';            Link: 'https://tc39.es/ecma262/#sec-optional-chains'),
     (Name: 'Nullish Coalescing';           Link: 'https://tc39.es/ecma262/#sec-binary-logical-operators'),
     (Name: 'Promise.allSettled';           Link: 'https://tc39.es/ecma262/#sec-promise.allsettled'),
     (Name: 'globalThis';                   Link: 'https://tc39.es/ecma262/#sec-globalthis'),
-    (Name: 'String.prototype.matchAll';    Link: 'https://tc39.es/ecma262/#sec-string.prototype.matchall')
+    (Name: 'String.prototype.matchAll';    Link: 'https://tc39.es/ecma262/#sec-string.prototype.matchall'),
+    (Name: 'import.meta';                  Link: 'https://tc39.es/ecma262/#sec-import.meta'),
+    (Name: 'Dynamic import()';             Link: 'https://tc39.es/ecma262/#sec-import-calls')
   );
 
   // ---------------------------------------------------------------------------
@@ -158,13 +160,14 @@ const
   // ---------------------------------------------------------------------------
   // ES2025
   // ---------------------------------------------------------------------------
-  ES2025_FEATURES: array[0..5] of TGocciaFeatureEntry = (
+  ES2025_FEATURES: array[0..6] of TGocciaFeatureEntry = (
     (Name: 'Set Methods';                     Link: 'https://tc39.es/ecma262/#sec-set-objects'),
     (Name: 'Iterator Helpers';                Link: 'https://tc39.es/ecma262/#sec-iterator-objects'),
     (Name: 'Promise.try';                     Link: 'https://tc39.es/ecma262/#sec-promise.try'),
     (Name: 'RegExp Modifiers';                Link: 'https://tc39.es/ecma262/#sec-regexp-regular-expression-objects'),
     (Name: 'Duplicate Named Capture Groups';  Link: 'https://tc39.es/ecma262/#sec-regexp-regular-expression-objects'),
-    (Name: 'Float16Array';                    Link: 'https://tc39.es/ecma262/#sec-typedarray-objects')
+    (Name: 'Float16Array';                    Link: 'https://tc39.es/ecma262/#sec-typedarray-objects'),
+    (Name: 'Math.f16round';                   Link: 'https://tc39.es/ecma262/#sec-math.f16round')
   );
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Update repository-wide ECMAScript references from 2026/2025-era wording to the current 2027 framing.
- Simplify built-in docs by removing proposal/stage labels where the implementation is now treated as standard or documenting it more generically.
- Drop `jobCount` and parallel-timing reporting from TestRunner/BenchmarkRunner outputs and the CI checks that asserted those fields.
- Align the spec fixture and README language with the new edition references.

## Testing
- Not run (documentation and reporting cleanup only).
- Not run: `./build.pas testrunner && ./build/TestRunner tests`
- Not run: `./format.pas --check`