### PR TITLE
Add +000000 acceptance tests for Temporal types and strengthen Date assertion

### DIFF
--- a/tests/built-ins/Date/year-zero.js
+++ b/tests/built-ins/Date/year-zero.js
@@ -10,7 +10,7 @@ describe("Date year zero", () => {
   });
 
   test("new Date('+000000-03-31T00:45Z') is valid", () => {
-    expect(isNaN(new Date("+000000-03-31T00:45Z").getTime())).toBe(false);
+    expect(new Date("+000000-03-31T00:45Z").getTime()).toBe(-62159440500000);
   });
 });
 

--- a/tests/built-ins/Temporal/Instant/from.js
+++ b/tests/built-ins/Temporal/Instant/from.js
@@ -16,4 +16,9 @@ describe.runIf(isTemporal)("Temporal.Instant.from", () => {
     const instant = Temporal.Instant.from("2024-01-15T12:30:45Z");
     expect(instant.epochMilliseconds).toBe(1705321845000);
   });
+
+  test("from() accepts +000000 as year zero", () => {
+    const instant = Temporal.Instant.from("+000000-03-31T00:45Z");
+    expect(instant.epochMilliseconds).toBe(-62159440500000);
+  });
 });

--- a/tests/built-ins/Temporal/PlainDate/from.js
+++ b/tests/built-ins/Temporal/PlainDate/from.js
@@ -41,4 +41,11 @@ describe.runIf(isTemporal)("Temporal.PlainDate.from", () => {
     const d = Temporal.PlainDate.from({ year: 2024, month: 3, day: 0 }, { overflow: "constrain" });
     expect(d.day).toBe(1);
   });
+
+  test("from() accepts +000000 as year zero", () => {
+    const d = Temporal.PlainDate.from("+000000-03-31");
+    expect(d.year).toBe(0);
+    expect(d.month).toBe(3);
+    expect(d.day).toBe(31);
+  });
 });

--- a/tests/built-ins/Temporal/PlainDateTime/from.js
+++ b/tests/built-ins/Temporal/PlainDateTime/from.js
@@ -22,4 +22,13 @@ describe.runIf(isTemporal)("Temporal.PlainDateTime.from", () => {
     expect(dt.day).toBe(15);
     expect(dt.hour).toBe(0);
   });
+
+  test("from() accepts +000000 as year zero", () => {
+    const dt = Temporal.PlainDateTime.from("+000000-03-31T00:45");
+    expect(dt.year).toBe(0);
+    expect(dt.month).toBe(3);
+    expect(dt.day).toBe(31);
+    expect(dt.hour).toBe(0);
+    expect(dt.minute).toBe(45);
+  });
 });

--- a/tests/built-ins/Temporal/PlainYearMonth/from.js
+++ b/tests/built-ins/Temporal/PlainYearMonth/from.js
@@ -54,4 +54,10 @@ describe.runIf(isTemporal)("Temporal.PlainYearMonth.from", () => {
     expect(() => Temporal.PlainYearMonth.from({ year: 2024, monthCode: "M13" })).toThrow();
     expect(() => Temporal.PlainYearMonth.from({ year: 2024, monthCode: "M00" })).toThrow();
   });
+
+  test("from() accepts +000000 as year zero", () => {
+    const ym = Temporal.PlainYearMonth.from("+000000-03");
+    expect(ym.year).toBe(0);
+    expect(ym.month).toBe(3);
+  });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/from.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/from.js
@@ -14,4 +14,11 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.from", () => {
     expect(zdt.hour).toBe(13);
     expect(zdt.timeZoneId).toBe("UTC");
   });
+
+  test("from() accepts +000000 as year zero", () => {
+    const zdt = Temporal.ZonedDateTime.from("+000000-03-31T00:45+00:00[UTC]");
+    expect(zdt.year).toBe(0);
+    expect(zdt.month).toBe(3);
+    expect(zdt.day).toBe(31);
+  });
 });


### PR DESCRIPTION
## Summary

- Add `+000000` (year zero / 1 BCE) acceptance tests to each Temporal type's `from.js`: `Instant`, `PlainDate`, `PlainDateTime`, `ZonedDateTime`, `PlainYearMonth`
- Strengthen the `Date` year-zero test to assert the exact epoch millisecond value (`-62159440500000`) instead of only checking `isNaN(...) === false`

Closes #567

## Test plan

- [x] `tests/built-ins/Date/year-zero.js` — 7/7 pass
- [x] All 5 Temporal `from.js` files — 25/25 pass
- [x] Full `Date` + `Temporal` suite — 449/449 pass, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)