### PR TITLE
Infer names for anonymous classes and object functions

### DIFF
--- a/source/units/Goccia.AST.Statements.pas
+++ b/source/units/Goccia.AST.Statements.pas
@@ -833,7 +833,9 @@ end;
     begin
       Value := Variables[I].Initializer.Evaluate(AContext);
       if (Value is TGocciaFunctionValue) and (TGocciaFunctionValue(Value).Name = '') then
-        TGocciaFunctionValue(Value).Name := Variables[I].Name;
+        TGocciaFunctionValue(Value).Name := Variables[I].Name
+      else
+        Value.SetInferredName(Variables[I].Name);
       if IsVar then
       begin
         HasRealInit := not ((Variables[I].Initializer is TGocciaLiteralExpression) and

--- a/source/units/Goccia.AST.Statements.pas
+++ b/source/units/Goccia.AST.Statements.pas
@@ -467,6 +467,7 @@ uses
   Goccia.Scope,
   Goccia.Scope.BindingMap,
   Goccia.Token,
+  Goccia.Values.ClassValue,
   Goccia.Values.Error,
   Goccia.Values.FunctionValue,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -834,8 +835,8 @@ end;
       Value := Variables[I].Initializer.Evaluate(AContext);
       if (Value is TGocciaFunctionValue) and (TGocciaFunctionValue(Value).Name = '') then
         TGocciaFunctionValue(Value).Name := Variables[I].Name
-      else
-        Value.SetInferredName(Variables[I].Name);
+      else if Value is TGocciaClassValue then
+        TGocciaClassValue(Value).SetInferredName(Variables[I].Name);
       if IsVar then
       begin
         HasRealInit := not ((Variables[I].Initializer is TGocciaLiteralExpression) and

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -1377,9 +1377,26 @@ procedure CompileObjectProperty(const ACtx: TGocciaCompilationContext;
 var
   ValReg: UInt8;
   KeyIdx: UInt16;
+  FuncCount: Integer;
+  InferredTemplate: TGocciaFunctionTemplate;
 begin
   ValReg := ACtx.Scope.AllocateRegister;
+  FuncCount := ACtx.Template.FunctionCount;
   ACtx.CompileExpression(AValExpr, ValReg);
+
+  if (AValExpr is TGocciaArrowFunctionExpression) or
+     (AValExpr is TGocciaMethodExpression) then
+  begin
+    if ACtx.Template.FunctionCount > FuncCount then
+    begin
+      InferredTemplate := ACtx.Template.GetFunction(
+        ACtx.Template.FunctionCount - 1);
+      if (InferredTemplate.Name = '<arrow>') or
+         (InferredTemplate.Name = '<method>') then
+        InferredTemplate.Name := AKey;
+    end;
+  end;
+
   KeyIdx := ACtx.Template.AddConstantString(AKey);
   if KeyIdx > High(UInt8) then
     raise Exception.Create('Constant pool overflow: property name index exceeds 255');
@@ -1403,7 +1420,7 @@ begin
   OldTemplate := ACtx.Template;
   OldScope := ACtx.Scope;
 
-  ChildTemplate := TGocciaFunctionTemplate.Create('<get ' + AKey + '>');
+  ChildTemplate := TGocciaFunctionTemplate.Create('get ' + AKey);
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
   ChildTemplate.SourceText := AGetter.SourceText;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
@@ -1453,7 +1470,7 @@ begin
   OldTemplate := ACtx.Template;
   OldScope := ACtx.Scope;
 
-  ChildTemplate := TGocciaFunctionTemplate.Create('<set ' + AKey + '>');
+  ChildTemplate := TGocciaFunctionTemplate.Create('set ' + AKey);
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
   ChildTemplate.SourceText := ASetter.SourceText;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -1382,7 +1382,13 @@ var
 begin
   ValReg := ACtx.Scope.AllocateRegister;
   FuncCount := ACtx.Template.FunctionCount;
-  ACtx.CompileExpression(AValExpr, ValReg);
+
+  if (AValExpr is TGocciaClassExpression) and
+     (TGocciaClassExpression(AValExpr).ClassDefinition.Name = '') then
+    Goccia.Compiler.Statements.CompileClassExpression(ACtx,
+      TGocciaClassExpression(AValExpr).ClassDefinition, ValReg, AKey)
+  else
+    ACtx.CompileExpression(AValExpr, ValReg);
 
   if (AValExpr is TGocciaArrowFunctionExpression) or
      (AValExpr is TGocciaMethodExpression) then

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -58,7 +58,8 @@ procedure CompileUsingDeclaration(const ACtx: TGocciaCompilationContext;
 procedure CompileClassDeclaration(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaClassDeclaration);
 procedure CompileClassExpression(const ACtx: TGocciaCompilationContext;
-  const AClassDef: TGocciaClassDefinition; const ADest: UInt8);
+  const AClassDef: TGocciaClassDefinition; const ADest: UInt8;
+  const AInferredName: string = '');
 
 function TypeAnnotationToLocalType(const AAnnotation: string): TGocciaLocalType;
 function IsArrayTypeAnnotation(const AAnnotation: string): Boolean;
@@ -558,7 +559,13 @@ begin
        not (AStmt.IsVar and (not HasRealInitializer) and IsVarRedeclaration) then
     begin
       FuncCount := ACtx.Template.FunctionCount;
-      ACtx.CompileExpression(Info.Initializer, Slot);
+
+      if (Info.Initializer is TGocciaClassExpression) and
+         (TGocciaClassExpression(Info.Initializer).ClassDefinition.Name = '') then
+        CompileClassExpression(ACtx,
+          TGocciaClassExpression(Info.Initializer).ClassDefinition, Slot, Info.Name)
+      else
+        ACtx.CompileExpression(Info.Initializer, Slot);
 
       if IsStrict and HasRealInitializer then
         if not TypesAreCompatible(InferLocalType(Info.Initializer), TypeHint) then
@@ -2532,7 +2539,8 @@ begin
 end;
 
 procedure CompileClassExpression(const ACtx: TGocciaCompilationContext;
-  const AClassDef: TGocciaClassDefinition; const ADest: UInt8);
+  const AClassDef: TGocciaClassDefinition; const ADest: UInt8;
+  const AInferredName: string = '');
 var
   ClassDef: TGocciaClassDefinition;
   SuperReg, ValReg: UInt8;
@@ -2557,6 +2565,8 @@ begin
 
   if HasNameBinding then
     NameIdx := ACtx.Template.AddConstantString(ClassDef.Name)
+  else if AInferredName <> '' then
+    NameIdx := ACtx.Template.AddConstantString(AInferredName)
   else
     NameIdx := ACtx.Template.AddConstantString('<anonymous>');
   EmitInstruction(ACtx, EncodeABx(OP_NEW_CLASS, ADest, NameIdx));

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1063,7 +1063,12 @@ begin
             // Static property: {key: value}
             PropertyName := AObjectExpression.PropertySourceOrder[I].StaticKey;
             if AObjectExpression.Properties.TryGetValue(PropertyName, PropertyExpression) then
-              Obj.DefineProperty(PropertyName, TGocciaPropertyDescriptorData.Create(EvaluateExpression(PropertyExpression, AContext), [pfEnumerable, pfConfigurable, pfWritable]));
+            begin
+              PropertyValue := EvaluateExpression(PropertyExpression, AContext);
+              if (PropertyValue is TGocciaFunctionValue) and (TGocciaFunctionValue(PropertyValue).Name = '') then
+                TGocciaFunctionValue(PropertyValue).Name := PropertyName;
+              Obj.DefineProperty(PropertyName, TGocciaPropertyDescriptorData.Create(PropertyValue, [pfEnumerable, pfConfigurable, pfWritable]));
+            end;
           end;
 
         pstComputed:
@@ -1121,6 +1126,8 @@ begin
           begin
             // Getter: {get prop() {...}}
             GetterFunction := EvaluateGetter(AObjectExpression.Getters[AObjectExpression.PropertySourceOrder[I].StaticKey], AContext);
+            if (GetterFunction is TGocciaFunctionValue) and (TGocciaFunctionValue(GetterFunction).Name = '') then
+              TGocciaFunctionValue(GetterFunction).Name := 'get ' + AObjectExpression.PropertySourceOrder[I].StaticKey;
             // Check if there's already a setter for this property
             ExistingDescriptor := Obj.GetOwnPropertyDescriptor(AObjectExpression.PropertySourceOrder[I].StaticKey);
             if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
@@ -1141,6 +1148,8 @@ begin
           begin
             // Setter: {set prop(val) {...}}
             SetterFunction := EvaluateSetter(AObjectExpression.Setters[AObjectExpression.PropertySourceOrder[I].StaticKey], AContext);
+            if (SetterFunction is TGocciaFunctionValue) and (TGocciaFunctionValue(SetterFunction).Name = '') then
+              TGocciaFunctionValue(SetterFunction).Name := 'set ' + AObjectExpression.PropertySourceOrder[I].StaticKey;
             // Check if there's already a getter for this property
             ExistingDescriptor := Obj.GetOwnPropertyDescriptor(AObjectExpression.PropertySourceOrder[I].StaticKey);
             if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1065,8 +1065,8 @@ begin
             if AObjectExpression.Properties.TryGetValue(PropertyName, PropertyExpression) then
             begin
               PropertyValue := EvaluateExpression(PropertyExpression, AContext);
-              if (PropertyValue is TGocciaFunctionValue) and (TGocciaFunctionValue(PropertyValue).Name = '') then
-                TGocciaFunctionValue(PropertyValue).Name := PropertyName;
+              if PropertyValue.IsCallable then
+                PropertyValue.SetInferredName(PropertyName);
               Obj.DefineProperty(PropertyName, TGocciaPropertyDescriptorData.Create(PropertyValue, [pfEnumerable, pfConfigurable, pfWritable]));
             end;
           end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1065,7 +1065,10 @@ begin
             if AObjectExpression.Properties.TryGetValue(PropertyName, PropertyExpression) then
             begin
               PropertyValue := EvaluateExpression(PropertyExpression, AContext);
-              if PropertyValue.IsCallable then
+              if (PropertyExpression is TGocciaMethodExpression)
+                or (PropertyExpression is TGocciaArrowFunctionExpression)
+                or ((PropertyExpression is TGocciaClassExpression)
+                  and (TGocciaClassExpression(PropertyExpression).ClassDefinition.FName = '')) then
                 PropertyValue.SetInferredName(PropertyName);
               Obj.DefineProperty(PropertyName, TGocciaPropertyDescriptorData.Create(PropertyValue, [pfEnumerable, pfConfigurable, pfWritable]));
             end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1130,8 +1130,8 @@ begin
           begin
             // Getter: {get prop() {...}}
             GetterFunction := EvaluateGetter(AObjectExpression.Getters[AObjectExpression.PropertySourceOrder[I].StaticKey], AContext);
-            if (GetterFunction is TGocciaFunctionValue) and (TGocciaFunctionValue(GetterFunction).Name = '') then
-              TGocciaFunctionValue(GetterFunction).Name := 'get ' + AObjectExpression.PropertySourceOrder[I].StaticKey;
+            if GetterFunction is TGocciaFunctionValue then
+              TGocciaFunctionValue(GetterFunction).SetInferredName('get ' + AObjectExpression.PropertySourceOrder[I].StaticKey);
             // Check if there's already a setter for this property
             ExistingDescriptor := Obj.GetOwnPropertyDescriptor(AObjectExpression.PropertySourceOrder[I].StaticKey);
             if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
@@ -1152,8 +1152,8 @@ begin
           begin
             // Setter: {set prop(val) {...}}
             SetterFunction := EvaluateSetter(AObjectExpression.Setters[AObjectExpression.PropertySourceOrder[I].StaticKey], AContext);
-            if (SetterFunction is TGocciaFunctionValue) and (TGocciaFunctionValue(SetterFunction).Name = '') then
-              TGocciaFunctionValue(SetterFunction).Name := 'set ' + AObjectExpression.PropertySourceOrder[I].StaticKey;
+            if SetterFunction is TGocciaFunctionValue then
+              TGocciaFunctionValue(SetterFunction).SetInferredName('set ' + AObjectExpression.PropertySourceOrder[I].StaticKey);
             // Check if there's already a getter for this property
             ExistingDescriptor := Obj.GetOwnPropertyDescriptor(AObjectExpression.PropertySourceOrder[I].StaticKey);
             if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1066,10 +1066,11 @@ begin
             begin
               PropertyValue := EvaluateExpression(PropertyExpression, AContext);
               if (PropertyExpression is TGocciaMethodExpression)
-                or (PropertyExpression is TGocciaArrowFunctionExpression)
-                or ((PropertyExpression is TGocciaClassExpression)
-                  and (TGocciaClassExpression(PropertyExpression).ClassDefinition.FName = '')) then
-                PropertyValue.SetInferredName(PropertyName);
+                or (PropertyExpression is TGocciaArrowFunctionExpression) then
+                TGocciaFunctionValue(PropertyValue).SetInferredName(PropertyName)
+              else if (PropertyExpression is TGocciaClassExpression)
+                and (TGocciaClassExpression(PropertyExpression).ClassDefinition.FName = '') then
+                TGocciaClassValue(PropertyValue).SetInferredName(PropertyName);
               Obj.DefineProperty(PropertyName, TGocciaPropertyDescriptorData.Create(PropertyValue, [pfEnumerable, pfConfigurable, pfWritable]));
             end;
           end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1852,30 +1852,25 @@ var
   BytecodeGetter: TGocciaBytecodeFunctionValue;
   Args: TGocciaArgumentsCollection;
 begin
-  Current := Self;
-  repeat
-    Getter := Current.StaticPropertyGetter[AName];
-    if Assigned(Getter) then
+  Getter := StaticPropertyGetter[AName];
+  if Assigned(Getter) then
+  begin
+    if (Getter is TGocciaBytecodeFunctionValue) then
     begin
-      if (Getter is TGocciaBytecodeFunctionValue) then
-      begin
-        BytecodeGetter := TGocciaBytecodeFunctionValue(Getter);
-        if Assigned(BytecodeGetter.FClosure) and
-           Assigned(BytecodeGetter.FClosure.Template) and
-           (not BytecodeGetter.FClosure.Template.IsAsync) then
-          Exit(RegisterToValue(FVM.ExecuteClosureRegisters(
-            BytecodeGetter.FClosure, RegisterObject(Self), [])));
-      end;
-      Args := TGocciaArgumentsCollection.CreateWithCapacity(0);
-      try
-        Exit(Getter.Call(Args, Self));
-      finally
-        Args.Free;
-      end;
+      BytecodeGetter := TGocciaBytecodeFunctionValue(Getter);
+      if Assigned(BytecodeGetter.FClosure) and
+         Assigned(BytecodeGetter.FClosure.Template) and
+         (not BytecodeGetter.FClosure.Template.IsAsync) then
+        Exit(RegisterToValue(FVM.ExecuteClosureRegisters(
+          BytecodeGetter.FClosure, RegisterObject(Self), [])));
     end;
-
-    Current := Current.SuperClass;
-  until not Assigned(Current);
+    Args := TGocciaArgumentsCollection.CreateWithCapacity(0);
+    try
+      Exit(Getter.Call(Args, Self));
+    finally
+      Args.Free;
+    end;
+  end;
 
   Result := inherited GetProperty(AName);
 end;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -889,8 +889,32 @@ begin
     Exit;
   end;
 
-  Current := Self;
-  repeat
+  if FStaticMethods.TryGetValue(AName, Result) then
+    Exit;
+
+  if FStaticGetters.TryGetValue(AName, Getter) then
+  begin
+    Args := TGocciaArgumentsCollection.CreateWithCapacity(0);
+    try
+      Result := Getter.Call(Args, Self);
+    finally
+      Args.Free;
+    end;
+    Exit;
+  end;
+
+  if AName = PROP_NAME then
+  begin
+    if FName = '<anonymous>' then
+      Result := TGocciaStringLiteralValue.Create('')
+    else
+      Result := TGocciaStringLiteralValue.Create(FName);
+    Exit;
+  end;
+
+  Current := FSuperClass;
+  while Assigned(Current) do
+  begin
     if Current.FStaticMethods.TryGetValue(AName, Result) then
       Exit;
 
@@ -906,15 +930,6 @@ begin
     end;
 
     Current := Current.FSuperClass;
-  until not Assigned(Current);
-
-  if AName = PROP_NAME then
-  begin
-    if FName = '<anonymous>' then
-      Result := TGocciaStringLiteralValue.Create('')
-    else
-      Result := TGocciaStringLiteralValue.Create(FName);
-    Exit;
   end;
 
   // Fall through to Function.prototype chain (classes are functions per ES spec)

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -111,6 +111,7 @@ type
     function GetSymbolProperty(const ASymbol: TGocciaSymbolValue): TGocciaValue;
     function GetSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AReceiver: TGocciaValue): TGocciaValue;
 
+    procedure SetInferredName(const AName: string); override;
     property Name: string read FName;
     property SuperClass: TGocciaClassValue read FSuperClass write FSuperClass;
     property Prototype: TGocciaObjectValue read FPrototype;
@@ -888,6 +889,15 @@ begin
     Exit;
   end;
 
+  if AName = PROP_NAME then
+  begin
+    if FName = '<anonymous>' then
+      Result := TGocciaStringLiteralValue.Create('')
+    else
+      Result := TGocciaStringLiteralValue.Create(FName);
+    Exit;
+  end;
+
   Current := Self;
   repeat
     if Current.FStaticMethods.TryGetValue(AName, Result) then
@@ -917,6 +927,12 @@ begin
   end;
 
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+procedure TGocciaClassValue.SetInferredName(const AName: string);
+begin
+  if FName = '<anonymous>' then
+    FName := AName;
 end;
 
 procedure TGocciaClassValue.SetProperty(const AName: string; const AValue: TGocciaValue);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -111,7 +111,7 @@ type
     function GetSymbolProperty(const ASymbol: TGocciaSymbolValue): TGocciaValue;
     function GetSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AReceiver: TGocciaValue): TGocciaValue;
 
-    procedure SetInferredName(const AName: string); override;
+    procedure SetInferredName(const AName: string);
     property Name: string read FName;
     property SuperClass: TGocciaClassValue read FSuperClass write FSuperClass;
     property Prototype: TGocciaObjectValue read FPrototype;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -889,15 +889,6 @@ begin
     Exit;
   end;
 
-  if AName = PROP_NAME then
-  begin
-    if FName = '<anonymous>' then
-      Result := TGocciaStringLiteralValue.Create('')
-    else
-      Result := TGocciaStringLiteralValue.Create(FName);
-    Exit;
-  end;
-
   Current := Self;
   repeat
     if Current.FStaticMethods.TryGetValue(AName, Result) then
@@ -916,6 +907,15 @@ begin
 
     Current := Current.FSuperClass;
   until not Assigned(Current);
+
+  if AName = PROP_NAME then
+  begin
+    if FName = '<anonymous>' then
+      Result := TGocciaStringLiteralValue.Create('')
+    else
+      Result := TGocciaStringLiteralValue.Create(FName);
+    Exit;
+  end;
 
   // Fall through to Function.prototype chain (classes are functions per ES spec)
   FuncProto := TGocciaFunctionBase.GetSharedPrototype;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -903,6 +903,12 @@ begin
     Exit;
   end;
 
+  if FStaticSetters.ContainsKey(AName) then
+  begin
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+
   if AName = PROP_NAME then
   begin
     if FName = '<anonymous>' then
@@ -926,6 +932,12 @@ begin
       finally
         Args.Free;
       end;
+      Exit;
+    end;
+
+    if Current.FStaticSetters.ContainsKey(AName) then
+    begin
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
       Exit;
     end;
 

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -41,6 +41,7 @@ type
 
     function Call(const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
     procedure MarkReferences; override;
+    procedure SetInferredName(const AName: string); override;
 
     property Parameters: TGocciaParameterArray read FParameters;
     property BodyStatements: TObjectList<TGocciaASTNode> read FBodyStatements;
@@ -302,6 +303,12 @@ end;
 function TGocciaFunctionValue.GetSourceText: string;
 begin
   Result := FSourceText;
+end;
+
+procedure TGocciaFunctionValue.SetInferredName(const AName: string);
+begin
+  if FName = '' then
+    FName := AName;
 end;
 
 { TGocciaArrowFunctionValue }

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -41,7 +41,7 @@ type
 
     function Call(const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
     procedure MarkReferences; override;
-    procedure SetInferredName(const AName: string); override;
+    procedure SetInferredName(const AName: string);
 
     property Parameters: TGocciaParameterArray read FParameters;
     property BodyStatements: TObjectList<TGocciaASTNode> read FBodyStatements;

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -32,7 +32,6 @@ type
     function IsCallable: Boolean; virtual;
     function GetProperty(const AName: string): TGocciaValue; virtual;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); virtual;
-    procedure SetInferredName(const AName: string); virtual;
   end;
 
   TGocciaValueList = TObjectList<TGocciaValue>;
@@ -234,10 +233,6 @@ begin
   // No-op for primitives
 end;
 
-procedure TGocciaValue.SetInferredName(const AName: string);
-begin
-  // No-op by default; overridden by ClassValue for anonymous class name inference
-end;
 
 { Utility functions }
 

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -32,6 +32,7 @@ type
     function IsCallable: Boolean; virtual;
     function GetProperty(const AName: string): TGocciaValue; virtual;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); virtual;
+    procedure SetInferredName(const AName: string); virtual;
   end;
 
   TGocciaValueList = TObjectList<TGocciaValue>;
@@ -231,6 +232,11 @@ end;
 procedure TGocciaValue.SetProperty(const AName: string; const AValue: TGocciaValue);
 begin
   // No-op for primitives
+end;
+
+procedure TGocciaValue.SetInferredName(const AName: string);
+begin
+  // No-op by default; overridden by ClassValue for anonymous class name inference
 end;
 
 { Utility functions }

--- a/tests/language/classes/class-name-property.js
+++ b/tests/language/classes/class-name-property.js
@@ -1,0 +1,34 @@
+/*---
+description: Class.name property returns the class name per ES spec
+features: [classes, Function.name]
+---*/
+
+describe("class declaration name", () => {
+  test("class declaration has .name matching identifier", () => {
+    class MyClass {}
+    expect(MyClass.name).toBe("MyClass");
+  });
+
+  test("subclass declaration has .name matching identifier", () => {
+    class Base {}
+    class Child extends Base {}
+    expect(Child.name).toBe("Child");
+  });
+});
+
+describe("class expression name", () => {
+  test("anonymous class expression infers name from variable", () => {
+    const Foo = class {};
+    expect(Foo.name).toBe("Foo");
+  });
+
+  test("named class expression uses its own name", () => {
+    const Bar = class InternalName {};
+    expect(Bar.name).toBe("InternalName");
+  });
+
+  test("let-assigned anonymous class expression infers name", () => {
+    let Baz = class {};
+    expect(Baz.name).toBe("Baz");
+  });
+});

--- a/tests/language/classes/class-name-property.js
+++ b/tests/language/classes/class-name-property.js
@@ -36,3 +36,15 @@ describe("class expression name", () => {
     expect((class {}).name).toBe("");
   });
 });
+
+describe("static name override", () => {
+  test("static getter overrides default .name", () => {
+    class Foo { static get name() { return "Custom"; } }
+    expect(Foo.name).toBe("Custom");
+  });
+
+  test("static field overrides default .name", () => {
+    class Bar { static name = "Override"; }
+    expect(Bar.name).toBe("Override");
+  });
+});

--- a/tests/language/classes/class-name-property.js
+++ b/tests/language/classes/class-name-property.js
@@ -37,6 +37,13 @@ describe("class expression name", () => {
   });
 });
 
+describe("class as object property", () => {
+  test("anonymous class expression infers name from property key", () => {
+    const obj = { MyClass: class {} };
+    expect(obj.MyClass.name).toBe("MyClass");
+  });
+});
+
 describe("static name override", () => {
   test("static getter overrides default .name", () => {
     class Foo { static get name() { return "Custom"; } }
@@ -46,5 +53,12 @@ describe("static name override", () => {
   test("static field overrides default .name", () => {
     class Bar { static name = "Override"; }
     expect(Bar.name).toBe("Override");
+  });
+
+  test("inherited static name getter does not shadow child built-in name", () => {
+    class Parent { static get name() { return "ParentCustom"; } }
+    class Child extends Parent {}
+    expect(Child.name).toBe("Child");
+    expect(Parent.name).toBe("ParentCustom");
   });
 });

--- a/tests/language/classes/class-name-property.js
+++ b/tests/language/classes/class-name-property.js
@@ -31,4 +31,8 @@ describe("class expression name", () => {
     let Baz = class {};
     expect(Baz.name).toBe("Baz");
   });
+
+  test("unbound anonymous class expression has empty name", () => {
+    expect((class {}).name).toBe("");
+  });
 });

--- a/tests/language/classes/class-name-property.js
+++ b/tests/language/classes/class-name-property.js
@@ -61,4 +61,9 @@ describe("static name override", () => {
     expect(Child.name).toBe("Child");
     expect(Parent.name).toBe("ParentCustom");
   });
+
+  test("setter-only static name shadows built-in name with undefined", () => {
+    class Foo { static set name(v) {} }
+    expect(Foo.name).toBe(undefined);
+  });
 });

--- a/tests/language/functions/function-length-name.js
+++ b/tests/language/functions/function-length-name.js
@@ -28,19 +28,35 @@ describe("Function.length", () => {
 });
 
 describe("Function.name", () => {
-  test("named function expression", () => {
+  test("variable-assigned arrow function infers name", () => {
     const add = (a, b) => a + b;
     expect(add.name).toBe("add");
   });
 
-  test("class methods have names", () => {
-    class Foo {
-      bar() {
-        return 1;
-      }
-    }
-    const foo = new Foo();
-    // Method name is accessible
-    expect(typeof Foo).toBe("function");
+  test("let-assigned arrow function infers name", () => {
+    let greet = () => "hello";
+    expect(greet.name).toBe("greet");
+  });
+
+  test("object shorthand method has name", () => {
+    const obj = { myMethod() { return 1; } };
+    expect(obj.myMethod.name).toBe("myMethod");
+  });
+
+  test("object arrow property infers name", () => {
+    const obj = { myArrow: () => 1 };
+    expect(obj.myArrow.name).toBe("myArrow");
+  });
+
+  test("object getter has prefixed name", () => {
+    const obj = { get myGetter() { return 1; } };
+    const desc = Object.getOwnPropertyDescriptor(obj, "myGetter");
+    expect(desc.get.name).toBe("get myGetter");
+  });
+
+  test("object setter has prefixed name", () => {
+    const obj = { set mySetter(v) {} };
+    const desc = Object.getOwnPropertyDescriptor(obj, "mySetter");
+    expect(desc.set.name).toBe("set mySetter");
   });
 });


### PR DESCRIPTION
## Summary
- Infer `name` for anonymous functions assigned to variables, including arrow functions and class expressions.
- Set inferred names for object literal function properties, getters, and setters so `Function.name` matches ES expectations.
- Add coverage for class `.name` behavior and object/function name inference cases.
