### PR TITLE
Enable strict types by default for bytecode executor

### DIFF
--- a/source/units/Goccia.Engine.Backend.pas
+++ b/source/units/Goccia.Engine.Backend.pas
@@ -35,6 +35,7 @@ type
     procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
       const AContext: TGocciaEvaluationContext); override;
     procedure ClearTransientCaches; override;
+    function DefaultStrictTypes: Boolean; override;
 
     function CompileToModule(
       const AProgram: TGocciaProgram): TGocciaBytecodeModule;
@@ -173,6 +174,11 @@ procedure TGocciaBytecodeExecutor.ClearTransientCaches;
 begin
   // The Goccia VM executes directly on TGocciaValue and does not maintain
   // bridge-side transient caches that need per-measurement clearing.
+end;
+
+function TGocciaBytecodeExecutor.DefaultStrictTypes: Boolean;
+begin
+  Result := True;
 end;
 
 end.

--- a/source/units/Goccia.Engine.StrictTypes.Test.pas
+++ b/source/units/Goccia.Engine.StrictTypes.Test.pas
@@ -1,0 +1,78 @@
+program Goccia.Engine.StrictTypes.Test;
+
+{$I Goccia.inc}
+
+uses
+  Classes,
+  SysUtils,
+
+  TestingPascalLibrary,
+
+  Goccia.Engine,
+  Goccia.Engine.Backend,
+  Goccia.TestSetup,
+  Goccia.Values.Primitives;
+
+type
+  TEngineStrictTypesTests = class(TTestSuite)
+  private
+    function CreateEmptySource: TStringList;
+    procedure TestDefaultExecutorStrictTypesFalse;
+    procedure TestBytecodeExecutorStrictTypesTrue;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TEngineStrictTypesTests.SetupTests;
+begin
+  Test('Default (interpreter) executor sets StrictTypes to False',
+    TestDefaultExecutorStrictTypesFalse);
+  Test('Bytecode executor sets StrictTypes to True',
+    TestBytecodeExecutorStrictTypesTrue);
+end;
+
+function TEngineStrictTypesTests.CreateEmptySource: TStringList;
+begin
+  Result := TStringList.Create;
+  Result.Text := '';
+end;
+
+procedure TEngineStrictTypesTests.TestDefaultExecutorStrictTypesFalse;
+var
+  Engine: TGocciaEngine;
+  Source: TStringList;
+begin
+  Source := CreateEmptySource;
+  Engine := TGocciaEngine.Create('<strict-test>', Source, []);
+  try
+    Expect<Boolean>(Engine.StrictTypes).ToBe(False);
+  finally
+    Engine.Free;
+    Source.Free;
+  end;
+end;
+
+procedure TEngineStrictTypesTests.TestBytecodeExecutorStrictTypesTrue;
+var
+  Engine: TGocciaEngine;
+  Executor: TGocciaBytecodeExecutor;
+  Source: TStringList;
+begin
+  Source := CreateEmptySource;
+  Executor := TGocciaBytecodeExecutor.Create;
+  Engine := TGocciaEngine.Create('<strict-test>', Source, [], Executor);
+  try
+    Expect<Boolean>(Engine.StrictTypes).ToBe(True);
+  finally
+    Engine.Free;
+    Executor.Free;
+    Source.Free;
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TEngineStrictTypesTests.Create(
+    'Engine StrictTypes'));
+  TestRunnerProgram.Run;
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -586,7 +586,10 @@ begin
 
   FPreprocessors := DefaultPreprocessors;
   FCompatibility := DefaultCompatibility;
-  FStrictTypes := False;
+  if Assigned(FExecutor) then
+    FStrictTypes := FExecutor.DefaultStrictTypes
+  else
+    FStrictTypes := False;
   FShims := TStringList.Create;
 
   FInterpreter := TGocciaInterpreter.Create(AFileName, ASourceLines,

--- a/source/units/Goccia.Executor.pas
+++ b/source/units/Goccia.Executor.pas
@@ -29,6 +29,7 @@ type
     procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
       const AContext: TGocciaEvaluationContext); virtual; abstract;
     procedure ClearTransientCaches; virtual;
+    function DefaultStrictTypes: Boolean; virtual;
 
     property CompileTimeNanoseconds: Int64 read FCompileTimeNanoseconds
       write FCompileTimeNanoseconds;
@@ -49,6 +50,11 @@ end;
 procedure TGocciaExecutor.ClearTransientCaches;
 begin
   // Default: no-op
+end;
+
+function TGocciaExecutor.DefaultStrictTypes: Boolean;
+begin
+  Result := False;
 end;
 
 end.


### PR DESCRIPTION
## Summary
- Add a `DefaultStrictTypes` hook to executors so engine initialization can derive the strict-type default from the active backend.
- Make the bytecode executor opt into strict types by default.
- Preserve the existing `False` default for other executors.
