### PR TITLE
Add `void` operator support

### DIFF
--- a/source/units/Goccia.Compiler.ConstantFolding.pas
+++ b/source/units/Goccia.Compiler.ConstantFolding.pas
@@ -317,6 +317,13 @@ begin
     Exit;
   end;
 
+  if AExpr.Operator = gttVoid then
+  begin
+    EmitInstruction(ACtx, EncodeABC(OP_LOAD_UNDEFINED, ADest, 0, 0));
+    Result := True;
+    Exit;
+  end;
+
   if AExpr.Operator = gttTypeof then
   begin
     TypeStr := '';

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -512,6 +512,7 @@ begin
     gttPlus:       EmitInstruction(ACtx, EncodeABC(OP_TO_NUMBER, ADest, RegB, 0));
     gttTypeof:     EmitInstruction(ACtx, EncodeABC(OP_TYPEOF, ADest, RegB, 0));
     gttBitwiseNot: EmitInstruction(ACtx, EncodeABC(OP_BNOT, ADest, RegB, 0));
+    gttVoid:       EmitInstruction(ACtx, EncodeABC(OP_LOAD_UNDEFINED, ADest, 0, 0));
   else
     EmitInstruction(ACtx, EncodeABC(OP_LOAD_UNDEFINED, ADest, 0, 0));
   end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -644,6 +644,8 @@ begin
     end;
     gttTypeof:
       Result := EvaluateTypeof(Operand);
+    gttVoid:
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     gttBitwiseNot:
       Result := EvaluateBitwiseNot(Operand);
   else

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -1507,6 +1507,7 @@ begin
   FKeywords.Add(KEYWORD_TRY, gttTry);
   FKeywords.Add(KEYWORD_TYPEOF, gttTypeof);
   FKeywords.Add(KEYWORD_VAR, gttVar);
+  FKeywords.Add(KEYWORD_VOID, gttVoid);
   FKeywords.Add(KEYWORD_WHILE, gttWhile);
   FKeywords.Add(KEYWORD_WITH, gttWith);
 

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -578,7 +578,7 @@ begin
     gttSuper, gttStatic, gttReturn, gttIf, gttElse, gttFor, gttWhile, gttDo,
     gttSwitch, gttCase, gttDefault, gttBreak, gttThrow, gttTry, gttCatch,
     gttFinally, gttImport, gttExport, gttFrom, gttAs, gttGet, gttSet,
-    gttVar, gttWith, gttFunction, gttTypeof, gttInstanceof, gttIn,
+    gttVar, gttWith, gttFunction, gttTypeof, gttVoid, gttInstanceof, gttIn,
     gttDelete:
       Exit(True);
   end;
@@ -748,7 +748,7 @@ begin
     Exit;
   end;
 
-  if Match([gttNot, gttMinus, gttPlus, gttTypeof, gttBitwiseNot, gttDelete]) then
+  if Match([gttNot, gttMinus, gttPlus, gttTypeof, gttVoid, gttBitwiseNot, gttDelete]) then
   begin
     Operator := Previous;
     Right := Unary;
@@ -866,7 +866,7 @@ begin
         else if Match([gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
                        gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
                        gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
-                       gttTrue, gttFalse, gttNull, gttTypeof, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
+                       gttTrue, gttFalse, gttNull, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
           PropertyName := Previous.Lexeme  // Reserved words are allowed as property names
         else
           raise TGocciaSyntaxError.Create('Expected property name after "."', Peek.Line, Peek.Column, FFileName, FSourceLines,
@@ -1847,7 +1847,7 @@ begin
     else if Match([gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
                    gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
                    gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
-                   gttTrue, gttFalse, gttNull, gttTypeof, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
+                   gttTrue, gttFalse, gttNull, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
       Key := Previous.Lexeme  // Reserved words are allowed as property names
     else
       raise TGocciaSyntaxError.Create('Expected property name', Peek.Line, Peek.Column, FFileName, FSourceLines,

--- a/source/units/Goccia.Token.pas
+++ b/source/units/Goccia.Token.pas
@@ -19,7 +19,7 @@ type
     // Operators
     gttPlus, gttMinus, gttStar, gttSlash, gttPercent, gttPower,
     gttEqual, gttNotEqual, gttLooseEqual, gttLooseNotEqual, gttLess, gttGreater, gttLessEqual, gttGreaterEqual,
-    gttAnd, gttOr, gttNullishCoalescing, gttNot, gttTypeof, gttInstanceof, gttIn, gttDelete, gttAssign, gttPlusAssign, gttMinusAssign,
+    gttAnd, gttOr, gttNullishCoalescing, gttNot, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttAssign, gttPlusAssign, gttMinusAssign,
     gttStarAssign, gttSlashAssign, gttPercentAssign, gttPowerAssign, gttNullishCoalescingAssign, gttLogicalAndAssign, gttLogicalOrAssign,
     gttIncrement, gttDecrement,
     gttQuestion, gttColon, gttOptionalChaining,

--- a/tests/language/expressions/void/void-operator.js
+++ b/tests/language/expressions/void/void-operator.js
@@ -1,0 +1,53 @@
+/*---
+description: Void operator evaluates operand and returns undefined
+features: [void-operator]
+---*/
+
+test("void 0 returns undefined", () => {
+  expect(void 0).toBe(undefined);
+});
+
+test("void with various literals returns undefined", () => {
+  expect(void 1).toBe(undefined);
+  expect(void "hello").toBe(undefined);
+  expect(void true).toBe(undefined);
+  expect(void false).toBe(undefined);
+  expect(void null).toBe(undefined);
+  expect(void undefined).toBe(undefined);
+});
+
+test("void with expressions returns undefined", () => {
+  expect(void (1 + 2)).toBe(undefined);
+  expect(void (3 * 4)).toBe(undefined);
+});
+
+test("void evaluates operand for side effects", () => {
+  let x = 0;
+  void (x = 5);
+  expect(x).toBe(5);
+});
+
+test("void with function call evaluates the call", () => {
+  let called = false;
+  const sideEffect = () => { called = true; };
+  void sideEffect();
+  expect(called).toBe(true);
+});
+
+test("typeof void 0 is undefined", () => {
+  expect(typeof (void 0)).toBe("undefined");
+});
+
+test("void has correct precedence", () => {
+  expect(void 0 === undefined).toBe(true);
+});
+
+test("void with object returns undefined", () => {
+  expect(void {}).toBe(undefined);
+  expect(void []).toBe(undefined);
+});
+
+test("void with variable returns undefined", () => {
+  const x = 42;
+  expect(void x).toBe(undefined);
+});


### PR DESCRIPTION
## Summary
- Adds `void` as a recognized keyword and unary operator in the lexer, parser, evaluator, and compiler.
- Lowers constant `void` expressions to `undefined` during constant folding and runtime evaluation.
- Expands reserved-word handling so `void` can still be used where property names are allowed.
- Adds language coverage for `void` behavior, side effects, precedence, and `typeof void 0`.

## Testing
- Not run in this environment.
- Added/updated test coverage in `tests/language/expressions/void/void-operator.js` for literals, expressions, side effects, and precedence.
- Recommended local check: `./build.pas testrunner && ./build/GocciaTestRunner tests/language/expressions/void/ --asi`