### PR TITLE
Accept all constructable function forms in Reflect.construct

### DIFF
--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -45,14 +45,10 @@ uses
   Goccia.Error.Suggestions,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
-  Goccia.Values.ClassValue,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
-  Goccia.Values.HoleValue,
-  Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.ProxyValue,
   Goccia.Values.SymbolValue;
 
 threadvar
@@ -144,15 +140,8 @@ end;
 
 function TGocciaGlobalReflect.ReflectConstruct(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Target: TGocciaValue;
-  ArgsList: TGocciaValue;
-  NewTarget: TGocciaValue;
-  CallArgs, CombinedArgs: TGocciaArgumentsCollection;
-  NewTargetClass: TGocciaClassValue;
-  Receiver: TGocciaObjectValue;
-  EffectiveTarget: TGocciaValue;
-  BoundFn: TGocciaBoundFunctionValue;
-  I: Integer;
+  Target, ArgsList, NewTarget: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Reflect.construct', ThrowError);
 
@@ -163,90 +152,23 @@ begin
   if not IsConstructorValue(Target) then
     ThrowTypeError(SErrorReflectConstructTargetMustBeConstructor, SSuggestNotConstructorType);
 
+  // Step 3: If newTarget provided, validate IsConstructor(newTarget)
+  if AArgs.Length >= 3 then
+  begin
+    NewTarget := AArgs.GetElement(2);
+    if not IsConstructorValue(NewTarget) then
+      ThrowTypeError(SErrorReflectConstructNewTargetMustBeConstructor, SSuggestNotConstructorType);
+  end
+  else
+    NewTarget := Target;
+
   // Step 2: Let args be ? CreateListFromArrayLike(argumentsList)
   CallArgs := CreateListFromArrayLike(ArgsList, 'Reflect.construct');
   try
-    // Step 3: If newTarget provided, validate IsConstructor(newTarget)
-    if AArgs.Length >= 3 then
-    begin
-      NewTarget := AArgs.GetElement(2);
-      if not IsConstructorValue(NewTarget) then
-        ThrowTypeError(SErrorReflectConstructNewTargetMustBeConstructor, SSuggestNotConstructorType);
-    end
-    else
-      NewTarget := Target;
-
-    // Bound function target (§10.4.1.2): at each level, merge the bound
-    // arguments into the call list and apply step 5's substitution —
-    // SameValue(F, newTarget) ⇒ newTarget := F.[[BoundTargetFunction]] —
-    // before recursing into the underlying target. The substitution preserves
-    // an explicit non-bound newTarget (e.g. Reflect.construct(Bound, [], C))
-    // while default-newTarget calls follow the bound chain to the eventual
-    // ordinary constructor.
-    EffectiveTarget := Target;
-    while EffectiveTarget is TGocciaBoundFunctionValue do
-    begin
-      BoundFn := TGocciaBoundFunctionValue(EffectiveTarget);
-      if NewTarget = EffectiveTarget then
-        NewTarget := BoundFn.OriginalFunction;
-      CombinedArgs := TGocciaArgumentsCollection.CreateWithCapacity(
-        BoundFn.BoundArgCount + CallArgs.Length);
-      try
-        for I := 0 to BoundFn.BoundArgCount - 1 do
-          CombinedArgs.Add(BoundFn.GetBoundArg(I));
-        for I := 0 to CallArgs.Length - 1 do
-          CombinedArgs.Add(CallArgs.GetElement(I));
-      except
-        CombinedArgs.Free;
-        raise;
-      end;
-      CallArgs.Free;
-      CallArgs := CombinedArgs;
-      EffectiveTarget := BoundFn.OriginalFunction;
-    end;
-
-    // Step 4: Return ? Construct(target, args, newTarget)
-    if EffectiveTarget is TGocciaProxyValue then
-      Result := TGocciaProxyValue(EffectiveTarget).ConstructTrap(CallArgs, NewTarget)
-    else if EffectiveTarget is TGocciaClassValue then
-    begin
-      if NewTarget is TGocciaClassValue then
-      begin
-        NewTargetClass := TGocciaClassValue(NewTarget);
-        if NewTargetClass <> TGocciaClassValue(EffectiveTarget) then
-          Result := TGocciaClassValue(EffectiveTarget).Instantiate(CallArgs, NewTargetClass)
-        else
-          Result := TGocciaClassValue(EffectiveTarget).Instantiate(CallArgs);
-      end
-      else
-      begin
-        // newTarget is a non-class constructor — patch the instance prototype
-        // from newTarget.prototype after instantiation (Instantiate only
-        // accepts a class for its newTarget parameter). GetProtoFromConstructor
-        // applies the §10.1.14 fallback to %Object.prototype% when
-        // newTarget.prototype is not an Object.
-        Result := TGocciaClassValue(EffectiveTarget).Instantiate(CallArgs);
-        if Result is TGocciaObjectValue then
-          TGocciaObjectValue(Result).Prototype := GetProtoFromConstructor(NewTarget);
-      end;
-    end
-    else if EffectiveTarget is TGocciaNativeFunctionValue then
-    begin
-      // Native constructors create their own internal-slot-backed instance;
-      // the receiver is unused so we pass HoleValue. newTarget-driven
-      // prototype propagation for native constructors is not yet wired here.
-      Result := TGocciaNativeFunctionValue(EffectiveTarget).Call(CallArgs,
-        TGocciaHoleValue.HoleValue);
-    end
-    else if EffectiveTarget is TGocciaFunctionBase then
-    begin
-      Receiver := TGocciaObjectValue.Create(GetProtoFromConstructor(NewTarget));
-      Result := ConstructOrdinaryWithReceiver(TGocciaFunctionBase(EffectiveTarget),
-        CallArgs, Receiver);
-    end
-    else
-      ThrowTypeError(SErrorReflectConstructTargetMustBeConstructor,
-        SSuggestNotConstructorType);
+    // Step 4: Return ? Construct(target, args, newTarget). ConstructValue
+    // walks the §10.4.1.2 bound chain (substituting newTarget where the
+    // SameValue rule applies) and dispatches by target kind.
+    Result := ConstructValue(Target, CallArgs, NewTarget);
   finally
     CallArgs.Free;
   end;

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -43,6 +43,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.GarbageCollector,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
@@ -52,6 +53,7 @@ uses
   Goccia.Values.HoleValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.ProxyValue,
   Goccia.Values.SymbolValue;
 
 threadvar
@@ -129,15 +131,69 @@ begin
 end;
 
 // ES2026 §28.1.2 Reflect.construct(target, argumentsList [, newTarget])
-// ES2026 §7.2.4 IsConstructor(argument) — check if a value can be used with new
+// ES2026 §7.2.4 IsConstructor(argument): defer to the value's virtual
+// IsConstructable. Each TGocciaFunctionBase descendant overrides it to
+// match the spec — function declarations/expressions return true (they own
+// a `prototype` data property), while arrow, async, generator, async-
+// generator, concise method, and revoked-proxy targets return false.
+// Bound functions delegate to their underlying [[BoundTargetFunction]],
+// matching ES2026 §10.4.1.2.
 function IsConstructorValue(const AValue: TGocciaValue): Boolean;
 begin
-  if AValue is TGocciaClassValue then
-    Exit(True);
-  if (AValue is TGocciaNativeFunctionValue) and
-     not TGocciaNativeFunctionValue(AValue).NotConstructable then
-    Exit(True);
-  Result := False;
+  Result := AValue.IsConstructable;
+end;
+
+// Walk through chained bound functions to find the [[Construct]]-bearing target.
+// Used to read `.prototype` for receiver allocation per ES2026 §10.1.14
+// GetPrototypeFromConstructor — the bound wrapper has no own `prototype`.
+function UnwrapBoundFunction(const AValue: TGocciaValue): TGocciaValue;
+begin
+  Result := AValue;
+  while Result is TGocciaBoundFunctionValue do
+    Result := TGocciaBoundFunctionValue(Result).OriginalFunction;
+end;
+
+// ES2026 §10.1.14 GetPrototypeFromConstructor: read newTarget.prototype;
+// if it is not an Object, fall back to %Object.prototype%.
+function GetProtoFromConstructor(const ANewTarget: TGocciaValue): TGocciaObjectValue;
+var
+  Unwrapped, ProtoValue: TGocciaValue;
+begin
+  Unwrapped := UnwrapBoundFunction(ANewTarget);
+  if Unwrapped is TGocciaObjectValue then
+    ProtoValue := TGocciaObjectValue(Unwrapped).GetProperty(PROP_PROTOTYPE)
+  else
+    ProtoValue := nil;
+
+  if ProtoValue is TGocciaObjectValue then
+    Result := TGocciaObjectValue(ProtoValue)
+  else
+  begin
+    if not Assigned(TGocciaObjectValue.SharedObjectPrototype) then
+      TGocciaObjectValue.InitializeSharedPrototype;
+    Result := TGocciaObjectValue.SharedObjectPrototype;
+  end;
+end;
+
+// ES2026 §10.2.2 [[Construct]] for ordinary function objects: call the body
+// with the receiver as `this`; if the body returns an Object, that wins —
+// otherwise the receiver is the result.
+function ConstructOrdinaryWithReceiver(const ATarget: TGocciaFunctionBase;
+  const AArguments: TGocciaArgumentsCollection;
+  const AReceiver: TGocciaObjectValue): TGocciaValue;
+var
+  ReturnValue: TGocciaValue;
+begin
+  TGarbageCollector.Instance.AddTempRoot(AReceiver);
+  try
+    ReturnValue := ATarget.Call(AArguments, AReceiver);
+    if ReturnValue is TGocciaObjectValue then
+      Result := ReturnValue
+    else
+      Result := AReceiver;
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(AReceiver);
+  end;
 end;
 
 function TGocciaGlobalReflect.ReflectConstruct(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -145,9 +201,13 @@ var
   Target: TGocciaValue;
   ArgsList: TGocciaValue;
   NewTarget: TGocciaValue;
-  CallArgs: TGocciaArgumentsCollection;
+  CallArgs, CombinedArgs: TGocciaArgumentsCollection;
   ProtoValue: TGocciaValue;
   NewTargetClass: TGocciaClassValue;
+  Receiver: TGocciaObjectValue;
+  EffectiveTarget: TGocciaValue;
+  BoundFn: TGocciaBoundFunctionValue;
+  I: Integer;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Reflect.construct', ThrowError);
 
@@ -171,32 +231,71 @@ begin
     else
       NewTarget := Target;
 
+    // Bound function target (§10.4.1.2): merge bound and call args, then
+    // dispatch on the underlying [[BoundTargetFunction]]. The bound wrapper
+    // contributes no [[Prototype]] of its own, so newTarget continues to
+    // drive receiver allocation for non-class underlying targets.
+    EffectiveTarget := Target;
+    while EffectiveTarget is TGocciaBoundFunctionValue do
+    begin
+      BoundFn := TGocciaBoundFunctionValue(EffectiveTarget);
+      CombinedArgs := TGocciaArgumentsCollection.CreateWithCapacity(
+        BoundFn.BoundArgCount + CallArgs.Length);
+      try
+        for I := 0 to BoundFn.BoundArgCount - 1 do
+          CombinedArgs.Add(BoundFn.GetBoundArg(I));
+        for I := 0 to CallArgs.Length - 1 do
+          CombinedArgs.Add(CallArgs.GetElement(I));
+      except
+        CombinedArgs.Free;
+        raise;
+      end;
+      CallArgs.Free;
+      CallArgs := CombinedArgs;
+      EffectiveTarget := BoundFn.OriginalFunction;
+    end;
+
     // Step 4: Return ? Construct(target, args, newTarget)
-    if Target is TGocciaClassValue then
+    if EffectiveTarget is TGocciaProxyValue then
+      Result := TGocciaProxyValue(EffectiveTarget).ConstructTrap(CallArgs)
+    else if EffectiveTarget is TGocciaClassValue then
     begin
       if NewTarget is TGocciaClassValue then
       begin
         NewTargetClass := TGocciaClassValue(NewTarget);
-        if NewTargetClass <> TGocciaClassValue(Target) then
-          Result := TGocciaClassValue(Target).Instantiate(CallArgs, NewTargetClass)
+        if NewTargetClass <> TGocciaClassValue(EffectiveTarget) then
+          Result := TGocciaClassValue(EffectiveTarget).Instantiate(CallArgs, NewTargetClass)
         else
-          Result := TGocciaClassValue(Target).Instantiate(CallArgs);
+          Result := TGocciaClassValue(EffectiveTarget).Instantiate(CallArgs);
       end
       else
       begin
-        // newTarget is a native function — get its .prototype for the instance
-        Result := TGocciaClassValue(Target).Instantiate(CallArgs);
-        ProtoValue := NewTarget.GetProperty(PROP_PROTOTYPE);
+        // newTarget is a non-class constructor — patch the instance prototype
+        // from newTarget.prototype after instantiation (Instantiate only
+        // accepts a class for its newTarget parameter).
+        Result := TGocciaClassValue(EffectiveTarget).Instantiate(CallArgs);
+        ProtoValue := UnwrapBoundFunction(NewTarget).GetProperty(PROP_PROTOTYPE);
         if ProtoValue is TGocciaObjectValue then
           TGocciaObjectValue(Result).Prototype := TGocciaObjectValue(ProtoValue);
       end;
     end
-    else
+    else if EffectiveTarget is TGocciaNativeFunctionValue then
     begin
-      // Target is a native function constructor
-      Result := TGocciaNativeFunctionValue(Target).Call(CallArgs,
+      // Native constructors create their own internal-slot-backed instance;
+      // the receiver is unused so we pass HoleValue. newTarget-driven
+      // prototype propagation for native constructors is not yet wired here.
+      Result := TGocciaNativeFunctionValue(EffectiveTarget).Call(CallArgs,
         TGocciaHoleValue.HoleValue);
-    end;
+    end
+    else if EffectiveTarget is TGocciaFunctionBase then
+    begin
+      Receiver := TGocciaObjectValue.Create(GetProtoFromConstructor(NewTarget));
+      Result := ConstructOrdinaryWithReceiver(TGocciaFunctionBase(EffectiveTarget),
+        CallArgs, Receiver);
+    end
+    else
+      ThrowTypeError(SErrorReflectConstructTargetMustBeConstructor,
+        SSuggestNotConstructorType);
   finally
     CallArgs.Free;
   end;

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -253,7 +253,7 @@ begin
 
     // Step 4: Return ? Construct(target, args, newTarget)
     if EffectiveTarget is TGocciaProxyValue then
-      Result := TGocciaProxyValue(EffectiveTarget).ConstructTrap(CallArgs)
+      Result := TGocciaProxyValue(EffectiveTarget).ConstructTrap(CallArgs, NewTarget)
     else if EffectiveTarget is TGocciaClassValue then
     begin
       if NewTarget is TGocciaClassValue then

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -43,7 +43,6 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.GarbageCollector,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
@@ -141,51 +140,6 @@ end;
 function IsConstructorValue(const AValue: TGocciaValue): Boolean;
 begin
   Result := AValue.IsConstructable;
-end;
-
-// ES2026 §10.1.14 GetPrototypeFromConstructor: Get(constructor, "prototype")
-// directly — no bound-function unwrap. If the property is not an Object,
-// fall back to %Object.prototype%. A plain bound function whose user has
-// not assigned an own `prototype` walks its prototype chain to undefined,
-// which lands on the fallback per spec.
-function GetProtoFromConstructor(const ANewTarget: TGocciaValue): TGocciaObjectValue;
-var
-  ProtoValue: TGocciaValue;
-begin
-  if ANewTarget is TGocciaObjectValue then
-    ProtoValue := TGocciaObjectValue(ANewTarget).GetProperty(PROP_PROTOTYPE)
-  else
-    ProtoValue := nil;
-
-  if ProtoValue is TGocciaObjectValue then
-    Result := TGocciaObjectValue(ProtoValue)
-  else
-  begin
-    if not Assigned(TGocciaObjectValue.SharedObjectPrototype) then
-      TGocciaObjectValue.InitializeSharedPrototype;
-    Result := TGocciaObjectValue.SharedObjectPrototype;
-  end;
-end;
-
-// ES2026 §10.2.2 [[Construct]] for ordinary function objects: call the body
-// with the receiver as `this`; if the body returns an Object, that wins —
-// otherwise the receiver is the result.
-function ConstructOrdinaryWithReceiver(const ATarget: TGocciaFunctionBase;
-  const AArguments: TGocciaArgumentsCollection;
-  const AReceiver: TGocciaObjectValue): TGocciaValue;
-var
-  ReturnValue: TGocciaValue;
-begin
-  TGarbageCollector.Instance.AddTempRoot(AReceiver);
-  try
-    ReturnValue := ATarget.Call(AArguments, AReceiver);
-    if ReturnValue is TGocciaObjectValue then
-      Result := ReturnValue
-    else
-      Result := AReceiver;
-  finally
-    TGarbageCollector.Instance.RemoveTempRoot(AReceiver);
-  end;
 end;
 
 function TGocciaGlobalReflect.ReflectConstruct(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -143,25 +143,17 @@ begin
   Result := AValue.IsConstructable;
 end;
 
-// Walk through chained bound functions to find the [[Construct]]-bearing target.
-// Used to read `.prototype` for receiver allocation per ES2026 §10.1.14
-// GetPrototypeFromConstructor — the bound wrapper has no own `prototype`.
-function UnwrapBoundFunction(const AValue: TGocciaValue): TGocciaValue;
-begin
-  Result := AValue;
-  while Result is TGocciaBoundFunctionValue do
-    Result := TGocciaBoundFunctionValue(Result).OriginalFunction;
-end;
-
-// ES2026 §10.1.14 GetPrototypeFromConstructor: read newTarget.prototype;
-// if it is not an Object, fall back to %Object.prototype%.
+// ES2026 §10.1.14 GetPrototypeFromConstructor: Get(constructor, "prototype")
+// directly — no bound-function unwrap. If the property is not an Object,
+// fall back to %Object.prototype%. A plain bound function whose user has
+// not assigned an own `prototype` walks its prototype chain to undefined,
+// which lands on the fallback per spec.
 function GetProtoFromConstructor(const ANewTarget: TGocciaValue): TGocciaObjectValue;
 var
-  Unwrapped, ProtoValue: TGocciaValue;
+  ProtoValue: TGocciaValue;
 begin
-  Unwrapped := UnwrapBoundFunction(ANewTarget);
-  if Unwrapped is TGocciaObjectValue then
-    ProtoValue := TGocciaObjectValue(Unwrapped).GetProperty(PROP_PROTOTYPE)
+  if ANewTarget is TGocciaObjectValue then
+    ProtoValue := TGocciaObjectValue(ANewTarget).GetProperty(PROP_PROTOTYPE)
   else
     ProtoValue := nil;
 
@@ -202,7 +194,6 @@ var
   ArgsList: TGocciaValue;
   NewTarget: TGocciaValue;
   CallArgs, CombinedArgs: TGocciaArgumentsCollection;
-  ProtoValue: TGocciaValue;
   NewTargetClass: TGocciaClassValue;
   Receiver: TGocciaObjectValue;
   EffectiveTarget: TGocciaValue;
@@ -231,14 +222,19 @@ begin
     else
       NewTarget := Target;
 
-    // Bound function target (§10.4.1.2): merge bound and call args, then
-    // dispatch on the underlying [[BoundTargetFunction]]. The bound wrapper
-    // contributes no [[Prototype]] of its own, so newTarget continues to
-    // drive receiver allocation for non-class underlying targets.
+    // Bound function target (§10.4.1.2): at each level, merge the bound
+    // arguments into the call list and apply step 5's substitution —
+    // SameValue(F, newTarget) ⇒ newTarget := F.[[BoundTargetFunction]] —
+    // before recursing into the underlying target. The substitution preserves
+    // an explicit non-bound newTarget (e.g. Reflect.construct(Bound, [], C))
+    // while default-newTarget calls follow the bound chain to the eventual
+    // ordinary constructor.
     EffectiveTarget := Target;
     while EffectiveTarget is TGocciaBoundFunctionValue do
     begin
       BoundFn := TGocciaBoundFunctionValue(EffectiveTarget);
+      if NewTarget = EffectiveTarget then
+        NewTarget := BoundFn.OriginalFunction;
       CombinedArgs := TGocciaArgumentsCollection.CreateWithCapacity(
         BoundFn.BoundArgCount + CallArgs.Length);
       try
@@ -272,11 +268,12 @@ begin
       begin
         // newTarget is a non-class constructor — patch the instance prototype
         // from newTarget.prototype after instantiation (Instantiate only
-        // accepts a class for its newTarget parameter).
+        // accepts a class for its newTarget parameter). GetProtoFromConstructor
+        // applies the §10.1.14 fallback to %Object.prototype% when
+        // newTarget.prototype is not an Object.
         Result := TGocciaClassValue(EffectiveTarget).Instantiate(CallArgs);
-        ProtoValue := UnwrapBoundFunction(NewTarget).GetProperty(PROP_PROTOTYPE);
-        if ProtoValue is TGocciaObjectValue then
-          TGocciaObjectValue(Result).Prototype := TGocciaObjectValue(ProtoValue);
+        if Result is TGocciaObjectValue then
+          TGocciaObjectValue(Result).Prototype := GetProtoFromConstructor(NewTarget);
       end;
     end
     else if EffectiveTarget is TGocciaNativeFunctionValue then

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -108,6 +108,19 @@ function ConstructOrdinaryWithReceiver(const ATarget: TGocciaFunctionBase;
   const AArguments: TGocciaArgumentsCollection;
   const AReceiver: TGocciaObjectValue): TGocciaValue;
 
+// ES2026 §7.3.14 Construct(F, argumentsList, newTarget): single dispatch
+// across all callable forms — proxies, classes, native constructors,
+// ordinary functions, and bound functions. Walks the §10.4.1.2 bound chain
+// (merging bound arguments and applying the SameValue(F, newTarget) ⇒
+// newTarget := F.[[BoundTargetFunction]] substitution) before routing the
+// unwrapped target to its [[Construct]] implementation. Callers must
+// pre-validate IsConstructable(ATarget); the trailing else-branch only
+// fires defensively. Used by Reflect.construct (§28.1.2) and the proxy
+// [[Construct]] fallback (§10.5.13).
+function ConstructValue(const ATarget: TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
+
 implementation
 
 uses
@@ -126,6 +139,7 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.HoleValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.ProxyValue;
 
@@ -176,6 +190,80 @@ begin
       Result := AReceiver;
   finally
     TGarbageCollector.Instance.RemoveTempRoot(AReceiver);
+  end;
+end;
+
+function ConstructValue(const ATarget: TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
+var
+  EffectiveTarget: TGocciaValue;
+  EffectiveNewTarget: TGocciaValue;
+  WorkingArgs, NextArgs: TGocciaArgumentsCollection;
+  BoundFn: TGocciaBoundFunctionValue;
+  I: Integer;
+begin
+  EffectiveTarget := ATarget;
+  EffectiveNewTarget := ANewTarget;
+
+  WorkingArgs := TGocciaArgumentsCollection.CreateWithCapacity(AArguments.Length);
+  try
+    for I := 0 to AArguments.Length - 1 do
+      WorkingArgs.Add(AArguments.GetElement(I));
+
+    while EffectiveTarget is TGocciaBoundFunctionValue do
+    begin
+      BoundFn := TGocciaBoundFunctionValue(EffectiveTarget);
+      if EffectiveNewTarget = EffectiveTarget then
+        EffectiveNewTarget := BoundFn.OriginalFunction;
+      NextArgs := TGocciaArgumentsCollection.CreateWithCapacity(
+        BoundFn.BoundArgCount + WorkingArgs.Length);
+      try
+        for I := 0 to BoundFn.BoundArgCount - 1 do
+          NextArgs.Add(BoundFn.GetBoundArg(I));
+        for I := 0 to WorkingArgs.Length - 1 do
+          NextArgs.Add(WorkingArgs.GetElement(I));
+      except
+        NextArgs.Free;
+        raise;
+      end;
+      WorkingArgs.Free;
+      WorkingArgs := NextArgs;
+      EffectiveTarget := BoundFn.OriginalFunction;
+    end;
+
+    if EffectiveTarget is TGocciaProxyValue then
+      Result := TGocciaProxyValue(EffectiveTarget).ConstructTrap(WorkingArgs,
+        EffectiveNewTarget)
+    else if EffectiveTarget is TGocciaClassValue then
+    begin
+      if EffectiveNewTarget is TGocciaClassValue then
+        Result := TGocciaClassValue(EffectiveTarget).Instantiate(WorkingArgs,
+          TGocciaClassValue(EffectiveNewTarget))
+      else
+      begin
+        // Patching the freshly-created instance's [[Prototype]] after the
+        // constructor returns is sound while Instantiate ignores explicit
+        // object returns; once that engine limitation is lifted (tracked
+        // alongside #529), this branch must derive the receiver pre-call.
+        Result := TGocciaClassValue(EffectiveTarget).Instantiate(WorkingArgs);
+        if Result is TGocciaObjectValue then
+          TGocciaObjectValue(Result).Prototype :=
+            GetProtoFromConstructor(EffectiveNewTarget);
+      end;
+    end
+    else if EffectiveTarget is TGocciaNativeFunctionValue then
+      Result := TGocciaNativeFunctionValue(EffectiveTarget).Call(WorkingArgs,
+        TGocciaHoleValue.HoleValue)
+    else if EffectiveTarget is TGocciaFunctionBase then
+      Result := ConstructOrdinaryWithReceiver(TGocciaFunctionBase(EffectiveTarget),
+        WorkingArgs,
+        TGocciaObjectValue.Create(GetProtoFromConstructor(EffectiveNewTarget)))
+    else
+      ThrowTypeError(SErrorReflectConstructTargetMustBeConstructor,
+        SSuggestNotConstructorType);
+  finally
+    WorkingArgs.Free;
   end;
 end;
 

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -94,6 +94,20 @@ type
     property BoundArgCount: Integer read FBoundArgCount;
   end;
 
+// ES2026 §10.1.14 GetPrototypeFromConstructor: Get(constructor, "prototype")
+// directly — no bound-function unwrap. If the property is not an Object,
+// fall back to %Object.prototype%. Shared by Reflect.construct (§28.1.2)
+// and the proxy [[Construct]] fallback (§10.5.13).
+function GetProtoFromConstructor(const ANewTarget: TGocciaValue): TGocciaObjectValue;
+
+// ES2026 §10.2.2 [[Construct]] for ordinary function objects: call the body
+// with the receiver as `this`; if the body returns an Object, that wins —
+// otherwise the receiver is the result. The receiver is rooted across the
+// call so a GC during the body cannot collect a reachable instance.
+function ConstructOrdinaryWithReceiver(const ATarget: TGocciaFunctionBase;
+  const AArguments: TGocciaArgumentsCollection;
+  const AReceiver: TGocciaObjectValue): TGocciaValue;
+
 implementation
 
 uses
@@ -126,6 +140,43 @@ begin
     Result := TGocciaFunctionSharedPrototype(CurrentRealm.GetSlot(GFunctionPrototypeSlot))
   else
     Result := nil;
+end;
+
+function GetProtoFromConstructor(const ANewTarget: TGocciaValue): TGocciaObjectValue;
+var
+  ProtoValue: TGocciaValue;
+begin
+  if ANewTarget is TGocciaObjectValue then
+    ProtoValue := TGocciaObjectValue(ANewTarget).GetProperty(PROP_PROTOTYPE)
+  else
+    ProtoValue := nil;
+
+  if ProtoValue is TGocciaObjectValue then
+    Result := TGocciaObjectValue(ProtoValue)
+  else
+  begin
+    if not Assigned(TGocciaObjectValue.SharedObjectPrototype) then
+      TGocciaObjectValue.InitializeSharedPrototype;
+    Result := TGocciaObjectValue.SharedObjectPrototype;
+  end;
+end;
+
+function ConstructOrdinaryWithReceiver(const ATarget: TGocciaFunctionBase;
+  const AArguments: TGocciaArgumentsCollection;
+  const AReceiver: TGocciaObjectValue): TGocciaValue;
+var
+  ReturnValue: TGocciaValue;
+begin
+  TGarbageCollector.Instance.AddTempRoot(AReceiver);
+  try
+    ReturnValue := ATarget.Call(AArguments, AReceiver);
+    if ReturnValue is TGocciaObjectValue then
+      Result := ReturnValue
+    else
+      Result := AReceiver;
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(AReceiver);
+  end;
 end;
 
 { TGocciaFunctionBase }

--- a/source/units/Goccia.Values.ProxyValue.pas
+++ b/source/units/Goccia.Values.ProxyValue.pas
@@ -1308,24 +1308,34 @@ begin
   end
   else
   begin
-    // No construct trap: construct the target directly (nested proxies first).
-    // Use Instantiate() for class values — it is virtual, so
-    // TGocciaVMClassValue dispatches to its bytecode-aware override.
-    // newTarget propagation through non-proxy fallback targets is tracked in
-    // #529 (classes) and #530 (native constructors); the chained-proxy case
-    // forwards EffectiveNewTarget so nested proxies still see the right
-    // newTarget at their trap invocation.
+    // No construct trap: forward to target's [[Construct]](args, EffectiveNewTarget).
+    // Instantiate() is virtual — TGocciaVMClassValue dispatches to its
+    // bytecode-aware override. Native-constructor newTarget propagation
+    // remains tracked in #530 (engine-wide change required: every native
+    // allocator would need to accept newTarget).
     if FTarget is TGocciaProxyValue then
       Result := TGocciaProxyValue(FTarget).ConstructTrap(AArguments,
         EffectiveNewTarget)
     else if FTarget is TGocciaClassValue then
-      Result := TGocciaClassValue(FTarget).Instantiate(AArguments)
+    begin
+      if EffectiveNewTarget is TGocciaClassValue then
+        Result := TGocciaClassValue(FTarget).Instantiate(AArguments,
+          TGocciaClassValue(EffectiveNewTarget))
+      else
+      begin
+        Result := TGocciaClassValue(FTarget).Instantiate(AArguments);
+        if Result is TGocciaObjectValue then
+          TGocciaObjectValue(Result).Prototype :=
+            GetProtoFromConstructor(EffectiveNewTarget);
+      end;
+    end
     else if FTarget is TGocciaNativeFunctionValue then
       Result := TGocciaNativeFunctionValue(FTarget).Call(AArguments,
         TGocciaHoleValue.HoleValue)
     else if FTarget is TGocciaFunctionBase then
-      Result := TGocciaFunctionBase(FTarget).Call(AArguments,
-        TGocciaHoleValue.HoleValue)
+      Result := ConstructOrdinaryWithReceiver(TGocciaFunctionBase(FTarget),
+        AArguments,
+        TGocciaObjectValue.Create(GetProtoFromConstructor(EffectiveNewTarget)))
     else
       ThrowTypeError(SErrorProxyTargetNotConstructor, SSuggestProxyTargetType);
   end;

--- a/source/units/Goccia.Values.ProxyValue.pas
+++ b/source/units/Goccia.Values.ProxyValue.pas
@@ -93,9 +93,12 @@ type
     function ApplyTrap(const AArguments: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
 
-    // ES2026 §28.1.1 [[Construct]](argumentsList, newTarget)
+    // ES2026 §28.1.1 [[Construct]](argumentsList, newTarget). ANewTarget is
+    // forwarded to the construct trap and to a nested proxy fallback. nil
+    // means "use this proxy as newTarget" — the default for `new proxy(...)`.
     function ConstructTrap(
-      const AArguments: TGocciaArgumentsCollection): TGocciaValue;
+      const AArguments: TGocciaArgumentsCollection;
+      const ANewTarget: TGocciaValue = nil): TGocciaValue;
 
     function TypeOf: string; override;
     function IsCallable: Boolean; override;
@@ -1261,11 +1264,13 @@ end;
 
 // ES2026 §28.1.1 [[Construct]](argumentsList, newTarget)
 function TGocciaProxyValue.ConstructTrap(
-  const AArguments: TGocciaArgumentsCollection): TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
 var
   Trap: TGocciaValue;
   Args: TGocciaArgumentsCollection;
   ArgsArray: TGocciaArrayValue;
+  EffectiveNewTarget: TGocciaValue;
   I: Integer;
 begin
   CheckRevoked;
@@ -1274,6 +1279,12 @@ begin
   // is constructable. Validate before dispatching to the trap.
   if not FTarget.IsConstructable then
     ThrowTypeError(SErrorProxyTargetNotConstructor, SSuggestProxyTargetType);
+
+  // Default newTarget for `new proxy(...)` is the proxy itself per ES2026.
+  if Assigned(ANewTarget) then
+    EffectiveNewTarget := ANewTarget
+  else
+    EffectiveNewTarget := Self;
 
   Trap := GetTrap(PROP_CONSTRUCT);
   if Assigned(Trap) then
@@ -1287,7 +1298,7 @@ begin
     try
       Args.Add(FTarget);
       Args.Add(ArgsArray);
-      Args.Add(Self);
+      Args.Add(EffectiveNewTarget);
       Result := InvokeTrap(Trap, Args);
       if Result.IsPrimitive then
         ThrowTypeError(SErrorProxyConstructReturnType, SSuggestProxyTrapReturnType);
@@ -1300,8 +1311,13 @@ begin
     // No construct trap: construct the target directly (nested proxies first).
     // Use Instantiate() for class values — it is virtual, so
     // TGocciaVMClassValue dispatches to its bytecode-aware override.
+    // newTarget propagation through non-proxy fallback targets is tracked in
+    // #529 (classes) and #530 (native constructors); the chained-proxy case
+    // forwards EffectiveNewTarget so nested proxies still see the right
+    // newTarget at their trap invocation.
     if FTarget is TGocciaProxyValue then
-      Result := TGocciaProxyValue(FTarget).ConstructTrap(AArguments)
+      Result := TGocciaProxyValue(FTarget).ConstructTrap(AArguments,
+        EffectiveNewTarget)
     else if FTarget is TGocciaClassValue then
       Result := TGocciaClassValue(FTarget).Instantiate(AArguments)
     else if FTarget is TGocciaNativeFunctionValue then

--- a/source/units/Goccia.Values.ProxyValue.pas
+++ b/source/units/Goccia.Values.ProxyValue.pas
@@ -150,9 +150,7 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
   Goccia.Values.ErrorHelper,
-  Goccia.Values.FunctionBase,
-  Goccia.Values.HoleValue,
-  Goccia.Values.NativeFunction;
+  Goccia.Values.FunctionBase;
 
 { TGocciaProxyValue }
 
@@ -1307,38 +1305,13 @@ begin
     end;
   end
   else
-  begin
-    // No construct trap: forward to target's [[Construct]](args, EffectiveNewTarget).
-    // Instantiate() is virtual — TGocciaVMClassValue dispatches to its
-    // bytecode-aware override. Native-constructor newTarget propagation
-    // remains tracked in #530 (engine-wide change required: every native
-    // allocator would need to accept newTarget).
-    if FTarget is TGocciaProxyValue then
-      Result := TGocciaProxyValue(FTarget).ConstructTrap(AArguments,
-        EffectiveNewTarget)
-    else if FTarget is TGocciaClassValue then
-    begin
-      if EffectiveNewTarget is TGocciaClassValue then
-        Result := TGocciaClassValue(FTarget).Instantiate(AArguments,
-          TGocciaClassValue(EffectiveNewTarget))
-      else
-      begin
-        Result := TGocciaClassValue(FTarget).Instantiate(AArguments);
-        if Result is TGocciaObjectValue then
-          TGocciaObjectValue(Result).Prototype :=
-            GetProtoFromConstructor(EffectiveNewTarget);
-      end;
-    end
-    else if FTarget is TGocciaNativeFunctionValue then
-      Result := TGocciaNativeFunctionValue(FTarget).Call(AArguments,
-        TGocciaHoleValue.HoleValue)
-    else if FTarget is TGocciaFunctionBase then
-      Result := ConstructOrdinaryWithReceiver(TGocciaFunctionBase(FTarget),
-        AArguments,
-        TGocciaObjectValue.Create(GetProtoFromConstructor(EffectiveNewTarget)))
-    else
-      ThrowTypeError(SErrorProxyTargetNotConstructor, SSuggestProxyTargetType);
-  end;
+    // No construct trap: forward to target's [[Construct]](args, EffectiveNewTarget)
+    // through the shared dispatch — handles bound chain unwrap (so
+    // `new Proxy(F.bind(obj), {})()` does not leak the bound `this` into the
+    // synthetic receiver), nested proxies, classes, ordinary functions, and
+    // native constructors. Native-constructor newTarget propagation remains
+    // tracked in #530.
+    Result := ConstructValue(FTarget, AArguments, EffectiveNewTarget);
 end;
 
 function TGocciaProxyValue.TypeOf: string;

--- a/tests/built-ins/Reflect/construct.js
+++ b/tests/built-ins/Reflect/construct.js
@@ -273,4 +273,13 @@ describe("Reflect.construct", () => {
     Reflect.construct(outerProxy, [], Other);
     expect(inner).toBe(Other);
   });
+
+  test("Proxy with no construct trap forwards class newTarget to Instantiate", () => {
+    class Foo {}
+    class Other {}
+    const proxy = new Proxy(Foo, {});
+    const obj = Reflect.construct(proxy, [], Other);
+    expect(Object.getPrototypeOf(obj)).toBe(Other.prototype);
+    expect(obj instanceof Other).toBe(true);
+  });
 });

--- a/tests/built-ins/Reflect/construct.js
+++ b/tests/built-ins/Reflect/construct.js
@@ -231,4 +231,46 @@ describe("Reflect.construct", () => {
     expect(obj.x).toBe(7);
     expect(obj instanceof Foo).toBe(true);
   });
+
+  test("Proxy construct trap receives the explicit newTarget supplied to Reflect.construct", () => {
+    class Foo {}
+    class Other {}
+    let receivedNewTarget;
+    const proxy = new Proxy(Foo, {
+      construct(target, args, newTarget) {
+        receivedNewTarget = newTarget;
+        return Reflect.construct(target, args, newTarget);
+      },
+    });
+    Reflect.construct(proxy, [], Other);
+    expect(receivedNewTarget).toBe(Other);
+  });
+
+  test("Proxy construct trap receives the proxy as default newTarget when none is supplied", () => {
+    class Foo {}
+    let receivedNewTarget;
+    const proxy = new Proxy(Foo, {
+      construct(target, args, newTarget) {
+        receivedNewTarget = newTarget;
+        return Reflect.construct(target, args, newTarget);
+      },
+    });
+    Reflect.construct(proxy, []);
+    expect(receivedNewTarget).toBe(proxy);
+  });
+
+  test("nested proxy forwards newTarget through the outer fallback to the inner construct trap", () => {
+    class Foo {}
+    class Other {}
+    let inner;
+    const innerProxy = new Proxy(Foo, {
+      construct(target, args, newTarget) {
+        inner = newTarget;
+        return Reflect.construct(target, args, newTarget);
+      },
+    });
+    const outerProxy = new Proxy(innerProxy, {});
+    Reflect.construct(outerProxy, [], Other);
+    expect(inner).toBe(Other);
+  });
 });

--- a/tests/built-ins/Reflect/construct.js
+++ b/tests/built-ins/Reflect/construct.js
@@ -148,4 +148,87 @@ describe("Reflect.construct", () => {
     expect(obj instanceof Foo).toBe(true);
     expect(obj.isFoo).toBe(true);
   });
+
+  test("rejects an object shorthand method (no [[Construct]] slot)", () => {
+    const obj = { m() {} };
+    expect(() => Reflect.construct(obj.m, [])).toThrow(TypeError);
+  });
+
+  test("rejects a class instance method reached via prototype (no [[Construct]] slot)", () => {
+    class C {
+      m() {}
+    }
+    expect(() => Reflect.construct(C.prototype.m, [])).toThrow(TypeError);
+  });
+
+  test("rejects an arrow function used as newTarget", () => {
+    class Foo {}
+    expect(() => Reflect.construct(Foo, [], () => {})).toThrow(TypeError);
+  });
+
+  test("constructs through a bound class — bound `this` is ignored, instance is fresh", () => {
+    class Counter {
+      constructor(start) {
+        this.value = start;
+      }
+      next() {
+        this.value += 1;
+        return this.value;
+      }
+    }
+    const Bound = Counter.bind(null, 10);
+    const obj = Reflect.construct(Bound, []);
+    expect(obj.value).toBe(10);
+    expect(obj.next()).toBe(11);
+    expect(obj instanceof Counter).toBe(true);
+  });
+
+  test("bound class with explicit newTarget uses newTarget.prototype on the instance", () => {
+    class Base {
+      constructor() {
+        this.x = 1;
+      }
+    }
+    class Other {}
+    const Bound = Base.bind(null);
+    const obj = Reflect.construct(Bound, [], Other);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(Other.prototype);
+  });
+
+  test("bound non-constructable target (bound arrow) still throws", () => {
+    const Bound = (() => {}).bind(null);
+    expect(() => Reflect.construct(Bound, [])).toThrow(TypeError);
+  });
+
+  test("Proxy over a class invokes the construct trap", () => {
+    class Foo {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    let trapCalled = false;
+    const proxy = new Proxy(Foo, {
+      construct(target, args, newTarget) {
+        trapCalled = true;
+        return Reflect.construct(target, args, newTarget);
+      },
+    });
+    const obj = Reflect.construct(proxy, [99]);
+    expect(trapCalled).toBe(true);
+    expect(obj.x).toBe(99);
+    expect(obj instanceof Foo).toBe(true);
+  });
+
+  test("Proxy over a class with no construct trap falls through to the target", () => {
+    class Foo {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    const proxy = new Proxy(Foo, {});
+    const obj = Reflect.construct(proxy, [7]);
+    expect(obj.x).toBe(7);
+    expect(obj instanceof Foo).toBe(true);
+  });
 });

--- a/tests/built-ins/Reflect/construct/function-keyword.js
+++ b/tests/built-ins/Reflect/construct/function-keyword.js
@@ -250,6 +250,41 @@ describe("Reflect.construct on a proxy wrapping a function-keyword target", () =
     expect(obj.x).toBe(1);
     expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
   });
+
+  test("proxy fallback over a bound function unwraps the bound chain — receiver wins over bound `this`", () => {
+    function Capture() {
+      this.captured = this;
+      this.flag = true;
+    }
+    const sentinel = { sentinel: true };
+    const proxy = new Proxy(Capture.bind(sentinel), {});
+    const obj = Reflect.construct(proxy, []);
+    expect(obj.flag).toBe(true);
+    expect(obj.captured).toBe(obj);
+    expect(obj.captured).not.toBe(sentinel);
+  });
+
+  test("proxy fallback over a doubly-bound function merges bound args through the chain", () => {
+    function Triple(a, b, c) {
+      this.sum = a + b + c;
+    }
+    const Once = Triple.bind(null, 1);
+    const Twice = Once.bind(null, 2);
+    const proxy = new Proxy(Twice, {});
+    const obj = Reflect.construct(proxy, [3]);
+    expect(obj.sum).toBe(6);
+  });
+
+  test("proxy fallback over a bound class runs the class constructor with merged bound args", () => {
+    class Counter {
+      constructor(start) {
+        this.value = start;
+      }
+    }
+    const proxy = new Proxy(Counter.bind(null, 10), {});
+    const obj = Reflect.construct(proxy, []);
+    expect(obj.value).toBe(10);
+  });
 });
 
 describe("Reflect.construct rejects non-constructable function forms", () => {

--- a/tests/built-ins/Reflect/construct/function-keyword.js
+++ b/tests/built-ins/Reflect/construct/function-keyword.js
@@ -200,6 +200,58 @@ describe("Reflect.construct on bound function-keyword targets", () => {
   });
 });
 
+describe("Reflect.construct on a proxy wrapping a function-keyword target", () => {
+  test("proxy fallback over a function declaration uses newTarget.prototype on the receiver", () => {
+    function Foo() {
+      this.x = 1;
+    }
+    function NewTarget() {}
+    const proxy = new Proxy(Foo, {});
+    const obj = Reflect.construct(proxy, [], NewTarget);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(NewTarget.prototype);
+  });
+
+  test("proxy fallback over a function declaration with non-object newTarget.prototype falls back to Object.prototype", () => {
+    function Foo() {
+      this.x = 1;
+    }
+    function NewTarget() {}
+    NewTarget.prototype = null;
+    const proxy = new Proxy(Foo, {});
+    const obj = Reflect.construct(proxy, [], NewTarget);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+  });
+
+  test("proxy fallback over a class with function newTarget patches instance prototype from newTarget.prototype", () => {
+    class Foo {
+      constructor() {
+        this.x = 1;
+      }
+    }
+    function NewTarget() {}
+    const proxy = new Proxy(Foo, {});
+    const obj = Reflect.construct(proxy, [], NewTarget);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(NewTarget.prototype);
+  });
+
+  test("proxy fallback over a class with function newTarget whose prototype is non-object falls back to Object.prototype", () => {
+    class Foo {
+      constructor() {
+        this.x = 1;
+      }
+    }
+    function NewTarget() {}
+    NewTarget.prototype = null;
+    const proxy = new Proxy(Foo, {});
+    const obj = Reflect.construct(proxy, [], NewTarget);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+  });
+});
+
 describe("Reflect.construct rejects non-constructable function forms", () => {
   test("async function declaration target throws TypeError", () => {
     async function asyncFn() {}

--- a/tests/built-ins/Reflect/construct/function-keyword.js
+++ b/tests/built-ins/Reflect/construct/function-keyword.js
@@ -1,0 +1,195 @@
+/*---
+description: Reflect.construct accepts function declarations and expressions as the target — they own a [[Construct]] slot per spec
+features: [Reflect, compat-function]
+---*/
+
+describe("Reflect.construct on function-keyword targets", () => {
+  test("function declaration target produces an instance whose [[Prototype]] is target.prototype", () => {
+    function Foo() {
+      this.x = 1;
+    }
+    const obj = Reflect.construct(Foo, []);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(Foo.prototype);
+    expect(obj instanceof Foo).toBe(true);
+  });
+
+  test("function expression target produces an instance with arguments forwarded", () => {
+    const Foo = function (x, y) {
+      this.sum = x + y;
+    };
+    const obj = Reflect.construct(Foo, [3, 4]);
+    expect(obj.sum).toBe(7);
+    expect(obj instanceof Foo).toBe(true);
+  });
+
+  test("named function expression target works the same as a declaration", () => {
+    const Foo = function NamedFoo(x) {
+      this.value = x;
+    };
+    const obj = Reflect.construct(Foo, [42]);
+    expect(obj.value).toBe(42);
+    expect(obj instanceof Foo).toBe(true);
+  });
+
+  test("constructor body sees `this` bound to the freshly created receiver", () => {
+    function Capture() {
+      this.captured = this;
+    }
+    const obj = Reflect.construct(Capture, []);
+    expect(obj.captured).toBe(obj);
+  });
+
+  test("explicit object return replaces the constructed receiver", () => {
+    function Replace() {
+      this.fromBody = true;
+      return { replaced: true };
+    }
+    const obj = Reflect.construct(Replace, []);
+    expect(obj.replaced).toBe(true);
+    expect(obj.fromBody).toBeUndefined();
+  });
+
+  test("explicit primitive return is ignored — receiver wins", () => {
+    function ReturnPrimitive() {
+      this.kept = true;
+      return 42;
+    }
+    const obj = Reflect.construct(ReturnPrimitive, []);
+    expect(obj.kept).toBe(true);
+  });
+
+  test("newTarget controls the instance [[Prototype]]", () => {
+    function Foo() {}
+    function Bar() {}
+    const obj = Reflect.construct(Foo, [], Bar);
+    expect(Object.getPrototypeOf(obj)).toBe(Bar.prototype);
+    expect(obj instanceof Bar).toBe(true);
+    expect(obj instanceof Foo).toBe(false);
+  });
+
+  test("when newTarget.prototype is non-object, the instance falls back to Object.prototype", () => {
+    function Foo() {
+      this.x = 1;
+    }
+    function Bar() {}
+    Bar.prototype = null;
+    const obj = Reflect.construct(Foo, [], Bar);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+  });
+
+  test("instanceof against newTarget is observable from inside the constructor body", () => {
+    function Bar() {}
+    function Base() {
+      this.isBar = this instanceof Bar;
+    }
+    const obj = Reflect.construct(Base, [], Bar);
+    expect(obj.isBar).toBe(true);
+  });
+
+  test("methods inherited from newTarget.prototype are reachable during construction", () => {
+    function Target() {
+      this.greeting = this.greet();
+    }
+    function NewTarget() {}
+    NewTarget.prototype.greet = function () {
+      return "hello from newTarget";
+    };
+    const obj = Reflect.construct(Target, [], NewTarget);
+    expect(obj.greeting).toBe("hello from newTarget");
+  });
+
+  test("matches `new` semantics for function declaration targets", () => {
+    function Foo(x) {
+      this.x = x;
+    }
+    const viaNew = new Foo(7);
+    const viaReflect = Reflect.construct(Foo, [7]);
+    expect(Object.getPrototypeOf(viaReflect)).toBe(Object.getPrototypeOf(viaNew));
+    expect(viaReflect.x).toBe(viaNew.x);
+  });
+});
+
+describe("Reflect.construct on bound function-keyword targets", () => {
+  test("bound function declaration target inherits constructibility from the underlying function", () => {
+    function Foo() {
+      this.x = 1;
+    }
+    const Bound = Foo.bind(null);
+    const obj = Reflect.construct(Bound, []);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(Foo.prototype);
+    expect(obj instanceof Foo).toBe(true);
+  });
+
+  test("bound function merges bound and call arguments in order", () => {
+    function Pair(a, b) {
+      this.a = a;
+      this.b = b;
+    }
+    const Bound = Pair.bind(null, 1);
+    const obj = Reflect.construct(Bound, [2]);
+    expect(obj.a).toBe(1);
+    expect(obj.b).toBe(2);
+  });
+
+  test("bound function ignores the bound `this` — receiver is the constructed instance", () => {
+    function Capture() {
+      this.captured = this;
+    }
+    const sentinel = { sentinel: true };
+    const Bound = Capture.bind(sentinel);
+    const obj = Reflect.construct(Bound, []);
+    expect(obj.captured).toBe(obj);
+    expect(obj.captured).not.toBe(sentinel);
+  });
+
+  test("doubly-bound function still routes through the original target", () => {
+    function Triple(a, b, c) {
+      this.sum = a + b + c;
+    }
+    const Once = Triple.bind(null, 1);
+    const Twice = Once.bind(null, 2);
+    const obj = Reflect.construct(Twice, [3]);
+    expect(obj.sum).toBe(6);
+    expect(Object.getPrototypeOf(obj)).toBe(Triple.prototype);
+  });
+
+  test("bound function with explicit newTarget honors newTarget.prototype", () => {
+    function Foo() {}
+    function NewTarget() {}
+    const Bound = Foo.bind(null);
+    const obj = Reflect.construct(Bound, [], NewTarget);
+    expect(Object.getPrototypeOf(obj)).toBe(NewTarget.prototype);
+  });
+
+  test("bound non-constructable function (bound arrow) still throws TypeError", () => {
+    const arrow = () => {};
+    const Bound = arrow.bind(null);
+    expect(() => Reflect.construct(Bound, [])).toThrow(TypeError);
+  });
+});
+
+describe("Reflect.construct rejects non-constructable function forms", () => {
+  test("async function declaration target throws TypeError", () => {
+    async function asyncFn() {}
+    expect(() => Reflect.construct(asyncFn, [])).toThrow(TypeError);
+  });
+
+  test("generator function declaration target throws TypeError", () => {
+    function* gen() {}
+    expect(() => Reflect.construct(gen, [])).toThrow(TypeError);
+  });
+
+  test("async generator function declaration target throws TypeError", () => {
+    async function* asyncGen() {}
+    expect(() => Reflect.construct(asyncGen, [])).toThrow(TypeError);
+  });
+
+  test("function declaration is rejected as newTarget when not constructable (sanity: declarations always are)", () => {
+    function Foo() {}
+    async function asyncFn() {}
+    expect(() => Reflect.construct(Foo, [], asyncFn)).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Reflect/construct/function-keyword.js
+++ b/tests/built-ins/Reflect/construct/function-keyword.js
@@ -169,6 +169,35 @@ describe("Reflect.construct on bound function-keyword targets", () => {
     const Bound = arrow.bind(null);
     expect(() => Reflect.construct(Bound, [])).toThrow(TypeError);
   });
+
+  test("bound newTarget without an own `prototype` falls back to Object.prototype per §10.1.14", () => {
+    function Foo() {
+      this.x = 1;
+    }
+    function Other() {}
+    const BoundOther = Other.bind(null);
+    // Per spec, Get(BoundOther, 'prototype') walks past the bound wrapper to
+    // Function.prototype, finds nothing, returns undefined; the §10.1.14
+    // fallback then yields %Object.prototype% — engines must not unwrap to
+    // Other.prototype.
+    expect(BoundOther.prototype).toBeUndefined();
+    const obj = Reflect.construct(Foo, [], BoundOther);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+  });
+
+  test("bound newTarget with a user-assigned `prototype` uses that prototype directly", () => {
+    function Foo() {
+      this.x = 1;
+    }
+    function Other() {}
+    const BoundOther = Other.bind(null);
+    const customProto = { tag: "custom" };
+    BoundOther.prototype = customProto;
+    const obj = Reflect.construct(Foo, [], BoundOther);
+    expect(obj.x).toBe(1);
+    expect(Object.getPrototypeOf(obj)).toBe(customProto);
+  });
 });
 
 describe("Reflect.construct rejects non-constructable function forms", () => {

--- a/tests/built-ins/Reflect/construct/goccia.json
+++ b/tests/built-ins/Reflect/construct/goccia.json
@@ -1,0 +1,3 @@
+{
+  "compat-function": true
+}


### PR DESCRIPTION
## Summary

- `Reflect.construct` previously rejected function declarations, function expressions, and bound functions because the local `IsConstructorValue` predicate only recognized classes and constructable native functions, while `new fn()` already accepted them via the value system's virtual `IsConstructable`.
- Defer the predicate to `TGocciaValue.IsConstructable` (the same hook used by the `new` operator in both interpreter and bytecode VM), and expand the construction dispatch to walk bound-function chains, allocate a receiver from `newTarget`'s prototype per ES2026 §10.1.14, and route proxies through `ConstructTrap`.
- Adds gated tests under `tests/built-ins/Reflect/construct/` (with `goccia.json` enabling `compat-function`) for function-keyword targets and bound-function-keyword targets, plus ungated tests in `construct.js` for arrow/method rejection, bound-class construction, proxy traps, and arrow-as-newTarget rejection.

## Test plan

- [x] `./build.pas testrunner && ./build/GocciaTestRunner tests/built-ins/Reflect --asi --no-progress` (interpreter): 133 pass, 0 fail
- [x] Same with `--mode=bytecode`: 133 pass, 0 fail
- [x] `./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress` (full suite, interpreter): 8628 pass, 0 fail
- [x] Same with `--mode=bytecode`: 8628 pass, 0 fail
- [x] `./format.pas --check`: clean
- [x] Issue's reproduction script (`fn decl`, `fn expr`, `class`, `arrow`) now reports OK/OK/OK/THROWS as the spec table expects.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)