### PR TITLE
Fix generator continuation replay

### DIFF
--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -97,12 +97,7 @@ Some opcode families intentionally use flags or mode operands instead of one opc
 - collection helpers use a shared opcode (`OP_COLLECTION_OP`) for object spread, object rest, and iterable-to-array spread
 - validation uses a shared opcode for require-object and require-iterable checks
 - generator metadata is serialized and a single `OP_YIELD` drives generator suspension; `yield*` uses the same opcode with delegation bookkeeping rather than a second opcode
-
-Note: bytecode generator resumption is currently replay-based: suspended generators
-re-enter from function entry and skip previously observed yields. True VM
-continuation snapshots that restore instruction pointer, registers, local cells,
-handler state, and GC marking are tracked in
-[#434](https://github.com/frostney/GocciaScript/issues/434).
+- bytecode generators suspend by snapshotting the VM continuation at `OP_YIELD` (instruction pointer, live registers, local cells, handler state, and GC-visible references) and resume from that snapshot instead of replaying from function entry
 
 Current opcode design rules:
 

--- a/source/units/Goccia.AST.Statements.pas
+++ b/source/units/Goccia.AST.Statements.pas
@@ -847,7 +847,7 @@ end;
 
   function TGocciaExpressionStatement.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
   begin
-    Result := TGocciaControlFlow.Normal(Expression.Evaluate(AContext));
+    Result := TGocciaControlFlow.Normal(EvaluateExpression(Expression, AContext));
   end;
 
   function TGocciaVariableDeclaration.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
@@ -862,7 +862,7 @@ end;
       Exit;
     for I := 0 to Length(Variables) - 1 do
     begin
-      Value := Variables[I].Initializer.Evaluate(AContext);
+      Value := EvaluateExpression(Variables[I].Initializer, AContext);
       if (Value is TGocciaFunctionValue) and (TGocciaFunctionValue(Value).Name = '') then
         TGocciaFunctionValue(Value).Name := Variables[I].Name
       else if Value is TGocciaClassValue then
@@ -926,7 +926,7 @@ end;
   begin
     if Assigned(Self.Value) then
     begin
-      ReturnValue := Self.Value.Evaluate(AContext);
+      ReturnValue := EvaluateExpression(Self.Value, AContext);
       if ReturnValue = nil then
         ReturnValue := TGocciaUndefinedLiteralValue.UndefinedValue;
     end
@@ -939,7 +939,7 @@ end;
   var
     ThrowValue: TGocciaValue;
   begin
-    ThrowValue := Self.Value.Evaluate(AContext);
+    ThrowValue := EvaluateExpression(Self.Value, AContext);
     raise TGocciaThrowValue.Create(ThrowValue);
   end;
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2110,6 +2110,16 @@ var
         HasUnhandledThrow := True;
         ThrownValue := E.Value;
       end;
+      on E: TGocciaTimeoutError do
+        raise;
+      on E: TGocciaInstructionLimitError do
+        raise;
+      on E: Exception do
+      begin
+        Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
+        HasUnhandledThrow := True;
+        ThrownValue := PascalExceptionToErrorObject(E);
+      end;
     end;
     CatchValue := nil;
   end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -376,6 +376,15 @@ begin
           Continuation.SaveStatementIndex(ANodes, I);
         raise;
       end;
+      else
+      begin
+        if Assigned(Continuation) then
+        begin
+          Continuation.ClearStatementIndex(ANodes);
+          Continuation.ClearExpressionValues;
+        end;
+        raise;
+      end;
     end;
     if Result.Kind <> cfkNormal then
     begin
@@ -2050,101 +2059,160 @@ end;
 
 function EvaluateTry(const ATryStatement: TGocciaTryStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
+  CatchValue: TGocciaValue;
+  Continuation: TGocciaGeneratorContinuation;
+  Phase: TGocciaGeneratorTryPhase;
+  TryState: TGocciaGeneratorTryState;
   ThrownValue: TGocciaValue;
   HasUnhandledThrow: Boolean;
   HasGeneratorReturn: Boolean;
   GeneratorReturnValue: TGocciaValue;
   FinallyCF: TGocciaControlFlow;
-begin
-  HasUnhandledThrow := False;
-  HasGeneratorReturn := False;
-  ThrownValue := nil;
-  GeneratorReturnValue := nil;
-  Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
 
-  // Phase 1: Execute try block, capturing throws
-  try
-    Result := EvaluateStatements(ATryStatement.Block.Nodes, AContext);
-  except
-    on E: EGocciaGeneratorYield do
-      raise;
-    on E: EGocciaGeneratorReturn do
-    begin
-      HasGeneratorReturn := True;
-      GeneratorReturnValue := E.Value;
-    end;
-    on E: TGocciaThrowValue do
-    begin
-      if Assigned(ATryStatement.CatchBlock) then
+  procedure SaveTryState(const APhase: TGocciaGeneratorTryPhase);
+  begin
+    if not Assigned(Continuation) then
+      Exit;
+    TryState := Continuation.EnsureTryState(ATryStatement);
+    TryState.Phase := APhase;
+    TryState.ResultFlow := Result;
+    TryState.CatchValue := CatchValue;
+    TryState.ThrownValue := ThrownValue;
+    TryState.GeneratorReturnValue := GeneratorReturnValue;
+    TryState.HasUnhandledThrow := HasUnhandledThrow;
+    TryState.HasGeneratorReturn := HasGeneratorReturn;
+  end;
+
+  procedure ClearTryState;
+  begin
+    if Assigned(Continuation) then
+      Continuation.ClearTryState(ATryStatement);
+  end;
+
+  procedure ExecuteCatchWithState(const AErrorValue: TGocciaValue);
+  begin
+    CatchValue := AErrorValue;
+    SaveTryState(gtpCatch);
+    try
+      Result := ExecuteCatchBlock(ATryStatement, AErrorValue, AContext);
+    except
+      on E: EGocciaGeneratorYield do
+        raise;
+      on E: EGocciaGeneratorReturn do
       begin
-        try
-          Result := ExecuteCatchBlock(ATryStatement, E.Value, AContext);
-        except
-          on E2: EGocciaGeneratorReturn do
-          begin
-            HasGeneratorReturn := True;
-            GeneratorReturnValue := E2.Value;
-          end;
-          on E2: TGocciaThrowValue do
-          begin
-            HasUnhandledThrow := True;
-            ThrownValue := E2.Value;
-          end;
-        end;
-      end
-      else
+        Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
+        HasGeneratorReturn := True;
+        GeneratorReturnValue := E.Value;
+      end;
+      on E: TGocciaThrowValue do
       begin
+        Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
         HasUnhandledThrow := True;
         ThrownValue := E.Value;
       end;
     end;
-    on E: TGocciaTimeoutError do
-      raise;
-    on E: TGocciaInstructionLimitError do
-      raise;
-    on E: Exception do
-    begin
-      if Assigned(ATryStatement.CatchBlock) then
+    CatchValue := nil;
+  end;
+begin
+  Continuation := CurrentGeneratorContinuation;
+  TryState := nil;
+  if Assigned(Continuation) then
+    TryState := Continuation.GetTryState(ATryStatement);
+  if Assigned(TryState) then
+  begin
+    Phase := TryState.Phase;
+    Result := TryState.ResultFlow;
+    CatchValue := TryState.CatchValue;
+    ThrownValue := TryState.ThrownValue;
+    GeneratorReturnValue := TryState.GeneratorReturnValue;
+    HasUnhandledThrow := TryState.HasUnhandledThrow;
+    HasGeneratorReturn := TryState.HasGeneratorReturn;
+  end
+  else
+  begin
+    Phase := gtpTry;
+    CatchValue := nil;
+    HasUnhandledThrow := False;
+    HasGeneratorReturn := False;
+    ThrownValue := nil;
+    GeneratorReturnValue := nil;
+    Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
+  end;
+
+  // Phase 1: Execute try block, capturing throws
+  if Phase = gtpTry then
+  begin
+    try
+      Result := EvaluateStatements(ATryStatement.Block.Nodes, AContext);
+    except
+      on E: EGocciaGeneratorYield do
+        raise;
+      on E: EGocciaGeneratorReturn do
       begin
-        try
-          Result := ExecuteCatchBlock(ATryStatement, PascalExceptionToErrorObject(E), AContext);
-        except
-          on E2: EGocciaGeneratorReturn do
-          begin
-            HasGeneratorReturn := True;
-            GeneratorReturnValue := E2.Value;
-          end;
-          on E2: TGocciaThrowValue do
-          begin
-            HasUnhandledThrow := True;
-            ThrownValue := E2.Value;
-          end;
+        Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
+        HasGeneratorReturn := True;
+        GeneratorReturnValue := E.Value;
+      end;
+      on E: TGocciaThrowValue do
+      begin
+        if Assigned(ATryStatement.CatchBlock) then
+          ExecuteCatchWithState(E.Value)
+        else
+        begin
+          Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
+          HasUnhandledThrow := True;
+          ThrownValue := E.Value;
         end;
-      end
-      else
+      end;
+      on E: TGocciaTimeoutError do
+        raise;
+      on E: TGocciaInstructionLimitError do
+        raise;
+      on E: Exception do
       begin
-        HasUnhandledThrow := True;
-        ThrownValue := PascalExceptionToErrorObject(E);
+        if Assigned(ATryStatement.CatchBlock) then
+          ExecuteCatchWithState(PascalExceptionToErrorObject(E))
+        else
+        begin
+          Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
+          HasUnhandledThrow := True;
+          ThrownValue := PascalExceptionToErrorObject(E);
+        end;
       end;
     end;
   end;
 
+  if Phase = gtpCatch then
+    ExecuteCatchWithState(CatchValue);
+
   // Phase 2: Execute finally block (always runs)
   if Assigned(ATryStatement.FinallyBlock) then
   begin
+    SaveTryState(gtpFinally);
     if HasUnhandledThrow and Assigned(TGarbageCollector.Instance) then
       TGarbageCollector.Instance.AddTempRoot(ThrownValue);
     if HasGeneratorReturn and Assigned(TGarbageCollector.Instance) then
       TGarbageCollector.Instance.AddTempRoot(GeneratorReturnValue);
     try
-      FinallyCF := EvaluateStatements(ATryStatement.FinallyBlock.Nodes, AContext);
-      // Per JS semantics: finally's control flow overrides try/catch result AND pending throw
-      if FinallyCF.Kind <> cfkNormal then
-      begin
-        Result := FinallyCF;
-        Exit;
+      try
+        FinallyCF := EvaluateStatements(ATryStatement.FinallyBlock.Nodes, AContext);
+        // Per JS semantics: finally's control flow overrides try/catch result AND pending throw
+        if FinallyCF.Kind <> cfkNormal then
+        begin
+          ClearTryState;
+          Result := FinallyCF;
+          Exit;
+        end;
+        // If finally throws (TGocciaThrowValue), it propagates naturally and overrides everything
+      except
+        on E: EGocciaGeneratorYield do
+          raise;
+        on E: Exception do
+        begin
+          ClearTryState;
+          raise;
+        end;
       end;
-      // If finally throws (TGocciaThrowValue), it propagates naturally and overrides everything
     finally
       if HasUnhandledThrow and Assigned(TGarbageCollector.Instance) then
         TGarbageCollector.Instance.RemoveTempRoot(ThrownValue);
@@ -2153,6 +2221,7 @@ begin
     end;
   end;
 
+  ClearTryState;
   if HasGeneratorReturn then
     raise EGocciaGeneratorReturn.Create(GeneratorReturnValue);
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -467,11 +467,11 @@ begin
     TGocciaCoverageTracker.Instance.RecordLineHit(
       AContext.CurrentFilePath, AExpression.Line);
   Continuation := CurrentGeneratorContinuation;
-  if Assigned(Continuation) and Continuation.TakeExpressionValue(AExpression, Result) then
+  if Assigned(Continuation) and Continuation.TakeCompletedExpressionValue(AExpression, Result) then
     Exit;
   Result := AExpression.Evaluate(AContext);
   if Assigned(Continuation) then
-    Continuation.SaveExpressionValue(AExpression, Result);
+    Continuation.SaveCompletedExpressionValue(AExpression, Result);
 end;
 
 function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -346,19 +346,47 @@ end;
 function EvaluateStatements(const ANodes: TObjectList<TGocciaASTNode>; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   I: Integer;
+  Continuation: TGocciaGeneratorContinuation;
 begin
   if Assigned(AContext.OnError) and not Assigned(AContext.Scope.OnError) then
     AContext.Scope.OnError := AContext.OnError;
 
+  Continuation := CurrentGeneratorContinuation;
   Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
-  for I := 0 to ANodes.Count - 1 do
+  if Assigned(Continuation) then
+    I := Continuation.GetStatementIndex(ANodes)
+  else
+    I := 0;
+  while I < ANodes.Count do
   begin
-    if ANodes[I] is TGocciaExpression then
-      Result := TGocciaControlFlow.Normal(EvaluateExpression(TGocciaExpression(ANodes[I]), AContext))
-    else
-      Result := EvaluateStatement(TGocciaStatement(ANodes[I]), AContext);
-    if Result.Kind <> cfkNormal then Exit;
+    try
+      if ANodes[I] is TGocciaExpression then
+        Result := TGocciaControlFlow.Normal(EvaluateExpression(TGocciaExpression(ANodes[I]), AContext))
+      else
+        Result := EvaluateStatement(TGocciaStatement(ANodes[I]), AContext);
+      if Assigned(Continuation) then
+      begin
+        Continuation.SaveStatementIndex(ANodes, I + 1);
+        Continuation.ClearExpressionValues;
+      end;
+    except
+      on E: EGocciaGeneratorYield do
+      begin
+        if Assigned(Continuation) then
+          Continuation.SaveStatementIndex(ANodes, I);
+        raise;
+      end;
+    end;
+    if Result.Kind <> cfkNormal then
+    begin
+      if Assigned(Continuation) then
+        Continuation.ClearStatementIndex(ANodes);
+      Exit;
+    end;
+    Inc(I);
   end;
+  if Assigned(Continuation) then
+    Continuation.ClearStatementIndex(ANodes);
 end;
 
 procedure SpreadIterableInto(const ASpreadValue: TGocciaValue; const ATarget: TGocciaValueList);
@@ -423,11 +451,18 @@ begin
 end;
 
 function EvaluateExpression(const AExpression: TGocciaExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
+var
+  Continuation: TGocciaGeneratorContinuation;
 begin
   if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
     TGocciaCoverageTracker.Instance.RecordLineHit(
       AContext.CurrentFilePath, AExpression.Line);
+  Continuation := CurrentGeneratorContinuation;
+  if Assigned(Continuation) and Continuation.TakeExpressionValue(AExpression, Result) then
+    Exit;
   Result := AExpression.Evaluate(AContext);
+  if Assigned(Continuation) then
+    Continuation.SaveExpressionValue(AExpression, Result);
 end;
 
 function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -463,12 +463,12 @@ function EvaluateExpression(const AExpression: TGocciaExpression; const AContext
 var
   Continuation: TGocciaGeneratorContinuation;
 begin
-  if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
-    TGocciaCoverageTracker.Instance.RecordLineHit(
-      AContext.CurrentFilePath, AExpression.Line);
   Continuation := CurrentGeneratorContinuation;
   if Assigned(Continuation) and Continuation.TakeCompletedExpressionValue(AExpression, Result) then
     Exit;
+  if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
+    TGocciaCoverageTracker.Instance.RecordLineHit(
+      AContext.CurrentFilePath, AExpression.Line);
   Result := AExpression.Evaluate(AContext);
   if Assigned(Continuation) then
     Continuation.SaveCompletedExpressionValue(AExpression, Result);

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -482,6 +482,27 @@ begin
   Result := AStatement.Execute(AContext);
 end;
 
+function EvaluateLoopBodyStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+var
+  Continuation: TGocciaGeneratorContinuation;
+begin
+  Continuation := CurrentGeneratorContinuation;
+  try
+    Result := EvaluateStatement(AStatement, AContext);
+    if Assigned(Continuation) then
+      Continuation.ClearExpressionValues;
+  except
+    on E: EGocciaGeneratorYield do
+      raise;
+    else
+    begin
+      if Assigned(Continuation) then
+        Continuation.ClearExpressionValues;
+      raise;
+    end;
+  end;
+end;
+
 function EvaluateBinary(const ABinaryExpression: TGocciaBinaryExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   Left, Right: TGocciaValue;
@@ -1451,7 +1472,7 @@ begin
       end;
 
       try
-        CF := EvaluateStatement(AForOfStatement.Body, IterContext);
+        CF := EvaluateLoopBodyStatement(AForOfStatement.Body, IterContext);
       finally
         if Assigned(AForOfStatement.MatchPattern) and
            (IterContext.Scope <> IterScope) then
@@ -1560,7 +1581,7 @@ begin
           end;
 
           try
-            CF := EvaluateStatement(AForAwaitOfStatement.Body, IterContext);
+            CF := EvaluateLoopBodyStatement(AForAwaitOfStatement.Body, IterContext);
           finally
             if Assigned(AForAwaitOfStatement.MatchPattern) and
                (IterContext.Scope <> IterScope) then
@@ -1626,7 +1647,7 @@ begin
         end;
 
         try
-          CF := EvaluateStatement(AForAwaitOfStatement.Body, IterContext);
+          CF := EvaluateLoopBodyStatement(AForAwaitOfStatement.Body, IterContext);
         finally
           if Assigned(AForAwaitOfStatement.MatchPattern) and
              (IterContext.Scope <> IterScope) then

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -128,7 +128,8 @@ type
   private
     FIterator: TGocciaIteratorValue;
     function PromiseReject(const AValue: TGocciaValue): TGocciaValue;
-    function ResolveIteratorResult(const AResult: TGocciaObjectValue): TGocciaValue;
+    function ResolveIteratorResult(const AResult: TGocciaObjectValue;
+      const ACloseOnRejection: Boolean): TGocciaValue;
     function Next(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ReturnValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ThrowValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -192,7 +193,7 @@ begin
 end;
 
 function TGocciaAsyncFromSyncIteratorValue.ResolveIteratorResult(
-  const AResult: TGocciaObjectValue): TGocciaValue;
+  const AResult: TGocciaObjectValue; const ACloseOnRejection: Boolean): TGocciaValue;
 var
   Done: Boolean;
   DoneValue: TGocciaValue;
@@ -212,7 +213,16 @@ begin
       Value := AResult.GetProperty(PROP_VALUE);
       if not Assigned(Value) then
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-      UnwrappedValue := AwaitValue(Value);
+      try
+        UnwrappedValue := AwaitValue(Value);
+      except
+        if ACloseOnRejection and not Done then
+        begin
+          CloseIteratorPreservingError(FIterator);
+          FIterator := nil;
+        end;
+        raise;
+      end;
       Promise.Resolve(CreateIteratorResult(UnwrappedValue, Done));
     except
       on E: TGocciaThrowValue do
@@ -256,7 +266,7 @@ begin
         Value := FIterator.DirectNextValue(AArgs.GetElement(0), Done);
         if Done then
           FIterator := nil;
-        Result := ResolveIteratorResult(CreateIteratorResult(Value, Done));
+        Result := ResolveIteratorResult(CreateIteratorResult(Value, Done), True);
       end
       else
       begin
@@ -264,12 +274,12 @@ begin
         DoneValue := IteratorResult.GetProperty(PROP_DONE);
         if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
           FIterator := nil;
-        Result := ResolveIteratorResult(IteratorResult);
+        Result := ResolveIteratorResult(IteratorResult, True);
       end;
     end
     else
       Result := ResolveIteratorResult(CreateIteratorResult(
-        TGocciaUndefinedLiteralValue.UndefinedValue, True));
+        TGocciaUndefinedLiteralValue.UndefinedValue, True), True);
   except
     on E: TGocciaThrowValue do
       Result := PromiseReject(E.Value);
@@ -302,10 +312,10 @@ begin
       DoneValue := IteratorResult.GetProperty(PROP_DONE);
       if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
         FIterator := nil;
-      Result := ResolveIteratorResult(IteratorResult);
+      Result := ResolveIteratorResult(IteratorResult, False);
       Exit;
     end;
-    Result := ResolveIteratorResult(CreateIteratorResult(Value, True));
+    Result := ResolveIteratorResult(CreateIteratorResult(Value, True), False);
   except
     on E: TGocciaThrowValue do
       Result := PromiseReject(E.Value);
@@ -338,7 +348,7 @@ begin
       DoneValue := IteratorResult.GetProperty(PROP_DONE);
       if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
         FIterator := nil;
-      Result := ResolveIteratorResult(IteratorResult);
+      Result := ResolveIteratorResult(IteratorResult, True);
       Exit;
     end;
     Result := PromiseReject(Value);

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -66,6 +66,7 @@ type
     FDelegateIterator: TGocciaIteratorValue;
     FDelegateAsyncIterator: TGocciaValue;
     FDelegateAsyncNext: TGocciaValue;
+    FCompletedExpressionValues: TDictionary<TObject, TGocciaValue>;
     FExpressionValues: TDictionary<TObject, TGocciaValue>;
     FStatementIndexes: TDictionary<TObject, Integer>;
     FTryStates: TDictionary<TObject, TGocciaGeneratorTryState>;
@@ -79,6 +80,8 @@ type
       const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue;
     function YieldValue(const AYieldExpression: TGocciaYieldExpression;
       const AContext: TGocciaEvaluationContext): TGocciaValue;
+    procedure SaveCompletedExpressionValue(const AExpression: TObject; const AValue: TGocciaValue);
+    function TakeCompletedExpressionValue(const AExpression: TObject; out AValue: TGocciaValue): Boolean;
     procedure SaveExpressionValue(const AExpression: TObject; const AValue: TGocciaValue);
     function TakeExpressionValue(const AExpression: TObject; out AValue: TGocciaValue): Boolean;
     procedure ClearExpressionValue(const AExpression: TObject);
@@ -265,6 +268,7 @@ begin
   FIsAsyncGenerator := AIsAsyncGenerator;
   FSuspendedYield := nil;
   FPendingValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+  FCompletedExpressionValues := TDictionary<TObject, TGocciaValue>.Create;
   FExpressionValues := TDictionary<TObject, TGocciaValue>.Create;
   FStatementIndexes := TDictionary<TObject, Integer>.Create;
   FTryStates := TDictionary<TObject, TGocciaGeneratorTryState>.Create;
@@ -276,6 +280,7 @@ begin
   FTryStates.Free;
   FStatementIndexes.Free;
   FExpressionValues.Free;
+  FCompletedExpressionValues.Free;
   inherited;
 end;
 
@@ -681,6 +686,20 @@ begin
   raise EGocciaGeneratorYield.Create(YieldedValue);
 end;
 
+procedure TGocciaGeneratorContinuation.SaveCompletedExpressionValue(
+  const AExpression: TObject; const AValue: TGocciaValue);
+begin
+  FCompletedExpressionValues.AddOrSetValue(AExpression, AValue);
+end;
+
+function TGocciaGeneratorContinuation.TakeCompletedExpressionValue(
+  const AExpression: TObject; out AValue: TGocciaValue): Boolean;
+begin
+  Result := FCompletedExpressionValues.TryGetValue(AExpression, AValue);
+  if Result then
+    FCompletedExpressionValues.Remove(AExpression);
+end;
+
 procedure TGocciaGeneratorContinuation.SaveExpressionValue(
   const AExpression: TObject; const AValue: TGocciaValue);
 begin
@@ -698,11 +717,13 @@ end;
 procedure TGocciaGeneratorContinuation.ClearExpressionValue(const AExpression: TObject);
 begin
   FExpressionValues.Remove(AExpression);
+  FCompletedExpressionValues.Remove(AExpression);
 end;
 
 procedure TGocciaGeneratorContinuation.ClearExpressionValues;
 begin
   FExpressionValues.Clear;
+  FCompletedExpressionValues.Clear;
 end;
 
 function TGocciaGeneratorContinuation.GetStatementIndex(
@@ -780,6 +801,9 @@ begin
     FDelegateAsyncIterator.MarkReferences;
   if Assigned(FDelegateAsyncNext) then
     FDelegateAsyncNext.MarkReferences;
+  for Value in FCompletedExpressionValues.Values do
+    if Assigned(Value) then
+      Value.MarkReferences;
   for Value in FExpressionValues.Values do
     if Assigned(Value) then
       Value.MarkReferences;

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -199,6 +199,8 @@ end;
 function TGocciaAsyncFromSyncIteratorValue.ReturnValue(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
+  DoneValue: TGocciaValue;
+  IteratorResult: TGocciaObjectValue;
   Value: TGocciaValue;
 begin
   if AArgs.Length > 0 then
@@ -207,8 +209,11 @@ begin
     Value := TGocciaUndefinedLiteralValue.UndefinedValue;
   if Assigned(FIterator) then
   begin
-    Result := ResolveIteratorResult(FIterator.ReturnValue(Value));
-    FIterator := nil;
+    IteratorResult := FIterator.ReturnValue(Value);
+    DoneValue := IteratorResult.GetProperty(PROP_DONE);
+    if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+      FIterator := nil;
+    Result := ResolveIteratorResult(IteratorResult);
     Exit;
   end;
   Result := ResolveIteratorResult(CreateIteratorResult(Value, True));
@@ -217,6 +222,8 @@ end;
 function TGocciaAsyncFromSyncIteratorValue.ThrowValue(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
+  DoneValue: TGocciaValue;
+  IteratorResult: TGocciaObjectValue;
   Value: TGocciaValue;
 begin
   if AArgs.Length > 0 then
@@ -225,8 +232,11 @@ begin
     Value := TGocciaUndefinedLiteralValue.UndefinedValue;
   if Assigned(FIterator) then
   begin
-    Result := ResolveIteratorResult(FIterator.ThrowValue(Value));
-    FIterator := nil;
+    IteratorResult := FIterator.ThrowValue(Value);
+    DoneValue := IteratorResult.GetProperty(PROP_DONE);
+    if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+      FIterator := nil;
+    Result := ResolveIteratorResult(IteratorResult);
     Exit;
   end;
   raise TGocciaThrowValue.Create(Value);

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -843,6 +843,7 @@ function TGocciaGeneratorContinuation.TakeCompletedExpressionValue(
 begin
   Result := FCompletedExpressionValues.TryGetValue(AExpression, AValue);
   if Result then
+    // Consume replayed completed values; statement completion clears the rest.
     FCompletedExpressionValues.Remove(AExpression);
 end;
 

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -71,6 +71,7 @@ type
     FStatementIndexes: TDictionary<TObject, Integer>;
     FTryStates: TDictionary<TObject, TGocciaGeneratorTryState>;
     FIsAsyncGenerator: Boolean;
+    procedure ClearDelegateState;
   public
     constructor Create(const ABodyStatements: TObjectList<TGocciaASTNode>;
       const ACallScope: TGocciaScope; const AContext: TGocciaEvaluationContext;
@@ -105,8 +106,11 @@ function EvaluateGeneratorYield(const AYieldExpression: TGocciaYieldExpression;
 implementation
 
 uses
+  Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error,
   Goccia.Evaluator,
+  Goccia.GarbageCollector,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -123,6 +127,7 @@ type
   TGocciaAsyncFromSyncIteratorValue = class(TGocciaObjectValue)
   private
     FIterator: TGocciaIteratorValue;
+    function PromiseReject(const AValue: TGocciaValue): TGocciaValue;
     function ResolveIteratorResult(const AResult: TGocciaObjectValue): TGocciaValue;
     function Next(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ReturnValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -160,18 +165,78 @@ begin
   AssignProperty(PROP_THROW, TGocciaNativeFunctionValue.Create(ThrowValue, PROP_THROW, 1));
 end;
 
-function TGocciaAsyncFromSyncIteratorValue.ResolveIteratorResult(
-  const AResult: TGocciaObjectValue): TGocciaValue;
+function TGocciaAsyncFromSyncIteratorValue.PromiseReject(
+  const AValue: TGocciaValue): TGocciaValue;
 var
+  IsRooted: Boolean;
   Promise: TGocciaPromiseValue;
 begin
   Promise := TGocciaPromiseValue.Create;
+  IsRooted := Assigned(TGarbageCollector.Instance);
+  if IsRooted then
+    TGarbageCollector.Instance.AddTempRoot(Promise);
   try
-    Promise.Resolve(AResult);
+    Promise.Reject(AValue);
   except
+    if IsRooted then
+    begin
+      TGarbageCollector.Instance.RemoveTempRoot(Promise);
+      IsRooted := False;
+    end;
     Promise.Free;
     raise;
   end;
+  if IsRooted then
+    TGarbageCollector.Instance.RemoveTempRoot(Promise);
+  Result := Promise;
+end;
+
+function TGocciaAsyncFromSyncIteratorValue.ResolveIteratorResult(
+  const AResult: TGocciaObjectValue): TGocciaValue;
+var
+  Done: Boolean;
+  DoneValue: TGocciaValue;
+  IsRooted: Boolean;
+  Promise: TGocciaPromiseValue;
+  UnwrappedValue: TGocciaValue;
+  Value: TGocciaValue;
+begin
+  Promise := TGocciaPromiseValue.Create;
+  IsRooted := Assigned(TGarbageCollector.Instance);
+  if IsRooted then
+    TGarbageCollector.Instance.AddTempRoot(Promise);
+  try
+    try
+      DoneValue := AResult.GetProperty(PROP_DONE);
+      Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
+      Value := AResult.GetProperty(PROP_VALUE);
+      if not Assigned(Value) then
+        Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+      UnwrappedValue := AwaitValue(Value);
+      Promise.Resolve(CreateIteratorResult(UnwrappedValue, Done));
+    except
+      on E: TGocciaThrowValue do
+        Promise.Reject(E.Value);
+      on E: TGocciaTypeError do
+        Promise.Reject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
+      on E: TGocciaReferenceError do
+        Promise.Reject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+      on E: TGocciaSyntaxError do
+        Promise.Reject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+      on E: Exception do
+        Promise.Reject(CreateErrorObject(ERROR_NAME, E.Message));
+    end;
+  except
+    if IsRooted then
+    begin
+      TGarbageCollector.Instance.RemoveTempRoot(Promise);
+      IsRooted := False;
+    end;
+    Promise.Free;
+    raise;
+  end;
+  if IsRooted then
+    TGarbageCollector.Instance.RemoveTempRoot(Promise);
   Result := Promise;
 end;
 
@@ -179,21 +244,44 @@ function TGocciaAsyncFromSyncIteratorValue.Next(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Done: Boolean;
+  DoneValue: TGocciaValue;
+  IteratorResult: TGocciaObjectValue;
   Value: TGocciaValue;
 begin
-  if Assigned(FIterator) then
-  begin
-    if AArgs.Length > 0 then
+  try
+    if Assigned(FIterator) then
     begin
-      Value := FIterator.DirectNextValue(AArgs.GetElement(0), Done);
-      Result := ResolveIteratorResult(CreateIteratorResult(Value, Done));
+      if AArgs.Length > 0 then
+      begin
+        Value := FIterator.DirectNextValue(AArgs.GetElement(0), Done);
+        if Done then
+          FIterator := nil;
+        Result := ResolveIteratorResult(CreateIteratorResult(Value, Done));
+      end
+      else
+      begin
+        IteratorResult := FIterator.AdvanceNext;
+        DoneValue := IteratorResult.GetProperty(PROP_DONE);
+        if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+          FIterator := nil;
+        Result := ResolveIteratorResult(IteratorResult);
+      end;
     end
     else
-      Result := ResolveIteratorResult(FIterator.AdvanceNext);
-  end
-  else
-    Result := ResolveIteratorResult(CreateIteratorResult(
-      TGocciaUndefinedLiteralValue.UndefinedValue, True));
+      Result := ResolveIteratorResult(CreateIteratorResult(
+        TGocciaUndefinedLiteralValue.UndefinedValue, True));
+  except
+    on E: TGocciaThrowValue do
+      Result := PromiseReject(E.Value);
+    on E: TGocciaTypeError do
+      Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
+    on E: TGocciaReferenceError do
+      Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+    on E: TGocciaSyntaxError do
+      Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: Exception do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
+  end;
 end;
 
 function TGocciaAsyncFromSyncIteratorValue.ReturnValue(
@@ -207,16 +295,29 @@ begin
     Value := AArgs.GetElement(0)
   else
     Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-  if Assigned(FIterator) then
-  begin
-    IteratorResult := FIterator.ReturnValue(Value);
-    DoneValue := IteratorResult.GetProperty(PROP_DONE);
-    if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
-      FIterator := nil;
-    Result := ResolveIteratorResult(IteratorResult);
-    Exit;
+  try
+    if Assigned(FIterator) then
+    begin
+      IteratorResult := FIterator.ReturnValue(Value);
+      DoneValue := IteratorResult.GetProperty(PROP_DONE);
+      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+        FIterator := nil;
+      Result := ResolveIteratorResult(IteratorResult);
+      Exit;
+    end;
+    Result := ResolveIteratorResult(CreateIteratorResult(Value, True));
+  except
+    on E: TGocciaThrowValue do
+      Result := PromiseReject(E.Value);
+    on E: TGocciaTypeError do
+      Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
+    on E: TGocciaReferenceError do
+      Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+    on E: TGocciaSyntaxError do
+      Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: Exception do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
-  Result := ResolveIteratorResult(CreateIteratorResult(Value, True));
 end;
 
 function TGocciaAsyncFromSyncIteratorValue.ThrowValue(
@@ -230,16 +331,29 @@ begin
     Value := AArgs.GetElement(0)
   else
     Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-  if Assigned(FIterator) then
-  begin
-    IteratorResult := FIterator.ThrowValue(Value);
-    DoneValue := IteratorResult.GetProperty(PROP_DONE);
-    if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
-      FIterator := nil;
-    Result := ResolveIteratorResult(IteratorResult);
-    Exit;
+  try
+    if Assigned(FIterator) then
+    begin
+      IteratorResult := FIterator.ThrowValue(Value);
+      DoneValue := IteratorResult.GetProperty(PROP_DONE);
+      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+        FIterator := nil;
+      Result := ResolveIteratorResult(IteratorResult);
+      Exit;
+    end;
+    Result := PromiseReject(Value);
+  except
+    on E: TGocciaThrowValue do
+      Result := PromiseReject(E.Value);
+    on E: TGocciaTypeError do
+      Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
+    on E: TGocciaReferenceError do
+      Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+    on E: TGocciaSyntaxError do
+      Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: Exception do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
-  raise TGocciaThrowValue.Create(Value);
 end;
 
 procedure TGocciaAsyncFromSyncIteratorValue.MarkReferences;
@@ -292,6 +406,14 @@ begin
   FExpressionValues.Free;
   FCompletedExpressionValues.Free;
   inherited;
+end;
+
+procedure TGocciaGeneratorContinuation.ClearDelegateState;
+begin
+  FDelegateIterator := nil;
+  FDelegateAsyncIterator := nil;
+  FDelegateAsyncNext := nil;
+  FDelegateExpression := nil;
 end;
 
 function TGocciaGeneratorContinuation.Resume(
@@ -351,6 +473,7 @@ begin
         if ControlFlow.Kind = cfkReturn then
         begin
           FCompleted := True;
+          ClearDelegateState;
           ClearExpressionValues;
           ClearStatementIndexes;
           ClearTryStates;
@@ -374,6 +497,7 @@ begin
         on E: EGocciaGeneratorReturn do
         begin
           FCompleted := True;
+          ClearDelegateState;
           ClearExpressionValues;
           ClearStatementIndexes;
           ClearTryStates;
@@ -388,6 +512,7 @@ begin
   end;
 
   FCompleted := True;
+  ClearDelegateState;
   ClearExpressionValues;
   ClearStatementIndexes;
   ClearTryStates;
@@ -407,7 +532,8 @@ var
   ReturnMethod: TGocciaValue;
   YieldedValue: TGocciaValue;
 begin
-  HasDelegateResumeValue := False;
+  try
+    HasDelegateResumeValue := False;
   if FHasPendingValue and (FSuspendedYield = AYieldExpression) then
   begin
     FHasPendingValue := False;
@@ -491,10 +617,7 @@ begin
           Result := IteratorResult.GetProperty(PROP_VALUE);
           if not Assigned(Result) then
             Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-          FDelegateIterator := nil;
-          FDelegateAsyncIterator := nil;
-          FDelegateAsyncNext := nil;
-          FDelegateExpression := nil;
+          ClearDelegateState;
           Exit;
         end;
         YieldedValue := IteratorResult.GetProperty(PROP_VALUE);
@@ -547,10 +670,7 @@ begin
         YieldedValue := IteratorResult.GetProperty(PROP_VALUE);
         if not Assigned(YieldedValue) then
           YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-        FDelegateIterator := nil;
-        FDelegateAsyncIterator := nil;
-        FDelegateAsyncNext := nil;
-        FDelegateExpression := nil;
+        ClearDelegateState;
         raise EGocciaGeneratorReturn.Create(YieldedValue);
       end;
       HasDelegateResumeValue := FPendingKind = grkNext;
@@ -575,8 +695,7 @@ begin
       else
         YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-      FDelegateAsyncIterator := nil;
-      FDelegateAsyncNext := nil;
+      ClearDelegateState;
       if FIsAsyncGenerator and (YieldedValue is TGocciaObjectValue) then
       begin
         IteratorMethod := TGocciaObjectValue(YieldedValue).GetSymbolProperty(
@@ -647,9 +766,7 @@ begin
           Result := IteratorResult.GetProperty(PROP_VALUE);
           if not Assigned(Result) then
             Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-          FDelegateAsyncIterator := nil;
-          FDelegateAsyncNext := nil;
-          FDelegateExpression := nil;
+          ClearDelegateState;
           Exit;
         end;
 
@@ -672,8 +789,7 @@ begin
         Result := IteratorResult.GetProperty(PROP_VALUE);
         if not Assigned(Result) then
           Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        FDelegateIterator := nil;
-        FDelegateExpression := nil;
+        ClearDelegateState;
         Exit;
       end;
 
@@ -694,6 +810,16 @@ begin
     YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
   FSuspendedYield := AYieldExpression;
   raise EGocciaGeneratorYield.Create(YieldedValue);
+  except
+    on E: EGocciaGeneratorYield do
+      raise;
+    else
+    begin
+      if AYieldExpression.IsDelegate then
+        ClearDelegateState;
+      raise;
+    end;
+  end;
 end;
 
 procedure TGocciaGeneratorContinuation.SaveCompletedExpressionValue(

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -19,6 +19,20 @@ uses
 
 type
   TGocciaGeneratorResumeKind = (grkNext, grkReturn, grkThrow);
+  TGocciaGeneratorTryPhase = (gtpTry, gtpCatch, gtpFinally);
+
+  TGocciaGeneratorTryState = class
+  public
+    Phase: TGocciaGeneratorTryPhase;
+    ResultFlow: TGocciaControlFlow;
+    CatchValue: TGocciaValue;
+    ThrownValue: TGocciaValue;
+    GeneratorReturnValue: TGocciaValue;
+    HasUnhandledThrow: Boolean;
+    HasGeneratorReturn: Boolean;
+    constructor Create;
+    procedure MarkReferences;
+  end;
 
   EGocciaGeneratorYield = class(Exception)
   private
@@ -54,6 +68,7 @@ type
     FDelegateAsyncNext: TGocciaValue;
     FExpressionValues: TDictionary<TObject, TGocciaValue>;
     FStatementIndexes: TDictionary<TObject, Integer>;
+    FTryStates: TDictionary<TObject, TGocciaGeneratorTryState>;
     FIsAsyncGenerator: Boolean;
   public
     constructor Create(const ABodyStatements: TObjectList<TGocciaASTNode>;
@@ -72,6 +87,10 @@ type
     procedure SaveStatementIndex(const AStatements: TObject; const AIndex: Integer);
     procedure ClearStatementIndex(const AStatements: TObject);
     procedure ClearStatementIndexes;
+    function EnsureTryState(const ATryStatement: TObject): TGocciaGeneratorTryState;
+    function GetTryState(const ATryStatement: TObject): TGocciaGeneratorTryState;
+    procedure ClearTryState(const ATryStatement: TObject);
+    procedure ClearTryStates;
     procedure MarkReferences;
     property Completed: Boolean read FCompleted;
   end;
@@ -110,6 +129,25 @@ type
     procedure MarkReferences; override;
   end;
 
+constructor TGocciaGeneratorTryState.Create;
+begin
+  inherited Create;
+  Phase := gtpTry;
+  ResultFlow := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
+end;
+
+procedure TGocciaGeneratorTryState.MarkReferences;
+begin
+  if Assigned(ResultFlow.Value) then
+    ResultFlow.Value.MarkReferences;
+  if Assigned(CatchValue) then
+    CatchValue.MarkReferences;
+  if Assigned(ThrownValue) then
+    ThrownValue.MarkReferences;
+  if Assigned(GeneratorReturnValue) then
+    GeneratorReturnValue.MarkReferences;
+end;
+
 constructor TGocciaAsyncFromSyncIteratorValue.Create(const AIterator: TGocciaIteratorValue);
 begin
   inherited Create;
@@ -136,9 +174,20 @@ end;
 
 function TGocciaAsyncFromSyncIteratorValue.Next(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Done: Boolean;
+  Value: TGocciaValue;
 begin
   if Assigned(FIterator) then
-    Result := ResolveIteratorResult(FIterator.AdvanceNext)
+  begin
+    if AArgs.Length > 0 then
+    begin
+      Value := FIterator.DirectNextValue(AArgs.GetElement(0), Done);
+      Result := ResolveIteratorResult(CreateIteratorResult(Value, Done));
+    end
+    else
+      Result := ResolveIteratorResult(FIterator.AdvanceNext);
+  end
   else
     Result := ResolveIteratorResult(CreateIteratorResult(
       TGocciaUndefinedLiteralValue.UndefinedValue, True));
@@ -149,15 +198,16 @@ function TGocciaAsyncFromSyncIteratorValue.ReturnValue(
 var
   Value: TGocciaValue;
 begin
-  if Assigned(FIterator) then
-  begin
-    FIterator.Close;
-    FIterator := nil;
-  end;
   if AArgs.Length > 0 then
     Value := AArgs.GetElement(0)
   else
     Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if Assigned(FIterator) then
+  begin
+    Result := ResolveIteratorResult(FIterator.ReturnValue(Value));
+    FIterator := nil;
+    Exit;
+  end;
   Result := ResolveIteratorResult(CreateIteratorResult(Value, True));
 end;
 
@@ -166,15 +216,16 @@ function TGocciaAsyncFromSyncIteratorValue.ThrowValue(
 var
   Value: TGocciaValue;
 begin
-  if Assigned(FIterator) then
-  begin
-    FIterator.Close;
-    FIterator := nil;
-  end;
   if AArgs.Length > 0 then
     Value := AArgs.GetElement(0)
   else
     Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if Assigned(FIterator) then
+  begin
+    Result := ResolveIteratorResult(FIterator.ThrowValue(Value));
+    FIterator := nil;
+    Exit;
+  end;
   raise TGocciaThrowValue.Create(Value);
 end;
 
@@ -216,10 +267,13 @@ begin
   FPendingValue := TGocciaUndefinedLiteralValue.UndefinedValue;
   FExpressionValues := TDictionary<TObject, TGocciaValue>.Create;
   FStatementIndexes := TDictionary<TObject, Integer>.Create;
+  FTryStates := TDictionary<TObject, TGocciaGeneratorTryState>.Create;
 end;
 
 destructor TGocciaGeneratorContinuation.Destroy;
 begin
+  ClearTryStates;
+  FTryStates.Free;
   FStatementIndexes.Free;
   FExpressionValues.Free;
   inherited;
@@ -284,6 +338,7 @@ begin
           FCompleted := True;
           ClearExpressionValues;
           ClearStatementIndexes;
+          ClearTryStates;
           ADone := True;
           if Assigned(ControlFlow.Value) then
             Result := ControlFlow.Value
@@ -306,6 +361,7 @@ begin
           FCompleted := True;
           ClearExpressionValues;
           ClearStatementIndexes;
+          ClearTryStates;
           ADone := True;
           Result := E.Value;
           Exit;
@@ -319,6 +375,7 @@ begin
   FCompleted := True;
   ClearExpressionValues;
   ClearStatementIndexes;
+  ClearTryStates;
   ADone := True;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -328,11 +385,14 @@ function TGocciaGeneratorContinuation.YieldValue(
   const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   CallArgs: TGocciaArgumentsCollection;
+  HasDelegateResumeValue: Boolean;
   IteratorResult: TGocciaObjectValue;
   IteratorMethod: TGocciaValue;
   RawIteratorResult: TGocciaValue;
+  ReturnMethod: TGocciaValue;
   YieldedValue: TGocciaValue;
 begin
+  HasDelegateResumeValue := False;
   if FHasPendingValue and (FSuspendedYield = AYieldExpression) then
   begin
     FHasPendingValue := False;
@@ -341,50 +401,72 @@ begin
     begin
       if FPendingKind = grkThrow then
       begin
-        if Assigned(FDelegateAsyncIterator) then
+        if Assigned(FDelegateIterator) then
+          RawIteratorResult := FDelegateIterator.ThrowValue(FPendingValue)
+        else if Assigned(FDelegateAsyncIterator) then
+        begin
           IteratorMethod := FDelegateAsyncIterator.GetProperty(PROP_THROW)
-        else if Assigned(FDelegateIterator) then
-          IteratorMethod := FDelegateIterator.GetProperty(PROP_THROW)
+        end
         else
           IteratorMethod := nil;
-        if not Assigned(IteratorMethod) or (IteratorMethod is TGocciaUndefinedLiteralValue) or
-           not IteratorMethod.IsCallable then
+        if not Assigned(FDelegateIterator) then
         begin
-          if Assigned(FDelegateAsyncIterator) then
-            IteratorMethod := FDelegateAsyncIterator.GetProperty(PROP_RETURN)
-          else if Assigned(FDelegateIterator) then
-            IteratorMethod := FDelegateIterator.GetProperty(PROP_RETURN)
-          else
-            IteratorMethod := nil;
-          if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and
-             IteratorMethod.IsCallable then
+          if Assigned(IteratorMethod) and
+             not (IteratorMethod is TGocciaUndefinedLiteralValue) and
+             not (IteratorMethod is TGocciaNullLiteralValue) then
           begin
-            CallArgs := TGocciaArgumentsCollection.Create;
+            if not IteratorMethod.IsCallable then
+            begin
+              ReturnMethod := FDelegateAsyncIterator.GetProperty(PROP_RETURN);
+              if Assigned(ReturnMethod) and
+                 not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+                 not (ReturnMethod is TGocciaNullLiteralValue) then
+              begin
+                if not ReturnMethod.IsCallable then
+                  ThrowTypeError('Iterator return is not callable');
+                CallArgs := TGocciaArgumentsCollection.Create;
+                try
+                  RawIteratorResult := AwaitValue(TGocciaFunctionBase(ReturnMethod).Call(
+                    CallArgs, FDelegateAsyncIterator));
+                finally
+                  CallArgs.Free;
+                end;
+                if not (RawIteratorResult is TGocciaObjectValue) then
+                  ThrowTypeError('Iterator return result is not an object');
+              end;
+              ThrowTypeError('Iterator throw is not callable');
+            end;
+            CallArgs := TGocciaArgumentsCollection.Create([FPendingValue]);
             try
-              if Assigned(FDelegateAsyncIterator) then
-                RawIteratorResult := AwaitValue(TGocciaFunctionBase(IteratorMethod).Call(
-                  CallArgs, FDelegateAsyncIterator))
-              else
-                RawIteratorResult := TGocciaFunctionBase(IteratorMethod).Call(
-                  CallArgs, FDelegateIterator);
+              RawIteratorResult := AwaitValue(TGocciaFunctionBase(IteratorMethod).Call(
+                CallArgs, FDelegateAsyncIterator));
             finally
               CallArgs.Free;
             end;
-            if not (RawIteratorResult is TGocciaObjectValue) then
-              ThrowTypeError('Iterator return result is not an object');
-          end;
-          ThrowTypeError('Delegated iterator has no throw method');
-        end;
-        CallArgs := TGocciaArgumentsCollection.Create([FPendingValue]);
-        try
-          if Assigned(FDelegateAsyncIterator) then
-            RawIteratorResult := AwaitValue(TGocciaFunctionBase(IteratorMethod).Call(
-              CallArgs, FDelegateAsyncIterator))
+          end
           else
-            RawIteratorResult := TGocciaFunctionBase(IteratorMethod).Call(
-              CallArgs, FDelegateIterator);
-        finally
-          CallArgs.Free;
+          begin
+            ReturnMethod := nil;
+            if Assigned(FDelegateAsyncIterator) then
+              ReturnMethod := FDelegateAsyncIterator.GetProperty(PROP_RETURN);
+            if Assigned(ReturnMethod) and
+               not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+               not (ReturnMethod is TGocciaNullLiteralValue) then
+            begin
+              if not ReturnMethod.IsCallable then
+                ThrowTypeError('Iterator return is not callable');
+              CallArgs := TGocciaArgumentsCollection.Create;
+              try
+                RawIteratorResult := AwaitValue(TGocciaFunctionBase(ReturnMethod).Call(
+                  CallArgs, FDelegateAsyncIterator));
+              finally
+                CallArgs.Free;
+              end;
+              if not (RawIteratorResult is TGocciaObjectValue) then
+                ThrowTypeError('Iterator return result is not an object');
+            end;
+            ThrowTypeError('Delegated iterator has no throw method');
+          end;
         end;
         if not (RawIteratorResult is TGocciaObjectValue) then
           ThrowTypeError('Iterator throw result is not an object');
@@ -409,48 +491,54 @@ begin
 
       if FPendingKind = grkReturn then
       begin
-        if Assigned(FDelegateAsyncIterator) then
+        if Assigned(FDelegateIterator) then
+          RawIteratorResult := FDelegateIterator.ReturnValue(FPendingValue)
+        else if Assigned(FDelegateAsyncIterator) then
+        begin
           IteratorMethod := FDelegateAsyncIterator.GetProperty(PROP_RETURN)
-        else if Assigned(FDelegateIterator) then
-          IteratorMethod := FDelegateIterator.GetProperty(PROP_RETURN)
+        end
         else
           IteratorMethod := nil;
-        if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and
-           IteratorMethod.IsCallable then
+        if not Assigned(FDelegateIterator) then
         begin
-          CallArgs := TGocciaArgumentsCollection.Create([FPendingValue]);
-          try
-            if Assigned(FDelegateAsyncIterator) then
-              RawIteratorResult := AwaitValue(TGocciaFunctionBase(IteratorMethod).Call(
-                CallArgs, FDelegateAsyncIterator))
-            else
-              RawIteratorResult := TGocciaFunctionBase(IteratorMethod).Call(
-                CallArgs, FDelegateIterator);
-          finally
-            CallArgs.Free;
-          end;
-          if not (RawIteratorResult is TGocciaObjectValue) then
-            ThrowTypeError('Iterator return result is not an object');
-          IteratorResult := TGocciaObjectValue(RawIteratorResult);
-          if not IteratorResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
+          if Assigned(IteratorMethod) and
+             not (IteratorMethod is TGocciaUndefinedLiteralValue) and
+             not (IteratorMethod is TGocciaNullLiteralValue) then
           begin
-            YieldedValue := IteratorResult.GetProperty(PROP_VALUE);
-            if not Assigned(YieldedValue) then
-              YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-            FSuspendedYield := AYieldExpression;
-            raise EGocciaGeneratorYield.Create(YieldedValue);
-          end;
+            if not IteratorMethod.IsCallable then
+              ThrowTypeError('Iterator return is not callable');
+            CallArgs := TGocciaArgumentsCollection.Create([FPendingValue]);
+            try
+              RawIteratorResult := AwaitValue(TGocciaFunctionBase(IteratorMethod).Call(
+                CallArgs, FDelegateAsyncIterator));
+            finally
+              CallArgs.Free;
+            end;
+          end
+          else
+            raise EGocciaGeneratorReturn.Create(FPendingValue);
+        end;
+        if not (RawIteratorResult is TGocciaObjectValue) then
+          ThrowTypeError('Iterator return result is not an object');
+        IteratorResult := TGocciaObjectValue(RawIteratorResult);
+        if not IteratorResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
+        begin
           YieldedValue := IteratorResult.GetProperty(PROP_VALUE);
           if not Assigned(YieldedValue) then
             YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-          FDelegateIterator := nil;
-          FDelegateAsyncIterator := nil;
-          FDelegateAsyncNext := nil;
-          FDelegateExpression := nil;
-          raise EGocciaGeneratorReturn.Create(YieldedValue);
+          FSuspendedYield := AYieldExpression;
+          raise EGocciaGeneratorYield.Create(YieldedValue);
         end;
-        raise EGocciaGeneratorReturn.Create(FPendingValue);
+        YieldedValue := IteratorResult.GetProperty(PROP_VALUE);
+        if not Assigned(YieldedValue) then
+          YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+        FDelegateIterator := nil;
+        FDelegateAsyncIterator := nil;
+        FDelegateAsyncNext := nil;
+        FDelegateExpression := nil;
+        raise EGocciaGeneratorReturn.Create(YieldedValue);
       end;
+      HasDelegateResumeValue := FPendingKind = grkNext;
     end;
     if FPendingKind = grkThrow then
       raise TGocciaThrowValue.Create(FPendingValue);
@@ -525,7 +613,10 @@ begin
         ThrowTypeError('Async iterator next is not callable')
       else
       begin
-        CallArgs := TGocciaArgumentsCollection.Create;
+        if HasDelegateResumeValue then
+          CallArgs := TGocciaArgumentsCollection.Create([FPendingValue])
+        else
+          CallArgs := TGocciaArgumentsCollection.Create;
         try
           RawIteratorResult := AwaitValue(TGocciaFunctionBase(FDelegateAsyncNext).Call(
             CallArgs, FDelegateAsyncIterator));
@@ -557,7 +648,10 @@ begin
 
     if Assigned(FDelegateIterator) then
     begin
-      IteratorResult := FDelegateIterator.AdvanceNext;
+      if HasDelegateResumeValue then
+        IteratorResult := FDelegateIterator.AdvanceNextValue(FPendingValue)
+      else
+        IteratorResult := FDelegateIterator.AdvanceNext;
       if IteratorResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
       begin
         Result := IteratorResult.GetProperty(PROP_VALUE);
@@ -635,8 +729,45 @@ begin
   FStatementIndexes.Clear;
 end;
 
+function TGocciaGeneratorContinuation.EnsureTryState(
+  const ATryStatement: TObject): TGocciaGeneratorTryState;
+begin
+  if not FTryStates.TryGetValue(ATryStatement, Result) then
+  begin
+    Result := TGocciaGeneratorTryState.Create;
+    FTryStates.Add(ATryStatement, Result);
+  end;
+end;
+
+function TGocciaGeneratorContinuation.GetTryState(
+  const ATryStatement: TObject): TGocciaGeneratorTryState;
+begin
+  if not FTryStates.TryGetValue(ATryStatement, Result) then
+    Result := nil;
+end;
+
+procedure TGocciaGeneratorContinuation.ClearTryState(
+  const ATryStatement: TObject);
+var
+  TryState: TGocciaGeneratorTryState;
+begin
+  if FTryStates.TryGetValue(ATryStatement, TryState) then
+    TryState.Free;
+  FTryStates.Remove(ATryStatement);
+end;
+
+procedure TGocciaGeneratorContinuation.ClearTryStates;
+var
+  TryState: TGocciaGeneratorTryState;
+begin
+  for TryState in FTryStates.Values do
+    TryState.Free;
+  FTryStates.Clear;
+end;
+
 procedure TGocciaGeneratorContinuation.MarkReferences;
 var
+  TryState: TGocciaGeneratorTryState;
   Value: TGocciaValue;
 begin
   if Assigned(FCallScope) then
@@ -652,6 +783,9 @@ begin
   for Value in FExpressionValues.Values do
     if Assigned(Value) then
       Value.MarkReferences;
+  for TryState in FTryStates.Values do
+    if Assigned(TryState) then
+      TryState.MarkReferences;
 end;
 
 function CurrentGeneratorContinuation: TGocciaGeneratorContinuation;

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -53,6 +53,7 @@ type
     FDelegateAsyncIterator: TGocciaValue;
     FDelegateAsyncNext: TGocciaValue;
     FExpressionValues: TDictionary<TObject, TGocciaValue>;
+    FStatementIndexes: TDictionary<TObject, Integer>;
     FIsAsyncGenerator: Boolean;
   public
     constructor Create(const ABodyStatements: TObjectList<TGocciaASTNode>;
@@ -66,6 +67,11 @@ type
     procedure SaveExpressionValue(const AExpression: TObject; const AValue: TGocciaValue);
     function TakeExpressionValue(const AExpression: TObject; out AValue: TGocciaValue): Boolean;
     procedure ClearExpressionValue(const AExpression: TObject);
+    procedure ClearExpressionValues;
+    function GetStatementIndex(const AStatements: TObject): Integer;
+    procedure SaveStatementIndex(const AStatements: TObject; const AIndex: Integer);
+    procedure ClearStatementIndex(const AStatements: TObject);
+    procedure ClearStatementIndexes;
     procedure MarkReferences;
     property Completed: Boolean read FCompleted;
   end;
@@ -209,10 +215,12 @@ begin
   FSuspendedYield := nil;
   FPendingValue := TGocciaUndefinedLiteralValue.UndefinedValue;
   FExpressionValues := TDictionary<TObject, TGocciaValue>.Create;
+  FStatementIndexes := TDictionary<TObject, Integer>.Create;
 end;
 
 destructor TGocciaGeneratorContinuation.Destroy;
 begin
+  FStatementIndexes.Free;
   FExpressionValues.Free;
   inherited;
 end;
@@ -274,6 +282,8 @@ begin
         if ControlFlow.Kind = cfkReturn then
         begin
           FCompleted := True;
+          ClearExpressionValues;
+          ClearStatementIndexes;
           ADone := True;
           if Assigned(ControlFlow.Value) then
             Result := ControlFlow.Value
@@ -283,6 +293,7 @@ begin
         end;
 
         Inc(FStatementIndex);
+        ClearExpressionValues;
       except
         on E: EGocciaGeneratorYield do
         begin
@@ -293,6 +304,8 @@ begin
         on E: EGocciaGeneratorReturn do
         begin
           FCompleted := True;
+          ClearExpressionValues;
+          ClearStatementIndexes;
           ADone := True;
           Result := E.Value;
           Exit;
@@ -304,6 +317,8 @@ begin
   end;
 
   FCompleted := True;
+  ClearExpressionValues;
+  ClearStatementIndexes;
   ADone := True;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -589,6 +604,35 @@ end;
 procedure TGocciaGeneratorContinuation.ClearExpressionValue(const AExpression: TObject);
 begin
   FExpressionValues.Remove(AExpression);
+end;
+
+procedure TGocciaGeneratorContinuation.ClearExpressionValues;
+begin
+  FExpressionValues.Clear;
+end;
+
+function TGocciaGeneratorContinuation.GetStatementIndex(
+  const AStatements: TObject): Integer;
+begin
+  if not FStatementIndexes.TryGetValue(AStatements, Result) then
+    Result := 0;
+end;
+
+procedure TGocciaGeneratorContinuation.SaveStatementIndex(
+  const AStatements: TObject; const AIndex: Integer);
+begin
+  FStatementIndexes.AddOrSetValue(AStatements, AIndex);
+end;
+
+procedure TGocciaGeneratorContinuation.ClearStatementIndex(
+  const AStatements: TObject);
+begin
+  FStatementIndexes.Remove(AStatements);
+end;
+
+procedure TGocciaGeneratorContinuation.ClearStatementIndexes;
+begin
+  FStatementIndexes.Clear;
 end;
 
 procedure TGocciaGeneratorContinuation.MarkReferences;

--- a/source/units/Goccia.VM.Exception.pas
+++ b/source/units/Goccia.VM.Exception.pas
@@ -16,6 +16,8 @@ type
     FrameDepth: Integer;
   end;
 
+  TGocciaBytecodeHandlerEntryArray = array of TGocciaBytecodeHandlerEntry;
+
   TGocciaBytecodeHandlerStack = class
   private
     FEntries: array of TGocciaBytecodeHandlerEntry;
@@ -24,6 +26,9 @@ type
     procedure Push(const ACatchIP: Integer; const ACatchRegister: UInt8;
       const AFrameDepth: Integer);
     procedure Pop;
+    procedure CopyFrom(const AStartIndex: Integer;
+      out AEntries: TGocciaBytecodeHandlerEntryArray);
+    procedure RestoreFrom(const AEntries: TGocciaBytecodeHandlerEntryArray);
     function Peek: TGocciaBytecodeHandlerEntry;
     function IsEmpty: Boolean;
     property Count: Integer read FCount;
@@ -58,6 +63,38 @@ procedure TGocciaBytecodeHandlerStack.Pop;
 begin
   if FCount > 0 then
     Dec(FCount);
+end;
+
+procedure TGocciaBytecodeHandlerStack.CopyFrom(const AStartIndex: Integer;
+  out AEntries: TGocciaBytecodeHandlerEntryArray);
+var
+  I, StartIndex: Integer;
+begin
+  StartIndex := AStartIndex;
+  if StartIndex < 0 then
+    StartIndex := 0;
+  if StartIndex > FCount then
+    StartIndex := FCount;
+
+  SetLength(AEntries, FCount - StartIndex);
+  for I := 0 to High(AEntries) do
+    AEntries[I] := FEntries[StartIndex + I];
+end;
+
+procedure TGocciaBytecodeHandlerStack.RestoreFrom(
+  const AEntries: TGocciaBytecodeHandlerEntryArray);
+var
+  I: Integer;
+begin
+  if Length(AEntries) = 0 then
+    Exit;
+  if FCount + Length(AEntries) > Length(FEntries) then
+    SetLength(FEntries, (FCount + Length(AEntries)) * 2);
+  for I := 0 to High(AEntries) do
+  begin
+    FEntries[FCount] := AEntries[I];
+    Inc(FCount);
+  end;
 end;
 
 function TGocciaBytecodeHandlerStack.Peek: TGocciaBytecodeHandlerEntry;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1677,9 +1677,9 @@ begin
           AArgs.GetElement(0), Done)
       else
         Value := TGocciaIteratorValue(FIteratorValue).DirectNext(Done);
-      UnwrappedValue := AwaitValue(Value);
       if Done then
         ClearIteratorState;
+      UnwrappedValue := AwaitValue(Value);
       IteratorResult := CreateIteratorResult(UnwrappedValue, Done);
       Exit(PromiseResolve(IteratorResult));
     end;
@@ -1703,9 +1703,9 @@ begin
     Value := IteratorResult.GetProperty(PROP_VALUE);
     if not Assigned(Value) then
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-    UnwrappedValue := AwaitValue(Value);
     if Done then
       ClearIteratorState;
+    UnwrappedValue := AwaitValue(Value);
     Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
   except
     on E: EGocciaBytecodeThrow do
@@ -1742,9 +1742,9 @@ begin
       Value := IteratorResult.GetProperty(PROP_VALUE);
       if not Assigned(Value) then
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-      UnwrappedValue := AwaitValue(Value);
       if Done then
         ClearIteratorState;
+      UnwrappedValue := AwaitValue(Value);
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
@@ -1772,9 +1772,9 @@ begin
     Value := IteratorResult.GetProperty(PROP_VALUE);
     if not Assigned(Value) then
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-    UnwrappedValue := AwaitValue(Value);
     if Done then
       ClearIteratorState;
+    UnwrappedValue := AwaitValue(Value);
     Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
   except
     on E: EGocciaBytecodeThrow do
@@ -1814,9 +1814,9 @@ begin
       Value := IteratorResult.GetProperty(PROP_VALUE);
       if not Assigned(Value) then
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-      UnwrappedValue := AwaitValue(Value);
       if Done then
         ClearIteratorState;
+      UnwrappedValue := AwaitValue(Value);
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
@@ -1840,9 +1840,9 @@ begin
       Value := IteratorResult.GetProperty(PROP_VALUE);
       if not Assigned(Value) then
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-      UnwrappedValue := AwaitValue(Value);
       if Done then
         ClearIteratorState;
+      UnwrappedValue := AwaitValue(Value);
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
@@ -2007,17 +2007,30 @@ procedure TGocciaBytecodeGeneratorObjectValue.CaptureContinuation(
   const AContinuationIP: Integer);
 var
   I: Integer;
+  LiveLocalCellCount: Integer;
+  LiveRegisterCount: Integer;
 begin
   FHasContinuation := True;
   FContinuationIP := AContinuationIP;
   FContinuationPrevCovLine := APrevCovLine;
   FResumeRegister := AResumeRegister;
 
-  SetLength(FContinuationRegisters, FVM.FRegisterCount);
+  LiveLocalCellCount := FVM.FLocalCellCount;
+  while (LiveLocalCellCount > 0) and
+        not Assigned(FVM.FLocalCells[LiveLocalCellCount - 1]) do
+    Dec(LiveLocalCellCount);
+
+  LiveRegisterCount := FVM.FRegisterCount;
+  while (LiveRegisterCount > 0) and
+        (FVM.FRegisters[LiveRegisterCount - 1].Kind = grkUndefined) and
+        (LiveRegisterCount > LiveLocalCellCount) do
+    Dec(LiveRegisterCount);
+
+  SetLength(FContinuationRegisters, LiveRegisterCount);
   for I := 0 to High(FContinuationRegisters) do
     FContinuationRegisters[I] := FVM.FRegisters[I];
 
-  SetLength(FContinuationLocalCells, FVM.FLocalCellCount);
+  SetLength(FContinuationLocalCells, LiveLocalCellCount);
   for I := 0 to High(FContinuationLocalCells) do
     FContinuationLocalCells[I] := FVM.FLocalCells[I];
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1378,7 +1378,12 @@ type
       const AArguments: TGocciaRegisterArray);
     destructor Destroy; override;
     function AdvanceNext: TGocciaObjectValue; override;
+    function AdvanceNextValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
     function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    function DirectNextValue(const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue; override;
+    function ReturnValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
+    function ThrowValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
+    procedure Close; override;
     function GeneratorNext(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     function GeneratorReturn(const AArgs: TGocciaArgumentsCollection;
@@ -1652,13 +1657,20 @@ begin
   try
     if FIteratorValue is TGocciaIteratorValue then
     begin
-      Value := TGocciaIteratorValue(FIteratorValue).DirectNext(Done);
+      if AArgs.Length > 0 then
+        Value := TGocciaIteratorValue(FIteratorValue).DirectNextValue(
+          AArgs.GetElement(0), Done)
+      else
+        Value := TGocciaIteratorValue(FIteratorValue).DirectNext(Done);
       UnwrappedValue := AwaitValue(Value);
       IteratorResult := CreateIteratorResult(UnwrappedValue, Done);
       Exit(PromiseResolve(IteratorResult));
     end;
 
-    CallArgs := TGocciaArgumentsCollection.Create;
+    if AArgs.Length > 0 then
+      CallArgs := TGocciaArgumentsCollection.Create([AArgs.GetElement(0)])
+    else
+      CallArgs := TGocciaArgumentsCollection.Create;
     try
       IteratorResult := TGocciaFunctionBase(FNextMethod).Call(CallArgs, FIteratorValue);
     finally
@@ -1889,6 +1901,7 @@ var
   DoneValue: TGocciaValue;
   IteratorValue: TGocciaValue;
   NextResult: TGocciaValue;
+  ReturnMethod: TGocciaValue;
   YieldedValue: TGocciaValue;
   HadDelegateContinuation: Boolean;
 begin
@@ -1912,15 +1925,19 @@ begin
 
   if FResumeKind = bgrkReturn then
   begin
+    NextResult := nil;
     FReturnValue := nil;
     if Assigned(FDelegateIterator) then
-      FDelegateIterator.Close
+      NextResult := FDelegateIterator.ReturnValue(RegisterToValue(FResumeValue))
     else if Assigned(FDelegateIteratorValue) then
     begin
       NextResult := FDelegateIteratorValue.GetProperty(PROP_RETURN);
-      if Assigned(NextResult) and not (NextResult is TGocciaUndefinedLiteralValue) and
-         NextResult.IsCallable then
+      if Assigned(NextResult) and
+         not (NextResult is TGocciaUndefinedLiteralValue) and
+         not (NextResult is TGocciaNullLiteralValue) then
       begin
+        if not NextResult.IsCallable then
+          ThrowTypeError('Iterator return is not callable');
         CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
         try
           NextResult := TGocciaFunctionBase(NextResult).Call(
@@ -1931,21 +1948,26 @@ begin
         finally
           CallArgs.Free;
         end;
-        if not (NextResult is TGocciaObjectValue) then
-          ThrowTypeError('Iterator return result is not an object');
-        DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
-        YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-        if not Assigned(YieldedValue) then
-          YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-        if not Assigned(DoneValue) or not DoneValue.ToBooleanLiteral.Value then
-        begin
-          CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
-            AResumeRegister, AContinuationIP);
-          raise EGocciaBytecodeYield.Create(
-            VMValueToRegisterFast(YieldedValue), 0);
-        end;
-        FReturnValue := YieldedValue;
+      end
+      else
+        NextResult := nil;
+    end;
+    if Assigned(NextResult) then
+    begin
+      if not (NextResult is TGocciaObjectValue) then
+        ThrowTypeError('Iterator return result is not an object');
+      DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
+      YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+      if not Assigned(YieldedValue) then
+        YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+      if not Assigned(DoneValue) or not DoneValue.ToBooleanLiteral.Value then
+      begin
+        CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
+          AResumeRegister, AContinuationIP);
+        raise EGocciaBytecodeYield.Create(
+          VMValueToRegisterFast(YieldedValue), 0);
       end;
+      FReturnValue := YieldedValue;
     end;
     ClearDelegateState;
     if not Assigned(FReturnValue) then
@@ -1957,12 +1979,41 @@ begin
 
   if FResumeKind = bgrkThrow then
   begin
-    if Assigned(FDelegateIteratorValue) then
+    NextResult := nil;
+    if Assigned(FDelegateIterator) then
+      NextResult := FDelegateIterator.ThrowValue(RegisterToValue(FResumeValue))
+    else if Assigned(FDelegateIteratorValue) then
     begin
       NextResult := FDelegateIteratorValue.GetProperty(PROP_THROW);
-      if Assigned(NextResult) and not (NextResult is TGocciaUndefinedLiteralValue) and
-         NextResult.IsCallable then
+      if Assigned(NextResult) and
+         not (NextResult is TGocciaUndefinedLiteralValue) and
+         not (NextResult is TGocciaNullLiteralValue) then
       begin
+        if not NextResult.IsCallable then
+        begin
+          ReturnMethod := FDelegateIteratorValue.GetProperty(PROP_RETURN);
+          if Assigned(ReturnMethod) and
+             not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+             not (ReturnMethod is TGocciaNullLiteralValue) then
+          begin
+            if not ReturnMethod.IsCallable then
+              ThrowTypeError('Iterator return is not callable');
+            CallArgs := TGocciaArgumentsCollection.Create;
+            try
+              ReturnMethod := TGocciaFunctionBase(ReturnMethod).Call(
+                CallArgs, FDelegateIteratorValue);
+              if Assigned(FClosure) and Assigned(FClosure.Template) and
+                 FClosure.Template.IsAsync then
+                ReturnMethod := AwaitValue(ReturnMethod);
+            finally
+              CallArgs.Free;
+            end;
+            if not (ReturnMethod is TGocciaObjectValue) then
+              ThrowTypeError('Iterator return result is not an object');
+          end;
+          ClearDelegateState;
+          ThrowTypeError('Iterator throw is not callable');
+        end;
         CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
         try
           NextResult := TGocciaFunctionBase(NextResult).Call(
@@ -1973,25 +2024,30 @@ begin
         finally
           CallArgs.Free;
         end;
-        if not (NextResult is TGocciaObjectValue) then
-          ThrowTypeError('Iterator throw result is not an object');
-        DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
-        if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
-        begin
-          YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-          if not Assigned(YieldedValue) then
-            YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-          FVM.FRegisters[AResumeRegister] := VMValueToRegisterFast(YieldedValue);
-          ClearDelegateState;
-          Exit;
-        end;
+      end
+      else
+        NextResult := nil;
+    end;
+    if Assigned(NextResult) then
+    begin
+      if not (NextResult is TGocciaObjectValue) then
+        ThrowTypeError('Iterator throw result is not an object');
+      DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
+      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+      begin
         YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
         if not Assigned(YieldedValue) then
           YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-        CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
-          AResumeRegister, AContinuationIP);
-        raise EGocciaBytecodeYield.Create(VMValueToRegisterFast(YieldedValue), 0);
+        FVM.FRegisters[AResumeRegister] := VMValueToRegisterFast(YieldedValue);
+        ClearDelegateState;
+        Exit;
       end;
+      YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+      if not Assigned(YieldedValue) then
+        YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+      CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
+        AResumeRegister, AContinuationIP);
+      raise EGocciaBytecodeYield.Create(VMValueToRegisterFast(YieldedValue), 0);
     end;
     ClearDelegateState;
     raise EGocciaBytecodeThrow.Create(RegisterToValue(FResumeValue));
@@ -2000,7 +2056,13 @@ begin
   while True do
   begin
     if Assigned(FDelegateIterator) then
-      YieldedValue := FDelegateIterator.DirectNext(Done)
+    begin
+      if HadDelegateContinuation and (FResumeKind = bgrkNext) then
+        YieldedValue := FDelegateIterator.DirectNextValue(
+          RegisterToValue(FResumeValue), Done)
+      else
+        YieldedValue := FDelegateIterator.DirectNext(Done);
+    end
     else
     begin
       if not Assigned(FDelegateNextMethod) or not FDelegateNextMethod.IsCallable then
@@ -2124,17 +2186,56 @@ begin
 end;
 
 function TGocciaBytecodeGeneratorObjectValue.AdvanceNext: TGocciaObjectValue;
+begin
+  Result := AdvanceNextValue(TGocciaUndefinedLiteralValue.UndefinedValue);
+end;
+
+function TGocciaBytecodeGeneratorObjectValue.AdvanceNextValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
 var
   Done: Boolean;
-  Value: TGocciaValue;
+  ResultValue: TGocciaValue;
 begin
-  Value := ResumeRaw(bgrkNext, TGocciaUndefinedLiteralValue.UndefinedValue, Done);
-  Result := CreateIteratorResult(Value, Done);
+  ResultValue := ResumeRaw(bgrkNext, AValue, Done);
+  Result := CreateIteratorResult(ResultValue, Done);
 end;
 
 function TGocciaBytecodeGeneratorObjectValue.DirectNext(out ADone: Boolean): TGocciaValue;
 begin
-  Result := ResumeRaw(bgrkNext, TGocciaUndefinedLiteralValue.UndefinedValue, ADone);
+  Result := DirectNextValue(TGocciaUndefinedLiteralValue.UndefinedValue, ADone);
+end;
+
+function TGocciaBytecodeGeneratorObjectValue.DirectNextValue(
+  const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue;
+begin
+  Result := ResumeRaw(bgrkNext, AValue, ADone);
+end;
+
+function TGocciaBytecodeGeneratorObjectValue.ReturnValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+var
+  Done: Boolean;
+  ResultValue: TGocciaValue;
+begin
+  ResultValue := ResumeRaw(bgrkReturn, AValue, Done);
+  Result := CreateIteratorResult(ResultValue, Done);
+end;
+
+function TGocciaBytecodeGeneratorObjectValue.ThrowValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+var
+  Done: Boolean;
+  ResultValue: TGocciaValue;
+begin
+  ResultValue := ResumeRaw(bgrkThrow, AValue, Done);
+  Result := CreateIteratorResult(ResultValue, Done);
+end;
+
+procedure TGocciaBytecodeGeneratorObjectValue.Close;
+begin
+  if FState = bgsCompleted then
+    Exit;
+  ReturnValue(TGocciaUndefinedLiteralValue.UndefinedValue);
 end;
 
 function TGocciaBytecodeGeneratorObjectValue.GeneratorNext(

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1714,6 +1714,14 @@ begin
       Result := PromiseReject(E.Value);
     on E: TGocciaTypeError do
       Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
+    on E: TGocciaReferenceError do
+      Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+    on E: TGocciaSyntaxError do
+      Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: TGocciaRuntimeError do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
+    on E: Exception do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
 end;
 
@@ -1789,6 +1797,14 @@ begin
       Result := PromiseReject(E.Value);
     on E: TGocciaTypeError do
       Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
+    on E: TGocciaReferenceError do
+      Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+    on E: TGocciaSyntaxError do
+      Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: TGocciaRuntimeError do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
+    on E: Exception do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
 end;
 
@@ -1877,6 +1893,14 @@ begin
       Result := PromiseReject(E.Value);
     on E: TGocciaTypeError do
       Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
+    on E: TGocciaReferenceError do
+      Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+    on E: TGocciaSyntaxError do
+      Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: TGocciaRuntimeError do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
+    on E: Exception do
+      Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
 end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1710,9 +1710,11 @@ function TGocciaVMAsyncFromSyncIteratorValue.ReturnValue(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   CallArgs: TGocciaArgumentsCollection;
+  Done: Boolean;
   DoneValue: TGocciaValue;
   IteratorResult: TGocciaValue;
   ReturnMethod: TGocciaValue;
+  UnwrappedValue: TGocciaValue;
   Value: TGocciaValue;
 begin
   if Assigned(AArgs) and (AArgs.Length > 0) then
@@ -1727,9 +1729,14 @@ begin
     begin
       IteratorResult := TGocciaIteratorValue(FIteratorValue).ReturnValue(Value);
       DoneValue := IteratorResult.GetProperty(PROP_DONE);
-      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+      Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
+      if Done then
         FIteratorValue := nil;
-      Exit(PromiseResolve(IteratorResult));
+      Value := IteratorResult.GetProperty(PROP_VALUE);
+      if not Assigned(Value) then
+        Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+      UnwrappedValue := AwaitValue(Value);
+      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
     ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);
@@ -1752,9 +1759,14 @@ begin
     if not (IteratorResult is TGocciaObjectValue) then
       ThrowTypeError('Iterator return result is not an object');
     DoneValue := IteratorResult.GetProperty(PROP_DONE);
-    if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+    Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
+    if Done then
       FIteratorValue := nil;
-    Result := PromiseResolve(IteratorResult);
+    Value := IteratorResult.GetProperty(PROP_VALUE);
+    if not Assigned(Value) then
+      Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+    UnwrappedValue := AwaitValue(Value);
+    Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
   except
     on E: EGocciaBytecodeThrow do
       Result := PromiseReject(E.ThrownValue);
@@ -1769,10 +1781,12 @@ function TGocciaVMAsyncFromSyncIteratorValue.ThrowValue(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   CallArgs: TGocciaArgumentsCollection;
+  Done: Boolean;
   DoneValue: TGocciaValue;
   IteratorResult: TGocciaValue;
   ReturnMethod: TGocciaValue;
   ThrowMethod: TGocciaValue;
+  UnwrappedValue: TGocciaValue;
   Value: TGocciaValue;
 begin
   if Assigned(AArgs) and (AArgs.Length > 0) then
@@ -1787,9 +1801,14 @@ begin
     begin
       IteratorResult := TGocciaIteratorValue(FIteratorValue).ThrowValue(Value);
       DoneValue := IteratorResult.GetProperty(PROP_DONE);
-      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+      Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
+      if Done then
         FIteratorValue := nil;
-      Exit(PromiseResolve(IteratorResult));
+      Value := IteratorResult.GetProperty(PROP_VALUE);
+      if not Assigned(Value) then
+        Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+      UnwrappedValue := AwaitValue(Value);
+      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
     ThrowMethod := FIteratorValue.GetProperty(PROP_THROW);
@@ -1808,9 +1827,14 @@ begin
       if not (IteratorResult is TGocciaObjectValue) then
         ThrowTypeError('Iterator throw result is not an object');
       DoneValue := IteratorResult.GetProperty(PROP_DONE);
-      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+      Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
+      if Done then
         FIteratorValue := nil;
-      Exit(PromiseResolve(IteratorResult));
+      Value := IteratorResult.GetProperty(PROP_VALUE);
+      if not Assigned(Value) then
+        Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+      UnwrappedValue := AwaitValue(Value);
+      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
     ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1347,17 +1347,29 @@ type
     FThisValue: TGocciaRegister;
     FArguments: TGocciaRegisterArray;
     FState: TGocciaBytecodeGeneratorState;
-    FResumeIndex: Integer;
-    FReplayYieldIndex: Integer;
     FResumeKind: TGocciaBytecodeGeneratorResumeKind;
     FResumeValue: TGocciaRegister;
+    FResumeRegister: UInt8;
     FReturnSentinel: TGocciaValue;
     FReturnValue: TGocciaValue;
-    FSentValues: TGocciaRegisterArray;
+    FHasContinuation: Boolean;
+    FContinuationIP: Integer;
+    FContinuationRegisters: TGocciaRegisterArray;
+    FContinuationLocalCells: TGocciaBytecodeCellArray;
+    FContinuationHandlers: TGocciaBytecodeHandlerEntryArray;
+    FContinuationPrevCovLine: UInt32;
+    FDelegateActive: Boolean;
+    FDelegateIteratorValue: TGocciaValue;
+    FDelegateIterator: TGocciaIteratorValue;
+    FDelegateNextMethod: TGocciaValue;
     function ResumeRaw(const AKind: TGocciaBytecodeGeneratorResumeKind;
       const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue;
-    procedure StoreResumeValue(const AValue: TGocciaValue);
-    function ReplayYield(const AResumeRegister: UInt8): Boolean;
+    procedure CaptureContinuation(const AFrame: TGocciaVMCallFrame;
+      const AHandlerBaseCount: Integer; const APrevCovLine: UInt32;
+      const AResumeRegister: UInt8; const AContinuationIP: Integer);
+    function RestoreContinuation(var AFrame: TGocciaVMCallFrame;
+      const AHandlerBaseCount: Integer; out APrevCovLine: UInt32): Boolean;
+    procedure ClearDelegateState;
   public
     constructor Create(const AVM: TGocciaVM; const AClosure: TGocciaBytecodeClosure;
       const AThisValue: TGocciaValue; const AArguments: TGocciaArgumentsCollection);
@@ -1373,9 +1385,14 @@ type
       const AThisValue: TGocciaValue): TGocciaValue;
     function GeneratorThrow(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
-    procedure HandleYield(const AValue: TGocciaRegister; const AResumeRegister: UInt8);
+    procedure HandleYield(const AValue: TGocciaRegister;
+      const AResumeRegister: UInt8; const AFrame: TGocciaVMCallFrame;
+      const AHandlerBaseCount: Integer; const APrevCovLine: UInt32;
+      const AContinuationIP: Integer);
     procedure HandleYieldDelegate(const AIterable: TGocciaRegister;
-      const AResumeRegister: UInt8);
+      const AResumeRegister: UInt8; const AFrame: TGocciaVMCallFrame;
+      const AHandlerBaseCount: Integer; const APrevCovLine: UInt32;
+      const AContinuationIP: Integer);
     procedure MarkReferences; override;
     function ToStringTag: string; override;
   end;
@@ -1794,94 +1811,207 @@ begin
     [pfConfigurable, pfWritable]));
 end;
 
-procedure TGocciaBytecodeGeneratorObjectValue.StoreResumeValue(
-  const AValue: TGocciaValue);
+procedure TGocciaBytecodeGeneratorObjectValue.CaptureContinuation(
+  const AFrame: TGocciaVMCallFrame; const AHandlerBaseCount: Integer;
+  const APrevCovLine: UInt32; const AResumeRegister: UInt8;
+  const AContinuationIP: Integer);
+var
+  I: Integer;
 begin
-  if FResumeIndex <= 0 then
-    Exit;
-  if Length(FSentValues) < FResumeIndex then
-    SetLength(FSentValues, FResumeIndex);
-  FSentValues[FResumeIndex - 1] := VMValueToRegisterFast(AValue);
+  FHasContinuation := True;
+  FContinuationIP := AContinuationIP;
+  FContinuationPrevCovLine := APrevCovLine;
+  FResumeRegister := AResumeRegister;
+
+  SetLength(FContinuationRegisters, FVM.FRegisterCount);
+  for I := 0 to High(FContinuationRegisters) do
+    FContinuationRegisters[I] := FVM.FRegisters[I];
+
+  SetLength(FContinuationLocalCells, FVM.FLocalCellCount);
+  for I := 0 to High(FContinuationLocalCells) do
+    FContinuationLocalCells[I] := FVM.FLocalCells[I];
+
+  FVM.FHandlerStack.CopyFrom(AHandlerBaseCount, FContinuationHandlers);
 end;
 
-function TGocciaBytecodeGeneratorObjectValue.ReplayYield(
-  const AResumeRegister: UInt8): Boolean;
+function TGocciaBytecodeGeneratorObjectValue.RestoreContinuation(
+  var AFrame: TGocciaVMCallFrame; const AHandlerBaseCount: Integer;
+  out APrevCovLine: UInt32): Boolean;
+var
+  I: Integer;
 begin
-  Result := FReplayYieldIndex < FResumeIndex;
+  Result := FHasContinuation;
   if not Result then
     Exit;
 
-  if (FReplayYieldIndex = FResumeIndex - 1) and (FResumeKind = bgrkThrow) then
-  begin
-    Inc(FReplayYieldIndex);
-    raise EGocciaBytecodeThrow.Create(RegisterToValue(FResumeValue));
-  end;
+  FHasContinuation := False;
+  FVM.EnsureRegisterCapacity(Length(FContinuationRegisters));
+  for I := 0 to High(FContinuationRegisters) do
+    FVM.FRegisters[I] := FContinuationRegisters[I];
+  FVM.EnsureLocalCapacity(Length(FContinuationLocalCells));
+  for I := 0 to High(FContinuationLocalCells) do
+    FVM.FLocalCells[I] := FContinuationLocalCells[I];
 
-  if (FReplayYieldIndex = FResumeIndex - 1) and (FResumeKind = bgrkReturn) then
-  begin
-    Inc(FReplayYieldIndex);
-    FReturnValue := RegisterToValue(FResumeValue);
-    if not Assigned(FReturnSentinel) then
-      FReturnSentinel := TGocciaObjectValue.Create;
-    raise EGocciaBytecodeThrow.Create(FReturnSentinel);
-  end;
+  while FVM.FHandlerStack.Count > AHandlerBaseCount do
+    FVM.FHandlerStack.Pop;
+  FVM.FHandlerStack.RestoreFrom(FContinuationHandlers);
 
-  if (FReplayYieldIndex < Length(FSentValues)) then
-    FVM.FRegisters[AResumeRegister] := FSentValues[FReplayYieldIndex]
-  else
-    FVM.FRegisters[AResumeRegister] := RegisterUndefined;
-  Inc(FReplayYieldIndex);
+  AFrame.IP := FContinuationIP;
+  APrevCovLine := FContinuationPrevCovLine;
+end;
+
+procedure TGocciaBytecodeGeneratorObjectValue.ClearDelegateState;
+begin
+  FDelegateActive := False;
+  FDelegateIteratorValue := nil;
+  FDelegateIterator := nil;
+  FDelegateNextMethod := nil;
 end;
 
 procedure TGocciaBytecodeGeneratorObjectValue.HandleYield(
-  const AValue: TGocciaRegister; const AResumeRegister: UInt8);
-var
-  YieldIndex: Integer;
+  const AValue: TGocciaRegister; const AResumeRegister: UInt8;
+  const AFrame: TGocciaVMCallFrame; const AHandlerBaseCount: Integer;
+  const APrevCovLine: UInt32; const AContinuationIP: Integer);
 begin
-  if ReplayYield(AResumeRegister) then
-    Exit;
-
-  YieldIndex := FReplayYieldIndex;
-  Inc(FReplayYieldIndex);
-  raise EGocciaBytecodeYield.Create(AValue, YieldIndex);
+  ClearDelegateState;
+  CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
+    AResumeRegister, AContinuationIP);
+  raise EGocciaBytecodeYield.Create(AValue, 0);
 end;
 
 procedure TGocciaBytecodeGeneratorObjectValue.HandleYieldDelegate(
-  const AIterable: TGocciaRegister; const AResumeRegister: UInt8);
+  const AIterable: TGocciaRegister; const AResumeRegister: UInt8;
+  const AFrame: TGocciaVMCallFrame; const AHandlerBaseCount: Integer;
+  const APrevCovLine: UInt32; const AContinuationIP: Integer);
 var
   CallArgs: TGocciaArgumentsCollection;
   Done: Boolean;
   DoneValue: TGocciaValue;
   IteratorValue: TGocciaValue;
-  Iterator: TGocciaIteratorValue;
-  NextMethod: TGocciaValue;
   NextResult: TGocciaValue;
-  YieldIndex: Integer;
   YieldedValue: TGocciaValue;
+  HadDelegateContinuation: Boolean;
 begin
-  IteratorValue := FVM.GetIteratorValue(RegisterToValue(AIterable),
-    Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync);
-  if not Assigned(IteratorValue) then
-    Exit;
+  HadDelegateContinuation := FDelegateActive;
+  if not FDelegateActive then
+  begin
+    IteratorValue := FVM.GetIteratorValue(RegisterToValue(AIterable),
+      Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync);
+    if not Assigned(IteratorValue) then
+      Exit;
 
-  Iterator := nil;
-  NextMethod := nil;
-  if IteratorValue is TGocciaIteratorValue then
-    Iterator := TGocciaIteratorValue(IteratorValue)
-  else if IteratorValue is TGocciaObjectValue then
-    NextMethod := IteratorValue.GetProperty(PROP_NEXT);
+    FDelegateIteratorValue := IteratorValue;
+    FDelegateIterator := nil;
+    FDelegateNextMethod := nil;
+    if IteratorValue is TGocciaIteratorValue then
+      FDelegateIterator := TGocciaIteratorValue(IteratorValue)
+    else if IteratorValue is TGocciaObjectValue then
+      FDelegateNextMethod := IteratorValue.GetProperty(PROP_NEXT);
+    FDelegateActive := True;
+  end;
+
+  if FResumeKind = bgrkReturn then
+  begin
+    FReturnValue := nil;
+    if Assigned(FDelegateIterator) then
+      FDelegateIterator.Close
+    else if Assigned(FDelegateIteratorValue) then
+    begin
+      NextResult := FDelegateIteratorValue.GetProperty(PROP_RETURN);
+      if Assigned(NextResult) and not (NextResult is TGocciaUndefinedLiteralValue) and
+         NextResult.IsCallable then
+      begin
+        CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
+        try
+          NextResult := TGocciaFunctionBase(NextResult).Call(
+            CallArgs, FDelegateIteratorValue);
+          if Assigned(FClosure) and Assigned(FClosure.Template) and
+             FClosure.Template.IsAsync then
+            NextResult := AwaitValue(NextResult);
+        finally
+          CallArgs.Free;
+        end;
+        if not (NextResult is TGocciaObjectValue) then
+          ThrowTypeError('Iterator return result is not an object');
+        DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
+        YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+        if not Assigned(YieldedValue) then
+          YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+        if not Assigned(DoneValue) or not DoneValue.ToBooleanLiteral.Value then
+        begin
+          CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
+            AResumeRegister, AContinuationIP);
+          raise EGocciaBytecodeYield.Create(
+            VMValueToRegisterFast(YieldedValue), 0);
+        end;
+        FReturnValue := YieldedValue;
+      end;
+    end;
+    ClearDelegateState;
+    if not Assigned(FReturnValue) then
+      FReturnValue := RegisterToValue(FResumeValue);
+    if not Assigned(FReturnSentinel) then
+      FReturnSentinel := TGocciaObjectValue.Create;
+    raise EGocciaBytecodeThrow.Create(FReturnSentinel);
+  end;
+
+  if FResumeKind = bgrkThrow then
+  begin
+    if Assigned(FDelegateIteratorValue) then
+    begin
+      NextResult := FDelegateIteratorValue.GetProperty(PROP_THROW);
+      if Assigned(NextResult) and not (NextResult is TGocciaUndefinedLiteralValue) and
+         NextResult.IsCallable then
+      begin
+        CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
+        try
+          NextResult := TGocciaFunctionBase(NextResult).Call(
+            CallArgs, FDelegateIteratorValue);
+          if Assigned(FClosure) and Assigned(FClosure.Template) and
+             FClosure.Template.IsAsync then
+            NextResult := AwaitValue(NextResult);
+        finally
+          CallArgs.Free;
+        end;
+        if not (NextResult is TGocciaObjectValue) then
+          ThrowTypeError('Iterator throw result is not an object');
+        DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
+        if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+        begin
+          YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+          if not Assigned(YieldedValue) then
+            YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+          FVM.FRegisters[AResumeRegister] := VMValueToRegisterFast(YieldedValue);
+          ClearDelegateState;
+          Exit;
+        end;
+        YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+        if not Assigned(YieldedValue) then
+          YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+        CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
+          AResumeRegister, AContinuationIP);
+        raise EGocciaBytecodeYield.Create(VMValueToRegisterFast(YieldedValue), 0);
+      end;
+    end;
+    ClearDelegateState;
+    raise EGocciaBytecodeThrow.Create(RegisterToValue(FResumeValue));
+  end;
 
   while True do
   begin
-    if Assigned(Iterator) then
-      YieldedValue := Iterator.DirectNext(Done)
+    if Assigned(FDelegateIterator) then
+      YieldedValue := FDelegateIterator.DirectNext(Done)
     else
     begin
-      if not Assigned(NextMethod) or not NextMethod.IsCallable then
+      if not Assigned(FDelegateNextMethod) or not FDelegateNextMethod.IsCallable then
         ThrowTypeError('Iterator.next is not a function');
-      CallArgs := TGocciaArgumentsCollection.Create;
+      if HadDelegateContinuation and (FResumeKind = bgrkNext) then
+        CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)])
+      else
+        CallArgs := TGocciaArgumentsCollection.Create;
       try
-        NextResult := TGocciaFunctionBase(NextMethod).Call(CallArgs, IteratorValue);
+        NextResult := TGocciaFunctionBase(FDelegateNextMethod).Call(
+          CallArgs, FDelegateIteratorValue);
         if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
           NextResult := AwaitValue(NextResult);
       finally
@@ -1900,15 +2030,13 @@ begin
     if Done then
     begin
       FVM.FRegisters[AResumeRegister] := VMValueToRegisterFast(YieldedValue);
+      ClearDelegateState;
       Exit;
     end;
 
-    if ReplayYield(AResumeRegister) then
-      Continue;
-
-    YieldIndex := FReplayYieldIndex;
-    Inc(FReplayYieldIndex);
-    raise EGocciaBytecodeYield.Create(VMValueToRegisterFast(YieldedValue), YieldIndex);
+    CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
+      AResumeRegister, AContinuationIP);
+    raise EGocciaBytecodeYield.Create(VMValueToRegisterFast(YieldedValue), 0);
   end;
 end;
 
@@ -1932,14 +2060,14 @@ begin
   if FState = bgsExecuting then
     raise TGocciaThrowValue.Create(VMGeneratorExecutingError);
 
-  if (FResumeIndex = 0) and (AKind = bgrkReturn) then
+  if (FState = bgsSuspendedStart) and (AKind = bgrkReturn) then
   begin
     FState := bgsCompleted;
     ADone := True;
     Exit(AValue);
   end;
 
-  if (FResumeIndex = 0) and (AKind = bgrkThrow) then
+  if (FState = bgsSuspendedStart) and (AKind = bgrkThrow) then
   begin
     FState := bgsCompleted;
     raise TGocciaThrowValue.Create(AValue);
@@ -1947,9 +2075,6 @@ begin
 
   FResumeKind := AKind;
   FResumeValue := VMValueToRegisterFast(AValue);
-  if AKind = bgrkNext then
-    StoreResumeValue(AValue);
-  FReplayYieldIndex := 0;
   FState := bgsExecuting;
 
   PreviousGenerator := GActiveBytecodeGenerator;
@@ -1958,14 +2083,12 @@ begin
     try
       ReturnRegister := FVM.ExecuteClosureRegisters(FClosure, FThisValue, FArguments);
       FState := bgsCompleted;
+      ClearDelegateState;
       ADone := True;
       Result := RegisterToValue(ReturnRegister);
     except
       on E: EGocciaBytecodeYield do
       begin
-        FResumeIndex := E.YieldIndex + 1;
-        if Length(FSentValues) < FResumeIndex then
-          SetLength(FSentValues, FResumeIndex);
         FState := bgsSuspendedYield;
         ADone := False;
         Result := RegisterToValue(E.Value);
@@ -1973,6 +2096,7 @@ begin
       on E: EGocciaBytecodeGeneratorReturn do
       begin
         FState := bgsCompleted;
+        ClearDelegateState;
         ADone := True;
         Result := E.Value;
       end;
@@ -1981,12 +2105,14 @@ begin
         if Assigned(FReturnSentinel) and (E.ThrownValue = FReturnSentinel) then
         begin
           FState := bgsCompleted;
+          ClearDelegateState;
           ADone := True;
           Result := FReturnValue;
         end
         else
         begin
           FState := bgsCompleted;
+          ClearDelegateState;
           ADone := True;
           raise;
         end;
@@ -2066,8 +2192,17 @@ begin
   MarkRegisterReferences(FThisValue);
   for I := 0 to High(FArguments) do
     MarkRegisterReferences(FArguments[I]);
-  for I := 0 to High(FSentValues) do
-    MarkRegisterReferences(FSentValues[I]);
+  for I := 0 to High(FContinuationRegisters) do
+    MarkRegisterReferences(FContinuationRegisters[I]);
+  for I := 0 to High(FContinuationLocalCells) do
+    if Assigned(FContinuationLocalCells[I]) then
+      MarkRegisterReferences(FContinuationLocalCells[I].Value);
+  if Assigned(FDelegateIteratorValue) then
+    FDelegateIteratorValue.MarkReferences;
+  if Assigned(FDelegateIterator) then
+    FDelegateIterator.MarkReferences;
+  if Assigned(FDelegateNextMethod) then
+    FDelegateNextMethod.MarkReferences;
   if Assigned(FReturnSentinel) then
     FReturnSentinel.MarkReferences;
   if Assigned(FReturnValue) then
@@ -5207,6 +5342,7 @@ var
   ProfileEntryTimestamp: Int64;
   DynImportPromise: TGocciaPromiseValue;
   SpreadArray: TGocciaArrayValue;
+  RestoredContinuation: Boolean;
 begin
   SavedRegisterBase := FRegisterBase;
   SavedRegisterCount := FRegisterCount;
@@ -5220,6 +5356,41 @@ begin
     SetupNewFrame(AClosure, AThisValue, AArguments, AArgCount,
       AArg0, AArg1, AArg2, AUseFixedArgs,
       Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+    RestoredContinuation := Assigned(GActiveBytecodeGenerator) and
+      GActiveBytecodeGenerator.RestoreContinuation(
+        Frame, SavedHandlerCount, PrevCovLine);
+    if RestoredContinuation then
+    begin
+      if GActiveBytecodeGenerator.FDelegateActive then
+      begin
+        if GActiveBytecodeGenerator.FResumeKind = bgrkNext then
+          SetRegisterRaw(GActiveBytecodeGenerator.FResumeRegister,
+            GActiveBytecodeGenerator.FResumeValue);
+      end
+      else
+      begin
+        case GActiveBytecodeGenerator.FResumeKind of
+          bgrkNext:
+            SetRegisterRaw(GActiveBytecodeGenerator.FResumeRegister,
+              GActiveBytecodeGenerator.FResumeValue);
+          bgrkThrow:
+            HandleExceptionUnwind(
+              RegisterToValue(GActiveBytecodeGenerator.FResumeValue),
+              InitialFrameStackCount, SavedHandlerCount,
+              Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+          bgrkReturn:
+            begin
+              GActiveBytecodeGenerator.FReturnValue :=
+                RegisterToValue(GActiveBytecodeGenerator.FResumeValue);
+              if not Assigned(GActiveBytecodeGenerator.FReturnSentinel) then
+                GActiveBytecodeGenerator.FReturnSentinel := TGocciaObjectValue.Create;
+              HandleExceptionUnwind(GActiveBytecodeGenerator.FReturnSentinel,
+                InitialFrameStackCount, SavedHandlerCount,
+                Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+            end;
+        end;
+      end;
+    end;
     Running := True;
     while Running and (Frame.IP < Template.CodeCount) do
     begin
@@ -6910,9 +7081,13 @@ begin
         if Assigned(GActiveBytecodeGenerator) then
         begin
           if (C and 1) <> 0 then
-            GActiveBytecodeGenerator.HandleYieldDelegate(FRegisters[A], B)
+            GActiveBytecodeGenerator.HandleYieldDelegate(
+              FRegisters[A], B, Frame, SavedHandlerCount, PrevCovLine,
+              Frame.IP - 1)
           else
-            GActiveBytecodeGenerator.HandleYield(FRegisters[A], B);
+            GActiveBytecodeGenerator.HandleYield(
+              FRegisters[A], B, Frame, SavedHandlerCount, PrevCovLine,
+              Frame.IP);
         end
         else if A <> B then
           FRegisters[B] := FRegisters[A];

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2086,6 +2086,19 @@ var
   YieldedValue: TGocciaValue;
   HadDelegateContinuation: Boolean;
 
+  procedure ClearDelegateAndThrowTypeError(const AMessage: string);
+  begin
+    ClearDelegateState;
+    ThrowTypeError(AMessage);
+  end;
+
+  procedure ClearDelegateAndThrowTypeErrorWithSuggestion(
+    const AMessage, ASuggestion: string);
+  begin
+    ClearDelegateState;
+    ThrowTypeError(AMessage, ASuggestion);
+  end;
+
   procedure CloseDelegateForMissingThrow;
   begin
     ReturnMethod := nil;
@@ -2152,7 +2165,7 @@ begin
          not (NextResult is TGocciaNullLiteralValue) then
       begin
         if not NextResult.IsCallable then
-          ThrowTypeError('Iterator return is not callable');
+          ClearDelegateAndThrowTypeError('Iterator return is not callable');
         CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
         try
           NextResult := TGocciaFunctionBase(NextResult).Call(
@@ -2170,7 +2183,7 @@ begin
     if Assigned(NextResult) then
     begin
       if not (NextResult is TGocciaObjectValue) then
-        ThrowTypeError('Iterator return result is not an object');
+        ClearDelegateAndThrowTypeError('Iterator return result is not an object');
       DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
       YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
       if not Assigned(YieldedValue) then
@@ -2223,7 +2236,7 @@ begin
     if Assigned(NextResult) then
     begin
       if not (NextResult is TGocciaObjectValue) then
-        ThrowTypeError('Iterator throw result is not an object');
+        ClearDelegateAndThrowTypeError('Iterator throw result is not an object');
       DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
       if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
       begin
@@ -2258,7 +2271,7 @@ begin
     else
     begin
       if not Assigned(FDelegateNextMethod) or not FDelegateNextMethod.IsCallable then
-        ThrowTypeError('Iterator.next is not a function');
+        ClearDelegateAndThrowTypeError('Iterator.next is not a function');
       if HadDelegateContinuation and (FResumeKind = bgrkNext) then
         CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)])
       else
@@ -2272,7 +2285,8 @@ begin
         CallArgs.Free;
       end;
       if not (NextResult is TGocciaObjectValue) then
-        ThrowTypeError(Format(SErrorIteratorResultNotObject,
+        ClearDelegateAndThrowTypeErrorWithSuggestion(
+          Format(SErrorIteratorResultNotObject,
           [NextResult.ToStringLiteral.Value]), SSuggestIteratorResultObject);
       DoneValue := NextResult.GetProperty(PROP_DONE);
       Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1695,8 +1695,8 @@ begin
     end;
 
     if not (IteratorResult is TGocciaObjectValue) then
-      ThrowTypeError(Format(SErrorIteratorResultNotObject,
-        [IteratorResult.ToStringLiteral.Value]), SSuggestIteratorResultObject);
+      Exit(PromiseReject(CreateErrorObject(TYPE_ERROR_NAME,
+        Format(SErrorIteratorResultNotObject, [IteratorResult.TypeName]))));
 
     DoneValue := IteratorResult.GetProperty(PROP_DONE);
     Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
@@ -1712,6 +1712,8 @@ begin
       Result := PromiseReject(E.ThrownValue);
     on E: TGocciaThrowValue do
       Result := PromiseReject(E.Value);
+    on E: TGocciaTypeError do
+      Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
   end;
 end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2015,6 +2015,9 @@ begin
 
   AFrame.IP := FContinuationIP;
   APrevCovLine := FContinuationPrevCovLine;
+  SetLength(FContinuationRegisters, 0);
+  SetLength(FContinuationLocalCells, 0);
+  SetLength(FContinuationHandlers, 0);
 end;
 
 procedure TGocciaBytecodeGeneratorObjectValue.ClearDelegateState;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1734,7 +1734,10 @@ begin
     Value := TGocciaUndefinedLiteralValue.UndefinedValue;
   try
     if not Assigned(FIteratorValue) then
-      Exit(PromiseResolve(CreateIteratorResult(Value, True)));
+    begin
+      UnwrappedValue := AwaitValue(Value);
+      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, True)));
+    end;
 
     if FIteratorValue is TGocciaIteratorValue then
     begin
@@ -1756,7 +1759,8 @@ begin
        (ReturnMethod is TGocciaNullLiteralValue) then
     begin
       ClearIteratorState;
-      Exit(PromiseResolve(CreateIteratorResult(Value, True)));
+      UnwrappedValue := AwaitValue(Value);
+      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, True)));
     end;
     if not ReturnMethod.IsCallable then
       ThrowTypeError('Iterator return is not callable');
@@ -2114,6 +2118,26 @@ var
     ThrowTypeError(AMessage, ASuggestion);
   end;
 
+  function AwaitDelegateResult(const AResult: TGocciaValue): TGocciaValue;
+  begin
+    Result := AResult;
+    if Assigned(FClosure) and Assigned(FClosure.Template) and
+       FClosure.Template.IsAsync then
+      Result := AwaitValue(Result);
+  end;
+
+  function CallDelegateMethod(const AMethod, AThisValue: TGocciaValue;
+    const AArgs: TGocciaArgumentsCollection): TGocciaValue;
+  begin
+    try
+      Result := AwaitDelegateResult(TGocciaFunctionBase(AMethod).Call(
+        AArgs, AThisValue));
+    except
+      ClearDelegateState;
+      raise;
+    end;
+  end;
+
   procedure CloseDelegateForMissingThrow;
   begin
     ReturnMethod := nil;
@@ -2130,11 +2154,8 @@ var
       end;
       CallArgs := TGocciaArgumentsCollection.Create;
       try
-        ReturnMethod := TGocciaFunctionBase(ReturnMethod).Call(
-          CallArgs, FDelegateIteratorValue);
-        if Assigned(FClosure) and Assigned(FClosure.Template) and
-           FClosure.Template.IsAsync then
-          ReturnMethod := AwaitValue(ReturnMethod);
+        ReturnMethod := CallDelegateMethod(ReturnMethod,
+          FDelegateIteratorValue, CallArgs);
       finally
         CallArgs.Free;
       end;
@@ -2148,178 +2169,180 @@ var
     ThrowTypeError('Iterator throw is not callable');
   end;
 begin
-  HadDelegateContinuation := FDelegateActive;
-  if not FDelegateActive then
-  begin
-    IteratorValue := FVM.GetIteratorValue(RegisterToValue(AIterable),
-      Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync);
-    if not Assigned(IteratorValue) then
-      Exit;
-
-    FDelegateIteratorValue := IteratorValue;
-    FDelegateIterator := nil;
-    FDelegateNextMethod := nil;
-    if IteratorValue is TGocciaIteratorValue then
-      FDelegateIterator := TGocciaIteratorValue(IteratorValue)
-    else if IteratorValue is TGocciaObjectValue then
-      FDelegateNextMethod := IteratorValue.GetProperty(PROP_NEXT);
-    FDelegateActive := True;
-  end;
-
-  if FResumeKind = bgrkReturn then
-  begin
-    NextResult := nil;
-    FReturnValue := nil;
-    if Assigned(FDelegateIterator) then
-      NextResult := FDelegateIterator.ReturnValue(RegisterToValue(FResumeValue))
-    else if Assigned(FDelegateIteratorValue) then
+  try
+    HadDelegateContinuation := FDelegateActive;
+    if not FDelegateActive then
     begin
-      NextResult := FDelegateIteratorValue.GetProperty(PROP_RETURN);
-      if Assigned(NextResult) and
-         not (NextResult is TGocciaUndefinedLiteralValue) and
-         not (NextResult is TGocciaNullLiteralValue) then
-      begin
-        if not NextResult.IsCallable then
-          ClearDelegateAndThrowTypeError('Iterator return is not callable');
-        CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
-        try
-          NextResult := TGocciaFunctionBase(NextResult).Call(
-            CallArgs, FDelegateIteratorValue);
-          if Assigned(FClosure) and Assigned(FClosure.Template) and
-             FClosure.Template.IsAsync then
-            NextResult := AwaitValue(NextResult);
-        finally
-          CallArgs.Free;
-        end;
-      end
-      else
-        NextResult := nil;
+      IteratorValue := FVM.GetIteratorValue(RegisterToValue(AIterable),
+        Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync);
+      if not Assigned(IteratorValue) then
+        Exit;
+
+      FDelegateIteratorValue := IteratorValue;
+      FDelegateIterator := nil;
+      FDelegateNextMethod := nil;
+      if IteratorValue is TGocciaIteratorValue then
+        FDelegateIterator := TGocciaIteratorValue(IteratorValue)
+      else if IteratorValue is TGocciaObjectValue then
+        FDelegateNextMethod := IteratorValue.GetProperty(PROP_NEXT);
+      FDelegateActive := True;
     end;
-    if Assigned(NextResult) then
+
+    if FResumeKind = bgrkReturn then
     begin
-      if not (NextResult is TGocciaObjectValue) then
-        ClearDelegateAndThrowTypeError('Iterator return result is not an object');
-      DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
-      YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-      if not Assigned(YieldedValue) then
-        YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-      if not Assigned(DoneValue) or not DoneValue.ToBooleanLiteral.Value then
+      NextResult := nil;
+      FReturnValue := nil;
+      if Assigned(FDelegateIterator) then
+        NextResult := FDelegateIterator.ReturnValue(RegisterToValue(FResumeValue))
+      else if Assigned(FDelegateIteratorValue) then
       begin
-        CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
-          AResumeRegister, AContinuationIP);
-        raise EGocciaBytecodeYield.Create(
-          VMValueToRegisterFast(YieldedValue), 0);
+        NextResult := FDelegateIteratorValue.GetProperty(PROP_RETURN);
+        if Assigned(NextResult) and
+           not (NextResult is TGocciaUndefinedLiteralValue) and
+           not (NextResult is TGocciaNullLiteralValue) then
+        begin
+          if not NextResult.IsCallable then
+            ClearDelegateAndThrowTypeError('Iterator return is not callable');
+          CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
+          try
+            NextResult := CallDelegateMethod(NextResult,
+              FDelegateIteratorValue, CallArgs);
+          finally
+            CallArgs.Free;
+          end;
+        end
+        else
+          NextResult := nil;
       end;
-      FReturnValue := YieldedValue;
-    end;
-    ClearDelegateState;
-    if not Assigned(FReturnValue) then
-      FReturnValue := RegisterToValue(FResumeValue);
-    if not Assigned(FReturnSentinel) then
-      FReturnSentinel := TGocciaObjectValue.Create;
-    raise EGocciaBytecodeThrow.Create(FReturnSentinel);
-  end;
-
-  if FResumeKind = bgrkThrow then
-  begin
-    NextResult := nil;
-    if Assigned(FDelegateIterator) then
-      NextResult := FDelegateIterator.ThrowValue(RegisterToValue(FResumeValue))
-    else if Assigned(FDelegateIteratorValue) then
-    begin
-      NextResult := FDelegateIteratorValue.GetProperty(PROP_THROW);
-      if Assigned(NextResult) and
-         not (NextResult is TGocciaUndefinedLiteralValue) and
-         not (NextResult is TGocciaNullLiteralValue) then
+      if Assigned(NextResult) then
       begin
-        if not NextResult.IsCallable then
-          CloseDelegateForMissingThrow;
-        CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
-        try
-          NextResult := TGocciaFunctionBase(NextResult).Call(
-            CallArgs, FDelegateIteratorValue);
-          if Assigned(FClosure) and Assigned(FClosure.Template) and
-             FClosure.Template.IsAsync then
-            NextResult := AwaitValue(NextResult);
-        finally
-          CallArgs.Free;
-        end;
-      end
-      else
-        CloseDelegateForMissingThrow;
-    end;
-    if Assigned(NextResult) then
-    begin
-      if not (NextResult is TGocciaObjectValue) then
-        ClearDelegateAndThrowTypeError('Iterator throw result is not an object');
-      DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
-      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
-      begin
+        if not (NextResult is TGocciaObjectValue) then
+          ClearDelegateAndThrowTypeError('Iterator return result is not an object');
+        DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
         YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
         if not Assigned(YieldedValue) then
           YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+        if not Assigned(DoneValue) or not DoneValue.ToBooleanLiteral.Value then
+        begin
+          CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
+            AResumeRegister, AContinuationIP);
+          raise EGocciaBytecodeYield.Create(
+            VMValueToRegisterFast(YieldedValue), 0);
+        end;
+        FReturnValue := YieldedValue;
+      end;
+      ClearDelegateState;
+      if not Assigned(FReturnValue) then
+        FReturnValue := RegisterToValue(FResumeValue);
+      if not Assigned(FReturnSentinel) then
+        FReturnSentinel := TGocciaObjectValue.Create;
+      raise EGocciaBytecodeThrow.Create(FReturnSentinel);
+    end;
+
+    if FResumeKind = bgrkThrow then
+    begin
+      NextResult := nil;
+      if Assigned(FDelegateIterator) then
+        NextResult := FDelegateIterator.ThrowValue(RegisterToValue(FResumeValue))
+      else if Assigned(FDelegateIteratorValue) then
+      begin
+        NextResult := FDelegateIteratorValue.GetProperty(PROP_THROW);
+        if Assigned(NextResult) and
+           not (NextResult is TGocciaUndefinedLiteralValue) and
+           not (NextResult is TGocciaNullLiteralValue) then
+        begin
+          if not NextResult.IsCallable then
+            CloseDelegateForMissingThrow;
+          CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
+          try
+            NextResult := CallDelegateMethod(NextResult,
+              FDelegateIteratorValue, CallArgs);
+          finally
+            CallArgs.Free;
+          end;
+        end
+        else
+          CloseDelegateForMissingThrow;
+      end;
+      if Assigned(NextResult) then
+      begin
+        if not (NextResult is TGocciaObjectValue) then
+          ClearDelegateAndThrowTypeError('Iterator throw result is not an object');
+        DoneValue := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
+        if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+        begin
+          YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+          if not Assigned(YieldedValue) then
+            YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+          FVM.FRegisters[AResumeRegister] := VMValueToRegisterFast(YieldedValue);
+          ClearDelegateState;
+          Exit;
+        end;
+        YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
+        if not Assigned(YieldedValue) then
+          YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+        CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
+          AResumeRegister, AContinuationIP);
+        raise EGocciaBytecodeYield.Create(VMValueToRegisterFast(YieldedValue), 0);
+      end;
+      ClearDelegateState;
+      raise EGocciaBytecodeThrow.Create(RegisterToValue(FResumeValue));
+    end;
+
+    while True do
+    begin
+      if Assigned(FDelegateIterator) then
+      begin
+        if HadDelegateContinuation and (FResumeKind = bgrkNext) then
+          YieldedValue := FDelegateIterator.DirectNextValue(
+            RegisterToValue(FResumeValue), Done)
+        else
+          YieldedValue := FDelegateIterator.DirectNext(Done);
+      end
+      else
+      begin
+        if not Assigned(FDelegateNextMethod) or not FDelegateNextMethod.IsCallable then
+          ClearDelegateAndThrowTypeError('Iterator.next is not a function');
+        if HadDelegateContinuation and (FResumeKind = bgrkNext) then
+          CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)])
+        else
+          CallArgs := TGocciaArgumentsCollection.Create;
+        try
+          NextResult := CallDelegateMethod(FDelegateNextMethod,
+            FDelegateIteratorValue, CallArgs);
+        finally
+          CallArgs.Free;
+        end;
+        if not (NextResult is TGocciaObjectValue) then
+          ClearDelegateAndThrowTypeErrorWithSuggestion(
+            Format(SErrorIteratorResultNotObject,
+            [NextResult.ToStringLiteral.Value]), SSuggestIteratorResultObject);
+        DoneValue := NextResult.GetProperty(PROP_DONE);
+        Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
+        YieldedValue := NextResult.GetProperty(PROP_VALUE);
+        if not Assigned(YieldedValue) then
+          YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+      end;
+
+      if Done then
+      begin
         FVM.FRegisters[AResumeRegister] := VMValueToRegisterFast(YieldedValue);
         ClearDelegateState;
         Exit;
       end;
-      YieldedValue := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-      if not Assigned(YieldedValue) then
-        YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+
       CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
         AResumeRegister, AContinuationIP);
       raise EGocciaBytecodeYield.Create(VMValueToRegisterFast(YieldedValue), 0);
     end;
-    ClearDelegateState;
-    raise EGocciaBytecodeThrow.Create(RegisterToValue(FResumeValue));
-  end;
-
-  while True do
-  begin
-    if Assigned(FDelegateIterator) then
-    begin
-      if HadDelegateContinuation and (FResumeKind = bgrkNext) then
-        YieldedValue := FDelegateIterator.DirectNextValue(
-          RegisterToValue(FResumeValue), Done)
-      else
-        YieldedValue := FDelegateIterator.DirectNext(Done);
-    end
+  except
+    on E: EGocciaBytecodeYield do
+      raise;
     else
     begin
-      if not Assigned(FDelegateNextMethod) or not FDelegateNextMethod.IsCallable then
-        ClearDelegateAndThrowTypeError('Iterator.next is not a function');
-      if HadDelegateContinuation and (FResumeKind = bgrkNext) then
-        CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)])
-      else
-        CallArgs := TGocciaArgumentsCollection.Create;
-      try
-        NextResult := TGocciaFunctionBase(FDelegateNextMethod).Call(
-          CallArgs, FDelegateIteratorValue);
-        if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
-          NextResult := AwaitValue(NextResult);
-      finally
-        CallArgs.Free;
-      end;
-      if not (NextResult is TGocciaObjectValue) then
-        ClearDelegateAndThrowTypeErrorWithSuggestion(
-          Format(SErrorIteratorResultNotObject,
-          [NextResult.ToStringLiteral.Value]), SSuggestIteratorResultObject);
-      DoneValue := NextResult.GetProperty(PROP_DONE);
-      Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
-      YieldedValue := NextResult.GetProperty(PROP_VALUE);
-      if not Assigned(YieldedValue) then
-        YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-    end;
-
-    if Done then
-    begin
-      FVM.FRegisters[AResumeRegister] := VMValueToRegisterFast(YieldedValue);
       ClearDelegateState;
-      Exit;
+      raise;
     end;
-
-    CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine,
-      AResumeRegister, AContinuationIP);
-    raise EGocciaBytecodeYield.Create(VMValueToRegisterFast(YieldedValue), 0);
   end;
 end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1578,6 +1578,9 @@ type
     function PromiseResolve(const AValue: TGocciaValue): TGocciaValue;
     function PromiseReject(const AValue: TGocciaValue): TGocciaValue;
     procedure ClearIteratorState;
+    procedure CloseIteratorAfterRejectedValue;
+    function AwaitIteratorValue(const AValue: TGocciaValue;
+      const ADone, ACloseOnRejection: Boolean): TGocciaValue;
     function Next(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ReturnValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ThrowValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -1601,6 +1604,51 @@ procedure TGocciaVMAsyncFromSyncIteratorValue.ClearIteratorState;
 begin
   FIteratorValue := nil;
   FNextMethod := nil;
+end;
+
+procedure TGocciaVMAsyncFromSyncIteratorValue.CloseIteratorAfterRejectedValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  ReturnMethod: TGocciaValue;
+begin
+  if not Assigned(FIteratorValue) then
+    Exit;
+  try
+    if FIteratorValue is TGocciaIteratorValue then
+      TGocciaIteratorValue(FIteratorValue).Close
+    else if FIteratorValue is TGocciaObjectValue then
+    begin
+      ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);
+      if Assigned(ReturnMethod) and
+         not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+         not (ReturnMethod is TGocciaNullLiteralValue) and
+         ReturnMethod.IsCallable then
+      begin
+        CallArgs := TGocciaArgumentsCollection.Create;
+        try
+          TGocciaFunctionBase(ReturnMethod).Call(CallArgs, FIteratorValue);
+        finally
+          CallArgs.Free;
+        end;
+      end;
+    end;
+  except
+    // AsyncFromSyncIteratorContinuation preserves the rejected value when
+    // closing after a rejected wrapped value also fails.
+  end;
+  ClearIteratorState;
+end;
+
+function TGocciaVMAsyncFromSyncIteratorValue.AwaitIteratorValue(
+  const AValue: TGocciaValue; const ADone, ACloseOnRejection: Boolean): TGocciaValue;
+begin
+  try
+    Result := AwaitValue(AValue);
+  except
+    if ACloseOnRejection and not ADone then
+      CloseIteratorAfterRejectedValue;
+    raise;
+  end;
 end;
 
 function TGocciaVMAsyncFromSyncIteratorValue.PromiseResolve(
@@ -1679,7 +1727,7 @@ begin
         Value := TGocciaIteratorValue(FIteratorValue).DirectNext(Done);
       if Done then
         ClearIteratorState;
-      UnwrappedValue := AwaitValue(Value);
+      UnwrappedValue := AwaitIteratorValue(Value, Done, True);
       IteratorResult := CreateIteratorResult(UnwrappedValue, Done);
       Exit(PromiseResolve(IteratorResult));
     end;
@@ -1705,7 +1753,7 @@ begin
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
     if Done then
       ClearIteratorState;
-    UnwrappedValue := AwaitValue(Value);
+    UnwrappedValue := AwaitIteratorValue(Value, Done, True);
     Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
   except
     on E: EGocciaBytecodeThrow do
@@ -1743,7 +1791,7 @@ begin
   try
     if not Assigned(FIteratorValue) then
     begin
-      UnwrappedValue := AwaitValue(Value);
+      UnwrappedValue := AwaitIteratorValue(Value, True, False);
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, True)));
     end;
 
@@ -1757,7 +1805,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Done then
         ClearIteratorState;
-      UnwrappedValue := AwaitValue(Value);
+      UnwrappedValue := AwaitIteratorValue(Value, Done, False);
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
@@ -1767,7 +1815,7 @@ begin
        (ReturnMethod is TGocciaNullLiteralValue) then
     begin
       ClearIteratorState;
-      UnwrappedValue := AwaitValue(Value);
+      UnwrappedValue := AwaitIteratorValue(Value, True, False);
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, True)));
     end;
     if not ReturnMethod.IsCallable then
@@ -1788,7 +1836,7 @@ begin
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
     if Done then
       ClearIteratorState;
-    UnwrappedValue := AwaitValue(Value);
+    UnwrappedValue := AwaitIteratorValue(Value, Done, False);
     Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
   except
     on E: EGocciaBytecodeThrow do
@@ -1838,7 +1886,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Done then
         ClearIteratorState;
-      UnwrappedValue := AwaitValue(Value);
+      UnwrappedValue := AwaitIteratorValue(Value, Done, True);
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
@@ -1864,7 +1912,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Done then
         ClearIteratorState;
-      UnwrappedValue := AwaitValue(Value);
+      UnwrappedValue := AwaitIteratorValue(Value, Done, True);
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1578,6 +1578,8 @@ type
     function PromiseResolve(const AValue: TGocciaValue): TGocciaValue;
     function PromiseReject(const AValue: TGocciaValue): TGocciaValue;
     function Next(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ReturnValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ThrowValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AIteratorValue, ANextMethod: TGocciaValue);
     procedure MarkReferences; override;
@@ -1590,6 +1592,8 @@ begin
   FIteratorValue := AIteratorValue;
   FNextMethod := ANextMethod;
   AssignProperty(PROP_NEXT, TGocciaNativeFunctionValue.Create(Next, PROP_NEXT, 1));
+  AssignProperty(PROP_RETURN, TGocciaNativeFunctionValue.Create(ReturnValue, PROP_RETURN, 1));
+  AssignProperty(PROP_THROW, TGocciaNativeFunctionValue.Create(ThrowValue, PROP_THROW, 1));
 end;
 
 function TGocciaVMAsyncFromSyncIteratorValue.PromiseResolve(
@@ -1655,6 +1659,10 @@ var
   Value: TGocciaValue;
 begin
   try
+    if not Assigned(FIteratorValue) then
+      Exit(PromiseResolve(CreateIteratorResult(
+        TGocciaUndefinedLiteralValue.UndefinedValue, True)));
+
     if FIteratorValue is TGocciaIteratorValue then
     begin
       if AArgs.Length > 0 then
@@ -1686,6 +1694,8 @@ begin
     Value := IteratorResult.GetProperty(PROP_VALUE);
     if not Assigned(Value) then
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+    if Done then
+      FIteratorValue := nil;
     UnwrappedValue := AwaitValue(Value);
     Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
   except
@@ -1693,6 +1703,141 @@ begin
       Result := PromiseReject(E.ThrownValue);
     on E: TGocciaThrowValue do
       Result := PromiseReject(E.Value);
+  end;
+end;
+
+function TGocciaVMAsyncFromSyncIteratorValue.ReturnValue(
+  const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  DoneValue: TGocciaValue;
+  IteratorResult: TGocciaValue;
+  ReturnMethod: TGocciaValue;
+  Value: TGocciaValue;
+begin
+  if Assigned(AArgs) and (AArgs.Length > 0) then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+  try
+    if not Assigned(FIteratorValue) then
+      Exit(PromiseResolve(CreateIteratorResult(Value, True)));
+
+    if FIteratorValue is TGocciaIteratorValue then
+    begin
+      IteratorResult := TGocciaIteratorValue(FIteratorValue).ReturnValue(Value);
+      DoneValue := IteratorResult.GetProperty(PROP_DONE);
+      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+        FIteratorValue := nil;
+      Exit(PromiseResolve(IteratorResult));
+    end;
+
+    ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);
+    if not Assigned(ReturnMethod) or
+       (ReturnMethod is TGocciaUndefinedLiteralValue) or
+       (ReturnMethod is TGocciaNullLiteralValue) then
+    begin
+      FIteratorValue := nil;
+      Exit(PromiseResolve(CreateIteratorResult(Value, True)));
+    end;
+    if not ReturnMethod.IsCallable then
+      ThrowTypeError('Iterator return is not callable');
+
+    CallArgs := TGocciaArgumentsCollection.Create([Value]);
+    try
+      IteratorResult := TGocciaFunctionBase(ReturnMethod).Call(CallArgs, FIteratorValue);
+    finally
+      CallArgs.Free;
+    end;
+    if not (IteratorResult is TGocciaObjectValue) then
+      ThrowTypeError('Iterator return result is not an object');
+    DoneValue := IteratorResult.GetProperty(PROP_DONE);
+    if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+      FIteratorValue := nil;
+    Result := PromiseResolve(IteratorResult);
+  except
+    on E: EGocciaBytecodeThrow do
+      Result := PromiseReject(E.ThrownValue);
+    on E: TGocciaThrowValue do
+      Result := PromiseReject(E.Value);
+    on E: TGocciaTypeError do
+      Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
+  end;
+end;
+
+function TGocciaVMAsyncFromSyncIteratorValue.ThrowValue(
+  const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  DoneValue: TGocciaValue;
+  IteratorResult: TGocciaValue;
+  ReturnMethod: TGocciaValue;
+  ThrowMethod: TGocciaValue;
+  Value: TGocciaValue;
+begin
+  if Assigned(AArgs) and (AArgs.Length > 0) then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+  try
+    if not Assigned(FIteratorValue) then
+      raise TGocciaThrowValue.Create(Value);
+
+    if FIteratorValue is TGocciaIteratorValue then
+    begin
+      IteratorResult := TGocciaIteratorValue(FIteratorValue).ThrowValue(Value);
+      DoneValue := IteratorResult.GetProperty(PROP_DONE);
+      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+        FIteratorValue := nil;
+      Exit(PromiseResolve(IteratorResult));
+    end;
+
+    ThrowMethod := FIteratorValue.GetProperty(PROP_THROW);
+    if Assigned(ThrowMethod) and
+       not (ThrowMethod is TGocciaUndefinedLiteralValue) and
+       not (ThrowMethod is TGocciaNullLiteralValue) then
+    begin
+      if not ThrowMethod.IsCallable then
+        ThrowTypeError('Iterator throw is not callable');
+      CallArgs := TGocciaArgumentsCollection.Create([Value]);
+      try
+        IteratorResult := TGocciaFunctionBase(ThrowMethod).Call(CallArgs, FIteratorValue);
+      finally
+        CallArgs.Free;
+      end;
+      if not (IteratorResult is TGocciaObjectValue) then
+        ThrowTypeError('Iterator throw result is not an object');
+      DoneValue := IteratorResult.GetProperty(PROP_DONE);
+      if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+        FIteratorValue := nil;
+      Exit(PromiseResolve(IteratorResult));
+    end;
+
+    ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);
+    if Assigned(ReturnMethod) and
+       not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+       not (ReturnMethod is TGocciaNullLiteralValue) then
+    begin
+      if not ReturnMethod.IsCallable then
+        ThrowTypeError('Iterator return is not callable');
+      CallArgs := TGocciaArgumentsCollection.Create;
+      try
+        IteratorResult := TGocciaFunctionBase(ReturnMethod).Call(CallArgs, FIteratorValue);
+      finally
+        CallArgs.Free;
+      end;
+      if not (IteratorResult is TGocciaObjectValue) then
+        ThrowTypeError('Iterator return result is not an object');
+    end;
+    FIteratorValue := nil;
+    ThrowTypeError('Iterator throw is not callable');
+  except
+    on E: EGocciaBytecodeThrow do
+      Result := PromiseReject(E.ThrownValue);
+    on E: TGocciaThrowValue do
+      Result := PromiseReject(E.Value);
+    on E: TGocciaTypeError do
+      Result := PromiseReject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
   end;
 end;
 
@@ -1904,6 +2049,40 @@ var
   ReturnMethod: TGocciaValue;
   YieldedValue: TGocciaValue;
   HadDelegateContinuation: Boolean;
+
+  procedure CloseDelegateForMissingThrow;
+  begin
+    ReturnMethod := nil;
+    if Assigned(FDelegateIteratorValue) then
+      ReturnMethod := FDelegateIteratorValue.GetProperty(PROP_RETURN);
+    if Assigned(ReturnMethod) and
+       not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+       not (ReturnMethod is TGocciaNullLiteralValue) then
+    begin
+      if not ReturnMethod.IsCallable then
+      begin
+        ClearDelegateState;
+        ThrowTypeError('Iterator return is not callable');
+      end;
+      CallArgs := TGocciaArgumentsCollection.Create;
+      try
+        ReturnMethod := TGocciaFunctionBase(ReturnMethod).Call(
+          CallArgs, FDelegateIteratorValue);
+        if Assigned(FClosure) and Assigned(FClosure.Template) and
+           FClosure.Template.IsAsync then
+          ReturnMethod := AwaitValue(ReturnMethod);
+      finally
+        CallArgs.Free;
+      end;
+      if not (ReturnMethod is TGocciaObjectValue) then
+      begin
+        ClearDelegateState;
+        ThrowTypeError('Iterator return result is not an object');
+      end;
+    end;
+    ClearDelegateState;
+    ThrowTypeError('Iterator throw is not callable');
+  end;
 begin
   HadDelegateContinuation := FDelegateActive;
   if not FDelegateActive then
@@ -1990,30 +2169,7 @@ begin
          not (NextResult is TGocciaNullLiteralValue) then
       begin
         if not NextResult.IsCallable then
-        begin
-          ReturnMethod := FDelegateIteratorValue.GetProperty(PROP_RETURN);
-          if Assigned(ReturnMethod) and
-             not (ReturnMethod is TGocciaUndefinedLiteralValue) and
-             not (ReturnMethod is TGocciaNullLiteralValue) then
-          begin
-            if not ReturnMethod.IsCallable then
-              ThrowTypeError('Iterator return is not callable');
-            CallArgs := TGocciaArgumentsCollection.Create;
-            try
-              ReturnMethod := TGocciaFunctionBase(ReturnMethod).Call(
-                CallArgs, FDelegateIteratorValue);
-              if Assigned(FClosure) and Assigned(FClosure.Template) and
-                 FClosure.Template.IsAsync then
-                ReturnMethod := AwaitValue(ReturnMethod);
-            finally
-              CallArgs.Free;
-            end;
-            if not (ReturnMethod is TGocciaObjectValue) then
-              ThrowTypeError('Iterator return result is not an object');
-          end;
-          ClearDelegateState;
-          ThrowTypeError('Iterator throw is not callable');
-        end;
+          CloseDelegateForMissingThrow;
         CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)]);
         try
           NextResult := TGocciaFunctionBase(NextResult).Call(
@@ -2026,7 +2182,7 @@ begin
         end;
       end
       else
-        NextResult := nil;
+        CloseDelegateForMissingThrow;
     end;
     if Assigned(NextResult) then
     begin

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2510,6 +2510,7 @@ begin
         MarkRegisterReferences(Upvalue.Cell.Value);
     end;
   MarkRegisterReferences(FThisValue);
+  MarkRegisterReferences(FResumeValue);
   for I := 0 to High(FArguments) do
     MarkRegisterReferences(FArguments[I]);
   for I := 0 to High(FContinuationRegisters) do

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1577,6 +1577,7 @@ type
     FNextMethod: TGocciaValue;
     function PromiseResolve(const AValue: TGocciaValue): TGocciaValue;
     function PromiseReject(const AValue: TGocciaValue): TGocciaValue;
+    procedure ClearIteratorState;
     function Next(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ReturnValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ThrowValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -1594,6 +1595,12 @@ begin
   AssignProperty(PROP_NEXT, TGocciaNativeFunctionValue.Create(Next, PROP_NEXT, 1));
   AssignProperty(PROP_RETURN, TGocciaNativeFunctionValue.Create(ReturnValue, PROP_RETURN, 1));
   AssignProperty(PROP_THROW, TGocciaNativeFunctionValue.Create(ThrowValue, PROP_THROW, 1));
+end;
+
+procedure TGocciaVMAsyncFromSyncIteratorValue.ClearIteratorState;
+begin
+  FIteratorValue := nil;
+  FNextMethod := nil;
 end;
 
 function TGocciaVMAsyncFromSyncIteratorValue.PromiseResolve(
@@ -1671,6 +1678,8 @@ begin
       else
         Value := TGocciaIteratorValue(FIteratorValue).DirectNext(Done);
       UnwrappedValue := AwaitValue(Value);
+      if Done then
+        ClearIteratorState;
       IteratorResult := CreateIteratorResult(UnwrappedValue, Done);
       Exit(PromiseResolve(IteratorResult));
     end;
@@ -1694,9 +1703,9 @@ begin
     Value := IteratorResult.GetProperty(PROP_VALUE);
     if not Assigned(Value) then
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
-    if Done then
-      FIteratorValue := nil;
     UnwrappedValue := AwaitValue(Value);
+    if Done then
+      ClearIteratorState;
     Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
   except
     on E: EGocciaBytecodeThrow do
@@ -1730,12 +1739,12 @@ begin
       IteratorResult := TGocciaIteratorValue(FIteratorValue).ReturnValue(Value);
       DoneValue := IteratorResult.GetProperty(PROP_DONE);
       Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
-      if Done then
-        FIteratorValue := nil;
       Value := IteratorResult.GetProperty(PROP_VALUE);
       if not Assigned(Value) then
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       UnwrappedValue := AwaitValue(Value);
+      if Done then
+        ClearIteratorState;
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
@@ -1744,7 +1753,7 @@ begin
        (ReturnMethod is TGocciaUndefinedLiteralValue) or
        (ReturnMethod is TGocciaNullLiteralValue) then
     begin
-      FIteratorValue := nil;
+      ClearIteratorState;
       Exit(PromiseResolve(CreateIteratorResult(Value, True)));
     end;
     if not ReturnMethod.IsCallable then
@@ -1760,12 +1769,12 @@ begin
       ThrowTypeError('Iterator return result is not an object');
     DoneValue := IteratorResult.GetProperty(PROP_DONE);
     Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
-    if Done then
-      FIteratorValue := nil;
     Value := IteratorResult.GetProperty(PROP_VALUE);
     if not Assigned(Value) then
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
     UnwrappedValue := AwaitValue(Value);
+    if Done then
+      ClearIteratorState;
     Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
   except
     on E: EGocciaBytecodeThrow do
@@ -1802,12 +1811,12 @@ begin
       IteratorResult := TGocciaIteratorValue(FIteratorValue).ThrowValue(Value);
       DoneValue := IteratorResult.GetProperty(PROP_DONE);
       Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
-      if Done then
-        FIteratorValue := nil;
       Value := IteratorResult.GetProperty(PROP_VALUE);
       if not Assigned(Value) then
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       UnwrappedValue := AwaitValue(Value);
+      if Done then
+        ClearIteratorState;
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
@@ -1828,12 +1837,12 @@ begin
         ThrowTypeError('Iterator throw result is not an object');
       DoneValue := IteratorResult.GetProperty(PROP_DONE);
       Done := Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value;
-      if Done then
-        FIteratorValue := nil;
       Value := IteratorResult.GetProperty(PROP_VALUE);
       if not Assigned(Value) then
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       UnwrappedValue := AwaitValue(Value);
+      if Done then
+        ClearIteratorState;
       Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
     end;
 
@@ -1853,7 +1862,7 @@ begin
       if not (IteratorResult is TGocciaObjectValue) then
         ThrowTypeError('Iterator return result is not an object');
     end;
-    FIteratorValue := nil;
+    ClearIteratorState;
     ThrowTypeError('Iterator throw is not callable');
   except
     on E: EGocciaBytecodeThrow do

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -27,7 +27,11 @@ type
     constructor Create(const AContinuation: TGocciaGeneratorContinuation);
     destructor Destroy; override;
     function AdvanceNext: TGocciaObjectValue; override;
+    function AdvanceNextValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
     function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    function DirectNextValue(const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue; override;
+    function ReturnValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
+    function ThrowValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
     function ToStringTag: string; override;
@@ -158,9 +162,15 @@ begin
 end;
 
 function TGocciaGeneratorObjectValue.AdvanceNext: TGocciaObjectValue;
+begin
+  Result := AdvanceNextValue(TGocciaUndefinedLiteralValue.UndefinedValue);
+end;
+
+function TGocciaGeneratorObjectValue.AdvanceNextValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
 var
   Done: Boolean;
-  Value: TGocciaValue;
+  ResultValue: TGocciaValue;
 begin
   if FState = gsCompleted then
     Exit(CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True));
@@ -168,7 +178,7 @@ begin
     raise TGocciaThrowValue.Create(GeneratorExecutingError);
   FState := gsExecuting;
   try
-    Value := FContinuation.Resume(grkNext, TGocciaUndefinedLiteralValue.UndefinedValue, Done);
+    ResultValue := FContinuation.Resume(grkNext, AValue, Done);
     if Done then
       FState := gsCompleted
     else
@@ -177,29 +187,37 @@ begin
     FState := gsCompleted;
     raise;
   end;
-  Result := CreateIteratorResult(Value, Done);
+  Result := CreateIteratorResult(ResultValue, Done);
 end;
 
 function TGocciaGeneratorObjectValue.DirectNext(out ADone: Boolean): TGocciaValue;
+begin
+  Result := DirectNextValue(TGocciaUndefinedLiteralValue.UndefinedValue, ADone);
+end;
+
+function TGocciaGeneratorObjectValue.DirectNextValue(
+  const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue;
 var
   IteratorResult: TGocciaObjectValue;
 begin
-  IteratorResult := AdvanceNext;
+  IteratorResult := AdvanceNextValue(AValue);
   ADone := IteratorResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value;
   Result := IteratorResult.GetProperty(PROP_VALUE);
 end;
 
-procedure TGocciaGeneratorObjectValue.Close;
+function TGocciaGeneratorObjectValue.ReturnValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
 var
   Done: Boolean;
+  ResultValue: TGocciaValue;
 begin
   if FState = gsCompleted then
-    Exit;
+    Exit(CreateIteratorResult(AValue, True));
   if FState = gsExecuting then
     raise TGocciaThrowValue.Create(GeneratorExecutingError);
   FState := gsExecuting;
   try
-    FContinuation.Resume(grkReturn, TGocciaUndefinedLiteralValue.UndefinedValue, Done);
+    ResultValue := FContinuation.Resume(grkReturn, AValue, Done);
     if Done then
       FState := gsCompleted
     else
@@ -208,6 +226,36 @@ begin
     FState := gsCompleted;
     raise;
   end;
+  Result := CreateIteratorResult(ResultValue, Done);
+end;
+
+function TGocciaGeneratorObjectValue.ThrowValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+var
+  Done: Boolean;
+  ResultValue: TGocciaValue;
+begin
+  if FState = gsExecuting then
+    raise TGocciaThrowValue.Create(GeneratorExecutingError);
+  FState := gsExecuting;
+  try
+    ResultValue := FContinuation.Resume(grkThrow, AValue, Done);
+    if Done then
+      FState := gsCompleted
+    else
+      FState := gsSuspendedYield;
+  except
+    FState := gsCompleted;
+    raise;
+  end;
+  Result := CreateIteratorResult(ResultValue, Done);
+end;
+
+procedure TGocciaGeneratorObjectValue.Close;
+begin
+  if FState = gsCompleted then
+    Exit;
+  ReturnValue(TGocciaUndefinedLiteralValue.UndefinedValue);
 end;
 
 procedure TGocciaGeneratorObjectValue.MarkReferences;

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -223,8 +223,11 @@ end;
 
 procedure TGocciaGenericIteratorValue.Close;
 begin
-  ReturnInternal(nil, False);
-  FDone := True;
+  try
+    ReturnInternal(nil, False);
+  finally
+    FDone := True;
+  end;
 end;
 
 procedure TGocciaGenericIteratorValue.MarkReferences;

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -13,10 +13,18 @@ type
   TGocciaGenericIteratorValue = class(TGocciaIteratorValue)
   private
     FSource: TGocciaValue;
+    function AdvanceNextInternal(const AValue: TGocciaValue;
+      const AHasValue: Boolean): TGocciaObjectValue;
+    function ReturnInternal(const AValue: TGocciaValue;
+      const AHasValue: Boolean): TGocciaObjectValue;
   public
     constructor Create(const AIteratorObject: TGocciaValue);
     function AdvanceNext: TGocciaObjectValue; override;
+    function AdvanceNextValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
     function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    function DirectNextValue(const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue; override;
+    function ReturnValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
+    function ThrowValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
@@ -41,7 +49,8 @@ begin
   FSource := AIteratorObject;
 end;
 
-function TGocciaGenericIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaGenericIteratorValue.AdvanceNextInternal(
+  const AValue: TGocciaValue; const AHasValue: Boolean): TGocciaObjectValue;
 var
   NextMethod, NextResult, DoneVal, ValueVal: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
@@ -60,7 +69,10 @@ begin
     Exit;
   end;
 
-  CallArgs := TGocciaArgumentsCollection.Create;
+  if AHasValue then
+    CallArgs := TGocciaArgumentsCollection.Create([AValue])
+  else
+    CallArgs := TGocciaArgumentsCollection.Create;
   try
     NextResult := TGocciaFunctionBase(NextMethod).Call(CallArgs, FSource);
   finally
@@ -84,77 +96,135 @@ begin
     Result := CreateIteratorResult(ValueVal, False);
 end;
 
-function TGocciaGenericIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
-var
-  NextMethod, NextResult, DoneVal, ValueVal: TGocciaValue;
-  CallArgs: TGocciaArgumentsCollection;
+function TGocciaGenericIteratorValue.AdvanceNext: TGocciaObjectValue;
 begin
-  if FDone then
-  begin
-    ADone := True;
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Exit;
-  end;
-
-  NextMethod := FSource.GetProperty(PROP_NEXT);
-  if not Assigned(NextMethod) or not NextMethod.IsCallable then
-  begin
-    FDone := True;
-    ADone := True;
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Exit;
-  end;
-
-  CallArgs := TGocciaArgumentsCollection.Create;
-  try
-    NextResult := TGocciaFunctionBase(NextMethod).Call(CallArgs, FSource);
-  finally
-    CallArgs.Free;
-  end;
-
-  if not (NextResult is TGocciaObjectValue) then
-    ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.TypeName]), SSuggestIteratorResultObject);
-
-  DoneVal := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
-  ValueVal := TGocciaObjectValue(NextResult).GetProperty(PROP_VALUE);
-  if not Assigned(ValueVal) then
-    ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue;
-
-  if Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value then
-  begin
-    FDone := True;
-    ADone := True;
-  end
-  else
-    ADone := False;
-  Result := ValueVal;
+  Result := AdvanceNextInternal(nil, False);
 end;
 
-procedure TGocciaGenericIteratorValue.Close;
+function TGocciaGenericIteratorValue.AdvanceNextValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+begin
+  Result := AdvanceNextInternal(AValue, True);
+end;
+
+function TGocciaGenericIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+var
+  IteratorResult: TGocciaObjectValue;
+begin
+  IteratorResult := AdvanceNext;
+  ADone := IteratorResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value;
+  Result := IteratorResult.GetProperty(PROP_VALUE);
+end;
+
+function TGocciaGenericIteratorValue.DirectNextValue(
+  const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue;
+var
+  IteratorResult: TGocciaObjectValue;
+begin
+  IteratorResult := AdvanceNextValue(AValue);
+  ADone := IteratorResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value;
+  Result := IteratorResult.GetProperty(PROP_VALUE);
+end;
+
+function TGocciaGenericIteratorValue.ReturnInternal(
+  const AValue: TGocciaValue; const AHasValue: Boolean): TGocciaObjectValue;
 var
   ReturnMethod: TGocciaValue;
+  DoneVal: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
   ReturnResult: TGocciaValue;
 begin
-  if FDone then Exit;
+  if FDone then
+  begin
+    if AHasValue then
+      Result := CreateIteratorResult(AValue, True)
+    else
+      Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
 
-  FDone := True;
   ReturnMethod := FSource.GetProperty(PROP_RETURN);
   if not Assigned(ReturnMethod) or
      (ReturnMethod is TGocciaUndefinedLiteralValue) or
      (ReturnMethod is TGocciaNullLiteralValue) then
+  begin
+    FDone := True;
+    if AHasValue then
+      Result := CreateIteratorResult(AValue, True)
+    else
+      Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
     Exit;
+  end;
   if not ReturnMethod.IsCallable then
     ThrowTypeError(SErrorIteratorReturnMustBeCallable, SSuggestIteratorProtocol);
 
-  CallArgs := TGocciaArgumentsCollection.Create;
+  if AHasValue then
+    CallArgs := TGocciaArgumentsCollection.Create([AValue])
+  else
+    CallArgs := TGocciaArgumentsCollection.Create;
   try
     ReturnResult := TGocciaFunctionBase(ReturnMethod).Call(CallArgs, FSource);
     if not (ReturnResult is TGocciaObjectValue) then
       ThrowTypeError(SErrorIteratorReturnObject, SSuggestIteratorResultObject);
+    DoneVal := TGocciaObjectValue(ReturnResult).GetProperty(PROP_DONE);
+    if Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value then
+      FDone := True;
+    Result := TGocciaObjectValue(ReturnResult);
   finally
     CallArgs.Free;
   end;
+end;
+
+function TGocciaGenericIteratorValue.ReturnValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+begin
+  Result := ReturnInternal(AValue, True);
+end;
+
+function TGocciaGenericIteratorValue.ThrowValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  DoneValue: TGocciaValue;
+  ThrowMethod: TGocciaValue;
+  ThrowResult: TGocciaValue;
+begin
+  if FDone then
+    ThrowTypeError('Delegated iterator has no throw method');
+
+  ThrowMethod := FSource.GetProperty(PROP_THROW);
+  if not Assigned(ThrowMethod) or
+     (ThrowMethod is TGocciaUndefinedLiteralValue) or
+     (ThrowMethod is TGocciaNullLiteralValue) then
+  begin
+    Close;
+    ThrowTypeError('Delegated iterator has no throw method');
+  end;
+  if not ThrowMethod.IsCallable then
+  begin
+    Close;
+    ThrowTypeError('Iterator throw is not callable');
+  end;
+
+  CallArgs := TGocciaArgumentsCollection.Create([AValue]);
+  try
+    ThrowResult := TGocciaFunctionBase(ThrowMethod).Call(CallArgs, FSource);
+  finally
+    CallArgs.Free;
+  end;
+
+  if not (ThrowResult is TGocciaObjectValue) then
+    ThrowTypeError('Iterator throw result is not an object');
+  DoneValue := TGocciaObjectValue(ThrowResult).GetProperty(PROP_DONE);
+  if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+    FDone := True;
+  Result := TGocciaObjectValue(ThrowResult);
+end;
+
+procedure TGocciaGenericIteratorValue.Close;
+begin
+  ReturnInternal(nil, False);
+  FDone := True;
 end;
 
 procedure TGocciaGenericIteratorValue.MarkReferences;

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -39,7 +39,11 @@ type
   public
     constructor Create;
     function AdvanceNext: TGocciaObjectValue; virtual;
+    function AdvanceNextValue(const AValue: TGocciaValue): TGocciaObjectValue; virtual;
     function DirectNext(out ADone: Boolean): TGocciaValue; virtual;
+    function DirectNextValue(const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue; virtual;
+    function ReturnValue(const AValue: TGocciaValue): TGocciaObjectValue; virtual;
+    function ThrowValue(const AValue: TGocciaValue): TGocciaObjectValue; virtual;
     procedure Close; virtual;
     function ToStringTag: string; override;
 
@@ -144,6 +148,12 @@ begin
   Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
 end;
 
+function TGocciaIteratorValue.AdvanceNextValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+begin
+  Result := AdvanceNext;
+end;
+
 function TGocciaIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
 var
   IterResult: TGocciaObjectValue;
@@ -154,6 +164,34 @@ begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue
   else
     Result := IterResult.GetProperty(PROP_VALUE);
+end;
+
+function TGocciaIteratorValue.DirectNextValue(
+  const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue;
+var
+  IterResult: TGocciaObjectValue;
+begin
+  IterResult := AdvanceNextValue(AValue);
+  ADone := TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value;
+  if ADone then
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue
+  else
+    Result := IterResult.GetProperty(PROP_VALUE);
+end;
+
+function TGocciaIteratorValue.ReturnValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+begin
+  Close;
+  Result := CreateIteratorResult(AValue, True);
+end;
+
+function TGocciaIteratorValue.ThrowValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+begin
+  Close;
+  ThrowTypeError('Delegated iterator has no throw method');
+  Result := nil;
 end;
 
 procedure TGocciaIteratorValue.Close;

--- a/tests/language/async-generators/object-method.js
+++ b/tests/language/async-generators/object-method.js
@@ -223,11 +223,21 @@ test("object async generator yield delegation rejects sync iterator failures asy
       };
     },
   };
+  const rejectedValueEvents = [];
+  const resultGetterEvents = [];
+  const rejectedThrowValueEvents = [];
+  const rejectedReturnValueEvents = [];
+  const rejectedThenGetterEvents = [];
   const rejectedValueSource = {
     [Symbol.iterator]() {
       return {
         next() {
+          rejectedValueEvents.push("next");
           return { value: Promise.reject("value boom"), done: false };
+        },
+        return() {
+          rejectedValueEvents.push("return");
+          return { value: "closed", done: true };
         },
       };
     },
@@ -236,12 +246,71 @@ test("object async generator yield delegation rejects sync iterator failures asy
     [Symbol.iterator]() {
       return {
         next() {
+          resultGetterEvents.push("next");
           return {
             get value() {
               return missingValue;
             },
             done: false,
           };
+        },
+        return() {
+          resultGetterEvents.push("return");
+          return { value: "closed", done: true };
+        },
+      };
+    },
+  };
+  const rejectedThrowValueSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          rejectedThrowValueEvents.push("next");
+          return { value: 1, done: false };
+        },
+        throw(value) {
+          rejectedThrowValueEvents.push("throw:" + value);
+          return { value: Promise.reject("throw value boom"), done: false };
+        },
+        return() {
+          rejectedThrowValueEvents.push("return");
+          return { value: "closed", done: true };
+        },
+      };
+    },
+  };
+  const rejectedReturnValueSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          rejectedReturnValueEvents.push("next");
+          return { value: 1, done: false };
+        },
+        return(value) {
+          rejectedReturnValueEvents.push("return:" + value);
+          return { value: Promise.reject("return value boom"), done: false };
+        },
+      };
+    },
+  };
+  const rejectedThenGetterSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          rejectedThenGetterEvents.push("next");
+          return {
+            value: {
+              get then() {
+                rejectedThenGetterEvents.push("then");
+                throw "then getter boom";
+              },
+            },
+            done: false,
+          };
+        },
+        return() {
+          rejectedThenGetterEvents.push("return");
+          return { value: "closed", done: true };
         },
       };
     },
@@ -262,6 +331,15 @@ test("object async generator yield delegation rejects sync iterator failures asy
     async *throwingFromResultGetter() {
       yield* resultGetterSource;
     },
+    async *rejectingThrowValue() {
+      yield* rejectedThrowValueSource;
+    },
+    async *rejectingReturnValue() {
+      yield* rejectedReturnValueSource;
+    },
+    async *rejectingThenGetter() {
+      yield* rejectedThenGetterSource;
+    },
   };
 
   await expect(obj.nexting().next()).rejects.toBe("next boom");
@@ -274,8 +352,26 @@ test("object async generator yield delegation rejects sync iterator failures asy
   await expect(throwIter.next()).resolves.toEqual({ value: 1, done: false });
   await expect(throwIter.throw(9)).rejects.toBe("throw boom");
 
-  await expect(obj.rejectingValue().next()).rejects.toBe("value boom");
+  const rejectingValueIter = obj.rejectingValue();
+  await expect(rejectingValueIter.next()).rejects.toBe("value boom");
+  expect(rejectedValueEvents).toEqual(["next", "return"]);
+  await expect(rejectingValueIter.next()).resolves.toEqual({ value: undefined, done: true });
   await expect(obj.throwingFromResultGetter().next()).rejects.toThrow(ReferenceError);
+  expect(resultGetterEvents).toEqual(["next"]);
+
+  const rejectedThrowValueIter = obj.rejectingThrowValue();
+  await expect(rejectedThrowValueIter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(rejectedThrowValueIter.throw(9)).rejects.toBe("throw value boom");
+  expect(rejectedThrowValueEvents).toEqual(["next", "throw:9", "return"]);
+  await expect(rejectedThrowValueIter.next()).resolves.toEqual({ value: undefined, done: true });
+
+  const rejectedReturnValueIter = obj.rejectingReturnValue();
+  await expect(rejectedReturnValueIter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(rejectedReturnValueIter.return(9)).rejects.toBe("return value boom");
+  expect(rejectedReturnValueEvents).toEqual(["next", "return:9"]);
+
+  await expect(obj.rejectingThenGetter().next()).rejects.toBe("then getter boom");
+  expect(rejectedThenGetterEvents).toEqual(["next", "then", "return"]);
 });
 
 test("object async generator yield delegation closes sync wrapper after completion", async () => {

--- a/tests/language/async-generators/object-method.js
+++ b/tests/language/async-generators/object-method.js
@@ -168,6 +168,45 @@ test("object async generator yield delegation awaits sync iterator return and th
   await expect(throwIter.throw(9)).resolves.toEqual({ value: "throw:9", done: false });
 });
 
+test("object async generator yield delegation closes sync wrapper after completion", async () => {
+  const events = [];
+  const source = {
+    [Symbol.iterator]() {
+      let step = 0;
+      return {
+        next() {
+          events.push("next");
+          step += 1;
+          if (step === 1) {
+            return { value: Promise.resolve(1), done: false };
+          }
+          return { value: Promise.resolve("done"), done: true };
+        },
+        return() {
+          events.push("return");
+          return { value: "returned", done: true };
+        },
+        throw() {
+          events.push("throw");
+          return { value: "thrown", done: true };
+        },
+      };
+    },
+  };
+  const obj = {
+    async *values() {
+      return yield* source;
+    },
+  };
+
+  const iter = obj.values();
+  await expect(iter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(iter.next()).resolves.toEqual({ value: "done", done: true });
+  await expect(iter.return(9)).resolves.toEqual({ value: 9, done: true });
+  await expect(iter.throw(10)).rejects.toBe(10);
+  expect(events).toEqual(["next", "next"]);
+});
+
 test("object async generator yield delegation rejects non-callable async next", async () => {
   const source = {
     [Symbol.asyncIterator]() {

--- a/tests/language/async-generators/object-method.js
+++ b/tests/language/async-generators/object-method.js
@@ -98,6 +98,33 @@ test("object async generator method delegates to sync iterable", async () => {
   expect(seen).toEqual([1, 2]);
 });
 
+test("object async generator yield delegation keeps sync iterator alive across return cleanup yield", async () => {
+  const events = [];
+  const source = {
+    *values() {
+      try {
+        yield 1;
+      } finally {
+        events.push("finally");
+        yield "cleanup";
+        events.push("after");
+      }
+    },
+  };
+  const obj = {
+    async *values() {
+      yield* source.values();
+    },
+  };
+
+  const iter = obj.values();
+  await expect(iter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(iter.return(9)).resolves.toEqual({ value: "cleanup", done: false });
+  expect(events).toEqual(["finally"]);
+  await expect(iter.next()).resolves.toEqual({ value: undefined, done: true });
+  expect(events).toEqual(["finally", "after"]);
+});
+
 test("object async generator yield delegation rejects non-callable async next", async () => {
   const source = {
     [Symbol.asyncIterator]() {

--- a/tests/language/async-generators/object-method.js
+++ b/tests/language/async-generators/object-method.js
@@ -168,6 +168,27 @@ test("object async generator yield delegation awaits sync iterator return and th
   await expect(throwIter.throw(9)).resolves.toEqual({ value: "throw:9", done: false });
 });
 
+test("object async generator yield delegation awaits short-circuit sync iterator return value", async () => {
+  const source = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+      };
+    },
+  };
+  const obj = {
+    async *values() {
+      yield* source;
+    },
+  };
+
+  const iter = obj.values();
+  await expect(iter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(iter.return(Promise.resolve(9))).resolves.toEqual({ value: 9, done: true });
+});
+
 test("object async generator yield delegation closes sync wrapper after completion", async () => {
   const events = [];
   const source = {

--- a/tests/language/async-generators/object-method.js
+++ b/tests/language/async-generators/object-method.js
@@ -232,6 +232,20 @@ test("object async generator yield delegation rejects sync iterator failures asy
       };
     },
   };
+  const resultGetterSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return {
+            get value() {
+              return missingValue;
+            },
+            done: false,
+          };
+        },
+      };
+    },
+  };
   const obj = {
     async *nexting() {
       yield* nextSource;
@@ -244,6 +258,9 @@ test("object async generator yield delegation rejects sync iterator failures asy
     },
     async *rejectingValue() {
       yield* rejectedValueSource;
+    },
+    async *throwingFromResultGetter() {
+      yield* resultGetterSource;
     },
   };
 
@@ -258,6 +275,7 @@ test("object async generator yield delegation rejects sync iterator failures asy
   await expect(throwIter.throw(9)).rejects.toBe("throw boom");
 
   await expect(obj.rejectingValue().next()).rejects.toBe("value boom");
+  await expect(obj.throwingFromResultGetter().next()).rejects.toThrow(ReferenceError);
 });
 
 test("object async generator yield delegation closes sync wrapper after completion", async () => {

--- a/tests/language/async-generators/object-method.js
+++ b/tests/language/async-generators/object-method.js
@@ -106,7 +106,7 @@ test("object async generator yield delegation keeps sync iterator alive across r
         yield 1;
       } finally {
         events.push("finally");
-        yield "cleanup";
+        yield Promise.resolve("cleanup");
         events.push("after");
       }
     },
@@ -123,6 +123,49 @@ test("object async generator yield delegation keeps sync iterator alive across r
   expect(events).toEqual(["finally"]);
   await expect(iter.next()).resolves.toEqual({ value: undefined, done: true });
   expect(events).toEqual(["finally", "after"]);
+});
+
+test("object async generator yield delegation awaits sync iterator return and throw values", async () => {
+  const returnSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        return(value) {
+          return { value: Promise.resolve("return:" + value), done: true };
+        },
+      };
+    },
+  };
+  const throwSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        throw(value) {
+          return { value: Promise.resolve("throw:" + value), done: false };
+        },
+      };
+    },
+  };
+  const obj = {
+    async *returning() {
+      yield* returnSource;
+    },
+    async *throwing() {
+      yield* throwSource;
+    },
+  };
+
+  const returnIter = obj.returning();
+  await expect(returnIter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(returnIter.return(9)).resolves.toEqual({ value: "return:9", done: true });
+
+  const throwIter = obj.throwing();
+  await expect(throwIter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(throwIter.throw(9)).resolves.toEqual({ value: "throw:9", done: false });
 });
 
 test("object async generator yield delegation rejects non-callable async next", async () => {

--- a/tests/language/async-generators/object-method.js
+++ b/tests/language/async-generators/object-method.js
@@ -18,6 +18,31 @@ test("object async generator method works without compat-function", async () => 
   expect(seen).toEqual([1, 2]);
 });
 
+test("object async generator method does not replay call arguments before a yielded argument", async () => {
+  const events = [];
+  const obj = {
+    async *values() {
+      const left = () => {
+        events.push("left");
+        return 10;
+      };
+      const combine = (a, b) => {
+        events.push("combine");
+        return a + b;
+      };
+
+      const result = combine(left(), yield "resume");
+      yield result;
+    },
+  };
+
+  const iter = obj.values();
+  await expect(iter.next()).resolves.toEqual({ value: "resume", done: false });
+  expect(events).toEqual(["left"]);
+  await expect(iter.next(5)).resolves.toEqual({ value: 15, done: false });
+  expect(events).toEqual(["left", "combine"]);
+});
+
 test("object async generator method delegates to async iterable", async () => {
   const source = {
     async *values() {
@@ -37,6 +62,25 @@ test("object async generator method delegates to async iterable", async () => {
   }
 
   expect(seen).toEqual([1, 2]);
+});
+
+test("object async generator yield delegation does not replay side effects before the delegation", async () => {
+  const events = [];
+  const obj = {
+    async *numbers() {
+      events.push("before");
+      yield* [1, 2];
+      events.push("after");
+    },
+  };
+
+  const iter = obj.numbers();
+  await expect(iter.next()).resolves.toEqual({ value: 1, done: false });
+  expect(events).toEqual(["before"]);
+  await expect(iter.next()).resolves.toEqual({ value: 2, done: false });
+  expect(events).toEqual(["before"]);
+  await expect(iter.next()).resolves.toEqual({ value: undefined, done: true });
+  expect(events).toEqual(["before", "after"]);
 });
 
 test("object async generator method delegates to sync iterable", async () => {

--- a/tests/language/async-generators/object-method.js
+++ b/tests/language/async-generators/object-method.js
@@ -189,6 +189,77 @@ test("object async generator yield delegation awaits short-circuit sync iterator
   await expect(iter.return(Promise.resolve(9))).resolves.toEqual({ value: 9, done: true });
 });
 
+test("object async generator yield delegation rejects sync iterator failures asynchronously", async () => {
+  const nextSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          throw "next boom";
+        },
+      };
+    },
+  };
+  const returnSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        return() {
+          throw "return boom";
+        },
+      };
+    },
+  };
+  const throwSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        throw() {
+          throw "throw boom";
+        },
+      };
+    },
+  };
+  const rejectedValueSource = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: Promise.reject("value boom"), done: false };
+        },
+      };
+    },
+  };
+  const obj = {
+    async *nexting() {
+      yield* nextSource;
+    },
+    async *returning() {
+      yield* returnSource;
+    },
+    async *throwing() {
+      yield* throwSource;
+    },
+    async *rejectingValue() {
+      yield* rejectedValueSource;
+    },
+  };
+
+  await expect(obj.nexting().next()).rejects.toBe("next boom");
+
+  const returnIter = obj.returning();
+  await expect(returnIter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(returnIter.return(9)).rejects.toBe("return boom");
+
+  const throwIter = obj.throwing();
+  await expect(throwIter.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(throwIter.throw(9)).rejects.toBe("throw boom");
+
+  await expect(obj.rejectingValue().next()).rejects.toBe("value boom");
+});
+
 test("object async generator yield delegation closes sync wrapper after completion", async () => {
   const events = [];
   const source = {

--- a/tests/language/for-of/for-await-of.js
+++ b/tests/language/for-of/for-await-of.js
@@ -188,6 +188,25 @@ describe("for-await-of", () => {
     })()).rejects.toThrow(TypeError);
   });
 
+  test("invalid sync iterator result rejects with TypeError through async wrapper", async () => {
+    const primitiveResult = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            return Symbol("not-object");
+          },
+        };
+      },
+    };
+
+    const iterate = async () => {
+      for await (const x of primitiveResult) {
+      }
+    };
+
+    await expect(iterate()).rejects.toThrow(TypeError);
+  });
+
   test("rejected Promise values from sync iterables throw", async () => {
     const values = [Promise.resolve(1), Promise.reject("fail"), Promise.resolve(3)];
     const result = [];

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -294,6 +294,33 @@ test("object generator yield delegation rejects non-callable return and throw", 
   expect(() => throwIter.throw(9)).toThrow(TypeError);
 });
 
+test("object generator yield delegation closes delegate when throw is missing", () => {
+  const events = [];
+  const source = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        return() {
+          events.push("return");
+          return { value: "closed", done: true };
+        },
+      };
+    },
+  };
+  const obj = {
+    *values() {
+      yield* source;
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(() => iter.throw(9)).toThrow(TypeError);
+  expect(events).toEqual(["return"]);
+});
+
 test("object generator method return closes through finally", () => {
   let closed = false;
   const obj = {

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -59,6 +59,27 @@ test("object generator method does not replay call arguments before a yielded ar
   expect(events).toEqual(["left", "combine"]);
 });
 
+test("object generator method resumes binary expressions instead of returning the cached left operand", () => {
+  const events = [];
+  const obj = {
+    *values() {
+      const left = () => {
+        events.push("left");
+        return 10;
+      };
+
+      const result = left() + (yield "resume");
+      yield result;
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: "resume", done: false });
+  expect(events).toEqual(["left"]);
+  expect(iter.next(5)).toEqual({ value: 15, done: false });
+  expect(events).toEqual(["left"]);
+});
+
 test("object generator method supports yield delegation", () => {
   const obj = {
     *numbers() {

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -140,6 +140,56 @@ test("object generator yield delegation rejects iterator protocol violations", (
   expect(() => obj.primitiveResult().next()).toThrow(TypeError);
 });
 
+test("object generator yield delegation clears delegate after protocol error", () => {
+  const events = [];
+  const primitiveResult = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          events.push("bad-next");
+          return 1;
+        },
+      };
+    },
+  };
+  const missingNext = {
+    [Symbol.iterator]() {
+      return {};
+    },
+  };
+  const obj = {
+    *primitiveThenGood() {
+      try {
+        yield* primitiveResult;
+      } catch (error) {
+        events.push(error instanceof TypeError ? "caught-primitive" : "wrong");
+      }
+      yield* ["ok"];
+    },
+    *missingThenGood() {
+      try {
+        yield* missingNext;
+      } catch (error) {
+        events.push(error instanceof TypeError ? "caught-missing" : "wrong");
+      }
+      yield* ["done"];
+    },
+  };
+
+  const primitiveIter = obj.primitiveThenGood();
+  expect(primitiveIter.next()).toEqual({ value: "ok", done: false });
+  expect(primitiveIter.next()).toEqual({ value: undefined, done: true });
+
+  const missingIter = obj.missingThenGood();
+  expect(missingIter.next()).toEqual({ value: "done", done: false });
+  expect(missingIter.next()).toEqual({ value: undefined, done: true });
+  expect(events).toEqual([
+    "bad-next",
+    "caught-primitive",
+    "caught-missing",
+  ]);
+});
+
 test("object generator yield delegation does not await sync iterator results", () => {
   let thenCalled = false;
   const source = {

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -34,6 +34,31 @@ test("object generator method supports next value send-back", () => {
   expect(iter.return(99)).toEqual({ value: 99, done: true });
 });
 
+test("object generator method does not replay call arguments before a yielded argument", () => {
+  const events = [];
+  const obj = {
+    *values() {
+      const left = () => {
+        events.push("left");
+        return 10;
+      };
+      const combine = (a, b) => {
+        events.push("combine");
+        return a + b;
+      };
+
+      const result = combine(left(), yield "resume");
+      yield result;
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: "resume", done: false });
+  expect(events).toEqual(["left"]);
+  expect(iter.next(5)).toEqual({ value: 15, done: false });
+  expect(events).toEqual(["left", "combine"]);
+});
+
 test("object generator method supports yield delegation", () => {
   const obj = {
     *numbers() {
@@ -121,6 +146,25 @@ test("object generator yield delegation does not await sync iterator results", (
   expect(thenCalled).toBe(false);
 });
 
+test("object generator yield delegation does not replay side effects before the delegation", () => {
+  const events = [];
+  const obj = {
+    *numbers() {
+      events.push("before");
+      yield* [1, 2];
+      events.push("after");
+    },
+  };
+
+  const iter = obj.numbers();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(events).toEqual(["before"]);
+  expect(iter.next()).toEqual({ value: 2, done: false });
+  expect(events).toEqual(["before"]);
+  expect(iter.next()).toEqual({ value: undefined, done: true });
+  expect(events).toEqual(["before", "after"]);
+});
+
 test("object generator method return closes through finally", () => {
   let closed = false;
   const obj = {
@@ -139,6 +183,26 @@ test("object generator method return closes through finally", () => {
   expect(closed).toBe(true);
 });
 
+test("object generator method return does not replay side effects before a yielded try block", () => {
+  const events = [];
+  const obj = {
+    *numbers() {
+      try {
+        events.push("before");
+        yield 1;
+        events.push("after");
+      } finally {
+        events.push("finally");
+      }
+    },
+  };
+
+  const iter = obj.numbers();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(iter.return(9)).toEqual({ value: 9, done: true });
+  expect(events).toEqual(["before", "finally"]);
+});
+
 test("object generator method throw is catchable", () => {
   const obj = {
     *numbers() {
@@ -153,6 +217,26 @@ test("object generator method throw is catchable", () => {
   const iter = obj.numbers();
   expect(iter.next()).toEqual({ value: 1, done: false });
   expect(iter.throw(7)).toEqual({ value: 7, done: false });
+});
+
+test("object generator method throw does not replay side effects before a yielded try block", () => {
+  const events = [];
+  const obj = {
+    *numbers() {
+      try {
+        events.push("before");
+        yield 1;
+      } catch (value) {
+        events.push("catch");
+        yield value;
+      }
+    },
+  };
+
+  const iter = obj.numbers();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(iter.throw(7)).toEqual({ value: 7, done: false });
+  expect(events).toEqual(["before", "catch"]);
 });
 
 test("object generator method uncaught throw closes generator", () => {

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -59,6 +59,49 @@ test("object generator method does not replay call arguments before a yielded ar
   expect(events).toEqual(["left", "combine"]);
 });
 
+test("object generator method preserves completed siblings across multiple yields in one statement", () => {
+  const events = [];
+  const obj = {
+    *values() {
+      const left = () => {
+        events.push("left");
+        return 1;
+      };
+      const combine = (a, b, c) => {
+        events.push("combine");
+        return a + b + c;
+      };
+
+      const result = combine(left(), yield "a", yield "b");
+      yield result;
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: "a", done: false });
+  expect(events).toEqual(["left"]);
+  expect(iter.next(2)).toEqual({ value: "b", done: false });
+  expect(events).toEqual(["left"]);
+  expect(iter.next(3)).toEqual({ value: 6, done: false });
+  expect(events).toEqual(["left", "combine"]);
+});
+
+test("object generator method does not reuse completed loop body expressions", () => {
+  const obj = {
+    *values() {
+      let total = 0;
+
+      for (const n of [1, 2, 3]) total = total + n;
+
+      yield total;
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: 6, done: false });
+  expect(iter.next()).toEqual({ value: undefined, done: true });
+});
+
 test("object generator method resumes binary expressions instead of returning the cached left operand", () => {
   const events = [];
   const obj = {

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -371,6 +371,86 @@ test("object generator yield delegation closes delegate when throw is missing", 
   expect(events).toEqual(["return"]);
 });
 
+test("object generator yield delegation closes after next throws", () => {
+  const events = [];
+  const source = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          events.push("bad-next");
+          throw "boom";
+        },
+      };
+    },
+  };
+  const obj = {
+    *values() {
+      yield* source;
+    },
+  };
+
+  const iter = obj.values();
+  expect(() => iter.next()).toThrow();
+  expect(iter.next()).toEqual({ value: undefined, done: true });
+  expect(events).toEqual(["bad-next"]);
+});
+
+test("object generator yield delegation closes after throw method throws", () => {
+  const events = [];
+  const source = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        throw(value) {
+          events.push("throw:" + value);
+          throw "boom";
+        },
+      };
+    },
+  };
+  const obj = {
+    *values() {
+      yield* source;
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(() => iter.throw(9)).toThrow();
+  expect(iter.next()).toEqual({ value: undefined, done: true });
+  expect(events).toEqual(["throw:9"]);
+});
+
+test("object generator yield delegation closes after return method throws", () => {
+  const events = [];
+  const source = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        return(value) {
+          events.push("return:" + value);
+          throw "boom";
+        },
+      };
+    },
+  };
+  const obj = {
+    *values() {
+      yield* source;
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(() => iter.return(9)).toThrow();
+  expect(iter.next()).toEqual({ value: undefined, done: true });
+  expect(events).toEqual(["return:9"]);
+});
+
 test("object generator method return closes through finally", () => {
   let closed = false;
   const obj = {

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -165,6 +165,114 @@ test("object generator yield delegation does not replay side effects before the 
   expect(events).toEqual(["before", "after"]);
 });
 
+test("object generator yield delegation forwards next values to delegated generators", () => {
+  const inner = {
+    *values() {
+      const value = yield 1;
+      yield value;
+    },
+  };
+  const outer = {
+    *values() {
+      yield* inner.values();
+    },
+  };
+
+  const iter = outer.values();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(iter.next(42)).toEqual({ value: 42, done: false });
+});
+
+test("object generator yield delegation forwards return values and runs delegated finally", () => {
+  const events = [];
+  const inner = {
+    *values() {
+      try {
+        yield 1;
+      } finally {
+        events.push("finally");
+      }
+    },
+  };
+  const outer = {
+    *values() {
+      yield* inner.values();
+    },
+  };
+
+  const iter = outer.values();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(iter.return(9)).toEqual({ value: 9, done: true });
+  expect(events).toEqual(["finally"]);
+});
+
+test("object generator yield delegation preserves delegated finally yields on return", () => {
+  const events = [];
+  const inner = {
+    *values() {
+      try {
+        yield 1;
+      } finally {
+        events.push("finally");
+        yield "cleanup";
+      }
+    },
+  };
+  const outer = {
+    *values() {
+      yield* inner.values();
+    },
+  };
+
+  const iter = outer.values();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(iter.return(9)).toEqual({ value: "cleanup", done: false });
+  expect(events).toEqual(["finally"]);
+  expect(iter.next()).toEqual({ value: undefined, done: true });
+});
+
+test("object generator yield delegation rejects non-callable return and throw", () => {
+  const nonCallableReturn = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        return: 1,
+      };
+    },
+  };
+  const nonCallableThrow = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: 1, done: false };
+        },
+        throw: 1,
+        return() {
+          return { value: "closed", done: true };
+        },
+      };
+    },
+  };
+  const obj = {
+    *returning() {
+      yield* nonCallableReturn;
+    },
+    *throwing() {
+      yield* nonCallableThrow;
+    },
+  };
+
+  const returnIter = obj.returning();
+  expect(returnIter.next()).toEqual({ value: 1, done: false });
+  expect(() => returnIter.return(9)).toThrow(TypeError);
+
+  const throwIter = obj.throwing();
+  expect(throwIter.next()).toEqual({ value: 1, done: false });
+  expect(() => throwIter.throw(9)).toThrow(TypeError);
+});
+
 test("object generator method return closes through finally", () => {
   let closed = false;
   const obj = {
@@ -201,6 +309,48 @@ test("object generator method return does not replay side effects before a yield
   expect(iter.next()).toEqual({ value: 1, done: false });
   expect(iter.return(9)).toEqual({ value: 9, done: true });
   expect(events).toEqual(["before", "finally"]);
+});
+
+test("object generator method finally yield preserves pending return without replaying try", () => {
+  const events = [];
+  const obj = {
+    *values() {
+      try {
+        events.push("try");
+        return 7;
+      } finally {
+        events.push("finally");
+        yield "cleanup";
+      }
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: "cleanup", done: false });
+  expect(events).toEqual(["try", "finally"]);
+  expect(iter.next()).toEqual({ value: 7, done: true });
+  expect(events).toEqual(["try", "finally"]);
+});
+
+test("object generator method finally yield preserves pending throw without replaying try", () => {
+  const events = [];
+  const obj = {
+    *values() {
+      try {
+        events.push("try");
+        throw 7;
+      } finally {
+        events.push("finally");
+        yield "cleanup";
+      }
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: "cleanup", done: false });
+  expect(events).toEqual(["try", "finally"]);
+  expect(() => iter.next()).toThrow();
+  expect(events).toEqual(["try", "finally"]);
 });
 
 test("object generator method throw is catchable", () => {


### PR DESCRIPTION
## Summary
- add interpreter generator continuation checkpoints for nested statement lists and expression results
- replace bytecode generator replay with continuation snapshots for IP, registers, local cells, handlers, and delegate state
- add sync/async generator regressions and update bytecode VM docs

Fixes #434
Fixes #436