### PR TITLE
fix(intl): localize DisplayNames currency codes

### DIFF
--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -219,6 +219,7 @@ const
   UDAT_RELATIVE_MONTHS = 5;
   UDAT_RELATIVE_YEARS = 6;
   UDAT_RELATIVE_QUARTERS = 7;
+  UCURR_LONG_NAME = 1;
 
 type
   TICUErrorCode = LongInt;
@@ -226,6 +227,7 @@ type
   PUChar = PWideChar;
   PPUChar = ^PUChar;
   PLongInt = ^LongInt;
+  PByteBool = ^ByteBool;
 
   TUlocGetDefault = function: PAnsiChar; cdecl;
   TUlocForLanguageTag = function(const ATag: PAnsiChar; ALocaleId: PAnsiChar;
@@ -252,6 +254,9 @@ type
   TUlocGetDisplayCountry = function(const ALocaleId: PAnsiChar; const AInLocaleId: PAnsiChar;
     AResult: PUChar; AMaxResultSize: LongInt;
     var AStatus: TICUErrorCode): LongInt; cdecl;
+  TUcurrGetName = function(const ACurrency: PUChar; const ALocale: PAnsiChar;
+    ANameStyle: LongInt; AIsChoiceFormat: PByteBool; ALength: PLongInt;
+    var AStatus: TICUErrorCode): PUChar; cdecl;
   TUcolOpen = function(const ALocale: PAnsiChar;
     var AStatus: TICUErrorCode): Pointer; cdecl;
   TUcolClose = procedure(ACollator: Pointer); cdecl;
@@ -433,6 +438,7 @@ type
     UlocGetDisplayLanguage: TUlocGetDisplayLanguage;
     UlocGetDisplayScript: TUlocGetDisplayScript;
     UlocGetDisplayCountry: TUlocGetDisplayCountry;
+    UcurrGetName: TUcurrGetName;
     UcolOpen: TUcolOpen;
     UcolClose: TUcolClose;
     UcolStrcoll: TUcolStrcoll;
@@ -590,6 +596,10 @@ begin
   S := ResolveSymbol(AHandle, 'uloc_getDisplayCountry');
   if not Assigned(S) then Exit;
   F.UlocGetDisplayCountry := TUlocGetDisplayCountry(S);
+
+  S := ResolveSymbol(AHandle, 'ucurr_getName');
+  if not Assigned(S) then Exit;
+  F.UcurrGetName := TUcurrGetName(S);
 
   S := ResolveSymbol(AHandle, 'ucol_open');
   if not Assigned(S) then Exit;
@@ -2893,8 +2903,13 @@ var
   Status: TICUErrorCode;
   Buffer: array[0..DISPLAY_BUFFER_CAPACITY - 1] of WideChar;
   ResultLen: LongInt;
-  LocaleAnsi, CodeAnsi: AnsiString;
+  LocaleAnsi, CodeAnsi, LocaleIdAnsi: AnsiString;
   DisplayFn: TUlocGetDisplayName;
+  CurrencyCode: UnicodeString;
+  CurrencyName: PUChar;
+  IsChoiceFormat: ByteBool;
+  LocaleId: string;
+  CurrencyNameStyle: LongInt;
 begin
   Result := False;
   AName := '';
@@ -2904,13 +2919,51 @@ begin
 
   LocaleAnsi := AnsiString(ALocale);
   CodeAnsi := AnsiString(ACode);
+  LocaleId := '';
+
+  if ADisplayType = idntCurrency then
+  begin
+    case AStyle of
+      idnsLong, idnsShort, idnsNarrow: CurrencyNameStyle := UCURR_LONG_NAME;
+    else
+      CurrencyNameStyle := UCURR_LONG_NAME;
+    end;
+    CurrencyCode := UnicodeString(UpperCase(ACode));
+    Status := ICU_SUCCESS;
+    ResultLen := 0;
+    IsChoiceFormat := False;
+    CurrencyName := IntlFunctions.UcurrGetName(PWideChar(CurrencyCode),
+      PAnsiChar(LocaleAnsi), CurrencyNameStyle, @IsChoiceFormat, @ResultLen, Status);
+    if not ICUSucceeded(Status) or not Assigned(CurrencyName) or (ResultLen <= 0) then
+      Exit;
+
+    AName := UnicodePointerToString(CurrencyName, ResultLen);
+    if SameText(AName, string(CurrencyCode)) then
+      Exit;
+    Result := True;
+    Exit;
+  end;
 
   case ADisplayType of
     idntLanguage: DisplayFn := TUlocGetDisplayName(IntlFunctions.UlocGetDisplayLanguage);
-    idntRegion: DisplayFn := TUlocGetDisplayName(IntlFunctions.UlocGetDisplayCountry);
-    idntScript: DisplayFn := TUlocGetDisplayName(IntlFunctions.UlocGetDisplayScript);
+    idntRegion:
+      begin
+        DisplayFn := TUlocGetDisplayName(IntlFunctions.UlocGetDisplayCountry);
+        LocaleId := '_' + ACode;
+      end;
+    idntScript:
+      begin
+        DisplayFn := TUlocGetDisplayName(IntlFunctions.UlocGetDisplayScript);
+        LocaleId := '_' + ACode;
+      end;
   else
     DisplayFn := IntlFunctions.UlocGetDisplayName;
+  end;
+
+  if LocaleId <> '' then
+  begin
+    LocaleIdAnsi := AnsiString(LocaleId);
+    CodeAnsi := LocaleIdAnsi;
   end;
 
   FillChar(Buffer, SizeOf(Buffer), 0);

--- a/tests/built-ins/Intl/DisplayNames/prototype/of.js
+++ b/tests/built-ins/Intl/DisplayNames/prototype/of.js
@@ -1,0 +1,26 @@
+/*---
+description: Intl.DisplayNames.prototype.of
+features: [Intl]
+---*/
+
+const isIntl = typeof Intl !== "undefined";
+
+describe.runIf(isIntl && typeof Intl.DisplayNames !== "undefined")("Intl.DisplayNames.prototype.of", () => {
+  test("returns localized currency display names", () => {
+    const dn = new Intl.DisplayNames("en", { type: "currency" });
+
+    expect(dn.of("USD")).toBe("US Dollar");
+  });
+
+  test("returns localized script display names", () => {
+    const dn = new Intl.DisplayNames("en", { type: "script" });
+
+    expect(dn.of("Latn")).toBe("Latin");
+  });
+
+  test("returns localized region display names", () => {
+    const dn = new Intl.DisplayNames("en", { type: "region" });
+
+    expect(dn.of("US")).toBe("United States");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add ICU `ucurr_getName` binding so `Intl.DisplayNames.prototype.of()` returns localized currency display names instead of raw lowercase codes.
- Pass ICU locale IDs for region and script DisplayNames lookups so those paths stay portable across ICU platforms.
- Closes #603.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Testing performed:
- `./build.pas loader testrunner loaderbare`
- `printf ... | ./build/GocciaScriptLoader` for USD/Latn/US DisplayNames repro
- `./build/GocciaTestRunner tests/built-ins/Intl/DisplayNames/prototype/of.js`
- `./build/GocciaTestRunner tests/built-ins/Intl/DisplayNames --mode=bytecode`
- `./build/GocciaTestRunner tests/built-ins/Intl`
- `./format.pas --check`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-d0c1b455 --categories intl402 --filter 'intl402/DisplayNames/prototype/of/*' --mode bytecode --jobs 1 --verbose` (valid cases pass; existing invalid-code DisplayNames failures remain unrelated)

Full `./build/GocciaTestRunner tests` was also run after `./build.pas tests`; it still fails only the existing FFI fixture-loading cases because `./fixtures/ffi/libfixture.dylib` is absent in this worktree.