### PR TITLE
Implement smallestUnit, roundingMode, roundingIncrement for Temporal until/since

### DIFF
--- a/docs/built-ins-temporal.md
+++ b/docs/built-ins-temporal.md
@@ -86,7 +86,7 @@ Represents a calendar date without time or timezone.
 |--------|-------------|
 | `with(fields)` | Return new date with overridden fields |
 | `add(duration)` / `subtract(duration)` | Date arithmetic |
-| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` where `largestUnit` is `"year"`, `"month"`, `"week"`, or `"day"` (default `"day"`). |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit, smallestUnit, roundingMode, roundingIncrement }`. Units: `"year"`, `"month"`, `"week"`, or `"day"` (defaults: largest `"day"`, smallest `"day"`). Rounding mode defaults to `"trunc"`; increment defaults to 1. |
 | `equals(other)` | Equality check |
 | `toPlainDateTime(time?)` | Combine with a time |
 | `toPlainYearMonth()` | Extract year and month as PlainYearMonth |
@@ -114,7 +114,7 @@ Represents a wall-clock time without date or timezone.
 |--------|-------------|
 | `with(fields)` | Return new time with overridden fields |
 | `add(duration)` / `subtract(duration)` | Time arithmetic (wraps at midnight) |
-| `until(other)` / `since(other)` | Difference as Duration |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit, smallestUnit, roundingMode, roundingIncrement }`. Units: `"hour"` through `"nanosecond"` (defaults: largest `"hour"`, smallest `"nanosecond"`). Rounding mode defaults to `"trunc"`; increment defaults to 1. |
 | `round(options)` | Round to nearest unit. Accepts a string (smallestUnit) or options object `{ smallestUnit, roundingMode, roundingIncrement }`. |
 | `equals(other)` | Equality check |
 | `toString([options])` / `toJSON()` | ISO time string (e.g., `"13:45:30"`). `toString` accepts `{ fractionalSecondDigits }` (0-9 or `"auto"`). |
@@ -139,7 +139,7 @@ Represents a date and time without timezone. Combines PlainDate and PlainTime.
 | `with(fields)` | Return new date-time with overridden fields |
 | `withPlainTime(time?)` | Replace time component |
 | `add(duration)` / `subtract(duration)` | Date-time arithmetic |
-| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` — any unit from `"year"` to `"nanosecond"` (default `"day"`). |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit, smallestUnit, roundingMode, roundingIncrement }`. Any unit from `"year"` to `"nanosecond"` (defaults: largest `"day"`, smallest `"nanosecond"`). Mode defaults to `"trunc"`, increment to 1. |
 | `round(options)` | Round to nearest unit. Accepts a string (smallestUnit) or options object `{ smallestUnit, roundingMode, roundingIncrement }`. |
 | `equals(other)` | Equality check |
 | `toPlainDate()` / `toPlainTime()` | Extract date or time component |
@@ -169,7 +169,7 @@ Represents an absolute point in time (epoch-based), independent of calendar or t
 | Method | Description |
 |--------|-------------|
 | `add(duration)` / `subtract(duration)` | Time arithmetic (no calendar units) |
-| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` — `"hour"` through `"nanosecond"` (default `"hour"`). Calendar units not allowed. |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit, smallestUnit, roundingMode, roundingIncrement }`. `"hour"` through `"nanosecond"` only — calendar units not allowed (defaults: largest `"hour"`, smallest `"nanosecond"`). Rounding: mode `"trunc"`, increment 1. |
 | `round(options)` | Round to nearest unit. Accepts a string (smallestUnit) or options object `{ smallestUnit, roundingMode, roundingIncrement }`. |
 | `equals(other)` | Equality check |
 | `toString([options])` / `toJSON()` | ISO string with UTC (e.g., `"2024-03-15T13:45:30Z"`). `toString` accepts `{ fractionalSecondDigits }` (0-9 or `"auto"`). |
@@ -197,7 +197,7 @@ Represents a year and month without a day, time, or timezone.
 |--------|-------------|
 | `with(fields)` | Return new year-month with overridden fields |
 | `add(duration)` / `subtract(duration)` | Year-month arithmetic (years and months only) |
-| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` — `"year"` (default) or `"month"`. |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit, smallestUnit, roundingMode, roundingIncrement }`. `"year"` (default largest) or `"month"` (default smallest). Supports rounding via mode (`"trunc"` default) and increment (default 1). |
 | `equals(other)` | Equality check |
 | `toPlainDate(item)` | Combine with a day (`{ day }`) to create a PlainDate |
 | `toString()` / `toJSON()` | ISO string (e.g., `"2024-03"`) |
@@ -260,7 +260,7 @@ Represents an absolute date and time in a specific timezone. Combines an instant
 | `withPlainTime(time?)` | Replace time component |
 | `withTimeZone(timeZone)` | Re-interpret the same instant in a different timezone |
 | `add(duration)` / `subtract(duration)` | Date-time arithmetic |
-| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit }` — any unit from `"year"` to `"nanosecond"` (default `"hour"`). |
+| `until(other [, options])` / `since(other [, options])` | Difference as Duration. Options: `{ largestUnit, smallestUnit, roundingMode, roundingIncrement }`. Accepts any unit from `"year"` to `"nanosecond"` (defaults: largest `"hour"`, smallest `"nanosecond"`). Rounding via mode (`"trunc"` default) and increment (default 1). Calendar-aware for day-or-larger units using wall-clock components. |
 | `round(options)` | Round to nearest unit. Accepts a string (smallestUnit) or options object `{ smallestUnit, roundingMode, roundingIncrement }`. |
 | `equals(other)` | Equality check |
 | `startOfDay()` | Return ZonedDateTime at the start of the wall-clock day |

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -266,6 +266,7 @@ resourcestring
   SErrorInvalidLargestUnit = 'Invalid largestUnit: %s';
   SErrorInvalidRoundingMode = 'Invalid roundingMode: %s';
   SErrorRoundingIncrementMin = 'roundingIncrement must be >= 1';
+  SErrorRoundingIncrementDivisor = 'roundingIncrement %d does not divide the maximum value %d for this unit';
   SErrorInvalidOverflow = 'Invalid overflow option: %s';
   SErrorInvalidFractionalDigits = 'Invalid fractionalSecondDigits: %s';
   SErrorFractionalDigitsRange = 'fractionalSecondDigits must be 0-9 or "auto"';

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -1037,6 +1037,33 @@ begin
         WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
         ResultDays := EndEpoch - WalkEpoch;
 
+        // When smallestUnit is "week", the day remainder must be divisible
+        // by 7.  Back off months until that holds (or fall to zero months).
+        if (ASmallestUnit = tuWeek) and (WholeUnits <> 0) and
+           (ResultDays mod 7 <> 0) then
+        begin
+          if Sign > 0 then
+          begin
+            while (WholeUnits > 0) and (ResultDays mod 7 <> 0) do
+            begin
+              Dec(WholeUnits);
+              WalkDate := AddMonthsToDate(AStartY, AStartM, AStartD, WholeUnits);
+              WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+              ResultDays := EndEpoch - WalkEpoch;
+            end;
+          end
+          else
+          begin
+            while (WholeUnits < 0) and (ResultDays mod 7 <> 0) do
+            begin
+              Inc(WholeUnits);
+              WalkDate := AddMonthsToDate(AStartY, AStartM, AStartD, WholeUnits);
+              WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+              ResultDays := EndEpoch - WalkEpoch;
+            end;
+          end;
+        end;
+
         if Ord(ALargestUnit) <= Ord(tuYear) then
         begin
           ResultYears := WholeUnits div 12;

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -91,6 +91,21 @@ procedure CalendarDateUntil(
   const ALargestUnit: TTemporalUnit;
   out AYears, AMonths, AWeeks, ADays: Int64);
 
+{ Round a diff duration produced by until/since.  Implements the TC39
+  RoundRelativeDuration algorithm for calendar-unit rounding (year/month)
+  and simple nanosecond rounding for sub-month units.
+  AStartY/M/D is the "start" date of the diff (needed for year/month walking).
+  For types without a date component pass 0,0,0 and ensure smallestUnit is
+  sub-day. }
+procedure RoundDiffDuration(
+  var AYears, AMonths, AWeeks, ADays,
+      AHours, AMinutes, ASeconds,
+      AMilliseconds, AMicroseconds, ANanoseconds: Int64;
+  const AStartY, AStartM, AStartD: Integer;
+  const ALargestUnit, ASmallestUnit: TTemporalUnit;
+  const AMode: TTemporalRoundingMode;
+  const AIncrement: Integer);
+
 { Extract diff options from an arguments collection at a given index.
   Returns nil if the argument is undefined/missing. }
 function GetDiffOptions(const AArgs: TGocciaArgumentsCollection;
@@ -772,6 +787,363 @@ begin
         AMonths := -AMonths;
         ADays := -ADays;
       end;
+    end;
+  end;
+end;
+
+{ --------------------------------------------------------------------------- }
+{ RoundDiffDuration                                                            }
+{ --------------------------------------------------------------------------- }
+
+procedure RoundDiffDuration(
+  var AYears, AMonths, AWeeks, ADays,
+      AHours, AMinutes, ASeconds,
+      AMilliseconds, AMicroseconds, ANanoseconds: Int64;
+  const AStartY, AStartM, AStartD: Integer;
+  const ALargestUnit, ASmallestUnit: TTemporalUnit;
+  const AMode: TTemporalRoundingMode;
+  const AIncrement: Integer);
+var
+  TimeNs, TotalNs, Divisor: Int64;
+  RemNs: Int64;
+  Sign: Integer;
+  WholeUnits, ScaledValue, PeriodNs, RoundedValue: Int64;
+  WalkDate, NextDate, EndDate: TTemporalDateRecord;
+  StartEpoch, EndEpoch, WalkEpoch, NextEpoch: Int64;
+  ResultYears, ResultMonths, ResultDays: Int64;
+  ResultHours, ResultMinutes, ResultSeconds: Int64;
+  ResultMs, ResultUs, ResultNs: Int64;
+begin
+  // Nothing to do when smallestUnit equals the finest granularity and increment is 1
+  if (ASmallestUnit = tuNanosecond) and (AIncrement = 1) then Exit;
+
+  // Compute the overall sign of the duration
+  if AYears > 0 then Sign := 1
+  else if AYears < 0 then Sign := -1
+  else if AMonths > 0 then Sign := 1
+  else if AMonths < 0 then Sign := -1
+  else if AWeeks > 0 then Sign := 1
+  else if AWeeks < 0 then Sign := -1
+  else if ADays > 0 then Sign := 1
+  else if ADays < 0 then Sign := -1
+  else if AHours > 0 then Sign := 1
+  else if AHours < 0 then Sign := -1
+  else if AMinutes > 0 then Sign := 1
+  else if AMinutes < 0 then Sign := -1
+  else if ASeconds > 0 then Sign := 1
+  else if ASeconds < 0 then Sign := -1
+  else if AMilliseconds > 0 then Sign := 1
+  else if AMilliseconds < 0 then Sign := -1
+  else if AMicroseconds > 0 then Sign := 1
+  else if AMicroseconds < 0 then Sign := -1
+  else if ANanoseconds > 0 then Sign := 1
+  else if ANanoseconds < 0 then Sign := -1
+  else
+    Exit; // zero duration, nothing to round
+
+  // Collect sub-day time as nanoseconds
+  TimeNs := ANanoseconds +
+            AMicroseconds * NANOSECONDS_PER_MICROSECOND +
+            AMilliseconds * NANOSECONDS_PER_MILLISECOND +
+            ASeconds * NANOSECONDS_PER_SECOND +
+            AMinutes * NANOSECONDS_PER_MINUTE +
+            AHours * NANOSECONDS_PER_HOUR;
+
+  // --- Calendar-unit rounding (year / month) ---
+  if (ASmallestUnit = tuYear) or (ASmallestUnit = tuMonth) then
+  begin
+    // Resolve duration to concrete end date via calendar walking
+    EndDate.Year := AStartY; EndDate.Month := AStartM; EndDate.Day := AStartD;
+    if AYears <> 0 then
+      EndDate := AddMonthsToDate(EndDate.Year, EndDate.Month, EndDate.Day, AYears * 12);
+    if AMonths <> 0 then
+      EndDate := AddMonthsToDate(EndDate.Year, EndDate.Month, EndDate.Day, AMonths);
+    EndDate := AddDaysToDate(EndDate.Year, EndDate.Month, EndDate.Day,
+      AWeeks * 7 + ADays + TimeNs div NANOSECONDS_PER_DAY);
+    TimeNs := TimeNs mod NANOSECONDS_PER_DAY;
+
+    StartEpoch := DateToEpochDays(AStartY, AStartM, AStartD);
+    EndEpoch := DateToEpochDays(EndDate.Year, EndDate.Month, EndDate.Day);
+
+    if ASmallestUnit = tuYear then
+    begin
+      // Walk years from start
+      WholeUnits := 0;
+      if Sign > 0 then
+      begin
+        repeat
+          NextDate := AddMonthsToDate(AStartY, AStartM, AStartD, (WholeUnits + 1) * 12);
+          NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+          if (NextEpoch > EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs <= 0)) then Break;
+          Inc(WholeUnits);
+        until False;
+      end
+      else
+      begin
+        repeat
+          NextDate := AddMonthsToDate(AStartY, AStartM, AStartD, (WholeUnits - 1) * 12);
+          NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+          if (NextEpoch < EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs >= 0)) then Break;
+          Dec(WholeUnits);
+        until False;
+      end;
+
+      // Align WholeUnits to the nearest increment boundary toward zero,
+      // then use the fractional distance to decide whether rounding carries
+      // us to the next bucket (sign-aware).
+      if Sign > 0 then
+        ScaledValue := (WholeUnits div AIncrement) * AIncrement
+      else
+        ScaledValue := -(((-WholeUnits) div AIncrement) * AIncrement);
+
+      WalkDate := AddMonthsToDate(AStartY, AStartM, AStartD, ScaledValue * 12);
+      WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+      NextDate := AddMonthsToDate(AStartY, AStartM, AStartD, (ScaledValue + Sign * AIncrement) * 12);
+      NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+      PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+      RoundedValue := RoundWithMode(
+        Abs((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs), PeriodNs, AMode);
+      if RoundedValue >= PeriodNs then
+        WholeUnits := ScaledValue + Sign * AIncrement
+      else
+        WholeUnits := ScaledValue;
+
+      AYears := WholeUnits; AMonths := 0; AWeeks := 0; ADays := 0;
+      AHours := 0; AMinutes := 0; ASeconds := 0;
+      AMilliseconds := 0; AMicroseconds := 0; ANanoseconds := 0;
+    end
+    else // tuMonth
+    begin
+      WholeUnits := 0;
+      if Sign > 0 then
+      begin
+        repeat
+          NextDate := AddMonthsToDate(AStartY, AStartM, AStartD, WholeUnits + 1);
+          NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+          if (NextEpoch > EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs <= 0)) then Break;
+          Inc(WholeUnits);
+        until False;
+      end
+      else
+      begin
+        repeat
+          NextDate := AddMonthsToDate(AStartY, AStartM, AStartD, WholeUnits - 1);
+          NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+          if (NextEpoch < EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs >= 0)) then Break;
+          Dec(WholeUnits);
+        until False;
+      end;
+
+      if Sign > 0 then
+        ScaledValue := (WholeUnits div AIncrement) * AIncrement
+      else
+        ScaledValue := -(((-WholeUnits) div AIncrement) * AIncrement);
+
+      WalkDate := AddMonthsToDate(AStartY, AStartM, AStartD, ScaledValue);
+      WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+      NextDate := AddMonthsToDate(AStartY, AStartM, AStartD, ScaledValue + Sign * AIncrement);
+      NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+      PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+      RoundedValue := RoundWithMode(
+        Abs((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs), PeriodNs, AMode);
+      if RoundedValue >= PeriodNs then
+        WholeUnits := ScaledValue + Sign * AIncrement
+      else
+        WholeUnits := ScaledValue;
+
+      if Ord(ALargestUnit) <= Ord(tuYear) then
+      begin
+        AYears := WholeUnits div 12;
+        AMonths := WholeUnits mod 12;
+      end
+      else
+      begin
+        AYears := 0;
+        AMonths := WholeUnits;
+      end;
+      AWeeks := 0; ADays := 0;
+      AHours := 0; AMinutes := 0; ASeconds := 0;
+      AMilliseconds := 0; AMicroseconds := 0; ANanoseconds := 0;
+    end;
+    Exit;
+  end;
+
+  // --- Week / day / time-unit rounding ---
+  // Convert everything to total nanoseconds from the start date
+  if (ASmallestUnit = tuWeek) or (ASmallestUnit = tuDay) or
+     (Ord(ASmallestUnit) >= Ord(tuHour)) then
+  begin
+    // For calendar types that have year/month, resolve to epoch days first
+    if (AYears <> 0) or (AMonths <> 0) then
+    begin
+      EndDate.Year := AStartY; EndDate.Month := AStartM; EndDate.Day := AStartD;
+      if AYears <> 0 then
+        EndDate := AddMonthsToDate(EndDate.Year, EndDate.Month, EndDate.Day, AYears * 12);
+      if AMonths <> 0 then
+        EndDate := AddMonthsToDate(EndDate.Year, EndDate.Month, EndDate.Day, AMonths);
+      EndDate := AddDaysToDate(EndDate.Year, EndDate.Month, EndDate.Day, AWeeks * 7 + ADays);
+      StartEpoch := DateToEpochDays(AStartY, AStartM, AStartD);
+      EndEpoch := DateToEpochDays(EndDate.Year, EndDate.Month, EndDate.Day);
+      TotalNs := (EndEpoch - StartEpoch) * NANOSECONDS_PER_DAY + TimeNs;
+    end
+    else
+      TotalNs := (AWeeks * 7 + ADays) * NANOSECONDS_PER_DAY + TimeNs;
+
+    // Round
+    if ASmallestUnit = tuWeek then
+      Divisor := NANOSECONDS_PER_DAY * 7 * AIncrement
+    else
+      Divisor := UnitToNanoseconds(ASmallestUnit) * AIncrement;
+    TotalNs := RoundWithMode(TotalNs, Divisor, AMode);
+
+    // Rebalance into largestUnit fields
+    if (AYears <> 0) or (AMonths <> 0) or
+       (Ord(ALargestUnit) <= Ord(tuMonth)) then
+    begin
+      // Need calendar rebalance back to year/month/day
+      ResultDays := TotalNs div NANOSECONDS_PER_DAY;
+      RemNs := TotalNs mod NANOSECONDS_PER_DAY;
+
+      StartEpoch := DateToEpochDays(AStartY, AStartM, AStartD);
+      EndEpoch := StartEpoch + ResultDays;
+
+      if Ord(ALargestUnit) <= Ord(tuMonth) then
+      begin
+        if TotalNs > 0 then Sign := 1
+        else if TotalNs < 0 then Sign := -1
+        else Sign := 0;
+
+        WholeUnits := 0;
+        if Sign > 0 then
+        begin
+          repeat
+            NextDate := AddMonthsToDate(AStartY, AStartM, AStartD, WholeUnits + 1);
+            NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+            if NextEpoch > EndEpoch then Break;
+            Inc(WholeUnits);
+          until False;
+        end
+        else if Sign < 0 then
+        begin
+          repeat
+            NextDate := AddMonthsToDate(AStartY, AStartM, AStartD, WholeUnits - 1);
+            NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+            if NextEpoch < EndEpoch then Break;
+            Dec(WholeUnits);
+          until False;
+        end;
+
+        WalkDate := AddMonthsToDate(AStartY, AStartM, AStartD, WholeUnits);
+        WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
+        ResultDays := EndEpoch - WalkEpoch;
+
+        if Ord(ALargestUnit) <= Ord(tuYear) then
+        begin
+          ResultYears := WholeUnits div 12;
+          ResultMonths := WholeUnits mod 12;
+        end
+        else
+        begin
+          ResultYears := 0;
+          ResultMonths := WholeUnits;
+        end;
+      end
+      else
+      begin
+        ResultYears := 0;
+        ResultMonths := 0;
+      end;
+
+      // Decompose time
+      ResultHours := RemNs div NANOSECONDS_PER_HOUR;
+      RemNs := RemNs mod NANOSECONDS_PER_HOUR;
+      ResultMinutes := RemNs div NANOSECONDS_PER_MINUTE;
+      RemNs := RemNs mod NANOSECONDS_PER_MINUTE;
+      ResultSeconds := RemNs div NANOSECONDS_PER_SECOND;
+      RemNs := RemNs mod NANOSECONDS_PER_SECOND;
+      ResultMs := RemNs div NANOSECONDS_PER_MILLISECOND;
+      RemNs := RemNs mod NANOSECONDS_PER_MILLISECOND;
+      ResultUs := RemNs div NANOSECONDS_PER_MICROSECOND;
+      ResultNs := RemNs mod NANOSECONDS_PER_MICROSECOND;
+
+      AYears := ResultYears; AMonths := ResultMonths;
+      if Ord(ALargestUnit) <= Ord(tuWeek) then
+      begin
+        AWeeks := ResultDays div 7;
+        ADays := ResultDays mod 7;
+      end
+      else
+      begin
+        AWeeks := 0;
+        ADays := ResultDays;
+      end;
+      AHours := ResultHours; AMinutes := ResultMinutes;
+      ASeconds := ResultSeconds; AMilliseconds := ResultMs;
+      AMicroseconds := ResultUs; ANanoseconds := ResultNs;
+    end
+    else
+    begin
+      // Non-calendar breakdown
+      RemNs := TotalNs;
+      ResultDays := 0;
+      ResultHours := 0;
+      ResultMinutes := 0;
+      ResultSeconds := 0;
+      ResultMs := 0;
+      ResultUs := 0;
+      ResultNs := 0;
+
+      if Ord(ALargestUnit) <= Ord(tuWeek) then
+      begin
+        ResultDays := RemNs div NANOSECONDS_PER_DAY;
+        RemNs := RemNs mod NANOSECONDS_PER_DAY;
+      end
+      else if Ord(ALargestUnit) <= Ord(tuDay) then
+      begin
+        ResultDays := RemNs div NANOSECONDS_PER_DAY;
+        RemNs := RemNs mod NANOSECONDS_PER_DAY;
+      end;
+      if Ord(ALargestUnit) <= Ord(tuHour) then
+      begin
+        ResultHours := RemNs div NANOSECONDS_PER_HOUR;
+        RemNs := RemNs mod NANOSECONDS_PER_HOUR;
+      end;
+      if Ord(ALargestUnit) <= Ord(tuMinute) then
+      begin
+        ResultMinutes := RemNs div NANOSECONDS_PER_MINUTE;
+        RemNs := RemNs mod NANOSECONDS_PER_MINUTE;
+      end;
+      if Ord(ALargestUnit) <= Ord(tuSecond) then
+      begin
+        ResultSeconds := RemNs div NANOSECONDS_PER_SECOND;
+        RemNs := RemNs mod NANOSECONDS_PER_SECOND;
+      end;
+      if Ord(ALargestUnit) <= Ord(tuMillisecond) then
+      begin
+        ResultMs := RemNs div NANOSECONDS_PER_MILLISECOND;
+        RemNs := RemNs mod NANOSECONDS_PER_MILLISECOND;
+      end;
+      if Ord(ALargestUnit) <= Ord(tuMicrosecond) then
+      begin
+        ResultUs := RemNs div NANOSECONDS_PER_MICROSECOND;
+        RemNs := RemNs mod NANOSECONDS_PER_MICROSECOND;
+      end;
+      ResultNs := RemNs;
+
+      AYears := 0; AMonths := 0;
+      if Ord(ALargestUnit) <= Ord(tuWeek) then
+      begin
+        AWeeks := ResultDays div 7;
+        ADays := ResultDays mod 7;
+      end
+      else
+      begin
+        AWeeks := 0;
+        ADays := ResultDays;
+      end;
+      AHours := ResultHours; AMinutes := ResultMinutes;
+      ASeconds := ResultSeconds; AMilliseconds := ResultMs;
+      AMicroseconds := ResultUs; ANanoseconds := ResultNs;
     end;
   end;
 end;

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -61,6 +61,8 @@ function GetRoundingMode(const AOptions: TGocciaObjectValue; const ADefault: TTe
 function GetRoundingIncrement(const AOptions: TGocciaObjectValue; const ADefault: Integer): Integer;
 function GetOverflowOption(const AOptions: TGocciaObjectValue): TTemporalOverflow;
 function GetFractionalSecondDigits(const AOptions: TGocciaObjectValue): Integer;
+procedure ValidateRoundingIncrement(const AIncrement: Integer;
+  const ASmallestUnit, ALargestUnit: TTemporalUnit);
 function UnitToNanoseconds(const AUnit: TTemporalUnit): Int64;
 function RoundWithMode(const AValue: Int64; const ADivisor: Int64; const AMode: TTemporalRoundingMode): Int64;
 function RoundBigIntWithMode(const AValue: TBigInteger; const ADivisor: TBigInteger; const AMode: TTemporalRoundingMode): TBigInteger;
@@ -234,6 +236,33 @@ begin
   Result := GetOptionInteger(AOptions, 'roundingIncrement', ADefault);
   if Result < 1 then
     ThrowRangeError(SErrorRoundingIncrementMin, SSuggestTemporalRoundArg);
+end;
+
+procedure ValidateRoundingIncrement(const AIncrement: Integer;
+  const ASmallestUnit, ALargestUnit: TTemporalUnit);
+var
+  MaxVal: Integer;
+begin
+  // Per TC39 MaximumTemporalDurationRoundingIncrement: when smallestUnit
+  // equals largestUnit the unit is unbounded, so any increment >= 1 is valid.
+  // For sub-largest units the increment must evenly divide the unit maximum.
+  if AIncrement <= 1 then Exit;
+  if ASmallestUnit = ALargestUnit then Exit;
+
+  case ASmallestUnit of
+    tuHour:        MaxVal := 24;
+    tuMinute,
+    tuSecond:      MaxVal := 60;
+    tuMillisecond,
+    tuMicrosecond,
+    tuNanosecond:  MaxVal := 1000;
+  else
+    Exit; // year/month/week/day — no fixed maximum
+  end;
+
+  if MaxVal mod AIncrement <> 0 then
+    ThrowRangeError(Format(SErrorRoundingIncrementDivisor, [AIncrement, MaxVal]),
+      SSuggestTemporalRoundArg);
 end;
 
 function GetOverflowOption(const AOptions: TGocciaObjectValue): TTemporalOverflow;

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -391,6 +391,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
   DiffMs := Other.FEpochMilliseconds - Inst.FEpochMilliseconds;
   DiffSubMs := Other.FSubMillisecondNanoseconds - Inst.FSubMillisecondNanoseconds;
@@ -449,6 +450,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
   DiffMs := Inst.FEpochMilliseconds - Other.FEpochMilliseconds;
   DiffSubMs := Inst.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -367,9 +367,13 @@ function TGocciaTemporalInstantValue.InstantUntil(const AArgs: TGocciaArgumentsC
 var
   Inst, Other: TGocciaTemporalInstantValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   DiffMs: Int64;
   DiffSubMs: Integer;
+  Dur: TGocciaTemporalDurationValue;
+  Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.until');
   Other := CoerceInstant(AArgs.GetElement(0), 'Instant.prototype.until');
@@ -379,6 +383,14 @@ begin
   if LargestUnit = tuAuto then LargestUnit := tuHour;
   if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
+  if not (SmallestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.until', 'smallestUnit']), SSuggestTemporalValidUnits);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
 
   DiffMs := Other.FEpochMilliseconds - Inst.FEpochMilliseconds;
   DiffSubMs := Other.FSubMillisecondNanoseconds - Inst.FSubMillisecondNanoseconds;
@@ -396,15 +408,30 @@ begin
   end;
 
   Result := InstantDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
+
+  if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+  begin
+    Dur := TGocciaTemporalDurationValue(Result);
+    Y := Dur.Years; Mo := Dur.Months; W := Dur.Weeks; D := Dur.Days;
+    H := Dur.Hours; Mi := Dur.Minutes; S := Dur.Seconds;
+    Ms := Dur.Milliseconds; Us := Dur.Microseconds; Ns := Dur.Nanoseconds;
+    RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,
+      0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
+    Result := TGocciaTemporalDurationValue.Create(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns);
+  end;
 end;
 
 function TGocciaTemporalInstantValue.InstantSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Inst, Other: TGocciaTemporalInstantValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   DiffMs: Int64;
   DiffSubMs: Integer;
+  Dur: TGocciaTemporalDurationValue;
+  Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.since');
   Other := CoerceInstant(AArgs.GetElement(0), 'Instant.prototype.since');
@@ -414,6 +441,14 @@ begin
   if LargestUnit = tuAuto then LargestUnit := tuHour;
   if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
+  if not (SmallestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Instant.prototype.since', 'smallestUnit']), SSuggestTemporalValidUnits);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
 
   DiffMs := Inst.FEpochMilliseconds - Other.FEpochMilliseconds;
   DiffSubMs := Inst.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;
@@ -431,6 +466,17 @@ begin
   end;
 
   Result := InstantDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
+
+  if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+  begin
+    Dur := TGocciaTemporalDurationValue(Result);
+    Y := Dur.Years; Mo := Dur.Months; W := Dur.Weeks; D := Dur.Days;
+    H := Dur.Hours; Mi := Dur.Minutes; S := Dur.Seconds;
+    Ms := Dur.Milliseconds; Us := Dur.Microseconds; Ns := Dur.Nanoseconds;
+    RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,
+      0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
+    Result := TGocciaTemporalDurationValue.Create(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns);
+  end;
 end;
 
 function TGocciaTemporalInstantValue.InstantRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -514,8 +514,11 @@ function TGocciaTemporalPlainDateValue.DateUntil(const AArgs: TGocciaArgumentsCo
 var
   D, Other: TGocciaTemporalPlainDateValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  Mode: TTemporalRoundingMode;
+  Increment: Integer;
   Years, Months, Weeks, Days: Int64;
+  ZeroH, ZeroM, ZeroS, ZeroMs, ZeroUs, ZeroNs: Int64;
 begin
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.until');
   Other := CoercePlainDate(AArgs.GetElement(0), 'PlainDate.prototype.until');
@@ -526,9 +529,26 @@ begin
   if not (LargestUnit in [tuYear, tuMonth, tuWeek, tuDay]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDate.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
 
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuDay);
+  if not (SmallestUnit in [tuYear, tuMonth, tuWeek, tuDay]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDate.prototype.until', 'smallestUnit']), SSuggestTemporalValidUnits);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  Mode := GetRoundingMode(OptionsObj, rmTrunc);
+  Increment := GetRoundingIncrement(OptionsObj, 1);
+
   CalendarDateUntil(D.FYear, D.FMonth, D.FDay,
     Other.FYear, Other.FMonth, Other.FDay, LargestUnit,
     Years, Months, Weeks, Days);
+
+  if (SmallestUnit <> tuDay) or (Increment <> 1) then
+  begin
+    ZeroH := 0; ZeroM := 0; ZeroS := 0; ZeroMs := 0; ZeroUs := 0; ZeroNs := 0;
+    RoundDiffDuration(Years, Months, Weeks, Days,
+      ZeroH, ZeroM, ZeroS, ZeroMs, ZeroUs, ZeroNs,
+      D.FYear, D.FMonth, D.FDay,
+      LargestUnit, SmallestUnit, Mode, Increment);
+  end;
 
   Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days, 0, 0, 0, 0, 0, 0);
 end;
@@ -537,8 +557,11 @@ function TGocciaTemporalPlainDateValue.DateSince(const AArgs: TGocciaArgumentsCo
 var
   D, Other: TGocciaTemporalPlainDateValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  Mode: TTemporalRoundingMode;
+  Increment: Integer;
   Years, Months, Weeks, Days: Int64;
+  ZeroH, ZeroM, ZeroS, ZeroMs, ZeroUs, ZeroNs: Int64;
 begin
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.since');
   Other := CoercePlainDate(AArgs.GetElement(0), 'PlainDate.prototype.since');
@@ -549,10 +572,27 @@ begin
   if not (LargestUnit in [tuYear, tuMonth, tuWeek, tuDay]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDate.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
 
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuDay);
+  if not (SmallestUnit in [tuYear, tuMonth, tuWeek, tuDay]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainDate.prototype.since', 'smallestUnit']), SSuggestTemporalValidUnits);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  Mode := GetRoundingMode(OptionsObj, rmTrunc);
+  Increment := GetRoundingIncrement(OptionsObj, 1);
+
   // since(other) = other.until(this): swap start/end
   CalendarDateUntil(Other.FYear, Other.FMonth, Other.FDay,
     D.FYear, D.FMonth, D.FDay, LargestUnit,
     Years, Months, Weeks, Days);
+
+  if (SmallestUnit <> tuDay) or (Increment <> 1) then
+  begin
+    ZeroH := 0; ZeroM := 0; ZeroS := 0; ZeroMs := 0; ZeroUs := 0; ZeroNs := 0;
+    RoundDiffDuration(Years, Months, Weeks, Days,
+      ZeroH, ZeroM, ZeroS, ZeroMs, ZeroUs, ZeroNs,
+      Other.FYear, Other.FMonth, Other.FDay,
+      LargestUnit, SmallestUnit, Mode, Increment);
+  end;
 
   Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days, 0, 0, 0, 0, 0, 0);
 end;

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -536,6 +536,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   Mode := GetRoundingMode(OptionsObj, rmTrunc);
   Increment := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(Increment, SmallestUnit, LargestUnit);
 
   CalendarDateUntil(D.FYear, D.FMonth, D.FDay,
     Other.FYear, Other.FMonth, Other.FDay, LargestUnit,

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -639,6 +639,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
   T1Ns := Int64(D.FNanosecond) + Int64(D.FMicrosecond) * 1000 + Int64(D.FMillisecond) * 1000000 +
            Int64(D.FSecond) * Int64(1000000000) + Int64(D.FMinute) * Int64(60000000000) +

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -616,13 +616,16 @@ function TGocciaTemporalPlainDateTimeValue.DateTimeUntil(const AArgs: TGocciaArg
 var
   D, Other: TGocciaTemporalPlainDateTimeValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   T1Ns, T2Ns, TimeDiffNs: Int64;
   DayDelta, Sgn: Int64;
   AdjY2, AdjM2, AdjD2: Integer;
   AdjDate: TTemporalDateRecord;
   Years, Months, Weeks, Days: Int64;
   AbsTimeNs, AbsDays, TotalInUnit, RemNs: Int64;
+  RH, RM, RS, RMs, RUs, RNs: Int64;
 begin
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.until');
   Other := CoercePlainDateTime(AArgs.GetElement(0), 'PlainDateTime.prototype.until');
@@ -630,6 +633,12 @@ begin
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuDay);
   if LargestUnit = tuAuto then LargestUnit := tuDay;
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
 
   T1Ns := Int64(D.FNanosecond) + Int64(D.FMicrosecond) * 1000 + Int64(D.FMillisecond) * 1000000 +
            Int64(D.FSecond) * Int64(1000000000) + Int64(D.FMinute) * Int64(60000000000) +
@@ -681,13 +690,21 @@ begin
 
     // Decompose time nanoseconds (same sign as overall result)
     AbsTimeNs := Abs(TimeDiffNs);
+    RH := Sgn * (AbsTimeNs div Int64(3600000000000));
+    RM := Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60);
+    RS := Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60);
+    RMs := Sgn * ((AbsTimeNs div 1000000) mod 1000);
+    RUs := Sgn * ((AbsTimeNs div 1000) mod 1000);
+    RNs := Sgn * (AbsTimeNs mod 1000);
+
+    if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+      RoundDiffDuration(Years, Months, Weeks, Days,
+        RH, RM, RS, RMs, RUs, RNs,
+        D.FYear, D.FMonth, D.FDay,
+        LargestUnit, SmallestUnit, RMode, RIncrement);
+
     Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days,
-      Sgn * (AbsTimeNs div Int64(3600000000000)),
-      Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60),
-      Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60),
-      Sgn * ((AbsTimeNs div 1000000) mod 1000),
-      Sgn * ((AbsTimeNs div 1000) mod 1000),
-      Sgn * (AbsTimeNs mod 1000));
+      RH, RM, RS, RMs, RUs, RNs);
   end
   else
   begin
@@ -723,63 +740,72 @@ begin
 
     // Decompose by converting day delta using safe integer multiplication,
     // then adding the within-day time remainder.
+    Years := 0; Months := 0; Weeks := 0; Days := 0;
     case LargestUnit of
       tuHour:
         begin
           TotalInUnit := AbsDays * 24 + AbsTimeNs div Int64(3600000000000);
           RemNs := AbsTimeNs mod Int64(3600000000000);
-          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-            Sgn * TotalInUnit,
-            Sgn * (RemNs div Int64(60000000000)),
-            Sgn * ((RemNs div Int64(1000000000)) mod 60),
-            Sgn * ((RemNs div 1000000) mod 1000),
-            Sgn * ((RemNs div 1000) mod 1000),
-            Sgn * (RemNs mod 1000));
+          RH := Sgn * TotalInUnit;
+          RM := Sgn * (RemNs div Int64(60000000000));
+          RS := Sgn * ((RemNs div Int64(1000000000)) mod 60);
+          RMs := Sgn * ((RemNs div 1000000) mod 1000);
+          RUs := Sgn * ((RemNs div 1000) mod 1000);
+          RNs := Sgn * (RemNs mod 1000);
         end;
       tuMinute:
         begin
           TotalInUnit := AbsDays * 1440 + AbsTimeNs div Int64(60000000000);
           RemNs := AbsTimeNs mod Int64(60000000000);
-          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0,
-            Sgn * TotalInUnit,
-            Sgn * (RemNs div Int64(1000000000)),
-            Sgn * ((RemNs div 1000000) mod 1000),
-            Sgn * ((RemNs div 1000) mod 1000),
-            Sgn * (RemNs mod 1000));
+          RH := 0;
+          RM := Sgn * TotalInUnit;
+          RS := Sgn * (RemNs div Int64(1000000000));
+          RMs := Sgn * ((RemNs div 1000000) mod 1000);
+          RUs := Sgn * ((RemNs div 1000) mod 1000);
+          RNs := Sgn * (RemNs mod 1000);
         end;
       tuSecond:
         begin
           TotalInUnit := AbsDays * 86400 + AbsTimeNs div Int64(1000000000);
           RemNs := AbsTimeNs mod Int64(1000000000);
-          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0,
-            Sgn * TotalInUnit,
-            Sgn * (RemNs div 1000000),
-            Sgn * ((RemNs div 1000) mod 1000),
-            Sgn * (RemNs mod 1000));
+          RH := 0; RM := 0;
+          RS := Sgn * TotalInUnit;
+          RMs := Sgn * (RemNs div 1000000);
+          RUs := Sgn * ((RemNs div 1000) mod 1000);
+          RNs := Sgn * (RemNs mod 1000);
         end;
       tuMillisecond:
         begin
           TotalInUnit := AbsDays * 86400000 + AbsTimeNs div 1000000;
           RemNs := AbsTimeNs mod 1000000;
-          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0,
-            Sgn * TotalInUnit,
-            Sgn * (RemNs div 1000),
-            Sgn * (RemNs mod 1000));
+          RH := 0; RM := 0; RS := 0;
+          RMs := Sgn * TotalInUnit;
+          RUs := Sgn * (RemNs div 1000);
+          RNs := Sgn * (RemNs mod 1000);
         end;
       tuMicrosecond:
         begin
           TotalInUnit := AbsDays * Int64(86400000000) + AbsTimeNs div 1000;
-          Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0,
-            Sgn * TotalInUnit,
-            Sgn * (AbsTimeNs mod 1000));
+          RH := 0; RM := 0; RS := 0; RMs := 0;
+          RUs := Sgn * TotalInUnit;
+          RNs := Sgn * (AbsTimeNs mod 1000);
         end;
     else // tuNanosecond
       begin
         TotalInUnit := AbsDays * Int64(86400000000000) + AbsTimeNs;
-        Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0,
-          Sgn * TotalInUnit);
+        RH := 0; RM := 0; RS := 0; RMs := 0; RUs := 0;
+        RNs := Sgn * TotalInUnit;
       end;
     end;
+
+    if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+      RoundDiffDuration(Years, Months, Weeks, Days,
+        RH, RM, RS, RMs, RUs, RNs,
+        D.FYear, D.FMonth, D.FDay,
+        LargestUnit, SmallestUnit, RMode, RIncrement);
+
+    Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days,
+      RH, RM, RS, RMs, RUs, RNs);
   end;
 end;
 

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -451,13 +451,48 @@ begin
 
   DiffNs := TimeToTotalNanoseconds(Other) - TimeToTotalNanoseconds(T);
 
+  // Decompose DiffNs based on largestUnit
   Y := 0; Mo := 0; W := 0; D := 0;
-  H := DiffNs div Int64(3600000000000);
-  Mi := (DiffNs div Int64(60000000000)) mod 60;
-  S := (DiffNs div Int64(1000000000)) mod 60;
-  Ms := (DiffNs div 1000000) mod 1000;
-  Us := (DiffNs div 1000) mod 1000;
-  Ns := DiffNs mod 1000;
+  H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
+  case LargestUnit of
+    tuHour:
+    begin
+      H := DiffNs div Int64(3600000000000);
+      Mi := (DiffNs mod Int64(3600000000000)) div Int64(60000000000);
+      S := (DiffNs mod Int64(60000000000)) div Int64(1000000000);
+      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
+      Us := (DiffNs mod 1000000) div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+    tuMinute:
+    begin
+      Mi := DiffNs div Int64(60000000000);
+      S := (DiffNs mod Int64(60000000000)) div Int64(1000000000);
+      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
+      Us := (DiffNs mod 1000000) div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+    tuSecond:
+    begin
+      S := DiffNs div Int64(1000000000);
+      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
+      Us := (DiffNs mod 1000000) div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+    tuMillisecond:
+    begin
+      Ms := DiffNs div 1000000;
+      Us := (DiffNs mod 1000000) div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+    tuMicrosecond:
+    begin
+      Us := DiffNs div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+  else // tuNanosecond
+    Ns := DiffNs;
+  end;
 
   if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
     RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,
@@ -495,13 +530,48 @@ begin
 
   DiffNs := TimeToTotalNanoseconds(T) - TimeToTotalNanoseconds(Other);
 
+  // Decompose DiffNs based on largestUnit
   Y := 0; Mo := 0; W := 0; D := 0;
-  H := DiffNs div Int64(3600000000000);
-  Mi := (DiffNs div Int64(60000000000)) mod 60;
-  S := (DiffNs div Int64(1000000000)) mod 60;
-  Ms := (DiffNs div 1000000) mod 1000;
-  Us := (DiffNs div 1000) mod 1000;
-  Ns := DiffNs mod 1000;
+  H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
+  case LargestUnit of
+    tuHour:
+    begin
+      H := DiffNs div Int64(3600000000000);
+      Mi := (DiffNs mod Int64(3600000000000)) div Int64(60000000000);
+      S := (DiffNs mod Int64(60000000000)) div Int64(1000000000);
+      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
+      Us := (DiffNs mod 1000000) div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+    tuMinute:
+    begin
+      Mi := DiffNs div Int64(60000000000);
+      S := (DiffNs mod Int64(60000000000)) div Int64(1000000000);
+      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
+      Us := (DiffNs mod 1000000) div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+    tuSecond:
+    begin
+      S := DiffNs div Int64(1000000000);
+      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
+      Us := (DiffNs mod 1000000) div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+    tuMillisecond:
+    begin
+      Ms := DiffNs div 1000000;
+      Us := (DiffNs mod 1000000) div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+    tuMicrosecond:
+    begin
+      Us := DiffNs div 1000;
+      Ns := DiffNs mod 1000;
+    end;
+  else // tuNanosecond
+    Ns := DiffNs;
+  end;
 
   if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
     RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -448,6 +448,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
   // Decompose ADiffNs based on largestUnit
   Y := 0; Mo := 0; W := 0; D := 0;

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -422,76 +422,74 @@ begin
     Balanced.Millisecond, Balanced.Microsecond, Balanced.Nanosecond);
 end;
 
-function TGocciaTemporalPlainTimeValue.TimeUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+{ Shared logic for PlainTime until/since: parse options, decompose by
+  largestUnit, round, and return the duration value.  ADiffNs is
+  Other-This for until, This-Other for since. }
+function ComputeTimeDiffDuration(const ADiffNs: Int64;
+  const AArgs: TGocciaArgumentsCollection;
+  const AMethodName: string): TGocciaValue;
 var
-  T, Other: TGocciaTemporalPlainTimeValue;
   OptionsObj: TGocciaObjectValue;
   LargestUnit, SmallestUnit: TTemporalUnit;
   RMode: TTemporalRoundingMode;
   RIncrement: Integer;
-  DiffNs: Int64;
   Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
 begin
-  T := AsPlainTime(AThisValue, 'PlainTime.prototype.until');
-  Other := CoercePlainTime(AArgs.GetElement(0), 'PlainTime.prototype.until');
-
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
   if LargestUnit = tuAuto then LargestUnit := tuHour;
   if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
-    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, [AMethodName, 'largestUnit']), SSuggestTemporalValidUnits);
 
   SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
   if not (SmallestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
-    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.until', 'smallestUnit']), SSuggestTemporalValidUnits);
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, [AMethodName, 'smallestUnit']), SSuggestTemporalValidUnits);
   if Ord(LargestUnit) > Ord(SmallestUnit) then
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
 
-  DiffNs := TimeToTotalNanoseconds(Other) - TimeToTotalNanoseconds(T);
-
-  // Decompose DiffNs based on largestUnit
+  // Decompose ADiffNs based on largestUnit
   Y := 0; Mo := 0; W := 0; D := 0;
   H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
   case LargestUnit of
     tuHour:
     begin
-      H := DiffNs div Int64(3600000000000);
-      Mi := (DiffNs mod Int64(3600000000000)) div Int64(60000000000);
-      S := (DiffNs mod Int64(60000000000)) div Int64(1000000000);
-      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
-      Us := (DiffNs mod 1000000) div 1000;
-      Ns := DiffNs mod 1000;
+      H := ADiffNs div Int64(3600000000000);
+      Mi := (ADiffNs mod Int64(3600000000000)) div Int64(60000000000);
+      S := (ADiffNs mod Int64(60000000000)) div Int64(1000000000);
+      Ms := (ADiffNs mod Int64(1000000000)) div 1000000;
+      Us := (ADiffNs mod 1000000) div 1000;
+      Ns := ADiffNs mod 1000;
     end;
     tuMinute:
     begin
-      Mi := DiffNs div Int64(60000000000);
-      S := (DiffNs mod Int64(60000000000)) div Int64(1000000000);
-      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
-      Us := (DiffNs mod 1000000) div 1000;
-      Ns := DiffNs mod 1000;
+      Mi := ADiffNs div Int64(60000000000);
+      S := (ADiffNs mod Int64(60000000000)) div Int64(1000000000);
+      Ms := (ADiffNs mod Int64(1000000000)) div 1000000;
+      Us := (ADiffNs mod 1000000) div 1000;
+      Ns := ADiffNs mod 1000;
     end;
     tuSecond:
     begin
-      S := DiffNs div Int64(1000000000);
-      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
-      Us := (DiffNs mod 1000000) div 1000;
-      Ns := DiffNs mod 1000;
+      S := ADiffNs div Int64(1000000000);
+      Ms := (ADiffNs mod Int64(1000000000)) div 1000000;
+      Us := (ADiffNs mod 1000000) div 1000;
+      Ns := ADiffNs mod 1000;
     end;
     tuMillisecond:
     begin
-      Ms := DiffNs div 1000000;
-      Us := (DiffNs mod 1000000) div 1000;
-      Ns := DiffNs mod 1000;
+      Ms := ADiffNs div 1000000;
+      Us := (ADiffNs mod 1000000) div 1000;
+      Ns := ADiffNs mod 1000;
     end;
     tuMicrosecond:
     begin
-      Us := DiffNs div 1000;
-      Ns := DiffNs mod 1000;
+      Us := ADiffNs div 1000;
+      Ns := ADiffNs mod 1000;
     end;
   else // tuNanosecond
-    Ns := DiffNs;
+    Ns := ADiffNs;
   end;
 
   if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
@@ -501,83 +499,26 @@ begin
   Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, H, Mi, S, Ms, Us, Ns);
 end;
 
+function TGocciaTemporalPlainTimeValue.TimeUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  T, Other: TGocciaTemporalPlainTimeValue;
+begin
+  T := AsPlainTime(AThisValue, 'PlainTime.prototype.until');
+  Other := CoercePlainTime(AArgs.GetElement(0), 'PlainTime.prototype.until');
+  Result := ComputeTimeDiffDuration(
+    TimeToTotalNanoseconds(Other) - TimeToTotalNanoseconds(T),
+    AArgs, 'PlainTime.prototype.until');
+end;
+
 function TGocciaTemporalPlainTimeValue.TimeSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   T, Other: TGocciaTemporalPlainTimeValue;
-  OptionsObj: TGocciaObjectValue;
-  LargestUnit, SmallestUnit: TTemporalUnit;
-  RMode: TTemporalRoundingMode;
-  RIncrement: Integer;
-  DiffNs: Int64;
-  Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
 begin
   T := AsPlainTime(AThisValue, 'PlainTime.prototype.since');
   Other := CoercePlainTime(AArgs.GetElement(0), 'PlainTime.prototype.since');
-
-  OptionsObj := GetDiffOptions(AArgs, 1);
-  LargestUnit := GetLargestUnit(OptionsObj, tuHour);
-  if LargestUnit = tuAuto then LargestUnit := tuHour;
-  if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
-    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
-
-  SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
-  if not (SmallestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
-    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.since', 'smallestUnit']), SSuggestTemporalValidUnits);
-  if Ord(LargestUnit) > Ord(SmallestUnit) then
-    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
-  RMode := GetRoundingMode(OptionsObj, rmTrunc);
-  RIncrement := GetRoundingIncrement(OptionsObj, 1);
-
-  DiffNs := TimeToTotalNanoseconds(T) - TimeToTotalNanoseconds(Other);
-
-  // Decompose DiffNs based on largestUnit
-  Y := 0; Mo := 0; W := 0; D := 0;
-  H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
-  case LargestUnit of
-    tuHour:
-    begin
-      H := DiffNs div Int64(3600000000000);
-      Mi := (DiffNs mod Int64(3600000000000)) div Int64(60000000000);
-      S := (DiffNs mod Int64(60000000000)) div Int64(1000000000);
-      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
-      Us := (DiffNs mod 1000000) div 1000;
-      Ns := DiffNs mod 1000;
-    end;
-    tuMinute:
-    begin
-      Mi := DiffNs div Int64(60000000000);
-      S := (DiffNs mod Int64(60000000000)) div Int64(1000000000);
-      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
-      Us := (DiffNs mod 1000000) div 1000;
-      Ns := DiffNs mod 1000;
-    end;
-    tuSecond:
-    begin
-      S := DiffNs div Int64(1000000000);
-      Ms := (DiffNs mod Int64(1000000000)) div 1000000;
-      Us := (DiffNs mod 1000000) div 1000;
-      Ns := DiffNs mod 1000;
-    end;
-    tuMillisecond:
-    begin
-      Ms := DiffNs div 1000000;
-      Us := (DiffNs mod 1000000) div 1000;
-      Ns := DiffNs mod 1000;
-    end;
-    tuMicrosecond:
-    begin
-      Us := DiffNs div 1000;
-      Ns := DiffNs mod 1000;
-    end;
-  else // tuNanosecond
-    Ns := DiffNs;
-  end;
-
-  if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
-    RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,
-      0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
-
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, H, Mi, S, Ms, Us, Ns);
+  Result := ComputeTimeDiffDuration(
+    TimeToTotalNanoseconds(T) - TimeToTotalNanoseconds(Other),
+    AArgs, 'PlainTime.prototype.since');
 end;
 
 function TGocciaTemporalPlainTimeValue.TimeRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -425,39 +425,89 @@ end;
 function TGocciaTemporalPlainTimeValue.TimeUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   T, Other: TGocciaTemporalPlainTimeValue;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   DiffNs: Int64;
+  Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
 begin
   T := AsPlainTime(AThisValue, 'PlainTime.prototype.until');
   Other := CoercePlainTime(AArgs.GetElement(0), 'PlainTime.prototype.until');
 
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuHour);
+  if LargestUnit = tuAuto then LargestUnit := tuHour;
+  if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
+  if not (SmallestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.until', 'smallestUnit']), SSuggestTemporalValidUnits);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
+
   DiffNs := TimeToTotalNanoseconds(Other) - TimeToTotalNanoseconds(T);
 
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    DiffNs div Int64(3600000000000),
-    (DiffNs div Int64(60000000000)) mod 60,
-    (DiffNs div Int64(1000000000)) mod 60,
-    (DiffNs div 1000000) mod 1000,
-    (DiffNs div 1000) mod 1000,
-    DiffNs mod 1000);
+  Y := 0; Mo := 0; W := 0; D := 0;
+  H := DiffNs div Int64(3600000000000);
+  Mi := (DiffNs div Int64(60000000000)) mod 60;
+  S := (DiffNs div Int64(1000000000)) mod 60;
+  Ms := (DiffNs div 1000000) mod 1000;
+  Us := (DiffNs div 1000) mod 1000;
+  Ns := DiffNs mod 1000;
+
+  if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+    RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,
+      0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
+
+  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, H, Mi, S, Ms, Us, Ns);
 end;
 
 function TGocciaTemporalPlainTimeValue.TimeSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   T, Other: TGocciaTemporalPlainTimeValue;
+  OptionsObj: TGocciaObjectValue;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   DiffNs: Int64;
+  Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
 begin
   T := AsPlainTime(AThisValue, 'PlainTime.prototype.since');
   Other := CoercePlainTime(AArgs.GetElement(0), 'PlainTime.prototype.since');
 
+  OptionsObj := GetDiffOptions(AArgs, 1);
+  LargestUnit := GetLargestUnit(OptionsObj, tuHour);
+  if LargestUnit = tuAuto then LargestUnit := tuHour;
+  if not (LargestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
+  if not (SmallestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond, tuMicrosecond, tuNanosecond]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainTime.prototype.since', 'smallestUnit']), SSuggestTemporalValidUnits);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
+
   DiffNs := TimeToTotalNanoseconds(T) - TimeToTotalNanoseconds(Other);
 
-  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-    DiffNs div Int64(3600000000000),
-    (DiffNs div Int64(60000000000)) mod 60,
-    (DiffNs div Int64(1000000000)) mod 60,
-    (DiffNs div 1000000) mod 1000,
-    (DiffNs div 1000) mod 1000,
-    DiffNs mod 1000);
+  Y := 0; Mo := 0; W := 0; D := 0;
+  H := DiffNs div Int64(3600000000000);
+  Mi := (DiffNs div Int64(60000000000)) mod 60;
+  S := (DiffNs div Int64(1000000000)) mod 60;
+  Ms := (DiffNs div 1000000) mod 1000;
+  Us := (DiffNs div 1000) mod 1000;
+  Ns := DiffNs mod 1000;
+
+  if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+    RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,
+      0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
+
+  Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, H, Mi, S, Ms, Us, Ns);
 end;
 
 function TGocciaTemporalPlainTimeValue.TimeRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -447,9 +447,12 @@ function TGocciaTemporalPlainYearMonthValue.YearMonthUntil(const AArgs: TGocciaA
 var
   YM, Other: TGocciaTemporalPlainYearMonthValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   TotalMonths1, TotalMonths2, DiffMonths: Int64;
   DiffYears, RemMonths: Int64;
+  W, D, H, Mi, S, Ms, Us, Ns: Int64;
 begin
   YM := AsPlainYearMonth(AThisValue, 'PlainYearMonth.prototype.until');
   Other := CoercePlainYearMonth(AArgs.GetElement(0), 'PlainYearMonth.prototype.until');
@@ -459,6 +462,14 @@ begin
   if LargestUnit = tuAuto then LargestUnit := tuYear;
   if not (LargestUnit in [tuYear, tuMonth]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainYearMonth.prototype.until', 'largestUnit']), SSuggestTemporalValidUnits);
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuMonth);
+  if not (SmallestUnit in [tuYear, tuMonth]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainYearMonth.prototype.until', 'smallestUnit']), SSuggestTemporalValidUnits);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
 
   TotalMonths1 := Int64(YM.FYear) * 12 + Int64(YM.FMonth);
   TotalMonths2 := Int64(Other.FYear) * 12 + Int64(Other.FMonth);
@@ -475,6 +486,14 @@ begin
     RemMonths := DiffMonths;
   end;
 
+  if (SmallestUnit <> tuMonth) or (RIncrement <> 1) then
+  begin
+    W := 0; D := 0; H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
+    RoundDiffDuration(DiffYears, RemMonths, W, D, H, Mi, S, Ms, Us, Ns,
+      YM.FYear, YM.FMonth, 1,
+      LargestUnit, SmallestUnit, RMode, RIncrement);
+  end;
+
   Result := TGocciaTemporalDurationValue.Create(DiffYears, RemMonths, 0, 0, 0, 0, 0, 0, 0, 0);
 end;
 
@@ -483,9 +502,12 @@ function TGocciaTemporalPlainYearMonthValue.YearMonthSince(const AArgs: TGocciaA
 var
   YM, Other: TGocciaTemporalPlainYearMonthValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   TotalMonths1, TotalMonths2, DiffMonths: Int64;
   DiffYears, RemMonths: Int64;
+  W, D, H, Mi, S, Ms, Us, Ns: Int64;
 begin
   YM := AsPlainYearMonth(AThisValue, 'PlainYearMonth.prototype.since');
   Other := CoercePlainYearMonth(AArgs.GetElement(0), 'PlainYearMonth.prototype.since');
@@ -495,6 +517,14 @@ begin
   if LargestUnit = tuAuto then LargestUnit := tuYear;
   if not (LargestUnit in [tuYear, tuMonth]) then
     ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainYearMonth.prototype.since', 'largestUnit']), SSuggestTemporalValidUnits);
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuMonth);
+  if not (SmallestUnit in [tuYear, tuMonth]) then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['PlainYearMonth.prototype.since', 'smallestUnit']), SSuggestTemporalValidUnits);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
 
   TotalMonths1 := Int64(YM.FYear) * 12 + Int64(YM.FMonth);
   TotalMonths2 := Int64(Other.FYear) * 12 + Int64(Other.FMonth);
@@ -509,6 +539,14 @@ begin
   begin
     DiffYears := 0;
     RemMonths := DiffMonths;
+  end;
+
+  if (SmallestUnit <> tuMonth) or (RIncrement <> 1) then
+  begin
+    W := 0; D := 0; H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
+    RoundDiffDuration(DiffYears, RemMonths, W, D, H, Mi, S, Ms, Us, Ns,
+      Other.FYear, Other.FMonth, 1,
+      LargestUnit, SmallestUnit, RMode, RIncrement);
   end;
 
   Result := TGocciaTemporalDurationValue.Create(DiffYears, RemMonths, 0, 0, 0, 0, 0, 0, 0, 0);

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -470,6 +470,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
   TotalMonths1 := Int64(YM.FYear) * 12 + Int64(YM.FMonth);
   TotalMonths2 := Int64(Other.FYear) * 12 + Int64(Other.FMonth);
@@ -525,6 +526,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
   TotalMonths1 := Int64(YM.FYear) * 12 + Int64(YM.FMonth);
   TotalMonths2 := Int64(Other.FYear) * 12 + Int64(Other.FMonth);

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -950,6 +950,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
   if LargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
   begin
@@ -1075,6 +1076,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
   RMode := GetRoundingMode(OptionsObj, rmTrunc);
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
+  ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
   if LargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
   begin

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -923,7 +923,9 @@ function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeUntil(const AArgs: TGocc
 var
   Zdt, Other: TGocciaTemporalZonedDateTimeValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   DiffMs: Int64;
   DiffSubMs: Integer;
   Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1: Integer;
@@ -932,6 +934,9 @@ var
   AdjDate: TTemporalDateRecord;
   AdjY2, AdjM2, AdjD2: Integer;
   Years, Months, Weeks, Days: Int64;
+  RH, RM, RS, RMs, RUs, RNs: Int64;
+  Dur: TGocciaTemporalDurationValue;
+  RY, RMo, RW, RD: Int64;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.until');
   Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.until');
@@ -939,6 +944,12 @@ begin
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
   if LargestUnit = tuAuto then LargestUnit := tuHour;
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
 
   if LargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
   begin
@@ -985,13 +996,20 @@ begin
       Years, Months, Weeks, Days);
 
     AbsTimeNs := Abs(TimeDiffNs);
+    RH := Sgn * (AbsTimeNs div Int64(3600000000000));
+    RM := Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60);
+    RS := Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60);
+    RMs := Sgn * ((AbsTimeNs div 1000000) mod 1000);
+    RUs := Sgn * ((AbsTimeNs div 1000) mod 1000);
+    RNs := Sgn * (AbsTimeNs mod 1000);
+
+    if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+      RoundDiffDuration(Years, Months, Weeks, Days,
+        RH, RM, RS, RMs, RUs, RNs,
+        Y1, M1, D1, LargestUnit, SmallestUnit, RMode, RIncrement);
+
     Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days,
-      Sgn * (AbsTimeNs div Int64(3600000000000)),
-      Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60),
-      Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60),
-      Sgn * ((AbsTimeNs div 1000000) mod 1000),
-      Sgn * ((AbsTimeNs div 1000) mod 1000),
-      Sgn * (AbsTimeNs mod 1000));
+      RH, RM, RS, RMs, RUs, RNs);
   end
   else
   begin
@@ -1011,6 +1029,17 @@ begin
     end;
 
     Result := ZonedDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
+
+    if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+    begin
+      Dur := TGocciaTemporalDurationValue(Result);
+      RY := Dur.Years; RMo := Dur.Months; RW := Dur.Weeks; RD := Dur.Days;
+      RH := Dur.Hours; RM := Dur.Minutes; RS := Dur.Seconds;
+      RMs := Dur.Milliseconds; RUs := Dur.Microseconds; RNs := Dur.Nanoseconds;
+      RoundDiffDuration(RY, RMo, RW, RD, RH, RM, RS, RMs, RUs, RNs,
+        0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
+      Result := TGocciaTemporalDurationValue.Create(RY, RMo, RW, RD, RH, RM, RS, RMs, RUs, RNs);
+    end;
   end;
 end;
 
@@ -1019,7 +1048,9 @@ function TGocciaTemporalZonedDateTimeValue.ZonedDateTimeSince(const AArgs: TGocc
 var
   Zdt, Other: TGocciaTemporalZonedDateTimeValue;
   OptionsObj: TGocciaObjectValue;
-  LargestUnit: TTemporalUnit;
+  LargestUnit, SmallestUnit: TTemporalUnit;
+  RMode: TTemporalRoundingMode;
+  RIncrement: Integer;
   DiffMs: Int64;
   DiffSubMs: Integer;
   Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1: Integer;
@@ -1028,6 +1059,9 @@ var
   AdjDate: TTemporalDateRecord;
   AdjY1, AdjM1, AdjD1: Integer;
   Years, Months, Weeks, Days: Int64;
+  RH, RM, RS, RMs, RUs, RNs: Int64;
+  Dur: TGocciaTemporalDurationValue;
+  RY, RMo, RW, RD: Int64;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.since');
   Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.since');
@@ -1035,6 +1069,12 @@ begin
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
   if LargestUnit = tuAuto then LargestUnit := tuHour;
+
+  SmallestUnit := GetSmallestUnit(OptionsObj, tuNanosecond);
+  if Ord(LargestUnit) > Ord(SmallestUnit) then
+    ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  RMode := GetRoundingMode(OptionsObj, rmTrunc);
+  RIncrement := GetRoundingIncrement(OptionsObj, 1);
 
   if LargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
   begin
@@ -1081,13 +1121,20 @@ begin
       Years, Months, Weeks, Days);
 
     AbsTimeNs := Abs(TimeDiffNs);
+    RH := Sgn * (AbsTimeNs div Int64(3600000000000));
+    RM := Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60);
+    RS := Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60);
+    RMs := Sgn * ((AbsTimeNs div 1000000) mod 1000);
+    RUs := Sgn * ((AbsTimeNs div 1000) mod 1000);
+    RNs := Sgn * (AbsTimeNs mod 1000);
+
+    if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+      RoundDiffDuration(Years, Months, Weeks, Days,
+        RH, RM, RS, RMs, RUs, RNs,
+        Y1, M1, D1, LargestUnit, SmallestUnit, RMode, RIncrement);
+
     Result := TGocciaTemporalDurationValue.Create(Years, Months, Weeks, Days,
-      Sgn * (AbsTimeNs div Int64(3600000000000)),
-      Sgn * ((AbsTimeNs div Int64(60000000000)) mod 60),
-      Sgn * ((AbsTimeNs div Int64(1000000000)) mod 60),
-      Sgn * ((AbsTimeNs div 1000000) mod 1000),
-      Sgn * ((AbsTimeNs div 1000) mod 1000),
-      Sgn * (AbsTimeNs mod 1000));
+      RH, RM, RS, RMs, RUs, RNs);
   end
   else
   begin
@@ -1107,6 +1154,17 @@ begin
     end;
 
     Result := ZonedDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
+
+    if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
+    begin
+      Dur := TGocciaTemporalDurationValue(Result);
+      RY := Dur.Years; RMo := Dur.Months; RW := Dur.Weeks; RD := Dur.Days;
+      RH := Dur.Hours; RM := Dur.Minutes; RS := Dur.Seconds;
+      RMs := Dur.Milliseconds; RUs := Dur.Microseconds; RNs := Dur.Nanoseconds;
+      RoundDiffDuration(RY, RMo, RW, RD, RH, RM, RS, RMs, RUs, RNs,
+        0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
+      Result := TGocciaTemporalDurationValue.Create(RY, RMo, RW, RD, RH, RM, RS, RMs, RUs, RNs);
+    end;
   end;
 end;
 

--- a/tests/built-ins/Temporal/Instant/prototype/since.js
+++ b/tests/built-ins/Temporal/Instant/prototype/since.js
@@ -24,4 +24,10 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.since", () => {
     const i2 = Temporal.Instant.fromEpochMilliseconds(0);
     expect(i1.since(i2, { largestUnit: "seconds" }).toString()).toBe("PT90061S");
   });
+
+  test("since() with smallestUnit seconds and roundingMode halfExpand", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(5500);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(0);
+    expect(i1.since(i2, { smallestUnit: "seconds", roundingMode: "halfExpand" }).toString()).toBe("PT6S");
+  });
 });

--- a/tests/built-ins/Temporal/Instant/prototype/until.js
+++ b/tests/built-ins/Temporal/Instant/prototype/until.js
@@ -49,4 +49,28 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
     const i2 = Temporal.Instant.fromEpochMilliseconds(0);
     expect(i1.until(i2, { largestUnit: "minutes" }).toString()).toBe("-PT1M30S");
   });
+
+  test("until() with smallestUnit seconds truncates milliseconds", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(0);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(5500);
+    expect(i1.until(i2, { smallestUnit: "seconds" }).toString()).toBe("PT5S");
+  });
+
+  test("until() with smallestUnit seconds and roundingMode halfExpand", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(0);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(5500);
+    expect(i1.until(i2, { smallestUnit: "seconds", roundingMode: "halfExpand" }).toString()).toBe("PT6S");
+  });
+
+  test("until() with smallestUnit minutes truncates seconds", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(0);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(90500);
+    expect(i1.until(i2, { largestUnit: "minutes", smallestUnit: "minutes" }).toString()).toBe("PT1M");
+  });
+
+  test("until() with roundingIncrement 15 and smallestUnit minutes", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(0);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(50 * 60000);
+    expect(i1.until(i2, { largestUnit: "hours", smallestUnit: "minutes", roundingIncrement: 15 }).toString()).toBe("PT45M");
+  });
 });

--- a/tests/built-ins/Temporal/PlainDate/prototype/since.js
+++ b/tests/built-ins/Temporal/PlainDate/prototype/since.js
@@ -30,4 +30,10 @@ describe.runIf(isTemporal)("Temporal.PlainDate.prototype.since", () => {
     const d2 = Temporal.PlainDate.from("2020-01-15");
     expect(d1.since(d2, { largestUnit: "years" }).toString()).toBe("P6Y6M15D");
   });
+
+  test("since() with smallestUnit month rounds", () => {
+    const d1 = Temporal.PlainDate.from("2020-04-20");
+    const d2 = Temporal.PlainDate.from("2020-01-01");
+    expect(d1.since(d2, { largestUnit: "years", smallestUnit: "month", roundingMode: "halfExpand" }).toString()).toBe("P4M");
+  });
 });

--- a/tests/built-ins/Temporal/PlainDate/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainDate/prototype/until.js
@@ -110,4 +110,19 @@ describe.runIf(isTemporal)("Temporal.PlainDate.prototype.until", () => {
     const d2 = Temporal.PlainDate.from("2020-01-01");
     expect(d1.until(d2, { largestUnit: "years", smallestUnit: "month" }).toString()).toBe("-P3M");
   });
+
+  test("until() negative with roundingIncrement 2 and halfExpand rounds away from zero", () => {
+    const d1 = Temporal.PlainDate.from("2020-04-15");
+    const d2 = Temporal.PlainDate.from("2020-01-01");
+    expect(d1.until(d2, { largestUnit: "years", smallestUnit: "month", roundingIncrement: 2, roundingMode: "halfExpand" }).toString()).toBe("-P4M");
+  });
+
+  test("until() smallestUnit week with largestUnit month does not leak days", () => {
+    const d1 = Temporal.PlainDate.from("2020-01-31");
+    const d2 = Temporal.PlainDate.from("2020-03-28");
+    const dur = d1.until(d2, { largestUnit: "month", smallestUnit: "week" });
+    expect(dur.days).toBe(0);
+    expect(dur.weeks).toBe(8);
+    expect(dur.months).toBe(0);
+  });
 });

--- a/tests/built-ins/Temporal/PlainDate/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainDate/prototype/until.js
@@ -68,4 +68,46 @@ describe.runIf(isTemporal)("Temporal.PlainDate.prototype.until", () => {
     const d2 = Temporal.PlainDate.from("2024-03-01");
     expect(d1.until(d2, { largestUnit: "months" }).toString()).toBe("P1M1D");
   });
+
+  test("until() with smallestUnit month truncates days", () => {
+    const d1 = Temporal.PlainDate.from("2020-01-01");
+    const d2 = Temporal.PlainDate.from("2020-04-15");
+    expect(d1.until(d2, { largestUnit: "years", smallestUnit: "month" }).toString()).toBe("P3M");
+  });
+
+  test("until() with smallestUnit month and roundingMode halfExpand", () => {
+    const d1 = Temporal.PlainDate.from("2020-01-01");
+    const d2 = Temporal.PlainDate.from("2020-04-20");
+    expect(d1.until(d2, { largestUnit: "years", smallestUnit: "month", roundingMode: "halfExpand" }).toString()).toBe("P4M");
+  });
+
+  test("until() with smallestUnit year truncates months", () => {
+    const d1 = Temporal.PlainDate.from("2020-01-01");
+    const d2 = Temporal.PlainDate.from("2023-08-15");
+    expect(d1.until(d2, { largestUnit: "years", smallestUnit: "year" }).toString()).toBe("P3Y");
+  });
+
+  test("until() with smallestUnit year and roundingMode halfExpand rounds up", () => {
+    const d1 = Temporal.PlainDate.from("2020-01-01");
+    const d2 = Temporal.PlainDate.from("2023-08-15");
+    expect(d1.until(d2, { largestUnit: "years", smallestUnit: "year", roundingMode: "halfExpand" }).toString()).toBe("P4Y");
+  });
+
+  test("until() with smallestUnit week truncates remaining days", () => {
+    const d1 = Temporal.PlainDate.from("2024-01-01");
+    const d2 = Temporal.PlainDate.from("2024-01-20");
+    expect(d1.until(d2, { largestUnit: "weeks", smallestUnit: "week" }).toString()).toBe("P2W");
+  });
+
+  test("until() with roundingIncrement 2 and smallestUnit month", () => {
+    const d1 = Temporal.PlainDate.from("2020-01-01");
+    const d2 = Temporal.PlainDate.from("2020-07-10");
+    expect(d1.until(d2, { largestUnit: "years", smallestUnit: "month", roundingIncrement: 2 }).toString()).toBe("P6M");
+  });
+
+  test("until() negative with smallestUnit month truncates", () => {
+    const d1 = Temporal.PlainDate.from("2020-04-15");
+    const d2 = Temporal.PlainDate.from("2020-01-01");
+    expect(d1.until(d2, { largestUnit: "years", smallestUnit: "month" }).toString()).toBe("-P3M");
+  });
 });

--- a/tests/built-ins/Temporal/PlainDateTime/prototype/since.js
+++ b/tests/built-ins/Temporal/PlainDateTime/prototype/since.js
@@ -25,4 +25,10 @@ describe.runIf(isTemporal)("Temporal.PlainDateTime.prototype.since", () => {
     const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0);
     expect(dt1.since(dt2, { largestUnit: "hours" }).toString()).toBe("PT36H");
   });
+
+  test("since() with smallestUnit hour and roundingMode halfExpand", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 12, 45);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 10, 0);
+    expect(dt1.since(dt2, { smallestUnit: "hour", roundingMode: "halfExpand" }).toString()).toBe("PT3H");
+  });
 });

--- a/tests/built-ins/Temporal/PlainDateTime/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainDateTime/prototype/until.js
@@ -55,4 +55,40 @@ describe.runIf(isTemporal)("Temporal.PlainDateTime.prototype.until", () => {
     const dt2 = new Temporal.PlainDateTime(2024, 1, 22, 12, 0);
     expect(dt1.until(dt2, { largestUnit: "weeks" }).toString()).toBe("P3WT12H");
   });
+
+  test("until() with smallestUnit hour truncates minutes", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 10, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 12, 45);
+    expect(dt1.until(dt2, { smallestUnit: "hour" }).toString()).toBe("PT2H");
+  });
+
+  test("until() with smallestUnit hour and roundingMode halfExpand", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 10, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 12, 45);
+    expect(dt1.until(dt2, { smallestUnit: "hour", roundingMode: "halfExpand" }).toString()).toBe("PT3H");
+  });
+
+  test("until() with smallestUnit minute truncates seconds", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 1, 0, 5, 45);
+    expect(dt1.until(dt2, { smallestUnit: "minute" }).toString()).toBe("PT5M");
+  });
+
+  test("until() with smallestUnit day truncates time", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 3, 18, 0);
+    expect(dt1.until(dt2, { smallestUnit: "day" }).toString()).toBe("P2D");
+  });
+
+  test("until() with smallestUnit day and roundingMode ceil rounds up", () => {
+    const dt1 = new Temporal.PlainDateTime(2024, 1, 1, 0, 0);
+    const dt2 = new Temporal.PlainDateTime(2024, 1, 3, 1, 0);
+    expect(dt1.until(dt2, { smallestUnit: "day", roundingMode: "ceil" }).toString()).toBe("P3D");
+  });
+
+  test("until() with smallestUnit month and largestUnit year", () => {
+    const dt1 = new Temporal.PlainDateTime(2020, 1, 1, 0, 0);
+    const dt2 = new Temporal.PlainDateTime(2020, 4, 20, 12, 0);
+    expect(dt1.until(dt2, { largestUnit: "years", smallestUnit: "month", roundingMode: "halfExpand" }).toString()).toBe("P4M");
+  });
 });

--- a/tests/built-ins/Temporal/PlainTime/prototype/since.js
+++ b/tests/built-ins/Temporal/PlainTime/prototype/since.js
@@ -13,4 +13,10 @@ describe.runIf(isTemporal)("Temporal.PlainTime.prototype.since", () => {
     expect(dur.hours).toBe(2);
     expect(dur.minutes).toBe(30);
   });
+
+  test("since() with largestUnit minute collapses hours", () => {
+    const t1 = new Temporal.PlainTime(12, 30, 0);
+    const t2 = new Temporal.PlainTime(10, 0, 0);
+    expect(t1.since(t2, { largestUnit: "minute" }).toString()).toBe("PT150M");
+  });
 });

--- a/tests/built-ins/Temporal/PlainTime/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainTime/prototype/until.js
@@ -55,4 +55,26 @@ describe.runIf(isTemporal)("Temporal.PlainTime.prototype.until", () => {
     const t2 = new Temporal.PlainTime(12, 30, 0);
     expect(() => t1.until(t2, { largestUnit: "second", smallestUnit: "hour" })).toThrow(RangeError);
   });
+
+  test("until() throws RangeError when roundingIncrement does not divide unit maximum", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(12, 30, 0);
+    expect(() => t1.until(t2, { smallestUnit: "minute", roundingIncrement: 7 })).toThrow(RangeError);
+    expect(() => t1.until(t2, { smallestUnit: "second", roundingIncrement: 7 })).toThrow(RangeError);
+    expect(() => t1.until(t2, { smallestUnit: "millisecond", roundingIncrement: 3 })).toThrow(RangeError);
+  });
+
+  test("until() allows roundingIncrement that divides unit maximum", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(10, 50, 0);
+    expect(t1.until(t2, { smallestUnit: "minute", roundingIncrement: 15 }).toString()).toBe("PT45M");
+    expect(t1.until(t2, { smallestUnit: "minute", roundingIncrement: 10 }).toString()).toBe("PT50M");
+  });
+
+  test("until() allows any roundingIncrement when smallestUnit equals largestUnit", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(10, 50, 0);
+    const dur = t1.until(t2, { largestUnit: "minute", smallestUnit: "minute", roundingIncrement: 7 });
+    expect(dur.minutes).toBe(49);
+  });
 });

--- a/tests/built-ins/Temporal/PlainTime/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainTime/prototype/until.js
@@ -49,4 +49,10 @@ describe.runIf(isTemporal)("Temporal.PlainTime.prototype.until", () => {
     const t2 = new Temporal.PlainTime(10, 1, 30);
     expect(t1.until(t2, { largestUnit: "second" }).toString()).toBe("PT90S");
   });
+
+  test("until() throws RangeError when smallestUnit is larger than largestUnit", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(12, 30, 0);
+    expect(() => t1.until(t2, { largestUnit: "second", smallestUnit: "hour" })).toThrow(RangeError);
+  });
 });

--- a/tests/built-ins/Temporal/PlainTime/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainTime/prototype/until.js
@@ -13,4 +13,28 @@ describe.runIf(isTemporal)("Temporal.PlainTime.prototype.until", () => {
     expect(dur.hours).toBe(2);
     expect(dur.minutes).toBe(30);
   });
+
+  test("until() with smallestUnit hour truncates minutes", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(12, 45, 0);
+    expect(t1.until(t2, { smallestUnit: "hour" }).toString()).toBe("PT2H");
+  });
+
+  test("until() with smallestUnit hour and roundingMode halfExpand", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(12, 45, 0);
+    expect(t1.until(t2, { smallestUnit: "hour", roundingMode: "halfExpand" }).toString()).toBe("PT3H");
+  });
+
+  test("until() with smallestUnit minute truncates seconds", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(10, 5, 45);
+    expect(t1.until(t2, { smallestUnit: "minute" }).toString()).toBe("PT5M");
+  });
+
+  test("until() with roundingIncrement 15 and smallestUnit minutes", () => {
+    const t1 = new Temporal.PlainTime(0, 0, 0);
+    const t2 = new Temporal.PlainTime(0, 50, 0);
+    expect(t1.until(t2, { smallestUnit: "minute", roundingIncrement: 15 }).toString()).toBe("PT45M");
+  });
 });

--- a/tests/built-ins/Temporal/PlainTime/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainTime/prototype/until.js
@@ -37,4 +37,16 @@ describe.runIf(isTemporal)("Temporal.PlainTime.prototype.until", () => {
     const t2 = new Temporal.PlainTime(0, 50, 0);
     expect(t1.until(t2, { smallestUnit: "minute", roundingIncrement: 15 }).toString()).toBe("PT45M");
   });
+
+  test("until() with largestUnit minute collapses hours into minutes", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(12, 30, 0);
+    expect(t1.until(t2, { largestUnit: "minute" }).toString()).toBe("PT150M");
+  });
+
+  test("until() with largestUnit second collapses all into seconds", () => {
+    const t1 = new Temporal.PlainTime(10, 0, 0);
+    const t2 = new Temporal.PlainTime(10, 1, 30);
+    expect(t1.until(t2, { largestUnit: "second" }).toString()).toBe("PT90S");
+  });
 });

--- a/tests/built-ins/Temporal/PlainYearMonth/prototype/until.js
+++ b/tests/built-ins/Temporal/PlainYearMonth/prototype/until.js
@@ -38,4 +38,22 @@ describe.runIf(isTemporal)("Temporal.PlainYearMonth.prototype.until", () => {
     expect(dur.years).toBe(0);
     expect(dur.months).toBe(0);
   });
+
+  test("until() with smallestUnit year truncates months", () => {
+    const a = new Temporal.PlainYearMonth(2020, 1);
+    const b = new Temporal.PlainYearMonth(2023, 8);
+    expect(a.until(b, { largestUnit: "years", smallestUnit: "year" }).toString()).toBe("P3Y");
+  });
+
+  test("until() with smallestUnit year and roundingMode halfExpand rounds up", () => {
+    const a = new Temporal.PlainYearMonth(2020, 1);
+    const b = new Temporal.PlainYearMonth(2023, 8);
+    expect(a.until(b, { largestUnit: "years", smallestUnit: "year", roundingMode: "halfExpand" }).toString()).toBe("P4Y");
+  });
+
+  test("until() with roundingIncrement 3 and smallestUnit month", () => {
+    const a = new Temporal.PlainYearMonth(2020, 1);
+    const b = new Temporal.PlainYearMonth(2020, 8);
+    expect(a.until(b, { largestUnit: "months", smallestUnit: "month", roundingIncrement: 3 }).toString()).toBe("P6M");
+  });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/until.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/until.js
@@ -37,4 +37,21 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.until", () => {
     expect(dur.seconds).toBe(90);
     expect(dur.minutes).toBe(0);
   });
+
+  test("until() with smallestUnit minutes truncates seconds", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(5400000 + 30000).toZonedDateTimeISO("UTC");
+    const dur = z1.until(z2, { largestUnit: "hours", smallestUnit: "minutes" });
+    expect(dur.hours).toBe(1);
+    expect(dur.minutes).toBe(30);
+    expect(dur.seconds).toBe(0);
+  });
+
+  test("until() with smallestUnit minutes and roundingMode ceil", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(5400000 + 30000).toZonedDateTimeISO("UTC");
+    const dur = z1.until(z2, { largestUnit: "hours", smallestUnit: "minutes", roundingMode: "ceil" });
+    expect(dur.hours).toBe(1);
+    expect(dur.minutes).toBe(31);
+  });
 });


### PR DESCRIPTION
## Summary

- Implement `smallestUnit`, `roundingMode`, and `roundingIncrement` options for all 12 `until`/`since` methods across 6 Temporal types (PlainDate, PlainDateTime, Instant, PlainYearMonth, ZonedDateTime, PlainTime)
- Add shared `RoundDiffDuration` procedure in `Goccia.Temporal.Options` implementing the TC39 `RoundRelativeDuration` algorithm — calendar-unit rounding (year/month) via month-walking with day-clamping, and nanosecond-based rounding for sub-month units
- Update `built-ins-temporal.md` to document the new rounding options for all types

Closes #419
