### PR TITLE
Fix NumberFormat digit option resolution

### DIFF
--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -75,6 +75,7 @@ function TryICULowerCase(const ALocale, AStr: string; out AResult: string): Bool
 implementation
 
 uses
+  Math,
   SysUtils,
 
   DynLibs,
@@ -275,6 +276,18 @@ type
   TUnumSetTextAttribute = procedure(AFormat: Pointer; ATag: LongInt;
     const ANewValue: PUChar; ANewValueLength: LongInt;
     var AStatus: TICUErrorCode); cdecl;
+  TUnumfOpenForSkeletonAndLocale = function(const ASkeleton: PUChar;
+    ASkeletonLength: LongInt; const ALocale: PAnsiChar;
+    var AStatus: TICUErrorCode): Pointer; cdecl;
+  TUnumfOpenResult = function(var AStatus: TICUErrorCode): Pointer; cdecl;
+  TUnumfFormatDouble = procedure(AFormatter: Pointer; AValue: Double;
+    AResult: Pointer; var AStatus: TICUErrorCode); cdecl;
+  TUnumfResultToString = function(AResult: Pointer; ABuffer: PUChar;
+    ABufferCapacity: LongInt; var AStatus: TICUErrorCode): LongInt; cdecl;
+  TUnumfResultAsValue = function(AResult: Pointer;
+    var AStatus: TICUErrorCode): Pointer; cdecl;
+  TUnumfClose = procedure(AFormatter: Pointer); cdecl;
+  TUnumfCloseResult = procedure(AResult: Pointer); cdecl;
   TUdatOpen = function(ATimeStyle: LongInt; ADateStyle: LongInt;
     const ALocale: PAnsiChar; const ATzId: PUChar; ATzIdLength: LongInt;
     const APattern: PUChar; APatternLength: LongInt;
@@ -402,6 +415,13 @@ type
     UnumSetDoubleAttribute: TUnumSetDoubleAttribute;
     UnumApplyPattern: TUnumApplyPattern;
     UnumSetTextAttribute: TUnumSetTextAttribute;
+    UnumfOpenForSkeletonAndLocale: TUnumfOpenForSkeletonAndLocale;
+    UnumfOpenResult: TUnumfOpenResult;
+    UnumfFormatDouble: TUnumfFormatDouble;
+    UnumfResultToString: TUnumfResultToString;
+    UnumfResultAsValue: TUnumfResultAsValue;
+    UnumfClose: TUnumfClose;
+    UnumfCloseResult: TUnumfCloseResult;
     UdatOpen: TUdatOpen;
     UdatClose: TUdatClose;
     UdatFormat: TUdatFormat;
@@ -592,6 +612,20 @@ begin
   if Assigned(S) then F.UnumSetTextAttribute := TUnumSetTextAttribute(S);
   S := ResolveSymbol(AHandle, 'unum_formatDoubleForFields');
   if Assigned(S) then F.UnumFormatDoubleForFields := TUnumFormatDoubleForFields(S);
+  S := ResolveSymbol(AHandle, 'unumf_openForSkeletonAndLocale');
+  if Assigned(S) then F.UnumfOpenForSkeletonAndLocale := TUnumfOpenForSkeletonAndLocale(S);
+  S := ResolveSymbol(AHandle, 'unumf_openResult');
+  if Assigned(S) then F.UnumfOpenResult := TUnumfOpenResult(S);
+  S := ResolveSymbol(AHandle, 'unumf_formatDouble');
+  if Assigned(S) then F.UnumfFormatDouble := TUnumfFormatDouble(S);
+  S := ResolveSymbol(AHandle, 'unumf_resultToString');
+  if Assigned(S) then F.UnumfResultToString := TUnumfResultToString(S);
+  S := ResolveSymbol(AHandle, 'unumf_resultAsValue');
+  if Assigned(S) then F.UnumfResultAsValue := TUnumfResultAsValue(S);
+  S := ResolveSymbol(AHandle, 'unumf_close');
+  if Assigned(S) then F.UnumfClose := TUnumfClose(S);
+  S := ResolveSymbol(AHandle, 'unumf_closeResult');
+  if Assigned(S) then F.UnumfCloseResult := TUnumfCloseResult(S);
   S := ResolveSymbol(AHandle, 'udat_formatForFields');
   if Assigned(S) then F.UdatFormatForFields := TUdatFormatForFields(S);
   S := ResolveSymbol(AHandle, 'udatpg_open');
@@ -1577,6 +1611,18 @@ begin
       StringOfChar('#', MaxFrac - MinFrac);
 end;
 
+function BuildFractionPrecisionStem(const AOptions: TIntlNumberFormatOptions): string;
+var
+  MinFrac, MaxFrac: Integer;
+begin
+  MinFrac := AOptions.MinimumFractionDigits;
+  MaxFrac := AOptions.MaximumFractionDigits;
+  if MinFrac < 0 then MinFrac := 0;
+  if MaxFrac < MinFrac then MaxFrac := MinFrac;
+  Result := '.' + StringOfChar('0', MinFrac) +
+    StringOfChar('#', MaxFrac - MinFrac);
+end;
+
 function BuildSignificantPrecisionSkeleton(const AOptions: TIntlNumberFormatOptions): string;
 var
   MinSig, MaxSig: Integer;
@@ -1587,6 +1633,55 @@ begin
   if MinSig < 1 then MinSig := 1;
   if MaxSig < MinSig then MaxSig := MinSig;
   Result := StringOfChar('@', MinSig) + StringOfChar('#', MaxSig - MinSig);
+end;
+
+function RoundingIncrementSkeletonDecimal(ARoundingIncrement,
+  AMaximumFractionDigits: Integer): string;
+var
+  Digits: string;
+  IntegerDigits: Integer;
+begin
+  Digits := IntToStr(ARoundingIncrement);
+  if AMaximumFractionDigits <= 0 then
+    Exit(Digits);
+
+  if Length(Digits) <= AMaximumFractionDigits then
+    Result := '0.' + StringOfChar('0', AMaximumFractionDigits - Length(Digits)) + Digits
+  else
+  begin
+    IntegerDigits := Length(Digits) - AMaximumFractionDigits;
+    Result := Copy(Digits, 1, IntegerDigits) + '.' +
+      Copy(Digits, IntegerDigits + 1, AMaximumFractionDigits);
+  end;
+end;
+
+function BuildPrecisionSkeleton(const AOptions: TIntlNumberFormatOptions): string;
+begin
+  if AOptions.RoundingIncrement > 1 then
+    Exit('precision-increment/' +
+      RoundingIncrementSkeletonDecimal(AOptions.RoundingIncrement,
+        AOptions.MaximumFractionDigits));
+
+  if (AOptions.RoundingPriority <> inrpAuto) and
+     (AOptions.MinimumFractionDigits >= 0) and
+     (AOptions.MaximumFractionDigits >= 0) and
+     (AOptions.MinimumSignificantDigits > 0) and
+     (AOptions.MaximumSignificantDigits > 0) then
+  begin
+    Result := BuildFractionPrecisionStem(AOptions) + '/' +
+      BuildSignificantPrecisionSkeleton(AOptions);
+    case AOptions.RoundingPriority of
+      inrpMorePrecision: Result := Result + 'r';
+      inrpLessPrecision: Result := Result + 's';
+    end;
+    Exit;
+  end;
+
+  if (AOptions.MinimumSignificantDigits > 0) or
+     (AOptions.MaximumSignificantDigits > 0) then
+    Result := BuildSignificantPrecisionSkeleton(AOptions)
+  else
+    Result := BuildFractionPrecisionSkeleton(AOptions);
 end;
 
 function BuildNumberSkeleton(const AOptions: TIntlNumberFormatOptions): string;
@@ -1630,11 +1725,7 @@ begin
         AddSkeletonToken(Result, 'compact-short');
   end;
 
-  if (AOptions.MinimumSignificantDigits > 0) or
-     (AOptions.MaximumSignificantDigits > 0) then
-    AddSkeletonToken(Result, BuildSignificantPrecisionSkeleton(AOptions))
-  else
-    AddSkeletonToken(Result, BuildFractionPrecisionSkeleton(AOptions));
+  AddSkeletonToken(Result, BuildPrecisionSkeleton(AOptions));
 
   if AOptions.MinimumIntegerDigits > 1 then
     AddSkeletonToken(Result, 'integer-width/*' +
@@ -1658,13 +1749,73 @@ begin
     inrmFloor: AddSkeletonToken(Result, 'rounding-mode-floor');
     inrmExpand: AddSkeletonToken(Result, 'rounding-mode-up');
     inrmTrunc: AddSkeletonToken(Result, 'rounding-mode-down');
+    inrmHalfCeil: AddSkeletonToken(Result, 'rounding-mode-half-ceiling');
+    inrmHalfFloor: AddSkeletonToken(Result, 'rounding-mode-half-floor');
     inrmHalfExpand: AddSkeletonToken(Result, 'rounding-mode-half-up');
     inrmHalfTrunc: AddSkeletonToken(Result, 'rounding-mode-half-down');
     inrmHalfEven: AddSkeletonToken(Result, 'rounding-mode-half-even');
   end;
 end;
 
-function TryICUFormatNumber(const ALocale: string; AValue: Double;
+function TryICUFormatNumberSkeleton(const ALocale: string; AValue: Double;
+  const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
+var
+  Status: TICUErrorCode;
+  Formatter, FormatResult: Pointer;
+  Skeleton: UnicodeString;
+  LocaleAnsi: AnsiString;
+  Buffer: array[0..FORMAT_BUFFER_CAPACITY - 1] of WideChar;
+  ResultLen: LongInt;
+begin
+  Result := False;
+  AFormatted := '';
+
+  if not EnsureLoaded or
+     not Assigned(IntlFunctions.UnumfOpenForSkeletonAndLocale) or
+     not Assigned(IntlFunctions.UnumfOpenResult) or
+     not Assigned(IntlFunctions.UnumfFormatDouble) or
+     not Assigned(IntlFunctions.UnumfResultToString) or
+     not Assigned(IntlFunctions.UnumfClose) or
+     not Assigned(IntlFunctions.UnumfCloseResult) then
+    Exit;
+
+  Skeleton := UnicodeString(BuildNumberSkeleton(AOptions));
+  LocaleAnsi := AnsiString(ALocale);
+  Status := ICU_SUCCESS;
+  Formatter := IntlFunctions.UnumfOpenForSkeletonAndLocale(PWideChar(Skeleton),
+    Length(Skeleton), PAnsiChar(LocaleAnsi), Status);
+  if not ICUSucceeded(Status) or not Assigned(Formatter) then
+    Exit;
+
+  try
+    Status := ICU_SUCCESS;
+    FormatResult := IntlFunctions.UnumfOpenResult(Status);
+    if not ICUSucceeded(Status) or not Assigned(FormatResult) then
+      Exit;
+    try
+      Status := ICU_SUCCESS;
+      IntlFunctions.UnumfFormatDouble(Formatter, AValue, FormatResult, Status);
+      if not ICUSucceeded(Status) then
+        Exit;
+
+      FillChar(Buffer, SizeOf(Buffer), 0);
+      Status := ICU_SUCCESS;
+      ResultLen := IntlFunctions.UnumfResultToString(FormatResult,
+        @Buffer[0], FORMAT_BUFFER_CAPACITY, Status);
+      if not ICUSucceeded(Status) or (ResultLen <= 0) then
+        Exit;
+
+      AFormatted := UnicodeToString(Buffer, ResultLen);
+      Result := True;
+    finally
+      IntlFunctions.UnumfCloseResult(FormatResult);
+    end;
+  finally
+    IntlFunctions.UnumfClose(Formatter);
+  end;
+end;
+
+function TryICUFormatNumberDirect(const ALocale: string; AValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
 var
   Status: TICUErrorCode;
@@ -1708,7 +1859,70 @@ begin
   end;
 end;
 
-function TryICUFormatNumberToParts(const ALocale: string; AValue: Double;
+function TryICUFormatNumber(const ALocale: string; AValue: Double;
+  const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
+begin
+  if TryICUFormatNumberSkeleton(ALocale, AValue, AOptions, AFormatted) then
+    Exit(True);
+  Result := TryICUFormatNumberDirect(ALocale, AValue, AOptions, AFormatted);
+end;
+
+function TryICUFormatNumberToPartsSkeleton(const ALocale: string; AValue: Double;
+  const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+var
+  Status: TICUErrorCode;
+  Formatter, FormatResult, FormattedValue: Pointer;
+  Skeleton: UnicodeString;
+  LocaleAnsi: AnsiString;
+  Formatted: string;
+begin
+  Result := False;
+  SetLength(AParts, 0);
+
+  if not EnsureLoaded or
+     not Assigned(IntlFunctions.UnumfOpenForSkeletonAndLocale) or
+     not Assigned(IntlFunctions.UnumfOpenResult) or
+     not Assigned(IntlFunctions.UnumfFormatDouble) or
+     not Assigned(IntlFunctions.UnumfResultAsValue) or
+     not Assigned(IntlFunctions.UnumfClose) or
+     not Assigned(IntlFunctions.UnumfCloseResult) then
+    Exit;
+
+  Skeleton := UnicodeString(BuildNumberSkeleton(AOptions));
+  LocaleAnsi := AnsiString(ALocale);
+  Status := ICU_SUCCESS;
+  Formatter := IntlFunctions.UnumfOpenForSkeletonAndLocale(PWideChar(Skeleton),
+    Length(Skeleton), PAnsiChar(LocaleAnsi), Status);
+  if not ICUSucceeded(Status) or not Assigned(Formatter) then
+    Exit;
+
+  try
+    Status := ICU_SUCCESS;
+    FormatResult := IntlFunctions.UnumfOpenResult(Status);
+    if not ICUSucceeded(Status) or not Assigned(FormatResult) then
+      Exit;
+    try
+      Status := ICU_SUCCESS;
+      IntlFunctions.UnumfFormatDouble(Formatter, AValue, FormatResult, Status);
+      if not ICUSucceeded(Status) then
+        Exit;
+
+      Status := ICU_SUCCESS;
+      FormattedValue := IntlFunctions.UnumfResultAsValue(FormatResult, Status);
+      if not ICUSucceeded(Status) or not Assigned(FormattedValue) then
+        Exit;
+
+      Result := FormattedValueToParts(FormattedValue, UFIELD_CATEGORY_NUMBER,
+        0, NumberFieldToPartType, Formatted, AParts);
+    finally
+      IntlFunctions.UnumfCloseResult(FormatResult);
+    end;
+  finally
+    IntlFunctions.UnumfClose(Formatter);
+  end;
+end;
+
+function TryICUFormatNumberToPartsDirect(const ALocale: string; AValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
 var
   Status: TICUErrorCode;
@@ -1768,6 +1982,14 @@ begin
   end;
 end;
 
+function TryICUFormatNumberToParts(const ALocale: string; AValue: Double;
+  const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+begin
+  if TryICUFormatNumberToPartsSkeleton(ALocale, AValue, AOptions, AParts) then
+    Exit(True);
+  Result := TryICUFormatNumberToPartsDirect(ALocale, AValue, AOptions, AParts);
+end;
+
 function TryICUFormatNumberRangeInternal(const ALocale: string;
   AUseDecimal: Boolean; AStartDouble, AEndDouble: Double;
   const AStartDecimal, AEndDecimal: string; const AOptions: TIntlNumberFormatOptions;
@@ -1794,12 +2016,6 @@ begin
     Exit;
   if (not AUseDecimal) and not Assigned(IntlFunctions.UnumrfFormatDoubleRange) then
     Exit;
-
-  if not AUseDecimal then
-  begin
-    AStartDouble := ApplyRoundingIncrement(AStartDouble, AOptions);
-    AEndDouble := ApplyRoundingIncrement(AEndDouble, AOptions);
-  end;
 
   Skeleton := UnicodeString(BuildNumberSkeleton(AOptions));
   LocaleAnsi := AnsiString(ALocale);

--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -1757,6 +1757,17 @@ begin
   end;
 end;
 
+function CanUseLegacyNumberFormatter(const AOptions: TIntlNumberFormatOptions): Boolean;
+begin
+  Result := (AOptions.Notation = innStandard) and
+    (AOptions.RoundingPriority = inrpAuto) and
+    (AOptions.Style <> insUnit);
+
+  if Result and (AOptions.Style = insCurrency) then
+    Result := (AOptions.CurrencyDisplay = incdSymbol) and
+      (AOptions.CurrencySign = incsStandard);
+end;
+
 function TryICUFormatNumberSkeleton(const ALocale: string; AValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
 var
@@ -1864,7 +1875,8 @@ function TryICUFormatNumber(const ALocale: string; AValue: Double;
 begin
   if TryICUFormatNumberSkeleton(ALocale, AValue, AOptions, AFormatted) then
     Exit(True);
-  Result := TryICUFormatNumberDirect(ALocale, AValue, AOptions, AFormatted);
+  Result := CanUseLegacyNumberFormatter(AOptions) and
+    TryICUFormatNumberDirect(ALocale, AValue, AOptions, AFormatted);
 end;
 
 function TryICUFormatNumberToPartsSkeleton(const ALocale: string; AValue: Double;
@@ -1987,7 +1999,8 @@ function TryICUFormatNumberToParts(const ALocale: string; AValue: Double;
 begin
   if TryICUFormatNumberToPartsSkeleton(ALocale, AValue, AOptions, AParts) then
     Exit(True);
-  Result := TryICUFormatNumberToPartsDirect(ALocale, AValue, AOptions, AParts);
+  Result := CanUseLegacyNumberFormatter(AOptions) and
+    TryICUFormatNumberToPartsDirect(ALocale, AValue, AOptions, AParts);
 end;
 
 function TryICUFormatNumberRangeInternal(const ALocale: string;

--- a/source/shared/IntlTypes.pas
+++ b/source/shared/IntlTypes.pas
@@ -17,6 +17,7 @@ type
   TIntlNumberTrailingZeroDisplay = (intzAuto, intzStripIfInteger);
   TIntlNumberRoundingMode = (inrmCeil, inrmFloor, inrmExpand, inrmTrunc,
     inrmHalfCeil, inrmHalfFloor, inrmHalfExpand, inrmHalfTrunc, inrmHalfEven);
+  TIntlNumberRoundingPriority = (inrpAuto, inrpMorePrecision, inrpLessPrecision);
   TIntlNumberUseGrouping = (inugAuto, inugAlways, inugMin2, inugFalse);
   TIntlDateTimeStyle = (idtsNone, idtsFull, idtsLong, idtsMedium, idtsShort);
   TIntlPluralType = (iptCardinal, iptOrdinal);
@@ -58,6 +59,7 @@ type
     MinimumSignificantDigits: Integer;
     MaximumSignificantDigits: Integer;
     RoundingIncrement: Integer;
+    RoundingPriority: TIntlNumberRoundingPriority;
     NumberingSystem: string;
   end;
 
@@ -160,6 +162,7 @@ begin
   Result.MinimumSignificantDigits := -1;
   Result.MaximumSignificantDigits := -1;
   Result.RoundingIncrement := 1;
+  Result.RoundingPriority := inrpAuto;
   Result.NumberingSystem := '';
 end;
 

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -145,6 +145,14 @@ begin
     Result := innStandard;
 end;
 
+function CompactDisplayStringToEnum(const AValue: string): TIntlNumberCompactDisplay;
+begin
+  if AValue = 'long' then
+    Result := incdLong
+  else
+    Result := incdShort;
+end;
+
 function UnitDisplayStringToEnum(const AValue: string): TIntlNumberUnitDisplay;
 begin
   if AValue = 'long' then
@@ -562,6 +570,9 @@ begin
      (FRoundingIncrement <> 2000) and (FRoundingIncrement <> 2500) and
      (FRoundingIncrement <> 5000) then
     ThrowRangeError(Format(SErrorIntlInvalidOption, [IntToStr(FRoundingIncrement), 'roundingIncrement']));
+  if (FRoundingPriority <> 'auto') and (FRoundingPriority <> 'morePrecision') and
+     (FRoundingPriority <> 'lessPrecision') then
+    ThrowRangeError(Format(SErrorIntlInvalidOption, [FRoundingPriority, 'roundingPriority']));
 
   // Default numberingSystem to "latn"
   if FNumberingSystem = '' then
@@ -665,6 +676,7 @@ begin
   FResolvedOptions.UnitIdentifier := FUnitIdentifier;
   FResolvedOptions.UnitDisplay := UnitDisplayStringToEnum(FUnitDisplay);
   FResolvedOptions.Notation := NotationStringToEnum(FNotation);
+  FResolvedOptions.CompactDisplay := CompactDisplayStringToEnum(FCompactDisplay);
   FResolvedOptions.SignDisplay := SignDisplayStringToEnum(FSignDisplay);
   FResolvedOptions.UseGrouping := UseGroupingStringToEnum(FUseGrouping);
   FResolvedOptions.MinimumIntegerDigits := FMinimumIntegerDigits;

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -189,6 +189,16 @@ begin
     Result := inrmHalfExpand;
 end;
 
+function RoundingPriorityStringToEnum(const AValue: string): TIntlNumberRoundingPriority;
+begin
+  if AValue = 'morePrecision' then
+    Result := inrpMorePrecision
+  else if AValue = 'lessPrecision' then
+    Result := inrpLessPrecision
+  else
+    Result := inrpAuto;
+end;
+
 function InsertGroupingSeparator(const AIntPart, ASep: string): string;
 var
   Len, I, GroupCount: Integer;
@@ -492,7 +502,9 @@ end;
 constructor TGocciaIntlNumberFormatValue.Create(const ALocale: string; const AOptions: TGocciaObjectValue);
 var
   Canonical, CurrSymbol, CurrNarrow: string;
-  CurrDigits: Integer;
+  CurrDigits, MinimumFractionDefault, MaximumFractionDefault: Integer;
+  HasFractionDigits, HasSignificantDigits: Boolean;
+  NeedFractionDigits, NeedSignificantDigits: Boolean;
 begin
   inherited Create;
   Canonical := CanonicalizeUnicodeLocaleId(ALocale);
@@ -555,47 +567,94 @@ begin
   if FNumberingSystem = '' then
     FNumberingSystem := 'latn';
 
-  if (FMinimumSignificantDigits >= 0) or (FMaximumSignificantDigits >= 0) then
+  HasSignificantDigits := (FMinimumSignificantDigits >= 0) or
+    (FMaximumSignificantDigits >= 0);
+  HasFractionDigits := (FMinimumFractionDigits >= 0) or
+    (FMaximumFractionDigits >= 0);
+
+  CurrDigits := 2;
+  if (FStyle = 'currency') and (FNotation = 'standard') then
   begin
-    if FMinimumSignificantDigits < 0 then
-      FMinimumSignificantDigits := 1;
-    if FMaximumSignificantDigits < 0 then
-      FMaximumSignificantDigits := 21;
-    FMinimumFractionDigits := -1;
-    FMaximumFractionDigits := -1;
+    if not TryGetCurrencyInfo(FLocale, FCurrency, CurrSymbol, CurrNarrow, CurrDigits) then
+      CurrDigits := 2;
+    MinimumFractionDefault := CurrDigits;
+    MaximumFractionDefault := CurrDigits;
   end
   else
   begin
-    if (FMinimumFractionDigits < 0) and (FMaximumFractionDigits < 0) then
+    MinimumFractionDefault := 0;
+    if FStyle = 'percent' then
+      MaximumFractionDefault := 0
+    else
+      MaximumFractionDefault := 3;
+  end;
+
+  if FRoundingIncrement <> 1 then
+    MaximumFractionDefault := MinimumFractionDefault;
+
+  NeedSignificantDigits := True;
+  NeedFractionDigits := True;
+  if FRoundingPriority = 'auto' then
+  begin
+    NeedSignificantDigits := HasSignificantDigits;
+    if NeedSignificantDigits or
+       ((not HasFractionDigits) and (FNotation = 'compact')) then
+      NeedFractionDigits := False;
+  end;
+
+  if NeedSignificantDigits then
+  begin
+    if HasSignificantDigits then
     begin
-      if FStyle = 'currency' then
-      begin
-        FMinimumFractionDigits := 2;
-        FMaximumFractionDigits := 2;
-        if TryGetCurrencyInfo(FLocale, FCurrency, CurrSymbol, CurrNarrow, CurrDigits) then
-        begin
-          FMinimumFractionDigits := CurrDigits;
-          FMaximumFractionDigits := CurrDigits;
-        end;
-      end
-      else if FStyle = 'percent' then
-      begin
-        FMinimumFractionDigits := 0;
-        FMaximumFractionDigits := 0;
-      end
-      else
-      begin
-        FMinimumFractionDigits := 0;
-        FMaximumFractionDigits := 3;
-      end;
+      if FMinimumSignificantDigits < 0 then
+        FMinimumSignificantDigits := 1;
+      if FMaximumSignificantDigits < 0 then
+        FMaximumSignificantDigits := 21;
+      if FMinimumSignificantDigits > FMaximumSignificantDigits then
+        ThrowRangeError(Format(SErrorIntlDigitsOutOfRange,
+          ['maximumSignificantDigits', FMinimumSignificantDigits, 21]));
     end
     else
     begin
-      if FMinimumFractionDigits < 0 then
-        FMinimumFractionDigits := 0;
-      if FMaximumFractionDigits < 0 then
-        FMaximumFractionDigits := Max(3, FMinimumFractionDigits);
+      FMinimumSignificantDigits := 1;
+      FMaximumSignificantDigits := 21;
     end;
+  end;
+
+  if NeedFractionDigits then
+  begin
+    if HasFractionDigits then
+    begin
+      if FMinimumFractionDigits < 0 then
+        FMinimumFractionDigits := Min(MinimumFractionDefault, FMaximumFractionDigits)
+      else if FMaximumFractionDigits < 0 then
+        FMaximumFractionDigits := Max(MaximumFractionDefault, FMinimumFractionDigits)
+      else if FMinimumFractionDigits > FMaximumFractionDigits then
+        ThrowRangeError(Format(SErrorIntlDigitsOutOfRange,
+          ['maximumFractionDigits', FMinimumFractionDigits, 100]));
+    end
+    else
+    begin
+      FMinimumFractionDigits := MinimumFractionDefault;
+      FMaximumFractionDigits := MaximumFractionDefault;
+    end;
+  end;
+
+  if (not NeedSignificantDigits) and (not NeedFractionDigits) then
+  begin
+    FMinimumFractionDigits := 0;
+    FMaximumFractionDigits := 0;
+    FMinimumSignificantDigits := 1;
+    FMaximumSignificantDigits := 2;
+    FRoundingPriority := 'morePrecision';
+  end;
+
+  if FRoundingIncrement <> 1 then
+  begin
+    if (FRoundingPriority <> 'auto') or HasSignificantDigits then
+      ThrowTypeError('roundingIncrement requires fraction digit rounding');
+    if FMinimumFractionDigits <> FMaximumFractionDigits then
+      ThrowRangeError('roundingIncrement requires matching fraction digit bounds');
   end;
 
   // Build resolved ICU options
@@ -615,6 +674,7 @@ begin
   FResolvedOptions.MaximumSignificantDigits := FMaximumSignificantDigits;
   FResolvedOptions.RoundingMode := RoundingModeStringToEnum(FRoundingMode);
   FResolvedOptions.RoundingIncrement := FRoundingIncrement;
+  FResolvedOptions.RoundingPriority := RoundingPriorityStringToEnum(FRoundingPriority);
   FResolvedOptions.NumberingSystem := FNumberingSystem;
 
   InitializePrototype;

--- a/tests/built-ins/Intl/NumberFormat/prototype/format.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/format.js
@@ -95,4 +95,27 @@ describe.runIf(isIntl)("Intl.NumberFormat.prototype.format", () => {
       maximumFractionDigits: 3,
     }).format(1.5)).toBe("2.500");
   });
+
+  test("notation options use ICU skeleton formatting", () => {
+    expect(new Intl.NumberFormat("en-US", {
+      notation: "scientific",
+      maximumFractionDigits: 2,
+    }).format(12345)).toBe("1.23E4");
+
+    expect(new Intl.NumberFormat("en-US", {
+      notation: "engineering",
+      maximumFractionDigits: 2,
+    }).format(12345)).toBe("12.35E3");
+
+    expect(new Intl.NumberFormat("en-US", {
+      notation: "compact",
+      useGrouping: false,
+    }).format(1234)).toBe("1.2K");
+
+    expect(new Intl.NumberFormat("en-US", {
+      notation: "compact",
+      compactDisplay: "long",
+      useGrouping: false,
+    }).format(1234)).toBe("1.2 thousand");
+  });
 });

--- a/tests/built-ins/Intl/NumberFormat/prototype/format.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/format.js
@@ -29,4 +29,70 @@ describe.runIf(isIntl)("Intl.NumberFormat.prototype.format", () => {
     const result = nf.format(0.75);
     expect(result.includes("%")).toBe(true);
   });
+
+  test("format preserves negative zero", () => {
+    expect(new Intl.NumberFormat("en-US").format(-0)).toBe("-0");
+    expect(new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(-0)).toBe("-0.00");
+    expect(new Intl.NumberFormat("en-US", {
+      maximumFractionDigits: 1,
+      signDisplay: "exceptZero",
+    }).format(-0.01)).toBe("0");
+  });
+
+  test("significant digit formatting keeps plain decimal precision", () => {
+    expect(new Intl.NumberFormat("en-US", {
+      useGrouping: false,
+      minimumSignificantDigits: 1,
+    }).format(0.00000123)).toBe("0.00000123");
+
+    expect(new Intl.NumberFormat("en-US", {
+      useGrouping: false,
+      minimumSignificantDigits: 1,
+    }).format(1234567890123456)).toBe("1234567890123456");
+  });
+
+  test("lessPrecision chooses the less precise mixed digit result", () => {
+    const nf = new Intl.NumberFormat("en-US", {
+      useGrouping: false,
+      roundingPriority: "lessPrecision",
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 3,
+      minimumSignificantDigits: 3,
+      maximumSignificantDigits: 3,
+    });
+    expect(nf.format(1)).toBe("1.00");
+    expect(nf.format(1.23456)).toBe("1.23");
+  });
+
+  test("morePrecision chooses the more precise mixed digit result", () => {
+    const nf = new Intl.NumberFormat("en-US", {
+      useGrouping: false,
+      roundingPriority: "morePrecision",
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 3,
+      minimumSignificantDigits: 3,
+      maximumSignificantDigits: 3,
+    });
+    expect(nf.format(1)).toBe("1.0");
+    expect(nf.format(1.23456)).toBe("1.235");
+  });
+
+  test("large roundingIncrement values round on the fraction digit grid", () => {
+    expect(new Intl.NumberFormat("en-US", {
+      useGrouping: false,
+      roundingIncrement: 1000,
+      minimumFractionDigits: 3,
+      maximumFractionDigits: 3,
+    }).format(1.0005)).toBe("1.000");
+
+    expect(new Intl.NumberFormat("en-US", {
+      useGrouping: false,
+      roundingIncrement: 2500,
+      minimumFractionDigits: 3,
+      maximumFractionDigits: 3,
+    }).format(1.5)).toBe("2.500");
+  });
 });

--- a/tests/built-ins/Intl/NumberFormat/prototype/formatRange.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/formatRange.js
@@ -43,6 +43,18 @@ describe.runIf(isIntl)("Intl.NumberFormat.prototype.formatRange", () => {
     expect(nf.formatRange(1.21, 1.22)).toBe("~1.20");
   });
 
+  test("uses endpoint formatting for mixed rounding priority", () => {
+    const nf = new Intl.NumberFormat("en-US", {
+      useGrouping: false,
+      roundingPriority: "morePrecision",
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 3,
+      minimumSignificantDigits: 3,
+      maximumSignificantDigits: 3,
+    });
+    expect(nf.formatRange(1, 1.23456)).toBe("1.0–1.235");
+  });
+
   test("throws RangeError for NaN endpoints", () => {
     const nf = new Intl.NumberFormat("en-US");
     expect(() => nf.formatRange(NaN, 1)).toThrow(RangeError);

--- a/tests/built-ins/Intl/NumberFormat/prototype/resolvedOptions.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/resolvedOptions.js
@@ -107,4 +107,10 @@ describe("Intl.NumberFormat.prototype.resolvedOptions", () => {
     expect(opts.maximumSignificantDigits).toBe(3);
     expect(opts.roundingPriority).toBe("lessPrecision");
   });
+
+  test("invalid roundingPriority throws RangeError", () => {
+    expect(() => new Intl.NumberFormat("en-US", {
+      roundingPriority: "bad",
+    })).toThrow(RangeError);
+  });
 });

--- a/tests/built-ins/Intl/NumberFormat/prototype/resolvedOptions.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/resolvedOptions.js
@@ -34,6 +34,24 @@ describe("Intl.NumberFormat.prototype.resolvedOptions", () => {
     expect(opts.maximumFractionDigits).toBe(2);
   });
 
+  test("currency style uses currency digits for missing one-sided fraction defaults", () => {
+    const maximumOnly = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 5,
+    }).resolvedOptions();
+    expect(maximumOnly.minimumFractionDigits).toBe(2);
+    expect(maximumOnly.maximumFractionDigits).toBe(5);
+
+    const minimumOnly = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 1,
+    }).resolvedOptions();
+    expect(minimumOnly.minimumFractionDigits).toBe(1);
+    expect(minimumOnly.maximumFractionDigits).toBe(2);
+  });
+
   test("currency style omits unit fields", () => {
     const opts = new Intl.NumberFormat("en-US", {
       style: "currency",
@@ -73,5 +91,20 @@ describe("Intl.NumberFormat.prototype.resolvedOptions", () => {
     expect(opts.maximumSignificantDigits).toBe(5);
     expect(opts.minimumFractionDigits).toBe(undefined);
     expect(opts.maximumFractionDigits).toBe(undefined);
+  });
+
+  test("non-auto roundingPriority resolves fraction and significant digit fields", () => {
+    const opts = new Intl.NumberFormat("en-US", {
+      roundingPriority: "lessPrecision",
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 3,
+      minimumSignificantDigits: 3,
+      maximumSignificantDigits: 3,
+    }).resolvedOptions();
+    expect(opts.minimumFractionDigits).toBe(1);
+    expect(opts.maximumFractionDigits).toBe(3);
+    expect(opts.minimumSignificantDigits).toBe(3);
+    expect(opts.maximumSignificantDigits).toBe(3);
+    expect(opts.roundingPriority).toBe("lessPrecision");
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fix `Intl.NumberFormat` digit option resolution for one-sided currency fraction bounds so missing bounds use currency-specific defaults.
- Resolve both fraction and significant digit families for non-`auto` `roundingPriority`.
- Route `format()`, `formatToParts()`, `formatRange()`, and `formatRangeToParts()` through ICU NumberFormatter skeletons so ICU owns rounding modes, rounding increments, sign display, and mixed fraction/significant precision consistently.
- Add focused `resolvedOptions()`, `format()`, and `formatRange()` regressions, including mixed `roundingPriority`, negative zero sign display, significant digits, and large `roundingIncrement` coverage.
- Closes #643.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation (not needed; behavior fix covered by tests)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional verification run locally:

- `./format.pas --check`
- `./build.pas testrunner loaderbare`
- `./build/GocciaTestRunner tests/built-ins/Intl/NumberFormat --asi --unsafe-ffi --no-progress`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/prototype/format/format-rounding-mode-*.js' --output /tmp/goccia-test262-rounding-mode.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/prototype/format/format-fraction-digits-precision.js' --output /tmp/goccia-test262-fraction-digits-precision.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/prototype/format/format-significant-digits.js' --output /tmp/goccia-test262-significant-digits.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/prototype/format/format-rounding-priority-*' --output /tmp/goccia-test262-rounding-priority.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/test-option-roundingPriority-mixed-options.js' --output /tmp/goccia-test262-rounding-priority-mixed.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/prototype/format/format-rounding-increment-*' --output /tmp/goccia-test262-rounding-increment.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/prototype/format/signDisplay-rounding.js' --output /tmp/goccia-test262-sign-display-rounding.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/prototype/formatRange/*.js' --output /tmp/goccia-test262-format-range-only.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/prototype/formatRangeToParts/*.js' --output /tmp/goccia-test262-format-range-parts.json --jobs=2`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --filter 'intl402/NumberFormat/**/*.js' --output /tmp/goccia-test262-numberformat-all.json --jobs=2` (subtree has expected pre-existing failures; the rounding regression files above pass)
- `./build/GocciaTestRunner tests --asi --unsafe-ffi --no-progress`