### PR TITLE
Add website Browserslist config

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,21 @@
     "format": "biome format --write",
     "test": "bun test"
   },
+  "browserslist": {
+    "production": [
+      "last 2 Chrome versions",
+      "last 2 Edge versions",
+      "last 2 Firefox versions",
+      "last 2 Safari versions",
+      "last 2 iOS versions",
+      "not dead"
+    ],
+    "development": [
+      "last 1 Chrome version",
+      "last 1 Firefox version",
+      "last 1 Safari version"
+    ]
+  },
   "dependencies": {
     "mermaid": "^11.14.0",
     "next": "16.2.4",


### PR DESCRIPTION
## Summary
- Add a rolling Browserslist configuration for the Next.js website
- Keep production targets on current evergreen browsers to avoid unnecessary legacy polyfills

## Verification
- bunx biome check package.json
- bun run build