### PR TITLE
Add Temporal.Duration.prototype.total relativeTo support

### DIFF
--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -99,6 +99,18 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     expect(() => d.total("years")).toThrow(RangeError);
   });
 
+  test("total() months with time-only overflow into days", () => {
+    // PT8760H = 365 days worth of hours; from 2023-01-01 that lands on 2024-01-01 = 12 months
+    const d = new Temporal.Duration(0, 0, 0, 0, 8760);
+    expect(d.total({ unit: "months", relativeTo: "2023-01-01" })).toBe(12);
+  });
+
+  test("total() years with time-only overflow into days", () => {
+    // PT8760H = 365 days; from 2023-01-01 that is exactly 1 year
+    const d = new Temporal.Duration(0, 0, 0, 0, 8760);
+    expect(d.total({ unit: "years", relativeTo: "2023-01-01" })).toBe(1);
+  });
+
   test("total() with day-clamping edge case", () => {
     // Adding 1 month from Jan 31 → Feb 29 (2024 leap year, clamped)
     const d = Temporal.Duration.from({ months: 1 });

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -111,6 +111,16 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     expect(d.total({ unit: "years", relativeTo: "2023-01-01" })).toBe(1);
   });
 
+  test("total() accepts singular unit names", () => {
+    const d = new Temporal.Duration(0, 0, 0, 0, 1, 30);
+    expect(d.total("minute")).toBe(90);
+    expect(d.total("hour")).toBe(1.5);
+    expect(d.total("second")).toBe(5400);
+    expect(d.total("nanosecond")).toBe(5400000000000);
+    expect(d.total("microsecond")).toBe(5400000000);
+    expect(d.total("millisecond")).toBe(5400000);
+  });
+
   test("total() with day-clamping edge case", () => {
     // Adding 1 month from Jan 31 → Feb 29 (2024 leap year, clamped)
     const d = Temporal.Duration.from({ months: 1 });

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -6,14 +6,14 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
-  test("total()", () => {
+  test("total() with time-only durations", () => {
     const d = new Temporal.Duration(0, 0, 0, 0, 1, 30);
     expect(d.total("minutes")).toBe(90);
     expect(d.total("hours")).toBe(1.5);
     expect(d.total("seconds")).toBe(5400);
   });
 
-  test("total() throws RangeError for durations with years or months", () => {
+  test("total() throws RangeError without relativeTo for year/month durations", () => {
     const withYears = new Temporal.Duration(1);
     expect(() => withYears.total("days")).toThrow(RangeError);
 
@@ -22,5 +22,86 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
 
     const withBoth = new Temporal.Duration(1, 2, 0, 5);
     expect(() => withBoth.total("hours")).toThrow(RangeError);
+  });
+
+  test("total() with relativeTo converts years and months to days", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    expect(d.total({ unit: "days", relativeTo: "2024-01-01" })).toBe(547);
+  });
+
+  test("total() with relativeTo converts to months", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    expect(d.total({ unit: "months", relativeTo: "2024-01-01" })).toBe(18);
+  });
+
+  test("total() with relativeTo converts to years", () => {
+    const d = Temporal.Duration.from({ years: 2 });
+    expect(d.total({ unit: "years", relativeTo: "2024-01-01" })).toBe(2);
+  });
+
+  test("total() accounts for actual month lengths", () => {
+    // Feb 2024 is a leap year (29 days)
+    const oneMonth = Temporal.Duration.from({ months: 1 });
+    expect(oneMonth.total({ unit: "days", relativeTo: "2024-02-01" })).toBe(29);
+    // Feb 2023 is not a leap year (28 days)
+    expect(oneMonth.total({ unit: "days", relativeTo: "2023-02-01" })).toBe(28);
+    // January always has 31 days
+    expect(oneMonth.total({ unit: "days", relativeTo: "2024-01-01" })).toBe(31);
+  });
+
+  test("total() accounts for actual year lengths", () => {
+    const oneYear = Temporal.Duration.from({ years: 1 });
+    expect(oneYear.total({ unit: "days", relativeTo: "2024-01-01" })).toBe(366);
+    expect(oneYear.total({ unit: "days", relativeTo: "2023-01-01" })).toBe(365);
+  });
+
+  test("total() with relativeTo and sub-day units", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    const totalHours = d.total({ unit: "hours", relativeTo: "2024-01-01" });
+    expect(totalHours).toBe(547 * 24);
+
+    const totalMinutes = d.total({ unit: "minutes", relativeTo: "2024-01-01" });
+    expect(totalMinutes).toBe(547 * 24 * 60);
+  });
+
+  test("total() with mixed calendar and day components", () => {
+    const d = Temporal.Duration.from({ months: 1, days: 15 });
+    // Jan has 31 days, so 1 month + 15 days = 46 days from Jan 1
+    expect(d.total({ unit: "days", relativeTo: "2024-01-01" })).toBe(46);
+  });
+
+  test("total() months with fractional result", () => {
+    const d = Temporal.Duration.from({ months: 1, days: 15 });
+    const months = d.total({ unit: "months", relativeTo: "2024-01-01" });
+    // 1 month from Jan 1 = Feb 1; remaining 15 days; Feb has 29 days in 2024
+    expect(months).toBeCloseTo(1 + 15 / 29, 10);
+  });
+
+  test("total() years with fractional result", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    const years = d.total({ unit: "years", relativeTo: "2024-01-01" });
+    // 1 year from Jan 1 2024 = Jan 1 2025; remaining 6 months = 181 days;
+    // year span from Jan 1 2025 to Jan 1 2026 = 365 days
+    expect(years).toBeCloseTo(1 + 181 / 365, 10);
+  });
+
+  test("total() with relativeTo as PlainDate object", () => {
+    const d = Temporal.Duration.from({ months: 6 });
+    const relTo = Temporal.PlainDate.from("2024-01-01");
+    const days = d.total({ unit: "days", relativeTo: relTo });
+    // Jan(31) + Feb(29) + Mar(31) + Apr(30) + May(31) + Jun(30) = 182
+    expect(days).toBe(182);
+  });
+
+  test("total() months/years requires relativeTo", () => {
+    const d = Temporal.Duration.from({ days: 30 });
+    expect(() => d.total("months")).toThrow(RangeError);
+    expect(() => d.total("years")).toThrow(RangeError);
+  });
+
+  test("total() with day-clamping edge case", () => {
+    // Adding 1 month from Jan 31 → Feb 29 (2024 leap year, clamped)
+    const d = Temporal.Duration.from({ months: 1 });
+    expect(d.total({ unit: "days", relativeTo: "2024-01-31" })).toBe(29);
   });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -126,4 +126,12 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     const d = Temporal.Duration.from({ months: 1 });
     expect(d.total({ unit: "days", relativeTo: "2024-01-31" })).toBe(29);
   });
+
+  test("total() leap-day clamping with separate year and month steps", () => {
+    // P1Y1M from 2020-02-29: +1Y → 2021-02-28 (clamped), +1M → 2021-03-28
+    const d = Temporal.Duration.from({ years: 1, months: 1 });
+    const days = d.total({ unit: "days", relativeTo: "2020-02-29" });
+    // 2020-02-29 to 2021-03-28 = 393 days
+    expect(days).toBe(393);
+  });
 });

--- a/units/Goccia.Error.Messages.pas
+++ b/units/Goccia.Error.Messages.pas
@@ -195,8 +195,8 @@ resourcestring
   SErrorDurationRoundRequiresRelativeTo = 'Duration with years or months requires relativeTo for round()';
   SErrorDurationTotalRequiresUnit = 'total() requires a unit option';
   SErrorDurationTotalRequiresRelativeTo = 'Duration with years or months requires relativeTo for total()';
-  SErrorDurationTotalRelativeToUnsupported = 'relativeTo for Duration.prototype.total is not yet supported';
   SErrorDurationTotalRequiresStringOrOptions = 'Duration.prototype.total requires a string or options object';
+  SErrorTemporalInvalidRelativeTo = 'Invalid relativeTo value for %s';
   SErrorInvalidDurationAddArg = 'Invalid argument to Duration.prototype.add';
   SErrorInvalidDurationSubtractArg = 'Invalid argument to Duration.prototype.subtract';
 

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -723,14 +723,17 @@ end;
 // Express the duration as a fractional month count relative to a reference date.
 // Walks forward from the reference date by the duration's calendar components,
 // then measures the result in calendar months plus a fractional remainder.
-function TotalInMonths(const D: TGocciaTemporalDurationValue;
-  const ARelDate: TTemporalDateRecord): TGocciaValue;
+// Shared calendar-walk helper for TotalInMonths and TotalInYears.
+// AMonthsPerUnit is 1 for months, 12 for years.
+function ComputeTotalInUnits(const D: TGocciaTemporalDurationValue;
+  const ARelDate: TTemporalDateRecord; const AMonthsPerUnit: Int64): Double;
 var
   EndRec, CheckRec, SpanRec: TTemporalDateRecord;
-  WholeMonths, CarryDays: Int64;
+  WholeUnits, CarryDays: Int64;
+  TotalMonthsDiff: Int64;
   CheckEpoch, EndEpoch, SpanEpoch: Int64;
   RemainingDays, DaysInSpan: Int64;
-  TimeNs, RemainderNs, FracDays, Total: Double;
+  TimeNs, RemainderNs, FracDays: Double;
 begin
   // Fold sub-day time overflow into whole days so the calendar walk is accurate
   TimeNs := SubDayNanoseconds(D);
@@ -740,26 +743,27 @@ begin
   EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays + CarryDays);
   EndEpoch := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day);
 
-  // Estimate whole months
-  WholeMonths := Int64(EndRec.Year - ARelDate.Year) * 12 +
-                 Int64(EndRec.Month - ARelDate.Month);
+  // Estimate whole units from the month difference
+  TotalMonthsDiff := Int64(EndRec.Year - ARelDate.Year) * 12 +
+                     Int64(EndRec.Month - ARelDate.Month);
+  WholeUnits := TotalMonthsDiff div AMonthsPerUnit;
 
   // Verify estimate by walking from the reference date
-  CheckRec := AddMonthsToDate(ARelDate, WholeMonths);
+  CheckRec := AddMonthsToDate(ARelDate, WholeUnits * AMonthsPerUnit);
   CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
 
   // Adjust if overshot forward
-  while (WholeMonths > 0) and (CheckEpoch > EndEpoch) do
+  while (WholeUnits > 0) and (CheckEpoch > EndEpoch) do
   begin
-    Dec(WholeMonths);
-    CheckRec := AddMonthsToDate(ARelDate, WholeMonths);
+    Dec(WholeUnits);
+    CheckRec := AddMonthsToDate(ARelDate, WholeUnits * AMonthsPerUnit);
     CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
   end;
   // Adjust if overshot backward
-  while (WholeMonths < 0) and (CheckEpoch < EndEpoch) do
+  while (WholeUnits < 0) and (CheckEpoch < EndEpoch) do
   begin
-    Inc(WholeMonths);
-    CheckRec := AddMonthsToDate(ARelDate, WholeMonths);
+    Inc(WholeUnits);
+    CheckRec := AddMonthsToDate(ARelDate, WholeUnits * AMonthsPerUnit);
     CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
   end;
 
@@ -767,87 +771,37 @@ begin
   RemainingDays := EndEpoch - CheckEpoch;
   FracDays := RemainingDays + RemainderNs / NANOSECONDS_PER_DAY;
 
-  // Determine the month span for the fractional calculation
+  // Determine the unit span for the fractional calculation
   if FracDays >= 0 then
   begin
-    SpanRec := AddMonthsToDate(ARelDate, WholeMonths + 1);
+    SpanRec := AddMonthsToDate(ARelDate, (WholeUnits + 1) * AMonthsPerUnit);
     SpanEpoch := DateToEpochDays(SpanRec.Year, SpanRec.Month, SpanRec.Day);
     DaysInSpan := SpanEpoch - CheckEpoch;
   end
   else
   begin
-    SpanRec := AddMonthsToDate(ARelDate, WholeMonths - 1);
+    SpanRec := AddMonthsToDate(ARelDate, (WholeUnits - 1) * AMonthsPerUnit);
     SpanEpoch := DateToEpochDays(SpanRec.Year, SpanRec.Month, SpanRec.Day);
     DaysInSpan := CheckEpoch - SpanEpoch;
   end;
 
   if DaysInSpan > 0 then
-    Total := WholeMonths + FracDays / DaysInSpan
+    Result := WholeUnits + FracDays / DaysInSpan
   else
-    Total := WholeMonths;
+    Result := WholeUnits;
+end;
 
-  Result := TGocciaNumberLiteralValue.Create(Total);
+function TotalInMonths(const D: TGocciaTemporalDurationValue;
+  const ARelDate: TTemporalDateRecord): TGocciaValue;
+begin
+  Result := TGocciaNumberLiteralValue.Create(ComputeTotalInUnits(D, ARelDate, 1));
 end;
 
 // Express the duration as a fractional year count relative to a reference date.
 function TotalInYears(const D: TGocciaTemporalDurationValue;
   const ARelDate: TTemporalDateRecord): TGocciaValue;
-var
-  EndRec, CheckRec, SpanRec: TTemporalDateRecord;
-  WholeYears, CarryDays: Int64;
-  CheckEpoch, EndEpoch, SpanEpoch: Int64;
-  RemainingDays, DaysInSpan: Int64;
-  TimeNs, RemainderNs, FracDays, Total: Double;
 begin
-  // Fold sub-day time overflow into whole days so the calendar walk is accurate
-  TimeNs := SubDayNanoseconds(D);
-  CarryDays := Trunc(TimeNs / NANOSECONDS_PER_DAY);
-  RemainderNs := TimeNs - CarryDays * NANOSECONDS_PER_DAY;
-
-  EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays + CarryDays);
-  EndEpoch := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day);
-
-  // Estimate whole years
-  WholeYears := EndRec.Year - ARelDate.Year;
-
-  CheckRec := AddMonthsToDate(ARelDate, WholeYears * 12);
-  CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
-
-  while (WholeYears > 0) and (CheckEpoch > EndEpoch) do
-  begin
-    Dec(WholeYears);
-    CheckRec := AddMonthsToDate(ARelDate, WholeYears * 12);
-    CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
-  end;
-  while (WholeYears < 0) and (CheckEpoch < EndEpoch) do
-  begin
-    Inc(WholeYears);
-    CheckRec := AddMonthsToDate(ARelDate, WholeYears * 12);
-    CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
-  end;
-
-  RemainingDays := EndEpoch - CheckEpoch;
-  FracDays := RemainingDays + RemainderNs / NANOSECONDS_PER_DAY;
-
-  if FracDays >= 0 then
-  begin
-    SpanRec := AddMonthsToDate(ARelDate, (WholeYears + 1) * 12);
-    SpanEpoch := DateToEpochDays(SpanRec.Year, SpanRec.Month, SpanRec.Day);
-    DaysInSpan := SpanEpoch - CheckEpoch;
-  end
-  else
-  begin
-    SpanRec := AddMonthsToDate(ARelDate, (WholeYears - 1) * 12);
-    SpanEpoch := DateToEpochDays(SpanRec.Year, SpanRec.Month, SpanRec.Day);
-    DaysInSpan := CheckEpoch - SpanEpoch;
-  end;
-
-  if DaysInSpan > 0 then
-    Total := WholeYears + FracDays / DaysInSpan
-  else
-    Total := WholeYears;
-
-  Result := TGocciaNumberLiteralValue.Create(Total);
+  Result := TGocciaNumberLiteralValue.Create(ComputeTotalInUnits(D, ARelDate, 12));
 end;
 
 function TGocciaTemporalDurationValue.DurationTotal(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -721,12 +721,17 @@ function TotalInMonths(const D: TGocciaTemporalDurationValue;
   const ARelDate: TTemporalDateRecord): TGocciaValue;
 var
   EndRec, CheckRec, SpanRec: TTemporalDateRecord;
-  WholeMonths: Int64;
+  WholeMonths, CarryDays: Int64;
   CheckEpoch, EndEpoch, SpanEpoch: Int64;
   RemainingDays, DaysInSpan: Int64;
-  FracDays, Total: Double;
+  TimeNs, RemainderNs, FracDays, Total: Double;
 begin
-  EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays);
+  // Fold sub-day time overflow into whole days so the calendar walk is accurate
+  TimeNs := SubDayNanoseconds(D);
+  CarryDays := Trunc(TimeNs / NANOSECONDS_PER_DAY);
+  RemainderNs := TimeNs - CarryDays * NANOSECONDS_PER_DAY;
+
+  EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays + CarryDays);
   EndEpoch := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day);
 
   // Estimate whole months
@@ -752,9 +757,9 @@ begin
     CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
   end;
 
-  // Fractional part: remaining days + sub-day time
+  // Fractional part: remaining days + sub-day remainder only
   RemainingDays := EndEpoch - CheckEpoch;
-  FracDays := RemainingDays + SubDayNanoseconds(D) / 8.64e13;
+  FracDays := RemainingDays + RemainderNs / NANOSECONDS_PER_DAY;
 
   // Determine the month span for the fractional calculation
   if FracDays >= 0 then
@@ -783,12 +788,17 @@ function TotalInYears(const D: TGocciaTemporalDurationValue;
   const ARelDate: TTemporalDateRecord): TGocciaValue;
 var
   EndRec, CheckRec, SpanRec: TTemporalDateRecord;
-  WholeYears: Int64;
+  WholeYears, CarryDays: Int64;
   CheckEpoch, EndEpoch, SpanEpoch: Int64;
   RemainingDays, DaysInSpan: Int64;
-  FracDays, Total: Double;
+  TimeNs, RemainderNs, FracDays, Total: Double;
 begin
-  EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays);
+  // Fold sub-day time overflow into whole days so the calendar walk is accurate
+  TimeNs := SubDayNanoseconds(D);
+  CarryDays := Trunc(TimeNs / NANOSECONDS_PER_DAY);
+  RemainderNs := TimeNs - CarryDays * NANOSECONDS_PER_DAY;
+
+  EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays + CarryDays);
   EndEpoch := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day);
 
   // Estimate whole years
@@ -811,7 +821,7 @@ begin
   end;
 
   RemainingDays := EndEpoch - CheckEpoch;
-  FracDays := RemainingDays + SubDayNanoseconds(D) / 8.64e13;
+  FracDays := RemainingDays + RemainderNs / NANOSECONDS_PER_DAY;
 
   if FracDays >= 0 then
   begin

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -705,13 +705,19 @@ begin
 end;
 
 function SubDayNanoseconds(const D: TGocciaTemporalDurationValue): Double;
+var
+  Ns, V: Double;
 begin
-  Result := D.FNanoseconds +
-            D.FMicroseconds * NANOSECONDS_PER_MICROSECOND +
-            D.FMilliseconds * NANOSECONDS_PER_MILLISECOND +
-            D.FSeconds * NANOSECONDS_PER_SECOND +
-            D.FMinutes * NANOSECONDS_PER_MINUTE +
-            D.FHours * NANOSECONDS_PER_HOUR;
+  // Accumulate via implicit Int64->Double assignment to avoid both FPC 3.2.2
+  // bugs: Bug A (Double(Int64) bit reinterpretation) and Bug B (Int64 * 1.0
+  // wrong results near +/-2^31 on AArch64). See docs/contributing/tooling.md.
+  Ns := D.FNanoseconds;
+  V := D.FMicroseconds; Ns := Ns + V * NANOSECONDS_PER_MICROSECOND;
+  V := D.FMilliseconds; Ns := Ns + V * NANOSECONDS_PER_MILLISECOND;
+  V := D.FSeconds;      Ns := Ns + V * NANOSECONDS_PER_SECOND;
+  V := D.FMinutes;      Ns := Ns + V * NANOSECONDS_PER_MINUTE;
+  V := D.FHours;        Ns := Ns + V * NANOSECONDS_PER_HOUR;
+  Result := Ns;
 end;
 
 // Express the duration as a fractional month count relative to a reference date.
@@ -854,7 +860,7 @@ var
   HasRelativeTo: Boolean;
   RelDate: TTemporalDateRecord;
   ResolvedDays: Int64;
-  TotalNs: Double;
+  TotalNs, V: Double;
 begin
   D := AsDuration(AThisValue, 'Duration.prototype.total');
   Arg := AArgs.GetElement(0);
@@ -910,13 +916,14 @@ begin
     RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.total');
     ResolvedDays := ResolveRelativeDays(RelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays);
 
-    TotalNs := SubDayNanoseconds(D) + ResolvedDays * NANOSECONDS_PER_DAY;
+    V := ResolvedDays;
+    TotalNs := SubDayNanoseconds(D) + V * NANOSECONDS_PER_DAY;
   end
   else
   begin
-    TotalNs := SubDayNanoseconds(D) +
-               D.FDays * NANOSECONDS_PER_DAY +
-               D.FWeeks * 7 * NANOSECONDS_PER_DAY;
+    TotalNs := SubDayNanoseconds(D);
+    V := D.FDays;  TotalNs := TotalNs + V * NANOSECONDS_PER_DAY;
+    V := D.FWeeks; TotalNs := TotalNs + V * 7 * NANOSECONDS_PER_DAY;
   end;
 
   if TargetUnit = tuNanosecond then

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -82,7 +82,8 @@ uses
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
-  Goccia.Values.ObjectPropertyDescriptor;
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.TemporalPlainDate;
 
 threadvar
   FShared: TGocciaSharedPrototype;
@@ -626,6 +627,213 @@ begin
       ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs);
 end;
 
+function ParseRelativeTo(const AValue: TGocciaValue; const AMethod: string): TTemporalDateRecord;
+var
+  DateRec: TTemporalDateRecord;
+  TimeRec: TTemporalTimeRecord;
+  PlainDate: TGocciaTemporalPlainDateValue;
+begin
+  if AValue is TGocciaTemporalPlainDateValue then
+  begin
+    PlainDate := TGocciaTemporalPlainDateValue(AValue);
+    Result.Year := PlainDate.Year;
+    Result.Month := PlainDate.Month;
+    Result.Day := PlainDate.Day;
+  end
+  else if AValue is TGocciaStringLiteralValue then
+  begin
+    if not TryParseISODate(TGocciaStringLiteralValue(AValue).Value, DateRec) then
+    begin
+      if TryParseISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
+        Result := DateRec
+      else
+        ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
+    end
+    else
+      Result := DateRec;
+  end
+  else
+    ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
+end;
+
+// Add AMonths calendar months to a date, clamping the day if needed.
+function AddMonthsToDate(const ADate: TTemporalDateRecord; const AMonths: Int64): TTemporalDateRecord;
+var
+  TotalMonths, Y: Int64;
+  M, D: Integer;
+begin
+  TotalMonths := Int64(ADate.Year) * 12 + Int64(ADate.Month - 1) + AMonths;
+  if TotalMonths >= 0 then
+  begin
+    Y := TotalMonths div 12;
+    M := Integer(TotalMonths mod 12) + 1;
+  end
+  else
+  begin
+    Y := (TotalMonths - 11) div 12;
+    M := Integer(TotalMonths - Y * 12) + 1;
+  end;
+  D := ADate.Day;
+  if D > DaysInMonth(Integer(Y), M) then
+    D := DaysInMonth(Integer(Y), M);
+  Result.Year := Integer(Y);
+  Result.Month := M;
+  Result.Day := D;
+end;
+
+// Compute the end date of a duration applied from a reference date using
+// ISO 8601 calendar arithmetic (add years+months, clamp day, add weeks+days).
+function DurationEndDate(const ADate: TTemporalDateRecord;
+  const AYears, AMonths, AWeeks, ADays: Int64): TTemporalDateRecord;
+var
+  Interm: TTemporalDateRecord;
+begin
+  Interm := AddMonthsToDate(ADate, AYears * 12 + AMonths);
+  Result := AddDaysToDate(Interm.Year, Interm.Month, Interm.Day, AWeeks * 7 + ADays);
+end;
+
+// Resolve calendar-relative duration components (years, months, weeks) to a
+// concrete day count by walking forward from a reference date.
+function ResolveRelativeDays(const ADate: TTemporalDateRecord;
+  const AYears, AMonths, AWeeks, ADays: Int64): Int64;
+var
+  EndRec: TTemporalDateRecord;
+begin
+  EndRec := DurationEndDate(ADate, AYears, AMonths, AWeeks, ADays);
+  Result := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day) -
+            DateToEpochDays(ADate.Year, ADate.Month, ADate.Day);
+end;
+
+function SubDayNanoseconds(const D: TGocciaTemporalDurationValue): Double;
+begin
+  Result := D.FNanoseconds +
+            D.FMicroseconds * 1000.0 +
+            D.FMilliseconds * 1000000.0 +
+            D.FSeconds * 1e9 +
+            D.FMinutes * 6e10 +
+            D.FHours * 3.6e12;
+end;
+
+// Express the duration as a fractional month count relative to a reference date.
+// Walks forward from the reference date by the duration's calendar components,
+// then measures the result in calendar months plus a fractional remainder.
+function TotalInMonths(const D: TGocciaTemporalDurationValue;
+  const ARelDate: TTemporalDateRecord): TGocciaValue;
+var
+  EndRec, CheckRec, SpanRec: TTemporalDateRecord;
+  WholeMonths: Int64;
+  CheckEpoch, EndEpoch, SpanEpoch: Int64;
+  RemainingDays, DaysInSpan: Int64;
+  FracDays, Total: Double;
+begin
+  EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays);
+  EndEpoch := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day);
+
+  // Estimate whole months
+  WholeMonths := Int64(EndRec.Year - ARelDate.Year) * 12 +
+                 Int64(EndRec.Month - ARelDate.Month);
+
+  // Verify estimate by walking from the reference date
+  CheckRec := AddMonthsToDate(ARelDate, WholeMonths);
+  CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
+
+  // Adjust if overshot forward
+  while (WholeMonths > 0) and (CheckEpoch > EndEpoch) do
+  begin
+    Dec(WholeMonths);
+    CheckRec := AddMonthsToDate(ARelDate, WholeMonths);
+    CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
+  end;
+  // Adjust if overshot backward
+  while (WholeMonths < 0) and (CheckEpoch < EndEpoch) do
+  begin
+    Inc(WholeMonths);
+    CheckRec := AddMonthsToDate(ARelDate, WholeMonths);
+    CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
+  end;
+
+  // Fractional part: remaining days + sub-day time
+  RemainingDays := EndEpoch - CheckEpoch;
+  FracDays := RemainingDays + SubDayNanoseconds(D) / 8.64e13;
+
+  // Determine the month span for the fractional calculation
+  if FracDays >= 0 then
+  begin
+    SpanRec := AddMonthsToDate(ARelDate, WholeMonths + 1);
+    SpanEpoch := DateToEpochDays(SpanRec.Year, SpanRec.Month, SpanRec.Day);
+    DaysInSpan := SpanEpoch - CheckEpoch;
+  end
+  else
+  begin
+    SpanRec := AddMonthsToDate(ARelDate, WholeMonths - 1);
+    SpanEpoch := DateToEpochDays(SpanRec.Year, SpanRec.Month, SpanRec.Day);
+    DaysInSpan := CheckEpoch - SpanEpoch;
+  end;
+
+  if DaysInSpan > 0 then
+    Total := WholeMonths + FracDays / DaysInSpan
+  else
+    Total := WholeMonths;
+
+  Result := TGocciaNumberLiteralValue.Create(Total);
+end;
+
+// Express the duration as a fractional year count relative to a reference date.
+function TotalInYears(const D: TGocciaTemporalDurationValue;
+  const ARelDate: TTemporalDateRecord): TGocciaValue;
+var
+  EndRec, CheckRec, SpanRec: TTemporalDateRecord;
+  WholeYears: Int64;
+  CheckEpoch, EndEpoch, SpanEpoch: Int64;
+  RemainingDays, DaysInSpan: Int64;
+  FracDays, Total: Double;
+begin
+  EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays);
+  EndEpoch := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day);
+
+  // Estimate whole years
+  WholeYears := EndRec.Year - ARelDate.Year;
+
+  CheckRec := AddMonthsToDate(ARelDate, WholeYears * 12);
+  CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
+
+  while (WholeYears > 0) and (CheckEpoch > EndEpoch) do
+  begin
+    Dec(WholeYears);
+    CheckRec := AddMonthsToDate(ARelDate, WholeYears * 12);
+    CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
+  end;
+  while (WholeYears < 0) and (CheckEpoch < EndEpoch) do
+  begin
+    Inc(WholeYears);
+    CheckRec := AddMonthsToDate(ARelDate, WholeYears * 12);
+    CheckEpoch := DateToEpochDays(CheckRec.Year, CheckRec.Month, CheckRec.Day);
+  end;
+
+  RemainingDays := EndEpoch - CheckEpoch;
+  FracDays := RemainingDays + SubDayNanoseconds(D) / 8.64e13;
+
+  if FracDays >= 0 then
+  begin
+    SpanRec := AddMonthsToDate(ARelDate, (WholeYears + 1) * 12);
+    SpanEpoch := DateToEpochDays(SpanRec.Year, SpanRec.Month, SpanRec.Day);
+    DaysInSpan := SpanEpoch - CheckEpoch;
+  end
+  else
+  begin
+    SpanRec := AddMonthsToDate(ARelDate, (WholeYears - 1) * 12);
+    SpanEpoch := DateToEpochDays(SpanRec.Year, SpanRec.Month, SpanRec.Day);
+    DaysInSpan := CheckEpoch - SpanEpoch;
+  end;
+
+  if DaysInSpan > 0 then
+    Total := WholeYears + FracDays / DaysInSpan
+  else
+    Total := WholeYears;
+
+  Result := TGocciaNumberLiteralValue.Create(Total);
+end;
+
 function TGocciaTemporalDurationValue.DurationTotal(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D: TGocciaTemporalDurationValue;
@@ -633,6 +841,8 @@ var
   Arg, RelToArg: TGocciaValue;
   OptionsObj: TGocciaObjectValue;
   HasRelativeTo: Boolean;
+  RelDate: TTemporalDateRecord;
+  ResolvedDays: Int64;
   TotalNs: Double;
 begin
   D := AsDuration(AThisValue, 'Duration.prototype.total');
@@ -659,22 +869,36 @@ begin
     UnitStr := '';
   end;
 
-  if (D.FYears <> 0) or (D.FMonths <> 0) then
+  // Calendar target units always require relativeTo
+  if (UnitStr = 'months') or (UnitStr = 'years') then
   begin
-    if HasRelativeTo then
-      ThrowRangeError(SErrorDurationTotalRelativeToUnsupported, SSuggestTemporalRelativeTo)
-    else
+    if not HasRelativeTo then
       ThrowRangeError(SErrorDurationTotalRequiresRelativeTo, SSuggestTemporalRelativeTo);
+    RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.total');
+    if UnitStr = 'months' then
+      Result := TotalInMonths(D, RelDate)
+    else
+      Result := TotalInYears(D, RelDate);
+    Exit;
   end;
 
-  TotalNs := D.FNanoseconds +
-             D.FMicroseconds * 1000.0 +
-             D.FMilliseconds * 1000000.0 +
-             D.FSeconds * 1e9 +
-             D.FMinutes * 6e10 +
-             D.FHours * 3.6e12 +
-             D.FDays * 8.64e13 +
-             D.FWeeks * 6.048e14;
+  // Calendar source components (years/months) require relativeTo
+  if (D.FYears <> 0) or (D.FMonths <> 0) then
+  begin
+    if not HasRelativeTo then
+      ThrowRangeError(SErrorDurationTotalRequiresRelativeTo, SSuggestTemporalRelativeTo);
+
+    RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.total');
+    ResolvedDays := ResolveRelativeDays(RelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays);
+
+    TotalNs := SubDayNanoseconds(D) + ResolvedDays * 8.64e13;
+  end
+  else
+  begin
+    TotalNs := SubDayNanoseconds(D) +
+               D.FDays * 8.64e13 +
+               D.FWeeks * 6.048e14;
+  end;
 
   if UnitStr = 'nanoseconds' then
     Result := TGocciaNumberLiteralValue.Create(TotalNs)

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -688,7 +688,14 @@ function DurationEndDate(const ADate: TTemporalDateRecord;
 var
   Interm: TTemporalDateRecord;
 begin
-  Interm := AddMonthsToDate(ADate, AYears * 12 + AMonths);
+  // Apply years and months as separate steps so the day clamps after each,
+  // matching TC39 Temporal calendar arithmetic (e.g. 2020-02-29 + P1Y1M
+  // clamps to 2021-02-28 after +1Y, then advances to 2021-03-28).
+  Interm := ADate;
+  if AYears <> 0 then
+    Interm := AddMonthsToDate(Interm, AYears * 12);
+  if AMonths <> 0 then
+    Interm := AddMonthsToDate(Interm, AMonths);
   Result := AddDaysToDate(Interm.Year, Interm.Month, Interm.Day, AWeeks * 7 + ADays);
 end;
 

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -848,6 +848,7 @@ function TGocciaTemporalDurationValue.DurationTotal(const AArgs: TGocciaArgument
 var
   D: TGocciaTemporalDurationValue;
   UnitStr: string;
+  TargetUnit: TTemporalUnit;
   Arg, RelToArg: TGocciaValue;
   OptionsObj: TGocciaObjectValue;
   HasRelativeTo: Boolean;
@@ -879,13 +880,21 @@ begin
     UnitStr := '';
   end;
 
+  // Validate unit (accepts both singular and plural: 'hour'/'hours', 'day'/'days', etc.)
+  if not GetTemporalUnitFromString(UnitStr, TargetUnit) or
+     (TargetUnit = tuAuto) or (TargetUnit = tuNone) then
+  begin
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Duration.prototype.total', UnitStr]), SSuggestTemporalValidUnits);
+    TargetUnit := tuNanosecond;
+  end;
+
   // Calendar target units always require relativeTo
-  if (UnitStr = 'months') or (UnitStr = 'years') then
+  if (TargetUnit = tuMonth) or (TargetUnit = tuYear) then
   begin
     if not HasRelativeTo then
       ThrowRangeError(SErrorDurationTotalRequiresRelativeTo, SSuggestTemporalRelativeTo);
     RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.total');
-    if UnitStr = 'months' then
+    if TargetUnit = tuMonth then
       Result := TotalInMonths(D, RelDate)
     else
       Result := TotalInYears(D, RelDate);
@@ -910,27 +919,12 @@ begin
                D.FWeeks * 7 * NANOSECONDS_PER_DAY;
   end;
 
-  if UnitStr = 'nanoseconds' then
+  if TargetUnit = tuNanosecond then
     Result := TGocciaNumberLiteralValue.Create(TotalNs)
-  else if UnitStr = 'microseconds' then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / 1000)
-  else if UnitStr = 'milliseconds' then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / 1000000)
-  else if UnitStr = 'seconds' then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / 1e9)
-  else if UnitStr = 'minutes' then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / 6e10)
-  else if UnitStr = 'hours' then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / 3.6e12)
-  else if UnitStr = 'days' then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / 8.64e13)
-  else if UnitStr = 'weeks' then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / 6.048e14)
+  else if TargetUnit = tuWeek then
+    Result := TGocciaNumberLiteralValue.Create(TotalNs / (7 * NANOSECONDS_PER_DAY))
   else
-  begin
-    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Duration.prototype.total', UnitStr]), SSuggestTemporalValidUnits);
-    Result := nil;
-  end;
+    Result := TGocciaNumberLiteralValue.Create(TotalNs / UnitToNanoseconds(TargetUnit));
 end;
 
 function TGocciaTemporalDurationValue.DurationToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -707,11 +707,11 @@ end;
 function SubDayNanoseconds(const D: TGocciaTemporalDurationValue): Double;
 begin
   Result := D.FNanoseconds +
-            D.FMicroseconds * 1000.0 +
-            D.FMilliseconds * 1000000.0 +
-            D.FSeconds * 1e9 +
-            D.FMinutes * 6e10 +
-            D.FHours * 3.6e12;
+            D.FMicroseconds * NANOSECONDS_PER_MICROSECOND +
+            D.FMilliseconds * NANOSECONDS_PER_MILLISECOND +
+            D.FSeconds * NANOSECONDS_PER_SECOND +
+            D.FMinutes * NANOSECONDS_PER_MINUTE +
+            D.FHours * NANOSECONDS_PER_HOUR;
 end;
 
 // Express the duration as a fractional month count relative to a reference date.
@@ -891,13 +891,13 @@ begin
     RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.total');
     ResolvedDays := ResolveRelativeDays(RelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays);
 
-    TotalNs := SubDayNanoseconds(D) + ResolvedDays * 8.64e13;
+    TotalNs := SubDayNanoseconds(D) + ResolvedDays * NANOSECONDS_PER_DAY;
   end
   else
   begin
     TotalNs := SubDayNanoseconds(D) +
-               D.FDays * 8.64e13 +
-               D.FWeeks * 6.048e14;
+               D.FDays * NANOSECONDS_PER_DAY +
+               D.FWeeks * 7 * NANOSECONDS_PER_DAY;
   end;
 
   if UnitStr = 'nanoseconds' then


### PR DESCRIPTION
## Summary
- Implemented `Temporal.Duration.prototype.total` support for `relativeTo` when converting calendar-relative durations to `days`, `months`, and `years`.
- Added parsing and validation for `relativeTo` values passed as ISO date strings, ISO date-time strings, or `Temporal.PlainDate`.
- Updated duration total calculations to use calendar-aware month/year arithmetic with day clamping and fractional results.
- Added error messaging for invalid `relativeTo` values and expanded Temporal total coverage with new tests.

Fixes #321 