### PR TITLE
Fix `new` on compat-function constructors (#501, #502)

### DIFF
--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2992,7 +2992,8 @@ var
   InitContext, SuperInitContext: TGocciaEvaluationContext;
   InitScope, SuperInitScope: TGocciaScope;
   FunctionCallee: TGocciaFunctionBase;
-  PrototypeValue, ConstructResult: TGocciaValue;
+  PrototypeTarget: TGocciaValue;
+  PrototypeValue: TGocciaValue;
   ReceiverPrototype: TGocciaObjectValue;
   ReceiverInstance: TGocciaObjectValue;
 begin
@@ -3055,11 +3056,20 @@ begin
         // OrdinaryCreateFromConstructor produces a fresh object whose
         // [[Prototype]] is constructor.prototype (or %Object.prototype% when
         // that property is not an Object — §10.1.14 GetPrototypeFromConstructor).
+        // For bound function exotic objects (§10.4.1.2) the receiver's
+        // [[Prototype]] comes from the underlying [[BoundTargetFunction]] —
+        // the bound wrapper itself has no own `prototype` data property.
         FunctionCallee := TGocciaFunctionBase(Callee);
         if not FunctionCallee.IsConstructable then
           ThrowTypeError(Format(SErrorNotConstructor, [CalleeName]),
             SSuggestNotConstructorType);
-        PrototypeValue := FunctionCallee.GetProperty(PROP_PROTOTYPE);
+        PrototypeTarget := FunctionCallee;
+        while PrototypeTarget is TGocciaBoundFunctionValue do
+          PrototypeTarget := TGocciaBoundFunctionValue(PrototypeTarget).OriginalFunction;
+        if PrototypeTarget is TGocciaObjectValue then
+          PrototypeValue := TGocciaObjectValue(PrototypeTarget).GetProperty(PROP_PROTOTYPE)
+        else
+          PrototypeValue := nil;
         if PrototypeValue is TGocciaObjectValue then
           ReceiverPrototype := TGocciaObjectValue(PrototypeValue)
         else
@@ -3071,11 +3081,11 @@ begin
         ReceiverInstance := TGocciaObjectValue.Create(ReceiverPrototype);
         TGarbageCollector.Instance.AddTempRoot(ReceiverInstance);
         try
-          ConstructResult := FunctionCallee.Call(Arguments, ReceiverInstance);
-          if ConstructResult is TGocciaObjectValue then
-            Result := ConstructResult
-          else
-            Result := ReceiverInstance;
+          // InvokeConstructableWithReceiver merges bound args, dispatches to
+          // the underlying target, and applies the spec return rules
+          // (explicit Object return wins; otherwise the receiver).
+          Result := InvokeConstructableWithReceiver(FunctionCallee, Arguments,
+            ReceiverInstance);
         finally
           TGarbageCollector.Instance.RemoveTempRoot(ReceiverInstance);
         end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2991,6 +2991,10 @@ var
   WalkClass, ClassValue: TGocciaClassValue;
   InitContext, SuperInitContext: TGocciaEvaluationContext;
   InitScope, SuperInitScope: TGocciaScope;
+  FunctionCallee: TGocciaFunctionBase;
+  PrototypeValue, ConstructResult: TGocciaValue;
+  ReceiverPrototype: TGocciaObjectValue;
+  ReceiverInstance: TGocciaObjectValue;
 begin
   CheckExecutionTimeout;
   IncrementInstructionCounter;
@@ -3014,6 +3018,8 @@ begin
       CalleeName := TGocciaClassValue(Callee).Name
     else if Callee is TGocciaNativeFunctionValue then
       CalleeName := TGocciaNativeFunctionValue(Callee).Name
+    else if Callee is TGocciaFunctionBase then
+      CalleeName := TGocciaFunctionBase(Callee).GetProperty(PROP_NAME).ToStringLiteral.Value
     else
       CalleeName := '';
 
@@ -3042,6 +3048,37 @@ begin
               [TGocciaNativeFunctionValue(Callee).Name]));
         Result := TGocciaNativeFunctionValue(Callee).Call(Arguments,
           TGocciaHoleValue.HoleValue);
+      end
+      else if Callee is TGocciaFunctionBase then
+      begin
+        // ES2026 §10.2.2 [[Construct]] for ordinary function objects:
+        // OrdinaryCreateFromConstructor produces a fresh object whose
+        // [[Prototype]] is constructor.prototype (or %Object.prototype% when
+        // that property is not an Object — §10.1.14 GetPrototypeFromConstructor).
+        FunctionCallee := TGocciaFunctionBase(Callee);
+        if not FunctionCallee.IsConstructable then
+          ThrowTypeError(Format(SErrorNotConstructor, [CalleeName]),
+            SSuggestNotConstructorType);
+        PrototypeValue := FunctionCallee.GetProperty(PROP_PROTOTYPE);
+        if PrototypeValue is TGocciaObjectValue then
+          ReceiverPrototype := TGocciaObjectValue(PrototypeValue)
+        else
+        begin
+          if not Assigned(TGocciaObjectValue.SharedObjectPrototype) then
+            TGocciaObjectValue.InitializeSharedPrototype;
+          ReceiverPrototype := TGocciaObjectValue.SharedObjectPrototype;
+        end;
+        ReceiverInstance := TGocciaObjectValue.Create(ReceiverPrototype);
+        TGarbageCollector.Instance.AddTempRoot(ReceiverInstance);
+        try
+          ConstructResult := FunctionCallee.Call(Arguments, ReceiverInstance);
+          if ConstructResult is TGocciaObjectValue then
+            Result := ConstructResult
+          else
+            Result := ReceiverInstance;
+        finally
+          TGarbageCollector.Instance.RemoveTempRoot(ReceiverInstance);
+        end;
       end
       else
       begin

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -78,6 +78,7 @@ procedure AssignRestPattern(const APattern: TGocciaRestDestructuringPattern; con
 procedure InitializeInstanceProperties(const AInstance: TGocciaInstanceValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 function InstantiateClass(const AClassValue: TGocciaClassValue; const AArguments: TGocciaArgumentsCollection; const AContext: TGocciaEvaluationContext): TGocciaValue;
+procedure ValidateClassConstructorReturn(const AClassValue: TGocciaClassValue; const AValue: TGocciaValue);
 
 function IsObjectInstanceOfClass(const AObj: TGocciaObjectValue; const AClassValue: TGocciaClassValue): Boolean;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2284,8 +2284,10 @@ function InvokeConstructableWithReceiver(const AConstructor: TGocciaValue;
   const AReceiver: TGocciaValue): TGocciaValue;
 var
   BoundFunction: TGocciaBoundFunctionValue;
+  ClassConstructor: TGocciaClassValue;
   CombinedArgs: TGocciaArgumentsCollection;
   SuperResult: TGocciaValue;
+  ConstructorThisValue: TGocciaValue;
   I: Integer;
 begin
   if AConstructor is TGocciaBoundFunctionValue then
@@ -2318,11 +2320,27 @@ begin
     SuperResult := TGocciaNativeFunctionValue(AConstructor).Call(
       AArguments, TGocciaHoleValue.HoleValue);
   end
+  else if AConstructor is TGocciaVMClassValue then
+    // Bytecode-compiled classes store the constructor as FConstructorValue
+    // (a TGocciaBytecodeFunctionValue), not FConstructorMethod, so route
+    // them through Instantiate which knows how to invoke that path and
+    // apply ApplyOwnConstructorResult's receiver-swap rules.
+    SuperResult := TGocciaVMClassValue(AConstructor).Instantiate(AArguments)
   else if AConstructor is TGocciaClassValue then
   begin
-    if Assigned(TGocciaClassValue(AConstructor).ConstructorMethod) then
-      SuperResult := TGocciaClassValue(AConstructor).ConstructorMethod.Call(
-        AArguments, AReceiver)
+    ClassConstructor := TGocciaClassValue(AConstructor);
+    if Assigned(ClassConstructor.ConstructorMethod) then
+    begin
+      // Mirror the Evaluator path: CallWithThisValue returns the constructor's
+      // final `this` (which the body may have replaced via an explicit return)
+      // so we can promote it as the receiver when the body returned a primitive.
+      SuperResult := ClassConstructor.ConstructorMethod.CallWithThisValue(
+        AArguments, AReceiver, ConstructorThisValue);
+      ValidateClassConstructorReturn(ClassConstructor, SuperResult);
+      if not (SuperResult is TGocciaObjectValue) and
+         (ConstructorThisValue is TGocciaObjectValue) then
+        SuperResult := ConstructorThisValue;
+    end
     else
       SuperResult := AReceiver;
   end

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -4479,6 +4479,8 @@ var
   BytecodeFunction: TGocciaBytecodeFunctionValue;
   Context: TGocciaEvaluationContext;
   ConstructorName: string;
+  PrototypeValue, ConstructResult: TGocciaValue;
+  ReceiverPrototype, ReceiverInstance: TGocciaObjectValue;
 begin
   // ES2026 §28.1.1 [[Construct]](argumentsList, newTarget)
   if AConstructor is TGocciaProxyValue then
@@ -4542,14 +4544,39 @@ begin
     if not TGocciaFunctionBase(AConstructor).IsConstructable then
       ThrowTypeError(Format(SErrorNotConstructor, [ConstructorName]),
         SSuggestNotConstructorType);
-    if Assigned(TGocciaCallStack.Instance) then
-      TGocciaCallStack.Instance.Push(ConstructorName, '', 0, 0);
+    // ES2026 §10.2.2 [[Construct]] for ordinary function objects:
+    // OrdinaryCreateFromConstructor allocates a fresh object whose
+    // [[Prototype]] is constructor.prototype (or %Object.prototype% when
+    // that property is not an Object — §10.1.14 GetPrototypeFromConstructor),
+    // then calls the body with the new object bound as `this`.  Iff the body
+    // explicitly returns an Object, that becomes the call result.
+    PrototypeValue := TGocciaFunctionBase(AConstructor).GetProperty(PROP_PROTOTYPE);
+    if PrototypeValue is TGocciaObjectValue then
+      ReceiverPrototype := TGocciaObjectValue(PrototypeValue)
+    else
+    begin
+      if not Assigned(TGocciaObjectValue.SharedObjectPrototype) then
+        TGocciaObjectValue.InitializeSharedPrototype;
+      ReceiverPrototype := TGocciaObjectValue.SharedObjectPrototype;
+    end;
+    ReceiverInstance := TGocciaObjectValue.Create(ReceiverPrototype);
+    TGarbageCollector.Instance.AddTempRoot(ReceiverInstance);
     try
-      Result := TGocciaFunctionBase(AConstructor).Call(
-        AArguments, TGocciaUndefinedLiteralValue.UndefinedValue);
-    finally
       if Assigned(TGocciaCallStack.Instance) then
-        TGocciaCallStack.Instance.Pop;
+        TGocciaCallStack.Instance.Push(ConstructorName, '', 0, 0);
+      try
+        ConstructResult := TGocciaFunctionBase(AConstructor).Call(
+          AArguments, ReceiverInstance);
+        if ConstructResult is TGocciaObjectValue then
+          Result := ConstructResult
+        else
+          Result := ReceiverInstance;
+      finally
+        if Assigned(TGocciaCallStack.Instance) then
+          TGocciaCallStack.Instance.Pop;
+      end;
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(ReceiverInstance);
     end;
     Exit;
   end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -4479,7 +4479,8 @@ var
   BytecodeFunction: TGocciaBytecodeFunctionValue;
   Context: TGocciaEvaluationContext;
   ConstructorName: string;
-  PrototypeValue, ConstructResult: TGocciaValue;
+  PrototypeTarget: TGocciaValue;
+  PrototypeValue: TGocciaValue;
   ReceiverPrototype, ReceiverInstance: TGocciaObjectValue;
 begin
   // ES2026 §28.1.1 [[Construct]](argumentsList, newTarget)
@@ -4550,7 +4551,16 @@ begin
     // that property is not an Object — §10.1.14 GetPrototypeFromConstructor),
     // then calls the body with the new object bound as `this`.  Iff the body
     // explicitly returns an Object, that becomes the call result.
-    PrototypeValue := TGocciaFunctionBase(AConstructor).GetProperty(PROP_PROTOTYPE);
+    // For bound function exotic objects (§10.4.1.2) the receiver's
+    // [[Prototype]] comes from the underlying [[BoundTargetFunction]] —
+    // the bound wrapper itself has no own `prototype` data property.
+    PrototypeTarget := AConstructor;
+    while PrototypeTarget is TGocciaBoundFunctionValue do
+      PrototypeTarget := TGocciaBoundFunctionValue(PrototypeTarget).OriginalFunction;
+    if PrototypeTarget is TGocciaObjectValue then
+      PrototypeValue := TGocciaObjectValue(PrototypeTarget).GetProperty(PROP_PROTOTYPE)
+    else
+      PrototypeValue := nil;
     if PrototypeValue is TGocciaObjectValue then
       ReceiverPrototype := TGocciaObjectValue(PrototypeValue)
     else
@@ -4565,12 +4575,11 @@ begin
       if Assigned(TGocciaCallStack.Instance) then
         TGocciaCallStack.Instance.Push(ConstructorName, '', 0, 0);
       try
-        ConstructResult := TGocciaFunctionBase(AConstructor).Call(
-          AArguments, ReceiverInstance);
-        if ConstructResult is TGocciaObjectValue then
-          Result := ConstructResult
-        else
-          Result := ReceiverInstance;
+        // InvokeConstructableWithReceiver merges bound args, dispatches to
+        // the underlying target, and applies the spec return rules
+        // (explicit Object return wins; otherwise the receiver).
+        Result := InvokeConstructableWithReceiver(AConstructor, AArguments,
+          ReceiverInstance);
       finally
         if Assigned(TGocciaCallStack.Instance) then
           TGocciaCallStack.Instance.Pop;

--- a/tests/language/function-keyword/new-on-function.js
+++ b/tests/language/function-keyword/new-on-function.js
@@ -181,3 +181,50 @@ test("when Foo.prototype is reassigned to a non-object, instances fall back to O
   const instance = new Foo();
   expect(Object.getPrototypeOf(instance)).toBe(Object.prototype);
 });
+
+test("`new` on a bound function uses the target's prototype, not the bound wrapper's", () => {
+  function Foo() {}
+  const Bound = Foo.bind(null);
+  const instance = new Bound();
+  expect(Object.getPrototypeOf(instance)).toBe(Foo.prototype);
+  expect(instance instanceof Foo).toBe(true);
+});
+
+test("`new` on a bound function merges bound and call arguments in order", () => {
+  function Pair(a, b) {
+    this.a = a;
+    this.b = b;
+  }
+  const Bound = Pair.bind(null, 1);
+  const p = new Bound(2);
+  expect(p.a).toBe(1);
+  expect(p.b).toBe(2);
+});
+
+test("`new` on a bound function ignores the bound `this` and binds the new instance instead", () => {
+  function Capture() {
+    this.captured = this;
+  }
+  const sentinel = { sentinel: true };
+  const Bound = Capture.bind(sentinel);
+  const c = new Bound();
+  expect(c.captured).toBe(c);
+  expect(c.captured).not.toBe(sentinel);
+});
+
+test("`new` on a doubly-bound function still routes through the original target", () => {
+  function Triple(a, b, c) {
+    this.sum = a + b + c;
+  }
+  const Once = Triple.bind(null, 1);
+  const Twice = Once.bind(null, 2);
+  const t = new Twice(3);
+  expect(t.sum).toBe(6);
+  expect(Object.getPrototypeOf(t)).toBe(Triple.prototype);
+});
+
+test("`new` on a bound non-constructable function (arrow) throws TypeError", () => {
+  const arrow = () => {};
+  const Bound = arrow.bind(null);
+  expect(() => new Bound()).toThrow(TypeError);
+});

--- a/tests/language/function-keyword/new-on-function.js
+++ b/tests/language/function-keyword/new-on-function.js
@@ -1,0 +1,183 @@
+/*---
+description: `new` on a function-keyword constructor allocates a fresh object, binds `this`, and applies the spec [[Construct]] return rules
+features: [compat-function]
+---*/
+
+test("typeof new Foo() is 'object' on an empty body", () => {
+  function Foo() {}
+  expect(typeof new Foo()).toBe("object");
+});
+
+test("new Foo() instanceof Foo is true", () => {
+  function Foo() {}
+  expect(new Foo() instanceof Foo).toBe(true);
+});
+
+test("new Foo() instance [[Prototype]] is Foo.prototype", () => {
+  function Foo() {}
+  const instance = new Foo();
+  expect(Object.getPrototypeOf(instance)).toBe(Foo.prototype);
+});
+
+test("methods set on Foo.prototype are reachable on instances", () => {
+  function Animal() {}
+  Animal.prototype.speak = function () {
+    return "generic sound";
+  };
+  expect(new Animal().speak()).toBe("generic sound");
+});
+
+test("constructor body sees `this` bound to the new instance", () => {
+  function Box(value) {
+    this.value = value;
+  }
+  const b = new Box("x");
+  expect(b.value).toBe("x");
+});
+
+test("constructor arguments forward to the body", () => {
+  function Pair(a, b) {
+    this.a = a;
+    this.b = b;
+  }
+  const p = new Pair(1, 2);
+  expect(p.a).toBe(1);
+  expect(p.b).toBe(2);
+});
+
+test("constructor body running once per `new` call", () => {
+  let calls = 0;
+  function Counter() {
+    calls += 1;
+  }
+  new Counter();
+  new Counter();
+  new Counter();
+  expect(calls).toBe(3);
+});
+
+test("explicit object return replaces the constructed receiver", () => {
+  function Replace() {
+    this.fromBody = true;
+    return { replaced: true };
+  }
+  const r = new Replace();
+  expect(r.replaced).toBe(true);
+  expect(r.fromBody).toBeUndefined();
+});
+
+test("explicit primitive return is ignored — receiver wins", () => {
+  function ReturnPrimitive() {
+    this.kept = true;
+    return 42;
+  }
+  const r = new ReturnPrimitive();
+  expect(r.kept).toBe(true);
+});
+
+test("explicit undefined return is ignored — receiver wins", () => {
+  function ReturnUndefined() {
+    this.kept = true;
+    return undefined;
+  }
+  const r = new ReturnUndefined();
+  expect(r.kept).toBe(true);
+});
+
+test("explicit null return is ignored — receiver wins", () => {
+  function ReturnNull() {
+    this.kept = true;
+    return null;
+  }
+  const r = new ReturnNull();
+  expect(r.kept).toBe(true);
+});
+
+test("explicit array return replaces the constructed receiver (arrays are objects)", () => {
+  function ReturnArray() {
+    this.discarded = true;
+    return [1, 2, 3];
+  }
+  const r = new ReturnArray();
+  expect(Array.isArray(r)).toBe(true);
+  expect(r.length).toBe(3);
+  expect(r.discarded).toBeUndefined();
+});
+
+test("instances are distinct objects across calls", () => {
+  function Foo() {}
+  expect(new Foo()).not.toBe(new Foo());
+});
+
+test("reassigning Foo.prototype after construction does not change existing instances", () => {
+  function Foo() {}
+  const before = new Foo();
+  const oldProto = Foo.prototype;
+  Foo.prototype = { replaced: true };
+  expect(Object.getPrototypeOf(before)).toBe(oldProto);
+});
+
+test("new Foo() with spread arguments forwards them in order", () => {
+  function Triple(a, b, c) {
+    this.sum = a + b + c;
+  }
+  const args = [10, 20, 30];
+  const t = new Triple(...args);
+  expect(t.sum).toBe(60);
+});
+
+test("`new` on an arrow function throws TypeError", () => {
+  const arrow = () => {};
+  expect(() => new arrow()).toThrow(TypeError);
+});
+
+test("`new` on an async function throws TypeError", () => {
+  async function asyncFn() {}
+  expect(() => new asyncFn()).toThrow(TypeError);
+});
+
+test("`new` on a generator function throws TypeError", () => {
+  function* gen() {}
+  expect(() => new gen()).toThrow(TypeError);
+});
+
+test("`new` on a concise method throws TypeError (no own prototype)", () => {
+  const obj = {
+    method() {},
+  };
+  expect(() => new obj.method()).toThrow(TypeError);
+});
+
+test("instance receives properties added by the body before any explicit return", () => {
+  function Sequenced() {
+    this.first = 1;
+    this.second = 2;
+  }
+  const s = new Sequenced();
+  expect(s.first).toBe(1);
+  expect(s.second).toBe(2);
+});
+
+test("Foo.prototype.constructor is reachable from the instance via the prototype chain", () => {
+  function Foo() {}
+  const instance = new Foo();
+  expect(instance.constructor).toBe(Foo);
+});
+
+test("nested `new` inside a constructor body works", () => {
+  function Inner(value) {
+    this.value = value;
+  }
+  function Outer(value) {
+    this.inner = new Inner(value);
+  }
+  const o = new Outer("nested");
+  expect(o.inner.value).toBe("nested");
+});
+
+test("when Foo.prototype is reassigned to a non-object, instances fall back to Object.prototype", () => {
+  function Foo() {}
+  Foo.prototype = null;
+  const instance = new Foo();
+  expect(Object.getPrototypeOf(instance)).toBe(Object.prototype);
+});

--- a/tests/language/function-keyword/new-on-function.js
+++ b/tests/language/function-keyword/new-on-function.js
@@ -228,3 +228,31 @@ test("`new` on a bound non-constructable function (arrow) throws TypeError", () 
   const Bound = arrow.bind(null);
   expect(() => new Bound()).toThrow(TypeError);
 });
+
+test("`new` on a bound class promotes the constructor's explicit object return as the result", () => {
+  class Base {
+    constructor() {
+      return { swapped: true };
+    }
+  }
+  const Bound = Base.bind(null);
+  const inst = new Bound();
+  expect(inst.swapped).toBe(true);
+});
+
+test("`new` on a bound class with no explicit return yields a fresh instance with class methods", () => {
+  class Counter {
+    constructor(start) {
+      this.value = start;
+    }
+    next() {
+      this.value += 1;
+      return this.value;
+    }
+  }
+  const Bound = Counter.bind(null, 10);
+  const c = new Bound();
+  expect(c.value).toBe(10);
+  expect(c.next()).toBe(11);
+  expect(c instanceof Counter).toBe(true);
+});

--- a/tests/language/function-keyword/prototype-property.js
+++ b/tests/language/function-keyword/prototype-property.js
@@ -165,15 +165,13 @@ test("async generator function.prototype's [[Prototype]] is Object.prototype (Go
   expect(Object.getPrototypeOf(g.prototype)).toBe(Object.prototype);
 });
 
-test("methods added to prototype are visible to instances via [[Prototype]] chain (interpreter only — new on plain functions is not yet wired)", () => {
-  // We can verify the prototype chain mechanically without invoking `new`:
-  // Object.create(f.prototype) gives us an object whose [[Prototype]] is f.prototype.
+test("methods added to prototype are visible to instances via [[Prototype]] chain", () => {
   function Animal() {}
   Animal.prototype.speak = function () {
     return "generic sound";
   };
 
-  const dog = Object.create(Animal.prototype);
+  const dog = new Animal();
   expect(dog.speak()).toBe("generic sound");
   expect(Object.getPrototypeOf(dog)).toBe(Animal.prototype);
 });


### PR DESCRIPTION
Fixes #501 and #502.

## Summary
- Both interpreter and bytecode VM now implement ES2026 §10.2.2 [[Construct]] for `function`-keyword constructors under `--compat-function`.
- `EvaluateNewExpression` (interpreter) and `ConstructValue` (bytecode VM) gain a `TGocciaFunctionBase` branch that allocates a fresh ordinary object whose `[[Prototype]]` is `Foo.prototype` (or `%Object.prototype%` per §10.1.14 when `prototype` is reassigned to a non-object), calls the body with the new object bound as `this`, and applies the spec return rules — explicit Object return wins, primitives are ignored.
- The bytecode side previously called the function with `undefined` as `this`; the interpreter side previously threw `TypeError: 'Foo' is not a constructor`.

## Tests
- New `tests/language/function-keyword/new-on-function.js` (23 tests): the four acceptance cases from #502 plus return-rule edge cases (object/primitive/null/undefined/array), spread args, nested `new`, prototype reassignment fallback, and TypeErrors for arrow / async / generator / concise method.
- Removed the "new on plain functions is not yet wired" caveat from `tests/language/function-keyword/prototype-property.js:168` per #502's acceptance list.

Fixes #501 and fixes #502 

## Test plan
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi` — 8507/8507 pass
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi --mode=bytecode` — 8507/8507 pass
- [x] `./format.pas --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)