### PR TITLE
Add unsafe Function constructor support

### DIFF
--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -449,6 +449,12 @@ begin
   else if FindConfigEntry(AFileConfig, 'compat-var', ValueStr) then
     AEngine.VarEnabled := ValueStr = 'true';
 
+  { unsafe-function-constructor: CLI flag > file config > default (false) }
+  if AEngineOptions.UnsafeFunctionConstructor.Present then
+    AEngine.FunctionConstructor.Enabled := True
+  else if FindConfigEntry(AFileConfig, 'unsafe-function-constructor', ValueStr) then
+    AEngine.FunctionConstructor.Enabled := ValueStr = 'true';
+
   { max-memory: CLI > file config > unlimited }
   if AEngineOptions.MaxMemory.Present then
     ApplyMaxMemory(AEngineOptions)

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -143,6 +143,7 @@ type
     FMaxMemory: TGocciaInt64Option;
     FMaxInstructions: TGocciaInt64Option;
     FUnsafeFFI: TGocciaFlagOption;
+    FUnsafeFunctionConstructor: TGocciaFlagOption;
     FStackSize: TGocciaIntegerOption;
     FCompatVar: TGocciaFlagOption;
   public
@@ -159,6 +160,7 @@ type
     property MaxMemory: TGocciaInt64Option read FMaxMemory;
     property MaxInstructions: TGocciaInt64Option read FMaxInstructions;
     property UnsafeFFI: TGocciaFlagOption read FUnsafeFFI;
+    property UnsafeFunctionConstructor: TGocciaFlagOption read FUnsafeFunctionConstructor;
     property StackSize: TGocciaIntegerOption read FStackSize;
     property CompatVar: TGocciaFlagOption read FCompatVar;
   end;
@@ -521,6 +523,8 @@ begin
     'Maximum execution steps before aborting', 'Engine');
   FUnsafeFFI := TGocciaFlagOption.Create('unsafe-ffi',
     'Enable the FFI global (foreign function interface)', 'Engine');
+  FUnsafeFunctionConstructor := TGocciaFlagOption.Create('unsafe-function-constructor',
+    'Enable the Function constructor (dynamic code generation)', 'Engine');
   FStackSize := TGocciaIntegerOption.Create('stack-size',
     'Maximum call stack depth (0 = no limit)', 'Engine');
   FCompatVar := TGocciaFlagOption.Create('compat-var',
@@ -537,6 +541,7 @@ begin
   FMaxMemory.Free;
   FMaxInstructions.Free;
   FUnsafeFFI.Free;
+  FUnsafeFunctionConstructor.Free;
   FStackSize.Free;
   FCompatVar.Free;
   inherited Destroy;
@@ -544,7 +549,7 @@ end;
 
 function TGocciaEngineOptions.Options: TGocciaOptionArray;
 begin
-  SetLength(Result, 10);
+  SetLength(Result, 11);
   Result[0] := FMode;
   Result[1] := FASI;
   Result[2] := FImportMap;
@@ -553,8 +558,9 @@ begin
   Result[5] := FMaxMemory;
   Result[6] := FMaxInstructions;
   Result[7] := FUnsafeFFI;
-  Result[8] := FStackSize;
-  Result[9] := FCompatVar;
+  Result[8] := FUnsafeFunctionConstructor;
+  Result[9] := FStackSize;
+  Result[10] := FCompatVar;
 end;
 
 { TGocciaCoverageOptions }

--- a/source/units/Goccia.Engine.Backend.pas
+++ b/source/units/Goccia.Engine.Backend.pas
@@ -34,6 +34,8 @@ type
       const AProgram: TGocciaProgram): TGocciaValue; override;
     procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
       const AContext: TGocciaEvaluationContext); override;
+    function ExecuteDynamicFunction(
+      const AProgram: TGocciaProgram): TGocciaValue; override;
     procedure ClearTransientCaches; override;
     function DefaultStrictTypes: Boolean; override;
 
@@ -125,6 +127,20 @@ begin
   finally
     Module.Free;
   end;
+end;
+
+function TGocciaBytecodeExecutor.ExecuteDynamicFunction(
+  const AProgram: TGocciaProgram): TGocciaValue;
+var
+  Module: TGocciaBytecodeModule;
+begin
+  Module := CompileToModule(AProgram);
+  // Patch method template name to 'anonymous' for Function constructor
+  if Module.TopLevel.FunctionCount > 0 then
+    Module.TopLevel.GetFunction(0).Name := 'anonymous';
+  // Retain the module: closures reference its function templates
+  FModuleModules.Add(Module);
+  Result := RunModule(Module);
 end;
 
 function TGocciaBytecodeExecutor.CompileToModule(

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -198,7 +198,8 @@ type
     procedure PrintParserWarnings(const AParser: TGocciaParser; const ASourceMap: TGocciaSourceMap = nil);
     procedure ThrowError(const AMessage: string; const ALine,
       AColumn: Integer);
-    function CompileDynamicFunction(const ASource: string): TGocciaFunctionBase;
+    function CompileDynamicFunction(const AParamsSources: array of string;
+      const ABodySource: string): TGocciaFunctionBase;
   public
     constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins); overload;
     constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AResolver: TGocciaModuleResolver); overload;
@@ -311,6 +312,7 @@ uses
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.BooleanObjectValue,
+  Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionValue,
   Goccia.Values.HeadersValue,
   Goccia.Values.MapValue,
@@ -1519,15 +1521,87 @@ begin
   raise TGocciaRuntimeError.Create(AMessage, ALine, AColumn, FSourcePath, FSourceLines);
 end;
 
-function TGocciaEngine.CompileDynamicFunction(const ASource: string): TGocciaFunctionBase;
+function TGocciaEngine.CompileDynamicFunction(
+  const AParamsSources: array of string;
+  const ABodySource: string): TGocciaFunctionBase;
 var
+  ParamStr, Source: string;
+  I: Integer;
   Lexer: TGocciaLexer;
   Tokens: TObjectList<TGocciaToken>;
   Parser: TGocciaParser;
   ProgramNode: TGocciaProgram;
   ResultValue: TGocciaValue;
 begin
-  Lexer := TGocciaLexer.Create(ASource, '<Function>');
+  // ES2026 §20.2.1.1: parse as  function anonymous(P) { body }
+  // We use method shorthand so the function gets its own this binding.
+  // The member access extracts the function from the wrapper object.
+  //
+  // Params and body are parsed as separate, self-contained programs first.
+  // This prevents injection: a crafted body that tries to close the method
+  // wrapper will fail validation because it will have unmatched braces when
+  // parsed as a standalone function body.
+  ParamStr := '';
+  for I := 0 to High(AParamsSources) do
+  begin
+    if I > 0 then
+      ParamStr := ParamStr + ', ';
+    ParamStr := ParamStr + AParamsSources[I];
+  end;
+
+  // Validate params: must parse as a valid parameter list.
+  // If params contain tokens that escape the signature, this will throw.
+  if ParamStr <> '' then
+  begin
+    Source := '(' + ParamStr + ') => {}';
+    Lexer := TGocciaLexer.Create(Source, '<Function:params>');
+    try
+      Tokens := Lexer.ScanTokens;
+      Parser := TGocciaParser.Create(Tokens, '<Function:params>', Lexer.SourceLines);
+      Parser.AutomaticSemicolonInsertion := cfASI in FCompatibility;
+      Parser.VarDeclarationsEnabled := cfVar in FCompatibility;
+      try
+        ProgramNode := Parser.Parse;
+        // Parse must consume exactly one expression statement (the arrow function)
+        if ProgramNode.Body.Count <> 1 then
+          ThrowSyntaxError('Invalid parameter list for Function constructor');
+        ProgramNode.Free;
+      finally
+        Parser.Free;
+      end;
+    finally
+      Lexer.Free;
+    end;
+  end;
+
+  // Validate body: must parse as a valid function body.
+  // An arrow wrapper ensures the body is enclosed in matching braces.
+  if ABodySource <> '' then
+  begin
+    Source := '() => {' + #10 + ABodySource + #10 + '}';
+    Lexer := TGocciaLexer.Create(Source, '<Function:body>');
+    try
+      Tokens := Lexer.ScanTokens;
+      Parser := TGocciaParser.Create(Tokens, '<Function:body>', Lexer.SourceLines);
+      Parser.AutomaticSemicolonInsertion := cfASI in FCompatibility;
+      Parser.VarDeclarationsEnabled := cfVar in FCompatibility;
+      try
+        ProgramNode := Parser.Parse;
+        if ProgramNode.Body.Count <> 1 then
+          ThrowSyntaxError('Invalid body for Function constructor');
+        ProgramNode.Free;
+      finally
+        Parser.Free;
+      end;
+    finally
+      Lexer.Free;
+    end;
+  end;
+
+  // Both pieces validated — safe to assemble the wrapper
+  Source := '({ anonymous(' + ParamStr + ') {' + #10 + ABodySource + #10 + '} }).anonymous';
+
+  Lexer := TGocciaLexer.Create(Source, '<Function>');
   try
     Tokens := Lexer.ScanTokens;
     Parser := TGocciaParser.Create(Tokens, '<Function>', Lexer.SourceLines);

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -105,6 +105,8 @@ type
       const ASourcePath: string); override;
     function ExecuteProgram(
       const AProgram: TGocciaProgram): TGocciaValue; override;
+    function ExecuteDynamicFunction(
+      const AProgram: TGocciaProgram): TGocciaValue; override;
     procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
       const AContext: TGocciaEvaluationContext); override;
   end;
@@ -196,6 +198,7 @@ type
     procedure PrintParserWarnings(const AParser: TGocciaParser; const ASourceMap: TGocciaSourceMap = nil);
     procedure ThrowError(const AMessage: string; const ALine,
       AColumn: Integer);
+    function CompileDynamicFunction(const ASource: string): TGocciaFunctionBase;
   public
     constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins); overload;
     constructor Create(const AFileName: string; const ASourceLines: TStringList; const AGlobals: TGocciaGlobalBuiltins; const AResolver: TGocciaModuleResolver); overload;
@@ -308,6 +311,7 @@ uses
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.BooleanObjectValue,
+  Goccia.Values.FunctionValue,
   Goccia.Values.HeadersValue,
   Goccia.Values.MapValue,
   Goccia.Values.NativeFunction,
@@ -351,6 +355,12 @@ begin
   Start := GetNanoseconds;
   Result := FInterpreter.Execute(AProgram);
   ExecuteTimeNanoseconds := GetNanoseconds - Start;
+end;
+
+function TGocciaInterpreterExecutor.ExecuteDynamicFunction(
+  const AProgram: TGocciaProgram): TGocciaValue;
+begin
+  Result := FInterpreter.Execute(AProgram);
 end;
 
 procedure TGocciaInterpreterExecutor.EvaluateModuleBody(
@@ -634,6 +644,9 @@ begin
     FOwnsExecutor := True;
   end;
   FExecutor.Initialize(FInterpreter.GlobalScope, FModuleLoader, AFileName);
+
+  if Assigned(FFunctionConstructor) then
+    FFunctionConstructor.CompileDynamicFunction := CompileDynamicFunction;
 end;
 
 destructor TGocciaEngine.Destroy;
@@ -1013,8 +1026,7 @@ begin
   RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
   BooleanConstructor := TGocciaBooleanClassValue(GenericConstructor);
 
-  FFunctionConstructor := TGocciaFunctionConstructorClassValue.Create('Function', nil,
-    False, FInterpreter.GlobalScope);
+  FFunctionConstructor := TGocciaFunctionConstructorClassValue.Create('Function', nil);
   FunctionConstructor := FFunctionConstructor;
   TGocciaFunctionBase.SetSharedPrototypeParent(FunctionConstructor.Prototype);
   FunctionConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, FunctionConstructor);
@@ -1505,6 +1517,37 @@ end;
 procedure TGocciaEngine.ThrowError(const AMessage: string; const ALine, AColumn: Integer);
 begin
   raise TGocciaRuntimeError.Create(AMessage, ALine, AColumn, FSourcePath, FSourceLines);
+end;
+
+function TGocciaEngine.CompileDynamicFunction(const ASource: string): TGocciaFunctionBase;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+  Parser: TGocciaParser;
+  ProgramNode: TGocciaProgram;
+  ResultValue: TGocciaValue;
+begin
+  Lexer := TGocciaLexer.Create(ASource, '<Function>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Parser := TGocciaParser.Create(Tokens, '<Function>', Lexer.SourceLines);
+    try
+      ProgramNode := Parser.ParseUnchecked;
+      try
+        ResultValue := FExecutor.ExecuteDynamicFunction(ProgramNode);
+        Result := TGocciaFunctionBase(ResultValue);
+        // ES2026 §20.2.1.1.1: the function's name is 'anonymous'
+        if Result is TGocciaFunctionValue then
+          TGocciaFunctionValue(Result).Name := 'anonymous';
+      finally
+        ProgramNode.Free;
+      end;
+    finally
+      Parser.Free;
+    end;
+  finally
+    Lexer.Free;
+  end;
 end;
 
 end.

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1531,6 +1531,8 @@ begin
   try
     Tokens := Lexer.ScanTokens;
     Parser := TGocciaParser.Create(Tokens, '<Function>', Lexer.SourceLines);
+    Parser.AutomaticSemicolonInsertion := cfASI in FCompatibility;
+    Parser.VarDeclarationsEnabled := cfVar in FCompatibility;
     try
       ProgramNode := Parser.ParseUnchecked;
       try

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -292,6 +292,8 @@ uses
 
   TimingUtils,
 
+  Goccia.AST.Expressions,
+  Goccia.AST.Statements,
   Goccia.CallStack,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
@@ -1562,10 +1564,15 @@ begin
       Parser.VarDeclarationsEnabled := cfVar in FCompatibility;
       try
         ProgramNode := Parser.Parse;
-        // Parse must consume exactly one expression statement (the arrow function)
-        if ProgramNode.Body.Count <> 1 then
-          ThrowSyntaxError('Invalid parameter list for Function constructor');
-        ProgramNode.Free;
+        try
+          if (ProgramNode.Body.Count <> 1) or
+             not (ProgramNode.Body[0] is TGocciaExpressionStatement) or
+             not (TGocciaExpressionStatement(ProgramNode.Body[0]).Expression
+               is TGocciaArrowFunctionExpression) then
+            ThrowSyntaxError('Invalid parameter list for Function constructor');
+        finally
+          ProgramNode.Free;
+        end;
       finally
         Parser.Free;
       end;
@@ -1587,9 +1594,15 @@ begin
       Parser.VarDeclarationsEnabled := cfVar in FCompatibility;
       try
         ProgramNode := Parser.Parse;
-        if ProgramNode.Body.Count <> 1 then
-          ThrowSyntaxError('Invalid body for Function constructor');
-        ProgramNode.Free;
+        try
+          if (ProgramNode.Body.Count <> 1) or
+             not (ProgramNode.Body[0] is TGocciaExpressionStatement) or
+             not (TGocciaExpressionStatement(ProgramNode.Body[0]).Expression
+               is TGocciaArrowFunctionExpression) then
+            ThrowSyntaxError('Invalid body for Function constructor');
+        finally
+          ProgramNode.Free;
+        end;
       finally
         Parser.Free;
       end;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -163,6 +163,7 @@ type
     FBuiltinURLSearchParams: TGocciaGlobalURLSearchParams;
     FBuiltinFetch: TGocciaGlobalFetch;
     FBuiltinDisposableStack: TGocciaBuiltinDisposableStack;
+    FFunctionConstructor: TGocciaFunctionConstructorClassValue;
     FPreviousExceptionMask: TFPUExceptionMask;
     FSuppressWarnings: Boolean;
     FLastTiming: TGocciaScriptResult;
@@ -237,6 +238,7 @@ type
     property ModuleLoader: TGocciaModuleLoader read FModuleLoader;
     property ASIEnabled: Boolean read GetASIEnabled write SetASIEnabled;
     property VarEnabled: Boolean read GetVarEnabled write SetVarEnabled;
+    property FunctionConstructor: TGocciaFunctionConstructorClassValue read FFunctionConstructor;
     property Preprocessors: TGocciaPreprocessors read FPreprocessors write SetPreprocessors;
     property Compatibility: TGocciaCompatibilityFlags read FCompatibility write SetCompatibility;
     property StrictTypes: Boolean read FStrictTypes write FStrictTypes;
@@ -1011,7 +1013,9 @@ begin
   RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
   BooleanConstructor := TGocciaBooleanClassValue(GenericConstructor);
 
-  FunctionConstructor := TGocciaClassValue.Create('Function', nil);
+  FFunctionConstructor := TGocciaFunctionConstructorClassValue.Create('Function', nil,
+    False, FInterpreter.GlobalScope);
+  FunctionConstructor := FFunctionConstructor;
   TGocciaFunctionBase.SetSharedPrototypeParent(FunctionConstructor.Prototype);
   FunctionConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, FunctionConstructor);
   FInterpreter.GlobalScope.DefineLexicalBinding('Function', FunctionConstructor, dtConst);

--- a/source/units/Goccia.Executor.pas
+++ b/source/units/Goccia.Executor.pas
@@ -28,6 +28,8 @@ type
       const AProgram: TGocciaProgram): TGocciaValue; virtual; abstract;
     procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
       const AContext: TGocciaEvaluationContext); virtual; abstract;
+    function ExecuteDynamicFunction(
+      const AProgram: TGocciaProgram): TGocciaValue; virtual; abstract;
     procedure ClearTransientCaches; virtual;
     function DefaultStrictTypes: Boolean; virtual;
 

--- a/source/units/Goccia.Runtime.Bootstrap.pas
+++ b/source/units/Goccia.Runtime.Bootstrap.pas
@@ -485,8 +485,7 @@ begin
   RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
   BooleanConstructor := TGocciaBooleanClassValue(GenericConstructor);
 
-  FunctionConstructor := TGocciaFunctionConstructorClassValue.Create('Function', nil,
-    False, FInterpreter.GlobalScope);
+  FunctionConstructor := TGocciaFunctionConstructorClassValue.Create('Function', nil);
   TGocciaFunctionBase.SetSharedPrototypeParent(FunctionConstructor.Prototype);
   FunctionConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, FunctionConstructor);
   FInterpreter.GlobalScope.DefineLexicalBinding('Function', FunctionConstructor, dtConst);

--- a/source/units/Goccia.Runtime.Bootstrap.pas
+++ b/source/units/Goccia.Runtime.Bootstrap.pas
@@ -485,7 +485,8 @@ begin
   RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, GenericConstructor);
   BooleanConstructor := TGocciaBooleanClassValue(GenericConstructor);
 
-  FunctionConstructor := TGocciaClassValue.Create('Function', nil);
+  FunctionConstructor := TGocciaFunctionConstructorClassValue.Create('Function', nil,
+    False, FInterpreter.GlobalScope);
   TGocciaFunctionBase.SetSharedPrototypeParent(FunctionConstructor.Prototype);
   FunctionConstructor.Prototype.AssignProperty(PROP_CONSTRUCTOR, FunctionConstructor);
   FInterpreter.GlobalScope.DefineLexicalBinding('Function', FunctionConstructor, dtConst);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -1288,6 +1288,9 @@ begin
     ThrowTypeError('Dynamic code generation is disabled. ' +
       'Pass --unsafe-function-constructor to enable the Function constructor');
 
+  if not Assigned(FCompileDynamicFunction) then
+    ThrowTypeError('Function constructor is not available in this environment');
+
   // ES2026 §20.2.1.1: collect parameters and body from arguments
   if AArguments.Length = 0 then
   begin

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -198,7 +198,8 @@ type
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
   end;
 
-  TGocciaCompileDynamicFunction = function(const ASource: string): TGocciaFunctionBase of object;
+  TGocciaCompileDynamicFunction = function(const AParamsSources: array of string;
+    const ABodySource: string): TGocciaFunctionBase of object;
 
   TGocciaFunctionConstructorClassValue = class(TGocciaClassValue)
   private
@@ -1281,7 +1282,8 @@ end;
 function TGocciaFunctionConstructorClassValue.BuildFunction(
   const AArguments: TGocciaArgumentsCollection): TGocciaFunctionBase;
 var
-  ParamStr, BodyStr, Source: string;
+  ParamSources: array of string;
+  BodyStr: string;
   I: Integer;
 begin
   if not FEnabled then
@@ -1294,27 +1296,23 @@ begin
   // ES2026 §20.2.1.1: collect parameters and body from arguments
   if AArguments.Length = 0 then
   begin
-    ParamStr := '';
+    SetLength(ParamSources, 0);
     BodyStr := '';
   end
   else if AArguments.Length = 1 then
   begin
-    ParamStr := '';
+    SetLength(ParamSources, 0);
     BodyStr := AArguments.GetElement(0).ToStringLiteral.Value;
   end
   else
   begin
-    ParamStr := AArguments.GetElement(0).ToStringLiteral.Value;
-    for I := 1 to AArguments.Length - 2 do
-      ParamStr := ParamStr + ', ' + AArguments.GetElement(I).ToStringLiteral.Value;
+    SetLength(ParamSources, AArguments.Length - 1);
+    for I := 0 to AArguments.Length - 2 do
+      ParamSources[I] := AArguments.GetElement(I).ToStringLiteral.Value;
     BodyStr := AArguments.GetElement(AArguments.Length - 1).ToStringLiteral.Value;
   end;
 
-  // Use method shorthand so the function gets its own this binding.
-  // The member access extracts the function from the wrapper object.
-  Source := '({ anonymous(' + ParamStr + ') {' + #10 + BodyStr + #10 + '} }).anonymous';
-
-  Result := FCompileDynamicFunction(Source);
+  Result := FCompileDynamicFunction(ParamSources, BodyStr);
 end;
 
 function TGocciaFunctionConstructorClassValue.Call(

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -13,6 +13,7 @@ uses
   Goccia.Arguments.Collection,
   Goccia.AST.Expressions,
   Goccia.AST.Node,
+  Goccia.Scope,
   Goccia.Values.FunctionBase,
   Goccia.Values.FunctionValue,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -197,6 +198,21 @@ type
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
   end;
 
+  TGocciaFunctionConstructorClassValue = class(TGocciaClassValue)
+  private
+    FEnabled: Boolean;
+    FGlobalScope: TGocciaScope;
+    function BuildFunction(const AArguments: TGocciaArgumentsCollection): TGocciaFunctionValue;
+  public
+    constructor Create(const AName: string; const ASuperClass: TGocciaClassValue;
+      const AEnabled: Boolean; const AGlobalScope: TGocciaScope);
+    function Call(const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
+    function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    procedure MarkReferences; override;
+
+    property Enabled: Boolean read FEnabled write FEnabled;
+  end;
+
   TGocciaInstanceValue = class(TGocciaObjectValue)
   private
     FClass: TGocciaClassValue;
@@ -225,8 +241,10 @@ type
 implementation
 
 uses
+  Generics.Collections,
   SysUtils,
 
+  Goccia.AST.Statements,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
@@ -235,6 +253,9 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
+  Goccia.Lexer,
+  Goccia.Parser,
+  Goccia.Token,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.AutoAccessor,
@@ -1205,6 +1226,123 @@ begin
   else
     Prim := AArguments.GetElement(0).ToBooleanLiteral;
   Result := Prim.Box;
+end;
+
+{ TGocciaFunctionConstructorClassValue }
+
+constructor TGocciaFunctionConstructorClassValue.Create(const AName: string;
+  const ASuperClass: TGocciaClassValue; const AEnabled: Boolean;
+  const AGlobalScope: TGocciaScope);
+begin
+  inherited Create(AName, ASuperClass);
+  FEnabled := AEnabled;
+  FGlobalScope := AGlobalScope;
+end;
+
+function TGocciaFunctionConstructorClassValue.BuildFunction(
+  const AArguments: TGocciaArgumentsCollection): TGocciaFunctionValue;
+var
+  ParamStr, BodyStr, Source: string;
+  I: Integer;
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+  Parser: TGocciaParser;
+  ProgramNode: TGocciaProgram;
+  ArrowExpr: TGocciaArrowFunctionExpression;
+  Statements: TObjectList<TGocciaASTNode>;
+begin
+  if not FEnabled then
+    ThrowTypeError('Dynamic code generation is disabled. ' +
+      'Pass --unsafe-function-constructor to enable the Function constructor');
+
+  // ES2026 §20.2.1.1: collect parameters and body from arguments
+  if AArguments.Length = 0 then
+  begin
+    ParamStr := '';
+    BodyStr := '';
+  end
+  else if AArguments.Length = 1 then
+  begin
+    ParamStr := '';
+    BodyStr := AArguments.GetElement(0).ToStringLiteral.Value;
+  end
+  else
+  begin
+    ParamStr := AArguments.GetElement(0).ToStringLiteral.Value;
+    for I := 1 to AArguments.Length - 2 do
+      ParamStr := ParamStr + ', ' + AArguments.GetElement(I).ToStringLiteral.Value;
+    BodyStr := AArguments.GetElement(AArguments.Length - 1).ToStringLiteral.Value;
+  end;
+
+  // Synthesize arrow function source for the parser
+  Source := '(' + ParamStr + ') => {' + #10 + BodyStr + #10 + '}';
+
+  Lexer := TGocciaLexer.Create(Source, '<Function>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Parser := TGocciaParser.Create(Tokens, '<Function>', Lexer.SourceLines);
+    try
+      ProgramNode := Parser.ParseUnchecked;
+      try
+        if (ProgramNode.Body.Count <> 1) or
+           not (ProgramNode.Body[0] is TGocciaExpressionStatement) or
+           not (TGocciaExpressionStatement(ProgramNode.Body[0]).Expression
+             is TGocciaArrowFunctionExpression) then
+          ThrowSyntaxError('Invalid function body');
+
+        ArrowExpr := TGocciaArrowFunctionExpression(
+          TGocciaExpressionStatement(ProgramNode.Body[0]).Expression);
+
+        // Extract body statements from the arrow function's block body
+        if ArrowExpr.Body is TGocciaBlockStatement then
+        begin
+          Statements := TObjectList<TGocciaASTNode>.Create(False);
+          for I := 0 to TGocciaBlockStatement(ArrowExpr.Body).Nodes.Count - 1 do
+            Statements.Add(TGocciaBlockStatement(ArrowExpr.Body).Nodes[I]);
+        end
+        else
+        begin
+          Statements := TObjectList<TGocciaASTNode>.Create(False);
+          Statements.Add(ArrowExpr.Body);
+        end;
+
+        // Create a regular function (not arrow) so it gets its own this binding.
+        // Closure is global scope per ES spec §20.2.1.1.1 step 30.
+        Result := TGocciaFunctionValue.Create(
+          ArrowExpr.Parameters, Statements, FGlobalScope, 'anonymous');
+        Result.SourceFilePath := '<Function>';
+      finally
+        ProgramNode.Free;
+      end;
+    finally
+      Parser.Free;
+    end;
+  finally
+    Lexer.Free;
+  end;
+end;
+
+function TGocciaFunctionConstructorClassValue.Call(
+  const AArguments: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  // ES2026 §20.2.1.1: Function(...) is equivalent to new Function(...)
+  Result := BuildFunction(AArguments);
+end;
+
+function TGocciaFunctionConstructorClassValue.CreateNativeInstance(
+  const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
+begin
+  // Return the function value directly; Instantiate will use it as the instance
+  Result := BuildFunction(AArguments);
+end;
+
+procedure TGocciaFunctionConstructorClassValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FGlobalScope) then
+    FGlobalScope.MarkReferences;
 end;
 
 { TGocciaInstanceValue }

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -13,7 +13,6 @@ uses
   Goccia.Arguments.Collection,
   Goccia.AST.Expressions,
   Goccia.AST.Node,
-  Goccia.Scope,
   Goccia.Values.FunctionBase,
   Goccia.Values.FunctionValue,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -198,19 +197,21 @@ type
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
   end;
 
+  TGocciaCompileDynamicFunction = function(const ASource: string): TGocciaFunctionBase of object;
+
   TGocciaFunctionConstructorClassValue = class(TGocciaClassValue)
   private
     FEnabled: Boolean;
-    FGlobalScope: TGocciaScope;
-    function BuildFunction(const AArguments: TGocciaArgumentsCollection): TGocciaFunctionValue;
+    FCompileDynamicFunction: TGocciaCompileDynamicFunction;
+    function BuildFunction(const AArguments: TGocciaArgumentsCollection): TGocciaFunctionBase;
   public
-    constructor Create(const AName: string; const ASuperClass: TGocciaClassValue;
-      const AEnabled: Boolean; const AGlobalScope: TGocciaScope);
+    constructor Create(const AName: string; const ASuperClass: TGocciaClassValue);
     function Call(const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
-    procedure MarkReferences; override;
 
     property Enabled: Boolean read FEnabled write FEnabled;
+    property CompileDynamicFunction: TGocciaCompileDynamicFunction
+      read FCompileDynamicFunction write FCompileDynamicFunction;
   end;
 
   TGocciaInstanceValue = class(TGocciaObjectValue)
@@ -244,7 +245,6 @@ uses
   Generics.Collections,
   SysUtils,
 
-  Goccia.AST.Statements,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
@@ -253,9 +253,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Lexer,
-  Goccia.Parser,
-  Goccia.Token,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.AutoAccessor,
@@ -1231,25 +1228,18 @@ end;
 { TGocciaFunctionConstructorClassValue }
 
 constructor TGocciaFunctionConstructorClassValue.Create(const AName: string;
-  const ASuperClass: TGocciaClassValue; const AEnabled: Boolean;
-  const AGlobalScope: TGocciaScope);
+  const ASuperClass: TGocciaClassValue);
 begin
   inherited Create(AName, ASuperClass);
-  FEnabled := AEnabled;
-  FGlobalScope := AGlobalScope;
+  FEnabled := False;
+  FCompileDynamicFunction := nil;
 end;
 
 function TGocciaFunctionConstructorClassValue.BuildFunction(
-  const AArguments: TGocciaArgumentsCollection): TGocciaFunctionValue;
+  const AArguments: TGocciaArgumentsCollection): TGocciaFunctionBase;
 var
   ParamStr, BodyStr, Source: string;
   I: Integer;
-  Lexer: TGocciaLexer;
-  Tokens: TObjectList<TGocciaToken>;
-  Parser: TGocciaParser;
-  ProgramNode: TGocciaProgram;
-  ArrowExpr: TGocciaArrowFunctionExpression;
-  Statements: TObjectList<TGocciaASTNode>;
 begin
   if not FEnabled then
     ThrowTypeError('Dynamic code generation is disabled. ' +
@@ -1274,52 +1264,11 @@ begin
     BodyStr := AArguments.GetElement(AArguments.Length - 1).ToStringLiteral.Value;
   end;
 
-  // Synthesize arrow function source for the parser
-  Source := '(' + ParamStr + ') => {' + #10 + BodyStr + #10 + '}';
+  // Use method shorthand so the function gets its own this binding.
+  // The member access extracts the function from the wrapper object.
+  Source := '({ anonymous(' + ParamStr + ') {' + #10 + BodyStr + #10 + '} }).anonymous';
 
-  Lexer := TGocciaLexer.Create(Source, '<Function>');
-  try
-    Tokens := Lexer.ScanTokens;
-    Parser := TGocciaParser.Create(Tokens, '<Function>', Lexer.SourceLines);
-    try
-      ProgramNode := Parser.ParseUnchecked;
-      try
-        if (ProgramNode.Body.Count <> 1) or
-           not (ProgramNode.Body[0] is TGocciaExpressionStatement) or
-           not (TGocciaExpressionStatement(ProgramNode.Body[0]).Expression
-             is TGocciaArrowFunctionExpression) then
-          ThrowSyntaxError('Invalid function body');
-
-        ArrowExpr := TGocciaArrowFunctionExpression(
-          TGocciaExpressionStatement(ProgramNode.Body[0]).Expression);
-
-        // Extract body statements from the arrow function's block body
-        if ArrowExpr.Body is TGocciaBlockStatement then
-        begin
-          Statements := TObjectList<TGocciaASTNode>.Create(False);
-          for I := 0 to TGocciaBlockStatement(ArrowExpr.Body).Nodes.Count - 1 do
-            Statements.Add(TGocciaBlockStatement(ArrowExpr.Body).Nodes[I]);
-        end
-        else
-        begin
-          Statements := TObjectList<TGocciaASTNode>.Create(False);
-          Statements.Add(ArrowExpr.Body);
-        end;
-
-        // Create a regular function (not arrow) so it gets its own this binding.
-        // Closure is global scope per ES spec §20.2.1.1.1 step 30.
-        Result := TGocciaFunctionValue.Create(
-          ArrowExpr.Parameters, Statements, FGlobalScope, 'anonymous');
-        Result.SourceFilePath := '<Function>';
-      finally
-        ProgramNode.Free;
-      end;
-    finally
-      Parser.Free;
-    end;
-  finally
-    Lexer.Free;
-  end;
+  Result := FCompileDynamicFunction(Source);
 end;
 
 function TGocciaFunctionConstructorClassValue.Call(
@@ -1333,16 +1282,7 @@ end;
 function TGocciaFunctionConstructorClassValue.CreateNativeInstance(
   const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
 begin
-  // Return the function value directly; Instantiate will use it as the instance
   Result := BuildFunction(AArguments);
-end;
-
-procedure TGocciaFunctionConstructorClassValue.MarkReferences;
-begin
-  if GCMarked then Exit;
-  inherited;
-  if Assigned(FGlobalScope) then
-    FGlobalScope.MarkReferences;
 end;
 
 { TGocciaInstanceValue }

--- a/tests/built-ins/Function/constructor-disabled.js
+++ b/tests/built-ins/Function/constructor-disabled.js
@@ -1,0 +1,14 @@
+/*---
+description: Function constructor throws when flag is not set
+features: [Function]
+---*/
+
+describe("Function constructor disabled", () => {
+  test("new Function() throws TypeError when disabled", () => {
+    expect(() => new Function("return 1")).toThrow();
+  });
+
+  test("Function() throws TypeError when disabled", () => {
+    expect(() => Function("return 1")).toThrow();
+  });
+});

--- a/tests/built-ins/Function/constructor-disabled.js
+++ b/tests/built-ins/Function/constructor-disabled.js
@@ -5,10 +5,10 @@ features: [Function]
 
 describe("Function constructor disabled", () => {
   test("new Function() throws TypeError when disabled", () => {
-    expect(() => new Function("return 1")).toThrow();
+    expect(() => new Function("return 1")).toThrow(TypeError);
   });
 
   test("Function() throws TypeError when disabled", () => {
-    expect(() => Function("return 1")).toThrow();
+    expect(() => Function("return 1")).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Function/constructor/basic.js
+++ b/tests/built-ins/Function/constructor/basic.js
@@ -1,0 +1,47 @@
+/*---
+description: Function constructor basic usage
+features: [Function, unsafe-function-constructor]
+---*/
+
+describe("Function constructor", () => {
+  test("no arguments creates empty function", () => {
+    const f = new Function();
+    expect(typeof f).toBe("function");
+    expect(f()).toBe(undefined);
+  });
+
+  test("body-only argument", () => {
+    const f = new Function("return 42");
+    expect(f()).toBe(42);
+  });
+
+  test("single parameter and body", () => {
+    const f = new Function("a", "return a");
+    expect(f(5)).toBe(5);
+  });
+
+  test("two parameters and body", () => {
+    const f = new Function("a", "b", "return a + b");
+    expect(f(2, 3)).toBe(5);
+  });
+
+  test("multiple parameters and body", () => {
+    const f = new Function("a", "b", "c", "return a + b + c");
+    expect(f(1, 2, 3)).toBe(6);
+  });
+
+  test("comma-separated params in single string", () => {
+    const f = new Function("a, b", "return a + b");
+    expect(f(10, 20)).toBe(30);
+  });
+
+  test("Function() without new is equivalent", () => {
+    const f = Function("a", "return a * 2");
+    expect(f(5)).toBe(10);
+  });
+
+  test("body with multiple statements", () => {
+    const f = new Function("a", "const x = a * 2; return x + 1");
+    expect(f(10)).toBe(21);
+  });
+});

--- a/tests/built-ins/Function/constructor/errors.js
+++ b/tests/built-ins/Function/constructor/errors.js
@@ -5,10 +5,10 @@ features: [Function, unsafe-function-constructor]
 
 describe("Function constructor errors", () => {
   test("invalid body throws SyntaxError", () => {
-    expect(() => new Function("}{")).toThrow();
+    expect(() => new Function("}{")).toThrow(SyntaxError);
   });
 
   test("invalid parameter throws SyntaxError", () => {
-    expect(() => new Function("@bad", "return 1")).toThrow();
+    expect(() => new Function("@bad", "return 1")).toThrow(SyntaxError);
   });
 });

--- a/tests/built-ins/Function/constructor/errors.js
+++ b/tests/built-ins/Function/constructor/errors.js
@@ -1,0 +1,14 @@
+/*---
+description: Function constructor - error handling
+features: [Function, unsafe-function-constructor]
+---*/
+
+describe("Function constructor errors", () => {
+  test("invalid body throws SyntaxError", () => {
+    expect(() => new Function("}{")).toThrow();
+  });
+
+  test("invalid parameter throws SyntaxError", () => {
+    expect(() => new Function("@bad", "return 1")).toThrow();
+  });
+});

--- a/tests/built-ins/Function/constructor/goccia.json
+++ b/tests/built-ins/Function/constructor/goccia.json
@@ -1,0 +1,3 @@
+{
+  "unsafe-function-constructor": true
+}

--- a/tests/built-ins/Function/constructor/properties.js
+++ b/tests/built-ins/Function/constructor/properties.js
@@ -1,0 +1,28 @@
+/*---
+description: Function constructor - function properties
+features: [Function, unsafe-function-constructor]
+---*/
+
+describe("Function constructor properties", () => {
+  test("length reflects parameter count", () => {
+    expect(new Function().length).toBe(0);
+    expect(new Function("return 1").length).toBe(0);
+    expect(new Function("a", "return a").length).toBe(1);
+    expect(new Function("a", "b", "return a + b").length).toBe(2);
+  });
+
+  test("name is 'anonymous'", () => {
+    const f = new Function("return 1");
+    expect(f.name).toBe("anonymous");
+  });
+
+  test("instanceof Function", () => {
+    const f = new Function("return 1");
+    expect(f instanceof Function).toBe(true);
+  });
+
+  test("typeof is 'function'", () => {
+    const f = new Function("return 1");
+    expect(typeof f).toBe("function");
+  });
+});

--- a/tests/built-ins/Function/constructor/scope.js
+++ b/tests/built-ins/Function/constructor/scope.js
@@ -1,0 +1,25 @@
+/*---
+description: Function constructor - scope behavior
+features: [Function, unsafe-function-constructor]
+---*/
+
+describe("Function constructor scope", () => {
+  test("does not capture lexical scope", () => {
+    const x = 42;
+    const f = new Function("return typeof x");
+    // Per ES spec, Function constructor creates functions in global scope
+    // so local 'x' is not visible
+    expect(f()).toBe("undefined");
+  });
+
+  test("can access global built-ins", () => {
+    const f = new Function("return typeof Math");
+    expect(f()).toBe("object");
+  });
+
+  test("receives its own this", () => {
+    const f = new Function("return this");
+    const obj = { method: f };
+    expect(obj.method()).toBe(obj);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new `--unsafe-function-constructor` engine option and matching `goccia.json` config key.
- Replaces the built-in `Function` constructor with a dedicated implementation that parses parameter and body strings into callable functions.
- Keeps the feature disabled by default and raises a `TypeError` unless explicitly enabled.
- Adds coverage for basic construction, error cases, scope behavior, and disabled-mode behavior.
