### PR TITLE
Expose build date in version metadata

### DIFF
--- a/build.pas
+++ b/build.pas
@@ -17,7 +17,7 @@ var
   I: Integer;
   BuildTriggers: TStringList;
   BuildMode: TBuildMode = bmDev;
-  GVersion, GCommit: string;
+  GVersion, GCommit, GBuildDate: string;
 
 function ComputeVersion: string;
 var
@@ -49,7 +49,12 @@ begin
     Result := 'unknown';
 end;
 
-procedure GenerateVersionInclude(const AVersion, ACommit: string);
+function ComputeBuildDate: string;
+begin
+  Result := FormatDateTime('yyyy-mm-dd', Now);
+end;
+
+procedure GenerateVersionInclude(const AVersion, ACommit, ABuildDate: string);
 var
   F: TextFile;
 begin
@@ -60,14 +65,15 @@ begin
     WriteLn(F, 'const');
     WriteLn(F, '  BAKED_VERSION = ''', AVersion, ''';');
     WriteLn(F, '  BAKED_COMMIT = ''', ACommit, ''';');
+    WriteLn(F, '  BAKED_BUILD_DATE = ''', ABuildDate, ''';');
   finally
     CloseFile(F);
   end;
 end;
 
-procedure PrintVersion(const AVersion, ACommit: string);
+procedure PrintVersion(const AVersion, ACommit, ABuildDate: string);
 begin
-  WriteLn('Version: ', AVersion, ' (', ACommit, ')');
+  WriteLn('Version: ', AVersion, ' (', ACommit, ') built ', ABuildDate);
   WriteLn('');
 end;
 
@@ -449,8 +455,9 @@ begin
   WriteLn('');
   GVersion := ComputeVersion;
   GCommit := ComputeCommit;
-  GenerateVersionInclude(GVersion, GCommit);
-  PrintVersion(GVersion, GCommit);
+  GBuildDate := ComputeBuildDate;
+  GenerateVersionInclude(GVersion, GCommit, GBuildDate);
+  PrintVersion(GVersion, GCommit, GBuildDate);
   PrintSourceStats;
 
   if BuildTriggers.Count = 0 then

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -271,6 +271,7 @@ A `const` global providing engine metadata and Goccia-owned utility APIs:
 |----------|------|-------------|
 | `os` | `string` | Operating system: `"darwin"`, `"linux"`, `"windows"`, `"freebsd"`, `"netbsd"`, `"openbsd"`, `"android"`, `"aix"`, `"solaris"`, or `"unknown"` |
 | `arch` | `string` | Processor architecture: `"x86_64"`, `"aarch64"`, `"x86"`, `"arm"`, `"powerpc64"`, `"powerpc"`, or `"unknown"` |
+| `date` | `string` | Build date in `YYYY-MM-DD` format (e.g., `"2026-04-20"`) |
 
 **`Goccia.semver`**
 

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1108,6 +1108,8 @@ begin
     TGocciaStringLiteralValue.Create(GetBuildOS), [pfEnumerable]));
   BuildObj.DefineProperty('arch', TGocciaPropertyDescriptorData.Create(
     TGocciaStringLiteralValue.Create(GetBuildArch), [pfEnumerable]));
+  BuildObj.DefineProperty('date', TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(GetBuildDate), [pfEnumerable]));
 
   ShimsArray := TGocciaArrayValue.Create;
   for I := 0 to FShims.Count - 1 do

--- a/source/units/Goccia.Runtime.Bootstrap.pas
+++ b/source/units/Goccia.Runtime.Bootstrap.pas
@@ -582,6 +582,8 @@ begin
     TGocciaStringLiteralValue.Create(GetBuildOS), [pfEnumerable]));
   BuildObj.DefineProperty('arch', TGocciaPropertyDescriptorData.Create(
     TGocciaStringLiteralValue.Create(GetBuildArch), [pfEnumerable]));
+  BuildObj.DefineProperty('date', TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(GetBuildDate), [pfEnumerable]));
 
   ShimsArray := TGocciaArrayValue.Create;
   if Assigned(FShims) then

--- a/source/units/Goccia.Version.pas
+++ b/source/units/Goccia.Version.pas
@@ -6,6 +6,7 @@ interface
 
 function GetVersion: string;
 function GetCommit: string;
+function GetBuildDate: string;
 
 implementation
 
@@ -19,6 +20,11 @@ end;
 function GetCommit: string;
 begin
   Result := BAKED_COMMIT;
+end;
+
+function GetBuildDate: string;
+begin
+  Result := BAKED_BUILD_DATE;
 end;
 
 end.


### PR DESCRIPTION
## Summary
- Adds a baked build date to generated version metadata during the build.
- Exposes the build date through `GetBuildDate()` and makes it available on runtime build info objects as `build.date`.
- Updates the build script to print the build date alongside version and commit information.
