### PR TITLE
fix(builtins): reject nullish prototype receivers

### DIFF
--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -192,6 +192,7 @@ const
         '    }.toLocaleString;'#10 +
         '    const arrayLocale = {'#10 +
         '      toLocaleString(...args: any[]): string {'#10 +
+        '        if (this === null || this === undefined) throw new TypeError("Array.prototype.toLocaleString called on null or undefined");'#10 +
         '        const array: any = Object(this);'#10 +
         '        const length: number = Number(array.length);'#10 +
         '        const len: number = !Number.isFinite(length) || length <= 0 ? 0 : Math.trunc(length);'#10 +
@@ -237,25 +238,26 @@ const
         '  #valid() { return Number.isFinite(this.#ms); }'#10 +
         '  #local() { return this.#valid() ? new Temporal.ZonedDateTime(BigInt(this.#ms) * 1000000n, Temporal.Now.timeZoneId()) : null; }'#10 +
         '  #utc() { return this.#valid() ? new Temporal.ZonedDateTime(BigInt(this.#ms) * 1000000n, "UTC") : null; }'#10 +
-        '  getTime(): number { return this.#ms; }'#10 +
-        '  valueOf(): number { return this.#ms; }'#10 +
-        '  getFullYear(): number { const z = this.#local(); return z ? z.year : NaN; }'#10 +
-        '  getMonth(): number { const z = this.#local(); return z ? z.month - 1 : NaN; }'#10 +
-        '  getDate(): number { const z = this.#local(); return z ? z.day : NaN; }'#10 +
-        '  getDay(): number { const z = this.#local(); return z ? z.dayOfWeek % 7 : NaN; }'#10 +
-        '  getHours(): number { const z = this.#local(); return z ? z.hour : NaN; }'#10 +
-        '  getMinutes(): number { const z = this.#local(); return z ? z.minute : NaN; }'#10 +
-        '  getSeconds(): number { const z = this.#local(); return z ? z.second : NaN; }'#10 +
-        '  getMilliseconds(): number { const z = this.#local(); return z ? z.millisecond : NaN; }'#10 +
-        '  getUTCFullYear(): number { const z = this.#utc(); return z ? z.year : NaN; }'#10 +
-        '  getUTCMonth(): number { const z = this.#utc(); return z ? z.month - 1 : NaN; }'#10 +
-        '  getUTCDate(): number { const z = this.#utc(); return z ? z.day : NaN; }'#10 +
-        '  getUTCDay(): number { const z = this.#utc(); return z ? z.dayOfWeek % 7 : NaN; }'#10 +
-        '  getUTCHours(): number { const z = this.#utc(); return z ? z.hour : NaN; }'#10 +
-        '  getUTCMinutes(): number { const z = this.#utc(); return z ? z.minute : NaN; }'#10 +
-        '  getUTCSeconds(): number { const z = this.#utc(); return z ? z.second : NaN; }'#10 +
-        '  getUTCMilliseconds(): number { const z = this.#utc(); return z ? z.millisecond : NaN; }'#10 +
+        '  getTime(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getTime called on non-Date"); return this.#ms; }'#10 +
+        '  valueOf(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.valueOf called on non-Date"); return this.#ms; }'#10 +
+        '  getFullYear(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getFullYear called on non-Date"); const z = this.#local(); return z ? z.year : NaN; }'#10 +
+        '  getMonth(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getMonth called on non-Date"); const z = this.#local(); return z ? z.month - 1 : NaN; }'#10 +
+        '  getDate(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getDate called on non-Date"); const z = this.#local(); return z ? z.day : NaN; }'#10 +
+        '  getDay(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getDay called on non-Date"); const z = this.#local(); return z ? z.dayOfWeek % 7 : NaN; }'#10 +
+        '  getHours(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getHours called on non-Date"); const z = this.#local(); return z ? z.hour : NaN; }'#10 +
+        '  getMinutes(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getMinutes called on non-Date"); const z = this.#local(); return z ? z.minute : NaN; }'#10 +
+        '  getSeconds(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getSeconds called on non-Date"); const z = this.#local(); return z ? z.second : NaN; }'#10 +
+        '  getMilliseconds(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getMilliseconds called on non-Date"); const z = this.#local(); return z ? z.millisecond : NaN; }'#10 +
+        '  getUTCFullYear(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getUTCFullYear called on non-Date"); const z = this.#utc(); return z ? z.year : NaN; }'#10 +
+        '  getUTCMonth(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getUTCMonth called on non-Date"); const z = this.#utc(); return z ? z.month - 1 : NaN; }'#10 +
+        '  getUTCDate(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getUTCDate called on non-Date"); const z = this.#utc(); return z ? z.day : NaN; }'#10 +
+        '  getUTCDay(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getUTCDay called on non-Date"); const z = this.#utc(); return z ? z.dayOfWeek % 7 : NaN; }'#10 +
+        '  getUTCHours(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getUTCHours called on non-Date"); const z = this.#utc(); return z ? z.hour : NaN; }'#10 +
+        '  getUTCMinutes(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getUTCMinutes called on non-Date"); const z = this.#utc(); return z ? z.minute : NaN; }'#10 +
+        '  getUTCSeconds(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getUTCSeconds called on non-Date"); const z = this.#utc(); return z ? z.second : NaN; }'#10 +
+        '  getUTCMilliseconds(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getUTCMilliseconds called on non-Date"); const z = this.#utc(); return z ? z.millisecond : NaN; }'#10 +
         '  setDate(day: number): number {'#10 +
+        '    if (!(this instanceof Date)) throw new TypeError("Date.prototype.setDate called on non-Date");'#10 +
         '    const z = this.#local();'#10 +
         '    const n = Number(day);'#10 +
         '    if (!z || !Number.isFinite(n)) { this.#ms = NaN; return NaN; }'#10 +
@@ -263,10 +265,36 @@ const
         '    this.#ms = next.epochMilliseconds;'#10 +
         '    return this.#ms;'#10 +
         '  }'#10 +
-        '  getTimezoneOffset(): number { const z = this.#local(); return z ? -(z.offsetNanoseconds / 60000000000) : NaN; }'#10 +
-        '  toISOString(): string { if (!this.#valid()) throw new RangeError("Invalid time value"); return Temporal.Instant.fromEpochMilliseconds(this.#ms).toString(); }'#10 +
-        '  toJSON(): string | null { if (!this.#valid()) return null; return this.toISOString(); }'#10 +
+        '  getTimezoneOffset(): number { if (!(this instanceof Date)) throw new TypeError("Date.prototype.getTimezoneOffset called on non-Date"); const z = this.#local(); return z ? -(z.offsetNanoseconds / 60000000000) : NaN; }'#10 +
+        '  toISOString(): string { if (!(this instanceof Date)) throw new TypeError("Date.prototype.toISOString called on non-Date"); if (!this.#valid()) throw new RangeError("Invalid time value"); return Temporal.Instant.fromEpochMilliseconds(this.#ms).toString(); }'#10 +
+        '  toJSON(): string | null {'#10 +
+        '    if (this === null || this === undefined) throw new TypeError("Date.prototype.toJSON called on null or undefined");'#10 +
+        '    const object: any = Object(this);'#10 +
+        '    const isObject = (value: any): boolean => (typeof value === "object" && value !== null) || typeof value === "function";'#10 +
+        '    let primitive: any;'#10 +
+        '    let hasPrimitive: boolean = false;'#10 +
+        '    const exotic: any = object[Symbol.toPrimitive];'#10 +
+        '    if (exotic !== undefined && exotic !== null) {'#10 +
+        '      if (typeof exotic !== "function") throw new TypeError("Date.prototype.toJSON @@toPrimitive is not a function");'#10 +
+        '      primitive = exotic.call(object, "number");'#10 +
+        '      hasPrimitive = true;'#10 +
+        '      if (isObject(primitive)) throw new TypeError("Date.prototype.toJSON @@toPrimitive returned an object");'#10 +
+        '    } else {'#10 +
+        '      const valueOf: any = object.valueOf;'#10 +
+        '      if (typeof valueOf === "function") { primitive = valueOf.call(object); hasPrimitive = true; }'#10 +
+        '      if (!hasPrimitive || isObject(primitive)) {'#10 +
+        '        const toString: any = object.toString;'#10 +
+        '        if (typeof toString === "function") { primitive = toString.call(object); hasPrimitive = true; }'#10 +
+        '      }'#10 +
+        '      if (!hasPrimitive || isObject(primitive)) throw new TypeError("Date.prototype.toJSON cannot convert receiver to primitive");'#10 +
+        '    }'#10 +
+        '    if (typeof primitive === "number" && !Number.isFinite(primitive)) return null;'#10 +
+        '    const toISO: any = object.toISOString;'#10 +
+        '    if (typeof toISO !== "function") throw new TypeError("Date.prototype.toJSON toISOString is not a function");'#10 +
+        '    return toISO.call(object);'#10 +
+        '  }'#10 +
         '  toString(): string {'#10 +
+        '    if (!(this instanceof Date)) throw new TypeError("Date.prototype.toString called on non-Date");'#10 +
         '    const z = this.#local();'#10 +
         '    if (!z) return "Invalid Date";'#10 +
         '    const pad = (n: number): string => n < 10 ? "0" + String(n) : String(n);'#10 +
@@ -293,21 +321,18 @@ const
         '    return out;'#10 +
         '  }'#10 +
         '  toLocaleString(...args: any[]): string {'#10 +
-        '    let valid: boolean;'#10 +
-        '    try { valid = this.#valid(); } catch (e) { throw new TypeError("Date.prototype.toLocaleString called on non-Date"); }'#10 +
-        '    if (!valid) return "Invalid Date";'#10 +
+        '    if (!(this instanceof Date)) throw new TypeError("Date.prototype.toLocaleString called on non-Date");'#10 +
+        '    if (!this.#valid()) return "Invalid Date";'#10 +
         '    return new __GocciaShimDateTimeFormat(args[0], this.#localeOptions(args[1], true, true)).format(this.#ms);'#10 +
         '  }'#10 +
         '  toLocaleDateString(...args: any[]): string {'#10 +
-        '    let valid: boolean;'#10 +
-        '    try { valid = this.#valid(); } catch (e) { throw new TypeError("Date.prototype.toLocaleDateString called on non-Date"); }'#10 +
-        '    if (!valid) return "Invalid Date";'#10 +
+        '    if (!(this instanceof Date)) throw new TypeError("Date.prototype.toLocaleDateString called on non-Date");'#10 +
+        '    if (!this.#valid()) return "Invalid Date";'#10 +
         '    return new __GocciaShimDateTimeFormat(args[0], this.#localeOptions(args[1], true, false)).format(this.#ms);'#10 +
         '  }'#10 +
         '  toLocaleTimeString(...args: any[]): string {'#10 +
-        '    let valid: boolean;'#10 +
-        '    try { valid = this.#valid(); } catch (e) { throw new TypeError("Date.prototype.toLocaleTimeString called on non-Date"); }'#10 +
-        '    if (!valid) return "Invalid Date";'#10 +
+        '    if (!(this instanceof Date)) throw new TypeError("Date.prototype.toLocaleTimeString called on non-Date");'#10 +
+        '    if (!this.#valid()) return "Invalid Date";'#10 +
         '    return new __GocciaShimDateTimeFormat(args[0], this.#localeOptions(args[1], false, true)).format(this.#ms);'#10 +
         '  }'#10 +
         '};'

--- a/source/units/Goccia.Values.BooleanObjectValue.pas
+++ b/source/units/Goccia.Values.BooleanObjectValue.pas
@@ -38,7 +38,6 @@ uses
   Goccia.GarbageCollector,
   Goccia.Realm,
   Goccia.Values.ErrorHelper,
-  Goccia.Values.NativeFunction,
   Goccia.Values.ToObject;
 
 // Boolean.prototype lives in a per-realm slot.  Method host and member

--- a/source/units/Goccia.Values.BooleanObjectValue.pas
+++ b/source/units/Goccia.Values.BooleanObjectValue.pas
@@ -15,6 +15,8 @@ type
   TGocciaBooleanObjectValue = class(TGocciaInstanceValue)
   private
     FPrimitive: TGocciaBooleanLiteralValue;
+
+    function ExtractPrimitive(const AValue: TGocciaValue): TGocciaBooleanLiteralValue;
   public
     constructor Create(const APrimitive: TGocciaBooleanLiteralValue; const AClass: TGocciaClassValue = nil);
     procedure InitializePrototype;
@@ -35,7 +37,9 @@ implementation
 uses
   Goccia.GarbageCollector,
   Goccia.Realm,
-  Goccia.Values.NativeFunction;
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ToObject;
 
 // Boolean.prototype lives in a per-realm slot.  Method host and member
 // definitions stay process-wide (immutable across realms).
@@ -52,6 +56,19 @@ begin
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GBooleanPrototypeSlot))
   else
     Result := nil;
+end;
+
+// ES2026 §20.3.3.3.1 ThisBooleanValue(value)
+function TGocciaBooleanObjectValue.ExtractPrimitive(const AValue: TGocciaValue): TGocciaBooleanLiteralValue;
+begin
+  RequireObjectCoercible(AValue);
+
+  if AValue is TGocciaBooleanLiteralValue then
+    Result := TGocciaBooleanLiteralValue(AValue)
+  else if AValue is TGocciaBooleanObjectValue then
+    Result := TGocciaBooleanObjectValue(AValue).Primitive
+  else
+    ThrowTypeError('Boolean.prototype method called on non-Boolean');
 end;
 
 constructor TGocciaBooleanObjectValue.Create(const APrimitive: TGocciaBooleanLiteralValue; const AClass: TGocciaClassValue = nil);
@@ -120,24 +137,14 @@ end;
 
 function TGocciaBooleanObjectValue.BooleanValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  if AThisValue is TGocciaBooleanObjectValue then
-    Result := TGocciaBooleanObjectValue(AThisValue).Primitive
-  else if AThisValue is TGocciaBooleanLiteralValue then
-    Result := AThisValue
-  else
-    Result := AThisValue.ToBooleanLiteral;
+  Result := ExtractPrimitive(AThisValue);
 end;
 
 function TGocciaBooleanObjectValue.BooleanToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Prim: TGocciaBooleanLiteralValue;
 begin
-  if AThisValue is TGocciaBooleanObjectValue then
-    Prim := TGocciaBooleanObjectValue(AThisValue).Primitive
-  else if AThisValue is TGocciaBooleanLiteralValue then
-    Prim := TGocciaBooleanLiteralValue(AThisValue)
-  else
-    Prim := AThisValue.ToBooleanLiteral;
+  Prim := ExtractPrimitive(AThisValue);
 
   if Prim.Value then
     Result := TGocciaStringLiteralValue.Create('true')

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -110,6 +110,11 @@ type
     property BoundArgCount: Integer read FBoundArgCount;
   end;
 
+// ES2026 §7.3.14 Call(F, V, argumentsList)
+function DispatchCall(const ACallee: TGocciaValue;
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+
 // ES2026 §10.1.14 GetPrototypeFromConstructor: Get(constructor, "prototype")
 // directly — no bound-function unwrap. If the property is not an Object,
 // fall back to %Object.prototype%. Shared by Reflect.construct (§28.1.2)

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -124,6 +124,7 @@ uses
   Goccia.GarbageCollector,
   Goccia.ObjectModel,
   Goccia.Realm,
+  Goccia.Values.ClassHelper,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.FunctionValue,
@@ -143,6 +144,32 @@ threadvar
 
 const
   MAX_PROTOTYPE_CHAIN_DEPTH = 256;
+
+// Local ToObject variant for Object.prototype methods.  Keeping this here
+// avoids a unit cycle with the shared ToObject unit.
+function ObjectPrototypeToObject(const AValue: TGocciaValue): TGocciaObjectValue;
+var
+  Boxed: TGocciaObjectValue;
+begin
+  if (AValue is TGocciaUndefinedLiteralValue) or (AValue is TGocciaNullLiteralValue) then
+    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
+
+  if AValue is TGocciaObjectValue then
+  begin
+    Result := TGocciaObjectValue(AValue);
+    Exit;
+  end;
+
+  Boxed := AValue.Box;
+  if Assigned(Boxed) then
+  begin
+    Result := Boxed;
+    Exit;
+  end;
+
+  ThrowTypeError(SErrorCannotConvertValueToObject, SSuggestObjectArgType);
+  Result := nil;
+end;
 
 procedure MarkPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor);
 begin
@@ -303,38 +330,37 @@ end;
 // ES2026 §20.1.3.5 Object.prototype.toLocaleString()
 function TGocciaObjectValue.ObjectPrototypeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
+  Obj: TGocciaObjectValue;
   ToStringMethod: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
 begin
   // Step 1: Let O be the this value
   // Step 2: Return ? Invoke(O, "toString")
-  if AThisValue is TGocciaObjectValue then
-  begin
-    ToStringMethod := TGocciaObjectValue(AThisValue).GetProperty(PROP_TO_STRING);
-    if Assigned(ToStringMethod) and ToStringMethod.IsCallable then
-    begin
-      CallArgs := TGocciaArgumentsCollection.Create;
-      try
-        if ToStringMethod is TGocciaFunctionBase then
-          Result := TGocciaFunctionBase(ToStringMethod).Call(CallArgs, AThisValue)
-        else
-          Result := AThisValue.ToStringLiteral;
-      finally
-        CallArgs.Free;
-      end;
-    end
-    else
-      Result := AThisValue.ToStringLiteral;
-  end
-  else
-    Result := AThisValue.ToStringLiteral;
+  Obj := ObjectPrototypeToObject(AThisValue);
+  if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
+    TGarbageCollector.Instance.AddTempRoot(Obj);
+  try
+    ToStringMethod := Obj.GetProperty(PROP_TO_STRING);
+    if not Assigned(ToStringMethod) or not ToStringMethod.IsCallable then
+      ThrowTypeError(Format(SErrorValueNotFunction, [PROP_TO_STRING]), SSuggestNotFunctionType);
+
+    CallArgs := TGocciaArgumentsCollection.Create;
+    try
+      Result := DispatchCall(ToStringMethod, CallArgs, AThisValue);
+    finally
+      CallArgs.Free;
+    end;
+  finally
+    if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
+      TGarbageCollector.Instance.RemoveTempRoot(Obj);
+  end;
 end;
 
 // ES2026 §20.1.3.7 Object.prototype.valueOf()
 function TGocciaObjectValue.ObjectPrototypeValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Return ? ToObject(this value)
-  Result := AThisValue;
+  Result := ObjectPrototypeToObject(AThisValue);
 end;
 
 class procedure TGocciaObjectValue.InitializeSharedPrototype;

--- a/source/units/Goccia.Values.ToObject.pas
+++ b/source/units/Goccia.Values.ToObject.pas
@@ -12,6 +12,10 @@ uses
 // Throws TypeError for undefined/null. Returns objects as-is. Boxes primitives.
 function ToObject(const AValue: TGocciaValue): TGocciaObjectValue;
 
+// ES2026 §7.2.1 RequireObjectCoercible(argument)
+// Throws TypeError for undefined/null and otherwise returns the original value.
+function RequireObjectCoercible(const AValue: TGocciaValue): TGocciaValue;
+
 // ES2026 §7.3.3 LengthOfArrayLike(obj)
 // Returns ToLength(? Get(obj, "length")).
 function LengthOfArrayLike(const AObj: TGocciaObjectValue): Integer;
@@ -39,8 +43,7 @@ function ToObject(const AValue: TGocciaValue): TGocciaObjectValue;
 var
   Boxed: TGocciaObjectValue;
 begin
-  if (AValue is TGocciaUndefinedLiteralValue) or (AValue is TGocciaNullLiteralValue) then
-    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
+  RequireObjectCoercible(AValue);
 
   if AValue is TGocciaObjectValue then
   begin
@@ -59,6 +62,14 @@ begin
   // Symbol and other non-coercible types
   ThrowTypeError(SErrorCannotConvertValueToObject, SSuggestObjectArgType);
   Result := nil;
+end;
+
+// ES2026 §7.2.1 RequireObjectCoercible(argument)
+function RequireObjectCoercible(const AValue: TGocciaValue): TGocciaValue;
+begin
+  if (AValue is TGocciaUndefinedLiteralValue) or (AValue is TGocciaNullLiteralValue) then
+    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
+  Result := AValue;
 end;
 
 // ES2026 §7.3.3 LengthOfArrayLike(obj)

--- a/tests/built-ins/Array/prototype/toLocaleString.js
+++ b/tests/built-ins/Array/prototype/toLocaleString.js
@@ -46,6 +46,20 @@ describe("Array.prototype.toLocaleString", () => {
       Array.prototype.join = originalJoin;
     }
   });
+
+  test("rejects nullish receivers", () => {
+    const toLocaleString = Array.prototype.toLocaleString;
+
+    expect(() => toLocaleString.call(null)).toThrow(TypeError);
+    expect(() => toLocaleString.call(undefined)).toThrow(TypeError);
+    expect(() => toLocaleString()).toThrow(TypeError);
+  });
+
+  test("works with generic array-like receivers", () => {
+    const receiver = { 0: 1, 1: null, 2: "x", length: 3 };
+
+    expect(Array.prototype.toLocaleString.call(receiver)).toBe("1,,x");
+  });
 });
 
 describe.runIf(isIntl)("Array.prototype.toLocaleString Intl elements", () => {

--- a/tests/built-ins/Boolean/prototype/toString.js
+++ b/tests/built-ins/Boolean/prototype/toString.js
@@ -1,0 +1,20 @@
+describe("Boolean.prototype.toString", () => {
+  test("returns primitive boolean strings", () => {
+    expect(Boolean.prototype.toString.call(true)).toBe("true");
+    expect(Boolean.prototype.toString.call(false)).toBe("false");
+    expect(new Boolean(true).toString()).toBe("true");
+  });
+
+  test("rejects nullish receivers", () => {
+    const toString = Boolean.prototype.toString;
+
+    expect(() => toString.call(null)).toThrow(TypeError);
+    expect(() => toString.call(undefined)).toThrow(TypeError);
+    expect(() => toString()).toThrow(TypeError);
+  });
+
+  test("rejects non-Boolean receivers", () => {
+    expect(() => Boolean.prototype.toString.call(1)).toThrow(TypeError);
+    expect(() => Boolean.prototype.toString.call({})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Boolean/prototype/valueOf.js
+++ b/tests/built-ins/Boolean/prototype/valueOf.js
@@ -1,0 +1,20 @@
+describe("Boolean.prototype.valueOf", () => {
+  test("returns primitive boolean values", () => {
+    expect(Boolean.prototype.valueOf.call(true)).toBe(true);
+    expect(Boolean.prototype.valueOf.call(false)).toBe(false);
+    expect(new Boolean(true).valueOf()).toBe(true);
+  });
+
+  test("rejects nullish receivers", () => {
+    const valueOf = Boolean.prototype.valueOf;
+
+    expect(() => valueOf.call(null)).toThrow(TypeError);
+    expect(() => valueOf.call(undefined)).toThrow(TypeError);
+    expect(() => valueOf()).toThrow(TypeError);
+  });
+
+  test("rejects non-Boolean receivers", () => {
+    expect(() => Boolean.prototype.valueOf.call(1)).toThrow(TypeError);
+    expect(() => Boolean.prototype.valueOf.call({})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Date/methods.js
+++ b/tests/built-ins/Date/methods.js
@@ -92,4 +92,65 @@ describe("Date methods", () => {
     expect(result).toBe(value.getTime());
     expect(value.getDate()).toBe(2);
   });
+
+  test("prototype methods reject nullish receivers", () => {
+    const methods = [
+      "getTime",
+      "valueOf",
+      "getFullYear",
+      "getMonth",
+      "getDate",
+      "getDay",
+      "getHours",
+      "getMinutes",
+      "getSeconds",
+      "getMilliseconds",
+      "getUTCFullYear",
+      "getUTCMonth",
+      "getUTCDate",
+      "getUTCDay",
+      "getUTCHours",
+      "getUTCMinutes",
+      "getUTCSeconds",
+      "getUTCMilliseconds",
+      "setDate",
+      "getTimezoneOffset",
+      "toISOString",
+      "toJSON",
+      "toString",
+      "toLocaleString",
+      "toLocaleDateString",
+      "toLocaleTimeString",
+    ];
+
+    for (const method of methods) {
+      const fn = Date.prototype[method];
+      expect(() => fn.call(null)).toThrow(TypeError);
+      expect(() => fn.call(undefined)).toThrow(TypeError);
+      expect(() => fn()).toThrow(TypeError);
+    }
+  });
+
+  test("toJSON remains generic for object receivers", () => {
+    const receiver = {
+      valueOf() { return 1; },
+      toISOString() { return "generic"; },
+    };
+
+    expect(Date.prototype.toJSON.call(receiver)).toBe("generic");
+  });
+
+  test("toJSON only returns null for non-finite number primitives", () => {
+    const stringPrimitiveReceiver = {
+      valueOf() { return "not-a-number"; },
+      toISOString() { return "generic"; },
+    };
+    const nonFiniteNumberReceiver = {
+      valueOf() { return NaN; },
+      toISOString() { return "unreachable"; },
+    };
+
+    expect(Date.prototype.toJSON.call(stringPrimitiveReceiver)).toBe("generic");
+    expect(Date.prototype.toJSON.call(nonFiniteNumberReceiver)).toBe(null);
+  });
 });

--- a/tests/built-ins/Object/prototype/toLocaleString.js
+++ b/tests/built-ins/Object/prototype/toLocaleString.js
@@ -11,6 +11,14 @@ describe('Object.prototype.toLocaleString', () => {
     expect(obj.toLocaleString()).toBe('custom');
   });
 
+  test('calls proxied toString methods', () => {
+    const obj = {
+      toString: new Proxy(() => 'proxied', {}),
+    };
+
+    expect(obj.toLocaleString()).toBe('proxied');
+  });
+
   test('works on arrays', () => {
     const arr = [1, 2, 3];
     expect(arr.toLocaleString()).toBe(arr.toString());
@@ -36,5 +44,23 @@ describe('Object.prototype.toLocaleString', () => {
     class Child extends Base {}
     const c = new Child();
     expect(c.toLocaleString()).toBe('Base');
+  });
+
+  test('rejects nullish receivers', () => {
+    const toLocaleString = Object.prototype.toLocaleString;
+
+    expect(() => toLocaleString.call(null)).toThrow(TypeError);
+    expect(() => toLocaleString.call(undefined)).toThrow(TypeError);
+    expect(() => toLocaleString()).toThrow(TypeError);
+  });
+
+  test('throws when toString is not callable', () => {
+    expect(() => Object.prototype.toLocaleString.call({ toString: 1 })).toThrow(TypeError);
+  });
+
+  test('uses primitive receiver toString methods', () => {
+    expect(Object.prototype.toLocaleString.call(1)).toBe('1');
+    expect(Object.prototype.toLocaleString.call(true)).toBe('true');
+    expect(Object.prototype.toLocaleString.call('x')).toBe('x');
   });
 });

--- a/tests/built-ins/Object/prototype/valueOf.js
+++ b/tests/built-ins/Object/prototype/valueOf.js
@@ -53,4 +53,18 @@ describe('Object.prototype.valueOf', () => {
     const child = Object.create(parent);
     expect(child.valueOf()).toBe(child);
   });
+
+  test('rejects nullish receivers', () => {
+    const valueOf = Object.prototype.valueOf;
+
+    expect(() => valueOf.call(null)).toThrow(TypeError);
+    expect(() => valueOf.call(undefined)).toThrow(TypeError);
+    expect(() => valueOf()).toThrow(TypeError);
+  });
+
+  test('boxes primitive receivers', () => {
+    expect(Object.prototype.valueOf.call(1).toString()).toBe('1');
+    expect(Object.prototype.valueOf.call(true).toString()).toBe('true');
+    expect(Object.prototype.valueOf.call('x').toString()).toBe('x');
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Reject nullish receivers consistently for affected built-in prototype methods.
- Route Object/Boolean receiver handling through spec-style coercion helpers and preserve callable proxy dispatch for Object.prototype.toLocaleString.
- Add Date shim receiver checks while preserving Date.prototype.toJSON generic behavior.

Closes #699.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Verification run:

- `./build/GocciaTestRunner tests/built-ins/Object/prototype/toLocaleString.js tests/built-ins/Date/methods.js tests/built-ins/Object/prototype/valueOf.js tests/built-ins/Boolean/prototype tests/built-ins/Array/prototype/toLocaleString.js --no-progress`
- `./build.pas loaderbare && bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/misc/builtin-methods-reject-null-undefined-this.js' --mode interpreted --jobs 1 --verbose && bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite-pinned --categories staging --filter 'staging/sm/misc/builtin-methods-reject-null-undefined-this.js' --mode bytecode --jobs 1 --verbose`
- `./format.pas --check`
- `./fixtures/ffi/build.sh && ./build.pas testrunner && ./build/GocciaTestRunner tests`