### PR TITLE
Fix GC roots for VM saved state and native callbacks

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -112,6 +112,35 @@ console.log("Loader: JSON output (bytecode)...");
   if (typeof json.memory?.gc?.peakLiveBytes !== "number") throw new Error("Bytecode JSON memory.gc.peakLiveBytes should be present");
 }
 
+console.log("Loader: bytecode TypedArray.from roots mapper during iterator GC...");
+{
+  const source = `
+let i = 0;
+const iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        i++;
+        Goccia.gc();
+        if (i > 2) return { done: true };
+        return { done: false, value: { value: i } };
+      }
+    };
+  }
+};
+const ta = Uint8Array.from(
+  iterable,
+  ({ mapper(item) { return item.value + this.offset; } }).mapper,
+  { offset: 0 },
+);
+ta[0] * 10 + ta[1];
+`;
+  const { exitCode, json, stderr } = runLoaderJson(source, ["--mode=bytecode"]);
+  if (exitCode !== 0) throw new Error(`TypedArray.from GC repro exited ${exitCode}: ${stderr}`);
+  const result = json.files?.[0]?.result;
+  if (result !== 12) throw new Error(`TypedArray.from GC repro expected 12, got ${result}`);
+}
+
 console.log("Loader: JSON undefined result...");
 {
   const { json } = runLoaderJson("undefined;\n");

--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -1581,6 +1581,20 @@ begin
     Result := ScaledInt / Scale;
 end;
 
+function CanonicalizeICUNumberFormatInput(AValue: Double): Double; inline;
+var
+  Bits: QWord;
+begin
+  if not IsNan(AValue) then
+    Exit(AValue);
+
+  // ECMA-402 models NaN as the unsigned abstract value not-a-number.
+  // ICU formats a negative NaN payload as "-NaN" on Linux, so normalize
+  // the payload before crossing the ICU boundary.
+  Bits := QWord($7FF8000000000000);
+  Move(Bits, Result, SizeOf(Result));
+end;
+
 procedure AddSkeletonToken(var ASkeleton: string; const AToken: string);
 begin
   if AToken = '' then
@@ -1873,6 +1887,7 @@ end;
 function TryICUFormatNumber(const ALocale: string; AValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
 begin
+  AValue := CanonicalizeICUNumberFormatInput(AValue);
   if TryICUFormatNumberSkeleton(ALocale, AValue, AOptions, AFormatted) then
     Exit(True);
   Result := CanUseLegacyNumberFormatter(AOptions) and
@@ -1997,6 +2012,7 @@ end;
 function TryICUFormatNumberToParts(const ALocale: string; AValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
 begin
+  AValue := CanonicalizeICUNumberFormatInput(AValue);
   if TryICUFormatNumberToPartsSkeleton(ALocale, AValue, AOptions, AParts) then
     Exit(True);
   Result := CanUseLegacyNumberFormatter(AOptions) and

--- a/source/units/Goccia.Builtins.GlobalArray.pas
+++ b/source/units/Goccia.Builtins.GlobalArray.pas
@@ -104,6 +104,7 @@ var
   SourceStr: string;
   Mapping: Boolean;
   K, Len: Integer;
+  SourceRoot, ResultRoot: TGocciaTempRoot;
 
   // ES2026 §7.3.5 CreateDataPropertyOrThrow(A, P, V)
   procedure CreateDataProperty(const AIndex: Integer; const AValue: TGocciaValue);
@@ -170,6 +171,7 @@ begin
   if Mapping then
     MapArgs := TGocciaArgumentsCollection.Create([TGocciaUndefinedLiteralValue.UndefinedValue, TGocciaNumberLiteralValue.ZeroValue]);
 
+  AddTempRootIfNeeded(SourceRoot, Source);
   try
     // Fast path: source is already an array (avoids iterator overhead)
     if Source is TGocciaArrayValue then
@@ -177,50 +179,60 @@ begin
       SourceArray := TGocciaArrayValue(Source);
       // Step 5a-b: Construct or create result (iterable path uses 0)
       ResultObj := ConstructOrCreate(0);
-      if ResultObj is TGocciaArrayValue then
-        TGocciaArrayValue(ResultObj).Elements.Capacity := SourceArray.Elements.Count;
-      // Step 5e: Iterate and populate
-      for K := 0 to SourceArray.Elements.Count - 1 do
-      begin
-        KValue := SourceArray.Elements[K];
-        if not Assigned(KValue) then
-          KValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-        // Step 5e-iv: If mapping, let mappedValue = Call(mapfn, thisArg, « next, k »)
-        if Mapping then
+      AddTempRootIfNeeded(ResultRoot, ResultObj);
+      try
+        if ResultObj is TGocciaArrayValue then
+          TGocciaArrayValue(ResultObj).Elements.Capacity := SourceArray.Elements.Count;
+        // Step 5e: Iterate and populate
+        for K := 0 to SourceArray.Elements.Count - 1 do
         begin
-          MapArgs.SetElement(0, KValue);
-          MapArgs.SetElement(1, TGocciaNumberLiteralValue.Create(K));
-          KValue := InvokeCallable(MapCallback, MapArgs, ThisArg);
+          KValue := SourceArray.Elements[K];
+          if not Assigned(KValue) then
+            KValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+          // Step 5e-iv: If mapping, let mappedValue = Call(mapfn, thisArg, « next, k »)
+          if Mapping then
+          begin
+            MapArgs.SetElement(0, KValue);
+            MapArgs.SetElement(1, TGocciaNumberLiteralValue.Create(K));
+            KValue := InvokeCallable(MapCallback, MapArgs, ThisArg);
+          end;
+          // Step 5e-v: CreateDataPropertyOrThrow(A, ToString(k), mappedValue)
+          CreateDataProperty(K, KValue);
         end;
-        // Step 5e-v: CreateDataPropertyOrThrow(A, ToString(k), mappedValue)
-        CreateDataProperty(K, KValue);
+        // Step 5e-iii: Set length
+        if UseConstructor and not (ResultObj is TGocciaArrayValue) then
+          ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(SourceArray.Elements.Count));
+        Result := ResultObj;
+      finally
+        RemoveTempRootIfNeeded(ResultRoot);
       end;
-      // Step 5e-iii: Set length
-      if UseConstructor and not (ResultObj is TGocciaArrayValue) then
-        ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(SourceArray.Elements.Count));
-      Result := ResultObj;
     end
     // Fast path: source is a string (iterate code points)
     else if Source is TGocciaStringLiteralValue then
     begin
       SourceStr := TGocciaStringLiteralValue(Source).Value;
       ResultObj := ConstructOrCreate(0);
-      if ResultObj is TGocciaArrayValue then
-        TGocciaArrayValue(ResultObj).Elements.Capacity := Length(SourceStr);
-      for K := 1 to Length(SourceStr) do
-      begin
-        KValue := TGocciaStringLiteralValue.Create(SourceStr[K]);
-        if Mapping then
+      AddTempRootIfNeeded(ResultRoot, ResultObj);
+      try
+        if ResultObj is TGocciaArrayValue then
+          TGocciaArrayValue(ResultObj).Elements.Capacity := Length(SourceStr);
+        for K := 1 to Length(SourceStr) do
         begin
-          MapArgs.SetElement(0, KValue);
-          MapArgs.SetElement(1, TGocciaNumberLiteralValue.Create(K - 1));
-          KValue := InvokeCallable(MapCallback, MapArgs, ThisArg);
+          KValue := TGocciaStringLiteralValue.Create(SourceStr[K]);
+          if Mapping then
+          begin
+            MapArgs.SetElement(0, KValue);
+            MapArgs.SetElement(1, TGocciaNumberLiteralValue.Create(K - 1));
+            KValue := InvokeCallable(MapCallback, MapArgs, ThisArg);
+          end;
+          CreateDataProperty(K - 1, KValue);
         end;
-        CreateDataProperty(K - 1, KValue);
+        if UseConstructor and not (ResultObj is TGocciaArrayValue) then
+          ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(Length(SourceStr)));
+        Result := ResultObj;
+      finally
+        RemoveTempRootIfNeeded(ResultRoot);
       end;
-      if UseConstructor and not (ResultObj is TGocciaArrayValue) then
-        ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(Length(SourceStr)));
-      Result := ResultObj;
     end
     else
     begin
@@ -260,7 +272,7 @@ begin
         // Step 5a-b: If IsConstructor(C), Construct(C, « »); else ArrayCreate(0)
         ResultObj := ConstructOrCreate(0);
         TGarbageCollector.Instance.AddTempRoot(Iterator);
-        TGarbageCollector.Instance.AddTempRoot(ResultObj);
+        AddTempRootIfNeeded(ResultRoot, ResultObj);
         try
           // Step 5d-e: Iterate
           K := 0;
@@ -280,7 +292,7 @@ begin
             IterResult := Iterator.AdvanceNext;
           end;
         finally
-          TGarbageCollector.Instance.RemoveTempRoot(ResultObj);
+          RemoveTempRootIfNeeded(ResultRoot);
           TGarbageCollector.Instance.RemoveTempRoot(Iterator);
         end;
         // Step 5e-iii: Set A.[[length]] to k
@@ -297,35 +309,41 @@ begin
           Len := Trunc(LengthVal.ToNumberLiteral.Value);
           // Step 9-10: If IsConstructor(C), Construct(C, « len »); else ArrayCreate(len)
           ResultObj := ConstructOrCreate(0);
-          if ResultObj is TGocciaArrayValue then
-            TGocciaArrayValue(ResultObj).Elements.Capacity := Len;
-          // Step 12: Iterate array-like
-          for K := 0 to Len - 1 do
-          begin
-            // Step 12b: Let kValue = Get(arrayLike, Pk)
-            KValue := Source.GetProperty(IntToStr(K));
-            if not Assigned(KValue) then
-              KValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-            // Step 12c-d: If mapping, Call(mapfn, thisArg, « kValue, k »)
-            if Mapping then
+          AddTempRootIfNeeded(ResultRoot, ResultObj);
+          try
+            if ResultObj is TGocciaArrayValue then
+              TGocciaArrayValue(ResultObj).Elements.Capacity := Len;
+            // Step 12: Iterate array-like
+            for K := 0 to Len - 1 do
             begin
-              MapArgs.SetElement(0, KValue);
-              MapArgs.SetElement(1, TGocciaNumberLiteralValue.Create(K));
-              KValue := InvokeCallable(MapCallback, MapArgs, ThisArg);
+              // Step 12b: Let kValue = Get(arrayLike, Pk)
+              KValue := Source.GetProperty(IntToStr(K));
+              if not Assigned(KValue) then
+                KValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+              // Step 12c-d: If mapping, Call(mapfn, thisArg, « kValue, k »)
+              if Mapping then
+              begin
+                MapArgs.SetElement(0, KValue);
+                MapArgs.SetElement(1, TGocciaNumberLiteralValue.Create(K));
+                KValue := InvokeCallable(MapCallback, MapArgs, ThisArg);
+              end;
+              // Step 12e: CreateDataPropertyOrThrow(A, Pk, mappedValue)
+              CreateDataProperty(K, KValue);
             end;
-            // Step 12e: CreateDataPropertyOrThrow(A, Pk, mappedValue)
-            CreateDataProperty(K, KValue);
+            // Step 13: Set A.[[length]] = len
+            if UseConstructor and not (ResultObj is TGocciaArrayValue) then
+              ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(Len));
+            Result := ResultObj;
+          finally
+            RemoveTempRootIfNeeded(ResultRoot);
           end;
-          // Step 13: Set A.[[length]] = len
-          if UseConstructor and not (ResultObj is TGocciaArrayValue) then
-            ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(Len));
-          Result := ResultObj;
         end
         else
           Result := ConstructOrCreate(0);
       end;
     end;
   finally
+    RemoveTempRootIfNeeded(SourceRoot);
     MapArgs.Free;
   end;
 end;
@@ -344,6 +362,7 @@ var
   K, Len: Integer;
   LengthValue: TGocciaValue;
   GC: TGarbageCollector;
+  SourceRoot: TGocciaTempRoot;
 
   procedure AddElement(const AIndex: Integer; const AValue: TGocciaValue);
   begin
@@ -384,6 +403,8 @@ var
 
 begin
   GC := TGarbageCollector.Instance;
+  SourceRoot.ObjectValue := nil;
+  SourceRoot.Added := False;
   Promise := TGocciaPromiseValue.Create;
 
   if Assigned(GC) then
@@ -398,6 +419,7 @@ begin
       Result := Promise;
       Exit;
     end;
+    AddTempRootIfNeeded(SourceRoot, Source);
 
     Mapping := False;
     MapCallback := nil;
@@ -658,6 +680,7 @@ begin
         GC.RemoveTempRoot(ResultObj);
     end;
   finally
+    RemoveTempRootIfNeeded(SourceRoot);
     if Assigned(GC) then
       GC.RemoveTempRoot(Promise);
   end;

--- a/source/units/Goccia.Builtins.GlobalArray.pas
+++ b/source/units/Goccia.Builtins.GlobalArray.pas
@@ -171,6 +171,8 @@ begin
   if Mapping then
     MapArgs := TGocciaArgumentsCollection.Create([TGocciaUndefinedLiteralValue.UndefinedValue, TGocciaNumberLiteralValue.ZeroValue]);
 
+  InitializeTempRoot(SourceRoot);
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(SourceRoot, Source);
   try
     // Fast path: source is already an array (avoids iterator overhead)
@@ -403,8 +405,7 @@ var
 
 begin
   GC := TGarbageCollector.Instance;
-  SourceRoot.ObjectValue := nil;
-  SourceRoot.Added := False;
+  InitializeTempRoot(SourceRoot);
   Promise := TGocciaPromiseValue.Create;
 
   if Assigned(GC) then

--- a/source/units/Goccia.Builtins.GlobalMap.pas
+++ b/source/units/Goccia.Builtins.GlobalMap.pas
@@ -99,6 +99,8 @@ begin
 
   // Step 2: Let map be a new empty Map
   ResultMap := TGocciaMapValue.Create;
+  InitializeTempRoot(SourceRoot);
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(SourceRoot, Source);
   AddTempRootIfNeeded(ResultRoot, ResultMap);
   try

--- a/source/units/Goccia.Builtins.GlobalMap.pas
+++ b/source/units/Goccia.Builtins.GlobalMap.pas
@@ -59,6 +59,7 @@ var
   Iterator: TGocciaIteratorValue;
   Done: Boolean;
   I: Integer;
+  SourceRoot, ResultRoot: TGocciaTempRoot;
 
   procedure AddToGroup(const AValue: TGocciaValue; const AIndex: Integer);
   var
@@ -98,59 +99,51 @@ begin
 
   // Step 2: Let map be a new empty Map
   ResultMap := TGocciaMapValue.Create;
+  AddTempRootIfNeeded(SourceRoot, Source);
+  AddTempRootIfNeeded(ResultRoot, ResultMap);
+  try
 
-  // Fast path: source is an array (avoids iterator overhead)
-  if Source is TGocciaArrayValue then
-  begin
-    SourceArray := TGocciaArrayValue(Source);
-    TGarbageCollector.Instance.AddTempRoot(ResultMap);
-    try
+    // Fast path: source is an array (avoids iterator overhead)
+    if Source is TGocciaArrayValue then
+    begin
+      SourceArray := TGocciaArrayValue(Source);
       I := 0;
       while I < SourceArray.Elements.Count do
       begin
         AddToGroup(SourceArray.Elements[I], I);
         Inc(I);
       end;
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(ResultMap);
+      Result := ResultMap;
+      Exit;
     end;
-    Result := ResultMap;
-    Exit;
-  end;
 
-  // Iterator path: strings via string iterator
-  if Source is TGocciaStringLiteralValue then
-  begin
-    Iterator := TGocciaStringIteratorValue.Create(Source);
-    TGarbageCollector.Instance.AddTempRoot(Iterator);
-    TGarbageCollector.Instance.AddTempRoot(ResultMap);
-    try
-      I := 0;
-      CurrentValue := Iterator.DirectNext(Done);
-      while not Done do
-      begin
-        AddToGroup(CurrentValue, I);
-        Inc(I);
-        CurrentValue := Iterator.DirectNext(Done);
-      end;
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(ResultMap);
-      TGarbageCollector.Instance.RemoveTempRoot(Iterator);
-    end;
-    Result := ResultMap;
-    Exit;
-  end;
-
-  // Iterator path: objects with [Symbol.iterator]
-  if Source is TGocciaObjectValue then
-  begin
-    IteratorMethod := TGocciaObjectValue(Source).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
-    if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
+    // Iterator path: strings via string iterator
+    if Source is TGocciaStringLiteralValue then
     begin
-      // Root ResultMap before calling [Symbol.iterator]() — that call
-      // executes user code and may trigger GC.
-      TGarbageCollector.Instance.AddTempRoot(ResultMap);
+      Iterator := TGocciaStringIteratorValue.Create(Source);
+      TGarbageCollector.Instance.AddTempRoot(Iterator);
       try
+        I := 0;
+        CurrentValue := Iterator.DirectNext(Done);
+        while not Done do
+        begin
+          AddToGroup(CurrentValue, I);
+          Inc(I);
+          CurrentValue := Iterator.DirectNext(Done);
+        end;
+      finally
+        TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+      end;
+      Result := ResultMap;
+      Exit;
+    end;
+
+    // Iterator path: objects with [Symbol.iterator]
+    if Source is TGocciaObjectValue then
+    begin
+      IteratorMethod := TGocciaObjectValue(Source).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
+      if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
+      begin
         CallArgs := TGocciaArgumentsCollection.Create;
         try
           IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, Source);
@@ -188,17 +181,18 @@ begin
         finally
           TGarbageCollector.Instance.RemoveTempRoot(Iterator);
         end;
-      finally
-        TGarbageCollector.Instance.RemoveTempRoot(ResultMap);
+        Result := ResultMap;
+        Exit;
       end;
-      Result := ResultMap;
-      Exit;
     end;
-  end;
 
-  // Non-iterable: throw TypeError
-  ThrowTypeError(SErrorMapGroupByRequiresIterable, SSuggestNotIterable);
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    // Non-iterable: throw TypeError
+    ThrowTypeError(SErrorMapGroupByRequiresIterable, SSuggestNotIterable);
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  finally
+    RemoveTempRootIfNeeded(ResultRoot);
+    RemoveTempRootIfNeeded(SourceRoot);
+  end;
 end;
 
 end.

--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -996,6 +996,7 @@ var
   CallArgs: TGocciaArgumentsCollection;
   KeyValue: TGocciaValue;
   I: Integer;
+  ItemsRoot, ResultRoot: TGocciaTempRoot;
 begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.groupBy', ThrowError);
 
@@ -1010,39 +1011,46 @@ begin
   // Step 2: Let obj be OrdinaryObjectCreate(null)
   ResultObj := TGocciaObjectValue.Create;
   ResultObj.Prototype := nil;
+  AddTempRootIfNeeded(ItemsRoot, Items);
+  AddTempRootIfNeeded(ResultRoot, ResultObj);
+  try
 
-  // Step 3: For each Record { [[Key]], [[Elements]] } g of groups
-  I := 0;
-  while I < Items.Elements.Count do
-  begin
-    CallArgs := TGocciaArgumentsCollection.Create;
-    try
-      CallArgs.Add(Items.Elements[I]);
-      CallArgs.Add(TGocciaNumberLiteralValue.Create(I));
-
-      KeyValue := InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
-    finally
-      CallArgs.Free;
-    end;
-
-    GroupKey := KeyValue.ToStringLiteral.Value;
-
-    if ResultObj.HasOwnProperty(GroupKey) then
-      GroupArray := TGocciaArrayValue(ResultObj.GetProperty(GroupKey))
-    else
+    // Step 3: For each Record { [[Key]], [[Elements]] } g of groups
+    I := 0;
+    while I < Items.Elements.Count do
     begin
-      // Step 3a: Let elements be CreateArrayFromList(g.[[Elements]])
-      GroupArray := TGocciaArrayValue.Create;
-      // Step 3b: Perform ! CreateDataPropertyOrThrow(obj, g.[[Key]], elements)
-      ResultObj.AssignProperty(GroupKey, GroupArray);
+      CallArgs := TGocciaArgumentsCollection.Create;
+      try
+        CallArgs.Add(Items.Elements[I]);
+        CallArgs.Add(TGocciaNumberLiteralValue.Create(I));
+
+        KeyValue := InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+      finally
+        CallArgs.Free;
+      end;
+
+      GroupKey := KeyValue.ToStringLiteral.Value;
+
+      if ResultObj.HasOwnProperty(GroupKey) then
+        GroupArray := TGocciaArrayValue(ResultObj.GetProperty(GroupKey))
+      else
+      begin
+        // Step 3a: Let elements be CreateArrayFromList(g.[[Elements]])
+        GroupArray := TGocciaArrayValue.Create;
+        // Step 3b: Perform ! CreateDataPropertyOrThrow(obj, g.[[Key]], elements)
+        ResultObj.AssignProperty(GroupKey, GroupArray);
+      end;
+
+      GroupArray.Elements.Add(Items.Elements[I]);
+      Inc(I);
     end;
 
-    GroupArray.Elements.Add(Items.Elements[I]);
-    Inc(I);
+    // Step 4: Return obj
+    Result := ResultObj;
+  finally
+    RemoveTempRootIfNeeded(ResultRoot);
+    RemoveTempRootIfNeeded(ItemsRoot);
   end;
-
-  // Step 4: Return obj
-  Result := ResultObj;
 end;
 
 end.

--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -1011,6 +1011,8 @@ begin
   // Step 2: Let obj be OrdinaryObjectCreate(null)
   ResultObj := TGocciaObjectValue.Create;
   ResultObj.Prototype := nil;
+  InitializeTempRoot(ItemsRoot);
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ItemsRoot, Items);
   AddTempRootIfNeeded(ResultRoot, ResultObj);
   try

--- a/source/units/Goccia.GarbageCollector.pas
+++ b/source/units/Goccia.GarbageCollector.pas
@@ -33,6 +33,11 @@ type
   TGCManagedObjectList = TObjectList<TGCManagedObject>;
   TGCObjectSet = THashMap<TGCManagedObject, Boolean>;
 
+  TGocciaTempRoot = record
+    ObjectValue: TGCManagedObject;
+    Added: Boolean;
+  end;
+
   TGarbageCollector = class
   private
     FManagedObjects: TGCManagedObjectList;
@@ -151,6 +156,9 @@ const
   MAX_BYTES_CAP_32BIT = 700 * 1024 * 1024;          { 700 MB cap for 32-bit }
 
 function DetectDefaultMaxBytes: Int64;
+procedure AddTempRootIfNeeded(var ARoot: TGocciaTempRoot;
+  const AObject: TGCManagedObject);
+procedure RemoveTempRootIfNeeded(var ARoot: TGocciaTempRoot);
 
 implementation
 
@@ -231,6 +239,35 @@ begin
   if Assigned(GC) then
     GC.UnregisterObject(Self);
   inherited;
+end;
+
+procedure AddTempRootIfNeeded(var ARoot: TGocciaTempRoot;
+  const AObject: TGCManagedObject);
+var
+  GC: TGarbageCollector;
+begin
+  ARoot.ObjectValue := AObject;
+  ARoot.Added := False;
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) and Assigned(AObject) and not GC.IsTempRoot(AObject) then
+  begin
+    GC.AddTempRoot(AObject);
+    ARoot.Added := True;
+  end;
+end;
+
+procedure RemoveTempRootIfNeeded(var ARoot: TGocciaTempRoot);
+var
+  GC: TGarbageCollector;
+begin
+  if ARoot.Added then
+  begin
+    GC := TGarbageCollector.Instance;
+    if Assigned(GC) then
+      GC.RemoveTempRoot(ARoot.ObjectValue);
+  end;
+  ARoot.ObjectValue := nil;
+  ARoot.Added := False;
 end;
 
 { TGarbageCollector }

--- a/source/units/Goccia.GarbageCollector.pas
+++ b/source/units/Goccia.GarbageCollector.pas
@@ -33,6 +33,7 @@ type
   TGCManagedObjectList = TObjectList<TGCManagedObject>;
   TGCObjectSet = THashMap<TGCManagedObject, Boolean>;
 
+  // Initialize stack-local roots with InitializeTempRoot before first use.
   TGocciaTempRoot = record
     ObjectValue: TGCManagedObject;
     Added: Boolean;
@@ -156,6 +157,7 @@ const
   MAX_BYTES_CAP_32BIT = 700 * 1024 * 1024;          { 700 MB cap for 32-bit }
 
 function DetectDefaultMaxBytes: Int64;
+procedure InitializeTempRoot(var ARoot: TGocciaTempRoot); inline;
 procedure AddTempRootIfNeeded(var ARoot: TGocciaTempRoot;
   const AObject: TGCManagedObject);
 procedure RemoveTempRootIfNeeded(var ARoot: TGocciaTempRoot);
@@ -241,11 +243,24 @@ begin
   inherited;
 end;
 
+procedure InitializeTempRoot(var ARoot: TGocciaTempRoot);
+begin
+  ARoot.ObjectValue := nil;
+  ARoot.Added := False;
+end;
+
 procedure AddTempRootIfNeeded(var ARoot: TGocciaTempRoot;
   const AObject: TGCManagedObject);
 var
   GC: TGarbageCollector;
 begin
+  if ARoot.Added then
+  begin
+    if ARoot.ObjectValue = AObject then
+      Exit;
+    RemoveTempRootIfNeeded(ARoot);
+  end;
+
   ARoot.ObjectValue := AObject;
   ARoot.Added := False;
   GC := TGarbageCollector.Instance;

--- a/source/units/Goccia.Utils.pas
+++ b/source/units/Goccia.Utils.pas
@@ -156,14 +156,15 @@ var
 begin
   InitializeTempRoot(CallableRoot);
   InitializeTempRoot(ThisRoot);
-  AddTempRootIfNeeded(CallableRoot, ACallable);
-  AddTempRootIfNeeded(ThisRoot, AThisValue);
-  SetLength(ArgRoots, AArgs.Length);
-  for I := 0 to High(ArgRoots) do
-    InitializeTempRoot(ArgRoots[I]);
-  for I := 0 to High(ArgRoots) do
-    AddTempRootIfNeeded(ArgRoots[I], AArgs.GetElement(I));
   try
+    AddTempRootIfNeeded(CallableRoot, ACallable);
+    AddTempRootIfNeeded(ThisRoot, AThisValue);
+    SetLength(ArgRoots, AArgs.Length);
+    for I := 0 to High(ArgRoots) do
+      InitializeTempRoot(ArgRoots[I]);
+    for I := 0 to High(ArgRoots) do
+      AddTempRootIfNeeded(ArgRoots[I], AArgs.GetElement(I));
+
     if ACallable is TGocciaFunctionBase then
       Result := TGocciaFunctionBase(ACallable).Call(AArgs, AThisValue)
     else if ACallable is TGocciaClassValue then

--- a/source/units/Goccia.Utils.pas
+++ b/source/units/Goccia.Utils.pas
@@ -55,6 +55,7 @@ uses
   SysUtils,
 
   Goccia.Constants.NumericLimits,
+  Goccia.GarbageCollector,
   Goccia.Values.ClassValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase;
@@ -148,13 +149,30 @@ end;
 
 function InvokeCallable(const ACallable: TGocciaValue; const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
+var
+  CallableRoot, ThisRoot: TGocciaTempRoot;
+  ArgRoots: array of TGocciaTempRoot;
+  I: Integer;
 begin
-  if ACallable is TGocciaFunctionBase then
-    Result := TGocciaFunctionBase(ACallable).Call(AArgs, AThisValue)
-  else if ACallable is TGocciaClassValue then
-    Result := TGocciaClassValue(ACallable).Call(AArgs, AThisValue)
-  else
-    ThrowTypeError(Format('%s is not a function', [ACallable.TypeName]));
+  AddTempRootIfNeeded(CallableRoot, ACallable);
+  AddTempRootIfNeeded(ThisRoot, AThisValue);
+  SetLength(ArgRoots, AArgs.Length);
+  for I := 0 to High(ArgRoots) do
+    AddTempRootIfNeeded(ArgRoots[I], AArgs.GetElement(I));
+  try
+    if ACallable is TGocciaFunctionBase then
+      Result := TGocciaFunctionBase(ACallable).Call(AArgs, AThisValue)
+    else if ACallable is TGocciaClassValue then
+      Result := TGocciaClassValue(ACallable).Call(AArgs, AThisValue)
+    else
+      ThrowTypeError(Format('%s is not a function', [ACallable.TypeName]));
+  finally
+    for I := High(ArgRoots) downto 0 do
+      RemoveTempRootIfNeeded(ArgRoots[I]);
+    SetLength(ArgRoots, 0);
+    RemoveTempRootIfNeeded(ThisRoot);
+    RemoveTempRootIfNeeded(CallableRoot);
+  end;
 end;
 
 end.

--- a/source/units/Goccia.Utils.pas
+++ b/source/units/Goccia.Utils.pas
@@ -154,9 +154,13 @@ var
   ArgRoots: array of TGocciaTempRoot;
   I: Integer;
 begin
+  InitializeTempRoot(CallableRoot);
+  InitializeTempRoot(ThisRoot);
   AddTempRootIfNeeded(CallableRoot, ACallable);
   AddTempRootIfNeeded(ThisRoot, AThisValue);
   SetLength(ArgRoots, AArgs.Length);
+  for I := 0 to High(ArgRoots) do
+    InitializeTempRoot(ArgRoots[I]);
   for I := 0 to High(ArgRoots) do
     AddTempRootIfNeeded(ArgRoots[I], AArgs.GetElement(I));
   try

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -69,6 +69,12 @@ type
   TGocciaBytecodeGeneratorResumeKind = (bgrkNext, bgrkReturn, bgrkThrow);
   TGocciaBytecodeGeneratorState = (bgsSuspendedStart, bgsSuspendedYield,
     bgsExecuting, bgsCompleted);
+  TGocciaVMSavedStateRoot = record
+    Closure: TGocciaBytecodeClosure;
+    NewTarget: TGocciaValue;
+    Arguments: TGocciaRegisterArray;
+  end;
+  TGocciaVMSavedStateRootArray = array of TGocciaVMSavedStateRoot;
 
   TGocciaVM = class
   private
@@ -104,6 +110,8 @@ type
     FLastClosureThisValue: TGocciaRegister;
     FPrivateInitializerReceiver: TGocciaValue;
     FStackRoot: TGocciaVMStackRoot;
+    FTempSavedStateRoots: TGocciaVMSavedStateRootArray;
+    FTempSavedStateRootCount: Integer;
     function ConstantToValue(const AConstant: TGocciaBytecodeConstant): TGocciaValue;
     // ES2026 §13.2.8.3 GetTemplateObject — lazy-build helper for bckTemplateObject constants.
     function BuildTemplateObjectConstant(const ATemplate: TGocciaFunctionTemplate;
@@ -234,6 +242,9 @@ type
       out APrevCovLine: UInt32; out AProfileTimestamp: Int64): Integer;
     procedure TeardownCurrentFrame(const ATemplate: TGocciaFunctionTemplate;
       const AProfileTimestamp: Int64; const ATargetHandlerCount: Integer);
+    procedure PushSavedStateRoot(const AClosure: TGocciaBytecodeClosure;
+      const ANewTarget: TGocciaValue; const AArguments: TGocciaRegisterArray);
+    procedure PopSavedStateRoot;
     procedure SetupNewFrame(const AClosure: TGocciaBytecodeClosure;
       const AThisValue: TGocciaRegister; const AArguments: TGocciaRegisterArray;
       const AArgCount: Integer; const AArg0, AArg1, AArg2: TGocciaRegister;
@@ -1050,6 +1061,14 @@ begin
       FVM.FFrameStack[I].LocalCellCount);
     if Assigned(FVM.FFrameStack[I].NewTarget) then
       TGocciaValue(FVM.FFrameStack[I].NewTarget).MarkReferences;
+  end;
+
+  for I := 0 to FVM.FTempSavedStateRootCount - 1 do
+  begin
+    MarkClosureReferences(FVM.FTempSavedStateRoots[I].Closure);
+    if Assigned(FVM.FTempSavedStateRoots[I].NewTarget) then
+      FVM.FTempSavedStateRoots[I].NewTarget.MarkReferences;
+    MarkRegisterArray(FVM.FTempSavedStateRoots[I].Arguments);
   end;
 
   if Assigned(FVM.FActiveDecoratorSession) then
@@ -3042,6 +3061,7 @@ begin
   FActiveDecoratorSession := nil;
   FLastClosureThisValue := RegisterUndefined;
   FPrivateInitializerReceiver := nil;
+  FTempSavedStateRootCount := 0;
   SetLength(FRegisterStack, INITIAL_STACK_SIZE);
   FRegisterBase := 0;
   FRegisters := nil;
@@ -3073,6 +3093,7 @@ begin
   for I := 0 to FArgumentPoolCount - 1 do
     FArgumentPool[I].Free;
   SetLength(FArgumentPool, 0);
+  SetLength(FTempSavedStateRoots, 0);
   FHandlerStack.Free;
   SetExceptionMask(FPreviousExceptionMask);
   inherited;
@@ -7387,6 +7408,27 @@ begin
   Dec(FFrameDepth);
 end;
 
+procedure TGocciaVM.PushSavedStateRoot(const AClosure: TGocciaBytecodeClosure;
+  const ANewTarget: TGocciaValue; const AArguments: TGocciaRegisterArray);
+begin
+  if FTempSavedStateRootCount >= Length(FTempSavedStateRoots) then
+    SetLength(FTempSavedStateRoots, FTempSavedStateRootCount * 2 + 4);
+  FTempSavedStateRoots[FTempSavedStateRootCount].Closure := AClosure;
+  FTempSavedStateRoots[FTempSavedStateRootCount].NewTarget := ANewTarget;
+  FTempSavedStateRoots[FTempSavedStateRootCount].Arguments := AArguments;
+  Inc(FTempSavedStateRootCount);
+end;
+
+procedure TGocciaVM.PopSavedStateRoot;
+begin
+  if FTempSavedStateRootCount <= 0 then
+    Exit;
+  Dec(FTempSavedStateRootCount);
+  FTempSavedStateRoots[FTempSavedStateRootCount].Closure := nil;
+  FTempSavedStateRoots[FTempSavedStateRootCount].NewTarget := nil;
+  FTempSavedStateRoots[FTempSavedStateRootCount].Arguments := nil;
+end;
+
 procedure TGocciaVM.SetupNewFrame(const AClosure: TGocciaBytecodeClosure;
   const AThisValue: TGocciaRegister; const AArguments: TGocciaRegisterArray;
   const AArgCount: Integer; const AArg0, AArg1, AArg2: TGocciaRegister;
@@ -7559,6 +7601,7 @@ begin
   SavedHandlerCount := FHandlerStack.Count;
   InitialFrameStackCount := FFrameStackCount;
   FLastClosureThisValue := AThisValue;
+  PushSavedStateRoot(SavedClosure, SavedNewTarget, SavedCurrentArguments);
   try
     SetupNewFrame(AClosure, AThisValue, AArguments, AArgCount,
       AArg0, AArg1, AArg2, AUseFixedArgs,
@@ -10420,26 +10463,30 @@ begin
     end;
     Result := RegisterUndefined;
   finally
-    // Unwind any remaining trampoline frames (exception escape path)
-    while FFrameStackCount > InitialFrameStackCount do
-    begin
-      TeardownCurrentFrame(Template, ProfileEntryTimestamp,
-        FFrameStack[FFrameStackCount - 1].HandlerCount);
-      PopFrame(Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+    try
+      // Unwind any remaining trampoline frames (exception escape path)
+      while FFrameStackCount > InitialFrameStackCount do
+      begin
+        TeardownCurrentFrame(Template, ProfileEntryTimestamp,
+          FFrameStack[FFrameStackCount - 1].HandlerCount);
+        PopFrame(Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+      end;
+      // Teardown the outermost frame
+      TeardownCurrentFrame(Template, ProfileEntryTimestamp, SavedHandlerCount);
+      // Restore the caller's state
+      FCurrentClosure := SavedClosure;
+      FCurrentNewTarget := SavedNewTarget;
+      FCurrentArguments := SavedCurrentArguments;
+      FArgCount := SavedArgCount;
+      FRegisterBase := SavedRegisterBase;
+      FRegisterCount := SavedRegisterCount;
+      FRegisters := @FRegisterStack[FRegisterBase];
+      FLocalCellBase := SavedLocalCellBase;
+      FLocalCellCount := SavedLocalCellCount;
+      FLocalCells := @FLocalCellStack[FLocalCellBase];
+    finally
+      PopSavedStateRoot;
     end;
-    // Teardown the outermost frame
-    TeardownCurrentFrame(Template, ProfileEntryTimestamp, SavedHandlerCount);
-    // Restore the caller's state
-    FCurrentClosure := SavedClosure;
-    FCurrentNewTarget := SavedNewTarget;
-    FCurrentArguments := SavedCurrentArguments;
-    FArgCount := SavedArgCount;
-    FRegisterBase := SavedRegisterBase;
-    FRegisterCount := SavedRegisterCount;
-    FRegisters := @FRegisterStack[FRegisterBase];
-    FLocalCellBase := SavedLocalCellBase;
-    FLocalCellCount := SavedLocalCellCount;
-    FLocalCells := @FLocalCellStack[FLocalCellBase];
   end;
 end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2680,6 +2680,7 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    InitializeTempRoot(PromiseRoot);
     AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
@@ -2747,6 +2748,7 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    InitializeTempRoot(PromiseRoot);
     AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
@@ -2802,6 +2804,7 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    InitializeTempRoot(PromiseRoot);
     AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
@@ -2859,6 +2862,7 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    InitializeTempRoot(PromiseRoot);
     AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
@@ -2918,6 +2922,7 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    InitializeTempRoot(PromiseRoot);
     AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2658,6 +2658,7 @@ function TGocciaBytecodeFunctionValue.Call(
 var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
+  PromiseRoot: TGocciaTempRoot;
 begin
   if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
@@ -2679,18 +2680,23 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
-        Promise.Resolve(FVM.ExecuteClosure(FClosure, EffectiveThis, AArguments));
+        try
+          Promise.Resolve(FVM.ExecuteClosure(FClosure, EffectiveThis, AArguments));
+        except
+          on E: EGocciaBytecodeThrow do
+            Promise.Reject(E.ThrownValue);
+          on E: TGocciaThrowValue do
+            Promise.Reject(E.Value);
+        end;
       except
-        on E: EGocciaBytecodeThrow do
-          Promise.Reject(E.ThrownValue);
-        on E: TGocciaThrowValue do
-          Promise.Reject(E.Value);
+        Promise.Free;
+        raise;
       end;
-    except
-      Promise.Free;
-      raise;
+    finally
+      RemoveTempRootIfNeeded(PromiseRoot);
     end;
     Exit(Promise);
   end;
@@ -2719,6 +2725,7 @@ function TGocciaBytecodeFunctionValue.CallNoArgs(
 var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
+  PromiseRoot: TGocciaTempRoot;
 begin
   if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
@@ -2740,19 +2747,24 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
-        Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters0(FClosure,
-          VMValueToRegisterFast(EffectiveThis))));
+        try
+          Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters0(FClosure,
+            VMValueToRegisterFast(EffectiveThis))));
+        except
+          on E: EGocciaBytecodeThrow do
+            Promise.Reject(E.ThrownValue);
+          on E: TGocciaThrowValue do
+            Promise.Reject(E.Value);
+        end;
       except
-        on E: EGocciaBytecodeThrow do
-          Promise.Reject(E.ThrownValue);
-        on E: TGocciaThrowValue do
-          Promise.Reject(E.Value);
+        Promise.Free;
+        raise;
       end;
-    except
-      Promise.Free;
-      raise;
+    finally
+      RemoveTempRootIfNeeded(PromiseRoot);
     end;
     Exit(Promise);
   end;
@@ -2766,6 +2778,7 @@ function TGocciaBytecodeFunctionValue.CallOneArg(const AArg0,
 var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
+  PromiseRoot: TGocciaTempRoot;
 begin
   if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
@@ -2789,19 +2802,24 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
-        Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters1(FClosure,
-          VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0))));
+        try
+          Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters1(FClosure,
+            VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0))));
+        except
+          on E: EGocciaBytecodeThrow do
+            Promise.Reject(E.ThrownValue);
+          on E: TGocciaThrowValue do
+            Promise.Reject(E.Value);
+        end;
       except
-        on E: EGocciaBytecodeThrow do
-          Promise.Reject(E.ThrownValue);
-        on E: TGocciaThrowValue do
-          Promise.Reject(E.Value);
+        Promise.Free;
+        raise;
       end;
-    except
-      Promise.Free;
-      raise;
+    finally
+      RemoveTempRootIfNeeded(PromiseRoot);
     end;
     Exit(Promise);
   end;
@@ -2815,6 +2833,7 @@ function TGocciaBytecodeFunctionValue.CallTwoArgs(const AArg0, AArg1,
 var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
+  PromiseRoot: TGocciaTempRoot;
 begin
   if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
@@ -2840,20 +2859,25 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
-        Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters2(FClosure,
-          VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0),
-          VMValueToRegisterFast(AArg1))));
+        try
+          Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters2(FClosure,
+            VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0),
+            VMValueToRegisterFast(AArg1))));
+        except
+          on E: EGocciaBytecodeThrow do
+            Promise.Reject(E.ThrownValue);
+          on E: TGocciaThrowValue do
+            Promise.Reject(E.Value);
+        end;
       except
-        on E: EGocciaBytecodeThrow do
-          Promise.Reject(E.ThrownValue);
-        on E: TGocciaThrowValue do
-          Promise.Reject(E.Value);
+        Promise.Free;
+        raise;
       end;
-    except
-      Promise.Free;
-      raise;
+    finally
+      RemoveTempRootIfNeeded(PromiseRoot);
     end;
     Exit(Promise);
   end;
@@ -2868,6 +2892,7 @@ function TGocciaBytecodeFunctionValue.CallThreeArgs(const AArg0, AArg1, AArg2,
 var
   Promise: TGocciaPromiseValue;
   EffectiveThis: TGocciaValue;
+  PromiseRoot: TGocciaTempRoot;
 begin
   if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
      (not Assigned(AThisValue) or
@@ -2893,20 +2918,25 @@ begin
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsAsync then
   begin
     Promise := TGocciaPromiseValue.Create;
+    AddTempRootIfNeeded(PromiseRoot, Promise);
     try
       try
-        Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters3(FClosure,
-          VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0),
-          VMValueToRegisterFast(AArg1), VMValueToRegisterFast(AArg2))));
+        try
+          Promise.Resolve(RegisterToValue(FVM.ExecuteClosureRegisters3(FClosure,
+            VMValueToRegisterFast(EffectiveThis), VMValueToRegisterFast(AArg0),
+            VMValueToRegisterFast(AArg1), VMValueToRegisterFast(AArg2))));
+        except
+          on E: EGocciaBytecodeThrow do
+            Promise.Reject(E.ThrownValue);
+          on E: TGocciaThrowValue do
+            Promise.Reject(E.Value);
+        end;
       except
-        on E: EGocciaBytecodeThrow do
-          Promise.Reject(E.ThrownValue);
-        on E: TGocciaThrowValue do
-          Promise.Reject(E.Value);
+        Promise.Free;
+        raise;
       end;
-    except
-      Promise.Free;
-      raise;
+    finally
+      RemoveTempRootIfNeeded(PromiseRoot);
     end;
     Exit(Promise);
   end;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -234,9 +234,13 @@ var
   ArgRoots: array of TGocciaTempRoot;
   I: Integer;
 begin
+  InitializeTempRoot(CallbackRoot);
+  InitializeTempRoot(ThisRoot);
   AddTempRootIfNeeded(CallbackRoot, ACallback);
   AddTempRootIfNeeded(ThisRoot, AThisArg);
   SetLength(ArgRoots, ACallArgs.Length);
+  for I := 0 to High(ArgRoots) do
+    InitializeTempRoot(ArgRoots[I]);
   for I := 0 to High(ArgRoots) do
     AddTempRootIfNeeded(ArgRoots[I], ACallArgs.GetElement(I));
   PreviousContinuation := SuspendCurrentGeneratorContinuation;
@@ -799,6 +803,10 @@ var
 begin
   ACallArgs.SetElement(0, A);
   ACallArgs.SetElement(1, B);
+  InitializeTempRoot(CompareRoot);
+  InitializeTempRoot(AValueRoot);
+  InitializeTempRoot(BValueRoot);
+  InitializeTempRoot(ThisRoot);
   AddTempRootIfNeeded(CompareRoot, ACompareFunc);
   AddTempRootIfNeeded(AValueRoot, A);
   AddTempRootIfNeeded(BValueRoot, B);
@@ -1144,6 +1152,7 @@ begin
     ResultArray := ArraySpeciesCreate(View.Arr, View.Len)
   else
     ResultArray := TGocciaArrayValue.Create(nil, View.Len);
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ResultRoot, ResultArray);
   try
     TypedCallback := nil;
@@ -1198,6 +1207,7 @@ begin
     ResultArray := ArraySpeciesCreate(View.Arr, 0)
   else
     ResultArray := TGocciaArrayValue.Create;
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ResultRoot, ResultArray);
   try
 
@@ -1758,6 +1768,7 @@ begin
     ResultArray := ArraySpeciesCreate(View.Arr, 0)
   else
     ResultArray := TGocciaArrayValue.Create;
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ResultRoot, ResultArray);
   try
 
@@ -2724,6 +2735,8 @@ begin
 
   // Step 2-3: Let O be ToObject(this value); Let len be LengthOfArrayLike(O).
   View.Init(AThisValue);
+  InitializeTempRoot(ReceiverRoot);
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ReceiverRoot, View.Obj);
   try
     // Step 4: Let A be ArrayCreate(len) — RangeError if len > 2^32-1
@@ -3231,6 +3244,8 @@ begin
     CustomSortFunction := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   View.Init(AThisValue);
+  InitializeTempRoot(ReceiverRoot);
+  InitializeTempRoot(TempRoot);
   AddTempRootIfNeeded(ReceiverRoot, View.Obj);
   try
 

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -230,15 +230,31 @@ function InvokeArrayCallback(const ACallback: TGocciaValue;
   const AThisArg: TGocciaValue): TGocciaValue; inline;
 var
   PreviousContinuation: TGocciaGeneratorContinuation;
+  CallbackRoot, ThisRoot: TGocciaTempRoot;
+  ArgRoots: array of TGocciaTempRoot;
+  I: Integer;
 begin
+  AddTempRootIfNeeded(CallbackRoot, ACallback);
+  AddTempRootIfNeeded(ThisRoot, AThisArg);
+  SetLength(ArgRoots, ACallArgs.Length);
+  for I := 0 to High(ArgRoots) do
+    AddTempRootIfNeeded(ArgRoots[I], ACallArgs.GetElement(I));
   PreviousContinuation := SuspendCurrentGeneratorContinuation;
   try
-    if Assigned(ATypedCallback) then
-      Result := ATypedCallback.Call(ACallArgs, AThisArg)
-    else
-      Result := InvokeCallable(ACallback, ACallArgs, AThisArg);
+    try
+      if Assigned(ATypedCallback) then
+        Result := ATypedCallback.Call(ACallArgs, AThisArg)
+      else
+        Result := InvokeCallable(ACallback, ACallArgs, AThisArg);
+    finally
+      RestoreCurrentGeneratorContinuation(PreviousContinuation);
+    end;
   finally
-    RestoreCurrentGeneratorContinuation(PreviousContinuation);
+    for I := High(ArgRoots) downto 0 do
+      RemoveTempRootIfNeeded(ArgRoots[I]);
+    SetLength(ArgRoots, 0);
+    RemoveTempRootIfNeeded(ThisRoot);
+    RemoveTempRootIfNeeded(CallbackRoot);
   end;
 end;
 
@@ -779,14 +795,26 @@ function CallCompareFunc(const ACompareFunc: TGocciaFunctionBase; const ACallArg
 var
   CompResult: TGocciaNumberLiteralValue;
   PreviousContinuation: TGocciaGeneratorContinuation;
+  CompareRoot, AValueRoot, BValueRoot, ThisRoot: TGocciaTempRoot;
 begin
   ACallArgs.SetElement(0, A);
   ACallArgs.SetElement(1, B);
+  AddTempRootIfNeeded(CompareRoot, ACompareFunc);
+  AddTempRootIfNeeded(AValueRoot, A);
+  AddTempRootIfNeeded(BValueRoot, B);
+  AddTempRootIfNeeded(ThisRoot, AThisValue);
   PreviousContinuation := SuspendCurrentGeneratorContinuation;
   try
-    CompResult := ACompareFunc.Call(ACallArgs, AThisValue).ToNumberLiteral;
+    try
+      CompResult := ACompareFunc.Call(ACallArgs, AThisValue).ToNumberLiteral;
+    finally
+      RestoreCurrentGeneratorContinuation(PreviousContinuation);
+    end;
   finally
-    RestoreCurrentGeneratorContinuation(PreviousContinuation);
+    RemoveTempRootIfNeeded(ThisRoot);
+    RemoveTempRootIfNeeded(BValueRoot);
+    RemoveTempRootIfNeeded(AValueRoot);
+    RemoveTempRootIfNeeded(CompareRoot);
   end;
 
   if CompResult.IsNaN then
@@ -1099,9 +1127,8 @@ var
   TypedCallback: TGocciaFunctionBase;
   ThisArg: TGocciaValue;
   CallArgs: TGocciaArrayCallbackArgs;
-  GC: TGarbageCollector;
   I: Integer;
-  WasResultRooted: Boolean;
+  ResultRoot: TGocciaTempRoot;
 begin
   View.Init(AThisValue);
   Callback := ValidateArrayMethodCall('map', AArgs, AThisValue, True);
@@ -1117,12 +1144,8 @@ begin
     ResultArray := ArraySpeciesCreate(View.Arr, View.Len)
   else
     ResultArray := TGocciaArrayValue.Create(nil, View.Len);
-  GC := TGarbageCollector.Instance;
-  WasResultRooted := Assigned(GC) and GC.IsTempRoot(ResultArray);
-  if Assigned(GC) and not WasResultRooted then
-    GC.AddTempRoot(ResultArray);
+  AddTempRootIfNeeded(ResultRoot, ResultArray);
   try
-
     TypedCallback := nil;
     if Callback is TGocciaFunctionBase then
       TypedCallback := TGocciaFunctionBase(Callback);
@@ -1149,8 +1172,7 @@ begin
 
     Result := ResultArray;
   finally
-    if Assigned(GC) and not WasResultRooted then
-      GC.RemoveTempRoot(ResultArray);
+    RemoveTempRootIfNeeded(ResultRoot);
   end;
 end;
 
@@ -1167,6 +1189,7 @@ var
   I: Integer;
   Sparse: TArray<Int64>;
   K: Int64;
+  ResultRoot: TGocciaTempRoot;
 begin
   View.Init(AThisValue);
   Callback := ValidateArrayMethodCall('filter', AArgs, AThisValue, True);
@@ -1175,47 +1198,52 @@ begin
     ResultArray := ArraySpeciesCreate(View.Arr, 0)
   else
     ResultArray := TGocciaArrayValue.Create;
-
-  TypedCallback := nil;
-  if Callback is TGocciaFunctionBase then
-    TypedCallback := TGocciaFunctionBase(Callback);
-
-  CallArgs := TGocciaArrayCallbackArgs.Create(View.Obj);
+  AddTempRootIfNeeded(ResultRoot, ResultArray);
   try
-    if View.NeedsSparsePath then
-    begin
-      Sparse := CollectSparseIndicesInRange(View.Obj, 0, View.Len64);
-      for K in Sparse do
-      begin
-        Element := View.Get64(K);
-        CallArgs.Element := Element;
-        CallArgs.Index := TGocciaNumberLiteralValue.Create(Int64ToDouble(K));
-        PredicateResult := InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg);
-        if PredicateResult.ToBooleanLiteral.Value then
-          ResultArray.Elements.Add(Element);
-      end;
-    end
-    else
-    begin
-      for I := 0 to View.Len - 1 do
-      begin
-        if not View.HasIndex(I) then
-          Continue;
 
-        Element := View.Get(I);
-        CallArgs.Element := Element;
-        CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
-        PredicateResult := InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg);
+    TypedCallback := nil;
+    if Callback is TGocciaFunctionBase then
+      TypedCallback := TGocciaFunctionBase(Callback);
 
-        if PredicateResult.ToBooleanLiteral.Value then
-          ResultArray.Elements.Add(Element);
+    CallArgs := TGocciaArrayCallbackArgs.Create(View.Obj);
+    try
+      if View.NeedsSparsePath then
+      begin
+        Sparse := CollectSparseIndicesInRange(View.Obj, 0, View.Len64);
+        for K in Sparse do
+        begin
+          Element := View.Get64(K);
+          CallArgs.Element := Element;
+          CallArgs.Index := TGocciaNumberLiteralValue.Create(Int64ToDouble(K));
+          PredicateResult := InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg);
+          if PredicateResult.ToBooleanLiteral.Value then
+            ResultArray.Elements.Add(Element);
+        end;
+      end
+      else
+      begin
+        for I := 0 to View.Len - 1 do
+        begin
+          if not View.HasIndex(I) then
+            Continue;
+
+          Element := View.Get(I);
+          CallArgs.Element := Element;
+          CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
+          PredicateResult := InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg);
+
+          if PredicateResult.ToBooleanLiteral.Value then
+            ResultArray.Elements.Add(Element);
+        end;
       end;
+    finally
+      CallArgs.Free;
     end;
-  finally
-    CallArgs.Free;
-  end;
 
-  Result := ResultArray;
+    Result := ResultArray;
+  finally
+    RemoveTempRootIfNeeded(ResultRoot);
+  end;
 end;
 
 // ES2026 §23.1.3.22 Array.prototype.reduce(callbackfn [, initialValue])
@@ -1721,6 +1749,7 @@ var
   CallArgs: TGocciaArrayCallbackArgs;
   I, J: Integer;
   MappedValue: TGocciaValue;
+  ResultRoot: TGocciaTempRoot;
 begin
   View.Init(AThisValue);
   Callback := ValidateArrayMethodCall('flatMap', AArgs, AThisValue, True);
@@ -1729,40 +1758,45 @@ begin
     ResultArray := ArraySpeciesCreate(View.Arr, 0)
   else
     ResultArray := TGocciaArrayValue.Create;
-
-  TypedCallback := nil;
-  if Callback is TGocciaFunctionBase then
-    TypedCallback := TGocciaFunctionBase(Callback);
-
-  CallArgs := TGocciaArrayCallbackArgs.Create(View.Obj);
+  AddTempRootIfNeeded(ResultRoot, ResultArray);
   try
-    for I := 0 to View.Len - 1 do
-    begin
-      if not View.HasIndex(I) then
-        Continue;
 
-      CallArgs.Element := View.Get(I);
-      CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
-      MappedValue := InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg);
+    TypedCallback := nil;
+    if Callback is TGocciaFunctionBase then
+      TypedCallback := TGocciaFunctionBase(Callback);
 
-      if MappedValue is TGocciaArrayValue then
+    CallArgs := TGocciaArrayCallbackArgs.Create(View.Obj);
+    try
+      for I := 0 to View.Len - 1 do
       begin
-        // Use View-based iteration for prototype-aware access
-        MappedView.Init(MappedValue);
-        for J := 0 to MappedView.Len - 1 do
-        begin
-          if MappedView.HasIndex(J) then
-            ResultArray.Elements.Add(MappedView.Get(J));
-        end;
-      end
-      else
-        ResultArray.Elements.Add(MappedValue);
-    end;
-  finally
-    CallArgs.Free;
-  end;
+        if not View.HasIndex(I) then
+          Continue;
 
-  Result := ResultArray;
+        CallArgs.Element := View.Get(I);
+        CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
+        MappedValue := InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg);
+
+        if MappedValue is TGocciaArrayValue then
+        begin
+          // Use View-based iteration for prototype-aware access
+          MappedView.Init(MappedValue);
+          for J := 0 to MappedView.Len - 1 do
+          begin
+            if MappedView.HasIndex(J) then
+              ResultArray.Elements.Add(MappedView.Get(J));
+          end;
+        end
+        else
+          ResultArray.Elements.Add(MappedValue);
+      end;
+    finally
+      CallArgs.Free;
+    end;
+
+    Result := ResultArray;
+  finally
+    RemoveTempRootIfNeeded(ResultRoot);
+  end;
 end;
 
 // ES2026 §23.1.3.21 Array.prototype.push(...items)
@@ -2673,6 +2707,7 @@ var
   CustomSortFunction: TGocciaValue;
   I: Integer;
   CallArgs: TGocciaArgumentsCollection;
+  ReceiverRoot, ResultRoot: TGocciaTempRoot;
 begin
   // Step 1: If comparefn is not undefined and IsCallable(comparefn) is false,
   // throw a TypeError. Spec §23.1.3.34 step 1 — must run BEFORE LengthOfArrayLike
@@ -2689,27 +2724,36 @@ begin
 
   // Step 2-3: Let O be ToObject(this value); Let len be LengthOfArrayLike(O).
   View.Init(AThisValue);
-  // Step 4: Let A be ArrayCreate(len) — RangeError if len > 2^32-1
-  View.CheckArrayCreateLen;
-  ResultArray := TGocciaArrayValue.Create;
-
-  // Step 5: Copy elements from O into A
-  for I := 0 to View.Len - 1 do
-    ResultArray.Elements.Add(View.Get(I));
-
-  if not (CustomSortFunction is TGocciaUndefinedLiteralValue) then
-  begin
-    CallArgs := TGocciaArgumentsCollection.Create([nil, nil]);
+  AddTempRootIfNeeded(ReceiverRoot, View.Obj);
+  try
+    // Step 4: Let A be ArrayCreate(len) — RangeError if len > 2^32-1
+    View.CheckArrayCreateLen;
+    ResultArray := TGocciaArrayValue.Create;
+    AddTempRootIfNeeded(ResultRoot, ResultArray);
     try
-      QuickSortElements(ResultArray.Elements, TGocciaFunctionBase(CustomSortFunction), CallArgs, AThisValue, 0, ResultArray.Elements.Count - 1);
-    finally
-      CallArgs.Free;
-    end;
-  end else
-    ResultArray.Elements.Sort(TComparer<TGocciaValue>.Construct(DefaultCompare));
+      // Step 5: Copy elements from O into A
+      for I := 0 to View.Len - 1 do
+        ResultArray.Elements.Add(View.Get(I));
 
-  // Step 7: Return A
-  Result := ResultArray;
+      if not (CustomSortFunction is TGocciaUndefinedLiteralValue) then
+      begin
+        CallArgs := TGocciaArgumentsCollection.Create([nil, nil]);
+        try
+          QuickSortElements(ResultArray.Elements, TGocciaFunctionBase(CustomSortFunction), CallArgs, AThisValue, 0, ResultArray.Elements.Count - 1);
+        finally
+          CallArgs.Free;
+        end;
+      end else
+        ResultArray.Elements.Sort(TComparer<TGocciaValue>.Construct(DefaultCompare));
+
+      // Step 7: Return A
+      Result := ResultArray;
+    finally
+      RemoveTempRootIfNeeded(ResultRoot);
+    end;
+  finally
+    RemoveTempRootIfNeeded(ReceiverRoot);
+  end;
 end;
 
 // ES2026 §23.1.3.35 Array.prototype.toSpliced(start, skipCount, ...items)
@@ -3172,6 +3216,7 @@ var
   CustomSortFunction: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
+  ReceiverRoot, TempRoot: TGocciaTempRoot;
 begin
   // Step 1: If comparefn is not undefined and IsCallable(comparefn) is false,
   // throw a TypeError. Per spec §23.1.3.29 this runs BEFORE LengthOfArrayLike.
@@ -3186,33 +3231,43 @@ begin
     CustomSortFunction := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   View.Init(AThisValue);
+  AddTempRootIfNeeded(ReceiverRoot, View.Obj);
+  try
 
-  // Collect only present elements via View for prototype-aware access
-  TempArr := TGocciaArrayValue.Create;
-  for I := 0 to View.Len - 1 do
-  begin
-    if View.HasIndex(I) then
-      TempArr.Elements.Add(View.Get(I));
-  end;
-
-  if not (CustomSortFunction is TGocciaUndefinedLiteralValue) then
-  begin
-    CallArgs := TGocciaArgumentsCollection.Create([nil, nil]);
+    // Collect only present elements via View for prototype-aware access
+    TempArr := TGocciaArrayValue.Create;
+    AddTempRootIfNeeded(TempRoot, TempArr);
     try
-      if TempArr.Elements.Count > 1 then
-        QuickSortElements(TempArr.Elements, TGocciaFunctionBase(CustomSortFunction), CallArgs, AThisValue, 0, TempArr.Elements.Count - 1);
-    finally
-      CallArgs.Free;
-    end;
-  end else if TempArr.Elements.Count > 1 then
-    TempArr.Elements.Sort(TComparer<TGocciaValue>.Construct(DefaultCompare));
+      for I := 0 to View.Len - 1 do
+      begin
+        if View.HasIndex(I) then
+          TempArr.Elements.Add(View.Get(I));
+      end;
 
-  // Write sorted elements back to front indices
-  for I := 0 to TempArr.Elements.Count - 1 do
-    View.Put(I, TempArr.Elements[I]);
-  // Delete trailing indices (holes moved to end)
-  for I := TempArr.Elements.Count to View.Len - 1 do
-    View.DeleteIndex(I);
+      if not (CustomSortFunction is TGocciaUndefinedLiteralValue) then
+      begin
+        CallArgs := TGocciaArgumentsCollection.Create([nil, nil]);
+        try
+          if TempArr.Elements.Count > 1 then
+            QuickSortElements(TempArr.Elements, TGocciaFunctionBase(CustomSortFunction), CallArgs, AThisValue, 0, TempArr.Elements.Count - 1);
+        finally
+          CallArgs.Free;
+        end;
+      end else if TempArr.Elements.Count > 1 then
+        TempArr.Elements.Sort(TComparer<TGocciaValue>.Construct(DefaultCompare));
+
+      // Write sorted elements back to front indices
+      for I := 0 to TempArr.Elements.Count - 1 do
+        View.Put(I, TempArr.Elements[I]);
+      // Delete trailing indices (holes moved to end)
+      for I := TempArr.Elements.Count to View.Len - 1 do
+        View.DeleteIndex(I);
+    finally
+      RemoveTempRootIfNeeded(TempRoot);
+    end;
+  finally
+    RemoveTempRootIfNeeded(ReceiverRoot);
+  end;
 
   Result := View.Obj;
 end;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -1759,7 +1759,7 @@ var
   CallArgs: TGocciaArrayCallbackArgs;
   I, J: Integer;
   MappedValue: TGocciaValue;
-  ResultRoot: TGocciaTempRoot;
+  ResultRoot, MappedValueRoot: TGocciaTempRoot;
 begin
   View.Init(AThisValue);
   Callback := ValidateArrayMethodCall('flatMap', AArgs, AThisValue, True);
@@ -1769,6 +1769,7 @@ begin
   else
     ResultArray := TGocciaArrayValue.Create;
   InitializeTempRoot(ResultRoot);
+  InitializeTempRoot(MappedValueRoot);
   AddTempRootIfNeeded(ResultRoot, ResultArray);
   try
 
@@ -1786,19 +1787,23 @@ begin
         CallArgs.Element := View.Get(I);
         CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
         MappedValue := InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg);
-
-        if MappedValue is TGocciaArrayValue then
-        begin
-          // Use View-based iteration for prototype-aware access
-          MappedView.Init(MappedValue);
-          for J := 0 to MappedView.Len - 1 do
+        AddTempRootIfNeeded(MappedValueRoot, MappedValue);
+        try
+          if MappedValue is TGocciaArrayValue then
           begin
-            if MappedView.HasIndex(J) then
-              ResultArray.Elements.Add(MappedView.Get(J));
-          end;
-        end
-        else
-          ResultArray.Elements.Add(MappedValue);
+            // Use View-based iteration for prototype-aware access
+            MappedView.Init(MappedValue);
+            for J := 0 to MappedView.Len - 1 do
+            begin
+              if MappedView.HasIndex(J) then
+                ResultArray.Elements.Add(MappedView.Get(J));
+            end;
+          end
+          else
+            ResultArray.Elements.Add(MappedValue);
+        finally
+          RemoveTempRootIfNeeded(MappedValueRoot);
+        end;
       end;
     finally
       CallArgs.Free;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -1099,7 +1099,9 @@ var
   TypedCallback: TGocciaFunctionBase;
   ThisArg: TGocciaValue;
   CallArgs: TGocciaArrayCallbackArgs;
+  GC: TGarbageCollector;
   I: Integer;
+  WasResultRooted: Boolean;
 begin
   View.Init(AThisValue);
   Callback := ValidateArrayMethodCall('map', AArgs, AThisValue, True);
@@ -1115,32 +1117,41 @@ begin
     ResultArray := ArraySpeciesCreate(View.Arr, View.Len)
   else
     ResultArray := TGocciaArrayValue.Create(nil, View.Len);
-
-  TypedCallback := nil;
-  if Callback is TGocciaFunctionBase then
-    TypedCallback := TGocciaFunctionBase(Callback);
-
-  CallArgs := TGocciaArrayCallbackArgs.Create(View.Obj);
+  GC := TGarbageCollector.Instance;
+  WasResultRooted := Assigned(GC) and GC.IsTempRoot(ResultArray);
+  if Assigned(GC) and not WasResultRooted then
+    GC.AddTempRoot(ResultArray);
   try
-    for I := 0 to View.Len - 1 do
-    begin
-      if not View.HasIndex(I) then
-        Continue;
 
-      CallArgs.Element := View.Get(I);
-      CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
-      ArrayCreateDataProperty(ResultArray, I,
-        InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg));
+    TypedCallback := nil;
+    if Callback is TGocciaFunctionBase then
+      TypedCallback := TGocciaFunctionBase(Callback);
+
+    CallArgs := TGocciaArrayCallbackArgs.Create(View.Obj);
+    try
+      for I := 0 to View.Len - 1 do
+      begin
+        if not View.HasIndex(I) then
+          Continue;
+
+        CallArgs.Element := View.Get(I);
+        CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
+        ArrayCreateDataProperty(ResultArray, I,
+          InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg));
+      end;
+    finally
+      CallArgs.Free;
     end;
+
+    // Ensure result has correct length (preserve trailing holes)
+    while ResultArray.Elements.Count < View.Len do
+      ResultArray.Elements.Add(TGocciaHoleValue.HoleValue);
+
+    Result := ResultArray;
   finally
-    CallArgs.Free;
+    if Assigned(GC) and not WasResultRooted then
+      GC.RemoveTempRoot(ResultArray);
   end;
-
-  // Ensure result has correct length (preserve trailing holes)
-  while ResultArray.Elements.Count < View.Len do
-    ResultArray.Elements.Add(TGocciaHoleValue.HoleValue);
-
-  Result := ResultArray;
 end;
 
 // ES2026 §23.1.3.8 Array.prototype.filter(callbackfn [, thisArg])

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -1787,8 +1787,8 @@ begin
         CallArgs.Element := View.Get(I);
         CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
         MappedValue := InvokeArrayCallback(Callback, TypedCallback, CallArgs, ThisArg);
-        AddTempRootIfNeeded(MappedValueRoot, MappedValue);
         try
+          AddTempRootIfNeeded(MappedValueRoot, MappedValue);
           if MappedValue is TGocciaArrayValue then
           begin
             // Use View-based iteration for prototype-aware access

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -76,6 +76,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -134,7 +135,7 @@ var
 begin
   CallArgs := TGocciaArgumentsCollection.Create([AValue, TGocciaNumberLiteralValue.Create(AIndex)]);
   try
-    Result := TGocciaFunctionBase(ACallback).Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+    Result := InvokeCallable(ACallback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
   finally
     CallArgs.Free;
   end;
@@ -469,7 +470,8 @@ begin
         begin
           CallArgs := TGocciaArgumentsCollection.Create([Accumulator, Value, TGocciaNumberLiteralValue.Create(Index)]);
           try
-            NewAccumulator := TGocciaFunctionBase(Callback).Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+            NewAccumulator := InvokeCallable(Callback, CallArgs,
+              TGocciaUndefinedLiteralValue.UndefinedValue);
           finally
             CallArgs.Free;
           end;

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -418,6 +418,9 @@ begin
   if Callback is TGocciaFunctionBase then
     TypedCallback := TGocciaFunctionBase(Callback);
 
+  InitializeTempRoot(MapRoot);
+  InitializeTempRoot(CallbackRoot);
+  InitializeTempRoot(ThisRoot);
   AddTempRootIfNeeded(MapRoot, M);
   AddTempRootIfNeeded(CallbackRoot, Callback);
   AddTempRootIfNeeded(ThisRoot, ThisArg);
@@ -562,6 +565,9 @@ begin
   if Index >= 0 then
     Exit(M.Entries[Index].Value);
 
+  InitializeTempRoot(MapRoot);
+  InitializeTempRoot(KeyRoot);
+  InitializeTempRoot(CallbackRoot);
   AddTempRootIfNeeded(MapRoot, M);
   AddTempRootIfNeeded(KeyRoot, MapKey);
   AddTempRootIfNeeded(CallbackRoot, CallbackArg);

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -393,6 +393,7 @@ var
   TypedCallback: TGocciaFunctionBase;
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
+  MapRoot, CallbackRoot, ThisRoot: TGocciaTempRoot;
 begin
   // Steps 1-3: If M does not have a [[MapData]] internal slot, throw a TypeError
   if not (AThisValue is TGocciaMapValue) then
@@ -417,23 +418,32 @@ begin
   if Callback is TGocciaFunctionBase then
     TypedCallback := TGocciaFunctionBase(Callback);
 
+  AddTempRootIfNeeded(MapRoot, M);
+  AddTempRootIfNeeded(CallbackRoot, Callback);
+  AddTempRootIfNeeded(ThisRoot, ThisArg);
+  try
   // Step 6: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
-  for I := 0 to M.Entries.Count - 1 do
-  begin
-    // Step 6b: Call(callbackfn, thisArg, « p.[[Value]], p.[[Key]], M »)
-    CallArgs := TGocciaArgumentsCollection.Create([M.Entries[I].Value, M.Entries[I].Key, M]);
-    try
-      if Assigned(TypedCallback) then
-        TypedCallback.Call(CallArgs, ThisArg)
-      else
-        InvokeCallable(Callback, CallArgs, ThisArg);
-    finally
-      CallArgs.Free;
+    for I := 0 to M.Entries.Count - 1 do
+    begin
+      // Step 6b: Call(callbackfn, thisArg, « p.[[Value]], p.[[Key]], M »)
+      CallArgs := TGocciaArgumentsCollection.Create([M.Entries[I].Value, M.Entries[I].Key, M]);
+      try
+        if Assigned(TypedCallback) then
+          TypedCallback.Call(CallArgs, ThisArg)
+        else
+          InvokeCallable(Callback, CallArgs, ThisArg);
+      finally
+        CallArgs.Free;
+      end;
     end;
-  end;
 
-  // Step 7: Return undefined
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    // Step 7: Return undefined
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  finally
+    RemoveTempRootIfNeeded(ThisRoot);
+    RemoveTempRootIfNeeded(CallbackRoot);
+    RemoveTempRootIfNeeded(MapRoot);
+  end;
 end;
 
 // ES2026 §24.1.3.8 Map.prototype.keys()
@@ -527,6 +537,7 @@ var
   TypedCallback: TGocciaFunctionBase;
   CallArgs: TGocciaArgumentsCollection;
   Index: Integer;
+  MapRoot, KeyRoot, CallbackRoot: TGocciaTempRoot;
 begin
   // Steps 1-3: If M does not have a [[MapData]] internal slot, throw a TypeError
   if not (AThisValue is TGocciaMapValue) then
@@ -551,20 +562,29 @@ begin
   if Index >= 0 then
     Exit(M.Entries[Index].Value);
 
-  // Step 5: Let value be ? Call(callbackfn, undefined, « key »)
-  TypedCallback := TGocciaFunctionBase(CallbackArg);
-  CallArgs := TGocciaArgumentsCollection.Create([MapKey]);
+  AddTempRootIfNeeded(MapRoot, M);
+  AddTempRootIfNeeded(KeyRoot, MapKey);
+  AddTempRootIfNeeded(CallbackRoot, CallbackArg);
   try
-    ComputedValue := TypedCallback.Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
-  finally
-    CallArgs.Free;
-  end;
+    // Step 5: Let value be ? Call(callbackfn, undefined, « key »)
+    TypedCallback := TGocciaFunctionBase(CallbackArg);
+    CallArgs := TGocciaArgumentsCollection.Create([MapKey]);
+    try
+      ComputedValue := TypedCallback.Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+    finally
+      CallArgs.Free;
+    end;
 
-  // Step 6: Set key to CanonicalizeKeyedCollectionKey(key)
-  // Step 7: Append Record { [[Key]]: key, [[Value]]: value } to M.[[MapData]]
-  M.SetEntry(MapKey, ComputedValue);
-  // Step 8: Return value
-  Result := ComputedValue;
+    // Step 6: Set key to CanonicalizeKeyedCollectionKey(key)
+    // Step 7: Append Record { [[Key]]: key, [[Value]]: value } to M.[[MapData]]
+    M.SetEntry(MapKey, ComputedValue);
+    // Step 8: Return value
+    Result := ComputedValue;
+  finally
+    RemoveTempRootIfNeeded(CallbackRoot);
+    RemoveTempRootIfNeeded(KeyRoot);
+    RemoveTempRootIfNeeded(MapRoot);
+  end;
 end;
 
 initialization

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -459,6 +459,9 @@ begin
   if Callback is TGocciaFunctionBase then
     TypedCallback := TGocciaFunctionBase(Callback);
 
+  InitializeTempRoot(SetRoot);
+  InitializeTempRoot(CallbackRoot);
+  InitializeTempRoot(ThisRoot);
   AddTempRootIfNeeded(SetRoot, S);
   AddTempRootIfNeeded(CallbackRoot, Callback);
   AddTempRootIfNeeded(ThisRoot, ThisArg);

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -434,6 +434,7 @@ var
   TypedCallback: TGocciaFunctionBase;
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
+  SetRoot, CallbackRoot, ThisRoot: TGocciaTempRoot;
 begin
   // Steps 1-3: If S does not have a [[SetData]] internal slot, throw a TypeError
   if not (AThisValue is TGocciaSetValue) then
@@ -458,23 +459,32 @@ begin
   if Callback is TGocciaFunctionBase then
     TypedCallback := TGocciaFunctionBase(Callback);
 
+  AddTempRootIfNeeded(SetRoot, S);
+  AddTempRootIfNeeded(CallbackRoot, Callback);
+  AddTempRootIfNeeded(ThisRoot, ThisArg);
+  try
   // Step 6: For each element e of S.[[SetData]], do
-  for I := 0 to S.FItems.Count - 1 do
-  begin
-    // Step 6b: Call(callbackfn, thisArg, « e, e, S »)
-    CallArgs := TGocciaArgumentsCollection.Create([S.FItems[I], S.FItems[I], S]);
-    try
-      if Assigned(TypedCallback) then
-        TypedCallback.Call(CallArgs, ThisArg)
-      else
-        InvokeCallable(Callback, CallArgs, ThisArg);
-    finally
-      CallArgs.Free;
+    for I := 0 to S.FItems.Count - 1 do
+    begin
+      // Step 6b: Call(callbackfn, thisArg, « e, e, S »)
+      CallArgs := TGocciaArgumentsCollection.Create([S.FItems[I], S.FItems[I], S]);
+      try
+        if Assigned(TypedCallback) then
+          TypedCallback.Call(CallArgs, ThisArg)
+        else
+          InvokeCallable(Callback, CallArgs, ThisArg);
+      finally
+        CallArgs.Free;
+      end;
     end;
-  end;
 
-  // Step 7: Return undefined
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    // Step 7: Return undefined
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  finally
+    RemoveTempRootIfNeeded(ThisRoot);
+    RemoveTempRootIfNeeded(CallbackRoot);
+    RemoveTempRootIfNeeded(SetRoot);
+  end;
 end;
 
 // ES2026 §24.2.3.10 Set.prototype.values()

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -161,6 +161,7 @@ uses
   Goccia.Float16,
   Goccia.GarbageCollector,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
@@ -1144,7 +1145,13 @@ end;
 function InvokeCallback(const ACallback: TGocciaValue; const AElement, AIndex, AArray, AThisArg: TGocciaValue): TGocciaValue;
 var
   Args: TGocciaArgumentsCollection;
+  CallbackRoot, ElementRoot, IndexRoot, ArrayRoot, ThisRoot: TGocciaTempRoot;
 begin
+  AddTempRootIfNeeded(CallbackRoot, ACallback);
+  AddTempRootIfNeeded(ElementRoot, AElement);
+  AddTempRootIfNeeded(IndexRoot, AIndex);
+  AddTempRootIfNeeded(ArrayRoot, AArray);
+  AddTempRootIfNeeded(ThisRoot, AThisArg);
   Args := TGocciaArgumentsCollection.Create;
   try
     Args.Add(AElement);
@@ -1153,6 +1160,11 @@ begin
     Result := TGocciaFunctionBase(ACallback).Call(Args, AThisArg);
   finally
     Args.Free;
+    RemoveTempRootIfNeeded(ThisRoot);
+    RemoveTempRootIfNeeded(ArrayRoot);
+    RemoveTempRootIfNeeded(IndexRoot);
+    RemoveTempRootIfNeeded(ElementRoot);
+    RemoveTempRootIfNeeded(CallbackRoot);
   end;
 end;
 
@@ -1512,6 +1524,7 @@ var
   ZeroJ: Double;
   ZeroJBits: Int64 absolute ZeroJ;
   TmpZeroBits: Int64 absolute Tmp;
+  ArrayRoot: TGocciaTempRoot;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.sort');
   HasCompare := (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable;
@@ -1540,7 +1553,13 @@ begin
               CompareArgs.Add(TGocciaBigIntValue.Create(TBigInteger.FromInt64(TA.ReadBigIntElement(J))));
               CompareArgs.Add(TGocciaBigIntValue.Create(TBigInteger.FromInt64(TmpBig)));
             end;
-            CompareResult := TGocciaFunctionBase(AArgs.GetElement(0)).Call(CompareArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+            AddTempRootIfNeeded(ArrayRoot, TA);
+            try
+              CompareResult := InvokeCallable(AArgs.GetElement(0), CompareArgs,
+                TGocciaUndefinedLiteralValue.UndefinedValue);
+            finally
+              RemoveTempRootIfNeeded(ArrayRoot);
+            end;
             CompResult := CompareResult.ToNumberLiteral.Value;
           finally
             CompareArgs.Free;
@@ -1617,7 +1636,13 @@ begin
         try
           CompareArgs.Add(TGocciaNumberLiteralValue.Create(TA.ReadElement(J)));
           CompareArgs.Add(TGocciaNumberLiteralValue.Create(Tmp));
-          CompareResult := TGocciaFunctionBase(AArgs.GetElement(0)).Call(CompareArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+          AddTempRootIfNeeded(ArrayRoot, TA);
+          try
+            CompareResult := InvokeCallable(AArgs.GetElement(0), CompareArgs,
+              TGocciaUndefinedLiteralValue.UndefinedValue);
+          finally
+            RemoveTempRootIfNeeded(ArrayRoot);
+          end;
           CompResult := CompareResult.ToNumberLiteral.Value;
         finally
           CompareArgs.Free;
@@ -1918,6 +1943,7 @@ var
   TA, NewTA: TGocciaTypedArrayValue;
   I: Integer;
   CallResult, ThisArg: TGocciaValue;
+  ResultRoot: TGocciaTempRoot;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.map');
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
@@ -1927,14 +1953,19 @@ begin
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
   NewTA := CreateSameKindArray(TA, TA.FLength);
-  for I := 0 to TA.FLength - 1 do
-  begin
-    CallResult := InvokeCallback(AArgs.GetElement(0),
-      TA.GetElementAsValue(I),
-      TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
-    NewTA.WriteValueToElement(I, CallResult);
+  AddTempRootIfNeeded(ResultRoot, NewTA);
+  try
+    for I := 0 to TA.FLength - 1 do
+    begin
+      CallResult := InvokeCallback(AArgs.GetElement(0),
+        TA.GetElementAsValue(I),
+        TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
+      NewTA.WriteValueToElement(I, CallResult);
+    end;
+    Result := NewTA;
+  finally
+    RemoveTempRootIfNeeded(ResultRoot);
   end;
-  Result := NewTA;
 end;
 
 // ES2026 §23.2.3.9 %TypedArray%.prototype.filter(callbackfn [, thisArg])
@@ -2012,7 +2043,8 @@ begin
       CallArgs.Add(TA.GetElementAsValue(I));
       CallArgs.Add(TGocciaNumberLiteralValue.Create(I));
       CallArgs.Add(AThisValue);
-      Accumulator := TGocciaFunctionBase(AArgs.GetElement(0)).Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+      Accumulator := InvokeCallable(AArgs.GetElement(0), CallArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue);
     finally
       CallArgs.Free;
     end;
@@ -2054,7 +2086,8 @@ begin
       CallArgs.Add(TA.GetElementAsValue(I));
       CallArgs.Add(TGocciaNumberLiteralValue.Create(I));
       CallArgs.Add(AThisValue);
-      Accumulator := TGocciaFunctionBase(AArgs.GetElement(0)).Call(CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+      Accumulator := InvokeCallable(AArgs.GetElement(0), CallArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue);
     finally
       CallArgs.Free;
     end;
@@ -2465,7 +2498,6 @@ var
   SrcTA: TGocciaTypedArrayValue;
   NewTA: TGocciaTypedArrayValue;
   HasMapFn: Boolean;
-  MapFn: TGocciaFunctionBase;
   MapFnArg: TGocciaValue;
   ThisArg: TGocciaValue;
   I, Len: Integer;
@@ -2475,138 +2507,162 @@ var
   IterResult: TGocciaObjectValue;
   Values: TGocciaValueList;
   SrcObj: TGocciaObjectValue;
+  SourceRoot, ResultRoot: TGocciaTempRoot;
 begin
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorTypedArrayFromRequiresArg, SSuggestTypedArraySetSource);
   Source := AArgs.GetElement(0);
   HasMapFn := False;
-  MapFn := nil;
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
   begin
     MapFnArg := AArgs.GetElement(1);
     if not MapFnArg.IsCallable then
       ThrowTypeError(SErrorTypedArrayFromMapFn, SSuggestTypedArrayCallable);
     HasMapFn := True;
-    MapFn := TGocciaFunctionBase(MapFnArg);
   end;
   if AArgs.Length > 2 then
     ThisArg := AArgs.GetElement(2)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  // ES2026 §23.2.2.1 step 5: GetMethod(source, @@iterator) before type fast paths
-  Iterator := GetIteratorFromValue(Source);
-  if Assigned(Iterator) then
-  begin
-    Values := TGocciaValueList.Create(False);
-    try
-      TGarbageCollector.Instance.AddTempRoot(Iterator);
+  AddTempRootIfNeeded(SourceRoot, Source);
+  try
+    // ES2026 §23.2.2.1 step 5: GetMethod(source, @@iterator) before type fast paths
+    Iterator := GetIteratorFromValue(Source);
+    if Assigned(Iterator) then
+    begin
+      Values := TGocciaValueList.Create(False);
       try
+        TGarbageCollector.Instance.AddTempRoot(Iterator);
         try
-          IterResult := Iterator.AdvanceNext;
-          while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
-          begin
-            Values.Add(IterResult.GetProperty(PROP_VALUE));
+          try
             IterResult := Iterator.AdvanceNext;
+            while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
+            begin
+              Values.Add(IterResult.GetProperty(PROP_VALUE));
+              IterResult := Iterator.AdvanceNext;
+            end;
+          except
+            AcquireExceptionObject;
+            CloseIteratorPreservingError(Iterator);
+            raise;
           end;
-        except
-          AcquireExceptionObject;
-          CloseIteratorPreservingError(Iterator);
-          raise;
+        finally
+          TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+        end;
+        NewTA := TGocciaTypedArrayValue.Create(FKind, Values.Count);
+        AddTempRootIfNeeded(ResultRoot, NewTA);
+        try
+          for I := 0 to Values.Count - 1 do
+          begin
+            Val := Values[I];
+            if HasMapFn then
+            begin
+              MapArgs := TGocciaArgumentsCollection.Create;
+              try
+                MapArgs.Add(Val);
+                MapArgs.Add(TGocciaNumberLiteralValue.Create(I));
+                Val := InvokeCallable(MapFnArg, MapArgs, ThisArg);
+              finally
+                MapArgs.Free;
+              end;
+            end;
+            NewTA.WriteValueToElement(I, Val);
+          end;
+        finally
+          RemoveTempRootIfNeeded(ResultRoot);
         end;
       finally
-        TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+        Values.Free;
       end;
-      NewTA := TGocciaTypedArrayValue.Create(FKind, Values.Count);
-      for I := 0 to Values.Count - 1 do
+      Exit(NewTA);
+    end;
+
+    if Source is TGocciaTypedArrayValue then
+    begin
+      SrcTA := TGocciaTypedArrayValue(Source);
+      NewTA := TGocciaTypedArrayValue.Create(FKind, SrcTA.Length);
+      AddTempRootIfNeeded(ResultRoot, NewTA);
+      try
+        for I := 0 to SrcTA.Length - 1 do
+        begin
+          Val := SrcTA.GetElementAsValue(I);
+          if HasMapFn then
+          begin
+            MapArgs := TGocciaArgumentsCollection.Create;
+            try
+              MapArgs.Add(Val);
+              MapArgs.Add(TGocciaNumberLiteralValue.Create(I));
+              Val := InvokeCallable(MapFnArg, MapArgs, ThisArg);
+            finally
+              MapArgs.Free;
+            end;
+          end;
+          NewTA.WriteValueToElement(I, Val);
+        end;
+      finally
+        RemoveTempRootIfNeeded(ResultRoot);
+      end;
+      Exit(NewTA);
+    end;
+
+    if Source is TGocciaArrayValue then
+    begin
+      SrcArr := TGocciaArrayValue(Source);
+      NewTA := TGocciaTypedArrayValue.Create(FKind, SrcArr.Elements.Count);
+      AddTempRootIfNeeded(ResultRoot, NewTA);
+      try
+        for I := 0 to SrcArr.Elements.Count - 1 do
+        begin
+          Val := SrcArr.Elements[I];
+          if HasMapFn then
+          begin
+            MapArgs := TGocciaArgumentsCollection.Create;
+            try
+              MapArgs.Add(Val);
+              MapArgs.Add(TGocciaNumberLiteralValue.Create(I));
+              Val := InvokeCallable(MapFnArg, MapArgs, ThisArg);
+            finally
+              MapArgs.Free;
+            end;
+          end;
+          NewTA.WriteValueToElement(I, Val);
+        end;
+      finally
+        RemoveTempRootIfNeeded(ResultRoot);
+      end;
+      Exit(NewTA);
+    end;
+
+    // Step 7: array-like path — ToObject(source), LengthOfArrayLike, indexed Get
+    SrcObj := ToObject(Source);
+    Len := LengthOfArrayLike(SrcObj);
+    NewTA := TGocciaTypedArrayValue.Create(FKind, Len);
+    AddTempRootIfNeeded(ResultRoot, NewTA);
+    try
+      for I := 0 to Len - 1 do
       begin
-        Val := Values[I];
+        Val := SrcObj.GetProperty(IntToStr(I));
         if HasMapFn then
         begin
           MapArgs := TGocciaArgumentsCollection.Create;
           try
             MapArgs.Add(Val);
             MapArgs.Add(TGocciaNumberLiteralValue.Create(I));
-            Val := MapFn.Call(MapArgs, ThisArg);
+            Val := InvokeCallable(MapFnArg, MapArgs, ThisArg);
           finally
             MapArgs.Free;
           end;
         end;
         NewTA.WriteValueToElement(I, Val);
       end;
+      Result := NewTA;
     finally
-      Values.Free;
+      RemoveTempRootIfNeeded(ResultRoot);
     end;
-    Exit(NewTA);
+  finally
+    RemoveTempRootIfNeeded(SourceRoot);
   end;
-
-  if Source is TGocciaTypedArrayValue then
-  begin
-    SrcTA := TGocciaTypedArrayValue(Source);
-    NewTA := TGocciaTypedArrayValue.Create(FKind, SrcTA.Length);
-    for I := 0 to SrcTA.Length - 1 do
-    begin
-      Val := SrcTA.GetElementAsValue(I);
-      if HasMapFn then
-      begin
-        MapArgs := TGocciaArgumentsCollection.Create;
-        try
-          MapArgs.Add(Val);
-          MapArgs.Add(TGocciaNumberLiteralValue.Create(I));
-          Val := MapFn.Call(MapArgs, ThisArg);
-        finally
-          MapArgs.Free;
-        end;
-      end;
-      NewTA.WriteValueToElement(I, Val);
-    end;
-    Exit(NewTA);
-  end;
-
-  if Source is TGocciaArrayValue then
-  begin
-    SrcArr := TGocciaArrayValue(Source);
-    NewTA := TGocciaTypedArrayValue.Create(FKind, SrcArr.Elements.Count);
-    for I := 0 to SrcArr.Elements.Count - 1 do
-    begin
-      Val := SrcArr.Elements[I];
-      if HasMapFn then
-      begin
-        MapArgs := TGocciaArgumentsCollection.Create;
-        try
-          MapArgs.Add(Val);
-          MapArgs.Add(TGocciaNumberLiteralValue.Create(I));
-          Val := MapFn.Call(MapArgs, ThisArg);
-        finally
-          MapArgs.Free;
-        end;
-      end;
-      NewTA.WriteValueToElement(I, Val);
-    end;
-    Exit(NewTA);
-  end;
-
-  // Step 7: array-like path — ToObject(source), LengthOfArrayLike, indexed Get
-  SrcObj := ToObject(Source);
-  Len := LengthOfArrayLike(SrcObj);
-  NewTA := TGocciaTypedArrayValue.Create(FKind, Len);
-  for I := 0 to Len - 1 do
-  begin
-    Val := SrcObj.GetProperty(IntToStr(I));
-    if HasMapFn then
-    begin
-      MapArgs := TGocciaArgumentsCollection.Create;
-      try
-        MapArgs.Add(Val);
-        MapArgs.Add(TGocciaNumberLiteralValue.Create(I));
-        Val := MapFn.Call(MapArgs, ThisArg);
-      finally
-        MapArgs.Free;
-      end;
-    end;
-    NewTA.WriteValueToElement(I, Val);
-  end;
-  Result := NewTA;
 end;
 
 // ES2026 §23.2.2.2 %TypedArray%.of(...items)

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -1147,6 +1147,11 @@ var
   Args: TGocciaArgumentsCollection;
   CallbackRoot, ElementRoot, IndexRoot, ArrayRoot, ThisRoot: TGocciaTempRoot;
 begin
+  InitializeTempRoot(CallbackRoot);
+  InitializeTempRoot(ElementRoot);
+  InitializeTempRoot(IndexRoot);
+  InitializeTempRoot(ArrayRoot);
+  InitializeTempRoot(ThisRoot);
   AddTempRootIfNeeded(CallbackRoot, ACallback);
   AddTempRootIfNeeded(ElementRoot, AElement);
   AddTempRootIfNeeded(IndexRoot, AIndex);
@@ -1529,6 +1534,7 @@ begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.sort');
   HasCompare := (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable;
   SortLen := TA.FLength;
+  InitializeTempRoot(ArrayRoot);
 
   // BigInt sort path
   if IsBigIntKind(TA.FKind) then
@@ -1953,6 +1959,7 @@ begin
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
   NewTA := CreateSameKindArray(TA, TA.FLength);
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ResultRoot, NewTA);
   try
     for I := 0 to TA.FLength - 1 do
@@ -2527,10 +2534,10 @@ begin
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  MapFnRoot.ObjectValue := nil;
-  MapFnRoot.Added := False;
-  ThisRoot.ObjectValue := nil;
-  ThisRoot.Added := False;
+  InitializeTempRoot(SourceRoot);
+  InitializeTempRoot(MapFnRoot);
+  InitializeTempRoot(ThisRoot);
+  InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(SourceRoot, Source);
   if HasMapFn then
   begin
@@ -2555,6 +2562,7 @@ begin
               Values.Add(Val);
               if ValueRootCount >= Length(ValueRoots) then
                 SetLength(ValueRoots, ValueRootCount * 2 + 4);
+              InitializeTempRoot(ValueRoots[ValueRootCount]);
               AddTempRootIfNeeded(ValueRoots[ValueRootCount], Val);
               Inc(ValueRootCount);
               IterResult := Iterator.AdvanceNext;

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -2508,6 +2508,8 @@ var
   Values: TGocciaValueList;
   SrcObj: TGocciaObjectValue;
   SourceRoot, ResultRoot: TGocciaTempRoot;
+  ValueRoots: array of TGocciaTempRoot;
+  ValueRootCount: Integer;
 begin
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorTypedArrayFromRequiresArg, SSuggestTypedArraySetSource);
@@ -2532,6 +2534,7 @@ begin
     if Assigned(Iterator) then
     begin
       Values := TGocciaValueList.Create(False);
+      ValueRootCount := 0;
       try
         TGarbageCollector.Instance.AddTempRoot(Iterator);
         try
@@ -2539,7 +2542,12 @@ begin
             IterResult := Iterator.AdvanceNext;
             while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
             begin
-              Values.Add(IterResult.GetProperty(PROP_VALUE));
+              Val := IterResult.GetProperty(PROP_VALUE);
+              Values.Add(Val);
+              if ValueRootCount >= Length(ValueRoots) then
+                SetLength(ValueRoots, ValueRootCount * 2 + 4);
+              AddTempRootIfNeeded(ValueRoots[ValueRootCount], Val);
+              Inc(ValueRootCount);
               IterResult := Iterator.AdvanceNext;
             end;
           except
@@ -2573,6 +2581,9 @@ begin
           RemoveTempRootIfNeeded(ResultRoot);
         end;
       finally
+        for I := ValueRootCount - 1 downto 0 do
+          RemoveTempRootIfNeeded(ValueRoots[I]);
+        SetLength(ValueRoots, 0);
         Values.Free;
       end;
       Exit(NewTA);

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -2507,7 +2507,7 @@ var
   IterResult: TGocciaObjectValue;
   Values: TGocciaValueList;
   SrcObj: TGocciaObjectValue;
-  SourceRoot, ResultRoot: TGocciaTempRoot;
+  SourceRoot, MapFnRoot, ThisRoot, ResultRoot: TGocciaTempRoot;
   ValueRoots: array of TGocciaTempRoot;
   ValueRootCount: Integer;
 begin
@@ -2527,7 +2527,16 @@ begin
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
+  MapFnRoot.ObjectValue := nil;
+  MapFnRoot.Added := False;
+  ThisRoot.ObjectValue := nil;
+  ThisRoot.Added := False;
   AddTempRootIfNeeded(SourceRoot, Source);
+  if HasMapFn then
+  begin
+    AddTempRootIfNeeded(MapFnRoot, MapFnArg);
+    AddTempRootIfNeeded(ThisRoot, ThisArg);
+  end;
   try
     // ES2026 §23.2.2.1 step 5: GetMethod(source, @@iterator) before type fast paths
     Iterator := GetIteratorFromValue(Source);
@@ -2672,6 +2681,8 @@ begin
       RemoveTempRootIfNeeded(ResultRoot);
     end;
   finally
+    RemoveTempRootIfNeeded(ThisRoot);
+    RemoveTempRootIfNeeded(MapFnRoot);
     RemoveTempRootIfNeeded(SourceRoot);
   end;
 end;

--- a/tests/built-ins/Intl/NumberFormat/prototype/format.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/format.js
@@ -42,6 +42,16 @@ describe.runIf(isIntl)("Intl.NumberFormat.prototype.format", () => {
     }).format(-0.01)).toBe("0");
   });
 
+  test("format treats NaN as unsigned for signDisplay", () => {
+    expect(new Intl.NumberFormat("en-US", { signDisplay: "auto" }).format(NaN)).toBe("NaN");
+    expect(new Intl.NumberFormat("en-US", { signDisplay: "always" }).format(NaN)).toBe("+NaN");
+    expect(new Intl.NumberFormat("en-US", { signDisplay: "never" }).format(NaN)).toBe("NaN");
+    expect(new Intl.NumberFormat("en-US", { signDisplay: "exceptZero" }).format(NaN)).toBe("NaN");
+    expect(new Intl.NumberFormat("en-US", { notation: "scientific" }).format(NaN)).toBe("NaN");
+    expect(new Intl.NumberFormat("en-US", { notation: "engineering" }).format(NaN)).toBe("NaN");
+    expect(new Intl.NumberFormat("en-US", { notation: "compact" }).format(NaN)).toBe("NaN");
+  });
+
   test("significant digit formatting keeps plain decimal precision", () => {
     expect(new Intl.NumberFormat("en-US", {
       useGrouping: false,

--- a/tests/built-ins/callback-gc-roots.js
+++ b/tests/built-ins/callback-gc-roots.js
@@ -139,6 +139,23 @@ describe.runIf(hasGoccia)("native callback GC roots", () => {
       Goccia.gc();
       return value * 2;
     });
+    const fromIterableResult = Uint8Array.from({
+      [Symbol.iterator]() {
+        let index = 0;
+        return {
+          next() {
+            index++;
+            if (index > 2) {
+              return { done: true };
+            }
+            return { value: { value: index }, done: false };
+          },
+        };
+      },
+    }, (item) => {
+      Goccia.gc();
+      return item.value;
+    });
 
     expect(sum).toBe(3);
     expect(Array.from(mapped)).toEqual([2, 4]);
@@ -151,6 +168,7 @@ describe.runIf(hasGoccia)("native callback GC roots", () => {
     expect(found).toBe(2);
     expect(foundIndex).toBe(1);
     expect(Array.from(fromResult)).toEqual([2, 4]);
+    expect(Array.from(fromIterableResult)).toEqual([1, 2]);
   });
 
   test("Iterator helper callbacks survive explicit GC", () => {

--- a/tests/built-ins/callback-gc-roots.js
+++ b/tests/built-ins/callback-gc-roots.js
@@ -25,6 +25,17 @@ describe.runIf(hasGoccia)("native callback GC roots", () => {
       Goccia.gc();
       return [value, value + 1];
     });
+    const flatMappedWithGetter = [1].flatMap((value) => {
+      const mapped = [];
+      Object.defineProperty(mapped, "0", {
+        get() {
+          Goccia.gc();
+          return value;
+        },
+      });
+      mapped.length = 1;
+      return mapped;
+    });
     const reduced = [1, 2].reduce((accumulator, value) => {
       Goccia.gc();
       return accumulator + value;
@@ -66,6 +77,7 @@ describe.runIf(hasGoccia)("native callback GC roots", () => {
     expect(mapped).toEqual([2, 4]);
     expect(filtered).toEqual([1, 2]);
     expect(flatMapped).toEqual([1, 2]);
+    expect(flatMappedWithGetter).toEqual([1]);
     expect(reduced).toBe(3);
     expect(sorted).toEqual([1, 2]);
     expect(toSorted).toEqual([1, 2]);

--- a/tests/built-ins/callback-gc-roots.js
+++ b/tests/built-ins/callback-gc-roots.js
@@ -1,0 +1,236 @@
+/*---
+description: Native callback APIs keep callback state reachable during explicit GC
+features: [Array.prototype.map, Array.from, TypedArray, Iterator, Map, Set, Object.groupBy, fetch, URLSearchParams]
+---*/
+
+const hasGoccia = typeof Goccia !== "undefined";
+
+describe.runIf(hasGoccia)("native callback GC roots", () => {
+  test("Array prototype callbacks survive explicit GC across iterations", () => {
+    let sum = 0;
+    [1, 2].forEach((value) => {
+      Goccia.gc();
+      sum += value;
+    });
+
+    const mapped = [1, 2].map((value) => {
+      Goccia.gc();
+      return value * 2;
+    });
+    const filtered = [1, 2].filter((value) => {
+      Goccia.gc();
+      return value > 0;
+    });
+    const flatMapped = [1].flatMap((value) => {
+      Goccia.gc();
+      return [value, value + 1];
+    });
+    const reduced = [1, 2].reduce((accumulator, value) => {
+      Goccia.gc();
+      return accumulator + value;
+    }, 0);
+    const sorted = [2, 1].sort((left, right) => {
+      Goccia.gc();
+      return left - right;
+    });
+    const toSorted = [2, 1].toSorted((left, right) => {
+      Goccia.gc();
+      return left - right;
+    });
+    const some = [0, 1].some((value) => {
+      Goccia.gc();
+      return value === 1;
+    });
+    const every = [1, 1].every((value) => {
+      Goccia.gc();
+      return value === 1;
+    });
+    const found = [0, 2].find((value) => {
+      Goccia.gc();
+      return value === 2;
+    });
+    const foundIndex = [0, 2].findIndex((value) => {
+      Goccia.gc();
+      return value === 2;
+    });
+    const foundLast = [2, 0, 2].findLast((value) => {
+      Goccia.gc();
+      return value === 2;
+    });
+    const foundLastIndex = [2, 0, 2].findLastIndex((value) => {
+      Goccia.gc();
+      return value === 2;
+    });
+
+    expect(sum).toBe(3);
+    expect(mapped).toEqual([2, 4]);
+    expect(filtered).toEqual([1, 2]);
+    expect(flatMapped).toEqual([1, 2]);
+    expect(reduced).toBe(3);
+    expect(sorted).toEqual([1, 2]);
+    expect(toSorted).toEqual([1, 2]);
+    expect(some).toBe(true);
+    expect(every).toBe(true);
+    expect(found).toBe(2);
+    expect(foundIndex).toBe(1);
+    expect(foundLast).toBe(2);
+    expect(foundLastIndex).toBe(2);
+  });
+
+  test("Array.from and Array.fromAsync mapping callbacks survive explicit GC", () => {
+    const fromResult = Array.from([1, 2], (value) => {
+      Goccia.gc();
+      return value * 2;
+    });
+
+    expect(fromResult).toEqual([2, 4]);
+    return Array.fromAsync([1, 2], (value) => {
+      Goccia.gc();
+      return value * 3;
+    }).then((fromAsyncResult) => {
+      expect(fromAsyncResult).toEqual([3, 6]);
+    });
+  });
+
+  test("TypedArray callbacks survive explicit GC", () => {
+    let sum = 0;
+    new Uint8Array([1, 2]).forEach((value) => {
+      Goccia.gc();
+      sum += value;
+    });
+
+    const mapped = new Uint8Array([1, 2]).map((value) => {
+      Goccia.gc();
+      return value * 2;
+    });
+    const filtered = new Uint8Array([1, 2]).filter((value) => {
+      Goccia.gc();
+      return value > 0;
+    });
+    const reduced = new Uint8Array([1, 2]).reduce((accumulator, value) => {
+      Goccia.gc();
+      return accumulator + value;
+    }, 0);
+    const sorted = new Uint8Array([2, 1]).sort((left, right) => {
+      Goccia.gc();
+      return left - right;
+    });
+    const toSorted = new Uint8Array([2, 1]).toSorted((left, right) => {
+      Goccia.gc();
+      return left - right;
+    });
+    const some = new Uint8Array([0, 1]).some((value) => {
+      Goccia.gc();
+      return value === 1;
+    });
+    const every = new Uint8Array([1, 1]).every((value) => {
+      Goccia.gc();
+      return value === 1;
+    });
+    const found = new Uint8Array([0, 2]).find((value) => {
+      Goccia.gc();
+      return value === 2;
+    });
+    const foundIndex = new Uint8Array([0, 2]).findIndex((value) => {
+      Goccia.gc();
+      return value === 2;
+    });
+    const fromResult = Uint8Array.from([1, 2], (value) => {
+      Goccia.gc();
+      return value * 2;
+    });
+
+    expect(sum).toBe(3);
+    expect(Array.from(mapped)).toEqual([2, 4]);
+    expect(Array.from(filtered)).toEqual([1, 2]);
+    expect(reduced).toBe(3);
+    expect(Array.from(sorted)).toEqual([1, 2]);
+    expect(Array.from(toSorted)).toEqual([1, 2]);
+    expect(some).toBe(true);
+    expect(every).toBe(true);
+    expect(found).toBe(2);
+    expect(foundIndex).toBe(1);
+    expect(Array.from(fromResult)).toEqual([2, 4]);
+  });
+
+  test("Iterator helper callbacks survive explicit GC", () => {
+    let sum = 0;
+    [1, 2].values().forEach((value) => {
+      Goccia.gc();
+      sum += value;
+    });
+    const reduced = [1, 2].values().reduce((accumulator, value) => {
+      Goccia.gc();
+      return accumulator + value;
+    }, 0);
+    const some = [0, 1].values().some((value) => {
+      Goccia.gc();
+      return value === 1;
+    });
+    const every = [1, 1].values().every((value) => {
+      Goccia.gc();
+      return value === 1;
+    });
+    const found = [0, 2].values().find((value) => {
+      Goccia.gc();
+      return value === 2;
+    });
+
+    expect(sum).toBe(3);
+    expect(reduced).toBe(3);
+    expect(some).toBe(true);
+    expect(every).toBe(true);
+    expect(found).toBe(2);
+  });
+
+  test("collection callbacks survive explicit GC", () => {
+    let mapSum = 0;
+    new Map([["a", 1], ["b", 2]]).forEach((value) => {
+      Goccia.gc();
+      mapSum += value;
+    });
+
+    let setSum = 0;
+    new Set([1, 2]).forEach((value) => {
+      Goccia.gc();
+      setSum += value;
+    });
+
+    const objectGroups = Object.groupBy([1, 2], () => {
+      Goccia.gc();
+      return "items";
+    });
+    const mapGroups = Map.groupBy([1, 2], () => {
+      Goccia.gc();
+      return "items";
+    });
+
+    const upsertMap = new Map();
+    const key = {};
+    const inserted = upsertMap.getOrInsertComputed(key, () => {
+      Goccia.gc();
+      return 3;
+    });
+
+    let headersJoined = "";
+    new Headers({ A: "1" }).forEach((value, name) => {
+      Goccia.gc();
+      headersJoined += name + value;
+    });
+
+    let paramsJoined = "";
+    new URLSearchParams("a=1").forEach((value, name) => {
+      Goccia.gc();
+      paramsJoined += name + value;
+    });
+
+    expect(mapSum).toBe(3);
+    expect(setSum).toBe(3);
+    expect(objectGroups.items).toEqual([1, 2]);
+    expect(mapGroups.get("items")).toEqual([1, 2]);
+    expect(inserted).toBe(3);
+    expect(upsertMap.get(key)).toBe(3);
+    expect(headersJoined).toBe("a1");
+    expect(paramsJoined).toBe("a1");
+  });
+});

--- a/tests/language/classes/scope-walk-function-boundary.js
+++ b/tests/language/classes/scope-walk-function-boundary.js
@@ -3,6 +3,8 @@ description: Find* scope walks stop at ordinary function boundaries
 features: [class-declaration, new-target, super]
 ---*/
 
+const hasGoccia = typeof Goccia !== "undefined";
+
 describe("new.target function boundary", () => {
   test("arrow inherits new.target from constructor", () => {
     class Foo {
@@ -63,6 +65,20 @@ describe("new.target function boundary", () => {
     const f = new Foo();
     expect(f.results[0]).toBe(Foo);
     expect(f.results[1]).toBe(Foo);
+  });
+
+  test.runIf(hasGoccia)("anonymous class new.target survives explicit GC during native callback", () => {
+    let seen;
+    const instance = new (class {
+      constructor() {
+        seen = [1].map(() => {
+          Goccia.gc();
+          return new.target;
+        })[0];
+      }
+    })();
+
+    expect(seen).toBe(instance.constructor);
   });
 });
 


### PR DESCRIPTION
## Summary

- Preserve caller VM state as GC roots while `ExecuteClosureRegistersInternal` runs nested closures, including saved closure references, `new.target`, and arguments.
- Add shared temp-root helpers and root callable dispatch state in `InvokeCallable` so native callback calls keep callback, `this`, and arguments reachable during explicit `Goccia.gc()`.
- Broaden native callback/root protection across Array, TypedArray, Iterator helpers, Array.from/fromAsync, Map/Set forEach, groupBy, getOrInsertComputed, and async bytecode promise execution.
- Root `TypedArray.from` iterator-collected values until mapping completes, and keep the mapper callback/`thisArg` rooted across iterator collection so iterator-side GC cannot collect either before mapping begins.
- Add forced-GC regression coverage for array, typed array, iterator, collection, Headers, URLSearchParams callbacks, plus a CLI-level bytecode `TypedArray.from` repro through `GocciaScriptLoader`.
- Closes #563.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation (not needed; runtime GC root fix only)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Commands run:

- `./build.pas loader testrunner`
- `./build.pas testrunner` (initial post-merge incremental rebuild hit an FPC internal compiler error; clean rebuild below succeeded)
- `./build.pas clean testrunner`
- `./build.pas loader loaderbare repl bundler benchmarkrunner testrunner`
- `./build.pas tests`
- Manual forced-GC reproduction with `Goccia.gc()` inside `[1].map(() => new.target)` in interpreted and bytecode modes
- Manual forced-GC reproduction for `Uint8Array.from(iteratorOfObjects, mapfn)` in Goccia bytecode, Bun 1.3.14 with `Bun.gc()`, and Node 24.0.1 with `--expose-gc`
- Manual top-level `GocciaScriptLoader --mode=bytecode` repro for `Uint8Array.from(iterable, mapper, thisArg)` with `Goccia.gc()` in `next()`
- `bun run scripts/test-cli-apps.ts`
- `./build/GocciaTestRunner tests/built-ins/callback-gc-roots.js --asi --unsafe-ffi`
- `./build/GocciaTestRunner tests/built-ins/callback-gc-roots.js --asi --unsafe-ffi --mode=bytecode`
- `./build/GocciaTestRunner tests/built-ins/TypedArray/from.js --asi --unsafe-ffi --mode=bytecode`
- `./build/GocciaTestRunner tests/built-ins/Iterator/prototype/forEach.js tests/built-ins/Iterator/prototype/reduce.js tests/built-ins/Iterator/prototype/some.js tests/built-ins/Iterator/prototype/every.js tests/built-ins/Iterator/prototype/find.js tests/built-ins/Iterator/prototype/map.js tests/built-ins/Iterator/prototype/filter.js tests/built-ins/Iterator/prototype/flatMap.js --asi --unsafe-ffi`
- `./build/GocciaTestRunner tests/built-ins/Map/groupBy.js tests/built-ins/Object/groupBy.js tests/built-ins/Set/prototype/forEach.js tests/built-ins/Map/prototype/forEach.js --asi --unsafe-ffi`
- `./fixtures/ffi/build.sh`
- `./build/GocciaTestRunner tests --asi --unsafe-ffi` (post-merge and latest: 1174 files, 9794 tests, 19908 assertions)
- `./format.pas --check`
- `git diff --check`
