### PR TITLE
fix(typedarray): use spec descriptors for built-ins

### DIFF
--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -891,7 +891,7 @@ begin
     TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create('TypedArray'), [pfConfigurable]));
   FTypedArrayIntrinsic.DefineProperty(PROP_LENGTH,
     TGocciaPropertyDescriptorData.Create(TGocciaNumberLiteralValue.Create(0), [pfConfigurable]));
-  TypedArrayStatic := TGocciaTypedArrayStaticFrom.Create(takUint8);
+  TypedArrayStatic := TGocciaTypedArrayStaticFrom.Create;
   FTypedArrayIntrinsic.DefineProperty(PROP_FROM,
     TGocciaPropertyDescriptorData.Create(
       TGocciaNativeFunctionValue.CreateWithoutPrototype(

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -779,6 +779,7 @@ var
   NumberConstructor: TGocciaNumberClassValue;
   BooleanConstructor: TGocciaBooleanClassValue;
   TypeDef: TGocciaTypeDefinition;
+  TypedArrayStatic: TGocciaTypedArrayStaticFrom;
 begin
   TGocciaObjectValue.InitializeSharedPrototype;
   TypeDef.ConstructorName := CONSTRUCTOR_OBJECT;
@@ -890,6 +891,17 @@ begin
     TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create('TypedArray'), [pfConfigurable]));
   FTypedArrayIntrinsic.DefineProperty(PROP_LENGTH,
     TGocciaPropertyDescriptorData.Create(TGocciaNumberLiteralValue.Create(0), [pfConfigurable]));
+  TypedArrayStatic := TGocciaTypedArrayStaticFrom.Create(takUint8);
+  FTypedArrayIntrinsic.DefineProperty(PROP_FROM,
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(
+        TypedArrayStatic.TypedArrayFrom, PROP_FROM, 1),
+      [pfConfigurable, pfWritable]));
+  FTypedArrayIntrinsic.DefineProperty(PROP_OF,
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(
+        TypedArrayStatic.TypedArrayOf, PROP_OF, 0),
+      [pfConfigurable, pfWritable]));
 
   RegisterTypedArrayConstructor(CONSTRUCTOR_INT8_ARRAY, takInt8, ObjectConstructor);
   RegisterTypedArrayConstructor(CONSTRUCTOR_UINT8_ARRAY, takUint8, ObjectConstructor);
@@ -992,22 +1004,16 @@ procedure TGocciaEngine.RegisterTypedArrayConstructor(const AName: string; const
 var
   TAConstructor: TGocciaTypedArrayClassValue;
   BPE: TGocciaNumberLiteralValue;
-  FromFn, OfFn: TGocciaTypedArrayStaticFrom;
   Encoding: TGocciaUint8ArrayEncoding;
 begin
   TAConstructor := TGocciaTypedArrayClassValue.Create(AName, FTypedArrayIntrinsic, AKind);
   TGocciaTypedArrayValue.ExposePrototype(TAConstructor);
   TGocciaTypedArrayValue.SetSharedPrototypeParent(AObjectConstructor.Prototype);
   BPE := TGocciaNumberLiteralValue.Create(TGocciaTypedArrayValue.BytesPerElement(AKind));
-  TAConstructor.SetProperty(PROP_BYTES_PER_ELEMENT, BPE);
-  TAConstructor.Prototype.AssignProperty(PROP_BYTES_PER_ELEMENT, BPE);
-
-  FromFn := TGocciaTypedArrayStaticFrom.Create(AKind);
-  TAConstructor.SetProperty(PROP_FROM,
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(FromFn.TypedArrayFrom, 'from', 1));
-  OfFn := TGocciaTypedArrayStaticFrom.Create(AKind);
-  TAConstructor.SetProperty(PROP_OF,
-    TGocciaNativeFunctionValue.CreateWithoutPrototype(OfFn.TypedArrayOf, 'of', 0));
+  TAConstructor.DefineProperty(PROP_BYTES_PER_ELEMENT,
+    TGocciaPropertyDescriptorData.Create(BPE, []));
+  TAConstructor.Prototype.DefineProperty(PROP_BYTES_PER_ELEMENT,
+    TGocciaPropertyDescriptorData.Create(BPE, []));
 
   // Uint8Array-only: Base64/Hex encoding methods (TC39 Uint8Array Base64)
   if AKind = takUint8 then
@@ -1015,20 +1021,38 @@ begin
     Encoding := TGocciaUint8ArrayEncoding.Create;
 
     // Static methods on Uint8Array constructor
-    TAConstructor.SetProperty(PROP_FROM_BASE64,
-      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.FromBase64, 'fromBase64', 1));
-    TAConstructor.SetProperty(PROP_FROM_HEX,
-      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.FromHex, 'fromHex', 1));
+    TAConstructor.DefineProperty(PROP_FROM_BASE64,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Encoding.FromBase64, PROP_FROM_BASE64, 1),
+        [pfConfigurable, pfWritable]));
+    TAConstructor.DefineProperty(PROP_FROM_HEX,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Encoding.FromHex, PROP_FROM_HEX, 1),
+        [pfConfigurable, pfWritable]));
 
     // Prototype methods on Uint8Array.prototype
-    TAConstructor.Prototype.AssignProperty(PROP_TO_BASE64,
-      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.ToBase64, 'toBase64', 0));
-    TAConstructor.Prototype.AssignProperty(PROP_TO_HEX,
-      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.ToHex, 'toHex', 0));
-    TAConstructor.Prototype.AssignProperty(PROP_SET_FROM_BASE64,
-      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.SetFromBase64, 'setFromBase64', 1));
-    TAConstructor.Prototype.AssignProperty(PROP_SET_FROM_HEX,
-      TGocciaNativeFunctionValue.CreateWithoutPrototype(Encoding.SetFromHex, 'setFromHex', 1));
+    TAConstructor.Prototype.DefineProperty(PROP_TO_BASE64,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Encoding.ToBase64, PROP_TO_BASE64, 0),
+        [pfConfigurable, pfWritable]));
+    TAConstructor.Prototype.DefineProperty(PROP_TO_HEX,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Encoding.ToHex, PROP_TO_HEX, 0),
+        [pfConfigurable, pfWritable]));
+    TAConstructor.Prototype.DefineProperty(PROP_SET_FROM_BASE64,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Encoding.SetFromBase64, PROP_SET_FROM_BASE64, 1),
+        [pfConfigurable, pfWritable]));
+    TAConstructor.Prototype.DefineProperty(PROP_SET_FROM_HEX,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Encoding.SetFromHex, PROP_SET_FROM_HEX, 1),
+        [pfConfigurable, pfWritable]));
 
     // Uint8Array instances use constructor's prototype (encoding methods + shared chain)
     TGocciaTypedArrayValue.SetUint8Prototype(TAConstructor.Prototype);

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -298,6 +298,7 @@ resourcestring
   SErrorTypedArrayFromRequiresArg = 'TypedArray.from requires at least one argument';
   SErrorTypedArrayFromMapFn = 'TypedArray.from mapfn must be a function';
   SErrorTypedArrayFromSource = 'TypedArray.from requires an array-like or iterable source';
+  SErrorTypedArrayStaticReceiver = '%s requires a TypedArray constructor receiver';
   SErrorInvalidTypedArrayIndex = 'Invalid index';
   SErrorInvalidTypedArrayLength = 'Invalid typed array length';
   SErrorTypedArrayStartOffsetNonNegative = 'Start offset of %s must be non-negative';

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -269,6 +269,7 @@ resourcestring
   SSuggestTypedArrayThisType = 'TypedArray methods must be called on a TypedArray instance';
   SSuggestTypedArrayCallable = 'pass a function as the callback argument';
   SSuggestTypedArraySetSource = 'pass an Array or TypedArray as the source';
+  SSuggestTypedArrayConstructorReceiver = 'call the method on a TypedArray constructor such as Uint8Array';
   SSuggestTypedArrayLength = 'the length or offset is outside the valid range for this buffer';
   SSuggestTypedArrayAlignment = 'the byte offset must be aligned to the element size of the TypedArray';
   SSuggestBigIntTypedArrayValue = 'BigInt64Array and BigUint64Array only accept BigInt values — use BigInt(n) to convert';

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -189,6 +189,18 @@ begin
     Result := nil;
 end;
 
+function RequireTypedArrayConstructorKind(
+  const AThisValue: TGocciaValue;
+  const AMethod: string): TGocciaTypedArrayKind;
+begin
+  if AThisValue is TGocciaTypedArrayClassValue then
+    Exit(TGocciaTypedArrayClassValue(AThisValue).Kind);
+
+  ThrowTypeError(Format(SErrorTypedArrayStaticReceiver, [AMethod]),
+    SSuggestTypedArrayConstructorReceiver);
+  Result := takUint8;
+end;
+
 class function TGocciaTypedArrayValue.BytesPerElement(const AKind: TGocciaTypedArrayKind): Integer;
 begin
   case AKind of
@@ -2512,12 +2524,14 @@ var
   MapArgs: TGocciaArgumentsCollection;
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
+  ConstructorKind: TGocciaTypedArrayKind;
   Values: TGocciaValueList;
   SrcObj: TGocciaObjectValue;
   SourceRoot, MapFnRoot, ThisRoot, ResultRoot: TGocciaTempRoot;
   ValueRoots: array of TGocciaTempRoot;
   ValueRootCount: Integer;
 begin
+  ConstructorKind := RequireTypedArrayConstructorKind(AThisValue, 'TypedArray.from');
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorTypedArrayFromRequiresArg, SSuggestTypedArraySetSource);
   Source := AArgs.GetElement(0);
@@ -2575,7 +2589,7 @@ begin
         finally
           TGarbageCollector.Instance.RemoveTempRoot(Iterator);
         end;
-        NewTA := TGocciaTypedArrayValue.Create(FKind, Values.Count);
+        NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, Values.Count);
         AddTempRootIfNeeded(ResultRoot, NewTA);
         try
           for I := 0 to Values.Count - 1 do
@@ -2609,7 +2623,7 @@ begin
     if Source is TGocciaTypedArrayValue then
     begin
       SrcTA := TGocciaTypedArrayValue(Source);
-      NewTA := TGocciaTypedArrayValue.Create(FKind, SrcTA.Length);
+      NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, SrcTA.Length);
       AddTempRootIfNeeded(ResultRoot, NewTA);
       try
         for I := 0 to SrcTA.Length - 1 do
@@ -2637,7 +2651,7 @@ begin
     if Source is TGocciaArrayValue then
     begin
       SrcArr := TGocciaArrayValue(Source);
-      NewTA := TGocciaTypedArrayValue.Create(FKind, SrcArr.Elements.Count);
+      NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, SrcArr.Elements.Count);
       AddTempRootIfNeeded(ResultRoot, NewTA);
       try
         for I := 0 to SrcArr.Elements.Count - 1 do
@@ -2665,7 +2679,7 @@ begin
     // Step 7: array-like path — ToObject(source), LengthOfArrayLike, indexed Get
     SrcObj := ToObject(Source);
     Len := LengthOfArrayLike(SrcObj);
-    NewTA := TGocciaTypedArrayValue.Create(FKind, Len);
+    NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, Len);
     AddTempRootIfNeeded(ResultRoot, NewTA);
     try
       for I := 0 to Len - 1 do
@@ -2699,9 +2713,11 @@ end;
 function TGocciaTypedArrayStaticFrom.TypedArrayOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   NewTA: TGocciaTypedArrayValue;
+  ConstructorKind: TGocciaTypedArrayKind;
   I: Integer;
 begin
-  NewTA := TGocciaTypedArrayValue.Create(FKind, AArgs.Length);
+  ConstructorKind := RequireTypedArrayConstructorKind(AThisValue, 'TypedArray.of');
+  NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, AArgs.Length);
   for I := 0 to AArgs.Length - 1 do
     NewTA.WriteValueToElement(I, AArgs.GetElement(I));
   Result := NewTA;

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -140,10 +140,8 @@ type
   end;
 
   TGocciaTypedArrayStaticFrom = class
-  private
-    FKind: TGocciaTypedArrayKind;
   public
-    constructor Create(const AKind: TGocciaTypedArrayKind);
+    constructor Create;
     function TypedArrayFrom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function TypedArrayOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
@@ -192,9 +190,22 @@ end;
 function RequireTypedArrayConstructorKind(
   const AThisValue: TGocciaValue;
   const AMethod: string): TGocciaTypedArrayKind;
+var
+  ClassValue: TGocciaClassValue;
 begin
   if AThisValue is TGocciaTypedArrayClassValue then
     Exit(TGocciaTypedArrayClassValue(AThisValue).Kind);
+
+  if AThisValue is TGocciaClassValue then
+  begin
+    ClassValue := TGocciaClassValue(AThisValue).SuperClass;
+    while Assigned(ClassValue) do
+    begin
+      if ClassValue is TGocciaTypedArrayClassValue then
+        Exit(TGocciaTypedArrayClassValue(ClassValue).Kind);
+      ClassValue := ClassValue.SuperClass;
+    end;
+  end;
 
   ThrowTypeError(Format(SErrorTypedArrayStaticReceiver, [AMethod]),
     SSuggestTypedArrayConstructorReceiver);
@@ -2503,10 +2514,9 @@ end;
 
 { TGocciaTypedArrayStaticFrom }
 
-constructor TGocciaTypedArrayStaticFrom.Create(const AKind: TGocciaTypedArrayKind);
+constructor TGocciaTypedArrayStaticFrom.Create;
 begin
   inherited Create;
-  FKind := AKind;
 end;
 
 // ES2026 §23.2.2.1 %TypedArray%.from(source [, mapfn [, thisArg]])

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -188,29 +188,52 @@ begin
     Result := nil;
 end;
 
-function RequireTypedArrayConstructorKind(
+function RequireTypedArrayConstructor(
   const AThisValue: TGocciaValue;
-  const AMethod: string): TGocciaTypedArrayKind;
+  const AMethod: string): TGocciaClassValue;
 var
   ClassValue: TGocciaClassValue;
 begin
   if AThisValue is TGocciaTypedArrayClassValue then
-    Exit(TGocciaTypedArrayClassValue(AThisValue).Kind);
+    Exit(TGocciaClassValue(AThisValue));
 
   if AThisValue is TGocciaClassValue then
   begin
-    ClassValue := TGocciaClassValue(AThisValue).SuperClass;
+    ClassValue := TGocciaClassValue(AThisValue);
     while Assigned(ClassValue) do
     begin
       if ClassValue is TGocciaTypedArrayClassValue then
-        Exit(TGocciaTypedArrayClassValue(ClassValue).Kind);
+        Exit(TGocciaClassValue(AThisValue));
       ClassValue := ClassValue.SuperClass;
     end;
   end;
 
   ThrowTypeError(Format(SErrorTypedArrayStaticReceiver, [AMethod]),
     SSuggestTypedArrayConstructorReceiver);
-  Result := takUint8;
+  Result := nil;
+end;
+
+function CreateTypedArrayFromConstructor(const AConstructor: TGocciaClassValue;
+  const AMethod: string; const ALength: Integer): TGocciaTypedArrayValue;
+var
+  ConstructArgs: TGocciaArgumentsCollection;
+  Constructed: TGocciaValue;
+begin
+  ConstructArgs := TGocciaArgumentsCollection.Create;
+  try
+    ConstructArgs.Add(TGocciaNumberLiteralValue.Create(ALength));
+    Constructed := AConstructor.Instantiate(ConstructArgs, AConstructor);
+  finally
+    ConstructArgs.Free;
+  end;
+
+  if not (Constructed is TGocciaTypedArrayValue) then
+    ThrowTypeError(Format(SErrorTypedArrayRequiresTypedArray, [AMethod]),
+      SSuggestTypedArrayConstructorReceiver);
+
+  Result := TGocciaTypedArrayValue(Constructed);
+  if Result.Length < ALength then
+    ThrowTypeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
 end;
 
 class function TGocciaTypedArrayValue.BytesPerElement(const AKind: TGocciaTypedArrayKind): Integer;
@@ -2580,14 +2603,14 @@ var
   MapArgs: TGocciaArgumentsCollection;
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
-  ConstructorKind: TGocciaTypedArrayKind;
+  ConstructorValue: TGocciaClassValue;
   Values: TGocciaValueList;
   SrcObj: TGocciaObjectValue;
   SourceRoot, MapFnRoot, ThisRoot, ResultRoot: TGocciaTempRoot;
   ValueRoots: array of TGocciaTempRoot;
   ValueRootCount: Integer;
 begin
-  ConstructorKind := RequireTypedArrayConstructorKind(AThisValue, 'TypedArray.from');
+  ConstructorValue := RequireTypedArrayConstructor(AThisValue, 'TypedArray.from');
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorTypedArrayFromRequiresArg, SSuggestTypedArraySetSource);
   Source := AArgs.GetElement(0);
@@ -2645,7 +2668,8 @@ begin
         finally
           TGarbageCollector.Instance.RemoveTempRoot(Iterator);
         end;
-        NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, Values.Count);
+        NewTA := CreateTypedArrayFromConstructor(ConstructorValue,
+          'TypedArray.from', Values.Count);
         AddTempRootIfNeeded(ResultRoot, NewTA);
         try
           for I := 0 to Values.Count - 1 do
@@ -2679,7 +2703,8 @@ begin
     if Source is TGocciaTypedArrayValue then
     begin
       SrcTA := TGocciaTypedArrayValue(Source);
-      NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, SrcTA.Length);
+      NewTA := CreateTypedArrayFromConstructor(ConstructorValue,
+        'TypedArray.from', SrcTA.Length);
       AddTempRootIfNeeded(ResultRoot, NewTA);
       try
         for I := 0 to SrcTA.Length - 1 do
@@ -2707,7 +2732,8 @@ begin
     if Source is TGocciaArrayValue then
     begin
       SrcArr := TGocciaArrayValue(Source);
-      NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, SrcArr.Elements.Count);
+      NewTA := CreateTypedArrayFromConstructor(ConstructorValue,
+        'TypedArray.from', SrcArr.Elements.Count);
       AddTempRootIfNeeded(ResultRoot, NewTA);
       try
         for I := 0 to SrcArr.Elements.Count - 1 do
@@ -2735,7 +2761,8 @@ begin
     // Step 7: array-like path — ToObject(source), LengthOfArrayLike, indexed Get
     SrcObj := ToObject(Source);
     Len := LengthOfArrayLike(SrcObj);
-    NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, Len);
+    NewTA := CreateTypedArrayFromConstructor(ConstructorValue,
+      'TypedArray.from', Len);
     AddTempRootIfNeeded(ResultRoot, NewTA);
     try
       for I := 0 to Len - 1 do
@@ -2769,11 +2796,12 @@ end;
 function TGocciaTypedArrayStaticFrom.TypedArrayOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   NewTA: TGocciaTypedArrayValue;
-  ConstructorKind: TGocciaTypedArrayKind;
+  ConstructorValue: TGocciaClassValue;
   I: Integer;
 begin
-  ConstructorKind := RequireTypedArrayConstructorKind(AThisValue, 'TypedArray.of');
-  NewTA := TGocciaTypedArrayValue.Create(ConstructorKind, AArgs.Length);
+  ConstructorValue := RequireTypedArrayConstructor(AThisValue, 'TypedArray.of');
+  NewTA := CreateTypedArrayFromConstructor(ConstructorValue,
+    'TypedArray.of', AArgs.Length);
   for I := 0 to AArgs.Length - 1 do
     NewTA.WriteValueToElement(I, AArgs.GetElement(I));
   Result := NewTA;

--- a/tests/built-ins/TypedArray/constructors.js
+++ b/tests/built-ins/TypedArray/constructors.js
@@ -248,6 +248,38 @@ describe("TypedArray constructors", () => {
       expect(new Int32Array(0).BYTES_PER_ELEMENT).toBe(4);
       expect(new Float64Array(0).BYTES_PER_ELEMENT).toBe(8);
     });
+
+    test("BYTES_PER_ELEMENT descriptors are non-writable, non-enumerable, and non-configurable", () => {
+      const cases = [
+        [Int8Array, 1],
+        [Uint8Array, 1],
+        [Uint8ClampedArray, 1],
+        [Int16Array, 2],
+        [Uint16Array, 2],
+        [Int32Array, 4],
+        [Uint32Array, 4],
+        [Float16Array, 2],
+        [Float32Array, 4],
+        [Float64Array, 8],
+        [BigInt64Array, 8],
+        [BigUint64Array, 8],
+      ];
+
+      for (const [TA, bytes] of cases) {
+        expect(Object.getOwnPropertyDescriptor(TA, "BYTES_PER_ELEMENT")).toEqual({
+          value: bytes,
+          writable: false,
+          enumerable: false,
+          configurable: false,
+        });
+        expect(Object.getOwnPropertyDescriptor(TA.prototype, "BYTES_PER_ELEMENT")).toEqual({
+          value: bytes,
+          writable: false,
+          enumerable: false,
+          configurable: false,
+        });
+      }
+    });
   });
 
   describe("negative length throws RangeError", () => {

--- a/tests/built-ins/TypedArray/for-in/detached-enumeration.js
+++ b/tests/built-ins/TypedArray/for-in/detached-enumeration.js
@@ -1,0 +1,11 @@
+test("detached typed arrays do not enumerate inherited built-in names", () => {
+  const sample = new Uint8Array(3);
+  const keys = [];
+
+  sample.buffer.transfer();
+  for (const key in sample) {
+    keys.push(key);
+  }
+
+  expect(keys).toEqual([]);
+});

--- a/tests/built-ins/TypedArray/for-in/goccia.json
+++ b/tests/built-ins/TypedArray/for-in/goccia.json
@@ -1,0 +1,3 @@
+{
+  "compat-for-in-loop": true
+}

--- a/tests/built-ins/TypedArray/from.js
+++ b/tests/built-ins/TypedArray/from.js
@@ -1,4 +1,18 @@
 describe("TypedArray.from", () => {
+  test("is inherited from %TypedArray% with built-in method attributes", () => {
+    const typedArrayIntrinsic = Object.getPrototypeOf(Uint8Array);
+
+    expect(Object.getOwnPropertyDescriptor(Uint8Array, "from")).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(typedArrayIntrinsic, "from")).toEqual({
+      value: Uint8Array.from,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+    expect(Int16Array.from([256])[0]).toBe(256);
+    expect(Uint8Array.from.call(Int16Array, [256])[0]).toBe(256);
+  });
+
   test("from another typed array with truncation", () => {
     const src = new Float64Array([1.7, 2.3, 3.9]);
     const ta = Int32Array.from(src);

--- a/tests/built-ins/TypedArray/from.js
+++ b/tests/built-ins/TypedArray/from.js
@@ -11,6 +11,8 @@ describe("TypedArray.from", () => {
     });
     expect(Int16Array.from([256])[0]).toBe(256);
     expect(Uint8Array.from.call(Int16Array, [256])[0]).toBe(256);
+    class MyInt16Array extends Int16Array {}
+    expect(MyInt16Array.from([256])[0]).toBe(256);
   });
 
   test("from another typed array with truncation", () => {

--- a/tests/built-ins/TypedArray/from.js
+++ b/tests/built-ins/TypedArray/from.js
@@ -12,7 +12,10 @@ describe("TypedArray.from", () => {
     expect(Int16Array.from([256])[0]).toBe(256);
     expect(Uint8Array.from.call(Int16Array, [256])[0]).toBe(256);
     class MyInt16Array extends Int16Array {}
-    expect(MyInt16Array.from([256])[0]).toBe(256);
+    const subclassResult = MyInt16Array.from([256]);
+    expect(subclassResult[0]).toBe(256);
+    expect(subclassResult instanceof MyInt16Array).toBe(true);
+    expect(Object.getPrototypeOf(subclassResult)).toBe(MyInt16Array.prototype);
   });
 
   test("from another typed array with truncation", () => {

--- a/tests/built-ins/TypedArray/fromBase64.js
+++ b/tests/built-ins/TypedArray/fromBase64.js
@@ -1,4 +1,13 @@
 describe("Uint8Array.fromBase64", () => {
+  test("has built-in method attributes", () => {
+    expect(Object.getOwnPropertyDescriptor(Uint8Array, "fromBase64")).toEqual({
+      value: Uint8Array.fromBase64,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
   test("decodes standard base64 string", () => {
     const result = Uint8Array.fromBase64("SGVsbG8=");
     expect(result.length).toBe(5);

--- a/tests/built-ins/TypedArray/fromHex.js
+++ b/tests/built-ins/TypedArray/fromHex.js
@@ -1,4 +1,13 @@
 describe("Uint8Array.fromHex", () => {
+  test("has built-in method attributes", () => {
+    expect(Object.getOwnPropertyDescriptor(Uint8Array, "fromHex")).toEqual({
+      value: Uint8Array.fromHex,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
   test("decodes hex string to Uint8Array", () => {
     const result = Uint8Array.fromHex("48656c6c6f");
     expect(result.length).toBe(5);

--- a/tests/built-ins/TypedArray/of.js
+++ b/tests/built-ins/TypedArray/of.js
@@ -1,4 +1,18 @@
 describe("TypedArray.of", () => {
+  test("is inherited from %TypedArray% with built-in method attributes", () => {
+    const typedArrayIntrinsic = Object.getPrototypeOf(Uint8Array);
+
+    expect(Object.getOwnPropertyDescriptor(Uint8Array, "of")).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(typedArrayIntrinsic, "of")).toEqual({
+      value: Uint8Array.of,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+    expect(Int16Array.of(256)[0]).toBe(256);
+    expect(Uint8Array.of.call(Int16Array, 256)[0]).toBe(256);
+  });
+
   test("Float64Array.of with decimals", () => {
     const ta = Float64Array.of(1.5, 2.5);
     expect(ta.length).toBe(2);

--- a/tests/built-ins/TypedArray/of.js
+++ b/tests/built-ins/TypedArray/of.js
@@ -12,7 +12,10 @@ describe("TypedArray.of", () => {
     expect(Int16Array.of(256)[0]).toBe(256);
     expect(Uint8Array.of.call(Int16Array, 256)[0]).toBe(256);
     class MyInt16Array extends Int16Array {}
-    expect(MyInt16Array.of(256)[0]).toBe(256);
+    const subclassResult = MyInt16Array.of(256);
+    expect(subclassResult[0]).toBe(256);
+    expect(subclassResult instanceof MyInt16Array).toBe(true);
+    expect(Object.getPrototypeOf(subclassResult)).toBe(MyInt16Array.prototype);
   });
 
   test("Float64Array.of with decimals", () => {

--- a/tests/built-ins/TypedArray/of.js
+++ b/tests/built-ins/TypedArray/of.js
@@ -11,6 +11,8 @@ describe("TypedArray.of", () => {
     });
     expect(Int16Array.of(256)[0]).toBe(256);
     expect(Uint8Array.of.call(Int16Array, 256)[0]).toBe(256);
+    class MyInt16Array extends Int16Array {}
+    expect(MyInt16Array.of(256)[0]).toBe(256);
   });
 
   test("Float64Array.of with decimals", () => {

--- a/tests/built-ins/TypedArray/prototype/setFromBase64.js
+++ b/tests/built-ins/TypedArray/prototype/setFromBase64.js
@@ -1,4 +1,13 @@
 describe("Uint8Array.prototype.setFromBase64", () => {
+  test("has built-in method attributes", () => {
+    expect(Object.getOwnPropertyDescriptor(Uint8Array.prototype, "setFromBase64")).toEqual({
+      value: Uint8Array.prototype.setFromBase64,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
   test("decodes base64 into existing array", () => {
     const target = new Uint8Array(5);
     const result = target.setFromBase64("SGVsbG8=");

--- a/tests/built-ins/TypedArray/prototype/setFromHex.js
+++ b/tests/built-ins/TypedArray/prototype/setFromHex.js
@@ -1,4 +1,13 @@
 describe("Uint8Array.prototype.setFromHex", () => {
+  test("has built-in method attributes", () => {
+    expect(Object.getOwnPropertyDescriptor(Uint8Array.prototype, "setFromHex")).toEqual({
+      value: Uint8Array.prototype.setFromHex,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
   test("decodes hex into existing array", () => {
     const target = new Uint8Array(5);
     const result = target.setFromHex("48656c6c6f");

--- a/tests/built-ins/TypedArray/prototype/toBase64.js
+++ b/tests/built-ins/TypedArray/prototype/toBase64.js
@@ -1,4 +1,13 @@
 describe("Uint8Array.prototype.toBase64", () => {
+  test("has built-in method attributes", () => {
+    expect(Object.getOwnPropertyDescriptor(Uint8Array.prototype, "toBase64")).toEqual({
+      value: Uint8Array.prototype.toBase64,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
   test("encodes bytes to base64 with padding", () => {
     const bytes = new Uint8Array([72, 101, 108, 108, 111]);
     expect(bytes.toBase64()).toBe("SGVsbG8=");

--- a/tests/built-ins/TypedArray/prototype/toHex.js
+++ b/tests/built-ins/TypedArray/prototype/toHex.js
@@ -1,4 +1,13 @@
 describe("Uint8Array.prototype.toHex", () => {
+  test("has built-in method attributes", () => {
+    expect(Object.getOwnPropertyDescriptor(Uint8Array.prototype, "toHex")).toEqual({
+      value: Uint8Array.prototype.toHex,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
   test("encodes bytes as lowercase hex pairs", () => {
     const bytes = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]);
     expect(bytes.toHex()).toBe("48656c6c6f");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Define TypedArray constructor and prototype built-ins with ECMAScript descriptor attributes so they are non-enumerable where required.
- Move `from`/`of` onto the non-exposed `%TypedArray%` intrinsic so concrete typed array constructors inherit them, matching the spec topology.
- Construct `TypedArray.from`/`TypedArray.of` results through concrete and subclass constructor receivers, preserving subclass prototype identity while removing the unused static host kind state.
- Add regression coverage for `BYTES_PER_ELEMENT`, Uint8Array base64/hex helper descriptors, inherited static `from`/`of` calls, subclass identity, and detached typed array `for...in` enumeration.

Closes #698

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation (not required; existing TypedArray docs already describe the supported API surface)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Commands run:

- `./build.pas loaderbare testrunner`
- `./build/GocciaTestRunner tests/built-ins/TypedArray/from.js tests/built-ins/TypedArray/of.js --no-progress`
- `./build/GocciaTestRunner tests/built-ins/TypedArray/from.js tests/built-ins/TypedArray/of.js --mode=bytecode --no-progress`
- direct `MyU8 extends Uint8Array` probes for `from`/`of` subclass identity in interpreter and bytecode
- `./build/GocciaTestRunner tests --no-progress`
- `./build/GocciaTestRunner tests --mode=bytecode --no-progress`
- `./format.pas --check`
- `bun scripts/run_test262_suite.ts --categories built-ins --filter 'built-ins/TypedArrayConstructors/internals/GetOwnProperty/*enumerate-detached-buffer.js' --mode=bytecode --jobs=1 --verbose`
- `bun scripts/run_test262_suite.ts --categories built-ins --filter 'built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/*enumerate-detached-buffer.js' --mode=bytecode --jobs=1 --verbose`