### PR TITLE
Fix spyOn restore descriptor for re-spying

### DIFF
--- a/source/units/Goccia.Builtins.TestingLibrary.Test.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.Test.pas
@@ -22,6 +22,7 @@ uses
   Goccia.Values.FunctionValue,
   Goccia.Values.MockFunction,
   Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives,
   Goccia.Values.PromiseValue,
@@ -305,6 +306,7 @@ type
     procedure TestSpyOnTracksCalls;
     procedure TestSpyOnMockImplementationOverrides;
     procedure TestSpyOnMockRestoreRestoresOriginal;
+    procedure TestSpyOnMockRestoreAllowsReSpy;
     procedure TestSpyOnMockReturnValueOverrides;
 
     { mock matchers - toHaveBeenCalled }
@@ -2933,6 +2935,7 @@ begin
   Test('spyOn tracks calls', TestSpyOnTracksCalls);
   Test('spyOn mockImplementation overrides original', TestSpyOnMockImplementationOverrides);
   Test('spyOn mockRestore restores the original method', TestSpyOnMockRestoreRestoresOriginal);
+  Test('spyOn mockRestore allows spying again', TestSpyOnMockRestoreAllowsReSpy);
   Test('spyOn mockReturnValue overrides original', TestSpyOnMockReturnValueOverrides);
 
   { mock matchers - toHaveBeenCalled }
@@ -3468,6 +3471,48 @@ begin
   end;
 
   // Verify original is restored
+  PropValue := Obj.GetProperty('method');
+  Expect<Boolean>(PropValue = OrigFn).ToBe(True);
+end;
+
+procedure TTestMockAndSpyAPIs.TestSpyOnMockRestoreAllowsReSpy;
+var
+  Obj: TGocciaObjectValue;
+  OrigFn: TGocciaNativeFunctionValue;
+  FirstSpy: TGocciaMockFunctionValue;
+  SecondSpy: TGocciaMockFunctionValue;
+  EmptyArgs: TGocciaArgumentsCollection;
+  Descriptor: TGocciaPropertyDescriptor;
+  PropValue: TGocciaValue;
+begin
+  OrigFn := TGocciaNativeFunctionValue.Create(CallbackReturnOriginal, 'orig', 0);
+  Obj := TGocciaObjectValue.Create;
+  Obj.AssignProperty('method', OrigFn);
+  FirstSpy := CreateSpyViaGlobal(Obj, 'method');
+
+  EmptyArgs := TGocciaArgumentsCollection.Create;
+  try
+    FirstSpy.DoMockRestore(EmptyArgs, nil);
+  finally
+    EmptyArgs.Free;
+  end;
+
+  Descriptor := Obj.GetOwnPropertyDescriptor('method');
+  Expect<Boolean>(Assigned(Descriptor)).ToBe(True);
+  Expect<Boolean>(Descriptor.Configurable).ToBe(True);
+  Expect<Boolean>(Descriptor.Writable).ToBe(True);
+
+  SecondSpy := CreateSpyViaGlobal(Obj, 'method');
+  PropValue := Obj.GetProperty('method');
+  Expect<Boolean>(PropValue = SecondSpy).ToBe(True);
+
+  EmptyArgs := TGocciaArgumentsCollection.Create;
+  try
+    SecondSpy.DoMockRestore(EmptyArgs, nil);
+  finally
+    EmptyArgs.Free;
+  end;
+
   PropValue := Obj.GetProperty('method');
   Expect<Boolean>(PropValue = OrigFn).ToBe(True);
 end;

--- a/source/units/Goccia.Values.MockFunction.pas
+++ b/source/units/Goccia.Values.MockFunction.pas
@@ -98,6 +98,22 @@ const
   RESULT_TYPE_RETURN = 'return';
   RESULT_TYPE_THROW = 'throw';
 
+function ClonePropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor): TGocciaPropertyDescriptor;
+begin
+  if not Assigned(ADescriptor) then
+    Exit(nil);
+
+  if ADescriptor is TGocciaPropertyDescriptorData then
+    Exit(TGocciaPropertyDescriptorData.Create(
+      TGocciaPropertyDescriptorData(ADescriptor).Value,
+      ADescriptor.Flags));
+
+  Result := TGocciaPropertyDescriptorAccessor.Create(
+    TGocciaPropertyDescriptorAccessor(ADescriptor).Getter,
+    TGocciaPropertyDescriptorAccessor(ADescriptor).Setter,
+    ADescriptor.Flags);
+end;
+
 { TGocciaMockFunctionValue }
 
 constructor TGocciaMockFunctionValue.Create(const AImplementation: TGocciaValue);
@@ -115,6 +131,7 @@ begin
   FDefaultReturnValue := nil;
   FSpyTarget := nil;
   FSpyOriginalValue := nil;
+  FSpyOriginalDescriptor := nil;
   FMockObject := nil;
 
   SetupMethods;
@@ -134,7 +151,8 @@ begin
   FSpyOriginalValue := OriginalValue;
 
   // Capture whether this is an own property and its descriptor for proper restore
-  FSpyOriginalDescriptor := ATarget.GetOwnPropertyDescriptor(AMethodName);
+  FSpyOriginalDescriptor := ClonePropertyDescriptor(
+    ATarget.GetOwnPropertyDescriptor(AMethodName));
   FSpyWasOwnProperty := Assigned(FSpyOriginalDescriptor);
 
   // Spy passes through to original by default
@@ -152,6 +170,7 @@ begin
   FResults.Free;
   FContexts.Free;
   FOnceQueue.Free;
+  FSpyOriginalDescriptor.Free;
   inherited;
 end;
 
@@ -405,6 +424,9 @@ begin
   if Assigned(FSpyOriginalValue) then
     FSpyOriginalValue.MarkReferences;
 
+  if Assigned(FSpyOriginalDescriptor) then
+    FSpyOriginalDescriptor.MarkValues;
+
   if Assigned(FMockObject) then
     FMockObject.MarkReferences;
 end;
@@ -514,8 +536,7 @@ begin
     if FSpyWasOwnProperty and Assigned(FSpyOriginalDescriptor) then
       // Restore the original own-property descriptor (preserves accessor/flags)
       FSpyTarget.DefineProperty(FSpyMethodName,
-        TGocciaPropertyDescriptorData.Create(FSpyOriginalValue,
-          FSpyOriginalDescriptor.Flags))
+        ClonePropertyDescriptor(FSpyOriginalDescriptor))
     else
       // Property was inherited — remove the shadowing own property
       FSpyTarget.DeleteProperty(FSpyMethodName);


### PR DESCRIPTION
## Summary

- Closes #394.
- Clone the original spy target descriptor before replacing the target property, so mockRestore() does not restore from a descriptor that DefineProperty has freed.
- Restore from a fresh cloned descriptor and mark/free the stored descriptor snapshot with the mock function.
- Add native Pascal coverage for mockRestore() preserving configurable/writable flags and allowing a second spyOn on the same method.

## Testing

- [x] Verified no regressions in end-to-end JavaScript/TypeScript tests: ./fixtures/ffi/build.sh && ./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the bugfix in native Pascal tests: ./build.pas tests && ./build/Goccia.Builtins.TestingLibrary.Test
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional checks:

- ./format.pas --check