### PR TITLE
Fix Object.isFrozen and Object.isSealed integrity checks

### DIFF
--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -711,7 +711,7 @@ begin
   end;
 
   // Step 2: Return ? TestIntegrityLevel(O, frozen)
-  if TGocciaObjectValue(AArgs.GetElement(0)).Frozen then
+  if TGocciaObjectValue(AArgs.GetElement(0)).TestIntegrityFrozen then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
@@ -834,7 +834,7 @@ begin
   end;
 
   // Step 2: Return ? TestIntegrityLevel(O, sealed)
-  if TGocciaObjectValue(AArgs.GetElement(0)).Sealed then
+  if TGocciaObjectValue(AArgs.GetElement(0)).TestIntegritySealed then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -85,6 +85,10 @@ type
     procedure Seal; virtual;
     procedure PreventExtensions; virtual;
 
+    // ES2026 §7.3.16 TestIntegrityLevel(O, level)
+    function TestIntegrityFrozen: Boolean; virtual;
+    function TestIntegritySealed: Boolean; virtual;
+
     procedure MarkReferences; override;
 
     property Properties: TGocciaPropertyMap read FProperties;
@@ -1404,6 +1408,64 @@ end;
 procedure TGocciaObjectValue.PreventExtensions;
 begin
   FExtensible := False;
+end;
+
+// ES2026 §7.3.16 TestIntegrityLevel(O, frozen)
+function TGocciaObjectValue.TestIntegrityFrozen: Boolean;
+var
+  Pair: TGocciaPropertyMap.TKeyValuePair;
+  SymPair: TSymbolDescriptorMap.TKeyValuePair;
+begin
+  // Step 3: If extensible is true, return false
+  if FExtensible then
+    Exit(False);
+
+  // Step 5: For each element key of keys
+  for Pair in FProperties do
+  begin
+    if Pair.Value.Configurable then
+      Exit(False);
+    if (Pair.Value is TGocciaPropertyDescriptorData) and Pair.Value.Writable then
+      Exit(False);
+  end;
+
+  for SymPair in FSymbolDescriptors do
+  begin
+    if SymPair.Value.Configurable then
+      Exit(False);
+    if (SymPair.Value is TGocciaPropertyDescriptorData) and SymPair.Value.Writable then
+      Exit(False);
+  end;
+
+  // Step 6: Return true
+  Result := True;
+end;
+
+// ES2026 §7.3.16 TestIntegrityLevel(O, sealed)
+function TGocciaObjectValue.TestIntegritySealed: Boolean;
+var
+  Pair: TGocciaPropertyMap.TKeyValuePair;
+  SymPair: TSymbolDescriptorMap.TKeyValuePair;
+begin
+  // Step 3: If extensible is true, return false
+  if FExtensible then
+    Exit(False);
+
+  // Step 5: For each element key of keys
+  for Pair in FProperties do
+  begin
+    if Pair.Value.Configurable then
+      Exit(False);
+  end;
+
+  for SymPair in FSymbolDescriptors do
+  begin
+    if SymPair.Value.Configurable then
+      Exit(False);
+  end;
+
+  // Step 6: Return true
+  Result := True;
 end;
 
 initialization

--- a/tests/built-ins/Object/isFrozen.js
+++ b/tests/built-ins/Object/isFrozen.js
@@ -45,4 +45,73 @@ describe("Object.isFrozen", () => {
     const frozen = Object.freeze(obj);
     expect(Object.isFrozen(frozen)).toBe(true);
   });
+
+  test("non-extensible object with non-writable non-configurable properties is structurally frozen", () => {
+    const obj = {};
+    Object.defineProperty(obj, "a", {
+      value: 1,
+      writable: false,
+      configurable: false,
+      enumerable: true,
+    });
+    Object.defineProperty(obj, "b", {
+      value: 2,
+      writable: false,
+      configurable: false,
+      enumerable: true,
+    });
+    Object.preventExtensions(obj);
+    expect(Object.isFrozen(obj)).toBe(true);
+  });
+
+  test("non-extensible object with writable property is not frozen", () => {
+    const obj = {};
+    Object.defineProperty(obj, "a", {
+      value: 1,
+      writable: true,
+      configurable: false,
+      enumerable: true,
+    });
+    Object.preventExtensions(obj);
+    expect(Object.isFrozen(obj)).toBe(false);
+  });
+
+  test("non-extensible object with configurable property is not frozen", () => {
+    const obj = {};
+    Object.defineProperty(obj, "a", {
+      value: 1,
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    });
+    Object.preventExtensions(obj);
+    expect(Object.isFrozen(obj)).toBe(false);
+  });
+
+  test("empty non-extensible object is frozen", () => {
+    const obj = {};
+    Object.preventExtensions(obj);
+    expect(Object.isFrozen(obj)).toBe(true);
+  });
+
+  test("non-extensible object with accessor properties is frozen when non-configurable", () => {
+    const obj = {};
+    Object.defineProperty(obj, "x", {
+      get() { return 42; },
+      configurable: false,
+      enumerable: true,
+    });
+    Object.preventExtensions(obj);
+    expect(Object.isFrozen(obj)).toBe(true);
+  });
+
+  test("extensible object is never frozen", () => {
+    const obj = {};
+    Object.defineProperty(obj, "a", {
+      value: 1,
+      writable: false,
+      configurable: false,
+    });
+    expect(Object.isFrozen(obj)).toBe(false);
+  });
 });

--- a/tests/built-ins/Object/isSealed.js
+++ b/tests/built-ins/Object/isSealed.js
@@ -19,4 +19,44 @@ describe("Object.isSealed", () => {
     expect(Object.isSealed(42)).toBe(true);
     expect(Object.isSealed("hello")).toBe(true);
   });
+
+  test("non-extensible object with non-configurable properties is structurally sealed", () => {
+    const obj = {};
+    Object.defineProperty(obj, "a", {
+      value: 1,
+      writable: true,
+      configurable: false,
+      enumerable: true,
+    });
+    Object.preventExtensions(obj);
+    expect(Object.isSealed(obj)).toBe(true);
+  });
+
+  test("non-extensible object with configurable property is not sealed", () => {
+    const obj = {};
+    Object.defineProperty(obj, "a", {
+      value: 1,
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    });
+    Object.preventExtensions(obj);
+    expect(Object.isSealed(obj)).toBe(false);
+  });
+
+  test("empty non-extensible object is sealed", () => {
+    const obj = {};
+    Object.preventExtensions(obj);
+    expect(Object.isSealed(obj)).toBe(true);
+  });
+
+  test("extensible object is never sealed", () => {
+    const obj = {};
+    Object.defineProperty(obj, "a", {
+      value: 1,
+      writable: false,
+      configurable: false,
+    });
+    expect(Object.isSealed(obj)).toBe(false);
+  });
 });

--- a/tests/language/enums/enum-immutability.js
+++ b/tests/language/enums/enum-immutability.js
@@ -34,3 +34,20 @@ test("Object.isExtensible returns false for enum", () => {
 
   expect(Object.isExtensible(E)).toBe(false);
 });
+
+test("Object.isFrozen returns true for enum", () => {
+  enum OrderStatus {
+    Pending = 0,
+    Brewing = 1,
+    Ready = 2,
+    Delivered = 3,
+  }
+
+  expect(Object.isFrozen(OrderStatus)).toBe(true);
+});
+
+test("Object.isSealed returns true for enum", () => {
+  enum E { A = 1, B = 2 }
+
+  expect(Object.isSealed(E)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Correct `Object.isFrozen` and `Object.isSealed` to use integrity-level checks instead of direct `Frozen` / `Sealed` flags.
- Add `TestIntegrityFrozen` and `TestIntegritySealed` logic for ordinary and symbol-keyed properties.
- Expand tests for frozen/sealed edge cases and enum immutability behavior.

Fixes #404 