### PR TITLE
Fix Function() constructor this-binding and strict-mode delete gaps

### DIFF
--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -648,6 +648,8 @@ begin
 
     ACtx.Scope.FreeRegister;
   end
+  else if AExpr.Operand is TGocciaIdentifierExpression then
+    raise Exception.Create('Delete of an unqualified identifier in strict mode')
   else
     EmitInstruction(ACtx, EncodeABC(OP_LOAD_TRUE, ADest, 0, 0));
 end;

--- a/source/units/Goccia.Engine.Backend.pas
+++ b/source/units/Goccia.Engine.Backend.pas
@@ -89,6 +89,7 @@ procedure TGocciaBytecodeExecutor.Initialize(const AGlobalScope: TGocciaScope;
 begin
   inherited;
   FVM.GlobalScope := AGlobalScope;
+  FVM.GlobalThisValue := AGlobalScope.ThisValue;
   FVM.LoadModule := AModuleLoader.LoadModule;
   AModuleLoader.EvaluateModuleBody := EvaluateModuleBody;
 end;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1675,6 +1675,8 @@ begin
         // ES2026 §20.2.1.1.1: the function's name is 'anonymous'
         if Result is TGocciaFunctionValue then
           TGocciaFunctionValue(Result).Name := 'anonymous';
+        // ES2026 §15.2.2.4: Function-constructor bodies are non-strict
+        Result.SloppyThis := True;
       finally
         ProgramNode.Free;
       end;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1568,7 +1568,7 @@ function TGocciaEngine.CompileDynamicFunction(
   const AParamsSources: array of string;
   const ABodySource: string): TGocciaFunctionBase;
 var
-  ParamStr, Source: string;
+  ParamStr, Source, TrimmedBody: string;
   I: Integer;
   Lexer: TGocciaLexer;
   Tokens: TObjectList<TGocciaToken>;
@@ -1676,7 +1676,11 @@ begin
         if Result is TGocciaFunctionValue then
           TGocciaFunctionValue(Result).Name := 'anonymous';
         // ES2026 §15.2.2.4: Function-constructor bodies are non-strict
-        Result.StrictThis := False;
+        // unless the body starts with a Use Strict Directive (§11.2.2).
+        TrimmedBody := TrimLeft(ABodySource);
+        if (Pos('"use strict"', TrimmedBody) <> 1) and
+           (Pos('''use strict''', TrimmedBody) <> 1) then
+          Result.StrictThis := False;
       finally
         ProgramNode.Free;
       end;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1676,7 +1676,7 @@ begin
         if Result is TGocciaFunctionValue then
           TGocciaFunctionValue(Result).Name := 'anonymous';
         // ES2026 §15.2.2.4: Function-constructor bodies are non-strict
-        Result.SloppyThis := True;
+        Result.StrictThis := False;
       finally
         ProgramNode.Free;
       end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -8824,31 +8824,38 @@ begin
               begin
                 if GlobalName = 'call' then
                 begin
+                  if B = 0 then
+                    CallThisRegister := RegisterUndefined
+                  else
+                    CallThisRegister := FRegisters[A + 1];
+                  if BytecodeFunction.FSloppyThis and Assigned(FGlobalThisValue) and
+                     (CallThisRegister.Kind in [grkUndefined, grkNull]) then
+                    CallThisRegister := VMValueToRegisterFast(FGlobalThisValue);
                   PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
                   case B of
                     0:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        RegisterUndefined, TGocciaRegisterArray(nil), 0,
+                        CallThisRegister, TGocciaRegisterArray(nil), 0,
                         RegisterUndefined, RegisterUndefined, RegisterUndefined,
                         True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     1:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], TGocciaRegisterArray(nil), 0,
+                        CallThisRegister, TGocciaRegisterArray(nil), 0,
                         RegisterUndefined, RegisterUndefined, RegisterUndefined,
                         True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     2:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], TGocciaRegisterArray(nil), 1,
+                        CallThisRegister, TGocciaRegisterArray(nil), 1,
                         FRegisters[A + 2], RegisterUndefined, RegisterUndefined,
                         True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     3:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], TGocciaRegisterArray(nil), 2,
+                        CallThisRegister, TGocciaRegisterArray(nil), 2,
                         FRegisters[A + 2], FRegisters[A + 3], RegisterUndefined,
                         True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     4:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], TGocciaRegisterArray(nil), 3,
+                        CallThisRegister, TGocciaRegisterArray(nil), 3,
                         FRegisters[A + 2], FRegisters[A + 3], FRegisters[A + 4],
                         True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                   else
@@ -8857,7 +8864,7 @@ begin
                       for I := 1 to B - 1 do
                         RegisterArgs[I - 1] := FRegisters[A + 1 + I];
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], RegisterArgs, Length(RegisterArgs),
+                        CallThisRegister, RegisterArgs, Length(RegisterArgs),
                         RegisterUndefined, RegisterUndefined, RegisterUndefined,
                         False, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     end;
@@ -8869,29 +8876,33 @@ begin
                         (FRegisters[A + 2].ObjectValue is TGocciaArrayValue) then
                 begin
                   ArgsArray := TGocciaArrayValue(FRegisters[A + 2].ObjectValue);
+                  CallThisRegister := FRegisters[A + 1];
+                  if BytecodeFunction.FSloppyThis and Assigned(FGlobalThisValue) and
+                     (CallThisRegister.Kind in [grkUndefined, grkNull]) then
+                    CallThisRegister := VMValueToRegisterFast(FGlobalThisValue);
                   PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
                   case ArgsArray.Elements.Count of
                     0:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], TGocciaRegisterArray(nil), 0,
+                        CallThisRegister, TGocciaRegisterArray(nil), 0,
                         RegisterUndefined, RegisterUndefined, RegisterUndefined,
                         True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     1:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], TGocciaRegisterArray(nil), 1,
+                        CallThisRegister, TGocciaRegisterArray(nil), 1,
                         VMValueToRegisterFast(ArgsArray.Elements[0]),
                         RegisterUndefined, RegisterUndefined,
                         True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     2:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], TGocciaRegisterArray(nil), 2,
+                        CallThisRegister, TGocciaRegisterArray(nil), 2,
                         VMValueToRegisterFast(ArgsArray.Elements[0]),
                         VMValueToRegisterFast(ArgsArray.Elements[1]),
                         RegisterUndefined,
                         True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     3:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], TGocciaRegisterArray(nil), 3,
+                        CallThisRegister, TGocciaRegisterArray(nil), 3,
                         VMValueToRegisterFast(ArgsArray.Elements[0]),
                         VMValueToRegisterFast(ArgsArray.Elements[1]),
                         VMValueToRegisterFast(ArgsArray.Elements[2]),
@@ -8902,7 +8913,7 @@ begin
                       for I := 0 to High(RegisterArgs) do
                         RegisterArgs[I] := VMValueToRegisterFast(ArgsArray.Elements[I]);
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        FRegisters[A + 1], RegisterArgs, Length(RegisterArgs),
+                        CallThisRegister, RegisterArgs, Length(RegisterArgs),
                         RegisterUndefined, RegisterUndefined, RegisterUndefined,
                         False, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2542,7 +2542,7 @@ var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
 begin
-  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
       (AThisValue is TGocciaUndefinedLiteralValue) or
       (AThisValue is TGocciaNullLiteralValue)) then
@@ -2603,7 +2603,7 @@ var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
 begin
-  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
       (AThisValue is TGocciaUndefinedLiteralValue) or
       (AThisValue is TGocciaNullLiteralValue)) then
@@ -2650,7 +2650,7 @@ var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
 begin
-  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
       (AThisValue is TGocciaUndefinedLiteralValue) or
       (AThisValue is TGocciaNullLiteralValue)) then
@@ -2699,7 +2699,7 @@ var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
 begin
-  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
       (AThisValue is TGocciaUndefinedLiteralValue) or
       (AThisValue is TGocciaNullLiteralValue)) then
@@ -2752,7 +2752,7 @@ var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
 begin
-  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
       (AThisValue is TGocciaUndefinedLiteralValue) or
       (AThisValue is TGocciaNullLiteralValue)) then
@@ -8722,7 +8722,7 @@ begin
              (not BytecodeFunction.FClosure.Template.IsAsync) and
              (not BytecodeFunction.FClosure.Template.IsGenerator) then
           begin
-            if BytecodeFunction.FSloppyThis and Assigned(FGlobalThisValue) then
+            if (not BytecodeFunction.FStrictThis) and Assigned(FGlobalThisValue) then
               CallThisRegister := VMValueToRegisterFast(FGlobalThisValue)
             else
               CallThisRegister := RegisterUndefined;
@@ -8828,7 +8828,7 @@ begin
                     CallThisRegister := RegisterUndefined
                   else
                     CallThisRegister := FRegisters[A + 1];
-                  if BytecodeFunction.FSloppyThis and Assigned(FGlobalThisValue) and
+                  if (not BytecodeFunction.FStrictThis) and Assigned(FGlobalThisValue) and
                      (CallThisRegister.Kind in [grkUndefined, grkNull]) then
                     CallThisRegister := VMValueToRegisterFast(FGlobalThisValue);
                   PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
@@ -8877,7 +8877,7 @@ begin
                 begin
                   ArgsArray := TGocciaArrayValue(FRegisters[A + 2].ObjectValue);
                   CallThisRegister := FRegisters[A + 1];
-                  if BytecodeFunction.FSloppyThis and Assigned(FGlobalThisValue) and
+                  if (not BytecodeFunction.FStrictThis) and Assigned(FGlobalThisValue) and
                      (CallThisRegister.Kind in [grkUndefined, grkNull]) then
                     CallThisRegister := VMValueToRegisterFast(FGlobalThisValue);
                   PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -79,6 +79,7 @@ type
     FLocalCellCount: Integer;
     FArgCount: Integer;
     FGlobalScope: TGocciaScope;
+    FGlobalThisValue: TGocciaValue;
     FLoadModule: TLoadModuleCallback;
     FCurrentClosure: TGocciaBytecodeClosure;
     FHandlerStack: TGocciaBytecodeHandlerStack;
@@ -244,6 +245,7 @@ type
     function ExecuteFunction(const ATemplate: TGocciaFunctionTemplate): TGocciaValue;
     function ExecuteModule(const AModule: TGocciaBytecodeModule): TGocciaValue;
     property GlobalScope: TGocciaScope read FGlobalScope write FGlobalScope;
+    property GlobalThisValue: TGocciaValue read FGlobalThisValue write FGlobalThisValue;
     property LoadModule: TLoadModuleCallback read FLoadModule write FLoadModule;
     property CoverageEnabled: Boolean read FCoverageEnabled write FCoverageEnabled;
     property ProfilingOpcodes: Boolean read FProfilingOpcodes write FProfilingOpcodes;
@@ -957,6 +959,8 @@ begin
 
   if Assigned(FVM.FGlobalScope) then
     FVM.FGlobalScope.MarkReferences;
+  if Assigned(FVM.FGlobalThisValue) then
+    FVM.FGlobalThisValue.MarkReferences;
   MarkClosureReferences(FVM.FCurrentClosure);
   MarkRegisterReferences(FVM.FLastClosureThisValue);
   if Assigned(FVM.FPrivateInitializerReceiver) then
@@ -2536,14 +2540,23 @@ function TGocciaBytecodeFunctionValue.Call(
   const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Promise: TGocciaPromiseValue;
+  EffectiveThis: TGocciaValue;
 begin
+  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+     (not Assigned(AThisValue) or
+      (AThisValue is TGocciaUndefinedLiteralValue) or
+      (AThisValue is TGocciaNullLiteralValue)) then
+    EffectiveThis := FVM.FGlobalThisValue
+  else
+    EffectiveThis := AThisValue;
+
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
     if FClosure.Template.IsAsync then
       Exit(TGocciaBytecodeAsyncGeneratorObjectValue.Create(FVM, FClosure,
-        AThisValue, AArguments));
+        EffectiveThis, AArguments));
     Exit(TGocciaBytecodeGeneratorObjectValue.Create(FVM, FClosure,
-      AThisValue, AArguments));
+      EffectiveThis, AArguments));
   end;
 
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
@@ -2551,7 +2564,7 @@ begin
     Promise := TGocciaPromiseValue.Create;
     try
       try
-        Promise.Resolve(FVM.ExecuteClosure(FClosure, AThisValue, AArguments));
+        Promise.Resolve(FVM.ExecuteClosure(FClosure, EffectiveThis, AArguments));
       except
         on E: EGocciaBytecodeThrow do
           Promise.Reject(E.ThrownValue);
@@ -2565,7 +2578,7 @@ begin
     Exit(Promise);
   end;
 
-  Result := FVM.ExecuteClosure(FClosure, AThisValue, AArguments);
+  Result := FVM.ExecuteClosure(FClosure, EffectiveThis, AArguments);
 end;
 
 function TGocciaBytecodeFunctionValue.CallPreparedArgs(
@@ -2588,14 +2601,23 @@ function TGocciaBytecodeFunctionValue.CallNoArgs(
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   Promise: TGocciaPromiseValue;
+  EffectiveThis: TGocciaValue;
 begin
+  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+     (not Assigned(AThisValue) or
+      (AThisValue is TGocciaUndefinedLiteralValue) or
+      (AThisValue is TGocciaNullLiteralValue)) then
+    EffectiveThis := FVM.FGlobalThisValue
+  else
+    EffectiveThis := AThisValue;
+
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
     if FClosure.Template.IsAsync then
       Exit(TGocciaBytecodeAsyncGeneratorObjectValue.CreateRegisters(FVM, FClosure,
-        VMValueToRegisterFast(AThisValue), TGocciaRegisterArray(nil)));
+        VMValueToRegisterFast(EffectiveThis), TGocciaRegisterArray(nil)));
     Exit(TGocciaBytecodeGeneratorObjectValue.CreateRegisters(FVM, FClosure,
-      VMValueToRegisterFast(AThisValue), TGocciaRegisterArray(nil)));
+      VMValueToRegisterFast(EffectiveThis), TGocciaRegisterArray(nil)));
   end;
 
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
@@ -2604,7 +2626,7 @@ begin
     try
       try
         Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters0(FClosure,
-          VMValueToRegisterFast(AThisValue))));
+          VMValueToRegisterFast(EffectiveThis))));
       except
         on E: EGocciaBytecodeThrow do
           Promise.Reject(E.ThrownValue);
@@ -2619,22 +2641,31 @@ begin
   end;
 
   Result := RegisterToValue(FVM.ExecuteClosureRegisters0(FClosure,
-    VMValueToRegisterFast(AThisValue)));
+    VMValueToRegisterFast(EffectiveThis)));
 end;
 
 function TGocciaBytecodeFunctionValue.CallOneArg(const AArg0,
   AThisValue: TGocciaValue): TGocciaValue;
 var
   Promise: TGocciaPromiseValue;
+  EffectiveThis: TGocciaValue;
 begin
+  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+     (not Assigned(AThisValue) or
+      (AThisValue is TGocciaUndefinedLiteralValue) or
+      (AThisValue is TGocciaNullLiteralValue)) then
+    EffectiveThis := FVM.FGlobalThisValue
+  else
+    EffectiveThis := AThisValue;
+
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
     if FClosure.Template.IsAsync then
       Exit(TGocciaBytecodeAsyncGeneratorObjectValue.CreateRegisters(FVM, FClosure,
-        VMValueToRegisterFast(AThisValue),
+        VMValueToRegisterFast(EffectiveThis),
         TGocciaRegisterArray.Create(VMValueToRegisterFast(AArg0))));
     Exit(TGocciaBytecodeGeneratorObjectValue.CreateRegisters(FVM, FClosure,
-      VMValueToRegisterFast(AThisValue),
+      VMValueToRegisterFast(EffectiveThis),
       TGocciaRegisterArray.Create(VMValueToRegisterFast(AArg0))));
   end;
 
@@ -2644,7 +2675,7 @@ begin
     try
       try
         Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters1(FClosure,
-          VMValueToRegisterFast(AThisValue), VMValueToRegisterFast(AArg0))));
+          VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0))));
       except
         on E: EGocciaBytecodeThrow do
           Promise.Reject(E.ThrownValue);
@@ -2659,23 +2690,32 @@ begin
   end;
 
   Result := RegisterToValue(FVM.ExecuteClosureRegisters1(FClosure,
-    VMValueToRegisterFast(AThisValue), VMValueToRegisterFast(AArg0)));
+    VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0)));
 end;
 
 function TGocciaBytecodeFunctionValue.CallTwoArgs(const AArg0, AArg1,
   AThisValue: TGocciaValue): TGocciaValue;
 var
   Promise: TGocciaPromiseValue;
+  EffectiveThis: TGocciaValue;
 begin
+  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+     (not Assigned(AThisValue) or
+      (AThisValue is TGocciaUndefinedLiteralValue) or
+      (AThisValue is TGocciaNullLiteralValue)) then
+    EffectiveThis := FVM.FGlobalThisValue
+  else
+    EffectiveThis := AThisValue;
+
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
     if FClosure.Template.IsAsync then
       Exit(TGocciaBytecodeAsyncGeneratorObjectValue.CreateRegisters(FVM, FClosure,
-        VMValueToRegisterFast(AThisValue),
+        VMValueToRegisterFast(EffectiveThis),
         TGocciaRegisterArray.Create(VMValueToRegisterFast(AArg0),
           VMValueToRegisterFast(AArg1))));
     Exit(TGocciaBytecodeGeneratorObjectValue.CreateRegisters(FVM, FClosure,
-      VMValueToRegisterFast(AThisValue),
+      VMValueToRegisterFast(EffectiveThis),
       TGocciaRegisterArray.Create(VMValueToRegisterFast(AArg0),
         VMValueToRegisterFast(AArg1))));
   end;
@@ -2686,7 +2726,7 @@ begin
     try
       try
         Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters2(FClosure,
-          VMValueToRegisterFast(AThisValue), VMValueToRegisterFast(AArg0),
+          VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0),
           VMValueToRegisterFast(AArg1))));
       except
         on E: EGocciaBytecodeThrow do
@@ -2702,7 +2742,7 @@ begin
   end;
 
   Result := RegisterToValue(FVM.ExecuteClosureRegisters2(FClosure,
-    VMValueToRegisterFast(AThisValue), VMValueToRegisterFast(AArg0),
+    VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0),
     VMValueToRegisterFast(AArg1)));
 end;
 
@@ -2710,16 +2750,25 @@ function TGocciaBytecodeFunctionValue.CallThreeArgs(const AArg0, AArg1, AArg2,
   AThisValue: TGocciaValue): TGocciaValue;
 var
   Promise: TGocciaPromiseValue;
+  EffectiveThis: TGocciaValue;
 begin
+  if FSloppyThis and Assigned(FVM.FGlobalThisValue) and
+     (not Assigned(AThisValue) or
+      (AThisValue is TGocciaUndefinedLiteralValue) or
+      (AThisValue is TGocciaNullLiteralValue)) then
+    EffectiveThis := FVM.FGlobalThisValue
+  else
+    EffectiveThis := AThisValue;
+
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
     if FClosure.Template.IsAsync then
       Exit(TGocciaBytecodeAsyncGeneratorObjectValue.CreateRegisters(FVM, FClosure,
-        VMValueToRegisterFast(AThisValue),
+        VMValueToRegisterFast(EffectiveThis),
         TGocciaRegisterArray.Create(VMValueToRegisterFast(AArg0),
           VMValueToRegisterFast(AArg1), VMValueToRegisterFast(AArg2))));
     Exit(TGocciaBytecodeGeneratorObjectValue.CreateRegisters(FVM, FClosure,
-      VMValueToRegisterFast(AThisValue),
+      VMValueToRegisterFast(EffectiveThis),
       TGocciaRegisterArray.Create(VMValueToRegisterFast(AArg0),
         VMValueToRegisterFast(AArg1), VMValueToRegisterFast(AArg2))));
   end;
@@ -2730,7 +2779,7 @@ begin
     try
       try
         Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters3(FClosure,
-          VMValueToRegisterFast(AThisValue), VMValueToRegisterFast(AArg0),
+          VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0),
           VMValueToRegisterFast(AArg1), VMValueToRegisterFast(AArg2))));
       except
         on E: EGocciaBytecodeThrow do
@@ -2746,7 +2795,7 @@ begin
   end;
 
   Result := RegisterToValue(FVM.ExecuteClosureRegisters3(FClosure,
-    VMValueToRegisterFast(AThisValue), VMValueToRegisterFast(AArg0),
+    VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0),
     VMValueToRegisterFast(AArg1), VMValueToRegisterFast(AArg2)));
 end;
 
@@ -6912,6 +6961,7 @@ var
   MatchHintObject: TGocciaObjectValue;
   BuiltinConstructorMatch: Boolean;
   RegisterArgs: TGocciaRegisterArray;
+  CallThisRegister: TGocciaRegister;
   BytecodeFunction: TGocciaBytecodeFunctionValue;
   BoundFunction: TGocciaBoundFunctionValue;
   JumpOffset: Integer;
@@ -8570,13 +8620,17 @@ begin
               TGocciaStringLiteralValue(PropKeyValue).Value) then
               FRegisters[A] := RegisterBoolean(True)
             else
-              FRegisters[A] := RegisterBoolean(False);
+              ThrowTypeError(Format(SErrorCannotDeletePropertyOf,
+                [TGocciaStringLiteralValue(PropKeyValue).Value, '[object Object]']),
+                SSuggestCannotDeleteNonConfigurable);
           end
           else if TGocciaObjectValue(FRegisters[B].ObjectValue).DeleteProperty(
             KeyToPropertyNameRegister(FRegisters[C])) then
             FRegisters[A] := RegisterBoolean(True)
           else
-            FRegisters[A] := RegisterBoolean(False);
+            ThrowTypeError(Format(SErrorCannotDeletePropertyOf,
+              [KeyToPropertyNameRegister(FRegisters[C]), '[object Object]']),
+              SSuggestCannotDeleteNonConfigurable);
         end
         else
           FRegisters[A] := RegisterBoolean(True);
@@ -8668,6 +8722,10 @@ begin
              (not BytecodeFunction.FClosure.Template.IsAsync) and
              (not BytecodeFunction.FClosure.Template.IsGenerator) then
           begin
+            if BytecodeFunction.FSloppyThis and Assigned(FGlobalThisValue) then
+              CallThisRegister := VMValueToRegisterFast(FGlobalThisValue)
+            else
+              CallThisRegister := RegisterUndefined;
             if (C and 1) = 0 then
             begin
               SetLength(RegisterArgs, B);
@@ -8675,7 +8733,7 @@ begin
                 RegisterArgs[I] := FRegisters[A + 1 + I];
               PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
               SetupNewFrame(BytecodeFunction.FClosure,
-                RegisterUndefined, RegisterArgs, B,
+                CallThisRegister, RegisterArgs, B,
                 RegisterUndefined, RegisterUndefined, RegisterUndefined, False,
                 Frame, Template, PrevCovLine, ProfileEntryTimestamp);
               Continue;
@@ -8690,7 +8748,7 @@ begin
                   TGocciaArrayValue(FRegisters[B].ObjectValue).Elements[I]);
               PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
               SetupNewFrame(BytecodeFunction.FClosure,
-                RegisterUndefined, RegisterArgs, Length(RegisterArgs),
+                CallThisRegister, RegisterArgs, Length(RegisterArgs),
                 RegisterUndefined, RegisterUndefined, RegisterUndefined, False,
                 Frame, Template, PrevCovLine, ProfileEntryTimestamp);
               Continue;

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -29,7 +29,7 @@ type
   // Base class for all callable functions
   TGocciaFunctionBase = class(TGocciaObjectValue)
   protected
-    FSloppyThis: Boolean;
+    FStrictThis: Boolean;
     // Subclasses should override these to provide name/length
     function GetFunctionLength: Integer; virtual;
     function GetFunctionName: string; virtual;
@@ -64,9 +64,10 @@ type
     function TypeName: string; override;
     function TypeOf: string; override;
 
-    // ES2026 §15.2.2.4: Function-constructor-created functions are non-strict
-    // for this-binding (OrdinaryCallBindThis coerces undefined/null to globalThis).
-    property SloppyThis: Boolean read FSloppyThis write FSloppyThis;
+    // ES2026 §10.2.1.1 OrdinaryCallBindThis: when true, undefined/null this
+    // stays as-is; when false, coerced to globalThis.  Defaults to true
+    // (Goccia is always strict); only Function constructor (§15.2.2.4) clears it.
+    property StrictThis: Boolean read FStrictThis write FStrictThis;
   end;
 
   // Helper class for bound functions
@@ -286,6 +287,7 @@ var
   Shared: TGocciaFunctionSharedPrototype;
 begin
   inherited Create;
+  FStrictThis := True;
 
   Shared := GetSharedFunctionPrototype;
   if not Assigned(Shared) and Assigned(CurrentRealm) then

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -29,6 +29,7 @@ type
   // Base class for all callable functions
   TGocciaFunctionBase = class(TGocciaObjectValue)
   protected
+    FSloppyThis: Boolean;
     // Subclasses should override these to provide name/length
     function GetFunctionLength: Integer; virtual;
     function GetFunctionName: string; virtual;
@@ -63,6 +64,9 @@ type
     function TypeName: string; override;
     function TypeOf: string; override;
 
+    // ES2026 §15.2.2.4: Function-constructor-created functions are non-strict
+    // for this-binding (OrdinaryCallBindThis coerces undefined/null to globalThis).
+    property SloppyThis: Boolean read FSloppyThis write FSloppyThis;
   end;
 
   // Helper class for bound functions

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -136,9 +136,21 @@ begin
 end;
 
 procedure TGocciaFunctionValue.BindThis(const ACallScope: TGocciaScope; const AThisValue: TGocciaValue);
+var
+  Root: TGocciaScope;
 begin
-  // Non-arrow function: use call-site this (shorthand methods, class methods, getters/setters)
-  ACallScope.ThisValue := AThisValue;
+  if FSloppyThis and
+     (not Assigned(AThisValue) or
+      (AThisValue is TGocciaUndefinedLiteralValue) or
+      (AThisValue is TGocciaNullLiteralValue)) then
+  begin
+    Root := FClosure;
+    while Assigned(Root.Parent) do
+      Root := Root.Parent;
+    ACallScope.ThisValue := Root.ThisValue;
+  end
+  else
+    ACallScope.ThisValue := AThisValue;
 end;
 
 function TGocciaFunctionValue.CreateCallScope: TGocciaScope;

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -139,7 +139,7 @@ procedure TGocciaFunctionValue.BindThis(const ACallScope: TGocciaScope; const AT
 var
   Root: TGocciaScope;
 begin
-  if FSloppyThis and
+  if (not FStrictThis) and
      (not Assigned(AThisValue) or
       (AThisValue is TGocciaUndefinedLiteralValue) or
       (AThisValue is TGocciaNullLiteralValue)) then

--- a/tests/built-ins/Function/constructor/this-binding.js
+++ b/tests/built-ins/Function/constructor/this-binding.js
@@ -58,4 +58,30 @@ describe("Function constructor this-binding", () => {
     const f = Function("return this");
     expect(f.apply(null)).toBe(globalThis);
   });
+
+  test("body with 'use strict' directive keeps this undefined", () => {
+    const f = Function('"use strict"; return typeof this;');
+    expect(f()).toBe("undefined");
+  });
+
+  test("new Function with 'use strict' directive keeps this undefined", () => {
+    const f = new Function('"use strict"; return typeof this;');
+    expect(f()).toBe("undefined");
+  });
+
+  test("body with single-quoted 'use strict' keeps this undefined", () => {
+    const f = Function("'use strict'; return typeof this;");
+    expect(f()).toBe("undefined");
+  });
+
+  test("'use strict' body with leading whitespace keeps this undefined", () => {
+    const f = Function('  "use strict"; return typeof this;');
+    expect(f()).toBe("undefined");
+  });
+
+  test("'use strict' body still coerces when called with explicit receiver", () => {
+    const obj = { x: 1 };
+    const f = Function('"use strict"; return this.x;');
+    expect(f.call(obj)).toBe(1);
+  });
 });

--- a/tests/built-ins/Function/constructor/this-binding.js
+++ b/tests/built-ins/Function/constructor/this-binding.js
@@ -1,0 +1,51 @@
+/*---
+description: Function constructor creates non-strict functions for this-binding (ES2026 15.2.2.4)
+features: [Function, unsafe-function-constructor]
+---*/
+
+describe("Function constructor this-binding", () => {
+  test("Function('return this')() returns globalThis", () => {
+    const f = Function("return this");
+    expect(f()).toBe(globalThis);
+  });
+
+  test("new Function('return this')() returns globalThis", () => {
+    const f = new Function("return this");
+    expect(f()).toBe(globalThis);
+  });
+
+  test("Function constructor this is globalThis even in module-shaped code", () => {
+    const getThis = Function("return this");
+    const result = getThis();
+    expect(result).toBe(globalThis);
+    expect(result).not.toBe(undefined);
+  });
+
+  test("Function.call(undefined) coerces to globalThis", () => {
+    const f = Function("return this");
+    expect(f.call(undefined)).toBe(globalThis);
+  });
+
+  test("Function.call(null) coerces to globalThis", () => {
+    const f = Function("return this");
+    expect(f.call(null)).toBe(globalThis);
+  });
+
+  test("Function.apply(undefined) coerces to globalThis", () => {
+    const f = Function("return this");
+    expect(f.apply(undefined)).toBe(globalThis);
+  });
+
+  test("Function.call with explicit receiver preserves it", () => {
+    const obj = { x: 42 };
+    const f = Function("return this.x");
+    expect(f.call(obj)).toBe(42);
+  });
+
+  test("bound Function constructor preserves bound this", () => {
+    const obj = { value: 99 };
+    const f = Function("return this.value");
+    const bound = f.bind(obj);
+    expect(bound()).toBe(99);
+  });
+});

--- a/tests/built-ins/Function/constructor/this-binding.js
+++ b/tests/built-ins/Function/constructor/this-binding.js
@@ -48,4 +48,14 @@ describe("Function constructor this-binding", () => {
     const bound = f.bind(obj);
     expect(bound()).toBe(99);
   });
+
+  test("Function.call() with no args coerces to globalThis", () => {
+    const f = Function("return this");
+    expect(f.call()).toBe(globalThis);
+  });
+
+  test("Function.apply(null) coerces to globalThis", () => {
+    const f = Function("return this");
+    expect(f.apply(null)).toBe(globalThis);
+  });
 });

--- a/tests/language/expressions/delete/delete-operator.js
+++ b/tests/language/expressions/delete/delete-operator.js
@@ -111,3 +111,23 @@ test("delete null?.[computed] returns true without evaluating key", () => {
   expect(delete null?.[key]).toBe(true);
   expect(called).toBe(false);
 });
+
+test("delete non-configurable property with computed key throws TypeError", () => {
+  const obj = Object.freeze({ x: 1 });
+  const key = "x";
+  expect(() => { delete obj[key]; }).toThrow(TypeError);
+});
+
+test("delete non-configurable property with dynamic key throws TypeError", () => {
+  const obj = {};
+  Object.defineProperty(obj, "fixed", { value: 1, configurable: false });
+  const key = "fixed";
+  expect(() => { delete obj[key]; }).toThrow(TypeError);
+});
+
+test("delete configurable property with computed key succeeds", () => {
+  const obj = { removable: 42 };
+  const key = "removable";
+  expect(delete obj[key]).toBe(true);
+  expect(obj.removable).toBeUndefined();
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- **Function() constructor this-binding** (ES2026 §15.2.2.4): `Function('return this')()` now correctly returns `globalThis` instead of `undefined`. Per spec, Function-constructor-created functions are non-strict for this-binding even though Goccia enforces strict-mode semantics everywhere else. Adds a `SloppyThis` flag to `TGocciaFunctionBase`, set only by `CompileDynamicFunction`. Coercion covers both interpreter (`BindThis`) and all bytecode VM call paths (`Call` variants + OP_CALL fast path). This unblocks the test262 `fnGlobalObject.js` harness.
- **OP_DEL_INDEX strict-mode compliance**: `delete obj[dynamicKey]` on a non-configurable string property now throws `TypeError` instead of silently returning `false`, matching `OP_DELETE_PROP_CONST` and the interpreter.
- **Bytecode compiler `delete identifier`**: The compiler now rejects `delete identifier` at compile time instead of silently emitting `OP_LOAD_TRUE`, matching the interpreter's strict-mode enforcement.
- Closes #517

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change