### PR TITLE
Add CLI-local print to GocciaScriptLoaderBare

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ For a smaller binary surface without the default runtime globals (console, JSON5
 ```bash
 ./build.pas loaderbare
 printf "Goccia.version;" | ./build/GocciaScriptLoaderBare
+printf "print('hello from bare');" | ./build/GocciaScriptLoaderBare
 ./build/GocciaScriptLoaderBare example.js
 ```
 
-`GocciaScriptLoaderBare` accepts an explicit file path, `-`, or no path for stdin. It reads the entry source in the frontend and passes source text to `TGocciaEngine`; it does not attach `TGocciaRuntime`.
+`GocciaScriptLoaderBare` accepts an explicit file path, `-`, or no path for stdin. It reads the entry source in the frontend and passes source text to `TGocciaEngine`; it exposes a CLI-local `print(...args)` helper for stdout, but does not attach `TGocciaRuntime`.
 
 Script files may start with a Unix shebang line like `#!/usr/bin/env goccia`; GocciaScript ignores that first line during lexing.
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -347,7 +347,7 @@ All compiled binaries go to the `build/` directory:
 |--------|--------|-------------|
 | `build/GocciaREPL` | `source/app/GocciaREPL.dpr` | Interactive read-eval-print loop |
 | `build/GocciaScriptLoader` | `source/app/GocciaScriptLoader.dpr` | Execute `.js` files or stdin input, with optional JSON output |
-| `build/GocciaScriptLoaderBare` | `source/app/GocciaScriptLoaderBare.dpr` | Execute file or stdin source with the core engine only; no default runtime globals |
+| `build/GocciaScriptLoaderBare` | `source/app/GocciaScriptLoaderBare.dpr` | Execute file or stdin source with the core engine and CLI-local `print`; no default runtime globals |
 | `build/GocciaTestRunner` | `source/app/GocciaTestRunner.dpr` | JavaScript test runner |
 | `build/GocciaBenchmarkRunner` | `source/app/GocciaBenchmarkRunner.dpr` | Performance benchmark runner for files or stdin input |
 | `build/GocciaBundler` | `source/app/GocciaBundler.dpr` | Standalone bytecode compiler (source to `.gbc`) |
@@ -547,7 +547,7 @@ Runs on **ubuntu-latest x64 only** (single runner, no matrix).
 
 **`test262`** (needs build, **non-blocking**) — Shallow-clones `tc39/test262@main`, runs `python3 scripts/run_test262_suite.py --suite-dir test262-suite --mode=bytecode --jobs=4 --output=test262-results.json`, and uploads the JSON report. Failing tests do not fail the job. The downstream `test262-comment` job (`if: always()`) restores the most recent `test262-baseline-` cache entry from main, computes a four-row metric table (Total / Eligible / Eligible passing / Total passing) and a top-three "Areas closest to 100%" table (≥ 25 attempted tests, below 100%, keyed by the first two test262 path components), and posts/updates a comment using marker `<!-- test262-results -->`. When a baseline is available, both tables include a Δ vs main column.
 
-**`cli`** (needs build) — Runs CLI behavior smoke tests via Bun (`scripts/test-cli.ts`, `scripts/test-cli-lexer.ts`, `scripts/test-cli-parser.ts`, `scripts/test-cli-config.ts`, `scripts/test-cli-apps.ts`). `test-cli-apps.ts` includes `GocciaScriptLoaderBare` coverage for stdin, `-`, file input, module source type, and absence of runtime globals.
+**`cli`** (needs build) — Runs CLI behavior smoke tests via Bun (`scripts/test-cli.ts`, `scripts/test-cli-lexer.ts`, `scripts/test-cli-parser.ts`, `scripts/test-cli-config.ts`, `scripts/test-cli-apps.ts`). `test-cli-apps.ts` includes `GocciaScriptLoaderBare` coverage for stdin, `-`, file input, CLI-local `print`, module source type, and absence of runtime globals.
 
 FPC is only installed once per platform in the `build` job. In `ci.yml`, the test, benchmark, cli, TOML, JSON5, and test262 conformance jobs reuse the pre-built binaries and artifacts from that job; in `pr.yml`, the test, benchmark, test262, and cli jobs do the same.
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -17,7 +17,7 @@ GocciaScript provides a set of built-in global objects that mirror JavaScript's 
 
 Core language built-ins (Math, Object, Array, Number, JSON, Symbol, Set, Map, WeakSet, WeakMap, Promise, Temporal, ArrayBuffer, Proxy, Reflect, etc.) are always registered unconditionally by the engine.
 
-Runtime globals (Console, JSON5, JSONL, TOML, YAML, CSV, TSV, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, SemVer) are registered by `TGocciaRuntime`. Frontends such as `GocciaScriptLoader`, `GocciaTestRunner`, `GocciaBenchmarkRunner`, and `GocciaREPL` attach that runtime; `GocciaScriptLoaderBare` does not.
+Runtime globals (Console, JSON5, JSONL, TOML, YAML, CSV, TSV, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, SemVer) are registered by `TGocciaRuntime`. Frontends such as `GocciaScriptLoader`, `GocciaTestRunner`, `GocciaBenchmarkRunner`, and `GocciaREPL` attach that runtime; `GocciaScriptLoaderBare` does not, and exposes only a CLI-local `print(...args)` helper.
 
 Only three runtime globals are special-purpose opt-ins in `TGocciaRuntimeGlobal`:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -529,7 +529,7 @@ build → test             → artifacts
 
 **`benchmark`** (needs build, all platforms) — Downloads pre-built binaries, runs all benchmarks.
 
-**`cli`** (needs build, all platforms) — Downloads pre-built binaries and runs CLI behavior smoke tests via Bun: `test-cli.ts` (flags across all apps), `test-cli-lexer.ts` (numeric-separator rejection), `test-cli-parser.ts` (error display), `test-cli-config.ts` (config-file loading and per-file inheritance), and `test-cli-apps.ts` (app-specific features, including `GocciaScriptLoaderBare` stdin/file checks and runtime-global absence). Windows runs additionally assert that the loader binary does not link against OpenSSL DLLs.
+**`cli`** (needs build, all platforms) — Downloads pre-built binaries and runs CLI behavior smoke tests via Bun: `test-cli.ts` (flags across all apps), `test-cli-lexer.ts` (numeric-separator rejection), `test-cli-parser.ts` (error display), `test-cli-config.ts` (config-file loading and per-file inheritance), and `test-cli-apps.ts` (app-specific features, including `GocciaScriptLoaderBare` stdin/file checks, CLI-local `print`, and runtime-global absence). Windows runs additionally assert that the loader binary does not link against OpenSSL DLLs.
 
 **`artifacts`** (needs test + toml-compliance + json5-compliance + benchmark + cli, `main` only) — Uploads release binaries after all checks pass. `test262` is **not** a gating dependency — failing tests there cannot block a release.
 

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -4,10 +4,10 @@
  *
  * App-specific features: GocciaScriptLoader (JSON output, --global/--globals,
  * coverage, source maps), GocciaScriptLoaderBare (core-engine-only stdin/file
- * execution and runtime-global absence), GocciaBundler (compile, roundtrip,
- * stdin, directory, .gbc rejection, source maps), GocciaBenchmarkRunner (file,
- * stdin, bytecode), GocciaREPL (banner, evaluation, ASI, error recovery,
- * bytecode).
+ * execution, CLI print, and runtime-global absence), GocciaBundler (compile,
+ * roundtrip, stdin, directory, .gbc rejection, source maps),
+ * GocciaBenchmarkRunner (file, stdin, bytecode), GocciaREPL (banner,
+ * evaluation, ASI, error recovery, bytecode).
  */
 
 import { $ } from "bun";
@@ -390,9 +390,22 @@ console.log("Bare Loader: file input...");
   }
 }
 
+console.log("Bare Loader: print global...");
+{
+  const proc = Bun.spawnSync([BARE], {
+    stdin: new TextEncoder().encode("print('hello', 7); undefined;\n"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) throw new Error(`Bare print exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+  if (proc.stdout.toString().trim() !== "hello 7") throw new Error(`Bare print expected hello 7, got: ${proc.stdout.toString()}`);
+}
+
 console.log("Bare Loader: no runtime globals...");
 {
   const source = [
+    "typeof print + ':' +",
+    "typeof globalThis.print + ':' +",
     "typeof console + ':' +",
     "typeof FFI + ':' +",
     "typeof Goccia + ':' +",
@@ -406,7 +419,7 @@ console.log("Bare Loader: no runtime globals...");
   });
   if (proc.exitCode !== 0) throw new Error(`Bare runtime-global check exited ${proc.exitCode}: ${proc.stderr.toString()}`);
   const output = proc.stdout.toString().trim();
-  if (output !== "undefined:undefined:object:true")
+  if (output !== "function:function:undefined:undefined:object:true")
     throw new Error(`Bare runtime-global check mismatch, got: ${output}`);
 }
 

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -8,6 +8,7 @@ uses
 
   TextSemantics,
 
+  Goccia.Arguments.Collection,
   Goccia.Engine,
   Goccia.Error,
   Goccia.Error.Detail,
@@ -15,9 +16,16 @@ uses
   Goccia.Terminal.Colors,
   Goccia.TextFiles,
   Goccia.Values.Error,
+  Goccia.Values.NativeFunction,
   Goccia.Values.Primitives;
 
 type
+  TBarePrintHost = class
+  public
+    function Print(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
   TBareOptions = record
     ASI: Boolean;
     CompatVar: Boolean;
@@ -27,6 +35,27 @@ type
     SourceType: TGocciaSourceType;
     FileName: string;
   end;
+
+const
+  BARE_PRINT_GLOBAL_NAME = 'print';
+
+function TBarePrintHost.Print(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  I: Integer;
+  Line: string;
+begin
+  Line := '';
+  for I := 0 to AArgs.Length - 1 do
+  begin
+    if I > 0 then
+      Line := Line + ' ';
+    Line := Line + AArgs.GetElement(I).ToStringLiteral.Value;
+  end;
+
+  WriteLn(Line);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
 
 procedure PrintUsage;
 begin
@@ -113,6 +142,15 @@ begin
   AEngine.FunctionConstructor.Enabled := AOptions.UnsafeFunctionConstructor;
 end;
 
+procedure RegisterBareGlobals(const AEngine: TGocciaEngine;
+  const APrintHost: TBarePrintHost);
+begin
+  AEngine.RegisterGlobal(BARE_PRINT_GLOBAL_NAME,
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(APrintHost.Print,
+      BARE_PRINT_GLOBAL_NAME, -1));
+  AEngine.RefreshGlobalThis;
+end;
+
 procedure PrintResult(const AResult: TGocciaValue);
 begin
   if not Assigned(AResult) then
@@ -126,6 +164,7 @@ function RunBare(const AOptions: TBareOptions): Integer;
 var
   DisplayName: string;
   Engine: TGocciaEngine;
+  PrintHost: TBarePrintHost;
   ScriptResult: TGocciaScriptResult;
   Source: TStringList;
 begin
@@ -137,22 +176,28 @@ begin
     else
       DisplayName := AOptions.FileName;
 
-    Engine := TGocciaEngine.Create(DisplayName, Source);
+    PrintHost := TBarePrintHost.Create;
     try
-      ConfigureEngine(Engine, AOptions);
+      Engine := TGocciaEngine.Create(DisplayName, Source);
       try
-        ScriptResult := Engine.Execute;
-        PrintResult(ScriptResult.Result);
-      except
-        on E: TGocciaThrowValue do
-        begin
-          WriteLn(StdErr, FormatThrowDetail(E.Value, DisplayName, Source,
-            IsColorTerminal, E.Suggestion));
-          Result := 1;
+        ConfigureEngine(Engine, AOptions);
+        RegisterBareGlobals(Engine, PrintHost);
+        try
+          ScriptResult := Engine.Execute;
+          PrintResult(ScriptResult.Result);
+        except
+          on E: TGocciaThrowValue do
+          begin
+            WriteLn(StdErr, FormatThrowDetail(E.Value, DisplayName, Source,
+              IsColorTerminal, E.Suggestion));
+            Result := 1;
+          end;
         end;
+      finally
+        Engine.Free;
       end;
     finally
-      Engine.Free;
+      PrintHost.Free;
     end;
   finally
     Source.Free;


### PR DESCRIPTION
## Summary
- Added a CLI-local `print(...args)` helper to `GocciaScriptLoaderBare` that writes space-separated arguments to stdout and returns `undefined`.
- Registered `print` as a bare-loader global without attaching `TGocciaRuntime`, while keeping runtime globals unavailable.
- Updated CLI smoke tests and docs to cover the new bare-loader behavior.

## Testing
- Not run (not requested).
- Added/updated CLI smoke coverage in `scripts/test-cli-apps.ts` for `print` output and `typeof print` / `typeof globalThis.print` expectations.
- Documentation references updated in `README.md`, `docs/build-system.md`, `docs/built-ins.md`, and `docs/testing.md`.