### PR TITLE
Include tests, benchmarks, and examples in nightly archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1184,6 +1184,10 @@ jobs:
             pkg_dir="${archive_name}"
             bash ./.github/scripts/stage-build-artifacts.sh "$artifact_dir" "$pkg_dir"
 
+            cp -r tests/ "$pkg_dir/tests/"
+            cp -r benchmarks/ "$pkg_dir/benchmarks/"
+            cp -r examples/ "$pkg_dir/examples/"
+
             if [[ "$target" == *win* ]]; then
               zip -r "${archive_name}.zip" "$pkg_dir/"
             else


### PR DESCRIPTION
## Summary
- Nightly release archives now include `tests/`, `benchmarks/`, and `examples/` directories, matching what tagged releases already ship
- Previously nightly builds only contained the executables


🤖 Generated with [Claude Code](https://claude.com/claude-code)