### PR TITLE
Handle EOF before REPL prompt on Windows

### DIFF
--- a/source/units/Goccia.REPL.LineEditor.pas
+++ b/source/units/Goccia.REPL.LineEditor.pas
@@ -288,6 +288,12 @@ begin
   {$IFDEF UNIX}
   Result := ReadLineRaw(APrompt, ALine);
   {$ELSE}
+  if System.Eof(Input) then
+  begin
+    Result := lrExit;
+    ALine := '';
+    Exit;
+  end;
   Result := lrLine;
   Write(APrompt);
   System.ReadLn(ALine);


### PR DESCRIPTION
## Summary
- Add an EOF guard in the REPL line editor on non-UNIX platforms before writing the prompt.
- Return `lrExit` immediately when `Input` is already at EOF, instead of attempting to read a line.
- Clear the current line buffer in the EOF path to keep REPL state consistent.

## Testing
- Not run (change is a small targeted fix in the REPL line editor).
- Verified by code review that the new branch only affects the non-UNIX prompt path before `ReadLn`.