### PR TITLE
Recompute ZonedDateTime UTC offset after rounding (#358)

### DIFF
--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -1112,6 +1112,7 @@ function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeToString(const AArgs: TG
 var
   Zdt: TGocciaTemporalZonedDateTimeValue;
   LYear, LMonth, LDay, LHour, LMinute, LSecond, LMs, LUs, LNs: Integer;
+  SavedHour, SavedMinute, SavedSecond, SavedMs: Integer;
   OffsetSeconds: Integer;
   Arg: TGocciaValue;
   OptionsObj: TGocciaObjectValue;
@@ -1135,6 +1136,10 @@ begin
   end;
   ResolveTemporalToStringOptions(OptionsObj, FracDigits, Mode);
   CalDisp := GetCalendarDisplay(OptionsObj);
+  SavedHour := LHour;
+  SavedMinute := LMinute;
+  SavedSecond := LSecond;
+  SavedMs := LMs;
   ExtraDays := 0;
   RoundTimeForToString(LHour, LMinute, LSecond, LMs, LUs, LNs, ExtraDays, FracDigits, Mode);
   if ExtraDays <> 0 then
@@ -1146,11 +1151,18 @@ begin
     DateRec.Day := LDay;
   end;
 
-  // Recompute UTC offset after rounding — the rounded instant may have crossed
-  // a DST boundary, making the pre-rounding offset stale.
-  RoundedEpochMs := LocalToEpochMs(DateRec.Year, DateRec.Month, DateRec.Day,
-    LHour, LMinute, LSecond, LMs, Zdt.FTimeZone);
-  OffsetSeconds := GetUtcOffsetSeconds(Zdt.FTimeZone, RoundedEpochMs div MILLISECONDS_PER_SECOND);
+  // Recompute UTC offset only when rounding actually changed the local time.
+  // Unconditional recomputation via LocalToEpochMs would lose fold information
+  // for ambiguous wall-clock times during DST fall-back (first-match disambiguation).
+  if (ExtraDays <> 0) or (LHour <> SavedHour) or (LMinute <> SavedMinute) or
+     (LSecond <> SavedSecond) or (LMs <> SavedMs) then
+  begin
+    RoundedEpochMs := LocalToEpochMs(DateRec.Year, DateRec.Month, DateRec.Day,
+      LHour, LMinute, LSecond, LMs, Zdt.FTimeZone);
+    OffsetSeconds := GetUtcOffsetSeconds(Zdt.FTimeZone, RoundedEpochMs div MILLISECONDS_PER_SECOND);
+  end
+  else
+    OffsetSeconds := GetUtcOffsetSeconds(Zdt.FTimeZone, Zdt.FEpochMilliseconds div MILLISECONDS_PER_SECOND);
 
   if FracDigits = -2 then // smallestUnit: minute
     TimeStr := PadTwo(LHour) + ':' + PadTwo(LMinute)

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -1119,11 +1119,11 @@ var
   Mode: TTemporalRoundingMode;
   CalDisp: TTemporalCalendarDisplay;
   DateRec: TTemporalDateRecord;
+  RoundedEpochMs: Int64;
   TimeStr, S: string;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.toString');
   ComputeLocalComponents(Zdt, LYear, LMonth, LDay, LHour, LMinute, LSecond, LMs, LUs, LNs);
-  OffsetSeconds := GetUtcOffsetSeconds(Zdt.FTimeZone, Zdt.FEpochMilliseconds div MILLISECONDS_PER_SECOND);
 
   OptionsObj := nil;
   Arg := AArgs.GetElement(0);
@@ -1145,6 +1145,13 @@ begin
     DateRec.Month := LMonth;
     DateRec.Day := LDay;
   end;
+
+  // Recompute UTC offset after rounding — the rounded instant may have crossed
+  // a DST boundary, making the pre-rounding offset stale.
+  RoundedEpochMs := LocalToEpochMs(DateRec.Year, DateRec.Month, DateRec.Day,
+    LHour, LMinute, LSecond, LMs, Zdt.FTimeZone);
+  OffsetSeconds := GetUtcOffsetSeconds(Zdt.FTimeZone, RoundedEpochMs div MILLISECONDS_PER_SECOND);
+
   if FracDigits = -2 then // smallestUnit: minute
     TimeStr := PadTwo(LHour) + ':' + PadTwo(LMinute)
   else

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toString.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toString.js
@@ -14,4 +14,23 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.toString", () => {
     expect(s).toContain("2024-03-15");
     expect(s).toContain("13:45:30");
   });
+
+  test("rounding recomputes UTC offset after day carry", () => {
+    // 2024-03-15T23:59:59.500Z — rounding to seconds with halfExpand produces
+    // a carry into the next day. The offset must be recomputed from the rounded
+    // instant so the formatted string remains consistent.
+    const epochNs = 1710547199500n * 1000000n; // 2024-03-15T23:59:59.500Z
+    const zdt = new Temporal.ZonedDateTime(epochNs, "UTC");
+    const s = zdt.toString({ fractionalSecondDigits: 0, roundingMode: "halfExpand" });
+    expect(s).toBe("2024-03-16T00:00:00+00:00[UTC]");
+  });
+
+  test("rounding with fixed-offset timezone recomputes correctly", () => {
+    // 2024-03-15T23:59:59.500 in +05:30 — rounding to seconds carries into next day
+    // Epoch: local 23:59:59.500 +05:30 → UTC 18:29:59.500
+    const epochNs = 1710527399500n * 1000000n; // UTC 2024-03-15T18:29:59.500
+    const zdt = new Temporal.ZonedDateTime(epochNs, "+05:30");
+    const s = zdt.toString({ fractionalSecondDigits: 0, roundingMode: "halfExpand" });
+    expect(s).toBe("2024-03-16T00:00:00+05:30[+05:30]");
+  });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toString.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toString.js
@@ -33,4 +33,18 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.toString", () => {
     const s = zdt.toString({ fractionalSecondDigits: 0, roundingMode: "halfExpand" });
     expect(s).toBe("2024-03-16T00:00:00+05:30[+05:30]");
   });
+
+  test("no-op rounding preserves original offset from epoch", () => {
+    // When no rounding occurs (auto precision), the offset must come from the
+    // original epoch, not from re-resolving local fields through LocalToEpochMs.
+    // This prevents fold-flip for ambiguous wall-clock times during DST fall-back.
+    const epochNs = 1710510330000n * 1000000n; // 2024-03-15T13:45:30Z
+    const zdt = new Temporal.ZonedDateTime(epochNs, "+05:30");
+    const auto = zdt.toString(); // auto precision — no rounding
+    expect(auto).toContain("+05:30");
+    expect(auto).toContain("[+05:30]");
+    const nano = zdt.toString({ fractionalSecondDigits: 9 }); // nanosecond — no rounding
+    expect(nano).toContain("+05:30");
+    expect(nano).toContain("[+05:30]");
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes #358: `ZonedDateTimeToString` now recomputes the UTC offset **after** `RoundTimeForToString` (and any day carry), ensuring the formatted string reflects the correct offset for the rounded instant rather than the pre-rounding one.
- Uses `LocalToEpochMs` to derive the rounded epoch, then calls `GetUtcOffsetSeconds` on it.
- Adds two tests verifying correct offset after rounding-induced day carry (UTC and fixed-offset `+05:30`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)