### PR TITLE
Route array length setter through ArraySetLength

### DIFF
--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -2754,9 +2754,15 @@ begin
     end;
     // Negative indices are ignored for array assignment
   end
+  else if AName = PROP_LENGTH then
+  begin
+    // §10.4.2.1 → OrdinarySet → OrdinarySetWithOwnDescriptor step 3e:
+    // own writable data property ⇒ [[DefineOwnProperty]](P, {[[Value]]: V})
+    DefineProperty(PROP_LENGTH,
+      TGocciaPropertyDescriptorData.Create(AValue, [pfWritable]));
+  end
   else
   begin
-    // Fall back to regular object property assignment
     inherited AssignProperty(AName, AValue);
   end;
 end;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -2739,6 +2739,7 @@ end;
 procedure TGocciaArrayValue.SetProperty(const AName: string; const AValue: TGocciaValue);
 var
   Index: Integer;
+  Desc: TGocciaPropertyDescriptorData;
 begin
   // Check if property name is a numeric index
   if TryStrToInt(AName, Index) then
@@ -2758,8 +2759,13 @@ begin
   begin
     // §10.4.2.1 → OrdinarySet → OrdinarySetWithOwnDescriptor step 3e:
     // own writable data property ⇒ [[DefineOwnProperty]](P, {[[Value]]: V})
-    DefineProperty(PROP_LENGTH,
-      TGocciaPropertyDescriptorData.Create(AValue, [pfWritable]));
+    Desc := TGocciaPropertyDescriptorData.Create(AValue, [pfWritable]);
+    try
+      DefineProperty(PROP_LENGTH, Desc);
+    except
+      Desc.Free;
+      raise;
+    end;
   end
   else
   begin

--- a/tests/built-ins/Array/array-modification.js
+++ b/tests/built-ins/Array/array-modification.js
@@ -125,3 +125,17 @@ test("setting length does not walk the prototype chain", () => {
   expect(traps.length).toBe(0);
   expect(array.length).toBe(0);
 });
+
+test("setting length to invalid value throws RangeError without walking prototype chain", () => {
+  const traps = [];
+  const array = [1, 2, 3];
+  Object.setPrototypeOf(array, new Proxy(Array.prototype, {
+    getOwnPropertyDescriptor(t, pk) {
+      traps.push("gOPD:" + String(pk));
+      return Reflect.getOwnPropertyDescriptor(t, pk);
+    }
+  }));
+  expect(() => { array.length = -1; }).toThrow(RangeError);
+  expect(traps.length).toBe(0);
+  expect(array.length).toBe(3);
+});

--- a/tests/built-ins/Array/array-modification.js
+++ b/tests/built-ins/Array/array-modification.js
@@ -111,3 +111,17 @@ test("setting length to NaN throws RangeError", () => {
     [].length = NaN;
   }).toThrow(RangeError);
 });
+
+test("setting length does not walk the prototype chain", () => {
+  const traps = [];
+  const array = [1, 2, 3];
+  Object.setPrototypeOf(array, new Proxy(Array.prototype, {
+    getOwnPropertyDescriptor(t, pk) {
+      traps.push("gOPD:" + String(pk));
+      return Reflect.getOwnPropertyDescriptor(t, pk);
+    }
+  }));
+  array.length = 0;
+  expect(traps.length).toBe(0);
+  expect(array.length).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Intercept `PROP_LENGTH` in `TGocciaArrayValue.SetProperty` and delegate to `DefineProperty`, which already implements ArraySetLength (ES2026 §10.4.2.4)
- This matches the spec path: `OrdinarySet` → `OrdinarySetWithOwnDescriptor` step 3e → `[[DefineOwnProperty]](P, {[[Value]]: V})` — never walking the prototype chain
- Previously, `length` fell through to `inherited AssignProperty`, which walked the prototype chain checking for accessors, causing spurious Proxy traps

Closes #553

## Test plan

- [x] Added test: setting `length` with a Proxy in the prototype chain fires no `getOwnPropertyDescriptor` traps
- [x] Existing `array-modification.js` length tests pass (truncation, extension, RangeError on invalid values)
- [x] Full test suite: 8818/8823 pass (5 failures are pre-existing FFI dylib issues)
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)