### PR TITLE
Exclude changelog update PR from generated changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -41,6 +41,8 @@ sh -c 'msg=$(cat); if git diff-tree --no-commit-id --name-only -r "$COMMIT_SHA" 
 commit_parsers = [
   { message = "^(Website: )?Merge branch", skip = true },
   { message = "^(Website: )?Merge pull request", skip = true },
+  # Skip the auto-generated changelog update PR itself so it never lists itself.
+  { message = "^(Website: )?Update CHANGELOG", skip = true },
 
   { message = "^Website: ", group = "🌐 Website" },
 


### PR DESCRIPTION
## Summary

- Add a `^(Website: )?Update CHANGELOG` skip rule to `cliff.toml`, ordered before the catch-all `^Update ` parser so git-cliff filters out the auto-generated changelog PR commit before it can be grouped.
- Without this rule, the CI workflow's `Update CHANGELOG.md for ${VERSION}` commit (created at `.github/workflows/ci.yml:975`) was being matched by `^Update ` and bucketed into the next release's 🏗️ Internal section, so the changelog listed itself (e.g. `Update CHANGELOG.md for 0.6.1 (#293)` under 0.7.0).
- The pattern mirrors the existing `^(Website: )?Merge ...` skip rules so it stays robust against the path-based `Website: ` preprocessor.

## Test plan

- [ ] Re-run `git cliff` against the current history and confirm no `Update CHANGELOG.md for ...` line appears in the regenerated output.
- [ ] Confirm next release's auto-generated changelog PR is not self-referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)