### PR TITLE
Fix CSV and TSV header option examples

### DIFF
--- a/website/src/lib/examples.ts
+++ b/website/src/lib/examples.ts
@@ -342,7 +342,7 @@ console.log("Features:", Object.keys(config.features));
 
 // CSV → array of rows
 const csv = "name,price\\nespresso,2.5\\nlatte,4.0";
-const rows = CSV.parse(csv, { header: true });
+const rows = CSV.parse(csv, { headers: true });
 console.log("Menu rows:", rows);`,
   },
   {

--- a/website/src/lib/landing-data.ts
+++ b/website/src/lib/landing-data.ts
@@ -28,13 +28,13 @@ const list = JSONL.parse(text);
   {
     name: "CSV",
     snippet: `const rows = CSV.parse(text, {
-  header: true,
+  headers: true,
 });  // → [{ name, price }, …]`,
   },
   {
     name: "TSV",
     snippet: `const rows = TSV.parse(text, {
-  header: true,
+  headers: true,
 });  // tab-separated, same shape`,
   },
   {


### PR DESCRIPTION
## Summary
- update CSV and TSV website snippets to use the canonical `headers` option
- keep runtime behavior unchanged with `headers` as the only supported option

## Verification
- pre-commit hooks passed for the committed files
- `bun run lint` could not run locally because `biome` is not installed in this checkout