### PR TITLE
Unify website console output with shared ConsolePanel

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -68,6 +68,8 @@
   --display: var(--font-instrument-serif), "Instrument Serif", Georgia, serif;
   --body: var(--font-ibm-plex-sans), "IBM Plex Sans", system-ui, sans-serif;
 
+  --console-bg: #d5c89c;
+
   --shadow-sm: 0 1px 0 rgba(42, 36, 25, 0.06), 0 1px 2px rgba(42, 36, 25, 0.08);
   --shadow:
     0 2px 0 rgba(42, 36, 25, 0.05), 0 6px 20px -6px rgba(42, 36, 25, 0.18);
@@ -93,6 +95,8 @@
   --amber: #e6a25c;
   --amber-2: #f0b57a;
   --espresso: #d4a074;
+
+  --console-bg: #13100b;
 
   --shadow-sm: 0 1px 0 rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.5);
   --shadow: 0 2px 0 rgba(0, 0, 0, 0.3), 0 10px 24px -6px rgba(0, 0, 0, 0.6);
@@ -1727,17 +1731,23 @@ p {
   background: color-mix(in oklab, var(--accent) 30%, transparent);
 }
 
-.pg-output {
+/* Shared console output panel — zsh/spaceship-inspired terminal look.
+   Used by the playground, sandbox host-result pane, and hero runnable
+   card. The background is a step darker than the editor panels so the
+   output area reads as "console". */
+.console-panel {
   flex: 1;
-  padding: 1rem 1.1rem;
+  padding: 0.8rem 1.1rem;
   font-family: var(--mono);
   font-size: 0.85rem;
   line-height: 1.65;
   color: var(--ink);
   overflow: auto;
   white-space: pre-wrap;
-  background: var(--paper-2);
+  background: var(--console-bg);
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.06);
 }
+
 
 /* Shared "console output" panel reused across the playground,
    sandbox preview, hero runnable card, and Compiler Pipeline. Lines
@@ -1759,6 +1769,48 @@ p {
 .anim-output-line.log-meta {
   color: var(--ink-3);
   font-style: italic;
+}
+/* Command line — the first meta line with ➜ prompt. Uses a typewriter
+   reveal instead of the standard fade-in, so it must opt out of the
+   default animation and be visible immediately. */
+.anim-output-line.log-command {
+  color: var(--ink-3);
+  opacity: 1;
+  transform: none;
+  animation: none;
+}
+.anim-output-typed {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  vertical-align: bottom;
+  max-width: 0;
+  animation: typewriter-expand 0.6s steps(30, end) forwards;
+}
+@keyframes typewriter-expand {
+  to {
+    max-width: 100%;
+  }
+}
+/* Inline caret that follows the typewriter text, then hides once
+   the command finishes typing and the trailing caret takes over. */
+.anim-output-caret-typing {
+  opacity: 1;
+  animation:
+    arch-caret-blink 0.85s steps(2, end) infinite,
+    caret-typing-hide 0.01s 0.6s forwards;
+}
+@keyframes caret-typing-hide {
+  to {
+    opacity: 0;
+    width: 0;
+    margin: 0;
+  }
+}
+/* Idle caret in the empty state — just blinks, no fade-in. */
+.anim-output-caret-idle {
+  opacity: 1;
+  animation: arch-caret-blink 0.85s steps(2, end) infinite;
 }
 .anim-output-line.log-result {
   color: var(--forest);
@@ -1796,6 +1848,13 @@ p {
     opacity: 1;
   }
 }
+.anim-output-hint {
+  margin-left: 0.6ch;
+  color: var(--ink-3);
+  opacity: 0.38;
+  font-style: normal;
+  user-select: none;
+}
 
 /* Code block with a left-side line-number gutter. Used by the
    Compiler Pipeline panels, EXCLUDED snippets, and any other static
@@ -1809,8 +1868,8 @@ p {
 }
 .numbered-code-gutter {
   margin: 0;
-  padding: 0.85rem 0.65rem 0.85rem 0.85rem;
-  background: var(--paper-2);
+  padding: 0.85rem 0.5rem 0.85rem 0.7rem;
+  background: color-mix(in oklab, var(--paper-2) 70%, var(--paper-3));
   border-right: 1px solid var(--rule-soft);
   color: var(--ink-3);
   font-family: var(--mono);
@@ -1819,7 +1878,7 @@ p {
   text-align: right;
   user-select: none;
   white-space: pre;
-  min-width: 2ch;
+  min-width: 2.5ch;
 }
 .numbered-code-body {
   margin: 0;
@@ -2110,6 +2169,12 @@ p {
   width: 28px;
   height: 28px;
 }
+.footer-brand-row {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
 .footer small {
   color: var(--ink-3);
   font-size: 0.82rem;
@@ -2311,23 +2376,23 @@ p {
   background: color-mix(in oklab, var(--accent) 28%, transparent);
   color: transparent;
 }
-.hero-output {
+/* Hero console — sits inside the code-card, below the editor.
+   Inherits from .console-panel; overrides are hero-specific sizing. */
+.hero-console {
   border-top: 1px solid var(--rule-soft);
   padding: 0.65rem 1.25rem;
-  background: var(--paper-3);
-  font-family: var(--mono);
   font-size: 0.78rem;
-  line-height: 1.65;
   /* 5 lines × 1.65 line-height × 0.78rem ≈ 6.45rem of text + 1.3rem padding */
   min-height: 7.75rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
 }
-.hero-output-empty {
-  color: var(--ink-3);
-  font-style: italic;
-  opacity: 0.7;
+/* Arch pipeline console tab — compact padding inside the artifact box. */
+.arch-console {
+  padding: 0.65rem 0.85rem;
+  font-size: 0.82rem;
+  border-radius: 0;
 }
 
 /* ---------- full-width playground ---------- */
@@ -2453,7 +2518,6 @@ p {
 
 /* ---------- HighlightedTextarea (transparent textarea over highlighted overlay) ---------- */
 .hta {
-  position: relative;
   background: var(--paper-2);
   border-radius: 0;
   flex: 1;
@@ -2497,6 +2561,27 @@ p {
 .hta-ta::selection {
   background: color-mix(in oklab, var(--accent) 28%, transparent);
   color: transparent;
+}
+.hta-gutter {
+  margin: 0;
+  padding: 0.85rem 0.5rem 0.85rem 0.7rem;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  text-align: right;
+  color: var(--ink-3);
+  user-select: none;
+  white-space: pre;
+  overflow: hidden;
+  min-width: 2.5ch;
+  border-right: 1px solid var(--rule-soft);
+  background: color-mix(in oklab, var(--paper-2) 70%, var(--paper-3));
+}
+.hta-editor {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  display: flex;
 }
 
 /* JSON tokens */
@@ -2681,7 +2766,7 @@ p {
   border: 1px solid var(--rule-soft);
   border-left: 3px solid var(--accent);
   background: color-mix(in oklab, var(--accent) 4%, var(--paper));
-  border-radius: 10px;
+  border-radius: 0;
   padding: 1.1rem 1.25rem;
   display: grid;
   gap: 0.5rem;
@@ -2744,7 +2829,7 @@ p {
 .arch-artifact-box {
   background: var(--paper);
   border: 1px solid var(--rule-soft);
-  border-radius: 10px;
+  border-radius: 0;
   overflow: hidden;
 }
 .arch-artifact-head {

--- a/website/src/components/animated-output.tsx
+++ b/website/src/components/animated-output.tsx
@@ -10,7 +10,12 @@ export type AnimatedOutputLine = {
 };
 
 /** Duration of the command-line typewriter reveal (ms). Output lines
- *  stagger after this so the command finishes "typing" first. */
+ *  stagger after this so the command finishes "typing" first.
+ *
+ *  These values must stay in sync with the CSS in globals.css:
+ *  - TYPEWRITER_MS ↔ `typewriter-expand` duration and
+ *    `caret-typing-hide` delay (both `0.6s`)
+ *  - STAGGER_MS ↔ `animationDelay` on `.anim-output-line` (inline) */
 const TYPEWRITER_MS = 600;
 const STAGGER_MS = 60;
 

--- a/website/src/components/animated-output.tsx
+++ b/website/src/components/animated-output.tsx
@@ -57,7 +57,7 @@ export function AnimatedOutput({
               className="anim-output-caret anim-output-caret-idle"
               aria-hidden="true"
             />
-            <span className="anim-output-hint" aria-hidden="true">
+            <span className="anim-output-hint" role="status">
               press Run or ⌘+Enter
             </span>
           </span>

--- a/website/src/components/animated-output.tsx
+++ b/website/src/components/animated-output.tsx
@@ -9,14 +9,19 @@ export type AnimatedOutputLine = {
   text: ReactNode;
 };
 
+/** Duration of the command-line typewriter reveal (ms). Output lines
+ *  stagger after this so the command finishes "typing" first. */
+const TYPEWRITER_MS = 600;
+const STAGGER_MS = 60;
+
 /** Console-style output panel with a synchronized line-by-line
  *  reveal animation: each line fades + slides in with a small
  *  stagger, and a blinking caret tails the final line.
  *
- *  The animation is driven entirely by CSS `animation-delay` so we
- *  don't need any state or timers — just remount on each new run by
- *  bumping the `runKey` prop, which lifts to a `key` on the wrapper
- *  and resets the animation cleanly.
+ *  The first meta line is treated as the "command" — it renders
+ *  with a ➜ prompt and a typewriter reveal so the caret appears
+ *  to type the command in real time. Subsequent lines fade in
+ *  after the typewriter finishes.
  *
  *  Used across the playground, sandbox preview, hero runnable card,
  *  and Compiler Pipeline result so the same "code just executed,
@@ -26,7 +31,6 @@ export function AnimatedOutput({
   runKey,
   className = "",
   showCaret = true,
-  emptyState,
 }: {
   lines: AnimatedOutputLine[];
   /** Bump this on each new run to restart the line-stagger animation. */
@@ -35,46 +39,94 @@ export function AnimatedOutput({
   /** When false, the trailing caret is hidden — useful for finalised
    *  output that's no longer "live". */
   showCaret?: boolean;
-  /** Rendered when `lines` is empty. */
-  emptyState?: ReactNode;
 }) {
   if (lines.length === 0) {
     return (
-      <div className={`anim-output ${className}`}>{emptyState ?? null}</div>
+      <div className={`anim-output ${className}`}>
+        <div className="anim-output-line log-command">
+          <span className="pg-log-gutter" aria-hidden="true">
+            ➜
+          </span>
+          <span className="anim-output-text">
+            <span
+              className="anim-output-caret anim-output-caret-idle"
+              aria-hidden="true"
+            />
+            <span className="anim-output-hint" aria-hidden="true">
+              press Run or ⌘+Enter
+            </span>
+          </span>
+        </div>
+      </div>
     );
   }
+
+  const hasCommand = lines[0]?.kind === "meta";
+
   return (
     <div key={runKey} className={`anim-output ${className}`}>
-      {lines.map((l, i) => (
-        <div
-          key={i}
-          className={`anim-output-line log-${
-            l.kind === "meta"
-              ? "meta"
-              : l.kind === "err"
-                ? "err"
-                : l.kind === "result"
-                  ? "result"
-                  : "out"
-          }`}
-          style={{ animationDelay: `${i * 60}ms` }}
-        >
-          <span className="pg-log-gutter" aria-hidden="true">
-            {l.kind === "meta"
-              ? ""
-              : l.kind === "err"
+      {lines.map((l, i) => {
+        const isCmd = i === 0 && hasCommand;
+
+        if (isCmd) {
+          const cmdOnly = lines.length === 1;
+          return (
+            <div key={i} className="anim-output-line log-command">
+              <span className="pg-log-gutter" aria-hidden="true">
+                ➜
+              </span>
+              <span className="anim-output-text">
+                <span className="anim-output-typed">{l.text}</span>
+                {cmdOnly && (
+                  <span
+                    className="anim-output-caret anim-output-caret-typing"
+                    aria-hidden="true"
+                  />
+                )}
+              </span>
+            </div>
+          );
+        }
+
+        const delay = hasCommand
+          ? TYPEWRITER_MS + (i - 1) * STAGGER_MS
+          : i * STAGGER_MS;
+        const kind =
+          l.kind === "meta"
+            ? "meta"
+            : l.kind === "err"
+              ? "err"
+              : l.kind === "result"
+                ? "result"
+                : "out";
+
+        return (
+          <div
+            key={i}
+            className={`anim-output-line log-${kind}`}
+            style={{ animationDelay: `${delay}ms` }}
+          >
+            <span className="pg-log-gutter" aria-hidden="true">
+              {l.kind === "err"
                 ? "✗"
                 : l.kind === "result"
                   ? "↳"
-                  : "›"}
-          </span>
-          <span className="anim-output-text">{l.text}</span>
-        </div>
-      ))}
+                  : ""}
+            </span>
+            <span className="anim-output-text">{l.text}</span>
+          </div>
+        );
+      })}
       {showCaret && (
         <span
           className="anim-output-caret"
-          style={{ animationDelay: `${lines.length * 60}ms` }}
+          style={{
+            animationDelay: `${
+              hasCommand
+                ? TYPEWRITER_MS + (lines.length - 1) * STAGGER_MS
+                : lines.length * STAGGER_MS
+            }ms`,
+          }}
           aria-hidden="true"
         />
       )}

--- a/website/src/components/console-panel.tsx
+++ b/website/src/components/console-panel.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+/** Console-style output wrapper with a zsh/spaceship terminal feel.
+ *
+ *  Provides a slightly darker background than the surrounding editor
+ *  panels so users immediately recognise the area as "console output".
+ *  Drop `<AnimatedOutput>` (or any other output content) inside as
+ *  `children`. Used across the playground, sandbox, and landing page
+ *  hero for a consistent look. */
+export function ConsolePanel({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={`console-panel ${className}`}>{children}</div>;
+}

--- a/website/src/components/highlighted-textarea.tsx
+++ b/website/src/components/highlighted-textarea.tsx
@@ -10,19 +10,26 @@ export function HighlightedTextarea({
   onChange,
   language = "goccia",
   className = "",
+  lineNumbers = false,
 }: {
   value: string;
   onChange: (next: string) => void;
   language?: Language;
   className?: string;
+  /** Show a line-number gutter alongside the editor. */
+  lineNumbers?: boolean;
 }) {
   const taRef = useRef<HTMLTextAreaElement>(null);
   const hlRef = useRef<HTMLPreElement>(null);
+  const gutterRef = useRef<HTMLPreElement>(null);
 
   const sync = () => {
     if (taRef.current && hlRef.current) {
       hlRef.current.scrollTop = taRef.current.scrollTop;
       hlRef.current.scrollLeft = taRef.current.scrollLeft;
+    }
+    if (taRef.current && gutterRef.current) {
+      gutterRef.current.scrollTop = taRef.current.scrollTop;
     }
   };
 
@@ -31,46 +38,58 @@ export function HighlightedTextarea({
       ? highlightJson(`${value}\n`)
       : highlightGoccia(`${value}\n`);
 
+  const lineCount = value.split("\n").length;
+  const gutter = lineNumbers
+    ? Array.from({ length: lineCount }, (_, i) => String(i + 1)).join("\n")
+    : null;
+
   return (
     <div className={`hta ${className}`}>
-      <pre className="hta-hl" ref={hlRef} aria-hidden="true">
-        <code>
-          {tokens.map((t, i) => (
-            <span
-              key={i}
-              className={
-                t.cls
-                  ? t.cls.startsWith("tok-")
-                    ? t.cls
-                    : `tk-${t.cls}`
-                  : undefined
-              }
-            >
-              {t.text}
-            </span>
-          ))}
-        </code>
-      </pre>
-      <textarea
-        ref={taRef}
-        className="hta-ta"
-        spellCheck={false}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        onScroll={sync}
-        onKeyDown={(e) => {
-          if (e.key === "Tab") {
-            e.preventDefault();
-            const target = e.currentTarget;
-            const { selectionStart: s, selectionEnd: en, value: v } = target;
-            const next = `${v.slice(0, s)}  ${v.slice(en)}`;
-            onChange(next);
-            requestAnimationFrame(() => {
-              target.selectionStart = target.selectionEnd = s + 2;
-            });
-          }
-        }}
-      />
+      {gutter !== null && (
+        <pre className="hta-gutter" ref={gutterRef} aria-hidden="true">
+          {gutter}
+        </pre>
+      )}
+      <div className="hta-editor">
+        <pre className="hta-hl" ref={hlRef} aria-hidden="true">
+          <code>
+            {tokens.map((t, i) => (
+              <span
+                key={i}
+                className={
+                  t.cls
+                    ? t.cls.startsWith("tok-")
+                      ? t.cls
+                      : `tk-${t.cls}`
+                    : undefined
+                }
+              >
+                {t.text}
+              </span>
+            ))}
+          </code>
+        </pre>
+        <textarea
+          ref={taRef}
+          className="hta-ta"
+          spellCheck={false}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onScroll={sync}
+          onKeyDown={(e) => {
+            if (e.key === "Tab") {
+              e.preventDefault();
+              const target = e.currentTarget;
+              const { selectionStart: s, selectionEnd: en, value: v } = target;
+              const next = `${v.slice(0, s)}  ${v.slice(en)}`;
+              onChange(next);
+              requestAnimationFrame(() => {
+                target.selectionStart = target.selectionEnd = s + 2;
+              });
+            }
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -146,7 +146,7 @@ function HeroRunnableCard({ code }: { code: string }) {
           totalMs !== undefined ? ` · ${totalMs.toFixed(2)}ms` : ""
         }`,
       });
-      // Pad to 7 lines so the hero console keeps a fixed height.
+      // Pad to 5 lines so the hero console keeps a fixed height.
       while (lines.length < 5) {
         lines.push({ kind: "meta", text: "" });
       }

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { AnchorH2, AnchorH3 } from "@/components/anchor-heading";
 import { AnimatedOutput } from "@/components/animated-output";
+import { ConsolePanel } from "@/components/console-panel";
 import {
   HighlightedCode,
   HighlightedGeneric,
@@ -102,7 +103,7 @@ function HeroRunnableCard({ code }: { code: string }) {
     if (running) return;
     setRunning(true);
     setRunTick((t) => t + 1);
-    const banner = "› GocciaScriptLoader coffee-shop.js";
+    const banner = "GocciaScriptLoader coffee-shop.js";
     setOutput([{ kind: "meta", text: banner }]);
     try {
       const res = await fetch("/api/run", {
@@ -145,6 +146,10 @@ function HeroRunnableCard({ code }: { code: string }) {
           totalMs !== undefined ? ` · ${totalMs.toFixed(2)}ms` : ""
         }`,
       });
+      // Pad to 7 lines so the hero console keeps a fixed height.
+      while (lines.length < 5) {
+        lines.push({ kind: "meta", text: "" });
+      }
       setOutput(lines);
     } catch (err) {
       // `err` from `fetch` / `res.json()` is *usually* an `Error`
@@ -167,6 +172,13 @@ function HeroRunnableCard({ code }: { code: string }) {
       setRunning(false);
     }
   };
+
+  // Run automatically on mount so the hero card shows live output
+  // immediately — same UX as the sandbox preview.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
+  useEffect(() => {
+    run();
+  }, []);
 
   // Auto-size the textarea to its content so its internal scroll never
   // engages; the outer .hero-editor handles overflow. With no internal
@@ -250,22 +262,24 @@ function HeroRunnableCard({ code }: { code: string }) {
           />
         </div>
       </div>
-      <div className="hero-output">
-        {output ? (
-          <AnimatedOutput
-            runKey={runTick}
-            lines={output.map((l) => ({
-              kind:
-                l.kind === "meta" ? "meta" : l.kind === "err" ? "err" : "out",
-              text: l.text,
-            }))}
-          />
-        ) : (
-          <div className="hero-output-empty">
-            {running ? "› running…" : "› press Run to execute (or ⌘↩)"}
-          </div>
-        )}
-      </div>
+      <ConsolePanel className="hero-console">
+        <AnimatedOutput
+          runKey={runTick}
+          lines={
+            output
+              ? output.map((l) => ({
+                  kind:
+                    l.kind === "meta"
+                      ? "meta"
+                      : l.kind === "err"
+                        ? "err"
+                        : "out",
+                  text: l.text,
+                }))
+              : []
+          }
+        />
+      </ConsolePanel>
     </div>
   );
 }
@@ -452,7 +466,7 @@ console.log("total:", total);`;
     {
       id: "source",
       label: "Source",
-      small: ".js · .ts · .jsx · .tsx · .esm",
+      small: ".js · .ts · .jsx · .tsx · .mjs",
       overview:
         "Every supported extension is the same language — TS/TSX type annotations are parsed and discarded, and JSX is rewritten to function calls in a preprocessing pass before the lexer ever sees it. There is no separate type-checker.",
       docId: "language",
@@ -509,20 +523,10 @@ console.log("total:", total);`;
   const [resultView, setResultView] = useState<"console" | "json">("console");
   const stage = stages[active];
 
-  // SSR-stable ids so the tab → panel association via `aria-controls` /
-  // `aria-labelledby` survives hydration. `useId` produces collision-free
-  // values even if this component were rendered multiple times on a page.
   const tabConsoleId = useId();
   const tabJsonId = useId();
   const panelConsoleId = useId();
   const panelJsonId = useId();
-
-  // The Result step's console output uses `<AnimatedOutput>` for its
-  // line-stagger reveal — same animation that drives the playground,
-  // sandbox preview, and hero runnable card. No local timer state
-  // needed; the component restarts when its `runKey` changes (here:
-  // when the active stage flips back to step 5 or the resultView
-  // toggle returns to "console").
 
   return (
     <div className="arch">
@@ -652,25 +656,32 @@ console.log("total:", total);`;
                   JSON result
                 </button>
               </div>
-              {/* Each panel is wired up with `role="tabpanel"` +
-                  `aria-labelledby` so screen readers announce the
-                  controlling tab when focus enters the panel content. We
-                  unmount the inactive panel rather than hide it via CSS
-                  to keep the line-stagger animation `runKey` clean. */}
               {resultView === "console" ? (
                 <div
                   role="tabpanel"
                   id={panelConsoleId}
                   aria-labelledby={tabConsoleId}
                 >
-                  <AnimatedOutput
-                    className="arch-anim-output"
-                    runKey={`console-${active}`}
-                    lines={CONSOLE_OUTPUT.split("\n").map((text) => ({
-                      kind: "out" as const,
-                      text,
-                    }))}
-                  />
+                  <ConsolePanel className="arch-console">
+                    <AnimatedOutput
+                      runKey={`console-${active}`}
+                      showCaret={false}
+                      lines={[
+                        {
+                          kind: "meta" as const,
+                          text: "GocciaScriptLoader example.js",
+                        },
+                        ...CONSOLE_OUTPUT.split("\n").map((text) => ({
+                          kind: "out" as const,
+                          text,
+                        })),
+                        {
+                          kind: "meta" as const,
+                          text: "— exit 0 · 0.08ms",
+                        },
+                      ]}
+                    />
+                  </ConsolePanel>
                 </div>
               ) : (
                 <div

--- a/website/src/components/playground.tsx
+++ b/website/src/components/playground.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { AnimatedOutput } from "@/components/animated-output";
+import { ConsolePanel } from "@/components/console-panel";
 import { HighlightedCode } from "@/components/highlighted-code";
 import {
   CopyIcon,
@@ -137,7 +138,7 @@ export function Playground({ stableTags = [] }: PlaygroundProps) {
 
   const run = useCallback(async () => {
     setRunning(true);
-    const banner = `› GocciaScriptLoader --mode=${
+    const banner = `GocciaScriptLoader --mode=${
       backend === "bytecode" ? "bytecode" : "interpreted"
     }${asi ? " --asi" : ""} ${version}`;
     setOutput([{ kind: "meta", text: banner }]);
@@ -569,7 +570,7 @@ export function Playground({ stableTags = [] }: PlaygroundProps) {
             <SparkleIcon size={14} /> output
             <span className="ml-auto text-[0.7rem]">{output.length} lines</span>
           </div>
-          <div className="pg-output">
+          <ConsolePanel>
             <AnimatedOutput
               // Run id derived from the output identity — bumping the
               // banner / clearing for a new execution remounts the
@@ -577,13 +578,8 @@ export function Playground({ stableTags = [] }: PlaygroundProps) {
               runKey={output.length === 0 ? "empty" : (output[0]?.text ?? "x")}
               lines={output}
               showCaret={!running ? output.length > 0 : true}
-              emptyState={
-                <span className="text-ink-3 italic">
-                  — no output yet. hit ⌘+Enter to run.
-                </span>
-              }
             />
-          </div>
+          </ConsolePanel>
         </div>
       </div>
     </div>

--- a/website/src/components/sandbox.tsx
+++ b/website/src/components/sandbox.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { AnchorH2 } from "@/components/anchor-heading";
 import { AnimatedOutput } from "@/components/animated-output";
+import { ConsolePanel } from "@/components/console-panel";
 import {
   HighlightedCode,
   HighlightedGeneric,
@@ -481,12 +482,18 @@ const RESERVED_BINDING_WORDS = new Set([
   "public",
 ]);
 
-/** Build the script that actually runs: each top-level globals key
- *  becomes a `const X = <JSON literal>;` declaration above the user's
- *  code. `JSON.stringify` of any JSON value is also a valid JS literal,
- *  so this round-trips cleanly without ad-hoc escaping. Throws on any
- *  globals key that wouldn't be a valid identifier — caller surfaces
- *  the message in the sandbox console. */
+/** System prompt prepended to every sandbox execution so the full
+ *  source (visible in tool-call logs) explains what GocciaScript is. */
+const GOCCIA_SYSTEM_PROMPT = `\
+// ─── system ───
+// GocciaScript is a strict ECMAScript subset, sandboxed by default.
+// No eval, no dynamic import, no fs, no env, no ambient globals.
+// No var, no function declarations, no loose equality (== / !=).
+// Only the injected globals below are available to the script.`;
+
+/** Build the script that actually runs: a system prompt header,
+ *  `const` declarations for each globals key, and the user's code.
+ *  Throws on globals keys that aren't valid JS identifiers. */
 function buildScript(userCode: string, parsedGlobals: Record<string, unknown>) {
   const prelude = Object.entries(parsedGlobals)
     .map(([k, v]) => {
@@ -503,8 +510,10 @@ function buildScript(userCode: string, parsedGlobals: Record<string, unknown>) {
       return `const ${k} = ${JSON.stringify(v)};`;
     })
     .join("\n");
-  if (!prelude) return userCode;
-  return `// ─── injected globals ───\n${prelude}\n\n// ─── user script ───\n${userCode}`;
+  const globalsBlock = prelude
+    ? `\n\n// ─── injected globals ───\n${prelude}`
+    : "";
+  return `${GOCCIA_SYSTEM_PROMPT}${globalsBlock}\n\n// ─── user script ───\n${userCode}`;
 }
 
 export function Sandbox() {
@@ -530,7 +539,7 @@ export function Sandbox() {
       setOutput([
         {
           kind: "meta",
-          text: "› goccia run --timeout=500 --memory=64MB --globals=context.json",
+          text: "GocciaScriptLoader --timeout=500 --globals=context.json",
         },
         {
           kind: "err",
@@ -554,7 +563,7 @@ export function Sandbox() {
       setOutput([
         {
           kind: "meta",
-          text: "› goccia run --timeout=500 --memory=64MB --globals=context.json",
+          text: "GocciaScriptLoader --timeout=500 --globals=context.json",
         },
         {
           kind: "err",
@@ -565,11 +574,11 @@ export function Sandbox() {
     }
     const banner: SbLine = {
       kind: "meta",
-      text: "› goccia run --timeout=500 --memory=64MB --globals=context.json",
+      text: "GocciaScriptLoader --timeout=500 --globals=context.json",
     };
     setRunning(true);
     setRunId((r) => r + 1);
-    setOutput([banner, { kind: "meta", text: "  caps: — none —" }]);
+    setOutput([banner]);
 
     try {
       const res = await fetch("/api/run", {
@@ -623,10 +632,7 @@ export function Sandbox() {
         return;
       }
 
-      const lines: SbLine[] = [
-        banner,
-        { kind: "meta", text: "  caps: — none —" },
-      ];
+      const lines: SbLine[] = [banner];
       if (data.error) {
         const where = data.error.line ? ` (line ${data.error.line})` : "";
         lines.push({
@@ -780,6 +786,7 @@ export function Sandbox() {
                 value={code}
                 onChange={setCode}
                 language="goccia"
+                lineNumbers
               />
             </div>
             <div className="sb-field">
@@ -792,11 +799,12 @@ export function Sandbox() {
                 value={globalsText}
                 onChange={setGlobalsText}
                 language="json"
+                lineNumbers
               />
             </div>
             <div className="sb-field">
               <div className="sb-field-label">host result</div>
-              <div className="pg-output flex-1 rounded-t-none">
+              <ConsolePanel className="flex-1 rounded-t-none">
                 <AnimatedOutput
                   runKey={runId}
                   lines={output.map((l) => ({
@@ -809,7 +817,7 @@ export function Sandbox() {
                     text: l.text,
                   }))}
                 />
-              </div>
+              </ConsolePanel>
             </div>
           </div>
         </div>

--- a/website/src/components/site-shell.tsx
+++ b/website/src/components/site-shell.tsx
@@ -270,16 +270,15 @@ export function SiteShell({
 
       <footer className="footer">
         <div className="container footer-inner">
-          <div>
+          <div className="footer-brand-row">
             <div className="footer-brand">
               <Image src="/logo.png" alt="" width={28} height={28} />
               <span>
                 Goccia<em className="text-accent italic">Script</em>
               </span>
             </div>
-            <small className="block mt-2 max-w-[42ch]">
-              A drop of JavaScript — a strict subset of ECMAScript 2027+,
-              sandboxed by default.
+            <small className="text-ink-3 text-[0.82rem]">
+              — A drop of JavaScript, sandboxed by default.
             </small>
           </div>
         </div>

--- a/website/src/lib/format-error.ts
+++ b/website/src/lib/format-error.ts
@@ -17,13 +17,11 @@ export function formatError(err: RunnerError, source: string): OutputLine[] {
     const lines = source.split("\n");
     const idx = err.line - 1;
     const lineText = lines[idx] ?? "";
-    const file = err.fileName ?? "<stdin>";
     const col = err.column && err.column > 0 ? err.column : 1;
 
-    out.push({
-      kind: "meta",
-      text: `${file}:${err.line}:${col}`,
-    });
+    if (err.fileName && err.fileName !== "<stdin>") {
+      out.push({ kind: "meta", text: `${err.fileName}:${err.line}:${col}` });
+    }
     const gutter = `${err.line} | `;
     out.push({ kind: "err", text: `${gutter}${lineText}` });
     out.push({


### PR DESCRIPTION
## Summary
- Introduce a shared `ConsolePanel` component with a zsh/spaceship-style terminal look (`--console-bg` darker background, inset shadow) used consistently across the hero, playground, sandbox, and compiler pipeline
- Rework `AnimatedOutput` with `➜` prompt in the gutter, typewriter reveal on the command line with inline caret, and clean empty state (`➜ ▊ press Run or ⌘+Enter`)
- Add optional `lineNumbers` prop to `HighlightedTextarea` with scroll-synced gutter; enable for both sandbox editors
- Add GocciaScript system prompt to sandbox `buildScript` (no eval, no var, no function, no loose equality)
- Hero auto-runs on mount; footer brand + tagline on one line; `format-error` skips `<stdin>` location line; compiler pipeline artifacts use sharp corners and `.esm` → `.mjs`

## Test plan
- [ ] Verify hero console shows typewriter command, output, exit code on page load
- [ ] Verify playground empty state shows `➜ ▊ press Run or ⌘+Enter`, transitions smoothly on run
- [ ] Verify sandbox editors have line numbers, host result uses ConsolePanel
- [ ] Verify compiler pipeline Result tab shows command + output + exit in console tab, JSON in JSON tab
- [ ] Verify footer brand + tagline renders on one line
- [ ] Check both cream and espresso themes for console background contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)