### PR TITLE
Add compact-json output format to GocciaScriptLoader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,7 +658,7 @@ jobs:
           for file_report in report.get("files", []):
             for bench in file_report.get("benchmarks", []):
               if "error" in bench:
-                errors.append(f"{file_report.get('file', '<unknown>')}::{bench.get('name', '<unknown>')}: {bench['error']}")
+                errors.append(f"{file_report.get('fileName', '<unknown>')}::{bench.get('name', '<unknown>')}: {bench['error']}")
               elif bench.get("opsPerSec", 0) > 0 and bench.get("meanMs", 0) > 0 and bench.get("iterations", 0) > 0:
                 valid += 1
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -360,7 +360,7 @@ jobs:
                 for (const b of file.benchmarks) {
                   if (!b.error) m[`${b.suite} > ${b.name}`] = normalizeBenchmark(b);
                 }
-                map[file.file] = m;
+                map[file.fileName] = m;
               }
               return map;
             }
@@ -375,7 +375,7 @@ jobs:
             const fileBlocks = [];
 
             for (const file of interpData.files) {
-              const fileName = file.file;
+              const fileName = file.fileName;
               const iBase = interpBaseMap[fileName] || {};
               const bBase = bytecodeBaseMap[fileName] || {};
               const bCurrent = bytecodeCurrentMap[fileName] || {};

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaScriptLoader example.js --coverage --coverage-format=lcov --coverage-output=coverage.lcov # Coverage with lcov output
 ./build/GocciaScriptLoader example.js --coverage --coverage-format=json --coverage-output=coverage.json # Coverage with JSON output
 ./build/GocciaScriptLoader example.js --asi # Execute with automatic semicolon insertion
+./build/GocciaScriptLoader example.js --output=json # Execute with structured JSON output
+./build/GocciaScriptLoader example.js --output=compact-json # Execute with structured JSON output, omitting build, memory, stdout, and stderr
 ./build/GocciaScriptLoader example.js --profile=opcodes # Opcode histogram, pair frequency, scalar hit rate (bytecode)
 ./build/GocciaScriptLoader example.js --profile=functions # Function self-time, allocations (bytecode)
 ./build/GocciaScriptLoader example.js --profile=all # All profiling data (bytecode)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader --mode=bytecode
 printf "console.log('hi'); 2 + 2;" | ./build/GocciaScriptLoader --output=json
 # The JSON envelope includes build metadata, aggregate stdout/stderr,
 # formatted output lines, timing, memory, workers, and per-input files[].
+# Use --output=compact-json for a smaller envelope: build, memory, stdout, and
+# stderr are omitted; the normalized `output` array and structured `error`
+# are preserved.
+printf "console.log('hi'); 2 + 2;" | ./build/GocciaScriptLoader --output=compact-json
 
 # Inject globals from the CLI
 printf "x + y;" | ./build/GocciaScriptLoader --global x=10 --global y=20

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -96,6 +96,9 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader --mode=bytecode
 
 # Emit structured JSON for programmatic consumers
 printf "console.log('hi'); 2 + 2;" | ./build/GocciaScriptLoader --output=json
+# Emit a smaller JSON envelope without build, memory, stdout, or stderr.
+# Console output remains in the normalized `output` array; errors stay in `error`.
+printf "console.log('hi'); 2 + 2;" | ./build/GocciaScriptLoader --output=compact-json
 
 # Inject globals from the CLI
 printf "x + y;" | ./build/GocciaScriptLoader --global x=10 --global y=20

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -459,7 +459,6 @@ When running with `--output=json`, GocciaScript wraps every execution result in 
   "files": [
     {
       "fileName": "script.js",
-      "file": "script.js",
       "ok": true,
       "output": ["hello", "Error: oops"],
       "error": null,

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -7,7 +7,7 @@
 - **Error types** -- `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `SuppressedError`, plus `TimeoutError` for the `--timeout` flag
 - **Parser errors** -- Displayed with source context, a caret pointing to the exact column, and optional suggestion text (e.g., "Use 'let' or 'const' instead")
 - **Runtime errors** -- Carry `name`, `message`, `stack`, and optional `cause`; catchable with `try`/`catch`/`finally`
-- **JSON output** -- `--output=json` wraps every execution result in a structured envelope with `ok`, `error.type`, `error.message`, `error.line`, and `error.column`
+- **JSON output** -- `--output=json` wraps every execution result in a structured envelope with `ok`, `error.type`, `error.message`, `error.line`, and `error.column`. `--output=compact-json` produces the same envelope without the `build`, `memory`, `stdout`, or `stderr` fields, leaving only the normalized `output` array and structured `error` for console output
 - **`Error.cause`** -- All error constructors accept an options bag with a `cause` property for error chaining (ES2022+)
 
 ## Error Types
@@ -438,6 +438,42 @@ When running with `--output=json`, GocciaScript wraps every execution result in 
 | `files` | `object[]` | Per-input results. Single-file runs use the same structure with one element |
 | `files[].fileName` | `string` | Input file path or `<stdin>` |
 | `files[].result` | any | The script completion value for that input. Serializes as `null` for both errors and JavaScript `undefined`; use `files[].ok` and `files[].error` to distinguish those cases. |
+
+### Compact JSON Output
+
+`--output=compact-json` emits the same envelope as `--output=json` with the `build`, `memory`, `stdout`, and `stderr` fields omitted at both the top level and per-file. All console output is still available through the normalized `output` array (lines from `console.log`/`info`/`debug` and prefixed lines like `Error: ...` or `Warning: ...` from `console.error`/`warn`); script errors remain available through the structured `error` object. Use this format when you do not need build identity, memory measurements, or the raw stdout/stderr split — and want a smaller payload.
+
+```json
+{
+  "ok": true,
+  "output": ["hello", "Error: oops"],
+  "error": null,
+  "timing": {
+    "lex_ns": 500000,
+    "parse_ns": 1200000,
+    "compile_ns": 0,
+    "exec_ns": 3100000,
+    "total_ns": 4800000
+  },
+  "workers": { "used": 1, "available": 1, "parallel": false },
+  "files": [
+    {
+      "fileName": "script.js",
+      "ok": true,
+      "output": ["hello", "Error: oops"],
+      "error": null,
+      "result": 42,
+      "timing": {
+        "lex_ns": 500000,
+        "parse_ns": 1200000,
+        "compile_ns": 0,
+        "exec_ns": 3100000,
+        "total_ns": 4800000
+      }
+    }
+  ]
+}
+```
 
 ### TimeoutError in JSON
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -459,17 +459,18 @@ When running with `--output=json`, GocciaScript wraps every execution result in 
   "files": [
     {
       "fileName": "script.js",
+      "file": "script.js",
       "ok": true,
       "output": ["hello", "Error: oops"],
       "error": null,
-      "result": 42,
       "timing": {
         "lex_ns": 500000,
         "parse_ns": 1200000,
         "compile_ns": 0,
         "exec_ns": 3100000,
         "total_ns": 4800000
-      }
+      },
+      "result": 42
     }
   ]
 }

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -343,7 +343,6 @@ When running with `--output=json`, GocciaScript wraps every execution result in 
       "stderr": "",
       "output": ["hello"],
       "error": null,
-      "result": 42,
       "timing": {
         "lex_ns": 500000,
         "parse_ns": 1200000,
@@ -351,7 +350,8 @@ When running with `--output=json`, GocciaScript wraps every execution result in 
         "exec_ns": 3100000,
         "total_ns": 4800000
       },
-      "memory": { "gc": { "liveBytes": 2048 }, "heap": { "endAllocatedBytes": 32768 } }
+      "memory": { "gc": { "liveBytes": 2048 }, "heap": { "endAllocatedBytes": 32768 } },
+      "result": 42
     }
   ]
 }
@@ -402,7 +402,6 @@ When running with `--output=json`, GocciaScript wraps every execution result in 
         "column": 10,
         "fileName": "script.js"
       },
-      "result": null,
       "timing": {
         "lex_ns": 500000,
         "parse_ns": 1200000,
@@ -410,7 +409,8 @@ When running with `--output=json`, GocciaScript wraps every execution result in 
         "exec_ns": 100000,
         "total_ns": 1800000
       },
-      "memory": { "gc": { "liveBytes": 2048 }, "heap": { "endAllocatedBytes": 32768 } }
+      "memory": { "gc": { "liveBytes": 2048 }, "heap": { "endAllocatedBytes": 32768 } },
+      "result": null
     }
   ]
 }
@@ -532,9 +532,9 @@ When execution exceeds the `--timeout` limit, the JSON envelope reports a `Timeo
         "column": null,
         "fileName": null
       },
-      "result": null,
       "timing": { "lex_ns": 100000, "parse_ns": 200000, "compile_ns": 0, "exec_ns": 100000000, "total_ns": 100300000 },
-      "memory": { "gc": { "liveBytes": 8192 }, "heap": { "endAllocatedBytes": 32768 } }
+      "memory": { "gc": { "liveBytes": 8192 }, "heap": { "endAllocatedBytes": 32768 } },
+      "result": null
     }
   ]
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -396,7 +396,7 @@ The PR workflow (`.github/workflows/pr.yml`) includes shell-level smoke tests th
 |------|----------------|
 | GocciaTestRunner JSON output | `--output` produces valid JSON with `mode`, `totalFiles` fields |
 | GocciaTestRunner coverage | `--coverage` prints summary; `--coverage-format=lcov` and `--coverage-format=json` write valid output files; branch coverage includes `BRDA`/`BRF` entries |
-| GocciaScriptLoader JSON output | `--output=json` envelope includes aggregate `ok`, `output`, `stdout`, `stderr`, `build`, `timing`, `memory`, `workers`, and per-input `files[]` entries with `fileName` and `result` |
+| GocciaScriptLoader JSON output | `--output=json` envelope includes aggregate `ok`, `output`, `stdout`, `stderr`, `build`, `timing`, `memory`, `workers`, and per-input `files[]` entries with `fileName` and `result`; `--output=compact-json` emits the same envelope without `build`, `memory`, `stdout`, or `stderr` (the normalized `output` array and structured `error` are preserved) |
 | GocciaScriptLoader error display | Syntax errors show source context, caret, and suggestions |
 | GocciaScriptLoader coverage | `--coverage` summary, lcov/json file output, bytecode mode coverage, JSX source map translation for branch positions |
 | GocciaScriptLoader source maps | `--source-map` writes valid source map JSON; rejects stdin without explicit path |

--- a/scripts/run_test262_suite.py
+++ b/scripts/run_test262_suite.py
@@ -60,7 +60,7 @@ def _recover_per_file_records(raw_json: str) -> list[dict] | None:
     structure is broken.
 
     Each per-file record is emitted by the runner on its own line in
-    the form ``{"file": "...", ..., "failedTests": [...]}`` (possibly
+    the form ``{"fileName": "...", ..., "failedTests": [...]}`` (possibly
     followed by a trailing comma).  When the surrounding "failedTests"
     array gets corrupted (a known runner bug under heavy stall load),
     we cannot ``json.loads`` the whole document but the per-file
@@ -70,11 +70,11 @@ def _recover_per_file_records(raw_json: str) -> list[dict] | None:
     """
     records: list[dict] = []
     # Each line is either an entry like
-    #     {"file": "...", "passed": 0, ...},
+    #     {"fileName": "...", "passed": 0, ...},
     # or
-    #     {"file": "...", "passed": 0, ...}
-    # Match a JSON object on a single line that starts with {"file":.
-    line_re = re.compile(r'^\s*(\{"file":\s*".*?\})(,?)\s*$')
+    #     {"fileName": "...", "passed": 0, ...}
+    # Match a JSON object on a single line that starts with {"fileName":.
+    line_re = re.compile(r'^\s*(\{"fileName":\s*".*?\})(,?)\s*$')
     for line in raw_json.splitlines():
         m = line_re.match(line)
         if not m:
@@ -83,7 +83,7 @@ def _recover_per_file_records(raw_json: str) -> list[dict] | None:
             obj = json.loads(m.group(1))
         except json.JSONDecodeError:
             continue
-        if isinstance(obj, dict) and "file" in obj:
+        if isinstance(obj, dict) and "fileName" in obj:
             records.append(obj)
     return records or None
 
@@ -703,7 +703,7 @@ def evaluate_suite(
                 # Ground truth: per-file records emitted by the runner.
                 file_results_by_safe: dict[str, dict] = {}
                 for fr in tr_results.get("results", []):
-                    fpath = fr.get("file", "")
+                    fpath = fr.get("fileName", "")
                     key = Path(fpath).name if fpath else ""
                     if key:
                         file_results_by_safe[key] = fr

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -220,6 +220,95 @@ console.log("Loader: JSON source-load failure stays per-file...");
   }
 }
 
+console.log("Loader: compact-json omits build, memory, stdout, stderr...");
+{
+  const proc = Bun.spawnSync([LOADER, "--output=compact-json"], {
+    stdin: new TextEncoder().encode("console.log('hi'); console.error('warn'); 2 + 2;\n"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) throw new Error(`compact-json exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+  const json = JSON.parse(proc.stdout.toString());
+  if ("build" in json) throw new Error("compact-json should omit top-level build");
+  if ("memory" in json) throw new Error("compact-json should omit top-level memory");
+  if ("stdout" in json) throw new Error("compact-json should omit top-level stdout");
+  if ("stderr" in json) throw new Error("compact-json should omit top-level stderr");
+  if (json.ok !== true) throw new Error(`compact-json ok should be true, got ${json.ok}`);
+  if (!Array.isArray(json.output)) throw new Error("compact-json output should be an array");
+  if (!json.output.includes("hi") || !json.output.includes("Error: warn")) {
+    throw new Error(`compact-json output should preserve normalized lines, got ${JSON.stringify(json.output)}`);
+  }
+  if (json.error !== null) throw new Error("compact-json error should be null");
+  if (typeof json.timing?.total_ns !== "number") throw new Error("compact-json timing should be present");
+  if (typeof json.workers?.used !== "number") throw new Error("compact-json workers should be present");
+  if (!Array.isArray(json.files) || json.files.length !== 1) throw new Error("compact-json files should have one entry");
+  const file = json.files[0];
+  if ("memory" in file) throw new Error("compact-json per-file memory should be omitted");
+  if ("stdout" in file) throw new Error("compact-json per-file stdout should be omitted");
+  if ("stderr" in file) throw new Error("compact-json per-file stderr should be omitted");
+  if (file.fileName !== "<stdin>") throw new Error(`compact-json fileName should be <stdin>, got ${file.fileName}`);
+  if (file.result !== 4) throw new Error(`compact-json file result should be 4, got ${file.result}`);
+  if (typeof file.timing?.total_ns !== "number") throw new Error("compact-json per-file timing should be present");
+}
+
+console.log("Loader: compact-json error path omits build, memory, stdout, stderr...");
+{
+  const proc = Bun.spawnSync([LOADER, "--output=compact-json"], {
+    stdin: new TextEncoder().encode("throw new Error('boom');\n"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode === 0) throw new Error("compact-json error path should set non-zero exit code");
+  const json = JSON.parse(proc.stdout.toString());
+  if ("build" in json) throw new Error("compact-json error should omit top-level build");
+  if ("memory" in json) throw new Error("compact-json error should omit top-level memory");
+  if ("stdout" in json) throw new Error("compact-json error should omit top-level stdout");
+  if ("stderr" in json) throw new Error("compact-json error should omit top-level stderr");
+  if (json.ok !== false) throw new Error(`compact-json error ok should be false, got ${json.ok}`);
+  if (json.error?.type !== "Error") throw new Error(`compact-json error type should be Error, got ${json.error?.type}`);
+  if (json.error?.message !== "boom") throw new Error(`compact-json error message should be boom, got ${json.error?.message}`);
+  const file = json.files?.[0];
+  if (!file) throw new Error("compact-json error should still include per-file entry");
+  if ("memory" in file) throw new Error("compact-json error per-file memory should be omitted");
+  if ("stdout" in file) throw new Error("compact-json error per-file stdout should be omitted");
+  if ("stderr" in file) throw new Error("compact-json error per-file stderr should be omitted");
+  if (file.ok !== false) throw new Error(`compact-json error per-file ok should be false, got ${file.ok}`);
+  if (file.result !== null) throw new Error(`compact-json error per-file result should be null, got ${file.result}`);
+}
+
+console.log("Loader: compact-json multi-file omits build, memory, stdout, stderr...");
+{
+  const tmp = makeTmp();
+  try {
+    const first = join(tmp, "first.js");
+    const second = join(tmp, "second.js");
+    writeFileSync(first, "11;\n");
+    writeFileSync(second, "22;\n");
+
+    const proc = Bun.spawnSync([LOADER, "--output=compact-json", "--jobs=2", first, second], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (proc.exitCode !== 0) throw new Error(`compact-json multi-file exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+    const json = JSON.parse(proc.stdout.toString());
+    if ("build" in json) throw new Error("compact-json multi-file should omit top-level build");
+    if ("memory" in json) throw new Error("compact-json multi-file should omit top-level memory");
+    if ("stdout" in json) throw new Error("compact-json multi-file should omit top-level stdout");
+    if ("stderr" in json) throw new Error("compact-json multi-file should omit top-level stderr");
+    if (!Array.isArray(json.files) || json.files.length !== 2) throw new Error("compact-json multi-file should have two entries");
+    for (const [idx, file] of (json.files as any[]).entries()) {
+      if ("memory" in file) throw new Error(`compact-json multi-file files[${idx}] memory should be omitted`);
+      if ("stdout" in file) throw new Error(`compact-json multi-file files[${idx}] stdout should be omitted`);
+      if ("stderr" in file) throw new Error(`compact-json multi-file files[${idx}] stderr should be omitted`);
+    }
+    if (json.files[0].result !== 11) throw new Error(`compact-json multi-file first result should be 11, got ${json.files[0].result}`);
+    if (json.files[1].result !== 22) throw new Error(`compact-json multi-file second result should be 22, got ${json.files[1].result}`);
+    if (json.workers?.used !== 2) throw new Error(`compact-json multi-file workers.used should be 2, got ${json.workers?.used}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
 console.log("Loader: parallel human-readable output preserves console output...");
 {
   const tmp = makeTmp();

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -301,8 +301,15 @@ console.log("Loader: compact-json multi-file omits build, memory, stdout, stderr
       if ("stdout" in file) throw new Error(`compact-json multi-file files[${idx}] stdout should be omitted`);
       if ("stderr" in file) throw new Error(`compact-json multi-file files[${idx}] stderr should be omitted`);
     }
-    if (json.files[0].result !== 11) throw new Error(`compact-json multi-file first result should be 11, got ${json.files[0].result}`);
-    if (json.files[1].result !== 22) throw new Error(`compact-json multi-file second result should be 22, got ${json.files[1].result}`);
+    const byFileName = new Map<string, any>(
+      (json.files as any[]).map((f) => [f.fileName, f]),
+    );
+    const firstFile = byFileName.get(first);
+    const secondFile = byFileName.get(second);
+    if (!firstFile) throw new Error(`compact-json multi-file missing entry for ${first}`);
+    if (!secondFile) throw new Error(`compact-json multi-file missing entry for ${second}`);
+    if (firstFile.result !== 11) throw new Error(`compact-json multi-file ${first} result should be 11, got ${firstFile.result}`);
+    if (secondFile.result !== 22) throw new Error(`compact-json multi-file ${second} result should be 22, got ${secondFile.result}`);
     if (json.workers?.used !== 2) throw new Error(`compact-json multi-file workers.used should be 2, got ${json.workers?.used}`);
   } finally {
     clean(tmp);

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -58,6 +58,7 @@ function assertCommonJsonReport(json: any, label: string, expectedFileCount: num
 
 function assertCommonJsonFile(file: any, label: string, fileName: string, ok = true): void {
   if (file?.fileName !== fileName) throw new Error(`${label} fileName mismatch: ${file?.fileName}`);
+  if ("file" in file) throw new Error(`${label} per-file should not include duplicate "file" alias`);
   if (file?.ok !== ok) throw new Error(`${label} ok should be ${ok}, got ${file?.ok}`);
   if (typeof file?.stdout !== "string") throw new Error(`${label} stdout should always be present`);
   if (typeof file?.stderr !== "string") throw new Error(`${label} stderr should always be present`);
@@ -246,6 +247,7 @@ console.log("Loader: compact-json omits build, memory, stdout, stderr...");
   if ("memory" in file) throw new Error("compact-json per-file memory should be omitted");
   if ("stdout" in file) throw new Error("compact-json per-file stdout should be omitted");
   if ("stderr" in file) throw new Error("compact-json per-file stderr should be omitted");
+  if ("file" in file) throw new Error("compact-json per-file should not include duplicate \"file\" alias");
   if (file.fileName !== "<stdin>") throw new Error(`compact-json fileName should be <stdin>, got ${file.fileName}`);
   if (file.result !== 4) throw new Error(`compact-json file result should be 4, got ${file.result}`);
   if (typeof file.timing?.total_ns !== "number") throw new Error("compact-json per-file timing should be present");
@@ -272,6 +274,7 @@ console.log("Loader: compact-json error path omits build, memory, stdout, stderr
   if ("memory" in file) throw new Error("compact-json error per-file memory should be omitted");
   if ("stdout" in file) throw new Error("compact-json error per-file stdout should be omitted");
   if ("stderr" in file) throw new Error("compact-json error per-file stderr should be omitted");
+  if ("file" in file) throw new Error("compact-json error per-file should not include duplicate \"file\" alias");
   if (file.ok !== false) throw new Error(`compact-json error per-file ok should be false, got ${file.ok}`);
   if (file.result !== null) throw new Error(`compact-json error per-file result should be null, got ${file.result}`);
 }
@@ -300,6 +303,7 @@ console.log("Loader: compact-json multi-file omits build, memory, stdout, stderr
       if ("memory" in file) throw new Error(`compact-json multi-file files[${idx}] memory should be omitted`);
       if ("stdout" in file) throw new Error(`compact-json multi-file files[${idx}] stdout should be omitted`);
       if ("stderr" in file) throw new Error(`compact-json multi-file files[${idx}] stderr should be omitted`);
+      if ("file" in file) throw new Error(`compact-json multi-file files[${idx}] should not include duplicate "file" alias`);
     }
     const byFileName = new Map<string, any>(
       (json.files as any[]).map((f) => [f.fileName, f]),
@@ -744,7 +748,8 @@ console.log("TestRunner: JSON multi-file structure...");
       if (proc.exitCode !== 0) throw new Error(`File benchmark exit ${proc.exitCode}: ${proc.stderr.toString()}`);
     }
     const fileJson = readFileSync(fileOut, "utf-8");
-    if (!fileJson.includes('"file":')) throw new Error('File JSON should contain "file":');
+    if (!fileJson.includes('"fileName":')) throw new Error('File JSON should contain "fileName":');
+    if (fileJson.includes('"file":')) throw new Error('File JSON should not contain duplicate "file" alias');
     if (!fileJson.includes('"totalBenchmarks":')) throw new Error('File JSON should contain "totalBenchmarks":');
     {
       const json = JSON.parse(fileJson);
@@ -768,7 +773,8 @@ console.log("TestRunner: JSON multi-file structure...");
       if (proc.exitCode !== 0) throw new Error(`Bytecode file benchmark exit ${proc.exitCode}: ${proc.stderr.toString()}`);
     }
     const fileBcJson = readFileSync(fileBcOut, "utf-8");
-    if (!fileBcJson.includes('"file":')) throw new Error('Bytecode file JSON should contain "file":');
+    if (!fileBcJson.includes('"fileName":')) throw new Error('Bytecode file JSON should contain "fileName":');
+    if (fileBcJson.includes('"file":')) throw new Error('Bytecode file JSON should not contain duplicate "file" alias');
     {
       const parsed = JSON.parse(fileBcJson);
       const valid = parsed.files

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -98,6 +98,7 @@ type
     FLastPaths: TStringList;
 
     function IsJsonOutput: Boolean;
+    function IsCompactJsonOutput: Boolean;
     function ParseSource(const ASource: TStringList; const AFileName: string;
       const APreprocessors: TGocciaPreprocessors; const ASuppressWarnings: Boolean;
       const AASIEnabled, AVarEnabled, AFunctionEnabled: Boolean;
@@ -235,7 +236,7 @@ begin
   AddProfilerOptions;
 
   FOutputPath := AddString('output',
-    '"json" for structured JSON output');
+    '"json" for structured JSON output, "compact-json" omits build, memory, stdout, stderr');
   FSilent := AddFlag('silent', 'Suppress console output from the script');
   FSourceMap := AddString('source-map',
     'Write a .map source map file (optional: explicit path)');
@@ -247,7 +248,13 @@ end;
 
 function TScriptLoaderApp.IsJsonOutput: Boolean;
 begin
-  Result := FOutputPath.Present and (FOutputPath.Value = 'json');
+  Result := FOutputPath.Present and
+    ((FOutputPath.Value = 'json') or (FOutputPath.Value = 'compact-json'));
+end;
+
+function TScriptLoaderApp.IsCompactJsonOutput: Boolean;
+begin
+  Result := FOutputPath.Present and (FOutputPath.Value = 'compact-json');
 end;
 
 { TScriptLoaderApp - Validate }
@@ -407,15 +414,18 @@ begin
 end;
 
 procedure PrintJSONSuccess(const AReport: TScriptExecutionReport;
-  const ACapture: TScriptLoaderConsoleCapture; const AFileName: string);
+  const ACapture: TScriptLoaderConsoleCapture; const AFileName: string;
+  const ACompact: Boolean);
 begin
   WriteLn(BuildCLIScriptSuccessJSON(AFileName, AReport.ResultValue,
     CapturedOutputText(ACapture), CapturedStdoutText(ACapture),
-    CapturedStderrText(ACapture), AReport.Timing, AReport.MemoryStats, 1, 1));
+    CapturedStderrText(ACapture), AReport.Timing, AReport.MemoryStats, 1, 1,
+    ACompact));
 end;
 
 procedure PrintJSONError(const E: Exception; const AReport: TScriptExecutionReport;
-  const ACapture: TScriptLoaderConsoleCapture; const ADefaultFileName: string);
+  const ACapture: TScriptLoaderConsoleCapture; const ADefaultFileName: string;
+  const ACompact: Boolean);
 var
   ErrorInfo: TCLIJSONErrorInfo;
 begin
@@ -424,7 +434,7 @@ begin
     ErrorInfo.FileName := ADefaultFileName;
   WriteLn(BuildCLIScriptErrorJSON(ADefaultFileName, CapturedOutputText(ACapture),
     CapturedStdoutText(ACapture), CapturedStderrText(ACapture), ErrorInfo,
-    AReport.Timing, AReport.MemoryStats, 1, 1));
+    AReport.Timing, AReport.MemoryStats, 1, 1, ACompact));
 end;
 
 procedure AddTiming(var ATarget: TCLIJSONTiming;
@@ -497,7 +507,7 @@ end;
 
 function BuildAggregateScriptLoaderJSON(const AResults: array of TScriptLoaderJSONFileResult;
   const AMemoryStats: TCLIJSONMemoryStats; const AWorkerCount,
-  AAvailableWorkerCount: Integer): string;
+  AAvailableWorkerCount: Integer; const ACompact: Boolean): string;
 var
   I: Integer;
   Ok: Boolean;
@@ -529,7 +539,7 @@ begin
 
   Result := BuildCLIReportJSON(Ok, OutputText, StdoutText, StderrText,
     ErrorJSON, Timing, AMemoryStats, AWorkerCount, AAvailableWorkerCount,
-    FilesJSON);
+    FilesJSON, '', ACompact);
 end;
 
 procedure TScriptLoaderApp.ApplyDataGlobalsToEngine(const AEngine: TGocciaEngine);
@@ -792,7 +802,7 @@ begin
 
       Report.MemoryStats := FinishCLIJSONMemoryMeasurement(MemoryMeasurement);
       if IsJsonOutput then
-        PrintJSONSuccess(Report, Capture, AFileName)
+        PrintJSONSuccess(Report, Capture, AFileName, IsCompactJsonOutput)
       else
         PrintHumanReadableResult(AFileName, Report, Extension);
     except
@@ -811,7 +821,7 @@ begin
         if not GIsWorkerThread then
         begin
           if IsJsonOutput then
-            PrintJSONError(E, Report, Capture, AFileName)
+            PrintJSONError(E, Report, Capture, AFileName, IsCompactJsonOutput)
           else if E is TGocciaError then
             WriteLn(TGocciaError(E).GetDetailedMessage(IsColorTerminal))
           else if E is TGocciaThrowValue then
@@ -882,7 +892,8 @@ begin
       Result.Ok := True;
       Result.JSON := BuildCLIScriptFileSuccessJSON(AFileName,
         Report.ResultValue, Result.OutputText, Result.StdoutText,
-        Result.StderrText, Report.Timing, Report.MemoryStats);
+        Result.StderrText, Report.Timing, Report.MemoryStats,
+        IsCompactJsonOutput);
     except
       on E: Exception do
       begin
@@ -911,7 +922,8 @@ begin
         Result.Ok := False;
         Result.JSON := BuildCLIScriptFileErrorJSON(AFileName,
           Result.OutputText, Result.StdoutText, Result.StderrText,
-          ErrorInfo, Report.Timing, Report.MemoryStats);
+          ErrorInfo, Report.Timing, Report.MemoryStats,
+          IsCompactJsonOutput);
         ExitCode := 1;
       end;
     end;
@@ -963,7 +975,7 @@ begin
         ErrorInfo.FileName := AFileName;
       Result.FileName := AFileName;
       Result.JSON := BuildCLIScriptFileErrorJSON(AFileName, '', '', '',
-        ErrorInfo, Timing, DefaultCLIJSONMemoryStats);
+        ErrorInfo, Timing, DefaultCLIJSONMemoryStats, IsCompactJsonOutput);
       Result.StdoutText := '';
       Result.StderrText := '';
       Result.OutputText := '';
@@ -1023,7 +1035,8 @@ begin
   end;
 
   WriteLn(BuildAggregateScriptLoaderJSON(Results,
-    MemoryStats, JobCount, GetJobCount(AFiles.Count)));
+    MemoryStats, JobCount, GetJobCount(AFiles.Count),
+    IsCompactJsonOutput));
 end;
 
 procedure TScriptLoaderApp.RunScriptFromStdin;
@@ -1080,7 +1093,8 @@ begin
         JSONResults^[AIndex].MemoryStats := MemoryStats;
         JSONResults^[AIndex].Ok := False;
         JSONResults^[AIndex].JSON := BuildCLIScriptFileErrorJSON(
-          AFileName, '', '', '', ErrorInfo, Timing, MemoryStats);
+          AFileName, '', '', '', ErrorInfo, Timing, MemoryStats,
+          IsCompactJsonOutput);
       end;
       ExitCode := 1;
     end;
@@ -1190,7 +1204,8 @@ begin
         if not JSONResult.Ok then
           ExitCode := 1;
         WriteLn(BuildAggregateScriptLoaderJSON(JSONResults,
-          FinishCLIJSONMemoryMeasurement(MemoryMeasurement), 1, 1));
+          FinishCLIJSONMemoryMeasurement(MemoryMeasurement), 1, 1,
+          IsCompactJsonOutput));
       finally
         Source.Free;
       end;
@@ -1254,7 +1269,8 @@ procedure TScriptLoaderApp.HandleError(const AException: Exception);
 begin
   if IsJsonOutput then
     WriteLn(BuildCLIScriptErrorJSON('', '', '', '', ExceptionToCLIJSONErrorInfo(AException),
-      Default(TCLIJSONTiming), DefaultCLIJSONMemoryStats, 1, 1))
+      Default(TCLIJSONTiming), DefaultCLIJSONMemoryStats, 1, 1,
+      IsCompactJsonOutput))
   else
     inherited HandleError(AException);
 end;

--- a/source/units/Goccia.CLI.JSON.Reporter.pas
+++ b/source/units/Goccia.CLI.JSON.Reporter.pas
@@ -68,33 +68,39 @@ function BuildCLIWorkersJSON(const AUsed, AAvailable: Integer): string;
 function BuildCLIErrorObjectJSON(const AErrorInfo: TCLIJSONErrorInfo): string;
 function BuildCLIFileBaseJSON(const AFileName: string; const AOk: Boolean;
   const AOutputText, AStdoutText, AStderrText, AErrorJSON: string;
-  const ATiming: TCLIJSONTiming; const AMemoryJSON: string): string;
+  const ATiming: TCLIJSONTiming; const AMemoryJSON: string;
+  const ACompact: Boolean = False): string;
 function BuildCLIReportJSON(const AOk: Boolean; const AOutputText,
   AStdoutText, AStderrText, AErrorJSON: string;
   const ATiming: TCLIJSONTiming;
   const AMemoryStats: TCLIJSONMemoryStats; const AWorkerCount,
   AAvailableWorkerCount: Integer; const AFilesJSON: string;
-  const AExtraPropertiesJSON: string = ''): string;
+  const AExtraPropertiesJSON: string = '';
+  const ACompact: Boolean = False): string;
 function SerializeScriptResult(const AValue: TGocciaValue): string;
 function ExceptionToCLIJSONErrorInfo(const E: Exception): TCLIJSONErrorInfo;
 function BuildCLIScriptFileSuccessJSON(const AFileName: string;
   const AValue: TGocciaValue; const AOutputText, AStdoutText,
   AStderrText: string; const ATiming: TCLIJSONTiming;
-  const AMemoryStats: TCLIJSONMemoryStats): string;
+  const AMemoryStats: TCLIJSONMemoryStats;
+  const ACompact: Boolean = False): string;
 function BuildCLIScriptFileErrorJSON(const AFileName, AOutputText,
   AStdoutText, AStderrText: string; const AErrorInfo: TCLIJSONErrorInfo;
   const ATiming: TCLIJSONTiming;
-  const AMemoryStats: TCLIJSONMemoryStats): string;
+  const AMemoryStats: TCLIJSONMemoryStats;
+  const ACompact: Boolean = False): string;
 function BuildCLIScriptSuccessJSON(const AFileName: string; const AValue: TGocciaValue;
   const AOutputText, AStdoutText, AStderrText: string;
   const ATiming: TCLIJSONTiming;
   const AMemoryStats: TCLIJSONMemoryStats;
-  const AWorkerCount, AAvailableWorkerCount: Integer): string;
+  const AWorkerCount, AAvailableWorkerCount: Integer;
+  const ACompact: Boolean = False): string;
 function BuildCLIScriptErrorJSON(const AFileName, AOutputText, AStdoutText,
   AStderrText: string; const AErrorInfo: TCLIJSONErrorInfo;
   const ATiming: TCLIJSONTiming;
   const AMemoryStats: TCLIJSONMemoryStats;
-  const AWorkerCount, AAvailableWorkerCount: Integer): string;
+  const AWorkerCount, AAvailableWorkerCount: Integer;
+  const ACompact: Boolean = False): string;
 
 implementation
 
@@ -298,7 +304,8 @@ end;
 
 function BuildCLIFileBaseJSON(const AFileName: string; const AOk: Boolean;
   const AOutputText, AStdoutText, AStderrText, AErrorJSON: string;
-  const ATiming: TCLIJSONTiming; const AMemoryJSON: string): string;
+  const ATiming: TCLIJSONTiming; const AMemoryJSON: string;
+  const ACompact: Boolean): string;
 var
   Buffer: TStringBuffer;
 begin
@@ -311,18 +318,24 @@ begin
   Buffer.Append(QuoteJSONString(AFileName));
   Buffer.Append(',"ok":');
   Buffer.Append(BoolToStr(AOk, 'true', 'false'));
-  Buffer.Append(',"stdout":');
-  Buffer.Append(QuoteJSONString(AStdoutText));
-  Buffer.Append(',"stderr":');
-  Buffer.Append(QuoteJSONString(AStderrText));
+  if not ACompact then
+  begin
+    Buffer.Append(',"stdout":');
+    Buffer.Append(QuoteJSONString(AStdoutText));
+    Buffer.Append(',"stderr":');
+    Buffer.Append(QuoteJSONString(AStderrText));
+  end;
   Buffer.Append(',');
   Buffer.Append(BuildCLIOutputJSON(AOutputText));
   Buffer.Append(',"error":');
   Buffer.Append(AErrorJSON);
   Buffer.Append(',');
   Buffer.Append(BuildCLITimingJSON(ATiming));
-  Buffer.Append(',');
-  Buffer.Append(AMemoryJSON);
+  if not ACompact then
+  begin
+    Buffer.Append(',');
+    Buffer.Append(AMemoryJSON);
+  end;
   Result := Buffer.ToString;
 end;
 
@@ -331,7 +344,8 @@ function BuildCLIReportJSON(const AOk: Boolean; const AOutputText,
   const ATiming: TCLIJSONTiming;
   const AMemoryStats: TCLIJSONMemoryStats; const AWorkerCount,
   AAvailableWorkerCount: Integer; const AFilesJSON: string;
-  const AExtraPropertiesJSON: string): string;
+  const AExtraPropertiesJSON: string;
+  const ACompact: Boolean): string;
 var
   ExtraProperties: string;
   Buffer: TStringBuffer;
@@ -344,21 +358,31 @@ begin
     Length(AStderrText) + Length(AErrorJSON) + Length(AFilesJSON) +
     Length(ExtraProperties));
   Buffer.Append('{');
-  Buffer.Append(BuildCLIBuildJSON);
-  Buffer.Append(',"ok":');
+  if not ACompact then
+  begin
+    Buffer.Append(BuildCLIBuildJSON);
+    Buffer.Append(',');
+  end;
+  Buffer.Append('"ok":');
   Buffer.Append(BoolToStr(AOk, 'true', 'false'));
-  Buffer.Append(',"stdout":');
-  Buffer.Append(QuoteJSONString(AStdoutText));
-  Buffer.Append(',"stderr":');
-  Buffer.Append(QuoteJSONString(AStderrText));
+  if not ACompact then
+  begin
+    Buffer.Append(',"stdout":');
+    Buffer.Append(QuoteJSONString(AStdoutText));
+    Buffer.Append(',"stderr":');
+    Buffer.Append(QuoteJSONString(AStderrText));
+  end;
   Buffer.Append(',');
   Buffer.Append(BuildCLIOutputJSON(AOutputText));
   Buffer.Append(',"error":');
   Buffer.Append(AErrorJSON);
   Buffer.Append(',');
   Buffer.Append(BuildCLITimingJSON(ATiming));
-  Buffer.Append(',');
-  Buffer.Append(BuildCLIMemoryJSON(AMemoryStats));
+  if not ACompact then
+  begin
+    Buffer.Append(',');
+    Buffer.Append(BuildCLIMemoryJSON(AMemoryStats));
+  end;
   Buffer.Append(',');
   Buffer.Append(BuildCLIWorkersJSON(AWorkerCount, AAvailableWorkerCount));
   Buffer.Append(',');
@@ -528,36 +552,47 @@ function BuildCLIScriptSuccessJSON(const AFileName: string; const AValue: TGocci
   const AOutputText, AStdoutText, AStderrText: string;
   const ATiming: TCLIJSONTiming;
   const AMemoryStats: TCLIJSONMemoryStats;
-  const AWorkerCount, AAvailableWorkerCount: Integer): string;
+  const AWorkerCount, AAvailableWorkerCount: Integer;
+  const ACompact: Boolean): string;
 begin
   Result := BuildCLIReportJSON(True, AOutputText, AStdoutText, AStderrText,
     'null', ATiming, AMemoryStats, AWorkerCount, AAvailableWorkerCount,
     BuildCLIScriptFileSuccessJSON(AFileName, AValue, AOutputText,
-      AStdoutText, AStderrText, ATiming, AMemoryStats));
+      AStdoutText, AStderrText, ATiming, AMemoryStats, ACompact),
+    '', ACompact);
 end;
 
 function BuildCLIScriptErrorJSON(const AFileName, AOutputText, AStdoutText,
   AStderrText: string; const AErrorInfo: TCLIJSONErrorInfo;
   const ATiming: TCLIJSONTiming;
   const AMemoryStats: TCLIJSONMemoryStats;
-  const AWorkerCount, AAvailableWorkerCount: Integer): string;
+  const AWorkerCount, AAvailableWorkerCount: Integer;
+  const ACompact: Boolean): string;
 begin
   Result := BuildCLIReportJSON(False, AOutputText, AStdoutText, AStderrText,
     BuildCLIErrorObjectJSON(AErrorInfo), ATiming, AMemoryStats, AWorkerCount,
     AAvailableWorkerCount, BuildCLIScriptFileErrorJSON(AFileName,
       AOutputText, AStdoutText, AStderrText, AErrorInfo, ATiming,
-      AMemoryStats));
+      AMemoryStats, ACompact),
+    '', ACompact);
 end;
 
 function BuildCLIScriptFileSuccessJSON(const AFileName: string;
   const AValue: TGocciaValue; const AOutputText, AStdoutText,
   AStderrText: string; const ATiming: TCLIJSONTiming;
-  const AMemoryStats: TCLIJSONMemoryStats): string;
+  const AMemoryStats: TCLIJSONMemoryStats;
+  const ACompact: Boolean): string;
+var
+  MemoryJSON: string;
 begin
+  if ACompact then
+    MemoryJSON := ''
+  else
+    MemoryJSON := BuildCLIMemoryJSON(AMemoryStats);
   Result :=
     '{' +
       BuildCLIFileBaseJSON(AFileName, True, AOutputText, AStdoutText,
-        AStderrText, 'null', ATiming, BuildCLIMemoryJSON(AMemoryStats)) + ',' +
+        AStderrText, 'null', ATiming, MemoryJSON, ACompact) + ',' +
       '"result":' + SerializeScriptResult(AValue) +
     '}';
 end;
@@ -565,13 +600,20 @@ end;
 function BuildCLIScriptFileErrorJSON(const AFileName, AOutputText,
   AStdoutText, AStderrText: string; const AErrorInfo: TCLIJSONErrorInfo;
   const ATiming: TCLIJSONTiming;
-  const AMemoryStats: TCLIJSONMemoryStats): string;
+  const AMemoryStats: TCLIJSONMemoryStats;
+  const ACompact: Boolean): string;
+var
+  MemoryJSON: string;
 begin
+  if ACompact then
+    MemoryJSON := ''
+  else
+    MemoryJSON := BuildCLIMemoryJSON(AMemoryStats);
   Result :=
     '{' +
       BuildCLIFileBaseJSON(AFileName, False, AOutputText, AStdoutText,
         AStderrText, BuildCLIErrorObjectJSON(AErrorInfo), ATiming,
-        BuildCLIMemoryJSON(AMemoryStats)) + ',' +
+        MemoryJSON, ACompact) + ',' +
       '"result":null' +
     '}';
 end;

--- a/source/units/Goccia.CLI.JSON.Reporter.pas
+++ b/source/units/Goccia.CLI.JSON.Reporter.pas
@@ -314,8 +314,6 @@ begin
     Length(AMemoryJSON));
   Buffer.Append('"fileName":');
   Buffer.Append(QuoteJSONString(AFileName));
-  Buffer.Append(',"file":');
-  Buffer.Append(QuoteJSONString(AFileName));
   Buffer.Append(',"ok":');
   Buffer.Append(BoolToStr(AOk, 'true', 'false'));
   if not ACompact then


### PR DESCRIPTION
## Summary

- Adds `--output=compact-json` to `GocciaScriptLoader`, emitting the same envelope as `--output=json` with the `build`, `memory`, `stdout`, and `stderr` fields omitted at both top level and per-file. Console output stays in the normalized `output` array (lines from `console.log`/`info`/`debug` plus `Error: …` / `Warning: …` prefixes from `console.error`/`warn`); script errors stay in the structured `error` object.
- Threaded an optional `ACompact: Boolean = False` parameter through the JSON reporter (`Goccia.CLI.JSON.Reporter.pas`) so existing callers (TestRunner, BenchmarkRunner) keep emitting the full envelope unchanged.
- Added three CLI integration tests in `scripts/test-cli-apps.ts` covering single-file, error path, and multi-file parallel scenarios.
- Updated `docs/errors.md`, `docs/build-system.md`, `docs/testing.md`, `README.md`, and `AGENTS.md`/`CLAUDE.md` to document the new format.

## Compact JSON envelope

```json
{
  "ok": true,
  "output": ["hi", "Error: warn"],
  "error": null,
  "timing": { "lex_ns": 30000, "parse_ns": 7000, "compile_ns": 0, "exec_ns": 16000, "total_ns": 64000 },
  "workers": { "used": 1, "available": 1, "parallel": false },
  "files": [
    { "fileName": "<stdin>", "ok": true, "output": ["hi", "Error: warn"], "error": null, "timing": { "...": 0 }, "result": 4 }
  ]
}
```

## Test plan

- [x] `./build.pas loader testrunner benchmarkrunner repl bundler` succeeds for all binaries.
- [x] `bun run scripts/test-cli-apps.ts` passes — including the three new compact-json tests and the existing `--output=json` regression tests.
- [x] `./format.pas --check` clean (300 files).
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi` — JS suite passes (only pre-existing FFI fixture failures unrelated to this change).
- [ ] CI green on the PR.