### PR TITLE
Add agent discovery Link headers

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -1,6 +1,20 @@
 import type { NextConfig } from "next";
+import { AGENT_DISCOVERY_LINK_HEADER } from "./src/lib/agent-discovery";
 
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Link",
+            value: AGENT_DISCOVERY_LINK_HEADER,
+          },
+        ],
+      },
+    ];
+  },
   outputFileTracingIncludes: {
     "/api/execute": ["./vendor/**"],
     "/api/test": ["./vendor/**"],

--- a/website/src/__tests__/agent-discovery.test.ts
+++ b/website/src/__tests__/agent-discovery.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { GET } from "@/app/.well-known/api-catalog/route";
+import {
+  AGENT_DISCOVERY_LINK_HEADER,
+  API_CATALOG_PATH,
+  buildApiCatalog,
+} from "@/lib/agent-discovery";
+import nextConfig from "../../next.config";
+
+describe("agent discovery", () => {
+  test("homepage advertises agent-useful Link relations", async () => {
+    const headers = await nextConfig.headers?.();
+    const homepage = headers?.find((entry) => entry.source === "/");
+    const link = homepage?.headers.find((header) => header.key === "Link");
+
+    expect(link?.value).toBe(AGENT_DISCOVERY_LINK_HEADER);
+    expect(link?.value).toContain(`<${API_CATALOG_PATH}>; rel="api-catalog"`);
+    expect(link?.value).toContain(`</docs>; rel="service-doc"`);
+  });
+
+  test("api catalog lists public API endpoints and documentation", () => {
+    const catalog = buildApiCatalog("https://example.test");
+
+    expect(catalog.linkset[0].anchor).toBe(
+      "https://example.test/.well-known/api-catalog",
+    );
+    expect(catalog.linkset[0].item).toEqual([
+      { href: "https://example.test/api/execute", type: "application/json" },
+      { href: "https://example.test/api/test", type: "application/json" },
+    ]);
+    expect(catalog.linkset[0]["service-doc"]).toEqual([
+      { href: "https://example.test/docs", type: "text/html" },
+      { href: "https://example.test/docs/testing-api", type: "text/html" },
+    ]);
+  });
+
+  test("api catalog route uses the Linkset media type", async () => {
+    const response = await GET(
+      new Request("https://example.test/.well-known/api-catalog"),
+    );
+    const body = await response.json();
+
+    expect(response.headers.get("content-type")).toContain(
+      "application/linkset+json",
+    );
+    expect(response.headers.get("link")).toContain(
+      `<${API_CATALOG_PATH}>; rel="self"`,
+    );
+    expect(body.linkset[0].item[0].href).toBe(
+      "https://example.test/api/execute",
+    );
+  });
+});

--- a/website/src/__tests__/agent-discovery.test.ts
+++ b/website/src/__tests__/agent-discovery.test.ts
@@ -44,10 +44,11 @@ describe("agent discovery", () => {
       "application/linkset+json",
     );
     expect(response.headers.get("link")).toContain(
-      `<${API_CATALOG_PATH}>; rel="self"`,
+      `<https://example.test${API_CATALOG_PATH}>; rel="self"`,
     );
-    expect(body.linkset[0].item[0].href).toBe(
-      "https://example.test/api/execute",
+    const itemHrefs = body.linkset[0].item.map(
+      (item: { href: string }) => item.href,
     );
+    expect(itemHrefs).toContain("https://example.test/api/execute");
   });
 });

--- a/website/src/app/.well-known/api-catalog/route.ts
+++ b/website/src/app/.well-known/api-catalog/route.ts
@@ -4,11 +4,12 @@ export const dynamic = "force-dynamic";
 
 export function GET(req: Request) {
   const origin = new URL(req.url).origin;
+  const selfHref = new URL(API_CATALOG_PATH, origin).toString();
   return new Response(JSON.stringify(buildApiCatalog(origin), null, 2), {
     headers: {
       "Content-Type":
         'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"; charset=utf-8',
-      Link: `<${API_CATALOG_PATH}>; rel="self"; type="application/linkset+json"`,
+      Link: `<${selfHref}>; rel="self"; type="application/linkset+json"`,
     },
   });
 }

--- a/website/src/app/.well-known/api-catalog/route.ts
+++ b/website/src/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,14 @@
+import { API_CATALOG_PATH, buildApiCatalog } from "@/lib/agent-discovery";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request) {
+  const origin = new URL(req.url).origin;
+  return new Response(JSON.stringify(buildApiCatalog(origin), null, 2), {
+    headers: {
+      "Content-Type":
+        'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"; charset=utf-8',
+      Link: `<${API_CATALOG_PATH}>; rel="self"; type="application/linkset+json"`,
+    },
+  });
+}

--- a/website/src/lib/agent-discovery.ts
+++ b/website/src/lib/agent-discovery.ts
@@ -1,0 +1,41 @@
+export const API_CATALOG_PATH = "/.well-known/api-catalog";
+
+export const AGENT_DISCOVERY_LINK_HEADER = [
+  `<${API_CATALOG_PATH}>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727"`,
+  `</docs>; rel="service-doc"; type="text/html"`,
+].join(", ");
+
+const API_ENDPOINTS = [
+  { href: "/api/execute", type: "application/json" },
+  { href: "/api/test", type: "application/json" },
+] as const;
+
+const SERVICE_DOCS = [
+  { href: "/docs", type: "text/html" },
+  { href: "/docs/testing-api", type: "text/html" },
+] as const;
+
+const DESCRIPTIONS = [{ href: "/docs/language", type: "text/html" }] as const;
+
+function absoluteLinks(
+  origin: string,
+  links: readonly { href: string; type: string }[],
+) {
+  return links.map((link) => ({
+    href: new URL(link.href, origin).toString(),
+    type: link.type,
+  }));
+}
+
+export function buildApiCatalog(origin: string) {
+  return {
+    linkset: [
+      {
+        anchor: new URL(API_CATALOG_PATH, origin).toString(),
+        item: absoluteLinks(origin, API_ENDPOINTS),
+        "service-doc": absoluteLinks(origin, SERVICE_DOCS),
+        describedby: absoluteLinks(origin, DESCRIPTIONS),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- Add RFC 8288 `Link` headers on the homepage for `api-catalog` and `service-doc` discovery.
- Add `/.well-known/api-catalog` as an `application/linkset+json` route listing public API endpoints and docs.
- Cover the discovery header and catalog route with Bun tests.

## Verification
- `bun run lint`
- `bun test`
- `bun run build`
- `curl -I http://localhost:3210/` confirmed `rel="api-catalog"` and `rel="service-doc"` headers.
- `curl http://localhost:3210/.well-known/api-catalog` returned Linkset JSON.