### PR TITLE
Preserve flatMap TypeError when source iterator Close throws

### DIFF
--- a/source/units/Goccia.Values.Iterator.Lazy.pas
+++ b/source/units/Goccia.Values.Iterator.Lazy.pas
@@ -508,8 +508,13 @@ begin
     FInnerIterator := ResolveIterator(MappedValue);
     if not Assigned(FInnerIterator) then
     begin
-      FSourceIterator.Close;
-      ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
+      try
+        ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
+      except
+        AcquireExceptionObject;
+        CloseIteratorPreservingError(FSourceIterator);
+        raise;
+      end;
     end;
 
     InnerResult := FInnerIterator.AdvanceNext;
@@ -562,8 +567,13 @@ begin
     FInnerIterator := ResolveIterator(MappedValue);
     if not Assigned(FInnerIterator) then
     begin
-      FSourceIterator.Close;
-      ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
+      try
+        ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
+      except
+        AcquireExceptionObject;
+        CloseIteratorPreservingError(FSourceIterator);
+        raise;
+      end;
     end;
 
     InnerValue := FInnerIterator.DirectNext(InnerDone);

--- a/tests/built-ins/Iterator/prototype/flatMap.js
+++ b/tests/built-ins/Iterator/prototype/flatMap.js
@@ -79,6 +79,19 @@ describe("Iterator.prototype.flatMap()", () => {
     expect(result).toEqual([10, 30, 20, 10, 30]);
   });
 
+  test("flatMap TypeError is preserved when source .return() throws", () => {
+    const source = Iterator.from({
+      next() {
+        return { value: 42, done: false };
+      },
+      return() {
+        throw new RangeError("close boom");
+      },
+    });
+
+    expect(() => source.flatMap((x) => x * 10).next()).toThrow(TypeError);
+  });
+
   test("flatMap can consume dropped inner iterators", () => {
     const result = Iterator.from([3, 5, 7][Symbol.iterator]())
       .flatMap((n) =>

--- a/tests/built-ins/Iterator/prototype/flatMap.js
+++ b/tests/built-ins/Iterator/prototype/flatMap.js
@@ -80,16 +80,19 @@ describe("Iterator.prototype.flatMap()", () => {
   });
 
   test("flatMap TypeError is preserved when source .return() throws", () => {
+    let closed = 0;
     const source = Iterator.from({
       next() {
         return { value: 42, done: false };
       },
       return() {
+        closed = closed + 1;
         throw new RangeError("close boom");
       },
     });
 
     expect(() => source.flatMap((x) => x * 10).next()).toThrow(TypeError);
+    expect(closed).toBe(1);
   });
 
   test("flatMap can consume dropped inner iterators", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Preserve the `TypeError` thrown by `Iterator.prototype.flatMap` when the mapper returns a non-iterable value, even when the source iterator's `.return()` also throws during cleanup.
- Both `DoAdvanceNext` and `DoDirectNext` in `TGocciaLazyFlatMapIteratorValue` now use the `CloseIteratorPreservingError` pattern (already used elsewhere in the same class) instead of calling `FSourceIterator.Close` directly before `ThrowTypeError`.
- Closes #592

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change