### PR TITLE
Sync playground gutter scroll with textarea

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -2015,6 +2015,12 @@ a.info-term {
   border-right: 1px solid var(--rule-soft);
   background: var(--paper-3);
   min-width: 2.5rem;
+  /* Clip overflowing line numbers and become a scrollable element so the
+     `syncScroll` handler in `playground.tsx` can mirror the textarea's
+     `scrollTop` here. With the default `overflow: visible`, `scrollTop`
+     is read-only and the line numbers stay anchored at line 1 even when
+     the source has scrolled past it. */
+  overflow: hidden;
 }
 .pg-editor-body {
   flex: 1;

--- a/website/src/components/playground.tsx
+++ b/website/src/components/playground.tsx
@@ -462,6 +462,7 @@ export function Playground({
   const [ghostDismissed, setGhostDismissed] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const hlRef = useRef<HTMLPreElement>(null);
+  const gutterRef = useRef<HTMLPreElement>(null);
   const runningRef = useRef(false);
   const hydratedRef = useRef(false);
   const runShortcut = useRunShortcut();
@@ -816,10 +817,19 @@ export function Playground({
     return () => clearTimeout(id);
   }, [shareTick]);
 
+  // Mirror the textarea's scroll onto the highlight overlay AND the line-
+  // number gutter. Without the gutter sync, the line numbers stay frozen
+  // at line 1 while the user scrolls the source, so the visible gutter
+  // labels no longer match the code beside them and clicks "look like"
+  // they hit the wrong line. The gutter needs `overflow: hidden` for
+  // `scrollTop` to take effect — see `.pg-gutter` in `globals.css`.
   const syncScroll = () => {
     if (taRef.current && hlRef.current) {
       hlRef.current.scrollTop = taRef.current.scrollTop;
       hlRef.current.scrollLeft = taRef.current.scrollLeft;
+    }
+    if (taRef.current && gutterRef.current) {
+      gutterRef.current.scrollTop = taRef.current.scrollTop;
     }
   };
 
@@ -1225,7 +1235,9 @@ export function Playground({
             </div>
             <p className="pg-example-desc">{example.desc}</p>
             <div className="pg-editor">
-              <pre className="pg-gutter">{gutter}</pre>
+              <pre className="pg-gutter" ref={gutterRef} aria-hidden="true">
+                {gutter}
+              </pre>
               <div className="pg-editor-body">
                 <pre className="pg-hl" ref={hlRef} aria-hidden="true">
                   <code>


### PR DESCRIPTION
## Summary
- Verified the playground ASI toggle is honored end-to-end (defaults to `true` but `--asi` is omitted when the user unchecks it). No code change needed there.
- Fixed the line-number gutter staying frozen at line 1 while the textarea/highlight scrolled, which made clicks and typing appear to land on the wrong line in long files.
- Mirror `scrollTop` from the textarea onto the gutter in `syncScroll`, matching the existing `HighlightedTextarea` pattern, and add `overflow: hidden` to `.pg-gutter` so `scrollTop` is no longer read-only.

## Test plan
- [ ] Open `/playground`, switch to a long example (e.g. paste 80+ lines), scroll the editor, and confirm gutter line numbers track the visible code.
- [ ] Click on a visible line after scrolling — caret lands on the line whose number is shown beside it; subsequent typing lands at that line.
- [ ] Verify the ASI checkbox: with the same `const a = 1\nconst b = 2\nconsole.log(a + b)` snippet, ASI on returns `3`, ASI off returns a `SyntaxError: Expected ";"`.
- [ ] No regression at the bottom of long files (gutter and code stay aligned through the last line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)