### PR TITLE
Add Function.prototype.constructor per ES spec

### DIFF
--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1010,6 +1010,7 @@ begin
 
   FunctionConstructor := TGocciaClassValue.Create('Function', nil);
   TGocciaFunctionBase.SetSharedPrototypeParent(FunctionConstructor.Prototype);
+  FunctionConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, FunctionConstructor);
   FInterpreter.GlobalScope.DefineLexicalBinding('Function', FunctionConstructor, dtConst);
 
   PerformanceConstructor := TGocciaPerformance.CreateInterfaceObject;

--- a/source/units/Goccia.Runtime.Bootstrap.pas
+++ b/source/units/Goccia.Runtime.Bootstrap.pas
@@ -487,6 +487,7 @@ begin
 
   FunctionConstructor := TGocciaClassValue.Create('Function', nil);
   TGocciaFunctionBase.SetSharedPrototypeParent(FunctionConstructor.Prototype);
+  FunctionConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, FunctionConstructor);
   FInterpreter.GlobalScope.DefineLexicalBinding('Function', FunctionConstructor, dtConst);
 
   PerformanceConstructor := TGocciaPerformance.CreateInterfaceObject;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -880,6 +880,7 @@ var
   Getter: TGocciaFunctionBase;
   Args: TGocciaArgumentsCollection;
   Current: TGocciaClassValue;
+  FuncProto: TGocciaObjectValue;
 begin
   if AName = PROP_PROTOTYPE then
   begin
@@ -905,6 +906,15 @@ begin
 
     Current := Current.FSuperClass;
   until not Assigned(Current);
+
+  // Fall through to Function.prototype chain (classes are functions per ES spec)
+  FuncProto := TGocciaFunctionBase.GetSharedPrototype;
+  if Assigned(FuncProto) then
+  begin
+    Result := FuncProto.GetProperty(AName);
+    if not (Result is TGocciaUndefinedLiteralValue) then
+      Exit;
+  end;
 
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -911,7 +911,7 @@ begin
   FuncProto := TGocciaFunctionBase.GetSharedPrototype;
   if Assigned(FuncProto) then
   begin
-    Result := FuncProto.GetProperty(AName);
+    Result := FuncProto.GetPropertyWithContext(AName, Self);
     if not (Result is TGocciaUndefinedLiteralValue) then
       Exit;
   end;

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -34,6 +34,7 @@ type
   public
     constructor Create;
     class procedure SetSharedPrototypeParent(const AParent: TGocciaObjectValue);
+    class function GetSharedPrototype: TGocciaFunctionSharedPrototype; static;
 
     // Override GetProperty to provide call, apply, bind methods and length/name
     function GetProperty(const AName: string): TGocciaValue; override;
@@ -273,6 +274,11 @@ begin
       TGarbageCollector.Instance.PinObject(FSharedPrototype);
   end;
   FSharedPrototype.Prototype := AParent;
+end;
+
+class function TGocciaFunctionBase.GetSharedPrototype: TGocciaFunctionSharedPrototype;
+begin
+  Result := FSharedPrototype;
 end;
 
 constructor TGocciaFunctionSharedPrototype.Create;

--- a/tests/built-ins/Function/prototype/constructor.js
+++ b/tests/built-ins/Function/prototype/constructor.js
@@ -1,0 +1,49 @@
+/*---
+description: Function.prototype.constructor
+features: [Function]
+---*/
+
+describe("Function.prototype.constructor", () => {
+  test("Function.prototype.constructor is Function", () => {
+    expect(Function.prototype.constructor).toBe(Function);
+  });
+
+  test("function instance .constructor is Function", () => {
+    const foo = () => {};
+    expect(foo.constructor).toBe(Function);
+  });
+
+  test("arrow function .constructor is Function", () => {
+    const arrow = () => {};
+    expect(arrow.constructor).toBe(Function);
+  });
+
+  test("method .constructor is Function", () => {
+    const obj = { method() {} };
+    expect(obj.method.constructor).toBe(Function);
+  });
+
+  test("class .constructor is Function", () => {
+    class Foo {}
+    expect(Foo.constructor).toBe(Function);
+  });
+
+  test("derived class .constructor is Function", () => {
+    class Base {}
+    class Derived extends Base {}
+    expect(Derived.constructor).toBe(Function);
+  });
+
+  test("class instance .constructor is the class", () => {
+    class Foo {}
+    const foo = new Foo();
+    expect(foo.constructor).toBe(Foo);
+  });
+
+  test("derived class instance .constructor is the derived class", () => {
+    class Base {}
+    class Derived extends Base {}
+    const d = new Derived();
+    expect(d.constructor).toBe(Derived);
+  });
+});

--- a/tests/built-ins/Function/prototype/constructor.js
+++ b/tests/built-ins/Function/prototype/constructor.js
@@ -8,11 +8,6 @@ describe("Function.prototype.constructor", () => {
     expect(Function.prototype.constructor).toBe(Function);
   });
 
-  test("function instance .constructor is Function", () => {
-    const foo = () => {};
-    expect(foo.constructor).toBe(Function);
-  });
-
   test("arrow function .constructor is Function", () => {
     const arrow = () => {};
     expect(arrow.constructor).toBe(Function);


### PR DESCRIPTION
## Summary
- Set `Function.prototype.constructor` to `Function` in both engine and runtime bootstrap initialization paths
- Add `GetSharedPrototype` accessor on `TGocciaFunctionBase` so `TGocciaClassValue` can fall through to the Function prototype chain
- Extend `TGocciaClassValue.GetProperty` to look up `Function.prototype` when a property isn't found in static members — classes are functions per ES spec and should inherit `constructor`, `call`, `apply`, `bind`

## Test plan
- [x] New `tests/built-ins/Function/prototype/constructor.js` covering:
  - `Function.prototype.constructor === Function`
  - Arrow functions, methods, classes, derived classes, and class instances
- [x] Full test suite passes (5864/5910 — 5 pre-existing FFI fixture failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)