### PR TITLE
Suppress progress output in structured and worker paths

### DIFF
--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -462,12 +462,14 @@ begin
   except
     on E: TGocciaError do
     begin
-      WriteLn(StdErr, E.GetDetailedMessage(IsColorTerminal));
+      if not GIsWorkerThread then
+        WriteLn(StdErr, E.GetDetailedMessage(IsColorTerminal));
       MakeErrorFileResult(AFileName, E.GetDetailedMessage, AReporter);
     end;
     on E: TGocciaThrowValue do
     begin
-      WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal, E.Suggestion));
+      if not GIsWorkerThread then
+        WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal, E.Suggestion));
       MakeErrorFileResult(AFileName,
         FormatThrowDetail(E.Value, AFileName, ASource, False, E.Suggestion), AReporter);
     end;
@@ -580,18 +582,21 @@ begin
   except
     on E: TGocciaError do
     begin
-      WriteLn(StdErr, E.GetDetailedMessage(IsColorTerminal));
+      if not GIsWorkerThread then
+        WriteLn(StdErr, E.GetDetailedMessage(IsColorTerminal));
       MakeErrorFileResult(AFileName, E.GetDetailedMessage, AReporter);
     end;
     on E: TGocciaThrowValue do
     begin
-      WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal, E.Suggestion));
+      if not GIsWorkerThread then
+        WriteLn(StdErr, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal, E.Suggestion));
       MakeErrorFileResult(AFileName,
         FormatThrowDetail(E.Value, AFileName, ASource, False, E.Suggestion), AReporter);
     end;
     on E: EGocciaBytecodeThrow do
     begin
-      WriteLn(StdErr, FormatThrowDetail(E.ThrownValue, AFileName, ASource, IsColorTerminal));
+      if not GIsWorkerThread then
+        WriteLn(StdErr, FormatThrowDetail(E.ThrownValue, AFileName, ASource, IsColorTerminal));
       MakeErrorFileResult(AFileName,
         FormatThrowDetail(E.ThrownValue, AFileName, ASource, False), AReporter);
     end;
@@ -714,7 +719,7 @@ begin
         Files.Add(APaths[P])
       else
       begin
-        WriteLn('Error: Path not found: ', APaths[P]);
+        WriteLn(StdErr, 'Error: Path not found: ', APaths[P]);
         ExitCode := 1;
         Exit;
       end;
@@ -722,11 +727,14 @@ begin
 
     JobCount := GetJobCount(Files.Count);
 
-    if JobCount > 1 then
-      WriteLn(SysUtils.Format('Running %d files with %d workers',
-        [Files.Count, JobCount]))
-    else if AShowProgress then
-      WriteLn(SysUtils.Format('Running %d files', [Files.Count]));
+    if AShowProgress then
+    begin
+      if JobCount > 1 then
+        WriteLn(SysUtils.Format('Running %d files with %d workers',
+          [Files.Count, JobCount]))
+      else
+        WriteLn(SysUtils.Format('Running %d files', [Files.Count]));
+    end;
 
     if JobCount > 1 then
     begin
@@ -850,6 +858,16 @@ begin
     if FOutputFile.Present then
       Reports[ReportCount - 1].OutputFile := FOutputFile.Value;
   end;
+
+  // Suppress progress when structured output (JSON/CSV) goes to stdout so
+  // that human-readable status messages do not corrupt the output document.
+  if ShowProgress then
+    for I := 0 to Length(Reports) - 1 do
+      if (Reports[I].Format in [brfJSON, brfCSV]) and (Reports[I].OutputFile = '') then
+      begin
+        ShowProgress := False;
+        Break;
+      end;
 
   if APaths.Count = 0 then
     RunBenchmarksFromStdin(Reports, Mode, ShowProgress)

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -63,6 +63,7 @@ type
     FInlineGlobals: TGocciaRepeatableOption;
     FLastPaths: TStringList;
 
+    function IsJsonOutput: Boolean;
     function ParseSource(const ASource: TStringList; const AFileName: string;
       const APreprocessors: TGocciaPreprocessors; const ASuppressWarnings: Boolean;
       out ALexTimeNanoseconds, AParseTimeNanoseconds: Int64;
@@ -120,6 +121,11 @@ begin
     'Inject globals from a JSON/JSON5/TOML/YAML file or a module with named exports');
   FInlineGlobals := AddRepeatable('global',
     'Inject a single global; value is parsed as JSON or kept as a string');
+end;
+
+function TScriptLoaderApp.IsJsonOutput: Boolean;
+begin
+  Result := FOutputPath.Present and (FOutputPath.Value = 'json');
 end;
 
 { TScriptLoaderApp - Validate }
@@ -234,7 +240,7 @@ begin
   ASourceMap.FileName := ExtractFileName(AFileName);
   ASourceMap.SetSourcePath(0, ExtractFileName(AFileName));
   ASourceMap.SaveToFile(MapOutputPath);
-  if not (FOutputPath.Present and (FOutputPath.Value = 'json')) then
+  if not IsJsonOutput then
     WriteLn(SysUtils.Format('  Source map written to %s', [MapOutputPath]));
 end;
 
@@ -245,7 +251,7 @@ begin
     Exit;
 
   AConsole.Enabled := (not FSilent.Present) and (not GIsWorkerThread);
-  if (FOutputPath.Present and (FOutputPath.Value = 'json')) and not FSilent.Present then
+  if IsJsonOutput and not FSilent.Present then
     AConsole.OutputLines := AOutputLines
   else
     AConsole.OutputLines := nil;
@@ -322,7 +328,7 @@ begin
   Engine := CreateEngine(AFileName, ASource);
   try
     Engine.SuppressWarnings := GIsWorkerThread or
-      (FOutputPath.Present and (FOutputPath.Value = 'json'));
+      IsJsonOutput;
     ConfigureConsole(Engine.BuiltinConsole, AOutputLines);
     ApplyDataGlobalsToEngine(Engine);
     StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
@@ -371,7 +377,7 @@ begin
       ApplyDataGlobalsToEngine(Engine);
 
       ProgramNode := ParseSource(ASource, AFileName, TGocciaEngine.DefaultPreprocessors,
-        (FOutputPath.Present and (FOutputPath.Value = 'json')), Result.Timing.LexTimeNanoseconds,
+        IsJsonOutput, Result.Timing.LexTimeNanoseconds,
         Result.Timing.ParseTimeNanoseconds, SourceMap);
       try
         WriteSourceMapIfEnabled(SourceMap, AFileName);
@@ -506,7 +512,7 @@ begin
   Report.ResultValue := nil;
 
   OutputLines := nil;
-  if (FOutputPath.Present and (FOutputPath.Value = 'json')) then
+  if IsJsonOutput then
     OutputLines := TStringList.Create;
   try
     StartTime := GetNanoseconds;
@@ -521,7 +527,7 @@ begin
           emBytecode:    Report := ExecuteBytecodeFromSource(ASource, AFileName, OutputLines);
         end;
 
-      if (FOutputPath.Present and (FOutputPath.Value = 'json')) then
+      if IsJsonOutput then
         PrintJSONSuccess(Report, OutputLines)
       else
         PrintHumanReadableResult(AFileName, Report, Extension);
@@ -539,7 +545,7 @@ begin
             Report.Timing.CompileTimeNanoseconds;
         if not GIsWorkerThread then
         begin
-          if (FOutputPath.Present and (FOutputPath.Value = 'json')) then
+          if IsJsonOutput then
             PrintJSONError(E, Report, OutputLines, AFileName)
           else if E is TGocciaError then
             WriteLn(TGocciaError(E).GetDetailedMessage(IsColorTerminal))
@@ -641,7 +647,7 @@ begin
 
   if DirectoryExists(APath) then
   begin
-    if (FOutputPath.Present and (FOutputPath.Value = 'json')) then
+    if IsJsonOutput then
       raise Exception.Create('--output=json does not support directory input.');
 
     Files := FindAllFiles(APath, ScriptExtensions);
@@ -677,7 +683,7 @@ var
 begin
   FLastPaths := APaths;
 
-  if (FOutputPath.Present and (FOutputPath.Value = 'json')) and (APaths.Count > 1) then
+  if IsJsonOutput and (APaths.Count > 1) then
     raise TGocciaParseError.Create('--output=json supports a single input path.');
 
   if FSourceMap.Present and (FSourceMap.ValueOr('') = '') and
@@ -707,7 +713,7 @@ end;
 
 procedure TScriptLoaderApp.HandleError(const AException: Exception);
 begin
-  if (FOutputPath.Present and (FOutputPath.Value = 'json')) then
+  if IsJsonOutput then
     WriteLn(BuildErrorJSON('', ExceptionToScriptLoaderErrorInfo(AException),
       Default(TScriptLoaderTiming)))
   else
@@ -725,7 +731,7 @@ begin
       CoverageOptions.OutputPath.Present) and
      Assigned(TGocciaCoverageTracker.Instance) then
   begin
-    if not (FOutputPath.Present and (FOutputPath.Value = 'json')) then
+    if not IsJsonOutput then
     begin
       PrintCoverageSummary(TGocciaCoverageTracker.Instance);
       if Assigned(FLastPaths) and (FLastPaths.Count = 1) and
@@ -756,7 +762,7 @@ begin
   if (ProfileOpcodes or ProfileFunctions) and
      Assigned(TGocciaProfiler.Instance) then
   begin
-    if not (FOutputPath.Present and (FOutputPath.Value = 'json')) then
+    if not IsJsonOutput then
     begin
       if ProfileOpcodes then
       begin

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -196,7 +196,7 @@ var
 begin
   if APaths.Count = 0 then
   begin
-    WriteLn('Error: No paths specified. Run with --help for usage.');
+    WriteLn(StdErr, 'Error: No paths specified. Run with --help for usage.');
     ExitCode := 1;
     Exit;
   end;
@@ -211,17 +211,20 @@ begin
         Files.Add(APaths[I])
       else
       begin
-        WriteLn('Error: Path not found: ', APaths[I]);
+        WriteLn(StdErr, 'Error: Path not found: ', APaths[I]);
         ExitCode := 1;
         Exit;
       end;
     end;
 
-    if GetJobCount(Files.Count) > 1 then
-      WriteLn(SysUtils.Format('Running %d files with %d workers',
-        [Files.Count, GetJobCount(Files.Count)]))
-    else if not FNoProgress.Present then
-      WriteLn(SysUtils.Format('Running %d files', [Files.Count]));
+    if not FNoProgress.Present then
+    begin
+      if GetJobCount(Files.Count) > 1 then
+        WriteLn(SysUtils.Format('Running %d files with %d workers',
+          [Files.Count, GetJobCount(Files.Count)]))
+      else
+        WriteLn(SysUtils.Format('Running %d files', [Files.Count]));
+    end;
 
     if Files.Count = 1 then
     begin
@@ -549,9 +552,9 @@ begin
     on E: Exception do
     begin
       if E is TGocciaError then
-        WriteLn(TGocciaError(E).GetDetailedMessage(IsColorTerminal))
+        WriteLn(StdErr, TGocciaError(E).GetDetailedMessage(IsColorTerminal))
       else
-        WriteLn('Fatal error: ', E.Message);
+        WriteLn(StdErr, 'Fatal error: ', E.Message);
       ExitCode := 1;
     end;
   end;
@@ -815,7 +818,7 @@ begin
       WriteLn(SysUtils.Format('[%d/%d] %s', [I + 1, AFiles.Count, AFiles[I]]));
 
     if WorkerData[I].ErrorMessage <> '' then
-      WriteLn(WorkerData[I].ErrorMessage);
+      WriteLn(StdErr, WorkerData[I].ErrorMessage);
 
     PassedCount := PassedCount + WorkerData[I].Passed;
     FailedCount := FailedCount + WorkerData[I].Failed;


### PR DESCRIPTION
## Summary
- Suppressed human-readable progress and error chatter when output must remain machine-readable, especially for JSON/CSV structured report paths.
- Routed error and status messages to `StdErr` in loader, test runner, and benchmark runner code paths that previously wrote to standard output.
- Added a shared JSON-output check in `GocciaScriptLoader` to reduce repeated output-mode conditionals.

Fixes #292 