### PR TITLE
Block PR merge on test262 regression vs main baseline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -860,17 +860,22 @@ jobs:
           restore-keys: test262-baseline-
 
       - name: Build comment markdown
-        # Reuses scripts/run_test262_suite.ts in --comment mode so the
-        # delta computation, "Areas closest to 100%" ranking, and
-        # wrapper-infra highlighting all live in one place under version
-        # control.  Pass "-" for the baseline arg if no cached baseline
-        # exists; the script handles both shapes.
+        id: build_comment
+        # `--comment` is dual-purpose: it writes the PR comment markdown
+        # to stdout AND exits non-zero on regression vs the cached main
+        # baseline (lower total pass count, or any PASS -> non-PASS
+        # transition).  The per-test deltas live in the comment itself —
+        # this step's exit code is the only signal we need.  We mark
+        # continue-on-error so a regression doesn't abort the post-comment
+        # step; the explicit gate below converts the captured outcome
+        # into a job failure.
         #
         # The artifact download above is `continue-on-error: true`, so
         # test262-results.json may be absent when the conformance job
-        # crashed or timed out.  In that case emit the same "results
-        # not produced" stub the runner does internally so the PR
-        # comment still updates instead of going stale.
+        # crashed or timed out.  In that case emit the "results not
+        # produced" stub directly so the PR comment still updates
+        # instead of going stale, and skip the regression gate.
+        continue-on-error: true
         run: |
           baseline=test262-baseline.json
           [ -f "$baseline" ] || baseline=-
@@ -917,3 +922,9 @@ jobs:
                 body,
               });
             }
+
+      - name: Fail on regression
+        if: steps.build_comment.outcome == 'failure'
+        run: |
+          echo "::error::test262 regression detected vs cached main baseline. See the PR comment for per-test deltas."
+          exit 1

--- a/scripts/run_test262_suite.ts
+++ b/scripts/run_test262_suite.ts
@@ -25,7 +25,14 @@
  *
  * Usage:
  *   bun scripts/run_test262_suite.ts [options]
- *   bun scripts/run_test262_suite.ts --comment <results.json> <baseline.json>
+ *   bun scripts/run_test262_suite.ts --comment <results.json> <baseline.json|->
+ *
+ * --comment writes the PR comment markdown to stdout.  When run with a
+ * cached `main` baseline, it also serves as the conformance gate: it
+ * exits non-zero iff total pass count dropped or any previously-passing
+ * test transitioned to non-PASS.  Steady-state failures (the long tail
+ * of unimplemented features) remain non-blocking via continue-on-error
+ * on the conformance job itself; only true regressions block.
  *
  * See docs/test262.md for the full harness contract.
  */
@@ -1305,6 +1312,41 @@ interface BaselineSummary {
   failed?: number;
 }
 
+interface RegressionDelta {
+  hasBaseline: boolean;
+  /** current.passed - baseline.passed; equals current.passed when hasBaseline is false. */
+  totalPassedDelta: number;
+  /** Tests that were not PASS in baseline but are PASS in current. */
+  newPasses: string[];
+  /** Tests that were PASS in baseline but are not PASS in current. */
+  newFails: string[];
+}
+
+function computeRegression(
+  data: { summary: SuiteSummary; results: PerTestRecord[] } | null,
+  baseline: { summary: BaselineSummary; results?: PerTestRecord[] } | null,
+): RegressionDelta {
+  const hasBaseline = !!(baseline && baseline.summary);
+  if (!data) return { hasBaseline, totalPassedDelta: 0, newPasses: [], newFails: [] };
+  const baseTotalPassed = hasBaseline ? (baseline!.summary.passed ?? 0) : 0;
+  const totalPassedDelta = hasBaseline
+    ? data.summary.passed - baseTotalPassed
+    : data.summary.passed;
+  const newPasses: string[] = [];
+  const newFails: string[] = [];
+  if (hasBaseline) {
+    const prevById = new Map<string, Outcome>();
+    for (const r of baseline!.results || []) prevById.set(r.id, r.status);
+    for (const r of data.results) {
+      const prev = prevById.get(r.id);
+      if (!prev) continue;
+      if (prev !== "PASS" && r.status === "PASS") newPasses.push(r.id);
+      else if (prev === "PASS" && r.status !== "PASS") newFails.push(r.id);
+    }
+  }
+  return { hasBaseline, totalPassedDelta, newPasses, newFails };
+}
+
 interface AreaBucket {
   key: string;
   attempted: number;
@@ -1331,7 +1373,7 @@ function bucketAreas(results: PerTestRecord[]): Map<string, AreaBucket> {
 function buildCommentMarkdown(
   data: { summary: SuiteSummary; results: PerTestRecord[] } | null,
   baseline: { summary: BaselineSummary; results?: PerTestRecord[] } | null,
-): string {
+): { markdown: string; regressed: boolean } {
   const marker = "<!-- test262-results -->";
   let body = "## test262 Conformance\n\n";
 
@@ -1339,11 +1381,18 @@ function buildCommentMarkdown(
     body +=
       "_test262 results were not produced for this run._\n\n" +
       "<sub>Non-blocking. The conformance job either timed out, crashed, or did not upload an artifact. See the workflow run for details.</sub>\n";
-    return marker + "\n" + body;
+    return { markdown: marker + "\n" + body, regressed: false };
   }
 
   const s = data.summary;
-  const hasBaseline = !!(baseline && baseline.summary);
+  const delta = computeRegression(data, baseline);
+  const hasBaseline = delta.hasBaseline;
+  const regressed =
+    hasBaseline && (delta.totalPassedDelta < 0 || delta.newFails.length > 0);
+
+  if (regressed) {
+    body += `> 🚫 **Regression vs cached \`main\` baseline.** ${delta.newFails.length} previously-passing test(s) now fail; pass count Δ ${delta.totalPassedDelta >= 0 ? "+" : ""}${delta.totalPassedDelta}. This run blocks merge — see "Newly failing" below.\n\n`;
+  }
   const baselineByCat = new Map<string, CategorySummary>();
   if (hasBaseline) {
     for (const c of baseline!.summary.byCategory || []) {
@@ -1369,8 +1418,7 @@ function buildCommentMarkdown(
   const baseTotalRun = (baseline?.summary.totalRun) ?? 0;
   const baseTotalPassed = (baseline?.summary.passed) ?? 0;
   const baseTotalRate = baseTotalRun > 0 ? baseTotalPassed / baseTotalRun : null;
-  const dTotalPass = hasBaseline ? s.passed - baseTotalPassed : s.passed;
-  body += `| **total** | ${fmt(s.totalRun)} | ${fmt(s.passed)} | ${hasBaseline ? signed(dTotalPass) : "🆕"} | ${fmt(s.failed)} | ${pct(s.passed, s.totalRun)} | ${signedPp(totalRate, baseTotalRate)} |\n\n`;
+  body += `| **total** | ${fmt(s.totalRun)} | ${fmt(s.passed)} | ${hasBaseline ? signed(delta.totalPassedDelta) : "🆕"} | ${fmt(s.failed)} | ${pct(s.passed, s.totalRun)} | ${signedPp(totalRate, baseTotalRate)} |\n\n`;
 
   // Areas closest to 100%
   const MIN_SAMPLE = 25;
@@ -1412,41 +1460,29 @@ function buildCommentMarkdown(
   }
 
   // Per-test deltas (collapsible)
-  if (hasBaseline) {
-    const baselineStatusById = new Map<string, Outcome>();
-    for (const r of baseline!.results || []) baselineStatusById.set(r.id, r.status);
-    const newPasses: string[] = [];
-    const newFails: string[] = [];
-    for (const r of data.results) {
-      const prev = baselineStatusById.get(r.id);
-      if (!prev) continue;
-      if (prev !== "PASS" && r.status === "PASS") newPasses.push(r.id);
-      else if (prev === "PASS" && r.status !== "PASS") newFails.push(r.id);
+  if (hasBaseline && (delta.newPasses.length > 0 || delta.newFails.length > 0)) {
+    body += `<details${regressed ? " open" : ""}>\n<summary>Per-test deltas (+${delta.newPasses.length} / -${delta.newFails.length})</summary>\n\n`;
+    if (delta.newFails.length > 0) {
+      body += `**Newly failing (${delta.newFails.length}):**\n\n`;
+      for (const id of delta.newFails.slice(0, 100)) body += `- \`${id}\`\n`;
+      if (delta.newFails.length > 100) body += `- _… ${delta.newFails.length - 100} more_\n`;
+      body += "\n";
     }
-    if (newPasses.length > 0 || newFails.length > 0) {
-      body += `<details>\n<summary>Per-test deltas (+${newPasses.length} / -${newFails.length})</summary>\n\n`;
-      if (newFails.length > 0) {
-        body += `**Newly failing (${newFails.length}):**\n\n`;
-        for (const id of newFails.slice(0, 100)) body += `- \`${id}\`\n`;
-        if (newFails.length > 100) body += `- _… ${newFails.length - 100} more_\n`;
-        body += "\n";
-      }
-      if (newPasses.length > 0) {
-        body += `**Newly passing (${newPasses.length}):**\n\n`;
-        for (const id of newPasses.slice(0, 100)) body += `- \`${id}\`\n`;
-        if (newPasses.length > 100) body += `- _… ${newPasses.length - 100} more_\n`;
-        body += "\n";
-      }
-      body += "</details>\n\n";
+    if (delta.newPasses.length > 0) {
+      body += `**Newly passing (${delta.newPasses.length}):**\n\n`;
+      for (const id of delta.newPasses.slice(0, 100)) body += `- \`${id}\`\n`;
+      if (delta.newPasses.length > 100) body += `- _… ${delta.newPasses.length - 100} more_\n`;
+      body += "\n";
     }
+    body += "</details>\n\n";
   }
 
   const baselineNote = hasBaseline
     ? " Δ vs main compares against the most recent cached `main` baseline."
     : " No `main` baseline cached yet — Δ columns will appear once a `main` run completes.";
-  body += `<sub>Non-blocking. Measured on ubuntu-latest x64, bytecode mode. Areas grouped by the first two test262 path components; minimum 25 attempted tests, areas already at 100% excluded.${baselineNote}</sub>\n`;
+  body += `<sub>Steady-state failures are non-blocking; regressions vs the cached main baseline (lower total pass count, or any PASS → non-PASS transition) fail the conformance gate. Measured on ubuntu-latest x64, bytecode mode. Areas grouped by the first two test262 path components; minimum 25 attempted tests, areas already at 100% excluded.${baselineNote}</sub>\n`;
 
-  return marker + "\n" + body;
+  return { markdown: marker + "\n" + body, regressed };
 }
 
 function runComment(argv: string[]): number {
@@ -1470,7 +1506,16 @@ function runComment(argv: string[]): number {
       // Missing baseline is fine — surfaces as 🆕 in the table.
     }
   }
-  process.stdout.write(buildCommentMarkdown(data, baseline));
+  const { markdown, regressed } = buildCommentMarkdown(data, baseline);
+  process.stdout.write(markdown);
+  if (regressed) {
+    // Single-line CI annotation; the per-test list is already in the
+    // markdown comment posted to the PR, so don't repeat it here.
+    console.error(
+      "::error title=test262 regression::Pass count dropped or a previously-passing test now fails. See the PR comment for per-test deltas.",
+    );
+    return 1;
+  }
   return 0;
 }
 


### PR DESCRIPTION
## Summary

- Make the test262 conformance job block PR merge when a regression is detected vs the cached `main` baseline. Regression = total pass count dropped, or any test that was PASS on `main` is no longer PASS on the PR. Steady-state failures (the long tail of unimplemented features) remain non-blocking.
- Reuse the existing per-test delta computation from the PR comment generator instead of re-implementing it. New `computeRegression(data, baseline)` helper feeds both `buildCommentMarkdown` and the gate; `--comment` is now dual-purpose (writes the comment, exits 1 on regression).
- The PR comment becomes the single source of truth for what regressed: a top-of-comment 🚫 banner appears on regression and the per-test `<details>` is auto-expanded so reviewers don't have to click. The CI annotation is one line pointing back to the comment — no duplicated test list.
- Workflow change is minimal: `Build comment markdown` step gets `id: build_comment` and `continue-on-error: true` so the post-comment step still runs; a 3-line `Fail on regression` step gates on `steps.build_comment.outcome == 'failure'`.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — exercised four fixture scenarios against `--comment`: no regression (exit 0), per-test regression with unchanged total count (exit 1, banner + auto-expanded details), no cached baseline (🆕 markers, exit 0), missing results (stub markdown, exit 0). PR comment markdown verified end-to-end in each case.
- [ ] Updated documentation — script docstring and PR comment subscript both updated to reflect the new gate semantics; no separate docs file changed.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — N/A, no engine changes.
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — N/A, no engine changes.

> [!NOTE]
> To make this gate actually block merge, `test262-comment` needs to be added as a required status check in branch protection. Doing this in a follow-up so the gate can be observed on a few PRs first.