### PR TITLE
Skip Vercel preview builds for non-website changes

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,6 +3,7 @@
   "framework": "nextjs",
   "buildCommand": "bun run build",
   "installCommand": "bun install --frozen-lockfile",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ./",
   "functions": {
     "src/app/api/run/route.ts": {
       "maxDuration": 15,

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,7 +3,7 @@
   "framework": "nextjs",
   "buildCommand": "bun run build",
   "installCommand": "bun install --frozen-lockfile",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ./",
+  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} ${VERCEL_GIT_COMMIT_SHA:-HEAD} -- ./",
   "functions": {
     "src/app/api/run/route.ts": {
       "maxDuration": 15,


### PR DESCRIPTION
## Summary
- Adds `ignoreCommand` to `website/vercel.json` so Vercel only builds previews when the `website/` directory has changes
- Uses `git diff --quiet HEAD^ HEAD -- ./` (Vercel's recommended approach) which exits 0 (skip) when no files changed, exits 1 (build) when they did

## Context
Vercel creates a preview deployment for every push to every branch by default. Since only the `website/` directory is deployed to Vercel, pushes that only touch Pascal source, tests, or other files outside `website/` don't need a preview build.
