### PR TITLE
fix(interpreter): root loop scopes during explicit gc

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -537,6 +537,39 @@ console.log("Bare Loader: --mode=interpreted...");
   if (proc.stdout.toString().trim() !== "42") throw new Error(`Bare --mode=interpreted expected 42, got: ${proc.stdout.toString()}`);
 }
 
+console.log("Bare Loader: interpreted for-in scope survives Goccia.gc...");
+{
+  const source = [
+    "function f() {",
+    "  let obj = { p: 1, r: 3, s: 4 };",
+    "  let seen = '';",
+    "  for (let key in obj) {",
+    "    Goccia.gc();",
+    "    seen = seen + key;",
+    "  }",
+    "  return seen;",
+    "}",
+    "print(f());",
+    "",
+  ].join("\n");
+  const proc = Bun.spawnSync([
+    BARE,
+    "--mode=interpreted",
+    "--compat-asi",
+    "--compat-function",
+    "--compat-for-in-loop",
+    "--compat-non-strict-mode",
+  ], {
+    stdin: new TextEncoder().encode(source),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0)
+    throw new Error(`Bare interpreted for-in Goccia.gc exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+  if (proc.stdout.toString().trim() !== "prs")
+    throw new Error(`Bare interpreted for-in Goccia.gc expected prs, got: ${proc.stdout.toString()}`);
+}
+
 console.log("Bare Loader: --mode=bytecode...");
 {
   const proc = Bun.spawnSync([BARE, "--print", "--mode=bytecode"], {

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -500,25 +500,41 @@ begin
     AStatement.HasLabel(AControlFlow.TargetLabel);
 end;
 
-function EvaluateLoopBodyStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+function EvaluateLoopBodyWithActiveScope(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 var
   Continuation: TGocciaGeneratorContinuation;
+  GC: TGarbageCollector;
+  ScopeRooted: Boolean;
 begin
   Continuation := CurrentGeneratorContinuation;
+  GC := TGarbageCollector.Instance;
+  ScopeRooted := Assigned(GC) and Assigned(AContext.Scope);
+  if ScopeRooted then
+    GC.PushActiveRoot(AContext.Scope);
   try
-    Result := EvaluateStatement(AStatement, AContext);
-    if Assigned(Continuation) then
-      Continuation.ClearExpressionValues;
-  except
-    on E: EGocciaGeneratorYield do
-      raise;
-    else
-    begin
+    try
+      Result := EvaluateStatement(AStatement, AContext);
       if Assigned(Continuation) then
         Continuation.ClearExpressionValues;
-      raise;
+    except
+      on E: EGocciaGeneratorYield do
+        raise;
+      else
+      begin
+        if Assigned(Continuation) then
+          Continuation.ClearExpressionValues;
+        raise;
+      end;
     end;
+  finally
+    if ScopeRooted then
+      GC.PopActiveRoot;
   end;
+end;
+
+function EvaluateLoopBodyStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
+begin
+  Result := EvaluateLoopBodyWithActiveScope(AStatement, AContext);
 end;
 
 function EvaluateBinary(const ABinaryExpression: TGocciaBinaryExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;

--- a/tests/language/for-in-loop/gc-active-scope.js
+++ b/tests/language/for-in-loop/gc-active-scope.js
@@ -1,0 +1,34 @@
+/*---
+description: for-in loop bindings survive explicit Goccia.gc calls in the body
+features: [compat-for-in-loop, Goccia.gc]
+---*/
+
+const hasGoccia = typeof Goccia !== "undefined";
+
+describe.runIf(hasGoccia)("for-in explicit GC", () => {
+  test("preserves the current iteration binding across Goccia.gc", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const keys = [];
+
+    for (let key in obj) {
+      Goccia.gc();
+      keys.push(key);
+    }
+
+    expect(keys).toEqual(["a", "b", "c"]);
+  });
+
+  test("handles deletion of unvisited properties after Goccia.gc", () => {
+    const obj = { p: 1, r: 3, s: 4, t: 5 };
+    const keys = [];
+
+    for (let key in obj) {
+      Goccia.gc();
+      keys.push(key);
+      delete obj.t;
+      delete obj.s;
+    }
+
+    expect(keys).toEqual(["p", "r"]);
+  });
+});

--- a/tests/language/for-loop/gc-active-scope.js
+++ b/tests/language/for-loop/gc-active-scope.js
@@ -1,0 +1,19 @@
+/*---
+description: traditional for-loop lexical bindings survive explicit Goccia.gc calls in the body
+features: [compat-traditional-for-loop, Goccia.gc]
+---*/
+
+const hasGoccia = typeof Goccia !== "undefined";
+
+describe.runIf(hasGoccia)("traditional for explicit GC", () => {
+  test("preserves the current lexical iteration binding across Goccia.gc", () => {
+    const values = [];
+
+    for (let i = 0; i < 3; i++) {
+      Goccia.gc();
+      values.push(i);
+    }
+
+    expect(values).toEqual([0, 1, 2]);
+  });
+});

--- a/tests/language/for-of/gc-active-scope.js
+++ b/tests/language/for-of/gc-active-scope.js
@@ -1,0 +1,19 @@
+/*---
+description: for-of loop bindings survive explicit Goccia.gc calls in the body
+features: [for-of, Goccia.gc]
+---*/
+
+const hasGoccia = typeof Goccia !== "undefined";
+
+describe.runIf(hasGoccia)("for-of explicit GC", () => {
+  test("preserves the current iteration binding across Goccia.gc", () => {
+    const values = [];
+
+    for (let value of ["a", "b", "c"]) {
+      Goccia.gc();
+      values.push(value);
+    }
+
+    expect(values).toEqual(["a", "b", "c"]);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Root active interpreter loop body scopes while evaluating loop bodies so explicit `Goccia.gc()` calls cannot collect per-iteration lexical bindings still needed by later body statements.
- Add interpreter and bytecode language regressions for `for-in`, `for-of`, and traditional `for` loops with explicit `Goccia.gc()` in the body.
- Add a Bare Loader interpreted CLI smoke for the minimal `for-in` path that exposed the issue.
- Follow-up to #705 / #552 for interpreter execution mode.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Verification run:

- `./build.pas`
- `./build/GocciaTestRunner tests/language/for-in-loop/gc-active-scope.js tests/language/for-of/gc-active-scope.js tests/language/for-loop/gc-active-scope.js --no-progress --exit-on-first-failure`
- `./build/GocciaTestRunner tests/language/for-in-loop/gc-active-scope.js tests/language/for-of/gc-active-scope.js tests/language/for-loop/gc-active-scope.js --mode=bytecode --no-progress --exit-on-first-failure`
- `bun scripts/test-cli-apps.ts`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/statements/for-in-with-gc-and-unvisited-deletion.js' --mode interpreted --jobs 1 --verbose`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/statements/for-in-with-gc-and-unvisited-deletion.js' --mode bytecode --jobs 1 --verbose`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/regress/regress-596103.js' --mode interpreted --jobs 1 --verbose`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/regress/regress-596103.js' --mode bytecode --jobs 1 --verbose`
- `./fixtures/ffi/build.sh`
- `./build/GocciaTestRunner tests`
- `./format.pas --check`
- `git diff --check`