### PR TITLE
Add `--unsafe-ffi` CLI toggle for FFI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,6 +687,18 @@ jobs:
       - name: Run example scripts
         run: ./build/GocciaScriptLoader examples
 
+      # ── --unsafe-ffi gating ──
+
+      - name: Check --unsafe-ffi gating
+        run: |
+          # FFI is unavailable without --unsafe-ffi
+          ffi_off="$(printf 'typeof FFI;\n' | ./build/GocciaScriptLoader --output=json)"
+          printf '%s\n' "$ffi_off" | grep -q '"value":"undefined"'
+
+          # FFI is available with --unsafe-ffi
+          ffi_on="$(printf 'typeof FFI;\n' | ./build/GocciaScriptLoader --unsafe-ffi --output=json)"
+          printf '%s\n' "$ffi_on" | grep -q '"value":"object"'
+
       # ── GocciaScriptLoader CLI ──
 
       - name: Run stdin smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,10 +308,10 @@ jobs:
         run: gcc -shared -o fixtures/ffi/libfixture.dll fixtures/ffi/fixture.c
 
       - name: Run all JavaScript tests (interpreted)
-        run: ./build/GocciaTestRunner tests --asi --silent --no-progress --output=test-results-interpreted.json
+        run: ./build/GocciaTestRunner tests --asi --unsafe-ffi --silent --no-progress --output=test-results-interpreted.json
 
       - name: Run all JavaScript tests (bytecode)
-        run: ./build/GocciaTestRunner tests --asi --mode=bytecode --silent --no-progress --output=test-results-bytecode.json
+        run: ./build/GocciaTestRunner tests --asi --unsafe-ffi --mode=bytecode --silent --no-progress --output=test-results-bytecode.json
 
       - name: Check GocciaTestRunner CLI behaviour
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,7 +86,7 @@ jobs:
         run: ./fixtures/ffi/build.sh
 
       - name: Run all JavaScript tests
-        run: ./build/GocciaTestRunner tests ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --asi --silent --no-progress --output=test-results-${{ matrix.mode }}.json
+        run: ./build/GocciaTestRunner tests ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --asi --unsafe-ffi --silent --no-progress --output=test-results-${{ matrix.mode }}.json
 
       - name: Check GocciaTestRunner CLI behaviour
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -227,6 +227,18 @@ jobs:
       - name: Run example scripts
         run: ./build/GocciaScriptLoader examples
 
+      # ── --unsafe-ffi gating ──
+
+      - name: Check --unsafe-ffi gating
+        run: |
+          # FFI is unavailable without --unsafe-ffi
+          ffi_off="$(printf 'typeof FFI;\n' | ./build/GocciaScriptLoader --output=json)"
+          printf '%s\n' "$ffi_off" | grep -q '"value":"undefined"'
+
+          # FFI is available with --unsafe-ffi
+          ffi_on="$(printf 'typeof FFI;\n' | ./build/GocciaScriptLoader --unsafe-ffi --output=json)"
+          printf '%s\n' "$ffi_on" | grep -q '"value":"object"'
+
       # ── GocciaScriptLoader CLI ──
 
       - name: Run stdin smoke tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Assistants should treat CONTRIBUTING as authoritative for contribution requireme
 ## Quick checks
 
 ```bash
-./build.pas testrunner && ./build/GocciaTestRunner tests --asi  # after substantive changes
+./build.pas testrunner && ./build/GocciaTestRunner tests --asi --unsafe-ffi  # after substantive changes
 ./build.pas bundler && ./build/GocciaBundler example.js  # build and run the bundler
 ./format.pas --check # before push / PR
 ```
@@ -63,11 +63,13 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaScriptLoader example.js --profile=all --profile-output=profile.json # Profile with JSON export
 ./build/GocciaScriptLoader example.js --profile=functions --profile-format=flamegraph --profile-output=flamegraph.txt # Flame graph export
 ./build/GocciaScriptLoader example.jsx --source-map --mode=bytecode # Write .map source map alongside execution
+./build/GocciaScriptLoader example.js --unsafe-ffi # Execute with FFI enabled
 ./build/GocciaREPL # Start interactive REPL (interpreted)
 ./build/GocciaREPL --mode=bytecode # Start the REPL via bytecode VM
 ./build/GocciaREPL --mode=bytecode --timing # Bytecode REPL with per-line timing
 ./build/GocciaREPL --import-map=imports.json # Start the REPL with an explicit import map
 ./build/GocciaREPL --asi # Start the REPL with automatic semicolon insertion
+./build/GocciaREPL --unsafe-ffi # Start the REPL with FFI enabled
 ./build/GocciaTestRunner tests/ --asi # Run all JavaScript tests
 ./build/GocciaTestRunner tests --import-map=imports.json # Run tests with an explicit import map
 ./build/GocciaTestRunner tests/language/expressions/ # Run a test category
@@ -81,6 +83,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaTestRunner tests --coverage --coverage-format=json --coverage-output=coverage.json # Coverage with JSON output
 ./build/GocciaTestRunner tests --jobs=4 # Run tests with 4 parallel workers
 ./build/GocciaTestRunner tests -j 1 # Force sequential execution (no threading)
+./build/GocciaTestRunner tests --asi --unsafe-ffi # Run all tests including FFI tests
 ./build/GocciaBenchmarkRunner benchmarks/ # Run all benchmarks
 ./build/GocciaBenchmarkRunner benchmarks --import-map=imports.json # Run benchmarks with an explicit import map
 ./build/GocciaBenchmarkRunner benchmarks/fibonacci.js # Run a specific benchmark
@@ -107,7 +110,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaBundler --output=out.gbc # Compile 
 ./build.pas loader && ./build/GocciaScriptLoader ./example.js
 
 # Compile and run all tests
-./build.pas testrunner && ./build/GocciaTestRunner tests --asi
+./build.pas testrunner && ./build/GocciaTestRunner tests --asi --unsafe-ffi
 
 # Compile and run a specific test
 ./build.pas testrunner && ./build/GocciaTestRunner tests/language/expressions/addition/basic-addition.js

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -27,7 +27,7 @@ TGocciaGlobalBuiltin = (
 
 The `GocciaTestRunner` adds `ggTestAssertions` to inject the test framework.
 The `GocciaBenchmarkRunner` adds `ggBenchmark` to inject the benchmark framework.
-FFI (`ggFFI`) is available but must be explicitly enabled.
+FFI (`ggFFI`) requires the `--unsafe-ffi` CLI flag to enable.
 
 ## Adding a New Built-in
 
@@ -574,7 +574,7 @@ See [Binary Data Built-ins](built-ins-binary-data.md) for the complete ArrayBuff
 
 ### FFI (`Goccia.Builtins.GlobalFFI.pas`)
 
-Foreign Function Interface for calling native shared libraries. Only available when `ggFFI` is enabled (not registered by default).
+Foreign Function Interface for calling native shared libraries. Only available when `--unsafe-ffi` is passed on the command line (enables the `ggFFI` flag internally). Not registered by default.
 
 **FFI global object:**
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -574,7 +574,7 @@ See [Binary Data Built-ins](built-ins-binary-data.md) for the complete ArrayBuff
 
 ### FFI (`Goccia.Builtins.GlobalFFI.pas`)
 
-Foreign Function Interface for calling native shared libraries. Only available when `--unsafe-ffi` is passed on the command line (enables the `ggFFI` flag internally). Not registered by default.
+Foreign Function Interface for calling native shared libraries. Only available when `ggFFI` is enabled (not registered by default).
 
 **FFI global object:**
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -326,9 +326,9 @@ The `TGocciaGlobalBuiltins` set controls three special-purpose built-ins that ar
 |------|----------|-------|
 | `ggTestAssertions` | `describe`, `test`, `expect` | Testing framework (GocciaTestRunner adds this) |
 | `ggBenchmark` | `suite`, `bench` | Benchmark framework (GocciaBenchmarkRunner adds this) |
-| `ggFFI` | `FFI.open`, `FFILibrary`, `FFIPointer` | Foreign Function Interface for native shared libraries; enabled via `--unsafe-ffi` CLI flag |
+| `ggFFI` | `FFI.open`, `FFILibrary`, `FFIPointer` | Foreign Function Interface for native shared libraries |
 
-All CLI tools (ScriptLoader, REPL, TestRunner, BenchmarkRunner, Bundler) accept `--unsafe-ffi` to enable the FFI global. Without this flag, the `FFI` object is not available.
+When embedding, pass `ggFFI` in the `TGocciaGlobalBuiltins` set during engine creation to enable the FFI global. CLI tools (ScriptLoader, REPL, TestRunner, BenchmarkRunner, Bundler) expose this as the `--unsafe-ffi` flag.
 
 To add the test framework for a custom test runner:
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -326,7 +326,9 @@ The `TGocciaGlobalBuiltins` set controls three special-purpose built-ins that ar
 |------|----------|-------|
 | `ggTestAssertions` | `describe`, `test`, `expect` | Testing framework (GocciaTestRunner adds this) |
 | `ggBenchmark` | `suite`, `bench` | Benchmark framework (GocciaBenchmarkRunner adds this) |
-| `ggFFI` | `FFI.open`, `FFILibrary`, `FFIPointer` | Foreign Function Interface for native shared libraries |
+| `ggFFI` | `FFI.open`, `FFILibrary`, `FFIPointer` | Foreign Function Interface for native shared libraries; enabled via `--unsafe-ffi` CLI flag |
+
+All CLI tools (ScriptLoader, REPL, TestRunner, BenchmarkRunner, Bundler) accept `--unsafe-ffi` to enable the FFI global. Without this flag, the `FFI` object is not available.
 
 To add the test framework for a custom test runner:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -378,7 +378,7 @@ Pascal unit tests (`*.Test.pas`) exist as a tertiary layer for behavior that can
 The `GocciaTestRunner` program:
 
 1. Scans the provided path for `.js`, `.jsx`, `.ts`, `.tsx`, and `.mjs` files.
-2. For each file, creates a fresh `TGocciaEngine` with `[ggTestAssertions, ggFFI]`.
+2. For each file, creates a fresh `TGocciaEngine` with `[ggTestAssertions]` (plus `ggFFI` when `--unsafe-ffi` is passed).
 3. Loads the source and appends a `runTests()` call.
 4. Executes the script — `describe`/`test` blocks register themselves during execution. Nested `describe` blocks are supported; suite names are composed with ` > ` separators (e.g., `"Outer > Inner"`). Skip state is inherited by nested describes.
 5. `runTests()` executes all registered tests and collects results.

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -43,6 +43,7 @@ type
     function AddInteger(const AName, AHelp: string): TGocciaIntegerOption;
     function AddRepeatable(const AName, AHelp: string): TGocciaRepeatableOption;
     function Add(const AOption: TGocciaOptionBase): TGocciaOptionBase;
+    function EffectiveBuiltins: TGocciaGlobalBuiltins;
     function CreateEngine(const AFileName: string;
       const ASource: TStringList): TGocciaEngine; overload;
     function CreateEngine(const AFileName: string;
@@ -220,10 +221,17 @@ begin
   Result := AOption;
 end;
 
+function TGocciaCLIApplication.EffectiveBuiltins: TGocciaGlobalBuiltins;
+begin
+  Result := GlobalBuiltins;
+  if Assigned(FEngineOptions) and FEngineOptions.UnsafeFFI.Present then
+    Include(Result, ggFFI);
+end;
+
 function TGocciaCLIApplication.CreateEngine(const AFileName: string;
   const ASource: TStringList): TGocciaEngine;
 begin
-  Result := TGocciaEngine.Create(AFileName, ASource, GlobalBuiltins);
+  Result := TGocciaEngine.Create(AFileName, ASource, EffectiveBuiltins);
   try
     if Assigned(FEngineOptions) then
     begin
@@ -240,7 +248,7 @@ end;
 function TGocciaCLIApplication.CreateEngine(const AFileName: string;
   const ASource: TStringList; const AExecutor: TGocciaExecutor): TGocciaEngine;
 begin
-  Result := TGocciaEngine.Create(AFileName, ASource, GlobalBuiltins,
+  Result := TGocciaEngine.Create(AFileName, ASource, EffectiveBuiltins,
     AExecutor);
   try
     if Assigned(FEngineOptions) then

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -753,7 +753,7 @@ begin
         SetLength(WorkerData[I].Entries, 0);
       end;
 
-      EnsureSharedPrototypesInitialized(GlobalBuiltins);
+      EnsureSharedPrototypesInitialized(EffectiveBuiltins);
 
       WallClockStart := GetNanoseconds;
 

--- a/source/app/GocciaBundler.dpr
+++ b/source/app/GocciaBundler.dpr
@@ -305,7 +305,7 @@ var
   Pool: TGocciaThreadPool;
   I: Integer;
 begin
-  EnsureSharedPrototypesInitialized(GlobalBuiltins);
+  EnsureSharedPrototypesInitialized(EffectiveBuiltins);
 
   Pool := TGocciaThreadPool.Create(AJobCount);
   try

--- a/source/app/GocciaREPL.dpr
+++ b/source/app/GocciaREPL.dpr
@@ -37,7 +37,7 @@ uses
 
 const
   REPL_FILE_NAME = 'REPL';
-  REPL_USAGE_LINE = '[--timing] [--mode=interpreted|bytecode] [--import-map=file] [--alias key=value] [--asi]';
+  REPL_USAGE_LINE = '[--timing] [--mode=interpreted|bytecode] [--import-map=file] [--alias key=value] [--asi] [--unsafe-ffi]';
 
 type
   TREPLApp = class(TGocciaApplication)
@@ -53,6 +53,7 @@ var
   AllOptions: TGocciaOptionArray;
   Positionals: TStringList;
   IsBytecodeMode: Boolean;
+  Builtins: TGocciaGlobalBuiltins;
 
   Line: string;
   Source: TStringList;
@@ -103,6 +104,10 @@ begin
 
           IsBytecodeMode := EngineOpts.Mode.Matches(emBytecode);
 
+          Builtins := [];
+          if EngineOpts.UnsafeFFI.Present then
+            Include(Builtins, ggFFI);
+
           if IsBytecodeMode then
             WriteLn('Goccia REPL v' + GetVersion + ' (bytecode)')
           else
@@ -117,7 +122,7 @@ begin
             BcExecutor.GlobalBackedTopLevel := True;
             LiveModules := TObjectList<TGocciaBytecodeModule>.Create(True);
             try
-              Eng := TGocciaEngine.Create(REPL_FILE_NAME, Source, [],
+              Eng := TGocciaEngine.Create(REPL_FILE_NAME, Source, Builtins,
                 BcExecutor);
               try
                 Eng.ASIEnabled := EngineOpts.ASI.Present;
@@ -232,7 +237,7 @@ begin
           end
           else
           begin
-            Eng := TGocciaEngine.Create(REPL_FILE_NAME, Source, []);
+            Eng := TGocciaEngine.Create(REPL_FILE_NAME, Source, Builtins);
             Eng.ASIEnabled := EngineOpts.ASI.Present;
             try
               ConfigureModuleResolver(Eng.Resolver, REPL_FILE_NAME,

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -617,7 +617,7 @@ var
   Pool: TGocciaThreadPool;
   I: Integer;
 begin
-  EnsureSharedPrototypesInitialized(GlobalBuiltins);
+  EnsureSharedPrototypesInitialized(EffectiveBuiltins);
 
   Pool := TGocciaThreadPool.Create(AJobCount);
   try

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -260,7 +260,7 @@ end;
 
 function TTestRunnerApp.GlobalBuiltins: TGocciaGlobalBuiltins;
 begin
-  Result := [ggTestAssertions, ggFFI];
+  Result := [ggTestAssertions];
 end;
 
 function TTestRunnerApp.RunGocciaScriptInterpreted(const AFileName: string): TTestFileResult;
@@ -762,7 +762,7 @@ begin
 
   // Force all shared prototypes to be initialised on the main thread
   // before any worker thread starts, avoiding class-var race conditions.
-  EnsureSharedPrototypesInitialized(GlobalBuiltins);
+  EnsureSharedPrototypesInitialized(EffectiveBuiltins);
 
   WallClockStart := GetNanoseconds;
 

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -128,6 +128,7 @@ type
     FImportMap: TGocciaStringOption;
     FAliases: TGocciaRepeatableOption;
     FTimeout: TGocciaIntegerOption;
+    FUnsafeFFI: TGocciaFlagOption;
   public
     constructor Create;
     destructor Destroy; override;
@@ -139,6 +140,7 @@ type
     property ImportMap: TGocciaStringOption read FImportMap;
     property Aliases: TGocciaRepeatableOption read FAliases;
     property Timeout: TGocciaIntegerOption read FTimeout;
+    property UnsafeFFI: TGocciaFlagOption read FUnsafeFFI;
   end;
 
   TGocciaCoverageFormat = (cfLcov, cfJson);
@@ -467,6 +469,8 @@ begin
     'Import alias (e.g. @/=./src/)', 'Engine');
   FTimeout := TGocciaIntegerOption.Create('timeout',
     'Per-file timeout in milliseconds', 'Engine');
+  FUnsafeFFI := TGocciaFlagOption.Create('unsafe-ffi',
+    'Enable the FFI global (foreign function interface)', 'Engine');
 end;
 
 destructor TGocciaEngineOptions.Destroy;
@@ -476,17 +480,19 @@ begin
   FImportMap.Free;
   FAliases.Free;
   FTimeout.Free;
+  FUnsafeFFI.Free;
   inherited Destroy;
 end;
 
 function TGocciaEngineOptions.Options: TGocciaOptionArray;
 begin
-  SetLength(Result, 5);
+  SetLength(Result, 6);
   Result[0] := FMode;
   Result[1] := FASI;
   Result[2] := FImportMap;
   Result[3] := FAliases;
   Result[4] := FTimeout;
+  Result[5] := FUnsafeFFI;
 end;
 
 { TGocciaCoverageOptions }

--- a/source/shared/CLI.Parser.Test.pas
+++ b/source/shared/CLI.Parser.Test.pas
@@ -4,11 +4,16 @@ program CLI.Parser.Test;
 
 uses
   SysUtils,
+  TypInfo,
 
   CLI.Options,
   TestingPascalLibrary,
 
   Goccia.CLI.Help;
+
+type
+  { Local two-value enum for testing EnumOption without coupling to engine types }
+  TTestColor = (tcRed, tcBlue);
 
 type
   TCLIOptionsTests = class(TTestSuite)
@@ -23,17 +28,13 @@ type
     procedure TestIntegerOptionValueOrWhenAbsent;
     procedure TestIntegerOptionInvalidValue;
     procedure TestRepeatableOptionMultipleValues;
-    procedure TestEnumOptionInterpreted;
-    procedure TestEnumOptionBytecode;
+    procedure TestEnumOptionFirstValue;
+    procedure TestEnumOptionSecondValue;
     procedure TestEnumOptionInvalidValue;
     procedure TestEnumOptionValidValues;
     procedure TestEnumOptionFormatForHelp;
-    procedure TestEngineOptionsSubOptions;
-    procedure TestEngineOptionsCount;
-    procedure TestCoverageOptionsSubOptions;
-    procedure TestCoverageOptionsCount;
     procedure TestOptionListAddFlagAndString;
-    procedure TestConcatOptions;
+    procedure TestConcatOptionsMergesTwoArrays;
     procedure TestGenerateHelpText;
   public
     procedure SetupTests; override;
@@ -51,17 +52,13 @@ begin
   Test('IntegerOption.ValueOr returns default when absent', TestIntegerOptionValueOrWhenAbsent);
   Test('IntegerOption.Apply raises TGocciaParseError for non-integer', TestIntegerOptionInvalidValue);
   Test('RepeatableOption accumulates multiple values', TestRepeatableOptionMultipleValues);
-  Test('EnumOption applies interpreted', TestEnumOptionInterpreted);
-  Test('EnumOption applies bytecode', TestEnumOptionBytecode);
+  Test('EnumOption applies first value', TestEnumOptionFirstValue);
+  Test('EnumOption applies second value', TestEnumOptionSecondValue);
   Test('EnumOption raises TGocciaParseError for invalid value', TestEnumOptionInvalidValue);
   Test('EnumOption.ValidValues returns comma-separated list', TestEnumOptionValidValues);
   Test('EnumOption.FormatForHelp returns pipe-separated values', TestEnumOptionFormatForHelp);
-  Test('EngineOptions exposes all sub-options', TestEngineOptionsSubOptions);
-  Test('EngineOptions.Options returns correct count', TestEngineOptionsCount);
-  Test('CoverageOptions exposes all sub-options', TestCoverageOptionsSubOptions);
-  Test('CoverageOptions.Options returns correct count', TestCoverageOptionsCount);
   Test('OptionList tracks added options', TestOptionListAddFlagAndString);
-  Test('ConcatOptions merges two arrays', TestConcatOptions);
+  Test('ConcatOptions merges two arrays', TestConcatOptionsMergesTwoArrays);
   Test('GenerateHelpText includes program name and option names', TestGenerateHelpText);
 end;
 
@@ -215,31 +212,31 @@ begin
   end;
 end;
 
-{ TGocciaEnumOption tests }
+{ TGocciaEnumOption tests — uses local TTestColor enum }
 
-procedure TCLIOptionsTests.TestEnumOptionInterpreted;
+procedure TCLIOptionsTests.TestEnumOptionFirstValue;
 var
-  Opt: TGocciaEnumOption<TGocciaExecutionMode>;
+  Opt: TGocciaEnumOption<TTestColor>;
 begin
-  Opt := TGocciaEnumOption<TGocciaExecutionMode>.Create('mode', 'Execution mode');
+  Opt := TGocciaEnumOption<TTestColor>.Create('color', 'Pick a color');
   try
-    Opt.Apply('interpreted');
+    Opt.Apply('red');
     Expect<Boolean>(Opt.Present).ToBe(True);
-    Expect<Boolean>(Opt.Matches(emInterpreted)).ToBe(True);
+    Expect<Boolean>(Opt.Matches(tcRed)).ToBe(True);
   finally
     Opt.Free;
   end;
 end;
 
-procedure TCLIOptionsTests.TestEnumOptionBytecode;
+procedure TCLIOptionsTests.TestEnumOptionSecondValue;
 var
-  Opt: TGocciaEnumOption<TGocciaExecutionMode>;
+  Opt: TGocciaEnumOption<TTestColor>;
 begin
-  Opt := TGocciaEnumOption<TGocciaExecutionMode>.Create('mode', 'Execution mode');
+  Opt := TGocciaEnumOption<TTestColor>.Create('color', 'Pick a color');
   try
-    Opt.Apply('bytecode');
+    Opt.Apply('blue');
     Expect<Boolean>(Opt.Present).ToBe(True);
-    Expect<Boolean>(Opt.Matches(emBytecode)).ToBe(True);
+    Expect<Boolean>(Opt.Matches(tcBlue)).ToBe(True);
   finally
     Opt.Free;
   end;
@@ -247,10 +244,10 @@ end;
 
 procedure TCLIOptionsTests.TestEnumOptionInvalidValue;
 var
-  Opt: TGocciaEnumOption<TGocciaExecutionMode>;
+  Opt: TGocciaEnumOption<TTestColor>;
   Raised: Boolean;
 begin
-  Opt := TGocciaEnumOption<TGocciaExecutionMode>.Create('mode', 'Execution mode');
+  Opt := TGocciaEnumOption<TTestColor>.Create('color', 'Pick a color');
   try
     Raised := False;
     try
@@ -267,11 +264,11 @@ end;
 
 procedure TCLIOptionsTests.TestEnumOptionValidValues;
 var
-  Opt: TGocciaEnumOption<TGocciaExecutionMode>;
+  Opt: TGocciaEnumOption<TTestColor>;
 begin
-  Opt := TGocciaEnumOption<TGocciaExecutionMode>.Create('mode', 'Execution mode');
+  Opt := TGocciaEnumOption<TTestColor>.Create('color', 'Pick a color');
   try
-    Expect<string>(Opt.ValidValues).ToBe('interpreted, bytecode');
+    Expect<string>(Opt.ValidValues).ToBe('red, blue');
   finally
     Opt.Free;
   end;
@@ -279,71 +276,13 @@ end;
 
 procedure TCLIOptionsTests.TestEnumOptionFormatForHelp;
 var
-  Opt: TGocciaEnumOption<TGocciaExecutionMode>;
+  Opt: TGocciaEnumOption<TTestColor>;
 begin
-  Opt := TGocciaEnumOption<TGocciaExecutionMode>.Create('mode', 'Execution mode');
+  Opt := TGocciaEnumOption<TTestColor>.Create('color', 'Pick a color');
   try
-    Expect<string>(Opt.FormatForHelp).ToBe('--mode=interpreted|bytecode');
+    Expect<string>(Opt.FormatForHelp).ToBe('--color=red|blue');
   finally
     Opt.Free;
-  end;
-end;
-
-{ TGocciaEngineOptions tests }
-
-procedure TCLIOptionsTests.TestEngineOptionsSubOptions;
-var
-  Opts: TGocciaEngineOptions;
-begin
-  Opts := TGocciaEngineOptions.Create;
-  try
-    Expect<Boolean>(Opts.Mode <> nil).ToBe(True);
-    Expect<Boolean>(Opts.ASI <> nil).ToBe(True);
-    Expect<Boolean>(Opts.ImportMap <> nil).ToBe(True);
-    Expect<Boolean>(Opts.Aliases <> nil).ToBe(True);
-    Expect<Boolean>(Opts.Timeout <> nil).ToBe(True);
-  finally
-    Opts.Free;
-  end;
-end;
-
-procedure TCLIOptionsTests.TestEngineOptionsCount;
-var
-  Opts: TGocciaEngineOptions;
-begin
-  Opts := TGocciaEngineOptions.Create;
-  try
-    Expect<Integer>(Length(Opts.Options)).ToBe(5);
-  finally
-    Opts.Free;
-  end;
-end;
-
-{ TGocciaCoverageOptions tests }
-
-procedure TCLIOptionsTests.TestCoverageOptionsSubOptions;
-var
-  Opts: TGocciaCoverageOptions;
-begin
-  Opts := TGocciaCoverageOptions.Create;
-  try
-    Expect<Boolean>(Opts.Enabled <> nil).ToBe(True);
-    Expect<Boolean>(Opts.Format <> nil).ToBe(True);
-    Expect<Boolean>(Opts.OutputPath <> nil).ToBe(True);
-  finally
-    Opts.Free;
-  end;
-end;
-
-procedure TCLIOptionsTests.TestCoverageOptionsCount;
-var
-  Opts: TGocciaCoverageOptions;
-begin
-  Opts := TGocciaCoverageOptions.Create;
-  try
-    Expect<Integer>(Length(Opts.Options)).ToBe(3);
-  finally
-    Opts.Free;
   end;
 end;
 
@@ -367,24 +306,27 @@ begin
   end;
 end;
 
-{ ConcatOptions tests }
+{ ConcatOptions tests — uses OptionList, no engine/coverage dependency }
 
-procedure TCLIOptionsTests.TestConcatOptions;
+procedure TCLIOptionsTests.TestConcatOptionsMergesTwoArrays;
 var
-  Engine: TGocciaEngineOptions;
-  Coverage: TGocciaCoverageOptions;
+  ListA, ListB: TGocciaOptionList;
   Combined: TGocciaOptionArray;
 begin
-  Engine := TGocciaEngineOptions.Create;
-  Coverage := TGocciaCoverageOptions.Create;
+  ListA := TGocciaOptionList.Create;
+  ListB := TGocciaOptionList.Create;
   try
-    Combined := ConcatOptions([Engine.Options, Coverage.Options]);
-    Expect<Integer>(Length(Combined)).ToBe(8);
-    Expect<string>(Combined[0].LongName).ToBe('mode');
-    Expect<string>(Combined[5].LongName).ToBe('coverage');
+    ListA.AddFlag('alpha', 'First flag');
+    ListA.AddString('beta', 'First string');
+    ListB.AddFlag('gamma', 'Second flag');
+    Combined := ConcatOptions([ListA.Options, ListB.Options]);
+    Expect<Integer>(Length(Combined)).ToBe(3);
+    Expect<string>(Combined[0].LongName).ToBe('alpha');
+    Expect<string>(Combined[1].LongName).ToBe('beta');
+    Expect<string>(Combined[2].LongName).ToBe('gamma');
   finally
-    Coverage.Free;
-    Engine.Free;
+    ListB.Free;
+    ListA.Free;
   end;
 end;
 


### PR DESCRIPTION
## Summary
- Adds a new `--unsafe-ffi` flag to all CLI tools to explicitly enable the `ggFFI` global.
- Updates engine setup so shared prototypes and runtime engines use the effective built-ins set when FFI is enabled.
- Aligns the REPL, ScriptLoader, TestRunner, Bundler, and BenchmarkRunner with the new opt-in FFI behavior.
- Updates docs, AGENTS guidance, and CI/PR test invocations to pass `--unsafe-ffi` where FFI tests are expected.