### PR TITLE
Make TGocciaLexerError inherit from TGocciaSyntaxError

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -762,19 +762,21 @@ try
 except
   on E: TGocciaRuntimeError do
     WriteLn('Runtime error: ', E.Message);
-  on E: TGocciaSyntaxError do
-    WriteLn('Syntax error: ', E.Message);
   on E: TGocciaLexerError do
     WriteLn('Lexer error: ', E.Message);
+  on E: TGocciaSyntaxError do
+    WriteLn('Syntax error: ', E.Message);
   on E: Exception do
     WriteLn('Unexpected error: ', E.Message);
 end;
 ```
 
+`TGocciaLexerError` inherits from `TGocciaSyntaxError`, so catching `TGocciaSyntaxError` alone covers both lexer and parser errors. Catch `TGocciaLexerError` first only when you need to distinguish them for diagnostics.
+
 | Exception Class | When |
 |----------------|------|
-| `TGocciaLexerError` | Invalid tokens (unterminated strings, invalid characters) |
-| `TGocciaSyntaxError` | Parse failures (unexpected token, missing semicolon) |
+| `TGocciaSyntaxError` | All early errors (base class for lexer and parser failures) |
+| `TGocciaLexerError` | Invalid tokens (unterminated strings, invalid characters) — subclass of `TGocciaSyntaxError` |
 | `TGocciaRuntimeError` | Execution errors (type errors, reference errors, throw statements) |
 | `TGocciaTypeError` | Type-specific runtime error |
 | `TGocciaReferenceError` | Undefined variable access |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -552,7 +552,7 @@ When execution exceeds the `--timeout` limit, the JSON envelope reports a `Timeo
 
 ## Embedding
 
-For Pascal-side error handling when embedding GocciaScript in FreePascal applications, see [Embedding the Engine](embedding.md). The engine raises `TGocciaError` subclasses (`TGocciaSyntaxError`, `TGocciaTypeError`, `TGocciaReferenceError`) on the Pascal side and `TGocciaThrowValue` for JS-level `throw` statements.
+For Pascal-side error handling when embedding GocciaScript in FreePascal applications, see [Embedding the Engine](embedding.md). The engine raises `TGocciaError` subclasses (`TGocciaSyntaxError` and its subclass `TGocciaLexerError`, `TGocciaTypeError`, `TGocciaReferenceError`) on the Pascal side and `TGocciaThrowValue` for JS-level `throw` statements.
 
 ## Related Documents
 

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -126,7 +126,7 @@ Scopes form a tree with parent pointers, implementing lexical scoping:
 
 GocciaScript uses a layered error approach (see [Errors](errors.md) for the full error type reference and user-facing display format):
 
-1. **Compile-time errors** (lexer/parser) use Pascal exceptions (`TGocciaLexerError`, `TGocciaSyntaxError`) — these terminate parsing immediately.
+1. **Compile-time errors** (lexer/parser) use Pascal exceptions (`TGocciaSyntaxError` and its subclass `TGocciaLexerError`) — these terminate parsing immediately.
 2. **Runtime errors** use a callback pattern (`OnError` in `TGocciaEvaluationContext`) — this keeps evaluator functions pure.
 3. **JavaScript-level errors** use `TGocciaThrowValue` for `throw` statements and `try/catch` — these flow through the evaluator's return path.
 4. **`try-finally` without `catch`** — The evaluator wraps the Pascal `try...except` in a Pascal `try...finally` to guarantee the JS `finally` block runs before exceptions propagate, even when no `catch` clause exists.

--- a/docs/value-system.md
+++ b/docs/value-system.md
@@ -749,4 +749,4 @@ JavaScript error objects are represented as `TGocciaObjectValue` instances with 
 
 Throwing is implemented via `TGocciaThrowValue`, a Pascal `Exception` subclass that wraps any `TGocciaValue` (the thrown value). The evaluator catches `TGocciaThrowValue` and extracts the wrapped value for `catch` blocks.
 
-`TGocciaError` is a separate Pascal `Exception` subclass (not a `TGocciaValue`) used for parser and lexer errors (`TGocciaSyntaxError` and its subclass `TGocciaLexerError`, `TGocciaRuntimeError`). These are internal Pascal exceptions, not JavaScript error objects. The subclass relationship mirrors the ES spec: all early errors (lexer and parser) are `SyntaxError`.
+`TGocciaError` is a separate Pascal `Exception` subclass (not a `TGocciaValue`) used for internal Pascal-side exceptions: early parser/lexer errors (`TGocciaSyntaxError` and its subclass `TGocciaLexerError`) and runtime engine errors (`TGocciaRuntimeError`). These are internal Pascal exceptions, not JavaScript error objects. The subclass relationship mirrors the ES spec: all early errors (lexer and parser) are `SyntaxError`.

--- a/docs/value-system.md
+++ b/docs/value-system.md
@@ -749,4 +749,4 @@ JavaScript error objects are represented as `TGocciaObjectValue` instances with 
 
 Throwing is implemented via `TGocciaThrowValue`, a Pascal `Exception` subclass that wraps any `TGocciaValue` (the thrown value). The evaluator catches `TGocciaThrowValue` and extracts the wrapped value for `catch` blocks.
 
-`TGocciaError` is a separate Pascal `Exception` subclass (not a `TGocciaValue`) used for parser and lexer errors (`TGocciaSyntaxError`, `TGocciaLexerError`, `TGocciaRuntimeError`). These are internal Pascal exceptions, not JavaScript error objects.
+`TGocciaError` is a separate Pascal `Exception` subclass (not a `TGocciaValue`) used for parser and lexer errors (`TGocciaSyntaxError` and its subclass `TGocciaLexerError`, `TGocciaRuntimeError`). These are internal Pascal exceptions, not JavaScript error objects. The subclass relationship mirrors the ES spec: all early errors (lexer and parser) are `SyntaxError`.

--- a/scripts/test-cli-lexer.ts
+++ b/scripts/test-cli-lexer.ts
@@ -111,4 +111,34 @@ console.log("String line continuation...");
   }
 }
 
+// -- Lexer errors surface as SyntaxError (#626) ---------------------------------
+
+console.log("Lexer errors are SyntaxError...");
+{
+  const cases: [string, string][] = [
+    ["'unterminated", "unterminated single-quoted string"],
+    ['"unterminated', "unterminated double-quoted string"],
+    ["`unterminated", "unterminated template literal"],
+    ["'\\xZZ'", "invalid hex escape"],
+    ["'\\u{ZZZZ}'", "invalid unicode escape"],
+  ];
+
+  for (const [source, desc] of cases) {
+    const proc = Bun.spawnSync([LOADER, "--output=json"], {
+      stdin: new TextEncoder().encode(source + "\n"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (proc.exitCode === 0) {
+      throw new Error(`Lexer error "${desc}" should fail, but exited 0`);
+    }
+    const json = JSON.parse(proc.stdout.toString());
+    if (json.ok !== false || json.error?.type !== "SyntaxError") {
+      throw new Error(
+        `Lexer error "${desc}" should be SyntaxError, got ok=${json.ok} type=${json.error?.type}`
+      );
+    }
+  }
+}
+
 console.log("\nAll test-cli-lexer.ts tests passed.");

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -1616,7 +1616,7 @@ begin
 
         if ((ExpectedErrorType = TYPE_ERROR_NAME) and (E is TGocciaTypeError)) or
            ((ExpectedErrorType = REFERENCE_ERROR_NAME) and (E is TGocciaReferenceError)) or
-           ((ExpectedErrorType = SYNTAX_ERROR_NAME) and ((E is TGocciaSyntaxError) or (E is TGocciaLexerError))) or
+           ((ExpectedErrorType = SYNTAX_ERROR_NAME) and (E is TGocciaSyntaxError)) or
            ((ExpectedErrorType = ERROR_NAME) and (E is TGocciaRuntimeError)) or
            (Pos(LowerCase(ExpectedErrorType), LowerCase(E.Message)) > 0) then
         begin

--- a/source/units/Goccia.Error.Test.pas
+++ b/source/units/Goccia.Error.Test.pas
@@ -26,6 +26,7 @@ type
     procedure TestGetDetailedMessageWithoutColorHasNoAnsiCodes;
     procedure TestErrorDisplayNameMapsSyntaxErrorCorrectly;
     procedure TestErrorDisplayNameMapsLexerErrorToSyntaxError;
+    procedure TestLexerErrorInheritFromSyntaxError;
     procedure TestErrorDisplayNameMapsTypeErrorCorrectly;
     procedure TestErrorDisplayNameMapsReferenceErrorCorrectly;
     procedure TestGetDetailedMessageHandlesSingleSourceLine;
@@ -73,6 +74,8 @@ begin
     TestErrorDisplayNameMapsSyntaxErrorCorrectly);
   Test('ErrorDisplayName maps LexerError to SyntaxError',
     TestErrorDisplayNameMapsLexerErrorToSyntaxError);
+  Test('LexerError inherits from SyntaxError',
+    TestLexerErrorInheritFromSyntaxError);
   Test('ErrorDisplayName maps TypeError correctly',
     TestErrorDisplayNameMapsTypeErrorCorrectly);
   Test('ErrorDisplayName maps ReferenceError correctly',
@@ -308,6 +311,18 @@ begin
   Error := TGocciaLexerError.Create('test', 1, 1, 'test.js', nil);
   try
     Expect<string>(ErrorDisplayName(Error)).ToBe('SyntaxError');
+  finally
+    Error.Free;
+  end;
+end;
+
+procedure TErrorTests.TestLexerErrorInheritFromSyntaxError;
+var
+  Error: TGocciaLexerError;
+begin
+  Error := TGocciaLexerError.Create('test', 1, 1, 'test.js', nil);
+  try
+    Expect<Boolean>(Error is TGocciaSyntaxError).ToBe(True);
   finally
     Error.Free;
   end;

--- a/source/units/Goccia.Error.pas
+++ b/source/units/Goccia.Error.pas
@@ -44,8 +44,8 @@ type
     property Suggestion: string read FSuggestion write FSuggestion;
   end;
 
-  TGocciaLexerError = class(TGocciaError);
   TGocciaSyntaxError = class(TGocciaError);
+  TGocciaLexerError = class(TGocciaSyntaxError);
   TGocciaRuntimeError = class(TGocciaError);
   TGocciaTypeError = class(TGocciaRuntimeError);
   TGocciaReferenceError = class(TGocciaRuntimeError);
@@ -82,8 +82,6 @@ begin
     Result := 'SyntaxError'
   else if AError is TGocciaRuntimeError then
     Result := 'RuntimeError'
-  else if AError is TGocciaLexerError then
-    Result := 'SyntaxError'
   else
     Result := 'Error';
 end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2873,7 +2873,7 @@ begin
     Result := CreateErrorObject(TYPE_ERROR_NAME, E.Message)
   else if E is TGocciaReferenceError then
     Result := CreateErrorObject(REFERENCE_ERROR_NAME, E.Message)
-  else if (E is TGocciaSyntaxError) or (E is TGocciaLexerError) then
+  else if E is TGocciaSyntaxError then
     Result := CreateErrorObject(SYNTAX_ERROR_NAME, E.Message)
   else if E is TGocciaRuntimeError then
     Result := CreateErrorObject(ERROR_NAME, E.Message)

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -9362,7 +9362,7 @@ begin
                 LeftValue := CreateErrorObject(TYPE_ERROR_NAME, E.Message)
               else if E is TGocciaReferenceError then
                 LeftValue := CreateErrorObject(REFERENCE_ERROR_NAME, E.Message)
-              else if (E is TGocciaSyntaxError) or (E is TGocciaLexerError) then
+              else if E is TGocciaSyntaxError then
                 LeftValue := CreateErrorObject(SYNTAX_ERROR_NAME, E.Message)
               else
                 LeftValue := CreateErrorObject(ERROR_NAME, E.Message);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Reparent `TGocciaLexerError` from `TGocciaError` to `TGocciaSyntaxError`, aligning the internal exception hierarchy with the ES spec which treats all early errors (lexer and parser) uniformly as `SyntaxError`.
- Remove the 3 compensating `or (E is TGocciaLexerError)` clauses added in #619 (evaluator, VM, testing library) — now redundant since `E is TGocciaSyntaxError` covers lexer errors via inheritance.
- Remove the dead `TGocciaLexerError` branch in `ErrorDisplayName`.
- Add a Pascal unit test asserting the inheritance relationship and JS tests confirming lexer errors surface as `SyntaxError` at the language level.

Closes #626

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change