### PR TITLE
Close source iterator when take limit is reached (#591)

### DIFF
--- a/source/units/Goccia.Values.Iterator.Lazy.pas
+++ b/source/units/Goccia.Values.Iterator.Lazy.pas
@@ -273,6 +273,7 @@ begin
   if FIndex >= FLimit then
   begin
     FDone := True;
+    CloseIteratorPreservingError(FSourceIterator);
     Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
     Exit;
   end;
@@ -292,6 +293,7 @@ begin
   if FIndex >= FLimit then
   begin
     FDone := True;
+    CloseIteratorPreservingError(FSourceIterator);
     ADone := True;
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;

--- a/source/units/Goccia.Values.Iterator.Lazy.pas
+++ b/source/units/Goccia.Values.Iterator.Lazy.pas
@@ -97,6 +97,7 @@ uses
   Goccia.Values.FunctionBase,
   Goccia.Values.Iterator.Concrete,
   Goccia.Values.Iterator.Generic,
+  Goccia.Values.IteratorSupport,
   Goccia.Values.SymbolValue;
 
 { TGocciaLazyMapIteratorValue }
@@ -273,7 +274,7 @@ begin
   if FIndex >= FLimit then
   begin
     FDone := True;
-    CloseIteratorPreservingError(FSourceIterator);
+    CloseIterator(FSourceIterator);
     Result := CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue, True);
     Exit;
   end;
@@ -293,7 +294,7 @@ begin
   if FIndex >= FLimit then
   begin
     FDone := True;
-    CloseIteratorPreservingError(FSourceIterator);
+    CloseIterator(FSourceIterator);
     ADone := True;
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;

--- a/tests/built-ins/Iterator/prototype/take.js
+++ b/tests/built-ins/Iterator/prototype/take.js
@@ -20,14 +20,13 @@ describe("Iterator.prototype.take()", () => {
     expect(() => [1].values().take(-1)).toThrow(RangeError);
   });
 
-  test("take only advances the source as needed", () => {
+  test("take closes the source when the limit is reached", () => {
     const source = [10, 20, 30, 40, 50].values();
     const taken = source.take(2);
 
     expect(taken.next().value).toBe(10);
     expect(taken.next().value).toBe(20);
     expect(taken.next().done).toBe(true);
-    // Source is closed when the take limit is reached (IteratorClose per spec)
     expect(source.next().done).toBe(true);
   });
 
@@ -118,6 +117,27 @@ describe("Iterator.prototype.take()", () => {
     const result = Iterator.from(source[Symbol.iterator]()).take(0).toArray();
     expect(result).toEqual([]);
     expect(closed).toBe(true);
+  });
+
+  test("take propagates errors from return() on normal completion", () => {
+    const source = {
+      [Symbol.iterator]() {
+        let i = 0;
+        return {
+          next() {
+            i++;
+            return { value: i, done: false };
+          },
+          return() {
+            throw new TypeError("close error");
+          },
+        };
+      },
+    };
+
+    expect(() => {
+      Iterator.from(source[Symbol.iterator]()).take(1).toArray();
+    }).toThrow(TypeError);
   });
 
   test("take can bound nested iterators inside helper chains", () => {

--- a/tests/built-ins/Iterator/prototype/take.js
+++ b/tests/built-ins/Iterator/prototype/take.js
@@ -27,7 +27,8 @@ describe("Iterator.prototype.take()", () => {
     expect(taken.next().value).toBe(10);
     expect(taken.next().value).toBe(20);
     expect(taken.next().done).toBe(true);
-    expect(source.next().value).toBe(30);
+    // Source is closed when the take limit is reached (IteratorClose per spec)
+    expect(source.next().done).toBe(true);
   });
 
   test("take composes after drop", () => {
@@ -37,6 +38,86 @@ describe("Iterator.prototype.take()", () => {
       .toArray();
 
     expect(result).toEqual([3, 4, 5]);
+  });
+
+  test("take closes source iterator when limit is reached", () => {
+    let closed = false;
+    const source = {
+      [Symbol.iterator]() {
+        let i = 0;
+        return {
+          next() {
+            i++;
+            return { value: i, done: false };
+          },
+          return() {
+            closed = true;
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    };
+
+    const result = Iterator.from(source[Symbol.iterator]()).take(2).toArray();
+    expect(result).toEqual([1, 2]);
+    expect(closed).toBe(true);
+  });
+
+  test("take runs generator finally blocks when limit is reached", () => {
+    let finalized = false;
+    const gen = {
+      *go() {
+        try { yield 1; yield 2; yield 3; }
+        finally { finalized = true; }
+      },
+    }.go;
+
+    const arr = gen().take(1).toArray();
+    expect(arr).toEqual([1]);
+    expect(finalized).toBe(true);
+  });
+
+  test("take does not close source when source is exhausted before limit", () => {
+    let closed = false;
+    const source = {
+      [Symbol.iterator]() {
+        let i = 0;
+        return {
+          next() {
+            i++;
+            if (i > 2) return { value: undefined, done: true };
+            return { value: i, done: false };
+          },
+          return() {
+            closed = true;
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    };
+
+    const result = Iterator.from(source[Symbol.iterator]()).take(5).toArray();
+    expect(result).toEqual([1, 2]);
+    expect(closed).toBe(false);
+  });
+
+  test("take(0) closes source iterator immediately", () => {
+    let closed = false;
+    const source = {
+      [Symbol.iterator]() {
+        return {
+          next() { return { value: 1, done: false }; },
+          return() {
+            closed = true;
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    };
+
+    const result = Iterator.from(source[Symbol.iterator]()).take(0).toArray();
+    expect(result).toEqual([]);
+    expect(closed).toBe(true);
   });
 
   test("take can bound nested iterators inside helper chains", () => {


### PR DESCRIPTION
## Summary

- Close the source iterator via `CloseIterator` (normal-completion variant) when `Iterator.prototype.take` reaches its limit, matching TC39 Iterator Helpers spec (`IteratorClose(iterated, NormalCompletion(undefined))`).
- Added to both `DoAdvanceNext` and `DoDirectNext` in `TGocciaLazyTakeIteratorValue`.
- Updated existing test that assumed the source stays open after take exhaustion.
- Closes #591

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

### New tests added

| Test | What it verifies |
|------|-----------------|
| `take closes the source when the limit is reached` | Source iterator marked done after take exhaustion |
| `take closes source iterator when limit is reached` | `.return()` called on custom iterator when take limit hit |
| `take runs generator finally blocks when limit is reached` | Generator `finally` block executes on take exhaustion |
| `take does not close source when source is exhausted before limit` | No spurious close when source ends naturally |
| `take(0) closes source iterator immediately` | Zero-limit case closes immediately |
| `take propagates errors from return() on normal completion` | `TypeError` from `.return()` propagates per ES2024 §7.4.10 |

### Full suite

8955/8960 pass (5 pre-existing FFI library loading failures, unrelated).
