### PR TITLE
Fix console.log TypeError on prototype-less objects, add --inspect-depth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader # Execute stdin source
 ./build/GocciaScriptLoader example.js --log=console.log # Write console output to a log file (tee to stdout + file)
 ./build/GocciaScriptLoader example.js --stack-size=5000 # Execute with custom call stack depth limit
 ./build/GocciaScriptLoader example.js --stack-size=0 --mode=bytecode # Execute with no call stack depth limit (bytecode trampoline)
+./build/GocciaScriptLoader example.js --inspect-depth=2 # Execute with shallow object inspection (default: 5)
 ./build/GocciaScriptLoader example.js --multifile # Split file on '---' separators and run each section as its own input
 ./build/GocciaScriptLoader example.js --multifile --jobs=4 # Multifile with parallel section dispatch
 printf '1;\n---\n2;\n' | ./build/GocciaScriptLoader --multifile # Split stdin on '---' (sections named <stdin>[part1], <stdin>[part2])

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -237,6 +237,7 @@ Relative paths are resolved against the current working directory. A missing fil
   "timeout": 5000,
   "max-memory": 10485760,
   "stack-size": 3500,
+  "inspect-depth": 5,
   "allowed-hosts": ["api.example.com", "cdn.example.com"],
   "imports": {
     "@/": "./src/"
@@ -271,6 +272,7 @@ mode = "bytecode"
 timeout = 5000
 max-memory = 10485760
 stack-size = 3500
+inspect-depth = 5
 ```
 
 **CLI vs. embedding** — Config file discovery is automatic for all CLI applications (`GocciaScriptLoader`, `GocciaTestRunner`, `GocciaBenchmarkRunner`, `GocciaBundler`, `GocciaREPL`) because they inherit from `TGocciaCLIApplication`. When embedding the engine directly, config file loading is not automatic. Use the shared `CLI.ConfigFile` unit to get the same behavior.

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -126,6 +126,7 @@ uses
   Goccia.Timeout,
   Goccia.TOML,
   Goccia.Values.ArrayValue,
+  Goccia.Values.Formatting,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
@@ -706,8 +707,12 @@ end;
 procedure TGocciaCLIApplication.InitializeSingletons;
 begin
   SetMaxStackDepth(DEFAULT_MAX_STACK_DEPTH);
+  SetInspectDepth(DEFAULT_INSPECT_DEPTH);
   if Assigned(FEngineOptions) then
+  begin
     SetMaxStackDepth(Max(0, FEngineOptions.StackSize.ValueOr(DEFAULT_MAX_STACK_DEPTH)));
+    SetInspectDepth(FEngineOptions.InspectDepth.ValueOr(DEFAULT_INSPECT_DEPTH));
+  end;
   if Assigned(FCoverageOptions) then
     InitializeCoverageIfEnabled(FCoverageOptions);
   if Assigned(FProfilerOptions) then

--- a/source/shared/CLI.Options.pas
+++ b/source/shared/CLI.Options.pas
@@ -170,6 +170,7 @@ type
     FCompatAll: TGocciaFlagOption;
     FStrictTypes: TGocciaFlagOption;
     FAllowedHosts: TGocciaRepeatableOption;
+    FInspectDepth: TGocciaIntegerOption;
   public
     constructor Create;
     destructor Destroy; override;
@@ -193,6 +194,7 @@ type
     property CompatAll: TGocciaFlagOption read FCompatAll;
     property StrictTypes: TGocciaFlagOption read FStrictTypes;
     property AllowedHosts: TGocciaRepeatableOption read FAllowedHosts;
+    property InspectDepth: TGocciaIntegerOption read FInspectDepth;
   end;
 
   TGocciaCoverageFormat = (cfLcov, cfJson);
@@ -584,6 +586,8 @@ begin
   FAllowedHosts := TGocciaRepeatableOption.Create('allowed-host',
     'Hostname allowed for fetch requests (repeatable)', 'Engine');
   FAllowedHosts.ConfigName := 'allowed-hosts';
+  FInspectDepth := TGocciaIntegerOption.Create('inspect-depth',
+    'Maximum object inspection depth for console output (default: 5)', 'Engine');
 end;
 
 destructor TGocciaEngineOptions.Destroy;
@@ -605,12 +609,13 @@ begin
   FCompatAll.Free;
   FStrictTypes.Free;
   FAllowedHosts.Free;
+  FInspectDepth.Free;
   inherited Destroy;
 end;
 
 function TGocciaEngineOptions.Options: TGocciaOptionArray;
 begin
-  SetLength(Result, 17);
+  SetLength(Result, 18);
   Result[0] := FMode;
   Result[1] := FSourceType;
   Result[2] := FASI;
@@ -628,6 +633,7 @@ begin
   Result[14] := FCompatAll;
   Result[15] := FStrictTypes;
   Result[16] := FAllowedHosts;
+  Result[17] := FInspectDepth;
 end;
 
 { TGocciaCoverageOptions }

--- a/source/units/Goccia.Builtins.Console.pas
+++ b/source/units/Goccia.Builtins.Console.pas
@@ -12,6 +12,7 @@ uses
   Goccia.Error.ThrowErrorCallback,
   Goccia.ObjectModel,
   Goccia.Scope,
+  Goccia.Values.Formatting,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
@@ -30,7 +31,6 @@ type
 
     function FormatArgs(const AArgs: TGocciaArgumentsCollection): string;
     function GroupPrefix: string;
-    function FormatValue(const AValue: TGocciaValue): string;
     procedure EmitLine(const AMethod, ALine: string);
     function GetEnabled: Boolean;
     procedure SetEnabled(const AValue: Boolean);
@@ -72,10 +72,7 @@ implementation
 uses
   SysUtils,
 
-  StringBuffer,
-  TimingUtils,
-
-  Goccia.Values.ArrayValue;
+  TimingUtils;
 
 threadvar
   FStaticMembers: TArray<TGocciaMemberDefinition>;
@@ -176,53 +173,6 @@ begin
   FLogCallback := AValue;
 end;
 
-function TGocciaConsole.FormatValue(const AValue: TGocciaValue): string;
-var
-  Arr: TGocciaArrayValue;
-  Obj: TGocciaObjectValue;
-  I: Integer;
-  Key: string;
-  SB: TStringBuffer;
-  First: Boolean;
-begin
-  if AValue is TGocciaArrayValue then
-  begin
-    Arr := TGocciaArrayValue(AValue);
-    SB := TStringBuffer.Create;
-    SB.AppendChar('[');
-    for I := 0 to Arr.Elements.Count - 1 do
-    begin
-      if I > 0 then
-        SB.Append(', ');
-      SB.Append(FormatValue(Arr.Elements[I]));
-    end;
-    SB.AppendChar(']');
-    Result := SB.ToString;
-  end
-  else if AValue is TGocciaObjectValue then
-  begin
-    Obj := TGocciaObjectValue(AValue);
-    SB := TStringBuffer.Create;
-    SB.AppendChar('{');
-    First := True;
-    for Key in Obj.GetEnumerablePropertyNames do
-    begin
-      if not First then
-        SB.Append(', ');
-      First := False;
-      SB.Append(Key);
-      SB.Append(': ');
-      SB.Append(FormatValue(Obj.GetProperty(Key)));
-    end;
-    SB.AppendChar('}');
-    Result := SB.ToString;
-  end
-  else if AValue is TGocciaStringLiteralValue then
-    Result := '''' + AValue.ToStringLiteral.Value + ''''
-  else
-    Result := AValue.ToStringLiteral.Value;
-end;
-
 function TGocciaConsole.FormatArgs(const AArgs: TGocciaArgumentsCollection): string;
 var
   I: Integer;
@@ -232,7 +182,7 @@ begin
   begin
     if I > 0 then
       Result := Result + ' ';
-    Result := Result + AArgs.GetElement(I).ToStringLiteral.Value;
+    Result := Result + FormatForDisplay(AArgs.GetElement(I));
   end;
 end;
 
@@ -282,7 +232,7 @@ begin
   if AArgs.Length >= 1 then
   begin
     Value := AArgs.GetElement(0);
-    EmitLine('dir', GroupPrefix + FormatValue(Value));
+    EmitLine('dir', GroupPrefix + FormatForDisplay(Value));
   end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -302,7 +252,7 @@ begin
       if AArgs.Length >= 2 then
       begin
         for I := 1 to AArgs.Length - 1 do
-          Msg := Msg + ' ' + AArgs.GetElement(I).ToStringLiteral.Value;
+          Msg := Msg + ' ' + FormatForDisplay(AArgs.GetElement(I));
       end;
       EmitLine('assert', GroupPrefix + Msg);
     end;
@@ -437,7 +387,7 @@ end;
 function TGocciaConsole.ConsoleTable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   if AArgs.Length >= 1 then
-    EmitLine('table', GroupPrefix + FormatValue(AArgs.GetElement(0)));
+    EmitLine('table', GroupPrefix + FormatForDisplay(AArgs.GetElement(0)));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -304,11 +304,6 @@ uses
   Goccia.Values.PromiseValue,
   Goccia.Values.SetValue;
 
-function FormatForMessage(const AValue: TGocciaValue): string;
-begin
-  Result := FormatForDisplay(AValue);
-end;
-
 function FormatThrowValueDetail(const AValue: TGocciaValue): string;
 var
   MsgValue, StackValue: TGocciaValue;
@@ -323,10 +318,10 @@ begin
     else if Assigned(MsgValue) and (MsgValue is TGocciaStringLiteralValue) then
       Result := TGocciaStringLiteralValue(MsgValue).Value
     else
-      Result := FormatForMessage(AValue);
+      Result := FormatForDisplay(AValue);
   end
   else
-    Result := FormatForMessage(AValue);
+    Result := FormatForDisplay(AValue);
 end;
 
 { TGocciaTestSuite }
@@ -713,10 +708,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBe',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBe',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -743,10 +738,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to equal ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to equal ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' to equal ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to equal ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -765,7 +760,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toContainEqual')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContainEqual',
-        'Expected an array but received ' + FormatForMessage(FActualValue));
+        'Expected an array but received ' + FormatForDisplay(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -791,10 +786,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContainEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to contain equal ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to contain equal ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContainEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' to contain equal ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to contain equal ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -821,10 +816,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toStrictEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to strictly equal ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to strictly equal ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toStrictEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' to strictly equal ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to strictly equal ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -844,7 +839,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toMatchObject')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatchObject',
-        'Expected an object but received ' + FormatForMessage(FActualValue));
+        'Expected an object but received ' + FormatForDisplay(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -855,7 +850,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toMatchObject')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatchObject',
-        'Expected a match object but received ' + FormatForMessage(Expected));
+        'Expected a match object but received ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -874,10 +869,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatchObject',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to match object ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to match object ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatchObject',
-        'Expected ' + FormatForMessage(FActualValue) + ' to match object ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to match object ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -901,7 +896,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toMatch')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatch',
-        'Expected a string but received ' + FormatForMessage(FActualValue));
+        'Expected a string but received ' + FormatForDisplay(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -914,12 +909,12 @@ begin
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatch',
         'Expected a string pattern or RegExp but received ' +
-        FormatForMessage(Expected));
+        FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
 
-  ActualString := FormatForMessage(FActualValue);
+  ActualString := FormatForDisplay(FActualValue);
   if IsRegExpValue(Expected) then
   begin
     ExpectedDescription := RegExpObjectToString(Expected);
@@ -928,7 +923,7 @@ begin
   end
   else
   begin
-    ExpectedDescription := FormatForMessage(Expected);
+    ExpectedDescription := FormatForDisplay(Expected);
     Matches := Pos(ExpectedDescription, ActualString) > 0;
   end;
 
@@ -944,11 +939,11 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatch',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to match ' +
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to match ' +
         ExpectedDescription)
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toMatch',
-        'Expected ' + FormatForMessage(FActualValue) + ' to match ' +
+        'Expected ' + FormatForDisplay(FActualValue) + ' to match ' +
         ExpectedDescription);
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
@@ -972,10 +967,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeNull',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be null')
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be null')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeNull',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be null');
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be null');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -998,10 +993,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeNaN',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be NaN')
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be NaN')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeNaN',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be NaN');
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be NaN');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1024,10 +1019,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeUndefined',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be undefined')
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be undefined')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeUndefined',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be undefined');
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be undefined');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1050,10 +1045,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeDefined',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be defined')
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be defined')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeDefined',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be defined');
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be defined');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1076,10 +1071,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeTruthy',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be truthy')
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be truthy')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeTruthy',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be truthy');
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be truthy');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1102,10 +1097,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeFalsy',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be falsy')
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be falsy')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeFalsy',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be falsy');
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be falsy');
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1132,10 +1127,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeGreaterThan',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be greater than ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be greater than ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeGreaterThan',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be greater than ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be greater than ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1162,10 +1157,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeGreaterThanOrEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be greater than or equal to ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be greater than or equal to ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeGreaterThanOrEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be greater than or equal to ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be greater than or equal to ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1192,10 +1187,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeLessThan',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be less than ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be less than ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeLessThan',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be less than ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be less than ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1222,10 +1217,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeLessThanOrEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be less than or equal to ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be less than or equal to ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeLessThanOrEqual',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be less than or equal to ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be less than or equal to ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1243,8 +1238,8 @@ begin
   // For strings, check substring
   if FActualValue is TGocciaStringLiteralValue then
   begin
-    ActualStr := FormatForMessage(FActualValue);
-    ExpectedStr := FormatForMessage(Expected);
+    ActualStr := FormatForDisplay(FActualValue);
+    ExpectedStr := FormatForDisplay(Expected);
     Contains := Pos(ExpectedStr, ActualStr) > 0;
   end
   else if FActualValue is TGocciaArrayValue then
@@ -1272,10 +1267,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContain',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to contain ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to contain ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContain',
-        'Expected ' + FormatForMessage(FActualValue) + ' to contain ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to contain ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1359,10 +1354,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeInstanceOf',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to be an instance of ' + FormatForMessage(ExpectedConstructor))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to be an instance of ' + FormatForDisplay(ExpectedConstructor))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeInstanceOf',
-        'Expected ' + FormatForMessage(FActualValue) + ' to be an instance of ' + FormatForMessage(ExpectedConstructor));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to be an instance of ' + FormatForDisplay(ExpectedConstructor));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1386,7 +1381,7 @@ begin
   end
   else if FActualValue is TGocciaStringLiteralValue then
   begin
-    HasLength := Length(FormatForMessage(FActualValue)) = Expected.ToNumberLiteral.Value;
+    HasLength := Length(FormatForDisplay(FActualValue)) = Expected.ToNumberLiteral.Value;
   end
   else
   begin
@@ -1405,10 +1400,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveLength',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to have length ' + FormatForMessage(Expected))
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to have length ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveLength',
-        'Expected ' + FormatForMessage(FActualValue) + ' to have length ' + FormatForMessage(Expected));
+        'Expected ' + FormatForDisplay(FActualValue) + ' to have length ' + FormatForDisplay(Expected));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1425,7 +1420,7 @@ begin
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toHaveProperty')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveProperty',
-        'Expected an object but received ' + FormatForMessage(FActualValue));
+        'Expected an object but received ' + FormatForDisplay(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
@@ -1444,10 +1439,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveProperty',
-        'Expected ' + FormatForMessage(FActualValue) + ' not to have property ' + AArgs.GetElement(0).ToStringLiteral.Value)
+        'Expected ' + FormatForDisplay(FActualValue) + ' not to have property ' + AArgs.GetElement(0).ToStringLiteral.Value)
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveProperty',
-        'Expected ' + FormatForMessage(FActualValue) + ' to have property ' + AArgs.GetElement(0).ToStringLiteral.Value);
+        'Expected ' + FormatForDisplay(FActualValue) + ' to have property ' + AArgs.GetElement(0).ToStringLiteral.Value);
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -1503,7 +1498,7 @@ begin
         end;
       end;
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-        'Expected error of type ' + ExpectedErrorType + ' but got: ' + FormatForMessage(FActualValue));
+        'Expected error of type ' + ExpectedErrorType + ' but got: ' + FormatForDisplay(FActualValue));
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
       Exit;
     end;
@@ -1577,7 +1572,7 @@ begin
         else
         begin
           TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-            'Expected ' + FormatForMessage(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + FormatForMessage(E.Value));
+            'Expected ' + FormatForDisplay(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + FormatForDisplay(E.Value));
           Exit;
         end;
       end;
@@ -1601,7 +1596,7 @@ begin
         else
         begin
           TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-            'Expected ' + FormatForMessage(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.Message);
+            'Expected ' + FormatForDisplay(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.Message);
           Exit;
         end;
       end;
@@ -1624,7 +1619,7 @@ begin
         else
         begin
           TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-            'Expected ' + FormatForMessage(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.ClassName + ': ' + E.Message);
+            'Expected ' + FormatForDisplay(FActualValue) + ' to throw ' + ExpectedErrorType + ' but threw: ' + E.ClassName + ': ' + E.Message);
           Exit;
         end;
       end;
@@ -1634,7 +1629,7 @@ begin
   end;
 
   TGocciaTestAssertions(FTestAssertions).AssertionFailed('toThrow',
-    'Expected ' + FormatForMessage(FActualValue) + ' to throw an exception');
+    'Expected ' + FormatForDisplay(FActualValue) + ' to throw an exception');
 end;
 
 function TGocciaExpectationValue.ToBeCloseTo(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -1702,11 +1697,11 @@ begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeCloseTo',
         Format('Expected %s not to be close to %s (precision: %d)',
-               [FormatForMessage(FActualValue), FormatForMessage(Expected), Precision]))
+               [FormatForDisplay(FActualValue), FormatForDisplay(Expected), Precision]))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toBeCloseTo',
         Format('Expected %s to be close to %s (precision: %d)',
-               [FormatForMessage(FActualValue), FormatForMessage(Expected), Precision]));
+               [FormatForDisplay(FActualValue), FormatForDisplay(Expected), Precision]));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
@@ -2133,10 +2128,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveReturnedWith',
-        'Expected mock not to have returned with ' + FormatForMessage(Expected))
+        'Expected mock not to have returned with ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveReturnedWith',
-        'Expected mock to have returned with ' + FormatForMessage(Expected));
+        'Expected mock to have returned with ' + FormatForDisplay(Expected));
   end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -2189,10 +2184,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveLastReturnedWith',
-        'Expected mock not to have last returned with ' + FormatForMessage(Expected))
+        'Expected mock not to have last returned with ' + FormatForDisplay(Expected))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveLastReturnedWith',
-        'Expected mock to have last returned with ' + FormatForMessage(Expected));
+        'Expected mock to have last returned with ' + FormatForDisplay(Expected));
   end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -2254,10 +2249,10 @@ begin
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveNthReturnedWith',
-        Format('Expected return %d not to be %s', [N, FormatForMessage(Expected)]))
+        Format('Expected return %d not to be %s', [N, FormatForDisplay(Expected)]))
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toHaveNthReturnedWith',
-        Format('Expected return %d to be %s', [N, FormatForMessage(Expected)]));
+        Format('Expected return %d to be %s', [N, FormatForDisplay(Expected)]));
   end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -2277,7 +2272,7 @@ begin
     if not (FActualValue is TGocciaPromiseValue) then
     begin
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('resolves',
-        'Expected a Promise but received ' + FormatForMessage(FActualValue));
+        'Expected a Promise but received ' + FormatForDisplay(FActualValue));
       Result := TGocciaExpectationValue.Create(TGocciaUndefinedLiteralValue.UndefinedValue, FTestAssertions, FIsNegated);
       Exit;
     end;
@@ -2290,7 +2285,7 @@ begin
     else if Promise.State = gpsRejected then
     begin
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('resolves',
-        'Expected Promise to resolve but it rejected with: ' + FormatForMessage(Promise.PromiseResult));
+        'Expected Promise to resolve but it rejected with: ' + FormatForDisplay(Promise.PromiseResult));
       Result := TGocciaExpectationValue.Create(TGocciaUndefinedLiteralValue.UndefinedValue, FTestAssertions, FIsNegated);
     end
     else
@@ -2315,7 +2310,7 @@ begin
     if not (FActualValue is TGocciaPromiseValue) then
     begin
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('rejects',
-        'Expected a Promise but received ' + FormatForMessage(FActualValue));
+        'Expected a Promise but received ' + FormatForDisplay(FActualValue));
       Result := TGocciaExpectationValue.Create(TGocciaUndefinedLiteralValue.UndefinedValue, FTestAssertions, FIsNegated);
       Exit;
     end;
@@ -2328,7 +2323,7 @@ begin
     else if Promise.State = gpsFulfilled then
     begin
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('rejects',
-        'Expected Promise to reject but it resolved with: ' + FormatForMessage(Promise.PromiseResult));
+        'Expected Promise to reject but it resolved with: ' + FormatForDisplay(Promise.PromiseResult));
       Result := TGocciaExpectationValue.Create(TGocciaUndefinedLiteralValue.UndefinedValue, FTestAssertions, FIsNegated);
     end
     else
@@ -2954,7 +2949,7 @@ begin
                   WaitForFetchPromise(TGocciaPromiseValue(TestResult));
                   if TGocciaPromiseValue(TestResult).State = gpsRejected then
                   begin
-                    RejectionReason := FormatForMessage(
+                    RejectionReason := FormatForDisplay(
                       TGocciaPromiseValue(TestResult).PromiseResult);
                     AssertionFailed('async test', 'Returned Promise rejected: ' +
                       RejectionReason);
@@ -3174,7 +3169,7 @@ begin
               Promise := TGocciaPromiseValue(CallbackResult);
               WaitForFetchPromise(Promise);
               if Promise.State = gpsRejected then
-                AssertionFailed('callback execution', 'Async callback rejected: ' + FormatForMessage(Promise.PromiseResult))
+                AssertionFailed('callback execution', 'Async callback rejected: ' + FormatForDisplay(Promise.PromiseResult))
               else if Promise.State = gpsPending then
                 AssertionFailed('callback execution', 'Async callback Promise still pending after microtask drain');
             end

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -299,31 +299,15 @@ uses
   Goccia.Values.ClassValue,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.Formatting,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.PromiseValue,
   Goccia.Values.SetValue,
   Goccia.Values.SymbolValue;
 
-// Render a value for an assertion failure message. Mirrors the philosophy of
-// Jest/Vitest pretty-format: objects are dumped structurally (via ToDebugString)
-// rather than passed through user-defined toString, so failure messages are
-// (a) deterministic, (b) safe on objects without a working prototype chain
-// (e.g. Object.create(null)), and (c) free of side effects from getters or
-// proxy traps. Primitives use ToStringLiteral, which never invokes user code.
-// Symbols use ToDisplayString to avoid the spec ToString TypeError on Symbol.
 function FormatForMessage(const AValue: TGocciaValue): string;
 begin
-  if not Assigned(AValue) then
-  begin
-    Result := 'undefined';
-    Exit;
-  end;
-  if AValue is TGocciaSymbolValue then
-    Result := TGocciaSymbolValue(AValue).ToDisplayString.Value
-  else if AValue is TGocciaObjectValue then
-    Result := TGocciaObjectValue(AValue).ToDebugString
-  else
-    Result := AValue.ToStringLiteral.Value;
+  Result := FormatForDisplay(AValue);
 end;
 
 function FormatThrowValueDetail(const AValue: TGocciaValue): string;

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -302,8 +302,7 @@ uses
   Goccia.Values.Formatting,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.PromiseValue,
-  Goccia.Values.SetValue,
-  Goccia.Values.SymbolValue;
+  Goccia.Values.SetValue;
 
 function FormatForMessage(const AValue: TGocciaValue): string;
 begin

--- a/source/units/Goccia.Values.Formatting.pas
+++ b/source/units/Goccia.Values.Formatting.pas
@@ -9,6 +9,7 @@ uses
 
 const
   DEFAULT_INSPECT_DEPTH = 5;
+  MAX_INSPECT_DEPTH = 64;
 
 procedure SetInspectDepth(const ADepth: Integer);
 function FormatForDisplay(const AValue: TGocciaValue): string;
@@ -30,7 +31,7 @@ var
 
 procedure SetInspectDepth(const ADepth: Integer);
 begin
-  GInspectDepth := Max(1, ADepth);
+  GInspectDepth := Min(MAX_INSPECT_DEPTH, Max(1, ADepth));
 end;
 
 function FormatRecursive(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string; forward;

--- a/source/units/Goccia.Values.Formatting.pas
+++ b/source/units/Goccia.Values.Formatting.pas
@@ -18,31 +18,44 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
 
-function DoFormat(const AValue: TGocciaValue; const ANested: Boolean): string; forward;
+const
+  MAX_FORMAT_DEPTH = 5;
 
-function FormatArray(const AArr: TGocciaArrayValue): string;
+function DoFormat(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string; forward;
+
+function FormatArray(const AArr: TGocciaArrayValue; const ADepth: Integer): string;
 var
   SB: TStringBuffer;
   I: Integer;
 begin
+  if ADepth >= MAX_FORMAT_DEPTH then
+  begin
+    Result := '[...]';
+    Exit;
+  end;
   SB := TStringBuffer.Create;
   SB.AppendChar('[');
   for I := 0 to AArr.Elements.Count - 1 do
   begin
     if I > 0 then
       SB.Append(', ');
-    SB.Append(DoFormat(AArr.Elements[I], True));
+    SB.Append(DoFormat(AArr.Elements[I], True, ADepth + 1));
   end;
   SB.AppendChar(']');
   Result := SB.ToString;
 end;
 
-function FormatObject(const AObj: TGocciaObjectValue): string;
+function FormatObject(const AObj: TGocciaObjectValue; const ADepth: Integer): string;
 var
   SB: TStringBuffer;
   Key: string;
   First: Boolean;
 begin
+  if ADepth >= MAX_FORMAT_DEPTH then
+  begin
+    Result := '{...}';
+    Exit;
+  end;
   SB := TStringBuffer.Create;
   SB.AppendChar('{');
   First := True;
@@ -53,13 +66,13 @@ begin
     First := False;
     SB.Append(Key);
     SB.Append(': ');
-    SB.Append(DoFormat(AObj.GetProperty(Key), True));
+    SB.Append(DoFormat(AObj.GetProperty(Key), True, ADepth + 1));
   end;
   SB.AppendChar('}');
   Result := SB.ToString;
 end;
 
-function DoFormat(const AValue: TGocciaValue; const ANested: Boolean): string;
+function DoFormat(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string;
 begin
   if not Assigned(AValue) then
   begin
@@ -70,9 +83,9 @@ begin
   if AValue is TGocciaSymbolValue then
     Result := TGocciaSymbolValue(AValue).ToDisplayString.Value
   else if AValue is TGocciaArrayValue then
-    Result := FormatArray(TGocciaArrayValue(AValue))
+    Result := FormatArray(TGocciaArrayValue(AValue), ADepth)
   else if AValue is TGocciaObjectValue then
-    Result := FormatObject(TGocciaObjectValue(AValue))
+    Result := FormatObject(TGocciaObjectValue(AValue), ADepth)
   else if ANested and (AValue is TGocciaStringLiteralValue) then
     Result := '''' + AValue.ToStringLiteral.Value + ''''
   else
@@ -81,7 +94,7 @@ end;
 
 function FormatForDisplay(const AValue: TGocciaValue): string;
 begin
-  Result := DoFormat(AValue, False);
+  Result := DoFormat(AValue, False, 0);
 end;
 
 end.

--- a/source/units/Goccia.Values.Formatting.pas
+++ b/source/units/Goccia.Values.Formatting.pas
@@ -45,6 +45,11 @@ begin
     Result := '[Array]';
     Exit;
   end;
+  if AArr.Elements.Count = 0 then
+  begin
+    Result := '[]';
+    Exit;
+  end;
   SB := TStringBuffer.Create;
   SB.Append('[ ');
   for I := 0 to AArr.Elements.Count - 1 do

--- a/source/units/Goccia.Values.Formatting.pas
+++ b/source/units/Goccia.Values.Formatting.pas
@@ -12,6 +12,8 @@ function FormatForDisplay(const AValue: TGocciaValue): string;
 implementation
 
 uses
+  Generics.Collections,
+
   StringBuffer,
 
   Goccia.Values.ArrayValue,
@@ -21,7 +23,7 @@ uses
 const
   MAX_FORMAT_DEPTH = 5;
 
-function DoFormat(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string; forward;
+function FormatRecursive(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string; forward;
 
 function FormatArray(const AArr: TGocciaArrayValue; const ADepth: Integer): string;
 var
@@ -39,7 +41,7 @@ begin
   begin
     if I > 0 then
       SB.Append(', ');
-    SB.Append(DoFormat(AArr.Elements[I], True, ADepth + 1));
+    SB.Append(FormatRecursive(AArr.Elements[I], True, ADepth + 1));
   end;
   SB.AppendChar(']');
   Result := SB.ToString;
@@ -48,7 +50,7 @@ end;
 function FormatObject(const AObj: TGocciaObjectValue; const ADepth: Integer): string;
 var
   SB: TStringBuffer;
-  Key: string;
+  Entry: TPair<string, TGocciaValue>;
   First: Boolean;
 begin
   if ADepth >= MAX_FORMAT_DEPTH then
@@ -59,20 +61,20 @@ begin
   SB := TStringBuffer.Create;
   SB.AppendChar('{');
   First := True;
-  for Key in AObj.GetEnumerablePropertyNames do
+  for Entry in AObj.GetEnumerablePropertyEntries do
   begin
     if not First then
       SB.Append(', ');
     First := False;
-    SB.Append(Key);
+    SB.Append(Entry.Key);
     SB.Append(': ');
-    SB.Append(DoFormat(AObj.GetProperty(Key), True, ADepth + 1));
+    SB.Append(FormatRecursive(Entry.Value, True, ADepth + 1));
   end;
   SB.AppendChar('}');
   Result := SB.ToString;
 end;
 
-function DoFormat(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string;
+function FormatRecursive(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string;
 begin
   if not Assigned(AValue) then
   begin
@@ -94,7 +96,7 @@ end;
 
 function FormatForDisplay(const AValue: TGocciaValue): string;
 begin
-  Result := DoFormat(AValue, False, 0);
+  Result := FormatRecursive(AValue, False, 0);
 end;
 
 end.

--- a/source/units/Goccia.Values.Formatting.pas
+++ b/source/units/Goccia.Values.Formatting.pas
@@ -95,6 +95,16 @@ begin
   Result := SB.ToString;
 end;
 
+function QuoteString(const AStr: string): string;
+begin
+  if Pos('''', AStr) = 0 then
+    Result := '''' + AStr + ''''
+  else if Pos('"', AStr) = 0 then
+    Result := '"' + AStr + '"'
+  else
+    Result := '`' + AStr + '`';
+end;
+
 function FormatRecursive(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string;
 begin
   if not Assigned(AValue) then
@@ -110,7 +120,7 @@ begin
   else if AValue is TGocciaObjectValue then
     Result := FormatObject(TGocciaObjectValue(AValue), ADepth)
   else if ANested and (AValue is TGocciaStringLiteralValue) then
-    Result := '''' + AValue.ToStringLiteral.Value + ''''
+    Result := QuoteString(AValue.ToStringLiteral.Value)
   else
     Result := AValue.ToStringLiteral.Value;
 end;

--- a/source/units/Goccia.Values.Formatting.pas
+++ b/source/units/Goccia.Values.Formatting.pas
@@ -7,12 +7,17 @@ interface
 uses
   Goccia.Values.Primitives;
 
+const
+  DEFAULT_INSPECT_DEPTH = 5;
+
+procedure SetInspectDepth(const ADepth: Integer);
 function FormatForDisplay(const AValue: TGocciaValue): string;
 
 implementation
 
 uses
   Generics.Collections,
+  Math,
 
   StringBuffer,
 
@@ -20,8 +25,13 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
 
-const
-  MAX_FORMAT_DEPTH = 5;
+var
+  GInspectDepth: Integer = DEFAULT_INSPECT_DEPTH;
+
+procedure SetInspectDepth(const ADepth: Integer);
+begin
+  GInspectDepth := Max(1, ADepth);
+end;
 
 function FormatRecursive(const AValue: TGocciaValue; const ANested: Boolean; const ADepth: Integer): string; forward;
 
@@ -30,20 +40,20 @@ var
   SB: TStringBuffer;
   I: Integer;
 begin
-  if ADepth >= MAX_FORMAT_DEPTH then
+  if ADepth >= GInspectDepth then
   begin
-    Result := '[...]';
+    Result := '[Array]';
     Exit;
   end;
   SB := TStringBuffer.Create;
-  SB.AppendChar('[');
+  SB.Append('[ ');
   for I := 0 to AArr.Elements.Count - 1 do
   begin
     if I > 0 then
       SB.Append(', ');
     SB.Append(FormatRecursive(AArr.Elements[I], True, ADepth + 1));
   end;
-  SB.AppendChar(']');
+  SB.Append(' ]');
   Result := SB.ToString;
 end;
 
@@ -52,25 +62,33 @@ var
   SB: TStringBuffer;
   Entry: TPair<string, TGocciaValue>;
   First: Boolean;
+  HasEntries: Boolean;
 begin
-  if ADepth >= MAX_FORMAT_DEPTH then
+  if ADepth >= GInspectDepth then
   begin
-    Result := '{...}';
+    Result := '[Object]';
     Exit;
   end;
   SB := TStringBuffer.Create;
   SB.AppendChar('{');
   First := True;
+  HasEntries := False;
   for Entry in AObj.GetEnumerablePropertyEntries do
   begin
-    if not First then
+    if First then
+      SB.AppendChar(' ')
+    else
       SB.Append(', ');
     First := False;
+    HasEntries := True;
     SB.Append(Entry.Key);
     SB.Append(': ');
     SB.Append(FormatRecursive(Entry.Value, True, ADepth + 1));
   end;
-  SB.AppendChar('}');
+  if HasEntries then
+    SB.Append(' }')
+  else
+    SB.AppendChar('}');
   Result := SB.ToString;
 end;
 

--- a/source/units/Goccia.Values.Formatting.pas
+++ b/source/units/Goccia.Values.Formatting.pas
@@ -1,0 +1,87 @@
+unit Goccia.Values.Formatting;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.Primitives;
+
+function FormatForDisplay(const AValue: TGocciaValue): string;
+
+implementation
+
+uses
+  StringBuffer,
+
+  Goccia.Values.ArrayValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.SymbolValue;
+
+function DoFormat(const AValue: TGocciaValue; const ANested: Boolean): string; forward;
+
+function FormatArray(const AArr: TGocciaArrayValue): string;
+var
+  SB: TStringBuffer;
+  I: Integer;
+begin
+  SB := TStringBuffer.Create;
+  SB.AppendChar('[');
+  for I := 0 to AArr.Elements.Count - 1 do
+  begin
+    if I > 0 then
+      SB.Append(', ');
+    SB.Append(DoFormat(AArr.Elements[I], True));
+  end;
+  SB.AppendChar(']');
+  Result := SB.ToString;
+end;
+
+function FormatObject(const AObj: TGocciaObjectValue): string;
+var
+  SB: TStringBuffer;
+  Key: string;
+  First: Boolean;
+begin
+  SB := TStringBuffer.Create;
+  SB.AppendChar('{');
+  First := True;
+  for Key in AObj.GetEnumerablePropertyNames do
+  begin
+    if not First then
+      SB.Append(', ');
+    First := False;
+    SB.Append(Key);
+    SB.Append(': ');
+    SB.Append(DoFormat(AObj.GetProperty(Key), True));
+  end;
+  SB.AppendChar('}');
+  Result := SB.ToString;
+end;
+
+function DoFormat(const AValue: TGocciaValue; const ANested: Boolean): string;
+begin
+  if not Assigned(AValue) then
+  begin
+    Result := 'undefined';
+    Exit;
+  end;
+
+  if AValue is TGocciaSymbolValue then
+    Result := TGocciaSymbolValue(AValue).ToDisplayString.Value
+  else if AValue is TGocciaArrayValue then
+    Result := FormatArray(TGocciaArrayValue(AValue))
+  else if AValue is TGocciaObjectValue then
+    Result := FormatObject(TGocciaObjectValue(AValue))
+  else if ANested and (AValue is TGocciaStringLiteralValue) then
+    Result := '''' + AValue.ToStringLiteral.Value + ''''
+  else
+    Result := AValue.ToStringLiteral.Value;
+end;
+
+function FormatForDisplay(const AValue: TGocciaValue): string;
+begin
+  Result := DoFormat(AValue, False);
+end;
+
+end.

--- a/source/units/Goccia.Values.Formatting.pas
+++ b/source/units/Goccia.Values.Formatting.pas
@@ -67,7 +67,6 @@ var
   SB: TStringBuffer;
   Entry: TPair<string, TGocciaValue>;
   First: Boolean;
-  HasEntries: Boolean;
 begin
   if ADepth >= GInspectDepth then
   begin
@@ -77,7 +76,6 @@ begin
   SB := TStringBuffer.Create;
   SB.AppendChar('{');
   First := True;
-  HasEntries := False;
   for Entry in AObj.GetEnumerablePropertyEntries do
   begin
     if First then
@@ -85,12 +83,11 @@ begin
     else
       SB.Append(', ');
     First := False;
-    HasEntries := True;
     SB.Append(Entry.Key);
     SB.Append(': ');
     SB.Append(FormatRecursive(Entry.Value, True, ADepth + 1));
   end;
-  if HasEntries then
+  if not First then
     SB.Append(' }')
   else
     SB.AppendChar('}');

--- a/source/units/Goccia.Values.ObjectValue.Test.pas
+++ b/source/units/Goccia.Values.ObjectValue.Test.pas
@@ -12,6 +12,7 @@ uses
   Goccia.Error,
   Goccia.TestSetup,
   Goccia.Values.Error,
+  Goccia.Values.Formatting,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
@@ -72,15 +73,15 @@ var
   ThrownTypeName: string;
 begin
   ObjectValue := SimpleObject;
-  DebugString := ObjectValue.ToDebugString;
+  DebugString := FormatForDisplay(ObjectValue);
 
-  Expect<Boolean>(ContainsFragment(DebugString, 'name: John')).ToBe(True);
+  Expect<Boolean>(ContainsFragment(DebugString, 'name: ''John''')).ToBe(True);
   Expect<Boolean>(ContainsFragment(DebugString, 'age: 30')).ToBe(True);
   Expect<Boolean>(ContainsFragment(DebugString, 'isStudent: true')).ToBe(True);
-  Expect<Boolean>(ContainsFragment(DebugString, 'address: 123 Main St')).ToBe(True);
-  Expect<Boolean>(ContainsFragment(DebugString, 'city: Anytown')).ToBe(True);
-  Expect<Boolean>(ContainsFragment(DebugString, 'state: CA')).ToBe(True);
-  Expect<Boolean>(ContainsFragment(DebugString, 'zip: 12345')).ToBe(True);
+  Expect<Boolean>(ContainsFragment(DebugString, 'address: ''123 Main St''')).ToBe(True);
+  Expect<Boolean>(ContainsFragment(DebugString, 'city: ''Anytown''')).ToBe(True);
+  Expect<Boolean>(ContainsFragment(DebugString, 'state: ''CA''')).ToBe(True);
+  Expect<Boolean>(ContainsFragment(DebugString, 'zip: ''12345''')).ToBe(True);
 
   // ES2026 §7.1.17 ToString on an object without Object.prototype.toString
   // (no prototype assigned in this test fixture) throws TypeError because

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -37,7 +37,6 @@ type
     constructor Create(const APrototype: TGocciaObjectValue = nil;
       const APropertyCapacity: Integer = 0);
     destructor Destroy; override;
-    function ToDebugString: string;
     function TypeName: string; override;
     function TypeOf: string; override;
     function ToStringTag: string; virtual;
@@ -110,8 +109,6 @@ implementation
 
 uses
   SysUtils,
-
-  StringBuffer,
 
   Goccia.Arithmetic,
   Goccia.Constants.ConstructorNames,
@@ -405,59 +402,6 @@ begin
     SymPair.Key.MarkReferences;
     SymPair.Value.MarkValues;
   end;
-end;
-
-function TGocciaObjectValue.ToDebugString: string;
-var
-  SB: TStringBuffer;
-  Pair: TGocciaPropertyMap.TKeyValuePair;
-  First: Boolean;
-  Value: TGocciaValue;
-begin
-  SB := TStringBuffer.Create;
-  SB.AppendChar('{');
-  First := True;
-
-  for Pair in FProperties do
-  begin
-    if not First then
-      SB.Append(', ');
-
-    if Pair.Value is TGocciaPropertyDescriptorData then
-      Value := TGocciaPropertyDescriptorData(Pair.Value).Value
-    else
-      Value := nil;
-
-    if Assigned(Value) then
-    begin
-      SB.Append(Pair.Key);
-      SB.Append(': ');
-      if Value is TGocciaObjectValue then
-        SB.Append(TGocciaObjectValue(Value).ToDebugString)
-      else if Value is TGocciaSymbolValue then
-        SB.Append(TGocciaSymbolValue(Value).ToDisplayString.Value)
-      else
-        SB.Append(Value.ToStringLiteral.Value);
-    end
-    else
-    begin
-      SB.Append(Pair.Key);
-      SB.Append(': [accessor]');
-    end;
-
-    First := False;
-  end;
-
-  if Assigned(FPrototype) then
-  begin
-    if not First then
-      SB.Append(', ');
-    SB.Append('[[Prototype]]: ');
-    SB.Append(FPrototype.ToDebugString);
-  end;
-
-  SB.AppendChar('}');
-  Result := SB.ToString;
 end;
 
 function TGocciaObjectValue.TypeName: string;

--- a/tests/built-ins/console/log.js
+++ b/tests/built-ins/console/log.js
@@ -24,3 +24,16 @@ test("console.log does not invoke user toString on objects", () => {
 test("console.log handles Symbol values", () => {
   expect(console.log(Symbol("test"))).toBeUndefined();
 });
+
+test("console.log handles circular references without crashing", () => {
+  const obj = { a: 1 };
+  obj.self = obj;
+  expect(console.log(obj)).toBeUndefined();
+});
+
+test("console.log handles deeply nested objects", () => {
+  const obj = {
+    a: { b: { c: { d: { e: { f: { g: { h: "deep" } } } } } } },
+  };
+  expect(console.log(obj)).toBeUndefined();
+});

--- a/tests/built-ins/console/log.js
+++ b/tests/built-ins/console/log.js
@@ -2,3 +2,25 @@ test("console.log exists and returns undefined", () => {
   expect(typeof console.log).toBe("function");
   expect(console.log("test")).toBeUndefined();
 });
+
+test("console.log handles prototype-less objects", () => {
+  expect(console.log(Object.create(null))).toBeUndefined();
+});
+
+test("console.log handles prototype-less objects with properties", () => {
+  const obj = Object.create(null);
+  obj.a = 1;
+  obj.b = "hello";
+  expect(console.log(obj)).toBeUndefined();
+});
+
+test("console.log does not invoke user toString on objects", () => {
+  let called = false;
+  const obj = { toString() { called = true; return "custom"; } };
+  console.log(obj);
+  expect(called).toBe(false);
+});
+
+test("console.log handles Symbol values", () => {
+  expect(console.log(Symbol("test"))).toBeUndefined();
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Extract shared `Goccia.Values.Formatting` unit with `FormatForDisplay` that renders values structurally (like V8/Node `util.inspect`) without invoking user `toString()`/`valueOf()`. This fixes `console.log(Object.create(null))` throwing `TypeError` instead of printing `{}`.
- Console (`FormatArgs`, `ConsoleAssert`, `ConsoleDir`, `ConsoleTable`) and TestingLibrary (`FormatForMessage`) both delegate to the single shared formatter, eliminating duplicated formatting logic.
- Remove `TGocciaObjectValue.ToDebugString` — its only consumer was `FormatForMessage`, now superseded by `FormatForDisplay`.
- Output matches V8/Node/Deno style: spaced braces (`{ a: 1 }` not `{a: 1}`), `[Object]`/`[Array]` truncation markers at depth limit, empty containers stay compact (`{}`, `[]`).
- Add `--inspect-depth=N` CLI flag and `"inspect-depth"` config key (default: 5) to control maximum object inspection depth.
- Depth guard prevents SIGSEGV on circular or deeply nested objects.

Closes #536

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
