### PR TITLE
Fix RegExp modifier word escapes

### DIFF
--- a/source/units/Goccia.RegExp.Compiler.pas
+++ b/source/units/Goccia.RegExp.Compiler.pas
@@ -53,6 +53,8 @@ const
   BACKREF_INDEX_MASK = $1FFFFF;
   LOOK_NEGATED_FLAG = $800000;
   LOOK_TARGET_MASK = $7FFFFF;
+  WORD_ASSERT_NEGATED_FLAG = $1;
+  WORD_ASSERT_ICASE_FLAG = $2;
 
 function CompileRegExp(const APattern, AFlags: string): TRegExpProgram;
 procedure ValidateRegExpPatternNew(const APattern, AFlags: string);
@@ -141,6 +143,8 @@ type
     procedure EmitClassContents(const AContents: TRegExpClassContents;
       ANegated: Boolean);
     procedure AddBuiltinCharClass(AEscapeChar: Char; var ARanges: array of TRegExpCharRange; var ARangeCount: Integer);
+    procedure AddWordCharacterRanges(var ARanges: array of TRegExpCharRange; var ARangeCount: Integer);
+    procedure AddCaseFoldedWordComplementRanges(var ARanges: array of TRegExpCharRange; var ARangeCount: Integer);
     procedure AddRange(var ARanges: array of TRegExpCharRange; var ARangeCount: Integer; ALo, AHi: Cardinal);
     procedure EmitUnicodePropertyClass(const APropertyName: string; ANegated: Boolean);
     procedure GetUnicodePropertyRanges(const APropertyName: string; var ARanges: array of TRegExpCharRange; var ARangeCount: Integer);
@@ -399,6 +403,15 @@ begin
   Inc(ARangeCount);
 end;
 
+procedure TRegExpCompiler.AddWordCharacterRanges(
+  var ARanges: array of TRegExpCharRange; var ARangeCount: Integer);
+begin
+  AddRange(ARanges, ARangeCount, Ord('0'), Ord('9'));
+  AddRange(ARanges, ARangeCount, Ord('A'), Ord('Z'));
+  AddRange(ARanges, ARangeCount, Ord('_'), Ord('_'));
+  AddRange(ARanges, ARangeCount, Ord('a'), Ord('z'));
+end;
+
 procedure TRegExpCompiler.AddBuiltinCharClass(AEscapeChar: Char;
   var ARanges: array of TRegExpCharRange; var ARangeCount: Integer);
 begin
@@ -411,19 +424,19 @@ begin
         AddRange(ARanges, ARangeCount, Ord('9') + 1, $10FFFF);
       end;
     'w':
-      begin
-        AddRange(ARanges, ARangeCount, Ord('0'), Ord('9'));
-        AddRange(ARanges, ARangeCount, Ord('A'), Ord('Z'));
-        AddRange(ARanges, ARangeCount, Ord('_'), Ord('_'));
-        AddRange(ARanges, ARangeCount, Ord('a'), Ord('z'));
-      end;
+      AddWordCharacterRanges(ARanges, ARangeCount);
     'W':
       begin
-        AddRange(ARanges, ARangeCount, 0, Ord('0') - 1);
-        AddRange(ARanges, ARangeCount, Ord('9') + 1, Ord('A') - 1);
-        AddRange(ARanges, ARangeCount, Ord('Z') + 1, Ord('_') - 1);
-        AddRange(ARanges, ARangeCount, Ord('_') + 1, Ord('a') - 1);
-        AddRange(ARanges, ARangeCount, Ord('z') + 1, $10FFFF);
+        if FModifier.IgnoreCase and FUnicode then
+          AddCaseFoldedWordComplementRanges(ARanges, ARangeCount)
+        else
+        begin
+          AddRange(ARanges, ARangeCount, 0, Ord('0') - 1);
+          AddRange(ARanges, ARangeCount, Ord('9') + 1, Ord('A') - 1);
+          AddRange(ARanges, ARangeCount, Ord('Z') + 1, Ord('_') - 1);
+          AddRange(ARanges, ARangeCount, Ord('_') + 1, Ord('a') - 1);
+          AddRange(ARanges, ARangeCount, Ord('z') + 1, $10FFFF);
+        end;
       end;
     's':
       begin
@@ -680,6 +693,44 @@ begin
       end;
     end;
   end;
+end;
+
+procedure TRegExpCompiler.AddCaseFoldedWordComplementRanges(
+  var ARanges: array of TRegExpCharRange; var ARangeCount: Integer);
+var
+  AllRange: array[0..0] of TRegExpCharRange;
+  ComplementRanges: array[0..MAX_CHAR_RANGES - 1] of TRegExpCharRange;
+  FoldRanges: TUnicodePropertyRangeArray;
+  FoldedRanges: array[0..MAX_CHAR_RANGES - 1] of TRegExpCharRange;
+  WordRanges: array[0..MAX_CHAR_RANGES - 1] of TRegExpCharRange;
+  ComplementCount, FoldedCount, I, WordCount: Integer;
+begin
+  WordCount := 0;
+  AddWordCharacterRanges(WordRanges, WordCount);
+  SetLength(FoldRanges, WordCount);
+  for I := 0 to WordCount - 1 do
+  begin
+    FoldRanges[I].Lo := WordRanges[I].Lo;
+    FoldRanges[I].Hi := WordRanges[I].Hi;
+  end;
+  ExpandUnicodeSimpleCaseFolding(FoldRanges);
+  if Length(FoldRanges) > Length(FoldedRanges) then
+    raise EConvertError.Create('Folded word character range count exceeds buffer capacity');
+  FoldedCount := Length(FoldRanges);
+  for I := 0 to FoldedCount - 1 do
+  begin
+    FoldedRanges[I].Lo := FoldRanges[I].Lo;
+    FoldedRanges[I].Hi := FoldRanges[I].Hi;
+  end;
+  NormalizeRanges(FoldedRanges, FoldedCount);
+
+  AllRange[0].Lo := 0;
+  AllRange[0].Hi := $10FFFF;
+  SubtractRanges(AllRange, 1, FoldedRanges, FoldedCount,
+    ComplementRanges, ComplementCount);
+  for I := 0 to ComplementCount - 1 do
+    AddRange(ARanges, ARangeCount, ComplementRanges[I].Lo,
+      ComplementRanges[I].Hi);
 end;
 
 procedure InitClassContents(var AContents: TRegExpClassContents);
@@ -1688,7 +1739,7 @@ var
   PropertyName: string;
   Negated: Boolean;
   GroupName: string;
-  BackrefIdx, I, GroupCount, BackrefFlags: Integer;
+  BackrefIdx, I, GroupCount, BackrefFlags, WordAssertFlags: Integer;
   CodePoint: Cardinal;
 begin
   BackrefFlags := 0;
@@ -1705,9 +1756,19 @@ begin
         EmitCharClassRanges(Ranges, RangeCount, False);
       end;
     'b':
-      Emit(EncodeOpBx(RX_ASSERT_WORD, 0));
+      begin
+        WordAssertFlags := 0;
+        if FModifier.IgnoreCase then
+          WordAssertFlags := WordAssertFlags or WORD_ASSERT_ICASE_FLAG;
+        Emit(EncodeOpBx(RX_ASSERT_WORD, WordAssertFlags));
+      end;
     'B':
-      Emit(EncodeOpBx(RX_ASSERT_WORD, 1));
+      begin
+        WordAssertFlags := WORD_ASSERT_NEGATED_FLAG;
+        if FModifier.IgnoreCase then
+          WordAssertFlags := WordAssertFlags or WORD_ASSERT_ICASE_FLAG;
+        Emit(EncodeOpBx(RX_ASSERT_WORD, WordAssertFlags));
+      end;
     'p', 'P':
       begin
         if FUnicode and Match('{') then

--- a/source/units/Goccia.RegExp.VM.pas
+++ b/source/units/Goccia.RegExp.VM.pas
@@ -138,12 +138,23 @@ begin
   Result := False;
 end;
 
-function IsWordChar(ACodePoint: Cardinal): Boolean; inline;
+function IsBasicWordChar(ACodePoint: Cardinal): Boolean; inline;
 begin
   Result := ((ACodePoint >= Ord('a')) and (ACodePoint <= Ord('z'))) or
             ((ACodePoint >= Ord('A')) and (ACodePoint <= Ord('Z'))) or
             ((ACodePoint >= Ord('0')) and (ACodePoint <= Ord('9'))) or
             (ACodePoint = Ord('_'));
+end;
+
+function IsWordChar(ACodePoint: Cardinal; AUnicodeAware,
+  AIgnoreCase: Boolean): Boolean; inline;
+begin
+  if IsBasicWordChar(ACodePoint) then
+    Exit(True);
+  if not AUnicodeAware or not AIgnoreCase then
+    Exit(False);
+  Result := IsBasicWordChar(RegExpCanonicalizeCodePoint(ACodePoint, True,
+    True));
 end;
 
 function IsLineTerminator(ACodePoint: Cardinal): Boolean; inline;
@@ -312,6 +323,7 @@ var
   MatchCP: Cardinal;
   BeforeCP: Cardinal;
   BeforeIsWord, AfterIsWord: Boolean;
+  WordIgnoreCase: Boolean;
   Negated: Boolean;
   BackrefGroup: Integer;
   BackrefICase: Boolean;
@@ -615,15 +627,18 @@ begin
 
       RX_ASSERT_WORD:
         begin
-          Negated := Bx <> 0;
+          Negated := (Bx and WORD_ASSERT_NEGATED_FLAG) <> 0;
+          WordIgnoreCase := (Bx and WORD_ASSERT_ICASE_FLAG) <> 0;
           BeforeIsWord := False;
           AfterIsWord := False;
           if GetCodePointBefore(AInput, InputPos, AProgram.FullUnicode,
              BeforeCP) then
-            BeforeIsWord := IsWordChar(BeforeCP);
+            BeforeIsWord := IsWordChar(BeforeCP, AProgram.FullUnicode,
+              WordIgnoreCase);
           if ReadInputCodePoint(AInput, InputPos, AProgram.FullUnicode,
              CodePoint, ByteLen) then
-            AfterIsWord := IsWordChar(CodePoint);
+            AfterIsWord := IsWordChar(CodePoint, AProgram.FullUnicode,
+              WordIgnoreCase);
           if Negated then
           begin
             if BeforeIsWord <> AfterIsWord then

--- a/source/units/Goccia.RegExp.VM.pas
+++ b/source/units/Goccia.RegExp.VM.pas
@@ -153,8 +153,8 @@ begin
     Exit(True);
   if not AUnicodeAware or not AIgnoreCase then
     Exit(False);
-  Result := IsBasicWordChar(RegExpCanonicalizeCodePoint(ACodePoint, True,
-    True));
+  Result := IsBasicWordChar(RegExpCanonicalizeCodePoint(ACodePoint,
+    AUnicodeAware, AIgnoreCase));
 end;
 
 function IsLineTerminator(ACodePoint: Cardinal): Boolean; inline;

--- a/tests/built-ins/RegExp/modifiers.js
+++ b/tests/built-ins/RegExp/modifiers.js
@@ -239,6 +239,31 @@ test("(?-i:\\1) disables case-folding for backreference", () => {
   expect(re.test("aA")).toBe(false);
 });
 
+// --- Modifier scoping affects word escapes ---
+
+test("(?i:...) enables Unicode case folding for word boundaries", () => {
+  expect(/(?i:\b)/u.test("\u017f")).toBe(true);
+  expect(/(?i:\b)/u.test("\u212a")).toBe(true);
+  expect(/(?i:Z\B)/u.test("Z\u017f")).toBe(true);
+  expect(/(?i:Z\B)/u.test("Z\u212a")).toBe(true);
+});
+
+test("(?i:...) enables Unicode case folding for word character classes", () => {
+  expect(/(?i:\w)/u.test("\u017f")).toBe(true);
+  expect(/(?i:\w)/u.test("\u212a")).toBe(true);
+  expect(/(?i:\W)/u.test("\u017f")).toBe(false);
+  expect(/(?i:\W)/u.test("\u212a")).toBe(false);
+});
+
+test("(?-i:...) disables Unicode case folding for word escapes", () => {
+  const boundary = new RegExp("(?-i:\\b)", "iu");
+  const word = new RegExp("(?-i:\\w)", "iu");
+  const nonWord = new RegExp("(?-i:\\W)", "iu");
+  expect(boundary.test("\u017f")).toBe(false);
+  expect(word.test("\u017f")).toBe(false);
+  expect(nonWord.test("\u017f")).toBe(true);
+});
+
 // --- Error cases: double dash ---
 
 test("(?i--s:...) double dash throws SyntaxError", () => {

--- a/tests/built-ins/RegExp/modifiers.js
+++ b/tests/built-ins/RegExp/modifiers.js
@@ -255,6 +255,15 @@ test("(?i:...) enables Unicode case folding for word character classes", () => {
   expect(/(?i:\W)/u.test("\u212a")).toBe(false);
 });
 
+test("(?i:...) preserves ASCII and punctuation behavior for word character classes", () => {
+  expect(/(?i:\w)/u.test("A")).toBe(true);
+  expect(/(?i:\w)/u.test("_")).toBe(true);
+  expect(/(?i:\w)/u.test("-")).toBe(false);
+  expect(/(?i:\W)/u.test("A")).toBe(false);
+  expect(/(?i:\W)/u.test("_")).toBe(false);
+  expect(/(?i:\W)/u.test("-")).toBe(true);
+});
+
 test("(?-i:...) disables Unicode case folding for word escapes", () => {
   const boundary = new RegExp("(?-i:\\b)", "iu");
   const word = new RegExp("(?-i:\\w)", "iu");


### PR DESCRIPTION
## Summary

- Encode inline `i` modifier state on RegExp word-boundary assertions so `\b` and `\B` classify Unicode case-folded word characters correctly.
- Compile `\W` as the complement of folded word characters for Unicode ignore-case regexps.
- Closes #613.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change