### PR TITLE
Propagate newTarget through class [[Construct]] for new.target

### DIFF
--- a/docs/language-tables.md
+++ b/docs/language-tables.md
@@ -59,6 +59,7 @@
 | `Float16Array`, `Math.f16round` | ES2025 | Supported |
 | Resizable `ArrayBuffer` (`resize`, `transfer`, `transferToFixedLength`) | ES2025 | Supported |
 | `import.meta` | ES2020 | Supported |
+| `new.target` | ES2015 | Supported |
 | Dynamic `import()` | ES2020 | Supported |
 | `Uint8Array` Base64/Hex (`fromBase64`, `fromHex`, `toBase64`, `toHex`) | ES2026 | Supported |
 | `Error.isError` | ES2026 | Supported |

--- a/docs/language.md
+++ b/docs/language.md
@@ -257,6 +257,8 @@ const currentUrl = import.meta.url;
 const helperUrl = import.meta.resolve("./helpers/math.js");
 ```
 
+`new.target` (ES2026 §13.3.12) is supported inside class constructors. It evaluates to the constructor that was directly invoked with `new`, or the `newTarget` argument supplied to `Reflect.construct`. Outside a constructor, `new.target` is `undefined`.
+
 Dynamic `import()` (ES2026 §13.3.10) is supported. It accepts an arbitrary expression as the module specifier, loads the module synchronously, and returns a Promise that resolves with the module namespace object. On failure, the returned Promise is rejected with the error. Dynamic imports work anywhere expressions are valid — including inside functions, conditionals, and async callbacks.
 
 ```javascript

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -466,6 +466,11 @@ type
     function Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue; override;
   end;
 
+  TGocciaNewTargetExpression = class(TGocciaExpression)
+  public
+    function Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue; override;
+  end;
+
   TGocciaImportCallExpression = class(TGocciaExpression)
   private
     FSpecifier: TGocciaExpression;
@@ -2012,6 +2017,14 @@ end;
 function TGocciaImportMetaExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 begin
   Result := GetOrCreateImportMeta(AContext.CurrentFilePath);
+end;
+
+// ES2026 §13.3.12.1 NewTarget : new . target
+function TGocciaNewTargetExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
+begin
+  Result := AContext.Scope.FindNewTarget;
+  if not Assigned(Result) then
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 constructor TGocciaImportCallExpression.Create(const ASpecifier: TGocciaExpression; const ALine, AColumn: Integer);

--- a/source/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/source/units/Goccia.Bytecode.OpCodeNames.pas
@@ -154,6 +154,7 @@ begin
     OP_MATCH_VALUE:                    Result := 'OP_MATCH_VALUE';
     OP_MATCH_HAS_PROPERTY:             Result := 'OP_MATCH_HAS_PROPERTY';
     OP_MATCH_EXTRACTOR:                Result := 'OP_MATCH_EXTRACTOR';
+    OP_NEW_TARGET:                     Result := 'OP_NEW_TARGET';
   else
     Result := Format('OP_UNKNOWN_%d', [AOp]);
   end;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -211,7 +211,8 @@ type
     OP_YIELD         = 174,
     OP_MATCH_VALUE   = 175,
     OP_MATCH_HAS_PROPERTY = 176,
-    OP_MATCH_EXTRACTOR = 177
+    OP_MATCH_EXTRACTOR = 177,
+    OP_NEW_TARGET    = 178
   );
 
 function EncodeABC(const AOp: TGocciaOpCode; const A, B, C: UInt8): UInt32; inline;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -36,7 +36,8 @@ const
   //               the synthetic super-constructor helper.
   //   v23 -> v24: #491 added OP_THROW_TYPE_ERROR_CONST_LONG so const-assignment
   //               diagnostics can reference constant-pool strings above 255.
-  GOCCIA_FORMAT_VERSION = 24;
+  //   v24 -> v25: #529 added OP_NEW_TARGET for the new.target meta-property.
+  GOCCIA_FORMAT_VERSION = 25;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -80,6 +80,8 @@ procedure CompileSuperAccess(const ACtx: TGocciaCompilationContext;
   const ADest: UInt8);
 procedure CompileImportMeta(const ACtx: TGocciaCompilationContext;
   const ADest: UInt8);
+procedure CompileNewTarget(const ACtx: TGocciaCompilationContext;
+  const ADest: UInt8);
 procedure CompileDynamicImport(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaImportCallExpression; const ADest: UInt8);
 procedure CompileYield(const ACtx: TGocciaCompilationContext;
@@ -3101,6 +3103,13 @@ procedure CompileImportMeta(const ACtx: TGocciaCompilationContext;
   const ADest: UInt8);
 begin
   EmitInstruction(ACtx, EncodeABC(OP_IMPORT_META, ADest, 0, 0));
+end;
+
+// ES2026 §13.3.12 MetaProperty — new.target
+procedure CompileNewTarget(const ACtx: TGocciaCompilationContext;
+  const ADest: UInt8);
+begin
+  EmitInstruction(ACtx, EncodeABC(OP_NEW_TARGET, ADest, 0, 0));
 end;
 
 // ES2026 §13.3.10 ImportCall — import(specifier)

--- a/source/units/Goccia.Compiler.pas
+++ b/source/units/Goccia.Compiler.pas
@@ -176,6 +176,8 @@ begin
   end
   else if AExpr is TGocciaImportMetaExpression then
     Goccia.Compiler.Expressions.CompileImportMeta(Ctx, ADest)
+  else if AExpr is TGocciaNewTargetExpression then
+    Goccia.Compiler.Expressions.CompileNewTarget(Ctx, ADest)
   else if AExpr is TGocciaImportCallExpression then
     Goccia.Compiler.Expressions.CompileDynamicImport(Ctx,
       TGocciaImportCallExpression(AExpr), ADest)

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -5234,13 +5234,13 @@ begin
     if Assigned(AClassValue.ConstructorMethod) then
     begin
       ConstructedValue := AClassValue.ConstructorMethod.CallWithThisValue(
-        AArguments, Instance, ConstructorThisValue);
+        AArguments, Instance, ConstructorThisValue, AClassValue);
       ApplyOwnConstructorResult(ConstructedValue, ConstructorThisValue);
     end
     else if Assigned(AClassValue.SuperClass) and Assigned(AClassValue.SuperClass.ConstructorMethod) then
     begin
       ConstructedValue := AClassValue.SuperClass.ConstructorMethod.CallWithThisValue(
-        AArguments, Instance, ConstructorThisValue);
+        AArguments, Instance, ConstructorThisValue, AClassValue);
       ValidateClassConstructorReturn(AClassValue.SuperClass, ConstructedValue);
       if IsUndefinedConstructedValue(ConstructedValue) then
         ApplyReplacementResult(ConstructorThisValue)

--- a/source/units/Goccia.Keywords.Contextual.pas
+++ b/source/units/Goccia.Keywords.Contextual.pas
@@ -10,6 +10,9 @@ const
   KEYWORD_FROM         = 'from';
   KEYWORD_META         = 'meta';
 
+  // Meta-properties
+  KEYWORD_TARGET       = 'target';
+
   // Class bodies
   KEYWORD_STATIC       = 'static';
   KEYWORD_GET          = 'get';

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -1737,6 +1737,15 @@ begin
     gttNew:
       begin
         Token := Advance;
+        // ES2026 §13.3.12 MetaProperty — new.target
+        if Check(gttDot) and CheckNext(gttIdentifier) and
+           (FTokens[FCurrent + 1].Lexeme = KEYWORD_TARGET) then
+        begin
+          Advance; // consume '.'
+          Advance; // consume 'target'
+          Result := TGocciaNewTargetExpression.Create(Token.Line, Token.Column);
+          Exit;
+        end;
         // Parse the callee: class name with optional member access (e.g. new a.B.C())
         // but NOT call expressions — those belong to the outer Call loop.
         Expr := Primary;

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -39,6 +39,7 @@ type
     function GetThisValue: TGocciaValue; virtual;
     function GetOwningClass: TGocciaValue; virtual;
     function GetSuperClass: TGocciaValue; virtual;
+    function GetNewTarget: TGocciaValue; virtual;
   public
     constructor Create(const AParent: TGocciaScope = nil; const AScopeKind: TGocciaScopeKind = skUnknown; const ACustomLabel: string = ''; const ACapacity: Integer = 0);
     destructor Destroy; override;
@@ -81,6 +82,7 @@ type
     // Walk the parent chain to find the nearest owning class / superclass
     function FindOwningClass: TGocciaValue;
     function FindSuperClass: TGocciaValue;
+    function FindNewTarget: TGocciaValue;
 
     { Read StrictTypes from the root (global) scope so that
       TGocciaEngine.SetStrictTypes propagates uniformly to closures
@@ -124,15 +126,18 @@ type
   private
     FSuperClass: TGocciaValue;
     FOwningClass: TGocciaValue;
+    FNewTarget: TGocciaValue;
   protected
     function GetOwningClass: TGocciaValue; override;
     function GetSuperClass: TGocciaValue; override;
+    function GetNewTarget: TGocciaValue; override;
   public
     constructor Create(const AParent: TGocciaScope; const AFunctionName: string;
       const ASuperClass, AOwningClass: TGocciaValue; const ACapacity: Integer = 0);
     procedure MarkReferences; override;
     property SuperClass: TGocciaValue read FSuperClass;
     property OwningClass: TGocciaValue read FOwningClass;
+    property NewTarget: TGocciaValue read FNewTarget write FNewTarget;
   end;
 
   // Scope for instance property initialization -- carries owning class
@@ -230,6 +235,11 @@ begin
   Result := nil;
 end;
 
+function TGocciaScope.GetNewTarget: TGocciaValue;
+begin
+  Result := nil;
+end;
+
 function TGocciaScope.FindFunctionOrModuleScope: TGocciaScope;
 begin
   Result := Self;
@@ -275,6 +285,20 @@ begin
   while Assigned(Current) do
   begin
     Result := Current.GetSuperClass;
+    if Assigned(Result) then Exit;
+    Current := Current.FParent;
+  end;
+  Result := nil;
+end;
+
+function TGocciaScope.FindNewTarget: TGocciaValue;
+var
+  Current: TGocciaScope;
+begin
+  Current := Self;
+  while Assigned(Current) do
+  begin
+    Result := Current.GetNewTarget;
     if Assigned(Result) then Exit;
     Current := Current.FParent;
   end;
@@ -649,6 +673,11 @@ begin
   Result := FSuperClass;
 end;
 
+function TGocciaMethodCallScope.GetNewTarget: TGocciaValue;
+begin
+  Result := FNewTarget;
+end;
+
 procedure TGocciaMethodCallScope.MarkReferences;
 begin
   inherited;
@@ -656,6 +685,8 @@ begin
     FSuperClass.MarkReferences;
   if Assigned(FOwningClass) then
     FOwningClass.MarkReferences;
+  if Assigned(FNewTarget) then
+    FNewTarget.MarkReferences;
 end;
 
 { TGocciaClassInitScope }

--- a/source/units/Goccia.VM.CallFrame.pas
+++ b/source/units/Goccia.VM.CallFrame.pas
@@ -22,6 +22,7 @@ type
     HandlerCount: Integer;
     PrevCovLine: UInt32;
     ProfileEntryTimestamp: Int64;
+    NewTarget: Pointer;
   end;
 
 implementation

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -3450,7 +3450,7 @@ begin
             EnsureBoxedArgs;
             FVM.RunClassInitializers(SuperClass, Instance);
             ConstructedValue := ConstructorToCall.CallWithThisValue(
-              BoxedArgs, Instance, ConstructorThisValue);
+              BoxedArgs, Instance, ConstructorThisValue, Self);
             ValidateClassConstructorReturn(SuperClass, ConstructedValue);
             if IsUndefinedConstructedValue(ConstructedValue) then
               ApplyReplacementResult(ConstructorThisValue)

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -88,6 +88,7 @@ type
     FCurrentModuleSourcePath: string;
     FCurrentModuleExports: TGocciaValueMap;
     FPendingNewTarget: TGocciaValue;
+    FCurrentNewTarget: TGocciaValue;
     FActiveDecoratorSession: TObject;
     FCoverageEnabled: Boolean;
     FProfilingOpcodes: Boolean;
@@ -958,6 +959,10 @@ begin
   MarkRegisterReferences(FVM.FLastClosureThisValue);
   if Assigned(FVM.FPrivateInitializerReceiver) then
     FVM.FPrivateInitializerReceiver.MarkReferences;
+  if Assigned(FVM.FPendingNewTarget) then
+    FVM.FPendingNewTarget.MarkReferences;
+  if Assigned(FVM.FCurrentNewTarget) then
+    FVM.FCurrentNewTarget.MarkReferences;
 
   Limit := FVM.FRegisterBase + FVM.FRegisterCount;
   if Limit > Length(FVM.FRegisterStack) then
@@ -979,6 +984,8 @@ begin
       FVM.FFrameStack[I].RegisterCount);
     MarkLocalCellRange(FVM.FFrameStack[I].LocalCellBase,
       FVM.FFrameStack[I].LocalCellCount);
+    if Assigned(FVM.FFrameStack[I].NewTarget) then
+      TGocciaValue(FVM.FFrameStack[I].NewTarget).MarkReferences;
   end;
 
   if Assigned(FVM.FActiveDecoratorSession) then
@@ -3387,6 +3394,7 @@ begin
         begin
           TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
             SuperClass, Instance);
+          TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := Self;
           if TGocciaVMClassValue(SuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
           begin
             BytecodeSuperConstructor := TGocciaBytecodeFunctionValue(
@@ -6659,6 +6667,7 @@ begin
   FFrameStack[FFrameStackCount].HandlerCount := FHandlerStack.Count;
   FFrameStack[FFrameStackCount].PrevCovLine := APrevCovLine;
   FFrameStack[FFrameStackCount].ProfileEntryTimestamp := AProfileTimestamp;
+  FFrameStack[FFrameStackCount].NewTarget := Pointer(FCurrentNewTarget);
   Inc(FFrameStackCount);
 end;
 
@@ -6680,6 +6689,7 @@ begin
   FCurrentClosure := FFrameStack[FFrameStackCount].Closure;
   APrevCovLine := FFrameStack[FFrameStackCount].PrevCovLine;
   AProfileTimestamp := FFrameStack[FFrameStackCount].ProfileEntryTimestamp;
+  FCurrentNewTarget := TGocciaValue(FFrameStack[FFrameStackCount].NewTarget);
   Result := FFrameStack[FFrameStackCount].ReturnRegister;
 end;
 
@@ -6866,7 +6876,7 @@ begin
     SetupNewFrame(AClosure, AThisValue, AArguments, AArgCount,
       AArg0, AArg1, AArg2, AUseFixedArgs,
       Frame, Template, PrevCovLine, ProfileEntryTimestamp);
-    Frame.NewTarget := Pointer(FPendingNewTarget);
+    FCurrentNewTarget := FPendingNewTarget;
     FPendingNewTarget := nil;
     RestoredContinuation := Assigned(GActiveBytecodeGenerator) and
       GActiveBytecodeGenerator.RestoreContinuation(
@@ -8835,8 +8845,8 @@ begin
 
       // ES2026 §13.3.12.1 — new.target reads the current frame's newTarget
       OP_NEW_TARGET:
-        if Assigned(Frame.NewTarget) then
-          SetRegister(A, TGocciaValue(Frame.NewTarget))
+        if Assigned(FCurrentNewTarget) then
+          SetRegister(A, FCurrentNewTarget)
         else
           SetRegister(A, TGocciaUndefinedLiteralValue.UndefinedValue);
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -87,6 +87,7 @@ type
     FFrameStackCount: Integer;
     FCurrentModuleSourcePath: string;
     FCurrentModuleExports: TGocciaValueMap;
+    FPendingNewTarget: TGocciaValue;
     FActiveDecoratorSession: TObject;
     FCoverageEnabled: Boolean;
     FProfilingOpcodes: Boolean;
@@ -876,7 +877,7 @@ type
       const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
     function GetClassLength: Integer; override;
     function Instantiate(const AArguments: TGocciaArgumentsCollection;
-      const ANewTarget: TGocciaClassValue = nil): TGocciaValue; override;
+      const ANewTarget: TGocciaValue = nil): TGocciaValue; override;
     function InstantiateRegisters(
       const AArguments: TGocciaRegisterArray): TGocciaRegister;
     function GetProperty(const AName: string): TGocciaValue; override;
@@ -2932,7 +2933,7 @@ end;
 // ES2026 §10.2.2 [[Construct]](argumentsList, newTarget)
 function TGocciaVMClassValue.Instantiate(
   const AArguments: TGocciaArgumentsCollection;
-  const ANewTarget: TGocciaClassValue): TGocciaValue;
+  const ANewTarget: TGocciaValue): TGocciaValue;
 var
   Instance: TGocciaObjectValue;
   RootedInstance: TGocciaObjectValue;
@@ -3020,7 +3021,7 @@ var
 begin
   // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
   if Assigned(ANewTarget) then
-    InstancePrototype := ANewTarget.Prototype
+    InstancePrototype := GetProtoFromConstructor(ANewTarget)
   else
     InstancePrototype := Prototype;
 
@@ -3055,6 +3056,9 @@ begin
     TGarbageCollector.Instance.AddTempRoot(RootedInstance);
     try
       FVM.RunClassInitializers(Self, Instance);
+      FVM.FPendingNewTarget := ANewTarget;
+      if not Assigned(FVM.FPendingNewTarget) then
+        FVM.FPendingNewTarget := Self;
       ConstructedValue := FVM.InvokeFunctionValue(
         FConstructorValue, AArguments, Instance);
       if FConstructorValue is TGocciaBytecodeFunctionValue then
@@ -3083,6 +3087,10 @@ begin
       begin
         TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
           SuperClass, Instance);
+        if Assigned(ANewTarget) then
+          TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := ANewTarget
+        else
+          TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := Self;
         ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
           TGocciaVMClassValue(SuperClass).FConstructorValue,
           AArguments, Instance);
@@ -3105,8 +3113,12 @@ begin
         if Assigned(ConstructorToCall) then
         begin
           FVM.RunClassInitializers(SuperClass, Instance);
-          ConstructedValue := ConstructorToCall.CallWithThisValue(
-            AArguments, Instance, ConstructorThisValue);
+          if Assigned(ANewTarget) then
+            ConstructedValue := ConstructorToCall.CallWithThisValue(
+              AArguments, Instance, ConstructorThisValue, ANewTarget)
+          else
+            ConstructedValue := ConstructorToCall.CallWithThisValue(
+              AArguments, Instance, ConstructorThisValue, Self);
           ValidateClassConstructorReturn(SuperClass, ConstructedValue);
           if IsUndefinedConstructedValue(ConstructedValue) then
             ApplyReplacementResult(ConstructorThisValue)
@@ -3330,6 +3342,7 @@ begin
       if Assigned(FConstructorValue) then
       begin
         FVM.RunClassInitializers(Self, Instance);
+        FVM.FPendingNewTarget := Self;
         if FConstructorValue is TGocciaBytecodeFunctionValue then
         begin
           BytecodeConstructor := TGocciaBytecodeFunctionValue(FConstructorValue);
@@ -6853,6 +6866,8 @@ begin
     SetupNewFrame(AClosure, AThisValue, AArguments, AArgCount,
       AArg0, AArg1, AArg2, AUseFixedArgs,
       Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+    Frame.NewTarget := Pointer(FPendingNewTarget);
+    FPendingNewTarget := nil;
     RestoredContinuation := Assigned(GActiveBytecodeGenerator) and
       GActiveBytecodeGenerator.RestoreContinuation(
         Frame, SavedHandlerCount, PrevCovLine);
@@ -8817,6 +8832,13 @@ begin
           SetRegister(A, GetOrCreateImportMeta(Template.DebugInfo.SourceFile))
         else
           SetRegister(A, GetOrCreateImportMeta(FCurrentModuleSourcePath));
+
+      // ES2026 §13.3.12.1 — new.target reads the current frame's newTarget
+      OP_NEW_TARGET:
+        if Assigned(Frame.NewTarget) then
+          SetRegister(A, TGocciaValue(Frame.NewTarget))
+        else
+          SetRegister(A, TGocciaUndefinedLiteralValue.UndefinedValue);
 
       // ES2026 §13.3.10.1 ImportCall — import(specifier)
       OP_DYNAMIC_IMPORT:

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -104,7 +104,7 @@ type
     procedure AppendOwnPrivateNames(const ANames: TStrings);
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; virtual;
     function Instantiate(const AArguments: TGocciaArgumentsCollection;
-      const ANewTarget: TGocciaClassValue = nil): TGocciaValue; virtual;
+      const ANewTarget: TGocciaValue = nil): TGocciaValue; virtual;
     function EstimatedInstancePropertyCapacity: Integer;
     // ECMAScript: number of expected constructor parameters before the first
     // default/rest. Built-in classes default to 0; user classes derive from
@@ -966,17 +966,18 @@ end;
 
 // ES2026 §10.2.2 [[Construct]](argumentsList, newTarget)
 function TGocciaClassValue.Instantiate(const AArguments: TGocciaArgumentsCollection;
-  const ANewTarget: TGocciaClassValue): TGocciaValue;
+  const ANewTarget: TGocciaValue): TGocciaValue;
 var
   Instance: TGocciaObjectValue;
   WalkClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
   ConstructorToCall: TGocciaMethodValue;
   InstancePrototype: TGocciaObjectValue;
+  FinalThis: TGocciaValue;
 begin
   // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
   if Assigned(ANewTarget) then
-    InstancePrototype := ANewTarget.Prototype
+    InstancePrototype := GetProtoFromConstructor(ANewTarget)
   else
     InstancePrototype := FClassPrototype;
 
@@ -1013,7 +1014,8 @@ begin
   begin
     TGarbageCollector.Instance.AddTempRoot(Instance);
     try
-      ConstructorToCall.Call(AArguments, Instance);
+      ConstructorToCall.CallWithThisValue(AArguments, Instance,
+        FinalThis, ANewTarget);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(Instance);
     end;

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -236,22 +236,8 @@ begin
       Result := TGocciaProxyValue(EffectiveTarget).ConstructTrap(WorkingArgs,
         EffectiveNewTarget)
     else if EffectiveTarget is TGocciaClassValue then
-    begin
-      if EffectiveNewTarget is TGocciaClassValue then
-        Result := TGocciaClassValue(EffectiveTarget).Instantiate(WorkingArgs,
-          TGocciaClassValue(EffectiveNewTarget))
-      else
-      begin
-        // Patching the freshly-created instance's [[Prototype]] after the
-        // constructor returns is sound while Instantiate ignores explicit
-        // object returns; once that engine limitation is lifted (tracked
-        // alongside #529), this branch must derive the receiver pre-call.
-        Result := TGocciaClassValue(EffectiveTarget).Instantiate(WorkingArgs);
-        if Result is TGocciaObjectValue then
-          TGocciaObjectValue(Result).Prototype :=
-            GetProtoFromConstructor(EffectiveNewTarget);
-      end;
-    end
+      Result := TGocciaClassValue(EffectiveTarget).Instantiate(WorkingArgs,
+        EffectiveNewTarget)
     else if EffectiveTarget is TGocciaNativeFunctionValue then
       Result := TGocciaNativeFunctionValue(EffectiveTarget).Call(WorkingArgs,
         TGocciaHoleValue.HoleValue)

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -67,7 +67,8 @@ type
   public
     constructor Create(const AParameters: TGocciaParameterArray; const ABodyStatements: TObjectList<TGocciaASTNode>; const AClosure: TGocciaScope; const AName: string; const ASuperClass: TGocciaValue = nil);
     function CallWithThisValue(const AArguments: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue; out AFinalThisValue: TGocciaValue): TGocciaValue;
+      const AThisValue: TGocciaValue; out AFinalThisValue: TGocciaValue;
+      const ANewTarget: TGocciaValue = nil): TGocciaValue;
     procedure MarkReferences; override;
 
     property SuperClass: TGocciaValue read FSuperClass write FSuperClass;
@@ -432,7 +433,8 @@ end;
 
 function TGocciaMethodValue.CallWithThisValue(
   const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue;
-  out AFinalThisValue: TGocciaValue): TGocciaValue;
+  out AFinalThisValue: TGocciaValue;
+  const ANewTarget: TGocciaValue): TGocciaValue;
 var
   CallScope: TGocciaScope;
   GC: TGarbageCollector;
@@ -451,6 +453,8 @@ begin
   end;
   try
     CallScope := CreateCallScope;
+    if Assigned(ANewTarget) and (CallScope is TGocciaMethodCallScope) then
+      TGocciaMethodCallScope(CallScope).NewTarget := ANewTarget;
     if Assigned(GC) then
     begin
       GC.PushActiveRoot(CallScope);

--- a/tests/built-ins/Reflect/construct.js
+++ b/tests/built-ins/Reflect/construct.js
@@ -282,4 +282,36 @@ describe("Reflect.construct", () => {
     expect(Object.getPrototypeOf(obj)).toBe(Other.prototype);
     expect(obj instanceof Other).toBe(true);
   });
+
+  test("new.target inside class constructor reflects non-class newTarget", () => {
+    class Foo {
+      constructor() {
+        this.observed = new.target;
+      }
+    }
+    class NewTarget {}
+    const obj = Reflect.construct(Foo, [], NewTarget);
+    expect(obj.observed).toBe(NewTarget);
+  });
+
+  test("new.target.name inside class constructor reflects newTarget class name", () => {
+    class Foo {
+      constructor() {
+        this.ntName = new.target.name;
+      }
+    }
+    class Custom {}
+    const obj = Reflect.construct(Foo, [], Custom);
+    expect(obj.ntName).toBe("Custom");
+  });
+
+  test("new.target is the class itself for normal new expression", () => {
+    class Bar {
+      constructor() {
+        this.nt = new.target;
+      }
+    }
+    const obj = new Bar();
+    expect(obj.nt).toBe(Bar);
+  });
 });


### PR DESCRIPTION
## Summary

- Parse `new.target` as a meta-property (ES2026 §13.3.12), mirroring the existing `import.meta` pattern
- Widen `TGocciaClassValue.Instantiate` to accept any `TGocciaValue` as newTarget (not just `TGocciaClassValue`), allowing `Reflect.construct(Class, args, ordinaryFunction)` to propagate the function through
- Thread the supplied newTarget into the constructor's scope (`TGocciaMethodCallScope.FNewTarget`) so `new.target` resolves correctly inside the constructor body
- Add `OP_NEW_TARGET` bytecode opcode for the VM path, stored on the call frame and set before constructor entry

Both interpreter and bytecode VM now produce the correct `new.target` value for `Reflect.construct` with a non-class newTarget, and for normal `new Class()` expressions.

Closes #529

## Test plan

- [x] Reproduction case from the issue (`Reflect.construct(Foo, [], NewTarget)` → `new.target.name === "NewTarget"`) passes in both modes
- [x] Normal `new Foo()` still reports `new.target === Foo`
- [x] Prototype correctly derived from newTarget via `GetProtoFromConstructor`
- [x] `new.target` is `undefined` outside constructors
- [x] Full test suite passes with no regressions (8657/8662, only pre-existing FFI fixture failures)
- [x] Bytecode mode tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)