### PR TITLE
Add nightly release and update artifact actions to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1096,6 +1096,9 @@ jobs:
   nightly:
     needs: [test, toml-compliance, json5-compliance, benchmark, cli]
     if: github.ref == 'refs/heads/main'
+    concurrency:
+      group: nightly-release
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -1166,6 +1169,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           COMMIT="$(git rev-parse --short HEAD)"
+          TARGET_SHA="$(git rev-parse HEAD)"
           DATE="$(date -u +'%Y-%m-%d')"
 
           gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
@@ -1179,7 +1183,7 @@ jobs:
           EOF
           )" \
             --prerelease \
-            --target main \
+            --target "$TARGET_SHA" \
             gocciascript-nightly-*.tar.gz gocciascript-nightly-*.zip
 
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -402,7 +402,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -483,7 +483,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -608,7 +608,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -673,7 +673,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -1078,7 +1078,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -1124,7 +1124,7 @@ jobs:
 
       - name: Download all build artifacts
         if: steps.check.outputs.skip != 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts/
 
@@ -1199,7 +1199,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
           fi
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: gocciascript-${{ matrix.target }}
           retention-days: 1
@@ -278,7 +278,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -402,7 +402,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -449,7 +449,7 @@ jobs:
 
       - name: Upload TOML compliance report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: toml-test-results-${{ matrix.target }}
           retention-days: 1
@@ -483,7 +483,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -550,7 +550,7 @@ jobs:
 
       - name: Upload JSON5 compliance report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: json5-test-results-${{ matrix.target }}
           retention-days: 1
@@ -608,7 +608,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -673,7 +673,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -1078,7 +1078,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -1087,11 +1087,100 @@ jobs:
         run: bash ./.github/scripts/stage-build-artifacts.sh build release-artifacts
 
       - name: Upload release artifact bundle
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: gocciascript-release-${{ matrix.target }}
           if-no-files-found: ignore
           path: release-artifacts/*
+
+  nightly:
+    needs: [test, toml-compliance, json5-compliance, benchmark, cli]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check if nightly already published today
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TODAY="$(date -u +'%Y-%m-%d')"
+          PUBLISHED="$(gh release view nightly --json publishedAt --jq .publishedAt 2>/dev/null || echo "")"
+          if [ -n "$PUBLISHED" ] && echo "$PUBLISHED" | grep -q "^${TODAY}"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Nightly already published today (${PUBLISHED}) — skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download all build artifacts
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts/
+
+      - name: Package nightly builds
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          declare -A DISPLAY_NAMES=(
+            ["aarch64-darwin"]="macos-arm64"
+            ["x86_64-darwin"]="macos-x64"
+            ["x86_64-linux"]="linux-x64"
+            ["aarch64-linux"]="linux-arm64"
+            ["x86_64-win64"]="windows-x64"
+            ["i386-win32"]="windows-x86"
+          )
+
+          targets=("aarch64-darwin" "x86_64-darwin" "x86_64-linux" "aarch64-linux" "x86_64-win64" "i386-win32")
+
+          for target in "${targets[@]}"; do
+            artifact_dir="artifacts/gocciascript-${target}"
+            if [ ! -d "$artifact_dir" ]; then
+              echo "Skipping $target (no artifact found)"
+              continue
+            fi
+
+            display="${DISPLAY_NAMES[$target]}"
+            archive_name="gocciascript-nightly-${display}"
+            pkg_dir="${archive_name}"
+            bash ./.github/scripts/stage-build-artifacts.sh "$artifact_dir" "$pkg_dir"
+
+            if [[ "$target" == *win* ]]; then
+              zip -r "${archive_name}.zip" "$pkg_dir/"
+            else
+              tar -czf "${archive_name}.tar.gz" "$pkg_dir/"
+            fi
+
+            rm -rf "$pkg_dir"
+          done
+
+      - name: Update nightly release
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMIT="$(git rev-parse --short HEAD)"
+          DATE="$(date -u +'%Y-%m-%d')"
+
+          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+
+          gh release create nightly \
+            --title "Nightly Build (${DATE})" \
+            --notes "$(cat <<EOF
+          Automated nightly build from \`main\` at [\`${COMMIT}\`](https://github.com/${{ github.repository }}/commit/${COMMIT}).
+
+          Built on ${DATE}. This pre-release is replaced by each new nightly build.
+          EOF
+          )" \
+            --prerelease \
+            --target main \
+            gocciascript-nightly-*.tar.gz gocciascript-nightly-*.zip
 
   release:
     needs: [test, toml-compliance, json5-compliance, benchmark, cli]
@@ -1106,7 +1195,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           path: artifacts/
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
         run: bash ./.github/scripts/stage-build-artifacts.sh build pr-artifacts --include-tests
 
       - name: Upload build
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: build-pr
           retention-days: 1
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: build-pr
           path: build/
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.mode }}
           retention-days: 1
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: build-pr
           path: build/
@@ -196,7 +196,7 @@ jobs:
           grep -q '"jobCount":' benchmark-${{ matrix.mode }}.json
 
       - name: Upload results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-${{ matrix.mode }}
           retention-days: 1
@@ -214,7 +214,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: build-pr
           path: build/
@@ -749,12 +749,12 @@ jobs:
         shell: bash
     steps:
       - name: Download interpreted results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: benchmark-interpreted
 
       - name: Download bytecode results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: benchmark-bytecode
 
@@ -1023,25 +1023,25 @@ jobs:
         shell: bash
     steps:
       - name: Download test results (interpreted)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: test-results-interpreted
 
       - name: Download test results (bytecode)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: test-results-bytecode
 
       - name: Download benchmark results (interpreted)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: benchmark-interpreted
 
       - name: Download benchmark results (bytecode)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: benchmark-bytecode


### PR DESCRIPTION
## Summary
- Add a `nightly` job to `ci.yml` that reuses existing CI build artifacts (no rebuild) to publish a rolling `nightly` pre-release on every push to `main`, capped at once per day (UTC)
- Update `actions/upload-artifact` and `actions/download-artifact` from deprecated `@v5` to `@v7` across both `ci.yml` and `pr.yml`

## Details

**Nightly release:**
- Runs after all tests/compliance/benchmarks/CLI checks pass on `main`
- Checks if a nightly was already published today — skips if so (max 1/day)
- Downloads the existing `gocciascript-{target}` artifacts, packages them into archives, and publishes a `nightly` pre-release
- Permanent download URLs: `https://github.com/OWNER/REPO/releases/download/nightly/gocciascript-nightly-{platform}.tar.gz`
- Mutually exclusive with the `release` job (nightly runs on `main`, release runs on tags)

**Artifact action upgrade:**
- `actions/upload-artifact@v5` → `@v7` (4 in ci.yml, 3 in pr.yml)
- `actions/download-artifact@v5` → `@v7` (8 in ci.yml, 6 in pr.yml)

## Test plan
- [ ] Verify CI workflow passes on this PR (artifact actions v7 compatibility)
- [ ] After merge, confirm nightly release appears under Releases on first push to main
- [ ] Confirm subsequent pushes to main on the same day skip the nightly job
- [ ] Verify tag pushes still create proper releases unaffected by the nightly job

🤖 Generated with [Claude Code](https://claude.com/claude-code)