### PR TITLE
Add GocciaScript issue validation skill

### DIFF
--- a/.agents/skills/gocciascript-issue-validation/SKILL.md
+++ b/.agents/skills/gocciascript-issue-validation/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: gocciascript-issue-validation
+description: Validate GocciaScript engine issues against the project-specific test262 harness. Use alongside implement-issue for GocciaScript issues that mention test262, ECMA-262/ECMA-402 conformance, Intl, or parser compatibility flags.
+---
+
+# GocciaScript Issue Validation
+
+Project-specific validation rules for GocciaScript issues. Use this skill with the generic `implement-issue` workflow when the issue references test262, ECMAScript/ECMA-402 behavior, or compatibility flags.
+
+## Test262 Validation
+
+When an issue references test262 files, patterns, or categories:
+
+1. Read `docs/test262.md` before running the reproduction.
+2. Use `scripts/run_test262_suite.ts` with `GocciaScriptLoaderBare`; do not run stock test262 files directly through `GocciaScriptLoader`, `GocciaTestRunner`, or hand-built wrappers.
+3. Use the pinned test262 SHA from `.github/workflows/pr.yml` or `.github/workflows/ci.yml` unless the issue explicitly targets another SHA.
+4. Build the bare loader first:
+
+```bash
+./build.pas loaderbare
+```
+
+5. Run exact issue paths through the project runner, for example:
+
+```bash
+bun scripts/run_test262_suite.ts \
+  --suite-dir /path/to/test262-suite \
+  --categories intl402 \
+  --filter 'intl402/NumberFormat/prototype/format/example.js' \
+  --mode bytecode \
+  --jobs 1 \
+  --verbose
+```
+
+The runner supplies the compatibility flags, harness substitutions, non-strict script handling, timeout/memory limits, pinned harness behavior, and PASS/FAIL/WRAPPER_INFRA classification used by CI. Direct loader experiments are only supplemental after the project runner result is known.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add a repo-local `gocciascript-issue-validation` skill for GocciaScript test262 issue triage.
- Document the project-specific test262 validation path through `scripts/run_test262_suite.ts` and the workflow-pinned suite SHA.
- Keep already-fixed issue handling and regression-hardening guidance out of this project-specific skill; that generic workflow will be authored separately.

## Testing

- [ ] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional verification run locally:

- `git diff --check -- .agents/skills/gocciascript-issue-validation/SKILL.md`
- `bunx markdownlint-cli2 .agents/skills/gocciascript-issue-validation/SKILL.md`
- pre-commit hooks: doc duplication scan, doc length, doc links, doc symbols, markdown lint