### PR TITLE
Refresh docs and website to match recent feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [Language](docs/language.md) for the complete specification of supported fea
 
 ### Built-in Objects
 
-`console`, `Math`, `JSON`, `JSON5`, `TOML`, `YAML`, `JSONL`, `CSV`, `TSV`, `Object`, `Array`, `Number`, `String`, `RegExp`, `Symbol`, `Set`, `Map`, `WeakSet`, `WeakMap`, `Promise`, `Temporal`, `Iterator`, `Proxy`, `Reflect`, `ArrayBuffer`, `SharedArrayBuffer`, TypedArrays (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float32Array`, `Float64Array`) with ArrayBuffer and SharedArrayBuffer backing, `fetch`, `Headers`, `Response` ([WHATWG Fetch](https://fetch.spec.whatwg.org/) — GET/HEAD only), `URL`, `URLSearchParams`, `TextEncoder`, `TextDecoder`, plus error constructors (`Error`, `TypeError`, `ReferenceError`, `RangeError`, `DOMException`).
+`console`, `Math`, `JSON`, `JSON5`, `TOML`, `YAML`, `JSONL`, `CSV`, `TSV`, `Object`, `Array`, `Number`, `String`, `RegExp`, `Symbol`, `Set`, `Map`, `WeakSet`, `WeakMap`, `Promise`, `Temporal`, `Iterator`, `Proxy`, `Reflect`, `ArrayBuffer`, `SharedArrayBuffer`, TypedArrays (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float16Array`, `Float32Array`, `Float64Array`, `BigInt64Array`, `BigUint64Array`) with ArrayBuffer and SharedArrayBuffer backing, `fetch`, `Headers`, `Response` ([WHATWG Fetch](https://fetch.spec.whatwg.org/) — GET/HEAD only), `URL`, `URLSearchParams`, `TextEncoder`, `TextDecoder`, plus error constructors (`Error`, `TypeError`, `ReferenceError`, `RangeError`, `DOMException`).
 
 See [Built-in Objects](docs/built-ins.md) for the complete API reference.
 
@@ -126,7 +126,7 @@ See [Bytecode VM](docs/bytecode-vm.md) for the current bytecode backend architec
 
 ### Run Tests
 
-GocciaScript has 3400+ JavaScript unit tests covering language features, built-in objects, and edge cases.
+GocciaScript has 8000+ JavaScript unit tests covering language features, built-in objects, and edge cases.
 
 ```bash
 # Run all tests (GocciaScript TestRunner)

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -15,14 +15,14 @@ AI agents need to execute generated code in a constrained environment. GocciaScr
 
 - **No ambient authority** — Scripts cannot access the file system, network, or operating system unless the host explicitly grants it through the embedding API
 - **Sandboxed file system** *(not yet implemented)* — A virtual file system API that allows scripts to read and write files within a host-defined boundary, without access to the real file system
-- **Read-only network access** *(not yet implemented)* — A `fetch`-like API for HTTP GET requests, allowing scripts to retrieve data without the ability to send arbitrary requests or modify remote state
+- **Read-only network access** — A WHATWG `fetch` (GET/HEAD only) gated by an explicit host allowlist (`--allowed-host`); without an allowlist any call to `fetch` throws `TypeError`, so scripts cannot retrieve data or reach the network unless the host opts in
 - **Deterministic execution** — Same input produces the same output; no implicit global state leakage between executions
 - **Timeout enforcement** — The `--timeout` flag and embedding API allow hosts to kill runaway scripts
 - **Controlled built-in surface** — The host chooses which built-ins to expose via `TGocciaGlobalBuiltins` flags (see [Embedding](embedding.md))
 - **No eval** — `eval()` is excluded by design, preventing code injection from within scripts
-- **No function constructor** — The `function` keyword and `Function()` constructor are excluded, closing another dynamic code generation vector
+- **No dynamic code generation by default** — The `Function()` constructor is excluded unless the host opts in via `--unsafe-function-constructor`; the `function` keyword (declarations and expressions) is excluded by default and only re-enabled in compatibility mode via `--compat-function`
 
-The sandbox is a *reduced attack surface*, not a formally verified security boundary. The engine has not been audited by a third party. The sandboxing relies on the host not exposing dangerous APIs and on the absence of `eval`/`Function` preventing dynamic code generation.
+The sandbox is a *reduced attack surface*, not a formally verified security boundary. The engine has not been audited by a third party. The sandboxing relies on the host not exposing dangerous APIs, on `eval` being unconditionally absent, and on the host not opting in to `--unsafe-function-constructor` (which would re-enable dynamic code generation via `Function()`).
 
 ## Secondary: Embeddable Desktop Platform
 
@@ -36,7 +36,7 @@ Desktop applications built with FreePascal (Lazarus, command-line tools, game en
 ## What GocciaScript is Not
 
 - **Not a Node.js replacement** — No `require()`, no `node:` built-in modules, no event loop with I/O callbacks
-- **Not aiming for 100% ECMAScript conformance** — Features excluded by design (`var`, `function`, `==`, `eval`, traditional loops) will not be added. See [Language](language.md) for the full list.
+- **Not aiming for 100% ECMAScript conformance** — Features excluded by design (`==`, `eval`, traditional loops) will not be added. `var` and the `function` keyword are excluded by default but available as opt-in compatibility toggles (`--compat-var`, `--compat-function`). See [Language](language.md) for the full list.
 - **Not a formally verified sandbox** — The sandbox reduces attack surface but has not been independently audited
 - **Not performance-competitive with V8/SpiderMonkey** — GocciaScript prioritizes correctness, embeddability, and reduced attack surface over raw throughput
 

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -874,7 +874,7 @@ export function Landing({
                 className="info-term info-term-button"
                 aria-describedby="portable-runtime-tip"
               >
-                portable runtime under 5MB
+                portable runtime under 6MB
                 <span
                   id="portable-runtime-tip"
                   role="tooltip"


### PR DESCRIPTION
## Summary
- Updated **README.md** Built-in Objects list to include the recently added typed arrays (`Float16Array`, `BigInt64Array`, `BigUint64Array`) and bumped the test-count claim from `3400+` to `8000+` (the runner currently reports 8235 tests across 1041 files).
- Refreshed **docs/goals.md** so the security framing matches what actually shipped: `fetch` is no longer "not yet implemented" — it's a WHATWG GET/HEAD subset gated by `--allowed-host`. The `function`-constructor / `function`-keyword bullet is reframed around the `--unsafe-function-constructor` and `--compat-function` opt-ins, and the same framing is carried through the sandbox caveat paragraph and the "What GocciaScript is Not" section (so `var` and `function` are no longer listed as "will not be added").
- Updated the **website landing page** copy from "portable runtime under 5MB" to "portable runtime under 6MB".

This is a documentation-only pass — no behavior changes. The intent was to update existing claims that the last ~200 commits had falsified, not to add new sections.

## Test plan
- [x] `git diff` reviewed — only the three intended files change.
- [x] Pre-commit hooks pass (markdown lint, doc link check, doc symbol check, doc length, doc duplication is warning-only and unrelated to this diff).
- [x] Test count verified locally: `./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress --jobs=4` → 8235 tests across 1041 files.
- [ ] Visual check of the website landing page tooltip after Vercel preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)