### PR TITLE
Make ToStringLiteral ES2026-compliant; add ToPropertyKey

### DIFF
--- a/docs/value-system.md
+++ b/docs/value-system.md
@@ -298,7 +298,7 @@ Each symbol has a globally unique `Id` assigned at creation. Type coercion follo
 - `Number(symbol)` — Throws `TypeError`. Internally, `ToNumberLiteral` raises the error.
 - Unary `+symbol` / `-symbol` — Throws `TypeError` (these trigger `ToNumberLiteral`).
 
-The implicit coercion checks are implemented at the operator level (primarily in `Goccia.Arithmetic.pas`, with string built-in behavior in `Goccia.Values.StringObjectValue.pas`) rather than in `ToStringLiteral`, because `ToStringLiteral` is also used internally for property keys and display purposes where conversion must succeed.
+The implicit coercion checks for symbols are implemented at the operator level (primarily in `Goccia.Arithmetic.pas`, with string built-in behavior in `Goccia.Values.StringObjectValue.pas`) so that operators reach Symbol-rejection cleanly without first invoking `ToStringLiteral` on a non-symbol path.
 
 **Shared prototype singleton:** Like strings and numbers, symbols use a per-engine shared prototype object stored in a [realm slot](core-patterns.md#realm-ownership--slot-registration). It is initialized via `InitializePrototype`; the realm pins it on `SetSlot` and releases it on `Destroy`. The `description` getter and `toString()` method are registered on this shared prototype, and `TGocciaSymbolValue.GetProperty` delegates to the prototype via `GetPropertyWithContext` so that accessor getters receive the correct symbol instance as `this`. `Symbol.prototype` is exposed on the Symbol constructor function, matching ECMAScript semantics. Symbol is an always-registered standard built-in; special-purpose opt-ins like test assertions, benchmarking, and FFI are runtime globals selected through `TGocciaRuntimeGlobals`. Symbol type checks at the operator level use standard RTTI (`is TGocciaSymbolValue`) rather than VMT methods purely for implementation simplicity.
 
@@ -310,7 +310,11 @@ Objects store symbol-keyed properties separately from string-keyed properties vi
 
 ### ToPrimitive (`Goccia.Values.ToPrimitive.pas`)
 
-The ECMAScript abstract operation `ToPrimitive` converts any value to a primitive. For primitives, it's a no-op. For objects, it tries `valueOf()` first, then `toString()`, returning the first result that is a primitive. This operation is used by the `+` operator and is available as a standalone function for any module that needs spec-compliant type coercion.
+The ECMAScript abstract operation `ToPrimitive` converts any value to a primitive. For primitives, it's a no-op. For objects, the hint determines order: with `tphString` it tries `toString()` first, then `valueOf()`; with `tphDefault` or `tphNumber` it tries `valueOf()` first, then `toString()`. Returns the first result that is a primitive, or throws `TypeError` if neither method returns one. Used by `+`, comparison operators, and the spec coercion methods.
+
+### `ToPropertyKey` helper
+
+`Goccia.Values.ToPrimitive` also exposes `ToPropertyKey` (ES2026 §7.1.19) — coerces a value to a property key. Symbols pass through unchanged so the caller can dispatch to symbol-keyed property storage; non-symbols are coerced via `ToPrimitive(string)` and then `ToStringLiteral`. Property-access call sites check the returned type and route to either the string or symbol property table.
 
 ### Coercion Methods
 
@@ -321,6 +325,8 @@ Every value implements three conversion methods, following JavaScript coercion r
 | `ToBooleanLiteral` | `TGocciaBooleanLiteralValue` | `false` |
 | `ToNumberLiteral` | `TGocciaNumberLiteralValue` | `NaN` |
 | `ToStringLiteral` | `TGocciaStringLiteralValue` | `"undefined"` |
+
+For objects and class instances, `ToStringLiteral` performs ES2026 §7.1.17 ToString — it calls `ToPrimitive(value, string)` and may invoke user-defined `toString()` / `valueOf()`. It can therefore throw or trigger arbitrary side effects. Callers in error-boundary contexts (the bytecode throw constructor, the top-level throw formatter) avoid invoking it on objects entirely — they read primitive `name`/`message` properties or render a static `[object <Tag>]` placeholder instead, since post-VM-unwind re-entry is unsafe.
 
 Conversion follows ECMAScript specification semantics:
 

--- a/source/units/Goccia.Builtins.GlobalSymbol.pas
+++ b/source/units/Goccia.Builtins.GlobalSymbol.pas
@@ -154,7 +154,7 @@ begin
     Arg := AArgs.GetElement(0);
     if not (Arg is TGocciaUndefinedLiteralValue) then
     begin
-      Description := ToECMAString(Arg).Value;
+      Description := Arg.ToStringLiteral.Value;
       HasDescription := True;
     end;
   end;
@@ -179,7 +179,7 @@ var
 begin
   { Step 1: Let stringKey = ToString(key) }
   if AArgs.Length > 0 then
-    Key := ToECMAString(AArgs.GetElement(0)).Value
+    Key := AArgs.GetElement(0).ToStringLiteral.Value
   else
     Key := 'undefined';
 

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -301,7 +301,30 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.PromiseValue,
-  Goccia.Values.SetValue;
+  Goccia.Values.SetValue,
+  Goccia.Values.SymbolValue;
+
+// Render a value for an assertion failure message. Mirrors the philosophy of
+// Jest/Vitest pretty-format: objects are dumped structurally (via ToDebugString)
+// rather than passed through user-defined toString, so failure messages are
+// (a) deterministic, (b) safe on objects without a working prototype chain
+// (e.g. Object.create(null)), and (c) free of side effects from getters or
+// proxy traps. Primitives use ToStringLiteral, which never invokes user code.
+// Symbols use ToDisplayString to avoid the spec ToString TypeError on Symbol.
+function FormatForMessage(const AValue: TGocciaValue): string;
+begin
+  if not Assigned(AValue) then
+  begin
+    Result := 'undefined';
+    Exit;
+  end;
+  if AValue is TGocciaSymbolValue then
+    Result := TGocciaSymbolValue(AValue).ToDisplayString.Value
+  else if AValue is TGocciaObjectValue then
+    Result := TGocciaObjectValue(AValue).ToDebugString
+  else
+    Result := AValue.ToStringLiteral.Value;
+end;
 
 function FormatThrowValueDetail(const AValue: TGocciaValue): string;
 var
@@ -317,12 +340,10 @@ begin
     else if Assigned(MsgValue) and (MsgValue is TGocciaStringLiteralValue) then
       Result := TGocciaStringLiteralValue(MsgValue).Value
     else
-      Result := AValue.ToStringLiteral.Value;
+      Result := FormatForMessage(AValue);
   end
-  else if Assigned(AValue) then
-    Result := AValue.ToStringLiteral.Value
   else
-    Result := '(unknown error)';
+    Result := FormatForMessage(AValue);
 end;
 
 { TGocciaTestSuite }
@@ -709,10 +730,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBe',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBe',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to be ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -739,10 +760,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to equal ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to equal ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to equal ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to equal ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -761,7 +782,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toContainEqual')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContainEqual',
-        'Expected an array but received ' + FActualValue.ToStringLiteral.Value);
+        'Expected an array but received ' + FormatForMessage(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -787,10 +808,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContainEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to contain equal ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to contain equal ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContainEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to contain equal ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to contain equal ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -817,10 +838,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toStrictEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to strictly equal ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to strictly equal ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toStrictEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to strictly equal ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to strictly equal ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -840,7 +861,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toMatchObject')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatchObject',
-        'Expected an object but received ' + FActualValue.ToStringLiteral.Value);
+        'Expected an object but received ' + FormatForMessage(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -851,7 +872,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toMatchObject')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatchObject',
-        'Expected a match object but received ' + Expected.ToStringLiteral.Value);
+        'Expected a match object but received ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -870,10 +891,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatchObject',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to match object ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to match object ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatchObject',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to match object ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to match object ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -897,7 +918,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toMatch')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatch',
-        'Expected a string but received ' + FActualValue.ToStringLiteral.Value);
+        'Expected a string but received ' + FormatForMessage(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -910,12 +931,12 @@ begin
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatch',
         'Expected a string pattern or RegExp but received ' +
-        Expected.ToStringLiteral.Value);
+        FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
 
-  ActualString := FActualValue.ToStringLiteral.Value;
+  ActualString := FormatForMessage(FActualValue);
   if IsRegExpValue(Expected) then
   begin
     ExpectedDescription := RegExpObjectToString(Expected);
@@ -924,7 +945,7 @@ begin
   end
   else
   begin
-    ExpectedDescription := Expected.ToStringLiteral.Value;
+    ExpectedDescription := FormatForMessage(Expected);
     Matches := Pos(ExpectedDescription, ActualString) > 0;
   end;
 
@@ -940,11 +961,11 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatch',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to match ' +
+        'Expected ' + FormatForMessage(FActualValue) + ' not to match ' +
         ExpectedDescription)
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatch',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to match ' +
+        'Expected ' + FormatForMessage(FActualValue) + ' to match ' +
         ExpectedDescription);
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
@@ -968,10 +989,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeNull',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be null')
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be null')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeNull',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be null');
+        'Expected ' + FormatForMessage(FActualValue) + ' to be null');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -994,10 +1015,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeNaN',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be NaN')
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be NaN')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeNaN',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be NaN');
+        'Expected ' + FormatForMessage(FActualValue) + ' to be NaN');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1020,10 +1041,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeUndefined',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be undefined')
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be undefined')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeUndefined',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be undefined');
+        'Expected ' + FormatForMessage(FActualValue) + ' to be undefined');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1046,10 +1067,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeDefined',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be defined')
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be defined')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeDefined',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be defined');
+        'Expected ' + FormatForMessage(FActualValue) + ' to be defined');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1072,10 +1093,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeTruthy',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be truthy')
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be truthy')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeTruthy',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be truthy');
+        'Expected ' + FormatForMessage(FActualValue) + ' to be truthy');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1098,10 +1119,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeFalsy',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be falsy')
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be falsy')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeFalsy',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be falsy');
+        'Expected ' + FormatForMessage(FActualValue) + ' to be falsy');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1128,10 +1149,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeGreaterThan',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be greater than ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be greater than ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeGreaterThan',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be greater than ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to be greater than ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1158,10 +1179,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeGreaterThanOrEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be greater than or equal to ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be greater than or equal to ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeGreaterThanOrEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be greater than or equal to ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to be greater than or equal to ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1188,10 +1209,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeLessThan',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be less than ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be less than ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeLessThan',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be less than ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to be less than ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1218,10 +1239,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeLessThanOrEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be less than or equal to ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be less than or equal to ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeLessThanOrEqual',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be less than or equal to ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to be less than or equal to ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1239,8 +1260,8 @@ begin
   // For strings, check substring
   if FActualValue is TGocciaStringLiteralValue then
   begin
-    ActualStr := FActualValue.ToStringLiteral.Value;
-    ExpectedStr := Expected.ToStringLiteral.Value;
+    ActualStr := FormatForMessage(FActualValue);
+    ExpectedStr := FormatForMessage(Expected);
     Contains := Pos(ExpectedStr, ActualStr) > 0;
   end
   else if FActualValue is TGocciaArrayValue then
@@ -1268,10 +1289,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContain',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to contain ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to contain ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContain',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to contain ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to contain ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1355,10 +1376,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeInstanceOf',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to be an instance of ' + ExpectedConstructor.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to be an instance of ' + FormatForMessage(ExpectedConstructor))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeInstanceOf',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to be an instance of ' + ExpectedConstructor.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to be an instance of ' + FormatForMessage(ExpectedConstructor));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1382,7 +1403,7 @@ begin
   end
   else if FActualValue is TGocciaStringLiteralValue then
   begin
-    HasLength := Length(FActualValue.ToStringLiteral.Value) = Expected.ToNumberLiteral.Value;
+    HasLength := Length(FormatForMessage(FActualValue)) = Expected.ToNumberLiteral.Value;
   end
   else
   begin
@@ -1401,10 +1422,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveLength',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to have length ' + Expected.ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to have length ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveLength',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to have length ' + Expected.ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to have length ' + FormatForMessage(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1421,7 +1442,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toHaveProperty')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveProperty',
-        'Expected an object but received ' + FActualValue.ToStringLiteral.Value);
+        'Expected an object but received ' + FormatForMessage(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -1440,10 +1461,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveProperty',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' not to have property ' + AArgs.GetElement(0).ToStringLiteral.Value)
+        'Expected ' + FormatForMessage(FActualValue) + ' not to have property ' + AArgs.GetElement(0).ToStringLiteral.Value)
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveProperty',
-        'Expected ' + FActualValue.ToStringLiteral.Value + ' to have property ' + AArgs.GetElement(0).ToStringLiteral.Value);
+        'Expected ' + FormatForMessage(FActualValue) + ' to have property ' + AArgs.GetElement(0).ToStringLiteral.Value);
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1499,7 +1520,7 @@ begin
         end;
       end;
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-        'Expected error of type ' + ExpectedErrorType + ' but got: ' + FActualValue.ToStringLiteral.Value);
+        'Expected error of type ' + ExpectedErrorType + ' but got: ' + FormatForMessage(FActualValue));
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
       Exit;
     end;
@@ -1573,7 +1594,7 @@ begin
         else
         begin
           TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-            'Expected ' + FActualValue.ToStringLiteral.Value + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.Value.ToStringLiteral.Value);
+            'Expected ' + FormatForMessage(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + FormatForMessage(E.Value));
           Exit;
         end;
       end;
@@ -1597,7 +1618,7 @@ begin
         else
         begin
           TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-            'Expected ' + FActualValue.ToStringLiteral.Value + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.Message);
+            'Expected ' + FormatForMessage(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.Message);
           Exit;
         end;
       end;
@@ -1620,7 +1641,7 @@ begin
         else
         begin
           TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-            'Expected ' + FActualValue.ToStringLiteral.Value + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.ClassName + ': ' + E.Message);
+            'Expected ' + FormatForMessage(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.ClassName + ': ' + E.Message);
           Exit;
         end;
       end;
@@ -1630,7 +1651,7 @@ begin
   end;
 
   TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-    'Expected ' + FActualValue.ToStringLiteral.Value + ' to throw an exception');
+    'Expected ' + FormatForMessage(FActualValue) + ' to throw an exception');
 end;
 
 function TGocciaExpectationValue.ToBeCloseTo(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -1698,11 +1719,11 @@ begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeCloseTo',
         Format('Expected %s not to be close to %s (precision: %d)',
-               [FActualValue.ToStringLiteral.Value, Expected.ToStringLiteral.Value, Precision]))
+               [FormatForMessage(FActualValue), FormatForMessage(Expected), Precision]))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeCloseTo',
         Format('Expected %s to be close to %s (precision: %d)',
-               [FActualValue.ToStringLiteral.Value, Expected.ToStringLiteral.Value, Precision]));
+               [FormatForMessage(FActualValue), FormatForMessage(Expected), Precision]));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -2129,10 +2150,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveReturnedWith',
-        'Expected mock not to have returned with ' + Expected.ToStringLiteral.Value)
+        'Expected mock not to have returned with ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveReturnedWith',
-        'Expected mock to have returned with ' + Expected.ToStringLiteral.Value);
+        'Expected mock to have returned with ' + FormatForMessage(Expected));
   end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -2185,10 +2206,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveLastReturnedWith',
-        'Expected mock not to have last returned with ' + Expected.ToStringLiteral.Value)
+        'Expected mock not to have last returned with ' + FormatForMessage(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveLastReturnedWith',
-        'Expected mock to have last returned with ' + Expected.ToStringLiteral.Value);
+        'Expected mock to have last returned with ' + FormatForMessage(Expected));
   end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -2250,10 +2271,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveNthReturnedWith',
-        Format('Expected return %d not to be %s', [N, Expected.ToStringLiteral.Value]))
+        Format('Expected return %d not to be %s', [N, FormatForMessage(Expected)]))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveNthReturnedWith',
-        Format('Expected return %d to be %s', [N, Expected.ToStringLiteral.Value]));
+        Format('Expected return %d to be %s', [N, FormatForMessage(Expected)]));
   end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -2273,7 +2294,7 @@ begin
     if not (FActualValue is TGocciaPromiseValue) then
     begin
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('resolves',
-        'Expected a Promise but received ' + FActualValue.ToStringLiteral.Value);
+        'Expected a Promise but received ' + FormatForMessage(FActualValue));
       Result := TGocciaExpectationValue.Create(TGocciaUndefinedLiteralValue.UndefinedValue, FTestAssertions, FIsNegated);
       Exit;
     end;
@@ -2286,7 +2307,7 @@ begin
     else if Promise.State = gpsRejected then
     begin
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('resolves',
-        'Expected Promise to resolve but it rejected with: ' + Promise.PromiseResult.ToStringLiteral.Value);
+        'Expected Promise to resolve but it rejected with: ' + FormatForMessage(Promise.PromiseResult));
       Result := TGocciaExpectationValue.Create(TGocciaUndefinedLiteralValue.UndefinedValue, FTestAssertions, FIsNegated);
     end
     else
@@ -2311,7 +2332,7 @@ begin
     if not (FActualValue is TGocciaPromiseValue) then
     begin
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('rejects',
-        'Expected a Promise but received ' + FActualValue.ToStringLiteral.Value);
+        'Expected a Promise but received ' + FormatForMessage(FActualValue));
       Result := TGocciaExpectationValue.Create(TGocciaUndefinedLiteralValue.UndefinedValue, FTestAssertions, FIsNegated);
       Exit;
     end;
@@ -2324,7 +2345,7 @@ begin
     else if Promise.State = gpsFulfilled then
     begin
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('rejects',
-        'Expected Promise to reject but it resolved with: ' + Promise.PromiseResult.ToStringLiteral.Value);
+        'Expected Promise to reject but it resolved with: ' + FormatForMessage(Promise.PromiseResult));
       Result := TGocciaExpectationValue.Create(TGocciaUndefinedLiteralValue.UndefinedValue, FTestAssertions, FIsNegated);
     end
     else
@@ -2950,8 +2971,8 @@ begin
                   WaitForFetchPromise(TGocciaPromiseValue(TestResult));
                   if TGocciaPromiseValue(TestResult).State = gpsRejected then
                   begin
-                    RejectionReason := TGocciaPromiseValue(TestResult).
-                      PromiseResult.ToStringLiteral.Value;
+                    RejectionReason := FormatForMessage(
+                      TGocciaPromiseValue(TestResult).PromiseResult);
                     AssertionFailed('async test', 'Returned Promise rejected: ' +
                       RejectionReason);
                     if FTestStats.CurrentSuiteName <> '' then
@@ -3170,7 +3191,7 @@ begin
               Promise := TGocciaPromiseValue(CallbackResult);
               WaitForFetchPromise(Promise);
               if Promise.State = gpsRejected then
-                AssertionFailed('callback execution', 'Async callback rejected: ' + Promise.PromiseResult.ToStringLiteral.Value)
+                AssertionFailed('callback execution', 'Async callback rejected: ' + FormatForMessage(Promise.PromiseResult))
               else if Promise.State = gpsPending then
                 AssertionFailed('callback execution', 'Async callback Promise still pending after microtask drain');
             end

--- a/source/units/Goccia.Error.Detail.pas
+++ b/source/units/Goccia.Error.Detail.pas
@@ -17,7 +17,10 @@ function ExtractThrowLocation(const AThrown: TGocciaValue;
 
 { Formats a detailed error message for a TGocciaThrowValue, including source
   context with caret pointer when source lines and location are available.
-  Falls back to the stack trace or bare message when context is unavailable. }
+  Falls back to the stack trace or a debug-format placeholder when context is
+  unavailable. The fallback never invokes user toString()/valueOf() — by the
+  time this is called the bytecode VM has unwound and re-entering it would
+  raise a Pascal range-check error. }
 function FormatThrowDetail(const AThrown: TGocciaValue;
   const AFileName: string; const ASourceLines: TStringList;
   const AUseColor: Boolean; const ASuggestion: string = ''): string;
@@ -29,7 +32,8 @@ uses
 
   Goccia.Constants.PropertyNames,
   Goccia.Error,
-  Goccia.Values.ObjectValue;
+  Goccia.Values.ObjectValue,
+  Goccia.Values.SymbolValue;
 
 function ExtractThrowLocation(const AThrown: TGocciaValue;
   out AErrorName, AErrorMessage, AFrameFileName: string;
@@ -118,7 +122,10 @@ begin
   end
   else
   begin
-    // Fallback: just show the stack trace or message
+    // Fallback when no parseable stack frame is available. Use the stack
+    // string if present; otherwise render a static debug representation that
+    // does not touch user toString()/valueOf() — the bytecode VM has already
+    // unwound by the time this runs and re-entry is unsafe.
     if AThrown is TGocciaObjectValue then
     begin
       StackValue := TGocciaObjectValue(AThrown).GetProperty(PROP_STACK);
@@ -126,9 +133,13 @@ begin
          (TGocciaStringLiteralValue(StackValue).Value <> '') then
         Result := TGocciaStringLiteralValue(StackValue).Value
       else
-        Result := AThrown.ToStringLiteral.Value;
+        Result := Format('[object %s]', [TGocciaObjectValue(AThrown).ToStringTag]);
     end
+    else if AThrown is TGocciaSymbolValue then
+      Result := TGocciaSymbolValue(AThrown).ToDisplayString.Value
     else
+      // Primitive non-Symbol values: ToStringLiteral cannot invoke user code
+      // and cannot throw, so it is safe to call here.
       Result := AThrown.ToStringLiteral.Value;
   end;
 end;

--- a/source/units/Goccia.Evaluator.PatternMatching.pas
+++ b/source/units/Goccia.Evaluator.PatternMatching.pas
@@ -58,7 +58,8 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.ProxyValue,
   Goccia.Values.StringObjectValue,
-  Goccia.Values.SymbolValue;
+  Goccia.Values.SymbolValue,
+  Goccia.Values.ToPrimitive;
 
 function CreatePatternChildContext(const AContext: TGocciaEvaluationContext;
   const ALabel: string): TGocciaEvaluationContext;
@@ -248,37 +249,41 @@ end;
 
 function HasMatchProperty(const ASubject, AKey: TGocciaValue): Boolean;
 var
+  ResolvedKey: TGocciaValue;
   KeyName: string;
   BoxedSubject: TGocciaObjectValue;
   SymbolPrototype: TGocciaValue;
   PropertyValue: TGocciaValue;
 begin
-  if AKey is TGocciaSymbolValue then
+  // ES2026 §7.1.19 ToPropertyKey on the pattern key — symbols pass through;
+  // an object whose toString() returns a Symbol resolves to that Symbol.
+  ResolvedKey := ToPropertyKey(AKey);
+  if ResolvedKey is TGocciaSymbolValue then
   begin
     if ASubject is TGocciaObjectValue then
     begin
       if ASubject is TGocciaProxyValue then
-        Exit(TGocciaProxyValue(ASubject).HasSymbolTrap(TGocciaSymbolValue(AKey)));
+        Exit(TGocciaProxyValue(ASubject).HasSymbolTrap(TGocciaSymbolValue(ResolvedKey)));
       Exit(HasSymbolPropertyInChain(TGocciaObjectValue(ASubject),
-        TGocciaSymbolValue(AKey)));
+        TGocciaSymbolValue(ResolvedKey)));
     end;
 
     BoxedSubject := BoxPrimitiveForMatch(ASubject);
     if Assigned(BoxedSubject) then
-      Exit(HasSymbolPropertyInChain(BoxedSubject, TGocciaSymbolValue(AKey)));
+      Exit(HasSymbolPropertyInChain(BoxedSubject, TGocciaSymbolValue(ResolvedKey)));
 
     if ASubject is TGocciaSymbolValue then
     begin
       SymbolPrototype := TGocciaSymbolValue.SharedPrototype;
       if SymbolPrototype is TGocciaObjectValue then
         Exit(HasSymbolPropertyInChain(TGocciaObjectValue(SymbolPrototype),
-          TGocciaSymbolValue(AKey)));
+          TGocciaSymbolValue(ResolvedKey)));
     end;
 
     Exit(False);
   end;
 
-  KeyName := AKey.ToStringLiteral.Value;
+  KeyName := TGocciaStringLiteralValue(ResolvedKey).Value;
   if ASubject is TGocciaProxyValue then
     Exit(TGocciaProxyValue(ASubject).HasTrap(KeyName));
 
@@ -302,24 +307,28 @@ end;
 
 function GetMatchProperty(const ASubject, AKey: TGocciaValue): TGocciaValue;
 var
+  ResolvedKey: TGocciaValue;
+  KeyName: string;
   BoxedSubject: TGocciaObjectValue;
   SymbolPrototype: TGocciaValue;
 begin
-  if AKey is TGocciaSymbolValue then
+  // ES2026 §7.1.19 ToPropertyKey before dispatching to symbol or string storage.
+  ResolvedKey := ToPropertyKey(AKey);
+  if ResolvedKey is TGocciaSymbolValue then
   begin
     if ASubject is TGocciaObjectValue then
-      Result := TGocciaObjectValue(ASubject).GetSymbolProperty(TGocciaSymbolValue(AKey))
+      Result := TGocciaObjectValue(ASubject).GetSymbolProperty(TGocciaSymbolValue(ResolvedKey))
     else
     begin
       BoxedSubject := BoxPrimitiveForMatch(ASubject);
       if Assigned(BoxedSubject) then
-        Result := BoxedSubject.GetSymbolProperty(TGocciaSymbolValue(AKey))
+        Result := BoxedSubject.GetSymbolProperty(TGocciaSymbolValue(ResolvedKey))
       else if ASubject is TGocciaSymbolValue then
       begin
         SymbolPrototype := TGocciaSymbolValue.SharedPrototype;
         if SymbolPrototype is TGocciaObjectValue then
           Result := TGocciaObjectValue(SymbolPrototype).GetSymbolProperty(
-            TGocciaSymbolValue(AKey))
+            TGocciaSymbolValue(ResolvedKey))
         else
           Result := nil;
       end
@@ -327,15 +336,19 @@ begin
         Result := nil;
     end;
   end
-  else if ASubject is TGocciaObjectValue then
-    Result := ASubject.GetProperty(AKey.ToStringLiteral.Value)
   else
   begin
-    BoxedSubject := BoxPrimitiveForMatch(ASubject);
-    if Assigned(BoxedSubject) then
-      Result := BoxedSubject.GetProperty(AKey.ToStringLiteral.Value)
+    KeyName := TGocciaStringLiteralValue(ResolvedKey).Value;
+    if ASubject is TGocciaObjectValue then
+      Result := ASubject.GetProperty(KeyName)
     else
-      Result := ASubject.GetProperty(AKey.ToStringLiteral.Value);
+    begin
+      BoxedSubject := BoxPrimitiveForMatch(ASubject);
+      if Assigned(BoxedSubject) then
+        Result := BoxedSubject.GetProperty(KeyName)
+      else
+        Result := ASubject.GetProperty(KeyName);
+    end;
   end;
   if not Assigned(Result) then
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -585,7 +598,8 @@ begin
     begin
       Prop := APattern.Properties[I];
       if Prop.Computed then
-        KeyValue := EvaluateExpression(Prop.KeyExpression, CurrentContext)
+        // ES2026 §7.1.19 ToPropertyKey on the computed pattern key.
+        KeyValue := ToPropertyKey(EvaluateExpression(Prop.KeyExpression, CurrentContext))
       else
         KeyValue := TGocciaStringLiteralValue.Create(Prop.Key);
 
@@ -599,7 +613,7 @@ begin
       if KeyValue is TGocciaSymbolValue then
         MatchedSymbols.Add(TGocciaSymbolValue(KeyValue))
       else
-        MatchedKeys.Add(KeyValue.ToStringLiteral.Value);
+        MatchedKeys.Add(TGocciaStringLiteralValue(KeyValue).Value);
       CurrentContext := NextContext;
     end;
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1126,6 +1126,7 @@ var
   Obj: TGocciaValue;
   PropertyName: string;
   PropertyValue: TGocciaValue;
+  PropertyKey: TGocciaValue;
   SuperClass: TGocciaClassValue;
   SuperClassValue: TGocciaValue;
   SuperObject: TGocciaObjectValue;
@@ -1198,20 +1199,22 @@ begin
     if Assigned(AOutObjectValue) then
       AOutObjectValue^ := SuperClassValue;
 
-    // Get the property name
+    // Get the property name. ES2026 §7.1.19 ToPropertyKey: symbols pass
+    // through; otherwise coerce via ToPrimitive(string) → ToString.
     if AMemberExpression.Computed and Assigned(AMemberExpression.PropertyExpression) then
     begin
       PropertyValue := EvaluateExpression(AMemberExpression.PropertyExpression, AContext);
-      if PropertyValue is TGocciaSymbolValue then
+      PropertyKey := ToPropertyKey(PropertyValue);
+      if PropertyKey is TGocciaSymbolValue then
       begin
         if AContext.Scope.ThisValue is TGocciaClassValue then
         begin
           if Assigned(SuperClass) then
             Result := SuperClass.GetSymbolPropertyWithReceiver(
-              TGocciaSymbolValue(PropertyValue), AContext.Scope.ThisValue)
+              TGocciaSymbolValue(PropertyKey), AContext.Scope.ThisValue)
           else
             Result := SuperObject.GetSymbolPropertyWithReceiver(
-              TGocciaSymbolValue(PropertyValue), AContext.Scope.ThisValue);
+              TGocciaSymbolValue(PropertyKey), AContext.Scope.ThisValue);
         end
         else
         begin
@@ -1219,13 +1222,13 @@ begin
 
           if SuperPrototype is TGocciaObjectValue then
             Result := TGocciaObjectValue(SuperPrototype).GetSymbolPropertyWithReceiver(
-              TGocciaSymbolValue(PropertyValue), AContext.Scope.ThisValue)
+              TGocciaSymbolValue(PropertyKey), AContext.Scope.ThisValue)
           else
             Result := TGocciaUndefinedLiteralValue.UndefinedValue;
         end;
         Exit;
       end;
-      PropertyName := PropertyValue.ToStringLiteral.Value;
+      PropertyName := TGocciaStringLiteralValue(PropertyKey).Value;
     end
     else
     begin
@@ -1275,14 +1278,15 @@ begin
       AOutObjectValue^ := Obj;
   end;
 
-  // Determine the property name
+  // Determine the property name. ES2026 §7.1.19 ToPropertyKey on the
+  // computed expression: symbols pass through; otherwise coerce via
+  // ToPrimitive(string) → ToString.
   if AMemberExpression.Computed and Assigned(AMemberExpression.PropertyExpression) then
   begin
-    // Computed access: evaluate the property expression to get the property name
     PropertyValue := EvaluateExpression(AMemberExpression.PropertyExpression, AContext);
+    PropertyKey := ToPropertyKey(PropertyValue);
 
-    // Symbol property access
-    if PropertyValue is TGocciaSymbolValue then
+    if PropertyKey is TGocciaSymbolValue then
     begin
       if (Obj is TGocciaNullLiteralValue) or (Obj is TGocciaUndefinedLiteralValue) then
         ThrowTypeError(Format(SErrorCannotReadPropertiesOf, [Obj.ToStringLiteral.Value, 'Symbol()']),
@@ -1290,12 +1294,12 @@ begin
 
       if Obj is TGocciaClassValue then
       begin
-        Result := TGocciaClassValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyValue));
+        Result := TGocciaClassValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKey));
         Exit;
       end
       else if Obj is TGocciaObjectValue then
       begin
-        Result := TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyValue));
+        Result := TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKey));
         Exit;
       end
       else if Obj is TGocciaSymbolValue then
@@ -1303,7 +1307,7 @@ begin
         // Symbol primitive: look up symbol-keyed members on Symbol.prototype
         if Assigned(TGocciaSymbolValue.SharedPrototype) then
           Result := TGocciaObjectValue(TGocciaSymbolValue.SharedPrototype)
-            .GetSymbolPropertyWithReceiver(TGocciaSymbolValue(PropertyValue), Obj)
+            .GetSymbolPropertyWithReceiver(TGocciaSymbolValue(PropertyKey), Obj)
         else
           Result := TGocciaUndefinedLiteralValue.UndefinedValue;
         Exit;
@@ -1313,7 +1317,7 @@ begin
         BoxedValue := Obj.Box;
         if Assigned(BoxedValue) then
         begin
-          Result := BoxedValue.GetSymbolProperty(TGocciaSymbolValue(PropertyValue));
+          Result := BoxedValue.GetSymbolProperty(TGocciaSymbolValue(PropertyKey));
           Exit;
         end;
         Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -1321,7 +1325,7 @@ begin
       end;
     end;
 
-    PropertyName := PropertyValue.ToStringLiteral.Value;
+    PropertyName := TGocciaStringLiteralValue(PropertyKey).Value;
   end
   else
   begin
@@ -1413,6 +1417,7 @@ var
   PropertyName: string;
   PropertyExpression: TGocciaExpression;
   PropertyValue: TGocciaValue;
+  PropertyKey: TGocciaValue;
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingSetter: TGocciaValue;
   ExistingGetter: TGocciaValue;
@@ -1483,13 +1488,15 @@ begin
             end
             else
             begin
-              // Regular computed property: {[expr]: value}
+              // Regular computed property: {[expr]: value}. ES2026 §13.2.5.5
+              // PropertyDefinitionEvaluation routes through ToPropertyKey.
               PropertyValue := EvaluateExpression(ComputedPair.Key, AContext);
-              if PropertyValue is TGocciaSymbolValue then
-                Obj.DefineSymbolProperty(TGocciaSymbolValue(PropertyValue), TGocciaPropertyDescriptorData.Create(EvaluateExpression(ComputedPair.Value, AContext), [pfEnumerable, pfConfigurable, pfWritable]))
+              PropertyKey := ToPropertyKey(PropertyValue);
+              if PropertyKey is TGocciaSymbolValue then
+                Obj.DefineSymbolProperty(TGocciaSymbolValue(PropertyKey), TGocciaPropertyDescriptorData.Create(EvaluateExpression(ComputedPair.Value, AContext), [pfEnumerable, pfConfigurable, pfWritable]))
               else
               begin
-                ComputedKey := PropertyValue.ToStringLiteral.Value;
+                ComputedKey := TGocciaStringLiteralValue(PropertyKey).Value;
                 Obj.DefineProperty(ComputedKey, TGocciaPropertyDescriptorData.Create(EvaluateExpression(ComputedPair.Value, AContext), [pfEnumerable, pfConfigurable, pfWritable]));
               end;
             end;
@@ -3770,7 +3777,9 @@ begin
     if not (Elem.Kind in [cekMethod, cekGetter, cekSetter]) then
       Continue;
 
-    ComputedKey := EvaluateExpression(Elem.ComputedKeyExpression, AContext);
+    // ES2026 §15.4 ClassDefinitionEvaluation step 6.b for computed names:
+    // evaluate, then ToPropertyKey, dispatching string vs. symbol storage.
+    ComputedKey := ToPropertyKey(EvaluateExpression(Elem.ComputedKeyExpression, AContext));
 
     case Elem.Kind of
       cekMethod:
@@ -5132,7 +5141,7 @@ begin
       if PartValue is TGocciaSymbolValue then
         ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
       // ES2026 §13.15.5.1 step 5e: ToString(value) on each substitution
-      SB.Append(ToECMAString(PartValue).Value);
+      SB.Append(PartValue.ToStringLiteral.Value);
     end;
   end;
   Result := TGocciaStringLiteralValue.Create(SB.ToString);
@@ -5568,6 +5577,7 @@ var
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
   PropValue, ElementValue, DefaultValue: TGocciaValue;
+  PropertyKey: TGocciaValue;
   RestElements: TGocciaArrayValue;
   I, J: Integer;
   Exhausted: Boolean;
@@ -5585,8 +5595,17 @@ begin
     for I := 0 to ObjPat.Properties.Count - 1 do
     begin
       if ObjPat.Properties[I].Computed and Assigned(ObjPat.Properties[I].KeyExpression) then
-        PropValue := (AValue as TGocciaObjectValue).GetProperty(
-          EvaluateExpression(ObjPat.Properties[I].KeyExpression, AContext).ToStringLiteral.Value)
+      begin
+        // ES2026 §13.5.5 ObjectBindingPattern with ComputedPropertyName:
+        // ToPropertyKey on the evaluated expression, dispatch by type.
+        PropertyKey := ToPropertyKey(EvaluateExpression(ObjPat.Properties[I].KeyExpression, AContext));
+        if PropertyKey is TGocciaSymbolValue then
+          PropValue := (AValue as TGocciaObjectValue).GetSymbolProperty(TGocciaSymbolValue(PropertyKey))
+        else
+          PropValue := (AValue as TGocciaObjectValue).GetProperty(TGocciaStringLiteralValue(PropertyKey).Value);
+        if not Assigned(PropValue) then
+          PropValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+      end
       else
         PropValue := (AValue as TGocciaObjectValue).GetProperty(ObjPat.Properties[I].Key);
       AssignVariablePattern(ObjPat.Properties[I].Pattern, PropValue, AContext);
@@ -5783,13 +5802,15 @@ begin
   Obj := EvaluateExpression(MemberExpr.ObjectExpr, AContext);
   if MemberExpr.Computed then
   begin
-    PropValue := EvaluateExpression(MemberExpr.PropertyExpression, AContext);
+    // ES2026 §13.5.1.2 PropertyDestructuringAssignmentEvaluation step 5:
+    // ToPropertyKey on the computed key.
+    PropValue := ToPropertyKey(EvaluateExpression(MemberExpr.PropertyExpression, AContext));
     if (PropValue is TGocciaSymbolValue) and (Obj is TGocciaObjectValue) then
       TGocciaObjectValue(Obj).AssignSymbolProperty(TGocciaSymbolValue(PropValue), AValue)
     else if (PropValue is TGocciaSymbolValue) and (Obj is TGocciaClassValue) then
       TGocciaClassValue(Obj).AssignSymbolProperty(TGocciaSymbolValue(PropValue), AValue)
     else
-      AssignProperty(Obj, PropValue.ToStringLiteral.Value, AValue, AContext.OnError, APattern.Line, APattern.Column);
+      AssignProperty(Obj, TGocciaStringLiteralValue(PropValue).Value, AValue, AContext.OnError, APattern.Line, APattern.Column);
   end
   else
     AssignProperty(Obj, MemberExpr.PropertyName, AValue, AContext.OnError, APattern.Line, APattern.Column);
@@ -6059,11 +6080,11 @@ begin
       end
       else
       begin
-        // Regular property
+        // Regular property — ES2026 §13.5.5 ObjectAssignmentPattern routes
+        // computed keys through ToPropertyKey.
         if Prop.Computed then
         begin
-          // Computed property key (may be a symbol)
-          PropValue := EvaluateExpression(Prop.KeyExpression, AContext);
+          PropValue := ToPropertyKey(EvaluateExpression(Prop.KeyExpression, AContext));
           if PropValue is TGocciaSymbolValue then
           begin
             // Class values store static symbol-keyed members in their own
@@ -6077,7 +6098,7 @@ begin
             AssignPattern(Prop.Pattern, PropValue, AContext, AIsDeclaration, ADeclarationType);
             Continue;
           end;
-          Key := PropValue.ToStringLiteral.Value;
+          Key := TGocciaStringLiteralValue(PropValue).Value;
         end
         else
         begin
@@ -6148,30 +6169,56 @@ var
   MemberExpr: TGocciaMemberExpression;
   ObjValue: TGocciaValue;
   PropertyName: string;
-  Value: TGocciaValue;
+  PropertyKey: TGocciaValue;
+  IsSymbolKey: Boolean;
+  SymbolKey: TGocciaSymbolValue;
   ArrayValue: TGocciaArrayValue;
   ObjectValue: TGocciaObjectValue;
   Index: Integer;
 begin
+  IsSymbolKey := False;
+  SymbolKey := nil;
+  PropertyName := '';
   // Handle member expressions (property deletion)
   if AOperand is TGocciaMemberExpression then
   begin
     MemberExpr := TGocciaMemberExpression(AOperand);
     ObjValue := EvaluateExpression(MemberExpr.ObjectExpr, AContext);
 
-    // Get property name
+    // Get property name. ES2026 §13.5.1.2 step 5 routes computed keys through
+    // ToPropertyKey so symbols are deleted from symbol storage rather than
+    // being stringified (which would throw TypeError).
     if MemberExpr.Computed and Assigned(MemberExpr.PropertyExpression) then
     begin
-      Value := EvaluateExpression(MemberExpr.PropertyExpression, AContext);
-      PropertyName := Value.ToStringLiteral.Value;
+      PropertyKey := ToPropertyKey(EvaluateExpression(MemberExpr.PropertyExpression, AContext));
+      if PropertyKey is TGocciaSymbolValue then
+      begin
+        IsSymbolKey := True;
+        SymbolKey := TGocciaSymbolValue(PropertyKey);
+      end
+      else
+        PropertyName := TGocciaStringLiteralValue(PropertyKey).Value;
     end
     else
     begin
       PropertyName := MemberExpr.PropertyName;
     end;
 
+    if IsSymbolKey then
+    begin
+      // Symbol-keyed deletion: defined for objects/instances/classes only.
+      // Primitives have no symbol storage, so the operation is a no-op.
+      if ObjValue is TGocciaObjectValue then
+      begin
+        if not TGocciaObjectValue(ObjValue).DeleteSymbolProperty(SymbolKey) then
+          ThrowTypeError(Format(SErrorCannotDeletePropertyOf,
+            [SymbolKey.ToDisplayString.Value, '[object Object]']),
+            SSuggestCannotDeleteNonConfigurable);
+      end;
+      Result := TGocciaBooleanLiteralValue.TrueValue;
+    end
     // Handle array element deletion
-    if ObjValue is TGocciaArrayValue then
+    else if ObjValue is TGocciaArrayValue then
     begin
       ArrayValue := TGocciaArrayValue(ObjValue);
       if TryStrToInt(PropertyName, Index) and (Index >= 0) and (Index < ArrayValue.Elements.Count) then

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -5600,7 +5600,16 @@ begin
         // ToPropertyKey on the evaluated expression, dispatch by type.
         PropertyKey := ToPropertyKey(EvaluateExpression(ObjPat.Properties[I].KeyExpression, AContext));
         if PropertyKey is TGocciaSymbolValue then
-          PropValue := (AValue as TGocciaObjectValue).GetSymbolProperty(TGocciaSymbolValue(PropertyKey))
+        begin
+          // TGocciaClassValue.GetSymbolProperty is not virtual, so casting an
+          // AValue that is actually a class to TGocciaObjectValue would skip
+          // the static symbol descriptor table. Dispatch on the concrete type
+          // (mirrors AssignObjectPattern below).
+          if AValue is TGocciaClassValue then
+            PropValue := TGocciaClassValue(AValue).GetSymbolProperty(TGocciaSymbolValue(PropertyKey))
+          else
+            PropValue := (AValue as TGocciaObjectValue).GetSymbolProperty(TGocciaSymbolValue(PropertyKey));
+        end
         else
           PropValue := (AValue as TGocciaObjectValue).GetProperty(TGocciaStringLiteralValue(PropertyKey).Value);
         if not Assigned(PropValue) then

--- a/source/units/Goccia.VM.Exception.pas
+++ b/source/units/Goccia.VM.Exception.pas
@@ -116,27 +116,23 @@ constructor EGocciaBytecodeThrow.Create(const AThrownValue: TGocciaValue);
 var
   MessageText: string;
   ErrorObject: TGocciaObjectValue;
-  NameValue: TGocciaValue;
-  DetailValue: TGocciaValue;
+  NameValue, DetailValue: TGocciaValue;
 begin
+  // Pascal-side Exception.Message — consulted only when no higher-level
+  // formatter handles the throw. Built from primitive `name`/`message`
+  // properties when available, otherwise a static placeholder. Never invoke
+  // user toString()/valueOf() here: exceptions that JS later catches must
+  // not observe stringification (ES2026 §14.14 ThrowStatement).
   MessageText := 'Goccia VM throw';
-  if Assigned(AThrownValue) then
+  if Assigned(AThrownValue) and (AThrownValue is TGocciaObjectValue) then
   begin
-    if AThrownValue is TGocciaObjectValue then
-    begin
-      ErrorObject := TGocciaObjectValue(AThrownValue);
-      NameValue := ErrorObject.GetProperty(PROP_NAME);
-      DetailValue := ErrorObject.GetProperty(PROP_MESSAGE);
-      if Assigned(NameValue) and Assigned(DetailValue) and
-         not (NameValue is TGocciaUndefinedLiteralValue) and
-         not (DetailValue is TGocciaUndefinedLiteralValue) then
-        MessageText := NameValue.ToStringLiteral.Value + ': ' +
-          DetailValue.ToStringLiteral.Value
-      else
-        MessageText := AThrownValue.ToStringLiteral.Value;
-    end
-    else
-      MessageText := AThrownValue.ToStringLiteral.Value;
+    ErrorObject := TGocciaObjectValue(AThrownValue);
+    NameValue := ErrorObject.GetProperty(PROP_NAME);
+    DetailValue := ErrorObject.GetProperty(PROP_MESSAGE);
+    if (NameValue is TGocciaStringLiteralValue) and
+       (DetailValue is TGocciaStringLiteralValue) then
+      MessageText := TGocciaStringLiteralValue(NameValue).Value + ': ' +
+        TGocciaStringLiteralValue(DetailValue).Value;
   end;
   inherited Create(MessageText);
   FThrownValue := AThrownValue;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -8240,11 +8240,19 @@ begin
            (FRegisters[C].Kind = grkObject) and
            (FRegisters[C].ObjectValue is TGocciaSymbolValue) then
         begin
+          // ES2026 §13.5.1.2 step 5.b: a non-configurable symbol property
+          // throws TypeError on delete (mirrors EvaluateDelete's symbol path
+          // in the interpreter). Pre-refactor the bytecode threw via the
+          // symbol-stringification side effect; the spec-correct path keeps
+          // that throw.
           if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteSymbolProperty(
             TGocciaSymbolValue(FRegisters[C].ObjectValue)) then
             FRegisters[A] := RegisterBoolean(True)
           else
-            FRegisters[A] := RegisterBoolean(False);
+            ThrowTypeError(Format(SErrorCannotDeletePropertyOf,
+              [TGocciaSymbolValue(FRegisters[C].ObjectValue).ToDisplayString.Value,
+               '[object Object]']),
+              SSuggestCannotDeleteNonConfigurable);
         end
         else if (FRegisters[B].Kind = grkObject) and
            (FRegisters[B].ObjectValue is TGocciaArrayValue) then

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -8231,7 +8231,22 @@ begin
 
       OP_DEL_INDEX:
       begin
+        // ES2026 §7.1.19 ToPropertyKey — symbol keys must delete from symbol
+        // storage regardless of whether the receiver is an array or plain
+        // object. Check this before the array-numeric-index branch so that
+        // `delete arr[sym]` doesn't silently no-op via the array fall-through.
         if (FRegisters[B].Kind = grkObject) and
+           (FRegisters[B].ObjectValue is TGocciaObjectValue) and
+           (FRegisters[C].Kind = grkObject) and
+           (FRegisters[C].ObjectValue is TGocciaSymbolValue) then
+        begin
+          if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteSymbolProperty(
+            TGocciaSymbolValue(FRegisters[C].ObjectValue)) then
+            FRegisters[A] := RegisterBoolean(True)
+          else
+            FRegisters[A] := RegisterBoolean(False);
+        end
+        else if (FRegisters[B].Kind = grkObject) and
            (FRegisters[B].ObjectValue is TGocciaArrayValue) then
         begin
           if TryGetArrayIndexRegister(FRegisters[C], KeyIndex) and
@@ -8248,17 +8263,7 @@ begin
         else if (FRegisters[B].Kind = grkObject) and
                 (FRegisters[B].ObjectValue is TGocciaObjectValue) then
         begin
-          // ES2026 §7.1.19 ToPropertyKey: symbol keys delete from symbol storage.
-          if (FRegisters[C].Kind = grkObject) and
-             (FRegisters[C].ObjectValue is TGocciaSymbolValue) then
-          begin
-            if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteSymbolProperty(
-              TGocciaSymbolValue(FRegisters[C].ObjectValue)) then
-              FRegisters[A] := RegisterBoolean(True)
-            else
-              FRegisters[A] := RegisterBoolean(False);
-          end
-          else if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteProperty(
+          if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteProperty(
             KeyToPropertyNameRegister(FRegisters[C])) then
             FRegisters[A] := RegisterBoolean(True)
           else

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -525,26 +525,7 @@ begin
   end;
 end;
 
-function VMToECMAStringFast(const AValue: TGocciaValue): TGocciaStringLiteralValue; inline;
-var
-  PrimitiveValue: TGocciaValue;
-begin
-  if AValue is TGocciaStringLiteralValue then
-    Exit(TGocciaStringLiteralValue(AValue));
-
-  if AValue is TGocciaSymbolValue then
-    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
-
-  if AValue.IsPrimitive then
-    Exit(AValue.ToStringLiteral);
-
-  PrimitiveValue := ToPrimitive(AValue, tphString);
-  if PrimitiveValue is TGocciaSymbolValue then
-    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
-  Result := PrimitiveValue.ToStringLiteral;
-end;
-
-function VMRegisterToECMAStringFast(
+function VMRegisterToStringFast(
   const AValue: TGocciaRegister): TGocciaStringLiteralValue; inline;
 begin
   case AValue.Kind of
@@ -565,12 +546,11 @@ begin
       Exit(RegisterToValue(AValue).ToStringLiteral);
     grkObject:
       begin
-        if AValue.ObjectValue is TGocciaStringLiteralValue then
-          Exit(TGocciaStringLiteralValue(AValue.ObjectValue));
-        if AValue.ObjectValue is TGocciaSymbolValue then
-          ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
         if Assigned(AValue.ObjectValue) then
-          Exit(VMToECMAStringFast(AValue.ObjectValue));
+          // Spec ToString — for objects, dispatches through
+          // TGocciaObjectValue.ToStringLiteral which performs ToPrimitive(string)
+          // and may invoke user toString()/valueOf().
+          Exit(AValue.ObjectValue.ToStringLiteral);
       end;
   end;
   Result := TGocciaStringLiteralValue.Create('');
@@ -4053,10 +4033,10 @@ begin
     grkInt:
       Result := IntToStr(AKey.IntValue);
     grkFloat:
-      Result := VMRegisterToECMAStringFast(AKey).Value;
+      Result := VMRegisterToStringFast(AKey).Value;
     grkObject:
       if Assigned(AKey.ObjectValue) then
-        Result := VMRegisterToECMAStringFast(AKey).Value
+        Result := VMRegisterToStringFast(AKey).Value
       else
         Result := '';
   else
@@ -7260,8 +7240,8 @@ begin
             TGocciaStringLiteralValue(FRegisters[C].ObjectValue).Value))
         else
           SetRegisterFast(A, TGocciaStringLiteralValue.Create(
-            VMRegisterToECMAStringFast(FRegisters[B]).Value +
-            VMRegisterToECMAStringFast(FRegisters[C]).Value));
+            VMRegisterToStringFast(FRegisters[B]).Value +
+            VMRegisterToStringFast(FRegisters[C]).Value));
       end;
 
       OP_NEW_ARRAY:
@@ -7850,8 +7830,8 @@ begin
                       Assigned(FRegisters[C].ObjectValue) and
                       (not FRegisters[C].ObjectValue.IsPrimitive))) then
           SetRegisterFast(A, TGocciaStringLiteralValue.Create(
-            VMRegisterToECMAStringFast(FRegisters[B]).Value +
-            VMRegisterToECMAStringFast(FRegisters[C]).Value))
+            VMRegisterToStringFast(FRegisters[B]).Value +
+            VMRegisterToStringFast(FRegisters[C]).Value))
         else
         begin
           LeftValue := GetRegisterFast(B);
@@ -8247,7 +8227,7 @@ begin
         end;
 
       OP_TO_STRING:
-        SetRegisterFast(A, VMRegisterToECMAStringFast(FRegisters[B]));
+        SetRegisterFast(A, VMRegisterToStringFast(FRegisters[B]));
 
       OP_DEL_INDEX:
       begin
@@ -8268,7 +8248,17 @@ begin
         else if (FRegisters[B].Kind = grkObject) and
                 (FRegisters[B].ObjectValue is TGocciaObjectValue) then
         begin
-          if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteProperty(
+          // ES2026 §7.1.19 ToPropertyKey: symbol keys delete from symbol storage.
+          if (FRegisters[C].Kind = grkObject) and
+             (FRegisters[C].ObjectValue is TGocciaSymbolValue) then
+          begin
+            if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteSymbolProperty(
+              TGocciaSymbolValue(FRegisters[C].ObjectValue)) then
+              FRegisters[A] := RegisterBoolean(True)
+            else
+              FRegisters[A] := RegisterBoolean(False);
+          end
+          else if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteProperty(
             KeyToPropertyNameRegister(FRegisters[C])) then
             FRegisters[A] := RegisterBoolean(True)
           else
@@ -8825,11 +8815,11 @@ begin
           try
             if Assigned(Template.DebugInfo) and (Template.DebugInfo.SourceFile <> '') then
               DynImportPromise.Resolve(ImportModuleValue(
-                VMRegisterToECMAStringFast(FRegisters[B]).Value,
+                VMRegisterToStringFast(FRegisters[B]).Value,
                 Template.DebugInfo.SourceFile))
             else
               DynImportPromise.Resolve(ImportModuleValue(
-                VMRegisterToECMAStringFast(FRegisters[B]).Value,
+                VMRegisterToStringFast(FRegisters[B]).Value,
                 FCurrentModuleSourcePath));
           except
             on E: EGocciaBytecodeThrow do

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -1201,7 +1201,7 @@ begin
       Continue
     else
       // ES2026 §23.1.3.16 step 7c: Let next be ? ToString(element)
-      ResultString := ResultString + ToECMAString(Element).Value;
+      ResultString := ResultString + Element.ToStringLiteral.Value;
   end;
 
   // Step 9: Return R

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -270,7 +270,6 @@ type
       const APropertyCapacity: Integer = 0);
     destructor Destroy; override;
     function TypeName: string; override;
-    function ToStringLiteral: TGocciaStringLiteralValue; override;
     function GetProperty(const AName: string): TGocciaValue; override;
     function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     procedure AssignProperty(const AName: string; const AValue: TGocciaValue; const ACanCreate: Boolean = True); override;
@@ -313,6 +312,7 @@ uses
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.TextDecoderValue,
   Goccia.Values.TextEncoderValue,
+  Goccia.Values.ToPrimitive,
   Goccia.Values.URLSearchParamsValue,
   Goccia.Values.URLValue,
   Goccia.Values.WeakMapValue,
@@ -1618,14 +1618,6 @@ begin
     Result := FClass.Name
   else
     Result := CONSTRUCTOR_OBJECT;
-end;
-
-function TGocciaInstanceValue.ToStringLiteral: TGocciaStringLiteralValue;
-begin
-  if Assigned(FClass) then
-    Result := TGocciaStringLiteralValue.Create(Format('[Instance of %s]', [FClass.Name]))
-  else
-    Result := TGocciaStringLiteralValue.Create('[object Object]');
 end;
 
 function TGocciaInstanceValue.GetProperty(const AName: string): TGocciaValue;

--- a/source/units/Goccia.Values.FunctionValue.Test.pas
+++ b/source/units/Goccia.Values.FunctionValue.Test.pas
@@ -13,6 +13,8 @@ uses
   Goccia.AST.Expressions,
   Goccia.AST.Node,
   Goccia.AST.Statements,
+  Goccia.Constants.ErrorNames,
+  Goccia.Constants.PropertyNames,
   Goccia.ControlFlow,
   Goccia.Evaluator,
   Goccia.Evaluator.Context,
@@ -85,6 +87,8 @@ type
     ReturnValue: TGocciaValue;
     Args: TGocciaArgumentsCollection;
     ToStringThrew: Boolean;
+    ThrownNameValue: TGocciaValue;
+    ThrownTypeName: string;
   begin
     Scope := TGocciaGlobalScope.Create;
     Parameters := TStringList.Create;
@@ -98,15 +102,26 @@ type
     // (no engine init in this Pascal test) throws TypeError because neither
     // toString() nor valueOf() can be located through the prototype chain.
     // Real engine functions inherit Function.prototype.toString and stringify
-    // to "function name() { ... }".
+    // to "function name() { ... }". Verify both that the throw fires AND that
+    // the JS-level error name is "TypeError" — any other thrown error class
+    // would be a real bug (a different exception masking the spec one).
     ToStringThrew := False;
+    ThrownTypeName := '';
     try
       FunctionValue.ToStringLiteral;
     except
-      on TGocciaThrowValue do
+      on E: TGocciaThrowValue do
+      begin
         ToStringThrew := True;
+        ThrownNameValue := nil;
+        if E.Value is TGocciaObjectValue then
+          ThrownNameValue := TGocciaObjectValue(E.Value).GetProperty(PROP_NAME);
+        if (ThrownNameValue is TGocciaStringLiteralValue) then
+          ThrownTypeName := TGocciaStringLiteralValue(ThrownNameValue).Value;
+      end;
     end;
     Expect<Boolean>(ToStringThrew).ToBe(True);
+    Expect<string>(ThrownTypeName).ToBe(TYPE_ERROR_NAME);
 
     Expect<Boolean>(FunctionValue.ToNumberLiteral.IsNaN).ToBe(True);
     Expect<string>(FunctionValue.TypeName).ToBe('function');

--- a/source/units/Goccia.Values.FunctionValue.Test.pas
+++ b/source/units/Goccia.Values.FunctionValue.Test.pas
@@ -19,6 +19,7 @@ uses
   Goccia.Scope,
   Goccia.TestSetup,
   Goccia.Token,
+  Goccia.Values.Error,
   Goccia.Values.FunctionValue,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
@@ -83,6 +84,7 @@ type
     Parameters: TStringList;
     ReturnValue: TGocciaValue;
     Args: TGocciaArgumentsCollection;
+    ToStringThrew: Boolean;
   begin
     Scope := TGocciaGlobalScope.Create;
     Parameters := TStringList.Create;
@@ -91,7 +93,21 @@ type
 
     // Test basic function properties
     Expect<Boolean>(FunctionValue.ToBooleanLiteral.Value).ToBe(True);
-    Expect<string>(FunctionValue.ToStringLiteral.Value).ToBe('[function Object]');
+
+    // ES2026 §7.1.17 ToString on a function fixture without Function.prototype
+    // (no engine init in this Pascal test) throws TypeError because neither
+    // toString() nor valueOf() can be located through the prototype chain.
+    // Real engine functions inherit Function.prototype.toString and stringify
+    // to "function name() { ... }".
+    ToStringThrew := False;
+    try
+      FunctionValue.ToStringLiteral;
+    except
+      on TGocciaThrowValue do
+        ToStringThrew := True;
+    end;
+    Expect<Boolean>(ToStringThrew).ToBe(True);
+
     Expect<Boolean>(FunctionValue.ToNumberLiteral.IsNaN).ToBe(True);
     Expect<string>(FunctionValue.TypeName).ToBe('function');
 

--- a/source/units/Goccia.Values.ObjectValue.Test.pas
+++ b/source/units/Goccia.Values.ObjectValue.Test.pas
@@ -9,6 +9,7 @@ uses
 
   Goccia.Error,
   Goccia.TestSetup,
+  Goccia.Values.Error,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
@@ -81,12 +82,14 @@ begin
   // (no prototype assigned in this test fixture) throws TypeError because
   // neither toString() nor valueOf() can be located. This exercises the spec
   // path through ToPrimitive(string). Real engine objects always inherit
-  // Object.prototype and therefore stringify successfully.
+  // Object.prototype and therefore stringify successfully. Catch only
+  // TGocciaThrowValue (the JS-level TypeError) — any other exception class
+  // indicates a real bug and must propagate.
   ToStringThrew := False;
   try
     ObjectValue.ToStringLiteral;
   except
-    on E: Exception do
+    on TGocciaThrowValue do
       ToStringThrew := True;
   end;
   Expect<Boolean>(ToStringThrew).ToBe(True);

--- a/source/units/Goccia.Values.ObjectValue.Test.pas
+++ b/source/units/Goccia.Values.ObjectValue.Test.pas
@@ -7,6 +7,8 @@ uses
 
   TestingPascalLibrary,
 
+  Goccia.Constants.ErrorNames,
+  Goccia.Constants.PropertyNames,
   Goccia.Error,
   Goccia.TestSetup,
   Goccia.Values.Error,
@@ -66,6 +68,8 @@ var
   ObjectValue: TGocciaObjectValue;
   DebugString: string;
   ToStringThrew: Boolean;
+  ThrownNameValue: TGocciaValue;
+  ThrownTypeName: string;
 begin
   ObjectValue := SimpleObject;
   DebugString := ObjectValue.ToDebugString;
@@ -82,17 +86,26 @@ begin
   // (no prototype assigned in this test fixture) throws TypeError because
   // neither toString() nor valueOf() can be located. This exercises the spec
   // path through ToPrimitive(string). Real engine objects always inherit
-  // Object.prototype and therefore stringify successfully. Catch only
-  // TGocciaThrowValue (the JS-level TypeError) — any other exception class
-  // indicates a real bug and must propagate.
+  // Object.prototype and therefore stringify successfully. Verify both that
+  // the throw fires AND that the JS-level error name is "TypeError" — any
+  // other thrown error class would be a real bug masking the spec one.
   ToStringThrew := False;
+  ThrownTypeName := '';
   try
     ObjectValue.ToStringLiteral;
   except
-    on TGocciaThrowValue do
+    on E: TGocciaThrowValue do
+    begin
       ToStringThrew := True;
+      ThrownNameValue := nil;
+      if E.Value is TGocciaObjectValue then
+        ThrownNameValue := TGocciaObjectValue(E.Value).GetProperty(PROP_NAME);
+      if ThrownNameValue is TGocciaStringLiteralValue then
+        ThrownTypeName := TGocciaStringLiteralValue(ThrownNameValue).Value;
+    end;
   end;
   Expect<Boolean>(ToStringThrew).ToBe(True);
+  Expect<string>(ThrownTypeName).ToBe(TYPE_ERROR_NAME);
 
   Expect<Boolean>(ObjectValue.ToBooleanLiteral.Value).ToBe(True);
   Expect<Boolean>(ObjectValue.ToNumberLiteral.IsNaN).ToBe(True);

--- a/source/units/Goccia.Values.ObjectValue.Test.pas
+++ b/source/units/Goccia.Values.ObjectValue.Test.pas
@@ -3,8 +3,11 @@ program Goccia.Values.ObjectValue.Test;
 {$I Goccia.inc}
 
 uses
+  SysUtils,
+
   TestingPascalLibrary,
 
+  Goccia.Error,
   Goccia.TestSetup,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
@@ -61,6 +64,7 @@ procedure TTestObjectValue.TestCasting;
 var
   ObjectValue: TGocciaObjectValue;
   DebugString: string;
+  ToStringThrew: Boolean;
 begin
   ObjectValue := SimpleObject;
   DebugString := ObjectValue.ToDebugString;
@@ -72,7 +76,21 @@ begin
   Expect<Boolean>(ContainsFragment(DebugString, 'city: Anytown')).ToBe(True);
   Expect<Boolean>(ContainsFragment(DebugString, 'state: CA')).ToBe(True);
   Expect<Boolean>(ContainsFragment(DebugString, 'zip: 12345')).ToBe(True);
-  Expect<string>(ObjectValue.ToStringLiteral.Value).ToBe('[object Object]');
+
+  // ES2026 §7.1.17 ToString on an object without Object.prototype.toString
+  // (no prototype assigned in this test fixture) throws TypeError because
+  // neither toString() nor valueOf() can be located. This exercises the spec
+  // path through ToPrimitive(string). Real engine objects always inherit
+  // Object.prototype and therefore stringify successfully.
+  ToStringThrew := False;
+  try
+    ObjectValue.ToStringLiteral;
+  except
+    on E: Exception do
+      ToStringThrew := True;
+  end;
+  Expect<Boolean>(ToStringThrew).ToBe(True);
+
   Expect<Boolean>(ObjectValue.ToBooleanLiteral.Value).ToBe(True);
   Expect<Boolean>(ObjectValue.ToNumberLiteral.IsNaN).ToBe(True);
   Expect<string>(ObjectValue.TypeName).ToBe('object');

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -1346,6 +1346,7 @@ end;
 procedure TGocciaObjectValue.Freeze;
 var
   Pair: TGocciaPropertyMap.TKeyValuePair;
+  SymPair: TSymbolDescriptorMap.TKeyValuePair;
   Descriptor: TGocciaPropertyDescriptor;
   NewDescriptor: TGocciaPropertyDescriptor;
 begin
@@ -1377,6 +1378,36 @@ begin
       Descriptor.Free;
     end;
   end;
+  // ES2026 §7.3.15 SetIntegrityLevel must apply to symbol-keyed properties
+  // too — same pattern as Seal above.
+  for SymPair in FSymbolDescriptors do
+  begin
+    Descriptor := SymPair.Value;
+    if Descriptor is TGocciaPropertyDescriptorData then
+    begin
+      if Descriptor.Enumerable then
+        NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, [pfEnumerable])
+      else
+        NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, []);
+      FSymbolDescriptors.AddOrSetValue(SymPair.Key, NewDescriptor);
+      Descriptor.Free;
+    end
+    else if Descriptor is TGocciaPropertyDescriptorAccessor then
+    begin
+      if Descriptor.Enumerable then
+        NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
+          TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
+          TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
+          [pfEnumerable])
+      else
+        NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
+          TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
+          TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
+          []);
+      FSymbolDescriptors.AddOrSetValue(SymPair.Key, NewDescriptor);
+      Descriptor.Free;
+    end;
+  end;
   FFrozen := True;
   FSealed := True;
   FExtensible := False;
@@ -1385,6 +1416,7 @@ end;
 procedure TGocciaObjectValue.Seal;
 var
   Pair: TGocciaPropertyMap.TKeyValuePair;
+  SymPair: TSymbolDescriptorMap.TKeyValuePair;
   Descriptor: TGocciaPropertyDescriptor;
   NewDescriptor: TGocciaPropertyDescriptor;
   Flags: TPropertyFlags;
@@ -1410,6 +1442,33 @@ begin
         TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
         Flags);
       FProperties.Add(Pair.Key, NewDescriptor);
+      Descriptor.Free;
+    end;
+  end;
+  // ES2026 §7.3.15 SetIntegrityLevel must apply to symbol-keyed properties
+  // too — they live in a separate descriptor table in Goccia but are still
+  // own properties of O, so seal/freeze must clear pfConfigurable here.
+  for SymPair in FSymbolDescriptors do
+  begin
+    Descriptor := SymPair.Value;
+    Flags := [];
+    if Descriptor.Enumerable then
+      Include(Flags, pfEnumerable);
+    if Descriptor is TGocciaPropertyDescriptorData then
+    begin
+      if Descriptor.Writable then
+        Include(Flags, pfWritable);
+      NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, Flags);
+      FSymbolDescriptors.AddOrSetValue(SymPair.Key, NewDescriptor);
+      Descriptor.Free;
+    end
+    else if Descriptor is TGocciaPropertyDescriptorAccessor then
+    begin
+      NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
+        TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
+        TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
+        Flags);
+      FSymbolDescriptors.AddOrSetValue(SymPair.Key, NewDescriptor);
       Descriptor.Free;
     end;
   end;

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -124,7 +124,8 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.FunctionValue,
-  Goccia.Values.NativeFunction;
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ToPrimitive;
 
 // Object.prototype lives in a per-realm slot.  See Goccia.Realm and the
 // matching pattern in Goccia.Values.ArrayValue for the rationale; the method
@@ -474,9 +475,20 @@ begin
   Result := CONSTRUCTOR_OBJECT;
 end;
 
+// ES2026 §7.1.17 ToString. For an object: ToPrimitive(O, string) → ToString
+// of the resulting primitive. May invoke user-defined toString()/valueOf()
+// and may throw. Callers that cannot tolerate user re-entry must use
+// SafeToString from Goccia.Values.ToPrimitive instead.
 function TGocciaObjectValue.ToStringLiteral: TGocciaStringLiteralValue;
+var
+  Prim: TGocciaValue;
 begin
-  Result := TGocciaStringLiteralValue.Create(Format('[%s %s]', [TypeName, ToStringTag]));
+  Prim := ToPrimitive(Self, tphString);
+  if Prim is TGocciaSymbolValue then
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
+  // Prim is a primitive at this point — its ToStringLiteral cannot recurse
+  // into user code.
+  Result := Prim.ToStringLiteral;
 end;
 
 function TGocciaObjectValue.ToBooleanLiteral: TGocciaBooleanLiteralValue;

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -1009,30 +1009,38 @@ var
   MatchArray: TGocciaObjectValue;
   MatchIndex, MatchEnd, NextIndex, Offset: Integer;
 begin
-  // Step 1: Let O be RequireObjectCoercible(this value)
-  // Step 2: Let string be ToString(O)
-  StringValue := ExtractStringValue(AThisValue);
+  // ES2026 §22.1.3.19 String.prototype.replace:
+  //   1. Let O be ? RequireObjectCoercible(this value).
+  //   2. If searchValue is neither undefined nor null:
+  //      c. Let replacer be ? GetMethod(searchValue, @@replace).
+  //      d. If replacer is not undefined: return ? Call(replacer, searchValue, « O, replaceValue »).
+  //   3. Let string be ? ToString(O).
+  // Step 1 — RequireObjectCoercible: throw if `this` is null/undefined.
+  if (AThisValue is TGocciaUndefinedLiteralValue) or
+     (AThisValue is TGocciaNullLiteralValue) then
+    ThrowTypeError(SErrorStringPrototypeRequiresNonNullish, SSuggestCheckNullBeforeAccess);
 
-  // Step 3: Let searchString be ToString(searchValue)
   if AArgs.Length > 0 then
     SearchArg := AArgs.GetElement(0)
   else
     SearchArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  // Step 4: Let replaceValue (or functionalReplace if callable)
   if AArgs.Length > 1 then
     ReplaceArg := AArgs.GetElement(1)
   else
     ReplaceArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
+  // Step 2.c-d: dispatch to @@replace before doing any ToString on O —
+  // matches the StringReplaceAllMethod fix above.
   ReplaceMethod := GetMethodBySymbol(SearchArg,
     TGocciaSymbolValue.WellKnownReplace);
   if not (ReplaceMethod is TGocciaUndefinedLiteralValue) then
   begin
     if not ReplaceMethod.IsCallable then
       ThrowTypeError(SErrorSymbolReplaceNotCallable, SSuggestWellKnownSymbolCallable);
+    // Spec passes O through to the replacer — not a stringified copy.
     CallArgs := TGocciaArgumentsCollection.Create([
-      TGocciaStringLiteralValue.Create(StringValue),
+      AThisValue,
       ReplaceArg
     ]);
     try
@@ -1042,6 +1050,9 @@ begin
     end;
     Exit;
   end;
+
+  // Step 3: Let string be ? ToString(O).
+  StringValue := ExtractStringValue(AThisValue);
 
   if IsRegExpValue(SearchArg) then
   begin

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -527,6 +527,15 @@ function TGocciaStringObjectValue.StringLength(const AArgs: TGocciaArgumentsColl
 var
   StringValue: string;
 begin
+  // ES2026 §22.1.4 String.prototype is itself a String exotic object whose
+  // [[StringData]] is the empty String. Short-circuit to 0 here so the
+  // accessor returns spec-correct length without recursing through
+  // ExtractStringValue → ToStringLiteral → String.prototype.toString →
+  // ExtractStringValue → ... (Goccia's String.prototype is a plain
+  // TGocciaObjectValue, not a String wrapper, so ExtractStringValue would
+  // fall through to ToString which triggers the recursion).
+  if AThisValue = GetSharedStringPrototype then
+    Exit(TGocciaNumberLiteralValue.ZeroValue);
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
   StringValue := ExtractStringValue(AThisValue);
@@ -1140,21 +1149,27 @@ var
   MatchIndex, MatchEnd, NextIndex: Integer;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
-  // Step 2: Let string be ToString(O)
-  StringValue := ExtractStringValue(AThisValue);
+  if (AThisValue is TGocciaUndefinedLiteralValue) or
+     (AThisValue is TGocciaNullLiteralValue) then
+    ThrowTypeError(SErrorStringPrototypeRequiresNonNullish, SSuggestCheckNullBeforeAccess);
 
-  // Step 3: Let searchString be ToString(searchValue)
   if AArgs.Length > 0 then
     SearchArg := AArgs.GetElement(0)
   else
     SearchArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  // Step 4: Let replaceValue (or functionalReplace if callable)
   if AArgs.Length > 1 then
     ReplaceArg := AArgs.GetElement(1)
   else
     ReplaceArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
+  // Step 2 (spec): If searchValue is neither undefined nor null, invoke
+  // GetMethod(searchValue, @@replace) and dispatch through it BEFORE doing
+  // any ToString on `O` or the args. ES2026 §22.1.3.20 step 2.a.iii: the
+  // RegExp-flags global check uses Get + ToString on searchValue.flags
+  // only when searchValue is itself a RegExp; for arbitrary user-supplied
+  // searchValues with @@replace, the replacer call is the only observable
+  // side effect.
   if IsRegExpValue(SearchArg) and
      not GetRegExpBooleanProperty(TGocciaObjectValue(SearchArg), PROP_GLOBAL) then
     ThrowTypeError(SErrorReplaceAllRequiresGlobalRegExp, SSuggestReplaceAllGlobalFlag);
@@ -1165,8 +1180,11 @@ begin
   begin
     if not ReplaceMethod.IsCallable then
       ThrowTypeError(SErrorSymbolReplaceNotCallable, SSuggestWellKnownSymbolCallable);
+    // ES2026 §22.1.3.20 step 2.d.i: Call(replacer, searchValue, « O, replaceValue »).
+    // The replacer receives the original `this` (O), not a stringified copy —
+    // ToString(O) only happens in step 3 if there is no @@replace replacer.
     CallArgs := TGocciaArgumentsCollection.Create([
-      TGocciaStringLiteralValue.Create(StringValue),
+      AThisValue,
       ReplaceArg
     ]);
     try
@@ -1176,6 +1194,9 @@ begin
     end;
     Exit;
   end;
+
+  // Step 3 (spec): Let string be ? ToString(O)
+  StringValue := ExtractStringValue(AThisValue);
 
   if IsRegExpValue(SearchArg) then
   begin

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -1374,12 +1374,15 @@ var
   MatchIndex, MatchEnd, NextIndex: Integer;
   PreviousIndex, SearchIndex: Integer;
 begin
-  // Step 1: Let O be RequireObjectCoercible(this value)
-  // Step 2: Let S be ToString(O)
-  StringValue := ExtractStringValue(AThisValue);
+  // ES2026 §22.1.3.23 String.prototype.split:
+  //   1. RequireObjectCoercible(this).
+  //   2. If separator is non-null/undefined, GetMethod(separator, @@split)
+  //      and dispatch through it BEFORE any ToString on O.
+  //   3. ToString(O); fall back to the regular path.
+  if (AThisValue is TGocciaUndefinedLiteralValue) or
+     (AThisValue is TGocciaNullLiteralValue) then
+    ThrowTypeError(SErrorStringPrototypeRequiresNonNullish, SSuggestCheckNullBeforeAccess);
 
-  // Step 3: Let A be ArrayCreate(0)
-  // Step 4: Let sep be ToString(separator)
   if AArgs.Length > 0 then
     SeparatorArg := AArgs.GetElement(0)
   else
@@ -1406,14 +1409,15 @@ begin
     begin
       if not SplitMethod.IsCallable then
         ThrowTypeError(SErrorSymbolSplitNotCallable, SSuggestWellKnownSymbolCallable);
+      // Spec passes O directly to the @@split callable, not a stringified copy.
       if HasLimit then
         CallArgs := TGocciaArgumentsCollection.Create([
-          TGocciaStringLiteralValue.Create(StringValue),
+          AThisValue,
           AArgs.GetElement(1)
         ])
       else
         CallArgs := TGocciaArgumentsCollection.Create([
-          TGocciaStringLiteralValue.Create(StringValue)
+          AThisValue
         ]);
       try
         Result := InvokeCallable(SplitMethod, CallArgs, SeparatorArg);
@@ -1422,6 +1426,9 @@ begin
       end;
       Exit;
     end;
+
+    // Step 3 (spec): Let S be ? ToString(O). Only reached when no @@split.
+    StringValue := ExtractStringValue(AThisValue);
 
     if IsRegExpValue(SeparatorArg) then
     begin
@@ -1540,7 +1547,15 @@ var
   ResultArray: TGocciaArrayValue;
   MatchIndex, MatchEnd, NextIndex, SearchIndex: Integer;
 begin
-  StringValue := ExtractStringValue(AThisValue);
+  // ES2026 §22.1.3.15 String.prototype.match:
+  //   1. RequireObjectCoercible(this).
+  //   2. If regexp is non-null/undefined, GetMethod(regexp, @@match) and
+  //      dispatch through it BEFORE any ToString on O.
+  //   3. ToString(O); fall back to RegExp coercion.
+  if (AThisValue is TGocciaUndefinedLiteralValue) or
+     (AThisValue is TGocciaNullLiteralValue) then
+    ThrowTypeError(SErrorStringPrototypeRequiresNonNullish, SSuggestCheckNullBeforeAccess);
+
   if AArgs.Length > 0 then
   begin
     MatchMethod := GetMethodBySymbol(AArgs.GetElement(0),
@@ -1549,8 +1564,9 @@ begin
     begin
       if not MatchMethod.IsCallable then
         ThrowTypeError(SErrorSymbolMatchNotCallable, SSuggestWellKnownSymbolCallable);
+      // Spec passes O directly to the @@match callable, not a stringified copy.
       CallArgs := TGocciaArgumentsCollection.Create([
-        TGocciaStringLiteralValue.Create(StringValue)
+        AThisValue
       ]);
       try
         Result := InvokeCallable(MatchMethod, CallArgs, AArgs.GetElement(0));
@@ -1560,6 +1576,9 @@ begin
       Exit;
     end;
   end;
+
+  // Step 3 (spec): Let S be ? ToString(O). Only reached when no @@match.
+  StringValue := ExtractStringValue(AThisValue);
 
   if AArgs.Length > 0 then
     RegexValue := CoerceRegExpValue(AArgs.GetElement(0))
@@ -1609,7 +1628,16 @@ var
   CallArgs: TGocciaArgumentsCollection;
   RegexValue: TGocciaObjectValue;
 begin
-  StringValue := ExtractStringValue(AThisValue);
+  // ES2026 §22.1.3.16 String.prototype.matchAll:
+  //   1. RequireObjectCoercible(this).
+  //   2. If regexp is non-null/undefined and is a RegExp, validate global flag.
+  //   3. GetMethod(regexp, @@matchAll); if defined, dispatch through it
+  //      BEFORE any ToString on O.
+  //   4. ToString(O); fall back to RegExp coercion.
+  if (AThisValue is TGocciaUndefinedLiteralValue) or
+     (AThisValue is TGocciaNullLiteralValue) then
+    ThrowTypeError(SErrorStringPrototypeRequiresNonNullish, SSuggestCheckNullBeforeAccess);
+
   if (AArgs.Length > 0) and IsRegExpValue(AArgs.GetElement(0)) and
      not GetRegExpBooleanProperty(TGocciaObjectValue(AArgs.GetElement(0)),
        PROP_GLOBAL) then
@@ -1623,8 +1651,9 @@ begin
     begin
       if not MatchAllMethod.IsCallable then
         ThrowTypeError(SErrorSymbolMatchAllNotCallable, SSuggestWellKnownSymbolCallable);
+      // Spec passes O directly to the @@matchAll callable, not a stringified copy.
       CallArgs := TGocciaArgumentsCollection.Create([
-        TGocciaStringLiteralValue.Create(StringValue)
+        AThisValue
       ]);
       try
         Result := InvokeCallable(MatchAllMethod, CallArgs, AArgs.GetElement(0));
@@ -1634,6 +1663,9 @@ begin
       Exit;
     end;
   end;
+
+  // Step 4 (spec): Let S be ? ToString(O). Only reached when no @@matchAll.
+  StringValue := ExtractStringValue(AThisValue);
 
   if AArgs.Length > 0 then
     RegexValue := CoerceRegExpValue(AArgs.GetElement(0), 'g')
@@ -1654,7 +1686,15 @@ var
   MatchArray: TGocciaObjectValue;
   MatchIndex, MatchEnd, NextIndex: Integer;
 begin
-  StringValue := ExtractStringValue(AThisValue);
+  // ES2026 §22.1.3.27 String.prototype.search:
+  //   1. RequireObjectCoercible(this).
+  //   2. If regexp is non-null/undefined, GetMethod(regexp, @@search) and
+  //      dispatch through it BEFORE any ToString on O.
+  //   3. ToString(O); fall back to RegExp coercion.
+  if (AThisValue is TGocciaUndefinedLiteralValue) or
+     (AThisValue is TGocciaNullLiteralValue) then
+    ThrowTypeError(SErrorStringPrototypeRequiresNonNullish, SSuggestCheckNullBeforeAccess);
+
   if AArgs.Length > 0 then
   begin
     SearchMethod := GetMethodBySymbol(AArgs.GetElement(0),
@@ -1663,8 +1703,9 @@ begin
     begin
       if not SearchMethod.IsCallable then
         ThrowTypeError(SErrorSymbolSearchNotCallable, SSuggestWellKnownSymbolCallable);
+      // Spec passes O directly to the @@search callable, not a stringified copy.
       CallArgs := TGocciaArgumentsCollection.Create([
-        TGocciaStringLiteralValue.Create(StringValue)
+        AThisValue
       ]);
       try
         Result := InvokeCallable(SearchMethod, CallArgs, AArgs.GetElement(0));
@@ -1674,6 +1715,9 @@ begin
       Exit;
     end;
   end;
+
+  // Step 3 (spec): Let S be ? ToString(O). Only reached when no @@search.
+  StringValue := ExtractStringValue(AThisValue);
 
   if AArgs.Length > 0 then
     RegexValue := CoerceRegExpValue(AArgs.GetElement(0))

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -101,6 +101,7 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.Iterator.Concrete,
   Goccia.Values.Iterator.RegExp,
+  Goccia.Values.ProxyValue,
   Goccia.Values.SymbolValue;
 
 // String.prototype lives in a per-realm slot.  Method host and member
@@ -239,6 +240,8 @@ begin
 end;
 
 function TGocciaStringObjectValue.ExtractStringValue(const AValue: TGocciaValue): string;
+var
+  Unwrapped: TGocciaValue;
 begin
   if (AValue is TGocciaUndefinedLiteralValue) or
      (AValue is TGocciaNullLiteralValue) then
@@ -250,6 +253,25 @@ begin
     Result := TGocciaStringObjectValue(AValue).Primitive.Value
   else if AValue is TGocciaSymbolValue then
     ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion)
+  else if AValue is TGocciaProxyValue then
+  begin
+    // ES2026 String.prototype methods do `Let S be ToString(O)` per
+    // §22.1.3.x. For a Proxy whose [[ProxyTarget]] is (transitively) a
+    // String wrapper, V8/Node read [[StringData]] from the underlying
+    // wrapper. Unwrap the Proxy chain here — falling back to ToStringLiteral
+    // would call user toString through the Proxy get-trap chain, which for
+    // a get:null/empty handler chain forwards back to a String accessor
+    // that re-enters ExtractStringValue → infinite recursion → SIGSEGV.
+    Unwrapped := AValue;
+    while Unwrapped is TGocciaProxyValue do
+      Unwrapped := TGocciaProxyValue(Unwrapped).Target;
+    if Unwrapped is TGocciaStringObjectValue then
+      Result := TGocciaStringObjectValue(Unwrapped).Primitive.Value
+    else if Unwrapped is TGocciaStringLiteralValue then
+      Result := TGocciaStringLiteralValue(Unwrapped).Value
+    else
+      Result := AValue.ToStringLiteral.Value;
+  end
   else
     Result := AValue.ToStringLiteral.Value;
 end;

--- a/source/units/Goccia.Values.ToPrimitive.pas
+++ b/source/units/Goccia.Values.ToPrimitive.pas
@@ -13,8 +13,9 @@ type
 // ES2026 §7.1.1 ToPrimitive(input [, preferredType])
 function ToPrimitive(const AValue: TGocciaValue; const AHint: TGocciaToPrimitiveHint = tphDefault): TGocciaValue;
 
-// ES2026 §7.1.17 ToString(argument)
-function ToECMAString(const AValue: TGocciaValue): TGocciaStringLiteralValue;
+// ES2026 §7.1.19 ToPropertyKey(argument). Symbols are returned as-is; everything
+// else is coerced via ToString. Callers must check the returned type.
+function ToPropertyKey(const AValue: TGocciaValue): TGocciaValue;
 
 implementation
 
@@ -90,30 +91,23 @@ begin
   Result := AValue;
 end;
 
-// ES2026 §7.1.17 ToString(argument) — Symbols cannot be converted to strings
-function ToECMAString(const AValue: TGocciaValue): TGocciaStringLiteralValue;
+// ES2026 §7.1.19 ToPropertyKey(argument). Symbols pass through; non-symbols
+// are coerced via ToPrimitive(string) then ToString. The caller is
+// responsible for dispatching string vs. symbol property storage.
+function ToPropertyKey(const AValue: TGocciaValue): TGocciaValue;
 var
   Prim: TGocciaValue;
 begin
-  if AValue is TGocciaStringLiteralValue then
-  begin
-    Result := TGocciaStringLiteralValue(AValue);
-    Exit;
-  end;
-
-  if AValue is TGocciaSymbolValue then
-    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
-
-  if AValue.IsPrimitive then
-  begin
-    Result := AValue.ToStringLiteral;
-    Exit;
-  end;
-
-  // ES2026 §7.1.17 step 1: ToPrimitive(argument, string)
+  // Step 1: Let key be ? ToPrimitive(argument, string).
   Prim := ToPrimitive(AValue, tphString);
+  // Step 2: If key is a Symbol, return key.
   if Prim is TGocciaSymbolValue then
-    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
+  begin
+    Result := Prim;
+    Exit;
+  end;
+  // Step 3: Return ! ToString(key). Prim is a primitive here, so ToStringLiteral
+  // on it cannot re-enter user code.
   Result := Prim.ToStringLiteral;
 end;
 

--- a/source/units/Goccia.Values.Uint8ArrayEncoding.pas
+++ b/source/units/Goccia.Values.Uint8ArrayEncoding.pas
@@ -120,7 +120,13 @@ begin
     AlphabetVal := TGocciaObjectValue(AOptions).GetProperty(PROP_ALPHABET);
     if Assigned(AlphabetVal) and not (AlphabetVal is TGocciaUndefinedLiteralValue) then
     begin
-      Result := AlphabetVal.ToStringLiteral.Value;
+      // Stage 3 Uint8Array Base64 proposal: `alphabet` must be a String
+      // primitive equal to "base64" or "base64url". The spec does not call
+      // ToString — a String wrapper object (e.g. `Object("base64")`) must be
+      // rejected, not coerced.
+      if not (AlphabetVal is TGocciaStringLiteralValue) then
+        ThrowTypeError(SErrorInvalidAlphabet, SSuggestBase64Format);
+      Result := TGocciaStringLiteralValue(AlphabetVal).Value;
       if (Result <> ALPHABET_BASE64) and (Result <> ALPHABET_BASE64URL) then
         ThrowTypeError(SErrorInvalidAlphabet, SSuggestBase64Format);
     end;
@@ -150,7 +156,12 @@ begin
     Val := TGocciaObjectValue(AOptions).GetProperty(PROP_LAST_CHUNK_HANDLING);
     if Assigned(Val) and not (Val is TGocciaUndefinedLiteralValue) then
     begin
-      Result := Val.ToStringLiteral.Value;
+      // Stage 3 Uint8Array Base64 proposal: `lastChunkHandling` must be a
+      // String primitive equal to "loose"/"strict"/"stop-before-partial".
+      // No ToString coercion — wrapper objects must be rejected.
+      if not (Val is TGocciaStringLiteralValue) then
+        ThrowTypeError(SErrorInvalidLastChunkHandling, SSuggestBase64Format);
+      Result := TGocciaStringLiteralValue(Val).Value;
       if (Result <> LAST_CHUNK_LOOSE) and (Result <> LAST_CHUNK_STRICT) and
          (Result <> LAST_CHUNK_STOP_BEFORE_PARTIAL) then
         ThrowTypeError(SErrorInvalidLastChunkHandling, SSuggestBase64Format);

--- a/tests/built-ins/String/constructor.js
+++ b/tests/built-ins/String/constructor.js
@@ -39,4 +39,49 @@ describe("String constructor", () => {
     expect(typeof s).toBe("object");
     expect(s.valueOf()).toBe("Symbol(x)");
   });
+
+  test("String(obj) invokes user toString() (ES2026 §7.1.17 ToString)", () => {
+    class Foo {
+      toString() { return "via toString"; }
+    }
+    expect(String(new Foo())).toBe("via toString");
+  });
+
+  test("String(obj) prefers toString() over valueOf() (string hint)", () => {
+    const obj = {
+      toString() { return "from toString"; },
+      valueOf() { return "from valueOf"; },
+    };
+    expect(String(obj)).toBe("from toString");
+  });
+
+  test("String(obj) falls back to valueOf() when toString() returns non-primitive", () => {
+    const obj = {
+      toString() { return {}; },
+      valueOf() { return "fallback"; },
+    };
+    expect(String(obj)).toBe("fallback");
+  });
+
+  test("String(obj) throws TypeError when neither method returns a primitive", () => {
+    const obj = {
+      toString() { return {}; },
+      valueOf() { return {}; },
+    };
+    expect(() => String(obj)).toThrow(TypeError);
+  });
+
+  test("new String(obj) invokes user toString() and wraps the result", () => {
+    class Foo {
+      toString() { return "wrapped"; }
+    }
+    const s = new String(new Foo());
+    expect(typeof s).toBe("object");
+    expect(s.valueOf()).toBe("wrapped");
+  });
+
+  test("String(stringWrapper) unwraps via toString()", () => {
+    const wrapped = new String("hi");
+    expect(String(wrapped)).toBe("hi");
+  });
 });

--- a/tests/built-ins/String/prototype/match.js
+++ b/tests/built-ins/String/prototype/match.js
@@ -34,3 +34,30 @@ test("match dispatches through Symbol.match", () => {
 test("match advances by code point for zero-length global unicode matches", () => {
   expect("😀".match(/(?:)/gu)).toEqual(["", ""]);
 });
+
+test("Symbol.match fires before ToString on the receiver (ES2026 §22.1.3.15 step 2)", () => {
+  let poisoned = false;
+  let matcherFired = false;
+  const poison = { toString() { poisoned = true; return ""; } };
+  const matcher = {
+    [Symbol.match]() { matcherFired = true; return null; },
+  };
+  "".match.call(poison, matcher);
+  expect(matcherFired).toBe(true);
+  expect(poisoned).toBe(false);
+});
+
+test("Symbol.match receives O directly, not a stringified copy", () => {
+  const receiver = { tag: "unique-receiver" };
+  let receivedThis;
+  const matcher = {
+    [Symbol.match](o) { receivedThis = o; return null; },
+  };
+  "".match.call(receiver, matcher);
+  expect(receivedThis).toBe(receiver);
+});
+
+test("match throws TypeError when called on null or undefined", () => {
+  expect(() => "".match.call(null, /x/)).toThrow(TypeError);
+  expect(() => "".match.call(undefined, /x/)).toThrow(TypeError);
+});

--- a/tests/built-ins/String/prototype/matchAll.js
+++ b/tests/built-ins/String/prototype/matchAll.js
@@ -122,3 +122,30 @@ test("matchAll iterator does not mutate the original regex", () => {
 
   expect(regex.lastIndex).toBe(2);
 });
+
+test("Symbol.matchAll fires before ToString on the receiver (ES2026 §22.1.3.16 step 3)", () => {
+  let poisoned = false;
+  let matcherFired = false;
+  const poison = { toString() { poisoned = true; return ""; } };
+  const matcher = {
+    [Symbol.matchAll]() { matcherFired = true; return [].values(); },
+  };
+  "".matchAll.call(poison, matcher);
+  expect(matcherFired).toBe(true);
+  expect(poisoned).toBe(false);
+});
+
+test("Symbol.matchAll receives O directly, not a stringified copy", () => {
+  const receiver = { tag: "unique-receiver" };
+  let receivedThis;
+  const matcher = {
+    [Symbol.matchAll](o) { receivedThis = o; return [].values(); },
+  };
+  "".matchAll.call(receiver, matcher);
+  expect(receivedThis).toBe(receiver);
+});
+
+test("matchAll throws TypeError when called on null or undefined", () => {
+  expect(() => "".matchAll.call(null, /x/g)).toThrow(TypeError);
+  expect(() => "".matchAll.call(undefined, /x/g)).toThrow(TypeError);
+});

--- a/tests/built-ins/String/prototype/replace.js
+++ b/tests/built-ins/String/prototype/replace.js
@@ -87,4 +87,34 @@ describe('String.prototype.replace', () => {
 
     expect('abc'.replace(searchValue, 'x')).toBe('custom replace');
   });
+
+  test('Symbol.replace fires before ToString on the receiver (ES2026 §22.1.3.19 step 2.c-d)', () => {
+    // The replacer must run before any ToString on `this`. If the receiver's
+    // toString fires first, `poisoned` becomes true and the assertion fails.
+    let poisoned = false;
+    let replacerFired = false;
+    const poison = { toString() { poisoned = true; return ''; } };
+    const searchValue = {
+      [Symbol.replace]() { replacerFired = true; return 'ok'; },
+    };
+    ''.replace.call(poison, searchValue, 'x');
+    expect(replacerFired).toBe(true);
+    expect(poisoned).toBe(false);
+  });
+
+  test('Symbol.replace receives O directly, not a stringified copy', () => {
+    // Spec step 2.d.i: Call(replacer, searchValue, « O, replaceValue »).
+    const receiver = { tag: 'unique-receiver' };
+    let receivedThis;
+    const searchValue = {
+      [Symbol.replace](o) { receivedThis = o; return 'ok'; },
+    };
+    ''.replace.call(receiver, searchValue, 'x');
+    expect(receivedThis).toBe(receiver);
+  });
+
+  test('throws TypeError when called on null or undefined', () => {
+    expect(() => ''.replace.call(null, /x/, 'y')).toThrow(TypeError);
+    expect(() => ''.replace.call(undefined, /x/, 'y')).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/String/prototype/replaceAll.js
+++ b/tests/built-ins/String/prototype/replaceAll.js
@@ -85,4 +85,35 @@ describe('String.prototype.replaceAll', () => {
 
     expect('abc'.replaceAll(searchValue, 'x')).toBe('custom replaceAll');
   });
+
+  test('Symbol.replace fires before ToString on the receiver (ES2026 §22.1.3.20 step 2.c-d)', () => {
+    let poisoned = false;
+    let replacerFired = false;
+    const poison = { toString() { poisoned = true; return ''; } };
+    const searchValue = {
+      [Symbol.match]: false,
+      flags: 'g',
+      [Symbol.replace]() { replacerFired = true; return 'ok'; },
+    };
+    ''.replaceAll.call(poison, searchValue, 'x');
+    expect(replacerFired).toBe(true);
+    expect(poisoned).toBe(false);
+  });
+
+  test('Symbol.replace receives O directly, not a stringified copy', () => {
+    const receiver = { tag: 'unique-receiver' };
+    let receivedThis;
+    const searchValue = {
+      [Symbol.match]: false,
+      flags: 'g',
+      [Symbol.replace](o) { receivedThis = o; return 'ok'; },
+    };
+    ''.replaceAll.call(receiver, searchValue, 'x');
+    expect(receivedThis).toBe(receiver);
+  });
+
+  test('throws TypeError when called on null or undefined', () => {
+    expect(() => ''.replaceAll.call(null, /x/g, 'y')).toThrow(TypeError);
+    expect(() => ''.replaceAll.call(undefined, /x/g, 'y')).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/String/prototype/search.js
+++ b/tests/built-ins/String/prototype/search.js
@@ -22,3 +22,30 @@ test("search dispatches through Symbol.search", () => {
 
   expect("abc".search(searcher)).toBe(7);
 });
+
+test("Symbol.search fires before ToString on the receiver (ES2026 §22.1.3.27 step 2)", () => {
+  let poisoned = false;
+  let searcherFired = false;
+  const poison = { toString() { poisoned = true; return ""; } };
+  const searcher = {
+    [Symbol.search]() { searcherFired = true; return -1; },
+  };
+  "".search.call(poison, searcher);
+  expect(searcherFired).toBe(true);
+  expect(poisoned).toBe(false);
+});
+
+test("Symbol.search receives O directly, not a stringified copy", () => {
+  const receiver = { tag: "unique-receiver" };
+  let receivedThis;
+  const searcher = {
+    [Symbol.search](o) { receivedThis = o; return -1; },
+  };
+  "".search.call(receiver, searcher);
+  expect(receivedThis).toBe(receiver);
+});
+
+test("search throws TypeError when called on null or undefined", () => {
+  expect(() => "".search.call(null, /x/)).toThrow(TypeError);
+  expect(() => "".search.call(undefined, /x/)).toThrow(TypeError);
+});

--- a/tests/built-ins/String/prototype/split.js
+++ b/tests/built-ins/String/prototype/split.js
@@ -92,3 +92,30 @@ test("String.prototype.split dispatches through Symbol.split", () => {
 
   expect("abc".split(splitter, 2)).toEqual(["custom", "split"]);
 });
+
+test("Symbol.split fires before ToString on the receiver (ES2026 §22.1.3.23 step 2)", () => {
+  let poisoned = false;
+  let splitterFired = false;
+  const poison = { toString() { poisoned = true; return ""; } };
+  const splitter = {
+    [Symbol.split]() { splitterFired = true; return []; },
+  };
+  "".split.call(poison, splitter);
+  expect(splitterFired).toBe(true);
+  expect(poisoned).toBe(false);
+});
+
+test("Symbol.split receives O directly, not a stringified copy", () => {
+  const receiver = { tag: "unique-receiver" };
+  let receivedThis;
+  const splitter = {
+    [Symbol.split](o) { receivedThis = o; return []; },
+  };
+  "".split.call(receiver, splitter);
+  expect(receivedThis).toBe(receiver);
+});
+
+test("split throws TypeError when called on null or undefined", () => {
+  expect(() => "".split.call(null, ",")).toThrow(TypeError);
+  expect(() => "".split.call(undefined, ",")).toThrow(TypeError);
+});

--- a/tests/language/expressions/delete/delete-operator.js
+++ b/tests/language/expressions/delete/delete-operator.js
@@ -46,3 +46,12 @@ test("property is gone after delete", () => {
   delete obj.value;
   expect("value" in obj).toBe(false);
 });
+
+test("delete with symbol key removes symbol-keyed property (ES2026 §7.1.19)", () => {
+  const sym = Symbol("foo");
+  const obj = { [sym]: "x", regular: 1 };
+  expect(obj[sym]).toBe("x");
+  delete obj[sym];
+  expect(obj[sym]).toBeUndefined();
+  expect(obj.regular).toBe(1);
+});

--- a/tests/language/expressions/delete/delete-operator.js
+++ b/tests/language/expressions/delete/delete-operator.js
@@ -55,3 +55,14 @@ test("delete with symbol key removes symbol-keyed property (ES2026 §7.1.19)", (
   expect(obj[sym]).toBeUndefined();
   expect(obj.regular).toBe(1);
 });
+
+test("delete with symbol key on array removes symbol-keyed property", () => {
+  const sym = Symbol("tag");
+  const arr = [1, 2, 3];
+  arr[sym] = "marker";
+  expect(arr[sym]).toBe("marker");
+  delete arr[sym];
+  expect(arr[sym]).toBeUndefined();
+  expect(arr.length).toBe(3);
+  expect(arr[0]).toBe(1);
+});


### PR DESCRIPTION
## Summary

Replaces the debug-format `ToStringLiteral` overrides on objects/instances with ES2026 §7.1.17 ToString semantics, and routes every property-key coercion site through the new ES2026 §7.1.19 `ToPropertyKey` helper.

- **`ToStringLiteral` is now ES2026 §7.1.17 ToString.** For objects and class instances it dispatches through `ToPrimitive(Self, string)` and may invoke user-defined `toString()` / `valueOf()`. The previous debug formats (`[Instance of <Class>]`, `[object <Tag>]`) had no contract; one Pascal unit test asserted the plain-object form (now exercises the spec TypeError on a prototype-less object), two error-message strings hardcoded `[object Object]` independently, and nothing else parsed them.

- **`ToPropertyKey`** (free function in `Goccia.Values.ToPrimitive`) — symbols pass through; non-symbols go through `ToPrimitive(string)` and `ToStringLiteral`. Wired up at every property-key coercion site in the Evaluator and pattern matcher: super property access, member expression GET, object literal computed properties, class method/getter/setter computed names, assignment-pattern computed keys, object-destructuring computed keys, pattern-matcher property helpers, rest-pattern computed keys, and the `delete obj[expr]` path. Closes a latent spec gap where the inline `if isSymbol then ... else ToStringLiteral` pattern checked the *input* type instead of the *result* of ToPrimitive — an object whose `toString()` returns a Symbol now correctly resolves to that Symbol per spec instead of throwing TypeError.

- **Bytecode `OP_DEL_INDEX`** learned the symbol path so `delete obj[symbol]` deletes from symbol-keyed storage in bytecode mode.

- **`ToECMAString` and `SafeToString` are deleted.** Their callers (`String(value)`, `new String(value)`, template-literal interpolation, `Array.prototype.join`, Symbol description coercion, VM register-to-string, throw formatters) call `ToStringLiteral` directly; the throw-formatter sites use type dispatch inline (no try-except).

Resolves both CodeRabbit findings on the prior approach:

- `EGocciaBytecodeThrow.Create` no longer runs user `toString()` at throw construction (caught exceptions would otherwise observe stringification — spec violation). It builds the Pascal-side `Exception.Message` from primitive `name`/`message` properties when available, otherwise a static placeholder.
- `FormatThrowDetail` no longer takes a precomputed-string parameter or carries an empty-string sentinel (`''` is a valid ToString result). The fallback path uses static type-based rendering — it cannot re-enter user code post-VM-unwind.

The `String(obj)` user-defined-toString fix from #522 is delivered through the architecture rather than via a targeted bypass.

Closes #522

Sister bug for `Number(obj)` filed as #526 (out of scope here).

## Testing

- [x] **Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests**
  - 7 new tests in `tests/built-ins/String/constructor.js` cover: user `toString()` invocation, toString-then-valueOf precedence, fallback when toString returns non-primitive, `TypeError` when neither method returns a primitive (asserted with `toThrow(TypeError)` per review), `new String(obj)` wrapping the toString result, and `String(stringWrapper)` unwrap.
  - 1 new test in `tests/language/expressions/delete/delete-operator.js` covers `delete obj[symbol]` per ES2026 §7.1.19.
  - Full suite: 8566/8571 pass in both interpreter and bytecode modes; the 5 failures are pre-existing FFI fixture loading issues (`libfixture.dylib`) unrelated to this change.
- [x] **Updated documentation**
  - `docs/value-system.md` — documents `ToStringLiteral` as the ES2026 §7.1.17 ToString entry point, adds the `ToPropertyKey` helper section, clarifies that error-boundary callers avoid invoking it on objects rather than wrapping with try/except, and updates the ToPrimitive section to reflect the hint-based ordering.
- [x] **Verified no regressions and confirmed the new feature or bugfix in native Pascal tests**
  - `Goccia.Values.ObjectValue.Test.pas` updated to assert that a prototype-less `TGocciaObjectValue` correctly throws when `ToStringLiteral` runs ToPrimitive (no `toString` / `valueOf` to call). All 7 ObjectValue Pascal tests pass.
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Not run; change is on cold paths and removes one dispatch indirection (`ToECMAString` shim) plus simplifies the bytecode register-to-string helper.