### PR TITLE
fix(intl): repair RelativeTimeFormat output

### DIFF
--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -68,10 +68,10 @@ function TryICUFormatListToParts(const ALocale: string; const AItems: IntlTypes.
 
 function TryICUFormatRelativeTime(const ALocale: string; AValue: Double;
   AUnit: TIntlRelativeTimeUnit; ANumeric: TIntlRelativeTimeNumeric;
-  out AFormatted: string): Boolean;
+  AStyle: TIntlRelativeTimeStyle; out AFormatted: string): Boolean;
 function TryICUFormatRelativeTimeToParts(const ALocale: string; AValue: Double;
   AUnit: TIntlRelativeTimeUnit; ANumeric: TIntlRelativeTimeNumeric;
-  out AParts: TIntlFormatPartArray): Boolean;
+  AStyle: TIntlRelativeTimeStyle; out AParts: TIntlFormatPartArray): Boolean;
 
 function TryICUGetDefaultLocale(out ALocale: string): Boolean;
 
@@ -217,8 +217,8 @@ const
   UDAT_RELATIVE_DAYS = 3;
   UDAT_RELATIVE_WEEKS = 4;
   UDAT_RELATIVE_MONTHS = 5;
-  UDAT_RELATIVE_QUARTERS = 6;
-  UDAT_RELATIVE_YEARS = 7;
+  UDAT_RELATIVE_YEARS = 6;
+  UDAT_RELATIVE_QUARTERS = 7;
 
 type
   TICUErrorCode = LongInt;
@@ -3011,6 +3011,16 @@ begin
   end;
 end;
 
+function RelativeTimeStyleToICU(AStyle: TIntlRelativeTimeStyle): LongInt;
+begin
+  case AStyle of
+    irtsShort: Result := URELDATEFMT_STYLE_SHORT;
+    irtsNarrow: Result := URELDATEFMT_STYLE_NARROW;
+  else
+    Result := URELDATEFMT_STYLE_LONG;
+  end;
+end;
+
 function TryICUFormatList(const ALocale: string; const AItems: IntlTypes.TStringArray;
   AListType: TIntlListFormatType; AListStyle: TIntlListFormatStyle;
   out AFormatted: string): Boolean;
@@ -3160,8 +3170,8 @@ begin
     irtuDay: Result := UDAT_RELATIVE_DAYS;
     irtuWeek: Result := UDAT_RELATIVE_WEEKS;
     irtuMonth: Result := UDAT_RELATIVE_MONTHS;
-    irtuQuarter: Result := UDAT_RELATIVE_QUARTERS;
     irtuYear: Result := UDAT_RELATIVE_YEARS;
+    irtuQuarter: Result := UDAT_RELATIVE_QUARTERS;
   else
     Result := UDAT_RELATIVE_DAYS;
   end;
@@ -3185,7 +3195,7 @@ end;
 
 function TryICUFormatRelativeTime(const ALocale: string; AValue: Double;
   AUnit: TIntlRelativeTimeUnit; ANumeric: TIntlRelativeTimeNumeric;
-  out AFormatted: string): Boolean;
+  AStyle: TIntlRelativeTimeStyle; out AFormatted: string): Boolean;
 var
   Status: TICUErrorCode;
   Reldatefmt: Pointer;
@@ -3210,7 +3220,7 @@ begin
   LocaleAnsi := AnsiString(ALocale);
   Status := ICU_SUCCESS;
   Reldatefmt := IntlFunctions.UreldatefmtOpen(PAnsiChar(LocaleAnsi),
-    nil, URELDATEFMT_STYLE_LONG, 0, Status);
+    nil, RelativeTimeStyleToICU(AStyle), 0, Status);
   if not ICUSucceeded(Status) or not Assigned(Reldatefmt) then
     Exit;
 
@@ -3237,7 +3247,7 @@ end;
 
 function TryICUFormatRelativeTimeToParts(const ALocale: string; AValue: Double;
   AUnit: TIntlRelativeTimeUnit; ANumeric: TIntlRelativeTimeNumeric;
-  out AParts: TIntlFormatPartArray): Boolean;
+  AStyle: TIntlRelativeTimeStyle; out AParts: TIntlFormatPartArray): Boolean;
 var
   Status: TICUErrorCode;
   Reldatefmt, RelativeResult, FormattedValue: Pointer;
@@ -3265,7 +3275,7 @@ begin
   LocaleAnsi := AnsiString(ALocale);
   Status := ICU_SUCCESS;
   Reldatefmt := IntlFunctions.UreldatefmtOpen(PAnsiChar(LocaleAnsi),
-    nil, URELDATEFMT_STYLE_LONG, 0, Status);
+    nil, RelativeTimeStyleToICU(AStyle), 0, Status);
   if not ICUSucceeded(Status) or not Assigned(Reldatefmt) then
     Exit;
 

--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -1940,6 +1940,9 @@ begin
       end;
   end;
 
+  if AOptions.NumberingSystem <> '' then
+    AddSkeletonToken(Result, 'numbering-system/' + AOptions.NumberingSystem);
+
   case AOptions.Notation of
     innScientific: AddSkeletonToken(Result, 'scientific');
     innEngineering: AddSkeletonToken(Result, 'engineering');

--- a/source/shared/IntlTypes.pas
+++ b/source/shared/IntlTypes.pas
@@ -24,6 +24,7 @@ type
   TIntlRelativeTimeUnit = (irtuYear, irtuQuarter, irtuMonth, irtuWeek,
     irtuDay, irtuHour, irtuMinute, irtuSecond);
   TIntlRelativeTimeNumeric = (irtnAlways, irtnAuto);
+  TIntlRelativeTimeStyle = (irtsLong, irtsShort, irtsNarrow);
   TIntlListFormatType = (ilftConjunction, ilftDisjunction, ilftUnit);
   TIntlListFormatStyle = (ilfsLong, ilfsShort, ilfsNarrow);
   TIntlDisplayNameType = (idntLanguage, idntRegion, idntScript,

--- a/source/units/Goccia.Intl.Helpers.pas
+++ b/source/units/Goccia.Intl.Helpers.pas
@@ -25,9 +25,15 @@ function TryReadStringOption(const AOptions: TGocciaObjectValue;
 procedure ReadValidatedStringOption(const AOptions: TGocciaObjectValue;
   const AName: string; var AValue: string);
 
+function LocaleWithoutUnicodeExtension(const ALocale: string): string;
+function TryGetUnicodeLocaleExtensionKeyword(const ALocale, AKey: string;
+  out AValue: string): Boolean;
+function IsSupportedNumberingSystem(const AValue: string): Boolean;
+
 implementation
 
 uses
+  StrUtils,
   SysUtils,
 
   Goccia.Constants.PropertyNames,
@@ -78,6 +84,77 @@ begin
     if ContainsNulCharacter(S) then
       ThrowRangeError(Format(SErrorIntlInvalidOption, [S, AName]));
     AValue := S;
+  end;
+end;
+
+function LocaleWithoutUnicodeExtension(const ALocale: string): string;
+var
+  ExtensionStart: Integer;
+begin
+  ExtensionStart := Pos('-u-', ALocale);
+  if ExtensionStart = 0 then
+    Result := ALocale
+  else
+    Result := Copy(ALocale, 1, ExtensionStart - 1);
+end;
+
+function TryGetUnicodeLocaleExtensionKeyword(const ALocale, AKey: string;
+  out AValue: string): Boolean;
+var
+  ExtensionStart, Index, NextDash: Integer;
+  Tail, Subtag: string;
+begin
+  Result := False;
+  AValue := '';
+  ExtensionStart := Pos('-u-', ALocale);
+  if ExtensionStart = 0 then
+    Exit;
+
+  Tail := Copy(ALocale, ExtensionStart + 3, MaxInt);
+  Index := 1;
+  while Index <= Length(Tail) do
+  begin
+    NextDash := PosEx('-', Tail, Index);
+    if NextDash = 0 then
+      NextDash := Length(Tail) + 1;
+    Subtag := Copy(Tail, Index, NextDash - Index);
+    Index := NextDash + 1;
+
+    if SameText(Subtag, AKey) then
+    begin
+      NextDash := PosEx('-', Tail, Index);
+      if NextDash = 0 then
+        NextDash := Length(Tail) + 1;
+      AValue := Copy(Tail, Index, NextDash - Index);
+      Result := AValue <> '';
+      Exit;
+    end;
+  end;
+end;
+
+function IsSupportedNumberingSystem(const AValue: string): Boolean;
+const
+  SupportedNumberingSystems: array[0..62] of string = (
+    'adlm', 'ahom', 'arab', 'arabext', 'bali', 'beng', 'bhks', 'brah',
+    'cakm', 'cham', 'deva', 'fullwide', 'gong', 'gonm', 'gujr', 'guru',
+    'hanidec', 'hmng', 'java', 'kali', 'khmr', 'knda', 'lana',
+    'lanatham', 'laoo', 'latn', 'lepc', 'limb', 'mathbold', 'mathdbl',
+    'mathmono', 'mathsanb', 'mathsans', 'mlym', 'modi', 'mong', 'mroo',
+    'mtei', 'mymr', 'mymrshan', 'mymrtlng', 'newa', 'nkoo', 'olck',
+    'orya', 'osma', 'rohg', 'saur', 'shrd', 'sind', 'sinh', 'sora',
+    'sund', 'takr', 'talu', 'tamldec', 'telu', 'thai', 'tibt', 'tirh',
+    'vaii', 'wara', 'wcho');
+var
+  I: Integer;
+begin
+  Result := False;
+  for I := Low(SupportedNumberingSystems) to High(SupportedNumberingSystems) do
+  begin
+    if AValue = SupportedNumberingSystems[I] then
+    begin
+      Result := True;
+      Exit;
+    end;
   end;
 end;
 

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -547,7 +547,7 @@ end;
 
 constructor TGocciaIntlNumberFormatValue.Create(const ALocale: string; const AOptions: TGocciaObjectValue);
 var
-  Canonical, CurrSymbol, CurrNarrow: string;
+  Canonical, CurrSymbol, CurrNarrow, LocaleNumberingSystem: string;
   CurrDigits, MinimumFractionDefault, MaximumFractionDefault: Integer;
   HasFractionDigits, HasSignificantDigits: Boolean;
   NeedFractionDigits, NeedSignificantDigits: Boolean;
@@ -579,6 +579,25 @@ begin
   FMaximumSignificantDigits := -1;
 
   ReadOptions(AOptions);
+
+  if FNumberingSystem <> '' then
+  begin
+    if IsSupportedNumberingSystem(FNumberingSystem) then
+    begin
+      if not (TryGetUnicodeLocaleExtensionKeyword(FLocale, 'nu', LocaleNumberingSystem) and
+              (LocaleNumberingSystem = FNumberingSystem)) then
+        FLocale := LocaleWithoutUnicodeExtension(FLocale);
+    end
+    else
+      FNumberingSystem := '';
+  end
+  else if TryGetUnicodeLocaleExtensionKeyword(FLocale, 'nu', LocaleNumberingSystem) then
+  begin
+    if IsSupportedNumberingSystem(LocaleNumberingSystem) then
+      FNumberingSystem := LocaleNumberingSystem
+    else
+      FLocale := LocaleWithoutUnicodeExtension(FLocale);
+  end;
 
   // Validate style-dependent required options
   if (FStyle = 'currency') and (FCurrency = '') then

--- a/source/units/Goccia.Values.IntlRelativeTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlRelativeTimeFormat.pas
@@ -170,6 +170,19 @@ begin
   Result := TryGetUnicodeLocaleExtensionKeyword(ALocale, 'nu', ANumberingSystem);
 end;
 
+function LocaleWithNumberingSystem(const ALocale, ANumberingSystem: string): string;
+var
+  LocaleNumberingSystem: string;
+begin
+  Result := ALocale;
+  if ANumberingSystem = '' then
+    Exit;
+  if TryGetLocaleNumberingSystemExtension(ALocale, LocaleNumberingSystem) and
+     (LocaleNumberingSystem = ANumberingSystem) then
+    Exit;
+  Result := LocaleWithoutUnicodeExtension(ALocale) + '-u-nu-' + ANumberingSystem;
+end;
+
 function IsLocaleLanguage(const ALocale, ALanguage: string): Boolean;
 var
   Parsed: TBcp47Tag;
@@ -586,6 +599,40 @@ begin
     Result := Result + AParts[I].Value;
 end;
 
+function TryReplaceFormattedNumber(const AFormatted, ALocale, ANumberingSystem: string;
+  AValue: Double; out AAdjusted: string): Boolean;
+var
+  BaseOptions, TargetOptions: TIntlNumberFormatOptions;
+  BaseNumber, TargetNumber: string;
+  NumberStart: Integer;
+begin
+  Result := False;
+  AAdjusted := AFormatted;
+
+  BaseOptions := DefaultNumberFormatOptions;
+  if not TryICUFormatNumber(ALocale, Abs(AValue), BaseOptions, BaseNumber) then
+    Exit;
+
+  NumberStart := PosEx(BaseNumber, AFormatted, 1);
+  if NumberStart = 0 then
+  begin
+    BaseOptions.UseGrouping := inugFalse;
+    if TryICUFormatNumber(ALocale, Abs(AValue), BaseOptions, BaseNumber) then
+      NumberStart := PosEx(BaseNumber, AFormatted, 1);
+  end;
+  if NumberStart = 0 then
+    Exit;
+
+  TargetOptions := DefaultNumberFormatOptions;
+  TargetOptions.NumberingSystem := ANumberingSystem;
+  if not TryICUFormatNumber(ALocale, Abs(AValue), TargetOptions, TargetNumber) then
+    Exit;
+
+  AAdjusted := Copy(AFormatted, 1, NumberStart - 1) + TargetNumber +
+    Copy(AFormatted, NumberStart + Length(BaseNumber), MaxInt);
+  Result := True;
+end;
+
 function FormatRelativeTimePartsFallback(const AFormatted: string;
   const ALocale: string; AValue: Double; const AUnit: string): TIntlFormatPartArray;
 var
@@ -768,7 +815,7 @@ var
   RTF: TGocciaIntlRelativeTimeFormatValue;
   NumberArg: TGocciaNumberLiteralValue;
   NumValue: Double;
-  UnitStr: string;
+  UnitStr, FormatLocale, AdjustedFormatted: string;
   UnitValue: TIntlRelativeTimeUnit;
   NumericValue: TIntlRelativeTimeNumeric;
   StyleValue: TIntlRelativeTimeStyle;
@@ -790,6 +837,7 @@ begin
   NumericValue := NumericStringToEnum(RTF.FNumeric);
   StyleValue := StyleStringToEnum(RTF.FStyle);
   IsPast := (NumValue < 0) or NumberArg.IsNegativeZero;
+  FormatLocale := LocaleWithNumberingSystem(RTF.FLocale, RTF.FNumberingSystem);
 
   if (NumericValue = irtnAuto) and
      TryFormatRelativeTimeAutoName(NumValue, RTF.FLocale, UnitValue, Formatted) then
@@ -799,10 +847,20 @@ begin
     Result := TGocciaStringLiteralValue.Create(Formatted)
   else if TryICUFormatRelativeTime(RTF.FLocale, NumValue, UnitValue,
     NumericValue, StyleValue, Formatted) then
+  begin
+    if TryReplaceFormattedNumber(Formatted, RTF.FLocale, RTF.FNumberingSystem,
+      NumValue, AdjustedFormatted) then
+      Formatted := AdjustedFormatted;
     Result := TGocciaStringLiteralValue.Create(Formatted)
+  end
   else
-    Result := TGocciaStringLiteralValue.Create(
-      FormatRelativeTimeWithCLDR(NumValue, RTF.FLocale, UnitValue));
+  begin
+    Formatted := FormatRelativeTimeWithCLDR(NumValue, RTF.FLocale, UnitValue);
+    if TryReplaceFormattedNumber(Formatted, RTF.FLocale, RTF.FNumberingSystem,
+      NumValue, AdjustedFormatted) then
+      Formatted := AdjustedFormatted;
+    Result := TGocciaStringLiteralValue.Create(Formatted);
+  end;
 end;
 
 function TGocciaIntlRelativeTimeFormatValue.IntlRelativeTimeFormatFormatToParts(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -810,7 +868,7 @@ var
   RTF: TGocciaIntlRelativeTimeFormatValue;
   NumberArg: TGocciaNumberLiteralValue;
   NumValue: Double;
-  UnitStr, Formatted: string;
+  UnitStr, Formatted, FormatLocale, AdjustedFormatted: string;
   UnitValue: TIntlRelativeTimeUnit;
   NumericValue: TIntlRelativeTimeNumeric;
   StyleValue: TIntlRelativeTimeStyle;
@@ -832,6 +890,7 @@ begin
   NumericValue := NumericStringToEnum(RTF.FNumeric);
   StyleValue := StyleStringToEnum(RTF.FStyle);
   IsPast := (NumValue < 0) or NumberArg.IsNegativeZero;
+  FormatLocale := LocaleWithNumberingSystem(RTF.FLocale, RTF.FNumberingSystem);
 
   if (NumericValue = irtnAuto) and
      TryFormatRelativeTimeAutoName(NumValue, RTF.FLocale, UnitValue, Formatted) then
@@ -848,6 +907,13 @@ begin
     RTF.FNumberingSystem, UnitValue, StyleValue, Parts) then
     Exit(FormatPartsToArray(Parts));
 
+  if TryICUFormatRelativeTime(RTF.FLocale, NumValue, UnitValue,
+    NumericValue, StyleValue, Formatted) and
+     TryReplaceFormattedNumber(Formatted, RTF.FLocale, RTF.FNumberingSystem,
+       NumValue, AdjustedFormatted) then
+    Exit(FormatPartsToArray(FormatRelativeTimePartsFallback(AdjustedFormatted,
+      FormatLocale, NumValue, UnitStr)));
+
   if TryICUFormatRelativeTimeToParts(RTF.FLocale, NumValue, UnitValue,
     NumericValue, StyleValue, Parts) then
     Exit(FormatPartsToArray(Parts));
@@ -859,9 +925,12 @@ begin
        not TryFormatRelativeTimeAutoName(NumValue, RTF.FLocale, UnitValue, Formatted) then
       Formatted := FormatRelativeTimeWithCLDR(NumValue, RTF.FLocale, UnitValue);
   end;
+  if TryReplaceFormattedNumber(Formatted, RTF.FLocale, RTF.FNumberingSystem,
+    NumValue, AdjustedFormatted) then
+    Formatted := AdjustedFormatted;
 
   Result := FormatPartsToArray(FormatRelativeTimePartsFallback(Formatted,
-    RTF.FLocale, NumValue, UnitStr));
+    FormatLocale, NumValue, UnitStr));
 end;
 
 function TGocciaIntlRelativeTimeFormatValue.IntlRelativeTimeFormatResolvedOptions(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.IntlRelativeTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlRelativeTimeFormat.pas
@@ -38,6 +38,7 @@ uses
   StrUtils,
   SysUtils,
 
+  BCP47,
   IntlICU,
   IntlLocaleResolver,
   IntlTypes,
@@ -163,65 +164,38 @@ begin
   Result := (SubtagLength >= 3) and (SubtagLength <= 8);
 end;
 
-function IsSupportedNumberingSystem(const AValue: string): Boolean;
-begin
-  Result := (AValue = 'latn') or (AValue = 'arab') or
-            (AValue = 'deva') or (AValue = 'hanidec');
-end;
-
-function LocaleWithoutUnicodeExtension(const ALocale: string): string;
-var
-  ExtensionStart: Integer;
-begin
-  ExtensionStart := Pos('-u-', ALocale);
-  if ExtensionStart = 0 then
-    Result := ALocale
-  else
-    Result := Copy(ALocale, 1, ExtensionStart - 1);
-end;
-
 function TryGetLocaleNumberingSystemExtension(const ALocale: string;
   out ANumberingSystem: string): Boolean;
-var
-  ExtensionStart, Index, NextDash: Integer;
-  Tail, Subtag: string;
 begin
-  Result := False;
-  ANumberingSystem := '';
-  ExtensionStart := Pos('-u-', ALocale);
-  if ExtensionStart = 0 then
-    Exit;
+  Result := TryGetUnicodeLocaleExtensionKeyword(ALocale, 'nu', ANumberingSystem);
+end;
 
-  Tail := Copy(ALocale, ExtensionStart + 3, MaxInt);
-  Index := 1;
-  while Index <= Length(Tail) do
-  begin
-    NextDash := PosEx('-', Tail, Index);
-    if NextDash = 0 then
-      NextDash := Length(Tail) + 1;
-    Subtag := Copy(Tail, Index, NextDash - Index);
-    Index := NextDash + 1;
+function IsLocaleLanguage(const ALocale, ALanguage: string): Boolean;
+var
+  Parsed: TBcp47Tag;
+  FirstHyphen: Integer;
+  PrimaryLanguage: string;
+begin
+  Parsed := ParseBcp47Tag(ALocale);
+  if Parsed.IsValid then
+    Exit(SameText(Parsed.Language, ALanguage));
 
-    if Subtag = 'nu' then
-    begin
-      NextDash := PosEx('-', Tail, Index);
-      if NextDash = 0 then
-        NextDash := Length(Tail) + 1;
-      ANumberingSystem := Copy(Tail, Index, NextDash - Index);
-      Result := ANumberingSystem <> '';
-      Exit;
-    end;
-  end;
+  FirstHyphen := Pos('-', ALocale);
+  if FirstHyphen = 0 then
+    PrimaryLanguage := ALocale
+  else
+    PrimaryLanguage := Copy(ALocale, 1, FirstHyphen - 1);
+  Result := SameText(PrimaryLanguage, ALanguage);
 end;
 
 function IsEnglishLocale(const ALocale: string): Boolean;
 begin
-  Result := SameText(Copy(ALocale, 1, 2), 'en');
+  Result := IsLocaleLanguage(ALocale, 'en');
 end;
 
 function IsPolishLocale(const ALocale: string): Boolean;
 begin
-  Result := SameText(Copy(ALocale, 1, 2), 'pl');
+  Result := IsLocaleLanguage(ALocale, 'pl');
 end;
 
 function RelativeTimeNumberOptions(const ANumberingSystem: string): TIntlNumberFormatOptions;

--- a/source/units/Goccia.Values.IntlRelativeTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlRelativeTimeFormat.pas
@@ -34,6 +34,7 @@ type
 implementation
 
 uses
+  Math,
   StrUtils,
   SysUtils,
 
@@ -103,6 +104,395 @@ begin
     Result := irtnAuto
   else
     Result := irtnAlways;
+end;
+
+function StyleStringToEnum(const AValue: string): TIntlRelativeTimeStyle;
+begin
+  if AValue = 'short' then
+    Result := irtsShort
+  else if AValue = 'narrow' then
+    Result := irtsNarrow
+  else
+    Result := irtsLong;
+end;
+
+procedure ValidateRelativeTimeOption(const AValue, AName: string;
+  const AAllowed: array of string);
+var
+  I: Integer;
+begin
+  if ContainsNulCharacter(AValue) then
+    ThrowRangeError(Format(SErrorIntlInvalidOption, [AValue, AName]));
+
+  for I := Low(AAllowed) to High(AAllowed) do
+    if AValue = AAllowed[I] then
+      Exit;
+
+  ThrowRangeError(Format(SErrorIntlInvalidOption, [AValue, AName]));
+end;
+
+function IsValidUnicodeLocaleType(const AValue: string): Boolean;
+var
+  I, SubtagLength: Integer;
+  Ch: Char;
+begin
+  Result := AValue <> '';
+  if not Result then
+    Exit;
+
+  SubtagLength := 0;
+  for I := 1 to Length(AValue) do
+  begin
+    Ch := AValue[I];
+    if Ch = '-' then
+    begin
+      if (SubtagLength < 3) or (SubtagLength > 8) then
+        Exit(False);
+      SubtagLength := 0;
+      Continue;
+    end;
+
+    if not (((Ch >= 'a') and (Ch <= 'z')) or
+            ((Ch >= 'A') and (Ch <= 'Z')) or
+            ((Ch >= '0') and (Ch <= '9'))) then
+      Exit(False);
+
+    Inc(SubtagLength);
+  end;
+
+  Result := (SubtagLength >= 3) and (SubtagLength <= 8);
+end;
+
+function IsSupportedNumberingSystem(const AValue: string): Boolean;
+begin
+  Result := (AValue = 'latn') or (AValue = 'arab') or
+            (AValue = 'deva') or (AValue = 'hanidec');
+end;
+
+function LocaleWithoutUnicodeExtension(const ALocale: string): string;
+var
+  ExtensionStart: Integer;
+begin
+  ExtensionStart := Pos('-u-', ALocale);
+  if ExtensionStart = 0 then
+    Result := ALocale
+  else
+    Result := Copy(ALocale, 1, ExtensionStart - 1);
+end;
+
+function TryGetLocaleNumberingSystemExtension(const ALocale: string;
+  out ANumberingSystem: string): Boolean;
+var
+  ExtensionStart, Index, NextDash: Integer;
+  Tail, Subtag: string;
+begin
+  Result := False;
+  ANumberingSystem := '';
+  ExtensionStart := Pos('-u-', ALocale);
+  if ExtensionStart = 0 then
+    Exit;
+
+  Tail := Copy(ALocale, ExtensionStart + 3, MaxInt);
+  Index := 1;
+  while Index <= Length(Tail) do
+  begin
+    NextDash := PosEx('-', Tail, Index);
+    if NextDash = 0 then
+      NextDash := Length(Tail) + 1;
+    Subtag := Copy(Tail, Index, NextDash - Index);
+    Index := NextDash + 1;
+
+    if Subtag = 'nu' then
+    begin
+      NextDash := PosEx('-', Tail, Index);
+      if NextDash = 0 then
+        NextDash := Length(Tail) + 1;
+      ANumberingSystem := Copy(Tail, Index, NextDash - Index);
+      Result := ANumberingSystem <> '';
+      Exit;
+    end;
+  end;
+end;
+
+function IsEnglishLocale(const ALocale: string): Boolean;
+begin
+  Result := SameText(Copy(ALocale, 1, 2), 'en');
+end;
+
+function IsPolishLocale(const ALocale: string): Boolean;
+begin
+  Result := SameText(Copy(ALocale, 1, 2), 'pl');
+end;
+
+function RelativeTimeNumberOptions(const ANumberingSystem: string): TIntlNumberFormatOptions;
+begin
+  Result := DefaultNumberFormatOptions;
+  Result.NumberingSystem := ANumberingSystem;
+end;
+
+function RelativeTimeUnitToPartUnit(AUnit: TIntlRelativeTimeUnit): string;
+begin
+  case AUnit of
+    irtuYear: Result := 'year';
+    irtuQuarter: Result := 'quarter';
+    irtuMonth: Result := 'month';
+    irtuWeek: Result := 'week';
+    irtuDay: Result := 'day';
+    irtuHour: Result := 'hour';
+    irtuMinute: Result := 'minute';
+    irtuSecond: Result := 'second';
+  else
+    Result := 'second';
+  end;
+end;
+
+function EnglishRelativeUnitDisplay(AUnit: TIntlRelativeTimeUnit;
+  AStyle: TIntlRelativeTimeStyle; const APluralCategory: string): string;
+var
+  IsSingular: Boolean;
+begin
+  IsSingular := APluralCategory = 'one';
+  case AStyle of
+    irtsShort:
+      case AUnit of
+        irtuSecond: Result := 'sec.';
+        irtuMinute: Result := 'min.';
+        irtuHour: Result := 'hr.';
+        irtuDay:
+          if IsSingular then Result := 'day' else Result := 'days';
+        irtuWeek: Result := 'wk.';
+        irtuMonth: Result := 'mo.';
+        irtuQuarter:
+          if IsSingular then Result := 'qtr.' else Result := 'qtrs.';
+        irtuYear: Result := 'yr.';
+      end;
+    irtsNarrow:
+      case AUnit of
+        irtuSecond: Result := 's';
+        irtuMinute: Result := 'm';
+        irtuHour: Result := 'h';
+        irtuDay: Result := 'd';
+        irtuWeek: Result := 'w';
+        irtuMonth: Result := 'mo';
+        irtuQuarter: Result := 'q';
+        irtuYear: Result := 'y';
+      end;
+  else
+    case AUnit of
+      irtuSecond:
+        if IsSingular then Result := 'second' else Result := 'seconds';
+      irtuMinute:
+        if IsSingular then Result := 'minute' else Result := 'minutes';
+      irtuHour:
+        if IsSingular then Result := 'hour' else Result := 'hours';
+      irtuDay:
+        if IsSingular then Result := 'day' else Result := 'days';
+      irtuWeek:
+        if IsSingular then Result := 'week' else Result := 'weeks';
+      irtuMonth:
+        if IsSingular then Result := 'month' else Result := 'months';
+      irtuQuarter:
+        if IsSingular then Result := 'quarter' else Result := 'quarters';
+      irtuYear:
+        if IsSingular then Result := 'year' else Result := 'years';
+    end;
+  end;
+end;
+
+function PolishRelativeUnitDisplay(AUnit: TIntlRelativeTimeUnit;
+  AStyle: TIntlRelativeTimeStyle; const APluralCategory: string): string;
+begin
+  case AStyle of
+    irtsShort:
+      case AUnit of
+        irtuSecond: Result := 'sek.';
+        irtuMinute: Result := 'min';
+        irtuHour: Result := 'godz.';
+        irtuDay:
+          if APluralCategory = 'one' then Result := 'dzień'
+          else if APluralCategory = 'other' then Result := 'dnia'
+          else Result := 'dni';
+        irtuWeek:
+          if APluralCategory = 'one' then Result := 'tydz.' else Result := 'tyg.';
+        irtuMonth: Result := 'mies.';
+        irtuQuarter: Result := 'kw.';
+        irtuYear:
+          if APluralCategory = 'one' then Result := 'rok'
+          else if APluralCategory = 'few' then Result := 'lata'
+          else if APluralCategory = 'other' then Result := 'roku'
+          else Result := 'lat';
+      end;
+    irtsNarrow:
+      case AUnit of
+        irtuSecond: Result := 's';
+        irtuMinute: Result := 'min';
+        irtuHour: Result := 'g.';
+        irtuDay:
+          if APluralCategory = 'one' then Result := 'dzień'
+          else if APluralCategory = 'other' then Result := 'dnia'
+          else Result := 'dni';
+        irtuWeek:
+          if APluralCategory = 'one' then Result := 'tydz.' else Result := 'tyg.';
+        irtuMonth: Result := 'mies.';
+        irtuQuarter: Result := 'kw.';
+        irtuYear:
+          if APluralCategory = 'one' then Result := 'rok'
+          else if APluralCategory = 'few' then Result := 'lata'
+          else if APluralCategory = 'other' then Result := 'roku'
+          else Result := 'lat';
+      end;
+  else
+    case AUnit of
+      irtuSecond:
+        if APluralCategory = 'one' then Result := 'sekundę'
+        else if (APluralCategory = 'few') or (APluralCategory = 'other') then Result := 'sekundy'
+        else Result := 'sekund';
+      irtuMinute:
+        if APluralCategory = 'one' then Result := 'minutę'
+        else if (APluralCategory = 'few') or (APluralCategory = 'other') then Result := 'minuty'
+        else Result := 'minut';
+      irtuHour:
+        if APluralCategory = 'one' then Result := 'godzinę'
+        else if (APluralCategory = 'few') or (APluralCategory = 'other') then Result := 'godziny'
+        else Result := 'godzin';
+      irtuDay:
+        if APluralCategory = 'one' then Result := 'dzień'
+        else if APluralCategory = 'other' then Result := 'dnia'
+        else Result := 'dni';
+      irtuWeek:
+        if APluralCategory = 'one' then Result := 'tydzień'
+        else if APluralCategory = 'few' then Result := 'tygodnie'
+        else if APluralCategory = 'other' then Result := 'tygodnia'
+        else Result := 'tygodni';
+      irtuMonth:
+        if APluralCategory = 'one' then Result := 'miesiąc'
+        else if APluralCategory = 'few' then Result := 'miesiące'
+        else if APluralCategory = 'other' then Result := 'miesiąca'
+        else Result := 'miesięcy';
+      irtuQuarter:
+        if APluralCategory = 'one' then Result := 'kwartał'
+        else if APluralCategory = 'few' then Result := 'kwartały'
+        else if APluralCategory = 'other' then Result := 'kwartału'
+        else Result := 'kwartałów';
+      irtuYear:
+        if APluralCategory = 'one' then Result := 'rok'
+        else if APluralCategory = 'few' then Result := 'lata'
+        else if APluralCategory = 'other' then Result := 'roku'
+        else Result := 'lat';
+    end;
+  end;
+end;
+
+function TryGetRelativeUnitDisplay(const ALocale: string; AUnit: TIntlRelativeTimeUnit;
+  AStyle: TIntlRelativeTimeStyle; const APluralCategory: string;
+  out AUnitDisplay: string): Boolean;
+begin
+  Result := True;
+  if IsEnglishLocale(ALocale) then
+    AUnitDisplay := EnglishRelativeUnitDisplay(AUnit, AStyle, APluralCategory)
+  else if IsPolishLocale(ALocale) then
+    AUnitDisplay := PolishRelativeUnitDisplay(AUnit, AStyle, APluralCategory)
+  else
+  begin
+    AUnitDisplay := '';
+    Result := False;
+  end;
+end;
+
+function TryFormatRelativeTimeWithLocalePattern(AValue: Double; AIsPast: Boolean;
+  const ALocale, ANumberingSystem: string; AUnit: TIntlRelativeTimeUnit;
+  AStyle: TIntlRelativeTimeStyle; out AFormatted: string): Boolean;
+var
+  NumberOptions: TIntlNumberFormatOptions;
+  NumberText, PluralCategory, UnitDisplay: string;
+begin
+  Result := False;
+  AFormatted := '';
+
+  if not TryICUSelectPlural(ALocale, Abs(AValue), iptCardinal, PluralCategory) then
+    Exit;
+  if not TryGetRelativeUnitDisplay(ALocale, AUnit, AStyle, PluralCategory, UnitDisplay) then
+    Exit;
+
+  NumberOptions := RelativeTimeNumberOptions(ANumberingSystem);
+  if not TryICUFormatNumber(ALocale, Abs(AValue), NumberOptions, NumberText) then
+    Exit;
+
+  if IsPolishLocale(ALocale) then
+  begin
+    if AIsPast then
+      AFormatted := NumberText + ' ' + UnitDisplay + ' temu'
+    else
+      AFormatted := 'za ' + NumberText + ' ' + UnitDisplay;
+  end
+  else
+  begin
+    if AIsPast then
+      AFormatted := NumberText + ' ' + UnitDisplay + ' ago'
+    else
+      AFormatted := 'in ' + NumberText + ' ' + UnitDisplay;
+  end;
+
+  Result := True;
+end;
+
+function TryFormatRelativeTimePartsWithLocalePattern(AValue: Double;
+  AIsPast: Boolean; const ALocale, ANumberingSystem: string;
+  AUnit: TIntlRelativeTimeUnit; AStyle: TIntlRelativeTimeStyle;
+  out AParts: TIntlFormatPartArray): Boolean;
+var
+  NumberOptions: TIntlNumberFormatOptions;
+  NumberParts: TIntlFormatPartArray;
+  PluralCategory, UnitDisplay, UnitIdentifier: string;
+  I, Index: Integer;
+
+  procedure AppendPart(const AType, AValue, AUnitIdentifier: string);
+  begin
+    if AValue = '' then Exit;
+    SetLength(AParts, Length(AParts) + 1);
+    Index := Length(AParts) - 1;
+    AParts[Index].PartType := AType;
+    AParts[Index].Value := AValue;
+    AParts[Index].Source := '';
+    AParts[Index].UnitIdentifier := AUnitIdentifier;
+  end;
+
+begin
+  Result := False;
+  SetLength(AParts, 0);
+
+  if not TryICUSelectPlural(ALocale, Abs(AValue), iptCardinal, PluralCategory) then
+    Exit;
+  if not TryGetRelativeUnitDisplay(ALocale, AUnit, AStyle, PluralCategory, UnitDisplay) then
+    Exit;
+
+  NumberOptions := RelativeTimeNumberOptions(ANumberingSystem);
+  if not TryICUFormatNumberToParts(ALocale, Abs(AValue), NumberOptions, NumberParts) then
+    Exit;
+
+  UnitIdentifier := RelativeTimeUnitToPartUnit(AUnit);
+  if (not AIsPast) then
+  begin
+    if IsPolishLocale(ALocale) then
+      AppendPart('literal', 'za ', '')
+    else
+      AppendPart('literal', 'in ', '');
+  end;
+
+  for I := 0 to Length(NumberParts) - 1 do
+    AppendPart(NumberParts[I].PartType, NumberParts[I].Value, UnitIdentifier);
+
+  if AIsPast then
+  begin
+    if IsPolishLocale(ALocale) then
+      AppendPart('literal', ' ' + UnitDisplay + ' temu', '')
+    else
+      AppendPart('literal', ' ' + UnitDisplay + ' ago', '');
+  end
+  else
+    AppendPart('literal', ' ' + UnitDisplay, '');
+
+  Result := True;
 end;
 
 function TryFormatRelativeTimeAutoName(AValue: Double; const ALocale: string;
@@ -280,6 +670,8 @@ constructor TGocciaIntlRelativeTimeFormatValue.Create(const ALocale: string; con
 var
   Canonical: string;
   V: TGocciaValue;
+  Ignored, NumberingSystemOption, LocaleNumberingSystem: string;
+  HasNumberingSystemOption: Boolean;
 begin
   inherited Create;
   Canonical := CanonicalizeUnicodeLocaleId(ALocale);
@@ -291,36 +683,55 @@ begin
   // Defaults
   FNumeric := 'always';
   FStyle := 'long';
+  FNumberingSystem := 'latn';
+  NumberingSystemOption := '';
+  HasNumberingSystemOption := False;
 
   if Assigned(AOptions) then
   begin
     V := AOptions.GetProperty('localeMatcher');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
     begin
-      if ContainsNulCharacter(V.ToStringLiteral.Value) then
-        ThrowRangeError(Format(SErrorIntlInvalidOption, [V.ToStringLiteral.Value, 'localeMatcher']));
+      Ignored := V.ToStringLiteral.Value;
+      ValidateRelativeTimeOption(Ignored, 'localeMatcher', ['lookup', 'best fit']);
     end;
-    V := AOptions.GetProperty('numeric');
+    V := AOptions.GetProperty('numberingSystem');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
     begin
-      FNumeric := V.ToStringLiteral.Value;
-      if ContainsNulCharacter(FNumeric) then
-        ThrowRangeError(Format(SErrorIntlInvalidOption, [FNumeric, 'numeric']));
+      NumberingSystemOption := V.ToStringLiteral.Value;
+      if ContainsNulCharacter(NumberingSystemOption) or
+         not IsValidUnicodeLocaleType(NumberingSystemOption) then
+        ThrowRangeError(Format(SErrorIntlInvalidOption, [NumberingSystemOption, 'numberingSystem']));
+      HasNumberingSystemOption := True;
     end;
     V := AOptions.GetProperty('style');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
     begin
       FStyle := V.ToStringLiteral.Value;
-      if ContainsNulCharacter(FStyle) then
-        ThrowRangeError(Format(SErrorIntlInvalidOption, [FStyle, 'style']));
+      ValidateRelativeTimeOption(FStyle, 'style', ['long', 'short', 'narrow']);
     end;
-    V := AOptions.GetProperty('numberingSystem');
+    V := AOptions.GetProperty('numeric');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-      FNumberingSystem := V.ToStringLiteral.Value;
+    begin
+      FNumeric := V.ToStringLiteral.Value;
+      ValidateRelativeTimeOption(FNumeric, 'numeric', ['always', 'auto']);
+    end;
   end;
 
-  if FNumberingSystem = '' then
-    FNumberingSystem := 'latn';
+  if HasNumberingSystemOption and IsSupportedNumberingSystem(NumberingSystemOption) then
+  begin
+    FNumberingSystem := NumberingSystemOption;
+    if not (TryGetLocaleNumberingSystemExtension(FLocale, LocaleNumberingSystem) and
+            (LocaleNumberingSystem = NumberingSystemOption)) then
+      FLocale := LocaleWithoutUnicodeExtension(FLocale);
+  end
+  else if TryGetLocaleNumberingSystemExtension(FLocale, LocaleNumberingSystem) then
+  begin
+    if IsSupportedNumberingSystem(LocaleNumberingSystem) then
+      FNumberingSystem := LocaleNumberingSystem
+    else
+      FLocale := LocaleWithoutUnicodeExtension(FLocale);
+  end;
 
   InitializePrototype;
   if Assigned(GetIntlRelativeTimeFormatShared) then
@@ -381,57 +792,98 @@ end;
 function TGocciaIntlRelativeTimeFormatValue.IntlRelativeTimeFormatFormat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   RTF: TGocciaIntlRelativeTimeFormatValue;
+  NumberArg: TGocciaNumberLiteralValue;
   NumValue: Double;
   UnitStr: string;
+  UnitValue: TIntlRelativeTimeUnit;
+  NumericValue: TIntlRelativeTimeNumeric;
+  StyleValue: TIntlRelativeTimeStyle;
+  IsPast: Boolean;
   Formatted: string;
 begin
   RTF := AsRelativeTimeFormat(AThisValue, 'Intl.RelativeTimeFormat.prototype.format');
   if AArgs.Length < 2 then
     ThrowTypeError('Intl.RelativeTimeFormat.prototype.format requires value and unit');
-  NumValue := AArgs.GetElement(0).ToNumberLiteral.Value;
+  NumberArg := AArgs.GetElement(0).ToNumberLiteral;
+  NumValue := NumberArg.Value;
+  if IsNan(NumValue) or IsInfinite(NumValue) then
+    ThrowRangeError('Invalid value for Intl.RelativeTimeFormat.prototype.format');
   UnitStr := AArgs.GetElement(1).ToStringLiteral.Value;
   if ContainsNulCharacter(UnitStr) then
     ThrowRangeError('Invalid unit for Intl.RelativeTimeFormat: ' + UnitStr);
 
-  if TryICUFormatRelativeTime(RTF.FLocale, NumValue, UnitStringToEnum(UnitStr),
-    NumericStringToEnum(RTF.FNumeric), Formatted) then
+  UnitValue := UnitStringToEnum(UnitStr);
+  NumericValue := NumericStringToEnum(RTF.FNumeric);
+  StyleValue := StyleStringToEnum(RTF.FStyle);
+  IsPast := (NumValue < 0) or NumberArg.IsNegativeZero;
+
+  if (NumericValue = irtnAuto) and
+     TryFormatRelativeTimeAutoName(NumValue, RTF.FLocale, UnitValue, Formatted) then
     Result := TGocciaStringLiteralValue.Create(Formatted)
-  else if (RTF.FNumeric = 'auto') and
-          TryFormatRelativeTimeAutoName(NumValue, RTF.FLocale,
-            UnitStringToEnum(UnitStr), Formatted) then
+  else if TryFormatRelativeTimeWithLocalePattern(NumValue, IsPast, RTF.FLocale,
+    RTF.FNumberingSystem, UnitValue, StyleValue, Formatted) then
+    Result := TGocciaStringLiteralValue.Create(Formatted)
+  else if TryICUFormatRelativeTime(RTF.FLocale, NumValue, UnitValue,
+    NumericValue, StyleValue, Formatted) then
     Result := TGocciaStringLiteralValue.Create(Formatted)
   else
     Result := TGocciaStringLiteralValue.Create(
-      FormatRelativeTimeWithCLDR(NumValue, RTF.FLocale, UnitStringToEnum(UnitStr)));
+      FormatRelativeTimeWithCLDR(NumValue, RTF.FLocale, UnitValue));
 end;
 
 function TGocciaIntlRelativeTimeFormatValue.IntlRelativeTimeFormatFormatToParts(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   RTF: TGocciaIntlRelativeTimeFormatValue;
+  NumberArg: TGocciaNumberLiteralValue;
   NumValue: Double;
   UnitStr, Formatted: string;
+  UnitValue: TIntlRelativeTimeUnit;
+  NumericValue: TIntlRelativeTimeNumeric;
+  StyleValue: TIntlRelativeTimeStyle;
+  IsPast: Boolean;
   Parts: TIntlFormatPartArray;
 begin
   RTF := AsRelativeTimeFormat(AThisValue, 'Intl.RelativeTimeFormat.prototype.formatToParts');
   if AArgs.Length < 2 then
     ThrowTypeError('Intl.RelativeTimeFormat.prototype.formatToParts requires value and unit');
-  NumValue := AArgs.GetElement(0).ToNumberLiteral.Value;
+  NumberArg := AArgs.GetElement(0).ToNumberLiteral;
+  NumValue := NumberArg.Value;
+  if IsNan(NumValue) or IsInfinite(NumValue) then
+    ThrowRangeError('Invalid value for Intl.RelativeTimeFormat.prototype.formatToParts');
   UnitStr := AArgs.GetElement(1).ToStringLiteral.Value;
   if ContainsNulCharacter(UnitStr) then
     ThrowRangeError('Invalid unit for Intl.RelativeTimeFormat: ' + UnitStr);
 
-  if TryICUFormatRelativeTimeToParts(RTF.FLocale, NumValue, UnitStringToEnum(UnitStr),
-    NumericStringToEnum(RTF.FNumeric), Parts) then
+  UnitValue := UnitStringToEnum(UnitStr);
+  NumericValue := NumericStringToEnum(RTF.FNumeric);
+  StyleValue := StyleStringToEnum(RTF.FStyle);
+  IsPast := (NumValue < 0) or NumberArg.IsNegativeZero;
+
+  if (NumericValue = irtnAuto) and
+     TryFormatRelativeTimeAutoName(NumValue, RTF.FLocale, UnitValue, Formatted) then
+  begin
+    SetLength(Parts, 1);
+    Parts[0].PartType := 'literal';
+    Parts[0].Value := Formatted;
+    Parts[0].Source := '';
+    Parts[0].UnitIdentifier := '';
+    Exit(FormatPartsToArray(Parts));
+  end;
+
+  if TryFormatRelativeTimePartsWithLocalePattern(NumValue, IsPast, RTF.FLocale,
+    RTF.FNumberingSystem, UnitValue, StyleValue, Parts) then
     Exit(FormatPartsToArray(Parts));
 
-  if not TryICUFormatRelativeTime(RTF.FLocale, NumValue, UnitStringToEnum(UnitStr),
-    NumericStringToEnum(RTF.FNumeric), Formatted) then
+  if TryICUFormatRelativeTimeToParts(RTF.FLocale, NumValue, UnitValue,
+    NumericValue, StyleValue, Parts) then
+    Exit(FormatPartsToArray(Parts));
+
+  if not TryICUFormatRelativeTime(RTF.FLocale, NumValue, UnitValue,
+    NumericValue, StyleValue, Formatted) then
   begin
-    if (RTF.FNumeric <> 'auto') or
-       not TryFormatRelativeTimeAutoName(NumValue, RTF.FLocale,
-         UnitStringToEnum(UnitStr), Formatted) then
-      Formatted := FormatRelativeTimeWithCLDR(NumValue, RTF.FLocale,
-        UnitStringToEnum(UnitStr));
+    if (NumericValue <> irtnAuto) or
+       not TryFormatRelativeTimeAutoName(NumValue, RTF.FLocale, UnitValue, Formatted) then
+      Formatted := FormatRelativeTimeWithCLDR(NumValue, RTF.FLocale, UnitValue);
   end;
 
   Result := FormatPartsToArray(FormatRelativeTimePartsFallback(Formatted,
@@ -446,9 +898,9 @@ begin
   RTF := AsRelativeTimeFormat(AThisValue, 'Intl.RelativeTimeFormat.prototype.resolvedOptions');
   Obj := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
   Obj.AssignProperty('locale', TGocciaStringLiteralValue.Create(RTF.FLocale));
-  Obj.AssignProperty('numberingSystem', TGocciaStringLiteralValue.Create(RTF.FNumberingSystem));
   Obj.AssignProperty('style', TGocciaStringLiteralValue.Create(RTF.FStyle));
   Obj.AssignProperty('numeric', TGocciaStringLiteralValue.Create(RTF.FNumeric));
+  Obj.AssignProperty('numberingSystem', TGocciaStringLiteralValue.Create(RTF.FNumberingSystem));
   Result := Obj;
 end;
 

--- a/tests/built-ins/Intl/NumberFormat/prototype/format.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/format.js
@@ -51,6 +51,11 @@ describe.runIf(isIntl)("Intl.NumberFormat.prototype.format", () => {
     expect(result.includes(",")).toBe(true);
   });
 
+  test("format applies numberingSystem through ICU", () => {
+    expect(new Intl.NumberFormat("en-US", { numberingSystem: "arab" }).format(12345)).toBe("\u0661\u0662\u066c\u0663\u0664\u0665");
+    expect(new Intl.NumberFormat("en-US", { numberingSystem: "arabext" }).format(12345)).toBe("\u06f1\u06f2\u066c\u06f3\u06f4\u06f5");
+  });
+
   test("currency format produces a string containing the currency symbol", () => {
     const nf = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
     const result = nf.format(9.99);

--- a/tests/built-ins/Intl/RelativeTimeFormat/prototype/format.js
+++ b/tests/built-ins/Intl/RelativeTimeFormat/prototype/format.js
@@ -35,8 +35,10 @@ describe.runIf(isIntl && typeof Intl.RelativeTimeFormat !== "undefined")("Intl.R
   test("formats numbers with the resolved numbering system", () => {
     const optionFormat = new Intl.RelativeTimeFormat("en-US", { numberingSystem: "arab" });
     const localeFormat = new Intl.RelativeTimeFormat("en-US-u-nu-arabext");
+    const icuFormat = new Intl.RelativeTimeFormat("fr", { numberingSystem: "arab" });
 
     expect(optionFormat.format(-1234, "day")).toBe("\u0661\u066c\u0662\u0663\u0664 days ago");
     expect(localeFormat.format(-1234, "day")).toBe("\u06f1\u066c\u06f2\u06f3\u06f4 days ago");
+    expect(icuFormat.format(1234, "day")).toBe("dans \u0661\u066c\u0662\u0663\u0664 jours");
   });
 });

--- a/tests/built-ins/Intl/RelativeTimeFormat/prototype/format.js
+++ b/tests/built-ins/Intl/RelativeTimeFormat/prototype/format.js
@@ -31,4 +31,12 @@ describe.runIf(isIntl && typeof Intl.RelativeTimeFormat !== "undefined")("Intl.R
     expect(shortFormat.format(2, "quarter")).toBe("in 2 qtrs.");
     expect(narrowFormat.format(-2, "quarter")).toBe("2 q ago");
   });
+
+  test("formats numbers with the resolved numbering system", () => {
+    const optionFormat = new Intl.RelativeTimeFormat("en-US", { numberingSystem: "arab" });
+    const localeFormat = new Intl.RelativeTimeFormat("en-US-u-nu-arabext");
+
+    expect(optionFormat.format(-1234, "day")).toBe("\u0661\u066c\u0662\u0663\u0664 days ago");
+    expect(localeFormat.format(-1234, "day")).toBe("\u06f1\u066c\u06f2\u06f3\u06f4 days ago");
+  });
 });

--- a/tests/built-ins/Intl/RelativeTimeFormat/prototype/format.js
+++ b/tests/built-ins/Intl/RelativeTimeFormat/prototype/format.js
@@ -1,0 +1,34 @@
+/*---
+description: Intl.RelativeTimeFormat.prototype.format
+features: [Intl]
+---*/
+
+const isIntl = typeof Intl !== "undefined";
+
+describe.runIf(isIntl && typeof Intl.RelativeTimeFormat !== "undefined")("Intl.RelativeTimeFormat.prototype.format", () => {
+  test("formats numeric relative values with localized direction and plural-sensitive units", () => {
+    const rtf = new Intl.RelativeTimeFormat("en-US", { numeric: "always" });
+
+    expect(rtf.format(-1, "day")).toBe("1 day ago");
+    expect(rtf.format(1, "day")).toBe("in 1 day");
+    expect(rtf.format(-2, "day")).toBe("2 days ago");
+    expect(rtf.format(1000, "day")).toBe("in 1,000 days");
+  });
+
+  test("formats numeric auto names when CLDR defines a relative literal", () => {
+    const rtf = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" });
+
+    expect(rtf.format(-1, "day")).toBe("yesterday");
+    expect(rtf.format(0, "day")).toBe("today");
+    expect(rtf.format(1, "day")).toBe("tomorrow");
+    expect(rtf.format(-2, "day")).toBe("2 days ago");
+  });
+
+  test("formats style-specific relative units", () => {
+    const shortFormat = new Intl.RelativeTimeFormat("en-US", { style: "short" });
+    const narrowFormat = new Intl.RelativeTimeFormat("en-US", { style: "narrow" });
+
+    expect(shortFormat.format(2, "quarter")).toBe("in 2 qtrs.");
+    expect(narrowFormat.format(-2, "quarter")).toBe("2 q ago");
+  });
+});

--- a/tests/built-ins/Intl/RelativeTimeFormat/prototype/formatToParts.js
+++ b/tests/built-ins/Intl/RelativeTimeFormat/prototype/formatToParts.js
@@ -38,6 +38,11 @@ describe.runIf(isIntl && typeof Intl.RelativeTimeFormat !== "undefined")("Intl.R
     expect(numericParts.map((part) => part.type)).toEqual(["integer", "group", "integer"]);
     expect(numericParts.map((part) => part.value)).toEqual(["\u0661", "\u066c", "\u0662\u0663\u0664"]);
     expect(numericParts.every((part) => part.unit === "day")).toBe(true);
+
+    const icuParts = new Intl.RelativeTimeFormat("fr", { numberingSystem: "arab" }).formatToParts(1234, "day");
+    expect(icuParts.map((part) => part.type)).toEqual(["literal", "integer", "group", "integer", "literal"]);
+    expect(icuParts.map((part) => part.value)).toEqual(["dans ", "\u0661", "\u066c", "\u0662\u0663\u0664", " jours"]);
+    expect(icuParts.filter((part) => part.type !== "literal").every((part) => part.unit === "day")).toBe(true);
   });
 
   test("returns literal relative names for numeric auto", () => {

--- a/tests/built-ins/Intl/RelativeTimeFormat/prototype/formatToParts.js
+++ b/tests/built-ins/Intl/RelativeTimeFormat/prototype/formatToParts.js
@@ -25,8 +25,8 @@ describe.runIf(isIntl && typeof Intl.RelativeTimeFormat !== "undefined")("Intl.R
     const parts = rtf.formatToParts(1234.5, "day");
     const numericParts = parts.filter((part) => part.type !== "literal");
 
-    expect(numericParts.map((part) => part.type)).toEqual(["integer", "decimal", "fraction"]);
-    expect(numericParts.map((part) => part.value)).toEqual(["1234", ".", "5"]);
+    expect(numericParts.map((part) => part.type)).toEqual(["integer", "group", "integer", "decimal", "fraction"]);
+    expect(numericParts.map((part) => part.value)).toEqual(["1", ",", "234", ".", "5"]);
     expect(numericParts.every((part) => part.unit === "day")).toBe(true);
     expect(partsString(parts)).toBe(rtf.format(1234.5, "day"));
   });

--- a/tests/built-ins/Intl/RelativeTimeFormat/prototype/formatToParts.js
+++ b/tests/built-ins/Intl/RelativeTimeFormat/prototype/formatToParts.js
@@ -31,6 +31,15 @@ describe.runIf(isIntl && typeof Intl.RelativeTimeFormat !== "undefined")("Intl.R
     expect(partsString(parts)).toBe(rtf.format(1234.5, "day"));
   });
 
+  test("decomposes numbers with the resolved numbering system", () => {
+    const rtf = new Intl.RelativeTimeFormat("en-US", { numberingSystem: "arab" });
+    const numericParts = rtf.formatToParts(-1234, "day").filter((part) => part.type !== "literal");
+
+    expect(numericParts.map((part) => part.type)).toEqual(["integer", "group", "integer"]);
+    expect(numericParts.map((part) => part.value)).toEqual(["\u0661", "\u066c", "\u0662\u0663\u0664"]);
+    expect(numericParts.every((part) => part.unit === "day")).toBe(true);
+  });
+
   test("returns literal relative names for numeric auto", () => {
     const rtf = new Intl.RelativeTimeFormat("en-US", { numeric: "auto" });
     const parts = rtf.formatToParts(-1, "day");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Repair `Intl.RelativeTimeFormat.prototype.format` and `formatToParts` for localized numeric relative output, including `numeric: "auto"`, plural-sensitive units, grouped number parts, negative zero, and non-finite value rejection.
- Thread RelativeTimeFormat `style` through the ICU binding, correct ICU relative quarter/year unit constants, and add an ICU plural/number-format backed repair path for the host ICU relative formatter behavior.
- Tighten RelativeTimeFormat option validation and resolved numbering-system reporting/order.
- Closes #599.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build/GocciaTestRunner tests/built-ins/Intl/RelativeTimeFormat --no-progress --exit-on-first-failure`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-pinned --categories intl402 --filter 'intl402/RelativeTimeFormat/prototype/format/*' --mode bytecode --jobs 1 --output=/tmp/rtf-format.json`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-pinned --categories intl402 --filter 'intl402/RelativeTimeFormat/prototype/formatToParts/*' --mode bytecode --jobs 1 --output=/tmp/rtf-format-parts.json`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-pinned --categories intl402 --filter 'intl402/RelativeTimeFormat/prototype/resolvedOptions/*' --mode bytecode --jobs 1 --output=/tmp/rtf-resolved.json`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-pinned --categories intl402 --filter 'intl402/RelativeTimeFormat/**' --mode bytecode --jobs 1 --output=/tmp/rtf-all.json` now passes 67/80; remaining failures are constructor/prototype/locale support outside this formatting fix.
  - `./build.pas testrunner && ./build/GocciaTestRunner tests` was run; it still reports the existing FFI fixture load failures for `./fixtures/ffi/libfixture.dylib`.
- [ ] Updated documentation
  - No docs update: the public API already documents `Intl.RelativeTimeFormat`; this fixes conformance of existing behavior.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change