### PR TITLE
Improve Temporal conformance and enable BigInt in test262

### DIFF
--- a/scripts/test262_syntax_filter.py
+++ b/scripts/test262_syntax_filter.py
@@ -166,7 +166,7 @@ SUPPORTED_FEATURES: dict[str, bool] = {
 
     # Core language -- NOT supported
     "generators": False,
-    "BigInt": False,
+    "BigInt": True,
     "Proxy": True,
     "Reflect": True,
     "Reflect.construct": True,
@@ -284,8 +284,6 @@ _UNSUPPORTED_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
      re.compile(r"\byield\b")),
     ("labeled_statement",
      re.compile(r"^\s*\w+\s*:\s*(?:for|while|do|if|switch)\b", re.MULTILINE)),
-    ("bigint_literal",
-     re.compile(r"\b\d[\d_]*n\b")),
 ]
 
 

--- a/source/units/Goccia.Builtins.Temporal.pas
+++ b/source/units/Goccia.Builtins.Temporal.pas
@@ -153,11 +153,16 @@ var
 begin
   ConstructorMethod := TGocciaNativeFunctionValue.Create(DurationConstructorFn, 'Duration', 0);
   TGocciaTemporalDurationValue.ExposePrototype(ConstructorMethod);
-  ConstructorMethod.AssignProperty('from',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(DurationFrom, 'from', 1));
-  ConstructorMethod.AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(DurationCompare, 'compare', 2));
-  FTemporalNamespace.AssignProperty('Duration', ConstructorMethod);
+  ConstructorMethod.DefineProperty('from',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(DurationFrom, 'from', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('compare',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(DurationCompare, 'compare', 2),
+      [pfConfigurable, pfWritable]));
+  FTemporalNamespace.DefineProperty('Duration',
+    TGocciaPropertyDescriptorData.Create(ConstructorMethod, [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaTemporalBuiltin.DurationConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -257,6 +262,18 @@ var
   var
     DurRec: TTemporalDurationRecord;
     Obj: TGocciaObjectValue;
+
+    function GetFieldOr(const AName: string; const ADefault: Int64): Int64;
+    var
+      V: TGocciaValue;
+    begin
+      V := Obj.GetProperty(AName);
+      if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+        Result := ADefault
+      else
+        Result := Trunc(V.ToNumberLiteral.Value);
+    end;
+
   begin
     if AArg is TGocciaTemporalDurationValue then
       Result := TGocciaTemporalDurationValue(AArg)
@@ -268,6 +285,15 @@ var
         DurRec.Years, DurRec.Months, DurRec.Weeks, DurRec.Days,
         DurRec.Hours, DurRec.Minutes, DurRec.Seconds,
         DurRec.Milliseconds, DurRec.Microseconds, DurRec.Nanoseconds);
+    end
+    else if AArg is TGocciaObjectValue then
+    begin
+      Obj := TGocciaObjectValue(AArg);
+      Result := TGocciaTemporalDurationValue.Create(
+        GetFieldOr('years', 0), GetFieldOr('months', 0), GetFieldOr('weeks', 0),
+        GetFieldOr('days', 0), GetFieldOr('hours', 0), GetFieldOr('minutes', 0),
+        GetFieldOr('seconds', 0), GetFieldOr('milliseconds', 0),
+        GetFieldOr('microseconds', 0), GetFieldOr('nanoseconds', 0));
     end
     else
     begin
@@ -304,15 +330,24 @@ var
 begin
   ConstructorMethod := TGocciaNativeFunctionValue.Create(InstantConstructorFn, 'Instant', 1);
   TGocciaTemporalInstantValue.ExposePrototype(ConstructorMethod);
-  ConstructorMethod.AssignProperty('from',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(InstantFrom, 'from', 1));
-  ConstructorMethod.AssignProperty('fromEpochMilliseconds',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(InstantFromEpochMilliseconds, 'fromEpochMilliseconds', 1));
-  ConstructorMethod.AssignProperty('fromEpochNanoseconds',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(InstantFromEpochNanoseconds, 'fromEpochNanoseconds', 1));
-  ConstructorMethod.AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(InstantCompare, 'compare', 2));
-  FTemporalNamespace.AssignProperty('Instant', ConstructorMethod);
+  ConstructorMethod.DefineProperty('from',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(InstantFrom, 'from', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('fromEpochMilliseconds',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(InstantFromEpochMilliseconds, 'fromEpochMilliseconds', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('fromEpochNanoseconds',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(InstantFromEpochNanoseconds, 'fromEpochNanoseconds', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('compare',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(InstantCompare, 'compare', 2),
+      [pfConfigurable, pfWritable]));
+  FTemporalNamespace.DefineProperty('Instant',
+    TGocciaPropertyDescriptorData.Create(ConstructorMethod, [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaTemporalBuiltin.InstantConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -344,6 +379,7 @@ var
   Inst: TGocciaTemporalInstantValue;
   DateRec: TTemporalDateRecord;
   TimeRec: TTemporalTimeRecord;
+  OffsetSeconds: Integer;
   EpochMs: Int64;
   SubMs: Integer;
 begin
@@ -356,11 +392,12 @@ begin
   end
   else if Arg is TGocciaStringLiteralValue then
   begin
-    if not TryParseISODateTime(TGocciaStringLiteralValue(Arg).Value, DateRec, TimeRec) then
+    if not CoerceToISOInstant(TGocciaStringLiteralValue(Arg).Value, DateRec, TimeRec, OffsetSeconds) then
       ThrowRangeError(SErrorInvalidISOInstant, SSuggestTemporalISOFormat);
     EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * Int64(86400000) +
                Int64(TimeRec.Hour) * 3600000 + Int64(TimeRec.Minute) * 60000 +
                Int64(TimeRec.Second) * 1000 + TimeRec.Millisecond;
+    EpochMs := EpochMs - Int64(OffsetSeconds) * 1000;
     SubMs := TimeRec.Microsecond * 1000 + TimeRec.Nanosecond;
     Result := TGocciaTemporalInstantValue.Create(EpochMs, SubMs);
   end
@@ -410,6 +447,7 @@ var
   var
     DateRec: TTemporalDateRecord;
     TimeRec: TTemporalTimeRecord;
+    OffsetSeconds: Integer;
     EpochMs: Int64;
     SubMs: Integer;
   begin
@@ -417,11 +455,12 @@ var
       Result := TGocciaTemporalInstantValue(AArg)
     else if AArg is TGocciaStringLiteralValue then
     begin
-      if not TryParseISODateTime(TGocciaStringLiteralValue(AArg).Value, DateRec, TimeRec) then
+      if not CoerceToISOInstant(TGocciaStringLiteralValue(AArg).Value, DateRec, TimeRec, OffsetSeconds) then
         ThrowRangeError(SErrorInvalidISOInstant, SSuggestTemporalISOFormat);
       EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * Int64(86400000) +
                  Int64(TimeRec.Hour) * 3600000 + Int64(TimeRec.Minute) * 60000 +
                  Int64(TimeRec.Second) * 1000 + TimeRec.Millisecond;
+      EpochMs := EpochMs - Int64(OffsetSeconds) * 1000;
       SubMs := TimeRec.Microsecond * 1000 + TimeRec.Nanosecond;
       Result := TGocciaTemporalInstantValue.Create(EpochMs, SubMs);
     end
@@ -456,11 +495,16 @@ var
 begin
   ConstructorMethod := TGocciaNativeFunctionValue.Create(PlainDateConstructorFn, 'PlainDate', 3);
   TGocciaTemporalPlainDateValue.ExposePrototype(ConstructorMethod);
-  ConstructorMethod.AssignProperty('from',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainDateFrom, 'from', 1));
-  ConstructorMethod.AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainDateCompare, 'compare', 2));
-  FTemporalNamespace.AssignProperty('PlainDate', ConstructorMethod);
+  ConstructorMethod.DefineProperty('from',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainDateFrom, 'from', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('compare',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainDateCompare, 'compare', 2),
+      [pfConfigurable, pfWritable]));
+  FTemporalNamespace.DefineProperty('PlainDate',
+    TGocciaPropertyDescriptorData.Create(ConstructorMethod, [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaTemporalBuiltin.PlainDateConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -479,7 +523,6 @@ var
   Arg, OptionsArg, V: TGocciaValue;
   D: TGocciaTemporalPlainDateValue;
   DateRec: TTemporalDateRecord;
-  TimeRec: TTemporalTimeRecord;
   Obj: TGocciaObjectValue;
   Y, Mo, Dy, MaxDay: Integer;
   Overflow: TTemporalOverflow;
@@ -502,12 +545,9 @@ begin
   end
   else if Arg is TGocciaStringLiteralValue then
   begin
-    if TryParseISODate(TGocciaStringLiteralValue(Arg).Value, DateRec) then
-      Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day)
-    else if TryParseISODateTime(TGocciaStringLiteralValue(Arg).Value, DateRec, TimeRec) then
-      Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day)
-    else
+    if not CoerceToISODate(TGocciaStringLiteralValue(Arg).Value, DateRec) then
       ThrowRangeError(SErrorInvalidISODate, SSuggestTemporalISOFormat);
+    Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day);
   end
   else if Arg is TGocciaObjectValue then
   begin
@@ -564,21 +604,39 @@ var
   function CoerceDate(const AArg: TGocciaValue): TGocciaTemporalPlainDateValue;
   var
     DateRec: TTemporalDateRecord;
-    TimeRec: TTemporalTimeRecord;
+    Obj: TGocciaObjectValue;
+    VY, VM, VD: TGocciaValue;
   begin
     if AArg is TGocciaTemporalPlainDateValue then
       Result := TGocciaTemporalPlainDateValue(AArg)
     else if AArg is TGocciaStringLiteralValue then
     begin
-      if TryParseISODate(TGocciaStringLiteralValue(AArg).Value, DateRec) then
-        Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day)
-      else if TryParseISODateTime(TGocciaStringLiteralValue(AArg).Value, DateRec, TimeRec) then
-        Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day)
-      else
+      if not CoerceToISODate(TGocciaStringLiteralValue(AArg).Value, DateRec) then
       begin
         ThrowRangeError(SErrorInvalidISODate, SSuggestTemporalISOFormat);
         Result := nil;
-      end;
+      end
+      else
+        Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day);
+    end
+    else if AArg is TGocciaObjectValue then
+    begin
+      Obj := TGocciaObjectValue(AArg);
+      VY := Obj.GetProperty(PROP_YEAR);
+      VM := Obj.GetProperty(PROP_MONTH);
+      VD := Obj.GetProperty(PROP_DAY);
+      if (VY = nil) or (VY is TGocciaUndefinedLiteralValue) or
+         (VM = nil) or (VM is TGocciaUndefinedLiteralValue) or
+         (VD = nil) or (VD is TGocciaUndefinedLiteralValue) then
+      begin
+        ThrowTypeError(SErrorTemporalPlainDateCompareArg, SSuggestTemporalCompareArg);
+        Result := nil;
+      end
+      else
+        Result := TGocciaTemporalPlainDateValue.Create(
+          Trunc(VY.ToNumberLiteral.Value),
+          Trunc(VM.ToNumberLiteral.Value),
+          Trunc(VD.ToNumberLiteral.Value));
     end
     else
     begin
@@ -603,11 +661,16 @@ var
 begin
   ConstructorMethod := TGocciaNativeFunctionValue.Create(PlainTimeConstructorFn, 'PlainTime', 0);
   TGocciaTemporalPlainTimeValue.ExposePrototype(ConstructorMethod);
-  ConstructorMethod.AssignProperty('from',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainTimeFrom, 'from', 1));
-  ConstructorMethod.AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainTimeCompare, 'compare', 2));
-  FTemporalNamespace.AssignProperty('PlainTime', ConstructorMethod);
+  ConstructorMethod.DefineProperty('from',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainTimeFrom, 'from', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('compare',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainTimeCompare, 'compare', 2),
+      [pfConfigurable, pfWritable]));
+  FTemporalNamespace.DefineProperty('PlainTime',
+    TGocciaPropertyDescriptorData.Create(ConstructorMethod, [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaTemporalBuiltin.PlainTimeConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -653,7 +716,7 @@ begin
   end
   else if Arg is TGocciaStringLiteralValue then
   begin
-    if not TryParseISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
+    if not CoerceToISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
       ThrowRangeError(SErrorInvalidISOTime, SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainTimeValue.Create(
       TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
@@ -691,12 +754,15 @@ var
   function CoerceTime(const AArg: TGocciaValue): TGocciaTemporalPlainTimeValue;
   var
     TimeRec: TTemporalTimeRecord;
+    Obj: TGocciaObjectValue;
+    V: TGocciaValue;
+    H, Mi, S, Ms, Us, Ns: Integer;
   begin
     if AArg is TGocciaTemporalPlainTimeValue then
       Result := TGocciaTemporalPlainTimeValue(AArg)
     else if AArg is TGocciaStringLiteralValue then
     begin
-      if not TryParseISOTime(TGocciaStringLiteralValue(AArg).Value, TimeRec) then
+      if not CoerceToISOTime(TGocciaStringLiteralValue(AArg).Value, TimeRec) then
       begin
         ThrowRangeError(SErrorInvalidISOTime, SSuggestTemporalISOFormat);
         Result := nil;
@@ -705,6 +771,24 @@ var
         Result := TGocciaTemporalPlainTimeValue.Create(
           TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
           TimeRec.Millisecond, TimeRec.Microsecond, TimeRec.Nanosecond);
+    end
+    else if AArg is TGocciaObjectValue then
+    begin
+      Obj := TGocciaObjectValue(AArg);
+      H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
+      V := Obj.GetProperty(PROP_HOUR);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_MINUTE);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_SECOND);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_MILLISECOND);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_MICROSECOND);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_NANOSECOND);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := Trunc(V.ToNumberLiteral.Value);
+      Result := TGocciaTemporalPlainTimeValue.Create(H, Mi, S, Ms, Us, Ns);
     end
     else
     begin
@@ -730,11 +814,16 @@ var
 begin
   ConstructorMethod := TGocciaNativeFunctionValue.Create(PlainDateTimeConstructorFn, 'PlainDateTime', 3);
   TGocciaTemporalPlainDateTimeValue.ExposePrototype(ConstructorMethod);
-  ConstructorMethod.AssignProperty('from',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainDateTimeFrom, 'from', 1));
-  ConstructorMethod.AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainDateTimeCompare, 'compare', 2));
-  FTemporalNamespace.AssignProperty('PlainDateTime', ConstructorMethod);
+  ConstructorMethod.DefineProperty('from',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainDateTimeFrom, 'from', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('compare',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainDateTimeCompare, 'compare', 2),
+      [pfConfigurable, pfWritable]));
+  FTemporalNamespace.DefineProperty('PlainDateTime',
+    TGocciaPropertyDescriptorData.Create(ConstructorMethod, [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaTemporalBuiltin.PlainDateTimeConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -785,7 +874,7 @@ begin
   end
   else if Arg is TGocciaStringLiteralValue then
   begin
-    if not TryParseISODateTime(TGocciaStringLiteralValue(Arg).Value, DateRec, TimeRec) then
+    if not CoerceToISODateTime(TGocciaStringLiteralValue(Arg).Value, DateRec, TimeRec) then
       ThrowRangeError(SErrorInvalidISODateTime, SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainDateTimeValue.Create(
       DateRec.Year, DateRec.Month, DateRec.Day,
@@ -823,12 +912,15 @@ var
   var
     DateRec: TTemporalDateRecord;
     TimeRec: TTemporalTimeRecord;
+    Obj: TGocciaObjectValue;
+    V: TGocciaValue;
+    Y, Mo, D, H, Mi, S, Ms, Us, Ns: Integer;
   begin
     if AArg is TGocciaTemporalPlainDateTimeValue then
       Result := TGocciaTemporalPlainDateTimeValue(AArg)
     else if AArg is TGocciaStringLiteralValue then
     begin
-      if not TryParseISODateTime(TGocciaStringLiteralValue(AArg).Value, DateRec, TimeRec) then
+      if not CoerceToISODateTime(TGocciaStringLiteralValue(AArg).Value, DateRec, TimeRec) then
       begin
         ThrowRangeError(SErrorInvalidISODateTime, SSuggestTemporalISOFormat);
         Result := nil;
@@ -838,6 +930,42 @@ var
           DateRec.Year, DateRec.Month, DateRec.Day,
           TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
           TimeRec.Millisecond, TimeRec.Microsecond, TimeRec.Nanosecond);
+    end
+    else if AArg is TGocciaObjectValue then
+    begin
+      Obj := TGocciaObjectValue(AArg);
+      V := Obj.GetProperty(PROP_YEAR);
+      if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+      begin
+        ThrowTypeError(SErrorTemporalPlainDateTimeCompareArg, SSuggestTemporalCompareArg);
+        Result := nil;
+        Exit;
+      end;
+      Y := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_MONTH);
+      if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+      begin
+        ThrowTypeError(SErrorTemporalPlainDateTimeCompareArg, SSuggestTemporalCompareArg);
+        Result := nil;
+        Exit;
+      end;
+      Mo := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_DAY);
+      if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+      begin
+        ThrowTypeError(SErrorTemporalPlainDateTimeCompareArg, SSuggestTemporalCompareArg);
+        Result := nil;
+        Exit;
+      end;
+      D := Trunc(V.ToNumberLiteral.Value);
+      H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
+      V := Obj.GetProperty(PROP_HOUR); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_MINUTE); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_SECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_MILLISECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_MICROSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_NANOSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := Trunc(V.ToNumberLiteral.Value);
+      Result := TGocciaTemporalPlainDateTimeValue.Create(Y, Mo, D, H, Mi, S, Ms, Us, Ns);
     end
     else
     begin
@@ -866,11 +994,16 @@ var
 begin
   ConstructorMethod := TGocciaNativeFunctionValue.Create(PlainYearMonthConstructorFn, 'PlainYearMonth', 2);
   TGocciaTemporalPlainYearMonthValue.ExposePrototype(ConstructorMethod);
-  ConstructorMethod.AssignProperty('from',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainYearMonthFrom, 'from', 1));
-  ConstructorMethod.AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainYearMonthCompare, 'compare', 2));
-  FTemporalNamespace.AssignProperty('PlainYearMonth', ConstructorMethod);
+  ConstructorMethod.DefineProperty('from',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainYearMonthFrom, 'from', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('compare',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainYearMonthCompare, 'compare', 2),
+      [pfConfigurable, pfWritable]));
+  FTemporalNamespace.DefineProperty('PlainYearMonth',
+    TGocciaPropertyDescriptorData.Create(ConstructorMethod, [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaTemporalBuiltin.PlainYearMonthConstructorFn(const AArgs: TGocciaArgumentsCollection;
@@ -909,7 +1042,7 @@ begin
   end
   else if Arg is TGocciaStringLiteralValue then
   begin
-    if not TryParseISOYearMonth(TGocciaStringLiteralValue(Arg).Value, Y, M) then
+    if not CoerceToISOYearMonth(TGocciaStringLiteralValue(Arg).Value, Y, M) then
       ThrowRangeError(SErrorInvalidISOYearMonth, SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainYearMonthValue.Create(Y, M);
   end
@@ -968,7 +1101,7 @@ var
       Result := TGocciaTemporalPlainYearMonthValue(AArg)
     else if AArg is TGocciaStringLiteralValue then
     begin
-      if not TryParseISOYearMonth(TGocciaStringLiteralValue(AArg).Value, Y, M) then
+      if not CoerceToISOYearMonth(TGocciaStringLiteralValue(AArg).Value, Y, M) then
       begin
         ThrowRangeError(SErrorInvalidISOYearMonth, SSuggestTemporalISOFormat);
         Result := nil;
@@ -1007,11 +1140,16 @@ var
 begin
   ConstructorMethod := TGocciaNativeFunctionValue.Create(PlainMonthDayConstructorFn, 'PlainMonthDay', 2);
   TGocciaTemporalPlainMonthDayValue.ExposePrototype(ConstructorMethod);
-  ConstructorMethod.AssignProperty('from',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainMonthDayFrom, 'from', 1));
-  ConstructorMethod.AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainMonthDayCompare, 'compare', 2));
-  FTemporalNamespace.AssignProperty('PlainMonthDay', ConstructorMethod);
+  ConstructorMethod.DefineProperty('from',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainMonthDayFrom, 'from', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('compare',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(PlainMonthDayCompare, 'compare', 2),
+      [pfConfigurable, pfWritable]));
+  FTemporalNamespace.DefineProperty('PlainMonthDay',
+    TGocciaPropertyDescriptorData.Create(ConstructorMethod, [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaTemporalBuiltin.PlainMonthDayConstructorFn(const AArgs: TGocciaArgumentsCollection;
@@ -1043,7 +1181,7 @@ begin
   end
   else if Arg is TGocciaStringLiteralValue then
   begin
-    if not TryParseISOMonthDay(TGocciaStringLiteralValue(Arg).Value, M, D) then
+    if not CoerceToISOMonthDay(TGocciaStringLiteralValue(Arg).Value, M, D) then
       ThrowRangeError(SErrorInvalidISOMonthDay, SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainMonthDayValue.Create(M, D);
   end
@@ -1098,7 +1236,7 @@ var
       Result := TGocciaTemporalPlainMonthDayValue(AArg)
     else if AArg is TGocciaStringLiteralValue then
     begin
-      if not TryParseISOMonthDay(TGocciaStringLiteralValue(AArg).Value, M, D) then
+      if not CoerceToISOMonthDay(TGocciaStringLiteralValue(AArg).Value, M, D) then
       begin
         ThrowRangeError(SErrorInvalidISOMonthDay, SSuggestTemporalISOFormat);
         Result := nil;
@@ -1137,11 +1275,16 @@ var
 begin
   ConstructorMethod := TGocciaNativeFunctionValue.Create(ZonedDateTimeConstructorFn, 'ZonedDateTime', 2);
   TGocciaTemporalZonedDateTimeValue.ExposePrototype(ConstructorMethod);
-  ConstructorMethod.AssignProperty('from',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(ZonedDateTimeFrom, 'from', 1));
-  ConstructorMethod.AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(ZonedDateTimeCompare, 'compare', 2));
-  FTemporalNamespace.AssignProperty('ZonedDateTime', ConstructorMethod);
+  ConstructorMethod.DefineProperty('from',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(ZonedDateTimeFrom, 'from', 1),
+      [pfConfigurable, pfWritable]));
+  ConstructorMethod.DefineProperty('compare',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(ZonedDateTimeCompare, 'compare', 2),
+      [pfConfigurable, pfWritable]));
+  FTemporalNamespace.DefineProperty('ZonedDateTime',
+    TGocciaPropertyDescriptorData.Create(ConstructorMethod, [pfConfigurable, pfWritable]));
 end;
 
 // TC39 Temporal §6.1.1 new Temporal.ZonedDateTime(epochNanoseconds, timeZone)
@@ -1286,7 +1429,8 @@ begin
   NowObj.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NowPlainDateTimeISO, 'plainDateTimeISO', 0));
   NowObj.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NowTimeZoneId, 'timeZoneId', 0));
   NowObj.RegisterNativeMethod(TGocciaNativeFunctionValue.Create(NowZonedDateTimeISO, 'zonedDateTimeISO', 0));
-  FTemporalNamespace.AssignProperty('Now', NowObj);
+  FTemporalNamespace.DefineProperty('Now',
+    TGocciaPropertyDescriptorData.Create(NowObj, [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaTemporalBuiltin.NowInstant(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -19,7 +19,8 @@ type
     rmHalfCeil,
     rmHalfFloor,
     rmHalfTrunc,
-    rmHalfEven
+    rmHalfEven,
+    rmExpand
   );
 
   TTemporalOverflow = (toConstrain, toReject);
@@ -65,6 +66,22 @@ function RoundBigIntWithMode(const AValue: TBigInteger; const ADivisor: TBigInte
 function FormatTimeWithPrecision(const AHour, AMinute, ASecond, AMillisecond,
   AMicrosecond, ANanosecond: Integer; const AFractionalDigits: Integer): string;
 
+type
+  TTemporalCalendarDisplay = (tcdAuto, tcdAlways, tcdNever, tcdCritical);
+
+{ Shared toString options — call from any Temporal toString method }
+procedure ResolveTemporalToStringOptions(
+  const AOptions: TGocciaObjectValue;
+  out AFractionalDigits: Integer;
+  out ARoundingMode: TTemporalRoundingMode);
+function GetCalendarDisplay(const AOptions: TGocciaObjectValue): TTemporalCalendarDisplay;
+procedure RoundTimeForToString(
+  var AHour, AMinute, ASecond, AMs, AUs, ANs: Integer;
+  var AExtraDays: Integer;
+  const AFractionalDigits: Integer;
+  const ARoundingMode: TTemporalRoundingMode);
+function FormatCalendarAnnotation(const ACalendarDisplay: TTemporalCalendarDisplay): string;
+
 implementation
 
 uses
@@ -103,6 +120,7 @@ begin
   else if AStr = 'halfFloor' then AMode := rmHalfFloor
   else if AStr = 'halfTrunc' then AMode := rmHalfTrunc
   else if AStr = 'halfEven' then AMode := rmHalfEven
+  else if AStr = 'expand' then AMode := rmExpand
   else Result := False;
 end;
 
@@ -366,6 +384,14 @@ begin
       else
         Result := Quotient * ADivisor;
     end;
+    rmExpand:
+    begin
+      // Always round away from zero
+      if AValue > 0 then
+        Result := (Quotient + 1) * ADivisor
+      else
+        Result := (Quotient - 1) * ADivisor;
+    end;
   else
     Result := Quotient * ADivisor;
   end;
@@ -487,6 +513,14 @@ begin
       else
         Result := Quotient.Multiply(ADivisor);
     end;
+    rmExpand:
+    begin
+      // Always round away from zero
+      if AValue.IsPositive then
+        Result := Quotient.Add(TBigInteger.One).Multiply(ADivisor)
+      else
+        Result := Quotient.Subtract(TBigInteger.One).Multiply(ADivisor);
+    end;
   else
     Result := Quotient.Multiply(ADivisor);
   end;
@@ -515,6 +549,132 @@ begin
   begin
     Frac := Format('%.3d%.3d%.3d', [AMillisecond, AMicrosecond, ANanosecond]);
     Result := Result + '.' + Copy(Frac, 1, AFractionalDigits);
+  end;
+end;
+
+{ --------------------------------------------------------------------------- }
+{ Shared toString options                                                      }
+{ --------------------------------------------------------------------------- }
+
+procedure ResolveTemporalToStringOptions(
+  const AOptions: TGocciaObjectValue;
+  out AFractionalDigits: Integer;
+  out ARoundingMode: TTemporalRoundingMode);
+var
+  SmallestUnit: TTemporalUnit;
+  SmallestStr: string;
+begin
+  AFractionalDigits := -1; // auto
+  ARoundingMode := rmTrunc;
+
+  if AOptions = nil then Exit;
+
+  // Check smallestUnit first — overrides fractionalSecondDigits
+  SmallestStr := GetOptionString(AOptions, 'smallestUnit', '');
+  if SmallestStr <> '' then
+  begin
+    if not GetTemporalUnitFromString(SmallestStr, SmallestUnit) then
+      ThrowRangeError(Format(SErrorInvalidSmallestUnit, [SmallestStr]), SSuggestTemporalValidUnits);
+
+    // smallestUnit and fractionalSecondDigits are mutually exclusive
+    case SmallestUnit of
+      tuMinute:       AFractionalDigits := -2; // special: truncate seconds entirely
+      tuSecond:       AFractionalDigits := 0;
+      tuMillisecond:  AFractionalDigits := 3;
+      tuMicrosecond:  AFractionalDigits := 6;
+      tuNanosecond:   AFractionalDigits := 9;
+    else
+      ThrowRangeError(Format(SErrorInvalidSmallestUnit, [SmallestStr]), SSuggestTemporalValidUnits);
+    end;
+  end
+  else
+    AFractionalDigits := GetFractionalSecondDigits(AOptions);
+
+  ARoundingMode := GetRoundingMode(AOptions, rmTrunc);
+end;
+
+function GetCalendarDisplay(const AOptions: TGocciaObjectValue): TTemporalCalendarDisplay;
+var
+  S: string;
+begin
+  Result := tcdAuto;
+  if AOptions = nil then Exit;
+  S := GetOptionString(AOptions, 'calendarName', 'auto');
+  if S = 'auto' then
+    Result := tcdAuto
+  else if S = 'always' then
+    Result := tcdAlways
+  else if S = 'never' then
+    Result := tcdNever
+  else if S = 'critical' then
+    Result := tcdCritical
+  else
+    ThrowRangeError('Invalid calendarName option: ' + S, SSuggestTemporalRoundArg);
+end;
+
+procedure RoundTimeForToString(
+  var AHour, AMinute, ASecond, AMs, AUs, ANs: Integer;
+  var AExtraDays: Integer;
+  const AFractionalDigits: Integer;
+  const ARoundingMode: TTemporalRoundingMode);
+var
+  TotalNs, Divisor, Rounded: Int64;
+  ExDays: Int64;
+  BalancedTime: TTemporalTimeRecord;
+begin
+  AExtraDays := 0;
+
+  // No rounding needed for auto or nanosecond precision
+  if (AFractionalDigits < 0) and (AFractionalDigits <> -2) then Exit;
+  if AFractionalDigits = 9 then Exit;
+
+  // Convert time to total nanoseconds
+  TotalNs := Int64(AHour) * NANOSECONDS_PER_HOUR +
+             Int64(AMinute) * NANOSECONDS_PER_MINUTE +
+             Int64(ASecond) * NANOSECONDS_PER_SECOND +
+             Int64(AMs) * NANOSECONDS_PER_MILLISECOND +
+             Int64(AUs) * NANOSECONDS_PER_MICROSECOND +
+             Int64(ANs);
+
+  // Determine divisor based on precision
+  if AFractionalDigits = -2 then
+    Divisor := NANOSECONDS_PER_MINUTE  // smallestUnit: 'minute'
+  else if AFractionalDigits = 0 then
+    Divisor := NANOSECONDS_PER_SECOND
+  else if AFractionalDigits <= 3 then
+    Divisor := NANOSECONDS_PER_MILLISECOND
+  else if AFractionalDigits <= 6 then
+    Divisor := NANOSECONDS_PER_MICROSECOND
+  else
+    Divisor := 1;
+
+  Rounded := RoundWithMode(TotalNs, Divisor, ARoundingMode);
+
+  // Balance back into time fields
+  BalancedTime := BalanceTime(Rounded div NANOSECONDS_PER_HOUR,
+    (Rounded mod NANOSECONDS_PER_HOUR) div NANOSECONDS_PER_MINUTE,
+    (Rounded mod NANOSECONDS_PER_MINUTE) div NANOSECONDS_PER_SECOND,
+    Integer((Rounded mod NANOSECONDS_PER_SECOND) div NANOSECONDS_PER_MILLISECOND),
+    Integer((Rounded mod NANOSECONDS_PER_MILLISECOND) div NANOSECONDS_PER_MICROSECOND),
+    Integer(Rounded mod NANOSECONDS_PER_MICROSECOND),
+    ExDays);
+
+  AHour := BalancedTime.Hour;
+  AMinute := BalancedTime.Minute;
+  ASecond := BalancedTime.Second;
+  AMs := BalancedTime.Millisecond;
+  AUs := BalancedTime.Microsecond;
+  ANs := BalancedTime.Nanosecond;
+  AExtraDays := Integer(ExDays);
+end;
+
+function FormatCalendarAnnotation(const ACalendarDisplay: TTemporalCalendarDisplay): string;
+begin
+  case ACalendarDisplay of
+    tcdAlways:   Result := '[u-ca=iso8601]';
+    tcdCritical: Result := '[!u-ca=iso8601]';
+  else
+    Result := ''; // auto and never: omit for iso8601
   end;
 end;
 

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -576,7 +576,7 @@ begin
     if not GetTemporalUnitFromString(SmallestStr, SmallestUnit) then
       ThrowRangeError(Format(SErrorInvalidSmallestUnit, [SmallestStr]), SSuggestTemporalValidUnits);
 
-    // smallestUnit and fractionalSecondDigits are mutually exclusive
+    // smallestUnit takes precedence over fractionalSecondDigits
     case SmallestUnit of
       tuMinute:       AFractionalDigits := -2; // special: truncate seconds entirely
       tuSecond:       AFractionalDigits := 0;

--- a/source/units/Goccia.Temporal.TimeZone.pas
+++ b/source/units/Goccia.Temporal.TimeZone.pas
@@ -396,9 +396,17 @@ end;
 {$ENDIF}
 
 function IsValidTimeZone(const ATimeZone: string): Boolean;
+var
+  Dummy: Integer;
 {$IFDEF UNIX}
 begin
   if ATimeZone = UTC_TIMEZONE_ID then
+  begin
+    Result := True;
+    Exit;
+  end;
+  // Accept offset strings like +05:30 as valid timezone IDs
+  if ParseOffsetString(ATimeZone, Dummy) then
   begin
     Result := True;
     Exit;
@@ -412,7 +420,7 @@ begin
 end;
 {$ELSE}
 begin
-  Result := ATimeZone = UTC_TIMEZONE_ID;
+  Result := (ATimeZone = UTC_TIMEZONE_ID) or ParseOffsetString(ATimeZone, Dummy);
 end;
 {$ENDIF}
 
@@ -420,10 +428,18 @@ function GetUtcOffsetSeconds(const ATimeZone: string; const AEpochSeconds: Int64
 var
   Data: TTimeZoneData;
   Index: Integer;
+  OffsetSecs: Integer;
 begin
   if ATimeZone = UTC_TIMEZONE_ID then
   begin
     Result := 0;
+    Exit;
+  end;
+
+  // Handle offset-based timezone IDs (e.g. +05:30, -08:00)
+  if ParseOffsetString(ATimeZone, OffsetSecs) then
+  begin
+    Result := OffsetSecs;
     Exit;
   end;
 

--- a/source/units/Goccia.Temporal.Utils.pas
+++ b/source/units/Goccia.Temporal.Utils.pas
@@ -451,6 +451,10 @@ begin
       if IsCritical then
         AnnotContent := Copy(AnnotContent, 2, Length(AnnotContent) - 1);
 
+      // Reject empty annotations
+      if Length(AnnotContent) = 0 then
+        Exit;
+
       // Check for key=value format
       KeyEnd := System.Pos('=', AnnotContent);
       if KeyEnd > 0 then
@@ -949,6 +953,9 @@ begin
       // Strip critical flag prefix '!'
       if (Length(AnnotContent) > 0) and (AnnotContent[1] = '!') then
         AnnotContent := Copy(AnnotContent, 2, Length(AnnotContent) - 1);
+      // Reject empty annotations
+      if Length(AnnotContent) = 0 then
+        Exit;
       // Calendar annotations start with 'u-ca='
       if (Length(AnnotContent) > 5) and (Copy(AnnotContent, 1, 5) = 'u-ca=') then
         // Calendar annotation - ignore (we only support iso8601)

--- a/source/units/Goccia.Temporal.Utils.pas
+++ b/source/units/Goccia.Temporal.Utils.pas
@@ -953,7 +953,9 @@ begin
       if (Length(AnnotContent) > 5) and (Copy(AnnotContent, 1, 5) = 'u-ca=') then
         // Calendar annotation - ignore (we only support iso8601)
       else if ATimeZone = '' then
-        ATimeZone := AnnotContent;
+        ATimeZone := AnnotContent
+      else
+        Exit; // Multiple timezone annotations - reject
       Rest := Copy(Rest, 1, BracketStart - 1);
     end
     else
@@ -1110,19 +1112,8 @@ begin
     Result := False;
     Exit;
   end;
-  if TryParseISODateTimeWithOffset(AStr, ADate, ATime, AOffsetSeconds, TimeZone) then
-  begin
-    Result := True;
-    Exit;
-  end;
-  // Fall back to basic datetime parsing (assume UTC)
-  if TryParseISODateTime(AStr, ADate, ATime) then
-  begin
-    AOffsetSeconds := 0;
-    Result := True;
-    Exit;
-  end;
-  Result := False;
+  // Instant requires an explicit UTC offset (Z or ±HH:MM) — no fallback
+  Result := TryParseISODateTimeWithOffset(AStr, ADate, ATime, AOffsetSeconds, TimeZone);
 end;
 
 function CoerceToISOYearMonth(const AStr: string; out AYear, AMonth: Integer): Boolean;

--- a/source/units/Goccia.Temporal.Utils.pas
+++ b/source/units/Goccia.Temporal.Utils.pas
@@ -69,6 +69,18 @@ function TryParseISODateTimeWithOffset(const AStr: string; out ADate: TTemporalD
 function FormatYearMonthString(const AYear, AMonth: Integer): string;
 function FormatMonthDayString(const AMonth, ADay: Integer): string;
 
+function StripAnnotations(const AStr: string): string;
+function StripOffsetAndAnnotations(const AStr: string): string;
+
+{ Unified Temporal string coercion — use these from CoerceXxx functions }
+function CoerceToISODate(const AStr: string; out ADate: TTemporalDateRecord): Boolean;
+function CoerceToISOTime(const AStr: string; out ATime: TTemporalTimeRecord): Boolean;
+function CoerceToISODateTime(const AStr: string; out ADate: TTemporalDateRecord; out ATime: TTemporalTimeRecord): Boolean;
+function CoerceToISOInstant(const AStr: string; out ADate: TTemporalDateRecord;
+  out ATime: TTemporalTimeRecord; out AOffsetSeconds: Integer): Boolean;
+function CoerceToISOYearMonth(const AStr: string; out AYear, AMonth: Integer): Boolean;
+function CoerceToISOMonthDay(const AStr: string; out AMonth, ADay: Integer): Boolean;
+
 function CompareIntegers(const A, B: Integer): Integer; inline;
 function CompareDates(const AYear1, AMonth1, ADay1, AYear2, AMonth2, ADay2: Integer): Integer;
 function CompareTimes(const AHour1, AMinute1, ASecond1, AMs1, AUs1, ANs1,
@@ -385,34 +397,148 @@ begin
   Result := ADigitCount > 0;
 end;
 
+function IsValidAnnotationKey(const AKey: string): Boolean;
+var
+  I: Integer;
+  C: Char;
+  InSegment: Boolean;
+begin
+  Result := False;
+  if Length(AKey) = 0 then Exit;
+  // First char must be lowercase letter
+  if (AKey[1] < 'a') or (AKey[1] > 'z') then Exit;
+  InSegment := True;
+  for I := 2 to Length(AKey) do
+  begin
+    C := AKey[I];
+    if C = '-' then
+    begin
+      if not InSegment then Exit; // double dash
+      InSegment := False;
+    end
+    else if ((C >= 'a') and (C <= 'z')) or ((C >= '0') and (C <= '9')) then
+      InSegment := True
+    else
+      Exit; // invalid char
+  end;
+  if not InSegment then Exit; // trailing dash
+  Result := True;
+end;
+
+function StripAnnotations(const AStr: string): string;
+var
+  I: Integer;
+  AnnotContent: string;
+  IsCritical: Boolean;
+  KeyEnd: Integer;
+  Key: string;
+  CalendarSeen, TimeZoneSeen: Boolean;
+begin
+  Result := AStr;
+  CalendarSeen := False;
+  TimeZoneSeen := False;
+
+  // Remove all trailing [...] annotations, validating them
+  while (Length(Result) > 0) and (Result[Length(Result)] = ']') do
+  begin
+    I := Length(Result) - 1;
+    while (I > 0) and (Result[I] <> '[') do
+      Dec(I);
+    if I > 0 then
+    begin
+      AnnotContent := Copy(Result, I + 1, Length(Result) - I - 1);
+      IsCritical := (Length(AnnotContent) > 0) and (AnnotContent[1] = '!');
+      if IsCritical then
+        AnnotContent := Copy(AnnotContent, 2, Length(AnnotContent) - 1);
+
+      // Check for key=value format
+      KeyEnd := System.Pos('=', AnnotContent);
+      if KeyEnd > 0 then
+      begin
+        Key := Copy(AnnotContent, 1, KeyEnd - 1);
+        // Validate key format (must be lowercase alphanumeric with dashes)
+        if not IsValidAnnotationKey(Key) then
+          Exit; // Invalid key - return unchanged so parser rejects
+
+        if Key = 'u-ca' then
+        begin
+          // Calendar annotation
+          if CalendarSeen then
+            Exit; // Multiple calendar annotations - reject
+          CalendarSeen := True;
+        end
+        else if IsCritical then
+          Exit; // Unknown critical annotation - reject
+        // Non-critical unknown key=value - strip silently
+      end
+      else
+      begin
+        // No key=value format: this is a timezone annotation
+        if TimeZoneSeen then
+          Exit; // Multiple timezone annotations - reject
+        TimeZoneSeen := True;
+      end;
+
+      Result := Copy(Result, 1, I - 1);
+    end
+    else
+      Break;
+  end;
+end;
+
+function StripOffsetAndAnnotations(const AStr: string): string;
+var
+  I: Integer;
+begin
+  Result := StripAnnotations(AStr);
+  // Remove trailing UTC offset (+HH:MM, -HH:MM, +HHMM, -HHMM, +HH, -HH, Z)
+  if (Length(Result) > 0) and ((Result[Length(Result)] = 'Z') or (Result[Length(Result)] = 'z')) then
+  begin
+    Result := Copy(Result, 1, Length(Result) - 1);
+    Exit;
+  end;
+  // Look for +/- offset at end
+  I := Length(Result);
+  while (I > 0) and (Result[I] >= '0') and (Result[I] <= '9') do
+    Dec(I);
+  if (I > 0) and (Result[I] = ':') then
+    Dec(I);
+  while (I > 0) and (Result[I] >= '0') and (Result[I] <= '9') do
+    Dec(I);
+  if (I > 0) and ((Result[I] = '+') or (Result[I] = '-')) then
+    Result := Copy(Result, 1, I - 1);
+end;
+
 function TryParseISODate(const AStr: string; out ADate: TTemporalDateRecord): Boolean;
 var
   Pos, Sign: Integer;
   Year, Month, Day: Integer;
   C: Char;
+  S: string;
 begin
   Result := False;
+  S := StripAnnotations(AStr);
   Pos := 1;
   Sign := 1;
 
   // Check for sign prefix
-  if Pos <= Length(AStr) then
+  if Pos <= Length(S) then
   begin
-    C := AStr[Pos];
+    C := S[Pos];
     if C = '+' then
     begin
       Inc(Pos);
-      if not TryParseDigits(AStr, Pos, 6, Year) then Exit;
+      if not TryParseDigits(S, Pos, 6, Year) then Exit;
     end
     else if C = '-' then
     begin
       Inc(Pos);
       Sign := -1;
-      if not TryParseDigits(AStr, Pos, 6, Year) then Exit;
+      if not TryParseDigits(S, Pos, 6, Year) then Exit;
     end
     else
     begin
-      if not TryParseDigits(AStr, Pos, 4, Year) then Exit;
+      if not TryParseDigits(S, Pos, 4, Year) then Exit;
     end;
   end
   else
@@ -421,19 +547,19 @@ begin
   Year := Year * Sign;
 
   // Expect '-'
-  if (Pos > Length(AStr)) or (AStr[Pos] <> '-') then Exit;
+  if (Pos > Length(S)) or (S[Pos] <> '-') then Exit;
   Inc(Pos);
 
-  if not TryParseDigits(AStr, Pos, 2, Month) then Exit;
+  if not TryParseDigits(S, Pos, 2, Month) then Exit;
 
   // Expect '-'
-  if (Pos > Length(AStr)) or (AStr[Pos] <> '-') then Exit;
+  if (Pos > Length(S)) or (S[Pos] <> '-') then Exit;
   Inc(Pos);
 
-  if not TryParseDigits(AStr, Pos, 2, Day) then Exit;
+  if not TryParseDigits(S, Pos, 2, Day) then Exit;
 
   // Must be at end of string (for pure date parsing)
-  if Pos <= Length(AStr) then Exit;
+  if Pos <= Length(S) then Exit;
 
   if not IsValidDate(Year, Month, Day) then Exit;
 
@@ -495,6 +621,10 @@ begin
     end;
   end;
 
+  // Clamp leap second (60) to 59
+  if Second = 60 then
+    Second := 59;
+
   if not IsValidTime(Hour, Minute, Second, ATime.Millisecond, ATime.Microsecond, ATime.Nanosecond) then Exit;
 
   ATime.Hour := Hour;
@@ -506,7 +636,7 @@ end;
 function TryParseISODateTime(const AStr: string; out ADate: TTemporalDateRecord; out ATime: TTemporalTimeRecord): Boolean;
 var
   TPos: Integer;
-  DatePart, TimePart: string;
+  DatePart, TimePart, S: string;
 begin
   Result := False;
   ATime.Hour := 0;
@@ -516,23 +646,24 @@ begin
   ATime.Microsecond := 0;
   ATime.Nanosecond := 0;
 
-  TPos := System.Pos('T', AStr);
+  S := AStr;
+
+  TPos := System.Pos('T', S);
   if TPos = 0 then
-    TPos := System.Pos('t', AStr);
+    TPos := System.Pos('t', S);
 
   if TPos = 0 then
   begin
-    // Try as date only
-    Result := TryParseISODate(AStr, ADate);
+    // Try as date only (StripAnnotations handled inside TryParseISODate)
+    Result := TryParseISODate(S, ADate);
     Exit;
   end;
 
-  DatePart := Copy(AStr, 1, TPos - 1);
-  TimePart := Copy(AStr, TPos + 1, Length(AStr) - TPos);
+  DatePart := Copy(S, 1, TPos - 1);
+  TimePart := Copy(S, TPos + 1, Length(S) - TPos);
 
-  // Strip trailing timezone info (Z or +/-HH:MM) from time part
-  if (Length(TimePart) > 0) and (TimePart[Length(TimePart)] = 'Z') then
-    TimePart := Copy(TimePart, 1, Length(TimePart) - 1);
+  // Strip offset and annotations from time part before parsing
+  TimePart := StripOffsetAndAnnotations(TimePart);
 
   if not TryParseISODate(DatePart, ADate) then Exit;
   if Length(TimePart) > 0 then
@@ -703,40 +834,42 @@ function TryParseISOYearMonth(const AStr: string; out AYear, AMonth: Integer): B
 var
   Pos, Sign: Integer;
   C: Char;
+  S: string;
 begin
   Result := False;
   AYear := 0;
   AMonth := 0;
+  S := StripAnnotations(AStr);
   Pos := 1;
   Sign := 1;
 
-  if Pos > Length(AStr) then Exit;
+  if Pos > Length(S) then Exit;
 
-  C := AStr[Pos];
+  C := S[Pos];
   if C = '+' then
   begin
     Inc(Pos);
-    if not TryParseDigits(AStr, Pos, 6, AYear) then Exit;
+    if not TryParseDigits(S, Pos, 6, AYear) then Exit;
   end
   else if C = '-' then
   begin
     Inc(Pos);
     Sign := -1;
-    if not TryParseDigits(AStr, Pos, 6, AYear) then Exit;
+    if not TryParseDigits(S, Pos, 6, AYear) then Exit;
   end
   else
   begin
-    if not TryParseDigits(AStr, Pos, 4, AYear) then Exit;
+    if not TryParseDigits(S, Pos, 4, AYear) then Exit;
   end;
 
   AYear := AYear * Sign;
 
-  if (Pos > Length(AStr)) or (AStr[Pos] <> '-') then Exit;
+  if (Pos > Length(S)) or (S[Pos] <> '-') then Exit;
   Inc(Pos);
 
-  if not TryParseDigits(AStr, Pos, 2, AMonth) then Exit;
+  if not TryParseDigits(S, Pos, 2, AMonth) then Exit;
 
-  if Pos <= Length(AStr) then Exit;
+  if Pos <= Length(S) then Exit;
 
   if (AMonth < 1) or (AMonth > 12) then Exit;
 
@@ -746,20 +879,26 @@ end;
 function TryParseISOMonthDay(const AStr: string; out AMonth, ADay: Integer): Boolean;
 var
   Pos: Integer;
+  S: string;
 begin
   Result := False;
   AMonth := 0;
   ADay := 0;
+  S := StripAnnotations(AStr);
   Pos := 1;
 
-  if not TryParseDigits(AStr, Pos, 2, AMonth) then Exit;
+  // Skip optional leading '--' (ISO 8601 month-day format)
+  if (Length(S) >= 2) and (S[1] = '-') and (S[2] = '-') then
+    Pos := 3;
 
-  if (Pos > Length(AStr)) or (AStr[Pos] <> '-') then Exit;
+  if not TryParseDigits(S, Pos, 2, AMonth) then Exit;
+
+  if (Pos > Length(S)) or (S[Pos] <> '-') then Exit;
   Inc(Pos);
 
-  if not TryParseDigits(AStr, Pos, 2, ADay) then Exit;
+  if not TryParseDigits(S, Pos, 2, ADay) then Exit;
 
-  if Pos <= Length(AStr) then Exit;
+  if Pos <= Length(S) then Exit;
 
   if (AMonth < 1) or (AMonth > 12) then Exit;
   // Validate day against month in a leap year (1972) to allow Feb 29
@@ -772,10 +911,8 @@ function TryParseISODateTimeWithOffset(const AStr: string; out ADate: TTemporalD
   out ATime: TTemporalTimeRecord; out AOffsetSeconds: Integer; out ATimeZone: string): Boolean;
 var
   TPos, BracketStart, BracketEnd, I: Integer;
-  DatePart, Rest, TimePart, OffsetPart: string;
+  DatePart, Rest, TimePart, OffsetPart, AnnotContent: string;
   OffsetSign, OffsetH, OffsetM: Integer;
-  FracVal: Int64;
-  FracDigits: Integer;
   ParsePos: Integer;
 begin
   Result := False;
@@ -798,22 +935,34 @@ begin
 
   if not TryParseISODate(DatePart, ADate) then Exit;
 
-  // Extract timezone annotation [timezone] from end
-  BracketStart := System.Pos('[', Rest);
-  if BracketStart > 0 then
+  // Extract all [...] annotations from end, in reverse order
+  // The first non-calendar annotation is the timezone; calendar annotations start with u-ca=
+  while (Length(Rest) > 0) and (Rest[Length(Rest)] = ']') do
   begin
-    BracketEnd := System.Pos(']', Rest);
-    if BracketEnd > BracketStart then
+    BracketEnd := Length(Rest);
+    BracketStart := BracketEnd - 1;
+    while (BracketStart > 0) and (Rest[BracketStart] <> '[') do
+      Dec(BracketStart);
+    if BracketStart > 0 then
     begin
-      ATimeZone := Copy(Rest, BracketStart + 1, BracketEnd - BracketStart - 1);
+      AnnotContent := Copy(Rest, BracketStart + 1, BracketEnd - BracketStart - 1);
+      // Strip critical flag prefix '!'
+      if (Length(AnnotContent) > 0) and (AnnotContent[1] = '!') then
+        AnnotContent := Copy(AnnotContent, 2, Length(AnnotContent) - 1);
+      // Calendar annotations start with 'u-ca='
+      if (Length(AnnotContent) > 5) and (Copy(AnnotContent, 1, 5) = 'u-ca=') then
+        // Calendar annotation - ignore (we only support iso8601)
+      else if ATimeZone = '' then
+        ATimeZone := AnnotContent;
       Rest := Copy(Rest, 1, BracketStart - 1);
-    end;
+    end
+    else
+      Break;
   end;
 
   // Find offset: look for Z, +, or - after time digits
-  // Time is at least HH:MM (5 chars)
   OffsetPart := '';
-  if (Length(Rest) > 0) and (Rest[Length(Rest)] = 'Z') then
+  if (Length(Rest) > 0) and ((Rest[Length(Rest)] = 'Z') or (Rest[Length(Rest)] = 'z')) then
   begin
     AOffsetSeconds := 0;
     Rest := Copy(Rest, 1, Length(Rest) - 1);
@@ -850,10 +999,12 @@ begin
       begin
         if not TryParseDigits(OffsetPart, ParsePos, 2, OffsetM) then Exit;
       end;
-      // Validate ranges and ensure no trailing characters
+      // Validate ranges
       if (OffsetH > 23) or (OffsetM > 59) then Exit;
-      if ParsePos <= Length(OffsetPart) then Exit;
       AOffsetSeconds := OffsetSign * (OffsetH * 3600 + OffsetM * 60);
+      // Set timezone to offset if no annotation timezone
+      if ATimeZone = '' then
+        ATimeZone := OffsetPart;
     end;
   end;
 
@@ -865,6 +1016,157 @@ begin
   end;
 
   Result := True;
+end;
+
+{ --------------------------------------------------------------------------- }
+{ Unified Temporal string coercion functions                                   }
+{ --------------------------------------------------------------------------- }
+
+function CoerceToISODate(const AStr: string; out ADate: TTemporalDateRecord): Boolean;
+var
+  TimeRec: TTemporalTimeRecord;
+  S: string;
+begin
+  // Validate annotations once up front — if invalid, reject immediately
+  S := StripAnnotations(AStr);
+  if (Length(AStr) > 0) and (AStr[Length(AStr)] = ']') and (S = AStr) then
+  begin
+    Result := False;
+    Exit;
+  end;
+  // Try date-only
+  if TryParseISODate(S, ADate) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  // Try full datetime
+  if TryParseISODateTime(AStr, ADate, TimeRec) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  Result := False;
+end;
+
+function CoerceToISOTime(const AStr: string; out ATime: TTemporalTimeRecord): Boolean;
+var
+  S: string;
+  TPos: Integer;
+begin
+  // Strip offset and annotations
+  S := StripOffsetAndAnnotations(AStr);
+  // Try time-only
+  if TryParseISOTime(S, ATime) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  // If string has T separator, extract and parse the time part only
+  // (but do NOT accept date-only strings — no implicit midnight)
+  TPos := System.Pos('T', S);
+  if TPos = 0 then
+    TPos := System.Pos('t', S);
+  if TPos > 0 then
+  begin
+    S := Copy(S, TPos + 1, Length(S) - TPos);
+    if (Length(S) > 0) and TryParseISOTime(S, ATime) then
+    begin
+      Result := True;
+      Exit;
+    end;
+  end;
+  Result := False;
+end;
+
+function CoerceToISODateTime(const AStr: string; out ADate: TTemporalDateRecord; out ATime: TTemporalTimeRecord): Boolean;
+var
+  S: string;
+begin
+  // Validate annotations up front
+  S := StripAnnotations(AStr);
+  if (Length(AStr) > 0) and (AStr[Length(AStr)] = ']') and (S = AStr) then
+  begin
+    Result := False;
+    Exit;
+  end;
+  if TryParseISODateTime(AStr, ADate, ATime) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  Result := False;
+end;
+
+function CoerceToISOInstant(const AStr: string; out ADate: TTemporalDateRecord;
+  out ATime: TTemporalTimeRecord; out AOffsetSeconds: Integer): Boolean;
+var
+  TimeZone, S: string;
+begin
+  // Validate annotations up front
+  S := StripAnnotations(AStr);
+  if (Length(AStr) > 0) and (AStr[Length(AStr)] = ']') and (S = AStr) then
+  begin
+    Result := False;
+    Exit;
+  end;
+  if TryParseISODateTimeWithOffset(AStr, ADate, ATime, AOffsetSeconds, TimeZone) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  // Fall back to basic datetime parsing (assume UTC)
+  if TryParseISODateTime(AStr, ADate, ATime) then
+  begin
+    AOffsetSeconds := 0;
+    Result := True;
+    Exit;
+  end;
+  Result := False;
+end;
+
+function CoerceToISOYearMonth(const AStr: string; out AYear, AMonth: Integer): Boolean;
+var
+  DateRec: TTemporalDateRecord;
+  TimeRec: TTemporalTimeRecord;
+begin
+  // Try short form YYYY-MM (with annotation stripping)
+  if TryParseISOYearMonth(AStr, AYear, AMonth) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  // Try full date or datetime, extract year+month
+  if TryParseISODate(AStr, DateRec) or TryParseISODateTime(AStr, DateRec, TimeRec) then
+  begin
+    AYear := DateRec.Year;
+    AMonth := DateRec.Month;
+    Result := True;
+    Exit;
+  end;
+  Result := False;
+end;
+
+function CoerceToISOMonthDay(const AStr: string; out AMonth, ADay: Integer): Boolean;
+var
+  DateRec: TTemporalDateRecord;
+  TimeRec: TTemporalTimeRecord;
+begin
+  // Try short form MM-DD or --MM-DD (with annotation stripping)
+  if TryParseISOMonthDay(AStr, AMonth, ADay) then
+  begin
+    Result := True;
+    Exit;
+  end;
+  // Try full date or datetime, extract month+day
+  if TryParseISODate(AStr, DateRec) or TryParseISODateTime(AStr, DateRec, TimeRec) then
+  begin
+    AMonth := DateRec.Month;
+    ADay := DateRec.Day;
+    Result := True;
+    Exit;
+  end;
+  Result := False;
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -70,6 +70,7 @@ type
     function DurationToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function DurationValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function DurationTotal(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DurationToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
 implementation
@@ -85,6 +86,7 @@ uses
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
   Goccia.Values.TemporalPlainDate,
   Goccia.Values.TemporalZonedDateTime;
 
@@ -213,6 +215,11 @@ begin
       Members.AddMethod(DurationToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(DurationToJSON, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(DurationValueOf, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(DurationToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Temporal.Duration'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -939,7 +946,6 @@ end;
 function ParseRelativeTo(const AValue: TGocciaValue; const AMethod: string): TTemporalDateRecord;
 var
   DateRec: TTemporalDateRecord;
-  TimeRec: TTemporalTimeRecord;
   PlainDate: TGocciaTemporalPlainDateValue;
 begin
   if AValue is TGocciaTemporalPlainDateValue then
@@ -953,15 +959,9 @@ begin
     Result := ZonedDateTimeToDateRecord(TGocciaTemporalZonedDateTimeValue(AValue))
   else if AValue is TGocciaStringLiteralValue then
   begin
-    if not TryParseISODate(TGocciaStringLiteralValue(AValue).Value, DateRec) then
-    begin
-      if TryParseISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
-        Result := DateRec
-      else
-        ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
-    end
-    else
-      Result := DateRec;
+    if not CoerceToISODate(TGocciaStringLiteralValue(AValue).Value, DateRec) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
+    Result := DateRec;
   end
   else if AValue is TGocciaObjectValue then
   begin
@@ -1228,6 +1228,11 @@ function TGocciaTemporalDurationValue.DurationValueOf(const AArgs: TGocciaArgume
 begin
   ThrowTypeError(Format(SErrorTemporalValueOf, ['Duration', 'toString or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
+end;
+
+function TGocciaTemporalDurationValue.DurationToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := DurationToString(AArgs, AThisValue);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -1231,8 +1231,15 @@ begin
 end;
 
 function TGocciaTemporalDurationValue.DurationToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := DurationToString(AArgs, AThisValue);
+  EmptyArgs := TGocciaArgumentsCollection.Create([]);
+  try
+    Result := DurationToString(EmptyArgs, AThisValue);
+  finally
+    EmptyArgs.Free;
+  end;
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -36,8 +36,10 @@ type
     function InstantRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function InstantEquals(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function InstantToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function InstantToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function InstantToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function InstantValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function InstantToZonedDateTimeISO(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
 implementation
@@ -54,7 +56,9 @@ uses
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.TemporalDuration;
+  Goccia.Values.SymbolValue,
+  Goccia.Values.TemporalDuration,
+  Goccia.Values.TemporalZonedDateTime;
 
 threadvar
   FShared: TGocciaSharedPrototype;
@@ -71,6 +75,7 @@ function CoerceInstant(const AValue: TGocciaValue; const AMethod: string): TGocc
 var
   DateRec: TTemporalDateRecord;
   TimeRec: TTemporalTimeRecord;
+  OffsetSeconds: Integer;
   EpochMs: Int64;
   SubMs: Integer;
 begin
@@ -78,12 +83,13 @@ begin
     Result := TGocciaTemporalInstantValue(AValue)
   else if AValue is TGocciaStringLiteralValue then
   begin
-    // Parse as ISO date-time and convert to epoch
-    if not TryParseISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
+    if not CoerceToISOInstant(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec, OffsetSeconds) then
       ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['instant', AMethod]), SSuggestTemporalISOFormat);
     EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * Int64(86400000) +
                Int64(TimeRec.Hour) * 3600000 + Int64(TimeRec.Minute) * 60000 +
                Int64(TimeRec.Second) * 1000 + TimeRec.Millisecond;
+    // Adjust for UTC offset
+    EpochMs := EpochMs - Int64(OffsetSeconds) * 1000;
     SubMs := TimeRec.Microsecond * 1000 + TimeRec.Nanosecond;
     Result := TGocciaTemporalInstantValue.Create(EpochMs, SubMs);
   end
@@ -143,8 +149,14 @@ begin
       Members.AddMethod(InstantRound, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(InstantEquals, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(InstantToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(InstantToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(InstantToJSON, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(InstantValueOf, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(InstantToZonedDateTimeISO, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Temporal.Instant'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -419,6 +431,10 @@ var
   EpochDays, RemainingMs: Int64;
   Hour, Minute, Second, Ms: Integer;
   Us, Ns: Integer;
+  Arg: TGocciaValue;
+  OptionsObj: TGocciaObjectValue;
+  FracDigits, ExtraDays: Integer;
+  Mode: TTemporalRoundingMode;
   S: string;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.toString');
@@ -442,21 +458,90 @@ begin
   Us := Inst.FSubMillisecondNanoseconds div 1000;
   Ns := Inst.FSubMillisecondNanoseconds mod 1000;
 
-  S := FormatDateString(DateRec.Year, DateRec.Month, DateRec.Day) + 'T' +
-       FormatTimeString(Hour, Minute, Second, Ms, Us, Ns) + 'Z';
+  OptionsObj := nil;
+  Arg := AArgs.GetElement(0);
+  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+    OptionsObj := TGocciaObjectValue(Arg);
+  ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
+  ExtraDays := 0;
+  RoundTimeForToString(Hour, Minute, Second, Ms, Us, Ns, ExtraDays, FracDigits, Mode);
+  if ExtraDays <> 0 then
+    DateRec := AddDaysToDate(DateRec.Year, DateRec.Month, DateRec.Day, ExtraDays);
+
+  if FracDigits = -2 then // smallestUnit: minute
+    S := FormatDateString(DateRec.Year, DateRec.Month, DateRec.Day) + 'T' +
+         PadTwo(Hour) + ':' + PadTwo(Minute) + 'Z'
+  else
+    S := FormatDateString(DateRec.Year, DateRec.Month, DateRec.Day) + 'T' +
+         FormatTimeWithPrecision(Hour, Minute, Second, Ms, Us, Ns, FracDigits) + 'Z';
 
   Result := TGocciaStringLiteralValue.Create(S);
 end;
 
 function TGocciaTemporalInstantValue.InstantToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Inst: TGocciaTemporalInstantValue;
+  DateRec: TTemporalDateRecord;
+  EpochDays, RemainingMs: Int64;
+  Hour, Minute, Second, Ms: Integer;
+  Us, Ns: Integer;
 begin
-  Result := InstantToString(AArgs, AThisValue);
+  Inst := AsInstant(AThisValue, 'Instant.prototype.toJSON');
+
+  EpochDays := Inst.FEpochMilliseconds div Int64(86400000);
+  RemainingMs := Inst.FEpochMilliseconds mod Int64(86400000);
+  if RemainingMs < 0 then
+  begin
+    Dec(EpochDays);
+    Inc(RemainingMs, Int64(86400000));
+  end;
+
+  DateRec := EpochDaysToDate(EpochDays);
+  Hour := Integer(RemainingMs div 3600000);
+  RemainingMs := RemainingMs mod 3600000;
+  Minute := Integer(RemainingMs div 60000);
+  RemainingMs := RemainingMs mod 60000;
+  Second := Integer(RemainingMs div 1000);
+  Ms := Integer(RemainingMs mod 1000);
+
+  Us := Inst.FSubMillisecondNanoseconds div 1000;
+  Ns := Inst.FSubMillisecondNanoseconds mod 1000;
+
+  Result := TGocciaStringLiteralValue.Create(
+    FormatDateString(DateRec.Year, DateRec.Month, DateRec.Day) + 'T' +
+    FormatTimeString(Hour, Minute, Second, Ms, Us, Ns) + 'Z');
 end;
 
 function TGocciaTemporalInstantValue.InstantValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   ThrowTypeError(Format(SErrorTemporalValueOf, ['Instant', 'epochMilliseconds, epochNanoseconds, or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
+end;
+
+function TGocciaTemporalInstantValue.InstantToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := InstantToString(AArgs, AThisValue);
+end;
+
+function TGocciaTemporalInstantValue.InstantToZonedDateTimeISO(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Inst: TGocciaTemporalInstantValue;
+  Arg: TGocciaValue;
+  TZ: string;
+begin
+  Inst := AsInstant(AThisValue, 'Instant.prototype.toZonedDateTimeISO');
+  if AArgs.Length < 1 then
+    ThrowTypeError('Instant.prototype.toZonedDateTimeISO requires a time zone argument', SSuggestTemporalTimezone);
+  Arg := AArgs.GetElement(0);
+  if Arg is TGocciaStringLiteralValue then
+    TZ := TGocciaStringLiteralValue(Arg).Value
+  else
+  begin
+    ThrowTypeError('Instant.prototype.toZonedDateTimeISO requires a string time zone', SSuggestTemporalTimezone);
+    TZ := '';
+  end;
+  Result := TGocciaTemporalZonedDateTimeValue.Create(
+    Inst.FEpochMilliseconds, Inst.FSubMillisecondNanoseconds, TZ);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -550,7 +550,7 @@ begin
     TZ := TGocciaStringLiteralValue(Arg).Value
   else
   begin
-    ThrowTypeError('Instant.prototype.toZonedDateTimeISO requires a string time zone', SSuggestTemporalTimezone);
+    ThrowTypeError('Instant.prototype.toZonedDateTimeISO requires a string time zone or ZonedDateTime', SSuggestTemporalTimezone);
     TZ := '';
   end;
   Result := TGocciaTemporalZonedDateTimeValue.Create(

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -523,8 +523,15 @@ begin
 end;
 
 function TGocciaTemporalInstantValue.InstantToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := InstantToString(AArgs, AThisValue);
+  EmptyArgs := TGocciaArgumentsCollection.Create([]);
+  try
+    Result := InstantToString(EmptyArgs, AThisValue);
+  finally
+    EmptyArgs.Free;
+  end;
 end;
 
 function TGocciaTemporalInstantValue.InstantToZonedDateTimeISO(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -537,7 +544,9 @@ begin
   if AArgs.Length < 1 then
     ThrowTypeError('Instant.prototype.toZonedDateTimeISO requires a time zone argument', SSuggestTemporalTimezone);
   Arg := AArgs.GetElement(0);
-  if Arg is TGocciaStringLiteralValue then
+  if Arg is TGocciaTemporalZonedDateTimeValue then
+    TZ := TGocciaTemporalZonedDateTimeValue(Arg).TimeZone
+  else if Arg is TGocciaStringLiteralValue then
     TZ := TGocciaStringLiteralValue(Arg).Value
   else
   begin

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -460,8 +460,12 @@ begin
 
   OptionsObj := nil;
   Arg := AArgs.GetElement(0);
-  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+  if Assigned(Arg) and not (Arg is TGocciaUndefinedLiteralValue) then
+  begin
+    if not (Arg is TGocciaObjectValue) then
+      ThrowTypeError('options must be an object or undefined', SSuggestTemporalFromArg);
     OptionsObj := TGocciaObjectValue(Arg);
+  end;
   ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
   ExtraDays := 0;
   RoundTimeForToString(Hour, Minute, Second, Ms, Us, Ns, ExtraDays, FracDigits, Mode);

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -528,8 +528,12 @@ begin
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.toString');
   OptionsObj := nil;
   Arg := AArgs.GetElement(0);
-  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+  if Assigned(Arg) and not (Arg is TGocciaUndefinedLiteralValue) then
+  begin
+    if not (Arg is TGocciaObjectValue) then
+      ThrowTypeError('options must be an object or undefined', SSuggestTemporalFromArg);
     OptionsObj := TGocciaObjectValue(Arg);
+  end;
   CalDisp := GetCalendarDisplay(OptionsObj);
   Result := TGocciaStringLiteralValue.Create(
     FormatDateString(D.FYear, D.FMonth, D.FDay) + FormatCalendarAnnotation(CalDisp));

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -662,6 +662,8 @@ var
 begin
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.withCalendar');
   Arg := AArgs.GetElement(0);
+  if (Arg = nil) or (Arg is TGocciaUndefinedLiteralValue) then
+    ThrowTypeError('PlainDate.prototype.withCalendar requires a calendar argument', SSuggestTemporalFromArg);
   CalId := Arg.ToStringLiteral.Value;
   if CalId <> 'iso8601' then
     ThrowRangeError('Unknown calendar: ' + CalId, SSuggestTemporalFromArg);

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -654,8 +654,15 @@ begin
 end;
 
 function TGocciaTemporalPlainDateValue.DateToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := DateToString(AArgs, AThisValue);
+  EmptyArgs := TGocciaArgumentsCollection.Create([]);
+  try
+    Result := DateToString(EmptyArgs, AThisValue);
+  finally
+    EmptyArgs.Free;
+  end;
 end;
 
 function TGocciaTemporalPlainDateValue.DateWithCalendar(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -46,6 +46,8 @@ type
     function DateToPlainYearMonth(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function DateToPlainMonthDay(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function DateToZonedDateTime(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DateToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DateWithCalendar(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     procedure InitializePrototype;
   public
@@ -68,10 +70,12 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
+  Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
   Goccia.Values.TemporalDuration,
   Goccia.Values.TemporalPlainDateTime,
   Goccia.Values.TemporalPlainMonthDay,
@@ -104,7 +108,6 @@ end;
 function CoercePlainDate(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainDateValue;
 var
   DateRec: TTemporalDateRecord;
-  TimeRec: TTemporalTimeRecord;
   Obj: TGocciaObjectValue;
   V, VMonth, VDay: TGocciaValue;
   RequiredFieldsMsg: string;
@@ -113,16 +116,9 @@ begin
     Result := TGocciaTemporalPlainDateValue(AValue)
   else if AValue is TGocciaStringLiteralValue then
   begin
-    if not TryParseISODate(TGocciaStringLiteralValue(AValue).Value, DateRec) then
-    begin
-      // Try parsing as datetime
-      if TryParseISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
-        Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day)
-      else
-        ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['date', AMethod]), SSuggestTemporalISOFormat);
-    end
-    else
-      Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day);
+    if not CoerceToISODate(TGocciaStringLiteralValue(AValue).Value, DateRec) then
+      ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['date', AMethod]), SSuggestTemporalISOFormat);
+    Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day);
   end
   else if AValue is TGocciaObjectValue then
   begin
@@ -201,6 +197,12 @@ begin
       Members.AddMethod(DateToPlainYearMonth, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(DateToPlainMonthDay, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(DateToZonedDateTime, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(DateToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(DateWithCalendar, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Temporal.PlainDate'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -519,9 +521,18 @@ end;
 function TGocciaTemporalPlainDateValue.DateToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D: TGocciaTemporalPlainDateValue;
+  Arg: TGocciaValue;
+  OptionsObj: TGocciaObjectValue;
+  CalDisp: TTemporalCalendarDisplay;
 begin
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.toString');
-  Result := TGocciaStringLiteralValue.Create(FormatDateString(D.FYear, D.FMonth, D.FDay));
+  OptionsObj := nil;
+  Arg := AArgs.GetElement(0);
+  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+    OptionsObj := TGocciaObjectValue(Arg);
+  CalDisp := GetCalendarDisplay(OptionsObj);
+  Result := TGocciaStringLiteralValue.Create(
+    FormatDateString(D.FYear, D.FMonth, D.FDay) + FormatCalendarAnnotation(CalDisp));
 end;
 
 function TGocciaTemporalPlainDateValue.DateToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -636,6 +647,25 @@ begin
   EpochMs := EpochMs - Int64(OffsetSec) * 1000;
 
   Result := TGocciaTemporalZonedDateTimeValue.Create(EpochMs, 0, TimeZoneStr);
+end;
+
+function TGocciaTemporalPlainDateValue.DateToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := DateToString(AArgs, AThisValue);
+end;
+
+function TGocciaTemporalPlainDateValue.DateWithCalendar(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  D: TGocciaTemporalPlainDateValue;
+  Arg: TGocciaValue;
+  CalId: string;
+begin
+  D := AsPlainDate(AThisValue, 'PlainDate.prototype.withCalendar');
+  Arg := AArgs.GetElement(0);
+  CalId := Arg.ToStringLiteral.Value;
+  if CalId <> 'iso8601' then
+    ThrowRangeError('Unknown calendar: ' + CalId, SSuggestTemporalFromArg);
+  Result := TGocciaTemporalPlainDateValue.Create(D.FYear, D.FMonth, D.FDay);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -876,6 +876,8 @@ var
 begin
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.withCalendar');
   Arg := AArgs.GetElement(0);
+  if (Arg = nil) or (Arg is TGocciaUndefinedLiteralValue) then
+    ThrowTypeError('PlainDateTime.prototype.withCalendar requires a calendar argument', SSuggestTemporalFromArg);
   CalId := Arg.ToStringLiteral.Value;
   if CalId <> 'iso8601' then
     ThrowRangeError('Unknown calendar: ' + CalId, SSuggestTemporalFromArg);

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -61,6 +61,8 @@ type
     function DateTimeToPlainYearMonth(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function DateTimeToPlainMonthDay(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function DateTimeToZonedDateTime(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DateTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DateTimeWithCalendar(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     procedure InitializePrototype;
   public
@@ -93,6 +95,7 @@ uses
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
   Goccia.Values.TemporalDuration,
   Goccia.Values.TemporalPlainDate,
   Goccia.Values.TemporalPlainMonthDay,
@@ -141,7 +144,7 @@ begin
     Result := TGocciaTemporalPlainDateTimeValue(AValue)
   else if AValue is TGocciaStringLiteralValue then
   begin
-    if not TryParseISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
+    if not CoerceToISODateTime(TGocciaStringLiteralValue(AValue).Value, DateRec, TimeRec) then
       ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['date-time', AMethod]), SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainDateTimeValue.Create(
       DateRec.Year, DateRec.Month, DateRec.Day,
@@ -237,6 +240,12 @@ begin
       Members.AddMethod(DateTimeToPlainYearMonth, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(DateTimeToPlainMonthDay, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(DateTimeToZonedDateTime, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(DateTimeToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(DateTimeWithCalendar, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Temporal.PlainDateTime'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -438,7 +447,7 @@ begin
     end
     else if Arg is TGocciaStringLiteralValue then
     begin
-      if not TryParseISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
+      if not CoerceToISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
         ThrowRangeError(SErrorInvalidTimeString, SSuggestTemporalISOFormat);
       H := TimeRec.Hour; Mi := TimeRec.Minute; S := TimeRec.Second;
       Ms := TimeRec.Millisecond; Us := TimeRec.Microsecond; Ns := TimeRec.Nanosecond;
@@ -727,11 +736,41 @@ end;
 function TGocciaTemporalPlainDateTimeValue.DateTimeToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D: TGocciaTemporalPlainDateTimeValue;
+  Arg: TGocciaValue;
+  OptionsObj: TGocciaObjectValue;
+  FracDigits, ExtraDays: Integer;
+  Mode: TTemporalRoundingMode;
+  CalDisp: TTemporalCalendarDisplay;
+  H, Mi, S, Ms, Us, Ns: Integer;
+  DateRec: TTemporalDateRecord;
+  TimeStr: string;
 begin
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.toString');
+  OptionsObj := nil;
+  Arg := AArgs.GetElement(0);
+  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+    OptionsObj := TGocciaObjectValue(Arg);
+  ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
+  CalDisp := GetCalendarDisplay(OptionsObj);
+  H := D.FHour; Mi := D.FMinute; S := D.FSecond;
+  Ms := D.FMillisecond; Us := D.FMicrosecond; Ns := D.FNanosecond;
+  ExtraDays := 0;
+  RoundTimeForToString(H, Mi, S, Ms, Us, Ns, ExtraDays, FracDigits, Mode);
+  if ExtraDays <> 0 then
+    DateRec := AddDaysToDate(D.FYear, D.FMonth, D.FDay, ExtraDays)
+  else
+  begin
+    DateRec.Year := D.FYear;
+    DateRec.Month := D.FMonth;
+    DateRec.Day := D.FDay;
+  end;
+  if FracDigits = -2 then // smallestUnit: minute
+    TimeStr := PadTwo(H) + ':' + PadTwo(Mi)
+  else
+    TimeStr := FormatTimeWithPrecision(H, Mi, S, Ms, Us, Ns, FracDigits);
   Result := TGocciaStringLiteralValue.Create(
-    FormatDateString(D.FYear, D.FMonth, D.FDay) + 'T' +
-    FormatTimeString(D.FHour, D.FMinute, D.FSecond, D.FMillisecond, D.FMicrosecond, D.FNanosecond));
+    FormatDateString(DateRec.Year, DateRec.Month, DateRec.Day) + 'T' +
+    TimeStr + FormatCalendarAnnotation(CalDisp));
 end;
 
 function TGocciaTemporalPlainDateTimeValue.DateTimeToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -822,6 +861,26 @@ begin
 
   Result := TGocciaTemporalZonedDateTimeValue.Create(EpochMs,
     D.FMicrosecond * 1000 + D.FNanosecond, TimeZoneStr);
+end;
+
+function TGocciaTemporalPlainDateTimeValue.DateTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := DateTimeToString(AArgs, AThisValue);
+end;
+
+function TGocciaTemporalPlainDateTimeValue.DateTimeWithCalendar(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  D: TGocciaTemporalPlainDateTimeValue;
+  Arg: TGocciaValue;
+  CalId: string;
+begin
+  D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.withCalendar');
+  Arg := AArgs.GetElement(0);
+  CalId := Arg.ToStringLiteral.Value;
+  if CalId <> 'iso8601' then
+    ThrowRangeError('Unknown calendar: ' + CalId, SSuggestTemporalFromArg);
+  Result := TGocciaTemporalPlainDateTimeValue.Create(D.FYear, D.FMonth, D.FDay,
+    D.FHour, D.FMinute, D.FSecond, D.FMillisecond, D.FMicrosecond, D.FNanosecond);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -868,8 +868,15 @@ begin
 end;
 
 function TGocciaTemporalPlainDateTimeValue.DateTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := DateTimeToString(AArgs, AThisValue);
+  EmptyArgs := TGocciaArgumentsCollection.Create([]);
+  try
+    Result := DateTimeToString(EmptyArgs, AThisValue);
+  finally
+    EmptyArgs.Free;
+  end;
 end;
 
 function TGocciaTemporalPlainDateTimeValue.DateTimeWithCalendar(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -748,8 +748,12 @@ begin
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.toString');
   OptionsObj := nil;
   Arg := AArgs.GetElement(0);
-  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+  if Assigned(Arg) and not (Arg is TGocciaUndefinedLiteralValue) then
+  begin
+    if not (Arg is TGocciaObjectValue) then
+      ThrowTypeError('options must be an object or undefined', SSuggestTemporalFromArg);
     OptionsObj := TGocciaObjectValue(Arg);
+  end;
   ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
   CalDisp := GetCalendarDisplay(OptionsObj);
   H := D.FHour; Mi := D.FMinute; S := D.FSecond;

--- a/source/units/Goccia.Values.TemporalPlainMonthDay.pas
+++ b/source/units/Goccia.Values.TemporalPlainMonthDay.pas
@@ -28,6 +28,7 @@ type
     function MonthDayToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function MonthDayValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function MonthDayToPlainDate(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function MonthDayToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     procedure InitializePrototype;
   public
@@ -50,9 +51,11 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
   Goccia.Values.TemporalPlainDate;
 
 threadvar
@@ -71,8 +74,6 @@ end;
 
 function CoercePlainMonthDay(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainMonthDayValue;
 var
-  S: string;
-  DashPos: Integer;
   MonthPart, DayPart: Integer;
   Obj: TGocciaObjectValue;
   V, VMonthCode, VDay: TGocciaValue;
@@ -85,13 +86,7 @@ begin
       TGocciaTemporalPlainMonthDayValue(AValue).FReferenceYear)
   else if AValue is TGocciaStringLiteralValue then
   begin
-    S := TGocciaStringLiteralValue(AValue).Value;
-    DashPos := Pos('-', S);
-    if (DashPos < 2) or (DashPos >= Length(S)) then
-      ThrowRangeError(Format(SErrorInvalidMonthDayStringFor, [AMethod]), SSuggestTemporalISOFormat);
-    if not TryStrToInt(Copy(S, 1, DashPos - 1), MonthPart) then
-      ThrowRangeError(Format(SErrorInvalidMonthDayStringFor, [AMethod]), SSuggestTemporalISOFormat);
-    if not TryStrToInt(Copy(S, DashPos + 1, Length(S) - DashPos), DayPart) then
+    if not CoerceToISOMonthDay(TGocciaStringLiteralValue(AValue).Value, MonthPart, DayPart) then
       ThrowRangeError(Format(SErrorInvalidMonthDayStringFor, [AMethod]), SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainMonthDayValue.Create(MonthPart, DayPart);
   end
@@ -175,6 +170,11 @@ begin
       Members.AddMethod(MonthDayToJSON, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(MonthDayValueOf, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(MonthDayToPlainDate, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(MonthDayToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Temporal.PlainMonthDay'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -292,9 +292,18 @@ end;
 function TGocciaTemporalPlainMonthDayValue.MonthDayToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   MD: TGocciaTemporalPlainMonthDayValue;
+  Arg: TGocciaValue;
+  OptionsObj: TGocciaObjectValue;
+  CalDisp: TTemporalCalendarDisplay;
 begin
   MD := AsPlainMonthDay(AThisValue, 'PlainMonthDay.prototype.toString');
-  Result := TGocciaStringLiteralValue.Create(PadTwo(MD.FMonth) + '-' + PadTwo(MD.FDay));
+  OptionsObj := nil;
+  Arg := AArgs.GetElement(0);
+  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+    OptionsObj := TGocciaObjectValue(Arg);
+  CalDisp := GetCalendarDisplay(OptionsObj);
+  Result := TGocciaStringLiteralValue.Create(
+    PadTwo(MD.FMonth) + '-' + PadTwo(MD.FDay) + FormatCalendarAnnotation(CalDisp));
 end;
 
 // TC39 Temporal §11.3.9 Temporal.PlainMonthDay.prototype.toJSON()
@@ -333,6 +342,11 @@ begin
 
   YearValue := Trunc(V.ToNumberLiteral.Value);
   Result := TGocciaTemporalPlainDateValue.Create(YearValue, MD.FMonth, MD.FDay);
+end;
+
+function TGocciaTemporalPlainMonthDayValue.MonthDayToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := MonthDayToString(AArgs, AThisValue);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalPlainMonthDay.pas
+++ b/source/units/Goccia.Values.TemporalPlainMonthDay.pas
@@ -299,8 +299,12 @@ begin
   MD := AsPlainMonthDay(AThisValue, 'PlainMonthDay.prototype.toString');
   OptionsObj := nil;
   Arg := AArgs.GetElement(0);
-  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+  if Assigned(Arg) and not (Arg is TGocciaUndefinedLiteralValue) then
+  begin
+    if not (Arg is TGocciaObjectValue) then
+      ThrowTypeError('options must be an object or undefined', SSuggestTemporalFromArg);
     OptionsObj := TGocciaObjectValue(Arg);
+  end;
   CalDisp := GetCalendarDisplay(OptionsObj);
   // When calendar annotation is present, include reference year for round-tripping
   if (CalDisp = tcdAlways) or (CalDisp = tcdCritical) then

--- a/source/units/Goccia.Values.TemporalPlainMonthDay.pas
+++ b/source/units/Goccia.Values.TemporalPlainMonthDay.pas
@@ -302,8 +302,13 @@ begin
   if Assigned(Arg) and (Arg is TGocciaObjectValue) then
     OptionsObj := TGocciaObjectValue(Arg);
   CalDisp := GetCalendarDisplay(OptionsObj);
-  Result := TGocciaStringLiteralValue.Create(
-    PadTwo(MD.FMonth) + '-' + PadTwo(MD.FDay) + FormatCalendarAnnotation(CalDisp));
+  // When calendar annotation is present, include reference year for round-tripping
+  if (CalDisp = tcdAlways) or (CalDisp = tcdCritical) then
+    Result := TGocciaStringLiteralValue.Create(
+      FormatDateString(MD.FReferenceYear, MD.FMonth, MD.FDay) + FormatCalendarAnnotation(CalDisp))
+  else
+    Result := TGocciaStringLiteralValue.Create(
+      PadTwo(MD.FMonth) + '-' + PadTwo(MD.FDay));
 end;
 
 // TC39 Temporal §11.3.9 Temporal.PlainMonthDay.prototype.toJSON()

--- a/source/units/Goccia.Values.TemporalPlainMonthDay.pas
+++ b/source/units/Goccia.Values.TemporalPlainMonthDay.pas
@@ -354,8 +354,15 @@ begin
 end;
 
 function TGocciaTemporalPlainMonthDayValue.MonthDayToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := MonthDayToString(AArgs, AThisValue);
+  EmptyArgs := TGocciaArgumentsCollection.Create([]);
+  try
+    Result := MonthDayToString(EmptyArgs, AThisValue);
+  finally
+    EmptyArgs.Free;
+  end;
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -511,8 +511,12 @@ begin
   T := AsPlainTime(AThisValue, 'PlainTime.prototype.toString');
   OptionsObj := nil;
   Arg := AArgs.GetElement(0);
-  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+  if Assigned(Arg) and not (Arg is TGocciaUndefinedLiteralValue) then
+  begin
+    if not (Arg is TGocciaObjectValue) then
+      ThrowTypeError('options must be an object or undefined', SSuggestTemporalFromArg);
     OptionsObj := TGocciaObjectValue(Arg);
+  end;
   ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
   H := T.FHour; Mi := T.FMinute; S := T.FSecond;
   Ms := T.FMillisecond; Us := T.FMicrosecond; Ns := T.FNanosecond;

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -545,8 +545,15 @@ begin
 end;
 
 function TGocciaTemporalPlainTimeValue.PlainTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := TimeToString(AArgs, AThisValue);
+  EmptyArgs := TGocciaArgumentsCollection.Create([]);
+  try
+    Result := TimeToString(EmptyArgs, AThisValue);
+  finally
+    EmptyArgs.Free;
+  end;
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -38,6 +38,7 @@ type
     function TimeToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function TimeToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function TimeValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function PlainTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     procedure InitializePrototype;
   public
@@ -65,6 +66,7 @@ uses
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
   Goccia.Values.TemporalDuration;
 
 threadvar
@@ -89,7 +91,7 @@ begin
     Result := TGocciaTemporalPlainTimeValue(AValue)
   else if AValue is TGocciaStringLiteralValue then
   begin
-    if not TryParseISOTime(TGocciaStringLiteralValue(AValue).Value, TimeRec) then
+    if not CoerceToISOTime(TGocciaStringLiteralValue(AValue).Value, TimeRec) then
       ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['time', AMethod]), SSuggestTemporalISOFormat);
     Result := TGocciaTemporalPlainTimeValue.Create(
       TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
@@ -174,6 +176,11 @@ begin
       Members.AddMethod(TimeToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(TimeToJSON, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(TimeValueOf, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(PlainTimeToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Temporal.PlainTime'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -496,18 +503,26 @@ function TGocciaTemporalPlainTimeValue.TimeToString(const AArgs: TGocciaArgument
 var
   T: TGocciaTemporalPlainTimeValue;
   Arg: TGocciaValue;
-  FracDigits: Integer;
+  OptionsObj: TGocciaObjectValue;
+  FracDigits, ExtraDays: Integer;
+  Mode: TTemporalRoundingMode;
+  H, Mi, S, Ms, Us, Ns: Integer;
 begin
   T := AsPlainTime(AThisValue, 'PlainTime.prototype.toString');
+  OptionsObj := nil;
   Arg := AArgs.GetElement(0);
-  FracDigits := -1; // auto
-
   if Assigned(Arg) and (Arg is TGocciaObjectValue) then
-    FracDigits := GetFractionalSecondDigits(TGocciaObjectValue(Arg));
-
-  Result := TGocciaStringLiteralValue.Create(
-    FormatTimeWithPrecision(T.FHour, T.FMinute, T.FSecond,
-      T.FMillisecond, T.FMicrosecond, T.FNanosecond, FracDigits));
+    OptionsObj := TGocciaObjectValue(Arg);
+  ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
+  H := T.FHour; Mi := T.FMinute; S := T.FSecond;
+  Ms := T.FMillisecond; Us := T.FMicrosecond; Ns := T.FNanosecond;
+  ExtraDays := 0;
+  RoundTimeForToString(H, Mi, S, Ms, Us, Ns, ExtraDays, FracDigits, Mode);
+  if FracDigits = -2 then // smallestUnit: minute
+    Result := TGocciaStringLiteralValue.Create(PadTwo(H) + ':' + PadTwo(Mi))
+  else
+    Result := TGocciaStringLiteralValue.Create(
+      FormatTimeWithPrecision(H, Mi, S, Ms, Us, Ns, FracDigits));
 end;
 
 function TGocciaTemporalPlainTimeValue.TimeToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -523,6 +538,11 @@ function TGocciaTemporalPlainTimeValue.TimeValueOf(const AArgs: TGocciaArguments
 begin
   ThrowTypeError(Format(SErrorTemporalValueOf, ['PlainTime', 'toString or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
+end;
+
+function TGocciaTemporalPlainTimeValue.PlainTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TimeToString(AArgs, AThisValue);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -485,8 +485,13 @@ begin
   if Assigned(Arg) and (Arg is TGocciaObjectValue) then
     OptionsObj := TGocciaObjectValue(Arg);
   CalDisp := GetCalendarDisplay(OptionsObj);
-  Result := TGocciaStringLiteralValue.Create(
-    FormatYearMonthString(YM.FYear, YM.FMonth) + FormatCalendarAnnotation(CalDisp));
+  // When calendar annotation is present, include reference day for round-tripping
+  if (CalDisp = tcdAlways) or (CalDisp = tcdCritical) then
+    Result := TGocciaStringLiteralValue.Create(
+      FormatDateString(YM.FYear, YM.FMonth, YM.FReferenceDay) + FormatCalendarAnnotation(CalDisp))
+  else
+    Result := TGocciaStringLiteralValue.Create(
+      FormatYearMonthString(YM.FYear, YM.FMonth));
 end;
 
 // TC39 Temporal §10.3.18 Temporal.PlainYearMonth.prototype.toJSON()

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -37,6 +37,7 @@ type
     function YearMonthToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function YearMonthValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function YearMonthToPlainDate(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function YearMonthToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     procedure InitializePrototype;
   public
@@ -57,9 +58,11 @@ uses
 
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
   Goccia.Values.TemporalDuration,
   Goccia.Values.TemporalPlainDate;
 
@@ -70,31 +73,6 @@ threadvar
 function FormatYearMonthString(const AYear, AMonth: Integer): string;
 begin
   Result := PadISOYear(AYear) + '-' + PadTwo(AMonth);
-end;
-
-function TryParseYearMonthDigits(const AStr: string; var APos: Integer; const ACount: Integer; out AValue: Integer): Boolean;
-var
-  I: Integer;
-  C: Char;
-begin
-  AValue := 0;
-  if APos + ACount - 1 > Length(AStr) then
-  begin
-    Result := False;
-    Exit;
-  end;
-  for I := 0 to ACount - 1 do
-  begin
-    C := AStr[APos + I];
-    if (C < '0') or (C > '9') then
-    begin
-      Result := False;
-      Exit;
-    end;
-    AValue := AValue * 10 + (Ord(C) - Ord('0'));
-  end;
-  Inc(APos, ACount);
-  Result := True;
 end;
 
 function AsPlainYearMonth(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainYearMonthValue;
@@ -108,49 +86,14 @@ function CoercePlainYearMonth(const AValue: TGocciaValue; const AMethod: string)
 var
   Obj: TGocciaObjectValue;
   V, VMonth: TGocciaValue;
-  S: string;
-  Pos, Year, Month, Sign: Integer;
+  Year, Month: Integer;
 begin
   if AValue is TGocciaTemporalPlainYearMonthValue then
     Result := TGocciaTemporalPlainYearMonthValue(AValue)
   else if AValue is TGocciaStringLiteralValue then
   begin
-    // Parse YYYY-MM format
-    S := TGocciaStringLiteralValue(AValue).Value;
-    Pos := 1;
-    Sign := 1;
-
-    if (Pos <= Length(S)) and (S[Pos] = '+') then
-    begin
-      Inc(Pos);
-      if not TryParseYearMonthDigits(S, Pos, 6, Year) then
-        ThrowRangeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
-    end
-    else if (Pos <= Length(S)) and (S[Pos] = '-') then
-    begin
-      Inc(Pos);
-      Sign := -1;
-      if not TryParseYearMonthDigits(S, Pos, 6, Year) then
-        ThrowRangeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
-    end
-    else
-    begin
-      if not TryParseYearMonthDigits(S, Pos, 4, Year) then
-        ThrowRangeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
-    end;
-
-    Year := Year * Sign;
-
-    if (Pos > Length(S)) or (S[Pos] <> '-') then
+    if not CoerceToISOYearMonth(TGocciaStringLiteralValue(AValue).Value, Year, Month) then
       ThrowRangeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
-    Inc(Pos);
-
-    if not TryParseYearMonthDigits(S, Pos, 2, Month) then
-      ThrowRangeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
-
-    if Pos <= Length(S) then
-      ThrowRangeError(Format(SErrorInvalidYearMonthStringFor, [AMethod]), SSuggestTemporalISOFormat);
-
     Result := TGocciaTemporalPlainYearMonthValue.Create(Year, Month);
   end
   else if AValue is TGocciaObjectValue then
@@ -224,6 +167,11 @@ begin
       Members.AddMethod(YearMonthToJSON, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(YearMonthValueOf, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(YearMonthToPlainDate, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(YearMonthToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Temporal.PlainYearMonth'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -527,9 +475,18 @@ end;
 function TGocciaTemporalPlainYearMonthValue.YearMonthToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   YM: TGocciaTemporalPlainYearMonthValue;
+  Arg: TGocciaValue;
+  OptionsObj: TGocciaObjectValue;
+  CalDisp: TTemporalCalendarDisplay;
 begin
   YM := AsPlainYearMonth(AThisValue, 'PlainYearMonth.prototype.toString');
-  Result := TGocciaStringLiteralValue.Create(FormatYearMonthString(YM.FYear, YM.FMonth));
+  OptionsObj := nil;
+  Arg := AArgs.GetElement(0);
+  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+    OptionsObj := TGocciaObjectValue(Arg);
+  CalDisp := GetCalendarDisplay(OptionsObj);
+  Result := TGocciaStringLiteralValue.Create(
+    FormatYearMonthString(YM.FYear, YM.FMonth) + FormatCalendarAnnotation(CalDisp));
 end;
 
 // TC39 Temporal §10.3.18 Temporal.PlainYearMonth.prototype.toJSON()
@@ -569,6 +526,11 @@ begin
 
   Day := Trunc(V.ToNumberLiteral.Value);
   Result := TGocciaTemporalPlainDateValue.Create(YM.FYear, YM.FMonth, Day);
+end;
+
+function TGocciaTemporalPlainYearMonthValue.YearMonthToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := YearMonthToString(AArgs, AThisValue);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -538,8 +538,15 @@ begin
 end;
 
 function TGocciaTemporalPlainYearMonthValue.YearMonthToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := YearMonthToString(AArgs, AThisValue);
+  EmptyArgs := TGocciaArgumentsCollection.Create([]);
+  try
+    Result := YearMonthToString(EmptyArgs, AThisValue);
+  finally
+    EmptyArgs.Free;
+  end;
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -482,8 +482,12 @@ begin
   YM := AsPlainYearMonth(AThisValue, 'PlainYearMonth.prototype.toString');
   OptionsObj := nil;
   Arg := AArgs.GetElement(0);
-  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+  if Assigned(Arg) and not (Arg is TGocciaUndefinedLiteralValue) then
+  begin
+    if not (Arg is TGocciaObjectValue) then
+      ThrowTypeError('options must be an object or undefined', SSuggestTemporalFromArg);
     OptionsObj := TGocciaObjectValue(Arg);
+  end;
   CalDisp := GetCalendarDisplay(OptionsObj);
   // When calendar annotation is present, include reference day for round-tripping
   if (CalDisp = tcdAlways) or (CalDisp = tcdCritical) then

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -65,6 +65,7 @@ type
     function ZonedDateTimeToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ZonedDateTimeToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ZonedDateTimeValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ZonedDateTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AEpochMilliseconds: Int64; const ASubMillisecondNanoseconds: Integer;
       const ATimeZone: string); overload;
@@ -92,6 +93,7 @@ uses
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
   Goccia.Values.TemporalDuration,
   Goccia.Values.TemporalInstant,
   Goccia.Values.TemporalPlainDate,
@@ -358,6 +360,11 @@ begin
       Members.AddMethod(ZonedDateTimeToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ZonedDateTimeToJSON, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ZonedDateTimeValueOf, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(ZonedDateTimeToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Temporal.ZonedDateTime'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -691,7 +698,7 @@ begin
     PlainDate := TGocciaTemporalPlainDateValue(Arg)
   else if Arg is TGocciaStringLiteralValue then
   begin
-    if not TryParseISODate(TGocciaStringLiteralValue(Arg).Value, DateRec) then
+    if not CoerceToISODate(TGocciaStringLiteralValue(Arg).Value, DateRec) then
       ThrowRangeError(SErrorInvalidDateStringForZDT, SSuggestTemporalISOFormat);
     PlainDate := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day);
   end
@@ -736,7 +743,7 @@ begin
     end
     else if Arg is TGocciaStringLiteralValue then
     begin
-      if not TryParseISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
+      if not CoerceToISOTime(TGocciaStringLiteralValue(Arg).Value, TimeRec) then
         ThrowRangeError(SErrorInvalidTimeStringForZDT, SSuggestTemporalISOFormat);
       NewHour := TimeRec.Hour; NewMinute := TimeRec.Minute; NewSecond := TimeRec.Second;
       NewMs := TimeRec.Millisecond; NewUs := TimeRec.Microsecond; NewNs := TimeRec.Nanosecond;
@@ -1106,24 +1113,61 @@ var
   Zdt: TGocciaTemporalZonedDateTimeValue;
   LYear, LMonth, LDay, LHour, LMinute, LSecond, LMs, LUs, LNs: Integer;
   OffsetSeconds: Integer;
-  S: string;
+  Arg: TGocciaValue;
+  OptionsObj: TGocciaObjectValue;
+  FracDigits, ExtraDays: Integer;
+  Mode: TTemporalRoundingMode;
+  CalDisp: TTemporalCalendarDisplay;
+  DateRec: TTemporalDateRecord;
+  TimeStr, S: string;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.toString');
   ComputeLocalComponents(Zdt, LYear, LMonth, LDay, LHour, LMinute, LSecond, LMs, LUs, LNs);
   OffsetSeconds := GetUtcOffsetSeconds(Zdt.FTimeZone, Zdt.FEpochMilliseconds div MILLISECONDS_PER_SECOND);
 
-  S := FormatDateString(LYear, LMonth, LDay) + 'T' +
-       FormatTimeString(LHour, LMinute, LSecond, LMs, LUs, LNs) +
-       FormatOffsetString(OffsetSeconds) +
-       '[' + Zdt.FTimeZone + ']';
+  OptionsObj := nil;
+  Arg := AArgs.GetElement(0);
+  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+    OptionsObj := TGocciaObjectValue(Arg);
+  ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
+  CalDisp := GetCalendarDisplay(OptionsObj);
+  ExtraDays := 0;
+  RoundTimeForToString(LHour, LMinute, LSecond, LMs, LUs, LNs, ExtraDays, FracDigits, Mode);
+  if ExtraDays <> 0 then
+    DateRec := AddDaysToDate(LYear, LMonth, LDay, ExtraDays)
+  else
+  begin
+    DateRec.Year := LYear;
+    DateRec.Month := LMonth;
+    DateRec.Day := LDay;
+  end;
+  if FracDigits = -2 then // smallestUnit: minute
+    TimeStr := PadTwo(LHour) + ':' + PadTwo(LMinute)
+  else
+    TimeStr := FormatTimeWithPrecision(LHour, LMinute, LSecond, LMs, LUs, LNs, FracDigits);
+
+  S := FormatDateString(DateRec.Year, DateRec.Month, DateRec.Day) + 'T' +
+       TimeStr + FormatOffsetString(OffsetSeconds) +
+       '[' + Zdt.FTimeZone + ']' + FormatCalendarAnnotation(CalDisp);
 
   Result := TGocciaStringLiteralValue.Create(S);
 end;
 
 // TC39 Temporal §6.3.38 Temporal.ZonedDateTime.prototype.toJSON()
 function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeToJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Zdt: TGocciaTemporalZonedDateTimeValue;
+  LYear, LMonth, LDay, LHour, LMinute, LSecond, LMs, LUs, LNs: Integer;
+  OffsetSeconds: Integer;
 begin
-  Result := ZonedDateTimeToString(AArgs, AThisValue);
+  Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.toJSON');
+  ComputeLocalComponents(Zdt, LYear, LMonth, LDay, LHour, LMinute, LSecond, LMs, LUs, LNs);
+  OffsetSeconds := GetUtcOffsetSeconds(Zdt.FTimeZone, Zdt.FEpochMilliseconds div MILLISECONDS_PER_SECOND);
+  Result := TGocciaStringLiteralValue.Create(
+    FormatDateString(LYear, LMonth, LDay) + 'T' +
+    FormatTimeString(LHour, LMinute, LSecond, LMs, LUs, LNs) +
+    FormatOffsetString(OffsetSeconds) +
+    '[' + Zdt.FTimeZone + ']');
 end;
 
 // TC39 Temporal §6.3.40 Temporal.ZonedDateTime.prototype.valueOf()
@@ -1131,6 +1175,11 @@ function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeValueOf(const AArgs: TGo
 begin
   ThrowTypeError(Format(SErrorTemporalValueOf, ['ZonedDateTime', 'epochMilliseconds, epochNanoseconds, or compare']), SSuggestTemporalNoValueOf);
   Result := nil;
+end;
+
+function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := ZonedDateTimeToString(AArgs, AThisValue);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -1127,8 +1127,12 @@ begin
 
   OptionsObj := nil;
   Arg := AArgs.GetElement(0);
-  if Assigned(Arg) and (Arg is TGocciaObjectValue) then
+  if Assigned(Arg) and not (Arg is TGocciaUndefinedLiteralValue) then
+  begin
+    if not (Arg is TGocciaObjectValue) then
+      ThrowTypeError('options must be an object or undefined', SSuggestTemporalFromArg);
     OptionsObj := TGocciaObjectValue(Arg);
+  end;
   ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
   CalDisp := GetCalendarDisplay(OptionsObj);
   ExtraDays := 0;

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -1182,8 +1182,15 @@ begin
 end;
 
 function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
 begin
-  Result := ZonedDateTimeToString(AArgs, AThisValue);
+  EmptyArgs := TGocciaArgumentsCollection.Create([]);
+  try
+    Result := ZonedDateTimeToString(EmptyArgs, AThisValue);
+  finally
+    EmptyArgs.Free;
+  end;
 end;
 
 end.


### PR DESCRIPTION
## Summary
- Add shared ISO string coercion primitives (`CoerceToISO*`) and toString options (`ResolveTemporalToStringOptions`, `RoundTimeForToString`, `GetCalendarDisplay`) to eliminate duplicated parsing logic across all Temporal types
- Fill missing API surface: `toLocaleString`, `Symbol.toStringTag`, `toZonedDateTimeISO`, `withCalendar`, `expand` rounding mode
- Fix property descriptors (non-enumerable constructor statics), timezone offset IDs, leap second handling, annotation validation
- Enable BigInt in test262 filter

test262: 6,612 → 6,837 passed (+225), Temporal 1,787 → 2,012 (+225, 42.5% → 47.9%)

## Test plan
- [x] `./build.pas testrunner && ./build/GocciaTestRunner tests --asi --unsafe-ffi` — 5,739 pass, 5 fail (pre-existing FFI fixture)
- [x] `./format.pas --check` — 274 files, all clean
- [x] Zero compiler warnings
- [x] test262 suite run confirms +225 net improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)