### PR TITLE
Support dynamic import call phases

### DIFF
--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -33,6 +33,7 @@ TGocciaEvaluationContext = record
   Scope: TGocciaScope;
   OnError: TGocciaThrowErrorCallback;
   LoadModule: TLoadModuleCallback;
+  LoadModuleSource: TLoadModuleSourceCallback;
   CurrentFilePath: string;
   CoverageEnabled: Boolean;
   DisposalTracker: TObject; // TGocciaDisposalTracker or nil

--- a/docs/language.md
+++ b/docs/language.md
@@ -260,6 +260,8 @@ const helperUrl = import.meta.resolve("./helpers/math.js");
 
 Dynamic `import()` (ES2026 §13.3.10) is supported. It accepts an arbitrary expression as the module specifier, loads the module synchronously, and returns a Promise that resolves with the module namespace object. On failure, the returned Promise is rejected with the error. Dynamic imports work anywhere expressions are valid — including inside functions, conditionals, and async callbacks.
 
+The parser accepts import attributes syntax (`import(specifier, options)`) and trailing commas. The options expression is evaluated for side effects, but GocciaScript does not consume import attributes semantically yet. Proposal-phase `import.source(specifier)` resolves with a `ModuleSource` object without evaluating the module, and `import.defer(specifier)` resolves with a namespace object that evaluates the module when its exports are observed.
+
 ```javascript
 // Dynamic import with a computed specifier
 const moduleName = "./helpers/math.js";
@@ -270,6 +272,13 @@ console.log(mod.add(2, 3)); // 5
 import("./config.json").then((config) => {
   console.log(config.name);
 });
+
+// Import attributes syntax is accepted; attributes are not interpreted yet.
+const json = await import("./config.json", { with: { type: "json" } });
+
+// Proposal-phase call forms are accepted.
+const sourcePromise = import.source("./helpers/math.js");
+const deferredPromise = import.defer("./helpers/math.js");
 ```
 
 ### Data Structures

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -13,6 +13,7 @@ uses
 
   Goccia.AST.Node,
   Goccia.Evaluator.Context,
+  Goccia.Modules,
   Goccia.Scope.BindingMap,
   Goccia.Token,
   Goccia.Values.Primitives;
@@ -487,10 +488,15 @@ type
   TGocciaImportCallExpression = class(TGocciaExpression)
   private
     FSpecifier: TGocciaExpression;
+    FOptions: TGocciaExpression;
+    FPhase: TGocciaImportCallPhase;
   public
-    constructor Create(const ASpecifier: TGocciaExpression; const ALine, AColumn: Integer);
+    constructor Create(const ASpecifier: TGocciaExpression; const AOptions: TGocciaExpression;
+      const APhase: TGocciaImportCallPhase; const ALine, AColumn: Integer);
     function Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue; override;
     property Specifier: TGocciaExpression read FSpecifier;
+    property Options: TGocciaExpression read FOptions;
+    property Phase: TGocciaImportCallPhase read FPhase;
   end;
 
   TGocciaHoleExpression = class(TGocciaExpression)
@@ -866,7 +872,6 @@ uses
   Goccia.Evaluator.PatternMatching,
   Goccia.GarbageCollector,
   Goccia.ImportMeta,
-  Goccia.Modules,
   Goccia.RegExp.Runtime,
   Goccia.Scope,
   Goccia.Values.BigIntValue,
@@ -2083,10 +2088,14 @@ begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
-constructor TGocciaImportCallExpression.Create(const ASpecifier: TGocciaExpression; const ALine, AColumn: Integer);
+constructor TGocciaImportCallExpression.Create(const ASpecifier: TGocciaExpression;
+  const AOptions: TGocciaExpression; const APhase: TGocciaImportCallPhase;
+  const ALine, AColumn: Integer);
 begin
   inherited Create(ALine, AColumn);
   FSpecifier := ASpecifier;
+  FOptions := AOptions;
+  FPhase := APhase;
 end;
 
 // ES2026 §13.3.10.1 Runtime Semantics: Evaluation — ImportCall
@@ -2105,11 +2114,33 @@ begin
     try
       // ES2026 §13.3.10.1 step 3: Evaluate specifier
       SpecifierValue := EvaluateExpression(FSpecifier, AContext);
-      // ES2026 §13.3.10.1 step 6-7: HostLoadImportedModule
-      Module := AContext.LoadModule(SpecifierValue.ToStringLiteral.Value,
-        AContext.CurrentFilePath);
-      // ES2026 §13.3.10.1 step 11: Resolve promise with namespace
-      Promise.Resolve(Module.GetNamespaceObject);
+      // ES2026 §13.3.10.1: optional import attributes are evaluated for
+      // observable side effects. Goccia does not consume them semantically yet.
+      if Assigned(FOptions) then
+        EvaluateExpression(FOptions, AContext);
+
+      case FPhase of
+        icpSource:
+          begin
+            if not Assigned(AContext.LoadModuleSource) then
+              raise Exception.Create('Module source loader is not available.');
+            Promise.Resolve(AContext.LoadModuleSource(
+              SpecifierValue.ToStringLiteral.Value, AContext.CurrentFilePath));
+          end;
+        icpDefer:
+          begin
+            if not Assigned(AContext.Scope.LoadDeferredModule) then
+              raise Exception.Create('Deferred module loader is not available.');
+            Promise.Resolve(AContext.Scope.LoadDeferredModule(
+              SpecifierValue.ToStringLiteral.Value, AContext.CurrentFilePath));
+          end;
+      else
+        // ES2026 §13.3.10.1 step 6-7: HostLoadImportedModule
+        Module := AContext.LoadModule(SpecifierValue.ToStringLiteral.Value,
+          AContext.CurrentFilePath);
+        // ES2026 §13.3.10.1 step 11: Resolve promise with namespace
+        Promise.Resolve(Module.GetNamespaceObject);
+      end;
     except
       on E: TGocciaThrowValue do
         Promise.Reject(E.Value);

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -3821,15 +3821,23 @@ begin
   EmitInstruction(ACtx, EncodeABC(OP_NEW_TARGET, ADest, 0, 0));
 end;
 
-// ES2026 §13.3.10 ImportCall — import(specifier)
+// ES2026 §13.3.10 ImportCall — import(specifier [, options])
 procedure CompileDynamicImport(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaImportCallExpression; const ADest: UInt8);
 var
   SpecReg: UInt8;
+  OptionsReg: UInt8;
 begin
   SpecReg := ACtx.Scope.AllocateRegister;
   ACtx.CompileExpression(AExpr.Specifier, SpecReg);
-  EmitInstruction(ACtx, EncodeABC(OP_DYNAMIC_IMPORT, ADest, SpecReg, 0));
+  if Assigned(AExpr.Options) then
+  begin
+    OptionsReg := ACtx.Scope.AllocateRegister;
+    ACtx.CompileExpression(AExpr.Options, OptionsReg);
+    ACtx.Scope.FreeRegister;
+  end;
+  EmitInstruction(ACtx, EncodeABC(OP_DYNAMIC_IMPORT, ADest, SpecReg,
+    Ord(AExpr.Phase)));
   ACtx.Scope.FreeRegister;
 end;
 

--- a/source/units/Goccia.Evaluator.Context.pas
+++ b/source/units/Goccia.Evaluator.Context.pas
@@ -14,6 +14,7 @@ type
     Scope: TGocciaScope;
     OnError: TGocciaThrowErrorCallback;
     LoadModule: TLoadModuleCallback;
+    LoadModuleSource: TLoadModuleSourceCallback;
     CurrentFilePath: string;
     CoverageEnabled: Boolean;
     StrictTypes: Boolean;

--- a/source/units/Goccia.Executor.Bytecode.pas
+++ b/source/units/Goccia.Executor.Bytecode.pas
@@ -86,6 +86,8 @@ begin
   FVM.GlobalScope := AGlobalScope;
   FVM.GlobalThisValue := AGlobalScope.ThisValue;
   FVM.LoadModule := AModuleLoader.LoadModule;
+  FVM.LoadModuleSource := AModuleLoader.LoadModuleSourceValue;
+  FVM.LoadDeferredModule := AModuleLoader.LoadDeferredModuleNamespaceValue;
   AModuleLoader.EvaluateModuleBody := EvaluateModuleBody;
 end;
 

--- a/source/units/Goccia.Interpreter.pas
+++ b/source/units/Goccia.Interpreter.pas
@@ -66,6 +66,10 @@ type
     destructor Destroy; override;
     function Execute(const AProgram: TGocciaProgram): TGocciaValue;
     function LoadModule(const AModulePath, AImportingFilePath: string): TGocciaModule;
+    function LoadModuleSourceValue(
+      const AModulePath, AImportingFilePath: string): TGocciaValue;
+    function LoadDeferredModuleNamespaceValue(
+      const AModulePath, AImportingFilePath: string): TGocciaValue;
 
     property ASIEnabled: Boolean read FASIEnabled write SetASIEnabled;
     property VarEnabled: Boolean read FVarEnabled write SetVarEnabled;
@@ -124,6 +128,8 @@ begin
   FModuleLoader.BindRuntime(FGlobalScope, ThrowError);
   FModuleLoader.EvaluateModuleBody := EvaluateModuleBody;
   FGlobalScope.LoadModule := LoadModule;
+  FGlobalScope.LoadModuleSource := LoadModuleSourceValue;
+  FGlobalScope.LoadDeferredModule := LoadDeferredModuleNamespaceValue;
 end;
 
 destructor TGocciaInterpreter.Destroy;
@@ -145,6 +151,7 @@ begin
   Result.Scope := FGlobalScope;
   Result.OnError := ThrowError;
   Result.LoadModule := LoadModule;
+  Result.LoadModuleSource := LoadModuleSourceValue;
   Result.CurrentFilePath := FFileName;
   Result.CoverageEnabled := Assigned(TGocciaCoverageTracker.Instance)
     and TGocciaCoverageTracker.Instance.Enabled;
@@ -179,6 +186,19 @@ end;
 function TGocciaInterpreter.LoadModule(const AModulePath, AImportingFilePath: string): TGocciaModule;
 begin
   Result := FModuleLoader.LoadModule(AModulePath, AImportingFilePath);
+end;
+
+function TGocciaInterpreter.LoadModuleSourceValue(
+  const AModulePath, AImportingFilePath: string): TGocciaValue;
+begin
+  Result := FModuleLoader.LoadModuleSourceValue(AModulePath, AImportingFilePath);
+end;
+
+function TGocciaInterpreter.LoadDeferredModuleNamespaceValue(
+  const AModulePath, AImportingFilePath: string): TGocciaValue;
+begin
+  Result := FModuleLoader.LoadDeferredModuleNamespaceValue(AModulePath,
+    AImportingFilePath);
 end;
 
 function TGocciaInterpreter.GetContentProvider: TGocciaModuleContentProvider;

--- a/source/units/Goccia.Keywords.Contextual.pas
+++ b/source/units/Goccia.Keywords.Contextual.pas
@@ -10,6 +10,7 @@ const
   KEYWORD_DEFER        = 'defer';
   KEYWORD_FROM         = 'from';
   KEYWORD_META         = 'meta';
+  KEYWORD_SOURCE       = 'source';
 
   // Meta-properties
   KEYWORD_TARGET       = 'target';

--- a/source/units/Goccia.Modules.Loader.pas
+++ b/source/units/Goccia.Modules.Loader.pas
@@ -78,6 +78,10 @@ type
     procedure CheckForModuleReload(const AModule: TGocciaModule);
     function LoadModule(const AModulePath,
       AImportingFilePath: string): TGocciaModule;
+    function LoadModuleSourceValue(const AModulePath,
+      AImportingFilePath: string): TGocciaValue;
+    function LoadDeferredModuleNamespaceValue(const AModulePath,
+      AImportingFilePath: string): TGocciaValue;
     procedure SetContentProvider(
       const AContentProvider: TGocciaModuleContentProvider;
       const AOwnsContentProvider: Boolean);
@@ -427,6 +431,7 @@ begin
           Context.Scope := ModuleScope;
           Context.OnError := FOnError;
           Context.LoadModule := LoadModule;
+          Context.LoadModuleSource := LoadModuleSourceValue;
           Context.CurrentFilePath := ResolvedPath;
           Context.CoverageEnabled := False;
           Context.StrictTypes := FStrictTypesEnabled;
@@ -522,6 +527,64 @@ begin
   finally
     Content.Free;
   end;
+end;
+
+function TGocciaModuleLoader.LoadModuleSourceValue(const AModulePath,
+  AImportingFilePath: string): TGocciaValue;
+var
+  Content: TGocciaModuleContent;
+  ResolvedPath: string;
+begin
+  try
+    if Assigned(FResolver) then
+      ResolvedPath := FResolver.Resolve(AModulePath, AImportingFilePath)
+    else
+      raise EGocciaModuleNotFound.CreateFmt(
+        'No module resolver configured and cannot resolve "%s"', [AModulePath]);
+  except
+    on E: TGocciaRuntimeError do
+      raise;
+    on E: Exception do
+      raise TGocciaRuntimeError.Create(E.Message, 0, 0, AImportingFilePath, nil);
+  end;
+
+  if not IsScriptExtension(ExtractFileExt(ResolvedPath)) then
+    raise TGocciaSyntaxError.Create(
+      Format('Module source is not available for "%s"', [ResolvedPath]),
+      0, 0, AImportingFilePath, nil);
+
+  Content := FContentProvider.LoadContent(ResolvedPath);
+  try
+    Result := TGocciaModuleSourceValue.Create(ResolvedPath, Content.Text);
+  finally
+    Content.Free;
+  end;
+end;
+
+function TGocciaModuleLoader.LoadDeferredModuleNamespaceValue(
+  const AModulePath, AImportingFilePath: string): TGocciaValue;
+var
+  ResolvedPath: string;
+begin
+  if FGlobalModules.ContainsKey(AModulePath) then
+    Exit(TGocciaDeferredModuleNamespaceObject.Create(AModulePath,
+      AImportingFilePath, LoadModule));
+
+  try
+    if Assigned(FResolver) then
+      ResolvedPath := FResolver.Resolve(AModulePath, AImportingFilePath)
+    else
+      raise EGocciaModuleNotFound.CreateFmt(
+        'No module resolver configured and cannot resolve "%s"', [AModulePath]);
+  except
+    on E: TGocciaRuntimeError do
+      raise;
+    on E: Exception do
+      raise TGocciaRuntimeError.Create(E.Message, 0, 0, AImportingFilePath, nil);
+  end;
+
+  Result := TGocciaDeferredModuleNamespaceObject.Create(ResolvedPath,
+    AImportingFilePath, LoadModule);
 end;
 
 procedure TGocciaModuleLoader.CheckForModuleReload(const AModule: TGocciaModule);

--- a/source/units/Goccia.Modules.pas
+++ b/source/units/Goccia.Modules.pas
@@ -5,6 +5,7 @@ unit Goccia.Modules;
 interface
 
 uses
+  Generics.Collections,
   SysUtils,
 
   OrderedStringMap,
@@ -15,6 +16,14 @@ uses
   Goccia.Values.Primitives;
 
 type
+  TGocciaImportCallPhase = (icpEvaluation, icpSource, icpDefer);
+  TGocciaModule = class;
+  TLoadModuleCallback = function(const AModulePath, AImportingFilePath: string): TGocciaModule of object;
+  TLoadModuleSourceCallback = function(const AModulePath,
+    AImportingFilePath: string): TGocciaValue of object;
+  TLoadDeferredModuleCallback = function(const AModulePath,
+    AImportingFilePath: string): TGocciaValue of object;
+
   TGocciaModule = class
   private
     FPath: string;
@@ -31,9 +40,47 @@ type
     property LastModified: TDateTime read FLastModified write FLastModified;
   end;
 
-  TLoadModuleCallback = function(const AModulePath, AImportingFilePath: string): TGocciaModule of object;
+  TGocciaModuleSourceValue = class(TGocciaObjectValue)
+  private
+    FPath: string;
+    FSourceText: UTF8String;
+  public
+    constructor Create(const APath: string; const ASourceText: UTF8String);
+    function ToStringTag: string; override;
+    property Path: string read FPath;
+    property SourceText: UTF8String read FSourceText;
+  end;
+
+  TGocciaDeferredModuleNamespaceObject = class(TGocciaObjectValue)
+  private
+    FModulePath: string;
+    FImportingFilePath: string;
+    FLoadModule: TLoadModuleCallback;
+    FNamespaceObject: TGocciaObjectValue;
+    function EnsureNamespaceObject: TGocciaObjectValue;
+  public
+    constructor Create(const AModulePath, AImportingFilePath: string;
+      const ALoadModule: TLoadModuleCallback);
+    function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string;
+      const AThisContext: TGocciaValue): TGocciaValue; override;
+    function GetOwnPropertyDescriptor(
+      const AName: string): TGocciaPropertyDescriptor; override;
+    function HasProperty(const AName: string): Boolean; override;
+    function HasOwnProperty(const AName: string): Boolean; override;
+    function GetEnumerablePropertyNames: TArray<string>; override;
+    function GetEnumerablePropertyValues: TArray<TGocciaValue>; override;
+    function GetEnumerablePropertyEntries: TArray<TPair<string, TGocciaValue>>; override;
+    function GetAllPropertyNames: TArray<string>; override;
+    function GetOwnPropertyNames: TArray<string>; override;
+    function GetOwnPropertyKeys: TArray<string>; override;
+    procedure MarkReferences; override;
+  end;
 
 implementation
+
+uses
+  Goccia.Constants.PropertyNames;
 
 constructor TGocciaModule.Create(const APath: string);
 begin
@@ -76,5 +123,123 @@ begin
   inherited;
 end;
 
+{ TGocciaModuleSourceValue }
+
+constructor TGocciaModuleSourceValue.Create(const APath: string;
+  const ASourceText: UTF8String);
+begin
+  inherited Create(nil);
+  FPath := APath;
+  FSourceText := ASourceText;
+  Freeze;
+end;
+
+function TGocciaModuleSourceValue.ToStringTag: string;
+begin
+  Result := 'ModuleSource';
+end;
+
+{ TGocciaDeferredModuleNamespaceObject }
+
+constructor TGocciaDeferredModuleNamespaceObject.Create(
+  const AModulePath, AImportingFilePath: string;
+  const ALoadModule: TLoadModuleCallback);
+begin
+  inherited Create(nil);
+  FModulePath := AModulePath;
+  FImportingFilePath := AImportingFilePath;
+  FLoadModule := ALoadModule;
+  Freeze;
+end;
+
+function TGocciaDeferredModuleNamespaceObject.EnsureNamespaceObject: TGocciaObjectValue;
+var
+  Module: TGocciaModule;
+begin
+  if not Assigned(FNamespaceObject) then
+  begin
+    if not Assigned(FLoadModule) then
+      raise Exception.Create('Module loader is not available.');
+    Module := FLoadModule(FModulePath, FImportingFilePath);
+    FNamespaceObject := Module.GetNamespaceObject;
+  end;
+  Result := FNamespaceObject;
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetProperty(
+  const AName: string): TGocciaValue;
+begin
+  if (AName = PROP_THEN) and not Assigned(FNamespaceObject) then
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  Result := EnsureNamespaceObject.GetProperty(AName);
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetPropertyWithContext(
+  const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
+  Result := EnsureNamespaceObject.GetPropertyWithContext(AName, AThisContext);
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetOwnPropertyDescriptor(
+  const AName: string): TGocciaPropertyDescriptor;
+begin
+  Result := EnsureNamespaceObject.GetOwnPropertyDescriptor(AName);
+end;
+
+function TGocciaDeferredModuleNamespaceObject.HasProperty(
+  const AName: string): Boolean;
+begin
+  Result := EnsureNamespaceObject.HasProperty(AName);
+end;
+
+function TGocciaDeferredModuleNamespaceObject.HasOwnProperty(
+  const AName: string): Boolean;
+begin
+  Result := EnsureNamespaceObject.HasOwnProperty(AName);
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetEnumerablePropertyNames:
+  TArray<string>;
+begin
+  Result := EnsureNamespaceObject.GetEnumerablePropertyNames;
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetEnumerablePropertyValues:
+  TArray<TGocciaValue>;
+begin
+  Result := EnsureNamespaceObject.GetEnumerablePropertyValues;
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetEnumerablePropertyEntries:
+  TArray<TPair<string, TGocciaValue>>;
+begin
+  Result := EnsureNamespaceObject.GetEnumerablePropertyEntries;
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetAllPropertyNames:
+  TArray<string>;
+begin
+  Result := EnsureNamespaceObject.GetAllPropertyNames;
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetOwnPropertyNames:
+  TArray<string>;
+begin
+  Result := EnsureNamespaceObject.GetOwnPropertyNames;
+end;
+
+function TGocciaDeferredModuleNamespaceObject.GetOwnPropertyKeys:
+  TArray<string>;
+begin
+  Result := EnsureNamespaceObject.GetOwnPropertyKeys;
+end;
+
+procedure TGocciaDeferredModuleNamespaceObject.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FNamespaceObject) then
+    FNamespaceObject.MarkReferences;
+end;
 
 end.

--- a/source/units/Goccia.Modules.pas
+++ b/source/units/Goccia.Modules.pas
@@ -161,6 +161,10 @@ begin
     if not Assigned(FLoadModule) then
       raise Exception.Create('Module loader is not available.');
     Module := FLoadModule(FModulePath, FImportingFilePath);
+    if not Assigned(Module) then
+      raise Exception.CreateFmt(
+        'Module loader returned nil for "%s" imported from "%s".',
+        [FModulePath, FImportingFilePath]);
     FNamespaceObject := Module.GetNamespaceObject;
   end;
   Result := FNamespaceObject;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -14,6 +14,7 @@ uses
   Goccia.AST.Expressions,
   Goccia.AST.Node,
   Goccia.AST.Statements,
+  Goccia.Modules,
   Goccia.Token,
   Goccia.Values.Primitives;
 
@@ -196,6 +197,8 @@ type
       const ATemplateToken: TGocciaToken;
       const ALine, AColumn: Integer): TGocciaTaggedTemplateExpression;
     function ParseTemplateLiteral(const AToken: TGocciaToken): TGocciaExpression;
+    function ParseImportCallExpression(const AToken: TGocciaToken;
+      const APhase: TGocciaImportCallPhase): TGocciaImportCallExpression;
     function Primary: TGocciaExpression;
     function ArrayLiteral: TGocciaExpression;
     function ObjectLiteral: TGocciaExpression;
@@ -1720,6 +1723,33 @@ begin
   Result := TGocciaTemplateWithInterpolationExpression.Create(Parts, AToken.Line, AToken.Column);
 end;
 
+// ES2026 §13.3.10 ImportCall — import(specifier [, options] [,])
+function TGocciaParser.ParseImportCallExpression(const AToken: TGocciaToken;
+  const APhase: TGocciaImportCallPhase): TGocciaImportCallExpression;
+var
+  Specifier: TGocciaExpression;
+  Options: TGocciaExpression;
+begin
+  Consume(gttLeftParen, 'Expected "(" after import call phase',
+    SSuggestDynamicImportSyntax);
+  Specifier := Assignment;
+  Options := nil;
+
+  if Match(gttComma) then
+  begin
+    if not Check(gttRightParen) then
+    begin
+      Options := Assignment;
+      Match(gttComma);
+    end;
+  end;
+
+  Consume(gttRightParen, 'Expected ")" after import() specifier',
+    SSuggestDynamicImportSyntax);
+  Result := TGocciaImportCallExpression.Create(Specifier, Options, APhase,
+    AToken.Line, AToken.Column);
+end;
+
 function TGocciaParser.Primary: TGocciaExpression;
 const
   REGEX_SEPARATOR = #0;
@@ -1805,27 +1835,32 @@ begin
       begin
         Token := Advance;
         if Check(gttLeftParen) then
-        begin
-          // ES2026 §13.3.10 ImportCall — import(specifier)
-          Advance; // consume '('
-          Expr := Assignment;
-          Consume(gttRightParen, 'Expected ")" after import() specifier',
-            SSuggestDynamicImportSyntax);
-          Result := TGocciaImportCallExpression.Create(Expr, Token.Line, Token.Column);
-        end
+          Result := ParseImportCallExpression(Token, icpEvaluation)
         else
         begin
-          // ES2026 §13.3.12 MetaProperty — import.meta
           Consume(gttDot, 'Expected "." or "(" after "import" in expression context',
             SSuggestDynamicImportSyntax);
           if CheckUnescapedIdentifierKeyword(KEYWORD_META) then
           begin
+            // ES2026 §13.3.12 MetaProperty — import.meta
             Advance;
             Result := TGocciaImportMetaExpression.Create(Token.Line, Token.Column);
           end
+          else if CheckUnescapedIdentifierKeyword(KEYWORD_SOURCE) then
+          begin
+            // TC39 Source Phase Imports — import.source(specifier)
+            Advance;
+            Result := ParseImportCallExpression(Token, icpSource);
+          end
+          else if CheckUnescapedIdentifierKeyword(KEYWORD_DEFER) then
+          begin
+            // TC39 Deferred Imports Evaluation — import.defer(specifier)
+            Advance;
+            Result := ParseImportCallExpression(Token, icpDefer);
+          end
           else
             raise TGocciaSyntaxError.Create(
-              'The only valid meta property for import is "import.meta"',
+              'Expected "meta", "source", or "defer" after "import."',
               Peek.Line, Peek.Column, FFileName, FSourceLines,
               SSuggestImportMetaSyntax);
         end;

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -35,6 +35,8 @@ type
     FCustomLabel: string;
     FOnError: TGocciaThrowErrorCallback;
     FLoadModule: TLoadModuleCallback;
+    FLoadModuleSource: TLoadModuleSourceCallback;
+    FLoadDeferredModule: TLoadDeferredModuleCallback;
     FStrictTypes: Boolean;
     FNonStrictMode: Boolean;
   protected
@@ -111,6 +113,10 @@ type
     property CustomLabel: string read FCustomLabel;
     property OnError: TGocciaThrowErrorCallback read FOnError write FOnError;
     property LoadModule: TLoadModuleCallback read FLoadModule write FLoadModule;
+    property LoadModuleSource: TLoadModuleSourceCallback
+      read FLoadModuleSource write FLoadModuleSource;
+    property LoadDeferredModule: TLoadDeferredModuleCallback
+      read FLoadDeferredModule write FLoadDeferredModule;
     { Strict-types enforcement flag.  Inherited from parent at scope
       creation so nested closures observe the same setting as the
       surrounding lexical scope.  For live engine state use
@@ -241,6 +247,8 @@ begin
   begin
     FOnError := AParent.FOnError;
     FLoadModule := AParent.FLoadModule;
+    FLoadModuleSource := AParent.FLoadModuleSource;
+    FLoadDeferredModule := AParent.FLoadDeferredModule;
     FStrictTypes := AParent.FStrictTypes;
     FNonStrictMode := AParent.FNonStrictMode;
   end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -91,6 +91,8 @@ type
     FGlobalScope: TGocciaScope;
     FGlobalThisValue: TGocciaValue;
     FLoadModule: TLoadModuleCallback;
+    FLoadModuleSource: TLoadModuleSourceCallback;
+    FLoadDeferredModule: TLoadDeferredModuleCallback;
     FCurrentClosure: TGocciaBytecodeClosure;
     FHandlerStack: TGocciaBytecodeHandlerStack;
     FFrameDepth: Integer;
@@ -166,6 +168,9 @@ type
       const AArguments: TGocciaArgumentsCollection): TGocciaValue;
     function ImportModuleValue(const APath: string): TGocciaValue; overload;
     function ImportModuleValue(const APath, AReferrer: string): TGocciaValue; overload;
+    function ImportModuleSourceValue(const APath, AReferrer: string): TGocciaValue;
+    function ImportDeferredModuleNamespaceValue(const APath,
+      AReferrer: string): TGocciaValue;
     procedure ExportBindingValue(const AName: string; const AValue: TGocciaValue);
     procedure DefineGetterProperty(const ATarget: TGocciaValue; const AName: string;
       const AGetter: TGocciaValue);
@@ -279,6 +284,10 @@ type
     property GlobalScope: TGocciaScope read FGlobalScope write FGlobalScope;
     property GlobalThisValue: TGocciaValue read FGlobalThisValue write FGlobalThisValue;
     property LoadModule: TLoadModuleCallback read FLoadModule write FLoadModule;
+    property LoadModuleSource: TLoadModuleSourceCallback
+      read FLoadModuleSource write FLoadModuleSource;
+    property LoadDeferredModule: TLoadDeferredModuleCallback
+      read FLoadDeferredModule write FLoadDeferredModule;
     property CoverageEnabled: Boolean read FCoverageEnabled write FCoverageEnabled;
     property ProfilingOpcodes: Boolean read FProfilingOpcodes write FProfilingOpcodes;
     property ProfilingFunctions: Boolean read FProfilingFunctions write FProfilingFunctions;
@@ -5147,6 +5156,23 @@ begin
 
   Module := FLoadModule(APath, AReferrer);
   Result := CreateModuleNamespaceObject(Module);
+end;
+
+function TGocciaVM.ImportModuleSourceValue(const APath, AReferrer: string): TGocciaValue;
+begin
+  if not Assigned(FLoadModuleSource) then
+    ThrowTypeError(SErrorModuleNotAvailableInVM);
+
+  Result := FLoadModuleSource(APath, AReferrer);
+end;
+
+function TGocciaVM.ImportDeferredModuleNamespaceValue(const APath,
+  AReferrer: string): TGocciaValue;
+begin
+  if not Assigned(FLoadDeferredModule) then
+    ThrowTypeError(SErrorModuleNotAvailableInVM);
+
+  Result := FLoadDeferredModule(APath, AReferrer);
 end;
 
 procedure TGocciaVM.ExportBindingValue(const AName: string; const AValue: TGocciaValue);
@@ -10142,13 +10168,39 @@ begin
         try
           try
             if Assigned(Template.DebugInfo) and (Template.DebugInfo.SourceFile <> '') then
-              DynImportPromise.Resolve(ImportModuleValue(
-                VMRegisterToStringFast(FRegisters[B]).Value,
-                Template.DebugInfo.SourceFile))
+            begin
+              case C of
+                Ord(icpSource):
+                  DynImportPromise.Resolve(ImportModuleSourceValue(
+                    VMRegisterToStringFast(FRegisters[B]).Value,
+                    Template.DebugInfo.SourceFile));
+                Ord(icpDefer):
+                  DynImportPromise.Resolve(ImportDeferredModuleNamespaceValue(
+                    VMRegisterToStringFast(FRegisters[B]).Value,
+                    Template.DebugInfo.SourceFile));
+              else
+                DynImportPromise.Resolve(ImportModuleValue(
+                  VMRegisterToStringFast(FRegisters[B]).Value,
+                  Template.DebugInfo.SourceFile));
+              end;
+            end
             else
-              DynImportPromise.Resolve(ImportModuleValue(
-                VMRegisterToStringFast(FRegisters[B]).Value,
-                FCurrentModuleSourcePath));
+            begin
+              case C of
+                Ord(icpSource):
+                  DynImportPromise.Resolve(ImportModuleSourceValue(
+                    VMRegisterToStringFast(FRegisters[B]).Value,
+                    FCurrentModuleSourcePath));
+                Ord(icpDefer):
+                  DynImportPromise.Resolve(ImportDeferredModuleNamespaceValue(
+                    VMRegisterToStringFast(FRegisters[B]).Value,
+                    FCurrentModuleSourcePath));
+              else
+                DynImportPromise.Resolve(ImportModuleValue(
+                  VMRegisterToStringFast(FRegisters[B]).Value,
+                  FCurrentModuleSourcePath));
+              end;
+            end;
           except
             on E: EGocciaBytecodeThrow do
               DynImportPromise.Reject(E.ThrownValue);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -10168,38 +10168,23 @@ begin
         try
           try
             if Assigned(Template.DebugInfo) and (Template.DebugInfo.SourceFile <> '') then
-            begin
-              case C of
-                Ord(icpSource):
-                  DynImportPromise.Resolve(ImportModuleSourceValue(
-                    VMRegisterToStringFast(FRegisters[B]).Value,
-                    Template.DebugInfo.SourceFile));
-                Ord(icpDefer):
-                  DynImportPromise.Resolve(ImportDeferredModuleNamespaceValue(
-                    VMRegisterToStringFast(FRegisters[B]).Value,
-                    Template.DebugInfo.SourceFile));
-              else
-                DynImportPromise.Resolve(ImportModuleValue(
-                  VMRegisterToStringFast(FRegisters[B]).Value,
-                  Template.DebugInfo.SourceFile));
-              end;
-            end
+              GlobalName := Template.DebugInfo.SourceFile
             else
-            begin
-              case C of
-                Ord(icpSource):
-                  DynImportPromise.Resolve(ImportModuleSourceValue(
-                    VMRegisterToStringFast(FRegisters[B]).Value,
-                    FCurrentModuleSourcePath));
-                Ord(icpDefer):
-                  DynImportPromise.Resolve(ImportDeferredModuleNamespaceValue(
-                    VMRegisterToStringFast(FRegisters[B]).Value,
-                    FCurrentModuleSourcePath));
-              else
+              GlobalName := FCurrentModuleSourcePath;
+
+            case C of
+              Ord(icpEvaluation):
                 DynImportPromise.Resolve(ImportModuleValue(
-                  VMRegisterToStringFast(FRegisters[B]).Value,
-                  FCurrentModuleSourcePath));
-              end;
+                  VMRegisterToStringFast(FRegisters[B]).Value, GlobalName));
+              Ord(icpSource):
+                DynImportPromise.Resolve(ImportModuleSourceValue(
+                  VMRegisterToStringFast(FRegisters[B]).Value, GlobalName));
+              Ord(icpDefer):
+                DynImportPromise.Resolve(ImportDeferredModuleNamespaceValue(
+                  VMRegisterToStringFast(FRegisters[B]).Value, GlobalName));
+            else
+              raise Exception.CreateFmt(
+                'Unsupported dynamic import phase: %d', [C]);
             end;
           except
             on E: EGocciaBytecodeThrow do

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -186,6 +186,7 @@ begin
   Context.Scope := FClosure;
   Context.OnError := FClosure.OnError;
   Context.LoadModule := FClosure.LoadModule;
+  Context.LoadModuleSource := FClosure.LoadModuleSource;
   Context.CurrentFilePath := FSourceFilePath;
   Context.CoverageEnabled := Assigned(TGocciaCoverageTracker.Instance)
     and TGocciaCoverageTracker.Instance.Enabled;

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -520,6 +520,7 @@ begin
   Context.Scope := CallScope;
   Context.OnError := FClosure.OnError;
   Context.LoadModule := FClosure.LoadModule;
+  Context.LoadModuleSource := FClosure.LoadModuleSource;
   Context.CurrentFilePath := FSourceFilePath;
   Context.CoverageEnabled := False;
   // EffectiveStrictTypes walks to the root scope so generator bodies
@@ -670,6 +671,7 @@ begin
   Context.Scope := CallScope;
   Context.OnError := FClosure.OnError;
   Context.LoadModule := FClosure.LoadModule;
+  Context.LoadModuleSource := FClosure.LoadModuleSource;
   Context.CurrentFilePath := FSourceFilePath;
   Context.CoverageEnabled := False;
   // EffectiveStrictTypes — see CreateContinuation above.

--- a/tests/language/modules/dynamic-import.js
+++ b/tests/language/modules/dynamic-import.js
@@ -29,6 +29,47 @@ describe("dynamic import()", () => {
     expect(mod.multiply(5, 6)).toBe(30);
   });
 
+  test("accepts trailing commas and import options", async () => {
+    let optionsEvaluated = false;
+    const mod = await import("./helpers/math-utils.js", { with: { type: "javascript" }, seen: (optionsEvaluated = true) },);
+    expect(optionsEvaluated).toBe(true);
+    expect(mod.add(3, 4)).toBe(7);
+  });
+
+  test("accepts source and defer import call forms", () => {
+    const sourcePromise = import.source("./helpers/math-utils.js");
+    const deferPromise = import.defer("./helpers/math-utils.js");
+    expect(typeof sourcePromise.then).toBe("function");
+    expect(typeof deferPromise.then).toBe("function");
+    expect(sourcePromise.constructor).toBe(Promise);
+    expect(deferPromise.constructor).toBe(Promise);
+  });
+
+  test("source import returns module source without evaluating the module", async () => {
+    globalThis.__gocciaSourceDynamicImportEvaluated = false;
+    const source = await import.source("./helpers/source-dynamic-import-side-effect.js");
+    expect(Object.prototype.toString.call(source)).toBe("[object ModuleSource]");
+    expect(globalThis.__gocciaSourceDynamicImportEvaluated).toBe(false);
+  });
+
+  test("deferred import evaluates the module when the namespace is observed", async () => {
+    globalThis.__gocciaDeferredDynamicImportEvaluated = false;
+    const mod = await import.defer("./helpers/deferred-dynamic-import-side-effect.js");
+    expect(globalThis.__gocciaDeferredDynamicImportEvaluated).toBe(false);
+    expect(mod.value).toBe(17);
+    expect(globalThis.__gocciaDeferredDynamicImportEvaluated).toBe(true);
+  });
+
+  test("deferred import rejects when the module cannot be resolved", async () => {
+    let caught = false;
+    try {
+      await import.defer("./helpers/nonexistent.js");
+    } catch (e) {
+      caught = true;
+    }
+    expect(caught).toBe(true);
+  });
+
   test("rejects for non-existent module", async () => {
     let caught = false;
     try {

--- a/tests/language/modules/helpers/deferred-dynamic-import-side-effect.js
+++ b/tests/language/modules/helpers/deferred-dynamic-import-side-effect.js
@@ -1,0 +1,3 @@
+globalThis.__gocciaDeferredDynamicImportEvaluated = true;
+
+export const value = 17;

--- a/tests/language/modules/helpers/source-dynamic-import-side-effect.js
+++ b/tests/language/modules/helpers/source-dynamic-import-side-effect.js
@@ -1,0 +1,3 @@
+globalThis.__gocciaSourceDynamicImportEvaluated = true;
+
+export const value = 23;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add parser support for dynamic import trailing commas, `import(specifier, options)`, and `import.source(...)` / `import.defer(...)` call spellings.
- Evaluate dynamic import options for observable side effects while preserving the parsed import-call phase for interpreter and bytecode execution.
- Implement proposal-phase behavior for `import.source(...)` as a `ModuleSource` value without target evaluation and `import.defer(...)` as a deferred namespace wrapper that resolves the specifier before fulfillment and evaluates when exports are observed.
- Closes #646.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas clean testrunner`
  - `./build/GocciaTestRunner tests/language/modules/dynamic-import.js`
  - `./build/GocciaTestRunner tests/language/modules/dynamic-import.js --mode=bytecode`
  - `./build/GocciaTestRunner tests/language/functions/stack-depth-limit.js`
  - `./build.pas loaderbare`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-vXUU7U --filter 'language/expressions/dynamic-import/syntax/valid/nested-with-*' --categories language --mode interpreted --jobs 1 --timeout-ms 10000 --max-tests 0`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-vXUU7U --filter 'language/expressions/dynamic-import/syntax/valid/nested-with-*' --categories language --mode bytecode --jobs 1 --timeout-ms 10000 --max-tests 0`
  - `./fixtures/ffi/build.sh`
  - `./build/GocciaTestRunner tests`
  - `./format.pas --check`
  - `git diff --check`
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
