### PR TITLE
Add chained-helper re-entrancy tests for iterator helpers (#582)

### DIFF
--- a/tests/built-ins/Iterator/iterator-helper-reentrant.js
+++ b/tests/built-ins/Iterator/iterator-helper-reentrant.js
@@ -128,7 +128,23 @@ describe("Chained iterator helper re-entrancy", () => {
       "zip → map",
       () => {
         let h;
-        h = Iterator.zip([makeReentrantIterable(() => h)]).map(x => x[0]);
+        h = Iterator.zip([makeReentrantIterable(() => h)]).map(x => x);
+        return h;
+      },
+    ],
+    [
+      "concat → drop",
+      () => {
+        let h;
+        h = Iterator.concat(makeReentrantIterable(() => h)).drop(0);
+        return h;
+      },
+    ],
+    [
+      "concat → flatMap",
+      () => {
+        let h;
+        h = Iterator.concat(makeReentrantIterable(() => h)).flatMap(x => [x]);
         return h;
       },
     ],
@@ -179,6 +195,13 @@ describe("Chained iterator helper re-entrancy", () => {
       () => {
         const inner = Iterator.zip([[1, 2, 3]]);
         return inner.map(x => { inner.next(); return x; });
+      },
+    ],
+    [
+      "drop → flatMap (flatMap callback re-enters drop)",
+      () => {
+        const inner = [1, 2, 3].values().drop(0);
+        return inner.flatMap(x => { inner.next(); return [x]; });
       },
     ],
     [

--- a/tests/built-ins/Iterator/iterator-helper-reentrant.js
+++ b/tests/built-ins/Iterator/iterator-helper-reentrant.js
@@ -1,5 +1,5 @@
 /*---
-description: Iterator helpers throw TypeError on re-entrant .next() (ES2026 §27.1.2.1.1)
+description: Iterator helpers throw TypeError on re-entrant .next() and chained helpers isolate per-instance guards
 features: [Iterator, iterator-helpers, iterator-sequencing]
 ---*/
 
@@ -87,5 +87,110 @@ describe("Iterator helper re-entrancy guard", () => {
   ])("%s throws TypeError on re-entrant .next()", (_name, factory) => {
     const helper = factory();
     expect(() => helper.next()).toThrow(TypeError);
+  });
+});
+
+describe("Chained iterator helper re-entrancy", () => {
+  test.each([
+    [
+      "concat → take",
+      () => {
+        let h;
+        h = Iterator.concat(makeReentrantIterable(() => h)).take(5);
+        return h;
+      },
+    ],
+    [
+      "concat → map",
+      () => {
+        let h;
+        h = Iterator.concat(makeReentrantIterable(() => h)).map(x => x);
+        return h;
+      },
+    ],
+    [
+      "concat → filter",
+      () => {
+        let h;
+        h = Iterator.concat(makeReentrantIterable(() => h)).filter(() => true);
+        return h;
+      },
+    ],
+    [
+      "zip → take",
+      () => {
+        let h;
+        h = Iterator.zip([makeReentrantIterable(() => h)]).take(5);
+        return h;
+      },
+    ],
+    [
+      "zip → map",
+      () => {
+        let h;
+        h = Iterator.zip([makeReentrantIterable(() => h)]).map(x => x[0]);
+        return h;
+      },
+    ],
+    [
+      "concat → filter → take (three-deep)",
+      () => {
+        let h;
+        h = Iterator.concat(makeReentrantIterable(() => h)).filter(() => true).take(5);
+        return h;
+      },
+    ],
+  ])("%s throws TypeError when source re-enters outermost helper", (_name, factory) => {
+    const helper = factory();
+    expect(() => helper.next()).toThrow(TypeError);
+  });
+
+  test.each([
+    [
+      "map → filter (predicate re-enters map)",
+      () => {
+        const inner = [1, 2, 3].values().map(x => x * 2);
+        return inner.filter(() => { inner.next(); return true; });
+      },
+    ],
+    [
+      "filter → map (mapper re-enters filter)",
+      () => {
+        const inner = [1, 2, 3].values().filter(() => true);
+        return inner.map(x => { inner.next(); return x; });
+      },
+    ],
+    [
+      "take → map (mapper re-enters take)",
+      () => {
+        const inner = [1, 2, 3].values().take(5);
+        return inner.map(x => { inner.next(); return x; });
+      },
+    ],
+    [
+      "concat → filter (predicate re-enters concat)",
+      () => {
+        const inner = Iterator.concat([1, 2, 3]);
+        return inner.filter(() => { inner.next(); return true; });
+      },
+    ],
+    [
+      "zip → map (mapper re-enters zip)",
+      () => {
+        const inner = Iterator.zip([[1, 2, 3]]);
+        return inner.map(x => { inner.next(); return x; });
+      },
+    ],
+    [
+      "map → filter → take (predicate re-enters map, three-deep)",
+      () => {
+        const inner = [1, 2, 3, 4, 5, 6].values().map(x => x);
+        return inner.filter(() => { inner.next(); return true; }).take(5);
+      },
+    ],
+  ])("%s does not throw (per-instance guard isolation)", (_name, factory) => {
+    const chain = factory();
+    const { done } = chain.next();
+    expect(done).toBe(false);
   });
 });

--- a/tests/built-ins/Iterator/iterator-helper-reentrant.js
+++ b/tests/built-ins/Iterator/iterator-helper-reentrant.js
@@ -90,72 +90,22 @@ describe("Iterator helper re-entrancy guard", () => {
   });
 });
 
+const makeChainedReentrant = (build) => {
+  let h;
+  h = build(makeReentrantIterable(() => h));
+  return h;
+};
+
 describe("Chained iterator helper re-entrancy", () => {
   test.each([
-    [
-      "concat → take",
-      () => {
-        let h;
-        h = Iterator.concat(makeReentrantIterable(() => h)).take(5);
-        return h;
-      },
-    ],
-    [
-      "concat → map",
-      () => {
-        let h;
-        h = Iterator.concat(makeReentrantIterable(() => h)).map(x => x);
-        return h;
-      },
-    ],
-    [
-      "concat → filter",
-      () => {
-        let h;
-        h = Iterator.concat(makeReentrantIterable(() => h)).filter(() => true);
-        return h;
-      },
-    ],
-    [
-      "zip → take",
-      () => {
-        let h;
-        h = Iterator.zip([makeReentrantIterable(() => h)]).take(5);
-        return h;
-      },
-    ],
-    [
-      "zip → map",
-      () => {
-        let h;
-        h = Iterator.zip([makeReentrantIterable(() => h)]).map(x => x);
-        return h;
-      },
-    ],
-    [
-      "concat → drop",
-      () => {
-        let h;
-        h = Iterator.concat(makeReentrantIterable(() => h)).drop(0);
-        return h;
-      },
-    ],
-    [
-      "concat → flatMap",
-      () => {
-        let h;
-        h = Iterator.concat(makeReentrantIterable(() => h)).flatMap(x => [x]);
-        return h;
-      },
-    ],
-    [
-      "concat → filter → take (three-deep)",
-      () => {
-        let h;
-        h = Iterator.concat(makeReentrantIterable(() => h)).filter(() => true).take(5);
-        return h;
-      },
-    ],
+    ["concat → take", () => makeChainedReentrant(src => Iterator.concat(src).take(5))],
+    ["concat → map", () => makeChainedReentrant(src => Iterator.concat(src).map(x => x))],
+    ["concat → filter", () => makeChainedReentrant(src => Iterator.concat(src).filter(() => true))],
+    ["zip → take", () => makeChainedReentrant(src => Iterator.zip([src]).take(5))],
+    ["zip → map", () => makeChainedReentrant(src => Iterator.zip([src]).map(x => x))],
+    ["concat → drop", () => makeChainedReentrant(src => Iterator.concat(src).drop(0))],
+    ["concat → flatMap", () => makeChainedReentrant(src => Iterator.concat(src).flatMap(x => [x]))],
+    ["concat → filter → take (three-deep)", () => makeChainedReentrant(src => Iterator.concat(src).filter(() => true).take(5))],
   ])("%s throws TypeError when source re-enters outermost helper", (_name, factory) => {
     const helper = factory();
     expect(() => helper.next()).toThrow(TypeError);
@@ -207,7 +157,7 @@ describe("Chained iterator helper re-entrancy", () => {
     [
       "map → filter → take (predicate re-enters map, three-deep)",
       () => {
-        const inner = [1, 2, 3, 4, 5, 6].values().map(x => x);
+        const inner = [1, 2, 3].values().map(x => x);
         return inner.filter(() => { inner.next(); return true; }).take(5);
       },
     ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add chained-helper re-entrancy tests for iterator helpers, covering two-deep and three-deep helper chains across all 8 helper types.
- **Cross-chain TypeError tests** (8 cases): verify that a re-entrant source iterator correctly triggers the outermost helper's `FExecuting` guard when all helpers in the chain are still executing (concat→take, concat→map, concat→filter, concat→drop, concat→flatMap, zip→take, zip→map, concat→filter→take three-deep).
- **Per-instance guard isolation tests** (7 cases): verify that a callback on the outermost helper can re-enter an inner helper whose guard has already been released by try/finally, proving the guards are truly per-instance (map→filter, filter→map, take→map, concat→filter, zip→map, drop→flatMap, map→filter→take three-deep).
- Extract `makeChainedReentrant` helper to factor out the repeated `let h; h = build(...); return h` closure pattern in the TypeError group.
- Closes #582.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
