### PR TITLE
Fix private elements on constructor return overrides

### DIFF
--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -150,7 +150,8 @@ uses
 
 procedure RunClassInstanceInitializers(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaObjectValue;
-  const AContext: TGocciaEvaluationContext); forward;
+  const AContext: TGocciaEvaluationContext;
+  const APreserveExistingRawPrivateSlots: Boolean); forward;
 
 const
   FOR_IN_ENTRY_OWNER = '__gocciaForInOwner';
@@ -826,11 +827,11 @@ var
     ValidateClassConstructorReturn(ClassConstructor, Result);
     if Result is TGocciaObjectValue then
       RunClassInstanceInitializers(ClassConstructor,
-        TGocciaObjectValue(Result), AContext)
+        TGocciaObjectValue(Result), AContext, False)
     else if AReceiver is TGocciaObjectValue then
     begin
       RunClassInstanceInitializers(ClassConstructor,
-        TGocciaObjectValue(AReceiver), AContext);
+        TGocciaObjectValue(AReceiver), AContext, False);
       Result := AReceiver;
     end;
   end;
@@ -880,7 +881,7 @@ begin
     begin
       if AReceiver is TGocciaObjectValue then
         RunClassInstanceInitializers(ClassConstructor,
-          TGocciaObjectValue(AReceiver), AContext);
+          TGocciaObjectValue(AReceiver), AContext, False);
       SuperResult := ClassConstructor.ConstructorMethod.CallWithThisValue(
         AArguments, AReceiver, ConstructorThisValue, EffectiveNewTarget);
       ValidateClassConstructorReturn(ClassConstructor, SuperResult);
@@ -891,7 +892,7 @@ begin
          (SuperResult <> AReceiver) and
          (SuperResult = ConstructorThisValue) then
         RunClassInstanceInitializers(ClassConstructor,
-          TGocciaObjectValue(SuperResult), AContext);
+          TGocciaObjectValue(SuperResult), AContext, False);
     end
     else
       SuperResult := InvokeImplicitClassConstructor;
@@ -923,6 +924,17 @@ var
   I: Integer;
   ThisScope: TGocciaScope;
   ConstructorThisValue: TGocciaValue;
+  NewTargetValue: TGocciaValue;
+  procedure InitializeReplacementThis(const AReplacement: TGocciaObjectValue;
+    const APreviousThis: TGocciaValue);
+  begin
+    if (not Assigned(AReplacement)) or (AReplacement = APreviousThis) then
+      Exit;
+    NewTargetValue := AContext.Scope.FindNewTarget;
+    if NewTargetValue is TGocciaClassValue then
+      RunClassInstanceInitializers(TGocciaClassValue(NewTargetValue),
+        AReplacement, AContext, False);
+  end;
 begin
   CheckExecutionTimeout;
   IncrementInstructionCounter;
@@ -965,6 +977,8 @@ begin
           AContext.Scope.FindNewTarget);
         if SuperResult is TGocciaObjectValue then
         begin
+          InitializeReplacementThis(TGocciaObjectValue(SuperResult),
+            AContext.Scope.ThisValue);
           AContext.Scope.ThisValue := TGocciaObjectValue(SuperResult);
           ThisScope := AContext.Scope.FindFunctionOrModuleScope;
           if Assigned(ThisScope) then
@@ -980,6 +994,8 @@ begin
             SSuggestNotConstructorType)
         else if ConstructorThisValue is TGocciaObjectValue then
         begin
+          InitializeReplacementThis(TGocciaObjectValue(ConstructorThisValue),
+            AContext.Scope.ThisValue);
           AContext.Scope.ThisValue := TGocciaObjectValue(ConstructorThisValue);
           ThisScope := AContext.Scope.FindFunctionOrModuleScope;
           if Assigned(ThisScope) then
@@ -1002,6 +1018,8 @@ begin
           AContext.Scope.FindNewTarget);
         if SuperResult is TGocciaObjectValue then
         begin
+          InitializeReplacementThis(TGocciaObjectValue(SuperResult),
+            AContext.Scope.ThisValue);
           AContext.Scope.ThisValue := TGocciaObjectValue(SuperResult);
           ThisScope := AContext.Scope.FindFunctionOrModuleScope;
           if Assigned(ThisScope) then
@@ -3984,9 +4002,10 @@ procedure StampRawPrivateInstanceBrand(const AReceiver: TGocciaObjectValue;
 
 procedure InitializeRawPrivateInstanceProperty(
   const AReceiver: TGocciaObjectValue; const APrivateName: string;
-  const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue); forward;
+  const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue;
+  const APreserveExisting: Boolean); forward;
 
-procedure InitializeObjectInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
+procedure InitializeObjectInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const APreserveExistingRawPrivateSlots: Boolean);
 var
   PropertyValue: TGocciaValue;
   Entry: TGocciaExpressionMap.TKeyValuePair;
@@ -4002,7 +4021,8 @@ begin
     SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue.SuperClass);
     SuperInitScope.ThisValue := AInstance;
     SuperInitContext.Scope := SuperInitScope;
-    InitializeObjectInstanceProperties(AInstance, AClassValue.SuperClass, SuperInitContext);
+    InitializeObjectInstanceProperties(AInstance, AClassValue.SuperClass,
+      SuperInitContext, APreserveExistingRawPrivateSlots);
   end;
 
   if AClassValue.HasPrivateInstanceElements then
@@ -4036,7 +4056,7 @@ begin
         begin
           PropertyValue := EvaluateExpression(Expr, AContext);
           InitializeRawPrivateInstanceProperty(AInstance, FOEntry.Name,
-            PropertyValue, AClassValue);
+            PropertyValue, AClassValue, APreserveExistingRawPrivateSlots);
         end;
       end
       else
@@ -5673,12 +5693,13 @@ end;
 
 procedure InitializeRawPrivateInstanceProperty(
   const AReceiver: TGocciaObjectValue; const APrivateName: string;
-  const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue);
+  const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue;
+  const APreserveExisting: Boolean);
 begin
   if not Assigned(AAccessClass) then
     ThrowPrivateBrandError(APrivateName);
   StampRawPrivateInstanceBrand(AReceiver, AAccessClass);
-  if Assigned(AReceiver.GetOwnPropertyDescriptor(
+  if APreserveExisting and Assigned(AReceiver.GetOwnPropertyDescriptor(
     RawPrivateInstanceKey(AAccessClass, APrivateName))) then
     Exit;
   AReceiver.DefineProperty(
@@ -5871,8 +5892,9 @@ begin
        AccessClass.PrivateInstancePropertyDefs.TryGetValue(
          APrivateName, FieldInitializer) then
     begin
-      InitializeRawPrivateInstanceProperty(AReceiver, APrivateName,
-        AValue, AccessClass);
+      StampRawPrivateInstanceBrand(AReceiver, AccessClass);
+      SetRawPrivateInstanceProperty(AReceiver, APrivateName, AValue,
+        AccessClass);
       Exit;
     end;
     ThrowPrivateBrandError(APrivateName);
@@ -6181,13 +6203,14 @@ begin
         Entry.Key, PropertyValue, AClassValue)
     else
       InitializeRawPrivateInstanceProperty(
-        AInstance, Entry.Key, PropertyValue, AClassValue);
+        AInstance, Entry.Key, PropertyValue, AClassValue, False);
   end;
 end;
 
 procedure RunClassInstanceInitializers(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaObjectValue;
-  const AContext: TGocciaEvaluationContext);
+  const AContext: TGocciaEvaluationContext;
+  const APreserveExistingRawPrivateSlots: Boolean);
 var
   InitContext, SuperInitContext: TGocciaEvaluationContext;
   InitScope, SuperInitScope: TGocciaScope;
@@ -6224,7 +6247,8 @@ begin
     end;
   end
   else
-    InitializeObjectInstanceProperties(AInstance, AClassValue, InitContext);
+    InitializeObjectInstanceProperties(AInstance, AClassValue, InitContext,
+      APreserveExistingRawPrivateSlots);
 
   AClassValue.RunMethodInitializers(AInstance);
   AClassValue.RunFieldInitializers(AInstance);
@@ -6332,9 +6356,11 @@ var
       InitializerReplayReceiver := Instance;
     end;
   end;
-  procedure RunInstanceInitializers;
+  procedure RunInstanceInitializers(
+    const APreserveExistingRawPrivateSlots: Boolean);
   begin
-    RunClassInstanceInitializers(AClassValue, Instance, AContext);
+    RunClassInstanceInitializers(AClassValue, Instance, AContext,
+      APreserveExistingRawPrivateSlots);
   end;
 begin
   CheckExecutionTimeout;
@@ -6375,7 +6401,7 @@ begin
   InitializerReplayReceiver := nil;
   TGarbageCollector.Instance.AddTempRoot(RootedInstance);
   try
-    RunInstanceInitializers;
+    RunInstanceInitializers(False);
 
     if Assigned(AClassValue.ConstructorMethod) then
     begin
@@ -6406,7 +6432,7 @@ begin
 
     if Assigned(InitializerReplayReceiver) and
        (Instance = InitializerReplayReceiver) then
-      RunInstanceInitializers;
+      RunInstanceInitializers(True);
   finally
     TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
   end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -945,16 +945,19 @@ var
   I: Integer;
   ThisScope: TGocciaScope;
   ConstructorThisValue: TGocciaValue;
-  NewTargetValue: TGocciaValue;
+  CurrentCtorClassValue: TGocciaValue;
+  CurrentCtorClass: TGocciaClassValue;
   procedure InitializeReplacementThis(const AReplacement: TGocciaObjectValue;
     const APreviousThis: TGocciaValue);
   begin
     if (not Assigned(AReplacement)) or (AReplacement = APreviousThis) then
       Exit;
-    NewTargetValue := AContext.Scope.FindNewTarget;
-    if NewTargetValue is TGocciaClassValue then
-      RunClassInstanceInitializers(TGocciaClassValue(NewTargetValue),
-        AReplacement, AContext, iimEagerReplacement);
+    CurrentCtorClassValue := AContext.Scope.FindOwningClass;
+    if not (CurrentCtorClassValue is TGocciaClassValue) then
+      Exit;
+    CurrentCtorClass := TGocciaClassValue(CurrentCtorClassValue);
+    RunClassInstanceInitializers(CurrentCtorClass, AReplacement, AContext,
+      iimEagerReplacement);
   end;
 begin
   CheckExecutionTimeout;
@@ -4036,7 +4039,8 @@ var
   SuperInitContext: TGocciaEvaluationContext;
   SuperInitScope: TGocciaScope;
 begin
-  if Assigned(AClassValue.SuperClass) then
+  if (AInitializationMode <> iimEagerReplacement) and
+     Assigned(AClassValue.SuperClass) then
   begin
     SuperInitContext := AContext;
     SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue.SuperClass);

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -24,6 +24,11 @@ uses
 
 type
   PGocciaValue = ^TGocciaValue;
+  TGocciaInstanceInitializationMode = (
+    iimFirstPass,
+    iimEagerReplacement,
+    iimReplay
+  );
 
 function Evaluate(const ANode: TGocciaASTNode; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 function EvaluateExpression(const AExpression: TGocciaExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
@@ -79,7 +84,7 @@ procedure AssignObjectPattern(const APattern: TGocciaObjectDestructuringPattern;
 procedure AssignAssignmentPattern(const APattern: TGocciaAssignmentDestructuringPattern; const AValue: TGocciaValue; const AContext: TGocciaEvaluationContext; const AIsDeclaration: Boolean = False; const ADeclarationType: TGocciaDeclarationType = dtLet);
 procedure AssignRestPattern(const APattern: TGocciaRestDestructuringPattern; const AValue: TGocciaValue; const AContext: TGocciaEvaluationContext; const AIsDeclaration: Boolean = False; const ADeclarationType: TGocciaDeclarationType = dtLet);
 procedure InitializeInstanceProperties(const AInstance: TGocciaInstanceValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
-procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
+procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const AInitializationMode: TGocciaInstanceInitializationMode = iimFirstPass);
 function InstantiateClass(const AClassValue: TGocciaClassValue; const AArguments: TGocciaArgumentsCollection; const AContext: TGocciaEvaluationContext): TGocciaValue;
 procedure ValidateClassConstructorReturn(const AClassValue: TGocciaClassValue; const AValue: TGocciaValue);
 
@@ -151,7 +156,7 @@ uses
 procedure RunClassInstanceInitializers(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaObjectValue;
   const AContext: TGocciaEvaluationContext;
-  const APreserveExistingRawPrivateSlots: Boolean); forward;
+  const AInitializationMode: TGocciaInstanceInitializationMode); forward;
 
 const
   FOR_IN_ENTRY_OWNER = '__gocciaForInOwner';
@@ -827,11 +832,11 @@ var
     ValidateClassConstructorReturn(ClassConstructor, Result);
     if Result is TGocciaObjectValue then
       RunClassInstanceInitializers(ClassConstructor,
-        TGocciaObjectValue(Result), AContext, False)
+        TGocciaObjectValue(Result), AContext, iimFirstPass)
     else if AReceiver is TGocciaObjectValue then
     begin
       RunClassInstanceInitializers(ClassConstructor,
-        TGocciaObjectValue(AReceiver), AContext, False);
+        TGocciaObjectValue(AReceiver), AContext, iimFirstPass);
       Result := AReceiver;
     end;
   end;
@@ -881,7 +886,7 @@ begin
     begin
       if AReceiver is TGocciaObjectValue then
         RunClassInstanceInitializers(ClassConstructor,
-          TGocciaObjectValue(AReceiver), AContext, False);
+          TGocciaObjectValue(AReceiver), AContext, iimFirstPass);
       SuperResult := ClassConstructor.ConstructorMethod.CallWithThisValue(
         AArguments, AReceiver, ConstructorThisValue, EffectiveNewTarget);
       ValidateClassConstructorReturn(ClassConstructor, SuperResult);
@@ -892,7 +897,7 @@ begin
          (SuperResult <> AReceiver) and
          (SuperResult = ConstructorThisValue) then
         RunClassInstanceInitializers(ClassConstructor,
-          TGocciaObjectValue(SuperResult), AContext, False);
+          TGocciaObjectValue(SuperResult), AContext, iimFirstPass);
     end
     else
       SuperResult := InvokeImplicitClassConstructor;
@@ -933,7 +938,7 @@ var
     NewTargetValue := AContext.Scope.FindNewTarget;
     if NewTargetValue is TGocciaClassValue then
       RunClassInstanceInitializers(TGocciaClassValue(NewTargetValue),
-        AReplacement, AContext, False);
+        AReplacement, AContext, iimEagerReplacement);
   end;
 begin
   CheckExecutionTimeout;
@@ -4005,7 +4010,7 @@ procedure InitializeRawPrivateInstanceProperty(
   const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue;
   const APreserveExisting: Boolean); forward;
 
-procedure InitializeObjectInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const APreserveExistingRawPrivateSlots: Boolean);
+procedure InitializeObjectInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const AInitializationMode: TGocciaInstanceInitializationMode);
 var
   PropertyValue: TGocciaValue;
   Entry: TGocciaExpressionMap.TKeyValuePair;
@@ -4022,7 +4027,7 @@ begin
     SuperInitScope.ThisValue := AInstance;
     SuperInitContext.Scope := SuperInitScope;
     InitializeObjectInstanceProperties(AInstance, AClassValue.SuperClass,
-      SuperInitContext, APreserveExistingRawPrivateSlots);
+      SuperInitContext, AInitializationMode);
   end;
 
   if AClassValue.HasPrivateInstanceElements then
@@ -4056,7 +4061,7 @@ begin
         begin
           PropertyValue := EvaluateExpression(Expr, AContext);
           InitializeRawPrivateInstanceProperty(AInstance, FOEntry.Name,
-            PropertyValue, AClassValue, APreserveExistingRawPrivateSlots);
+            PropertyValue, AClassValue, AInitializationMode = iimReplay);
         end;
       end
       else
@@ -4077,7 +4082,8 @@ begin
       PropertyValue := EvaluateExpression(Entry.Value, AContext);
       AInstance.AssignProperty(Entry.Key, PropertyValue);
     end;
-    InitializePrivateInstanceProperties(AInstance, AClassValue, AContext);
+    InitializePrivateInstanceProperties(AInstance, AClassValue, AContext,
+      AInitializationMode);
   end;
 end;
 
@@ -5639,6 +5645,41 @@ begin
   Result := '#slot:' + AAccessClass.PrivateBrandToken + ':' + APrivateName;
 end;
 
+function RawPrivateInitializedKey(const AAccessClass: TGocciaClassValue): string;
+begin
+  Result := '#initialized:' + AAccessClass.PrivateBrandToken;
+end;
+
+function HasRawPrivateInstanceInitializersApplied(
+  const AReceiver: TGocciaObjectValue;
+  const AAccessClass: TGocciaClassValue): Boolean;
+var
+  Descriptor: TGocciaPropertyDescriptor;
+begin
+  Result := False;
+  if not Assigned(AAccessClass) then
+    Exit;
+  Descriptor := AReceiver.GetOwnPropertyDescriptor(
+    RawPrivateInitializedKey(AAccessClass));
+  Result := Descriptor is TGocciaPropertyDescriptorData;
+end;
+
+procedure StampRawPrivateInstanceInitializersApplied(
+  const AReceiver: TGocciaObjectValue;
+  const AAccessClass: TGocciaClassValue);
+begin
+  if not Assigned(AAccessClass) then
+    Exit;
+  if not AAccessClass.HasInstanceInitializerWork then
+    Exit;
+  if HasRawPrivateInstanceInitializersApplied(AReceiver, AAccessClass) then
+    Exit;
+  AReceiver.DefineProperty(
+    RawPrivateInitializedKey(AAccessClass),
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaBooleanLiteralValue.TrueValue, []));
+end;
+
 function HasRawPrivateInstanceBrand(const AReceiver: TGocciaObjectValue;
   const AAccessClass: TGocciaClassValue): Boolean;
 var
@@ -6188,7 +6229,7 @@ begin
       AContext);
 end;
 
-procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
+procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const AInitializationMode: TGocciaInstanceInitializationMode);
 var
   PropertyValue: TGocciaValue;
   Entry: TGocciaExpressionMap.TKeyValuePair;
@@ -6203,14 +6244,15 @@ begin
         Entry.Key, PropertyValue, AClassValue)
     else
       InitializeRawPrivateInstanceProperty(
-        AInstance, Entry.Key, PropertyValue, AClassValue, False);
+        AInstance, Entry.Key, PropertyValue, AClassValue,
+        AInitializationMode = iimReplay);
   end;
 end;
 
 procedure RunClassInstanceInitializers(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaObjectValue;
   const AContext: TGocciaEvaluationContext;
-  const APreserveExistingRawPrivateSlots: Boolean);
+  const AInitializationMode: TGocciaInstanceInitializationMode);
 var
   InitContext, SuperInitContext: TGocciaEvaluationContext;
   InitScope, SuperInitScope: TGocciaScope;
@@ -6239,20 +6281,24 @@ begin
         SuperInitContext.Scope := SuperInitScope;
         if WalkClass.FieldOrderCount = 0 then
           InitializePrivateInstanceProperties(
-            AInstance, WalkClass, SuperInitContext);
+            AInstance, WalkClass, SuperInitContext, AInitializationMode);
         WalkClass := WalkClass.SuperClass;
       end;
 
-      InitializePrivateInstanceProperties(AInstance, AClassValue, InitContext);
+      InitializePrivateInstanceProperties(AInstance, AClassValue, InitContext,
+        AInitializationMode);
     end;
   end
   else
     InitializeObjectInstanceProperties(AInstance, AClassValue, InitContext,
-      APreserveExistingRawPrivateSlots);
+      AInitializationMode);
 
   AClassValue.RunMethodInitializers(AInstance);
   AClassValue.RunFieldInitializers(AInstance);
   AClassValue.RunDecoratorFieldInitializers(AInstance);
+  if (AInitializationMode = iimEagerReplacement) and
+     (not (AInstance is TGocciaInstanceValue)) then
+    StampRawPrivateInstanceInitializersApplied(AInstance, AClassValue);
 end;
 
 function InstantiateClass(const AClassValue: TGocciaClassValue;
@@ -6357,10 +6403,10 @@ var
     end;
   end;
   procedure RunInstanceInitializers(
-    const APreserveExistingRawPrivateSlots: Boolean);
+    const AInitializationMode: TGocciaInstanceInitializationMode);
   begin
     RunClassInstanceInitializers(AClassValue, Instance, AContext,
-      APreserveExistingRawPrivateSlots);
+      AInitializationMode);
   end;
 begin
   CheckExecutionTimeout;
@@ -6401,7 +6447,7 @@ begin
   InitializerReplayReceiver := nil;
   TGarbageCollector.Instance.AddTempRoot(RootedInstance);
   try
-    RunInstanceInitializers(False);
+    RunInstanceInitializers(iimFirstPass);
 
     if Assigned(AClassValue.ConstructorMethod) then
     begin
@@ -6431,8 +6477,9 @@ begin
       TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
 
     if Assigned(InitializerReplayReceiver) and
-       (Instance = InitializerReplayReceiver) then
-      RunInstanceInitializers(True);
+       (Instance = InitializerReplayReceiver) and
+       not HasRawPrivateInstanceInitializersApplied(Instance, AClassValue) then
+      RunInstanceInitializers(iimReplay);
   finally
     TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
   end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -5678,6 +5678,9 @@ begin
   if not Assigned(AAccessClass) then
     ThrowPrivateBrandError(APrivateName);
   StampRawPrivateInstanceBrand(AReceiver, AAccessClass);
+  if Assigned(AReceiver.GetOwnPropertyDescriptor(
+    RawPrivateInstanceKey(AAccessClass, APrivateName))) then
+    Exit;
   AReceiver.DefineProperty(
     RawPrivateInstanceKey(AAccessClass, APrivateName),
     TGocciaPropertyDescriptorData.Create(AValue, [pfWritable, pfConfigurable]));
@@ -5852,12 +5855,28 @@ var
   AccessClass: TGocciaClassValue;
   SetterFn: TGocciaFunctionBase;
   SetterArgs: TGocciaArgumentsCollection;
+  PendingNewTarget: TGocciaValue;
+  FieldInitializer: TGocciaExpression;
 begin
   AccessClass := ResolveLexicalOwningClass(AContext);
   if not Assigned(AccessClass) then
     ThrowPrivateBrandError(APrivateName);
 
-  EnsureRawPrivateInstanceBrand(AReceiver, APrivateName, AccessClass);
+  if not HasRawPrivateInstanceBrand(AReceiver, AccessClass) then
+  begin
+    PendingNewTarget := AContext.Scope.FindNewTarget;
+    if (AReceiver = AContext.Scope.ThisValue) and
+       (PendingNewTarget is TGocciaClassValue) and
+       (TGocciaClassValue(PendingNewTarget) = AccessClass) and
+       AccessClass.PrivateInstancePropertyDefs.TryGetValue(
+         APrivateName, FieldInitializer) then
+    begin
+      InitializeRawPrivateInstanceProperty(AReceiver, APrivateName,
+        AValue, AccessClass);
+      Exit;
+    end;
+    ThrowPrivateBrandError(APrivateName);
+  end;
 
   if AccessClass.HasPrivateSetter(APrivateName) then
   begin

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -6312,8 +6312,7 @@ begin
   AClassValue.RunMethodInitializers(AInstance);
   AClassValue.RunFieldInitializers(AInstance);
   AClassValue.RunDecoratorFieldInitializers(AInstance);
-  if (AInitializationMode = iimEagerReplacement) and
-     (not (AInstance is TGocciaInstanceValue)) then
+  if AInitializationMode = iimEagerReplacement then
     StampRawPrivateInstanceInitializersApplied(AInstance, AClassValue);
 end;
 

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -5746,6 +5746,12 @@ begin
   try
     while not Check(gttRightBrace) and not IsAtEnd do
     begin
+      if Check(gttSemicolon) then
+      begin
+        Advance;
+        Continue;
+      end;
+
       MemberDecorators := ParseDecorators;
       IsAccessor := False;
       MemberStartLine := Peek.Line;

--- a/source/units/Goccia.VM.Closure.pas
+++ b/source/units/Goccia.VM.Closure.pas
@@ -16,6 +16,7 @@ type
     FTemplate: TGocciaFunctionTemplate;
     FUpvalues: array of TGocciaBytecodeUpvalue;
     FHomeObject: TGocciaObjectValue;
+    FHomeClass: TGocciaObjectValue;
     FFunctionValue: TGocciaValue;
   public
     constructor Create(const ATemplate: TGocciaFunctionTemplate;
@@ -28,6 +29,7 @@ type
     property Template: TGocciaFunctionTemplate read FTemplate;
     property UpvalueCount: Integer read GetUpvalueCount;
     property HomeObject: TGocciaObjectValue read FHomeObject write FHomeObject;
+    property HomeClass: TGocciaObjectValue read FHomeClass write FHomeClass;
     property FunctionValue: TGocciaValue read FFunctionValue write FFunctionValue;
   end;
 
@@ -39,6 +41,7 @@ begin
   inherited Create;
   FTemplate := ATemplate;
   FHomeObject := nil;
+  FHomeClass := nil;
   FFunctionValue := nil;
   SetLength(FUpvalues, AUpvalueCount);
 end;
@@ -55,6 +58,7 @@ var
 begin
   Result := TGocciaBytecodeClosure.Create(FTemplate, Length(FUpvalues));
   Result.FHomeObject := FHomeObject;
+  Result.FHomeClass := FHomeClass;
   Result.FFunctionValue := FFunctionValue;
   for I := 0 to High(FUpvalues) do
     Result.FUpvalues[I] := FUpvalues[I];

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -115,6 +115,7 @@ type
     FArgumentPoolCount: Integer;
     FLastClosureThisValue: TGocciaRegister;
     FPrivateInitializerReceiver: TGocciaValue;
+    FPrivateInitializerPreserveExisting: Boolean;
     FStackRoot: TGocciaVMStackRoot;
     FTempSavedStateRoots: TGocciaVMSavedStateRootArray;
     FTempSavedStateRootCount: Integer;
@@ -207,7 +208,8 @@ type
     procedure SetupAutoAccessorValueByKey(const AKey: TGocciaValue;
       const ABackingName: string; const AIsStatic: Boolean);
     procedure RunClassInitializers(const AClassValue: TGocciaClassValue;
-      const AInstance: TGocciaValue);
+      const AInstance: TGocciaValue;
+      const APreserveExistingPrivateSlots: Boolean = False);
     function MaterializeArguments(
       const AArguments: TGocciaRegisterArray): TGocciaArgumentsCollection;
     function CreateArgumentsObjectFromCurrentFrame: TGocciaObjectValue;
@@ -3003,6 +3005,14 @@ var
         'Derived constructor returned non-object',
         SSuggestNotConstructorType);
   end;
+  procedure InitializeNewTargetReplacement(const AReplacement: TGocciaValue);
+  begin
+    if (AReplacement is TGocciaObjectValue) and
+       (AReplacement <> AThisValue) and
+       (FNewTarget is TGocciaVMClassValue) then
+      TGocciaVMClassValue(FNewTarget).FVM.RunClassInitializers(
+        TGocciaClassValue(FNewTarget), AReplacement, False);
+  end;
 begin
   if (FSuperClass is TGocciaObjectValue) and
      (not (FSuperClass is TGocciaClassValue)) and
@@ -3010,6 +3020,7 @@ begin
   begin
     SuperResult := InvokeConstructableWithReceiver(FSuperClass, AArguments,
       AThisValue, FNewTarget);
+    InitializeNewTargetReplacement(SuperResult);
     Exit(SuperResult);
   end;
 
@@ -3034,6 +3045,7 @@ begin
       if SuperResult <> AThisValue then
         TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
           SuperClass, SuperResult);
+      InitializeNewTargetReplacement(SuperResult);
       Exit(SuperResult);
     end;
     ValidateSuperConstructorResult(SuperResult);
@@ -3048,6 +3060,7 @@ begin
         if ConstructorThisValue <> AThisValue then
           TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
             SuperClass, ConstructorThisValue);
+        InitializeNewTargetReplacement(ConstructorThisValue);
         Exit(ConstructorThisValue);
       end;
     end;
@@ -3067,6 +3080,7 @@ begin
          (SuperClass is TGocciaVMClassValue) then
         TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
           SuperClass, SuperResult);
+      InitializeNewTargetReplacement(SuperResult);
       Exit(SuperResult);
     end;
     ValidateSuperConstructorResult(SuperResult);
@@ -3076,6 +3090,7 @@ begin
          (SuperClass is TGocciaVMClassValue) then
         TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
           SuperClass, ConstructorThisValue);
+      InitializeNewTargetReplacement(ConstructorThisValue);
       Exit(ConstructorThisValue);
     end;
     Exit(AThisValue);
@@ -3107,7 +3122,10 @@ begin
     if NewThis is TGocciaInstanceValue then
       TGocciaInstanceValue(NewThis).InitializeNativeFromArguments(AArguments);
     if NewThis is TGocciaObjectValue then
+    begin
+      InitializeNewTargetReplacement(NewThis);
       Exit(NewThis);
+    end;
     Exit(AThisValue);
   end;
 
@@ -3126,6 +3144,7 @@ begin
   FActiveDecoratorSession := nil;
   FLastClosureThisValue := RegisterUndefined;
   FPrivateInitializerReceiver := nil;
+  FPrivateInitializerPreserveExisting := False;
   FTempSavedStateRootCount := 0;
   FCurrentExecutionContextPushed := False;
   SetLength(FRegisterStack, INITIAL_STACK_SIZE);
@@ -3309,7 +3328,7 @@ begin
       ApplyOwnConstructorResult(ConstructedValue, ConstructorThisValue);
       if Assigned(InitializerReplayReceiver) and
          (Instance = InitializerReplayReceiver) then
-        FVM.RunClassInitializers(Self, Instance);
+        FVM.RunClassInitializers(Self, Instance, True);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
     end;
@@ -3388,7 +3407,7 @@ begin
 
       if Assigned(InitializerReplayReceiver) and
          (Instance = InitializerReplayReceiver) then
-        FVM.RunClassInitializers(Self, Instance);
+        FVM.RunClassInitializers(Self, Instance, True);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
     end;
@@ -3721,7 +3740,7 @@ begin
       end;
       if Assigned(InitializerReplayReceiver) and
          (Instance = InitializerReplayReceiver) then
-        FVM.RunClassInitializers(Self, Instance);
+        FVM.RunClassInitializers(Self, Instance, True);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
     end;
@@ -5780,19 +5799,26 @@ begin
 end;
 
 procedure TGocciaVM.RunClassInitializers(const AClassValue: TGocciaClassValue;
-  const AInstance: TGocciaValue);
+  const AInstance: TGocciaValue;
+  const APreserveExistingPrivateSlots: Boolean);
 var
   PreviousPrivateInitializerReceiver: TGocciaValue;
+  PreviousPrivateInitializerPreserveExisting: Boolean;
 begin
   StampBytecodePrivateBrands(AClassValue, AInstance);
   PreviousPrivateInitializerReceiver := FPrivateInitializerReceiver;
+  PreviousPrivateInitializerPreserveExisting :=
+    FPrivateInitializerPreserveExisting;
   FPrivateInitializerReceiver := AInstance;
+  FPrivateInitializerPreserveExisting := APreserveExistingPrivateSlots;
   try
     AClassValue.RunMethodInitializers(AInstance);
     AClassValue.RunFieldInitializers(AInstance);
     AClassValue.RunDecoratorFieldInitializers(AInstance);
   finally
     FPrivateInitializerReceiver := PreviousPrivateInitializerReceiver;
+    FPrivateInitializerPreserveExisting :=
+      PreviousPrivateInitializerPreserveExisting;
   end;
 end;
 
@@ -7055,7 +7081,8 @@ begin
     end;
     if TryGetRawPrivateValue(AObject, AKey, ExistingValue) then
     begin
-      if AObject = FPrivateInitializerReceiver then
+      if (AObject = FPrivateInitializerReceiver) and
+         FPrivateInitializerPreserveExisting then
         Exit;
     end
     else

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -5730,11 +5730,15 @@ var
   PrototypeNames: TArray<string>;
   PrototypeName: string;
   PrivateBrandToken: string;
+  PrototypeDescriptor: TGocciaPropertyDescriptor;
+  ReceiverObject: TGocciaObjectValue;
   I: Integer;
 begin
   if (not Assigned(AClassValue)) or
      not (AInstance is TGocciaObjectValue) then
     Exit;
+
+  ReceiverObject := TGocciaObjectValue(AInstance);
 
   Names := TStringList.Create;
   try
@@ -5758,6 +5762,17 @@ begin
         NormalizeBytecodePrivateKey(Names[I], PrivateBrandToken),
         PrivateBrandToken),
         TGocciaBooleanLiteralValue.TrueValue);
+
+      if (not (AInstance is TGocciaInstanceValue)) and
+         Assigned(AClassValue.Prototype) and
+         IsBytecodePrivateKey(Names[I]) then
+      begin
+        PrototypeDescriptor := AClassValue.Prototype.GetOwnPropertyDescriptor(
+          Names[I]);
+        if Assigned(PrototypeDescriptor) then
+          ReceiverObject.DefineProperty(Names[I],
+            ClonePropertyDescriptor(PrototypeDescriptor));
+      end;
     end;
   finally
     Names.Free;
@@ -6974,6 +6989,7 @@ var
   BoxedValue: TGocciaObjectValue;
   PrivateBrandToken: string;
   ExistingValue: TGocciaValue;
+  CurrentClass: TGocciaClassValue;
 begin
   if AObject is TGocciaNullLiteralValue then
     ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, [AKey]),
@@ -7037,11 +7053,28 @@ begin
         Current := Current.Prototype;
       end;
     end;
-    if not TryGetRawPrivateValue(AObject, AKey, ExistingValue) then
+    if TryGetRawPrivateValue(AObject, AKey, ExistingValue) then
+    begin
+      if AObject = FPrivateInitializerReceiver then
+        Exit;
+    end
+    else
     begin
       if AObject <> FPrivateInitializerReceiver then
-        ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
-          SSuggestPrivateFieldAccess);
+      begin
+        if (AObject = RegisterToValue(GetLocalRegister(0))) and
+           (FCurrentNewTarget is TGocciaClassValue) then
+        begin
+          CurrentClass := TGocciaClassValue(FCurrentNewTarget);
+          if Assigned(CurrentClass.Prototype) and
+             Assigned(CurrentClass.Prototype.GetOwnPropertyDescriptor(AKey)) then
+            ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
+              SSuggestPrivateFieldAccess);
+        end
+        else
+          ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
+            SSuggestPrivateFieldAccess);
+      end;
       SetRawPrivateValue(AObject, BytecodePrivateBrandKey(AKey,
         PrivateBrandToken),
         TGocciaBooleanLiteralValue.TrueValue);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -958,10 +958,12 @@ type
   private
     FSuperClass: TGocciaValue;
     FNewTarget: TGocciaValue;
+    FCurrentCtorClass: TGocciaClassValue;
   protected
     function GetFunctionName: string; override;
   public
-    constructor Create(const ASuperClass, ANewTarget: TGocciaValue);
+    constructor Create(const ASuperClass, ANewTarget: TGocciaValue;
+      const ACurrentCtorClass: TGocciaClassValue);
     function Call(const AArguments: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue; override;
     procedure MarkReferences; override;
@@ -1257,11 +1259,13 @@ begin
 end;
 
 constructor TGocciaVMSuperConstructorValue.Create(
-  const ASuperClass, ANewTarget: TGocciaValue);
+  const ASuperClass, ANewTarget: TGocciaValue;
+  const ACurrentCtorClass: TGocciaClassValue);
 begin
   inherited Create;
   FSuperClass := ASuperClass;
   FNewTarget := ANewTarget;
+  FCurrentCtorClass := ACurrentCtorClass;
 end;
 
 function TGocciaBytecodeFunctionValue.GetFunctionLength: Integer;
@@ -3013,16 +3017,16 @@ var
         'Derived constructor returned non-object',
         SSuggestNotConstructorType);
   end;
-  procedure InitializeNewTargetReplacement(const AReplacement: TGocciaValue);
+  procedure InitializeCurrentCtorReplacement(const AReplacement: TGocciaValue);
   begin
     if (AReplacement is TGocciaObjectValue) and
        (AReplacement <> AThisValue) and
-       (FNewTarget is TGocciaVMClassValue) then
+       (FCurrentCtorClass is TGocciaVMClassValue) then
     begin
-      TGocciaVMClassValue(FNewTarget).FVM.RunClassInitializers(
-        TGocciaClassValue(FNewTarget), AReplacement, False);
+      TGocciaVMClassValue(FCurrentCtorClass).FVM.RunClassInitializers(
+        FCurrentCtorClass, AReplacement, False);
       StampBytecodePrivateInitializersApplied(AReplacement,
-        TGocciaClassValue(FNewTarget));
+        FCurrentCtorClass);
     end;
   end;
 begin
@@ -3032,7 +3036,7 @@ begin
   begin
     SuperResult := InvokeConstructableWithReceiver(FSuperClass, AArguments,
       AThisValue, FNewTarget);
-    InitializeNewTargetReplacement(SuperResult);
+    InitializeCurrentCtorReplacement(SuperResult);
     Exit(SuperResult);
   end;
 
@@ -3054,10 +3058,11 @@ begin
       AArguments, AThisValue);
     if SuperResult is TGocciaObjectValue then
     begin
-      if SuperResult <> AThisValue then
+      if (SuperResult <> AThisValue) and
+         not HasBytecodePrivateInitializersApplied(SuperResult, SuperClass) then
         TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
           SuperClass, SuperResult);
-      InitializeNewTargetReplacement(SuperResult);
+      InitializeCurrentCtorReplacement(SuperResult);
       Exit(SuperResult);
     end;
     ValidateSuperConstructorResult(SuperResult);
@@ -3069,10 +3074,11 @@ begin
         BytecodeConstructor.FVM.FLastClosureThisValue);
       if ConstructorThisValue is TGocciaObjectValue then
       begin
-        if ConstructorThisValue <> AThisValue then
+        if (ConstructorThisValue <> AThisValue) and
+           not HasBytecodePrivateInitializersApplied(ConstructorThisValue, SuperClass) then
           TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
             SuperClass, ConstructorThisValue);
-        InitializeNewTargetReplacement(ConstructorThisValue);
+        InitializeCurrentCtorReplacement(ConstructorThisValue);
         Exit(ConstructorThisValue);
       end;
     end;
@@ -3089,20 +3095,22 @@ begin
     if SuperResult is TGocciaObjectValue then
     begin
       if (SuperResult <> AThisValue) and
-         (SuperClass is TGocciaVMClassValue) then
+         (SuperClass is TGocciaVMClassValue) and
+         not HasBytecodePrivateInitializersApplied(SuperResult, SuperClass) then
         TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
           SuperClass, SuperResult);
-      InitializeNewTargetReplacement(SuperResult);
+      InitializeCurrentCtorReplacement(SuperResult);
       Exit(SuperResult);
     end;
     ValidateSuperConstructorResult(SuperResult);
     if ConstructorThisValue is TGocciaObjectValue then
     begin
       if (ConstructorThisValue <> AThisValue) and
-         (SuperClass is TGocciaVMClassValue) then
+         (SuperClass is TGocciaVMClassValue) and
+         not HasBytecodePrivateInitializersApplied(ConstructorThisValue, SuperClass) then
         TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
           SuperClass, ConstructorThisValue);
-      InitializeNewTargetReplacement(ConstructorThisValue);
+      InitializeCurrentCtorReplacement(ConstructorThisValue);
       Exit(ConstructorThisValue);
     end;
     Exit(AThisValue);
@@ -3135,7 +3143,7 @@ begin
       TGocciaInstanceValue(NewThis).InitializeNativeFromArguments(AArguments);
     if NewThis is TGocciaObjectValue then
     begin
-      InitializeNewTargetReplacement(NewThis);
+      InitializeCurrentCtorReplacement(NewThis);
       Exit(NewThis);
     end;
     Exit(AThisValue);
@@ -3884,6 +3892,8 @@ begin
     FSuperClass.MarkReferences;
   if Assigned(FNewTarget) then
     FNewTarget.MarkReferences;
+  if Assigned(FCurrentCtorClass) then
+    FCurrentCtorClass.MarkReferences;
 end;
 
 procedure TGocciaBytecodeFunctionValue.MarkReferences;
@@ -6850,6 +6860,17 @@ var
   SuperObject: TGocciaObjectValue;
   HomeObject: TGocciaObjectValue;
   SuperPrototype: TGocciaValue;
+  function ResolveCurrentCtorClass: TGocciaClassValue;
+  var
+    CtorValue: TGocciaValue;
+  begin
+    Result := nil;
+    if not Assigned(HomeObject) then
+      Exit;
+    CtorValue := HomeObject.GetProperty(PROP_CONSTRUCTOR);
+    if CtorValue is TGocciaClassValue then
+      Result := TGocciaClassValue(CtorValue);
+  end;
 begin
   HomeObject := nil;
   if Assigned(FCurrentClosure) then
@@ -6862,7 +6883,7 @@ begin
     SuperObject := TGocciaObjectValue(ASuperValue);
     if AUseSuperConstructor and (AName = PROP_CONSTRUCTOR) then
       Exit(TGocciaVMSuperConstructorValue.Create(SuperObject,
-        FCurrentNewTarget));
+        FCurrentNewTarget, ResolveCurrentCtorClass));
 
     if AThisValue is TGocciaClassValue then
       Exit(SuperObject.GetPropertyWithContext(AName, AThisValue));
@@ -6890,7 +6911,7 @@ begin
   SuperClass := TGocciaClassValue(ASuperValue);
   if AUseSuperConstructor and (AName = PROP_CONSTRUCTOR) then
     Exit(TGocciaVMSuperConstructorValue.Create(SuperClass,
-      FCurrentNewTarget));
+      FCurrentNewTarget, ResolveCurrentCtorClass));
 
   if AThisValue is TGocciaClassValue then
     Exit(SuperClass.GetPropertyWithContext(AName, AThisValue));

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1010,6 +1010,8 @@ begin
     Exit;
   if Assigned(AClosure.HomeObject) then
     AClosure.HomeObject.MarkReferences;
+  if Assigned(AClosure.HomeClass) then
+    AClosure.HomeClass.MarkReferences;
   for I := 0 to AClosure.UpvalueCount - 1 do
   begin
     Upvalue := AClosure.GetUpvalue(I);
@@ -2372,6 +2374,8 @@ begin
   begin
     if Assigned(FClosure.HomeObject) then
       FClosure.HomeObject.MarkReferences;
+    if Assigned(FClosure.HomeClass) then
+      FClosure.HomeClass.MarkReferences;
     for I := 0 to FClosure.UpvalueCount - 1 do
     begin
       Upvalue := FClosure.GetUpvalue(I);
@@ -3909,6 +3913,8 @@ begin
 
   if Assigned(FClosure.HomeObject) then
     FClosure.HomeObject.MarkReferences;
+  if Assigned(FClosure.HomeClass) then
+    FClosure.HomeClass.MarkReferences;
 
   for I := 0 to FClosure.UpvalueCount - 1 do
   begin
@@ -4222,19 +4228,38 @@ procedure SetBytecodeHomeObject(const AFunctionValue: TGocciaValue;
   const AHomeObject: TGocciaValue);
 var
   EffectiveHomeObject: TGocciaObjectValue;
+  EffectiveHomeClass: TGocciaClassValue;
+  Closure: TGocciaBytecodeClosure;
 begin
   if AHomeObject is TGocciaClassValue then
-    EffectiveHomeObject := TGocciaClassValue(AHomeObject).Prototype
+  begin
+    EffectiveHomeObject := TGocciaClassValue(AHomeObject).Prototype;
+    EffectiveHomeClass := TGocciaClassValue(AHomeObject);
+  end
   else if AHomeObject is TGocciaObjectValue then
-    EffectiveHomeObject := TGocciaObjectValue(AHomeObject)
+  begin
+    EffectiveHomeObject := TGocciaObjectValue(AHomeObject);
+    EffectiveHomeClass := nil;
+  end
   else
+  begin
     EffectiveHomeObject := nil;
+    EffectiveHomeClass := nil;
+  end;
 
-  if (AFunctionValue is TGocciaBytecodeFunctionValue) and
-     Assigned(EffectiveHomeObject) and
-     Assigned(TGocciaBytecodeFunctionValue(AFunctionValue).FClosure) and
-     not Assigned(TGocciaBytecodeFunctionValue(AFunctionValue).FClosure.HomeObject) then
-    TGocciaBytecodeFunctionValue(AFunctionValue).FClosure.HomeObject := EffectiveHomeObject;
+  if not ((AFunctionValue is TGocciaBytecodeFunctionValue) and
+     Assigned(EffectiveHomeObject)) then
+    Exit;
+
+  Closure := TGocciaBytecodeFunctionValue(AFunctionValue).FClosure;
+  if not Assigned(Closure) then
+    Exit;
+
+  if not Assigned(Closure.HomeObject) then
+    Closure.HomeObject := EffectiveHomeObject;
+  if Assigned(EffectiveHomeClass) and not Assigned(Closure.HomeClass) and
+     (Closure.HomeObject = EffectiveHomeObject) then
+    Closure.HomeClass := EffectiveHomeClass;
 end;
 
 function TGocciaVM.GetLocal(const AIndex: Integer): TGocciaValue;
@@ -6861,15 +6886,11 @@ var
   HomeObject: TGocciaObjectValue;
   SuperPrototype: TGocciaValue;
   function ResolveCurrentCtorClass: TGocciaClassValue;
-  var
-    CtorValue: TGocciaValue;
   begin
     Result := nil;
-    if not Assigned(HomeObject) then
-      Exit;
-    CtorValue := HomeObject.GetProperty(PROP_CONSTRUCTOR);
-    if CtorValue is TGocciaClassValue then
-      Result := TGocciaClassValue(CtorValue);
+    if Assigned(FCurrentClosure) and
+       (FCurrentClosure.HomeClass is TGocciaClassValue) then
+      Result := TGocciaClassValue(FCurrentClosure.HomeClass);
   end;
 begin
   HomeObject := nil;
@@ -8719,7 +8740,7 @@ begin
            (FRegisters[A].ObjectValue is TGocciaVMClassValue) then
         begin
           SetBytecodeHomeObject(RegisterToValue(FRegisters[C]),
-            TGocciaVMClassValue(FRegisters[A].ObjectValue).Prototype);
+            FRegisters[A].ObjectValue);
           if GlobalName = PROP_CONSTRUCTOR then
           begin
             TGocciaVMClassValue(FRegisters[A].ObjectValue).SetVMConstructor(

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -367,12 +367,17 @@ uses
 const
   BYTECODE_PRIVATE_SLOT_PREFIX = '#slot:';
   BYTECODE_PRIVATE_BRAND_PREFIX = '#brand:';
+  BYTECODE_PRIVATE_INITIALIZED_PREFIX = '#initialized:';
   FOR_IN_ENTRY_OWNER = '__gocciaForInOwner';
   FOR_IN_ENTRY_KEY = '__gocciaForInKey';
   FOR_IN_MAX_PROTOTYPE_CHAIN_DEPTH = 256;
 
 function IsBytecodePrivateKey(const AKey: string): Boolean; forward;
 function IsBytecodePrivateBrandKey(const AKey: string): Boolean; forward;
+function HasBytecodePrivateInitializersApplied(const AInstance: TGocciaValue;
+  const AClassValue: TGocciaClassValue): Boolean; forward;
+procedure StampBytecodePrivateInitializersApplied(const AInstance: TGocciaValue;
+  const AClassValue: TGocciaClassValue); forward;
 function NormalizeBytecodePrivateKey(const AName,
   APrivateBrandToken: string): string; forward;
 function BytecodePrivateBrandKey(const AKey,
@@ -3010,8 +3015,12 @@ var
     if (AReplacement is TGocciaObjectValue) and
        (AReplacement <> AThisValue) and
        (FNewTarget is TGocciaVMClassValue) then
+    begin
       TGocciaVMClassValue(FNewTarget).FVM.RunClassInitializers(
         TGocciaClassValue(FNewTarget), AReplacement, False);
+      StampBytecodePrivateInitializersApplied(AReplacement,
+        TGocciaClassValue(FNewTarget));
+    end;
   end;
 begin
   if (FSuperClass is TGocciaObjectValue) and
@@ -3327,7 +3336,8 @@ begin
         ConstructorThisValue := Instance;
       ApplyOwnConstructorResult(ConstructedValue, ConstructorThisValue);
       if Assigned(InitializerReplayReceiver) and
-         (Instance = InitializerReplayReceiver) then
+         (Instance = InitializerReplayReceiver) and
+         not HasBytecodePrivateInitializersApplied(Instance, Self) then
         FVM.RunClassInitializers(Self, Instance, True);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
@@ -3406,7 +3416,8 @@ begin
         FVM.RunClassInitializers(Self, Instance);
 
       if Assigned(InitializerReplayReceiver) and
-         (Instance = InitializerReplayReceiver) then
+         (Instance = InitializerReplayReceiver) and
+         not HasBytecodePrivateInitializersApplied(Instance, Self) then
         FVM.RunClassInitializers(Self, Instance, True);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
@@ -3739,7 +3750,8 @@ begin
           FVM.RunClassInitializers(Self, Instance);
       end;
       if Assigned(InitializerReplayReceiver) and
-         (Instance = InitializerReplayReceiver) then
+         (Instance = InitializerReplayReceiver) and
+         not HasBytecodePrivateInitializersApplied(Instance, Self) then
         FVM.RunClassInitializers(Self, Instance, True);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
@@ -5740,6 +5752,40 @@ begin
   else
     Result := BYTECODE_PRIVATE_BRAND_PREFIX + APrivateBrandToken + ':' +
       NormalizeBytecodePrivateKey(AKey, APrivateBrandToken);
+end;
+
+function BytecodePrivateInitializedKey(
+  const APrivateBrandToken: string): string;
+begin
+  Result := BYTECODE_PRIVATE_INITIALIZED_PREFIX + APrivateBrandToken;
+end;
+
+function HasBytecodePrivateInitializersApplied(const AInstance: TGocciaValue;
+  const AClassValue: TGocciaClassValue): Boolean;
+var
+  Descriptor: TGocciaPropertyDescriptor;
+begin
+  Result := False;
+  if (not Assigned(AClassValue)) or
+     not (AInstance is TGocciaObjectValue) then
+    Exit;
+  Descriptor := TGocciaObjectValue(AInstance).GetOwnPropertyDescriptor(
+    BytecodePrivateInitializedKey(AClassValue.PrivateBrandToken));
+  Result := Descriptor is TGocciaPropertyDescriptorData;
+end;
+
+procedure StampBytecodePrivateInitializersApplied(const AInstance: TGocciaValue;
+  const AClassValue: TGocciaClassValue);
+begin
+  if (not Assigned(AClassValue)) or
+     (not AClassValue.HasInstanceInitializerWork) or
+     HasBytecodePrivateInitializersApplied(AInstance, AClassValue) then
+    Exit;
+  if AInstance is TGocciaObjectValue then
+    TGocciaObjectValue(AInstance).DefineProperty(
+    BytecodePrivateInitializedKey(AClassValue.PrivateBrandToken),
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaBooleanLiteralValue.TrueValue, []));
 end;
 
 procedure TGocciaVM.StampBytecodePrivateBrands(

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -107,6 +107,7 @@ type
     function Instantiate(const AArguments: TGocciaArgumentsCollection;
       const ANewTarget: TGocciaValue = nil): TGocciaValue; virtual;
     function EstimatedInstancePropertyCapacity: Integer;
+    function HasInstanceInitializerWork: Boolean;
     // ECMAScript: number of expected constructor parameters before the first
     // default/rest. Built-in classes default to 0; user classes derive from
     // their constructor method's formal parameters.
@@ -1098,6 +1099,23 @@ begin
         Inc(Result);
     WalkClass := WalkClass.SuperClass;
   end;
+end;
+
+function TGocciaClassValue.HasInstanceInitializerWork: Boolean;
+var
+  I: Integer;
+begin
+  if HasPrivateInstanceElements or
+     (Length(FFieldOrder) > 0) or
+     (Length(FMethodInitializers) > 0) or
+     (Length(FFieldInitializers) > 0) then
+    Exit(True);
+
+  for I := 0 to High(FDecoratorFieldInitializers) do
+    if not FDecoratorFieldInitializers[I].IsStatic then
+      Exit(True);
+
+  Result := False;
 end;
 
 // ES2026 §10.2.2 [[Construct]](argumentsList, newTarget)

--- a/tests/language/classes/class-inheritance.js
+++ b/tests/language/classes/class-inheritance.js
@@ -295,6 +295,47 @@ test("super() replacement initializes constructor layers in order", () => {
   expect(leaf.readLeafPrivate()).toBe(5);
 });
 
+test("super() replacement ignores mutable prototype constructor", () => {
+  const order = [];
+  let leafPrototype;
+  let replacement;
+  let constructorReads = 0;
+
+  class Base {
+    constructor() {
+      replacement = Object.create(leafPrototype);
+      return replacement;
+    }
+  }
+
+  class Leaf extends Base {
+    #privateValue = this === replacement ? order.push("private") : -1;
+
+    constructor() {
+      super();
+      order.push("body");
+    }
+
+    readPrivate() {
+      return this.#privateValue;
+    }
+  }
+
+  Object.defineProperty(Leaf.prototype, "constructor", {
+    get() {
+      constructorReads++;
+      return class Wrong {};
+    },
+    configurable: true
+  });
+  leafPrototype = Leaf.prototype;
+
+  const leaf = new Leaf();
+  expect(leaf.readPrivate()).toBe(1);
+  expect(order.join(",")).toBe("private,body");
+  expect(constructorReads).toBe(0);
+});
+
 test("implicit super preserves derived constructor receiver replacement", () => {
   let leafPrototype;
 

--- a/tests/language/classes/class-inheritance.js
+++ b/tests/language/classes/class-inheritance.js
@@ -243,6 +243,58 @@ test("super() replacement receives superclass initializers", () => {
   expect(leaf.readBase()).toBe("base");
 });
 
+test("super() replacement initializes constructor layers in order", () => {
+  const order = [];
+  let leafPrototype;
+  let replacement;
+
+  class Base {
+    constructor() {
+      replacement = Object.create(leafPrototype);
+      return replacement;
+    }
+  }
+
+  class Middle extends Base {
+    middleField = this === replacement ? order.push("middle field") : -1;
+    #middlePrivate = this === replacement ? order.push("middle private") : -1;
+
+    constructor() {
+      super();
+      order.push("middle body");
+    }
+
+    readMiddlePrivate() {
+      return this.#middlePrivate;
+    }
+  }
+
+  class Leaf extends Middle {
+    leafField = this === replacement ? order.push("leaf field") : -1;
+    #leafPrivate = this === replacement ? order.push("leaf private") : -1;
+
+    constructor() {
+      super();
+      order.push("leaf body");
+    }
+
+    readLeafPrivate() {
+      return this.#leafPrivate;
+    }
+  }
+
+  leafPrototype = Leaf.prototype;
+
+  const leaf = new Leaf();
+  expect(order.join(",")).toBe(
+    "middle field,middle private,middle body,leaf field,leaf private,leaf body"
+  );
+  expect(leaf.middleField).toBe(1);
+  expect(leaf.readMiddlePrivate()).toBe(2);
+  expect(leaf.leafField).toBe(4);
+  expect(leaf.readLeafPrivate()).toBe(5);
+});
+
 test("implicit super preserves derived constructor receiver replacement", () => {
   let leafPrototype;
 

--- a/tests/language/classes/private-elements-nonextensible-return-override.js
+++ b/tests/language/classes/private-elements-nonextensible-return-override.js
@@ -1,0 +1,90 @@
+/*---
+description: Private elements cannot be added to non-extensible constructor return overrides
+features: [private-fields, private-methods, class-inheritance]
+---*/
+
+describe("Private elements on constructor return overrides", () => {
+  class ReturnOverrideBase {
+    constructor(obj) {
+      return obj;
+    }
+  }
+
+  test("private fields throw when the replacement object is non-extensible", () => {
+    class WithPrivateField extends ReturnOverrideBase {
+      #value;
+
+      constructor(obj) {
+        super(obj);
+        this.#value = 42;
+      }
+
+      static read(obj) {
+        return obj.#value;
+      }
+    }
+
+    expect(() => new WithPrivateField(Object.preventExtensions({}))).toThrow(TypeError);
+
+    const obj = {};
+    new WithPrivateField(obj);
+    expect(WithPrivateField.read(obj)).toBe(42);
+  });
+
+  test("private field fallback does not brand unrelated constructor arguments", () => {
+    class WithPrivateField extends ReturnOverrideBase {
+      #value;
+
+      constructor(obj, other) {
+        super(obj);
+        other.#value = 42;
+      }
+    }
+
+    expect(() => new WithPrivateField({}, {})).toThrow(TypeError);
+  });
+
+  test("private methods throw when the replacement object is non-extensible", () => {
+    class WithPrivateMethod extends ReturnOverrideBase {
+      #method() {
+        return 42;
+      };
+
+      constructor(obj) {
+        super(obj);
+      }
+
+      static call(obj) {
+        return obj.#method();
+      }
+    }
+
+    expect(() => new WithPrivateMethod(Object.preventExtensions({}))).toThrow(TypeError);
+
+    const obj = {};
+    new WithPrivateMethod(obj);
+    expect(WithPrivateMethod.call(obj)).toBe(42);
+  });
+
+  test("private accessors throw when the replacement object is non-extensible", () => {
+    class WithPrivateAccessor extends ReturnOverrideBase {
+      get #accessor() {
+        return 7;
+      };
+
+      constructor(obj) {
+        super(obj);
+      }
+
+      static read(obj) {
+        return obj.#accessor;
+      }
+    }
+
+    expect(() => new WithPrivateAccessor(Object.preventExtensions({}))).toThrow(TypeError);
+
+    const obj = {};
+    new WithPrivateAccessor(obj);
+    expect(WithPrivateAccessor.read(obj)).toBe(7);
+  });
+});

--- a/tests/language/classes/private-elements-nonextensible-return-override.js
+++ b/tests/language/classes/private-elements-nonextensible-return-override.js
@@ -87,4 +87,65 @@ describe("Private elements on constructor return overrides", () => {
     new WithPrivateAccessor(obj);
     expect(WithPrivateAccessor.read(obj)).toBe(7);
   });
+
+  test("private accessors are initialized before constructor body resumes", () => {
+    class WithPrivateAccessorWrite extends ReturnOverrideBase {
+      #value = 0;
+
+      set #accessor(value) {
+        this.#value = value;
+      };
+
+      get #accessor() {
+        return this.#value;
+      };
+
+      constructor(obj) {
+        super(obj);
+        this.#accessor = 42;
+      }
+
+      static read(obj) {
+        return obj.#accessor;
+      }
+    }
+
+    expect(() => new WithPrivateAccessorWrite(Object.preventExtensions({}))).toThrow(TypeError);
+
+    const obj = {};
+    new WithPrivateAccessorWrite(obj);
+    expect(WithPrivateAccessorWrite.read(obj)).toBe(42);
+  });
+
+  test("replacement initialization overwrites copied raw private state", () => {
+    class WithPrivateFieldInitializer extends ReturnOverrideBase {
+      #value = 1;
+
+      constructor(obj, replacementValue) {
+        super(obj);
+        if (replacementValue !== undefined) {
+          this.#value = replacementValue;
+        }
+      }
+
+      static read(obj) {
+        return obj.#value;
+      }
+    }
+
+    const donor = {};
+    new WithPrivateFieldInitializer(donor, 99);
+
+    const forged = {};
+    for (const key of Object.getOwnPropertyNames(donor)) {
+      Object.defineProperty(
+        forged,
+        key,
+        Object.getOwnPropertyDescriptor(donor, key)
+      );
+    }
+
+    new WithPrivateFieldInitializer(forged);
+    expect(WithPrivateFieldInitializer.read(forged)).toBe(1);
+  });
 });

--- a/tests/language/classes/private-elements-nonextensible-return-override.js
+++ b/tests/language/classes/private-elements-nonextensible-return-override.js
@@ -117,6 +117,36 @@ describe("Private elements on constructor return overrides", () => {
     expect(WithPrivateAccessorWrite.read(obj)).toBe(42);
   });
 
+  test("replacement initialization is not replayed after constructor body writes", () => {
+    class WithPublicAndPrivateInitializers extends ReturnOverrideBase {
+      value = 1;
+      #privateValue = 0;
+
+      set #accessor(value) {
+        this.#privateValue = value;
+      };
+
+      get #accessor() {
+        return this.#privateValue;
+      };
+
+      constructor(obj) {
+        super(obj);
+        this.value = 2;
+        this.#accessor = 42;
+      }
+
+      static readPrivate(obj) {
+        return obj.#accessor;
+      }
+    }
+
+    const obj = {};
+    new WithPublicAndPrivateInitializers(obj);
+    expect(obj.value).toBe(2);
+    expect(WithPublicAndPrivateInitializers.readPrivate(obj)).toBe(42);
+  });
+
   test("replacement initialization overwrites copied raw private state", () => {
     class WithPrivateFieldInitializer extends ReturnOverrideBase {
       #value = 1;


### PR DESCRIPTION
## Summary

- Fix private elements on constructor return overrides: private fields, private methods, and private accessors now attach to the replacement object only when allowed.
- Enforce the non-extensible replacement-object TypeError path for private element initialization in both interpreter and bytecode execution.
- Accept empty semicolon class elements so private method/accessor test262 cases parse.
- Keep this PR scoped to the return-override/private-element slice; broader private static and nested-class private environment semantics remain separate follow-up work.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional verification:

- `./build.pas testrunner loader loaderbare`
- `./build/GocciaTestRunner tests/language/classes/private-elements-nonextensible-return-override.js --jobs=1`
- `./build/GocciaTestRunner tests/language/classes/private-elements-nonextensible-return-override.js --mode=bytecode --jobs=1`
- `./build/GocciaTestRunner tests/language/classes --jobs=1`
- `./build/GocciaTestRunner tests/language/classes --mode=bytecode --jobs=1`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/test262-suite-d0c1b455 --categories language --filter 'language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js' --mode interpreted --jobs 1 --output /tmp/goccia-private-nonextensible-interpreted.json`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/test262-suite-d0c1b455 --categories language --filter 'language/statements/class/subclass/private-class-field-on-nonextensible-return-override.js' --mode bytecode --jobs 1 --output /tmp/goccia-private-nonextensible-bytecode.json`
- `./format.pas --check`