### PR TITLE
Fix `Array.prototype.slice` for high-index array-like values

### DIFF
--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -1646,6 +1646,7 @@ var
   ResultArray: TGocciaArrayValue;
   StartIndex, EndIndex, Needed: Integer;
   I, N: Integer;
+  K: Int64;
   RawStart, RawEnd, RawK, RawFinal, RawNeeded: Double;
 begin
   // Step 1: Let O be ToObject(this value)
@@ -1710,15 +1711,6 @@ begin
 
   // After the check, RawNeeded ≤ MaxInt — safe to truncate for the loop.
   Needed := Integer(Trunc(RawNeeded));
-  // RawK could exceed MaxInt only when RawLen > MaxInt and the slice starts
-  // near the end; clamp to View.Len so the dense Integer loop stays in bounds.
-  if RawK > View.Len then
-    StartIndex := View.Len
-  else
-    StartIndex := Integer(Trunc(RawK));
-  EndIndex := StartIndex + Needed;
-  if EndIndex > View.Len then
-    EndIndex := View.Len;
 
   if Assigned(View.Arr) then
     ResultArray := ArraySpeciesCreate(View.Arr, Needed)
@@ -1727,13 +1719,32 @@ begin
 
   // Step 9: Let n be 0; repeat while k < final
   N := 0;
-  for I := StartIndex to EndIndex - 1 do
+  // RawK exceeds MaxInt only when RawLen > MaxInt and the slice starts past
+  // the dense Integer range; route through HasIndex64/Get64 so the window
+  // is not collapsed to empty by Integer clamping.
+  if RawK > MaxInt then
   begin
-    // Step 9b-c: only create property when source index is present (preserve holes)
-    if View.HasIndex(I) then
-      ArrayCreateDataProperty(ResultArray, N, View.Get(I));
-    // Step 9e: n increments unconditionally per ES spec
-    Inc(N);
+    K := Trunc(RawK);
+    while N < Needed do
+    begin
+      if View.HasIndex64(K) then
+        ArrayCreateDataProperty(ResultArray, N, View.Get64(K));
+      Inc(K);
+      Inc(N);
+    end;
+  end
+  else
+  begin
+    StartIndex := Integer(Trunc(RawK));
+    EndIndex := StartIndex + Needed;
+    if EndIndex > View.Len then
+      EndIndex := View.Len;
+    for I := StartIndex to EndIndex - 1 do
+    begin
+      if View.HasIndex(I) then
+        ArrayCreateDataProperty(ResultArray, N, View.Get(I));
+      Inc(N);
+    end;
   end;
 
   // Ensure result has correct length (preserve trailing holes)

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -1719,10 +1719,10 @@ begin
 
   // Step 9: Let n be 0; repeat while k < final
   N := 0;
-  // RawK exceeds MaxInt only when RawLen > MaxInt and the slice starts past
-  // the dense Integer range; route through HasIndex64/Get64 so the window
-  // is not collapsed to empty by Integer clamping.
-  if RawK > MaxInt then
+  // Use 64-bit probing whenever the copy window can touch indices > MaxInt.
+  // Branching on RawFinal (not RawK) catches boundary-crossing windows
+  // where start <= MaxInt but start + count overflows the Integer range.
+  if RawFinal > MaxInt then
   begin
     K := Trunc(RawK);
     while N < Needed do
@@ -1736,7 +1736,7 @@ begin
   else
   begin
     StartIndex := Integer(Trunc(RawK));
-    EndIndex := StartIndex + Needed;
+    EndIndex := Integer(Trunc(RawFinal));
     if EndIndex > View.Len then
       EndIndex := View.Len;
     for I := StartIndex to EndIndex - 1 do

--- a/tests/built-ins/Array/prototype/slice.js
+++ b/tests/built-ins/Array/prototype/slice.js
@@ -182,6 +182,17 @@ test("slice on generic array-like with large positive start and end", () => {
   expect(result).toEqual(["x", "y"]);
 });
 
+test("slice with negative indices on generic array-like with length > 2**31", () => {
+  const len = 2 ** 33;
+  const obj = { length: len };
+  obj[len - 3] = "a";
+  obj[len - 2] = "b";
+  const result = Array.prototype.slice.call(obj, -3, -1);
+  expect(result.length).toBe(2);
+  expect(result[0]).toBe("a");
+  expect(result[1]).toBe("b");
+});
+
 test("slice window crossing the 2**31 boundary on generic array-like", () => {
   const boundary = 2 ** 31 - 1;
   const obj = { length: 2 ** 33 };

--- a/tests/built-ins/Array/prototype/slice.js
+++ b/tests/built-ins/Array/prototype/slice.js
@@ -173,7 +173,7 @@ test("slice on generic array-like with high start returns empty when start >= en
   expect(result).toEqual([]);
 });
 
-test("slice on generic array-like with high negative end", () => {
+test("slice on generic array-like with large positive start and end", () => {
   const high = 2 ** 32;
   const obj = { length: 2 ** 33 };
   obj[high] = "x";

--- a/tests/built-ins/Array/prototype/slice.js
+++ b/tests/built-ins/Array/prototype/slice.js
@@ -181,3 +181,15 @@ test("slice on generic array-like with high negative end", () => {
   const result = Array.prototype.slice.call(obj, high, high + 2);
   expect(result).toEqual(["x", "y"]);
 });
+
+test("slice window crossing the 2**31 boundary on generic array-like", () => {
+  const boundary = 2 ** 31 - 1;
+  const obj = { length: 2 ** 33 };
+  obj[boundary] = "at-boundary";
+  obj[boundary + 1] = "past-boundary";
+  const result = Array.prototype.slice.call(obj, boundary, boundary + 3);
+  expect(result.length).toBe(3);
+  expect(result[0]).toBe("at-boundary");
+  expect(result[1]).toBe("past-boundary");
+  expect(2 in result).toBe(false);
+});

--- a/tests/built-ins/Array/prototype/slice.js
+++ b/tests/built-ins/Array/prototype/slice.js
@@ -151,3 +151,33 @@ test("slice(NaN) on array-like with positive length is a no-op start", () => {
   const sliced = Array.prototype.slice.call(arrayLike, NaN);
   expect(sliced).toEqual(["a", "b", "c"]);
 });
+
+test("slice on generic array-like with length > 2**31 and high start index", () => {
+  const high = 2 ** 32;
+  const obj = { length: 2 ** 33 };
+  obj[high] = "present";
+  const result = Array.prototype.slice.call(obj, high, high + 3);
+  expect(result.length).toBe(3);
+  expect(result[0]).toBe("present");
+  expect(result[1]).toBe(undefined);
+  expect(result[2]).toBe(undefined);
+  expect(0 in result).toBe(true);
+  expect(1 in result).toBe(false);
+  expect(2 in result).toBe(false);
+});
+
+test("slice on generic array-like with high start returns empty when start >= end", () => {
+  const high = 2 ** 32;
+  const obj = { length: 2 ** 33 };
+  const result = Array.prototype.slice.call(obj, high + 5, high);
+  expect(result).toEqual([]);
+});
+
+test("slice on generic array-like with high negative end", () => {
+  const high = 2 ** 32;
+  const obj = { length: 2 ** 33 };
+  obj[high] = "x";
+  obj[high + 1] = "y";
+  const result = Array.prototype.slice.call(obj, high, high + 2);
+  expect(result).toEqual(["x", "y"]);
+});


### PR DESCRIPTION
## Summary
- Fixed `Array.prototype.slice` so generic array-like objects with indices above `2**31` are handled without collapsing the slice window.
- Switched the slice copy path to use 64-bit index accessors when the computed start index exceeds `MaxInt`.
- Added regression tests covering high start indexes, sparse results, and empty slices for large array-like objects.

Fixes #409 