### PR TITLE
Extend compact-json output to TestRunner and BenchmarkRunner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,9 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaTestRunner tests/language/expressions/ # Run a test category
 ./build/GocciaTestRunner tests --no-progress --exit-on-first-failure # CI mode
 ./build/GocciaTestRunner tests --silent # Suppress all console output
-./build/GocciaTestRunner tests --output=results.json # Write test results as JSON
+./build/GocciaTestRunner tests --output=results.json # Write test results as JSON to a file
+./build/GocciaTestRunner tests --output=json # Emit a structured JSON envelope to stdout
+./build/GocciaTestRunner tests --output=compact-json # Same envelope to stdout, omitting build, memory, stdout, and stderr
 ./build/GocciaTestRunner tests --mode=bytecode # Run tests via the Goccia bytecode VM
 ./build/GocciaTestRunner tests/language/asi --asi # Run ASI tests with automatic semicolon insertion
 ./build/GocciaTestRunner tests --coverage # Run tests with line and branch coverage
@@ -108,6 +110,7 @@ printf 'test("two plus two", () => { expect(2 + 2).toBe(4); });\n' | ./build/Goc
 ./build/GocciaBenchmarkRunner benchmarks/fibonacci.js # Run a specific benchmark
 printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/GocciaBenchmarkRunner # Run benchmark source from stdin
 ./build/GocciaBenchmarkRunner benchmarks --format=json --output=out.json # Export as JSON
+./build/GocciaBenchmarkRunner benchmarks --format=compact-json --output=out.json # Export as JSON, omitting build, memory, stdout, and stderr
 ./build/GocciaBenchmarkRunner benchmarks --format=console --format=json --output=out.json # Console + JSON
 ./build/GocciaBenchmarkRunner benchmarks --no-progress # Suppress progress (CI)
 ./build/GocciaBenchmarkRunner benchmarks --mode=bytecode # Benchmarks via the Goccia bytecode VM

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ printf "console.log('hi'); 2 + 2;" | ./build/GocciaScriptLoader --output=json
 # are preserved.
 printf "console.log('hi'); 2 + 2;" | ./build/GocciaScriptLoader --output=compact-json
 
+# The same `compact-json` value is accepted by GocciaTestRunner (via --output)
+# and GocciaBenchmarkRunner (via --format) for the same envelope.
+./build/GocciaTestRunner tests --output=compact-json
+./build/GocciaBenchmarkRunner benchmarks --format=compact-json --output=out.json
+
 # Inject globals from the CLI
 printf "x + y;" | ./build/GocciaScriptLoader --global x=10 --global y=20
 printf "name;" | ./build/GocciaScriptLoader --globals=context.json --output=json

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./bu
 ./build/GocciaBenchmarkRunner benchmarks --format=csv --output=results.csv
 ```
 
-The benchmark runner auto-calibrates iterations per benchmark, reports ops/sec with variance (CV%) and engine-level timing breakdown (lex/parse/execute). Output formats: `console` (default), `text`, `csv`, `json`. Calibration and measurement parameters are configurable via [environment variables](docs/benchmarks.md#configuring-benchmark-parameters).
+The benchmark runner auto-calibrates iterations per benchmark, reports ops/sec with variance (CV%) and engine-level timing breakdown (lex/parse/execute). Output formats: `console` (default), `text`, `csv`, `json`, `compact-json` (the same envelope as `json` without `build`, `memory`, `stdout`, or `stderr`). Calibration and measurement parameters are configurable via [environment variables](docs/benchmarks.md#configuring-benchmark-parameters).
 
 ## Quick Tour
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -100,6 +100,17 @@ printf "console.log('hi'); 2 + 2;" | ./build/GocciaScriptLoader --output=json
 # Console output remains in the normalized `output` array; errors stay in `error`.
 printf "console.log('hi'); 2 + 2;" | ./build/GocciaScriptLoader --output=compact-json
 
+# `compact-json` is recognised by every runner that emits JSON.
+# - GocciaTestRunner: pass it as the value of --output. `--output=json` and
+#   `--output=compact-json` emit JSON to stdout (suppressing the human-readable
+#   summary); any other --output value is treated as a file path that receives
+#   the full JSON envelope.
+./build/GocciaTestRunner tests --output=compact-json
+# - GocciaBenchmarkRunner: pass it as the value of --format alongside the
+#   existing console/text/csv/json options. `--output=<path>` still selects the
+#   destination file when provided.
+./build/GocciaBenchmarkRunner benchmarks --format=compact-json --output=out.json
+
 # Inject globals from the CLI
 printf "x + y;" | ./build/GocciaScriptLoader --global x=10 --global y=20
 printf "name;" | ./build/GocciaScriptLoader --globals=context.json --output=json

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -7,7 +7,7 @@
 - **Error types** -- `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `SuppressedError`, plus `TimeoutError` for the `--timeout` flag
 - **Parser errors** -- Displayed with source context, a caret pointing to the exact column, and optional suggestion text (e.g., "Use 'let' or 'const' instead")
 - **Runtime errors** -- Carry `name`, `message`, `stack`, and optional `cause`; catchable with `try`/`catch`/`finally`
-- **JSON output** -- `--output=json` wraps every execution result in a structured envelope with `ok`, `error.type`, `error.message`, `error.line`, and `error.column`. `--output=compact-json` produces the same envelope without the `build`, `memory`, `stdout`, or `stderr` fields, leaving only the normalized `output` array and structured `error` for console output
+- **JSON output** -- `--output=json` wraps every execution result in a structured envelope with `ok`, `error.type`, `error.message`, `error.line`, and `error.column`. `--output=compact-json` produces the same envelope without the `build`, `memory`, `stdout`, or `stderr` fields, leaving only the normalized `output` array and structured `error` for console output. The same `compact-json` value is recognised by `GocciaTestRunner` (via `--output`) and `GocciaBenchmarkRunner` (via `--format`).
 - **`Error.cause`** -- All error constructors accept an options bag with a `cause` property for error chaining (ES2022+)
 
 ## Error Types

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -394,9 +394,10 @@ The PR workflow (`.github/workflows/pr.yml`) includes shell-level smoke tests th
 
 | Area | What is checked |
 |------|----------------|
-| GocciaTestRunner JSON output | `--output` produces valid JSON with `mode`, `totalFiles` fields |
+| GocciaTestRunner JSON output | `--output=<file>` writes valid JSON with `mode`, `totalFiles` fields to a file; `--output=json` emits the same envelope to stdout and suppresses the human-readable summary; `--output=compact-json` emits the same stdout envelope without `build`, `memory`, `stdout`, or `stderr` |
 | GocciaTestRunner coverage | `--coverage` prints summary; `--coverage-format=lcov` and `--coverage-format=json` write valid output files; branch coverage includes `BRDA`/`BRF` entries |
 | GocciaScriptLoader JSON output | `--output=json` envelope includes aggregate `ok`, `output`, `stdout`, `stderr`, `build`, `timing`, `memory`, `workers`, and per-input `files[]` entries with `fileName` and `result`; `--output=compact-json` emits the same envelope without `build`, `memory`, `stdout`, or `stderr` (the normalized `output` array and structured `error` are preserved) |
+| GocciaBenchmarkRunner JSON output | `--format=json` writes the same JSON envelope as the loader and test runner; `--format=compact-json` emits the same envelope without `build`, `memory`, `stdout`, or `stderr` at the top level or per-file |
 | GocciaScriptLoader error display | Syntax errors show source context, caret, and suggestions |
 | GocciaScriptLoader coverage | `--coverage` summary, lcov/json file output, bytecode mode coverage, JSX source map translation for branch positions |
 | GocciaScriptLoader source maps | `--source-map` writes valid source map JSON; rejects stdin without explicit path |

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -613,7 +613,9 @@ console.log("TestRunner: --output=json keeps stdout clean when test throws...");
       [resolve(TESTRUNNER), file, "--no-progress", "--output=json"],
       { stdout: "pipe", stderr: "pipe" },
     );
-    // ExitCode is 1 because the test failed; stdout must still be parseable.
+    // ExitCode must be non-zero because the test failed; stdout must still be parseable.
+    if (proc.exitCode === 0)
+      throw new Error(`TestRunner --output=json with throwing test should exit non-zero, got 0`);
     const stdout = proc.stdout.toString();
     if (stdout.includes("Error: boom") && !stdout.startsWith("{"))
       throw new Error(`TestRunner --output=json should not leak diagnostic before JSON, got: ${stdout.slice(0, 200)}`);
@@ -625,8 +627,9 @@ console.log("TestRunner: --output=json keeps stdout clean when test throws...");
     }
     if (json.ok !== false) throw new Error(`TestRunner --output=json with throwing test should mark ok=false, got ${json.ok}`);
     if (json.failed !== 1) throw new Error(`TestRunner --output=json with throwing test should mark failed=1, got ${json.failed}`);
-    if (json.files?.[0]?.errorMessage?.length === 0)
-      throw new Error("TestRunner --output=json with throwing test should populate per-file errorMessage");
+    const errorMessage = json.files?.[0]?.errorMessage;
+    if (typeof errorMessage !== "string" || errorMessage.length === 0)
+      throw new Error(`TestRunner --output=json with throwing test should populate per-file errorMessage with a non-empty string, got: ${JSON.stringify(errorMessage)}`);
   } finally {
     clean(tmp);
   }

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -602,6 +602,88 @@ console.log("TestRunner: --output=json emits structured JSON envelope to stdout.
   }
 }
 
+console.log("TestRunner: --output=json keeps stdout clean when test throws...");
+{
+  const tmp = makeTmp();
+  try {
+    const file = join(tmp, "test-throws.js");
+    writeFileSync(file, 'throw new Error("boom");\n');
+
+    const proc = Bun.spawnSync(
+      [resolve(TESTRUNNER), file, "--no-progress", "--output=json"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    // ExitCode is 1 because the test failed; stdout must still be parseable.
+    const stdout = proc.stdout.toString();
+    if (stdout.includes("Error: boom") && !stdout.startsWith("{"))
+      throw new Error(`TestRunner --output=json should not leak diagnostic before JSON, got: ${stdout.slice(0, 200)}`);
+    let json: any;
+    try {
+      json = JSON.parse(stdout);
+    } catch (e) {
+      throw new Error(`TestRunner --output=json with throwing test should produce parseable JSON, got: ${stdout.slice(0, 200)}`);
+    }
+    if (json.ok !== false) throw new Error(`TestRunner --output=json with throwing test should mark ok=false, got ${json.ok}`);
+    if (json.failed !== 1) throw new Error(`TestRunner --output=json with throwing test should mark failed=1, got ${json.failed}`);
+    if (json.files?.[0]?.errorMessage?.length === 0)
+      throw new Error("TestRunner --output=json with throwing test should populate per-file errorMessage");
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("TestRunner: --output=json keeps stdout clean when script logs to console...");
+{
+  const tmp = makeTmp();
+  try {
+    const file = join(tmp, "test-with-log.js");
+    writeFileSync(
+      file,
+      [
+        'console.log("THIS WOULD LEAK");',
+        'console.error("THIS TOO");',
+        'test("ok", () => { expect(1).toBe(1); });',
+        "",
+      ].join("\n"),
+    );
+
+    const proc = Bun.spawnSync(
+      [resolve(TESTRUNNER), file, "--no-progress", "--output=json"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (proc.exitCode !== 0) throw new Error(`TestRunner --output=json with console output exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+    const stdout = proc.stdout.toString();
+    if (stdout.includes("THIS WOULD LEAK") || stdout.includes("THIS TOO"))
+      throw new Error(`TestRunner --output=json should suppress test-script console output, got: ${stdout.slice(0, 200)}`);
+    const json = JSON.parse(stdout);
+    if (json.ok !== true) throw new Error(`TestRunner --output=json with console output ok should be true, got ${json.ok}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("TestRunner: --output=json keeps stdout clean when --coverage is enabled...");
+{
+  const tmp = makeTmp();
+  try {
+    const file = join(tmp, "test-coverage.js");
+    writeFileSync(file, 'test("ok", () => { expect(1 + 1).toBe(2); });\n');
+
+    const proc = Bun.spawnSync(
+      [resolve(TESTRUNNER), file, "--no-progress", "--output=json", "--coverage"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (proc.exitCode !== 0) throw new Error(`TestRunner --output=json --coverage exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+    const stdout = proc.stdout.toString();
+    if (stdout.includes("Coverage Summary"))
+      throw new Error(`TestRunner --output=json should suppress coverage summary on stdout, got: ${stdout.slice(0, 200)}`);
+    const json = JSON.parse(stdout);
+    if (json.ok !== true) throw new Error(`TestRunner --output=json --coverage ok should be true, got ${json.ok}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
 console.log("TestRunner: --output=compact-json omits build, memory, stdout, stderr...");
 {
   const tmp = makeTmp();

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -566,6 +566,107 @@ console.log("TestRunner: JSON multi-file structure...");
   }
 }
 
+console.log("TestRunner: --output=json emits structured JSON envelope to stdout...");
+{
+  const tmp = makeTmp();
+  try {
+    const file = join(tmp, "test-stdout-json.js");
+    writeFileSync(
+      file,
+      [
+        'describe("a", () => {',
+        '  test("passes", () => { expect(1 + 1).toBe(2); });',
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const proc = Bun.spawnSync(
+      [resolve(TESTRUNNER), file, "--no-progress", "--output=json"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (proc.exitCode !== 0) throw new Error(`TestRunner --output=json exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+
+    const stdout = proc.stdout.toString();
+    if (stdout.includes("Test Results"))
+      throw new Error(`TestRunner --output=json should suppress human-readable summary, got: ${stdout}`);
+    const json = JSON.parse(stdout);
+    assertCommonJsonReport(json, "TestRunner --output=json", 1);
+    if (json.ok !== true) throw new Error(`TestRunner --output=json ok should be true, got ${json.ok}`);
+    if (json.totalFiles !== 1) throw new Error(`TestRunner --output=json totalFiles should be 1, got ${json.totalFiles}`);
+    if (json.passed !== 1 || json.failed !== 0)
+      throw new Error(`TestRunner --output=json pass/fail mismatch: ${json.passed}/${json.failed}`);
+    assertCommonJsonFile(json.files[0], "TestRunner --output=json file", file);
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("TestRunner: --output=compact-json omits build, memory, stdout, stderr...");
+{
+  const tmp = makeTmp();
+  try {
+    const first = join(tmp, "test-compact-a.js");
+    const second = join(tmp, "test-compact-b.js");
+    writeFileSync(
+      first,
+      [
+        'describe("a", () => {',
+        '  test("passes a", () => { expect(1 + 1).toBe(2); });',
+        "});",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      second,
+      [
+        'describe("b", () => {',
+        '  test("passes b", () => { expect(2 + 2).toBe(4); });',
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const proc = Bun.spawnSync(
+      [resolve(TESTRUNNER), first, second, "--no-progress", "--jobs=2", "--output=compact-json"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (proc.exitCode !== 0) throw new Error(`TestRunner --output=compact-json exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+
+    const stdout = proc.stdout.toString();
+    if (stdout.includes("Test Results"))
+      throw new Error(`TestRunner --output=compact-json should suppress human-readable summary, got: ${stdout}`);
+    const json = JSON.parse(stdout);
+    if ("build" in json) throw new Error("TestRunner --output=compact-json should omit top-level build");
+    if ("memory" in json) throw new Error("TestRunner --output=compact-json should omit top-level memory");
+    if ("stdout" in json) throw new Error("TestRunner --output=compact-json should omit top-level stdout");
+    if ("stderr" in json) throw new Error("TestRunner --output=compact-json should omit top-level stderr");
+    if (json.ok !== true) throw new Error(`TestRunner --output=compact-json ok should be true, got ${json.ok}`);
+    if (json.totalFiles !== 2) throw new Error(`TestRunner --output=compact-json totalFiles should be 2, got ${json.totalFiles}`);
+    if (json.passed !== 2 || json.failed !== 0)
+      throw new Error(`TestRunner --output=compact-json pass/fail mismatch: ${json.passed}/${json.failed}`);
+    if (typeof json.timing?.total_ns !== "number")
+      throw new Error("TestRunner --output=compact-json timing should be present");
+    if (typeof json.workers?.used !== "number")
+      throw new Error("TestRunner --output=compact-json workers should be present");
+    if (!Array.isArray(json.files) || json.files.length !== 2)
+      throw new Error("TestRunner --output=compact-json files should have two entries");
+    for (const [idx, file] of (json.files as any[]).entries()) {
+      if ("memory" in file) throw new Error(`TestRunner --output=compact-json files[${idx}] memory should be omitted`);
+      if ("stdout" in file) throw new Error(`TestRunner --output=compact-json files[${idx}] stdout should be omitted`);
+      if ("stderr" in file) throw new Error(`TestRunner --output=compact-json files[${idx}] stderr should be omitted`);
+      if (typeof file.fileName !== "string")
+        throw new Error(`TestRunner --output=compact-json files[${idx}] fileName should be present`);
+      if (typeof file.timing?.total_ns !== "number")
+        throw new Error(`TestRunner --output=compact-json files[${idx}] timing should be present`);
+      if (file.passed !== 1 || file.failed !== 0)
+        throw new Error(`TestRunner --output=compact-json files[${idx}] pass/fail mismatch: ${JSON.stringify(file)}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
 // -- Source maps (Loader) -------------------------------------------------------
 
 {
@@ -817,6 +918,36 @@ console.log("TestRunner: JSON multi-file structure...");
       if (json.files[1].benchmarks?.[0]?.name !== "two") throw new Error(`Benchmark second file entry mismatch: ${JSON.stringify(json.files[1].benchmarks)}`);
       if (json.files[0].memory !== null || json.files[1].memory !== null)
         throw new Error("Benchmark multi-file per-file memory should be null when top-level memory is aggregated");
+    }
+
+    console.log("BenchmarkRunner: --format=compact-json omits build, memory, stdout, stderr...");
+    const compactBenchOut = join(tmp, "bench-compact.json");
+    {
+      const proc = Bun.spawnSync(
+        [resolve(BENCHRUNNER), benchA, benchB, "--no-progress", "--jobs=2", "--format=compact-json", `--output=${compactBenchOut}`],
+        { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
+      );
+      if (proc.exitCode !== 0) throw new Error(`Benchmark --format=compact-json exit ${proc.exitCode}: ${proc.stderr.toString()}`);
+    }
+    {
+      const json = JSON.parse(readFileSync(compactBenchOut, "utf-8"));
+      if ("build" in json) throw new Error("Benchmark --format=compact-json should omit top-level build");
+      if ("memory" in json) throw new Error("Benchmark --format=compact-json should omit top-level memory");
+      if ("stdout" in json) throw new Error("Benchmark --format=compact-json should omit top-level stdout");
+      if ("stderr" in json) throw new Error("Benchmark --format=compact-json should omit top-level stderr");
+      if (json.ok !== true) throw new Error(`Benchmark --format=compact-json ok should be true, got ${json.ok}`);
+      if (json.totalBenchmarks !== 2) throw new Error(`Benchmark --format=compact-json totalBenchmarks should be 2, got ${json.totalBenchmarks}`);
+      if (typeof json.timing?.total_ns !== "number") throw new Error("Benchmark --format=compact-json timing should be present");
+      if (typeof json.workers?.used !== "number") throw new Error("Benchmark --format=compact-json workers should be present");
+      if (!Array.isArray(json.files) || json.files.length !== 2) throw new Error("Benchmark --format=compact-json files should have two entries");
+      for (const [idx, file] of (json.files as any[]).entries()) {
+        if ("memory" in file) throw new Error(`Benchmark --format=compact-json files[${idx}] memory should be omitted`);
+        if ("stdout" in file) throw new Error(`Benchmark --format=compact-json files[${idx}] stdout should be omitted`);
+        if ("stderr" in file) throw new Error(`Benchmark --format=compact-json files[${idx}] stderr should be omitted`);
+        if (typeof file.fileName !== "string") throw new Error(`Benchmark --format=compact-json files[${idx}] fileName should be present`);
+        if (!Array.isArray(file.benchmarks) || file.benchmarks.length !== 1)
+          throw new Error(`Benchmark --format=compact-json files[${idx}] benchmarks length mismatch: ${JSON.stringify(file.benchmarks)}`);
+      }
     }
 
     console.log("BenchmarkRunner: benchmark failure JSON output...");

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -875,7 +875,9 @@ procedure TBenchmarkRunnerApp.Configure;
 begin
   AddEngineOptions;
   FNoProgress := AddFlag('no-progress', 'Suppress progress output');
-  FFormats := AddRepeatable('format', 'Output format (console, text, csv, json)');
+  FFormats := AddRepeatable('format',
+    'Output format (console, text, csv, json, compact-json). ' +
+    '"compact-json" emits the json envelope without build, memory, stdout, stderr.');
   FOutputFile := AddString('output', 'Output file path (attaches to last --format)');
 end;
 
@@ -925,7 +927,7 @@ begin
   for I := 0 to Length(Reports) - 1 do
     if Reports[I].OutputFile = '' then
     begin
-      if Reports[I].Format in [brfJSON, brfCSV] then
+      if Reports[I].Format in [brfJSON, brfCompactJSON, brfCSV] then
         HasStructuredStdout := True
       else
         HasReadableStdout := True;
@@ -941,7 +943,7 @@ begin
   // that human-readable status messages do not corrupt the output document.
   if ShowProgress then
     for I := 0 to Length(Reports) - 1 do
-      if (Reports[I].Format in [brfJSON, brfCSV]) and (Reports[I].OutputFile = '') then
+      if (Reports[I].Format in [brfJSON, brfCompactJSON, brfCSV]) and (Reports[I].OutputFile = '') then
       begin
         ShowProgress := False;
         Break;

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -338,9 +338,15 @@ begin
         CoverageOptions.OutputPath.Present) and
        Assigned(TGocciaCoverageTracker.Instance) then
     begin
-      PrintCoverageSummary(TGocciaCoverageTracker.Instance);
-      if Files.Count = 1 then
-        PrintCoverageDetail(TGocciaCoverageTracker.Instance, Files[0]);
+      { Coverage summary writes to stdout; suppress in JSON-to-stdout mode so
+        the JSON envelope remains the only stdout payload. The
+        --coverage-output=<file> machine-readable forms still fire below. }
+      if not IsJsonOutput then
+      begin
+        PrintCoverageSummary(TGocciaCoverageTracker.Instance);
+        if Files.Count = 1 then
+          PrintCoverageDetail(TGocciaCoverageTracker.Instance, Files[0]);
+      end;
       if CoverageOptions.Format.Matches(cfLcov) and
          (CoverageOptions.OutputPath.ValueOr('') <> '') then
         WriteCoverageLcov(TGocciaCoverageTracker.Instance,
@@ -384,7 +390,7 @@ begin
       except
         on E: EStreamError do
         begin
-          if not GIsWorkerThread then
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn('Error loading test file: ', E.Message);
           MarkLoadError(ScriptResult, AFileName, E.Message);
           Result := MakeEmptyTestResult(ScriptResult, E.Message);
@@ -399,7 +405,7 @@ begin
     try
       Engine := CreateEngine(AFileName, Source);
       try
-        if FSilent.Present or GIsWorkerThread then
+        if FSilent.Present or GIsWorkerThread or IsJsonOutput then
         begin
           Engine.BuiltinConsole.Enabled := False;
           Engine.SuppressWarnings := True;
@@ -426,7 +432,7 @@ begin
       begin
         if E is TGocciaError then
         begin
-          if not GIsWorkerThread then
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn(TGocciaError(E).GetDetailedMessage(IsColorTerminal));
           MarkLoadError(ScriptResult, AFileName, TGocciaError(E).GetDetailedMessage);
           Result := MakeEmptyTestResult(ScriptResult,
@@ -434,7 +440,7 @@ begin
         end
         else if E is TGocciaThrowValue then
         begin
-          if not GIsWorkerThread then
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, IsColorTerminal, TGocciaThrowValue(E).Suggestion));
           MarkLoadError(ScriptResult, AFileName,
             FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, False, TGocciaThrowValue(E).Suggestion));
@@ -444,7 +450,7 @@ begin
         end
         else
         begin
-          if not GIsWorkerThread then
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn('Fatal error: ', E.Message);
           MarkLoadError(ScriptResult, AFileName, E.Message);
           Result := MakeEmptyTestResult(ScriptResult, E.Message);
@@ -489,7 +495,7 @@ begin
       except
         on E: EStreamError do
         begin
-          if not GIsWorkerThread then
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn('Error loading test file: ', E.Message);
           MarkLoadError(ScriptResult, AFileName, E.Message);
           Result := MakeEmptyTestResult(ScriptResult, E.Message);
@@ -515,7 +521,7 @@ begin
       try
         Engine := CreateEngine(AFileName, Source, Executor);
         try
-          if FSilent.Present or GIsWorkerThread then
+          if FSilent.Present or GIsWorkerThread or IsJsonOutput then
           begin
             Engine.BuiltinConsole.Enabled := False;
             Engine.SuppressWarnings := True;
@@ -545,7 +551,7 @@ begin
                       AFileName, SourceMap.Clone);
                 end;
 
-                if (not FSilent.Present) and (not GIsWorkerThread) then
+                if (not FSilent.Present) and (not GIsWorkerThread) and (not IsJsonOutput) then
                   for I := 0 to Parser.WarningCount - 1 do
                   begin
                     Warning := Parser.GetWarning(I);
@@ -607,7 +613,7 @@ begin
       begin
         if E is TGocciaError then
         begin
-          if not GIsWorkerThread then
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn(TGocciaError(E).GetDetailedMessage(IsColorTerminal));
           MarkLoadError(ScriptResult, AFileName, TGocciaError(E).GetDetailedMessage);
           Result := MakeEmptyTestResult(ScriptResult,
@@ -615,7 +621,7 @@ begin
         end
         else if E is TGocciaThrowValue then
         begin
-          if not GIsWorkerThread then
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, IsColorTerminal, TGocciaThrowValue(E).Suggestion));
           MarkLoadError(ScriptResult, AFileName,
             FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, False, TGocciaThrowValue(E).Suggestion));
@@ -625,7 +631,7 @@ begin
         end
         else
         begin
-          if not GIsWorkerThread then
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn('Fatal error: ', E.Message);
           MarkLoadError(ScriptResult, AFileName, E.Message);
           Result := MakeEmptyTestResult(ScriptResult, E.Message);

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -130,6 +130,8 @@ type
     procedure ExecuteWithPaths(const APaths: TStringList); override;
     function GlobalBuiltins: TGocciaGlobalBuiltins; override;
   private
+    function IsJsonOutput: Boolean;
+    function IsCompactJsonOutput: Boolean;
     function RunGocciaScriptInterpreted(const AFileName: string;
       APreloadedSource: TStringList = nil): TTestFileResult;
     function RunGocciaScriptBytecode(const AFileName: string;
@@ -142,9 +144,11 @@ type
     function RunScriptsFromFilesParallel(const AFiles: TStringList; const AJobCount: Integer): TAggregatedTestResult;
     procedure TestWorkerProc(const AFileName: string; const AIndex: Integer;
       out AConsoleOutput: string; out AErrorMessage: string; AData: Pointer);
-    procedure WriteResultsJSON(const AResult: TAggregatedTestResult; const AFileName: string);
+    procedure WriteResultsJSON(const AResult: TAggregatedTestResult;
+      const AFileName: string; const ACompact: Boolean);
     procedure WriteFileResults(ALines: TStringList; const AResult: TAggregatedTestResult;
-      const APropertyName: string; const ATrailingComma: Boolean);
+      const APropertyName: string; const ATrailingComma: Boolean;
+      const ACompact: Boolean);
     procedure PrintTestResults(const AResult: TAggregatedTestResult);
   end;
 
@@ -212,7 +216,10 @@ begin
   FNoResults := AddFlag('no-results', 'Suppress test results summary');
   FExitOnFirst := AddFlag('exit-on-first-failure', 'Stop on first test failure');
   FSilent := AddFlag('silent', 'Suppress console output from test scripts');
-  FOutputFile := AddString('output', 'Write test results as JSON to file');
+  FOutputFile := AddString('output',
+    '"json" emits a structured JSON envelope to stdout, "compact-json" '
+    + 'omits build, memory, stdout, stderr; any other value is treated as '
+    + 'a file path that receives the full JSON envelope.');
   FTestTimeout := AddInteger('test-timeout',
     'Per-test timeout in ms (0 disables). Marks the test TIMEOUT and continues.');
   FDescribeTimeout := AddInteger('describe-timeout',
@@ -223,6 +230,17 @@ procedure TTestRunnerApp.Validate;
 begin
   if CoverageOptions.Format.Present or CoverageOptions.OutputPath.Present then
     CoverageOptions.Enabled.Apply('');
+end;
+
+function TTestRunnerApp.IsJsonOutput: Boolean;
+begin
+  Result := FOutputFile.Present and
+    ((FOutputFile.Value = 'json') or (FOutputFile.Value = 'compact-json'));
+end;
+
+function TTestRunnerApp.IsCompactJsonOutput: Boolean;
+begin
+  Result := FOutputFile.Present and (FOutputFile.Value = 'compact-json');
 end;
 
 function TTestRunnerApp.UsageLine: string;
@@ -289,7 +307,7 @@ begin
         end;
       end;
 
-    if not FNoProgress.Present then
+    if (not FNoProgress.Present) and (not IsJsonOutput) then
     begin
       if GetJobCount(Files.Count) > 1 then
         WriteLn(SysUtils.Format('Running %d files with %d workers',
@@ -301,7 +319,7 @@ begin
     BeginCLIJSONMemoryMeasurement(MemoryMeasurement);
     if Files.Count = 1 then
     begin
-      if not FNoProgress.Present then
+      if (not FNoProgress.Present) and (not IsJsonOutput) then
         WriteLn('[1/1] ', Files[0]);
       { Stdin is always a single source — the callee takes ownership of
         StdinSource and frees it like a disk-loaded TStringList. }
@@ -760,7 +778,7 @@ begin
 
   for I := 0 to AFiles.Count - 1 do
   begin
-    if not FNoProgress.Present then
+    if (not FNoProgress.Present) and (not IsJsonOutput) then
       WriteLn(SysUtils.Format('[%d/%d] %s', [I + 1, AFiles.Count, AFiles[I]]));
     FileResult := RunScriptFromFile(AFiles[I]);
     if FileResult.TestResult = nil then
@@ -1084,7 +1102,7 @@ begin
 
   for I := 0 to AFiles.Count - 1 do
   begin
-    if not FNoProgress.Present then
+    if (not FNoProgress.Present) and (not IsJsonOutput) then
       WriteLn(SysUtils.Format('[%d/%d] %s', [I + 1, AFiles.Count, AFiles[I]]));
 
     { Source orphaned slots from OrphanResults so we never read the
@@ -1151,12 +1169,13 @@ begin
   Result.TestResult := AllTestResults;
 end;
 
-procedure TTestRunnerApp.WriteResultsJSON(const AResult: TAggregatedTestResult; const AFileName: string);
+procedure TTestRunnerApp.WriteResultsJSON(const AResult: TAggregatedTestResult;
+  const AFileName: string; const ACompact: Boolean);
 var
   Lines: TStringList;
   TotalNanoseconds: Int64;
   IsBytecodeMode: Boolean;
-  FailedCount: Integer;
+  FailedCount, I: Integer;
   Timing: TCLIJSONTiming;
 begin
   IsBytecodeMode := EngineOptions.Mode.Matches(emBytecode);
@@ -1174,10 +1193,14 @@ begin
   Lines := TStringList.Create;
   try
     Lines.Add('{');
-    Lines.Add('  ' + BuildCLIBuildJSON + ',');
+    if not ACompact then
+      Lines.Add('  ' + BuildCLIBuildJSON + ',');
     Lines.Add(Format('  "ok": %s,', [BoolToStr(FailedCount = 0, 'true', 'false')]));
-    Lines.Add('  "stdout": "",');
-    Lines.Add('  "stderr": "",');
+    if not ACompact then
+    begin
+      Lines.Add('  "stdout": "",');
+      Lines.Add('  "stderr": "",');
+    end;
     Lines.Add('  ' + BuildCLIOutputJSON('') + ',');
     Lines.Add('  "error": null,');
     Lines.Add(Format('  "mode": "%s",', [IfThen(IsBytecodeMode, 'bytecode', 'interpreted')]));
@@ -1196,7 +1219,8 @@ begin
     Lines.Add(Format('  "executeTimeNanoseconds": %d,', [AResult.TotalExecNanoseconds]));
     Lines.Add(Format('  "totalEngineNanoseconds": %d,', [TotalNanoseconds]));
     Lines.Add('  ' + BuildCLITimingJSON(Timing) + ',');
-    Lines.Add('  ' + BuildCLIMemoryJSON(AResult.MemoryStats) + ',');
+    if not ACompact then
+      Lines.Add('  ' + BuildCLIMemoryJSON(AResult.MemoryStats) + ',');
     Lines.Add('  ' + BuildCLIWorkersJSON(AResult.JobCount, AResult.JobCount) + ',');
 
     { Per-file results. External harnesses (the test262 driver) use
@@ -1210,11 +1234,17 @@ begin
       occasionally produced torn AnsiString refcount reads, corrupting
       the serialised JSON. The per-file records below carry the same
       information and are written from main-thread-owned data only. }
-    WriteFileResults(Lines, AResult, 'files', True);
-    WriteFileResults(Lines, AResult, 'results', False);
+    WriteFileResults(Lines, AResult, 'files', True, ACompact);
+    WriteFileResults(Lines, AResult, 'results', False, ACompact);
 
     Lines.Add('}');
-    Lines.SaveToFile(AFileName);
+    if AFileName = '' then
+    begin
+      for I := 0 to Lines.Count - 1 do
+        WriteLn(Lines[I]);
+    end
+    else
+      Lines.SaveToFile(AFileName);
   finally
     Lines.Free;
   end;
@@ -1222,7 +1252,7 @@ end;
 
 procedure TTestRunnerApp.WriteFileResults(ALines: TStringList;
   const AResult: TAggregatedTestResult; const APropertyName: string;
-  const ATrailingComma: Boolean);
+  const ATrailingComma: Boolean; const ACompact: Boolean);
 var
   I, J, Count: Integer;
   Fr: TTestFilePerResult;
@@ -1276,7 +1306,7 @@ begin
       Entry.Append('    {');
       Entry.Append(BuildCLIFileBaseJSON(Fr.FileName,
         (Fr.Failed = 0) and (Fr.ErrorMessage = ''), '', '', '', ErrorJSON,
-        Timing, '"memory":null'));
+        Timing, '"memory":null', ACompact));
       Entry.Append(', ');
       Entry.Append('"passed": ');
       Entry.Append(Round(Fr.Passed));
@@ -1335,7 +1365,7 @@ begin
   IsBytecodeMode := EngineOptions.Mode.Matches(emBytecode);
   IsParallel := AResult.JobCount > 1;
 
-  if not FNoResults.Present then
+  if (not FNoResults.Present) and (not IsJsonOutput) then
   begin
     Writeln('Test Results Test Files: ', TestResult.GetProperty('totalTests').ToStringLiteral.Value);
     Writeln(Format('Test Results Run Tests: %s', [TotalRunTests]));
@@ -1392,9 +1422,14 @@ begin
     end;
   end;
 
-  CurrentOutputFile := FOutputFile.ValueOr('');
-  if CurrentOutputFile <> '' then
-    WriteResultsJSON(AResult, CurrentOutputFile);
+  if IsJsonOutput then
+    WriteResultsJSON(AResult, '', IsCompactJsonOutput)
+  else
+  begin
+    CurrentOutputFile := FOutputFile.ValueOr('');
+    if CurrentOutputFile <> '' then
+      WriteResultsJSON(AResult, CurrentOutputFile, False);
+  end;
 
   if StrToFloat(TotalFailed) > 0 then
     ExitCode := 1;

--- a/source/units/Goccia.Benchmark.Reporter.pas
+++ b/source/units/Goccia.Benchmark.Reporter.pas
@@ -35,7 +35,8 @@ type
     DurationNanoseconds: Int64;
   end;
 
-  TBenchmarkReportFormat = (brfConsole, brfText, brfCSV, brfJSON);
+  TBenchmarkReportFormat = (brfConsole, brfText, brfCSV, brfJSON,
+    brfCompactJSON);
 
   TBenchmarkReporter = class
   private
@@ -45,6 +46,7 @@ type
     FWallClockDurationNanoseconds: Int64;
     FJobCount: Integer;
     FMemoryStats: TCLIJSONMemoryStats;
+    FRenderCompact: Boolean;
 
     procedure RenderConsole;
     procedure RenderText;
@@ -108,6 +110,8 @@ begin
     Result := brfCSV
   else if (Lower = 'json') then
     Result := brfJSON
+  else if (Lower = 'compact-json') then
+    Result := brfCompactJSON
   else
     Result := brfConsole;
 end;
@@ -122,6 +126,7 @@ begin
   FWallClockDurationNanoseconds := 0;
   FJobCount := 1;
   FMemoryStats := DefaultCLIJSONMemoryStats;
+  FRenderCompact := False;
   SetLength(FFiles, 0);
 end;
 
@@ -179,11 +184,13 @@ end;
 procedure TBenchmarkReporter.Render(const AFormat: TBenchmarkReportFormat);
 begin
   FOutput.Clear;
+  FRenderCompact := AFormat = brfCompactJSON;
   case AFormat of
-    brfConsole: RenderConsole;
-    brfText:    RenderText;
-    brfCSV:     RenderCSV;
-    brfJSON:    RenderJSON;
+    brfConsole:     RenderConsole;
+    brfText:        RenderText;
+    brfCSV:         RenderCSV;
+    brfJSON:        RenderJSON;
+    brfCompactJSON: RenderJSON;
   end;
 end;
 
@@ -447,7 +454,7 @@ begin
     FileJSON :=
       '{' +
         BuildCLIFileBaseJSON(FFiles[F].FileName, FileOk, '', '', '',
-          FileErrorJSON, FileTiming, '"memory":null') + ',' +
+          FileErrorJSON, FileTiming, '"memory":null', FRenderCompact) + ',' +
         SysUtils.Format('"lexTimeNanoseconds":%d,', [FFiles[F].LexTimeNanoseconds]) +
         SysUtils.Format('"parseTimeNanoseconds":%d,', [FFiles[F].ParseTimeNanoseconds]) +
         SysUtils.Format('"compileTimeNanoseconds":%d,', [FFiles[F].CompileTimeNanoseconds]) +
@@ -489,7 +496,8 @@ begin
     SysUtils.Format('"totalBenchmarks":%d,', [TotalBenchmarks]) +
     SysUtils.Format('"totalDurationNanoseconds":%d', [TotalDurationNanoseconds]);
   FOutput.Text := BuildCLIReportJSON(not HasFailures, '', '', '', 'null',
-    Timing, FMemoryStats, FJobCount, FJobCount, FilesJSON, ExtraJSON);
+    Timing, FMemoryStats, FJobCount, FJobCount, FilesJSON, ExtraJSON,
+    FRenderCompact);
 end;
 
 procedure TBenchmarkReporter.WriteToStream(const AStream: TStream);


### PR DESCRIPTION
## Summary

The `compact-json` value already accepted by `GocciaScriptLoader` for `--output` is now also recognised by the other two runners that emit JSON, using each tool's existing format-selection mechanism — no new flag, no new mechanism.

- **`GocciaTestRunner`**: `--output=json` and `--output=compact-json` emit the structured JSON envelope to stdout (suppressing the human-readable summary). Any other `--output` value continues to be treated as a file path that receives the full JSON envelope, so existing CI workflows and the test262 driver are unaffected.
- **`GocciaBenchmarkRunner`**: `--format=compact-json` is now a sibling of `--format=json`, honoured by the existing `--output=<file>` destination flow.
- **`GocciaScriptLoader` is untouched.** Both new entry points reuse the existing `ACompact` parameter on `BuildCLIFileBaseJSON` / `BuildCLIReportJSON` in `Goccia.CLI.JSON.Reporter`, so the omitted fields (`build`, `memory`, `stdout`, `stderr` at top level and per-file) match exactly across all three runners.

| Tool | Trigger |
|---|---|
| `GocciaScriptLoader` | `--output=compact-json` *(unchanged)* |
| `GocciaTestRunner` | `--output=compact-json` *(new)* |
| `GocciaBenchmarkRunner` | `--format=compact-json` *(new)* |

## Test plan

- [x] `./build.pas` cleanly builds all five binaries
- [x] `./format.pas --check` — 300 files clean
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi` — 8244 passed, 0 failed, 41 skipped
- [x] `bun scripts/test-cli-apps.ts` — all CLI integration tests pass, including:
  - `TestRunner: --output=json emits structured JSON envelope to stdout`
  - `TestRunner: --output=compact-json omits build, memory, stdout, stderr`
  - `BenchmarkRunner: --format=compact-json omits build, memory, stdout, stderr`
- [x] Verified `git diff source/app/GocciaScriptLoader.dpr` between this branch and `main` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)