### PR TITLE
Fix generator loop closure resumes

### DIFF
--- a/source/units/Goccia.AST.Statements.pas
+++ b/source/units/Goccia.AST.Statements.pas
@@ -483,6 +483,7 @@ uses
   Goccia.Evaluator,
   Goccia.GarbageCollector,
   Goccia.Modules,
+  Goccia.Runtime.GeneratorContinuation,
   Goccia.Scope,
   Goccia.Scope.BindingMap,
   Goccia.Token,
@@ -859,14 +860,35 @@ end;
     Value: TGocciaValue;
     HasRealStrictInit: Boolean;
     AnnotationType, TypeHint: TGocciaLocalType;
+    Continuation: TGocciaGeneratorContinuation;
   begin
     Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
     // Function declarations are no-ops at runtime — already hoisted with their value
     if IsFunctionDeclaration then
       Exit;
-    for I := 0 to Length(Variables) - 1 do
+    Continuation := CurrentGeneratorContinuation;
+    if Assigned(Continuation) then
+      I := Continuation.GetStatementIndex(Self)
+    else
+      I := 0;
+    while I < Length(Variables) do
     begin
-      Value := EvaluateExpression(Variables[I].Initializer, AContext);
+      try
+        Value := EvaluateExpression(Variables[I].Initializer, AContext);
+      except
+        on E: EGocciaGeneratorYield do
+        begin
+          if Assigned(Continuation) then
+            Continuation.SaveStatementIndex(Self, I);
+          raise;
+        end;
+        else
+        begin
+          if Assigned(Continuation) then
+            Continuation.ClearStatementIndex(Self);
+          raise;
+        end;
+      end;
       if (Value is TGocciaFunctionValue) and (TGocciaFunctionValue(Value).Name = '') then
         TGocciaFunctionValue(Value).Name := Variables[I].Name
       else if Value is TGocciaClassValue then
@@ -919,7 +941,12 @@ end;
         else
           AContext.Scope.SetOwnBindingTypeHint(Variables[I].Name, TypeHint);
       end;
+      if Assigned(Continuation) then
+        Continuation.SaveStatementIndex(Self, I + 1);
+      Inc(I);
     end;
+    if Assigned(Continuation) then
+      Continuation.ClearStatementIndex(Self);
   end;
 
   function TGocciaDestructuringDeclaration.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1707,9 +1707,10 @@ var
   MatchContext, MatchBaseContext: TGocciaEvaluationContext;
   Continuation: TGocciaGeneratorContinuation;
   SavedIteratorValue, SavedCurrentValue, SavedNextMethod: TGocciaValue;
-  SavedIterScope: TGocciaScope;
+  SavedIterScope, SavedActiveScope: TGocciaScope;
   HasSavedLoopState: Boolean;
   HeadCompleted, HeadYielding: Boolean;
+  BodyYielding: Boolean;
   ShouldCloseIterator: Boolean;
 begin
   Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
@@ -1717,7 +1718,7 @@ begin
   Continuation := CurrentGeneratorContinuation;
   HasSavedLoopState := Assigned(Continuation) and
     Continuation.GetLoopState(AForOfStatement, SavedIteratorValue,
-      SavedCurrentValue, SavedNextMethod, SavedIterScope);
+      SavedCurrentValue, SavedNextMethod, SavedIterScope, SavedActiveScope);
   if HasSavedLoopState then
     Iterator := TGocciaIteratorValue(SavedIteratorValue)
   else
@@ -1771,7 +1772,12 @@ begin
       if Assigned(IterScope) then
       begin
         IterContext := AContext;
-        IterContext.Scope := IterScope;
+        if Assigned(SavedActiveScope) then
+          IterContext.Scope := SavedActiveScope
+        else
+          IterContext.Scope := IterScope;
+        MatchBaseContext := AContext;
+        MatchBaseContext.Scope := IterScope;
       end
       else
       begin
@@ -1792,7 +1798,8 @@ begin
             begin
               // var binding: define/update on function/module scope
               if AForOfStatement.BindingPattern <> nil then
-                AssignVariablePattern(AForOfStatement.BindingPattern, CurrentValue, AContext)
+                AssignPattern(AForOfStatement.BindingPattern, CurrentValue,
+                  IterContext)
               else
                 AContext.Scope.DefineVariableBinding(AForOfStatement.BindingName, CurrentValue, True);
             end
@@ -1818,7 +1825,7 @@ begin
             HeadCompleted := True;
             if Assigned(Continuation) then
               Continuation.SaveLoopState(AForOfStatement, Iterator, CurrentValue,
-                nil, IterScope);
+                nil, IterScope, IterContext.Scope);
           except
             on E: EGocciaGeneratorYield do
             begin
@@ -1843,13 +1850,17 @@ begin
       end;
 
       try
+        BodyYielding := False;
         try
           CF := EvaluateLoopBodyStatement(AForOfStatement.Body, IterContext);
           if Assigned(Continuation) then
             Continuation.ClearLoopState(AForOfStatement);
         except
           on E: EGocciaGeneratorYield do
+          begin
+            BodyYielding := True;
             raise;
+          end;
           else
           begin
             if Assigned(Continuation) then
@@ -1859,7 +1870,7 @@ begin
           end;
         end;
       finally
-        if Assigned(AForOfStatement.MatchPattern) and
+        if (not BodyYielding) and Assigned(AForOfStatement.MatchPattern) and
            (IterContext.Scope <> IterScope) then
           ReleaseMatchContext(IterContext, MatchBaseContext);
       end;
@@ -2172,7 +2183,7 @@ var
   MatchContext, MatchBaseContext: TGocciaEvaluationContext;
   Continuation: TGocciaGeneratorContinuation;
   SavedIteratorValue, SavedCurrentValue, SavedNextMethod: TGocciaValue;
-  SavedIterScope: TGocciaScope;
+  SavedIterScope, SavedActiveScope: TGocciaScope;
   HasSavedLoopState: Boolean;
   HeadCompleted, HeadYielding: Boolean;
   ShouldCloseIterator: Boolean;
@@ -2220,7 +2231,7 @@ begin
   Continuation := CurrentGeneratorContinuation;
   HasSavedLoopState := Assigned(Continuation) and
     Continuation.GetLoopState(AForAwaitOfStatement, SavedIteratorValue,
-      SavedCurrentValue, SavedNextMethod, SavedIterScope);
+      SavedCurrentValue, SavedNextMethod, SavedIterScope, SavedActiveScope);
   if not HasSavedLoopState then
     IterableValue := EvaluateExpression(AForAwaitOfStatement.Iterable, AContext)
   else
@@ -2324,7 +2335,8 @@ begin
               if AForAwaitOfStatement.IsVar then
               begin
                 if AForAwaitOfStatement.BindingPattern <> nil then
-                  AssignVariablePattern(AForAwaitOfStatement.BindingPattern, CurrentValue, AContext)
+                  AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue,
+                    IterContext)
                 else
                   AContext.Scope.DefineVariableBinding(AForAwaitOfStatement.BindingName, CurrentValue, True);
               end
@@ -2467,7 +2479,8 @@ begin
             if AForAwaitOfStatement.IsVar then
             begin
               if AForAwaitOfStatement.BindingPattern <> nil then
-                AssignVariablePattern(AForAwaitOfStatement.BindingPattern, CurrentValue, AContext)
+                AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue,
+                  IterContext)
               else
                 AContext.Scope.DefineVariableBinding(AForAwaitOfStatement.BindingName, CurrentValue, True);
             end

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1707,6 +1707,7 @@ var
   MatchContext, MatchBaseContext: TGocciaEvaluationContext;
   Continuation: TGocciaGeneratorContinuation;
   SavedIteratorValue, SavedCurrentValue, SavedNextMethod: TGocciaValue;
+  SavedIterScope: TGocciaScope;
   HasSavedLoopState: Boolean;
   HeadCompleted, HeadYielding: Boolean;
   ShouldCloseIterator: Boolean;
@@ -1716,7 +1717,7 @@ begin
   Continuation := CurrentGeneratorContinuation;
   HasSavedLoopState := Assigned(Continuation) and
     Continuation.GetLoopState(AForOfStatement, SavedIteratorValue,
-      SavedCurrentValue, SavedNextMethod);
+      SavedCurrentValue, SavedNextMethod, SavedIterScope);
   if HasSavedLoopState then
     Iterator := TGocciaIteratorValue(SavedIteratorValue)
   else
@@ -1751,9 +1752,11 @@ begin
       IterResult := Iterator.AdvanceNext;
     while True do
     begin
+      IterScope := nil;
       if HasSavedLoopState then
       begin
         CurrentValue := SavedCurrentValue;
+        IterScope := SavedIterScope;
         HasSavedLoopState := False;
       end
       else
@@ -1762,69 +1765,80 @@ begin
           Break;
         CurrentValue := IterResult.GetProperty(PROP_VALUE);
       end;
-      if Assigned(Continuation) then
+      if Assigned(Continuation) and not Assigned(IterScope) then
         Continuation.SaveLoopState(AForOfStatement, Iterator, CurrentValue);
 
-      HeadCompleted := False;
-      HeadYielding := False;
-      ShouldCloseIterator := True;
-      try
+      if Assigned(IterScope) then
+      begin
+        IterContext := AContext;
+        IterContext.Scope := IterScope;
+      end
+      else
+      begin
+        HeadCompleted := False;
+        HeadYielding := False;
+        ShouldCloseIterator := True;
         try
-          CheckExecutionTimeout;
-          IncrementInstructionCounter;
-          CheckInstructionLimit;
+          try
+            CheckExecutionTimeout;
+            IncrementInstructionCounter;
+            CheckInstructionLimit;
 
-          IterScope := AContext.Scope.CreateChild(skBlock);
-          IterContext := AContext;
-          IterContext.Scope := IterScope;
+            IterScope := AContext.Scope.CreateChild(skBlock);
+            IterContext := AContext;
+            IterContext.Scope := IterScope;
 
-          if AForOfStatement.IsVar then
-          begin
-            // var binding: define/update on function/module scope
-            if AForOfStatement.BindingPattern <> nil then
-              AssignVariablePattern(AForOfStatement.BindingPattern, CurrentValue, AContext)
-            else
-              AContext.Scope.DefineVariableBinding(AForOfStatement.BindingName, CurrentValue, True);
-          end
-          else if AForOfStatement.BindingPattern <> nil then
-            AssignPattern(AForOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
-          else
-            IterScope.DefineLexicalBinding(AForOfStatement.BindingName, CurrentValue, DeclarationType);
-
-          if Assigned(AForOfStatement.MatchPattern) then
-          begin
-            MatchBaseContext := IterContext;
-            if not TryEvaluateMatchPatternInContext(CurrentValue,
-               AForOfStatement.MatchPattern, IterContext, MatchContext) then
+            if AForOfStatement.IsVar then
             begin
-              if Assigned(Continuation) then
-                Continuation.ClearLoopState(AForOfStatement);
-              ShouldCloseIterator := False;
-              IterResult := Iterator.AdvanceNext;
-              Continue;
+              // var binding: define/update on function/module scope
+              if AForOfStatement.BindingPattern <> nil then
+                AssignVariablePattern(AForOfStatement.BindingPattern, CurrentValue, AContext)
+              else
+                AContext.Scope.DefineVariableBinding(AForOfStatement.BindingName, CurrentValue, True);
+            end
+            else if AForOfStatement.BindingPattern <> nil then
+              AssignPattern(AForOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
+            else
+              IterScope.DefineLexicalBinding(AForOfStatement.BindingName, CurrentValue, DeclarationType);
+
+            if Assigned(AForOfStatement.MatchPattern) then
+            begin
+              MatchBaseContext := IterContext;
+              if not TryEvaluateMatchPatternInContext(CurrentValue,
+                 AForOfStatement.MatchPattern, IterContext, MatchContext) then
+              begin
+                if Assigned(Continuation) then
+                  Continuation.ClearLoopState(AForOfStatement);
+                ShouldCloseIterator := False;
+                IterResult := Iterator.AdvanceNext;
+                Continue;
+              end;
+              IterContext := MatchContext;
             end;
-            IterContext := MatchContext;
+            HeadCompleted := True;
+            if Assigned(Continuation) then
+              Continuation.SaveLoopState(AForOfStatement, Iterator, CurrentValue,
+                nil, IterScope);
+          except
+            on E: EGocciaGeneratorYield do
+            begin
+              HeadYielding := True;
+              raise;
+            end;
+            on E: Exception do
+            begin
+              if ShouldCloseIterator then
+                Goccia.Values.IteratorSupport.CloseIteratorPreservingError(Iterator);
+              raise;
+            end;
           end;
-          HeadCompleted := True;
-        except
-          on E: EGocciaGeneratorYield do
+        finally
+          if (not HeadCompleted) and (not HeadYielding) and
+             Assigned(Continuation) then
           begin
-            HeadYielding := True;
-            raise;
+            Continuation.ClearLoopState(AForOfStatement);
+            Continuation.ClearExpressionValues;
           end;
-          on E: Exception do
-          begin
-            if ShouldCloseIterator then
-              Goccia.Values.IteratorSupport.CloseIteratorPreservingError(Iterator);
-            raise;
-          end;
-        end;
-      finally
-        if (not HeadCompleted) and (not HeadYielding) and
-           Assigned(Continuation) then
-        begin
-          Continuation.ClearLoopState(AForOfStatement);
-          Continuation.ClearExpressionValues;
         end;
       end;
 
@@ -1957,7 +1971,7 @@ begin
       HeaderContext.Scope := HeaderScope;
     end;
     ResumePhase := ForState.Phase;
-    if (ResumePhase = gflpBody) and IsLexical then
+    if (ResumePhase in [gflpTest, gflpBody]) and IsLexical then
     begin
       IterScope := ForState.IterScope;
       IterContext.Scope := IterScope;
@@ -1978,6 +1992,15 @@ begin
           HeaderContext.Scope := HeaderScope;
         end;
 
+        if Assigned(Continuation) then
+        begin
+          ForState := Continuation.EnsureForLoopState(AForStatement, HeaderScope);
+          ForState.Phase := gflpInit;
+        end;
+      end;
+
+      if (not HasResumeState) or (ResumePhase = gflpInit) then
+      begin
         if Assigned(AForStatement.Init) then
         begin
           CF := EvaluateStatement(AForStatement.Init, HeaderContext);
@@ -1995,6 +2018,7 @@ begin
           ForState := Continuation.EnsureForLoopState(AForStatement, HeaderScope);
           ForState.Phase := gflpIterStart;
         end;
+        ResumePhase := gflpIterStart;
       end;
 
       while True do
@@ -2025,10 +2049,19 @@ begin
               if HeaderBinding.TypeHint <> sltUntyped then
                 IterScope.SetOwnBindingTypeHint(Name, HeaderBinding.TypeHint);
             end;
+            if Assigned(ForState) then
+            begin
+              ForState.Phase := gflpTest;
+              ForState.IterScope := IterScope;
+            end;
           end
           else
             IterContext := HeaderContext;
+          ResumePhase := gflpTest;
+        end;
 
+        if ResumePhase = gflpTest then
+        begin
           if Assigned(AForStatement.Condition) then
           begin
             CondValue := EvaluateExpression(AForStatement.Condition, IterContext);
@@ -2139,6 +2172,7 @@ var
   MatchContext, MatchBaseContext: TGocciaEvaluationContext;
   Continuation: TGocciaGeneratorContinuation;
   SavedIteratorValue, SavedCurrentValue, SavedNextMethod: TGocciaValue;
+  SavedIterScope: TGocciaScope;
   HasSavedLoopState: Boolean;
   HeadCompleted, HeadYielding: Boolean;
   ShouldCloseIterator: Boolean;
@@ -2186,7 +2220,7 @@ begin
   Continuation := CurrentGeneratorContinuation;
   HasSavedLoopState := Assigned(Continuation) and
     Continuation.GetLoopState(AForAwaitOfStatement, SavedIteratorValue,
-      SavedCurrentValue, SavedNextMethod);
+      SavedCurrentValue, SavedNextMethod, SavedIterScope);
   if not HasSavedLoopState then
     IterableValue := EvaluateExpression(AForAwaitOfStatement.Iterable, AContext)
   else

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2186,6 +2186,7 @@ var
   SavedIterScope, SavedActiveScope: TGocciaScope;
   HasSavedLoopState: Boolean;
   HeadCompleted, HeadYielding: Boolean;
+  BodyYielding: Boolean;
   ShouldCloseIterator: Boolean;
 
   procedure CloseAsyncIterator(const AIter: TGocciaValue);
@@ -2293,12 +2294,14 @@ begin
 
         while True do
         begin
+          IterScope := nil;
           CheckExecutionTimeout;
           IncrementInstructionCounter;
           CheckInstructionLimit;
           if HasSavedLoopState then
           begin
             CurrentValue := SavedCurrentValue;
+            IterScope := SavedIterScope;
             HasSavedLoopState := False;
           end
           else
@@ -2319,76 +2322,96 @@ begin
             if not Assigned(CurrentValue) then
               CurrentValue := TGocciaUndefinedLiteralValue.UndefinedValue;
           end;
-          if Assigned(Continuation) then
+          if Assigned(Continuation) and not Assigned(IterScope) then
             Continuation.SaveLoopState(AForAwaitOfStatement, IteratorObj,
               CurrentValue, NextMethod);
 
-          HeadCompleted := False;
-          HeadYielding := False;
-          ShouldCloseIterator := True;
-          try
-            try
-              IterScope := AContext.Scope.CreateChild(skBlock);
-              IterContext := AContext;
+          if Assigned(IterScope) then
+          begin
+            IterContext := AContext;
+            if Assigned(SavedActiveScope) then
+              IterContext.Scope := SavedActiveScope
+            else
               IterContext.Scope := IterScope;
+            MatchBaseContext := AContext;
+            MatchBaseContext.Scope := IterScope;
+          end
+          else
+          begin
+            HeadCompleted := False;
+            HeadYielding := False;
+            ShouldCloseIterator := True;
+            try
+              try
+                IterScope := AContext.Scope.CreateChild(skBlock);
+                IterContext := AContext;
+                IterContext.Scope := IterScope;
 
-              if AForAwaitOfStatement.IsVar then
-              begin
-                if AForAwaitOfStatement.BindingPattern <> nil then
-                  AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue,
-                    IterContext)
-                else
-                  AContext.Scope.DefineVariableBinding(AForAwaitOfStatement.BindingName, CurrentValue, True);
-              end
-              else if AForAwaitOfStatement.BindingPattern <> nil then
-                AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
-              else
-                IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
-
-              if Assigned(AForAwaitOfStatement.MatchPattern) then
-              begin
-                MatchBaseContext := IterContext;
-                if not TryEvaluateMatchPatternInContext(CurrentValue,
-                   AForAwaitOfStatement.MatchPattern, IterContext, MatchContext) then
+                if AForAwaitOfStatement.IsVar then
                 begin
-                  if Assigned(Continuation) then
-                    Continuation.ClearLoopState(AForAwaitOfStatement);
-                  ShouldCloseIterator := False;
-                  Continue;
+                  if AForAwaitOfStatement.BindingPattern <> nil then
+                    AssignPattern(AForAwaitOfStatement.BindingPattern,
+                      CurrentValue, IterContext)
+                  else
+                    AContext.Scope.DefineVariableBinding(AForAwaitOfStatement.BindingName, CurrentValue, True);
+                end
+                else if AForAwaitOfStatement.BindingPattern <> nil then
+                  AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
+                else
+                  IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
+
+                if Assigned(AForAwaitOfStatement.MatchPattern) then
+                begin
+                  MatchBaseContext := IterContext;
+                  if not TryEvaluateMatchPatternInContext(CurrentValue,
+                     AForAwaitOfStatement.MatchPattern, IterContext, MatchContext) then
+                  begin
+                    if Assigned(Continuation) then
+                      Continuation.ClearLoopState(AForAwaitOfStatement);
+                    ShouldCloseIterator := False;
+                    Continue;
+                  end;
+                  IterContext := MatchContext;
                 end;
-                IterContext := MatchContext;
+                HeadCompleted := True;
+                if Assigned(Continuation) then
+                  Continuation.SaveLoopState(AForAwaitOfStatement, IteratorObj,
+                    CurrentValue, NextMethod, IterScope, IterContext.Scope);
+              except
+                on E: EGocciaGeneratorYield do
+                begin
+                  HeadYielding := True;
+                  raise;
+                end;
+                on E: Exception do
+                begin
+                  if ShouldCloseIterator then
+                    CloseAsyncIteratorPreservingError(IteratorObj);
+                  raise;
+                end;
               end;
-              HeadCompleted := True;
-            except
-              on E: EGocciaGeneratorYield do
+            finally
+              if (not HeadCompleted) and (not HeadYielding) and
+                 Assigned(Continuation) then
               begin
-                HeadYielding := True;
-                raise;
+                Continuation.ClearLoopState(AForAwaitOfStatement);
+                Continuation.ClearExpressionValues;
               end;
-              on E: Exception do
-              begin
-                if ShouldCloseIterator then
-                  CloseAsyncIteratorPreservingError(IteratorObj);
-                raise;
-              end;
-            end;
-          finally
-            if (not HeadCompleted) and (not HeadYielding) and
-               Assigned(Continuation) then
-            begin
-              Continuation.ClearLoopState(AForAwaitOfStatement);
-              Continuation.ClearExpressionValues;
             end;
           end;
 
           try
+            BodyYielding := False;
             try
               CF := EvaluateLoopBodyStatement(AForAwaitOfStatement.Body, IterContext);
               if Assigned(Continuation) then
                 Continuation.ClearLoopState(AForAwaitOfStatement);
             except
               on E: EGocciaGeneratorYield do
+              begin
+                BodyYielding := True;
                 raise;
+              end;
               else
               begin
                 if Assigned(Continuation) then
@@ -2398,7 +2421,7 @@ begin
               end;
             end;
           finally
-            if Assigned(AForAwaitOfStatement.MatchPattern) and
+            if (not BodyYielding) and Assigned(AForAwaitOfStatement.MatchPattern) and
                (IterContext.Scope <> IterScope) then
               ReleaseMatchContext(IterContext, MatchBaseContext);
           end;
@@ -2448,12 +2471,14 @@ begin
         GenericNextResult := Iterator.AdvanceNext;
       while True do
       begin
+        IterScope := nil;
         CheckExecutionTimeout;
         IncrementInstructionCounter;
         CheckInstructionLimit;
         if HasSavedLoopState then
         begin
           CurrentValue := SavedCurrentValue;
+          IterScope := SavedIterScope;
           HasSavedLoopState := False;
         end
         else
@@ -2463,77 +2488,97 @@ begin
           CurrentValue := GenericNextResult.GetProperty(PROP_VALUE);
           CurrentValue := AwaitValue(CurrentValue);
         end;
-        if Assigned(Continuation) then
+        if Assigned(Continuation) and not Assigned(IterScope) then
           Continuation.SaveLoopState(AForAwaitOfStatement, Iterator,
             CurrentValue);
 
-        HeadCompleted := False;
-        HeadYielding := False;
-        ShouldCloseIterator := True;
-        try
-          try
-            IterScope := AContext.Scope.CreateChild(skBlock);
-            IterContext := AContext;
+        if Assigned(IterScope) then
+        begin
+          IterContext := AContext;
+          if Assigned(SavedActiveScope) then
+            IterContext.Scope := SavedActiveScope
+          else
             IterContext.Scope := IterScope;
+          MatchBaseContext := AContext;
+          MatchBaseContext.Scope := IterScope;
+        end
+        else
+        begin
+          HeadCompleted := False;
+          HeadYielding := False;
+          ShouldCloseIterator := True;
+          try
+            try
+              IterScope := AContext.Scope.CreateChild(skBlock);
+              IterContext := AContext;
+              IterContext.Scope := IterScope;
 
-            if AForAwaitOfStatement.IsVar then
-            begin
-              if AForAwaitOfStatement.BindingPattern <> nil then
-                AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue,
-                  IterContext)
-              else
-                AContext.Scope.DefineVariableBinding(AForAwaitOfStatement.BindingName, CurrentValue, True);
-            end
-            else if AForAwaitOfStatement.BindingPattern <> nil then
-              AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
-            else
-              IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
-
-            if Assigned(AForAwaitOfStatement.MatchPattern) then
-            begin
-              MatchBaseContext := IterContext;
-              if not TryEvaluateMatchPatternInContext(CurrentValue,
-                 AForAwaitOfStatement.MatchPattern, IterContext, MatchContext) then
+              if AForAwaitOfStatement.IsVar then
               begin
-                if Assigned(Continuation) then
-                  Continuation.ClearLoopState(AForAwaitOfStatement);
-                ShouldCloseIterator := False;
-                GenericNextResult := Iterator.AdvanceNext;
-                Continue;
+                if AForAwaitOfStatement.BindingPattern <> nil then
+                  AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue,
+                    IterContext)
+                else
+                  AContext.Scope.DefineVariableBinding(AForAwaitOfStatement.BindingName, CurrentValue, True);
+              end
+              else if AForAwaitOfStatement.BindingPattern <> nil then
+                AssignPattern(AForAwaitOfStatement.BindingPattern, CurrentValue, IterContext, True, DeclarationType)
+              else
+                IterScope.DefineLexicalBinding(AForAwaitOfStatement.BindingName, CurrentValue, DeclarationType);
+
+              if Assigned(AForAwaitOfStatement.MatchPattern) then
+              begin
+                MatchBaseContext := IterContext;
+                if not TryEvaluateMatchPatternInContext(CurrentValue,
+                   AForAwaitOfStatement.MatchPattern, IterContext, MatchContext) then
+                begin
+                  if Assigned(Continuation) then
+                    Continuation.ClearLoopState(AForAwaitOfStatement);
+                  ShouldCloseIterator := False;
+                  GenericNextResult := Iterator.AdvanceNext;
+                  Continue;
+                end;
+                IterContext := MatchContext;
               end;
-              IterContext := MatchContext;
+              HeadCompleted := True;
+              if Assigned(Continuation) then
+                Continuation.SaveLoopState(AForAwaitOfStatement, Iterator,
+                  CurrentValue, nil, IterScope, IterContext.Scope);
+            except
+              on E: EGocciaGeneratorYield do
+              begin
+                HeadYielding := True;
+                raise;
+              end;
+              on E: Exception do
+              begin
+                if ShouldCloseIterator then
+                  Goccia.Values.IteratorSupport.CloseIteratorPreservingError(Iterator);
+                raise;
+              end;
             end;
-            HeadCompleted := True;
-          except
-            on E: EGocciaGeneratorYield do
+          finally
+            if (not HeadCompleted) and (not HeadYielding) and
+               Assigned(Continuation) then
             begin
-              HeadYielding := True;
-              raise;
+              Continuation.ClearLoopState(AForAwaitOfStatement);
+              Continuation.ClearExpressionValues;
             end;
-            on E: Exception do
-            begin
-              if ShouldCloseIterator then
-                Goccia.Values.IteratorSupport.CloseIteratorPreservingError(Iterator);
-              raise;
-            end;
-          end;
-        finally
-          if (not HeadCompleted) and (not HeadYielding) and
-             Assigned(Continuation) then
-          begin
-            Continuation.ClearLoopState(AForAwaitOfStatement);
-            Continuation.ClearExpressionValues;
           end;
         end;
 
         try
+          BodyYielding := False;
           try
             CF := EvaluateLoopBodyStatement(AForAwaitOfStatement.Body, IterContext);
             if Assigned(Continuation) then
               Continuation.ClearLoopState(AForAwaitOfStatement);
           except
             on E: EGocciaGeneratorYield do
+            begin
+              BodyYielding := True;
               raise;
+            end;
             else
             begin
               if Assigned(Continuation) then
@@ -2543,7 +2588,7 @@ begin
             end;
           end;
         finally
-          if Assigned(AForAwaitOfStatement.MatchPattern) and
+          if (not BodyYielding) and Assigned(AForAwaitOfStatement.MatchPattern) and
              (IterContext.Scope <> IterScope) then
             ReleaseMatchContext(IterContext, MatchBaseContext);
         end;

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -39,10 +39,11 @@ type
     IteratorValue: TGocciaValue;
     CurrentValue: TGocciaValue;
     NextMethod: TGocciaValue;
+    IterScope: TGocciaScope;
     constructor Create(const AIteratorValue, ACurrentValue,
-      ANextMethod: TGocciaValue);
+      ANextMethod: TGocciaValue; const AIterScope: TGocciaScope = nil);
     procedure Assign(const AIteratorValue, ACurrentValue,
-      ANextMethod: TGocciaValue);
+      ANextMethod: TGocciaValue; const AIterScope: TGocciaScope = nil);
     procedure MarkReferences;
   end;
 
@@ -50,8 +51,10 @@ type
   // for(init; test; update) loops. Phase records which sub-step suspended so
   // a resume picks up there instead of re-entering Init from the top.
   TGocciaGeneratorForLoopPhase = (
-    gflpIterStart,  // Between iterations: snapshot HeaderScope, create IterScope, evaluate test
-    gflpBody,       // Test passed and IterScope is committed; body is mid-execution
+    gflpInit,       // Init is mid-execution
+    gflpIterStart,  // Between iterations: snapshot HeaderScope and create IterScope
+    gflpTest,       // IterScope is committed and the test is mid-execution
+    gflpBody,       // Test passed and body is mid-execution
     gflpUpdate      // Body completed and IterScope was synced back; update is mid-execution
   );
 
@@ -59,7 +62,7 @@ type
   public
     Phase: TGocciaGeneratorForLoopPhase;
     HeaderScope: TGocciaScope;  // nil for non-lexical for-loops
-    IterScope: TGocciaScope;    // non-nil only while Phase = gflpBody and loop is lexical
+    IterScope: TGocciaScope;    // non-nil while test/body is active for lexical loops
     constructor Create(const AHeaderScope: TGocciaScope);
     procedure MarkReferences;
   end;
@@ -129,9 +132,11 @@ type
     procedure ClearTryStates;
     procedure SaveLoopState(const ALoopStatement: TObject;
       const AIteratorValue, ACurrentValue: TGocciaValue;
-      const ANextMethod: TGocciaValue = nil);
+      const ANextMethod: TGocciaValue = nil;
+      const AIterScope: TGocciaScope = nil);
     function GetLoopState(const ALoopStatement: TObject;
-      out AIteratorValue, ACurrentValue, ANextMethod: TGocciaValue): Boolean;
+      out AIteratorValue, ACurrentValue, ANextMethod: TGocciaValue;
+      out AIterScope: TGocciaScope): Boolean;
     procedure ClearLoopState(const ALoopStatement: TObject);
     procedure ClearLoopStates;
     function EnsureForLoopState(const ALoopStatement: TObject;
@@ -144,6 +149,9 @@ type
   end;
 
 function CurrentGeneratorContinuation: TGocciaGeneratorContinuation;
+function SuspendCurrentGeneratorContinuation: TGocciaGeneratorContinuation;
+procedure RestoreCurrentGeneratorContinuation(
+  const AContinuation: TGocciaGeneratorContinuation);
 function EvaluateGeneratorYield(const AYieldExpression: TGocciaYieldExpression;
   const AContext: TGocciaEvaluationContext): TGocciaValue;
 
@@ -202,18 +210,19 @@ begin
 end;
 
 constructor TGocciaGeneratorLoopState.Create(const AIteratorValue,
-  ACurrentValue, ANextMethod: TGocciaValue);
+  ACurrentValue, ANextMethod: TGocciaValue; const AIterScope: TGocciaScope);
 begin
   inherited Create;
-  Assign(AIteratorValue, ACurrentValue, ANextMethod);
+  Assign(AIteratorValue, ACurrentValue, ANextMethod, AIterScope);
 end;
 
 procedure TGocciaGeneratorLoopState.Assign(const AIteratorValue,
-  ACurrentValue, ANextMethod: TGocciaValue);
+  ACurrentValue, ANextMethod: TGocciaValue; const AIterScope: TGocciaScope);
 begin
   IteratorValue := AIteratorValue;
   CurrentValue := ACurrentValue;
   NextMethod := ANextMethod;
+  IterScope := AIterScope;
 end;
 
 procedure TGocciaGeneratorLoopState.MarkReferences;
@@ -224,6 +233,8 @@ begin
     CurrentValue.MarkReferences;
   if Assigned(NextMethod) then
     NextMethod.MarkReferences;
+  if Assigned(IterScope) then
+    IterScope.MarkReferences;
 end;
 
 constructor TGocciaGeneratorForLoopState.Create(const AHeaderScope: TGocciaScope);
@@ -1033,21 +1044,22 @@ end;
 
 procedure TGocciaGeneratorContinuation.SaveLoopState(
   const ALoopStatement: TObject; const AIteratorValue,
-  ACurrentValue: TGocciaValue; const ANextMethod: TGocciaValue);
+  ACurrentValue: TGocciaValue; const ANextMethod: TGocciaValue;
+  const AIterScope: TGocciaScope);
 var
   LoopState: TGocciaGeneratorLoopState;
 begin
   if FLoopStates.TryGetValue(ALoopStatement, LoopState) then
-    LoopState.Assign(AIteratorValue, ACurrentValue, ANextMethod)
+    LoopState.Assign(AIteratorValue, ACurrentValue, ANextMethod, AIterScope)
   else
     FLoopStates.Add(ALoopStatement,
       TGocciaGeneratorLoopState.Create(AIteratorValue, ACurrentValue,
-        ANextMethod));
+        ANextMethod, AIterScope));
 end;
 
 function TGocciaGeneratorContinuation.GetLoopState(
   const ALoopStatement: TObject; out AIteratorValue, ACurrentValue,
-  ANextMethod: TGocciaValue): Boolean;
+  ANextMethod: TGocciaValue; out AIterScope: TGocciaScope): Boolean;
 var
   LoopState: TGocciaGeneratorLoopState;
 begin
@@ -1057,12 +1069,14 @@ begin
     AIteratorValue := LoopState.IteratorValue;
     ACurrentValue := LoopState.CurrentValue;
     ANextMethod := LoopState.NextMethod;
+    AIterScope := LoopState.IterScope;
   end
   else
   begin
     AIteratorValue := nil;
     ACurrentValue := nil;
     ANextMethod := nil;
+    AIterScope := nil;
   end;
 end;
 
@@ -1158,6 +1172,18 @@ end;
 function CurrentGeneratorContinuation: TGocciaGeneratorContinuation;
 begin
   Result := GCurrentContinuation;
+end;
+
+function SuspendCurrentGeneratorContinuation: TGocciaGeneratorContinuation;
+begin
+  Result := GCurrentContinuation;
+  GCurrentContinuation := nil;
+end;
+
+procedure RestoreCurrentGeneratorContinuation(
+  const AContinuation: TGocciaGeneratorContinuation);
+begin
+  GCurrentContinuation := AContinuation;
 end;
 
 function EvaluateGeneratorYield(const AYieldExpression: TGocciaYieldExpression;

--- a/source/units/Goccia.Runtime.GeneratorContinuation.pas
+++ b/source/units/Goccia.Runtime.GeneratorContinuation.pas
@@ -40,10 +40,13 @@ type
     CurrentValue: TGocciaValue;
     NextMethod: TGocciaValue;
     IterScope: TGocciaScope;
+    ActiveScope: TGocciaScope;
     constructor Create(const AIteratorValue, ACurrentValue,
-      ANextMethod: TGocciaValue; const AIterScope: TGocciaScope = nil);
+      ANextMethod: TGocciaValue; const AIterScope: TGocciaScope = nil;
+      const AActiveScope: TGocciaScope = nil);
     procedure Assign(const AIteratorValue, ACurrentValue,
-      ANextMethod: TGocciaValue; const AIterScope: TGocciaScope = nil);
+      ANextMethod: TGocciaValue; const AIterScope: TGocciaScope = nil;
+      const AActiveScope: TGocciaScope = nil);
     procedure MarkReferences;
   end;
 
@@ -133,10 +136,11 @@ type
     procedure SaveLoopState(const ALoopStatement: TObject;
       const AIteratorValue, ACurrentValue: TGocciaValue;
       const ANextMethod: TGocciaValue = nil;
-      const AIterScope: TGocciaScope = nil);
+      const AIterScope: TGocciaScope = nil;
+      const AActiveScope: TGocciaScope = nil);
     function GetLoopState(const ALoopStatement: TObject;
       out AIteratorValue, ACurrentValue, ANextMethod: TGocciaValue;
-      out AIterScope: TGocciaScope): Boolean;
+      out AIterScope, AActiveScope: TGocciaScope): Boolean;
     procedure ClearLoopState(const ALoopStatement: TObject);
     procedure ClearLoopStates;
     function EnsureForLoopState(const ALoopStatement: TObject;
@@ -210,19 +214,22 @@ begin
 end;
 
 constructor TGocciaGeneratorLoopState.Create(const AIteratorValue,
-  ACurrentValue, ANextMethod: TGocciaValue; const AIterScope: TGocciaScope);
+  ACurrentValue, ANextMethod: TGocciaValue; const AIterScope: TGocciaScope;
+  const AActiveScope: TGocciaScope);
 begin
   inherited Create;
-  Assign(AIteratorValue, ACurrentValue, ANextMethod, AIterScope);
+  Assign(AIteratorValue, ACurrentValue, ANextMethod, AIterScope, AActiveScope);
 end;
 
 procedure TGocciaGeneratorLoopState.Assign(const AIteratorValue,
-  ACurrentValue, ANextMethod: TGocciaValue; const AIterScope: TGocciaScope);
+  ACurrentValue, ANextMethod: TGocciaValue; const AIterScope: TGocciaScope;
+  const AActiveScope: TGocciaScope);
 begin
   IteratorValue := AIteratorValue;
   CurrentValue := ACurrentValue;
   NextMethod := ANextMethod;
   IterScope := AIterScope;
+  ActiveScope := AActiveScope;
 end;
 
 procedure TGocciaGeneratorLoopState.MarkReferences;
@@ -235,6 +242,8 @@ begin
     NextMethod.MarkReferences;
   if Assigned(IterScope) then
     IterScope.MarkReferences;
+  if Assigned(ActiveScope) then
+    ActiveScope.MarkReferences;
 end;
 
 constructor TGocciaGeneratorForLoopState.Create(const AHeaderScope: TGocciaScope);
@@ -1045,21 +1054,22 @@ end;
 procedure TGocciaGeneratorContinuation.SaveLoopState(
   const ALoopStatement: TObject; const AIteratorValue,
   ACurrentValue: TGocciaValue; const ANextMethod: TGocciaValue;
-  const AIterScope: TGocciaScope);
+  const AIterScope: TGocciaScope; const AActiveScope: TGocciaScope);
 var
   LoopState: TGocciaGeneratorLoopState;
 begin
   if FLoopStates.TryGetValue(ALoopStatement, LoopState) then
-    LoopState.Assign(AIteratorValue, ACurrentValue, ANextMethod, AIterScope)
+    LoopState.Assign(AIteratorValue, ACurrentValue, ANextMethod,
+      AIterScope, AActiveScope)
   else
     FLoopStates.Add(ALoopStatement,
       TGocciaGeneratorLoopState.Create(AIteratorValue, ACurrentValue,
-        ANextMethod, AIterScope));
+        ANextMethod, AIterScope, AActiveScope));
 end;
 
 function TGocciaGeneratorContinuation.GetLoopState(
   const ALoopStatement: TObject; out AIteratorValue, ACurrentValue,
-  ANextMethod: TGocciaValue; out AIterScope: TGocciaScope): Boolean;
+  ANextMethod: TGocciaValue; out AIterScope, AActiveScope: TGocciaScope): Boolean;
 var
   LoopState: TGocciaGeneratorLoopState;
 begin
@@ -1070,6 +1080,7 @@ begin
     ACurrentValue := LoopState.CurrentValue;
     ANextMethod := LoopState.NextMethod;
     AIterScope := LoopState.IterScope;
+    AActiveScope := LoopState.ActiveScope;
   end
   else
   begin
@@ -1077,6 +1088,7 @@ begin
     ACurrentValue := nil;
     ANextMethod := nil;
     AIterScope := nil;
+    AActiveScope := nil;
   end;
 end;
 

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -601,10 +601,16 @@ function CallCompareFunc(const ACompareFunc: TGocciaFunctionBase; const ACallArg
   const A, B: TGocciaValue; const AThisValue: TGocciaValue): Double;
 var
   CompResult: TGocciaNumberLiteralValue;
+  PreviousContinuation: TGocciaGeneratorContinuation;
 begin
   ACallArgs.SetElement(0, A);
   ACallArgs.SetElement(1, B);
-  CompResult := ACompareFunc.Call(ACallArgs, AThisValue).ToNumberLiteral;
+  PreviousContinuation := SuspendCurrentGeneratorContinuation;
+  try
+    CompResult := ACompareFunc.Call(ACallArgs, AThisValue).ToNumberLiteral;
+  finally
+    RestoreCurrentGeneratorContinuation(PreviousContinuation);
+  end;
 
   if CompResult.IsNaN then
     Result := 0
@@ -1067,10 +1073,8 @@ begin
         CallArgs.Accumulator := Accumulator;
         CallArgs.Element := View.Get64(Sparse[J]);
         CallArgs.Index := TGocciaNumberLiteralValue.Create(Int64ToDouble(Sparse[J]));
-        if Assigned(TypedCallback) then
-          Accumulator := TypedCallback.Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue)
-        else
-          Accumulator := InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+        Accumulator := InvokeArrayCallback(Callback, TypedCallback, CallArgs,
+          TGocciaUndefinedLiteralValue.UndefinedValue);
       end;
     finally
       CallArgs.Free;
@@ -1113,10 +1117,8 @@ begin
       CallArgs.Accumulator := Accumulator;
       CallArgs.Element := View.Get(I);
       CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
-      if Assigned(TypedCallback) then
-        Accumulator := TypedCallback.Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue)
-      else
-        Accumulator := InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+      Accumulator := InvokeArrayCallback(Callback, TypedCallback, CallArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue);
     end;
   finally
     CallArgs.Free;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -119,6 +119,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Realm,
+  Goccia.Runtime.GeneratorContinuation,
   Goccia.Timeout,
   Goccia.Utils,
   Goccia.Utils.Arrays,
@@ -226,11 +227,18 @@ function InvokeArrayCallback(const ACallback: TGocciaValue;
   const ATypedCallback: TGocciaFunctionBase;
   const ACallArgs: TGocciaArgumentsCollection;
   const AThisArg: TGocciaValue): TGocciaValue; inline;
+var
+  PreviousContinuation: TGocciaGeneratorContinuation;
 begin
-  if Assigned(ATypedCallback) then
-    Result := ATypedCallback.Call(ACallArgs, AThisArg)
-  else
-    Result := InvokeCallable(ACallback, ACallArgs, AThisArg);
+  PreviousContinuation := SuspendCurrentGeneratorContinuation;
+  try
+    if Assigned(ATypedCallback) then
+      Result := ATypedCallback.Call(ACallArgs, AThisArg)
+    else
+      Result := InvokeCallable(ACallback, ACallArgs, AThisArg);
+  finally
+    RestoreCurrentGeneratorContinuation(PreviousContinuation);
+  end;
 end;
 
 

--- a/tests/language/for-loop/generator-yield-body.js
+++ b/tests/language/for-loop/generator-yield-body.js
@@ -123,6 +123,44 @@ test("closures captured in yielded body pin per-iteration binding", () => {
   expect(g.next()).toEqual({ value: [0, 1, 2], done: true });
 });
 
+test("array reduce callbacks do not reuse generator replay values", () => {
+  const obj = {
+    *gen() {
+      const fns = [];
+      for (let i = 0; i < 3; i++) {
+        fns.push(() => i);
+        yield i;
+      }
+      return fns.reduce((acc, fn) => acc.concat(fn()), []);
+    },
+  };
+
+  const g = obj.gen();
+  expect(g.next().value).toBe(0);
+  expect(g.next().value).toBe(1);
+  expect(g.next().value).toBe(2);
+  expect(g.next()).toEqual({ value: [0, 1, 2], done: true });
+});
+
+test("array sort callbacks do not reuse generator replay values", () => {
+  const obj = {
+    *gen() {
+      const fns = [];
+      for (let i = 2; i >= 0; i--) {
+        fns.push(() => i);
+        yield i;
+      }
+      return fns.sort((a, b) => a() - b()).map((fn) => fn());
+    },
+  };
+
+  const g = obj.gen();
+  expect(g.next().value).toBe(2);
+  expect(g.next().value).toBe(1);
+  expect(g.next().value).toBe(0);
+  expect(g.next()).toEqual({ value: [0, 1, 2], done: true });
+});
+
 test("comma-separated init bindings advance per iteration", () => {
   const g = factory.commaInit();
   expect(g.next().value).toEqual([0, 10]);

--- a/tests/language/for-loop/generator-yield-body.js
+++ b/tests/language/for-loop/generator-yield-body.js
@@ -104,6 +104,25 @@ test("body with multiple statements before yield", () => {
   expect(g.next()).toEqual({ value: [0, 1, 2], done: true });
 });
 
+test("closures captured in yielded body pin per-iteration binding", () => {
+  const obj = {
+    *gen() {
+      const fns = [];
+      for (let i = 0; i < 3; i++) {
+        fns.push(() => i);
+        yield i;
+      }
+      return fns.map((fn) => fn());
+    },
+  };
+
+  const g = obj.gen();
+  expect(g.next().value).toBe(0);
+  expect(g.next().value).toBe(1);
+  expect(g.next().value).toBe(2);
+  expect(g.next()).toEqual({ value: [0, 1, 2], done: true });
+});
+
 test("comma-separated init bindings advance per iteration", () => {
   const g = factory.commaInit();
   expect(g.next().value).toEqual([0, 10]);

--- a/tests/language/for-loop/generator-yield-condition.js
+++ b/tests/language/for-loop/generator-yield-condition.js
@@ -41,3 +41,20 @@ test("body side effects accumulate across condition-yield resumes", () => {
   expect(g.next().value).toBe(3);
   expect(g.next()).toEqual({ value: [0, 1, 2], done: true });
 });
+
+test("closure captured before yield in condition pins active iteration binding", () => {
+  const obj = {
+    *gen() {
+      let snap;
+      for (let i = 0; (snap = () => i, yield "condition", i < 1); i++) {
+        yield snap();
+      }
+    },
+  };
+
+  const g = obj.gen();
+  expect(g.next().value).toBe("condition");
+  expect(g.next().value).toBe(0);
+  expect(g.next().value).toBe("condition");
+  expect(g.next().done).toBe(true);
+});

--- a/tests/language/for-loop/generator-yield-init.js
+++ b/tests/language/for-loop/generator-yield-init.js
@@ -42,3 +42,34 @@ test("yield in multi-binding init", () => {
   expect(g.next().value).toEqual([1, 99]);
   expect(g.next().done).toBe(true);
 });
+
+test("closure captured before yield in init pins resumed header binding", () => {
+  const obj = {
+    *gen() {
+      let snap;
+      for (let i = (snap = () => i, yield "init"); i < 1; i++) {
+        yield snap();
+      }
+    },
+  };
+
+  const g = obj.gen();
+  expect(g.next().value).toBe("init");
+  expect(g.next(0).value).toBe(0);
+  expect(g.next().done).toBe(true);
+});
+
+test("yield in later init binding resumes without redeclaring prior bindings", () => {
+  const obj = {
+    *gen() {
+      for (let i = 1, j = yield "mid", k = 3; j < 1; j++) {
+        yield [i, j, k];
+      }
+    },
+  };
+
+  const g = obj.gen();
+  expect(g.next().value).toBe("mid");
+  expect(g.next(0).value).toEqual([1, 0, 3]);
+  expect(g.next().done).toBe(true);
+});

--- a/tests/language/for-of/for-await-of.js
+++ b/tests/language/for-of/for-await-of.js
@@ -358,6 +358,59 @@ describe("for-await-of", () => {
     expect(chars).toEqual(["a", "b", "c"]);
   });
 
+  test("async generator for-await-of async iterator resumes with pattern bindings after body yield", async () => {
+    const asyncIterable = {
+      [Symbol.asyncIterator]() {
+        const values = [{ x: 1 }, { y: 2 }, { x: 3 }];
+        let i = 0;
+        return {
+          next() {
+            if (i < values.length) {
+              const value = values[i];
+              i = i + 1;
+              return Promise.resolve({ value, done: false });
+            }
+            return Promise.resolve({ value: undefined, done: true });
+          }
+        };
+      }
+    };
+
+    const obj = {
+      async *values() {
+        const fns = [];
+        for await (const item is { x: const x } of asyncIterable) {
+          yield x;
+          fns.push(() => x);
+        }
+        return fns.map((fn) => fn());
+      },
+    };
+
+    const iter = obj.values();
+    expect(await iter.next()).toEqual({ value: 1, done: false });
+    expect(await iter.next()).toEqual({ value: 3, done: false });
+    expect(await iter.next()).toEqual({ value: [1, 3], done: true });
+  });
+
+  test("async generator for-await-of sync fallback resumes with pattern bindings after body yield", async () => {
+    const obj = {
+      async *values() {
+        const fns = [];
+        for await (const item is { x: const x } of [{ x: 1 }, { y: 2 }, { x: 3 }]) {
+          yield x;
+          fns.push(() => x);
+        }
+        return fns.map((fn) => fn());
+      },
+    };
+
+    const iter = obj.values();
+    expect(await iter.next()).toEqual({ value: 1, done: false });
+    expect(await iter.next()).toEqual({ value: 3, done: false });
+    expect(await iter.next()).toEqual({ value: [1, 3], done: true });
+  });
+
   test("calls async iterator return on break and awaits result", async () => {
     const log = [];
     const asyncIter = {

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -132,6 +132,25 @@ test("object generator method preserves for-of iterator across yielded loop body
   expect(iter.next()).toEqual({ value: undefined, done: true });
 });
 
+test("object generator method keeps for-of body closure bindings across yields", () => {
+  const obj = {
+    *values() {
+      const fns = [];
+      for (const n of [1, 2, 3]) {
+        fns.push(() => n);
+        yield n;
+      }
+      return fns.map((fn) => fn());
+    },
+  };
+
+  const iter = obj.values();
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(iter.next()).toEqual({ value: 2, done: false });
+  expect(iter.next()).toEqual({ value: 3, done: false });
+  expect(iter.next()).toEqual({ value: [1, 2, 3], done: true });
+});
+
 test("object generator method preserves for-of iterator across yielded loop head", () => {
   const obj = {
     *values() {

--- a/tests/language/pattern-matching/integration.js
+++ b/tests/language/pattern-matching/integration.js
@@ -21,6 +21,24 @@ describe("pattern matching integrations", () => {
     expect(() => new Function("for (const item is _ items) {}")).toThrow();
   });
 
+  test("generator for-of resumes with pattern bindings after body yield", () => {
+    const obj = {
+      *values() {
+        const fns = [];
+        for (const item is { x: const x } of [{ x: 1 }, { y: 2 }, { x: 3 }]) {
+          yield x;
+          fns.push(() => x);
+        }
+        return fns.map((fn) => fn());
+      },
+    };
+
+    const iter = obj.values();
+    expect(iter.next()).toEqual({ value: 1, done: false });
+    expect(iter.next()).toEqual({ value: 3, done: false });
+    expect(iter.next()).toEqual({ value: [1, 3], done: true });
+  });
+
   test("for-await-of filters awaited iterations", () => {
     const fn = async () => {
       const seen = [];


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Preserve generator resume state for lexical `for` init/test/body phases and `for-of` iteration scopes so closures keep the correct per-iteration binding after yields.
- Resume multi-binding `let` declarations inside generator loop headers without redeclaring already-completed bindings.
- Isolate native array callback invocation from parent generator replay state so callback expression caches do not leak across `map`/callback iterations.
- Closes #634.
- Closes #637.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Commands run:

- `./format.pas --check`
- `./build.pas clean testrunner`
- `./build/GocciaTestRunner tests/language/for-loop/generator-yield-body.js tests/language/for-loop/generator-yield-init.js tests/language/for-loop/generator-yield-condition.js tests/language/generators/object-method.js --asi --compat-traditional-for-loop --unsafe-ffi --no-progress`
- `./build/GocciaTestRunner tests/language/for-loop/generator-yield-body.js tests/language/for-loop/generator-yield-init.js tests/language/for-loop/generator-yield-condition.js tests/language/generators/object-method.js --asi --compat-traditional-for-loop --unsafe-ffi --mode=bytecode --no-progress`
- `./build/GocciaTestRunner tests/language/for-loop tests/language/generators/object-method.js tests/language/for-of --asi --compat-traditional-for-loop --unsafe-ffi --no-progress`
- `./build/GocciaTestRunner tests/language/for-loop tests/language/generators/object-method.js tests/language/for-of --asi --compat-traditional-for-loop --unsafe-ffi --mode=bytecode --no-progress`
- `./build.pas`
- `./fixtures/ffi/build.sh`
- `./build/GocciaTestRunner tests --asi --unsafe-ffi`