### PR TITLE
chore(agent): add tc39-mcp spec lookup workflow

### DIFF
--- a/.agents/skills/gocciascript-issue-validation/SKILL.md
+++ b/.agents/skills/gocciascript-issue-validation/SKILL.md
@@ -7,6 +7,19 @@ description: Validate GocciaScript engine issues against the project-specific te
 
 Project-specific validation rules for GocciaScript issues. Use this skill with the generic `implement-issue` workflow when the issue references test262, ECMAScript/ECMA-402 behavior, or compatibility flags.
 
+## Spec Lookup
+
+For ECMA-262 or ECMA-402 semantics, use the pinned `tc39-mcp@0.1.4` server from `.mcp.example.json` when it is available:
+
+1. Use `spec.search` when the exact clause id is unknown.
+2. Use `clause.get` for the relevant clause before deciding expected behavior.
+3. Use `spec.crossrefs` when behavior depends on abstract operations or cross-spec references.
+4. Use `spec.diff` or `spec.history` when the issue may involve recent prose drift.
+5. Use `test262.search` to map a clause id or feature area to conformance tests.
+6. Use `proposal.list` or `proposal.get` for proposal-stage features.
+
+Record the spec, edition, clause id, section number, and snapshot SHA when the MCP response provides one. If `tc39-mcp` is not available, fall back to the official TC39 sources (`tc39.es/ecma262`, `tc39.es/ecma402`) rather than guessing.
+
 ## Test262 Validation
 
 When an issue references test262 files, patterns, or categories:

--- a/.github/workflows/tc39-mcp-bump.yml
+++ b/.github/workflows/tc39-mcp-bump.yml
@@ -19,9 +19,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - id: latest
         run: |
@@ -46,7 +48,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: chore/tc39-mcp-bump
           commit-message: "chore(tc39-mcp): bump pin to v${{ steps.latest.outputs.version }}"

--- a/.github/workflows/tc39-mcp-bump.yml
+++ b/.github/workflows/tc39-mcp-bump.yml
@@ -1,0 +1,60 @@
+name: tc39-mcp weekly bump
+
+# Pulls the latest tc39-mcp npm version, updates the pinned agent MCP
+# config/docs, and opens a PR. This affects agent spec-lookup tooling only;
+# it does not affect GocciaScript runtime behavior or conformance gates.
+#
+# Cadence: weekly (Mondays 07:30 UTC). Manual trigger available via
+# workflow_dispatch.
+
+on:
+  schedule:
+    - cron: '30 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+
+      - id: latest
+        run: |
+          version=$(npm view tc39-mcp version)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Update pin in agent docs
+        run: bun scripts/tc39-mcp-bump-pin.ts ${{ steps.latest.outputs.version }}
+
+      - id: changed
+        run: |
+          if git diff --quiet -- .mcp.example.json AGENTS.md .agents/skills/gocciascript-issue-validation/SKILL.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "tc39-mcp already pinned to v${{ steps.latest.outputs.version }} — no PR to open."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update PR
+        if: steps.changed.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/tc39-mcp-bump
+          commit-message: "chore(tc39-mcp): bump pin to v${{ steps.latest.outputs.version }}"
+          title: "chore(tc39-mcp): bump pin to v${{ steps.latest.outputs.version }}"
+          body: |
+            Automated bump of the tc39-mcp npm pin to `v${{ steps.latest.outputs.version }}`.
+
+            This updates agent spec-lookup tooling only. It does not change
+            GocciaScript runtime behavior, build outputs, or CI conformance
+            gates.
+
+            Cron: weekly, Mondays 07:30 UTC. See `.github/workflows/tc39-mcp-bump.yml`.
+          labels: |
+            spec compliance
+            automated

--- a/.github/workflows/tc39-mcp-bump.yml
+++ b/.github/workflows/tc39-mcp-bump.yml
@@ -29,13 +29,17 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Update pin in agent docs
-        run: bun scripts/tc39-mcp-bump-pin.ts ${{ steps.latest.outputs.version }}
+        env:
+          VERSION: ${{ steps.latest.outputs.version }}
+        run: bun scripts/tc39-mcp-bump-pin.ts "$VERSION"
 
       - id: changed
+        env:
+          VERSION: ${{ steps.latest.outputs.version }}
         run: |
           if git diff --quiet -- .mcp.example.json AGENTS.md .agents/skills/gocciascript-issue-validation/SKILL.md; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "tc39-mcp already pinned to v${{ steps.latest.outputs.version }} — no PR to open."
+            echo "tc39-mcp already pinned to v${VERSION} — no PR to open."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/test262-bump.yml
+++ b/.github/workflows/test262-bump.yml
@@ -20,9 +20,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - id: latest
         run: |
@@ -51,7 +53,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: chore/test262-bump
           commit-message: "chore(test262): bump pin to ${{ steps.latest.outputs.short }}"

--- a/.github/workflows/toml-test-bump.yml
+++ b/.github/workflows/toml-test-bump.yml
@@ -19,9 +19,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - id: latest
         run: |
@@ -45,7 +47,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: chore/toml-test-bump
           commit-message: "chore(toml-test): bump pin to ${{ steps.latest.outputs.short }}"

--- a/.github/workflows/yaml-test-bump.yml
+++ b/.github/workflows/yaml-test-bump.yml
@@ -19,9 +19,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - id: latest
         run: |
@@ -45,7 +47,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: chore/yaml-test-bump
           commit-message: "chore(yaml-test): bump pin to ${{ steps.latest.outputs.short }}"

--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tc39": {
+      "command": "npx",
+      "args": ["tc39-mcp@0.1.4"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,23 @@ Assistants should treat CONTRIBUTING as authoritative for contribution requireme
 - **Match the project's workflow**: branch from `main`, focused diffs, tests and docs updated per CONTRIBUTING.
 - **Do not paste large chunks of CONTRIBUTING into this file** when CONTRIBUTING changes—edit CONTRIBUTING instead, and keep AGENTS short.
 
+## TC39 spec lookup
+
+For ECMAScript or ECMA-402 behavior, prefer the `tc39-mcp` MCP server when it is available. The repo includes `.mcp.example.json` with the pinned local stdio setup:
+
+```json
+{
+  "mcpServers": {
+    "tc39": {
+      "command": "npx",
+      "args": ["tc39-mcp@0.1.4"]
+    }
+  }
+}
+```
+
+Use `spec.search` when you do not know the clause id, `clause.get` when you do, `spec.crossrefs` to follow abstract-operation dependencies, `spec.diff` / `spec.history` for prose drift, `test262.search` to map clauses to conformance tests, and `proposal.list` / `proposal.get` for proposal-stage features. When making durable claims in code review, issues, or PR notes, record the spec, edition, clause id, section number, and snapshot SHA when the MCP response provides one. If `tc39-mcp` is unavailable, fall back to the official TC39 sources (`tc39.es/ecma262`, `tc39.es/ecma402`) rather than guessing.
+
 ## Quick checks
 
 ```bash

--- a/scripts/tc39-mcp-bump-pin.ts
+++ b/scripts/tc39-mcp-bump-pin.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+/**
+ * tc39-mcp-bump-pin.ts
+ *
+ * Update checked-in tc39-mcp npm version pins.
+ * Invoked by the weekly tc39-mcp-bump.yml workflow.
+ *
+ * Usage:
+ *   bun scripts/tc39-mcp-bump-pin.ts <semver-version> [target...]
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+
+const VERSION_RE =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const PIN_RE = /tc39-mcp@((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)/g;
+
+const DEFAULT_TARGETS = [
+  ".mcp.example.json",
+  "AGENTS.md",
+  ".agents/skills/gocciascript-issue-validation/SKILL.md",
+];
+
+function updateTarget(target: string, version: string): boolean {
+  let text: string;
+  try {
+    text = readFileSync(target, "utf8");
+  } catch (err) {
+    console.error(`Failed to read ${target}: ${(err as Error).message}`);
+    process.exitCode = 1;
+    return false;
+  }
+
+  let seen = 0;
+  let changed = 0;
+  const updated = text.replace(PIN_RE, (full, oldVersion) => {
+    seen++;
+    if (oldVersion === version) return full;
+    changed++;
+    return `tc39-mcp@${version}`;
+  });
+
+  if (seen === 0) {
+    console.error(`${target}: no tc39-mcp@<version> pin found`);
+    process.exitCode = 1;
+    return false;
+  }
+
+  if (changed > 0) {
+    writeFileSync(target, updated);
+    console.log(`${target}: bumped ${changed} pin(s) -> ${version}`);
+    return true;
+  }
+
+  console.log(`${target}: already at ${version}`);
+  return false;
+}
+
+function main(argv: string[]): number {
+  if (argv.length < 1 || !VERSION_RE.test(argv[0])) {
+    console.error(
+      "Usage: bun scripts/tc39-mcp-bump-pin.ts <semver-version> [target...]",
+    );
+    return 2;
+  }
+
+  const [version, ...targets] = argv;
+  const resolvedTargets = targets.length > 0 ? targets : DEFAULT_TARGETS;
+  for (const target of resolvedTargets) {
+    updateTarget(target, version);
+  }
+
+  return process.exitCode ?? 0;
+}
+
+process.exit(main(process.argv.slice(2)));


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add a pinned `.mcp.example.json` for local `tc39-mcp` stdio setup.
- Document `tc39-mcp` as the preferred agent path for ECMA-262 / ECMA-402 lookup and issue validation.
- Add a weekly `tc39-mcp` npm pin bump workflow plus a small Bun updater script.
- Non-goal: this does not change GocciaScript runtime behavior, build outputs, or conformance gates.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `jq -e . .mcp.example.json`
  - `bun scripts/tc39-mcp-bump-pin.ts 0.1.4`
  - Temp-fixture bump test across `.mcp.example.json`, `AGENTS.md`, and the issue-validation skill
  - `git diff --check`
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change