### PR TITLE
Handle Infinity in Number parsing

### DIFF
--- a/tests/built-ins/Number/parseFloat.js
+++ b/tests/built-ins/Number/parseFloat.js
@@ -24,4 +24,11 @@ describe("Number.parseFloat", () => {
   test("returns NaN for non-parseable strings", () => {
     expect(Number.isNaN(Number.parseFloat("abc"))).toBe(true);
   });
+
+  test("parses Infinity", () => {
+    expect(Number.parseFloat("Infinity")).toBe(Infinity);
+    expect(Number.parseFloat("+Infinity")).toBe(Infinity);
+    expect(Number.parseFloat("-Infinity")).toBe(-Infinity);
+    expect(Number.parseFloat("  Infinity  ")).toBe(Infinity);
+  });
 });

--- a/tests/built-ins/Number/parseInt.js
+++ b/tests/built-ins/Number/parseInt.js
@@ -56,4 +56,10 @@ describe("Number.parseInt", () => {
   test("leading plus sign", () => {
     expect(Number.parseInt("+42")).toBe(42);
   });
+
+  test("Infinity returns NaN", () => {
+    expect(Number.isNaN(Number.parseInt("Infinity"))).toBe(true);
+    expect(Number.isNaN(Number.parseInt("-Infinity"))).toBe(true);
+    expect(Number.isNaN(Number.parseInt("+Infinity"))).toBe(true);
+  });
 });

--- a/units/Goccia.Builtins.GlobalNumber.pas
+++ b/units/Goccia.Builtins.GlobalNumber.pas
@@ -222,9 +222,19 @@ begin
     Inc(I);
   end;
 
+  // Step 3b: Check for "Infinity" literal (StrDecimalLiteral :: Infinity)
+  if Copy(InputStr, I, 8) = 'Infinity' then
+  begin
+    if Sign = -1 then
+      Result := TGocciaNumberLiteralValue.NegativeInfinityValue
+    else
+      Result := TGocciaNumberLiteralValue.InfinityValue;
+    Exit;
+  end;
+
   IntegerPart := 0;
 
-  // Step 3b: Parse DecimalDigits (integer part)
+  // Step 3c: Parse DecimalDigits (integer part)
   while I <= Length(InputStr) do
   begin
     C := InputStr[I];
@@ -241,7 +251,7 @@ begin
   FractionalPart := 0;
   FractionDivisor := 1;
 
-  // Step 3c: Parse optional '.' DecimalDigits (fractional part)
+  // Step 3d: Parse optional '.' DecimalDigits (fractional part)
   if (I <= Length(InputStr)) and (InputStr[I] = '.') then
   begin
     Inc(I);


### PR DESCRIPTION
## Summary
- Added `Number.parseFloat` coverage for `Infinity`, signed infinity, and surrounding whitespace.
- Added `Number.parseInt` coverage to verify `Infinity` forms still return `NaN`.
- Updated the number parsing implementation to recognize the `Infinity` literal during decimal parsing.