### PR TITLE
Fix for-of `continue` raising ReferenceError instead of skipping iteration

### DIFF
--- a/source/units/Goccia.AST.Statements.pas
+++ b/source/units/Goccia.AST.Statements.pas
@@ -446,6 +446,12 @@ type
     function Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow; override;
   end;
 
+  TGocciaContinueStatement = class(TGocciaStatement)
+  public
+    constructor Create(const ALine, AColumn: Integer);
+    function Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow; override;
+  end;
+
   TGocciaUsingDeclaration = class(TGocciaStatement)
   private
     FVariables: TArray<TGocciaVariableInfo>;
@@ -818,6 +824,13 @@ end;
     inherited Create(ALine, AColumn);
   end;
 
+  { TGocciaContinueStatement }
+
+  constructor TGocciaContinueStatement.Create(const ALine, AColumn: Integer);
+  begin
+    inherited Create(ALine, AColumn);
+  end;
+
   { Execute / Evaluate overrides }
 
   function TGocciaExpressionStatement.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
@@ -931,6 +944,11 @@ end;
   function TGocciaBreakStatement.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
   begin
     Result := TGocciaControlFlow.Break;
+  end;
+
+  function TGocciaContinueStatement.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+  begin
+    Result := TGocciaControlFlow.Continue;
   end;
 
   function TGocciaClassDeclaration.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -45,6 +45,7 @@ procedure CompileReExportDeclaration(const ACtx: TGocciaCompilationContext;
 procedure CompileSwitchStatement(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaSwitchStatement);
 procedure CompileBreakStatement(const ACtx: TGocciaCompilationContext);
+procedure CompileContinueStatement(const ACtx: TGocciaCompilationContext);
 procedure CompileDestructuringDeclaration(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaDestructuringDeclaration);
 procedure CompileEnumDeclaration(const ACtx: TGocciaCompilationContext;
@@ -109,8 +110,10 @@ type
 
 threadvar
   GBreakJumps: TList<Integer>;
+  GContinueJumps: TList<Integer>;
   GPendingFinally: TList<TPendingFinallyEntry>;
   GBreakFinallyBase: Integer;
+  GContinueFinallyBase: Integer;
 
 procedure CompileExpressionStatement(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaExpressionStatement);
@@ -1048,6 +1051,9 @@ var
   OldBreakJumps: TList<Integer>;
   OldBreakFinallyBase: Integer;
   BreakJumps: TList<Integer>;
+  OldContinueJumps: TList<Integer>;
+  OldContinueFinallyBase: Integer;
+  ContinueJumps: TList<Integer>;
   ElemAnnotation: string;
   ElemType: TGocciaLocalType;
 begin
@@ -1067,10 +1073,20 @@ begin
   OldBreakFinallyBase := GBreakFinallyBase;
   BreakJumps := TList<Integer>.Create;
   GBreakJumps := BreakJumps;
+  OldContinueJumps := GContinueJumps;
+  OldContinueFinallyBase := GContinueFinallyBase;
+  ContinueJumps := TList<Integer>.Create;
+  GContinueJumps := ContinueJumps;
   if Assigned(GPendingFinally) then
-    GBreakFinallyBase := GPendingFinally.Count
+  begin
+    GBreakFinallyBase := GPendingFinally.Count;
+    GContinueFinallyBase := GPendingFinally.Count;
+  end
   else
+  begin
     GBreakFinallyBase := 0;
+    GContinueFinallyBase := 0;
+  end;
   try
     LoopStart := CurrentCodePosition(ACtx);
 
@@ -1124,6 +1140,10 @@ begin
     for I := 0 to ClosedCount - 1 do
       EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
 
+    // Patch continue jumps to the increment + back-jump sequence
+    for I := 0 to ContinueJumps.Count - 1 do
+      PatchJumpTarget(ACtx, ContinueJumps[I]);
+
     EmitInstruction(ACtx, EncodeABC(OP_ADD_INT, IdxReg, IdxReg, OneReg));
     EmitInstruction(ACtx, EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
 
@@ -1135,6 +1155,9 @@ begin
     BreakJumps.Free;
     GBreakJumps := OldBreakJumps;
     GBreakFinallyBase := OldBreakFinallyBase;
+    ContinueJumps.Free;
+    GContinueJumps := OldContinueJumps;
+    GContinueFinallyBase := OldContinueFinallyBase;
   end;
 
   ACtx.Scope.FreeRegister;
@@ -1156,6 +1179,9 @@ var
   OldBreakJumps: TList<Integer>;
   OldBreakFinallyBase: Integer;
   BreakJumps: TList<Integer>;
+  OldContinueJumps: TList<Integer>;
+  OldContinueFinallyBase: Integer;
+  ContinueJumps: TList<Integer>;
   ArrayLocalIdx: Integer;
 begin
   if IsConstArrayLocal(ACtx, AStmt.Iterable, ArrayLocalIdx) then
@@ -1175,10 +1201,20 @@ begin
   OldBreakFinallyBase := GBreakFinallyBase;
   BreakJumps := TList<Integer>.Create;
   GBreakJumps := BreakJumps;
+  OldContinueJumps := GContinueJumps;
+  OldContinueFinallyBase := GContinueFinallyBase;
+  ContinueJumps := TList<Integer>.Create;
+  GContinueJumps := ContinueJumps;
   if Assigned(GPendingFinally) then
-    GBreakFinallyBase := GPendingFinally.Count
+  begin
+    GBreakFinallyBase := GPendingFinally.Count;
+    GContinueFinallyBase := GPendingFinally.Count;
+  end
   else
+  begin
     GBreakFinallyBase := 0;
+    GContinueFinallyBase := 0;
+  end;
   try
     LoopStart := CurrentCodePosition(ACtx);
 
@@ -1204,6 +1240,10 @@ begin
     for I := 0 to ClosedCount - 1 do
       EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
 
+    // Patch continue jumps to the back-jump (iterator advances via ITER_NEXT)
+    for I := 0 to ContinueJumps.Count - 1 do
+      PatchJumpTarget(ACtx, ContinueJumps[I]);
+
     EmitInstruction(ACtx, EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
 
     PatchJumpTarget(ACtx, ExitJump);
@@ -1214,6 +1254,9 @@ begin
     BreakJumps.Free;
     GBreakJumps := OldBreakJumps;
     GBreakFinallyBase := OldBreakFinallyBase;
+    ContinueJumps.Free;
+    GContinueJumps := OldContinueJumps;
+    GContinueFinallyBase := OldContinueFinallyBase;
   end;
 
   ACtx.Scope.FreeRegister;
@@ -1232,6 +1275,9 @@ var
   OldBreakJumps: TList<Integer>;
   OldBreakFinallyBase: Integer;
   BreakJumps: TList<Integer>;
+  OldContinueJumps: TList<Integer>;
+  OldContinueFinallyBase: Integer;
+  ContinueJumps: TList<Integer>;
 begin
   IterReg := ACtx.Scope.AllocateRegister;
   ValueReg := ACtx.Scope.AllocateRegister;
@@ -1244,10 +1290,20 @@ begin
   OldBreakFinallyBase := GBreakFinallyBase;
   BreakJumps := TList<Integer>.Create;
   GBreakJumps := BreakJumps;
+  OldContinueJumps := GContinueJumps;
+  OldContinueFinallyBase := GContinueFinallyBase;
+  ContinueJumps := TList<Integer>.Create;
+  GContinueJumps := ContinueJumps;
   if Assigned(GPendingFinally) then
-    GBreakFinallyBase := GPendingFinally.Count
+  begin
+    GBreakFinallyBase := GPendingFinally.Count;
+    GContinueFinallyBase := GPendingFinally.Count;
+  end
   else
+  begin
     GBreakFinallyBase := 0;
+    GContinueFinallyBase := 0;
+  end;
   try
     LoopStart := CurrentCodePosition(ACtx);
 
@@ -1274,6 +1330,10 @@ begin
     for I := 0 to ClosedCount - 1 do
       EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
 
+    // Patch continue jumps to the back-jump (iterator advances via ITER_NEXT)
+    for I := 0 to ContinueJumps.Count - 1 do
+      PatchJumpTarget(ACtx, ContinueJumps[I]);
+
     EmitInstruction(ACtx, EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
 
     PatchJumpTarget(ACtx, ExitJump);
@@ -1284,6 +1344,9 @@ begin
     BreakJumps.Free;
     GBreakJumps := OldBreakJumps;
     GBreakFinallyBase := OldBreakFinallyBase;
+    ContinueJumps.Free;
+    GContinueJumps := OldContinueJumps;
+    GContinueFinallyBase := OldContinueFinallyBase;
   end;
 
   ACtx.Scope.FreeRegister;
@@ -1542,6 +1605,36 @@ begin
     end;
 
   GBreakJumps.Add(EmitJumpInstruction(ACtx, OP_JUMP, 0));
+end;
+
+procedure CompileContinueStatement(const ACtx: TGocciaCompilationContext);
+var
+  I: Integer;
+  Entry: TPendingFinallyEntry;
+  NullishJump: Integer;
+begin
+  if not Assigned(GContinueJumps) then
+    Exit;
+
+  if Assigned(GPendingFinally) and (GPendingFinally.Count > GContinueFinallyBase) then
+    for I := GPendingFinally.Count - 1 downto GContinueFinallyBase do
+    begin
+      Entry := GPendingFinally[I];
+      EmitInstruction(ACtx, EncodeABC(OP_POP_HANDLER, 0, 0, 0));
+      if Assigned(Entry.FinallyBlock) then
+        CompileBlockStatement(ACtx, Entry.FinallyBlock)
+      else if Length(Entry.UsingResources) > 0 then
+      begin
+        EmitDisposalSequence(ACtx, Entry.UsingResources,
+          Length(Entry.UsingResources), Entry.UsingErrorReg);
+        NullishJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_NULLISH,
+          Entry.UsingErrorReg);
+        EmitInstruction(ACtx, EncodeABC(OP_THROW, Entry.UsingErrorReg, 0, 0));
+        PatchJumpTarget(ACtx, NullishJump);
+      end;
+    end;
+
+  GContinueJumps.Add(EmitJumpInstruction(ACtx, OP_JUMP, 0));
 end;
 
 procedure CompileMethodBody(const ACtx: TGocciaCompilationContext;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -1136,13 +1136,13 @@ begin
 
     ACtx.CompileStatement(AStmt.Body);
 
+    // Patch continue jumps before close-upvalue so closures see correct iteration values
+    for I := 0 to ContinueJumps.Count - 1 do
+      PatchJumpTarget(ACtx, ContinueJumps[I]);
+
     ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
     for I := 0 to ClosedCount - 1 do
       EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
-
-    // Patch continue jumps to the increment + back-jump sequence
-    for I := 0 to ContinueJumps.Count - 1 do
-      PatchJumpTarget(ACtx, ContinueJumps[I]);
 
     EmitInstruction(ACtx, EncodeABC(OP_ADD_INT, IdxReg, IdxReg, OneReg));
     EmitInstruction(ACtx, EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
@@ -1236,13 +1236,13 @@ begin
 
     ACtx.CompileStatement(AStmt.Body);
 
+    // Patch continue jumps before close-upvalue so closures see correct iteration values
+    for I := 0 to ContinueJumps.Count - 1 do
+      PatchJumpTarget(ACtx, ContinueJumps[I]);
+
     ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
     for I := 0 to ClosedCount - 1 do
       EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
-
-    // Patch continue jumps to the back-jump (iterator advances via ITER_NEXT)
-    for I := 0 to ContinueJumps.Count - 1 do
-      PatchJumpTarget(ACtx, ContinueJumps[I]);
 
     EmitInstruction(ACtx, EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
 
@@ -1326,13 +1326,13 @@ begin
 
     ACtx.CompileStatement(AStmt.Body);
 
+    // Patch continue jumps before close-upvalue so closures see correct iteration values
+    for I := 0 to ContinueJumps.Count - 1 do
+      PatchJumpTarget(ACtx, ContinueJumps[I]);
+
     ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
     for I := 0 to ClosedCount - 1 do
       EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
-
-    // Patch continue jumps to the back-jump (iterator advances via ITER_NEXT)
-    for I := 0 to ContinueJumps.Count - 1 do
-      PatchJumpTarget(ACtx, ContinueJumps[I]);
 
     EmitInstruction(ACtx, EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
 
@@ -1609,7 +1609,8 @@ end;
 
 procedure CompileContinueStatement(const ACtx: TGocciaCompilationContext);
 var
-  I: Integer;
+  I, Count, Base: Integer;
+  Entries: array of TPendingFinallyEntry;
   Entry: TPendingFinallyEntry;
   NullishJump: Integer;
 begin
@@ -1617,9 +1618,20 @@ begin
     Exit;
 
   if Assigned(GPendingFinally) and (GPendingFinally.Count > GContinueFinallyBase) then
-    for I := GPendingFinally.Count - 1 downto GContinueFinallyBase do
+  begin
+    Count := GPendingFinally.Count;
+    Base := GContinueFinallyBase;
+    // Snapshot entries above the continue-finally base
+    SetLength(Entries, Count - Base);
+    for I := Base to Count - 1 do
+      Entries[I - Base] := GPendingFinally[I];
+    // Process from innermost to outermost, removing each before compiling
+    // its cleanup so nested abrupt completions do not see the same entry.
+    for I := Count - 1 downto Base do
     begin
-      Entry := GPendingFinally[I];
+      if GPendingFinally.Count > I then
+        GPendingFinally.Delete(I);
+      Entry := Entries[I - Base];
       EmitInstruction(ACtx, EncodeABC(OP_POP_HANDLER, 0, 0, 0));
       if Assigned(Entry.FinallyBlock) then
         CompileBlockStatement(ACtx, Entry.FinallyBlock)
@@ -1633,6 +1645,10 @@ begin
         PatchJumpTarget(ACtx, NullishJump);
       end;
     end;
+    // Restore entries so normal-path compilation still sees them
+    for I := 0 to Length(Entries) - 1 do
+      GPendingFinally.Insert(Base + I, Entries[I]);
+  end;
 
   GContinueJumps.Add(EmitJumpInstruction(ACtx, OP_JUMP, 0));
 end;

--- a/source/units/Goccia.Compiler.pas
+++ b/source/units/Goccia.Compiler.pas
@@ -218,6 +218,8 @@ begin
     Goccia.Compiler.Statements.CompileSwitchStatement(Ctx, TGocciaSwitchStatement(AStmt))
   else if AStmt is TGocciaBreakStatement then
     Goccia.Compiler.Statements.CompileBreakStatement(Ctx)
+  else if AStmt is TGocciaContinueStatement then
+    Goccia.Compiler.Statements.CompileContinueStatement(Ctx)
   else if AStmt is TGocciaImportDeclaration then
     Goccia.Compiler.Statements.CompileImportDeclaration(Ctx, TGocciaImportDeclaration(AStmt))
   else if AStmt is TGocciaExportVariableDeclaration then

--- a/source/units/Goccia.ControlFlow.pas
+++ b/source/units/Goccia.ControlFlow.pas
@@ -8,7 +8,7 @@ uses
   Goccia.Values.Primitives;
 
 type
-  TGocciaControlFlowKind = (cfkNormal, cfkReturn, cfkBreak);
+  TGocciaControlFlowKind = (cfkNormal, cfkReturn, cfkBreak, cfkContinue);
 
   // Tagged-pointer representation: the control flow kind is encoded in the low
   // 2 bits of the value pointer. TGocciaValue instances are always 16-byte
@@ -24,6 +24,7 @@ type
     class function Normal(const AValue: TGocciaValue): TGocciaControlFlow; static; inline;
     class function Return(const AValue: TGocciaValue): TGocciaControlFlow; static; inline;
     class function Break: TGocciaControlFlow; static; inline;
+    class function Continue: TGocciaControlFlow; static; inline;
     property Kind: TGocciaControlFlowKind read GetKind;
     property Value: TGocciaValue read GetValue;
   end;
@@ -53,6 +54,11 @@ end;
 class function TGocciaControlFlow.Break: TGocciaControlFlow;
 begin
   Result.FBits := 2;
+end;
+
+class function TGocciaControlFlow.Continue: TGocciaControlFlow;
+begin
+  Result.FBits := 3;
 end;
 
 end.

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -621,6 +621,7 @@ resourcestring
 
   // Function body errors
   SErrorIllegalBreakStatement = 'Illegal break statement';
+  SErrorIllegalContinueStatement = 'Illegal continue statement';
 
   // Function.prototype errors
   SErrorFunctionApplyNonFunction = 'Function.prototype.apply called on non-function';

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1432,6 +1432,7 @@ begin
       CF := EvaluateStatement(AForOfStatement.Body, IterContext);
       if CF.Kind = cfkBreak then Break;
       if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
+      // cfkContinue: skip remaining body, advance to next iteration
 
       IterResult := Iterator.AdvanceNext;
     end;
@@ -2222,7 +2223,7 @@ begin
       begin
         CF := EvaluateStatement(CaseClause.Consequent[J], AContext);
         if CF.Kind = cfkBreak then begin Done := True; Break; end;
-        if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
+        if CF.Kind in [cfkReturn, cfkContinue] then begin Result := CF; Exit; end;
         Result := CF;
       end;
       if Done then Break;
@@ -2242,7 +2243,7 @@ begin
       begin
         CF := EvaluateStatement(CaseClause.Consequent[J], AContext);
         if CF.Kind = cfkBreak then begin Done := True; Break; end;
-        if CF.Kind = cfkReturn then begin Result := CF; Exit; end;
+        if CF.Kind in [cfkReturn, cfkContinue] then begin Result := CF; Exit; end;
         Result := CF;
       end;
       if Done then Break;

--- a/source/units/Goccia.Keywords.Reserved.pas
+++ b/source/units/Goccia.Keywords.Reserved.pas
@@ -7,6 +7,7 @@ interface
 const
   KEYWORD_BREAK      = 'break';
   KEYWORD_CASE       = 'case';
+  KEYWORD_CONTINUE   = 'continue';
   KEYWORD_CATCH      = 'catch';
   KEYWORD_CLASS      = 'class';
   KEYWORD_CONST      = 'const';

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -1477,6 +1477,7 @@ begin
   // Reserved keywords
   FKeywords.Add(KEYWORD_BREAK, gttBreak);
   FKeywords.Add(KEYWORD_CASE, gttCase);
+  FKeywords.Add(KEYWORD_CONTINUE, gttContinue);
   FKeywords.Add(KEYWORD_CATCH, gttCatch);
   FKeywords.Add(KEYWORD_CLASS, gttClass);
   FKeywords.Add(KEYWORD_CONST, gttConst);

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -192,6 +192,7 @@ type
     function UsingStatement: TGocciaStatement;
     function SwitchStatement: TGocciaStatement;
     function BreakStatement: TGocciaStatement;
+    function ContinueStatement: TGocciaStatement;
   public
     constructor Create(const ATokens: TObjectList<TGocciaToken>;
       const AFileName: string; const ASourceLines: TStringList);
@@ -589,7 +590,7 @@ begin
     gttTrue, gttFalse, gttNull,
     gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis,
     gttSuper, gttStatic, gttReturn, gttIf, gttElse, gttFor, gttWhile, gttDo,
-    gttSwitch, gttCase, gttDefault, gttBreak, gttThrow, gttTry, gttCatch,
+    gttSwitch, gttCase, gttDefault, gttBreak, gttContinue, gttThrow, gttTry, gttCatch,
     gttFinally, gttImport, gttExport, gttFrom, gttAs, gttGet, gttSet,
     gttVar, gttWith, gttFunction, gttTypeof, gttVoid, gttInstanceof, gttIn,
     gttDelete:
@@ -877,7 +878,7 @@ begin
         if Check(gttIdentifier) then
           PropertyName := Advance.Lexeme
         else if Match([gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
-                       gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
+                       gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
                        gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
                        gttTrue, gttFalse, gttNull, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
           PropertyName := Previous.Lexeme  // Reserved words are allowed as property names
@@ -1896,7 +1897,7 @@ begin
       end
       else if Match([gttIdentifier, gttString, gttNumber,
                      gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
-                     gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
+                     gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
                      gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
                      gttTrue, gttFalse, gttNull, gttTypeof, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
         { name consumed };
@@ -1961,7 +1962,7 @@ begin
       Key := FloatToStr(NumericValue);
     end
     else if Match([gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
-                   gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
+                   gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
                    gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
                    gttTrue, gttFalse, gttNull, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
       Key := Previous.Lexeme  // Reserved words are allowed as property names
@@ -2568,6 +2569,8 @@ begin
     Result := SwitchStatement
   else if Match(gttBreak) then
     Result := BreakStatement
+  else if Match(gttContinue) then
+    Result := ContinueStatement
   else if Match(gttReturn) then
     Result := ReturnStatement
   else if Match(gttThrow) then
@@ -4112,7 +4115,7 @@ begin
         end
         else if Match([gttIdentifier, gttString, gttNumber,
                        gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
-                       gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
+                       gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
                        gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
                        gttTrue, gttFalse, gttNull, gttTypeof, gttInstanceof, gttIn, gttDelete, gttVar, gttWith]) then
           { name consumed };
@@ -5172,6 +5175,18 @@ begin
   ConsumeSemicolonOrASI('Expected ";" after break statement',
     SSuggestAddSemicolon);
   Result := TGocciaBreakStatement.Create(Line, Column);
+end;
+
+function TGocciaParser.ContinueStatement: TGocciaStatement;
+var
+  Line, Column: Integer;
+begin
+  Line := Previous.Line;
+  Column := Previous.Column;
+
+  ConsumeSemicolonOrASI('Expected ";" after continue statement',
+    SSuggestAddSemicolon);
+  Result := TGocciaContinueStatement.Create(Line, Column);
 end;
 
 procedure TGocciaParser.SkipDestructuringPattern;

--- a/source/units/Goccia.Token.pas
+++ b/source/units/Goccia.Token.pas
@@ -13,7 +13,7 @@ type
     gttIdentifier,
     // Keywords
     gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
-    gttReturn, gttIf, gttElse, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak,
+    gttReturn, gttIf, gttElse, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
     gttThrow, gttTry, gttCatch, gttFinally,
     gttImport, gttExport, gttFrom, gttAs, gttGet, gttSet, gttVar, gttWith, gttFunction,
     // Operators

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -264,6 +264,8 @@ begin
     end;
     if CF.Kind = cfkBreak then
       ThrowSyntaxError(SErrorIllegalBreakStatement, SSuggestExpressionExpected);
+    if CF.Kind = cfkContinue then
+      ThrowSyntaxError(SErrorIllegalContinueStatement, SSuggestExpressionExpected);
   end;
 end;
 

--- a/tests/language/for-of/for-of-continue.js
+++ b/tests/language/for-of/for-of-continue.js
@@ -1,0 +1,122 @@
+/*---
+description: for...of with continue statement
+features: [for-of]
+---*/
+
+describe("for...of continue", () => {
+  test("continue skips current iteration", () => {
+    const result = [];
+    for (const item of [1, 2, 3, 4, 5]) {
+      if (item === 3) {
+        continue;
+      }
+      result.push(item);
+    }
+    expect(result).toEqual([1, 2, 4, 5]);
+  });
+
+  test("continue skips even values", () => {
+    const result = [];
+    for (const x of [1, 2, 3, 4]) {
+      if (x === 2) continue;
+      result.push(x);
+    }
+    expect(result).toEqual([1, 3, 4]);
+  });
+
+  test("continue in nested for...of only affects inner loop", () => {
+    const result = [];
+    for (const outer of ["a", "b"]) {
+      for (const inner of [1, 2, 3]) {
+        if (inner === 2) {
+          continue;
+        }
+        result.push(outer + inner);
+      }
+    }
+    expect(result).toEqual(["a1", "a3", "b1", "b3"]);
+  });
+
+  test("continue with all iterations skipped", () => {
+    const result = [];
+    for (const x of [1, 2, 3]) {
+      continue;
+      result.push(x);
+    }
+    expect(result).toEqual([]);
+  });
+
+  test("continue on last iteration", () => {
+    const result = [];
+    for (const x of [1, 2, 3]) {
+      if (x === 3) continue;
+      result.push(x);
+    }
+    expect(result).toEqual([1, 2]);
+  });
+
+  test("continue on first iteration", () => {
+    const result = [];
+    for (const x of [1, 2, 3]) {
+      if (x === 1) continue;
+      result.push(x);
+    }
+    expect(result).toEqual([2, 3]);
+  });
+
+  test("continue inside switch inside for-of", () => {
+    const result = [];
+    for (const x of [1, 2, 3, 4]) {
+      switch (x) {
+        case 2:
+          continue;
+        case 3:
+          continue;
+        default:
+          result.push(x);
+      }
+    }
+    expect(result).toEqual([1, 4]);
+  });
+
+  test("continue with destructuring binding", () => {
+    const pairs = [[1, "a"], [2, "b"], [3, "c"]];
+    const result = [];
+    for (const [n, s] of pairs) {
+      if (n === 2) continue;
+      result.push(s);
+    }
+    expect(result).toEqual(["a", "c"]);
+  });
+
+  test("continue and break in same loop", () => {
+    const result = [];
+    for (const x of [1, 2, 3, 4, 5]) {
+      if (x === 2) continue;
+      if (x === 4) break;
+      result.push(x);
+    }
+    expect(result).toEqual([1, 3]);
+  });
+
+  test("continue with custom iterator", () => {
+    const iterable = {
+      [Symbol.iterator]() {
+        let i = 0;
+        return {
+          next() {
+            i++;
+            return i <= 5 ? { value: i, done: false } : { done: true };
+          }
+        };
+      }
+    };
+
+    const result = [];
+    for (const x of iterable) {
+      if (x % 2 === 0) continue;
+      result.push(x);
+    }
+    expect(result).toEqual([1, 3, 5]);
+  });
+});

--- a/tests/language/for-of/for-of-continue.js
+++ b/tests/language/for-of/for-of-continue.js
@@ -119,4 +119,15 @@ describe("for...of continue", () => {
     }
     expect(result).toEqual([1, 3, 5]);
   });
+
+  test("closures capture correct iteration value across continue", () => {
+    const fns = [];
+    for (const x of [1, 2, 3, 4]) {
+      if (x % 2 === 0) continue;
+      fns.push(() => x);
+    }
+    expect(fns.length).toBe(2);
+    expect(fns[0]()).toBe(1);
+    expect(fns[1]()).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #401.

- **`continue` was completely unimplemented** — the lexer treated it as an identifier, so `continue;` inside a for-of loop produced `ReferenceError: Undefined variable: continue`
- Added the full pipeline across 11 source files: keyword constant → token type → lexer registration → control-flow kind (`cfkContinue`, tag value 3 in the 2-bit tagged-pointer scheme) → AST node → parser rule → evaluator propagation (including through `switch`) → bytecode compiler (`GContinueJumps` with pending-finally support for all three loop variants: counted for-of, iterator for-of, for-await-of) → illegal-continue guard in function bodies
- Registered `gttContinue` in all five keyword-as-property-name lists so `{ continue: "v" }` keeps working
