### PR TITLE
Add receiver brand checks to Set/Map prototype methods

### DIFF
--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -648,6 +648,13 @@ resourcestring
   SErrorMapGetOrInsertNonMap = 'Map.prototype.getOrInsert called on non-Map object';
   SErrorMapGetOrInsertComputedNonMap = 'Map.prototype.getOrInsertComputed called on non-Map object';
 
+  // Set/Map forEach errors
+  SErrorSetForEachNotCallable = 'Set.prototype.forEach: callback is not a function';
+  SErrorMapForEachNotCallable = 'Map.prototype.forEach: callback is not a function';
+
+  // Set operation argument errors
+  SErrorSetOperationRequiresSet = 'Set.prototype.%s: argument must be a Set';
+
   // Map upsert errors
   SErrorMapGetOrInsertComputedNotCallable = 'Map.getOrInsertComputed: callbackfn is not a function';
 

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -616,6 +616,38 @@ resourcestring
   // Number method errors
   SErrorToExponentialArgRange = 'toExponential() argument must be between 0 and 100';
 
+  // Set brand-check errors
+  SErrorSetHasNonSet = 'Set.prototype.has called on non-Set object';
+  SErrorSetAddNonSet = 'Set.prototype.add called on non-Set object';
+  SErrorSetDeleteNonSet = 'Set.prototype.delete called on non-Set object';
+  SErrorSetClearNonSet = 'Set.prototype.clear called on non-Set object';
+  SErrorSetForEachNonSet = 'Set.prototype.forEach called on non-Set object';
+  SErrorSetValuesNonSet = 'Set.prototype.values called on non-Set object';
+  SErrorSetKeysNonSet = 'Set.prototype.keys called on non-Set object';
+  SErrorSetEntriesNonSet = 'Set.prototype.entries called on non-Set object';
+  SErrorSetIteratorNonSet = 'Set.prototype[Symbol.iterator] called on non-Set object';
+  SErrorSetUnionNonSet = 'Set.prototype.union called on non-Set object';
+  SErrorSetIntersectionNonSet = 'Set.prototype.intersection called on non-Set object';
+  SErrorSetDifferenceNonSet = 'Set.prototype.difference called on non-Set object';
+  SErrorSetSymmetricDifferenceNonSet = 'Set.prototype.symmetricDifference called on non-Set object';
+  SErrorSetIsSubsetOfNonSet = 'Set.prototype.isSubsetOf called on non-Set object';
+  SErrorSetIsSupersetOfNonSet = 'Set.prototype.isSupersetOf called on non-Set object';
+  SErrorSetIsDisjointFromNonSet = 'Set.prototype.isDisjointFrom called on non-Set object';
+
+  // Map brand-check errors
+  SErrorMapGetNonMap = 'Map.prototype.get called on non-Map object';
+  SErrorMapSetNonMap = 'Map.prototype.set called on non-Map object';
+  SErrorMapHasNonMap = 'Map.prototype.has called on non-Map object';
+  SErrorMapDeleteNonMap = 'Map.prototype.delete called on non-Map object';
+  SErrorMapClearNonMap = 'Map.prototype.clear called on non-Map object';
+  SErrorMapForEachNonMap = 'Map.prototype.forEach called on non-Map object';
+  SErrorMapKeysNonMap = 'Map.prototype.keys called on non-Map object';
+  SErrorMapValuesNonMap = 'Map.prototype.values called on non-Map object';
+  SErrorMapEntriesNonMap = 'Map.prototype.entries called on non-Map object';
+  SErrorMapIteratorNonMap = 'Map.prototype[Symbol.iterator] called on non-Map object';
+  SErrorMapGetOrInsertNonMap = 'Map.prototype.getOrInsert called on non-Map object';
+  SErrorMapGetOrInsertComputedNonMap = 'Map.prototype.getOrInsertComputed called on non-Map object';
+
   // Map upsert errors
   SErrorMapGetOrInsertComputedNotCallable = 'Map.getOrInsertComputed: callbackfn is not a function';
 

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -329,6 +329,8 @@ resourcestring
 
   // Runtime errors — Set
   SSuggestSetThisType = 'Set prototype methods must be called on a Set instance';
+  SSuggestSetCallbackRequired = 'pass a function as the callback argument';
+  SSuggestSetOperationArgType = 'pass a Set instance as the argument';
 
   // Runtime errors — Map
   SSuggestMapThisType = 'Map prototype methods must be called on a Map instance';

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -327,7 +327,11 @@ resourcestring
   // Runtime errors — import.meta
   SSuggestImportMetaUsage = 'import.meta.resolve() requires a string specifier argument';
 
+  // Runtime errors — Set
+  SSuggestSetThisType = 'Set prototype methods must be called on a Set instance';
+
   // Runtime errors — Map
+  SSuggestMapThisType = 'Map prototype methods must be called on a Map instance';
   SSuggestMapCallbackRequired = 'pass a function as the callback argument';
 
   // Runtime errors — Number

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -389,7 +389,7 @@ end;
 function TGocciaMapValue.MapForEach(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   M: TGocciaMapValue;
-  Callback: TGocciaValue;
+  Callback, ThisArg: TGocciaValue;
   TypedCallback: TGocciaFunctionBase;
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
@@ -397,31 +397,43 @@ begin
   // Steps 1-3: If M does not have a [[MapData]] internal slot, throw a TypeError
   if not (AThisValue is TGocciaMapValue) then
     ThrowTypeError(SErrorMapForEachNonMap, SSuggestMapThisType);
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  if AArgs.Length = 0 then Exit;
-
   M := TGocciaMapValue(AThisValue);
-  Callback := AArgs.GetElement(0);
+
   // Step 4: If IsCallable(callbackfn) is false, throw a TypeError
+  if AArgs.Length > 0 then
+    Callback := AArgs.GetElement(0)
+  else
+    Callback := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not Callback.IsCallable then
     ThrowTypeError(SErrorMapForEachNotCallable, SSuggestMapCallbackRequired);
+
+  // Step 5: Let thisArg be the second argument
+  if AArgs.Length > 1 then
+    ThisArg := AArgs.GetElement(1)
+  else
+    ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   TypedCallback := nil;
   if Callback is TGocciaFunctionBase then
     TypedCallback := TGocciaFunctionBase(Callback);
 
+  // Step 6: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
   for I := 0 to M.Entries.Count - 1 do
   begin
-    CallArgs := TGocciaArgumentsCollection.Create([M.Entries[I].Value, M.Entries[I].Key, AThisValue]);
+    // Step 6b: Call(callbackfn, thisArg, « p.[[Value]], p.[[Key]], M »)
+    CallArgs := TGocciaArgumentsCollection.Create([M.Entries[I].Value, M.Entries[I].Key, M]);
     try
       if Assigned(TypedCallback) then
-        TypedCallback.Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue)
+        TypedCallback.Call(CallArgs, ThisArg)
       else
-        InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+        InvokeCallable(Callback, CallArgs, ThisArg);
     finally
       CallArgs.Free;
     end;
   end;
+
+  // Step 7: Return undefined
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 // ES2026 §24.1.3.8 Map.prototype.keys()

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -402,7 +402,9 @@ begin
 
   M := TGocciaMapValue(AThisValue);
   Callback := AArgs.GetElement(0);
-  if not Callback.IsCallable then Exit;
+  // Step 4: If IsCallable(callbackfn) is false, throw a TypeError
+  if not Callback.IsCallable then
+    ThrowTypeError(SErrorMapForEachNotCallable, SSuggestMapCallbackRequired);
 
   TypedCallback := nil;
   if Callback is TGocciaFunctionBase then

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -277,8 +277,10 @@ var
   Index: Integer;
 begin
   // Step 1: Let M be the this value
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapGetNonMap, SSuggestMapThisType);
   M := TGocciaMapValue(AThisValue);
-  // Steps 2-3 (implicit): Require M has [[MapData]] internal slot
   if AArgs.Length > 0 then
   begin
     // Step 4: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
@@ -301,8 +303,10 @@ var
   MapKey, MapValue: TGocciaValue;
 begin
   // Step 1: Let M be the this value
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapSetNonMap, SSuggestMapThisType);
   M := TGocciaMapValue(AThisValue);
-  // Steps 2-3 (implicit): Require M has [[MapData]] internal slot
   if AArgs.Length >= 2 then
   begin
     MapKey := AArgs.GetElement(0);
@@ -325,8 +329,10 @@ var
   M: TGocciaMapValue;
 begin
   // Step 1: Let M be the this value
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapHasNonMap, SSuggestMapThisType);
   M := TGocciaMapValue(AThisValue);
-  // Steps 2-3 (implicit): Require M has [[MapData]] internal slot
   // Step 4: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
   //   If p.[[Key]] is not empty and SameValueZero(p.[[Key]], key) is true, return true
   if (AArgs.Length > 0) and (M.FindEntry(AArgs.GetElement(0)) >= 0) then
@@ -343,8 +349,10 @@ var
   Index: Integer;
 begin
   // Step 1: Let M be the this value
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapDeleteNonMap, SSuggestMapThisType);
   M := TGocciaMapValue(AThisValue);
-  // Steps 2-3 (implicit): Require M has [[MapData]] internal slot
   // Step 5 (early): Default return false
   Result := TGocciaBooleanLiteralValue.FalseValue;
   if AArgs.Length > 0 then
@@ -367,7 +375,9 @@ end;
 function TGocciaMapValue.MapClear(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Let M be the this value
-  // Steps 2-3 (implicit): Require M has [[MapData]] internal slot
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapClearNonMap, SSuggestMapThisType);
   // Step 4: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
   //   Set p.[[Key]] to empty, set p.[[Value]] to empty
   TGocciaMapValue(AThisValue).FEntries.Clear;
@@ -384,6 +394,9 @@ var
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
 begin
+  // Steps 1-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapForEachNonMap, SSuggestMapThisType);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if AArgs.Length = 0 then Exit;
 
@@ -413,7 +426,10 @@ end;
 function TGocciaMapValue.MapKeys(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Let M be the this value
-  // Step 2: Return CreateMapIterator(M, key)
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapKeysNonMap, SSuggestMapThisType);
+  // Step 4: Return CreateMapIterator(M, key)
   Result := TGocciaMapIteratorValue.Create(AThisValue, mkKeys);
 end;
 
@@ -421,7 +437,10 @@ end;
 function TGocciaMapValue.MapValues(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Let M be the this value
-  // Step 2: Return CreateMapIterator(M, value)
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapValuesNonMap, SSuggestMapThisType);
+  // Step 4: Return CreateMapIterator(M, value)
   Result := TGocciaMapIteratorValue.Create(AThisValue, mkValues);
 end;
 
@@ -429,14 +448,21 @@ end;
 function TGocciaMapValue.MapEntries(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Let M be the this value
-  // Step 2: Return CreateMapIterator(M, key+value)
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapEntriesNonMap, SSuggestMapThisType);
+  // Step 4: Return CreateMapIterator(M, key+value)
   Result := TGocciaMapIteratorValue.Create(AThisValue, mkEntries);
 end;
 
 // ES2026 §24.1.3.12 Map.prototype[@@iterator]()
 function TGocciaMapValue.MapSymbolIterator(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  // Step 1: Return the result of calling Map.prototype.entries()
+  // Step 1: Let M be the this value
+  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapIteratorNonMap, SSuggestMapThisType);
+  // Step 4: Return the result of calling Map.prototype.entries()
   Result := TGocciaMapIteratorValue.Create(AThisValue, mkEntries);
 end;
 
@@ -447,6 +473,9 @@ var
   MapKey, DefaultValue: TGocciaValue;
   Index: Integer;
 begin
+  // Steps 1-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapGetOrInsertNonMap, SSuggestMapThisType);
   M := TGocciaMapValue(AThisValue);
   if AArgs.Length < 2 then
   begin
@@ -485,6 +514,9 @@ var
   CallArgs: TGocciaArgumentsCollection;
   Index: Integer;
 begin
+  // Steps 1-3: If M does not have a [[MapData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaMapValue) then
+    ThrowTypeError(SErrorMapGetOrInsertComputedNonMap, SSuggestMapThisType);
   M := TGocciaMapValue(AThisValue);
   if AArgs.Length > 0 then
     MapKey := AArgs.GetElement(0)

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -61,10 +61,13 @@ implementation
 uses
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Evaluator.Comparison,
   Goccia.GarbageCollector,
   Goccia.Realm,
   Goccia.Utils,
+  Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.Iterator.Concrete,
   Goccia.Values.NativeFunction,
@@ -253,8 +256,10 @@ var
   S: TGocciaSetValue;
 begin
   // Step 1: Let S be the this value
+  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetHasNonSet, SSuggestSetThisType);
   S := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require S has [[SetData]] internal slot
   // Step 4: For each element e of S.[[SetData]], do
   //   If e is not empty and SameValueZero(e, value) is true, return true
   if (AArgs.Length > 0) and S.ContainsValue(AArgs.GetElement(0)) then
@@ -270,8 +275,10 @@ var
   S: TGocciaSetValue;
 begin
   // Step 1: Let S be the this value
+  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetAddNonSet, SSuggestSetThisType);
   S := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require S has [[SetData]] internal slot
   // Step 4: For each element e of S.[[SetData]], do
   //   If e is not empty and SameValueZero(e, value) is true, return S
   // Step 5: If value is -0, set value to +0
@@ -289,8 +296,10 @@ var
   I: Integer;
 begin
   // Step 1: Let S be the this value
+  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetDeleteNonSet, SSuggestSetThisType);
   S := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require S has [[SetData]] internal slot
   // Step 5 (early): Default return false
   Result := TGocciaBooleanLiteralValue.FalseValue;
   if AArgs.Length > 0 then
@@ -316,7 +325,9 @@ end;
 function TGocciaSetValue.SetClear(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Let S be the this value
-  // Steps 2-3 (implicit): Require S has [[SetData]] internal slot
+  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetClearNonSet, SSuggestSetThisType);
   // Step 4: For each element e of S.[[SetData]], replace e with empty
   TGocciaSetValue(AThisValue).FItems.Clear;
   // Step 5: Return undefined
@@ -332,6 +343,9 @@ var
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
 begin
+  // Steps 1-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetForEachNonSet, SSuggestSetThisType);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if AArgs.Length = 0 then Exit;
 
@@ -361,7 +375,10 @@ end;
 function TGocciaSetValue.SetValues(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Let S be the this value
-  // Step 2: Return CreateSetIterator(S, value)
+  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetValuesNonSet, SSuggestSetThisType);
+  // Step 4: Return CreateSetIterator(S, value)
   Result := TGocciaSetIteratorValue.Create(AThisValue, skValues);
 end;
 
@@ -369,7 +386,10 @@ end;
 function TGocciaSetValue.SetKeys(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: This method is the same function as Set.prototype.values (per spec)
-  // Step 2: Return CreateSetIterator(S, value)
+  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetKeysNonSet, SSuggestSetThisType);
+  // Step 4: Return CreateSetIterator(S, value)
   Result := TGocciaSetIteratorValue.Create(AThisValue, skValues);
 end;
 
@@ -377,7 +397,10 @@ end;
 function TGocciaSetValue.SetEntries(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Let S be the this value
-  // Step 2: Return CreateSetIterator(S, key+value)
+  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetEntriesNonSet, SSuggestSetThisType);
+  // Step 4: Return CreateSetIterator(S, key+value)
   Result := TGocciaSetIteratorValue.Create(AThisValue, skEntries);
 end;
 
@@ -385,6 +408,9 @@ end;
 function TGocciaSetValue.SetSymbolIterator(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: This method is the same function as Set.prototype.values (per spec)
+  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetIteratorNonSet, SSuggestSetThisType);
   Result := TGocciaSetIteratorValue.Create(AThisValue, skValues);
 end;
 
@@ -395,8 +421,10 @@ var
   I: Integer;
 begin
   // Step 1: Let O be the this value
+  // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetUnionNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require O has [[SetData]] internal slot
   // Step 4: Let otherRec be GetSetRecord(other)
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
@@ -423,8 +451,10 @@ var
   I: Integer;
 begin
   // Step 1: Let O be the this value
+  // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetIntersectionNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require O has [[SetData]] internal slot
   // Step 4: Let otherRec be GetSetRecord(other)
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
   // Step 5: Let resultSetData be a new empty List
@@ -449,8 +479,10 @@ var
   I: Integer;
 begin
   // Step 1: Let O be the this value
+  // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetDifferenceNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require O has [[SetData]] internal slot
   // Step 4: Let otherRec be GetSetRecord(other)
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
@@ -475,8 +507,10 @@ var
   I: Integer;
 begin
   // Step 1: Let O be the this value
+  // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetSymmetricDifferenceNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require O has [[SetData]] internal slot
   // Step 4: Let otherRec be GetSetRecord(other)
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
@@ -507,8 +541,10 @@ var
   I: Integer;
 begin
   // Step 1: Let O be the this value
+  // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetIsSubsetOfNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require O has [[SetData]] internal slot
   // Step 4: Let otherRec be GetSetRecord(other)
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
 
@@ -533,8 +569,10 @@ var
   I: Integer;
 begin
   // Step 1: Let O be the this value
+  // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetIsSupersetOfNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require O has [[SetData]] internal slot
   // Step 4: Let otherRec be GetSetRecord(other)
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
 
@@ -560,8 +598,10 @@ var
   I: Integer;
 begin
   // Step 1: Let O be the this value
+  // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
+  if not (AThisValue is TGocciaSetValue) then
+    ThrowTypeError(SErrorSetIsDisjointFromNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
-  // Steps 2-3 (implicit): Require O has [[SetData]] internal slot
   // Step 4: Let otherRec be GetSetRecord(other)
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
 

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -340,7 +340,7 @@ end;
 function TGocciaSetValue.SetForEach(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   S: TGocciaSetValue;
-  Callback: TGocciaValue;
+  Callback, ThisArg: TGocciaValue;
   TypedCallback: TGocciaFunctionBase;
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
@@ -348,31 +348,43 @@ begin
   // Steps 1-3: If S does not have a [[SetData]] internal slot, throw a TypeError
   if not (AThisValue is TGocciaSetValue) then
     ThrowTypeError(SErrorSetForEachNonSet, SSuggestSetThisType);
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  if AArgs.Length = 0 then Exit;
-
   S := TGocciaSetValue(AThisValue);
-  Callback := AArgs.GetElement(0);
+
   // Step 4: If IsCallable(callbackfn) is false, throw a TypeError
+  if AArgs.Length > 0 then
+    Callback := AArgs.GetElement(0)
+  else
+    Callback := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not Callback.IsCallable then
     ThrowTypeError(SErrorSetForEachNotCallable, SSuggestSetCallbackRequired);
+
+  // Step 5: Let thisArg be the second argument
+  if AArgs.Length > 1 then
+    ThisArg := AArgs.GetElement(1)
+  else
+    ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   TypedCallback := nil;
   if Callback is TGocciaFunctionBase then
     TypedCallback := TGocciaFunctionBase(Callback);
 
+  // Step 6: For each element e of S.[[SetData]], do
   for I := 0 to S.FItems.Count - 1 do
   begin
-    CallArgs := TGocciaArgumentsCollection.Create([S.FItems[I], S.FItems[I], AThisValue]);
+    // Step 6b: Call(callbackfn, thisArg, « e, e, S »)
+    CallArgs := TGocciaArgumentsCollection.Create([S.FItems[I], S.FItems[I], S]);
     try
       if Assigned(TypedCallback) then
-        TypedCallback.Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue)
+        TypedCallback.Call(CallArgs, ThisArg)
       else
-        InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+        InvokeCallable(Callback, CallArgs, ThisArg);
     finally
       CallArgs.Free;
     end;
   end;
+
+  // Step 7: Return undefined
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 // ES2026 §24.2.3.10 Set.prototype.values()

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -59,6 +59,8 @@ type
 implementation
 
 uses
+  SysUtils,
+
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
@@ -351,7 +353,9 @@ begin
 
   S := TGocciaSetValue(AThisValue);
   Callback := AArgs.GetElement(0);
-  if not Callback.IsCallable then Exit;
+  // Step 4: If IsCallable(callbackfn) is false, throw a TypeError
+  if not Callback.IsCallable then
+    ThrowTypeError(SErrorSetForEachNotCallable, SSuggestSetCallbackRequired);
 
   TypedCallback := nil;
   if Callback is TGocciaFunctionBase then
@@ -426,6 +430,8 @@ begin
     ThrowTypeError(SErrorSetUnionNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
+  if not (AArgs.GetElement(0) is TGocciaSetValue) then
+    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['union']), SSuggestSetOperationArgType);
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
   ResultSet := TGocciaSetValue.Create;
@@ -456,6 +462,8 @@ begin
     ThrowTypeError(SErrorSetIntersectionNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
+  if not (AArgs.GetElement(0) is TGocciaSetValue) then
+    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['intersection']), SSuggestSetOperationArgType);
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
   // Step 5: Let resultSetData be a new empty List
   ResultSet := TGocciaSetValue.Create;
@@ -484,6 +492,8 @@ begin
     ThrowTypeError(SErrorSetDifferenceNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
+  if not (AArgs.GetElement(0) is TGocciaSetValue) then
+    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['difference']), SSuggestSetOperationArgType);
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
   ResultSet := TGocciaSetValue.Create;
@@ -512,6 +522,8 @@ begin
     ThrowTypeError(SErrorSetSymmetricDifferenceNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
+  if not (AArgs.GetElement(0) is TGocciaSetValue) then
+    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['symmetricDifference']), SSuggestSetOperationArgType);
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
   ResultSet := TGocciaSetValue.Create;
@@ -546,6 +558,8 @@ begin
     ThrowTypeError(SErrorSetIsSubsetOfNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
+  if not (AArgs.GetElement(0) is TGocciaSetValue) then
+    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['isSubsetOf']), SSuggestSetOperationArgType);
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
 
   // Step 5: If SetDataSize(O) > otherRec.[[Size]], return false (optimization)
@@ -574,6 +588,8 @@ begin
     ThrowTypeError(SErrorSetIsSupersetOfNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
+  if not (AArgs.GetElement(0) is TGocciaSetValue) then
+    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['isSupersetOf']), SSuggestSetOperationArgType);
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
 
   // Step 5: If SetDataSize(O) < otherRec.[[Size]], return false (optimization)
@@ -603,6 +619,8 @@ begin
     ThrowTypeError(SErrorSetIsDisjointFromNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
+  if not (AArgs.GetElement(0) is TGocciaSetValue) then
+    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['isDisjointFrom']), SSuggestSetOperationArgType);
   OtherSet := TGocciaSetValue(AArgs.GetElement(0));
 
   // Step 5: For each element e of O.[[SetData]], do

--- a/tests/built-ins/Map/prototype/clear.js
+++ b/tests/built-ins/Map/prototype/clear.js
@@ -27,3 +27,10 @@ test("set after clear", () => {
   expect(map.has("a")).toBe(false);
   expect(map.has("b")).toBe(true);
 });
+
+test("throws TypeError when called on non-Map", () => {
+  const clear = Map.prototype.clear;
+  expect(() => clear.call(Map.prototype)).toThrow(TypeError);
+  expect(() => clear.call({})).toThrow(TypeError);
+  expect(() => clear.call(new Set())).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/delete.js
+++ b/tests/built-ins/Map/prototype/delete.js
@@ -35,3 +35,10 @@ test("delete on empty Map", () => {
   const map = new Map();
   expect(map.delete("a")).toBe(false);
 });
+
+test("throws TypeError when called on non-Map", () => {
+  const del = Map.prototype.delete;
+  expect(() => del.call(Map.prototype, "key")).toThrow(TypeError);
+  expect(() => del.call({}, "key")).toThrow(TypeError);
+  expect(() => del.call(new Set(), "key")).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/entries.js
+++ b/tests/built-ins/Map/prototype/entries.js
@@ -42,3 +42,16 @@ test("spread on map produces entries", () => {
   const map = new Map([["a", 1], ["b", 2]]);
   expect([...map]).toEqual([["a", 1], ["b", 2]]);
 });
+
+test("entries throws TypeError when called on non-Map", () => {
+  const entries = Map.prototype.entries;
+  expect(() => entries.call(Map.prototype)).toThrow(TypeError);
+  expect(() => entries.call({})).toThrow(TypeError);
+  expect(() => entries.call(new Set())).toThrow(TypeError);
+});
+
+test("[Symbol.iterator] throws TypeError when called on non-Map", () => {
+  const iter = Map.prototype[Symbol.iterator];
+  expect(() => iter.call(Map.prototype)).toThrow(TypeError);
+  expect(() => iter.call({})).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/forEach.js
+++ b/tests/built-ins/Map/prototype/forEach.js
@@ -55,3 +55,17 @@ test("throws TypeError when callback is not a function", () => {
   expect(() => map.forEach(42)).toThrow(TypeError);
   expect(() => map.forEach(null)).toThrow(TypeError);
 });
+
+test("throws TypeError when no callback is provided", () => {
+  const map = new Map([["a", 1]]);
+  expect(() => map.forEach()).toThrow(TypeError);
+});
+
+test("forEach passes map as third callback argument", () => {
+  const map = new Map([["a", 1]]);
+  let receivedMap;
+  map.forEach((value, key, m) => {
+    receivedMap = m;
+  });
+  expect(receivedMap).toBe(map);
+});

--- a/tests/built-ins/Map/prototype/forEach.js
+++ b/tests/built-ins/Map/prototype/forEach.js
@@ -48,3 +48,10 @@ test("throws TypeError when called on non-Map", () => {
   expect(() => forEach.call({}, () => {})).toThrow(TypeError);
   expect(() => forEach.call(new Set(), () => {})).toThrow(TypeError);
 });
+
+test("throws TypeError when callback is not a function", () => {
+  const map = new Map([["a", 1]]);
+  expect(() => map.forEach("not a function")).toThrow(TypeError);
+  expect(() => map.forEach(42)).toThrow(TypeError);
+  expect(() => map.forEach(null)).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/forEach.js
+++ b/tests/built-ins/Map/prototype/forEach.js
@@ -41,3 +41,10 @@ test("forEach visits each entry exactly once", () => {
   });
   expect(count).toBe(3);
 });
+
+test("throws TypeError when called on non-Map", () => {
+  const forEach = Map.prototype.forEach;
+  expect(() => forEach.call(Map.prototype, () => {})).toThrow(TypeError);
+  expect(() => forEach.call({}, () => {})).toThrow(TypeError);
+  expect(() => forEach.call(new Set(), () => {})).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/get.js
+++ b/tests/built-ins/Map/prototype/get.js
@@ -49,3 +49,10 @@ test("get property descriptor on Map.prototype", () => {
   expect(desc.enumerable).toBe(false);
   expect(desc.configurable).toBe(true);
 });
+
+test("throws TypeError when called on non-Map", () => {
+  const get = Map.prototype.get;
+  expect(() => get.call(Map.prototype, "key")).toThrow(TypeError);
+  expect(() => get.call({}, "key")).toThrow(TypeError);
+  expect(() => get.call(new Set(), "key")).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/getOrInsert.js
+++ b/tests/built-ins/Map/prototype/getOrInsert.js
@@ -80,4 +80,10 @@ describe.runIf(hasGoccia)("Map.prototype.getOrInsert", () => {
     expect(map.get("b")).toBe(2);
     expect(map.get("c")).toBe(1);
   });
+
+  test("throws TypeError when called on non-Map", () => {
+    const getOrInsert = Map.prototype.getOrInsert;
+    expect(() => getOrInsert.call(Map.prototype, "k", "v")).toThrow(TypeError);
+    expect(() => getOrInsert.call({}, "k", "v")).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Map/prototype/getOrInsertComputed.js
+++ b/tests/built-ins/Map/prototype/getOrInsertComputed.js
@@ -85,4 +85,10 @@ describe.runIf(hasGoccia)("Map.prototype.getOrInsertComputed", () => {
     expect(map.get("a").length).toBe(2);
     expect(map.get("b").length).toBe(1);
   });
+
+  test("throws TypeError when called on non-Map", () => {
+    const getOrInsertComputed = Map.prototype.getOrInsertComputed;
+    expect(() => getOrInsertComputed.call(Map.prototype, "k", () => "v")).toThrow(TypeError);
+    expect(() => getOrInsertComputed.call({}, "k", () => "v")).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Map/prototype/has.js
+++ b/tests/built-ins/Map/prototype/has.js
@@ -37,3 +37,10 @@ test("has after delete", () => {
   map.delete("a");
   expect(map.has("a")).toBe(false);
 });
+
+test("throws TypeError when called on non-Map", () => {
+  const has = Map.prototype.has;
+  expect(() => has.call(Map.prototype, "key")).toThrow(TypeError);
+  expect(() => has.call({}, "key")).toThrow(TypeError);
+  expect(() => has.call(new Set(), "key")).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/keys.js
+++ b/tests/built-ins/Map/prototype/keys.js
@@ -27,3 +27,10 @@ test("keys returns an iterator with next()", () => {
   expect(iter.next().value).toBe("c");
   expect(iter.next().done).toBe(true);
 });
+
+test("throws TypeError when called on non-Map", () => {
+  const keys = Map.prototype.keys;
+  expect(() => keys.call(Map.prototype)).toThrow(TypeError);
+  expect(() => keys.call({})).toThrow(TypeError);
+  expect(() => keys.call(new Set())).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/set.js
+++ b/tests/built-ins/Map/prototype/set.js
@@ -41,3 +41,10 @@ test("set with NaN key", () => {
   expect(map.size).toBe(1);
   expect(map.get(NaN)).toBe("second");
 });
+
+test("throws TypeError when called on non-Map", () => {
+  const set = Map.prototype.set;
+  expect(() => set.call(Map.prototype, "k", "v")).toThrow(TypeError);
+  expect(() => set.call({}, "k", "v")).toThrow(TypeError);
+  expect(() => set.call(new Set(), "k", "v")).toThrow(TypeError);
+});

--- a/tests/built-ins/Map/prototype/values.js
+++ b/tests/built-ins/Map/prototype/values.js
@@ -26,3 +26,10 @@ test("values returns an iterator with next()", () => {
   expect(iter.next().value).toBe(3);
   expect(iter.next().done).toBe(true);
 });
+
+test("throws TypeError when called on non-Map", () => {
+  const values = Map.prototype.values;
+  expect(() => values.call(Map.prototype)).toThrow(TypeError);
+  expect(() => values.call({})).toThrow(TypeError);
+  expect(() => values.call(new Set())).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/prototype/add.js
+++ b/tests/built-ins/Set/prototype/add.js
@@ -61,3 +61,10 @@ test("add object references", () => {
   set.add(obj1);
   expect(set.size).toBe(2);
 });
+
+test("throws TypeError when called on non-Set", () => {
+  const add = Set.prototype.add;
+  expect(() => add.call(Set.prototype, 1)).toThrow(TypeError);
+  expect(() => add.call({}, 1)).toThrow(TypeError);
+  expect(() => add.call(new Map(), 1)).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/prototype/clear.js
+++ b/tests/built-ins/Set/prototype/clear.js
@@ -26,3 +26,10 @@ test("add after clear", () => {
   expect(set.has(4)).toBe(true);
   expect(set.has(1)).toBe(false);
 });
+
+test("throws TypeError when called on non-Set", () => {
+  const clear = Set.prototype.clear;
+  expect(() => clear.call(Set.prototype)).toThrow(TypeError);
+  expect(() => clear.call({})).toThrow(TypeError);
+  expect(() => clear.call(new Map())).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/prototype/delete.js
+++ b/tests/built-ins/Set/prototype/delete.js
@@ -37,3 +37,10 @@ test("delete on empty Set", () => {
   const set = new Set();
   expect(set.delete(1)).toBe(false);
 });
+
+test("throws TypeError when called on non-Set", () => {
+  const del = Set.prototype.delete;
+  expect(() => del.call(Set.prototype, 1)).toThrow(TypeError);
+  expect(() => del.call({}, 1)).toThrow(TypeError);
+  expect(() => del.call(new Map(), 1)).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/prototype/difference.js
+++ b/tests/built-ins/Set/prototype/difference.js
@@ -19,4 +19,10 @@ describe("Set.prototype.difference", () => {
     const b = new Set([1, 2, 3]);
     expect(a.difference(b).size).toBe(0);
   });
+
+  test("throws TypeError when called on non-Set", () => {
+    const difference = Set.prototype.difference;
+    expect(() => difference.call(Set.prototype, new Set())).toThrow(TypeError);
+    expect(() => difference.call({}, new Set())).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Set/prototype/difference.js
+++ b/tests/built-ins/Set/prototype/difference.js
@@ -24,5 +24,12 @@ describe("Set.prototype.difference", () => {
     const difference = Set.prototype.difference;
     expect(() => difference.call(Set.prototype, new Set())).toThrow(TypeError);
     expect(() => difference.call({}, new Set())).toThrow(TypeError);
+    expect(() => difference.call(new Map(), new Set())).toThrow(TypeError);
+  });
+
+  test("throws TypeError when argument is not a Set", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.difference({})).toThrow(TypeError);
+    expect(() => s.difference([])).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Set/prototype/forEach.js
+++ b/tests/built-ins/Set/prototype/forEach.js
@@ -52,3 +52,17 @@ test("throws TypeError when callback is not a function", () => {
   expect(() => set.forEach(42)).toThrow(TypeError);
   expect(() => set.forEach(null)).toThrow(TypeError);
 });
+
+test("throws TypeError when no callback is provided", () => {
+  const set = new Set([1, 2]);
+  expect(() => set.forEach()).toThrow(TypeError);
+});
+
+test("forEach passes set as third callback argument", () => {
+  const set = new Set([1]);
+  let receivedSet;
+  set.forEach((value, key, s) => {
+    receivedSet = s;
+  });
+  expect(receivedSet).toBe(set);
+});

--- a/tests/built-ins/Set/prototype/forEach.js
+++ b/tests/built-ins/Set/prototype/forEach.js
@@ -45,3 +45,10 @@ test("throws TypeError when called on non-Set", () => {
   expect(() => forEach.call({}, () => {})).toThrow(TypeError);
   expect(() => forEach.call(new Map(), () => {})).toThrow(TypeError);
 });
+
+test("throws TypeError when callback is not a function", () => {
+  const set = new Set([1, 2]);
+  expect(() => set.forEach("not a function")).toThrow(TypeError);
+  expect(() => set.forEach(42)).toThrow(TypeError);
+  expect(() => set.forEach(null)).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/prototype/forEach.js
+++ b/tests/built-ins/Set/prototype/forEach.js
@@ -38,3 +38,10 @@ test("forEach visits each value exactly once", () => {
   });
   expect(count).toBe(3);
 });
+
+test("throws TypeError when called on non-Set", () => {
+  const forEach = Set.prototype.forEach;
+  expect(() => forEach.call(Set.prototype, () => {})).toThrow(TypeError);
+  expect(() => forEach.call({}, () => {})).toThrow(TypeError);
+  expect(() => forEach.call(new Map(), () => {})).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/prototype/has.js
+++ b/tests/built-ins/Set/prototype/has.js
@@ -47,3 +47,10 @@ test("has property descriptor on Set.prototype", () => {
   expect(desc.enumerable).toBe(false);
   expect(desc.configurable).toBe(true);
 });
+
+test("throws TypeError when called on non-Set", () => {
+  const has = Set.prototype.has;
+  expect(() => has.call(Set.prototype, 1)).toThrow(TypeError);
+  expect(() => has.call({}, 1)).toThrow(TypeError);
+  expect(() => has.call(new Map(), 1)).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/prototype/intersection.js
+++ b/tests/built-ins/Set/prototype/intersection.js
@@ -23,5 +23,12 @@ describe("Set.prototype.intersection", () => {
     const intersection = Set.prototype.intersection;
     expect(() => intersection.call(Set.prototype, new Set())).toThrow(TypeError);
     expect(() => intersection.call({}, new Set())).toThrow(TypeError);
+    expect(() => intersection.call(new Map(), new Set())).toThrow(TypeError);
+  });
+
+  test("throws TypeError when argument is not a Set", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.intersection({})).toThrow(TypeError);
+    expect(() => s.intersection([])).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Set/prototype/intersection.js
+++ b/tests/built-ins/Set/prototype/intersection.js
@@ -18,4 +18,10 @@ describe("Set.prototype.intersection", () => {
     const a = new Set([1, 2]);
     expect(a.intersection(new Set()).size).toBe(0);
   });
+
+  test("throws TypeError when called on non-Set", () => {
+    const intersection = Set.prototype.intersection;
+    expect(() => intersection.call(Set.prototype, new Set())).toThrow(TypeError);
+    expect(() => intersection.call({}, new Set())).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Set/prototype/isDisjointFrom.js
+++ b/tests/built-ins/Set/prototype/isDisjointFrom.js
@@ -23,5 +23,12 @@ describe("Set.prototype.isDisjointFrom", () => {
     const isDisjointFrom = Set.prototype.isDisjointFrom;
     expect(() => isDisjointFrom.call(Set.prototype, new Set())).toThrow(TypeError);
     expect(() => isDisjointFrom.call({}, new Set())).toThrow(TypeError);
+    expect(() => isDisjointFrom.call(new Map(), new Set())).toThrow(TypeError);
+  });
+
+  test("throws TypeError when argument is not a Set", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.isDisjointFrom({})).toThrow(TypeError);
+    expect(() => s.isDisjointFrom([])).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Set/prototype/isDisjointFrom.js
+++ b/tests/built-ins/Set/prototype/isDisjointFrom.js
@@ -18,4 +18,10 @@ describe("Set.prototype.isDisjointFrom", () => {
   test("empty set is disjoint from any set", () => {
     expect(new Set().isDisjointFrom(new Set([1, 2]))).toBe(true);
   });
+
+  test("throws TypeError when called on non-Set", () => {
+    const isDisjointFrom = Set.prototype.isDisjointFrom;
+    expect(() => isDisjointFrom.call(Set.prototype, new Set())).toThrow(TypeError);
+    expect(() => isDisjointFrom.call({}, new Set())).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Set/prototype/isSubsetOf.js
+++ b/tests/built-ins/Set/prototype/isSubsetOf.js
@@ -21,4 +21,10 @@ describe("Set.prototype.isSubsetOf", () => {
     const b = new Set([1, 2]);
     expect(a.isSubsetOf(b)).toBe(true);
   });
+
+  test("throws TypeError when called on non-Set", () => {
+    const isSubsetOf = Set.prototype.isSubsetOf;
+    expect(() => isSubsetOf.call(Set.prototype, new Set())).toThrow(TypeError);
+    expect(() => isSubsetOf.call({}, new Set())).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Set/prototype/isSubsetOf.js
+++ b/tests/built-ins/Set/prototype/isSubsetOf.js
@@ -26,5 +26,12 @@ describe("Set.prototype.isSubsetOf", () => {
     const isSubsetOf = Set.prototype.isSubsetOf;
     expect(() => isSubsetOf.call(Set.prototype, new Set())).toThrow(TypeError);
     expect(() => isSubsetOf.call({}, new Set())).toThrow(TypeError);
+    expect(() => isSubsetOf.call(new Map(), new Set())).toThrow(TypeError);
+  });
+
+  test("throws TypeError when argument is not a Set", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.isSubsetOf({})).toThrow(TypeError);
+    expect(() => s.isSubsetOf([])).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Set/prototype/isSupersetOf.js
+++ b/tests/built-ins/Set/prototype/isSupersetOf.js
@@ -20,5 +20,12 @@ describe("Set.prototype.isSupersetOf", () => {
     const isSupersetOf = Set.prototype.isSupersetOf;
     expect(() => isSupersetOf.call(Set.prototype, new Set())).toThrow(TypeError);
     expect(() => isSupersetOf.call({}, new Set())).toThrow(TypeError);
+    expect(() => isSupersetOf.call(new Map(), new Set())).toThrow(TypeError);
+  });
+
+  test("throws TypeError when argument is not a Set", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.isSupersetOf({})).toThrow(TypeError);
+    expect(() => s.isSupersetOf([])).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Set/prototype/isSupersetOf.js
+++ b/tests/built-ins/Set/prototype/isSupersetOf.js
@@ -15,4 +15,10 @@ describe("Set.prototype.isSupersetOf", () => {
     expect(new Set([1]).isSupersetOf(new Set())).toBe(true);
     expect(new Set().isSupersetOf(new Set())).toBe(true);
   });
+
+  test("throws TypeError when called on non-Set", () => {
+    const isSupersetOf = Set.prototype.isSupersetOf;
+    expect(() => isSupersetOf.call(Set.prototype, new Set())).toThrow(TypeError);
+    expect(() => isSupersetOf.call({}, new Set())).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Set/prototype/symmetricDifference.js
+++ b/tests/built-ins/Set/prototype/symmetricDifference.js
@@ -19,4 +19,10 @@ describe("Set.prototype.symmetricDifference", () => {
     const b = new Set([1, 2]);
     expect(a.symmetricDifference(b).size).toBe(0);
   });
+
+  test("throws TypeError when called on non-Set", () => {
+    const symDiff = Set.prototype.symmetricDifference;
+    expect(() => symDiff.call(Set.prototype, new Set())).toThrow(TypeError);
+    expect(() => symDiff.call({}, new Set())).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Set/prototype/symmetricDifference.js
+++ b/tests/built-ins/Set/prototype/symmetricDifference.js
@@ -24,5 +24,12 @@ describe("Set.prototype.symmetricDifference", () => {
     const symDiff = Set.prototype.symmetricDifference;
     expect(() => symDiff.call(Set.prototype, new Set())).toThrow(TypeError);
     expect(() => symDiff.call({}, new Set())).toThrow(TypeError);
+    expect(() => symDiff.call(new Map(), new Set())).toThrow(TypeError);
+  });
+
+  test("throws TypeError when argument is not a Set", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.symmetricDifference({})).toThrow(TypeError);
+    expect(() => s.symmetricDifference([])).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Set/prototype/union.js
+++ b/tests/built-ins/Set/prototype/union.js
@@ -31,5 +31,12 @@ describe("Set.prototype.union", () => {
     const union = Set.prototype.union;
     expect(() => union.call(Set.prototype, new Set())).toThrow(TypeError);
     expect(() => union.call({}, new Set())).toThrow(TypeError);
+    expect(() => union.call(new Map(), new Set())).toThrow(TypeError);
+  });
+
+  test("throws TypeError when argument is not a Set", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.union({})).toThrow(TypeError);
+    expect(() => s.union([])).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Set/prototype/union.js
+++ b/tests/built-ins/Set/prototype/union.js
@@ -26,4 +26,10 @@ describe("Set.prototype.union", () => {
     const result = new Set().union(new Set());
     expect(result.size).toBe(0);
   });
+
+  test("throws TypeError when called on non-Set", () => {
+    const union = Set.prototype.union;
+    expect(() => union.call(Set.prototype, new Set())).toThrow(TypeError);
+    expect(() => union.call({}, new Set())).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Set/prototype/values.js
+++ b/tests/built-ins/Set/prototype/values.js
@@ -67,3 +67,27 @@ test("Set.entries() iterator with next()", () => {
   expect(second[1]).toBe("b");
   expect(iter.next().done).toBe(true);
 });
+
+test("values throws TypeError when called on non-Set", () => {
+  const values = Set.prototype.values;
+  expect(() => values.call(Set.prototype)).toThrow(TypeError);
+  expect(() => values.call({})).toThrow(TypeError);
+});
+
+test("keys throws TypeError when called on non-Set", () => {
+  const keys = Set.prototype.keys;
+  expect(() => keys.call(Set.prototype)).toThrow(TypeError);
+  expect(() => keys.call({})).toThrow(TypeError);
+});
+
+test("entries throws TypeError when called on non-Set", () => {
+  const entries = Set.prototype.entries;
+  expect(() => entries.call(Set.prototype)).toThrow(TypeError);
+  expect(() => entries.call({})).toThrow(TypeError);
+});
+
+test("[Symbol.iterator] throws TypeError when called on non-Set", () => {
+  const iter = Set.prototype[Symbol.iterator];
+  expect(() => iter.call(Set.prototype)).toThrow(TypeError);
+  expect(() => iter.call({})).toThrow(TypeError);
+});


### PR DESCRIPTION
## Summary

- Add `is` type-guard brand checks to all 28 Set/Map prototype methods (16 Set, 12 Map) so they throw `TypeError` per ES2026 §24.1/§24.2 when the receiver lacks the `[[SetData]]`/`[[MapData]]` internal slot
- Previously, calling e.g. `Set.prototype.clear.call(Set.prototype)` triggered a fatal Pascal `Invalid type cast` crash; now it correctly throws a catchable `TypeError`
- Add brand-check test cases to all existing Set and Map prototype test files

Closes #408
