### PR TITLE
Add engine to decision-log area tags and sort alphabetically

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -9,7 +9,7 @@ Chronological record of key architectural and implementation decisions, newest f
 ```
 
 - **Date** — When the decision was made
-- **Area** — One of: `bytecode`, `interpreter`, `parser`, `data-structures`, `strings`, `fpc-platform`, `runtime`, `testing`, `build`
+- **Area** — One of: `build`, `bytecode`, `data-structures`, `engine`, `fpc-platform`, `interpreter`, `parser`, `runtime`, `strings`, `testing`
 - **Summary** — 1–3 sentences explaining the decision and why
 - **PR / Detail** — Link to the pull request and/or the `docs/` section where the full rationale lives
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add `engine` to the decision-log area-tag enumeration — it has been used in entries since 2026-05-04 but was missing from the how-to-add reference list.
- Sort the area-tag list alphabetically for consistency.
- Closes #618.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] ~~Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)~~
- [ ] ~~Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change~~