### PR TITLE
fix(interpreter): collect under memory pressure

### DIFF
--- a/docs/garbage-collector.md
+++ b/docs/garbage-collector.md
@@ -53,8 +53,8 @@ When working with the GC, follow these rules:
 - **Override `MarkReferences`** in every value type that holds `TGocciaValue` references. Call `inherited` first, then mark each owned reference.
 - **Pin singletons** — `UndefinedValue`, `TrueValue`, `NaNValue`, etc. are pinned via `PinObject` during engine initialization (consolidated in `PinPrimitiveSingletons`). Built-in prototype singletons are stored per-engine in realm slots (see next bullet); the realm pins them on `SetSlot` and releases them on `Destroy`, so contributors do not need to call `PinObject` from `InitializePrototype` themselves.
 - **Realm-owned pinning** — Built-in prototypes are stored in per-engine [realm slots](core-patterns.md#realm-ownership--slot-registration). `TGocciaRealm.SetSlot` pins the stored object via `PinObject`; the realm tracks every pin it took and releases all of them in `Destroy` via `UnpinObject`. Owned-slot helpers (`TGocciaSharedPrototype` instances) are `Free`d before the pin-release pass, so their destructors can still call `UnpinObject` on objects they own. This means engine tear-down releases the entire intrinsic prototype graph atomically — embedders should not pin or unpin built-in prototypes manually.
-- **Protect stack-held values** — Values held only by Pascal code (not in any GocciaScript scope) must be protected with `AddTempRoot`/`RemoveTempRoot`.
-- **Use `CollectIfNeeded(AProtect)`** when holding a `TGCManagedObject` on the stack. The no-arg `CollectIfNeeded` is only safe when all live values are already rooted.
+- **Protect stack-held values** — Values held only by Pascal code (not in any GocciaScript scope) must be protected. Use `TGocciaActiveRootFrame` for stack-local groups of roots, especially nested evaluator paths where the same object may be rooted more than once; use `AddTempRoot`/`RemoveTempRoot` for simple one-off temporary ownership.
+- **Use `CollectIfNeeded(AProtect)` or `CollectForMemoryPressure(AProtect)`** when holding a `TGCManagedObject` on the stack. The no-arg `CollectIfNeeded` is only safe when all live values are already rooted.
 - **Weak containers and weak references must not mark weak targets during `MarkReferences`**. Put weak-value propagation in `TraceWeakReferences` and dead-target pruning or cleanup scheduling in `SweepWeakReferences`; otherwise weak semantics collapse into strong references.
 - **Queued jobs must root their callback payloads**. Promise reactions, `queueMicrotask` callbacks, and FinalizationRegistry cleanup jobs use queued roots so callback functions, held values, and result promises survive collections until the job runs.
 - **Clear kept objects at host job boundaries**. Engine idle checkpoints and the shared microtask/fetch drain helper clear the kept-objects set before and after draining; individual microtask/finalization jobs clear it after they complete.
@@ -94,6 +94,8 @@ The GC tracks approximate heap usage via `InstanceSize` per registered object. A
 - **Override:** `--max-memory=<bytes>` sets an explicit limit.
 
 Any allocation that pushes `BytesAllocated` above `MaxBytes` raises a JavaScript `RangeError`. The error is catchable with `try/catch`; after catching, the script can call `Goccia.gc()` to free unreachable objects and retry.
+
+The interpreter also has safe checkpoints that call `CollectForMemoryPressure` as live bytes approach the ceiling. These checkpoints protect the current expression result and active Pascal-local temporaries, allowing transient-heavy programs to reclaim unreachable values before the hard allocation guard fires. If a collection cannot bring usage below the ceiling, the next allocation still raises `RangeError`.
 
 From JavaScript, `Goccia.gc.bytesAllocated` and `Goccia.gc.maxBytes` are read-only getters. The ceiling can only be changed from the engine level (CLI option or Pascal API: `TGarbageCollector.Instance.MaxBytes`).
 

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -564,6 +564,20 @@ console.log("--max-memory (manual gc reclaims inside active calls)...");
   }
 }
 
+console.log("--max-memory (interpreter recursive expression pressure reclaims)...");
+{
+  const src = [
+    "const fib = (n) => n < 2 ? n : fib(n - 1) + fib(n - 2);",
+    "fib(24);",
+    "",
+  ].join("\n");
+
+  const { exitCode, json, stderr } = runLoaderJson(src, ["--max-memory=500000", "--compat-asi"], { timeout: 30_000 });
+  if (exitCode !== 0) throw new Error(`Recursive expression pressure exit code should be 0, got ${exitCode}: ${JSON.stringify(json)}${stderr}`);
+  if (json.files?.[0]?.result !== 46368) throw new Error(`Recursive expression pressure should return 46368, got ${json.files?.[0]?.result}`);
+  if ((json.memory?.gc?.collections ?? 0) <= 0) throw new Error(`Recursive expression pressure should report collections, got ${json.memory?.gc?.collections}`);
+}
+
 console.log("--max-memory (maxBytes readonly)...");
 {
   const res = await $`echo 'Goccia.gc.maxBytes = 999' | ${LOADER} --compat-asi 2>&1`.nothrow();

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -163,6 +163,31 @@ const
   FOR_IN_ENTRY_KEY = '__gocciaForInKey';
   FOR_IN_MAX_PROTOTYPE_CHAIN_DEPTH = 256;
 
+procedure AddValueRoot(var ARoots: TGocciaActiveRootFrame;
+  const AValue: TGocciaValue); inline;
+begin
+  if Assigned(AValue) then
+    ARoots.Add(AValue);
+end;
+
+procedure RootArgumentsFrom(var ARoots: TGocciaActiveRootFrame;
+  const AArguments: TGocciaArgumentsCollection; const AStartIndex: Integer);
+var
+  I: Integer;
+begin
+  for I := AStartIndex to AArguments.Length - 1 do
+    AddValueRoot(ARoots, AArguments.GetElement(I));
+end;
+
+procedure CollectInterpreterMemoryPressure(const AProtect: TGocciaValue); inline;
+var
+  GC: TGarbageCollector;
+begin
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) then
+    GC.CollectForMemoryPressure(AProtect);
+end;
+
 // Helper: create a non-owning copy of a statement list (AST owns the nodes)
 function CopyStatementList(const ASource: TObjectList<TGocciaASTNode>): TObjectList<TGocciaASTNode>;
 var
@@ -479,13 +504,17 @@ var
 begin
   Continuation := CurrentGeneratorContinuation;
   if Assigned(Continuation) and Continuation.TakeCompletedExpressionValue(AExpression, Result) then
+  begin
+    CollectInterpreterMemoryPressure(Result);
     Exit;
+  end;
   if AContext.CoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) then
     TGocciaCoverageTracker.Instance.RecordLineHit(
       AContext.CurrentFilePath, AExpression.Line);
   Result := AExpression.Evaluate(AContext);
   if Assigned(Continuation) then
     Continuation.SaveCompletedExpressionValue(AExpression, Result);
+  CollectInterpreterMemoryPressure(Result);
 end;
 
 function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
@@ -546,8 +575,12 @@ end;
 function EvaluateBinary(const ABinaryExpression: TGocciaBinaryExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   Left, Right: TGocciaValue;
+  Roots: TGocciaActiveRootFrame;
 begin
-  // Handle short-circuiting logical operators first
+  Roots.Initialize;
+  // Handle short-circuiting logical operators first. The left value is not
+  // needed across right-side evaluation when the right side is taken, and
+  // CollectForMemoryPressure protects the returned value directly.
   if ABinaryExpression.Operator = gttAnd then
   begin
     Left := EvaluateExpression(ABinaryExpression.Left, AContext);
@@ -568,6 +601,7 @@ begin
       Right := EvaluateExpression(ABinaryExpression.Right, AContext);
       Result := Right;  // Return right operand
     end;
+    CollectInterpreterMemoryPressure(Result);
     Exit;
   end
   else if ABinaryExpression.Operator = gttOr then
@@ -590,6 +624,7 @@ begin
       Right := EvaluateExpression(ABinaryExpression.Right, AContext);
       Result := Right;  // Return right operand
     end;
+    CollectInterpreterMemoryPressure(Result);
     Exit;
   end
   else if ABinaryExpression.Operator = gttNullishCoalescing then
@@ -613,6 +648,7 @@ begin
           ABinaryExpression.Column, 1);
       Result := Left;  // Return left operand for all other values (including falsy ones)
     end;
+    CollectInterpreterMemoryPressure(Result);
     Exit;
   end;
 
@@ -622,82 +658,96 @@ begin
   if not Assigned(CurrentGeneratorContinuation) or
      not CurrentGeneratorContinuation.TakeExpressionValue(ABinaryExpression, Left) then
     Left := EvaluateExpression(ABinaryExpression.Left, AContext);
+  AddValueRoot(Roots, Left);
   try
     Right := EvaluateExpression(ABinaryExpression.Right, AContext);
+    AddValueRoot(Roots, Right);
     if Assigned(CurrentGeneratorContinuation) then
       CurrentGeneratorContinuation.ClearExpressionValue(ABinaryExpression);
+
+    case ABinaryExpression.Operator of
+      gttPlus:
+        Result := EvaluateAddition(Left, Right);
+      gttMinus:
+        Result := EvaluateSubtraction(Left, Right);
+      gttStar:
+        Result := EvaluateMultiplication(Left, Right);
+      gttSlash:
+        Result := EvaluateDivision(Left, Right);
+      gttPercent:
+        Result := EvaluateModulo(Left, Right);
+      gttPower:
+        Result := EvaluateExponentiation(Left, Right);
+      gttEqual:
+        Result := TGocciaBooleanLiteralValue.FromBoolean(
+          Goccia.Arithmetic.IsStrictEqual(Left, Right));
+      gttNotEqual:
+        Result := TGocciaBooleanLiteralValue.FromBoolean(
+          Goccia.Arithmetic.IsNotStrictEqual(Left, Right));
+      gttLooseEqual:
+        Result := TGocciaBooleanLiteralValue.FromBoolean(
+          Goccia.Arithmetic.IsLooselyEqual(Left, Right));
+      gttLooseNotEqual:
+        Result := TGocciaBooleanLiteralValue.FromBoolean(
+          Goccia.Arithmetic.IsNotLooselyEqual(Left, Right));
+      gttLess:
+        Result := TGocciaBooleanLiteralValue.FromBoolean(
+          Goccia.Arithmetic.LessThan(Left, Right));
+      gttGreater:
+        Result := TGocciaBooleanLiteralValue.FromBoolean(
+          Goccia.Arithmetic.GreaterThan(Left, Right));
+      gttLessEqual:
+        Result := TGocciaBooleanLiteralValue.FromBoolean(
+          Goccia.Arithmetic.LessThanOrEqual(Left, Right));
+      gttGreaterEqual:
+        Result := TGocciaBooleanLiteralValue.FromBoolean(
+          Goccia.Arithmetic.GreaterThanOrEqual(Left, Right));
+      gttInstanceof:
+        Result := EvaluateInstanceof(Left, Right, IsObjectInstanceOfClass);
+      gttIn:
+        Result := EvaluateInOperator(Left, Right);
+      // Bitwise operators
+      gttBitwiseAnd:
+        Result := EvaluateBitwiseAnd(Left, Right);
+      gttBitwiseOr:
+        Result := EvaluateBitwiseOr(Left, Right);
+      gttBitwiseXor:
+        Result := EvaluateBitwiseXor(Left, Right);
+      gttLeftShift:
+        Result := EvaluateLeftShift(Left, Right);
+      gttRightShift:
+        Result := EvaluateRightShift(Left, Right);
+      gttUnsignedRightShift:
+        Result := EvaluateUnsignedRightShift(Left, Right);
+    else
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    end;
   except
     on E: EGocciaGeneratorYield do
     begin
       if Assigned(CurrentGeneratorContinuation) then
         CurrentGeneratorContinuation.SaveExpressionValue(ABinaryExpression, Left);
+      Roots.Clear;
+      raise;
+    end;
+    else
+    begin
+      Roots.Clear;
       raise;
     end;
   end;
-
-  case ABinaryExpression.Operator of
-    gttPlus:
-      Result := EvaluateAddition(Left, Right);
-    gttMinus:
-      Result := EvaluateSubtraction(Left, Right);
-    gttStar:
-      Result := EvaluateMultiplication(Left, Right);
-    gttSlash:
-      Result := EvaluateDivision(Left, Right);
-    gttPercent:
-      Result := EvaluateModulo(Left, Right);
-    gttPower:
-      Result := EvaluateExponentiation(Left, Right);
-    gttEqual:
-      Result := TGocciaBooleanLiteralValue.FromBoolean(
-        Goccia.Arithmetic.IsStrictEqual(Left, Right));
-    gttNotEqual:
-      Result := TGocciaBooleanLiteralValue.FromBoolean(
-        Goccia.Arithmetic.IsNotStrictEqual(Left, Right));
-    gttLooseEqual:
-      Result := TGocciaBooleanLiteralValue.FromBoolean(
-        Goccia.Arithmetic.IsLooselyEqual(Left, Right));
-    gttLooseNotEqual:
-      Result := TGocciaBooleanLiteralValue.FromBoolean(
-        Goccia.Arithmetic.IsNotLooselyEqual(Left, Right));
-    gttLess:
-      Result := TGocciaBooleanLiteralValue.FromBoolean(
-        Goccia.Arithmetic.LessThan(Left, Right));
-    gttGreater:
-      Result := TGocciaBooleanLiteralValue.FromBoolean(
-        Goccia.Arithmetic.GreaterThan(Left, Right));
-    gttLessEqual:
-      Result := TGocciaBooleanLiteralValue.FromBoolean(
-        Goccia.Arithmetic.LessThanOrEqual(Left, Right));
-    gttGreaterEqual:
-      Result := TGocciaBooleanLiteralValue.FromBoolean(
-        Goccia.Arithmetic.GreaterThanOrEqual(Left, Right));
-    gttInstanceof:
-      Result := EvaluateInstanceof(Left, Right, IsObjectInstanceOfClass);
-    gttIn:
-      Result := EvaluateInOperator(Left, Right);
-    // Bitwise operators
-    gttBitwiseAnd:
-      Result := EvaluateBitwiseAnd(Left, Right);
-    gttBitwiseOr:
-      Result := EvaluateBitwiseOr(Left, Right);
-    gttBitwiseXor:
-      Result := EvaluateBitwiseXor(Left, Right);
-    gttLeftShift:
-      Result := EvaluateLeftShift(Left, Right);
-    gttRightShift:
-      Result := EvaluateRightShift(Left, Right);
-    gttUnsignedRightShift:
-      Result := EvaluateUnsignedRightShift(Left, Right);
-  else
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  end;
+  AddValueRoot(Roots, Result);
+  CollectInterpreterMemoryPressure(Result);
+  Roots.Clear;
 end;
 
 function EvaluateUnary(const AUnaryExpression: TGocciaUnaryExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   Operand: TGocciaValue;
+  Roots: TGocciaActiveRootFrame;
 begin
+  Roots.Initialize;
+  try
   // Special handling for delete operator
   if AUnaryExpression.Operator = gttDelete then
   begin
@@ -710,6 +760,7 @@ begin
   begin
     try
       Operand := EvaluateExpression(AUnaryExpression.Operand, AContext);
+      AddValueRoot(Roots, Operand);
     except
       on E: TGocciaReferenceError do
       begin
@@ -723,6 +774,7 @@ begin
   end;
 
   Operand := EvaluateExpression(AUnaryExpression.Operand, AContext);
+  AddValueRoot(Roots, Operand);
 
   case AUnaryExpression.Operator of
     gttNot:
@@ -738,6 +790,7 @@ begin
         // instead of being silently coerced to NaN by the boxed
         // object's ToNumberLiteral.
         Operand := ToPrimitive(Operand);
+        AddValueRoot(Roots, Operand);
         if Operand is TGocciaSymbolValue then
           ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
         // ES2026 §6.1.6.2.1 BigInt::unaryMinus
@@ -775,6 +828,7 @@ begin
       // surface the spec-mandated TypeError instead of silently
       // producing a number from the boxed object's coercion path.
       Operand := ToPrimitive(Operand);
+      AddValueRoot(Roots, Operand);
       if Operand is TGocciaSymbolValue then
         ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
       // ES2026 §7.1.4: unary + on BigInt throws TypeError
@@ -790,6 +844,11 @@ begin
       Result := EvaluateBitwiseNot(Operand);
   else
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  end;
+  AddValueRoot(Roots, Result);
+  CollectInterpreterMemoryPressure(Result);
+  finally
+    Roots.Clear;
   end;
 end;
 
@@ -941,12 +1000,14 @@ var
   SuperClassValue, SuperResult: TGocciaValue;
   MemberExpr: TGocciaMemberExpression;
   SpreadValue: TGocciaValue;
+  ArgumentValue: TGocciaValue;
   CalleeName: string;
-  I: Integer;
+  FirstAddedIndex, I: Integer;
   ThisScope: TGocciaScope;
   ConstructorThisValue: TGocciaValue;
   CurrentCtorClassValue: TGocciaValue;
   CurrentCtorClass: TGocciaClassValue;
+  Roots: TGocciaActiveRootFrame;
   procedure InitializeReplacementThis(const AReplacement: TGocciaObjectValue;
     const APreviousThis: TGocciaValue);
   begin
@@ -960,6 +1021,7 @@ var
       iimEagerReplacement);
   end;
 begin
+  Roots.Initialize;
   CheckExecutionTimeout;
   IncrementInstructionCounter;
   CheckInstructionLimit;
@@ -967,6 +1029,7 @@ begin
   if ACallExpression.Callee is TGocciaSuperExpression then
   begin
     SuperClassValue := EvaluateExpression(ACallExpression.Callee, AContext);
+    AddValueRoot(Roots, SuperClassValue);
     if SuperClassValue is TGocciaClassValue then
       SuperClass := TGocciaClassValue(SuperClassValue)
     else
@@ -977,6 +1040,7 @@ begin
       AContext.OnError('super() can only be called within a method with a superclass',
         ACallExpression.Line, ACallExpression.Column);
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Roots.Clear;
       Exit;
     end;
 
@@ -988,10 +1052,17 @@ begin
         if ArgumentExpr is TGocciaSpreadExpression then
         begin
           SpreadValue := EvaluateExpression(TGocciaSpreadExpression(ArgumentExpr).Argument, AContext);
+          AddValueRoot(Roots, SpreadValue);
+          FirstAddedIndex := Arguments.Length;
           SpreadIterableIntoArgs(SpreadValue, Arguments);
+          RootArgumentsFrom(Roots, Arguments, FirstAddedIndex);
         end
         else
-          Arguments.Add(EvaluateExpression(ArgumentExpr, AContext));
+        begin
+          ArgumentValue := EvaluateExpression(ArgumentExpr, AContext);
+          Arguments.Add(ArgumentValue);
+          AddValueRoot(Roots, ArgumentValue);
+        end;
       end;
 
       if Assigned(SuperClass) and Assigned(SuperClass.ConstructorMethod) then
@@ -1059,7 +1130,11 @@ begin
       end;
     finally
       Arguments.Free;
+      Roots.Clear;
     end;
+    AddValueRoot(Roots, Result);
+    CollectInterpreterMemoryPressure(Result);
+    Roots.Clear;
     Exit;
   end;
 
@@ -1072,15 +1147,20 @@ begin
       // Super method calls: evaluate normally
       Callee := EvaluateExpression(ACallExpression.Callee, AContext);
       ThisValue := AContext.Scope.ThisValue;  // Use current instance's 'this'
+      AddValueRoot(Roots, Callee);
+      AddValueRoot(Roots, ThisValue);
     end
     else
     begin
       // Regular method calls: use overloaded function to get both method and object
       Callee := EvaluateMember(MemberExpr, AContext, ThisValue);
+      AddValueRoot(Roots, Callee);
+      AddValueRoot(Roots, ThisValue);
       if MemberExpr.Optional and
          ((ThisValue is TGocciaNullLiteralValue) or (ThisValue is TGocciaUndefinedLiteralValue)) then
       begin
         Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+        Roots.Clear;
         Exit;
       end;
     end;
@@ -1089,6 +1169,8 @@ begin
   begin
     // Private method calls: use overloaded function to get both method and object
     Callee := EvaluatePrivateMember(TGocciaPrivateMemberExpression(ACallExpression.Callee), AContext, ThisValue);
+    AddValueRoot(Roots, Callee);
+    AddValueRoot(Roots, ThisValue);
   end
   else
   begin
@@ -1102,12 +1184,15 @@ begin
       Callee := EvaluateExpression(ACallExpression.Callee, AContext);
       ThisValue := TGocciaUndefinedLiteralValue.UndefinedValue;
     end;
+    AddValueRoot(Roots, Callee);
+    AddValueRoot(Roots, ThisValue);
   end;
 
   if ACallExpression.Optional and
      ((Callee is TGocciaNullLiteralValue) or (Callee is TGocciaUndefinedLiteralValue)) then
   begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Roots.Clear;
     Exit;
   end;
 
@@ -1118,11 +1203,16 @@ begin
       if ArgumentExpr is TGocciaSpreadExpression then
       begin
         SpreadValue := EvaluateExpression(TGocciaSpreadExpression(ArgumentExpr).Argument, AContext);
+        AddValueRoot(Roots, SpreadValue);
+        FirstAddedIndex := Arguments.Length;
         SpreadIterableIntoArgs(SpreadValue, Arguments);
+        RootArgumentsFrom(Roots, Arguments, FirstAddedIndex);
       end
       else
       begin
-        Arguments.Add(EvaluateExpression(ArgumentExpr, AContext));
+        ArgumentValue := EvaluateExpression(ArgumentExpr, AContext);
+        Arguments.Add(ArgumentValue);
+        AddValueRoot(Roots, ArgumentValue);
       end;
     end;
 
@@ -1191,9 +1281,12 @@ begin
       if Assigned(TGocciaCallStack.Instance) then
         TGocciaCallStack.Instance.Pop;
     end;
+    AddValueRoot(Roots, Result);
+    CollectInterpreterMemoryPressure(Result);
 
   finally
     Arguments.Free;
+    Roots.Clear;
   end;
 end;
 
@@ -4464,8 +4557,9 @@ var
   Callee: TGocciaValue;
   Arguments: TGocciaArgumentsCollection;
   SpreadValue: TGocciaValue;
+  ArgumentValue: TGocciaValue;
   CalleeName: string;
-  I: Integer;
+  FirstAddedIndex, I: Integer;
   Instance: TGocciaInstanceValue;
   NativeInstance: TGocciaObjectValue;
   WalkClass, ClassValue: TGocciaClassValue;
@@ -4476,11 +4570,14 @@ var
   PrototypeValue: TGocciaValue;
   ReceiverPrototype: TGocciaObjectValue;
   ReceiverInstance: TGocciaObjectValue;
+  Roots: TGocciaActiveRootFrame;
 begin
+  Roots.Initialize;
   CheckExecutionTimeout;
   IncrementInstructionCounter;
   CheckInstructionLimit;
   Callee := EvaluateExpression(ANewExpression.Callee, AContext);
+  AddValueRoot(Roots, Callee);
 
   Arguments := TGocciaArgumentsCollection.Create;
   try
@@ -4489,10 +4586,17 @@ begin
       if ANewExpression.Arguments[I] is TGocciaSpreadExpression then
       begin
         SpreadValue := EvaluateExpression(TGocciaSpreadExpression(ANewExpression.Arguments[I]).Argument, AContext);
+        AddValueRoot(Roots, SpreadValue);
+        FirstAddedIndex := Arguments.Length;
         SpreadIterableIntoArgs(SpreadValue, Arguments);
+        RootArgumentsFrom(Roots, Arguments, FirstAddedIndex);
       end
       else
-        Arguments.Add(EvaluateExpression(ANewExpression.Arguments[I], AContext));
+      begin
+        ArgumentValue := EvaluateExpression(ANewExpression.Arguments[I], AContext);
+        Arguments.Add(ArgumentValue);
+        AddValueRoot(Roots, ArgumentValue);
+      end;
     end;
 
     if Callee is TGocciaClassValue then
@@ -4590,8 +4694,11 @@ begin
       if Assigned(TGocciaCallStack.Instance) then
         TGocciaCallStack.Instance.Pop;
     end;
+    AddValueRoot(Roots, Result);
+    CollectInterpreterMemoryPressure(Result);
   finally
     Arguments.Free;
+    Roots.Clear;
   end;
 end;
 

--- a/source/units/Goccia.GarbageCollector.pas
+++ b/source/units/Goccia.GarbageCollector.pas
@@ -40,6 +40,15 @@ type
     Added: Boolean;
   end;
 
+  TGocciaActiveRootFrame = record
+  private
+    FCount: Integer;
+  public
+    procedure Initialize; inline;
+    procedure Add(const AObject: TGCManagedObject);
+    procedure Clear;
+  end;
+
   TGarbageCollector = class
   private
     FManagedObjects: TGCManagedObjectList;
@@ -118,6 +127,9 @@ type
     // active root stack so a stack-held object survives the collection.
     procedure CollectIfNeeded(const AProtect: TGCManagedObject); overload;
 
+    function NeedsMemoryPressureCollection: Boolean;
+    procedure CollectForMemoryPressure(const AProtect: TGCManagedObject);
+
     // Young-generation collection: pre-marks objects before AWatermark
     // as surviving, then runs mark-and-sweep. MarkReferences on old
     // objects short-circuits via "if GCMarked then Exit", and the sweep
@@ -162,6 +174,8 @@ const
   DEFAULT_MAX_BYTES   = 512 * 1024 * 1024;         { 512 MB fallback }
   MAX_BYTES_CAP_64BIT = Int64(8192) * 1024 * 1024;  { 8 GB cap for 64-bit }
   MAX_BYTES_CAP_32BIT = 700 * 1024 * 1024;          { 700 MB cap for 32-bit }
+  MEMORY_PRESSURE_COLLECTION_MIN_RESERVE = 16 * 1024;
+  MEMORY_PRESSURE_COLLECTION_MAX_RESERVE = 1024 * 1024;
 
 function DetectDefaultMaxBytes: Int64;
 procedure InitializeTempRoot(var ARoot: TGocciaTempRoot); inline;
@@ -295,6 +309,43 @@ begin
   end;
   ARoot.ObjectValue := nil;
   ARoot.Added := False;
+end;
+
+{ TGocciaActiveRootFrame }
+
+procedure TGocciaActiveRootFrame.Initialize;
+begin
+  FCount := 0;
+end;
+
+procedure TGocciaActiveRootFrame.Add(const AObject: TGCManagedObject);
+var
+  GC: TGarbageCollector;
+begin
+  if not Assigned(AObject) then
+    Exit;
+  GC := TGarbageCollector.Instance;
+  if not Assigned(GC) then
+    Exit;
+  GC.PushActiveRoot(AObject);
+  Inc(FCount);
+end;
+
+procedure TGocciaActiveRootFrame.Clear;
+var
+  GC: TGarbageCollector;
+begin
+  if FCount <= 0 then
+    Exit;
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) then
+    while FCount > 0 do
+    begin
+      GC.PopActiveRoot;
+      Dec(FCount);
+    end
+  else
+    FCount := 0;
 end;
 
 { TGarbageCollector }
@@ -694,6 +745,46 @@ begin
   try
     Collect;
   finally
+    if Assigned(AProtect) then
+      FActiveRootStack.Delete(FActiveRootStack.Count - 1);
+  end;
+end;
+
+function TGarbageCollector.NeedsMemoryPressureCollection: Boolean;
+var
+  Reserve: Int64;
+begin
+  Result := False;
+  if not FEnabled or (FMaxBytes <= 0) or FCollecting or FMemoryLimitFiring then
+    Exit;
+
+  Reserve := FMaxBytes div 8;
+  if Reserve < MEMORY_PRESSURE_COLLECTION_MIN_RESERVE then
+    Reserve := MEMORY_PRESSURE_COLLECTION_MIN_RESERVE;
+  if Reserve > MEMORY_PRESSURE_COLLECTION_MAX_RESERVE then
+    Reserve := MEMORY_PRESSURE_COLLECTION_MAX_RESERVE;
+  if Reserve >= FMaxBytes then
+    Reserve := FMaxBytes div 2;
+
+  Result := FBytesAllocated >= (FMaxBytes - Reserve);
+end;
+
+procedure TGarbageCollector.CollectForMemoryPressure(
+  const AProtect: TGCManagedObject);
+var
+  WasFiring: Boolean;
+begin
+  if not NeedsMemoryPressureCollection then
+    Exit;
+
+  if Assigned(AProtect) then
+    FActiveRootStack.Add(AProtect);
+  WasFiring := FMemoryLimitFiring;
+  FMemoryLimitFiring := True;
+  try
+    Collect;
+  finally
+    FMemoryLimitFiring := WasFiring;
     if Assigned(AProtect) then
       FActiveRootStack.Delete(FActiveRootStack.Count - 1);
   end;

--- a/tests/built-ins/WeakRef/gc.js
+++ b/tests/built-ins/WeakRef/gc.js
@@ -47,4 +47,95 @@ describe.runIf(hasGoccia)("WeakRef GC behavior", () => {
       expect(ref.deref().marker).toBe("live");
     });
   });
+
+  test("caught call argument errors do not keep argument roots alive", () => {
+    let target = { marker: "call-root" };
+    const ref = new WeakRef(target);
+    const callee = () => undefined;
+    const thrower = () => {
+      throw new Error("boom");
+    };
+
+    try {
+      callee(target, thrower());
+    } catch (e) {}
+
+    target = null;
+
+    const result = new Promise((resolve) => {
+      queueMicrotask(() => {});
+      queueMicrotask(() => {
+        Goccia.gc();
+      });
+      queueMicrotask(() => {
+        Goccia.gc();
+        resolve(ref.deref());
+      });
+    });
+
+    return result.then((value) => {
+      expect(value).toBe(undefined);
+    });
+  });
+
+  test("caught binary coercion errors do not keep operand roots alive", () => {
+    let target = { marker: "binary-root" };
+    const ref = new WeakRef(target);
+    const thrower = {
+      [Symbol.toPrimitive]: () => {
+        throw new Error("boom");
+      },
+    };
+
+    try {
+      target + thrower;
+    } catch (e) {}
+
+    target = null;
+
+    const result = new Promise((resolve) => {
+      queueMicrotask(() => {});
+      queueMicrotask(() => {
+        Goccia.gc();
+      });
+      queueMicrotask(() => {
+        Goccia.gc();
+        resolve(ref.deref());
+      });
+    });
+
+    return result.then((value) => {
+      expect(value).toBe(undefined);
+    });
+  });
+
+  test("caught constructor argument errors do not keep argument roots alive", () => {
+    let target = { marker: "new-root" };
+    const ref = new WeakRef(target);
+    const thrower = () => {
+      throw new Error("boom");
+    };
+    class Holder {}
+
+    try {
+      new Holder(target, thrower());
+    } catch (e) {}
+
+    target = null;
+
+    const result = new Promise((resolve) => {
+      queueMicrotask(() => {});
+      queueMicrotask(() => {
+        Goccia.gc();
+      });
+      queueMicrotask(() => {
+        Goccia.gc();
+        resolve(ref.deref());
+      });
+    });
+
+    return result.then((value) => {
+      expect(value).toBe(undefined);
+    });
+  });
 });

--- a/tests/built-ins/global-properties/goccia.js
+++ b/tests/built-ins/global-properties/goccia.js
@@ -45,5 +45,14 @@ describe.runIf(hasGoccia)("Goccia global", () => {
       Goccia.gc();
       expect(array.t).toBe(3);
     });
+
+    test("gc preserves nested recursive binary expression temporaries", () => {
+      const fib = (n) => {
+        Goccia.gc();
+        return n < 2 ? n : fib(n - 1) + fib(n - 2);
+      };
+
+      expect(fib(8)).toBe(21);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add interpreter memory-pressure safe points that collect before the hard `--max-memory` allocation guard fires.
- Root expression temporaries, call/new arguments, and binary/unary operands that are held in Pascal locals across nested evaluation or user-code coercion.
- Add regressions for recursive interpreter memory pressure, explicit GC during nested binary recursion, and caught-exception root cleanup.
- Closes #511.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional verification run locally:

- `./build.pas loader testrunner`
- `./build/GocciaTestRunner tests/built-ins/WeakRef/gc.js --no-progress --exit-on-first-failure`
- `./build/GocciaTestRunner tests/built-ins/global-properties/goccia.js --no-progress --exit-on-first-failure`
- `./build/GocciaTestRunner tests/language/functions/stack-depth-limit.js --no-progress --exit-on-first-failure`
- `./build/GocciaTestRunner tests --no-progress --exit-on-first-failure`
- `bun run scripts/test-cli.ts`
- `./format.pas --check`
- `git diff --check`