### PR TITLE
Fix changelog website grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,6 @@ All notable changes to GocciaScript are documented in this file.
 
 ## [0.7.0] - 2026-04-29
 
-### 🏗️ Internal
-
-- Update playground examples and controls (#447)
-
-### 🐛 Fixed
-
-- Fix generator continuation replay (#448)
-- Fix CSV and TSV header option examples (#452)
-
-### 📖 Other
-
-- Declare Content Signals in robots.txt (#449)
-
-### 🚀 Added
-
-- Add agent discovery Link headers (#450)
-- Enable markdown negotiation for agents (#451)
-- Implement WeakMap and WeakSet built-ins (#437)
-- Implement TC39 pattern matching (#438)
-
-## [nightly] - 2026-04-29
-
 ### ✨ Improved
 
 - Make fetch asynchronous with fetch manager (#396)
@@ -37,10 +15,25 @@ All notable changes to GocciaScript are documented in this file.
 - Improve REPL object previews with depth-aware formatting (#296)
 - Make import.meta tests account for Windows drive letters (#274)
 
+### 🌐 Website
+
+- Fix CSV and TSV header option examples (#452)
+- Add agent discovery Link headers (#450)
+- Declare Content Signals in robots.txt (#449)
+- Enable markdown negotiation for agents (#451)
+- Update playground examples and controls (#447)
+- Add website Browserslist config (#446)
+- Refine website landing and sandbox copy (#445)
+- Update website API execution endpoints (#444)
+- Fix Vercel ignore diff for shallow clones (#443)
+- Fix website labels, hero console alignment, and example file extensions (#423)
+- Unify website console output with shared ConsolePanel (#418)
+- Skip Vercel preview builds for non-website changes (#414)
+- Add Next.js 16 website (docs, playground, sandbox, install) (#407)
+
 ### 🏗️ Internal
 
 - Extract shared text semantics utilities (#439)
-- Update website API execution endpoints (#444)
 - Update copyright year in LICENSE file (#384)
 - Refactor engine around pluggable executors (#332)
 - Update ECMAScript edition references to 2027 (#323)
@@ -51,14 +44,13 @@ All notable changes to GocciaScript are documented in this file.
 
 ### 🐛 Fixed
 
-- Fix Vercel ignore diff for shallow clones (#443)
+- Fix generator continuation replay (#448)
 - Fix CI cross toolchain resource compiler (#442)
 - Fix ZonedDateTime DST-aware diff rounding (#435)
 - Fix Temporal BigInt duration overflow (#431)
 - Fix Windows parser CLI output assertions (#430)
 - Fix unsupported var recovery before block close (#427)
 - Fix for-of `continue` raising ReferenceError instead of skipping iteration (#425)
-- Fix website labels, hero console alignment, and example file extensions (#423)
 - Thread options through Temporal *.until / *.since methods (#417)
 - Fix Number toString scientific notation threshold and format (#415)
 - Fix decorator wrapper this-binding test gap and misdirecting warning (#416)
@@ -82,11 +74,8 @@ All notable changes to GocciaScript are documented in this file.
 
 ### 📖 Other
 
-- Refine website landing and sandbox copy (#445)
 - Embed IANA timezone data for Temporal (#440)
 - Unify CLI JSON reporting (#433)
-- Unify website console output with shared ConsolePanel (#418)
-- Skip Vercel preview builds for non-website changes (#414)
 - Strengthen test262 runner and ECMAScript edge-case coverage (#402)
 - Skip unsupported generator methods during parsing (#388)
 - Infer names for anonymous classes and object functions (#387)
@@ -114,7 +103,8 @@ All notable changes to GocciaScript are documented in this file.
 
 ### 🚀 Added
 
-- Add website Browserslist config (#446)
+- Implement WeakMap and WeakSet built-ins (#437)
+- Implement TC39 pattern matching (#438)
 - Add generator and async generator support (#432)
 - Add generated sources to CI FPC search path (#441)
 - Add native TLS transport backends (#428)
@@ -122,7 +112,6 @@ All notable changes to GocciaScript are documented in this file.
 - Implement smallestUnit, roundingMode, roundingIncrement for Temporal until/since (#424)
 - Add receiver brand checks to Set/Map prototype methods (#421)
 - Support destructuring into member expression targets (#413)
-- Add Next.js 16 website (docs, playground, sandbox, install) (#407)
 - Add fetch host allowlist support (#395)
 - Add fetch host allowlist support (#391)
 - Add opt-in `function` keyword support (`--compat-function`) (#390)

--- a/cliff.toml
+++ b/cliff.toml
@@ -16,7 +16,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim }}
 {% for commit in commits %}
-  - {{ commit.message | split(pat="\n") | first | trim }}
+  - {{ commit.message | split(pat="\n") | first | trim | trim_start_matches(pat="Website: ") }}
 {%- endfor %}
 {% endfor %}\n
 """
@@ -28,9 +28,22 @@ conventional_commits = false
 filter_unconventional = false
 split_commits = false
 protect_breaking_commits = false
-tag_pattern = "[0-9]*"
+tag_pattern = "^v?[0-9]+\\.[0-9]+\\.[0-9]+$"
 sort_commits = "newest"
+commit_preprocessors = [
+  # Keep website release work distinct from language/runtime changes.
+  # git-cliff does not expose changed paths to commit_parsers, so prefix the
+  # commit message before parsing when a commit touches website/.
+  { pattern = "(?s).*", replace_command = '''
+sh -c 'msg=$(cat); if git diff-tree --no-commit-id --name-only -r "$COMMIT_SHA" | grep -q "^website/"; then printf "Website: %s" "$msg"; else printf "%s" "$msg"; fi'
+''' },
+]
 commit_parsers = [
+  { message = "^(Website: )?Merge branch", skip = true },
+  { message = "^(Website: )?Merge pull request", skip = true },
+
+  { message = "^Website: ", group = "🌐 Website" },
+
   { message = "^Add ", group = "🚀 Added" },
   { message = "^Implement ", group = "🚀 Added" },
   { message = "^Support ", group = "🚀 Added" },
@@ -100,9 +113,6 @@ commit_parsers = [
   { message = "^Benchmark tests regression", group = "🏗️ Internal" },
   { message = "^Benchmark runner exit codes", group = "🏗️ Internal" },
   { message = "^Environment specific test failure", group = "🏗️ Internal" },
-
-  { message = "^Merge branch", skip = true },
-  { message = "^Merge pull request", skip = true },
 
   { message = ".*", group = "📖 Other" },
 ]

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -496,8 +496,9 @@ Commits are categorized by their leading verb into groups:
 | `Replace`, `Optimize`, `Promote`, `Eliminate`, `Bypass`, `Inline` | ⚡ Performance |
 | `Remove` | 🗑️ Removed |
 | `Refactor`, `Extract`, `Update`, `Strip` | 🏗️ Internal |
+| Commits touching `website/` | 🌐 Website |
 
-This table shows common prefixes. See `cliff.toml` for the complete list of patterns, which includes additional verb-specific and phrase-specific matchers.
+This table shows common prefixes. See `cliff.toml` for the complete list of patterns, which includes additional verb-specific and phrase-specific matchers. Website commits are detected by changed path before prefix grouping so site changes stay separate from language/runtime changes. Release sections are generated only for semver-style tags such as `0.7.0` or `v0.7.0`; moving tags such as `nightly` are ignored.
 
 ### Generating the Changelog
 

--- a/scripts/check-doc-length.ts
+++ b/scripts/check-doc-length.ts
@@ -32,6 +32,8 @@ const IGNORE_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next", "
 // Build artifacts whose contents are synced from elsewhere and validated at
 // the source location. Path-prefix matched against repo-relative paths.
 const IGNORE_PATH_PREFIXES = ["website/content/docs/"];
+// Generated history files are expected to grow past the human-doc line budget.
+const EXEMPT_FILES = new Set(["CHANGELOG.md"]);
 
 // Files that are inherently large by nature (API references, test catalogs)
 // get a higher limit.  The per-file override comment takes precedence.
@@ -88,10 +90,19 @@ const parseFileLimit = (content: string): number | null => {
 const main = (): void => {
   const files = findMarkdownFiles(ROOT);
   let failures = 0;
+  let exemptCount = 0;
   const results: { file: string; lines: number; limit: number }[] = [];
 
   for (const file of files) {
-    const rel = relative(ROOT, file);
+    const rel = relative(ROOT, file).split("\\").join("/");
+    if (EXEMPT_FILES.has(rel)) {
+      exemptCount++;
+      if (VERBOSE) {
+        console.log(`  SKIP  ${rel}: exempt from doc length limit`);
+      }
+      continue;
+    }
+
     const content = readFileSync(file, "utf-8");
     const lineCount = content.split("\n").length;
 
@@ -107,7 +118,10 @@ const main = (): void => {
     }
   }
 
-  console.log(`\nChecked ${files.length} files, default limit ${DEFAULT_LIMIT} lines.`);
+  const evaluatedCount = files.length - exemptCount;
+  console.log(
+    `\nDiscovered ${files.length} files; exempt ${exemptCount}; checked ${evaluatedCount}; default limit ${DEFAULT_LIMIT} lines.`,
+  );
 
   if (failures > 0) {
     console.log(`\n${failures} file(s) exceed their line limit.\n`);


### PR DESCRIPTION
## Summary
- group commits touching `website/` into a dedicated changelog Website section
- restrict git-cliff release sections to semver-style tags so `nightly` is ignored
- exempt generated `CHANGELOG.md` from the markdown document length checker
