### PR TITLE
Add Object.hasOwn-backed hasOwnProperty shim

### DIFF
--- a/source/units/Goccia.Constants.PropertyNames.pas
+++ b/source/units/Goccia.Constants.PropertyNames.pas
@@ -67,7 +67,6 @@ const
   PROP_OF               = 'of';
   PROP_URL              = 'url';
   PROP_RESOLVE          = 'resolve';
-  PROP_HAS_OWN_PROPERTY       = 'hasOwnProperty';
   PROP_IS_PROTOTYPE_OF        = 'isPrototypeOf';
   PROP_PROPERTY_IS_ENUMERABLE = 'propertyIsEnumerable';
   PROP_TO_LOCALE_STRING       = 'toLocaleString';

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -54,7 +54,7 @@ uses
   Goccia.Token;
 
 const
-  DEFAULT_SHIMS: array[0..6] of TGocciaShimDefinition = (
+  DEFAULT_SHIMS: array[0..7] of TGocciaShimDefinition = (
     ( // WHATWG HTML spec §8.3 — legacy btoa(data) via Uint8Array.toBase64
       Name: 'btoa';
       FileName: '<shim:btoa>';
@@ -201,6 +201,17 @@ const
         '      String(z.year) + " " + pad(z.hour) + ":" + pad(z.minute) + ":" + pad(z.second) + " GMT" + z.offset;'#10 +
         '  }'#10 +
         '};'
+    ),
+    ( // ES2026 §20.1.3.2 — legacy hasOwnProperty via Object.hasOwn
+      Name: 'hasOwnProperty';
+      FileName: '<shim:hasOwnProperty>';
+      Source:
+        'export const hasOwnProperty = ((proto) => {'#10 +
+        '  class _H { hasOwnProperty(prop) { return Object.hasOwn(this, prop); } }'#10 +
+        '  const fn = new _H().hasOwnProperty;'#10 +
+        '  proto.hasOwnProperty = fn;'#10 +
+        '  return fn;'#10 +
+        '})(Object.getPrototypeOf({}));'
     )
   );
 

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -209,7 +209,9 @@ const
         'export const hasOwnProperty = ((proto) => {'#10 +
         '  class _H { hasOwnProperty(prop) { return Object.hasOwn(this, prop); } }'#10 +
         '  const fn = new _H().hasOwnProperty;'#10 +
-        '  proto.hasOwnProperty = fn;'#10 +
+        '  Object.defineProperty(proto, "hasOwnProperty", {'#10 +
+        '    value: fn, writable: true, enumerable: false, configurable: true'#10 +
+        '  });'#10 +
         '  return fn;'#10 +
         '})(Object.getPrototypeOf({}));'
     )

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -95,7 +95,6 @@ type
     property HasErrorData: Boolean read FHasErrorData write FHasErrorData;
   published
     function ObjectPrototypeToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-    function ObjectPrototypeHasOwnProperty(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectPrototypeIsPrototypeOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectPrototypePropertyIsEnumerable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectPrototypeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -193,45 +192,6 @@ begin
     Tag := CONSTRUCTOR_OBJECT;
 
   Result := TGocciaStringLiteralValue.Create('[object ' + Tag + ']');
-end;
-
-// ES2026 §20.1.3.2 Object.prototype.hasOwnProperty(V)
-function TGocciaObjectValue.ObjectPrototypeHasOwnProperty(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-var
-  Key: string;
-  Obj: TGocciaObjectValue;
-  PropertyArg: TGocciaValue;
-begin
-  // Step 2: Let O be ? ToObject(this value)
-  if (AThisValue is TGocciaUndefinedLiteralValue) or (AThisValue is TGocciaNullLiteralValue) then
-    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
-
-  if not (AThisValue is TGocciaObjectValue) then
-    Exit(TGocciaBooleanLiteralValue.FalseValue);
-
-  Obj := TGocciaObjectValue(AThisValue);
-
-  // Step 1: Let P be ? ToPropertyKey(V)
-  if AArgs.Length = 0 then
-    PropertyArg := TGocciaUndefinedLiteralValue.UndefinedValue
-  else
-    PropertyArg := AArgs.GetElement(0);
-
-  if PropertyArg is TGocciaSymbolValue then
-  begin
-    if Assigned(Obj.GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(PropertyArg))) then
-      Result := TGocciaBooleanLiteralValue.TrueValue
-    else
-      Result := TGocciaBooleanLiteralValue.FalseValue;
-  end
-  else
-  begin
-    Key := PropertyArg.ToStringLiteral.Value;
-    if Obj.HasOwnProperty(Key) then
-      Result := TGocciaBooleanLiteralValue.TrueValue
-    else
-      Result := TGocciaBooleanLiteralValue.FalseValue;
-  end;
 end;
 
 // ES2026 §20.1.3.3 Object.prototype.isPrototypeOf(V)
@@ -362,7 +322,6 @@ begin
     Members := TGocciaMemberCollection.Create;
     try
       Members.AddMethod(FPrototypeMethodHost.ObjectPrototypeToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddMethod(FPrototypeMethodHost.ObjectPrototypeHasOwnProperty, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(FPrototypeMethodHost.ObjectPrototypeIsPrototypeOf, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(FPrototypeMethodHost.ObjectPrototypePropertyIsEnumerable, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(FPrototypeMethodHost.ObjectPrototypeToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -372,11 +331,10 @@ begin
       Members.Free;
     end;
     FPrototypeMembers[0].ExposedName := PROP_TO_STRING;
-    FPrototypeMembers[1].ExposedName := PROP_HAS_OWN_PROPERTY;
-    FPrototypeMembers[2].ExposedName := PROP_IS_PROTOTYPE_OF;
-    FPrototypeMembers[3].ExposedName := PROP_PROPERTY_IS_ENUMERABLE;
-    FPrototypeMembers[4].ExposedName := PROP_TO_LOCALE_STRING;
-    FPrototypeMembers[5].ExposedName := PROP_VALUE_OF;
+    FPrototypeMembers[1].ExposedName := PROP_IS_PROTOTYPE_OF;
+    FPrototypeMembers[2].ExposedName := PROP_PROPERTY_IS_ENUMERABLE;
+    FPrototypeMembers[3].ExposedName := PROP_TO_LOCALE_STRING;
+    FPrototypeMembers[4].ExposedName := PROP_VALUE_OF;
   end;
   RegisterMemberDefinitions(FSharedObjectPrototype, FPrototypeMembers);
 

--- a/tests/built-ins/Object/hasOwn.js
+++ b/tests/built-ins/Object/hasOwn.js
@@ -50,6 +50,30 @@ test("Object.hasOwn with symbol key does not match prototype symbol", () => {
   expect(Object.hasOwn(proto, sym)).toBe(true);
 });
 
+// §20.1.2.9 — Object.hasOwn works on null-prototype objects where
+// Object.prototype.hasOwnProperty is unavailable (MDN "Problematic cases").
+
+test("Object.hasOwn works on null-prototype objects", () => {
+  const obj = Object.create(null);
+  obj.a = 1;
+  obj.b = undefined;
+  expect(Object.hasOwn(obj, "a")).toBe(true);
+  expect(Object.hasOwn(obj, "b")).toBe(true);
+  expect(Object.hasOwn(obj, "c")).toBe(false);
+  // Confirm hasOwnProperty is not available on the object itself
+  expect(typeof obj.hasOwnProperty).toBe("undefined");
+});
+
+test("Object.hasOwn via call/apply is not shadowed by target properties", () => {
+  const obj = { a: 5, hasOwn: () => false };
+  // Own hasOwn returns false — the override is in effect
+  expect(obj.hasOwn("a")).toBe(false);
+  // Static method with this bound to obj still works correctly
+  expect(Object.hasOwn.call(obj, obj, "a")).toBe(true);
+  expect(Object.hasOwn.call(obj, obj, "hasOwn")).toBe(true);
+  expect(Object.hasOwn.call(obj, obj, "missing")).toBe(false);
+});
+
 test("Object.hasOwn throws for null", () => {
   expect(() => Object.hasOwn(null, "foo")).toThrow(TypeError);
 });

--- a/tests/built-ins/Object/prototype/hasOwnProperty.js
+++ b/tests/built-ins/Object/prototype/hasOwnProperty.js
@@ -96,4 +96,46 @@ describe('Object.prototype.hasOwnProperty', () => {
     expect(obj.hasOwnProperty(Symbol.toStringTag)).toBe(true);
     expect(obj.hasOwnProperty(Symbol.iterator)).toBe(false);
   });
+
+  // §20.1.3.2 vs §20.1.2.9 — behavioral differences from Object.hasOwn
+  // hasOwnProperty is a legacy API; Object.hasOwn is the modern replacement.
+  // These tests document the cases where the two diverge.
+
+  test('overridden hasOwnProperty takes precedence', () => {
+    const obj = {
+      hasOwnProperty: () => false,
+      bar: "exists"
+    };
+    // Legacy behavior: the override wins, returning a wrong answer
+    expect(obj.hasOwnProperty("bar")).toBe(false);
+    // Modern API bypasses the override
+    expect(Object.hasOwn(obj, "bar")).toBe(true);
+  });
+
+  test('not available on null-prototype objects', () => {
+    const obj = Object.create(null);
+    obj.prop = "exists";
+    // Legacy behavior: null-prototype objects lack hasOwnProperty
+    expect(() => obj.hasOwnProperty("prop")).toThrow(TypeError);
+    // Modern API works regardless of prototype chain
+    expect(Object.hasOwn(obj, "prop")).toBe(true);
+  });
+
+  test('Object.prototype.hasOwnProperty.call bypasses override', () => {
+    const obj = {
+      hasOwnProperty: () => false,
+      key: 1
+    };
+    // Defensive call-pattern avoids the override issue
+    expect(Object.prototype.hasOwnProperty.call(obj, "key")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(obj, "missing")).toBe(false);
+  });
+
+  test('Object.prototype.hasOwnProperty.call works on null-prototype objects', () => {
+    const obj = Object.create(null);
+    obj.a = 1;
+    // The call-pattern also works for null-prototype objects
+    expect(Object.prototype.hasOwnProperty.call(obj, "a")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(obj, "b")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Add a `hasOwnProperty` shim that delegates to `Object.hasOwn`.
- Remove the native `Object.prototype.hasOwnProperty` implementation from the runtime and register the shim instead.
- Update object built-in tests to cover null-prototype objects, overridden methods, and the legacy call pattern.