### PR TITLE
Add Report issue button to playground

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -2072,7 +2072,13 @@ a.info-term {
   line-height: 1.65;
   color: var(--ink);
   overflow: auto;
-  white-space: pre-wrap;
+  /* `pre` (not `pre-wrap`) so long output lines don't wrap — they
+     stay on one line and the panel scrolls horizontally instead.
+     Mirrors how a real terminal renders output and prevents the
+     "cut-off without a scrollbar" confusion when a line happens to
+     contain a long unbreakable token (a stringified blob, a path,
+     an error message). `overflow: auto` above surfaces the bar. */
+  white-space: pre;
   background: var(--console-bg);
   box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.06);
 }
@@ -2147,7 +2153,10 @@ a.info-term {
   color: var(--forest-light);
 }
 .anim-output-text {
-  white-space: pre-wrap;
+  /* Match the parent `.console-panel`: don't wrap, so long output
+     lines extend past the panel width and trigger the panel's
+     horizontal scrollbar instead of wrapping silently. */
+  white-space: pre;
 }
 .anim-output-caret {
   display: inline-block;

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -2119,11 +2119,27 @@ a.info-term {
   white-space: nowrap;
   vertical-align: bottom;
   max-width: 0;
-  animation: typewriter-expand 0.6s steps(30, end) forwards;
+  /* `typewriter-expand` is the reveal animation. `typewriter-unclip`
+     chains in afterwards (0.6s delay matches the reveal's duration)
+     and snaps the constraints off so a command line longer than the
+     panel can extend past its right edge — the parent .console-panel's
+     overflow: auto then surfaces a horizontal scrollbar to access the
+     rest. Without this second animation, `overflow: hidden` and the
+     `max-width: 100%` cap stay applied forever (forwards fill mode)
+     and the long command gets silently clipped at the panel edge. */
+  animation:
+    typewriter-expand 0.6s steps(30, end) forwards,
+    typewriter-unclip 0.01s 0.6s forwards;
 }
 @keyframes typewriter-expand {
   to {
     max-width: 100%;
+  }
+}
+@keyframes typewriter-unclip {
+  to {
+    overflow: visible;
+    max-width: none;
   }
 }
 /* Inline caret that follows the typewriter text, then hides once

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -1793,6 +1793,18 @@ a.info-term {
   opacity: 0.6;
   cursor: wait;
 }
+/* Keyboard-shortcut tail inside the Run / Execute button. Subdued so it
+   reads as a hint rather than a second label, monospaced so the symbols
+   line up. Matches the "plain monospace tail" pattern used in command
+   palettes (Linear, Raycast). */
+.pg-run-kbd {
+  font-family: var(--mono);
+  font-size: 0.78em;
+  font-weight: 500;
+  opacity: 0.7;
+  margin-left: 0.1rem;
+  letter-spacing: 0.02em;
+}
 .pg-share {
   padding: 0.45rem 0.85rem;
   border-radius: 7px;
@@ -2631,6 +2643,16 @@ a.info-term {
 .hero-action:disabled {
   opacity: 0.6;
   cursor: default;
+}
+/* Keyboard-shortcut tail inside the hero Run button. Smaller scale than
+   .pg-run-kbd because .hero-action is itself a smaller button — letter-
+   spacing kept tight to avoid overflowing the button's min-width. */
+.hero-action-kbd {
+  font-size: 0.85em;
+  font-weight: 500;
+  opacity: 0.75;
+  margin-left: 0.1rem;
+  letter-spacing: 0.02em;
 }
 
 /* hero card editor — always editable transparent textarea over highlighted overlay */

--- a/website/src/components/animated-output.tsx
+++ b/website/src/components/animated-output.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { useRunShortcut } from "@/components/command-tabs";
 
 /** Per-line entry rendered inside `<AnimatedOutput>`. Mirrors the
  *  shape the playground / sandbox / hero outputs already use. */
@@ -45,6 +46,7 @@ export function AnimatedOutput({
    *  output that's no longer "live". */
   showCaret?: boolean;
 }) {
+  const runShortcut = useRunShortcut();
   if (lines.length === 0) {
     return (
       <div className={`anim-output ${className}`}>
@@ -58,7 +60,7 @@ export function AnimatedOutput({
               aria-hidden="true"
             />
             <span className="anim-output-hint" role="status">
-              press Run or ⌘+Enter
+              press Run or {runShortcut.long}
             </span>
           </span>
         </div>

--- a/website/src/components/command-tabs.tsx
+++ b/website/src/components/command-tabs.tsx
@@ -75,6 +75,45 @@ export function detectOs(ua: string): OsKey {
  *  We use one union for simplicity; per-OS code clamps to the legal set. */
 export type ArchKey = "arm64" | "x64" | "x86";
 
+/** Platform-aware label set for the ⌘/Ctrl+Enter Run shortcut. The
+ *  same physical key combo is bound on every platform — the keydown
+ *  handlers all check `e.metaKey || e.ctrlKey` — but the symbol the
+ *  UI displays for it differs: macOS users expect `⌘`, everyone else
+ *  expects `Ctrl`. `short` is the compact form for inline use inside
+ *  buttons (matches the visual weight of `⌘↵`); `long` is the expanded
+ *  form for tooltips and prose. */
+export type RunShortcut = {
+  short: string;
+  long: string;
+};
+
+const RUN_SHORTCUT_MAC: RunShortcut = { short: "⌘↵", long: "⌘+Enter" };
+const RUN_SHORTCUT_NON_MAC: RunShortcut = {
+  short: "Ctrl+↵",
+  long: "Ctrl+Enter",
+};
+
+/** Returns the platform-appropriate Run-shortcut label.
+ *
+ *  Hydration-safe: SSR (and the first client paint) renders the
+ *  macOS form so the markup is deterministic, then a `useEffect`
+ *  re-detects on the client via `navigator.userAgent` — same shape
+ *  as `<QuickInstall>`'s OS auto-pick. Users on Linux/Windows see a
+ *  brief flash of `⌘` before it swaps to `Ctrl` on first paint;
+ *  acceptable trade-off for not blocking SSR on user-agent inspection. */
+export function useRunShortcut(): RunShortcut {
+  const [shortcut, setShortcut] = useState<RunShortcut>(RUN_SHORTCUT_MAC);
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+    setShortcut(
+      detectOs(navigator.userAgent) === "macos"
+        ? RUN_SHORTCUT_MAC
+        : RUN_SHORTCUT_NON_MAC,
+    );
+  }, []);
+  return shortcut;
+}
+
 /** Best-guess CPU architecture from a navigator user-agent string and
  *  an optional `os` hint. Default-pick reflects current desktop sales:
  *  arm64 for Apple Silicon Macs (the default for new hardware since

--- a/website/src/components/highlighted-textarea.tsx
+++ b/website/src/components/highlighted-textarea.tsx
@@ -11,6 +11,7 @@ export function HighlightedTextarea({
   language = "goccia",
   className = "",
   lineNumbers = false,
+  onSubmit,
 }: {
   value: string;
   onChange: (next: string) => void;
@@ -18,6 +19,10 @@ export function HighlightedTextarea({
   className?: string;
   /** Show a line-number gutter alongside the editor. */
   lineNumbers?: boolean;
+  /** Called when the user presses ⌘/Ctrl+Enter inside the editor. Lets a
+   *  caller wire the editor to its primary action (e.g. Execute / Run)
+   *  without having to attach a global key listener. */
+  onSubmit?: () => void;
 }) {
   const taRef = useRef<HTMLTextAreaElement>(null);
   const hlRef = useRef<HTMLPreElement>(null);
@@ -86,6 +91,16 @@ export function HighlightedTextarea({
               requestAnimationFrame(() => {
                 target.selectionStart = target.selectionEnd = s + 2;
               });
+            } else if (
+              onSubmit &&
+              e.key === "Enter" &&
+              (e.metaKey || e.ctrlKey)
+            ) {
+              // ⌘/Ctrl+Enter fires the caller's primary action (e.g. Execute).
+              // preventDefault stops the newline from being inserted into the
+              // editor before submission.
+              e.preventDefault();
+              onSubmit();
             }
           }}
         />

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { AnchorH2, AnchorH3 } from "@/components/anchor-heading";
 import { AnimatedOutput } from "@/components/animated-output";
+import { useRunShortcut } from "@/components/command-tabs";
 import { ConsolePanel } from "@/components/console-panel";
 import {
   HighlightedCode,
@@ -62,6 +63,7 @@ function HeroRunnableCard({ code }: { code: string }) {
   const [src, setSrc] = useState(code);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const hlRef = useRef<HTMLPreElement>(null);
+  const runShortcut = useRunShortcut();
 
   const copy = async () => {
     let ok = false;
@@ -233,13 +235,13 @@ function HeroRunnableCard({ code }: { code: string }) {
           className="hero-action primary"
           onClick={run}
           disabled={running}
-          title="Run · ⌘+Enter"
+          title={`Run · ${runShortcut.long}`}
           aria-label="Run"
         >
           <RunIcon size={11} />
           <span>{running ? "…" : "Run"}</span>
           <span className="hero-action-kbd" aria-hidden="true">
-            ⌘↵
+            {runShortcut.short}
           </span>
         </button>
       </div>

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -233,10 +233,14 @@ function HeroRunnableCard({ code }: { code: string }) {
           className="hero-action primary"
           onClick={run}
           disabled={running}
-          title="Run"
+          title="Run · ⌘+Enter"
           aria-label="Run"
         >
-          <RunIcon size={11} /> <span>{running ? "…" : "Run"}</span>
+          <RunIcon size={11} />
+          <span>{running ? "…" : "Run"}</span>
+          <span className="hero-action-kbd" aria-hidden="true">
+            ⌘↵
+          </span>
         </button>
       </div>
       <div className="hero-editor">

--- a/website/src/components/playground.tsx
+++ b/website/src/components/playground.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { AnimatedOutput } from "@/components/animated-output";
+import { useRunShortcut } from "@/components/command-tabs";
 import { ConsolePanel } from "@/components/console-panel";
 import { HighlightedCode } from "@/components/highlighted-code";
 import {
@@ -463,6 +464,7 @@ export function Playground({
   const hlRef = useRef<HTMLPreElement>(null);
   const runningRef = useRef(false);
   const hydratedRef = useRef(false);
+  const runShortcut = useRunShortcut();
   // Skip the example-restore effect's first fire so it doesn't clobber the
   // share/saved code that the mount effect just set.
   const initialMountRef = useRef(true);
@@ -1142,12 +1144,12 @@ export function Playground({
             className="pg-run"
             disabled={running}
             onClick={run}
-            title="Run · ⌘+Enter"
+            title={`Run · ${runShortcut.long}`}
           >
             <RunIcon size={14} />
             <span>{running ? "Running…" : "Run"}</span>
             <span className="pg-run-kbd" aria-hidden="true">
-              ⌘↵
+              {runShortcut.short}
             </span>
           </button>
         </div>

--- a/website/src/components/playground.tsx
+++ b/website/src/components/playground.tsx
@@ -9,6 +9,7 @@ import {
   CopyIcon,
   FilePlusIcon,
   FileTestIcon,
+  GithubIcon,
   RunIcon,
   SidebarIcon,
   SparkleIcon,
@@ -20,6 +21,7 @@ import {
   type OutputLine,
 } from "@/lib/examples";
 import { formatError } from "@/lib/format-error";
+import { GITHUB_REPO_URL } from "@/lib/github";
 import { validateGocciaToolInput } from "@/lib/goccia-tool-schema";
 import { loadCode, saveCode } from "@/lib/playground-storage";
 import { decodeShare, encodeShare } from "@/lib/share";
@@ -736,7 +738,7 @@ export function Playground({
     }
   }, [code, backend, version, runner, asi, compatVar, compatFunction]);
 
-  const share = useCallback(async () => {
+  const buildShareLink = useCallback(() => {
     const url = new URL(window.location.href);
     url.search = "";
     url.searchParams.set(
@@ -751,7 +753,11 @@ export function Playground({
         version,
       }),
     );
-    const link = url.toString();
+    return url.toString();
+  }, [code, backend, runner, asi, compatVar, compatFunction, version]);
+
+  const share = useCallback(async () => {
+    const link = buildShareLink();
     let ok = false;
     try {
       if (navigator.clipboard?.writeText) {
@@ -760,7 +766,47 @@ export function Playground({
       }
     } catch {}
     if (ok) setShareTick((t) => t + 1);
-  }, [code, backend, runner, asi, compatVar, compatFunction, version]);
+  }, [buildShareLink]);
+
+  const reportIssue = useCallback(() => {
+    const link = buildShareLink();
+    const onOff = (b: boolean) => (b ? "on" : "off");
+    const body = [
+      `[Open in playground](${link})`,
+      "",
+      "| Setting | Value |",
+      "|---|---|",
+      `| Backend | \`${backend}\` |`,
+      `| Runner | \`${runner}\` |`,
+      `| Version | \`${version}\` |`,
+      `| ASI | ${onOff(asi)} |`,
+      `| Compat \`var\` | ${onOff(compatVar)} |`,
+      `| Compat \`function\` | ${onOff(compatFunction)} |`,
+      "",
+      "---",
+      "",
+      "### What did you expect to happen?",
+      "",
+      "<!-- Describe the expected behavior -->",
+      "",
+      "### What actually happened?",
+      "",
+      "<!-- Describe the actual behavior, paste any error output -->",
+      "",
+    ].join("\n");
+    const issueUrl = new URL(`${GITHUB_REPO_URL}/issues/new`);
+    issueUrl.searchParams.set("title", "Playground report: ");
+    issueUrl.searchParams.set("body", body);
+    window.open(issueUrl.toString(), "_blank", "noopener,noreferrer");
+  }, [
+    buildShareLink,
+    backend,
+    runner,
+    version,
+    asi,
+    compatVar,
+    compatFunction,
+  ]);
 
   useEffect(() => {
     if (shareTick === 0) return;
@@ -1068,6 +1114,15 @@ export function Playground({
 
         <div className="ml-auto flex items-center gap-2">
           <span className="font-mono text-[0.72rem] text-ink-3">⌘ + Enter</span>
+          <button
+            type="button"
+            className="pg-share"
+            onClick={reportIssue}
+            title="Open a GitHub issue with a link to this playground"
+          >
+            <GithubIcon size={14} />
+            <span>Report issue</span>
+          </button>
           <button
             type="button"
             className="pg-share"

--- a/website/src/components/playground.tsx
+++ b/website/src/components/playground.tsx
@@ -1113,7 +1113,6 @@ export function Playground({
         </select>
 
         <div className="ml-auto flex items-center gap-2">
-          <span className="font-mono text-[0.72rem] text-ink-3">⌘ + Enter</span>
           <button
             type="button"
             className="pg-share"
@@ -1143,8 +1142,13 @@ export function Playground({
             className="pg-run"
             disabled={running}
             onClick={run}
+            title="Run · ⌘+Enter"
           >
-            <RunIcon size={14} /> {running ? "Running…" : "Run"}
+            <RunIcon size={14} />
+            <span>{running ? "Running…" : "Run"}</span>
+            <span className="pg-run-kbd" aria-hidden="true">
+              ⌘↵
+            </span>
           </button>
         </div>
       </div>

--- a/website/src/components/sandbox.tsx
+++ b/website/src/components/sandbox.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { AnchorH2 } from "@/components/anchor-heading";
 import { AnimatedOutput } from "@/components/animated-output";
+import { useRunShortcut } from "@/components/command-tabs";
 import { ConsolePanel } from "@/components/console-panel";
 import {
   HighlightedCode,
@@ -346,6 +347,7 @@ export function Sandbox() {
   // Bumped on each new execution so `<AnimatedOutput>` re-mounts and
   // re-runs its line-stagger reveal cleanly.
   const [runId, setRunId] = useState(0);
+  const runShortcut = useRunShortcut();
   const [paneCols, setPaneCols] = useState<[number, number, number]>([
     1.3, 0.9, 1,
   ]);
@@ -720,12 +722,12 @@ export function Sandbox() {
                 className="pg-run"
                 onClick={execute}
                 disabled={running}
-                title="Run · ⌘+Enter"
+                title={`Run · ${runShortcut.long}`}
               >
                 <RunIcon size={14} />
                 <span>{running ? "Running…" : "Run"}</span>
                 <span className="pg-run-kbd" aria-hidden="true">
-                  ⌘↵
+                  {runShortcut.short}
                 </span>
               </button>
             </div>

--- a/website/src/components/sandbox.tsx
+++ b/website/src/components/sandbox.tsx
@@ -704,8 +704,13 @@ export function Sandbox() {
                 className="pg-run"
                 onClick={execute}
                 disabled={running}
+                title="Execute · ⌘+Enter"
               >
-                <RunIcon size={14} /> {running ? "Running…" : "Execute"}
+                <RunIcon size={14} />
+                <span>{running ? "Running…" : "Execute"}</span>
+                <span className="pg-run-kbd" aria-hidden="true">
+                  ⌘↵
+                </span>
               </button>
             </div>
           </div>
@@ -731,6 +736,7 @@ export function Sandbox() {
                 onChange={setCode}
                 language="goccia"
                 lineNumbers
+                onSubmit={execute}
               />
             </div>
             {/* biome-ignore lint/a11y/useSemanticElements: this is an interactive splitter; button keeps pointer dragging reliable while ARIA exposes separator semantics. */}
@@ -766,6 +772,7 @@ export function Sandbox() {
                 onChange={setGlobalsText}
                 language="json"
                 lineNumbers
+                onSubmit={execute}
               />
             </div>
             {/* biome-ignore lint/a11y/useSemanticElements: this is an interactive splitter; button keeps pointer dragging reliable while ARIA exposes separator semantics. */}

--- a/website/src/components/sandbox.tsx
+++ b/website/src/components/sandbox.tsx
@@ -693,8 +693,8 @@ export function Sandbox() {
             <div>
               <h4>Sandbox preview</h4>
               <p className="m-0 text-ink-3 text-[0.88rem]">
-                Edit the script or globals and hit <strong>Execute</strong> —
-                the code runs in the same sandboxed runtime used by the server
+                Edit the script or globals and hit <strong>Run</strong> — the
+                code runs in the same sandboxed runtime used by the server
                 preview and returns a structured host result.
               </p>
             </div>
@@ -704,10 +704,10 @@ export function Sandbox() {
                 className="pg-run"
                 onClick={execute}
                 disabled={running}
-                title="Execute · ⌘+Enter"
+                title="Run · ⌘+Enter"
               >
                 <RunIcon size={14} />
-                <span>{running ? "Running…" : "Execute"}</span>
+                <span>{running ? "Running…" : "Run"}</span>
                 <span className="pg-run-kbd" aria-hidden="true">
                   ⌘↵
                 </span>

--- a/website/src/components/sandbox.tsx
+++ b/website/src/components/sandbox.tsx
@@ -335,6 +335,14 @@ export function Sandbox() {
   const [globalsText, setGlobalsText] = useState(DEFAULT_GLOBALS);
   const [output, setOutput] = useState<SbLine[]>([]);
   const [running, setRunning] = useState(false);
+  // Mirrors `running` for the synchronous re-entry guard inside
+  // `execute`. The Run button is `disabled` while running, but the
+  // ⌘/Ctrl+Enter shortcut on the editors bypasses that — without
+  // this ref a fast double-press could fire two overlapping
+  // `/api/execute` requests and race the output panel. State alone
+  // isn't enough because the closure captures a stale value across
+  // renders; a ref reads the latest value synchronously.
+  const runningRef = useRef(false);
   // Bumped on each new execution so `<AnimatedOutput>` re-mounts and
   // re-runs its line-stagger reveal cleanly.
   const [runId, setRunId] = useState(0);
@@ -379,6 +387,9 @@ export function Sandbox() {
   );
 
   const execute = useCallback(async () => {
+    // Bail if a previous run is still in flight — see `runningRef`
+    // above for why state alone isn't enough here.
+    if (runningRef.current) return;
     // Validate globals JSON up-front so a typo there doesn't cost us a
     // round-trip to the runner.
     let parsedGlobals: Record<string, unknown>;
@@ -429,6 +440,10 @@ export function Sandbox() {
       kind: "meta",
       text: "GocciaScriptLoader --timeout=500 --globals=context.json",
     };
+    // Set the re-entry flag *after* the synchronous validation guards
+    // above have committed to actually running — so a validation
+    // failure early-returns without leaving the flag stuck on.
+    runningRef.current = true;
     setRunning(true);
     setRunId((r) => r + 1);
     setOutput([banner]);
@@ -526,6 +541,7 @@ export function Sandbox() {
       ]);
     } finally {
       setRunning(false);
+      runningRef.current = false;
     }
   }, [code, globalsText]);
 


### PR DESCRIPTION
## Summary
- New "Report issue" button in the playground header opens `github.com/frostney/GocciaScript/issues/new` in a new tab, pre-filled with a back-link to the current playground state and a markdown table of the active settings (backend, runner, version, ASI, compat `var`/`function`).
- Share-URL building is factored out of the existing `share` callback into `buildShareLink`, so the Share button and the new issue link share one source of truth.

## Test plan
- [ ] Open the playground, edit some code, click **Report issue** — verify a new tab opens to `issues/new` with the playground link, settings table, and "expected/actual" sections pre-filled.
- [ ] Click the playground link from inside the issue body — verify it round-trips the code and configuration back into the playground.
- [ ] Toggle each of backend, runner, version, ASI, and the two compat flags — verify each is reflected in the settings table the next time **Report issue** is clicked.
- [ ] Click **Share** — verify it still copies a working share URL (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)