### PR TITLE
Fix bytecode top-level lexical binding semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,10 +313,10 @@ jobs:
         run: gcc -shared -o fixtures/ffi/libfixture.dll fixtures/ffi/fixture.c
 
       - name: Run all JavaScript tests (interpreted)
-        run: ./build/GocciaTestRunner tests --asi --unsafe-ffi --silent --no-progress --output=test-results-interpreted.json
+        run: ./build/GocciaTestRunner tests --silent --no-progress --output=test-results-interpreted.json
 
       - name: Run all JavaScript tests (bytecode)
-        run: ./build/GocciaTestRunner tests --asi --unsafe-ffi --mode=bytecode --silent --no-progress --output=test-results-bytecode.json
+        run: ./build/GocciaTestRunner tests --mode=bytecode --silent --no-progress --output=test-results-bytecode.json
 
       - name: Check GocciaTestRunner CLI behaviour
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,7 +86,7 @@ jobs:
         run: ./fixtures/ffi/build.sh
 
       - name: Run all JavaScript tests
-        run: ./build/GocciaTestRunner tests ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --asi --unsafe-ffi --silent --no-progress --output=test-results-${{ matrix.mode }}.json
+        run: ./build/GocciaTestRunner tests ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --silent --no-progress --output=test-results-${{ matrix.mode }}.json
 
       - name: Check GocciaTestRunner CLI behaviour
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Assistants should treat CONTRIBUTING as authoritative for contribution requireme
 ## Quick checks
 
 ```bash
-./build.pas testrunner && ./build/GocciaTestRunner tests --asi --unsafe-ffi  # after substantive changes
+./build.pas testrunner && ./build/GocciaTestRunner tests  # after substantive changes
 ./build.pas bundler && ./build/GocciaBundler example.js  # build and run the bundler
 ./format.pas --check # before push / PR
 ```
@@ -99,7 +99,7 @@ printf '1;\n---\n2;\n' | ./build/GocciaScriptLoader --multifile # Split stdin on
 ./build/GocciaREPL --log=repl.log # Start the REPL with console log capture
 ./build/GocciaREPL --stack-size=5000 # Start the REPL with custom call stack depth limit
 ./build/GocciaREPL --max-memory=10485760 # Start the REPL with 10 MB GC heap limit
-./build/GocciaTestRunner tests/ --asi # Run all JavaScript tests
+./build/GocciaTestRunner tests/ # Run all JavaScript tests
 ./build/GocciaTestRunner tests --import-map=imports.json # Run tests with an explicit import map
 ./build/GocciaTestRunner tests --config=./configs/ci.json # Run tests with an explicit config path (skips auto-discovery)
 ./build/GocciaTestRunner tests/language/expressions/ # Run a test category
@@ -109,13 +109,13 @@ printf '1;\n---\n2;\n' | ./build/GocciaScriptLoader --multifile # Split stdin on
 ./build/GocciaTestRunner tests --output=json # Emit a structured JSON envelope to stdout
 ./build/GocciaTestRunner tests --output=compact-json # Same envelope to stdout, omitting build, memory, stdout, and stderr
 ./build/GocciaTestRunner tests --mode=bytecode # Run tests via the Goccia bytecode VM
-./build/GocciaTestRunner tests/language/asi --asi # Run ASI tests with automatic semicolon insertion
+./build/GocciaTestRunner tests/language/asi # Run ASI tests configured by tests/language/asi/goccia.json
 ./build/GocciaTestRunner tests --coverage # Run tests with line and branch coverage
 ./build/GocciaTestRunner tests --coverage --coverage-format=lcov --coverage-output=coverage.lcov # Coverage with lcov output
 ./build/GocciaTestRunner tests --coverage --coverage-format=json --coverage-output=coverage.json # Coverage with JSON output
 ./build/GocciaTestRunner tests --jobs=4 # Run tests with 4 parallel workers
 ./build/GocciaTestRunner tests -j 1 # Force sequential execution (no threading)
-./build/GocciaTestRunner tests --asi --unsafe-ffi # Run all tests including FFI tests
+./build/GocciaTestRunner tests # Run all tests, including folder-configured ASI and FFI tests
 ./build/GocciaTestRunner tests --log=test-console.log # Capture console output to a log file
 ./build/GocciaTestRunner suites.js --multifile # Split a single test file on '---' and run each section as its own file
 printf 'test("two plus two", () => { expect(2 + 2).toBe(4); });\n' | ./build/GocciaTestRunner # Run a test source from stdin
@@ -150,7 +150,7 @@ printf "const x = 2 + 2; x;" | ./build/GocciaBundler --output=out.gbc # Compile 
 ./build.pas loader && ./build/GocciaScriptLoader ./example.js
 
 # Compile and run all tests
-./build.pas testrunner && ./build/GocciaTestRunner tests --asi --unsafe-ffi
+./build.pas testrunner && ./build/GocciaTestRunner tests
 
 # Compile and run a specific test
 ./build.pas testrunner && ./build/GocciaTestRunner tests/language/expressions/addition/basic-addition.js
@@ -174,6 +174,11 @@ All CLI options can be set via `goccia.json` (or `.json5` / `.toml`) discovered 
 ```json
 // tests/language/asi/goccia.json — enables ASI for this subtree
 { "asi": true }
+```
+
+```json
+// tests/built-ins/FFI/goccia.json — enables FFI for this subtree
+{ "unsafe-ffi": true }
 ```
 
 ```json

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -238,6 +238,7 @@ Relative paths are resolved against the current working directory. A missing fil
   "compat-traditional-for-loop": true,
   "compat-while-loops": true,
   "strict-types": true,
+  "unsafe-ffi": true,
   "timeout": 5000,
   "max-memory": 10485760,
   "stack-size": 3500,
@@ -268,11 +269,20 @@ This is useful for test subdirectories that need specific flags. For example, `t
 }
 ```
 
+Likewise, `tests/built-ins/FFI/goccia.json` enables FFI only for the FFI tests:
+
+```json
+{
+  "unsafe-ffi": true
+}
+```
+
 TOML equivalent (`goccia.toml`):
 
 ```toml
 asi = true
 mode = "bytecode"
+unsafe-ffi = true
 timeout = 5000
 max-memory = 10485760
 stack-size = 3500

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -19,7 +19,7 @@ Core language built-ins (Math, Object, Array, Number, JSON, Symbol, Set, Map, We
 
 Runtime globals (Console, JSON5, JSONL, TOML, YAML, CSV, TSV, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, SemVer) are registered by runtime extension classes under `source/units/Goccia.RuntimeExtensions.*.pas`. Frontends such as `GocciaScriptLoader` and `GocciaREPL` apply `TGocciaLoaderRuntimeProfile`; `GocciaTestRunner` applies the loader profile plus `TGocciaTestingLibraryRuntimeExtension`; `GocciaBenchmarkRunner` applies the loader profile plus `TGocciaBenchmarkRuntimeExtension`. `GocciaScriptLoaderBare` does not attach a runtime and exposes only a CLI-local `print(...args)` helper.
 
-FFI is not part of the loader profile. CLI tools install `TGocciaFFIRuntimeExtension` only when `--unsafe-ffi` is passed.
+FFI is not part of the loader profile. CLI tools install `TGocciaFFIRuntimeExtension` when `--unsafe-ffi` is passed or `"unsafe-ffi": true` is set in config.
 
 ## Adding a New Built-in
 
@@ -614,7 +614,7 @@ See [Binary Data Built-ins](built-ins-binary-data.md) for the complete ArrayBuff
 
 ### FFI (`Goccia.Builtins.GlobalFFI.pas`)
 
-Foreign Function Interface for calling native shared libraries. Only available when `TGocciaFFIRuntimeExtension` is installed (CLI tools do this only for `--unsafe-ffi`).
+Foreign Function Interface for calling native shared libraries. Only available when `TGocciaFFIRuntimeExtension` is installed (CLI tools do this for `--unsafe-ffi` or `"unsafe-ffi": true` in config).
 
 **FFI global object:**
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -361,7 +361,7 @@ This keeps the evaluator fully reentrant — all dependencies are explicit, maki
 - **Loader profile** — `TGocciaLoaderRuntimeProfile` installs the ordinary CLI host surface: console, host globals, structured data modules, text assets, performance, text encoding, URL/fetch, and SemVer.
 - **Testing** — The GocciaTestRunner installs `TGocciaTestingLibraryRuntimeExtension` to inject `describe`, `test`, and `expect` without polluting the loader runtime.
 - **Benchmarking** — The GocciaBenchmarkRunner installs `TGocciaBenchmarkRuntimeExtension` to inject `suite` and `bench`.
-- **FFI** — `TGocciaFFIRuntimeExtension` enables the Foreign Function Interface for calling native shared libraries, and CLI tools install it only for `--unsafe-ffi`.
+- **FFI** — `TGocciaFFIRuntimeExtension` enables the Foreign Function Interface for calling native shared libraries, and CLI tools install it for `--unsafe-ffi` or `"unsafe-ffi": true` in config.
 
 ### Global Function Placement
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -471,9 +471,9 @@ Runtime extensions are ordinary Pascal classes installed on `TGocciaRuntimeCore`
 | `TGocciaLoaderRuntimeProfile` | console, host globals, data modules, text assets, performance, text encoding, URL/fetch, SemVer | Used by ScriptLoader and REPL |
 | `TGocciaTestingLibraryRuntimeExtension` | `describe`, `test`, `expect` | Testing framework; TestRunner installs this through `TGocciaTestRunnerRuntimeProfile` |
 | `TGocciaBenchmarkRuntimeExtension` | `suite`, `bench` | Benchmark framework; BenchmarkRunner installs this through `TGocciaBenchmarkRunnerRuntimeProfile` |
-| `TGocciaFFIRuntimeExtension` | `FFI.open`, `FFILibrary`, `FFIPointer` | Native shared-library FFI; CLI tools install this only for `--unsafe-ffi` |
+| `TGocciaFFIRuntimeExtension` | `FFI.open`, `FFILibrary`, `FFIPointer` | Native shared-library FFI; CLI tools install this for `--unsafe-ffi` or `"unsafe-ffi": true` in config |
 
-When embedding, install `TGocciaFFIRuntimeExtension` to enable the FFI global. CLI tools (ScriptLoader, REPL, TestRunner, BenchmarkRunner, Bundler) expose this as the `--unsafe-ffi` flag.
+When embedding, install `TGocciaFFIRuntimeExtension` to enable the FFI global. CLI tools (ScriptLoader, REPL, TestRunner, BenchmarkRunner, Bundler) expose this as the `--unsafe-ffi` flag and matching `"unsafe-ffi"` config key.
 
 To add the test framework for a custom test runner:
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -737,9 +737,9 @@ return
 GocciaScript requires explicit semicolons by default, preventing this class of bugs. However, ASI can be enabled as an opt-in feature for greater ECMAScript compatibility:
 
 ```bash
-# Enable ASI via CLI
+# Enable ASI via CLI, or use a subtree goccia.json for tests
 ./build/GocciaScriptLoader example.js --asi
-./build/GocciaTestRunner tests/ --asi
+./build/GocciaTestRunner tests/language/asi
 ./build/GocciaREPL --asi
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@
 - **Three testing layers** — JavaScript end-to-end tests (primary), CLI behavior tests (secondary), Pascal unit tests (tertiary)
 - **Built-in test framework** — `describe`/`test`/`expect` with async support, mock functions, lifecycle hooks, and Vitest-compatible matchers
 - **One method per file** — Each test file focuses on a single method; edge cases are co-located with happy-path tests
-- **Run with**: `./build.pas testrunner && ./build/GocciaTestRunner tests --asi`
+- **Run with**: `./build.pas testrunner && ./build/GocciaTestRunner tests`
 
 GocciaScript uses three testing layers in priority order:
 
@@ -229,14 +229,14 @@ features: [addition, arithmetic]
 ### Run All Tests
 
 ```bash
-# Interpreted mode (default) — include --asi for ASI test coverage
-./build/GocciaTestRunner tests --asi
+# Interpreted mode (default)
+./build/GocciaTestRunner tests
 
 # Bytecode mode
-./build/GocciaTestRunner tests --mode=bytecode --asi
+./build/GocciaTestRunner tests --mode=bytecode
 ```
 
-Both modes must pass. The `--asi` flag enables automatic semicolon insertion tests under `tests/language/asi/`. CI runs the full suite with `--asi` in both interpreted and bytecode mode as separate matrix jobs.
+Both modes must pass. Test subtrees that require opt-in parser or runtime behavior declare it with a local `goccia.json` (for example, `tests/language/asi/goccia.json` enables ASI and `tests/built-ins/FFI/goccia.json` enables FFI). CI runs the full suite in both interpreted and bytecode mode as separate matrix jobs.
 
 ### Run a Specific Test File
 
@@ -378,7 +378,7 @@ Pascal unit tests (`*.Test.pas`) exist as a tertiary layer for behavior that can
 The `GocciaTestRunner` program:
 
 1. Scans the provided path for `.js`, `.jsx`, `.ts`, `.tsx`, and `.mjs` files.
-2. For each file, creates a fresh `TGocciaEngine`, attaches `TGocciaRuntimeCore`, applies the test-runner runtime profile, and installs the FFI runtime extension only when `--unsafe-ffi` is passed.
+2. For each file, creates a fresh `TGocciaEngine`, attaches `TGocciaRuntimeCore`, applies the test-runner runtime profile, and installs the FFI runtime extension when `--unsafe-ffi` or the file's `goccia.json` enables it.
 3. Loads the source and appends a `runTests()` call.
 4. Executes the script — `describe`/`test` blocks register themselves during execution. Nested `describe` blocks are supported; suite names are composed with ` > ` separators (e.g., `"Outer > Inner"`). Skip state is inherited by nested describes.
 5. `runTests()` executes all registered tests and collects results.

--- a/scripts/test-cli-config.ts
+++ b/scripts/test-cli-config.ts
@@ -434,7 +434,76 @@ console.log("Per-file ASI config across all apps...");
   }
 }
 
-// -- Per-file compat-var config across all apps ---------------------------------
+// -- Per-file unsafe-ffi config across runtime apps ----------------------------
+
+console.log("Per-file unsafe-ffi config across runtime apps...");
+{
+  const tmp = makeTmp();
+  const noConfigDir = makeTmp();
+  try {
+    writeFileSync(join(tmp, "goccia.json"), '{"unsafe-ffi": true}\n');
+    writeFileSync(join(tmp, "test.js"), "typeof FFI;\n");
+    writeFileSync(join(noConfigDir, "test.js"), "typeof FFI;\n");
+    writeFileSync(
+      join(tmp, "test-runner.js"),
+      'test("unsafe ffi config", () => { expect(typeof FFI).toBe("object"); });\n',
+    );
+    writeFileSync(
+      join(tmp, "bench.js"),
+      [
+        'suite("unsafe-ffi", () => {',
+        '  bench("global", {',
+        "    run: () => {",
+        '      if (typeof FFI !== "object") throw new Error("FFI missing");',
+        "      return FFI.suffix;",
+        "    },",
+        "  });",
+        "});",
+      ].join("\n") + "\n",
+    );
+
+    const loaderNoConfig = await $`${LOADER} --print ${join(noConfigDir, "test.js")} 2>&1`.text();
+    if (!containsLine(loaderNoConfig, "undefined")) throw new Error(`Loader without unsafe-ffi config should leave FFI undefined, got: ${loaderNoConfig}`);
+
+    const loaderOut = await $`${LOADER} --print ${join(tmp, "test.js")} 2>&1`.text();
+    if (!containsLine(loaderOut, "object")) throw new Error(`Loader unsafe-ffi config should expose FFI, got: ${loaderOut}`);
+
+    const loaderBc = await $`${LOADER} --print ${join(tmp, "test.js")} --mode=bytecode 2>&1`.text();
+    if (!containsLine(loaderBc, "object")) throw new Error(`Loader bytecode unsafe-ffi config should expose FFI, got: ${loaderBc}`);
+
+    const trInterp = await $`${TESTRUNNER} ${join(tmp, "test-runner.js")} --no-progress 2>&1`.text();
+    if (!trInterp.includes("Passed: 1")) throw new Error(`TestRunner unsafe-ffi config should pass, got: ${trInterp}`);
+
+    const trBc = await $`${TESTRUNNER} ${join(tmp, "test-runner.js")} --mode=bytecode --no-progress 2>&1`.text();
+    if (!trBc.includes("Passed: 1")) throw new Error(`TestRunner bytecode unsafe-ffi config should pass, got: ${trBc}`);
+
+    for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+      const bench = Bun.spawnSync(
+        [resolve(BENCHRUNNER), join(tmp, "bench.js"), "--no-progress", ...modeArgs],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env, GOCCIA_BENCH_CALIBRATION_MS: "50", GOCCIA_BENCH_ROUNDS: "3" } as Record<string, string>,
+          timeout: 60_000,
+        },
+      );
+      if (bench.exitCode !== 0)
+        throw new Error(`BenchmarkRunner unsafe-ffi config ${modeArgs.join(" ")} exited ${bench.exitCode}: ${bench.stderr.toString()}`);
+      if (!bench.stdout.toString().includes("unsafe-ffi"))
+        throw new Error(`BenchmarkRunner unsafe-ffi config output should mention 'unsafe-ffi', got: ${bench.stdout.toString()}`);
+    }
+
+    const replOut = runCwd(REPL, [`--config=${join(tmp, "goccia.json")}`], tmp, {
+      stdin: "typeof FFI;\n",
+    });
+    if (!replOut.combined.includes("object")) throw new Error(`REPL unsafe-ffi config should expose FFI, got: ${replOut.combined}`);
+  } finally {
+    clean(tmp);
+    clean(noConfigDir);
+  }
+}
+
+// -- Per-file compat-var config across all apps --------------------------------
 
 console.log("Per-file compat-var config across all apps...");
 {

--- a/scripts/test-cli-config.ts
+++ b/scripts/test-cli-config.ts
@@ -477,6 +477,34 @@ console.log("Per-file unsafe-ffi config across runtime apps...");
     const trBc = await $`${TESTRUNNER} ${join(tmp, "test-runner.js")} --mode=bytecode --no-progress 2>&1`.text();
     if (!trBc.includes("Passed: 1")) throw new Error(`TestRunner bytecode unsafe-ffi config should pass, got: ${trBc}`);
 
+    const parallelLoaderDir = join(tmp, "loader-parallel");
+    mkdirSync(parallelLoaderDir);
+    writeFileSync(join(parallelLoaderDir, "goccia.json"), '{"unsafe-ffi": true}\n');
+    writeFileSync(
+      join(parallelLoaderDir, "a.js"),
+      'if (typeof FFI !== "object") throw new Error("FFI missing");\n',
+    );
+    writeFileSync(
+      join(parallelLoaderDir, "b.js"),
+      'if (typeof FFI !== "object") throw new Error("FFI missing");\n',
+    );
+    runCwd(LOADER, ["a.js", "b.js", "--jobs=2", "--output=compact-json"], parallelLoaderDir);
+
+    const parallelTestDir = join(tmp, "test-parallel");
+    mkdirSync(parallelTestDir);
+    writeFileSync(join(parallelTestDir, "goccia.json"), '{"unsafe-ffi": true}\n');
+    writeFileSync(
+      join(parallelTestDir, "a.js"),
+      'test("unsafe ffi config a", () => { expect(typeof FFI).toBe("object"); });\n',
+    );
+    writeFileSync(
+      join(parallelTestDir, "b.js"),
+      'test("unsafe ffi config b", () => { expect(typeof FFI).toBe("object"); });\n',
+    );
+    const trParallel = runCwd(TESTRUNNER, [".", "--jobs=2", "--no-progress"], parallelTestDir);
+    if (!trParallel.combined.includes("Passed: 2"))
+      throw new Error(`TestRunner parallel unsafe-ffi config should pass, got: ${trParallel.combined}`);
+
     for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
       const bench = Bun.spawnSync(
         [resolve(BENCHRUNNER), join(tmp, "bench.js"), "--no-progress", ...modeArgs],
@@ -492,6 +520,36 @@ console.log("Per-file unsafe-ffi config across runtime apps...");
       if (!bench.stdout.toString().includes("unsafe-ffi"))
         throw new Error(`BenchmarkRunner unsafe-ffi config output should mention 'unsafe-ffi', got: ${bench.stdout.toString()}`);
     }
+
+    const parallelBenchDir = join(tmp, "bench-parallel");
+    mkdirSync(parallelBenchDir);
+    writeFileSync(join(parallelBenchDir, "goccia.json"), '{"unsafe-ffi": true}\n');
+    for (const name of ["a", "b"]) {
+      writeFileSync(
+        join(parallelBenchDir, `${name}.js`),
+        [
+          `suite("unsafe-ffi-${name}", () => {`,
+          '  bench("global", {',
+          "    run: () => {",
+          '      if (typeof FFI !== "object") throw new Error("FFI missing");',
+          "      return FFI.suffix;",
+          "    },",
+          "  });",
+          "});",
+        ].join("\n") + "\n",
+      );
+    }
+    const benchParallel = Bun.spawnSync(
+      [resolve(BENCHRUNNER), parallelBenchDir, "--jobs=2", "--no-progress"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, GOCCIA_BENCH_CALIBRATION_MS: "50", GOCCIA_BENCH_ROUNDS: "3" } as Record<string, string>,
+        timeout: 60_000,
+      },
+    );
+    if (benchParallel.exitCode !== 0)
+      throw new Error(`BenchmarkRunner parallel unsafe-ffi config exited ${benchParallel.exitCode}: ${benchParallel.stderr.toString()}`);
 
     const replOut = runCwd(REPL, [`--config=${join(tmp, "goccia.json")}`], tmp, {
       stdin: "typeof FFI;\n",

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -36,6 +36,17 @@ console.log("Stdin smoke (bytecode)...");
   if (!containsLine(out, "4")) throw new Error(`Expected 4 on its own line, got: ${out}`);
 }
 
+console.log("Bytecode top-level lexical TDZ...");
+for (const [label, source] of [
+  ["let", "let x = x;\n"],
+  ["const", "const x = x;\n"],
+] as const) {
+  const { exitCode, json } = runLoaderJson(source, ["--mode=bytecode"]);
+  if (exitCode === 0) throw new Error(`Top-level ${label} self-reference should fail in bytecode`);
+  if (json.error?.type !== "ReferenceError")
+    throw new Error(`Top-level ${label} self-reference should throw ReferenceError, got ${json.error?.type}`);
+}
+
 // -- Stdin smoke (TestRunner) --------------------------------------------------
 
 console.log("Stdin smoke (TestRunner)...");

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -527,8 +527,7 @@ begin
     Exit;
 
   { ASI: CLI flag > per-file config > root config > default (false) }
-  AEngine.ASIEnabled := ResolveFlagOption(
-    AEngineOptions.ASI, AFileConfig, 'asi');
+  AEngine.ASIEnabled := ResolveFlagOption(AEngineOptions.ASI, AFileConfig);
 
   { source-type: CLI flag > per-file config > root config > default (script) }
   AEngine.SourceType := ResolveSourceTypeOption(
@@ -536,35 +535,35 @@ begin
 
   { compat-var: CLI flag > per-file config > root config > default (false) }
   AEngine.VarEnabled := ResolveFlagOption(
-    AEngineOptions.CompatVar, AFileConfig, 'compat-var');
+    AEngineOptions.CompatVar, AFileConfig);
 
   { compat-function: CLI flag > per-file config > root config > default (false) }
   AEngine.FunctionEnabled := ResolveFlagOption(
-    AEngineOptions.CompatFunction, AFileConfig, 'compat-function');
+    AEngineOptions.CompatFunction, AFileConfig);
 
   { compat-traditional-for-loop: CLI flag > per-file config > root config > default (false) }
   AEngine.TraditionalForLoopsEnabled := ResolveFlagOption(
-    AEngineOptions.CompatTraditionalFor, AFileConfig, 'compat-traditional-for-loop');
+    AEngineOptions.CompatTraditionalFor, AFileConfig);
 
   { compat-while-loops: CLI flag > per-file config > root config > default (false) }
   AEngine.WhileLoopsEnabled := ResolveFlagOption(
-    AEngineOptions.CompatWhileLoops, AFileConfig, 'compat-while-loops');
+    AEngineOptions.CompatWhileLoops, AFileConfig);
 
   { compat-loose-equality: CLI flag > per-file config > root config > default (false) }
   AEngine.LooseEqualityEnabled := ResolveFlagOption(
-    AEngineOptions.CompatLooseEquality, AFileConfig, 'compat-loose-equality');
+    AEngineOptions.CompatLooseEquality, AFileConfig);
 
   { compat-non-strict-mode: CLI flag > per-file config > root config > default (false) }
   AEngine.NonStrictModeEnabled := ResolveFlagOption(
-    AEngineOptions.CompatNonStrictMode, AFileConfig, 'compat-non-strict-mode');
+    AEngineOptions.CompatNonStrictMode, AFileConfig);
 
   { strict-types: CLI flag > per-file config > root config > default (false) }
   AEngine.StrictTypes := ResolveFlagOption(
-    AEngineOptions.StrictTypes, AFileConfig, 'strict-types');
+    AEngineOptions.StrictTypes, AFileConfig);
 
   { unsafe-function-constructor: CLI flag > per-file config > root config > default (false) }
   AEngine.FunctionConstructor.Enabled := ResolveFlagOption(
-    AEngineOptions.UnsafeFunctionConstructor, AFileConfig, 'unsafe-function-constructor');
+    AEngineOptions.UnsafeFunctionConstructor, AFileConfig);
 
   { max-memory: CLI > per-file config > root config > system default.
     Always set explicitly so a previous file's per-file override does

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -62,6 +62,8 @@ type
       config is found.  Thread-safe: does not mutate shared state. }
     function DiscoverFileConfig(
       const AFileName: string): TConfigEntryArray;
+    function AnyFileConfigEnablesFlag(const AFiles: TStrings;
+      const AFlag: TGocciaFlagOption): Boolean;
     function CreateEngine(const AFileName: string;
       const ASource: TStringList;
       const AExecutor: TGocciaExecutor): TGocciaEngine;
@@ -460,6 +462,21 @@ begin
     [CONFIG_BASE_NAME], CONFIG_EXTENSIONS);
   if ConfigPath <> '' then
     Result := ParseConfigFile(ConfigPath);
+end;
+
+function TGocciaCLIApplication.AnyFileConfigEnablesFlag(
+  const AFiles: TStrings; const AFlag: TGocciaFlagOption): Boolean;
+var
+  I: Integer;
+begin
+  if not Assigned(AFlag) then
+    Exit(False);
+
+  for I := 0 to AFiles.Count - 1 do
+    if ResolveFlagOption(AFlag, DiscoverFileConfig(AFiles[I])) then
+      Exit(True);
+
+  Result := False;
 end;
 
 { Resolve --source-type / config "source-type" into the engine's

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -222,6 +222,7 @@ type
       const AReports: array of TReportSpec;
       const AMode: TGocciaExecutionMode; const AShowProgress: Boolean);
     procedure InitializeRuntime(const AEngine: TGocciaEngine);
+    procedure InitializeRuntimeWithUnsafeFFI(const AEngine: TGocciaEngine);
   protected
     procedure Configure; override;
     procedure Validate; override;
@@ -976,7 +977,10 @@ begin
         SetLength(WorkerData[I].Entries, 0);
       end;
 
-      EnsureSharedPrototypesInitialized(InitializeRuntime);
+      if AnyFileConfigEnablesFlag(Files, EngineOptions.UnsafeFFI) then
+        EnsureSharedPrototypesInitialized(InitializeRuntimeWithUnsafeFFI)
+      else
+        EnsureSharedPrototypesInitialized(InitializeRuntime);
 
       BeginCLIJSONMemoryMeasurement(MemoryMeasurement);
       WallClockStart := GetNanoseconds;
@@ -1154,6 +1158,13 @@ var
 begin
   Runtime := AttachRuntime(AEngine);
   TGocciaBenchmarkRunnerRuntimeProfile.Apply(Runtime);
+end;
+
+procedure TBenchmarkRunnerApp.InitializeRuntimeWithUnsafeFFI(
+  const AEngine: TGocciaEngine);
+begin
+  InitializeRuntime(AEngine);
+  GetRuntime(AEngine).Install(TGocciaFFIRuntimeExtension.Create);
 end;
 
 procedure TBenchmarkRunnerApp.ExecuteWithPaths(const APaths: TStringList);

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -1138,6 +1138,9 @@ var
 begin
   InitializeRuntime(AEngine);
   Runtime := GetRuntime(AEngine);
+  if Assigned(EngineOptions) and
+     ResolveFlagOption(EngineOptions.UnsafeFFI, AFileConfig) then
+    Runtime.Install(TGocciaFFIRuntimeExtension.Create);
   ConsoleExtension := TGocciaConsoleRuntimeExtension(
     Runtime.FindRuntimeExtension(TGocciaConsoleRuntimeExtension));
   if LogFileOpen and Assigned(ConsoleExtension) and
@@ -1151,8 +1154,6 @@ var
 begin
   Runtime := AttachRuntime(AEngine);
   TGocciaBenchmarkRunnerRuntimeProfile.Apply(Runtime);
-  if Assigned(EngineOptions) and EngineOptions.UnsafeFFI.Present then
-    Runtime.Install(TGocciaFFIRuntimeExtension.Create);
 end;
 
 procedure TBenchmarkRunnerApp.ExecuteWithPaths(const APaths: TStringList);

--- a/source/app/GocciaBundler.dpr
+++ b/source/app/GocciaBundler.dpr
@@ -212,24 +212,23 @@ begin
   { Resolve ASI and compatibility flags: CLI flag > per-file config >
     root config > default (false). }
   FileConfig := DiscoverFileConfig(AFileName);
-  EffectiveASI := ResolveFlagOption(EngineOptions.ASI, FileConfig, 'asi');
+  EffectiveASI := ResolveFlagOption(EngineOptions.ASI, FileConfig);
   EffectiveVar := ResolveFlagOption(
-    EngineOptions.CompatVar, FileConfig, 'compat-var');
+    EngineOptions.CompatVar, FileConfig);
   EffectiveFunction := ResolveFlagOption(
-    EngineOptions.CompatFunction, FileConfig, 'compat-function');
+    EngineOptions.CompatFunction, FileConfig);
   EffectiveTraditionalFor := ResolveFlagOption(
-    EngineOptions.CompatTraditionalFor, FileConfig,
-    'compat-traditional-for-loop');
+    EngineOptions.CompatTraditionalFor, FileConfig);
   EffectiveWhileLoops := ResolveFlagOption(
-    EngineOptions.CompatWhileLoops, FileConfig, 'compat-while-loops');
+    EngineOptions.CompatWhileLoops, FileConfig);
   EffectiveLooseEquality := ResolveFlagOption(
-    EngineOptions.CompatLooseEquality, FileConfig, 'compat-loose-equality');
+    EngineOptions.CompatLooseEquality, FileConfig);
   EffectiveNonStrictMode := ResolveFlagOption(
-    EngineOptions.CompatNonStrictMode, FileConfig, 'compat-non-strict-mode');
+    EngineOptions.CompatNonStrictMode, FileConfig);
   EffectiveSourceType := ResolveSourceTypeOption(EngineOptions.SourceType,
     FileConfig);
   EffectiveStrictTypes := ResolveFlagOption(
-    EngineOptions.StrictTypes, FileConfig, 'strict-types');
+    EngineOptions.StrictTypes, FileConfig);
 
   CompiledModule := nil;
   ProgramNode := ParseSource(ASource, AFileName, EffectiveASI, EffectiveVar,

--- a/source/app/GocciaREPL.dpr
+++ b/source/app/GocciaREPL.dpr
@@ -68,8 +68,6 @@ var
 begin
   Runtime := AttachRuntime(AEngine);
   TGocciaLoaderRuntimeProfile.Apply(Runtime);
-  if Assigned(EngineOptions) and EngineOptions.UnsafeFFI.Present then
-    Runtime.Install(TGocciaFFIRuntimeExtension.Create);
 end;
 
 procedure TREPLApp.ConfigureCreatedEngine(const AEngine: TGocciaEngine;
@@ -80,6 +78,9 @@ var
 begin
   InitializeRuntime(AEngine);
   Runtime := GetRuntime(AEngine);
+  if Assigned(EngineOptions) and
+     ResolveFlagOption(EngineOptions.UnsafeFFI, AFileConfig) then
+    Runtime.Install(TGocciaFFIRuntimeExtension.Create);
   ConsoleExtension := TGocciaConsoleRuntimeExtension(
     Runtime.FindRuntimeExtension(TGocciaConsoleRuntimeExtension));
   if LogFileOpen and Assigned(ConsoleExtension) and

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -262,8 +262,6 @@ var
 begin
   Runtime := AttachRuntime(AEngine);
   TGocciaLoaderRuntimeProfile.Apply(Runtime);
-  if Assigned(EngineOptions) and EngineOptions.UnsafeFFI.Present then
-    Runtime.Install(TGocciaFFIRuntimeExtension.Create);
 end;
 
 function TScriptLoaderApp.UsageLine: string;
@@ -298,6 +296,9 @@ var
 begin
   InitializeRuntime(AEngine);
   Runtime := GetRuntime(AEngine);
+  if Assigned(EngineOptions) and
+     ResolveFlagOption(EngineOptions.UnsafeFFI, AFileConfig) then
+    Runtime.Install(TGocciaFFIRuntimeExtension.Create);
   ConsoleExtension := TGocciaConsoleRuntimeExtension(
     Runtime.FindRuntimeExtension(TGocciaConsoleRuntimeExtension));
   if LogFileOpen and Assigned(ConsoleExtension) and

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -106,6 +106,7 @@ type
     FLastPaths: TStringList;
 
     procedure InitializeRuntime(const AEngine: TGocciaEngine);
+    procedure InitializeRuntimeWithUnsafeFFI(const AEngine: TGocciaEngine);
     function IsJsonOutput: Boolean;
     function IsCompactJsonOutput: Boolean;
     function ParseSource(const ASource: TStringList; const AFileName: string;
@@ -262,6 +263,13 @@ var
 begin
   Runtime := AttachRuntime(AEngine);
   TGocciaLoaderRuntimeProfile.Apply(Runtime);
+end;
+
+procedure TScriptLoaderApp.InitializeRuntimeWithUnsafeFFI(
+  const AEngine: TGocciaEngine);
+begin
+  InitializeRuntime(AEngine);
+  GetRuntime(AEngine).Install(TGocciaFFIRuntimeExtension.Create);
 end;
 
 function TScriptLoaderApp.UsageLine: string;
@@ -1046,7 +1054,10 @@ begin
 
   if JobCount > 1 then
   begin
-    EnsureSharedPrototypesInitialized(InitializeRuntime);
+    if AnyFileConfigEnablesFlag(AFiles, EngineOptions.UnsafeFFI) then
+      EnsureSharedPrototypesInitialized(InitializeRuntimeWithUnsafeFFI)
+    else
+      EnsureSharedPrototypesInitialized(InitializeRuntime);
     BeginCLIJSONMemoryMeasurement(MemoryMeasurement);
     Pool := TGocciaThreadPool.Create(JobCount);
     try
@@ -1175,7 +1186,10 @@ var
   Pool: TGocciaThreadPool;
   I: Integer;
 begin
-  EnsureSharedPrototypesInitialized(InitializeRuntime);
+  if AnyFileConfigEnablesFlag(AFiles, EngineOptions.UnsafeFFI) then
+    EnsureSharedPrototypesInitialized(InitializeRuntimeWithUnsafeFFI)
+  else
+    EnsureSharedPrototypesInitialized(InitializeRuntime);
 
   Pool := TGocciaThreadPool.Create(AJobCount);
   try

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -260,6 +260,9 @@ var
 begin
   InitializeRuntime(AEngine);
   Runtime := GetRuntime(AEngine);
+  if Assigned(EngineOptions) and
+     ResolveFlagOption(EngineOptions.UnsafeFFI, AFileConfig) then
+    Runtime.Install(TGocciaFFIRuntimeExtension.Create);
   ConsoleExtension := TGocciaConsoleRuntimeExtension(
     Runtime.FindRuntimeExtension(TGocciaConsoleRuntimeExtension));
   if LogFileOpen and Assigned(ConsoleExtension) and
@@ -461,8 +464,6 @@ var
 begin
   Runtime := AttachRuntime(AEngine);
   TGocciaTestRunnerRuntimeProfile.Apply(Runtime);
-  if Assigned(EngineOptions) and EngineOptions.UnsafeFFI.Present then
-    Runtime.Install(TGocciaFFIRuntimeExtension.Create);
 end;
 
 function TTestRunnerApp.RunGocciaScriptInterpreted(const AFileName: string;

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -131,6 +131,7 @@ type
     FTestTimeout: TGocciaIntegerOption;
     FDescribeTimeout: TGocciaIntegerOption;
     procedure InitializeRuntime(const AEngine: TGocciaEngine);
+    procedure InitializeRuntimeWithUnsafeFFI(const AEngine: TGocciaEngine);
   protected
     procedure Configure; override;
     procedure ConfigureCreatedEngine(const AEngine: TGocciaEngine;
@@ -464,6 +465,13 @@ var
 begin
   Runtime := AttachRuntime(AEngine);
   TGocciaTestRunnerRuntimeProfile.Apply(Runtime);
+end;
+
+procedure TTestRunnerApp.InitializeRuntimeWithUnsafeFFI(
+  const AEngine: TGocciaEngine);
+begin
+  InitializeRuntime(AEngine);
+  GetRuntime(AEngine).Install(TGocciaFFIRuntimeExtension.Create);
 end;
 
 function TTestRunnerApp.RunGocciaScriptInterpreted(const AFileName: string;
@@ -1131,7 +1139,10 @@ begin
 
   // Force all shared prototypes to be initialised on the main thread
   // before any worker thread starts, avoiding class-var race conditions.
-  EnsureSharedPrototypesInitialized(InitializeRuntime);
+  if AnyFileConfigEnablesFlag(AFiles, EngineOptions.UnsafeFFI) then
+    EnsureSharedPrototypesInitialized(InitializeRuntimeWithUnsafeFFI)
+  else
+    EnsureSharedPrototypesInitialized(InitializeRuntime);
 
   WallClockStart := GetNanoseconds;
 

--- a/source/shared/CLI.ConfigFile.Test.pas
+++ b/source/shared/CLI.ConfigFile.Test.pas
@@ -73,6 +73,7 @@ type
     procedure TestResolveFlagOptionPerFileFalseOverridesRoot;
     procedure TestResolveFlagOptionFallsBackToRoot;
     procedure TestResolveFlagOptionEmptyStringEnablesFlag;
+    procedure TestResolveFlagOptionUsesConfigName;
     procedure TestResolveFlagOptionDefaultsFalse;
   protected
     procedure BeforeAll; override;
@@ -127,6 +128,7 @@ begin
   Test('ResolveFlagOption per-file false overrides root true', TestResolveFlagOptionPerFileFalseOverridesRoot);
   Test('ResolveFlagOption falls back to root when no per-file config', TestResolveFlagOptionFallsBackToRoot);
   Test('ResolveFlagOption treats empty string as enabled', TestResolveFlagOptionEmptyStringEnablesFlag);
+  Test('ResolveFlagOption uses option ConfigName', TestResolveFlagOptionUsesConfigName);
   Test('ResolveFlagOption defaults to False when nothing is set', TestResolveFlagOptionDefaultsFalse);
 end;
 
@@ -951,7 +953,7 @@ begin
     FileConfig[0].Key := 'asi';
     FileConfig[0].Value := 'false';
 
-    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(True);
   finally
     Flag.Free;
   end;
@@ -980,7 +982,7 @@ begin
     FileConfig[0].Key := 'asi';
     FileConfig[0].Value := 'true';
 
-    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(True);
   finally
     Flag.Free;
   end;
@@ -1009,7 +1011,7 @@ begin
     FileConfig[0].Key := 'asi';
     FileConfig[0].Value := 'false';
 
-    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(False);
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(False);
   finally
     Flag.Free;
   end;
@@ -1035,7 +1037,7 @@ begin
     { No per-file config — should fall back to root (Present=True) }
     SetLength(FileConfig, 0);
 
-    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(True);
   finally
     Flag.Free;
   end;
@@ -1053,7 +1055,25 @@ begin
     FileConfig[0].Key := 'asi';
     FileConfig[0].Value := '';
 
-    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(True);
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(True);
+  finally
+    Flag.Free;
+  end;
+end;
+
+procedure TConfigFileTests.TestResolveFlagOptionUsesConfigName;
+var
+  Flag: TGocciaFlagOption;
+  FileConfig: TConfigEntryArray;
+begin
+  Flag := TGocciaFlagOption.Create('enable-ffi', 'FFI');
+  try
+    Flag.ConfigName := 'unsafe-ffi';
+    SetLength(FileConfig, 1);
+    FileConfig[0].Key := 'unsafe-ffi';
+    FileConfig[0].Value := 'true';
+
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(True);
   finally
     Flag.Free;
   end;
@@ -1069,7 +1089,7 @@ begin
     { No CLI, no root config, no per-file config — should default to False }
     SetLength(FileConfig, 0);
 
-    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig, 'asi')).ToBe(False);
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(False);
   finally
     Flag.Free;
   end;

--- a/source/shared/CLI.ConfigFile.Test.pas
+++ b/source/shared/CLI.ConfigFile.Test.pas
@@ -74,6 +74,7 @@ type
     procedure TestResolveFlagOptionFallsBackToRoot;
     procedure TestResolveFlagOptionEmptyStringEnablesFlag;
     procedure TestResolveFlagOptionUsesConfigName;
+    procedure TestResolveFlagOptionMixedAliasExtendsPrecedence;
     procedure TestResolveFlagOptionDefaultsFalse;
   protected
     procedure BeforeAll; override;
@@ -129,6 +130,8 @@ begin
   Test('ResolveFlagOption falls back to root when no per-file config', TestResolveFlagOptionFallsBackToRoot);
   Test('ResolveFlagOption treats empty string as enabled', TestResolveFlagOptionEmptyStringEnablesFlag);
   Test('ResolveFlagOption uses option ConfigName', TestResolveFlagOptionUsesConfigName);
+  Test('ResolveFlagOption preserves extends precedence across aliases',
+    TestResolveFlagOptionMixedAliasExtendsPrecedence);
   Test('ResolveFlagOption defaults to False when nothing is set', TestResolveFlagOptionDefaultsFalse);
 end;
 
@@ -1074,6 +1077,29 @@ begin
     FileConfig[0].Value := 'true';
 
     Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(True);
+  finally
+    Flag.Free;
+  end;
+end;
+
+procedure TConfigFileTests.TestResolveFlagOptionMixedAliasExtendsPrecedence;
+var
+  Dir, BasePath, ChildPath: string;
+  Flag: TGocciaFlagOption;
+  FileConfig: TConfigEntryArray;
+begin
+  Dir := CreateTempDirectory;
+  BasePath := IncludeTrailingPathDelimiter(Dir) + 'base.json';
+  ChildPath := IncludeTrailingPathDelimiter(Dir) + 'goccia.json';
+  WriteTextFile(BasePath, '{"unsafe-ffi": true}');
+  WriteTextFile(ChildPath, '{"extends": "base.json", "enable-ffi": false}');
+
+  Flag := TGocciaFlagOption.Create('enable-ffi', 'FFI');
+  try
+    Flag.ConfigName := 'unsafe-ffi';
+    FileConfig := ParseConfigFile(ChildPath);
+
+    Expect<Boolean>(ResolveFlagOption(Flag, FileConfig)).ToBe(False);
   finally
     Flag.Free;
   end;

--- a/source/shared/CLI.ConfigFile.pas
+++ b/source/shared/CLI.ConfigFile.pas
@@ -307,11 +307,18 @@ end;
 
 function FindOptionConfigEntry(const AEntries: TConfigEntryArray;
   const AOption: TGocciaOptionBase; out AValue: string): Boolean;
+var
+  I: Integer;
 begin
-  if (AOption.ConfigName <> '') and
-     FindConfigEntry(AEntries, AOption.ConfigName, AValue) then
-    Exit(True);
-  Result := FindConfigEntry(AEntries, AOption.LongName, AValue);
+  for I := 0 to High(AEntries) do
+    if ((AOption.ConfigName <> '') and
+        (AEntries[I].Key = AOption.ConfigName)) or
+       (AEntries[I].Key = AOption.LongName) then
+    begin
+      AValue := AEntries[I].Value;
+      Exit(True);
+    end;
+  Result := False;
 end;
 
 procedure ApplyConfigEntries(const AEntries: TConfigEntryArray;

--- a/source/shared/CLI.ConfigFile.pas
+++ b/source/shared/CLI.ConfigFile.pas
@@ -16,7 +16,7 @@ type
   TConfigEntryArray = array of TConfigEntry;
 
   { Callback that parses file content into flat key-value entries.
-    Keys are option long names (e.g. 'mode', 'timeout').
+    Keys are option long names or config names (e.g. 'mode', 'timeout').
     Values are their string representations (e.g. 'bytecode', '5000').
     Boolean true produces 'true'; false produces 'false'.
     Arrays produce multiple entries with the same key. }
@@ -29,7 +29,7 @@ procedure RegisterConfigParser(const AExtension: string;
   AParser: TConfigParseFunc);
 
 { Apply configuration entries to the given options.
-  Each entry whose key matches an option long name is applied.
+  Each entry whose key matches an option long name or config name is applied.
   Options that are already Present are skipped, so CLI arguments
   parsed before this call naturally take precedence.
   Unknown keys are silently skipped (config files may contain
@@ -75,12 +75,11 @@ function FindConfigEntry(const AEntries: TConfigEntryArray;
 
 { Resolve an effective boolean for a flag option using the
   standard precedence: CLI flag > per-file config > root config >
-  default (False).  AFlag is the parsed option, AFileConfig the
-  per-file config entries, and AConfigKey the config key name
-  (e.g. 'asi', 'compat-var'). }
+  default (False).  AFlag is the parsed option and AFileConfig the
+  per-file config entries.  The config key is resolved from the
+  option metadata, checking ConfigName before LongName. }
 function ResolveFlagOption(const AFlag: TGocciaFlagOption;
-  const AFileConfig: TConfigEntryArray;
-  const AConfigKey: string): Boolean;
+  const AFileConfig: TConfigEntryArray): Boolean;
 
 implementation
 
@@ -306,6 +305,15 @@ begin
   Result := nil;
 end;
 
+function FindOptionConfigEntry(const AEntries: TConfigEntryArray;
+  const AOption: TGocciaOptionBase; out AValue: string): Boolean;
+begin
+  if (AOption.ConfigName <> '') and
+     FindConfigEntry(AEntries, AOption.ConfigName, AValue) then
+    Exit(True);
+  Result := FindConfigEntry(AEntries, AOption.LongName, AValue);
+end;
+
 procedure ApplyConfigEntries(const AEntries: TConfigEntryArray;
   const AOptions: TGocciaOptionArray);
 var
@@ -518,14 +526,13 @@ end;
 { ── Flag resolution ────────────────────────────────────────── }
 
 function ResolveFlagOption(const AFlag: TGocciaFlagOption;
-  const AFileConfig: TConfigEntryArray;
-  const AConfigKey: string): Boolean;
+  const AFileConfig: TConfigEntryArray): Boolean;
 var
   ValueStr: string;
 begin
   if AFlag.FromCommandLine then
     Result := True
-  else if FindConfigEntry(AFileConfig, AConfigKey, ValueStr) then
+  else if FindOptionConfigEntry(AFileConfig, AFlag, ValueStr) then
     Result := (ValueStr = 'true') or (ValueStr = '')
   else
     Result := AFlag.Present;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -532,8 +532,7 @@ begin
       Exit;
     end;
     Slot := Local.Slot;
-    if Slot <> ADest then
-      EmitInstruction(ACtx, EncodeABx(OP_GET_LOCAL, ADest, Slot));
+    EmitInstruction(ACtx, EncodeABx(OP_GET_LOCAL, ADest, Slot));
     Exit;
   end;
 

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -590,8 +590,8 @@ begin
     end;
 
     IsTopLevelGlobalBacked := ACtx.GlobalBackedTopLevel and
-      (AStmt.IsVar or ((not AStmt.IsVar) and (ACtx.Scope.Depth = 0)));
-    if IsTopLevelGlobalBacked and AStmt.IsVar then
+      (AStmt.IsVar or (ACtx.Scope.Depth = 0));
+    if IsTopLevelGlobalBacked then
     begin
       LocalIdx := FindLocalBySlot(ACtx.Scope, Info.Name, Slot);
       if LocalIdx >= 0 then
@@ -4640,6 +4640,7 @@ begin
       begin
         Local := ACtx.Scope.GetLocal(I);
         EmitGlobalDefine(ACtx, Local.Slot, Local.Name, AStmt.IsConst);
+        ACtx.Scope.MarkGlobalBacked(I);
       end;
   end;
 end;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -539,6 +539,30 @@ function FindLocalBySlot(const AScope: TGocciaCompilerScope;
 procedure CopyLocalTypeMetadata(const ACtx: TGocciaCompilationContext;
   const ASourceIdx, ATargetIdx: Integer); forward;
 
+procedure PrepareLexicalDeclarationLocals(
+  const ACtx: TGocciaCompilationContext;
+  const AStmt: TGocciaVariableDeclaration);
+var
+  I, LocalIdx: Integer;
+  Info: TGocciaVariableInfo;
+  Slot: UInt8;
+begin
+  if AStmt.IsVar then
+    Exit;
+
+  for I := 0 to High(AStmt.Variables) do
+  begin
+    Info := AStmt.Variables[I];
+    LocalIdx := ACtx.Scope.ResolveLocal(Info.Name);
+    if (LocalIdx >= 0) and
+       (ACtx.Scope.GetLocal(LocalIdx).Depth = ACtx.Scope.Depth) then
+      Slot := ACtx.Scope.GetLocal(LocalIdx).Slot
+    else
+      Slot := ACtx.Scope.DeclareLocal(Info.Name, AStmt.IsConst);
+    EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, Slot, 0, 0));
+  end;
+end;
+
 procedure EmitGlobalDefine(const ACtx: TGocciaCompilationContext;
   const ASlot: UInt8; const AName: string; const AIsConst: Boolean;
   const AIsVar: Boolean = False; const AHasInitializer: Boolean = True);
@@ -575,6 +599,8 @@ var
   IsVarRedeclaration: Boolean;
   CanTrackConstant: Boolean;
 begin
+  PrepareLexicalDeclarationLocals(ACtx, AStmt);
+
   for I := 0 to High(AStmt.Variables) do
   begin
     Info := AStmt.Variables[I];
@@ -601,7 +627,7 @@ begin
 
     IsTopLevelGlobalBacked := ACtx.GlobalBackedTopLevel and
       (AStmt.IsVar or (ACtx.Scope.Depth = 0));
-    if IsTopLevelGlobalBacked then
+    if IsTopLevelGlobalBacked and AStmt.IsVar then
     begin
       LocalIdx := FindLocalBySlot(ACtx.Scope, Info.Name, Slot);
       if LocalIdx >= 0 then
@@ -736,8 +762,16 @@ begin
     end;
 
     if IsTopLevelGlobalBacked then
+    begin
+      if not AStmt.IsVar then
+      begin
+        LocalIdx := FindLocalBySlot(ACtx.Scope, Info.Name, Slot);
+        if LocalIdx >= 0 then
+          ACtx.Scope.MarkGlobalBacked(LocalIdx);
+      end;
       EmitGlobalDefine(ACtx, Slot, Info.Name, AStmt.IsConst, AStmt.IsVar,
         HasInitializer);
+    end;
   end;
 end;
 

--- a/tests/built-ins/FFI/goccia.json
+++ b/tests/built-ins/FFI/goccia.json
@@ -1,0 +1,3 @@
+{
+  "unsafe-ffi": true
+}

--- a/tests/language/declarations/let/temporal-dead-zone.js
+++ b/tests/language/declarations/let/temporal-dead-zone.js
@@ -18,6 +18,18 @@ describe("Temporal Dead Zone", () => {
     }).toThrow(ReferenceError);
   });
 
+  test("let self-reference in initializer throws", () => {
+    expect(() => {
+      let x = x;
+    }).toThrow(ReferenceError);
+  });
+
+  test("const self-reference in initializer throws", () => {
+    expect(() => {
+      const x = x;
+    }).toThrow(ReferenceError);
+  });
+
   test("typeof on undeclared variable returns undefined", () => {
     expect(typeof nonExistentVar).toBe("undefined");
   });

--- a/tests/language/modules/helpers/live-top-level-let.js
+++ b/tests/language/modules/helpers/live-top-level-let.js
@@ -1,0 +1,8 @@
+let hit = 0;
+export default class {};
+if (true) { hit = 1; }
+
+let { destructuredHit } = { destructuredHit: 0 };
+if (true) { destructuredHit = 1; }
+
+export { destructuredHit, hit };

--- a/tests/language/modules/live-bindings.js
+++ b/tests/language/modules/live-bindings.js
@@ -1,0 +1,8 @@
+import { destructuredHit, hit } from "./helpers/live-top-level-let.js";
+
+describe("module live bindings", () => {
+  test("exports reassigned top-level lexical bindings", () => {
+    expect(hit).toBe(1);
+    expect(destructuredHit).toBe(1);
+  });
+});

--- a/tests/language/with/asi/goccia.json
+++ b/tests/language/with/asi/goccia.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../goccia.json",
+  "asi": true
+}

--- a/tests/language/with/asi/with-statement-asi.js
+++ b/tests/language/with/asi/with-statement-asi.js
@@ -1,0 +1,27 @@
+/*---
+description: ASI boundaries after with statement bodies
+features: [automatic-semicolon-insertion, compat-non-strict-mode]
+---*/
+
+describe("with statement ASI", () => {
+  test("inserts a semicolon after an expression body before a following block", () => {
+    let hit = 0;
+
+    with ({ value: 1 }) hit = value
+    {
+      const blockScoped = 2;
+      hit += blockScoped;
+    }
+
+    expect(hit).toBe(3);
+  });
+
+  test("parses let as an expression body before a following block", () => {
+    if (false) {
+      with ({}) let
+      {}
+    }
+
+    expect(true).toBe(true);
+  });
+});

--- a/tests/language/with/with-statement.js
+++ b/tests/language/with/with-statement.js
@@ -100,15 +100,6 @@ describe("with statement", () => {
     expect(result).toBe("outer x");
   });
 
-  test("parses ASI after let as a with body expression statement", () => {
-    if (false) {
-      with ({}) let
-      {}
-    }
-
-    expect(true).toBe(true);
-  });
-
   test("closures created inside with retain the object environment", () => {
     const obj = { x: 4 };
     let read;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fix bytecode module top-level lexical bindings so reassignment updates the module scope used for named exports.
- Preserve bytecode TDZ checks for top-level `let`/`const` self-references while still publishing initialized lexical bindings through the global-backed module scope.
- Add module and TDZ regression coverage, including CLI-level bytecode coverage for top-level lexical self-references.
- Move full-suite ASI/FFI coverage to per-folder `goccia.json` config, including `tests/built-ins/FFI/goccia.json` for FFI tests.
- Update agent guidance, CI commands, and docs so default full-suite runs do not pass `--asi` or `--unsafe-ffi` globally.
- Closes #665.
- Closes #678.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Commands run:

- `./build.pas clean`
- `./build.pas loader testrunner loaderbare repl bundler benchmarkrunner tests`
- `./format.pas --check`
- `./build/Goccia.Compiler.Test`
- `./build/GocciaTestRunner tests/language/declarations/let/temporal-dead-zone.js --no-progress`
- `./build/GocciaTestRunner tests/language/declarations/let/temporal-dead-zone.js --mode=bytecode --no-progress`
- `./build/GocciaTestRunner tests --no-progress --exit-on-first-failure`
- `./build/GocciaTestRunner tests --mode=bytecode --no-progress --exit-on-first-failure`
- `bun run scripts/test-cli.ts`
- `bun run scripts/test-cli-config.ts`
- `./build/GocciaTestRunner tests/language/modules/live-bindings.js --silent --no-progress`
- `./build/GocciaTestRunner tests/language/modules/live-bindings.js --mode=bytecode --silent --no-progress`
- `./build/GocciaTestRunner tests/built-ins/FFI --silent --no-progress`
- `./build/GocciaTestRunner tests/language/asi --silent --no-progress`
- `./build/GocciaScriptLoader /tmp/goccia-ffi-config.Ve2N4k/main.js --print` (verified `"unsafe-ffi": true` config enables FFI without CLI flag)
