### PR TITLE
Simplify hasOwnProperty shim binding

### DIFF
--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -207,8 +207,7 @@ const
       FileName: '<shim:hasOwnProperty>';
       Source:
         'export const hasOwnProperty = ((proto) => {'#10 +
-        '  class _H { hasOwnProperty(prop) { return Object.hasOwn(this, prop); } }'#10 +
-        '  const fn = new _H().hasOwnProperty;'#10 +
+        '  const fn = ({ hasOwnProperty(prop) { return Object.hasOwn(this, prop); } }).hasOwnProperty;'#10 +
         '  Object.defineProperty(proto, "hasOwnProperty", {'#10 +
         '    value: fn, writable: true, enumerable: false, configurable: true'#10 +
         '  });'#10 +

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -207,11 +207,11 @@ const
       FileName: '<shim:hasOwnProperty>';
       Source:
         'export const hasOwnProperty = ((proto) => {'#10 +
-        '  const fn = ({ hasOwnProperty(prop) { return Object.hasOwn(this, prop); } }).hasOwnProperty;'#10 +
         '  Object.defineProperty(proto, "hasOwnProperty", {'#10 +
-        '    value: fn, writable: true, enumerable: false, configurable: true'#10 +
+        '    value(prop) { return Object.hasOwn(this, prop); },'#10 +
+        '    writable: true, enumerable: false, configurable: true'#10 +
         '  });'#10 +
-        '  return fn;'#10 +
+        '  return proto.hasOwnProperty;'#10 +
         '})(Object.getPrototypeOf({}));'
     )
   );


### PR DESCRIPTION
## Summary
- Simplified the `hasOwnProperty` shim by replacing the temporary class with an inline object literal binding.
- Kept the exported shim behavior unchanged while reducing indirection in `Goccia.Shims.pas`.
