### PR TITLE
Honor explicit object returns from class constructors in Instantiate

### DIFF
--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -968,6 +968,7 @@ var
   ConstructorToCall: TGocciaMethodValue;
   InstancePrototype: TGocciaObjectValue;
   FinalThis: TGocciaValue;
+  ConstructResult: TGocciaValue;
 begin
   // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
   if Assigned(ANewTarget) then
@@ -1008,10 +1009,29 @@ begin
   begin
     TGarbageCollector.Instance.AddTempRoot(Instance);
     try
-      ConstructorToCall.CallWithThisValue(AArguments, Instance,
-        FinalThis, ANewTarget);
+      ConstructResult := ConstructorToCall.CallWithThisValue(AArguments,
+        Instance, FinalThis, ANewTarget);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(Instance);
+    end;
+
+    // ES2026 §10.2.2 step 11: explicit Object return replaces the receiver
+    if ConstructResult is TGocciaObjectValue then
+      Exit(TGocciaObjectValue(ConstructResult));
+
+    // ES2026 §10.2.2 step 12: derived constructors must return Object or
+    // undefined — any other value is a TypeError
+    if Assigned(FSuperClass) or Assigned(FNativeSuperConstructor) then
+    begin
+      if Assigned(ConstructResult) and
+         not (ConstructResult is TGocciaUndefinedLiteralValue) then
+        ThrowTypeError('Derived constructor returned non-object',
+          SSuggestNotConstructorType);
+
+      // Derived constructor returned undefined — use the (possibly replaced)
+      // this binding from super()
+      if (FinalThis is TGocciaObjectValue) then
+        Exit(TGocciaObjectValue(FinalThis));
     end;
   end
   else if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -1028,8 +1028,6 @@ begin
         ThrowTypeError('Derived constructor returned non-object',
           SSuggestNotConstructorType);
 
-      // Derived constructor returned undefined — use the (possibly replaced)
-      // this binding from super()
       if (FinalThis is TGocciaObjectValue) then
         Exit(TGocciaObjectValue(FinalThis));
     end;

--- a/tests/built-ins/Reflect/construct/class-constructor-return.js
+++ b/tests/built-ins/Reflect/construct/class-constructor-return.js
@@ -63,6 +63,29 @@ describe("Reflect.construct with class constructor explicit object return", () =
     expect(() => Reflect.construct(Derived, [])).toThrow(TypeError);
   });
 
+  test("base class returning null is ignored — receiver wins", () => {
+    class Foo {
+      constructor() {
+        this.kept = true;
+        return null;
+      }
+    }
+    const obj = Reflect.construct(Foo, []);
+    expect(obj.kept).toBe(true);
+    expect(obj instanceof Foo).toBe(true);
+  });
+
+  test("derived class returning null throws TypeError", () => {
+    class Base {}
+    class Derived extends Base {
+      constructor() {
+        super();
+        return null;
+      }
+    }
+    expect(() => Reflect.construct(Derived, [])).toThrow(TypeError);
+  });
+
   test("explicit object return prototype is not patched by newTarget", () => {
     class Foo {
       constructor() {
@@ -89,6 +112,23 @@ describe("Reflect.construct with class constructor explicit object return", () =
     }
     const obj = Reflect.construct(Derived, []);
     expect(obj.fromBase).toBe(true);
+  });
+
+  test("super() replacement with separate newTarget returns replacement unchanged", () => {
+    class Base {
+      constructor() {
+        return { fromBase: true };
+      }
+    }
+    class Derived extends Base {
+      constructor() {
+        super();
+      }
+    }
+    class NT {}
+    const obj = Reflect.construct(Derived, [], NT);
+    expect(obj.fromBase).toBe(true);
+    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
   });
 
   test("constructor arguments are forwarded correctly", () => {

--- a/tests/built-ins/Reflect/construct/class-constructor-return.js
+++ b/tests/built-ins/Reflect/construct/class-constructor-return.js
@@ -1,0 +1,129 @@
+/*---
+description: Reflect.construct honors explicit object returns from class constructors per ES2026 §10.2.2 step 11
+features: [Reflect]
+---*/
+
+describe("Reflect.construct with class constructor explicit object return", () => {
+  test("base class explicit object return replaces the receiver", () => {
+    class Foo {
+      constructor() {
+        return { explicit: true };
+      }
+    }
+    const obj = Reflect.construct(Foo, []);
+    expect(obj.explicit).toBe(true);
+    expect(obj instanceof Foo).toBe(false);
+  });
+
+  test("base class explicit object return matches new operator behavior", () => {
+    class Foo {
+      constructor() {
+        return { replaced: true };
+      }
+    }
+    const viaNew = new Foo();
+    const viaReflect = Reflect.construct(Foo, []);
+    expect(viaNew.replaced).toBe(true);
+    expect(viaReflect.replaced).toBe(true);
+  });
+
+  test("base class primitive return is ignored — receiver wins", () => {
+    class Foo {
+      constructor() {
+        this.kept = true;
+        return 42;
+      }
+    }
+    const obj = Reflect.construct(Foo, []);
+    expect(obj.kept).toBe(true);
+    expect(obj instanceof Foo).toBe(true);
+  });
+
+  test("derived class explicit object return replaces the receiver", () => {
+    class Base {}
+    class Derived extends Base {
+      constructor() {
+        super();
+        return { derived: true };
+      }
+    }
+    const obj = Reflect.construct(Derived, []);
+    expect(obj.derived).toBe(true);
+    expect(obj instanceof Derived).toBe(false);
+  });
+
+  test("derived class primitive return throws TypeError", () => {
+    class Base {}
+    class Derived extends Base {
+      constructor() {
+        super();
+        return 7;
+      }
+    }
+    expect(() => Reflect.construct(Derived, [])).toThrow(TypeError);
+  });
+
+  test("explicit object return prototype is not patched by newTarget", () => {
+    class Foo {
+      constructor() {
+        return { userObj: true };
+      }
+    }
+    class NT {}
+    const obj = Reflect.construct(Foo, [], NT);
+    expect(obj.userObj).toBe(true);
+    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(obj)).not.toBe(NT.prototype);
+  });
+
+  test("super() replacement object is returned when constructor returns undefined", () => {
+    class Base {
+      constructor() {
+        return { fromBase: true };
+      }
+    }
+    class Derived extends Base {
+      constructor() {
+        super();
+      }
+    }
+    const obj = Reflect.construct(Derived, []);
+    expect(obj.fromBase).toBe(true);
+  });
+
+  test("constructor arguments are forwarded correctly", () => {
+    class Foo {
+      constructor(x, y) {
+        return { sum: x + y };
+      }
+    }
+    const obj = Reflect.construct(Foo, [3, 4]);
+    expect(obj.sum).toBe(7);
+  });
+});
+
+describe("Reflect.construct with class constructor via proxy fallback", () => {
+  test("proxy without construct trap honors explicit object return from class", () => {
+    class Foo {
+      constructor() {
+        return { proxied: true };
+      }
+    }
+    const proxy = new Proxy(Foo, {});
+    const obj = Reflect.construct(proxy, []);
+    expect(obj.proxied).toBe(true);
+    expect(obj instanceof Foo).toBe(false);
+  });
+
+  test("proxy fallback derived class primitive return throws TypeError", () => {
+    class Base {}
+    class Derived extends Base {
+      constructor() {
+        super();
+        return 7;
+      }
+    }
+    const proxy = new Proxy(Derived, {});
+    expect(() => Reflect.construct(proxy, [])).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Reflect/construct/class-constructor-return.js
+++ b/tests/built-ins/Reflect/construct/class-constructor-return.js
@@ -10,21 +10,11 @@ describe("Reflect.construct with class constructor explicit object return", () =
         return { explicit: true };
       }
     }
-    const obj = Reflect.construct(Foo, []);
-    expect(obj.explicit).toBe(true);
-    expect(obj instanceof Foo).toBe(false);
-  });
-
-  test("base class explicit object return matches new operator behavior", () => {
-    class Foo {
-      constructor() {
-        return { replaced: true };
-      }
-    }
     const viaNew = new Foo();
     const viaReflect = Reflect.construct(Foo, []);
-    expect(viaNew.replaced).toBe(true);
-    expect(viaReflect.replaced).toBe(true);
+    expect(viaReflect.explicit).toBe(true);
+    expect(viaReflect instanceof Foo).toBe(false);
+    expect(viaNew.explicit).toBe(viaReflect.explicit);
   });
 
   test("base class primitive return is ignored — receiver wins", () => {


### PR DESCRIPTION
## Summary

- Fix `TGocciaClassValue.Instantiate` to observe the constructor's return value per ES2026 §10.2.2 steps 11–12: if the constructor returns an Object, that object becomes the construction result; for derived classes, non-object/non-undefined returns throw TypeError
- Previously `Instantiate` always returned the freshly-allocated receiver, silently discarding explicit object returns — this affected `Reflect.construct` and proxy `[[Construct]]` fallback (both route through `ConstructValue` → `Instantiate`)
- Add 10 tests covering base/derived class returns, primitive rejection, newTarget prototype isolation, super() replacement, and the proxy fallback path

Closes #534

## Test plan

- [x] Reproduction from the issue returns `{ explicit: true }` for both `new Foo()` and `Reflect.construct(Foo, [])`
- [x] New test file `tests/built-ins/Reflect/construct/class-constructor-return.js` — 10 tests, all pass
- [x] Full test suite (8849 passed, 5 failed — all 5 are pre-existing FFI `libfixture.dylib` load failures)
- [x] Class inheritance tests (`tests/language/classes/class-inheritance.js`) — 21/21 pass
- [x] `./format.pas --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)