### PR TITLE
Add --config flag to override config auto-discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ Assistants should treat CONTRIBUTING as authoritative for contribution requireme
 ./build/GocciaScriptLoader example.js # Execute a script (interpreted)
 ./build/GocciaScriptLoader example.js --mode=bytecode # Execute via bytecode VM
 ./build/GocciaScriptLoader example.js --import-map=imports.json # Execute with an explicit import map
+./build/GocciaScriptLoader example.js --config=./configs/strict.toml # Load root config from an explicit file (skips auto-discovery)
+./build/GocciaScriptLoader example.js --config=./configs/ # Load root config from a directory (looks up goccia.{toml,json5,json}, no walk-up)
 ./build/GocciaScriptLoader example.js --alias @/=./src/ --alias config=./config/default.js # One-off import-map-style aliases
 ./build/GocciaScriptLoader out.gbc # Load and execute .gbc bytecode
 printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
@@ -82,6 +84,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaREPL --mode=bytecode # Start the REPL via bytecode VM
 ./build/GocciaREPL --mode=bytecode --timing # Bytecode REPL with per-line timing
 ./build/GocciaREPL --import-map=imports.json # Start the REPL with an explicit import map
+./build/GocciaREPL --config=./configs/dev.json # Start the REPL with an explicit config path (skips auto-discovery)
 ./build/GocciaREPL --asi # Start the REPL with automatic semicolon insertion
 ./build/GocciaREPL --unsafe-ffi # Start the REPL with FFI enabled
 ./build/GocciaREPL --log=repl.log # Start the REPL with console log capture
@@ -89,6 +92,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaREPL --max-memory=10485760 # Start the REPL with 10 MB GC heap limit
 ./build/GocciaTestRunner tests/ --asi # Run all JavaScript tests
 ./build/GocciaTestRunner tests --import-map=imports.json # Run tests with an explicit import map
+./build/GocciaTestRunner tests --config=./configs/ci.json # Run tests with an explicit config path (skips auto-discovery)
 ./build/GocciaTestRunner tests/language/expressions/ # Run a test category
 ./build/GocciaTestRunner tests --no-progress --exit-on-first-failure # CI mode
 ./build/GocciaTestRunner tests --silent # Suppress all console output
@@ -105,6 +109,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 printf 'test("two plus two", () => { expect(2 + 2).toBe(4); });\n' | ./build/GocciaTestRunner # Run a test source from stdin
 ./build/GocciaBenchmarkRunner benchmarks/ # Run all benchmarks
 ./build/GocciaBenchmarkRunner benchmarks --import-map=imports.json # Run benchmarks with an explicit import map
+./build/GocciaBenchmarkRunner benchmarks --config=./configs/bench.toml # Run benchmarks with an explicit config path (skips auto-discovery)
 ./build/GocciaBenchmarkRunner benchmarks/fibonacci.js # Run a specific benchmark
 printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/GocciaBenchmarkRunner # Run benchmark source from stdin
 ./build/GocciaBenchmarkRunner benchmarks --format=json --output=out.json # Export as JSON
@@ -120,6 +125,7 @@ printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./bu
 printf "const x = 2 + 2; x;" | ./build/GocciaBundler --output=out.gbc # Compile stdin to .gbc
 ./build/GocciaBundler src/ --jobs=4 # Compile with 4 parallel workers
 ./build/GocciaBundler example.js --asi # Compile with automatic semicolon insertion
+./build/GocciaBundler example.js --config=./configs/release.toml # Compile with an explicit config path (skips auto-discovery)
 ```
 
 ### Compile and run (common workflows)
@@ -143,7 +149,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaBundler --output=out.gbc # Compile 
 
 ### Configuration file
 
-All CLI options can be set via `goccia.json` (or `.json5` / `.toml`) discovered from the entry file's directory upward. Priority: TOML > JSON5 > JSON. CLI arguments override config values. Config files support `"extends"` to inherit from a base config.
+All CLI options can be set via `goccia.json` (or `.json5` / `.toml`) discovered from the entry file's directory upward. Priority: TOML > JSON5 > JSON. CLI arguments override config values. Config files support `"extends"` to inherit from a base config. Pass `--config=<path>` to skip auto-discovery — the path may be a config file or a directory (which is searched only for `goccia.{toml,json5,json}` without walking up).
 
 ```json
 // goccia.json

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -166,8 +166,23 @@ The first file found is loaded and applied as the **root config**. When running 
 
 1. **CLI arguments** (highest priority — always win)
 2. **Per-file config** (`goccia.toml`, `goccia.json5`, or `goccia.json` nearest to the file being processed)
-3. **Root config** (discovered from the entry path at startup)
+3. **Root config** (discovered from the entry path at startup, or supplied via `--config`)
 4. **System default** (engine defaults)
+
+**`--config=<path>`** — Override auto-discovery and load the root config from an explicit location. Available on every CLI tool.
+
+The path may be either a **file** (any registered extension — `.json`, `.json5`, `.toml`; the parser is selected by extension), or a **directory**, in which case the CLI looks for `goccia.toml` → `goccia.json5` → `goccia.json` in that directory only (same priority as auto-discovery). The directory form does **not** walk upward — that's the point of the explicit override.
+
+```bash
+# File form (use this exact file)
+./build/GocciaScriptLoader example.js --config=./configs/strict.toml
+./build/GocciaTestRunner tests --config=./configs/ci.json
+
+# Directory form (find goccia.{toml,json5,json} inside, no walk-up)
+./build/GocciaScriptLoader example.js --config=./configs/
+```
+
+Relative paths are resolved against the current working directory. A missing file or a directory with no recognised `goccia.*` is a hard error so a typo is not silently ignored. CLI arguments still take precedence over values from the file, and per-file configs continue to be discovered normally for individual files.
 
 ```json
 {

--- a/scripts/test-cli-config.ts
+++ b/scripts/test-cli-config.ts
@@ -725,4 +725,310 @@ console.log("Config allowed-hosts TestRunner integration...");
   }
 }
 
+// -- --config=<file> ------------------------------------------------------------
+//
+// The --config flag points at a specific config file and skips auto-discovery
+// entirely.  All three supported extensions must work because the parser is
+// chosen by extension.
+
+console.log("--config=<file> loads .json explicitly...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    // Script lives in tmp with no goccia.* anywhere on its parent chain.
+    writeFileSync(join(tmp, "test.js"), "const x = 11\nx\n");
+    // Config lives in a sibling directory; auto-discovery would never find it.
+    writeFileSync(join(cfgDir, "custom.json"), '{"asi": true, "mode": "bytecode"}\n');
+
+    const out = await $`${LOADER} ${join(tmp, "test.js")} --config=${join(cfgDir, "custom.json")} 2>&1`.text();
+    if (!out.includes("(bytecode)")) throw new Error(`--config=.json should enable bytecode, got: ${out}`);
+    if (!out.includes("Result: 11")) throw new Error(`--config=.json should enable ASI (Result: 11), got: ${out}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+console.log("--config=<file> loads .toml explicitly...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    writeFileSync(join(tmp, "test.js"), "const x = 21\nx\n");
+    writeFileSync(join(cfgDir, "custom.toml"), 'asi = true\nmode = "bytecode"\n');
+
+    const out = await $`${LOADER} ${join(tmp, "test.js")} --config=${join(cfgDir, "custom.toml")} 2>&1`.text();
+    if (!out.includes("(bytecode)")) throw new Error(`--config=.toml should enable bytecode, got: ${out}`);
+    if (!out.includes("Result: 21")) throw new Error(`--config=.toml should enable ASI (Result: 21), got: ${out}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+console.log("--config=<file> loads .json5 explicitly...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    writeFileSync(join(tmp, "test.js"), "const x = 31\nx\n");
+    writeFileSync(join(cfgDir, "custom.json5"), '{asi: true, mode: "bytecode"}\n');
+
+    const out = await $`${LOADER} ${join(tmp, "test.js")} --config=${join(cfgDir, "custom.json5")} 2>&1`.text();
+    if (!out.includes("(bytecode)")) throw new Error(`--config=.json5 should enable bytecode, got: ${out}`);
+    if (!out.includes("Result: 31")) throw new Error(`--config=.json5 should enable ASI (Result: 31), got: ${out}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+console.log("--config=<file> with relative path resolves against cwd...");
+{
+  const tmp = makeTmp();
+  try {
+    writeFileSync(join(tmp, "test.js"), "const x = 41\nx\n");
+    writeFileSync(join(tmp, "custom.json"), '{"asi": true, "mode": "bytecode"}\n');
+
+    // Relative path; cwd is tmp.
+    const out = runCwd(LOADER, ["test.js", "--config=./custom.json"], tmp);
+    if (!out.combined.includes("(bytecode)")) throw new Error(`Relative --config should resolve, got: ${out.combined}`);
+    if (!out.combined.includes("Result: 41")) throw new Error(`Relative --config should enable ASI, got: ${out.combined}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
+// -- --config=<dir> -------------------------------------------------------------
+//
+// A directory path expands to goccia.{toml,json5,json} inside that directory,
+// preserving the same priority as auto-discovery.  The lookup must NOT walk
+// upward — that's the point of an explicit override.
+
+console.log("--config=<dir> finds goccia.json...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    writeFileSync(join(tmp, "test.js"), "const x = 51\nx\n");
+    writeFileSync(join(cfgDir, "goccia.json"), '{"asi": true, "mode": "bytecode"}\n');
+
+    const out = await $`${LOADER} ${join(tmp, "test.js")} --config=${cfgDir} 2>&1`.text();
+    if (!out.includes("(bytecode)")) throw new Error(`--config=<dir> with goccia.json should enable bytecode, got: ${out}`);
+    if (!out.includes("Result: 51")) throw new Error(`--config=<dir> should enable ASI, got: ${out}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+console.log("--config=<dir> respects priority TOML > JSON5 > JSON...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    writeFileSync(join(tmp, "test.js"), "const x = 61\nx\n");
+    // All three present; TOML must win (matches auto-discovery priority).
+    writeFileSync(join(cfgDir, "goccia.json"), '{"asi": true, "mode": "interpreted"}\n');
+    writeFileSync(join(cfgDir, "goccia.json5"), '{asi: true, mode: "interpreted"}\n');
+    writeFileSync(join(cfgDir, "goccia.toml"), 'asi = true\nmode = "bytecode"\n');
+
+    const out = await $`${LOADER} ${join(tmp, "test.js")} --config=${cfgDir} 2>&1`.text();
+    if (!out.includes("(bytecode)")) throw new Error(`--config=<dir> should pick TOML over JSON5/JSON, got: ${out}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+console.log("--config=<dir> with trailing slash works...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    writeFileSync(join(tmp, "test.js"), "const x = 71\nx\n");
+    writeFileSync(join(cfgDir, "goccia.toml"), 'asi = true\nmode = "bytecode"\n');
+
+    // Some shells/users will pass the directory with a trailing slash.
+    const out = await $`${LOADER} ${join(tmp, "test.js")} --config=${cfgDir + "/"} 2>&1`.text();
+    if (!out.includes("(bytecode)")) throw new Error(`--config=<dir>/ should still find config, got: ${out}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+console.log("--config=<dir> does not walk upward...");
+{
+  const tmp = makeTmp();
+  try {
+    // Place a config in tmp; pass an empty subdirectory as --config.
+    // Auto-discovery would walk up and find tmp/goccia.toml, but the
+    // explicit directory form must NOT — it should error out.
+    writeFileSync(join(tmp, "goccia.toml"), 'asi = true\nmode = "bytecode"\n');
+    const empty = join(tmp, "empty");
+    mkdirSync(empty);
+    writeFileSync(join(tmp, "test.js"), "const x = 81\nx\n");
+
+    const res = await $`${LOADER} ${join(tmp, "test.js")} --config=${empty} 2>&1`.nothrow();
+    if (res.exitCode === 0) throw new Error("--config=<empty-dir> should not silently walk up to parent");
+    if (!res.text().includes("No goccia.")) throw new Error(`Error should mention missing goccia.* file, got: ${res.text()}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
+// -- --config error handling ----------------------------------------------------
+
+console.log("--config=<missing path> is a hard error...");
+{
+  const tmp = makeTmp();
+  try {
+    writeFileSync(join(tmp, "test.js"), "const x = 91;\nx;\n");
+
+    const res = await $`${LOADER} ${join(tmp, "test.js")} --config=${join(tmp, "does-not-exist.json")} 2>&1`.nothrow();
+    if (res.exitCode === 0) throw new Error("--config pointing to nonexistent path should fail");
+    if (!res.text().includes("not found")) throw new Error(`Error should mention "not found", got: ${res.text()}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
+// -- --config skips auto-discovery ---------------------------------------------
+//
+// With --config given, the root-config walk-up MUST be skipped.  We prove
+// this by placing a hostile goccia.json near the entry file (which would
+// flip mode to interpreted) and showing that the explicit config wins.
+
+console.log("--config skips auto-discovery of nearby goccia.*...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    // Hostile config alongside the script; auto-discovery would pick this up.
+    writeFileSync(join(tmp, "goccia.json"), '{"asi": true, "mode": "interpreted"}\n');
+    writeFileSync(join(tmp, "test.js"), "const x = 101\nx\n");
+    // Explicit config selects bytecode.
+    writeFileSync(join(cfgDir, "good.toml"), 'asi = true\nmode = "bytecode"\n');
+
+    const out = await $`${LOADER} ${join(tmp, "test.js")} --config=${join(cfgDir, "good.toml")} 2>&1`.text();
+    if (!out.includes("(bytecode)")) throw new Error(`--config should skip nearby goccia.json, got: ${out}`);
+    if (!out.includes("Result: 101")) throw new Error(`--config should still apply ASI, got: ${out}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+// -- CLI args still beat --config -----------------------------------------------
+
+console.log("CLI flags override values from --config...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    writeFileSync(join(tmp, "test.js"), "const x = 111\nx\n");
+    // --config says interpreted...
+    writeFileSync(join(cfgDir, "custom.toml"), 'asi = true\nmode = "interpreted"\n');
+
+    // ...but a direct --mode=bytecode on the CLI must win.
+    const out = await $`${LOADER} ${join(tmp, "test.js")} --config=${join(cfgDir, "custom.toml")} --mode=bytecode 2>&1`.text();
+    if (!out.includes("(bytecode)")) throw new Error(`CLI --mode should override --config value, got: ${out}`);
+    if (!out.includes("Result: 111")) throw new Error(`ASI from --config should still apply, got: ${out}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+// -- --config across the other CLI tools ---------------------------------------
+//
+// The flag lives in the shared base class, so smoke-test that each consumer
+// actually honors it.  The Loader is covered above; here we hit the rest.
+
+console.log("--config works on TestRunner...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    writeFileSync(join(cfgDir, "ci.toml"), 'asi = true\nmode = "bytecode"\n');
+    writeFileSync(
+      join(tmp, "test.js"),
+      [
+        'describe("config-flag", () => {',
+        '  test("works", () => {',
+        "    expect(2 + 2).toBe(4)",
+        "  })",
+        "})",
+      ].join("\n") + "\n",
+    );
+
+    const out = runCwd(TESTRUNNER, [join(tmp, "test.js"), "--no-progress", `--config=${join(cfgDir, "ci.toml")}`], tmp);
+    if (!out.combined.includes("Passed: 1")) throw new Error(`TestRunner --config should pass, got: ${out.combined}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+console.log("--config works on Bundler...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    // Bad-without-ASI source; --config supplies ASI so compile must succeed.
+    writeFileSync(join(tmp, "test.js"), "const x = 1\nx\n");
+    writeFileSync(join(cfgDir, "goccia.json"), '{"asi": true}\n');
+
+    // Sanity: without --config, compile rejects (no goccia.* near tmp).
+    const noCfg = await $`${BUNDLER} ${join(tmp, "test.js")} 2>&1`.nothrow();
+    if (noCfg.exitCode === 0) throw new Error("Bundler without ASI/--config should reject missing semicolons");
+
+    // With --config=<dir>, compile succeeds.
+    await $`${BUNDLER} ${join(tmp, "test.js")} --config=${cfgDir}`.quiet();
+    if (!existsSync(join(tmp, "test.gbc"))) throw new Error("Bundler --config=<dir> should compile");
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
+console.log("--config works on BenchmarkRunner...");
+{
+  const tmp = makeTmp();
+  const cfgDir = makeTmp();
+  try {
+    writeFileSync(join(cfgDir, "goccia.toml"), 'asi = true\n');
+    writeFileSync(
+      join(tmp, "bench.js"),
+      [
+        // No semicolons — proves --config-supplied ASI is in effect.
+        'suite("config-flag", () => {',
+        '  bench("sum", {',
+        "    run: () => 1 + 1",
+        "  })",
+        "})",
+      ].join("\n") + "\n",
+    );
+
+    const proc = Bun.spawnSync(
+      [resolve(BENCHRUNNER), join(tmp, "bench.js"), "--no-progress", `--config=${cfgDir}`],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, GOCCIA_BENCH_CALIBRATION_MS: "50", GOCCIA_BENCH_ROUNDS: "3" } as Record<string, string>,
+        timeout: 60_000,
+      },
+    );
+    if (proc.exitCode !== 0)
+      throw new Error(`BenchmarkRunner --config exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+    if (!proc.stdout.toString().includes("config-flag"))
+      throw new Error(`BenchmarkRunner --config output should mention 'config-flag', got: ${proc.stdout.toString()}`);
+  } finally {
+    clean(tmp);
+    clean(cfgDir);
+  }
+}
+
 console.log("\nAll test-cli-config.ts tests passed.");

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -22,6 +22,7 @@ type
     FHelp: TGocciaFlagOption;
     FJobs: TGocciaIntegerOption;
     FLog: TGocciaStringOption;
+    FConfig: TGocciaStringOption;
     FLogFileHandle: TextFile;
     FLogLock: TRTLCriticalSection;
     FLogFileOpen: Boolean;
@@ -294,6 +295,7 @@ begin
   FHelp := nil;
   FJobs := nil;
   FLog := nil;
+  FConfig := nil;
   FLogFileOpen := False;
 end;
 
@@ -307,6 +309,7 @@ begin
   FHelp.Free;
   FJobs.Free;
   FLog.Free;
+  FConfig.Free;
   inherited Destroy;
 end;
 
@@ -654,6 +657,41 @@ begin
   Result := GetCurrentDir;
 end;
 
+{ Resolve an explicit --config value to a concrete file path.
+  Accepts either a path to a config file or to a directory containing
+  goccia.toml / goccia.json5 / goccia.json (priority order).  The
+  directory form checks only that directory and does not walk upward,
+  so the user gets exactly what they asked for and a typo errors out
+  rather than silently picking up a parent's config.  Raises when the
+  path does not exist or when a directory contains no recognised
+  config file. }
+function ResolveExplicitConfigPath(const AValue: string): string;
+var
+  Expanded, Candidate: string;
+  E: Integer;
+begin
+  Expanded := ExpandFileName(AValue);
+
+  if DirectoryExists(Expanded) then
+  begin
+    for E := 0 to High(CONFIG_EXTENSIONS) do
+    begin
+      Candidate := IncludeTrailingPathDelimiter(Expanded) +
+        CONFIG_BASE_NAME + CONFIG_EXTENSIONS[E];
+      if FileExists(Candidate) then
+        Exit(Candidate);
+    end;
+    raise Exception.CreateFmt(
+      'No %s.{toml,json5,json} found in config directory: %s',
+      [CONFIG_BASE_NAME, AValue]);
+  end;
+
+  if FileExists(Expanded) then
+    Exit(Expanded);
+
+  raise Exception.CreateFmt('Config path not found: %s', [AValue]);
+end;
+
 procedure TGocciaCLIApplication.Execute;
 var
   Paths: TStringList;
@@ -670,11 +708,15 @@ begin
 
   FLog := TGocciaStringOption.Create('log', 'Write console output to a log file');
 
+  FConfig := TGocciaStringOption.Create('config',
+    'Path to a config file or a directory containing one (skips auto-discovery)');
+
   BuildAllOptions;
-  // Append --jobs and --log after BuildAllOptions so they appear in help
-  SetLength(FAllOptions, Length(FAllOptions) + 2);
-  FAllOptions[High(FAllOptions) - 1] := FJobs;
-  FAllOptions[High(FAllOptions)] := FLog;
+  // Append --jobs, --log, and --config after BuildAllOptions so they appear in help
+  SetLength(FAllOptions, Length(FAllOptions) + 3);
+  FAllOptions[High(FAllOptions) - 2] := FJobs;
+  FAllOptions[High(FAllOptions) - 1] := FLog;
+  FAllOptions[High(FAllOptions)] := FConfig;
 
   { Parse CLI first so we know the entry file path. }
   Paths := ParseCommandLine(FAllOptions);
@@ -693,12 +735,25 @@ begin
       if FAllOptions[I].Present then
         FAllOptions[I].MarkFromCommandLine;
 
-    { Discover config file starting from the entry file's directory.
-      Apply as defaults — options already set by CLI are skipped. }
+    { Resolve the root config path.  When --config is given it takes
+      precedence over auto-discovery and a missing path is a hard
+      error so a typo is not silently ignored.  The value may point
+      to a config file directly or to a directory containing
+      goccia.toml / goccia.json5 / goccia.json (priority order); the
+      directory form does NOT walk upward.  Otherwise walk up from
+      the entry file's directory.  Either way, options already set by
+      CLI are skipped during application. }
     EnsureConfigParsersRegistered;
-    ConfigStartDir := ResolveConfigStartDirectory(Paths);
-    ConfigPath := DiscoverConfigFile(ConfigStartDir,
-      [CONFIG_BASE_NAME], CONFIG_EXTENSIONS);
+    if FConfig.Present then
+    begin
+      ConfigPath := ResolveExplicitConfigPath(FConfig.Value);
+    end
+    else
+    begin
+      ConfigStartDir := ResolveConfigStartDirectory(Paths);
+      ConfigPath := DiscoverConfigFile(ConfigStartDir,
+        [CONFIG_BASE_NAME], CONFIG_EXTENSIONS);
+    end;
     if ConfigPath <> '' then
       ApplyConfigFile(ConfigPath, FAllOptions);
 


### PR DESCRIPTION
## Summary

- Adds `--config=<path>` to the shared `TGocciaCLIApplication` base, so every CLI tool (`GocciaScriptLoader`, `GocciaREPL`, `GocciaTestRunner`, `GocciaBenchmarkRunner`, `GocciaBundler`) gets it automatically.
- The path may be a config **file** (any registered extension — `.json`, `.json5`, `.toml`) **or** a **directory** containing `goccia.{toml,json5,json}` (priority order). The directory form does **not** walk upward — that's the point of an explicit override.
- A missing file or a directory with no recognised `goccia.*` is a hard error so a typo isn't silently ignored.
- When `--config` is given, root-level auto-discovery is skipped; per-file config discovery and `CLI > config > default` precedence are preserved. CLI args still beat values from `--config`.

## Test plan

- [x] `./build.pas` — all five binaries compile cleanly.
- [x] `--help` shows the new flag on every CLI tool.
- [x] `bun run scripts/test-cli-config.ts` — entire suite passes, including 13 new `--config` tests (each extension; directory form; priority TOML > JSON5 > JSON within a directory; trailing slash; no walk-up; missing-path error; auto-discovery skip; CLI override precedence; per-tool integration for TestRunner, Bundler, BenchmarkRunner).
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi` — 8244/8244 passing, 0 failures.
- [x] `./format.pas --check` — all 300 Pascal files clean.
- [x] Pre-commit hooks (lefthook) — markdownlint, doc-links, doc-symbols, swimmies all pass.

## Notes

- Implementation lives in `source/app/Goccia.CLI.Application.pas`; the new `ResolveExplicitConfigPath` helper handles file vs. directory disambiguation and produces clear error messages.
- Tests are added to the existing `scripts/test-cli-config.ts` so they run as part of the CLI CI test layer (`.github/workflows/ci.yml`); no new test infrastructure was added.
- Docs updated: `docs/build-system.md` (Configuration File section) and `AGENTS.md` (CLI command examples + Configuration file summary).