### PR TITLE
Add --compat-all meta-flag across CLIs

### DIFF
--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -10,6 +10,7 @@
 import { $ } from "bun";
 import {
   mkdtempSync,
+  mkdirSync,
   writeFileSync,
   readFileSync,
   existsSync,
@@ -178,6 +179,68 @@ console.log("--compat-var (Loader + Bundler + TestRunner)...");
     );
     const trOut = await $`${TESTRUNNER} ${testSrc} --compat-var --no-progress 2>&1`.text();
     if (!trOut.includes("Passed: 1")) throw new Error(`TestRunner --compat-var expected Passed: 1, got: ${trOut}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// -- --compat-all (Loader + Bare + TestRunner) ----------------------------------
+
+console.log("--compat-all (Loader + Bare + TestRunner)...");
+{
+  const tmp = mkdtempSync(join(tmpdir(), "goccia-compat-all-"));
+  try {
+    // Source uses both var and function — both compat flags required.
+    const src = join(tmp, "use-both.js");
+    writeFileSync(src, "var x = 10;\nfunction f() { return x; }\nf();\n");
+
+    // Loader with --compat-all matches enumerating both flags.
+    const allOut = await $`${LOADER} ${src} --compat-all 2>&1`.text();
+    if (!allOut.includes("Result: 10")) throw new Error(`Loader --compat-all expected Result: 10, got: ${allOut}`);
+    const enumOut = await $`${LOADER} ${src} --compat-var --compat-function 2>&1`.text();
+    if (!enumOut.includes("Result: 10")) throw new Error(`Loader enumerated flags expected Result: 10, got: ${enumOut}`);
+
+    // Without any compat flag the source must fail (function declaration unsupported).
+    const noFlag = await $`${LOADER} ${src} 2>&1`.nothrow();
+    if (noFlag.exitCode === 0) throw new Error("Loader without compat flags should reject var/function");
+
+    // Bare loader with --compat-all.
+    const bareOut = await $`${BARE} ${src} --compat-all 2>&1`.text();
+    if (!bareOut.includes("10")) throw new Error(`Bare --compat-all expected output 10, got: ${bareOut}`);
+    const bareNoFlag = await $`${BARE} ${src} 2>&1`.nothrow();
+    if (bareNoFlag.exitCode === 0) throw new Error("Bare without compat flags should reject var/function");
+
+    // TestRunner with --compat-all.
+    const testSrc = join(tmp, "test-both.js");
+    writeFileSync(
+      testSrc,
+      [
+        "var y = 20;",
+        "function getY() { return y; }",
+        'describe("compat-all", () => {',
+        '  test("works", () => {',
+        "    expect(getY()).toBe(20);",
+        "  });",
+        "});",
+      ].join("\n") + "\n",
+    );
+    const trOut = await $`${TESTRUNNER} ${testSrc} --compat-all --no-progress 2>&1`.text();
+    if (!trOut.includes("Passed: 1")) throw new Error(`TestRunner --compat-all expected Passed: 1, got: ${trOut}`);
+
+    // goccia.json equivalent: "compat-all": true.
+    const cfgDir = join(tmp, "cfg");
+    mkdirSync(cfgDir);
+    writeFileSync(join(cfgDir, "goccia.json"), '{"compat-all": true}\n');
+    const cfgSrc = join(cfgDir, "use-both.js");
+    writeFileSync(cfgSrc, "var x = 10;\nfunction f() { return x; }\nf();\n");
+    const cfgOut = await $`${LOADER} ${cfgSrc} 2>&1`.text();
+    if (!cfgOut.includes("Result: 10")) throw new Error(`Config compat-all expected Result: 10, got: ${cfgOut}`);
+
+    // --help mentions --compat-all on every CLI.
+    for (const bin of [LOADER, BARE, REPL, TESTRUNNER, BUNDLER, BENCHRUNNER]) {
+      const help = await $`${bin} --help 2>&1`.text();
+      if (!help.includes("--compat-all")) throw new Error(`${bin} --help should mention --compat-all`);
+    }
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -241,6 +241,29 @@ console.log("--compat-all (Loader + Bare + TestRunner)...");
       const help = await $`${bin} --help 2>&1`.text();
       if (!help.includes("--compat-all")) throw new Error(`${bin} --help should mention --compat-all`);
     }
+
+    // Runtime smoke: every CLI must accept --compat-all without parser error.
+    // Each invocation feeds the binary an input it can complete and exit on,
+    // so the option actually flows through ParseCommandLine into engine setup.
+    const bundlerOut = join(tmp, "smoke.gbc");
+    const benchSrc = `suite("smoke", () => { bench("noop", { run: () => 1 }); });\n`;
+    const smokes: Array<[string, string[], string]> = [
+      [LOADER, ["--compat-all", "--output=compact-json"], ""],
+      [BARE, ["--compat-all"], ""],
+      [REPL, ["--compat-all"], ""],
+      [TESTRUNNER, ["--compat-all", "--no-progress"], 'test("noop", () => expect(1).toBe(1));\n'],
+      [BUNDLER, ["--compat-all", `--output=${bundlerOut}`], "1;\n"],
+      [BENCHRUNNER, ["--compat-all", "--no-progress"], benchSrc],
+    ];
+    for (const [bin, args, stdin] of smokes) {
+      const proc = Bun.spawnSync([bin, ...args], {
+        stdin: new TextEncoder().encode(stdin),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (proc.exitCode !== 0)
+        throw new Error(`${bin} --compat-all smoke should exit 0, got ${proc.exitCode}: ${proc.stderr.toString()}`);
+    }
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -517,6 +517,7 @@ var
   FileHosts: TStringList;
   HasFileHosts: Boolean;
   I: Integer;
+  CompatAll: Boolean;
 begin
   if not Assigned(AEngineOptions) then
     Exit;
@@ -529,12 +530,18 @@ begin
   AEngine.SourceType := ResolveSourceTypeOption(
     AEngineOptions.SourceType, AFileConfig);
 
+  { compat-all: meta-flag enabling every --compat-* option.  ORs into
+    each individual flag so embedders can opt into "as legacy-compatible
+    as the engine offers" without enumerating each flag. }
+  CompatAll := ResolveFlagOption(
+    AEngineOptions.CompatAll, AFileConfig, 'compat-all');
+
   { compat-var: CLI flag > per-file config > root config > default (false) }
-  AEngine.VarEnabled := ResolveFlagOption(
+  AEngine.VarEnabled := CompatAll or ResolveFlagOption(
     AEngineOptions.CompatVar, AFileConfig, 'compat-var');
 
   { compat-function: CLI flag > per-file config > root config > default (false) }
-  AEngine.FunctionEnabled := ResolveFlagOption(
+  AEngine.FunctionEnabled := CompatAll or ResolveFlagOption(
     AEngineOptions.CompatFunction, AFileConfig, 'compat-function');
 
   { strict-types: CLI flag > per-file config > root config > default (false) }

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -70,6 +70,7 @@ begin
   WriteLn('  --asi                         Enable automatic semicolon insertion');
   WriteLn('  --compat-var                  Enable var declarations');
   WriteLn('  --compat-function             Enable function declarations/expressions');
+  WriteLn('  --compat-all                  Enable all compatibility flags (--compat-*)');
   WriteLn('  --strict-types                Enforce type annotations at runtime');
   WriteLn('  --mode=interpreted|bytecode   Execution mode (default: interpreted)');
   WriteLn('  --source-type=script|module   Load entry as a script or module');
@@ -125,6 +126,11 @@ begin
       Result.CompatVar := True
     else if Arg = '--compat-function' then
       Result.CompatFunction := True
+    else if Arg = '--compat-all' then
+    begin
+      Result.CompatVar := True;
+      Result.CompatFunction := True;
+    end
     else if Arg = '--strict-types' then
       Result.StrictTypes := True
     else if Arg = '--unsafe-function-constructor' then

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -34,6 +34,7 @@ type
     ASI: Boolean;
     CompatVar: Boolean;
     CompatFunction: Boolean;
+    CompatAll: Boolean;
     StrictTypes: Boolean;
     UnsafeFunctionConstructor: Boolean;
     Mode: TBareExecutionMode;
@@ -106,6 +107,7 @@ begin
   Result.ASI := False;
   Result.CompatVar := False;
   Result.CompatFunction := False;
+  Result.CompatAll := False;
   Result.StrictTypes := False;
   Result.UnsafeFunctionConstructor := False;
   Result.Mode := bemInterpreted;
@@ -127,10 +129,7 @@ begin
     else if Arg = '--compat-function' then
       Result.CompatFunction := True
     else if Arg = '--compat-all' then
-    begin
-      Result.CompatVar := True;
-      Result.CompatFunction := True;
-    end
+      Result.CompatAll := True
     else if Arg = '--strict-types' then
       Result.StrictTypes := True
     else if Arg = '--unsafe-function-constructor' then
@@ -160,8 +159,11 @@ procedure ConfigureEngine(const AEngine: TGocciaEngine;
   const AOptions: TBareOptions);
 begin
   AEngine.ASIEnabled := AOptions.ASI;
-  AEngine.VarEnabled := AOptions.CompatVar;
-  AEngine.FunctionEnabled := AOptions.CompatFunction;
+  { CompatAll is a meta-flag — OR it into every per-flag setting so future
+    --compat-* options only need their own field; the meta-flag fan-out
+    happens here rather than in the parser. }
+  AEngine.VarEnabled := AOptions.CompatVar or AOptions.CompatAll;
+  AEngine.FunctionEnabled := AOptions.CompatFunction or AOptions.CompatAll;
   AEngine.StrictTypes := AOptions.StrictTypes;
   AEngine.SourceType := AOptions.SourceType;
   AEngine.FunctionConstructor.Enabled := AOptions.UnsafeFunctionConstructor;

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -166,6 +166,7 @@ type
     FStackSize: TGocciaIntegerOption;
     FCompatVar: TGocciaFlagOption;
     FCompatFunction: TGocciaFlagOption;
+    FCompatAll: TGocciaFlagOption;
     FStrictTypes: TGocciaFlagOption;
     FAllowedHosts: TGocciaRepeatableOption;
   public
@@ -187,6 +188,7 @@ type
     property StackSize: TGocciaIntegerOption read FStackSize;
     property CompatVar: TGocciaFlagOption read FCompatVar;
     property CompatFunction: TGocciaFlagOption read FCompatFunction;
+    property CompatAll: TGocciaFlagOption read FCompatAll;
     property StrictTypes: TGocciaFlagOption read FStrictTypes;
     property AllowedHosts: TGocciaRepeatableOption read FAllowedHosts;
   end;
@@ -571,6 +573,8 @@ begin
     'Enable var declarations (compatibility)', 'Engine');
   FCompatFunction := TGocciaFlagOption.Create('compat-function',
     'Enable function declarations and expressions (compatibility)', 'Engine');
+  FCompatAll := TGocciaFlagOption.Create('compat-all',
+    'Enable all compatibility flags (--compat-*)', 'Engine');
   FStrictTypes := TGocciaFlagOption.Create('strict-types',
     'Enforce type annotations at runtime (interpreter and bytecode)', 'Engine');
   FAllowedHosts := TGocciaRepeatableOption.Create('allowed-host',
@@ -593,6 +597,7 @@ begin
   FStackSize.Free;
   FCompatVar.Free;
   FCompatFunction.Free;
+  FCompatAll.Free;
   FStrictTypes.Free;
   FAllowedHosts.Free;
   inherited Destroy;
@@ -600,7 +605,7 @@ end;
 
 function TGocciaEngineOptions.Options: TGocciaOptionArray;
 begin
-  SetLength(Result, 15);
+  SetLength(Result, 16);
   Result[0] := FMode;
   Result[1] := FSourceType;
   Result[2] := FASI;
@@ -614,8 +619,9 @@ begin
   Result[10] := FStackSize;
   Result[11] := FCompatVar;
   Result[12] := FCompatFunction;
-  Result[13] := FStrictTypes;
-  Result[14] := FAllowedHosts;
+  Result[13] := FCompatAll;
+  Result[14] := FStrictTypes;
+  Result[15] := FAllowedHosts;
 end;
 
 { TGocciaCoverageOptions }


### PR DESCRIPTION
## Summary
- Add `--compat-all` to every CLI that exposes any `--compat-*` flag (Loader, LoaderBare, REPL, TestRunner, Bundler, BenchmarkRunner). Equivalent to enumerating every present and future compat flag, so embedders pinned to `--compat-all` opt into new compat behaviour automatically.
- Wire the meta-flag through `TGocciaEngineOptions` so the 5 shared CLIs auto-inherit it (option, help, and `goccia.json` `\"compat-all\": true` key); add explicit handling in `GocciaScriptLoaderBare`'s manual parser.
- In `ApplyFileConfigToEngine`, resolve `compat-all` with the same precedence as the individual flags and OR it into `VarEnabled` / `FunctionEnabled`. Future `--compat-*` flags become one extra OR line.

Closes #504.

## Test plan
- [x] \`./build.pas\` clean build succeeds
- [x] \`./format.pas --check\` passes
- [x] \`bun run scripts/test-cli.ts\` passes (new \`--compat-all\` block: Loader / Bare / TestRunner equivalence, \`goccia.json\` config, \`--help\` mention on all 6 CLIs)
- [x] \`bun run scripts/test-cli-config.ts\` passes
- [x] \`./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress\` — 8475/8480 (5 pre-existing FFI fixture failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)