### PR TITLE
Optimize lexer hot paths

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -17,6 +17,8 @@ Chronological record of key architectural and implementation decisions, newest f
 
 ---
 
+**2026-04-29** · `parser` — Lexer hot paths favor direct scanning and measured tiny-method `inline` hints over abstraction in the numeric scanner. Comment skipping, block comments, regex literal slicing, and template line-terminator handling were simplified and benchmarked with `GocciaBenchmarkRunner` lex timing; the numeric separator helper was rejected because it shortened the code but regressed decimal and radix-heavy cases. [spikes/lexer-performance-simplification.md](spikes/lexer-performance-simplification.md).
+
 **2026-04-28** · `runtime` · [#440](https://github.com/frostney/GocciaScript/pull/440) — Temporal named time zones use layered providers in this order: `GOCCIA_TZDIR`, Unix TZif files, Windows ICU, then embedded TZif resource fallback. The embedded IANA payload is generated as `Generated.TimeZoneData.res` with a small linker unit instead of a large Pascal array, keeping portability while leaving lookup and parsing logic in hand-authored units. [Temporal Time Zone Data](built-ins-temporal.md#time-zone-data). [Generated Timezone Data](build-system.md#generated-timezone-data).
 
 **2026-04-27** · `runtime` — Generator and async generator support. Generator method shorthand (`*method()` and `async *method()`) is now part of the default method syntax, while `function*` and `async function*` remain behind `--compat-function` because they use the compatibility-gated `function` keyword. The interpreter uses resumable generator continuations and the bytecode format reserves a single `OP_YIELD` opcode; `yield*` is represented as delegation logic rather than a second opcode. [language.md § Generators](language.md#generators).

--- a/docs/spikes/lexer-performance-simplification.md
+++ b/docs/spikes/lexer-performance-simplification.md
@@ -1,0 +1,151 @@
+# Lexer Performance Simplification
+
+Point-in-time spike for reducing lexer hot-path overhead and code size
+
+## Executive Summary
+
+- Direct cursor advancement is faster than routing every skipped comment character through `Advance`.
+- Regex literal scanning should collect the pattern with one `Copy` after scanning, not append each pattern byte into a `TStringBuffer`.
+- Small lexer primitives are reasonable `inline` candidates when measured, especially `Advance` and line-terminator helpers.
+- The numeric separator helper was rejected, even with `inline`, because it shortened the code but regressed decimal and radix-heavy cases.
+- The final lexer change reduced `Goccia.Lexer.pas` from 1744 to 1632 lines while keeping the full test suite green.
+
+## Context
+
+The lexer had several hot paths where simple scanning work went through helper calls or repeated equivalent branches:
+
+- hashbang and single-line comments called `IsLineTerminator` and `Advance` for each skipped character
+- block comments repeatedly called `Peek` and `Advance`
+- template interpolation scanning duplicated line-terminator and "append current char to cooked/raw buffers" logic
+- regex literal scanning appended each pattern byte into `TStringBuffer`
+- numeric separator scanning repeated nearly identical loops for decimal, radix, fraction, and exponent parts
+
+The goal was to simplify the code without losing lexer correctness, and to keep changes only when the integrated timing tools showed neutral or better behavior.
+
+## Methodology
+
+Measurements used the repository's benchmark runner and its JSON timing output:
+
+```bash
+./build.pas --prod benchmarkrunner
+GOCCIA_BENCH_CALIBRATION_MS=1 \
+GOCCIA_BENCH_ROUNDS=1 \
+GOCCIA_BENCH_WARMUP=1 \
+  ./build/GocciaBenchmarkRunner --mode=bytecode --format=json --no-progress
+```
+
+The measured field was `files[0].lexTimeNanoseconds`, converted to milliseconds. Runs alternated before/after binaries to reduce order bias. The final before/after comparison used a detached `HEAD` worktree as the baseline and the working tree as the candidate. Values below are medians.
+
+Environment for the final run:
+
+- Date: 2026-04-29
+- FPC: 3.2.2
+- OS/arch: Darwin aarch64
+- Build: production benchmark runner
+- Baseline commit: `ba88a512`
+
+These are synthetic lexer stress cases, not a replacement for the full benchmark suite.
+
+## Accepted Changes
+
+### Direct comment scanning
+
+`SkipUntilLineTerminator` advances `FCurrent` and `FColumn` directly until it sees LF, CR, LS, or PS. Hashbang and single-line comments use this path.
+
+Block comments now scan `FSource[FCurrent]` directly and only delegate to the shared line-terminator helper when a terminator is actually present. This removes repeated `Peek`/`Advance` calls from the common non-terminator path.
+
+### Shared line-terminator handling
+
+`ConsumeLineTerminator` centralizes line and column updates for LF, CR, CRLF, LS, and PS. `AppendLineTerminator` uses the same tracking while appending the correct cooked/raw template bytes.
+
+This removed duplicated CR/LF/Unicode branches from whitespace and template interpolation code.
+
+### Template append helper
+
+`AppendCurrent` consumes the current source byte and appends it to both template buffers. This made nested template and interpolation scanning smaller without changing how raw and cooked content are collected.
+
+### Regex pattern slicing
+
+Regex literal scanning now records `PatternStart`, scans through the pattern, and slices the source once:
+
+```pascal
+Pattern := Copy(FSource, PatternStart, FCurrent - PatternStart - 1);
+```
+
+This avoids one `TStringBuffer.AppendChar` per regex pattern byte.
+
+### Selected inline hints
+
+The final inline pass kept only small primitives that measured neutral or faster:
+
+- `Advance`
+- `IsValidIdentifierChar`
+- `ConsumeUnicodeLineTerminator`
+- implementation-side `inline` markers for small methods already declared inline
+
+`inline` remains a compiler hint, not a guarantee. The decision was based on measured behavior from the production benchmark runner.
+
+## Rejected Changes
+
+### Numeric separator helper
+
+A helper for digit runs with numeric separators shortened `ScanNumber`, but it was rejected. The first non-inline spike regressed the mixed operator/number case by about 6%. Adding `inline` helped one mixed case but still regressed decimal-heavy and radix-heavy inputs.
+
+Inline helper spike, measured against the current non-helper implementation:
+
+| Case | Delta |
+|---|---:|
+| `operators_numbers` | -5.4% |
+| `decimal_numbers` | +15.6% |
+| `base_numbers` | +7.3% |
+| `line_comments` | +11.0% |
+| `templates_interp` | +6.4% |
+
+The duplicated loops in `ScanNumber` are deliberately kept because they are clearer to the compiler and faster across the important numeric cases.
+
+## Final Before/After Results
+
+Final current tree compared against baseline `HEAD` (`ba88a512`). Each row uses 18 alternating repeats except `templates_large`, which uses 30 repeats to reduce noise in the template case.
+
+| Case | Before | After | Delta |
+|---|---:|---:|---:|
+| `operators_numbers` | 9.942 ms | 9.999 ms | +0.6% |
+| `decimal_numbers` | 6.801 ms | 6.745 ms | -0.8% |
+| `base_numbers` | 10.954 ms | 9.898 ms | -9.6% |
+| `identifiers` | 14.948 ms | 14.160 ms | -5.3% |
+| `regex_literals` | 2.790 ms | 2.397 ms | -14.1% |
+| `line_comments` | 2.654 ms | 2.195 ms | -17.3% |
+| `block_comments` | 2.469 ms | 1.713 ms | -30.6% |
+| `templates_large` | 10.755 ms | 9.677 ms | -10.0% |
+
+The mixed operator/number case is effectively neutral, while radix numbers, identifiers, regex literals, comments, and larger template interpolation inputs improved.
+
+## Inline-Only Spike
+
+The selected inline hints were measured separately against the pre-inline lexer changes:
+
+| Case | Delta |
+|---|---:|
+| `operators_numbers` | -5.5% |
+| `decimal_numbers` | -8.2% |
+| `base_numbers` | -4.0% |
+| `identifiers` | -0.4% |
+| `regex_literals` | -11.2% |
+| `line_comments` | -9.5% |
+| `block_comments` | -3.2% |
+| `templates_interp` | -2.6% |
+
+This supports keeping tiny lexer primitives inline, while still avoiding larger helper extraction on hot numeric loops.
+
+## Verification
+
+Final verification after the lexer and docs work:
+
+```bash
+./format.pas --check
+./build.pas clean tests
+./build/Goccia.Lexer.Test
+./build.pas clean testrunner
+./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress
+git diff --check
+```

--- a/source/units/Goccia.Lexer.Test.pas
+++ b/source/units/Goccia.Lexer.Test.pas
@@ -8,6 +8,7 @@ uses
 
   TestingPascalLibrary,
 
+  Goccia.Error,
   Goccia.GarbageCollector,
   Goccia.Lexer,
   Goccia.TestSetup,
@@ -24,6 +25,11 @@ type
     procedure TestCommentTerminatedByUnicodeLineTerminators;
     procedure TestCRIncrementsLineInWhitespace;
     procedure TestCRIncrementsLineInBlockComment;
+    procedure TestUnicodeLineTerminatorsInBlockComment;
+    procedure TestRegexLiteralPreservesRawPattern;
+    procedure TestRegexUnterminatedAtEOF;
+    procedure TestNumericSeparatorsNormalize;
+    procedure TestTemplateInterpolationTracksLineTerminators;
   public
     procedure SetupTests; override;
   end;
@@ -35,6 +41,11 @@ begin
   Test('Terminates comment on Unicode line terminators', TestCommentTerminatedByUnicodeLineTerminators);
   Test('CR increments line counter in whitespace', TestCRIncrementsLineInWhitespace);
   Test('CR increments line counter in block comments', TestCRIncrementsLineInBlockComment);
+  Test('Unicode line terminators increment line counter in block comments', TestUnicodeLineTerminatorsInBlockComment);
+  Test('Regex literal preserves raw pattern', TestRegexLiteralPreservesRawPattern);
+  Test('Unterminated regex at EOF raises lexer error', TestRegexUnterminatedAtEOF);
+  Test('Numeric separators normalize', TestNumericSeparatorsNormalize);
+  Test('Template interpolation tracks line terminators', TestTemplateInterpolationTracksLineTerminators);
 end;
 
 procedure TLexerTests.AssertIgnoresLeadingHashbang(const ALineBreak: string);
@@ -176,6 +187,110 @@ begin
     Tokens := Lexer.ScanTokens;
     Expect<TGocciaTokenType>(Tokens[0].TokenType).ToBe(gttConst);
     Expect<Integer>(Tokens[0].Line).ToBe(2);
+  finally
+    Lexer.Free;
+  end;
+end;
+
+procedure TLexerTests.TestUnicodeLineTerminatorsInBlockComment;
+const
+  UTF8_LINE_SEPARATOR = #$E2#$80#$A8;
+  UTF8_PARAGRAPH_SEPARATOR = #$E2#$80#$A9;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+begin
+  Lexer := TGocciaLexer.Create('/* a' + UTF8_LINE_SEPARATOR + 'b */const x = 1;', '<test>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Expect<TGocciaTokenType>(Tokens[0].TokenType).ToBe(gttConst);
+    Expect<Integer>(Tokens[0].Line).ToBe(2);
+  finally
+    Lexer.Free;
+  end;
+
+  Lexer := TGocciaLexer.Create('/* a' + UTF8_PARAGRAPH_SEPARATOR + 'b */const x = 1;', '<test>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Expect<TGocciaTokenType>(Tokens[0].TokenType).ToBe(gttConst);
+    Expect<Integer>(Tokens[0].Line).ToBe(2);
+  finally
+    Lexer.Free;
+  end;
+end;
+
+procedure TLexerTests.TestRegexLiteralPreservesRawPattern;
+const
+  REGEX_SEPARATOR = #0;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+begin
+  Lexer := TGocciaLexer.Create('const value = /a\/b[\/]/gi;', '<test>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Expect<TGocciaTokenType>(Tokens[3].TokenType).ToBe(gttRegex);
+    Expect<string>(Tokens[3].Lexeme).ToBe('a\/b[\/]' + REGEX_SEPARATOR + 'gi');
+  finally
+    Lexer.Free;
+  end;
+end;
+
+procedure TLexerTests.TestRegexUnterminatedAtEOF;
+var
+  Lexer: TGocciaLexer;
+  Raised: Boolean;
+  MessageMatches: Boolean;
+begin
+  Lexer := TGocciaLexer.Create('const value = /', '<test>');
+  try
+    Raised := False;
+    MessageMatches := False;
+    try
+      Lexer.ScanTokens;
+    except
+      on E: TGocciaLexerError do
+      begin
+        Raised := True;
+        MessageMatches := Pos('Unterminated regular expression literal', E.Message) > 0;
+      end;
+    end;
+    Expect<Boolean>(Raised).ToBe(True);
+    Expect<Boolean>(MessageMatches).ToBe(True);
+  finally
+    Lexer.Free;
+  end;
+end;
+
+procedure TLexerTests.TestNumericSeparatorsNormalize;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+begin
+  Lexer := TGocciaLexer.Create('const a = 1_234.5_6e7_8; const b = 0xFF_FFn;', '<test>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Expect<TGocciaTokenType>(Tokens[3].TokenType).ToBe(gttNumber);
+    Expect<string>(Tokens[3].Lexeme).ToBe('1234.56e78');
+    Expect<TGocciaTokenType>(Tokens[8].TokenType).ToBe(gttBigInt);
+    Expect<string>(Tokens[8].Lexeme).ToBe('0xFFFF');
+  finally
+    Lexer.Free;
+  end;
+end;
+
+procedure TLexerTests.TestTemplateInterpolationTracksLineTerminators;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+begin
+  Lexer := TGocciaLexer.Create('`a${/* x' + #13#10 + '*/ 1}b`;const x = 1;', '<test>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Expect<TGocciaTokenType>(Tokens[0].TokenType).ToBe(gttTemplate);
+    Expect<TGocciaTokenType>(Tokens[2].TokenType).ToBe(gttConst);
+    Expect<Integer>(Tokens[2].Line).ToBe(2);
+    Expect<Integer>(Tokens[2].Column).ToBe(9);
   finally
     Lexer.Free;
   end;

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -37,11 +37,12 @@ type
     function GetSourceLines: TStringList;
 
     function IsAtEnd: Boolean; inline;
-    function Advance: Char;
+    function Advance: Char; inline;
     function Peek: Char; inline;
     function PeekNext: Char; inline;
     function Match(const AExpected: Char): Boolean; inline;
-    function IsValidIdentifierChar(const C: Char): Boolean;
+    function IsValidIdentifierChar(const C: Char): Boolean; inline;
+    procedure AppendCurrent(var ASB, ARawSB: TStringBuffer); inline;
     procedure AddToken(const ATokenType: TGocciaTokenType); overload;
     procedure AddToken(const ATokenType: TGocciaTokenType; const ALiteral: string); overload;
     procedure ScanToken;
@@ -75,9 +76,12 @@ type
     procedure SkipHashbang;
     procedure SkipComment;
     procedure SkipBlockComment;
+    procedure SkipUntilLineTerminator;
     function IsLineTerminator: Boolean; inline;
     function IsUnicodeLineTerminator: Boolean; inline;
-    procedure ConsumeUnicodeLineTerminator;
+    function ConsumeLineTerminator: Boolean; inline;
+    function AppendLineTerminator(var ASB, ARawSB: TStringBuffer): Boolean; inline;
+    procedure ConsumeUnicodeLineTerminator; inline;
   public
     constructor Create(const ASource, AFileName: string);
     destructor Destroy; override;
@@ -143,19 +147,19 @@ begin
   Result := FSourceLines;
 end;
 
-function TGocciaLexer.IsAtEnd: Boolean;
+function TGocciaLexer.IsAtEnd: Boolean; inline;
 begin
   Result := FCurrent > Length(FSource);
 end;
 
-function TGocciaLexer.Advance: Char;
+function TGocciaLexer.Advance: Char; inline;
 begin
   Result := FSource[FCurrent];
   Inc(FCurrent);
   Inc(FColumn);
 end;
 
-function TGocciaLexer.Peek: Char;
+function TGocciaLexer.Peek: Char; inline;
 begin
   if IsAtEnd then
     Result := #0
@@ -163,7 +167,7 @@ begin
     Result := FSource[FCurrent];
 end;
 
-function TGocciaLexer.PeekNext: Char;
+function TGocciaLexer.PeekNext: Char; inline;
 begin
   if FCurrent + 1 > Length(FSource) then
     Result := #0
@@ -190,6 +194,15 @@ begin
   Result := True;
 end;
 
+procedure TGocciaLexer.AppendCurrent(var ASB, ARawSB: TStringBuffer); inline;
+var
+  C: Char;
+begin
+  C := Advance;
+  ASB.AppendChar(C);
+  ARawSB.AppendChar(C);
+end;
+
 procedure TGocciaLexer.AddToken(const ATokenType: TGocciaTokenType);
 begin
   AddToken(ATokenType, Copy(FSource, FStart, FCurrent - FStart));
@@ -203,7 +216,7 @@ begin
 end;
 
 // ES2026 §12.3 LineTerminator :: <LF> | <CR> | <LS> | <PS>
-function TGocciaLexer.IsLineTerminator: Boolean;
+function TGocciaLexer.IsLineTerminator: Boolean; inline;
 begin
   if IsAtEnd then
     Exit(False);
@@ -216,7 +229,7 @@ begin
 end;
 
 // ES2026 §12.3 LS (U+2028) = UTF-8 E2 80 A8, PS (U+2029) = UTF-8 E2 80 A9
-function TGocciaLexer.IsUnicodeLineTerminator: Boolean;
+function TGocciaLexer.IsUnicodeLineTerminator: Boolean; inline;
 begin
   Result := (FSource[FCurrent] = UTF8_LINE_TERMINATOR_LEAD_BYTE) and
             (FCurrent + 2 <= Length(FSource)) and
@@ -225,11 +238,92 @@ begin
              (FSource[FCurrent + 2] = UTF8_PARAGRAPH_SEPARATOR_FINAL_BYTE));
 end;
 
-procedure TGocciaLexer.ConsumeUnicodeLineTerminator;
+procedure TGocciaLexer.ConsumeUnicodeLineTerminator; inline;
 begin
   Inc(FCurrent, UTF8_LINE_TERMINATOR_BYTE_LENGTH);
   Inc(FLine);
   FColumn := 1;
+end;
+
+function TGocciaLexer.ConsumeLineTerminator: Boolean; inline;
+begin
+  if IsAtEnd then
+    Exit(False);
+
+  case FSource[FCurrent] of
+    #13:
+      begin
+        Inc(FCurrent);
+        if (not IsAtEnd) and (FSource[FCurrent] = #10) then
+          Inc(FCurrent);
+        Inc(FLine);
+        FColumn := 1;
+        Result := True;
+      end;
+    #10:
+      begin
+        Inc(FCurrent);
+        Inc(FLine);
+        FColumn := 1;
+        Result := True;
+      end;
+    UTF8_LINE_TERMINATOR_LEAD_BYTE:
+      begin
+        Result := IsUnicodeLineTerminator;
+        if Result then
+          ConsumeUnicodeLineTerminator;
+      end;
+  else
+    Result := False;
+  end;
+end;
+
+function TGocciaLexer.AppendLineTerminator(var ASB, ARawSB: TStringBuffer): Boolean; inline;
+var
+  C: Char;
+  I: Integer;
+begin
+  if IsAtEnd then
+    Exit(False);
+
+  case FSource[FCurrent] of
+    #13:
+      begin
+        Inc(FCurrent);
+        if (not IsAtEnd) and (FSource[FCurrent] = #10) then
+          Inc(FCurrent);
+        Inc(FLine);
+        FColumn := 1;
+        ASB.AppendChar(#10);
+        ARawSB.AppendChar(#10);
+        Result := True;
+      end;
+    #10:
+      begin
+        Inc(FCurrent);
+        Inc(FLine);
+        FColumn := 1;
+        ASB.AppendChar(#10);
+        ARawSB.AppendChar(#10);
+        Result := True;
+      end;
+    UTF8_LINE_TERMINATOR_LEAD_BYTE:
+      begin
+        Result := IsUnicodeLineTerminator;
+        if Result then
+        begin
+          for I := 0 to UTF8_LINE_TERMINATOR_BYTE_LENGTH - 1 do
+          begin
+            C := FSource[FCurrent + I];
+            ASB.AppendChar(C);
+            ARawSB.AppendChar(C);
+          end;
+          ConsumeUnicodeLineTerminator;
+        end;
+      end;
+  else
+    Result := False;
+  end;
 end;
 
 procedure TGocciaLexer.SkipWhitespace;
@@ -240,25 +334,11 @@ begin
       ' ', #9:
         Advance;
       // ES2026 §12.3 LineTerminator — CR and CRLF
-      #13:
-        begin
-          Advance;
-          if (not IsAtEnd) and (Peek = #10) then
-            Advance;
-          Inc(FLine);
-          FColumn := 1;
-        end;
-      #10:
-        begin
-          Inc(FLine);
-          FColumn := 0;
-          Advance;
-        end;
+      #13, #10:
+        ConsumeLineTerminator;
       // ES2026 §12.3 Line Terminators — LS (U+2028) and PS (U+2029)
       UTF8_LINE_TERMINATOR_LEAD_BYTE:
-        if IsUnicodeLineTerminator then
-          ConsumeUnicodeLineTerminator
-        else
+        if not ConsumeLineTerminator then
           Break;
       '/':
         if PeekNext = '/' then
@@ -273,14 +353,28 @@ begin
   end;
 end;
 
+procedure TGocciaLexer.SkipUntilLineTerminator;
+var
+  C: Char;
+begin
+  while not IsAtEnd do
+  begin
+    C := FSource[FCurrent];
+    if (C = #10) or (C = #13) or
+       ((C = UTF8_LINE_TERMINATOR_LEAD_BYTE) and IsUnicodeLineTerminator) then
+      Break;
+    Inc(FCurrent);
+    Inc(FColumn);
+  end;
+end;
+
 // ES2026 §12.5 HashbangComment :: #! SingleLineCommentCharsₒₚₜ
 procedure TGocciaLexer.SkipHashbang;
 begin
   if (FCurrent <> 1) or (Length(FSource) < 2) or (Copy(FSource, 1, 2) <> '#!') then
     Exit;
 
-  while not IsAtEnd and not IsLineTerminator do
-    Advance;
+  SkipUntilLineTerminator;
 end;
 
 // ES2026 §12.4 SingleLineComment :: // SingleLineCommentCharsₒₚₜ
@@ -290,11 +384,12 @@ begin
   Advance;
   Advance;
 
-  while not IsAtEnd and not IsLineTerminator do
-    Advance;
+  SkipUntilLineTerminator;
 end;
 
 procedure TGocciaLexer.SkipBlockComment;
+var
+  C: Char;
 begin
   // Skip '/*'
   Advance;
@@ -302,35 +397,26 @@ begin
 
   while not IsAtEnd do
   begin
-    if Peek = '*' then
+    C := FSource[FCurrent];
+    if C = '*' then
     begin
-      Advance;
-      if Peek = '/' then
+      Inc(FCurrent);
+      Inc(FColumn);
+      if (not IsAtEnd) and (FSource[FCurrent] = '/') then
       begin
-        Advance; // Skip the closing '/'
+        Inc(FCurrent);
+        Inc(FColumn);
         Exit;
       end;
     end
-    // ES2026 §12.3 LineTerminator — CR and CRLF
-    else if Peek = #13 then
-    begin
-      Advance;
-      if (not IsAtEnd) and (Peek = #10) then
-        Advance;
-      Inc(FLine);
-      FColumn := 1;
-    end
-    else if Peek = #10 then
-    begin
-      Inc(FLine);
-      FColumn := 0;
-      Advance;
-    end
-    // ES2026 §12.3 Line Terminators — LS (U+2028) and PS (U+2029)
-    else if (Peek = UTF8_LINE_TERMINATOR_LEAD_BYTE) and IsUnicodeLineTerminator then
-      ConsumeUnicodeLineTerminator
+    else if (C = #13) or (C = #10) or
+            ((C = UTF8_LINE_TERMINATOR_LEAD_BYTE) and IsUnicodeLineTerminator) then
+      ConsumeLineTerminator
     else
-      Advance;
+    begin
+      Inc(FCurrent);
+      Inc(FColumn);
+    end;
   end;
 
   // If we reach here, we hit end of file without finding closing */
@@ -647,105 +733,45 @@ end;
 procedure TGocciaLexer.ScanNestedTemplateInExpression(var ASB, ARawSB: TStringBuffer);
 var
   C: Char;
-  J: Integer;
 begin
   while not IsAtEnd do
   begin
     C := Peek;
+    if ((C = #13) or (C = #10) or (C = UTF8_LINE_TERMINATOR_LEAD_BYTE)) and
+       AppendLineTerminator(ASB, ARawSB) then
+      Continue;
+
     case C of
       '`':
       begin
         // Closing backtick of nested template
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
+        AppendCurrent(ASB, ARawSB);
         Exit;
       end;
       '\':
       begin
         // Escape sequence — consume \ and next char verbatim
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
+        AppendCurrent(ASB, ARawSB);
         if not IsAtEnd then
-        begin
-          C := Advance;
-          ASB.AppendChar(C);
-          ARawSB.AppendChar(C);
-        end;
+          AppendCurrent(ASB, ARawSB);
       end;
       '$':
       begin
         if PeekNext = '{' then
         begin
           // Nested interpolation within nested template
-          Advance; // consume $
-          ASB.AppendChar('$');
-          ARawSB.AppendChar('$');
-          Advance; // consume {
-          ASB.AppendChar('{');
-          ARawSB.AppendChar('{');
+          AppendCurrent(ASB, ARawSB); // consume $
+          AppendCurrent(ASB, ARawSB); // consume {
           ScanInterpolationExpression(ASB, ARawSB);
           // ScanInterpolationExpression leaves the closing } unconsumed
           if not IsAtEnd then
-          begin
-            Advance; // consume }
-            ASB.AppendChar('}');
-            ARawSB.AppendChar('}');
-          end;
+            AppendCurrent(ASB, ARawSB); // consume }
         end
         else
-        begin
-          Advance;
-          ASB.AppendChar(C);
-          ARawSB.AppendChar(C);
-        end;
-      end;
-      #13:
-      begin
-        Advance;
-        if Peek = #10 then
-          Advance;
-        Inc(FLine);
-        FColumn := 1;
-        ASB.AppendChar(#10);
-        ARawSB.AppendChar(#10);
-      end;
-      #10:
-      begin
-        Inc(FLine);
-        FColumn := 0;
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
-      end;
-      UTF8_LINE_TERMINATOR_LEAD_BYTE:
-      begin
-        if IsUnicodeLineTerminator then
-        begin
-          for J := 0 to UTF8_LINE_TERMINATOR_BYTE_LENGTH - 1 do
-          begin
-            C := FSource[FCurrent + J];
-            ASB.AppendChar(C);
-            ARawSB.AppendChar(C);
-          end;
-          Inc(FCurrent, UTF8_LINE_TERMINATOR_BYTE_LENGTH);
-          Inc(FLine);
-          FColumn := 1;
-        end
-        else
-        begin
-          Advance;
-          ASB.AppendChar(C);
-          ARawSB.AppendChar(C);
-        end;
+          AppendCurrent(ASB, ARawSB);
       end;
     else
-      begin
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
-      end;
+      AppendCurrent(ASB, ARawSB);
     end;
   end;
 end;
@@ -767,216 +793,105 @@ end;
 //   - Line terminators (CR, CRLF, LF, LS, PS) with line/column tracking
 procedure TGocciaLexer.ScanInterpolationExpression(var ASB, ARawSB: TStringBuffer);
 var
-  BraceCount, J: Integer;
+  BraceCount: Integer;
   C, Quote: Char;
 begin
   BraceCount := 1;
   while (BraceCount > 0) and not IsAtEnd do
   begin
     C := Peek;
+    if ((C = #13) or (C = #10) or (C = UTF8_LINE_TERMINATOR_LEAD_BYTE)) and
+       AppendLineTerminator(ASB, ARawSB) then
+      Continue;
+
     case C of
       '{':
       begin
         Inc(BraceCount);
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
+        AppendCurrent(ASB, ARawSB);
       end;
       '}':
       begin
         Dec(BraceCount);
         if BraceCount > 0 then
-        begin
-          Advance;
-          ASB.AppendChar(C);
-          ARawSB.AppendChar(C);
-        end;
+          AppendCurrent(ASB, ARawSB);
         // When BraceCount = 0, leave the closing } unconsumed for the caller
       end;
       '''', '"':
       begin
         // String literal — scan until matching unescaped quote
         Quote := C;
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
+        AppendCurrent(ASB, ARawSB);
         while not IsAtEnd do
         begin
           C := Peek;
           if C = '\' then
           begin
             // Escape — consume \ and the next character verbatim
-            Advance;
-            ASB.AppendChar(C);
-            ARawSB.AppendChar(C);
+            AppendCurrent(ASB, ARawSB);
             if not IsAtEnd then
-            begin
-              C := Advance;
-              ASB.AppendChar(C);
-              ARawSB.AppendChar(C);
-            end;
+              AppendCurrent(ASB, ARawSB);
           end
           else if C = Quote then
           begin
-            Advance;
-            ASB.AppendChar(C);
-            ARawSB.AppendChar(C);
+            AppendCurrent(ASB, ARawSB);
             Break;
           end
+          else if ((C = #13) or (C = #10) or
+                   (C = UTF8_LINE_TERMINATOR_LEAD_BYTE)) and
+                  AppendLineTerminator(ASB, ARawSB) then
+            Continue
           else
-          begin
-            // Track line terminators inside strings
-            if C = #13 then
-            begin
-              Advance;
-              if Peek = #10 then
-                Advance;
-              Inc(FLine);
-              FColumn := 1;
-              ASB.AppendChar(#10);
-              ARawSB.AppendChar(#10);
-            end
-            else if C = #10 then
-            begin
-              Inc(FLine);
-              FColumn := 0;
-              Advance;
-              ASB.AppendChar(C);
-              ARawSB.AppendChar(C);
-            end
-            else
-            begin
-              Advance;
-              ASB.AppendChar(C);
-              ARawSB.AppendChar(C);
-            end;
-          end;
+            AppendCurrent(ASB, ARawSB);
         end;
       end;
       '`':
       begin
         // Nested template literal — delegate to mutual recursion
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
+        AppendCurrent(ASB, ARawSB);
         ScanNestedTemplateInExpression(ASB, ARawSB);
       end;
       '/':
       begin
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
+        AppendCurrent(ASB, ARawSB);
         if not IsAtEnd then
         begin
           if Peek = '/' then
           begin
             // Line comment — consume until line terminator (LF, CR, LS, PS)
-            C := Advance;
-            ASB.AppendChar(C);
-            ARawSB.AppendChar(C);
+            AppendCurrent(ASB, ARawSB);
             while not IsAtEnd and not IsLineTerminator do
-            begin
-              C := Advance;
-              ASB.AppendChar(C);
-              ARawSB.AppendChar(C);
-            end;
+              AppendCurrent(ASB, ARawSB);
           end
           else if Peek = '*' then
           begin
             // Block comment — consume until */
-            C := Advance; // consume *
-            ASB.AppendChar(C);
-            ARawSB.AppendChar(C);
+            AppendCurrent(ASB, ARawSB); // consume *
             while not IsAtEnd do
             begin
               C := Peek;
               if C = '*' then
               begin
-                Advance;
-                ASB.AppendChar(C);
-                ARawSB.AppendChar(C);
+                AppendCurrent(ASB, ARawSB);
                 if not IsAtEnd and (Peek = '/') then
                 begin
-                  C := Advance;
-                  ASB.AppendChar(C);
-                  ARawSB.AppendChar(C);
+                  AppendCurrent(ASB, ARawSB);
                   Break;
                 end;
               end
-              else if C = #13 then
-              begin
-                Advance;
-                if Peek = #10 then
-                  Advance;
-                Inc(FLine);
-                FColumn := 1;
-                ASB.AppendChar(#10);
-                ARawSB.AppendChar(#10);
-              end
-              else if C = #10 then
-              begin
-                Inc(FLine);
-                FColumn := 0;
-                Advance;
-                ASB.AppendChar(C);
-                ARawSB.AppendChar(C);
-              end
+              else if ((C = #13) or (C = #10) or
+                       (C = UTF8_LINE_TERMINATOR_LEAD_BYTE)) and
+                      AppendLineTerminator(ASB, ARawSB) then
+                Continue
               else
-              begin
-                Advance;
-                ASB.AppendChar(C);
-                ARawSB.AppendChar(C);
-              end;
+                AppendCurrent(ASB, ARawSB);
             end;
           end;
           // If neither // nor /*, the / was already appended — continue
         end;
       end;
-      #13:
-      begin
-        Advance;
-        if Peek = #10 then
-          Advance;
-        Inc(FLine);
-        FColumn := 1;
-        ASB.AppendChar(#10);
-        ARawSB.AppendChar(#10);
-      end;
-      #10:
-      begin
-        Inc(FLine);
-        FColumn := 0;
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
-      end;
-      UTF8_LINE_TERMINATOR_LEAD_BYTE:
-      begin
-        if IsUnicodeLineTerminator then
-        begin
-          for J := 0 to UTF8_LINE_TERMINATOR_BYTE_LENGTH - 1 do
-          begin
-            C := FSource[FCurrent + J];
-            ASB.AppendChar(C);
-            ARawSB.AppendChar(C);
-          end;
-          Inc(FCurrent, UTF8_LINE_TERMINATOR_BYTE_LENGTH);
-          Inc(FLine);
-          FColumn := 1;
-        end
-        else
-        begin
-          Advance;
-          ASB.AppendChar(C);
-          ARawSB.AppendChar(C);
-        end;
-      end;
     else
-      begin
-        Advance;
-        ASB.AppendChar(C);
-        ARawSB.AppendChar(C);
-      end;
+      AppendCurrent(ASB, ARawSB);
     end;
   end;
 end;
@@ -1096,39 +1011,12 @@ begin
   SegmentValid := True;
   while (Peek <> '`') and not IsAtEnd do
   begin
-    if Peek = #13 then
-    begin
-      Advance;
-      if Peek = #10 then
-        Advance;
-      Inc(FLine);
-      FColumn := 1;
-      // ES2026 §12.9.6: TV and TRV both normalize CR and CRLF to LF
-      SB.AppendChar(#10);
-      RawSB.AppendChar(#10);
-    end
-    else if Peek = #10 then
-    begin
-      Inc(FLine);
-      FColumn := 0;
-      C := Advance;
-      SB.AppendChar(C);
-      RawSB.AppendChar(C);
-    end
-    // ES2026 §12.9.6: TV = TRV; TRV of LS/PS preserves the original code point
-    else if (Peek = UTF8_LINE_TERMINATOR_LEAD_BYTE) and IsUnicodeLineTerminator then
-    begin
-      for J := 0 to UTF8_LINE_TERMINATOR_BYTE_LENGTH - 1 do
-      begin
-        C := FSource[FCurrent + J];
-        SB.AppendChar(C);
-        RawSB.AppendChar(C);
-      end;
-      Inc(FCurrent, UTF8_LINE_TERMINATOR_BYTE_LENGTH);
-      Inc(FLine);
-      FColumn := 1;
-    end
-    else if Peek = '\' then
+    C := Peek;
+    // ES2026 §12.9.6: CR/CRLF normalize to LF; LS/PS preserve their bytes.
+    if ((C = #13) or (C = #10) or (C = UTF8_LINE_TERMINATOR_LEAD_BYTE)) and
+       AppendLineTerminator(SB, RawSB) then
+      Continue
+    else if C = '\' then
     begin
       Advance; // consume '\'
       if not IsAtEnd then
@@ -1164,7 +1052,7 @@ begin
         end;
       end;
     end
-    else if (Peek = '$') and (PeekNext = '{') then
+    else if (C = '$') and (PeekNext = '{') then
     begin
       // Interpolation expression boundary — detect and record with lexical
       // awareness so braces inside strings, comments, and nested templates
@@ -1206,15 +1094,18 @@ procedure TGocciaLexer.ScanRegexLiteral;
 const
   REGEX_SEPARATOR = #0;
 var
-  PatternBuffer: TStringBuffer;
+  PatternStart: Integer;
+  Pattern: string;
   FlagsStart: Integer;
   Flags: string;
   InCharacterClass: Boolean;
+  SawClosingDelimiter: Boolean;
   C: Char;
   I: Integer;
 begin
-  PatternBuffer := TStringBuffer.Create;
+  PatternStart := FCurrent;
   InCharacterClass := False;
+  SawClosingDelimiter := False;
 
   // ES2026 §12.9.5: RegularExpressionNonTerminator :: SourceCharacter but not LineTerminator
   while not IsAtEnd do
@@ -1228,12 +1119,11 @@ begin
 
     if C = '\' then
     begin
-      PatternBuffer.AppendChar(C);
       if IsAtEnd or IsLineTerminator then
         raise TGocciaLexerError.Create('Unterminated regular expression literal',
           FLine, FColumn, FFileName, GetSourceLines,
           SSuggestCloseRegex);
-      PatternBuffer.AppendChar(Advance);
+      Advance;
       Continue;
     end;
 
@@ -1242,15 +1132,18 @@ begin
     else if (C = ']') and InCharacterClass then
       InCharacterClass := False
     else if (C = '/') and not InCharacterClass then
+    begin
+      SawClosingDelimiter := True;
       Break;
-
-    PatternBuffer.AppendChar(C);
+    end;
   end;
 
-  if IsAtEnd and ((FCurrent = 1) or (FSource[FCurrent - 1] <> '/')) then
+  if not SawClosingDelimiter then
     raise TGocciaLexerError.Create('Unterminated regular expression literal',
       FLine, FColumn, FFileName, GetSourceLines,
       SSuggestCloseRegex);
+
+  Pattern := Copy(FSource, PatternStart, FCurrent - PatternStart - 1);
 
   FlagsStart := FCurrent;
   while CharInSet(Peek, ['a'..'z', 'A'..'Z']) do
@@ -1274,7 +1167,7 @@ begin
       FLine, FColumn, FFileName, GetSourceLines,
       SSuggestRegexSuffixFlags);
 
-  AddToken(gttRegex, PatternBuffer.ToString + REGEX_SEPARATOR + Flags);
+  AddToken(gttRegex, Pattern + REGEX_SEPARATOR + Flags);
 end;
 
 // ES2026 §12.9.3 NumericLiteral
@@ -1466,7 +1359,7 @@ begin
   end;
 end;
 
-function TGocciaLexer.IsValidIdentifierChar(const C: Char): Boolean;
+function TGocciaLexer.IsValidIdentifierChar(const C: Char): Boolean; inline;
 begin
   Result := CharInSet(C, ValidIdentifierChars) or (Ord(C) > 127);
 end;


### PR DESCRIPTION
## Summary

- Simplify lexer hot paths for comments, line terminators, template interpolation, and regex literals.
- Keep numeric separator scanning expanded after benchmarked helper variants regressed decimal and radix-heavy cases.
- Add lexer regression tests plus a decision-log entry and point-in-time spike documentation for the measured tradeoffs.

## Verification

- `./format.pas --check`
- `./build.pas clean tests`
- `./build/Goccia.Lexer.Test`
- `./build.pas clean testrunner`
- `./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress`
- `git diff --check`
- pre-commit hooks: doc duplication, doc length, doc links, doc symbols, swimmies, Pascal format, markdown lint
