### PR TITLE
Honor root config precedence for per-file CLI options

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -162,7 +162,7 @@ All CLI options can also be set via a project configuration file. The CLI discov
 The first file found is loaded and applied as the **root config**. When running multiple files (e.g. via `GocciaTestRunner` or `GocciaBundler`), a **per-file config** is also discovered from each file's directory. The full precedence is:
 
 1. **CLI arguments** (highest priority — always win)
-2. **Per-file config** (`goccia.json` nearest to the file being processed)
+2. **Per-file config** (`goccia.toml`, `goccia.json5`, or `goccia.json` nearest to the file being processed)
 3. **Root config** (discovered from the entry path at startup)
 4. **System default** (engine defaults)
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -159,7 +159,12 @@ All CLI options can also be set via a project configuration file. The CLI discov
 2. `goccia.json5`
 3. `goccia.json`
 
-The first file found is loaded. CLI arguments override any values set in the config file.
+The first file found is loaded and applied as the **root config**. When running multiple files (e.g. via `GocciaTestRunner` or `GocciaBundler`), a **per-file config** is also discovered from each file's directory. The full precedence is:
+
+1. **CLI arguments** (highest priority — always win)
+2. **Per-file config** (`goccia.json` nearest to the file being processed)
+3. **Root config** (discovered from the entry path at startup)
+4. **System default** (engine defaults)
 
 ```json
 {

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -431,20 +431,12 @@ begin
     Exit;
 
   { ASI: CLI flag > per-file config > root config > default (false) }
-  if AEngineOptions.ASI.FromCommandLine then
-    AEngine.ASIEnabled := True
-  else if FindConfigEntry(AFileConfig, 'asi', ValueStr) then
-    AEngine.ASIEnabled := ValueStr = 'true'
-  else
-    AEngine.ASIEnabled := AEngineOptions.ASI.Present;
+  AEngine.ASIEnabled := ResolveFlagOption(
+    AEngineOptions.ASI, AFileConfig, 'asi');
 
   { compat-var: CLI flag > per-file config > root config > default (false) }
-  if AEngineOptions.CompatVar.FromCommandLine then
-    AEngine.VarEnabled := True
-  else if FindConfigEntry(AFileConfig, 'compat-var', ValueStr) then
-    AEngine.VarEnabled := ValueStr = 'true'
-  else
-    AEngine.VarEnabled := AEngineOptions.CompatVar.Present;
+  AEngine.VarEnabled := ResolveFlagOption(
+    AEngineOptions.CompatVar, AFileConfig, 'compat-var');
 
   { max-memory: CLI > per-file config > root config > system default.
     Always set explicitly so a previous file's per-file override does
@@ -454,9 +446,13 @@ begin
   begin
     if AEngineOptions.MaxMemory.FromCommandLine then
       GC.MaxBytes := AEngineOptions.MaxMemory.Value
-    else if FindConfigEntry(AFileConfig, 'max-memory', ValueStr) and
-            TryStrToInt64(ValueStr, MemoryLimit) then
-      GC.MaxBytes := MemoryLimit
+    else if FindConfigEntry(AFileConfig, 'max-memory', ValueStr) then
+    begin
+      if not TryStrToInt64(ValueStr, MemoryLimit) then
+        raise Exception.CreateFmt(
+          'Invalid max-memory value in config: %s', [ValueStr]);
+      GC.MaxBytes := MemoryLimit;
+    end
     else if AEngineOptions.MaxMemory.Present then
       GC.MaxBytes := AEngineOptions.MaxMemory.Value
     else

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -397,15 +397,6 @@ begin
     Include(Result, ggFFI);
 end;
 
-procedure ApplyMaxMemory(const AEngineOptions: TGocciaEngineOptions);
-var
-  GC: TGarbageCollector;
-begin
-  GC := TGarbageCollector.Instance;
-  if Assigned(GC) and AEngineOptions.MaxMemory.Present then
-    GC.MaxBytes := AEngineOptions.MaxMemory.Value;
-end;
-
 function TGocciaCLIApplication.DiscoverFileConfig(
   const AFileName: string): TConfigEntryArray;
 var
@@ -424,8 +415,10 @@ begin
     Result := ParseConfigFile(ConfigPath);
 end;
 
-{ Apply per-file config entries to the engine.  CLI options
-  always win; file config overrides the global default. }
+{ Apply per-file config entries to the engine.
+  Priority: CLI flag > per-file config > root config > default.
+  FromCommandLine distinguishes CLI-set options from root-config-set options
+  so that a per-file config can override a root-level config value. }
 procedure ApplyFileConfigToEngine(const AEngine: TGocciaEngine;
   const AEngineOptions: TGocciaEngineOptions;
   const AFileConfig: TConfigEntryArray);
@@ -437,27 +430,37 @@ begin
   if not Assigned(AEngineOptions) then
     Exit;
 
-  { ASI: CLI flag > file config > default (false) }
-  if AEngineOptions.ASI.Present then
+  { ASI: CLI flag > per-file config > root config > default (false) }
+  if AEngineOptions.ASI.FromCommandLine then
     AEngine.ASIEnabled := True
   else if FindConfigEntry(AFileConfig, 'asi', ValueStr) then
-    AEngine.ASIEnabled := ValueStr = 'true';
+    AEngine.ASIEnabled := ValueStr = 'true'
+  else
+    AEngine.ASIEnabled := AEngineOptions.ASI.Present;
 
-  { compat-var: CLI flag > file config > default (false) }
-  if AEngineOptions.CompatVar.Present then
+  { compat-var: CLI flag > per-file config > root config > default (false) }
+  if AEngineOptions.CompatVar.FromCommandLine then
     AEngine.VarEnabled := True
   else if FindConfigEntry(AFileConfig, 'compat-var', ValueStr) then
-    AEngine.VarEnabled := ValueStr = 'true';
-
-  { max-memory: CLI > file config > unlimited }
-  if AEngineOptions.MaxMemory.Present then
-    ApplyMaxMemory(AEngineOptions)
+    AEngine.VarEnabled := ValueStr = 'true'
   else
+    AEngine.VarEnabled := AEngineOptions.CompatVar.Present;
+
+  { max-memory: CLI > per-file config > root config > system default.
+    Always set explicitly so a previous file's per-file override does
+    not leak into subsequent files (GC.MaxBytes is process-global). }
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) then
   begin
-    GC := TGarbageCollector.Instance;
-    if Assigned(GC) and FindConfigEntry(AFileConfig, 'max-memory', ValueStr) and
-       TryStrToInt64(ValueStr, MemoryLimit) then
-      GC.MaxBytes := MemoryLimit;
+    if AEngineOptions.MaxMemory.FromCommandLine then
+      GC.MaxBytes := AEngineOptions.MaxMemory.Value
+    else if FindConfigEntry(AFileConfig, 'max-memory', ValueStr) and
+            TryStrToInt64(ValueStr, MemoryLimit) then
+      GC.MaxBytes := MemoryLimit
+    else if AEngineOptions.MaxMemory.Present then
+      GC.MaxBytes := AEngineOptions.MaxMemory.Value
+    else
+      GC.MaxBytes := GC.SuggestedMaxBytes;
   end;
 end;
 
@@ -602,6 +605,7 @@ procedure TGocciaCLIApplication.Execute;
 var
   Paths: TStringList;
   HelpText, ConfigPath, ConfigStartDir: string;
+  I: Integer;
 begin
   Configure;
 
@@ -628,6 +632,13 @@ begin
       Write(HelpText);
       Exit;
     end;
+
+    { Snapshot CLI origin: any option Present at this point was set
+      by the command line.  ApplyConfigFile below may set additional
+      options, but those will not be marked FromCommandLine. }
+    for I := 0 to High(FAllOptions) do
+      if FAllOptions[I].Present then
+        FAllOptions[I].MarkFromCommandLine;
 
     { Discover config file starting from the entry file's directory.
       Apply as defaults — options already set by CLI are skipped. }

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -527,8 +527,8 @@ begin
           LexEnd := GetNanoseconds;
 
           Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
-          Parser.AutomaticSemicolonInsertion := EngineOptions.ASI.Present;
-          Parser.VarDeclarationsEnabled := EngineOptions.CompatVar.Present;
+          Parser.AutomaticSemicolonInsertion := Engine.ASIEnabled;
+          Parser.VarDeclarationsEnabled := Engine.VarEnabled;
           try
             ProgramNode := Parser.Parse;
             ParseEnd := GetNanoseconds;

--- a/source/app/GocciaBundler.dpr
+++ b/source/app/GocciaBundler.dpr
@@ -197,22 +197,23 @@ var
   ConfigValue: string;
   EffectiveASI, EffectiveVar: Boolean;
 begin
-  { Resolve ASI and compat-var: CLI flag > per-file config > default }
+  { Resolve ASI and compat-var:
+    CLI flag > per-file config > root config > default (false). }
   FileConfig := DiscoverFileConfig(AFileName);
 
-  if EngineOptions.ASI.Present then
+  if EngineOptions.ASI.FromCommandLine then
     EffectiveASI := True
   else if FindConfigEntry(FileConfig, 'asi', ConfigValue) then
     EffectiveASI := ConfigValue = 'true'
   else
-    EffectiveASI := False;
+    EffectiveASI := EngineOptions.ASI.Present;
 
-  if EngineOptions.CompatVar.Present then
+  if EngineOptions.CompatVar.FromCommandLine then
     EffectiveVar := True
   else if FindConfigEntry(FileConfig, 'compat-var', ConfigValue) then
     EffectiveVar := ConfigValue = 'true'
   else
-    EffectiveVar := False;
+    EffectiveVar := EngineOptions.CompatVar.Present;
 
   CompiledModule := nil;
   ProgramNode := ParseSource(ASource, AFileName, EffectiveASI, EffectiveVar,

--- a/source/app/GocciaBundler.dpr
+++ b/source/app/GocciaBundler.dpr
@@ -194,26 +194,14 @@ var
   LexTimeNanoseconds, ParseTimeNanoseconds: Int64;
   SourceMap: TGocciaSourceMap;
   FileConfig: TConfigEntryArray;
-  ConfigValue: string;
   EffectiveASI, EffectiveVar: Boolean;
 begin
   { Resolve ASI and compat-var:
     CLI flag > per-file config > root config > default (false). }
   FileConfig := DiscoverFileConfig(AFileName);
-
-  if EngineOptions.ASI.FromCommandLine then
-    EffectiveASI := True
-  else if FindConfigEntry(FileConfig, 'asi', ConfigValue) then
-    EffectiveASI := ConfigValue = 'true'
-  else
-    EffectiveASI := EngineOptions.ASI.Present;
-
-  if EngineOptions.CompatVar.FromCommandLine then
-    EffectiveVar := True
-  else if FindConfigEntry(FileConfig, 'compat-var', ConfigValue) then
-    EffectiveVar := ConfigValue = 'true'
-  else
-    EffectiveVar := EngineOptions.CompatVar.Present;
+  EffectiveASI := ResolveFlagOption(EngineOptions.ASI, FileConfig, 'asi');
+  EffectiveVar := ResolveFlagOption(
+    EngineOptions.CompatVar, FileConfig, 'compat-var');
 
   CompiledModule := nil;
   ProgramNode := ParseSource(ASource, AFileName, EffectiveASI, EffectiveVar,

--- a/source/app/GocciaREPL.dpr
+++ b/source/app/GocciaREPL.dpr
@@ -145,8 +145,8 @@ begin
 
               Parser := TGocciaParser.Create(Tokens, REPL_FILE_NAME,
                 Lexer.SourceLines);
-              Parser.AutomaticSemicolonInsertion := EngineOptions.ASI.Present;
-              Parser.VarDeclarationsEnabled := EngineOptions.CompatVar.Present;
+              Parser.AutomaticSemicolonInsertion := Eng.ASIEnabled;
+              Parser.VarDeclarationsEnabled := Eng.VarEnabled;
               try
                 ProgramNode := Parser.Parse;
                 ParseEnd := GetNanoseconds;

--- a/source/shared/CLI.ConfigFile.Test.pas
+++ b/source/shared/CLI.ConfigFile.Test.pas
@@ -911,7 +911,8 @@ var
 begin
   Flag := TGocciaFlagOption.Create('asi', 'ASI');
   try
-    { Simulate root config setting asi=false (Present but not FromCommandLine) }
+    { Root config sets asi='false' — ApplyConfigEntries skips Apply for
+      flag value 'false', so Present remains False. }
     SetLength(Options, 1);
     Options[0] := Flag;
     SetLength(RootEntries, 1);

--- a/source/shared/CLI.ConfigFile.Test.pas
+++ b/source/shared/CLI.ConfigFile.Test.pas
@@ -69,6 +69,7 @@ type
     procedure TestResolveFlagOptionPerFileOverridesRoot;
     procedure TestResolveFlagOptionPerFileFalseOverridesRoot;
     procedure TestResolveFlagOptionFallsBackToRoot;
+    procedure TestResolveFlagOptionEmptyStringEnablesFlag;
   protected
     procedure BeforeAll; override;
     procedure AfterAll; override;
@@ -119,6 +120,7 @@ begin
   Test('ResolveFlagOption uses per-file config over root config', TestResolveFlagOptionPerFileOverridesRoot);
   Test('ResolveFlagOption per-file false overrides root true', TestResolveFlagOptionPerFileFalseOverridesRoot);
   Test('ResolveFlagOption falls back to root when no per-file config', TestResolveFlagOptionFallsBackToRoot);
+  Test('ResolveFlagOption treats empty string as enabled', TestResolveFlagOptionEmptyStringEnablesFlag);
 end;
 
 procedure TConfigFileTests.BeforeAll;
@@ -976,6 +978,24 @@ begin
 
     { No per-file config — should fall back to root (Present=True) }
     SetLength(FileConfig, 0);
+
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+  finally
+    Flag.Free;
+  end;
+end;
+
+procedure TConfigFileTests.TestResolveFlagOptionEmptyStringEnablesFlag;
+var
+  Flag: TGocciaFlagOption;
+  FileConfig: TConfigEntryArray;
+begin
+  Flag := TGocciaFlagOption.Create('asi', 'ASI');
+  try
+    { Per-file config with empty string — matches ApplyConfigEntries behavior }
+    SetLength(FileConfig, 1);
+    FileConfig[0].Key := 'asi';
+    FileConfig[0].Value := '';
 
     Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
   finally

--- a/source/shared/CLI.ConfigFile.Test.pas
+++ b/source/shared/CLI.ConfigFile.Test.pas
@@ -70,6 +70,7 @@ type
     procedure TestResolveFlagOptionPerFileFalseOverridesRoot;
     procedure TestResolveFlagOptionFallsBackToRoot;
     procedure TestResolveFlagOptionEmptyStringEnablesFlag;
+    procedure TestResolveFlagOptionDefaultsFalse;
   protected
     procedure BeforeAll; override;
     procedure AfterAll; override;
@@ -121,6 +122,7 @@ begin
   Test('ResolveFlagOption per-file false overrides root true', TestResolveFlagOptionPerFileFalseOverridesRoot);
   Test('ResolveFlagOption falls back to root when no per-file config', TestResolveFlagOptionFallsBackToRoot);
   Test('ResolveFlagOption treats empty string as enabled', TestResolveFlagOptionEmptyStringEnablesFlag);
+  Test('ResolveFlagOption defaults to False when nothing is set', TestResolveFlagOptionDefaultsFalse);
 end;
 
 procedure TConfigFileTests.BeforeAll;
@@ -999,6 +1001,22 @@ begin
     FileConfig[0].Value := '';
 
     Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+  finally
+    Flag.Free;
+  end;
+end;
+
+procedure TConfigFileTests.TestResolveFlagOptionDefaultsFalse;
+var
+  Flag: TGocciaFlagOption;
+  FileConfig: TConfigEntryArray;
+begin
+  Flag := TGocciaFlagOption.Create('asi', 'ASI');
+  try
+    { No CLI, no root config, no per-file config — should default to False }
+    SetLength(FileConfig, 0);
+
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(False);
   finally
     Flag.Free;
   end;

--- a/source/shared/CLI.ConfigFile.Test.pas
+++ b/source/shared/CLI.ConfigFile.Test.pas
@@ -63,6 +63,12 @@ type
     procedure TestFindConfigEntryReturnsMatch;
     procedure TestFindConfigEntryReturnsFalseWhenMissing;
     procedure TestFindConfigEntryFirstMatchWins;
+
+    { ResolveFlagOption }
+    procedure TestResolveFlagOptionCLIWins;
+    procedure TestResolveFlagOptionPerFileOverridesRoot;
+    procedure TestResolveFlagOptionPerFileFalseOverridesRoot;
+    procedure TestResolveFlagOptionFallsBackToRoot;
   protected
     procedure BeforeAll; override;
     procedure AfterAll; override;
@@ -108,6 +114,11 @@ begin
   Test('FindConfigEntry returns matching value', TestFindConfigEntryReturnsMatch);
   Test('FindConfigEntry returns false when key missing', TestFindConfigEntryReturnsFalseWhenMissing);
   Test('FindConfigEntry first match wins for duplicate keys', TestFindConfigEntryFirstMatchWins);
+
+  Test('ResolveFlagOption returns True when flag is from CLI', TestResolveFlagOptionCLIWins);
+  Test('ResolveFlagOption uses per-file config over root config', TestResolveFlagOptionPerFileOverridesRoot);
+  Test('ResolveFlagOption per-file false overrides root true', TestResolveFlagOptionPerFileFalseOverridesRoot);
+  Test('ResolveFlagOption falls back to root when no per-file config', TestResolveFlagOptionFallsBackToRoot);
 end;
 
 procedure TConfigFileTests.BeforeAll;
@@ -864,6 +875,112 @@ begin
 
   Expect<Boolean>(FindConfigEntry(Entries, 'alias', Value)).ToBe(True);
   Expect<string>(Value).ToBe('@/=./src/');
+end;
+
+{ ── ResolveFlagOption tests ─────────────────────────────────── }
+
+procedure TConfigFileTests.TestResolveFlagOptionCLIWins;
+var
+  Flag: TGocciaFlagOption;
+  FileConfig: TConfigEntryArray;
+begin
+  Flag := TGocciaFlagOption.Create('asi', 'ASI');
+  try
+    Flag.Apply('');
+    Flag.MarkFromCommandLine;
+
+    { Per-file config says false, but CLI should win }
+    SetLength(FileConfig, 1);
+    FileConfig[0].Key := 'asi';
+    FileConfig[0].Value := 'false';
+
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+  finally
+    Flag.Free;
+  end;
+end;
+
+procedure TConfigFileTests.TestResolveFlagOptionPerFileOverridesRoot;
+var
+  Flag: TGocciaFlagOption;
+  FileConfig: TConfigEntryArray;
+  Options: TGocciaOptionArray;
+  RootEntries: TConfigEntryArray;
+begin
+  Flag := TGocciaFlagOption.Create('asi', 'ASI');
+  try
+    { Simulate root config setting asi=false (Present but not FromCommandLine) }
+    SetLength(Options, 1);
+    Options[0] := Flag;
+    SetLength(RootEntries, 1);
+    RootEntries[0].Key := 'asi';
+    RootEntries[0].Value := 'false';
+    ApplyConfigEntries(RootEntries, Options);
+
+    { Per-file config says true — should override root }
+    SetLength(FileConfig, 1);
+    FileConfig[0].Key := 'asi';
+    FileConfig[0].Value := 'true';
+
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+  finally
+    Flag.Free;
+  end;
+end;
+
+procedure TConfigFileTests.TestResolveFlagOptionPerFileFalseOverridesRoot;
+var
+  Flag: TGocciaFlagOption;
+  FileConfig: TConfigEntryArray;
+  Options: TGocciaOptionArray;
+  RootEntries: TConfigEntryArray;
+begin
+  Flag := TGocciaFlagOption.Create('asi', 'ASI');
+  try
+    { Simulate root config setting asi=true (Present but not FromCommandLine) }
+    SetLength(Options, 1);
+    Options[0] := Flag;
+    SetLength(RootEntries, 1);
+    RootEntries[0].Key := 'asi';
+    RootEntries[0].Value := 'true';
+    ApplyConfigEntries(RootEntries, Options);
+    Expect<Boolean>(Flag.Present).ToBe(True);
+
+    { Per-file config says false — should override root }
+    SetLength(FileConfig, 1);
+    FileConfig[0].Key := 'asi';
+    FileConfig[0].Value := 'false';
+
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(False);
+  finally
+    Flag.Free;
+  end;
+end;
+
+procedure TConfigFileTests.TestResolveFlagOptionFallsBackToRoot;
+var
+  Flag: TGocciaFlagOption;
+  FileConfig: TConfigEntryArray;
+  Options: TGocciaOptionArray;
+  RootEntries: TConfigEntryArray;
+begin
+  Flag := TGocciaFlagOption.Create('asi', 'ASI');
+  try
+    { Simulate root config setting asi=true }
+    SetLength(Options, 1);
+    Options[0] := Flag;
+    SetLength(RootEntries, 1);
+    RootEntries[0].Key := 'asi';
+    RootEntries[0].Value := 'true';
+    ApplyConfigEntries(RootEntries, Options);
+
+    { No per-file config — should fall back to root (Present=True) }
+    SetLength(FileConfig, 0);
+
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+  finally
+    Flag.Free;
+  end;
 end;
 
 begin

--- a/source/shared/CLI.ConfigFile.pas
+++ b/source/shared/CLI.ConfigFile.pas
@@ -73,6 +73,15 @@ function DiscoverConfigFile(const AStartDirectory: string;
 function FindConfigEntry(const AEntries: TConfigEntryArray;
   const AKey: string; out AValue: string): Boolean;
 
+{ Resolve an effective boolean for a flag option using the
+  standard precedence: CLI flag > per-file config > root config >
+  default (False).  AFlag is the parsed option, AFileConfig the
+  per-file config entries, and AConfigKey the config key name
+  (e.g. 'asi', 'compat-var'). }
+function ResolveFlagOption(const AFlag: TGocciaFlagOption;
+  const AFileConfig: TConfigEntryArray;
+  const AConfigKey: string): Boolean;
+
 implementation
 
 uses
@@ -462,6 +471,22 @@ begin
       Exit(True);
     end;
   Result := False;
+end;
+
+{ ── Flag resolution ────────────────────────────────────────── }
+
+function ResolveFlagOption(const AFlag: TGocciaFlagOption;
+  const AFileConfig: TConfigEntryArray;
+  const AConfigKey: string): Boolean;
+var
+  ValueStr: string;
+begin
+  if AFlag.FromCommandLine then
+    Result := True
+  else if FindConfigEntry(AFileConfig, AConfigKey, ValueStr) then
+    Result := ValueStr = 'true'
+  else
+    Result := AFlag.Present;
 end;
 
 initialization

--- a/source/shared/CLI.ConfigFile.pas
+++ b/source/shared/CLI.ConfigFile.pas
@@ -484,7 +484,7 @@ begin
   if AFlag.FromCommandLine then
     Result := True
   else if FindConfigEntry(AFileConfig, AConfigKey, ValueStr) then
-    Result := ValueStr = 'true'
+    Result := (ValueStr = 'true') or (ValueStr = '')
   else
     Result := AFlag.Present;
 end;

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -20,6 +20,7 @@ type
     FHelpText: string;
     FGroup: string;
     FPresent: Boolean;
+    FFromCommandLine: Boolean;
   public
     constructor Create(const ALongName, AHelpText: string; const AGroup: string = '');
 
@@ -27,11 +28,17 @@ type
     function FormatForHelp: string; virtual; abstract;
     function ValidValues: string; virtual;
 
+    { Mark this option as having been set by the command line.
+      Called after ParseCommandLine so that per-file config can
+      distinguish CLI-set values from root-config-set values. }
+    procedure MarkFromCommandLine;
+
     property LongName: string read FLongName;
     property ShortName: string read FShortName write FShortName;
     property HelpText: string read FHelpText;
     property Group: string read FGroup;
     property Present: Boolean read FPresent;
+    property FromCommandLine: Boolean read FFromCommandLine;
   end;
 
   TGocciaOptionArray = array of TGocciaOptionBase;
@@ -236,6 +243,12 @@ begin
   FHelpText := AHelpText;
   FGroup := AGroup;
   FPresent := False;
+  FFromCommandLine := False;
+end;
+
+procedure TGocciaOptionBase.MarkFromCommandLine;
+begin
+  FFromCommandLine := True;
 end;
 
 function TGocciaOptionBase.ValidValues: string;

--- a/source/shared/CLI.Parser.Test.pas
+++ b/source/shared/CLI.Parser.Test.pas
@@ -6,6 +6,7 @@ uses
   SysUtils,
   TypInfo,
 
+  CLI.ConfigFile,
   CLI.Options,
   TestingPascalLibrary,
 
@@ -36,6 +37,9 @@ type
     procedure TestOptionListAddFlagAndString;
     procedure TestConcatOptionsMergesTwoArrays;
     procedure TestGenerateHelpText;
+    procedure TestFromCommandLineIsFalseInitially;
+    procedure TestMarkFromCommandLineSetsTrue;
+    procedure TestConfigAppliedOptionNotFromCommandLine;
   public
     procedure SetupTests; override;
   end;
@@ -60,6 +64,9 @@ begin
   Test('OptionList tracks added options', TestOptionListAddFlagAndString);
   Test('ConcatOptions merges two arrays', TestConcatOptionsMergesTwoArrays);
   Test('GenerateHelpText includes program name and option names', TestGenerateHelpText);
+  Test('FromCommandLine is False initially', TestFromCommandLineIsFalseInitially);
+  Test('MarkFromCommandLine sets FromCommandLine to True', TestMarkFromCommandLineSetsTrue);
+  Test('Config-applied option has Present but not FromCommandLine', TestConfigAppliedOptionNotFromCommandLine);
 end;
 
 { TGocciaFlagOption tests }
@@ -349,6 +356,58 @@ begin
     Expect<Boolean>(Pos('Output file path', HelpText) > 0).ToBe(True);
   finally
     List.Free;
+  end;
+end;
+
+{ FromCommandLine tests }
+
+procedure TCLIOptionsTests.TestFromCommandLineIsFalseInitially;
+var
+  Opt: TGocciaFlagOption;
+begin
+  Opt := TGocciaFlagOption.Create('asi', 'Enable ASI');
+  try
+    Expect<Boolean>(Opt.FromCommandLine).ToBe(False);
+  finally
+    Opt.Free;
+  end;
+end;
+
+procedure TCLIOptionsTests.TestMarkFromCommandLineSetsTrue;
+var
+  Opt: TGocciaFlagOption;
+begin
+  Opt := TGocciaFlagOption.Create('asi', 'Enable ASI');
+  try
+    Opt.Apply('');
+    Opt.MarkFromCommandLine;
+    Expect<Boolean>(Opt.Present).ToBe(True);
+    Expect<Boolean>(Opt.FromCommandLine).ToBe(True);
+  finally
+    Opt.Free;
+  end;
+end;
+
+procedure TCLIOptionsTests.TestConfigAppliedOptionNotFromCommandLine;
+var
+  Opt: TGocciaFlagOption;
+  Options: TGocciaOptionArray;
+  Entries: TConfigEntryArray;
+begin
+  Opt := TGocciaFlagOption.Create('asi', 'Enable ASI');
+  try
+    SetLength(Options, 1);
+    Options[0] := Opt;
+    SetLength(Entries, 1);
+    Entries[0].Key := 'asi';
+    Entries[0].Value := 'true';
+
+    ApplyConfigEntries(Entries, Options);
+
+    Expect<Boolean>(Opt.Present).ToBe(True);
+    Expect<Boolean>(Opt.FromCommandLine).ToBe(False);
+  finally
+    Opt.Free;
   end;
 end;
 


### PR DESCRIPTION
## Summary
- Added per-option CLI origin tracking so config loaded from the command line can be distinguished from root config defaults.
- Updated per-file config resolution to use the precedence `CLI > per-file config > root config > default` for `asi`, `compat-var`, and `max-memory`.
- Ensured `max-memory` is always reapplied per file so a previous file's GC limit does not leak into later files.
- Switched the benchmark runner and REPL to use the engine's resolved settings instead of raw option presence.

Fixes #379 