### PR TITLE
Unify stdin handling across all three runners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaTestRunner tests -j 1 # Force sequential execution (no threading)
 ./build/GocciaTestRunner tests --asi --unsafe-ffi # Run all tests including FFI tests
 ./build/GocciaTestRunner tests --log=test-console.log # Capture console output to a log file
+printf 'test("two plus two", () => { expect(2 + 2).toBe(4); });\n' | ./build/GocciaTestRunner # Run a test source from stdin
 ./build/GocciaBenchmarkRunner benchmarks/ # Run all benchmarks
 ./build/GocciaBenchmarkRunner benchmarks --import-map=imports.json # Run benchmarks with an explicit import map
 ./build/GocciaBenchmarkRunner benchmarks/fibonacci.js # Run a specific benchmark

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -39,6 +39,53 @@ console.log("Stdin smoke (bytecode)...");
   if (!out.includes("Result: 4")) throw new Error(`Expected Result: 4, got: ${out}`);
 }
 
+// -- Stdin smoke (TestRunner) --------------------------------------------------
+
+console.log("Stdin smoke (TestRunner)...");
+{
+  const src = `test("two plus two", () => { expect(2 + 2).toBe(4); });\n`;
+
+  // No path arg -> stdin
+  const out = await $`echo ${src} | ${TESTRUNNER} --no-progress`.text();
+  if (!out.includes("Passed: 1")) throw new Error(`TestRunner stdin (no arg) expected Passed: 1, got: ${out}`);
+
+  // Sole "-" arg -> stdin
+  const outDash = await $`echo ${src} | ${TESTRUNNER} - --no-progress`.text();
+  if (!outDash.includes("Passed: 1")) throw new Error(`TestRunner stdin ("-" arg) expected Passed: 1, got: ${outDash}`);
+}
+
+// -- Stdin smoke (BenchmarkRunner) ---------------------------------------------
+
+console.log("Stdin smoke (BenchmarkRunner)...");
+{
+  const src = `suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n`;
+  const out = await $`echo ${src} | ${BENCHRUNNER} --no-progress 2>&1`.text();
+  if (!out.includes("sum")) throw new Error(`BenchmarkRunner stdin expected "sum" benchmark, got: ${out}`);
+
+  const outDash = await $`echo ${src} | ${BENCHRUNNER} - --no-progress 2>&1`.text();
+  if (!outDash.includes("sum")) throw new Error(`BenchmarkRunner stdin ("-" arg) expected "sum" benchmark, got: ${outDash}`);
+}
+
+// -- Stdin mixed-with-paths rejection (all three runners) ----------------------
+
+console.log("Stdin mixed-with-paths rejection (Loader, TestRunner, BenchmarkRunner)...");
+{
+  const tmp = mkdtempSync(join(tmpdir(), "goccia-stdin-mix-"));
+  try {
+    const f = join(tmp, "x.js");
+    writeFileSync(f, "1;\n");
+
+    for (const [bin, label] of [[LOADER, "Loader"], [TESTRUNNER, "TestRunner"], [BENCHRUNNER, "BenchmarkRunner"]] as const) {
+      const proc = await $`${bin} - ${f} 2>&1`.nothrow();
+      if (proc.exitCode === 0) throw new Error(`${label} should reject "-" mixed with file paths`);
+      if (!proc.text().includes("stdin supports only as the sole input path"))
+        throw new Error(`${label} mixed-path error missing unified message, got: ${proc.text()}`);
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 // -- --help (all 5 apps) -------------------------------------------------------
 
 console.log("--help (all 5 apps)...");

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -949,12 +949,22 @@ begin
 
   if APaths.Count = 0 then
     RunBenchmarksFromStdin(Reports, Mode, ShowProgress)
+  else if (APaths.Count = 1) and IsStdinPath(APaths[0]) then
+    RunBenchmarksFromStdin(Reports, Mode, ShowProgress)
   else
   begin
-    if (APaths.Count = 1) and IsStdinPath(APaths[0]) then
-      RunBenchmarksFromStdin(Reports, Mode, ShowProgress)
-    else
-      RunBenchmarks(APaths, Reports, Mode, ShowProgress);
+    { Reject mixing "-" with file paths so stdin cannot silently be
+      interleaved with on-disk files. Matches the rule enforced by
+      GocciaScriptLoader and GocciaTestRunner. }
+    for I := 0 to APaths.Count - 1 do
+      if IsStdinPath(APaths[I]) then
+      begin
+        WriteLn(StdErr,
+          'Error: stdin supports only as the sole input path.');
+        ExitCode := 1;
+        Exit;
+      end;
+    RunBenchmarks(APaths, Reports, Mode, ShowProgress);
   end;
 end;
 

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -1203,7 +1203,7 @@ begin
       begin
         if IsStdinPath(APaths[I]) then
           raise TGocciaParseError.Create(
-            '--output=json supports stdin only as the sole input path.');
+            'stdin supports only as the sole input path.');
         if DirectoryExists(APaths[I]) then
         begin
           TempFiles := FindAllFiles(APaths[I], ScriptExtensions);
@@ -1227,13 +1227,25 @@ begin
 
   if APaths.Count = 0 then
     RunScriptFromStdin
+  else if (APaths.Count = 1) and IsStdinPath(APaths[0]) then
+    RunScriptFromStdin
   else
+  begin
+    { Reject mixing "-" with file paths so stdin cannot silently be
+      interleaved with on-disk files. Matches the rule enforced by
+      --output=json mode and by GocciaTestRunner / GocciaBenchmarkRunner. }
+    for I := 0 to APaths.Count - 1 do
+      if IsStdinPath(APaths[I]) then
+        raise TGocciaParseError.Create(
+          'stdin supports only as the sole input path.');
+
     for I := 0 to APaths.Count - 1 do
     begin
       if I > 0 then
         WriteLn;
       RunScripts(APaths[I]);
     end;
+  end;
 end;
 
 { TScriptLoaderApp - HandleError }

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -30,6 +30,7 @@ uses
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.Parser,
+  Goccia.ScriptLoader.Input,
   Goccia.SourceMap,
   Goccia.Builtins.TestingLibrary,
   Goccia.CLI.JSON.Reporter,
@@ -129,10 +130,14 @@ type
     procedure ExecuteWithPaths(const APaths: TStringList); override;
     function GlobalBuiltins: TGocciaGlobalBuiltins; override;
   private
-    function RunGocciaScriptInterpreted(const AFileName: string): TTestFileResult;
-    function RunGocciaScriptBytecode(const AFileName: string): TTestFileResult;
-    function RunGocciaScript(const AFileName: string): TTestFileResult;
-    function RunScriptFromFile(const AFileName: string): TAggregatedTestResult;
+    function RunGocciaScriptInterpreted(const AFileName: string;
+      APreloadedSource: TStringList = nil): TTestFileResult;
+    function RunGocciaScriptBytecode(const AFileName: string;
+      APreloadedSource: TStringList = nil): TTestFileResult;
+    function RunGocciaScript(const AFileName: string;
+      APreloadedSource: TStringList = nil): TTestFileResult;
+    function RunScriptFromFile(const AFileName: string;
+      APreloadedSource: TStringList = nil): TAggregatedTestResult;
     function RunScriptsFromFiles(const AFiles: TStringList): TAggregatedTestResult;
     function RunScriptsFromFilesParallel(const AFiles: TStringList; const AJobCount: Integer): TAggregatedTestResult;
     procedure TestWorkerProc(const AFileName: string; const AIndex: Integer;
@@ -222,7 +227,7 @@ end;
 
 function TTestRunnerApp.UsageLine: string;
 begin
-  Result := '<path...> [options]';
+  Result := '[path...|-] [options]';
 end;
 
 procedure TTestRunnerApp.ExecuteWithPaths(const APaths: TStringList);
@@ -231,13 +236,27 @@ var
   I: Integer;
   AggregatedResult: TAggregatedTestResult;
   MemoryMeasurement: TCLIJSONMemoryMeasurement;
+  StdinSource: TStringList;
+  UseStdin: Boolean;
 begin
-  if APaths.Count = 0 then
-  begin
-    WriteLn(StdErr, 'Error: No paths specified. Run with --help for usage.');
-    ExitCode := 1;
-    Exit;
-  end;
+  { stdin support — match GocciaScriptLoader and GocciaBenchmarkRunner.
+    Source is read from stdin and tagged as <stdin> when either:
+      * no path arguments are supplied, OR
+      * the sole path argument is "-".
+    Mixing "-" with other paths is rejected so structured stdin input
+    cannot silently be interleaved with on-disk files. }
+  UseStdin := (APaths.Count = 0) or
+              ((APaths.Count = 1) and IsStdinPath(APaths[0]));
+
+  if (not UseStdin) and (APaths.Count > 1) then
+    for I := 0 to APaths.Count - 1 do
+      if IsStdinPath(APaths[I]) then
+      begin
+        WriteLn(StdErr,
+          'Error: stdin supports only as the sole input path.');
+        ExitCode := 1;
+        Exit;
+      end;
 
   { Publish per-test/per-describe deadlines to the testing library
     before any workers spawn. These globals are read-only after this
@@ -248,20 +267,27 @@ begin
   GTestRunnerDescribeTimeoutMs := FDescribeTimeout.ValueOr(0);
 
   Files := TStringList.Create;
+  StdinSource := nil;
   try
-    for I := 0 to APaths.Count - 1 do
+    if UseStdin then
     begin
-      if DirectoryExists(APaths[I]) then
-        Files.AddStrings(FindAllFiles(APaths[I], ScriptExtensions))
-      else if FileExists(APaths[I]) then
-        Files.Add(APaths[I])
-      else
+      StdinSource := ReadSourceFromText(Input);
+      Files.Add(STDIN_FILE_NAME);
+    end
+    else
+      for I := 0 to APaths.Count - 1 do
       begin
-        WriteLn(StdErr, 'Error: Path not found: ', APaths[I]);
-        ExitCode := 1;
-        Exit;
+        if DirectoryExists(APaths[I]) then
+          Files.AddStrings(FindAllFiles(APaths[I], ScriptExtensions))
+        else if FileExists(APaths[I]) then
+          Files.Add(APaths[I])
+        else
+        begin
+          WriteLn(StdErr, 'Error: Path not found: ', APaths[I]);
+          ExitCode := 1;
+          Exit;
+        end;
       end;
-    end;
 
     if not FNoProgress.Present then
     begin
@@ -277,7 +303,10 @@ begin
     begin
       if not FNoProgress.Present then
         WriteLn('[1/1] ', Files[0]);
-      AggregatedResult := RunScriptFromFile(Files[0]);
+      { Stdin is always a single source — the callee takes ownership of
+        StdinSource and frees it like a disk-loaded TStringList. }
+      AggregatedResult := RunScriptFromFile(Files[0], StdinSource);
+      StdinSource := nil;
     end
     else if GetJobCount(Files.Count) > 1 then
       AggregatedResult := RunScriptsFromFilesParallel(Files, GetJobCount(Files.Count))
@@ -305,6 +334,9 @@ begin
     end;
   finally
     Files.Free;
+    { StdinSource is normally consumed by RunScriptFromFile (which frees
+      it). Free here only if an early exit left it dangling. }
+    StdinSource.Free;
   end;
 end;
 
@@ -313,7 +345,8 @@ begin
   Result := [ggTestAssertions];
 end;
 
-function TTestRunnerApp.RunGocciaScriptInterpreted(const AFileName: string): TTestFileResult;
+function TTestRunnerApp.RunGocciaScriptInterpreted(const AFileName: string;
+  APreloadedSource: TStringList): TTestFileResult;
 var
   Source: TStringList;
   ScriptResult, FileResult: TGocciaObjectValue;
@@ -324,16 +357,21 @@ begin
 
   Source := nil;
   try
-    try
-      Source := CreateUTF8FileTextLines(ReadUTF8FileText(AFileName));
-    except
-      on E: EStreamError do
-      begin
-        if not GIsWorkerThread then
-          WriteLn('Error loading test file: ', E.Message);
-        MarkLoadError(ScriptResult, AFileName, E.Message);
-        Result := MakeEmptyTestResult(ScriptResult, E.Message);
-        Exit;
+    if Assigned(APreloadedSource) then
+      Source := APreloadedSource
+    else
+    begin
+      try
+        Source := CreateUTF8FileTextLines(ReadUTF8FileText(AFileName));
+      except
+        on E: EStreamError do
+        begin
+          if not GIsWorkerThread then
+            WriteLn('Error loading test file: ', E.Message);
+          MarkLoadError(ScriptResult, AFileName, E.Message);
+          Result := MakeEmptyTestResult(ScriptResult, E.Message);
+          Exit;
+        end;
       end;
     end;
 
@@ -400,7 +438,8 @@ begin
   end;
 end;
 
-function TTestRunnerApp.RunGocciaScriptBytecode(const AFileName: string): TTestFileResult;
+function TTestRunnerApp.RunGocciaScriptBytecode(const AFileName: string;
+  APreloadedSource: TStringList): TTestFileResult;
 var
   Source: TStringList;
   SourceText: string;
@@ -423,16 +462,21 @@ begin
 
   Source := nil;
   try
-    try
-      Source := CreateUTF8FileTextLines(ReadUTF8FileText(AFileName));
-    except
-      on E: EStreamError do
-      begin
-        if not GIsWorkerThread then
-          WriteLn('Error loading test file: ', E.Message);
-        MarkLoadError(ScriptResult, AFileName, E.Message);
-        Result := MakeEmptyTestResult(ScriptResult, E.Message);
-        Exit;
+    if Assigned(APreloadedSource) then
+      Source := APreloadedSource
+    else
+    begin
+      try
+        Source := CreateUTF8FileTextLines(ReadUTF8FileText(AFileName));
+      except
+        on E: EStreamError do
+        begin
+          if not GIsWorkerThread then
+            WriteLn('Error loading test file: ', E.Message);
+          MarkLoadError(ScriptResult, AFileName, E.Message);
+          Result := MakeEmptyTestResult(ScriptResult, E.Message);
+          Exit;
+        end;
       end;
     end;
 
@@ -578,15 +622,17 @@ begin
   end;
 end;
 
-function TTestRunnerApp.RunGocciaScript(const AFileName: string): TTestFileResult;
+function TTestRunnerApp.RunGocciaScript(const AFileName: string;
+  APreloadedSource: TStringList): TTestFileResult;
 begin
   case EngineOptions.Mode.ValueOr(emInterpreted) of
-    emInterpreted: Result := RunGocciaScriptInterpreted(AFileName);
-    emBytecode:    Result := RunGocciaScriptBytecode(AFileName);
+    emInterpreted: Result := RunGocciaScriptInterpreted(AFileName, APreloadedSource);
+    emBytecode:    Result := RunGocciaScriptBytecode(AFileName, APreloadedSource);
   end;
 end;
 
-function TTestRunnerApp.RunScriptFromFile(const AFileName: string): TAggregatedTestResult;
+function TTestRunnerApp.RunScriptFromFile(const AFileName: string;
+  APreloadedSource: TStringList): TAggregatedTestResult;
 var
   FileResult: TTestFileResult;
   FileFailedTests: TGocciaValue;
@@ -605,7 +651,7 @@ begin
   SetLength(Result.FileResults, 1);
   Result.FileResults[0].FileName := AFileName;
   try
-    FileResult := RunGocciaScript(AFileName);
+    FileResult := RunGocciaScript(AFileName, APreloadedSource);
     Result.TestResult := FileResult.TestResult;
     Result.TotalLexNanoseconds := FileResult.Timing.LexTimeNanoseconds;
     Result.TotalParseNanoseconds := FileResult.Timing.ParseTimeNanoseconds;


### PR DESCRIPTION
## Summary

- **`GocciaTestRunner` now accepts source from stdin** (tagged `<stdin>`) when invoked with no path arguments or with a sole `-`, matching the existing behavior of `GocciaScriptLoader` and `GocciaBenchmarkRunner`.
- **All three runners now reject `-` mixed with file paths** with the same unified error: `"stdin supports only as the sole input path."` Replaces `GocciaScriptLoader`'s JSON-mode-only error wording and `GocciaBenchmarkRunner`'s silent `Path not found: -` fallthrough.
- Shared primitives (`STDIN_FILE_NAME = '<stdin>'`, `IsStdinPath`, `ReadSourceFromText`) in `Goccia.ScriptLoader.Input.pas` are reused unchanged — TestRunner just wires them in.

## Unified rule (now identical across all three runners)

| Invocation | Behavior |
|---|---|
| zero path args | read stdin → run as `<stdin>` |
| sole `-` arg | read stdin → run as `<stdin>` |
| `-` mixed with paths | error: `stdin supports only as the sole input path.`, exit 1 |

## Test plan

- [x] `./build.pas testrunner loader benchmarkrunner` — all three build clean
- [x] `./format.pas --check` — passes (300 files)
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress` — passes (only pre-existing FFI fixture failures from missing `libfixture.dylib`)
- [x] `printf 'test(...)' | ./build/GocciaTestRunner` — runs, reports `Passed: 1`
- [x] `printf 'test(...)' | ./build/GocciaTestRunner -` — runs, reports `Passed: 1`
- [x] `echo ... | <runner> - somefile.js` — all three exit 1 with the unified error
- [x] `bun scripts/test-cli.ts` — new stdin and mixed-path smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)