### PR TITLE
Fix test262 literal conformance

### DIFF
--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -537,10 +537,19 @@ end;
 
 procedure TGocciaLexer.ProcessEscapeSequence(var ASB: TStringBuffer);
 begin
+  if IsLineTerminator then
+  begin
+    ConsumeLineTerminator;
+    Exit;
+  end;
+
   case Peek of
+    'b': begin ASB.AppendChar(#8); Advance; end;
+    'f': begin ASB.AppendChar(#12); Advance; end;
     'n': begin ASB.AppendChar(#10); Advance; end;
     'r': begin ASB.AppendChar(#13); Advance; end;
     't': begin ASB.AppendChar(#9); Advance; end;
+    'v': begin ASB.AppendChar(#11); Advance; end;
     '\': begin ASB.AppendChar('\'); Advance; end;
     '0': begin ASB.AppendChar(#0); Advance; end;
     'u': begin Advance; ASB.Append(ScanUnicodeEscape); end;
@@ -1591,6 +1600,12 @@ begin
         Advance; // consume second dot
         Advance; // consume third dot
         AddToken(gttSpread);
+      end
+      else if CharInSet(Peek, ['0'..'9']) then
+      begin
+        Dec(FCurrent);
+        Dec(FColumn);
+        ScanNumber;
       end
       else
         AddToken(gttDot);

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -5421,16 +5421,20 @@ function TGocciaParser.ConvertNumberLiteral(const ALexeme: string): Double;
 var
   Value: Double;
   IntValue: Int64;
-  HexStr, BinStr, OctStr: string;
+  NormalizedLexeme, HexStr, BinStr, OctStr: string;
   I: Integer;
 begin
+  NormalizedLexeme := ALexeme;
+  if (Length(NormalizedLexeme) > 0) and (NormalizedLexeme[1] = '.') then
+    NormalizedLexeme := '0' + NormalizedLexeme;
+
   // Handle special number formats
-  if Length(ALexeme) >= 3 then
+  if Length(NormalizedLexeme) >= 3 then
   begin
     // Hexadecimal: 0x10, 0X10
-    if (ALexeme[1] = '0') and ((ALexeme[2] = 'x') or (ALexeme[2] = 'X')) then
+    if (NormalizedLexeme[1] = '0') and ((NormalizedLexeme[2] = 'x') or (NormalizedLexeme[2] = 'X')) then
     begin
-      HexStr := Copy(ALexeme, 3, Length(ALexeme) - 2);
+      HexStr := Copy(NormalizedLexeme, 3, Length(NormalizedLexeme) - 2);
       IntValue := 0;
       for I := 1 to Length(HexStr) do
       begin
@@ -5445,9 +5449,9 @@ begin
     end
 
     // Binary: 0b1010, 0B1010
-    else if (ALexeme[1] = '0') and ((ALexeme[2] = 'b') or (ALexeme[2] = 'B')) then
+    else if (NormalizedLexeme[1] = '0') and ((NormalizedLexeme[2] = 'b') or (NormalizedLexeme[2] = 'B')) then
     begin
-      BinStr := Copy(ALexeme, 3, Length(ALexeme) - 2);
+      BinStr := Copy(NormalizedLexeme, 3, Length(NormalizedLexeme) - 2);
       IntValue := 0;
       for I := 1 to Length(BinStr) do
       begin
@@ -5459,9 +5463,9 @@ begin
     end
 
     // Octal: 0o12, 0O12
-    else if (ALexeme[1] = '0') and ((ALexeme[2] = 'o') or (ALexeme[2] = 'O')) then
+    else if (NormalizedLexeme[1] = '0') and ((NormalizedLexeme[2] = 'o') or (NormalizedLexeme[2] = 'O')) then
     begin
-      OctStr := Copy(ALexeme, 3, Length(ALexeme) - 2);
+      OctStr := Copy(NormalizedLexeme, 3, Length(NormalizedLexeme) - 2);
       IntValue := 0;
       for I := 1 to Length(OctStr) do
       begin
@@ -5473,7 +5477,7 @@ begin
   end;
 
   // Regular decimal numbers (including scientific notation)
-  if TryStrToFloat(ALexeme, Value) then
+  if TryStrToFloat(NormalizedLexeme, Value) then
     Exit(Value);
 
   raise TGocciaSyntaxError.Create('Invalid number format: ' + ALexeme, Peek.Line, Peek.Column,

--- a/source/units/Goccia.RegExp.Engine.pas
+++ b/source/units/Goccia.RegExp.Engine.pas
@@ -396,7 +396,8 @@ begin
   ConvertedPattern := PreprocessRegExpPattern(ExecutablePattern, DiscardedGroups);
   // ES2026 §22.2.2.9: Apply Unicode pattern preprocessing when u flag is set
   if IsUnicode then
-    ConvertedPattern := PreprocessUnicodePattern(ConvertedPattern);
+    ConvertedPattern := PreprocessUnicodePattern(ConvertedPattern,
+      HasRegExpFlag(AFlags, 'i'));
   Matcher := TRegExpr.Create;
   try
     Matcher.Expression := ConvertedPattern;
@@ -680,6 +681,7 @@ var
   BackrefResult: string;
   AltStack: array of Integer;
   AltStackDepth: Integer;
+  CaptureIndex, TargetIndex: Integer;
 begin
   // Pass 1: collect all named groups so forward backreferences resolve
   ANamedGroups := CollectNamedGroups(APattern);
@@ -697,6 +699,7 @@ begin
   SetLength(AltStack, 64);
   AltStackDepth := 0;
   AltStack[0] := 0;
+  CaptureIndex := 0;
   while I <= PatternLength do
   begin
     if APattern[I] = '\' then
@@ -715,12 +718,21 @@ begin
           begin
             GroupName := Copy(APattern, I + 3, CloseAngle - I - 3);
             // ES2025: Resolve with duplicate named group awareness
-            BackrefResult := ResolveNamedBackreference(ANamedGroups,
-              GroupName, Copy(AltStack, 0, AltStackDepth + 1));
+            TargetIndex := FindNamedGroupIndex(ANamedGroups, GroupName);
+            if TargetIndex > CaptureIndex then
+              BackrefResult := ''
+            else
+              BackrefResult := ResolveNamedBackreference(ANamedGroups,
+                GroupName, Copy(AltStack, 0, AltStackDepth + 1));
             if BackrefResult = '' then
-              raise EConvertError.CreateFmt(
-                'Invalid named backreference: %s', [GroupName]);
-            Result := Result + BackrefResult;
+            begin
+              if TargetIndex < 0 then
+                raise EConvertError.CreateFmt(
+                  'Invalid named backreference: %s', [GroupName]);
+              Result := Result + '(?:)';
+            end
+            else
+              Result := Result + BackrefResult;
             I := CloseAngle + 1;
             Continue;
           end;
@@ -798,6 +810,7 @@ begin
           if CloseAngle <= PatternLength then
           begin
             // Strip the name, emit plain capturing group
+            Inc(CaptureIndex);
             Result := Result + '(';
             I := CloseAngle + 1;
             Continue;
@@ -807,6 +820,7 @@ begin
         Inc(I, 2);
         Continue;
       end;
+      Inc(CaptureIndex);
       Result := Result + APattern[I];
       Inc(I);
       Continue;
@@ -856,7 +870,8 @@ begin
   ConvertedPattern := PreprocessRegExpPattern(ExecutablePattern, NamedGroups);
   // ES2026 §22.2.2.9: Apply Unicode pattern preprocessing when u flag is set
   if IsUnicode then
-    ConvertedPattern := PreprocessUnicodePattern(ConvertedPattern);
+    ConvertedPattern := PreprocessUnicodePattern(ConvertedPattern,
+      HasRegExpFlag(AFlags, 'i'));
   Matcher := TRegExpr.Create;
   try
     Matcher.Expression := ConvertedPattern;

--- a/source/units/Goccia.RegExp.Unicode.pas
+++ b/source/units/Goccia.RegExp.Unicode.pas
@@ -6,7 +6,8 @@ interface
 
 function ExpandUnicodePropertyEscape(const APropertyName: string;
   const ANegated: Boolean): string;
-function PreprocessUnicodePattern(const APattern: string): string;
+function PreprocessUnicodePattern(const APattern: string;
+  const AIgnoreCase: Boolean = False): string;
 
 implementation
 
@@ -15,6 +16,15 @@ uses
 
 const
   UNSUPPORTED_PROPERTY_PREFIX = 'Invalid Unicode property name: ';
+  UTF8_ANY_CODE_POINT =
+    '(?:[\x00-\x7F]|[\xC2-\xDF][\x80-\xBF]|' +
+    '[\xE0-\xEF][\x80-\xBF][\x80-\xBF]|' +
+    '[\xF0-\xF4][\x80-\xBF][\x80-\xBF][\x80-\xBF])';
+  UTF8_NON_SPACE_CODE_POINT =
+    '(?:[\x00-\x08\x0E-\x1F\x21-\x7F]|' +
+    '[\xC2-\xDF][\x80-\xBF]|' +
+    '[\xE0-\xEF][\x80-\xBF][\x80-\xBF]|' +
+    '[\xF0-\xF4][\x80-\xBF][\x80-\xBF][\x80-\xBF])';
 
   // ES2026 §22.2.2.9 Unicode property escape character classes.
   // These use ASCII-safe approximations for the most commonly used
@@ -99,16 +109,319 @@ begin
       IntToHex(ACodePoint, 4));
 end;
 
+function DecodeUtf8At(const APattern: string; const AIndex: Integer;
+  out ACodePoint: Cardinal; out AByteLength: Integer): Boolean;
+var
+  B1, B2, B3, B4: Byte;
+begin
+  Result := False;
+  ACodePoint := 0;
+  AByteLength := 0;
+  if AIndex > Length(APattern) then
+    Exit;
+  B1 := Ord(APattern[AIndex]);
+  if B1 < $80 then
+  begin
+    ACodePoint := B1;
+    AByteLength := 1;
+    Exit(True);
+  end;
+  if (B1 >= $C2) and (B1 <= $DF) and (AIndex + 1 <= Length(APattern)) then
+  begin
+    B2 := Ord(APattern[AIndex + 1]);
+    if (B2 and $C0) <> $80 then
+      Exit;
+    ACodePoint := ((B1 and $1F) shl 6) or (B2 and $3F);
+    AByteLength := 2;
+    Exit(True);
+  end;
+  if (B1 >= $E0) and (B1 <= $EF) and (AIndex + 2 <= Length(APattern)) then
+  begin
+    B2 := Ord(APattern[AIndex + 1]);
+    B3 := Ord(APattern[AIndex + 2]);
+    if ((B2 and $C0) <> $80) or ((B3 and $C0) <> $80) then
+      Exit;
+    ACodePoint := ((B1 and $0F) shl 12) or ((B2 and $3F) shl 6) or
+      (B3 and $3F);
+    AByteLength := 3;
+    Exit(True);
+  end;
+  if (B1 >= $F0) and (B1 <= $F4) and (AIndex + 3 <= Length(APattern)) then
+  begin
+    B2 := Ord(APattern[AIndex + 1]);
+    B3 := Ord(APattern[AIndex + 2]);
+    B4 := Ord(APattern[AIndex + 3]);
+    if ((B2 and $C0) <> $80) or ((B3 and $C0) <> $80) or
+       ((B4 and $C0) <> $80) then
+      Exit;
+    ACodePoint := ((B1 and $07) shl 18) or ((B2 and $3F) shl 12) or
+      ((B3 and $3F) shl 6) or (B4 and $3F);
+    AByteLength := 4;
+    Exit(True);
+  end;
+end;
+
 function IsHexDigit(const C: Char): Boolean; inline;
 begin
   Result := CharInSet(C, ['0'..'9', 'a'..'f', 'A'..'F']);
+end;
+
+function EscapeLiteralAtom(const AValue: string): string;
+const
+  REGEXP_SYNTAX_CHARS = ['\', '^', '$', '.', '|', '?', '*', '+', '(', ')',
+    '[', ']', '{', '}'];
+var
+  I: Integer;
+begin
+  Result := '';
+  for I := 1 to Length(AValue) do
+  begin
+    if CharInSet(AValue[I], REGEXP_SYNTAX_CHARS) then
+      Result := Result + '\';
+    Result := Result + AValue[I];
+  end;
+end;
+
+function HexByte(const AValue: Byte): string; inline;
+begin
+  Result := '\x' + IntToHex(AValue, 2);
+end;
+
+function ByteRangeExcept(const AMin, AMax, AExcluded: Byte): string;
+begin
+  Result := '';
+  if AExcluded > AMin then
+    Result := Result + HexByte(AMin) + '-' + HexByte(AExcluded - 1);
+  if AExcluded < AMax then
+  begin
+    if Result <> '' then
+      Result := Result + HexByte(AExcluded + 1) + '-' + HexByte(AMax)
+    else
+      Result := HexByte(AExcluded + 1) + '-' + HexByte(AMax);
+  end;
+  if Result = '' then
+    Result := '[^\s\S]'
+  else
+    Result := '[' + Result + ']';
+end;
+
+function Utf8AnyCodePointExcept(const ACodePoint: Cardinal): string;
+var
+  Bytes: string;
+  Parts: array of string;
+
+  procedure AddPart(const APart: string);
+  begin
+    SetLength(Parts, Length(Parts) + 1);
+    Parts[High(Parts)] := APart;
+  end;
+
+var
+  I: Integer;
+begin
+  Bytes := CodePointToUtf8(ACodePoint);
+  SetLength(Parts, 0);
+  if Length(Bytes) <> 1 then
+    AddPart('[\x00-\x7F]');
+  if Length(Bytes) <> 2 then
+    AddPart('[\xC2-\xDF][\x80-\xBF]');
+  if Length(Bytes) <> 3 then
+    AddPart('[\xE0-\xEF][\x80-\xBF][\x80-\xBF]');
+  if Length(Bytes) <> 4 then
+    AddPart('[\xF0-\xF4][\x80-\xBF][\x80-\xBF][\x80-\xBF]');
+
+  case Length(Bytes) of
+    1:
+      AddPart(ByteRangeExcept($00, $7F, Ord(Bytes[1])));
+    2:
+      begin
+        AddPart(ByteRangeExcept($C2, $DF, Ord(Bytes[1])) + '[\x80-\xBF]');
+        AddPart(HexByte(Ord(Bytes[1])) +
+          ByteRangeExcept($80, $BF, Ord(Bytes[2])));
+      end;
+    3:
+      begin
+        AddPart(ByteRangeExcept($E0, $EF, Ord(Bytes[1])) +
+          '[\x80-\xBF][\x80-\xBF]');
+        AddPart(HexByte(Ord(Bytes[1])) +
+          ByteRangeExcept($80, $BF, Ord(Bytes[2])) + '[\x80-\xBF]');
+        AddPart(HexByte(Ord(Bytes[1])) + HexByte(Ord(Bytes[2])) +
+          ByteRangeExcept($80, $BF, Ord(Bytes[3])));
+      end;
+    4:
+      begin
+        AddPart(ByteRangeExcept($F0, $F4, Ord(Bytes[1])) +
+          '[\x80-\xBF][\x80-\xBF][\x80-\xBF]');
+        AddPart(HexByte(Ord(Bytes[1])) +
+          ByteRangeExcept($80, $BF, Ord(Bytes[2])) +
+          '[\x80-\xBF][\x80-\xBF]');
+        AddPart(HexByte(Ord(Bytes[1])) + HexByte(Ord(Bytes[2])) +
+          ByteRangeExcept($80, $BF, Ord(Bytes[3])) + '[\x80-\xBF]');
+        AddPart(HexByte(Ord(Bytes[1])) + HexByte(Ord(Bytes[2])) +
+          HexByte(Ord(Bytes[3])) + ByteRangeExcept($80, $BF, Ord(Bytes[4])));
+      end;
+  end;
+
+  Result := '(?:';
+  for I := 0 to High(Parts) do
+  begin
+    if I > 0 then
+      Result := Result + '|';
+    Result := Result + Parts[I];
+  end;
+  Result := Result + ')';
+end;
+
+function EmitUnicodeAtom(const ACodePoint: Cardinal;
+  const AIgnoreCase: Boolean): string;
+begin
+  if AIgnoreCase and (ACodePoint = $212A) then
+    Result := '[Kk]'
+  else
+    Result := '(?:' + EscapeLiteralAtom(CodePointToUtf8(ACodePoint)) + ')';
+end;
+
+function TryParseUnicodeClassAtom(const APattern: string; var AIndex: Integer;
+  const AStopIndex: Integer; out ACodePoint: Cardinal): Boolean;
+var
+  HexStr: string;
+  HighSurrogate, LowSurrogate: Cardinal;
+  ByteLength: Integer;
+begin
+  Result := False;
+  ACodePoint := 0;
+  if AIndex > AStopIndex then
+    Exit;
+  if (APattern[AIndex] = '\') and (AIndex + 5 <= AStopIndex) and
+     (APattern[AIndex + 1] = 'u') then
+  begin
+    HexStr := Copy(APattern, AIndex + 2, 4);
+    if not ((Length(HexStr) = 4) and IsHexDigit(HexStr[1]) and
+            IsHexDigit(HexStr[2]) and IsHexDigit(HexStr[3]) and
+            IsHexDigit(HexStr[4])) then
+      Exit;
+    HighSurrogate := StrToInt('$' + HexStr);
+    Inc(AIndex, 6);
+    if (HighSurrogate >= $D800) and (HighSurrogate <= $DBFF) and
+       (AIndex + 5 <= AStopIndex) and (APattern[AIndex] = '\') and
+       (APattern[AIndex + 1] = 'u') then
+    begin
+      HexStr := Copy(APattern, AIndex + 2, 4);
+      if (Length(HexStr) = 4) and IsHexDigit(HexStr[1]) and
+         IsHexDigit(HexStr[2]) and IsHexDigit(HexStr[3]) and
+         IsHexDigit(HexStr[4]) then
+      begin
+        LowSurrogate := StrToInt('$' + HexStr);
+        if (LowSurrogate >= $DC00) and (LowSurrogate <= $DFFF) then
+        begin
+          ACodePoint := $10000 + ((HighSurrogate - $D800) shl 10) +
+            (LowSurrogate - $DC00);
+          Inc(AIndex, 6);
+          Exit(True);
+        end;
+      end;
+    end;
+    ACodePoint := HighSurrogate;
+    Exit(True);
+  end;
+  if DecodeUtf8At(APattern, AIndex, ACodePoint, ByteLength) and
+     (ByteLength > 1) then
+  begin
+    Inc(AIndex, ByteLength);
+    Exit(True);
+  end;
+end;
+
+function TryConvertUnicodeCharacterClass(const APattern: string;
+  const AStartIndex: Integer; const AIgnoreCase: Boolean;
+  out AReplacement: string; out ANextIndex: Integer): Boolean;
+var
+  EndIndex, AtomStart, I: Integer;
+  Negated: Boolean;
+  FirstCodePoint, LastCodePoint, CurrentCodePoint: Cardinal;
+  CodePoints: array of Cardinal;
+begin
+  Result := False;
+  AReplacement := '';
+  ANextIndex := AStartIndex;
+  EndIndex := AStartIndex + 1;
+  while (EndIndex <= Length(APattern)) and (APattern[EndIndex] <> ']') do
+    Inc(EndIndex);
+  if EndIndex > Length(APattern) then
+    Exit;
+  AtomStart := AStartIndex + 1;
+  Negated := (AtomStart < EndIndex) and (APattern[AtomStart] = '^');
+  if Negated then
+    Inc(AtomStart);
+  I := AtomStart;
+  if not TryParseUnicodeClassAtom(APattern, I, EndIndex - 1, FirstCodePoint) then
+    Exit;
+  if I = EndIndex then
+  begin
+    if Negated then
+      AReplacement := Utf8AnyCodePointExcept(FirstCodePoint)
+    else
+      AReplacement := EmitUnicodeAtom(FirstCodePoint, AIgnoreCase);
+    ANextIndex := EndIndex + 1;
+    Exit(True);
+  end;
+  if (not Negated) and (I < EndIndex) and (APattern[I] = '-') then
+  begin
+    Inc(I);
+    if TryParseUnicodeClassAtom(APattern, I, EndIndex - 1, LastCodePoint) and
+       (I = EndIndex) and (FirstCodePoint <= LastCodePoint) and
+       (LastCodePoint - FirstCodePoint <= 32) then
+    begin
+      AReplacement := '(?:';
+      for CurrentCodePoint := FirstCodePoint to LastCodePoint do
+      begin
+        if CurrentCodePoint > FirstCodePoint then
+          AReplacement := AReplacement + '|';
+        AReplacement := AReplacement +
+          EscapeLiteralAtom(CodePointToUtf8(CurrentCodePoint));
+      end;
+      AReplacement := AReplacement + ')';
+      ANextIndex := EndIndex + 1;
+      Exit(True);
+    end;
+  end;
+
+  SetLength(CodePoints, 1);
+  CodePoints[0] := FirstCodePoint;
+  while I < EndIndex do
+  begin
+    if not TryParseUnicodeClassAtom(APattern, I, EndIndex - 1, CurrentCodePoint) then
+      Exit(False);
+    SetLength(CodePoints, Length(CodePoints) + 1);
+    CodePoints[High(CodePoints)] := CurrentCodePoint;
+  end;
+
+  if Negated then
+  begin
+    AReplacement := '[^\s\S]';
+    ANextIndex := EndIndex + 1;
+    Exit(True);
+  end;
+  AReplacement := '';
+  AReplacement := AReplacement + '(?:';
+  for I := 0 to High(CodePoints) do
+  begin
+    if I > 0 then
+      AReplacement := AReplacement + '|';
+    AReplacement := AReplacement +
+      EscapeLiteralAtom(CodePointToUtf8(CodePoints[I]));
+  end;
+  AReplacement := AReplacement + ')';
+  ANextIndex := EndIndex + 1;
+  Result := True;
 end;
 
 // ES2026 §22.2.1 Patterns — preprocess pattern for Unicode mode.
 // Expands \p{...} / \P{...} property escapes into TRegExpr-compatible
 // character classes and converts \u{XXXX} code point escapes into
 // literal UTF-8 byte sequences.
-function PreprocessUnicodePattern(const APattern: string): string;
+function PreprocessUnicodePattern(const APattern: string;
+  const AIgnoreCase: Boolean): string;
 var
   I, J, PatternLength: Integer;
   PropertyName: string;
@@ -117,6 +430,10 @@ var
   CodePoint: Cardinal;
   HexStart, HexLen: Integer;
   HexStr: string;
+  LowSurrogate: Cardinal;
+  ByteLength: Integer;
+  ClassReplacement: string;
+  NextIndex: Integer;
 begin
   Result := '';
   I := 1;
@@ -135,6 +452,16 @@ begin
       end;
 
       case APattern[I + 1] of
+        '0':
+          begin
+            Result := Result + '(?:' + #0 + ')';
+            Inc(I, 2);
+          end;
+        'S':
+          begin
+            Result := Result + UTF8_NON_SPACE_CODE_POINT;
+            Inc(I, 2);
+          end;
         'p', 'P':
           begin
             Negated := APattern[I + 1] = 'P';
@@ -187,9 +514,9 @@ begin
                 raise EConvertError.Create(
                   'Unicode escape out of range: \u{' + HexStr + '}');
               if InCharacterClass then
-                Result := Result + CodePointToUtf8(CodePoint)
+                Result := Result + EscapeLiteralAtom(CodePointToUtf8(CodePoint))
               else
-                Result := Result + '(?:' + CodePointToUtf8(CodePoint) + ')';
+                Result := Result + EmitUnicodeAtom(CodePoint, AIgnoreCase);
               I := HexStart + HexLen + 1;
             end
             // \uHHHH four-digit Unicode escape
@@ -201,10 +528,32 @@ begin
             begin
               HexStr := Copy(APattern, I + 2, 4);
               CodePoint := StrToInt('$' + HexStr);
+              if (CodePoint >= $D800) and (CodePoint <= $DBFF) and
+                 (I + 11 <= PatternLength) and (APattern[I + 6] = '\') and
+                 (APattern[I + 7] = 'u') and
+                 IsHexDigit(APattern[I + 8]) and
+                 IsHexDigit(APattern[I + 9]) and
+                 IsHexDigit(APattern[I + 10]) and
+                 IsHexDigit(APattern[I + 11]) then
+              begin
+                HexStr := Copy(APattern, I + 8, 4);
+                LowSurrogate := StrToInt('$' + HexStr);
+                if (LowSurrogate >= $DC00) and (LowSurrogate <= $DFFF) then
+                begin
+                  CodePoint := $10000 + ((CodePoint - $D800) shl 10) +
+                    (LowSurrogate - $DC00);
+                  if InCharacterClass then
+                    Result := Result + EscapeLiteralAtom(CodePointToUtf8(CodePoint))
+                  else
+                    Result := Result + EmitUnicodeAtom(CodePoint, AIgnoreCase);
+                  Inc(I, 12);
+                  Continue;
+                end;
+              end;
               if InCharacterClass then
-                Result := Result + CodePointToUtf8(CodePoint)
+                Result := Result + EscapeLiteralAtom(CodePointToUtf8(CodePoint))
               else
-                Result := Result + '(?:' + CodePointToUtf8(CodePoint) + ')';
+                Result := Result + EmitUnicodeAtom(CodePoint, AIgnoreCase);
               Inc(I, 6);
             end
             else
@@ -222,9 +571,28 @@ begin
     end
     else if APattern[I] = '[' then
     begin
+      if TryConvertUnicodeCharacterClass(APattern, I, AIgnoreCase,
+         ClassReplacement, NextIndex) then
+      begin
+        Result := Result + ClassReplacement;
+        I := NextIndex;
+        Continue;
+      end;
       InCharacterClass := True;
       Result := Result + APattern[I];
       Inc(I);
+    end
+    else if (not InCharacterClass) and (APattern[I] = '.') then
+    begin
+      Result := Result + UTF8_ANY_CODE_POINT;
+      Inc(I);
+    end
+    else if (not InCharacterClass) and
+            DecodeUtf8At(APattern, I, CodePoint, ByteLength) and
+            (ByteLength > 1) then
+    begin
+      Result := Result + EmitUnicodeAtom(CodePoint, AIgnoreCase);
+      Inc(I, ByteLength);
     end
     else if (APattern[I] = ']') and InCharacterClass then
     begin

--- a/tests/built-ins/RegExp/prototype/named-groups.js
+++ b/tests/built-ins/RegExp/prototype/named-groups.js
@@ -93,7 +93,8 @@ test("forward backreference resolves correctly", () => {
   // Forward backreference matches empty string before group is captured,
   // so it matches " hello" (empty backreference + space + "hello")
   const result = re.exec(" hello");
-  expect(result).toBe(null);
+  expect(result[0]).toBe(" hello");
+  expect(result.groups.word).toBe("hello");
 });
 
 test("invalid named backreference throws", () => {

--- a/tests/language/expressions/numeric-separators.js
+++ b/tests/language/expressions/numeric-separators.js
@@ -14,6 +14,8 @@ describe("numeric separators", () => {
   test("decimal with fractional separators", () => {
     expect(1_000.5).toBe(1000.5);
     expect(1_000.00_1).toBe(1000.001);
+    expect(.0_1e2).toBe(1);
+    expect(.10_1e2).toBe(10.1);
     expect(3.141_592).toBe(3.141592);
     expect(1_0.1_0).toBe(10.10);
   });

--- a/tests/language/expressions/regex/regex-literals.js
+++ b/tests/language/expressions/regex/regex-literals.js
@@ -29,3 +29,19 @@ test("regex literals are allowed after condition parentheses", () => {
 
   expect(matched).toBe(true);
 });
+
+test("unicode regex literals treat astral symbols as code points", () => {
+  expect(/𝌆{2}/u.test("𝌆𝌆")).toBe(true);
+  expect(/^.$/u.test("𝌆")).toBe(true);
+  expect(/^[𝌆]$/u.test("𝌆")).toBe(true);
+  expect(/[💩-💫]/u.test("💩")).toBe(true);
+  expect(/[💩-💫]/u.test("💨")).toBe(false);
+});
+
+test("unicode regex literals handle escapes and forward named references", () => {
+  expect(/\u{3f}/u.test("?")).toBe(true);
+  expect(/\0/u.test(String.fromCharCode(0))).toBe(true);
+  expect(/\u212a/iu.test("k")).toBe(true);
+  expect(/\u212a/u.test("k")).toBe(false);
+  expect(/\k<a>(?<a>x)/.test("x")).toBe(true);
+});

--- a/tests/language/expressions/string-literals.js
+++ b/tests/language/expressions/string-literals.js
@@ -1,0 +1,17 @@
+/*---
+description: String literal escape semantics
+features: [string-literals]
+---*/
+
+test("single-character string escapes are cooked correctly", () => {
+  expect("\b").toBe(String.fromCharCode(0x0008));
+  expect("\f").toBe(String.fromCharCode(0x000c));
+  expect("\v").toBe(String.fromCharCode(0x000b));
+});
+
+test("line continuations are omitted from string literal values", () => {
+  expect("left\
+right").toBe("leftright");
+  expect('left\
+right').toBe("leftright");
+});


### PR DESCRIPTION
## Summary
- support leading-dot decimal literals and numeric separators in fractional leading-dot forms
- fix string literal escape cooking for \b/\f/\v and line continuations
- improve Unicode RegExp preprocessing for astral literals/classes/ranges, \u{...}, \0, \S, Kelvin case folding, and forward named backreferences
- add local regressions for numeric, string, and RegExp literal behavior