### PR TITLE
Centralize FExecuting re-entrancy guard into TGocciaIteratorHelperValue (#581)

### DIFF
--- a/docs/value-system.md
+++ b/docs/value-system.md
@@ -41,12 +41,16 @@ classDiagram
     TGocciaIteratorValue <|-- TGocciaStringIteratorValue
     TGocciaIteratorValue <|-- TGocciaMapIteratorValue
     TGocciaIteratorValue <|-- TGocciaSetIteratorValue
-    TGocciaIteratorValue <|-- TGocciaLazyMapIteratorValue
-    TGocciaIteratorValue <|-- TGocciaLazyFilterIteratorValue
-    TGocciaIteratorValue <|-- TGocciaLazyTakeIteratorValue
-    TGocciaIteratorValue <|-- TGocciaLazyDropIteratorValue
-    TGocciaIteratorValue <|-- TGocciaLazyFlatMapIteratorValue
     TGocciaIteratorValue <|-- TGocciaGenericIteratorValue
+    TGocciaIteratorValue <|-- TGocciaIteratorHelperValue
+    TGocciaIteratorHelperValue <|-- TGocciaLazyMapIteratorValue
+    TGocciaIteratorHelperValue <|-- TGocciaLazyFilterIteratorValue
+    TGocciaIteratorHelperValue <|-- TGocciaLazyTakeIteratorValue
+    TGocciaIteratorHelperValue <|-- TGocciaLazyDropIteratorValue
+    TGocciaIteratorHelperValue <|-- TGocciaLazyFlatMapIteratorValue
+    TGocciaIteratorHelperValue <|-- TGocciaConcatIteratorValue
+    TGocciaIteratorHelperValue <|-- TGocciaZipIteratorValue
+    TGocciaIteratorHelperValue <|-- TGocciaZipKeyedIteratorValue
     TGocciaObjectValue <|-- TGocciaArrayBufferValue
     TGocciaObjectValue <|-- TGocciaSharedArrayBufferValue
     TGocciaObjectValue <|-- TGocciaTypedArrayValue

--- a/source/units/Goccia.Values.Iterator.Concat.pas
+++ b/source/units/Goccia.Values.Iterator.Concat.pas
@@ -15,17 +15,17 @@ type
     IteratorMethod: TGocciaValue; // nil for string iterables (handled specially)
   end;
 
-  TGocciaConcatIteratorValue = class(TGocciaIteratorValue)
+  TGocciaConcatIteratorValue = class(TGocciaIteratorHelperValue)
   private
     FIterables: array of TGocciaConcatIterableRecord;
     FCurrentIndex: Integer;
     FCurrentIterator: TGocciaIteratorValue;
-    FExecuting: Boolean;
     function OpenNextIterator: Boolean;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; override;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
     constructor Create(const AIterables: array of TGocciaConcatIterableRecord);
-    function AdvanceNext: TGocciaObjectValue; override;
-    function DirectNext(out ADone: Boolean): TGocciaValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
@@ -99,111 +99,84 @@ begin
 end;
 
 // TC39 Iterator Sequencing §1 Iterator.concat ( ...items ) — step 3.a.iv-v
-function TGocciaConcatIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaConcatIteratorValue.DoAdvanceNext: TGocciaObjectValue;
 var
   InnerResult: TGocciaObjectValue;
 begin
-  if FDone then
-  begin
-    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-    Exit;
-  end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    repeat
-      if Assigned(FCurrentIterator) then
-      begin
-        try
-          InnerResult := FCurrentIterator.AdvanceNext;
-        except
-          AcquireExceptionObject;
-          CloseIteratorPreservingError(FCurrentIterator);
-          FCurrentIterator := nil;
-          FDone := True;
-          raise;
-        end;
-        if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
-        begin
-          Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
-          Exit;
-        end;
-        FCurrentIterator := nil;
-      end;
-
+  repeat
+    if Assigned(FCurrentIterator) then
+    begin
       try
-        if not OpenNextIterator then
-        begin
-          FDone := True;
-          Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-          Exit;
-        end;
+        InnerResult := FCurrentIterator.AdvanceNext;
       except
+        AcquireExceptionObject;
+        CloseIteratorPreservingError(FCurrentIterator);
+        FCurrentIterator := nil;
         FDone := True;
         raise;
       end;
-    until False;
-  finally
-    FExecuting := False;
-  end;
+      if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
+      begin
+        Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
+        Exit;
+      end;
+      FCurrentIterator := nil;
+    end;
+
+    try
+      if not OpenNextIterator then
+      begin
+        FDone := True;
+        Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+        Exit;
+      end;
+    except
+      FDone := True;
+      raise;
+    end;
+  until False;
 end;
 
-// TC39 Iterator Sequencing §1 Iterator.concat ( ...items ) — step 3.a.iv-v (DirectNext)
-function TGocciaConcatIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+// TC39 Iterator Sequencing §1 Iterator.concat ( ...items ) — step 3.a.iv-v (DoDirectNext)
+function TGocciaConcatIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 var
   InnerDone: Boolean;
   InnerValue: TGocciaValue;
 begin
-  if FDone then
-  begin
-    ADone := True;
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Exit;
-  end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    repeat
-      if Assigned(FCurrentIterator) then
-      begin
-        try
-          InnerValue := FCurrentIterator.DirectNext(InnerDone);
-        except
-          AcquireExceptionObject;
-          CloseIteratorPreservingError(FCurrentIterator);
-          FCurrentIterator := nil;
-          FDone := True;
-          raise;
-        end;
-        if not InnerDone then
-        begin
-          ADone := False;
-          Result := InnerValue;
-          Exit;
-        end;
-        FCurrentIterator := nil;
-      end;
-
+  repeat
+    if Assigned(FCurrentIterator) then
+    begin
       try
-        if not OpenNextIterator then
-        begin
-          FDone := True;
-          ADone := True;
-          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-          Exit;
-        end;
+        InnerValue := FCurrentIterator.DirectNext(InnerDone);
       except
+        AcquireExceptionObject;
+        CloseIteratorPreservingError(FCurrentIterator);
+        FCurrentIterator := nil;
         FDone := True;
         raise;
       end;
-    until False;
-  finally
-    FExecuting := False;
-  end;
+      if not InnerDone then
+      begin
+        ADone := False;
+        Result := InnerValue;
+        Exit;
+      end;
+      FCurrentIterator := nil;
+    end;
+
+    try
+      if not OpenNextIterator then
+      begin
+        FDone := True;
+        ADone := True;
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Exit;
+      end;
+    except
+      FDone := True;
+      raise;
+    end;
+  until False;
 end;
 
 procedure TGocciaConcatIteratorValue.Close;

--- a/source/units/Goccia.Values.Iterator.Lazy.pas
+++ b/source/units/Goccia.Values.Iterator.Lazy.pas
@@ -10,74 +10,74 @@ uses
   Goccia.Values.Primitives;
 
 type
-  TGocciaLazyMapIteratorValue = class(TGocciaIteratorValue)
+  TGocciaLazyMapIteratorValue = class(TGocciaIteratorHelperValue)
   private
     FSourceIterator: TGocciaIteratorValue;
     FCallback: TGocciaValue;
     FIndex: Integer;
-    FExecuting: Boolean;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; override;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
     constructor Create(const ASourceIterator: TGocciaIteratorValue; const ACallback: TGocciaValue);
-    function AdvanceNext: TGocciaObjectValue; override;
-    function DirectNext(out ADone: Boolean): TGocciaValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
 
-  TGocciaLazyFilterIteratorValue = class(TGocciaIteratorValue)
+  TGocciaLazyFilterIteratorValue = class(TGocciaIteratorHelperValue)
   private
     FSourceIterator: TGocciaIteratorValue;
     FCallback: TGocciaValue;
     FIndex: Integer;
-    FExecuting: Boolean;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; override;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
     constructor Create(const ASourceIterator: TGocciaIteratorValue; const ACallback: TGocciaValue);
-    function AdvanceNext: TGocciaObjectValue; override;
-    function DirectNext(out ADone: Boolean): TGocciaValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
 
-  TGocciaLazyTakeIteratorValue = class(TGocciaIteratorValue)
+  TGocciaLazyTakeIteratorValue = class(TGocciaIteratorHelperValue)
   private
     FSourceIterator: TGocciaIteratorValue;
     FIndex: Integer;
     FLimit: Integer;
-    FExecuting: Boolean;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; override;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
     constructor Create(const ASourceIterator: TGocciaIteratorValue; const ALimit: Integer);
-    function AdvanceNext: TGocciaObjectValue; override;
-    function DirectNext(out ADone: Boolean): TGocciaValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
 
-  TGocciaLazyDropIteratorValue = class(TGocciaIteratorValue)
+  TGocciaLazyDropIteratorValue = class(TGocciaIteratorHelperValue)
   private
     FSourceIterator: TGocciaIteratorValue;
     FIndex: Integer;
     FLimit: Integer;
-    FExecuting: Boolean;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; override;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
     constructor Create(const ASourceIterator: TGocciaIteratorValue; const ALimit: Integer);
-    function AdvanceNext: TGocciaObjectValue; override;
-    function DirectNext(out ADone: Boolean): TGocciaValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
 
-  TGocciaLazyFlatMapIteratorValue = class(TGocciaIteratorValue)
+  TGocciaLazyFlatMapIteratorValue = class(TGocciaIteratorHelperValue)
   private
     FSourceIterator: TGocciaIteratorValue;
     FCallback: TGocciaValue;
     FIndex: Integer;
     FInnerIterator: TGocciaIteratorValue;
-    FExecuting: Boolean;
     function ResolveIterator(const AValue: TGocciaValue): TGocciaIteratorValue;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; override;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
     constructor Create(const ASourceIterator: TGocciaIteratorValue; const ACallback: TGocciaValue);
-    function AdvanceNext: TGocciaObjectValue; override;
-    function DirectNext(out ADone: Boolean): TGocciaValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
@@ -109,76 +109,49 @@ begin
   FIndex := 0;
 end;
 
-function TGocciaLazyMapIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaLazyMapIteratorValue.DoAdvanceNext: TGocciaObjectValue;
 var
   IterResult: TGocciaObjectValue;
   Value, MappedValue: TGocciaValue;
 begin
-  if FDone then
+  IterResult := FSourceIterator.AdvanceNext;
+  if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
   begin
+    FDone := True;
     Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
     Exit;
   end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
+  Value := IterResult.GetProperty(PROP_VALUE);
   try
-    IterResult := FSourceIterator.AdvanceNext;
-    if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
-    begin
-      FDone := True;
-      Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-      Exit;
-    end;
-    Value := IterResult.GetProperty(PROP_VALUE);
-    try
-      MappedValue := InvokeIteratorCallback(FCallback, Value, FIndex);
-    except
-      AcquireExceptionObject;
-      CloseIteratorPreservingError(FSourceIterator);
-      raise;
-    end;
-    Inc(FIndex);
-    Result := CreateIteratorResult(MappedValue, False);
-  finally
-    FExecuting := False;
+    MappedValue := InvokeIteratorCallback(FCallback, Value, FIndex);
+  except
+    AcquireExceptionObject;
+    CloseIteratorPreservingError(FSourceIterator);
+    raise;
   end;
+  Inc(FIndex);
+  Result := CreateIteratorResult(MappedValue, False);
 end;
 
-function TGocciaLazyMapIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+function TGocciaLazyMapIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 var
   Value: TGocciaValue;
 begin
-  if FDone then
+  Value := FSourceIterator.DirectNext(ADone);
+  if ADone then
   begin
-    ADone := True;
+    FDone := True;
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
   try
-    Value := FSourceIterator.DirectNext(ADone);
-    if ADone then
-    begin
-      FDone := True;
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Exit;
-    end;
-    try
-      Result := InvokeIteratorCallback(FCallback, Value, FIndex);
-    except
-      AcquireExceptionObject;
-      CloseIteratorPreservingError(FSourceIterator);
-      raise;
-    end;
-    Inc(FIndex);
-  finally
-    FExecuting := False;
+    Result := InvokeIteratorCallback(FCallback, Value, FIndex);
+  except
+    AcquireExceptionObject;
+    CloseIteratorPreservingError(FSourceIterator);
+    raise;
   end;
+  Inc(FIndex);
 end;
 
 procedure TGocciaLazyMapIteratorValue.Close;
@@ -208,89 +181,62 @@ begin
   FIndex := 0;
 end;
 
-function TGocciaLazyFilterIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaLazyFilterIteratorValue.DoAdvanceNext: TGocciaObjectValue;
 var
   IterResult: TGocciaObjectValue;
   Value: TGocciaValue;
 begin
-  if FDone then
-  begin
-    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-    Exit;
-  end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    repeat
-      IterResult := FSourceIterator.AdvanceNext;
-      if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
+  repeat
+    IterResult := FSourceIterator.AdvanceNext;
+    if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
+    begin
+      FDone := True;
+      Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+      Exit;
+    end;
+    Value := IterResult.GetProperty(PROP_VALUE);
+    try
+      if InvokeIteratorCallback(FCallback, Value, FIndex).ToBooleanLiteral.Value then
       begin
-        FDone := True;
-        Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+        Inc(FIndex);
+        Result := CreateIteratorResult(Value, False);
         Exit;
       end;
-      Value := IterResult.GetProperty(PROP_VALUE);
-      try
-        if InvokeIteratorCallback(FCallback, Value, FIndex).ToBooleanLiteral.Value then
-        begin
-          Inc(FIndex);
-          Result := CreateIteratorResult(Value, False);
-          Exit;
-        end;
-      except
-        AcquireExceptionObject;
-        CloseIteratorPreservingError(FSourceIterator);
-        raise;
-      end;
-      Inc(FIndex);
-    until False;
-  finally
-    FExecuting := False;
-  end;
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(FSourceIterator);
+      raise;
+    end;
+    Inc(FIndex);
+  until False;
 end;
 
-function TGocciaLazyFilterIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+function TGocciaLazyFilterIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 var
   Value: TGocciaValue;
 begin
-  if FDone then
-  begin
-    ADone := True;
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Exit;
-  end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    repeat
-      Value := FSourceIterator.DirectNext(ADone);
-      if ADone then
+  repeat
+    Value := FSourceIterator.DirectNext(ADone);
+    if ADone then
+    begin
+      FDone := True;
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Exit;
+    end;
+    try
+      if InvokeIteratorCallback(FCallback, Value, FIndex).ToBooleanLiteral.Value then
       begin
-        FDone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Inc(FIndex);
+        Result := Value;
         Exit;
       end;
-      try
-        if InvokeIteratorCallback(FCallback, Value, FIndex).ToBooleanLiteral.Value then
-        begin
-          Inc(FIndex);
-          Result := Value;
-          Exit;
-        end;
-      except
-        AcquireExceptionObject;
-        CloseIteratorPreservingError(FSourceIterator);
-        raise;
-      end;
-      Inc(FIndex);
-    until False;
-  finally
-    FExecuting := False;
-  end;
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(FSourceIterator);
+      raise;
+    end;
+    Inc(FIndex);
+  until False;
 end;
 
 procedure TGocciaLazyFilterIteratorValue.Close;
@@ -320,60 +266,44 @@ begin
   FLimit := ALimit;
 end;
 
-function TGocciaLazyTakeIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaLazyTakeIteratorValue.DoAdvanceNext: TGocciaObjectValue;
 var
   IterResult: TGocciaObjectValue;
 begin
-  if FDone or (FIndex >= FLimit) then
+  if FIndex >= FLimit then
   begin
     FDone := True;
     Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
     Exit;
   end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    IterResult := FSourceIterator.AdvanceNext;
-    if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
-    begin
-      FDone := True;
-      Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-      Exit;
-    end;
-    Inc(FIndex);
-    Result := CreateIteratorResult(IterResult.GetProperty(PROP_VALUE), False);
-  finally
-    FExecuting := False;
+  IterResult := FSourceIterator.AdvanceNext;
+  if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
+  begin
+    FDone := True;
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
   end;
+  Inc(FIndex);
+  Result := CreateIteratorResult(IterResult.GetProperty(PROP_VALUE), False);
 end;
 
-function TGocciaLazyTakeIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+function TGocciaLazyTakeIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 begin
-  if FDone or (FIndex >= FLimit) then
+  if FIndex >= FLimit then
   begin
     FDone := True;
     ADone := True;
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    Result := FSourceIterator.DirectNext(ADone);
-    if ADone then
-    begin
-      FDone := True;
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Exit;
-    end;
-    Inc(FIndex);
-  finally
-    FExecuting := False;
+  Result := FSourceIterator.DirectNext(ADone);
+  if ADone then
+  begin
+    FDone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
   end;
+  Inc(FIndex);
 end;
 
 procedure TGocciaLazyTakeIteratorValue.Close;
@@ -401,32 +331,12 @@ begin
   FLimit := ALimit;
 end;
 
-function TGocciaLazyDropIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaLazyDropIteratorValue.DoAdvanceNext: TGocciaObjectValue;
 var
   IterResult: TGocciaObjectValue;
 begin
-  if FDone then
+  while FIndex < FLimit do
   begin
-    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-    Exit;
-  end;
-
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    while FIndex < FLimit do
-    begin
-      IterResult := FSourceIterator.AdvanceNext;
-      if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
-      begin
-        FDone := True;
-        Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-        Exit;
-      end;
-      Inc(FIndex);
-    end;
-
     IterResult := FSourceIterator.AdvanceNext;
     if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
     begin
@@ -434,47 +344,38 @@ begin
       Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
       Exit;
     end;
-    Result := CreateIteratorResult(IterResult.GetProperty(PROP_VALUE), False);
-  finally
-    FExecuting := False;
+    Inc(FIndex);
   end;
-end;
 
-function TGocciaLazyDropIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
-var
-  Value: TGocciaValue;
-begin
-  if FDone then
+  IterResult := FSourceIterator.AdvanceNext;
+  if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
   begin
-    ADone := True;
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    FDone := True;
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
     Exit;
   end;
+  Result := CreateIteratorResult(IterResult.GetProperty(PROP_VALUE), False);
+end;
 
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    while FIndex < FLimit do
-    begin
-      Value := FSourceIterator.DirectNext(ADone);
-      if ADone then
-      begin
-        FDone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
-      Inc(FIndex);
-    end;
-
+function TGocciaLazyDropIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
+begin
+  while FIndex < FLimit do
+  begin
     Result := FSourceIterator.DirectNext(ADone);
     if ADone then
     begin
       FDone := True;
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Exit;
     end;
-  finally
-    FExecuting := False;
+    Inc(FIndex);
+  end;
+
+  Result := FSourceIterator.DirectNext(ADone);
+  if ADone then
+  begin
+    FDone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
 end;
 
@@ -564,140 +465,113 @@ begin
   Result := nil;
 end;
 
-function TGocciaLazyFlatMapIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaLazyFlatMapIteratorValue.DoAdvanceNext: TGocciaObjectValue;
 var
   IterResult, InnerResult: TGocciaObjectValue;
   Value, MappedValue: TGocciaValue;
 begin
-  if FDone then
+  if Assigned(FInnerIterator) then
   begin
-    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-    Exit;
+    InnerResult := FInnerIterator.AdvanceNext;
+    if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
+    begin
+      Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
+      Exit;
+    end;
+    FInnerIterator := nil;
   end;
 
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    if Assigned(FInnerIterator) then
+  repeat
+    IterResult := FSourceIterator.AdvanceNext;
+    if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
     begin
-      InnerResult := FInnerIterator.AdvanceNext;
-      if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
-      begin
-        Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
-        Exit;
-      end;
-      FInnerIterator := nil;
+      FDone := True;
+      Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+      Exit;
     end;
 
-    repeat
-      IterResult := FSourceIterator.AdvanceNext;
-      if TGocciaBooleanLiteralValue(IterResult.GetProperty(PROP_DONE)).Value then
-      begin
-        FDone := True;
-        Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-        Exit;
-      end;
+    Value := IterResult.GetProperty(PROP_VALUE);
+    try
+      MappedValue := InvokeIteratorCallback(FCallback, Value, FIndex);
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(FSourceIterator);
+      if Assigned(FInnerIterator) then
+        CloseIteratorPreservingError(FInnerIterator);
+      raise;
+    end;
+    Inc(FIndex);
 
-      Value := IterResult.GetProperty(PROP_VALUE);
-      try
-        MappedValue := InvokeIteratorCallback(FCallback, Value, FIndex);
-      except
-        AcquireExceptionObject;
-        CloseIteratorPreservingError(FSourceIterator);
-        if Assigned(FInnerIterator) then
-          CloseIteratorPreservingError(FInnerIterator);
-        raise;
-      end;
-      Inc(FIndex);
+    FInnerIterator := ResolveIterator(MappedValue);
+    if not Assigned(FInnerIterator) then
+    begin
+      FSourceIterator.Close;
+      ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
+    end;
 
-      FInnerIterator := ResolveIterator(MappedValue);
-      if not Assigned(FInnerIterator) then
-      begin
-        FSourceIterator.Close;
-        ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
-      end;
-
-      InnerResult := FInnerIterator.AdvanceNext;
-      if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
-      begin
-        Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
-        Exit;
-      end;
-      FInnerIterator := nil;
-    until False;
-  finally
-    FExecuting := False;
-  end;
+    InnerResult := FInnerIterator.AdvanceNext;
+    if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
+    begin
+      Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
+      Exit;
+    end;
+    FInnerIterator := nil;
+  until False;
 end;
 
-function TGocciaLazyFlatMapIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+function TGocciaLazyFlatMapIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 var
   Value, MappedValue, InnerValue: TGocciaValue;
   InnerDone: Boolean;
 begin
-  if FDone then
+  if Assigned(FInnerIterator) then
   begin
-    ADone := True;
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Exit;
+    InnerValue := FInnerIterator.DirectNext(InnerDone);
+    if not InnerDone then
+    begin
+      ADone := False;
+      Result := InnerValue;
+      Exit;
+    end;
+    FInnerIterator := nil;
   end;
 
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
-  try
-    if Assigned(FInnerIterator) then
+  repeat
+    Value := FSourceIterator.DirectNext(ADone);
+    if ADone then
     begin
-      InnerValue := FInnerIterator.DirectNext(InnerDone);
-      if not InnerDone then
-      begin
-        ADone := False;
-        Result := InnerValue;
-        Exit;
-      end;
-      FInnerIterator := nil;
+      FDone := True;
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Exit;
     end;
 
-    repeat
-      Value := FSourceIterator.DirectNext(ADone);
-      if ADone then
-      begin
-        FDone := True;
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
+    try
+      MappedValue := InvokeIteratorCallback(FCallback, Value, FIndex);
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(FSourceIterator);
+      if Assigned(FInnerIterator) then
+        CloseIteratorPreservingError(FInnerIterator);
+      raise;
+    end;
+    Inc(FIndex);
 
-      try
-        MappedValue := InvokeIteratorCallback(FCallback, Value, FIndex);
-      except
-        AcquireExceptionObject;
-        CloseIteratorPreservingError(FSourceIterator);
-        if Assigned(FInnerIterator) then
-          CloseIteratorPreservingError(FInnerIterator);
-        raise;
-      end;
-      Inc(FIndex);
+    FInnerIterator := ResolveIterator(MappedValue);
+    if not Assigned(FInnerIterator) then
+    begin
+      FSourceIterator.Close;
+      ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
+    end;
 
-      FInnerIterator := ResolveIterator(MappedValue);
-      if not Assigned(FInnerIterator) then
-      begin
-        FSourceIterator.Close;
-        ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
-      end;
-
-      InnerValue := FInnerIterator.DirectNext(InnerDone);
-      if not InnerDone then
-      begin
-        ADone := False;
-        Result := InnerValue;
-        Exit;
-      end;
-      FInnerIterator := nil;
-    until False;
-  finally
-    FExecuting := False;
-  end;
+    InnerValue := FInnerIterator.DirectNext(InnerDone);
+    if not InnerDone then
+    begin
+      ADone := False;
+      Result := InnerValue;
+      Exit;
+    end;
+    FInnerIterator := nil;
+  until False;
 end;
 
 procedure TGocciaLazyFlatMapIteratorValue.Close;

--- a/source/units/Goccia.Values.Iterator.Zip.pas
+++ b/source/units/Goccia.Values.Iterator.Zip.pas
@@ -12,38 +12,38 @@ uses
 type
   TGocciaZipMode = (zmShortest, zmLongest, zmStrict);
 
-  TGocciaZipIteratorValue = class(TGocciaIteratorValue)
+  TGocciaZipIteratorValue = class(TGocciaIteratorHelperValue)
   private
     FIterators: array of TGocciaIteratorValue;
     FPadding: array of TGocciaValue;
     FMode: TGocciaZipMode;
     FExhausted: array of Boolean;
-    FExecuting: Boolean;
     procedure CloseAllIterators;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; override;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
     constructor Create(const AIterators: array of TGocciaIteratorValue;
       const APadding: array of TGocciaValue; const AMode: TGocciaZipMode);
-    function AdvanceNext: TGocciaObjectValue; override;
-    function DirectNext(out ADone: Boolean): TGocciaValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
 
-  TGocciaZipKeyedIteratorValue = class(TGocciaIteratorValue)
+  TGocciaZipKeyedIteratorValue = class(TGocciaIteratorHelperValue)
   private
     FKeys: array of string;
     FIterators: array of TGocciaIteratorValue;
     FPadding: array of TGocciaValue;
     FMode: TGocciaZipMode;
     FExhausted: array of Boolean;
-    FExecuting: Boolean;
     procedure CloseAllIterators;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; override;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
     constructor Create(const AKeys: array of string;
       const AIterators: array of TGocciaIteratorValue;
       const APadding: array of TGocciaValue; const AMode: TGocciaZipMode);
-    function AdvanceNext: TGocciaObjectValue; override;
-    function DirectNext(out ADone: Boolean): TGocciaValue; override;
     procedure Close; override;
     procedure MarkReferences; override;
   end;
@@ -142,23 +142,17 @@ begin
 end;
 
 // TC39 Joint Iteration §1.1 Iterator.zip(iterables [, options])
-function TGocciaZipIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaZipIteratorValue.DoAdvanceNext: TGocciaObjectValue;
 var
   Value: TGocciaValue;
   Done: Boolean;
 begin
-  if FDone then
-  begin
-    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-    Exit;
-  end;
-
-  Value := DirectNext(Done);
+  Value := DoDirectNext(Done);
   Result := CreateIteratorResult(Value, Done);
 end;
 
 // TC39 Joint Iteration §1.1 Iterator.zip(iterables [, options]) — yield step
-function TGocciaZipIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+function TGocciaZipIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 var
   ResultArray: TGocciaArrayValue;
   I: Integer;
@@ -166,124 +160,105 @@ var
   InnerDone: Boolean;
   AnyDone, AllDone: Boolean;
 begin
-  if FDone then
+  if Length(FIterators) = 0 then
   begin
+    FDone := True;
     ADone := True;
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
 
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
+  ResultArray := TGocciaArrayValue.Create;
+  TGarbageCollector.Instance.AddTempRoot(ResultArray);
   try
-    if Length(FIterators) = 0 then
+    AnyDone := False;
+    AllDone := True;
+
+    // TC39 Joint Iteration §1.1 step 6.a: For each iteratorRecord of iteratorRecords
+    for I := 0 to High(FIterators) do
     begin
-      FDone := True;
-      ADone := True;
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Exit;
+      if FExhausted[I] then
+      begin
+        if I < Length(FPadding) then
+          ResultArray.Elements.Add(FPadding[I])
+        else
+          ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+        AnyDone := True;
+        Continue;
+      end;
+
+      try
+        InnerValue := FIterators[I].DirectNext(InnerDone);
+      except
+        AcquireExceptionObject;
+        CloseAllIterators;
+        FDone := True;
+        raise;
+      end;
+
+      if InnerDone then
+      begin
+        FExhausted[I] := True;
+        AnyDone := True;
+        if I < Length(FPadding) then
+          ResultArray.Elements.Add(FPadding[I])
+        else
+          ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+      end
+      else
+      begin
+        AllDone := False;
+        ResultArray.Elements.Add(InnerValue);
+      end;
     end;
 
-    ResultArray := TGocciaArrayValue.Create;
-    TGarbageCollector.Instance.AddTempRoot(ResultArray);
-    try
-      AnyDone := False;
-      AllDone := True;
+    if not AnyDone then
+      AllDone := False;
 
-      // TC39 Joint Iteration §1.1 step 6.a: For each iteratorRecord of iteratorRecords
-      for I := 0 to High(FIterators) do
+    case FMode of
+      zmShortest:
       begin
-        if FExhausted[I] then
+        if AnyDone then
         begin
-          // Already exhausted — use padding (only relevant for longest mode)
-          if I < Length(FPadding) then
-            ResultArray.Elements.Add(FPadding[I])
-          else
-            ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
-          AnyDone := True;
-          Continue;
-        end;
-
-        try
-          InnerValue := FIterators[I].DirectNext(InnerDone);
-        except
-          AcquireExceptionObject;
           CloseAllIterators;
           FDone := True;
-          raise;
-        end;
-
-        if InnerDone then
-        begin
-          FExhausted[I] := True;
-          AnyDone := True;
-          if I < Length(FPadding) then
-            ResultArray.Elements.Add(FPadding[I])
-          else
-            ResultArray.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
-        end
-        else
-        begin
-          AllDone := False;
-          ResultArray.Elements.Add(InnerValue);
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
         end;
       end;
-
-      if not AnyDone then
-        AllDone := False;
-
-      case FMode of
-        zmShortest:
+      zmLongest:
+      begin
+        if AllDone then
         begin
-          // TC39 Joint Iteration §1.1 step 6.a.ii: If mode is "shortest", close remaining
-          if AnyDone then
-          begin
-            CloseAllIterators;
-            FDone := True;
-            ADone := True;
-            Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-            Exit;
-          end;
-        end;
-        zmLongest:
-        begin
-          // TC39 Joint Iteration §1.1: If all are done, complete
-          if AllDone then
-          begin
-            FDone := True;
-            ADone := True;
-            Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-            Exit;
-          end;
-          // Otherwise yield the array with padding values for exhausted iterators
-        end;
-        zmStrict:
-        begin
-          // TC39 Joint Iteration §1.1: In strict mode, all must finish together
-          if AnyDone and not AllDone then
-          begin
-            CloseAllIterators;
-            FDone := True;
-            ThrowTypeError(SErrorIteratorZipStrictLengthMismatch, SSuggestIteratorZipMode);
-          end;
-          if AllDone then
-          begin
-            FDone := True;
-            ADone := True;
-            Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-            Exit;
-          end;
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
         end;
       end;
-
-      ADone := False;
-      Result := ResultArray;
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(ResultArray);
+      zmStrict:
+      begin
+        if AnyDone and not AllDone then
+        begin
+          CloseAllIterators;
+          FDone := True;
+          ThrowTypeError(SErrorIteratorZipStrictLengthMismatch, SSuggestIteratorZipMode);
+        end;
+        if AllDone then
+        begin
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+      end;
     end;
+
+    ADone := False;
+    Result := ResultArray;
   finally
-    FExecuting := False;
+    TGarbageCollector.Instance.RemoveTempRoot(ResultArray);
   end;
 end;
 
@@ -348,23 +323,17 @@ begin
 end;
 
 // TC39 Joint Iteration §1.2 Iterator.zipKeyed(iterables [, options])
-function TGocciaZipKeyedIteratorValue.AdvanceNext: TGocciaObjectValue;
+function TGocciaZipKeyedIteratorValue.DoAdvanceNext: TGocciaObjectValue;
 var
   Value: TGocciaValue;
   Done: Boolean;
 begin
-  if FDone then
-  begin
-    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
-    Exit;
-  end;
-
-  Value := DirectNext(Done);
+  Value := DoDirectNext(Done);
   Result := CreateIteratorResult(Value, Done);
 end;
 
 // TC39 Joint Iteration §1.2 Iterator.zipKeyed(iterables [, options]) — yield step
-function TGocciaZipKeyedIteratorValue.DirectNext(out ADone: Boolean): TGocciaValue;
+function TGocciaZipKeyedIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 var
   ResultObj: TGocciaObjectValue;
   I: Integer;
@@ -372,119 +341,105 @@ var
   InnerDone: Boolean;
   AnyDone, AllDone: Boolean;
 begin
-  if FDone then
+  if Length(FIterators) = 0 then
   begin
+    FDone := True;
     ADone := True;
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
 
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
-  FExecuting := True;
+  ResultObj := TGocciaObjectValue.Create;
+  TGarbageCollector.Instance.AddTempRoot(ResultObj);
   try
-    if Length(FIterators) = 0 then
+    AnyDone := False;
+    AllDone := True;
+
+    // TC39 Joint Iteration §1.2 step 6.a: For each key of keys
+    for I := 0 to High(FIterators) do
     begin
-      FDone := True;
-      ADone := True;
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Exit;
+      if FExhausted[I] then
+      begin
+        if I < Length(FPadding) then
+          ResultObj.AssignProperty(FKeys[I], FPadding[I])
+        else
+          ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
+        AnyDone := True;
+        Continue;
+      end;
+
+      try
+        InnerValue := FIterators[I].DirectNext(InnerDone);
+      except
+        AcquireExceptionObject;
+        CloseAllIterators;
+        FDone := True;
+        raise;
+      end;
+
+      if InnerDone then
+      begin
+        FExhausted[I] := True;
+        AnyDone := True;
+        if I < Length(FPadding) then
+          ResultObj.AssignProperty(FKeys[I], FPadding[I])
+        else
+          ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
+      end
+      else
+      begin
+        AllDone := False;
+        ResultObj.AssignProperty(FKeys[I], InnerValue);
+      end;
     end;
 
-    ResultObj := TGocciaObjectValue.Create;
-    TGarbageCollector.Instance.AddTempRoot(ResultObj);
-    try
-      AnyDone := False;
-      AllDone := True;
+    if not AnyDone then
+      AllDone := False;
 
-      // TC39 Joint Iteration §1.2 step 6.a: For each key of keys
-      for I := 0 to High(FIterators) do
+    case FMode of
+      zmShortest:
       begin
-        if FExhausted[I] then
+        if AnyDone then
         begin
-          if I < Length(FPadding) then
-            ResultObj.AssignProperty(FKeys[I], FPadding[I])
-          else
-            ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
-          AnyDone := True;
-          Continue;
-        end;
-
-        try
-          InnerValue := FIterators[I].DirectNext(InnerDone);
-        except
-          AcquireExceptionObject;
           CloseAllIterators;
           FDone := True;
-          raise;
-        end;
-
-        if InnerDone then
-        begin
-          FExhausted[I] := True;
-          AnyDone := True;
-          if I < Length(FPadding) then
-            ResultObj.AssignProperty(FKeys[I], FPadding[I])
-          else
-            ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
-        end
-        else
-        begin
-          AllDone := False;
-          ResultObj.AssignProperty(FKeys[I], InnerValue);
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
         end;
       end;
-
-      if not AnyDone then
-        AllDone := False;
-
-      case FMode of
-        zmShortest:
+      zmLongest:
+      begin
+        if AllDone then
         begin
-          if AnyDone then
-          begin
-            CloseAllIterators;
-            FDone := True;
-            ADone := True;
-            Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-            Exit;
-          end;
-        end;
-        zmLongest:
-        begin
-          if AllDone then
-          begin
-            FDone := True;
-            ADone := True;
-            Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-            Exit;
-          end;
-        end;
-        zmStrict:
-        begin
-          if AnyDone and not AllDone then
-          begin
-            CloseAllIterators;
-            FDone := True;
-            ThrowTypeError(SErrorIteratorZipKeyedStrictLengthMismatch, SSuggestIteratorZipMode);
-          end;
-          if AllDone then
-          begin
-            FDone := True;
-            ADone := True;
-            Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-            Exit;
-          end;
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
         end;
       end;
-
-      ADone := False;
-      Result := ResultObj;
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(ResultObj);
+      zmStrict:
+      begin
+        if AnyDone and not AllDone then
+        begin
+          CloseAllIterators;
+          FDone := True;
+          ThrowTypeError(SErrorIteratorZipKeyedStrictLengthMismatch, SSuggestIteratorZipMode);
+        end;
+        if AllDone then
+        begin
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+      end;
     end;
+
+    ADone := False;
+    Result := ResultObj;
   finally
-    FExecuting := False;
+    TGarbageCollector.Instance.RemoveTempRoot(ResultObj);
   end;
 end;
 

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -50,6 +50,17 @@ type
     class function CreateGlobalObject: TGocciaObjectValue;
   end;
 
+  TGocciaIteratorHelperValue = class(TGocciaIteratorValue)
+  private
+    FExecuting: Boolean;
+  protected
+    function DoAdvanceNext: TGocciaObjectValue; virtual; abstract;
+    function DoDirectNext(out ADone: Boolean): TGocciaValue; virtual; abstract;
+  public
+    function AdvanceNext: TGocciaObjectValue; override;
+    function DirectNext(out ADone: Boolean): TGocciaValue; override;
+  end;
+
 function CreateIteratorResult(const AValue: TGocciaValue; const ADone: Boolean): TGocciaObjectValue;
 function InvokeIteratorCallback(const ACallback: TGocciaValue; const AValue: TGocciaValue; const AIndex: Integer): TGocciaValue;
 procedure CloseIteratorPreservingError(const AIterator: TGocciaIteratorValue);
@@ -1050,6 +1061,43 @@ begin
     // Unroot iterators — the zipKeyed iterator now owns them via MarkReferences
     for I := 0 to Count - 1 do
       GC.RemoveTempRoot(Iterators[I]);
+  end;
+end;
+
+{ TGocciaIteratorHelperValue }
+
+function TGocciaIteratorHelperValue.AdvanceNext: TGocciaObjectValue;
+begin
+  if FDone then
+  begin
+    Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
+    Exit;
+  end;
+  if FExecuting then
+    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
+  FExecuting := True;
+  try
+    Result := DoAdvanceNext;
+  finally
+    FExecuting := False;
+  end;
+end;
+
+function TGocciaIteratorHelperValue.DirectNext(out ADone: Boolean): TGocciaValue;
+begin
+  if FDone then
+  begin
+    ADone := True;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
+  if FExecuting then
+    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
+  FExecuting := True;
+  try
+    Result := DoDirectNext(ADone);
+  finally
+    FExecuting := False;
   end;
 end;
 


### PR DESCRIPTION
## Summary

- Introduce `TGocciaIteratorHelperValue` as a template-method base class between `TGocciaIteratorValue` and all 8 iterator helper classes (concat, map, filter, take, drop, flatMap, zip, zipKeyed).
- The base class owns `FExecuting` and overrides `AdvanceNext`/`DirectNext` with the re-entrancy guard + try/finally, delegating to abstract `DoAdvanceNext`/`DoDirectNext` that subclasses implement. This mirrors the spec's `GeneratorResume` structure (ES2026 §27.1.2.1.1).
- Eliminates 8 duplicated field declarations and 16 duplicated guard sites. Non-helper iterators (array, string, map-entry, set-entry, generator, generic) are unaffected.
- Update `docs/value-system.md` class diagram to reflect the new hierarchy and add previously missing Concat/Zip/ZipKeyed entries.

Closes #581

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change