### PR TITLE
Cache compiled RegExp programs

### DIFF
--- a/source/units/Goccia.RegExp.Compiler.pas
+++ b/source/units/Goccia.RegExp.Compiler.pas
@@ -5,7 +5,7 @@ unit Goccia.RegExp.Compiler;
 interface
 
 uses
-  Goccia.RegExp.Engine;
+  Goccia.RegExp.&Program;
 
 type
   TRegExpOpCode = (
@@ -27,25 +27,6 @@ type
     RX_FAIL          = 15
   );
 
-  TRegExpCharRange = record
-    Lo: Cardinal;
-    Hi: Cardinal;
-  end;
-
-  TRegExpCharRangeArray = array of TRegExpCharRange;
-
-  TRegExpCharClass = record
-    Ranges: TRegExpCharRangeArray;
-  end;
-
-  TRegExpProgram = record
-    Code: array of UInt32;
-    CharClasses: array of TRegExpCharClass;
-    CaptureCount: Integer;
-    FullUnicode: Boolean;
-    NamedGroups: TGocciaRegExpNamedGroups;
-  end;
-
 const
   BACKREF_STRICT_FLAG = $800000;
   BACKREF_ICASE_FLAG = $400000;
@@ -57,7 +38,6 @@ const
   WORD_ASSERT_ICASE_FLAG = $2;
 
 function CompileRegExp(const APattern, AFlags: string): TRegExpProgram;
-procedure ValidateRegExpPatternNew(const APattern, AFlags: string);
 
 implementation
 
@@ -69,6 +49,7 @@ uses
   UnicodeICU,
 
   Goccia.Identifier,
+  Goccia.RegExp.Engine,
   Goccia.RegExp.UnicodeData;
 
 type
@@ -2739,14 +2720,6 @@ begin
   finally
     Compiler.Free;
   end;
-end;
-
-procedure ValidateRegExpPatternNew(const APattern, AFlags: string);
-begin
-  ValidateRegExpFlags(AFlags);
-  if APattern = '(?:)' then
-    Exit;
-  CompileRegExp(APattern, AFlags);
 end;
 
 end.

--- a/source/units/Goccia.RegExp.Engine.pas
+++ b/source/units/Goccia.RegExp.Engine.pas
@@ -4,6 +4,9 @@ unit Goccia.RegExp.Engine;
 
 interface
 
+uses
+  Goccia.RegExp.&Program;
+
 type
   TGocciaRegExpMatchGroup = record
     Matched: Boolean;
@@ -13,14 +16,6 @@ type
   end;
 
   TGocciaRegExpMatchGroups = array of TGocciaRegExpMatchGroup;
-
-  TGocciaRegExpNamedGroup = record
-    Name: string;
-    Index: Integer;
-    DisjunctionPath: array of Integer;
-  end;
-
-  TGocciaRegExpNamedGroups = array of TGocciaRegExpNamedGroup;
 
   TGocciaRegExpMatchResult = record
     Found: Boolean;
@@ -36,8 +31,12 @@ function NormalizeRegExpSource(const APattern: string): string;
 function HasRegExpFlag(const AFlags: string; const AFlag: Char): Boolean;
 procedure ValidateRegExpFlags(const AFlags: string);
 procedure ValidateRegExpPattern(const APattern, AFlags: string);
+function CompileRegExpProgram(const APattern, AFlags: string): TRegExpProgram;
 function CanonicalizeRegExpFlags(const AFlags: string): string;
 function RegExpToString(const APattern, AFlags: string): string;
+function ExecuteCompiledRegExp(const AProgram: TRegExpProgram;
+  const APattern, AFlags, AInput: string; const AStartIndex: Integer;
+  const ARequireStart: Boolean; out AResult: TGocciaRegExpMatchResult): Boolean;
 function ExecuteRegExp(const APattern, AFlags, AInput: string;
   const AStartIndex: Integer; const ARequireStart: Boolean;
   out AResult: TGocciaRegExpMatchResult): Boolean;
@@ -89,7 +88,18 @@ end;
 
 procedure ValidateRegExpPattern(const APattern, AFlags: string);
 begin
-  ValidateRegExpPatternNew(APattern, AFlags);
+  CompileRegExpProgram(APattern, AFlags);
+end;
+
+function CompileRegExpProgram(const APattern, AFlags: string): TRegExpProgram;
+var
+  PatternToCompile: string;
+begin
+  ValidateRegExpFlags(AFlags);
+  PatternToCompile := APattern;
+  if PatternToCompile = EMPTY_REGEX then
+    PatternToCompile := '';
+  Result := CompileRegExp(PatternToCompile, AFlags);
 end;
 
 function CanonicalizeRegExpFlags(const AFlags: string): string;
@@ -111,15 +121,14 @@ begin
     CanonicalizeRegExpFlags(AFlags);
 end;
 
-function ExecuteRegExp(const APattern, AFlags, AInput: string;
-  const AStartIndex: Integer; const ARequireStart: Boolean;
+function ExecuteCompiledRegExp(const AProgram: TRegExpProgram;
+  const APattern, AFlags, AInput: string; const AStartIndex: Integer;
+  const ARequireStart: Boolean;
   out AResult: TGocciaRegExpMatchResult): Boolean;
 var
-  Prog: TRegExpProgram;
   VMResult: TRegExpVMResult;
   IsUnicode: Boolean;
   I, GroupCount: Integer;
-  PatternToCompile: string;
   SlotStart, SlotEnd: Integer;
 begin
   AResult.Found := False;
@@ -147,11 +156,7 @@ begin
     AResult.Groups[0].Value := '';
     Exit(True);
   end;
-  PatternToCompile := APattern;
-  if PatternToCompile = EMPTY_REGEX then
-    PatternToCompile := '';
-  Prog := CompileRegExp(PatternToCompile, AFlags);
-  Result := ExecuteRegExpVM(Prog, AInput, AStartIndex, ARequireStart, VMResult);
+  Result := ExecuteRegExpVM(AProgram, AInput, AStartIndex, ARequireStart, VMResult);
   if not Result then
     Exit(False);
   AResult.Found := True;
@@ -163,7 +168,7 @@ begin
   if AResult.MatchEnd = AResult.MatchIndex then
     AResult.NextIndex := AdvanceUTF16StringIndex(AInput, AResult.NextIndex,
       IsUnicode);
-  GroupCount := Prog.CaptureCount + 1;
+  GroupCount := AProgram.CaptureCount + 1;
   SetLength(AResult.Groups, GroupCount);
   for I := 0 to GroupCount - 1 do
   begin
@@ -191,7 +196,18 @@ begin
       AResult.Groups[I].Value := '';
     end;
   end;
-  AResult.NamedGroups := Prog.NamedGroups;
+  AResult.NamedGroups := AProgram.NamedGroups;
+end;
+
+function ExecuteRegExp(const APattern, AFlags, AInput: string;
+  const AStartIndex: Integer; const ARequireStart: Boolean;
+  out AResult: TGocciaRegExpMatchResult): Boolean;
+var
+  CompiledProgram: TRegExpProgram;
+begin
+  CompiledProgram := CompileRegExpProgram(APattern, AFlags);
+  Result := ExecuteCompiledRegExp(CompiledProgram, APattern, AFlags, AInput,
+    AStartIndex, ARequireStart, AResult);
 end;
 
 end.

--- a/source/units/Goccia.RegExp.Program.pas
+++ b/source/units/Goccia.RegExp.Program.pas
@@ -1,0 +1,37 @@
+unit Goccia.RegExp.&Program;
+
+{$I Goccia.inc}
+
+interface
+
+type
+  TGocciaRegExpNamedGroup = record
+    Name: string;
+    Index: Integer;
+    DisjunctionPath: array of Integer;
+  end;
+
+  TGocciaRegExpNamedGroups = array of TGocciaRegExpNamedGroup;
+
+  TRegExpCharRange = record
+    Lo: Cardinal;
+    Hi: Cardinal;
+  end;
+
+  TRegExpCharRangeArray = array of TRegExpCharRange;
+
+  TRegExpCharClass = record
+    Ranges: TRegExpCharRangeArray;
+  end;
+
+  TRegExpProgram = record
+    Code: array of UInt32;
+    CharClasses: array of TRegExpCharClass;
+    CaptureCount: Integer;
+    FullUnicode: Boolean;
+    NamedGroups: TGocciaRegExpNamedGroups;
+  end;
+
+implementation
+
+end.

--- a/source/units/Goccia.RegExp.Runtime.pas
+++ b/source/units/Goccia.RegExp.Runtime.pas
@@ -42,6 +42,7 @@ uses
   Goccia.Constants.NumericLimits,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
+  Goccia.RegExp.&Program,
   Goccia.RegExp.VM,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
@@ -50,8 +51,23 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
 
+type
+  TGocciaRegExpProgramData = class
+  private
+    FCompiledProgram: TRegExpProgram;
+  public
+    constructor Create(const AProgram: TRegExpProgram);
+    property CompiledProgram: TRegExpProgram read FCompiledProgram;
+  end;
+
 threadvar
   GRegExpPrototype: TGocciaObjectValue;
+
+constructor TGocciaRegExpProgramData.Create(const AProgram: TRegExpProgram);
+begin
+  inherited Create;
+  FCompiledProgram := AProgram;
+end;
 
 function GetRegExpPrototype: TGocciaValue;
 begin
@@ -283,18 +299,20 @@ var
   Obj: TGocciaObjectValue;
   Source: string;
   CanonicalFlags: string;
+  CompiledProgram: TRegExpProgram;
 begin
   try
-    ValidateRegExpPattern(APattern, AFlags);
+    CanonicalFlags := CanonicalizeRegExpFlags(AFlags);
+    CompiledProgram := CompileRegExpProgram(APattern, CanonicalFlags);
   except
     on E: Exception do
       ThrowSyntaxError(E.Message);
   end;
 
   Source := NormalizeRegExpSource(APattern);
-  CanonicalFlags := CanonicalizeRegExpFlags(AFlags);
   Obj := TGocciaObjectValue.Create(GRegExpPrototype);
   Obj.HasRegExpData := True;
+  Obj.RegExpData := TGocciaRegExpProgramData.Create(CompiledProgram);
   Obj.DefineProperty(PROP_SOURCE,
     TGocciaPropertyDescriptorData.Create(
       TGocciaStringLiteralValue.Create(Source), []));
@@ -366,6 +384,7 @@ var
   ExecResult: TGocciaValue;
   MatchText: string;
   MatchResult: TGocciaRegExpMatchResult;
+  ProgramData: TGocciaRegExpProgramData;
   ShouldUpdate: Boolean;
 begin
   Obj := TGocciaObjectValue(AValue);
@@ -412,13 +431,26 @@ begin
     ThrowTypeError(SErrorRegExpExecNonRegExp);
 
   try
-    Result := ExecuteRegExp(
-      GetStringProperty(Obj, PROP_SOURCE),
-      GetStringProperty(Obj, PROP_FLAGS),
-      AInput,
-      AStartIndex,
-      ARequireStart,
-      MatchResult);
+    if Obj.RegExpData is TGocciaRegExpProgramData then
+    begin
+      ProgramData := TGocciaRegExpProgramData(Obj.RegExpData);
+      Result := ExecuteCompiledRegExp(
+        ProgramData.CompiledProgram,
+        GetStringProperty(Obj, PROP_SOURCE),
+        GetStringProperty(Obj, PROP_FLAGS),
+        AInput,
+        AStartIndex,
+        ARequireStart,
+        MatchResult);
+    end
+    else
+      Result := ExecuteRegExp(
+        GetStringProperty(Obj, PROP_SOURCE),
+        GetStringProperty(Obj, PROP_FLAGS),
+        AInput,
+        AStartIndex,
+        ARequireStart,
+        MatchResult);
   except
     on E: ERegExpRuntimeError do
       ThrowError(E.Message);

--- a/source/units/Goccia.RegExp.VM.pas
+++ b/source/units/Goccia.RegExp.VM.pas
@@ -7,6 +7,7 @@ interface
 uses
   SysUtils,
 
+  Goccia.RegExp.&Program,
   Goccia.RegExp.Compiler;
 
 type

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -20,6 +20,7 @@ type
 
   TGocciaObjectValue = class(TGocciaValue)
   private
+    procedure SetRegExpData(const AValue: TObject);
   protected
     FProperties: TGocciaPropertyMap;
     FSymbolDescriptors: TSymbolDescriptorMap;
@@ -30,6 +31,7 @@ type
     FExtensible: Boolean;
     FHasErrorData: Boolean;
     FHasRegExpData: Boolean;
+    FRegExpData: TObject;
   public
     class procedure InitializeSharedPrototype;
     class function GetSharedObjectPrototype: TGocciaObjectValue; static;
@@ -98,6 +100,7 @@ type
     property Extensible: Boolean read FExtensible;
     property HasErrorData: Boolean read FHasErrorData write FHasErrorData;
     property HasRegExpData: Boolean read FHasRegExpData write FHasRegExpData;
+    property RegExpData: TObject read FRegExpData write SetRegExpData;
   published
     function ObjectPrototypeToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectPrototypeIsPrototypeOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -146,6 +149,14 @@ begin
 end;
 
 { TGocciaObjectValue }
+
+procedure TGocciaObjectValue.SetRegExpData(const AValue: TObject);
+begin
+  if FRegExpData = AValue then
+    Exit;
+  FRegExpData.Free;
+  FRegExpData := AValue;
+end;
 
 class function TGocciaObjectValue.GetSharedObjectPrototype: TGocciaObjectValue;
 begin
@@ -382,6 +393,7 @@ begin
   FSymbolDescriptors.Free;
 
   FSymbolInsertionOrder.Free;
+  FRegExpData.Free;
   inherited;
 end;
 


### PR DESCRIPTION
## Summary

- Split compiled RegExp program record types into `Goccia.RegExp.&Program` so the engine, compiler, and VM can share them without the old validation dependency.
- Compile a RegExp pattern once during object construction and store the compiled `TRegExpProgram` on the RegExp object for native execution paths.
- Route native `exec`, `test`, `match`, `matchAll`, `search`, `replace`, and `split` matching through the cached program instead of recompiling per match.
- Closes #596.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation (not applicable; internal performance change)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change