### PR TITLE
Validate Temporal.Duration field magnitudes

### DIFF
--- a/tests/built-ins/Temporal/Duration/magnitude-validation.js
+++ b/tests/built-ins/Temporal/Duration/magnitude-validation.js
@@ -1,0 +1,79 @@
+/*---
+description: Temporal.Duration magnitude validation (TC39 §7.5.22)
+features: [Temporal]
+---*/
+
+const isTemporal = typeof Temporal !== "undefined";
+
+describe.runIf(isTemporal)("Temporal.Duration magnitude validation", () => {
+  // Calendar units: absolute value must be < 2^32 (4294967296)
+
+  test("years at 2^32 throws RangeError", () => {
+    expect(() => new Temporal.Duration(4294967296)).toThrow(RangeError);
+  });
+
+  test("years at -(2^32) throws RangeError", () => {
+    expect(() => new Temporal.Duration(-4294967296)).toThrow(RangeError);
+  });
+
+  test("months at 2^32 throws RangeError", () => {
+    expect(() => new Temporal.Duration(0, 4294967296)).toThrow(RangeError);
+  });
+
+  test("weeks at 2^32 throws RangeError", () => {
+    expect(() => new Temporal.Duration(0, 0, 4294967296)).toThrow(RangeError);
+  });
+
+  test("years just below 2^32 is valid", () => {
+    const d = new Temporal.Duration(4294967295);
+    expect(d.years).toBe(4294967295);
+  });
+
+  test("months just below 2^32 is valid", () => {
+    const d = new Temporal.Duration(0, 4294967295);
+    expect(d.months).toBe(4294967295);
+  });
+
+  test("weeks just below 2^32 is valid", () => {
+    const d = new Temporal.Duration(0, 0, 4294967295);
+    expect(d.weeks).toBe(4294967295);
+  });
+
+  test("negative years just above -(2^32) is valid", () => {
+    const d = new Temporal.Duration(-4294967295);
+    expect(d.years).toBe(-4294967295);
+  });
+
+  // Normalized time: |days*86400 + hours*3600 + minutes*60 + seconds + ms*1e-3 + us*1e-6 + ns*1e-9| < 2^53
+
+  test("days producing normalized seconds >= 2^53 throws RangeError", () => {
+    // 2^53 / 86400 ≈ 1.0425e11, so 104251000000 days exceeds the limit
+    expect(() => new Temporal.Duration(0, 0, 0, 104251000000)).toThrow(RangeError);
+  });
+
+  test("hours producing normalized seconds >= 2^53 throws RangeError", () => {
+    // 2^53 / 3600 ≈ 2.502e12
+    expect(() => new Temporal.Duration(0, 0, 0, 0, 2502000000000)).toThrow(RangeError);
+  });
+
+  test("seconds at 2^53 throws RangeError", () => {
+    expect(() => new Temporal.Duration(0, 0, 0, 0, 0, 0, 9007199254740992)).toThrow(RangeError);
+  });
+
+  test("moderate day count is valid", () => {
+    // 1000 days = 86,400,000 normalized seconds, well under 2^53
+    const d = new Temporal.Duration(0, 0, 0, 1000);
+    expect(d.days).toBe(1000);
+  });
+
+  // Validation via Temporal.Duration.from (object form -> DurationFromObject)
+
+  test("from() with object with years >= 2^32 throws RangeError", () => {
+    expect(() => Temporal.Duration.from({ years: 4294967296 })).toThrow(RangeError);
+  });
+
+  test("from() with object with valid years succeeds", () => {
+    const d = Temporal.Duration.from({ years: 100 });
+    expect(d.years).toBe(100);
+  });
+});

--- a/tests/built-ins/Temporal/Duration/magnitude-validation.js
+++ b/tests/built-ins/Temporal/Duration/magnitude-validation.js
@@ -60,6 +60,18 @@ describe.runIf(isTemporal)("Temporal.Duration magnitude validation", () => {
     expect(() => new Temporal.Duration(0, 0, 0, 0, 0, 0, 9007199254740992)).toThrow(RangeError);
   });
 
+  test("negative days producing normalized seconds <= -(2^53) throws RangeError", () => {
+    expect(() => new Temporal.Duration(0, 0, 0, -104251000000)).toThrow(RangeError);
+  });
+
+  test("negative hours producing normalized seconds <= -(2^53) throws RangeError", () => {
+    expect(() => new Temporal.Duration(0, 0, 0, 0, -2502000000000)).toThrow(RangeError);
+  });
+
+  test("negative seconds at -(2^53) throws RangeError", () => {
+    expect(() => new Temporal.Duration(0, 0, 0, 0, 0, 0, -9007199254740992)).toThrow(RangeError);
+  });
+
   test("moderate day count is valid", () => {
     // 1000 days = 86,400,000 normalized seconds, well under 2^53
     const d = new Temporal.Duration(0, 0, 0, 1000);

--- a/units/Goccia.Error.Messages.pas
+++ b/units/Goccia.Error.Messages.pas
@@ -191,6 +191,8 @@ resourcestring
 
   // Temporal prototype errors — Duration
   SErrorDurationMixedSigns = 'Duration fields must not have mixed signs';
+  SErrorDurationCalendarOutOfRange = 'Duration calendar fields (years, months, weeks) must have absolute value less than 2^32';
+  SErrorDurationTimeOutOfRange = 'Duration time fields out of range: normalized seconds must have absolute value less than 2^53';
   SErrorDurationRoundRequiresUnit = 'round() requires at least a smallestUnit or largestUnit';
   SErrorDurationRoundRequiresRelativeTo = 'Duration with years or months requires relativeTo for round()';
   SErrorDurationTotalRequiresUnit = 'total() requires a unit option';

--- a/units/Goccia.Error.Suggestions.pas
+++ b/units/Goccia.Error.Suggestions.pas
@@ -239,6 +239,7 @@ resourcestring
   SSuggestTemporalNoValueOf = 'Temporal objects cannot be implicitly converted; use toString() or compare() instead';
   SSuggestTemporalValidUnits = 'valid units are: year, month, week, day, hour, minute, second, millisecond, microsecond, nanosecond';
   SSuggestTemporalDurationSigns = 'all duration fields must have the same sign (all positive or all negative)';
+  SSuggestTemporalDurationRange = 'calendar units (years, months, weeks) must be < 2^32 and normalized time must be < 2^53 seconds';
   SSuggestTemporalRelativeTo = 'pass a relativeTo option with a PlainDate or ZonedDateTime for calendar-sensitive operations';
   SSuggestTemporalOverflow = 'valid overflow options are "constrain" or "reject"';
   SSuggestTemporalRoundingMode = 'valid modes: ceil, floor, expand, trunc, halfCeil, halfFloor, halfExpand, halfTrunc, halfEven';

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -130,6 +130,7 @@ constructor TGocciaTemporalDurationValue.Create(const AYears, AMonths, AWeeks, A
   AMilliseconds, AMicroseconds, ANanoseconds: Int64);
 var
   HasPositive, HasNegative: Boolean;
+  NormalizedSeconds, V: Double;
 begin
   inherited Create(nil);
   FYears := AYears;
@@ -152,6 +153,22 @@ begin
                  (AMilliseconds < 0) or (AMicroseconds < 0) or (ANanoseconds < 0);
   if HasPositive and HasNegative then
     ThrowRangeError(SErrorDurationMixedSigns, SSuggestTemporalDurationSigns);
+
+  // Validate: calendar unit magnitudes must be < 2^32
+  if (Abs(AYears) >= 4294967296) or (Abs(AMonths) >= 4294967296) or (Abs(AWeeks) >= 4294967296) then
+    ThrowRangeError(SErrorDurationCalendarOutOfRange, SSuggestTemporalDurationRange);
+
+  // Validate: normalized seconds must be < 2^53 (TC39 §7.5.22 step 6-7)
+  // Use implicit Int64->Double assignment to avoid FPC 3.2.2 cast bugs.
+  V := ADays;         NormalizedSeconds := V * 86400;
+  V := AHours;        NormalizedSeconds := NormalizedSeconds + V * 3600;
+  V := AMinutes;      NormalizedSeconds := NormalizedSeconds + V * 60;
+  V := ASeconds;      NormalizedSeconds := NormalizedSeconds + V;
+  V := AMilliseconds; NormalizedSeconds := NormalizedSeconds + V * 1e-3;
+  V := AMicroseconds; NormalizedSeconds := NormalizedSeconds + V * 1e-6;
+  V := ANanoseconds;  NormalizedSeconds := NormalizedSeconds + V * 1e-9;
+  if Abs(NormalizedSeconds) >= 9007199254740992.0 then
+    ThrowRangeError(SErrorDurationTimeOutOfRange, SSuggestTemporalDurationRange);
 
   InitializePrototype;
   if Assigned(FShared) then


### PR DESCRIPTION
## Summary
- Add `Temporal.Duration` magnitude checks for calendar fields so `years`, `months`, and `weeks` reject absolute values at or above `2^32`.
- Add normalized time validation so the combined day/time portion rejects values whose normalized seconds reach `2^53` or more.
- Introduce matching range error messages and suggestions for the new Temporal validation failures.
- Add coverage for constructor and `Temporal.Duration.from()` object-form validation, including boundary cases just below and at the limits.

Fixes #326 