### PR TITLE
Add instruction counter / interrupt handler with configurable limit

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -335,6 +335,66 @@ jobs:
           printf '%s\n' "$timeout_output_bytecode" | grep -q '"message":"Execution timed out after 50ms"'
 
           set +e
+          inslimit_output="$("$PYTHON_BIN" - <<'PY'
+          import subprocess
+          import sys
+
+          script = 'const iterable = { [Symbol.iterator]: () => ({ next: () => ({ done: false, value: 1 }) }) }; for (const x of iterable) { }' + '\n'
+          try:
+              result = subprocess.run(
+                  ['./build/GocciaScriptLoader', '--max-instructions=500', '--output=json'],
+                  input=script,
+                  text=True,
+                  capture_output=True,
+                  timeout=10,
+                  check=False,
+              )
+          except subprocess.TimeoutExpired:
+              sys.exit(124)
+
+          sys.stdout.write(result.stdout)
+          sys.stderr.write(result.stderr)
+          sys.exit(result.returncode)
+          PY
+          )"
+          inslimit_status=$?
+          set -e
+          test "$inslimit_status" -eq 1
+          printf '%s\n' "$inslimit_output" | grep -q '"ok":false'
+          printf '%s\n' "$inslimit_output" | grep -q '"type":"InstructionLimitError"'
+          printf '%s\n' "$inslimit_output" | grep -q '"message":"Execution exceeded instruction limit of 500"'
+
+          set +e
+          inslimit_output_bytecode="$("$PYTHON_BIN" - <<'PY'
+          import subprocess
+          import sys
+
+          script = 'const iterable = { [Symbol.iterator]: () => ({ next: () => ({ done: false, value: 1 }) }) }; for (const x of iterable) { }' + '\n'
+          try:
+              result = subprocess.run(
+                  ['./build/GocciaScriptLoader', '-', '--mode=bytecode', '--max-instructions=500', '--output=json'],
+                  input=script,
+                  text=True,
+                  capture_output=True,
+                  timeout=10,
+                  check=False,
+              )
+          except subprocess.TimeoutExpired:
+              sys.exit(124)
+
+          sys.stdout.write(result.stdout)
+          sys.stderr.write(result.stderr)
+          sys.exit(result.returncode)
+          PY
+          )"
+          inslimit_status_bytecode=$?
+          set -e
+          test "$inslimit_status_bytecode" -eq 1
+          printf '%s\n' "$inslimit_output_bytecode" | grep -q '"ok":false'
+          printf '%s\n' "$inslimit_output_bytecode" | grep -q '"type":"InstructionLimitError"'
+          printf '%s\n' "$inslimit_output_bytecode" | grep -q '"message":"Execution exceeded instruction limit of 500"'
+
+          set +e
           globals_collision_output="$(printf '%s\n' 'console;' | ./build/GocciaScriptLoader --global console=1 --output=json)"
           globals_collision_status=$?
           set -e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaScriptLoader example.js --profile=all --profile-output=profile.json # Profile with JSON export
 ./build/GocciaScriptLoader example.js --profile=functions --profile-format=flamegraph --profile-output=flamegraph.txt # Flame graph export
 ./build/GocciaScriptLoader example.jsx --source-map --mode=bytecode # Write .map source map alongside execution
+./build/GocciaScriptLoader example.js --max-instructions=1000000 --mode=bytecode # Abort after 1M bytecode instructions
 ./build/GocciaREPL # Start interactive REPL (interpreted)
 ./build/GocciaREPL --mode=bytecode # Start the REPL via bytecode VM
 ./build/GocciaREPL --mode=bytecode --timing # Bytecode REPL with per-line timing

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -123,6 +123,9 @@ printf 'import { add } from "@/math"; add(1, 2);' | ./build/GocciaScriptLoader
 # Abort long-running scripts
 printf "const f = () => f(); f();" | ./build/GocciaScriptLoader --timeout=100
 
+# Abort after a fixed number of bytecode instructions
+printf "const f = () => f(); f();" | ./build/GocciaScriptLoader --max-instructions=1000000 --mode=bytecode
+
 # Write .map source map alongside execution
 ./build/GocciaScriptLoader example.jsx --source-map --mode=bytecode
 

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -128,7 +128,7 @@ The profiler follows the same singleton-tracker pattern as coverage (`Goccia.Cov
 
 ## Instruction Limit
 
-The `--max-instructions` flag caps execution steps before aborting. In the bytecode VM the counter increments on every dispatched instruction (exact); the check runs at the top of each dispatch iteration with zero overhead when disabled. See [Embedding — Execution Limits](embedding.md#execution-limits) for the full API, interpreter-mode behavior, and CLI defaults.
+The `--max-instructions` flag caps execution steps before aborting. In the bytecode VM the counter increments on every dispatched instruction (exact); the check runs at the top of each dispatch iteration. When disabled, only the guard read of the limit threadvar remains on the hot path. See [Embedding — Execution Limits](embedding.md#execution-limits) for the full API, interpreter-mode behavior, and CLI defaults.
 
 ## Binary Format
 

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -126,6 +126,16 @@ The `--profile` flag on GocciaScriptLoader enables language-level profiling of t
 
 The profiler follows the same singleton-tracker pattern as coverage (`Goccia.Coverage.pas`). Zero overhead when disabled. Opcode counting adds ~1% overhead; function timing adds ~3%.
 
+## Instruction Limit
+
+The `--max-instructions` flag caps the number of bytecode instructions a script may execute before aborting with a `TGocciaInstructionLimitError`. This is useful for sandboxing untrusted scripts or detecting infinite loops without relying on wall-clock timeouts.
+
+- `--max-instructions=1000000` — abort after 1 000 000 dispatched instructions
+
+The counter lives in `Goccia.InstructionLimit.pas` using thread-local storage (same pattern as `Goccia.Timeout.pas`). It increments on every instruction fetch in the dispatch loop and is checked at the same checkpoints as the execution timeout (backward jumps, calls, iterator loops, and object allocation). Zero overhead when the limit is not set.
+
+In interpreter mode the counter increments at function-call and loop-iteration checkpoints rather than per-AST-node, so the count is an approximation. In bytecode mode it is exact.
+
 ## Binary Format
 
 - Magic: `GBC\0`

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -128,7 +128,7 @@ The profiler follows the same singleton-tracker pattern as coverage (`Goccia.Cov
 
 ## Instruction Limit
 
-The `--max-instructions` flag caps execution steps before aborting. In the bytecode VM the counter increments on every dispatched instruction (exact); the check runs at the top of each dispatch iteration. When disabled, only the guard read of the limit threadvar remains on the hot path. See [Embedding — Execution Limits](embedding.md#execution-limits) for the full API, interpreter-mode behavior, and CLI defaults.
+The dispatch loop supports an optional instruction counter (`Goccia.InstructionLimit.pas`). When armed, the counter increments on every dispatched instruction and the limit is checked at the top of each iteration. When disabled, only the guard read of the limit threadvar remains on the hot path. See [Embedding — Execution Limits](embedding.md#execution-limits) for the full API and interpreter-mode behavior.
 
 ## Binary Format
 

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -128,14 +128,7 @@ The profiler follows the same singleton-tracker pattern as coverage (`Goccia.Cov
 
 ## Instruction Limit
 
-The `--max-instructions` flag caps the number of bytecode instructions a script may execute before aborting with a `TGocciaInstructionLimitError`. This is useful for sandboxing untrusted scripts or detecting infinite loops without relying on wall-clock timeouts.
-
-- `--max-instructions=1000000` — abort after 1 000 000 dispatched instructions
-- `--max-instructions=0` or omitted — no limit (default)
-
-The counter lives in `Goccia.InstructionLimit.pas` using thread-local storage (same pattern as `Goccia.Timeout.pas`). It increments on every instruction fetch in the dispatch loop and is checked at the top of each dispatch iteration. A limit of zero (the default) disables the counter entirely — no threadvar access, no comparisons, zero overhead.
-
-In interpreter mode the counter increments at function-call and loop-iteration checkpoints rather than per-AST-node, so the count is an approximation. In bytecode mode it is exact.
+The `--max-instructions` flag caps execution steps before aborting. In the bytecode VM the counter increments on every dispatched instruction (exact); the check runs at the top of each dispatch iteration with zero overhead when disabled. See [Embedding — Execution Limits](embedding.md#execution-limits) for the full API, interpreter-mode behavior, and CLI defaults.
 
 ## Binary Format
 

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -131,8 +131,9 @@ The profiler follows the same singleton-tracker pattern as coverage (`Goccia.Cov
 The `--max-instructions` flag caps the number of bytecode instructions a script may execute before aborting with a `TGocciaInstructionLimitError`. This is useful for sandboxing untrusted scripts or detecting infinite loops without relying on wall-clock timeouts.
 
 - `--max-instructions=1000000` — abort after 1 000 000 dispatched instructions
+- `--max-instructions=0` or omitted — no limit (default)
 
-The counter lives in `Goccia.InstructionLimit.pas` using thread-local storage (same pattern as `Goccia.Timeout.pas`). It increments on every instruction fetch in the dispatch loop and is checked at the same checkpoints as the execution timeout (backward jumps, calls, iterator loops, and object allocation). Zero overhead when the limit is not set.
+The counter lives in `Goccia.InstructionLimit.pas` using thread-local storage (same pattern as `Goccia.Timeout.pas`). It increments on every instruction fetch in the dispatch loop and is checked at the top of each dispatch iteration. A limit of zero (the default) disables the counter entirely — no threadvar access, no comparisons, zero overhead.
 
 In interpreter mode the counter increments at function-call and loop-iteration checkpoints rather than per-AST-node, so the count is an approximation. In bytecode mode it is exact.
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -5,7 +5,7 @@
 ## Executive Summary
 
 - **Quick start** — `TGocciaEngine.RunScript('code')` for one-shot execution; `TGocciaEngine.Create(...)` for long-lived engines
-- **Sandboxing** — Control available built-ins via `TGocciaGlobalBuiltins` flags; inject custom globals via `DefineLexicalBinding`
+- **Sandboxing** — Control available built-ins via `TGocciaGlobalBuiltins` flags; inject custom globals via `DefineLexicalBinding`; enforce execution limits via timeout or instruction cap
 - **Module resolution** — Pluggable resolver with extensionless imports, import maps, custom content providers, and global modules
 - **Transparent GC** — Mark-and-sweep GC initializes automatically; FPU exceptions are masked for IEEE 754 semantics
 
@@ -598,6 +598,50 @@ end;
 | `TGocciaTypeError` | Type-specific runtime error |
 | `TGocciaReferenceError` | Undefined variable access |
 | `TGocciaThrowValue` | JavaScript `throw` — wraps any thrown value including `RangeError` |
+
+## Execution Limits
+
+Two mechanisms prevent runaway scripts: wall-clock timeouts and instruction limits. Both use thread-local storage and are safe with `--jobs` parallelism — each worker thread gets its own independent counter.
+
+### Timeout
+
+`StartExecutionTimeout` arms a wall-clock deadline. `ClearExecutionTimeout` disarms it. The check is sampled (every 1024th call site) to minimize overhead.
+
+```pascal
+uses
+  Goccia.Timeout;
+
+StartExecutionTimeout(5000); // 5 000 ms
+try
+  Engine.Execute;
+finally
+  ClearExecutionTimeout;
+end;
+```
+
+Raises `TGocciaTimeoutError` when the deadline is exceeded. A value of zero disables the timeout.
+
+CLI: `--timeout=<ms>` (default: 0 for ScriptLoader/BenchmarkRunner, 10 000 ms for TestRunner).
+
+### Instruction Limit
+
+`StartInstructionLimit` caps the number of execution steps. In bytecode mode the counter increments on every dispatched instruction (exact). In interpreter mode it increments at function-call and loop-iteration checkpoints (approximate).
+
+```pascal
+uses
+  Goccia.InstructionLimit;
+
+StartInstructionLimit(1000000); // 1 000 000 steps
+try
+  Engine.Execute;
+finally
+  ClearInstructionLimit;
+end;
+```
+
+Raises `TGocciaInstructionLimitError` when the limit is reached. A value of zero (the default) disables the counter entirely — no threadvar access, no comparisons, zero overhead.
+
+CLI: `--max-instructions=<N>` (default: 0, unlimited).
 
 ## FPU Exception Mask
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -637,7 +637,7 @@ finally
 end;
 ```
 
-Raises `TGocciaInstructionLimitError` when the limit is reached. A value of zero (the default) disables the counter entirely — no threadvar access, no comparisons, zero overhead.
+Raises `TGocciaInstructionLimitError` when the limit is reached. A value of zero (the default) skips all counter increments and limit comparisons — only the guard read of `GMaxInstructions` remains on the hot path.
 
 The CLI tools expose both limits as flags; see [Build System — Run Commands](build-system.md) for usage.
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -601,7 +601,7 @@ end;
 
 ## Execution Limits
 
-Two mechanisms prevent runaway scripts: wall-clock timeouts and instruction limits. Both use thread-local storage and are safe with `--jobs` parallelism — each worker thread gets its own independent counter.
+Two mechanisms prevent runaway scripts: wall-clock timeouts and instruction limits. Both use thread-local storage and are safe with parallel workers — each thread gets its own independent counter.
 
 ### Timeout
 
@@ -621,8 +621,6 @@ end;
 
 Raises `TGocciaTimeoutError` when the deadline is exceeded. A value of zero disables the timeout.
 
-CLI: `--timeout=<ms>` (default: 0 for ScriptLoader/BenchmarkRunner, 10 000 ms for TestRunner).
-
 ### Instruction Limit
 
 `StartInstructionLimit` caps the number of execution steps. In bytecode mode the counter increments on every dispatched instruction (exact). In interpreter mode it increments at function-call and loop-iteration checkpoints (approximate).
@@ -641,7 +639,7 @@ end;
 
 Raises `TGocciaInstructionLimitError` when the limit is reached. A value of zero (the default) disables the counter entirely — no threadvar access, no comparisons, zero overhead.
 
-CLI: `--max-instructions=<N>` (default: 0, unlimited).
+The CLI tools expose both limits as flags; see [Build System — Run Commands](build-system.md) for usage.
 
 ## FPU Exception Mask
 

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -24,6 +24,7 @@ uses
   Goccia.Error.Detail,
   Goccia.FileExtensions,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.Parser,
@@ -213,10 +214,12 @@ begin
           Engine.BuiltinBenchmark.OnProgress := TBenchmarkProgress.OnProgress;
 
         StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
+        StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
         try
           EngineResult := Engine.Execute;
         finally
           ClearExecutionTimeout;
+          ClearInstructionLimit;
         end;
         FileResult.FileName := AFileName;
         FileResult.LexTimeNanoseconds := EngineResult.LexTimeNanoseconds;
@@ -332,11 +335,13 @@ begin
             Engine.BuiltinBenchmark.OnBeforeMeasurement := Engine.ClearTransientCaches;
 
           StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
+          StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
           try
             try
               ResultValue := TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
             finally
               ClearExecutionTimeout;
+              ClearInstructionLimit;
             end;
             ExecEnd := GetNanoseconds;
 
@@ -432,10 +437,12 @@ begin
         Engine.BuiltinBenchmark.OnProgress := TBenchmarkProgress.OnProgress;
 
       StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
+      StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
       try
         EngineResult := Engine.Execute;
       finally
         ClearExecutionTimeout;
+        ClearInstructionLimit;
       end;
       FileResult.FileName := AFileName;
       FileResult.LexTimeNanoseconds := EngineResult.LexTimeNanoseconds;
@@ -543,11 +550,13 @@ begin
           Engine.BuiltinBenchmark.OnBeforeMeasurement := Engine.ClearTransientCaches;
 
         StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
+        StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
         try
           try
             ResultValue := TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
           finally
             ClearExecutionTimeout;
+            ClearInstructionLimit;
           end;
           ExecEnd := GetNanoseconds;
 

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -26,6 +26,7 @@ uses
   Goccia.Error.Detail,
   Goccia.FileExtensions,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.Parser,
@@ -332,11 +333,13 @@ begin
     ConfigureConsole(Engine.BuiltinConsole, AOutputLines);
     ApplyDataGlobalsToEngine(Engine);
     StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
+    StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
     try
       ApplyModuleGlobalsToEngine(Engine);
       ScriptResult := Engine.Execute;
     finally
       ClearExecutionTimeout;
+      ClearInstructionLimit;
       SourceMap := Engine.TakeLastSourceMap;
       try
         if Assigned(SourceMap) and Assigned(ASource) then
@@ -397,12 +400,14 @@ begin
       end;
 
       StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
+      StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
       try
         try
           ApplyModuleGlobalsToEngine(Engine);
           Result.ResultValue := TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
         finally
           ClearExecutionTimeout;
+          ClearInstructionLimit;
         end;
         ExecEnd := GetNanoseconds;
         Result.Timing.ExecuteTimeNanoseconds := ExecEnd - CompileEnd;
@@ -437,11 +442,13 @@ begin
         ConfigureConsole(Engine.BuiltinConsole, AOutputLines);
         ApplyDataGlobalsToEngine(Engine);
         StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
+        StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
         try
           ApplyModuleGlobalsToEngine(Engine);
           Result.ResultValue := TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
         finally
           ClearExecutionTimeout;
+          ClearInstructionLimit;
         end;
         ExecEnd := GetNanoseconds;
         Result.Timing.LexTimeNanoseconds := 0;

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -25,6 +25,7 @@ uses
   Goccia.Error.Detail,
   Goccia.FileExtensions,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.JSON.Utils,
   Goccia.JSX.Transformer,
   Goccia.Lexer,
@@ -310,10 +311,12 @@ begin
         end;
 
         StartExecutionTimeout(EngineOptions.Timeout.ValueOr(DEFAULT_TIMEOUT_MS));
+        StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
         try
           EngineResult := Engine.Execute;
         finally
           ClearExecutionTimeout;
+          ClearInstructionLimit;
         end;
       finally
         SilentCon.Free;
@@ -459,11 +462,13 @@ begin
             end;
 
             StartExecutionTimeout(EngineOptions.Timeout.ValueOr(DEFAULT_TIMEOUT_MS));
+            StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
             try
               try
                 ResultValue := TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
               finally
                 ClearExecutionTimeout;
+                ClearInstructionLimit;
               end;
               ExecEnd := GetNanoseconds;
 

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -128,6 +128,7 @@ type
     FImportMap: TGocciaStringOption;
     FAliases: TGocciaRepeatableOption;
     FTimeout: TGocciaIntegerOption;
+    FMaxInstructions: TGocciaIntegerOption;
   public
     constructor Create;
     destructor Destroy; override;
@@ -139,6 +140,7 @@ type
     property ImportMap: TGocciaStringOption read FImportMap;
     property Aliases: TGocciaRepeatableOption read FAliases;
     property Timeout: TGocciaIntegerOption read FTimeout;
+    property MaxInstructions: TGocciaIntegerOption read FMaxInstructions;
   end;
 
   TGocciaCoverageFormat = (cfLcov, cfJson);
@@ -467,6 +469,8 @@ begin
     'Import alias (e.g. @/=./src/)', 'Engine');
   FTimeout := TGocciaIntegerOption.Create('timeout',
     'Per-file timeout in milliseconds', 'Engine');
+  FMaxInstructions := TGocciaIntegerOption.Create('max-instructions',
+    'Maximum bytecode instructions before aborting', 'Engine');
 end;
 
 destructor TGocciaEngineOptions.Destroy;
@@ -476,17 +480,19 @@ begin
   FImportMap.Free;
   FAliases.Free;
   FTimeout.Free;
+  FMaxInstructions.Free;
   inherited Destroy;
 end;
 
 function TGocciaEngineOptions.Options: TGocciaOptionArray;
 begin
-  SetLength(Result, 5);
+  SetLength(Result, 6);
   Result[0] := FMode;
   Result[1] := FASI;
   Result[2] := FImportMap;
   Result[3] := FAliases;
   Result[4] := FTimeout;
+  Result[5] := FMaxInstructions;
 end;
 
 { TGocciaCoverageOptions }

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -472,7 +472,7 @@ begin
   FTimeout := TGocciaIntegerOption.Create('timeout',
     'Per-file timeout in milliseconds', 'Engine');
   FMaxInstructions := TGocciaIntegerOption.Create('max-instructions',
-    'Maximum bytecode instructions before aborting', 'Engine');
+    'Maximum execution steps before aborting', 'Engine');
   FUnsafeFFI := TGocciaFlagOption.Create('unsafe-ffi',
     'Enable the FFI global (foreign function interface)', 'Engine');
 end;

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -66,6 +66,18 @@ type
     property Value: Integer read FValue;
   end;
 
+  TGocciaInt64Option = class(TGocciaOptionBase)
+  private
+    FValue: Int64;
+  public
+    procedure Apply(const AValue: string); override;
+    function FormatForHelp: string; override;
+
+    function ValueOr(const ADefault: Int64): Int64;
+
+    property Value: Int64 read FValue;
+  end;
+
   TGocciaRepeatableOption = class(TGocciaOptionBase)
   private
     FValues: TStringList;
@@ -128,7 +140,7 @@ type
     FImportMap: TGocciaStringOption;
     FAliases: TGocciaRepeatableOption;
     FTimeout: TGocciaIntegerOption;
-    FMaxInstructions: TGocciaIntegerOption;
+    FMaxInstructions: TGocciaInt64Option;
     FUnsafeFFI: TGocciaFlagOption;
   public
     constructor Create;
@@ -141,7 +153,7 @@ type
     property ImportMap: TGocciaStringOption read FImportMap;
     property Aliases: TGocciaRepeatableOption read FAliases;
     property Timeout: TGocciaIntegerOption read FTimeout;
-    property MaxInstructions: TGocciaIntegerOption read FMaxInstructions;
+    property MaxInstructions: TGocciaInt64Option read FMaxInstructions;
     property UnsafeFFI: TGocciaFlagOption read FUnsafeFFI;
   end;
 
@@ -277,6 +289,32 @@ begin
 end;
 
 function TGocciaIntegerOption.ValueOr(const ADefault: Integer): Integer;
+begin
+  if FPresent then
+    Result := FValue
+  else
+    Result := ADefault;
+end;
+
+{ TGocciaInt64Option }
+
+procedure TGocciaInt64Option.Apply(const AValue: string);
+var
+  Parsed: Int64;
+begin
+  if not TryStrToInt64(AValue, Parsed) then
+    raise TGocciaParseError.CreateFmt('Invalid integer value for --%s: %s',
+      [LongName, AValue]);
+  FValue := Parsed;
+  FPresent := True;
+end;
+
+function TGocciaInt64Option.FormatForHelp: string;
+begin
+  Result := '--' + LongName + '=<N>';
+end;
+
+function TGocciaInt64Option.ValueOr(const ADefault: Int64): Int64;
 begin
   if FPresent then
     Result := FValue
@@ -471,7 +509,7 @@ begin
     'Import alias (e.g. @/=./src/)', 'Engine');
   FTimeout := TGocciaIntegerOption.Create('timeout',
     'Per-file timeout in milliseconds', 'Engine');
-  FMaxInstructions := TGocciaIntegerOption.Create('max-instructions',
+  FMaxInstructions := TGocciaInt64Option.Create('max-instructions',
     'Maximum execution steps before aborting', 'Engine');
   FUnsafeFFI := TGocciaFlagOption.Create('unsafe-ffi',
     'Enable the FFI global (foreign function interface)', 'Engine');

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -104,6 +104,7 @@ uses
   Goccia.Evaluator.Decorators,
   Goccia.Evaluator.TypeOperations,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.Keywords.Reserved,
   Goccia.Lexer,
   Goccia.MicrotaskQueue,
@@ -513,6 +514,8 @@ var
   I: Integer;
 begin
   CheckExecutionTimeout;
+  IncrementInstructionCounter;
+  CheckInstructionLimit;
   // Handle super() calls specially
   if ACallExpression.Callee is TGocciaSuperExpression then
   begin
@@ -1181,6 +1184,8 @@ begin
     while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
     begin
       CheckExecutionTimeout;
+      IncrementInstructionCounter;
+      CheckInstructionLimit;
       CurrentValue := IterResult.GetProperty(PROP_VALUE);
 
       IterScope := AContext.Scope.CreateChild(skBlock);
@@ -1250,6 +1255,8 @@ begin
         while True do
         begin
           CheckExecutionTimeout;
+          IncrementInstructionCounter;
+          CheckInstructionLimit;
           NextResult := TGocciaFunctionBase(NextMethod).Call(EmptyArgs, IteratorObj);
           NextResult := AwaitValue(NextResult);
 
@@ -1302,6 +1309,8 @@ begin
       while not GenericNextResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
       begin
         CheckExecutionTimeout;
+        IncrementInstructionCounter;
+        CheckInstructionLimit;
         CurrentValue := GenericNextResult.GetProperty(PROP_VALUE);
         CurrentValue := AwaitValue(CurrentValue);
 
@@ -1728,6 +1737,8 @@ begin
     end;
     on E: TGocciaTimeoutError do
       raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
     begin
       if Assigned(ATryStatement.CatchBlock) then
@@ -1989,6 +2000,8 @@ var
   InitScope, SuperInitScope: TGocciaScope;
 begin
   CheckExecutionTimeout;
+  IncrementInstructionCounter;
+  CheckInstructionLimit;
   Callee := EvaluateExpression(ANewExpression.Callee, AContext);
 
   Arguments := TGocciaArgumentsCollection.Create;
@@ -3170,11 +3183,15 @@ var
   InitScope, SuperInitScope: TGocciaScope;
 begin
   CheckExecutionTimeout;
+  IncrementInstructionCounter;
+  CheckInstructionLimit;
   NativeInstance := nil;
   WalkClass := AClassValue;
   while Assigned(WalkClass) do
   begin
     CheckExecutionTimeout;
+    IncrementInstructionCounter;
+    CheckInstructionLimit;
     NativeInstance := WalkClass.CreateNativeInstance(AArguments);
     if Assigned(NativeInstance) then
       Break;
@@ -3211,6 +3228,8 @@ begin
         while Assigned(WalkClass) do
         begin
           CheckExecutionTimeout;
+          IncrementInstructionCounter;
+          CheckInstructionLimit;
           SuperInitContext := AContext;
           SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, WalkClass);
           SuperInitScope.ThisValue := Instance;
@@ -3287,6 +3306,8 @@ var
   CalleeName: string;
 begin
   CheckExecutionTimeout;
+  IncrementInstructionCounter;
+  CheckInstructionLimit;
 
   // ES2026 §13.3.11 step 1: Evaluate the tag expression
   if ATaggedTemplateExpression.Tag is TGocciaMemberExpression then

--- a/source/units/Goccia.InstructionLimit.pas
+++ b/source/units/Goccia.InstructionLimit.pas
@@ -35,7 +35,8 @@ end;
 
 procedure IncrementInstructionCounter; inline;
 begin
-  Inc(GInstructionCount);
+  if GMaxInstructions > 0 then
+    Inc(GInstructionCount);
 end;
 
 procedure CheckInstructionLimit; inline;

--- a/source/units/Goccia.InstructionLimit.pas
+++ b/source/units/Goccia.InstructionLimit.pas
@@ -1,0 +1,48 @@
+unit Goccia.InstructionLimit;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TGocciaInstructionLimitError = class(Exception);
+
+procedure StartInstructionLimit(const AMaxInstructions: Int64);
+procedure ClearInstructionLimit;
+procedure IncrementInstructionCounter; inline;
+procedure CheckInstructionLimit; inline;
+
+implementation
+
+threadvar
+  GMaxInstructions: Int64;
+  GInstructionCount: Int64;
+
+procedure StartInstructionLimit(const AMaxInstructions: Int64);
+begin
+  GMaxInstructions := AMaxInstructions;
+  GInstructionCount := 0;
+end;
+
+procedure ClearInstructionLimit;
+begin
+  GMaxInstructions := 0;
+  GInstructionCount := 0;
+end;
+
+procedure IncrementInstructionCounter; inline;
+begin
+  Inc(GInstructionCount);
+end;
+
+procedure CheckInstructionLimit; inline;
+begin
+  if (GMaxInstructions > 0) and (GInstructionCount >= GMaxInstructions) then
+    raise TGocciaInstructionLimitError.CreateFmt(
+      'Execution exceeded instruction limit of %d', [GMaxInstructions]);
+end;
+
+end.

--- a/source/units/Goccia.MicrotaskQueue.pas
+++ b/source/units/Goccia.MicrotaskQueue.pas
@@ -98,7 +98,6 @@ begin
     while I < FQueue.Count do
     begin
       CheckExecutionTimeout;
-      IncrementInstructionCounter;
       CheckInstructionLimit;
       Task := FQueue[I];
       Inc(I);

--- a/source/units/Goccia.MicrotaskQueue.pas
+++ b/source/units/Goccia.MicrotaskQueue.pas
@@ -43,6 +43,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.Timeout,
   Goccia.Values.Error,
   Goccia.Values.FunctionBase,
@@ -97,6 +98,8 @@ begin
     while I < FQueue.Count do
     begin
       CheckExecutionTimeout;
+      IncrementInstructionCounter;
+      CheckInstructionLimit;
       Task := FQueue[I];
       Inc(I);
 

--- a/source/units/Goccia.ScriptLoader.JSON.pas
+++ b/source/units/Goccia.ScriptLoader.JSON.pas
@@ -43,6 +43,7 @@ uses
 
   Goccia.Constants.PropertyNames,
   Goccia.Error,
+  Goccia.InstructionLimit,
   Goccia.JSON,
   Goccia.JSON.Utils,
   Goccia.Timeout,
@@ -146,6 +147,8 @@ function ExceptionClassToErrorType(const E: Exception): string;
 begin
   if E is TGocciaTimeoutError then
     Result := 'TimeoutError'
+  else if E is TGocciaInstructionLimitError then
+    Result := 'InstructionLimitError'
   else if E is TGocciaError then
     Result := ErrorDisplayName(TGocciaError(E))
   else

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -3877,6 +3877,7 @@ begin
     while Running and (Frame.IP < Template.CodeCount) do
     begin
       try
+        CheckInstructionLimit;
         Instruction := Template.GetInstructionUnchecked(Frame.IP);
         Inc(Frame.IP);
         IncrementInstructionCounter;
@@ -3988,10 +3989,7 @@ begin
         JumpOffset := DecodeAx(Instruction);
         Inc(Frame.IP, JumpOffset);
         if JumpOffset < 0 then
-        begin
           CheckExecutionTimeout;
-          CheckInstructionLimit;
-        end;
       end;
 
       OP_JUMP_IF_TRUE:
@@ -4005,10 +4003,7 @@ begin
           JumpOffset := DecodesBx(Instruction);
           Inc(Frame.IP, JumpOffset);
           if JumpOffset < 0 then
-          begin
             CheckExecutionTimeout;
-            CheckInstructionLimit;
-          end;
         end
         else if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
           TGocciaCoverageTracker.Instance.RecordBranchHit(
@@ -4027,10 +4022,7 @@ begin
           JumpOffset := DecodesBx(Instruction);
           Inc(Frame.IP, JumpOffset);
           if JumpOffset < 0 then
-          begin
             CheckExecutionTimeout;
-            CheckInstructionLimit;
-          end;
         end
         else if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
           TGocciaCoverageTracker.Instance.RecordBranchHit(
@@ -5044,7 +5036,6 @@ begin
       OP_CALL:
       begin
         CheckExecutionTimeout;
-        CheckInstructionLimit;
         if (FRegisters[A].Kind = grkObject) and
            (FRegisters[A].ObjectValue is TGocciaBoundFunctionValue) then
         begin
@@ -5142,7 +5133,6 @@ begin
       OP_CALL_METHOD:
       begin
         CheckExecutionTimeout;
-        CheckInstructionLimit;
         if (C and 1) = 0 then
         begin
           if (FRegisters[A - 1].Kind = grkObject) and

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -213,6 +213,7 @@ uses
   Goccia.Evaluator.Decorators,
   Goccia.GarbageCollector,
   Goccia.ImportMeta,
+  Goccia.InstructionLimit,
   Goccia.Profiler,
   Goccia.Timeout,
   Goccia.Values.BigIntValue,
@@ -1692,6 +1693,7 @@ var
   end;
 begin
   CheckExecutionTimeout;
+  CheckInstructionLimit;
   BoxedArgs := nil;
   try
     NativeInstance := nil;
@@ -2343,6 +2345,7 @@ begin
   begin
     repeat
       CheckExecutionTimeout;
+      CheckInstructionLimit;
       NextResult := TGocciaIteratorValue(IteratorValue).DirectNext(DoneFlag);
       if not DoneFlag then
         Result.Elements.Add(NextResult);
@@ -2354,6 +2357,7 @@ begin
   begin
     repeat
       CheckExecutionTimeout;
+      CheckInstructionLimit;
       NextMethod := IteratorValue.GetProperty(PROP_NEXT);
       if not Assigned(NextMethod) or
          (NextMethod is TGocciaUndefinedLiteralValue) or
@@ -3714,6 +3718,7 @@ function TGocciaVM.ExecuteClosureRegisters(const AClosure: TGocciaBytecodeClosur
   const AThisValue: TGocciaRegister; const AArguments: TGocciaRegisterArray): TGocciaRegister;
 begin
   CheckExecutionTimeout;
+  CheckInstructionLimit;
   Result := ExecuteClosureRegistersInternal(AClosure, AThisValue, AArguments,
     Length(AArguments), RegisterUndefined, RegisterUndefined, RegisterUndefined,
     False);
@@ -3874,6 +3879,7 @@ begin
       try
         Instruction := Template.GetInstructionUnchecked(Frame.IP);
         Inc(Frame.IP);
+        IncrementInstructionCounter;
 
         if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and
            Assigned(Template.DebugInfo) then
@@ -3982,7 +3988,10 @@ begin
         JumpOffset := DecodeAx(Instruction);
         Inc(Frame.IP, JumpOffset);
         if JumpOffset < 0 then
+        begin
           CheckExecutionTimeout;
+          CheckInstructionLimit;
+        end;
       end;
 
       OP_JUMP_IF_TRUE:
@@ -3996,7 +4005,10 @@ begin
           JumpOffset := DecodesBx(Instruction);
           Inc(Frame.IP, JumpOffset);
           if JumpOffset < 0 then
+          begin
             CheckExecutionTimeout;
+            CheckInstructionLimit;
+          end;
         end
         else if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
           TGocciaCoverageTracker.Instance.RecordBranchHit(
@@ -4015,7 +4027,10 @@ begin
           JumpOffset := DecodesBx(Instruction);
           Inc(Frame.IP, JumpOffset);
           if JumpOffset < 0 then
+          begin
             CheckExecutionTimeout;
+            CheckInstructionLimit;
+          end;
         end
         else if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and Assigned(Template.DebugInfo) then
           TGocciaCoverageTracker.Instance.RecordBranchHit(
@@ -5029,6 +5044,7 @@ begin
       OP_CALL:
       begin
         CheckExecutionTimeout;
+        CheckInstructionLimit;
         if (FRegisters[A].Kind = grkObject) and
            (FRegisters[A].ObjectValue is TGocciaBoundFunctionValue) then
         begin
@@ -5126,6 +5142,7 @@ begin
       OP_CALL_METHOD:
       begin
         CheckExecutionTimeout;
+        CheckInstructionLimit;
         if (C and 1) = 0 then
         begin
           if (FRegisters[A - 1].Kind = grkObject) and

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -166,6 +166,7 @@ uses
 
   Goccia.Constants,
   Goccia.Constants.TypeNames,
+  Goccia.InstructionLimit,
   Goccia.Profiler,
   Goccia.TextFiles,
   Goccia.Threading,
@@ -181,6 +182,7 @@ begin
   if GProfilingAllocations and Assigned(TGocciaProfiler.Instance) then
     TGocciaProfiler.Instance.RecordAllocation;
   CheckExecutionTimeout;
+  CheckInstructionLimit;
 end;
 
 function TGocciaValue.RuntimeCopy: TGocciaValue;


### PR DESCRIPTION
## Summary

- Add `--max-instructions=<N>` CLI flag that caps the number of instructions a script may execute before aborting with a `TGocciaInstructionLimitError`
- In bytecode mode the counter increments on every dispatched instruction (exact count); in interpreter mode it increments at function-call and loop-iteration checkpoints (approximate)
- The counter uses thread-local storage (`Goccia.InstructionLimit.pas`) following the same pattern as `Goccia.Timeout.pas`, with zero overhead when the limit is not set

## Test plan

- [x] All binaries build cleanly (loader, testrunner, benchmarkrunner, bundler, repl)
- [x] Full test suite passes in both interpreted and bytecode modes (same pre-existing FFI-only failures)
- [x] `./format.pas --check` passes
- [x] Manual verification: infinite loop aborts with correct error and JSON output in both modes
- [x] CI tests added to `pr.yml` validating `--max-instructions` in both interpreted and bytecode modes (exit code, JSON error type, error message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)