### PR TITLE
Remove disable-model-invocation from skill frontmatter

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: create-issue
 description: Create a well-structured GocciaScript GitHub issue from a tagline or short description, using the repository issue template and project issue style. Use when the user enters /create-issue.
-disable-model-invocation: true
 ---
 
 # Create Issue

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: create-pr
 description: Commit relevant changes, push the branch, and create a GocciaScript pull request using the repository PR template. Use when the user enters /create-pr.
-disable-model-invocation: true
 ---
 
 # Create PR

--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: implement-issue
 description: Validate a GitHub issue against the GocciaScript codebase, present implementation options, implement the chosen fix, and prepare a PR. Use when the user enters /implement-issue with an issue number.
-disable-model-invocation: true
 ---
 
 # Implement Issue

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: review-pr
 description: Resolve review comments on the current GocciaScript pull request without posting top-level PR comments. Use when the user enters /review-pr.
-disable-model-invocation: true
 ---
 
 # Review PR

--- a/.agents/skills/update-pr/SKILL.md
+++ b/.agents/skills/update-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: update-pr
 description: Commit relevant local changes and push them to the current GocciaScript pull request branch. Use when the user enters /update-pr.
-disable-model-invocation: true
 ---
 
 # Update PR


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Remove `disable-model-invocation: true` from all five project skills (`create-pr`, `update-pr`, `review-pr`, `implement-issue`, `create-issue`).
- Per the [official docs](https://code.claude.com/docs/en/skills), the default is already `false`, so the explicit field was unnecessary. Removing the line is the recommended approach over setting it to `false`.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation