### PR TITLE
Fix decorator wrapper this-binding test gap and misdirecting warning

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -1,3 +1,4 @@
+<!-- doc-length-limit: 850 -->
 # Language
 
 *GocciaScript's ECMAScript subset: what we implement, TC39 proposals, and what we exclude.*
@@ -427,6 +428,18 @@ class C {}
 C[Symbol.metadata].decorated; // true
 ```
 
+**Writing wrappers:** Wrapping decorators need call-site `this` to flow through. Arrow functions capture lexical `this`, so they are not suitable. The `function` keyword is not available by default. Use **object-method shorthand** — it produces a real function with call-site `this` binding:
+
+```javascript
+const wrap = (method, context) => ({
+  [context.name](...args) {
+    return method.apply(this, args); // this = call-site receiver
+  },
+})[context.name];
+```
+
+The computed key `[context.name]` preserves the wrapper's `.name` for stack traces.
+
 **Not supported:** Parameter decorators.
 
 ### Decorator Metadata (Stage 3)
@@ -585,7 +598,7 @@ When disabled (default), the parser accepts `function` declarations and expressi
 
 ```text
 Warning: 'function' declarations are not supported in GocciaScript
-  Suggestion: Use arrow functions instead: const name = (...) => { ... }
+  Suggestion: Use arrow functions: const name = (...) => { ... }; for this binding, use method shorthand: ({ name(...) {} }).name
   --> script.js:1:1
 ```
 

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -1738,7 +1738,7 @@ begin
     if not FFunctionDeclarationsEnabled then
     begin
       AddWarning('''function'' expressions are not supported in GocciaScript',
-        'Use arrow functions instead: const name = (...) => { ... }',
+        'Use arrow functions: const f = (...) => { ... }; for wrappers needing call-site this, use method shorthand: ({ m(...) {} }).m',
         Token.Line, Token.Column);
       SkipUnsupportedFunctionSignature;
       Result := TGocciaLiteralExpression.Create(
@@ -2981,7 +2981,7 @@ begin
   if not FFunctionDeclarationsEnabled then
   begin
     AddWarning('''async function'' is not supported in GocciaScript',
-      'Use async arrow functions instead: const name = async (...) => { ... }',
+      'Use async arrow functions: const name = async (...) => { ... }; for this binding, use async method shorthand: ({ async m(...) {} }).m',
       AAsyncLine, AAsyncColumn);
     SkipUnsupportedFunctionSignature;
     Exit(afcDisabled);
@@ -3251,7 +3251,7 @@ begin
   if not FFunctionDeclarationsEnabled then
   begin
     AddWarning('''function'' declarations are not supported in GocciaScript',
-      'Use arrow functions instead: const name = (...) => { ... }',
+      'Use arrow functions: const name = (...) => { ... }; for this binding, use method shorthand: ({ name(...) {} }).name',
       Line, Column);
     SkipUnsupportedFunctionSignature;
     Result := TGocciaEmptyStatement.Create(Line, Column);
@@ -3859,7 +3859,7 @@ begin
     if not FFunctionDeclarationsEnabled then
     begin
       AddWarning('''function'' declarations are not supported in GocciaScript',
-        'Use arrow functions instead: const name = (...) => { ... }',
+        'Use arrow functions: const name = (...) => { ... }; for this binding, use method shorthand: ({ name(...) {} }).name',
         Line, Column);
       Advance;
       SkipUnsupportedFunctionSignature;

--- a/tests/language/decorators/basic-method-decorator.js
+++ b/tests/language/decorators/basic-method-decorator.js
@@ -27,11 +27,10 @@ describe("method decorators", () => {
     expect(receivedContext.private).toBe(false);
   });
 
-  test("decorator can replace method", () => {
+  test("decorator can replace method with arrow wrapper", () => {
     const double = (method, context) => {
-      return (/* ...args */) => {
-        const result = method.call(this);
-        return result * 2;
+      return (...args) => {
+        return method(...args) * 2;
       };
     };
 
@@ -44,6 +43,51 @@ describe("method decorators", () => {
 
     const calc = new Calculator();
     expect(calc.value()).toBe(42);
+  });
+
+  test("wrapper preserves call-site this", () => {
+    const wrap = (method, context) => ({
+      [context.name](...args) {
+        return method.apply(this, args);
+      },
+    })[context.name];
+
+    class Counter {
+      count = 10;
+
+      @wrap
+      getCount() {
+        return this.count;
+      }
+    }
+
+    const c = new Counter();
+    expect(c.getCount()).toBe(10);
+    c.count = 42;
+    expect(c.getCount()).toBe(42);
+  });
+
+  test("wrapper supports recursive self-call", () => {
+    const calls = [];
+    const trace = (method, context) => ({
+      [context.name](...args) {
+        calls.push(args[0]);
+        return method.apply(this, args);
+      },
+    })[context.name];
+
+    class Math2 {
+      @trace
+      fib(n) {
+        if (n < 2) return n;
+        return this.fib(n - 1) + this.fib(n - 2);
+      }
+    }
+
+    const result = new Math2().fib(6);
+    expect(result).toBe(8);
+    expect(calls[0]).toBe(6);
+    expect(calls.length).toBeGreaterThan(1);
   });
 
   test("decorator returning undefined keeps original", () => {


### PR DESCRIPTION
## Summary

Closes #405.

- **Tests**: fix "decorator can replace method" to use an honest arrow wrapper (this-independent method), add "wrapper preserves call-site this" and "wrapper supports recursive self-call" using object-method shorthand
- **Docs**: add "Writing wrappers" subsection to Decorators in `language.md` showing the object-method-shorthand pattern and why arrows/function expressions are unsuitable for this-capturing wrappers
- **Warning**: update all four function/async-function parser warnings to suggest object-method shorthand alongside arrow functions, instead of recommending only arrows (which lose call-site this)