### PR TITLE
Fix benchmark failure JSON output

### DIFF
--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -96,6 +96,7 @@ begin
 
       for I := 0 to EntryCount - 1 do
       begin
+        Entry := Default(TBenchmarkEntry);
         SingleResult := TGocciaObjectValue(ResultsArray.GetElement(I));
 
         Entry.Suite := SingleResult.GetProperty('suite').ToStringLiteral.Value;
@@ -145,6 +146,7 @@ procedure MakeErrorFileResult(const AFileName, AMessage: string;
 var
   FileResult: TBenchmarkFileResult;
 begin
+  FileResult := Default(TBenchmarkFileResult);
   FileResult.FileName := AFileName;
   FileResult.LexTimeNanoseconds := 0;
   FileResult.ParseTimeNanoseconds := 0;

--- a/source/units/Goccia.Benchmark.Reporter.pas
+++ b/source/units/Goccia.Benchmark.Reporter.pas
@@ -99,6 +99,24 @@ begin
     IsPositiveFinite(AEntry.MeanMs) and (AEntry.Iterations > 0);
 end;
 
+function FormatJSONNumber(const AValue: Double;
+  const AFormatSettings: TFormatSettings): string;
+begin
+  if Math.IsNan(AValue) or Math.IsInfinite(AValue) then
+    Exit('null');
+
+  Result := SysUtils.Format('%.6f', [AValue], AFormatSettings);
+end;
+
+function FormatJSONPercentage(const AValue: Double;
+  const AFormatSettings: TFormatSettings): string;
+begin
+  if Math.IsNan(AValue) or Math.IsInfinite(AValue) then
+    Exit('null');
+
+  Result := SysUtils.Format('%.4f', [AValue], AFormatSettings);
+end;
+
 function ParseReportFormat(const S: string): TBenchmarkReportFormat;
 var
   Lower: string;
@@ -420,14 +438,18 @@ begin
       end
       else
         BenchmarkJSON := SysUtils.Format(
-          '{"suite":"%s","name":"%s","opsPerSec":%.6f,' +
-          '"variancePercentage":%.4f,"meanMs":%.6f,"iterations":%d,' +
-          '"setupMs":%.6f,"teardownMs":%.6f,"minOpsPerSec":%.6f,' +
-          '"maxOpsPerSec":%.6f}',
-          [EscapeJSON(Entry.Suite), EscapeJSON(Entry.Name), Entry.OpsPerSec,
-           Entry.VariancePercentage, Entry.MeanMs, Entry.Iterations,
-           Entry.SetupMs, Entry.TeardownMs, Entry.MinOpsPerSec,
-           Entry.MaxOpsPerSec], JSONFormatSettings);
+          '{"suite":"%s","name":"%s","opsPerSec":%s,' +
+          '"variancePercentage":%s,"meanMs":%s,"iterations":%d,' +
+          '"setupMs":%s,"teardownMs":%s,"minOpsPerSec":%s,' +
+          '"maxOpsPerSec":%s}',
+          [EscapeJSON(Entry.Suite), EscapeJSON(Entry.Name),
+           FormatJSONNumber(Entry.OpsPerSec, JSONFormatSettings),
+           FormatJSONPercentage(Entry.VariancePercentage, JSONFormatSettings),
+           FormatJSONNumber(Entry.MeanMs, JSONFormatSettings), Entry.Iterations,
+           FormatJSONNumber(Entry.SetupMs, JSONFormatSettings),
+           FormatJSONNumber(Entry.TeardownMs, JSONFormatSettings),
+           FormatJSONNumber(Entry.MinOpsPerSec, JSONFormatSettings),
+           FormatJSONNumber(Entry.MaxOpsPerSec, JSONFormatSettings)]);
 
       if BenchmarksJSON <> '' then
         BenchmarksJSON := BenchmarksJSON + ',';


### PR DESCRIPTION
## Summary
- initialize benchmark result records before populating entries
- serialize non-finite benchmark JSON numbers as null instead of platform-specific tokens

## Verification
- bun run scripts/test-cli-apps.ts
- ./format.pas --check
- git diff --check
- ./build.pas --prod
- direct failing benchmark JSON parse against production GocciaBenchmarkRunner