### PR TITLE
Add RegExp accessor receiver regression tests

### DIFF
--- a/tests/built-ins/RegExp/constructor.js
+++ b/tests/built-ins/RegExp/constructor.js
@@ -3,6 +3,32 @@ description: RegExp constructor
 features: [RegExp]
 ---*/
 
+const regexpAccessorNames = [
+  "source",
+  "flags",
+  "global",
+  "ignoreCase",
+  "multiline",
+  "dotAll",
+  "unicode",
+  "sticky",
+  "unicodeSets",
+  "hasIndices",
+];
+
+const invalidThisValues = [
+  null,
+  undefined,
+  1,
+  true,
+  "x",
+  Symbol("regexp"),
+  {},
+  [],
+  Object.create(null),
+  () => {},
+];
+
 test("RegExp constructor creates regex objects with flags and properties", () => {
   const regex = new RegExp("ab", "gi");
 
@@ -206,4 +232,14 @@ test("plain object with source and flags is not a RegExp instance", () => {
   const fake = { source: "abc", flags: "g" };
   expect(() => { RegExp.prototype.exec.call(fake, "abc"); }).toThrow(TypeError);
   expect(() => { RegExp.prototype.test.call(fake, "abc"); }).toThrow(TypeError);
+});
+
+test.each(regexpAccessorNames)("%s getter throws TypeError for invalid this values", (accessorName) => {
+  const getter = Object.getOwnPropertyDescriptor(RegExp.prototype, accessorName).get;
+
+  for (const thisValue of invalidThisValues) {
+    expect(() => {
+      getter.call(thisValue);
+    }).toThrow(TypeError);
+  }
 });


### PR DESCRIPTION
## Summary

- Add focused RegExp accessor receiver regression coverage to the existing RegExp constructor/property test file.
- Cover primitive receivers and non-RegExp objects across `source`, `flags`, and all flag accessors using `test.each`.
- Test-only change; runtime behavior already matched the expected TypeError contract.
- Closes #614.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation (not needed; test-only coverage)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Verification run:

- `./build/GocciaTestRunner tests/built-ins/RegExp/constructor.js --asi`
- `./build/GocciaTestRunner tests/built-ins/RegExp --asi`
- `./format.pas --check`