### PR TITLE
Fix Number toString scientific notation threshold and format

### DIFF
--- a/source/units/Goccia.JSON.pas
+++ b/source/units/Goccia.JSON.pas
@@ -110,10 +110,6 @@ type
   end;
 
 const
-  // IEEE-754 binary64 values need up to 17 significant decimal digits to
-  // round-trip back to the same Double. This scientific pattern gives us
-  // one digit before the decimal point and up to 16 after it.
-  JSON_DOUBLE_ROUNDTRIP_SCIENTIFIC_FORMAT = '0.################E+00';
   JSON5_NO_BREAK_SPACE = #$C2#$A0;
   JSON5_OGHAM_SPACE_MARK = #$E1#$9A#$80;
   JSON5_EN_QUAD = #$E2#$80#$80;
@@ -250,72 +246,10 @@ begin
   end;
 end;
 
-function SameDoubleBits(const ALeft, ARight: Double): Boolean;
-var
-  LeftValue, RightValue: Double;
-  LeftBits: Int64 absolute LeftValue;
-  RightBits: Int64 absolute RightValue;
-begin
-  LeftValue := ALeft;
-  RightValue := ARight;
-  Result := LeftBits = RightBits;
-end;
-
-function TrimTrailingFractionalZeros(const AValue: string): string;
-begin
-  Result := AValue;
-  while (Pos('.', Result) > 0) and (Length(Result) > 0) and (Result[Length(Result)] = '0') do
-    Delete(Result, Length(Result), 1);
-  if (Length(Result) > 0) and (Result[Length(Result)] = '.') then
-    Delete(Result, Length(Result), 1);
-end;
-
-function NormalizeExponentNumber(const AValue: string): string;
-var
-  ExponentIndex, SignIndex: Integer;
-  Mantissa, ExponentPart: string;
-begin
-  ExponentIndex := Pos('E', AValue);
-  if ExponentIndex = 0 then
-  begin
-    Result := TrimTrailingFractionalZeros(AValue);
-    Exit;
-  end;
-
-  Mantissa := TrimTrailingFractionalZeros(Copy(AValue, 1, ExponentIndex - 1));
-  ExponentPart := Copy(AValue, ExponentIndex + 1, MaxInt);
-
-  if (Length(ExponentPart) > 0) and ((ExponentPart[1] = '+') or (ExponentPart[1] = '-')) then
-    SignIndex := 2
-  else
-    SignIndex := 1;
-
-  while (Length(ExponentPart) > SignIndex) and (ExponentPart[SignIndex] = '0') do
-    Delete(ExponentPart, SignIndex, 1);
-
-  Result := Mantissa + 'e' + ExponentPart;
-end;
-
-function NumericStringRoundTrips(const ASerialized: string; const AValue: Double): Boolean;
-var
-  ParsedValue: Double;
-begin
-  if not TryStrToFloat(ASerialized, ParsedValue, DefaultFormatSettings) then
-    Exit(False);
-  Result := SameDoubleBits(ParsedValue, AValue);
-end;
-
+// ES2026 §25.5.2.5 SerializeJSONProperty — step 8.a: ToString(value)
 function SerializeJSONNumber(const AValue: Double): string;
 begin
-  if AValue = 0 then
-    Exit('0');
-
-  Result := FloatToStr(AValue, DefaultFormatSettings);
-  if NumericStringRoundTrips(Result, AValue) then
-    Exit;
-
-  Result := NormalizeExponentNumber(
-    FormatFloat(JSON_DOUBLE_ROUNDTRIP_SCIENTIFIC_FORMAT, AValue, DefaultFormatSettings));
+  Result := DoubleToESString(AValue);
 end;
 
 procedure AppendEscapedChar(var ASB: TStringBuffer; const AValue: Char);

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -1958,7 +1958,7 @@ begin
     begin
       // Convert numeric literals to their decimal string representation
       NumericValue := ConvertNumberLiteral(Advance.Lexeme);
-      Key := FloatToStr(NumericValue);
+      Key := DoubleToESString(NumericValue);
     end
     else if Match([gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
                    gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
@@ -4197,7 +4197,7 @@ begin
       end
       else if Check(gttNumber) then
       begin
-        MemberName := FloatToStr(ConvertNumberLiteral(Advance.Lexeme));
+        MemberName := DoubleToESString(ConvertNumberLiteral(Advance.Lexeme));
       end
       else if Check(gttString) then
       begin

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -158,6 +158,9 @@ type
 
   procedure PinPrimitiveSingletons;
 
+  // ES2026 §6.1.6.1.13 — Number::toString for finite, non-zero doubles.
+  function DoubleToESString(AValue: Double): string;
+
 implementation
 
 uses
@@ -174,6 +177,144 @@ uses
   Goccia.Threading,
   Goccia.Timeout,
   Goccia.Values.ErrorHelper;
+
+const
+  MAX_SAFE_INTEGER_VALUE = 9007199254740991.0;
+
+// ES2026 §6.1.6.1.13 Number::toString
+//
+// Finds the shortest decimal representation (unique n, k, s triple with
+// k minimal) and formats it according to the spec's fixed-point vs
+// scientific-notation thresholds (n <= 21 for fixed, n > -6 for leading
+// zeros, scientific otherwise).
+//
+// Uses Str(V:W) with increasing width to find the shortest round-tripping
+// representation, since FloatToStrF caps precision at 15 significant digits
+// for Double values.
+function DoubleToESString(AValue: Double): string;
+
+  procedure FormatES(const AMantissa: string; AK, AN: Integer; ANeg: Boolean;
+    out AResult: string);
+  begin
+    // Step 7: k <= n <= 21 — integer with trailing zeros
+    if (AK <= AN) and (AN <= 21) then
+      AResult := AMantissa + StringOfChar('0', AN - AK)
+    // Step 8: 0 < n <= 21 (and n < k) — decimal within digits
+    else if (0 < AN) and (AN <= 21) then
+      AResult := Copy(AMantissa, 1, AN) + '.' + Copy(AMantissa, AN + 1, AK - AN)
+    // Step 9: -6 < n <= 0 — leading zeros after "0."
+    else if (AN > -6) and (AN <= 0) then
+      AResult := '0.' + StringOfChar('0', -AN) + AMantissa
+    // Steps 10-11: scientific notation
+    else if AK = 1 then
+    begin
+      if AN - 1 > 0 then
+        AResult := AMantissa + 'e+' + IntToStr(AN - 1)
+      else
+        AResult := AMantissa + 'e-' + IntToStr(1 - AN);
+    end
+    else
+    begin
+      if AN - 1 > 0 then
+        AResult := AMantissa[1] + '.' + Copy(AMantissa, 2, AK - 1) + 'e+' + IntToStr(AN - 1)
+      else
+        AResult := AMantissa[1] + '.' + Copy(AMantissa, 2, AK - 1) + 'e-' + IntToStr(1 - AN);
+    end;
+
+    if ANeg then
+      AResult := '-' + AResult;
+  end;
+
+var
+  IsNeg: Boolean;
+  SciStr, Mantissa, TestStr: string;
+  Exp, N, K, I, W, EPos, D: Integer;
+  Parsed: Double;
+  FS: TFormatSettings;
+begin
+  if AValue = 0 then
+    Exit('0');
+
+  IsNeg := AValue < 0;
+  if IsNeg then
+    AValue := -AValue;
+
+  // Fast path: safe integers (all digits exact, n <= 16 <= 21)
+  if (Frac(AValue) = 0) and (AValue <= MAX_SAFE_INTEGER_VALUE) then
+  begin
+    Str(AValue:0:0, Result);
+    if IsNeg then
+      Result := '-' + Result;
+    Exit;
+  end;
+
+  FS := DefaultFormatSettings;
+
+  // Probe k=1 (single significant digit). Str(V:9) always outputs at
+  // least 2 significant digits ("d.dE+ddd"), so we round the 2-digit
+  // mantissa to 1 digit and check round-trip. This handles cases like
+  // Number.MIN_VALUE whose shortest representation is "5e-324".
+  Str(AValue:9, SciStr);
+  SciStr := Trim(SciStr);
+  EPos := Pos('E', SciStr);
+  Exp := StrToInt(Copy(SciStr, EPos + 1, Length(SciStr) - EPos));
+
+  D := Ord(SciStr[1]) - Ord('0');
+  if SciStr[3] >= '5' then
+    Inc(D);
+  if D >= 10 then
+  begin
+    D := 1;
+    Inc(Exp);
+  end;
+
+  TestStr := IntToStr(D) + 'E' + IntToStr(Exp);
+  if TryStrToFloat(TestStr, Parsed, FS) and (Parsed = AValue) then
+  begin
+    N := Exp + 1;
+    FormatES(IntToStr(D), 1, N, IsNeg, Result);
+    Exit;
+  end;
+
+  // General case: find the shortest round-tripping representation.
+  // Str(V:W) outputs scientific notation with (W - 7) significant digits
+  // (for 3-digit exponents) and correctly rounds at each precision level.
+  // W=9 gives the minimum (2 sig digits), W=24 gives the maximum (17).
+  for W := 9 to 24 do
+  begin
+    Str(AValue:W, SciStr);
+    SciStr := Trim(SciStr);
+
+    if TryStrToFloat(SciStr, Parsed, FS) and (Parsed = AValue) then
+    begin
+      EPos := Pos('E', SciStr);
+      Mantissa := Copy(SciStr, 1, EPos - 1);
+      Exp := StrToInt(Copy(SciStr, EPos + 1, Length(SciStr) - EPos));
+      N := Exp + 1;
+
+      // Remove decimal point from mantissa
+      I := Pos('.', Mantissa);
+      if I > 0 then
+        Delete(Mantissa, I, 1);
+
+      // Strip trailing zeros
+      I := Length(Mantissa);
+      while (I > 1) and (Mantissa[I] = '0') do
+        Dec(I);
+      SetLength(Mantissa, I);
+      K := Length(Mantissa);
+
+      FormatES(Mantissa, K, N, IsNeg, Result);
+      Exit;
+    end;
+  end;
+
+  // Fallback (unreachable for valid finite doubles — 17 sig digits always
+  // suffice). Use FloatToStr as a safety net.
+  Result := FloatToStr(AValue, FS);
+  if IsNeg then
+    Result := '-' + Result;
+end;
 
 { TGocciaValue }
 
@@ -580,7 +721,7 @@ begin
   else if IsNegativeZero then
     Result := TGocciaStringLiteralValue.Create('0')
   else
-    Result := TGocciaStringLiteralValue.Create(FloatToStr(FValue));
+    Result := TGocciaStringLiteralValue.Create(DoubleToESString(FValue));
 end;
 
 

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -240,6 +240,7 @@ begin
   end;
 
   FS := DefaultFormatSettings;
+  FS.DecimalSeparator := '.';
 
   // Probe k=1 (single significant digit). Str(V:9) always outputs at
   // least 2 significant digits ("d.dE+ddd"), so we round the 2-digit

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -158,7 +158,7 @@ type
 
   procedure PinPrimitiveSingletons;
 
-  // ES2026 §6.1.6.1.13 — Number::toString for finite, non-zero doubles.
+  // ES2026 §6.1.6.1.13 Number::toString(x)
   function DoubleToESString(AValue: Double): string;
 
 implementation
@@ -181,16 +181,7 @@ uses
 const
   MAX_SAFE_INTEGER_VALUE = 9007199254740991.0;
 
-// ES2026 §6.1.6.1.13 Number::toString
-//
-// Finds the shortest decimal representation (unique n, k, s triple with
-// k minimal) and formats it according to the spec's fixed-point vs
-// scientific-notation thresholds (n <= 21 for fixed, n > -6 for leading
-// zeros, scientific otherwise).
-//
-// Uses Str(V:W) with increasing width to find the shortest round-tripping
-// representation, since FloatToStrF caps precision at 15 significant digits
-// for Double values.
+// ES2026 §6.1.6.1.13 Number::toString(x)
 function DoubleToESString(AValue: Double): string;
 
   procedure FormatES(const AMantissa: string; AK, AN: Integer; ANeg: Boolean;

--- a/tests/built-ins/Number/prototype/toString.js
+++ b/tests/built-ins/Number/prototype/toString.js
@@ -34,4 +34,71 @@ describe("Number.prototype.toString", () => {
   test("toString on negative zero", () => {
     expect((-0).toString()).toBe("0");
   });
+
+  test("integers >= 1e15 and < 1e21 use fixed-point notation", () => {
+    expect((1e15).toString()).toBe("1000000000000000");
+    expect((1e16).toString()).toBe("10000000000000000");
+    expect((1e17).toString()).toBe("100000000000000000");
+    expect((1e18).toString()).toBe("1000000000000000000");
+    expect((1e19).toString()).toBe("10000000000000000000");
+    expect((1e20).toString()).toBe("100000000000000000000");
+  });
+
+  test("integers >= 1e21 use scientific notation with lowercase e+", () => {
+    expect((1e21).toString()).toBe("1e+21");
+    expect((1e25).toString()).toBe("1e+25");
+    expect((1e100).toString()).toBe("1e+100");
+  });
+
+  test("Number.MAX_SAFE_INTEGER uses fixed-point notation", () => {
+    expect((9007199254740991).toString()).toBe("9007199254740991");
+  });
+
+  test("large integers near 1e15 boundary", () => {
+    expect((999999999999999).toString()).toBe("999999999999999");
+    expect((1234567890123456).toString()).toBe("1234567890123456");
+    expect((4294967295).toString()).toBe("4294967295");
+    expect((4294967296).toString()).toBe("4294967296");
+  });
+
+  test("negative large integers use fixed-point notation", () => {
+    expect((-1e15).toString()).toBe("-1000000000000000");
+    expect((-1e20).toString()).toBe("-100000000000000000000");
+    expect((-9007199254740991).toString()).toBe("-9007199254740991");
+  });
+
+  test("negative large integers >= 1e21 use scientific notation", () => {
+    expect((-1e21).toString()).toBe("-1e+21");
+  });
+
+  test("very small numbers use scientific notation with e-", () => {
+    expect((1e-7).toString()).toBe("1e-7");
+    expect((1.5e-10).toString()).toBe("1.5e-10");
+    expect((5e-324).toString()).toBe("5e-324");
+  });
+
+  test("small numbers above 1e-7 threshold use fixed-point", () => {
+    expect((0.000001).toString()).toBe("0.000001");
+    expect((0.0000001).toString()).toBe("1e-7");
+  });
+
+  test("String() coercion matches toString for large integers", () => {
+    expect(String(1e15)).toBe("1000000000000000");
+    expect(String(1e20)).toBe("100000000000000000000");
+    expect(String(1e21)).toBe("1e+21");
+    expect(String(9007199254740991)).toBe("9007199254740991");
+  });
+
+  test("template literal coercion matches toString for large integers", () => {
+    expect(`${1e15}`).toBe("1000000000000000");
+    expect(`${1e20}`).toBe("100000000000000000000");
+    expect(`${1e21}`).toBe("1e+21");
+    expect(`${9007199254740991}`).toBe("9007199254740991");
+  });
+
+  test("string concatenation coercion matches toString for large integers", () => {
+    expect("" + 1e15).toBe("1000000000000000");
+    expect("" + 1e20).toBe("100000000000000000000");
+    expect("" + 1e21).toBe("1e+21");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #400.

- Implement `DoubleToESString` per ES2026 §6.1.6.1.13 — integers in `[1e15, 1e21)` now use fixed-point notation instead of premature scientific notation, and scientific notation uses lowercase `e+`/`e-` per spec
- Replace `FloatToStr` in `ToStringLiteral` and the parser's numeric property key paths, fixing `String(n)`, template literals, `JSON.stringify`, and computed member names for large integers
- Add 10 new test cases covering the issue's repro, `Number.MAX_SAFE_INTEGER`, negative large integers, `5e-324`, small-number thresholds, and implicit coercion paths
