### PR TITLE
Fix if condition double evaluation

### DIFF
--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2286,11 +2286,7 @@ begin
   ConditionResult := EvaluateConditionWithPatternBindings(AIfStatement.Condition,
     AContext, BodyContext, PatternHandled);
   if not PatternHandled then
-  begin
     BodyContext := AContext;
-    ConditionResult := EvaluateExpression(AIfStatement.Condition, AContext)
-      .ToBooleanLiteral.Value;
-  end;
   if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
   begin
     if ConditionResult then

--- a/tests/language/statements/if/condition-evaluation.js
+++ b/tests/language/statements/if/condition-evaluation.js
@@ -1,0 +1,42 @@
+/*---
+description: If statement conditions evaluate exactly once
+features: [if-statement]
+---*/
+
+test("if condition side effects run once for true and false branches", () => {
+  let calls = 0;
+  const pass = () => {
+    calls = calls + 1;
+    return true;
+  };
+
+  if (pass()) {
+  }
+
+  expect(calls).toBe(1);
+
+  calls = 0;
+  const fail = () => {
+    calls = calls + 1;
+    return false;
+  };
+  let branch = "";
+
+  if (fail()) {
+    branch = "then";
+  } else {
+    branch = "else";
+  }
+
+  expect(calls).toBe(1);
+  expect(branch).toBe("else");
+});
+
+test("postfix updates in if conditions run once", () => {
+  let index = 0;
+
+  if (index++ < 3) {
+  }
+
+  expect(index).toBe(1);
+});

--- a/tests/language/statements/if/condition-evaluation.js
+++ b/tests/language/statements/if/condition-evaluation.js
@@ -3,7 +3,7 @@ description: If statement conditions evaluate exactly once
 features: [if-statement]
 ---*/
 
-test("if condition side effects run once for true and false branches", () => {
+test("if condition side effects run once for true, false, and throwing paths", () => {
   let calls = 0;
   const pass = () => {
     calls = calls + 1;
@@ -30,6 +30,23 @@ test("if condition side effects run once for true and false branches", () => {
 
   expect(calls).toBe(1);
   expect(branch).toBe("else");
+
+  calls = 0;
+  const boom = () => {
+    calls = calls + 1;
+    throw new Error("boom");
+  };
+  let caught = false;
+
+  try {
+    if (boom()) {
+    }
+  } catch (error) {
+    caught = error.message === "boom";
+  }
+
+  expect(caught).toBe(true);
+  expect(calls).toBe(1);
 });
 
 test("postfix updates in if conditions run once", () => {


### PR DESCRIPTION
## Summary
- Fix interpreter `if` statements so ordinary conditions are evaluated once.
- Keep pattern-aware condition evaluation intact while reusing its boolean result.
- Add regression coverage for true/false condition side effects and postfix updates.

## Verification
- `./build.pas clean testrunner`
- `./build.pas loader`
- `./build/GocciaTestRunner tests/language/statements/if --asi`
- `./build/GocciaTestRunner tests/language/statements/if --asi --mode=bytecode`
- `./fixtures/ffi/build.sh`
- `./build/GocciaTestRunner tests --asi --unsafe-ffi --silent --no-progress`
- `./build/GocciaTestRunner tests --asi --unsafe-ffi --mode=bytecode --silent --no-progress`
- `./format.pas --check`

Fixes #483.