### PR TITLE
Fix Goccia.gc test runner result rooting

### DIFF
--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -457,8 +457,15 @@ var
   Engine: TGocciaEngine;
   Executor: TGocciaInterpreterExecutor;
   EngineResult: TGocciaScriptResult;
+  GC: TGarbageCollector;
+  EngineResultRooted: Boolean;
 begin
   ScriptResult := CreateDefaultScriptResult;
+  GC := TGarbageCollector.Instance;
+  EngineResult.Result := nil;
+  EngineResultRooted := False;
+  if Assigned(GC) then
+    GC.AddTempRoot(ScriptResult);
 
   Source := nil;
   try
@@ -498,6 +505,11 @@ begin
           StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
           try
             EngineResult := Engine.Execute;
+            if Assigned(GC) and Assigned(EngineResult.Result) then
+            begin
+              GC.AddTempRoot(EngineResult.Result);
+              EngineResultRooted := True;
+            end;
           finally
             ClearExecutionTimeout;
             ClearInstructionLimit;
@@ -544,6 +556,10 @@ begin
       end;
     end;
   finally
+    if EngineResultRooted and Assigned(GC) then
+      GC.RemoveTempRoot(EngineResult.Result);
+    if Assigned(GC) then
+      GC.RemoveTempRoot(ScriptResult);
     Source.Free;
   end;
 end;
@@ -572,10 +588,17 @@ var
   Engine: TGocciaEngine;
   ScriptResult: TGocciaObjectValue;
   ResultValue: TGocciaValue;
+  GC: TGarbageCollector;
+  ResultValueRooted: Boolean;
   OrigLine, OrigCol, I: Integer;
   LexStart, LexEnd, ParseEnd, CompileEnd, ExecEnd: Int64;
 begin
   ScriptResult := CreateDefaultScriptResult;
+  ResultValue := nil;
+  GC := TGarbageCollector.Instance;
+  ResultValueRooted := False;
+  if Assigned(GC) then
+    GC.AddTempRoot(ScriptResult);
 
   Source := nil;
   try
@@ -678,6 +701,11 @@ begin
             StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
             try
               ResultValue := RunBytecodeTestModule(Engine, Module, AFileName);
+              if Assigned(GC) and Assigned(ResultValue) then
+              begin
+                GC.AddTempRoot(ResultValue);
+                ResultValueRooted := True;
+              end;
             finally
               ClearExecutionTimeout;
               ClearInstructionLimit;
@@ -736,6 +764,10 @@ begin
       SourceMap.Free;
     end;
   finally
+    if ResultValueRooted and Assigned(GC) then
+      GC.RemoveTempRoot(ResultValue);
+    if Assigned(GC) then
+      GC.RemoveTempRoot(ScriptResult);
     Source.Free;
   end;
 end;

--- a/tests/built-ins/global-properties/goccia.js
+++ b/tests/built-ins/global-properties/goccia.js
@@ -27,6 +27,11 @@ describe.runIf(hasGoccia)("Goccia global", () => {
       expect(result).toBe(undefined);
     });
 
+    test("gc does not interrupt test result aggregation", () => {
+      Goccia.gc();
+      expect(1).toBe(1);
+    });
+
     test("gc can be called multiple times", () => {
       Goccia.gc();
       Goccia.gc();


### PR DESCRIPTION
## Summary

- Root the test runner's per-file result object while scripts execute so `Goccia.gc()` cannot sweep it before result aggregation.
- Root the `runTests()` result during post-engine teardown merging in both interpreted and bytecode test-runner paths.
- Add a focused `Goccia.gc` regression assertion for continued test result aggregation.
- Closes #660.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas testrunner`
  - `printf 'test("gc returns", () => { const result = Goccia.gc(); expect(result).toBe(undefined); });\n' | ./build/GocciaTestRunner --asi`
  - `./build/GocciaTestRunner tests/built-ins/global-properties/goccia.js --asi --unsafe-ffi --jobs=1`
  - `./build/GocciaTestRunner tests/built-ins/global-properties/goccia.js --asi --unsafe-ffi --jobs=1 --mode=bytecode`
  - `./build/GocciaTestRunner tests/built-ins/WeakMap/gc.js --asi --unsafe-ffi --jobs=1`
  - `./build/GocciaTestRunner tests/built-ins/WeakSet/gc.js --asi --unsafe-ffi --jobs=1`
  - `./format.pas --check`
  - `cc -shared -o libfixture.dylib fixture.c` from `fixtures/ffi/`, then `./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress`
- [ ] Updated documentation (not applicable: internal test-runner GC lifetime fix)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change