### PR TITLE
Skip unsupported generator methods during parsing

### DIFF
--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -1807,7 +1807,7 @@ begin
         'Use a regular method instead',
         Peek.Line, Peek.Column);
       Advance; // skip *
-      // Skip method name
+      // Skip method name (identifiers, strings, numbers, or reserved words)
       if Check(gttLeftBracket) then
       begin
         Advance;
@@ -1815,8 +1815,12 @@ begin
         Consume(gttRightBracket, 'Expected "]" after computed property name',
           SSuggestCloseBracketComputedPropertyName);
       end
-      else if Check(gttIdentifier) or Check(gttString) or Check(gttNumber) then
-        Advance;
+      else if Match([gttIdentifier, gttString, gttNumber,
+                     gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
+                     gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
+                     gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
+                     gttTrue, gttFalse, gttNull, gttTypeof, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
+        { name consumed };
       CollectGenericParameters;
       if Check(gttLeftParen) then
         SkipBalancedParens;
@@ -3863,7 +3867,7 @@ begin
         // Skip optional # for private generator methods
         if Check(gttHash) then
           Advance;
-        // Skip method name
+        // Skip method name (identifiers, strings, numbers, or reserved words)
         if Check(gttLeftBracket) then
         begin
           Advance;
@@ -3871,8 +3875,12 @@ begin
           Consume(gttRightBracket, 'Expected "]" after computed property name',
             SSuggestCloseBracketComputedPropertyName);
         end
-        else if Check(gttIdentifier) or Check(gttString) or Check(gttNumber) then
-          Advance;
+        else if Match([gttIdentifier, gttString, gttNumber,
+                       gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
+                       gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
+                       gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
+                       gttTrue, gttFalse, gttNull, gttTypeof, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
+          { name consumed };
         CollectGenericParameters;
         if Check(gttLeftParen) then
           SkipBalancedParens;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -1800,6 +1800,39 @@ begin
       IsSetter := True;
     end;
 
+    // Generator method syntax: *methodName() { ... } or async *methodName() { ... }
+    if Check(gttStar) then
+    begin
+      AddWarning('Generator methods are not supported in GocciaScript',
+        'Use a regular method instead',
+        Peek.Line, Peek.Column);
+      Advance; // skip *
+      // Skip method name
+      if Check(gttLeftBracket) then
+      begin
+        Advance;
+        Expression;
+        Consume(gttRightBracket, 'Expected "]" after computed property name',
+          SSuggestCloseBracketComputedPropertyName);
+      end
+      else if Check(gttIdentifier) or Check(gttString) or Check(gttNumber) then
+        Advance;
+      CollectGenericParameters;
+      if Check(gttLeftParen) then
+        SkipBalancedParens;
+      // Skip return type annotation
+      if Check(gttColon) then
+      begin
+        Advance;
+        CollectTypeAnnotation([gttLeftBrace]);
+      end;
+      if Check(gttLeftBrace) then
+        SkipBlock;
+      if not Match(gttComma) then
+        Break;
+      Continue;
+    end;
+
         // Handle spread syntax: ...obj
     if not IsGetter and not IsSetter and Match(gttSpread) then
     begin
@@ -3595,6 +3628,17 @@ begin
     Exit;
   end;
 
+  if Check(gttFunction) then
+  begin
+    AddWarning('''function'' declarations are not supported in GocciaScript',
+      'Use arrow functions instead: const name = (...) => { ... }',
+      Line, Column);
+    Advance;
+    SkipUnsupportedFunctionSignature;
+    Result := TGocciaEmptyStatement.Create(Line, Column);
+    Exit;
+  end;
+
   if Check(gttStar) then
   begin
     AddWarning('Wildcard re-exports (export * from ...) are not supported in GocciaScript',
@@ -3807,6 +3851,40 @@ begin
       begin
         Advance;
         IsAsync := True;
+      end;
+
+      // Generator method syntax: *methodName() { ... } or async *methodName() { ... }
+      if Check(gttStar) then
+      begin
+        AddWarning('Generator methods are not supported in GocciaScript',
+          'Use a regular method instead',
+          Peek.Line, Peek.Column);
+        Advance; // skip *
+        // Skip optional # for private generator methods
+        if Check(gttHash) then
+          Advance;
+        // Skip method name
+        if Check(gttLeftBracket) then
+        begin
+          Advance;
+          Expression;
+          Consume(gttRightBracket, 'Expected "]" after computed property name',
+            SSuggestCloseBracketComputedPropertyName);
+        end
+        else if Check(gttIdentifier) or Check(gttString) or Check(gttNumber) then
+          Advance;
+        CollectGenericParameters;
+        if Check(gttLeftParen) then
+          SkipBalancedParens;
+        // Skip return type annotation
+        if Check(gttColon) then
+        begin
+          Advance;
+          CollectTypeAnnotation([gttLeftBrace]);
+        end;
+        if Check(gttLeftBrace) then
+          SkipBlock;
+        Continue;
       end;
 
       IsPrivate := Match(gttHash);

--- a/tests/language/statements/unsupported-features.js
+++ b/tests/language/statements/unsupported-features.js
@@ -153,6 +153,12 @@ describe.runIf(hasGoccia)("unsupported features are skipped", () => {
     expect(obj.b).toBe(2);
   });
 
+  test("generator method with reserved-word name is skipped", () => {
+    const obj = { *delete() { yield 1; }, x: 42 };
+    expect(obj.x).toBe(42);
+    expect(typeof obj.delete).toBe("undefined");
+  });
+
   test("code after function declaration continues correctly", () => {
     let x = 1;
     function ignored() { x = 99; }

--- a/tests/language/statements/unsupported-features.js
+++ b/tests/language/statements/unsupported-features.js
@@ -100,6 +100,59 @@ describe.runIf(hasGoccia)("unsupported features are skipped", () => {
     expect(typeof gen).toBe("undefined");
   });
 
+  test("generator function expression evaluates to undefined", () => {
+    const fn = function*() { yield 1; };
+    expect(fn).toBe(undefined);
+  });
+
+  test("generator method in object is skipped", () => {
+    const obj = { *gen() { yield 1; }, x: 42 };
+    expect(obj.x).toBe(42);
+    expect(typeof obj.gen).toBe("undefined");
+  });
+
+  test("async generator method in object is skipped", () => {
+    const obj = { async *gen() { yield 1; }, x: 42 };
+    expect(obj.x).toBe(42);
+    expect(typeof obj.gen).toBe("undefined");
+  });
+
+  test("generator method in class is skipped", () => {
+    class Foo {
+      *gen() { yield 1; }
+      bar() { return 42; }
+    }
+    const f = new Foo();
+    expect(f.bar()).toBe(42);
+    expect(typeof f.gen).toBe("undefined");
+  });
+
+  test("async generator method in class is skipped", () => {
+    class Foo {
+      async *gen() { yield 1; }
+      bar() { return 42; }
+    }
+    const f = new Foo();
+    expect(f.bar()).toBe(42);
+    expect(typeof f.gen).toBe("undefined");
+  });
+
+  test("static generator method in class is skipped", () => {
+    class Foo {
+      static *gen() { yield 1; }
+      bar() { return 42; }
+    }
+    const f = new Foo();
+    expect(f.bar()).toBe(42);
+    expect(typeof Foo.gen).toBe("undefined");
+  });
+
+  test("generator method between other properties is skipped", () => {
+    const obj = { a: 1, *gen() { yield 1; }, b: 2 };
+    expect(obj.a).toBe(1);
+    expect(obj.b).toBe(2);
+  });
+
   test("code after function declaration continues correctly", () => {
     let x = 1;
     function ignored() { x = 99; }


### PR DESCRIPTION
## Summary
- Teach the parser to recognize and skip unsupported generator methods in object literals and classes, including async and static variants.
- Add handling for unsupported `function` declarations so they are skipped consistently during parsing.
- Expand language tests to cover generator function expressions and generator methods across objects and classes.
