### PR TITLE
Fix BigInt Test262 compliance gaps

### DIFF
--- a/scripts/test262_harness/isConstructor.js
+++ b/scripts/test262_harness/isConstructor.js
@@ -1,20 +1,15 @@
-// test262 isConstructor.js -- GocciaScript-compatible reimplementation
-// GocciaScript does not have Reflect.construct, so we approximate by
-// attempting `new f()` and catching any TypeError.
+// test262 isConstructor.js — uses Reflect.construct to test [[Construct]]
+// Matches the official test262 harness: uses newTarget parameter to avoid
+// actually invoking the target's constructor logic.
 
 const isConstructor = (f) => {
   if (typeof f !== "function") {
     return false;
   }
   try {
-    new f();
+    Reflect.construct(class {}, [], f);
     return true;
   } catch (e) {
-    // TypeError from non-constructor, other errors from constructor body
-    if (e instanceof TypeError && /is not a constructor/.test(e.message)) {
-      return false;
-    }
-    // If it threw something else, it IS a constructor (the body just errored)
-    return true;
+    return false;
   }
 };

--- a/scripts/test262_harness/propertyHelper.js
+++ b/scripts/test262_harness/propertyHelper.js
@@ -2,7 +2,11 @@
 // Provides verifyProperty and related helpers for checking property descriptors.
 
 const verifyProperty = (obj, name, desc, options) => {
-  const actual = Object.getOwnPropertyDescriptor(obj, name);
+  // When test262 tests use `this` expecting the global object but the harness
+  // wraps them in an arrow function, `this` is undefined.  Fall back to
+  // globalThis so property-descriptor tests still work.
+  const target = obj ?? globalThis;
+  const actual = Object.getOwnPropertyDescriptor(target, name);
 
   if (actual === undefined) {
     throw new Test262Error(
@@ -64,7 +68,7 @@ const verifyProperty = (obj, name, desc, options) => {
 };
 
 const verifyNotEnumerable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   if (desc === undefined) {
     throw new Test262Error(
       "Expected property '" + String(name) + "' to exist on object"
@@ -78,7 +82,7 @@ const verifyNotEnumerable = (obj, name) => {
 };
 
 const verifyEnumerable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   if (!desc || !desc.enumerable) {
     throw new Test262Error(
       "Expected " + String(name) + " to be enumerable"
@@ -87,7 +91,7 @@ const verifyEnumerable = (obj, name) => {
 };
 
 const verifyNotWritable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   if (desc === undefined) {
     throw new Test262Error(
       "Expected property '" + String(name) + "' to exist on object"
@@ -101,7 +105,7 @@ const verifyNotWritable = (obj, name) => {
 };
 
 const verifyWritable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   if (!desc || !desc.writable) {
     throw new Test262Error(
       "Expected " + String(name) + " to be writable"
@@ -110,7 +114,7 @@ const verifyWritable = (obj, name) => {
 };
 
 const verifyNotConfigurable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   if (desc === undefined) {
     throw new Test262Error(
       "Expected property '" + String(name) + "' to exist on object"
@@ -124,7 +128,7 @@ const verifyNotConfigurable = (obj, name) => {
 };
 
 const verifyConfigurable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   if (!desc || !desc.configurable) {
     throw new Test262Error(
       "Expected " + String(name) + " to be configurable"
@@ -133,16 +137,16 @@ const verifyConfigurable = (obj, name) => {
 };
 
 const isConfigurable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   return desc !== undefined && desc.configurable === true;
 };
 
 const isEnumerable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   return desc !== undefined && desc.enumerable === true;
 };
 
 const isWritable = (obj, name) => {
-  const desc = Object.getOwnPropertyDescriptor(obj, name);
+  const desc = Object.getOwnPropertyDescriptor(obj ?? globalThis, name);
   return desc !== undefined && desc.writable === true;
 };

--- a/scripts/test262_harness/temporalHelpers.js
+++ b/scripts/test262_harness/temporalHelpers.js
@@ -1,8 +1,8 @@
 // test262 temporalHelpers.js -- GocciaScript-compatible reimplementation
 // Provides the TemporalHelpers object used by Temporal test262 tests.
 // Covers the most-used assertion methods; less-common helpers that require
-// unsupported features (BigInt literals, Object.defineProperty observers)
-// are stubbed as no-ops or simplified.
+// unsupported features (Object.defineProperty observers) are stubbed or
+// simplified.
 
 const ASCII_IDENTIFIER = /^[$_a-zA-Z][$_a-zA-Z0-9]*$/;
 
@@ -269,11 +269,191 @@ const TemporalHelpers = {
   },
 
   checkSubclassingIgnored(...args) {
-    // Simplified: subclassing checks require Reflect.construct (not supported)
+    this.checkSubclassConstructorNotObject(...args);
+    this.checkSubclassConstructorUndefined(...args);
+    this.checkSubclassConstructorThrows(...args);
+    this.checkSubclassConstructorNotCalled(...args);
+    this.checkSubclassSpeciesInvalidResult(...args);
+    this.checkSubclassSpeciesNotAConstructor(...args);
+    this.checkSubclassSpeciesNull(...args);
+    this.checkSubclassSpeciesUndefined(...args);
+    this.checkSubclassSpeciesThrows(...args);
+  },
+
+  checkSubclassConstructorNotObject(construct, constructArgs, method, methodArgs, resultAssertions) {
+    const check = (value, description) => {
+      const instance = new construct(...constructArgs);
+      instance.constructor = value;
+      const result = instance[method](...methodArgs);
+      assert.sameValue(Object.getPrototypeOf(result), construct.prototype, description);
+      resultAssertions(result);
+    };
+    check(null, "null");
+    check(true, "true");
+    check("test", "string");
+    check(Symbol(), "Symbol");
+    check(7, "number");
+    check(7n, "bigint");
+  },
+
+  checkSubclassConstructorUndefined(construct, constructArgs, method, methodArgs, resultAssertions) {
+    let called = 0;
+    class MySubclass extends construct {
+      constructor() { ++called; super(...constructArgs); }
+    }
+    const instance = new MySubclass();
+    assert.sameValue(called, 1);
+    MySubclass.prototype.constructor = undefined;
+    const result = instance[method](...methodArgs);
+    assert.sameValue(called, 1);
+    assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+    resultAssertions(result);
+  },
+
+  checkSubclassConstructorThrows(construct, constructArgs, method, methodArgs, resultAssertions) {
+    class CustomError {}
+    const instance = new construct(...constructArgs);
+    Object.defineProperty(instance, "constructor", {
+      get() { throw new CustomError(); }
+    });
+    const result = instance[method](...methodArgs);
+    assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+    resultAssertions(result);
+  },
+
+  checkSubclassConstructorNotCalled(construct, constructArgs, method, methodArgs, resultAssertions) {
+    let called = 0;
+    class MySubclass extends construct {
+      constructor() { ++called; super(...constructArgs); }
+    }
+    const instance = new MySubclass();
+    assert.sameValue(called, 1);
+    const result = instance[method](...methodArgs);
+    assert.sameValue(called, 1);
+    assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+    resultAssertions(result);
+  },
+
+  checkSubclassSpeciesInvalidResult(construct, constructArgs, method, methodArgs, resultAssertions) {
+    const check = (value, description) => {
+      const instance = new construct(...constructArgs);
+      instance.constructor = { [Symbol.species]: () => value };
+      const result = instance[method](...methodArgs);
+      assert.sameValue(Object.getPrototypeOf(result), construct.prototype, description);
+      resultAssertions(result);
+    };
+    check(undefined, "undefined");
+    check(null, "null");
+    check(true, "true");
+    check("test", "string");
+    check(Symbol(), "Symbol");
+    check(7, "number");
+    check(7n, "bigint");
+    check({}, "plain object");
+  },
+
+  checkSubclassSpeciesNotAConstructor(construct, constructArgs, method, methodArgs, resultAssertions) {
+    const check = (value, description) => {
+      const instance = new construct(...constructArgs);
+      instance.constructor = { [Symbol.species]: value };
+      const result = instance[method](...methodArgs);
+      assert.sameValue(Object.getPrototypeOf(result), construct.prototype, description);
+      resultAssertions(result);
+    };
+    check(true, "true");
+    check("test", "string");
+    check(Symbol(), "Symbol");
+    check(7, "number");
+    check(7n, "bigint");
+    check({}, "plain object");
+  },
+
+  checkSubclassSpeciesNull(construct, constructArgs, method, methodArgs, resultAssertions) {
+    let called = 0;
+    class MySubclass extends construct {
+      constructor() { ++called; super(...constructArgs); }
+    }
+    const instance = new MySubclass();
+    assert.sameValue(called, 1);
+    MySubclass.prototype.constructor = { [Symbol.species]: null };
+    const result = instance[method](...methodArgs);
+    assert.sameValue(called, 1);
+    assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+    resultAssertions(result);
+  },
+
+  checkSubclassSpeciesUndefined(construct, constructArgs, method, methodArgs, resultAssertions) {
+    let called = 0;
+    class MySubclass extends construct {
+      constructor() { ++called; super(...constructArgs); }
+    }
+    const instance = new MySubclass();
+    assert.sameValue(called, 1);
+    MySubclass.prototype.constructor = { [Symbol.species]: undefined };
+    const result = instance[method](...methodArgs);
+    assert.sameValue(called, 1);
+    assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+    resultAssertions(result);
+  },
+
+  checkSubclassSpeciesThrows(construct, constructArgs, method, methodArgs, resultAssertions) {
+    class CustomError {}
+    const instance = new construct(...constructArgs);
+    instance.constructor = {
+      get [Symbol.species]() { throw new CustomError(); },
+    };
+    const result = instance[method](...methodArgs);
+    assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
   },
 
   checkSubclassingIgnoredStatic(...args) {
-    // Simplified: subclassing checks require Reflect.construct (not supported)
+    this.checkStaticInvalidReceiver(...args);
+    this.checkStaticReceiverNotCalled(...args);
+    this.checkThisValueNotCalled(...args);
+  },
+
+  checkStaticInvalidReceiver(construct, method, methodArgs, resultAssertions) {
+    const check = (value, description) => {
+      const result = construct[method].apply(value, methodArgs);
+      assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+      resultAssertions(result);
+    };
+    check(undefined, "undefined");
+    check(null, "null");
+    check(true, "true");
+    check("test", "string");
+    check(Symbol(), "symbol");
+    check(7, "number");
+    check(7n, "bigint");
+    check({}, "Non-callable object");
+  },
+
+  checkStaticReceiverNotCalled(construct, method, methodArgs, resultAssertions) {
+    const check = (value, description) => {
+      const receiver = () => value;
+      const result = construct[method].apply(receiver, methodArgs);
+      assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+      resultAssertions(result);
+    };
+    check(undefined, "undefined");
+    check(null, "null");
+    check(true, "true");
+    check("test", "string");
+    check(Symbol(), "symbol");
+    check(7, "number");
+    check(7n, "bigint");
+    check({}, "Non-callable object");
+  },
+
+  checkThisValueNotCalled(construct, method, methodArgs, resultAssertions) {
+    let called = false;
+    class MySubclass extends construct {
+      constructor(...args) { called = true; super(...args); }
+    }
+    const result = MySubclass[method](...methodArgs);
+    assert.sameValue(called, false);
+    assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+    resultAssertions(result);
   },
 
   checkPlainDateTimeConversionFastPath(func, message = "checkPlainDateTimeConversionFastPath") {

--- a/scripts/test262_harness/testTypedArray.js
+++ b/scripts/test262_harness/testTypedArray.js
@@ -1,6 +1,6 @@
 // test262 testTypedArray.js -- GocciaScript-compatible reimplementation
 // Provides TypedArray constructor lists and iteration helpers.
-// Omits BigInt typed arrays (GocciaScript does not support BigInt).
+// Omits BigInt typed arrays (BigInt64Array/BigUint64Array are not implemented).
 
 const floatArrayConstructors = [
   Float64Array,
@@ -120,7 +120,7 @@ const testWithTypedArrayConstructors = (f, constructors, includeArgFactories, ex
 };
 
 const testWithBigIntTypedArrayConstructors = (f, constructors, includeArgFactories, excludeArgFactories) => {
-  // GocciaScript does not support BigInt; this is a no-op.
+  // BigInt64Array/BigUint64Array are not implemented; this is a no-op.
 };
 
 const nonAtomicsFriendlyTypedArrayConstructors = [...floatArrayConstructors, Uint8ClampedArray];

--- a/source/shared/BigInteger.pas
+++ b/source/shared/BigInteger.pas
@@ -365,6 +365,7 @@ class function TBigInteger.FromDouble(const AValue: Double): TBigInteger;
 var
   V: Double;
   Limb: Cardinal;
+  DecStr: string;
 begin
   if IsNaN(AValue) or IsInfinite(AValue) then
     raise Exception.Create('Cannot convert non-finite number to BigInt');
@@ -380,20 +381,11 @@ begin
   if (AValue >= -9007199254740992.0) and (AValue <= 9007199254740992.0) then
     Exit(FromInt64(Trunc(AValue)));
 
-  Result.FNegative := AValue < 0;
-  V := Abs(AValue);
-  Result.FLimbs := nil;
-
-  while V >= 1 do
-  begin
-    {$Q-}{$R-}
-    Limb := Cardinal(Trunc(FMod(V, LIMB_BASE)));
-    {$IFDEF PRODUCTION}{$Q-}{$R-}{$ELSE}{$Q+}{$R+}{$ENDIF}
-    SetLength(Result.FLimbs, Length(Result.FLimbs) + 1);
-    Result.FLimbs[High(Result.FLimbs)] := Limb;
-    V := Int(V / LIMB_BASE);
-  end;
-  Result.Normalize;
+  // For values above 2^53 (representable as aligned integers in IEEE 754),
+  // convert via decimal string to avoid FPC AArch64 FMod precision bugs.
+  // FormatFloat('0', v) renders the exact integer without scientific notation.
+  DecStr := FormatFloat('0', AValue);
+  Result := FromDecimalString(DecStr);
 end;
 
 class function TBigInteger.FromDecimalString(const AValue: string): TBigInteger;

--- a/source/units/Goccia.Builtins.GlobalBigInt.pas
+++ b/source/units/Goccia.Builtins.GlobalBigInt.pas
@@ -40,10 +40,14 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.ObjectModel.Types,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.HoleValue,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.ObjectValue;
+  Goccia.Values.ObjectValue,
+  Goccia.Values.SymbolValue,
+  Goccia.Values.ToPrimitive;
 
 threadvar
   FStaticMembers: TArray<TGocciaMemberDefinition>;
@@ -51,6 +55,7 @@ threadvar
 constructor TGocciaGlobalBigInt.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
   PrototypeInitializer: TGocciaBigIntValue;
+  Proto: TGocciaObjectValue;
 begin
   inherited Create(AName, AScope, AThrowError);
 
@@ -59,13 +64,14 @@ begin
   PrototypeInitializer.InitializePrototype;
 
   // Create the BigInt function (callable, converts values to BigInt)
+  // BigInt implements [[Construct]] but rejects new target inside the body
   FBigIntFunction := TGocciaNativeFunctionValue.Create(BigIntConstructor, 'BigInt', 1);
 
   // Register static methods on the BigInt function
   with TGocciaMemberCollection.Create do
   try
-    AddMethod(BigIntAsIntN, 2, gmkStaticMethod);
-    AddMethod(BigIntAsUintN, 2, gmkStaticMethod);
+    AddMethod(BigIntAsIntN, 2, gmkStaticMethod, [gmfNotConstructable]);
+    AddMethod(BigIntAsUintN, 2, gmkStaticMethod, [gmfNotConstructable]);
     FStaticMembers := ToDefinitions;
   finally
     Free;
@@ -74,8 +80,21 @@ begin
   FStaticMembers[1].ExposedName := 'asUintN';
   RegisterMemberDefinitions(FBigIntFunction, FStaticMembers);
 
-  // Expose BigInt.prototype
-  FBigIntFunction.AssignProperty(PROP_PROTOTYPE, TGocciaBigIntValue.SharedPrototype);
+  // Set up BigInt.prototype
+  Proto := TGocciaObjectValue(TGocciaBigIntValue.SharedPrototype);
+
+  // ES2026 §21.2.3.1 BigInt.prototype.constructor
+  Proto.DefineProperty(PROP_CONSTRUCTOR,
+    TGocciaPropertyDescriptorData.Create(FBigIntFunction, [pfWritable, pfConfigurable]));
+
+  // ES2026 §21.2.3.5 BigInt.prototype[@@toStringTag]
+  Proto.DefineSymbolProperty(TGocciaSymbolValue.WellKnownToStringTag,
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaStringLiteralValue.Create('BigInt'), [pfConfigurable]));
+
+  // Expose BigInt.prototype as non-writable, non-enumerable, non-configurable
+  FBigIntFunction.DefineProperty(PROP_PROTOTYPE,
+    TGocciaPropertyDescriptorData.Create(Proto, []));
 
   // Bind BigInt in scope
   AScope.DefineLexicalBinding(AName, FBigIntFunction, dtLet);
@@ -89,6 +108,11 @@ var
   NumVal: Double;
   StrVal: string;
 begin
+  // ES2026 §21.2.1.1 Step 1: If NewTarget is not undefined, throw TypeError
+  if AThisValue is TGocciaHoleValue then
+    ThrowTypeError('Cannot use ''new'' with BigInt',
+      'Use BigInt(value) without ''new'' to convert to BigInt');
+
   if AArgs.Length = 0 then
     ThrowTypeError(Format(SErrorBigIntInvalidConversion, ['undefined']),
       SSuggestBigIntNoImplicitConversion);
@@ -203,24 +227,79 @@ begin
   Result := Trunc(IntegerIndex);
 end;
 
+// ES2026 §7.1.13 ToBigInt(argument) — forward declaration
+function ToBigIntValue(const AValue: TGocciaValue): TGocciaBigIntValue; forward;
+
+// ES2026 §7.1.13 ToBigInt — apply ToPrimitive then convert primitive to BigInt
+function ToBigIntValue(const AValue: TGocciaValue): TGocciaBigIntValue;
+var
+  Prim: TGocciaValue;
+  StrVal: string;
+begin
+  // Step 1: If argument is an object, apply ToPrimitive(argument, number)
+  if (AValue is TGocciaObjectValue) and not (AValue is TGocciaBigIntValue) then
+  begin
+    Prim := ToPrimitive(AValue, tphNumber);
+    Exit(ToBigIntValue(Prim));
+  end;
+
+  if AValue is TGocciaBigIntValue then
+    Exit(TGocciaBigIntValue(AValue));
+
+  if AValue is TGocciaBooleanLiteralValue then
+  begin
+    if TGocciaBooleanLiteralValue(AValue).Value then
+      Result := TGocciaBigIntValue.BigIntOne
+    else
+      Result := TGocciaBigIntValue.BigIntZero;
+    Exit;
+  end;
+
+  if AValue is TGocciaStringLiteralValue then
+  begin
+    StrVal := Trim(TGocciaStringLiteralValue(AValue).Value);
+    if StrVal = '' then
+      Exit(TGocciaBigIntValue.BigIntZero);
+    try
+      if (Length(StrVal) >= 3) and (StrVal[1] = '0') then
+      begin
+        if (StrVal[2] = 'x') or (StrVal[2] = 'X') then
+          Exit(TGocciaBigIntValue.Create(
+            TBigInteger.FromHexString(Copy(StrVal, 3, Length(StrVal) - 2))))
+        else if (StrVal[2] = 'o') or (StrVal[2] = 'O') then
+          Exit(TGocciaBigIntValue.Create(
+            TBigInteger.FromOctalString(Copy(StrVal, 3, Length(StrVal) - 2))))
+        else if (StrVal[2] = 'b') or (StrVal[2] = 'B') then
+          Exit(TGocciaBigIntValue.Create(
+            TBigInteger.FromBinaryString(Copy(StrVal, 3, Length(StrVal) - 2))));
+      end;
+      Result := TGocciaBigIntValue.Create(TBigInteger.FromDecimalString(StrVal));
+    except
+      ThrowSyntaxError(Format(SErrorBigIntInvalidConversion, [
+        '''' + TGocciaStringLiteralValue(AValue).Value + '''']),
+        SSuggestBigIntNoImplicitConversion);
+      Result := nil;
+    end;
+    Exit;
+  end;
+
+  // Number, undefined, null, symbol, object — all throw TypeError
+  ThrowTypeError(Format(SErrorBigIntInvalidConversion, [AValue.TypeName]),
+    SSuggestBigIntNoImplicitConversion);
+  Result := nil;
+end;
+
 // ES2026 §21.2.2.1 BigInt.asIntN(bits, bigint)
 function TGocciaGlobalBigInt.BigIntAsIntN(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   Bits: Integer;
-  BigIntArg: TGocciaValue;
+  BigIntVal: TGocciaBigIntValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'BigInt.asIntN', ThrowError);
-
   Bits := BigIntToIndex(AArgs.GetElement(0));
+  BigIntVal := ToBigIntValue(AArgs.GetElement(1));
 
-  BigIntArg := AArgs.GetElement(1);
-  if not (BigIntArg is TGocciaBigIntValue) then
-    ThrowTypeError(Format(SErrorBigIntInvalidConversion, [BigIntArg.TypeName]),
-      SSuggestBigIntNoImplicitConversion);
-
-  Result := TGocciaBigIntValue.Create(
-    TGocciaBigIntValue(BigIntArg).Value.AsIntN(Bits));
+  Result := TGocciaBigIntValue.Create(BigIntVal.Value.AsIntN(Bits));
 end;
 
 // ES2026 §21.2.2.2 BigInt.asUintN(bits, bigint)
@@ -228,19 +307,12 @@ function TGocciaGlobalBigInt.BigIntAsUintN(const AArgs: TGocciaArgumentsCollecti
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   Bits: Integer;
-  BigIntArg: TGocciaValue;
+  BigIntVal: TGocciaBigIntValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'BigInt.asUintN', ThrowError);
-
   Bits := BigIntToIndex(AArgs.GetElement(0));
+  BigIntVal := ToBigIntValue(AArgs.GetElement(1));
 
-  BigIntArg := AArgs.GetElement(1);
-  if not (BigIntArg is TGocciaBigIntValue) then
-    ThrowTypeError(Format(SErrorBigIntInvalidConversion, [BigIntArg.TypeName]),
-      SSuggestBigIntNoImplicitConversion);
-
-  Result := TGocciaBigIntValue.Create(
-    TGocciaBigIntValue(BigIntArg).Value.AsUintN(Bits));
+  Result := TGocciaBigIntValue.Create(BigIntVal.Value.AsUintN(Bits));
 end;
 
 end.

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -49,6 +49,8 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
+  Goccia.Values.HoleValue,
+  Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -127,12 +129,25 @@ begin
 end;
 
 // ES2026 §28.1.2 Reflect.construct(target, argumentsList [, newTarget])
+// ES2026 §7.2.4 IsConstructor(argument) — check if a value can be used with new
+function IsConstructorValue(const AValue: TGocciaValue): Boolean;
+begin
+  if AValue is TGocciaClassValue then
+    Exit(True);
+  if (AValue is TGocciaNativeFunctionValue) and
+     not TGocciaNativeFunctionValue(AValue).NotConstructable then
+    Exit(True);
+  Result := False;
+end;
+
 function TGocciaGlobalReflect.ReflectConstruct(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Target: TGocciaValue;
   ArgsList: TGocciaValue;
   NewTarget: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
+  ProtoValue: TGocciaValue;
+  NewTargetClass: TGocciaClassValue;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Reflect.construct', ThrowError);
 
@@ -140,28 +155,48 @@ begin
   ArgsList := AArgs.GetElement(1);
 
   // Step 1: If IsConstructor(target) is false, throw a TypeError exception
-  if not (Target is TGocciaClassValue) then
+  if not IsConstructorValue(Target) then
     ThrowTypeError(SErrorReflectConstructTargetMustBeConstructor, SSuggestNotConstructorType);
 
   // Step 2: Let args be ? CreateListFromArrayLike(argumentsList)
   CallArgs := CreateListFromArrayLike(ArgsList, 'Reflect.construct');
   try
-    // Step 3: If IsConstructor(newTarget) is false, throw a TypeError exception
+    // Step 3: If newTarget provided, validate IsConstructor(newTarget)
     if AArgs.Length >= 3 then
     begin
       NewTarget := AArgs.GetElement(2);
-      if not (NewTarget is TGocciaClassValue) then
+      if not IsConstructorValue(NewTarget) then
         ThrowTypeError(SErrorReflectConstructNewTargetMustBeConstructor, SSuggestNotConstructorType);
     end
     else
       NewTarget := Target;
 
     // Step 4: Return ? Construct(target, args, newTarget)
-    // Pass newTarget so the instance prototype is set before the constructor runs
-    if NewTarget <> Target then
-      Result := TGocciaClassValue(Target).Instantiate(CallArgs, TGocciaClassValue(NewTarget))
+    if Target is TGocciaClassValue then
+    begin
+      if NewTarget is TGocciaClassValue then
+      begin
+        NewTargetClass := TGocciaClassValue(NewTarget);
+        if NewTargetClass <> TGocciaClassValue(Target) then
+          Result := TGocciaClassValue(Target).Instantiate(CallArgs, NewTargetClass)
+        else
+          Result := TGocciaClassValue(Target).Instantiate(CallArgs);
+      end
+      else
+      begin
+        // newTarget is a native function — get its .prototype for the instance
+        Result := TGocciaClassValue(Target).Instantiate(CallArgs);
+        ProtoValue := NewTarget.GetProperty(PROP_PROTOTYPE);
+        if ProtoValue is TGocciaObjectValue then
+          TGocciaObjectValue(Result).Prototype := TGocciaObjectValue(ProtoValue);
+      end;
+    end
     else
-      Result := TGocciaClassValue(Target).Instantiate(CallArgs);
+    begin
+      // Target is a native function constructor
+      Result := TGocciaNativeFunctionValue(Target).Call(CallArgs,
+        TGocciaHoleValue.HoleValue);
+    end;
   finally
     CallArgs.Free;
   end;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1075,10 +1075,14 @@ begin
   Scope := FInterpreter.GlobalScope;
   GlobalThisObj := TGocciaObjectValue.Create;
 
+  // ES2026 §19.1: Global object properties have
+  // { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }
   for Name in Scope.GetOwnBindingNames do
-    GlobalThisObj.AssignProperty(Name, Scope.GetValue(Name));
+    GlobalThisObj.DefineProperty(Name,
+      TGocciaPropertyDescriptorData.Create(Scope.GetValue(Name), [pfWritable, pfConfigurable]));
 
-  GlobalThisObj.AssignProperty('globalThis', GlobalThisObj);
+  GlobalThisObj.DefineProperty('globalThis',
+    TGocciaPropertyDescriptorData.Create(GlobalThisObj, [pfWritable, pfConfigurable]));
   Scope.DefineLexicalBinding('globalThis', GlobalThisObj, dtConst);
 end;
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2038,6 +2038,12 @@ begin
       end
       else if Callee is TGocciaNativeFunctionValue then
       begin
+        if TGocciaNativeFunctionValue(Callee).NotConstructable then
+          ThrowTypeError(
+            Format(SErrorNotConstructor,
+              [TGocciaNativeFunctionValue(Callee).Name]),
+            Format('''%s'' is not a constructor',
+              [TGocciaNativeFunctionValue(Callee).Name]));
         Result := TGocciaNativeFunctionValue(Callee).Call(Arguments,
           TGocciaHoleValue.HoleValue);
       end

--- a/source/units/Goccia.ObjectModel.Types.pas
+++ b/source/units/Goccia.ObjectModel.Types.pas
@@ -25,7 +25,8 @@ type
 
   TGocciaMemberFlag = (
     gmfNoFunctionPrototype,
-    gmfVariadic
+    gmfVariadic,
+    gmfNotConstructable
   );
   TGocciaMemberFlags = set of TGocciaMemberFlag;
 

--- a/source/units/Goccia.ObjectModel.pas
+++ b/source/units/Goccia.ObjectModel.pas
@@ -628,6 +628,8 @@ begin
   else
     Result := TGocciaNativeFunctionValue.Create(
       ADefinition.Callback, ADefinition.ExposedName, ADefinition.Arity);
+  if gmfNotConstructable in ADefinition.MemberFlags then
+    Result.NotConstructable := True;
 end;
 
 procedure ValidateMemberDefinition(const ADefinition: TGocciaMemberDefinition);

--- a/source/units/Goccia.Runtime.Bootstrap.pas
+++ b/source/units/Goccia.Runtime.Bootstrap.pas
@@ -549,10 +549,14 @@ begin
   Scope := FInterpreter.GlobalScope;
   GlobalThisObj := TGocciaObjectValue.Create;
 
+  // ES2026 §19.1: Global object properties have
+  // { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }
   for Name in Scope.GetOwnBindingNames do
-    GlobalThisObj.AssignProperty(Name, Scope.GetValue(Name));
+    GlobalThisObj.DefineProperty(Name,
+      TGocciaPropertyDescriptorData.Create(Scope.GetValue(Name), [pfWritable, pfConfigurable]));
 
-  GlobalThisObj.AssignProperty('globalThis', GlobalThisObj);
+  GlobalThisObj.DefineProperty('globalThis',
+    TGocciaPropertyDescriptorData.Create(GlobalThisObj, [pfWritable, pfConfigurable]));
   Scope.DefineLexicalBinding('globalThis', GlobalThisObj, dtConst);
 end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2565,6 +2565,12 @@ begin
 
   if AConstructor is TGocciaNativeFunctionValue then
   begin
+    if TGocciaNativeFunctionValue(AConstructor).NotConstructable then
+      ThrowTypeError(
+        Format(SErrorNotConstructor,
+          [TGocciaNativeFunctionValue(AConstructor).Name]),
+        Format('''%s'' is not a constructor',
+          [TGocciaNativeFunctionValue(AConstructor).Name]));
     ConstructorName := TGocciaNativeFunctionValue(AConstructor).Name;
     if Assigned(TGocciaCallStack.Instance) then
       TGocciaCallStack.Instance.Push(ConstructorName, '', 0, 0);

--- a/source/units/Goccia.Values.BigIntValue.pas
+++ b/source/units/Goccia.Values.BigIntValue.pas
@@ -114,9 +114,9 @@ begin
   begin
     Members := TGocciaMemberCollection.Create;
     try
-      Members.AddMethod(BigIntToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddMethod(BigIntValueOf, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-      Members.AddMethod(BigIntToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(BigIntToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype, gmfNotConstructable]);
+      Members.AddMethod(BigIntValueOf, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype, gmfNotConstructable]);
+      Members.AddMethod(BigIntToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype, gmfNotConstructable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;

--- a/source/units/Goccia.Values.NativeFunction.pas
+++ b/source/units/Goccia.Values.NativeFunction.pas
@@ -16,6 +16,7 @@ type
     FFunction: TGocciaNativeFunctionCallback;
     FName: string;
     FArity: Integer;
+    FNotConstructable: Boolean;
   protected
     function GetFunctionLength: Integer; override;
     function GetFunctionName: string; override;
@@ -28,6 +29,7 @@ type
     property NativeFunction: TGocciaNativeFunctionCallback read FFunction;
     property Name: string read FName;
     property Arity: Integer read FArity;
+    property NotConstructable: Boolean read FNotConstructable write FNotConstructable;
   end;
 
 


### PR DESCRIPTION
## Summary
- Tightened BigInt builtins to match Test262 and ES2026 expectations, including `BigInt.prototype` metadata and `BigInt.asIntN`/`asUintN` coercion behavior.
- Added constructor checks for native functions so `new BigInt()` and other non-constructable natives now throw consistent `TypeError`s in both interpreter and VM paths.
- Improved `Reflect.construct` handling, including constructor detection and `newTarget` prototype behavior for native and class constructors.
- Updated harness helpers so Test262 property and Temporal tests work more reliably in this runtime.
- Fixed BigInteger conversion for large IEEE-754 integer values by routing through decimal-string parsing.
