### PR TITLE
Add fcl-net and OpenSSL to cross-build toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
           FCL_DIR="$PREFIX/lib/fpc/${FPC_VERSION}/units/${TARGET}/fcl-process"
           FCL_BASE_SRC="$PREFIX/share/fpcsrc/packages/fcl-base/src"
           REGEXPR_SRC="$PREFIX/share/fpcsrc/packages/regexpr/src"
+          FCL_NET_SRC="$PREFIX/share/fpcsrc/packages/fcl-net/src"
+          OPENSSL_SRC="$PREFIX/share/fpcsrc/packages/openssl/src"
 
           # Verify RTL units exist
           echo "RTL units: $(ls "$RTL_DIR"/*.ppu 2>/dev/null | wc -l) .ppu files"
@@ -135,8 +137,12 @@ jobs:
           echo "fcl-process units: $(ls "$FCL_DIR"/*.ppu 2>/dev/null | wc -l) .ppu files"
           echo "fcl-base source path: $FCL_BASE_SRC"
           echo "regexpr source path: $REGEXPR_SRC"
+          echo "fcl-net source path: $FCL_NET_SRC"
+          echo "openssl source path: $OPENSSL_SRC"
           test -d "$FCL_BASE_SRC"
           test -d "$REGEXPR_SRC"
+          test -d "$FCL_NET_SRC"
+          test -d "$OPENSSL_SRC"
 
           # Build program entrypoints
           shopt -s nullglob
@@ -154,7 +160,7 @@ jobs:
             "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
               -Fu./source/units -Fu./source/shared -Fu./source/app -Fu./souffle \
               -Fi./source/units -Fi./source/shared -Fi./souffle \
-              -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" \
+              -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" -Fu"$FCL_NET_SRC" -Fu"$OPENSSL_SRC" \
               -FU"build/compiled" -FE"build" \
               $EXTRA_FLAGS \
               -dFPC_SOFT_FPUX80 \
@@ -170,7 +176,7 @@ jobs:
             "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
               -Fu./source/units -Fu./source/shared -Fu./source/app -Fu./souffle \
               -Fi./source/units -Fi./source/shared -Fi./souffle \
-              -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" \
+              -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" -Fu"$FCL_NET_SRC" -Fu"$OPENSSL_SRC" \
               -FU"build/compiled" -FE"build" \
               $EXTRA_FLAGS \
               -dFPC_SOFT_FPUX80 \
@@ -183,7 +189,7 @@ jobs:
           "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
             -Fu./source/units -Fu./source/shared -Fu./source/app -Fu./souffle \
             -Fi./source/units -Fi./source/shared -Fi./souffle \
-            -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" \
+            -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" -Fu"$FCL_NET_SRC" -Fu"$OPENSSL_SRC" \
             -FU"build/compiled" -FE"build" \
             $EXTRA_FLAGS \
             -dFPC_SOFT_FPUX80 \
@@ -195,7 +201,7 @@ jobs:
           "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
             -Fu./source/units -Fu./source/shared -Fu./source/app -Fu./souffle \
             -Fi./source/units -Fi./source/shared -Fi./souffle \
-            -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" \
+            -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" -Fu"$FCL_NET_SRC" -Fu"$OPENSSL_SRC" \
             -FU"build/compiled" -FE"build" \
             $EXTRA_FLAGS \
             -dFPC_SOFT_FPUX80 \

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -10,7 +10,7 @@ on:
 env:
   FPC_VERSION: "3.2.2"
   BINUTILS_VERSION: "2.44"
-  CACHE_VERSION: "v30"
+  CACHE_VERSION: "v31"
 
 jobs:
   build:
@@ -109,6 +109,8 @@ jobs:
           # source-based lookup is needed for units like Base64 and RegExpr.
           cp -R "$GITHUB_WORKSPACE/fpc-source/packages/fcl-base" "$PREFIX/share/fpcsrc/packages/"
           cp -R "$GITHUB_WORKSPACE/fpc-source/packages/regexpr" "$PREFIX/share/fpcsrc/packages/"
+          cp -R "$GITHUB_WORKSPACE/fpc-source/packages/fcl-net" "$PREFIX/share/fpcsrc/packages/"
+          cp -R "$GITHUB_WORKSPACE/fpc-source/packages/openssl" "$PREFIX/share/fpcsrc/packages/"
 
       - name: Compile soft-float units for native RTL
         if: steps.cache-check.outputs.cache-hit != 'true'

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -10,7 +10,7 @@ on:
 env:
   FPC_VERSION: "3.2.2"
   BINUTILS_VERSION: "2.44"
-  CACHE_VERSION: "v31"
+  CACHE_VERSION: "v32"
 
 jobs:
   build:
@@ -364,6 +364,36 @@ jobs:
             "$cross_fpc" -T"${os}" -O2 -dFPC_SOFT_FPUX80 $pkg_extra_flags \
               -Fu"$rtl_dir" -Fu"$fcl_dir" -FU"$fcl_dir" \
               $process_fi "packages/fcl-process/src/process.pp"
+
+            # Build socket units from packages/rtl-extra (not produced by cross make rtl)
+            # Sockets for Unix/Darwin, WinSock2 for Windows
+            local rtl_extra="packages/rtl-extra/src"
+            echo "--- socket units for ${target} ---"
+            case "$os" in
+              linux)
+                if [ ! -f "$rtl_dir/sockets.ppu" ]; then
+                  "$cross_fpc" -T"${os}" -O2 -dFPC_SOFT_FPUX80 $pkg_extra_flags \
+                    -Fu"$rtl_dir" -FU"$rtl_dir" \
+                    -Fi"${rtl_extra}/inc" -Fi"${rtl_extra}/linux" \
+                    "${rtl_extra}/unix/sockets.pp"
+                fi
+                ;;
+              darwin)
+                if [ ! -f "$rtl_dir/sockets.ppu" ]; then
+                  "$cross_fpc" -T"${os}" -O2 -dFPC_SOFT_FPUX80 $pkg_extra_flags \
+                    -Fu"$rtl_dir" -FU"$rtl_dir" \
+                    -Fi"${rtl_extra}/inc" -Fi"${rtl_extra}/bsd" -Fi"${rtl_extra}/darwin" \
+                    "${rtl_extra}/unix/sockets.pp"
+                fi
+                ;;
+              win32|win64)
+                if [ ! -f "$rtl_dir/winsock2.ppu" ]; then
+                  "$cross_fpc" -T"${os}" -O2 -dFPC_SOFT_FPUX80 $pkg_extra_flags \
+                    -Fu"$rtl_dir" -FU"$rtl_dir" \
+                    "${rtl_extra}/win/winsock2.pp"
+                fi
+                ;;
+            esac
           }
 
           # macOS x86_64

--- a/source/shared/HTTPClient.pas
+++ b/source/shared/HTTPClient.pas
@@ -61,6 +61,25 @@ type
   end;
 
 {$IFDEF MSWINDOWS}
+type
+  PAddrInfo = ^TAddrInfo;
+  TAddrInfo = record
+    ai_flags: LongInt;
+    ai_family: LongInt;
+    ai_socktype: LongInt;
+    ai_protocol: LongInt;
+    ai_addrlen: PtrUInt;
+    ai_canonname: PAnsiChar;
+    ai_addr: PSockAddr;
+    ai_next: PAddrInfo;
+  end;
+
+function Getaddrinfo(ANodeName, AServName: PAnsiChar;
+  AHints: PAddrInfo; out ARes: PAddrInfo): LongInt; stdcall;
+  external WINSOCK2_DLL name 'getaddrinfo';
+procedure Freeaddrinfo(AI: PAddrInfo); stdcall;
+  external WINSOCK2_DLL name 'freeaddrinfo';
+
 var
   GWinSockInitialized: Boolean = False;
 
@@ -217,8 +236,8 @@ begin
     PortStr := AnsiString(IntToStr(APort));
     Res := nil;
 
-    if getaddrinfo(PAnsiChar(AnsiString(AHost)), PAnsiChar(PortStr),
-                   Hints, @Res) <> 0 then
+    if Getaddrinfo(PAnsiChar(AnsiString(AHost)), PAnsiChar(PortStr),
+                   Hints, Res) <> 0 then
       raise EHTTPError.CreateFmt('Failed to resolve host: %s', [AHost]);
   finally
     Dispose(Hints);
@@ -250,7 +269,7 @@ begin
 
     Result := Sock;
   finally
-    freeaddrinfo(Res);
+    Freeaddrinfo(Res);
   end;
 end;
 {$ENDIF}


### PR DESCRIPTION
## Summary
- Added `fcl-net` and `openssl` source packages to the cached FPC toolchain assets.
- Updated cross-build CI to include the new source lookup paths when compiling targets.
- Bumped the toolchain cache version so workflows rebuild with the expanded package set.
