### PR TITLE
fix(intl): format BigInt locale strings

### DIFF
--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -24,7 +24,11 @@ function TryICUCompareStrings(const ALocale: string; const AStr1, AStr2: Unicode
 
 function TryICUFormatNumber(const ALocale: string; AValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
+function TryICUFormatNumberDecimal(const ALocale, AValue: string;
+  const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
 function TryICUFormatNumberToParts(const ALocale: string; AValue: Double;
+  const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+function TryICUFormatNumberDecimalToParts(const ALocale, AValue: string;
   const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
 function TryICUFormatNumberRange(const ALocale: string; AStartValue, AEndValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
@@ -305,6 +309,8 @@ type
   TUnumfOpenResult = function(var AStatus: TICUErrorCode): Pointer; cdecl;
   TUnumfFormatDouble = procedure(AFormatter: Pointer; AValue: Double;
     AResult: Pointer; var AStatus: TICUErrorCode); cdecl;
+  TUnumfFormatDecimal = procedure(AFormatter: Pointer; const AValue: PAnsiChar;
+    AValueLength: LongInt; AResult: Pointer; var AStatus: TICUErrorCode); cdecl;
   TUnumfResultToString = function(AResult: Pointer; ABuffer: PUChar;
     ABufferCapacity: LongInt; var AStatus: TICUErrorCode): LongInt; cdecl;
   TUnumfResultAsValue = function(AResult: Pointer;
@@ -463,6 +469,7 @@ type
     UnumfOpenForSkeletonAndLocale: TUnumfOpenForSkeletonAndLocale;
     UnumfOpenResult: TUnumfOpenResult;
     UnumfFormatDouble: TUnumfFormatDouble;
+    UnumfFormatDecimal: TUnumfFormatDecimal;
     UnumfResultToString: TUnumfResultToString;
     UnumfResultAsValue: TUnumfResultAsValue;
     UnumfClose: TUnumfClose;
@@ -677,6 +684,8 @@ begin
   if Assigned(S) then F.UnumfOpenResult := TUnumfOpenResult(S);
   S := ResolveSymbol(AHandle, 'unumf_formatDouble');
   if Assigned(S) then F.UnumfFormatDouble := TUnumfFormatDouble(S);
+  S := ResolveSymbol(AHandle, 'unumf_formatDecimal');
+  if Assigned(S) then F.UnumfFormatDecimal := TUnumfFormatDecimal(S);
   S := ResolveSymbol(AHandle, 'unumf_resultToString');
   if Assigned(S) then F.UnumfResultToString := TUnumfResultToString(S);
   S := ResolveSymbol(AHandle, 'unumf_resultAsValue');
@@ -2099,6 +2108,66 @@ begin
   end;
 end;
 
+function TryICUFormatNumberDecimalSkeleton(const ALocale, AValue: string;
+  const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
+var
+  Status: TICUErrorCode;
+  Formatter, FormatResult: Pointer;
+  Skeleton: UnicodeString;
+  LocaleAnsi, ValueAnsi: AnsiString;
+  Buffer: array[0..FORMAT_BUFFER_CAPACITY - 1] of WideChar;
+  ResultLen: LongInt;
+begin
+  Result := False;
+  AFormatted := '';
+
+  if not EnsureLoaded or
+     not Assigned(IntlFunctions.UnumfOpenForSkeletonAndLocale) or
+     not Assigned(IntlFunctions.UnumfOpenResult) or
+     not Assigned(IntlFunctions.UnumfFormatDecimal) or
+     not Assigned(IntlFunctions.UnumfResultToString) or
+     not Assigned(IntlFunctions.UnumfClose) or
+     not Assigned(IntlFunctions.UnumfCloseResult) then
+    Exit;
+
+  Skeleton := UnicodeString(BuildNumberSkeleton(AOptions));
+  LocaleAnsi := AnsiString(ALocale);
+  ValueAnsi := AnsiString(AValue);
+  Status := ICU_SUCCESS;
+  Formatter := IntlFunctions.UnumfOpenForSkeletonAndLocale(PWideChar(Skeleton),
+    Length(Skeleton), PAnsiChar(LocaleAnsi), Status);
+  if not ICUSucceeded(Status) or not Assigned(Formatter) then
+    Exit;
+
+  try
+    Status := ICU_SUCCESS;
+    FormatResult := IntlFunctions.UnumfOpenResult(Status);
+    if not ICUSucceeded(Status) or not Assigned(FormatResult) then
+      Exit;
+    try
+      Status := ICU_SUCCESS;
+      IntlFunctions.UnumfFormatDecimal(Formatter, PAnsiChar(ValueAnsi),
+        Length(ValueAnsi), FormatResult, Status);
+      if not ICUSucceeded(Status) then
+        Exit;
+
+      FillChar(Buffer, SizeOf(Buffer), 0);
+      Status := ICU_SUCCESS;
+      ResultLen := IntlFunctions.UnumfResultToString(FormatResult,
+        @Buffer[0], FORMAT_BUFFER_CAPACITY, Status);
+      if not ICUSucceeded(Status) or (ResultLen <= 0) then
+        Exit;
+
+      AFormatted := UnicodeToString(Buffer, ResultLen);
+      Result := True;
+    finally
+      IntlFunctions.UnumfCloseResult(FormatResult);
+    end;
+  finally
+    IntlFunctions.UnumfClose(Formatter);
+  end;
+end;
+
 function TryICUFormatNumberDirect(const ALocale: string; AValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
 var
@@ -2153,6 +2222,13 @@ begin
     TryICUFormatNumberDirect(ALocale, AValue, AOptions, AFormatted);
 end;
 
+function TryICUFormatNumberDecimal(const ALocale, AValue: string;
+  const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
+begin
+  Result := TryICUFormatNumberDecimalSkeleton(ALocale, AValue, AOptions,
+    AFormatted);
+end;
+
 function TryICUFormatNumberToPartsSkeleton(const ALocale: string; AValue: Double;
   const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
 var
@@ -2190,6 +2266,63 @@ begin
     try
       Status := ICU_SUCCESS;
       IntlFunctions.UnumfFormatDouble(Formatter, AValue, FormatResult, Status);
+      if not ICUSucceeded(Status) then
+        Exit;
+
+      Status := ICU_SUCCESS;
+      FormattedValue := IntlFunctions.UnumfResultAsValue(FormatResult, Status);
+      if not ICUSucceeded(Status) or not Assigned(FormattedValue) then
+        Exit;
+
+      Result := FormattedValueToParts(FormattedValue, UFIELD_CATEGORY_NUMBER,
+        0, NumberFieldToPartType, Formatted, AParts);
+    finally
+      IntlFunctions.UnumfCloseResult(FormatResult);
+    end;
+  finally
+    IntlFunctions.UnumfClose(Formatter);
+  end;
+end;
+
+function TryICUFormatNumberDecimalToPartsSkeleton(const ALocale, AValue: string;
+  const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+var
+  Status: TICUErrorCode;
+  Formatter, FormatResult, FormattedValue: Pointer;
+  Skeleton: UnicodeString;
+  LocaleAnsi, ValueAnsi: AnsiString;
+  Formatted: string;
+begin
+  Result := False;
+  SetLength(AParts, 0);
+
+  if not EnsureLoaded or
+     not Assigned(IntlFunctions.UnumfOpenForSkeletonAndLocale) or
+     not Assigned(IntlFunctions.UnumfOpenResult) or
+     not Assigned(IntlFunctions.UnumfFormatDecimal) or
+     not Assigned(IntlFunctions.UnumfResultAsValue) or
+     not Assigned(IntlFunctions.UnumfClose) or
+     not Assigned(IntlFunctions.UnumfCloseResult) then
+    Exit;
+
+  Skeleton := UnicodeString(BuildNumberSkeleton(AOptions));
+  LocaleAnsi := AnsiString(ALocale);
+  ValueAnsi := AnsiString(AValue);
+  Status := ICU_SUCCESS;
+  Formatter := IntlFunctions.UnumfOpenForSkeletonAndLocale(PWideChar(Skeleton),
+    Length(Skeleton), PAnsiChar(LocaleAnsi), Status);
+  if not ICUSucceeded(Status) or not Assigned(Formatter) then
+    Exit;
+
+  try
+    Status := ICU_SUCCESS;
+    FormatResult := IntlFunctions.UnumfOpenResult(Status);
+    if not ICUSucceeded(Status) or not Assigned(FormatResult) then
+      Exit;
+    try
+      Status := ICU_SUCCESS;
+      IntlFunctions.UnumfFormatDecimal(Formatter, PAnsiChar(ValueAnsi),
+        Length(ValueAnsi), FormatResult, Status);
       if not ICUSucceeded(Status) then
         Exit;
 
@@ -2276,6 +2409,13 @@ begin
     Exit(True);
   Result := CanUseLegacyNumberFormatter(AOptions) and
     TryICUFormatNumberToPartsDirect(ALocale, AValue, AOptions, AParts);
+end;
+
+function TryICUFormatNumberDecimalToParts(const ALocale, AValue: string;
+  const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+begin
+  Result := TryICUFormatNumberDecimalToPartsSkeleton(ALocale, AValue, AOptions,
+    AParts);
 end;
 
 function TryICUFormatNumberRangeInternal(const ALocale: string;

--- a/source/units/Goccia.Builtins.Intl.pas
+++ b/source/units/Goccia.Builtins.Intl.pas
@@ -798,16 +798,17 @@ end;
 function TGocciaIntlBuiltin.NumberFormatConstructorFn(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Locale: string;
-  Options: TGocciaObjectValue;
+  LocalesArg, OptionsArg: TGocciaValue;
 begin
-  Locale := '';
   if AArgs.Length >= 1 then
-    Locale := AArgs.GetElement(0).ToStringLiteral.Value;
-  Options := nil;
-  if (AArgs.Length >= 2) and (AArgs.GetElement(1) is TGocciaObjectValue) then
-    Options := TGocciaObjectValue(AArgs.GetElement(1));
-  Result := TGocciaIntlNumberFormatValue.Create(Locale, Options);
+    LocalesArg := AArgs.GetElement(0)
+  else
+    LocalesArg := nil;
+  if AArgs.Length >= 2 then
+    OptionsArg := AArgs.GetElement(1)
+  else
+    OptionsArg := nil;
+  Result := TGocciaIntlNumberFormatValue.CreateFromArguments(LocalesArg, OptionsArg);
 end;
 
 procedure TGocciaIntlBuiltin.RegisterNumberFormat;

--- a/source/units/Goccia.Values.BigIntObjectValue.pas
+++ b/source/units/Goccia.Values.BigIntObjectValue.pas
@@ -68,8 +68,11 @@ var
 begin
   inherited Create(AClass);
   FPrimitive := APrimitive;
-  InitializePrototype;
-  SharedPrototype := GetSharedBigIntPrototype;
+  if APrimitive is TGocciaBigIntValue then
+    TGocciaBigIntValue(APrimitive).InitializePrototype
+  else
+    TGocciaBigIntValue.BigIntZero.InitializePrototype;
+  SharedPrototype := TGocciaObjectValue(TGocciaBigIntValue.SharedPrototype);
   if not Assigned(AClass) and Assigned(SharedPrototype) then
     FPrototype := SharedPrototype;
 end;
@@ -117,15 +120,16 @@ begin
   if not (Result is TGocciaUndefinedLiteralValue) then
     Exit;
 
-  if Assigned(GetSharedBigIntPrototype) then
-    Result := GetSharedBigIntPrototype.GetPropertyWithContext(AName, AThisContext);
+  if Assigned(TGocciaBigIntValue.SharedPrototype) then
+    Result := TGocciaObjectValue(TGocciaBigIntValue.SharedPrototype)
+      .GetPropertyWithContext(AName, AThisContext);
 end;
 
 class function TGocciaBigIntObjectValue.GetSharedPrototype: TGocciaObjectValue;
 begin
-  if not Assigned(GetSharedBigIntPrototype) then
-    TGocciaBigIntObjectValue.Create(TGocciaBigIntValue.BigIntZero);
-  Result := GetSharedBigIntPrototype;
+  if not Assigned(TGocciaBigIntValue.SharedPrototype) then
+    TGocciaBigIntValue.BigIntZero.InitializePrototype;
+  Result := TGocciaObjectValue(TGocciaBigIntValue.SharedPrototype);
 end;
 
 function TGocciaBigIntObjectValue.BigIntObjectValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -180,10 +184,9 @@ begin
 end;
 
 initialization
-  // Registered separately from the JS-visible BigInt.prototype (which lives on
-  // the primitive class TGocciaBigIntValue).  The wrapper prototype here is
-  // used by the rare Object(1n) wrapping path; keeping its slot name distinct
-  // makes diagnostic output unambiguous.
+  // Registered separately from the JS-visible BigInt.prototype for legacy
+  // wrapper diagnostics.  Object(1n) itself uses TGocciaBigIntValue's shared
+  // BigInt.prototype slot.
   GBigIntPrototypeSlot := RegisterRealmSlot('BigInt.wrapperPrototype');
 
 end.

--- a/source/units/Goccia.Values.BigIntValue.pas
+++ b/source/units/Goccia.Values.BigIntValue.pas
@@ -64,7 +64,9 @@ uses
   Goccia.ObjectModel,
   Goccia.Realm,
   Goccia.Threading,
+  Goccia.Values.BigIntObjectValue,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.IntlNumberFormat,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue;
 
@@ -125,6 +127,21 @@ begin
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GBigIntPrimitivePrototypeSlot))
   else
     Result := nil;
+end;
+
+function ThisBigIntValue(const AThisValue: TGocciaValue;
+  const AMethodName: string): TGocciaBigIntValue;
+begin
+  if AThisValue is TGocciaBigIntValue then
+    Exit(TGocciaBigIntValue(AThisValue));
+
+  if (AThisValue is TGocciaBigIntObjectValue) and
+     (TGocciaBigIntObjectValue(AThisValue).Primitive is TGocciaBigIntValue) then
+    Exit(TGocciaBigIntValue(TGocciaBigIntObjectValue(AThisValue).Primitive));
+
+  ThrowTypeError(Format(SErrorBigIntRequiresBigIntValue, [AMethodName]),
+    SSuggestBigIntRequiresBigIntValue);
+  Result := nil;
 end;
 
 { TGocciaBigIntValue }
@@ -258,12 +275,11 @@ end;
 function TGocciaBigIntValue.BigIntToString(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
+  BigIntValue: TGocciaBigIntValue;
   Radix: Integer;
   RadixValue: TGocciaValue;
 begin
-  if not (AThisValue is TGocciaBigIntValue) then
-    ThrowTypeError(Format(SErrorBigIntRequiresBigIntValue, ['BigInt.prototype.toString']),
-      SSuggestBigIntRequiresBigIntValue);
+  BigIntValue := ThisBigIntValue(AThisValue, 'BigInt.prototype.toString');
 
   Radix := 10;
   if AArgs.Length > 0 then
@@ -278,28 +294,43 @@ begin
   end;
 
   Result := TGocciaStringLiteralValue.Create(
-    TGocciaBigIntValue(AThisValue).FValue.ToRadixString(Radix));
+    BigIntValue.FValue.ToRadixString(Radix));
 end;
 
 // ES2026 §21.2.3.4 BigInt.prototype.valueOf()
 function TGocciaBigIntValue.BigIntValueOf(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  if not (AThisValue is TGocciaBigIntValue) then
-    ThrowTypeError(Format(SErrorBigIntRequiresBigIntValue, ['BigInt.prototype.valueOf']),
-      SSuggestBigIntRequiresBigIntValue);
-  Result := AThisValue;
+  Result := ThisBigIntValue(AThisValue, 'BigInt.prototype.valueOf');
 end;
 
 // ES2026 §21.2.3.2 BigInt.prototype.toLocaleString()
 function TGocciaBigIntValue.BigIntToLocaleString(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
+var
+  BigIntValue: TGocciaBigIntValue;
+  Locale: string;
+  Options: TGocciaObjectValue;
+  FormatArgs: TGocciaArgumentsCollection;
+  NumberFormat: TGocciaIntlNumberFormatValue;
 begin
-  if not (AThisValue is TGocciaBigIntValue) then
-    ThrowTypeError(Format(SErrorBigIntRequiresBigIntValue, ['BigInt.prototype.toLocaleString']),
-      SSuggestBigIntRequiresBigIntValue);
-  Result := TGocciaStringLiteralValue.Create(
-    TGocciaBigIntValue(AThisValue).FValue.ToString);
+  BigIntValue := ThisBigIntValue(AThisValue, 'BigInt.prototype.toLocaleString');
+  Locale := '';
+  if (AArgs.Length > 0) and
+     not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
+    Locale := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  Options := nil;
+  if (AArgs.Length > 1) and (AArgs.GetElement(1) is TGocciaObjectValue) then
+    Options := TGocciaObjectValue(AArgs.GetElement(1));
+
+  NumberFormat := TGocciaIntlNumberFormatValue.Create(Locale, Options);
+  FormatArgs := TGocciaArgumentsCollection.Create([BigIntValue]);
+  try
+    Result := NumberFormat.IntlNumberFormatFormat(FormatArgs, NumberFormat);
+  finally
+    FormatArgs.Free;
+  end;
 end;
 
 initialization

--- a/source/units/Goccia.Values.BigIntValue.pas
+++ b/source/units/Goccia.Values.BigIntValue.pas
@@ -309,22 +309,22 @@ function TGocciaBigIntValue.BigIntToLocaleString(const AArgs: TGocciaArgumentsCo
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   BigIntValue: TGocciaBigIntValue;
-  Locale: string;
-  Options: TGocciaObjectValue;
+  LocalesArg: TGocciaValue;
+  OptionsArg: TGocciaValue;
   FormatArgs: TGocciaArgumentsCollection;
   NumberFormat: TGocciaIntlNumberFormatValue;
 begin
   BigIntValue := ThisBigIntValue(AThisValue, 'BigInt.prototype.toLocaleString');
-  Locale := '';
-  if (AArgs.Length > 0) and
-     not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
-    Locale := AArgs.GetElement(0).ToStringLiteral.Value;
+  if AArgs.Length > 0 then
+    LocalesArg := AArgs.GetElement(0)
+  else
+    LocalesArg := nil;
+  if AArgs.Length > 1 then
+    OptionsArg := AArgs.GetElement(1)
+  else
+    OptionsArg := nil;
 
-  Options := nil;
-  if (AArgs.Length > 1) and (AArgs.GetElement(1) is TGocciaObjectValue) then
-    Options := TGocciaObjectValue(AArgs.GetElement(1));
-
-  NumberFormat := TGocciaIntlNumberFormatValue.Create(Locale, Options);
+  NumberFormat := TGocciaIntlNumberFormatValue.CreateFromArguments(LocalesArg, OptionsArg);
   FormatArgs := TGocciaArgumentsCollection.Create([BigIntValue]);
   try
     Result := NumberFormat.IntlNumberFormatFormat(FormatArgs, NumberFormat);

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -44,6 +44,7 @@ type
     procedure ReadOptions(const AOptions: TGocciaObjectValue);
   public
     constructor Create(const ALocale: string; const AOptions: TGocciaObjectValue = nil);
+    class function CreateFromArguments(const ALocales, AOptions: TGocciaValue): TGocciaIntlNumberFormatValue; static;
 
     function ToStringTag: string; override;
     procedure MarkReferences; override;
@@ -739,6 +740,71 @@ begin
     Result := False;
 end;
 
+function NumberFormatLocaleArgumentToLocale(const AArg: TGocciaValue): string;
+var
+  Tag, Canonical, LowerTag, Tail: string;
+  FirstUnicodeExtension, SecondUnicodeExtension: Integer;
+  Element: TGocciaValue;
+begin
+  Result := '';
+  if (AArg = nil) or (AArg is TGocciaUndefinedLiteralValue) then
+    Exit;
+
+  if AArg is TGocciaStringLiteralValue then
+    Tag := TGocciaStringLiteralValue(AArg).Value
+  else if AArg is TGocciaArrayValue then
+  begin
+    if TGocciaArrayValue(AArg).GetLength = 0 then
+      Exit;
+    Element := TGocciaArrayValue(AArg).GetElement(0);
+    if Element is TGocciaStringLiteralValue then
+      Tag := TGocciaStringLiteralValue(Element).Value
+    else if Element is TGocciaObjectValue then
+      Tag := Element.ToStringLiteral.Value
+    else
+      ThrowTypeError('locales array elements must be strings or objects');
+  end
+  else if AArg is TGocciaObjectValue then
+    Tag := AArg.ToStringLiteral.Value
+  else
+    ThrowTypeError('locales argument must be a string, object, array, or undefined');
+
+  Canonical := CanonicalizeUnicodeLocaleId(Tag);
+  if Canonical = '' then
+  begin
+    LowerTag := LowerCase(Tag);
+    FirstUnicodeExtension := Pos('-u-', LowerTag);
+    if FirstUnicodeExtension <> 0 then
+    begin
+      Tail := Copy(LowerTag, FirstUnicodeExtension + 3, MaxInt);
+      SecondUnicodeExtension := Pos('-u-', Tail);
+      if SecondUnicodeExtension <> 0 then
+      begin
+        SecondUnicodeExtension := FirstUnicodeExtension + 3 +
+          SecondUnicodeExtension - 1;
+        Canonical := CanonicalizeUnicodeLocaleId(Copy(Tag, 1,
+          SecondUnicodeExtension - 1));
+      end;
+    end;
+    if Canonical = '' then
+      ThrowRangeError(Format('invalid language tag: %s', [Tag]));
+  end;
+  Result := Tag;
+end;
+
+function NumberFormatOptionsArgumentToObject(
+  const AArg: TGocciaValue): TGocciaObjectValue;
+begin
+  if (AArg = nil) or (AArg is TGocciaUndefinedLiteralValue) then
+    Result := nil
+  else if AArg is TGocciaNullLiteralValue then
+    ThrowTypeError('Cannot convert null or undefined to object')
+  else if AArg is TGocciaObjectValue then
+    Result := TGocciaObjectValue(AArg)
+  else
+    Result := nil;
+end;
+
 { TGocciaIntlNumberFormatValue }
 
 procedure TGocciaIntlNumberFormatValue.ReadOptions(const AOptions: TGocciaObjectValue);
@@ -990,6 +1056,14 @@ begin
   InitializePrototype;
   if Assigned(GetIntlNumberFormatShared) then
     FPrototype := GetIntlNumberFormatShared.Prototype;
+end;
+
+class function TGocciaIntlNumberFormatValue.CreateFromArguments(
+  const ALocales, AOptions: TGocciaValue): TGocciaIntlNumberFormatValue;
+begin
+  Result := TGocciaIntlNumberFormatValue.Create(
+    NumberFormatLocaleArgumentToLocale(ALocales),
+    NumberFormatOptionsArgumentToObject(AOptions));
 end;
 
 function TGocciaIntlNumberFormatValue.ToStringTag: string;

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -72,6 +72,7 @@ uses
   Goccia.ObjectModel.Types,
   Goccia.Realm,
   Goccia.Values.ArrayValue,
+  Goccia.Values.BigIntObjectValue,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -155,6 +156,14 @@ begin
     Result := incdName
   else
     Result := incdSymbol;
+end;
+
+function CurrencySignStringToEnum(const AValue: string): TIntlNumberCurrencySign;
+begin
+  if AValue = 'accounting' then
+    Result := incsAccounting
+  else
+    Result := incsStandard;
 end;
 
 function SignDisplayStringToEnum(const AValue: string): TIntlNumberSignDisplay;
@@ -243,6 +252,15 @@ begin
     Result := inrpLessPrecision
   else
     Result := inrpAuto;
+end;
+
+function TrailingZeroDisplayStringToEnum(
+  const AValue: string): TIntlNumberTrailingZeroDisplay;
+begin
+  if AValue = 'stripIfInteger' then
+    Result := intzStripIfInteger
+  else
+    Result := intzAuto;
 end;
 
 function InsertGroupingSeparator(const AIntPart, ASep: string): string;
@@ -396,6 +414,213 @@ begin
     Result := MinusSign + Result;
 end;
 
+function NormalizeDecimalIntegerString(const AValue: string; out AIsNegative: Boolean;
+  out ADigits: string): Boolean;
+var
+  I, StartIndex: Integer;
+begin
+  Result := False;
+  AIsNegative := False;
+  ADigits := Trim(AValue);
+  if ADigits = '' then
+    Exit;
+
+  StartIndex := 1;
+  if ADigits[1] in ['+', '-'] then
+  begin
+    AIsNegative := ADigits[1] = '-';
+    StartIndex := 2;
+  end;
+
+  if StartIndex > Length(ADigits) then
+    Exit;
+
+  for I := StartIndex to Length(ADigits) do
+    if not (ADigits[I] in ['0'..'9']) then
+      Exit;
+
+  ADigits := Copy(ADigits, StartIndex, MaxInt);
+  while (Length(ADigits) > 1) and (ADigits[1] = '0') do
+    Delete(ADigits, 1, 1);
+  if ADigits = '0' then
+    AIsNegative := False;
+
+  Result := True;
+end;
+
+function FormatDecimalStringWithCLDR(const AValue, ALocale: string;
+  const AOptions: TIntlNumberFormatOptions): string;
+var
+  DecimalSep, GroupSep, PercentSign, MinusSign, PlusSign: string;
+  IsNeg, IsZero: Boolean;
+  IntPart, FracPart: string;
+  MinFrac, MaxFrac: Integer;
+  CurrSymbol, CurrNarrow: string;
+  CurrDigits: Integer;
+begin
+  if not NormalizeDecimalIntegerString(AValue, IsNeg, IntPart) then
+    Exit(AValue);
+  IsZero := IntPart = '0';
+
+  if not TryGetNumberSymbol(ALocale, 'decimal', DecimalSep) then
+    DecimalSep := '.';
+  if not TryGetNumberSymbol(ALocale, 'group', GroupSep) then
+    GroupSep := ',';
+  if not TryGetNumberSymbol(ALocale, 'percentSign', PercentSign) then
+    PercentSign := '%';
+  if not TryGetNumberSymbol(ALocale, 'minusSign', MinusSign) then
+    MinusSign := '-';
+  if not TryGetNumberSymbol(ALocale, 'plusSign', PlusSign) then
+    PlusSign := '+';
+
+  case AOptions.Style of
+    insPercent:
+      IntPart := IntPart + '00';
+    insCurrency:
+    begin
+      if not TryGetCurrencyInfo(ALocale, AOptions.Currency,
+        CurrSymbol, CurrNarrow, CurrDigits) then
+      begin
+        CurrDigits := 2;
+        if AOptions.Currency = 'USD' then CurrSymbol := '$'
+        else if AOptions.Currency = 'EUR' then CurrSymbol := #$E2#$82#$AC
+        else if AOptions.Currency = 'GBP' then CurrSymbol := #$C2#$A3
+        else if (AOptions.Currency = 'JPY') or (AOptions.Currency = 'CNY') then
+        begin
+          CurrSymbol := #$C2#$A5;
+          CurrDigits := 0;
+        end
+        else
+          CurrSymbol := AOptions.Currency;
+        CurrNarrow := CurrSymbol;
+      end;
+    end;
+  end;
+
+  MinFrac := AOptions.MinimumFractionDigits;
+  MaxFrac := AOptions.MaximumFractionDigits;
+  if (MinFrac < 0) and (MaxFrac < 0) then
+  begin
+    case AOptions.Style of
+      insCurrency:
+      begin
+        MinFrac := CurrDigits;
+        MaxFrac := CurrDigits;
+      end;
+      insPercent:
+      begin
+        MinFrac := 0;
+        MaxFrac := 0;
+      end;
+    else
+      MinFrac := 0;
+      MaxFrac := 3;
+    end;
+  end;
+  if MinFrac < 0 then MinFrac := 0;
+  if MaxFrac < 0 then MaxFrac := 3;
+  if MaxFrac < MinFrac then MaxFrac := MinFrac;
+
+  while Length(IntPart) < AOptions.MinimumIntegerDigits do
+    IntPart := '0' + IntPart;
+  if AOptions.UseGrouping <> inugFalse then
+    IntPart := InsertGroupingSeparator(IntPart, GroupSep);
+
+  FracPart := StringOfChar('0', MinFrac);
+  if FracPart <> '' then
+    Result := IntPart + DecimalSep + FracPart
+  else
+    Result := IntPart;
+
+  case AOptions.Style of
+    insPercent:
+      Result := Result + PercentSign;
+    insCurrency:
+    begin
+      case AOptions.CurrencyDisplay of
+        incdCode:
+          Result := AOptions.Currency + ' ' + Result;
+        incdNarrowSymbol:
+          Result := CurrNarrow + Result;
+      else
+        Result := CurrSymbol + Result;
+      end;
+    end;
+  end;
+
+  case AOptions.SignDisplay of
+    insdNever:
+      ;
+    insdAlways:
+      if IsNeg then
+        Result := MinusSign + Result
+      else
+        Result := PlusSign + Result;
+    insdExceptZero:
+      if IsNeg then
+        Result := MinusSign + Result
+      else if not IsZero then
+        Result := PlusSign + Result;
+    insdNegative:
+      if IsNeg then
+        Result := MinusSign + Result;
+  else
+    if IsNeg then
+      Result := MinusSign + Result;
+  end;
+end;
+
+function CanFormatDecimalStringWithCLDR(
+  const AOptions: TIntlNumberFormatOptions): Boolean;
+begin
+  Result :=
+    (AOptions.Notation = innStandard) and
+    (AOptions.Style <> insUnit) and
+    (AOptions.NumberingSystem = 'latn') and
+    (AOptions.CurrencyDisplay <> incdName) and
+    (AOptions.CurrencySign = incsStandard) and
+    (AOptions.UseGrouping <> inugMin2) and
+    (AOptions.MinimumSignificantDigits < 0) and
+    (AOptions.MaximumSignificantDigits < 0) and
+    (AOptions.RoundingIncrement = 1) and
+    (AOptions.RoundingMode = inrmHalfExpand) and
+    (AOptions.RoundingPriority = inrpAuto) and
+    (AOptions.TrailingZeroDisplay = intzAuto);
+end;
+
+function TryFormatDecimalStringFallback(const ALocale, ADecimal: string;
+  const AOptions: TIntlNumberFormatOptions; out AFormatted: string): Boolean;
+var
+  NumberValue: Double;
+begin
+  if CanFormatDecimalStringWithCLDR(AOptions) then
+  begin
+    AFormatted := FormatDecimalStringWithCLDR(ADecimal, ALocale, AOptions);
+    Exit(True);
+  end;
+
+  Result := TryStrToFloat(ADecimal, NumberValue, InvariantFormatSettings) and
+    TryICUFormatNumber(ALocale, NumberValue, AOptions, AFormatted);
+end;
+
+function TryFormatDecimalStringPartsFallback(const ALocale, ADecimal: string;
+  const AOptions: TIntlNumberFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+var
+  NumberValue: Double;
+begin
+  SetLength(AParts, 0);
+  if CanFormatDecimalStringWithCLDR(AOptions) then
+  begin
+    SetLength(AParts, 1);
+    AParts[0].PartType := 'literal';
+    AParts[0].Value := FormatDecimalStringWithCLDR(ADecimal, ALocale, AOptions);
+    Exit(True);
+  end;
+
+  Result := TryStrToFloat(ADecimal, NumberValue, InvariantFormatSettings) and
+    TryICUFormatNumberToParts(ALocale, NumberValue, AOptions, AParts);
+end;
+
 function NumberRangeSeparator(const AOptions: TIntlNumberFormatOptions): string;
 begin
   if (AOptions.Style = insDecimal) and (AOptions.SignDisplay = insdAuto) then
@@ -499,6 +724,19 @@ begin
 
   ANumber := AValue.ToNumberLiteral.Value;
   Result := not IsNan(ANumber);
+end;
+
+function TryReadBigIntDecimalInput(const AValue: TGocciaValue;
+  out ADecimal: string): Boolean;
+begin
+  Result := True;
+  if AValue is TGocciaBigIntValue then
+    ADecimal := TGocciaBigIntValue(AValue).Value.ToString
+  else if (AValue is TGocciaBigIntObjectValue) and
+          (TGocciaBigIntObjectValue(AValue).Primitive is TGocciaBigIntValue) then
+    ADecimal := TGocciaBigIntValue(TGocciaBigIntObjectValue(AValue).Primitive).Value.ToString
+  else
+    Result := False;
 end;
 
 { TGocciaIntlNumberFormatValue }
@@ -730,6 +968,7 @@ begin
   FResolvedOptions.Style := StyleStringToEnum(FStyle);
   FResolvedOptions.Currency := FCurrency;
   FResolvedOptions.CurrencyDisplay := CurrencyDisplayStringToEnum(FCurrencyDisplay);
+  FResolvedOptions.CurrencySign := CurrencySignStringToEnum(FCurrencySign);
   FResolvedOptions.UnitIdentifier := FUnitIdentifier;
   FResolvedOptions.UnitDisplay := UnitDisplayStringToEnum(FUnitDisplay);
   FResolvedOptions.Notation := NotationStringToEnum(FNotation);
@@ -744,6 +983,8 @@ begin
   FResolvedOptions.RoundingMode := RoundingModeStringToEnum(FRoundingMode);
   FResolvedOptions.RoundingIncrement := FRoundingIncrement;
   FResolvedOptions.RoundingPriority := RoundingPriorityStringToEnum(FRoundingPriority);
+  FResolvedOptions.TrailingZeroDisplay :=
+    TrailingZeroDisplayStringToEnum(FTrailingZeroDisplay);
   FResolvedOptions.NumberingSystem := FNumberingSystem;
 
   InitializePrototype;
@@ -829,12 +1070,26 @@ end;
 function TGocciaIntlNumberFormatValue.IntlNumberFormatFormat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   NF: TGocciaIntlNumberFormatValue;
+  InputValue: TGocciaValue;
   NumValue: Double;
-  Formatted: string;
+  DecimalValue, Formatted: string;
 begin
   NF := AsNumberFormat(AThisValue, 'Intl.NumberFormat.prototype.format');
-  NumValue := AArgs.GetElement(0).ToNumberLiteral.Value;
+  InputValue := AArgs.GetElement(0);
 
+  if TryReadBigIntDecimalInput(InputValue, DecimalValue) then
+  begin
+    if TryICUFormatNumberDecimal(NF.FLocale, DecimalValue,
+      NF.FResolvedOptions, Formatted) then
+      Exit(TGocciaStringLiteralValue.Create(Formatted));
+    if TryFormatDecimalStringFallback(NF.FLocale, DecimalValue,
+      NF.FResolvedOptions, Formatted) then
+      Exit(TGocciaStringLiteralValue.Create(Formatted));
+    ThrowTypeError(
+      'Intl.NumberFormat BigInt fallback cannot format this option set without ICU decimal support');
+  end;
+
+  NumValue := InputValue.ToNumberLiteral.Value;
   if TryICUFormatNumber(NF.FLocale, NumValue, NF.FResolvedOptions, Formatted) then
     Result := TGocciaStringLiteralValue.Create(Formatted)
   else
@@ -845,12 +1100,27 @@ end;
 function TGocciaIntlNumberFormatValue.IntlNumberFormatFormatToParts(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   NF: TGocciaIntlNumberFormatValue;
+  InputValue: TGocciaValue;
   NumValue: Double;
+  DecimalValue: string;
   Parts: TIntlFormatPartArray;
 begin
   NF := AsNumberFormat(AThisValue, 'Intl.NumberFormat.prototype.formatToParts');
-  NumValue := AArgs.GetElement(0).ToNumberLiteral.Value;
+  InputValue := AArgs.GetElement(0);
 
+  if TryReadBigIntDecimalInput(InputValue, DecimalValue) then
+  begin
+    if TryICUFormatNumberDecimalToParts(NF.FLocale, DecimalValue,
+      NF.FResolvedOptions, Parts) then
+      Exit(FormatPartsToArray(Parts));
+    if not TryFormatDecimalStringPartsFallback(NF.FLocale, DecimalValue,
+      NF.FResolvedOptions, Parts) then
+      ThrowTypeError(
+        'Intl.NumberFormat BigInt fallback cannot format this option set without ICU decimal support');
+    Exit(FormatPartsToArray(Parts));
+  end;
+
+  NumValue := InputValue.ToNumberLiteral.Value;
   if TryICUFormatNumberToParts(NF.FLocale, NumValue, NF.FResolvedOptions, Parts) then
     Result := FormatPartsToArray(Parts)
   else

--- a/tests/built-ins/Array/prototype/toLocaleString.js
+++ b/tests/built-ins/Array/prototype/toLocaleString.js
@@ -55,4 +55,11 @@ describe.runIf(isIntl)("Array.prototype.toLocaleString Intl elements", () => {
 
     expect([1234.5].toLocaleString("de-DE", options)).toBe(expected);
   });
+
+  test("formats BigInt elements through BigInt.prototype.toLocaleString", () => {
+    const options = { style: "currency", currency: "EUR" };
+    const expected = new Intl.NumberFormat("de-DE", options).format(1234n);
+
+    expect([1234n].toLocaleString("de-DE", options)).toBe(expected);
+  });
 });

--- a/tests/built-ins/BigInt/prototype-methods.js
+++ b/tests/built-ins/BigInt/prototype-methods.js
@@ -37,4 +37,11 @@ test("toLocaleString(locales, options)", () => {
   expect(BigInt.prototype.toLocaleString.call(Object(value), "de-DE", options)).toBe(
     new Intl.NumberFormat("de-DE", options).format(value)
   );
+  expect(value.toLocaleString(["de-DE", "en-US"], options)).toBe(
+    new Intl.NumberFormat(["de-DE", "en-US"], options).format(value)
+  );
+});
+
+test("toLocaleString rejects null options", () => {
+  expect(() => (1234n).toLocaleString("en-US", null)).toThrow(TypeError);
 });

--- a/tests/built-ins/BigInt/prototype-methods.js
+++ b/tests/built-ins/BigInt/prototype-methods.js
@@ -7,6 +7,7 @@ test("toString()", () => {
   expect((42n).toString()).toBe("42");
   expect((-42n).toString()).toBe("-42");
   expect((0n).toString()).toBe("0");
+  expect(Object(42n).toString()).toBe("42");
 });
 
 test("toString(radix)", () => {
@@ -17,8 +18,23 @@ test("toString(radix)", () => {
 
 test("valueOf()", () => {
   expect((42n).valueOf()).toBe(42n);
+  expect(Object(42n).valueOf()).toBe(42n);
 });
 
 test("toLocaleString()", () => {
   expect((42n).toLocaleString()).toBe("42");
+  expect(typeof Object(42n).toLocaleString).toBe("function");
+  expect(Object(42n).toLocaleString()).toBe("42");
+});
+
+test("toLocaleString(locales, options)", () => {
+  const options = { style: "currency", currency: "EUR" };
+  const value = 1234n;
+
+  expect(value.toLocaleString("de-DE", options)).toBe(
+    new Intl.NumberFormat("de-DE", options).format(value)
+  );
+  expect(BigInt.prototype.toLocaleString.call(Object(value), "de-DE", options)).toBe(
+    new Intl.NumberFormat("de-DE", options).format(value)
+  );
 });

--- a/tests/built-ins/Intl/NumberFormat/prototype/format.js
+++ b/tests/built-ins/Intl/NumberFormat/prototype/format.js
@@ -62,6 +62,17 @@ describe.runIf(isIntl)("Intl.NumberFormat.prototype.format", () => {
     expect(result.includes("$")).toBe(true);
   });
 
+  test("format accepts BigInt values without losing precision", () => {
+    const value = 123456789012345678901234567890n;
+
+    expect(new Intl.NumberFormat("en-US", { useGrouping: false }).format(value)).toBe(
+      "123456789012345678901234567890"
+    );
+    expect(new Intl.NumberFormat("de-DE").format(value)).toBe(
+      "123.456.789.012.345.678.901.234.567.890"
+    );
+  });
+
   test("percent format produces a string containing the percent sign", () => {
     const nf = new Intl.NumberFormat("en-US", { style: "percent" });
     const result = nf.format(0.75);

--- a/tests/built-ins/TypedArray/prototype/toLocaleString.js
+++ b/tests/built-ins/TypedArray/prototype/toLocaleString.js
@@ -22,6 +22,23 @@ describe("%TypedArray%.prototype.toLocaleString", () => {
       Number.prototype.toLocaleString = original;
     }
   });
+
+  test("invokes BigInt element toLocaleString with locales and options", () => {
+    const original = BigInt.prototype.toLocaleString;
+    const options = { marker: "yes" };
+
+    try {
+      BigInt.prototype.toLocaleString = {
+        method(locales, receivedOptions) {
+          return "bigint:" + locales + ":" + receivedOptions.marker;
+        },
+      }.method;
+
+      expect(new BigInt64Array([0n]).toLocaleString("xx", options)).toBe("bigint:xx:yes");
+    } finally {
+      BigInt.prototype.toLocaleString = original;
+    }
+  });
 });
 
 describe.runIf(isIntl)("%TypedArray%.prototype.toLocaleString Intl elements", () => {
@@ -30,5 +47,12 @@ describe.runIf(isIntl)("%TypedArray%.prototype.toLocaleString Intl elements", ()
     const expected = new Intl.NumberFormat("th-u-nu-thai", options).format(0);
 
     expect(new Uint8Array([0]).toLocaleString("th-u-nu-thai", options)).toBe(expected);
+  });
+
+  test("formats BigInt elements through BigInt.prototype.toLocaleString", () => {
+    const options = { useGrouping: false };
+    const expected = new Intl.NumberFormat("de-DE", options).format(1234n);
+
+    expect(new BigInt64Array([1234n]).toLocaleString("de-DE", options)).toBe(expected);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add exact decimal-string ICU formatting for BigInt values in Intl.NumberFormat.
- Route BigInt.prototype.toLocaleString(locales, options) through Intl.NumberFormat and share the JS-visible BigInt.prototype with boxed BigInt wrappers.
- Centralize raw Intl.NumberFormat locale/options argument handling so BigInt forwards locale lists and nullish options validation through the same path as the constructor.
- Add regressions for boxed BigInt lookup, locale-array forwarding, Array/TypedArray locale delegation, and precision-preserving BigInt number formatting.
- Closes #704.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - ./build.pas clean && ./build.pas loader testrunner loaderbare
  - ./build/GocciaTestRunner tests/built-ins/BigInt/prototype-methods.js tests/built-ins/Array/prototype/toLocaleString.js tests/built-ins/TypedArray/prototype/toLocaleString.js tests/built-ins/Intl/NumberFormat/prototype/format.js --no-progress --exit-on-first-failure
  - ./build/GocciaTestRunner tests/built-ins/BigInt/prototype-methods.js tests/built-ins/Array/prototype/toLocaleString.js tests/built-ins/TypedArray/prototype/toLocaleString.js tests/built-ins/Intl/NumberFormat/prototype/format.js --mode=bytecode --no-progress --exit-on-first-failure
  - bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b455 --categories built-ins --filter built-ins/Array/prototype/toLocaleString/user-provided-tolocalestring-grow.js --mode bytecode --jobs 1 --verbose
  - bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b455 --categories built-ins --filter built-ins/TypedArray/prototype/toLocaleString/BigInt/get-length-uses-internal-arraylength.js --mode bytecode --jobs 1 --verbose
  - bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b455 --categories built-ins --filter built-ins/TypedArray/prototype/toLocaleString/BigInt/return-result.js --mode bytecode --jobs 1 --verbose
  - bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-d0c1b455 --categories built-ins --filter built-ins/TypedArray/prototype/toLocaleString/user-provided-tolocalestring-grow.js --mode bytecode --jobs 1 --verbose
  - ./build/GocciaTestRunner tests --no-progress --exit-on-first-failure (10032/10032 passing)
  - ./format.pas --check
  - git diff --check
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change