### PR TITLE
Fix for-loop update closure environments

### DIFF
--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -529,6 +529,9 @@ function FindVarLocalIndex(const AScope: TGocciaCompilerScope;
 function FindLocalBySlot(const AScope: TGocciaCompilerScope;
   const AName: string; const ASlot: UInt8): Integer; forward;
 
+procedure CopyLocalTypeMetadata(const ACtx: TGocciaCompilationContext;
+  const ASourceIdx, ATargetIdx: Integer); forward;
+
 procedure EmitGlobalDefine(const ACtx: TGocciaCompilationContext;
   const ASlot: UInt8; const AName: string; const AIsConst: Boolean;
   const AIsVar: Boolean = False; const AHasInitializer: Boolean = True);
@@ -958,6 +961,34 @@ begin
       Exit(I);
   end;
   Result := -1;
+end;
+
+procedure CopyLocalTypeMetadata(const ACtx: TGocciaCompilationContext;
+  const ASourceIdx, ATargetIdx: Integer);
+var
+  Source: TGocciaCompilerLocal;
+  Target: TGocciaCompilerLocal;
+begin
+  if (ASourceIdx < 0) or (ATargetIdx < 0) then
+    Exit;
+
+  Source := ACtx.Scope.GetLocal(ASourceIdx);
+  Target := ACtx.Scope.GetLocal(ATargetIdx);
+
+  ACtx.Scope.SetLocalTypeHint(ATargetIdx, Source.TypeHint);
+  ACtx.Scope.SetLocalStrictlyTyped(ATargetIdx, Source.IsStrictlyTyped);
+  ACtx.Scope.SetLocalArrayTyped(ATargetIdx, Source.IsArrayTyped);
+  ACtx.Scope.SetLocalReturnTypeHint(ATargetIdx, Source.ReturnTypeHint);
+  ACtx.Scope.SetLocalParamTypeSignature(ATargetIdx,
+    Source.ParamTypeSignature);
+  ACtx.Scope.SetLocalTypeAnnotation(ATargetIdx, Source.TypeAnnotation);
+  ACtx.Scope.SetLocalElementTypeAnnotation(ATargetIdx,
+    Source.ElementTypeAnnotation);
+
+  if Source.TypeHint <> sltUntyped then
+    ACtx.Template.SetLocalType(Target.Slot, Source.TypeHint);
+  if Source.IsStrictlyTyped then
+    ACtx.Template.SetLocalStrictFlag(Target.Slot, True);
 end;
 
 procedure PredeclareBlockFunctionLocal(const AFunctionDecl: TGocciaFunctionDeclaration;
@@ -2492,9 +2523,11 @@ var
   PerIterNames: TStringList;
   PerIterIsConst: Boolean;
   OuterSlots, BodySlots, UpdateSlots: array of UInt8;
+  OuterLocalIdxs: array of Integer;
   Name: string;
   VarDecl: TGocciaVariableDeclaration;
   DestructDecl: TGocciaDestructuringDeclaration;
+  LocalIdx: Integer;
 begin
   if TryCompileCountedFor(ACtx, AStmt) then
     Exit;
@@ -2541,10 +2574,12 @@ begin
         SetLength(OuterSlots, PerIterNames.Count);
         SetLength(BodySlots, PerIterNames.Count);
         SetLength(UpdateSlots, PerIterNames.Count);
+        SetLength(OuterLocalIdxs, PerIterNames.Count);
         for I := 0 to PerIterNames.Count - 1 do
         begin
           Name := PerIterNames[I];
-          OuterSlots[I] := ACtx.Scope.GetLocal(ACtx.Scope.ResolveLocal(Name)).Slot;
+          OuterLocalIdxs[I] := ACtx.Scope.ResolveLocal(Name);
+          OuterSlots[I] := ACtx.Scope.GetLocal(OuterLocalIdxs[I]).Slot;
         end;
 
         LoopStart := CurrentCodePosition(ACtx);
@@ -2558,6 +2593,8 @@ begin
         begin
           Name := PerIterNames[I];
           BodySlots[I] := ACtx.Scope.DeclareLocal(Name, PerIterIsConst);
+          LocalIdx := ACtx.Scope.ResolveLocal(Name);
+          CopyLocalTypeMetadata(ACtx, OuterLocalIdxs[I], LocalIdx);
           EmitInstruction(ACtx,
             EncodeABC(OP_MOVE, BodySlots[I], OuterSlots[I], 0));
         end;
@@ -2593,6 +2630,8 @@ begin
         begin
           Name := PerIterNames[I];
           UpdateSlots[I] := ACtx.Scope.DeclareLocal(Name, PerIterIsConst);
+          LocalIdx := ACtx.Scope.ResolveLocal(Name);
+          CopyLocalTypeMetadata(ACtx, OuterLocalIdxs[I], LocalIdx);
           EmitInstruction(ACtx,
             EncodeABC(OP_MOVE, UpdateSlots[I], BodySlots[I], 0));
         end;
@@ -4597,7 +4636,10 @@ begin
     // when HasNameBinding is true, __super__ lives inside the inner scope
     // and EndScope below will free it together with the name binding local.
     if not HasNameBinding then
+    begin
+      EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, SuperReg, 0, 0));
       ACtx.Scope.FreeRegister;
+    end;
   end
   else
     CompileDecoratorAndAccessorPass(ACtx, ADest, ClassDef, -1);

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -2483,11 +2483,15 @@ var
   LoopStart, ExitJump, I: Integer;
   ClosedLocals: array[0..255] of UInt8;
   ClosedCount: Integer;
+  BodyClosedLocals: array[0..255] of UInt8;
+  BodyClosedCount: Integer;
+  UpdateClosedLocals: array[0..255] of UInt8;
+  UpdateClosedCount: Integer;
   LoopControl: TLoopControlState;
   HasLexicalInit: Boolean;
   PerIterNames: TStringList;
   PerIterIsConst: Boolean;
-  OuterSlots, InnerSlots: array of UInt8;
+  OuterSlots, BodySlots, UpdateSlots: array of UInt8;
   Name: string;
   VarDecl: TGocciaVariableDeclaration;
   DestructDecl: TGocciaDestructuringDeclaration;
@@ -2532,79 +2536,145 @@ begin
     BeginLoopControl(ACtx, LoopControl);
 
     try
-      LoopStart := CurrentCodePosition(ACtx);
-      ExitJump := -1;
-
-      if Assigned(AStmt.Condition) then
-      begin
-        CondReg := ACtx.Scope.AllocateRegister;
-        try
-          ACtx.CompileExpression(AStmt.Condition, CondReg);
-          ExitJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_FALSE, CondReg);
-        finally
-          ACtx.Scope.FreeRegister;
-        end;
-      end;
-
-      // Capture outer slots BEFORE entering the per-iteration scope, where
-      // ResolveLocal would shadow with the inner declaration.
       if HasLexicalInit then
       begin
         SetLength(OuterSlots, PerIterNames.Count);
-        SetLength(InnerSlots, PerIterNames.Count);
+        SetLength(BodySlots, PerIterNames.Count);
+        SetLength(UpdateSlots, PerIterNames.Count);
         for I := 0 to PerIterNames.Count - 1 do
         begin
           Name := PerIterNames[I];
           OuterSlots[I] := ACtx.Scope.GetLocal(ACtx.Scope.ResolveLocal(Name)).Slot;
         end;
-      end;
 
-      ACtx.Scope.BeginScope;
-      SetLoopContinueScopeDepth(ACtx);
+        LoopStart := CurrentCodePosition(ACtx);
+        ExitJump := -1;
 
-      if HasLexicalInit then
-      begin
+        // ES2026 §14.7.4.4 step 2: create the per-iteration environment
+        // before evaluating the test and body.
+        ACtx.Scope.BeginScope;
+        SetLoopContinueScopeDepth(ACtx);
         for I := 0 to PerIterNames.Count - 1 do
         begin
           Name := PerIterNames[I];
-          InnerSlots[I] := ACtx.Scope.DeclareLocal(Name, PerIterIsConst);
+          BodySlots[I] := ACtx.Scope.DeclareLocal(Name, PerIterIsConst);
           EmitInstruction(ACtx,
-            EncodeABC(OP_MOVE, InnerSlots[I], OuterSlots[I], 0));
+            EncodeABC(OP_MOVE, BodySlots[I], OuterSlots[I], 0));
         end;
-      end;
 
-      ACtx.CompileStatement(AStmt.Body);
+        if Assigned(AStmt.Condition) then
+        begin
+          CondReg := ACtx.Scope.AllocateRegister;
+          try
+            ACtx.CompileExpression(AStmt.Condition, CondReg);
+            ExitJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_FALSE, CondReg);
+          finally
+            ACtx.Scope.FreeRegister;
+          end;
+        end;
 
-      PatchJumpList(ACtx, LoopControl.ContinueJumps);
+        ACtx.CompileStatement(AStmt.Body);
 
-      if HasLexicalInit then
-      begin
+        PatchJumpList(ACtx, LoopControl.ContinueJumps);
+
+        // BodySlots are no longer visible to name resolution after EndScope,
+        // but their registers still hold the body iteration values for the
+        // update environment snapshot.
+        ACtx.Scope.EndScope(BodyClosedLocals, BodyClosedCount);
+        for I := 0 to BodyClosedCount - 1 do
+          EmitInstruction(ACtx,
+            EncodeABC(OP_CLOSE_UPVALUE, BodyClosedLocals[I], 0, 0));
+
+        // ES2026 §14.7.4.4 step 3.e: create a fresh per-iteration
+        // environment for the update expression, distinct from the body
+        // iteration environment that closures in the body captured.
+        ACtx.Scope.BeginScope;
+        for I := 0 to PerIterNames.Count - 1 do
+        begin
+          Name := PerIterNames[I];
+          UpdateSlots[I] := ACtx.Scope.DeclareLocal(Name, PerIterIsConst);
+          EmitInstruction(ACtx,
+            EncodeABC(OP_MOVE, UpdateSlots[I], BodySlots[I], 0));
+        end;
+
+        if Assigned(AStmt.Update) then
+        begin
+          TempReg := ACtx.Scope.AllocateRegister;
+          try
+            ACtx.CompileExpression(AStmt.Update, TempReg);
+          finally
+            ACtx.Scope.FreeRegister;
+          end;
+        end;
+
         for I := 0 to PerIterNames.Count - 1 do
           EmitInstruction(ACtx,
-            EncodeABC(OP_MOVE, OuterSlots[I], InnerSlots[I], 0));
-      end;
+            EncodeABC(OP_MOVE, OuterSlots[I], UpdateSlots[I], 0));
 
-      ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
-      for I := 0 to ClosedCount - 1 do
-        EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+        ACtx.Scope.EndScope(UpdateClosedLocals, UpdateClosedCount);
+        for I := 0 to UpdateClosedCount - 1 do
+          EmitInstruction(ACtx,
+            EncodeABC(OP_CLOSE_UPVALUE, UpdateClosedLocals[I], 0, 0));
 
-      if Assigned(AStmt.Update) then
-      begin
-        TempReg := ACtx.Scope.AllocateRegister;
-        try
-          ACtx.CompileExpression(AStmt.Update, TempReg);
-        finally
-          ACtx.Scope.FreeRegister;
+        EmitInstruction(ACtx,
+          EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
+
+        if ExitJump >= 0 then
+        begin
+          PatchJumpTarget(ACtx, ExitJump);
+          for I := 0 to BodyClosedCount - 1 do
+            EmitInstruction(ACtx,
+              EncodeABC(OP_CLOSE_UPVALUE, BodyClosedLocals[I], 0, 0));
         end;
+
+        PatchJumpList(ACtx, LoopControl.BreakJumps);
+      end
+      else
+      begin
+        LoopStart := CurrentCodePosition(ACtx);
+        ExitJump := -1;
+
+        if Assigned(AStmt.Condition) then
+        begin
+          CondReg := ACtx.Scope.AllocateRegister;
+          try
+            ACtx.CompileExpression(AStmt.Condition, CondReg);
+            ExitJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_FALSE, CondReg);
+          finally
+            ACtx.Scope.FreeRegister;
+          end;
+        end;
+
+        ACtx.Scope.BeginScope;
+        SetLoopContinueScopeDepth(ACtx);
+
+        ACtx.CompileStatement(AStmt.Body);
+
+        PatchJumpList(ACtx, LoopControl.ContinueJumps);
+
+        ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
+        for I := 0 to ClosedCount - 1 do
+          EmitInstruction(ACtx,
+            EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+
+        if Assigned(AStmt.Update) then
+        begin
+          TempReg := ACtx.Scope.AllocateRegister;
+          try
+            ACtx.CompileExpression(AStmt.Update, TempReg);
+          finally
+            ACtx.Scope.FreeRegister;
+          end;
+        end;
+
+        EmitInstruction(ACtx,
+          EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
+
+        if ExitJump >= 0 then
+          PatchJumpTarget(ACtx, ExitJump);
+
+        PatchJumpList(ACtx, LoopControl.BreakJumps);
       end;
-
-      EmitInstruction(ACtx,
-        EncodeAx(OP_JUMP, LoopStart - CurrentCodePosition(ACtx) - 1));
-
-      if ExitJump >= 0 then
-        PatchJumpTarget(ACtx, ExitJump);
-
-      PatchJumpList(ACtx, LoopControl.BreakJumps);
     finally
       EndLoopControl(LoopControl);
     end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -1872,8 +1872,8 @@ end;
 function EvaluateFor(const AForStatement: TGocciaForStatement;
   const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
-  HeaderScope, IterScope: TGocciaScope;
-  HeaderContext, IterContext: TGocciaEvaluationContext;
+  HeaderScope, IterScope, UpdateScope: TGocciaScope;
+  HeaderContext, IterContext, UpdateContext: TGocciaEvaluationContext;
   IsLexical: Boolean;
   PerIterNames: TStringList;
   PrevValues: array of TGocciaValue;
@@ -1896,8 +1896,10 @@ begin
   PerIterNames := nil;
   HeaderScope := nil;
   IterScope := nil;
+  UpdateScope := nil;
   HeaderContext := AContext;
   IterContext := AContext;
+  UpdateContext := AContext;
 
   if Assigned(AForStatement.Init) then
   begin
@@ -1952,6 +1954,11 @@ begin
     begin
       IterScope := ForState.IterScope;
       IterContext.Scope := IterScope;
+    end
+    else if (ResumePhase = gflpUpdate) and IsLexical then
+    begin
+      UpdateScope := ForState.UpdateScope;
+      UpdateContext.Scope := UpdateScope;
     end
     else
       IterContext := HeaderContext;
@@ -2079,18 +2086,22 @@ begin
           end;
           // cfkContinue and cfkNormal both fall through to update.
 
-          // Sync body's writes (including the iteration variable) back to the
-          // header so the update expression and the next iteration's snapshot
-          // see them. The body's per-iteration scope stays alive and pinned to
-          // its captured value for any closure created during the body — the
-          // header carries the canonical mutating cell that update will modify.
+          // ES2026 §14.7.4.4 step 3.e: create the next per-iteration
+          // environment after the body and before the update expression.
+          // Closures created in the body keep IterScope; closures created in
+          // the update expression capture this fresh UpdateScope.
           if IsLexical then
           begin
+            UpdateScope := AContext.Scope.CreateChild(skBlock, 'ForUpdate');
+            UpdateContext := AContext;
+            UpdateContext.Scope := UpdateScope;
             for I := 0 to PerIterNames.Count - 1 do
             begin
               Name := PerIterNames[I];
               IterBinding := IterScope.GetBinding(Name);
-              HeaderScope.ForceUpdateBinding(Name, IterBinding.Value);
+              UpdateScope.DefineLexicalBinding(Name, IterBinding.Value, DeclarationType);
+              if IterBinding.TypeHint <> sltUntyped then
+                UpdateScope.SetOwnBindingTypeHint(Name, IterBinding.TypeHint);
             end;
           end;
 
@@ -2098,25 +2109,34 @@ begin
           begin
             ForState.Phase := gflpUpdate;
             ForState.IterScope := nil;
+            if IsLexical then
+              ForState.UpdateScope := UpdateScope;
           end;
           ResumePhase := gflpUpdate;
         end;
 
-        // Update runs on the header so it mutates the canonical cell rather
-        // than the iteration's frozen scope. Per-iteration semantics for
-        // closures created _inside_ the update expression are intentionally
-        // simpler than the spec (they pin the header rather than a fresh
-        // per-iteration env); closures inside update bodies are rare.
         if Assigned(AForStatement.Update) then
         begin
           if IsLexical then
-            EvaluateExpression(AForStatement.Update, HeaderContext)
+            EvaluateExpression(AForStatement.Update, UpdateContext)
           else
             EvaluateExpression(AForStatement.Update, IterContext);
         end;
 
+        if IsLexical then
+        begin
+          for I := 0 to PerIterNames.Count - 1 do
+          begin
+            Name := PerIterNames[I];
+            HeaderScope.ForceUpdateBinding(Name, UpdateScope.GetBinding(Name).Value);
+          end;
+        end;
+
         if Assigned(ForState) then
+        begin
           ForState.Phase := gflpIterStart;
+          ForState.UpdateScope := nil;
+        end;
         ResumePhase := gflpIterStart;
       end;
     except

--- a/source/units/Goccia.Generator.Continuation.pas
+++ b/source/units/Goccia.Generator.Continuation.pas
@@ -58,7 +58,7 @@ type
     gflpIterStart,  // Between iterations: snapshot HeaderScope and create IterScope
     gflpTest,       // IterScope is committed and the test is mid-execution
     gflpBody,       // Test passed and body is mid-execution
-    gflpUpdate      // Body completed and IterScope was synced back; update is mid-execution
+    gflpUpdate      // Body completed and UpdateScope is mid-execution
   );
 
   TGocciaGeneratorForLoopState = class
@@ -66,6 +66,7 @@ type
     Phase: TGocciaGeneratorForLoopPhase;
     HeaderScope: TGocciaScope;  // nil for non-lexical for-loops
     IterScope: TGocciaScope;    // non-nil while test/body is active for lexical loops
+    UpdateScope: TGocciaScope;  // non-nil while update is active for lexical loops
     constructor Create(const AHeaderScope: TGocciaScope);
     procedure MarkReferences;
   end;
@@ -253,6 +254,7 @@ begin
   Phase := gflpIterStart;
   HeaderScope := AHeaderScope;
   IterScope := nil;
+  UpdateScope := nil;
 end;
 
 procedure TGocciaGeneratorForLoopState.MarkReferences;
@@ -261,6 +263,8 @@ begin
     HeaderScope.MarkReferences;
   if Assigned(IterScope) then
     IterScope.MarkReferences;
+  if Assigned(UpdateScope) then
+    UpdateScope.MarkReferences;
 end;
 
 constructor TGocciaAsyncFromSyncIteratorValue.Create(const AIterator: TGocciaIteratorValue);

--- a/tests/language/classes/class-expression-extends.js
+++ b/tests/language/classes/class-expression-extends.js
@@ -4,6 +4,27 @@ features: [classes]
 ---*/
 
 describe("class expression extends dynamic value", () => {
+  test("top-level class expression with constructor calling super()", () => {
+    class Original {
+      constructor() { this.x = 1; }
+      getX() { return this.x; }
+    }
+
+    let Wrapped = class extends Original {
+      constructor() {
+        super();
+        this.wrapped = true;
+      }
+    };
+
+    const w = new Wrapped();
+    expect(w.x).toBe(1);
+    expect(w.wrapped).toBe(true);
+    expect(w.getX()).toBe(1);
+    expect(w instanceof Wrapped).toBe(true);
+    expect(w instanceof Original).toBe(true);
+  });
+
   test("class expression extends parameter with constructor calling super()", () => {
     const makeWrapper = (Base) => {
       return class extends Base {

--- a/tests/language/for-loop/let-per-iteration.js
+++ b/tests/language/for-loop/let-per-iteration.js
@@ -30,3 +30,33 @@ test("continue after capture preserves per-iteration binding in general path", (
   }
   expect(fns.map(fn => fn())).toEqual([0, 1, 2]);
 });
+
+test("closures in update capture the post-body per-iteration binding", () => {
+  const fns = [];
+  for (let i = 0; i < 3; i++, fns.push(() => i)) {}
+  expect(fns.map(fn => fn())).toEqual([1, 2, 3]);
+});
+
+test("body and update closures capture distinct per-iteration bindings", () => {
+  const bodyFns = [];
+  const updateFns = [];
+  for (let i = 0; i < 3; i++, updateFns.push(() => i)) {
+    bodyFns.push(() => i);
+  }
+  expect(bodyFns.map(fn => fn())).toEqual([0, 1, 2]);
+  expect(updateFns.map(fn => fn())).toEqual([1, 2, 3]);
+});
+
+test("continue evaluates update closures in the next per-iteration binding", () => {
+  const fns = [];
+  for (let i = 0; i < 3; i++, fns.push(() => i)) {
+    continue;
+  }
+  expect(fns.map(fn => fn())).toEqual([1, 2, 3]);
+});
+
+test("closures in the test expression capture the body per-iteration binding", () => {
+  const fns = [];
+  for (let i = 0; i < 3 && (fns.push(() => i), true); i++) {}
+  expect(fns.map(fn => fn())).toEqual([0, 1, 2]);
+});

--- a/tests/language/for-loop/strict-types/goccia.json
+++ b/tests/language/for-loop/strict-types/goccia.json
@@ -1,0 +1,4 @@
+{
+  "compat-traditional-for-loop": true,
+  "strict-types": true
+}

--- a/tests/language/for-loop/strict-types/per-iteration-type-metadata.js
+++ b/tests/language/for-loop/strict-types/per-iteration-type-metadata.js
@@ -1,0 +1,24 @@
+/*---
+description: Traditional for-loop per-iteration bindings preserve strict type metadata
+features: [compat-traditional-for-loop, types-as-comments, strict-type-enforcement]
+---*/
+
+test("condition bindings keep annotations", () => {
+  expect(() => {
+    for (let i: number = 0; (i = "bad", i < 1); i++) {}
+  }).toThrow(TypeError);
+});
+
+test("body bindings keep annotations", () => {
+  expect(() => {
+    for (let i: number = 0; i < 1; i++) {
+      i = "bad";
+    }
+  }).toThrow(TypeError);
+});
+
+test("update bindings keep annotations", () => {
+  expect(() => {
+    for (let i: number = 0; i < 1; i = "bad") {}
+  }).toThrow(TypeError);
+});


### PR DESCRIPTION
## Summary

- Create distinct post-body update environments for lexical traditional `for` loops in interpreter and bytecode mode.
- Preserve the update environment across generator resumes and close bytecode upvalues for body/update scopes separately.
- Add end-to-end regressions for update closures, body/update closure separation, `continue`, and test-expression captures.
- Closes #539.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress`
  - `./build/GocciaTestRunner tests --asi --unsafe-ffi --mode=bytecode --no-progress`
  - `./build/GocciaTestRunner tests/language/for-loop/let-per-iteration.js --asi --unsafe-ffi --mode=bytecode`
  - `./build/GocciaTestRunner tests/language/for-loop --asi --unsafe-ffi`
  - `./build/GocciaTestRunner tests/language/for-loop --asi --unsafe-ffi --mode=bytecode`
  - `./build/GocciaTestRunner tests/language/for-loop-var --asi --unsafe-ffi`
  - `./build/GocciaTestRunner tests/language/for-loop-var --asi --unsafe-ffi --mode=bytecode`
- [ ] Updated documentation
  - Not needed; this fixes internal spec behavior for an existing compatibility feature and adds regression coverage.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional checks:

- `./format.pas --check`
- `./build.pas clean testrunner`
- `./build.pas bundler`
- `printf '%s\n' 'const fns = []; for (let i = 0; i < 3; i++, fns.push(() => i)) {} fns.map(fn => fn());' | ./build/GocciaBundler --compat-traditional-for-loop --output=/tmp/issue539-update-closures.gbc`