### PR TITLE
Fix Test262 line terminator handling

### DIFF
--- a/source/shared/TextSemantics.Test.pas
+++ b/source/shared/TextSemantics.Test.pas
@@ -15,7 +15,10 @@ type
     procedure TestTrimECMAScriptWhitespace;
     procedure TestUnicodeCaseMapping;
     procedure TestUTF8WellFormedChecks;
+    procedure TestUTF8CodePointIndexing;
+    procedure TestUTF16CodeUnitIndexing;
     procedure TestReplacementPatternExpansion;
+    procedure TestECMAScriptSourceLinesSplitUnicodeLineTerminators;
     procedure TestTextLineHelpersPreserveUTF8;
   public
     procedure SetupTests; override;
@@ -29,8 +32,14 @@ begin
     TestUnicodeCaseMapping);
   Test('UTF-8 well-formed helpers reject invalid sequences',
     TestUTF8WellFormedChecks);
+  Test('UTF-8 code point helpers index multibyte characters',
+    TestUTF8CodePointIndexing);
+  Test('UTF-16 code unit helpers count astral characters as surrogate pairs',
+    TestUTF16CodeUnitIndexing);
   Test('Replacement pattern expansion follows GetSubstitution tokens',
     TestReplacementPatternExpansion);
+  Test('ECMAScript source lines split Unicode line terminators',
+    TestECMAScriptSourceLinesSplitUnicodeLineTerminators);
   Test('Text line helpers preserve UTF-8 bytes',
     TestTextLineHelpersPreserveUTF8);
 end;
@@ -79,6 +88,45 @@ begin
     UTF8_REPLACEMENT_CHARACTER + 'A');
 end;
 
+procedure TTextSemanticsTests.TestUTF8CodePointIndexing;
+const
+  UTF8_LINE_SEPARATOR = #$E2#$80#$A8;
+  UTF8_PARAGRAPH_SEPARATOR = #$E2#$80#$A9;
+  UTF8_NONCHARACTER = #$EF#$BF#$BF;
+var
+  Text: string;
+begin
+  Text := 'a' + UTF8_LINE_SEPARATOR + UTF8_PARAGRAPH_SEPARATOR +
+    UTF8_NONCHARACTER + 'b';
+  Expect<Integer>(UTF8CodePointLength(Text)).ToBe(5);
+  Expect<string>(UTF8CodePointAt(Text, 0)).ToBe('a');
+  Expect<string>(UTF8CodePointAt(Text, 1)).ToBe(UTF8_LINE_SEPARATOR);
+  Expect<string>(UTF8CodePointAt(Text, 2)).ToBe(UTF8_PARAGRAPH_SEPARATOR);
+  Expect<string>(UTF8CodePointAt(Text, 3)).ToBe(UTF8_NONCHARACTER);
+  Expect<string>(UTF8CodePointAt(Text, 4)).ToBe('b');
+  Expect<string>(UTF8CodePointAt(Text, 5)).ToBe('');
+end;
+
+procedure TTextSemanticsTests.TestUTF16CodeUnitIndexing;
+const
+  UTF8_LINE_SEPARATOR = #$E2#$80#$A8;
+  UTF8_GRINNING_FACE = #$F0#$9F#$98#$80;
+var
+  CodePoint: Cardinal;
+begin
+  Expect<Integer>(UTF16CodeUnitLength('a' + UTF8_LINE_SEPARATOR + 'b')).ToBe(3);
+  Expect<string>(UTF16CodeUnitAt('a' + UTF8_LINE_SEPARATOR + 'b', 1)).ToBe(
+    UTF8_LINE_SEPARATOR);
+  Expect<Integer>(UTF16CodeUnitLength('a' + UTF8_GRINNING_FACE + 'b')).ToBe(4);
+  Expect<string>(UTF16CodeUnitAt('a' + UTF8_GRINNING_FACE + 'b', 4)).ToBe('');
+  Expect<Boolean>(TryUTF16CodePointValueAt(UTF8_GRINNING_FACE, 0, CodePoint))
+    .ToBe(True);
+  Expect<Integer>(CodePoint).ToBe($1F600);
+  Expect<Boolean>(TryUTF16CodePointValueAt(UTF8_GRINNING_FACE, 1, CodePoint))
+    .ToBe(True);
+  Expect<Integer>(CodePoint).ToBe($DE00);
+end;
+
 procedure TTextSemanticsTests.TestReplacementPatternExpansion;
 var
   Captures: array[0..1] of TReplacementCapture;
@@ -99,6 +147,25 @@ begin
     'bc', 'abcde', 1, Captures, NamedCaptures)).ToBe('b::$<');
   Expect<string>(ExpandReplacementPattern('$<letter>', 'a', 'a', 0, [],
     [])).ToBe('$<letter>');
+end;
+
+procedure TTextSemanticsTests.TestECMAScriptSourceLinesSplitUnicodeLineTerminators;
+const
+  UTF8_LINE_SEPARATOR = #$E2#$80#$A8;
+  UTF8_PARAGRAPH_SEPARATOR = #$E2#$80#$A9;
+var
+  Lines: TStringList;
+begin
+  Lines := CreateECMAScriptSourceLines(
+    'var' + UTF8_LINE_SEPARATOR + 'x' + UTF8_PARAGRAPH_SEPARATOR + '= 1;');
+  try
+    Expect<Integer>(Lines.Count).ToBe(3);
+    Expect<string>(Lines[0]).ToBe('var');
+    Expect<string>(Lines[1]).ToBe('x');
+    Expect<string>(Lines[2]).ToBe('= 1;');
+  finally
+    Lines.Free;
+  end;
 end;
 
 procedure TTextSemanticsTests.TestTextLineHelpersPreserveUTF8;

--- a/source/shared/TextSemantics.Test.pas
+++ b/source/shared/TextSemantics.Test.pas
@@ -93,6 +93,7 @@ const
   UTF8_LINE_SEPARATOR = #$E2#$80#$A8;
   UTF8_PARAGRAPH_SEPARATOR = #$E2#$80#$A9;
   UTF8_NONCHARACTER = #$EF#$BF#$BF;
+  UTF8_HIGH_SURROGATE = #$ED#$A0#$80;
 var
   Text: string;
 begin
@@ -105,6 +106,11 @@ begin
   Expect<string>(UTF8CodePointAt(Text, 3)).ToBe(UTF8_NONCHARACTER);
   Expect<string>(UTF8CodePointAt(Text, 4)).ToBe('b');
   Expect<string>(UTF8CodePointAt(Text, 5)).ToBe('');
+  Expect<Integer>(UTF8CodePointLength(UTF8_HIGH_SURROGATE)).ToBe(1);
+  Text := 'a' + UTF8_HIGH_SURROGATE + 'b';
+  Expect<Integer>(UTF8CodePointLength(Text)).ToBe(3);
+  Expect<string>(UTF8CodePointAt(Text, 0)).ToBe('a');
+  Expect<string>(UTF8CodePointAt(Text, 2)).ToBe('b');
 end;
 
 procedure TTextSemanticsTests.TestUTF16CodeUnitIndexing;

--- a/source/shared/TextSemantics.Test.pas
+++ b/source/shared/TextSemantics.Test.pas
@@ -111,6 +111,7 @@ procedure TTextSemanticsTests.TestUTF16CodeUnitIndexing;
 const
   UTF8_LINE_SEPARATOR = #$E2#$80#$A8;
   UTF8_GRINNING_FACE = #$F0#$9F#$98#$80;
+  UTF8_HIGH_SURROGATE = #$ED#$A0#$80;
 var
   CodePoint: Cardinal;
 begin
@@ -125,6 +126,20 @@ begin
   Expect<Boolean>(TryUTF16CodePointValueAt(UTF8_GRINNING_FACE, 1, CodePoint))
     .ToBe(True);
   Expect<Integer>(CodePoint).ToBe($DE00);
+  Expect<Integer>(UTF16CodeUnitLength(UTF8_HIGH_SURROGATE)).ToBe(1);
+  Expect<string>(UTF16CodeUnitAt(UTF8_HIGH_SURROGATE, 0)).ToBe(
+    UTF8_HIGH_SURROGATE);
+  Expect<Boolean>(TryUTF16CodePointValueAt(UTF8_HIGH_SURROGATE, 0, CodePoint))
+    .ToBe(True);
+  Expect<Integer>(CodePoint).ToBe($D800);
+  Expect<string>(UTF16Substring('a' + UTF8_GRINNING_FACE + 'b', 1, 2)).ToBe(
+    UTF8_GRINNING_FACE);
+  Expect<string>(UTF16Substring('a' + UTF8_GRINNING_FACE + 'b', 1, 1)).ToBe(
+    #$ED#$A0#$BD);
+  Expect<Integer>(UTF16IndexOf('a' + UTF8_GRINNING_FACE + 'b',
+    UTF8_GRINNING_FACE)).ToBe(1);
+  Expect<Integer>(UTF16LastIndexOf(UTF8_GRINNING_FACE + 'a' +
+    UTF8_GRINNING_FACE, UTF8_GRINNING_FACE, 4)).ToBe(3);
 end;
 
 procedure TTextSemanticsTests.TestReplacementPatternExpansion;

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -38,6 +38,12 @@ function TrimECMAScriptWhitespaceStart(const AText: string): string;
 function TrimECMAScriptWhitespaceEnd(const AText: string): string;
 function IsWellFormedUTF8(const AText: string): Boolean;
 function ToWellFormedUTF8(const AText: string): string;
+function UTF8CodePointLength(const AText: string): Integer;
+function UTF8CodePointAt(const AText: string; const AIndex: Integer): string;
+function UTF16CodeUnitLength(const AText: string): Integer;
+function UTF16CodeUnitAt(const AText: string; const AIndex: Integer): string;
+function TryUTF16CodePointValueAt(const AText: string; const AIndex: Integer;
+  out ACodePoint: Cardinal): Boolean;
 function UnicodeLowerCaseUTF8(const AText: string): string;
 function UnicodeUpperCaseUTF8(const AText: string): string;
 function AdvanceUTF8StringIndex(const AText: string; const AIndex: Integer;
@@ -47,6 +53,7 @@ function ExpandReplacementPattern(const AReplacement, AMatched,
   const ACaptures: array of TReplacementCapture;
   const ANamedCaptures: array of TReplacementNamedCapture): string;
 function CreateUTF8StringList(const AText: string): TStringList;
+function CreateECMAScriptSourceLines(const AText: string): TStringList;
 function CreateUTF8FileTextLines(const AText: UTF8String): TStringList;
 function NormalizeNewlinesToLF(const AText: string): string;
 function NormalizeUTF8NewlinesToLF(const AText: UTF8String): UTF8String;
@@ -326,6 +333,207 @@ begin
   Result := Buffer.ToString;
 end;
 
+function UTF8CodePointLength(const AText: string): Integer;
+var
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  Index: Integer;
+begin
+  Result := 0;
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+      Inc(Index, ByteLength)
+    else
+      Inc(Index);
+    Inc(Result);
+  end;
+end;
+
+function UTF8CodePointAt(const AText: string; const AIndex: Integer): string;
+var
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  CodePointIndex: Integer;
+  Index: Integer;
+begin
+  if AIndex < 0 then
+    Exit('');
+
+  CodePointIndex := 0;
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    begin
+      if CodePointIndex = AIndex then
+        Exit(Copy(AText, Index, ByteLength));
+      Inc(Index, ByteLength);
+    end
+    else
+    begin
+      if CodePointIndex = AIndex then
+        Exit(AText[Index]);
+      Inc(Index);
+    end;
+    Inc(CodePointIndex);
+  end;
+
+  Result := '';
+end;
+
+function UTF16CodeUnitToUTF8(const ACodeUnit: Cardinal): string;
+begin
+  if ACodeUnit <= $7F then
+    Result := Chr(ACodeUnit)
+  else if ACodeUnit <= $7FF then
+    Result := Chr($C0 or (ACodeUnit shr 6)) +
+      Chr($80 or (ACodeUnit and $3F))
+  else
+    Result := Chr($E0 or (ACodeUnit shr 12)) +
+      Chr($80 or ((ACodeUnit shr 6) and $3F)) +
+      Chr($80 or (ACodeUnit and $3F));
+end;
+
+function UTF16CodeUnitLength(const AText: string): Integer;
+var
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  Index: Integer;
+begin
+  Result := 0;
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    begin
+      if CodePoint > $FFFF then
+        Inc(Result, 2)
+      else
+        Inc(Result);
+      Inc(Index, ByteLength);
+    end
+    else
+    begin
+      Inc(Result);
+      Inc(Index);
+    end;
+  end;
+end;
+
+function UTF16CodeUnitAt(const AText: string; const AIndex: Integer): string;
+var
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  CodeUnitIndex: Integer;
+  HighSurrogate: Cardinal;
+  Index: Integer;
+  LowSurrogate: Cardinal;
+  Supplementary: Cardinal;
+begin
+  if AIndex < 0 then
+    Exit('');
+
+  CodeUnitIndex := 0;
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    begin
+      if CodePoint <= $FFFF then
+      begin
+        if CodeUnitIndex = AIndex then
+          Exit(Copy(AText, Index, ByteLength));
+        Inc(CodeUnitIndex);
+      end
+      else
+      begin
+        Supplementary := CodePoint - $10000;
+        HighSurrogate := $D800 + (Supplementary shr 10);
+        LowSurrogate := $DC00 + (Supplementary and $3FF);
+        if CodeUnitIndex = AIndex then
+          Exit(UTF16CodeUnitToUTF8(HighSurrogate));
+        if CodeUnitIndex + 1 = AIndex then
+          Exit(UTF16CodeUnitToUTF8(LowSurrogate));
+        Inc(CodeUnitIndex, 2);
+      end;
+      Inc(Index, ByteLength);
+    end
+    else
+    begin
+      if CodeUnitIndex = AIndex then
+        Exit(AText[Index]);
+      Inc(CodeUnitIndex);
+      Inc(Index);
+    end;
+  end;
+
+  Result := '';
+end;
+
+function TryUTF16CodePointValueAt(const AText: string; const AIndex: Integer;
+  out ACodePoint: Cardinal): Boolean;
+var
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  CodeUnitIndex: Integer;
+  Index: Integer;
+  LowSurrogate: Cardinal;
+  Supplementary: Cardinal;
+begin
+  ACodePoint := 0;
+  if AIndex < 0 then
+    Exit(False);
+
+  CodeUnitIndex := 0;
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    begin
+      if CodePoint <= $FFFF then
+      begin
+        if CodeUnitIndex = AIndex then
+        begin
+          ACodePoint := CodePoint;
+          Exit(True);
+        end;
+        Inc(CodeUnitIndex);
+      end
+      else
+      begin
+        if CodeUnitIndex = AIndex then
+        begin
+          ACodePoint := CodePoint;
+          Exit(True);
+        end;
+        Supplementary := CodePoint - $10000;
+        LowSurrogate := $DC00 + (Supplementary and $3FF);
+        if CodeUnitIndex + 1 = AIndex then
+        begin
+          ACodePoint := LowSurrogate;
+          Exit(True);
+        end;
+        Inc(CodeUnitIndex, 2);
+      end;
+      Inc(Index, ByteLength);
+    end
+    else
+    begin
+      if CodeUnitIndex = AIndex then
+      begin
+        ACodePoint := Ord(AText[Index]);
+        Exit(True);
+      end;
+      Inc(CodeUnitIndex);
+      Inc(Index);
+    end;
+  end;
+
+  Result := False;
+end;
+
 function UTF8TextToUnicodeString(const AText: string): UnicodeString;
 var
   Bytes: RawByteString;
@@ -556,6 +764,58 @@ begin
     Result.Add(Copy(AText, LineStart, Length(AText) - LineStart + 1))
   else if (Length(AText) > 0) and ((AText[Length(AText)] = #10) or
     (AText[Length(AText)] = #13)) then
+    Result.Add('');
+end;
+
+function IsUTF8LineOrParagraphSeparatorAt(const AText: string;
+  const AIndex: Integer): Boolean;
+begin
+  Result := (AIndex >= 1) and (AIndex + 2 <= Length(AText)) and
+    (AText[AIndex] = #$E2) and
+    (AText[AIndex + 1] = #$80) and
+    ((AText[AIndex + 2] = #$A8) or (AText[AIndex + 2] = #$A9));
+end;
+
+function CreateECMAScriptSourceLines(const AText: string): TStringList;
+const
+  UTF8_LINE_TERMINATOR_BYTE_LENGTH = 3;
+var
+  LineStart: Integer;
+  TextIndex: Integer;
+begin
+  Result := TStringList.Create;
+  LineStart := 1;
+  TextIndex := 1;
+
+  while TextIndex <= Length(AText) do
+  begin
+    if AText[TextIndex] = #13 then
+    begin
+      Result.Add(Copy(AText, LineStart, TextIndex - LineStart));
+      if (TextIndex < Length(AText)) and (AText[TextIndex + 1] = #10) then
+        Inc(TextIndex);
+      LineStart := TextIndex + 1;
+    end
+    else if AText[TextIndex] = #10 then
+    begin
+      Result.Add(Copy(AText, LineStart, TextIndex - LineStart));
+      LineStart := TextIndex + 1;
+    end
+    else if IsUTF8LineOrParagraphSeparatorAt(AText, TextIndex) then
+    begin
+      Result.Add(Copy(AText, LineStart, TextIndex - LineStart));
+      Inc(TextIndex, UTF8_LINE_TERMINATOR_BYTE_LENGTH - 1);
+      LineStart := TextIndex + 1;
+    end;
+    Inc(TextIndex);
+  end;
+
+  if LineStart <= Length(AText) then
+    Result.Add(Copy(AText, LineStart, Length(AText) - LineStart + 1))
+  else if (Length(AText) > 0) and
+    ((AText[Length(AText)] = #10) or (AText[Length(AText)] = #13) or
+    IsUTF8LineOrParagraphSeparatorAt(AText,
+    Length(AText) - UTF8_LINE_TERMINATOR_BYTE_LENGTH + 1)) then
     Result.Add('');
 end;
 

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -30,6 +30,9 @@ function UTF8SequenceLengthAt(const AText: string;
   const AIndex: Integer): Integer;
 function TryReadUTF8CodePoint(const AText: string; const AIndex: Integer;
   out ACodePoint: Cardinal; out AByteLength: Integer): Boolean;
+function TryReadUTF8CodePointAllowSurrogates(const AText: string;
+  const AIndex: Integer; out ACodePoint: Cardinal;
+  out AByteLength: Integer): Boolean;
 function CodePointToUTF8(const ACodePoint: Cardinal): string;
 function IsUnicodeSurrogateCodePoint(const ACodePoint: Cardinal): Boolean; inline;
 function IsECMAScriptWhitespaceCodePoint(const ACodePoint: Cardinal): Boolean;
@@ -44,6 +47,12 @@ function UTF16CodeUnitLength(const AText: string): Integer;
 function UTF16CodeUnitAt(const AText: string; const AIndex: Integer): string;
 function TryUTF16CodePointValueAt(const AText: string; const AIndex: Integer;
   out ACodePoint: Cardinal): Boolean;
+function UTF16Substring(const AText: string; const AStart,
+  ACount: Integer): string;
+function UTF16IndexOf(const AText, ASearch: string;
+  const AStart: Integer = 0): Integer;
+function UTF16LastIndexOf(const AText, ASearch: string;
+  const AStart: Integer): Integer;
 function UnicodeLowerCaseUTF8(const AText: string): string;
 function UnicodeUpperCaseUTF8(const AText: string): string;
 function AdvanceUTF8StringIndex(const AText: string; const AIndex: Integer;
@@ -167,6 +176,44 @@ begin
     Cardinal(ByteValue[2] and $3F) shl 6 or
     Cardinal(ByteValue[3] and $3F);
   Result := True;
+end;
+
+function TryReadUTF8SurrogateCodePoint(const AText: string;
+  const AIndex: Integer; out ACodePoint: Cardinal;
+  out AByteLength: Integer): Boolean;
+var
+  ByteValue: array[0..2] of Byte;
+begin
+  Result := False;
+  ACodePoint := 0;
+  AByteLength := 1;
+
+  if (AIndex < 1) or (AIndex + 2 > Length(AText)) then
+    Exit;
+
+  ByteValue[0] := Ord(AText[AIndex]);
+  ByteValue[1] := Ord(AText[AIndex + 1]);
+  ByteValue[2] := Ord(AText[AIndex + 2]);
+
+  if (ByteValue[0] <> $ED) or (ByteValue[1] < $A0) or
+     (ByteValue[1] > $BF) or ((ByteValue[2] and $C0) <> $80) then
+    Exit;
+
+  ACodePoint := Cardinal(ByteValue[0] and $0F) shl 12 or
+    Cardinal(ByteValue[1] and $3F) shl 6 or
+    Cardinal(ByteValue[2] and $3F);
+  AByteLength := 3;
+  Result := True;
+end;
+
+function TryReadUTF8CodePointAllowSurrogates(const AText: string;
+  const AIndex: Integer; out ACodePoint: Cardinal;
+  out AByteLength: Integer): Boolean;
+begin
+  Result := TryReadUTF8SurrogateCodePoint(AText, AIndex, ACodePoint,
+    AByteLength);
+  if not Result then
+    Result := TryReadUTF8CodePoint(AText, AIndex, ACodePoint, AByteLength);
 end;
 
 function UTF8SequenceLengthAt(const AText: string;
@@ -406,7 +453,8 @@ begin
   Index := 1;
   while Index <= Length(AText) do
   begin
-    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
     begin
       if CodePoint > $FFFF then
         Inc(Result, 2)
@@ -439,7 +487,8 @@ begin
   Index := 1;
   while Index <= Length(AText) do
   begin
-    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
     begin
       if CodePoint <= $FFFF then
       begin
@@ -490,7 +539,8 @@ begin
   Index := 1;
   while Index <= Length(AText) do
   begin
-    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
     begin
       if CodePoint <= $FFFF then
       begin
@@ -532,6 +582,139 @@ begin
   end;
 
   Result := False;
+end;
+
+function UTF16Substring(const AText: string; const AStart,
+  ACount: Integer): string;
+var
+  Buffer: TStringBuffer;
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  CodeUnitIndex: Integer;
+  HighSurrogate: Cardinal;
+  Index: Integer;
+  LowSelected: Boolean;
+  LowSurrogate: Cardinal;
+  HighSelected: Boolean;
+  TargetEnd: Integer;
+  Supplementary: Cardinal;
+begin
+  if (AStart < 0) or (ACount <= 0) then
+    Exit('');
+
+  Buffer := TStringBuffer.Create(Length(AText));
+  CodeUnitIndex := 0;
+  Index := 1;
+  TargetEnd := AStart + ACount;
+  while (Index <= Length(AText)) and (CodeUnitIndex < TargetEnd) do
+  begin
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
+    begin
+      if CodePoint <= $FFFF then
+      begin
+        if (CodeUnitIndex >= AStart) and (CodeUnitIndex < TargetEnd) then
+          Buffer.Append(Copy(AText, Index, ByteLength));
+        Inc(CodeUnitIndex);
+      end
+      else
+      begin
+        HighSelected := (CodeUnitIndex >= AStart) and
+          (CodeUnitIndex < TargetEnd);
+        LowSelected := (CodeUnitIndex + 1 >= AStart) and
+          (CodeUnitIndex + 1 < TargetEnd);
+        if HighSelected and LowSelected then
+          Buffer.Append(Copy(AText, Index, ByteLength))
+        else
+        begin
+          Supplementary := CodePoint - $10000;
+          HighSurrogate := $D800 + (Supplementary shr 10);
+          LowSurrogate := $DC00 + (Supplementary and $3FF);
+          if HighSelected then
+            Buffer.Append(UTF16CodeUnitToUTF8(HighSurrogate));
+          if LowSelected then
+            Buffer.Append(UTF16CodeUnitToUTF8(LowSurrogate));
+        end;
+        Inc(CodeUnitIndex, 2);
+      end;
+      Inc(Index, ByteLength);
+    end
+    else
+    begin
+      if (CodeUnitIndex >= AStart) and (CodeUnitIndex < TargetEnd) then
+        Buffer.Append(AText[Index]);
+      Inc(CodeUnitIndex);
+      Inc(Index);
+    end;
+  end;
+  Result := Buffer.ToString;
+end;
+
+function UTF16CodeUnitsEqualAt(const AText: string; const AStart: Integer;
+  const ASearch: string): Boolean;
+var
+  I: Integer;
+  SearchLength: Integer;
+begin
+  SearchLength := UTF16CodeUnitLength(ASearch);
+  if SearchLength = 0 then
+    Exit(True);
+  if AStart + SearchLength > UTF16CodeUnitLength(AText) then
+    Exit(False);
+
+  for I := 0 to SearchLength - 1 do
+    if UTF16CodeUnitAt(AText, AStart + I) <> UTF16CodeUnitAt(ASearch, I) then
+      Exit(False);
+
+  Result := True;
+end;
+
+function UTF16IndexOf(const AText, ASearch: string;
+  const AStart: Integer): Integer;
+var
+  I: Integer;
+  SearchLength: Integer;
+  StartIndex: Integer;
+  TextLength: Integer;
+begin
+  TextLength := UTF16CodeUnitLength(AText);
+  SearchLength := UTF16CodeUnitLength(ASearch);
+  StartIndex := Max(0, Min(AStart, TextLength));
+
+  if SearchLength = 0 then
+    Exit(StartIndex);
+  if SearchLength > TextLength then
+    Exit(-1);
+
+  for I := StartIndex to TextLength - SearchLength do
+    if UTF16CodeUnitsEqualAt(AText, I, ASearch) then
+      Exit(I);
+
+  Result := -1;
+end;
+
+function UTF16LastIndexOf(const AText, ASearch: string;
+  const AStart: Integer): Integer;
+var
+  I: Integer;
+  SearchLength: Integer;
+  StartIndex: Integer;
+  TextLength: Integer;
+begin
+  TextLength := UTF16CodeUnitLength(AText);
+  SearchLength := UTF16CodeUnitLength(ASearch);
+  StartIndex := Max(0, Min(AStart, TextLength));
+
+  if SearchLength = 0 then
+    Exit(StartIndex);
+  if SearchLength > TextLength then
+    Exit(-1);
+
+  for I := Min(StartIndex, TextLength - SearchLength) downto 0 do
+    if UTF16CodeUnitsEqualAt(AText, I, ASearch) then
+      Exit(I);
+
+  Result := -1;
 end;
 
 function UTF8TextToUnicodeString(const AText: string): UnicodeString;

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -650,20 +650,61 @@ begin
   Result := Buffer.ToString;
 end;
 
-function UTF16CodeUnitsEqualAt(const AText: string; const AStart: Integer;
-  const ASearch: string): Boolean;
+type
+  TUTF16CodeUnitArray = array of Cardinal;
+
+function BuildUTF16CodeUnitArray(const AText: string): TUTF16CodeUnitArray;
+var
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  Count: Integer;
+  Index: Integer;
+  Supplementary: Cardinal;
+begin
+  SetLength(Result, Length(AText));
+  Count := 0;
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
+    begin
+      if CodePoint <= $FFFF then
+      begin
+        Result[Count] := CodePoint;
+        Inc(Count);
+      end
+      else
+      begin
+        Supplementary := CodePoint - $10000;
+        Result[Count] := $D800 + (Supplementary shr 10);
+        Result[Count + 1] := $DC00 + (Supplementary and $3FF);
+        Inc(Count, 2);
+      end;
+      Inc(Index, ByteLength);
+    end
+    else
+    begin
+      Result[Count] := Ord(AText[Index]);
+      Inc(Count);
+      Inc(Index);
+    end;
+  end;
+  SetLength(Result, Count);
+end;
+
+function UTF16CodeUnitsEqualAt(const ATextUnits,
+  ASearchUnits: TUTF16CodeUnitArray; const AStart: Integer): Boolean;
 var
   I: Integer;
-  SearchLength: Integer;
 begin
-  SearchLength := UTF16CodeUnitLength(ASearch);
-  if SearchLength = 0 then
+  if Length(ASearchUnits) = 0 then
     Exit(True);
-  if AStart + SearchLength > UTF16CodeUnitLength(AText) then
+  if AStart + Length(ASearchUnits) > Length(ATextUnits) then
     Exit(False);
 
-  for I := 0 to SearchLength - 1 do
-    if UTF16CodeUnitAt(AText, AStart + I) <> UTF16CodeUnitAt(ASearch, I) then
+  for I := 0 to Length(ASearchUnits) - 1 do
+    if ATextUnits[AStart + I] <> ASearchUnits[I] then
       Exit(False);
 
   Result := True;
@@ -673,12 +714,16 @@ function UTF16IndexOf(const AText, ASearch: string;
   const AStart: Integer): Integer;
 var
   I: Integer;
+  SearchUnits: TUTF16CodeUnitArray;
   SearchLength: Integer;
   StartIndex: Integer;
+  TextUnits: TUTF16CodeUnitArray;
   TextLength: Integer;
 begin
-  TextLength := UTF16CodeUnitLength(AText);
-  SearchLength := UTF16CodeUnitLength(ASearch);
+  TextUnits := BuildUTF16CodeUnitArray(AText);
+  SearchUnits := BuildUTF16CodeUnitArray(ASearch);
+  TextLength := Length(TextUnits);
+  SearchLength := Length(SearchUnits);
   StartIndex := Max(0, Min(AStart, TextLength));
 
   if SearchLength = 0 then
@@ -687,7 +732,7 @@ begin
     Exit(-1);
 
   for I := StartIndex to TextLength - SearchLength do
-    if UTF16CodeUnitsEqualAt(AText, I, ASearch) then
+    if UTF16CodeUnitsEqualAt(TextUnits, SearchUnits, I) then
       Exit(I);
 
   Result := -1;
@@ -697,12 +742,16 @@ function UTF16LastIndexOf(const AText, ASearch: string;
   const AStart: Integer): Integer;
 var
   I: Integer;
+  SearchUnits: TUTF16CodeUnitArray;
   SearchLength: Integer;
   StartIndex: Integer;
+  TextUnits: TUTF16CodeUnitArray;
   TextLength: Integer;
 begin
-  TextLength := UTF16CodeUnitLength(AText);
-  SearchLength := UTF16CodeUnitLength(ASearch);
+  TextUnits := BuildUTF16CodeUnitArray(AText);
+  SearchUnits := BuildUTF16CodeUnitArray(ASearch);
+  TextLength := Length(TextUnits);
+  SearchLength := Length(SearchUnits);
   StartIndex := Max(0, Min(AStart, TextLength));
 
   if SearchLength = 0 then
@@ -711,7 +760,7 @@ begin
     Exit(-1);
 
   for I := Min(StartIndex, TextLength - SearchLength) downto 0 do
-    if UTF16CodeUnitsEqualAt(AText, I, ASearch) then
+    if UTF16CodeUnitsEqualAt(TextUnits, SearchUnits, I) then
       Exit(I);
 
   Result := -1;

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -390,7 +390,8 @@ begin
   Index := 1;
   while Index <= Length(AText) do
   begin
-    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
       Inc(Index, ByteLength)
     else
       Inc(Index);
@@ -412,7 +413,8 @@ begin
   Index := 1;
   while Index <= Length(AText) do
   begin
-    if TryReadUTF8CodePoint(AText, Index, CodePoint, ByteLength) then
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
     begin
       if CodePointIndex = AIndex then
         Exit(Copy(AText, Index, ByteLength));

--- a/source/units/Goccia.Lexer.Test.pas
+++ b/source/units/Goccia.Lexer.Test.pas
@@ -26,6 +26,7 @@ type
     procedure TestCRIncrementsLineInWhitespace;
     procedure TestCRIncrementsLineInBlockComment;
     procedure TestUnicodeLineTerminatorsInBlockComment;
+    procedure TestUnicodeLineTerminatorsBetweenTokens;
     procedure TestRegexLiteralPreservesRawPattern;
     procedure TestRegexUnterminatedAtEOF;
     procedure TestNumericSeparatorsNormalize;
@@ -42,6 +43,7 @@ begin
   Test('CR increments line counter in whitespace', TestCRIncrementsLineInWhitespace);
   Test('CR increments line counter in block comments', TestCRIncrementsLineInBlockComment);
   Test('Unicode line terminators increment line counter in block comments', TestUnicodeLineTerminatorsInBlockComment);
+  Test('Unicode line terminators split tokens', TestUnicodeLineTerminatorsBetweenTokens);
   Test('Regex literal preserves raw pattern', TestRegexLiteralPreservesRawPattern);
   Test('Unterminated regex at EOF raises lexer error', TestRegexUnterminatedAtEOF);
   Test('Numeric separators normalize', TestNumericSeparatorsNormalize);
@@ -214,6 +216,31 @@ begin
     Tokens := Lexer.ScanTokens;
     Expect<TGocciaTokenType>(Tokens[0].TokenType).ToBe(gttConst);
     Expect<Integer>(Tokens[0].Line).ToBe(2);
+  finally
+    Lexer.Free;
+  end;
+end;
+
+procedure TLexerTests.TestUnicodeLineTerminatorsBetweenTokens;
+const
+  UTF8_LINE_SEPARATOR = #$E2#$80#$A8;
+  UTF8_PARAGRAPH_SEPARATOR = #$E2#$80#$A9;
+var
+  Lexer: TGocciaLexer;
+  Tokens: TObjectList<TGocciaToken>;
+begin
+  Lexer := TGocciaLexer.Create(
+    'var' + UTF8_LINE_SEPARATOR + 'x' + UTF8_PARAGRAPH_SEPARATOR +
+    '=' + UTF8_LINE_SEPARATOR + '1' + UTF8_PARAGRAPH_SEPARATOR + ';',
+    '<test>');
+  try
+    Tokens := Lexer.ScanTokens;
+    Expect<TGocciaTokenType>(Tokens[0].TokenType).ToBe(gttVar);
+    Expect<TGocciaTokenType>(Tokens[1].TokenType).ToBe(gttIdentifier);
+    Expect<string>(Tokens[1].Lexeme).ToBe('x');
+    Expect<TGocciaTokenType>(Tokens[2].TokenType).ToBe(gttAssign);
+    Expect<TGocciaTokenType>(Tokens[3].TokenType).ToBe(gttNumber);
+    Expect<TGocciaTokenType>(Tokens[4].TokenType).ToBe(gttSemicolon);
   finally
     Lexer.Free;
   end;

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -143,7 +143,7 @@ end;
 function TGocciaLexer.GetSourceLines: TStringList;
 begin
   if not Assigned(FSourceLines) then
-    FSourceLines := CreateUTF8StringList(FSource);
+    FSourceLines := CreateECMAScriptSourceLines(FSource);
   Result := FSourceLines;
 end;
 
@@ -1431,7 +1431,7 @@ var
   Text: string;
   TokenType: TGocciaTokenType;
 begin
-  while not IsAtEnd and IsValidIdentifierChar(Peek) do
+  while not IsAtEnd and (not IsLineTerminator) and IsValidIdentifierChar(Peek) do
     Advance;
 
   Text := Copy(FSource, FStart, FCurrent - FStart);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -234,6 +234,7 @@ uses
   SysUtils,
 
   BigInteger,
+  TextSemantics,
   TimingUtils,
 
   Goccia.CallStack,
@@ -6568,9 +6569,11 @@ begin
               TGocciaSymbolValue(FRegisters[C].ObjectValue)))
           else if TryGetArrayIndexRegister(FRegisters[C], KeyIndex) and
              (KeyIndex >= 0) and
-             (KeyIndex < Length(TGocciaStringLiteralValue(FRegisters[B].ObjectValue).Value)) then
+             (KeyIndex < UTF16CodeUnitLength(TGocciaStringLiteralValue(
+               FRegisters[B].ObjectValue).Value)) then
             SetRegister(A, TGocciaStringLiteralValue.Create(
-              TGocciaStringLiteralValue(FRegisters[B].ObjectValue).Value[KeyIndex + 1]))
+              UTF16CodeUnitAt(TGocciaStringLiteralValue(
+                FRegisters[B].ObjectValue).Value, KeyIndex)))
           else
             FRegisters[A] := RegisterUndefined;
         end
@@ -6641,6 +6644,10 @@ begin
            (FRegisters[B].ObjectValue is TGocciaArrayValue) then
           FRegisters[A] := VMNumberRegister(
             TGocciaArrayValue(FRegisters[B].ObjectValue).GetLength)
+        else if (FRegisters[B].Kind = grkObject) and
+                (FRegisters[B].ObjectValue is TGocciaStringLiteralValue) then
+          FRegisters[A] := VMNumberRegister(UTF16CodeUnitLength(
+            TGocciaStringLiteralValue(FRegisters[B].ObjectValue).Value))
         else
           FRegisters[A] := RegisterInt(0);
       end;
@@ -6884,9 +6891,11 @@ begin
               TGocciaSymbolValue(FRegisters[C].ObjectValue)))
           else if TryGetArrayIndexRegister(FRegisters[C], KeyIndex) and
              (KeyIndex >= 0) and
-             (KeyIndex < Length(TGocciaStringLiteralValue(FRegisters[B].ObjectValue).Value)) then
+             (KeyIndex < UTF16CodeUnitLength(TGocciaStringLiteralValue(
+               FRegisters[B].ObjectValue).Value)) then
             SetRegister(A, TGocciaStringLiteralValue.Create(
-              TGocciaStringLiteralValue(FRegisters[B].ObjectValue).Value[KeyIndex + 1]))
+              UTF16CodeUnitAt(TGocciaStringLiteralValue(
+                FRegisters[B].ObjectValue).Value, KeyIndex)))
           else
             SetRegister(A, TGocciaUndefinedLiteralValue.UndefinedValue);
         end

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -581,7 +581,8 @@ begin
   end;
 
   Character := UTF16CodeUnitAt(StringValue, Index);
-  if TryReadUTF8CodePoint(Character, 1, CodePoint, ByteLength) then
+  if TryReadUTF8CodePointAllowSurrogates(Character, 1, CodePoint,
+    ByteLength) then
     Result := TGocciaNumberLiteralValue.Create(CodePoint)
   else if Character <> '' then
     Result := TGocciaNumberLiteralValue.Create(Ord(Character[1]))
@@ -643,7 +644,7 @@ begin
   StringValue := ExtractStringValue(AThisValue);
 
   // Step 3: Let len be the length of S
-  Len := Length(StringValue);
+  Len := UTF16CodeUnitLength(StringValue);
 
   // Step 4: Let intStart be ToIntegerOrInfinity(start)
   StartIndex := ToIntegerFromArgs(AArgs);
@@ -663,7 +664,8 @@ begin
 
   // Step 9: Return the substring of S from index from to index to
   if (StartIndex >= 0) and (StartIndex < Len) and (EndIndex > StartIndex) then
-    Result := TGocciaStringLiteralValue.Create(Copy(StringValue, StartIndex + 1, EndIndex - StartIndex))
+    Result := TGocciaStringLiteralValue.Create(
+      UTF16Substring(StringValue, StartIndex, EndIndex - StartIndex))
   else
     Result := TGocciaStringLiteralValue.Create('');
 end;
@@ -681,7 +683,7 @@ begin
   StringValue := ExtractStringValue(AThisValue);
 
   // Step 3: Let len be the length of S
-  Len := Length(StringValue);
+  Len := UTF16CodeUnitLength(StringValue);
 
   // Step 4: Let intStart be ToIntegerOrInfinity(start)
   StartIndex := ToIntegerFromArgs(AArgs);
@@ -704,7 +706,8 @@ begin
 
   // Step 9: Return the substring of S from index from to index to
   if EndIndex > StartIndex then
-    Result := TGocciaStringLiteralValue.Create(Copy(StringValue, StartIndex + 1, EndIndex - StartIndex))
+    Result := TGocciaStringLiteralValue.Create(
+      UTF16Substring(StringValue, StartIndex, EndIndex - StartIndex))
   else
     Result := TGocciaStringLiteralValue.Create('');
 end;
@@ -715,6 +718,7 @@ var
   StringValue, SearchValue: string;
   StartPosition: Integer;
   FoundIndex: Integer;
+  Len: Integer;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
@@ -730,25 +734,18 @@ begin
   StartPosition := ToIntegerFromArgs(AArgs, 1);
 
   // Step 5: Let start be min(max(pos, 0), len)
-  StartPosition := Max(0, StartPosition);
+  Len := UTF16CodeUnitLength(StringValue);
+  StartPosition := Min(Max(0, StartPosition), Len);
 
   if SearchValue = '' then
   begin
-    Result := TGocciaNumberLiteralValue.Create(Min(StartPosition, Length(StringValue)));
+    Result := TGocciaNumberLiteralValue.Create(StartPosition);
     Exit;
   end;
 
   // Step 6-7: Search for first occurrence of searchStr in S at or after start; return index or -1
-  if StartPosition < Length(StringValue) then
-  begin
-    FoundIndex := Pos(SearchValue, Copy(StringValue, StartPosition + 1, Length(StringValue)));
-    if FoundIndex > 0 then
-      Result := TGocciaNumberLiteralValue.Create(FoundIndex + StartPosition - 1)
-    else
-      Result := TGocciaNumberLiteralValue.Create(-1);
-  end
-  else
-    Result := TGocciaNumberLiteralValue.Create(-1);
+  FoundIndex := UTF16IndexOf(StringValue, SearchValue, StartPosition);
+  Result := TGocciaNumberLiteralValue.Create(FoundIndex);
 end;
 
 // ES2026 §22.1.3.10 String.prototype.lastIndexOf(searchString [, position])
@@ -757,7 +754,7 @@ var
   StringValue, SearchValue: string;
   StartPosition: Integer;
   FoundIndex: Integer;
-  I: Integer;
+  Len: Integer;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
@@ -772,12 +769,13 @@ begin
   // Step 4: Let numPos be ToNumber(position); if NaN let pos be +∞, else ToIntegerOrInfinity
   if (AArgs.Length > 1) and
      not (AArgs.GetElement(1).ToNumberLiteral.IsNaN) then
-    StartPosition := ToIntegerFromArgs(AArgs, 1, Length(StringValue))
+    StartPosition := ToIntegerFromArgs(AArgs, 1, UTF16CodeUnitLength(StringValue))
   else
-    StartPosition := Length(StringValue);
+    StartPosition := UTF16CodeUnitLength(StringValue);
 
   // Step 5: Let start be min(max(pos, 0), len)
-  StartPosition := Min(Max(StartPosition, 0), Length(StringValue));
+  Len := UTF16CodeUnitLength(StringValue);
+  StartPosition := Min(Max(StartPosition, 0), Len);
 
   if SearchValue = '' then
   begin
@@ -786,20 +784,7 @@ begin
   end;
 
   // Step 6-7: Search backwards for last occurrence of searchStr at or before start; return index or -1
-  FoundIndex := -1;
-  if StartPosition >= 0 then
-  begin
-    for I := Min(StartPosition, Length(StringValue) - Length(SearchValue)) downto 0 do
-    begin
-      if (I + Length(SearchValue) <= Length(StringValue)) and
-         (Copy(StringValue, I + 1, Length(SearchValue)) = SearchValue) then
-      begin
-        FoundIndex := I;
-        Break;
-      end;
-    end;
-  end;
-
+  FoundIndex := UTF16LastIndexOf(StringValue, SearchValue, StartPosition);
   Result := TGocciaNumberLiteralValue.Create(FoundIndex);
 end;
 
@@ -809,6 +794,7 @@ var
   StringValue, SearchValue: string;
   StartPosition: Integer;
   FoundIndex: Integer;
+  Len: Integer;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
@@ -824,9 +810,10 @@ begin
   StartPosition := ToIntegerFromArgs(AArgs, 1);
 
   // Step 5: Let start be min(max(pos, 0), len)
-  StartPosition := Max(0, StartPosition);
+  Len := UTF16CodeUnitLength(StringValue);
+  StartPosition := Min(Max(0, StartPosition), Len);
 
-  if StartPosition >= Length(StringValue) then
+  if StartPosition >= Len then
   begin
     if SearchValue = '' then
       Result := TGocciaBooleanLiteralValue.TrueValue
@@ -843,8 +830,8 @@ begin
 
   // Step 6: Search for searchStr in S starting at start
   // Step 7: If found, return true; otherwise return false
-  FoundIndex := Pos(SearchValue, Copy(StringValue, StartPosition + 1, Length(StringValue)));
-  if FoundIndex > 0 then
+  FoundIndex := UTF16IndexOf(StringValue, SearchValue, StartPosition);
+  if FoundIndex >= 0 then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
@@ -855,6 +842,7 @@ function TGocciaStringObjectValue.StringStartsWith(const AArgs: TGocciaArguments
 var
   StringValue, SearchValue: string;
   StartPosition: Integer;
+  Len: Integer;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
@@ -868,13 +856,14 @@ begin
 
   // Step 4: Let searchLength be the length of searchStr
   // Step 5: Let start be min(max(ToIntegerOrInfinity(position), 0), len)
-  StartPosition := Max(0, ToIntegerFromArgs(AArgs, 1));
+  Len := UTF16CodeUnitLength(StringValue);
+  StartPosition := Min(Max(0, ToIntegerFromArgs(AArgs, 1)), Len);
 
   // Step 6: If searchLength + start > len(S), return false
   // Step 7: If the code units of S starting at start match searchStr, return true; else false
-  if StartPosition + Length(SearchValue) > Length(StringValue) then
+  if StartPosition + UTF16CodeUnitLength(SearchValue) > Len then
     Result := TGocciaBooleanLiteralValue.FalseValue
-  else if Copy(StringValue, StartPosition + 1, Length(SearchValue)) = SearchValue then
+  else if UTF16IndexOf(StringValue, SearchValue, StartPosition) = StartPosition then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
@@ -885,6 +874,8 @@ function TGocciaStringObjectValue.StringEndsWith(const AArgs: TGocciaArgumentsCo
 var
   StringValue, SearchValue: string;
   EndPosition: Integer;
+  SearchLength: Integer;
+  StartPosition: Integer;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
@@ -900,14 +891,16 @@ begin
   // Step 5: If endPosition is undefined, let pos be len; else let pos be ToIntegerOrInfinity(endPosition)
   // Step 6: Let end be min(max(pos, 0), len)
   EndPosition := Min(Max(0, ToIntegerFromArgs(AArgs, 1,
-    Length(StringValue))), Length(StringValue));
+    UTF16CodeUnitLength(StringValue))), UTF16CodeUnitLength(StringValue));
 
   // Step 7: Let start be end - searchLength
   // Step 8: If start < 0, return false
   // Step 9: If code units of S from start to end match searchStr, return true; else false
-  if EndPosition < Length(SearchValue) then
+  SearchLength := UTF16CodeUnitLength(SearchValue);
+  StartPosition := EndPosition - SearchLength;
+  if StartPosition < 0 then
     Result := TGocciaBooleanLiteralValue.FalseValue
-  else if Copy(StringValue, EndPosition - Length(SearchValue) + 1, Length(SearchValue)) = SearchValue then
+  else if UTF16IndexOf(StringValue, SearchValue, StartPosition) = StartPosition then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
@@ -1335,7 +1328,9 @@ var
   SeparatorArg: TGocciaValue;
   ResultArray: TGocciaArrayValue;
   I: Integer;
-  RemainingString: string;
+  PreviousSeparatorEnd: Integer;
+  SearchStart: Integer;
+  SeparatorLength: Integer;
   SeparatorPos: Integer;
   Segment: string;
   Limit: Cardinal;
@@ -1452,9 +1447,10 @@ begin
     // Step 6: If sep is "", split each character
     if Separator = '' then
     begin
-      for I := 1 to Length(StringValue) do
+      for I := 0 to UTF16CodeUnitLength(StringValue) - 1 do
       begin
-        ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(StringValue[I]));
+        ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(
+          UTF16CodeUnitAt(StringValue, I)));
         if HasLimit and (Cardinal(ResultArray.Elements.Count) >= Limit) then
           Break;
       end;
@@ -1463,28 +1459,34 @@ begin
     end;
 
     // Step 7: Split by occurrences of sep, respecting limit
-    if Pos(Separator, StringValue) = 0 then
+    if UTF16IndexOf(StringValue, Separator) = -1 then
       ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(StringValue))
     else
     begin
-      RemainingString := StringValue;
+      SeparatorLength := UTF16CodeUnitLength(Separator);
+      PreviousSeparatorEnd := 0;
+      SearchStart := 0;
       while True do
       begin
-        SeparatorPos := Pos(Separator, RemainingString);
-        if SeparatorPos = 0 then
+        SeparatorPos := UTF16IndexOf(StringValue, Separator, SearchStart);
+        if SeparatorPos = -1 then
         begin
-          ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(RemainingString));
+          ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(
+            UTF16Substring(StringValue, PreviousSeparatorEnd,
+            UTF16CodeUnitLength(StringValue) - PreviousSeparatorEnd)));
           Break;
         end
         else
         begin
-          Segment := Copy(RemainingString, 1, SeparatorPos - 1);
+          Segment := UTF16Substring(StringValue, PreviousSeparatorEnd,
+            SeparatorPos - PreviousSeparatorEnd);
           ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(Segment));
 
           if HasLimit and (Cardinal(ResultArray.Elements.Count) >= Limit) then
             Break;
 
-          RemainingString := Copy(RemainingString, SeparatorPos + Length(Separator), Length(RemainingString));
+          PreviousSeparatorEnd := SeparatorPos + SeparatorLength;
+          SearchStart := PreviousSeparatorEnd;
         end;
       end;
     end;
@@ -1697,7 +1699,7 @@ end;
 function TGocciaStringObjectValue.StringPadStart(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   StringValue, PadString, Padding: string;
-  TargetLength, PadNeeded: Integer;
+  StringLength, TargetLength, PadNeeded: Integer;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
@@ -1707,7 +1709,8 @@ begin
   TargetLength := ToIntegerFromArgs(AArgs);
 
   // Step 4: If intMaxLength <= len(S), return S
-  if Length(StringValue) >= TargetLength then
+  StringLength := UTF16CodeUnitLength(StringValue);
+  if StringLength >= TargetLength then
   begin
     Result := TGocciaStringLiteralValue.Create(StringValue);
     Exit;
@@ -1728,11 +1731,11 @@ begin
   // Step 6: Let fillLen be intMaxLength - len(S)
   // Step 7: Let truncatedStringFiller be filler repeated and truncated to fillLen
   // Step 8: Return truncatedStringFiller + S
-  PadNeeded := TargetLength - Length(StringValue);
+  PadNeeded := TargetLength - StringLength;
   Padding := '';
-  while Length(Padding) < PadNeeded do
+  while UTF16CodeUnitLength(Padding) < PadNeeded do
     Padding := Padding + PadString;
-  Padding := Copy(Padding, 1, PadNeeded);
+  Padding := UTF16Substring(Padding, 0, PadNeeded);
 
   Result := TGocciaStringLiteralValue.Create(Padding + StringValue);
 end;
@@ -1741,7 +1744,7 @@ end;
 function TGocciaStringObjectValue.StringPadEnd(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   StringValue, PadString, Padding: string;
-  TargetLength, PadNeeded: Integer;
+  StringLength, TargetLength, PadNeeded: Integer;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
@@ -1751,7 +1754,8 @@ begin
   TargetLength := ToIntegerFromArgs(AArgs);
 
   // Step 4: If intMaxLength <= len(S), return S
-  if Length(StringValue) >= TargetLength then
+  StringLength := UTF16CodeUnitLength(StringValue);
+  if StringLength >= TargetLength then
   begin
     Result := TGocciaStringLiteralValue.Create(StringValue);
     Exit;
@@ -1772,11 +1776,11 @@ begin
   // Step 6: Let fillLen be intMaxLength - len(S)
   // Step 7: Let truncatedStringFiller be filler repeated and truncated to fillLen
   // Step 8: Return S + truncatedStringFiller
-  PadNeeded := TargetLength - Length(StringValue);
+  PadNeeded := TargetLength - StringLength;
   Padding := '';
-  while Length(Padding) < PadNeeded do
+  while UTF16CodeUnitLength(Padding) < PadNeeded do
     Padding := Padding + PadString;
-  Padding := Copy(Padding, 1, PadNeeded);
+  Padding := UTF16Substring(Padding, 0, PadNeeded);
 
   Result := TGocciaStringLiteralValue.Create(StringValue + Padding);
 end;

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -299,8 +299,9 @@ begin
 
   if TryStrToInt(AName, Index) then
   begin
-    if (Index >= 0) and (Index < Length(StringValue)) then
-      Result := TGocciaStringLiteralValue.Create(StringValue[Index + 1])
+    if (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue)) then
+      Result := TGocciaStringLiteralValue.Create(
+        UTF16CodeUnitAt(StringValue, Index))
     else
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
@@ -327,11 +328,11 @@ var
 begin
   StringValue := FPrimitive.ToStringLiteral.Value;
   InheritedNames := inherited GetEnumerablePropertyNames;
-  SetLength(Result, Length(StringValue) + Length(InheritedNames));
-  for I := 0 to Length(StringValue) - 1 do
+  SetLength(Result, UTF16CodeUnitLength(StringValue) + Length(InheritedNames));
+  for I := 0 to UTF16CodeUnitLength(StringValue) - 1 do
     Result[I] := IntToStr(I);
   for I := 0 to High(InheritedNames) do
-    Result[Length(StringValue) + I] := InheritedNames[I];
+    Result[UTF16CodeUnitLength(StringValue) + I] := InheritedNames[I];
 end;
 
 function TGocciaStringObjectValue.GetEnumerablePropertyValues: TArray<TGocciaValue>;
@@ -342,11 +343,12 @@ var
 begin
   StringValue := FPrimitive.ToStringLiteral.Value;
   InheritedValues := inherited GetEnumerablePropertyValues;
-  SetLength(Result, Length(StringValue) + Length(InheritedValues));
-  for I := 0 to Length(StringValue) - 1 do
-    Result[I] := TGocciaStringLiteralValue.Create(StringValue[I + 1]);
+  SetLength(Result, UTF16CodeUnitLength(StringValue) + Length(InheritedValues));
+  for I := 0 to UTF16CodeUnitLength(StringValue) - 1 do
+    Result[I] := TGocciaStringLiteralValue.Create(
+      UTF16CodeUnitAt(StringValue, I));
   for I := 0 to High(InheritedValues) do
-    Result[Length(StringValue) + I] := InheritedValues[I];
+    Result[UTF16CodeUnitLength(StringValue) + I] := InheritedValues[I];
 end;
 
 function TGocciaStringObjectValue.GetEnumerablePropertyEntries: TArray<TPair<string, TGocciaValue>>;
@@ -358,15 +360,16 @@ var
 begin
   StringValue := FPrimitive.ToStringLiteral.Value;
   InheritedEntries := inherited GetEnumerablePropertyEntries;
-  SetLength(Result, Length(StringValue) + Length(InheritedEntries));
-  for I := 0 to Length(StringValue) - 1 do
+  SetLength(Result, UTF16CodeUnitLength(StringValue) + Length(InheritedEntries));
+  for I := 0 to UTF16CodeUnitLength(StringValue) - 1 do
   begin
     Entry.Key := IntToStr(I);
-    Entry.Value := TGocciaStringLiteralValue.Create(StringValue[I + 1]);
+    Entry.Value := TGocciaStringLiteralValue.Create(
+      UTF16CodeUnitAt(StringValue, I));
     Result[I] := Entry;
   end;
   for I := 0 to High(InheritedEntries) do
-    Result[Length(StringValue) + I] := InheritedEntries[I];
+    Result[UTF16CodeUnitLength(StringValue) + I] := InheritedEntries[I];
 end;
 
 // ES2026 §10.4.3.6 StringExoticObject [[OwnPropertyKeys]] (all own string keys)
@@ -379,12 +382,13 @@ var
 begin
   StringValue := FPrimitive.ToStringLiteral.Value;
   InheritedNames := inherited GetAllPropertyNames;
-  SetLength(Result, Length(StringValue) + 1 + Length(InheritedNames));
-  for I := 0 to Length(StringValue) - 1 do
+  SetLength(Result, UTF16CodeUnitLength(StringValue) + 1 +
+    Length(InheritedNames));
+  for I := 0 to UTF16CodeUnitLength(StringValue) - 1 do
     Result[I] := IntToStr(I);
-  Result[Length(StringValue)] := PROP_LENGTH;
+  Result[UTF16CodeUnitLength(StringValue)] := PROP_LENGTH;
   for I := 0 to High(InheritedNames) do
-    Result[Length(StringValue) + 1 + I] := InheritedNames[I];
+    Result[UTF16CodeUnitLength(StringValue) + 1 + I] := InheritedNames[I];
 end;
 
 // ES2026 §10.4.3.1 StringExoticObject [[GetOwnProperty]](P)
@@ -398,11 +402,11 @@ begin
   if TryStrToInt(AName, Index) and (AName = IntToStr(Index)) then
   begin
     StringValue := FPrimitive.ToStringLiteral.Value;
-    if (Index >= 0) and (Index < Length(StringValue)) then
+    if (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue)) then
     begin
       // String character indices: enumerable, non-writable, non-configurable
       Result := TGocciaPropertyDescriptorData.Create(
-        TGocciaStringLiteralValue.Create(StringValue[Index + 1]),
+        TGocciaStringLiteralValue.Create(UTF16CodeUnitAt(StringValue, Index)),
         [pfEnumerable]);
       Exit;
     end;
@@ -412,7 +416,8 @@ begin
   begin
     // length: non-enumerable, non-writable, non-configurable
     Result := TGocciaPropertyDescriptorData.Create(
-      TGocciaNumberLiteralValue.Create(Length(FPrimitive.ToStringLiteral.Value)),
+      TGocciaNumberLiteralValue.Create(
+        UTF16CodeUnitLength(FPrimitive.ToStringLiteral.Value)),
       []);
     Exit;
   end;
@@ -430,7 +435,7 @@ begin
   if TryStrToInt(AName, Index) and (AName = IntToStr(Index)) then
   begin
     StringValue := FPrimitive.ToStringLiteral.Value;
-    Result := (Index >= 0) and (Index < Length(StringValue));
+    Result := (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue));
     Exit;
   end;
   if AName = PROP_LENGTH then
@@ -526,7 +531,7 @@ begin
   // Step 2: Let S be ToString(O)
   StringValue := ExtractStringValue(AThisValue);
   // Step 3: Return the number of code units in S
-  Result := TGocciaNumberLiteralValue.Create(Length(StringValue));
+  Result := TGocciaNumberLiteralValue.Create(UTF16CodeUnitLength(StringValue));
 end;
 
 // ES2026 §22.1.3.1 String.prototype.charAt(pos)
@@ -544,8 +549,9 @@ begin
 
   // Step 4: If position < 0 or position >= len(S), return ""
   // Step 5: Return the String value of length 1 containing the code unit at index position
-  if (Index >= 0) and (Index < Length(StringValue)) then
-    Result := TGocciaStringLiteralValue.Create(StringValue[Index + 1])
+  if (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue)) then
+    Result := TGocciaStringLiteralValue.Create(
+      UTF16CodeUnitAt(StringValue, Index))
   else
     Result := TGocciaStringLiteralValue.Create('');
 end;
@@ -553,6 +559,9 @@ end;
 // ES2026 §22.1.3.2 String.prototype.charCodeAt(pos)
 function TGocciaStringObjectValue.StringCharCodeAt(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
+  Character: string;
+  ByteLength: Integer;
+  CodePoint: Cardinal;
   StringValue: string;
   Index: Integer;
 begin
@@ -565,8 +574,17 @@ begin
 
   // Step 4: If position < 0 or position >= len(S), return NaN
   // Step 5: Return the numeric value of the code unit at index position
-  if (Index >= 0) and (Index < Length(StringValue)) then
-    Result := TGocciaNumberLiteralValue.Create(Ord(StringValue[Index + 1]))
+  if (Index < 0) or (Index >= UTF16CodeUnitLength(StringValue)) then
+  begin
+    Result := TGocciaNumberLiteralValue.NaNValue;
+    Exit;
+  end;
+
+  Character := UTF16CodeUnitAt(StringValue, Index);
+  if TryReadUTF8CodePoint(Character, 1, CodePoint, ByteLength) then
+    Result := TGocciaNumberLiteralValue.Create(CodePoint)
+  else if Character <> '' then
+    Result := TGocciaNumberLiteralValue.Create(Ord(Character[1]))
   else
     Result := TGocciaNumberLiteralValue.NaNValue;
 end;
@@ -1801,17 +1819,17 @@ begin
 
   // Step 5: If relativeIndex >= 0, let k be relativeIndex; else let k be len + relativeIndex
   if Index < 0 then
-    Index := Length(StringValue) + Index;
+    Index := UTF16CodeUnitLength(StringValue) + Index;
 
   // Step 6: If k < 0 or k >= len, return undefined
-  if (Index < 0) or (Index >= Length(StringValue)) then
+  if (Index < 0) or (Index >= UTF16CodeUnitLength(StringValue)) then
   begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
 
   // Step 7: Return the substring of S from k to k + 1
-  Result := TGocciaStringLiteralValue.Create(StringValue[Index + 1]);
+  Result := TGocciaStringLiteralValue.Create(UTF16CodeUnitAt(StringValue, Index));
 end;
 
 // ES2026 §22.1.3.32 String.prototype.valueOf()
@@ -1841,7 +1859,6 @@ end;
 function TGocciaStringObjectValue.StringCodePointAt(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   StringValue: string;
-  ByteLength: Integer;
   CodePoint: Cardinal;
   Index: Integer;
 begin
@@ -1853,20 +1870,17 @@ begin
   Index := ToIntegerFromArgs(AArgs);
 
   // Step 4: If position < 0 or position >= len(S), return undefined
-  if (Index < 0) or (Index >= Length(StringValue)) then
+  if (Index < 0) or (Index >= UTF16CodeUnitLength(StringValue)) then
   begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
 
   // Step 5: Let cp be CodePointAt(S, position) and return cp.[[CodePoint]]
-  if not TryReadUTF8CodePoint(StringValue, Index + 1, CodePoint,
-    ByteLength) then
-  begin
-    CodePoint := Ord(StringValue[Index + 1]);
-  end;
-
-  Result := TGocciaNumberLiteralValue.Create(CodePoint);
+  if TryUTF16CodePointValueAt(StringValue, Index, CodePoint) then
+    Result := TGocciaNumberLiteralValue.Create(CodePoint)
+  else
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 // ES2026 §22.1.3.11 String.prototype.localeCompare(that)

--- a/tests/built-ins/String/prototype/codePointAt.js
+++ b/tests/built-ins/String/prototype/codePointAt.js
@@ -19,8 +19,17 @@ describe("String.prototype.codePointAt", () => {
     expect("".codePointAt(0)).toBe(undefined);
   });
 
+  test("indexes valid UTF-8 characters as ECMAScript string positions", () => {
+    expect("é".codePointAt(0)).toBe(0xe9);
+    expect("é".codePointAt(1)).toBe(undefined);
+  });
+
+  test("returns full code point for leading surrogate position", () => {
+    expect("😀".codePointAt(0)).toBe(0x1f600);
+    expect("😀".codePointAt(1)).toBe(0xde00);
+  });
+
   test("falls back to raw byte values for invalid UTF-8 positions", () => {
-    expect("é".codePointAt(1)).toBe(0xa9);
     expect("\uD800".codePointAt(0)).toBe(0xed);
   });
 });

--- a/tests/built-ins/String/prototype/codePointAt.js
+++ b/tests/built-ins/String/prototype/codePointAt.js
@@ -29,7 +29,7 @@ describe("String.prototype.codePointAt", () => {
     expect("😀".codePointAt(1)).toBe(0xde00);
   });
 
-  test("falls back to raw byte values for invalid UTF-8 positions", () => {
-    expect("\uD800".codePointAt(0)).toBe(0xed);
+  test("returns lone surrogate code unit values", () => {
+    expect("\uD800".codePointAt(0)).toBe(0xd800);
   });
 });

--- a/tests/built-ins/String/prototype/utf16-code-units.js
+++ b/tests/built-ins/String/prototype/utf16-code-units.js
@@ -1,0 +1,42 @@
+/*---
+description: String prototype methods use UTF-16 code unit indexes
+features: [String.prototype]
+---*/
+
+describe("String.prototype UTF-16 code unit indexing", () => {
+  const face = "\uD83D\uDE00";
+  const text = "a" + face + "b";
+
+  test("slice and substring operate on UTF-16 code units", () => {
+    expect(text.slice(1, 3)).toBe(face);
+    expect(text.substring(1, 3)).toBe(face);
+    expect(text.slice(1, 2).charCodeAt(0)).toBe(0xd83d);
+    expect(text.substring(2, 3).charCodeAt(0)).toBe(0xde00);
+  });
+
+  test("search methods return and consume UTF-16 code unit positions", () => {
+    expect(text.indexOf(face)).toBe(1);
+    expect(text.indexOf("b")).toBe(3);
+    expect((face + "x" + face).lastIndexOf(face)).toBe(3);
+    expect(text.includes(face, 2)).toBe(false);
+    expect(text.startsWith(face, 1)).toBe(true);
+    expect(text.endsWith(face, 3)).toBe(true);
+  });
+
+  test("padding computes target lengths in UTF-16 code units", () => {
+    expect("x".padStart(3, face)).toBe(face + "x");
+    expect("x".padEnd(3, face)).toBe("x" + face);
+  });
+
+  test("split uses UTF-16 code units for empty and non-empty separators", () => {
+    const units = face.split("");
+    expect(units.length).toBe(2);
+    expect(units[0].charCodeAt(0)).toBe(0xd83d);
+    expect(units[1].charCodeAt(0)).toBe(0xde00);
+    expect(("a" + face + "b" + face + "c").split(face)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- split lexer source lines with ECMAScript line terminator semantics, including U+2028 and U+2029
- stop identifier scanning at Unicode line terminators
- use shared UTF-16 string indexing helpers for string length/index access and codePointAt behavior

## Verification
- python3 scripts/run_test262_suite.py --suite-dir /tmp/test262 --filter 'language/line-terminators/*' --jobs 1 --timeout 5\n- ./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress\n- ./build/TextSemantics.Test\n- ./build/Goccia.Lexer.Test\n- ./format.pas --check\n- ./build.pas tests testrunner loader