### PR TITLE
Fix TypedArray detach-safe element access

### DIFF
--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -278,6 +278,7 @@ resourcestring
 
   // TypedArray errors
   SErrorTypedArrayRequiresTypedArray = '%s requires a TypedArray';
+  SErrorCannotUseDetachedTypedArray = '%s cannot be used with a detached ArrayBuffer';
   SErrorTypedArraySetRequiresArg = 'TypedArray.prototype.set requires at least one argument';
   SErrorTypedArraySetOffsetNonNegative = 'TypedArray.prototype.set offset must be >= 0';
   SErrorTypedArraySetArgType = 'TypedArray.prototype.set argument must be an array or typed array';

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -153,6 +153,7 @@ implementation
 uses
   Math,
 
+  Goccia.Arithmetic,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
@@ -934,7 +935,12 @@ begin
   if AName = PROP_BYTE_LENGTH then
     Exit(TGocciaNumberLiteralValue.Create(GetLength * BytesPerElement(FKind)));
   if AName = PROP_BYTE_OFFSET then
+  begin
+    if (FBufferValue is TGocciaArrayBufferValue) and
+       TGocciaArrayBufferValue(FBufferValue).Detached then
+      Exit(TGocciaNumberLiteralValue.Create(0));
     Exit(TGocciaNumberLiteralValue.Create(FByteOffset));
+  end;
   if AName = PROP_BUFFER then
     Exit(FBufferValue);
   if AName = PROP_BYTES_PER_ELEMENT then
@@ -1098,6 +1104,24 @@ begin
   Result := TGocciaTypedArrayValue(AThisValue);
 end;
 
+function IsDetachedTypedArray(const AArray: TGocciaTypedArrayValue): Boolean;
+begin
+  Result := (AArray.FBufferValue is TGocciaArrayBufferValue) and
+    TGocciaArrayBufferValue(AArray.FBufferValue).Detached;
+end;
+
+procedure EnsureTypedArrayAttached(const AArray: TGocciaTypedArrayValue; const AMethod: string);
+begin
+  if IsDetachedTypedArray(AArray) then
+    ThrowTypeError(Format(SErrorCannotUseDetachedTypedArray, [AMethod]), SSuggestArrayBufferDetached);
+end;
+
+function RequireAttachedTypedArray(const AThisValue: TGocciaValue; const AMethod: string): TGocciaTypedArrayValue;
+begin
+  Result := RequireTypedArray(AThisValue, AMethod);
+  EnsureTypedArrayAttached(Result, AMethod);
+end;
+
 function ToIntegerOrInfinityBounded(const AValue: TGocciaValue): Integer;
 var
   Num: TGocciaNumberLiteralValue;
@@ -1154,8 +1178,13 @@ begin
 end;
 
 function TGocciaTypedArrayValue.TypedArrayByteOffsetGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  TA: TGocciaTypedArrayValue;
 begin
-  Result := TGocciaNumberLiteralValue.Create(RequireTypedArray(AThisValue, 'TypedArray.prototype.byteOffset').FByteOffset);
+  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.byteOffset');
+  if IsDetachedTypedArray(TA) then
+    Exit(TGocciaNumberLiteralValue.Create(0));
+  Result := TGocciaNumberLiteralValue.Create(TA.FByteOffset);
 end;
 
 function TGocciaTypedArrayValue.TypedArrayLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -1179,7 +1208,7 @@ var
   TA: TGocciaTypedArrayValue;
   RelIndex, ActualIndex: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.at');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.at');
   if AArgs.Length = 0 then
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
   RelIndex := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
@@ -1200,7 +1229,7 @@ var
   FillBigInt: Int64;
   First, Final, I, RelStart, RelEnd: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.fill');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.fill');
   FillBigInt := 0;
   FillNum := nil;
   if IsBigIntKind(TA.FKind) then
@@ -1241,6 +1270,8 @@ begin
   else
     Final := TA.FLength;
 
+  EnsureTypedArrayAttached(TA, 'TypedArray.prototype.fill');
+
   if IsBigIntKind(TA.FKind) then
   begin
     for I := First to Final - 1 do
@@ -1262,7 +1293,7 @@ var
   BPE: Integer;
   TempBuf: TBytes;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.copyWithin');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.copyWithin');
   if AArgs.Length < 2 then
     Exit(AThisValue);
 
@@ -1283,6 +1314,7 @@ begin
   Count := Min(Final - Start, TA.FLength - Target);
   if Count <= 0 then
     Exit(AThisValue);
+  EnsureTypedArrayAttached(TA, 'TypedArray.prototype.copyWithin');
 
   BPE := BytesPerElement(TA.FKind);
   SetLength(TempBuf, Count * BPE);
@@ -1300,7 +1332,7 @@ var
   TA, NewTA: TGocciaTypedArrayValue;
   First, Final, NewLen, I: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.slice');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.slice');
 
   if AArgs.Length > 0 then
   begin
@@ -1359,6 +1391,8 @@ begin
     EndIdx := TA.FLength;
 
   NewLen := Max(EndIdx - BeginIdx, 0);
+  if NewLen > 0 then
+    EnsureTypedArrayAttached(TA, 'TypedArray.prototype.subarray');
   if TA.FBufferValue is TGocciaSharedArrayBufferValue then
     Result := TGocciaTypedArrayValue.Create(TA.FKind, TGocciaSharedArrayBufferValue(TA.FBufferValue), TA.FByteOffset + BeginIdx * BPE, NewLen)
   else
@@ -1387,9 +1421,12 @@ begin
   else
     TargetOffset := 0;
 
+  EnsureTypedArrayAttached(TA, 'TypedArray.prototype.set');
+
   if AArgs.GetElement(0) is TGocciaTypedArrayValue then
   begin
     SrcTA := TGocciaTypedArrayValue(AArgs.GetElement(0));
+    EnsureTypedArrayAttached(SrcTA, 'TypedArray.prototype.set');
     if (TargetOffset > TA.FLength) or
        (SrcTA.FLength > TA.FLength - TargetOffset) then
       ThrowRangeError(SErrorTypedArraySourceTooLarge, SSuggestTypedArrayLength);
@@ -1439,7 +1476,7 @@ var
   Tmp: Double;
   TmpBig: Int64;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.reverse');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.reverse');
   if IsBigIntKind(TA.FKind) then
   begin
     for I := 0 to (TA.FLength div 2) - 1 do
@@ -1476,7 +1513,7 @@ var
   ZeroJBits: Int64 absolute ZeroJ;
   TmpZeroBits: Int64 absolute Tmp;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.sort');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.sort');
   HasCompare := (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable;
   SortLen := TA.FLength;
 
@@ -1624,12 +1661,10 @@ end;
 function TGocciaTypedArrayValue.TypedArrayIndexOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  SearchNum: TGocciaNumberLiteralValue;
-  SearchVal: Double;
-  SearchBigInt: Int64;
+  SearchValue: TGocciaValue;
   I, StartIdx: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.indexOf');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.indexOf');
   if TA.FLength = 0 then
     Exit(TGocciaNumberLiteralValue.Create(-1));
   if AArgs.Length = 0 then
@@ -1643,35 +1678,12 @@ begin
   else
     StartIdx := 0;
 
-  if IsBigIntKind(TA.FKind) then
-  begin
-    if not (AArgs.GetElement(0) is TGocciaBigIntValue) then
-      Exit(TGocciaNumberLiteralValue.Create(-1));
-    SearchBigInt := TGocciaBigIntValue(AArgs.GetElement(0)).Value.ToInt64;
-    for I := StartIdx to TA.FLength - 1 do
-      if TA.ReadBigIntElement(I) = SearchBigInt then
-        Exit(TGocciaNumberLiteralValue.Create(I));
+  if IsDetachedTypedArray(TA) then
     Exit(TGocciaNumberLiteralValue.Create(-1));
-  end;
 
-  SearchNum := AArgs.GetElement(0).ToNumberLiteral;
-  // ES2026: indexOf uses strict equality — NaN !== NaN
-  if SearchNum.IsNaN then
-    Exit(TGocciaNumberLiteralValue.Create(-1));
-  if SearchNum.IsInfinite then
-  begin
-    if not (IsFloatKind(TA.FKind)) then
-      Exit(TGocciaNumberLiteralValue.Create(-1));
-    for I := StartIdx to TA.FLength - 1 do
-      if Math.IsInfinite(TA.ReadElement(I)) and
-         ((SearchNum.IsInfinity and (TA.ReadElement(I) > 0)) or
-          (SearchNum.IsNegativeInfinity and (TA.ReadElement(I) < 0))) then
-        Exit(TGocciaNumberLiteralValue.Create(I));
-    Exit(TGocciaNumberLiteralValue.Create(-1));
-  end;
-  SearchVal := SearchNum.Value;
+  SearchValue := AArgs.GetElement(0);
   for I := StartIdx to TA.FLength - 1 do
-    if TA.ReadElement(I) = SearchVal then
+    if IsStrictEqual(TA.GetElementAsValue(I), SearchValue) then
       Exit(TGocciaNumberLiteralValue.Create(I));
   Result := TGocciaNumberLiteralValue.Create(-1);
 end;
@@ -1680,12 +1692,10 @@ end;
 function TGocciaTypedArrayValue.TypedArrayLastIndexOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  SearchNum: TGocciaNumberLiteralValue;
-  SearchVal: Double;
-  SearchBigInt: Int64;
+  SearchValue: TGocciaValue;
   I, StartIdx: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.lastIndexOf');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.lastIndexOf');
   if TA.FLength = 0 then
     Exit(TGocciaNumberLiteralValue.Create(-1));
   if AArgs.Length = 0 then
@@ -1698,34 +1708,12 @@ begin
   else
     StartIdx := TA.FLength - 1;
 
-  if IsBigIntKind(TA.FKind) then
-  begin
-    if not (AArgs.GetElement(0) is TGocciaBigIntValue) then
-      Exit(TGocciaNumberLiteralValue.Create(-1));
-    SearchBigInt := TGocciaBigIntValue(AArgs.GetElement(0)).Value.ToInt64;
-    for I := Min(StartIdx, TA.FLength - 1) downto 0 do
-      if TA.ReadBigIntElement(I) = SearchBigInt then
-        Exit(TGocciaNumberLiteralValue.Create(I));
+  if IsDetachedTypedArray(TA) then
     Exit(TGocciaNumberLiteralValue.Create(-1));
-  end;
 
-  SearchNum := AArgs.GetElement(0).ToNumberLiteral;
-  if SearchNum.IsNaN then
-    Exit(TGocciaNumberLiteralValue.Create(-1));
-  if SearchNum.IsInfinite then
-  begin
-    if not (IsFloatKind(TA.FKind)) then
-      Exit(TGocciaNumberLiteralValue.Create(-1));
-    for I := Min(StartIdx, TA.FLength - 1) downto 0 do
-      if Math.IsInfinite(TA.ReadElement(I)) and
-         ((SearchNum.IsInfinity and (TA.ReadElement(I) > 0)) or
-          (SearchNum.IsNegativeInfinity and (TA.ReadElement(I) < 0))) then
-        Exit(TGocciaNumberLiteralValue.Create(I));
-    Exit(TGocciaNumberLiteralValue.Create(-1));
-  end;
-  SearchVal := SearchNum.Value;
+  SearchValue := AArgs.GetElement(0);
   for I := Min(StartIdx, TA.FLength - 1) downto 0 do
-    if TA.ReadElement(I) = SearchVal then
+    if IsStrictEqual(TA.GetElementAsValue(I), SearchValue) then
       Exit(TGocciaNumberLiteralValue.Create(I));
   Result := TGocciaNumberLiteralValue.Create(-1);
 end;
@@ -1734,12 +1722,10 @@ end;
 function TGocciaTypedArrayValue.TypedArrayIncludes(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  SearchNum: TGocciaNumberLiteralValue;
-  SearchVal: Double;
-  SearchBigInt: Int64;
+  SearchValue: TGocciaValue;
   I, StartIdx: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.includes');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.includes');
   if TA.FLength = 0 then
     Exit(TGocciaBooleanLiteralValue.FalseValue);
   if AArgs.Length = 0 then
@@ -1752,43 +1738,9 @@ begin
   else
     StartIdx := 0;
 
-  if IsBigIntKind(TA.FKind) then
-  begin
-    if not (AArgs.GetElement(0) is TGocciaBigIntValue) then
-      Exit(TGocciaBooleanLiteralValue.FalseValue);
-    SearchBigInt := TGocciaBigIntValue(AArgs.GetElement(0)).Value.ToInt64;
-    for I := StartIdx to TA.FLength - 1 do
-      if TA.ReadBigIntElement(I) = SearchBigInt then
-        Exit(TGocciaBooleanLiteralValue.TrueValue);
-    Exit(TGocciaBooleanLiteralValue.FalseValue);
-  end;
-
-  if not (AArgs.GetElement(0) is TGocciaNumberLiteralValue) then
-    Exit(TGocciaBooleanLiteralValue.FalseValue);
-  SearchNum := TGocciaNumberLiteralValue(AArgs.GetElement(0));
-  // SameValueZero: NaN === NaN for includes
-  if SearchNum.IsNaN then
-  begin
-    if IsFloatKind(TA.FKind) then
-      for I := StartIdx to TA.FLength - 1 do
-        if Math.IsNaN(TA.ReadElement(I)) then
-          Exit(TGocciaBooleanLiteralValue.TrueValue);
-    Exit(TGocciaBooleanLiteralValue.FalseValue);
-  end;
-  if SearchNum.IsInfinite then
-  begin
-    if not (IsFloatKind(TA.FKind)) then
-      Exit(TGocciaBooleanLiteralValue.FalseValue);
-    for I := StartIdx to TA.FLength - 1 do
-      if Math.IsInfinite(TA.ReadElement(I)) and
-         ((SearchNum.IsInfinity and (TA.ReadElement(I) > 0)) or
-          (SearchNum.IsNegativeInfinity and (TA.ReadElement(I) < 0))) then
-        Exit(TGocciaBooleanLiteralValue.TrueValue);
-    Exit(TGocciaBooleanLiteralValue.FalseValue);
-  end;
-  SearchVal := SearchNum.Value;
+  SearchValue := AArgs.GetElement(0);
   for I := StartIdx to TA.FLength - 1 do
-    if TA.ReadElement(I) = SearchVal then
+    if IsSameValueZero(TA.GetElementAsValue(I), SearchValue) then
       Exit(TGocciaBooleanLiteralValue.TrueValue);
   Result := TGocciaBooleanLiteralValue.FalseValue;
 end;
@@ -1800,7 +1752,7 @@ var
   I: Integer;
   Element, CallResult, ThisArg: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.find');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.find');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFindCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -1824,7 +1776,7 @@ var
   I: Integer;
   Element, CallResult, ThisArg: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.findIndex');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.findIndex');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFindIndexCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -1848,7 +1800,7 @@ var
   I: Integer;
   Element, CallResult, ThisArg: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.findLast');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.findLast');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFindLastCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -1872,7 +1824,7 @@ var
   I: Integer;
   Element, CallResult, ThisArg: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.findLastIndex');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.findLastIndex');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFindLastIndexCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -1896,7 +1848,7 @@ var
   I: Integer;
   CallResult, ThisArg: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.every');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.every');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayEveryCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -1921,7 +1873,7 @@ var
   I: Integer;
   CallResult, ThisArg: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.some');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.some');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArraySomeCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -1946,7 +1898,7 @@ var
   I: Integer;
   ThisArg: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.forEach');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.forEach');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayForEachCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -1967,7 +1919,7 @@ var
   I: Integer;
   CallResult, ThisArg: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.map');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.map');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayMapCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -1993,7 +1945,7 @@ var
   CallResult, ThisArg, Element: TGocciaValue;
   Kept: TGocciaValueList;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.filter');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.filter');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFilterCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -2009,13 +1961,20 @@ begin
       CallResult := InvokeCallback(AArgs.GetElement(0),
         Element, TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
       if CallResult.ToBooleanLiteral.Value then
+      begin
         Kept.Add(Element);
+        if Assigned(TGarbageCollector.Instance) then
+          TGarbageCollector.Instance.AddTempRoot(Element);
+      end;
     end;
     NewTA := CreateSameKindArray(TA, Kept.Count);
     for I := 0 to Kept.Count - 1 do
       NewTA.WriteValueToElement(I, Kept[I]);
     Result := NewTA;
   finally
+    if Assigned(TGarbageCollector.Instance) then
+      for I := 0 to Kept.Count - 1 do
+        TGarbageCollector.Instance.RemoveTempRoot(Kept[I]);
     Kept.Free;
   end;
 end;
@@ -2028,7 +1987,7 @@ var
   Accumulator: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.reduce');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.reduce');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayReduceCallable, SSuggestTypedArrayCallable);
 
@@ -2070,7 +2029,7 @@ var
   Accumulator: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.reduceRight');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.reduceRight');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayReduceRightCallable, SSuggestTypedArrayCallable);
 
@@ -2111,8 +2070,9 @@ var
   Sep: string;
   I: Integer;
   S: string;
+  Element: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.join');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.join');
   if (AArgs.Length > 0) and not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
     Sep := AArgs.GetElement(0).ToStringLiteral.Value
   else
@@ -2121,7 +2081,10 @@ begin
   for I := 0 to TA.FLength - 1 do
   begin
     if I > 0 then S := S + Sep;
-    S := S + TA.GetElementAsValue(I).ToStringLiteral.Value;
+    Element := TA.GetElementAsValue(I);
+    if not ((Element is TGocciaUndefinedLiteralValue) or
+            (Element is TGocciaNullLiteralValue)) then
+      S := S + Element.ToStringLiteral.Value;
   end;
   Result := TGocciaStringLiteralValue.Create(S);
 end;
@@ -2138,7 +2101,7 @@ var
   TA, NewTA: TGocciaTypedArrayValue;
   I: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.toReversed');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.toReversed');
   NewTA := CreateSameKindArray(TA, TA.FLength);
   if IsBigIntKind(TA.FKind) then
   begin
@@ -2160,7 +2123,7 @@ var
   I: Integer;
   SortArgs: TGocciaArgumentsCollection;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.toSorted');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.toSorted');
   NewTA := CreateSameKindArray(TA, TA.FLength);
   if IsBigIntKind(TA.FKind) then
   begin
@@ -2192,7 +2155,7 @@ var
   NewBigInt: Int64;
   NewVal: TGocciaValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.with');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.with');
   // ES2026 §23.2.3.36 step 3: Let relativeIndex be ? ToIntegerOrInfinity(index)
   if AArgs.Length > 0 then
     ActualIndex := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value)
@@ -2247,7 +2210,7 @@ var
   Arr: TGocciaArrayValue;
   I: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.values');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.values');
   Arr := TGocciaArrayValue.Create;
   for I := 0 to TA.FLength - 1 do
     Arr.Elements.Add(TA.GetElementAsValue(I));
@@ -2261,7 +2224,7 @@ var
   Arr: TGocciaArrayValue;
   I: Integer;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.keys');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.keys');
   Arr := TGocciaArrayValue.Create;
   for I := 0 to TA.FLength - 1 do
     Arr.Elements.Add(TGocciaNumberLiteralValue.Create(I));
@@ -2276,7 +2239,7 @@ var
   I: Integer;
   Entry: TGocciaArrayValue;
 begin
-  TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.entries');
+  TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.entries');
   Arr := TGocciaArrayValue.Create;
   for I := 0 to TA.FLength - 1 do
   begin

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -41,6 +41,7 @@ type
     procedure SyncBufferData;
     function GetLength: Integer;
     function HasValidBackingRange(const ALength: Integer): Boolean;
+    function HasValidElementIndex(const AIndex: Integer): Boolean;
 
     function ReadElement(const AIndex: Integer): Double;
     procedure WriteElement(const AIndex: Integer; const AValue: Double);
@@ -273,6 +274,11 @@ begin
   Result := RequiredBytes <= System.Length(FBufferData);
 end;
 
+function TGocciaTypedArrayValue.HasValidElementIndex(const AIndex: Integer): Boolean;
+begin
+  Result := (AIndex >= 0) and (AIndex < GetLength);
+end;
+
 { Element read/write via buffer }
 
 function TGocciaTypedArrayValue.ReadElement(const AIndex: Integer): Double;
@@ -288,6 +294,9 @@ var
   F32: Single;
   F64: Double;
 begin
+  if not HasValidElementIndex(AIndex) then
+    Exit(0);
+
   SyncBufferData;
   Offset := FByteOffset + AIndex * BytesPerElement(FKind);
   case FKind of
@@ -356,6 +365,9 @@ var
   F64: Double;
   Clamped: Integer;
 begin
+  if not HasValidElementIndex(AIndex) then
+    Exit;
+
   SyncBufferData;
   Offset := FByteOffset + AIndex * BytesPerElement(FKind);
   case FKind of
@@ -446,6 +458,9 @@ procedure TGocciaTypedArrayValue.WriteNumberLiteral(const AIndex: Integer; const
 var
   Offset: Integer;
 begin
+  if not HasValidElementIndex(AIndex) then
+    Exit;
+
   SyncBufferData;
   if ANum.IsNaN then
   begin
@@ -492,6 +507,9 @@ var
   I64: Int64;
   U64: QWord;
 begin
+  if not HasValidElementIndex(AIndex) then
+    Exit(0);
+
   SyncBufferData;
   Offset := FByteOffset + AIndex * 8;
   case FKind of
@@ -514,6 +532,9 @@ procedure TGocciaTypedArrayValue.WriteBigIntElement(const AIndex: Integer; const
 var
   Offset: Integer;
 begin
+  if not HasValidElementIndex(AIndex) then
+    Exit;
+
   SyncBufferData;
   Offset := FByteOffset + AIndex * 8;
   Move(AValue, FBufferData[Offset], 8);
@@ -596,6 +617,9 @@ function TGocciaTypedArrayValue.GetElementAsValue(const AIndex: Integer): TGocci
 var
   Raw: Int64;
 begin
+  if not HasValidElementIndex(AIndex) then
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+
   if IsBigIntKind(FKind) then
   begin
     Raw := ReadBigIntElement(AIndex);
@@ -1965,12 +1989,9 @@ end;
 function TGocciaTypedArrayValue.TypedArrayFilter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA, NewTA: TGocciaTypedArrayValue;
-  I, Count: Integer;
-  ElemVal: Double;
-  ElemBigVal: Int64;
+  I: Integer;
   CallResult, ThisArg, Element: TGocciaValue;
-  Kept: array of Double;
-  KeptBig: array of Int64;
+  Kept: TGocciaValueList;
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.filter');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
@@ -1980,47 +2001,23 @@ begin
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  if IsBigIntKind(TA.FKind) then
-  begin
-    SetLength(KeptBig, 0);
+  Kept := TGocciaValueList.Create(False);
+  try
     for I := 0 to TA.FLength - 1 do
     begin
-      ElemBigVal := TA.ReadBigIntElement(I);
       Element := TA.GetElementAsValue(I);
       CallResult := InvokeCallback(AArgs.GetElement(0),
         Element, TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
       if CallResult.ToBooleanLiteral.Value then
-      begin
-        Count := System.Length(KeptBig);
-        SetLength(KeptBig, Count + 1);
-        KeptBig[Count] := ElemBigVal;
-      end;
+        Kept.Add(Element);
     end;
-    NewTA := CreateSameKindArray(TA, System.Length(KeptBig));
-    for I := 0 to System.Length(KeptBig) - 1 do
-      NewTA.WriteBigIntElement(I, KeptBig[I]);
-  end
-  else
-  begin
-    SetLength(Kept, 0);
-    for I := 0 to TA.FLength - 1 do
-    begin
-      ElemVal := TA.ReadElement(I);
-      CallResult := InvokeCallback(AArgs.GetElement(0),
-        TGocciaNumberLiteralValue.Create(ElemVal),
-        TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
-      if CallResult.ToBooleanLiteral.Value then
-      begin
-        Count := System.Length(Kept);
-        SetLength(Kept, Count + 1);
-        Kept[Count] := ElemVal;
-      end;
-    end;
-    NewTA := CreateSameKindArray(TA, System.Length(Kept));
-    for I := 0 to System.Length(Kept) - 1 do
-      NewTA.WriteElement(I, Kept[I]);
+    NewTA := CreateSameKindArray(TA, Kept.Count);
+    for I := 0 to Kept.Count - 1 do
+      NewTA.WriteValueToElement(I, Kept[I]);
+    Result := NewTA;
+  finally
+    Kept.Free;
   end;
-  Result := NewTA;
 end;
 
 // ES2026 §23.2.3.22 %TypedArray%.prototype.reduce(callbackfn [, initialValue])

--- a/tests/built-ins/TypedArray/prototype/copyWithin.js
+++ b/tests/built-ins/TypedArray/prototype/copyWithin.js
@@ -34,6 +34,16 @@ describe("TypedArray.prototype.copyWithin", () => {
       expect(ta[0]).toBe(4);
       expect(ta[1]).toBe(5);
     });
+
+    test("throws if start coercion detaches buffer before copy", () => {
+      const ta = new TA([1, 2, 3, 4]);
+      expect(() => ta.copyWithin(0, {
+        valueOf() {
+          ta.buffer.transfer();
+          return 1;
+        }
+      }, 3)).toThrow(TypeError);
+    });
   });
 
   test.each([BigInt64Array, BigUint64Array])("%s copyWithin", (TA) => {

--- a/tests/built-ins/TypedArray/prototype/fill.js
+++ b/tests/built-ins/TypedArray/prototype/fill.js
@@ -47,6 +47,16 @@ describe("TypedArray.prototype.fill", () => {
       expect(ta[3]).toBe(9);
       expect(ta[4]).toBe(5);
     });
+
+    test("throws if value coercion detaches buffer before fill", () => {
+      const ta = new TA(2);
+      expect(() => ta.fill({
+        valueOf() {
+          ta.buffer.transfer();
+          return 7;
+        }
+      })).toThrow(TypeError);
+    });
   });
 
   describe.each([BigInt64Array, BigUint64Array])("%s", (TA) => {

--- a/tests/built-ins/TypedArray/prototype/filter.js
+++ b/tests/built-ins/TypedArray/prototype/filter.js
@@ -44,6 +44,23 @@ describe("TypedArray.prototype.filter", () => {
       expect(filtered[1]).toBe(4);
       expect(filtered[2]).toBe(5);
     });
+
+    test("continues after callback detaches buffer", () => {
+      const ta = new TA(2);
+      const buffer = ta.buffer;
+      const seen = [];
+      const filtered = ta.filter((value) => {
+        seen.push(value);
+        if (seen.length === 1) {
+          buffer.transfer();
+        }
+        return true;
+      });
+
+      expect(seen.length).toBe(2);
+      expect(seen[1]).toBeUndefined();
+      expect(filtered.length).toBe(2);
+    });
   });
 
   test.each([BigInt64Array, BigUint64Array])("%s filter", (TA) => {
@@ -53,5 +70,24 @@ describe("TypedArray.prototype.filter", () => {
     expect(filtered.length).toBe(2);
     expect(filtered[0]).toBe(3n);
     expect(filtered[1]).toBe(4n);
+  });
+
+  test.each([BigInt64Array, BigUint64Array])("%s continues after callback detaches buffer", (TA) => {
+    const ta = new TA(2);
+    const buffer = ta.buffer;
+    const seen = [];
+    const filtered = ta.filter((value) => {
+      seen.push(value);
+      if (seen.length === 1) {
+        buffer.transfer();
+        return true;
+      }
+      return false;
+    });
+
+    expect(seen.length).toBe(2);
+    expect(seen[1]).toBeUndefined();
+    expect(filtered.length).toBe(1);
+    expect(filtered[0]).toBe(0n);
   });
 });

--- a/tests/built-ins/TypedArray/prototype/find.js
+++ b/tests/built-ins/TypedArray/prototype/find.js
@@ -28,10 +28,44 @@ describe("TypedArray.prototype.find", () => {
       ta.find(x => { count++; return x === 3; });
       expect(count).toBe(3);
     });
+
+    test("continues after predicate detaches buffer", () => {
+      const ta = new TA(2);
+      const buffer = ta.buffer;
+      const seen = [];
+      const found = ta.find((value) => {
+        seen.push(value);
+        if (seen.length === 1) {
+          buffer.transfer();
+        }
+        return false;
+      });
+
+      expect(found).toBeUndefined();
+      expect(seen.length).toBe(2);
+      expect(seen[1]).toBeUndefined();
+    });
   });
 
   test.each([BigInt64Array, BigUint64Array])("%s find", (TA) => {
     const ta = new TA([1n, 2n, 3n]);
     expect(ta.find(x => x > 1n)).toBe(2n);
+  });
+
+  test.each([BigInt64Array, BigUint64Array])("%s continues after predicate detaches buffer", (TA) => {
+    const ta = new TA(2);
+    const buffer = ta.buffer;
+    const seen = [];
+    const found = ta.find((value) => {
+      seen.push(value);
+      if (seen.length === 1) {
+        buffer.transfer();
+      }
+      return false;
+    });
+
+    expect(found).toBeUndefined();
+    expect(seen.length).toBe(2);
+    expect(seen[1]).toBeUndefined();
   });
 });

--- a/tests/built-ins/TypedArray/prototype/includes.js
+++ b/tests/built-ins/TypedArray/prototype/includes.js
@@ -42,4 +42,21 @@ describe("TypedArray.prototype.includes", () => {
     expect(ta.includes(2n)).toBe(true);
     expect(ta.includes(4n)).toBe(false);
   });
+
+  test("throws on detached buffer", () => {
+    const ta = new Int32Array([1, 2, 3]);
+    ta.buffer.transfer();
+    expect(() => ta.includes(1)).toThrow(TypeError);
+  });
+
+  test("reads undefined when fromIndex detaches buffer", () => {
+    const ta = new Int32Array(1);
+    const fromIndex = {
+      valueOf() {
+        ta.buffer.transfer();
+        return 0;
+      }
+    };
+    expect(ta.includes(undefined, fromIndex)).toBe(true);
+  });
 });

--- a/tests/built-ins/TypedArray/prototype/indexOf.js
+++ b/tests/built-ins/TypedArray/prototype/indexOf.js
@@ -34,6 +34,23 @@ describe("TypedArray.prototype.indexOf", () => {
     expect(() => Int32Array.prototype.indexOf.call({}, 1)).toThrow(TypeError);
   });
 
+  test("throws on detached buffer", () => {
+    const ta = new Int32Array([1, 2, 3]);
+    ta.buffer.transfer();
+    expect(() => ta.indexOf(1)).toThrow(TypeError);
+  });
+
+  test("returns -1 when fromIndex detaches buffer", () => {
+    const ta = new Int32Array(1);
+    const fromIndex = {
+      valueOf() {
+        ta.buffer.transfer();
+        return 0;
+      }
+    };
+    expect(ta.indexOf(undefined, fromIndex)).toBe(-1);
+  });
+
   test.each([BigInt64Array, BigUint64Array])("%s indexOf", (TA) => {
     const ta = new TA([1n, 2n, 3n, 2n]);
     expect(ta.indexOf(2n)).toBe(1);

--- a/tests/built-ins/TypedArray/prototype/join.js
+++ b/tests/built-ins/TypedArray/prototype/join.js
@@ -33,6 +33,17 @@ describe("TypedArray.prototype.join", () => {
       const ta = new TA([1, 2]);
       expect(() => ta.join(Symbol())).toThrow(TypeError);
     });
+
+    test("uses empty fields if separator coercion detaches buffer", () => {
+      const ta = new TA([1, 2, 3]);
+      const joined = ta.join({
+        toString() {
+          ta.buffer.transfer();
+          return ",";
+        }
+      });
+      expect(joined).toBe(",,");
+    });
   });
 
   test.each([BigInt64Array, BigUint64Array])("%s join", (TA) => {

--- a/tests/built-ins/TypedArray/prototype/lastIndexOf.js
+++ b/tests/built-ins/TypedArray/prototype/lastIndexOf.js
@@ -25,4 +25,21 @@ describe("TypedArray.prototype.lastIndexOf", () => {
     const ta = new TA([1n, 2n, 3n, 2n]);
     expect(ta.lastIndexOf(2n)).toBe(3);
   });
+
+  test("throws on detached buffer", () => {
+    const ta = new Int32Array([1, 2, 3]);
+    ta.buffer.transfer();
+    expect(() => ta.lastIndexOf(1)).toThrow(TypeError);
+  });
+
+  test("returns -1 when fromIndex detaches buffer", () => {
+    const ta = new Int32Array(1);
+    const fromIndex = {
+      valueOf() {
+        ta.buffer.transfer();
+        return 0;
+      }
+    };
+    expect(ta.lastIndexOf(undefined, fromIndex)).toBe(-1);
+  });
 });

--- a/tests/built-ins/TypedArray/prototype/map.js
+++ b/tests/built-ins/TypedArray/prototype/map.js
@@ -35,6 +35,24 @@ describe("TypedArray.prototype.map", () => {
       expect(mapped[1]).toBe(6);
       expect(mapped[2]).toBe(9);
     });
+
+    test("continues after callback detaches buffer", () => {
+      const ta = new TA(2);
+      const buffer = ta.buffer;
+      const seen = [];
+      const mapped = ta.map((value) => {
+        seen.push(value);
+        if (seen.length === 1) {
+          buffer.transfer();
+        }
+        return 7;
+      });
+
+      expect(seen.length).toBe(2);
+      expect(seen[1]).toBeUndefined();
+      expect(mapped[0]).toBe(7);
+      expect(mapped[1]).toBe(7);
+    });
   });
 
   test.each([BigInt64Array, BigUint64Array])("%s map", (TA) => {
@@ -43,5 +61,23 @@ describe("TypedArray.prototype.map", () => {
     expect(mapped[0]).toBe(2n);
     expect(mapped[1]).toBe(4n);
     expect(mapped[2]).toBe(6n);
+  });
+
+  test.each([BigInt64Array, BigUint64Array])("%s continues after callback detaches buffer", (TA) => {
+    const ta = new TA(2);
+    const buffer = ta.buffer;
+    const seen = [];
+    const mapped = ta.map((value) => {
+      seen.push(value);
+      if (seen.length === 1) {
+        buffer.transfer();
+      }
+      return true;
+    });
+
+    expect(seen.length).toBe(2);
+    expect(seen[1]).toBeUndefined();
+    expect(mapped[0]).toBe(1n);
+    expect(mapped[1]).toBe(1n);
   });
 });

--- a/tests/built-ins/TypedArray/prototype/map.js
+++ b/tests/built-ins/TypedArray/prototype/map.js
@@ -26,6 +26,17 @@ describe("TypedArray.prototype.map", () => {
       expect(() => ta.map()).toThrow(TypeError);
     });
 
+    test("throws on detached buffer before callback", () => {
+      const ta = new TA([1, 2, 3]);
+      let called = false;
+      ta.buffer.transfer();
+      expect(() => ta.map(() => {
+        called = true;
+        return 0;
+      })).toThrow(TypeError);
+      expect(called).toBe(false);
+    });
+
     test("passes thisArg to callback", () => {
       const ta = new TA([1, 2, 3]);
       const ctx = { mult: 3 };

--- a/tests/built-ins/TypedArray/prototype/reverse.js
+++ b/tests/built-ins/TypedArray/prototype/reverse.js
@@ -32,4 +32,10 @@ describe("TypedArray.prototype.reverse", () => {
     expect(ta[1]).toBe(2n);
     expect(ta[2]).toBe(1n);
   });
+
+  test("throws on detached buffer", () => {
+    const ta = new Int32Array([1, 2, 3]);
+    ta.buffer.transfer();
+    expect(() => ta.reverse()).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/TypedArray/prototype/set.js
+++ b/tests/built-ins/TypedArray/prototype/set.js
@@ -48,6 +48,12 @@ describe("TypedArray.prototype.set", () => {
       const ta = new TA(3);
       expect(() => ta.set([1, 2], 2)).toThrow(RangeError);
     });
+
+    test("throws when target buffer is already detached", () => {
+      const ta = new TA(3);
+      ta.buffer.transfer();
+      expect(() => ta.set([1])).toThrow(TypeError);
+    });
   });
 
   describe("set from array-like", () => {
@@ -108,5 +114,12 @@ describe("TypedArray.prototype.set", () => {
     expect(dst[0]).toBe(0n);
     expect(dst[1]).toBe(10n);
     expect(dst[2]).toBe(20n);
+  });
+
+  test("throws when typed array source buffer is already detached", () => {
+    const src = new Int32Array([1]);
+    const dst = new Int32Array(1);
+    src.buffer.transfer();
+    expect(() => dst.set(src)).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/TypedArray/prototype/set.js
+++ b/tests/built-ins/TypedArray/prototype/set.js
@@ -95,8 +95,12 @@ describe("TypedArray.prototype.set", () => {
     test("array-like length getter can detach target buffer", () => {
       const ta = new Int32Array(4);
       const buffer = ta.buffer;
+      let sourceRead = false;
       ta.set({
-        0: 17,
+        get 0() {
+          sourceRead = true;
+          return 17;
+        },
         get length() {
           buffer.transfer();
           return 1;
@@ -104,6 +108,10 @@ describe("TypedArray.prototype.set", () => {
       }, 1);
 
       expect(buffer.detached).toBe(true);
+      expect(sourceRead).toBe(true);
+      expect(ta.length).toBe(0);
+      expect(ta.byteLength).toBe(0);
+      expect(ta.byteOffset).toBe(0);
     });
   });
 

--- a/tests/built-ins/TypedArray/prototype/set.js
+++ b/tests/built-ins/TypedArray/prototype/set.js
@@ -85,6 +85,20 @@ describe("TypedArray.prototype.set", () => {
       const ta = new Int32Array(3);
       expect(() => ta.set({ 0: 1, 1: 2, length: 2 }, 2)).toThrow(RangeError);
     });
+
+    test("array-like length getter can detach target buffer", () => {
+      const ta = new Int32Array(4);
+      const buffer = ta.buffer;
+      ta.set({
+        0: 17,
+        get length() {
+          buffer.transfer();
+          return 1;
+        }
+      }, 1);
+
+      expect(buffer.detached).toBe(true);
+    });
   });
 
   test.each([BigInt64Array, BigUint64Array])("%s set from BigInt typed array", (TA) => {

--- a/tests/built-ins/TypedArray/prototype/slice.js
+++ b/tests/built-ins/TypedArray/prototype/slice.js
@@ -78,4 +78,10 @@ describe("TypedArray.prototype.slice", () => {
     expect(sliced[0]).toBe(2n);
     expect(sliced[1]).toBe(3n);
   });
+
+  test("throws on detached buffer", () => {
+    const ta = new Int32Array([1, 2, 3]);
+    ta.buffer.transfer();
+    expect(() => ta.slice()).toThrow(TypeError);
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Centralize TypedArray element-index validation so detached buffers produce spec-level `undefined` reads and no-op writes instead of Pascal range-check exceptions.
- Route `TypedArray.prototype.filter` through the same element-get/write path so callback detachment is handled consistently for Number and BigInt typed arrays.
- Add regression coverage for callback/predicate detachment and `set(arrayLike)` length getter detachment.
- Closes #647.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas testrunner`
  - `./build/GocciaTestRunner tests/built-ins/TypedArray/prototype/map.js tests/built-ins/TypedArray/prototype/filter.js tests/built-ins/TypedArray/prototype/find.js tests/built-ins/TypedArray/prototype/set.js --asi --unsafe-ffi --no-progress`
  - `./build/GocciaTestRunner tests/built-ins/TypedArray --asi --unsafe-ffi --no-progress`
  - `./build/GocciaTestRunner tests/built-ins/TypedArray --asi --unsafe-ffi --mode=bytecode --no-progress`
  - `./fixtures/ffi/build.sh && ./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-suite --filter "built-ins/TypedArray/prototype/**/callbackfn-detachbuffer.js" --mode=bytecode --jobs=2`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-suite --filter "built-ins/TypedArray/prototype/**/predicate-may-detach-buffer.js" --mode=bytecode --jobs=2`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-suite --filter "staging/sm/extensions/TypedArray-set-object-funky-length-detaches.js" --mode=bytecode --jobs=1`
  - `./format.pas --check`
- [x] Updated documentation (docs reviewed; no user-facing documentation change needed for this bugfix)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change