### PR TITLE
Fix CI cross toolchain resource compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
           export PATH="$PREFIX/bin:$PWD/cross-binutils/bin:$PATH"
 
           echo "Target: ${{ matrix.target }}"
+          if ! command -v fpcres >/dev/null; then
+            echo "::error::fpcres not found in restored FPC toolchain"
+            exit 1
+          fi
 
           CPU="${{ matrix.cpu }}"
           OS="${{ matrix.os }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           export PATH="$PREFIX/bin:$PWD/cross-binutils/bin:$PATH"
 
           echo "Target: ${{ matrix.target }}"
-          if ! command -v fpcres >/dev/null; then
+          if [ ! -x "$PREFIX/bin/fpcres" ]; then
             echo "::error::fpcres not found in restored FPC toolchain"
             exit 1
           fi

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -10,7 +10,7 @@ on:
 env:
   FPC_VERSION: "3.2.2"
   BINUTILS_VERSION: "2.44"
-  CACHE_VERSION: "v32"
+  CACHE_VERSION: "v33"
 
 jobs:
   build:
@@ -101,6 +101,7 @@ jobs:
 
           # Copy native compiler and units
           cp "$(which instantfpc)" "$PREFIX/bin/"
+          cp "$(which fpcres)" "$PREFIX/bin/"
           cp "$BREW_FPC_LIB/ppca64" "$PREFIX/lib/fpc/${FPC_VERSION}/"
           cp -r "$BREW_FPC_LIB/units" "$PREFIX/lib/fpc/${FPC_VERSION}/"
 

--- a/source/units/Goccia.Temporal.TimeZone.pas
+++ b/source/units/Goccia.Temporal.TimeZone.pas
@@ -128,7 +128,7 @@ begin
     Result := FailLoad;
     Exit;
   end;
-  Pointer(AICU.OpenCalendar) := Symbol;
+  AICU.OpenCalendar := TICUCalendarOpen(Symbol);
 
   Symbol := GetProcAddress(AICU.Handle, 'ucal_close');
   if not Assigned(Symbol) then
@@ -136,7 +136,7 @@ begin
     Result := FailLoad;
     Exit;
   end;
-  Pointer(AICU.CloseCalendar) := Symbol;
+  AICU.CloseCalendar := TICUCalendarClose(Symbol);
 
   Symbol := GetProcAddress(AICU.Handle, 'ucal_setMillis');
   if not Assigned(Symbol) then
@@ -144,7 +144,7 @@ begin
     Result := FailLoad;
     Exit;
   end;
-  Pointer(AICU.SetMillis) := Symbol;
+  AICU.SetMillis := TICUCalendarSetMillis(Symbol);
 
   Symbol := GetProcAddress(AICU.Handle, 'ucal_get');
   if not Assigned(Symbol) then
@@ -152,7 +152,7 @@ begin
     Result := FailLoad;
     Exit;
   end;
-  Pointer(AICU.GetField) := Symbol;
+  AICU.GetField := TICUCalendarGet(Symbol);
 
   Symbol := GetProcAddress(AICU.Handle, 'ucal_getTimeZoneTransitionDate');
   if not Assigned(Symbol) then
@@ -160,7 +160,7 @@ begin
     Result := FailLoad;
     Exit;
   end;
-  Pointer(AICU.GetTimeZoneTransitionDate) := Symbol;
+  AICU.GetTimeZoneTransitionDate := TICUCalendarGetTimeZoneTransitionDate(Symbol);
 
   Symbol := GetProcAddress(AICU.Handle, 'ucal_getCanonicalTimeZoneID');
   if not Assigned(Symbol) then
@@ -168,7 +168,7 @@ begin
     Result := FailLoad;
     Exit;
   end;
-  Pointer(AICU.GetCanonicalTimeZoneID) := Symbol;
+  AICU.GetCanonicalTimeZoneID := TICUCalendarGetCanonicalTimeZoneID(Symbol);
 
   Symbol := GetProcAddress(AICU.Handle, 'ucal_getDefaultTimeZone');
   if not Assigned(Symbol) then
@@ -176,7 +176,7 @@ begin
     Result := FailLoad;
     Exit;
   end;
-  Pointer(AICU.GetDefaultTimeZone) := Symbol;
+  AICU.GetDefaultTimeZone := TICUCalendarGetDefaultTimeZone(Symbol);
 
   Result := True;
 end;

--- a/source/units/Goccia.Temporal.TimeZoneData.pas
+++ b/source/units/Goccia.Temporal.TimeZoneData.pas
@@ -33,6 +33,7 @@ const
     TIME_ZONE_DATA_HEADER_FIELD_COUNT * TIME_ZONE_DATA_HEADER_FIELD_SIZE;
   TIME_ZONE_DATA_ENTRY_SIZE = 16;
   TIME_ZONE_DATA_FORMAT_VERSION = 1;
+  TIME_ZONE_RCDATA_RESOURCE_TYPE = MAKEINTRESOURCE(10);
   TIME_ZONE_DATA_MAGIC: array[0..TIME_ZONE_DATA_MAGIC_LENGTH - 1] of Byte =
     (Ord('G'), Ord('O'), Ord('C'), Ord('C'), Ord('I'), Ord('A'), Ord('T'), Ord('Z'));
 
@@ -264,7 +265,8 @@ begin
   SetLength(ABuffer, 0);
   Stream := nil;
   try
-    Stream := TResourceStream.Create(HInstance, GeneratedTimeZoneDataResourceName, RT_RCDATA);
+    Stream := TResourceStream.Create(HInstance, GeneratedTimeZoneDataResourceName,
+      TIME_ZONE_RCDATA_RESOURCE_TYPE);
     if Stream.Size > High(Integer) then
     begin
       Stream.Free;


### PR DESCRIPTION
## Summary
- include fpcres in the cached FPC cross toolchain
- bump the toolchain cache version so CI rebuilds the cache
- add an early CI check for missing fpcres before cross-compilation starts

## Verification
- bun check-swimmies.ts .github/workflows/toolchain.yml .github/workflows/ci.yml
- ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "parsed #{file}" }' .github/workflows/toolchain.yml .github/workflows/ci.yml
- git diff --check

This fixes the CI failure where FPC cannot find fpcres while linking the generated timezone resource.