### PR TITLE
Thread options through Temporal *.until / *.since methods

### DIFF
--- a/docs/built-ins-temporal.md
+++ b/docs/built-ins-temporal.md
@@ -86,7 +86,7 @@ Represents a calendar date without time or timezone.
 |--------|-------------|
 | `with(fields)` | Return new date with overridden fields |
 | `add(duration)` / `subtract(duration)` | Date arithmetic |
-| `until(other)` / `since(other)` | Difference as Duration |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` where `largestUnit` is `"year"`, `"month"`, `"week"`, or `"day"` (default `"day"`). |
 | `equals(other)` | Equality check |
 | `toPlainDateTime(time?)` | Combine with a time |
 | `toPlainYearMonth()` | Extract year and month as PlainYearMonth |
@@ -139,7 +139,7 @@ Represents a date and time without timezone. Combines PlainDate and PlainTime.
 | `with(fields)` | Return new date-time with overridden fields |
 | `withPlainTime(time?)` | Replace time component |
 | `add(duration)` / `subtract(duration)` | Date-time arithmetic |
-| `until(other)` / `since(other)` | Difference as Duration |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` — any unit from `"year"` to `"nanosecond"` (default `"day"`). |
 | `round(options)` | Round to nearest unit. Accepts a string (smallestUnit) or options object `{ smallestUnit, roundingMode, roundingIncrement }`. |
 | `equals(other)` | Equality check |
 | `toPlainDate()` / `toPlainTime()` | Extract date or time component |
@@ -169,7 +169,7 @@ Represents an absolute point in time (epoch-based), independent of calendar or t
 | Method | Description |
 |--------|-------------|
 | `add(duration)` / `subtract(duration)` | Time arithmetic (no calendar units) |
-| `until(other)` / `since(other)` | Difference as Duration |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` — `"hour"` through `"nanosecond"` (default `"hour"`). Calendar units not allowed. |
 | `round(options)` | Round to nearest unit. Accepts a string (smallestUnit) or options object `{ smallestUnit, roundingMode, roundingIncrement }`. |
 | `equals(other)` | Equality check |
 | `toString([options])` / `toJSON()` | ISO string with UTC (e.g., `"2024-03-15T13:45:30Z"`). `toString` accepts `{ fractionalSecondDigits }` (0-9 or `"auto"`). |
@@ -197,7 +197,7 @@ Represents a year and month without a day, time, or timezone.
 |--------|-------------|
 | `with(fields)` | Return new year-month with overridden fields |
 | `add(duration)` / `subtract(duration)` | Year-month arithmetic (years and months only) |
-| `until(other)` / `since(other)` | Difference as Duration (years and months) |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` — `"year"` (default) or `"month"`. |
 | `equals(other)` | Equality check |
 | `toPlainDate(item)` | Combine with a day (`{ day }`) to create a PlainDate |
 | `toString()` / `toJSON()` | ISO string (e.g., `"2024-03"`) |
@@ -260,7 +260,7 @@ Represents an absolute date and time in a specific timezone. Combines an instant
 | `withPlainTime(time?)` | Replace time component |
 | `withTimeZone(timeZone)` | Re-interpret the same instant in a different timezone |
 | `add(duration)` / `subtract(duration)` | Date-time arithmetic |
-| `until(other)` / `since(other)` | Difference as Duration |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` — any unit from `"year"` to `"nanosecond"` (default `"hour"`). |
 | `round(options)` | Round to nearest unit. Accepts a string (smallestUnit) or options object `{ smallestUnit, roundingMode, roundingIncrement }`. |
 | `equals(other)` | Equality check |
 | `startOfDay()` | Return ZonedDateTime at the start of the wall-clock day |

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -787,8 +787,12 @@ var
 begin
   Result := nil;
   Arg := AArgs.GetElement(AIndex);
+  if (Arg = nil) or (Arg is TGocciaUndefinedLiteralValue) then
+    Exit;
   if Arg is TGocciaObjectValue then
-    Result := TGocciaObjectValue(Arg);
+    Result := TGocciaObjectValue(Arg)
+  else
+    ThrowTypeError('Options argument must be an object or undefined', '');
 end;
 
 end.

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -7,6 +7,7 @@ interface
 uses
   BigInteger,
 
+  Goccia.Arguments.Collection,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
@@ -81,6 +82,19 @@ procedure RoundTimeForToString(
   const AFractionalDigits: Integer;
   const ARoundingMode: TTemporalRoundingMode);
 function FormatCalendarAnnotation(const ACalendarDisplay: TTemporalCalendarDisplay): string;
+
+{ Calendar-aware date differencing — implements CalendarDateUntil from TC39.
+  Computes the difference (Y2,M2,D2) - (Y1,M1,D1) broken into years, months,
+  weeks, and days based on ALargestUnit (tuYear, tuMonth, tuWeek, or tuDay). }
+procedure CalendarDateUntil(
+  const AY1, AM1, AD1, AY2, AM2, AD2: Integer;
+  const ALargestUnit: TTemporalUnit;
+  out AYears, AMonths, AWeeks, ADays: Int64);
+
+{ Extract diff options from an arguments collection at a given index.
+  Returns nil if the argument is undefined/missing. }
+function GetDiffOptions(const AArgs: TGocciaArgumentsCollection;
+  const AIndex: Integer): TGocciaObjectValue;
 
 implementation
 
@@ -676,6 +690,105 @@ begin
   else
     Result := ''; // auto and never: omit for iso8601
   end;
+end;
+
+{ --------------------------------------------------------------------------- }
+{ CalendarDateUntil                                                            }
+{ --------------------------------------------------------------------------- }
+
+procedure CalendarDateUntil(
+  const AY1, AM1, AD1, AY2, AM2, AD2: Integer;
+  const ALargestUnit: TTemporalUnit;
+  out AYears, AMonths, AWeeks, ADays: Int64);
+var
+  Sign: Integer;
+  FromY, FromM, FromD, ToY, ToM, ToD: Integer;
+  TotalMonths: Int64;
+  Mid: TTemporalDateRecord;
+  TotalDays: Int64;
+begin
+  AYears := 0;
+  AMonths := 0;
+  AWeeks := 0;
+  ADays := 0;
+
+  case ALargestUnit of
+    tuDay:
+    begin
+      ADays := DateToEpochDays(AY2, AM2, AD2) - DateToEpochDays(AY1, AM1, AD1);
+    end;
+
+    tuWeek:
+    begin
+      TotalDays := DateToEpochDays(AY2, AM2, AD2) - DateToEpochDays(AY1, AM1, AD1);
+      AWeeks := TotalDays div 7;
+      ADays := TotalDays mod 7;
+    end;
+
+    tuMonth, tuYear:
+    begin
+      Sign := CompareDates(AY2, AM2, AD2, AY1, AM1, AD1);
+      if Sign = 0 then Exit;
+
+      // Always work from earlier to later, sign-correct at end
+      if Sign > 0 then
+      begin
+        FromY := AY1; FromM := AM1; FromD := AD1;
+        ToY := AY2; ToM := AM2; ToD := AD2;
+      end
+      else
+      begin
+        FromY := AY2; FromM := AM2; FromD := AD2;
+        ToY := AY1; ToM := AM1; ToD := AD1;
+      end;
+
+      // Estimate total months from year/month components
+      TotalMonths := Int64(ToY - FromY) * 12 + Int64(ToM - FromM);
+
+      // Check if the estimate overshoots due to day clamping
+      Mid := AddMonthsToDate(FromY, FromM, FromD, TotalMonths);
+      if CompareDates(Mid.Year, Mid.Month, Mid.Day, ToY, ToM, ToD) > 0 then
+      begin
+        Dec(TotalMonths);
+        Mid := AddMonthsToDate(FromY, FromM, FromD, TotalMonths);
+      end;
+
+      // Remainder in days
+      ADays := DateToEpochDays(ToY, ToM, ToD) -
+               DateToEpochDays(Mid.Year, Mid.Month, Mid.Day);
+
+      if ALargestUnit = tuYear then
+      begin
+        AYears := TotalMonths div 12;
+        AMonths := TotalMonths mod 12;
+      end
+      else
+        AMonths := TotalMonths;
+
+      // Apply sign
+      if Sign < 0 then
+      begin
+        AYears := -AYears;
+        AMonths := -AMonths;
+        ADays := -ADays;
+      end;
+    end;
+  end;
+end;
+
+{ --------------------------------------------------------------------------- }
+{ GetDiffOptions                                                               }
+{ --------------------------------------------------------------------------- }
+
+function GetDiffOptions(const AArgs: TGocciaArgumentsCollection;
+  const AIndex: Integer): TGocciaObjectValue;
+var
+  Arg: TGocciaValue;
+begin
+  Result := nil;
+  Arg := AArgs.GetElement(AIndex);
+  if Arg is TGocciaObjectValue then
+    Result := TGocciaObjectValue(Arg);
 end;
 
 end.

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -376,6 +376,7 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
+  if LargestUnit = tuAuto then LargestUnit := tuHour;
   if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
 
@@ -410,6 +411,7 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
+  if LargestUnit = tuAuto then LargestUnit := tuHour;
   if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
 

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -309,15 +309,75 @@ begin
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
 end;
 
+function InstantDiffToUnits(const ADiffMs: Int64; const ADiffSubMs: Integer;
+  const ALargestUnit: TTemporalUnit): TGocciaValue;
+var
+  Ms, SubMs: Int64;
+  TotalSec, TotalMin: Int64;
+begin
+  Ms := ADiffMs;
+  SubMs := ADiffSubMs;
+
+  case ALargestUnit of
+    tuHour:
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
+        Ms div 3600000,
+        (Ms mod 3600000) div 60000,
+        ((Ms mod 3600000) mod 60000) div 1000,
+        ((Ms mod 3600000) mod 60000) mod 1000,
+        SubMs div 1000,
+        SubMs mod 1000);
+    tuMinute:
+    begin
+      TotalMin := Ms div 60000;
+      Ms := Ms mod 60000;
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0,
+        TotalMin,
+        Ms div 1000,
+        Ms mod 1000,
+        SubMs div 1000,
+        SubMs mod 1000);
+    end;
+    tuSecond:
+    begin
+      TotalSec := Ms div 1000;
+      Ms := Ms mod 1000;
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0,
+        TotalSec,
+        Ms,
+        SubMs div 1000,
+        SubMs mod 1000);
+    end;
+    tuMillisecond:
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0,
+        Ms,
+        SubMs div 1000,
+        SubMs mod 1000);
+    tuMicrosecond:
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0,
+        Ms * 1000 + SubMs div 1000,
+        SubMs mod 1000);
+  else // tuNanosecond
+    Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0,
+      Ms * 1000000 + SubMs);
+  end;
+end;
+
 function TGocciaTemporalInstantValue.InstantUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Inst, Other: TGocciaTemporalInstantValue;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
   DiffMs: Int64;
   DiffSubMs: Integer;
-  RemMs: Int64;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.until');
   Other := CoerceInstant(AArgs.GetElement(0), 'Instant.prototype.until');
+
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuHour);
+  if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
 
   DiffMs := Other.FEpochMilliseconds - Inst.FEpochMilliseconds;
   DiffSubMs := Other.FSubMillisecondNanoseconds - Inst.FSubMillisecondNanoseconds;
@@ -334,26 +394,24 @@ begin
     Dec(DiffSubMs, 1000000);
   end;
 
-  // Decompose ms into hours/minutes/seconds/ms without collapsing to total ns
-  RemMs := DiffMs;
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    RemMs div 3600000,
-    (RemMs mod 3600000) div 60000,
-    ((RemMs mod 3600000) mod 60000) div 1000,
-    ((RemMs mod 3600000) mod 60000) mod 1000,
-    DiffSubMs div 1000,
-    DiffSubMs mod 1000);
+  Result := InstantDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
 end;
 
 function TGocciaTemporalInstantValue.InstantSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Inst, Other: TGocciaTemporalInstantValue;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
   DiffMs: Int64;
   DiffSubMs: Integer;
-  RemMs: Int64;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.since');
   Other := CoerceInstant(AArgs.GetElement(0), 'Instant.prototype.since');
+
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuHour);
+  if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
 
   DiffMs := Inst.FEpochMilliseconds - Other.FEpochMilliseconds;
   DiffSubMs := Inst.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;
@@ -370,14 +428,7 @@ begin
     Dec(DiffSubMs, 1000000);
   end;
 
-  RemMs := DiffMs;
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    RemMs div 3600000,
-    (RemMs mod 3600000) div 60000,
-    ((RemMs mod 3600000) mod 60000) div 1000,
-    ((RemMs mod 3600000) mod 60000) mod 1000,
-    DiffSubMs div 1000,
-    DiffSubMs mod 1000);
+  Result := InstantDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
 end;
 
 function TGocciaTemporalInstantValue.InstantRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -522,6 +522,7 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuDay);
+  if LargestUnit = tuAuto then LargestUnit := tuDay;
   if not (LargestUnit in [tuYear, tuMonth, tuWeek, tuDay]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDate.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
 
@@ -544,6 +545,7 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuDay);
+  if LargestUnit = tuAuto then LargestUnit := tuDay;
   if not (LargestUnit in [tuYear, tuMonth, tuWeek, tuDay]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDate.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
 

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -513,29 +513,46 @@ end;
 function TGocciaTemporalPlainDateValue.DateUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D, Other: TGocciaTemporalPlainDateValue;
-  DiffDays: Int64;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
+  Years, Months, Weeks, Days: Int64;
 begin
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.until');
   Other := CoercePlainDate(AArgs.GetElement(0), 'PlainDate.prototype.until');
 
-  DiffDays := DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay) -
-              DateToEpochDays(D.FYear, D.FMonth, D.FDay);
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuDay);
+  if not (LargestUnit in [tuYear, tuMonth, tuWeek, tuDay]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDate.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
 
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, DiffDays, 0, 0, 0, 0, 0, 0);
+  CalendarDateUntil(D.FYear, D.FMonth, D.FDay,
+    Other.FYear, Other.FMonth, Other.FDay, LargestUnit,
+    Years, Months, Weeks, Days);
+
+  Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days, 0, 0, 0, 0, 0, 0);
 end;
 
 function TGocciaTemporalPlainDateValue.DateSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D, Other: TGocciaTemporalPlainDateValue;
-  DiffDays: Int64;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
+  Years, Months, Weeks, Days: Int64;
 begin
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.since');
   Other := CoercePlainDate(AArgs.GetElement(0), 'PlainDate.prototype.since');
 
-  DiffDays := DateToEpochDays(D.FYear, D.FMonth, D.FDay) -
-              DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay);
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuDay);
+  if not (LargestUnit in [tuYear, tuMonth, tuWeek, tuDay]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDate.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
 
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, DiffDays, 0, 0, 0, 0, 0, 0);
+  // since(other) = other.until(this): swap start/end
+  CalendarDateUntil(Other.FYear, Other.FMonth, Other.FDay,
+    D.FYear, D.FMonth, D.FDay, LargestUnit,
+    Years, Months, Weeks, Days);
+
+  Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days, 0, 0, 0, 0, 0, 0);
 end;
 
 function TGocciaTemporalPlainDateValue.DateEquals(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -629,6 +629,7 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuDay);
+  if LargestUnit = tuAuto then LargestUnit := tuDay;
 
   T1Ns := Int64(D.FNanosecond) + Int64(D.FMicrosecond) * 1000 + Int64(D.FMillisecond) * 1000000 +
            Int64(D.FSecond) * Int64(1000000000) + Int64(D.FMinute) * Int64(60000000000) +

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -617,12 +617,12 @@ var
   D, Other: TGocciaTemporalPlainDateTimeValue;
   OptionsObj: TGocciaObjectValue;
   LargestUnit: TTemporalUnit;
-  T1Ns, T2Ns, TimeDiffNs, TotalNs, AbsNs, RemNs: Int64;
-  Sgn: Int64;
+  T1Ns, T2Ns, TimeDiffNs: Int64;
+  DayDelta, Sgn: Int64;
   AdjY2, AdjM2, AdjD2: Integer;
   AdjDate: TTemporalDateRecord;
   Years, Months, Weeks, Days: Int64;
-  AbsTimeNs: Int64;
+  AbsTimeNs, AbsDays, TotalInUnit, RemNs: Int64;
 begin
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.until');
   Other := CoercePlainDateTime(AArgs.GetElement(0), 'PlainDateTime.prototype.until');
@@ -640,18 +640,18 @@ begin
 
   if LargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
   begin
-    // Calendar-aware differencing
+    // Calendar-aware differencing — keep days and time-ns separate to avoid
+    // Int64 overflow when multiplying day deltas by nanoseconds-per-day.
+    DayDelta := DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay) -
+                DateToEpochDays(D.FYear, D.FMonth, D.FDay);
     TimeDiffNs := T2Ns - T1Ns;
 
-    // Determine overall sign
-    TotalNs := (DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay) -
-                DateToEpochDays(D.FYear, D.FMonth, D.FDay)) * Int64(86400000000000) +
-               TimeDiffNs;
-
-    if TotalNs > 0 then
-      Sgn := 1
-    else if TotalNs < 0 then
-      Sgn := -1
+    // Determine overall sign from the two components.
+    // |TimeDiffNs| < 86400000000000 (always < 1 day), so DayDelta dominates.
+    if DayDelta > 0 then Sgn := 1
+    else if DayDelta < 0 then Sgn := -1
+    else if TimeDiffNs > 0 then Sgn := 1
+    else if TimeDiffNs < 0 then Sgn := -1
     else
     begin
       Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -691,56 +691,94 @@ begin
   end
   else
   begin
-    // Sub-day largestUnit: collapse everything to total nanoseconds
-    TotalNs := (DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay) -
-                DateToEpochDays(D.FYear, D.FMonth, D.FDay)) * Int64(86400000000000) +
-               (T2Ns - T1Ns);
+    // Sub-day largestUnit: keep days and time-ns separate to avoid overflow.
+    DayDelta := DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay) -
+                DateToEpochDays(D.FYear, D.FMonth, D.FDay);
+    TimeDiffNs := T2Ns - T1Ns;
 
-    if TotalNs > 0 then
-      Sgn := 1
-    else if TotalNs < 0 then
-      Sgn := -1
+    // Normalize: borrow/carry so DayDelta and TimeDiffNs share the same sign
+    if (DayDelta > 0) and (TimeDiffNs < 0) then
+    begin
+      Dec(DayDelta);
+      TimeDiffNs := TimeDiffNs + Int64(86400000000000);
+    end
+    else if (DayDelta < 0) and (TimeDiffNs > 0) then
+    begin
+      Inc(DayDelta);
+      TimeDiffNs := TimeDiffNs - Int64(86400000000000);
+    end;
+
+    if DayDelta > 0 then Sgn := 1
+    else if DayDelta < 0 then Sgn := -1
+    else if TimeDiffNs > 0 then Sgn := 1
+    else if TimeDiffNs < 0 then Sgn := -1
     else
     begin
       Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
       Exit;
     end;
 
-    AbsNs := Abs(TotalNs);
+    AbsDays := Abs(DayDelta);
+    AbsTimeNs := Abs(TimeDiffNs);
+
+    // Decompose by converting day delta using safe integer multiplication,
+    // then adding the within-day time remainder.
     case LargestUnit of
       tuHour:
-        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-          Sgn * (AbsNs div Int64(3600000000000)),
-          Sgn * ((AbsNs div Int64(60000000000)) mod 60),
-          Sgn * ((AbsNs div Int64(1000000000)) mod 60),
-          Sgn * ((AbsNs div 1000000) mod 1000),
-          Sgn * ((AbsNs div 1000) mod 1000),
-          Sgn * (AbsNs mod 1000));
+        begin
+          TotalInUnit := AbsDays * 24 + AbsTimeNs div Int64(3600000000000);
+          RemNs := AbsTimeNs mod Int64(3600000000000);
+          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
+            Sgn * TotalInUnit,
+            Sgn * (RemNs div Int64(60000000000)),
+            Sgn * ((RemNs div Int64(1000000000)) mod 60),
+            Sgn * ((RemNs div 1000000) mod 1000),
+            Sgn * ((RemNs div 1000) mod 1000),
+            Sgn * (RemNs mod 1000));
+        end;
       tuMinute:
-        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0,
-          Sgn * (AbsNs div Int64(60000000000)),
-          Sgn * ((AbsNs div Int64(1000000000)) mod 60),
-          Sgn * ((AbsNs div 1000000) mod 1000),
-          Sgn * ((AbsNs div 1000) mod 1000),
-          Sgn * (AbsNs mod 1000));
+        begin
+          TotalInUnit := AbsDays * 1440 + AbsTimeNs div Int64(60000000000);
+          RemNs := AbsTimeNs mod Int64(60000000000);
+          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0,
+            Sgn * TotalInUnit,
+            Sgn * (RemNs div Int64(1000000000)),
+            Sgn * ((RemNs div 1000000) mod 1000),
+            Sgn * ((RemNs div 1000) mod 1000),
+            Sgn * (RemNs mod 1000));
+        end;
       tuSecond:
-        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0,
-          Sgn * (AbsNs div Int64(1000000000)),
-          Sgn * ((AbsNs div 1000000) mod 1000),
-          Sgn * ((AbsNs div 1000) mod 1000),
-          Sgn * (AbsNs mod 1000));
+        begin
+          TotalInUnit := AbsDays * 86400 + AbsTimeNs div Int64(1000000000);
+          RemNs := AbsTimeNs mod Int64(1000000000);
+          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0,
+            Sgn * TotalInUnit,
+            Sgn * (RemNs div 1000000),
+            Sgn * ((RemNs div 1000) mod 1000),
+            Sgn * (RemNs mod 1000));
+        end;
       tuMillisecond:
-        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0,
-          Sgn * (AbsNs div 1000000),
-          Sgn * ((AbsNs div 1000) mod 1000),
-          Sgn * (AbsNs mod 1000));
+        begin
+          TotalInUnit := AbsDays * 86400000 + AbsTimeNs div 1000000;
+          RemNs := AbsTimeNs mod 1000000;
+          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0,
+            Sgn * TotalInUnit,
+            Sgn * (RemNs div 1000),
+            Sgn * (RemNs mod 1000));
+        end;
       tuMicrosecond:
-        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0,
-          Sgn * (AbsNs div 1000),
-          Sgn * (AbsNs mod 1000));
+        begin
+          TotalInUnit := AbsDays * Int64(86400000000) + AbsTimeNs div 1000;
+          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0,
+            Sgn * TotalInUnit,
+            Sgn * (AbsTimeNs mod 1000));
+        end;
     else // tuNanosecond
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0,
-        Sgn * AbsNs);
+      begin
+        TotalInUnit := AbsDays * Int64(86400000000000) + AbsTimeNs;
+        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0,
+          Sgn * TotalInUnit);
+      end;
     end;
   end;
 end;

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -615,12 +615,20 @@ end;
 function TGocciaTemporalPlainDateTimeValue.DateTimeUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D, Other: TGocciaTemporalPlainDateTimeValue;
-  T1Ns, T2Ns, TotalNs, AbsNs, RemNs: Int64;
-  DiffDays: Int64;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
+  T1Ns, T2Ns, TimeDiffNs, TotalNs, AbsNs, RemNs: Int64;
   Sgn: Int64;
+  AdjY2, AdjM2, AdjD2: Integer;
+  AdjDate: TTemporalDateRecord;
+  Years, Months, Weeks, Days: Int64;
+  AbsTimeNs: Int64;
 begin
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.until');
   Other := CoercePlainDateTime(AArgs.GetElement(0), 'PlainDateTime.prototype.until');
+
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuDay);
 
   T1Ns := Int64(D.FNanosecond) + Int64(D.FMicrosecond) * 1000 + Int64(D.FMillisecond) * 1000000 +
            Int64(D.FSecond) * Int64(1000000000) + Int64(D.FMinute) * Int64(60000000000) +
@@ -629,48 +637,133 @@ begin
            Int64(Other.FSecond) * Int64(1000000000) + Int64(Other.FMinute) * Int64(60000000000) +
            Int64(Other.FHour) * Int64(3600000000000);
 
-  // Compute total nanosecond difference to avoid mixed-sign components
-  TotalNs := (DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay) -
-              DateToEpochDays(D.FYear, D.FMonth, D.FDay)) * Int64(86400000000000) +
-             (T2Ns - T1Ns);
+  if LargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
+  begin
+    // Calendar-aware differencing
+    TimeDiffNs := T2Ns - T1Ns;
 
-  if TotalNs > 0 then
-    Sgn := 1
-  else if TotalNs < 0 then
-    Sgn := -1
+    // Determine overall sign
+    TotalNs := (DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay) -
+                DateToEpochDays(D.FYear, D.FMonth, D.FDay)) * Int64(86400000000000) +
+               TimeDiffNs;
+
+    if TotalNs > 0 then
+      Sgn := 1
+    else if TotalNs < 0 then
+      Sgn := -1
+    else
+    begin
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      Exit;
+    end;
+
+    // If time diff has opposite sign to overall diff, borrow/carry a day
+    AdjY2 := Other.FYear;
+    AdjM2 := Other.FMonth;
+    AdjD2 := Other.FDay;
+    if (Sgn > 0) and (TimeDiffNs < 0) then
+    begin
+      AdjDate := AddDaysToDate(AdjY2, AdjM2, AdjD2, -1);
+      AdjY2 := AdjDate.Year; AdjM2 := AdjDate.Month; AdjD2 := AdjDate.Day;
+      TimeDiffNs := TimeDiffNs + Int64(86400000000000);
+    end
+    else if (Sgn < 0) and (TimeDiffNs > 0) then
+    begin
+      AdjDate := AddDaysToDate(AdjY2, AdjM2, AdjD2, 1);
+      AdjY2 := AdjDate.Year; AdjM2 := AdjDate.Month; AdjD2 := AdjDate.Day;
+      TimeDiffNs := TimeDiffNs - Int64(86400000000000);
+    end;
+
+    CalendarDateUntil(D.FYear, D.FMonth, D.FDay,
+      AdjY2, AdjM2, AdjD2, LargestUnit,
+      Years, Months, Weeks, Days);
+
+    // Decompose time nanoseconds (same sign as overall result)
+    AbsTimeNs := Abs(TimeDiffNs);
+    Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days,
+      Sgn * (AbsTimeNs div Int64(3600000000000)),
+      Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60),
+      Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60),
+      Sgn * ((AbsTimeNs div 1000000) mod 1000),
+      Sgn * ((AbsTimeNs div 1000) mod 1000),
+      Sgn * (AbsTimeNs mod 1000));
+  end
   else
-    Sgn := 0;
+  begin
+    // Sub-day largestUnit: collapse everything to total nanoseconds
+    TotalNs := (DateToEpochDays(Other.FYear, Other.FMonth, Other.FDay) -
+                DateToEpochDays(D.FYear, D.FMonth, D.FDay)) * Int64(86400000000000) +
+               (T2Ns - T1Ns);
 
-  AbsNs := Abs(TotalNs);
-  DiffDays := AbsNs div Int64(86400000000000);
-  RemNs := AbsNs mod Int64(86400000000000);
+    if TotalNs > 0 then
+      Sgn := 1
+    else if TotalNs < 0 then
+      Sgn := -1
+    else
+    begin
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      Exit;
+    end;
 
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, Sgn * DiffDays,
-    Sgn * (RemNs div Int64(3600000000000)),
-    Sgn * ((RemNs div Int64(60000000000)) mod 60),
-    Sgn * ((RemNs div Int64(1000000000)) mod 60),
-    Sgn * ((RemNs div 1000000) mod 1000),
-    Sgn * ((RemNs div 1000) mod 1000),
-    Sgn * (RemNs mod 1000));
+    AbsNs := Abs(TotalNs);
+    case LargestUnit of
+      tuHour:
+        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
+          Sgn * (AbsNs div Int64(3600000000000)),
+          Sgn * ((AbsNs div Int64(60000000000)) mod 60),
+          Sgn * ((AbsNs div Int64(1000000000)) mod 60),
+          Sgn * ((AbsNs div 1000000) mod 1000),
+          Sgn * ((AbsNs div 1000) mod 1000),
+          Sgn * (AbsNs mod 1000));
+      tuMinute:
+        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0,
+          Sgn * (AbsNs div Int64(60000000000)),
+          Sgn * ((AbsNs div Int64(1000000000)) mod 60),
+          Sgn * ((AbsNs div 1000000) mod 1000),
+          Sgn * ((AbsNs div 1000) mod 1000),
+          Sgn * (AbsNs mod 1000));
+      tuSecond:
+        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0,
+          Sgn * (AbsNs div Int64(1000000000)),
+          Sgn * ((AbsNs div 1000000) mod 1000),
+          Sgn * ((AbsNs div 1000) mod 1000),
+          Sgn * (AbsNs mod 1000));
+      tuMillisecond:
+        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0,
+          Sgn * (AbsNs div 1000000),
+          Sgn * ((AbsNs div 1000) mod 1000),
+          Sgn * (AbsNs mod 1000));
+      tuMicrosecond:
+        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0,
+          Sgn * (AbsNs div 1000),
+          Sgn * (AbsNs mod 1000));
+    else // tuNanosecond
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0,
+        Sgn * AbsNs);
+    end;
+  end;
 end;
 
 function TGocciaTemporalPlainDateTimeValue.DateTimeSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D, Other: TGocciaTemporalPlainDateTimeValue;
   NewArgs: TGocciaArgumentsCollection;
-  UntilResult: TGocciaTemporalDurationValue;
+  OptionsArg: TGocciaValue;
 begin
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.since');
   Other := CoercePlainDateTime(AArgs.GetElement(0), 'PlainDateTime.prototype.since');
 
-  // since(other) = other.until(this)
-  NewArgs := TGocciaArgumentsCollection.Create([D]);
+  // since(other, options) = other.until(this, options)
+  OptionsArg := AArgs.GetElement(1);
+  if (OptionsArg <> nil) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    NewArgs := TGocciaArgumentsCollection.Create([D, OptionsArg])
+  else
+    NewArgs := TGocciaArgumentsCollection.Create([D]);
   try
-    UntilResult := TGocciaTemporalDurationValue(DateTimeUntil(NewArgs, Other));
+    Result := DateTimeUntil(NewArgs, Other);
   finally
     NewArgs.Free;
   end;
-  Result := UntilResult;
 end;
 
 function TGocciaTemporalPlainDateTimeValue.DateTimeRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -442,42 +442,72 @@ begin
   end;
 end;
 
-// TC39 Temporal §10.3.14 Temporal.PlainYearMonth.prototype.until(other)
+// TC39 Temporal §10.3.14 Temporal.PlainYearMonth.prototype.until(other [, options])
 function TGocciaTemporalPlainYearMonthValue.YearMonthUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   YM, Other: TGocciaTemporalPlainYearMonthValue;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
   TotalMonths1, TotalMonths2, DiffMonths: Int64;
   DiffYears, RemMonths: Int64;
 begin
   YM := AsPlainYearMonth(AThisValue, 'PlainYearMonth.prototype.until');
   Other := CoercePlainYearMonth(AArgs.GetElement(0), 'PlainYearMonth.prototype.until');
 
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuYear);
+  if not (LargestUnit in [tuYear, tuMonth]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainYearMonth.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
+
   TotalMonths1 := Int64(YM.FYear) * 12 + Int64(YM.FMonth);
   TotalMonths2 := Int64(Other.FYear) * 12 + Int64(Other.FMonth);
   DiffMonths := TotalMonths2 - TotalMonths1;
 
-  DiffYears := DiffMonths div 12;
-  RemMonths := DiffMonths mod 12;
+  if LargestUnit = tuYear then
+  begin
+    DiffYears := DiffMonths div 12;
+    RemMonths := DiffMonths mod 12;
+  end
+  else
+  begin
+    DiffYears := 0;
+    RemMonths := DiffMonths;
+  end;
 
   Result := TGocciaTemporalDurationValue.Create(DiffYears, RemMonths, 0, 0, 0, 0, 0, 0, 0, 0);
 end;
 
-// TC39 Temporal §10.3.15 Temporal.PlainYearMonth.prototype.since(other)
+// TC39 Temporal §10.3.15 Temporal.PlainYearMonth.prototype.since(other [, options])
 function TGocciaTemporalPlainYearMonthValue.YearMonthSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   YM, Other: TGocciaTemporalPlainYearMonthValue;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
   TotalMonths1, TotalMonths2, DiffMonths: Int64;
   DiffYears, RemMonths: Int64;
 begin
   YM := AsPlainYearMonth(AThisValue, 'PlainYearMonth.prototype.since');
   Other := CoercePlainYearMonth(AArgs.GetElement(0), 'PlainYearMonth.prototype.since');
 
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuYear);
+  if not (LargestUnit in [tuYear, tuMonth]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainYearMonth.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
+
   TotalMonths1 := Int64(YM.FYear) * 12 + Int64(YM.FMonth);
   TotalMonths2 := Int64(Other.FYear) * 12 + Int64(Other.FMonth);
   DiffMonths := TotalMonths1 - TotalMonths2;
 
-  DiffYears := DiffMonths div 12;
-  RemMonths := DiffMonths mod 12;
+  if LargestUnit = tuYear then
+  begin
+    DiffYears := DiffMonths div 12;
+    RemMonths := DiffMonths mod 12;
+  end
+  else
+  begin
+    DiffYears := 0;
+    RemMonths := DiffMonths;
+  end;
 
   Result := TGocciaTemporalDurationValue.Create(DiffYears, RemMonths, 0, 0, 0, 0, 0, 0, 0, 0);
 end;

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -456,6 +456,7 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuYear);
+  if LargestUnit = tuAuto then LargestUnit := tuYear;
   if not (LargestUnit in [tuYear, tuMonth]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainYearMonth.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
 
@@ -491,6 +492,7 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuYear);
+  if LargestUnit = tuAuto then LargestUnit := tuYear;
   if not (LargestUnit in [tuYear, tuMonth]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainYearMonth.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
 

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -870,32 +870,10 @@ end;
 function ZonedDiffToUnits(const ADiffMs: Int64; const ADiffSubMs: Integer;
   const ALargestUnit: TTemporalUnit): TGocciaValue;
 var
-  TotalSec, TotalMin, TotalDays, RemMs: Int64;
+  TotalSec, TotalMin: Int64;
+  RemMs: Int64;
 begin
   case ALargestUnit of
-    tuDay:
-    begin
-      TotalDays := ADiffMs div MILLISECONDS_PER_DAY;
-      RemMs := ADiffMs mod MILLISECONDS_PER_DAY;
-      // Normalize remainder sign with days sign
-      if (TotalDays > 0) and (RemMs < 0) then
-      begin
-        Dec(TotalDays);
-        RemMs := RemMs + MILLISECONDS_PER_DAY;
-      end
-      else if (TotalDays < 0) and (RemMs > 0) then
-      begin
-        Inc(TotalDays);
-        RemMs := RemMs - MILLISECONDS_PER_DAY;
-      end;
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, TotalDays,
-        RemMs div MILLISECONDS_PER_HOUR,
-        (RemMs mod MILLISECONDS_PER_HOUR) div MILLISECONDS_PER_MINUTE,
-        ((RemMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) div MILLISECONDS_PER_SECOND,
-        ((RemMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) mod MILLISECONDS_PER_SECOND,
-        ADiffSubMs div 1000,
-        ADiffSubMs mod 1000);
-    end;
     tuHour:
       Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
         ADiffMs div MILLISECONDS_PER_HOUR,
@@ -960,10 +938,11 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
+  if LargestUnit = tuAuto then LargestUnit := tuHour;
 
-  if LargestUnit in [tuYear, tuMonth, tuWeek] then
+  if LargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
   begin
-    // Calendar-aware: use wall-clock components
+    // Calendar-aware: use wall-clock components (DST-correct for day counting)
     ComputeLocalComponents(Zdt, Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1);
     ComputeLocalComponents(Other, Y2, M2, D2, H2, Mi2, S2, Ms2, Us2, Ns2);
 
@@ -1055,8 +1034,9 @@ begin
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
+  if LargestUnit = tuAuto then LargestUnit := tuHour;
 
-  if LargestUnit in [tuYear, tuMonth, tuWeek] then
+  if LargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
   begin
     // Calendar-aware: since = other.until(this) with same options
     ComputeLocalComponents(Other, Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1);

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -867,73 +867,267 @@ begin
   end;
 end;
 
+function ZonedDiffToUnits(const ADiffMs: Int64; const ADiffSubMs: Integer;
+  const ALargestUnit: TTemporalUnit): TGocciaValue;
+var
+  TotalSec, TotalMin, TotalDays, RemMs: Int64;
+begin
+  case ALargestUnit of
+    tuDay:
+    begin
+      TotalDays := ADiffMs div MILLISECONDS_PER_DAY;
+      RemMs := ADiffMs mod MILLISECONDS_PER_DAY;
+      // Normalize remainder sign with days sign
+      if (TotalDays > 0) and (RemMs < 0) then
+      begin
+        Dec(TotalDays);
+        RemMs := RemMs + MILLISECONDS_PER_DAY;
+      end
+      else if (TotalDays < 0) and (RemMs > 0) then
+      begin
+        Inc(TotalDays);
+        RemMs := RemMs - MILLISECONDS_PER_DAY;
+      end;
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, TotalDays,
+        RemMs div MILLISECONDS_PER_HOUR,
+        (RemMs mod MILLISECONDS_PER_HOUR) div MILLISECONDS_PER_MINUTE,
+        ((RemMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) div MILLISECONDS_PER_SECOND,
+        ((RemMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) mod MILLISECONDS_PER_SECOND,
+        ADiffSubMs div 1000,
+        ADiffSubMs mod 1000);
+    end;
+    tuHour:
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
+        ADiffMs div MILLISECONDS_PER_HOUR,
+        (ADiffMs mod MILLISECONDS_PER_HOUR) div MILLISECONDS_PER_MINUTE,
+        ((ADiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) div MILLISECONDS_PER_SECOND,
+        ((ADiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) mod MILLISECONDS_PER_SECOND,
+        ADiffSubMs div 1000,
+        ADiffSubMs mod 1000);
+    tuMinute:
+    begin
+      TotalMin := ADiffMs div MILLISECONDS_PER_MINUTE;
+      RemMs := ADiffMs mod MILLISECONDS_PER_MINUTE;
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0,
+        TotalMin,
+        RemMs div MILLISECONDS_PER_SECOND,
+        RemMs mod MILLISECONDS_PER_SECOND,
+        ADiffSubMs div 1000,
+        ADiffSubMs mod 1000);
+    end;
+    tuSecond:
+    begin
+      TotalSec := ADiffMs div MILLISECONDS_PER_SECOND;
+      RemMs := ADiffMs mod MILLISECONDS_PER_SECOND;
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0,
+        TotalSec,
+        RemMs,
+        ADiffSubMs div 1000,
+        ADiffSubMs mod 1000);
+    end;
+    tuMillisecond:
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0,
+        ADiffMs,
+        ADiffSubMs div 1000,
+        ADiffSubMs mod 1000);
+    tuMicrosecond:
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0,
+        ADiffMs * 1000 + ADiffSubMs div 1000,
+        ADiffSubMs mod 1000);
+  else // tuNanosecond
+    Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0,
+      ADiffMs * 1000000 + ADiffSubMs);
+  end;
+end;
+
 // TC39 Temporal §6.3.28 Temporal.ZonedDateTime.prototype.until(other [, options])
 function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Zdt, Other: TGocciaTemporalZonedDateTimeValue;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
   DiffMs: Int64;
   DiffSubMs: Integer;
+  Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1: Integer;
+  Y2, M2, D2, H2, Mi2, S2, Ms2, Us2, Ns2: Integer;
+  T1Ns, T2Ns, TimeDiffNs, TotalNs, Sgn, AbsTimeNs: Int64;
+  AdjDate: TTemporalDateRecord;
+  AdjY2, AdjM2, AdjD2: Integer;
+  Years, Months, Weeks, Days: Int64;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.until');
   Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.until');
 
-  DiffMs := Other.FEpochMilliseconds - Zdt.FEpochMilliseconds;
-  DiffSubMs := Other.FSubMillisecondNanoseconds - Zdt.FSubMillisecondNanoseconds;
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuHour);
 
-  // Normalize so DiffMs and DiffSubMs share the same sign
-  if (DiffMs > 0) and (DiffSubMs < 0) then
+  if LargestUnit in [tuYear, tuMonth, tuWeek] then
   begin
-    Dec(DiffMs);
-    Inc(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+    // Calendar-aware: use wall-clock components
+    ComputeLocalComponents(Zdt, Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1);
+    ComputeLocalComponents(Other, Y2, M2, D2, H2, Mi2, S2, Ms2, Us2, Ns2);
+
+    T1Ns := Int64(Ns1) + Int64(Us1) * 1000 + Int64(Ms1) * 1000000 +
+             Int64(S1) * Int64(1000000000) + Int64(Mi1) * Int64(60000000000) +
+             Int64(H1) * Int64(3600000000000);
+    T2Ns := Int64(Ns2) + Int64(Us2) * 1000 + Int64(Ms2) * 1000000 +
+             Int64(S2) * Int64(1000000000) + Int64(Mi2) * Int64(60000000000) +
+             Int64(H2) * Int64(3600000000000);
+    TimeDiffNs := T2Ns - T1Ns;
+
+    TotalNs := (DateToEpochDays(Y2, M2, D2) - DateToEpochDays(Y1, M1, D1)) *
+               Int64(86400000000000) + TimeDiffNs;
+
+    if TotalNs > 0 then
+      Sgn := 1
+    else if TotalNs < 0 then
+      Sgn := -1
+    else
+    begin
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      Exit;
+    end;
+
+    AdjY2 := Y2; AdjM2 := M2; AdjD2 := D2;
+    if (Sgn > 0) and (TimeDiffNs < 0) then
+    begin
+      AdjDate := AddDaysToDate(AdjY2, AdjM2, AdjD2, -1);
+      AdjY2 := AdjDate.Year; AdjM2 := AdjDate.Month; AdjD2 := AdjDate.Day;
+      TimeDiffNs := TimeDiffNs + Int64(86400000000000);
+    end
+    else if (Sgn < 0) and (TimeDiffNs > 0) then
+    begin
+      AdjDate := AddDaysToDate(AdjY2, AdjM2, AdjD2, 1);
+      AdjY2 := AdjDate.Year; AdjM2 := AdjDate.Month; AdjD2 := AdjDate.Day;
+      TimeDiffNs := TimeDiffNs - Int64(86400000000000);
+    end;
+
+    CalendarDateUntil(Y1, M1, D1, AdjY2, AdjM2, AdjD2, LargestUnit,
+      Years, Months, Weeks, Days);
+
+    AbsTimeNs := Abs(TimeDiffNs);
+    Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days,
+      Sgn * (AbsTimeNs div Int64(3600000000000)),
+      Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60),
+      Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60),
+      Sgn * ((AbsTimeNs div 1000000) mod 1000),
+      Sgn * ((AbsTimeNs div 1000) mod 1000),
+      Sgn * (AbsTimeNs mod 1000));
   end
-  else if (DiffMs < 0) and (DiffSubMs > 0) then
+  else
   begin
-    Inc(DiffMs);
-    Dec(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
-  end;
+    // Sub-day or day: use epoch difference
+    DiffMs := Other.FEpochMilliseconds - Zdt.FEpochMilliseconds;
+    DiffSubMs := Other.FSubMillisecondNanoseconds - Zdt.FSubMillisecondNanoseconds;
 
-  // Decompose ms into hours/minutes/seconds/ms without collapsing to total ns
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    DiffMs div MILLISECONDS_PER_HOUR,
-    (DiffMs mod MILLISECONDS_PER_HOUR) div MILLISECONDS_PER_MINUTE,
-    ((DiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) div MILLISECONDS_PER_SECOND,
-    ((DiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) mod MILLISECONDS_PER_SECOND,
-    DiffSubMs div 1000,
-    DiffSubMs mod 1000);
+    if (DiffMs > 0) and (DiffSubMs < 0) then
+    begin
+      Dec(DiffMs);
+      Inc(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+    end
+    else if (DiffMs < 0) and (DiffSubMs > 0) then
+    begin
+      Inc(DiffMs);
+      Dec(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+    end;
+
+    Result := ZonedDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
+  end;
 end;
 
 // TC39 Temporal §6.3.29 Temporal.ZonedDateTime.prototype.since(other [, options])
 function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Zdt, Other: TGocciaTemporalZonedDateTimeValue;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit: TTemporalUnit;
   DiffMs: Int64;
   DiffSubMs: Integer;
+  Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1: Integer;
+  Y2, M2, D2, H2, Mi2, S2, Ms2, Us2, Ns2: Integer;
+  T1Ns, T2Ns, TimeDiffNs, TotalNs, Sgn, AbsTimeNs: Int64;
+  AdjDate: TTemporalDateRecord;
+  AdjY1, AdjM1, AdjD1: Integer;
+  Years, Months, Weeks, Days: Int64;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.since');
   Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.since');
 
-  DiffMs := Zdt.FEpochMilliseconds - Other.FEpochMilliseconds;
-  DiffSubMs := Zdt.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuHour);
 
-  // Normalize so DiffMs and DiffSubMs share the same sign
-  if (DiffMs > 0) and (DiffSubMs < 0) then
+  if LargestUnit in [tuYear, tuMonth, tuWeek] then
   begin
-    Dec(DiffMs);
-    Inc(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+    // Calendar-aware: since = other.until(this) with same options
+    ComputeLocalComponents(Other, Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1);
+    ComputeLocalComponents(Zdt, Y2, M2, D2, H2, Mi2, S2, Ms2, Us2, Ns2);
+
+    T1Ns := Int64(Ns1) + Int64(Us1) * 1000 + Int64(Ms1) * 1000000 +
+             Int64(S1) * Int64(1000000000) + Int64(Mi1) * Int64(60000000000) +
+             Int64(H1) * Int64(3600000000000);
+    T2Ns := Int64(Ns2) + Int64(Us2) * 1000 + Int64(Ms2) * 1000000 +
+             Int64(S2) * Int64(1000000000) + Int64(Mi2) * Int64(60000000000) +
+             Int64(H2) * Int64(3600000000000);
+    TimeDiffNs := T2Ns - T1Ns;
+
+    TotalNs := (DateToEpochDays(Y2, M2, D2) - DateToEpochDays(Y1, M1, D1)) *
+               Int64(86400000000000) + TimeDiffNs;
+
+    if TotalNs > 0 then
+      Sgn := 1
+    else if TotalNs < 0 then
+      Sgn := -1
+    else
+    begin
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      Exit;
+    end;
+
+    AdjY1 := Y2; AdjM1 := M2; AdjD1 := D2;
+    if (Sgn > 0) and (TimeDiffNs < 0) then
+    begin
+      AdjDate := AddDaysToDate(AdjY1, AdjM1, AdjD1, -1);
+      AdjY1 := AdjDate.Year; AdjM1 := AdjDate.Month; AdjD1 := AdjDate.Day;
+      TimeDiffNs := TimeDiffNs + Int64(86400000000000);
+    end
+    else if (Sgn < 0) and (TimeDiffNs > 0) then
+    begin
+      AdjDate := AddDaysToDate(AdjY1, AdjM1, AdjD1, 1);
+      AdjY1 := AdjDate.Year; AdjM1 := AdjDate.Month; AdjD1 := AdjDate.Day;
+      TimeDiffNs := TimeDiffNs - Int64(86400000000000);
+    end;
+
+    CalendarDateUntil(Y1, M1, D1, AdjY1, AdjM1, AdjD1, LargestUnit,
+      Years, Months, Weeks, Days);
+
+    AbsTimeNs := Abs(TimeDiffNs);
+    Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days,
+      Sgn * (AbsTimeNs div Int64(3600000000000)),
+      Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60),
+      Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60),
+      Sgn * ((AbsTimeNs div 1000000) mod 1000),
+      Sgn * ((AbsTimeNs div 1000) mod 1000),
+      Sgn * (AbsTimeNs mod 1000));
   end
-  else if (DiffMs < 0) and (DiffSubMs > 0) then
+  else
   begin
-    Inc(DiffMs);
-    Dec(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
-  end;
+    // Sub-day or day: use epoch difference (this - other)
+    DiffMs := Zdt.FEpochMilliseconds - Other.FEpochMilliseconds;
+    DiffSubMs := Zdt.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;
 
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    DiffMs div MILLISECONDS_PER_HOUR,
-    (DiffMs mod MILLISECONDS_PER_HOUR) div MILLISECONDS_PER_MINUTE,
-    ((DiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) div MILLISECONDS_PER_SECOND,
-    ((DiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) mod MILLISECONDS_PER_SECOND,
-    DiffSubMs div 1000,
-    DiffSubMs mod 1000);
+    if (DiffMs > 0) and (DiffSubMs < 0) then
+    begin
+      Dec(DiffMs);
+      Inc(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+    end
+    else if (DiffMs < 0) and (DiffSubMs > 0) then
+    begin
+      Inc(DiffMs);
+      Dec(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
+    end;
+
+    Result := ZonedDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
+  end;
 end;
 
 // TC39 Temporal §6.3.30 Temporal.ZonedDateTime.prototype.round(roundTo)

--- a/tests/built-ins/Temporal/Instant/prototype/since.js
+++ b/tests/built-ins/Temporal/Instant/prototype/since.js
@@ -6,10 +6,22 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.Instant.prototype.since", () => {
-  test("since()", () => {
+  test("since() default returns hours", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(3600000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(0);
     const dur = i1.since(i2);
     expect(dur.hours).toBe(1);
+  });
+
+  test("since() with largestUnit minutes", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(90061000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(0);
+    expect(i1.since(i2, { largestUnit: "minutes" }).toString()).toBe("PT1501M1S");
+  });
+
+  test("since() with largestUnit seconds", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(90061000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(0);
+    expect(i1.since(i2, { largestUnit: "seconds" }).toString()).toBe("PT90061S");
   });
 });

--- a/tests/built-ins/Temporal/Instant/prototype/until.js
+++ b/tests/built-ins/Temporal/Instant/prototype/until.js
@@ -27,7 +27,7 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
   test("until() with largestUnit minutes", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(0);
     const i2 = Temporal.Instant.fromEpochMilliseconds(90061000);
-    expect(i2.until === undefined ? "missing" : i1.until(i2, { largestUnit: "minutes" }).toString()).toBe("PT1501M1S");
+    expect(i1.until(i2, { largestUnit: "minutes" }).toString()).toBe("PT1501M1S");
   });
 
   test("until() with largestUnit seconds", () => {

--- a/tests/built-ins/Temporal/Instant/prototype/until.js
+++ b/tests/built-ins/Temporal/Instant/prototype/until.js
@@ -6,7 +6,7 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
-  test("until()", () => {
+  test("until() default returns hours", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(0);
     const i2 = Temporal.Instant.fromEpochMilliseconds(3600000);
     const dur = i1.until(i2);
@@ -15,14 +15,38 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
   });
 
   test("until at extreme range does not overflow", () => {
-    // Span of ~200 million days — would overflow Int64 if collapsed to total ns
     const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
     const dur = i1.until(i2);
-    // Total = 17280000000000000 ms = 4800000000 hours
     expect(dur.hours).toBe(4800000000);
     expect(dur.minutes).toBe(0);
     expect(dur.seconds).toBe(0);
     expect(dur.milliseconds).toBe(0);
+  });
+
+  test("until() with largestUnit minutes", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(0);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(90061000);
+    expect(i2.until === undefined ? "missing" : i1.until(i2, { largestUnit: "minutes" }).toString()).toBe("PT1501M1S");
+  });
+
+  test("until() with largestUnit seconds", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(0);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(90061000);
+    expect(i1.until(i2, { largestUnit: "seconds" }).toString()).toBe("PT90061S");
+  });
+
+  test("until() with largestUnit milliseconds", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(0);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(5000);
+    const dur = i1.until(i2, { largestUnit: "milliseconds" });
+    expect(dur.milliseconds).toBe(5000);
+    expect(dur.seconds).toBe(0);
+  });
+
+  test("until() negative with largestUnit minutes", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(90000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(0);
+    expect(i1.until(i2, { largestUnit: "minutes" }).toString()).toBe("-PT1M30S");
   });
 });

--- a/tests/built-ins/Temporal/PlainDate/prototype/since.js
+++ b/tests/built-ins/Temporal/PlainDate/prototype/since.js
@@ -6,10 +6,28 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.PlainDate.prototype.since", () => {
-  test("since()", () => {
+  test("since() default returns days", () => {
     const d1 = new Temporal.PlainDate(2024, 1, 11);
     const d2 = new Temporal.PlainDate(2024, 1, 1);
     const dur = d1.since(d2);
     expect(dur.days).toBe(10);
+  });
+
+  test("since() with largestUnit months", () => {
+    const d1 = Temporal.PlainDate.from("2026-07-30");
+    const d2 = Temporal.PlainDate.from("2026-05-01");
+    expect(d1.since(d2, { largestUnit: "months" }).toString()).toBe("P2M29D");
+  });
+
+  test("since() with largestUnit weeks", () => {
+    const d1 = Temporal.PlainDate.from("2026-07-30");
+    const d2 = Temporal.PlainDate.from("2026-05-01");
+    expect(d1.since(d2, { largestUnit: "weeks" }).toString()).toBe("P12W6D");
+  });
+
+  test("since() with largestUnit years across multi-year span", () => {
+    const d1 = Temporal.PlainDate.from("2026-07-30");
+    const d2 = Temporal.PlainDate.from("2020-01-15");
+    expect(d1.since(d2, { largestUnit: "years" }).toString()).toBe("P6Y6M15D");
   });
 });

--- a/tests/built-ins/Temporal/PlainDate/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainDate/prototype/until.js
@@ -6,10 +6,66 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.PlainDate.prototype.until", () => {
-  test("until()", () => {
+  test("until() default returns days", () => {
     const d1 = new Temporal.PlainDate(2024, 1, 1);
     const d2 = new Temporal.PlainDate(2024, 1, 11);
     const dur = d1.until(d2);
     expect(dur.days).toBe(10);
+  });
+
+  test("until() with largestUnit day", () => {
+    const d1 = Temporal.PlainDate.from("2026-05-01");
+    const d2 = Temporal.PlainDate.from("2026-07-30");
+    expect(d1.until(d2, { largestUnit: "day" }).toString()).toBe("P90D");
+  });
+
+  test("until() with largestUnit months", () => {
+    const d1 = Temporal.PlainDate.from("2026-05-01");
+    const d2 = Temporal.PlainDate.from("2026-07-30");
+    expect(d1.until(d2, { largestUnit: "months" }).toString()).toBe("P2M29D");
+  });
+
+  test("until() with largestUnit years on sub-year span", () => {
+    const d1 = Temporal.PlainDate.from("2026-05-01");
+    const d2 = Temporal.PlainDate.from("2026-07-30");
+    expect(d1.until(d2, { largestUnit: "years" }).toString()).toBe("P2M29D");
+  });
+
+  test("until() with largestUnit weeks", () => {
+    const d1 = Temporal.PlainDate.from("2026-05-01");
+    const d2 = Temporal.PlainDate.from("2026-07-30");
+    expect(d1.until(d2, { largestUnit: "weeks" }).toString()).toBe("P12W6D");
+  });
+
+  test("until() multi-year span with largestUnit years", () => {
+    const d1 = Temporal.PlainDate.from("2020-01-15");
+    const d2 = Temporal.PlainDate.from("2026-07-30");
+    expect(d1.until(d2, { largestUnit: "years" }).toString()).toBe("P6Y6M15D");
+  });
+
+  test("until() negative result with largestUnit months", () => {
+    const d1 = Temporal.PlainDate.from("2026-07-30");
+    const d2 = Temporal.PlainDate.from("2026-05-01");
+    expect(d1.until(d2, { largestUnit: "months" }).toString()).toBe("-P2M29D");
+  });
+
+  test("until() day clamping across months with largestUnit months", () => {
+    const d1 = Temporal.PlainDate.from("2026-01-31");
+    const d2 = Temporal.PlainDate.from("2026-03-28");
+    expect(d1.until(d2, { largestUnit: "months" }).toString()).toBe("P1M28D");
+  });
+
+  test("until() same date returns zero duration", () => {
+    const d = Temporal.PlainDate.from("2026-06-15");
+    const dur = d.until(d, { largestUnit: "years" });
+    expect(dur.years).toBe(0);
+    expect(dur.months).toBe(0);
+    expect(dur.days).toBe(0);
+  });
+
+  test("until() leap year boundary with largestUnit months", () => {
+    const d1 = Temporal.PlainDate.from("2024-01-29");
+    const d2 = Temporal.PlainDate.from("2024-03-01");
+    expect(d1.until(d2, { largestUnit: "months" }).toString()).toBe("P1M1D");
   });
 });

--- a/tests/built-ins/Temporal/PlainDateTime/prototype/since.js
+++ b/tests/built-ins/Temporal/PlainDateTime/prototype/since.js
@@ -6,11 +6,23 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.PlainDateTime.prototype.since", () => {
-  test("since()", () => {
+  test("since() default returns days and time", () => {
     const dt1 = new Temporal.PlainDateTime(2024, 1, 2, 12, 0);
     const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0);
     const dur = dt1.since(dt2);
     expect(dur.days).toBe(1);
     expect(dur.hours).toBe(12);
+  });
+
+  test("since() with largestUnit months", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 4, 15, 14, 30);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 10, 0);
+    expect(dt1.since(dt2, { largestUnit: "months" }).toString()).toBe("P3M14DT4H30M");
+  });
+
+  test("since() with largestUnit hours", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 2, 12, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0);
+    expect(dt1.since(dt2, { largestUnit: "hours" }).toString()).toBe("PT36H");
   });
 });

--- a/tests/built-ins/Temporal/PlainDateTime/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainDateTime/prototype/until.js
@@ -6,11 +6,53 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.PlainDateTime.prototype.until", () => {
-  test("until()", () => {
+  test("until() default returns days and time", () => {
     const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0);
     const dt2 = new Temporal.PlainDateTime(2024, 1, 2, 12, 0);
     const dur = dt1.until(dt2);
     expect(dur.days).toBe(1);
     expect(dur.hours).toBe(12);
+  });
+
+  test("until() with largestUnit months", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 10, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 4, 15, 14, 30);
+    expect(dt1.until(dt2, { largestUnit: "months" }).toString()).toBe("P3M14DT4H30M");
+  });
+
+  test("until() with largestUnit years", () => {
+    const dt1 = new Temporal.PlainDateTime(2020, 6, 1, 0, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 9, 15, 12, 0);
+    expect(dt1.until(dt2, { largestUnit: "years" }).toString()).toBe("P4Y3M14DT12H");
+  });
+
+  test("until() with largestUnit hours", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 10, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 4, 15, 14, 30);
+    expect(dt1.until(dt2, { largestUnit: "hours" }).toString()).toBe("PT2524H30M");
+  });
+
+  test("until() with largestUnit minutes", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 2, 30);
+    expect(dt1.until(dt2, { largestUnit: "minutes" }).toString()).toBe("PT150M");
+  });
+
+  test("until() with largestUnit seconds", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 0, 1, 30);
+    expect(dt1.until(dt2, { largestUnit: "seconds" }).toString()).toBe("PT90S");
+  });
+
+  test("until() time borrowing across day with months", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 15, 20, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 3, 15, 8, 0);
+    expect(dt1.until(dt2, { largestUnit: "months" }).toString()).toBe("P1M28DT12H");
+  });
+
+  test("until() with largestUnit weeks", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 22, 12, 0);
+    expect(dt1.until(dt2, { largestUnit: "weeks" }).toString()).toBe("P3WT12H");
   });
 });

--- a/tests/built-ins/Temporal/PlainYearMonth/prototype/since.js
+++ b/tests/built-ins/Temporal/PlainYearMonth/prototype/since.js
@@ -6,11 +6,17 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.PlainYearMonth.prototype.since", () => {
-  test("since", () => {
+  test("since() default returns years and months", () => {
     const a = new Temporal.PlainYearMonth(2025, 6);
     const b = new Temporal.PlainYearMonth(2024, 3);
     const dur = a.since(b);
     expect(dur.years).toBe(1);
     expect(dur.months).toBe(3);
+  });
+
+  test("since() with largestUnit months returns months only", () => {
+    const a = new Temporal.PlainYearMonth(2025, 6);
+    const b = new Temporal.PlainYearMonth(2024, 3);
+    expect(a.since(b, { largestUnit: "months" }).toString()).toBe("P15M");
   });
 });

--- a/tests/built-ins/Temporal/PlainYearMonth/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainYearMonth/prototype/until.js
@@ -6,11 +6,36 @@ features: [Temporal]
 const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.PlainYearMonth.prototype.until", () => {
-  test("until", () => {
+  test("until() default returns years and months", () => {
     const a = new Temporal.PlainYearMonth(2024, 3);
     const b = new Temporal.PlainYearMonth(2025, 6);
     const dur = a.until(b);
     expect(dur.years).toBe(1);
     expect(dur.months).toBe(3);
+  });
+
+  test("until() with largestUnit year", () => {
+    const a = new Temporal.PlainYearMonth(2024, 3);
+    const b = new Temporal.PlainYearMonth(2025, 6);
+    expect(a.until(b, { largestUnit: "years" }).toString()).toBe("P1Y3M");
+  });
+
+  test("until() with largestUnit month returns months only", () => {
+    const a = new Temporal.PlainYearMonth(2024, 3);
+    const b = new Temporal.PlainYearMonth(2025, 6);
+    expect(a.until(b, { largestUnit: "months" }).toString()).toBe("P15M");
+  });
+
+  test("until() negative result with largestUnit months", () => {
+    const a = new Temporal.PlainYearMonth(2025, 6);
+    const b = new Temporal.PlainYearMonth(2024, 3);
+    expect(a.until(b, { largestUnit: "months" }).toString()).toBe("-P15M");
+  });
+
+  test("until() same month returns zero", () => {
+    const a = new Temporal.PlainYearMonth(2024, 6);
+    const dur = a.until(a, { largestUnit: "months" });
+    expect(dur.years).toBe(0);
+    expect(dur.months).toBe(0);
   });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/since.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/since.js
@@ -1,0 +1,24 @@
+/*---
+description: Temporal.ZonedDateTime.prototype.since
+features: [Temporal]
+---*/
+
+const isTemporal = typeof Temporal !== "undefined";
+
+describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.since", () => {
+  test("since() default returns hours", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(7200000).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const dur = z1.since(z2);
+    expect(dur.hours).toBe(2);
+    expect(dur.minutes).toBe(0);
+  });
+
+  test("since() with largestUnit minutes", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(5400000).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const dur = z1.since(z2, { largestUnit: "minutes" });
+    expect(dur.minutes).toBe(90);
+    expect(dur.hours).toBe(0);
+  });
+});

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/until.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/until.js
@@ -1,0 +1,40 @@
+/*---
+description: Temporal.ZonedDateTime.prototype.until
+features: [Temporal]
+---*/
+
+const isTemporal = typeof Temporal !== "undefined";
+
+describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.until", () => {
+  test("until() default returns hours", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(7200000).toZonedDateTimeISO("UTC");
+    const dur = z1.until(z2);
+    expect(dur.hours).toBe(2);
+    expect(dur.minutes).toBe(0);
+  });
+
+  test("until() with largestUnit days", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(90000000).toZonedDateTimeISO("UTC");
+    const dur = z1.until(z2, { largestUnit: "days" });
+    expect(dur.days).toBe(1);
+    expect(dur.hours).toBe(1);
+  });
+
+  test("until() with largestUnit minutes", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(5400000).toZonedDateTimeISO("UTC");
+    const dur = z1.until(z2, { largestUnit: "minutes" });
+    expect(dur.minutes).toBe(90);
+    expect(dur.hours).toBe(0);
+  });
+
+  test("until() with largestUnit seconds", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(90000).toZonedDateTimeISO("UTC");
+    const dur = z1.until(z2, { largestUnit: "seconds" });
+    expect(dur.seconds).toBe(90);
+    expect(dur.minutes).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- All ten `until`/`since` methods across `PlainDate`, `PlainYearMonth`, `PlainDateTime`, `Instant`, and `ZonedDateTime` now honor the `largestUnit` option instead of ignoring the second argument
- Adds `CalendarDateUntil` helper for spec-compliant month/year walking with day-clamping adjustment
- Expands Temporal test coverage from 315 to 353 tests with per-`largestUnit` coverage, boundary cases (day clamping, leap year, negative, zero), and new ZonedDateTime until/since test files
- Updates `docs/built-ins-temporal.md` to document the options parameter

Closes #406