### PR TITLE
Fix version constant propagation in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,9 @@ jobs:
           mkdir -p "build"
 
           # Generate baked version constants
-          DESCRIBE="$(git describe --tags --always 2>/dev/null || echo "")"
+          DESCRIBE="$(git describe --tags --always --match '[0-9]*' 2>/dev/null || echo "")"
           GC_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+          GC_BUILD_DATE="$(date -u +%Y-%m-%d)"
           if [ -z "$GC_COMMIT" ]; then GC_COMMIT="unknown"; fi
           if [ -z "$DESCRIBE" ] || ! echo "$DESCRIBE" | grep -q '\.'; then
             GC_VERSION="0.0.0-dev"
@@ -119,6 +120,7 @@ jobs:
             "const" \
             "  BAKED_VERSION = '$GC_VERSION';" \
             "  BAKED_COMMIT = '$GC_COMMIT';" \
+            "  BAKED_BUILD_DATE = '$GC_BUILD_DATE';" \
             > source/units/Goccia.Version.Generated.inc
 
           RTL_DIR="$PREFIX/lib/fpc/${FPC_VERSION}/units/${TARGET}/rtl"

--- a/build.pas
+++ b/build.pas
@@ -24,7 +24,7 @@ var
   Describe: string;
   DashPos: SizeInt;
 begin
-  if not RunCommand('git', ['describe', '--tags', '--always'], Describe) then
+  if not RunCommand('git', ['describe', '--tags', '--always', '--match', '[0-9]*'], Describe) then
     Describe := '';
   Describe := Trim(Describe);
 


### PR DESCRIPTION
## Summary
- Add missing `BAKED_BUILD_DATE` constant to the CI-generated `Goccia.Version.Generated.inc`, fixing `identifier not found` compilation failure introduced by #360
- Add `--match '[0-9]*'` to `git describe` in both `build.pas` and CI so the `nightly` tag no longer shadows release tags (resolves `0.6.1-dev` instead of `0.0.0-dev`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)