### PR TITLE
Use static Vercel ignore config

### DIFF
--- a/website/scripts/vercel-ignore.sh
+++ b/website/scripts/vercel-ignore.sh
@@ -1,6 +1,8 @@
-const ignoreCommand = `
-target="\${VERCEL_GIT_COMMIT_SHA:-HEAD}"
-base="\${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}"
+#!/usr/bin/env bash
+set -u
+
+target="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+base="${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}"
 website_path="./"
 
 if [ -d "website" ] && [ -f "website/package.json" ]; then
@@ -32,22 +34,10 @@ if ! ensure_commit "$target"; then
   exit 1
 fi
 
-git diff --quiet "$base" "$target" -- "$website_path"
-`.trim();
+if git diff --quiet "$base" "$target" -- "$website_path"; then
+  echo "No website changes detected; skipping build."
+  exit 0
+fi
 
-export const config = {
-  framework: "nextjs",
-  buildCommand: "bun run build",
-  installCommand: "bun install --frozen-lockfile",
-  ignoreCommand,
-  functions: {
-    "src/app/api/execute/route.ts": {
-      maxDuration: 15,
-      memory: 1024,
-    },
-    "src/app/api/test/route.ts": {
-      maxDuration: 15,
-      memory: 1024,
-    },
-  },
-} as const;
+echo "Website changes detected; building."
+exit 1

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "bun run build",
+  "installCommand": "bun install --frozen-lockfile",
+  "ignoreCommand": "bash scripts/vercel-ignore.sh",
+  "functions": {
+    "src/app/api/execute/route.ts": {
+      "maxDuration": 15,
+      "memory": 1024
+    },
+    "src/app/api/test/route.ts": {
+      "maxDuration": 15,
+      "memory": 1024
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the programmatic `website/vercel.ts` deployment config with static `website/vercel.json`
- Move the website-scoped ignore logic into `website/scripts/vercel-ignore.sh`
- Preserve the existing SHA fallback and shallow-clone commit resolution while applying the same skip behavior to preview and production builds
