### PR TITLE
Fix static class setter assignment

### DIFF
--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -338,6 +338,30 @@ console.log("--compat-non-strict-mode (Loader + Bundler + TestRunner + Bare)..."
     const bareOut = await $`${BARE} --print ${src} --compat-function --compat-non-strict-mode 2>&1`.text();
     if (bareOut.trim() !== "7") throw new Error(`Bare --compat-non-strict-mode expected 7, got: ${bareOut}`);
 
+    const staticSetterSrc = join(tmp, "static-setter-nonstrict.js");
+    writeFileSync(
+      staticSetterSrc,
+      [
+        "let captured = 0;",
+        'const computed = "computed";',
+        'const symbolKey = Symbol("staticSetter");',
+        "class C {",
+        "  static set eval(value) { captured = captured + value; }",
+        "  static set arguments(value) { captured = captured + value * 10; }",
+        "  static set [computed](value) { captured = captured + value * 100; }",
+        "  static set [symbolKey](value) { captured = captured + value * 1000; }",
+        "}",
+        "C.eval = 1;",
+        "C.arguments = 2;",
+        "C[computed] = 3;",
+        "C[symbolKey] = 4;",
+        "captured;",
+      ].join("\n") + "\n",
+    );
+    const staticSetterBareOut = await $`${BARE} --print ${staticSetterSrc} --compat-non-strict-mode 2>&1`.text();
+    if (staticSetterBareOut.trim() !== "4321")
+      throw new Error(`Bare static setters in non-strict mode expected 4321, got: ${staticSetterBareOut}`);
+
     const noFlagOut = join(tmp, "no-flag.gbc");
     const bundleNoFlag = await $`${BUNDLER} ${src} --compat-function --output=${noFlagOut} 2>&1`.nothrow();
     if (bundleNoFlag.exitCode !== 0) throw new Error(`Bundler without --compat-non-strict-mode should skip unsupported with and still compile, got: ${bundleNoFlag.stderr.toString()}`);

--- a/source/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/source/units/Goccia.Bytecode.OpCodeNames.pas
@@ -139,6 +139,8 @@ begin
     OP_SET_INDEX:                      Result := 'OP_SET_INDEX';
     OP_DEL_INDEX:                      Result := 'OP_DEL_INDEX';
     OP_DELETE_GLOBAL:                  Result := 'OP_DELETE_GLOBAL';
+    OP_DEFINE_STATIC_PROP_CONST:       Result := 'OP_DEFINE_STATIC_PROP_CONST';
+    OP_DEFINE_STATIC_METHOD_CONST:     Result := 'OP_DEFINE_STATIC_METHOD_CONST';
     OP_ADD:                            Result := 'OP_ADD';
     OP_SUB:                            Result := 'OP_SUB';
     OP_MUL:                            Result := 'OP_MUL';

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -49,7 +49,11 @@ const
   //               --compat-non-strict-mode bytecode.
   //   v30 -> v31: added non-strict assignment/global-delete opcodes for
   //               --compat-non-strict-mode bytecode.
-  GOCCIA_FORMAT_VERSION = 31;
+  //   v31 -> v32: added OP_DEFINE_STATIC_PROP_CONST and
+  //               OP_DEFINE_STATIC_METHOD_CONST so class static fields and
+  //               methods define own data properties instead of using ordinary
+  //               assignment semantics.
+  GOCCIA_FORMAT_VERSION = 32;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;
@@ -210,6 +214,8 @@ type
     OP_SET_INDEX     = 120,
     OP_DEL_INDEX     = 121,
     OP_DELETE_GLOBAL = 122,
+    OP_DEFINE_STATIC_PROP_CONST = 123,
+    OP_DEFINE_STATIC_METHOD_CONST = 124,
     OP_ADD           = 128,
     OP_SUB           = 129,
     OP_MUL           = 130,

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -4051,7 +4051,7 @@ begin
   begin
     if MethodPair.Value.IsStatic then
       CompileMethodBody(ACtx, ClassReg, MethodPair.Key,
-        MethodPair.Value, OP_SET_PROP_CONST)
+        MethodPair.Value, OP_DEFINE_STATIC_METHOD_CONST)
     else
       CompileMethodBody(ACtx, ClassReg, MethodPair.Key,
         MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
@@ -4120,7 +4120,7 @@ begin
       KeyIdx := ACtx.Template.AddConstantString(StaticPropPair.Key);
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
-      EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ClassReg,
+      EmitInstruction(ACtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ClassReg,
         UInt8(KeyIdx), ValReg));
       ACtx.Scope.FreeRegister;
     end;
@@ -4170,7 +4170,7 @@ begin
         KeyIdx := ACtx.Template.AddConstantString(ClassDef.FElements[I].Name);
         if KeyIdx > High(UInt8) then
           raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
-        EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ClassReg,
+        EmitInstruction(ACtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ClassReg,
           UInt8(KeyIdx), ValReg));
       end;
       ACtx.Scope.FreeRegister;
@@ -4262,7 +4262,7 @@ begin
   begin
     if MethodPair.Value.IsStatic then
       CompileMethodBody(ACtx, ADest, MethodPair.Key,
-        MethodPair.Value, OP_SET_PROP_CONST)
+        MethodPair.Value, OP_DEFINE_STATIC_METHOD_CONST)
     else
       CompileMethodBody(ACtx, ADest, MethodPair.Key,
         MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
@@ -4331,7 +4331,7 @@ begin
       KeyIdx := ACtx.Template.AddConstantString(StaticPropPair.Key);
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
-      EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ADest,
+      EmitInstruction(ACtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ADest,
         UInt8(KeyIdx), ValReg));
       ACtx.Scope.FreeRegister;
     end;
@@ -4381,7 +4381,7 @@ begin
         KeyIdx := ACtx.Template.AddConstantString(ClassDef.FElements[I].Name);
         if KeyIdx > High(UInt8) then
           raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
-        EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ADest,
+        EmitInstruction(ACtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ADest,
           UInt8(KeyIdx), ValReg));
       end;
       ACtx.Scope.FreeRegister;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -6226,10 +6226,7 @@ begin
         PropertyKey := ToPropertyKey(EvaluateExpression(ObjPat.Properties[I].KeyExpression, AContext));
         if PropertyKey is TGocciaSymbolValue then
         begin
-          // TGocciaClassValue.GetSymbolProperty is not virtual, so casting an
-          // AValue that is actually a class to TGocciaObjectValue would skip
-          // the static symbol descriptor table. Dispatch on the concrete type
-          // (mirrors AssignObjectPattern below).
+          // Keep the class dispatch explicit to mirror assignment patterns.
           if AValue is TGocciaClassValue then
             PropValue := TGocciaClassValue(AValue).GetSymbolProperty(TGocciaSymbolValue(PropertyKey))
           else
@@ -6727,10 +6724,7 @@ begin
           PropValue := ToPropertyKey(EvaluateExpression(Prop.KeyExpression, AContext));
           if PropValue is TGocciaSymbolValue then
           begin
-            // Class values store static symbol-keyed members in their own
-            // descriptor table; the TGocciaClassValue.GetSymbolProperty
-            // method is not virtual, so a TGocciaObjectValue receiver would
-            // miss them. Dispatch via the class entry point when applicable.
+            // Keep the class dispatch explicit to mirror binding patterns.
             if ObjectValue is TGocciaClassValue then
               PropValue := TGocciaClassValue(ObjectValue).GetSymbolProperty(TGocciaSymbolValue(PropValue))
             else

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -4305,7 +4305,8 @@ begin
     Method.OwningClass := ClassValue;
 
     if MethodPair.Value.IsStatic then
-      ClassValue.SetProperty(MethodPair.Key, Method)
+      ClassValue.DefineProperty(MethodPair.Key,
+        TGocciaPropertyDescriptorData.Create(Method, [pfConfigurable, pfWritable]))
     else
       ClassValue.AddMethod(MethodPair.Key, Method);
   end;
@@ -4316,7 +4317,9 @@ begin
     for PropertyPair in AClassDef.StaticProperties do
     begin
       PropertyValue := EvaluateExpression(PropertyPair.Value, AContext);
-      ClassValue.SetProperty(PropertyPair.Key, PropertyValue);
+      ClassValue.DefineProperty(PropertyPair.Key,
+        TGocciaPropertyDescriptorData.Create(PropertyValue,
+          [pfEnumerable, pfConfigurable, pfWritable]));
     end;
 
     for PropertyPair in AClassDef.PrivateStaticProperties do
@@ -4429,7 +4432,8 @@ begin
         else
         begin
           if Elem.IsStatic then
-            ClassValue.SetProperty(ComputedKey.ToStringLiteral.Value, Method)
+            ClassValue.DefineProperty(ComputedKey.ToStringLiteral.Value,
+              TGocciaPropertyDescriptorData.Create(Method, [pfConfigurable, pfWritable]))
           else
             ClassValue.AddMethod(ComputedKey.ToStringLiteral.Value, Method);
         end;
@@ -4535,7 +4539,9 @@ begin
       if Elem.IsPrivate then
         ClassValue.AddPrivateStaticProperty(Elem.Name, PropertyValue)
       else
-        ClassValue.SetProperty(Elem.Name, PropertyValue);
+        ClassValue.DefineProperty(Elem.Name,
+          TGocciaPropertyDescriptorData.Create(PropertyValue,
+            [pfEnumerable, pfConfigurable, pfWritable]));
     end;
   end;
 
@@ -4690,7 +4696,9 @@ begin
                     ClassValue.AddPrivateMethod(ElementName, TGocciaMethodValue(DecoratorResult));
                 end
                 else if Elem.IsStatic then
-                  ClassValue.SetProperty(ElementName, DecoratorResult)
+                  ClassValue.DefineProperty(ElementName,
+                    TGocciaPropertyDescriptorData.Create(
+                      DecoratorResult, [pfConfigurable, pfWritable]))
                 else
                   ClassValue.Prototype.AssignProperty(ElementName, DecoratorResult);
               end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -3598,12 +3598,17 @@ end;
 
 function TGocciaVMClassValue.GetProperty(const AName: string): TGocciaValue;
 var
+  Descriptor: TGocciaPropertyDescriptor;
   Getter: TGocciaFunctionBase;
-  Current: TGocciaClassValue;
   BytecodeGetter: TGocciaBytecodeFunctionValue;
   Args: TGocciaArgumentsCollection;
 begin
-  Getter := StaticPropertyGetter[AName];
+  Getter := nil;
+  Descriptor := inherited GetOwnPropertyDescriptor(AName);
+  if Descriptor is TGocciaPropertyDescriptorAccessor then
+    if TGocciaPropertyDescriptorAccessor(Descriptor).Getter is TGocciaFunctionBase then
+      Getter := TGocciaFunctionBase(TGocciaPropertyDescriptorAccessor(Descriptor).Getter);
+
   if Assigned(Getter) then
   begin
     if (Getter is TGocciaBytecodeFunctionValue) then
@@ -3629,40 +3634,41 @@ end;
 procedure TGocciaVMClassValue.SetProperty(const AName: string;
   const AValue: TGocciaValue);
 var
+  Descriptor: TGocciaPropertyDescriptor;
   Setter: TGocciaFunctionBase;
-  Current: TGocciaClassValue;
   BytecodeSetter: TGocciaBytecodeFunctionValue;
   Args: TGocciaArgumentsCollection;
 begin
-  Current := Self;
-  repeat
-    Setter := Current.StaticPropertySetter[AName];
-    if Assigned(Setter) then
-    begin
-      if Setter is TGocciaBytecodeFunctionValue then
-      begin
-        BytecodeSetter := TGocciaBytecodeFunctionValue(Setter);
-        if Assigned(BytecodeSetter.FClosure) and
-           Assigned(BytecodeSetter.FClosure.Template) and
-           (not BytecodeSetter.FClosure.Template.IsAsync) then
-        begin
-          FVM.ExecuteClosureRegisters(BytecodeSetter.FClosure, RegisterObject(Self),
-            [ValueToRegister(AValue)]);
-          Exit;
-        end;
-      end;
+  Setter := nil;
+  Descriptor := inherited GetOwnPropertyDescriptor(AName);
+  if Descriptor is TGocciaPropertyDescriptorAccessor then
+    if TGocciaPropertyDescriptorAccessor(Descriptor).Setter is TGocciaFunctionBase then
+      Setter := TGocciaFunctionBase(TGocciaPropertyDescriptorAccessor(Descriptor).Setter);
 
-      Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
-      try
-        Args.Add(AValue);
-        Setter.Call(Args, Self);
-      finally
-        Args.Free;
+  if Assigned(Setter) then
+  begin
+    if Setter is TGocciaBytecodeFunctionValue then
+    begin
+      BytecodeSetter := TGocciaBytecodeFunctionValue(Setter);
+      if Assigned(BytecodeSetter.FClosure) and
+         Assigned(BytecodeSetter.FClosure.Template) and
+         (not BytecodeSetter.FClosure.Template.IsAsync) then
+      begin
+        FVM.ExecuteClosureRegisters(BytecodeSetter.FClosure, RegisterObject(Self),
+          [ValueToRegister(AValue)]);
+        Exit;
       end;
-      Exit;
     end;
-    Current := Current.SuperClass;
-  until not Assigned(Current);
+
+    Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
+    try
+      Args.Add(AValue);
+      Setter.Call(Args, Self);
+    finally
+      Args.Free;
+    end;
+    Exit;
+  end;
 
   inherited SetProperty(AName, AValue);
 end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -3616,7 +3616,8 @@ begin
       BytecodeGetter := TGocciaBytecodeFunctionValue(Getter);
       if Assigned(BytecodeGetter.FClosure) and
          Assigned(BytecodeGetter.FClosure.Template) and
-         (not BytecodeGetter.FClosure.Template.IsAsync) then
+         (not BytecodeGetter.FClosure.Template.IsAsync) and
+         (not BytecodeGetter.FClosure.Template.IsGenerator) then
         Exit(RegisterToValue(FVM.ExecuteClosureRegisters(
           BytecodeGetter.FClosure, RegisterObject(Self), [])));
     end;
@@ -3652,7 +3653,8 @@ begin
       BytecodeSetter := TGocciaBytecodeFunctionValue(Setter);
       if Assigned(BytecodeSetter.FClosure) and
          Assigned(BytecodeSetter.FClosure.Template) and
-         (not BytecodeSetter.FClosure.Template.IsAsync) then
+         (not BytecodeSetter.FClosure.Template.IsAsync) and
+         (not BytecodeSetter.FClosure.Template.IsGenerator) then
       begin
         FVM.ExecuteClosureRegisters(BytecodeSetter.FClosure, RegisterObject(Self),
           [ValueToRegister(AValue)]);
@@ -8052,6 +8054,42 @@ begin
            (TargetValue is TGocciaObjectValue) then
           SetBytecodeHomeObject(RightValue, TargetValue);
         SetPropertyValueLoose(TargetValue, GlobalName, RightValue);
+      end;
+
+      OP_DEFINE_STATIC_PROP_CONST:
+      begin
+        GlobalName := Template.GetConstantUnchecked(B).StringValue;
+        RightValue := RegisterToValue(FRegisters[C]);
+        if (FRegisters[A].Kind = grkObject) and
+           (FRegisters[A].ObjectValue is TGocciaObjectValue) then
+        begin
+          if FRegisters[A].ObjectValue is TGocciaVMClassValue then
+            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
+          TGocciaObjectValue(FRegisters[A].ObjectValue).DefineProperty(
+            GlobalName,
+            TGocciaPropertyDescriptorData.Create(
+              RightValue, [pfEnumerable, pfConfigurable, pfWritable]));
+        end
+        else
+          SetPropertyValue(GetRegister(A), GlobalName, RightValue);
+      end;
+
+      OP_DEFINE_STATIC_METHOD_CONST:
+      begin
+        GlobalName := Template.GetConstantUnchecked(B).StringValue;
+        RightValue := RegisterToValue(FRegisters[C]);
+        if (FRegisters[A].Kind = grkObject) and
+           (FRegisters[A].ObjectValue is TGocciaObjectValue) then
+        begin
+          if FRegisters[A].ObjectValue is TGocciaVMClassValue then
+            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
+          TGocciaObjectValue(FRegisters[A].ObjectValue).DefineProperty(
+            GlobalName,
+            TGocciaPropertyDescriptorData.Create(
+              RightValue, [pfConfigurable, pfWritable]));
+        end
+        else
+          SetPropertyValue(GetRegister(A), GlobalName, RightValue);
       end;
 
       OP_DELETE_PROP_CONST:

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -5232,7 +5232,7 @@ begin
     TGocciaClassValue(ATarget).DefineSymbolProperty(
       TGocciaSymbolValue(AKey),
       TGocciaPropertyDescriptorAccessor.Create(
-        AGetter, ExistingSetter, [pfEnumerable, pfConfigurable, pfWritable]));
+        AGetter, ExistingSetter, [pfConfigurable]));
     Exit;
   end;
 
@@ -5257,7 +5257,7 @@ begin
     TGocciaClassValue(ATarget).DefineSymbolProperty(
       TGocciaSymbolValue(AKey),
       TGocciaPropertyDescriptorAccessor.Create(
-        ExistingGetter, ASetter, [pfEnumerable, pfConfigurable, pfWritable]));
+        ExistingGetter, ASetter, [pfConfigurable]));
     Exit;
   end;
 

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -7,7 +7,6 @@ interface
 uses
   Classes,
 
-  HashMap,
   OrderedStringMap,
 
   Goccia.Arguments.Collection,
@@ -21,7 +20,6 @@ uses
   Goccia.Values.SymbolValue;
 
 type
-  TStaticSymbolDescriptorMap = THashMap<TGocciaSymbolValue, TGocciaPropertyDescriptor>;
   // Forward declaration
   TGocciaInstanceValue = class;
 
@@ -49,7 +47,6 @@ type
     FPrivateSetters: TOrderedStringMap<TGocciaFunctionBase>;
     FStaticGetters: TOrderedStringMap<TGocciaFunctionBase>;
     FStaticSetters: TOrderedStringMap<TGocciaFunctionBase>;
-    FStaticSymbolDescriptors: TStaticSymbolDescriptorMap;
     FNativeSuperConstructor: TGocciaObjectValue;
     FPrivateBrandToken: string;
     FMethodInitializers: array of TGocciaValue;
@@ -120,13 +117,7 @@ type
     procedure SetConstructorPrototype(const APrototype: TGocciaObjectValue);
     procedure LinkNativeSuperConstructor(const ASuperConstructor: TGocciaObjectValue);
     procedure SetInferredName(const AName: string);
-    procedure DefineSymbolProperty(const ASymbol: TGocciaSymbolValue; const ADescriptor: TGocciaPropertyDescriptor);
-    procedure AssignSymbolProperty(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue);
     function GetOwnStaticSymbolDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor;
-    function GetOwnSymbolPropertyDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor; override;
-    function GetOwnSymbols: TArray<TGocciaSymbolValue>; override;
-    function GetSymbolProperty(const ASymbol: TGocciaSymbolValue): TGocciaValue;
-    function GetSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AReceiver: TGocciaValue): TGocciaValue; override;
 
     property Name: string read FName;
     property PrivateBrandToken: string read FPrivateBrandToken;
@@ -366,7 +357,6 @@ begin
   FPrivateSetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
   FStaticGetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
   FStaticSetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
-  FStaticSymbolDescriptors := TStaticSymbolDescriptorMap.Create;
   FNativeSuperConstructor := nil;
   FClassPrototype := TGocciaObjectValue.Create;
   FConstructorMethod := nil;
@@ -393,7 +383,6 @@ begin
   FPrivateSetters.Free;
   FStaticGetters.Free;
   FStaticSetters.Free;
-  FStaticSymbolDescriptors.Free;
   // Don't free FClassPrototype - it's GC-managed
   inherited;
 end;
@@ -403,8 +392,6 @@ var
   MethodPair: TOrderedStringMap<TGocciaMethodValue>.TKeyValuePair;
   FuncPair: TOrderedStringMap<TGocciaFunctionBase>.TKeyValuePair;
   ValPair: TGocciaValueMap.TKeyValuePair;
-  SymPair: TStaticSymbolDescriptorMap.TKeyValuePair;
-  Accessor: TGocciaPropertyDescriptorAccessor;
   I: Integer;
 begin
   if GCMarked then Exit;
@@ -450,24 +437,6 @@ begin
     FuncPair.Value.MarkReferences;
   for FuncPair in FStaticSetters do
     FuncPair.Value.MarkReferences;
-
-  for SymPair in FStaticSymbolDescriptors do
-  begin
-    SymPair.Key.MarkReferences;
-    if SymPair.Value is TGocciaPropertyDescriptorData then
-    begin
-      if Assigned(TGocciaPropertyDescriptorData(SymPair.Value).Value) then
-        TGocciaPropertyDescriptorData(SymPair.Value).Value.MarkReferences;
-    end
-    else if SymPair.Value is TGocciaPropertyDescriptorAccessor then
-    begin
-      Accessor := TGocciaPropertyDescriptorAccessor(SymPair.Value);
-      if Assigned(Accessor.Getter) then
-        Accessor.Getter.MarkReferences;
-      if Assigned(Accessor.Setter) then
-        Accessor.Setter.MarkReferences;
-    end;
-  end;
 
   // Mark decorator initializer arrays
   for I := 0 to High(FMethodInitializers) do
@@ -588,13 +557,39 @@ begin
 end;
 
 procedure TGocciaClassValue.AddStaticGetter(const AName: string; const AGetter: TGocciaFunctionBase);
+var
+  ExistingDescriptor: TGocciaPropertyDescriptor;
+  ExistingSetter: TGocciaValue;
 begin
   FStaticGetters.AddOrSetValue(AName, AGetter);
+
+  ExistingDescriptor := inherited GetOwnPropertyDescriptor(AName);
+  ExistingSetter := nil;
+  if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
+     Assigned(TGocciaPropertyDescriptorAccessor(ExistingDescriptor).Setter) then
+    ExistingSetter := TGocciaPropertyDescriptorAccessor(ExistingDescriptor).Setter;
+
+  inherited DefineProperty(AName,
+    TGocciaPropertyDescriptorAccessor.Create(
+      AGetter, ExistingSetter, [pfConfigurable]));
 end;
 
 procedure TGocciaClassValue.AddStaticSetter(const AName: string; const ASetter: TGocciaFunctionBase);
+var
+  ExistingDescriptor: TGocciaPropertyDescriptor;
+  ExistingGetter: TGocciaValue;
 begin
   FStaticSetters.AddOrSetValue(AName, ASetter);
+
+  ExistingDescriptor := inherited GetOwnPropertyDescriptor(AName);
+  ExistingGetter := nil;
+  if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
+     Assigned(TGocciaPropertyDescriptorAccessor(ExistingDescriptor).Getter) then
+    ExistingGetter := TGocciaPropertyDescriptorAccessor(ExistingDescriptor).Getter;
+
+  inherited DefineProperty(AName,
+    TGocciaPropertyDescriptorAccessor.Create(
+      ExistingGetter, ASetter, [pfConfigurable]));
 end;
 
 procedure TGocciaClassValue.AddPrivateGetter(const AName: string; const AGetter: TGocciaFunctionBase);
@@ -1193,142 +1188,9 @@ begin
     Result := inherited HasOwnProperty(AName);
 end;
 
-procedure TGocciaClassValue.DefineSymbolProperty(const ASymbol: TGocciaSymbolValue; const ADescriptor: TGocciaPropertyDescriptor);
-begin
-  FStaticSymbolDescriptors.AddOrSetValue(ASymbol, ADescriptor);
-end;
-
 function TGocciaClassValue.GetOwnStaticSymbolDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor;
 begin
-  if not FStaticSymbolDescriptors.TryGetValue(ASymbol, Result) then
-    Result := nil;
-end;
-
-function TGocciaClassValue.GetOwnSymbolPropertyDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor;
-begin
-  Result := GetOwnStaticSymbolDescriptor(ASymbol);
-  if not Assigned(Result) then
-    Result := inherited GetOwnSymbolPropertyDescriptor(ASymbol);
-end;
-
-function TGocciaClassValue.GetOwnSymbols: TArray<TGocciaSymbolValue>;
-var
-  Symbols, InheritedSymbols: TArray<TGocciaSymbolValue>;
-  Seen: THashMap<TGocciaSymbolValue, Boolean>;
-  Symbol: TGocciaSymbolValue;
-  Count: Integer;
-begin
-  Symbols := FStaticSymbolDescriptors.Keys;
-  InheritedSymbols := inherited GetOwnSymbols;
-  Seen := THashMap<TGocciaSymbolValue, Boolean>.Create;
-  try
-    SetLength(Result, Length(Symbols) + Length(InheritedSymbols));
-    Count := 0;
-
-    for Symbol in Symbols do
-    begin
-      if Seen.ContainsKey(Symbol) then
-        Continue;
-      Seen.Add(Symbol, True);
-      Result[Count] := Symbol;
-      Inc(Count);
-    end;
-
-    for Symbol in InheritedSymbols do
-    begin
-      if Seen.ContainsKey(Symbol) then
-        Continue;
-      Seen.Add(Symbol, True);
-      Result[Count] := Symbol;
-      Inc(Count);
-    end;
-
-    SetLength(Result, Count);
-  finally
-    Seen.Free;
-  end;
-end;
-
-procedure TGocciaClassValue.AssignSymbolProperty(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue);
-var
-  Descriptor: TGocciaPropertyDescriptor;
-  Accessor: TGocciaPropertyDescriptorAccessor;
-  Args: TGocciaArgumentsCollection;
-  Current: TGocciaClassValue;
-begin
-  Current := Self;
-  while Assigned(Current) do
-  begin
-    if Current.FStaticSymbolDescriptors.TryGetValue(ASymbol, Descriptor) then
-    begin
-      if Descriptor is TGocciaPropertyDescriptorAccessor then
-      begin
-        Accessor := TGocciaPropertyDescriptorAccessor(Descriptor);
-      if Assigned(Accessor.Setter) then
-      begin
-        Args := TGocciaArgumentsCollection.Create;
-        try
-          Args.Add(AValue);
-          if Accessor.Setter is TGocciaFunctionBase then
-            TGocciaFunctionBase(Accessor.Setter).Call(Args, Self);
-        finally
-          Args.Free;
-        end;
-        Exit;
-        end
-        else
-          ThrowTypeError(SErrorClassSetterOnlyAccessor, SSuggestPropertyHasOnlyGetter);
-      end;
-      Break;
-    end;
-    Current := Current.FSuperClass;
-  end;
-
-  DefineSymbolProperty(ASymbol, TGocciaPropertyDescriptorData.Create(AValue, [pfEnumerable, pfConfigurable, pfWritable]));
-end;
-
-function TGocciaClassValue.GetSymbolProperty(const ASymbol: TGocciaSymbolValue): TGocciaValue;
-begin
-  Result := GetSymbolPropertyWithReceiver(ASymbol, Self);
-end;
-
-function TGocciaClassValue.GetSymbolPropertyWithReceiver(const ASymbol: TGocciaSymbolValue; const AReceiver: TGocciaValue): TGocciaValue;
-var
-  Descriptor: TGocciaPropertyDescriptor;
-  Accessor: TGocciaPropertyDescriptorAccessor;
-  Args: TGocciaArgumentsCollection;
-begin
-  if FStaticSymbolDescriptors.TryGetValue(ASymbol, Descriptor) then
-  begin
-    if Descriptor is TGocciaPropertyDescriptorData then
-    begin
-      Result := TGocciaPropertyDescriptorData(Descriptor).Value;
-      Exit;
-    end
-    else if Descriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      Accessor := TGocciaPropertyDescriptorAccessor(Descriptor);
-      if Assigned(Accessor.Getter) then
-      begin
-        if Accessor.Getter is TGocciaFunctionBase then
-        begin
-          Args := TGocciaArgumentsCollection.CreateWithCapacity(0);
-          try
-            Result := TGocciaFunctionBase(Accessor.Getter).Call(Args, AReceiver);
-          finally
-            Args.Free;
-          end;
-        end
-        else
-          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-        Exit;
-      end;
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Exit;
-    end;
-  end;
-
-  Result := inherited GetSymbolPropertyWithReceiver(ASymbol, AReceiver);
+  Result := inherited GetOwnSymbolPropertyDescriptor(ASymbol);
 end;
 
 // ES2026 §10.2.2 [[Call]] — class constructors are not callable without new

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -45,8 +45,6 @@ type
     FPrivateMethods: TOrderedStringMap<TGocciaMethodValue>;
     FPrivateGetters: TOrderedStringMap<TGocciaFunctionBase>;
     FPrivateSetters: TOrderedStringMap<TGocciaFunctionBase>;
-    FStaticGetters: TOrderedStringMap<TGocciaFunctionBase>;
-    FStaticSetters: TOrderedStringMap<TGocciaFunctionBase>;
     FNativeSuperConstructor: TGocciaObjectValue;
     FPrivateBrandToken: string;
     FMethodInitializers: array of TGocciaValue;
@@ -355,8 +353,6 @@ begin
   FPrivateMethods := TOrderedStringMap<TGocciaMethodValue>.Create;
   FPrivateGetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
   FPrivateSetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
-  FStaticGetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
-  FStaticSetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
   FNativeSuperConstructor := nil;
   FClassPrototype := TGocciaObjectValue.Create;
   FConstructorMethod := nil;
@@ -381,8 +377,6 @@ begin
   FPrivateMethods.Free;
   FPrivateGetters.Free;
   FPrivateSetters.Free;
-  FStaticGetters.Free;
-  FStaticSetters.Free;
   // Don't free FClassPrototype - it's GC-managed
   inherited;
 end;
@@ -431,11 +425,6 @@ begin
   for FuncPair in FPrivateGetters do
     FuncPair.Value.MarkReferences;
   for FuncPair in FPrivateSetters do
-    FuncPair.Value.MarkReferences;
-
-  for FuncPair in FStaticGetters do
-    FuncPair.Value.MarkReferences;
-  for FuncPair in FStaticSetters do
     FuncPair.Value.MarkReferences;
 
   // Mark decorator initializer arrays
@@ -561,8 +550,6 @@ var
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingSetter: TGocciaValue;
 begin
-  FStaticGetters.AddOrSetValue(AName, AGetter);
-
   ExistingDescriptor := inherited GetOwnPropertyDescriptor(AName);
   ExistingSetter := nil;
   if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
@@ -579,8 +566,6 @@ var
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingGetter: TGocciaValue;
 begin
-  FStaticSetters.AddOrSetValue(AName, ASetter);
-
   ExistingDescriptor := inherited GetOwnPropertyDescriptor(AName);
   ExistingGetter := nil;
   if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
@@ -687,15 +672,33 @@ begin
 end;
 
 function TGocciaClassValue.GetStaticPropertyGetter(const AName: string): TGocciaFunctionBase;
+var
+  Descriptor: TGocciaPropertyDescriptor;
+  Getter: TGocciaValue;
 begin
-  if not FStaticGetters.TryGetValue(AName, Result) then
-    Result := nil;
+  Result := nil;
+  Descriptor := inherited GetOwnPropertyDescriptor(AName);
+  if Descriptor is TGocciaPropertyDescriptorAccessor then
+  begin
+    Getter := TGocciaPropertyDescriptorAccessor(Descriptor).Getter;
+    if Getter is TGocciaFunctionBase then
+      Result := TGocciaFunctionBase(Getter);
+  end;
 end;
 
 function TGocciaClassValue.GetStaticPropertySetter(const AName: string): TGocciaFunctionBase;
+var
+  Descriptor: TGocciaPropertyDescriptor;
+  Setter: TGocciaValue;
 begin
-  if not FStaticSetters.TryGetValue(AName, Result) then
-    Result := nil;
+  Result := nil;
+  Descriptor := inherited GetOwnPropertyDescriptor(AName);
+  if Descriptor is TGocciaPropertyDescriptorAccessor then
+  begin
+    Setter := TGocciaPropertyDescriptorAccessor(Descriptor).Setter;
+    if Setter is TGocciaFunctionBase then
+      Result := TGocciaFunctionBase(Setter);
+  end;
 end;
 
 procedure TGocciaClassValue.AddFieldInitializer(const AName: string; const AInitializer: TGocciaValue; const AIsPrivate, AIsStatic: Boolean);
@@ -1061,8 +1064,7 @@ end;
 
 function TGocciaClassValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 var
-  Getter: TGocciaFunctionBase;
-  Args: TGocciaArgumentsCollection;
+  Descriptor: TGocciaPropertyDescriptor;
 begin
   if AName = PROP_PROTOTYPE then
   begin
@@ -1073,25 +1075,15 @@ begin
   if FStaticMethods.TryGetValue(AName, Result) then
     Exit;
 
-  if FStaticGetters.TryGetValue(AName, Getter) then
-  begin
-    Args := TGocciaArgumentsCollection.CreateWithCapacity(0);
-    try
-      Result := Getter.Call(Args, AThisContext);
-    finally
-      Args.Free;
-    end;
-    Exit;
-  end;
-
-  if FStaticSetters.ContainsKey(AName) then
-  begin
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Exit;
-  end;
-
   if AName = PROP_NAME then
   begin
+    Descriptor := inherited GetOwnPropertyDescriptor(AName);
+    if Assigned(Descriptor) then
+    begin
+      Result := inherited GetPropertyWithContext(AName, AThisContext);
+      Exit;
+    end;
+
     if FName = '<anonymous>' then
       Result := TGocciaStringLiteralValue.Create('')
     else
@@ -1101,6 +1093,13 @@ begin
 
   if AName = PROP_LENGTH then
   begin
+    Descriptor := inherited GetOwnPropertyDescriptor(AName);
+    if Assigned(Descriptor) then
+    begin
+      Result := inherited GetPropertyWithContext(AName, AThisContext);
+      Exit;
+    end;
+
     Result := TGocciaNumberLiteralValue.Create(GetClassLength);
     Exit;
   end;
@@ -1112,30 +1111,23 @@ end;
 
 procedure TGocciaClassValue.SetProperty(const AName: string; const AValue: TGocciaValue);
 var
-  Setter: TGocciaFunctionBase;
-  Args: TGocciaArgumentsCollection;
-  Current: TGocciaClassValue;
+  Descriptor: TGocciaPropertyDescriptor;
 begin
-  Current := Self;
-  repeat
-    if Current.FStaticSetters.TryGetValue(AName, Setter) then
-    begin
-      Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
-      try
-        Args.Add(AValue);
-        Setter.Call(Args, Self);
-      finally
-        Args.Free;
-      end;
-      Exit;
-    end;
-    Current := Current.FSuperClass;
-  until not Assigned(Current);
-
   // .name override via static field or assignment: use DefineProperty to
   // override the synthesized non-writable descriptor (which is configurable)
   if AName = PROP_NAME then
   begin
+    Descriptor := inherited GetOwnPropertyDescriptor(AName);
+    if Assigned(Descriptor) then
+    begin
+      inherited SetProperty(AName, AValue);
+      Descriptor := inherited GetOwnPropertyDescriptor(AName);
+      if (Descriptor is TGocciaPropertyDescriptorData) and
+         (TGocciaPropertyDescriptorData(Descriptor).Value is TGocciaStringLiteralValue) then
+        FName := TGocciaStringLiteralValue(TGocciaPropertyDescriptorData(Descriptor).Value).Value;
+      Exit;
+    end;
+
     if AValue is TGocciaStringLiteralValue then
       FName := TGocciaStringLiteralValue(AValue).Value;
     inherited DefineProperty(AName,

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -1128,6 +1128,15 @@ begin
       Exit;
     end;
 
+    Descriptor := GetOwnPropertyDescriptor(AName);
+    if (Descriptor is TGocciaPropertyDescriptorData) and
+       (not TGocciaPropertyDescriptorData(Descriptor).Writable) then
+    begin
+      inherited DefineProperty(AName, Descriptor);
+      inherited SetProperty(AName, AValue);
+      Exit;
+    end;
+
     if AValue is TGocciaStringLiteralValue then
       FName := TGocciaStringLiteralValue(AValue).Value;
     inherited DefineProperty(AName,

--- a/tests/language/classes/class-name-property.js
+++ b/tests/language/classes/class-name-property.js
@@ -45,9 +45,28 @@ describe("class as object property", () => {
 });
 
 describe("static name override", () => {
+  test("ordinary assignment does not override built-in .name", () => {
+    class Foo {}
+
+    expect(() => {
+      Foo.name = "Changed";
+    }).toThrow(TypeError);
+    expect(Foo.name).toBe("Foo");
+  });
+
   test("static getter overrides default .name", () => {
     class Foo { static get name() { return "Custom"; } }
     expect(Foo.name).toBe("Custom");
+  });
+
+  test("static method overrides default .name", () => {
+    class Foo {
+      static name() {
+        return "Custom";
+      }
+    }
+
+    expect(Foo.name()).toBe("Custom");
   });
 
   test("static field overrides default .name", () => {

--- a/tests/language/classes/getters-setters.js
+++ b/tests/language/classes/getters-setters.js
@@ -191,6 +191,29 @@ test("static getter and setter", () => {
   expect(Registry.count).toBe(5);
 });
 
+test("static getters and setters are constructor own accessor descriptors", () => {
+  let stored = 1;
+  class Registry {
+    static get value() {
+      return stored;
+    }
+
+    static set value(next) {
+      stored = next;
+    }
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(Registry, "value");
+
+  expect(typeof descriptor.get).toBe("function");
+  expect(typeof descriptor.set).toBe("function");
+  expect(descriptor.enumerable).toBe(false);
+  expect(descriptor.configurable).toBe(true);
+
+  Registry.value = 9;
+  expect(Registry.value).toBe(9);
+});
+
 test("static getter is not on instances", () => {
   class Foo {
     static get bar() {

--- a/tests/language/classes/getters-setters.js
+++ b/tests/language/classes/getters-setters.js
@@ -214,6 +214,63 @@ test("static getters and setters are constructor own accessor descriptors", () =
   expect(Registry.value).toBe(9);
 });
 
+test("static string accessor descriptors can be redefined or deleted", () => {
+  let setterCalls = 0;
+  class SetterOnly {
+    static set value(next) {
+      setterCalls = next;
+    }
+  }
+
+  Object.defineProperty(SetterOnly, "value", {
+    value: 1,
+    writable: true,
+    configurable: true,
+  });
+  SetterOnly.value = 2;
+
+  expect(SetterOnly.value).toBe(2);
+  expect(setterCalls).toBe(0);
+
+  class GetterOnly {
+    static get value() {
+      return 1;
+    }
+  }
+
+  Object.defineProperty(GetterOnly, "value", {
+    value: 2,
+    writable: true,
+    configurable: true,
+  });
+  expect(GetterOnly.value).toBe(2);
+
+  expect(delete GetterOnly.value).toBe(true);
+  GetterOnly.value = 3;
+  expect(GetterOnly.value).toBe(3);
+});
+
+test("own static data descriptors shadow inherited static setters", () => {
+  class Base {
+    static set value(next) {
+      this.received = next;
+    }
+  }
+
+  class Derived extends Base {}
+
+  Object.defineProperty(Derived, "value", {
+    value: 1,
+    writable: true,
+    configurable: true,
+  });
+  Derived.value = 2;
+
+  expect(Derived.value).toBe(2);
+  expect(Derived.received).toBeUndefined();
+  expect(Base.received).toBeUndefined();
+});
+
 test("static getter is not on instances", () => {
   class Foo {
     static get bar() {

--- a/tests/language/classes/method-enumerable.js
+++ b/tests/language/classes/method-enumerable.js
@@ -26,6 +26,18 @@ describe("class method enumerability", () => {
     expect(keys.includes("doStuff")).toBe(false);
   });
 
+  test("static methods are non-enumerable on the constructor", () => {
+    class Foo {
+      static bar() { return 1; }
+    }
+
+    const desc = Object.getOwnPropertyDescriptor(Foo, "bar");
+    expect(desc.enumerable).toBe(false);
+    expect(desc.writable).toBe(true);
+    expect(desc.configurable).toBe(true);
+    expect(Object.keys(Foo).includes("bar")).toBe(false);
+  });
+
   test("constructor property is also non-enumerable", () => {
     class C {}
     const desc = Object.getOwnPropertyDescriptor(C.prototype, "constructor");

--- a/tests/language/function-keyword/generator-function.js
+++ b/tests/language/function-keyword/generator-function.js
@@ -41,3 +41,34 @@ test("function* is not constructable", () => {
 
   expect(() => new make()).toThrow(TypeError);
 });
+
+test("class static getter backed by function* returns a generator object", () => {
+  class C {}
+  Object.defineProperty(C, "value", {
+    get: function* () {
+      yield 1;
+    },
+    configurable: true,
+  });
+
+  const iter = C.value;
+
+  expect(iter.next()).toEqual({ value: 1, done: false });
+  expect(iter.next()).toEqual({ value: undefined, done: true });
+});
+
+test("class static setter backed by function* is called as a generator function", () => {
+  let called = 0;
+  class C {}
+  Object.defineProperty(C, "value", {
+    set: function* (next) {
+      called = next;
+      yield next;
+    },
+    configurable: true,
+  });
+
+  C.value = 5;
+
+  expect(called).toBe(0);
+});

--- a/tests/language/non-strict-mode/assignment.js
+++ b/tests/language/non-strict-mode/assignment.js
@@ -153,4 +153,59 @@ describe("non-strict assignment", () => {
     expect(10 in array).toBe(false);
     expect(array[10]).toBeUndefined();
   });
+
+  test("class constructor static setters receive non-strict assignments", () => {
+    let captured = 0;
+    const computed = "computed";
+    const symbolKey = Symbol("staticSetter");
+
+    class C {
+      static set eval(value) {
+        captured = captured + value;
+      }
+
+      static set arguments(value) {
+        captured = captured + value * 10;
+      }
+
+      static set [computed](value) {
+        captured = captured + value * 100;
+      }
+
+      static set [symbolKey](value) {
+        captured = captured + value * 1000;
+      }
+    }
+
+    const evalDescriptor = Object.getOwnPropertyDescriptor(C, "eval");
+    const symbolDescriptor = Object.getOwnPropertyDescriptor(C, symbolKey);
+
+    C.eval = 1;
+    C.arguments = 2;
+    C[computed] = 3;
+    C[symbolKey] = 4;
+
+    expect(captured).toBe(4321);
+    expect(typeof evalDescriptor.set).toBe("function");
+    expect(evalDescriptor.enumerable).toBe(false);
+    expect(evalDescriptor.configurable).toBe(true);
+    expect(typeof symbolDescriptor.set).toBe("function");
+    expect(symbolDescriptor.enumerable).toBe(false);
+    expect(symbolDescriptor.configurable).toBe(true);
+  });
+
+  test("inherited static setters receive the derived constructor as receiver", () => {
+    class Base {
+      static set value(next) {
+        this.received = next;
+      }
+    }
+
+    class Derived extends Base {}
+
+    Derived.value = 7;
+
+    expect(Derived.received).toBe(7);
+    expect(Base.received).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Represent static class string accessors as constructor own accessor descriptors so descriptor lookup and assignment use the ordinary object property path.
- Store static symbol descriptors on the constructor's normal symbol descriptor storage and keep static accessor descriptors non-enumerable.
- Closes #650.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation (not applicable: spec-compliance bugfix with no user-facing docs change)
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
