### PR TITLE
Add native fetch, Headers, and Response support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [Language](docs/language.md) for the complete specification of supported fea
 
 ### Built-in Objects
 
-`console`, `Math`, `JSON`, `JSON5`, `TOML`, `YAML`, `Object`, `Array`, `Number`, `String`, `RegExp`, `Symbol`, `Set`, `Map`, `Promise`, `Temporal`, `Iterator`, `Proxy`, `Reflect`, `ArrayBuffer`, `SharedArrayBuffer`, TypedArrays (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float32Array`, `Float64Array`) with ArrayBuffer and SharedArrayBuffer backing, plus error constructors (`Error`, `TypeError`, `ReferenceError`, `RangeError`, `DOMException`).
+`console`, `Math`, `JSON`, `JSON5`, `TOML`, `YAML`, `Object`, `Array`, `Number`, `String`, `RegExp`, `Symbol`, `Set`, `Map`, `Promise`, `Temporal`, `Iterator`, `Proxy`, `Reflect`, `ArrayBuffer`, `SharedArrayBuffer`, TypedArrays (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float32Array`, `Float64Array`) with ArrayBuffer and SharedArrayBuffer backing, `fetch`, `Headers`, `Response` ([WHATWG Fetch](https://fetch.spec.whatwg.org/) — GET/HEAD only), `URL`, `URLSearchParams`, `TextEncoder`, `TextDecoder`, plus error constructors (`Error`, `TypeError`, `ReferenceError`, `RangeError`, `DOMException`).
 
 See [Built-in Objects](docs/built-ins.md) for the complete API reference.
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -4,7 +4,7 @@
 
 ## Executive Summary
 
-- **Unconditional registration** — Standard built-ins (Console, Math, Object, Array, String, Number, RegExp, JSON, JSON5, JSONL, TOML, YAML, Symbol, Set, Map, Promise, Performance, Temporal, ArrayBuffer, SharedArrayBuffer, TypedArrays, Proxy, Reflect, Iterator, TextEncoder, TextDecoder, URL, URLSearchParams, DisposableStack, AsyncDisposableStack) are always registered
+- **Unconditional registration** — Standard built-ins (Console, Math, Object, Array, String, Number, RegExp, JSON, JSON5, JSONL, TOML, YAML, Symbol, Set, Map, Promise, Performance, Temporal, ArrayBuffer, SharedArrayBuffer, TypedArrays, Proxy, Reflect, Iterator, TextEncoder, TextDecoder, URL, URLSearchParams, fetch, Headers, Response, DisposableStack, AsyncDisposableStack) are always registered
 - **Flag-gated extras** — Only `ggTestAssertions`, `ggBenchmark`, and `ggFFI` use flag-gating for opt-in registration
 - **Adding new built-ins** — See [Adding Built-in Types](adding-built-in-types.md) for the step-by-step recipe
 - **Always-present globals** — `globalThis` and `Goccia` namespace are registered after all built-ins
@@ -13,7 +13,7 @@ GocciaScript provides a set of built-in global objects that mirror JavaScript's 
 
 ## Registration System
 
-Standard built-ins (Console, Math, Object, Array, Number, JSON, JSON5, JSONL, TOML, YAML, Symbol, Set, Map, Promise, Performance, Temporal, ArrayBuffer, Proxy, Reflect) are always registered unconditionally by the engine. There is no flag-gating for these — they are available in every execution context.
+Standard built-ins (Console, Math, Object, Array, Number, JSON, JSON5, JSONL, TOML, YAML, Symbol, Set, Map, Promise, Performance, Temporal, ArrayBuffer, Proxy, Reflect, fetch, Headers, Response) are always registered unconditionally by the engine. There is no flag-gating for these — they are available in every execution context.
 
 Only three built-ins use flag-gated registration via the `TGocciaGlobalBuiltins` enum:
 
@@ -785,6 +785,56 @@ Implements the [WHATWG URL Standard](https://developer.mozilla.org/en-US/docs/We
 Implements the [WHATWG URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). See [MDN URLSearchParams reference](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) for the full API.
 
 **GocciaScript differences:** None -- full standard compliance.
+
+### fetch (`Goccia.Builtins.GlobalFetch.pas`)
+
+Implements a subset of the [WHATWG Fetch Standard](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). Only `GET` and `HEAD` methods are supported; other methods throw `TypeError`.
+
+| Function / Property | Description |
+|---------------------|-------------|
+| `fetch(url, options?)` | Perform an HTTP request, returns `Promise<Response>` |
+
+The `options` object supports `method` (`"GET"` or `"HEAD"`) and `headers` (plain object or `Headers` instance). Redirects (301/302/303/307/308) are followed automatically up to 20 hops. HTTPS requires OpenSSL libraries at runtime.
+
+**GocciaScript differences:** Only `GET` and `HEAD` methods. No `Request` object, `AbortSignal`, streaming body, or CORS. Requests are synchronous internally; the returned Promise is already settled.
+
+### Headers (`Goccia.Values.HeadersValue.pas`)
+
+Implements the [WHATWG Fetch Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) interface.
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `new Headers()` | Create empty headers |
+| `new Headers(object)` | Create from plain object or another `Headers` |
+| `headers.get(name)` | Get header value (case-insensitive), or `null` |
+| `headers.has(name)` | Check if header exists (case-insensitive) |
+| `headers.forEach(callback)` | Iterate entries as `callback(value, name, headers)` |
+| `headers.entries()` | Iterator of `[name, value]` pairs |
+| `headers.keys()` | Iterator of header names |
+| `headers.values()` | Iterator of header values |
+| `headers[Symbol.iterator]()` | Same as `entries()` |
+
+**GocciaScript differences:** Read-only on Response headers. No `append`, `set`, or `delete` mutations.
+
+### Response (`Goccia.Values.ResponseValue.pas`)
+
+Implements the [WHATWG Fetch Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) interface.
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `response.status` | HTTP status code (e.g. `200`) |
+| `response.statusText` | HTTP status text (e.g. `"OK"`) |
+| `response.ok` | `true` if status is 200–299 |
+| `response.url` | Final URL after redirects |
+| `response.headers` | `Headers` object |
+| `response.type` | Always `"basic"` |
+| `response.redirected` | `true` if any redirect was followed |
+| `response.bodyUsed` | `true` after a body method is called |
+| `response.text()` | Returns `Promise<string>` (UTF-8 decoded body) |
+| `response.json()` | Returns `Promise<any>` (parsed JSON body) |
+| `response.arrayBuffer()` | Returns `Promise<ArrayBuffer>` (raw bytes) |
+
+**GocciaScript differences:** No `Response.body` (ReadableStream), `blob()`, `formData()`, or `clone()`. Body is fully buffered. Each body method can only be called once.
 
 ### DisposableStack / AsyncDisposableStack (`Goccia.Builtins.DisposableStack.pas`)
 

--- a/docs/language-tables.md
+++ b/docs/language-tables.md
@@ -83,6 +83,7 @@ APIs from WHATWG and W3C specifications — not part of ECMA-262, but widely exp
 | `TextEncoder` | [WHATWG Encoding §8.3](https://encoding.spec.whatwg.org/#textencoder) | Supported |
 | `TextDecoder` | [WHATWG Encoding §8.2](https://encoding.spec.whatwg.org/#textdecoder) | Supported |
 | `performance.now`, `timeOrigin` | [High Resolution Time](https://w3c.github.io/hr-time/#dom-performance-now) | Supported |
+| `fetch`, `Headers`, `Response` | [WHATWG Fetch](https://fetch.spec.whatwg.org/) | Supported (GET/HEAD only) |
 
 ## TC39 Proposals
 

--- a/scripts/fetch-e2e.sh
+++ b/scripts/fetch-e2e.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# End-to-end CLI tests for fetch().
+# Spins up a local HTTP server, makes real requests, validates responses.
+#
+# Usage: bash tests/cli/fetch-e2e.sh
+# Requires: ./build/GocciaScriptLoader, python3
+
+set -euo pipefail
+
+LOADER="./build/GocciaScriptLoader"
+PASS=0
+FAIL=0
+TMPFILE="/tmp/goccia-fetch-e2e-$$.js"
+SERVER_SCRIPT="/tmp/goccia-fetch-server-$$.py"
+PORT_FILE="/tmp/goccia-fetch-port-$$.txt"
+
+cleanup() {
+  [ -f /tmp/goccia-fetch-server.pid ] && kill "$(cat /tmp/goccia-fetch-server.pid)" 2>/dev/null || true
+  rm -f "$TMPFILE" "$SERVER_SCRIPT" "$PORT_FILE" /tmp/goccia-fetch-server.pid
+}
+trap cleanup EXIT
+
+# --- Write and start local HTTP test server ---
+
+cat > "$SERVER_SCRIPT" << 'PYEOF'
+import http.server, json, sys, os
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_GET(self):
+        if self.path == "/json":
+            body = json.dumps({"url": self.path, "method": "GET"}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path.startswith("/echo-headers"):
+            headers_dict = {k: v for k, v in self.headers.items()}
+            body = json.dumps({"headers": headers_dict}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", "/json")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        elif self.path == "/status/404":
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        elif self.path == "/status/500":
+            self.send_response(500)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        elif self.path == "/text":
+            body = b"hello world"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            body = b"ok"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", "5")
+        self.end_headers()
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+port = server.server_address[1]
+with open(sys.argv[1], "w") as f:
+    f.write(str(port))
+with open("/tmp/goccia-fetch-server.pid", "w") as f:
+    f.write(str(os.getpid()))
+server.serve_forever()
+PYEOF
+
+python3 "$SERVER_SCRIPT" "$PORT_FILE" &
+sleep 0.5
+PORT="$(cat "$PORT_FILE")"
+BASE="http://127.0.0.1:${PORT}"
+
+echo "=== fetch CLI end-to-end tests (server on port $PORT) ==="
+echo ""
+
+run_js() {
+  echo "$1" > "$TMPFILE"
+  "$LOADER" "$TMPFILE" --asi 2>&1
+}
+
+check() {
+  local desc="$1"
+  local expected_exit="$2"
+  local source="$3"
+  shift 3
+  local expected_output="${1:-}"
+
+  set +e
+  actual="$(run_js "$source")"
+  exit_code=$?
+  set -e
+
+  if [ "$exit_code" -ne "$expected_exit" ]; then
+    echo "FAIL: $desc (exit code: expected $expected_exit, got $exit_code)"
+    echo "  output: $actual"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ -n "$expected_output" ]; then
+    if echo "$actual" | grep -qF "$expected_output"; then
+      echo "PASS: $desc"
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL: $desc (output mismatch)"
+      echo "  expected to contain: $expected_output"
+      echo "  actual: $actual"
+      FAIL=$((FAIL + 1))
+    fi
+  else
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# --- GET text ---
+check "GET /text returns 200 with body" 0 "
+const r = await fetch('${BASE}/text')
+const t = await r.text()
+console.log(r.status, r.ok, t)
+" "200 true hello world"
+
+# --- GET JSON ---
+check "Response.json() parses body" 0 "
+const r = await fetch('${BASE}/json')
+const data = await r.json()
+console.log(data.method, data.url)
+" "GET /json"
+
+# --- Custom headers ---
+check "custom headers are sent" 0 "
+const r = await fetch('${BASE}/echo-headers', {
+  headers: { 'X-Goccia-Test': 'hello123' },
+})
+const data = await r.json()
+const val = data.headers['X-Goccia-Test'] || data.headers['x-goccia-test']
+console.log(val)
+" "hello123"
+
+# --- HEAD ---
+check "HEAD returns empty body" 0 "
+const r = await fetch('${BASE}/', { method: 'HEAD' })
+const t = await r.text()
+console.log(r.status, t.length)
+" "200 0"
+
+# --- Response headers ---
+check "response headers.get returns content-type" 0 "
+const r = await fetch('${BASE}/text')
+console.log(r.headers.get('content-type'))
+" "text/plain"
+
+# --- arrayBuffer ---
+check "arrayBuffer() has correct byteLength" 0 "
+const r = await fetch('${BASE}/text')
+const buf = await r.arrayBuffer()
+console.log(buf instanceof ArrayBuffer, buf.byteLength)
+" "true 11"
+
+# --- bodyUsed ---
+check "bodyUsed lifecycle" 0 "
+const r = await fetch('${BASE}/text')
+const before = r.bodyUsed
+await r.text()
+console.log(before, r.bodyUsed)
+" "false true"
+
+# --- Redirect ---
+check "302 redirect is followed" 0 "
+const r = await fetch('${BASE}/redirect')
+const data = await r.json()
+console.log(r.status, r.redirected, data.method)
+" "200 true GET"
+
+# --- Non-200 status ---
+check "404 returns ok=false" 0 "
+const r = await fetch('${BASE}/status/404')
+console.log(r.status, r.ok)
+" "404 false"
+
+check "500 returns ok=false" 0 "
+const r = await fetch('${BASE}/status/500')
+console.log(r.status, r.ok)
+" "500 false"
+
+# --- Method restriction ---
+check "POST is rejected" 1 \
+  "fetch('${BASE}/', { method: 'POST' })" \
+  "TypeError"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/fetch-e2e.sh
+++ b/scripts/fetch-e2e.sh
@@ -13,17 +13,22 @@ PASS=0
 FAIL=0
 TMPFILE="/tmp/goccia-fetch-e2e-$$.js"
 PORT_FILE="/tmp/goccia-fetch-port-$$.txt"
+SERVER_PID=""
 
 cleanup() {
-  [ -f /tmp/goccia-fetch-server.pid ] && kill "$(cat /tmp/goccia-fetch-server.pid)" 2>/dev/null || true
-  rm -f "$TMPFILE" "$PORT_FILE" /tmp/goccia-fetch-server.pid
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  rm -f "$TMPFILE" "$PORT_FILE"
 }
 trap cleanup EXIT
 
 # --- Start test server ---
 
 python3 scripts/fetch_test_server.py "$PORT_FILE" &
-sleep 0.5
+SERVER_PID=$!
+for _ in $(seq 1 50); do
+  [ -s "$PORT_FILE" ] && break
+  sleep 0.1
+done
 PORT="$(cat "$PORT_FILE")"
 BASE="http://127.0.0.1:${PORT}"
 

--- a/scripts/fetch-e2e.sh
+++ b/scripts/fetch-e2e.sh
@@ -3,7 +3,7 @@
 # End-to-end CLI tests for fetch().
 # Spins up a local HTTP server, makes real requests, validates responses.
 #
-# Usage: bash tests/cli/fetch-e2e.sh
+# Usage: bash scripts/fetch-e2e.sh
 # Requires: ./build/GocciaScriptLoader, python3
 
 set -euo pipefail
@@ -12,84 +12,17 @@ LOADER="./build/GocciaScriptLoader"
 PASS=0
 FAIL=0
 TMPFILE="/tmp/goccia-fetch-e2e-$$.js"
-SERVER_SCRIPT="/tmp/goccia-fetch-server-$$.py"
 PORT_FILE="/tmp/goccia-fetch-port-$$.txt"
 
 cleanup() {
   [ -f /tmp/goccia-fetch-server.pid ] && kill "$(cat /tmp/goccia-fetch-server.pid)" 2>/dev/null || true
-  rm -f "$TMPFILE" "$SERVER_SCRIPT" "$PORT_FILE" /tmp/goccia-fetch-server.pid
+  rm -f "$TMPFILE" "$PORT_FILE" /tmp/goccia-fetch-server.pid
 }
 trap cleanup EXIT
 
-# --- Write and start local HTTP test server ---
+# --- Start test server ---
 
-cat > "$SERVER_SCRIPT" << 'PYEOF'
-import http.server, json, sys, os
-
-class Handler(http.server.BaseHTTPRequestHandler):
-    def log_message(self, fmt, *args):
-        pass
-
-    def do_GET(self):
-        if self.path == "/json":
-            body = json.dumps({"url": self.path, "method": "GET"}).encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-        elif self.path.startswith("/echo-headers"):
-            headers_dict = {k: v for k, v in self.headers.items()}
-            body = json.dumps({"headers": headers_dict}).encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-        elif self.path == "/redirect":
-            self.send_response(302)
-            self.send_header("Location", "/json")
-            self.send_header("Content-Length", "0")
-            self.end_headers()
-        elif self.path == "/status/404":
-            self.send_response(404)
-            self.send_header("Content-Length", "0")
-            self.end_headers()
-        elif self.path == "/status/500":
-            self.send_response(500)
-            self.send_header("Content-Length", "0")
-            self.end_headers()
-        elif self.path == "/text":
-            body = b"hello world"
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-        else:
-            body = b"ok"
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-
-    def do_HEAD(self):
-        self.send_response(200)
-        self.send_header("Content-Type", "text/plain")
-        self.send_header("Content-Length", "5")
-        self.end_headers()
-
-server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
-port = server.server_address[1]
-with open(sys.argv[1], "w") as f:
-    f.write(str(port))
-with open("/tmp/goccia-fetch-server.pid", "w") as f:
-    f.write(str(os.getpid()))
-server.serve_forever()
-PYEOF
-
-python3 "$SERVER_SCRIPT" "$PORT_FILE" &
+python3 scripts/fetch_test_server.py "$PORT_FILE" &
 sleep 0.5
 PORT="$(cat "$PORT_FILE")"
 BASE="http://127.0.0.1:${PORT}"

--- a/scripts/fetch_test_server.py
+++ b/scripts/fetch_test_server.py
@@ -1,0 +1,94 @@
+"""Minimal HTTP test server for fetch() end-to-end tests.
+
+Endpoints:
+  GET  /text          — 200 "hello world" (text/plain)
+  GET  /json          — 200 {"url":"/json","method":"GET"} (application/json)
+  GET  /echo-headers  — 200 {"headers":{...}} reflecting request headers
+  GET  /redirect      — 302 → /json
+  GET  /status/<code> — responds with <code> and empty body
+  GET  /              — 200 "ok"
+  HEAD *              — 200 with Content-Length but no body
+
+Usage:
+  python3 scripts/fetch_test_server.py <port-file>
+
+Writes the assigned port to <port-file> and its PID to
+/tmp/goccia-fetch-server.pid, then serves until killed.
+"""
+
+import http.server
+import json
+import os
+import sys
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_GET(self):
+        if self.path == "/json":
+            body = json.dumps({"url": self.path, "method": "GET"}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path.startswith("/echo-headers"):
+            headers_dict = {k: v for k, v in self.headers.items()}
+            body = json.dumps({"headers": headers_dict}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", "/json")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        elif self.path.startswith("/status/"):
+            code = int(self.path.split("/")[-1])
+            self.send_response(code)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        elif self.path == "/text":
+            body = b"hello world"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            body = b"ok"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", "5")
+        self.end_headers()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 fetch_test_server.py <port-file>", file=sys.stderr)
+        sys.exit(1)
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+
+    with open(sys.argv[1], "w") as f:
+        f.write(str(port))
+    with open("/tmp/goccia-fetch-server.pid", "w") as f:
+        f.write(str(os.getpid()))
+
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_test_server.py
+++ b/scripts/fetch_test_server.py
@@ -12,13 +12,11 @@ Endpoints:
 Usage:
   python3 scripts/fetch_test_server.py <port-file>
 
-Writes the assigned port to <port-file> and its PID to
-/tmp/goccia-fetch-server.pid, then serves until killed.
+Writes the assigned port to <port-file>, then serves until killed.
 """
 
 import http.server
 import json
-import os
 import sys
 
 
@@ -48,7 +46,19 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_header("Content-Length", "0")
             self.end_headers()
         elif self.path.startswith("/status/"):
-            code = int(self.path.split("/")[-1])
+            raw_code = self.path.rsplit("/", 1)[-1]
+            try:
+                code = int(raw_code)
+            except ValueError:
+                self.send_response(400)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            if code < 100 or code > 599:
+                self.send_response(400)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
             self.send_response(code)
             self.send_header("Content-Length", "0")
             self.end_headers()
@@ -84,8 +94,6 @@ def main():
 
     with open(sys.argv[1], "w") as f:
         f.write(str(port))
-    with open("/tmp/goccia-fetch-server.pid", "w") as f:
-        f.write(str(os.getpid()))
 
     server.serve_forever()
 

--- a/source/shared/HTTPClient.pas
+++ b/source/shared/HTTPClient.pas
@@ -120,17 +120,17 @@ begin
   // Parse host:port
   if (Length(Rest) > 0) and (Rest[1] = '[') then
   begin
-    // IPv6
+    // IPv6 — strip brackets for DNS resolution
     I := Pos(']', Rest);
     if I > 0 then
     begin
-      Result.Host := Copy(Rest, 1, I);
+      Result.Host := Copy(Rest, 2, I - 2);
       Rest := Copy(Rest, I + 1, Length(Rest));
       if (Length(Rest) > 0) and (Rest[1] = ':') then
         Result.Port := StrToIntDef(Copy(Rest, 2, Length(Rest)), 0);
     end
     else
-      Result.Host := Rest;
+      Result.Host := Copy(Rest, 2, Length(Rest));
   end
   else
   begin
@@ -633,11 +633,13 @@ var
   CurrentURL, Location, HostHeader: string;
   HasUserAgent: Boolean;
   IsHead: Boolean;
+  Method: string;
 begin
   CurrentURL := AURL;
   Redirects := 0;
   Result.Redirected := False;
-  IsHead := (UpperCase(AMethod) = 'HEAD');
+  Method := UpperCase(AMethod);
+  IsHead := (Method = 'HEAD');
 
   while True do
   begin
@@ -656,7 +658,7 @@ begin
         else
           HostHeader := Parsed.Host + ':' + IntToStr(Parsed.Port);
 
-        Request := AnsiString(AMethod + ' ' + Parsed.Path + ' HTTP/1.1' + CRLF);
+        Request := AnsiString(Method + ' ' + Parsed.Path + ' HTTP/1.1' + CRLF);
         Request := Request + AnsiString('Host: ' + HostHeader + CRLF);
         Request := Request + AnsiString('Connection: close' + CRLF);
 
@@ -705,9 +707,12 @@ begin
         else
           CurrentURL := Location;
 
-        // 303: change method to GET
+        // 303: change method to GET per RFC 7231
         if Raw.StatusCode = 303 then
+        begin
+          Method := 'GET';
           IsHead := False;
+        end;
 
         Continue;
       end;

--- a/source/shared/HTTPClient.pas
+++ b/source/shared/HTTPClient.pas
@@ -1,0 +1,742 @@
+unit HTTPClient;
+
+// Minimal HTTP/1.1 client built on raw BSD sockets.
+// Supports GET and HEAD over HTTP and HTTPS (via OpenSSL).
+// Cross-platform: Unix (macOS, Linux) and Windows.
+// Designed for synchronous use today with a path to non-blocking I/O later.
+
+{$I Shared.inc}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  THTTPHeader = record
+    Name: string;
+    Value: string;
+  end;
+
+  THTTPHeaders = array of THTTPHeader;
+
+  THTTPResponse = record
+    StatusCode: Integer;
+    StatusText: string;
+    Headers: THTTPHeaders;
+    Body: TBytes;
+    FinalURL: string;
+    Redirected: Boolean;
+  end;
+
+  EHTTPError = class(Exception);
+
+function HTTPGet(const AURL: string;
+  const AHeaders: THTTPHeaders): THTTPResponse;
+function HTTPHead(const AURL: string;
+  const AHeaders: THTTPHeaders): THTTPResponse;
+
+implementation
+
+uses
+  {$IFDEF UNIX}
+  Sockets, BaseUnix, NetDB,
+  {$ENDIF}
+  {$IFDEF MSWINDOWS}
+  WinSock2,
+  {$ENDIF}
+  OpenSSL;
+
+const
+  MAX_REDIRECTS   = 20;
+  CRLF            = #13#10;
+  RECV_BUF_SIZE   = 8192;
+
+type
+  THTTPParsedURL = record
+    Scheme: string;
+    Host: string;
+    Port: Integer;
+    Path: string;
+  end;
+
+{$IFDEF MSWINDOWS}
+var
+  GWinSockInitialized: Boolean = False;
+
+procedure EnsureWinSockInit;
+var
+  WSAData: TWSAData;
+begin
+  if GWinSockInitialized then Exit;
+  if WSAStartup($0202, WSAData) <> 0 then
+    raise EHTTPError.Create('WSAStartup failed');
+  GWinSockInitialized := True;
+end;
+{$ENDIF}
+
+// ---------------------------------------------------------------------------
+// Minimal URL parsing (self-contained, no engine dependencies)
+// ---------------------------------------------------------------------------
+
+function ParseHTTPURL(const AURL: string): THTTPParsedURL;
+var
+  S, Rest: string;
+  I: Integer;
+begin
+  Result.Scheme := '';
+  Result.Host := '';
+  Result.Port := 0;
+  Result.Path := '/';
+
+  S := AURL;
+
+  // Scheme
+  I := Pos('://', S);
+  if I > 0 then
+  begin
+    Result.Scheme := LowerCase(Copy(S, 1, I - 1));
+    Rest := Copy(S, I + 3, Length(S));
+  end
+  else
+    raise EHTTPError.Create('Invalid URL: missing scheme');
+
+  if (Result.Scheme <> 'http') and (Result.Scheme <> 'https') then
+    raise EHTTPError.Create('Unsupported scheme: ' + Result.Scheme);
+
+  // Split host from path
+  I := Pos('/', Rest);
+  if I > 0 then
+  begin
+    Result.Path := Copy(Rest, I, Length(Rest));
+    Rest := Copy(Rest, 1, I - 1);
+  end;
+
+  // Strip userinfo if present
+  I := Pos('@', Rest);
+  if I > 0 then
+    Rest := Copy(Rest, I + 1, Length(Rest));
+
+  // Parse host:port
+  if (Length(Rest) > 0) and (Rest[1] = '[') then
+  begin
+    // IPv6
+    I := Pos(']', Rest);
+    if I > 0 then
+    begin
+      Result.Host := Copy(Rest, 1, I);
+      Rest := Copy(Rest, I + 1, Length(Rest));
+      if (Length(Rest) > 0) and (Rest[1] = ':') then
+        Result.Port := StrToIntDef(Copy(Rest, 2, Length(Rest)), 0);
+    end
+    else
+      Result.Host := Rest;
+  end
+  else
+  begin
+    I := Pos(':', Rest);
+    if I > 0 then
+    begin
+      Result.Host := Copy(Rest, 1, I - 1);
+      Result.Port := StrToIntDef(Copy(Rest, I + 1, Length(Rest)), 0);
+    end
+    else
+      Result.Host := Rest;
+  end;
+
+  if Result.Host = '' then
+    raise EHTTPError.Create('Invalid URL: empty host');
+
+  // Default ports
+  if Result.Port = 0 then
+  begin
+    if Result.Scheme = 'https' then
+      Result.Port := 443
+    else
+      Result.Port := 80;
+  end;
+
+  if Result.Path = '' then
+    Result.Path := '/';
+end;
+
+// ---------------------------------------------------------------------------
+// Socket connect (cross-platform)
+// ---------------------------------------------------------------------------
+
+{$IFDEF UNIX}
+function ConnectSocket(const AHost: string; const APort: Integer): TSocket;
+var
+  SockAddr: TInetSockAddr;
+  HostEntry: THostEntry;
+  Addr: in_addr;
+begin
+  // Try as numeric IP first
+  Addr := StrToNetAddr(AHost);
+  if Addr.s_addr = 0 then
+  begin
+    // DNS lookup via netdb
+    if not ResolveHostByName(AHost, HostEntry) then
+      raise EHTTPError.CreateFmt('Failed to resolve host: %s', [AHost]);
+    Addr := HostEntry.Addr;
+  end;
+
+  Result := fpSocket(AF_INET, SOCK_STREAM, 0);
+  if Result < 0 then
+    raise EHTTPError.Create('Failed to create socket');
+
+  FillChar(SockAddr, SizeOf(SockAddr), 0);
+  SockAddr.sin_family := AF_INET;
+  SockAddr.sin_port := htons(APort);
+  SockAddr.sin_addr := Addr;
+
+  if fpConnect(Result, @SockAddr, SizeOf(SockAddr)) <> 0 then
+  begin
+    CloseSocket(Result);
+    raise EHTTPError.CreateFmt('Failed to connect to %s:%d', [AHost, APort]);
+  end;
+end;
+{$ENDIF}
+
+{$IFDEF MSWINDOWS}
+function ConnectSocket(const AHost: string; const APort: Integer): TSocket;
+var
+  Hints, Res, Cur: PAddrInfo;
+  PortStr: AnsiString;
+  Sock: TSocket;
+begin
+  EnsureWinSockInit;
+
+  FillChar(Hints, SizeOf(Hints), 0);
+  New(Hints);
+  try
+    FillChar(Hints^, SizeOf(TAddrInfo), 0);
+    Hints^.ai_family := AF_INET;
+    Hints^.ai_socktype := SOCK_STREAM;
+    Hints^.ai_protocol := IPPROTO_TCP;
+    PortStr := AnsiString(IntToStr(APort));
+    Res := nil;
+
+    if getaddrinfo(PAnsiChar(AnsiString(AHost)), PAnsiChar(PortStr),
+                   Hints, @Res) <> 0 then
+      raise EHTTPError.CreateFmt('Failed to resolve host: %s', [AHost]);
+  finally
+    Dispose(Hints);
+  end;
+
+  try
+    Cur := Res;
+    Sock := INVALID_SOCKET;
+    while Assigned(Cur) do
+    begin
+      Sock := WinSock2.socket(Cur^.ai_family, Cur^.ai_socktype,
+                               Cur^.ai_protocol);
+      if Sock = INVALID_SOCKET then
+      begin
+        Cur := Cur^.ai_next;
+        Continue;
+      end;
+
+      if WinSock2.connect(Sock, Cur^.ai_addr, Cur^.ai_addrlen) = 0 then
+        Break;
+
+      WinSock2.closesocket(Sock);
+      Sock := INVALID_SOCKET;
+      Cur := Cur^.ai_next;
+    end;
+
+    if Sock = INVALID_SOCKET then
+      raise EHTTPError.CreateFmt('Failed to connect to %s:%d', [AHost, APort]);
+
+    Result := Sock;
+  finally
+    freeaddrinfo(Res);
+  end;
+end;
+{$ENDIF}
+
+// ---------------------------------------------------------------------------
+// Platform-neutral socket I/O wrappers
+// ---------------------------------------------------------------------------
+
+function SocketSend(const ASock: TSocket; const ABuf: Pointer;
+  const ALen: Integer): Integer; inline;
+begin
+  {$IFDEF UNIX}
+  Result := fpSend(ASock, ABuf, ALen, 0);
+  {$ENDIF}
+  {$IFDEF MSWINDOWS}
+  Result := WinSock2.send(ASock, ABuf^, ALen, 0);
+  {$ENDIF}
+end;
+
+function SocketRecv(const ASock: TSocket; const ABuf: Pointer;
+  const ALen: Integer): Integer; inline;
+begin
+  {$IFDEF UNIX}
+  Result := fpRecv(ASock, ABuf, ALen, 0);
+  {$ENDIF}
+  {$IFDEF MSWINDOWS}
+  Result := WinSock2.recv(ASock, ABuf^, ALen, 0);
+  {$ENDIF}
+end;
+
+procedure SocketClose(const ASock: TSocket); inline;
+begin
+  {$IFDEF UNIX}
+  CloseSocket(ASock);
+  {$ENDIF}
+  {$IFDEF MSWINDOWS}
+  WinSock2.closesocket(ASock);
+  {$ENDIF}
+end;
+
+// ---------------------------------------------------------------------------
+// SSL wrapper
+// ---------------------------------------------------------------------------
+
+type
+  TSSLConnection = record
+    Context: PSSL_CTX;
+    SSL: PSSL;
+    Active: Boolean;
+  end;
+
+function InitSSL(const ASock: TSocket; const AHost: string): TSSLConnection;
+begin
+  Result.Active := False;
+  Result.Context := nil;
+  Result.SSL := nil;
+
+  if not IsSSLloaded then
+  begin
+    if not InitSSLInterface then
+      raise EHTTPError.Create('HTTPS requires OpenSSL but it could not be loaded');
+  end;
+
+  Result.Context := SslCtxNew(SslMethodTLSV1_2);
+  if not Assigned(Result.Context) then
+    raise EHTTPError.Create('Failed to create SSL context');
+
+  Result.SSL := SslNew(Result.Context);
+  if not Assigned(Result.SSL) then
+  begin
+    SslCtxFree(Result.Context);
+    raise EHTTPError.Create('Failed to create SSL session');
+  end;
+
+  // Set SNI hostname via SSL_ctrl
+  SslCtrl(Result.SSL, SSL_CTRL_SET_TLSEXT_HOSTNAME,
+    TLSEXT_NAMETYPE_host_name, PAnsiChar(AnsiString(AHost)));
+
+  SslSetFd(Result.SSL, ASock);
+  if SslConnect(Result.SSL) <= 0 then
+  begin
+    SslFree(Result.SSL);
+    SslCtxFree(Result.Context);
+    raise EHTTPError.Create('SSL handshake failed');
+  end;
+
+  Result.Active := True;
+end;
+
+procedure FreeSSL(var AConn: TSSLConnection);
+begin
+  if AConn.Active then
+  begin
+    SslShutdown(AConn.SSL);
+    SslFree(AConn.SSL);
+    SslCtxFree(AConn.Context);
+    AConn.Active := False;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// Send / Receive wrappers (unified SSL + plain)
+// ---------------------------------------------------------------------------
+
+procedure SendAll(const ASock: TSocket; const ASSL: TSSLConnection;
+  const AData: AnsiString);
+var
+  Sent, Total, Len, N: Integer;
+begin
+  Total := Length(AData);
+  Sent := 0;
+  while Sent < Total do
+  begin
+    Len := Total - Sent;
+    if ASSL.Active then
+      N := SslWrite(ASSL.SSL, @AData[Sent + 1], Len)
+    else
+      N := SocketSend(ASock, @AData[Sent + 1], Len);
+    if N <= 0 then
+      raise EHTTPError.Create('Send failed');
+    Inc(Sent, N);
+  end;
+end;
+
+function RecvBytes(const ASock: TSocket; const ASSL: TSSLConnection;
+  var ABuf: array of Byte; const ALen: Integer): Integer;
+begin
+  if ASSL.Active then
+    Result := SslRead(ASSL.SSL, @ABuf[0], ALen)
+  else
+    Result := SocketRecv(ASock, @ABuf[0], ALen);
+end;
+
+// ---------------------------------------------------------------------------
+// HTTP response parsing
+// ---------------------------------------------------------------------------
+
+type
+  TRawHTTPResponse = record
+    StatusCode: Integer;
+    StatusText: string;
+    Headers: THTTPHeaders;
+    Body: TBytes;
+  end;
+
+function FindHeaderValue(const AHeaders: THTTPHeaders;
+  const AName: string): string;
+var
+  I: Integer;
+  Lower: string;
+begin
+  Result := '';
+  Lower := LowerCase(AName);
+  for I := 0 to High(AHeaders) do
+    if AHeaders[I].Name = Lower then
+    begin
+      Result := AHeaders[I].Value;
+      Exit;
+    end;
+end;
+
+function ReadResponse(const ASock: TSocket; const ASSL: TSSLConnection;
+  const AIsHead: Boolean): TRawHTTPResponse;
+var
+  Buf: array[0..RECV_BUF_SIZE - 1] of Byte;
+  RawHeader: AnsiString;
+  N, HeaderEnd, I, J, ContentLen, ChunkSize: Integer;
+  Line, HeaderBlock: string;
+  Lines: array of string;
+  ColonPos: Integer;
+  TransferEncoding: string;
+  BodyBytes: TBytes;
+  BodyLen: Integer;
+  ChunkBuf: AnsiString;
+  Done: Boolean;
+  Remaining: Integer;
+begin
+  Result.StatusCode := 0;
+  Result.StatusText := '';
+  SetLength(Result.Headers, 0);
+  SetLength(Result.Body, 0);
+
+  // Read until we find the end of headers (CRLFCRLF)
+  RawHeader := '';
+  HeaderEnd := 0;
+  repeat
+    N := RecvBytes(ASock, ASSL, Buf, RECV_BUF_SIZE);
+    if N <= 0 then Break;
+    RawHeader := RawHeader + Copy(PAnsiChar(@Buf[0]), 1, N);
+    HeaderEnd := Pos(CRLF + CRLF, string(RawHeader));
+  until HeaderEnd > 0;
+
+  if HeaderEnd = 0 then
+    raise EHTTPError.Create('Invalid HTTP response: no header terminator');
+
+  // Split headers from any body bytes already received
+  HeaderBlock := Copy(string(RawHeader), 1, HeaderEnd - 1);
+  I := HeaderEnd + 4; // skip CRLFCRLF
+  if I <= Length(RawHeader) then
+  begin
+    SetLength(BodyBytes, Length(RawHeader) - I + 1);
+    Move(RawHeader[I], BodyBytes[0], Length(BodyBytes));
+  end
+  else
+    SetLength(BodyBytes, 0);
+
+  // Parse status line: "HTTP/1.1 200 OK"
+  I := Pos(CRLF, HeaderBlock);
+  if I > 0 then
+    Line := Copy(HeaderBlock, 1, I - 1)
+  else
+    Line := HeaderBlock;
+
+  J := Pos(' ', Line);
+  if J > 0 then
+  begin
+    Delete(Line, 1, J);
+    J := Pos(' ', Line);
+    if J > 0 then
+    begin
+      Result.StatusCode := StrToIntDef(Copy(Line, 1, J - 1), 0);
+      Result.StatusText := Copy(Line, J + 1, Length(Line));
+    end
+    else
+      Result.StatusCode := StrToIntDef(Line, 0);
+  end;
+
+  // Parse header lines
+  HeaderBlock := Copy(HeaderBlock, Pos(CRLF, HeaderBlock) + 2, Length(HeaderBlock));
+  SetLength(Lines, 0);
+  while Length(HeaderBlock) > 0 do
+  begin
+    I := Pos(CRLF, HeaderBlock);
+    if I > 0 then
+    begin
+      SetLength(Lines, Length(Lines) + 1);
+      Lines[High(Lines)] := Copy(HeaderBlock, 1, I - 1);
+      Delete(HeaderBlock, 1, I + 1);
+    end
+    else
+    begin
+      if HeaderBlock <> '' then
+      begin
+        SetLength(Lines, Length(Lines) + 1);
+        Lines[High(Lines)] := HeaderBlock;
+      end;
+      Break;
+    end;
+  end;
+
+  SetLength(Result.Headers, Length(Lines));
+  for I := 0 to High(Lines) do
+  begin
+    ColonPos := Pos(':', Lines[I]);
+    if ColonPos > 0 then
+    begin
+      Result.Headers[I].Name := LowerCase(Trim(Copy(Lines[I], 1, ColonPos - 1)));
+      Result.Headers[I].Value := Trim(Copy(Lines[I], ColonPos + 1, Length(Lines[I])));
+    end
+    else
+    begin
+      Result.Headers[I].Name := LowerCase(Trim(Lines[I]));
+      Result.Headers[I].Value := '';
+    end;
+  end;
+
+  // Don't read body for HEAD requests or 1xx/204/304 responses
+  if AIsHead or (Result.StatusCode div 100 = 1) or
+     (Result.StatusCode = 204) or (Result.StatusCode = 304) then
+    Exit;
+
+  // Read body
+  TransferEncoding := LowerCase(FindHeaderValue(Result.Headers, 'transfer-encoding'));
+
+  if Pos('chunked', TransferEncoding) > 0 then
+  begin
+    // Chunked transfer encoding
+    ChunkBuf := AnsiString(BodyBytes);
+    SetLength(Result.Body, 0);
+    Done := False;
+
+    while not Done do
+    begin
+      while Pos(CRLF, string(ChunkBuf)) = 0 do
+      begin
+        N := RecvBytes(ASock, ASSL, Buf, RECV_BUF_SIZE);
+        if N <= 0 then begin Done := True; Break; end;
+        ChunkBuf := ChunkBuf + Copy(PAnsiChar(@Buf[0]), 1, N);
+      end;
+      if Done then Break;
+
+      I := Pos(CRLF, string(ChunkBuf));
+      Line := Copy(string(ChunkBuf), 1, I - 1);
+      Delete(ChunkBuf, 1, I + 1);
+
+      J := Pos(';', Line);
+      if J > 0 then
+        Line := Copy(Line, 1, J - 1);
+
+      ChunkSize := StrToIntDef('$' + Trim(Line), 0);
+      if ChunkSize = 0 then Break;
+
+      while Length(ChunkBuf) < ChunkSize + 2 do
+      begin
+        N := RecvBytes(ASock, ASSL, Buf, RECV_BUF_SIZE);
+        if N <= 0 then begin Done := True; Break; end;
+        ChunkBuf := ChunkBuf + Copy(PAnsiChar(@Buf[0]), 1, N);
+      end;
+
+      BodyLen := Length(Result.Body);
+      SetLength(Result.Body, BodyLen + ChunkSize);
+      Move(ChunkBuf[1], Result.Body[BodyLen], ChunkSize);
+      Delete(ChunkBuf, 1, ChunkSize + 2);
+    end;
+  end
+  else
+  begin
+    ContentLen := StrToIntDef(FindHeaderValue(Result.Headers, 'content-length'), -1);
+
+    if ContentLen >= 0 then
+    begin
+      SetLength(Result.Body, ContentLen);
+      BodyLen := 0;
+
+      // Copy bytes already read with headers
+      if Length(BodyBytes) > 0 then
+      begin
+        if Length(BodyBytes) >= ContentLen then
+        begin
+          Move(BodyBytes[0], Result.Body[0], ContentLen);
+          BodyLen := ContentLen;
+        end
+        else
+        begin
+          Move(BodyBytes[0], Result.Body[0], Length(BodyBytes));
+          BodyLen := Length(BodyBytes);
+        end;
+      end;
+
+      // Read remaining
+      while BodyLen < ContentLen do
+      begin
+        N := RecvBytes(ASock, ASSL, Buf, RECV_BUF_SIZE);
+        if N <= 0 then Break;
+        Remaining := ContentLen - BodyLen;
+        if N > Remaining then N := Remaining;
+        Move(Buf[0], Result.Body[BodyLen], N);
+        Inc(BodyLen, N);
+      end;
+    end
+    else
+    begin
+      // Read until connection close
+      Result.Body := Copy(BodyBytes);
+      repeat
+        N := RecvBytes(ASock, ASSL, Buf, RECV_BUF_SIZE);
+        if N <= 0 then Break;
+        BodyLen := Length(Result.Body);
+        SetLength(Result.Body, BodyLen + N);
+        Move(Buf[0], Result.Body[BodyLen], N);
+      until False;
+    end;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// Core request logic
+// ---------------------------------------------------------------------------
+
+function DoRequest(const AMethod, AURL: string;
+  const AHeaders: THTTPHeaders;
+  const AMaxRedirects: Integer): THTTPResponse;
+var
+  Parsed: THTTPParsedURL;
+  Sock: TSocket;
+  SSL: TSSLConnection;
+  Request: AnsiString;
+  Raw: TRawHTTPResponse;
+  I, Redirects: Integer;
+  CurrentURL, Location, HostHeader: string;
+  HasUserAgent: Boolean;
+  IsHead: Boolean;
+begin
+  CurrentURL := AURL;
+  Redirects := 0;
+  Result.Redirected := False;
+  IsHead := (UpperCase(AMethod) = 'HEAD');
+
+  while True do
+  begin
+    Parsed := ParseHTTPURL(CurrentURL);
+    SSL.Active := False;
+    Sock := ConnectSocket(Parsed.Host, Parsed.Port);
+    try
+      if Parsed.Scheme = 'https' then
+        SSL := InitSSL(Sock, Parsed.Host);
+
+      try
+        // Build Host header value
+        if ((Parsed.Scheme = 'http') and (Parsed.Port = 80)) or
+           ((Parsed.Scheme = 'https') and (Parsed.Port = 443)) then
+          HostHeader := Parsed.Host
+        else
+          HostHeader := Parsed.Host + ':' + IntToStr(Parsed.Port);
+
+        Request := AnsiString(AMethod + ' ' + Parsed.Path + ' HTTP/1.1' + CRLF);
+        Request := Request + AnsiString('Host: ' + HostHeader + CRLF);
+        Request := Request + AnsiString('Connection: close' + CRLF);
+
+        // Check if user provided User-Agent
+        HasUserAgent := False;
+        for I := 0 to High(AHeaders) do
+          if LowerCase(AHeaders[I].Name) = 'user-agent' then
+            HasUserAgent := True;
+
+        if not HasUserAgent then
+          Request := Request + AnsiString('User-Agent: GocciaScript/1.0' + CRLF);
+
+        // Add custom headers (skip Host since we already set it)
+        for I := 0 to High(AHeaders) do
+        begin
+          if LowerCase(AHeaders[I].Name) = 'host' then Continue;
+          Request := Request + AnsiString(AHeaders[I].Name + ': ' + AHeaders[I].Value + CRLF);
+        end;
+
+        Request := Request + AnsiString(CRLF);
+
+        SendAll(Sock, SSL, Request);
+        Raw := ReadResponse(Sock, SSL, IsHead);
+      finally
+        FreeSSL(SSL);
+      end;
+    finally
+      SocketClose(Sock);
+    end;
+
+    // Handle redirects
+    if (Raw.StatusCode >= 301) and (Raw.StatusCode <= 308) and
+       (Raw.StatusCode <> 304) and (Raw.StatusCode <> 305) then
+    begin
+      Location := FindHeaderValue(Raw.Headers, 'location');
+      if (Location <> '') and (Redirects < AMaxRedirects) then
+      begin
+        Inc(Redirects);
+        Result.Redirected := True;
+
+        // Handle relative URLs
+        if (Length(Location) > 0) and (Location[1] = '/') then
+          CurrentURL := Parsed.Scheme + '://' + HostHeader + Location
+        else if Pos('://', Location) = 0 then
+          CurrentURL := Parsed.Scheme + '://' + HostHeader + '/' + Location
+        else
+          CurrentURL := Location;
+
+        // 303: change method to GET
+        if Raw.StatusCode = 303 then
+          IsHead := False;
+
+        Continue;
+      end;
+    end;
+
+    // No redirect — build final response
+    Result.StatusCode := Raw.StatusCode;
+    Result.StatusText := Raw.StatusText;
+    Result.Headers := Raw.Headers;
+    Result.Body := Raw.Body;
+    Result.FinalURL := CurrentURL;
+    Break;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+function HTTPGet(const AURL: string;
+  const AHeaders: THTTPHeaders): THTTPResponse;
+begin
+  Result := DoRequest('GET', AURL, AHeaders, MAX_REDIRECTS);
+end;
+
+function HTTPHead(const AURL: string;
+  const AHeaders: THTTPHeaders): THTTPResponse;
+begin
+  Result := DoRequest('HEAD', AURL, AHeaders, MAX_REDIRECTS);
+end;
+
+end.

--- a/source/units/Goccia.Builtins.GlobalFetch.pas
+++ b/source/units/Goccia.Builtins.GlobalFetch.pas
@@ -1,0 +1,170 @@
+unit Goccia.Builtins.GlobalFetch;
+
+// Fetch API — global fetch() function and Headers/Response registration
+// https://fetch.spec.whatwg.org/
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Builtins.Base,
+  Goccia.Error.ThrowErrorCallback,
+  Goccia.Scope,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaGlobalFetch = class(TGocciaBuiltin)
+  private
+    function FetchCallback(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AName: string; const AScope: TGocciaScope;
+      const AThrowError: TGocciaThrowErrorCallback);
+  end;
+
+implementation
+
+uses
+  SysUtils,
+
+  HTTPClient,
+
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.HeadersValue,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.PromiseValue,
+  Goccia.Values.ResponseValue,
+  Goccia.Values.URLValue;
+
+{ TGocciaGlobalFetch }
+
+constructor TGocciaGlobalFetch.Create(const AName: string;
+  const AScope: TGocciaScope;
+  const AThrowError: TGocciaThrowErrorCallback);
+begin
+  inherited Create(AName, AScope, AThrowError);
+
+  // Register fetch as a global function
+  AScope.DefineLexicalBinding('fetch',
+    TGocciaNativeFunctionValue.Create(FetchCallback, 'fetch', 1), dtConst);
+end;
+
+function TGocciaGlobalFetch.FetchCallback(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  URLArg, OptionsArg, MethodVal, HeadersVal: TGocciaValue;
+  URLStr, Method: string;
+  RequestHeaders: THTTPHeaders;
+  HTTPResp: THTTPResponse;
+  RespHeaders: TGocciaHeadersValue;
+  RespValue: TGocciaResponseValue;
+  Promise: TGocciaPromiseValue;
+  Obj: TGocciaObjectValue;
+  PropNames: TArray<string>;
+  I: Integer;
+begin
+  // Extract URL
+  if AArgs.Length = 0 then
+    ThrowTypeError(SErrorFetchRequiresURL, SSuggestFetchUsage);
+
+  URLArg := AArgs.GetElement(0);
+  if URLArg is TGocciaURLValue then
+    URLStr := TGocciaURLValue(URLArg).ComputeHref
+  else
+    URLStr := URLArg.ToStringLiteral.Value;
+
+  // Extract options
+  Method := 'GET';
+  SetLength(RequestHeaders, 0);
+
+  if AArgs.Length >= 2 then
+  begin
+    OptionsArg := AArgs.GetElement(1);
+    if (OptionsArg is TGocciaObjectValue) and
+       not (OptionsArg is TGocciaUndefinedLiteralValue) and
+       not (OptionsArg is TGocciaNullLiteralValue) then
+    begin
+      Obj := TGocciaObjectValue(OptionsArg);
+
+      // Read method
+      MethodVal := Obj.GetProperty(PROP_METHOD);
+      if Assigned(MethodVal) and not (MethodVal is TGocciaUndefinedLiteralValue) then
+        Method := UpperCase(MethodVal.ToStringLiteral.Value);
+
+      // Read headers
+      HeadersVal := Obj.GetProperty(PROP_HEADERS);
+      if Assigned(HeadersVal) and not (HeadersVal is TGocciaUndefinedLiteralValue) then
+      begin
+        if HeadersVal is TGocciaHeadersValue then
+        begin
+          SetLength(RequestHeaders, TGocciaHeadersValue(HeadersVal).Entries.Count);
+          for I := 0 to TGocciaHeadersValue(HeadersVal).Entries.Count - 1 do
+          begin
+            RequestHeaders[I].Name := TGocciaHeadersValue(HeadersVal).Entries[I].Name;
+            RequestHeaders[I].Value := TGocciaHeadersValue(HeadersVal).Entries[I].Value;
+          end;
+        end
+        else if HeadersVal is TGocciaObjectValue then
+        begin
+          PropNames := TGocciaObjectValue(HeadersVal).GetAllPropertyNames;
+          SetLength(RequestHeaders, Length(PropNames));
+          for I := 0 to High(PropNames) do
+          begin
+            RequestHeaders[I].Name := LowerCase(PropNames[I]);
+            RequestHeaders[I].Value :=
+              TGocciaObjectValue(HeadersVal).GetProperty(PropNames[I]).ToStringLiteral.Value;
+          end;
+        end;
+      end;
+    end;
+  end;
+
+  // Validate method — only GET and HEAD allowed
+  if (Method <> 'GET') and (Method <> 'HEAD') then
+    ThrowTypeError(Format(SErrorFetchUnsupportedMethod, [Method]),
+      SSuggestFetchUsage);
+
+  // Perform the request
+  Promise := TGocciaPromiseValue.Create;
+  try
+    if Method = 'HEAD' then
+      HTTPResp := HTTPHead(URLStr, RequestHeaders)
+    else
+      HTTPResp := HTTPGet(URLStr, RequestHeaders);
+
+    // Build Headers object from response
+    RespHeaders := TGocciaHeadersValue.Create;
+    RespHeaders.Immutable := True;
+    for I := 0 to High(HTTPResp.Headers) do
+      RespHeaders.AddHeader(HTTPResp.Headers[I].Name, HTTPResp.Headers[I].Value);
+
+    // Build Response object
+    RespValue := TGocciaResponseValue.Create;
+    RespValue.InitFromHTTP(
+      HTTPResp.StatusCode,
+      HTTPResp.StatusText,
+      HTTPResp.FinalURL,
+      RespHeaders,
+      HTTPResp.Body,
+      HTTPResp.Redirected);
+
+    Promise.Resolve(RespValue);
+  except
+    on E: EHTTPError do
+      Promise.Reject(CreateErrorObject('TypeError', E.Message));
+    on E: Exception do
+      Promise.Reject(CreateErrorObject('TypeError', 'fetch failed: ' + E.Message));
+  end;
+
+  Result := Promise;
+end;
+
+end.

--- a/source/units/Goccia.Constants.ConstructorNames.pas
+++ b/source/units/Goccia.Constants.ConstructorNames.pas
@@ -46,6 +46,9 @@ const
   CONSTRUCTOR_ASYNC_DISPOSABLE_STACK = 'AsyncDisposableStack';
   CONSTRUCTOR_SUPPRESSED_ERROR       = 'SuppressedError';
 
+  CONSTRUCTOR_HEADERS  = 'Headers';
+  CONSTRUCTOR_RESPONSE = 'Response';
+
 implementation
 
 end.

--- a/source/units/Goccia.Constants.PropertyNames.pas
+++ b/source/units/Goccia.Constants.PropertyNames.pas
@@ -176,6 +176,18 @@ const
   PROP_PROXY                     = 'proxy';
   PROP_REVOKER_INTERNAL          = '__revoker';
 
+  // Fetch API properties
+  PROP_STATUS              = 'status';
+  PROP_STATUS_TEXT          = 'statusText';
+  PROP_OK                  = 'ok';
+  PROP_HEADERS             = 'headers';
+  PROP_BODY_USED           = 'bodyUsed';
+  PROP_REDIRECTED          = 'redirected';
+  PROP_TEXT                = 'text';
+  PROP_JSON                = 'json';
+  PROP_ARRAY_BUFFER_METHOD = 'arrayBuffer';
+  PROP_METHOD              = 'method';
+
 implementation
 
 end.

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -15,6 +15,7 @@ uses
   Goccia.Builtins.DisposableStack,
   Goccia.Builtins.GlobalArray,
   Goccia.Builtins.GlobalArrayBuffer,
+  Goccia.Builtins.GlobalFetch,
   Goccia.Builtins.GlobalFFI,
   Goccia.Builtins.GlobalMap,
   Goccia.Builtins.GlobalNumber,
@@ -153,6 +154,7 @@ type
     FBuiltinTextDecoder: TGocciaGlobalTextDecoder;
     FBuiltinURL: TGocciaGlobalURL;
     FBuiltinURLSearchParams: TGocciaGlobalURLSearchParams;
+    FBuiltinFetch: TGocciaGlobalFetch;
     FBuiltinDisposableStack: TGocciaBuiltinDisposableStack;
     FPreviousExceptionMask: TFPUExceptionMask;
     FSuppressWarnings: Boolean;
@@ -287,11 +289,13 @@ uses
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.BooleanObjectValue,
+  Goccia.Values.HeadersValue,
   Goccia.Values.MapValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.NumberObjectValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
+  Goccia.Values.ResponseValue,
   Goccia.Values.SetValue,
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.StringObjectValue,
@@ -645,6 +649,7 @@ begin
     FBuiltinTextDecoder.Free;
     FBuiltinURL.Free;
     FBuiltinURLSearchParams.Free;
+    FBuiltinFetch.Free;
     FBuiltinDisposableStack.Free;
     ClearImportMetaCache;
     FLastSourceMap.Free;
@@ -700,6 +705,7 @@ begin
   FBuiltinURL := TGocciaGlobalURL.Create(CONSTRUCTOR_URL, Scope, ThrowError);
   FBuiltinURLSearchParams := TGocciaGlobalURLSearchParams.Create(
     CONSTRUCTOR_URL_SEARCH_PARAMS, Scope, ThrowError);
+  FBuiltinFetch := TGocciaGlobalFetch.Create('Fetch', Scope, ThrowError);
 
   // Special-purpose built-ins: flag-gated.
   if ggTestAssertions in FGlobals then
@@ -778,6 +784,16 @@ end;
 procedure ExposeURLSearchParamsPrototype(const AConstructor: TGocciaValue);
 begin
   TGocciaURLSearchParamsValue.ExposePrototype(AConstructor);
+end;
+
+procedure ExposeHeadersPrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaHeadersValue.ExposePrototype(AConstructor);
+end;
+
+procedure ExposeResponsePrototype(const AConstructor: TGocciaValue);
+begin
+  TGocciaResponseValue.ExposePrototype(AConstructor);
 end;
 
 procedure TGocciaEngine.RegisterBuiltinConstructors;
@@ -883,6 +899,26 @@ begin
   TypeDef.AddSpeciesGetter := False;
   RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
   URLSearchParamsConstructor := TGocciaURLSearchParamsClassValue(GenericConstructor);
+
+  TypeDef.ConstructorName := CONSTRUCTOR_HEADERS;
+  TypeDef.Kind := gtdkNativeInstanceType;
+  TypeDef.ClassValueClass := TGocciaHeadersClassValue;
+  TypeDef.ExposePrototype := @ExposeHeadersPrototype;
+  TypeDef.PrototypeProvider := nil;
+  TypeDef.StaticSource := nil;
+  TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+  TypeDef.AddSpeciesGetter := False;
+  RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
+
+  TypeDef.ConstructorName := CONSTRUCTOR_RESPONSE;
+  TypeDef.Kind := gtdkNativeInstanceType;
+  TypeDef.ClassValueClass := TGocciaResponseClassValue;
+  TypeDef.ExposePrototype := @ExposeResponsePrototype;
+  TypeDef.PrototypeProvider := nil;
+  TypeDef.StaticSource := nil;
+  TypeDef.PrototypeParent := ObjectConstructor.Prototype;
+  TypeDef.AddSpeciesGetter := False;
+  RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
 
   ArrayBufferConstructor := TGocciaArrayBufferClassValue.Create(CONSTRUCTOR_ARRAY_BUFFER, nil);
   TGocciaArrayBufferValue.ExposePrototype(ArrayBufferConstructor);

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -677,6 +677,14 @@ resourcestring
   SErrorSemverInvalidIncrement = 'invalid increment';
   SErrorJSON5StringifyError = 'JSON5.stringify error: %s';
 
+  // Fetch API
+  SErrorFetchRequiresURL = 'fetch requires a URL argument';
+  SErrorFetchUnsupportedMethod = 'fetch does not support method ''%s''; only GET and HEAD are allowed';
+  SErrorHeadersNotHeaders = 'Headers method called on non-Headers object';
+  SErrorHeadersForEachNotCallable = 'Headers.prototype.forEach: callback is not a function';
+  SErrorResponseNotResponse = 'Response method called on non-Response object';
+  SErrorResponseBodyAlreadyUsed = 'body has already been consumed';
+
 implementation
 
 end.

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -350,6 +350,11 @@ resourcestring
   // Runtime errors — read-only property
   SSuggestReadOnlyProperty = 'the property is read-only and cannot be assigned to';
 
+  // Fetch API
+  SSuggestFetchUsage = 'use fetch(url) or fetch(url, { method: "GET" })';
+  SSuggestHeadersThisType = 'Headers prototype methods must be called on a Headers object';
+  SSuggestResponseThisType = 'Response prototype methods must be called on a Response object';
+
 implementation
 
 end.

--- a/source/units/Goccia.Spec.pas
+++ b/source/units/Goccia.Spec.pas
@@ -195,7 +195,7 @@ const
   // ---------------------------------------------------------------------------
   // WHATWG / W3C Web Platform APIs
   // ---------------------------------------------------------------------------
-  WHATWG_FEATURES: array[0..9] of TGocciaFeatureEntry = (
+  WHATWG_FEATURES: array[0..12] of TGocciaFeatureEntry = (
     (Name: 'console';           Link: 'https://console.spec.whatwg.org/'),
     (Name: 'structuredClone';   Link: 'https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone'),
     (Name: 'DOMException';      Link: 'https://webidl.spec.whatwg.org/#idl-DOMException'),
@@ -205,7 +205,10 @@ const
     (Name: 'URLSearchParams';   Link: 'https://url.spec.whatwg.org/#urlsearchparams'),
     (Name: 'TextEncoder';       Link: 'https://encoding.spec.whatwg.org/#textencoder'),
     (Name: 'TextDecoder';       Link: 'https://encoding.spec.whatwg.org/#textdecoder'),
-    (Name: 'Performance';       Link: 'https://w3c.github.io/hr-time/#dom-performance-now')
+    (Name: 'Performance';       Link: 'https://w3c.github.io/hr-time/#dom-performance-now'),
+    (Name: 'fetch';             Link: 'https://fetch.spec.whatwg.org/#fetch-method'),
+    (Name: 'Headers';           Link: 'https://fetch.spec.whatwg.org/#headers-class'),
+    (Name: 'Response';          Link: 'https://fetch.spec.whatwg.org/#response-class')
   );
 
   // ---------------------------------------------------------------------------

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -189,6 +189,14 @@ type
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
   end;
 
+  TGocciaHeadersClassValue = class(TGocciaClassValue)
+    function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+  end;
+
+  TGocciaResponseClassValue = class(TGocciaClassValue)
+    function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+  end;
+
   TGocciaInstanceValue = class(TGocciaObjectValue)
   private
     FClass: TGocciaClassValue;
@@ -232,8 +240,10 @@ uses
   Goccia.Values.AutoAccessor,
   Goccia.Values.ClassHelper,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.HeadersValue,
   Goccia.Values.MapValue,
   Goccia.Values.NativeFunction,
+  Goccia.Values.ResponseValue,
   Goccia.Values.SetValue,
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.TextDecoderValue,
@@ -1113,6 +1123,20 @@ end;
 function TGocciaURLSearchParamsClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
 begin
   Result := TGocciaURLSearchParamsValue.Create(nil);
+end;
+
+{ TGocciaHeadersClassValue }
+
+function TGocciaHeadersClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
+begin
+  Result := TGocciaHeadersValue.Create;
+end;
+
+{ TGocciaResponseClassValue }
+
+function TGocciaResponseClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
+begin
+  Result := TGocciaResponseValue.Create;
 end;
 
 { TGocciaStringClassValue }

--- a/source/units/Goccia.Values.HeadersValue.pas
+++ b/source/units/Goccia.Values.HeadersValue.pas
@@ -1,0 +1,365 @@
+unit Goccia.Values.HeadersValue;
+
+// Fetch API Headers
+// https://fetch.spec.whatwg.org/#headers-class
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Generics.Collections,
+
+  Goccia.Arguments.Collection,
+  Goccia.ObjectModel,
+  Goccia.SharedPrototype,
+  Goccia.Values.ClassValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaHeaderEntry = record
+    Name: string;   // stored lowercase
+    Value: string;
+  end;
+
+  TGocciaHeadersValue = class(TGocciaInstanceValue)
+  private
+    FEntries: TList<TGocciaHeaderEntry>;
+    FImmutable: Boolean;
+
+    // Prototype methods
+    function HeadersGet(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function HeadersHas(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function HeadersForEach(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function HeadersEntries(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function HeadersKeys(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function HeadersValues(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function HeadersSymbolIterator(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+
+    procedure InitializePrototype;
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil);
+    destructor Destroy; override;
+
+    // Internal helpers for populating from HTTP response
+    procedure AddHeader(const AName, AValue: string);
+    function GetHeader(const AName: string): string;
+
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+
+    procedure InitializeNativeFromArguments(
+      const AArguments: TGocciaArgumentsCollection); override;
+
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+
+    property Entries: TList<TGocciaHeaderEntry> read FEntries;
+    property Immutable: Boolean read FImmutable write FImmutable;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
+  Goccia.Utils,
+  Goccia.Values.ArrayValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.Iterator.Concrete,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+
+{ TGocciaHeadersValue }
+
+constructor TGocciaHeadersValue.Create(const AClass: TGocciaClassValue);
+begin
+  inherited Create(AClass);
+  FEntries := TList<TGocciaHeaderEntry>.Create;
+  FImmutable := False;
+  InitializePrototype;
+  if not Assigned(AClass) and Assigned(FShared) then
+    FPrototype := FShared.Prototype;
+end;
+
+destructor TGocciaHeadersValue.Destroy;
+begin
+  FEntries.Free;
+  inherited;
+end;
+
+procedure TGocciaHeadersValue.InitializePrototype;
+var
+  Members: TGocciaMemberCollection;
+begin
+  if Assigned(FShared) then Exit;
+
+  FShared := TGocciaSharedPrototype.Create(Self);
+  if Length(FPrototypeMembers) = 0 then
+  begin
+    Members := TGocciaMemberCollection.Create;
+    try
+      Members.AddNamedMethod(PROP_GET, HeadersGet, 1,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod(PROP_HAS, HeadersHas, 1,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod(PROP_FOR_EACH, HeadersForEach, 1,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod(PROP_ENTRIES, HeadersEntries, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod(PROP_KEYS, HeadersKeys, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod(PROP_VALUES, HeadersValues, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolMethod(
+        TGocciaSymbolValue.WellKnownIterator,
+        '[Symbol.iterator]', HeadersSymbolIterator, 0,
+        [pfConfigurable, pfWritable]);
+      FPrototypeMembers := Members.ToDefinitions;
+    finally
+      Members.Free;
+    end;
+  end;
+  RegisterMemberDefinitions(FShared.Prototype, FPrototypeMembers);
+end;
+
+class procedure TGocciaHeadersValue.ExposePrototype(const AConstructor: TGocciaValue);
+begin
+  if not Assigned(FShared) then
+    TGocciaHeadersValue.Create;
+  ExposeSharedPrototypeOnConstructor(FShared, AConstructor);
+end;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+procedure TGocciaHeadersValue.AddHeader(const AName, AValue: string);
+var
+  Entry: TGocciaHeaderEntry;
+begin
+  Entry.Name := LowerCase(AName);
+  Entry.Value := AValue;
+  FEntries.Add(Entry);
+end;
+
+function TGocciaHeadersValue.GetHeader(const AName: string): string;
+var
+  I: Integer;
+  Lower: string;
+begin
+  Result := '';
+  Lower := LowerCase(AName);
+  for I := 0 to FEntries.Count - 1 do
+    if FEntries[I].Name = Lower then
+    begin
+      // Fetch spec: combine multiple values with ', '
+      if Result = '' then
+        Result := FEntries[I].Value
+      else
+        Result := Result + ', ' + FEntries[I].Value;
+    end;
+end;
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+procedure TGocciaHeadersValue.InitializeNativeFromArguments(
+  const AArguments: TGocciaArgumentsCollection);
+var
+  InitArg: TGocciaValue;
+  Obj: TGocciaObjectValue;
+  PropNames: TArray<string>;
+  I: Integer;
+  Entry: TGocciaHeaderEntry;
+begin
+  if AArguments.Length = 0 then Exit;
+
+  InitArg := AArguments.GetElement(0);
+  if (InitArg is TGocciaUndefinedLiteralValue) or
+     (InitArg is TGocciaNullLiteralValue) then
+    Exit;
+
+  if InitArg is TGocciaHeadersValue then
+  begin
+    // Copy from another Headers instance
+    for I := 0 to TGocciaHeadersValue(InitArg).FEntries.Count - 1 do
+      FEntries.Add(TGocciaHeadersValue(InitArg).FEntries[I]);
+  end
+  else if InitArg is TGocciaObjectValue then
+  begin
+    Obj := TGocciaObjectValue(InitArg);
+    PropNames := Obj.GetAllPropertyNames;
+    for I := 0 to High(PropNames) do
+    begin
+      Entry.Name := LowerCase(PropNames[I]);
+      Entry.Value := Obj.GetProperty(PropNames[I]).ToStringLiteral.Value;
+      FEntries.Add(Entry);
+    end;
+  end;
+end;
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+function HeaderExists(const AHeaders: TGocciaHeadersValue; const AName: string): Boolean;
+var
+  I: Integer;
+  Lower: string;
+begin
+  Result := False;
+  Lower := LowerCase(AName);
+  for I := 0 to AHeaders.Entries.Count - 1 do
+    if AHeaders.Entries[I].Name = Lower then
+    begin
+      Result := True;
+      Exit;
+    end;
+end;
+
+// ---------------------------------------------------------------------------
+// Prototype methods
+// ---------------------------------------------------------------------------
+
+function TGocciaHeadersValue.HeadersGet(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  H: TGocciaHeadersValue;
+  Name, Combined: string;
+begin
+  if not (AThisValue is TGocciaHeadersValue) then
+    ThrowTypeError(SErrorHeadersNotHeaders, SSuggestHeadersThisType);
+  H := TGocciaHeadersValue(AThisValue);
+  Name := AArgs.GetElement(0).ToStringLiteral.Value;
+  Combined := H.GetHeader(Name);
+  if Combined = '' then
+  begin
+    // Check if the header actually exists with an empty value
+    if not HeaderExists(H, Name) then
+    begin
+      Result := TGocciaNullLiteralValue.NullValue;
+      Exit;
+    end;
+  end;
+  Result := TGocciaStringLiteralValue.Create(Combined);
+end;
+
+function TGocciaHeadersValue.HeadersHas(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  H: TGocciaHeadersValue;
+begin
+  if not (AThisValue is TGocciaHeadersValue) then
+    ThrowTypeError(SErrorHeadersNotHeaders, SSuggestHeadersThisType);
+  H := TGocciaHeadersValue(AThisValue);
+  if HeaderExists(H, AArgs.GetElement(0).ToStringLiteral.Value) then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+function TGocciaHeadersValue.HeadersForEach(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  H: TGocciaHeadersValue;
+  Callback, ThisArg: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
+  I: Integer;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not (AThisValue is TGocciaHeadersValue) then
+    ThrowTypeError(SErrorHeadersNotHeaders, SSuggestHeadersThisType);
+  H := TGocciaHeadersValue(AThisValue);
+
+  Callback := AArgs.GetElement(0);
+  if not Callback.IsCallable then
+    ThrowTypeError(SErrorHeadersForEachNotCallable, SSuggestCallbackRequired);
+
+  if AArgs.Length >= 2 then
+    ThisArg := AArgs.GetElement(1)
+  else
+    ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  I := 0;
+  while I < H.FEntries.Count do
+  begin
+    CallArgs := TGocciaArgumentsCollection.Create([
+      TGocciaStringLiteralValue.Create(H.FEntries[I].Value),
+      TGocciaStringLiteralValue.Create(H.FEntries[I].Name),
+      AThisValue]);
+    try
+      InvokeCallable(Callback, CallArgs, ThisArg);
+    finally
+      CallArgs.Free;
+    end;
+    Inc(I);
+  end;
+end;
+
+function TGocciaHeadersValue.HeadersEntries(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaHeadersValue) then
+    ThrowTypeError(SErrorHeadersNotHeaders, SSuggestHeadersThisType);
+  Result := TGocciaHeadersIteratorValue.Create(AThisValue, hikEntries);
+end;
+
+function TGocciaHeadersValue.HeadersKeys(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaHeadersValue) then
+    ThrowTypeError(SErrorHeadersNotHeaders, SSuggestHeadersThisType);
+  Result := TGocciaHeadersIteratorValue.Create(AThisValue, hikKeys);
+end;
+
+function TGocciaHeadersValue.HeadersValues(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaHeadersValue) then
+    ThrowTypeError(SErrorHeadersNotHeaders, SSuggestHeadersThisType);
+  Result := TGocciaHeadersIteratorValue.Create(AThisValue, hikValues);
+end;
+
+function TGocciaHeadersValue.HeadersSymbolIterator(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaHeadersValue) then
+    ThrowTypeError(SErrorHeadersNotHeaders, SSuggestHeadersThisType);
+  Result := TGocciaHeadersIteratorValue.Create(AThisValue, hikEntries);
+end;
+
+// ---------------------------------------------------------------------------
+// GC / Boilerplate
+// ---------------------------------------------------------------------------
+
+function TGocciaHeadersValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_HEADERS;
+end;
+
+procedure TGocciaHeadersValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  // FEntries contains only plain strings — no TGocciaValue references
+end;
+
+end.

--- a/source/units/Goccia.Values.Iterator.Concrete.pas
+++ b/source/units/Goccia.Values.Iterator.Concrete.pas
@@ -83,10 +83,27 @@ type
     procedure MarkReferences; override;
   end;
 
+  TGocciaHeadersIteratorKind = (hikEntries, hikKeys, hikValues);
+
+  TGocciaHeadersIteratorValue = class(TGocciaIteratorValue)
+  private
+    FSource: TGocciaValue;
+    FIndex: Integer;
+    FKind: TGocciaHeadersIteratorKind;
+  public
+    constructor Create(const ASource: TGocciaValue;
+      const AKind: TGocciaHeadersIteratorKind);
+    function AdvanceNext: TGocciaObjectValue; override;
+    function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+  end;
+
 implementation
 
 uses
   Goccia.Values.ArrayValue,
+  Goccia.Values.HeadersValue,
   Goccia.Values.HoleValue,
   Goccia.Values.MapValue,
   Goccia.Values.SetValue,
@@ -550,6 +567,109 @@ begin
 end;
 
 procedure TGocciaURLSearchParamsIteratorValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FSource) then
+    FSource.MarkReferences;
+end;
+
+{ TGocciaHeadersIteratorValue }
+
+constructor TGocciaHeadersIteratorValue.Create(const ASource: TGocciaValue;
+  const AKind: TGocciaHeadersIteratorKind);
+begin
+  inherited Create;
+  FSource := ASource;
+  FIndex := 0;
+  FKind := AKind;
+end;
+
+function TGocciaHeadersIteratorValue.AdvanceNext: TGocciaObjectValue;
+var
+  H: TGocciaHeadersValue;
+  EntryArray: TGocciaArrayValue;
+begin
+  if FDone then
+  begin
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+
+  H := TGocciaHeadersValue(FSource);
+  if FIndex >= H.Entries.Count then
+  begin
+    FDone := True;
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+
+  case FKind of
+    hikEntries:
+    begin
+      EntryArray := TGocciaArrayValue.Create;
+      EntryArray.Elements.Add(
+        TGocciaStringLiteralValue.Create(H.Entries[FIndex].Name));
+      EntryArray.Elements.Add(
+        TGocciaStringLiteralValue.Create(H.Entries[FIndex].Value));
+      Result := CreateIteratorResult(EntryArray, False);
+    end;
+    hikKeys:
+      Result := CreateIteratorResult(
+        TGocciaStringLiteralValue.Create(H.Entries[FIndex].Name), False);
+    hikValues:
+      Result := CreateIteratorResult(
+        TGocciaStringLiteralValue.Create(H.Entries[FIndex].Value), False);
+  end;
+  Inc(FIndex);
+end;
+
+function TGocciaHeadersIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+var
+  H: TGocciaHeadersValue;
+  EntryArray: TGocciaArrayValue;
+begin
+  if FDone then
+  begin
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  H := TGocciaHeadersValue(FSource);
+  if FIndex >= H.Entries.Count then
+  begin
+    FDone := True;
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
+  ADone := False;
+  case FKind of
+    hikEntries:
+    begin
+      EntryArray := TGocciaArrayValue.Create;
+      EntryArray.Elements.Add(
+        TGocciaStringLiteralValue.Create(H.Entries[FIndex].Name));
+      EntryArray.Elements.Add(
+        TGocciaStringLiteralValue.Create(H.Entries[FIndex].Value));
+      Result := EntryArray;
+    end;
+    hikKeys:
+      Result := TGocciaStringLiteralValue.Create(H.Entries[FIndex].Name);
+    hikValues:
+      Result := TGocciaStringLiteralValue.Create(H.Entries[FIndex].Value);
+  end;
+  Inc(FIndex);
+end;
+
+function TGocciaHeadersIteratorValue.ToStringTag: string;
+begin
+  Result := 'Headers Iterator';
+end;
+
+procedure TGocciaHeadersIteratorValue.MarkReferences;
 begin
   if GCMarked then Exit;
   inherited;

--- a/source/units/Goccia.Values.ResponseValue.pas
+++ b/source/units/Goccia.Values.ResponseValue.pas
@@ -1,0 +1,385 @@
+unit Goccia.Values.ResponseValue;
+
+// Fetch API Response
+// https://fetch.spec.whatwg.org/#response-class
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  SysUtils,
+
+  Goccia.Arguments.Collection,
+  Goccia.ObjectModel,
+  Goccia.SharedPrototype,
+  Goccia.Values.ClassValue,
+  Goccia.Values.HeadersValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaResponseValue = class(TGocciaInstanceValue)
+  private
+    FStatus: Integer;
+    FStatusText: string;
+    FUrl: string;
+    FHeaders: TGocciaHeadersValue;
+    FBody: TBytes;
+    FBodyUsed: Boolean;
+    FRedirected: Boolean;
+
+    // Prototype getters
+    function ResponseStatusGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseStatusTextGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseOkGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseUrlGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseHeadersGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseTypeGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseRedirectedGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseBodyUsedGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+
+    // Prototype methods
+    function ResponseText(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseJSON(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResponseArrayBuffer(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+
+    procedure InitializePrototype;
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil);
+
+    procedure InitFromHTTP(const AStatus: Integer; const AStatusText, AUrl: string;
+      const AHeaders: TGocciaHeadersValue; const ABody: TBytes;
+      const ARedirected: Boolean);
+
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+
+    procedure InitializeNativeFromArguments(
+      const AArguments: TGocciaArgumentsCollection); override;
+
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+
+    property Status: Integer read FStatus;
+    property StatusText: string read FStatusText;
+  end;
+
+implementation
+
+uses
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
+  Goccia.JSON,
+  Goccia.Values.ArrayBufferValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.PromiseValue;
+
+threadvar
+  FShared: TGocciaSharedPrototype;
+  FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+
+{ TGocciaResponseValue }
+
+constructor TGocciaResponseValue.Create(const AClass: TGocciaClassValue);
+begin
+  inherited Create(AClass);
+  FStatus := 200;
+  FStatusText := '';
+  FUrl := '';
+  FHeaders := nil;
+  SetLength(FBody, 0);
+  FBodyUsed := False;
+  FRedirected := False;
+  InitializePrototype;
+  if not Assigned(AClass) and Assigned(FShared) then
+    FPrototype := FShared.Prototype;
+end;
+
+procedure TGocciaResponseValue.InitFromHTTP(const AStatus: Integer;
+  const AStatusText, AUrl: string; const AHeaders: TGocciaHeadersValue;
+  const ABody: TBytes; const ARedirected: Boolean);
+begin
+  FStatus := AStatus;
+  FStatusText := AStatusText;
+  FUrl := AUrl;
+  FHeaders := AHeaders;
+  FBody := ABody;
+  FRedirected := ARedirected;
+  FBodyUsed := False;
+end;
+
+procedure TGocciaResponseValue.InitializePrototype;
+var
+  Members: TGocciaMemberCollection;
+begin
+  if Assigned(FShared) then Exit;
+
+  FShared := TGocciaSharedPrototype.Create(Self);
+  if Length(FPrototypeMembers) = 0 then
+  begin
+    Members := TGocciaMemberCollection.Create;
+    try
+      // Read-only accessors
+      Members.AddAccessor(PROP_STATUS,
+        ResponseStatusGetter, nil, [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_STATUS_TEXT,
+        ResponseStatusTextGetter, nil, [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_OK,
+        ResponseOkGetter, nil, [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_URL,
+        ResponseUrlGetter, nil, [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_HEADERS,
+        ResponseHeadersGetter, nil, [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_TYPE,
+        ResponseTypeGetter, nil, [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_REDIRECTED,
+        ResponseRedirectedGetter, nil, [pfConfigurable, pfEnumerable]);
+      Members.AddAccessor(PROP_BODY_USED,
+        ResponseBodyUsedGetter, nil, [pfConfigurable, pfEnumerable]);
+
+      // Body consumption methods
+      Members.AddNamedMethod(PROP_TEXT, ResponseText, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod(PROP_JSON, ResponseJSON, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod(PROP_ARRAY_BUFFER_METHOD, ResponseArrayBuffer, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+
+      FPrototypeMembers := Members.ToDefinitions;
+    finally
+      Members.Free;
+    end;
+  end;
+  RegisterMemberDefinitions(FShared.Prototype, FPrototypeMembers);
+end;
+
+class procedure TGocciaResponseValue.ExposePrototype(const AConstructor: TGocciaValue);
+begin
+  if not Assigned(FShared) then
+    TGocciaResponseValue.Create;
+  ExposeSharedPrototypeOnConstructor(FShared, AConstructor);
+end;
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+function TGocciaResponseValue.ResponseStatusGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  Result := TGocciaNumberLiteralValue.Create(
+    TGocciaResponseValue(AThisValue).FStatus);
+end;
+
+function TGocciaResponseValue.ResponseStatusTextGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaResponseValue(AThisValue).FStatusText);
+end;
+
+function TGocciaResponseValue.ResponseOkGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  S: Integer;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  S := TGocciaResponseValue(AThisValue).FStatus;
+  if (S >= 200) and (S <= 299) then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+function TGocciaResponseValue.ResponseUrlGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaResponseValue(AThisValue).FUrl);
+end;
+
+function TGocciaResponseValue.ResponseHeadersGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  Result := TGocciaResponseValue(AThisValue).FHeaders;
+  if not Assigned(Result) then
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaResponseValue.ResponseTypeGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  Result := TGocciaStringLiteralValue.Create('basic');
+end;
+
+function TGocciaResponseValue.ResponseRedirectedGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  if TGocciaResponseValue(AThisValue).FRedirected then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+function TGocciaResponseValue.ResponseBodyUsedGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  if TGocciaResponseValue(AThisValue).FBodyUsed then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// ---------------------------------------------------------------------------
+// Body consumption methods
+// ---------------------------------------------------------------------------
+
+function TGocciaResponseValue.ResponseText(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  R: TGocciaResponseValue;
+  U8: UTF8String;
+  P: TGocciaPromiseValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  R := TGocciaResponseValue(AThisValue);
+  if R.FBodyUsed then
+    ThrowTypeError(SErrorResponseBodyAlreadyUsed, SSuggestResponseThisType);
+  R.FBodyUsed := True;
+
+  // Decode body as UTF-8
+  SetLength(U8, Length(R.FBody));
+  if Length(R.FBody) > 0 then
+    Move(R.FBody[0], U8[1], Length(R.FBody));
+
+  P := TGocciaPromiseValue.Create;
+  P.Resolve(TGocciaStringLiteralValue.Create(string(U8)));
+  Result := P;
+end;
+
+function TGocciaResponseValue.ResponseJSON(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  R: TGocciaResponseValue;
+  U8: UTF8String;
+  Parser: TGocciaJSONParser;
+  Parsed: TGocciaValue;
+  P: TGocciaPromiseValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  R := TGocciaResponseValue(AThisValue);
+  if R.FBodyUsed then
+    ThrowTypeError(SErrorResponseBodyAlreadyUsed, SSuggestResponseThisType);
+  R.FBodyUsed := True;
+
+  SetLength(U8, Length(R.FBody));
+  if Length(R.FBody) > 0 then
+    Move(R.FBody[0], U8[1], Length(R.FBody));
+
+  P := TGocciaPromiseValue.Create;
+  Parser := TGocciaJSONParser.Create;
+  try
+    try
+      Parsed := Parser.Parse(U8);
+      P.Resolve(Parsed);
+    except
+      on E: Exception do
+        P.Reject(CreateErrorObject('SyntaxError', E.Message));
+    end;
+  finally
+    Parser.Free;
+  end;
+  Result := P;
+end;
+
+function TGocciaResponseValue.ResponseArrayBuffer(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  R: TGocciaResponseValue;
+  AB: TGocciaArrayBufferValue;
+  P: TGocciaPromiseValue;
+begin
+  if not (AThisValue is TGocciaResponseValue) then
+    ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
+  R := TGocciaResponseValue(AThisValue);
+  if R.FBodyUsed then
+    ThrowTypeError(SErrorResponseBodyAlreadyUsed, SSuggestResponseThisType);
+  R.FBodyUsed := True;
+
+  AB := TGocciaArrayBufferValue.Create(Length(R.FBody));
+  if Length(R.FBody) > 0 then
+    Move(R.FBody[0], AB.Data[0], Length(R.FBody));
+
+  P := TGocciaPromiseValue.Create;
+  P.Resolve(AB);
+  Result := P;
+end;
+
+// ---------------------------------------------------------------------------
+// Constructor / boilerplate
+// ---------------------------------------------------------------------------
+
+procedure TGocciaResponseValue.InitializeNativeFromArguments(
+  const AArguments: TGocciaArgumentsCollection);
+begin
+  // Response constructor: new Response() is not commonly used externally
+  // but support it minimally
+end;
+
+function TGocciaResponseValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_RESPONSE;
+end;
+
+procedure TGocciaResponseValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FHeaders) then
+    FHeaders.MarkReferences;
+end;
+
+end.

--- a/source/units/Goccia.Values.ResponseValue.pas
+++ b/source/units/Goccia.Values.ResponseValue.pas
@@ -101,7 +101,7 @@ begin
   FStatus := 200;
   FStatusText := '';
   FUrl := '';
-  FHeaders := nil;
+  FHeaders := TGocciaHeadersValue.Create;
   SetLength(FBody, 0);
   FBodyUsed := False;
   FRedirected := False;
@@ -283,8 +283,13 @@ begin
   if not (AThisValue is TGocciaResponseValue) then
     ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
   R := TGocciaResponseValue(AThisValue);
+  P := TGocciaPromiseValue.Create;
   if R.FBodyUsed then
-    ThrowTypeError(SErrorResponseBodyAlreadyUsed, SSuggestResponseThisType);
+  begin
+    P.Reject(CreateErrorObject('TypeError', SErrorResponseBodyAlreadyUsed));
+    Result := P;
+    Exit;
+  end;
   R.FBodyUsed := True;
 
   // Decode body as UTF-8
@@ -292,7 +297,6 @@ begin
   if Length(R.FBody) > 0 then
     Move(R.FBody[0], U8[1], Length(R.FBody));
 
-  P := TGocciaPromiseValue.Create;
   P.Resolve(TGocciaStringLiteralValue.Create(string(U8)));
   Result := P;
 end;
@@ -310,15 +314,19 @@ begin
   if not (AThisValue is TGocciaResponseValue) then
     ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
   R := TGocciaResponseValue(AThisValue);
+  P := TGocciaPromiseValue.Create;
   if R.FBodyUsed then
-    ThrowTypeError(SErrorResponseBodyAlreadyUsed, SSuggestResponseThisType);
+  begin
+    P.Reject(CreateErrorObject('TypeError', SErrorResponseBodyAlreadyUsed));
+    Result := P;
+    Exit;
+  end;
   R.FBodyUsed := True;
 
   SetLength(U8, Length(R.FBody));
   if Length(R.FBody) > 0 then
     Move(R.FBody[0], U8[1], Length(R.FBody));
 
-  P := TGocciaPromiseValue.Create;
   Parser := TGocciaJSONParser.Create;
   try
     try
@@ -345,15 +353,19 @@ begin
   if not (AThisValue is TGocciaResponseValue) then
     ThrowTypeError(SErrorResponseNotResponse, SSuggestResponseThisType);
   R := TGocciaResponseValue(AThisValue);
+  P := TGocciaPromiseValue.Create;
   if R.FBodyUsed then
-    ThrowTypeError(SErrorResponseBodyAlreadyUsed, SSuggestResponseThisType);
+  begin
+    P.Reject(CreateErrorObject('TypeError', SErrorResponseBodyAlreadyUsed));
+    Result := P;
+    Exit;
+  end;
   R.FBodyUsed := True;
 
   AB := TGocciaArrayBufferValue.Create(Length(R.FBody));
   if Length(R.FBody) > 0 then
     Move(R.FBody[0], AB.Data[0], Length(R.FBody));
 
-  P := TGocciaPromiseValue.Create;
   P.Resolve(AB);
   Result := P;
 end;

--- a/source/units/Goccia.Values.ResponseValue.pas
+++ b/source/units/Goccia.Values.ResponseValue.pas
@@ -422,7 +422,13 @@ begin
   if Assigned(PropVal) and not (PropVal is TGocciaUndefinedLiteralValue) then
   begin
     if PropVal is TGocciaHeadersValue then
-      FHeaders := TGocciaHeadersValue(PropVal)
+    begin
+      // Snapshot: copy entries so caller mutations don't leak through
+      for I := 0 to TGocciaHeadersValue(PropVal).Entries.Count - 1 do
+        FHeaders.AddHeader(
+          TGocciaHeadersValue(PropVal).Entries[I].Name,
+          TGocciaHeadersValue(PropVal).Entries[I].Value);
+    end
     else if PropVal is TGocciaObjectValue then
     begin
       HeadersObj := TGocciaObjectValue(PropVal);

--- a/source/units/Goccia.Values.ResponseValue.pas
+++ b/source/units/Goccia.Values.ResponseValue.pas
@@ -381,7 +381,7 @@ var
   InitObj, HeadersObj: TGocciaObjectValue;
   U8: UTF8String;
   PropNames: TArray<string>;
-  I: Integer;
+  I, StatusVal: Integer;
 begin
   if AArguments.Length = 0 then Exit;
 
@@ -402,10 +402,15 @@ begin
   if not (InitArg is TGocciaObjectValue) then Exit;
   InitObj := TGocciaObjectValue(InitArg);
 
-  // status
+  // status — must be 200-599 per WHATWG Fetch spec
   PropVal := InitObj.GetProperty(PROP_STATUS);
   if Assigned(PropVal) and not (PropVal is TGocciaUndefinedLiteralValue) then
-    FStatus := Trunc(PropVal.ToNumberLiteral.Value);
+  begin
+    StatusVal := Trunc(PropVal.ToNumberLiteral.Value);
+    if (StatusVal < 200) or (StatusVal > 599) then
+      ThrowRangeError('Response status must be in the range 200-599');
+    FStatus := StatusVal;
+  end;
 
   // statusText
   PropVal := InitObj.GetProperty(PROP_STATUS_TEXT);

--- a/source/units/Goccia.Values.ResponseValue.pas
+++ b/source/units/Goccia.Values.ResponseValue.pas
@@ -376,9 +376,57 @@ end;
 
 procedure TGocciaResponseValue.InitializeNativeFromArguments(
   const AArguments: TGocciaArgumentsCollection);
+var
+  BodyArg, InitArg, PropVal: TGocciaValue;
+  InitObj, HeadersObj: TGocciaObjectValue;
+  U8: UTF8String;
+  PropNames: TArray<string>;
+  I: Integer;
 begin
-  // Response constructor: new Response() is not commonly used externally
-  // but support it minimally
+  if AArguments.Length = 0 then Exit;
+
+  // Argument 0: body (string or null/undefined)
+  BodyArg := AArguments.GetElement(0);
+  if not ((BodyArg is TGocciaUndefinedLiteralValue) or
+          (BodyArg is TGocciaNullLiteralValue)) then
+  begin
+    U8 := UTF8String(BodyArg.ToStringLiteral.Value);
+    SetLength(FBody, Length(U8));
+    if Length(U8) > 0 then
+      Move(U8[1], FBody[0], Length(U8));
+  end;
+
+  // Argument 1: init dictionary { status, statusText, headers }
+  if AArguments.Length < 2 then Exit;
+  InitArg := AArguments.GetElement(1);
+  if not (InitArg is TGocciaObjectValue) then Exit;
+  InitObj := TGocciaObjectValue(InitArg);
+
+  // status
+  PropVal := InitObj.GetProperty(PROP_STATUS);
+  if Assigned(PropVal) and not (PropVal is TGocciaUndefinedLiteralValue) then
+    FStatus := Trunc(PropVal.ToNumberLiteral.Value);
+
+  // statusText
+  PropVal := InitObj.GetProperty(PROP_STATUS_TEXT);
+  if Assigned(PropVal) and not (PropVal is TGocciaUndefinedLiteralValue) then
+    FStatusText := PropVal.ToStringLiteral.Value;
+
+  // headers
+  PropVal := InitObj.GetProperty(PROP_HEADERS);
+  if Assigned(PropVal) and not (PropVal is TGocciaUndefinedLiteralValue) then
+  begin
+    if PropVal is TGocciaHeadersValue then
+      FHeaders := TGocciaHeadersValue(PropVal)
+    else if PropVal is TGocciaObjectValue then
+    begin
+      HeadersObj := TGocciaObjectValue(PropVal);
+      PropNames := HeadersObj.GetAllPropertyNames;
+      for I := 0 to High(PropNames) do
+        FHeaders.AddHeader(PropNames[I],
+          HeadersObj.GetProperty(PropNames[I]).ToStringLiteral.Value);
+    end;
+  end;
 end;
 
 function TGocciaResponseValue.ToStringTag: string;

--- a/tests/built-ins/Headers/constructor.js
+++ b/tests/built-ins/Headers/constructor.js
@@ -1,0 +1,29 @@
+/*---
+description: Headers constructor
+features: [fetch]
+---*/
+
+describe("Headers constructor", () => {
+  test("creates empty Headers with no arguments", () => {
+    const h = new Headers();
+    expect(h).toBeInstanceOf(Headers);
+    expect(h.has("x")).toBe(false);
+  });
+
+  test("creates Headers from a plain object", () => {
+    const h = new Headers({ "Content-Type": "text/html", Accept: "application/json" });
+    expect(h.get("content-type")).toBe("text/html");
+    expect(h.get("accept")).toBe("application/json");
+  });
+
+  test("creates Headers from another Headers instance", () => {
+    const original = new Headers({ "X-Custom": "value" });
+    const copy = new Headers(original);
+    expect(copy.get("x-custom")).toBe("value");
+  });
+
+  test("toString tag is Headers", () => {
+    const h = new Headers();
+    expect(Object.prototype.toString.call(h)).toBe("[object Headers]");
+  });
+});

--- a/tests/built-ins/Headers/prototype/entries.js
+++ b/tests/built-ins/Headers/prototype/entries.js
@@ -1,0 +1,46 @@
+/*---
+description: Headers.prototype.entries / keys / values / Symbol.iterator
+features: [fetch]
+---*/
+
+describe("Headers.prototype.entries", () => {
+  test("returns an iterator of [name, value] pairs", () => {
+    const h = new Headers({ "X-A": "1", "X-B": "2" });
+    const entries = [...h.entries()];
+    expect(entries).toEqual([["x-a", "1"], ["x-b", "2"]]);
+  });
+});
+
+describe("Headers.prototype.keys", () => {
+  test("returns an iterator of header names", () => {
+    const h = new Headers({ "X-A": "1", "X-B": "2" });
+    const keys = [...h.keys()];
+    expect(keys).toEqual(["x-a", "x-b"]);
+  });
+});
+
+describe("Headers.prototype.values", () => {
+  test("returns an iterator of header values", () => {
+    const h = new Headers({ "X-A": "1", "X-B": "2" });
+    const values = [...h.values()];
+    expect(values).toEqual(["1", "2"]);
+  });
+});
+
+describe("Headers[Symbol.iterator]", () => {
+  test("is the same as entries", () => {
+    const h = new Headers({ "X-A": "1" });
+    const fromIter = [...h];
+    const fromEntries = [...h.entries()];
+    expect(fromIter).toEqual(fromEntries);
+  });
+
+  test("works in for...of", () => {
+    const h = new Headers({ "X-A": "1", "X-B": "2" });
+    const collected = [];
+    for (const [name, value] of h) {
+      collected.push(name + "=" + value);
+    }
+    expect(collected).toEqual(["x-a=1", "x-b=2"]);
+  });
+});

--- a/tests/built-ins/Headers/prototype/forEach.js
+++ b/tests/built-ins/Headers/prototype/forEach.js
@@ -1,0 +1,43 @@
+/*---
+description: Headers.prototype.forEach
+features: [fetch]
+---*/
+
+describe("Headers.prototype.forEach", () => {
+  test("iterates over all entries", () => {
+    const h = new Headers({ "X-A": "1", "X-B": "2" });
+    const collected = [];
+    h.forEach((value, name) => {
+      collected.push([name, value]);
+    });
+    expect(collected).toEqual([["x-a", "1"], ["x-b", "2"]]);
+  });
+
+  test("callback receives value as first argument, name as second", () => {
+    const h = new Headers({ Key: "val" });
+    h.forEach((value, name) => {
+      expect(name).toBe("key");
+      expect(value).toBe("val");
+    });
+  });
+
+  test("callback receives Headers as third argument", () => {
+    const h = new Headers({ A: "1" });
+    h.forEach((value, name, headers) => {
+      expect(headers).toBe(h);
+    });
+  });
+
+  test("callback not called for empty headers", () => {
+    const fn = mock();
+    const h = new Headers();
+    h.forEach(fn);
+    expect(fn).toHaveBeenCalledTimes(0);
+  });
+
+  test("throws TypeError when callback is not callable", () => {
+    const h = new Headers({ A: "1" });
+    expect(() => h.forEach(null)).toThrow(TypeError);
+    expect(() => h.forEach(42)).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Headers/prototype/get.js
+++ b/tests/built-ins/Headers/prototype/get.js
@@ -1,0 +1,22 @@
+/*---
+description: Headers.prototype.get
+features: [fetch]
+---*/
+
+describe("Headers.prototype.get", () => {
+  test("returns value for existing header", () => {
+    const h = new Headers({ "Content-Type": "text/plain" });
+    expect(h.get("Content-Type")).toBe("text/plain");
+  });
+
+  test("is case-insensitive", () => {
+    const h = new Headers({ "Content-Type": "text/plain" });
+    expect(h.get("content-type")).toBe("text/plain");
+    expect(h.get("CONTENT-TYPE")).toBe("text/plain");
+  });
+
+  test("returns null for missing header", () => {
+    const h = new Headers();
+    expect(h.get("x-missing")).toBeNull();
+  });
+});

--- a/tests/built-ins/Headers/prototype/has.js
+++ b/tests/built-ins/Headers/prototype/has.js
@@ -1,0 +1,22 @@
+/*---
+description: Headers.prototype.has
+features: [fetch]
+---*/
+
+describe("Headers.prototype.has", () => {
+  test("returns true for existing header", () => {
+    const h = new Headers({ Accept: "text/html" });
+    expect(h.has("Accept")).toBe(true);
+  });
+
+  test("is case-insensitive", () => {
+    const h = new Headers({ Accept: "text/html" });
+    expect(h.has("accept")).toBe(true);
+    expect(h.has("ACCEPT")).toBe(true);
+  });
+
+  test("returns false for missing header", () => {
+    const h = new Headers();
+    expect(h.has("x-missing")).toBe(false);
+  });
+});

--- a/tests/built-ins/Response/constructor.js
+++ b/tests/built-ins/Response/constructor.js
@@ -75,6 +75,14 @@ describe("Response constructor", () => {
     expect(r.headers.get("content-type")).toBe("text/plain");
   });
 
+  test("response headers are independent from init headers", () => {
+    const h = new Headers({ "X-Test": "original" });
+    const r = new Response(null, { headers: h });
+    expect(r.headers.get("x-test")).toBe("original");
+    // response.headers should be a separate object
+    expect(r.headers).not.toBe(h);
+  });
+
   test("throws RangeError for status below 200", () => {
     expect(() => new Response(null, { status: 100 })).toThrow(RangeError);
   });

--- a/tests/built-ins/Response/constructor.js
+++ b/tests/built-ins/Response/constructor.js
@@ -75,6 +75,14 @@ describe("Response constructor", () => {
     expect(r.headers.get("content-type")).toBe("text/plain");
   });
 
+  test("throws RangeError for status below 200", () => {
+    expect(() => new Response(null, { status: 100 })).toThrow(RangeError);
+  });
+
+  test("throws RangeError for status above 599", () => {
+    expect(() => new Response(null, { status: 600 })).toThrow(RangeError);
+  });
+
   test("body and init together", async () => {
     const r = new Response("ok", { status: 201, statusText: "Created" });
     expect(r.status).toBe(201);

--- a/tests/built-ins/Response/constructor.js
+++ b/tests/built-ins/Response/constructor.js
@@ -38,4 +38,48 @@ describe("Response constructor", () => {
     const r = new Response();
     expect(Object.prototype.toString.call(r)).toBe("[object Response]");
   });
+
+  test("accepts body as first argument", async () => {
+    const r = new Response("hello");
+    const text = await r.text();
+    expect(text).toBe("hello");
+  });
+
+  test("accepts null body", async () => {
+    const r = new Response(null);
+    const text = await r.text();
+    expect(text).toBe("");
+  });
+
+  test("accepts status in init", () => {
+    const r = new Response(null, { status: 404 });
+    expect(r.status).toBe(404);
+    expect(r.ok).toBe(false);
+  });
+
+  test("accepts statusText in init", () => {
+    const r = new Response(null, { status: 404, statusText: "Not Found" });
+    expect(r.statusText).toBe("Not Found");
+  });
+
+  test("accepts headers as plain object in init", () => {
+    const r = new Response(null, {
+      headers: { "X-Custom": "value" },
+    });
+    expect(r.headers.get("x-custom")).toBe("value");
+  });
+
+  test("accepts headers as Headers instance in init", () => {
+    const h = new Headers({ "Content-Type": "text/plain" });
+    const r = new Response(null, { headers: h });
+    expect(r.headers.get("content-type")).toBe("text/plain");
+  });
+
+  test("body and init together", async () => {
+    const r = new Response("ok", { status: 201, statusText: "Created" });
+    expect(r.status).toBe(201);
+    expect(r.statusText).toBe("Created");
+    const text = await r.text();
+    expect(text).toBe("ok");
+  });
 });

--- a/tests/built-ins/Response/constructor.js
+++ b/tests/built-ins/Response/constructor.js
@@ -1,0 +1,41 @@
+/*---
+description: Response constructor and property accessors
+features: [fetch]
+---*/
+
+describe("Response constructor", () => {
+  test("creates a Response instance", () => {
+    const r = new Response();
+    expect(r).toBeInstanceOf(Response);
+  });
+
+  test("has default status 200", () => {
+    const r = new Response();
+    expect(r.status).toBe(200);
+  });
+
+  test("ok is true for default status", () => {
+    const r = new Response();
+    expect(r.ok).toBe(true);
+  });
+
+  test("type is basic", () => {
+    const r = new Response();
+    expect(r.type).toBe("basic");
+  });
+
+  test("bodyUsed is initially false", () => {
+    const r = new Response();
+    expect(r.bodyUsed).toBe(false);
+  });
+
+  test("redirected is initially false", () => {
+    const r = new Response();
+    expect(r.redirected).toBe(false);
+  });
+
+  test("toString tag is Response", () => {
+    const r = new Response();
+    expect(Object.prototype.toString.call(r)).toBe("[object Response]");
+  });
+});

--- a/tests/built-ins/Response/prototype/arrayBuffer.js
+++ b/tests/built-ins/Response/prototype/arrayBuffer.js
@@ -1,0 +1,37 @@
+/*---
+description: Response.prototype.arrayBuffer
+features: [fetch]
+---*/
+
+describe("Response.prototype.arrayBuffer", () => {
+  test("returns a promise", () => {
+    const r = new Response();
+    const p = r.arrayBuffer();
+    expect(p).toHaveProperty("then");
+  });
+
+  test("resolves to an ArrayBuffer", async () => {
+    const r = new Response();
+    const buf = await r.arrayBuffer();
+    expect(buf).toBeInstanceOf(ArrayBuffer);
+  });
+
+  test("resolves to zero-length ArrayBuffer for empty body", async () => {
+    const r = new Response();
+    const buf = await r.arrayBuffer();
+    expect(buf.byteLength).toBe(0);
+  });
+
+  test("sets bodyUsed to true after consumption", async () => {
+    const r = new Response();
+    expect(r.bodyUsed).toBe(false);
+    await r.arrayBuffer();
+    expect(r.bodyUsed).toBe(true);
+  });
+
+  test("throws TypeError on second consumption", async () => {
+    const r = new Response();
+    await r.arrayBuffer();
+    expect(() => r.arrayBuffer()).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Response/prototype/arrayBuffer.js
+++ b/tests/built-ins/Response/prototype/arrayBuffer.js
@@ -29,9 +29,13 @@ describe("Response.prototype.arrayBuffer", () => {
     expect(r.bodyUsed).toBe(true);
   });
 
-  test("throws TypeError on second consumption", async () => {
+  test("rejects with TypeError on second consumption", async () => {
     const r = new Response();
     await r.arrayBuffer();
-    expect(() => r.arrayBuffer()).toThrow(TypeError);
+    let caught;
+    await r.arrayBuffer().catch((e) => {
+      caught = e;
+    });
+    expect(caught instanceof TypeError).toBe(true);
   });
 });

--- a/tests/built-ins/Response/prototype/json.js
+++ b/tests/built-ins/Response/prototype/json.js
@@ -1,0 +1,26 @@
+/*---
+description: Response.prototype.json
+features: [fetch]
+---*/
+
+describe("Response.prototype.json", () => {
+  test("returns a promise", () => {
+    const r = new Response();
+    const p = r.json();
+    expect(p).toHaveProperty("then");
+  });
+
+  test("sets bodyUsed to true after consumption", async () => {
+    const r = new Response();
+    expect(r.bodyUsed).toBe(false);
+    // Empty body will fail JSON parse, but bodyUsed should still be set
+    try { await r.json(); } catch {}
+    expect(r.bodyUsed).toBe(true);
+  });
+
+  test("throws TypeError on second consumption", async () => {
+    const r = new Response();
+    try { await r.json(); } catch {}
+    expect(() => r.json()).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Response/prototype/json.js
+++ b/tests/built-ins/Response/prototype/json.js
@@ -18,9 +18,13 @@ describe("Response.prototype.json", () => {
     expect(r.bodyUsed).toBe(true);
   });
 
-  test("throws TypeError on second consumption", async () => {
+  test("rejects with TypeError on second consumption", async () => {
     const r = new Response();
     try { await r.json(); } catch {}
-    expect(() => r.json()).toThrow(TypeError);
+    let caught;
+    await r.json().catch((e) => {
+      caught = e;
+    });
+    expect(caught instanceof TypeError).toBe(true);
   });
 });

--- a/tests/built-ins/Response/prototype/text.js
+++ b/tests/built-ins/Response/prototype/text.js
@@ -1,0 +1,31 @@
+/*---
+description: Response.prototype.text
+features: [fetch]
+---*/
+
+describe("Response.prototype.text", () => {
+  test("returns a promise", () => {
+    const r = new Response();
+    const p = r.text();
+    expect(p).toHaveProperty("then");
+  });
+
+  test("resolves to empty string for empty body", async () => {
+    const r = new Response();
+    const text = await r.text();
+    expect(text).toBe("");
+  });
+
+  test("sets bodyUsed to true after consumption", async () => {
+    const r = new Response();
+    expect(r.bodyUsed).toBe(false);
+    await r.text();
+    expect(r.bodyUsed).toBe(true);
+  });
+
+  test("throws TypeError on second consumption", async () => {
+    const r = new Response();
+    await r.text();
+    expect(() => r.text()).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Response/prototype/text.js
+++ b/tests/built-ins/Response/prototype/text.js
@@ -23,9 +23,13 @@ describe("Response.prototype.text", () => {
     expect(r.bodyUsed).toBe(true);
   });
 
-  test("throws TypeError on second consumption", async () => {
+  test("rejects with TypeError on second consumption", async () => {
     const r = new Response();
     await r.text();
-    expect(() => r.text()).toThrow(TypeError);
+    let caught;
+    await r.text().catch((e) => {
+      caught = e;
+    });
+    expect(caught instanceof TypeError).toBe(true);
   });
 });

--- a/tests/built-ins/fetch/fetch-mock-response.js
+++ b/tests/built-ins/fetch/fetch-mock-response.js
@@ -1,0 +1,84 @@
+/*---
+description: fetch Response and Headers behavior tested via mock callbacks
+features: [fetch]
+---*/
+
+describe("fetch response handling via mock callbacks", () => {
+  test("rejected promise calls catch handler with TypeError", async () => {
+    const onReject = mock();
+    await fetch("http://0.0.0.0:1/").catch(onReject);
+    expect(onReject).toHaveBeenCalledTimes(1);
+    expect(onReject.mock.calls[0][0].name).toBe("TypeError");
+  });
+
+  test("rejected promise error has a message", async () => {
+    const onReject = mock();
+    await fetch("http://0.0.0.0:1/").catch(onReject);
+    const err = onReject.mock.calls[0][0];
+    expect(typeof err.message).toBe("string");
+    expect(err.message.length).toBeGreaterThan(0);
+  });
+
+  test("then handler is not called on network error", async () => {
+    const onFulfill = mock();
+    const onReject = mock();
+    await fetch("http://0.0.0.0:1/").then(onFulfill, onReject);
+    expect(onFulfill).toHaveBeenCalledTimes(0);
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+
+  test("catch handler receives single argument", async () => {
+    const onReject = mock();
+    await fetch("http://0.0.0.0:1/").catch(onReject);
+    expect(onReject.mock.calls[0].length).toBe(1);
+  });
+});
+
+describe("Headers mock integration", () => {
+  test("forEach calls mock for each header", () => {
+    const h = new Headers({ "X-A": "1", "X-B": "2", "X-C": "3" });
+    const fn = mock();
+    h.forEach(fn);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test("forEach mock receives correct arguments", () => {
+    const h = new Headers({ "X-Key": "val" });
+    const fn = mock();
+    h.forEach(fn);
+    expect(fn).toHaveBeenCalledWith("val", "x-key", h);
+  });
+
+  test("spyOn can wrap forEach callback", () => {
+    const h = new Headers({ A: "1", B: "2" });
+    const handler = { cb: (v, k) => k + "=" + v };
+    const spy = spyOn(handler, "cb");
+    h.forEach(handler.cb);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Response body consumption mock tracking", () => {
+  test("text() fulfillment handler is called once", async () => {
+    const r = new Response();
+    const onFulfill = mock();
+    await r.text().then(onFulfill);
+    expect(onFulfill).toHaveBeenCalledTimes(1);
+    expect(onFulfill).toHaveBeenCalledWith("");
+  });
+
+  test("arrayBuffer() fulfillment handler receives ArrayBuffer", async () => {
+    const r = new Response();
+    const onFulfill = mock();
+    await r.arrayBuffer().then(onFulfill);
+    expect(onFulfill).toHaveBeenCalledTimes(1);
+    expect(onFulfill.mock.calls[0][0]).toBeInstanceOf(ArrayBuffer);
+  });
+
+  test("json() rejection handler called for empty body", async () => {
+    const r = new Response();
+    const onReject = mock();
+    await r.json().catch(onReject);
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/built-ins/fetch/fetch-validation.js
+++ b/tests/built-ins/fetch/fetch-validation.js
@@ -30,6 +30,7 @@ describe("fetch", () => {
 
   test("returns a thenable for GET", () => {
     const p = fetch("http://0.0.0.0:1/");
+    p.catch(() => {});
     expect(typeof p.then).toBe("function");
     expect(typeof p.catch).toBe("function");
   });
@@ -56,16 +57,19 @@ describe("fetch", () => {
   test("accepts URL object as first argument", () => {
     const url = new URL("http://0.0.0.0:1/");
     const p = fetch(url);
+    p.catch(() => {});
     expect(typeof p.then).toBe("function");
   });
 
   test("accepts method option case-insensitively", () => {
     const p = fetch("http://0.0.0.0:1/", { method: "get" });
+    p.catch(() => {});
     expect(typeof p.then).toBe("function");
   });
 
   test("accepts head method", () => {
     const p = fetch("http://0.0.0.0:1/", { method: "HEAD" });
+    p.catch(() => {});
     expect(typeof p.then).toBe("function");
   });
 
@@ -73,12 +77,14 @@ describe("fetch", () => {
     const p = fetch("http://0.0.0.0:1/", {
       headers: { "X-Custom": "value" },
     });
+    p.catch(() => {});
     expect(typeof p.then).toBe("function");
   });
 
   test("accepts headers as Headers instance", () => {
     const h = new Headers({ "X-Custom": "value" });
     const p = fetch("http://0.0.0.0:1/", { headers: h });
+    p.catch(() => {});
     expect(typeof p.then).toBe("function");
   });
 });

--- a/tests/built-ins/fetch/fetch-validation.js
+++ b/tests/built-ins/fetch/fetch-validation.js
@@ -1,0 +1,84 @@
+/*---
+description: fetch argument validation and method restrictions
+features: [fetch]
+---*/
+
+describe("fetch", () => {
+  test("is a function", () => {
+    expect(typeof fetch).toBe("function");
+  });
+
+  test("throws TypeError when called with no arguments", () => {
+    expect(() => fetch()).toThrow(TypeError);
+  });
+
+  test("throws TypeError for POST method", () => {
+    expect(() => fetch("http://example.com", { method: "POST" })).toThrow(TypeError);
+  });
+
+  test("throws TypeError for PUT method", () => {
+    expect(() => fetch("http://example.com", { method: "PUT" })).toThrow(TypeError);
+  });
+
+  test("throws TypeError for DELETE method", () => {
+    expect(() => fetch("http://example.com", { method: "DELETE" })).toThrow(TypeError);
+  });
+
+  test("throws TypeError for PATCH method", () => {
+    expect(() => fetch("http://example.com", { method: "PATCH" })).toThrow(TypeError);
+  });
+
+  test("returns a thenable for GET", () => {
+    const p = fetch("http://0.0.0.0:1/");
+    expect(typeof p.then).toBe("function");
+    expect(typeof p.catch).toBe("function");
+  });
+
+  test("rejected promise for invalid host", async () => {
+    let caught = false;
+    await fetch("http://0.0.0.0:1/").catch((e) => {
+      caught = true;
+      expect(e.name).toBe("TypeError");
+      expect(typeof e.message).toBe("string");
+    });
+    expect(caught).toBe(true);
+  });
+
+  test("rejected promise for unsupported scheme", async () => {
+    let caught = false;
+    await fetch("ftp://example.com").catch((e) => {
+      caught = true;
+      expect(e.name).toBe("TypeError");
+    });
+    expect(caught).toBe(true);
+  });
+
+  test("accepts URL object as first argument", () => {
+    const url = new URL("http://0.0.0.0:1/");
+    const p = fetch(url);
+    expect(typeof p.then).toBe("function");
+  });
+
+  test("accepts method option case-insensitively", () => {
+    const p = fetch("http://0.0.0.0:1/", { method: "get" });
+    expect(typeof p.then).toBe("function");
+  });
+
+  test("accepts head method", () => {
+    const p = fetch("http://0.0.0.0:1/", { method: "HEAD" });
+    expect(typeof p.then).toBe("function");
+  });
+
+  test("accepts headers as plain object", () => {
+    const p = fetch("http://0.0.0.0:1/", {
+      headers: { "X-Custom": "value" },
+    });
+    expect(typeof p.then).toBe("function");
+  });
+
+  test("accepts headers as Headers instance", () => {
+    const h = new Headers({ "X-Custom": "value" });
+    const p = fetch("http://0.0.0.0:1/", { headers: h });
+    expect(typeof p.then).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- Added a native `fetch()` implementation backed by a new raw HTTP client, with support for `GET` and `HEAD`, redirects, HTTPS, and custom request headers.
- Introduced built-in `Headers` and `Response` constructors plus prototype methods such as `get`, `has`, `entries`, `forEach`, `text`, `json`, and `arrayBuffer`.
- Wired the new fetch types into the engine and added dedicated error messages and suggestions for fetch-related failures.
- Added end-to-end and built-in tests covering request validation, response parsing, header handling, redirect behavior, and `bodyUsed` lifecycle.