### PR TITLE
Implement ECMAScript DataView

### DIFF
--- a/docs/built-ins-binary-data.md
+++ b/docs/built-ins-binary-data.md
@@ -1,14 +1,14 @@
 # Binary Data Built-ins
 
-*ArrayBuffer, SharedArrayBuffer, and TypedArray API reference.*
+*ArrayBuffer, SharedArrayBuffer, DataView, and TypedArray API reference.*
 
 ## Executive Summary
 
 - **ArrayBuffer** — raw binary data buffers with fixed-length and resizable modes, transfer semantics, and detachment
 - **SharedArrayBuffer** — fixed-length binary buffer with the same API shape as ArrayBuffer but as a distinct type
+- **DataView** — endian-aware typed reads and writes over ArrayBuffer and SharedArrayBuffer storage
 - **TypedArrays** — array-like views over buffer data with 12 element types (Int8 through Float64, BigInt64, BigUint64)
 - **Uint8Array encoding** — Base64 and hex encoding/decoding
-- **Not supported** — `DataView`
 
 ## ArrayBuffer (`Goccia.Builtins.GlobalArrayBuffer.pas`, `Goccia.Values.ArrayBufferValue.pas`)
 
@@ -23,6 +23,12 @@ Internally backed by a zero-initialized `TBytes` array. ArrayBuffer instances ar
 Implements the [ECMAScript SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer). See [MDN SharedArrayBuffer reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) for the full API.
 
 **Full standard compliance.** In GocciaScript, `SharedArrayBuffer` has the same API as `ArrayBuffer` but is a distinct type (not an instance of `ArrayBuffer`). SharedArrayBuffer instances are cloneable via `structuredClone`.
+
+## DataView (`Goccia.Values.DataViewValue.pas`)
+
+Implements the [ECMAScript DataView](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView). DataView instances provide endian-aware typed reads and writes over `ArrayBuffer` and `SharedArrayBuffer` storage.
+
+**Full standard compliance** — includes integer, BigInt, Float16, Float32, and Float64 getters and setters, `buffer`, `byteLength`, `byteOffset`, and detached/out-of-bounds buffer checks. Auto-length views over resizable `ArrayBuffer` instances track the current buffer length.
 
 ## TypedArrays (`Goccia.Values.TypedArrayValue.pas`)
 
@@ -46,8 +52,6 @@ Implements the [ECMAScript TypedArray](https://developer.mozilla.org/en-US/docs/
 | `Float64Array` | 8 bytes | IEEE 754 double-precision |
 | `BigInt64Array` | 8 bytes | -2⁶³ to 2⁶³-1 (BigInt) |
 | `BigUint64Array` | 8 bytes | 0 to 2⁶⁴-1 (BigInt) |
-
-**Not supported:** `DataView`.
 
 **Value encoding:** Integer types use fixed-width truncation (overflow wraps). `Uint8ClampedArray` clamps to [0, 255] with half-to-even rounding. `Float16Array` rounds to IEEE 754 half precision (max finite ±65504, epsilon 2⁻¹⁰ at 1.0). `Float32Array` rounds to IEEE 754 single precision. `Float64Array` preserves full double precision. NaN is stored as 0 in integer types and as NaN in float types.
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -637,9 +637,9 @@ Core High Resolution Time API:
 
 See [Temporal Built-ins](built-ins-temporal.md) for the complete Temporal API reference (PlainDate, PlainTime, PlainDateTime, Duration, Instant, ZonedDateTime, and more).
 
-### Binary Data (ArrayBuffer, SharedArrayBuffer, TypedArrays)
+### Binary Data (ArrayBuffer, SharedArrayBuffer, DataView, TypedArrays)
 
-See [Binary Data Built-ins](built-ins-binary-data.md) for the complete ArrayBuffer, SharedArrayBuffer, and TypedArray API reference.
+See [Binary Data Built-ins](built-ins-binary-data.md) for the complete ArrayBuffer, SharedArrayBuffer, DataView, and TypedArray API reference.
 
 ### FFI (`Goccia.Builtins.GlobalFFI.pas`)
 

--- a/docs/value-system.md
+++ b/docs/value-system.md
@@ -55,6 +55,7 @@ classDiagram
     TGocciaIteratorHelperValue <|-- TGocciaZipKeyedIteratorValue
     TGocciaObjectValue <|-- TGocciaArrayBufferValue
     TGocciaObjectValue <|-- TGocciaSharedArrayBufferValue
+    TGocciaObjectValue <|-- TGocciaDataViewValue
     TGocciaObjectValue <|-- TGocciaTypedArrayValue
     TGocciaObjectValue <|-- TGocciaNumberObjectValue
     TGocciaObjectValue <|-- TGocciaStringObjectValue
@@ -110,6 +111,9 @@ classDiagram
     }
     class TGocciaSharedArrayBufferValue {
         Shared-memory binary data buffer
+    }
+    class TGocciaDataViewValue {
+        Endian-aware view over binary data
     }
     class TGocciaTypedArrayValue {
         Typed view over ArrayBuffer
@@ -269,7 +273,7 @@ TGocciaStringLiteralValue = class(TGocciaValue)
 end;
 ```
 
-String values implement property access for methods like `.length`, `.charAt()`, `.includes()`, etc. through the string prototype system. When strings are boxed into `TGocciaStringObjectValue` (e.g., via `new String()` or implicit boxing), all instances share a single per-engine string prototype singleton — methods are registered once and reused across all string object instances of that engine. The prototype graph is per-engine and lives in a [realm slot](core-patterns.md#realm-ownership--slot-registration), but the wiring varies by type. `TGocciaArrayValue`, `TGocciaSetValue`, `TGocciaMapValue`, `TGocciaFunctionBase`, `TGocciaArrayBufferValue`, `TGocciaSharedArrayBufferValue`, and `TGocciaTypedArrayValue` use `TGocciaSharedPrototype` — a managed wrapper that bundles the prototype object and method host together; the realm pins both via `TGocciaRealm.SetOwnedSlot` when it takes ownership and unpins them on tear-down. `TGocciaStringObjectValue` reads its prototype directly via `CurrentRealm.GetSlot(GStringPrototypeSlot)` (set with `CurrentRealm.SetSlot`), with the method host held in a thread-local `FPrototypeMethodHost` and pinned manually via `TGarbageCollector.Instance.PinObject`. `TGocciaNumberObjectValue` and `TGocciaSymbolValue` use a similar raw-slot pattern with a process-wide method-host singleton. In all cases mutations on one engine's `String.prototype` do not leak into the next engine on the same worker thread.
+String values implement property access for methods like `.length`, `.charAt()`, `.includes()`, etc. through the string prototype system. When strings are boxed into `TGocciaStringObjectValue` (e.g., via `new String()` or implicit boxing), all instances share a single per-engine string prototype singleton — methods are registered once and reused across all string object instances of that engine. The prototype graph is per-engine and lives in a [realm slot](core-patterns.md#realm-ownership--slot-registration), but the wiring varies by type. `TGocciaArrayValue`, `TGocciaSetValue`, `TGocciaMapValue`, `TGocciaFunctionBase`, `TGocciaArrayBufferValue`, `TGocciaSharedArrayBufferValue`, `TGocciaDataViewValue`, and `TGocciaTypedArrayValue` use `TGocciaSharedPrototype` — a managed wrapper that bundles the prototype object and method host together; the realm pins both via `TGocciaRealm.SetOwnedSlot` when it takes ownership and unpins them on tear-down. `TGocciaStringObjectValue` reads its prototype directly via `CurrentRealm.GetSlot(GStringPrototypeSlot)` (set with `CurrentRealm.SetSlot`), with the method host held in a thread-local `FPrototypeMethodHost` and pinned manually via `TGarbageCollector.Instance.PinObject`. `TGocciaNumberObjectValue` and `TGocciaSymbolValue` use a similar raw-slot pattern with a process-wide method-host singleton. In all cases mutations on one engine's `String.prototype` do not leak into the next engine on the same worker thread.
 
 ### Symbols
 
@@ -664,15 +668,24 @@ Self-references in initializers are supported via a child scope that binds each 
 - **`slice(begin?, end?)`** — Returns a new SharedArrayBuffer (not ArrayBuffer).
 - **structuredClone** — Byte contents are copied into a new buffer.
 
+## DataView
+
+`TGocciaDataViewValue` extends `TGocciaInstanceValue` (`Goccia.Values.DataViewValue.pas`). It provides endian-aware typed reads and writes over `ArrayBuffer` or `SharedArrayBuffer` storage.
+
+- **Internal storage** — `FBufferValue: TGocciaValue` stores the underlying buffer, `FBufferData: TBytes` mirrors the current backing byte array, `FByteOffset: Integer` stores the view offset, and `FByteLength: Integer` stores either a fixed byte length or the auto-length sentinel for resizable ArrayBuffer views.
+- **Shared prototype singleton** — All DataView instances within an engine share a single per-engine prototype (`TGocciaSharedPrototype`), stored in a realm slot. Prototype methods are registered once during `InitializePrototype`.
+- **Element access** — DataView and TypedArray raw byte encoding use `Goccia.BinaryData`, which centralizes endian-aware integer, BigInt, Float16, Float32, and Float64 serialization.
+- **Detached and out-of-bounds checks** — Accessors and prototype methods reject detached ArrayBuffers and views that no longer fit after a resizable ArrayBuffer shrink. Auto-length views over resizable ArrayBuffers compute byte length from the current backing buffer.
+- **GC integration** — `MarkReferences` marks `FBufferValue`, preserving the viewed ArrayBuffer or SharedArrayBuffer.
+
 ## TypedArray
 
 `TGocciaTypedArrayValue` extends `TGocciaInstanceValue` (`Goccia.Values.TypedArrayValue.pas`). Provides array-like views over ArrayBuffer data with fixed element types. Ten non-BigInt types are supported: `Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float16Array`, `Float32Array`, `Float64Array`. `Float16Array` uses IEEE 754 half-precision (binary16) with conversion helpers in `Goccia.Float16.pas`.
 
 - **Internal storage** — `FBufferValue: TGocciaValue` (the underlying buffer — either `TGocciaArrayBufferValue` or `TGocciaSharedArrayBufferValue`, returned by `.buffer`), `FBufferData: TBytes` (shared reference to the buffer's byte array for element access), `FByteOffset: Integer`, `FLength: Integer`, `FKind: TGocciaTypedArrayKind`.
 - **Shared prototype singleton** — All TypedArray instances (regardless of kind) within an engine share a single per-engine prototype (`TGocciaSharedPrototype`), stored in a [realm slot](core-patterns.md#realm-ownership--slot-registration). Prototype methods are registered once during `InitializePrototype`. The prototype and method host are pinned automatically by `TGocciaRealm.SetOwnedSlot` when the realm takes ownership of the `TGocciaSharedPrototype`.
-- **Element access** — `ReadElement(index): Double` reads raw bytes from `FBufferData` and converts to `Double`. `WriteElement(index, value)` converts from `Double` to the target element type with overflow wrapping (integer types) or clamping (`Uint8ClampedArray`).
-- **`WriteNumberLiteral(index, num)`** — Handles `TGocciaNumberLiteralValue` special values (`NaN`, `Infinity`, `-Infinity`) correctly: NaN → 0 for integer types, NaN for float types; Infinity → 255 for `Uint8ClampedArray`, 0 for other integer types; raw IEEE 754 bytes for float types via `WriteFloatSpecial`. All write sites (property assignment, `fill`, `set`, `map`, `with`, constructors, `from`, `of`) use this helper.
-- **`WriteFloatSpecial`** — Writes canonical IEEE 754 byte representations of NaN, Infinity, and -Infinity directly into `FBufferData` via `Move`, bypassing FPC's floating-point conversion.
+- **Element access** — `ReadElement(index): Double` and `WriteElement(index, value)` delegate raw byte encoding to `Goccia.BinaryData`, using the same endian-aware helpers as DataView. Integer types wrap, `Uint8ClampedArray` clamps, and float types preserve IEEE 754 encodings.
+- **`WriteNumberLiteral(index, num)`** — Handles `TGocciaNumberLiteralValue` special values (`NaN`, `Infinity`, `-Infinity`) correctly: NaN → 0 for integer types, NaN for float types; Infinity → 255 for `Uint8ClampedArray`, 0 for other integer types; raw IEEE 754 bytes for float types through `Goccia.BinaryData`. All write sites (property assignment, `fill`, `set`, `map`, `with`, constructors, `from`, `of`) use this helper.
 - **Buffer sharing** — Multiple TypedArrays can share the same ArrayBuffer or SharedArrayBuffer with different byte offsets and element types. Changes through one view are visible in others. `FBufferData` is a FPC dynamic array reference that shares the underlying byte array with the buffer object, so element writes are visible across all views without copying.
 - **SharedArrayBuffer support** — TypedArrays can be constructed from both `TGocciaArrayBufferValue` and `TGocciaSharedArrayBufferValue`. The `.buffer` property returns the original buffer object (preserving its type). `subarray` creates a new view sharing the same buffer; `slice` always creates a new `TGocciaArrayBufferValue` copy.
 - **Prototype methods** — `at`, `fill`, `copyWithin`, `slice`, `subarray`, `set`, `reverse`, `sort`, `indexOf`, `lastIndexOf`, `includes`, `find`, `findIndex`, `findLast`, `findLastIndex`, `every`, `some`, `forEach`, `map`, `filter`, `reduce`, `reduceRight`, `join`, `toString`, `toReversed`, `toSorted`, `with`, `values`, `keys`, `entries`, `[Symbol.iterator]`.

--- a/docs/value-system.md
+++ b/docs/value-system.md
@@ -55,7 +55,7 @@ classDiagram
     TGocciaIteratorHelperValue <|-- TGocciaZipKeyedIteratorValue
     TGocciaObjectValue <|-- TGocciaArrayBufferValue
     TGocciaObjectValue <|-- TGocciaSharedArrayBufferValue
-    TGocciaObjectValue <|-- TGocciaDataViewValue
+    TGocciaInstanceValue <|-- TGocciaDataViewValue
     TGocciaObjectValue <|-- TGocciaTypedArrayValue
     TGocciaObjectValue <|-- TGocciaNumberObjectValue
     TGocciaObjectValue <|-- TGocciaStringObjectValue

--- a/source/units/Goccia.BinaryData.pas
+++ b/source/units/Goccia.BinaryData.pas
@@ -1,0 +1,320 @@
+unit Goccia.BinaryData;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TGocciaBinaryElementKind = (
+    bekInt8, bekUint8, bekUint8Clamped,
+    bekInt16, bekUint16,
+    bekInt32, bekUint32,
+    bekFloat16, bekFloat32, bekFloat64,
+    bekBigInt64, bekBigUint64
+  );
+
+function BinaryBytesPerElement(const AKind: TGocciaBinaryElementKind): Integer;
+function BinaryIsFloatElement(const AKind: TGocciaBinaryElementKind): Boolean; inline;
+function BinaryIsBigIntElement(const AKind: TGocciaBinaryElementKind): Boolean; inline;
+
+function ReadBinaryNumberElement(const AData: TBytes; const AOffset: Integer;
+  const AKind: TGocciaBinaryElementKind; const ALittleEndian: Boolean): Double;
+procedure WriteBinaryNumberElement(var AData: TBytes; const AOffset: Integer;
+  const AKind: TGocciaBinaryElementKind; const AValue: Double;
+  const ALittleEndian: Boolean);
+
+function ReadBinaryBigIntElement(const AData: TBytes; const AOffset: Integer;
+  const AKind: TGocciaBinaryElementKind; const ALittleEndian: Boolean): Int64;
+procedure WriteBinaryBigIntElement(var AData: TBytes; const AOffset: Integer;
+  const AValue: Int64; const ALittleEndian: Boolean);
+
+implementation
+
+uses
+  Math,
+
+  BigInteger,
+
+  Goccia.Float16,
+  Goccia.Values.Primitives;
+
+const
+  MAX_SAFE_DOUBLE_INTEGER = 9007199254740992.0;
+
+function BinaryBytesPerElement(const AKind: TGocciaBinaryElementKind): Integer;
+begin
+  case AKind of
+    bekInt8, bekUint8, bekUint8Clamped:
+      Result := 1;
+    bekInt16, bekUint16, bekFloat16:
+      Result := 2;
+    bekInt32, bekUint32, bekFloat32:
+      Result := 4;
+    bekFloat64, bekBigInt64, bekBigUint64:
+      Result := 8;
+  else
+    Result := 1;
+  end;
+end;
+
+function BinaryIsFloatElement(const AKind: TGocciaBinaryElementKind): Boolean;
+begin
+  Result := AKind in [bekFloat16, bekFloat32, bekFloat64];
+end;
+
+function BinaryIsBigIntElement(const AKind: TGocciaBinaryElementKind): Boolean;
+begin
+  Result := AKind in [bekBigInt64, bekBigUint64];
+end;
+
+function ReadUnsignedRaw(const AData: TBytes; const AOffset, ASize: Integer;
+  const ALittleEndian: Boolean): QWord;
+var
+  I: Integer;
+begin
+  Result := 0;
+  if ALittleEndian then
+  begin
+    for I := ASize - 1 downto 0 do
+      Result := (Result shl 8) or QWord(AData[AOffset + I]);
+  end
+  else
+  begin
+    for I := 0 to ASize - 1 do
+      Result := (Result shl 8) or QWord(AData[AOffset + I]);
+  end;
+end;
+
+procedure WriteUnsignedRaw(var AData: TBytes; const AOffset, ASize: Integer;
+  const AValue: QWord; const ALittleEndian: Boolean);
+var
+  I: Integer;
+begin
+  if ALittleEndian then
+  begin
+    for I := 0 to ASize - 1 do
+      AData[AOffset + I] := Byte((AValue shr (I * 8)) and $FF);
+  end
+  else
+  begin
+    for I := 0 to ASize - 1 do
+      AData[AOffset + ASize - 1 - I] := Byte((AValue shr (I * 8)) and $FF);
+  end;
+end;
+
+function SignExtendRaw(const AValue: QWord; const ABits: Integer): Int64;
+var
+  SignBit: QWord;
+begin
+  if ABits = 64 then
+    Exit(Int64(AValue));
+
+  SignBit := QWord(1) shl (ABits - 1);
+  if (AValue and SignBit) <> 0 then
+    Result := Int64(AValue) - Int64(QWord(1) shl ABits)
+  else
+    Result := Int64(AValue);
+end;
+
+function IntegerBitsForKind(const AKind: TGocciaBinaryElementKind): Integer;
+begin
+  case AKind of
+    bekInt8, bekUint8, bekUint8Clamped:
+      Result := 8;
+    bekInt16, bekUint16:
+      Result := 16;
+    bekInt32, bekUint32:
+      Result := 32;
+  else
+    Result := 64;
+  end;
+end;
+
+function IntegralNumberDecimalString(const AValue: Double): string;
+var
+  DecimalDigits, DotPos, EPos, Exponent, I: Integer;
+  Digits, ExponentText, Mantissa, NumberText: string;
+  IsNegative: Boolean;
+begin
+  NumberText := FormatDouble(AValue);
+  IsNegative := (Length(NumberText) > 0) and (NumberText[1] = '-');
+  if IsNegative then
+    Delete(NumberText, 1, 1);
+
+  EPos := Pos('e', LowerCase(NumberText));
+  if EPos = 0 then
+  begin
+    DotPos := Pos('.', NumberText);
+    if DotPos > 0 then
+      Result := Copy(NumberText, 1, DotPos - 1)
+    else
+      Result := NumberText;
+  end
+  else
+  begin
+    Mantissa := Copy(NumberText, 1, EPos - 1);
+    ExponentText := Copy(NumberText, EPos + 1, Length(NumberText) - EPos);
+    if (Length(ExponentText) > 0) and (ExponentText[1] = '+') then
+      Delete(ExponentText, 1, 1);
+    Exponent := StrToInt(ExponentText);
+
+    DotPos := Pos('.', Mantissa);
+    if DotPos > 0 then
+    begin
+      DecimalDigits := Length(Mantissa) - DotPos;
+      Delete(Mantissa, DotPos, 1);
+    end
+    else
+      DecimalDigits := 0;
+
+    Digits := Mantissa;
+    if Exponent >= DecimalDigits then
+      Result := Digits + StringOfChar('0', Exponent - DecimalDigits)
+    else
+    begin
+      Result := Copy(Digits, 1, Length(Digits) - (DecimalDigits - Exponent));
+      if Result = '' then
+        Result := '0';
+    end;
+  end;
+
+  I := 1;
+  while (I < Length(Result)) and (Result[I] = '0') do
+    Inc(I);
+  if I > 1 then
+    Delete(Result, 1, I - 1);
+
+  if IsNegative and (Result <> '0') then
+    Result := '-' + Result;
+end;
+
+function IntegralNumberToBigInteger(const AValue: Double): TBigInteger;
+begin
+  if (AValue >= -MAX_SAFE_DOUBLE_INTEGER) and
+     (AValue <= MAX_SAFE_DOUBLE_INTEGER) then
+    Exit(TBigInteger.FromInt64(Trunc(AValue)));
+
+  Result := TBigInteger.FromDecimalString(IntegralNumberDecimalString(AValue));
+end;
+
+function TruncatedIntegerBits(const AValue: Double;
+  const ABits: Integer): QWord;
+var
+  IntegerValue: TBigInteger;
+begin
+  if Math.IsNan(AValue) or Math.IsInfinite(AValue) or (AValue = 0.0) then
+    Exit(0);
+
+  if not (ABits in [8, 16, 32]) then
+    Exit(0);
+
+  IntegerValue := IntegralNumberToBigInteger(AValue);
+  Result := QWord(IntegerValue.AsUintN(ABits).ToInt64);
+end;
+
+function ReadBinaryNumberElement(const AData: TBytes; const AOffset: Integer;
+  const AKind: TGocciaBinaryElementKind; const ALittleEndian: Boolean): Double;
+var
+  Raw: QWord;
+  RawWord: Word;
+  RawLongWord: LongWord;
+  RawQWord: QWord;
+  Float32Value: Single;
+  Float64Value: Double;
+begin
+  case AKind of
+    bekInt8, bekInt16, bekInt32:
+      Result := SignExtendRaw(
+        ReadUnsignedRaw(AData, AOffset, BinaryBytesPerElement(AKind),
+          ALittleEndian),
+        IntegerBitsForKind(AKind));
+    bekUint8, bekUint8Clamped, bekUint16, bekUint32:
+    begin
+      Raw := ReadUnsignedRaw(AData, AOffset, BinaryBytesPerElement(AKind),
+        ALittleEndian);
+      Result := Raw;
+    end;
+    bekFloat16:
+    begin
+      RawWord := Word(ReadUnsignedRaw(AData, AOffset, 2, ALittleEndian));
+      Result := Float16ToDouble(RawWord);
+    end;
+    bekFloat32:
+    begin
+      RawLongWord := LongWord(ReadUnsignedRaw(AData, AOffset, 4, ALittleEndian));
+      Move(RawLongWord, Float32Value, 4);
+      Result := Float32Value;
+    end;
+    bekFloat64:
+    begin
+      RawQWord := ReadUnsignedRaw(AData, AOffset, 8, ALittleEndian);
+      Move(RawQWord, Float64Value, 8);
+      Result := Float64Value;
+    end;
+  else
+    Result := 0;
+  end;
+end;
+
+procedure WriteBinaryNumberElement(var AData: TBytes; const AOffset: Integer;
+  const AKind: TGocciaBinaryElementKind; const AValue: Double;
+  const ALittleEndian: Boolean);
+var
+  Clamped: Integer;
+  Float32Value: Single;
+  RawWord: Word;
+  RawLongWord: LongWord;
+  RawQWord: QWord;
+  Float64Value: Double;
+begin
+  case AKind of
+    bekUint8Clamped:
+    begin
+      if Math.IsNan(AValue) or (AValue <= 0) then
+        Clamped := 0
+      else if AValue >= 255 then
+        Clamped := 255
+      else
+        Clamped := Round(AValue);
+      WriteUnsignedRaw(AData, AOffset, 1, QWord(Clamped), ALittleEndian);
+    end;
+    bekInt8, bekUint8, bekInt16, bekUint16, bekInt32, bekUint32:
+      WriteUnsignedRaw(AData, AOffset, BinaryBytesPerElement(AKind),
+        TruncatedIntegerBits(AValue, IntegerBitsForKind(AKind)), ALittleEndian);
+    bekFloat16:
+    begin
+      RawWord := DoubleToFloat16(AValue);
+      WriteUnsignedRaw(AData, AOffset, 2, RawWord, ALittleEndian);
+    end;
+    bekFloat32:
+    begin
+      Float32Value := AValue;
+      Move(Float32Value, RawLongWord, 4);
+      WriteUnsignedRaw(AData, AOffset, 4, RawLongWord, ALittleEndian);
+    end;
+    bekFloat64:
+    begin
+      Float64Value := AValue;
+      Move(Float64Value, RawQWord, 8);
+      WriteUnsignedRaw(AData, AOffset, 8, RawQWord, ALittleEndian);
+    end;
+  end;
+end;
+
+function ReadBinaryBigIntElement(const AData: TBytes; const AOffset: Integer;
+  const AKind: TGocciaBinaryElementKind; const ALittleEndian: Boolean): Int64;
+begin
+  Result := Int64(ReadUnsignedRaw(AData, AOffset, BinaryBytesPerElement(AKind),
+    ALittleEndian));
+end;
+
+procedure WriteBinaryBigIntElement(var AData: TBytes; const AOffset: Integer;
+  const AValue: Int64; const ALittleEndian: Boolean);
+begin
+  WriteUnsignedRaw(AData, AOffset, 8, QWord(AValue), ALittleEndian);
+end;
+
+end.

--- a/source/units/Goccia.Builtins.GlobalArrayBuffer.pas
+++ b/source/units/Goccia.Builtins.GlobalArrayBuffer.pas
@@ -38,6 +38,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.Values.DataViewValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.HoleValue,
@@ -150,7 +151,9 @@ end;
 // ES2026 §25.1.5.1 ArrayBuffer.isView(arg)
 function TGocciaGlobalArrayBuffer.ArrayBufferIsView(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  if (AArgs.Length > 0) and (AArgs.GetElement(0) is TGocciaTypedArrayValue) then
+  if (AArgs.Length > 0) and
+     ((AArgs.GetElement(0) is TGocciaTypedArrayValue) or
+      (AArgs.GetElement(0) is TGocciaDataViewValue)) then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;

--- a/source/units/Goccia.Constants.ConstructorNames.pas
+++ b/source/units/Goccia.Constants.ConstructorNames.pas
@@ -26,6 +26,7 @@ const
   CONSTRUCTOR_ITERATOR     = 'Iterator';
   CONSTRUCTOR_ARRAY_BUFFER        = 'ArrayBuffer';
   CONSTRUCTOR_SHARED_ARRAY_BUFFER = 'SharedArrayBuffer';
+  CONSTRUCTOR_DATA_VIEW           = 'DataView';
   CONSTRUCTOR_COMPARATOR          = 'Comparator';
   CONSTRUCTOR_RANGE               = 'Range';
   CONSTRUCTOR_SEMVER              = 'SemVer';

--- a/source/units/Goccia.Engine.Realm.Test.pas
+++ b/source/units/Goccia.Engine.Realm.Test.pas
@@ -47,6 +47,7 @@ type
     procedure TestSequentialEnginesHaveIsolatedArrayPrototype;
     procedure TestSequentialEnginesHaveIsolatedObjectPrototype;
     procedure TestSequentialEnginesHaveIsolatedStringPrototype;
+    procedure TestSequentialEnginesHaveFreshDataViewPrototypeMembers;
     procedure TestSequentialEnginesHaveFreshURLSearchParamsPrototype;
     procedure TestSequentialEnginesHaveFreshURLPrototype;
     procedure TestNestedEngineRestoresOuterRealmOnDestroy;
@@ -73,6 +74,8 @@ begin
     TestSequentialEnginesHaveIsolatedObjectPrototype);
   Test('String.prototype mutations do not leak to the next engine',
     TestSequentialEnginesHaveIsolatedStringPrototype);
+  Test('DataView.prototype methods are fresh for each engine',
+    TestSequentialEnginesHaveFreshDataViewPrototypeMembers);
   Test('URLSearchParams.prototype is fresh for each engine',
     TestSequentialEnginesHaveFreshURLSearchParamsPrototype);
   Test('URL.prototype is fresh for each engine',
@@ -370,6 +373,20 @@ begin
     'function');
 
   ResultB := RunInline('typeof String.prototype.__poisonStr;');
+  Expect<string>((ResultB.Result as TGocciaStringLiteralValue).Value).ToBe(
+    'undefined');
+end;
+
+procedure TTestEngineRealm.TestSequentialEnginesHaveFreshDataViewPrototypeMembers;
+var
+  ResultA, ResultB: TGocciaScriptResult;
+begin
+  ResultA := RunInline(
+    'DataView.prototype.getUint8.__poisonDV = 7;' +
+    'DataView.prototype.getUint8.__poisonDV;');
+  Expect<Double>((ResultA.Result as TGocciaNumberLiteralValue).Value).ToBe(7);
+
+  ResultB := RunInline('typeof DataView.prototype.getUint8.__poisonDV;');
   Expect<string>((ResultB.Result as TGocciaStringLiteralValue).Value).ToBe(
     'undefined');
 end;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -309,6 +309,7 @@ uses
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.BooleanObjectValue,
+  Goccia.Values.DataViewValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FinalizationRegistryValue,
   Goccia.Values.FunctionValue,
@@ -772,6 +773,7 @@ var
   FinalizationRegistryConstructor: TGocciaFinalizationRegistryClassValue;
   ArrayBufferConstructor: TGocciaArrayBufferClassValue;
   SharedArrayBufferConstructor: TGocciaSharedArrayBufferClassValue;
+  DataViewConstructor: TGocciaDataViewClassValue;
   StringConstructor: TGocciaStringClassValue;
   NumberConstructor: TGocciaNumberClassValue;
   BooleanConstructor: TGocciaBooleanClassValue;
@@ -880,6 +882,11 @@ begin
   SharedArrayBufferConstructor.Prototype.Prototype := ObjectConstructor.Prototype;
   FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_SHARED_ARRAY_BUFFER, SharedArrayBufferConstructor, dtConst, True);
 
+  DataViewConstructor := TGocciaDataViewClassValue.Create(CONSTRUCTOR_DATA_VIEW, nil);
+  TGocciaDataViewValue.ExposePrototype(DataViewConstructor);
+  DataViewConstructor.Prototype.Prototype := ObjectConstructor.Prototype;
+  FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_DATA_VIEW, DataViewConstructor, dtConst, True);
+
   // Create %TypedArray% intrinsic (not globally exposed per spec §23.2.1)
   FTypedArrayIntrinsic := TGocciaClassValue.Create('TypedArray', nil);
   // §17: built-in name/length are {writable: false, enumerable: false, configurable: true}
@@ -970,6 +977,7 @@ begin
   TGocciaClassValue.PatchDefaultPrototype(FinalizationRegistryConstructor);
   TGocciaClassValue.PatchDefaultPrototype(ArrayBufferConstructor);
   TGocciaClassValue.PatchDefaultPrototype(SharedArrayBufferConstructor);
+  TGocciaClassValue.PatchDefaultPrototype(DataViewConstructor);
   TGocciaClassValue.PatchDefaultPrototype(FTypedArrayIntrinsic);
   TGocciaClassValue.PatchDefaultPrototype(StringConstructor);
   TGocciaClassValue.PatchDefaultPrototype(NumberConstructor);

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -307,6 +307,13 @@ resourcestring
   SErrorBigIntTypedArrayRequiresBigInt = 'Cannot convert a non-BigInt value to a BigInt; use BigInt() to wrap';
   SErrorBigIntTypedArrayCannotMix = 'Cannot mix BigInt and non-BigInt typed arrays';
 
+  // DataView errors
+  SErrorDataViewRequiresDataView = '%s requires a DataView';
+  SErrorDataViewRequiresArrayBuffer = 'DataView constructor requires an ArrayBuffer or SharedArrayBuffer';
+  SErrorCannotUseDetachedDataView = 'DataView cannot be used with a detached or out-of-bounds ArrayBuffer';
+  SErrorInvalidDataViewOffset = 'Invalid DataView byte offset';
+  SErrorInvalidDataViewLength = 'Invalid DataView byte length';
+
   // Proxy trap errors
   SErrorProxyRevoked = 'Cannot perform operation on a revoked proxy';
   SErrorProxyTrapNotFunction = 'Proxy handler trap ''%s'' is not a function';

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -200,6 +200,7 @@ resourcestring
   SSuggestArrayBufferThisType = 'ArrayBuffer methods must be called on an ArrayBuffer instance';
   SSuggestArrayBufferDetached = 'the ArrayBuffer has been detached (transferred) and can no longer be used';
   SSuggestArrayBufferResizable = 'create a resizable ArrayBuffer with: new ArrayBuffer(length, { maxByteLength: ... })';
+  SSuggestDataViewThisType = 'DataView prototype methods must be called on a DataView instance';
 
   // Runtime errors — DisposableStack
   SSuggestDisposableStackThisType = 'DisposableStack methods must be called on a DisposableStack instance';

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -221,6 +221,12 @@ type
     function GetClassLength: Integer; override;
   end;
 
+  TGocciaDataViewClassValue = class(TGocciaClassValue)
+    function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    // ECMAScript 25.3.2.1: DataView constructor length is 1.
+    function GetClassLength: Integer; override;
+  end;
+
   TGocciaTextEncoderClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
   end;
@@ -311,6 +317,7 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.AutoAccessor,
   Goccia.Values.ClassHelper,
+  Goccia.Values.DataViewValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FinalizationRegistryValue,
   Goccia.Values.HeadersValue,
@@ -1471,6 +1478,18 @@ begin
 end;
 
 function TGocciaSharedArrayBufferClassValue.GetClassLength: Integer;
+begin
+  Result := 1;
+end;
+
+{ TGocciaDataViewClassValue }
+
+function TGocciaDataViewClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
+begin
+  Result := TGocciaDataViewValue.Create(TGocciaClassValue(nil));
+end;
+
+function TGocciaDataViewClassValue.GetClassLength: Integer;
 begin
   Result := 1;
 end;

--- a/source/units/Goccia.Values.DataViewValue.pas
+++ b/source/units/Goccia.Values.DataViewValue.pas
@@ -47,8 +47,6 @@ type
     constructor Create(const ABuffer: TGocciaSharedArrayBufferValue;
       const AByteOffset: Integer = 0; const AByteLength: Integer = AUTO_BYTE_LENGTH); overload;
 
-    function GetProperty(const AName: string): TGocciaValue; override;
-    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToStringTag: string; override;
 
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
@@ -425,31 +423,6 @@ begin
     ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
   if IsViewOutOfBounds then
     ThrowRangeError(SErrorInvalidDataViewLength, SSuggestTypedArrayLength);
-end;
-
-function TGocciaDataViewValue.GetProperty(const AName: string): TGocciaValue;
-begin
-  Result := GetPropertyWithContext(AName, Self);
-end;
-
-function TGocciaDataViewValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
-begin
-  if AName = PROP_BUFFER then
-    Result := FBufferValue
-  else if AName = PROP_BYTE_LENGTH then
-  begin
-    if IsViewOutOfBounds then
-      ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
-    Result := TGocciaNumberLiteralValue.Create(GetViewByteLength);
-  end
-  else if AName = PROP_BYTE_OFFSET then
-  begin
-    if IsViewOutOfBounds then
-      ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
-    Result := TGocciaNumberLiteralValue.Create(FByteOffset);
-  end
-  else
-    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaDataViewValue.ToStringTag: string;

--- a/source/units/Goccia.Values.DataViewValue.pas
+++ b/source/units/Goccia.Values.DataViewValue.pas
@@ -1,0 +1,701 @@
+unit Goccia.Values.DataViewValue;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  SysUtils,
+
+  BigInteger,
+
+  Goccia.Arguments.Collection,
+  Goccia.BinaryData,
+  Goccia.ObjectModel,
+  Goccia.SharedPrototype,
+  Goccia.Values.ArrayBufferValue,
+  Goccia.Values.ClassValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives,
+  Goccia.Values.SharedArrayBufferValue;
+
+type
+  TGocciaDataViewValue = class(TGocciaInstanceValue)
+  private
+    const AUTO_BYTE_LENGTH = -1;
+  private
+    FBufferValue: TGocciaValue;
+    FBufferData: TBytes;
+    FByteOffset: Integer;
+    FByteLength: Integer;
+
+    procedure InitializePrototype;
+    procedure SyncBufferData;
+    function IsDetachedBuffer: Boolean;
+    function IsAutoLength: Boolean; inline;
+    function IsViewOutOfBounds: Boolean;
+    function GetViewByteLength: Integer;
+    function GetBufferByteLength: Integer;
+    function GetViewValue(const ARequestIndex, ALittleEndian: TGocciaValue;
+      const AKind: TGocciaBinaryElementKind): TGocciaValue;
+    function SetViewValue(const ARequestIndex, ALittleEndian: TGocciaValue;
+      const AKind: TGocciaBinaryElementKind; const AValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil); overload;
+    constructor Create(const ABuffer: TGocciaArrayBufferValue;
+      const AByteOffset: Integer = 0; const AByteLength: Integer = AUTO_BYTE_LENGTH); overload;
+    constructor Create(const ABuffer: TGocciaSharedArrayBufferValue;
+      const AByteOffset: Integer = 0; const AByteLength: Integer = AUTO_BYTE_LENGTH); overload;
+
+    function GetProperty(const AName: string): TGocciaValue; override;
+    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
+    function ToStringTag: string; override;
+
+    procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
+    procedure MarkReferences; override;
+
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+
+    property BufferValue: TGocciaValue read FBufferValue;
+    property ByteOffset: Integer read FByteOffset;
+  published
+    function DataViewBufferGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewByteOffsetGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+
+    function DataViewGetBigInt64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetBigUint64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetFloat16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetFloat32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetFloat64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetInt8(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetInt16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetInt32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetUint8(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetUint16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewGetUint32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+
+    function DataViewSetBigInt64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetBigUint64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetFloat16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetFloat32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetFloat64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetInt8(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetInt16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetInt32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetUint8(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetUint16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function DataViewSetUint32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+implementation
+
+uses
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.NumericLimits,
+  Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
+  Goccia.Realm,
+  Goccia.Values.BigIntValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
+  Goccia.Values.ToPrimitive;
+
+var
+  GDataViewSharedSlot: TGocciaRealmOwnedSlotId;
+
+function GetDataViewShared: TGocciaSharedPrototype; inline;
+begin
+  if Assigned(CurrentRealm) then
+    Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GDataViewSharedSlot))
+  else
+    Result := nil;
+end;
+
+function RequireDataView(const AThisValue: TGocciaValue; const AMethodName: string): TGocciaDataViewValue;
+begin
+  if not (AThisValue is TGocciaDataViewValue) then
+    ThrowTypeError(Format(SErrorDataViewRequiresDataView, [AMethodName]),
+      SSuggestDataViewThisType);
+  Result := TGocciaDataViewValue(AThisValue);
+end;
+
+// ES2026 §6.2.4.2 ToIndex(value)
+function DataViewToIndex(const AValue: TGocciaValue): Integer;
+var
+  Num: TGocciaNumberLiteralValue;
+  IntegerIndex: Double;
+begin
+  if (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue) then
+    Exit(0);
+
+  Num := AValue.ToNumberLiteral;
+  if Num.IsNaN then
+    IntegerIndex := 0
+  else if Num.IsInfinite then
+  begin
+    ThrowRangeError(SErrorInvalidDataViewOffset, SSuggestTypedArrayLength);
+    Exit(0);
+  end
+  else
+    IntegerIndex := Trunc(Num.Value);
+
+  if (IntegerIndex < 0) or (IntegerIndex > MAX_SAFE_INTEGER_F) or
+     (IntegerIndex > High(Integer)) then
+    ThrowRangeError(SErrorInvalidDataViewOffset, SSuggestTypedArrayLength);
+
+  Result := Trunc(IntegerIndex);
+end;
+
+function BigIntFromQWord(const AValue: QWord): TBigInteger;
+var
+  LowPart, HighPart: Int64;
+begin
+  LowPart := Int64(AValue and $FFFFFFFF);
+  HighPart := Int64(AValue shr 32);
+  if HighPart = 0 then
+    Result := TBigInteger.FromInt64(LowPart)
+  else
+    Result := TBigInteger.FromInt64(HighPart).Multiply(TBigInteger.FromInt64($100000000)).Add(TBigInteger.FromInt64(LowPart));
+end;
+
+// ES2026 §7.1.13 ToBigInt(argument)
+function ToBigIntForDataView(const AValue: TGocciaValue): TGocciaBigIntValue;
+var
+  PrimitiveValue: TGocciaValue;
+  StringBigInt: TBigInteger;
+begin
+  if AValue is TGocciaObjectValue then
+  begin
+    PrimitiveValue := ToPrimitive(AValue, tphNumber);
+    Exit(ToBigIntForDataView(PrimitiveValue));
+  end;
+
+  if AValue is TGocciaBigIntValue then
+    Exit(TGocciaBigIntValue(AValue));
+
+  if AValue is TGocciaBooleanLiteralValue then
+  begin
+    if TGocciaBooleanLiteralValue(AValue).Value then
+      Exit(TGocciaBigIntValue.BigIntOne)
+    else
+      Exit(TGocciaBigIntValue.BigIntZero);
+  end;
+
+  if AValue is TGocciaStringLiteralValue then
+  begin
+    if not TryStringToBigInt(TGocciaStringLiteralValue(AValue).Value, StringBigInt) then
+      ThrowSyntaxError(Format(SErrorBigIntInvalidConversion,
+        [TGocciaStringLiteralValue(AValue).Value]), SSuggestBigIntNoImplicitConversion);
+    Exit(TGocciaBigIntValue.Create(StringBigInt));
+  end;
+
+  ThrowTypeError(SErrorBigIntTypedArrayRequiresBigInt, SSuggestBigIntTypedArrayValue);
+  Result := nil;
+end;
+
+function RawBigIntForDataView(const AKind: TGocciaBinaryElementKind;
+  const AValue: TGocciaBigIntValue): Int64;
+begin
+  if AKind = bekBigUint64 then
+    Result := AValue.Value.AsUintN(64).ToInt64
+  else
+    Result := AValue.Value.AsIntN(64).ToInt64;
+end;
+
+constructor TGocciaDataViewValue.Create(const AClass: TGocciaClassValue);
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  inherited Create(AClass);
+  FBufferValue := nil;
+  SetLength(FBufferData, 0);
+  FByteOffset := 0;
+  FByteLength := 0;
+  InitializePrototype;
+  Shared := GetDataViewShared;
+  if not Assigned(AClass) and Assigned(Shared) then
+    FPrototype := Shared.Prototype;
+end;
+
+constructor TGocciaDataViewValue.Create(const ABuffer: TGocciaArrayBufferValue;
+  const AByteOffset: Integer; const AByteLength: Integer);
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  inherited Create(nil);
+  FBufferValue := ABuffer;
+  FBufferData := ABuffer.Data;
+  FByteOffset := AByteOffset;
+  FByteLength := AByteLength;
+  InitializePrototype;
+  Shared := GetDataViewShared;
+  if Assigned(Shared) then
+    FPrototype := Shared.Prototype;
+end;
+
+constructor TGocciaDataViewValue.Create(const ABuffer: TGocciaSharedArrayBufferValue;
+  const AByteOffset: Integer; const AByteLength: Integer);
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  inherited Create(nil);
+  FBufferValue := ABuffer;
+  FBufferData := ABuffer.Data;
+  FByteOffset := AByteOffset;
+  FByteLength := AByteLength;
+  InitializePrototype;
+  Shared := GetDataViewShared;
+  if Assigned(Shared) then
+    FPrototype := Shared.Prototype;
+end;
+
+procedure TGocciaDataViewValue.InitializePrototype;
+var
+  Members: TGocciaMemberCollection;
+  Shared: TGocciaSharedPrototype;
+begin
+  if not Assigned(CurrentRealm) then Exit;
+  if Assigned(GetDataViewShared) then Exit;
+
+  Shared := TGocciaSharedPrototype.Create(Self);
+  CurrentRealm.SetOwnedSlot(GDataViewSharedSlot, Shared);
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddAccessor(PROP_BUFFER, DataViewBufferGetter, nil, [pfConfigurable]);
+    Members.AddAccessor(PROP_BYTE_LENGTH, DataViewByteLengthGetter, nil, [pfConfigurable]);
+    Members.AddAccessor(PROP_BYTE_OFFSET, DataViewByteOffsetGetter, nil, [pfConfigurable]);
+
+    Members.AddMethod(DataViewGetBigInt64, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetBigUint64, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetFloat16, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetFloat32, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetFloat64, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetInt8, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetInt16, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetInt32, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetUint8, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetUint16, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewGetUint32, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+
+    Members.AddMethod(DataViewSetBigInt64, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetBigUint64, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetFloat16, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetFloat32, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetFloat64, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetInt8, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetInt16, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetInt32, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetUint8, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetUint16, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(DataViewSetUint32, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+
+    Members.AddSymbolDataProperty(
+      TGocciaSymbolValue.WellKnownToStringTag,
+      TGocciaStringLiteralValue.Create(CONSTRUCTOR_DATA_VIEW),
+      [pfConfigurable]);
+    RegisterMemberDefinitions(Shared.Prototype, Members.ToDefinitions);
+  finally
+    Members.Free;
+  end;
+end;
+
+class procedure TGocciaDataViewValue.ExposePrototype(const AConstructor: TGocciaValue);
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Shared := GetDataViewShared;
+  if not Assigned(Shared) then
+  begin
+    TGocciaDataViewValue.Create;
+    Shared := GetDataViewShared;
+  end;
+  if Assigned(Shared) then
+    ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+procedure TGocciaDataViewValue.SyncBufferData;
+begin
+  if FBufferValue is TGocciaArrayBufferValue then
+    FBufferData := TGocciaArrayBufferValue(FBufferValue).Data
+  else if FBufferValue is TGocciaSharedArrayBufferValue then
+    FBufferData := TGocciaSharedArrayBufferValue(FBufferValue).Data;
+end;
+
+function TGocciaDataViewValue.IsDetachedBuffer: Boolean;
+begin
+  Result := (FBufferValue is TGocciaArrayBufferValue) and
+    TGocciaArrayBufferValue(FBufferValue).Detached;
+end;
+
+function TGocciaDataViewValue.IsAutoLength: Boolean;
+begin
+  Result := FByteLength = AUTO_BYTE_LENGTH;
+end;
+
+function TGocciaDataViewValue.GetBufferByteLength: Integer;
+begin
+  if IsDetachedBuffer then
+    Exit(0);
+  SyncBufferData;
+  Result := Length(FBufferData);
+end;
+
+// ES2026 §25.3.1.4 IsViewOutOfBounds(viewRecord)
+function TGocciaDataViewValue.IsViewOutOfBounds: Boolean;
+var
+  BufferByteLength, ByteOffsetEnd: Integer;
+begin
+  if IsDetachedBuffer then
+    Exit(True);
+
+  BufferByteLength := GetBufferByteLength;
+  if IsAutoLength then
+    ByteOffsetEnd := BufferByteLength
+  else
+    ByteOffsetEnd := FByteOffset + FByteLength;
+
+  Result := (FByteOffset > BufferByteLength) or
+    (ByteOffsetEnd > BufferByteLength);
+end;
+
+// ES2026 §25.3.1.3 GetViewByteLength(viewRecord)
+function TGocciaDataViewValue.GetViewByteLength: Integer;
+begin
+  if IsAutoLength then
+    Result := GetBufferByteLength - FByteOffset
+  else
+    Result := FByteLength;
+end;
+
+// ES2026 §25.3.2.1 DataView(buffer [, byteOffset [, byteLength]])
+procedure TGocciaDataViewValue.InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
+var
+  BufferArg, ByteLengthArg: TGocciaValue;
+  Offset, ViewByteLength, BufferByteLength: Integer;
+  HasByteLength: Boolean;
+  BufferIsResizable: Boolean;
+begin
+  if (AArguments = nil) or (AArguments.Length = 0) then
+    ThrowTypeError(SErrorDataViewRequiresArrayBuffer, SSuggestArrayBufferThisType);
+
+  BufferArg := AArguments.GetElement(0);
+  if not (BufferArg is TGocciaArrayBufferValue) and
+     not (BufferArg is TGocciaSharedArrayBufferValue) then
+    ThrowTypeError(SErrorDataViewRequiresArrayBuffer, SSuggestArrayBufferThisType);
+
+  if AArguments.Length > 1 then
+    Offset := DataViewToIndex(AArguments.GetElement(1))
+  else
+    Offset := 0;
+
+  if (BufferArg is TGocciaArrayBufferValue) and
+     TGocciaArrayBufferValue(BufferArg).Detached then
+    ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
+
+  FBufferValue := BufferArg;
+  SyncBufferData;
+  BufferByteLength := Length(FBufferData);
+  if Offset > BufferByteLength then
+    ThrowRangeError(SErrorInvalidDataViewOffset, SSuggestTypedArrayLength);
+
+  HasByteLength := (AArguments.Length > 2) and
+    not (AArguments.GetElement(2) is TGocciaUndefinedLiteralValue);
+  BufferIsResizable := (BufferArg is TGocciaArrayBufferValue) and
+    (TGocciaArrayBufferValue(BufferArg).MaxByteLength >= 0);
+
+  if HasByteLength then
+  begin
+    ByteLengthArg := AArguments.GetElement(2);
+    ViewByteLength := DataViewToIndex(ByteLengthArg);
+    if Int64(Offset) + Int64(ViewByteLength) > Int64(BufferByteLength) then
+      ThrowRangeError(SErrorInvalidDataViewLength, SSuggestTypedArrayLength);
+  end
+  else if BufferIsResizable then
+    ViewByteLength := AUTO_BYTE_LENGTH
+  else
+    ViewByteLength := BufferByteLength - Offset;
+
+  FByteOffset := Offset;
+  FByteLength := ViewByteLength;
+
+  if IsDetachedBuffer then
+    ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
+  if IsViewOutOfBounds then
+    ThrowRangeError(SErrorInvalidDataViewLength, SSuggestTypedArrayLength);
+end;
+
+function TGocciaDataViewValue.GetProperty(const AName: string): TGocciaValue;
+begin
+  Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaDataViewValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
+begin
+  if AName = PROP_BUFFER then
+    Result := FBufferValue
+  else if AName = PROP_BYTE_LENGTH then
+  begin
+    if IsViewOutOfBounds then
+      ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
+    Result := TGocciaNumberLiteralValue.Create(GetViewByteLength);
+  end
+  else if AName = PROP_BYTE_OFFSET then
+  begin
+    if IsViewOutOfBounds then
+      ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
+    Result := TGocciaNumberLiteralValue.Create(FByteOffset);
+  end
+  else
+    Result := inherited GetPropertyWithContext(AName, AThisContext);
+end;
+
+function TGocciaDataViewValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_DATA_VIEW;
+end;
+
+procedure TGocciaDataViewValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FBufferValue) and not FBufferValue.GCMarked then
+    FBufferValue.MarkReferences;
+end;
+
+// ES2026 §25.3.1.5 GetViewValue(view, requestIndex, isLittleEndian, type)
+function TGocciaDataViewValue.GetViewValue(const ARequestIndex, ALittleEndian: TGocciaValue;
+  const AKind: TGocciaBinaryElementKind): TGocciaValue;
+var
+  Index, ViewSize, ElementSize, BufferIndex: Integer;
+  IsLittleEndian: Boolean;
+  RawBigInt: Int64;
+begin
+  Index := DataViewToIndex(ARequestIndex);
+  IsLittleEndian := Assigned(ALittleEndian) and ALittleEndian.ToBooleanLiteral.Value;
+
+  if IsViewOutOfBounds then
+    ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
+
+  ViewSize := GetViewByteLength;
+  ElementSize := BinaryBytesPerElement(AKind);
+  if Int64(Index) + Int64(ElementSize) > Int64(ViewSize) then
+    ThrowRangeError(SErrorInvalidDataViewOffset, SSuggestTypedArrayLength);
+
+  BufferIndex := Index + FByteOffset;
+  SyncBufferData;
+  if BinaryIsBigIntElement(AKind) then
+  begin
+    RawBigInt := ReadBinaryBigIntElement(FBufferData, BufferIndex, AKind,
+      IsLittleEndian);
+    if AKind = bekBigUint64 then
+      Result := TGocciaBigIntValue.Create(BigIntFromQWord(QWord(RawBigInt)))
+    else
+      Result := TGocciaBigIntValue.Create(TBigInteger.FromInt64(RawBigInt));
+  end
+  else
+    Result := TGocciaNumberLiteralValue.Create(
+      ReadBinaryNumberElement(FBufferData, BufferIndex, AKind, IsLittleEndian));
+end;
+
+// ES2026 §25.3.1.6 SetViewValue(view, requestIndex, isLittleEndian, type, value)
+function TGocciaDataViewValue.SetViewValue(const ARequestIndex, ALittleEndian: TGocciaValue;
+  const AKind: TGocciaBinaryElementKind; const AValue: TGocciaValue): TGocciaValue;
+var
+  Index, ViewSize, ElementSize, BufferIndex: Integer;
+  IsLittleEndian: Boolean;
+  NumberValue: TGocciaNumberLiteralValue;
+  BigIntRaw: Int64;
+begin
+  Index := DataViewToIndex(ARequestIndex);
+  NumberValue := nil;
+  BigIntRaw := 0;
+  if BinaryIsBigIntElement(AKind) then
+    BigIntRaw := RawBigIntForDataView(AKind, ToBigIntForDataView(AValue))
+  else
+    NumberValue := AValue.ToNumberLiteral;
+
+  IsLittleEndian := Assigned(ALittleEndian) and ALittleEndian.ToBooleanLiteral.Value;
+
+  if IsViewOutOfBounds then
+    ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
+
+  ViewSize := GetViewByteLength;
+  ElementSize := BinaryBytesPerElement(AKind);
+  if Int64(Index) + Int64(ElementSize) > Int64(ViewSize) then
+    ThrowRangeError(SErrorInvalidDataViewOffset, SSuggestTypedArrayLength);
+
+  BufferIndex := Index + FByteOffset;
+  SyncBufferData;
+  if BinaryIsBigIntElement(AKind) then
+    WriteBinaryBigIntElement(FBufferData, BufferIndex, BigIntRaw, IsLittleEndian)
+  else
+    WriteBinaryNumberElement(FBufferData, BufferIndex, AKind,
+      NumberValue.Value, IsLittleEndian);
+
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaDataViewValue.DataViewBufferGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.buffer').FBufferValue;
+end;
+
+function TGocciaDataViewValue.DataViewByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  View: TGocciaDataViewValue;
+begin
+  View := RequireDataView(AThisValue, 'DataView.prototype.byteLength');
+  if View.IsViewOutOfBounds then
+    ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
+  Result := TGocciaNumberLiteralValue.Create(View.GetViewByteLength);
+end;
+
+function TGocciaDataViewValue.DataViewByteOffsetGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  View: TGocciaDataViewValue;
+begin
+  View := RequireDataView(AThisValue, 'DataView.prototype.byteOffset');
+  if View.IsViewOutOfBounds then
+    ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
+  Result := TGocciaNumberLiteralValue.Create(View.FByteOffset);
+end;
+
+function TGocciaDataViewValue.DataViewGetBigInt64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getBigInt64').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekBigInt64);
+end;
+
+function TGocciaDataViewValue.DataViewGetBigUint64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getBigUint64').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekBigUint64);
+end;
+
+function TGocciaDataViewValue.DataViewGetFloat16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getFloat16').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekFloat16);
+end;
+
+function TGocciaDataViewValue.DataViewGetFloat32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getFloat32').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekFloat32);
+end;
+
+function TGocciaDataViewValue.DataViewGetFloat64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getFloat64').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekFloat64);
+end;
+
+function TGocciaDataViewValue.DataViewGetInt8(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getInt8').GetViewValue(
+    AArgs.GetElement(0), TGocciaBooleanLiteralValue.TrueValue, bekInt8);
+end;
+
+function TGocciaDataViewValue.DataViewGetInt16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getInt16').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekInt16);
+end;
+
+function TGocciaDataViewValue.DataViewGetInt32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getInt32').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekInt32);
+end;
+
+function TGocciaDataViewValue.DataViewGetUint8(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getUint8').GetViewValue(
+    AArgs.GetElement(0), TGocciaBooleanLiteralValue.TrueValue, bekUint8);
+end;
+
+function TGocciaDataViewValue.DataViewGetUint16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getUint16').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekUint16);
+end;
+
+function TGocciaDataViewValue.DataViewGetUint32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.getUint32').GetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(1), bekUint32);
+end;
+
+function TGocciaDataViewValue.DataViewSetBigInt64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setBigInt64').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekBigInt64, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetBigUint64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setBigUint64').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekBigUint64, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetFloat16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setFloat16').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekFloat16, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetFloat32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setFloat32').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekFloat32, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetFloat64(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setFloat64').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekFloat64, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetInt8(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setInt8').SetViewValue(
+    AArgs.GetElement(0), TGocciaBooleanLiteralValue.TrueValue, bekInt8, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetInt16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setInt16').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekInt16, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetInt32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setInt32').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekInt32, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetUint8(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setUint8').SetViewValue(
+    AArgs.GetElement(0), TGocciaBooleanLiteralValue.TrueValue, bekUint8, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetUint16(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setUint16').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekUint16, AArgs.GetElement(1));
+end;
+
+function TGocciaDataViewValue.DataViewSetUint32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireDataView(AThisValue, 'DataView.prototype.setUint32').SetViewValue(
+    AArgs.GetElement(0), AArgs.GetElement(2), bekUint32, AArgs.GetElement(1));
+end;
+
+initialization
+  GDataViewSharedSlot := RegisterRealmOwnedSlot('DataView.shared');
+
+end.

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -155,11 +155,11 @@ uses
   Math,
 
   Goccia.Arithmetic,
+  Goccia.BinaryData,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.Float16,
   Goccia.GarbageCollector,
   Goccia.Realm,
   Goccia.Utils,
@@ -182,6 +182,9 @@ threadvar
   FPrototypeMembers: TArray<TGocciaMemberDefinition>;
   FUint8Prototype: TGocciaObjectValue;
 
+const
+  TYPED_ARRAY_LITTLE_ENDIAN = True;
+
 function GetTypedArrayShared: TGocciaSharedPrototype; inline;
 begin
   if Assigned(CurrentRealm) then
@@ -190,26 +193,51 @@ begin
     Result := nil;
 end;
 
-class function TGocciaTypedArrayValue.BytesPerElement(const AKind: TGocciaTypedArrayKind): Integer;
+function ToBinaryElementKind(const AKind: TGocciaTypedArrayKind): TGocciaBinaryElementKind;
 begin
   case AKind of
-    takInt8, takUint8, takUint8Clamped: Result := 1;
-    takInt16, takUint16, takFloat16: Result := 2;
-    takInt32, takUint32, takFloat32: Result := 4;
-    takFloat64, takBigInt64, takBigUint64: Result := 8;
+    takInt8:
+      Result := bekInt8;
+    takUint8:
+      Result := bekUint8;
+    takUint8Clamped:
+      Result := bekUint8Clamped;
+    takInt16:
+      Result := bekInt16;
+    takUint16:
+      Result := bekUint16;
+    takInt32:
+      Result := bekInt32;
+    takUint32:
+      Result := bekUint32;
+    takFloat16:
+      Result := bekFloat16;
+    takFloat32:
+      Result := bekFloat32;
+    takFloat64:
+      Result := bekFloat64;
+    takBigInt64:
+      Result := bekBigInt64;
+    takBigUint64:
+      Result := bekBigUint64;
   else
-    Result := 1;
+    Result := bekUint8;
   end;
+end;
+
+class function TGocciaTypedArrayValue.BytesPerElement(const AKind: TGocciaTypedArrayKind): Integer;
+begin
+  Result := BinaryBytesPerElement(ToBinaryElementKind(AKind));
 end;
 
 class function TGocciaTypedArrayValue.IsFloatKind(const AKind: TGocciaTypedArrayKind): Boolean;
 begin
-  Result := AKind in [takFloat16, takFloat32, takFloat64];
+  Result := BinaryIsFloatElement(ToBinaryElementKind(AKind));
 end;
 
 class function TGocciaTypedArrayValue.IsBigIntKind(const AKind: TGocciaTypedArrayKind): Boolean;
 begin
-  Result := AKind in [takBigInt64, takBigUint64];
+  Result := BinaryIsBigIntElement(ToBinaryElementKind(AKind));
 end;
 
 class function TGocciaTypedArrayValue.KindName(const AKind: TGocciaTypedArrayKind): string;
@@ -287,174 +315,27 @@ end;
 function TGocciaTypedArrayValue.ReadElement(const AIndex: Integer): Double;
 var
   Offset: Integer;
-  I8: ShortInt;
-  U8: Byte;
-  I16: SmallInt;
-  U16: Word;
-  I32: LongInt;
-  U32: LongWord;
-  I64: Int64;
-  F32: Single;
-  F64: Double;
 begin
   if not HasValidElementIndex(AIndex) then
     Exit(0);
 
   SyncBufferData;
   Offset := FByteOffset + AIndex * BytesPerElement(FKind);
-  case FKind of
-    takInt8:
-    begin
-      I8 := ShortInt(FBufferData[Offset]);
-      Result := I8;
-    end;
-    takUint8, takUint8Clamped:
-    begin
-      U8 := FBufferData[Offset];
-      Result := U8;
-    end;
-    takInt16:
-    begin
-      Move(FBufferData[Offset], I16, 2);
-      Result := I16;
-    end;
-    takUint16:
-    begin
-      Move(FBufferData[Offset], U16, 2);
-      Result := U16;
-    end;
-    takInt32:
-    begin
-      Move(FBufferData[Offset], I32, 4);
-      I64 := I32;
-      Result := I64;
-    end;
-    takUint32:
-    begin
-      Move(FBufferData[Offset], U32, 4);
-      I64 := U32;
-      Result := I64;
-    end;
-    takFloat16:
-    begin
-      Move(FBufferData[Offset], U16, 2);
-      Result := Float16ToDouble(U16);
-    end;
-    takFloat32:
-    begin
-      Move(FBufferData[Offset], F32, 4);
-      Result := F32;
-    end;
-    takFloat64:
-    begin
-      Move(FBufferData[Offset], F64, 8);
-      Result := F64;
-    end;
-  else
-    Result := 0;
-  end;
+  Result := ReadBinaryNumberElement(FBufferData, Offset,
+    ToBinaryElementKind(FKind), TYPED_ARRAY_LITTLE_ENDIAN);
 end;
 
 procedure TGocciaTypedArrayValue.WriteElement(const AIndex: Integer; const AValue: Double);
 var
   Offset: Integer;
-  I8: ShortInt;
-  U8: Byte;
-  I16: SmallInt;
-  U16: Word;
-  I32: LongInt;
-  U32: LongWord;
-  F32: Single;
-  F64: Double;
-  Clamped: Integer;
 begin
   if not HasValidElementIndex(AIndex) then
     Exit;
 
   SyncBufferData;
   Offset := FByteOffset + AIndex * BytesPerElement(FKind);
-  case FKind of
-    takInt8:
-    begin
-      I8 := ShortInt(Trunc(AValue));
-      FBufferData[Offset] := Byte(I8);
-    end;
-    takUint8:
-    begin
-      U8 := Byte(Trunc(AValue));
-      FBufferData[Offset] := U8;
-    end;
-    takUint8Clamped:
-    begin
-      if IsNan(AValue) then
-        Clamped := 0
-      else if AValue <= 0 then
-        Clamped := 0
-      else if AValue >= 255 then
-        Clamped := 255
-      else
-        Clamped := Round(AValue);
-      FBufferData[Offset] := Byte(Clamped);
-    end;
-    takInt16:
-    begin
-      I16 := SmallInt(Trunc(AValue));
-      Move(I16, FBufferData[Offset], 2);
-    end;
-    takUint16:
-    begin
-      U16 := Word(Trunc(AValue));
-      Move(U16, FBufferData[Offset], 2);
-    end;
-    takInt32:
-    begin
-      I32 := LongInt(Trunc(AValue));
-      Move(I32, FBufferData[Offset], 4);
-    end;
-    takUint32:
-    begin
-      U32 := LongWord(Trunc(AValue));
-      Move(U32, FBufferData[Offset], 4);
-    end;
-    takFloat16:
-    begin
-      U16 := DoubleToFloat16(AValue);
-      Move(U16, FBufferData[Offset], 2);
-    end;
-    takFloat32:
-    begin
-      F32 := AValue;
-      Move(F32, FBufferData[Offset], 4);
-    end;
-    takFloat64:
-    begin
-      F64 := AValue;
-      Move(F64, FBufferData[Offset], 8);
-    end;
-  end;
-end;
-
-procedure WriteFloatDirect(var AData: TBytes;
-  const AOffset: Integer; const AKind: TGocciaTypedArrayKind;
-  const AValue: Double);
-var
-  F16: Word;
-  F32: Single;
-begin
-  case AKind of
-    takFloat16:
-    begin
-      F16 := DoubleToFloat16(AValue);
-      Move(F16, AData[AOffset], 2);
-    end;
-    takFloat32:
-    begin
-      F32 := AValue;
-      Move(F32, AData[AOffset], 4);
-    end;
-    takFloat64:
-      Move(AValue, AData[AOffset], 8);
-  end;
+  WriteBinaryNumberElement(FBufferData, Offset, ToBinaryElementKind(FKind),
+    AValue, TYPED_ARRAY_LITTLE_ENDIAN);
 end;
 
 procedure TGocciaTypedArrayValue.WriteNumberLiteral(const AIndex: Integer; const ANum: TGocciaNumberLiteralValue);
@@ -470,7 +351,8 @@ begin
     if IsFloatKind(FKind) then
     begin
       Offset := FByteOffset + AIndex * BytesPerElement(FKind);
-      WriteFloatDirect(FBufferData, Offset, FKind, ANum.Value);
+      WriteBinaryNumberElement(FBufferData, Offset, ToBinaryElementKind(FKind),
+        ANum.Value, TYPED_ARRAY_LITTLE_ENDIAN);
     end
     else
       WriteElement(AIndex, 0);
@@ -482,7 +364,8 @@ begin
       takFloat16, takFloat32, takFloat64:
       begin
         Offset := FByteOffset + AIndex * BytesPerElement(FKind);
-        WriteFloatDirect(FBufferData, Offset, FKind, ANum.Value);
+        WriteBinaryNumberElement(FBufferData, Offset, ToBinaryElementKind(FKind),
+          ANum.Value, TYPED_ARRAY_LITTLE_ENDIAN);
       end;
     else
       WriteElement(AIndex, 0);
@@ -494,7 +377,8 @@ begin
       takFloat16, takFloat32, takFloat64:
       begin
         Offset := FByteOffset + AIndex * BytesPerElement(FKind);
-        WriteFloatDirect(FBufferData, Offset, FKind, ANum.Value);
+        WriteBinaryNumberElement(FBufferData, Offset, ToBinaryElementKind(FKind),
+          ANum.Value, TYPED_ARRAY_LITTLE_ENDIAN);
       end;
     else
       WriteElement(AIndex, 0);
@@ -507,28 +391,14 @@ end;
 function TGocciaTypedArrayValue.ReadBigIntElement(const AIndex: Integer): Int64;
 var
   Offset: Integer;
-  I64: Int64;
-  U64: QWord;
 begin
   if not HasValidElementIndex(AIndex) then
     Exit(0);
 
   SyncBufferData;
   Offset := FByteOffset + AIndex * 8;
-  case FKind of
-    takBigInt64:
-    begin
-      Move(FBufferData[Offset], I64, 8);
-      Result := I64;
-    end;
-    takBigUint64:
-    begin
-      Move(FBufferData[Offset], U64, 8);
-      Result := Int64(U64);
-    end;
-  else
-    Result := 0;
-  end;
+  Result := ReadBinaryBigIntElement(FBufferData, Offset,
+    ToBinaryElementKind(FKind), TYPED_ARRAY_LITTLE_ENDIAN);
 end;
 
 procedure TGocciaTypedArrayValue.WriteBigIntElement(const AIndex: Integer; const AValue: Int64);
@@ -540,7 +410,8 @@ begin
 
   SyncBufferData;
   Offset := FByteOffset + AIndex * 8;
-  Move(AValue, FBufferData[Offset], 8);
+  WriteBinaryBigIntElement(FBufferData, Offset, AValue,
+    TYPED_ARRAY_LITTLE_ENDIAN);
 end;
 
 function BigIntFromQWord(const AValue: QWord): TBigInteger;

--- a/tests/built-ins/ArrayBuffer/isView.js
+++ b/tests/built-ins/ArrayBuffer/isView.js
@@ -11,6 +11,10 @@ describe("ArrayBuffer.isView", () => {
     expect(ArrayBuffer.isView(new Float64Array(1))).toBe(true);
   });
 
+  test("returns true for DataView", () => {
+    expect(ArrayBuffer.isView(new DataView(new ArrayBuffer(1)))).toBe(true);
+  });
+
   test("returns false for ArrayBuffer", () => {
     const buf = new ArrayBuffer(8);
     expect(ArrayBuffer.isView(buf)).toBe(false);

--- a/tests/built-ins/DataView/constructor.js
+++ b/tests/built-ins/DataView/constructor.js
@@ -1,0 +1,73 @@
+/*---
+description: DataView constructor
+features: [DataView, ArrayBuffer, SharedArrayBuffer]
+---*/
+
+describe("DataView constructor", () => {
+  test("creates a view over an ArrayBuffer", () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+    expect(view.buffer).toBe(buffer);
+    expect(view.byteOffset).toBe(0);
+    expect(view.byteLength).toBe(8);
+    expect(view instanceof DataView).toBe(true);
+  });
+
+  test("creates a view with byteOffset and byteLength", () => {
+    const buffer = new ArrayBuffer(16);
+    const view = new DataView(buffer, 4, 8);
+    expect(view.buffer).toBe(buffer);
+    expect(view.byteOffset).toBe(4);
+    expect(view.byteLength).toBe(8);
+  });
+
+  test("supports SharedArrayBuffer backing storage", () => {
+    const buffer = new SharedArrayBuffer(8);
+    const view = new DataView(buffer, 2, 4);
+    expect(view.buffer).toBe(buffer);
+    expect(view.byteOffset).toBe(2);
+    expect(view.byteLength).toBe(4);
+  });
+
+  test("auto-length view over resizable ArrayBuffer tracks resize", () => {
+    const buffer = new ArrayBuffer(4, { maxByteLength: 16 });
+    const view = new DataView(buffer, 1);
+    expect(view.byteLength).toBe(3);
+    buffer.resize(8);
+    expect(view.byteLength).toBe(7);
+  });
+
+  test("fixed-length view over resizable ArrayBuffer keeps byteLength", () => {
+    const buffer = new ArrayBuffer(4, { maxByteLength: 16 });
+    const view = new DataView(buffer, 1, 2);
+    buffer.resize(8);
+    expect(view.byteLength).toBe(2);
+  });
+});
+
+describe("DataView constructor error cases", () => {
+  test("requires new", () => {
+    expect(() => DataView(new ArrayBuffer(1))).toThrow(TypeError);
+  });
+
+  test("requires ArrayBuffer-compatible backing storage", () => {
+    expect(() => new DataView({})).toThrow(TypeError);
+    expect(() => new DataView()).toThrow(TypeError);
+  });
+
+  test("throws RangeError when offset is outside the buffer", () => {
+    const buffer = new ArrayBuffer(4);
+    expect(() => new DataView(buffer, 5)).toThrow(RangeError);
+  });
+
+  test("throws RangeError when byteLength extends past the buffer", () => {
+    const buffer = new ArrayBuffer(4);
+    expect(() => new DataView(buffer, 2, 3)).toThrow(RangeError);
+  });
+
+  test("throws TypeError when constructed over a detached ArrayBuffer", () => {
+    const buffer = new ArrayBuffer(4);
+    buffer.transfer();
+    expect(() => new DataView(buffer)).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/DataView/prototype/buffer.js
+++ b/tests/built-ins/DataView/prototype/buffer.js
@@ -10,6 +10,12 @@ describe("get DataView.prototype.buffer", () => {
     expect(view.buffer).toBe(buffer);
   });
 
+  test("returns the viewed SharedArrayBuffer", () => {
+    const buffer = new SharedArrayBuffer(8);
+    const view = new DataView(buffer, 2, 4);
+    expect(view.buffer).toBe(buffer);
+  });
+
   test("returns a detached viewed buffer", () => {
     const buffer = new ArrayBuffer(8);
     const view = new DataView(buffer);

--- a/tests/built-ins/DataView/prototype/buffer.js
+++ b/tests/built-ins/DataView/prototype/buffer.js
@@ -1,0 +1,24 @@
+/*---
+description: DataView.prototype.buffer
+features: [DataView]
+---*/
+
+describe("get DataView.prototype.buffer", () => {
+  test("returns the viewed buffer", () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer, 2, 4);
+    expect(view.buffer).toBe(buffer);
+  });
+
+  test("returns a detached viewed buffer", () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+    buffer.transfer();
+    expect(view.buffer).toBe(buffer);
+  });
+
+  test("throws TypeError when called on non-DataView", () => {
+    const getter = Object.getOwnPropertyDescriptor(DataView.prototype, "buffer").get;
+    expect(() => getter.call({})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/DataView/prototype/buffer.js
+++ b/tests/built-ins/DataView/prototype/buffer.js
@@ -17,8 +17,21 @@ describe("get DataView.prototype.buffer", () => {
     expect(view.buffer).toBe(buffer);
   });
 
+  test("can be shadowed by an own property", () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+    Object.defineProperty(view, "buffer", { value: "shadow" });
+    expect(view.buffer).toBe("shadow");
+  });
+
   test("throws TypeError when called on non-DataView", () => {
     const getter = Object.getOwnPropertyDescriptor(DataView.prototype, "buffer").get;
     expect(() => getter.call({})).toThrow(TypeError);
+  });
+
+  test("throws TypeError when inherited from a DataView", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    const child = Object.create(view);
+    expect(() => child.buffer).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/DataView/prototype/byteLength.js
+++ b/tests/built-ins/DataView/prototype/byteLength.js
@@ -1,0 +1,32 @@
+/*---
+description: DataView.prototype.byteLength
+features: [DataView]
+---*/
+
+describe("get DataView.prototype.byteLength", () => {
+  test("returns fixed view byte length", () => {
+    const view = new DataView(new ArrayBuffer(8), 2, 4);
+    expect(view.byteLength).toBe(4);
+  });
+
+  test("auto-length view updates after resize", () => {
+    const buffer = new ArrayBuffer(4, { maxByteLength: 16 });
+    const view = new DataView(buffer, 1);
+    buffer.resize(10);
+    expect(view.byteLength).toBe(9);
+  });
+
+  test("throws TypeError for detached buffer", () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+    buffer.transfer();
+    expect(() => view.byteLength).toThrow(TypeError);
+  });
+
+  test("throws TypeError for out-of-bounds fixed view after resize", () => {
+    const buffer = new ArrayBuffer(8, { maxByteLength: 16 });
+    const view = new DataView(buffer, 4, 4);
+    buffer.resize(6);
+    expect(() => view.byteLength).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/DataView/prototype/byteLength.js
+++ b/tests/built-ins/DataView/prototype/byteLength.js
@@ -16,6 +16,12 @@ describe("get DataView.prototype.byteLength", () => {
     expect(view.byteLength).toBe(9);
   });
 
+  test("can be shadowed by an own property", () => {
+    const view = new DataView(new ArrayBuffer(8), 2, 4);
+    Object.defineProperty(view, "byteLength", { value: 99 });
+    expect(view.byteLength).toBe(99);
+  });
+
   test("throws TypeError for detached buffer", () => {
     const buffer = new ArrayBuffer(8);
     const view = new DataView(buffer);
@@ -28,5 +34,11 @@ describe("get DataView.prototype.byteLength", () => {
     const view = new DataView(buffer, 4, 4);
     buffer.resize(6);
     expect(() => view.byteLength).toThrow(TypeError);
+  });
+
+  test("throws TypeError when inherited from a DataView", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    const child = Object.create(view);
+    expect(() => child.byteLength).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/DataView/prototype/byteOffset.js
+++ b/tests/built-ins/DataView/prototype/byteOffset.js
@@ -1,0 +1,18 @@
+/*---
+description: DataView.prototype.byteOffset
+features: [DataView]
+---*/
+
+describe("get DataView.prototype.byteOffset", () => {
+  test("returns view byte offset", () => {
+    const view = new DataView(new ArrayBuffer(8), 3, 4);
+    expect(view.byteOffset).toBe(3);
+  });
+
+  test("throws TypeError for detached buffer", () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer, 1);
+    buffer.transfer();
+    expect(() => view.byteOffset).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/DataView/prototype/byteOffset.js
+++ b/tests/built-ins/DataView/prototype/byteOffset.js
@@ -9,10 +9,22 @@ describe("get DataView.prototype.byteOffset", () => {
     expect(view.byteOffset).toBe(3);
   });
 
+  test("can be shadowed by an own property", () => {
+    const view = new DataView(new ArrayBuffer(8), 3, 4);
+    Object.defineProperty(view, "byteOffset", { value: 88 });
+    expect(view.byteOffset).toBe(88);
+  });
+
   test("throws TypeError for detached buffer", () => {
     const buffer = new ArrayBuffer(8);
     const view = new DataView(buffer, 1);
     buffer.transfer();
     expect(() => view.byteOffset).toThrow(TypeError);
+  });
+
+  test("throws TypeError when inherited from a DataView", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    const child = Object.create(view);
+    expect(() => child.byteOffset).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/DataView/prototype/getBigInt64.js
+++ b/tests/built-ins/DataView/prototype/getBigInt64.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.getBigInt64
+features: [DataView, BigInt]
+---*/
+
+describe("DataView.prototype.getBigInt64", () => {
+  test("reads signed BigInt values", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    view.setBigInt64(0, -1n);
+    expect(view.getBigInt64(0)).toBe(-1n);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getBigUint64.js
+++ b/tests/built-ins/DataView/prototype/getBigUint64.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.getBigUint64
+features: [DataView, BigInt]
+---*/
+
+describe("DataView.prototype.getBigUint64", () => {
+  test("reads unsigned BigInt values", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    view.setBigUint64(0, 18446744073709551615n);
+    expect(view.getBigUint64(0)).toBe(18446744073709551615n);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getFloat16.js
+++ b/tests/built-ins/DataView/prototype/getFloat16.js
@@ -1,0 +1,18 @@
+/*---
+description: DataView.prototype.getFloat16
+features: [DataView, Float16Array]
+---*/
+
+describe("DataView.prototype.getFloat16", () => {
+  test("reads IEEE 754 half precision values", () => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setFloat16(0, 1.5);
+    expect(view.getFloat16(0)).toBe(1.5);
+  });
+
+  test("preserves negative zero", () => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setFloat16(0, -0);
+    expect(Object.is(view.getFloat16(0), -0)).toBe(true);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getFloat32.js
+++ b/tests/built-ins/DataView/prototype/getFloat32.js
@@ -1,0 +1,18 @@
+/*---
+description: DataView.prototype.getFloat32
+features: [DataView]
+---*/
+
+describe("DataView.prototype.getFloat32", () => {
+  test("reads IEEE 754 single precision values", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setFloat32(0, 1.5);
+    expect(view.getFloat32(0)).toBe(1.5);
+  });
+
+  test("stores NaN", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setFloat32(0, NaN);
+    expect(Number.isNaN(view.getFloat32(0))).toBe(true);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getFloat64.js
+++ b/tests/built-ins/DataView/prototype/getFloat64.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.getFloat64
+features: [DataView]
+---*/
+
+describe("DataView.prototype.getFloat64", () => {
+  test("reads IEEE 754 double precision values", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    view.setFloat64(0, Math.PI);
+    expect(view.getFloat64(0)).toBe(Math.PI);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getInt16.js
+++ b/tests/built-ins/DataView/prototype/getInt16.js
@@ -1,0 +1,13 @@
+/*---
+description: DataView.prototype.getInt16
+features: [DataView]
+---*/
+
+describe("DataView.prototype.getInt16", () => {
+  test("reads signed 16-bit values", () => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setUint8(0, 0xff);
+    view.setUint8(1, 0xff);
+    expect(view.getInt16(0)).toBe(-1);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getInt32.js
+++ b/tests/built-ins/DataView/prototype/getInt32.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.getInt32
+features: [DataView]
+---*/
+
+describe("DataView.prototype.getInt32", () => {
+  test("reads signed 32-bit values", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setUint32(0, 0xffffffff);
+    expect(view.getInt32(0)).toBe(-1);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getInt8.js
+++ b/tests/built-ins/DataView/prototype/getInt8.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.getInt8
+features: [DataView]
+---*/
+
+describe("DataView.prototype.getInt8", () => {
+  test("reads one signed byte", () => {
+    const view = new DataView(new ArrayBuffer(1));
+    view.setUint8(0, 255);
+    expect(view.getInt8(0)).toBe(-1);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getUint16.js
+++ b/tests/built-ins/DataView/prototype/getUint16.js
@@ -1,0 +1,14 @@
+/*---
+description: DataView.prototype.getUint16
+features: [DataView]
+---*/
+
+describe("DataView.prototype.getUint16", () => {
+  test("reads big-endian by default and little-endian when requested", () => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setUint8(0, 0x12);
+    view.setUint8(1, 0x34);
+    expect(view.getUint16(0)).toBe(0x1234);
+    expect(view.getUint16(0, true)).toBe(0x3412);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getUint32.js
+++ b/tests/built-ins/DataView/prototype/getUint32.js
@@ -1,0 +1,16 @@
+/*---
+description: DataView.prototype.getUint32
+features: [DataView]
+---*/
+
+describe("DataView.prototype.getUint32", () => {
+  test("reads big-endian by default and little-endian when requested", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setUint8(0, 0x12);
+    view.setUint8(1, 0x34);
+    view.setUint8(2, 0x56);
+    view.setUint8(3, 0x78);
+    expect(view.getUint32(0)).toBe(0x12345678);
+    expect(view.getUint32(0, true)).toBe(0x78563412);
+  });
+});

--- a/tests/built-ins/DataView/prototype/getUint8.js
+++ b/tests/built-ins/DataView/prototype/getUint8.js
@@ -1,0 +1,19 @@
+/*---
+description: DataView.prototype.getUint8
+features: [DataView]
+---*/
+
+describe("DataView.prototype.getUint8", () => {
+  test("reads one unsigned byte", () => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setUint8(0, 255);
+    view.setUint8(1, 1);
+    expect(view.getUint8(0)).toBe(255);
+    expect(view.getUint8(1)).toBe(1);
+  });
+
+  test("throws RangeError when read extends past view", () => {
+    const view = new DataView(new ArrayBuffer(1));
+    expect(() => view.getUint8(1)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setBigInt64.js
+++ b/tests/built-ins/DataView/prototype/setBigInt64.js
@@ -1,0 +1,17 @@
+/*---
+description: DataView.prototype.setBigInt64
+features: [DataView, BigInt]
+---*/
+
+describe("DataView.prototype.setBigInt64", () => {
+  test("writes signed BigInt values", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    view.setBigInt64(0, -2n);
+    expect(view.getBigInt64(0)).toBe(-2n);
+  });
+
+  test("converts value before range validation", () => {
+    const view = new DataView(new ArrayBuffer(1));
+    expect(() => view.setBigInt64(1, 1)).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setBigUint64.js
+++ b/tests/built-ins/DataView/prototype/setBigUint64.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.setBigUint64
+features: [DataView, BigInt]
+---*/
+
+describe("DataView.prototype.setBigUint64", () => {
+  test("writes unsigned BigInt values", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    view.setBigUint64(0, 18446744073709551615n);
+    expect(view.getBigUint64(0)).toBe(18446744073709551615n);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setFloat16.js
+++ b/tests/built-ins/DataView/prototype/setFloat16.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.setFloat16
+features: [DataView, Float16Array]
+---*/
+
+describe("DataView.prototype.setFloat16", () => {
+  test("writes half precision values", () => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setFloat16(0, 65520);
+    expect(view.getFloat16(0)).toBe(Infinity);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setFloat32.js
+++ b/tests/built-ins/DataView/prototype/setFloat32.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.setFloat32
+features: [DataView]
+---*/
+
+describe("DataView.prototype.setFloat32", () => {
+  test("writes single precision values", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setFloat32(0, -0);
+    expect(Object.is(view.getFloat32(0), -0)).toBe(true);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setFloat64.js
+++ b/tests/built-ins/DataView/prototype/setFloat64.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.setFloat64
+features: [DataView]
+---*/
+
+describe("DataView.prototype.setFloat64", () => {
+  test("writes double precision values", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    view.setFloat64(0, -Infinity);
+    expect(view.getFloat64(0)).toBe(-Infinity);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setInt16.js
+++ b/tests/built-ins/DataView/prototype/setInt16.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.setInt16
+features: [DataView]
+---*/
+
+describe("DataView.prototype.setInt16", () => {
+  test("writes signed 16-bit values", () => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setInt16(0, -1);
+    expect(view.getUint16(0)).toBe(0xffff);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setInt32.js
+++ b/tests/built-ins/DataView/prototype/setInt32.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.setInt32
+features: [DataView]
+---*/
+
+describe("DataView.prototype.setInt32", () => {
+  test("writes signed 32-bit values", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setInt32(0, -1);
+    expect(view.getUint32(0)).toBe(0xffffffff);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setInt8.js
+++ b/tests/built-ins/DataView/prototype/setInt8.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.setInt8
+features: [DataView]
+---*/
+
+describe("DataView.prototype.setInt8", () => {
+  test("writes one signed byte", () => {
+    const view = new DataView(new ArrayBuffer(1));
+    view.setInt8(0, -1);
+    expect(view.getUint8(0)).toBe(255);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setUint16.js
+++ b/tests/built-ins/DataView/prototype/setUint16.js
@@ -1,0 +1,16 @@
+/*---
+description: DataView.prototype.setUint16
+features: [DataView]
+---*/
+
+describe("DataView.prototype.setUint16", () => {
+  test("writes big-endian by default and little-endian when requested", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setUint16(0, 0x1234);
+    view.setUint16(2, 0x1234, true);
+    expect(view.getUint8(0)).toBe(0x12);
+    expect(view.getUint8(1)).toBe(0x34);
+    expect(view.getUint8(2)).toBe(0x34);
+    expect(view.getUint8(3)).toBe(0x12);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setUint32.js
+++ b/tests/built-ins/DataView/prototype/setUint32.js
@@ -1,0 +1,20 @@
+/*---
+description: DataView.prototype.setUint32
+features: [DataView]
+---*/
+
+describe("DataView.prototype.setUint32", () => {
+  test("writes big-endian by default and little-endian when requested", () => {
+    const view = new DataView(new ArrayBuffer(8));
+    view.setUint32(0, 0x12345678);
+    view.setUint32(4, 0x12345678, true);
+    expect(view.getUint32(0)).toBe(0x12345678);
+    expect(view.getUint32(4, true)).toBe(0x12345678);
+  });
+
+  test("wraps large finite numbers modulo 2^32", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setUint32(0, 1e20);
+    expect(view.getUint32(0)).toBe(1661992960);
+  });
+});

--- a/tests/built-ins/DataView/prototype/setUint8.js
+++ b/tests/built-ins/DataView/prototype/setUint8.js
@@ -1,0 +1,12 @@
+/*---
+description: DataView.prototype.setUint8
+features: [DataView]
+---*/
+
+describe("DataView.prototype.setUint8", () => {
+  test("writes one unsigned byte", () => {
+    const view = new DataView(new ArrayBuffer(1));
+    expect(view.setUint8(0, 511)).toBeUndefined();
+    expect(view.getUint8(0)).toBe(255);
+  });
+});

--- a/tests/built-ins/DataView/toString-tag.js
+++ b/tests/built-ins/DataView/toString-tag.js
@@ -1,0 +1,11 @@
+/*---
+description: DataView @@toStringTag
+features: [DataView]
+---*/
+
+describe("DataView @@toStringTag", () => {
+  test("Object.prototype.toString reports DataView", () => {
+    const view = new DataView(new ArrayBuffer(1));
+    expect(Object.prototype.toString.call(view)).toBe("[object DataView]");
+  });
+});

--- a/tests/built-ins/TypedArray/element-access.js
+++ b/tests/built-ins/TypedArray/element-access.js
@@ -135,6 +135,12 @@ describe("TypedArray element access", () => {
       expect(ta[0]).toBe(0);
       expect(ta[1]).toBe(4294967295);
     });
+
+    test("wraps large finite numbers modulo 2^32", () => {
+      const ta = new Uint32Array(1);
+      ta[0] = 1e20;
+      expect(ta[0]).toBe(1661992960);
+    });
   });
 
   describe("Float32Array precision", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Implement ECMAScript `DataView` over `ArrayBuffer` and `SharedArrayBuffer`, including endian-aware integer, BigInt, Float16, Float32, and Float64 accessors.
- Add shared binary element encoding for DataView and TypedArray so integer wrapping, BigInt storage, and IEEE float serialization stay aligned.
- Cover detached/out-of-bounds buffer semantics, `ArrayBuffer.isView(new DataView(...))`, realm-fresh DataView prototype methods, and update binary-data/value-system docs.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build/GocciaTestRunner tests/built-ins/DataView --no-progress --exit-on-first-failure`
  - `./build/GocciaTestRunner tests/built-ins/DataView --mode=bytecode --no-progress --exit-on-first-failure`
  - `./build/GocciaTestRunner tests/built-ins/TypedArray --no-progress --exit-on-first-failure`
  - `./build/GocciaTestRunner tests/built-ins/TypedArray --mode=bytecode --no-progress --exit-on-first-failure`
  - `./build/GocciaTestRunner tests --no-progress --exit-on-first-failure` passes 10013/10016; the remaining 3 failures are existing local FFI fixture load failures for `./fixtures/ffi/libfixture.dylib`.
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./build/Goccia.Engine.Realm.Test`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change