### PR TITLE
Require BigInt for Temporal epoch nanoseconds

### DIFF
--- a/docs/built-ins-temporal.md
+++ b/docs/built-ins-temporal.md
@@ -155,16 +155,16 @@ Represents an absolute point in time (epoch-based), independent of calendar or t
 
 | Constructor / Static | Description |
 |---------------------|-------------|
-| `new Temporal.Instant(epochNanoseconds)` | Create from epoch nanoseconds |
+| `new Temporal.Instant(epochNanoseconds)` | Create from epoch nanoseconds (BigInt) |
 | `Temporal.Instant.from(item)` | Create from string or Instant |
-| `Temporal.Instant.fromEpochMilliseconds(ms)` | Create from epoch milliseconds |
-| `Temporal.Instant.fromEpochNanoseconds(ns)` | Create from epoch nanoseconds |
+| `Temporal.Instant.fromEpochMilliseconds(ms)` | Create from epoch milliseconds (Number) |
+| `Temporal.Instant.fromEpochNanoseconds(ns)` | Create from epoch nanoseconds (BigInt) |
 | `Temporal.Instant.compare(one, two)` | Compare two instants (-1, 0, 1) |
 
 | Getter | Description |
 |--------|-------------|
-| `epochMilliseconds` | Milliseconds since Unix epoch |
-| `epochNanoseconds` | Nanoseconds since Unix epoch (as number) |
+| `epochMilliseconds` | Milliseconds since Unix epoch (Number) |
+| `epochNanoseconds` | Nanoseconds since Unix epoch (BigInt) |
 
 | Method | Description |
 |--------|-------------|
@@ -233,7 +233,7 @@ Represents an absolute date and time in a specific timezone. Combines an instant
 
 | Constructor / Static | Description |
 |---------------------|-------------|
-| `new Temporal.ZonedDateTime(epochNanoseconds, timeZone)` | Create from epoch nanoseconds and timezone ID |
+| `new Temporal.ZonedDateTime(epochNanoseconds, timeZone)` | Create from epoch nanoseconds (BigInt) and timezone ID |
 | `Temporal.ZonedDateTime.from(item)` | Create from ISO string with timezone annotation (e.g., `"2024-03-15T13:45:30+05:30[Asia/Kolkata]"`), ZonedDateTime, or object |
 | `Temporal.ZonedDateTime.compare(one, two)` | Compare two zoned date-times (-1, 0, 1) |
 
@@ -250,8 +250,8 @@ Represents an absolute date and time in a specific timezone. Combines an instant
 | `millisecond`, `microsecond`, `nanosecond` | Sub-second components |
 | `offset` | UTC offset string (e.g., `"+05:30"`) |
 | `offsetNanoseconds` | UTC offset in nanoseconds |
-| `epochMilliseconds` | Milliseconds since Unix epoch |
-| `epochNanoseconds` | Nanoseconds since Unix epoch (as number) |
+| `epochMilliseconds` | Milliseconds since Unix epoch (Number) |
+| `epochNanoseconds` | Nanoseconds since Unix epoch (BigInt) |
 
 | Method | Description |
 |--------|-------------|

--- a/scripts/test262_harness/temporalHelpers.js
+++ b/scripts/test262_harness/temporalHelpers.js
@@ -291,7 +291,7 @@ const TemporalHelpers = {
   },
 
   checkToTemporalInstantFastPath(func) {
-    func(new Temporal.Instant(0));
+    func(new Temporal.Instant(0n));
   },
 
   checkStringOptionWrongType(propertyName, value, checkFunc, assertFunc) {

--- a/source/shared/BigInteger.Test.pas
+++ b/source/shared/BigInteger.Test.pas
@@ -241,8 +241,8 @@ begin
   Test('FromDouble NaN raises', TestFromDoubleNaN);
   Test('FromDouble Infinity raises', TestFromDoubleInfinity);
   Test('FromDouble non-integer raises', TestFromDoubleNonInteger);
-  Test('FromDouble MAX_SAFE_INTEGER', TestFromDoubleMaxSafeInteger);
-  Test('FromDouble -MAX_SAFE_INTEGER', TestFromDoubleNegMaxSafeInteger);
+  Test('FromDouble 2^53 (Int64 fast-path boundary)', TestFromDoubleMaxSafeInteger);
+  Test('FromDouble -2^53 (Int64 fast-path boundary)', TestFromDoubleNegMaxSafeInteger);
 
   { FromDecimalString }
   Test('FromDecimalString "0"', TestFromDecimalStringZero);

--- a/source/shared/BigInteger.Test.pas
+++ b/source/shared/BigInteger.Test.pas
@@ -1,0 +1,1465 @@
+program BigInteger.Test;
+
+{$I Shared.inc}
+
+uses
+  Math,
+  SysUtils,
+
+  BigInteger,
+  TestingPascalLibrary;
+
+type
+  TBigIntegerTests = class(TTestSuite)
+  private
+    { Constructors — Zero, One, NegativeOne }
+    procedure TestZeroIsZero;
+    procedure TestZeroIsNotNegative;
+    procedure TestOneIsOne;
+    procedure TestOneIsPositive;
+    procedure TestNegativeOneIsMinusOne;
+    procedure TestNegativeOneIsNegative;
+
+    { FromInt64 }
+    procedure TestFromInt64Zero;
+    procedure TestFromInt64Positive;
+    procedure TestFromInt64Negative;
+    procedure TestFromInt64MaxInt;
+    procedure TestFromInt64MinInt;
+    procedure TestFromInt64LargePositive;
+    procedure TestFromInt64LargeNegative;
+
+    { FromDouble }
+    procedure TestFromDoubleZero;
+    procedure TestFromDoublePositive;
+    procedure TestFromDoubleNegative;
+    procedure TestFromDoubleLargeValue;
+    procedure TestFromDoubleNaN;
+    procedure TestFromDoubleInfinity;
+    procedure TestFromDoubleNonInteger;
+    procedure TestFromDoubleMaxSafeInteger;
+    procedure TestFromDoubleNegMaxSafeInteger;
+
+    { FromDecimalString }
+    procedure TestFromDecimalStringZero;
+    procedure TestFromDecimalStringPositive;
+    procedure TestFromDecimalStringNegative;
+    procedure TestFromDecimalStringLeadingPlus;
+    procedure TestFromDecimalStringLargeNumber;
+    procedure TestFromDecimalStringEmpty;
+    procedure TestFromDecimalStringInvalidChar;
+    procedure TestFromDecimalStringSignOnly;
+
+    { FromHexString }
+    procedure TestFromHexStringSmall;
+    procedure TestFromHexStringUpperCase;
+    procedure TestFromHexStringLarge;
+    procedure TestFromHexStringEmpty;
+    procedure TestFromHexStringInvalidChar;
+
+    { FromBinaryString }
+    procedure TestFromBinaryStringSmall;
+    procedure TestFromBinaryStringByte;
+    procedure TestFromBinaryStringEmpty;
+    procedure TestFromBinaryStringInvalidChar;
+
+    { FromOctalString }
+    procedure TestFromOctalStringSmall;
+    procedure TestFromOctalStringLarger;
+    procedure TestFromOctalStringEmpty;
+    procedure TestFromOctalStringInvalidChar;
+
+    { Predicates }
+    procedure TestIsZeroTrue;
+    procedure TestIsZeroFalse;
+    procedure TestIsNegativeTrue;
+    procedure TestIsNegativeFalse;
+    procedure TestIsPositiveTrue;
+    procedure TestIsPositiveFalse;
+    procedure TestIsOneTrue;
+    procedure TestIsOneFalse;
+    procedure TestIsMinusOneTrue;
+    procedure TestIsMinusOneFalse;
+    procedure TestBitLength;
+    procedure TestBitLengthZero;
+    procedure TestGetBit;
+
+    { Conversions }
+    procedure TestToDoubleZero;
+    procedure TestToDoublePositive;
+    procedure TestToDoubleNegative;
+    procedure TestToInt64Zero;
+    procedure TestToInt64Positive;
+    procedure TestToInt64Negative;
+    procedure TestToInt64Large;
+    procedure TestToStringZero;
+    procedure TestToStringPositive;
+    procedure TestToStringNegative;
+    procedure TestToRadixStringBinary;
+    procedure TestToRadixStringHex;
+    procedure TestToRadixStringOctal;
+    procedure TestToRadixStringBase36;
+    procedure TestToRadixStringInvalidRadix;
+
+    { Unary operations }
+    procedure TestNegatePositive;
+    procedure TestNegateNegative;
+    procedure TestNegateZero;
+    procedure TestAbsValuePositive;
+    procedure TestAbsValueNegative;
+    procedure TestAbsValueZero;
+
+    { Addition }
+    procedure TestAddBothPositive;
+    procedure TestAddBothNegative;
+    procedure TestAddPositiveNegative;
+    procedure TestAddNegativePositive;
+    procedure TestAddZeroLeft;
+    procedure TestAddZeroRight;
+    procedure TestAddCancelToZero;
+    procedure TestAddCarry;
+
+    { Subtraction }
+    procedure TestSubtractBasic;
+    procedure TestSubtractNegativeResult;
+    procedure TestSubtractFromZero;
+    procedure TestSubtractToZero;
+
+    { Multiplication }
+    procedure TestMultiplyBasic;
+    procedure TestMultiplyByZero;
+    procedure TestMultiplyNegatives;
+    procedure TestMultiplyMixedSign;
+    procedure TestMultiplyLarge;
+
+    { Division }
+    procedure TestDivideExact;
+    procedure TestDivideWithRemainder;
+    procedure TestDivideNegative;
+    procedure TestDivideTruncatesTowardZero;
+    procedure TestDivideByZero;
+    procedure TestDivideZeroByNonZero;
+    procedure TestDivideSmallerByLarger;
+
+    { Modulo }
+    procedure TestModuloBasic;
+    procedure TestModuloNegativeDividend;
+    procedure TestModuloZeroDividend;
+    procedure TestModuloByZero;
+    procedure TestModuloSmallerByLarger;
+
+    { Power }
+    procedure TestPowerBasic;
+    procedure TestPowerOfZero;
+    procedure TestPowerToZero;
+    procedure TestPowerNegativeExponent;
+    procedure TestPowerLarge;
+
+    { Bitwise AND }
+    procedure TestBitwiseAndBasic;
+    procedure TestBitwiseAndWithZero;
+    procedure TestBitwiseAndNegative;
+
+    { Bitwise OR }
+    procedure TestBitwiseOrBasic;
+    procedure TestBitwiseOrWithZero;
+    procedure TestBitwiseOrNegative;
+
+    { Bitwise XOR }
+    procedure TestBitwiseXorBasic;
+    procedure TestBitwiseXorSelf;
+    procedure TestBitwiseXorNegative;
+
+    { Bitwise NOT }
+    procedure TestBitwiseNotPositive;
+    procedure TestBitwiseNotNegative;
+    procedure TestBitwiseNotZero;
+
+    { Shift left }
+    procedure TestShiftLeftBasic;
+    procedure TestShiftLeftZeroCount;
+    procedure TestShiftLeftZeroValue;
+    procedure TestShiftLeftLarge;
+
+    { Shift right }
+    procedure TestShiftRightBasic;
+    procedure TestShiftRightZeroCount;
+    procedure TestShiftRightAllBits;
+    procedure TestShiftRightNegativeFloors;
+
+    { Comparison }
+    procedure TestCompareEqual;
+    procedure TestCompareLess;
+    procedure TestCompareGreater;
+    procedure TestCompareNegatives;
+    procedure TestCompareMixedSign;
+    procedure TestEqualTrue;
+    procedure TestEqualFalse;
+
+    { AsIntN / AsUintN }
+    procedure TestAsIntN8;
+    procedure TestAsIntN8Negative;
+    procedure TestAsIntN8Overflow;
+    procedure TestAsUintN8;
+    procedure TestAsUintN8Large;
+    procedure TestAsUintNZeroBits;
+    procedure TestAsIntNZeroBits;
+
+    { Roundtrip }
+    procedure TestRoundtripFromInt64;
+    procedure TestRoundtripDecimalString;
+    procedure TestRoundtripDivModConsistency;
+    procedure TestRoundtripFromDoubleToInt64;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TBigIntegerTests.SetupTests;
+begin
+  { Constructors }
+  Test('Zero.IsZero is True', TestZeroIsZero);
+  Test('Zero is not negative', TestZeroIsNotNegative);
+  Test('One.IsOne is True', TestOneIsOne);
+  Test('One is positive', TestOneIsPositive);
+  Test('NegativeOne.IsMinusOne is True', TestNegativeOneIsMinusOne);
+  Test('NegativeOne is negative', TestNegativeOneIsNegative);
+
+  { FromInt64 }
+  Test('FromInt64(0) produces zero', TestFromInt64Zero);
+  Test('FromInt64 positive value', TestFromInt64Positive);
+  Test('FromInt64 negative value', TestFromInt64Negative);
+  Test('FromInt64 max 32-bit', TestFromInt64MaxInt);
+  Test('FromInt64 min Int64', TestFromInt64MinInt);
+  Test('FromInt64 large positive (>32-bit)', TestFromInt64LargePositive);
+  Test('FromInt64 large negative (>32-bit)', TestFromInt64LargeNegative);
+
+  { FromDouble }
+  Test('FromDouble(0.0) produces zero', TestFromDoubleZero);
+  Test('FromDouble positive integer', TestFromDoublePositive);
+  Test('FromDouble negative integer', TestFromDoubleNegative);
+  Test('FromDouble large value (epoch ns)', TestFromDoubleLargeValue);
+  Test('FromDouble NaN raises', TestFromDoubleNaN);
+  Test('FromDouble Infinity raises', TestFromDoubleInfinity);
+  Test('FromDouble non-integer raises', TestFromDoubleNonInteger);
+  Test('FromDouble MAX_SAFE_INTEGER', TestFromDoubleMaxSafeInteger);
+  Test('FromDouble -MAX_SAFE_INTEGER', TestFromDoubleNegMaxSafeInteger);
+
+  { FromDecimalString }
+  Test('FromDecimalString "0"', TestFromDecimalStringZero);
+  Test('FromDecimalString positive', TestFromDecimalStringPositive);
+  Test('FromDecimalString negative', TestFromDecimalStringNegative);
+  Test('FromDecimalString leading plus', TestFromDecimalStringLeadingPlus);
+  Test('FromDecimalString large number', TestFromDecimalStringLargeNumber);
+  Test('FromDecimalString empty raises', TestFromDecimalStringEmpty);
+  Test('FromDecimalString invalid char raises', TestFromDecimalStringInvalidChar);
+  Test('FromDecimalString sign only raises', TestFromDecimalStringSignOnly);
+
+  { FromHexString }
+  Test('FromHexString small value', TestFromHexStringSmall);
+  Test('FromHexString upper case', TestFromHexStringUpperCase);
+  Test('FromHexString large value', TestFromHexStringLarge);
+  Test('FromHexString empty raises', TestFromHexStringEmpty);
+  Test('FromHexString invalid char raises', TestFromHexStringInvalidChar);
+
+  { FromBinaryString }
+  Test('FromBinaryString small', TestFromBinaryStringSmall);
+  Test('FromBinaryString byte', TestFromBinaryStringByte);
+  Test('FromBinaryString empty raises', TestFromBinaryStringEmpty);
+  Test('FromBinaryString invalid char raises', TestFromBinaryStringInvalidChar);
+
+  { FromOctalString }
+  Test('FromOctalString small', TestFromOctalStringSmall);
+  Test('FromOctalString larger', TestFromOctalStringLarger);
+  Test('FromOctalString empty raises', TestFromOctalStringEmpty);
+  Test('FromOctalString invalid char raises', TestFromOctalStringInvalidChar);
+
+  { Predicates }
+  Test('IsZero true for zero', TestIsZeroTrue);
+  Test('IsZero false for non-zero', TestIsZeroFalse);
+  Test('IsNegative true for negative', TestIsNegativeTrue);
+  Test('IsNegative false for positive', TestIsNegativeFalse);
+  Test('IsPositive true for positive', TestIsPositiveTrue);
+  Test('IsPositive false for negative', TestIsPositiveFalse);
+  Test('IsOne true for one', TestIsOneTrue);
+  Test('IsOne false for other', TestIsOneFalse);
+  Test('IsMinusOne true for -1', TestIsMinusOneTrue);
+  Test('IsMinusOne false for other', TestIsMinusOneFalse);
+  Test('BitLength of non-zero', TestBitLength);
+  Test('BitLength of zero', TestBitLengthZero);
+  Test('GetBit reads individual bits', TestGetBit);
+
+  { Conversions }
+  Test('ToDouble zero', TestToDoubleZero);
+  Test('ToDouble positive', TestToDoublePositive);
+  Test('ToDouble negative', TestToDoubleNegative);
+  Test('ToInt64 zero', TestToInt64Zero);
+  Test('ToInt64 positive', TestToInt64Positive);
+  Test('ToInt64 negative', TestToInt64Negative);
+  Test('ToInt64 large', TestToInt64Large);
+  Test('ToString zero', TestToStringZero);
+  Test('ToString positive', TestToStringPositive);
+  Test('ToString negative', TestToStringNegative);
+  Test('ToRadixString binary', TestToRadixStringBinary);
+  Test('ToRadixString hex', TestToRadixStringHex);
+  Test('ToRadixString octal', TestToRadixStringOctal);
+  Test('ToRadixString base 36', TestToRadixStringBase36);
+  Test('ToRadixString invalid radix raises', TestToRadixStringInvalidRadix);
+
+  { Unary }
+  Test('Negate positive', TestNegatePositive);
+  Test('Negate negative', TestNegateNegative);
+  Test('Negate zero', TestNegateZero);
+  Test('AbsValue positive', TestAbsValuePositive);
+  Test('AbsValue negative', TestAbsValueNegative);
+  Test('AbsValue zero', TestAbsValueZero);
+
+  { Addition }
+  Test('Add both positive', TestAddBothPositive);
+  Test('Add both negative', TestAddBothNegative);
+  Test('Add positive + negative', TestAddPositiveNegative);
+  Test('Add negative + positive', TestAddNegativePositive);
+  Test('Add zero + x', TestAddZeroLeft);
+  Test('Add x + zero', TestAddZeroRight);
+  Test('Add cancels to zero', TestAddCancelToZero);
+  Test('Add with carry', TestAddCarry);
+
+  { Subtraction }
+  Test('Subtract basic', TestSubtractBasic);
+  Test('Subtract yields negative', TestSubtractNegativeResult);
+  Test('Subtract from zero', TestSubtractFromZero);
+  Test('Subtract to zero', TestSubtractToZero);
+
+  { Multiplication }
+  Test('Multiply basic', TestMultiplyBasic);
+  Test('Multiply by zero', TestMultiplyByZero);
+  Test('Multiply two negatives', TestMultiplyNegatives);
+  Test('Multiply mixed signs', TestMultiplyMixedSign);
+  Test('Multiply large values', TestMultiplyLarge);
+
+  { Division }
+  Test('Divide exact', TestDivideExact);
+  Test('Divide with remainder (truncated)', TestDivideWithRemainder);
+  Test('Divide negative values', TestDivideNegative);
+  Test('Divide truncates toward zero', TestDivideTruncatesTowardZero);
+  Test('Divide by zero raises', TestDivideByZero);
+  Test('Divide zero by non-zero', TestDivideZeroByNonZero);
+  Test('Divide smaller by larger yields zero', TestDivideSmallerByLarger);
+
+  { Modulo }
+  Test('Modulo basic', TestModuloBasic);
+  Test('Modulo sign follows dividend', TestModuloNegativeDividend);
+  Test('Modulo of zero', TestModuloZeroDividend);
+  Test('Modulo by zero raises', TestModuloByZero);
+  Test('Modulo smaller by larger returns self', TestModuloSmallerByLarger);
+
+  { Power }
+  Test('Power basic', TestPowerBasic);
+  Test('Power of zero', TestPowerOfZero);
+  Test('Power to zero yields one', TestPowerToZero);
+  Test('Power negative exponent raises', TestPowerNegativeExponent);
+  Test('Power large exponent', TestPowerLarge);
+
+  { Bitwise AND }
+  Test('Bitwise AND basic', TestBitwiseAndBasic);
+  Test('Bitwise AND with zero', TestBitwiseAndWithZero);
+  Test('Bitwise AND negative (two''s complement)', TestBitwiseAndNegative);
+
+  { Bitwise OR }
+  Test('Bitwise OR basic', TestBitwiseOrBasic);
+  Test('Bitwise OR with zero', TestBitwiseOrWithZero);
+  Test('Bitwise OR negative', TestBitwiseOrNegative);
+
+  { Bitwise XOR }
+  Test('Bitwise XOR basic', TestBitwiseXorBasic);
+  Test('Bitwise XOR self yields zero', TestBitwiseXorSelf);
+  Test('Bitwise XOR negative', TestBitwiseXorNegative);
+
+  { Bitwise NOT }
+  Test('Bitwise NOT positive', TestBitwiseNotPositive);
+  Test('Bitwise NOT negative', TestBitwiseNotNegative);
+  Test('Bitwise NOT zero', TestBitwiseNotZero);
+
+  { Shift left }
+  Test('ShiftLeft basic', TestShiftLeftBasic);
+  Test('ShiftLeft zero count', TestShiftLeftZeroCount);
+  Test('ShiftLeft zero value', TestShiftLeftZeroValue);
+  Test('ShiftLeft large count', TestShiftLeftLarge);
+
+  { Shift right }
+  Test('ShiftRight basic', TestShiftRightBasic);
+  Test('ShiftRight zero count', TestShiftRightZeroCount);
+  Test('ShiftRight all bits', TestShiftRightAllBits);
+  Test('ShiftRight negative floors toward -inf', TestShiftRightNegativeFloors);
+
+  { Comparison }
+  Test('Compare equal', TestCompareEqual);
+  Test('Compare less', TestCompareLess);
+  Test('Compare greater', TestCompareGreater);
+  Test('Compare negatives', TestCompareNegatives);
+  Test('Compare mixed sign', TestCompareMixedSign);
+  Test('Equal true', TestEqualTrue);
+  Test('Equal false', TestEqualFalse);
+
+  { AsIntN / AsUintN }
+  Test('AsIntN(8) positive in range', TestAsIntN8);
+  Test('AsIntN(8) negative value', TestAsIntN8Negative);
+  Test('AsIntN(8) overflow wraps', TestAsIntN8Overflow);
+  Test('AsUintN(8) basic', TestAsUintN8);
+  Test('AsUintN(8) large value masks', TestAsUintN8Large);
+  Test('AsUintN(0) yields zero', TestAsUintNZeroBits);
+  Test('AsIntN(0) yields zero', TestAsIntNZeroBits);
+
+  { Roundtrip }
+  Test('Roundtrip FromInt64 -> ToInt64', TestRoundtripFromInt64);
+  Test('Roundtrip FromDecimalString -> ToString', TestRoundtripDecimalString);
+  Test('Roundtrip a = (a/b)*b + (a mod b)', TestRoundtripDivModConsistency);
+  Test('Roundtrip FromDouble -> ToInt64 for large values', TestRoundtripFromDoubleToInt64);
+end;
+
+{ ── Constructors ─────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestZeroIsZero;
+begin
+  Expect<Boolean>(TBigInteger.Zero.IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestZeroIsNotNegative;
+begin
+  Expect<Boolean>(TBigInteger.Zero.IsNegative).ToBe(False);
+end;
+
+procedure TBigIntegerTests.TestOneIsOne;
+begin
+  Expect<Boolean>(TBigInteger.One.IsOne).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestOneIsPositive;
+begin
+  Expect<Boolean>(TBigInteger.One.IsPositive).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestNegativeOneIsMinusOne;
+begin
+  Expect<Boolean>(TBigInteger.NegativeOne.IsMinusOne).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestNegativeOneIsNegative;
+begin
+  Expect<Boolean>(TBigInteger.NegativeOne.IsNegative).ToBe(True);
+end;
+
+{ ── FromInt64 ────────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestFromInt64Zero;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(0).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromInt64Positive;
+begin
+  Expect<String>(TBigInteger.FromInt64(42).ToString).ToBe('42');
+end;
+
+procedure TBigIntegerTests.TestFromInt64Negative;
+begin
+  Expect<String>(TBigInteger.FromInt64(-42).ToString).ToBe('-42');
+end;
+
+procedure TBigIntegerTests.TestFromInt64MaxInt;
+var
+  B: TBigInteger;
+begin
+  B := TBigInteger.FromInt64(2147483647); // MaxInt32
+  Expect<Int64>(B.ToInt64).ToBe(2147483647);
+end;
+
+procedure TBigIntegerTests.TestFromInt64MinInt;
+var
+  B: TBigInteger;
+begin
+  B := TBigInteger.FromInt64(Low(Int64));
+  Expect<Boolean>(B.IsNegative).ToBe(True);
+  Expect<String>(B.ToString).ToBe('-9223372036854775808');
+end;
+
+procedure TBigIntegerTests.TestFromInt64LargePositive;
+var
+  B: TBigInteger;
+begin
+  B := TBigInteger.FromInt64(Int64(5000000000)); // > 2^32
+  Expect<Int64>(B.ToInt64).ToBe(Int64(5000000000));
+end;
+
+procedure TBigIntegerTests.TestFromInt64LargeNegative;
+var
+  B: TBigInteger;
+begin
+  B := TBigInteger.FromInt64(Int64(-5000000000));
+  Expect<Int64>(B.ToInt64).ToBe(Int64(-5000000000));
+end;
+
+{ ── FromDouble ───────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestFromDoubleZero;
+begin
+  Expect<Boolean>(TBigInteger.FromDouble(0.0).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromDoublePositive;
+begin
+  Expect<String>(TBigInteger.FromDouble(123.0).ToString).ToBe('123');
+end;
+
+procedure TBigIntegerTests.TestFromDoubleNegative;
+begin
+  Expect<String>(TBigInteger.FromDouble(-456.0).ToString).ToBe('-456');
+end;
+
+procedure TBigIntegerTests.TestFromDoubleLargeValue;
+var
+  B: TBigInteger;
+begin
+  // Epoch nanoseconds magnitude — the value that triggered the AArch64 bug
+  B := TBigInteger.FromDouble(1718451045123.0);
+  Expect<Int64>(B.ToInt64).ToBe(Int64(1718451045123));
+end;
+
+procedure TBigIntegerTests.TestFromDoubleNaN;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromDouble(NaN);
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromDoubleInfinity;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromDouble(Infinity);
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromDoubleNonInteger;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromDouble(1.5);
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromDoubleMaxSafeInteger;
+var
+  B: TBigInteger;
+begin
+  // 2^53 = 9007199254740992
+  B := TBigInteger.FromDouble(9007199254740992.0);
+  Expect<String>(B.ToString).ToBe('9007199254740992');
+end;
+
+procedure TBigIntegerTests.TestFromDoubleNegMaxSafeInteger;
+var
+  B: TBigInteger;
+begin
+  B := TBigInteger.FromDouble(-9007199254740992.0);
+  Expect<String>(B.ToString).ToBe('-9007199254740992');
+end;
+
+{ ── FromDecimalString ────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestFromDecimalStringZero;
+begin
+  Expect<Boolean>(TBigInteger.FromDecimalString('0').IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromDecimalStringPositive;
+begin
+  Expect<String>(TBigInteger.FromDecimalString('12345').ToString).ToBe('12345');
+end;
+
+procedure TBigIntegerTests.TestFromDecimalStringNegative;
+begin
+  Expect<String>(TBigInteger.FromDecimalString('-9999').ToString).ToBe('-9999');
+end;
+
+procedure TBigIntegerTests.TestFromDecimalStringLeadingPlus;
+begin
+  Expect<String>(TBigInteger.FromDecimalString('+42').ToString).ToBe('42');
+end;
+
+procedure TBigIntegerTests.TestFromDecimalStringLargeNumber;
+var
+  B: TBigInteger;
+begin
+  B := TBigInteger.FromDecimalString('123456789012345678901234567890');
+  Expect<String>(B.ToString).ToBe('123456789012345678901234567890');
+end;
+
+procedure TBigIntegerTests.TestFromDecimalStringEmpty;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromDecimalString('');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromDecimalStringInvalidChar;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromDecimalString('12x34');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromDecimalStringSignOnly;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromDecimalString('-');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+{ ── FromHexString ────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestFromHexStringSmall;
+begin
+  Expect<String>(TBigInteger.FromHexString('ff').ToString).ToBe('255');
+end;
+
+procedure TBigIntegerTests.TestFromHexStringUpperCase;
+begin
+  Expect<String>(TBigInteger.FromHexString('FF').ToString).ToBe('255');
+end;
+
+procedure TBigIntegerTests.TestFromHexStringLarge;
+begin
+  Expect<String>(TBigInteger.FromHexString('100000000').ToString).ToBe('4294967296');
+end;
+
+procedure TBigIntegerTests.TestFromHexStringEmpty;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromHexString('');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromHexStringInvalidChar;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromHexString('GG');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+{ ── FromBinaryString ─────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestFromBinaryStringSmall;
+begin
+  Expect<String>(TBigInteger.FromBinaryString('1010').ToString).ToBe('10');
+end;
+
+procedure TBigIntegerTests.TestFromBinaryStringByte;
+begin
+  Expect<String>(TBigInteger.FromBinaryString('11111111').ToString).ToBe('255');
+end;
+
+procedure TBigIntegerTests.TestFromBinaryStringEmpty;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromBinaryString('');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromBinaryStringInvalidChar;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromBinaryString('102');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+{ ── FromOctalString ──────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestFromOctalStringSmall;
+begin
+  Expect<String>(TBigInteger.FromOctalString('17').ToString).ToBe('15');
+end;
+
+procedure TBigIntegerTests.TestFromOctalStringLarger;
+begin
+  Expect<String>(TBigInteger.FromOctalString('777').ToString).ToBe('511');
+end;
+
+procedure TBigIntegerTests.TestFromOctalStringEmpty;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromOctalString('');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestFromOctalStringInvalidChar;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromOctalString('89');
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+{ ── Predicates ───────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestIsZeroTrue;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(0).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestIsZeroFalse;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(1).IsZero).ToBe(False);
+end;
+
+procedure TBigIntegerTests.TestIsNegativeTrue;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(-5).IsNegative).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestIsNegativeFalse;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(5).IsNegative).ToBe(False);
+end;
+
+procedure TBigIntegerTests.TestIsPositiveTrue;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(5).IsPositive).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestIsPositiveFalse;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(-5).IsPositive).ToBe(False);
+end;
+
+procedure TBigIntegerTests.TestIsOneTrue;
+begin
+  Expect<Boolean>(TBigInteger.One.IsOne).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestIsOneFalse;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(2).IsOne).ToBe(False);
+end;
+
+procedure TBigIntegerTests.TestIsMinusOneTrue;
+begin
+  Expect<Boolean>(TBigInteger.NegativeOne.IsMinusOne).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestIsMinusOneFalse;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(-2).IsMinusOne).ToBe(False);
+end;
+
+procedure TBigIntegerTests.TestBitLength;
+begin
+  Expect<Integer>(TBigInteger.FromInt64(255).BitLength).ToBe(8);
+  Expect<Integer>(TBigInteger.FromInt64(256).BitLength).ToBe(9);
+  Expect<Integer>(TBigInteger.FromInt64(1).BitLength).ToBe(1);
+end;
+
+procedure TBigIntegerTests.TestBitLengthZero;
+begin
+  Expect<Integer>(TBigInteger.Zero.BitLength).ToBe(0);
+end;
+
+procedure TBigIntegerTests.TestGetBit;
+var
+  B: TBigInteger;
+begin
+  B := TBigInteger.FromInt64(5); // binary 101
+  Expect<Boolean>(B.GetBit(0)).ToBe(True);
+  Expect<Boolean>(B.GetBit(1)).ToBe(False);
+  Expect<Boolean>(B.GetBit(2)).ToBe(True);
+  Expect<Boolean>(B.GetBit(3)).ToBe(False);
+  Expect<Boolean>(B.GetBit(100)).ToBe(False);
+end;
+
+{ ── Conversions ──────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestToDoubleZero;
+begin
+  Expect<Boolean>(TBigInteger.Zero.ToDouble = 0.0).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestToDoublePositive;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(42).ToDouble = 42.0).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestToDoubleNegative;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(-42).ToDouble = -42.0).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestToInt64Zero;
+begin
+  Expect<Int64>(TBigInteger.Zero.ToInt64).ToBe(Int64(0));
+end;
+
+procedure TBigIntegerTests.TestToInt64Positive;
+begin
+  Expect<Int64>(TBigInteger.FromInt64(12345).ToInt64).ToBe(Int64(12345));
+end;
+
+procedure TBigIntegerTests.TestToInt64Negative;
+begin
+  Expect<Int64>(TBigInteger.FromInt64(-12345).ToInt64).ToBe(Int64(-12345));
+end;
+
+procedure TBigIntegerTests.TestToInt64Large;
+begin
+  Expect<Int64>(TBigInteger.FromInt64(Int64(4294967296)).ToInt64).ToBe(Int64(4294967296));
+end;
+
+procedure TBigIntegerTests.TestToStringZero;
+begin
+  Expect<String>(TBigInteger.Zero.ToString).ToBe('0');
+end;
+
+procedure TBigIntegerTests.TestToStringPositive;
+begin
+  Expect<String>(TBigInteger.FromInt64(12345).ToString).ToBe('12345');
+end;
+
+procedure TBigIntegerTests.TestToStringNegative;
+begin
+  Expect<String>(TBigInteger.FromInt64(-12345).ToString).ToBe('-12345');
+end;
+
+procedure TBigIntegerTests.TestToRadixStringBinary;
+begin
+  Expect<String>(TBigInteger.FromInt64(10).ToRadixString(2)).ToBe('1010');
+end;
+
+procedure TBigIntegerTests.TestToRadixStringHex;
+begin
+  Expect<String>(TBigInteger.FromInt64(255).ToRadixString(16)).ToBe('ff');
+end;
+
+procedure TBigIntegerTests.TestToRadixStringOctal;
+begin
+  Expect<String>(TBigInteger.FromInt64(8).ToRadixString(8)).ToBe('10');
+end;
+
+procedure TBigIntegerTests.TestToRadixStringBase36;
+begin
+  Expect<String>(TBigInteger.FromInt64(35).ToRadixString(36)).ToBe('z');
+end;
+
+procedure TBigIntegerTests.TestToRadixStringInvalidRadix;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromInt64(1).ToRadixString(1);
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+{ ── Unary ────────────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestNegatePositive;
+begin
+  Expect<String>(TBigInteger.FromInt64(5).Negate.ToString).ToBe('-5');
+end;
+
+procedure TBigIntegerTests.TestNegateNegative;
+begin
+  Expect<String>(TBigInteger.FromInt64(-5).Negate.ToString).ToBe('5');
+end;
+
+procedure TBigIntegerTests.TestNegateZero;
+begin
+  Expect<Boolean>(TBigInteger.Zero.Negate.IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestAbsValuePositive;
+begin
+  Expect<String>(TBigInteger.FromInt64(5).AbsValue.ToString).ToBe('5');
+end;
+
+procedure TBigIntegerTests.TestAbsValueNegative;
+begin
+  Expect<String>(TBigInteger.FromInt64(-5).AbsValue.ToString).ToBe('5');
+end;
+
+procedure TBigIntegerTests.TestAbsValueZero;
+begin
+  Expect<Boolean>(TBigInteger.Zero.AbsValue.IsZero).ToBe(True);
+end;
+
+{ ── Addition ─────────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestAddBothPositive;
+begin
+  Expect<String>(TBigInteger.FromInt64(3).Add(TBigInteger.FromInt64(4)).ToString).ToBe('7');
+end;
+
+procedure TBigIntegerTests.TestAddBothNegative;
+begin
+  Expect<String>(TBigInteger.FromInt64(-3).Add(TBigInteger.FromInt64(-4)).ToString).ToBe('-7');
+end;
+
+procedure TBigIntegerTests.TestAddPositiveNegative;
+begin
+  Expect<String>(TBigInteger.FromInt64(10).Add(TBigInteger.FromInt64(-3)).ToString).ToBe('7');
+end;
+
+procedure TBigIntegerTests.TestAddNegativePositive;
+begin
+  Expect<String>(TBigInteger.FromInt64(-10).Add(TBigInteger.FromInt64(3)).ToString).ToBe('-7');
+end;
+
+procedure TBigIntegerTests.TestAddZeroLeft;
+begin
+  Expect<String>(TBigInteger.Zero.Add(TBigInteger.FromInt64(5)).ToString).ToBe('5');
+end;
+
+procedure TBigIntegerTests.TestAddZeroRight;
+begin
+  Expect<String>(TBigInteger.FromInt64(5).Add(TBigInteger.Zero).ToString).ToBe('5');
+end;
+
+procedure TBigIntegerTests.TestAddCancelToZero;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(42).Add(TBigInteger.FromInt64(-42)).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestAddCarry;
+var
+  A, B: TBigInteger;
+begin
+  // 2^32 - 1 + 1 = 2^32 (forces carry across limb boundary)
+  A := TBigInteger.FromInt64(Int64(4294967295));
+  B := TBigInteger.FromInt64(1);
+  Expect<String>(A.Add(B).ToString).ToBe('4294967296');
+end;
+
+{ ── Subtraction ──────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestSubtractBasic;
+begin
+  Expect<String>(TBigInteger.FromInt64(10).Subtract(TBigInteger.FromInt64(3)).ToString).ToBe('7');
+end;
+
+procedure TBigIntegerTests.TestSubtractNegativeResult;
+begin
+  Expect<String>(TBigInteger.FromInt64(3).Subtract(TBigInteger.FromInt64(10)).ToString).ToBe('-7');
+end;
+
+procedure TBigIntegerTests.TestSubtractFromZero;
+begin
+  Expect<String>(TBigInteger.Zero.Subtract(TBigInteger.FromInt64(5)).ToString).ToBe('-5');
+end;
+
+procedure TBigIntegerTests.TestSubtractToZero;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(7).Subtract(TBigInteger.FromInt64(7)).IsZero).ToBe(True);
+end;
+
+{ ── Multiplication ───────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestMultiplyBasic;
+begin
+  Expect<String>(TBigInteger.FromInt64(6).Multiply(TBigInteger.FromInt64(7)).ToString).ToBe('42');
+end;
+
+procedure TBigIntegerTests.TestMultiplyByZero;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(42).Multiply(TBigInteger.Zero).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestMultiplyNegatives;
+begin
+  Expect<String>(TBigInteger.FromInt64(-3).Multiply(TBigInteger.FromInt64(-4)).ToString).ToBe('12');
+end;
+
+procedure TBigIntegerTests.TestMultiplyMixedSign;
+begin
+  Expect<String>(TBigInteger.FromInt64(3).Multiply(TBigInteger.FromInt64(-4)).ToString).ToBe('-12');
+end;
+
+procedure TBigIntegerTests.TestMultiplyLarge;
+var
+  A, B: TBigInteger;
+begin
+  // 1000000 * 1000000 = 10^12
+  A := TBigInteger.FromInt64(1000000);
+  B := TBigInteger.FromInt64(1000000);
+  Expect<String>(A.Multiply(B).ToString).ToBe('1000000000000');
+end;
+
+{ ── Division ─────────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestDivideExact;
+begin
+  Expect<String>(TBigInteger.FromInt64(42).Divide(TBigInteger.FromInt64(6)).ToString).ToBe('7');
+end;
+
+procedure TBigIntegerTests.TestDivideWithRemainder;
+begin
+  // 7 / 2 = 3 (truncated)
+  Expect<String>(TBigInteger.FromInt64(7).Divide(TBigInteger.FromInt64(2)).ToString).ToBe('3');
+end;
+
+procedure TBigIntegerTests.TestDivideNegative;
+begin
+  Expect<String>(TBigInteger.FromInt64(-42).Divide(TBigInteger.FromInt64(6)).ToString).ToBe('-7');
+end;
+
+procedure TBigIntegerTests.TestDivideTruncatesTowardZero;
+begin
+  // -7 / 2 = -3 (truncates toward zero, not -4)
+  Expect<String>(TBigInteger.FromInt64(-7).Divide(TBigInteger.FromInt64(2)).ToString).ToBe('-3');
+end;
+
+procedure TBigIntegerTests.TestDivideByZero;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromInt64(1).Divide(TBigInteger.Zero);
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestDivideZeroByNonZero;
+begin
+  Expect<Boolean>(TBigInteger.Zero.Divide(TBigInteger.FromInt64(5)).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestDivideSmallerByLarger;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(3).Divide(TBigInteger.FromInt64(10)).IsZero).ToBe(True);
+end;
+
+{ ── Modulo ───────────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestModuloBasic;
+begin
+  Expect<String>(TBigInteger.FromInt64(7).Modulo(TBigInteger.FromInt64(3)).ToString).ToBe('1');
+end;
+
+procedure TBigIntegerTests.TestModuloNegativeDividend;
+begin
+  // -7 % 3 = -1 (sign follows dividend per ES2026)
+  Expect<String>(TBigInteger.FromInt64(-7).Modulo(TBigInteger.FromInt64(3)).ToString).ToBe('-1');
+end;
+
+procedure TBigIntegerTests.TestModuloZeroDividend;
+begin
+  Expect<Boolean>(TBigInteger.Zero.Modulo(TBigInteger.FromInt64(5)).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestModuloByZero;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromInt64(1).Modulo(TBigInteger.Zero);
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestModuloSmallerByLarger;
+begin
+  // 3 % 10 = 3 (returns self)
+  Expect<String>(TBigInteger.FromInt64(3).Modulo(TBigInteger.FromInt64(10)).ToString).ToBe('3');
+end;
+
+{ ── Power ────────────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestPowerBasic;
+begin
+  Expect<String>(TBigInteger.FromInt64(2).Power(TBigInteger.FromInt64(10)).ToString).ToBe('1024');
+end;
+
+procedure TBigIntegerTests.TestPowerOfZero;
+begin
+  Expect<Boolean>(TBigInteger.Zero.Power(TBigInteger.FromInt64(5)).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestPowerToZero;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(99).Power(TBigInteger.Zero).IsOne).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestPowerNegativeExponent;
+var
+  Raised: Boolean;
+begin
+  Raised := False;
+  try
+    TBigInteger.FromInt64(2).Power(TBigInteger.FromInt64(-1));
+  except
+    Raised := True;
+  end;
+  Expect<Boolean>(Raised).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestPowerLarge;
+begin
+  // 10^18 = 1000000000000000000
+  Expect<String>(TBigInteger.FromInt64(10).Power(TBigInteger.FromInt64(18)).ToString).ToBe('1000000000000000000');
+end;
+
+{ ── Bitwise AND ──────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestBitwiseAndBasic;
+begin
+  // 0b1100 & 0b1010 = 0b1000 = 8
+  Expect<String>(TBigInteger.FromInt64(12).BitwiseAnd(TBigInteger.FromInt64(10)).ToString).ToBe('8');
+end;
+
+procedure TBigIntegerTests.TestBitwiseAndWithZero;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(255).BitwiseAnd(TBigInteger.Zero).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestBitwiseAndNegative;
+begin
+  // -1 & 255 = 255 (two's complement: -1 is all 1s)
+  Expect<String>(TBigInteger.FromInt64(-1).BitwiseAnd(TBigInteger.FromInt64(255)).ToString).ToBe('255');
+end;
+
+{ ── Bitwise OR ───────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestBitwiseOrBasic;
+begin
+  // 0b1100 | 0b1010 = 0b1110 = 14
+  Expect<String>(TBigInteger.FromInt64(12).BitwiseOr(TBigInteger.FromInt64(10)).ToString).ToBe('14');
+end;
+
+procedure TBigIntegerTests.TestBitwiseOrWithZero;
+begin
+  Expect<String>(TBigInteger.FromInt64(42).BitwiseOr(TBigInteger.Zero).ToString).ToBe('42');
+end;
+
+procedure TBigIntegerTests.TestBitwiseOrNegative;
+begin
+  // -1 | 0 = -1
+  Expect<String>(TBigInteger.FromInt64(-1).BitwiseOr(TBigInteger.Zero).ToString).ToBe('-1');
+end;
+
+{ ── Bitwise XOR ──────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestBitwiseXorBasic;
+begin
+  // 0b1100 ^ 0b1010 = 0b0110 = 6
+  Expect<String>(TBigInteger.FromInt64(12).BitwiseXor(TBigInteger.FromInt64(10)).ToString).ToBe('6');
+end;
+
+procedure TBigIntegerTests.TestBitwiseXorSelf;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(42).BitwiseXor(TBigInteger.FromInt64(42)).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestBitwiseXorNegative;
+begin
+  // -1 ^ 0 = -1
+  Expect<String>(TBigInteger.FromInt64(-1).BitwiseXor(TBigInteger.Zero).ToString).ToBe('-1');
+end;
+
+{ ── Bitwise NOT ──────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestBitwiseNotPositive;
+begin
+  // ~0 = -1
+  Expect<String>(TBigInteger.Zero.BitwiseNot.ToString).ToBe('-1');
+end;
+
+procedure TBigIntegerTests.TestBitwiseNotNegative;
+begin
+  // ~(-1) = 0
+  Expect<Boolean>(TBigInteger.FromInt64(-1).BitwiseNot.IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestBitwiseNotZero;
+begin
+  // ~5 = -6
+  Expect<String>(TBigInteger.FromInt64(5).BitwiseNot.ToString).ToBe('-6');
+end;
+
+{ ── Shift left ───────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestShiftLeftBasic;
+begin
+  // 1 << 8 = 256
+  Expect<String>(TBigInteger.FromInt64(1).ShiftLeft(8).ToString).ToBe('256');
+end;
+
+procedure TBigIntegerTests.TestShiftLeftZeroCount;
+begin
+  Expect<String>(TBigInteger.FromInt64(42).ShiftLeft(0).ToString).ToBe('42');
+end;
+
+procedure TBigIntegerTests.TestShiftLeftZeroValue;
+begin
+  Expect<Boolean>(TBigInteger.Zero.ShiftLeft(10).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestShiftLeftLarge;
+begin
+  // 1 << 64 = 18446744073709551616
+  Expect<String>(TBigInteger.FromInt64(1).ShiftLeft(64).ToString).ToBe('18446744073709551616');
+end;
+
+{ ── Shift right ──────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestShiftRightBasic;
+begin
+  // 256 >> 4 = 16
+  Expect<String>(TBigInteger.FromInt64(256).ShiftRight(4).ToString).ToBe('16');
+end;
+
+procedure TBigIntegerTests.TestShiftRightZeroCount;
+begin
+  Expect<String>(TBigInteger.FromInt64(42).ShiftRight(0).ToString).ToBe('42');
+end;
+
+procedure TBigIntegerTests.TestShiftRightAllBits;
+begin
+  // 255 >> 100 = 0 (all bits shifted out for positive)
+  Expect<Boolean>(TBigInteger.FromInt64(255).ShiftRight(100).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestShiftRightNegativeFloors;
+begin
+  // -1 >> 1 = -1 (floor division semantics)
+  Expect<String>(TBigInteger.FromInt64(-1).ShiftRight(1).ToString).ToBe('-1');
+  // -3 >> 1 = -2 (floor: -1.5 rounds to -2)
+  Expect<String>(TBigInteger.FromInt64(-3).ShiftRight(1).ToString).ToBe('-2');
+end;
+
+{ ── Comparison ───────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestCompareEqual;
+begin
+  Expect<Integer>(TBigInteger.FromInt64(42).Compare(TBigInteger.FromInt64(42))).ToBe(0);
+end;
+
+procedure TBigIntegerTests.TestCompareLess;
+begin
+  Expect<Integer>(TBigInteger.FromInt64(3).Compare(TBigInteger.FromInt64(5))).ToBe(-1);
+end;
+
+procedure TBigIntegerTests.TestCompareGreater;
+begin
+  Expect<Integer>(TBigInteger.FromInt64(5).Compare(TBigInteger.FromInt64(3))).ToBe(1);
+end;
+
+procedure TBigIntegerTests.TestCompareNegatives;
+begin
+  Expect<Integer>(TBigInteger.FromInt64(-5).Compare(TBigInteger.FromInt64(-3))).ToBe(-1);
+  Expect<Integer>(TBigInteger.FromInt64(-3).Compare(TBigInteger.FromInt64(-5))).ToBe(1);
+end;
+
+procedure TBigIntegerTests.TestCompareMixedSign;
+begin
+  Expect<Integer>(TBigInteger.FromInt64(-1).Compare(TBigInteger.FromInt64(1))).ToBe(-1);
+  Expect<Integer>(TBigInteger.FromInt64(1).Compare(TBigInteger.FromInt64(-1))).ToBe(1);
+end;
+
+procedure TBigIntegerTests.TestEqualTrue;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(42).Equal(TBigInteger.FromInt64(42))).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestEqualFalse;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(42).Equal(TBigInteger.FromInt64(43))).ToBe(False);
+end;
+
+{ ── AsIntN / AsUintN ─────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestAsIntN8;
+begin
+  // 127 fits in signed 8-bit
+  Expect<String>(TBigInteger.FromInt64(127).AsIntN(8).ToString).ToBe('127');
+end;
+
+procedure TBigIntegerTests.TestAsIntN8Negative;
+begin
+  // -128 is the minimum signed 8-bit value
+  Expect<String>(TBigInteger.FromInt64(-128).AsIntN(8).ToString).ToBe('-128');
+end;
+
+procedure TBigIntegerTests.TestAsIntN8Overflow;
+begin
+  // 128 overflows signed 8-bit → wraps to -128
+  Expect<String>(TBigInteger.FromInt64(128).AsIntN(8).ToString).ToBe('-128');
+  // 255 → -1
+  Expect<String>(TBigInteger.FromInt64(255).AsIntN(8).ToString).ToBe('-1');
+end;
+
+procedure TBigIntegerTests.TestAsUintN8;
+begin
+  Expect<String>(TBigInteger.FromInt64(200).AsUintN(8).ToString).ToBe('200');
+end;
+
+procedure TBigIntegerTests.TestAsUintN8Large;
+begin
+  // 256 mod 256 = 0
+  Expect<String>(TBigInteger.FromInt64(256).AsUintN(8).ToString).ToBe('0');
+  // 257 mod 256 = 1
+  Expect<String>(TBigInteger.FromInt64(257).AsUintN(8).ToString).ToBe('1');
+end;
+
+procedure TBigIntegerTests.TestAsUintNZeroBits;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(42).AsUintN(0).IsZero).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestAsIntNZeroBits;
+begin
+  Expect<Boolean>(TBigInteger.FromInt64(42).AsIntN(0).IsZero).ToBe(True);
+end;
+
+{ ── Roundtrips ───────────────────────────────────────────────────── }
+
+procedure TBigIntegerTests.TestRoundtripFromInt64;
+var
+  Values: array[0..5] of Int64;
+  I: Integer;
+begin
+  Values[0] := 0;
+  Values[1] := 1;
+  Values[2] := -1;
+  Values[3] := 2147483647;
+  Values[4] := Int64(-2147483648);
+  Values[5] := Int64(1718451045123);
+
+  for I := 0 to High(Values) do
+    Expect<Int64>(TBigInteger.FromInt64(Values[I]).ToInt64).ToBe(Values[I]);
+end;
+
+procedure TBigIntegerTests.TestRoundtripDecimalString;
+var
+  S: string;
+begin
+  S := '99999999999999999999';
+  Expect<String>(TBigInteger.FromDecimalString(S).ToString).ToBe(S);
+end;
+
+procedure TBigIntegerTests.TestRoundtripDivModConsistency;
+var
+  A, B, Q, R, Reconstructed: TBigInteger;
+begin
+  // Verify: a = (a / b) * b + (a mod b) for several cases
+  A := TBigInteger.FromInt64(100);
+  B := TBigInteger.FromInt64(7);
+  Q := A.Divide(B);
+  R := A.Modulo(B);
+  Reconstructed := Q.Multiply(B).Add(R);
+  Expect<Boolean>(A.Equal(Reconstructed)).ToBe(True);
+
+  // Negative dividend
+  A := TBigInteger.FromInt64(-100);
+  Q := A.Divide(B);
+  R := A.Modulo(B);
+  Reconstructed := Q.Multiply(B).Add(R);
+  Expect<Boolean>(A.Equal(Reconstructed)).ToBe(True);
+end;
+
+procedure TBigIntegerTests.TestRoundtripFromDoubleToInt64;
+var
+  Values: array[0..3] of Int64;
+  I: Integer;
+  D: Double;
+begin
+  Values[0] := Int64(1718451045123);
+  Values[1] := Int64(9007199254740992);
+  Values[2] := Int64(-9007199254740992);
+  Values[3] := Int64(4294967296);
+
+  for I := 0 to High(Values) do
+  begin
+    D := Values[I];
+    Expect<Int64>(TBigInteger.FromDouble(D).ToInt64).ToBe(Values[I]);
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TBigIntegerTests.Create('BigInteger'));
+  TestRunnerProgram.Run;
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/shared/BigInteger.Test.pas
+++ b/source/shared/BigInteger.Test.pas
@@ -37,8 +37,8 @@ type
     procedure TestFromDoubleNaN;
     procedure TestFromDoubleInfinity;
     procedure TestFromDoubleNonInteger;
-    procedure TestFromDoubleMaxSafeInteger;
-    procedure TestFromDoubleNegMaxSafeInteger;
+    procedure TestFromDouble2Pow53;
+    procedure TestFromDoubleNeg2Pow53;
 
     { FromDecimalString }
     procedure TestFromDecimalStringZero;
@@ -237,12 +237,12 @@ begin
   Test('FromDouble(0.0) produces zero', TestFromDoubleZero);
   Test('FromDouble positive integer', TestFromDoublePositive);
   Test('FromDouble negative integer', TestFromDoubleNegative);
-  Test('FromDouble large value (epoch ns)', TestFromDoubleLargeValue);
+  Test('FromDouble large value (epoch ms)', TestFromDoubleLargeValue);
   Test('FromDouble NaN raises', TestFromDoubleNaN);
   Test('FromDouble Infinity raises', TestFromDoubleInfinity);
   Test('FromDouble non-integer raises', TestFromDoubleNonInteger);
-  Test('FromDouble 2^53 (Int64 fast-path boundary)', TestFromDoubleMaxSafeInteger);
-  Test('FromDouble -2^53 (Int64 fast-path boundary)', TestFromDoubleNegMaxSafeInteger);
+  Test('FromDouble 2^53 (Int64 fast-path boundary)', TestFromDouble2Pow53);
+  Test('FromDouble -2^53 (Int64 fast-path boundary)', TestFromDoubleNeg2Pow53);
 
   { FromDecimalString }
   Test('FromDecimalString "0"', TestFromDecimalStringZero);
@@ -519,7 +519,7 @@ procedure TBigIntegerTests.TestFromDoubleLargeValue;
 var
   B: TBigInteger;
 begin
-  // Epoch nanoseconds magnitude — the value that triggered the AArch64 bug
+  // Epoch milliseconds magnitude — the value that triggered the AArch64 bug
   B := TBigInteger.FromDouble(1718451045123.0);
   Expect<Int64>(B.ToInt64).ToBe(Int64(1718451045123));
 end;
@@ -563,7 +563,7 @@ begin
   Expect<Boolean>(Raised).ToBe(True);
 end;
 
-procedure TBigIntegerTests.TestFromDoubleMaxSafeInteger;
+procedure TBigIntegerTests.TestFromDouble2Pow53;
 var
   B: TBigInteger;
 begin
@@ -572,7 +572,7 @@ begin
   Expect<String>(B.ToString).ToBe('9007199254740992');
 end;
 
-procedure TBigIntegerTests.TestFromDoubleNegMaxSafeInteger;
+procedure TBigIntegerTests.TestFromDoubleNeg2Pow53;
 var
   B: TBigInteger;
 begin

--- a/source/shared/BigInteger.Test.pas
+++ b/source/shared/BigInteger.Test.pas
@@ -1243,8 +1243,8 @@ end;
 
 procedure TBigIntegerTests.TestBitwiseNotPositive;
 begin
-  // ~0 = -1
-  Expect<String>(TBigInteger.Zero.BitwiseNot.ToString).ToBe('-1');
+  // ~5 = -6
+  Expect<String>(TBigInteger.FromInt64(5).BitwiseNot.ToString).ToBe('-6');
 end;
 
 procedure TBigIntegerTests.TestBitwiseNotNegative;
@@ -1255,8 +1255,8 @@ end;
 
 procedure TBigIntegerTests.TestBitwiseNotZero;
 begin
-  // ~5 = -6
-  Expect<String>(TBigInteger.FromInt64(5).BitwiseNot.ToString).ToBe('-6');
+  // ~0 = -1
+  Expect<String>(TBigInteger.Zero.BitwiseNot.ToString).ToBe('-1');
 end;
 
 { ── Shift left ───────────────────────────────────────────────────── }

--- a/source/shared/BigInteger.pas
+++ b/source/shared/BigInteger.pas
@@ -375,6 +375,11 @@ begin
   if AValue = 0 then
     Exit(Zero);
 
+  // All exact IEEE 754 integers fit in Int64 — use direct conversion to avoid
+  // FPC 3.2.2 AArch64 floating-point precision bugs with FMod/LIMB_BASE arithmetic
+  if (AValue >= -9007199254740992.0) and (AValue <= 9007199254740992.0) then
+    Exit(FromInt64(Trunc(AValue)));
+
   Result.FNegative := AValue < 0;
   V := Abs(AValue);
   Result.FLimbs := nil;

--- a/source/units/Goccia.Builtins.Temporal.pas
+++ b/source/units/Goccia.Builtins.Temporal.pas
@@ -87,6 +87,7 @@ uses
   DateUtils,
   SysUtils,
 
+  BigInteger,
   TimingUtils,
 
   Goccia.Constants.PropertyNames,
@@ -96,6 +97,7 @@ uses
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
+  Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -315,18 +317,23 @@ end;
 
 function TGocciaTemporalBuiltin.InstantConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  EpochNs, MsFloat: Double;
+  Arg: TGocciaValue;
+  BigNs, BigMs, BigSubMs: TBigInteger;
   Ms: Int64;
   SubMs: Integer;
 begin
   if AArgs.Length < 1 then
     ThrowTypeError(SErrorTemporalInstantRequiresEpoch, SSuggestTemporalFromArg);
 
-  EpochNs := AArgs.GetElement(0).ToNumberLiteral.Value;
-  Ms := Trunc(EpochNs / 1000000);
-  // Safe Int64 → Double conversion (FPC 3.2.2 AArch64 bug: Int64 * Double gives wrong results)
-  MsFloat := Ms;
-  SubMs := Trunc(EpochNs - MsFloat * 1000000.0);
+  Arg := AArgs.GetElement(0);
+  if not (Arg is TGocciaBigIntValue) then
+    ThrowTypeError(SErrorTemporalInstantRequiresBigInt, SSuggestTemporalBigIntArg);
+
+  BigNs := TGocciaBigIntValue(Arg).Value;
+  BigMs := BigNs.Divide(TBigInteger.FromInt64(1000000));
+  BigSubMs := BigNs.Modulo(TBigInteger.FromInt64(1000000));
+  Ms := BigMs.ToInt64;
+  SubMs := Integer(BigSubMs.ToInt64);
 
   Result := TGocciaTemporalInstantValue.Create(Ms, SubMs);
 end;
@@ -374,17 +381,24 @@ end;
 
 function TGocciaTemporalBuiltin.InstantFromEpochNanoseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  EpochNs, MsFloat: Double;
+  Arg: TGocciaValue;
+  BigNs, BigMs, BigSubMs: TBigInteger;
   Ms: Int64;
   SubMs: Integer;
 begin
   if AArgs.Length < 1 then
     ThrowTypeError(SErrorTemporalInstantFromEpochNanos, SSuggestTemporalFromArg);
-  EpochNs := AArgs.GetElement(0).ToNumberLiteral.Value;
-  Ms := Trunc(EpochNs / 1000000);
-  // Safe Int64 → Double conversion (FPC 3.2.2 AArch64 bug: Int64 * Double gives wrong results)
-  MsFloat := Ms;
-  SubMs := Trunc(EpochNs - MsFloat * 1000000.0);
+
+  Arg := AArgs.GetElement(0);
+  if not (Arg is TGocciaBigIntValue) then
+    ThrowTypeError(SErrorTemporalInstantRequiresBigInt, SSuggestTemporalBigIntArg);
+
+  BigNs := TGocciaBigIntValue(Arg).Value;
+  BigMs := BigNs.Divide(TBigInteger.FromInt64(1000000));
+  BigSubMs := BigNs.Modulo(TBigInteger.FromInt64(1000000));
+  Ms := BigMs.ToInt64;
+  SubMs := Integer(BigSubMs.ToInt64);
+
   Result := TGocciaTemporalInstantValue.Create(Ms, SubMs);
 end;
 
@@ -1134,7 +1148,8 @@ end;
 function TGocciaTemporalBuiltin.ZonedDateTimeConstructorFn(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  EpochNs, MsFloat: Double;
+  Arg: TGocciaValue;
+  BigNs, BigMs, BigSubMs: TBigInteger;
   Ms: Int64;
   SubMs: Integer;
   TZ: string;
@@ -1142,11 +1157,15 @@ begin
   if AArgs.Length < 2 then
     ThrowTypeError(SErrorTemporalZonedDateTimeArgs, SSuggestTemporalTimezone);
 
-  EpochNs := AArgs.GetElement(0).ToNumberLiteral.Value;
-  Ms := Trunc(EpochNs / 1000000);
-  // Safe Int64 → Double conversion (FPC 3.2.2 AArch64 bug: Int64 * Double gives wrong results)
-  MsFloat := Ms;
-  SubMs := Trunc(EpochNs - MsFloat * 1000000.0);
+  Arg := AArgs.GetElement(0);
+  if not (Arg is TGocciaBigIntValue) then
+    ThrowTypeError(SErrorTemporalZonedDateTimeRequiresBigInt, SSuggestTemporalBigIntArg);
+
+  BigNs := TGocciaBigIntValue(Arg).Value;
+  BigMs := BigNs.Divide(TBigInteger.FromInt64(1000000));
+  BigSubMs := BigNs.Modulo(TBigInteger.FromInt64(1000000));
+  Ms := BigMs.ToInt64;
+  SubMs := Integer(BigSubMs.ToInt64);
   TZ := AArgs.GetElement(1).ToStringLiteral.Value;
 
   Result := TGocciaTemporalZonedDateTimeValue.Create(Ms, SubMs, TZ);

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -131,6 +131,7 @@ resourcestring
 
   // Temporal API errors — Instant
   SErrorTemporalInstantRequiresEpoch = 'Temporal.Instant requires epochNanoseconds argument';
+  SErrorTemporalInstantRequiresBigInt = 'Temporal.Instant epochNanoseconds must be a BigInt';
   SErrorInvalidISOInstant = 'Invalid ISO instant string';
   SErrorTemporalInstantFromArg = 'Temporal.Instant.from requires a string or Instant';
   SErrorTemporalInstantFromEpochMillis = 'Temporal.Instant.fromEpochMilliseconds requires an argument';
@@ -177,6 +178,7 @@ resourcestring
 
   // Temporal API errors — ZonedDateTime
   SErrorTemporalZonedDateTimeArgs = 'Temporal.ZonedDateTime requires epochNanoseconds and timeZone arguments';
+  SErrorTemporalZonedDateTimeRequiresBigInt = 'Temporal.ZonedDateTime epochNanoseconds must be a BigInt';
   SErrorTemporalZonedDateTimeFromArg = 'Temporal.ZonedDateTime.from requires a string or ZonedDateTime';
   SErrorTemporalZonedDateTimeCompareArg = 'Temporal.ZonedDateTime.compare requires ZonedDateTime or string arguments';
   SErrorInvalidISOZonedDateTime = 'Invalid ISO zoned date-time string';

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -237,6 +237,7 @@ resourcestring
   // Runtime errors — Temporal
   SSuggestTemporalISOFormat = 'provide a valid ISO 8601 string (e.g., "2024-01-15", "2024-01-15T10:30:00")';
   SSuggestTemporalFromArg = 'pass a string in ISO 8601 format, an existing Temporal object, or a property bag';
+  SSuggestTemporalBigIntArg = 'epochNanoseconds must be a BigInt (e.g., 0n or BigInt(1000000))';
   SSuggestTemporalCompareArg = 'both arguments must be the same Temporal type or valid ISO strings';
   SSuggestTemporalWithObject = 'pass an object with the date/time fields to update (e.g., { year: 2025 })';
   SSuggestTemporalDurationArg = 'pass a Temporal.Duration, a duration string (e.g., "P1Y2M"), or a duration-like object';

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -169,8 +169,8 @@ const
         '      this.#ms = dt.toZonedDateTime(Temporal.Now.timeZoneId()).epochMilliseconds;'#10 +
         '    }'#10 +
         '  }'#10 +
-        '  #local() { return new Temporal.ZonedDateTime(this.#ms * 1000000, Temporal.Now.timeZoneId()); }'#10 +
-        '  #utc() { return new Temporal.ZonedDateTime(this.#ms * 1000000, "UTC"); }'#10 +
+        '  #local() { return new Temporal.ZonedDateTime(BigInt(this.#ms) * 1000000n, Temporal.Now.timeZoneId()); }'#10 +
+        '  #utc() { return new Temporal.ZonedDateTime(BigInt(this.#ms) * 1000000n, "UTC"); }'#10 +
         '  getTime(): number { return this.#ms; }'#10 +
         '  valueOf(): number { return this.#ms; }'#10 +
         '  getFullYear(): number { return this.#local().year; }'#10 +

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -152,14 +152,18 @@ const
         '  #ms;'#10 +
         '  static now(): number { return Temporal.Now.instant().epochMilliseconds; }'#10 +
         '  static parse(str: string): number {'#10 +
-        '    return Temporal.Instant.from(String(str)).epochMilliseconds;'#10 +
+        '    try { return Temporal.Instant.from(String(str)).epochMilliseconds; }'#10 +
+        '    catch (e) { return NaN; }'#10 +
         '  }'#10 +
         '  constructor(...args: any[]) {'#10 +
         '    if (args.length === 0) {'#10 +
         '      this.#ms = Temporal.Now.instant().epochMilliseconds;'#10 +
         '    } else if (args.length === 1) {'#10 +
         '      const v = args[0];'#10 +
-        '      this.#ms = typeof v === "number" ? Math.trunc(v) : Temporal.Instant.from(String(v)).epochMilliseconds;'#10 +
+        '      if (typeof v === "number") {'#10 +
+        '        const t = Math.trunc(v);'#10 +
+        '        this.#ms = Number.isFinite(t) && Math.abs(t) <= 8.64e15 ? t : NaN;'#10 +
+        '      } else { this.#ms = Date.parse(String(v)); }'#10 +
         '    } else {'#10 +
         '      const y: number = args[0] >= 0 && args[0] <= 99 ? 1900 + args[0] : args[0];'#10 +
         '      const dt = new Temporal.PlainDateTime('#10 +
@@ -191,8 +195,8 @@ const
         '  getUTCSeconds(): number { const z = this.#utc(); return z ? z.second : NaN; }'#10 +
         '  getUTCMilliseconds(): number { const z = this.#utc(); return z ? z.millisecond : NaN; }'#10 +
         '  getTimezoneOffset(): number { const z = this.#local(); return z ? -(z.offsetNanoseconds / 60000000000) : NaN; }'#10 +
-        '  toISOString(): string { if (!this.#valid()) return "Invalid Date"; return Temporal.Instant.fromEpochMilliseconds(this.#ms).toString(); }'#10 +
-        '  toJSON(): string { return this.toISOString(); }'#10 +
+        '  toISOString(): string { if (!this.#valid()) throw new RangeError("Invalid time value"); return Temporal.Instant.fromEpochMilliseconds(this.#ms).toString(); }'#10 +
+        '  toJSON(): string { if (!this.#valid()) return null; return this.toISOString(); }'#10 +
         '  toString(): string {'#10 +
         '    const z = this.#local();'#10 +
         '    if (!z) return "Invalid Date";'#10 +

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -196,7 +196,7 @@ const
         '  getUTCMilliseconds(): number { const z = this.#utc(); return z ? z.millisecond : NaN; }'#10 +
         '  getTimezoneOffset(): number { const z = this.#local(); return z ? -(z.offsetNanoseconds / 60000000000) : NaN; }'#10 +
         '  toISOString(): string { if (!this.#valid()) throw new RangeError("Invalid time value"); return Temporal.Instant.fromEpochMilliseconds(this.#ms).toString(); }'#10 +
-        '  toJSON(): string { if (!this.#valid()) return null; return this.toISOString(); }'#10 +
+        '  toJSON(): string | null { if (!this.#valid()) return null; return this.toISOString(); }'#10 +
         '  toString(): string {'#10 +
         '    const z = this.#local();'#10 +
         '    if (!z) return "Invalid Date";'#10 +

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -159,7 +159,7 @@ const
         '      this.#ms = Temporal.Now.instant().epochMilliseconds;'#10 +
         '    } else if (args.length === 1) {'#10 +
         '      const v = args[0];'#10 +
-        '      this.#ms = typeof v === "number" ? v : Temporal.Instant.from(String(v)).epochMilliseconds;'#10 +
+        '      this.#ms = typeof v === "number" ? Math.trunc(v) : Temporal.Instant.from(String(v)).epochMilliseconds;'#10 +
         '    } else {'#10 +
         '      const y: number = args[0] >= 0 && args[0] <= 99 ? 1900 + args[0] : args[0];'#10 +
         '      const dt = new Temporal.PlainDateTime('#10 +
@@ -169,31 +169,33 @@ const
         '      this.#ms = dt.toZonedDateTime(Temporal.Now.timeZoneId()).epochMilliseconds;'#10 +
         '    }'#10 +
         '  }'#10 +
-        '  #local() { return new Temporal.ZonedDateTime(BigInt(this.#ms) * 1000000n, Temporal.Now.timeZoneId()); }'#10 +
-        '  #utc() { return new Temporal.ZonedDateTime(BigInt(this.#ms) * 1000000n, "UTC"); }'#10 +
+        '  #valid() { return Number.isFinite(this.#ms); }'#10 +
+        '  #local() { return this.#valid() ? new Temporal.ZonedDateTime(BigInt(this.#ms) * 1000000n, Temporal.Now.timeZoneId()) : null; }'#10 +
+        '  #utc() { return this.#valid() ? new Temporal.ZonedDateTime(BigInt(this.#ms) * 1000000n, "UTC") : null; }'#10 +
         '  getTime(): number { return this.#ms; }'#10 +
         '  valueOf(): number { return this.#ms; }'#10 +
-        '  getFullYear(): number { return this.#local().year; }'#10 +
-        '  getMonth(): number { return this.#local().month - 1; }'#10 +
-        '  getDate(): number { return this.#local().day; }'#10 +
-        '  getDay(): number { return this.#local().dayOfWeek % 7; }'#10 +
-        '  getHours(): number { return this.#local().hour; }'#10 +
-        '  getMinutes(): number { return this.#local().minute; }'#10 +
-        '  getSeconds(): number { return this.#local().second; }'#10 +
-        '  getMilliseconds(): number { return this.#local().millisecond; }'#10 +
-        '  getUTCFullYear(): number { return this.#utc().year; }'#10 +
-        '  getUTCMonth(): number { return this.#utc().month - 1; }'#10 +
-        '  getUTCDate(): number { return this.#utc().day; }'#10 +
-        '  getUTCDay(): number { return this.#utc().dayOfWeek % 7; }'#10 +
-        '  getUTCHours(): number { return this.#utc().hour; }'#10 +
-        '  getUTCMinutes(): number { return this.#utc().minute; }'#10 +
-        '  getUTCSeconds(): number { return this.#utc().second; }'#10 +
-        '  getUTCMilliseconds(): number { return this.#utc().millisecond; }'#10 +
-        '  getTimezoneOffset(): number { return -(this.#local().offsetNanoseconds / 60000000000); }'#10 +
-        '  toISOString(): string { return Temporal.Instant.fromEpochMilliseconds(this.#ms).toString(); }'#10 +
+        '  getFullYear(): number { const z = this.#local(); return z ? z.year : NaN; }'#10 +
+        '  getMonth(): number { const z = this.#local(); return z ? z.month - 1 : NaN; }'#10 +
+        '  getDate(): number { const z = this.#local(); return z ? z.day : NaN; }'#10 +
+        '  getDay(): number { const z = this.#local(); return z ? z.dayOfWeek % 7 : NaN; }'#10 +
+        '  getHours(): number { const z = this.#local(); return z ? z.hour : NaN; }'#10 +
+        '  getMinutes(): number { const z = this.#local(); return z ? z.minute : NaN; }'#10 +
+        '  getSeconds(): number { const z = this.#local(); return z ? z.second : NaN; }'#10 +
+        '  getMilliseconds(): number { const z = this.#local(); return z ? z.millisecond : NaN; }'#10 +
+        '  getUTCFullYear(): number { const z = this.#utc(); return z ? z.year : NaN; }'#10 +
+        '  getUTCMonth(): number { const z = this.#utc(); return z ? z.month - 1 : NaN; }'#10 +
+        '  getUTCDate(): number { const z = this.#utc(); return z ? z.day : NaN; }'#10 +
+        '  getUTCDay(): number { const z = this.#utc(); return z ? z.dayOfWeek % 7 : NaN; }'#10 +
+        '  getUTCHours(): number { const z = this.#utc(); return z ? z.hour : NaN; }'#10 +
+        '  getUTCMinutes(): number { const z = this.#utc(); return z ? z.minute : NaN; }'#10 +
+        '  getUTCSeconds(): number { const z = this.#utc(); return z ? z.second : NaN; }'#10 +
+        '  getUTCMilliseconds(): number { const z = this.#utc(); return z ? z.millisecond : NaN; }'#10 +
+        '  getTimezoneOffset(): number { const z = this.#local(); return z ? -(z.offsetNanoseconds / 60000000000) : NaN; }'#10 +
+        '  toISOString(): string { if (!this.#valid()) return "Invalid Date"; return Temporal.Instant.fromEpochMilliseconds(this.#ms).toString(); }'#10 +
         '  toJSON(): string { return this.toISOString(); }'#10 +
         '  toString(): string {'#10 +
         '    const z = this.#local();'#10 +
+        '    if (!z) return "Invalid Date";'#10 +
         '    const pad = (n: number): string => n < 10 ? "0" + String(n) : String(n);'#10 +
         '    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];'#10 +
         '    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];'#10 +

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -5,6 +5,8 @@ unit Goccia.Temporal.Options;
 interface
 
 uses
+  BigInteger,
+
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
@@ -59,6 +61,7 @@ function GetOverflowOption(const AOptions: TGocciaObjectValue): TTemporalOverflo
 function GetFractionalSecondDigits(const AOptions: TGocciaObjectValue): Integer;
 function UnitToNanoseconds(const AUnit: TTemporalUnit): Int64;
 function RoundWithMode(const AValue: Int64; const ADivisor: Int64; const AMode: TTemporalRoundingMode): Int64;
+function RoundBigIntWithMode(const AValue: TBigInteger; const ADivisor: TBigInteger; const AMode: TTemporalRoundingMode): TBigInteger;
 function FormatTimeWithPrecision(const AHour, AMinute, ASecond, AMillisecond,
   AMicrosecond, ANanosecond: Integer; const AFractionalDigits: Integer): string;
 
@@ -365,6 +368,127 @@ begin
     end;
   else
     Result := Quotient * ADivisor;
+  end;
+end;
+
+function RoundBigIntWithMode(const AValue: TBigInteger; const ADivisor: TBigInteger;
+  const AMode: TTemporalRoundingMode): TBigInteger;
+var
+  Quotient, Remainder, AbsRemainder, Half, AbsDivisor, Two: TBigInteger;
+begin
+  if ADivisor.IsOne then
+    Exit(AValue);
+
+  Quotient := AValue.Divide(ADivisor);
+  Remainder := AValue.Modulo(ADivisor);
+
+  if Remainder.IsZero then
+    Exit(Quotient.Multiply(ADivisor));
+
+  AbsRemainder := Remainder.AbsValue;
+  AbsDivisor := ADivisor.AbsValue;
+  Two := TBigInteger.FromInt64(2);
+
+  case AMode of
+    rmTrunc:
+      Result := Quotient.Multiply(ADivisor);
+    rmFloor:
+    begin
+      if AValue.IsNegative then
+        Result := Quotient.Subtract(TBigInteger.One).Multiply(ADivisor)
+      else
+        Result := Quotient.Multiply(ADivisor);
+    end;
+    rmCeil:
+    begin
+      if AValue.IsPositive then
+        Result := Quotient.Add(TBigInteger.One).Multiply(ADivisor)
+      else
+        Result := Quotient.Multiply(ADivisor);
+    end;
+    rmHalfExpand:
+    begin
+      Half := AbsRemainder.Multiply(Two);
+      if Half.Compare(AbsDivisor) >= 0 then
+      begin
+        if AValue.IsPositive then
+          Result := Quotient.Add(TBigInteger.One).Multiply(ADivisor)
+        else
+          Result := Quotient.Subtract(TBigInteger.One).Multiply(ADivisor);
+      end
+      else
+        Result := Quotient.Multiply(ADivisor);
+    end;
+    rmHalfTrunc:
+    begin
+      Half := AbsRemainder.Multiply(Two);
+      if Half.Compare(AbsDivisor) > 0 then
+      begin
+        if AValue.IsPositive then
+          Result := Quotient.Add(TBigInteger.One).Multiply(ADivisor)
+        else
+          Result := Quotient.Subtract(TBigInteger.One).Multiply(ADivisor);
+      end
+      else
+        Result := Quotient.Multiply(ADivisor);
+    end;
+    rmHalfCeil:
+    begin
+      Half := AbsRemainder.Multiply(Two);
+      if Half.Compare(AbsDivisor) >= 0 then
+      begin
+        if AValue.IsPositive then
+          Result := Quotient.Add(TBigInteger.One).Multiply(ADivisor)
+        else if Half.Compare(AbsDivisor) > 0 then
+          Result := Quotient.Subtract(TBigInteger.One).Multiply(ADivisor)
+        else
+          Result := Quotient.Multiply(ADivisor);
+      end
+      else
+        Result := Quotient.Multiply(ADivisor);
+    end;
+    rmHalfFloor:
+    begin
+      Half := AbsRemainder.Multiply(Two);
+      if Half.Compare(AbsDivisor) >= 0 then
+      begin
+        if AValue.IsNegative then
+          Result := Quotient.Subtract(TBigInteger.One).Multiply(ADivisor)
+        else if Half.Compare(AbsDivisor) > 0 then
+          Result := Quotient.Add(TBigInteger.One).Multiply(ADivisor)
+        else
+          Result := Quotient.Multiply(ADivisor);
+      end
+      else
+        Result := Quotient.Multiply(ADivisor);
+    end;
+    rmHalfEven:
+    begin
+      Half := AbsRemainder.Multiply(Two);
+      if Half.Compare(AbsDivisor) > 0 then
+      begin
+        if AValue.IsPositive then
+          Result := Quotient.Add(TBigInteger.One).Multiply(ADivisor)
+        else
+          Result := Quotient.Subtract(TBigInteger.One).Multiply(ADivisor);
+      end
+      else if Half.Compare(AbsDivisor) = 0 then
+      begin
+        if Quotient.GetBit(0) then
+        begin
+          if AValue.IsPositive then
+            Result := Quotient.Add(TBigInteger.One).Multiply(ADivisor)
+          else
+            Result := Quotient.Subtract(TBigInteger.One).Multiply(ADivisor);
+        end
+        else
+          Result := Quotient.Multiply(ADivisor);
+      end
+      else
+        Result := Quotient.Multiply(ADivisor);
+    end;
+  else
+    Result := Quotient.Multiply(ADivisor);
   end;
 end;
 

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -278,7 +278,7 @@ var
   Inst, Other: TGocciaTemporalInstantValue;
   DiffMs: Int64;
   DiffSubMs: Integer;
-  DiffNs: Int64;
+  RemMs: Int64;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.until');
   Other := CoerceInstant(AArgs.GetElement(0), 'Instant.prototype.until');
@@ -286,16 +286,27 @@ begin
   DiffMs := Other.FEpochMilliseconds - Inst.FEpochMilliseconds;
   DiffSubMs := Other.FSubMillisecondNanoseconds - Inst.FSubMillisecondNanoseconds;
 
-  // Convert to total nanoseconds
-  DiffNs := DiffMs * 1000000 + DiffSubMs;
+  // Normalize so DiffMs and DiffSubMs share the same sign
+  if (DiffMs > 0) and (DiffSubMs < 0) then
+  begin
+    Dec(DiffMs);
+    Inc(DiffSubMs, 1000000);
+  end
+  else if (DiffMs < 0) and (DiffSubMs > 0) then
+  begin
+    Inc(DiffMs);
+    Dec(DiffSubMs, 1000000);
+  end;
 
+  // Decompose ms into hours/minutes/seconds/ms without collapsing to total ns
+  RemMs := DiffMs;
   Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    DiffNs div Int64(3600000000000),
-    (DiffNs div Int64(60000000000)) mod 60,
-    (DiffNs div Int64(1000000000)) mod 60,
-    (DiffNs div 1000000) mod 1000,
-    (DiffNs div 1000) mod 1000,
-    DiffNs mod 1000);
+    RemMs div 3600000,
+    (RemMs mod 3600000) div 60000,
+    ((RemMs mod 3600000) mod 60000) div 1000,
+    ((RemMs mod 3600000) mod 60000) mod 1000,
+    DiffSubMs div 1000,
+    DiffSubMs mod 1000);
 end;
 
 function TGocciaTemporalInstantValue.InstantSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -303,7 +314,7 @@ var
   Inst, Other: TGocciaTemporalInstantValue;
   DiffMs: Int64;
   DiffSubMs: Integer;
-  DiffNs: Int64;
+  RemMs: Int64;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.since');
   Other := CoerceInstant(AArgs.GetElement(0), 'Instant.prototype.since');
@@ -311,15 +322,26 @@ begin
   DiffMs := Inst.FEpochMilliseconds - Other.FEpochMilliseconds;
   DiffSubMs := Inst.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;
 
-  DiffNs := DiffMs * 1000000 + DiffSubMs;
+  // Normalize so DiffMs and DiffSubMs share the same sign
+  if (DiffMs > 0) and (DiffSubMs < 0) then
+  begin
+    Dec(DiffMs);
+    Inc(DiffSubMs, 1000000);
+  end
+  else if (DiffMs < 0) and (DiffSubMs > 0) then
+  begin
+    Inc(DiffMs);
+    Dec(DiffSubMs, 1000000);
+  end;
 
+  RemMs := DiffMs;
   Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    DiffNs div Int64(3600000000000),
-    (DiffNs div Int64(60000000000)) mod 60,
-    (DiffNs div Int64(1000000000)) mod 60,
-    (DiffNs div 1000000) mod 1000,
-    (DiffNs div 1000) mod 1000,
-    DiffNs mod 1000);
+    RemMs div 3600000,
+    (RemMs mod 3600000) div 60000,
+    ((RemMs mod 3600000) mod 60000) div 1000,
+    ((RemMs mod 3600000) mod 60000) mod 1000,
+    DiffSubMs div 1000,
+    DiffSubMs mod 1000);
 end;
 
 function TGocciaTemporalInstantValue.InstantRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -328,11 +350,12 @@ var
   UnitStr: string;
   Arg: TGocciaValue;
   OptionsObj: TGocciaObjectValue;
-  TotalNs, Divisor, Rounded, NewMs: Int64;
+  NewMs: Int64;
   NewSubMs: Integer;
   SmallestUnit: TTemporalUnit;
   Mode: TTemporalRoundingMode;
   Increment: Integer;
+  BigTotal, BigDivisor, BigRounded, BigMillion: TBigInteger;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.round');
   Arg := AArgs.GetElement(0);
@@ -361,17 +384,16 @@ begin
     SmallestUnit := tuNanosecond;
   end;
 
-  TotalNs := Inst.FEpochMilliseconds * 1000000 + Inst.FSubMillisecondNanoseconds;
-  Divisor := UnitToNanoseconds(SmallestUnit) * Increment;
-  Rounded := RoundWithMode(TotalNs, Divisor, Mode);
+  // Use TBigInteger to avoid Int64 overflow on epochMs * 1000000
+  BigMillion := TBigInteger.FromInt64(1000000);
+  BigTotal := TBigInteger.FromInt64(Inst.FEpochMilliseconds)
+    .Multiply(BigMillion)
+    .Add(TBigInteger.FromInt64(Inst.FSubMillisecondNanoseconds));
+  BigDivisor := TBigInteger.FromInt64(UnitToNanoseconds(SmallestUnit) * Increment);
+  BigRounded := RoundBigIntWithMode(BigTotal, BigDivisor, Mode);
 
-  NewMs := Rounded div 1000000;
-  NewSubMs := Integer(Rounded mod 1000000);
-  if NewSubMs < 0 then
-  begin
-    Dec(NewMs);
-    Inc(NewSubMs, 1000000);
-  end;
+  NewMs := BigRounded.Divide(BigMillion).ToInt64;
+  NewSubMs := Integer(BigRounded.Modulo(BigMillion).ToInt64);
 
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
 end;

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -18,7 +18,6 @@ type
     FSubMillisecondNanoseconds: Integer;
 
     procedure InitializePrototype;
-    function TotalNanoseconds: Double;
   public
     constructor Create(const AEpochMilliseconds: Int64; const ASubMillisecondNanoseconds: Integer); overload;
 
@@ -46,10 +45,13 @@ implementation
 uses
   SysUtils,
 
+  BigInteger,
+
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
+  Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.TemporalDuration;
@@ -163,15 +165,6 @@ begin
   Result := 'Temporal.Instant';
 end;
 
-function TGocciaTemporalInstantValue.TotalNanoseconds: Double;
-var
-  MsFloat: Double;
-begin
-  // Safe Int64 → Double conversion (FPC 3.2.2 AArch64 bug: Int64 * Double gives wrong results)
-  MsFloat := FEpochMilliseconds;
-  Result := MsFloat * 1000000.0 + FSubMillisecondNanoseconds;
-end;
-
 { Getters }
 
 function TGocciaTemporalInstantValue.GetEpochMilliseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -182,9 +175,13 @@ end;
 function TGocciaTemporalInstantValue.GetEpochNanoseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Inst: TGocciaTemporalInstantValue;
+  BigNs: TBigInteger;
 begin
   Inst := AsInstant(AThisValue, 'get Instant.epochNanoseconds');
-  Result := TGocciaNumberLiteralValue.Create(Inst.TotalNanoseconds);
+  BigNs := TBigInteger.FromInt64(Inst.FEpochMilliseconds)
+    .Multiply(TBigInteger.FromInt64(1000000))
+    .Add(TBigInteger.FromInt64(Inst.FSubMillisecondNanoseconds));
+  Result := TGocciaBigIntValue.Create(BigNs);
 end;
 
 { Methods }

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -82,11 +82,14 @@ implementation
 uses
   SysUtils,
 
+  BigInteger,
+
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
+  Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.TemporalDuration,
@@ -616,12 +619,13 @@ end;
 function TGocciaTemporalZonedDateTimeValue.GetEpochNanoseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Zdt: TGocciaTemporalZonedDateTimeValue;
-  MsFloat: Double;
+  BigNs: TBigInteger;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'get ZonedDateTime.epochNanoseconds');
-  // Safe Int64 → Double conversion (FPC 3.2.2 AArch64 bug: Int64 * Double gives wrong results)
-  MsFloat := Zdt.FEpochMilliseconds;
-  Result := TGocciaNumberLiteralValue.Create(MsFloat * 1000000.0 + Zdt.FSubMillisecondNanoseconds);
+  BigNs := TBigInteger.FromInt64(Zdt.FEpochMilliseconds)
+    .Multiply(TBigInteger.FromInt64(1000000))
+    .Add(TBigInteger.FromInt64(Zdt.FSubMillisecondNanoseconds));
+  Result := TGocciaBigIntValue.Create(BigNs);
 end;
 
 { Methods }

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -843,7 +843,6 @@ var
   Zdt, Other: TGocciaTemporalZonedDateTimeValue;
   DiffMs: Int64;
   DiffSubMs: Integer;
-  DiffNs: Int64;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.until');
   Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.until');
@@ -851,16 +850,26 @@ begin
   DiffMs := Other.FEpochMilliseconds - Zdt.FEpochMilliseconds;
   DiffSubMs := Other.FSubMillisecondNanoseconds - Zdt.FSubMillisecondNanoseconds;
 
-  // Convert to total nanoseconds
-  DiffNs := DiffMs * SUB_MS_NANOSECOND_LIMIT + DiffSubMs;
+  // Normalize so DiffMs and DiffSubMs share the same sign
+  if (DiffMs > 0) and (DiffSubMs < 0) then
+  begin
+    Dec(DiffMs);
+    Inc(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+  end
+  else if (DiffMs < 0) and (DiffSubMs > 0) then
+  begin
+    Inc(DiffMs);
+    Dec(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+  end;
 
+  // Decompose ms into hours/minutes/seconds/ms without collapsing to total ns
   Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    DiffNs div NANOSECONDS_PER_HOUR,
-    (DiffNs div NANOSECONDS_PER_MINUTE) mod 60,
-    (DiffNs div NANOSECONDS_PER_SECOND) mod 60,
-    (DiffNs div NANOSECONDS_PER_MILLISECOND) mod 1000,
-    (DiffNs div NANOSECONDS_PER_MICROSECOND) mod 1000,
-    DiffNs mod 1000);
+    DiffMs div MILLISECONDS_PER_HOUR,
+    (DiffMs mod MILLISECONDS_PER_HOUR) div MILLISECONDS_PER_MINUTE,
+    ((DiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) div MILLISECONDS_PER_SECOND,
+    ((DiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) mod MILLISECONDS_PER_SECOND,
+    DiffSubMs div 1000,
+    DiffSubMs mod 1000);
 end;
 
 // TC39 Temporal §6.3.29 Temporal.ZonedDateTime.prototype.since(other [, options])
@@ -869,7 +878,6 @@ var
   Zdt, Other: TGocciaTemporalZonedDateTimeValue;
   DiffMs: Int64;
   DiffSubMs: Integer;
-  DiffNs: Int64;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.since');
   Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.since');
@@ -877,15 +885,25 @@ begin
   DiffMs := Zdt.FEpochMilliseconds - Other.FEpochMilliseconds;
   DiffSubMs := Zdt.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;
 
-  DiffNs := DiffMs * SUB_MS_NANOSECOND_LIMIT + DiffSubMs;
+  // Normalize so DiffMs and DiffSubMs share the same sign
+  if (DiffMs > 0) and (DiffSubMs < 0) then
+  begin
+    Dec(DiffMs);
+    Inc(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+  end
+  else if (DiffMs < 0) and (DiffSubMs > 0) then
+  begin
+    Inc(DiffMs);
+    Dec(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+  end;
 
   Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    DiffNs div NANOSECONDS_PER_HOUR,
-    (DiffNs div NANOSECONDS_PER_MINUTE) mod 60,
-    (DiffNs div NANOSECONDS_PER_SECOND) mod 60,
-    (DiffNs div NANOSECONDS_PER_MILLISECOND) mod 1000,
-    (DiffNs div NANOSECONDS_PER_MICROSECOND) mod 1000,
-    DiffNs mod 1000);
+    DiffMs div MILLISECONDS_PER_HOUR,
+    (DiffMs mod MILLISECONDS_PER_HOUR) div MILLISECONDS_PER_MINUTE,
+    ((DiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) div MILLISECONDS_PER_SECOND,
+    ((DiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) mod MILLISECONDS_PER_SECOND,
+    DiffSubMs div 1000,
+    DiffSubMs mod 1000);
 end;
 
 // TC39 Temporal §6.3.30 Temporal.ZonedDateTime.prototype.round(roundTo)

--- a/tests/built-ins/Temporal/Instant/fromEpochMilliseconds.js
+++ b/tests/built-ins/Temporal/Instant/fromEpochMilliseconds.js
@@ -21,8 +21,9 @@ describe.runIf(isTemporal)("Temporal.Instant.fromEpochMilliseconds", () => {
     expect(instant.epochMilliseconds).toBe(-86400000);
   });
 
-  test("epochNanoseconds getter", () => {
+  test("epochNanoseconds getter returns BigInt", () => {
     const instant = Temporal.Instant.fromEpochMilliseconds(5000);
-    expect(instant.epochNanoseconds).toBe(5000000000);
+    expect(instant.epochNanoseconds).toBe(5000000000n);
+    expect(typeof instant.epochNanoseconds).toBe("bigint");
   });
 });

--- a/tests/built-ins/Temporal/Instant/fromEpochNanoseconds.js
+++ b/tests/built-ins/Temporal/Instant/fromEpochNanoseconds.js
@@ -7,8 +7,12 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.Instant.fromEpochNanoseconds", () => {
   test("fromEpochNanoseconds()", () => {
-    const instant = Temporal.Instant.fromEpochNanoseconds(1000000000);
+    const instant = Temporal.Instant.fromEpochNanoseconds(1000000000n);
     expect(instant.epochMilliseconds).toBe(1000);
-    expect(instant.epochNanoseconds).toBe(1000000000);
+    expect(instant.epochNanoseconds).toBe(1000000000n);
+  });
+
+  test("requires BigInt argument", () => {
+    expect(() => Temporal.Instant.fromEpochNanoseconds(1000000000)).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Temporal/Instant/prototype/round.js
+++ b/tests/built-ins/Temporal/Instant/prototype/round.js
@@ -18,4 +18,17 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.round", () => {
     const rounded = inst.round({ smallestUnit: "second", roundingMode: "trunc" });
     expect(rounded.epochMilliseconds).toBe(1710510330000);
   });
+
+  test("round at large epoch does not overflow", () => {
+    const inst = Temporal.Instant.fromEpochMilliseconds(1710510330999);
+    const rounded = inst.round("second");
+    expect(rounded.epochMilliseconds).toBe(1710510331000);
+  });
+
+  test("round at extreme epoch boundary", () => {
+    // Near max allowed: 1e8 days = 8.64e15 ms — would overflow Int64 if * 1e6
+    const inst = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const rounded = inst.round("hour");
+    expect(rounded.epochMilliseconds).toBe(8640000000000000);
+  });
 });

--- a/tests/built-ins/Temporal/Instant/prototype/round.js
+++ b/tests/built-ins/Temporal/Instant/prototype/round.js
@@ -20,9 +20,10 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.round", () => {
   });
 
   test("round at large epoch does not overflow", () => {
-    const inst = Temporal.Instant.fromEpochMilliseconds(1710510330999);
+    // 9223372036855 > Int64_MAX / 1e6 — overflows Int64 when * 1e6
+    const inst = Temporal.Instant.fromEpochMilliseconds(9223372036855);
     const rounded = inst.round("second");
-    expect(rounded.epochMilliseconds).toBe(1710510331000);
+    expect(rounded.epochMilliseconds).toBe(9223372037000);
   });
 
   test("round at extreme epoch boundary", () => {

--- a/tests/built-ins/Temporal/Instant/prototype/until.js
+++ b/tests/built-ins/Temporal/Instant/prototype/until.js
@@ -13,4 +13,16 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
     expect(dur.hours).toBe(1);
     expect(dur.minutes).toBe(0);
   });
+
+  test("until at extreme range does not overflow", () => {
+    // Span of ~200 million days — would overflow Int64 if collapsed to total ns
+    const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const dur = i1.until(i2);
+    // Total = 17280000000000000 ms = 4800000000 hours
+    expect(dur.hours).toBe(4800000000);
+    expect(dur.minutes).toBe(0);
+    expect(dur.seconds).toBe(0);
+    expect(dur.milliseconds).toBe(0);
+  });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/compare.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/compare.js
@@ -7,8 +7,8 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.compare", () => {
   test("compare", () => {
-    const a = new Temporal.ZonedDateTime(1000000000, "UTC");
-    const b = new Temporal.ZonedDateTime(2000000000, "UTC");
+    const a = new Temporal.ZonedDateTime(1000000000n, "UTC");
+    const b = new Temporal.ZonedDateTime(2000000000n, "UTC");
     expect(Temporal.ZonedDateTime.compare(a, b)).toBe(-1);
     expect(Temporal.ZonedDateTime.compare(b, a)).toBe(1);
     expect(Temporal.ZonedDateTime.compare(a, a)).toBe(0);

--- a/tests/built-ins/Temporal/ZonedDateTime/constructor.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/constructor.js
@@ -8,7 +8,7 @@ const isTemporal = typeof Temporal !== "undefined";
 describe.runIf(isTemporal)("Temporal.ZonedDateTime constructor", () => {
   test("constructor from epoch nanoseconds", () => {
     // 2024-03-15T13:45:30Z = epoch ms 1710510330000
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     expect(zdt.timeZoneId).toBe("UTC");
     expect(zdt.year).toBe(2024);
@@ -20,27 +20,32 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime constructor", () => {
   });
 
   test("calendarId is iso8601", () => {
-    const zdt = new Temporal.ZonedDateTime(0, "UTC");
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
     expect(zdt.calendarId).toBe("iso8601");
   });
 
   test("epochMilliseconds", () => {
-    const zdt = new Temporal.ZonedDateTime(1710510330000000000, "UTC");
+    const zdt = new Temporal.ZonedDateTime(1710510330000000000n, "UTC");
     expect(zdt.epochMilliseconds).toBe(1710510330000);
   });
 
-  test("epochNanoseconds", () => {
-    const zdt = new Temporal.ZonedDateTime(1710510330000000000, "UTC");
-    expect(zdt.epochNanoseconds).toBe(1710510330000000000);
+  test("epochNanoseconds returns BigInt", () => {
+    const zdt = new Temporal.ZonedDateTime(1710510330000000000n, "UTC");
+    expect(zdt.epochNanoseconds).toBe(1710510330000000000n);
+    expect(typeof zdt.epochNanoseconds).toBe("bigint");
   });
 
   test("offset for UTC", () => {
-    const zdt = new Temporal.ZonedDateTime(0, "UTC");
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
     expect(zdt.offset).toBe("+00:00");
   });
 
   test("offsetNanoseconds for UTC", () => {
-    const zdt = new Temporal.ZonedDateTime(0, "UTC");
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
     expect(zdt.offsetNanoseconds).toBe(0);
+  });
+
+  test("requires BigInt for epochNanoseconds", () => {
+    expect(() => new Temporal.ZonedDateTime(0, "UTC")).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/add.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/add.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.add", () => {
   test("add duration", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const added = zdt.add({ hours: 2, minutes: 30 });
     expect(added.hour).toBe(16);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/calendarGetters.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/calendarGetters.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype calendar getters", () => {
   test("calendar getters", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     expect(zdt.dayOfWeek).toBe(5); // Friday
     expect(zdt.dayOfYear).toBe(75);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/equals.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/equals.js
@@ -7,9 +7,9 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.equals", () => {
   test("equals", () => {
-    const a = new Temporal.ZonedDateTime(1000000000, "UTC");
-    const b = new Temporal.ZonedDateTime(1000000000, "UTC");
-    const c = new Temporal.ZonedDateTime(2000000000, "UTC");
+    const a = new Temporal.ZonedDateTime(1000000000n, "UTC");
+    const b = new Temporal.ZonedDateTime(1000000000n, "UTC");
+    const c = new Temporal.ZonedDateTime(2000000000n, "UTC");
     expect(a.equals(b)).toBe(true);
     expect(a.equals(c)).toBe(false);
   });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/hoursInDay.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/hoursInDay.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.hoursInDay", () => {
   test("hoursInDay", () => {
-    const zdt = new Temporal.ZonedDateTime(0, "UTC");
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
     expect(zdt.hoursInDay).toBe(24);
   });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/round.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/round.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.round", () => {
   test("roundingMode trunc", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const rounded = zdt.round({ smallestUnit: "second", roundingMode: "trunc" });
     expect(rounded.second).toBe(30);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/startOfDay.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/startOfDay.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.startOfDay", () => {
   test("startOfDay", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const sod = zdt.startOfDay();
     expect(sod.hour).toBe(0);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/subtract.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/subtract.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.subtract", () => {
   test("subtract duration", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const sub = zdt.subtract({ hours: 1 });
     expect(sub.hour).toBe(12);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toInstant.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toInstant.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.toInstant", () => {
   test("toInstant", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const inst = zdt.toInstant();
     expect(inst.epochMilliseconds).toBe(1710510330000);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toJSON.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toJSON.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.toJSON", () => {
   test("toJSON matches toString", () => {
-    const zdt = new Temporal.ZonedDateTime(0, "UTC");
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
     expect(zdt.toJSON()).toBe(zdt.toString());
   });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toPlainDate.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toPlainDate.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.toPlainDate", () => {
   test("toPlainDate", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const d = zdt.toPlainDate();
     expect(d.year).toBe(2024);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toPlainDateTime.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toPlainDateTime.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.toPlainDateTime", () => {
   test("toPlainDateTime", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const dt = zdt.toPlainDateTime();
     expect(dt.year).toBe(2024);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toPlainTime.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toPlainTime.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.toPlainTime", () => {
   test("toPlainTime", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const t = zdt.toPlainTime();
     expect(t.hour).toBe(13);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toString.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toString.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.toString", () => {
   test("toString includes timezone annotation", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const s = zdt.toString();
     expect(s).toContain("[UTC]");

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toStringTag.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toStringTag.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype[Symbol.toStringTag]", () => {
   test("Symbol.toStringTag", () => {
-    const zdt = new Temporal.ZonedDateTime(0, "UTC");
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
     expect(Object.prototype.toString.call(zdt)).toBe("[object Temporal.ZonedDateTime]");
   });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/valueOf.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/valueOf.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.valueOf", () => {
   test("valueOf throws", () => {
-    const zdt = new Temporal.ZonedDateTime(0, "UTC");
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
     expect(() => zdt.valueOf()).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/with.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/with.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.with", () => {
   test("with modifies fields", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const updated = zdt.with({ hour: 10 });
     expect(updated.hour).toBe(10);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate-invalid.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/withPlainDate-invalid.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.withPlainDate/withPlainTime invalid strings", () => {
   test("withPlainDate throws RangeError for non-date string", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     expect(() => {
       zdt.withPlainDate("not-a-date");
@@ -15,7 +15,7 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.withPlainDate/withP
   });
 
   test("withPlainTime throws RangeError for non-time string", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     expect(() => {
       zdt.withPlainTime("not-a-time");

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.withPlainTime", () => {
   test("withPlainTime", () => {
-    const epochNs = 1710510330000 * 1000000;
+    const epochNs = 1710510330000n * 1000000n;
     const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
     const updated = zdt.withPlainTime(new Temporal.PlainTime(0, 0, 0));
     expect(updated.hour).toBe(0);

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/withTimeZone.js
@@ -7,7 +7,7 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.withTimeZone", () => {
   test("withTimeZone", () => {
-    const zdt = new Temporal.ZonedDateTime(0, "UTC");
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
     const rezoned = zdt.withTimeZone("UTC");
     expect(rezoned.timeZoneId).toBe("UTC");
     expect(rezoned.epochMilliseconds).toBe(0);


### PR DESCRIPTION
## Summary
- Make `Temporal.Instant` and `Temporal.ZonedDateTime` constructors and nanosecond factories accept `BigInt` epoch values instead of `Number`.
- Update `epochNanoseconds` getters to return `BigInt` for both `Instant` and `ZonedDateTime`.
- Add type errors and suggestions for non-BigInt epoch nanosecond inputs.
- Adjust Temporal shims, docs, and test262 harness expectations to use `BigInt`-based epoch nanoseconds.
- Update Temporal tests to cover the new `BigInt` contract and invalid `Number` inputs.