### PR TITLE
Enable markdown negotiation for agents

### DIFF
--- a/website/src/__tests__/markdown-negotiation.test.ts
+++ b/website/src/__tests__/markdown-negotiation.test.ts
@@ -28,6 +28,12 @@ describe("acceptsMarkdown", () => {
   test("ignores text/markdown when q=0", () => {
     expect(acceptsMarkdown("text/markdown;q=0")).toBe(false);
   });
+
+  test("normalizes text/markdown quality values", () => {
+    expect(acceptsMarkdown("text/markdown;q=1.5")).toBe(true);
+    expect(acceptsMarkdown("text/markdown;q=-1")).toBe(false);
+    expect(acceptsMarkdown("text/markdown;q=abc")).toBe(false);
+  });
 });
 
 describe("markdown response headers", () => {

--- a/website/src/__tests__/markdown-negotiation.test.ts
+++ b/website/src/__tests__/markdown-negotiation.test.ts
@@ -5,7 +5,11 @@ import {
   MARKDOWN_CONTENT_TYPE,
   markdownResponseHeaders,
 } from "@/lib/markdown-negotiation";
-import { createSiteMarkdown, resolveMarkdownRoute } from "@/lib/site-markdown";
+import {
+  createSiteMarkdown,
+  resolveMarkdownRoute,
+  yamlScalar,
+} from "@/lib/site-markdown";
 
 describe("acceptsMarkdown", () => {
   test("requires an explicit text/markdown accept entry", () => {
@@ -78,6 +82,12 @@ describe("resolveMarkdownRoute", () => {
 });
 
 describe("createSiteMarkdown", () => {
+  test("serializes frontmatter scalars with YAML-safe quoting", () => {
+    expect(yamlScalar('Title: "quoted"\nnext')).toBe(
+      '"Title: \\"quoted\\"\\nnext"',
+    );
+  });
+
   test("returns markdown for the playground selected example", async () => {
     const markdown = await createSiteMarkdown(
       ["playground"],

--- a/website/src/__tests__/markdown-negotiation.test.ts
+++ b/website/src/__tests__/markdown-negotiation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  acceptsMarkdown,
+  estimateMarkdownTokens,
+  MARKDOWN_CONTENT_TYPE,
+  markdownResponseHeaders,
+} from "@/lib/markdown-negotiation";
+import { createSiteMarkdown, resolveMarkdownRoute } from "@/lib/site-markdown";
+
+describe("acceptsMarkdown", () => {
+  test("requires an explicit text/markdown accept entry", () => {
+    expect(acceptsMarkdown(null)).toBe(false);
+    expect(acceptsMarkdown("")).toBe(false);
+    expect(
+      acceptsMarkdown(
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      ),
+    ).toBe(false);
+    expect(acceptsMarkdown("*/*")).toBe(false);
+  });
+
+  test("accepts text/markdown with optional parameters", () => {
+    expect(acceptsMarkdown("text/markdown")).toBe(true);
+    expect(acceptsMarkdown("text/html, text/markdown;q=0.7")).toBe(true);
+    expect(acceptsMarkdown("TEXT/MARKDOWN; charset=utf-8")).toBe(true);
+  });
+
+  test("ignores text/markdown when q=0", () => {
+    expect(acceptsMarkdown("text/markdown;q=0")).toBe(false);
+  });
+});
+
+describe("markdown response headers", () => {
+  test("set markdown content type, vary, and token count", () => {
+    const markdown = "# Title\n\nSome markdown content.";
+    const headers = markdownResponseHeaders(markdown);
+
+    expect(headers.get("content-type")).toBe(MARKDOWN_CONTENT_TYPE);
+    expect(headers.get("vary")).toBe("Accept");
+    expect(headers.get("x-markdown-tokens")).toBe(
+      String(estimateMarkdownTokens(markdown)),
+    );
+  });
+});
+
+describe("resolveMarkdownRoute", () => {
+  test("maps HTML page paths to markdown routes", () => {
+    expect(resolveMarkdownRoute(undefined)).toEqual({ kind: "home" });
+    expect(resolveMarkdownRoute([])).toEqual({ kind: "home" });
+    expect(resolveMarkdownRoute(["docs"])).toEqual({
+      kind: "docs",
+      id: "readme",
+    });
+    expect(resolveMarkdownRoute(["docs", "language"])).toEqual({
+      kind: "docs",
+      id: "language",
+    });
+    expect(resolveMarkdownRoute(["installation"])).toEqual({
+      kind: "installation",
+    });
+    expect(resolveMarkdownRoute(["playground"])).toEqual({
+      kind: "playground",
+    });
+    expect(resolveMarkdownRoute(["sandbox"])).toEqual({ kind: "sandbox" });
+  });
+
+  test("does not invent markdown for unknown routes", () => {
+    expect(resolveMarkdownRoute(["api", "execute"])).toBeNull();
+    expect(resolveMarkdownRoute(["missing"])).toBeNull();
+    expect(resolveMarkdownRoute(["docs", "missing"])).toBeNull();
+  });
+});
+
+describe("createSiteMarkdown", () => {
+  test("returns markdown for the playground selected example", async () => {
+    const markdown = await createSiteMarkdown(
+      ["playground"],
+      new URLSearchParams("example=coffee"),
+    );
+
+    expect(markdown).toContain("# Playground");
+    expect(markdown).toContain("CoffeeShop");
+    expect(markdown).toContain("```js");
+  });
+});

--- a/website/src/app/agent-markdown/[[...path]]/route.ts
+++ b/website/src/app/agent-markdown/[[...path]]/route.ts
@@ -1,0 +1,48 @@
+import { markdownResponseHeaders } from "@/lib/markdown-negotiation";
+import { createSiteMarkdown } from "@/lib/site-markdown";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type MarkdownContext = {
+  params: Promise<{ path?: string[] }>;
+};
+
+async function buildResponse(
+  request: Request,
+  context: MarkdownContext,
+  includeBody: boolean,
+): Promise<Response> {
+  const { path } = await context.params;
+  const { searchParams } = new URL(request.url);
+  const markdown = await createSiteMarkdown(path, searchParams);
+
+  if (markdown === null) {
+    const body = [
+      "---",
+      "title: Not Found",
+      "description: No markdown representation is available for this route.",
+      "---",
+      "",
+      "# Not Found",
+      "",
+      "No markdown representation is available for this route.",
+    ].join("\n");
+    return new Response(includeBody ? body : null, {
+      status: 404,
+      headers: markdownResponseHeaders(body),
+    });
+  }
+
+  return new Response(includeBody ? markdown : null, {
+    headers: markdownResponseHeaders(markdown),
+  });
+}
+
+export async function GET(request: Request, context: MarkdownContext) {
+  return buildResponse(request, context, true);
+}
+
+export async function HEAD(request: Request, context: MarkdownContext) {
+  return buildResponse(request, context, false);
+}

--- a/website/src/lib/markdown-negotiation.ts
+++ b/website/src/lib/markdown-negotiation.ts
@@ -1,0 +1,51 @@
+export const MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8";
+export const MARKDOWN_ROUTE_PREFIX = "/agent-markdown";
+
+type AcceptEntry = {
+  mediaType: string;
+  quality: number;
+};
+
+function parseQuality(params: string[]): number {
+  for (const param of params) {
+    const [rawKey, rawValue] = param.split("=");
+    if (rawKey?.trim().toLowerCase() !== "q") continue;
+    const quality = Number(rawValue?.trim());
+    if (!Number.isFinite(quality)) return 0;
+    return Math.min(Math.max(quality, 0), 1);
+  }
+  return 1;
+}
+
+function parseAccept(accept: string | null | undefined): AcceptEntry[] {
+  if (!accept) return [];
+  return accept
+    .split(",")
+    .map((part) => {
+      const [rawMediaType, ...params] = part.split(";");
+      const mediaType = rawMediaType?.trim().toLowerCase();
+      if (!mediaType) return null;
+      return { mediaType, quality: parseQuality(params) };
+    })
+    .filter((entry): entry is AcceptEntry => entry !== null);
+}
+
+export function acceptsMarkdown(accept: string | null | undefined): boolean {
+  return parseAccept(accept).some(
+    (entry) => entry.mediaType === "text/markdown" && entry.quality > 0,
+  );
+}
+
+export function estimateMarkdownTokens(markdown: string): number {
+  const compact = markdown.trim();
+  if (!compact) return 0;
+  return Math.max(1, Math.ceil(compact.length / 4));
+}
+
+export function markdownResponseHeaders(markdown: string): Headers {
+  return new Headers({
+    "Content-Type": MARKDOWN_CONTENT_TYPE,
+    Vary: "Accept",
+    "x-markdown-tokens": String(estimateMarkdownTokens(markdown)),
+  });
+}

--- a/website/src/lib/site-markdown.ts
+++ b/website/src/lib/site-markdown.ts
@@ -1,6 +1,6 @@
 import { readDocSource } from "@/lib/doc-source";
 import { DOC_PAGES, type DocPage } from "@/lib/docs-data";
-import { EXAMPLES } from "@/lib/examples";
+import { EXAMPLES, type Example } from "@/lib/examples";
 import {
   fetchLatestRelease,
   GITHUB_RELEASES_URL,
@@ -17,6 +17,13 @@ export type MarkdownRoute =
   | { kind: "installation" }
   | { kind: "playground" }
   | { kind: "sandbox" };
+
+const EMPTY_EXAMPLE: Example = {
+  id: "",
+  label: "",
+  desc: "",
+  code: "",
+};
 
 function frontmatter(title: string, description: string): string {
   return ["---", `title: ${title}`, `description: ${description}`, "---"].join(
@@ -48,6 +55,19 @@ function releaseSummary(release: ReleaseInfo | null): string {
 
 function docPageForId(id: string): DocPage | undefined {
   return DOC_PAGES.find((page) => page.id === id);
+}
+
+function pickExample(
+  preferredId: string | null | undefined,
+  fallbackId?: string,
+): Example {
+  if (EXAMPLES.length === 0) return EMPTY_EXAMPLE;
+  return (
+    EXAMPLES.find((example) => example.id === preferredId) ??
+    EXAMPLES.find((example) => example.id === fallbackId) ??
+    EXAMPLES[0] ??
+    EMPTY_EXAMPLE
+  );
 }
 
 export function resolveMarkdownRoute(
@@ -96,8 +116,7 @@ async function docsMarkdown(id: string): Promise<string | null> {
 
 async function homeMarkdown(): Promise<string> {
   const release = await fetchLatestRelease();
-  const heroExample =
-    EXAMPLES.find((example) => example.id === "coffee-typed") ?? EXAMPLES[0];
+  const heroExample = pickExample("coffee-typed");
 
   return [
     frontmatter(
@@ -211,10 +230,7 @@ async function installationMarkdown(): Promise<string> {
 
 function playgroundMarkdown(searchParams: URLSearchParams): string {
   const requested = searchParams.get("example");
-  const example =
-    EXAMPLES.find((item) => item.id === requested) ??
-    EXAMPLES.find((item) => item.id === "coffee-typed") ??
-    EXAMPLES[0];
+  const example = pickExample(requested, "coffee-typed");
 
   return [
     frontmatter(

--- a/website/src/lib/site-markdown.ts
+++ b/website/src/lib/site-markdown.ts
@@ -25,10 +25,17 @@ const EMPTY_EXAMPLE: Example = {
   code: "",
 };
 
+export function yamlScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
 function frontmatter(title: string, description: string): string {
-  return ["---", `title: ${title}`, `description: ${description}`, "---"].join(
-    "\n",
-  );
+  return [
+    "---",
+    `title: ${yamlScalar(title)}`,
+    `description: ${yamlScalar(description)}`,
+    "---",
+  ].join("\n");
 }
 
 function fence(code: string, language = ""): string {

--- a/website/src/lib/site-markdown.ts
+++ b/website/src/lib/site-markdown.ts
@@ -1,0 +1,303 @@
+import { readDocSource } from "@/lib/doc-source";
+import { DOC_PAGES, type DocPage } from "@/lib/docs-data";
+import { EXAMPLES } from "@/lib/examples";
+import {
+  fetchLatestRelease,
+  GITHUB_RELEASES_URL,
+  GITHUB_REPO_URL,
+  isPreStable,
+  type ReleaseInfo,
+} from "@/lib/github";
+import { BUILTINS, EXCLUDED, FEATURES } from "@/lib/landing-data";
+import { TOOL_CALL_FLOWS, TOOL_CALL_TASK } from "@/lib/tool-call-comparison";
+
+export type MarkdownRoute =
+  | { kind: "home" }
+  | { kind: "docs"; id: string }
+  | { kind: "installation" }
+  | { kind: "playground" }
+  | { kind: "sandbox" };
+
+function frontmatter(title: string, description: string): string {
+  return ["---", `title: ${title}`, `description: ${description}`, "---"].join(
+    "\n",
+  );
+}
+
+function fence(code: string, language = ""): string {
+  return [`\`\`\`${language}`, code.trimEnd(), "```"].join("\n");
+}
+
+function list(items: string[]): string {
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+function releaseSummary(release: ReleaseInfo | null): string {
+  if (!release) {
+    return `Latest release: see [GitHub Releases](${GITHUB_RELEASES_URL}).`;
+  }
+
+  const published = release.publishedAt
+    ? `, published ${release.publishedAt.slice(0, 10)}`
+    : "";
+  const prestable = isPreStable(release)
+    ? " Pre-1.0 releases may include breaking changes before 1.0.0."
+    : "";
+  return `Latest release: [${release.tagName}](${release.htmlUrl})${published}.${prestable}`;
+}
+
+function docPageForId(id: string): DocPage | undefined {
+  return DOC_PAGES.find((page) => page.id === id);
+}
+
+export function resolveMarkdownRoute(
+  segments: readonly string[] | undefined,
+): MarkdownRoute | null {
+  const path = segments ?? [];
+  if (path.length === 0) return { kind: "home" };
+
+  const [section, id] = path;
+  if (section === "docs") {
+    if (path.length === 1) return { kind: "docs", id: "readme" };
+    if (path.length === 2 && id && docPageForId(id)) {
+      return { kind: "docs", id };
+    }
+    return null;
+  }
+  if (path.length !== 1) return null;
+  if (section === "installation") return { kind: "installation" };
+  if (section === "playground") return { kind: "playground" };
+  if (section === "sandbox") return { kind: "sandbox" };
+  return null;
+}
+
+async function docsMarkdown(id: string): Promise<string | null> {
+  const page = docPageForId(id);
+  if (!page) return null;
+
+  const source = await readDocSource(id);
+  if (source !== null) return source;
+
+  return [
+    frontmatter(
+      `${page.title} - Docs - GocciaScript`,
+      page.desc ?? "Reference documentation for GocciaScript.",
+    ),
+    "",
+    `# ${page.title}`,
+    "",
+    page.desc ?? "Reference documentation for GocciaScript.",
+    "",
+    `The markdown source file for this page was not found at \`content/docs/${page.file}\`.`,
+    "",
+    "Run `bun run sync-docs` from the website directory to sync the docs source.",
+  ].join("\n");
+}
+
+async function homeMarkdown(): Promise<string> {
+  const release = await fetchLatestRelease();
+  const heroExample =
+    EXAMPLES.find((example) => example.id === "coffee-typed") ?? EXAMPLES[0];
+
+  return [
+    frontmatter(
+      "GocciaScript",
+      "A strict JavaScript subset with a sandbox-first runtime for embedding and AI agents.",
+    ),
+    "",
+    "# GocciaScript",
+    "",
+    "A strict subset of ECMAScript 2027+, implemented from scratch with a sandbox-first runtime designed for tinkerers, embedding, and AI agents.",
+    "",
+    releaseSummary(release),
+    "",
+    "## Quick install",
+    "",
+    "macOS / Linux:",
+    "",
+    fence("curl -fsSL https://gocciascript.dev/install | sh", "sh"),
+    "",
+    "Windows PowerShell:",
+    "",
+    fence("irm https://gocciascript.dev/install.ps1 | iex", "powershell"),
+    "",
+    "## Start here",
+    "",
+    list([
+      "[Open the Playground](/playground?example=coffee-typed)",
+      "[Read the docs](/docs)",
+      "[Installation options](/installation)",
+      `[Source on GitHub](${GITHUB_REPO_URL})`,
+    ]),
+    "",
+    "## Design principles",
+    "",
+    list(FEATURES.map((feature) => `**${feature.title}** - ${feature.body}`)),
+    "",
+    "## Intentionally excluded",
+    "",
+    "Dynamic code construction and scope-changing syntax are left out to keep execution predictable in embedded runtimes. Compatibility mode can opt back into selected syntax such as `var`, `function`, and ASI via CLI or config flags.",
+    "",
+    list(EXCLUDED.map((item) => `\`${item.name}\` - ${item.why}`)),
+    "",
+    "## Runtime globals",
+    "",
+    "GocciaScript includes structured-data imports and parsers, capability-gated `fetch` for GET/HEAD requests to explicit hosts, console output, SemVer helpers, import maps, and a built-in test runner with `test`, `describe`, and `expect`.",
+    "",
+    list(BUILTINS.map((item) => `\`${item.name}\``)),
+    "",
+    "## Example",
+    "",
+    heroExample.desc,
+    "",
+    fence(heroExample.code, heroExample.ext ?? "js"),
+  ].join("\n");
+}
+
+async function installationMarkdown(): Promise<string> {
+  const release = await fetchLatestRelease();
+
+  return [
+    frontmatter(
+      "Installation - GocciaScript",
+      "Install GocciaScript with a one-line installer, prebuilt binaries, or a source build.",
+    ),
+    "",
+    "# Installation",
+    "",
+    "Pick the install method that fits your platform. The runtime is a single self-contained binary with no Node.js requirement.",
+    "",
+    releaseSummary(release),
+    "",
+    "## Quick install",
+    "",
+    "macOS / Linux:",
+    "",
+    fence("curl -fsSL https://gocciascript.dev/install | sh", "sh"),
+    "",
+    "Windows PowerShell:",
+    "",
+    fence("irm https://gocciascript.dev/install.ps1 | iex", "powershell"),
+    "",
+    "You can inspect the install scripts directly at `/install` and `/install.ps1`.",
+    "",
+    "## Pre-built binaries",
+    "",
+    `Download release archives from [GitHub Releases](${GITHUB_RELEASES_URL}). Each archive includes \`GocciaScriptLoader\`, \`GocciaTestRunner\`, and \`GocciaREPL\`.`,
+    "",
+    "## Build from source",
+    "",
+    "FreePascal is required.",
+    "",
+    fence(
+      [
+        "git clone https://github.com/frostney/GocciaScript",
+        "cd GocciaScript",
+        "./build.pas loader testrunner repl",
+        "./build/GocciaScriptLoader --help",
+      ].join("\n"),
+      "sh",
+    ),
+    "",
+    "## Next",
+    "",
+    list([
+      "[Read the docs](/docs)",
+      "[Try the playground](/playground?example=coffee-typed)",
+      `[Source on GitHub](${GITHUB_REPO_URL})`,
+    ]),
+  ].join("\n");
+}
+
+function playgroundMarkdown(searchParams: URLSearchParams): string {
+  const requested = searchParams.get("example");
+  const example =
+    EXAMPLES.find((item) => item.id === requested) ??
+    EXAMPLES.find((item) => item.id === "coffee-typed") ??
+    EXAMPLES[0];
+
+  return [
+    frontmatter(
+      "Playground - GocciaScript",
+      "Run GocciaScript in the browser with example programs and selectable backends.",
+    ),
+    "",
+    "# Playground",
+    "",
+    "Run GocciaScript in the browser. Choose an example, select the tree-walk or bytecode VM backend, toggle ASI, and execute the script.",
+    "",
+    "## Examples",
+    "",
+    list(
+      EXAMPLES.map((item) => `\`${item.id}\` - ${item.label}: ${item.desc}`),
+    ),
+    "",
+    "## Selected example",
+    "",
+    `**${example.label}**`,
+    "",
+    example.desc,
+    "",
+    fence(example.code, example.ext ?? "js"),
+  ].join("\n");
+}
+
+function sandboxMarkdown(): string {
+  const gocciaFlow = TOOL_CALL_FLOWS.goccia;
+
+  return [
+    frontmatter(
+      "Sandbox - GocciaScript",
+      "A runtime designed for untrusted code, host-provided globals, and AI agent tool calls.",
+    ),
+    "",
+    "# Sandbox",
+    "",
+    "GocciaScript is meant for running untrusted or user-provided code in a host-controlled environment. Scripts receive only the data and capabilities the host provides, run with explicit limits, and return structured results that the host can inspect.",
+    "",
+    "## Agent flow",
+    "",
+    list([
+      "AI agent emits GocciaScript via a tool call.",
+      "Goccia sandbox runs the script with explicit globals, capability gates, timeout, and memory cap.",
+      "The host receives a structured JSON result.",
+    ]),
+    "",
+    "## Tool-call comparison",
+    "",
+    `Task: ${TOOL_CALL_TASK}`,
+    "",
+    "A typical shell-tool flow takes several dependent calls. The GocciaScript flow handles the same task in one sandboxed call:",
+    "",
+    fence(gocciaFlow.steps[0]?.call ?? "", "js"),
+    "",
+    "Result:",
+    "",
+    fence(gocciaFlow.steps[0]?.result ?? "", "json"),
+    "",
+    "## Sandbox preview",
+    "",
+    "The interactive page lets you edit a script and JSON globals, execute the runtime, and inspect the host result.",
+  ].join("\n");
+}
+
+export async function createSiteMarkdown(
+  segments: readonly string[] | undefined,
+  searchParams = new URLSearchParams(),
+): Promise<string | null> {
+  const route = resolveMarkdownRoute(segments);
+  if (!route) return null;
+
+  switch (route.kind) {
+    case "home":
+      return homeMarkdown();
+    case "docs":
+      return docsMarkdown(route.id);
+    case "installation":
+      return installationMarkdown();
+    case "playground":
+      return playgroundMarkdown(searchParams);
+    case "sandbox":
+      return sandboxMarkdown();
+  }
+}

--- a/website/src/proxy.ts
+++ b/website/src/proxy.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  acceptsMarkdown,
+  MARKDOWN_ROUTE_PREFIX,
+} from "@/lib/markdown-negotiation";
+
+const SKIPPED_PATHS = new Set([
+  "/favicon.ico",
+  "/install",
+  "/opengraph-image",
+  "/twitter-image",
+]);
+
+function shouldSkipPath(pathname: string): boolean {
+  if (pathname.startsWith("/api/")) return true;
+  if (pathname.startsWith("/_next/")) return true;
+  if (pathname.startsWith(`${MARKDOWN_ROUTE_PREFIX}/`)) return true;
+  if (pathname === MARKDOWN_ROUTE_PREFIX) return true;
+  if (SKIPPED_PATHS.has(pathname)) return true;
+  return /\.[^/]+$/.test(pathname);
+}
+
+export function proxy(request: NextRequest) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return NextResponse.next();
+  }
+  if (!acceptsMarkdown(request.headers.get("accept"))) {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  if (shouldSkipPath(url.pathname)) return NextResponse.next();
+
+  url.pathname =
+    url.pathname === "/"
+      ? MARKDOWN_ROUTE_PREFIX
+      : `${MARKDOWN_ROUTE_PREFIX}${url.pathname}`;
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: ["/:path*"],
+};

--- a/website/src/proxy.ts
+++ b/website/src/proxy.ts
@@ -13,8 +13,8 @@ const SKIPPED_PATHS = new Set([
 ]);
 
 function shouldSkipPath(pathname: string): boolean {
-  if (pathname.startsWith("/api/")) return true;
-  if (pathname.startsWith("/_next/")) return true;
+  if (pathname === "/api" || pathname.startsWith("/api/")) return true;
+  if (pathname === "/_next" || pathname.startsWith("/_next/")) return true;
   if (pathname.startsWith(`${MARKDOWN_ROUTE_PREFIX}/`)) return true;
   if (pathname === MARKDOWN_ROUTE_PREFIX) return true;
   if (SKIPPED_PATHS.has(pathname)) return true;


### PR DESCRIPTION
## Summary
- Add Accept: text/markdown negotiation for website page requests via Next proxy rewrites
- Serve markdown responses with Content-Type: text/markdown, Vary: Accept, and x-markdown-tokens
- Add generated markdown coverage for home, docs, installation, playground, and sandbox pages

## Verification
- bun test
- bun run lint
- bun run build
- curl confirmed default HTML and markdown response headers locally