### PR TITLE
Add Temporal.Duration.round support for relativeTo

### DIFF
--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -137,6 +137,14 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(rounded.months).toBe(-4);
   });
 
+  test("round large time-only duration to months folds carry days", () => {
+    // PT2000H = ~83.33 days from 2021-01-01:
+    // Jan 31 + Feb 28 = 59 days → 2 months, remainder 24.33/31 ≈ 0.785 → rounds to 3 months
+    const d = Temporal.Duration.from({ hours: 2000 });
+    const rounded = d.round({ smallestUnit: "months", relativeTo: "2021-01-01" });
+    expect(rounded.months).toBe(3);
+  });
+
   test("round with largestUnit month flattens years", () => {
     const d = Temporal.Duration.from({ years: 1, months: 6 });
     const rounded = d.round({ smallestUnit: "months", largestUnit: "months", relativeTo: "2024-01-01" });

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -115,6 +115,17 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(inDays.days).toBe(393);
   });
 
+  test("round months with roundingIncrement uses real calendar bucket span", () => {
+    // P3M from 2021-01-31: end = 2021-04-30 (clamped). Bucket [2M, 4M]:
+    // 2M = 2021-03-31, 4M = 2021-05-31 → span = 61 days.
+    // Position = 2021-04-30 - 2021-03-31 = 30 days. 30/61 < 0.5 → round to 2M.
+    const d = Temporal.Duration.from({ months: 3 });
+    const rounded = d.round({
+      smallestUnit: "months", roundingIncrement: 2, relativeTo: "2021-01-31"
+    });
+    expect(rounded.months).toBe(2);
+  });
+
   test("round with largestUnit month flattens years", () => {
     const d = Temporal.Duration.from({ years: 1, months: 6 });
     const rounded = d.round({ smallestUnit: "months", largestUnit: "months", relativeTo: "2024-01-01" });

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -107,6 +107,14 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(() => d.round({ smallestUnit: "months" })).toThrow();
   });
 
+  test("round applies years and months as separate calendar steps", () => {
+    // 2020-02-29 + 1Y = 2021-02-28 (day clamps), + 1M = 2021-03-28 = 393 days.
+    // Collapsing to +13M gives 2021-03-29 = 394 days (wrong).
+    const d = Temporal.Duration.from({ years: 1, months: 1 });
+    const inDays = d.round({ smallestUnit: "days", largestUnit: "days", relativeTo: "2020-02-29" });
+    expect(inDays.days).toBe(393);
+  });
+
   test("round with largestUnit month flattens years", () => {
     const d = Temporal.Duration.from({ years: 1, months: 6 });
     const rounded = d.round({ smallestUnit: "months", largestUnit: "months", relativeTo: "2024-01-01" });

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -107,6 +107,11 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(() => d.round({ smallestUnit: "months" })).toThrow();
   });
 
+  test("round with largestUnit smaller than smallestUnit throws", () => {
+    const d = Temporal.Duration.from({ days: 10 });
+    expect(() => d.round({ smallestUnit: "month", largestUnit: "day", relativeTo: "2024-01-01" })).toThrow();
+  });
+
   test("round applies years and months as separate calendar steps", () => {
     // 2020-02-29 + 1Y = 2021-02-28 (day clamps), + 1M = 2021-03-28 = 393 days.
     // Collapsing to +13M gives 2021-03-29 = 394 days (wrong).

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -32,4 +32,85 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(rounded.weeks).toBe(1);
     expect(rounded.days).toBe(0);
   });
+
+  test("round years+months to months with relativeTo", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    const rounded = d.round({ smallestUnit: "months", relativeTo: "2024-01-01" });
+    // Default largestUnit is "year" (largest existing unit)
+    expect(rounded.years).toBe(1);
+    expect(rounded.months).toBe(6);
+    expect(rounded.days).toBe(0);
+  });
+
+  test("round years+months+days to months with relativeTo", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6, days: 20 });
+    // 2024-01-01 + 1Y = 2025-01-01, + 6M = 2025-07-01, + 20D = 2025-07-21
+    // 18 complete months from 2024-01-01 to 2025-07-01; remaining 20/31 ≈ 0.645 → rounds to 19 months
+    const rounded = d.round({ smallestUnit: "months", relativeTo: "2024-01-01" });
+    expect(rounded.years).toBe(1);
+    expect(rounded.months).toBe(7);
+    expect(rounded.days).toBe(0);
+  });
+
+  test("round to years with relativeTo", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    // 2024-01-01 + 1Y6M = 2025-07-01
+    // 1 complete year (2024-01-01 to 2025-01-01 = 366 days, 2024 is leap)
+    // remaining: 2025-01-01 to 2025-07-01 = 181 days
+    // year period: 2025-01-01 to 2026-01-01 = 365 days
+    // fraction: 181/365 ≈ 0.496 < 0.5 → rounds to 1
+    const rounded = d.round({ smallestUnit: "years", relativeTo: "2024-01-01" });
+    expect(rounded.years).toBe(1);
+    expect(rounded.months).toBe(0);
+  });
+
+  test("round to years rounds up at half boundary", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 7 });
+    // 2023-07-01 + 1Y7M = 2025-02-01
+    // 1 complete year (2023-07-01 to 2024-07-01 = 366 days)
+    // remaining: 2024-07-01 to 2025-02-01 = 215 days
+    // year period: 2024-07-01 to 2025-07-01 = 365 days
+    // fraction: 215/365 ≈ 0.589 >= 0.5 → rounds to 2
+    const rounded = d.round({ smallestUnit: "years", relativeTo: "2023-07-01" });
+    expect(rounded.years).toBe(2);
+    expect(rounded.months).toBe(0);
+  });
+
+  test("round months+hours to days with relativeTo", () => {
+    const d = Temporal.Duration.from({ months: 1, hours: 36 });
+    // 2024-01-15 + 1M = 2024-02-15 (31 days), then 36h = 1.5 days
+    // total = 32.5 days → rounds to 33 days (halfExpand)
+    // rebalance: 1 month (31 days) + 2 days
+    const rounded = d.round({ smallestUnit: "days", relativeTo: "2024-01-15" });
+    expect(rounded.months).toBe(1);
+    expect(rounded.days).toBe(2);
+    expect(rounded.hours).toBe(0);
+  });
+
+  test("round with relativeTo string datetime", () => {
+    const d = Temporal.Duration.from({ years: 2, months: 3 });
+    const rounded = d.round({ smallestUnit: "months", relativeTo: "2020-06-15T10:30:00" });
+    expect(rounded.years).toBe(2);
+    expect(rounded.months).toBe(3);
+  });
+
+  test("round with relativeTo PlainDate object", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    const rd = Temporal.PlainDate.from("2024-01-01");
+    const rounded = d.round({ smallestUnit: "months", relativeTo: rd });
+    expect(rounded.years).toBe(1);
+    expect(rounded.months).toBe(6);
+  });
+
+  test("round years+months without relativeTo throws", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    expect(() => d.round({ smallestUnit: "months" })).toThrow();
+  });
+
+  test("round with largestUnit month flattens years", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    const rounded = d.round({ smallestUnit: "months", largestUnit: "months", relativeTo: "2024-01-01" });
+    expect(rounded.years).toBe(0);
+    expect(rounded.months).toBe(18);
+  });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -126,6 +126,17 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(rounded.months).toBe(2);
   });
 
+  test("round negative months with roundingIncrement uses correct bucket", () => {
+    // -P3M from 2021-07-31: end = 2021-04-30. Bucket [-4M, -2M]:
+    // -4M = 2021-03-31, -2M = 2021-05-31 → span = 61 days.
+    // Position from -4M boundary = 30 days. 30/61 < 0.5 → round to -4M.
+    const d = Temporal.Duration.from({ months: -3 });
+    const rounded = d.round({
+      smallestUnit: "months", roundingIncrement: 2, relativeTo: "2021-07-31"
+    });
+    expect(rounded.months).toBe(-4);
+  });
+
   test("round with largestUnit month flattens years", () => {
     const d = Temporal.Duration.from({ years: 1, months: 6 });
     const rounded = d.round({ smallestUnit: "months", largestUnit: "months", relativeTo: "2024-01-01" });

--- a/units/Goccia.Error.Messages.pas
+++ b/units/Goccia.Error.Messages.pas
@@ -192,6 +192,7 @@ resourcestring
   // Temporal prototype errors — Duration
   SErrorDurationMixedSigns = 'Duration fields must not have mixed signs';
   SErrorDurationRoundRequiresUnit = 'round() requires at least a smallestUnit or largestUnit';
+  SErrorDurationRoundLargestSmallerThanSmallest = 'largestUnit must not be smaller than smallestUnit';
   SErrorDurationRoundRequiresRelativeTo = 'Duration with years or months requires relativeTo for round()';
   SErrorDurationTotalRequiresUnit = 'total() requires a unit option';
   SErrorDurationTotalRequiresRelativeTo = 'Duration with years or months requires relativeTo for total()';

--- a/units/Goccia.Temporal.Utils.pas
+++ b/units/Goccia.Temporal.Utils.pas
@@ -45,6 +45,7 @@ function WeekOfYear(const AYear, AMonth, ADay: Integer): Integer;
 function YearOfWeek(const AYear, AMonth, ADay: Integer): Integer;
 
 function AddDaysToDate(const AYear, AMonth, ADay: Integer; const ADays: Int64): TTemporalDateRecord;
+function AddMonthsToDate(const AYear, AMonth, ADay: Integer; const AMonths: Int64): TTemporalDateRecord;
 function DateToEpochDays(const AYear, AMonth, ADay: Integer): Int64;
 function EpochDaysToDate(const ADays: Int64): TTemporalDateRecord;
 
@@ -247,6 +248,30 @@ var
 begin
   EpochDays := DateToEpochDays(AYear, AMonth, ADay);
   Result := EpochDaysToDate(EpochDays + ADays);
+end;
+
+function AddMonthsToDate(const AYear, AMonth, ADay: Integer; const AMonths: Int64): TTemporalDateRecord;
+var
+  TotalMonths: Int64;
+  NewYear: Int64;
+  NewMonth: Integer;
+  MaxDay: Integer;
+begin
+  TotalMonths := Int64(AYear) * 12 + (AMonth - 1) + AMonths;
+  NewYear := TotalMonths div 12;
+  NewMonth := Integer(TotalMonths mod 12) + 1;
+  if NewMonth < 1 then
+  begin
+    Inc(NewMonth, 12);
+    Dec(NewYear);
+  end;
+  Result.Year := Integer(NewYear);
+  Result.Month := NewMonth;
+  MaxDay := DaysInMonth(Result.Year, Result.Month);
+  if ADay > MaxDay then
+    Result.Day := MaxDay
+  else
+    Result.Day := ADay;
 end;
 
 function BalanceTime(const AHour, AMinute, ASecond, AMillisecond, AMicrosecond, ANanosecond: Int64;

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -602,9 +602,17 @@ begin
       Exit;
     end;
 
-    // Resolve duration to concrete end date
-    IntermDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day,
-      D.FYears * 12 + D.FMonths);
+    // Resolve duration to concrete end date. Apply years and months as
+    // separate calendar steps so day-clamping is applied after each,
+    // matching TC39 Temporal semantics (e.g. 2020-02-29 + P1Y1M clamps to
+    // 2021-02-28 after +1Y, then advances to 2021-03-28).
+    IntermDate := RelDate;
+    if D.FYears <> 0 then
+      IntermDate := AddMonthsToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
+        D.FYears * 12);
+    if D.FMonths <> 0 then
+      IntermDate := AddMonthsToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
+        D.FMonths);
     EndDate := AddDaysToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
       D.FWeeks * 7 + D.FDays);
     StartEpoch := DateToEpochDays(RelDate.Year, RelDate.Month, RelDate.Day);

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -586,6 +586,9 @@ begin
       LargestUnit := SmallestUnit;
   end;
 
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+
   // Determine if calendar-relative computation is needed
   NeedCalendar := (D.FYears <> 0) or (D.FMonths <> 0) or
     (Ord(SmallestUnit) <= Ord(tuMonth)) or (Ord(LargestUnit) <= Ord(tuMonth));

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -653,16 +653,22 @@ begin
           until False;
         end;
 
-        WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits * 12);
-        WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
-        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, (WholeUnits + Sign) * 12);
-        NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
-        PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+        // Align to increment-boundary bucket and compute real calendar span
+        ScaledValue := WholeUnits div Increment;
+        if (WholeUnits < 0) and (WholeUnits mod Increment <> 0) then
+          Dec(ScaledValue);
+        ScaledValue := ScaledValue * Increment;
 
-        ScaledValue := WholeUnits * PeriodNs + (EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs;
-        Divisor := PeriodNs * Increment;
-        RoundedValue := RoundWithMode(ScaledValue, Divisor, Mode);
-        WholeUnits := RoundedValue div PeriodNs;
+        WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, ScaledValue * 12);
+        WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, (ScaledValue + Increment) * 12);
+        NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+        PeriodNs := (NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+        RoundedValue := RoundWithMode((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs, PeriodNs, Mode);
+        if RoundedValue >= PeriodNs then
+          WholeUnits := ScaledValue + Increment
+        else
+          WholeUnits := ScaledValue;
 
         Result := TGocciaTemporalDurationValue.Create(WholeUnits, 0, 0, 0, 0, 0, 0, 0, 0, 0);
       end
@@ -691,16 +697,22 @@ begin
           until False;
         end;
 
-        WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits);
-        WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
-        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits + Sign);
-        NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
-        PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+        // Align to increment-boundary bucket and compute real calendar span
+        ScaledValue := WholeUnits div Increment;
+        if (WholeUnits < 0) and (WholeUnits mod Increment <> 0) then
+          Dec(ScaledValue);
+        ScaledValue := ScaledValue * Increment;
 
-        ScaledValue := WholeUnits * PeriodNs + (EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs;
-        Divisor := PeriodNs * Increment;
-        RoundedValue := RoundWithMode(ScaledValue, Divisor, Mode);
-        WholeUnits := RoundedValue div PeriodNs;
+        WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, ScaledValue);
+        WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, ScaledValue + Increment);
+        NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+        PeriodNs := (NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+        RoundedValue := RoundWithMode((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs, PeriodNs, Mode);
+        if RoundedValue >= PeriodNs then
+          WholeUnits := ScaledValue + Increment
+        else
+          WholeUnits := ScaledValue;
 
         if Ord(LargestUnit) <= Ord(tuYear) then
         begin

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -653,11 +653,17 @@ begin
           until False;
         end;
 
-        // Align to increment-boundary bucket and compute real calendar span
-        ScaledValue := WholeUnits div Increment;
-        if (WholeUnits < 0) and (WholeUnits mod Increment <> 0) then
-          Dec(ScaledValue);
-        ScaledValue := ScaledValue * Increment;
+        // Align to increment-boundary bucket. For negative durations the
+        // fractional position extends past WholeUnits in the negative
+        // direction, so use WholeUnits - 1 as alignment base.
+        if Sign < 0 then
+          ScaledValue := WholeUnits - 1
+        else
+          ScaledValue := WholeUnits;
+        if (ScaledValue >= 0) or (ScaledValue mod Increment = 0) then
+          ScaledValue := (ScaledValue div Increment) * Increment
+        else
+          ScaledValue := ((ScaledValue div Increment) - 1) * Increment;
 
         WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, ScaledValue * 12);
         WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
@@ -697,11 +703,15 @@ begin
           until False;
         end;
 
-        // Align to increment-boundary bucket and compute real calendar span
-        ScaledValue := WholeUnits div Increment;
-        if (WholeUnits < 0) and (WholeUnits mod Increment <> 0) then
-          Dec(ScaledValue);
-        ScaledValue := ScaledValue * Increment;
+        // Align to increment-boundary bucket (same sign-aware logic as years)
+        if Sign < 0 then
+          ScaledValue := WholeUnits - 1
+        else
+          ScaledValue := WholeUnits;
+        if (ScaledValue >= 0) or (ScaledValue mod Increment = 0) then
+          ScaledValue := (ScaledValue div Increment) * Increment
+        else
+          ScaledValue := ((ScaledValue div Increment) - 1) * Increment;
 
         WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, ScaledValue);
         WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -497,26 +497,33 @@ end;
 function TGocciaTemporalDurationValue.DurationRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D: TGocciaTemporalDurationValue;
-  Arg: TGocciaValue;
+  Arg, RelToArg: TGocciaValue;
   OptionsObj: TGocciaObjectValue;
   SmallestUnit, LargestUnit: TTemporalUnit;
   Mode: TTemporalRoundingMode;
   Increment: Integer;
-  TotalNs, Divisor, Rounded: Int64;
-  RemNs: Int64;
+  HasRelativeTo: Boolean;
+  RelDate: TTemporalDateRecord;
+  RelTimeRec: TTemporalTimeRecord;
+  TotalNs, Divisor: Int64;
+  RemNs, TimeNs: Int64;
+  ResultYears, ResultMonths: Int64;
   ResultDays, ResultHours, ResultMinutes, ResultSeconds: Int64;
   ResultMs, ResultUs, ResultNs: Int64;
+  NeedCalendar: Boolean;
+  IntermDate, EndDate, WalkDate, NextDate: TTemporalDateRecord;
+  StartEpoch, EndEpoch, WalkEpoch, NextEpoch: Int64;
+  WholeUnits, PeriodNs, ScaledValue, RoundedValue: Int64;
+  Sign: Integer;
 begin
   D := AsDuration(AThisValue, 'Duration.prototype.round');
   Arg := AArgs.GetElement(0);
-
-  if (D.FYears <> 0) or (D.FMonths <> 0) then
-    ThrowRangeError(SErrorDurationRoundRequiresRelativeTo, SSuggestTemporalRelativeTo);
 
   SmallestUnit := tuNone;
   LargestUnit := tuNone;
   Mode := rmHalfExpand;
   Increment := 1;
+  HasRelativeTo := False;
 
   if Arg is TGocciaStringLiteralValue then
   begin
@@ -530,51 +537,278 @@ begin
     LargestUnit := GetLargestUnit(OptionsObj, tuNone);
     Mode := GetRoundingMode(OptionsObj, rmHalfExpand);
     Increment := GetRoundingIncrement(OptionsObj, 1);
+
+    RelToArg := OptionsObj.GetProperty('relativeTo');
+    if (RelToArg <> nil) and not (RelToArg is TGocciaUndefinedLiteralValue) then
+    begin
+      if RelToArg is TGocciaTemporalPlainDateValue then
+      begin
+        RelDate.Year := TGocciaTemporalPlainDateValue(RelToArg).Year;
+        RelDate.Month := TGocciaTemporalPlainDateValue(RelToArg).Month;
+        RelDate.Day := TGocciaTemporalPlainDateValue(RelToArg).Day;
+        HasRelativeTo := True;
+      end
+      else if RelToArg is TGocciaStringLiteralValue then
+      begin
+        if TryParseISODate(TGocciaStringLiteralValue(RelToArg).Value, RelDate) then
+          HasRelativeTo := True
+        else if TryParseISODateTime(TGocciaStringLiteralValue(RelToArg).Value, RelDate, RelTimeRec) then
+          HasRelativeTo := True
+        else
+          ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['relativeTo', 'Duration.prototype.round']), SSuggestTemporalISOFormat);
+      end
+      else
+        ThrowTypeError('relativeTo must be a Temporal.PlainDate or ISO 8601 string', SSuggestTemporalRelativeTo);
+    end;
   end
   else
     ThrowTypeError(Format(SErrorTemporalRoundRequiresStringOrOptions, ['Duration']), SSuggestTemporalRoundArg);
 
-  // If only largestUnit is specified, rebalance without rounding
+  // Validate units
   if (SmallestUnit = tuNone) and (LargestUnit = tuNone) then
     ThrowRangeError(SErrorDurationRoundRequiresUnit, SSuggestTemporalRoundArg);
   if SmallestUnit = tuNone then
     SmallestUnit := tuNanosecond;
   if LargestUnit = tuNone then
   begin
-    // Default largestUnit to the largest defined unit of the duration
-    if D.FDays <> 0 then LargestUnit := tuDay
+    if D.FYears <> 0 then LargestUnit := tuYear
+    else if D.FMonths <> 0 then LargestUnit := tuMonth
+    else if D.FWeeks <> 0 then LargestUnit := tuWeek
+    else if D.FDays <> 0 then LargestUnit := tuDay
     else if D.FHours <> 0 then LargestUnit := tuHour
     else if D.FMinutes <> 0 then LargestUnit := tuMinute
     else if D.FSeconds <> 0 then LargestUnit := tuSecond
     else if D.FMilliseconds <> 0 then LargestUnit := tuMillisecond
     else if D.FMicroseconds <> 0 then LargestUnit := tuMicrosecond
     else LargestUnit := SmallestUnit;
-    // Ensure largestUnit >= smallestUnit
     if Ord(LargestUnit) > Ord(SmallestUnit) then
       LargestUnit := SmallestUnit;
   end;
 
-  // Compute total nanoseconds (for time-only durations)
-  TotalNs := D.FNanoseconds +
-             D.FMicroseconds * NANOSECONDS_PER_MICROSECOND +
-             D.FMilliseconds * NANOSECONDS_PER_MILLISECOND +
-             D.FSeconds * NANOSECONDS_PER_SECOND +
-             D.FMinutes * NANOSECONDS_PER_MINUTE +
-             D.FHours * NANOSECONDS_PER_HOUR +
-             D.FDays * NANOSECONDS_PER_DAY +
-             D.FWeeks * 7 * NANOSECONDS_PER_DAY;
+  // Determine if calendar-relative computation is needed
+  NeedCalendar := (D.FYears <> 0) or (D.FMonths <> 0) or
+    (Ord(SmallestUnit) <= Ord(tuMonth)) or (Ord(LargestUnit) <= Ord(tuMonth));
 
-  // Round to smallestUnit
-  if SmallestUnit <> tuNanosecond then
+  if NeedCalendar and not HasRelativeTo then
+    ThrowRangeError(SErrorDurationRoundRequiresRelativeTo, SSuggestTemporalRelativeTo);
+
+  // --- Calendar-relative path ---
+  if NeedCalendar then
   begin
-    if SmallestUnit = tuWeek then
-      Divisor := NANOSECONDS_PER_DAY * 7 * Increment
-    else
-      Divisor := UnitToNanoseconds(SmallestUnit) * Increment;
-    TotalNs := RoundWithMode(TotalNs, Divisor, Mode);
+    Sign := D.ComputeSign;
+    if Sign = 0 then
+    begin
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      Exit;
+    end;
+
+    // Resolve duration to concrete end date
+    IntermDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day,
+      D.FYears * 12 + D.FMonths);
+    EndDate := AddDaysToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
+      D.FWeeks * 7 + D.FDays);
+    StartEpoch := DateToEpochDays(RelDate.Year, RelDate.Month, RelDate.Day);
+    EndEpoch := DateToEpochDays(EndDate.Year, EndDate.Month, EndDate.Day);
+
+    TimeNs := D.FNanoseconds +
+              D.FMicroseconds * NANOSECONDS_PER_MICROSECOND +
+              D.FMilliseconds * NANOSECONDS_PER_MILLISECOND +
+              D.FSeconds * NANOSECONDS_PER_SECOND +
+              D.FMinutes * NANOSECONDS_PER_MINUTE +
+              D.FHours * NANOSECONDS_PER_HOUR;
+
+    // --- Round to year or month ---
+    if (SmallestUnit = tuYear) or (SmallestUnit = tuMonth) then
+    begin
+      if SmallestUnit = tuYear then
+      begin
+        // Walk years from relativeTo
+        WholeUnits := 0;
+        if Sign > 0 then
+        begin
+          repeat
+            NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, (WholeUnits + 1) * 12);
+            NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+            if (NextEpoch > EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs <= 0)) then
+              Break;
+            Inc(WholeUnits);
+          until False;
+        end
+        else
+        begin
+          repeat
+            NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, (WholeUnits - 1) * 12);
+            NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+            if (NextEpoch < EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs >= 0)) then
+              Break;
+            Dec(WholeUnits);
+          until False;
+        end;
+
+        WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits * 12);
+        WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, (WholeUnits + Sign) * 12);
+        NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+        PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+
+        ScaledValue := WholeUnits * PeriodNs + (EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs;
+        Divisor := PeriodNs * Increment;
+        RoundedValue := RoundWithMode(ScaledValue, Divisor, Mode);
+        WholeUnits := RoundedValue div PeriodNs;
+
+        Result := TGocciaTemporalDurationValue.Create(WholeUnits, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      end
+      else // SmallestUnit = tuMonth
+      begin
+        // Walk months from relativeTo
+        WholeUnits := 0;
+        if Sign > 0 then
+        begin
+          repeat
+            NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits + 1);
+            NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+            if (NextEpoch > EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs <= 0)) then
+              Break;
+            Inc(WholeUnits);
+          until False;
+        end
+        else
+        begin
+          repeat
+            NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits - 1);
+            NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+            if (NextEpoch < EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs >= 0)) then
+              Break;
+            Dec(WholeUnits);
+          until False;
+        end;
+
+        WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits);
+        WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits + Sign);
+        NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+        PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+
+        ScaledValue := WholeUnits * PeriodNs + (EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs;
+        Divisor := PeriodNs * Increment;
+        RoundedValue := RoundWithMode(ScaledValue, Divisor, Mode);
+        WholeUnits := RoundedValue div PeriodNs;
+
+        if Ord(LargestUnit) <= Ord(tuYear) then
+        begin
+          ResultYears := WholeUnits div 12;
+          ResultMonths := WholeUnits mod 12;
+        end
+        else
+        begin
+          ResultYears := 0;
+          ResultMonths := WholeUnits;
+        end;
+
+        Result := TGocciaTemporalDurationValue.Create(ResultYears, ResultMonths, 0, 0, 0, 0, 0, 0, 0, 0);
+      end;
+      Exit;
+    end;
+
+    // --- SmallestUnit is week, day, or time: convert to nanoseconds ---
+    TotalNs := (EndEpoch - StartEpoch) * NANOSECONDS_PER_DAY + TimeNs;
+
+    if SmallestUnit <> tuNanosecond then
+    begin
+      if SmallestUnit = tuWeek then
+        Divisor := NANOSECONDS_PER_DAY * 7 * Increment
+      else
+        Divisor := UnitToNanoseconds(SmallestUnit) * Increment;
+      TotalNs := RoundWithMode(TotalNs, Divisor, Mode);
+    end;
+
+    // --- Rebalance to year/month if needed ---
+    if Ord(LargestUnit) <= Ord(tuMonth) then
+    begin
+      ResultDays := TotalNs div NANOSECONDS_PER_DAY;
+      RemNs := TotalNs mod NANOSECONDS_PER_DAY;
+
+      EndEpoch := StartEpoch + ResultDays;
+      WholeUnits := 0;
+      if Sign > 0 then
+      begin
+        repeat
+          NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits + 1);
+          NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+          if NextEpoch > EndEpoch then Break;
+          Inc(WholeUnits);
+        until False;
+      end
+      else
+      begin
+        repeat
+          NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits - 1);
+          NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+          if NextEpoch < EndEpoch then Break;
+          Dec(WholeUnits);
+        until False;
+      end;
+
+      WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits);
+      WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+      ResultDays := EndEpoch - WalkEpoch;
+
+      if Ord(LargestUnit) <= Ord(tuYear) then
+      begin
+        ResultYears := WholeUnits div 12;
+        ResultMonths := WholeUnits mod 12;
+      end
+      else
+      begin
+        ResultYears := 0;
+        ResultMonths := WholeUnits;
+      end;
+
+      ResultHours := RemNs div NANOSECONDS_PER_HOUR;
+      RemNs := RemNs mod NANOSECONDS_PER_HOUR;
+      ResultMinutes := RemNs div NANOSECONDS_PER_MINUTE;
+      RemNs := RemNs mod NANOSECONDS_PER_MINUTE;
+      ResultSeconds := RemNs div NANOSECONDS_PER_SECOND;
+      RemNs := RemNs mod NANOSECONDS_PER_SECOND;
+      ResultMs := RemNs div NANOSECONDS_PER_MILLISECOND;
+      RemNs := RemNs mod NANOSECONDS_PER_MILLISECOND;
+      ResultUs := RemNs div NANOSECONDS_PER_MICROSECOND;
+      ResultNs := RemNs mod NANOSECONDS_PER_MICROSECOND;
+
+      if Ord(LargestUnit) <= Ord(tuWeek) then
+        Result := TGocciaTemporalDurationValue.Create(ResultYears, ResultMonths,
+          ResultDays div 7, ResultDays mod 7,
+          ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs)
+      else
+        Result := TGocciaTemporalDurationValue.Create(ResultYears, ResultMonths, 0, ResultDays,
+          ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs);
+      Exit;
+    end;
+    // Fall through to non-calendar breakdown below
+  end
+  else
+  begin
+    // --- Non-calendar path (existing behavior) ---
+    TotalNs := D.FNanoseconds +
+               D.FMicroseconds * NANOSECONDS_PER_MICROSECOND +
+               D.FMilliseconds * NANOSECONDS_PER_MILLISECOND +
+               D.FSeconds * NANOSECONDS_PER_SECOND +
+               D.FMinutes * NANOSECONDS_PER_MINUTE +
+               D.FHours * NANOSECONDS_PER_HOUR +
+               D.FDays * NANOSECONDS_PER_DAY +
+               D.FWeeks * 7 * NANOSECONDS_PER_DAY;
+
+    if SmallestUnit <> tuNanosecond then
+    begin
+      if SmallestUnit = tuWeek then
+        Divisor := NANOSECONDS_PER_DAY * 7 * Increment
+      else
+        Divisor := UnitToNanoseconds(SmallestUnit) * Increment;
+      TotalNs := RoundWithMode(TotalNs, Divisor, Mode);
+    end;
   end;
 
-  // Break down from largestUnit
+  // Break down from largestUnit (non-calendar output)
   ResultDays := 0;
   ResultHours := 0;
   ResultMinutes := 0;
@@ -616,12 +850,9 @@ begin
   end;
   ResultNs := RemNs;
 
-  // Extract weeks from days if largestUnit allows it
   if Ord(LargestUnit) <= Ord(tuWeek) then
-  begin
     Result := TGocciaTemporalDurationValue.Create(0, 0, ResultDays div 7, ResultDays mod 7,
-      ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs);
-  end
+      ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs)
   else
     Result := TGocciaTemporalDurationValue.Create(0, 0, 0, ResultDays,
       ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs);

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -514,6 +514,7 @@ var
   IntermDate, EndDate, WalkDate, NextDate: TTemporalDateRecord;
   StartEpoch, EndEpoch, WalkEpoch, NextEpoch: Int64;
   WholeUnits, PeriodNs, ScaledValue, RoundedValue: Int64;
+  CarryDays: Int64;
   Sign: Integer;
 begin
   D := AsDuration(AThisValue, 'Duration.prototype.round');
@@ -613,17 +614,19 @@ begin
     if D.FMonths <> 0 then
       IntermDate := AddMonthsToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
         D.FMonths);
-    EndDate := AddDaysToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
-      D.FWeeks * 7 + D.FDays);
-    StartEpoch := DateToEpochDays(RelDate.Year, RelDate.Month, RelDate.Day);
-    EndEpoch := DateToEpochDays(EndDate.Year, EndDate.Month, EndDate.Day);
-
     TimeNs := D.FNanoseconds +
               D.FMicroseconds * NANOSECONDS_PER_MICROSECOND +
               D.FMilliseconds * NANOSECONDS_PER_MILLISECOND +
               D.FSeconds * NANOSECONDS_PER_SECOND +
               D.FMinutes * NANOSECONDS_PER_MINUTE +
               D.FHours * NANOSECONDS_PER_HOUR;
+    CarryDays := TimeNs div NANOSECONDS_PER_DAY;
+    TimeNs := TimeNs mod NANOSECONDS_PER_DAY;
+
+    EndDate := AddDaysToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
+      D.FWeeks * 7 + D.FDays + CarryDays);
+    StartEpoch := DateToEpochDays(RelDate.Year, RelDate.Month, RelDate.Day);
+    EndEpoch := DateToEpochDays(EndDate.Year, EndDate.Month, EndDate.Day);
 
     // --- Round to year or month ---
     if (SmallestUnit = tuYear) or (SmallestUnit = tuMonth) then


### PR DESCRIPTION
## Summary
- Added `relativeTo` handling to `Temporal.Duration.prototype.round`, including ISO date/datetime strings and `Temporal.PlainDate` inputs.
- Implemented calendar-aware rounding for year/month durations and mixed durations that need date context.
- Added month arithmetic helper logic to support correct calendar rebasing when rounding across variable-length months.
- Expanded Temporal.Duration.round tests for year/month rounding, mixed units, and error cases without `relativeTo`.

Fixes #320 