### PR TITLE
Add top-level await while condition regressions

### DIFF
--- a/tests/language/while-loops/top-level-await/conditions.js
+++ b/tests/language/while-loops/top-level-await/conditions.js
@@ -1,0 +1,24 @@
+/*---
+description: Top-level await operands in while-loop conditions
+features: [top-level-await, compat-while-loops]
+---*/
+
+let objectConditionIterations = 0;
+while (await { function() {} }) {
+  objectConditionIterations++;
+  break;
+}
+
+let regexpConditionIterations = 0;
+while (await /1/) {
+  regexpConditionIterations++;
+  break;
+}
+
+test("while condition accepts top-level await of object literal with function property name", () => {
+  expect(objectConditionIterations).toBe(1);
+});
+
+test("while condition accepts top-level await of regular expression literal", () => {
+  expect(regexpConditionIterations).toBe(1);
+});

--- a/tests/language/while-loops/top-level-await/goccia.json
+++ b/tests/language/while-loops/top-level-await/goccia.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../goccia.json",
+  "source-type": "module"
+}


### PR DESCRIPTION
## Summary

- Add module-source regression coverage for `while (await { function() {} })` and `while (await /1/)` under `compat-while-loops`.
- Confirm the current parser accepts object-literal and regular-expression operands after top-level `await`; no engine changes needed.
- Closes #653.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build/GocciaTestRunner tests/language/while-loops/top-level-await/conditions.js --asi --output=compact-json`
  - `./build/GocciaTestRunner tests/language/while-loops/top-level-await/conditions.js --asi --mode=bytecode --output=compact-json`
  - `./build/GocciaTestRunner tests/language/while-loops --asi --output=compact-json`
  - `./build/GocciaTestRunner tests/language/while-loops --asi --mode=bytecode --output=compact-json`
  - `./fixtures/ffi/build.sh`
  - `./build.pas testrunner && ./build/GocciaTestRunner tests --asi --unsafe-ffi`
- [x] Updated documentation (not applicable; tests-only regression coverage)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change