### PR TITLE
Add generated sources to CI FPC search path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
             echo ""
             echo "=== Building ${name} for ${TARGET} ==="
             "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
-              -Fu./source/units -Fu./source/shared -Fu./source/app -Fu./souffle \
+              -Fu./source/units -Fu./source/generated -Fu./source/shared -Fu./source/app -Fu./souffle \
               -Fi./source/units -Fi./source/shared -Fi./souffle \
               -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" -Fu"$FCL_NET_SRC" -Fu"$OPENSSL_SRC" \
               -FU"build/compiled" -FE"build" \
@@ -178,7 +178,7 @@ jobs:
             echo ""
             echo "=== Building ${name} for ${TARGET} ==="
             "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
-              -Fu./source/units -Fu./source/shared -Fu./source/app -Fu./souffle \
+              -Fu./source/units -Fu./source/generated -Fu./source/shared -Fu./source/app -Fu./souffle \
               -Fi./source/units -Fi./source/shared -Fi./souffle \
               -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" -Fu"$FCL_NET_SRC" -Fu"$OPENSSL_SRC" \
               -FU"build/compiled" -FE"build" \
@@ -191,7 +191,7 @@ jobs:
           echo ""
           echo "=== Building GocciaTOMLCheck for ${TARGET} ==="
           "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
-            -Fu./source/units -Fu./source/shared -Fu./source/app -Fu./souffle \
+            -Fu./source/units -Fu./source/generated -Fu./source/shared -Fu./source/app -Fu./souffle \
             -Fi./source/units -Fi./source/shared -Fi./souffle \
             -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" -Fu"$FCL_NET_SRC" -Fu"$OPENSSL_SRC" \
             -FU"build/compiled" -FE"build" \
@@ -203,7 +203,7 @@ jobs:
           echo ""
           echo "=== Building GocciaJSON5Check for ${TARGET} ==="
           "$CROSS_FPC" -T"${OS}" -O4 -dPRODUCTION -Xs -CX -XX -B \
-            -Fu./source/units -Fu./source/shared -Fu./source/app -Fu./souffle \
+            -Fu./source/units -Fu./source/generated -Fu./source/shared -Fu./source/app -Fu./souffle \
             -Fi./source/units -Fi./source/shared -Fi./souffle \
             -Fu"$RTL_DIR" -Fu"$OBJPAS_DIR" -Fu"$GEN_DIR" -Fu"$FCL_DIR" -Fu"$FCL_BASE_SRC" -Fu"$REGEXPR_SRC" -Fu"$FCL_NET_SRC" -Fu"$OPENSSL_SRC" \
             -FU"build/compiled" -FE"build" \


### PR DESCRIPTION
## Summary
- Add `source/generated` to CI cross-compile FPC unit search paths.
- Fixes the TimeZoat/Temporal data build failure where `Goccia.Temporal.TimeZoneData` could not resolve `Generated.TimeZoneData`.

## Verification
- `./build.pas --prod benchmarkrunner`
- CI-shaped direct `fpc ... -Fu./source/generated ... source/app/GocciaBenchmarkRunner.dpr`
- `./build.pas clean testrunner`
- `./fixtures/ffi/build.sh && ./build/GocciaTestRunner tests --asi --unsafe-ffi`
- `./format.pas --check`