### PR TITLE
Fix Intl format and compare accessors

### DIFF
--- a/source/units/Goccia.Values.IntlCollator.pas
+++ b/source/units/Goccia.Values.IntlCollator.pas
@@ -21,15 +21,17 @@ type
     FNumeric: Boolean;
     FCaseFirst: string;
     FCollation: string;
+    FBoundCompare: TGocciaValue;
 
     procedure InitializePrototype;
-    function BoundCompare(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const ALocale: string; const AOptions: TGocciaObjectValue = nil);
 
     function ToStringTag: string; override;
+    procedure MarkReferences; override;
     class procedure ExposePrototype(const AConstructor: TGocciaObjectValue);
   published
+    function IntlCollatorCompareGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IntlCollatorCompare(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IntlCollatorResolvedOptions(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
@@ -58,6 +60,16 @@ var
 threadvar
   FPrototypeMembers: TArray<TGocciaMemberDefinition>;
 
+type
+  TGocciaIntlCollatorBoundCompareValue = class(TGocciaNativeFunctionValue)
+  private
+    FCollator: TGocciaIntlCollatorValue;
+    function Compare(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const ACollator: TGocciaIntlCollatorValue);
+    procedure MarkReferences; override;
+  end;
+
 function GetIntlCollatorShared: TGocciaSharedPrototype; inline;
 begin
   if Assigned(CurrentRealm) then
@@ -71,6 +83,30 @@ begin
   if not (AValue is TGocciaIntlCollatorValue) then
     ThrowTypeError(AMethod + ' called on non-Collator');
   Result := TGocciaIntlCollatorValue(AValue);
+end;
+
+{ TGocciaIntlCollatorBoundCompareValue }
+
+constructor TGocciaIntlCollatorBoundCompareValue.Create(
+  const ACollator: TGocciaIntlCollatorValue);
+begin
+  inherited CreateWithoutPrototype(Compare, '', 2);
+  FCollator := ACollator;
+end;
+
+function TGocciaIntlCollatorBoundCompareValue.Compare(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := FCollator.IntlCollatorCompare(AArgs, FCollator);
+end;
+
+procedure TGocciaIntlCollatorBoundCompareValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FCollator) then
+    FCollator.MarkReferences;
 end;
 
 function SensitivityStringToEnum(const AValue: string): TIntlCollatorSensitivity;
@@ -126,17 +162,19 @@ begin
   InitializePrototype;
   if Assigned(GetIntlCollatorShared) then
     FPrototype := GetIntlCollatorShared.Prototype;
-
-  // ES2024 §10.2.1: Intl.Collator.prototype.compare is a getter that returns
-  // a bound compare function.  Define an own 'compare' property so that
-  // extracting `collator.compare` as a callback works without losing `this`.
-  AssignProperty('compare',
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(BoundCompare, 'compare', 2));
 end;
 
 function TGocciaIntlCollatorValue.ToStringTag: string;
 begin
   Result := 'Intl.Collator';
+end;
+
+procedure TGocciaIntlCollatorValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FBoundCompare) then
+    FBoundCompare.MarkReferences;
 end;
 
 procedure TGocciaIntlCollatorValue.InitializePrototype;
@@ -153,8 +191,8 @@ begin
   begin
     Members := TGocciaMemberCollection.Create;
     try
-      Members.AddNamedMethod('compare', IntlCollatorCompare, 2,
-        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddAccessor('compare', IntlCollatorCompareGetter, nil,
+        [pfConfigurable]);
       Members.AddNamedMethod('resolvedOptions', IntlCollatorResolvedOptions, 0,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddSymbolDataProperty(
@@ -183,25 +221,21 @@ begin
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
 end;
 
-function TGocciaIntlCollatorValue.BoundCompare(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+function TGocciaIntlCollatorValue.IntlCollatorCompareGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Str1, Str2: UnicodeString;
-  CompareResult: Integer;
+  C: TGocciaIntlCollatorValue;
 begin
-  // Bound compare uses Self directly, so it works when detached from the
-  // Collator (e.g. passed as a callback to Array.prototype.sort).
-  // Per ECMA-402, missing arguments are ToString-coerced (undefined -> "undefined").
-  Str1 := UnicodeString(AArgs.GetElement(0).ToStringLiteral.Value);
-  Str2 := UnicodeString(AArgs.GetElement(1).ToStringLiteral.Value);
-
-  if TryICUCompareStrings(FLocale, Str1, Str2,
-    SensitivityStringToEnum(FSensitivity), FIgnorePunctuation, CompareResult) then
-    Result := TGocciaNumberLiteralValue.Create(CompareResult)
-  else
-    Result := TGocciaNumberLiteralValue.Create(CompareStr(string(Str1), string(Str2)));
+  C := AsCollator(AThisValue, 'get Intl.Collator.prototype.compare');
+  if not Assigned(C.FBoundCompare) then
+    C.FBoundCompare := TGocciaIntlCollatorBoundCompareValue.Create(C);
+  Result := C.FBoundCompare;
 end;
 
-function TGocciaIntlCollatorValue.IntlCollatorCompare(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+function TGocciaIntlCollatorValue.IntlCollatorCompare(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
 var
   C: TGocciaIntlCollatorValue;
   Str1, Str2: UnicodeString;

--- a/source/units/Goccia.Values.IntlDateTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlDateTimeFormat.pas
@@ -64,6 +64,7 @@ uses
 
   IntlICU,
   IntlLocaleResolver,
+  TimingUtils,
 
   Goccia.Error.Messages,
   Goccia.Intl.Helpers,
@@ -91,6 +92,7 @@ threadvar
 
 const
   GREGORIAN_CYCLE_YEARS = 400;
+  NANOSECONDS_PER_MILLISECOND = 1000000;
   TEMPORAL_SURROGATE_YEAR_BASE = 2000;
   TEMPORAL_DIRECT_ICU_YEAR_LIMIT = 9999;
   TWO_DIGIT_YEAR_MODULUS = 100;
@@ -288,6 +290,23 @@ begin
   if IsNan(AValue) or Math.IsInfinite(AValue) or (Abs(AValue) > 8.64e15) then
     Exit(Math.NaN);
   Result := Trunc(AValue);
+end;
+
+function CurrentEpochMilliseconds: Double;
+begin
+  Result := GetEpochNanoseconds div NANOSECONDS_PER_MILLISECOND;
+end;
+
+function DateTimeFormatArgumentMilliseconds(
+  const AArgs: TGocciaArgumentsCollection): Double;
+var
+  DateValue: TGocciaValue;
+begin
+  DateValue := AArgs.GetElement(0);
+  if DateValue is TGocciaUndefinedLiteralValue then
+    Result := CurrentEpochMilliseconds
+  else
+    Result := TimeClipMillis(DateValue.ToNumberLiteral.Value);
 end;
 
 function EpochMillisFromDateTimeParts(const AYear, AMonth, ADay, AHour,
@@ -1116,9 +1135,7 @@ var
   Formatted: string;
 begin
   DTF := AsDateTimeFormat(AThisValue, 'Intl.DateTimeFormat.prototype.format');
-  if AArgs.Length < 1 then
-    ThrowTypeError('Intl.DateTimeFormat.prototype.format requires a date value');
-  Millis := TimeClipMillis(AArgs.GetElement(0).ToNumberLiteral.Value);
+  Millis := DateTimeFormatArgumentMilliseconds(AArgs);
   if IsNan(Millis) then
     ThrowRangeError('Invalid time value');
 
@@ -1135,9 +1152,7 @@ var
   Parts: TIntlFormatPartArray;
 begin
   DTF := AsDateTimeFormat(AThisValue, 'Intl.DateTimeFormat.prototype.formatToParts');
-  if AArgs.Length < 1 then
-    ThrowTypeError('Intl.DateTimeFormat.prototype.formatToParts requires a date value');
-  Millis := TimeClipMillis(AArgs.GetElement(0).ToNumberLiteral.Value);
+  Millis := DateTimeFormatArgumentMilliseconds(AArgs);
   if IsNan(Millis) then
     ThrowRangeError('Invalid time value');
 

--- a/source/units/Goccia.Values.IntlDateTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlDateTimeFormat.pas
@@ -37,6 +37,7 @@ type
     FTimeZoneName: string;
     FResolvedOptions: TIntlDateTimeFormatOptions;
     FHasExplicitCoreOptions: Boolean;
+    FBoundFormat: TGocciaValue;
 
     procedure InitializePrototype;
     procedure ReadOptions(const AOptions: TGocciaObjectValue);
@@ -44,8 +45,10 @@ type
     constructor Create(const ALocale: string; const AOptions: TGocciaObjectValue = nil);
 
     function ToStringTag: string; override;
+    procedure MarkReferences; override;
     class procedure ExposePrototype(const AConstructor: TGocciaObjectValue);
   published
+    function IntlDateTimeFormatFormatGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IntlDateTimeFormatFormat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IntlDateTimeFormatFormatToParts(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IntlDateTimeFormatFormatRange(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -69,6 +72,7 @@ uses
   Goccia.Temporal.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
   Goccia.Values.TemporalInstant,
@@ -92,6 +96,15 @@ const
   TWO_DIGIT_YEAR_MODULUS = 100;
 
 type
+  TGocciaIntlDateTimeFormatBoundFormatValue = class(TGocciaNativeFunctionValue)
+  private
+    FDateTimeFormat: TGocciaIntlDateTimeFormatValue;
+    function Format(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const ADateTimeFormat: TGocciaIntlDateTimeFormatValue);
+    procedure MarkReferences; override;
+  end;
+
   TDateTimeFormattableKind = (dtfkNumber, dtfkPlainDate, dtfkPlainDateTime,
     dtfkPlainTime, dtfkPlainYearMonth, dtfkPlainMonthDay, dtfkInstant,
     dtfkZonedDateTime);
@@ -230,6 +243,30 @@ begin
   if not (AValue is TGocciaIntlDateTimeFormatValue) then
     ThrowTypeError(AMethod + ' called on non-DateTimeFormat');
   Result := TGocciaIntlDateTimeFormatValue(AValue);
+end;
+
+{ TGocciaIntlDateTimeFormatBoundFormatValue }
+
+constructor TGocciaIntlDateTimeFormatBoundFormatValue.Create(
+  const ADateTimeFormat: TGocciaIntlDateTimeFormatValue);
+begin
+  inherited CreateWithoutPrototype(Format, '', 1);
+  FDateTimeFormat := ADateTimeFormat;
+end;
+
+function TGocciaIntlDateTimeFormatBoundFormatValue.Format(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := FDateTimeFormat.IntlDateTimeFormatFormat(AArgs, FDateTimeFormat);
+end;
+
+procedure TGocciaIntlDateTimeFormatBoundFormatValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FDateTimeFormat) then
+    FDateTimeFormat.MarkReferences;
 end;
 
 function DateStyleStringToEnum(const AValue: string): TIntlDateTimeStyle;
@@ -1002,6 +1039,14 @@ begin
   Result := 'Intl.DateTimeFormat';
 end;
 
+procedure TGocciaIntlDateTimeFormatValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FBoundFormat) then
+    FBoundFormat.MarkReferences;
+end;
+
 procedure TGocciaIntlDateTimeFormatValue.InitializePrototype;
 var
   Members: TGocciaMemberCollection;
@@ -1016,8 +1061,8 @@ begin
   begin
     Members := TGocciaMemberCollection.Create;
     try
-      Members.AddNamedMethod('format', IntlDateTimeFormatFormat, 1,
-        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddAccessor('format', IntlDateTimeFormatFormatGetter, nil,
+        [pfConfigurable]);
       Members.AddNamedMethod('formatToParts', IntlDateTimeFormatFormatToParts, 1,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddNamedMethod('formatRange', IntlDateTimeFormatFormatRange, 2,
@@ -1050,6 +1095,18 @@ begin
   end;
   if Assigned(Shared) then
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+function TGocciaIntlDateTimeFormatValue.IntlDateTimeFormatFormatGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  DTF: TGocciaIntlDateTimeFormatValue;
+begin
+  DTF := AsDateTimeFormat(AThisValue, 'get Intl.DateTimeFormat.prototype.format');
+  if not Assigned(DTF.FBoundFormat) then
+    DTF.FBoundFormat := TGocciaIntlDateTimeFormatBoundFormatValue.Create(DTF);
+  Result := DTF.FBoundFormat;
 end;
 
 function TGocciaIntlDateTimeFormatValue.IntlDateTimeFormatFormat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -38,6 +38,7 @@ type
     FTrailingZeroDisplay: string;
     FNumberingSystem: string;
     FResolvedOptions: TIntlNumberFormatOptions;
+    FBoundFormat: TGocciaValue;
 
     procedure InitializePrototype;
     procedure ReadOptions(const AOptions: TGocciaObjectValue);
@@ -45,8 +46,10 @@ type
     constructor Create(const ALocale: string; const AOptions: TGocciaObjectValue = nil);
 
     function ToStringTag: string; override;
+    procedure MarkReferences; override;
     class procedure ExposePrototype(const AConstructor: TGocciaObjectValue);
   published
+    function IntlNumberFormatFormatGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IntlNumberFormatFormat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IntlNumberFormatFormatToParts(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IntlNumberFormatFormatRange(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -71,6 +74,7 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -79,6 +83,16 @@ var
 
 threadvar
   FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+
+type
+  TGocciaIntlNumberFormatBoundFormatValue = class(TGocciaNativeFunctionValue)
+  private
+    FNumberFormat: TGocciaIntlNumberFormatValue;
+    function Format(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const ANumberFormat: TGocciaIntlNumberFormatValue);
+    procedure MarkReferences; override;
+  end;
 
 function GetIntlNumberFormatShared: TGocciaSharedPrototype; inline;
 begin
@@ -93,6 +107,30 @@ begin
   if not (AValue is TGocciaIntlNumberFormatValue) then
     ThrowTypeError(AMethod + ' called on non-NumberFormat');
   Result := TGocciaIntlNumberFormatValue(AValue);
+end;
+
+{ TGocciaIntlNumberFormatBoundFormatValue }
+
+constructor TGocciaIntlNumberFormatBoundFormatValue.Create(
+  const ANumberFormat: TGocciaIntlNumberFormatValue);
+begin
+  inherited CreateWithoutPrototype(Format, '', 1);
+  FNumberFormat := ANumberFormat;
+end;
+
+function TGocciaIntlNumberFormatBoundFormatValue.Format(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := FNumberFormat.IntlNumberFormatFormat(AArgs, FNumberFormat);
+end;
+
+procedure TGocciaIntlNumberFormatBoundFormatValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FNumberFormat) then
+    FNumberFormat.MarkReferences;
 end;
 
 function StyleStringToEnum(const AValue: string): TIntlNumberStyle;
@@ -699,6 +737,14 @@ begin
   Result := 'Intl.NumberFormat';
 end;
 
+procedure TGocciaIntlNumberFormatValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FBoundFormat) then
+    FBoundFormat.MarkReferences;
+end;
+
 procedure TGocciaIntlNumberFormatValue.InitializePrototype;
 var
   Members: TGocciaMemberCollection;
@@ -713,8 +759,8 @@ begin
   begin
     Members := TGocciaMemberCollection.Create;
     try
-      Members.AddNamedMethod('format', IntlNumberFormatFormat, 1,
-        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddAccessor('format', IntlNumberFormatFormatGetter, nil,
+        [pfConfigurable]);
       Members.AddNamedMethod('formatToParts', IntlNumberFormatFormatToParts, 1,
         gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddNamedMethod('formatRange', IntlNumberFormatFormatRange, 2,
@@ -747,6 +793,18 @@ begin
   end;
   if Assigned(Shared) then
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+function TGocciaIntlNumberFormatValue.IntlNumberFormatFormatGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  NF: TGocciaIntlNumberFormatValue;
+begin
+  NF := AsNumberFormat(AThisValue, 'get Intl.NumberFormat.prototype.format');
+  if not Assigned(NF.FBoundFormat) then
+    NF.FBoundFormat := TGocciaIntlNumberFormatBoundFormatValue.Create(NF);
+  Result := NF.FBoundFormat;
 end;
 
 function TGocciaIntlNumberFormatValue.IntlNumberFormatFormat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -814,8 +814,6 @@ var
   Formatted: string;
 begin
   NF := AsNumberFormat(AThisValue, 'Intl.NumberFormat.prototype.format');
-  if AArgs.Length < 1 then
-    ThrowTypeError('Intl.NumberFormat.prototype.format requires a value');
   NumValue := AArgs.GetElement(0).ToNumberLiteral.Value;
 
   if TryICUFormatNumber(NF.FLocale, NumValue, NF.FResolvedOptions, Formatted) then
@@ -832,8 +830,6 @@ var
   Parts: TIntlFormatPartArray;
 begin
   NF := AsNumberFormat(AThisValue, 'Intl.NumberFormat.prototype.formatToParts');
-  if AArgs.Length < 1 then
-    ThrowTypeError('Intl.NumberFormat.prototype.formatToParts requires a value');
   NumValue := AArgs.GetElement(0).ToNumberLiteral.Value;
 
   if TryICUFormatNumberToParts(NF.FLocale, NumValue, NF.FResolvedOptions, Parts) then

--- a/tests/built-ins/Intl/Collator/prototype/compare.js
+++ b/tests/built-ins/Intl/Collator/prototype/compare.js
@@ -6,6 +6,33 @@ features: [Intl]
 const isIntl = typeof Intl !== "undefined";
 
 describe.runIf(isIntl)("Intl.Collator.prototype.compare", () => {
+  test("compare is an accessor property on the prototype", () => {
+    const desc = Object.getOwnPropertyDescriptor(Intl.Collator.prototype, "compare");
+    expect(typeof desc.get).toBe("function");
+    expect(desc.set).toBe(undefined);
+    expect(desc.value).toBe(undefined);
+    expect(desc.enumerable).toBe(false);
+    expect(desc.configurable).toBe(true);
+  });
+
+  test("compare getter returns a cached bound function", () => {
+    const collator = new Intl.Collator("en");
+    const first = collator.compare;
+    const second = collator.compare;
+
+    expect(typeof first).toBe("function");
+    expect(first).toBe(second);
+    expect(first("a", "b") < 0).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(collator, "compare")).toBe(false);
+  });
+
+  test("compare getter creates distinct functions for distinct instances", () => {
+    const first = new Intl.Collator("en").compare;
+    const second = new Intl.Collator("en").compare;
+
+    expect(first === second).toBe(false);
+  });
+
   test("returns negative when first string sorts before second", () => {
     const collator = new Intl.Collator("en");
     expect(collator.compare("a", "b") < 0).toBe(true);

--- a/tests/built-ins/Intl/DateTimeFormat/prototype/format.js
+++ b/tests/built-ins/Intl/DateTimeFormat/prototype/format.js
@@ -1,0 +1,42 @@
+/*---
+description: Intl.DateTimeFormat.prototype.format
+features: [Intl]
+---*/
+
+const isIntl = typeof Intl !== "undefined";
+
+describe.runIf(isIntl)("Intl.DateTimeFormat.prototype.format", () => {
+  test("format is an accessor property on the prototype", () => {
+    const desc = Object.getOwnPropertyDescriptor(Intl.DateTimeFormat.prototype, "format");
+    expect(typeof desc.get).toBe("function");
+    expect(desc.set).toBe(undefined);
+    expect(desc.value).toBe(undefined);
+    expect(desc.enumerable).toBe(false);
+    expect(desc.configurable).toBe(true);
+  });
+
+  test("format getter returns a cached bound function", () => {
+    const dtf = new Intl.DateTimeFormat("en-US");
+    const first = dtf.format;
+    const second = dtf.format;
+
+    expect(typeof first).toBe("function");
+    expect(first).toBe(second);
+    expect(first(0)).toBe(dtf.format(0));
+    expect(Object.prototype.hasOwnProperty.call(dtf, "format")).toBe(false);
+  });
+
+  test("format getter creates distinct functions for distinct instances", () => {
+    const first = new Intl.DateTimeFormat("en-US").format;
+    const second = new Intl.DateTimeFormat("en-US").format;
+
+    expect(first === second).toBe(false);
+  });
+
+  test("format returns a string for a Date object", () => {
+    const dtf = new Intl.DateTimeFormat("en-US");
+    const result = dtf.format(new Date(2025, 0, 1));
+    expect(typeof result).toBe("string");
+    expect(result.length > 0).toBe(true);
+  });
+});

--- a/tests/built-ins/Intl/DateTimeFormat/prototype/format.js
+++ b/tests/built-ins/Intl/DateTimeFormat/prototype/format.js
@@ -5,6 +5,16 @@ features: [Intl]
 
 const isIntl = typeof Intl !== "undefined";
 
+const expectCurrentDateResult = (readActual, formatAt) => {
+  const before = Date.now();
+  const actual = readActual();
+  const after = Date.now();
+  const beforeFormatted = formatAt(before);
+  const afterFormatted = formatAt(after);
+
+  expect(actual === beforeFormatted || actual === afterFormatted).toBe(true);
+};
+
 describe.runIf(isIntl)("Intl.DateTimeFormat.prototype.format", () => {
   test("format is an accessor property on the prototype", () => {
     const desc = Object.getOwnPropertyDescriptor(Intl.DateTimeFormat.prototype, "format");
@@ -38,5 +48,16 @@ describe.runIf(isIntl)("Intl.DateTimeFormat.prototype.format", () => {
     const result = dtf.format(new Date(2025, 0, 1));
     expect(typeof result).toBe("string");
     expect(result.length > 0).toBe(true);
+  });
+
+  test("format uses the current date for omitted and undefined values", () => {
+    const dtf = new Intl.DateTimeFormat("en-US", { timeZone: "UTC" });
+    expectCurrentDateResult(() => dtf.format(), (value) => dtf.format(value));
+    expectCurrentDateResult(() => dtf.format(undefined), (value) => dtf.format(value));
+  });
+
+  test("format rejects invalid numeric dates", () => {
+    const dtf = new Intl.DateTimeFormat("en-US");
+    expect(() => dtf.format(NaN)).toThrow(RangeError);
   });
 });

--- a/tests/built-ins/Intl/DateTimeFormat/prototype/formatToParts.js
+++ b/tests/built-ins/Intl/DateTimeFormat/prototype/formatToParts.js
@@ -1,0 +1,33 @@
+/*---
+description: Intl.DateTimeFormat.prototype.formatToParts
+features: [Intl]
+---*/
+
+const isIntl = typeof Intl !== "undefined";
+
+const partsString = (parts) => {
+  return parts.map((part) => part.value).join("");
+};
+
+const expectCurrentDateParts = (readActual, formatAt) => {
+  const before = Date.now();
+  const actual = partsString(readActual());
+  const after = Date.now();
+  const beforeFormatted = partsString(formatAt(before));
+  const afterFormatted = partsString(formatAt(after));
+
+  expect(actual === beforeFormatted || actual === afterFormatted).toBe(true);
+};
+
+describe.runIf(isIntl)("Intl.DateTimeFormat.prototype.formatToParts", () => {
+  test("formatToParts uses the current date for omitted and undefined values", () => {
+    const dtf = new Intl.DateTimeFormat("en-US", { timeZone: "UTC" });
+    expectCurrentDateParts(() => dtf.formatToParts(), (value) => dtf.formatToParts(value));
+    expectCurrentDateParts(() => dtf.formatToParts(undefined), (value) => dtf.formatToParts(value));
+  });
+
+  test("formatToParts rejects invalid numeric dates", () => {
+    const dtf = new Intl.DateTimeFormat("en-US");
+    expect(() => dtf.formatToParts(NaN)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Intl/NumberFormat/prototype/format.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/format.js
@@ -6,6 +6,33 @@ features: [Intl]
 const isIntl = typeof Intl !== "undefined";
 
 describe.runIf(isIntl)("Intl.NumberFormat.prototype.format", () => {
+  test("format is an accessor property on the prototype", () => {
+    const desc = Object.getOwnPropertyDescriptor(Intl.NumberFormat.prototype, "format");
+    expect(typeof desc.get).toBe("function");
+    expect(desc.set).toBe(undefined);
+    expect(desc.value).toBe(undefined);
+    expect(desc.enumerable).toBe(false);
+    expect(desc.configurable).toBe(true);
+  });
+
+  test("format getter returns a cached bound function", () => {
+    const nf = new Intl.NumberFormat("en-US");
+    const first = nf.format;
+    const second = nf.format;
+
+    expect(typeof first).toBe("function");
+    expect(first).toBe(second);
+    expect(first(1234)).toBe(nf.format(1234));
+    expect(Object.prototype.hasOwnProperty.call(nf, "format")).toBe(false);
+  });
+
+  test("format getter creates distinct functions for distinct instances", () => {
+    const first = new Intl.NumberFormat("en-US").format;
+    const second = new Intl.NumberFormat("en-US").format;
+
+    expect(first === second).toBe(false);
+  });
+
   test("format returns a string", () => {
     const nf = new Intl.NumberFormat("en-US");
     const result = nf.format(1234.56);

--- a/tests/built-ins/Intl/NumberFormat/prototype/format.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/format.js
@@ -39,6 +39,12 @@ describe.runIf(isIntl)("Intl.NumberFormat.prototype.format", () => {
     expect(typeof result).toBe("string");
   });
 
+  test("format converts omitted and undefined values to NaN", () => {
+    const nf = new Intl.NumberFormat("en-US");
+    expect(nf.format()).toBe("NaN");
+    expect(nf.format(undefined)).toBe("NaN");
+  });
+
   test("format includes grouping separator for large numbers", () => {
     const nf = new Intl.NumberFormat("en-US");
     const result = nf.format(1234567);

--- a/tests/built-ins/Intl/NumberFormat/prototype/formatToParts.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/formatToParts.js
@@ -1,0 +1,18 @@
+/*---
+description: Intl.NumberFormat.prototype.formatToParts
+features: [Intl]
+---*/
+
+const isIntl = typeof Intl !== "undefined";
+
+const partsString = (parts) => {
+  return parts.map((part) => part.value).join("");
+};
+
+describe.runIf(isIntl)("Intl.NumberFormat.prototype.formatToParts", () => {
+  test("formatToParts converts omitted and undefined values to NaN", () => {
+    const nf = new Intl.NumberFormat("en-US");
+    expect(partsString(nf.formatToParts())).toBe("NaN");
+    expect(partsString(nf.formatToParts(undefined))).toBe("NaN");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Register `Intl.NumberFormat.prototype.format`, `Intl.DateTimeFormat.prototype.format`, and `Intl.Collator.prototype.compare` as accessor properties with undefined setters.
- Cache anonymous bound functions in internal value fields so detached callbacks work without exposing own `format`/`compare` properties.
- Align single-value Intl formatting defaults with ECMA-402 and current engine behavior: `NumberFormat` formats omitted/`undefined` as `NaN`, while `DateTimeFormat` formats omitted/`undefined` dates using the current time.
- Add end-to-end Intl tests for descriptor shape, cached getter results, distinct instance functions, detached callback behavior, and default-argument semantics.
- Closes #604.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas testrunner && ./build/GocciaTestRunner tests`
  - `./build/GocciaTestRunner tests/built-ins/Intl`
  - `./build/GocciaTestRunner tests/built-ins/Intl/NumberFormat/prototype/format.js`
  - `./build/GocciaTestRunner tests/built-ins/Intl/NumberFormat/prototype/formatToParts.js`
  - `./build/GocciaTestRunner tests/built-ins/Intl/DateTimeFormat/prototype/format.js`
  - `./build/GocciaTestRunner tests/built-ins/Intl/DateTimeFormat/prototype/formatToParts.js`
  - `./format.pas --check`
- [ ] Updated documentation
  - Runtime conformance fix only; no user-facing docs changed.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
