### PR TITLE
Clarify implement-issue skill to invoke /create-pr skill

### DIFF
--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -32,4 +32,4 @@ gh api "repos/$OWNER/$REPO/issues/$ISSUE_NUMBER"
 8. Implement the smallest complete change that satisfies the chosen approach.
 9. Add or update tests and documentation according to `CONTRIBUTING.md`.
 10. Run targeted verification, then broader verification when the change has wider impact.
-11. Finish by running the `/create-pr` workflow. Include `Closes #<number>` in the PR body.
+11. Invoke the `/create-pr` skill to commit, push, and open the pull request. Include `Closes #<number>` in the PR body.


### PR DESCRIPTION
## Summary

- Clarify step 11 of the `implement-issue` skill to explicitly invoke the `/create-pr` skill rather than ambiguously referencing "running the workflow."
- No functional change — just tighter wording so the agent delegates to the skill instead of potentially reimplementing the PR flow inline.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation