### PR TITLE
Add `Goccia.gc` manual garbage collection hook

### DIFF
--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -183,6 +183,7 @@ type
       const AOwnsModuleLoader: Boolean);
     function GetResolver: TGocciaModuleResolver;
     function SpeciesGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function GocciaGC(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure PrintParserWarnings(const AParser: TGocciaParser; const ASourceMap: TGocciaSourceMap = nil);
     procedure ThrowError(const AMessage: string; const ALine,
       AColumn: Integer);
@@ -1115,6 +1116,8 @@ begin
     CreateProposalObject, [pfEnumerable]));
   GocciaObj.DefineProperty('shims', TGocciaPropertyDescriptorData.Create(
     ShimsArray, [pfEnumerable]));
+  GocciaObj.AssignProperty('gc',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(GocciaGC, 'gc', 0));
 
   FInterpreter.GlobalScope.DefineLexicalBinding('Goccia', GocciaObj, dtConst);
 end;
@@ -1323,6 +1326,16 @@ end;
 function TGocciaEngine.SpeciesGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   Result := AThisValue;
+end;
+
+function TGocciaEngine.GocciaGC(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  GC: TGarbageCollector;
+begin
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) and GC.Enabled then
+    GC.Collect;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 procedure TGocciaEngine.SetASIEnabled(const AValue: Boolean);

--- a/source/units/Goccia.Runtime.Bootstrap.pas
+++ b/source/units/Goccia.Runtime.Bootstrap.pas
@@ -100,6 +100,7 @@ type
     procedure RegisterGlobalThis;
     procedure RegisterGocciaScriptGlobal;
     function SpeciesGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function GocciaGC(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AInterpreter: TGocciaInterpreter; const AGlobals: TGocciaGlobalBuiltins;
       const AThrowError: TGocciaThrowErrorCallback;
@@ -599,6 +600,8 @@ begin
     CreateProposalObject, [pfEnumerable]));
   GocciaObj.DefineProperty('shims', TGocciaPropertyDescriptorData.Create(
     ShimsArray, [pfEnumerable]));
+  GocciaObj.AssignProperty('gc',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(GocciaGC, 'gc', 0));
 
   FInterpreter.GlobalScope.DefineLexicalBinding('Goccia', GocciaObj, dtConst);
 end;
@@ -607,6 +610,17 @@ function TGocciaRuntimeBootstrap.SpeciesGetter(const AArgs: TGocciaArgumentsColl
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   Result := AThisValue;
+end;
+
+function TGocciaRuntimeBootstrap.GocciaGC(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  GC: TGarbageCollector;
+begin
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) and GC.Enabled then
+    GC.Collect;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 end.

--- a/tests/built-ins/global-properties/goccia.js
+++ b/tests/built-ins/global-properties/goccia.js
@@ -16,4 +16,20 @@ describe.runIf(hasGoccia)("Goccia global", () => {
       Goccia = {};
     }).toThrow(TypeError);
   });
+
+  describe("Goccia.gc", () => {
+    test("gc is a function", () => {
+      expect(typeof Goccia.gc).toBe("function");
+    });
+
+    test("gc returns undefined", () => {
+      const result = Goccia.gc();
+      expect(result).toBe(undefined);
+    });
+
+    test("gc can be called multiple times", () => {
+      Goccia.gc();
+      Goccia.gc();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Added a `Goccia.gc()` built-in on the `Goccia` global in both the engine and runtime bootstrap paths.
- The new hook triggers the garbage collector when available and enabled, then returns `undefined`.
- Added tests covering the new global property, return value, and repeatable invocation.