### PR TITLE
Fix global descriptors for NaN, Infinity, and undefined

### DIFF
--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1077,15 +1077,24 @@ var
   GlobalThisObj: TGocciaObjectValue;
   Scope: TGocciaScope;
   Name: string;
+  Flags: TPropertyFlags;
 begin
   Scope := FInterpreter.GlobalScope;
   GlobalThisObj := TGocciaObjectValue.Create;
 
-  // ES2026 §19.1: Global object properties have
-  // { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }
   for Name in Scope.GetOwnBindingNames do
+  begin
+    // ES2026 §19.1: Value properties (NaN, Infinity, undefined) are
+    // { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+    // All other global object properties are
+    // { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+    if (Name = 'NaN') or (Name = 'Infinity') or (Name = 'undefined') then
+      Flags := []
+    else
+      Flags := [pfWritable, pfConfigurable];
     GlobalThisObj.DefineProperty(Name,
-      TGocciaPropertyDescriptorData.Create(Scope.GetValue(Name), [pfWritable, pfConfigurable]));
+      TGocciaPropertyDescriptorData.Create(Scope.GetValue(Name), Flags));
+  end;
 
   GlobalThisObj.DefineProperty('globalThis',
     TGocciaPropertyDescriptorData.Create(GlobalThisObj, [pfWritable, pfConfigurable]));

--- a/source/units/Goccia.Runtime.Bootstrap.pas
+++ b/source/units/Goccia.Runtime.Bootstrap.pas
@@ -552,15 +552,24 @@ var
   GlobalThisObj: TGocciaObjectValue;
   Scope: TGocciaScope;
   Name: string;
+  Flags: TPropertyFlags;
 begin
   Scope := FInterpreter.GlobalScope;
   GlobalThisObj := TGocciaObjectValue.Create;
 
-  // ES2026 §19.1: Global object properties have
-  // { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }
   for Name in Scope.GetOwnBindingNames do
+  begin
+    // ES2026 §19.1: Value properties (NaN, Infinity, undefined) are
+    // { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+    // All other global object properties are
+    // { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+    if (Name = 'NaN') or (Name = 'Infinity') or (Name = 'undefined') then
+      Flags := []
+    else
+      Flags := [pfWritable, pfConfigurable];
     GlobalThisObj.DefineProperty(Name,
-      TGocciaPropertyDescriptorData.Create(Scope.GetValue(Name), [pfWritable, pfConfigurable]));
+      TGocciaPropertyDescriptorData.Create(Scope.GetValue(Name), Flags));
+  end;
 
   GlobalThisObj.DefineProperty('globalThis',
     TGocciaPropertyDescriptorData.Create(GlobalThisObj, [pfWritable, pfConfigurable]));

--- a/tests/built-ins/global-properties/infinity.js
+++ b/tests/built-ins/global-properties/infinity.js
@@ -66,6 +66,25 @@ describe("Infinity as a global property", () => {
   });
 });
 
+describe("Infinity property descriptor on globalThis", () => {
+  test("Infinity is an own property of globalThis", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "Infinity");
+    expect(desc !== undefined).toBe(true);
+  });
+
+  test("Infinity has correct property descriptor flags", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "Infinity");
+    expect(desc.writable).toBe(false);
+    expect(desc.enumerable).toBe(false);
+    expect(desc.configurable).toBe(false);
+  });
+
+  test("Infinity descriptor value is Infinity", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "Infinity");
+    expect(desc.value).toBe(Infinity);
+  });
+});
+
 describe("Infinity immutability", () => {
   test("global Infinity cannot be reassigned", () => {
     expect(() => {

--- a/tests/built-ins/global-properties/nan.js
+++ b/tests/built-ins/global-properties/nan.js
@@ -40,6 +40,25 @@ describe("NaN as a global property", () => {
   });
 });
 
+describe("NaN property descriptor on globalThis", () => {
+  test("NaN is an own property of globalThis", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "NaN");
+    expect(desc !== undefined).toBe(true);
+  });
+
+  test("NaN has correct property descriptor flags", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "NaN");
+    expect(desc.writable).toBe(false);
+    expect(desc.enumerable).toBe(false);
+    expect(desc.configurable).toBe(false);
+  });
+
+  test("NaN descriptor value is NaN", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "NaN");
+    expect(Number.isNaN(desc.value)).toBe(true);
+  });
+});
+
 describe("NaN immutability", () => {
   test("global NaN cannot be reassigned", () => {
     expect(() => {

--- a/tests/built-ins/global-properties/undefined.js
+++ b/tests/built-ins/global-properties/undefined.js
@@ -41,6 +41,25 @@ describe("undefined as a global property", () => {
   });
 });
 
+describe("undefined property descriptor on globalThis", () => {
+  test("undefined is an own property of globalThis", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "undefined");
+    expect(desc !== undefined).toBe(true);
+  });
+
+  test("undefined has correct property descriptor flags", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "undefined");
+    expect(desc.writable).toBe(false);
+    expect(desc.enumerable).toBe(false);
+    expect(desc.configurable).toBe(false);
+  });
+
+  test("undefined descriptor value is undefined", () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, "undefined");
+    expect(desc.value).toBeUndefined();
+  });
+});
+
 describe("undefined immutability", () => {
   test("global undefined cannot be reassigned", () => {
     expect(() => {


### PR DESCRIPTION
## Summary
- Corrected `globalThis` property descriptors for the global value properties `NaN`, `Infinity`, and `undefined` so they are non-writable, non-enumerable, and non-configurable.
- Kept other global bindings on `globalThis` writable and configurable as before.
- Added tests covering descriptor flags and values for all three properties.

Fixes #374 