### PR TITLE
Fix arrow function this binding in module mode

### DIFF
--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -412,21 +412,8 @@ begin
 end;
 
 procedure TGocciaArrowFunctionValue.BindThis(const ACallScope: TGocciaScope; const AThisValue: TGocciaValue);
-var
-  ClosureScope: TGocciaScope;
 begin
-  // Arrow functions always inherit 'this' from their lexical (closure) scope,
-  // per ECMAScript spec. They never use the call-site AThisValue.
-  ClosureScope := FClosure;
-  while Assigned(ClosureScope) do
-  begin
-    if Assigned(ClosureScope.ThisValue) and not (ClosureScope.ThisValue is TGocciaUndefinedLiteralValue) then
-    begin
-      ACallScope.ThisValue := ClosureScope.ThisValue;
-      Break;
-    end;
-    ClosureScope := ClosureScope.Parent;
-  end;
+  ACallScope.ThisValue := FClosure.ThisValue;
 end;
 
 { TGocciaMethodValue }

--- a/tests/language/source-type/this-binding.js
+++ b/tests/language/source-type/this-binding.js
@@ -44,4 +44,28 @@ describe("source-type=module entry", () => {
     };
     expect(outer()).toBeUndefined();
   });
+
+  test("arrow this is immune to .call()", () => {
+    const arrow = () => this;
+    expect(arrow.call({ x: 1 })).toBeUndefined();
+  });
+
+  test("arrow this is immune to .apply()", () => {
+    const arrow = () => this;
+    expect(arrow.apply({ x: 1 }, [])).toBeUndefined();
+  });
+
+  test("arrow this is immune to .bind()", () => {
+    const arrow = () => this;
+    const bound = arrow.bind({ x: 1 });
+    expect(bound()).toBeUndefined();
+  });
+
+  test("arrow as object method inherits module undefined this", () => {
+    const obj = {
+      value: 42,
+      arrow: () => this,
+    };
+    expect(obj.arrow()).toBeUndefined();
+  });
 });

--- a/tests/language/source-type/this-binding.js
+++ b/tests/language/source-type/this-binding.js
@@ -9,6 +9,8 @@ description: >
 
 const topLevelThis = this;
 const topLevelThisType = typeof this;
+const arrowThis = (() => this)();
+const arrowThisType = (() => typeof this)();
 
 describe("source-type=module entry", () => {
   test("top-level this is undefined", () => {
@@ -21,5 +23,25 @@ describe("source-type=module entry", () => {
 
   test("top-level this is not globalThis", () => {
     expect(topLevelThis === globalThis).toBe(false);
+  });
+
+  test("arrow function inherits module-level undefined this", () => {
+    expect(arrowThis).toBeUndefined();
+  });
+
+  test("arrow function typeof this is 'undefined' in module", () => {
+    expect(arrowThisType).toBe("undefined");
+  });
+
+  test("arrow function this is not globalThis in module", () => {
+    expect(arrowThis === globalThis).toBe(false);
+  });
+
+  test("nested arrow inherits module-level undefined this", () => {
+    const outer = () => {
+      const inner = () => this;
+      return inner();
+    };
+    expect(outer()).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Arrow functions in module mode incorrectly resolved `this` to `globalThis` instead of inheriting the lexical `undefined` from the module scope
- The scope-chain walk in `TGocciaArrowFunctionValue.BindThis` skipped `undefined` values and fell through to the global scope — replaced with a direct capture from `FClosure.ThisValue`, matching ES2026 §10.2.1.1
- Added tests for arrow `this` in module mode (including nested arrows)

Closes #520

## Test plan

- [x] Reproduction from issue confirmed fixed (`() => this` returns `undefined` in module mode)
- [x] Script mode unaffected (arrow `this` still inherits `globalThis`)
- [x] Bytecode mode already correct (uses upvalue capture)
- [x] New tests pass in both interpreter and bytecode modes
- [x] Full test suite: 8839/8844 pass (5 pre-existing FFI failures)
- [x] `./format.pas --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)