### PR TITLE
Allow var/function declarations to shadow built-in globals in script mode

### DIFF
--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -185,9 +185,9 @@ begin
   FRegisteredBenchmarks := TObjectList<TBenchmarkCase>.Create;
   FCurrentSuiteName := '';
 
-  AScope.DefineLexicalBinding('suite', TGocciaNativeFunctionValue.Create(Suite, 'suite', 2), dtConst);
-  AScope.DefineLexicalBinding('bench', TGocciaNativeFunctionValue.Create(Bench, 'bench', 2), dtConst);
-  AScope.DefineLexicalBinding('runBenchmarks', TGocciaNativeFunctionValue.Create(RunBenchmarks, 'runBenchmarks', 0), dtConst);
+  AScope.DefineLexicalBinding('suite', TGocciaNativeFunctionValue.Create(Suite, 'suite', 2), dtConst, True);
+  AScope.DefineLexicalBinding('bench', TGocciaNativeFunctionValue.Create(Bench, 'bench', 2), dtConst, True);
+  AScope.DefineLexicalBinding('runBenchmarks', TGocciaNativeFunctionValue.Create(RunBenchmarks, 'runBenchmarks', 0), dtConst, True);
 end;
 
 destructor TGocciaBenchmark.Destroy;

--- a/source/units/Goccia.Builtins.CSV.pas
+++ b/source/units/Goccia.Builtins.CSV.pas
@@ -81,7 +81,7 @@ begin
   end;
 
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 destructor TGocciaCSVBuiltin.Destroy;

--- a/source/units/Goccia.Builtins.Console.pas
+++ b/source/units/Goccia.Builtins.Console.pas
@@ -118,7 +118,7 @@ begin
   end;
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 procedure TGocciaConsole.EmitLine(const AMethod, ALine: string);

--- a/source/units/Goccia.Builtins.DisposableStack.pas
+++ b/source/units/Goccia.Builtins.DisposableStack.pas
@@ -359,11 +359,11 @@ begin
 
   DisposableStackFunc := TGocciaNativeFunctionValue.Create(
     DisposableStackConstructor, CONSTRUCTOR_DISPOSABLE_STACK, 0);
-  AScope.DefineLexicalBinding(CONSTRUCTOR_DISPOSABLE_STACK, DisposableStackFunc, dtConst);
+  AScope.DefineLexicalBinding(CONSTRUCTOR_DISPOSABLE_STACK, DisposableStackFunc, dtConst, True);
 
   AsyncDisposableStackFunc := TGocciaNativeFunctionValue.Create(
     AsyncDisposableStackConstructor, CONSTRUCTOR_ASYNC_DISPOSABLE_STACK, 0);
-  AScope.DefineLexicalBinding(CONSTRUCTOR_ASYNC_DISPOSABLE_STACK, AsyncDisposableStackFunc, dtConst);
+  AScope.DefineLexicalBinding(CONSTRUCTOR_ASYNC_DISPOSABLE_STACK, AsyncDisposableStackFunc, dtConst, True);
 end;
 
 function TGocciaBuiltinDisposableStack.DisposableStackConstructor(

--- a/source/units/Goccia.Builtins.GlobalBigInt.pas
+++ b/source/units/Goccia.Builtins.GlobalBigInt.pas
@@ -98,7 +98,7 @@ begin
     TGocciaPropertyDescriptorData.Create(Proto, []));
 
   // Bind BigInt in scope
-  AScope.DefineLexicalBinding(AName, FBigIntFunction, dtLet);
+  AScope.DefineLexicalBinding(AName, FBigIntFunction, dtLet, True);
 end;
 
 // ES2026 §21.2.1.1 BigInt(value) — conversion function

--- a/source/units/Goccia.Builtins.GlobalFFI.pas
+++ b/source/units/Goccia.Builtins.GlobalFFI.pas
@@ -67,7 +67,7 @@ begin
   end;
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtConst);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtConst, True);
 end;
 
 function TGocciaGlobalFFI.FFIOpen(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Builtins.GlobalFetch.pas
+++ b/source/units/Goccia.Builtins.GlobalFetch.pas
@@ -107,7 +107,7 @@ begin
 
   // Register fetch as a global function
   AScope.DefineLexicalBinding('fetch',
-    TGocciaNativeFunctionValue.Create(FetchCallback, 'fetch', 1), dtConst);
+    TGocciaNativeFunctionValue.Create(FetchCallback, 'fetch', 1), dtConst, True);
 end;
 
 destructor TGocciaGlobalFetch.Destroy;

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -478,7 +478,7 @@ begin
   end;
   RegisterMemberDefinitions(FPromiseConstructor, FStaticMembers);
 
-  AScope.DefineLexicalBinding(AName, FPromiseConstructor, dtLet);
+  AScope.DefineLexicalBinding(AName, FPromiseConstructor, dtLet, True);
 end;
 
 // ES2026 §27.2.4.8 get Promise [ @@species ]

--- a/source/units/Goccia.Builtins.GlobalProxy.pas
+++ b/source/units/Goccia.Builtins.GlobalProxy.pas
@@ -48,7 +48,7 @@ begin
       PROP_REVOCABLE, 2));
   FConstructorValue := ConstructorFn;
 
-  AScope.DefineLexicalBinding(CONSTRUCTOR_PROXY, FConstructorValue, dtConst);
+  AScope.DefineLexicalBinding(CONSTRUCTOR_PROXY, FConstructorValue, dtConst, True);
 end;
 
 // ES2026 §28.2.1 Proxy(target, handler)

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -96,7 +96,7 @@ begin
   end;
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtConst);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtConst, True);
 end;
 
 // ES2026 §28.1.1 Reflect.apply(target, thisArgument, argumentsList)

--- a/source/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/source/units/Goccia.Builtins.GlobalRegExp.pas
@@ -350,7 +350,7 @@ begin
   end;
   RegisterMemberDefinitions(FRegExpConstructor, FStaticMembers);
 
-  AScope.DefineLexicalBinding(AName, FRegExpConstructor, dtConst);
+  AScope.DefineLexicalBinding(AName, FRegExpConstructor, dtConst, True);
 end;
 
 // ES2026 §22.2.4.2 get RegExp [ @@species ]

--- a/source/units/Goccia.Builtins.GlobalSymbol.pas
+++ b/source/units/Goccia.Builtins.GlobalSymbol.pas
@@ -116,7 +116,7 @@ begin
     TGocciaPropertyDescriptorData.Create(FSymbolFunction, [pfConfigurable, pfWritable]));
 
   // Bind Symbol in scope
-  AScope.DefineLexicalBinding(AName, FSymbolFunction, dtLet);
+  AScope.DefineLexicalBinding(AName, FSymbolFunction, dtLet, True);
 end;
 
 destructor TGocciaGlobalSymbol.Destroy;

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -209,9 +209,9 @@ var
 begin
   inherited Create(AName, AScope, AThrowError);
 
-  AScope.DefineLexicalBinding('undefined', TGocciaUndefinedLiteralValue.UndefinedValue, dtConst);
-  AScope.DefineLexicalBinding('NaN', TGocciaNumberLiteralValue.NaNValue, dtConst);
-  AScope.DefineLexicalBinding('Infinity', TGocciaNumberLiteralValue.InfinityValue, dtConst);
+  AScope.DefineLexicalBinding('undefined', TGocciaUndefinedLiteralValue.UndefinedValue, dtConst, True);
+  AScope.DefineLexicalBinding('NaN', TGocciaNumberLiteralValue.NaNValue, dtConst, True);
+  AScope.DefineLexicalBinding('Infinity', TGocciaNumberLiteralValue.InfinityValue, dtConst, True);
 
   FErrorProto := TGocciaObjectValue.Create;
   FErrorProto.DefineProperty(PROP_NAME, TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create(ERROR_NAME), [pfConfigurable, pfWritable]));
@@ -323,36 +323,36 @@ begin
   FSuppressedErrorProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(SuppressedErrorConstructorFunc, [pfConfigurable, pfWritable]));
   FDOMExceptionProto.DefineProperty(PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(DOMExceptionConstructorFunc, [pfConfigurable, pfWritable]));
 
-  AScope.DefineLexicalBinding(ERROR_NAME, ErrorConstructorFunc, dtConst);
-  AScope.DefineLexicalBinding(TYPE_ERROR_NAME, TypeErrorConstructorFunc, dtConst);
-  AScope.DefineLexicalBinding(REFERENCE_ERROR_NAME, ReferenceErrorConstructorFunc, dtConst);
-  AScope.DefineLexicalBinding(RANGE_ERROR_NAME, RangeErrorConstructorFunc, dtConst);
-  AScope.DefineLexicalBinding(SYNTAX_ERROR_NAME, SyntaxErrorConstructorFunc, dtConst);
-  AScope.DefineLexicalBinding(URI_ERROR_NAME, URIErrorConstructorFunc, dtConst);
-  AScope.DefineLexicalBinding(AGGREGATE_ERROR_NAME, AggregateErrorConstructorFunc, dtConst);
-  AScope.DefineLexicalBinding(SUPPRESSED_ERROR_NAME, SuppressedErrorConstructorFunc, dtConst);
-  AScope.DefineLexicalBinding(DOM_EXCEPTION_NAME, DOMExceptionConstructorFunc, dtConst);
+  AScope.DefineLexicalBinding(ERROR_NAME, ErrorConstructorFunc, dtConst, True);
+  AScope.DefineLexicalBinding(TYPE_ERROR_NAME, TypeErrorConstructorFunc, dtConst, True);
+  AScope.DefineLexicalBinding(REFERENCE_ERROR_NAME, ReferenceErrorConstructorFunc, dtConst, True);
+  AScope.DefineLexicalBinding(RANGE_ERROR_NAME, RangeErrorConstructorFunc, dtConst, True);
+  AScope.DefineLexicalBinding(SYNTAX_ERROR_NAME, SyntaxErrorConstructorFunc, dtConst, True);
+  AScope.DefineLexicalBinding(URI_ERROR_NAME, URIErrorConstructorFunc, dtConst, True);
+  AScope.DefineLexicalBinding(AGGREGATE_ERROR_NAME, AggregateErrorConstructorFunc, dtConst, True);
+  AScope.DefineLexicalBinding(SUPPRESSED_ERROR_NAME, SuppressedErrorConstructorFunc, dtConst, True);
+  AScope.DefineLexicalBinding(DOM_EXCEPTION_NAME, DOMExceptionConstructorFunc, dtConst, True);
 
   AScope.DefineLexicalBinding('encodeURI',
-    TGocciaNativeFunctionValue.Create(EncodeURICallback, 'encodeURI', 1), dtConst);
+    TGocciaNativeFunctionValue.Create(EncodeURICallback, 'encodeURI', 1), dtConst, True);
 
   AScope.DefineLexicalBinding('decodeURI',
-    TGocciaNativeFunctionValue.Create(DecodeURICallback, 'decodeURI', 1), dtConst);
+    TGocciaNativeFunctionValue.Create(DecodeURICallback, 'decodeURI', 1), dtConst, True);
 
   AScope.DefineLexicalBinding('encodeURIComponent',
-    TGocciaNativeFunctionValue.Create(EncodeURIComponentCallback, 'encodeURIComponent', 1), dtConst);
+    TGocciaNativeFunctionValue.Create(EncodeURIComponentCallback, 'encodeURIComponent', 1), dtConst, True);
 
   AScope.DefineLexicalBinding('decodeURIComponent',
-    TGocciaNativeFunctionValue.Create(DecodeURIComponentCallback, 'decodeURIComponent', 1), dtConst);
+    TGocciaNativeFunctionValue.Create(DecodeURIComponentCallback, 'decodeURIComponent', 1), dtConst, True);
 end;
 
 procedure TGocciaGlobals.RegisterRuntimeGlobals;
 begin
   FScope.DefineLexicalBinding('queueMicrotask',
-    TGocciaNativeFunctionValue.Create(QueueMicrotaskCallback, 'queueMicrotask', 1), dtConst);
+    TGocciaNativeFunctionValue.Create(QueueMicrotaskCallback, 'queueMicrotask', 1), dtConst, True);
 
   FScope.DefineLexicalBinding('structuredClone',
-    TGocciaNativeFunctionValue.Create(StructuredCloneCallback, 'structuredClone', 1), dtConst);
+    TGocciaNativeFunctionValue.Create(StructuredCloneCallback, 'structuredClone', 1), dtConst, True);
 end;
 
 { NativeError ( message [ , options ] ) — §20.5.6.1.1 (shared by all NativeError constructors)

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -92,7 +92,7 @@ begin
   end;
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 destructor TGocciaJSONBuiltin.Destroy;

--- a/source/units/Goccia.Builtins.JSON5.pas
+++ b/source/units/Goccia.Builtins.JSON5.pas
@@ -130,7 +130,7 @@ begin
   end;
 
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 destructor TGocciaJSON5Builtin.Destroy;

--- a/source/units/Goccia.Builtins.JSONL.pas
+++ b/source/units/Goccia.Builtins.JSONL.pas
@@ -75,7 +75,7 @@ begin
   end;
 
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 destructor TGocciaJSONLBuiltin.Destroy;

--- a/source/units/Goccia.Builtins.Math.pas
+++ b/source/units/Goccia.Builtins.Math.pas
@@ -151,7 +151,7 @@ begin
   end;
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 // §21.3.2.1 Math.abs ( x )

--- a/source/units/Goccia.Builtins.Performance.pas
+++ b/source/units/Goccia.Builtins.Performance.pas
@@ -239,7 +239,7 @@ begin
     TGocciaObjectValue.InitializeSharedPrototype;
 
   FBuiltinObject := TGocciaPerformanceValue.Create;
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 initialization

--- a/source/units/Goccia.Builtins.TOML.pas
+++ b/source/units/Goccia.Builtins.TOML.pas
@@ -63,7 +63,7 @@ begin
   end;
 
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 destructor TGocciaTOMLBuiltin.Destroy;

--- a/source/units/Goccia.Builtins.TSV.pas
+++ b/source/units/Goccia.Builtins.TSV.pas
@@ -81,7 +81,7 @@ begin
   end;
 
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 destructor TGocciaTSVBuiltin.Destroy;

--- a/source/units/Goccia.Builtins.Temporal.pas
+++ b/source/units/Goccia.Builtins.Temporal.pas
@@ -140,7 +140,7 @@ begin
       [pfConfigurable]);
     RegisterMemberDefinitions(FTemporalNamespace, TemporalMembers);
 
-    AScope.DefineLexicalBinding(AName, FTemporalNamespace, dtLet);
+    AScope.DefineLexicalBinding(AName, FTemporalNamespace, dtLet, True);
   finally
     TGarbageCollector.Instance.RemoveTempRoot(FTemporalNamespace);
   end;

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -2384,7 +2384,7 @@ var
       GlobalObject.DefineProperty(AName,
         TGocciaPropertyDescriptorData.Create(AValue, [pfWritable, pfConfigurable]))
     else
-      AScope.DefineLexicalBinding(AName, AValue, dtConst);
+      AScope.DefineLexicalBinding(AName, AValue, dtConst, True);
   end;
 
 begin
@@ -2419,8 +2419,8 @@ begin
   // Private aliases used by generated Test262 wrappers.  Some conformance
   // tests intentionally declare globals named describe/test.
   AScope.DefineLexicalBinding('__gocciaTest262Describe', DescribeFunction,
-    dtConst);
-  AScope.DefineLexicalBinding('__gocciaTest262Test', TestFunction, dtConst);
+    dtConst, True);
+  AScope.DefineLexicalBinding('__gocciaTest262Test', TestFunction, dtConst, True);
 
   ItFunction := TGocciaNativeFunctionValue.Create(It, 'it', 2);
   ConfigureTestFunction(ItFunction);

--- a/source/units/Goccia.Builtins.YAML.pas
+++ b/source/units/Goccia.Builtins.YAML.pas
@@ -66,7 +66,7 @@ begin
   end;
 
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
-  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
 
 destructor TGocciaYAMLBuiltin.Destroy;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -442,7 +442,7 @@ begin
   end
   else
   begin
-    FInterpreter.GlobalScope.DefineLexicalBinding(AName, AValue, dtConst, True);
+    FInterpreter.GlobalScope.DefineLexicalBinding(AName, AValue, dtConst);
     FInjectedGlobals.Add(AName);
   end;
 end;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -442,7 +442,7 @@ begin
   end
   else
   begin
-    FInterpreter.GlobalScope.DefineLexicalBinding(AName, AValue, dtConst);
+    FInterpreter.GlobalScope.DefineLexicalBinding(AName, AValue, dtConst, True);
     FInjectedGlobals.Add(AName);
   end;
 end;
@@ -587,7 +587,7 @@ begin
       LoadShimValue(FInterpreter, Shim)
     else
       FInterpreter.GlobalScope.DefineLexicalBinding(Shim.Name,
-        LoadShimValue(FInterpreter, Shim), dtConst);
+        LoadShimValue(FInterpreter, Shim), dtConst, True);
   end;
 end;
 
@@ -745,7 +745,7 @@ begin
   FBuiltinGlobalString := TGocciaGlobalString.Create(CONSTRUCTOR_STRING, Scope, ThrowError);
   FBuiltinGlobals := TGocciaGlobals.Create('Globals', Scope, ThrowError);
   FBuiltinDisposableStack := TGocciaBuiltinDisposableStack.Create('DisposableStack', Scope, ThrowError);
-  Scope.DefineLexicalBinding(CONSTRUCTOR_ITERATOR, TGocciaIteratorValue.CreateGlobalObject, dtConst);
+  Scope.DefineLexicalBinding(CONSTRUCTOR_ITERATOR, TGocciaIteratorValue.CreateGlobalObject, dtConst, True);
   RegisterBuiltinConstructors;
 end;
 
@@ -892,12 +892,12 @@ begin
   if Assigned(FBuiltinArrayBuffer) then
     for Key in FBuiltinArrayBuffer.BuiltinObject.GetAllPropertyNames do
       ArrayBufferConstructor.SetProperty(Key, FBuiltinArrayBuffer.BuiltinObject.GetProperty(Key));
-  FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_ARRAY_BUFFER, ArrayBufferConstructor, dtConst);
+  FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_ARRAY_BUFFER, ArrayBufferConstructor, dtConst, True);
 
   SharedArrayBufferConstructor := TGocciaSharedArrayBufferClassValue.Create(CONSTRUCTOR_SHARED_ARRAY_BUFFER, nil);
   TGocciaSharedArrayBufferValue.ExposePrototype(SharedArrayBufferConstructor);
   SharedArrayBufferConstructor.Prototype.Prototype := ObjectConstructor.Prototype;
-  FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_SHARED_ARRAY_BUFFER, SharedArrayBufferConstructor, dtConst);
+  FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_SHARED_ARRAY_BUFFER, SharedArrayBufferConstructor, dtConst, True);
 
   // Create %TypedArray% intrinsic (not globally exposed per spec §23.2.1)
   FTypedArrayIntrinsic := TGocciaClassValue.Create('TypedArray', nil);
@@ -992,7 +992,7 @@ begin
   TGocciaClassValue.PatchDefaultPrototype(NumberConstructor);
   TGocciaClassValue.PatchDefaultPrototype(BooleanConstructor);
   TGocciaClassValue.PatchDefaultPrototype(FunctionConstructor);
-  FInterpreter.GlobalScope.DefineLexicalBinding('Function', FunctionConstructor, dtConst);
+  FInterpreter.GlobalScope.DefineLexicalBinding('Function', FunctionConstructor, dtConst, True);
 
   // ES2026 §20.4.3: Symbol.prototype's [[Prototype]] is %Object.prototype%
   if Assigned(TGocciaSymbolValue.SharedPrototype) then
@@ -1048,7 +1048,7 @@ begin
     TGocciaTypedArrayValue.SetUint8Prototype(TAConstructor.Prototype);
   end;
 
-  FInterpreter.GlobalScope.DefineLexicalBinding(AName, TAConstructor, dtConst);
+  FInterpreter.GlobalScope.DefineLexicalBinding(AName, TAConstructor, dtConst, True);
 end;
 
 procedure TGocciaEngine.RegisterGlobalThis;
@@ -1084,7 +1084,7 @@ begin
   if Scope.ContainsOwnLexicalBinding('globalThis') then
     Scope.ForceUpdateBinding('globalThis', GlobalThisObj)
   else
-    Scope.DefineLexicalBinding('globalThis', GlobalThisObj, dtConst);
+    Scope.DefineLexicalBinding('globalThis', GlobalThisObj, dtConst, True);
 
   // ES2026 §9.1.2.5 NewGlobalEnvironment: a global Environment Record's
   // [[GlobalThisValue]] is the global object. Top-level `this` resolves
@@ -1150,7 +1150,7 @@ begin
   GocciaObj.AssignProperty('gc', GCFunc);
 
   FGocciaGlobal := GocciaObj;
-  FInterpreter.GlobalScope.DefineLexicalBinding('Goccia', FGocciaGlobal, dtConst);
+  FInterpreter.GlobalScope.DefineLexicalBinding('Goccia', FGocciaGlobal, dtConst, True);
 end;
 
 function TGocciaEngine.GetResolver: TGocciaModuleResolver;

--- a/source/units/Goccia.ObjectModel.Engine.pas
+++ b/source/units/Goccia.ObjectModel.Engine.pas
@@ -136,7 +136,7 @@ begin
           ASpeciesGetter, 'get [Symbol.species]', 0),
         nil, [pfConfigurable]));
 
-  AScope.DefineLexicalBinding(ATypeDefinition.ConstructorName, AConstructor, dtConst);
+  AScope.DefineLexicalBinding(ATypeDefinition.ConstructorName, AConstructor, dtConst, True);
 end;
 
 end.

--- a/source/units/Goccia.Runtime.pas
+++ b/source/units/Goccia.Runtime.pas
@@ -812,7 +812,7 @@ begin
   begin
     PerformanceConstructor := TGocciaPerformance.CreateInterfaceObject;
     FEngine.Interpreter.GlobalScope.DefineLexicalBinding(
-      CONSTRUCTOR_PERFORMANCE, PerformanceConstructor, dtConst);
+      CONSTRUCTOR_PERFORMANCE, PerformanceConstructor, dtConst, True);
   end;
 end;
 

--- a/source/units/Goccia.Scope.BindingMap.pas
+++ b/source/units/Goccia.Scope.BindingMap.pas
@@ -23,6 +23,7 @@ type
     Value: TGocciaValue;
     DeclarationType: TGocciaDeclarationType;
     Initialized: Boolean;
+    BuiltIn: Boolean;
     { Strict-types annotation enforced on every assignment.  Default
       sltUntyped means no enforcement (typical untyped binding). }
     TypeHint: TGocciaLocalType;

--- a/source/units/Goccia.Scope.Redeclaration.pas
+++ b/source/units/Goccia.Scope.Redeclaration.pas
@@ -22,27 +22,32 @@ uses
 
 procedure CheckPatternRedeclarations(
   const APattern: TGocciaDestructuringPattern;
-  const AScope: TGocciaScope; const ASourcePath: string);
+  const AScope: TGocciaScope; const ASourcePath: string;
+  const AIsVar: Boolean);
 var
   ObjPat: TGocciaObjectDestructuringPattern;
   ArrPat: TGocciaArrayDestructuringPattern;
+  DeclName: string;
   I: Integer;
 begin
   if APattern is TGocciaIdentifierDestructuringPattern then
   begin
-    if AScope.ContainsOwnLexicalBinding(
-         TGocciaIdentifierDestructuringPattern(APattern).Name) then
+    DeclName := TGocciaIdentifierDestructuringPattern(APattern).Name;
+    if AScope.ContainsOwnLexicalBinding(DeclName) then
+    begin
+      if AIsVar and AScope.IsBuiltInBinding(DeclName) then
+        Exit;
       raise TGocciaSyntaxError.Create(
         SysUtils.Format('Identifier ''%s'' has already been declared',
-          [TGocciaIdentifierDestructuringPattern(APattern).Name]),
-        0, 0, ASourcePath, nil);
+          [DeclName]), 0, 0, ASourcePath, nil);
+    end;
   end
   else if APattern is TGocciaObjectDestructuringPattern then
   begin
     ObjPat := TGocciaObjectDestructuringPattern(APattern);
     for I := 0 to ObjPat.Properties.Count - 1 do
       CheckPatternRedeclarations(ObjPat.Properties[I].Pattern,
-        AScope, ASourcePath);
+        AScope, ASourcePath, AIsVar);
   end
   else if APattern is TGocciaArrayDestructuringPattern then
   begin
@@ -50,16 +55,16 @@ begin
     for I := 0 to ArrPat.Elements.Count - 1 do
       if Assigned(ArrPat.Elements[I]) then
         CheckPatternRedeclarations(ArrPat.Elements[I],
-          AScope, ASourcePath);
+          AScope, ASourcePath, AIsVar);
   end
   else if APattern is TGocciaAssignmentDestructuringPattern then
     CheckPatternRedeclarations(
       TGocciaAssignmentDestructuringPattern(APattern).Left,
-      AScope, ASourcePath)
+      AScope, ASourcePath, AIsVar)
   else if APattern is TGocciaRestDestructuringPattern then
     CheckPatternRedeclarations(
       TGocciaRestDestructuringPattern(APattern).Argument,
-      AScope, ASourcePath);
+      AScope, ASourcePath, AIsVar);
 end;
 
 procedure CheckTopLevelRedeclarations(const AProgram: TGocciaProgram;
@@ -102,7 +107,8 @@ begin
     end
     else if Stmt is TGocciaDestructuringDeclaration then
       CheckPatternRedeclarations(
-        TGocciaDestructuringDeclaration(Stmt).Pattern, AScope, ASourcePath)
+        TGocciaDestructuringDeclaration(Stmt).Pattern, AScope, ASourcePath,
+        TGocciaDestructuringDeclaration(Stmt).IsVar)
     else if Stmt is TGocciaEnumDeclaration then
     begin
       DeclName := TGocciaEnumDeclaration(Stmt).Name;

--- a/source/units/Goccia.Scope.Redeclaration.pas
+++ b/source/units/Goccia.Scope.Redeclaration.pas
@@ -76,19 +76,21 @@ begin
     if Stmt is TGocciaVariableDeclaration then
     begin
       VarDecl := TGocciaVariableDeclaration(Stmt);
-      // §16.1.7: var and function declarations may shadow built-in
-      // globals in script mode.  Only block the redeclaration when the
-      // existing binding is a user-declared lexical (let/const/class).
-      if not (VarDecl.IsVar or VarDecl.IsFunctionDeclaration) then
-        for J := 0 to High(VarDecl.Variables) do
+      for J := 0 to High(VarDecl.Variables) do
+      begin
+        DeclName := VarDecl.Variables[J].Name;
+        if AScope.ContainsOwnLexicalBinding(DeclName) then
         begin
-          DeclName := VarDecl.Variables[J].Name;
-          if AScope.ContainsOwnLexicalBinding(DeclName) and
-             not AScope.IsBuiltInBinding(DeclName) then
-            raise TGocciaSyntaxError.Create(
-              SysUtils.Format('Identifier ''%s'' has already been declared',
-                [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+          // §16.1.7: var/function declarations may shadow built-in
+          // globals in script mode, but not user-declared bindings.
+          if (VarDecl.IsVar or VarDecl.IsFunctionDeclaration) and
+             AScope.IsBuiltInBinding(DeclName) then
+            Continue;
+          raise TGocciaSyntaxError.Create(
+            SysUtils.Format('Identifier ''%s'' has already been declared',
+              [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
         end;
+      end;
     end
     else if Stmt is TGocciaClassDeclaration then
     begin

--- a/source/units/Goccia.Scope.Redeclaration.pas
+++ b/source/units/Goccia.Scope.Redeclaration.pas
@@ -76,14 +76,19 @@ begin
     if Stmt is TGocciaVariableDeclaration then
     begin
       VarDecl := TGocciaVariableDeclaration(Stmt);
-      for J := 0 to High(VarDecl.Variables) do
-      begin
-        DeclName := VarDecl.Variables[J].Name;
-        if AScope.ContainsOwnLexicalBinding(DeclName) then
-          raise TGocciaSyntaxError.Create(
-            SysUtils.Format('Identifier ''%s'' has already been declared',
-              [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
-      end;
+      // §16.1.7: var and function declarations may shadow built-in
+      // globals in script mode.  Only block the redeclaration when the
+      // existing binding is a user-declared lexical (let/const/class).
+      if not (VarDecl.IsVar or VarDecl.IsFunctionDeclaration) then
+        for J := 0 to High(VarDecl.Variables) do
+        begin
+          DeclName := VarDecl.Variables[J].Name;
+          if AScope.ContainsOwnLexicalBinding(DeclName) and
+             not AScope.IsBuiltInBinding(DeclName) then
+            raise TGocciaSyntaxError.Create(
+              SysUtils.Format('Identifier ''%s'' has already been declared',
+                [DeclName]), Stmt.Line, Stmt.Column, ASourcePath, nil);
+        end;
     end
     else if Stmt is TGocciaClassDeclaration then
     begin

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -433,10 +433,10 @@ begin
   EffectiveValue := AValue;
 
   // §16.1.7: var/function declarations may shadow built-in globals in
-  // script mode.  Remove the lexical binding so the var binding is
-  // visible through GetBinding.  Preserve the original value when the
-  // declaration has no initializer (e.g. bare `var NaN;`).
-  if TargetScope.FLexicalBindings.TryGetValue(AName, ExistingBuiltIn) and
+  // script mode.  Only the global scope carries built-in bindings, so
+  // skip the lookup for function/module-scoped vars (the common case).
+  if (TargetScope.FScopeKind = skGlobal) and
+     TargetScope.FLexicalBindings.TryGetValue(AName, ExistingBuiltIn) and
      ExistingBuiltIn.BuiltIn then
   begin
     if not AHasInitializer then

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -50,7 +50,7 @@ type
 
     // New Define/Assign pattern
     procedure PredeclareLexicalBinding(const AName: string; const ADeclarationType: TGocciaDeclarationType; const ALine: Integer = 0; const AColumn: Integer = 0);
-    procedure DefineLexicalBinding(const AName: string; const AValue: TGocciaValue; const ADeclarationType: TGocciaDeclarationType; const ALine: Integer = 0; const AColumn: Integer = 0);
+    procedure DefineLexicalBinding(const AName: string; const AValue: TGocciaValue; const ADeclarationType: TGocciaDeclarationType; const ABuiltIn: Boolean = False; const ALine: Integer = 0; const AColumn: Integer = 0);
     procedure AssignBinding(const AName: string; const AValue: TGocciaValue; const ALine: Integer = 0; const AColumn: Integer = 0); virtual;
     procedure ForceUpdateBinding(const AName: string; const AValue: TGocciaValue);
 
@@ -74,6 +74,7 @@ type
 
     function ResolveIdentifier(const AName: string): TGocciaValue; inline;
     function ContainsOwnLexicalBinding(const AName: string): Boolean; inline;
+    function IsBuiltInBinding(const AName: string): Boolean;
     function Contains(const AName: string): Boolean; inline;
     function GetOwnBindingNames: TGocciaStringArray; inline;
 
@@ -348,7 +349,7 @@ begin
   FLexicalBindings.Add(AName, LexicalBinding);
 end;
 
-procedure TGocciaScope.DefineLexicalBinding(const AName: string; const AValue: TGocciaValue; const ADeclarationType: TGocciaDeclarationType; const ALine: Integer = 0; const AColumn: Integer = 0);
+procedure TGocciaScope.DefineLexicalBinding(const AName: string; const AValue: TGocciaValue; const ADeclarationType: TGocciaDeclarationType; const ABuiltIn: Boolean = False; const ALine: Integer = 0; const AColumn: Integer = 0);
 var
   LexicalBinding: TLexicalBinding;
   ExistingLexicalBinding: TLexicalBinding;
@@ -386,6 +387,7 @@ begin
   // - dtLet: no TDZ after declaration statement is processed
   // - dtParameter: parameters have no TDZ
   LexicalBinding.Initialized := True;
+  LexicalBinding.BuiltIn := ABuiltIn;
   LexicalBinding.TypeHint := sltUntyped;
 
   FLexicalBindings.AddOrSetValue(AName, LexicalBinding);
@@ -422,9 +424,24 @@ procedure TGocciaScope.DefineVariableBinding(const AName: string; const AValue: 
 var
   TargetScope: TGocciaScope;
   Binding: TLexicalBinding;
+  ExistingBuiltIn: TLexicalBinding;
+  EffectiveValue: TGocciaValue;
   GlobalObject: TGocciaObjectValue;
 begin
   TargetScope := FindFunctionOrModuleScope;
+  EffectiveValue := AValue;
+
+  // §16.1.7: var/function declarations may shadow built-in globals in
+  // script mode.  Remove the lexical binding so the var binding is
+  // visible through GetBinding.  Preserve the original value when the
+  // declaration has no initializer (e.g. bare `var NaN;`).
+  if TargetScope.FLexicalBindings.TryGetValue(AName, ExistingBuiltIn) and
+     ExistingBuiltIn.BuiltIn then
+  begin
+    if not AHasInitializer then
+      EffectiveValue := ExistingBuiltIn.Value;
+    TargetScope.FLexicalBindings.Remove(AName);
+  end;
 
   if (TargetScope.FScopeKind = skGlobal) and
      (TargetScope.FThisValue is TGocciaObjectValue) then
@@ -432,7 +449,7 @@ begin
     GlobalObject := TGocciaObjectValue(TargetScope.FThisValue);
     if (not AHasInitializer) and GlobalObject.HasOwnProperty(AName) then
       Exit;
-    GlobalObject.AssignProperty(AName, AValue);
+    GlobalObject.AssignProperty(AName, EffectiveValue);
     Exit;
   end;
 
@@ -445,14 +462,14 @@ begin
     // Redeclaration: only update if the source had a syntactic initializer.
     if AHasInitializer then
     begin
-      Binding.Value := AValue;
+      Binding.Value := EffectiveValue;
       TargetScope.FVarBindings.AddOrSetValue(AName, Binding);
     end;
   end
   else
   begin
     // First declaration: create the binding
-    Binding.Value := AValue;
+    Binding.Value := EffectiveValue;
     Binding.DeclarationType := dtVar;
     Binding.Initialized := True;
     Binding.TypeHint := sltUntyped;
@@ -608,6 +625,13 @@ end;
 function TGocciaScope.ContainsOwnLexicalBinding(const AName: string): Boolean; inline;
 begin
   Result := FLexicalBindings.ContainsKey(AName);
+end;
+
+function TGocciaScope.IsBuiltInBinding(const AName: string): Boolean;
+var
+  Binding: TLexicalBinding;
+begin
+  Result := FLexicalBindings.TryGetValue(AName, Binding) and Binding.BuiltIn;
 end;
 
 function TGocciaScope.Contains(const AName: string): Boolean; inline;

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -364,6 +364,7 @@ begin
       ExistingLexicalBinding.Value := AValue;
       ExistingLexicalBinding.DeclarationType := ADeclarationType;
       ExistingLexicalBinding.Initialized := True;
+      ExistingLexicalBinding.BuiltIn := ABuiltIn;
       FLexicalBindings.AddOrSetValue(AName, ExistingLexicalBinding);
       Exit;
     end;
@@ -473,6 +474,7 @@ begin
     Binding.Value := EffectiveValue;
     Binding.DeclarationType := dtVar;
     Binding.Initialized := True;
+    Binding.BuiltIn := False;
     Binding.TypeHint := sltUntyped;
     TargetScope.FVarBindings.AddOrSetValue(AName, Binding);
   end;

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -345,6 +345,7 @@ begin
   LexicalBinding.Value := TGocciaUndefinedLiteralValue.UndefinedValue;
   LexicalBinding.DeclarationType := ADeclarationType;
   LexicalBinding.Initialized := False;
+  LexicalBinding.BuiltIn := False;
   LexicalBinding.TypeHint := sltUntyped;
   FLexicalBindings.Add(AName, LexicalBinding);
 end;

--- a/tests/language/declarations/const/cannot-shadow-builtin-globals.js
+++ b/tests/language/declarations/const/cannot-shadow-builtin-globals.js
@@ -1,0 +1,24 @@
+/*---
+description: const declarations cannot shadow built-in globals at the same scope level
+features: [const-declaration]
+---*/
+
+test("const NaN at top level throws SyntaxError", () => {
+  expect(() => {
+    eval("const NaN = 42");
+  }).toThrow();
+});
+
+test("const Array at top level throws SyntaxError", () => {
+  expect(() => {
+    eval("const Array = []");
+  }).toThrow();
+});
+
+test("const in a nested block does not conflict with built-in globals", () => {
+  {
+    const NaN = 42;
+    expect(NaN).toBe(42);
+  }
+  expect(NaN).toBeNaN();
+});

--- a/tests/language/declarations/const/cannot-shadow-builtin-globals.js
+++ b/tests/language/declarations/const/cannot-shadow-builtin-globals.js
@@ -1,24 +1,20 @@
 /*---
-description: const declarations cannot shadow built-in globals at the same scope level
+description: const cannot shadow built-in globals at the same scope level but can in nested blocks
 features: [const-declaration]
 ---*/
 
-test("const NaN at top level throws SyntaxError", () => {
-  expect(() => {
-    eval("const NaN = 42");
-  }).toThrow();
-});
-
-test("const Array at top level throws SyntaxError", () => {
-  expect(() => {
-    eval("const Array = []");
-  }).toThrow();
-});
-
-test("const in a nested block does not conflict with built-in globals", () => {
+test("const in a nested block shadows built-in NaN locally", () => {
   {
     const NaN = 42;
     expect(NaN).toBe(42);
   }
   expect(NaN).toBeNaN();
+});
+
+test("const in a nested block shadows built-in Array locally", () => {
+  {
+    const Array = "not-an-array";
+    expect(Array).toBe("not-an-array");
+  }
+  expect(typeof Array).toBe("function");
 });

--- a/tests/language/declarations/let/cannot-shadow-builtin-globals.js
+++ b/tests/language/declarations/let/cannot-shadow-builtin-globals.js
@@ -1,36 +1,28 @@
 /*---
-description: let declarations cannot shadow built-in globals at the same scope level
+description: let cannot shadow built-in globals at the same scope level but can in nested blocks
 features: [let-declaration]
 ---*/
 
-test("let NaN at top level throws SyntaxError", () => {
-  expect(() => {
-    eval("let NaN = 42");
-  }).toThrow();
-});
-
-test("let Infinity at top level throws SyntaxError", () => {
-  expect(() => {
-    eval("let Infinity = 42");
-  }).toThrow();
-});
-
-test("let undefined at top level throws SyntaxError", () => {
-  expect(() => {
-    eval("let undefined = 42");
-  }).toThrow();
-});
-
-test("let Array at top level throws SyntaxError", () => {
-  expect(() => {
-    eval("let Array = 42");
-  }).toThrow();
-});
-
-test("let in a nested block does not conflict with built-in globals", () => {
+test("let in a nested block shadows built-in NaN locally", () => {
   {
     let NaN = 42;
     expect(NaN).toBe(42);
   }
   expect(NaN).toBeNaN();
+});
+
+test("let in a nested block shadows built-in Infinity locally", () => {
+  {
+    let Infinity = "finite";
+    expect(Infinity).toBe("finite");
+  }
+  expect(Infinity).toBe(1 / 0);
+});
+
+test("let in a nested block shadows built-in Array locally", () => {
+  {
+    let Array = "not-an-array";
+    expect(Array).toBe("not-an-array");
+  }
+  expect(typeof Array).toBe("function");
 });

--- a/tests/language/declarations/let/cannot-shadow-builtin-globals.js
+++ b/tests/language/declarations/let/cannot-shadow-builtin-globals.js
@@ -1,0 +1,36 @@
+/*---
+description: let declarations cannot shadow built-in globals at the same scope level
+features: [let-declaration]
+---*/
+
+test("let NaN at top level throws SyntaxError", () => {
+  expect(() => {
+    eval("let NaN = 42");
+  }).toThrow();
+});
+
+test("let Infinity at top level throws SyntaxError", () => {
+  expect(() => {
+    eval("let Infinity = 42");
+  }).toThrow();
+});
+
+test("let undefined at top level throws SyntaxError", () => {
+  expect(() => {
+    eval("let undefined = 42");
+  }).toThrow();
+});
+
+test("let Array at top level throws SyntaxError", () => {
+  expect(() => {
+    eval("let Array = 42");
+  }).toThrow();
+});
+
+test("let in a nested block does not conflict with built-in globals", () => {
+  {
+    let NaN = 42;
+    expect(NaN).toBe(42);
+  }
+  expect(NaN).toBeNaN();
+});

--- a/tests/language/function-keyword/shadow-builtin-globals.js
+++ b/tests/language/function-keyword/shadow-builtin-globals.js
@@ -1,0 +1,22 @@
+/*---
+description: function declarations may shadow built-in globals in script mode (§16.1.7)
+features: [compat-function, compat-var]
+---*/
+
+test("function declaration shadows built-in Array", () => {
+  function Array() { return "custom"; }
+  expect(typeof Array).toBe("function");
+  expect(Array()).toBe("custom");
+});
+
+test("function declaration shadows built-in Object", () => {
+  function Object() { return "custom-object"; }
+  expect(typeof Object).toBe("function");
+  expect(Object()).toBe("custom-object");
+});
+
+test("function declaration shadows built-in Error", () => {
+  function Error() { return "custom-error"; }
+  expect(typeof Error).toBe("function");
+  expect(Error()).toBe("custom-error");
+});

--- a/tests/language/function-keyword/shadow-builtin-globals.js
+++ b/tests/language/function-keyword/shadow-builtin-globals.js
@@ -3,20 +3,21 @@ description: function declarations may shadow built-in globals in script mode (Â
 features: [compat-function, compat-var]
 ---*/
 
-test("function declaration shadows built-in Array", () => {
-  function Array() { return "custom"; }
+function Array() { return "custom"; }
+function Object() { return "custom-object"; }
+function Error() { return "custom-error"; }
+
+test("top-level function declaration shadows built-in Array", () => {
   expect(typeof Array).toBe("function");
   expect(Array()).toBe("custom");
 });
 
-test("function declaration shadows built-in Object", () => {
-  function Object() { return "custom-object"; }
+test("top-level function declaration shadows built-in Object", () => {
   expect(typeof Object).toBe("function");
   expect(Object()).toBe("custom-object");
 });
 
-test("function declaration shadows built-in Error", () => {
-  function Error() { return "custom-error"; }
+test("top-level function declaration shadows built-in Error", () => {
   expect(typeof Error).toBe("function");
   expect(Error()).toBe("custom-error");
 });

--- a/tests/language/var/shadow-builtin-globals.js
+++ b/tests/language/var/shadow-builtin-globals.js
@@ -11,6 +11,14 @@ test("top-level var NaN without initializer preserves the built-in value", () =>
   expect(typeof NaN).toBe("number");
 });
 
+test("function-scoped var NaN with initializer creates a local binding", () => {
+  const fn = () => {
+    var NaN = 42;
+    return NaN;
+  };
+  expect(fn()).toBe(42);
+});
+
 test("top-level var Infinity without initializer preserves the built-in value", () => {
   expect(typeof Infinity).toBe("number");
   expect(Infinity).toBe(1 / 0);

--- a/tests/language/var/shadow-builtin-globals.js
+++ b/tests/language/var/shadow-builtin-globals.js
@@ -13,6 +13,7 @@ test("top-level var NaN without initializer preserves the built-in value", () =>
 
 test("top-level var Infinity without initializer preserves the built-in value", () => {
   expect(typeof Infinity).toBe("number");
+  expect(Infinity).toBe(1 / 0);
 });
 
 test("top-level var undefined without initializer preserves the built-in value", () => {
@@ -21,7 +22,7 @@ test("top-level var undefined without initializer preserves the built-in value",
 
 var Array = "shadowed";
 
-test("top-level var Array with initializer shadows the constructor", () => {
+test("top-level var with initializer shadows a writable built-in", () => {
   expect(Array).toBe("shadowed");
 });
 

--- a/tests/language/var/shadow-builtin-globals.js
+++ b/tests/language/var/shadow-builtin-globals.js
@@ -1,0 +1,35 @@
+/*---
+description: top-level var declarations may shadow built-in globals in script mode (§16.1.7)
+features: [compat-var]
+---*/
+
+var NaN;
+var Infinity;
+var undefined;
+
+test("top-level var NaN without initializer preserves the built-in value", () => {
+  expect(typeof NaN).toBe("number");
+});
+
+test("top-level var Infinity without initializer preserves the built-in value", () => {
+  expect(typeof Infinity).toBe("number");
+});
+
+test("top-level var undefined without initializer preserves the built-in value", () => {
+  expect(typeof undefined).toBe("undefined");
+});
+
+var Array = "shadowed";
+
+test("top-level var Array with initializer shadows the constructor", () => {
+  expect(Array).toBe("shadowed");
+});
+
+test("var inside a function creates a local binding, does not touch the global", () => {
+  const fn = () => {
+    var Map = "local";
+    return Map;
+  };
+  expect(fn()).toBe("local");
+  expect(typeof Map).toBe("function");
+});


### PR DESCRIPTION
## Summary

- Allow top-level `var`, `function`, and `var`-destructuring declarations to shadow built-in globals (`Array`, `NaN`, `Infinity`, `undefined`, etc.) in script mode, per ES2026 §16.1.7 GlobalDeclarationInstantiation.
- Previously all such redeclarations were rejected with a SyntaxError regardless of declaration kind or script-vs-module mode. Now only `let`/`const`/`class` redeclarations of built-in globals are blocked.
- Adds a `BuiltIn` flag to `TLexicalBinding` so the engine can distinguish engine-registered bindings from user declarations. All built-in registration sites pass `True` at the call site. User-injected globals (`RegisterGlobal`) are intentionally **not** marked built-in.
- `CheckTopLevelRedeclarations` skips `var`/`function` declarations when the existing binding is built-in; `CheckPatternRedeclarations` receives the `IsVar` flag so `var`-destructuring patterns get the same exemption.
- `DefineVariableBinding` removes the built-in lexical binding at runtime (preserving the original value for bare `var NaN;`-style declarations without initializers) so the var binding becomes visible through `GetBinding`. The built-in check is guarded by `skGlobal` to skip the probe for function/module-scoped vars.
- All `TLexicalBinding` creation sites (`PredeclareLexicalBinding`, `DefineLexicalBinding` materialization branch, `DefineVariableBinding` first-declaration branch) explicitly initialize the `BuiltIn` field.
- Closes #521, closes #580

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - 8901/8906 tests pass (5 pre-existing FFI fixture failures)
  - New tests cover `var` shadowing (`NaN`, `Infinity`, `undefined`, `Array`), `function` shadowing (`Array`, `Object`, `Error`), function-scoped `var NaN = 42`, and `let`/`const` block-scope shadowing
  - Verified in both interpreter and bytecode modes
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
