### PR TITLE
Fix use-after-free in class field initializer scopes

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -21,7 +21,7 @@ This command is explicit permission to commit relevant changes, push the branch,
 5. Commit with a concise message passed via HEREDOC.
 6. Push the branch with upstream tracking when needed: `git push -u origin HEAD`.
 7. Build the PR body from the repository's pull request template. Read `.github/pull_request_template.md`, or the relevant template under `.github/PULL_REQUEST_TEMPLATE/` if the repository uses multiple templates. Fill the template faithfully and preserve its structure.
-8. Create the pull request with GraphQL first:
+8. Create the pull request as a **draft** with GraphQL first:
 
 ```bash
 gh api graphql \
@@ -31,7 +31,8 @@ gh api graphql \
       baseRefName: $base,
       headRefName: $head,
       title: $title,
-      body: $body
+      body: $body,
+      draft: true
     }) {
       pullRequest { url number }
     }
@@ -43,7 +44,7 @@ gh api graphql \
   -f body="$PR_BODY"
 ```
 
-9. If GraphQL is rate-limited or unavailable, create the pull request with REST:
+9. If GraphQL is rate-limited or unavailable, create the pull request as a **draft** with REST:
 
 ```bash
 gh api "repos/$OWNER/$REPO/pulls" \
@@ -51,6 +52,7 @@ gh api "repos/$OWNER/$REPO/pulls" \
   -f head="$HEAD_BRANCH" \
   -f base="$BASE_BRANCH" \
   -f body="$PR_BODY" \
+  -F draft=true \
   --jq '.html_url'
 ```
 

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -15,5 +15,13 @@ Resolve review comments on the current PR by following `.agents/skills/resolve-r
 - Keep the final summary in chat unless the user explicitly asks to post it to GitHub.
 - Preserve unrelated work in the working tree. Do not revert changes you did not make.
 - Run relevant verification before committing review fixes.
+- **Merge the `main` baseline** before starting review work if the branch is behind `origin/main`:
+
+```bash
+git fetch origin main
+git merge origin/main --no-edit
+```
+
+   If the merge has conflicts, resolve them and commit the merge before addressing review comments.
 
 Avoid commands that create top-level comments, including `gh pr comment`, REST issue comment endpoints, or a review body that is not tied to an existing thread.

--- a/.agents/skills/update-pr/SKILL.md
+++ b/.agents/skills/update-pr/SKILL.md
@@ -8,6 +8,11 @@ disable-model-invocation: true
 
 This command is explicit permission to commit relevant changes and push them to the current PR branch.
 
+## Rules
+
+- **Never amend commits.** Always create new commits.
+- **Never force push.** Use `git push` without `--force` or `--force-with-lease`.
+
 ## Steps
 
 1. Inspect the repository state:
@@ -17,22 +22,30 @@ This command is explicit permission to commit relevant changes and push them to 
    - `git log --oneline -5`
 2. Confirm the current branch is not `main`. If it is `main`, stop and ask for the intended PR branch.
 3. Confirm the branch has an associated PR with `gh pr view`. If there is no PR, ask whether to run `/create-pr` instead.
-4. Confirm there are changes to commit. If there are none, stop.
-5. Stage only relevant files. Exclude secrets and unrelated user changes.
-6. Commit with a concise message passed via HEREDOC.
-7. Push the branch, setting upstream tracking if needed:
+4. **Merge the `main` baseline** if the branch is behind `origin/main`:
+
+```bash
+git fetch origin main
+git merge origin/main --no-edit
+```
+
+   If the merge has conflicts, resolve them and commit the merge before continuing.
+5. Confirm there are changes to commit. If there are none (beyond the merge), skip to step 7.
+6. Stage only relevant files. Exclude secrets and unrelated user changes.
+7. Commit with a concise message passed via HEREDOC.
+8. Push the branch, setting upstream tracking if needed:
 
 ```bash
 git push -u origin HEAD
 ```
 
-8. Review the current PR title and body against the latest implementation:
+9. Review the current PR title and body against the latest implementation:
    - Read `.github/pull_request_template.md`, or the relevant template under `.github/PULL_REQUEST_TEMPLATE/` if the repository uses multiple templates.
    - Fetch the PR body with `gh pr view --json body,url,title`.
    - Compare the title, Summary, Testing, linked issues, and any scope notes with the actual commits and verification just performed.
    - If the title is stale, too narrow, or no longer matches the implementation, update it with `gh pr edit --title "$PR_TITLE"`.
    - If the body is stale, incomplete, or no longer matches the implementation, update it with `gh pr edit --body-file <file>`.
    - Preserve the repository pull request template structure and avoid removing useful reviewer context.
-9. Report the commit hash, pushed branch, PR URL, whether the PR title or body was updated, and verification performed.
+10. Report the commit hash, pushed branch, PR URL, whether the PR title or body was updated, and verification performed.
 
 Do not skip git hooks or verification unless the user explicitly asks.

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -5041,48 +5041,40 @@ var
 begin
   InitContext := AContext;
   InitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue);
-  try
-    InitScope.ThisValue := AInstance;
-    InitContext.Scope := InitScope;
+  InitScope.ThisValue := AInstance;
+  InitContext.Scope := InitScope;
 
-    if AInstance is TGocciaInstanceValue then
+  if AInstance is TGocciaInstanceValue then
+  begin
+    InitializeInstanceProperties(TGocciaInstanceValue(AInstance), AClassValue, InitContext);
+
+    if AClassValue.FieldOrderCount = 0 then
     begin
-      InitializeInstanceProperties(TGocciaInstanceValue(AInstance), AClassValue, InitContext);
-
-      if AClassValue.FieldOrderCount = 0 then
+      WalkClass := AClassValue.SuperClass;
+      while Assigned(WalkClass) do
       begin
-        WalkClass := AClassValue.SuperClass;
-        while Assigned(WalkClass) do
-        begin
-          CheckExecutionTimeout;
-          IncrementInstructionCounter;
-          CheckInstructionLimit;
-          SuperInitContext := AContext;
-          SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, WalkClass);
-          try
-            SuperInitScope.ThisValue := AInstance;
-            SuperInitContext.Scope := SuperInitScope;
-            if WalkClass.FieldOrderCount = 0 then
-              InitializePrivateInstanceProperties(
-                AInstance, WalkClass, SuperInitContext);
-          finally
-            SuperInitScope.Free;
-          end;
-          WalkClass := WalkClass.SuperClass;
-        end;
-
-        InitializePrivateInstanceProperties(AInstance, AClassValue, InitContext);
+        CheckExecutionTimeout;
+        IncrementInstructionCounter;
+        CheckInstructionLimit;
+        SuperInitContext := AContext;
+        SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, WalkClass);
+        SuperInitScope.ThisValue := AInstance;
+        SuperInitContext.Scope := SuperInitScope;
+        if WalkClass.FieldOrderCount = 0 then
+          InitializePrivateInstanceProperties(
+            AInstance, WalkClass, SuperInitContext);
+        WalkClass := WalkClass.SuperClass;
       end;
-    end
-    else
-      InitializeObjectInstanceProperties(AInstance, AClassValue, InitContext);
 
-    AClassValue.RunMethodInitializers(AInstance);
-    AClassValue.RunFieldInitializers(AInstance);
-    AClassValue.RunDecoratorFieldInitializers(AInstance);
-  finally
-    InitScope.Free;
-  end;
+      InitializePrivateInstanceProperties(AInstance, AClassValue, InitContext);
+    end;
+  end
+  else
+    InitializeObjectInstanceProperties(AInstance, AClassValue, InitContext);
+
+  AClassValue.RunMethodInitializers(AInstance);
+  AClassValue.RunFieldInitializers(AInstance);
+  AClassValue.RunDecoratorFieldInitializers(AInstance);
 end;
 
 function InstantiateClass(const AClassValue: TGocciaClassValue;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -3161,21 +3161,14 @@ var
   Expr: TGocciaExpression;
   SuperInitContext: TGocciaEvaluationContext;
   SuperInitScope: TGocciaScope;
-  OldScope: TGocciaScope;
 begin
   if Assigned(AClassValue.SuperClass) then
   begin
     SuperInitContext := AContext;
-    OldScope := SuperInitContext.Scope;
     SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue.SuperClass);
-    try
-      SuperInitScope.ThisValue := AInstance;
-      SuperInitContext.Scope := SuperInitScope;
-      InitializeObjectInstanceProperties(AInstance, AClassValue.SuperClass, SuperInitContext);
-    finally
-      SuperInitContext.Scope := OldScope;
-      SuperInitScope.Free;
-    end;
+    SuperInitScope.ThisValue := AInstance;
+    SuperInitContext.Scope := SuperInitScope;
+    InitializeObjectInstanceProperties(AInstance, AClassValue.SuperClass, SuperInitContext);
   end;
 
   if AClassValue.HasPrivateInstanceElements then


### PR DESCRIPTION
## Summary

- Fix use-after-free in `RunClassInstanceInitializers`: the `TGocciaClassInitScope` was explicitly freed while arrow functions created during field initialization still held a dangling `FClosure` reference. When those arrows were called later, `BindThis` walked freed memory — causing stack overflows on x86_64-darwin and infinite loops on i386-win32.
- Remove the explicit `Free` calls on `InitScope` and `SuperInitScope`; let the GC collect them. Arrow closures keep the scopes reachable through `FClosure` marking.
- Update project command skills: `/create-pr` creates draft PRs, `/update-pr` merges main baseline and never amends/force-pushes, `/review-pr` merges main baseline before addressing comments.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change