### PR TITLE
Add deterministic benchmark profile diffs to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,6 +748,31 @@ jobs:
           path: benchmark-${{ matrix.mode }}-results.json
           key: benchmark-${{ matrix.mode }}-baseline-${{ github.sha }}
 
+      - name: Capture deterministic profile baseline
+        if: github.ref == 'refs/heads/main' && matrix.target == 'x86_64-linux' && matrix.mode == 'bytecode'
+        run: |
+          set -euo pipefail
+          mkdir -p profile-baseline
+          while IFS= read -r bench; do
+            rel="${bench#benchmarks/}"
+            out="profile-baseline/${rel%.*}.json"
+            mkdir -p "$(dirname "$out")"
+            ./build/GocciaBenchmarkRunner "$bench" \
+              --profile-deterministic \
+              --profile=all \
+              --profile-output="$out" \
+              --no-progress \
+              --format=compact-json \
+              > /dev/null
+          done < <(find benchmarks -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' \) ! -path '*/helpers/*' | sort)
+
+      - name: Cache deterministic profile baseline
+        if: github.ref == 'refs/heads/main' && matrix.target == 'x86_64-linux' && matrix.mode == 'bytecode'
+        uses: actions/cache/save@v5
+        with:
+          path: profile-baseline/
+          key: profile-baseline-${{ github.sha }}
+
   cli:
     needs: build
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,6 +758,7 @@ jobs:
             out="profile-baseline/${rel%.*}.json"
             mkdir -p "$(dirname "$out")"
             ./build/GocciaBenchmarkRunner "$bench" \
+              --mode=bytecode \
               --profile-deterministic \
               --profile=all \
               --profile-output="$out" \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -200,6 +200,7 @@ jobs:
             out="profile-current/${rel%.*}.json"
             mkdir -p "$(dirname "$out")"
             ./build/GocciaBenchmarkRunner "$bench" \
+              --mode=bytecode \
               --profile-deterministic \
               --profile=all \
               --profile-output="$out" \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -189,6 +189,25 @@ jobs:
           GOCCIA_BENCH_ROUNDS: 7
         run: ./build/GocciaBenchmarkRunner benchmarks ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --no-progress --format=json --output=benchmark-${{ matrix.mode }}.json
 
+      - name: Capture deterministic profiles
+        if: matrix.mode == 'bytecode'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p profile-current
+          while IFS= read -r bench; do
+            rel="${bench#benchmarks/}"
+            out="profile-current/${rel%.*}.json"
+            mkdir -p "$(dirname "$out")"
+            ./build/GocciaBenchmarkRunner "$bench" \
+              --profile-deterministic \
+              --profile=all \
+              --profile-output="$out" \
+              --no-progress \
+              --format=compact-json \
+              > /dev/null
+          done < <(find benchmarks -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' \) ! -path '*/helpers/*' | sort)
+
       - name: Check benchmark CLI behaviour
         run: |
           grep -q '"files": \[' benchmark-${{ matrix.mode }}.json
@@ -201,6 +220,14 @@ jobs:
           name: benchmark-${{ matrix.mode }}
           retention-days: 1
           path: benchmark-${{ matrix.mode }}.json
+
+      - name: Upload deterministic profiles
+        if: matrix.mode == 'bytecode'
+        uses: actions/upload-artifact@v7
+        with:
+          name: profile-current
+          retention-days: 1
+          path: profile-current/
 
   cli:
     needs: build
@@ -308,6 +335,8 @@ jobs:
       run:
         shell: bash
     steps:
+      - uses: actions/checkout@v5
+
       - name: Download interpreted results
         uses: actions/download-artifact@v7
         with:
@@ -317,6 +346,13 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: benchmark-bytecode
+
+      - name: Download deterministic profiles
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          name: profile-current
+          path: profile-current/
 
       - name: Restore interpreted baseline
         uses: actions/cache/restore@v5
@@ -331,6 +367,13 @@ jobs:
           path: benchmark-bytecode-results.json
           key: benchmark-bytecode-baseline-will-not-match
           restore-keys: benchmark-bytecode-baseline-
+
+      - name: Restore deterministic profile baseline
+        uses: actions/cache/restore@v5
+        with:
+          path: profile-baseline/
+          key: profile-baseline-will-not-match
+          restore-keys: profile-baseline-
 
       - name: Check baselines
         run: |
@@ -350,6 +393,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const { buildProfileDiffSection } = require('./scripts/profile-diff.js');
 
             const fmtOps = (n) => Math.round(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
             const fmtPercent = (change) => {
@@ -544,6 +588,19 @@ jobs:
               body += `<summary><strong>${shortName}</strong> — ${block.fileSummary}</summary>\n\n`;
               body += block.fileRows;
               body += `\n</details>\n\n`;
+            }
+
+            const skipProfile = /\[skip-profile-check\]/.test(context.payload.pull_request?.body || '');
+            try {
+              const profileDiff = buildProfileDiffSection({
+                baselineDir: 'profile-baseline',
+                currentDir: 'profile-current',
+                skip: skipProfile,
+              });
+              body += profileDiff.markdown + '\n\n';
+            } catch (error) {
+              console.log('Failed to build deterministic profile diff:', error.message);
+              body += '## Deterministic profile diff\n\nDeterministic profile diff: unavailable due to a comparison error.\n\n';
             }
 
             body += '<sub>Measured on ubuntu-latest x64. Benchmark ranges compare cached main-branch min/max ops/sec with the PR run; overlapping ranges are treated as unchanged noise. Percentage deltas are secondary context.</sub>';

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,7 +6,7 @@
 
 - **`suite`/`bench` API** — `bench(name, { setup?, run, teardown? })` with auto-calibration, warmup, and IQR outlier filtering
 - **Four output formats** — `console` (default), `text`, `csv`, `json`; configurable via `--format` and `--output`
-- **Profiler-backed runs** — Bytecode benchmark runs can emit opcode/function profiles with `--profile`
+- **Profiler-backed runs** — Bytecode benchmark runs can emit opcode/function profiles with `--profile`, including deterministic single-run capture
 - **CI integration** — PR workflow posts benchmark comparison comments with range-overlap classification
 - **Environment tuning** — Calibration time, warmup iterations, and measurement rounds configurable via environment variables
 
@@ -33,6 +33,9 @@ printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./bu
 
 # Run bytecode benchmarks with VM profiler data
 ./build/GocciaBenchmarkRunner benchmarks --profile=all --profile-output=bench-profile.json --jobs=1
+
+# Capture a deterministic opcode/allocation profile for CI-style diffing
+./build/GocciaBenchmarkRunner benchmarks/numbers.js --profile-deterministic --profile-output=profile.json
 
 # Export results in different formats
 ./build/GocciaBenchmarkRunner benchmarks --format=json --output=results.json
@@ -73,6 +76,21 @@ allocation attribution:
   --format=json \
   --output=tmp/numbers-bench.json \
   --jobs=1
+```
+
+For deterministic CI signals, add `--profile-deterministic`. This skips warmup,
+calibration, and repeated measurement rounds, then runs each registered benchmark
+once through the existing `setup`/`run`/`teardown` path. If `--profile` is not
+provided, it defaults to `--profile=all`. The benchmark report remains
+structurally valid, but throughput fields are placeholders; use the profile JSON
+for deterministic comparisons.
+
+```bash
+./build/GocciaBenchmarkRunner benchmarks/numbers.js \
+  --profile-deterministic \
+  --profile-output=tmp/numbers-deterministic-profile.json \
+  --format=compact-json \
+  --output=tmp/numbers-deterministic-report.json
 ```
 
 ## Configuring Benchmark Parameters

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -5,7 +5,7 @@
 ## Executive Summary
 
 - **`suite`/`bench` API** — `bench(name, { setup?, run, teardown? })` with auto-calibration, warmup, and IQR outlier filtering
-- **Four output formats** — `console` (default), `text`, `csv`, `json`; configurable via `--format` and `--output`
+- **Five output formats** — `console` (default), `text`, `csv`, `json`, `compact-json`; configurable via `--format` and `--output`
 - **Profiler-backed runs** — Bytecode benchmark runs can emit opcode/function profiles with `--profile`, including deterministic single-run capture
 - **CI integration** — PR workflow posts benchmark comparison comments with range-overlap classification
 - **Environment tuning** — Calibration time, warmup iterations, and measurement rounds configurable via environment variables
@@ -39,6 +39,7 @@ printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./bu
 
 # Export results in different formats
 ./build/GocciaBenchmarkRunner benchmarks --format=json --output=results.json
+./build/GocciaBenchmarkRunner benchmarks --format=compact-json --output=compact-results.json
 ./build/GocciaBenchmarkRunner benchmarks --format=csv --output=results.csv
 ./build/GocciaBenchmarkRunner benchmarks --format=text
 ```
@@ -47,7 +48,7 @@ When no path is provided, `GocciaBenchmarkRunner` reads benchmark source from st
 
 ## Output Formats
 
-The GocciaBenchmarkRunner supports four output formats via the `--format` flag:
+The GocciaBenchmarkRunner supports five output formats via the `--format` flag:
 
 | Format | Description |
 |--------|-------------|
@@ -55,6 +56,7 @@ The GocciaBenchmarkRunner supports four output formats via the `--format` flag:
 | `text` | Compact one-line-per-benchmark format with optional `setup=Xms teardown=Xms` suffixes |
 | `csv` | Standard CSV with header row (`file,suite,name,ops_per_sec,variance_percentage,mean_ms,iterations,setup_ms,teardown_ms,error`) |
 | `json` | Structured JSON with the common CLI envelope (`build`, aggregate `output`, `timing`, `memory`, `workers`) and a `files[]` array containing each `fileName`, per-file timing, and nested `benchmarks[]`, including `opsPerSec`, `variancePercentage`, `minOpsPerSec`, `maxOpsPerSec`, `setupMs`, and `teardownMs` |
+| `compact-json` | Same structured JSON shape, omitting `build`, `memory`, `stdout`, and `stderr` for smaller machine-readable output |
 
 Use `--output=<file>` to write results to a file instead of stdout.
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -30,6 +30,9 @@ Profiling implies `--mode=bytecode` automatically. Near-zero overhead when disab
 # JSON export (includes all sections regardless of console mode)
 ./build/GocciaScriptLoader script.js --profile=all --profile-output=profile.json
 
+# Deterministic benchmark profile capture for CI comparisons
+./build/GocciaBenchmarkRunner benchmarks/numbers.js --profile-deterministic --profile-output=numbers-profile.json
+
 # Stdin works too
 echo 'const x = 1 + 2; x;' | ./build/GocciaScriptLoader --profile=all
 ```

--- a/scripts/profile-diff.js
+++ b/scripts/profile-diff.js
@@ -106,9 +106,11 @@ function allocationMap(profile) {
     const allocations = entry.allocations ?? entry.allocs ?? 0;
     if (typeof allocations !== 'number') continue;
     const key = functionKey(entry);
+    const location = functionLocation(entry);
+    const label = location ? `${functionLabel(entry)} @ ${location} allocs` : `${functionLabel(entry)} allocs`;
     map.set(key, {
       value: allocations,
-      label: `${functionLabel(entry)} allocs`,
+      label,
     });
   }
   return map;
@@ -289,10 +291,16 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--baseline') {
+      if (!argv[i + 1] || argv[i + 1].startsWith('--')) {
+        throw new Error('Missing value for --baseline');
+      }
       args.baselineDir = argv[++i];
     } else if (arg.startsWith('--baseline=')) {
       args.baselineDir = arg.slice('--baseline='.length);
     } else if (arg === '--current') {
+      if (!argv[i + 1] || argv[i + 1].startsWith('--')) {
+        throw new Error('Missing value for --current');
+      }
       args.currentDir = argv[++i];
     } else if (arg.startsWith('--current=')) {
       args.currentDir = arg.slice('--current='.length);

--- a/scripts/profile-diff.js
+++ b/scripts/profile-diff.js
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const RELATIVE_THRESHOLD = 0.01;
+const SMALL_COUNT = 1000;
+const ABSOLUTE_THRESHOLD = 100;
+const MAX_LINES_PER_BENCHMARK = 25;
+const ARROW = '\u2192';
+const RED = '\u{1F534}';
+const NEW_ICON = '\u{1F195}';
+
+function formatInteger(value) {
+  return Math.round(value).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function formatPercent(baseValue, currentValue) {
+  if (baseValue === 0) return null;
+  const percent = ((currentValue - baseValue) / baseValue) * 100;
+  const abs = Math.abs(percent);
+  const digits = abs >= 1000 ? 0 : 1;
+  return `${percent >= 0 ? '+' : ''}${percent.toFixed(digits)}%`;
+}
+
+function formatLabel(entry) {
+  if (entry.kind === 'new') return 'NEW';
+  if (entry.kind === 'removed') return 'REMOVED';
+  return formatChangeLabel(entry.baseValue, entry.currentValue);
+}
+
+function formatChangeLabel(baseValue, currentValue) {
+  const percent = formatPercent(baseValue, currentValue);
+  if (percent) return percent;
+  const delta = currentValue - baseValue;
+  return `${delta >= 0 ? '+' : ''}${formatInteger(delta)}`;
+}
+
+function hasSignificantDelta(baseValue, currentValue) {
+  if (baseValue === currentValue) return false;
+  const delta = Math.abs(currentValue - baseValue);
+  if (Math.min(Math.abs(baseValue), Math.abs(currentValue)) < SMALL_COUNT) {
+    return delta > ABSOLUTE_THRESHOLD;
+  }
+  return delta / Math.abs(baseValue) > RELATIVE_THRESHOLD;
+}
+
+function readProfile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function listProfileFiles(dir) {
+  const files = [];
+  if (!fs.existsSync(dir)) return files;
+
+  function walk(currentDir) {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.json')) {
+        files.push(path.relative(dir, fullPath).split(path.sep).join('/'));
+      }
+    }
+  }
+
+  walk(dir);
+  files.sort();
+  return files;
+}
+
+function opcodeMap(profile) {
+  const map = new Map();
+  for (const entry of profile.opcodes || []) {
+    if (entry && entry.opcode && typeof entry.count === 'number' && entry.count > 0) {
+      map.set(entry.opcode, entry.count);
+    }
+  }
+  return map;
+}
+
+function totalOpcodes(profile) {
+  return (profile.opcodes || []).reduce((sum, entry) => sum + (entry.count || 0), 0);
+}
+
+function functionLocation(entry) {
+  if (entry.location) return entry.location;
+  if (entry.sourceFile) {
+    return entry.line ? `${entry.sourceFile}:${entry.line}` : entry.sourceFile;
+  }
+  return '';
+}
+
+function functionLabel(entry) {
+  const rawName = entry.name || '<anonymous>';
+  return `${rawName}()`;
+}
+
+function functionKey(entry) {
+  return `${entry.name || '<anonymous>'}\u0000${functionLocation(entry)}`;
+}
+
+function allocationMap(profile) {
+  const map = new Map();
+  for (const entry of profile.functions || []) {
+    const allocations = entry.allocations ?? entry.allocs ?? 0;
+    if (typeof allocations !== 'number') continue;
+    const key = functionKey(entry);
+    map.set(key, {
+      value: allocations,
+      label: `${functionLabel(entry)} allocs`,
+    });
+  }
+  return map;
+}
+
+function compareMaps(baseMap, currentMap, metric) {
+  const entries = [];
+  const keys = new Set([...baseMap.keys(), ...currentMap.keys()]);
+
+  for (const key of [...keys].sort()) {
+    const baseRaw = baseMap.get(key);
+    const currentRaw = currentMap.get(key);
+    const baseValue = typeof baseRaw === 'object' ? baseRaw.value : baseRaw;
+    const currentValue = typeof currentRaw === 'object' ? currentRaw.value : currentRaw;
+    const label = (typeof currentRaw === 'object' && currentRaw.label) ||
+      (typeof baseRaw === 'object' && baseRaw.label) ||
+      key;
+
+    if (baseValue == null && currentValue != null) {
+      if (currentValue !== 0) {
+        entries.push({
+          metric,
+          label,
+          kind: 'new',
+          baseValue: 0,
+          currentValue,
+        });
+      }
+    } else if (baseValue != null && currentValue == null) {
+      if (baseValue !== 0) {
+        entries.push({
+          metric,
+          label,
+          kind: 'removed',
+          baseValue,
+          currentValue: 0,
+        });
+      }
+    } else if (hasSignificantDelta(baseValue, currentValue)) {
+      entries.push({
+        metric,
+        label,
+        kind: 'changed',
+        baseValue,
+        currentValue,
+      });
+    }
+  }
+
+  return entries;
+}
+
+function compareProfile(baseProfile, currentProfile) {
+  const entries = [];
+  entries.push(...compareMaps(opcodeMap(baseProfile), opcodeMap(currentProfile), 'opcode'));
+  entries.push(...compareMaps(allocationMap(baseProfile), allocationMap(currentProfile), 'allocation'));
+
+  const baseTotal = totalOpcodes(baseProfile);
+  const currentTotal = totalOpcodes(currentProfile);
+  const totalChanged = hasSignificantDelta(baseTotal, currentTotal);
+
+  entries.sort((a, b) => {
+    const kindRank = { new: 0, removed: 1, changed: 2 };
+    const kindDelta = kindRank[a.kind] - kindRank[b.kind];
+    if (kindDelta !== 0) return kindDelta;
+    const magnitudeDelta = Math.abs(b.currentValue - b.baseValue) - Math.abs(a.currentValue - a.baseValue);
+    if (magnitudeDelta !== 0) return magnitudeDelta;
+    return a.label.localeCompare(b.label);
+  });
+
+  return {
+    entries,
+    total: totalChanged
+      ? {
+          label: 'Total instructions',
+          baseValue: baseTotal,
+          currentValue: currentTotal,
+        }
+      : null,
+  };
+}
+
+function formatEntry(entry) {
+  return `- ${RED} ${entry.label}: ${formatInteger(entry.baseValue)} ${ARROW} ${formatInteger(entry.currentValue)} (${formatLabel(entry)})`;
+}
+
+function benchmarkName(relativePath) {
+  return relativePath.replace(/\.json$/, '');
+}
+
+function buildProfileDiffSection(options) {
+  const baselineDir = options.baselineDir;
+  const currentDir = options.currentDir;
+
+  if (options.skip) {
+    return {
+      markdown: '## Deterministic profile diff\n\nDeterministic profile diff: skipped by `[skip-profile-check]`.',
+      signalCount: 0,
+    };
+  }
+
+  const baselineFiles = listProfileFiles(baselineDir);
+  const currentFiles = listProfileFiles(currentDir);
+
+  if (baselineFiles.length === 0) {
+    return {
+      markdown: '## Deterministic profile diff\n\nDeterministic profile diff: no cached baseline was restored.',
+      signalCount: 0,
+    };
+  }
+
+  if (currentFiles.length === 0) {
+    return {
+      markdown: '## Deterministic profile diff\n\nDeterministic profile diff: no current profile artifact was found.',
+      signalCount: 0,
+    };
+  }
+
+  const allFiles = [...new Set([...baselineFiles, ...currentFiles])].sort();
+  const blocks = [];
+  let signalCount = 0;
+
+  for (const relativePath of allFiles) {
+    const basePath = path.join(baselineDir, relativePath);
+    const currentPath = path.join(currentDir, relativePath);
+    const name = benchmarkName(relativePath);
+
+    if (!fs.existsSync(basePath)) {
+      signalCount++;
+      blocks.push(`### ${name}\n- ${NEW_ICON} Profile added in current run.`);
+      continue;
+    }
+
+    if (!fs.existsSync(currentPath)) {
+      signalCount++;
+      blocks.push(`### ${name}\n- ${RED} Profile missing from current run.`);
+      continue;
+    }
+
+    const comparison = compareProfile(readProfile(basePath), readProfile(currentPath));
+    if (comparison.entries.length === 0 && !comparison.total) continue;
+
+    signalCount += comparison.entries.length + (comparison.total ? 1 : 0);
+    const lines = [`### ${name}`];
+    for (const entry of comparison.entries.slice(0, MAX_LINES_PER_BENCHMARK)) {
+      lines.push(formatEntry(entry));
+    }
+    if (comparison.entries.length > MAX_LINES_PER_BENCHMARK) {
+      lines.push(`- ... ${comparison.entries.length - MAX_LINES_PER_BENCHMARK} more profile changes suppressed.`);
+    }
+    if (comparison.total) {
+      const total = comparison.total;
+      lines.push(`- Total instructions: ${formatInteger(total.baseValue)} ${ARROW} ${formatInteger(total.currentValue)} (${formatChangeLabel(total.baseValue, total.currentValue)})`);
+    }
+    blocks.push(lines.join('\n'));
+  }
+
+  if (blocks.length === 0) {
+    return {
+      markdown: '## Deterministic profile diff\n\nDeterministic profile diff: no significant changes.',
+      signalCount: 0,
+    };
+  }
+
+  return {
+    markdown: `## Deterministic profile diff\n\n${blocks.join('\n\n')}`,
+    signalCount,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    baselineDir: 'profile-baseline',
+    currentDir: 'profile-current',
+    skip: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--baseline') {
+      args.baselineDir = argv[++i];
+    } else if (arg.startsWith('--baseline=')) {
+      args.baselineDir = arg.slice('--baseline='.length);
+    } else if (arg === '--current') {
+      args.currentDir = argv[++i];
+    } else if (arg.startsWith('--current=')) {
+      args.currentDir = arg.slice('--current='.length);
+    } else if (arg === '--skip') {
+      args.skip = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+if (require.main === module) {
+  try {
+    const result = buildProfileDiffSection(parseArgs(process.argv.slice(2)));
+    process.stdout.write(`${result.markdown}\n`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  buildProfileDiffSection,
+  compareProfile,
+};

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -1114,6 +1114,53 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
       if (valid.length === 0) throw new Error("Bytecode benchmark JSON should contain at least one valid result");
     }
 
+    console.log("BenchmarkRunner: deterministic profile mode...");
+    const profileBench = join(tmp, "profile-deterministic.js");
+    const profileOut = join(tmp, "profile.json");
+    writeFileSync(profileBench, [
+      'let count = 0;',
+      'suite("profile", () => {',
+      '  bench("runs once", {',
+      '    setup: () => ({ value: 1 }),',
+      '    run: async (state) => {',
+      '      count = count + await Promise.resolve(state.value);',
+      '    },',
+      '    teardown: () => {',
+      '      if (count !== 1) { throw new Error("expected one deterministic run, got " + count); }',
+      '    },',
+      '  });',
+      '});',
+      '',
+    ].join("\n"));
+    {
+      const proc = Bun.spawnSync(
+        [
+          resolve(BENCHRUNNER),
+          profileBench,
+          "--profile-deterministic",
+          "--profile=all",
+          `--profile-output=${profileOut}`,
+          "--no-progress",
+          "--format=compact-json",
+        ],
+        { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
+      );
+      if (proc.exitCode !== 0) throw new Error(`Deterministic profile benchmark exit ${proc.exitCode}: ${proc.stderr.toString()}`);
+      const report = JSON.parse(proc.stdout.toString());
+      const bench = report.files?.[0]?.benchmarks?.[0];
+      if (bench?.iterations !== 1)
+        throw new Error(`Deterministic profile report should record one iteration, got ${bench?.iterations}`);
+    }
+    {
+      const profile = JSON.parse(readFileSync(profileOut, "utf-8"));
+      if (!Array.isArray(profile.opcodes) || profile.opcodes.length === 0)
+        throw new Error("Deterministic profile should include opcode counts");
+      if (!Array.isArray(profile.functions) || profile.functions.length === 0)
+        throw new Error("Deterministic profile should include function counts");
+      if (!profile.functions.some((fn: Record<string, unknown>) => typeof fn.allocations === "number"))
+        throw new Error("Deterministic profile should include function allocation counts");
+    }
+
     console.log("BenchmarkRunner: file benchmark JSON output...");
     if (!fileJson.includes('"totalBenchmarks":')) throw new Error('JSON should contain totalBenchmarks');
 

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -184,6 +184,7 @@ type
   TBenchmarkRunnerApp = class(TGocciaCLIApplication)
   private
     FNoProgress: TGocciaFlagOption;
+    FProfileDeterministic: TGocciaFlagOption;
     FFormats: TGocciaRepeatableOption;
     FOutputFile: TGocciaStringOption;
     FCanPrintProfile: Boolean;
@@ -265,7 +266,8 @@ begin
     Benchmark.OnBeforeMeasurement := AEngine.ClearTransientCaches;
 end;
 
-function RunRegisteredBenchmarks(const AEngine: TGocciaEngine): TGocciaObjectValue;
+function RunRegisteredBenchmarks(const AEngine: TGocciaEngine;
+  const ADeterministicProfile: Boolean): TGocciaObjectValue;
 var
   Benchmark: TGocciaBenchmark;
   EmptyArgs: TGocciaArgumentsCollection;
@@ -277,8 +279,12 @@ begin
 
   EmptyArgs := TGocciaArgumentsCollection.Create;
   try
-    Value := Benchmark.RunBenchmarks(EmptyArgs,
-      TGocciaUndefinedLiteralValue.UndefinedValue);
+    if ADeterministicProfile then
+      Value := Benchmark.RunDeterministicProfile(EmptyArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue)
+    else
+      Value := Benchmark.RunBenchmarks(EmptyArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue);
   finally
     EmptyArgs.Free;
   end;
@@ -344,11 +350,13 @@ begin
         try
           EngineResult := Engine.Execute;
           FileResult.FileName := AFileName;
+          FileResult.DeterministicProfile := FProfileDeterministic.Present;
           FileResult.LexTimeNanoseconds := EngineResult.LexTimeNanoseconds;
           FileResult.ParseTimeNanoseconds := EngineResult.ParseTimeNanoseconds;
           FileResult.CompileTimeNanoseconds := 0;
           BenchStart := GetNanoseconds;
-          ScriptResult := RunRegisteredBenchmarks(Engine);
+          ScriptResult := RunRegisteredBenchmarks(Engine,
+            FProfileDeterministic.Present);
           FileResult.ExecuteTimeNanoseconds := EngineResult.ExecuteTimeNanoseconds +
             (GetNanoseconds - BenchStart);
         finally
@@ -474,13 +482,18 @@ begin
             RunBytecodeBenchmarkModule(Engine,
               TGocciaBytecodeExecutor(Engine.Executor), Module, AFileName);
             ExecEnd := GetNanoseconds;
+            if FProfileDeterministic.Present and
+               Assigned(TGocciaProfiler.Instance) then
+              TGocciaProfiler.Instance.ResetCounts;
 
             FileResult.FileName := AFileName;
+            FileResult.DeterministicProfile := FProfileDeterministic.Present;
             FileResult.LexTimeNanoseconds := LexEnd - LexStart;
             FileResult.ParseTimeNanoseconds := ParseEnd - LexEnd;
             FileResult.CompileTimeNanoseconds := CompileEnd - ParseEnd;
             BenchStart := GetNanoseconds;
-            ScriptResult := RunRegisteredBenchmarks(Engine);
+            ScriptResult := RunRegisteredBenchmarks(Engine,
+              FProfileDeterministic.Present);
             FileResult.ExecuteTimeNanoseconds := ExecEnd - CompileEnd +
               (GetNanoseconds - BenchStart);
           finally
@@ -573,11 +586,13 @@ begin
       try
         EngineResult := Engine.Execute;
         FileResult.FileName := AFileName;
+        FileResult.DeterministicProfile := FProfileDeterministic.Present;
         FileResult.LexTimeNanoseconds := EngineResult.LexTimeNanoseconds;
         FileResult.ParseTimeNanoseconds := EngineResult.ParseTimeNanoseconds;
         FileResult.CompileTimeNanoseconds := 0;
         BenchStart := GetNanoseconds;
-        ScriptResult := RunRegisteredBenchmarks(Engine);
+        ScriptResult := RunRegisteredBenchmarks(Engine,
+          FProfileDeterministic.Present);
         FileResult.ExecuteTimeNanoseconds := EngineResult.ExecuteTimeNanoseconds +
           (GetNanoseconds - BenchStart);
       finally
@@ -684,13 +699,18 @@ begin
           RunBytecodeBenchmarkModule(Engine,
             TGocciaBytecodeExecutor(Engine.Executor), Module, AFileName);
           ExecEnd := GetNanoseconds;
+          if FProfileDeterministic.Present and
+             Assigned(TGocciaProfiler.Instance) then
+            TGocciaProfiler.Instance.ResetCounts;
 
           FileResult.FileName := AFileName;
+          FileResult.DeterministicProfile := FProfileDeterministic.Present;
           FileResult.LexTimeNanoseconds := LexEnd - LexStart;
           FileResult.ParseTimeNanoseconds := ParseEnd - LexEnd;
           FileResult.CompileTimeNanoseconds := CompileEnd - ParseEnd;
           BenchStart := GetNanoseconds;
-          ScriptResult := RunRegisteredBenchmarks(Engine);
+          ScriptResult := RunRegisteredBenchmarks(Engine,
+            FProfileDeterministic.Present);
           FileResult.ExecuteTimeNanoseconds := ExecEnd - CompileEnd +
             (GetNanoseconds - BenchStart);
         finally
@@ -944,6 +964,7 @@ begin
         WorkerData[I].ExecuteTimeNanoseconds := 0;
         WorkerData[I].TotalBenchmarks := 0;
         WorkerData[I].DurationNanoseconds := 0;
+        WorkerData[I].DeterministicProfile := False;
         SetLength(WorkerData[I].Entries, 0);
       end;
 
@@ -1026,6 +1047,8 @@ begin
   AddEngineOptions;
   AddProfilerOptions;
   FNoProgress := AddFlag('no-progress', 'Suppress progress output');
+  FProfileDeterministic := AddFlag('profile-deterministic',
+    'Run each registered benchmark once for deterministic profile capture');
   FFormats := AddRepeatable('format',
     'Output format (console, text, csv, json, compact-json). ' +
     '"compact-json" emits the json envelope without build, memory, stdout, stderr.');
@@ -1038,6 +1061,9 @@ begin
 
   if ProfilerOptions.Format.Present and not ProfilerOptions.Mode.Present then
     ProfilerOptions.Mode.Apply('functions');
+
+  if FProfileDeterministic.Present and not ProfilerOptions.Mode.Present then
+    ProfilerOptions.Mode.Apply('all');
 
   if ProfilerOptions.Mode.Present then
     EngineOptions.Mode.Apply('bytecode');

--- a/source/units/Goccia.Benchmark.Reporter.pas
+++ b/source/units/Goccia.Benchmark.Reporter.pas
@@ -33,6 +33,7 @@ type
     Entries: array of TBenchmarkEntry;
     TotalBenchmarks: Integer;
     DurationNanoseconds: Int64;
+    DeterministicProfile: Boolean;
   end;
 
   TBenchmarkReportFormat = (brfConsole, brfText, brfCSV, brfJSON,
@@ -93,10 +94,14 @@ begin
     not Math.IsInfinite(AValue);
 end;
 
-function IsValidBenchmarkEntry(const AEntry: TBenchmarkEntry): Boolean;
+function IsValidBenchmarkEntry(const AEntry: TBenchmarkEntry;
+  const ADeterministicProfile: Boolean): Boolean;
 begin
-  Result := (AEntry.Error = '') and IsPositiveFinite(AEntry.OpsPerSec) and
-    IsPositiveFinite(AEntry.MeanMs) and (AEntry.Iterations > 0);
+  if ADeterministicProfile then
+    Result := (AEntry.Error = '') and (AEntry.Iterations > 0)
+  else
+    Result := (AEntry.Error = '') and IsPositiveFinite(AEntry.OpsPerSec) and
+      IsPositiveFinite(AEntry.MeanMs) and (AEntry.Iterations > 0);
 end;
 
 function FormatJSONNumber(const AValue: Double;
@@ -416,7 +421,7 @@ begin
     begin
       Entry := FFiles[F].Entries[E];
 
-      if IsValidBenchmarkEntry(Entry) then
+      if IsValidBenchmarkEntry(Entry, FFiles[F].DeterministicProfile) then
         Inc(ValidFileBenchmarkCount)
       else if FileOk then
       begin
@@ -562,7 +567,7 @@ begin
     for E := 0 to Length(FFiles[F].Entries) - 1 do
     begin
       Entry := FFiles[F].Entries[E];
-      if not IsValidBenchmarkEntry(Entry) then
+      if not IsValidBenchmarkEntry(Entry, FFiles[F].DeterministicProfile) then
         Exit(True);
       Inc(ValidBenchmarkCount);
     end;

--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -61,6 +61,7 @@ type
     FOnBeforeMeasurement: TBenchmarkNotifyEvent;
 
     function RunSingleBenchmark(const ABenchCase: TBenchmarkCase): TBenchmarkResult;
+    function RunSingleBenchmarkDeterministic(const ABenchCase: TBenchmarkCase): TBenchmarkResult;
     function CalibrateIterations(const ABenchCase: TBenchmarkCase;
       const ASetupResult: TGocciaValue;
       const ARunArgs: TGocciaArgumentsCollection): Int64;
@@ -72,6 +73,7 @@ type
     function Suite(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function Bench(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function RunBenchmarks(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function RunDeterministicProfile(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     property OnProgress: TBenchmarkProgressEvent read FOnProgress write FOnProgress;
     property OnBeforeMeasurement: TBenchmarkNotifyEvent read FOnBeforeMeasurement write FOnBeforeMeasurement;
@@ -566,6 +568,56 @@ begin
   end;
 end;
 
+function TGocciaBenchmark.RunSingleBenchmarkDeterministic(
+  const ABenchCase: TBenchmarkCase): TBenchmarkResult;
+var
+  SetupResult: TGocciaValue;
+  RunArgs: TGocciaArgumentsCollection;
+  GC: TGarbageCollector;
+begin
+  Result.Name := ABenchCase.Name;
+  Result.SuiteName := ABenchCase.SuiteName;
+  Result.Iterations := 1;
+  Result.TotalMs := 0;
+  Result.OpsPerSec := 0;
+  Result.MeanMs := 0;
+  Result.VariancePercentage := 0;
+  Result.SetupMs := 0;
+  Result.TeardownMs := 0;
+  Result.MinOpsPerSec := 0;
+  Result.MaxOpsPerSec := 0;
+
+  GC := TGarbageCollector.Instance;
+  SetupResult := nil;
+  RunArgs := TGocciaArgumentsCollection.CreateWithCapacity(1);
+  try
+    if Assigned(ABenchCase.SetupFunction) then
+    begin
+      SetupResult := ABenchCase.SetupFunction.CallNoArgs(
+        TGocciaUndefinedLiteralValue.UndefinedValue);
+      WaitForFetchIdle;
+      if Assigned(SetupResult) and Assigned(GC) then
+        GC.AddTempRoot(SetupResult);
+    end;
+
+    try
+      InvokeBenchmarkFunction(ABenchCase.RunFunction, SetupResult, RunArgs);
+      WaitForFetchIdle;
+
+      if Assigned(ABenchCase.TeardownFunction) then
+      begin
+        InvokeBenchmarkFunction(ABenchCase.TeardownFunction, SetupResult, RunArgs);
+        WaitForFetchIdle;
+      end;
+    finally
+      if Assigned(SetupResult) and Assigned(GC) then
+        GC.RemoveTempRoot(SetupResult);
+    end;
+  finally
+    RunArgs.Free;
+  end;
+end;
+
 function TGocciaBenchmark.RunBenchmarks(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   I: Integer;
@@ -640,6 +692,76 @@ begin
       if Assigned(ResultsArray) then
         TGarbageCollector.Instance.RemoveTempRoot(ResultsArray);
     end;
+  end;
+end;
+
+function TGocciaBenchmark.RunDeterministicProfile(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  I: Integer;
+  BenchCase: TBenchmarkCase;
+  BenchResult: TBenchmarkResult;
+  ResultObj: TGocciaObjectValue;
+  ResultsArray: TGocciaArrayValue;
+  SingleResult: TGocciaObjectValue;
+  StartNanoseconds, TotalDurationNanoseconds: Int64;
+begin
+  StartNanoseconds := GetNanoseconds;
+
+  ResultsArray := nil;
+  try
+    ResultsArray := TGocciaArrayValue.Create;
+    if Assigned(TGarbageCollector.Instance) then
+      TGarbageCollector.Instance.AddTempRoot(ResultsArray);
+
+    for I := 0 to FRegisteredBenchmarks.Count - 1 do
+    begin
+      BenchCase := FRegisteredBenchmarks[I];
+
+      if Assigned(FOnProgress) then
+        FOnProgress(BenchCase.SuiteName, BenchCase.Name, I + 1, FRegisteredBenchmarks.Count);
+
+      try
+        BenchResult := RunSingleBenchmarkDeterministic(BenchCase);
+
+        SingleResult := TGocciaObjectValue.Create;
+        SingleResult.AssignProperty('name', TGocciaStringLiteralValue.Create(BenchResult.Name));
+        SingleResult.AssignProperty('suite', TGocciaStringLiteralValue.Create(BenchResult.SuiteName));
+        SingleResult.AssignProperty('opsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.OpsPerSec));
+        SingleResult.AssignProperty('meanMs', TGocciaNumberLiteralValue.Create(BenchResult.MeanMs));
+        SingleResult.AssignProperty('iterations', TGocciaNumberLiteralValue.Create(BenchResult.Iterations));
+        SingleResult.AssignProperty('totalMs', TGocciaNumberLiteralValue.Create(BenchResult.TotalMs));
+        SingleResult.AssignProperty('variancePercentage', TGocciaNumberLiteralValue.Create(BenchResult.VariancePercentage));
+        SingleResult.AssignProperty('setupMs', TGocciaNumberLiteralValue.Create(BenchResult.SetupMs));
+        SingleResult.AssignProperty('teardownMs', TGocciaNumberLiteralValue.Create(BenchResult.TeardownMs));
+        SingleResult.AssignProperty('minOpsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.MinOpsPerSec));
+        SingleResult.AssignProperty('maxOpsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.MaxOpsPerSec));
+
+        ResultsArray.SetElement(ResultsArray.GetLength, SingleResult);
+      except
+        on E: Exception do
+        begin
+          if Assigned(TGocciaMicrotaskQueue.Instance) then
+            TGocciaMicrotaskQueue.Instance.ClearQueue;
+          DiscardFetchCompletions;
+
+          SingleResult := TGocciaObjectValue.Create;
+          SingleResult.AssignProperty('name', TGocciaStringLiteralValue.Create(BenchCase.Name));
+          SingleResult.AssignProperty('suite', TGocciaStringLiteralValue.Create(BenchCase.SuiteName));
+          SingleResult.AssignProperty('error', TGocciaStringLiteralValue.Create(E.Message));
+          ResultsArray.SetElement(ResultsArray.GetLength, SingleResult);
+        end;
+      end;
+    end;
+
+    TotalDurationNanoseconds := GetNanoseconds - StartNanoseconds;
+    ResultObj := TGocciaObjectValue.Create;
+    ResultObj.AssignProperty('totalBenchmarks', TGocciaNumberLiteralValue.Create(FRegisteredBenchmarks.Count));
+    ResultObj.AssignProperty('durationNanoseconds', TGocciaNumberLiteralValue.Create(TotalDurationNanoseconds));
+    ResultObj.AssignProperty('results', ResultsArray);
+    Result := ResultObj;
+  finally
+    if Assigned(TGarbageCollector.Instance) and Assigned(ResultsArray) then
+      TGarbageCollector.Instance.RemoveTempRoot(ResultsArray);
   end;
 end;
 

--- a/source/units/Goccia.Profiler.pas
+++ b/source/units/Goccia.Profiler.pas
@@ -64,6 +64,8 @@ type
     constructor Create;
     destructor Destroy; override;
 
+    procedure ResetCounts;
+
     procedure RecordOpcode(const AOp: UInt8); inline;
     procedure RecordScalarHit; inline;
     procedure RecordScalarMiss; inline;
@@ -143,6 +145,29 @@ begin
   if Assigned(FOpcodePairs) then
     FreeMem(FOpcodePairs);
   inherited;
+end;
+
+procedure TGocciaProfiler.ResetCounts;
+var
+  I: Integer;
+begin
+  for I := 0 to MAX_OPCODE_ORDINAL do
+    FOpcodeCount[I] := 0;
+  FillChar(FOpcodePairs^, SizeOf(TGocciaOpcodePairArray), 0);
+  FHasPrevOp := False;
+  FPrevOp := 0;
+  FScalarHits := 0;
+  FScalarMisses := 0;
+  FTimingStackCount := 0;
+  FCollapsedStacks.Clear;
+
+  for I := 0 to FFunctionProfileCount - 1 do
+  begin
+    FFunctionProfiles[I].CallCount := 0;
+    FFunctionProfiles[I].SelfTimeNanoseconds := 0;
+    FFunctionProfiles[I].TotalTimeNanoseconds := 0;
+    FFunctionProfiles[I].Allocations := 0;
+  end;
 end;
 
 procedure TGocciaProfiler.RecordOpcode(const AOp: UInt8);


### PR DESCRIPTION
## Summary
- Adds `--profile-deterministic` to benchmark runs so CI can capture one-pass, reproducible profile data for each benchmark.
- Extends benchmark reporting and profiler internals to support deterministic profile mode without requiring normal throughput metrics.
- Adds CI workflow steps to generate, cache, upload, and compare deterministic profile artifacts, with PR comments showing profile diffs.
- Documents the new workflow in the benchmarks and profiling docs.
- Adds CLI coverage for deterministic profile capture and report validation.

## Testing
- Added automated CLI checks in `scripts/test-cli-apps.ts` for deterministic benchmark execution and profile output shape.
- Not run: repository build and test suite in this environment.
- Not run: CI workflow execution for the new baseline/profile diff steps.