### PR TITLE
Fix trailing-dot numeric literals and spread tokenization

### DIFF
--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -1281,10 +1281,12 @@ var
   Ch: Char;
   HasSeparator: Boolean;
   HasDecimalOrExponent: Boolean;
+  IsDecimal: Boolean;
   Lexeme: string;
 begin
   HasSeparator := False;
   HasDecimalOrExponent := False;
+  IsDecimal := True;
   Ch := Peek;
 
   if Ch = '0' then
@@ -1294,6 +1296,7 @@ begin
 
     if (Ch = 'x') or (Ch = 'X') then
     begin
+      IsDecimal := False;
       Advance;
       if not CharInSet(Peek, ['0'..'9', 'a'..'f', 'A'..'F']) then
         raise TGocciaLexerError.Create('Invalid hexadecimal number', FLine, FColumn, FFileName, GetSourceLines,
@@ -1314,6 +1317,7 @@ begin
     end
     else if (Ch = 'b') or (Ch = 'B') then
     begin
+      IsDecimal := False;
       Advance;
       if not CharInSet(Peek, ['0', '1']) then
         raise TGocciaLexerError.Create('Invalid binary number', FLine, FColumn, FFileName, GetSourceLines,
@@ -1334,6 +1338,7 @@ begin
     end
     else if (Ch = 'o') or (Ch = 'O') then
     begin
+      IsDecimal := False;
       Advance;
       if not CharInSet(Peek, ['0'..'7']) then
         raise TGocciaLexerError.Create('Invalid octal number', FLine, FColumn, FFileName, GetSourceLines,
@@ -1380,58 +1385,64 @@ begin
     end;
   end;
 
-  if (Peek = '.') and (PeekNext = '_') then
-    raise TGocciaLexerError.Create('Numeric separator must be between digits',
-      FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator)
-  else if (Peek = '.') and CharInSet(PeekNext, ['0'..'9']) then
+  // Fraction, trailing dot, and exponent are only valid for decimal literals.
+  // Hex (0x), binary (0b), and octal (0o) literals must not consume a
+  // following dot — it belongs to the property-access tokeniser.
+  if IsDecimal then
   begin
-    HasDecimalOrExponent := True;
-    Advance;
-    while CharInSet(Peek, ['0'..'9', '_']) do
+    if (Peek = '.') and (PeekNext = '_') then
+      raise TGocciaLexerError.Create('Numeric separator must be between digits',
+        FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator)
+    else if (Peek = '.') and CharInSet(PeekNext, ['0'..'9']) then
     begin
-      if Peek = '_' then
-      begin
-        HasSeparator := True;
-        Advance;
-        if not CharInSet(Peek, ['0'..'9']) then
-          raise TGocciaLexerError.Create('Numeric separator must be between digits',
-            FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
-      end
-      else
-        Advance;
-    end;
-  end
-  else if Peek = '.' then
-  begin
-    // ES2026 §12.9.3: trailing dot with no fractional digits is a valid
-    // DecimalLiteral (e.g. `10.`).  This enables `10..toString(16)` by
-    // tokenising `10.` as a numeric literal, leaving the second dot for
-    // the property-access tokeniser.
-    HasDecimalOrExponent := True;
-    Advance;
-  end;
-
-  if CharInSet(Peek, ['e', 'E']) then
-  begin
-    HasDecimalOrExponent := True;
-    Advance;
-    if CharInSet(Peek, ['+', '-']) then
+      HasDecimalOrExponent := True;
       Advance;
-    if not CharInSet(Peek, ['0'..'9']) then
-      raise TGocciaLexerError.Create('Invalid scientific notation', FLine, FColumn, FFileName, GetSourceLines,
-        SSuggestScientificNotation);
-    while CharInSet(Peek, ['0'..'9', '_']) do
-    begin
-      if Peek = '_' then
+      while CharInSet(Peek, ['0'..'9', '_']) do
       begin
-        HasSeparator := True;
+        if Peek = '_' then
+        begin
+          HasSeparator := True;
+          Advance;
+          if not CharInSet(Peek, ['0'..'9']) then
+            raise TGocciaLexerError.Create('Numeric separator must be between digits',
+              FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+        end
+        else
+          Advance;
+      end;
+    end
+    else if Peek = '.' then
+    begin
+      // ES2026 §12.9.3: trailing dot with no fractional digits is a valid
+      // DecimalLiteral (e.g. `10.`).  This enables `10..toString(16)` by
+      // tokenising `10.` as a numeric literal, leaving the second dot for
+      // the property-access tokeniser.
+      HasDecimalOrExponent := True;
+      Advance;
+    end;
+
+    if CharInSet(Peek, ['e', 'E']) then
+    begin
+      HasDecimalOrExponent := True;
+      Advance;
+      if CharInSet(Peek, ['+', '-']) then
         Advance;
-        if not CharInSet(Peek, ['0'..'9']) then
-          raise TGocciaLexerError.Create('Numeric separator must be between digits',
-            FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
-      end
-      else
-        Advance;
+      if not CharInSet(Peek, ['0'..'9']) then
+        raise TGocciaLexerError.Create('Invalid scientific notation', FLine, FColumn, FFileName, GetSourceLines,
+          SSuggestScientificNotation);
+      while CharInSet(Peek, ['0'..'9', '_']) do
+      begin
+        if Peek = '_' then
+        begin
+          HasSeparator := True;
+          Advance;
+          if not CharInSet(Peek, ['0'..'9']) then
+            raise TGocciaLexerError.Create('Numeric separator must be between digits',
+              FLine, FColumn, FFileName, GetSourceLines, SSuggestNumericSeparator);
+        end
+        else
+          Advance;
+      end;
     end;
   end;
 

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -1400,6 +1400,15 @@ begin
       else
         Advance;
     end;
+  end
+  else if Peek = '.' then
+  begin
+    // ES2026 §12.9.3: trailing dot with no fractional digits is a valid
+    // DecimalLiteral (e.g. `10.`).  This enables `10..toString(16)` by
+    // tokenising `10.` as a numeric literal, leaving the second dot for
+    // the property-access tokeniser.
+    HasDecimalOrExponent := True;
+    Advance;
   end;
 
   if CharInSet(Peek, ['e', 'E']) then
@@ -1669,14 +1678,11 @@ begin
     '~':
       AddToken(gttBitwiseNot);
     '.':
-      if Match('.') then
+      if (Peek = '.') and (PeekNext = '.') then
       begin
-        if Match('.') then
-          AddToken(gttSpread)
-        else
-          raise TGocciaLexerError.Create('Invalid token ..',
-            FLine, FStartColumn, FFileName, GetSourceLines,
-            SSuggestInvalidDoubleDot);
+        Advance; // consume second dot
+        Advance; // consume third dot
+        AddToken(gttSpread);
       end
       else
         AddToken(gttDot);

--- a/tests/language/expressions/numeric-trailing-dot.js
+++ b/tests/language/expressions/numeric-trailing-dot.js
@@ -42,4 +42,17 @@ describe("trailing-dot numeric literals", () => {
     expect(result[0]).toBe(0);
     expect(result[1]).toBe(1);
   });
+
+  test("hex literal dot is property access, not fractional", () => {
+    expect(0xFF.toString()).toBe("255");
+    expect(0xFF.toString(16)).toBe("ff");
+  });
+
+  test("binary literal dot is property access, not fractional", () => {
+    expect(0b101.toString()).toBe("5");
+  });
+
+  test("octal literal dot is property access, not fractional", () => {
+    expect(0o77.toString()).toBe("63");
+  });
 });

--- a/tests/language/expressions/numeric-trailing-dot.js
+++ b/tests/language/expressions/numeric-trailing-dot.js
@@ -1,0 +1,45 @@
+/*---
+description: Trailing-dot numeric literals and method calls (e.g. 10..toString())
+features: [numeric-literals]
+---*/
+
+describe("trailing-dot numeric literals", () => {
+  test("10..toString() returns decimal string", () => {
+    expect(10..toString()).toBe("10");
+  });
+
+  test("10..toString(16) returns hex string", () => {
+    expect(10..toString(16)).toBe("a");
+  });
+
+  test("255..toString(16) returns hex string", () => {
+    expect(255..toString(16)).toBe("ff");
+  });
+
+  test("0..toString() returns '0'", () => {
+    expect(0..toString()).toBe("0");
+  });
+
+  test("trailing dot produces correct numeric value", () => {
+    expect(10.).toBe(10);
+    expect(0.).toBe(0);
+    expect(123.).toBe(123);
+  });
+
+  test("trailing dot with exponent", () => {
+    expect(10.e2).toBe(1000);
+    expect(1.e3).toBe(1000);
+  });
+
+  test("numeric separator with trailing dot method call", () => {
+    expect(1_000..toString()).toBe("1000");
+  });
+
+  test("spread after numeric literal still works", () => {
+    const arr = [1, 2, 3];
+    const result = [0, ...arr];
+    expect(result.length).toBe(4);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow trailing-dot decimal literals like `10.` so expressions such as `10..toString()` parse correctly.
- Preserve spread tokenization by recognizing `...` directly without misclassifying `..` as an invalid token.
- Add coverage for trailing-dot literals, exponent forms, numeric separators, and spread usage.
