### PR TITLE
Sync upvalue cell after increment/decrement on captured locals

### DIFF
--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -2916,6 +2916,8 @@ begin
     if not AExpr.IsPrefix then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));
     EmitInstruction(ACtx, EncodeABC(Op, Slot, Slot, 0));
+    if ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
     if AExpr.IsPrefix then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));
     Exit;

--- a/tests/language/expressions/arithmetic/increment.js
+++ b/tests/language/expressions/arithmetic/increment.js
@@ -106,3 +106,69 @@ test("increment cannot mutate captured const binding", () => {
     mutate();
   }).toThrow(TypeError);
 });
+
+test("post-increment on captured local syncs upvalue cell", () => {
+  const f = () => {
+    let i = 0;
+    const get = () => i;
+    i++;
+    i++;
+    return [get(), i];
+  };
+  expect(f()).toEqual([2, 2]);
+});
+
+test("pre-increment on captured local syncs upvalue cell", () => {
+  const f = () => {
+    let i = 0;
+    const get = () => i;
+    ++i;
+    ++i;
+    return [get(), i];
+  };
+  expect(f()).toEqual([2, 2]);
+});
+
+test("post-decrement on captured local syncs upvalue cell", () => {
+  const f = () => {
+    let i = 5;
+    const get = () => i;
+    i--;
+    i--;
+    return [get(), i];
+  };
+  expect(f()).toEqual([3, 3]);
+});
+
+test("pre-decrement on captured local syncs upvalue cell", () => {
+  const f = () => {
+    let i = 5;
+    const get = () => i;
+    --i;
+    --i;
+    return [get(), i];
+  };
+  expect(f()).toEqual([3, 3]);
+});
+
+test("post-increment on captured local returns old value", () => {
+  const f = () => {
+    let i = 10;
+    const get = () => i;
+    const a = i++;
+    const b = i++;
+    return [a, b, get()];
+  };
+  expect(f()).toEqual([10, 11, 12]);
+});
+
+test("pre-increment on captured local returns new value", () => {
+  const f = () => {
+    let i = 10;
+    const get = () => i;
+    const a = ++i;
+    const b = ++i;
+    return [a, b, get()];
+  };
+  expect(f()).toEqual([11, 12, 12]);
+});

--- a/tests/language/expressions/arithmetic/increment.js
+++ b/tests/language/expressions/arithmetic/increment.js
@@ -172,3 +172,33 @@ test("pre-increment on captured local returns new value", () => {
   };
   expect(f()).toEqual([11, 12, 12]);
 });
+
+test("increment on captured local coerces string and syncs", () => {
+  const f = () => {
+    let i = "5";
+    const get = () => i;
+    i++;
+    return [get(), i, typeof i];
+  };
+  expect(f()).toEqual([6, 6, "number"]);
+});
+
+test("increment on captured local coerces boolean and syncs", () => {
+  const f = () => {
+    let i = true;
+    const get = () => i;
+    i++;
+    return [get(), i];
+  };
+  expect(f()).toEqual([2, 2]);
+});
+
+test("increment on captured local coerces null and syncs", () => {
+  const f = () => {
+    let i = null;
+    const get = () => i;
+    i++;
+    return [get(), i];
+  };
+  expect(f()).toEqual([1, 1]);
+});

--- a/tests/language/for-loop-var/var-shared-binding.js
+++ b/tests/language/for-loop-var/var-shared-binding.js
@@ -23,3 +23,13 @@ test("multiple var declarations in for-init hoist", () => {
   };
   expect(f()).toEqual([4, 5]);
 });
+
+test("var captures shared binding across iterations", () => {
+  const fns = [];
+  for (var i = 0; i < 3; i++) {
+    fns.push(() => i);
+  }
+  expect(fns[0]()).toBe(3);
+  expect(fns[1]()).toBe(3);
+  expect(fns[2]()).toBe(3);
+});

--- a/tests/language/var/closure-over-var.js
+++ b/tests/language/var/closure-over-var.js
@@ -44,3 +44,36 @@ test("var redeclaration with undefined initializer updates captured cell", () =>
   };
   expect(fn()).toBeUndefined();
 });
+
+test("post-increment on captured var syncs upvalue cell", () => {
+  const fn = () => {
+    var i = 0;
+    const get = () => i;
+    i++;
+    i++;
+    return [get(), i];
+  };
+  expect(fn()).toEqual([2, 2]);
+});
+
+test("pre-increment on captured var syncs upvalue cell", () => {
+  const fn = () => {
+    var i = 0;
+    const get = () => i;
+    ++i;
+    ++i;
+    return [get(), i];
+  };
+  expect(fn()).toEqual([2, 2]);
+});
+
+test("decrement on captured var syncs upvalue cell", () => {
+  const fn = () => {
+    var i = 5;
+    const get = () => i;
+    i--;
+    --i;
+    return [get(), i];
+  };
+  expect(fn()).toEqual([3, 3]);
+});

--- a/tests/language/var/closure-over-var.js
+++ b/tests/language/var/closure-over-var.js
@@ -45,35 +45,14 @@ test("var redeclaration with undefined initializer updates captured cell", () =>
   expect(fn()).toBeUndefined();
 });
 
-test("post-increment on captured var syncs upvalue cell", () => {
+test("increment and decrement on captured var sync upvalue cell", () => {
   const fn = () => {
     var i = 0;
     const get = () => i;
     i++;
-    i++;
-    return [get(), i];
-  };
-  expect(fn()).toEqual([2, 2]);
-});
-
-test("pre-increment on captured var syncs upvalue cell", () => {
-  const fn = () => {
-    var i = 0;
-    const get = () => i;
     ++i;
-    ++i;
-    return [get(), i];
-  };
-  expect(fn()).toEqual([2, 2]);
-});
-
-test("decrement on captured var syncs upvalue cell", () => {
-  const fn = () => {
-    var i = 5;
-    const get = () => i;
     i--;
-    --i;
     return [get(), i];
   };
-  expect(fn()).toEqual([3, 3]);
+  expect(fn()).toEqual([1, 1]);
 });


### PR DESCRIPTION
## Summary

- Emit `OP_SET_LOCAL` after `OP_ADD`/`OP_SUB` in `CompileIncrement` when the local is captured, propagating the register write into the upvalue cell
- Matches the existing sync pattern used by variable declarations and compound assignments
- Zero overhead for non-captured locals (compile-time `IsCaptured` guard)

## Root cause

`CompileIncrement` wrote the arithmetic result directly to the register slot via `OP_ADD`/`OP_SUB`, which bypass the upvalue cell (`FLocalCells`). Closures that captured the binding before the mutation kept reading the pre-increment value. Plain assignment (`OP_MOVE`) and compound assignment already synced correctly.

## Test plan

- [x] Added captured-local increment/decrement tests to `tests/language/expressions/arithmetic/increment.js` (uses `let`, no `--compat-var` needed)
- [x] Added `var`-specific increment tests to `tests/language/var/closure-over-var.js`
- [x] Re-added the `var` captures shared binding across iterations test to `tests/language/for-loop-var/var-shared-binding.js`
- [x] All new tests pass in both interpreter and bytecode modes
- [x] Full test suite: zero regressions (only pre-existing FFI library failures)
- [x] Format check passes

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)