### PR TITLE
Fix detached buffer revalidation in binary data methods

### DIFF
--- a/source/units/Goccia.Values.ArrayBufferValue.pas
+++ b/source/units/Goccia.Values.ArrayBufferValue.pas
@@ -92,6 +92,12 @@ begin
   Result := TGocciaArrayBufferValue(AThisValue);
 end;
 
+procedure EnsureArrayBufferAttached(const ABuffer: TGocciaArrayBufferValue; const AErrorMessage: string);
+begin
+  if ABuffer.FDetached then
+    ThrowTypeError(AErrorMessage, SSuggestArrayBufferDetached);
+end;
+
 // ES2026 §6.2.4.2 ToIndex(value)
 function ToIndex(const AValue: TGocciaValue): Integer;
 var
@@ -398,19 +404,18 @@ var
 begin
   Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.resize');
 
-  // ES2026 §25.1.6.5 step 4: If IsDetachedBuffer(O), throw TypeError
-  if Buf.FDetached then
-    ThrowTypeError(SErrorCannotResizeDetachedArrayBuffer, SSuggestArrayBufferDetached);
-
-  // ES2026 §25.1.6.5 step 5: If IsFixedLengthArrayBuffer(O), throw TypeError
-  if Buf.FMaxByteLength < 0 then
-    ThrowTypeError(SErrorCannotResizeFixedLengthArrayBuffer, SSuggestArrayBufferResizable);
-
-  // ES2026 §25.1.6.5 step 6: Let newByteLength be ToIndex(newLength)
+  // ES2026 §25.1.6.5: ToIndex(newLength) can detach the receiver.
   if AArgs.Length > 0 then
     NewByteLength := ToIndex(AArgs.GetElement(0))
   else
     NewByteLength := 0;
+
+  // Revalidate before checking fixed/resizable state or touching storage.
+  EnsureArrayBufferAttached(Buf, SErrorCannotResizeDetachedArrayBuffer);
+
+  // ES2026 §25.1.6.5 step 5: If IsFixedLengthArrayBuffer(O), throw TypeError
+  if Buf.FMaxByteLength < 0 then
+    ThrowTypeError(SErrorCannotResizeFixedLengthArrayBuffer, SSuggestArrayBufferResizable);
 
   // ES2026 §25.1.6.5 step 7: If newByteLength > maxByteLength, throw RangeError
   if NewByteLength > Buf.FMaxByteLength then
@@ -436,6 +441,9 @@ function ArrayBufferCopyAndDetach(const ABuf: TGocciaArrayBufferValue;
 var
   NewMaxByteLength, CopyLength: Integer;
 begin
+  // Callers have converted newLength; revalidate before reading storage.
+  EnsureArrayBufferAttached(ABuf, SErrorCannotTransferDetachedArrayBuffer);
+
   // ES2026 §25.1.2.4 steps 5-6: Determine new maxByteLength
   // Preserve the original maxByteLength; AllocateArrayBuffer throws RangeError
   // if newByteLength > newMaxByteLength
@@ -468,11 +476,7 @@ var
 begin
   Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.transfer');
 
-  // ES2026 §25.1.6.6 step 2: If IsDetachedBuffer(O), throw TypeError
-  if Buf.FDetached then
-    ThrowTypeError(SErrorCannotTransferDetachedArrayBuffer, SSuggestArrayBufferDetached);
-
-  // ES2026 §25.1.6.6 step 1: newLength defaults to current byteLength
+  // ES2026 §25.1.6.6: ArrayBufferCopyAndDetach converts newLength before the detached check.
   if (AArgs.Length = 0) or (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
     NewByteLength := Length(Buf.FData)
   else
@@ -490,11 +494,7 @@ var
 begin
   Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.transferToFixedLength');
 
-  // ES2026 §25.1.6.7 step 2: If IsDetachedBuffer(O), throw TypeError
-  if Buf.FDetached then
-    ThrowTypeError(SErrorCannotTransferDetachedArrayBuffer, SSuggestArrayBufferDetached);
-
-  // ES2026 §25.1.6.7 step 1: newLength defaults to current byteLength
+  // ES2026 §25.1.6.7: ArrayBufferCopyAndDetach converts newLength before the detached check.
   if (AArgs.Length = 0) or (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
     NewByteLength := Length(Buf.FData)
   else
@@ -555,6 +555,9 @@ begin
     Final := Max(Len + Final, 0)
   else
     Final := Min(Final, Len);
+
+  // Side effects from argument coercion may have detached the receiver.
+  EnsureArrayBufferAttached(Buf, SErrorCannotSliceDetachedArrayBuffer);
 
   // Step 15: Let newLen be max(final - first, 0)
   NewLen := Max(Final - First, 0);

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -1370,6 +1370,8 @@ begin
     Final := TA.FLength;
 
   NewLen := Max(Final - First, 0);
+  if NewLen > 0 then
+    EnsureTypedArrayAttached(TA, 'TypedArray.prototype.slice');
   NewTA := CreateSameKindArray(TA, NewLen);
   if IsBigIntKind(TA.FKind) then
   begin

--- a/tests/built-ins/ArrayBuffer/prototype/resize.js
+++ b/tests/built-ins/ArrayBuffer/prototype/resize.js
@@ -99,6 +99,19 @@ describe("ArrayBuffer.prototype.resize", () => {
     expect(() => buf.resize(4)).toThrow(TypeError);
   });
 
+  test("throws TypeError if newLength coercion detaches buffer", () => {
+    const buf = new ArrayBuffer(8, { maxByteLength: 16 });
+    const newLength = {
+      valueOf() {
+        buf.transfer();
+        return 4;
+      }
+    };
+
+    expect(() => buf.resize(newLength)).toThrow(TypeError);
+    expect(buf.byteLength).toBe(0);
+  });
+
   test("throws RangeError when newLength exceeds maxByteLength", () => {
     const buf = new ArrayBuffer(4, { maxByteLength: 16 });
     expect(() => buf.resize(17)).toThrow(RangeError);

--- a/tests/built-ins/ArrayBuffer/prototype/slice.js
+++ b/tests/built-ins/ArrayBuffer/prototype/slice.js
@@ -83,6 +83,45 @@ describe("ArrayBuffer.prototype.slice", () => {
     const sliced = buf.slice(0, 0);
     expect(sliced.byteLength).toBe(0);
   });
+
+  test("throws if start coercion detaches buffer before copy", () => {
+    const buf = new ArrayBuffer(0x1000);
+    const start = {
+      valueOf() {
+        buf.transfer();
+        return 0x800;
+      }
+    };
+
+    expect(() => buf.slice(start)).toThrow(TypeError);
+    expect(buf.byteLength).toBe(0);
+  });
+
+  test("throws if end coercion detaches buffer before copy", () => {
+    const buf = new ArrayBuffer(0x1000);
+    const end = {
+      valueOf() {
+        buf.transfer();
+        return 0xc00;
+      }
+    };
+
+    expect(() => buf.slice(0x800, end)).toThrow(TypeError);
+    expect(buf.byteLength).toBe(0);
+  });
+
+  test("throws when detachment leaves an empty computed slice", () => {
+    const buf = new ArrayBuffer(8);
+    const start = {
+      valueOf() {
+        buf.transfer();
+        return 8;
+      }
+    };
+
+    expect(() => buf.slice(start)).toThrow(TypeError);
+    expect(buf.byteLength).toBe(0);
+  });
 });
 
 describe("ArrayBuffer.prototype.slice edge cases", () => {

--- a/tests/built-ins/ArrayBuffer/prototype/transfer.js
+++ b/tests/built-ins/ArrayBuffer/prototype/transfer.js
@@ -118,6 +118,19 @@ describe("ArrayBuffer.prototype.transfer", () => {
     expect(() => buf.transfer()).toThrow(TypeError);
   });
 
+  test("throws TypeError if newLength coercion detaches buffer", () => {
+    const buf = new ArrayBuffer(8);
+    const newLength = {
+      valueOf() {
+        buf.transfer();
+        return 4;
+      }
+    };
+
+    expect(() => buf.transfer(newLength)).toThrow(TypeError);
+    expect(buf.byteLength).toBe(0);
+  });
+
   test("throws TypeError when called on non-ArrayBuffer", () => {
     const transfer = ArrayBuffer.prototype.transfer;
     expect(() => transfer.call({})).toThrow(TypeError);

--- a/tests/built-ins/ArrayBuffer/prototype/transferToFixedLength.js
+++ b/tests/built-ins/ArrayBuffer/prototype/transferToFixedLength.js
@@ -89,6 +89,19 @@ describe("ArrayBuffer.prototype.transferToFixedLength", () => {
     expect(() => buf.transferToFixedLength()).toThrow(TypeError);
   });
 
+  test("throws TypeError if newLength coercion detaches buffer", () => {
+    const buf = new ArrayBuffer(8);
+    const newLength = {
+      valueOf() {
+        buf.transfer();
+        return 4;
+      }
+    };
+
+    expect(() => buf.transferToFixedLength(newLength)).toThrow(TypeError);
+    expect(buf.byteLength).toBe(0);
+  });
+
   test("throws TypeError when called on non-ArrayBuffer", () => {
     const transferToFixedLength = ArrayBuffer.prototype.transferToFixedLength;
     expect(() => transferToFixedLength.call({})).toThrow(TypeError);

--- a/tests/built-ins/TypedArray/prototype/slice.js
+++ b/tests/built-ins/TypedArray/prototype/slice.js
@@ -84,4 +84,40 @@ describe("TypedArray.prototype.slice", () => {
     ta.buffer.transfer();
     expect(() => ta.slice()).toThrow(TypeError);
   });
+
+  test("throws if start coercion detaches buffer before copy", () => {
+    const ta = new Int32Array([1, 2, 3, 4]);
+    const start = {
+      valueOf() {
+        ta.buffer.transfer();
+        return 1;
+      }
+    };
+
+    expect(() => ta.slice(start)).toThrow(TypeError);
+  });
+
+  test("throws if end coercion detaches buffer before copy", () => {
+    const ta = new Int32Array([1, 2, 3, 4]);
+    const end = {
+      valueOf() {
+        ta.buffer.transfer();
+        return 3;
+      }
+    };
+
+    expect(() => ta.slice(1, end)).toThrow(TypeError);
+  });
+
+  test("returns empty if detachment happens after the slice is clamped empty", () => {
+    const ta = new Int32Array([1, 2, 3]);
+    const start = {
+      valueOf() {
+        ta.buffer.transfer();
+        return 3;
+      }
+    };
+
+    expect(ta.slice(start).length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Revalidate ArrayBuffer receivers after observable argument coercion in `slice`, `resize`, `transfer`, and `transferToFixedLength`.
- Revalidate `%TypedArray%.prototype.slice` before copying when `start`/`end` coercion detaches the backing buffer.
- Add regression coverage for detachment through `valueOf` across the affected binary-data prototype methods.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Verification run:

- `./format.pas --check`
- `./build.pas clean testrunner`
- `./build.pas loaderbare`
- `./build/GocciaTestRunner tests/built-ins/ArrayBuffer/prototype tests/built-ins/TypedArray/prototype/slice.js`
- `./build/GocciaTestRunner tests/built-ins/ArrayBuffer/prototype tests/built-ins/TypedArray/prototype/slice.js --mode=bytecode`
- `./build/GocciaTestRunner tests`
- `./build/GocciaTestRunner tests --mode=bytecode`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b455 --categories staging --filter 'staging/sm/extensions/ArrayBuffer-slice-arguments-detaching.js' --jobs 1 --verbose`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b455 --categories staging --filter 'staging/sm/extensions/ArrayBuffer-slice-arguments-detaching.js' --mode bytecode --jobs 1 --verbose`

Notes:

- Reviewed `docs/value-system.md` and `docs/built-ins-binary-data.md`; no documentation change was needed for this conformance fix.