### PR TITLE
Implement Error.prototype.toString (ES2026 §20.5.3.4)

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -344,6 +344,12 @@ try { null.x; } catch (e) {
 |--------|-------------|
 | `Error.isError(arg)` | Returns `true` if `arg` is an Error instance (has `[[ErrorData]]` internal slot), `false` otherwise |
 
+**Prototype methods:**
+
+| Method | Description |
+|--------|-------------|
+| `error.toString()` | Returns `"name: message"`, or just `name` if message is empty, or just `message` if name is empty (ES2026 §20.5.3.4). Inherited by all NativeError subclasses through the prototype chain |
+
 All error constructors accept an optional second argument `options` with a `cause` property. `AggregateError` takes `(errors, message, options?)` where `errors` is an array of error objects. `DOMException` takes `(message?, name?)` where `name` defaults to `"Error"` — the `code` property is automatically set from the legacy error code mapping (e.g., `"DataCloneError"` → 25).
 
 Each creates an error object with `name`, `message`, and `stack` properties. The `stack` property is a formatted string with the following structure:

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -203,7 +203,8 @@ begin
   FErrorProto.DefineProperty(PROP_MESSAGE, TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create(''), [pfConfigurable, pfWritable]));
   with TGocciaMemberCollection.Create do
   try
-    AddNamedMethod(PROP_TO_STRING, ErrorPrototypeToString, 0);
+    AddNamedMethod(PROP_TO_STRING, ErrorPrototypeToString, 0,
+      gmkPrototypeMethod, [gmfNotConstructable]);
     ErrorProtoMembers := ToDefinitions;
   finally
     Free;

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -399,7 +399,7 @@ var
   Name, Msg: string;
 begin
   if not (AThisValue is TGocciaObjectValue) then
-    ThrowTypeError('Error.prototype.toString requires that ''this'' be an Object');
+    ThrowTypeError(SErrorErrorProtoToStringRequiresObject);
 
   Obj := TGocciaObjectValue(AThisValue);
 

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -53,6 +53,7 @@ type
     function SuppressedErrorConstructor(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function DOMExceptionConstructor(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ErrorIsError(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ErrorPrototypeToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function QueueMicrotaskCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function StructuredCloneCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function EncodeURICallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -189,6 +190,7 @@ var
   SuppressedErrorConstructorFunc: TGocciaNativeFunctionValue;
   DOMExceptionConstructorFunc: TGocciaNativeFunctionValue;
   ErrorStaticMembers: TArray<TGocciaMemberDefinition>;
+  ErrorProtoMembers: TArray<TGocciaMemberDefinition>;
 begin
   inherited Create(AName, AScope, AThrowError);
 
@@ -199,6 +201,14 @@ begin
   FErrorProto := TGocciaObjectValue.Create;
   FErrorProto.DefineProperty(PROP_NAME, TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create(ERROR_NAME), [pfConfigurable, pfWritable]));
   FErrorProto.DefineProperty(PROP_MESSAGE, TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create(''), [pfConfigurable, pfWritable]));
+  with TGocciaMemberCollection.Create do
+  try
+    AddNamedMethod(PROP_TO_STRING, ErrorPrototypeToString, 0);
+    ErrorProtoMembers := ToDefinitions;
+  finally
+    Free;
+  end;
+  RegisterMemberDefinitions(FErrorProto, ErrorProtoMembers);
 
   FTypeErrorProto := TGocciaObjectValue.Create(FErrorProto);
   FTypeErrorProto.DefineProperty(PROP_NAME, TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create(TYPE_ERROR_NAME), [pfConfigurable, pfWritable]));
@@ -379,6 +389,38 @@ begin
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// ES2026 §20.5.3.4 Error.prototype.toString()
+function TGocciaGlobals.ErrorPrototypeToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Obj: TGocciaObjectValue;
+  NameValue, MsgValue: TGocciaValue;
+  Name, Msg: string;
+begin
+  if not (AThisValue is TGocciaObjectValue) then
+    ThrowTypeError('Error.prototype.toString requires that ''this'' be an Object');
+
+  Obj := TGocciaObjectValue(AThisValue);
+
+  NameValue := Obj.GetProperty(PROP_NAME);
+  if (NameValue = nil) or (NameValue is TGocciaUndefinedLiteralValue) then
+    Name := ERROR_NAME
+  else
+    Name := NameValue.ToStringLiteral.Value;
+
+  MsgValue := Obj.GetProperty(PROP_MESSAGE);
+  if (MsgValue = nil) or (MsgValue is TGocciaUndefinedLiteralValue) then
+    Msg := ''
+  else
+    Msg := MsgValue.ToStringLiteral.Value;
+
+  if Name = '' then
+    Result := TGocciaStringLiteralValue.Create(Msg)
+  else if Msg = '' then
+    Result := TGocciaStringLiteralValue.Create(Name)
+  else
+    Result := TGocciaStringLiteralValue.Create(Name + ': ' + Msg);
 end;
 
 { TypeError ( message [ , options ] ) — §20.5.6.1.1 (NativeError) }

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -582,6 +582,9 @@ resourcestring
   // Disposal method errors
   SErrorDisposePropertyNotFunction = 'Property [Symbol.%s] is not a function';
 
+  // Error prototype errors
+  SErrorErrorProtoToStringRequiresObject = 'Error.prototype.toString requires that ''this'' be an Object';
+
   // Symbol prototype errors
   SErrorSymbolConstructorRequiresCall = 'Symbol is not a constructor';
   SErrorSymbolProtoToStringRequiresSymbol = 'Symbol.prototype.toString requires that ''this'' be a Symbol';

--- a/tests/built-ins/Error/toString.js
+++ b/tests/built-ins/Error/toString.js
@@ -1,0 +1,80 @@
+/*---
+description: Error.prototype.toString (ES2026 §20.5.3.4)
+features: [Error]
+---*/
+
+test("Error.prototype.toString returns name: message", () => {
+  expect(new Error("hi").toString()).toBe("Error: hi");
+});
+
+test("TypeError.prototype.toString returns name: message", () => {
+  expect(new TypeError("nope").toString()).toBe("TypeError: nope");
+});
+
+test("RangeError.prototype.toString returns name: message", () => {
+  expect(new RangeError("out").toString()).toBe("RangeError: out");
+});
+
+test("ReferenceError.prototype.toString returns name: message", () => {
+  expect(new ReferenceError("x").toString()).toBe("ReferenceError: x");
+});
+
+test("SyntaxError.prototype.toString returns name: message", () => {
+  expect(new SyntaxError("bad").toString()).toBe("SyntaxError: bad");
+});
+
+test("URIError.prototype.toString returns name: message", () => {
+  expect(new URIError("uri").toString()).toBe("URIError: uri");
+});
+
+test("Error.prototype.toString returns just name when message is empty", () => {
+  expect(new Error().toString()).toBe("Error");
+  expect(new Error("").toString()).toBe("Error");
+});
+
+test("Error.prototype.toString returns just message when name is empty", () => {
+  const e = new Error("foo");
+  e.name = "";
+  expect(e.toString()).toBe("foo");
+});
+
+test("Error.prototype.toString returns empty string when both are empty", () => {
+  const e = new Error();
+  e.name = "";
+  expect(e.toString()).toBe("");
+});
+
+test("Error.prototype.toString uses undefined name as 'Error'", () => {
+  const e = new Error("test");
+  e.name = undefined;
+  expect(e.toString()).toBe("Error: test");
+});
+
+test("user class extending Error inherits prototype.toString", () => {
+  class MyErr extends Error {}
+  expect(new MyErr("x").toString()).toBe("Error: x");
+});
+
+test("String(error) uses prototype.toString", () => {
+  expect(String(new Error("hi"))).toBe("Error: hi");
+  expect(String(new TypeError("t"))).toBe("TypeError: t");
+});
+
+test("template literal uses prototype.toString", () => {
+  const e = new Error("hello");
+  expect(`${e}`).toBe("Error: hello");
+});
+
+test("Error.prototype.toString is inherited, not per-subclass", () => {
+  const desc = Object.getOwnPropertyDescriptor(TypeError.prototype, "toString");
+  expect(desc).toBe(undefined);
+  expect(typeof Object.getOwnPropertyDescriptor(Error.prototype, "toString")).toBe("object");
+});
+
+test("Error.prototype.toString throws on non-object this", () => {
+  const fn = Error.prototype.toString;
+  expect(() => fn.call(null)).toThrow(TypeError);
+  expect(() => fn.call(undefined)).toThrow(TypeError);
+  expect(() => fn.call(42)).toThrow(TypeError);
+  expect(() => fn.call("string")).toThrow(TypeError);
+});

--- a/tests/built-ins/Error/toString.js
+++ b/tests/built-ins/Error/toString.js
@@ -78,3 +78,9 @@ test("Error.prototype.toString throws on non-object this", () => {
   expect(() => fn.call(42)).toThrow(TypeError);
   expect(() => fn.call("string")).toThrow(TypeError);
 });
+
+test("Error.prototype.toString is not a constructor", () => {
+  const fn = Error.prototype.toString;
+  expect(() => new fn()).toThrow(TypeError);
+  expect(() => Reflect.construct(Object, [], fn)).toThrow(TypeError);
+});


### PR DESCRIPTION
## Summary

- Define `Error.prototype.toString` on `FErrorProto` per ES2026 §20.5.3.4, so all NativeError subclasses and user `class extends Error` inherit it through the prototype chain
- Fixes `String(error)` and template-literal `${error}` which threw `TypeError: Cannot convert object to primitive value` after #527
- Add 15 tests covering all error types, edge cases (empty name/message, undefined name), inheritance, `String()` coercion, template literals, and TypeError on non-object `this`
- Document the new method in `docs/built-ins.md`

Closes #545

## Test plan

- [x] Reproduction script from the issue passes in both interpreter and bytecode modes
- [x] All 15 new `tests/built-ins/Error/toString.js` tests pass
- [x] All 124 existing Error tests pass (no regressions)
- [x] Full test suite: 8710/8715 pass (5 pre-existing FFI library failures)
- [x] `./format.pas --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)