### PR TITLE
Define prototype.constructor on native Error hierarchy

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -327,7 +327,7 @@ The constructor-backed objects mirror the `node-semver` public fields and core i
 
 **Error constructors:** `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `DOMException`
 
-**Prototype chain:** All error types follow the standard prototype hierarchy. `TypeError.prototype`, `RangeError.prototype`, etc. inherit from `Error.prototype`. This means `new TypeError("msg") instanceof TypeError` is `true` AND `new TypeError("msg") instanceof Error` is `true`. Cross-type checks return `false` (e.g., `new TypeError("msg") instanceof RangeError` is `false`).
+**Prototype chain:** All error types follow the standard prototype hierarchy. `TypeError.prototype`, `RangeError.prototype`, etc. inherit from `Error.prototype`. Each error prototype has a `constructor` property pointing back to its constructor (e.g., `Error.prototype.constructor === Error`), so `new TypeError("x").constructor.name === "TypeError"`. `instanceof` checks and cross-type checks also work correctly: `new TypeError("msg") instanceof TypeError` is `true`, `new TypeError("msg") instanceof Error` is `true`, and `new TypeError("msg") instanceof RangeError` is `false`.
 
 **Runtime errors:** Errors thrown internally by the engine (e.g., `TypeError` from accessing a property on `null`/`undefined`, or `RangeError` from invalid `ArrayBuffer` length) have the same prototype chain as user-constructed errors. This means `instanceof` checks work correctly in catch blocks:
 

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -313,6 +313,16 @@ begin
   SuppressedErrorConstructorFunc.DefineProperty(PROP_PROTOTYPE, TGocciaPropertyDescriptorData.Create(FSuppressedErrorProto, []));
   DOMExceptionConstructorFunc.DefineProperty(PROP_PROTOTYPE, TGocciaPropertyDescriptorData.Create(FDOMExceptionProto, []));
 
+  FErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(ErrorConstructorFunc, [pfConfigurable, pfWritable]));
+  FTypeErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(TypeErrorConstructorFunc, [pfConfigurable, pfWritable]));
+  FReferenceErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(ReferenceErrorConstructorFunc, [pfConfigurable, pfWritable]));
+  FRangeErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(RangeErrorConstructorFunc, [pfConfigurable, pfWritable]));
+  FSyntaxErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(SyntaxErrorConstructorFunc, [pfConfigurable, pfWritable]));
+  FURIErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(URIErrorConstructorFunc, [pfConfigurable, pfWritable]));
+  FAggregateErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(AggregateErrorConstructorFunc, [pfConfigurable, pfWritable]));
+  FSuppressedErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(SuppressedErrorConstructorFunc, [pfConfigurable, pfWritable]));
+  FDOMExceptionProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(DOMExceptionConstructorFunc, [pfConfigurable, pfWritable]));
+
   AScope.DefineLexicalBinding(ERROR_NAME, ErrorConstructorFunc, dtConst);
   AScope.DefineLexicalBinding(TYPE_ERROR_NAME, TypeErrorConstructorFunc, dtConst);
   AScope.DefineLexicalBinding(REFERENCE_ERROR_NAME, ReferenceErrorConstructorFunc, dtConst);

--- a/tests/built-ins/Error/error-prototype-constructor.js
+++ b/tests/built-ins/Error/error-prototype-constructor.js
@@ -3,52 +3,10 @@ description: Error.prototype.constructor and NativeError.prototype.constructor
 features: [Error]
 ---*/
 
-test("Error.prototype.constructor === Error", () => {
-  expect(Error.prototype.constructor).toBe(Error);
-});
-
-test("TypeError.prototype.constructor === TypeError", () => {
-  expect(TypeError.prototype.constructor).toBe(TypeError);
-});
-
-test("RangeError.prototype.constructor === RangeError", () => {
-  expect(RangeError.prototype.constructor).toBe(RangeError);
-});
-
-test("ReferenceError.prototype.constructor === ReferenceError", () => {
-  expect(ReferenceError.prototype.constructor).toBe(ReferenceError);
-});
-
-test("SyntaxError.prototype.constructor === SyntaxError", () => {
-  expect(SyntaxError.prototype.constructor).toBe(SyntaxError);
-});
-
-test("URIError.prototype.constructor === URIError", () => {
-  expect(URIError.prototype.constructor).toBe(URIError);
-});
-
-test("AggregateError.prototype.constructor === AggregateError", () => {
-  expect(AggregateError.prototype.constructor).toBe(AggregateError);
-});
-
-test("SuppressedError.prototype.constructor === SuppressedError", () => {
-  expect(SuppressedError.prototype.constructor).toBe(SuppressedError);
-});
-
-test("DOMException.prototype.constructor === DOMException", () => {
-  expect(DOMException.prototype.constructor).toBe(DOMException);
-});
-
-test("Error.prototype.constructor descriptor is {writable: true, configurable: true, enumerable: false}", () => {
-  const desc = Object.getOwnPropertyDescriptor(Error.prototype, "constructor");
-  expect(desc.writable).toBe(true);
-  expect(desc.configurable).toBe(true);
-  expect(desc.enumerable).toBe(false);
-});
-
-test("NativeError.prototype.constructor descriptors are {writable: true, configurable: true, enumerable: false}", () => {
-  const types = [TypeError, RangeError, ReferenceError, SyntaxError, URIError, AggregateError, SuppressedError, DOMException];
+test("prototype.constructor identity and descriptor for all error types", () => {
+  const types = [Error, TypeError, RangeError, ReferenceError, SyntaxError, URIError, AggregateError, SuppressedError, DOMException];
   types.forEach((ErrorType) => {
+    expect(ErrorType.prototype.constructor).toBe(ErrorType);
     const desc = Object.getOwnPropertyDescriptor(ErrorType.prototype, "constructor");
     expect(desc.writable).toBe(true);
     expect(desc.configurable).toBe(true);

--- a/tests/built-ins/Error/error-prototype-constructor.js
+++ b/tests/built-ins/Error/error-prototype-constructor.js
@@ -31,6 +31,14 @@ test("AggregateError.prototype.constructor === AggregateError", () => {
   expect(AggregateError.prototype.constructor).toBe(AggregateError);
 });
 
+test("SuppressedError.prototype.constructor === SuppressedError", () => {
+  expect(SuppressedError.prototype.constructor).toBe(SuppressedError);
+});
+
+test("DOMException.prototype.constructor === DOMException", () => {
+  expect(DOMException.prototype.constructor).toBe(DOMException);
+});
+
 test("Error.prototype.constructor descriptor is {writable: true, configurable: true, enumerable: false}", () => {
   const desc = Object.getOwnPropertyDescriptor(Error.prototype, "constructor");
   expect(desc.writable).toBe(true);
@@ -39,7 +47,7 @@ test("Error.prototype.constructor descriptor is {writable: true, configurable: t
 });
 
 test("NativeError.prototype.constructor descriptors are {writable: true, configurable: true, enumerable: false}", () => {
-  const types = [TypeError, RangeError, ReferenceError, SyntaxError, URIError, AggregateError];
+  const types = [TypeError, RangeError, ReferenceError, SyntaxError, URIError, AggregateError, SuppressedError, DOMException];
   types.forEach((ErrorType) => {
     const desc = Object.getOwnPropertyDescriptor(ErrorType.prototype, "constructor");
     expect(desc.writable).toBe(true);
@@ -52,6 +60,12 @@ test("error instance .constructor resolves through prototype chain", () => {
   expect(new Error("x").constructor).toBe(Error);
   expect(new TypeError("x").constructor).toBe(TypeError);
   expect(new RangeError("x").constructor).toBe(RangeError);
+});
+
+test("constructor is inherited, not own on instances", () => {
+  const e = new TypeError("x");
+  expect(Object.prototype.hasOwnProperty.call(e, "constructor")).toBe(false);
+  expect(e.constructor).toBe(TypeError);
 });
 
 test("caught error has .constructor.name", () => {

--- a/tests/built-ins/Error/error-prototype-constructor.js
+++ b/tests/built-ins/Error/error-prototype-constructor.js
@@ -1,0 +1,63 @@
+/*---
+description: Error.prototype.constructor and NativeError.prototype.constructor
+features: [Error]
+---*/
+
+test("Error.prototype.constructor === Error", () => {
+  expect(Error.prototype.constructor).toBe(Error);
+});
+
+test("TypeError.prototype.constructor === TypeError", () => {
+  expect(TypeError.prototype.constructor).toBe(TypeError);
+});
+
+test("RangeError.prototype.constructor === RangeError", () => {
+  expect(RangeError.prototype.constructor).toBe(RangeError);
+});
+
+test("ReferenceError.prototype.constructor === ReferenceError", () => {
+  expect(ReferenceError.prototype.constructor).toBe(ReferenceError);
+});
+
+test("SyntaxError.prototype.constructor === SyntaxError", () => {
+  expect(SyntaxError.prototype.constructor).toBe(SyntaxError);
+});
+
+test("URIError.prototype.constructor === URIError", () => {
+  expect(URIError.prototype.constructor).toBe(URIError);
+});
+
+test("AggregateError.prototype.constructor === AggregateError", () => {
+  expect(AggregateError.prototype.constructor).toBe(AggregateError);
+});
+
+test("Error.prototype.constructor descriptor is {writable: true, configurable: true, enumerable: false}", () => {
+  const desc = Object.getOwnPropertyDescriptor(Error.prototype, "constructor");
+  expect(desc.writable).toBe(true);
+  expect(desc.configurable).toBe(true);
+  expect(desc.enumerable).toBe(false);
+});
+
+test("NativeError.prototype.constructor descriptors are {writable: true, configurable: true, enumerable: false}", () => {
+  const types = [TypeError, RangeError, ReferenceError, SyntaxError, URIError, AggregateError];
+  types.forEach((ErrorType) => {
+    const desc = Object.getOwnPropertyDescriptor(ErrorType.prototype, "constructor");
+    expect(desc.writable).toBe(true);
+    expect(desc.configurable).toBe(true);
+    expect(desc.enumerable).toBe(false);
+  });
+});
+
+test("error instance .constructor resolves through prototype chain", () => {
+  expect(new Error("x").constructor).toBe(Error);
+  expect(new TypeError("x").constructor).toBe(TypeError);
+  expect(new RangeError("x").constructor).toBe(RangeError);
+});
+
+test("caught error has .constructor.name", () => {
+  try {
+    throw new TypeError("fail");
+  } catch (e) {
+    expect(e.constructor.name).toBe("TypeError");
+  }
+});

--- a/tests/built-ins/Error/error-prototype-constructor.js
+++ b/tests/built-ins/Error/error-prototype-constructor.js
@@ -3,15 +3,12 @@ description: Error.prototype.constructor and NativeError.prototype.constructor
 features: [Error]
 ---*/
 
-test("prototype.constructor identity and descriptor for all error types", () => {
-  const types = [Error, TypeError, RangeError, ReferenceError, SyntaxError, URIError, AggregateError, SuppressedError, DOMException];
-  types.forEach((ErrorType) => {
-    expect(ErrorType.prototype.constructor).toBe(ErrorType);
-    const desc = Object.getOwnPropertyDescriptor(ErrorType.prototype, "constructor");
-    expect(desc.writable).toBe(true);
-    expect(desc.configurable).toBe(true);
-    expect(desc.enumerable).toBe(false);
-  });
+test.each([Error, TypeError, RangeError, ReferenceError, SyntaxError, URIError, AggregateError, SuppressedError, DOMException])("%s.prototype.constructor identity and descriptor", (ErrorType) => {
+  expect(ErrorType.prototype.constructor).toBe(ErrorType);
+  const desc = Object.getOwnPropertyDescriptor(ErrorType.prototype, "constructor");
+  expect(desc.writable).toBe(true);
+  expect(desc.configurable).toBe(true);
+  expect(desc.enumerable).toBe(false);
 });
 
 test("error instance .constructor resolves through prototype chain", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add missing `prototype.constructor` property to all nine native error prototypes (Error, TypeError, RangeError, ReferenceError, SyntaxError, URIError, AggregateError, SuppressedError, DOMException) during realm initialization
- Add test file covering identity checks, property descriptors, prototype chain resolution, and `caught.constructor.name` usage via `test.each`
- Document the `constructor` property in the error section of `built-ins.md`

Closes #519

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)

**Details:**

- New test file `tests/built-ins/Error/error-prototype-constructor.js` — 12 tests, 42 assertions, all pass
- Full `tests/built-ins/Error/` suite — 136/136 pass (no regressions)
- Full test suite — 8829/8834 pass (5 pre-existing FFI fixture failures, unrelated)
- Format check and doc hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
