### PR TITLE
fix(bytecode): preserve VM roots during explicit GC

### DIFF
--- a/docs/test262.md
+++ b/docs/test262.md
@@ -163,6 +163,8 @@ Bodies see only the identifiers stock test262 expects:
 - `assert` and its methods (from `assert.js`)
 - `$DONE`, `$DONOTEVALUATE` (from `sta.js` / `doneprintHandle.js` when included)
 - `print` (Goccia engine global; the `positive_async` wrapper calls it to emit the `Test262:Async*` markers after `await __donePromise`. The bundled `doneprintHandle.js` itself only resolves / rejects `__donePromise`; it does NOT call `print`.)
+- `$262` host hooks implemented by Goccia's bundled adaptation:
+  `detachArrayBuffer` and `gc`
 - Anything declared in test-included harness files (e.g. `compareArray`,
   `propertyHelper`)
 
@@ -173,8 +175,8 @@ Bodies do NOT see:
   `spyOn` — none of these exist on the Bare engine.
 - `console`, `fetch`, `URL`, `performance` — Bare doesn't register
   Goccia's runtime extension.
-- `$262` — Goccia doesn't implement test262's optional host hooks
-  object. Tests that depend on it fail honestly.
+- Optional `$262` hooks outside the bundled implementation. Tests that
+  depend on unavailable host hooks fail honestly.
 
 ## Bundled harness adaptations
 

--- a/scripts/test262_harness/$262.js
+++ b/scripts/test262_harness/$262.js
@@ -16,4 +16,8 @@ var $262 = {
   detachArrayBuffer(buffer) {
     buffer.transfer();
   },
+
+  gc() {
+    Goccia.gc();
+  },
 };

--- a/source/units/Goccia.Executor.Bytecode.pas
+++ b/source/units/Goccia.Executor.Bytecode.pas
@@ -83,6 +83,7 @@ procedure TGocciaBytecodeExecutor.Initialize(const AGlobalScope: TGocciaScope;
   const AModuleLoader: TGocciaModuleLoader; const ASourcePath: string);
 begin
   inherited;
+  FVM.EnsureStackRootRegistered;
   FVM.GlobalScope := AGlobalScope;
   FVM.GlobalThisValue := AGlobalScope.ThisValue;
   FVM.LoadModule := AModuleLoader.LoadModule;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -112,6 +112,7 @@ type
     FLastClosureThisValue: TGocciaRegister;
     FPrivateInitializerReceiver: TGocciaValue;
     FStackRoot: TGocciaVMStackRoot;
+    FStackRootRegistered: Boolean;
     FTempSavedStateRoots: TGocciaVMSavedStateRootArray;
     FTempSavedStateRootCount: Integer;
     function ConstantToValue(const AConstant: TGocciaBytecodeConstant): TGocciaValue;
@@ -281,6 +282,7 @@ type
   public
     constructor Create;
     destructor Destroy; override;
+    procedure EnsureStackRootRegistered;
     function ExecuteFunction(const ATemplate: TGocciaFunctionTemplate): TGocciaValue;
     function ExecuteModule(const AModule: TGocciaBytecodeModule): TGocciaValue;
     property GlobalScope: TGocciaScope read FGlobalScope write FGlobalScope;
@@ -970,6 +972,7 @@ constructor TGocciaVMStackRoot.Create(const AVM: TGocciaVM);
 begin
   FVM := AVM;
   inherited Create;
+  GCIndex := -1;
   if Assigned(TGarbageCollector.Instance) then
     TGarbageCollector.Instance.RegisterObject(Self);
 end;
@@ -3122,15 +3125,15 @@ begin
   SetLength(FFrameStack, 64);
   FFrameStackCount := 0;
   FStackRoot := TGocciaVMStackRoot.Create(Self);
-  if Assigned(TGarbageCollector.Instance) then
-    TGarbageCollector.Instance.AddRootObject(FStackRoot);
+  EnsureStackRootRegistered;
 end;
 
 destructor TGocciaVM.Destroy;
 var
   I: Integer;
 begin
-  if Assigned(TGarbageCollector.Instance) and Assigned(FStackRoot) then
+  if Assigned(TGarbageCollector.Instance) and Assigned(FStackRoot) and
+     FStackRootRegistered then
     TGarbageCollector.Instance.RemoveRootObject(FStackRoot);
   FStackRoot.Free;
   if Assigned(FActiveDecoratorSession) then
@@ -3146,6 +3149,23 @@ begin
   FHandlerStack.Free;
   SetExceptionMask(FPreviousExceptionMask);
   inherited;
+end;
+
+procedure TGocciaVM.EnsureStackRootRegistered;
+var
+  GC: TGarbageCollector;
+begin
+  if FStackRootRegistered or not Assigned(FStackRoot) then
+    Exit;
+
+  GC := TGarbageCollector.Instance;
+  if not Assigned(GC) then
+    Exit;
+
+  if FStackRoot.GCIndex < 0 then
+    GC.RegisterObject(FStackRoot);
+  GC.AddRootObject(FStackRoot);
+  FStackRootRegistered := True;
 end;
 
 destructor TGocciaBytecodeFunctionValue.Destroy;

--- a/tests/built-ins/global-properties/goccia.js
+++ b/tests/built-ins/global-properties/goccia.js
@@ -36,5 +36,14 @@ describe.runIf(hasGoccia)("Goccia global", () => {
       Goccia.gc();
       Goccia.gc();
     });
+
+    test("gc preserves reachable objects after expression temporaries", () => {
+      const array = [];
+      array.length;
+      Goccia.gc();
+      array.t = 3;
+      Goccia.gc();
+      expect(array.t).toBe(3);
+    });
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Register the bytecode VM stack root after the engine initializes the thread-local GC, so explicit `Goccia.gc()` preserves reachable bytecode locals.
- Add the test262 `$262.gc()` host hook by delegating to `Goccia.gc()`.
- Update test262 harness docs and add a bytecode regression for reachable objects across explicit GC.
- Closes #552.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Verification run after merging `origin/main`:

- `./build.pas clean && ./build.pas loaderbare`
- `./build.pas testrunner`
- `./build/GocciaTestRunner tests/built-ins/global-properties/goccia.js --mode=bytecode`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/regress/regress-596103.js' --mode bytecode --jobs 1 --verbose`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/statements/for-in-with-gc-and-unvisited-deletion.js' --mode bytecode --jobs 1 --verbose`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/regress/regress-596103.js' --mode interpreted --jobs 1 --verbose`
- `./fixtures/ffi/build.sh`
- `./build/GocciaTestRunner tests` (9995/9995 passed)
- `./format.pas --check`
