### PR TITLE
Add resource management example to playground

### DIFF
--- a/website/src/lib/examples.ts
+++ b/website/src/lib/examples.ts
@@ -154,6 +154,61 @@ for (const order is { total: const total } if (total > 10) of orders) {
 }`,
   },
   {
+    id: "resources",
+    label: "Resource management — using / await using",
+    desc: "TC39 explicit resource management: 'using' and 'await using' bindings auto-dispose at block exit, in reverse declaration order. DisposableStack collects an unknown number of resources.",
+    code: `// TC39 explicit resource management — automatic cleanup at block exit.
+class Grinder {
+  constructor(label) {
+    this.label = label;
+    console.log(\`→ \${label}: warming up\`);
+  }
+  grind(beans) {
+    return \`\${beans} grounds\`;
+  }
+  [Symbol.dispose]() {
+    console.log(\`← \${this.label}: cleaned\`);
+  }
+}
+
+class SteamWand {
+  constructor() {
+    console.log("→ wand: pressurized");
+  }
+  steam(milk) {
+    return \`foamed \${milk}\`;
+  }
+  async [Symbol.asyncDispose]() {
+    await Promise.resolve();
+    console.log("← wand: purged");
+  }
+}
+
+// Resources declared with 'using' / 'await using' auto-dispose
+// when the surrounding { } block exits — in reverse declaration order.
+{
+  using grinder = new Grinder("grinder");
+  await using wand = new SteamWand();
+
+  const shot = grinder.grind("Arabica");
+  const foam = wand.steam("oat");
+  console.log(\`  ☕ \${shot} + \${foam}\`);
+  // Block exit:
+  //   1. await wand[Symbol.asyncDispose]()
+  //   2. grinder[Symbol.dispose]()
+}
+
+// DisposableStack collects resources opened in a loop.
+{
+  using stack = new DisposableStack();
+  for (const drink of ["espresso", "cortado"]) {
+    stack.use(new Grinder(\`mill: \${drink}\`));
+  }
+  // 'stack' is itself bound with 'using', so it disposes
+  // every enrolled resource (LIFO) when the block ends.
+}`,
+  },
+  {
     id: "test-runner",
     label: "Test runner — describe / test / expect",
     desc: "GocciaTestRunner globals for suites, assertions, and runner output.",

--- a/website/src/lib/examples.ts
+++ b/website/src/lib/examples.ts
@@ -156,8 +156,8 @@ for (const order is { total: const total } if (total > 10) of orders) {
   {
     id: "resources",
     label: "Resource management — using / await using",
-    desc: "TC39 explicit resource management: 'using' and 'await using' bindings auto-dispose at block exit, in reverse declaration order. DisposableStack collects an unknown number of resources.",
-    code: `// TC39 explicit resource management — automatic cleanup at block exit.
+    desc: "ES2026 explicit resource management: 'using' and 'await using' bindings auto-dispose at block exit, in reverse declaration order. DisposableStack collects an unknown number of resources.",
+    code: `// ES2026 explicit resource management — automatic cleanup at block exit.
 class Grinder {
   constructor(label) {
     this.label = label;


### PR DESCRIPTION
## Summary

- Adds a new `id: "resources"` entry to the playground examples list, showcasing ES2026 explicit resource management end-to-end.
- The example covers: `using` with `Symbol.dispose` (sync), `await using` with `Symbol.asyncDispose` (async), reverse-order disposal across both kinds, and `DisposableStack` collecting an unknown number of resources opened in a loop.
- Each `using` declaration is wrapped in an explicit `{ }` block — this engine requires an explicit block scope for `using`, matching every test in `tests/language/explicit-resource-management/`. Function/arrow bodies on their own are not treated as block scopes here.
- Placed between `pattern-matching` and `test-runner`, alongside the other recent-language-feature demos.

> Note: explicit resource management reached Stage 4 in 2025 and is part of the official ECMAScript 2026 standard (see `docs/language-tables.md` and `docs/language.md` §"Explicit Resource Management"). The original draft of this PR mis-framed it as a TC39 proposal; corrected in `b554da36`.

## Testing

- [ ] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

What I verified locally for this PR (no engine code changes, so no regression surface for the JS suite):

- Ran the new example via `./build/GocciaScriptLoader` in both interpreter and bytecode modes — identical output, demonstrating LIFO disposal across `await using` (purges first) and `using`, plus stack-driven LIFO inside `DisposableStack`.
- `biome check src/lib/examples.ts` — passes with no findings.
- `tsc --noEmit` shows no errors in `examples.ts` (pre-existing missing-`@types/node`/`zod`/`next` errors in unrelated files were already there on `main`).

Documentation was already accurate (`docs/language.md` §"Explicit Resource Management" lines 137–157, `docs/language-tables.md` line 69).