### PR TITLE
Support ZonedDateTime relativeTo in Temporal duration ops

### DIFF
--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -156,4 +156,39 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(rounded.years).toBe(0);
     expect(rounded.months).toBe(18);
   });
+
+  test("round with relativeTo as ZonedDateTime", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    const zdt = Temporal.ZonedDateTime.from("2024-01-01T00:00:00+00:00[UTC]");
+    const rounded = d.round({ smallestUnit: "months", relativeTo: zdt });
+    expect(rounded.years).toBe(1);
+    expect(rounded.months).toBe(6);
+  });
+
+  test("round with relativeTo as ZonedDateTime to days", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 1 });
+    const zdt = Temporal.ZonedDateTime.from("2020-02-29T10:30:00+00:00[UTC]");
+    const rounded = d.round({ smallestUnit: "days", largestUnit: "days", relativeTo: zdt });
+    // 2020-02-29 + 1Y = 2021-02-28 (clamped), + 1M = 2021-03-28 = 393 days
+    expect(rounded.days).toBe(393);
+  });
+
+  test("round with relativeTo as property bag", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    const rounded = d.round({ smallestUnit: "months", relativeTo: { year: 2024, month: 1, day: 1 } });
+    expect(rounded.years).toBe(1);
+    expect(rounded.months).toBe(6);
+  });
+
+  test("round with relativeTo as property bag to days", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 1 });
+    const rounded = d.round({ smallestUnit: "days", largestUnit: "days", relativeTo: { year: 2020, month: 2, day: 29 } });
+    expect(rounded.days).toBe(393);
+  });
+
+  test("round with relativeTo property bag missing fields throws", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    expect(() => d.round({ smallestUnit: "months", relativeTo: { year: 2024, month: 1 } })).toThrow();
+    expect(() => d.round({ smallestUnit: "months", relativeTo: {} })).toThrow();
+  });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -191,4 +191,10 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(() => d.round({ smallestUnit: "months", relativeTo: { year: 2024, month: 1 } })).toThrow();
     expect(() => d.round({ smallestUnit: "months", relativeTo: {} })).toThrow();
   });
+
+  test("round with relativeTo property bag with invalid date throws", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    expect(() => d.round({ smallestUnit: "months", relativeTo: { year: 2024, month: 13, day: 1 } })).toThrow();
+    expect(() => d.round({ smallestUnit: "months", relativeTo: { year: 2024, month: 2, day: 30 } })).toThrow();
+  });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -167,4 +167,10 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     expect(() => d.total({ unit: "days", relativeTo: { year: 2024 } })).toThrow();
     expect(() => d.total({ unit: "days", relativeTo: {} })).toThrow();
   });
+
+  test("total() with relativeTo property bag with invalid date throws", () => {
+    const d = Temporal.Duration.from({ months: 1 });
+    expect(() => d.total({ unit: "days", relativeTo: { year: 2024, month: 13, day: 1 } })).toThrow();
+    expect(() => d.total({ unit: "days", relativeTo: { year: 2024, month: 2, day: 30 } })).toThrow();
+  });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -134,4 +134,37 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     // 2020-02-29 to 2021-03-28 = 393 days
     expect(days).toBe(393);
   });
+
+  test("total() with relativeTo as ZonedDateTime", () => {
+    const d = Temporal.Duration.from({ months: 6 });
+    const zdt = Temporal.ZonedDateTime.from("2024-01-01T00:00:00+00:00[UTC]");
+    const days = d.total({ unit: "days", relativeTo: zdt });
+    // Jan(31) + Feb(29) + Mar(31) + Apr(30) + May(31) + Jun(30) = 182
+    expect(days).toBe(182);
+  });
+
+  test("total() with relativeTo as ZonedDateTime converts to years", () => {
+    const d = Temporal.Duration.from({ years: 2 });
+    const zdt = Temporal.ZonedDateTime.from("2024-01-01T12:00:00+00:00[UTC]");
+    expect(d.total({ unit: "years", relativeTo: zdt })).toBe(2);
+  });
+
+  test("total() with relativeTo as property bag", () => {
+    const d = Temporal.Duration.from({ months: 1 });
+    const days = d.total({ unit: "days", relativeTo: { year: 2024, month: 2, day: 1 } });
+    // Feb 2024 is a leap year = 29 days
+    expect(days).toBe(29);
+  });
+
+  test("total() with relativeTo as property bag converts to months", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    expect(d.total({ unit: "months", relativeTo: { year: 2024, month: 1, day: 1 } })).toBe(18);
+  });
+
+  test("total() with relativeTo property bag missing fields throws", () => {
+    const d = Temporal.Duration.from({ months: 1 });
+    expect(() => d.total({ unit: "days", relativeTo: { year: 2024, month: 2 } })).toThrow();
+    expect(() => d.total({ unit: "days", relativeTo: { year: 2024 } })).toThrow();
+    expect(() => d.total({ unit: "days", relativeTo: {} })).toThrow();
+  });
 });

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -77,13 +77,16 @@ implementation
 uses
   SysUtils,
 
+  Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Temporal.Options,
+  Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.TemporalPlainDate;
+  Goccia.Values.TemporalPlainDate,
+  Goccia.Values.TemporalZonedDateTime;
 
 threadvar
   FShared: TGocciaSharedPrototype;
@@ -95,6 +98,8 @@ begin
     ThrowTypeError(AMethod + ' called on non-Duration', SSuggestTemporalThisType);
   Result := TGocciaTemporalDurationValue(AValue);
 end;
+
+function ParseRelativeTo(const AValue: TGocciaValue; const AMethod: string): TTemporalDateRecord; forward;
 
 function DurationFromObject(const AObj: TGocciaObjectValue): TGocciaTemporalDurationValue;
 
@@ -521,7 +526,6 @@ var
   Increment: Integer;
   HasRelativeTo: Boolean;
   RelDate: TTemporalDateRecord;
-  RelTimeRec: TTemporalTimeRecord;
   TotalNs, Divisor: Int64;
   RemNs, TimeNs: Int64;
   ResultYears, ResultMonths: Int64;
@@ -559,24 +563,8 @@ begin
     RelToArg := OptionsObj.GetProperty('relativeTo');
     if (RelToArg <> nil) and not (RelToArg is TGocciaUndefinedLiteralValue) then
     begin
-      if RelToArg is TGocciaTemporalPlainDateValue then
-      begin
-        RelDate.Year := TGocciaTemporalPlainDateValue(RelToArg).Year;
-        RelDate.Month := TGocciaTemporalPlainDateValue(RelToArg).Month;
-        RelDate.Day := TGocciaTemporalPlainDateValue(RelToArg).Day;
-        HasRelativeTo := True;
-      end
-      else if RelToArg is TGocciaStringLiteralValue then
-      begin
-        if TryParseISODate(TGocciaStringLiteralValue(RelToArg).Value, RelDate) then
-          HasRelativeTo := True
-        else if TryParseISODateTime(TGocciaStringLiteralValue(RelToArg).Value, RelDate, RelTimeRec) then
-          HasRelativeTo := True
-        else
-          ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['relativeTo', 'Duration.prototype.round']), SSuggestTemporalISOFormat);
-      end
-      else
-        ThrowTypeError('relativeTo must be a Temporal.PlainDate or ISO 8601 string', SSuggestTemporalRelativeTo);
+      RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.round');
+      HasRelativeTo := True;
     end;
   end
   else
@@ -911,6 +899,41 @@ begin
       ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs);
 end;
 
+function ZonedDateTimeToDateRecord(const AZdt: TGocciaTemporalZonedDateTimeValue): TTemporalDateRecord;
+var
+  OffsetSeconds: Integer;
+  LocalEpochMs, EpochDays, RemainingMs: Int64;
+begin
+  OffsetSeconds := GetUtcOffsetSeconds(AZdt.TimeZone, AZdt.EpochMilliseconds div 1000);
+  LocalEpochMs := AZdt.EpochMilliseconds + Int64(OffsetSeconds) * 1000;
+  EpochDays := LocalEpochMs div 86400000;
+  RemainingMs := LocalEpochMs mod 86400000;
+  if RemainingMs < 0 then
+    Dec(EpochDays);
+  Result := EpochDaysToDate(EpochDays);
+end;
+
+function TryParseDateFromPropertyBag(const AObj: TGocciaObjectValue;
+  out ADate: TTemporalDateRecord): Boolean;
+var
+  V: TGocciaValue;
+begin
+  Result := False;
+  V := AObj.GetProperty(PROP_YEAR);
+  if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+    Exit;
+  ADate.Year := Trunc(V.ToNumberLiteral.Value);
+  V := AObj.GetProperty(PROP_MONTH);
+  if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+    Exit;
+  ADate.Month := Trunc(V.ToNumberLiteral.Value);
+  V := AObj.GetProperty(PROP_DAY);
+  if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+    Exit;
+  ADate.Day := Trunc(V.ToNumberLiteral.Value);
+  Result := True;
+end;
+
 function ParseRelativeTo(const AValue: TGocciaValue; const AMethod: string): TTemporalDateRecord;
 var
   DateRec: TTemporalDateRecord;
@@ -924,6 +947,8 @@ begin
     Result.Month := PlainDate.Month;
     Result.Day := PlainDate.Day;
   end
+  else if AValue is TGocciaTemporalZonedDateTimeValue then
+    Result := ZonedDateTimeToDateRecord(TGocciaTemporalZonedDateTimeValue(AValue))
   else if AValue is TGocciaStringLiteralValue then
   begin
     if not TryParseISODate(TGocciaStringLiteralValue(AValue).Value, DateRec) then
@@ -935,6 +960,12 @@ begin
     end
     else
       Result := DateRec;
+  end
+  else if AValue is TGocciaObjectValue then
+  begin
+    if not TryParseDateFromPropertyBag(TGocciaObjectValue(AValue), DateRec) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
+    Result := DateRec;
   end
   else
     ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);

--- a/units/Goccia.Values.TemporalDuration.pas
+++ b/units/Goccia.Values.TemporalDuration.pas
@@ -931,6 +931,8 @@ begin
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
     Exit;
   ADate.Day := Trunc(V.ToNumberLiteral.Value);
+  if not IsValidDate(ADate.Year, ADate.Month, ADate.Day) then
+    Exit;
   Result := True;
 end;
 


### PR DESCRIPTION
## Summary
- Added `Temporal.ZonedDateTime` support for `Duration.prototype.round()` and `Duration.prototype.total()` via `relativeTo`.
- Added property-bag `relativeTo` parsing for date-only inputs, including validation when required fields are missing.
- Updated Temporal duration tests to cover ZonedDateTime, property-bag, and invalid `relativeTo` cases.

Fixes #325 