### PR TITLE
Fix website labels, hero console alignment, and example file extensions

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -2386,7 +2386,7 @@ p {
   min-height: 7.75rem;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
 }
 /* Arch pipeline console tab — compact padding inside the artifact box. */
 .arch-console {

--- a/website/src/app/installation/page.tsx
+++ b/website/src/app/installation/page.tsx
@@ -5,7 +5,7 @@ import { fetchLatestRelease } from "@/lib/github";
 import { parseAcceptLanguage } from "@/lib/locale";
 
 export const metadata: Metadata = {
-  title: "Install",
+  title: "Installation",
   description:
     "Install GocciaScript — one-line installer, prebuilt binaries, or build from source. Single self-contained runtime, no Node.js required.",
   alternates: { canonical: "/installation" },

--- a/website/src/app/installation/page.tsx
+++ b/website/src/app/installation/page.tsx
@@ -10,13 +10,13 @@ export const metadata: Metadata = {
     "Install GocciaScript — one-line installer, prebuilt binaries, or build from source. Single self-contained runtime, no Node.js required.",
   alternates: { canonical: "/installation" },
   openGraph: {
-    title: "Install · GocciaScript",
+    title: "Installation · GocciaScript",
     description:
       "Install GocciaScript — one-line installer, prebuilt binaries, or build from source.",
     url: "/installation",
   },
   twitter: {
-    title: "Install · GocciaScript",
+    title: "Installation · GocciaScript",
     description:
       "Install GocciaScript — one-line installer, prebuilt binaries, or build from source.",
   },

--- a/website/src/components/install.tsx
+++ b/website/src/components/install.tsx
@@ -193,7 +193,7 @@ export function Install({
         <div className="install-hero">
           <div className="install-hero-text">
             <div className="section-head">
-              <div className="section-kicker">Install</div>
+              <div className="section-kicker">Installation</div>
               <h1>
                 Get Goccia<em>Script</em> on your machine.
               </h1>

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -103,7 +103,7 @@ function HeroRunnableCard({ code }: { code: string }) {
     if (running) return;
     setRunning(true);
     setRunTick((t) => t + 1);
-    const banner = "GocciaScriptLoader coffee-shop.js";
+    const banner = "GocciaScriptLoader coffee-typed.ts";
     setOutput([{ kind: "meta", text: banner }]);
     try {
       const res = await fetch("/api/run", {
@@ -201,7 +201,7 @@ function HeroRunnableCard({ code }: { code: string }) {
           <span />
           <span />
         </div>
-        <span className="flex-1">coffee-shop.js</span>
+        <span className="flex-1">coffee-typed.ts</span>
         {copied && (
           <span key={copyTick} className="copied-flash">
             copied

--- a/website/src/components/playground.tsx
+++ b/website/src/components/playground.tsx
@@ -384,7 +384,7 @@ export function Playground({ stableTags = [] }: PlaygroundProps) {
       <div className="pg-panes pg-panes-full">
         <div className="pg-pane">
           <div className="pg-pane-head">
-            <TerminalIcon size={14} /> {example.id}.js
+            <TerminalIcon size={14} /> {example.id}.{example.ext ?? "js"}
             <span className="ml-auto text-[0.7rem]">{lineCount} lines</span>
           </div>
           <div className="pg-editor">

--- a/website/src/components/site-shell.tsx
+++ b/website/src/components/site-shell.tsx
@@ -35,7 +35,7 @@ type Tab = "home" | "install" | "docs" | "playground" | "sandbox";
 
 const TABS: { id: Tab; label: string; href: string }[] = [
   { id: "home", label: "Home", href: "/" },
-  { id: "install", label: "Install", href: "/installation" },
+  { id: "install", label: "Installation", href: "/installation" },
   { id: "docs", label: "Docs", href: "/docs" },
   { id: "playground", label: "Playground", href: "/playground" },
   { id: "sandbox", label: "Sandbox", href: "/sandbox" },

--- a/website/src/lib/examples.ts
+++ b/website/src/lib/examples.ts
@@ -8,6 +8,7 @@ export type Example = {
   label: string;
   desc: string;
   code: string;
+  ext?: string;
 };
 
 export const EXAMPLES: Example[] = [
@@ -21,6 +22,7 @@ export const EXAMPLES: Example[] = [
   },
   {
     id: "types",
+    ext: "ts",
     label: "Types-as-comments — TypeScript-style annotations",
     desc: "TC39 types-as-comments: TypeScript-style annotations are parsed and stripped at runtime — no separate compilation step.",
     code: `// Type annotations are allowed, but treated as comments at runtime.
@@ -54,6 +56,7 @@ console.log("Total:", format(subtotal(cart), "EUR"));`,
   },
   {
     id: "enums",
+    ext: "ts",
     label: "Enums — TC39 Stage-1 proposal",
     desc: "Enum declarations compile to frozen objects with reverse-mapping. Enums are exhaustive in a switch.",
     code: `// Enum declarations — TC39 Stage-1 proposal
@@ -117,6 +120,7 @@ console.log("Menu:", shop.getMenu());`,
   },
   {
     id: "coffee-typed",
+    ext: "ts",
     label: "CoffeeShop · typed — types, enums, private fields",
     desc: "The home-page example. Types-as-comments, enums, interfaces, private fields, getters, and mapped object types — all in one program.",
     code: `// Types-as-comments, enums, private fields — all stock GocciaScript.

--- a/website/src/lib/examples.ts
+++ b/website/src/lib/examples.ts
@@ -8,7 +8,7 @@ export type Example = {
   label: string;
   desc: string;
   code: string;
-  ext?: string;
+  ext?: "js" | "ts" | "jsx" | "tsx";
 };
 
 export const EXAMPLES: Example[] = [


### PR DESCRIPTION
## Summary
- Fix hero console output growing from center instead of top (`justify-content: flex-start`)
- Rename "Install" to "Installation" in nav tab, page metadata, and section kicker breadcrumb
- Rename hero code tab from `coffee-shop.js` to `coffee-typed.ts` (matching the playground link)
- Add per-example `ext` field so typed examples (`types`, `enums`, `coffee-typed`) display `.ts` in the playground