### PR TITLE
Fix Temporal BigInt duration overflow

### DIFF
--- a/source/units/Goccia.Builtins.Temporal.pas
+++ b/source/units/Goccia.Builtins.Temporal.pas
@@ -94,6 +94,7 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
+  Goccia.Temporal.DurationMath,
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
@@ -365,6 +366,8 @@ begin
     ThrowTypeError(SErrorTemporalInstantRequiresBigInt, SSuggestTemporalBigIntArg);
 
   BigNs := TGocciaBigIntValue(Arg).Value;
+  if not IsValidEpochNanoseconds(BigNs) then
+    ThrowRangeError(SErrorTemporalInstantOutOfRange, SSuggestTemporalInstantRange);
   BigMs := BigNs.Divide(TBigInteger.FromInt64(1000000));
   BigSubMs := BigNs.Modulo(TBigInteger.FromInt64(1000000));
   Ms := BigMs.ToInt64;
@@ -431,6 +434,8 @@ begin
     ThrowTypeError(SErrorTemporalInstantRequiresBigInt, SSuggestTemporalBigIntArg);
 
   BigNs := TGocciaBigIntValue(Arg).Value;
+  if not IsValidEpochNanoseconds(BigNs) then
+    ThrowRangeError(SErrorTemporalInstantOutOfRange, SSuggestTemporalInstantRange);
   BigMs := BigNs.Divide(TBigInteger.FromInt64(1000000));
   BigSubMs := BigNs.Modulo(TBigInteger.FromInt64(1000000));
   Ms := BigMs.ToInt64;
@@ -1305,6 +1310,8 @@ begin
     ThrowTypeError(SErrorTemporalZonedDateTimeRequiresBigInt, SSuggestTemporalBigIntArg);
 
   BigNs := TGocciaBigIntValue(Arg).Value;
+  if not IsValidEpochNanoseconds(BigNs) then
+    ThrowRangeError(SErrorTemporalInstantOutOfRange, SSuggestTemporalInstantRange);
   BigMs := BigNs.Divide(TBigInteger.FromInt64(1000000));
   BigSubMs := BigNs.Modulo(TBigInteger.FromInt64(1000000));
   Ms := BigMs.ToInt64;

--- a/source/units/Goccia.Builtins.Temporal.pas
+++ b/source/units/Goccia.Builtins.Temporal.pas
@@ -225,9 +225,9 @@ begin
   if Arg is TGocciaTemporalDurationValue then
   begin
     D := TGocciaTemporalDurationValue(Arg);
-    Result := TGocciaTemporalDurationValue.Create(
-      D.Years, D.Months, D.Weeks, D.Days, D.Hours, D.Minutes,
-      D.Seconds, D.Milliseconds, D.Microseconds, D.Nanoseconds);
+    Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+      D.YearsBig, D.MonthsBig, D.WeeksBig, D.DaysBig, D.HoursBig, D.MinutesBig,
+      D.SecondsBig, D.MillisecondsBig, D.MicrosecondsBig, D.NanosecondsBig);
   end
   else if Arg is TGocciaStringLiteralValue then
   begin
@@ -257,7 +257,7 @@ end;
 function TGocciaTemporalBuiltin.DurationCompare(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   D1, D2: TGocciaTemporalDurationValue;
-  TotalNs1, TotalNs2: Double;
+  TotalNs1, TotalNs2: TBigInteger;
 
   function CoerceDuration(const AArg: TGocciaValue): TGocciaTemporalDurationValue;
   var
@@ -303,21 +303,27 @@ var
     end;
   end;
 
+  function DurationExactTotalNanoseconds(const ADuration: TGocciaTemporalDurationValue): TBigInteger;
+  begin
+    Result := TimeDurationFromComponents(ADuration.HoursBig, ADuration.MinutesBig,
+      ADuration.SecondsBig, ADuration.MillisecondsBig, ADuration.MicrosecondsBig,
+      ADuration.NanosecondsBig)
+      .Add(ADuration.DaysBig.Multiply(TBigInteger.FromInt64(NANOSECONDS_PER_DAY)))
+      .Add(ADuration.WeeksBig.Multiply(TBigInteger.FromInt64(7)).Multiply(
+        TBigInteger.FromInt64(NANOSECONDS_PER_DAY)));
+  end;
+
 begin
   D1 := CoerceDuration(AArgs.GetElement(0));
   D2 := CoerceDuration(AArgs.GetElement(1));
 
   // Compare using total nanoseconds (ignoring calendar units for simplicity)
-  TotalNs1 := D1.Nanoseconds + D1.Microseconds * 1000.0 + D1.Milliseconds * 1000000.0 +
-              D1.Seconds * 1e9 + D1.Minutes * 6e10 + D1.Hours * 3.6e12 +
-              D1.Days * 8.64e13 + D1.Weeks * 6.048e14;
-  TotalNs2 := D2.Nanoseconds + D2.Microseconds * 1000.0 + D2.Milliseconds * 1000000.0 +
-              D2.Seconds * 1e9 + D2.Minutes * 6e10 + D2.Hours * 3.6e12 +
-              D2.Days * 8.64e13 + D2.Weeks * 6.048e14;
+  TotalNs1 := DurationExactTotalNanoseconds(D1);
+  TotalNs2 := DurationExactTotalNanoseconds(D2);
 
-  if TotalNs1 < TotalNs2 then
+  if TotalNs1.Compare(TotalNs2) < 0 then
     Result := TGocciaNumberLiteralValue.Create(-1)
-  else if TotalNs1 > TotalNs2 then
+  else if TotalNs1.Compare(TotalNs2) > 0 then
     Result := TGocciaNumberLiteralValue.Create(1)
   else
     Result := TGocciaNumberLiteralValue.ZeroValue;

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -132,6 +132,7 @@ resourcestring
   // Temporal API errors — Instant
   SErrorTemporalInstantRequiresEpoch = 'Temporal.Instant requires epochNanoseconds argument';
   SErrorTemporalInstantRequiresBigInt = 'Temporal.Instant epochNanoseconds must be a BigInt';
+  SErrorTemporalInstantOutOfRange = 'Temporal.Instant epochNanoseconds out of range';
   SErrorInvalidISOInstant = 'Invalid ISO instant string';
   SErrorTemporalInstantFromArg = 'Temporal.Instant.from requires a string or Instant';
   SErrorTemporalInstantFromEpochMillis = 'Temporal.Instant.fromEpochMilliseconds requires an argument';

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -238,6 +238,7 @@ resourcestring
   SSuggestTemporalISOFormat = 'provide a valid ISO 8601 string (e.g., "2024-01-15", "2024-01-15T10:30:00")';
   SSuggestTemporalFromArg = 'pass a string in ISO 8601 format, an existing Temporal object, or a property bag';
   SSuggestTemporalBigIntArg = 'epochNanoseconds must be a BigInt (e.g., 0n or BigInt(1000000))';
+  SSuggestTemporalInstantRange = 'epochNanoseconds must be between -8640000000000000000000n and 8640000000000000000000n';
   SSuggestTemporalCompareArg = 'both arguments must be the same Temporal type or valid ISO strings';
   SSuggestTemporalWithObject = 'pass an object with the date/time fields to update (e.g., { year: 2025 })';
   SSuggestTemporalDurationArg = 'pass a Temporal.Duration, a duration string (e.g., "P1Y2M"), or a duration-like object';

--- a/source/units/Goccia.Temporal.DurationMath.pas
+++ b/source/units/Goccia.Temporal.DurationMath.pas
@@ -1,0 +1,165 @@
+unit Goccia.Temporal.DurationMath;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  BigInteger,
+
+  Goccia.Temporal.Options;
+
+function EpochNanosecondsFromParts(const AEpochMilliseconds: Int64;
+  const ASubMillisecondNanoseconds: Integer): TBigInteger;
+function TimeDurationFromEpochNanosecondsDifference(const AOne, ATwo: TBigInteger): TBigInteger;
+function TimeDurationFromComponents(const AHours, AMinutes, ASeconds, AMilliseconds,
+  AMicroseconds, ANanoseconds: TBigInteger): TBigInteger;
+function RoundTimeDurationToIncrement(const ATimeDuration, AIncrement: TBigInteger;
+  const AMode: TTemporalRoundingMode): TBigInteger;
+function IsValidEpochNanoseconds(const AValue: TBigInteger): Boolean;
+function IsValidTimeDuration(const AValue: TBigInteger): Boolean;
+procedure BalanceTimeDurationToFields(const ATimeDuration: TBigInteger;
+  const ALargestUnit: TTemporalUnit;
+  out AHours, AMinutes, ASeconds, AMilliseconds, AMicroseconds, ANanoseconds: TBigInteger;
+  out ADays: Int64);
+
+implementation
+
+const
+  MAX_EPOCH_NANOSECONDS_DECIMAL = '8640000000000000000000';
+  MAX_TIME_DURATION_DECIMAL = '9007199254740991999999999';
+
+function BigInt(const AValue: Int64): TBigInteger; inline;
+begin
+  Result := TBigInteger.FromInt64(AValue);
+end;
+
+function BigIntFromDecimal(const AValue: string): TBigInteger; inline;
+begin
+  Result := TBigInteger.FromDecimalString(AValue);
+end;
+
+function BigIntForUnit(const AUnit: TTemporalUnit): TBigInteger;
+begin
+  case AUnit of
+    tuDay: Result := BigInt(NANOSECONDS_PER_DAY);
+    tuHour: Result := BigInt(NANOSECONDS_PER_HOUR);
+    tuMinute: Result := BigInt(NANOSECONDS_PER_MINUTE);
+    tuSecond: Result := BigInt(NANOSECONDS_PER_SECOND);
+    tuMillisecond: Result := BigInt(NANOSECONDS_PER_MILLISECOND);
+    tuMicrosecond: Result := BigInt(NANOSECONDS_PER_MICROSECOND);
+  else
+    Result := TBigInteger.One;
+  end;
+end;
+
+// TC39 Temporal §8.3.4 get Temporal.Instant.prototype.epochNanoseconds
+function EpochNanosecondsFromParts(const AEpochMilliseconds: Int64;
+  const ASubMillisecondNanoseconds: Integer): TBigInteger;
+begin
+  Result := BigInt(AEpochMilliseconds)
+    .Multiply(BigInt(NANOSECONDS_PER_MILLISECOND))
+    .Add(BigInt(ASubMillisecondNanoseconds));
+end;
+
+// TC39 Temporal §7.5.26 TimeDurationFromEpochNanosecondsDifference(one, two)
+function TimeDurationFromEpochNanosecondsDifference(const AOne, ATwo: TBigInteger): TBigInteger;
+begin
+  Result := AOne.Subtract(ATwo);
+end;
+
+// TC39 Temporal §7.5.21 TimeDurationFromComponents(hours, minutes, seconds, milliseconds, microseconds, nanoseconds)
+function TimeDurationFromComponents(const AHours, AMinutes, ASeconds, AMilliseconds,
+  AMicroseconds, ANanoseconds: TBigInteger): TBigInteger;
+var
+  Minutes, Seconds, Milliseconds, Microseconds: TBigInteger;
+begin
+  Minutes := AMinutes.Add(AHours.Multiply(BigInt(60)));
+  Seconds := ASeconds.Add(Minutes.Multiply(BigInt(60)));
+  Milliseconds := AMilliseconds.Add(Seconds.Multiply(BigInt(1000)));
+  Microseconds := AMicroseconds.Add(Milliseconds.Multiply(BigInt(1000)));
+  Result := ANanoseconds.Add(Microseconds.Multiply(BigInt(1000)));
+end;
+
+// TC39 Temporal §7.5.27 RoundTimeDurationToIncrement(d, increment, roundingMode)
+function RoundTimeDurationToIncrement(const ATimeDuration, AIncrement: TBigInteger;
+  const AMode: TTemporalRoundingMode): TBigInteger;
+begin
+  Result := RoundBigIntWithMode(ATimeDuration, AIncrement, AMode);
+end;
+
+// TC39 Temporal §8.5.2 IsValidEpochNanoseconds(epochNanoseconds)
+function IsValidEpochNanoseconds(const AValue: TBigInteger): Boolean;
+begin
+  Result := AValue.AbsValue.Compare(BigIntFromDecimal(MAX_EPOCH_NANOSECONDS_DECIMAL)) <= 0;
+end;
+
+// TC39 Temporal §7.5.3 time duration
+function IsValidTimeDuration(const AValue: TBigInteger): Boolean;
+begin
+  Result := AValue.AbsValue.Compare(BigIntFromDecimal(MAX_TIME_DURATION_DECIMAL)) <= 0;
+end;
+
+procedure TakeUnit(var ARemaining: TBigInteger; const AUnit: TBigInteger; out AField: TBigInteger);
+begin
+  AField := ARemaining.Divide(AUnit);
+  ARemaining := ARemaining.Modulo(AUnit);
+end;
+
+// TC39 Temporal §7.5.8 TemporalDurationFromInternal(internalDuration, largestUnit)
+procedure BalanceTimeDurationToFields(const ATimeDuration: TBigInteger;
+  const ALargestUnit: TTemporalUnit;
+  out AHours, AMinutes, ASeconds, AMilliseconds, AMicroseconds, ANanoseconds: TBigInteger;
+  out ADays: Int64);
+var
+  Sign: Integer;
+  Remaining, DaysBig: TBigInteger;
+begin
+  AHours := TBigInteger.Zero;
+  AMinutes := TBigInteger.Zero;
+  ASeconds := TBigInteger.Zero;
+  AMilliseconds := TBigInteger.Zero;
+  AMicroseconds := TBigInteger.Zero;
+  ANanoseconds := TBigInteger.Zero;
+  ADays := 0;
+
+  if ATimeDuration.IsZero then
+    Exit;
+
+  if ATimeDuration.IsNegative then
+    Sign := -1
+  else
+    Sign := 1;
+  Remaining := ATimeDuration.AbsValue;
+
+  if ALargestUnit in [tuYear, tuMonth, tuWeek, tuDay] then
+  begin
+    DaysBig := Remaining.Divide(BigIntForUnit(tuDay));
+    ADays := DaysBig.ToInt64 * Sign;
+    Remaining := Remaining.Modulo(BigIntForUnit(tuDay));
+  end;
+
+  if Ord(ALargestUnit) <= Ord(tuHour) then
+    TakeUnit(Remaining, BigIntForUnit(tuHour), AHours);
+  if Ord(ALargestUnit) <= Ord(tuMinute) then
+    TakeUnit(Remaining, BigIntForUnit(tuMinute), AMinutes);
+  if Ord(ALargestUnit) <= Ord(tuSecond) then
+    TakeUnit(Remaining, BigIntForUnit(tuSecond), ASeconds);
+  if Ord(ALargestUnit) <= Ord(tuMillisecond) then
+    TakeUnit(Remaining, BigIntForUnit(tuMillisecond), AMilliseconds);
+  if Ord(ALargestUnit) <= Ord(tuMicrosecond) then
+    TakeUnit(Remaining, BigIntForUnit(tuMicrosecond), AMicroseconds);
+  ANanoseconds := Remaining;
+
+  if Sign < 0 then
+  begin
+    AHours := AHours.Negate;
+    AMinutes := AMinutes.Negate;
+    ASeconds := ASeconds.Negate;
+    AMilliseconds := AMilliseconds.Negate;
+    AMicroseconds := AMicroseconds.Negate;
+    ANanoseconds := ANanoseconds.Negate;
+  end;
+end;
+
+end.

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -16,16 +16,6 @@ uses
 type
   TGocciaTemporalDurationValue = class(TGocciaObjectValue)
   private
-    FYears: Int64;
-    FMonths: Int64;
-    FWeeks: Int64;
-    FDays: Int64;
-    FHours: Int64;
-    FMinutes: Int64;
-    FSeconds: Int64;
-    FMilliseconds: Int64;
-    FMicroseconds: Int64;
-    FNanoseconds: Int64;
     FYearsBig: TBigInteger;
     FMonthsBig: TBigInteger;
     FWeeksBig: TBigInteger;
@@ -41,6 +31,16 @@ type
     procedure SetDurationFields(const AYears, AMonths, AWeeks, ADays, AHours, AMinutes, ASeconds,
       AMilliseconds, AMicroseconds, ANanoseconds: TBigInteger);
 
+    function GetYearsInt64: Int64;
+    function GetMonthsInt64: Int64;
+    function GetWeeksInt64: Int64;
+    function GetDaysInt64: Int64;
+    function GetHoursInt64: Int64;
+    function GetMinutesInt64: Int64;
+    function GetSecondsInt64: Int64;
+    function GetMillisecondsInt64: Int64;
+    function GetMicrosecondsInt64: Int64;
+    function GetNanosecondsInt64: Int64;
     function ComputeSign: Integer;
     function IsBlank: Boolean;
     function ToISOString: string;
@@ -53,16 +53,16 @@ type
     function ToStringTag: string; override;
     class procedure ExposePrototype(const AConstructor: TGocciaObjectValue);
 
-    property Years: Int64 read FYears;
-    property Months: Int64 read FMonths;
-    property Weeks: Int64 read FWeeks;
-    property Days: Int64 read FDays;
-    property Hours: Int64 read FHours;
-    property Minutes: Int64 read FMinutes;
-    property Seconds: Int64 read FSeconds;
-    property Milliseconds: Int64 read FMilliseconds;
-    property Microseconds: Int64 read FMicroseconds;
-    property Nanoseconds: Int64 read FNanoseconds;
+    property Years: Int64 read GetYearsInt64;
+    property Months: Int64 read GetMonthsInt64;
+    property Weeks: Int64 read GetWeeksInt64;
+    property Days: Int64 read GetDaysInt64;
+    property Hours: Int64 read GetHoursInt64;
+    property Minutes: Int64 read GetMinutesInt64;
+    property Seconds: Int64 read GetSecondsInt64;
+    property Milliseconds: Int64 read GetMillisecondsInt64;
+    property Microseconds: Int64 read GetMicrosecondsInt64;
+    property Nanoseconds: Int64 read GetNanosecondsInt64;
   published
     function GetYears(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function GetMonths(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -172,13 +172,12 @@ begin
     Result := 0;
 end;
 
-function BigIntToLegacyInt64(const AValue: TBigInteger): Int64;
+function BigIntToCheckedInt64(const AValue: TBigInteger; const AFieldName: string): Int64;
 begin
   if (AValue.Compare(TBigInteger.FromInt64(Low(Int64))) < 0) or
      (AValue.Compare(TBigInteger.FromInt64(High(Int64))) > 0) then
-    Result := 0
-  else
-    Result := AValue.ToInt64;
+    raise ERangeError.CreateFmt('Temporal.Duration.%s is outside Int64 range', [AFieldName]);
+  Result := AValue.ToInt64;
 end;
 
 function BigIntFieldToNumber(const AValue: TBigInteger): TGocciaNumberLiteralValue;
@@ -228,17 +227,6 @@ begin
   FMicrosecondsBig := AMicroseconds;
   FNanosecondsBig := ANanoseconds;
 
-  FYears := BigIntToLegacyInt64(AYears);
-  FMonths := BigIntToLegacyInt64(AMonths);
-  FWeeks := BigIntToLegacyInt64(AWeeks);
-  FDays := BigIntToLegacyInt64(ADays);
-  FHours := BigIntToLegacyInt64(AHours);
-  FMinutes := BigIntToLegacyInt64(AMinutes);
-  FSeconds := BigIntToLegacyInt64(ASeconds);
-  FMilliseconds := BigIntToLegacyInt64(AMilliseconds);
-  FMicroseconds := BigIntToLegacyInt64(AMicroseconds);
-  FNanoseconds := BigIntToLegacyInt64(ANanoseconds);
-
   // Validate: sign of non-zero components must be uniform
   HasPositive := (BigIntSign(AYears) > 0) or (BigIntSign(AMonths) > 0) or
                  (BigIntSign(AWeeks) > 0) or (BigIntSign(ADays) > 0) or
@@ -269,6 +257,56 @@ begin
   InitializePrototype;
   if Assigned(GetTemporalDurationShared) then
     FPrototype := GetTemporalDurationShared.Prototype;
+end;
+
+function TGocciaTemporalDurationValue.GetYearsInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FYearsBig, 'years');
+end;
+
+function TGocciaTemporalDurationValue.GetMonthsInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FMonthsBig, 'months');
+end;
+
+function TGocciaTemporalDurationValue.GetWeeksInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FWeeksBig, 'weeks');
+end;
+
+function TGocciaTemporalDurationValue.GetDaysInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FDaysBig, 'days');
+end;
+
+function TGocciaTemporalDurationValue.GetHoursInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FHoursBig, 'hours');
+end;
+
+function TGocciaTemporalDurationValue.GetMinutesInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FMinutesBig, 'minutes');
+end;
+
+function TGocciaTemporalDurationValue.GetSecondsInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FSecondsBig, 'seconds');
+end;
+
+function TGocciaTemporalDurationValue.GetMillisecondsInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FMillisecondsBig, 'milliseconds');
+end;
+
+function TGocciaTemporalDurationValue.GetMicrosecondsInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FMicrosecondsBig, 'microseconds');
+end;
+
+function TGocciaTemporalDurationValue.GetNanosecondsInt64: Int64;
+begin
+  Result := BigIntToCheckedInt64(FNanosecondsBig, 'nanoseconds');
 end;
 
 procedure TGocciaTemporalDurationValue.InitializePrototype;
@@ -598,9 +636,9 @@ var
   Obj: TGocciaObjectValue;
   V: TGocciaValue;
   NewYears, NewMonths, NewWeeks, NewDays, NewHours, NewMinutes, NewSeconds,
-  NewMilliseconds, NewMicroseconds, NewNanoseconds: Int64;
+  NewMilliseconds, NewMicroseconds, NewNanoseconds: TBigInteger;
 
-  function GetFieldOr(const AName: string; const ADefault: Int64): Int64;
+  function GetFieldOr(const AName: string; const ADefault: TBigInteger): TBigInteger;
   var
     Val: TGocciaValue;
   begin
@@ -608,7 +646,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := TBigInteger.FromDouble(Trunc(Val.ToNumberLiteral.Value));
   end;
 
 begin
@@ -618,17 +656,20 @@ begin
     ThrowTypeError(Format(SErrorTemporalWithRequiresObject, ['Duration']), SSuggestTemporalWithObject);
   Obj := TGocciaObjectValue(V);
 
-  Result := TGocciaTemporalDurationValue.Create(
-    GetFieldOr('years', D.FYears),
-    GetFieldOr('months', D.FMonths),
-    GetFieldOr('weeks', D.FWeeks),
-    GetFieldOr('days', D.FDays),
-    GetFieldOr('hours', D.FHours),
-    GetFieldOr('minutes', D.FMinutes),
-    GetFieldOr('seconds', D.FSeconds),
-    GetFieldOr('milliseconds', D.FMilliseconds),
-    GetFieldOr('microseconds', D.FMicroseconds),
-    GetFieldOr('nanoseconds', D.FNanoseconds));
+  NewYears := GetFieldOr('years', D.FYearsBig);
+  NewMonths := GetFieldOr('months', D.FMonthsBig);
+  NewWeeks := GetFieldOr('weeks', D.FWeeksBig);
+  NewDays := GetFieldOr('days', D.FDaysBig);
+  NewHours := GetFieldOr('hours', D.FHoursBig);
+  NewMinutes := GetFieldOr('minutes', D.FMinutesBig);
+  NewSeconds := GetFieldOr('seconds', D.FSecondsBig);
+  NewMilliseconds := GetFieldOr('milliseconds', D.FMillisecondsBig);
+  NewMicroseconds := GetFieldOr('microseconds', D.FMicrosecondsBig);
+  NewNanoseconds := GetFieldOr('nanoseconds', D.FNanosecondsBig);
+
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    NewYears, NewMonths, NewWeeks, NewDays, NewHours, NewMinutes, NewSeconds,
+    NewMilliseconds, NewMicroseconds, NewNanoseconds);
 end;
 
 // TC39 Temporal §7.3.21 Temporal.Duration.prototype.round(roundTo)
@@ -693,15 +734,15 @@ begin
     SmallestUnit := tuNanosecond;
   if LargestUnit = tuNone then
   begin
-    if D.FYears <> 0 then LargestUnit := tuYear
-    else if D.FMonths <> 0 then LargestUnit := tuMonth
-    else if D.FWeeks <> 0 then LargestUnit := tuWeek
-    else if D.FDays <> 0 then LargestUnit := tuDay
-    else if D.FHours <> 0 then LargestUnit := tuHour
-    else if D.FMinutes <> 0 then LargestUnit := tuMinute
-    else if D.FSeconds <> 0 then LargestUnit := tuSecond
-    else if D.FMilliseconds <> 0 then LargestUnit := tuMillisecond
-    else if D.FMicroseconds <> 0 then LargestUnit := tuMicrosecond
+    if D.Years <> 0 then LargestUnit := tuYear
+    else if D.Months <> 0 then LargestUnit := tuMonth
+    else if D.Weeks <> 0 then LargestUnit := tuWeek
+    else if D.Days <> 0 then LargestUnit := tuDay
+    else if D.Hours <> 0 then LargestUnit := tuHour
+    else if D.Minutes <> 0 then LargestUnit := tuMinute
+    else if D.Seconds <> 0 then LargestUnit := tuSecond
+    else if D.Milliseconds <> 0 then LargestUnit := tuMillisecond
+    else if D.Microseconds <> 0 then LargestUnit := tuMicrosecond
     else LargestUnit := SmallestUnit;
     if Ord(LargestUnit) > Ord(SmallestUnit) then
       LargestUnit := SmallestUnit;
@@ -711,7 +752,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
 
   // Determine if calendar-relative computation is needed
-  NeedCalendar := (D.FYears <> 0) or (D.FMonths <> 0) or
+  NeedCalendar := (D.Years <> 0) or (D.Months <> 0) or
     (Ord(SmallestUnit) <= Ord(tuMonth)) or (Ord(LargestUnit) <= Ord(tuMonth));
 
   if NeedCalendar and not HasRelativeTo then
@@ -732,23 +773,23 @@ begin
     // matching TC39 Temporal semantics (e.g. 2020-02-29 + P1Y1M clamps to
     // 2021-02-28 after +1Y, then advances to 2021-03-28).
     IntermDate := RelDate;
-    if D.FYears <> 0 then
+    if D.Years <> 0 then
       IntermDate := AddMonthsToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
-        D.FYears * 12);
-    if D.FMonths <> 0 then
+        D.Years * 12);
+    if D.Months <> 0 then
       IntermDate := AddMonthsToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
-        D.FMonths);
-    TimeNs := D.FNanoseconds +
-              D.FMicroseconds * NANOSECONDS_PER_MICROSECOND +
-              D.FMilliseconds * NANOSECONDS_PER_MILLISECOND +
-              D.FSeconds * NANOSECONDS_PER_SECOND +
-              D.FMinutes * NANOSECONDS_PER_MINUTE +
-              D.FHours * NANOSECONDS_PER_HOUR;
+        D.Months);
+    TimeNs := D.Nanoseconds +
+              D.Microseconds * NANOSECONDS_PER_MICROSECOND +
+              D.Milliseconds * NANOSECONDS_PER_MILLISECOND +
+              D.Seconds * NANOSECONDS_PER_SECOND +
+              D.Minutes * NANOSECONDS_PER_MINUTE +
+              D.Hours * NANOSECONDS_PER_HOUR;
     CarryDays := TimeNs div NANOSECONDS_PER_DAY;
     TimeNs := TimeNs mod NANOSECONDS_PER_DAY;
 
     EndDate := AddDaysToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
-      D.FWeeks * 7 + D.FDays + CarryDays);
+      D.Weeks * 7 + D.Days + CarryDays);
     StartEpoch := DateToEpochDays(RelDate.Year, RelDate.Month, RelDate.Day);
     EndEpoch := DateToEpochDays(EndDate.Year, EndDate.Month, EndDate.Day);
 
@@ -946,14 +987,14 @@ begin
   else
   begin
     // --- Non-calendar path (existing behavior) ---
-    TotalNs := D.FNanoseconds +
-               D.FMicroseconds * NANOSECONDS_PER_MICROSECOND +
-               D.FMilliseconds * NANOSECONDS_PER_MILLISECOND +
-               D.FSeconds * NANOSECONDS_PER_SECOND +
-               D.FMinutes * NANOSECONDS_PER_MINUTE +
-               D.FHours * NANOSECONDS_PER_HOUR +
-               D.FDays * NANOSECONDS_PER_DAY +
-               D.FWeeks * 7 * NANOSECONDS_PER_DAY;
+    TotalNs := D.Nanoseconds +
+               D.Microseconds * NANOSECONDS_PER_MICROSECOND +
+               D.Milliseconds * NANOSECONDS_PER_MILLISECOND +
+               D.Seconds * NANOSECONDS_PER_SECOND +
+               D.Minutes * NANOSECONDS_PER_MINUTE +
+               D.Hours * NANOSECONDS_PER_HOUR +
+               D.Days * NANOSECONDS_PER_DAY +
+               D.Weeks * 7 * NANOSECONDS_PER_DAY;
 
     if SmallestUnit <> tuNanosecond then
     begin
@@ -1144,12 +1185,12 @@ begin
   // Accumulate via implicit Int64->Double assignment to avoid both FPC 3.2.2
   // bugs: Bug A (Double(Int64) bit reinterpretation) and Bug B (Int64 * 1.0
   // wrong results near +/-2^31 on AArch64). See docs/contributing/tooling.md.
-  Ns := D.FNanoseconds;
-  V := D.FMicroseconds; Ns := Ns + V * NANOSECONDS_PER_MICROSECOND;
-  V := D.FMilliseconds; Ns := Ns + V * NANOSECONDS_PER_MILLISECOND;
-  V := D.FSeconds;      Ns := Ns + V * NANOSECONDS_PER_SECOND;
-  V := D.FMinutes;      Ns := Ns + V * NANOSECONDS_PER_MINUTE;
-  V := D.FHours;        Ns := Ns + V * NANOSECONDS_PER_HOUR;
+  Ns := D.Nanoseconds;
+  V := D.Microseconds; Ns := Ns + V * NANOSECONDS_PER_MICROSECOND;
+  V := D.Milliseconds; Ns := Ns + V * NANOSECONDS_PER_MILLISECOND;
+  V := D.Seconds;      Ns := Ns + V * NANOSECONDS_PER_SECOND;
+  V := D.Minutes;      Ns := Ns + V * NANOSECONDS_PER_MINUTE;
+  V := D.Hours;        Ns := Ns + V * NANOSECONDS_PER_HOUR;
   Result := Ns;
 end;
 
@@ -1173,7 +1214,7 @@ begin
   CarryDays := Trunc(TimeNs / NANOSECONDS_PER_DAY);
   RemainderNs := TimeNs - CarryDays * NANOSECONDS_PER_DAY;
 
-  EndRec := DurationEndDate(ARelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays + CarryDays);
+  EndRec := DurationEndDate(ARelDate, D.Years, D.Months, D.Weeks, D.Days + CarryDays);
   EndEpoch := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day);
 
   // Estimate whole units from the month difference
@@ -1295,13 +1336,13 @@ begin
   end;
 
   // Calendar source components (years/months) require relativeTo
-  if (D.FYears <> 0) or (D.FMonths <> 0) then
+  if (D.Years <> 0) or (D.Months <> 0) then
   begin
     if not HasRelativeTo then
       ThrowRangeError(SErrorDurationTotalRequiresRelativeTo, SSuggestTemporalRelativeTo);
 
     RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.total');
-    ResolvedDays := ResolveRelativeDays(RelDate, D.FYears, D.FMonths, D.FWeeks, D.FDays);
+    ResolvedDays := ResolveRelativeDays(RelDate, D.Years, D.Months, D.Weeks, D.Days);
 
     V := ResolvedDays;
     TotalNs := SubDayNanoseconds(D) + V * NANOSECONDS_PER_DAY;
@@ -1309,8 +1350,8 @@ begin
   else
   begin
     TotalNs := SubDayNanoseconds(D);
-    V := D.FDays;  TotalNs := TotalNs + V * NANOSECONDS_PER_DAY;
-    V := D.FWeeks; TotalNs := TotalNs + V * 7 * NANOSECONDS_PER_DAY;
+    V := D.Days;  TotalNs := TotalNs + V * NANOSECONDS_PER_DAY;
+    V := D.Weeks; TotalNs := TotalNs + V * 7 * NANOSECONDS_PER_DAY;
   end;
 
   if TargetUnit = tuNanosecond then

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -5,6 +5,8 @@ unit Goccia.Values.TemporalDuration;
 interface
 
 uses
+  SysUtils,
+
   BigInteger,
 
   Goccia.Arguments.Collection,
@@ -14,6 +16,8 @@ uses
   Goccia.Values.Primitives;
 
 type
+  ETemporalDurationInt64Overflow = class(Exception);
+
   TGocciaTemporalDurationValue = class(TGocciaObjectValue)
   private
     FYearsBig: TBigInteger;
@@ -103,7 +107,6 @@ implementation
 
 uses
   Math,
-  SysUtils,
 
   Goccia.Constants.NumericLimits,
   Goccia.Constants.PropertyNames,
@@ -112,7 +115,6 @@ uses
   Goccia.Realm,
   Goccia.Temporal.DurationMath,
   Goccia.Temporal.Options,
-  Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -189,7 +191,7 @@ function BigIntToCheckedInt64(const AValue: TBigInteger; const AFieldName: strin
 begin
   if (AValue.Compare(TBigInteger.FromInt64(Low(Int64))) < 0) or
      (AValue.Compare(TBigInteger.FromInt64(High(Int64))) > 0) then
-    raise ERangeError.CreateFmt('Temporal.Duration.%s is outside Int64 range', [AFieldName]);
+    raise ETemporalDurationInt64Overflow.CreateFmt('Temporal.Duration.%s is outside Int64 range', [AFieldName]);
   Result := AValue.ToInt64;
 end;
 
@@ -758,6 +760,7 @@ var
   Sign: Integer;
   CalendarYears, CalendarMonths, CalendarWeeks, CalendarDays: Int64;
 begin
+  try
   D := AsDuration(AThisValue, 'Duration.prototype.round');
   Arg := AArgs.GetElement(0);
 
@@ -1066,20 +1069,10 @@ begin
     Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(TBigInteger.Zero, TBigInteger.Zero,
       TBigInteger.Zero, BigIntUnit(ResultDays),
       ResultHoursBig, ResultMinutesBig, ResultSecondsBig, ResultMsBig, ResultUsBig, ResultNsBig);
-end;
-
-function ZonedDateTimeToDateRecord(const AZdt: TGocciaTemporalZonedDateTimeValue): TTemporalDateRecord;
-var
-  OffsetSeconds: Integer;
-  LocalEpochMs, EpochDays, RemainingMs: Int64;
-begin
-  OffsetSeconds := GetUtcOffsetSeconds(AZdt.TimeZone, AZdt.EpochMilliseconds div 1000);
-  LocalEpochMs := AZdt.EpochMilliseconds + Int64(OffsetSeconds) * 1000;
-  EpochDays := LocalEpochMs div 86400000;
-  RemainingMs := LocalEpochMs mod 86400000;
-  if RemainingMs < 0 then
-    Dec(EpochDays);
-  Result := EpochDaysToDate(EpochDays);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 function TryParseDateFromPropertyBag(const AObj: TGocciaObjectValue;
@@ -1118,7 +1111,11 @@ begin
     Result.Day := PlainDate.Day;
   end
   else if AValue is TGocciaTemporalZonedDateTimeValue then
-    Result := ZonedDateTimeToDateRecord(TGocciaTemporalZonedDateTimeValue(AValue))
+  begin
+    // ZonedDateTime relativeTo needs timezone-aware DST handling. Reject it
+    // until Duration round/total can route through that aware path.
+    ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
+  end
   else if AValue is TGocciaStringLiteralValue then
   begin
     if not CoerceToISODate(TGocciaStringLiteralValue(AValue).Value, DateRec) then
@@ -1295,6 +1292,7 @@ var
   ResolvedDays: Int64;
   TotalNsBig: TBigInteger;
 begin
+  try
   D := AsDuration(AThisValue, 'Duration.prototype.total');
   Arg := AArgs.GetElement(0);
   HasRelativeTo := False;
@@ -1367,6 +1365,10 @@ begin
   else
     Result := TGocciaNumberLiteralValue.Create(
       TotalNsBig.ToDouble / UnitToNanoseconds(TargetUnit));
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 function TGocciaTemporalDurationValue.DurationToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -63,6 +63,16 @@ type
     property Milliseconds: Int64 read GetMillisecondsInt64;
     property Microseconds: Int64 read GetMicrosecondsInt64;
     property Nanoseconds: Int64 read GetNanosecondsInt64;
+    property YearsBig: TBigInteger read FYearsBig;
+    property MonthsBig: TBigInteger read FMonthsBig;
+    property WeeksBig: TBigInteger read FWeeksBig;
+    property DaysBig: TBigInteger read FDaysBig;
+    property HoursBig: TBigInteger read FHoursBig;
+    property MinutesBig: TBigInteger read FMinutesBig;
+    property SecondsBig: TBigInteger read FSecondsBig;
+    property MillisecondsBig: TBigInteger read FMillisecondsBig;
+    property MicrosecondsBig: TBigInteger read FMicrosecondsBig;
+    property NanosecondsBig: TBigInteger read FNanosecondsBig;
   published
     function GetYears(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function GetMonths(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -92,6 +102,7 @@ type
 implementation
 
 uses
+  Math,
   SysUtils,
 
   Goccia.Constants.NumericLimits,
@@ -131,10 +142,12 @@ begin
 end;
 
 function ParseRelativeTo(const AValue: TGocciaValue; const AMethod: string): TTemporalDateRecord; forward;
+function ValueToBigInteger(const AValue: TGocciaValue): TBigInteger; forward;
 
 function DurationFromObject(const AObj: TGocciaObjectValue): TGocciaTemporalDurationValue;
 
-  function GetFieldOr(const AObj: TGocciaObjectValue; const AName: string; const ADefault: Int64): Int64;
+  function GetFieldOr(const AObj: TGocciaObjectValue; const AName: string;
+    const ADefault: TBigInteger): TBigInteger;
   var
     V: TGocciaValue;
   begin
@@ -142,21 +155,21 @@ function DurationFromObject(const AObj: TGocciaObjectValue): TGocciaTemporalDura
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(V.ToNumberLiteral.Value);
+      Result := ValueToBigInteger(V);
   end;
 
 begin
-  Result := TGocciaTemporalDurationValue.Create(
-    GetFieldOr(AObj, 'years', 0),
-    GetFieldOr(AObj, 'months', 0),
-    GetFieldOr(AObj, 'weeks', 0),
-    GetFieldOr(AObj, 'days', 0),
-    GetFieldOr(AObj, 'hours', 0),
-    GetFieldOr(AObj, 'minutes', 0),
-    GetFieldOr(AObj, 'seconds', 0),
-    GetFieldOr(AObj, 'milliseconds', 0),
-    GetFieldOr(AObj, 'microseconds', 0),
-    GetFieldOr(AObj, 'nanoseconds', 0)
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    GetFieldOr(AObj, 'years', TBigInteger.Zero),
+    GetFieldOr(AObj, 'months', TBigInteger.Zero),
+    GetFieldOr(AObj, 'weeks', TBigInteger.Zero),
+    GetFieldOr(AObj, 'days', TBigInteger.Zero),
+    GetFieldOr(AObj, 'hours', TBigInteger.Zero),
+    GetFieldOr(AObj, 'minutes', TBigInteger.Zero),
+    GetFieldOr(AObj, 'seconds', TBigInteger.Zero),
+    GetFieldOr(AObj, 'milliseconds', TBigInteger.Zero),
+    GetFieldOr(AObj, 'microseconds', TBigInteger.Zero),
+    GetFieldOr(AObj, 'nanoseconds', TBigInteger.Zero)
   );
 end;
 
@@ -183,6 +196,26 @@ end;
 function BigIntFieldToNumber(const AValue: TBigInteger): TGocciaNumberLiteralValue;
 begin
   Result := TGocciaNumberLiteralValue.Create(AValue.ToDouble);
+end;
+
+function NumberToBigInteger(const AValue: Double): TBigInteger;
+var
+  DecStr: string;
+begin
+  if IsNaN(AValue) or IsInfinite(AValue) then
+    raise Exception.Create('Cannot convert non-finite number to BigInt');
+  if Frac(AValue) <> 0 then
+    raise Exception.Create('Cannot convert non-integer to BigInt');
+  Str(AValue:0:0, DecStr);
+  Result := TBigInteger.FromDecimalString(DecStr);
+end;
+
+function ValueToBigInteger(const AValue: TGocciaValue): TBigInteger;
+begin
+  if AValue is TGocciaNumberLiteralValue then
+    Result := NumberToBigInteger(TGocciaNumberLiteralValue(AValue).Value)
+  else
+    Result := NumberToBigInteger(AValue.ToNumberLiteral.Value);
 end;
 
 function BigIntUnit(const AValue: Int64): TBigInteger; inline;
@@ -671,7 +704,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := TBigInteger.FromDouble(Trunc(Val.ToNumberLiteral.Value));
+      Result := ValueToBigInteger(Val);
   end;
 
 begin
@@ -850,26 +883,23 @@ begin
           until False;
         end;
 
-        // Align to increment-boundary bucket. For negative durations the
-        // fractional position extends past WholeUnits in the negative
-        // direction, so use WholeUnits - 1 as alignment base.
-        if Sign < 0 then
-          ScaledValue := WholeUnits - 1
+        // Align to increment-boundary bucket toward zero, then use the
+        // sign-aware bucket span to decide whether rounding carries.
+        if Sign > 0 then
+          ScaledValue := (WholeUnits div Increment) * Increment
         else
-          ScaledValue := WholeUnits;
-        if (ScaledValue >= 0) or (ScaledValue mod Increment = 0) then
-          ScaledValue := (ScaledValue div Increment) * Increment
-        else
-          ScaledValue := ((ScaledValue div Increment) - 1) * Increment;
+          ScaledValue := -(((-WholeUnits) div Increment) * Increment);
 
         WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, ScaledValue * 12);
         WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
-        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, (ScaledValue + Increment) * 12);
+        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day,
+          (ScaledValue + Sign * Increment) * 12);
         NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
-        PeriodNs := (NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
-        RoundedValue := RoundWithMode((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs, PeriodNs, Mode);
+        PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+        RoundedValue := RoundWithMode(
+          Abs((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs), PeriodNs, Mode);
         if RoundedValue >= PeriodNs then
-          WholeUnits := ScaledValue + Increment
+          WholeUnits := ScaledValue + Sign * Increment
         else
           WholeUnits := ScaledValue;
 
@@ -900,24 +930,21 @@ begin
           until False;
         end;
 
-        // Align to increment-boundary bucket (same sign-aware logic as years)
-        if Sign < 0 then
-          ScaledValue := WholeUnits - 1
+        if Sign > 0 then
+          ScaledValue := (WholeUnits div Increment) * Increment
         else
-          ScaledValue := WholeUnits;
-        if (ScaledValue >= 0) or (ScaledValue mod Increment = 0) then
-          ScaledValue := (ScaledValue div Increment) * Increment
-        else
-          ScaledValue := ((ScaledValue div Increment) - 1) * Increment;
+          ScaledValue := -(((-WholeUnits) div Increment) * Increment);
 
         WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, ScaledValue);
         WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
-        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, ScaledValue + Increment);
+        NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day,
+          ScaledValue + Sign * Increment);
         NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
-        PeriodNs := (NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
-        RoundedValue := RoundWithMode((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs, PeriodNs, Mode);
+        PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+        RoundedValue := RoundWithMode(
+          Abs((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs), PeriodNs, Mode);
         if RoundedValue >= PeriodNs then
-          WholeUnits := ScaledValue + Increment
+          WholeUnits := ScaledValue + Sign * Increment
         else
           WholeUnits := ScaledValue;
 

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -203,9 +203,11 @@ var
   DecStr: string;
 begin
   if IsNaN(AValue) or IsInfinite(AValue) then
-    raise Exception.Create('Cannot convert non-finite number to BigInt');
+    ThrowRangeError('Temporal.Duration field must be a finite integer',
+      SSuggestTemporalDurationRange);
   if Frac(AValue) <> 0 then
-    raise Exception.Create('Cannot convert non-integer to BigInt');
+    ThrowRangeError('Temporal.Duration field must be an integer',
+      SSuggestTemporalDurationRange);
   Str(AValue:0:0, DecStr);
   Result := TBigInteger.FromDecimalString(DecStr);
 end;

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -5,6 +5,8 @@ unit Goccia.Values.TemporalDuration;
 interface
 
 uses
+  BigInteger,
+
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
   Goccia.SharedPrototype,
@@ -24,8 +26,20 @@ type
     FMilliseconds: Int64;
     FMicroseconds: Int64;
     FNanoseconds: Int64;
+    FYearsBig: TBigInteger;
+    FMonthsBig: TBigInteger;
+    FWeeksBig: TBigInteger;
+    FDaysBig: TBigInteger;
+    FHoursBig: TBigInteger;
+    FMinutesBig: TBigInteger;
+    FSecondsBig: TBigInteger;
+    FMillisecondsBig: TBigInteger;
+    FMicrosecondsBig: TBigInteger;
+    FNanosecondsBig: TBigInteger;
 
     procedure InitializePrototype;
+    procedure SetDurationFields(const AYears, AMonths, AWeeks, ADays, AHours, AMinutes, ASeconds,
+      AMilliseconds, AMicroseconds, ANanoseconds: TBigInteger);
 
     function ComputeSign: Integer;
     function IsBlank: Boolean;
@@ -33,6 +47,8 @@ type
   public
     constructor Create(const AYears, AMonths, AWeeks, ADays, AHours, AMinutes, ASeconds,
       AMilliseconds, AMicroseconds, ANanoseconds: Int64); overload;
+    constructor CreateFromBigIntegers(const AYears, AMonths, AWeeks, ADays, AHours, AMinutes, ASeconds,
+      AMilliseconds, AMicroseconds, ANanoseconds: TBigInteger); overload;
 
     function ToStringTag: string; override;
     class procedure ExposePrototype(const AConstructor: TGocciaObjectValue);
@@ -83,6 +99,7 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Realm,
+  Goccia.Temporal.DurationMath,
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
@@ -145,53 +162,108 @@ end;
 
 { TGocciaTemporalDurationValue }
 
+function BigIntSign(const AValue: TBigInteger): Integer;
+begin
+  if AValue.IsPositive then
+    Result := 1
+  else if AValue.IsNegative then
+    Result := -1
+  else
+    Result := 0;
+end;
+
+function BigIntToLegacyInt64(const AValue: TBigInteger): Int64;
+begin
+  if (AValue.Compare(TBigInteger.FromInt64(Low(Int64))) < 0) or
+     (AValue.Compare(TBigInteger.FromInt64(High(Int64))) > 0) then
+    Result := 0
+  else
+    Result := AValue.ToInt64;
+end;
+
+function BigIntFieldToNumber(const AValue: TBigInteger): TGocciaNumberLiteralValue;
+begin
+  Result := TGocciaNumberLiteralValue.Create(AValue.ToDouble);
+end;
+
 constructor TGocciaTemporalDurationValue.Create(const AYears, AMonths, AWeeks, ADays, AHours, AMinutes, ASeconds,
   AMilliseconds, AMicroseconds, ANanoseconds: Int64);
-var
-  HasPositive, HasNegative: Boolean;
-  NormalizedSeconds, V: Double;
 begin
   inherited Create(nil);
-  FYears := AYears;
-  FMonths := AMonths;
-  FWeeks := AWeeks;
-  FDays := ADays;
-  FHours := AHours;
-  FMinutes := AMinutes;
-  FSeconds := ASeconds;
-  FMilliseconds := AMilliseconds;
-  FMicroseconds := AMicroseconds;
-  FNanoseconds := ANanoseconds;
+  SetDurationFields(
+    TBigInteger.FromInt64(AYears),
+    TBigInteger.FromInt64(AMonths),
+    TBigInteger.FromInt64(AWeeks),
+    TBigInteger.FromInt64(ADays),
+    TBigInteger.FromInt64(AHours),
+    TBigInteger.FromInt64(AMinutes),
+    TBigInteger.FromInt64(ASeconds),
+    TBigInteger.FromInt64(AMilliseconds),
+    TBigInteger.FromInt64(AMicroseconds),
+    TBigInteger.FromInt64(ANanoseconds));
+end;
+
+constructor TGocciaTemporalDurationValue.CreateFromBigIntegers(const AYears, AMonths, AWeeks, ADays,
+  AHours, AMinutes, ASeconds, AMilliseconds, AMicroseconds, ANanoseconds: TBigInteger);
+begin
+  inherited Create(nil);
+  SetDurationFields(AYears, AMonths, AWeeks, ADays, AHours, AMinutes, ASeconds,
+    AMilliseconds, AMicroseconds, ANanoseconds);
+end;
+
+procedure TGocciaTemporalDurationValue.SetDurationFields(const AYears, AMonths, AWeeks, ADays,
+  AHours, AMinutes, ASeconds, AMilliseconds, AMicroseconds, ANanoseconds: TBigInteger);
+var
+  HasPositive, HasNegative: Boolean;
+  TimeDuration, NormalizedNanoseconds: TBigInteger;
+begin
+  FYearsBig := AYears;
+  FMonthsBig := AMonths;
+  FWeeksBig := AWeeks;
+  FDaysBig := ADays;
+  FHoursBig := AHours;
+  FMinutesBig := AMinutes;
+  FSecondsBig := ASeconds;
+  FMillisecondsBig := AMilliseconds;
+  FMicrosecondsBig := AMicroseconds;
+  FNanosecondsBig := ANanoseconds;
+
+  FYears := BigIntToLegacyInt64(AYears);
+  FMonths := BigIntToLegacyInt64(AMonths);
+  FWeeks := BigIntToLegacyInt64(AWeeks);
+  FDays := BigIntToLegacyInt64(ADays);
+  FHours := BigIntToLegacyInt64(AHours);
+  FMinutes := BigIntToLegacyInt64(AMinutes);
+  FSeconds := BigIntToLegacyInt64(ASeconds);
+  FMilliseconds := BigIntToLegacyInt64(AMilliseconds);
+  FMicroseconds := BigIntToLegacyInt64(AMicroseconds);
+  FNanoseconds := BigIntToLegacyInt64(ANanoseconds);
 
   // Validate: sign of non-zero components must be uniform
-  HasPositive := (AYears > 0) or (AMonths > 0) or (AWeeks > 0) or (ADays > 0) or
-                 (AHours > 0) or (AMinutes > 0) or (ASeconds > 0) or
-                 (AMilliseconds > 0) or (AMicroseconds > 0) or (ANanoseconds > 0);
-  HasNegative := (AYears < 0) or (AMonths < 0) or (AWeeks < 0) or (ADays < 0) or
-                 (AHours < 0) or (AMinutes < 0) or (ASeconds < 0) or
-                 (AMilliseconds < 0) or (AMicroseconds < 0) or (ANanoseconds < 0);
+  HasPositive := (BigIntSign(AYears) > 0) or (BigIntSign(AMonths) > 0) or
+                 (BigIntSign(AWeeks) > 0) or (BigIntSign(ADays) > 0) or
+                 (BigIntSign(AHours) > 0) or (BigIntSign(AMinutes) > 0) or
+                 (BigIntSign(ASeconds) > 0) or (BigIntSign(AMilliseconds) > 0) or
+                 (BigIntSign(AMicroseconds) > 0) or (BigIntSign(ANanoseconds) > 0);
+  HasNegative := (BigIntSign(AYears) < 0) or (BigIntSign(AMonths) < 0) or
+                 (BigIntSign(AWeeks) < 0) or (BigIntSign(ADays) < 0) or
+                 (BigIntSign(AHours) < 0) or (BigIntSign(AMinutes) < 0) or
+                 (BigIntSign(ASeconds) < 0) or (BigIntSign(AMilliseconds) < 0) or
+                 (BigIntSign(AMicroseconds) < 0) or (BigIntSign(ANanoseconds) < 0);
   if HasPositive and HasNegative then
     ThrowRangeError(SErrorDurationMixedSigns, SSuggestTemporalDurationSigns);
 
-  // Validate: calendar unit magnitudes must be < 2^32.
-  // Use signed bounds rather than `Abs(X) >= UINT32_MODULUS`: in FPC,
-  // `Abs(Low(Int64))` overflows (the result wraps back to Low(Int64)), so a
-  // worst-case input would slip past the magnitude check.
-  if (AYears <= -Int64(UINT32_MODULUS)) or (AYears >= UINT32_MODULUS) or
-     (AMonths <= -Int64(UINT32_MODULUS)) or (AMonths >= UINT32_MODULUS) or
-     (AWeeks <= -Int64(UINT32_MODULUS)) or (AWeeks >= UINT32_MODULUS) then
+  // TC39 Temporal §7.5.16 IsValidDuration step 3-5
+  if (AYears.AbsValue.Compare(TBigInteger.FromInt64(UINT32_MODULUS)) >= 0) or
+     (AMonths.AbsValue.Compare(TBigInteger.FromInt64(UINT32_MODULUS)) >= 0) or
+     (AWeeks.AbsValue.Compare(TBigInteger.FromInt64(UINT32_MODULUS)) >= 0) then
     ThrowRangeError(SErrorDurationCalendarOutOfRange, SSuggestTemporalDurationRange);
 
-  // Validate: normalized seconds must be < 2^53 (TC39 §7.5.22 step 6-7)
-  // Use implicit Int64->Double assignment to avoid FPC 3.2.2 cast bugs.
-  V := ADays;         NormalizedSeconds := V * 86400;
-  V := AHours;        NormalizedSeconds := NormalizedSeconds + V * 3600;
-  V := AMinutes;      NormalizedSeconds := NormalizedSeconds + V * 60;
-  V := ASeconds;      NormalizedSeconds := NormalizedSeconds + V;
-  V := AMilliseconds; NormalizedSeconds := NormalizedSeconds + V * 1e-3;
-  V := AMicroseconds; NormalizedSeconds := NormalizedSeconds + V * 1e-6;
-  V := ANanoseconds;  NormalizedSeconds := NormalizedSeconds + V * 1e-9;
-  if Abs(NormalizedSeconds) >= 9007199254740992.0 then
+  // TC39 Temporal §7.5.16 IsValidDuration step 6-8
+  TimeDuration := TimeDurationFromComponents(AHours, AMinutes, ASeconds,
+    AMilliseconds, AMicroseconds, ANanoseconds);
+  NormalizedNanoseconds := TimeDuration.Add(ADays.Multiply(TBigInteger.FromInt64(NANOSECONDS_PER_DAY)));
+  if not IsValidTimeDuration(NormalizedNanoseconds) then
     ThrowRangeError(SErrorDurationTimeOutOfRange, SSuggestTemporalDurationRange);
 
   InitializePrototype;
@@ -264,13 +336,15 @@ end;
 
 function TGocciaTemporalDurationValue.ComputeSign: Integer;
 begin
-  if (FYears > 0) or (FMonths > 0) or (FWeeks > 0) or (FDays > 0) or
-     (FHours > 0) or (FMinutes > 0) or (FSeconds > 0) or
-     (FMilliseconds > 0) or (FMicroseconds > 0) or (FNanoseconds > 0) then
+  if (FYearsBig.IsPositive) or (FMonthsBig.IsPositive) or (FWeeksBig.IsPositive) or
+     (FDaysBig.IsPositive) or (FHoursBig.IsPositive) or (FMinutesBig.IsPositive) or
+     (FSecondsBig.IsPositive) or (FMillisecondsBig.IsPositive) or
+     (FMicrosecondsBig.IsPositive) or (FNanosecondsBig.IsPositive) then
     Result := 1
-  else if (FYears < 0) or (FMonths < 0) or (FWeeks < 0) or (FDays < 0) or
-          (FHours < 0) or (FMinutes < 0) or (FSeconds < 0) or
-          (FMilliseconds < 0) or (FMicroseconds < 0) or (FNanoseconds < 0) then
+  else if (FYearsBig.IsNegative) or (FMonthsBig.IsNegative) or (FWeeksBig.IsNegative) or
+          (FDaysBig.IsNegative) or (FHoursBig.IsNegative) or (FMinutesBig.IsNegative) or
+          (FSecondsBig.IsNegative) or (FMillisecondsBig.IsNegative) or
+          (FMicrosecondsBig.IsNegative) or (FNanosecondsBig.IsNegative) then
     Result := -1
   else
     Result := 0;
@@ -285,7 +359,9 @@ function TGocciaTemporalDurationValue.ToISOString: string;
 var
   DatePart, TimePart: string;
   ASign: Integer;
-  AbsY, AbsMo, AbsW, AbsD, AbsH, AbsMi, AbsS, AbsMs, AbsUs, AbsNs: Int64;
+  AbsY, AbsMo, AbsW, AbsD, AbsH, AbsMi: TBigInteger;
+  SecondsDuration, AbsSecondsDuration, SecondsPart, SubSecondsPart: TBigInteger;
+  Fraction: string;
 begin
   ASign := ComputeSign;
   if ASign = 0 then
@@ -294,39 +370,45 @@ begin
     Exit;
   end;
 
-  AbsY := Abs(FYears);
-  AbsMo := Abs(FMonths);
-  AbsW := Abs(FWeeks);
-  AbsD := Abs(FDays);
-  AbsH := Abs(FHours);
-  AbsMi := Abs(FMinutes);
-  AbsS := Abs(FSeconds);
-  AbsMs := Abs(FMilliseconds);
-  AbsUs := Abs(FMicroseconds);
-  AbsNs := Abs(FNanoseconds);
+  AbsY := FYearsBig.AbsValue;
+  AbsMo := FMonthsBig.AbsValue;
+  AbsW := FWeeksBig.AbsValue;
+  AbsD := FDaysBig.AbsValue;
+  AbsH := FHoursBig.AbsValue;
+  AbsMi := FMinutesBig.AbsValue;
 
   DatePart := '';
-  if AbsY > 0 then DatePart := DatePart + IntToStr(AbsY) + 'Y';
-  if AbsMo > 0 then DatePart := DatePart + IntToStr(AbsMo) + 'M';
-  if AbsW > 0 then DatePart := DatePart + IntToStr(AbsW) + 'W';
-  if AbsD > 0 then DatePart := DatePart + IntToStr(AbsD) + 'D';
+  if not AbsY.IsZero then DatePart := DatePart + AbsY.ToString + 'Y';
+  if not AbsMo.IsZero then DatePart := DatePart + AbsMo.ToString + 'M';
+  if not AbsW.IsZero then DatePart := DatePart + AbsW.ToString + 'W';
+  if not AbsD.IsZero then DatePart := DatePart + AbsD.ToString + 'D';
 
   TimePart := '';
-  if AbsH > 0 then TimePart := TimePart + IntToStr(AbsH) + 'H';
-  if AbsMi > 0 then TimePart := TimePart + IntToStr(AbsMi) + 'M';
+  if not AbsH.IsZero then TimePart := TimePart + AbsH.ToString + 'H';
+  if not AbsMi.IsZero then TimePart := TimePart + AbsMi.ToString + 'M';
 
-  if (AbsS > 0) or (AbsMs > 0) or (AbsUs > 0) or (AbsNs > 0) then
+  // TC39 Temporal §7.5.40 step 12: recombine second-and-smaller fields before formatting.
+  SecondsDuration := TimeDurationFromComponents(TBigInteger.Zero, TBigInteger.Zero,
+    FSecondsBig, FMillisecondsBig, FMicrosecondsBig, FNanosecondsBig);
+  if (not SecondsDuration.IsZero) or ((DatePart = '') and (TimePart = '')) then
   begin
-    TimePart := TimePart + IntToStr(AbsS);
-    if (AbsMs > 0) or (AbsUs > 0) or (AbsNs > 0) then
+    AbsSecondsDuration := SecondsDuration.AbsValue;
+    SecondsPart := AbsSecondsDuration.Divide(TBigInteger.FromInt64(NANOSECONDS_PER_SECOND));
+    SubSecondsPart := AbsSecondsDuration.Modulo(TBigInteger.FromInt64(NANOSECONDS_PER_SECOND));
+    TimePart := TimePart + SecondsPart.ToString;
+    if not SubSecondsPart.IsZero then
     begin
-      TimePart := TimePart + '.';
-      if AbsNs > 0 then
-        TimePart := TimePart + Format('%.3d%.3d%.3d', [AbsMs, AbsUs, AbsNs])
-      else if AbsUs > 0 then
-        TimePart := TimePart + Format('%.3d%.3d', [AbsMs, AbsUs])
+      Fraction := Format('%.9d', [SubSecondsPart.ToInt64]);
+      if not FNanosecondsBig.IsZero then
+      begin
+        while (Length(Fraction) > 0) and (Fraction[Length(Fraction)] = '0') do
+          Delete(Fraction, Length(Fraction), 1);
+      end
+      else if not FMicrosecondsBig.IsZero then
+        Fraction := Copy(Fraction, 1, 6)
       else
-        TimePart := TimePart + Format('%.3d', [AbsMs]);
+        Fraction := Copy(Fraction, 1, 3);
+      TimePart := TimePart + '.' + Fraction;
     end;
     TimePart := TimePart + 'S';
   end;
@@ -348,52 +430,52 @@ end;
 
 function TGocciaTemporalDurationValue.GetYears(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.years').FYears);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.years').FYearsBig);
 end;
 
 function TGocciaTemporalDurationValue.GetMonths(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.months').FMonths);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.months').FMonthsBig);
 end;
 
 function TGocciaTemporalDurationValue.GetWeeks(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.weeks').FWeeks);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.weeks').FWeeksBig);
 end;
 
 function TGocciaTemporalDurationValue.GetDays(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.days').FDays);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.days').FDaysBig);
 end;
 
 function TGocciaTemporalDurationValue.GetHours(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.hours').FHours);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.hours').FHoursBig);
 end;
 
 function TGocciaTemporalDurationValue.GetMinutes(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.minutes').FMinutes);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.minutes').FMinutesBig);
 end;
 
 function TGocciaTemporalDurationValue.GetSeconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.seconds').FSeconds);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.seconds').FSecondsBig);
 end;
 
 function TGocciaTemporalDurationValue.GetMilliseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.milliseconds').FMilliseconds);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.milliseconds').FMillisecondsBig);
 end;
 
 function TGocciaTemporalDurationValue.GetMicroseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.microseconds').FMicroseconds);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.microseconds').FMicrosecondsBig);
 end;
 
 function TGocciaTemporalDurationValue.GetNanoseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(AsDuration(AThisValue, 'get Duration.nanoseconds').FNanoseconds);
+  Result := BigIntFieldToNumber(AsDuration(AThisValue, 'get Duration.nanoseconds').FNanosecondsBig);
 end;
 
 function TGocciaTemporalDurationValue.GetSign(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -416,10 +498,10 @@ var
   D: TGocciaTemporalDurationValue;
 begin
   D := AsDuration(AThisValue, 'Duration.prototype.negated');
-  Result := TGocciaTemporalDurationValue.Create(
-    -D.FYears, -D.FMonths, -D.FWeeks, -D.FDays,
-    -D.FHours, -D.FMinutes, -D.FSeconds,
-    -D.FMilliseconds, -D.FMicroseconds, -D.FNanoseconds);
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    D.FYearsBig.Negate, D.FMonthsBig.Negate, D.FWeeksBig.Negate, D.FDaysBig.Negate,
+    D.FHoursBig.Negate, D.FMinutesBig.Negate, D.FSecondsBig.Negate,
+    D.FMillisecondsBig.Negate, D.FMicrosecondsBig.Negate, D.FNanosecondsBig.Negate);
 end;
 
 function TGocciaTemporalDurationValue.DurationAbs(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -427,10 +509,10 @@ var
   D: TGocciaTemporalDurationValue;
 begin
   D := AsDuration(AThisValue, 'Duration.prototype.abs');
-  Result := TGocciaTemporalDurationValue.Create(
-    Abs(D.FYears), Abs(D.FMonths), Abs(D.FWeeks), Abs(D.FDays),
-    Abs(D.FHours), Abs(D.FMinutes), Abs(D.FSeconds),
-    Abs(D.FMilliseconds), Abs(D.FMicroseconds), Abs(D.FNanoseconds));
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    D.FYearsBig.AbsValue, D.FMonthsBig.AbsValue, D.FWeeksBig.AbsValue, D.FDaysBig.AbsValue,
+    D.FHoursBig.AbsValue, D.FMinutesBig.AbsValue, D.FSecondsBig.AbsValue,
+    D.FMillisecondsBig.AbsValue, D.FMicrosecondsBig.AbsValue, D.FNanosecondsBig.AbsValue);
 end;
 
 function TGocciaTemporalDurationValue.DurationAdd(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -464,12 +546,12 @@ begin
     Other := nil;
   end;
 
-  Result := TGocciaTemporalDurationValue.Create(
-    D.FYears + Other.FYears, D.FMonths + Other.FMonths,
-    D.FWeeks + Other.FWeeks, D.FDays + Other.FDays,
-    D.FHours + Other.FHours, D.FMinutes + Other.FMinutes,
-    D.FSeconds + Other.FSeconds, D.FMilliseconds + Other.FMilliseconds,
-    D.FMicroseconds + Other.FMicroseconds, D.FNanoseconds + Other.FNanoseconds);
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    D.FYearsBig.Add(Other.FYearsBig), D.FMonthsBig.Add(Other.FMonthsBig),
+    D.FWeeksBig.Add(Other.FWeeksBig), D.FDaysBig.Add(Other.FDaysBig),
+    D.FHoursBig.Add(Other.FHoursBig), D.FMinutesBig.Add(Other.FMinutesBig),
+    D.FSecondsBig.Add(Other.FSecondsBig), D.FMillisecondsBig.Add(Other.FMillisecondsBig),
+    D.FMicrosecondsBig.Add(Other.FMicrosecondsBig), D.FNanosecondsBig.Add(Other.FNanosecondsBig));
 end;
 
 function TGocciaTemporalDurationValue.DurationSubtract(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -502,12 +584,12 @@ begin
     Other := nil;
   end;
 
-  Result := TGocciaTemporalDurationValue.Create(
-    D.FYears - Other.FYears, D.FMonths - Other.FMonths,
-    D.FWeeks - Other.FWeeks, D.FDays - Other.FDays,
-    D.FHours - Other.FHours, D.FMinutes - Other.FMinutes,
-    D.FSeconds - Other.FSeconds, D.FMilliseconds - Other.FMilliseconds,
-    D.FMicroseconds - Other.FMicroseconds, D.FNanoseconds - Other.FNanoseconds);
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    D.FYearsBig.Subtract(Other.FYearsBig), D.FMonthsBig.Subtract(Other.FMonthsBig),
+    D.FWeeksBig.Subtract(Other.FWeeksBig), D.FDaysBig.Subtract(Other.FDaysBig),
+    D.FHoursBig.Subtract(Other.FHoursBig), D.FMinutesBig.Subtract(Other.FMinutesBig),
+    D.FSecondsBig.Subtract(Other.FSecondsBig), D.FMillisecondsBig.Subtract(Other.FMillisecondsBig),
+    D.FMicrosecondsBig.Subtract(Other.FMicrosecondsBig), D.FNanosecondsBig.Subtract(Other.FNanosecondsBig));
 end;
 
 function TGocciaTemporalDurationValue.DurationWith(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -185,6 +185,37 @@ begin
   Result := TGocciaNumberLiteralValue.Create(AValue.ToDouble);
 end;
 
+function BigIntUnit(const AValue: Int64): TBigInteger; inline;
+begin
+  Result := TBigInteger.FromInt64(AValue);
+end;
+
+function UnitToNanosecondsBig(const AUnit: TTemporalUnit): TBigInteger;
+begin
+  Result := BigIntUnit(UnitToNanoseconds(AUnit));
+end;
+
+function DurationSubDayNanosecondsBig(const D: TGocciaTemporalDurationValue): TBigInteger;
+begin
+  Result := TimeDurationFromComponents(D.FHoursBig, D.FMinutesBig, D.FSecondsBig,
+    D.FMillisecondsBig, D.FMicrosecondsBig, D.FNanosecondsBig);
+end;
+
+function DurationTotalNanosecondsBig(const D: TGocciaTemporalDurationValue): TBigInteger;
+begin
+  Result := DurationSubDayNanosecondsBig(D)
+    .Add(D.FDaysBig.Multiply(BigIntUnit(NANOSECONDS_PER_DAY)))
+    .Add(D.FWeeksBig.Multiply(BigIntUnit(7)).Multiply(BigIntUnit(NANOSECONDS_PER_DAY)));
+end;
+
+function RoundingDivisorBig(const ASmallestUnit: TTemporalUnit; const AIncrement: Integer): TBigInteger;
+begin
+  if ASmallestUnit = tuWeek then
+    Result := BigIntUnit(NANOSECONDS_PER_DAY).Multiply(BigIntUnit(7)).Multiply(BigIntUnit(AIncrement))
+  else
+    Result := UnitToNanosecondsBig(ASmallestUnit).Multiply(BigIntUnit(AIncrement));
+end;
+
 constructor TGocciaTemporalDurationValue.Create(const AYears, AMonths, AWeeks, ADays, AHours, AMinutes, ASeconds,
   AMilliseconds, AMicroseconds, ANanoseconds: Int64);
 begin
@@ -437,16 +468,10 @@ begin
     if not SubSecondsPart.IsZero then
     begin
       Fraction := Format('%.9d', [SubSecondsPart.ToInt64]);
-      if not FNanosecondsBig.IsZero then
-      begin
-        while (Length(Fraction) > 0) and (Fraction[Length(Fraction)] = '0') do
-          Delete(Fraction, Length(Fraction), 1);
-      end
-      else if not FMicrosecondsBig.IsZero then
-        Fraction := Copy(Fraction, 1, 6)
-      else
-        Fraction := Copy(Fraction, 1, 3);
-      TimePart := TimePart + '.' + Fraction;
+      while (Length(Fraction) > 0) and (Fraction[Length(Fraction)] = '0') do
+        Delete(Fraction, Length(Fraction), 1);
+      if Length(Fraction) > 0 then
+        TimePart := TimePart + '.' + Fraction;
     end;
     TimePart := TimePart + 'S';
   end;
@@ -683,7 +708,9 @@ var
   Increment: Integer;
   HasRelativeTo: Boolean;
   RelDate: TTemporalDateRecord;
-  TotalNs, Divisor: Int64;
+  TotalNsBig, DivisorBig, TimeNsBig, CarryDaysBig: TBigInteger;
+  ResultHoursBig, ResultMinutesBig, ResultSecondsBig: TBigInteger;
+  ResultMsBig, ResultUsBig, ResultNsBig: TBigInteger;
   RemNs, TimeNs: Int64;
   ResultYears, ResultMonths: Int64;
   ResultDays, ResultHours, ResultMinutes, ResultSeconds: Int64;
@@ -694,6 +721,7 @@ var
   WholeUnits, PeriodNs, ScaledValue, RoundedValue: Int64;
   CarryDays: Int64;
   Sign: Integer;
+  CalendarYears, CalendarMonths, CalendarWeeks, CalendarDays: Int64;
 begin
   D := AsDuration(AThisValue, 'Duration.prototype.round');
   Arg := AArgs.GetElement(0);
@@ -734,15 +762,15 @@ begin
     SmallestUnit := tuNanosecond;
   if LargestUnit = tuNone then
   begin
-    if D.Years <> 0 then LargestUnit := tuYear
-    else if D.Months <> 0 then LargestUnit := tuMonth
-    else if D.Weeks <> 0 then LargestUnit := tuWeek
-    else if D.Days <> 0 then LargestUnit := tuDay
-    else if D.Hours <> 0 then LargestUnit := tuHour
-    else if D.Minutes <> 0 then LargestUnit := tuMinute
-    else if D.Seconds <> 0 then LargestUnit := tuSecond
-    else if D.Milliseconds <> 0 then LargestUnit := tuMillisecond
-    else if D.Microseconds <> 0 then LargestUnit := tuMicrosecond
+    if not D.FYearsBig.IsZero then LargestUnit := tuYear
+    else if not D.FMonthsBig.IsZero then LargestUnit := tuMonth
+    else if not D.FWeeksBig.IsZero then LargestUnit := tuWeek
+    else if not D.FDaysBig.IsZero then LargestUnit := tuDay
+    else if not D.FHoursBig.IsZero then LargestUnit := tuHour
+    else if not D.FMinutesBig.IsZero then LargestUnit := tuMinute
+    else if not D.FSecondsBig.IsZero then LargestUnit := tuSecond
+    else if not D.FMillisecondsBig.IsZero then LargestUnit := tuMillisecond
+    else if not D.FMicrosecondsBig.IsZero then LargestUnit := tuMicrosecond
     else LargestUnit := SmallestUnit;
     if Ord(LargestUnit) > Ord(SmallestUnit) then
       LargestUnit := SmallestUnit;
@@ -752,7 +780,7 @@ begin
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
 
   // Determine if calendar-relative computation is needed
-  NeedCalendar := (D.Years <> 0) or (D.Months <> 0) or
+  NeedCalendar := (not D.FYearsBig.IsZero) or (not D.FMonthsBig.IsZero) or
     (Ord(SmallestUnit) <= Ord(tuMonth)) or (Ord(LargestUnit) <= Ord(tuMonth));
 
   if NeedCalendar and not HasRelativeTo then
@@ -772,24 +800,25 @@ begin
     // separate calendar steps so day-clamping is applied after each,
     // matching TC39 Temporal semantics (e.g. 2020-02-29 + P1Y1M clamps to
     // 2021-02-28 after +1Y, then advances to 2021-03-28).
+    CalendarYears := BigIntToCheckedInt64(D.FYearsBig, 'years');
+    CalendarMonths := BigIntToCheckedInt64(D.FMonthsBig, 'months');
+    CalendarWeeks := BigIntToCheckedInt64(D.FWeeksBig, 'weeks');
+    CalendarDays := BigIntToCheckedInt64(D.FDaysBig, 'days');
     IntermDate := RelDate;
-    if D.Years <> 0 then
+    if not D.FYearsBig.IsZero then
       IntermDate := AddMonthsToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
-        D.Years * 12);
-    if D.Months <> 0 then
+        CalendarYears * 12);
+    if not D.FMonthsBig.IsZero then
       IntermDate := AddMonthsToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
-        D.Months);
-    TimeNs := D.Nanoseconds +
-              D.Microseconds * NANOSECONDS_PER_MICROSECOND +
-              D.Milliseconds * NANOSECONDS_PER_MILLISECOND +
-              D.Seconds * NANOSECONDS_PER_SECOND +
-              D.Minutes * NANOSECONDS_PER_MINUTE +
-              D.Hours * NANOSECONDS_PER_HOUR;
-    CarryDays := TimeNs div NANOSECONDS_PER_DAY;
-    TimeNs := TimeNs mod NANOSECONDS_PER_DAY;
+        CalendarMonths);
+    TimeNsBig := DurationSubDayNanosecondsBig(D);
+    CarryDaysBig := TimeNsBig.Divide(BigIntUnit(NANOSECONDS_PER_DAY));
+    TimeNsBig := TimeNsBig.Modulo(BigIntUnit(NANOSECONDS_PER_DAY));
+    CarryDays := BigIntToCheckedInt64(CarryDaysBig, 'carry days');
+    TimeNs := BigIntToCheckedInt64(TimeNsBig, 'sub-day nanoseconds');
 
     EndDate := AddDaysToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
-      D.Weeks * 7 + D.Days + CarryDays);
+      CalendarWeeks * 7 + CalendarDays + CarryDays);
     StartEpoch := DateToEpochDays(RelDate.Year, RelDate.Month, RelDate.Day);
     EndEpoch := DateToEpochDays(EndDate.Year, EndDate.Month, EndDate.Day);
 
@@ -909,22 +938,23 @@ begin
     end;
 
     // --- SmallestUnit is week, day, or time: convert to nanoseconds ---
-    TotalNs := (EndEpoch - StartEpoch) * NANOSECONDS_PER_DAY + TimeNs;
+    TotalNsBig := BigIntUnit(EndEpoch - StartEpoch)
+      .Multiply(BigIntUnit(NANOSECONDS_PER_DAY))
+      .Add(BigIntUnit(TimeNs));
 
     if SmallestUnit <> tuNanosecond then
     begin
-      if SmallestUnit = tuWeek then
-        Divisor := NANOSECONDS_PER_DAY * 7 * Increment
-      else
-        Divisor := UnitToNanoseconds(SmallestUnit) * Increment;
-      TotalNs := RoundWithMode(TotalNs, Divisor, Mode);
+      DivisorBig := RoundingDivisorBig(SmallestUnit, Increment);
+      TotalNsBig := RoundTimeDurationToIncrement(TotalNsBig, DivisorBig, Mode);
     end;
 
     // --- Rebalance to year/month if needed ---
     if Ord(LargestUnit) <= Ord(tuMonth) then
     begin
-      ResultDays := TotalNs div NANOSECONDS_PER_DAY;
-      RemNs := TotalNs mod NANOSECONDS_PER_DAY;
+      ResultDays := BigIntToCheckedInt64(
+        TotalNsBig.Divide(BigIntUnit(NANOSECONDS_PER_DAY)), 'days');
+      RemNs := BigIntToCheckedInt64(
+        TotalNsBig.Modulo(BigIntUnit(NANOSECONDS_PER_DAY)), 'sub-day nanoseconds');
 
       EndEpoch := StartEpoch + ResultDays;
       WholeUnits := 0;
@@ -986,74 +1016,27 @@ begin
   end
   else
   begin
-    // --- Non-calendar path (existing behavior) ---
-    TotalNs := D.Nanoseconds +
-               D.Microseconds * NANOSECONDS_PER_MICROSECOND +
-               D.Milliseconds * NANOSECONDS_PER_MILLISECOND +
-               D.Seconds * NANOSECONDS_PER_SECOND +
-               D.Minutes * NANOSECONDS_PER_MINUTE +
-               D.Hours * NANOSECONDS_PER_HOUR +
-               D.Days * NANOSECONDS_PER_DAY +
-               D.Weeks * 7 * NANOSECONDS_PER_DAY;
+    TotalNsBig := DurationTotalNanosecondsBig(D);
 
     if SmallestUnit <> tuNanosecond then
     begin
-      if SmallestUnit = tuWeek then
-        Divisor := NANOSECONDS_PER_DAY * 7 * Increment
-      else
-        Divisor := UnitToNanoseconds(SmallestUnit) * Increment;
-      TotalNs := RoundWithMode(TotalNs, Divisor, Mode);
+      DivisorBig := RoundingDivisorBig(SmallestUnit, Increment);
+      TotalNsBig := RoundTimeDurationToIncrement(TotalNsBig, DivisorBig, Mode);
     end;
   end;
 
-  // Break down from largestUnit (non-calendar output)
-  ResultDays := 0;
-  ResultHours := 0;
-  ResultMinutes := 0;
-  ResultSeconds := 0;
-  ResultMs := 0;
-  ResultUs := 0;
-  ResultNs := 0;
-  RemNs := TotalNs;
-
-  if Ord(LargestUnit) <= Ord(tuDay) then
-  begin
-    ResultDays := RemNs div NANOSECONDS_PER_DAY;
-    RemNs := RemNs mod NANOSECONDS_PER_DAY;
-  end;
-  if Ord(LargestUnit) <= Ord(tuHour) then
-  begin
-    ResultHours := RemNs div NANOSECONDS_PER_HOUR;
-    RemNs := RemNs mod NANOSECONDS_PER_HOUR;
-  end;
-  if Ord(LargestUnit) <= Ord(tuMinute) then
-  begin
-    ResultMinutes := RemNs div NANOSECONDS_PER_MINUTE;
-    RemNs := RemNs mod NANOSECONDS_PER_MINUTE;
-  end;
-  if Ord(LargestUnit) <= Ord(tuSecond) then
-  begin
-    ResultSeconds := RemNs div NANOSECONDS_PER_SECOND;
-    RemNs := RemNs mod NANOSECONDS_PER_SECOND;
-  end;
-  if Ord(LargestUnit) <= Ord(tuMillisecond) then
-  begin
-    ResultMs := RemNs div NANOSECONDS_PER_MILLISECOND;
-    RemNs := RemNs mod NANOSECONDS_PER_MILLISECOND;
-  end;
-  if Ord(LargestUnit) <= Ord(tuMicrosecond) then
-  begin
-    ResultUs := RemNs div NANOSECONDS_PER_MICROSECOND;
-    RemNs := RemNs mod NANOSECONDS_PER_MICROSECOND;
-  end;
-  ResultNs := RemNs;
+  BalanceTimeDurationToFields(TotalNsBig, LargestUnit, ResultHoursBig,
+    ResultMinutesBig, ResultSecondsBig, ResultMsBig, ResultUsBig, ResultNsBig,
+    ResultDays);
 
   if Ord(LargestUnit) <= Ord(tuWeek) then
-    Result := TGocciaTemporalDurationValue.Create(0, 0, ResultDays div 7, ResultDays mod 7,
-      ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs)
+    Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(TBigInteger.Zero, TBigInteger.Zero,
+      BigIntUnit(ResultDays div 7), BigIntUnit(ResultDays mod 7),
+      ResultHoursBig, ResultMinutesBig, ResultSecondsBig, ResultMsBig, ResultUsBig, ResultNsBig)
   else
-    Result := TGocciaTemporalDurationValue.Create(0, 0, 0, ResultDays,
-      ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs);
+    Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(TBigInteger.Zero, TBigInteger.Zero,
+      TBigInteger.Zero, BigIntUnit(ResultDays),
+      ResultHoursBig, ResultMinutesBig, ResultSecondsBig, ResultMsBig, ResultUsBig, ResultNsBig);
 end;
 
 function ZonedDateTimeToDateRecord(const AZdt: TGocciaTemporalZonedDateTimeValue): TTemporalDateRecord;
@@ -1178,22 +1161,6 @@ begin
             DateToEpochDays(ADate.Year, ADate.Month, ADate.Day);
 end;
 
-function SubDayNanoseconds(const D: TGocciaTemporalDurationValue): Double;
-var
-  Ns, V: Double;
-begin
-  // Accumulate via implicit Int64->Double assignment to avoid both FPC 3.2.2
-  // bugs: Bug A (Double(Int64) bit reinterpretation) and Bug B (Int64 * 1.0
-  // wrong results near +/-2^31 on AArch64). See docs/contributing/tooling.md.
-  Ns := D.Nanoseconds;
-  V := D.Microseconds; Ns := Ns + V * NANOSECONDS_PER_MICROSECOND;
-  V := D.Milliseconds; Ns := Ns + V * NANOSECONDS_PER_MILLISECOND;
-  V := D.Seconds;      Ns := Ns + V * NANOSECONDS_PER_SECOND;
-  V := D.Minutes;      Ns := Ns + V * NANOSECONDS_PER_MINUTE;
-  V := D.Hours;        Ns := Ns + V * NANOSECONDS_PER_HOUR;
-  Result := Ns;
-end;
-
 // Express the duration as a fractional month count relative to a reference date.
 // Walks forward from the reference date by the duration's calendar components,
 // then measures the result in calendar months plus a fractional remainder.
@@ -1204,17 +1171,26 @@ function ComputeTotalInUnits(const D: TGocciaTemporalDurationValue;
 var
   EndRec, CheckRec, SpanRec: TTemporalDateRecord;
   WholeUnits, CarryDays: Int64;
+  CalendarYears, CalendarMonths, CalendarWeeks, CalendarDays: Int64;
   TotalMonthsDiff: Int64;
   CheckEpoch, EndEpoch, SpanEpoch: Int64;
   RemainingDays, DaysInSpan: Int64;
-  TimeNs, RemainderNs, FracDays: Double;
+  RemainderNs, FracDays: Double;
+  TimeNsBig, CarryDaysBig, RemainderNsBig: TBigInteger;
 begin
   // Fold sub-day time overflow into whole days so the calendar walk is accurate
-  TimeNs := SubDayNanoseconds(D);
-  CarryDays := Trunc(TimeNs / NANOSECONDS_PER_DAY);
-  RemainderNs := TimeNs - CarryDays * NANOSECONDS_PER_DAY;
+  TimeNsBig := DurationSubDayNanosecondsBig(D);
+  CarryDaysBig := TimeNsBig.Divide(BigIntUnit(NANOSECONDS_PER_DAY));
+  RemainderNsBig := TimeNsBig.Modulo(BigIntUnit(NANOSECONDS_PER_DAY));
+  CarryDays := BigIntToCheckedInt64(CarryDaysBig, 'carry days');
+  RemainderNs := RemainderNsBig.ToDouble;
 
-  EndRec := DurationEndDate(ARelDate, D.Years, D.Months, D.Weeks, D.Days + CarryDays);
+  CalendarYears := BigIntToCheckedInt64(D.FYearsBig, 'years');
+  CalendarMonths := BigIntToCheckedInt64(D.FMonthsBig, 'months');
+  CalendarWeeks := BigIntToCheckedInt64(D.FWeeksBig, 'weeks');
+  CalendarDays := BigIntToCheckedInt64(D.FDaysBig, 'days');
+  EndRec := DurationEndDate(ARelDate, CalendarYears, CalendarMonths,
+    CalendarWeeks, CalendarDays + CarryDays);
   EndEpoch := DateToEpochDays(EndRec.Year, EndRec.Month, EndRec.Day);
 
   // Estimate whole units from the month difference
@@ -1288,7 +1264,7 @@ var
   HasRelativeTo: Boolean;
   RelDate: TTemporalDateRecord;
   ResolvedDays: Int64;
-  TotalNs, V: Double;
+  TotalNsBig: TBigInteger;
 begin
   D := AsDuration(AThisValue, 'Duration.prototype.total');
   Arg := AArgs.GetElement(0);
@@ -1336,30 +1312,32 @@ begin
   end;
 
   // Calendar source components (years/months) require relativeTo
-  if (D.Years <> 0) or (D.Months <> 0) then
+  if (not D.FYearsBig.IsZero) or (not D.FMonthsBig.IsZero) then
   begin
     if not HasRelativeTo then
       ThrowRangeError(SErrorDurationTotalRequiresRelativeTo, SSuggestTemporalRelativeTo);
 
     RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.total');
-    ResolvedDays := ResolveRelativeDays(RelDate, D.Years, D.Months, D.Weeks, D.Days);
+    ResolvedDays := ResolveRelativeDays(RelDate,
+      BigIntToCheckedInt64(D.FYearsBig, 'years'),
+      BigIntToCheckedInt64(D.FMonthsBig, 'months'),
+      BigIntToCheckedInt64(D.FWeeksBig, 'weeks'),
+      BigIntToCheckedInt64(D.FDaysBig, 'days'));
 
-    V := ResolvedDays;
-    TotalNs := SubDayNanoseconds(D) + V * NANOSECONDS_PER_DAY;
+    TotalNsBig := DurationSubDayNanosecondsBig(D)
+      .Add(BigIntUnit(ResolvedDays).Multiply(BigIntUnit(NANOSECONDS_PER_DAY)));
   end
   else
-  begin
-    TotalNs := SubDayNanoseconds(D);
-    V := D.Days;  TotalNs := TotalNs + V * NANOSECONDS_PER_DAY;
-    V := D.Weeks; TotalNs := TotalNs + V * 7 * NANOSECONDS_PER_DAY;
-  end;
+    TotalNsBig := DurationTotalNanosecondsBig(D);
 
   if TargetUnit = tuNanosecond then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs)
+    Result := TGocciaNumberLiteralValue.Create(TotalNsBig.ToDouble)
   else if TargetUnit = tuWeek then
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / (7 * NANOSECONDS_PER_DAY))
+    Result := TGocciaNumberLiteralValue.Create(
+      TotalNsBig.ToDouble / (7 * NANOSECONDS_PER_DAY))
   else
-    Result := TGocciaNumberLiteralValue.Create(TotalNs / UnitToNanoseconds(TargetUnit));
+    Result := TGocciaNumberLiteralValue.Create(
+      TotalNsBig.ToDouble / UnitToNanoseconds(TargetUnit));
 end;
 
 function TGocciaTemporalDurationValue.DurationToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -83,21 +83,30 @@ begin
   Result := TGocciaTemporalInstantValue(AValue);
 end;
 
-procedure NormalizeInstantSubMillisecondNanoseconds(var AEpochMilliseconds: Int64;
-  const ASubNanosecondsTotal: Int64; out ASubMillisecondNanoseconds: Integer);
+procedure NormalizeInstantSubMillisecondNanoseconds(var AEpochMilliseconds: TBigInteger;
+  const ASubNanosecondsTotal: TBigInteger; out ASubMillisecondNanoseconds: Integer);
 var
-  CarryMilliseconds, RemainderNanoseconds: Int64;
+  CarryMilliseconds, RemainderNanoseconds, Million: TBigInteger;
 begin
-  CarryMilliseconds := ASubNanosecondsTotal div NANOSECONDS_PER_MILLISECOND;
-  RemainderNanoseconds := ASubNanosecondsTotal mod NANOSECONDS_PER_MILLISECOND;
-  if RemainderNanoseconds < 0 then
+  Million := TBigInteger.FromInt64(NANOSECONDS_PER_MILLISECOND);
+  CarryMilliseconds := ASubNanosecondsTotal.Divide(Million);
+  RemainderNanoseconds := ASubNanosecondsTotal.Modulo(Million);
+  if RemainderNanoseconds.IsNegative then
   begin
-    Dec(CarryMilliseconds);
-    Inc(RemainderNanoseconds, NANOSECONDS_PER_MILLISECOND);
+    CarryMilliseconds := CarryMilliseconds.Subtract(TBigInteger.One);
+    RemainderNanoseconds := RemainderNanoseconds.Add(Million);
   end;
 
-  Inc(AEpochMilliseconds, CarryMilliseconds);
-  ASubMillisecondNanoseconds := Integer(RemainderNanoseconds);
+  AEpochMilliseconds := AEpochMilliseconds.Add(CarryMilliseconds);
+  ASubMillisecondNanoseconds := Integer(RemainderNanoseconds.ToInt64);
+end;
+
+function BigIntToInstantInt64(const AValue: TBigInteger; const AFieldName: string): Int64;
+begin
+  if (AValue.Compare(TBigInteger.FromInt64(Low(Int64))) < 0) or
+     (AValue.Compare(TBigInteger.FromInt64(High(Int64))) > 0) then
+    raise ETemporalDurationInt64Overflow.CreateFmt('Temporal.Instant.%s is outside Int64 range', [AFieldName]);
+  Result := AValue.ToInt64;
 end;
 
 function CoerceInstant(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalInstantValue;
@@ -248,7 +257,7 @@ var
   DurRec: TTemporalDurationRecord;
   NewMs: Int64;
   NewSubMs: Integer;
-  SubNsTotal: Int64;
+  NewMsBig, SubNsTotal: TBigInteger;
 begin
   try
   Inst := AsInstant(AThisValue, 'Instant.prototype.add');
@@ -271,19 +280,21 @@ begin
   end;
 
   // Instant only supports time-based duration
-  if (Dur.Years <> 0) or (Dur.Months <> 0) or (Dur.Weeks <> 0) then
+  if (not Dur.YearsBig.IsZero) or (not Dur.MonthsBig.IsZero) or
+     (not Dur.WeeksBig.IsZero) then
     ThrowRangeError(SErrorInstantAddNoCalendar, SSuggestTemporalDurationArg);
 
-  NewMs := Inst.FEpochMilliseconds +
-           Dur.Days * Int64(86400000) +
-           Dur.Hours * 3600000 +
-           Dur.Minutes * 60000 +
-           Dur.Seconds * 1000 +
-           Dur.Milliseconds;
-  SubNsTotal := Int64(Inst.FSubMillisecondNanoseconds) +
-                Dur.Microseconds * Int64(NANOSECONDS_PER_MICROSECOND) +
-                Dur.Nanoseconds;
-  NormalizeInstantSubMillisecondNanoseconds(NewMs, SubNsTotal, NewSubMs);
+  NewMsBig := TBigInteger.FromInt64(Inst.FEpochMilliseconds)
+    .Add(Dur.DaysBig.Multiply(TBigInteger.FromInt64(86400000)))
+    .Add(Dur.HoursBig.Multiply(TBigInteger.FromInt64(3600000)))
+    .Add(Dur.MinutesBig.Multiply(TBigInteger.FromInt64(60000)))
+    .Add(Dur.SecondsBig.Multiply(TBigInteger.FromInt64(1000)))
+    .Add(Dur.MillisecondsBig);
+  SubNsTotal := TBigInteger.FromInt64(Inst.FSubMillisecondNanoseconds)
+    .Add(Dur.MicrosecondsBig.Multiply(TBigInteger.FromInt64(NANOSECONDS_PER_MICROSECOND)))
+    .Add(Dur.NanosecondsBig);
+  NormalizeInstantSubMillisecondNanoseconds(NewMsBig, SubNsTotal, NewSubMs);
+  NewMs := BigIntToInstantInt64(NewMsBig, 'epochMilliseconds');
 
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
   except
@@ -300,7 +311,7 @@ var
   DurRec: TTemporalDurationRecord;
   NewMs: Int64;
   NewSubMs: Integer;
-  SubNsTotal: Int64;
+  NewMsBig, SubNsTotal: TBigInteger;
 begin
   try
   Inst := AsInstant(AThisValue, 'Instant.prototype.subtract');
@@ -322,19 +333,21 @@ begin
     Dur := nil;
   end;
 
-  if (Dur.Years <> 0) or (Dur.Months <> 0) or (Dur.Weeks <> 0) then
+  if (not Dur.YearsBig.IsZero) or (not Dur.MonthsBig.IsZero) or
+     (not Dur.WeeksBig.IsZero) then
     ThrowRangeError(SErrorInstantSubtractNoCalendar, SSuggestTemporalDurationArg);
 
-  NewMs := Inst.FEpochMilliseconds -
-           Dur.Days * Int64(86400000) -
-           Dur.Hours * 3600000 -
-           Dur.Minutes * 60000 -
-           Dur.Seconds * 1000 -
-           Dur.Milliseconds;
-  SubNsTotal := Int64(Inst.FSubMillisecondNanoseconds) -
-                Dur.Microseconds * Int64(NANOSECONDS_PER_MICROSECOND) -
-                Dur.Nanoseconds;
-  NormalizeInstantSubMillisecondNanoseconds(NewMs, SubNsTotal, NewSubMs);
+  NewMsBig := TBigInteger.FromInt64(Inst.FEpochMilliseconds)
+    .Subtract(Dur.DaysBig.Multiply(TBigInteger.FromInt64(86400000)))
+    .Subtract(Dur.HoursBig.Multiply(TBigInteger.FromInt64(3600000)))
+    .Subtract(Dur.MinutesBig.Multiply(TBigInteger.FromInt64(60000)))
+    .Subtract(Dur.SecondsBig.Multiply(TBigInteger.FromInt64(1000)))
+    .Subtract(Dur.MillisecondsBig);
+  SubNsTotal := TBigInteger.FromInt64(Inst.FSubMillisecondNanoseconds)
+    .Subtract(Dur.MicrosecondsBig.Multiply(TBigInteger.FromInt64(NANOSECONDS_PER_MICROSECOND)))
+    .Subtract(Dur.NanosecondsBig);
+  NormalizeInstantSubMillisecondNanoseconds(NewMsBig, SubNsTotal, NewSubMs);
+  NewMs := BigIntToInstantInt64(NewMsBig, 'epochMilliseconds');
 
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
   except
@@ -479,7 +492,8 @@ begin
   BigTotal := TBigInteger.FromInt64(Inst.FEpochMilliseconds)
     .Multiply(BigMillion)
     .Add(TBigInteger.FromInt64(Inst.FSubMillisecondNanoseconds));
-  BigDivisor := TBigInteger.FromInt64(UnitToNanoseconds(SmallestUnit) * Increment);
+  BigDivisor := TBigInteger.FromInt64(UnitToNanoseconds(SmallestUnit))
+    .Multiply(TBigInteger.FromInt64(Increment));
   BigRounded := RoundBigIntWithMode(BigTotal, BigDivisor, Mode);
 
   NewMs := BigRounded.Divide(BigMillion).ToInt64;

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -232,6 +232,7 @@ var
   NewMs: Int64;
   NewSubMs: Integer;
 begin
+  try
   Inst := AsInstant(AThisValue, 'Instant.prototype.add');
   Arg := AArgs.GetElement(0);
 
@@ -265,6 +266,10 @@ begin
               Integer(Dur.Microseconds * 1000 + Dur.Nanoseconds);
 
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 function TGocciaTemporalInstantValue.InstantSubtract(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -276,6 +281,7 @@ var
   NewMs: Int64;
   NewSubMs: Integer;
 begin
+  try
   Inst := AsInstant(AThisValue, 'Instant.prototype.subtract');
   Arg := AArgs.GetElement(0);
 
@@ -308,6 +314,10 @@ begin
               Integer(Dur.Microseconds * 1000 + Dur.Nanoseconds);
 
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 function InstantDiffToUnits(const ATimeDuration: TBigInteger;

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -52,6 +52,7 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Realm,
+  Goccia.Temporal.DurationMath,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
   Goccia.Values.BigIntValue,
@@ -309,58 +310,17 @@ begin
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
 end;
 
-function InstantDiffToUnits(const ADiffMs: Int64; const ADiffSubMs: Integer;
+function InstantDiffToUnits(const ATimeDuration: TBigInteger;
   const ALargestUnit: TTemporalUnit): TGocciaValue;
 var
-  Ms, SubMs: Int64;
-  TotalSec, TotalMin: Int64;
+  Hours, Minutes, Seconds, Milliseconds, Microseconds, Nanoseconds: TBigInteger;
+  Days: Int64;
 begin
-  Ms := ADiffMs;
-  SubMs := ADiffSubMs;
-
-  case ALargestUnit of
-    tuHour:
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-        Ms div 3600000,
-        (Ms mod 3600000) div 60000,
-        ((Ms mod 3600000) mod 60000) div 1000,
-        ((Ms mod 3600000) mod 60000) mod 1000,
-        SubMs div 1000,
-        SubMs mod 1000);
-    tuMinute:
-    begin
-      TotalMin := Ms div 60000;
-      Ms := Ms mod 60000;
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0,
-        TotalMin,
-        Ms div 1000,
-        Ms mod 1000,
-        SubMs div 1000,
-        SubMs mod 1000);
-    end;
-    tuSecond:
-    begin
-      TotalSec := Ms div 1000;
-      Ms := Ms mod 1000;
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0,
-        TotalSec,
-        Ms,
-        SubMs div 1000,
-        SubMs mod 1000);
-    end;
-    tuMillisecond:
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0,
-        Ms,
-        SubMs div 1000,
-        SubMs mod 1000);
-    tuMicrosecond:
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0,
-        Ms * 1000 + SubMs div 1000,
-        SubMs mod 1000);
-  else // tuNanosecond
-    Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0,
-      Ms * 1000000 + SubMs);
-  end;
+  BalanceTimeDurationToFields(ATimeDuration, ALargestUnit,
+    Hours, Minutes, Seconds, Milliseconds, Microseconds, Nanoseconds, Days);
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    TBigInteger.Zero, TBigInteger.Zero, TBigInteger.Zero, TBigInteger.FromInt64(Days),
+    Hours, Minutes, Seconds, Milliseconds, Microseconds, Nanoseconds);
 end;
 
 function TGocciaTemporalInstantValue.InstantUntil(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -370,10 +330,7 @@ var
   LargestUnit, SmallestUnit: TTemporalUnit;
   RMode: TTemporalRoundingMode;
   RIncrement: Integer;
-  DiffMs: Int64;
-  DiffSubMs: Integer;
-  Dur: TGocciaTemporalDurationValue;
-  Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
+  StartNs, EndNs, DiffNs, IncrementNs: TBigInteger;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.until');
   Other := CoerceInstant(AArgs.GetElement(0), 'Instant.prototype.until');
@@ -393,33 +350,16 @@ begin
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
   ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
-  DiffMs := Other.FEpochMilliseconds - Inst.FEpochMilliseconds;
-  DiffSubMs := Other.FSubMillisecondNanoseconds - Inst.FSubMillisecondNanoseconds;
-
-  // Normalize so DiffMs and DiffSubMs share the same sign
-  if (DiffMs > 0) and (DiffSubMs < 0) then
-  begin
-    Dec(DiffMs);
-    Inc(DiffSubMs, 1000000);
-  end
-  else if (DiffMs < 0) and (DiffSubMs > 0) then
-  begin
-    Inc(DiffMs);
-    Dec(DiffSubMs, 1000000);
-  end;
-
-  Result := InstantDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
-
+  StartNs := EpochNanosecondsFromParts(Inst.FEpochMilliseconds, Inst.FSubMillisecondNanoseconds);
+  EndNs := EpochNanosecondsFromParts(Other.FEpochMilliseconds, Other.FSubMillisecondNanoseconds);
+  DiffNs := TimeDurationFromEpochNanosecondsDifference(EndNs, StartNs);
   if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
   begin
-    Dur := TGocciaTemporalDurationValue(Result);
-    Y := Dur.Years; Mo := Dur.Months; W := Dur.Weeks; D := Dur.Days;
-    H := Dur.Hours; Mi := Dur.Minutes; S := Dur.Seconds;
-    Ms := Dur.Milliseconds; Us := Dur.Microseconds; Ns := Dur.Nanoseconds;
-    RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,
-      0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
-    Result := TGocciaTemporalDurationValue.Create(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns);
+    IncrementNs := TBigInteger.FromInt64(UnitToNanoseconds(SmallestUnit))
+      .Multiply(TBigInteger.FromInt64(RIncrement));
+    DiffNs := RoundTimeDurationToIncrement(DiffNs, IncrementNs, RMode);
   end;
+  Result := InstantDiffToUnits(DiffNs, LargestUnit);
 end;
 
 function TGocciaTemporalInstantValue.InstantSince(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -429,10 +369,7 @@ var
   LargestUnit, SmallestUnit: TTemporalUnit;
   RMode: TTemporalRoundingMode;
   RIncrement: Integer;
-  DiffMs: Int64;
-  DiffSubMs: Integer;
-  Dur: TGocciaTemporalDurationValue;
-  Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
+  StartNs, EndNs, DiffNs, IncrementNs: TBigInteger;
 begin
   Inst := AsInstant(AThisValue, 'Instant.prototype.since');
   Other := CoerceInstant(AArgs.GetElement(0), 'Instant.prototype.since');
@@ -452,33 +389,16 @@ begin
   RIncrement := GetRoundingIncrement(OptionsObj, 1);
   ValidateRoundingIncrement(RIncrement, SmallestUnit, LargestUnit);
 
-  DiffMs := Inst.FEpochMilliseconds - Other.FEpochMilliseconds;
-  DiffSubMs := Inst.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;
-
-  // Normalize so DiffMs and DiffSubMs share the same sign
-  if (DiffMs > 0) and (DiffSubMs < 0) then
-  begin
-    Dec(DiffMs);
-    Inc(DiffSubMs, 1000000);
-  end
-  else if (DiffMs < 0) and (DiffSubMs > 0) then
-  begin
-    Inc(DiffMs);
-    Dec(DiffSubMs, 1000000);
-  end;
-
-  Result := InstantDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
-
+  StartNs := EpochNanosecondsFromParts(Other.FEpochMilliseconds, Other.FSubMillisecondNanoseconds);
+  EndNs := EpochNanosecondsFromParts(Inst.FEpochMilliseconds, Inst.FSubMillisecondNanoseconds);
+  DiffNs := TimeDurationFromEpochNanosecondsDifference(EndNs, StartNs);
   if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
   begin
-    Dur := TGocciaTemporalDurationValue(Result);
-    Y := Dur.Years; Mo := Dur.Months; W := Dur.Weeks; D := Dur.Days;
-    H := Dur.Hours; Mi := Dur.Minutes; S := Dur.Seconds;
-    Ms := Dur.Milliseconds; Us := Dur.Microseconds; Ns := Dur.Nanoseconds;
-    RoundDiffDuration(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns,
-      0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
-    Result := TGocciaTemporalDurationValue.Create(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns);
+    IncrementNs := TBigInteger.FromInt64(UnitToNanoseconds(SmallestUnit))
+      .Multiply(TBigInteger.FromInt64(RIncrement));
+    DiffNs := RoundTimeDurationToIncrement(DiffNs, IncrementNs, RMode);
   end;
+  Result := InstantDiffToUnits(DiffNs, LargestUnit);
 end;
 
 function TGocciaTemporalInstantValue.InstantRound(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -83,6 +83,23 @@ begin
   Result := TGocciaTemporalInstantValue(AValue);
 end;
 
+procedure NormalizeInstantSubMillisecondNanoseconds(var AEpochMilliseconds: Int64;
+  const ASubNanosecondsTotal: Int64; out ASubMillisecondNanoseconds: Integer);
+var
+  CarryMilliseconds, RemainderNanoseconds: Int64;
+begin
+  CarryMilliseconds := ASubNanosecondsTotal div NANOSECONDS_PER_MILLISECOND;
+  RemainderNanoseconds := ASubNanosecondsTotal mod NANOSECONDS_PER_MILLISECOND;
+  if RemainderNanoseconds < 0 then
+  begin
+    Dec(CarryMilliseconds);
+    Inc(RemainderNanoseconds, NANOSECONDS_PER_MILLISECOND);
+  end;
+
+  Inc(AEpochMilliseconds, CarryMilliseconds);
+  ASubMillisecondNanoseconds := Integer(RemainderNanoseconds);
+end;
+
 function CoerceInstant(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalInstantValue;
 var
   DateRec: TTemporalDateRecord;
@@ -231,6 +248,7 @@ var
   DurRec: TTemporalDurationRecord;
   NewMs: Int64;
   NewSubMs: Integer;
+  SubNsTotal: Int64;
 begin
   try
   Inst := AsInstant(AThisValue, 'Instant.prototype.add');
@@ -262,8 +280,10 @@ begin
            Dur.Minutes * 60000 +
            Dur.Seconds * 1000 +
            Dur.Milliseconds;
-  NewSubMs := Inst.FSubMillisecondNanoseconds +
-              Integer(Dur.Microseconds * 1000 + Dur.Nanoseconds);
+  SubNsTotal := Int64(Inst.FSubMillisecondNanoseconds) +
+                Dur.Microseconds * Int64(NANOSECONDS_PER_MICROSECOND) +
+                Dur.Nanoseconds;
+  NormalizeInstantSubMillisecondNanoseconds(NewMs, SubNsTotal, NewSubMs);
 
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
   except
@@ -280,6 +300,7 @@ var
   DurRec: TTemporalDurationRecord;
   NewMs: Int64;
   NewSubMs: Integer;
+  SubNsTotal: Int64;
 begin
   try
   Inst := AsInstant(AThisValue, 'Instant.prototype.subtract');
@@ -310,8 +331,10 @@ begin
            Dur.Minutes * 60000 -
            Dur.Seconds * 1000 -
            Dur.Milliseconds;
-  NewSubMs := Inst.FSubMillisecondNanoseconds -
-              Integer(Dur.Microseconds * 1000 + Dur.Nanoseconds);
+  SubNsTotal := Int64(Inst.FSubMillisecondNanoseconds) -
+                Dur.Microseconds * Int64(NANOSECONDS_PER_MICROSECOND) -
+                Dur.Nanoseconds;
+  NormalizeInstantSubMillisecondNanoseconds(NewMs, SubNsTotal, NewSubMs);
 
   Result := TGocciaTemporalInstantValue.Create(NewMs, NewSubMs);
   except

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -395,6 +395,7 @@ var
   NewYear, NewMonth, NewDay: Integer;
   DateRec: TTemporalDateRecord;
 begin
+  try
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.add');
   Arg := AArgs.GetElement(0);
 
@@ -450,6 +451,10 @@ begin
   DateRec := AddDaysToDate(NewYear, NewMonth, NewDay, Dur.Weeks * 7 + Dur.Days);
 
   Result := TGocciaTemporalPlainDateValue.Create(DateRec.Year, DateRec.Month, DateRec.Day);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 function TGocciaTemporalPlainDateValue.DateSubtract(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -462,6 +467,7 @@ var
   NegatedDur: TGocciaTemporalDurationValue;
   NewArgs: TGocciaArgumentsCollection;
 begin
+  try
   D := AsPlainDate(AThisValue, 'PlainDate.prototype.subtract');
   Arg := AArgs.GetElement(0);
 
@@ -507,6 +513,10 @@ begin
     end;
   finally
     TGarbageCollector.Instance.RemoveTempRoot(NegatedDur);
+  end;
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
   end;
 end;
 

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -494,6 +494,7 @@ var
   VF: TGocciaValue;
   Y, Mo, W, Da, H, Mi, S, Ms, Us, Ns: Int64;
 begin
+  try
   D := AsPlainDateTime(AThisValue, 'PlainDateTime.prototype.add');
   Arg := AArgs.GetElement(0);
 
@@ -551,6 +552,10 @@ begin
     DateRec.Year, DateRec.Month, DateRec.Day,
     Balanced.Hour, Balanced.Minute, Balanced.Second,
     Balanced.Millisecond, Balanced.Microsecond, Balanced.Nanosecond);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 function TGocciaTemporalPlainDateTimeValue.DateTimeSubtract(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -564,6 +569,7 @@ var
   VF: TGocciaValue;
   Y, Mo, W, Da, H, Mi, S, Ms, Us, Ns: Int64;
 begin
+  try
   Arg := AArgs.GetElement(0);
 
   if Arg is TGocciaTemporalDurationValue then
@@ -609,6 +615,10 @@ begin
     Result := DateTimeAdd(NewArgs, AThisValue);
   finally
     NewArgs.Free;
+  end;
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
   end;
 end;
 

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -306,6 +306,7 @@ var
   VH: TGocciaValue;
   H, Mi, S, Ms, Us, Ns: Int64;
 begin
+  try
   T := AsPlainTime(AThisValue, 'PlainTime.prototype.add');
   Arg := AArgs.GetElement(0);
 
@@ -356,6 +357,10 @@ begin
   Result := TGocciaTemporalPlainTimeValue.Create(
     Balanced.Hour, Balanced.Minute, Balanced.Second,
     Balanced.Millisecond, Balanced.Microsecond, Balanced.Nanosecond);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 function TGocciaTemporalPlainTimeValue.TimeSubtract(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -370,6 +375,7 @@ var
   VH: TGocciaValue;
   H, Mi, S, Ms, Us, Ns: Int64;
 begin
+  try
   T := AsPlainTime(AThisValue, 'PlainTime.prototype.subtract');
   Arg := AArgs.GetElement(0);
 
@@ -420,6 +426,10 @@ begin
   Result := TGocciaTemporalPlainTimeValue.Create(
     Balanced.Hour, Balanced.Minute, Balanced.Second,
     Balanced.Millisecond, Balanced.Microsecond, Balanced.Nanosecond);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 { Shared logic for PlainTime until/since: parse options, decompose by

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -333,6 +333,7 @@ var
   end;
 
 begin
+  try
   YM := AsPlainYearMonth(AThisValue, 'PlainYearMonth.prototype.add');
   Arg := AArgs.GetElement(0);
 
@@ -378,6 +379,10 @@ begin
   end;
 
   Result := TGocciaTemporalPlainYearMonthValue.Create(NewYear, NewMonth, YM.FReferenceDay);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 // TC39 Temporal §10.3.13 Temporal.PlainYearMonth.prototype.subtract(temporalDurationLike)
@@ -402,6 +407,7 @@ var
   end;
 
 begin
+  try
   Arg := AArgs.GetElement(0);
 
   if Arg is TGocciaTemporalDurationValue then
@@ -439,6 +445,10 @@ begin
     Result := YearMonthAdd(NewArgs, AThisValue);
   finally
     NewArgs.Free;
+  end;
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
   end;
 end;
 

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -88,6 +88,7 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Realm,
+  Goccia.Temporal.DurationMath,
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
@@ -867,55 +868,17 @@ begin
   end;
 end;
 
-function ZonedDiffToUnits(const ADiffMs: Int64; const ADiffSubMs: Integer;
+function ZonedDiffToUnits(const ADiffNs: TBigInteger;
   const ALargestUnit: TTemporalUnit): TGocciaValue;
 var
-  TotalSec, TotalMin: Int64;
-  RemMs: Int64;
+  Hours, Minutes, Seconds, Milliseconds, Microseconds, Nanoseconds: TBigInteger;
+  Days: Int64;
 begin
-  case ALargestUnit of
-    tuHour:
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0,
-        ADiffMs div MILLISECONDS_PER_HOUR,
-        (ADiffMs mod MILLISECONDS_PER_HOUR) div MILLISECONDS_PER_MINUTE,
-        ((ADiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) div MILLISECONDS_PER_SECOND,
-        ((ADiffMs mod MILLISECONDS_PER_HOUR) mod MILLISECONDS_PER_MINUTE) mod MILLISECONDS_PER_SECOND,
-        ADiffSubMs div 1000,
-        ADiffSubMs mod 1000);
-    tuMinute:
-    begin
-      TotalMin := ADiffMs div MILLISECONDS_PER_MINUTE;
-      RemMs := ADiffMs mod MILLISECONDS_PER_MINUTE;
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0,
-        TotalMin,
-        RemMs div MILLISECONDS_PER_SECOND,
-        RemMs mod MILLISECONDS_PER_SECOND,
-        ADiffSubMs div 1000,
-        ADiffSubMs mod 1000);
-    end;
-    tuSecond:
-    begin
-      TotalSec := ADiffMs div MILLISECONDS_PER_SECOND;
-      RemMs := ADiffMs mod MILLISECONDS_PER_SECOND;
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0,
-        TotalSec,
-        RemMs,
-        ADiffSubMs div 1000,
-        ADiffSubMs mod 1000);
-    end;
-    tuMillisecond:
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0,
-        ADiffMs,
-        ADiffSubMs div 1000,
-        ADiffSubMs mod 1000);
-    tuMicrosecond:
-      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0,
-        ADiffMs * 1000 + ADiffSubMs div 1000,
-        ADiffSubMs mod 1000);
-  else // tuNanosecond
-    Result := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, 0, 0, 0, 0, 0,
-      ADiffMs * 1000000 + ADiffSubMs);
-  end;
+  BalanceTimeDurationToFields(ADiffNs, ALargestUnit,
+    Hours, Minutes, Seconds, Milliseconds, Microseconds, Nanoseconds, Days);
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    TBigInteger.Zero, TBigInteger.Zero, TBigInteger.Zero, TBigInteger.FromInt64(Days),
+    Hours, Minutes, Seconds, Milliseconds, Microseconds, Nanoseconds);
 end;
 
 // TC39 Temporal §6.3.28 Temporal.ZonedDateTime.prototype.until(other [, options])
@@ -926,8 +889,7 @@ var
   LargestUnit, SmallestUnit: TTemporalUnit;
   RMode: TTemporalRoundingMode;
   RIncrement: Integer;
-  DiffMs: Int64;
-  DiffSubMs: Integer;
+  StartNs, EndNs, DiffNs, IncrementNs: TBigInteger;
   Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1: Integer;
   Y2, M2, D2, H2, Mi2, S2, Ms2, Us2, Ns2: Integer;
   T1Ns, T2Ns, TimeDiffNs, TotalNs, Sgn, AbsTimeNs: Int64;
@@ -1014,33 +976,17 @@ begin
   end
   else
   begin
-    // Sub-day or day: use epoch difference
-    DiffMs := Other.FEpochMilliseconds - Zdt.FEpochMilliseconds;
-    DiffSubMs := Other.FSubMillisecondNanoseconds - Zdt.FSubMillisecondNanoseconds;
-
-    if (DiffMs > 0) and (DiffSubMs < 0) then
-    begin
-      Dec(DiffMs);
-      Inc(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
-    end
-    else if (DiffMs < 0) and (DiffSubMs > 0) then
-    begin
-      Inc(DiffMs);
-      Dec(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
-    end;
-
-    Result := ZonedDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
-
+    // Sub-day: use exact epoch nanosecond difference.
+    StartNs := EpochNanosecondsFromParts(Zdt.FEpochMilliseconds, Zdt.FSubMillisecondNanoseconds);
+    EndNs := EpochNanosecondsFromParts(Other.FEpochMilliseconds, Other.FSubMillisecondNanoseconds);
+    DiffNs := TimeDurationFromEpochNanosecondsDifference(EndNs, StartNs);
     if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
     begin
-      Dur := TGocciaTemporalDurationValue(Result);
-      RY := Dur.Years; RMo := Dur.Months; RW := Dur.Weeks; RD := Dur.Days;
-      RH := Dur.Hours; RM := Dur.Minutes; RS := Dur.Seconds;
-      RMs := Dur.Milliseconds; RUs := Dur.Microseconds; RNs := Dur.Nanoseconds;
-      RoundDiffDuration(RY, RMo, RW, RD, RH, RM, RS, RMs, RUs, RNs,
-        0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
-      Result := TGocciaTemporalDurationValue.Create(RY, RMo, RW, RD, RH, RM, RS, RMs, RUs, RNs);
+      IncrementNs := TBigInteger.FromInt64(UnitToNanoseconds(SmallestUnit))
+        .Multiply(TBigInteger.FromInt64(RIncrement));
+      DiffNs := RoundTimeDurationToIncrement(DiffNs, IncrementNs, RMode);
     end;
+    Result := ZonedDiffToUnits(DiffNs, LargestUnit);
   end;
 end;
 
@@ -1052,8 +998,7 @@ var
   LargestUnit, SmallestUnit: TTemporalUnit;
   RMode: TTemporalRoundingMode;
   RIncrement: Integer;
-  DiffMs: Int64;
-  DiffSubMs: Integer;
+  StartNs, EndNs, DiffNs, IncrementNs: TBigInteger;
   Y1, M1, D1, H1, Mi1, S1, Ms1, Us1, Ns1: Integer;
   Y2, M2, D2, H2, Mi2, S2, Ms2, Us2, Ns2: Integer;
   T1Ns, T2Ns, TimeDiffNs, TotalNs, Sgn, AbsTimeNs: Int64;
@@ -1140,33 +1085,17 @@ begin
   end
   else
   begin
-    // Sub-day or day: use epoch difference (this - other)
-    DiffMs := Zdt.FEpochMilliseconds - Other.FEpochMilliseconds;
-    DiffSubMs := Zdt.FSubMillisecondNanoseconds - Other.FSubMillisecondNanoseconds;
-
-    if (DiffMs > 0) and (DiffSubMs < 0) then
-    begin
-      Dec(DiffMs);
-      Inc(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
-    end
-    else if (DiffMs < 0) and (DiffSubMs > 0) then
-    begin
-      Inc(DiffMs);
-      Dec(DiffSubMs, SUB_MS_NANOSECOND_LIMIT);
-    end;
-
-    Result := ZonedDiffToUnits(DiffMs, DiffSubMs, LargestUnit);
-
+    // Sub-day: use exact epoch nanosecond difference (this - other).
+    StartNs := EpochNanosecondsFromParts(Other.FEpochMilliseconds, Other.FSubMillisecondNanoseconds);
+    EndNs := EpochNanosecondsFromParts(Zdt.FEpochMilliseconds, Zdt.FSubMillisecondNanoseconds);
+    DiffNs := TimeDurationFromEpochNanosecondsDifference(EndNs, StartNs);
     if (SmallestUnit <> tuNanosecond) or (RIncrement <> 1) then
     begin
-      Dur := TGocciaTemporalDurationValue(Result);
-      RY := Dur.Years; RMo := Dur.Months; RW := Dur.Weeks; RD := Dur.Days;
-      RH := Dur.Hours; RM := Dur.Minutes; RS := Dur.Seconds;
-      RMs := Dur.Milliseconds; RUs := Dur.Microseconds; RNs := Dur.Nanoseconds;
-      RoundDiffDuration(RY, RMo, RW, RD, RH, RM, RS, RMs, RUs, RNs,
-        0, 0, 0, LargestUnit, SmallestUnit, RMode, RIncrement);
-      Result := TGocciaTemporalDurationValue.Create(RY, RMo, RW, RD, RH, RM, RS, RMs, RUs, RNs);
+      IncrementNs := TBigInteger.FromInt64(UnitToNanoseconds(SmallestUnit))
+        .Multiply(TBigInteger.FromInt64(RIncrement));
+      DiffNs := RoundTimeDurationToIncrement(DiffNs, IncrementNs, RMode);
     end;
+    Result := ZonedDiffToUnits(DiffNs, LargestUnit);
   end;
 end;
 

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -815,6 +815,7 @@ var
   NewEpochMs: Int64;
   NewSubMs: Integer;
 begin
+  try
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.add');
   Dur := CoerceDuration(AArgs.GetElement(0), 'ZonedDateTime.prototype.add');
 
@@ -844,6 +845,10 @@ begin
   NewSubMs := Balanced.Microsecond * 1000 + Balanced.Nanosecond;
 
   Result := TGocciaTemporalZonedDateTimeValue.Create(NewEpochMs, NewSubMs, Zdt.FTimeZone);
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
+  end;
 end;
 
 // TC39 Temporal §6.3.27 Temporal.ZonedDateTime.prototype.subtract(temporalDurationLike [, options])
@@ -853,6 +858,7 @@ var
   NegDur: TGocciaTemporalDurationValue;
   NewArgs: TGocciaArgumentsCollection;
 begin
+  try
   Dur := CoerceDuration(AArgs.GetElement(0), 'ZonedDateTime.prototype.subtract');
 
   NegDur := TGocciaTemporalDurationValue.Create(
@@ -865,6 +871,10 @@ begin
     Result := ZonedDateTimeAdd(NewArgs, AThisValue);
   finally
     NewArgs.Free;
+  end;
+  except
+    on E: ETemporalDurationInt64Overflow do
+      ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
   end;
 end;
 

--- a/tests/built-ins/Temporal/Duration/compare.js
+++ b/tests/built-ins/Temporal/Duration/compare.js
@@ -13,4 +13,14 @@ describe.runIf(isTemporal)("Temporal.Duration.compare", () => {
     expect(Temporal.Duration.compare(d2, d1)).toBe(1);
     expect(Temporal.Duration.compare(d1, d1)).toBe(0);
   });
+
+  test("compare() handles BigInt-backed exact-time durations", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const large = i1.until(i2, { largestUnit: "microseconds" });
+    const larger = large.add({ seconds: 1 });
+    expect(Temporal.Duration.compare(large, larger)).toBe(-1);
+    expect(Temporal.Duration.compare(larger, large)).toBe(1);
+    expect(Temporal.Duration.compare(large, large)).toBe(0);
+  });
 });

--- a/tests/built-ins/Temporal/Duration/from.js
+++ b/tests/built-ins/Temporal/Duration/from.js
@@ -22,4 +22,11 @@ describe.runIf(isTemporal)("Temporal.Duration.from", () => {
     expect(d.minutes).toBe(30);
     expect(d.days).toBe(0);
   });
+
+  test("from() preserves BigInt-backed duration components", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const d = i1.until(i2, { largestUnit: "microseconds" });
+    expect(Temporal.Duration.from(d).toString()).toBe("PT17280000000000S");
+  });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -165,20 +165,16 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(rounded.months).toBe(18);
   });
 
-  test("round with relativeTo as ZonedDateTime", () => {
+  test("round rejects relativeTo as ZonedDateTime", () => {
     const d = Temporal.Duration.from({ years: 1, months: 6 });
     const zdt = Temporal.ZonedDateTime.from("2024-01-01T00:00:00+00:00[UTC]");
-    const rounded = d.round({ smallestUnit: "months", relativeTo: zdt });
-    expect(rounded.years).toBe(1);
-    expect(rounded.months).toBe(6);
+    expect(() => d.round({ smallestUnit: "months", relativeTo: zdt })).toThrow(RangeError);
   });
 
-  test("round with relativeTo as ZonedDateTime to days", () => {
+  test("round rejects relativeTo as ZonedDateTime to days", () => {
     const d = Temporal.Duration.from({ years: 1, months: 1 });
     const zdt = Temporal.ZonedDateTime.from("2020-02-29T10:30:00+00:00[UTC]");
-    const rounded = d.round({ smallestUnit: "days", largestUnit: "days", relativeTo: zdt });
-    // 2020-02-29 + 1Y = 2021-02-28 (clamped), + 1M = 2021-03-28 = 393 days
-    expect(rounded.days).toBe(393);
+    expect(() => d.round({ smallestUnit: "days", largestUnit: "days", relativeTo: zdt })).toThrow(RangeError);
   });
 
   test("round with relativeTo as property bag", () => {

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -20,6 +20,14 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(rounded.hours).toBe(2);
   });
 
+  test("round BigInt-backed exact-time duration", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const d = i1.until(i2, { largestUnit: "microseconds" });
+    const rounded = d.round({ smallestUnit: "seconds" });
+    expect(rounded.toString()).toBe("PT17280000000000S");
+  });
+
   test("round floor", () => {
     const d = new Temporal.Duration(0, 0, 0, 0, 1, 59);
     const rounded = d.round({ smallestUnit: "hour", roundingMode: "floor" });

--- a/tests/built-ins/Temporal/Duration/prototype/toString.js
+++ b/tests/built-ins/Temporal/Duration/prototype/toString.js
@@ -11,4 +11,11 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.toString", () => {
     expect(new Temporal.Duration().toString()).toBe("PT0S");
     expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 500).toString()).toBe("PT0.500S");
   });
+
+  test("toString() balances second-and-smaller fields", () => {
+    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 5000000000).toString()).toBe("PT5S");
+    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 500).toString()).toBe("PT0.500S");
+    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 1).toString()).toBe("PT0.000001S");
+    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 1).toString()).toBe("PT0.000000001S");
+  });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/toString.js
+++ b/tests/built-ins/Temporal/Duration/prototype/toString.js
@@ -9,12 +9,13 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.toString", () => {
   test("toString()", () => {
     expect(new Temporal.Duration(1, 2, 3, 4, 5, 6, 7).toString()).toBe("P1Y2M3W4DT5H6M7S");
     expect(new Temporal.Duration().toString()).toBe("PT0S");
-    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 500).toString()).toBe("PT0.500S");
+    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 500).toString()).toBe("PT0.5S");
   });
 
   test("toString() balances second-and-smaller fields", () => {
     expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 5000000000).toString()).toBe("PT5S");
-    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 500).toString()).toBe("PT0.500S");
+    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 1200).toString()).toBe("PT1.2S");
+    expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 500).toString()).toBe("PT0.5S");
     expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 1).toString()).toBe("PT0.000001S");
     expect(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 1).toString()).toBe("PT0.000000001S");
   });

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -13,6 +13,14 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     expect(d.total("seconds")).toBe(5400);
   });
 
+  test("total() with BigInt-backed exact-time duration", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const d = i1.until(i2, { largestUnit: "microseconds" });
+    expect(d.total("seconds")).toBe(17280000000000);
+    expect(d.total("hours")).toBe(4800000000);
+  });
+
   test("total() throws RangeError without relativeTo for year/month durations", () => {
     const withYears = new Temporal.Duration(1);
     expect(() => withYears.total("days")).toThrow(RangeError);

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -143,18 +143,16 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     expect(days).toBe(393);
   });
 
-  test("total() with relativeTo as ZonedDateTime", () => {
+  test("total() rejects relativeTo as ZonedDateTime", () => {
     const d = Temporal.Duration.from({ months: 6 });
     const zdt = Temporal.ZonedDateTime.from("2024-01-01T00:00:00+00:00[UTC]");
-    const days = d.total({ unit: "days", relativeTo: zdt });
-    // Jan(31) + Feb(29) + Mar(31) + Apr(30) + May(31) + Jun(30) = 182
-    expect(days).toBe(182);
+    expect(() => d.total({ unit: "days", relativeTo: zdt })).toThrow(RangeError);
   });
 
-  test("total() with relativeTo as ZonedDateTime converts to years", () => {
+  test("total() rejects relativeTo as ZonedDateTime for years", () => {
     const d = Temporal.Duration.from({ years: 2 });
     const zdt = Temporal.ZonedDateTime.from("2024-01-01T12:00:00+00:00[UTC]");
-    expect(d.total({ unit: "years", relativeTo: zdt })).toBe(2);
+    expect(() => d.total({ unit: "years", relativeTo: zdt })).toThrow(RangeError);
   });
 
   test("total() with relativeTo as property bag", () => {

--- a/tests/built-ins/Temporal/Duration/prototype/with.js
+++ b/tests/built-ins/Temporal/Duration/prototype/with.js
@@ -20,4 +20,10 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.with", () => {
     const updated = d.with({ microseconds: 17280000000000000000 });
     expect(updated.toString()).toBe("PT17280000000000S");
   });
+
+  test("with() rejects invalid numeric fields with RangeError", () => {
+    const d = new Temporal.Duration();
+    expect(() => d.with({ seconds: Infinity })).toThrow(RangeError);
+    expect(() => d.with({ seconds: 1.5 })).toThrow(RangeError);
+  });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/with.js
+++ b/tests/built-ins/Temporal/Duration/prototype/with.js
@@ -14,4 +14,10 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.with", () => {
     expect(updated.weeks).toBe(3);
     expect(updated.days).toBe(10);
   });
+
+  test("with() accepts large exact-time number fields", () => {
+    const d = new Temporal.Duration();
+    const updated = d.with({ microseconds: 17280000000000000000 });
+    expect(updated.toString()).toBe("PT17280000000000S");
+  });
 });

--- a/tests/built-ins/Temporal/Instant/fromEpochNanoseconds.js
+++ b/tests/built-ins/Temporal/Instant/fromEpochNanoseconds.js
@@ -15,4 +15,16 @@ describe.runIf(isTemporal)("Temporal.Instant.fromEpochNanoseconds", () => {
   test("requires BigInt argument", () => {
     expect(() => Temporal.Instant.fromEpochNanoseconds(1000000000)).toThrow(TypeError);
   });
+
+  test("accepts epoch nanoseconds range boundaries", () => {
+    const max = Temporal.Instant.fromEpochNanoseconds(8640000000000000000000n);
+    const min = Temporal.Instant.fromEpochNanoseconds(-8640000000000000000000n);
+    expect(max.epochNanoseconds).toBe(8640000000000000000000n);
+    expect(min.epochNanoseconds).toBe(-8640000000000000000000n);
+  });
+
+  test("throws RangeError for out-of-range epoch nanoseconds", () => {
+    expect(() => Temporal.Instant.fromEpochNanoseconds(8640000000000000000001n)).toThrow(RangeError);
+    expect(() => Temporal.Instant.fromEpochNanoseconds(-8640000000000000000001n)).toThrow(RangeError);
+  });
 });

--- a/tests/built-ins/Temporal/Instant/prototype/add.js
+++ b/tests/built-ins/Temporal/Instant/prototype/add.js
@@ -24,6 +24,13 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.add", () => {
     expect(result.epochNanoseconds).toBe(2147484000n);
   });
 
+  test("add() accepts BigInt-backed microsecond durations", () => {
+    const min = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const max = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const duration = min.until(max, { largestUnit: "microseconds" });
+    expect(min.add(duration).epochNanoseconds).toBe(max.epochNanoseconds);
+  });
+
   test("add() throws on years", () => {
     const instant = Temporal.Instant.fromEpochMilliseconds(0);
     expect(() => {

--- a/tests/built-ins/Temporal/Instant/prototype/add.js
+++ b/tests/built-ins/Temporal/Instant/prototype/add.js
@@ -12,6 +12,18 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.add", () => {
     expect(result.epochMilliseconds).toBe(3600000);
   });
 
+  test("add() normalizes sub-millisecond carry", () => {
+    const instant = Temporal.Instant.fromEpochNanoseconds(999999n);
+    const result = instant.add(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 1));
+    expect(result.epochNanoseconds).toBe(1000999n);
+  });
+
+  test("add() does not overflow 32-bit sub-millisecond accumulation", () => {
+    const instant = Temporal.Instant.fromEpochMilliseconds(0);
+    const result = instant.add(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 2147484));
+    expect(result.epochNanoseconds).toBe(2147484000n);
+  });
+
   test("add() throws on years", () => {
     const instant = Temporal.Instant.fromEpochMilliseconds(0);
     expect(() => {

--- a/tests/built-ins/Temporal/Instant/prototype/round.js
+++ b/tests/built-ins/Temporal/Instant/prototype/round.js
@@ -32,4 +32,10 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.round", () => {
     const rounded = inst.round("hour");
     expect(rounded.epochMilliseconds).toBe(8640000000000000);
   });
+
+  test("round with large day increment does not overflow divisor", () => {
+    const inst = Temporal.Instant.fromEpochMilliseconds(0);
+    const rounded = inst.round({ smallestUnit: "day", roundingIncrement: 200000 });
+    expect(rounded.epochNanoseconds).toBe(0n);
+  });
 });

--- a/tests/built-ins/Temporal/Instant/prototype/since.js
+++ b/tests/built-ins/Temporal/Instant/prototype/since.js
@@ -17,7 +17,7 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.since", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
     const dur = i1.since(i2, { largestUnit: "microseconds" });
-    expect(dur.microseconds).toBe(17280000000000000000);
+    expect(dur.toString()).toBe("PT17280000000000S");
     expect(dur.nanoseconds).toBe(0);
   });
 
@@ -25,7 +25,6 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.since", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
     const dur = i1.since(i2, { largestUnit: "nanoseconds" });
-    expect(dur.nanoseconds).toBe(17280000000000000000000);
     expect(dur.toString()).toBe("PT17280000000000S");
   });
 
@@ -33,7 +32,6 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.since", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
     const dur = i1.since(i2, { largestUnit: "nanoseconds" });
-    expect(dur.nanoseconds).toBe(-17280000000000000000000);
     expect(dur.toString()).toBe("-PT17280000000000S");
   });
 

--- a/tests/built-ins/Temporal/Instant/prototype/since.js
+++ b/tests/built-ins/Temporal/Instant/prototype/since.js
@@ -13,6 +13,30 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.since", () => {
     expect(dur.hours).toBe(1);
   });
 
+  test("since at extreme range with largestUnit microseconds does not overflow", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const dur = i1.since(i2, { largestUnit: "microseconds" });
+    expect(dur.microseconds).toBe(17280000000000000000);
+    expect(dur.nanoseconds).toBe(0);
+  });
+
+  test("since at extreme range with largestUnit nanoseconds does not overflow", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const dur = i1.since(i2, { largestUnit: "nanoseconds" });
+    expect(dur.nanoseconds).toBe(17280000000000000000000);
+    expect(dur.toString()).toBe("PT17280000000000S");
+  });
+
+  test("since negative at extreme range with largestUnit nanoseconds does not overflow", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const dur = i1.since(i2, { largestUnit: "nanoseconds" });
+    expect(dur.nanoseconds).toBe(-17280000000000000000000);
+    expect(dur.toString()).toBe("-PT17280000000000S");
+  });
+
   test("since() with largestUnit minutes", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(90061000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(0);
@@ -29,5 +53,13 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.since", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(5500);
     const i2 = Temporal.Instant.fromEpochMilliseconds(0);
     expect(i1.since(i2, { smallestUnit: "seconds", roundingMode: "halfExpand" }).toString()).toBe("PT6S");
+  });
+
+  test("since() with largestUnit nanoseconds formats balanced seconds", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(5000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(0);
+    const dur = i1.since(i2, { largestUnit: "nanoseconds" });
+    expect(dur.nanoseconds).toBe(5000000000);
+    expect(dur.toString()).toBe("PT5S");
   });
 });

--- a/tests/built-ins/Temporal/Instant/prototype/subtract.js
+++ b/tests/built-ins/Temporal/Instant/prototype/subtract.js
@@ -24,6 +24,13 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.subtract", () => {
     expect(result.epochNanoseconds).toBe(-2147484000n);
   });
 
+  test("subtract() accepts BigInt-backed microsecond durations", () => {
+    const min = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const max = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const duration = min.until(max, { largestUnit: "microseconds" });
+    expect(max.subtract(duration).epochNanoseconds).toBe(min.epochNanoseconds);
+  });
+
   test("subtract() throws on weeks", () => {
     const instant = Temporal.Instant.fromEpochMilliseconds(0);
     expect(() => {

--- a/tests/built-ins/Temporal/Instant/prototype/subtract.js
+++ b/tests/built-ins/Temporal/Instant/prototype/subtract.js
@@ -12,6 +12,18 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.subtract", () => {
     expect(result.epochMilliseconds).toBe(0);
   });
 
+  test("subtract() normalizes sub-millisecond borrow", () => {
+    const instant = Temporal.Instant.fromEpochNanoseconds(1n);
+    const result = instant.subtract(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 1));
+    expect(result.epochNanoseconds).toBe(-999n);
+  });
+
+  test("subtract() does not overflow 32-bit sub-millisecond accumulation", () => {
+    const instant = Temporal.Instant.fromEpochMilliseconds(0);
+    const result = instant.subtract(new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 2147484));
+    expect(result.epochNanoseconds).toBe(-2147484000n);
+  });
+
   test("subtract() throws on weeks", () => {
     const instant = Temporal.Instant.fromEpochMilliseconds(0);
     expect(() => {

--- a/tests/built-ins/Temporal/Instant/prototype/until.js
+++ b/tests/built-ins/Temporal/Instant/prototype/until.js
@@ -28,7 +28,7 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
     const dur = i1.until(i2, { largestUnit: "microseconds" });
-    expect(dur.microseconds).toBe(17280000000000000000);
+    expect(dur.toString()).toBe("PT17280000000000S");
     expect(dur.nanoseconds).toBe(0);
   });
 
@@ -36,7 +36,6 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
     const dur = i1.until(i2, { largestUnit: "nanoseconds" });
-    expect(dur.nanoseconds).toBe(17280000000000000000000);
     expect(dur.toString()).toBe("PT17280000000000S");
   });
 
@@ -44,7 +43,6 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
     const i2 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
     const dur = i1.until(i2, { largestUnit: "nanoseconds" });
-    expect(dur.nanoseconds).toBe(-17280000000000000000000);
     expect(dur.toString()).toBe("-PT17280000000000S");
   });
 

--- a/tests/built-ins/Temporal/Instant/prototype/until.js
+++ b/tests/built-ins/Temporal/Instant/prototype/until.js
@@ -24,6 +24,30 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
     expect(dur.milliseconds).toBe(0);
   });
 
+  test("until at extreme range with largestUnit microseconds does not overflow", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const dur = i1.until(i2, { largestUnit: "microseconds" });
+    expect(dur.microseconds).toBe(17280000000000000000);
+    expect(dur.nanoseconds).toBe(0);
+  });
+
+  test("until at extreme range with largestUnit nanoseconds does not overflow", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const dur = i1.until(i2, { largestUnit: "nanoseconds" });
+    expect(dur.nanoseconds).toBe(17280000000000000000000);
+    expect(dur.toString()).toBe("PT17280000000000S");
+  });
+
+  test("until negative at extreme range with largestUnit nanoseconds does not overflow", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(8640000000000000);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000);
+    const dur = i1.until(i2, { largestUnit: "nanoseconds" });
+    expect(dur.nanoseconds).toBe(-17280000000000000000000);
+    expect(dur.toString()).toBe("-PT17280000000000S");
+  });
+
   test("until() with largestUnit minutes", () => {
     const i1 = Temporal.Instant.fromEpochMilliseconds(0);
     const i2 = Temporal.Instant.fromEpochMilliseconds(90061000);
@@ -42,6 +66,14 @@ describe.runIf(isTemporal)("Temporal.Instant.prototype.until", () => {
     const dur = i1.until(i2, { largestUnit: "milliseconds" });
     expect(dur.milliseconds).toBe(5000);
     expect(dur.seconds).toBe(0);
+  });
+
+  test("until() with largestUnit nanoseconds formats balanced seconds", () => {
+    const i1 = Temporal.Instant.fromEpochMilliseconds(0);
+    const i2 = Temporal.Instant.fromEpochMilliseconds(5000);
+    const dur = i1.until(i2, { largestUnit: "nanoseconds" });
+    expect(dur.nanoseconds).toBe(5000000000);
+    expect(dur.toString()).toBe("PT5S");
   });
 
   test("until() negative with largestUnit minutes", () => {

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/since.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/since.js
@@ -26,7 +26,7 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.since", () => {
     const z1 = Temporal.Instant.fromEpochMilliseconds(8640000000000000).toZonedDateTimeISO("UTC");
     const z2 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000).toZonedDateTimeISO("UTC");
     const dur = z1.since(z2, { largestUnit: "microseconds" });
-    expect(dur.microseconds).toBe(17280000000000000000);
+    expect(dur.toString()).toBe("PT17280000000000S");
     expect(dur.nanoseconds).toBe(0);
   });
 

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/since.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/since.js
@@ -21,4 +21,20 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.since", () => {
     expect(dur.minutes).toBe(90);
     expect(dur.hours).toBe(0);
   });
+
+  test("since() with largestUnit microseconds does not overflow", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(8640000000000000).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000).toZonedDateTimeISO("UTC");
+    const dur = z1.since(z2, { largestUnit: "microseconds" });
+    expect(dur.microseconds).toBe(17280000000000000000);
+    expect(dur.nanoseconds).toBe(0);
+  });
+
+  test("since() with largestUnit nanoseconds formats balanced seconds", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(5000).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const dur = z1.since(z2, { largestUnit: "nanoseconds" });
+    expect(dur.nanoseconds).toBe(5000000000);
+    expect(dur.toString()).toBe("PT5S");
+  });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/until.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/until.js
@@ -38,6 +38,22 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.until", () => {
     expect(dur.minutes).toBe(0);
   });
 
+  test("until() with largestUnit microseconds does not overflow", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000).toZonedDateTimeISO("UTC");
+    const dur = z1.until(z2, { largestUnit: "microseconds" });
+    expect(dur.microseconds).toBe(17280000000000000000);
+    expect(dur.nanoseconds).toBe(0);
+  });
+
+  test("until() with largestUnit nanoseconds formats balanced seconds", () => {
+    const z1 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
+    const z2 = Temporal.Instant.fromEpochMilliseconds(5000).toZonedDateTimeISO("UTC");
+    const dur = z1.until(z2, { largestUnit: "nanoseconds" });
+    expect(dur.nanoseconds).toBe(5000000000);
+    expect(dur.toString()).toBe("PT5S");
+  });
+
   test("until() with smallestUnit minutes truncates seconds", () => {
     const z1 = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO("UTC");
     const z2 = Temporal.Instant.fromEpochMilliseconds(5400000 + 30000).toZonedDateTimeISO("UTC");

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/until.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/until.js
@@ -42,7 +42,7 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.prototype.until", () => {
     const z1 = Temporal.Instant.fromEpochMilliseconds(-8640000000000000).toZonedDateTimeISO("UTC");
     const z2 = Temporal.Instant.fromEpochMilliseconds(8640000000000000).toZonedDateTimeISO("UTC");
     const dur = z1.until(z2, { largestUnit: "microseconds" });
-    expect(dur.microseconds).toBe(17280000000000000000);
+    expect(dur.toString()).toBe("PT17280000000000S");
     expect(dur.nanoseconds).toBe(0);
   });
 


### PR DESCRIPTION
## Summary
- add shared BigInt-backed Temporal duration math helpers
- route Instant/ZonedDateTime exact-time diffs through BigInt nanosecond totals
- fix Duration string formatting for large second-and-smaller fields
- validate BigInt epoch nanoseconds range and add JS regressions for #420

Fixes #420