### PR TITLE
Add --source-type CLI flag and config to load entry as a module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaScriptLoader example.js --coverage --coverage-format=lcov --coverage-output=coverage.lcov # Coverage with lcov output
 ./build/GocciaScriptLoader example.js --coverage --coverage-format=json --coverage-output=coverage.json # Coverage with JSON output
 ./build/GocciaScriptLoader example.js --asi # Execute with automatic semicolon insertion
+./build/GocciaScriptLoader example.js --source-type=module # Load entry as a module (top-level this is undefined; default is script)
 ./build/GocciaScriptLoader example.js --output=json # Execute with structured JSON output
 ./build/GocciaScriptLoader example.js --output=compact-json # Execute with structured JSON output, omitting build, memory, stdout, and stderr
 ./build/GocciaScriptLoader example.js --profile=opcodes # Opcode histogram, pair frequency, scalar hit rate (bytecode)

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -183,6 +183,7 @@ The first file found is loaded and applied as the **root config**. When running 
 ```json
 {
   "mode": "bytecode",
+  "source-type": "module",
   "asi": true,
   "timeout": 5000,
   "max-memory": 10485760,

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -446,6 +446,8 @@ Engine.StrictTypes := True;              // Enable strict type enforcement
 
 When `SourceType` is `stModule`, `Execute` runs the entry program in a fresh module scope (`skModule`) with `this = undefined`, mirroring the semantics imported modules already receive from the module loader (ES2026 §16.2.1.6.4). The CLI surface for this is `--source-type=script|module` and the matching `goccia.json` key `"source-type"`.
 
+**Top-level binding persistence differs between the two modes.** In default `stScript` mode the engine reuses `Interpreter.GlobalScope` across every call to `Execute`, which is what makes the [long-lived engine pattern](#instance-usage-long-lived-engine) above work — `const x = 42` defined in one `Execute` is visible to the next. In `stModule` mode each `Execute` allocates a brand-new `skModule` child scope, so top-level `let`/`const`/`class` declarations live and die with that single call. If callers need cross-`Execute` persistence, keep `SourceType` at `stScript` (the default) or expose the desired symbols through the global scope (e.g. `Engine.RegisterGlobal(...)` or `Engine.Interpreter.GlobalScope.DefineLexicalBinding(...)`).
+
 ## Injecting Custom Globals
 
 You can inject Pascal functions and values into the script's global scope by working with the engine's interpreter scope directly.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -433,14 +433,18 @@ TGocciaEngine.RunScriptFromFile('tests/my-test.js', [ggTestAssertions]);
 |--------|------|---------|---------|
 | `Preprocessors` | `TGocciaPreprocessors` | `[ppJSX]` | Source transformations before parsing |
 | `Compatibility` | `TGocciaCompatibilityFlags` | `[]` | Parser behavior toggles |
+| `SourceType` | `TGocciaSourceType` | `stScript` | Load entry as a Script (default) or Module |
 | `StrictTypes` | `Boolean` | `False` (interpreter), `True` (bytecode) | Type enforcement for annotated variables |
 
 ```pascal
 Engine := TGocciaEngine.Create('app.js', Source, []);
 Engine.Preprocessors := [];              // Disable JSX
 Engine.ASIEnabled := True;               // Enable ASI (convenience for cfASI)
+Engine.SourceType := stModule;           // Run entry as a Module (top-level this is undefined; import.meta resolves)
 Engine.StrictTypes := True;              // Enable strict type enforcement
 ```
+
+When `SourceType` is `stModule`, `Execute` runs the entry program in a fresh module scope (`skModule`) with `this = undefined`, mirroring the semantics imported modules already receive from the module loader (ES2026 §16.2.1.6.4). The CLI surface for this is `--source-type=script|module` and the matching `goccia.json` key `"source-type"`.
 
 ## Injecting Custom Globals
 

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -426,12 +426,19 @@ end;
 
 { Resolve --source-type / config "source-type" into the engine's
   TGocciaSourceType enum.  Priority: CLI > per-file config > root
-  config > default (script). }
+  config > default (script).
+
+  CLI flag and root-config values are validated by TGocciaEnumOption.Apply
+  before they reach this function (invalid values raise TGocciaParseError
+  at parse/apply time).  Per-file config values come in as raw strings via
+  FindConfigEntry, so we validate here: 'module' and 'script' are accepted
+  case-insensitively, anything else emits a stderr warning and falls back
+  to stScript so a typo never silently flips into module mode. }
 function ResolveSourceTypeOption(
   const AOption: TGocciaEnumOption<CLI.Options.TGocciaSourceType>;
   const AFileConfig: TConfigEntryArray): Goccia.Engine.TGocciaSourceType;
 var
-  ValueStr: string;
+  ValueStr, NormalizedValue: string;
 begin
   if AOption.FromCommandLine then
   begin
@@ -442,8 +449,14 @@ begin
 
   if FindConfigEntry(AFileConfig, 'source-type', ValueStr) then
   begin
-    if LowerCase(ValueStr) = 'module' then
+    NormalizedValue := LowerCase(Trim(ValueStr));
+    if NormalizedValue = 'module' then
       Exit(Goccia.Engine.stModule);
+    if NormalizedValue = 'script' then
+      Exit(Goccia.Engine.stScript);
+    WriteLn(StdErr, Format(
+      'Warning: invalid per-file config value for "source-type": %s '
+      + '(valid: script, module). Falling back to script.', [ValueStr]));
     Exit(Goccia.Engine.stScript);
   end;
 

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -424,6 +424,39 @@ begin
     Result := ParseConfigFile(ConfigPath);
 end;
 
+{ Resolve --source-type / config "source-type" into the engine's
+  TGocciaSourceType enum.  Priority: CLI > per-file config > root
+  config > default (script). }
+function ResolveSourceTypeOption(
+  const AOption: TGocciaEnumOption<CLI.Options.TGocciaSourceType>;
+  const AFileConfig: TConfigEntryArray): Goccia.Engine.TGocciaSourceType;
+var
+  ValueStr: string;
+begin
+  if AOption.FromCommandLine then
+  begin
+    if AOption.Matches(CLI.Options.stModule) then
+      Exit(Goccia.Engine.stModule);
+    Exit(Goccia.Engine.stScript);
+  end;
+
+  if FindConfigEntry(AFileConfig, 'source-type', ValueStr) then
+  begin
+    if LowerCase(ValueStr) = 'module' then
+      Exit(Goccia.Engine.stModule);
+    Exit(Goccia.Engine.stScript);
+  end;
+
+  if AOption.Present then
+  begin
+    if AOption.Matches(CLI.Options.stModule) then
+      Exit(Goccia.Engine.stModule);
+    Exit(Goccia.Engine.stScript);
+  end;
+
+  Result := Goccia.Engine.stScript;
+end;
+
 { Apply per-file config entries to the engine.
   Priority: CLI flag > per-file config > root config > default.
   FromCommandLine distinguishes CLI-set options from root-config-set options
@@ -445,6 +478,10 @@ begin
   { ASI: CLI flag > per-file config > root config > default (false) }
   AEngine.ASIEnabled := ResolveFlagOption(
     AEngineOptions.ASI, AFileConfig, 'asi');
+
+  { source-type: CLI flag > per-file config > root config > default (script) }
+  AEngine.SourceType := ResolveSourceTypeOption(
+    AEngineOptions.SourceType, AFileConfig);
 
   { compat-var: CLI flag > per-file config > root config > default (false) }
   AEngine.VarEnabled := ResolveFlagOption(

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -30,6 +30,7 @@ uses
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.Parser,
+  Goccia.Scope,
   Goccia.ScriptLoader.Input,
   Goccia.CLI.JSON.Reporter,
   Goccia.SourceMap,
@@ -164,6 +165,9 @@ type
     FNoProgress: TGocciaFlagOption;
     FFormats: TGocciaRepeatableOption;
     FOutputFile: TGocciaStringOption;
+    procedure RunBytecodeBenchmarkModule(const AEngine: TGocciaEngine;
+      const AExecutor: TGocciaBytecodeExecutor;
+      const AModule: TGocciaBytecodeModule; const AFileName: string);
     procedure CollectBenchmarkFileInterpreted(const AFileName: string;
       const AReporter: TBenchmarkReporter; const AShowProgress: Boolean);
     procedure CollectBenchmarkFileBytecode(const AFileName: string;
@@ -223,6 +227,26 @@ begin
     Result := TGocciaObjectValue(Value)
   else
     Result := nil;
+end;
+
+procedure TBenchmarkRunnerApp.RunBytecodeBenchmarkModule(
+  const AEngine: TGocciaEngine;
+  const AExecutor: TGocciaBytecodeExecutor;
+  const AModule: TGocciaBytecodeModule; const AFileName: string);
+var
+  ModuleScope: TGocciaScope;
+begin
+  if AEngine.SourceType = stModule then
+  begin
+    { Run with module semantics: fresh module scope, this = undefined.
+      Mirrors TGocciaModuleLoader.LoadModule for nested module loads. }
+    ModuleScope := AEngine.Interpreter.GlobalScope.CreateChild(skModule,
+      'Module:' + AFileName);
+    ModuleScope.ThisValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+    AExecutor.RunModuleInScope(AModule, ModuleScope);
+  end
+  else
+    AExecutor.RunModule(AModule);
 end;
 
 procedure TBenchmarkRunnerApp.CollectBenchmarkFileInterpreted(
@@ -369,7 +393,8 @@ begin
           StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
           StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
           try
-            TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
+            RunBytecodeBenchmarkModule(Engine,
+              TGocciaBytecodeExecutor(Engine.Executor), Module, AFileName);
             ExecEnd := GetNanoseconds;
 
             FileResult.FileName := AFileName;
@@ -582,7 +607,8 @@ begin
         StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
         StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
         try
-          TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
+          RunBytecodeBenchmarkModule(Engine,
+            TGocciaBytecodeExecutor(Engine.Executor), Module, AFileName);
           ExecEnd := GetNanoseconds;
 
           FileResult.FileName := AFileName;

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -33,6 +33,7 @@ uses
   Goccia.Parser,
   Goccia.Profiler,
   Goccia.Profiler.Report,
+  Goccia.Scope,
   Goccia.ScriptLoader.Globals,
   Goccia.ScriptLoader.Input,
   Goccia.CLI.JSON.Reporter,
@@ -112,6 +113,10 @@ type
     procedure ApplyModuleGlobalsToEngine(const AEngine: TGocciaEngine);
     function ExecuteInterpreted(const ASource: TStringList; const AFileName: string;
       const ACapture: TScriptLoaderConsoleCapture): TScriptExecutionReport;
+    function RunBytecodeModule(const AEngine: TGocciaEngine;
+      const AExecutor: TGocciaBytecodeExecutor;
+      const AModule: TGocciaBytecodeModule;
+      const AFileName: string): TGocciaValue;
     function ExecuteBytecodeFromSource(const ASource: TStringList; const AFileName: string;
       const ACapture: TScriptLoaderConsoleCapture): TScriptExecutionReport;
     function ExecuteBytecodeFromFile(const AFileName: string;
@@ -618,6 +623,26 @@ begin
   Result.Timing.TotalTimeNanoseconds := ScriptResult.TotalTimeNanoseconds;
 end;
 
+function TScriptLoaderApp.RunBytecodeModule(const AEngine: TGocciaEngine;
+  const AExecutor: TGocciaBytecodeExecutor;
+  const AModule: TGocciaBytecodeModule;
+  const AFileName: string): TGocciaValue;
+var
+  ModuleScope: TGocciaScope;
+begin
+  if AEngine.SourceType = stModule then
+  begin
+    { Run with module semantics: fresh module scope, this = undefined.
+      Mirrors TGocciaModuleLoader.LoadModule for nested module loads. }
+    ModuleScope := AEngine.Interpreter.GlobalScope.CreateChild(skModule,
+      'Module:' + AFileName);
+    ModuleScope.ThisValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Result := AExecutor.RunModuleInScope(AModule, ModuleScope);
+  end
+  else
+    Result := AExecutor.RunModule(AModule);
+end;
+
 function TScriptLoaderApp.ExecuteBytecodeFromSource(const ASource: TStringList;
   const AFileName: string; const ACapture: TScriptLoaderConsoleCapture): TScriptExecutionReport;
 var
@@ -667,7 +692,8 @@ begin
       try
         try
           ApplyModuleGlobalsToEngine(Engine);
-          Result.ResultValue := TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
+          Result.ResultValue := RunBytecodeModule(Engine,
+            TGocciaBytecodeExecutor(Engine.Executor), Module, AFileName);
         finally
           ClearExecutionTimeout;
           ClearInstructionLimit;
@@ -708,7 +734,8 @@ begin
         StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
         try
           ApplyModuleGlobalsToEngine(Engine);
-          Result.ResultValue := TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
+          Result.ResultValue := RunBytecodeModule(Engine,
+            TGocciaBytecodeExecutor(Engine.Executor), Module, AFileName);
         finally
           ClearExecutionTimeout;
           ClearInstructionLimit;

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -30,6 +30,7 @@ uses
   Goccia.JSX.Transformer,
   Goccia.Lexer,
   Goccia.Parser,
+  Goccia.Scope,
   Goccia.ScriptLoader.Input,
   Goccia.SourceMap,
   Goccia.Builtins.TestingLibrary,
@@ -134,6 +135,10 @@ type
     function IsCompactJsonOutput: Boolean;
     function RunGocciaScriptInterpreted(const AFileName: string;
       APreloadedSource: TStringList = nil): TTestFileResult;
+    function RunBytecodeTestModule(const AEngine: TGocciaEngine;
+      const AExecutor: TGocciaBytecodeExecutor;
+      const AModule: TGocciaBytecodeModule;
+      const AFileName: string): TGocciaValue;
     function RunGocciaScriptBytecode(const AFileName: string;
       APreloadedSource: TStringList = nil): TTestFileResult;
     function RunGocciaScript(const AFileName: string;
@@ -462,6 +467,26 @@ begin
   end;
 end;
 
+function TTestRunnerApp.RunBytecodeTestModule(const AEngine: TGocciaEngine;
+  const AExecutor: TGocciaBytecodeExecutor;
+  const AModule: TGocciaBytecodeModule;
+  const AFileName: string): TGocciaValue;
+var
+  ModuleScope: TGocciaScope;
+begin
+  if AEngine.SourceType = stModule then
+  begin
+    { Run with module semantics: fresh module scope, this = undefined.
+      Mirrors TGocciaModuleLoader.LoadModule for nested module loads. }
+    ModuleScope := AEngine.Interpreter.GlobalScope.CreateChild(skModule,
+      'Module:' + AFileName);
+    ModuleScope.ThisValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Result := AExecutor.RunModuleInScope(AModule, ModuleScope);
+  end
+  else
+    Result := AExecutor.RunModule(AModule);
+end;
+
 function TTestRunnerApp.RunGocciaScriptBytecode(const AFileName: string;
   APreloadedSource: TStringList): TTestFileResult;
 var
@@ -580,7 +605,8 @@ begin
             StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
             try
               try
-                ResultValue := TGocciaBytecodeExecutor(Engine.Executor).RunModule(Module);
+                ResultValue := RunBytecodeTestModule(Engine,
+                  TGocciaBytecodeExecutor(Engine.Executor), Module, AFileName);
               finally
                 ClearExecutionTimeout;
                 ClearInstructionLimit;

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -149,10 +149,12 @@ type
   end;
 
   TGocciaExecutionMode = (emInterpreted, emBytecode);
+  TGocciaSourceType = (stScript, stModule);
 
   TGocciaEngineOptions = class
   private
     FMode: TGocciaEnumOption<TGocciaExecutionMode>;
+    FSourceType: TGocciaEnumOption<TGocciaSourceType>;
     FASI: TGocciaFlagOption;
     FImportMap: TGocciaStringOption;
     FAliases: TGocciaRepeatableOption;
@@ -172,6 +174,7 @@ type
     function Options: TGocciaOptionArray;
 
     property Mode: TGocciaEnumOption<TGocciaExecutionMode> read FMode;
+    property SourceType: TGocciaEnumOption<TGocciaSourceType> read FSourceType;
     property ASI: TGocciaFlagOption read FASI;
     property ImportMap: TGocciaStringOption read FImportMap;
     property Aliases: TGocciaRepeatableOption read FAliases;
@@ -542,6 +545,8 @@ begin
   inherited Create;
   FMode := TGocciaEnumOption<TGocciaExecutionMode>.Create('mode',
     'Execution mode', 'Engine');
+  FSourceType := TGocciaEnumOption<TGocciaSourceType>.Create('source-type',
+    'Source loading kind (default: script)', 'Engine');
   FASI := TGocciaFlagOption.Create('asi',
     'Enable automatic semicolon insertion', 'Engine');
   FImportMap := TGocciaStringOption.Create('import-map',
@@ -572,6 +577,7 @@ end;
 destructor TGocciaEngineOptions.Destroy;
 begin
   FMode.Free;
+  FSourceType.Free;
   FASI.Free;
   FImportMap.Free;
   FAliases.Free;
@@ -589,20 +595,21 @@ end;
 
 function TGocciaEngineOptions.Options: TGocciaOptionArray;
 begin
-  SetLength(Result, 13);
+  SetLength(Result, 14);
   Result[0] := FMode;
-  Result[1] := FASI;
-  Result[2] := FImportMap;
-  Result[3] := FAliases;
-  Result[4] := FTimeout;
-  Result[5] := FMaxMemory;
-  Result[6] := FMaxInstructions;
-  Result[7] := FUnsafeFFI;
-  Result[8] := FUnsafeFunctionConstructor;
-  Result[9] := FStackSize;
-  Result[10] := FCompatVar;
-  Result[11] := FCompatFunction;
-  Result[12] := FAllowedHosts;
+  Result[1] := FSourceType;
+  Result[2] := FASI;
+  Result[3] := FImportMap;
+  Result[4] := FAliases;
+  Result[5] := FTimeout;
+  Result[6] := FMaxMemory;
+  Result[7] := FMaxInstructions;
+  Result[8] := FUnsafeFFI;
+  Result[9] := FUnsafeFunctionConstructor;
+  Result[10] := FStackSize;
+  Result[11] := FCompatVar;
+  Result[12] := FCompatFunction;
+  Result[13] := FAllowedHosts;
 end;
 
 { TGocciaCoverageOptions }

--- a/source/units/Goccia.Engine.Backend.pas
+++ b/source/units/Goccia.Engine.Backend.pas
@@ -32,8 +32,8 @@ type
       const ASourcePath: string); override;
     function ExecuteProgram(
       const AProgram: TGocciaProgram): TGocciaValue; override;
-    procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
-      const AContext: TGocciaEvaluationContext); override;
+    function EvaluateModuleBody(const AProgram: TGocciaProgram;
+      const AContext: TGocciaEvaluationContext): TGocciaValue; override;
     function ExecuteDynamicFunction(
       const AProgram: TGocciaProgram): TGocciaValue; override;
     procedure ClearTransientCaches; override;
@@ -42,6 +42,12 @@ type
     function CompileToModule(
       const AProgram: TGocciaProgram): TGocciaBytecodeModule;
     function RunModule(const AModule: TGocciaBytecodeModule): TGocciaValue;
+    { Run AModule with FVM.GlobalScope temporarily replaced by AScope.
+      Used to execute the entry program with a fresh module scope when
+      --source-type=module is set; mirrors the swap that
+      EvaluateModuleBody does for nested module loads. }
+    function RunModuleInScope(const AModule: TGocciaBytecodeModule;
+      const AScope: TGocciaScope): TGocciaValue;
 
     property VM: TGocciaVM read FVM;
     property GlobalBackedTopLevel: Boolean read FGlobalBackedTopLevel
@@ -85,8 +91,9 @@ begin
   AModuleLoader.EvaluateModuleBody := EvaluateModuleBody;
 end;
 
-procedure TGocciaBytecodeExecutor.EvaluateModuleBody(
-  const AProgram: TGocciaProgram; const AContext: TGocciaEvaluationContext);
+function TGocciaBytecodeExecutor.EvaluateModuleBody(
+  const AProgram: TGocciaProgram;
+  const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   Compiler: TGocciaCompiler;
   BytecodeModule: TGocciaBytecodeModule;
@@ -105,7 +112,7 @@ begin
   SavedGlobalScope := FVM.GlobalScope;
   FVM.GlobalScope := AContext.Scope;
   try
-    FVM.ExecuteModule(BytecodeModule);
+    Result := FVM.ExecuteModule(BytecodeModule);
   finally
     FVM.GlobalScope := SavedGlobalScope;
   end;
@@ -183,6 +190,21 @@ begin
   finally
     GProfilingAllocations := False;
     GC.Enabled := WasEnabled;
+  end;
+end;
+
+function TGocciaBytecodeExecutor.RunModuleInScope(
+  const AModule: TGocciaBytecodeModule;
+  const AScope: TGocciaScope): TGocciaValue;
+var
+  SavedGlobalScope: TGocciaScope;
+begin
+  SavedGlobalScope := FVM.GlobalScope;
+  FVM.GlobalScope := AScope;
+  try
+    Result := RunModule(AModule);
+  finally
+    FVM.GlobalScope := SavedGlobalScope;
   end;
 end;
 

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -87,6 +87,8 @@ type
   TGocciaCompatibility = (cfASI, cfVar, cfFunction);
   TGocciaCompatibilityFlags = set of TGocciaCompatibility;
 
+  TGocciaSourceType = (stScript, stModule);
+
   TGocciaScriptResult = record
     Result: TGocciaValue;
     LexTimeNanoseconds: Int64;
@@ -109,14 +111,15 @@ type
       const AProgram: TGocciaProgram): TGocciaValue; override;
     function ExecuteDynamicFunction(
       const AProgram: TGocciaProgram): TGocciaValue; override;
-    procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
-      const AContext: TGocciaEvaluationContext); override;
+    function EvaluateModuleBody(const AProgram: TGocciaProgram;
+      const AContext: TGocciaEvaluationContext): TGocciaValue; override;
   end;
 
   TGocciaEngine = class
   public
     const DefaultPreprocessors: TGocciaPreprocessors = [ppJSX];
     const DefaultCompatibility: TGocciaCompatibilityFlags = [];
+    const DefaultSourceType: TGocciaSourceType = stScript;
   private
     FInterpreter: TGocciaInterpreter;
     FSourcePath: string;
@@ -125,6 +128,7 @@ type
     FInjectedGlobals: TStringList;
     FPreprocessors: TGocciaPreprocessors;
     FCompatibility: TGocciaCompatibilityFlags;
+    FSourceType: TGocciaSourceType;
     FStrictTypes: Boolean;
     FShims: TStringList;
     FExecutor: TGocciaExecutor;
@@ -256,6 +260,7 @@ type
     property FunctionConstructor: TGocciaFunctionConstructorClassValue read FFunctionConstructor;
     property Preprocessors: TGocciaPreprocessors read FPreprocessors write SetPreprocessors;
     property Compatibility: TGocciaCompatibilityFlags read FCompatibility write SetCompatibility;
+    property SourceType: TGocciaSourceType read FSourceType write FSourceType;
     property StrictTypes: Boolean read FStrictTypes write FStrictTypes;
     property Shims: TStringList read FShims;
     property BuiltinConsole: TGocciaConsole read FBuiltinConsole;
@@ -311,6 +316,7 @@ uses
   Goccia.CallStack,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.ControlFlow,
   Goccia.Coverage,
   Goccia.Error,
   Goccia.Evaluator,
@@ -385,17 +391,24 @@ begin
   Result := FInterpreter.Execute(AProgram);
 end;
 
-procedure TGocciaInterpreterExecutor.EvaluateModuleBody(
-  const AProgram: TGocciaProgram; const AContext: TGocciaEvaluationContext);
+function TGocciaInterpreterExecutor.EvaluateModuleBody(
+  const AProgram: TGocciaProgram;
+  const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   I: Integer;
+  CF: TGocciaControlFlow;
 begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if FInterpreter.VarEnabled then
     HoistVarDeclarations(AProgram.Body, AContext.Scope);
   if FInterpreter.FunctionEnabled then
     HoistFunctionDeclarations(AProgram.Body, AContext);
   for I := 0 to AProgram.Body.Count - 1 do
-    EvaluateStatement(AProgram.Body[I], AContext);
+  begin
+    CF := EvaluateStatement(AProgram.Body[I], AContext);
+    Result := CF.Value;
+    if CF.Kind = cfkReturn then Exit;
+  end;
 end;
 
 { TGocciaEngine }
@@ -656,6 +669,7 @@ begin
 
   FPreprocessors := DefaultPreprocessors;
   FCompatibility := DefaultCompatibility;
+  FSourceType := DefaultSourceType;
   if Assigned(FExecutor) then
     FStrictTypes := FExecutor.DefaultStrictTypes
   else
@@ -1389,11 +1403,13 @@ var
   Parser: TGocciaParser;
   ProgramNode: TGocciaProgram;
   Tokens: TObjectList<TGocciaToken>;
-  StartTime, LexEnd, ParseEnd, ExecEnd: Int64;
+  StartTime, LexEnd, ParseEnd, ExecStart, ExecEnd: Int64;
   SourceText: string;
   JSXResult: TGocciaJSXTransformResult;
   SourceMap: TGocciaSourceMap;
   OrigLine, OrigCol: Integer;
+  ModuleScope: TGocciaScope;
+  ModuleContext: TGocciaEvaluationContext;
 begin
   FillChar(FLastTiming, SizeOf(FLastTiming), 0);
   FLastTiming.FileName := FSourcePath;
@@ -1443,13 +1459,40 @@ begin
           end;
 
           try
-            CheckTopLevelRedeclarations(ProgramNode,
-              FInterpreter.GlobalScope, FSourcePath);
-            FLastTiming.Result := FExecutor.ExecuteProgram(ProgramNode);
-            WaitForFetchIdle;
-            ExecEnd := GetNanoseconds;
-            FLastTiming.CompileTimeNanoseconds := FExecutor.CompileTimeNanoseconds;
-            FLastTiming.ExecuteTimeNanoseconds := FExecutor.ExecuteTimeNanoseconds;
+            if FSourceType = stModule then
+            begin
+              // ES2026 §16.2.1.6.4: a Module Environment Record's
+              // [[ThisValue]] is undefined.  Run the entry program in a
+              // fresh module scope so import.meta resolves and top-level
+              // `this` is undefined, matching the semantics imported
+              // modules already receive via TGocciaModuleLoader.
+              ModuleScope := FInterpreter.GlobalScope.CreateChild(skModule,
+                'Module:' + FSourcePath);
+              ModuleScope.ThisValue :=
+                TGocciaUndefinedLiteralValue.UndefinedValue;
+              ModuleContext := FInterpreter.CreateEvaluationContext;
+              ModuleContext.Scope := ModuleScope;
+              ModuleContext.CurrentFilePath := FSourcePath;
+              ExecStart := GetNanoseconds;
+              FLastTiming.Result :=
+                FExecutor.EvaluateModuleBody(ProgramNode, ModuleContext);
+              WaitForFetchIdle;
+              ExecEnd := GetNanoseconds;
+              FLastTiming.CompileTimeNanoseconds := 0;
+              FLastTiming.ExecuteTimeNanoseconds := ExecEnd - ExecStart;
+            end
+            else
+            begin
+              CheckTopLevelRedeclarations(ProgramNode,
+                FInterpreter.GlobalScope, FSourcePath);
+              FLastTiming.Result := FExecutor.ExecuteProgram(ProgramNode);
+              WaitForFetchIdle;
+              ExecEnd := GetNanoseconds;
+              FLastTiming.CompileTimeNanoseconds :=
+                FExecutor.CompileTimeNanoseconds;
+              FLastTiming.ExecuteTimeNanoseconds :=
+                FExecutor.ExecuteTimeNanoseconds;
+            end;
             FLastTiming.TotalTimeNanoseconds := ExecEnd - StartTime;
           finally
             if Assigned(TGocciaMicrotaskQueue.Instance) then

--- a/source/units/Goccia.Executor.pas
+++ b/source/units/Goccia.Executor.pas
@@ -26,8 +26,11 @@ type
       const ASourcePath: string); virtual;
     function ExecuteProgram(
       const AProgram: TGocciaProgram): TGocciaValue; virtual; abstract;
-    procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
-      const AContext: TGocciaEvaluationContext); virtual; abstract;
+    { Evaluate the module body in AContext and return the completion
+      value (last expression value, or undefined). }
+    function EvaluateModuleBody(const AProgram: TGocciaProgram;
+      const AContext: TGocciaEvaluationContext): TGocciaValue;
+      virtual; abstract;
     function ExecuteDynamicFunction(
       const AProgram: TGocciaProgram): TGocciaValue; virtual; abstract;
     procedure ClearTransientCaches; virtual;

--- a/source/units/Goccia.Interpreter.pas
+++ b/source/units/Goccia.Interpreter.pas
@@ -37,8 +37,8 @@ type
     FModuleLoader: TGocciaModuleLoader;
     FOwnsModuleLoader: Boolean;
 
-    procedure EvaluateModuleBody(const AProgram: TGocciaProgram;
-      const AContext: TGocciaEvaluationContext);
+    function EvaluateModuleBody(const AProgram: TGocciaProgram;
+      const AContext: TGocciaEvaluationContext): TGocciaValue;
     procedure ThrowError(const AMessage: string; const ALine, AColumn: Integer);
     function GetContentProvider: TGocciaModuleContentProvider;
     function GetGlobalModules: TOrderedStringMap<TGocciaModule>;
@@ -203,17 +203,24 @@ begin
       'Create the interpreter with a configured TGocciaModuleLoader instead.');
 end;
 
-procedure TGocciaInterpreter.EvaluateModuleBody(
-  const AProgram: TGocciaProgram; const AContext: TGocciaEvaluationContext);
+function TGocciaInterpreter.EvaluateModuleBody(
+  const AProgram: TGocciaProgram;
+  const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   I: Integer;
+  CF: TGocciaControlFlow;
 begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if FVarEnabled then
     HoistVarDeclarations(AProgram.Body, AContext.Scope);
   if FFunctionEnabled then
     HoistFunctionDeclarations(AProgram.Body, AContext);
   for I := 0 to AProgram.Body.Count - 1 do
-    EvaluateStatement(AProgram.Body[I], AContext);
+  begin
+    CF := EvaluateStatement(AProgram.Body[I], AContext);
+    Result := CF.Value;
+    if CF.Kind = cfkReturn then Exit;
+  end;
 end;
 
 procedure TGocciaInterpreter.ThrowError(const AMessage: string; const ALine, AColumn: Integer);

--- a/source/units/Goccia.Modules.Loader.pas
+++ b/source/units/Goccia.Modules.Loader.pas
@@ -15,11 +15,17 @@ uses
   Goccia.Modules,
   Goccia.Modules.ContentProvider,
   Goccia.Modules.Resolver,
-  Goccia.Scope;
+  Goccia.Scope,
+  Goccia.Values.Primitives;
 
 type
-  TGocciaModuleBodyEvaluator = procedure(const AProgram: TGocciaProgram;
-    const AContext: TGocciaEvaluationContext) of object;
+  { Evaluate the body of a module-form program in AContext.
+    Returns the last expression's completion value (or undefined for
+    declaration-only bodies).  Module imports discard the return; the
+    --source-type=module entry path uses it so the test runner can
+    read the runTests(...) results object. }
+  TGocciaModuleBodyEvaluator = function(const AProgram: TGocciaProgram;
+    const AContext: TGocciaEvaluationContext): TGocciaValue of object;
 
   TGocciaModuleLoader = class
   private
@@ -90,7 +96,6 @@ uses
   Goccia.TSV,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
-  Goccia.Values.Primitives,
   Goccia.YAML;
 
 const

--- a/tests/language/source-type/goccia.json
+++ b/tests/language/source-type/goccia.json
@@ -1,0 +1,3 @@
+{
+  "source-type": "module"
+}

--- a/tests/language/source-type/import-meta.js
+++ b/tests/language/source-type/import-meta.js
@@ -1,0 +1,24 @@
+/*---
+description: >
+  --source-type=module makes the entry script a Module, so import.meta
+  resolves to a Module Record's import meta object (ES2026 §13.3.12.1)
+  and exposes a `url` string identifying this file.
+---*/
+
+const meta = import.meta;
+const metaUrl = import.meta.url;
+
+describe("source-type=module entry import.meta", () => {
+  test("import.meta is an object", () => {
+    expect(typeof meta).toBe("object");
+    expect(meta).not.toBeNull();
+  });
+
+  test("import.meta.url is a string", () => {
+    expect(typeof metaUrl).toBe("string");
+  });
+
+  test("import.meta.url points at this file", () => {
+    expect(metaUrl.endsWith("/import-meta.js")).toBe(true);
+  });
+});

--- a/tests/language/source-type/this-binding.js
+++ b/tests/language/source-type/this-binding.js
@@ -1,0 +1,25 @@
+/*---
+description: >
+  --source-type=module loads the entry script as a Module. Per
+  ES2026 §16.2.1.6.4, a Module Environment Record's [[ThisValue]] is
+  undefined, so top-level `this` resolves to undefined rather than
+  globalThis. The directory-level goccia.json sets the source type so
+  every file in this directory runs as a Module.
+---*/
+
+const topLevelThis = this;
+const topLevelThisType = typeof this;
+
+describe("source-type=module entry", () => {
+  test("top-level this is undefined", () => {
+    expect(topLevelThis).toBeUndefined();
+  });
+
+  test("top-level typeof this is 'undefined'", () => {
+    expect(topLevelThisType).toBe("undefined");
+  });
+
+  test("top-level this is not globalThis", () => {
+    expect(topLevelThis === globalThis).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--source-type=script|module` (and matching `goccia.json` `"source-type"`) on every CLI that calls `AddEngineOptions`: `GocciaScriptLoader`, `GocciaTestRunner`, `GocciaBenchmarkRunner`, `GocciaBundler`, `GocciaREPL`. Default is `script`, preserving existing behavior.
- New `TGocciaSourceType = (stScript, stModule)` on `TGocciaEngine`. When set to `stModule`, `Execute` runs the entry program in a fresh `skModule` scope with `this = undefined`, mirroring the semantics imported modules already get from `TGocciaModuleLoader` (ES2026 §16.2.1.6.4). `import.meta.url` resolves and top-level `this` no longer aliases `globalThis`.
- `EvaluateModuleBody` changes from procedure to function returning `TGocciaValue` so the test runner can still observe the `runTests(...)` completion value when the entry runs as a module. Existing module loader call sites discard the return.
- New `TGocciaBytecodeExecutor.RunModuleInScope` lets non-`Engine.Execute` callers (the script loader's bytecode-from-source/file paths plus the test and benchmark runners) honor the flag without losing their per-phase timing optimizations.

## Test plan

- [x] `./build.pas` clean dev build of all five binaries
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress` (interpreted) — 8233/8279 (5 pre-existing FFI fixture failures, unrelated)
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi --mode=bytecode --no-progress` — 8274/8279 (same 5 pre-existing failures)
- [x] All Pascal unit tests pass (`build/Goccia.*.Test`)
- [x] `./format.pas --check` passes
- [x] New `tests/language/source-type/` directory with a per-directory `goccia.json` and assertions on top-level `this` + `import.meta` — 6/6 tests pass in both interpreted and bytecode mode
- [x] Manual smoke: CLI flag, config file, CLI-overrides-config priority, invalid-value error, `--help` listing all five binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)