### PR TITLE
Create per-class init scope in InitializeInstanceProperties

### DIFF
--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -3106,9 +3106,16 @@ var
   I: Integer;
   FOEntry: TGocciaClassFieldOrderEntry;
   Expr: TGocciaExpression;
+  LocalContext: TGocciaEvaluationContext;
+  LocalScope: TGocciaScope;
 begin
+  LocalContext := AContext;
+  LocalScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue);
+  LocalScope.ThisValue := AInstance;
+  LocalContext.Scope := LocalScope;
+
   if Assigned(AClassValue.SuperClass) then
-    InitializeInstanceProperties(AInstance, AClassValue.SuperClass, AContext);
+    InitializeInstanceProperties(AInstance, AClassValue.SuperClass, LocalContext);
 
   if AClassValue.FieldOrderCount > 0 then
   begin
@@ -3120,7 +3127,7 @@ begin
       begin
         if AClassValue.PrivateInstancePropertyDefs.TryGetValue(FOEntry.Name, Expr) and Assigned(Expr) then
         begin
-          PropertyValue := EvaluateExpression(Expr, AContext);
+          PropertyValue := EvaluateExpression(Expr, LocalContext);
           AInstance.SetPrivateProperty(FOEntry.Name, PropertyValue, AClassValue);
         end;
       end
@@ -3128,7 +3135,7 @@ begin
       begin
         if AClassValue.InstancePropertyDefs.TryGetValue(FOEntry.Name, Expr) and Assigned(Expr) then
         begin
-          PropertyValue := EvaluateExpression(Expr, AContext);
+          PropertyValue := EvaluateExpression(Expr, LocalContext);
           AInstance.AssignProperty(FOEntry.Name, PropertyValue);
         end;
       end;
@@ -3139,7 +3146,7 @@ begin
     for I := 0 to AClassValue.InstancePropertyDefs.Count - 1 do
     begin
       Entry := AClassValue.InstancePropertyDefs.EntryAt(I);
-      PropertyValue := EvaluateExpression(Entry.Value, AContext);
+      PropertyValue := EvaluateExpression(Entry.Value, LocalContext);
       AInstance.AssignProperty(Entry.Key, PropertyValue);
     end;
   end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -3388,7 +3388,6 @@ begin
       end
       else
       begin
-        FVM.RunClassInitializers(Self, Instance);
         ConstructorToCall := nil;
 
         if (SuperClass is TGocciaVMClassValue) and
@@ -3480,6 +3479,10 @@ begin
               TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
           end;
         end;
+
+        if not Assigned(InitializerReplayReceiver) or
+           (Instance <> InitializerReplayReceiver) then
+          FVM.RunClassInitializers(Self, Instance);
       end;
       if Assigned(InitializerReplayReceiver) and
          (Instance = InitializerReplayReceiver) then

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -3088,8 +3088,6 @@ begin
     InitializerReplayReceiver := nil;
     TGarbageCollector.Instance.AddTempRoot(RootedInstance);
     try
-      FVM.RunClassInitializers(Self, Instance);
-
       ConstructorToCall := nil;
       if (SuperClass is TGocciaVMClassValue) and
          Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
@@ -3151,6 +3149,11 @@ begin
         else if Instance is TGocciaInstanceValue then
           TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
       end;
+
+      if not Assigned(InitializerReplayReceiver) or
+         (Instance <> InitializerReplayReceiver) then
+        FVM.RunClassInitializers(Self, Instance);
+
       if Assigned(InitializerReplayReceiver) and
          (Instance = InitializerReplayReceiver) then
         FVM.RunClassInitializers(Self, Instance);

--- a/tests/language/classes/private-fields-in-superclass-initializers.js
+++ b/tests/language/classes/private-fields-in-superclass-initializers.js
@@ -1,0 +1,62 @@
+/*---
+description: Superclass arrow field initializers resolve private fields against the declaring class
+features: [private-fields, arrow-functions, class-inheritance]
+---*/
+
+describe("Superclass private fields in arrow field initializers", () => {
+  test("superclass arrow field accesses own private field", () => {
+    class Base {
+      #x = 10;
+      fn = () => this.#x;
+    }
+    class Derived extends Base {
+      y = 20;
+    }
+    const d = new Derived();
+    expect(d.fn()).toBe(10);
+    expect(d.y).toBe(20);
+  });
+
+  test("deep chain: each class resolves own private fields", () => {
+    class A {
+      #a = 1;
+      getA = () => this.#a;
+    }
+    class B extends A {
+      #b = 2;
+      getB = () => this.#b;
+    }
+    class C extends B {
+      #c = 3;
+      getC = () => this.#c;
+    }
+    const c = new C();
+    expect(c.getA()).toBe(1);
+    expect(c.getB()).toBe(2);
+    expect(c.getC()).toBe(3);
+  });
+
+  test("superclass private field via method called in derived field initializer", () => {
+    class Base {
+      #secret = 42;
+      getSecret() { return this.#secret; }
+    }
+    class Derived extends Base {
+      value = this.getSecret();
+    }
+    const d = new Derived();
+    expect(d.value).toBe(42);
+  });
+
+  test("superclass private field via getter in derived field initializer", () => {
+    class Base {
+      #val = 99;
+      get val() { return this.#val; }
+    }
+    class Derived extends Base {
+      doubled = this.val * 2;
+    }
+    const d = new Derived();
+    expect(d.doubled).toBe(198);
+  });
+});

--- a/tests/language/classes/private-fields-in-superclass-initializers.js
+++ b/tests/language/classes/private-fields-in-superclass-initializers.js
@@ -35,28 +35,4 @@ describe("Superclass private fields in arrow field initializers", () => {
     expect(c.getB()).toBe(2);
     expect(c.getC()).toBe(3);
   });
-
-  test("superclass private field via method called in derived field initializer", () => {
-    class Base {
-      #secret = 42;
-      getSecret() { return this.#secret; }
-    }
-    class Derived extends Base {
-      value = this.getSecret();
-    }
-    const d = new Derived();
-    expect(d.value).toBe(42);
-  });
-
-  test("superclass private field via getter in derived field initializer", () => {
-    class Base {
-      #val = 99;
-      get val() { return this.#val; }
-    }
-    class Derived extends Base {
-      doubled = this.val * 2;
-    }
-    const d = new Derived();
-    expect(d.doubled).toBe(198);
-  });
 });

--- a/tests/language/classes/private-fields-in-superclass-initializers.js
+++ b/tests/language/classes/private-fields-in-superclass-initializers.js
@@ -35,4 +35,28 @@ describe("Superclass private fields in arrow field initializers", () => {
     expect(c.getB()).toBe(2);
     expect(c.getC()).toBe(3);
   });
+
+  test("superclass private field via method called in derived field initializer", () => {
+    class Base {
+      #secret = 42;
+      getSecret() { return this.#secret; }
+    }
+    class Derived extends Base {
+      value = this.getSecret();
+    }
+    const d = new Derived();
+    expect(d.value).toBe(42);
+  });
+
+  test("superclass private field via getter in derived field initializer", () => {
+    class Base {
+      #val = 99;
+      get val() { return this.#val; }
+    }
+    class Derived extends Base {
+      doubled = this.val * 2;
+    }
+    const d = new Derived();
+    expect(d.doubled).toBe(198);
+  });
 });


### PR DESCRIPTION
## Summary

- Fix superclass arrow field initializers resolving private fields against the derived class instead of the declaring class.
- `InitializeInstanceProperties` now creates a fresh `TGocciaClassInitScope` bound to `AClassValue` at each recursion level, so `FindOwningClass` returns the declaring class. This mirrors the per-class scope walk that `InitializeObjectInstanceProperties` already uses.
- Adds regression test covering single inheritance, deep chains, method-based access, and getter-based access.
- Closes #561

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change