### PR TITLE
Support set-like operands for Set methods

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -431,7 +431,7 @@ obj[sym]; // "value"
 
 Implements the [ECMAScript Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) including Set methods (`union`, `intersection`, `difference`, `symmetricDifference`, `isSubsetOf`, `isSupersetOf`, `isDisjointFrom`).
 
-A collection of unique values with insertion-order iteration.
+A collection of unique values with insertion-order iteration. Set operation methods accept either another `Set` or a set-like object with `size`, `has(value)`, and `keys()`.
 
 | Method/Property | Description |
 |--------|-------------|

--- a/docs/value-system.md
+++ b/docs/value-system.md
@@ -408,7 +408,8 @@ Each helper creates a `TGocciaObjectValue` with `name` and `message` properties 
 
 - **Uniqueness** — Uses `IsSameValueZero` (same as `===` except `NaN === NaN` is true) to test for duplicates.
 - **Shared prototype singleton** — All set instances within an engine share a single per-engine prototype, stored in a [realm slot](core-patterns.md#realm-ownership--slot-registration). Methods are registered once during `InitializePrototype` and pinned automatically by `TGocciaRealm.SetSlot`. Each method operates through `ThisValue` to access instance data.
-- **Methods** — `add`, `has`, `delete`, `clear`, `forEach`, `values` — all registered on the shared prototype.
+- **Methods** — `add`, `has`, `delete`, `clear`, `forEach`, `values`, `keys`, `entries`, `union`, `intersection`, `difference`, `symmetricDifference`, `isSubsetOf`, `isSupersetOf`, `isDisjointFrom` — all registered on the shared prototype.
+- **Set-like operations** — Set operation methods accept either a `Set` or an object with `size`, `has(value)`, and `keys()` properties. Runtime validation follows the Set Record shape used by the ECMAScript algorithms.
 - **`size`** — Returned dynamically via `GetProperty` override.
 - **Spreadable** — `ToArray` converts to a `TGocciaArrayValue` for spread syntax support.
 

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -653,7 +653,12 @@ resourcestring
   SErrorMapForEachNotCallable = 'Map.prototype.forEach: callback is not a function';
 
   // Set operation argument errors
-  SErrorSetOperationRequiresSet = 'Set.prototype.%s: argument must be a Set';
+  SErrorSetOperationRequiresSetLike = 'Set.prototype.%s: argument must be a Set or set-like object';
+  SErrorSetLikeSizeMustBeNumber = 'Set.prototype.%s: set-like size must be a number';
+  SErrorSetLikeSizeNonNegative = 'Set.prototype.%s: set-like size must be non-negative';
+  SErrorSetLikeHasNotCallable = 'Set.prototype.%s: set-like has must be a function';
+  SErrorSetLikeKeysNotCallable = 'Set.prototype.%s: set-like keys must be a function';
+  SErrorSetLikeKeysIterator = 'Set.prototype.%s: set-like keys must return an iterator';
 
   // Map upsert errors
   SErrorMapGetOrInsertComputedNotCallable = 'Map.getOrInsertComputed: callbackfn is not a function';

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -330,7 +330,7 @@ resourcestring
   // Runtime errors — Set
   SSuggestSetThisType = 'Set prototype methods must be called on a Set instance';
   SSuggestSetCallbackRequired = 'pass a function as the callback argument';
-  SSuggestSetOperationArgType = 'pass a Set instance as the argument';
+  SSuggestSetOperationArgType = 'pass a Set instance or an object with size, has(), and keys()';
 
   // Runtime errors — Map
   SSuggestMapThisType = 'Map prototype methods must be called on a Map instance';

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -70,30 +70,18 @@ begin
   if not (NextResult is TGocciaObjectValue) then
     ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.TypeName]), SSuggestIteratorResultObject);
 
-  if NextResult is TGocciaObjectValue then
-  begin
-    DoneVal := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
-    if Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value then
-    begin
-      FDone := True;
-      ValueVal := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-      if not Assigned(ValueVal) then
-        ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Result := CreateIteratorResult(ValueVal, True);
-    end
-    else
-    begin
-      ValueVal := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-      if not Assigned(ValueVal) then
-        ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Result := CreateIteratorResult(ValueVal, False);
-    end;
-  end
-  else
+  DoneVal := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
+  ValueVal := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+  if not Assigned(ValueVal) then
+    ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  if Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value then
   begin
     FDone := True;
-    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-  end;
+    Result := CreateIteratorResult(ValueVal, True);
+  end
+  else
+    Result := CreateIteratorResult(ValueVal, False);
 end;
 
 function TGocciaGenericIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
@@ -127,33 +115,19 @@ begin
   if not (NextResult is TGocciaObjectValue) then
     ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.TypeName]), SSuggestIteratorResultObject);
 
-  if NextResult is TGocciaObjectValue then
-  begin
-    DoneVal := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
-    if Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value then
-    begin
-      FDone := True;
-      ADone := True;
-      ValueVal := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-      if not Assigned(ValueVal) then
-        ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Result := ValueVal;
-    end
-    else
-    begin
-      ADone := False;
-      ValueVal := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-      if not Assigned(ValueVal) then
-        ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Result := ValueVal;
-    end;
-  end
-  else
+  DoneVal := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
+  ValueVal := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+  if not Assigned(ValueVal) then
+    ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  if Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value then
   begin
     FDone := True;
     ADone := True;
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  end;
+  end
+  else
+    ADone := False;
+  Result := ValueVal;
 end;
 
 procedure TGocciaGenericIteratorValue.Close;

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -24,6 +24,8 @@ type
 implementation
 
 uses
+  SysUtils,
+
   Goccia.Arguments.Collection,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
@@ -64,6 +66,9 @@ begin
   finally
     CallArgs.Free;
   end;
+
+  if not (NextResult is TGocciaObjectValue) then
+    ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.TypeName]), SSuggestIteratorResultObject);
 
   if NextResult is TGocciaObjectValue then
   begin
@@ -118,6 +123,9 @@ begin
   finally
     CallArgs.Free;
   end;
+
+  if not (NextResult is TGocciaObjectValue) then
+    ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.TypeName]), SSuggestIteratorResultObject);
 
   if NextResult is TGocciaObjectValue then
   begin

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -72,9 +72,19 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.Iterator.Concrete,
+  Goccia.Values.Iterator.Generic,
+  Goccia.Values.IteratorValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
+
+type
+  TGocciaSetRecord = record
+    SetObject: TGocciaObjectValue;
+    Size: Double;
+    HasMethod: TGocciaValue;
+    KeysMethod: TGocciaValue;
+  end;
 
 var
   GSetSharedSlot: TGocciaRealmOwnedSlotId;
@@ -88,6 +98,94 @@ begin
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GSetSharedSlot))
   else
     Result := nil;
+end;
+
+function SetDataIndex(const AItems: TGocciaValueList; const AValue: TGocciaValue): Integer;
+var
+  I: Integer;
+begin
+  for I := 0 to AItems.Count - 1 do
+    if IsSameValueZero(AItems[I], AValue) then
+      Exit(I);
+  Result := -1;
+end;
+
+procedure RemoveSetItem(const ASet: TGocciaSetValue; const AValue: TGocciaValue);
+var
+  Index: Integer;
+begin
+  Index := SetDataIndex(ASet.FItems, AValue);
+  if Index >= 0 then
+    ASet.FItems.Delete(Index);
+end;
+
+function GetSetRecord(const AValue: TGocciaValue; const AMethodName: string): TGocciaSetRecord;
+var
+  RawSize: TGocciaValue;
+  NumberSize: TGocciaNumberLiteralValue;
+begin
+  // ES2026 §24.2.1.2 GetSetRecord(obj)
+  if not (AValue is TGocciaObjectValue) then
+    ThrowTypeError(Format(SErrorSetOperationRequiresSetLike, [AMethodName]), SSuggestSetOperationArgType);
+
+  Result.SetObject := TGocciaObjectValue(AValue);
+  RawSize := Result.SetObject.GetProperty(PROP_SIZE);
+  NumberSize := RawSize.ToNumberLiteral;
+  if NumberSize.IsNaN then
+    ThrowTypeError(Format(SErrorSetLikeSizeMustBeNumber, [AMethodName]), SSuggestSetOperationArgType);
+  if NumberSize.Value < 0 then
+    ThrowRangeError(Format(SErrorSetLikeSizeNonNegative, [AMethodName]), SSuggestSetOperationArgType);
+  if NumberSize.IsInfinity then
+    Result.Size := NumberSize.Value
+  else
+    Result.Size := Trunc(NumberSize.Value);
+
+  Result.HasMethod := Result.SetObject.GetProperty(PROP_HAS);
+  if not Result.HasMethod.IsCallable then
+    ThrowTypeError(Format(SErrorSetLikeHasNotCallable, [AMethodName]), SSuggestSetOperationArgType);
+
+  Result.KeysMethod := Result.SetObject.GetProperty(PROP_KEYS);
+  if not Result.KeysMethod.IsCallable then
+    ThrowTypeError(Format(SErrorSetLikeKeysNotCallable, [AMethodName]), SSuggestSetOperationArgType);
+end;
+
+function SetRecordHas(const ARecord: TGocciaSetRecord; const AValue: TGocciaValue): Boolean;
+var
+  CallArgs: TGocciaArgumentsCollection;
+begin
+  CallArgs := TGocciaArgumentsCollection.Create([AValue]);
+  try
+    Result := InvokeCallable(ARecord.HasMethod, CallArgs, ARecord.SetObject).ToBooleanLiteral.Value;
+  finally
+    CallArgs.Free;
+  end;
+end;
+
+function GetSetRecordKeysIterator(const ARecord: TGocciaSetRecord; const AMethodName: string): TGocciaIteratorValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  IteratorObject, NextMethod: TGocciaValue;
+begin
+  // ES2026 §24.2.4 Set operation methods: GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]])
+  CallArgs := TGocciaArgumentsCollection.Create;
+  try
+    IteratorObject := InvokeCallable(ARecord.KeysMethod, CallArgs, ARecord.SetObject);
+  finally
+    CallArgs.Free;
+  end;
+
+  if IteratorObject is TGocciaIteratorValue then
+    Exit(TGocciaIteratorValue(IteratorObject));
+
+  if IteratorObject is TGocciaObjectValue then
+  begin
+    NextMethod := TGocciaObjectValue(IteratorObject).GetProperty(PROP_NEXT);
+    if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
+      Exit(TGocciaGenericIteratorValue.Create(IteratorObject));
+  end;
+
+  ThrowTypeError(Format(SErrorSetLikeKeysIterator, [AMethodName]), SSuggestIteratorProtocol);
+  Result := nil;
 end;
 
 constructor TGocciaSetValue.Create(const AClass: TGocciaClassValue = nil);
@@ -203,18 +301,8 @@ begin
 end;
 
 function TGocciaSetValue.ContainsValue(const AValue: TGocciaValue): Boolean;
-var
-  I: Integer;
 begin
-  for I := 0 to FItems.Count - 1 do
-  begin
-    if IsSameValueZero(FItems[I], AValue) then
-    begin
-      Result := True;
-      Exit;
-    end;
-  end;
-  Result := False;
+  Result := SetDataIndex(FItems, AValue) >= 0;
 end;
 
 procedure TGocciaSetValue.AddItem(const AValue: TGocciaValue);
@@ -433,8 +521,13 @@ end;
 // ES2026 §24.2.3.12 Set.prototype.union(other)
 function TGocciaSetValue.SetUnion(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  ThisSet, OtherSet, ResultSet: TGocciaSetValue;
+  ThisSet, ResultSet: TGocciaSetValue;
+  OtherRecord: TGocciaSetRecord;
+  Iterator: TGocciaIteratorValue;
+  NextValue: TGocciaValue;
+  Done, WasResultRooted, WasIteratorRooted: Boolean;
   I: Integer;
+  GC: TGarbageCollector;
 begin
   // Step 1: Let O be the this value
   // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
@@ -442,31 +535,55 @@ begin
     ThrowTypeError(SErrorSetUnionNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
-  if not (AArgs.GetElement(0) is TGocciaSetValue) then
-    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['union']), SSuggestSetOperationArgType);
-  OtherSet := TGocciaSetValue(AArgs.GetElement(0));
+  OtherRecord := GetSetRecord(AArgs.GetElement(0), 'union');
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
   ResultSet := TGocciaSetValue.Create;
+  GC := TGarbageCollector.Instance;
+  WasResultRooted := Assigned(GC) and GC.IsTempRoot(ResultSet);
+  if Assigned(GC) and not WasResultRooted then
+    GC.AddTempRoot(ResultSet);
+  try
+    for I := 0 to ThisSet.FItems.Count - 1 do
+      ResultSet.AddItem(ThisSet.FItems[I]);
+    // Step 6: Let keysIter be GetIteratorFromSetLike(otherRec)
+    Iterator := GetSetRecordKeysIterator(OtherRecord, 'union');
+    WasIteratorRooted := Assigned(GC) and GC.IsTempRoot(Iterator);
+    if Assigned(GC) and not WasIteratorRooted then
+      GC.AddTempRoot(Iterator);
+    try
+      // Step 7: For each element nextValue from keysIter, do
+      NextValue := Iterator.DirectNext(Done);
+      while not Done do
+      begin
+        // If nextValue is not already in resultSetData, append nextValue
+        ResultSet.AddItem(NextValue);
+        NextValue := Iterator.DirectNext(Done);
+      end;
+    finally
+      if Assigned(GC) and not WasIteratorRooted then
+        GC.RemoveTempRoot(Iterator);
+    end;
 
-  for I := 0 to ThisSet.FItems.Count - 1 do
-    ResultSet.AddItem(ThisSet.FItems[I]);
-  // Step 6: Let keysIter be GetIteratorFromSetLike(otherRec)
-  // Step 7: For each element nextValue from keysIter, do
-  //   If nextValue is not already in resultSetData, append nextValue
-  for I := 0 to OtherSet.FItems.Count - 1 do
-    ResultSet.AddItem(OtherSet.FItems[I]);
-
-  // Step 8: Let result be OrdinaryObjectCreate(SetPrototype, « [[SetData]] »)
-  // Step 9: Set result.[[SetData]] to resultSetData
-  // Step 10: Return result
-  Result := ResultSet;
+    // Step 8: Let result be OrdinaryObjectCreate(SetPrototype, « [[SetData]] »)
+    // Step 9: Set result.[[SetData]] to resultSetData
+    // Step 10: Return result
+    Result := ResultSet;
+  finally
+    if Assigned(GC) and not WasResultRooted then
+      GC.RemoveTempRoot(ResultSet);
+  end;
 end;
 
 // ES2026 §24.2.3.7 Set.prototype.intersection(other)
 function TGocciaSetValue.SetIntersection(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  ThisSet, OtherSet, ResultSet: TGocciaSetValue;
+  ThisSet, ResultSet: TGocciaSetValue;
+  OtherRecord: TGocciaSetRecord;
+  Iterator: TGocciaIteratorValue;
+  NextValue: TGocciaValue;
+  Done, WasResultRooted, WasIteratorRooted: Boolean;
   I: Integer;
+  GC: TGarbageCollector;
 begin
   // Step 1: Let O be the this value
   // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
@@ -474,29 +591,62 @@ begin
     ThrowTypeError(SErrorSetIntersectionNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
-  if not (AArgs.GetElement(0) is TGocciaSetValue) then
-    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['intersection']), SSuggestSetOperationArgType);
-  OtherSet := TGocciaSetValue(AArgs.GetElement(0));
+  OtherRecord := GetSetRecord(AArgs.GetElement(0), 'intersection');
   // Step 5: Let resultSetData be a new empty List
   ResultSet := TGocciaSetValue.Create;
+  GC := TGarbageCollector.Instance;
+  WasResultRooted := Assigned(GC) and GC.IsTempRoot(ResultSet);
+  if Assigned(GC) and not WasResultRooted then
+    GC.AddTempRoot(ResultSet);
+  try
+    if ThisSet.FItems.Count <= OtherRecord.Size then
+    begin
+      // Step 6: For each element e of O.[[SetData]], do
+      for I := 0 to ThisSet.FItems.Count - 1 do
+        // Step 6a: If e is not empty and SetDataHas(otherRec, e) is true, append e
+        if SetRecordHas(OtherRecord, ThisSet.FItems[I]) then
+          ResultSet.AddItem(ThisSet.FItems[I]);
+    end
+    else
+    begin
+      Iterator := GetSetRecordKeysIterator(OtherRecord, 'intersection');
+      WasIteratorRooted := Assigned(GC) and GC.IsTempRoot(Iterator);
+      if Assigned(GC) and not WasIteratorRooted then
+        GC.AddTempRoot(Iterator);
+      try
+        NextValue := Iterator.DirectNext(Done);
+        while not Done do
+        begin
+          if ThisSet.ContainsValue(NextValue) then
+            ResultSet.AddItem(NextValue);
+          NextValue := Iterator.DirectNext(Done);
+        end;
+      finally
+        if Assigned(GC) and not WasIteratorRooted then
+          GC.RemoveTempRoot(Iterator);
+      end;
+    end;
 
-  // Step 6: For each element e of O.[[SetData]], do
-  for I := 0 to ThisSet.FItems.Count - 1 do
-    // Step 6a: If e is not empty and SetDataHas(otherRec, e) is true, append e
-    if OtherSet.ContainsValue(ThisSet.FItems[I]) then
-      ResultSet.AddItem(ThisSet.FItems[I]);
-
-  // Step 7: Let result be OrdinaryObjectCreate(SetPrototype, « [[SetData]] »)
-  // Step 8: Set result.[[SetData]] to resultSetData
-  // Step 9: Return result
-  Result := ResultSet;
+    // Step 7: Let result be OrdinaryObjectCreate(SetPrototype, « [[SetData]] »)
+    // Step 8: Set result.[[SetData]] to resultSetData
+    // Step 9: Return result
+    Result := ResultSet;
+  finally
+    if Assigned(GC) and not WasResultRooted then
+      GC.RemoveTempRoot(ResultSet);
+  end;
 end;
 
 // ES2026 §24.2.3.3 Set.prototype.difference(other)
 function TGocciaSetValue.SetDifference(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  ThisSet, OtherSet, ResultSet: TGocciaSetValue;
+  ThisSet, ResultSet: TGocciaSetValue;
+  OtherRecord: TGocciaSetRecord;
+  Iterator: TGocciaIteratorValue;
+  NextValue: TGocciaValue;
+  Done, WasResultRooted, WasIteratorRooted: Boolean;
   I: Integer;
+  GC: TGarbageCollector;
 begin
   // Step 1: Let O be the this value
   // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
@@ -504,29 +654,64 @@ begin
     ThrowTypeError(SErrorSetDifferenceNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
-  if not (AArgs.GetElement(0) is TGocciaSetValue) then
-    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['difference']), SSuggestSetOperationArgType);
-  OtherSet := TGocciaSetValue(AArgs.GetElement(0));
+  OtherRecord := GetSetRecord(AArgs.GetElement(0), 'difference');
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
   ResultSet := TGocciaSetValue.Create;
+  GC := TGarbageCollector.Instance;
+  WasResultRooted := Assigned(GC) and GC.IsTempRoot(ResultSet);
+  if Assigned(GC) and not WasResultRooted then
+    GC.AddTempRoot(ResultSet);
+  try
+    if ThisSet.FItems.Count <= OtherRecord.Size then
+    begin
+      // Step 6: For each element e of resultSetData, do
+      for I := 0 to ThisSet.FItems.Count - 1 do
+        // Step 6a: If e is not empty and SetDataHas(otherRec, e) is true, remove e
+        if not SetRecordHas(OtherRecord, ThisSet.FItems[I]) then
+          ResultSet.AddItem(ThisSet.FItems[I]);
+    end
+    else
+    begin
+      for I := 0 to ThisSet.FItems.Count - 1 do
+        ResultSet.AddItem(ThisSet.FItems[I]);
 
-  // Step 6: For each element e of resultSetData, do
-  for I := 0 to ThisSet.FItems.Count - 1 do
-    // Step 6a: If e is not empty and SetDataHas(otherRec, e) is true, remove e
-    if not OtherSet.ContainsValue(ThisSet.FItems[I]) then
-      ResultSet.AddItem(ThisSet.FItems[I]);
+      Iterator := GetSetRecordKeysIterator(OtherRecord, 'difference');
+      WasIteratorRooted := Assigned(GC) and GC.IsTempRoot(Iterator);
+      if Assigned(GC) and not WasIteratorRooted then
+        GC.AddTempRoot(Iterator);
+      try
+        NextValue := Iterator.DirectNext(Done);
+        while not Done do
+        begin
+          RemoveSetItem(ResultSet, NextValue);
+          NextValue := Iterator.DirectNext(Done);
+        end;
+      finally
+        if Assigned(GC) and not WasIteratorRooted then
+          GC.RemoveTempRoot(Iterator);
+      end;
+    end;
 
-  // Step 7: Let result be OrdinaryObjectCreate(SetPrototype, « [[SetData]] »)
-  // Step 8: Set result.[[SetData]] to resultSetData
-  // Step 9: Return result
-  Result := ResultSet;
+    // Step 7: Let result be OrdinaryObjectCreate(SetPrototype, « [[SetData]] »)
+    // Step 8: Set result.[[SetData]] to resultSetData
+    // Step 9: Return result
+    Result := ResultSet;
+  finally
+    if Assigned(GC) and not WasResultRooted then
+      GC.RemoveTempRoot(ResultSet);
+  end;
 end;
 
 // ES2026 §24.2.3.9 Set.prototype.symmetricDifference(other)
 function TGocciaSetValue.SetSymmetricDifference(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  ThisSet, OtherSet, ResultSet: TGocciaSetValue;
+  ThisSet, ResultSet: TGocciaSetValue;
+  OtherRecord: TGocciaSetRecord;
+  Iterator: TGocciaIteratorValue;
+  NextValue: TGocciaValue;
+  Done, WasResultRooted, WasIteratorRooted: Boolean;
   I: Integer;
+  GC: TGarbageCollector;
 begin
   // Step 1: Let O be the this value
   // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
@@ -534,34 +719,54 @@ begin
     ThrowTypeError(SErrorSetSymmetricDifferenceNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
-  if not (AArgs.GetElement(0) is TGocciaSetValue) then
-    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['symmetricDifference']), SSuggestSetOperationArgType);
-  OtherSet := TGocciaSetValue(AArgs.GetElement(0));
+  OtherRecord := GetSetRecord(AArgs.GetElement(0), 'symmetricDifference');
   // Step 5: Let resultSetData be a copy of O.[[SetData]]
   ResultSet := TGocciaSetValue.Create;
-
-  // Step 6: Remove elements from resultSetData that are in other
-  for I := 0 to ThisSet.FItems.Count - 1 do
-    if not OtherSet.ContainsValue(ThisSet.FItems[I]) then
+  GC := TGarbageCollector.Instance;
+  WasResultRooted := Assigned(GC) and GC.IsTempRoot(ResultSet);
+  if Assigned(GC) and not WasResultRooted then
+    GC.AddTempRoot(ResultSet);
+  try
+    for I := 0 to ThisSet.FItems.Count - 1 do
       ResultSet.AddItem(ThisSet.FItems[I]);
 
-  // Step 7: Let keysIter be GetIteratorFromSetLike(otherRec)
-  // Step 8: For each element nextValue from keysIter, do
-  //   If nextValue was in O.[[SetData]], it was already removed; otherwise append it
-  for I := 0 to OtherSet.FItems.Count - 1 do
-    if not ThisSet.ContainsValue(OtherSet.FItems[I]) then
-      ResultSet.AddItem(OtherSet.FItems[I]);
+    // Step 7: Let keysIter be GetIteratorFromSetLike(otherRec)
+    Iterator := GetSetRecordKeysIterator(OtherRecord, 'symmetricDifference');
+    WasIteratorRooted := Assigned(GC) and GC.IsTempRoot(Iterator);
+    if Assigned(GC) and not WasIteratorRooted then
+      GC.AddTempRoot(Iterator);
+    try
+      // Step 8: For each element nextValue from keysIter, do
+      NextValue := Iterator.DirectNext(Done);
+      while not Done do
+      begin
+        // If nextValue was in O.[[SetData]], remove it; otherwise append it
+        if ThisSet.ContainsValue(NextValue) then
+          RemoveSetItem(ResultSet, NextValue)
+        else
+          ResultSet.AddItem(NextValue);
+        NextValue := Iterator.DirectNext(Done);
+      end;
+    finally
+      if Assigned(GC) and not WasIteratorRooted then
+        GC.RemoveTempRoot(Iterator);
+    end;
 
-  // Step 9: Let result be OrdinaryObjectCreate(SetPrototype, « [[SetData]] »)
-  // Step 10: Set result.[[SetData]] to resultSetData
-  // Step 11: Return result
-  Result := ResultSet;
+    // Step 9: Let result be OrdinaryObjectCreate(SetPrototype, « [[SetData]] »)
+    // Step 10: Set result.[[SetData]] to resultSetData
+    // Step 11: Return result
+    Result := ResultSet;
+  finally
+    if Assigned(GC) and not WasResultRooted then
+      GC.RemoveTempRoot(ResultSet);
+  end;
 end;
 
 // ES2026 §24.2.3.8 Set.prototype.isSubsetOf(other)
 function TGocciaSetValue.SetIsSubsetOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  ThisSet, OtherSet: TGocciaSetValue;
+  ThisSet: TGocciaSetValue;
+  OtherRecord: TGocciaSetRecord;
   I: Integer;
 begin
   // Step 1: Let O be the this value
@@ -570,15 +775,19 @@ begin
     ThrowTypeError(SErrorSetIsSubsetOfNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
-  if not (AArgs.GetElement(0) is TGocciaSetValue) then
-    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['isSubsetOf']), SSuggestSetOperationArgType);
-  OtherSet := TGocciaSetValue(AArgs.GetElement(0));
+  OtherRecord := GetSetRecord(AArgs.GetElement(0), 'isSubsetOf');
 
   // Step 5: If SetDataSize(O) > otherRec.[[Size]], return false (optimization)
+  if ThisSet.FItems.Count > OtherRecord.Size then
+  begin
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+
   // Step 6: For each element e of O.[[SetData]], do
   for I := 0 to ThisSet.FItems.Count - 1 do
     // Step 6a: If SetDataHas(otherRec, e) is false, return false
-    if not OtherSet.ContainsValue(ThisSet.FItems[I]) then
+    if not SetRecordHas(OtherRecord, ThisSet.FItems[I]) then
     begin
       Result := TGocciaBooleanLiteralValue.FalseValue;
       Exit;
@@ -591,8 +800,12 @@ end;
 // ES2026 §24.2.3.9 Set.prototype.isSupersetOf(other)
 function TGocciaSetValue.SetIsSupersetOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  ThisSet, OtherSet: TGocciaSetValue;
-  I: Integer;
+  ThisSet: TGocciaSetValue;
+  OtherRecord: TGocciaSetRecord;
+  Iterator: TGocciaIteratorValue;
+  NextValue: TGocciaValue;
+  Done, WasIteratorRooted: Boolean;
+  GC: TGarbageCollector;
 begin
   // Step 1: Let O be the this value
   // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
@@ -600,20 +813,39 @@ begin
     ThrowTypeError(SErrorSetIsSupersetOfNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
-  if not (AArgs.GetElement(0) is TGocciaSetValue) then
-    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['isSupersetOf']), SSuggestSetOperationArgType);
-  OtherSet := TGocciaSetValue(AArgs.GetElement(0));
+  OtherRecord := GetSetRecord(AArgs.GetElement(0), 'isSupersetOf');
 
   // Step 5: If SetDataSize(O) < otherRec.[[Size]], return false (optimization)
+  if ThisSet.FItems.Count < OtherRecord.Size then
+  begin
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+
   // Step 6: Let keysIter be GetIteratorFromSetLike(otherRec)
-  // Step 7: For each element nextValue from keysIter, do
-  for I := 0 to OtherSet.FItems.Count - 1 do
-    // Step 7a: If SetDataHas(O, nextValue) is false, return false
-    if not ThisSet.ContainsValue(OtherSet.FItems[I]) then
+  Iterator := GetSetRecordKeysIterator(OtherRecord, 'isSupersetOf');
+  GC := TGarbageCollector.Instance;
+  WasIteratorRooted := Assigned(GC) and GC.IsTempRoot(Iterator);
+  if Assigned(GC) and not WasIteratorRooted then
+    GC.AddTempRoot(Iterator);
+  try
+    // Step 7: For each element nextValue from keysIter, do
+    NextValue := Iterator.DirectNext(Done);
+    while not Done do
     begin
-      Result := TGocciaBooleanLiteralValue.FalseValue;
-      Exit;
+      // Step 7a: If SetDataHas(O, nextValue) is false, return false
+      if not ThisSet.ContainsValue(NextValue) then
+      begin
+        Iterator.Close;
+        Result := TGocciaBooleanLiteralValue.FalseValue;
+        Exit;
+      end;
+      NextValue := Iterator.DirectNext(Done);
     end;
+  finally
+    if Assigned(GC) and not WasIteratorRooted then
+      GC.RemoveTempRoot(Iterator);
+  end;
 
   // Step 8: Return true
   Result := TGocciaBooleanLiteralValue.TrueValue;
@@ -622,8 +854,13 @@ end;
 // ES2026 §24.2.3.6 Set.prototype.isDisjointFrom(other)
 function TGocciaSetValue.SetIsDisjointFrom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  ThisSet, OtherSet: TGocciaSetValue;
+  ThisSet: TGocciaSetValue;
+  OtherRecord: TGocciaSetRecord;
+  Iterator: TGocciaIteratorValue;
+  NextValue: TGocciaValue;
+  Done, WasIteratorRooted: Boolean;
   I: Integer;
+  GC: TGarbageCollector;
 begin
   // Step 1: Let O be the this value
   // Steps 2-3: If O does not have a [[SetData]] internal slot, throw a TypeError
@@ -631,18 +868,43 @@ begin
     ThrowTypeError(SErrorSetIsDisjointFromNonSet, SSuggestSetThisType);
   ThisSet := TGocciaSetValue(AThisValue);
   // Step 4: Let otherRec be GetSetRecord(other)
-  if not (AArgs.GetElement(0) is TGocciaSetValue) then
-    ThrowTypeError(Format(SErrorSetOperationRequiresSet, ['isDisjointFrom']), SSuggestSetOperationArgType);
-  OtherSet := TGocciaSetValue(AArgs.GetElement(0));
+  OtherRecord := GetSetRecord(AArgs.GetElement(0), 'isDisjointFrom');
 
-  // Step 5: For each element e of O.[[SetData]], do
-  for I := 0 to ThisSet.FItems.Count - 1 do
-    // Step 5a: If e is not empty and SetDataHas(otherRec, e) is true, return false
-    if OtherSet.ContainsValue(ThisSet.FItems[I]) then
-    begin
-      Result := TGocciaBooleanLiteralValue.FalseValue;
-      Exit;
+  if ThisSet.FItems.Count <= OtherRecord.Size then
+  begin
+    // Step 5: For each element e of O.[[SetData]], do
+    for I := 0 to ThisSet.FItems.Count - 1 do
+      // Step 5a: If e is not empty and SetDataHas(otherRec, e) is true, return false
+      if SetRecordHas(OtherRecord, ThisSet.FItems[I]) then
+      begin
+        Result := TGocciaBooleanLiteralValue.FalseValue;
+        Exit;
+      end;
+  end
+  else
+  begin
+    Iterator := GetSetRecordKeysIterator(OtherRecord, 'isDisjointFrom');
+    GC := TGarbageCollector.Instance;
+    WasIteratorRooted := Assigned(GC) and GC.IsTempRoot(Iterator);
+    if Assigned(GC) and not WasIteratorRooted then
+      GC.AddTempRoot(Iterator);
+    try
+      NextValue := Iterator.DirectNext(Done);
+      while not Done do
+      begin
+        if ThisSet.ContainsValue(NextValue) then
+        begin
+          Iterator.Close;
+          Result := TGocciaBooleanLiteralValue.FalseValue;
+          Exit;
+        end;
+        NextValue := Iterator.DirectNext(Done);
+      end;
+    finally
+      if Assigned(GC) and not WasIteratorRooted then
+        GC.RemoveTempRoot(Iterator);
     end;
+  end;
 
   // Step 6: Return true
   Result := TGocciaBooleanLiteralValue.TrueValue;

--- a/tests/built-ins/Iterator/from.js
+++ b/tests/built-ins/Iterator/from.js
@@ -74,6 +74,16 @@ describe("Iterator.from()", () => {
     expect(iter.next().done).toBe(true);
   });
 
+  test("wrapped iterator throws TypeError when next returns non-object", () => {
+    const iteratorLike = {
+      next() {
+        return 1;
+      }
+    };
+    const iter = Iterator.from(iteratorLike);
+    expect(() => iter.next()).toThrow(TypeError);
+  });
+
   test("wrapped iterator has helper methods", () => {
     const set = new Set([1, 2, 3, 4, 5]);
     const result = Iterator.from(set).filter((x) => x > 2).toArray();

--- a/tests/built-ins/Set/prototype/difference.js
+++ b/tests/built-ins/Set/prototype/difference.js
@@ -20,6 +20,38 @@ describe("Set.prototype.difference", () => {
     expect(a.difference(b).size).toBe(0);
   });
 
+  test("accepts set-like object", () => {
+    const setLike = {
+      size: 10,
+      has(value) {
+        return value === 2 || value === 4;
+      },
+      keys() {
+        return [2, 4].values();
+      },
+    };
+    const result = new Set([1, 2, 3, 4]).difference(setLike);
+    expect(result.size).toBe(2);
+    expect(result.has(1)).toBe(true);
+    expect(result.has(3)).toBe(true);
+  });
+
+  test("uses set-like keys when other size is smaller", () => {
+    const setLike = {
+      size: 1,
+      has(value) {
+        return value === 2 || value === 4;
+      },
+      keys() {
+        return [2, 4, 4].values();
+      },
+    };
+    const result = new Set([1, 2, 3, 4]).difference(setLike);
+    expect(result.size).toBe(2);
+    expect(result.has(1)).toBe(true);
+    expect(result.has(3)).toBe(true);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const difference = Set.prototype.difference;
     expect(() => difference.call(Set.prototype, new Set())).toThrow(TypeError);
@@ -27,7 +59,7 @@ describe("Set.prototype.difference", () => {
     expect(() => difference.call(new Map(), new Set())).toThrow(TypeError);
   });
 
-  test("throws TypeError when argument is not a Set", () => {
+  test("throws TypeError when argument is not set-like", () => {
     const s = new Set([1, 2]);
     expect(() => s.difference({})).toThrow(TypeError);
     expect(() => s.difference([])).toThrow(TypeError);

--- a/tests/built-ins/Set/prototype/difference.js
+++ b/tests/built-ins/Set/prototype/difference.js
@@ -37,16 +37,19 @@ describe("Set.prototype.difference", () => {
   });
 
   test("uses set-like keys when other size is smaller", () => {
+    let hasCalls = 0;
     const setLike = {
       size: 1,
       has(value) {
-        return value === 2 || value === 4;
+        hasCalls = hasCalls + 1;
+        throw new Error("difference should use keys() when other size is smaller");
       },
       keys() {
         return [2, 4, 4].values();
       },
     };
     const result = new Set([1, 2, 3, 4]).difference(setLike);
+    expect(hasCalls).toBe(0);
     expect(result.size).toBe(2);
     expect(result.has(1)).toBe(true);
     expect(result.has(3)).toBe(true);

--- a/tests/built-ins/Set/prototype/intersection.js
+++ b/tests/built-ins/Set/prototype/intersection.js
@@ -19,6 +19,38 @@ describe("Set.prototype.intersection", () => {
     expect(a.intersection(new Set()).size).toBe(0);
   });
 
+  test("accepts set-like object", () => {
+    const setLike = {
+      size: 10,
+      has(value) {
+        return value === 2 || value === 4;
+      },
+      keys() {
+        return [2, 4].values();
+      },
+    };
+    const result = new Set([1, 2, 3, 4]).intersection(setLike);
+    expect(result.size).toBe(2);
+    expect(result.has(2)).toBe(true);
+    expect(result.has(4)).toBe(true);
+  });
+
+  test("uses set-like keys when other size is smaller", () => {
+    const setLike = {
+      size: 1,
+      has(value) {
+        return value === 2 || value === 4;
+      },
+      keys() {
+        return [2, 4, 4].values();
+      },
+    };
+    const result = new Set([1, 2, 3, 4]).intersection(setLike);
+    expect(result.size).toBe(2);
+    expect(result.has(2)).toBe(true);
+    expect(result.has(4)).toBe(true);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const intersection = Set.prototype.intersection;
     expect(() => intersection.call(Set.prototype, new Set())).toThrow(TypeError);
@@ -26,7 +58,7 @@ describe("Set.prototype.intersection", () => {
     expect(() => intersection.call(new Map(), new Set())).toThrow(TypeError);
   });
 
-  test("throws TypeError when argument is not a Set", () => {
+  test("throws TypeError when argument is not set-like", () => {
     const s = new Set([1, 2]);
     expect(() => s.intersection({})).toThrow(TypeError);
     expect(() => s.intersection([])).toThrow(TypeError);

--- a/tests/built-ins/Set/prototype/intersection.js
+++ b/tests/built-ins/Set/prototype/intersection.js
@@ -39,7 +39,7 @@ describe("Set.prototype.intersection", () => {
     const setLike = {
       size: 1,
       has(value) {
-        return value === 2 || value === 4;
+        return value === 2;
       },
       keys() {
         return [2, 4, 4].values();

--- a/tests/built-ins/Set/prototype/intersection.js
+++ b/tests/built-ins/Set/prototype/intersection.js
@@ -39,7 +39,7 @@ describe("Set.prototype.intersection", () => {
     const setLike = {
       size: 1,
       has(value) {
-        return value === 2;
+        throw new Error("has should not be called");
       },
       keys() {
         return [2, 4, 4].values();

--- a/tests/built-ins/Set/prototype/isDisjointFrom.js
+++ b/tests/built-ins/Set/prototype/isDisjointFrom.js
@@ -34,10 +34,12 @@ describe("Set.prototype.isDisjointFrom", () => {
   });
 
   test("uses set-like keys when other size is smaller", () => {
+    let hasCalls = 0;
     const setLike = {
       size: 1,
       has(value) {
-        return value === 3 || value === 4;
+        hasCalls = hasCalls + 1;
+        throw new Error("isDisjointFrom should use keys() when other size is smaller");
       },
       keys() {
         return [3, 4].values();
@@ -45,6 +47,7 @@ describe("Set.prototype.isDisjointFrom", () => {
     };
     expect(new Set([1, 2]).isDisjointFrom(setLike)).toBe(true);
     expect(new Set([2, 3]).isDisjointFrom(setLike)).toBe(false);
+    expect(hasCalls).toBe(0);
   });
 
   test("throws TypeError when called on non-Set", () => {

--- a/tests/built-ins/Set/prototype/isDisjointFrom.js
+++ b/tests/built-ins/Set/prototype/isDisjointFrom.js
@@ -19,6 +19,34 @@ describe("Set.prototype.isDisjointFrom", () => {
     expect(new Set().isDisjointFrom(new Set([1, 2]))).toBe(true);
   });
 
+  test("accepts set-like object", () => {
+    const setLike = {
+      size: 10,
+      has(value) {
+        return value === 3 || value === 4;
+      },
+      keys() {
+        return [3, 4].values();
+      },
+    };
+    expect(new Set([1, 2]).isDisjointFrom(setLike)).toBe(true);
+    expect(new Set([2, 3]).isDisjointFrom(setLike)).toBe(false);
+  });
+
+  test("uses set-like keys when other size is smaller", () => {
+    const setLike = {
+      size: 1,
+      has(value) {
+        return value === 3 || value === 4;
+      },
+      keys() {
+        return [3, 4].values();
+      },
+    };
+    expect(new Set([1, 2]).isDisjointFrom(setLike)).toBe(true);
+    expect(new Set([2, 3]).isDisjointFrom(setLike)).toBe(false);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const isDisjointFrom = Set.prototype.isDisjointFrom;
     expect(() => isDisjointFrom.call(Set.prototype, new Set())).toThrow(TypeError);
@@ -26,7 +54,7 @@ describe("Set.prototype.isDisjointFrom", () => {
     expect(() => isDisjointFrom.call(new Map(), new Set())).toThrow(TypeError);
   });
 
-  test("throws TypeError when argument is not a Set", () => {
+  test("throws TypeError when argument is not set-like", () => {
     const s = new Set([1, 2]);
     expect(() => s.isDisjointFrom({})).toThrow(TypeError);
     expect(() => s.isDisjointFrom([])).toThrow(TypeError);

--- a/tests/built-ins/Set/prototype/isSubsetOf.js
+++ b/tests/built-ins/Set/prototype/isSubsetOf.js
@@ -22,6 +22,20 @@ describe("Set.prototype.isSubsetOf", () => {
     expect(a.isSubsetOf(b)).toBe(true);
   });
 
+  test("accepts set-like object", () => {
+    const setLike = {
+      size: 3,
+      has(value) {
+        return value === 1 || value === 2 || value === 3;
+      },
+      keys() {
+        return [1, 2, 3].values();
+      },
+    };
+    expect(new Set([1, 2]).isSubsetOf(setLike)).toBe(true);
+    expect(new Set([1, 4]).isSubsetOf(setLike)).toBe(false);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const isSubsetOf = Set.prototype.isSubsetOf;
     expect(() => isSubsetOf.call(Set.prototype, new Set())).toThrow(TypeError);
@@ -29,7 +43,7 @@ describe("Set.prototype.isSubsetOf", () => {
     expect(() => isSubsetOf.call(new Map(), new Set())).toThrow(TypeError);
   });
 
-  test("throws TypeError when argument is not a Set", () => {
+  test("throws TypeError when argument is not set-like", () => {
     const s = new Set([1, 2]);
     expect(() => s.isSubsetOf({})).toThrow(TypeError);
     expect(() => s.isSubsetOf([])).toThrow(TypeError);

--- a/tests/built-ins/Set/prototype/isSupersetOf.js
+++ b/tests/built-ins/Set/prototype/isSupersetOf.js
@@ -16,6 +16,20 @@ describe("Set.prototype.isSupersetOf", () => {
     expect(new Set().isSupersetOf(new Set())).toBe(true);
   });
 
+  test("accepts set-like object", () => {
+    const setLike = {
+      size: 2,
+      has(value) {
+        return value === 1 || value === 2;
+      },
+      keys() {
+        return [1, 2].values();
+      },
+    };
+    expect(new Set([1, 2, 3]).isSupersetOf(setLike)).toBe(true);
+    expect(new Set([1, 3]).isSupersetOf(setLike)).toBe(false);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const isSupersetOf = Set.prototype.isSupersetOf;
     expect(() => isSupersetOf.call(Set.prototype, new Set())).toThrow(TypeError);
@@ -23,7 +37,7 @@ describe("Set.prototype.isSupersetOf", () => {
     expect(() => isSupersetOf.call(new Map(), new Set())).toThrow(TypeError);
   });
 
-  test("throws TypeError when argument is not a Set", () => {
+  test("throws TypeError when argument is not set-like", () => {
     const s = new Set([1, 2]);
     expect(() => s.isSupersetOf({})).toThrow(TypeError);
     expect(() => s.isSupersetOf([])).toThrow(TypeError);

--- a/tests/built-ins/Set/prototype/symmetricDifference.js
+++ b/tests/built-ins/Set/prototype/symmetricDifference.js
@@ -20,6 +20,22 @@ describe("Set.prototype.symmetricDifference", () => {
     expect(a.symmetricDifference(b).size).toBe(0);
   });
 
+  test("accepts set-like object", () => {
+    const setLike = {
+      size: 3,
+      has(value) {
+        return value === 2 || value === 3 || value === 4;
+      },
+      keys() {
+        return [2, 3, 4, 4].values();
+      },
+    };
+    const result = new Set([1, 2, 3]).symmetricDifference(setLike);
+    expect(result.size).toBe(2);
+    expect(result.has(1)).toBe(true);
+    expect(result.has(4)).toBe(true);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const symDiff = Set.prototype.symmetricDifference;
     expect(() => symDiff.call(Set.prototype, new Set())).toThrow(TypeError);
@@ -27,7 +43,7 @@ describe("Set.prototype.symmetricDifference", () => {
     expect(() => symDiff.call(new Map(), new Set())).toThrow(TypeError);
   });
 
-  test("throws TypeError when argument is not a Set", () => {
+  test("throws TypeError when argument is not set-like", () => {
     const s = new Set([1, 2]);
     expect(() => s.symmetricDifference({})).toThrow(TypeError);
     expect(() => s.symmetricDifference([])).toThrow(TypeError);

--- a/tests/built-ins/Set/prototype/union.js
+++ b/tests/built-ins/Set/prototype/union.js
@@ -100,4 +100,21 @@ describe("Set.prototype.union", () => {
       },
     })).toThrow(TypeError);
   });
+
+  test("throws TypeError when set-like keys iterator next returns non-object", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.union({
+      size: 1,
+      has(value) {
+        return value === 1;
+      },
+      keys() {
+        return {
+          next() {
+            return 1;
+          },
+        };
+      },
+    })).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Set/prototype/union.js
+++ b/tests/built-ins/Set/prototype/union.js
@@ -27,6 +27,23 @@ describe("Set.prototype.union", () => {
     expect(result.size).toBe(0);
   });
 
+  test("accepts set-like object", () => {
+    const setLike = {
+      size: "3",
+      has(value) {
+        return value === 2 || value === 3;
+      },
+      keys() {
+        return [2, 3, 3].values();
+      },
+    };
+    const result = new Set([1, 2]).union(setLike);
+    expect(result.size).toBe(3);
+    expect(result.has(1)).toBe(true);
+    expect(result.has(2)).toBe(true);
+    expect(result.has(3)).toBe(true);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const union = Set.prototype.union;
     expect(() => union.call(Set.prototype, new Set())).toThrow(TypeError);
@@ -34,9 +51,53 @@ describe("Set.prototype.union", () => {
     expect(() => union.call(new Map(), new Set())).toThrow(TypeError);
   });
 
-  test("throws TypeError when argument is not a Set", () => {
+  test("throws TypeError when argument is not set-like", () => {
     const s = new Set([1, 2]);
     expect(() => s.union({})).toThrow(TypeError);
     expect(() => s.union([])).toThrow(TypeError);
+  });
+
+  test("validates set-like object fields", () => {
+    const s = new Set([1, 2]);
+    expect(() => s.union({
+      has(value) {
+        return value === 1;
+      },
+      keys() {
+        return [1].values();
+      },
+    })).toThrow(TypeError);
+    expect(() => s.union({
+      size: -1,
+      has(value) {
+        return value === 1;
+      },
+      keys() {
+        return [1].values();
+      },
+    })).toThrow(RangeError);
+    expect(() => s.union({
+      size: 1,
+      has: 1,
+      keys() {
+        return [1].values();
+      },
+    })).toThrow(TypeError);
+    expect(() => s.union({
+      size: 1,
+      has(value) {
+        return value === 1;
+      },
+      keys: 1,
+    })).toThrow(TypeError);
+    expect(() => s.union({
+      size: 1,
+      has(value) {
+        return value === 1;
+      },
+      keys() {
+        return {};
+      },
+    })).toThrow(TypeError);
   });
 });


### PR DESCRIPTION
## Summary
- implement ES Set Record handling for Set operation operands
- allow Set-like objects with size, has(), and keys() across union/intersection/difference/symmetricDifference and subset/superset/disjoint checks
- add JS regressions and update Set docs

Fixes #422.