### PR TITLE
Fix ++/-- on BigInt operands; add OP_INC, OP_DEC, OP_TO_NUMERIC

### DIFF
--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -188,6 +188,7 @@ Language features are compiled into compact bytecode instruction sequences rathe
 - **Nullish coalescing (`??`) and nullish coalescing assignment (`??=`)** — The compiler emits `OP_JUMP_IF_NOT_NULLISH` in its nullish-match mode, so `undefined`, `null`, and internal hole values all follow the same short-circuit path without extra comparison instructions.
 - **Template literals** — The compiler parses interpolations at compile time, emits string constants and `OP_TO_STRING` for expression parts, then chains `OP_CONCAT` instructions.
 - **Object spread** — The compiler emits dedicated Goccia bytecode rather than routing through a generic extension dispatcher.
+- **Increment/decrement (`++`/`--`)** — The compiler emits `OP_TO_NUMERIC` (which preserves BigInt, converts others to Number) followed by `OP_INC`/`OP_DEC` (type-aware unit addition: `+1n` for BigInt, `+1` for Number). This replaces the prior `OP_TO_NUMBER` + `OP_LOAD_INT 1` + `OP_ADD/SUB` sequence and correctly implements ES2026 §13.4.4.1 ToNumeric semantics.
 
 This keeps the emitted bytecode compact and makes opcode additions deliberate instead of reactive.
 

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -850,6 +850,7 @@ uses
   Goccia.ImportMeta,
   Goccia.Modules,
   Goccia.RegExp.Runtime,
+  Goccia.Values.BigIntValue,
   Goccia.Values.ClassHelper,
   Goccia.Values.ClassValue,
   Goccia.Values.Error,
@@ -1867,7 +1868,8 @@ begin
   begin
     PropName := TGocciaIdentifierExpression(Operand).Name;
     OldValue := AContext.Scope.GetValue(PropName);
-    OldValue := OldValue.ToNumberLiteral;
+    if not (OldValue is TGocciaBigIntValue) then
+      OldValue := OldValue.ToNumberLiteral;
     NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
     AContext.Scope.AssignBinding(PropName, NewValue);
     if IsPrefix then
@@ -1890,7 +1892,8 @@ begin
           OldValue := TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue));
         if OldValue = nil then
           OldValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-        OldValue := OldValue.ToNumberLiteral;
+        if not (OldValue is TGocciaBigIntValue) then
+          OldValue := OldValue.ToNumberLiteral;
         NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
         if Obj is TGocciaClassValue then
           TGocciaClassValue(Obj).AssignSymbolProperty(TGocciaSymbolValue(PropertyKeyValue), NewValue)
@@ -1913,7 +1916,8 @@ begin
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
       Exit;
     end;
-    OldValue := OldValue.ToNumberLiteral;
+    if not (OldValue is TGocciaBigIntValue) then
+      OldValue := OldValue.ToNumberLiteral;
     NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
     AssignProperty(Obj, PropName, NewValue, AContext.OnError, Line, Column);
     if IsPrefix then

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -857,7 +857,8 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue,
   Goccia.Values.PromiseValue,
-  Goccia.Values.SymbolValue;
+  Goccia.Values.SymbolValue,
+  Goccia.Values.ToPrimitive;
 
 function IsNullishAssignmentValue(const AValue: TGocciaValue): Boolean; inline;
 begin
@@ -1867,7 +1868,7 @@ begin
   if Operand is TGocciaIdentifierExpression then
   begin
     PropName := TGocciaIdentifierExpression(Operand).Name;
-    OldValue := AContext.Scope.GetValue(PropName);
+    OldValue := ToPrimitive(AContext.Scope.GetValue(PropName));
     if not (OldValue is TGocciaBigIntValue) then
       OldValue := OldValue.ToNumberLiteral;
     NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
@@ -1892,6 +1893,7 @@ begin
           OldValue := TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue));
         if OldValue = nil then
           OldValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+        OldValue := ToPrimitive(OldValue);
         if not (OldValue is TGocciaBigIntValue) then
           OldValue := OldValue.ToNumberLiteral;
         NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
@@ -1916,6 +1918,7 @@ begin
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
       Exit;
     end;
+    OldValue := ToPrimitive(OldValue);
     if not (OldValue is TGocciaBigIntValue) then
       OldValue := OldValue.ToNumberLiteral;
     NewValue := PerformIncrement(OldValue, Operator = gttIncrement);

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -1859,6 +1859,13 @@ begin
   Result := NormalizeAssignmentValue(Obj.GetProperty(PropName));
 end;
 
+function ToNumericValue(const AValue: TGocciaValue): TGocciaValue; inline;
+begin
+  Result := ToPrimitive(AValue);
+  if not (Result is TGocciaBigIntValue) then
+    Result := Result.ToNumberLiteral;
+end;
+
 function TGocciaIncrementExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   Obj, OldValue, NewValue, PropertyKeyValue: TGocciaValue;
@@ -1868,9 +1875,7 @@ begin
   if Operand is TGocciaIdentifierExpression then
   begin
     PropName := TGocciaIdentifierExpression(Operand).Name;
-    OldValue := ToPrimitive(AContext.Scope.GetValue(PropName));
-    if not (OldValue is TGocciaBigIntValue) then
-      OldValue := OldValue.ToNumberLiteral;
+    OldValue := ToNumericValue(AContext.Scope.GetValue(PropName));
     NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
     AContext.Scope.AssignBinding(PropName, NewValue);
     if IsPrefix then
@@ -1893,9 +1898,7 @@ begin
           OldValue := TGocciaObjectValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKeyValue));
         if OldValue = nil then
           OldValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-        OldValue := ToPrimitive(OldValue);
-        if not (OldValue is TGocciaBigIntValue) then
-          OldValue := OldValue.ToNumberLiteral;
+        OldValue := ToNumericValue(OldValue);
         NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
         if Obj is TGocciaClassValue then
           TGocciaClassValue(Obj).AssignSymbolProperty(TGocciaSymbolValue(PropertyKeyValue), NewValue)
@@ -1913,14 +1916,8 @@ begin
       PropName := MemberExpr.PropertyName;
     OldValue := Obj.GetProperty(PropName);
     if OldValue = nil then
-    begin
-      AContext.OnError('Cannot access property on non-object', Line, Column);
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Exit;
-    end;
-    OldValue := ToPrimitive(OldValue);
-    if not (OldValue is TGocciaBigIntValue) then
-      OldValue := OldValue.ToNumberLiteral;
+      OldValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+    OldValue := ToNumericValue(OldValue);
     NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
     AssignProperty(Obj, PropName, NewValue, AContext.OnError, Line, Column);
     if IsPrefix then

--- a/source/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/source/units/Goccia.Bytecode.OpCodeNames.pas
@@ -154,6 +154,9 @@ begin
     OP_MATCH_VALUE:                    Result := 'OP_MATCH_VALUE';
     OP_MATCH_HAS_PROPERTY:             Result := 'OP_MATCH_HAS_PROPERTY';
     OP_MATCH_EXTRACTOR:                Result := 'OP_MATCH_EXTRACTOR';
+    OP_INC:                            Result := 'OP_INC';
+    OP_DEC:                            Result := 'OP_DEC';
+    OP_TO_NUMERIC:                     Result := 'OP_TO_NUMERIC';
   else
     Result := Format('OP_UNKNOWN_%d', [AOp]);
   end;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -36,7 +36,9 @@ const
   //               the synthetic super-constructor helper.
   //   v23 -> v24: #491 added OP_THROW_TYPE_ERROR_CONST_LONG so const-assignment
   //               diagnostics can reference constant-pool strings above 255.
-  GOCCIA_FORMAT_VERSION = 24;
+  //   v24 -> v25: #540 added OP_INC, OP_DEC, OP_TO_NUMERIC for spec-correct
+  //               BigInt increment/decrement (ES2026 §13.4.4.1 ToNumeric).
+  GOCCIA_FORMAT_VERSION = 25;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -211,7 +211,10 @@ type
     OP_YIELD         = 174,
     OP_MATCH_VALUE   = 175,
     OP_MATCH_HAS_PROPERTY = 176,
-    OP_MATCH_EXTRACTOR = 177
+    OP_MATCH_EXTRACTOR = 177,
+    OP_INC           = 178,
+    OP_DEC           = 179,
+    OP_TO_NUMERIC    = 180
   );
 
 function EncodeABC(const AOp: TGocciaOpCode; const A, B, C: UInt8): UInt32; inline;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -2792,25 +2792,21 @@ procedure CompileIncrementMember(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaIncrementExpression; const AMember: TGocciaMemberExpression;
   const ADest: UInt8; const AOp: TGocciaOpCode);
 var
-  ObjReg, CurReg, RegOne: UInt8;
-  PropIdx: UInt16;
+  ObjReg, CurReg: UInt8;
 begin
   ObjReg := ACtx.Scope.AllocateRegister;
   CurReg := ACtx.Scope.AllocateRegister;
-  RegOne := ACtx.Scope.AllocateRegister;
 
   ACtx.CompileExpression(AMember.ObjectExpr, ObjReg);
   EmitLoadPropertyByName(ACtx, CurReg, ObjReg, AMember.PropertyName);
-  EmitInstruction(ACtx, EncodeABC(OP_TO_NUMBER, CurReg, CurReg, 0));
-  EmitInstruction(ACtx, EncodeAsBx(OP_LOAD_INT, RegOne, 1));
+  EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, CurReg, CurReg, 0));
   if not AExpr.IsPrefix then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
-  EmitInstruction(ACtx, EncodeABC(AOp, CurReg, CurReg, RegOne));
+  EmitInstruction(ACtx, EncodeABC(AOp, CurReg, CurReg, 0));
   EmitStorePropertyByName(ACtx, ObjReg, AMember.PropertyName, CurReg);
   if AExpr.IsPrefix then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
 
-  ACtx.Scope.FreeRegister;
   ACtx.Scope.FreeRegister;
   ACtx.Scope.FreeRegister;
 end;
@@ -2819,26 +2815,23 @@ procedure CompileIncrementComputedMember(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaIncrementExpression; const AMember: TGocciaMemberExpression;
   const ADest: UInt8; const AOp: TGocciaOpCode);
 var
-  ObjReg, KeyReg, CurReg, RegOne: UInt8;
+  ObjReg, KeyReg, CurReg: UInt8;
 begin
   ObjReg := ACtx.Scope.AllocateRegister;
   KeyReg := ACtx.Scope.AllocateRegister;
   CurReg := ACtx.Scope.AllocateRegister;
-  RegOne := ACtx.Scope.AllocateRegister;
 
   ACtx.CompileExpression(AMember.ObjectExpr, ObjReg);
   ACtx.CompileExpression(AMember.PropertyExpression, KeyReg);
   EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
-  EmitInstruction(ACtx, EncodeABC(OP_TO_NUMBER, CurReg, CurReg, 0));
-  EmitInstruction(ACtx, EncodeAsBx(OP_LOAD_INT, RegOne, 1));
+  EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, CurReg, CurReg, 0));
   if not AExpr.IsPrefix then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
-  EmitInstruction(ACtx, EncodeABC(AOp, CurReg, CurReg, RegOne));
+  EmitInstruction(ACtx, EncodeABC(AOp, CurReg, CurReg, 0));
   EmitInstruction(ACtx, EncodeABC(OP_ARRAY_SET, ObjReg, KeyReg, CurReg));
   if AExpr.IsPrefix then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
 
-  ACtx.Scope.FreeRegister;
   ACtx.Scope.FreeRegister;
   ACtx.Scope.FreeRegister;
   ACtx.Scope.FreeRegister;
@@ -2848,15 +2841,15 @@ procedure CompileIncrement(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaIncrementExpression; const ADest: UInt8);
 var
   LocalIdx, UpvalIdx: Integer;
-  Slot, RegOne, RegResult: UInt8;
+  Slot, RegResult: UInt8;
   Op: TGocciaOpCode;
   Ident: TGocciaIdentifierExpression;
   MemberExpr: TGocciaMemberExpression;
 begin
   if AExpr.Operator = gttIncrement then
-    Op := OP_ADD
+    Op := OP_INC
   else
-    Op := OP_SUB;
+    Op := OP_DEC;
 
   if AExpr.Operand is TGocciaMemberExpression then
   begin
@@ -2887,32 +2880,26 @@ begin
     if ACtx.Scope.GetLocal(LocalIdx).IsGlobalBacked then
     begin
       RegResult := ACtx.Scope.AllocateRegister;
-      RegOne := ACtx.Scope.AllocateRegister;
       EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, RegResult,
         ACtx.Template.AddConstantString(Ident.Name)));
-      EmitInstruction(ACtx, EncodeABC(OP_TO_NUMBER, RegResult, RegResult, 0));
-      EmitInstruction(ACtx, EncodeAsBx(OP_LOAD_INT, RegOne, 1));
+      EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, RegResult, RegResult, 0));
       if not AExpr.IsPrefix then
         EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, RegResult, 0));
-      EmitInstruction(ACtx, EncodeABC(Op, RegResult, RegResult, RegOne));
+      EmitInstruction(ACtx, EncodeABC(Op, RegResult, RegResult, 0));
       EmitInstruction(ACtx, EncodeABx(OP_SET_GLOBAL, RegResult,
         ACtx.Template.AddConstantString(Ident.Name)));
       if AExpr.IsPrefix then
         EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, RegResult, 0));
       ACtx.Scope.FreeRegister;
-      ACtx.Scope.FreeRegister;
       Exit;
     end;
     Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
-    EmitInstruction(ACtx, EncodeABC(OP_TO_NUMBER, Slot, Slot, 0));
-    RegOne := ACtx.Scope.AllocateRegister;
-    EmitInstruction(ACtx, EncodeAsBx(OP_LOAD_INT, RegOne, 1));
+    EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, Slot, Slot, 0));
     if not AExpr.IsPrefix then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));
-    EmitInstruction(ACtx, EncodeABC(Op, Slot, Slot, RegOne));
+    EmitInstruction(ACtx, EncodeABC(Op, Slot, Slot, 0));
     if AExpr.IsPrefix then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));
-    ACtx.Scope.FreeRegister;
     Exit;
   end;
 
@@ -2925,17 +2912,15 @@ begin
       Exit;
     end;
     RegResult := ACtx.Scope.AllocateRegister;
-    RegOne := ACtx.Scope.AllocateRegister;
     if ACtx.Scope.GetUpvalue(UpvalIdx).IsGlobalBacked then
       EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, RegResult,
         ACtx.Template.AddConstantString(Ident.Name)))
     else
       EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, RegResult, UInt16(UpvalIdx)));
-    EmitInstruction(ACtx, EncodeABC(OP_TO_NUMBER, RegResult, RegResult, 0));
-    EmitInstruction(ACtx, EncodeAsBx(OP_LOAD_INT, RegOne, 1));
+    EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, RegResult, RegResult, 0));
     if not AExpr.IsPrefix then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, RegResult, 0));
-    EmitInstruction(ACtx, EncodeABC(Op, RegResult, RegResult, RegOne));
+    EmitInstruction(ACtx, EncodeABC(Op, RegResult, RegResult, 0));
     if ACtx.Scope.GetUpvalue(UpvalIdx).IsGlobalBacked then
       EmitInstruction(ACtx, EncodeABx(OP_SET_GLOBAL, RegResult,
         ACtx.Template.AddConstantString(Ident.Name)))
@@ -2944,24 +2929,20 @@ begin
     if AExpr.IsPrefix then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, RegResult, 0));
     ACtx.Scope.FreeRegister;
-    ACtx.Scope.FreeRegister;
     Exit;
   end;
 
   RegResult := ACtx.Scope.AllocateRegister;
-  RegOne := ACtx.Scope.AllocateRegister;
   EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, RegResult,
     ACtx.Template.AddConstantString(Ident.Name)));
-  EmitInstruction(ACtx, EncodeABC(OP_TO_NUMBER, RegResult, RegResult, 0));
-  EmitInstruction(ACtx, EncodeAsBx(OP_LOAD_INT, RegOne, 1));
+  EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, RegResult, RegResult, 0));
   if not AExpr.IsPrefix then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, RegResult, 0));
-  EmitInstruction(ACtx, EncodeABC(Op, RegResult, RegResult, RegOne));
+  EmitInstruction(ACtx, EncodeABC(Op, RegResult, RegResult, 0));
   EmitInstruction(ACtx, EncodeABx(OP_SET_GLOBAL, RegResult,
     ACtx.Template.AddConstantString(Ident.Name)));
   if AExpr.IsPrefix then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, RegResult, 0));
-  ACtx.Scope.FreeRegister;
   ACtx.Scope.FreeRegister;
 end;
 

--- a/source/units/Goccia.Evaluator.Assignment.pas
+++ b/source/units/Goccia.Evaluator.Assignment.pas
@@ -19,12 +19,14 @@ procedure PerformPropertyCompoundAssignment(const AObj: TGocciaValue; const APro
 procedure PerformSymbolPropertyCompoundAssignment(const AObj: TGocciaValue; const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer);
 
 // Increment/Decrement operations
-function PerformIncrement(const AOldValue: TGocciaValue; const AIsIncrement: Boolean): TGocciaValue; inline;
+function PerformIncrement(const AOldValue: TGocciaValue; const AIsIncrement: Boolean): TGocciaValue;
 
 implementation
 
 uses
   SysUtils,
+
+  BigInteger,
 
   Goccia.Arithmetic,
   Goccia.Error.Messages,
@@ -221,10 +223,22 @@ end;
 
 function PerformIncrement(const AOldValue: TGocciaValue; const AIsIncrement: Boolean): TGocciaValue;
 begin
-  if AIsIncrement then
-    Result := TGocciaNumberLiteralValue.Create(AOldValue.ToNumberLiteral.Value + 1)
+  if AOldValue is TGocciaBigIntValue then
+  begin
+    if AIsIncrement then
+      Result := TGocciaBigIntValue.Create(
+        TGocciaBigIntValue(AOldValue).Value.Add(TBigInteger.One))
+    else
+      Result := TGocciaBigIntValue.Create(
+        TGocciaBigIntValue(AOldValue).Value.Subtract(TBigInteger.One));
+  end
   else
-    Result := TGocciaNumberLiteralValue.Create(AOldValue.ToNumberLiteral.Value - 1);
+  begin
+    if AIsIncrement then
+      Result := TGocciaNumberLiteralValue.Create(AOldValue.ToNumberLiteral.Value + 1)
+    else
+      Result := TGocciaNumberLiteralValue.Create(AOldValue.ToNumberLiteral.Value - 1);
+  end;
 end;
 
 end.

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -7879,6 +7879,30 @@ begin
         end;
       end;
 
+      OP_INC:
+        if FRegisters[B].Kind = grkInt then
+          FRegisters[A] := VMIntResult(FRegisters[B].IntValue + 1)
+        else if FRegisters[B].Kind = grkFloat then
+          FRegisters[A] := VMNumberRegister(FRegisters[B].FloatValue + 1.0)
+        else if (FRegisters[B].Kind = grkObject) and
+                (FRegisters[B].ObjectValue is TGocciaBigIntValue) then
+          SetRegister(A, TGocciaBigIntValue.Create(
+            TGocciaBigIntValue(FRegisters[B].ObjectValue).Value.Add(TBigInteger.One)))
+        else
+          SetRegister(A, VMNumberValue(GetRegisterFast(B).ToNumberLiteral.Value + 1));
+
+      OP_DEC:
+        if FRegisters[B].Kind = grkInt then
+          FRegisters[A] := VMIntResult(FRegisters[B].IntValue - 1)
+        else if FRegisters[B].Kind = grkFloat then
+          FRegisters[A] := VMNumberRegister(FRegisters[B].FloatValue - 1.0)
+        else if (FRegisters[B].Kind = grkObject) and
+                (FRegisters[B].ObjectValue is TGocciaBigIntValue) then
+          SetRegister(A, TGocciaBigIntValue.Create(
+            TGocciaBigIntValue(FRegisters[B].ObjectValue).Value.Subtract(TBigInteger.One)))
+        else
+          SetRegister(A, VMNumberValue(GetRegisterFast(B).ToNumberLiteral.Value - 1));
+
       OP_MUL:
       begin
         if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
@@ -8224,6 +8248,27 @@ begin
             FRegisters[A] := RegisterObject(TGocciaNumberLiteralValue.NaNValue);
         else
           SetRegister(A, GetRegister(B).ToNumberLiteral);
+        end;
+
+      OP_TO_NUMERIC:
+        case FRegisters[B].Kind of
+          grkInt, grkFloat:
+            FRegisters[A] := FRegisters[B];
+          grkBoolean:
+            if FRegisters[B].BoolValue then
+              FRegisters[A] := RegisterInt(1)
+            else
+              FRegisters[A] := RegisterInt(0);
+          grkNull:
+            FRegisters[A] := RegisterInt(0);
+          grkUndefined, grkHole:
+            FRegisters[A] := RegisterObject(TGocciaNumberLiteralValue.NaNValue);
+        else
+          LeftValue := ToPrimitive(GetRegisterFast(B));
+          if LeftValue is TGocciaBigIntValue then
+            SetRegisterFast(A, LeftValue)
+          else
+            SetRegister(A, LeftValue.ToNumberLiteral);
         end;
 
       OP_TO_STRING:

--- a/tests/language/expressions/bigint/bigint-increment-decrement.js
+++ b/tests/language/expressions/bigint/bigint-increment-decrement.js
@@ -1,0 +1,89 @@
+/*---
+description: Increment and decrement operators on BigInt values
+features: [bigint]
+---*/
+
+test("postfix increment on BigInt variable", () => {
+  let i = 10n;
+  const old = i++;
+  expect(old).toBe(10n);
+  expect(i).toBe(11n);
+});
+
+test("postfix decrement on BigInt variable", () => {
+  let i = 10n;
+  const old = i--;
+  expect(old).toBe(10n);
+  expect(i).toBe(9n);
+});
+
+test("prefix increment on BigInt variable", () => {
+  let i = 10n;
+  const result = ++i;
+  expect(result).toBe(11n);
+  expect(i).toBe(11n);
+});
+
+test("prefix decrement on BigInt variable", () => {
+  let i = 10n;
+  const result = --i;
+  expect(result).toBe(9n);
+  expect(i).toBe(9n);
+});
+
+test("increment BigInt zero", () => {
+  let i = 0n;
+  i++;
+  expect(i).toBe(1n);
+});
+
+test("decrement BigInt zero", () => {
+  let i = 0n;
+  i--;
+  expect(i).toBe(-1n);
+});
+
+test("increment negative BigInt", () => {
+  let i = -5n;
+  i++;
+  expect(i).toBe(-4n);
+});
+
+test("decrement negative BigInt", () => {
+  let i = -1n;
+  i--;
+  expect(i).toBe(-2n);
+});
+
+test("increment large BigInt", () => {
+  let i = 9007199254740992n;
+  i++;
+  expect(i).toBe(9007199254740993n);
+});
+
+test("increment on BigInt object property", () => {
+  const obj = { count: 5n };
+  obj.count++;
+  expect(obj.count).toBe(6n);
+});
+
+test("decrement on BigInt object property", () => {
+  const obj = { count: 5n };
+  obj.count--;
+  expect(obj.count).toBe(4n);
+});
+
+test("prefix increment on BigInt computed property", () => {
+  const obj = { x: 3n };
+  const key = "x";
+  const result = ++obj[key];
+  expect(result).toBe(4n);
+  expect(obj.x).toBe(4n);
+});
+
+test("postfix decrement on BigInt computed property", () => {
+  const arr = [10n, 20n, 30n];
+  const old = arr[1]--;
+  expect(old).toBe(20n);
+  expect(arr[1]).toBe(19n);
+});

--- a/tests/language/for-loop/bigint-counter.js
+++ b/tests/language/for-loop/bigint-counter.js
@@ -1,0 +1,34 @@
+/*---
+description: Traditional for-loop with BigInt counter variable
+features: [compat-traditional-for-loop, bigint]
+---*/
+
+test("BigInt counter counts up", () => {
+  const result = [];
+  for (let i = 0n; i < 5n; i++) result.push(i);
+  expect(result).toEqual([0n, 1n, 2n, 3n, 4n]);
+});
+
+test("BigInt counter counts down", () => {
+  const result = [];
+  for (let i = 5n; i > 0n; i--) result.push(i);
+  expect(result).toEqual([5n, 4n, 3n, 2n, 1n]);
+});
+
+test("BigInt counter with prefix increment", () => {
+  const result = [];
+  for (let i = 0n; i < 5n; ++i) result.push(i);
+  expect(result).toEqual([0n, 1n, 2n, 3n, 4n]);
+});
+
+test("BigInt counter with prefix decrement", () => {
+  const result = [];
+  for (let i = 5n; i > 0n; --i) result.push(i);
+  expect(result).toEqual([5n, 4n, 3n, 2n, 1n]);
+});
+
+test("BigInt counter large range", () => {
+  let sum = 0n;
+  for (let i = 10n; i < 20n; i++) sum += i;
+  expect(sum).toBe(145n);
+});


### PR DESCRIPTION
## Summary

- Fixes `++`/`--` on BigInt-valued bindings which threw `TypeError: Cannot convert a BigInt value to a number` instead of producing a BigInt result (ES2026 §13.4.4.1 UpdateExpression).
- Adds three new bytecode opcodes: `OP_TO_NUMERIC` (passes BigInt through, converts others to Number), `OP_INC` and `OP_DEC` (type-aware increment/decrement: BigInt → +1n, Number → +1).
- Fixes the interpreter's `PerformIncrement` and the three `ToNumberLiteral` call sites in `TGocciaIncrementExpression.Evaluate` to use ToNumeric semantics.
- Net reduction: saves 1 instruction and 1 register per increment/decrement site in emitted bytecode.

## Test plan

- [x] New `bigint-increment-decrement.js` test file (13 tests): postfix/prefix ++/--, zero, negative, large, member, computed-member targets
- [x] New `for-loop/bigint-counter.js` test file (5 tests): traditional for-loop with BigInt counter (exercises #531 compat flag + this fix)
- [x] All 50 BigInt expression tests pass (interpreter + bytecode)
- [x] All 28 for-loop tests pass (interpreter + bytecode)
- [x] Full test suite (8677 tests): 8672 pass, 5 pre-existing FFI fixture failures — zero regressions
- [x] Original reproducer (`let i = 10n; i++; console.log(typeof i, i === 11n)`) outputs `bigint true`

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)