### PR TITLE
Extract shared resource container infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -828,6 +828,9 @@ jobs:
       - name: Check app-specific CLI features
         run: bun run scripts/test-cli-apps.ts
 
+      - name: Check embedded resource CLI behaviour
+        run: bun run scripts/test-cli-embedded-resources.ts
+
       - name: Check Windows TLS dependencies
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -267,6 +267,9 @@ jobs:
       - name: Check app-specific CLI features
         run: bun run scripts/test-cli-apps.ts
 
+      - name: Check embedded resource CLI behaviour
+        run: bun run scripts/test-cli-embedded-resources.ts
+
   test262:
     needs: build
     runs-on: ubuntu-latest

--- a/scripts/generate-intl-data.js
+++ b/scripts/generate-intl-data.js
@@ -4,6 +4,12 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
+const {
+  buildResourceContainer,
+  generateResourceFile,
+  pascalUnitNameForOutput,
+  resourceFileForOutput,
+} = require("./lib/resource-container");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const DEFAULT_OUTPUT = path.join(
@@ -30,10 +36,6 @@ const RELATIVE_TIME_UNITS = [
 ];
 const RESOURCE_NAME = "GOCCIA_CLDR";
 const RESOURCE_MAGIC = Buffer.from("GOCCIACL", "ascii");
-const RESOURCE_FORMAT_VERSION = 1;
-const RESOURCE_HEADER_SIZE = RESOURCE_MAGIC.length + 6 * 4;
-const RESOURCE_ENTRY_SIZE = 4 * 4;
-const PASCAL_UNIT_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function usage() {
   console.error("Usage: node scripts/generate-intl-data.js [cldr-version] [output-file]");
@@ -47,46 +49,14 @@ function parseArguments() {
 
   const cldrVersion = process.argv[2] || DEFAULT_CLDR_VERSION;
   const outputFile = process.argv[3] ? path.resolve(process.argv[3]) : DEFAULT_OUTPUT;
-  const outputResourceFile = resourceFileForOutput(outputFile);
-  const unitName = pascalUnitNameForOutput(outputFile);
+  const outputResourceFile = resourceFileForOutput(outputFile, "Intl data");
+  const unitName = pascalUnitNameForOutput(outputFile, "Intl data");
 
   if (path.resolve(outputFile) === path.resolve(outputResourceFile)) {
     throw new Error(`Refusing to use ${outputFile} for both Pascal and resource output`);
   }
 
   return { cldrVersion, outputFile, outputResourceFile, unitName };
-}
-
-function pascalUnitNameForOutput(outputFile) {
-  if (path.extname(outputFile).toLowerCase() !== ".pas") {
-    throw new Error(`Intl data output must be a .pas file: ${outputFile}`);
-  }
-
-  const unitName = path.basename(outputFile, path.extname(outputFile));
-  if (unitName.length === 0) {
-    throw new Error(`Intl data output must have a non-empty Pascal unit name: ${outputFile}`);
-  }
-
-  const unitNameParts = unitName.split(".");
-  if (
-    unitNameParts.length === 0 ||
-    unitNameParts.some((unitNamePart) => !PASCAL_UNIT_IDENTIFIER_PATTERN.test(unitNamePart))
-  ) {
-    throw new Error(`Intl data output basename is not a valid Pascal unit name: ${unitName}`);
-  }
-
-  return unitName;
-}
-
-function resourceFileForOutput(outputFile) {
-  if (path.extname(outputFile).toLowerCase() !== ".pas") {
-    throw new Error(`Intl data output must be a .pas file: ${outputFile}`);
-  }
-
-  return path.join(
-    path.dirname(outputFile),
-    `${path.basename(outputFile, path.extname(outputFile))}.res`,
-  );
 }
 
 function downloadCldrPackages(cldrVersion, outputDirectory) {
@@ -658,77 +628,6 @@ function packSections(sections) {
   };
 }
 
-function writeUInt32LE(buffer, value, offset) {
-  if (value < 0 || value > 0xffffffff) {
-    throw new Error(`Resource integer ${value} is outside UInt32 range`);
-  }
-  buffer.writeUInt32LE(value, offset);
-}
-
-function buildResourceContainer(version, entries, blob) {
-  const versionBuffer = Buffer.from(version, "utf8");
-  const nameBuffers = entries.map((entry) => Buffer.from(entry.name, "utf8"));
-  const namesByteCount = nameBuffers.reduce((total, nameBuffer) => total + nameBuffer.length, 0);
-  const entryTableByteCount = entries.length * RESOURCE_ENTRY_SIZE;
-  const totalByteCount =
-    RESOURCE_HEADER_SIZE +
-    versionBuffer.length +
-    entryTableByteCount +
-    namesByteCount +
-    blob.length;
-
-  const resource = Buffer.alloc(totalByteCount);
-  let offset = 0;
-
-  RESOURCE_MAGIC.copy(resource, offset);
-  offset += RESOURCE_MAGIC.length;
-  writeUInt32LE(resource, RESOURCE_FORMAT_VERSION, offset); offset += 4;
-  writeUInt32LE(resource, versionBuffer.length, offset); offset += 4;
-  writeUInt32LE(resource, entries.length, offset); offset += 4;
-  writeUInt32LE(resource, namesByteCount, offset); offset += 4;
-  writeUInt32LE(resource, blob.length, offset); offset += 4;
-  writeUInt32LE(resource, 0, offset); offset += 4;
-
-  versionBuffer.copy(resource, offset);
-  offset += versionBuffer.length;
-
-  let nameOffset = 0;
-  const namesOffset = RESOURCE_HEADER_SIZE + versionBuffer.length + entryTableByteCount;
-  for (let index = 0; index < entries.length; index += 1) {
-    const entry = entries[index];
-    const nameBuffer = nameBuffers[index];
-    writeUInt32LE(resource, nameOffset, offset); offset += 4;
-    writeUInt32LE(resource, nameBuffer.length, offset); offset += 4;
-    writeUInt32LE(resource, entry.offset, offset); offset += 4;
-    writeUInt32LE(resource, entry.length, offset); offset += 4;
-    nameBuffer.copy(resource, namesOffset + nameOffset);
-    nameOffset += nameBuffer.length;
-  }
-
-  blob.copy(resource, namesOffset + namesByteCount);
-  return resource;
-}
-
-function generateResourceFile(resourceBytes, outputResourceFile) {
-  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "goccia-cldrresource-"));
-  const resourceDataFile = path.join(temporaryDirectory, "intl-data.bin");
-  const resourceScriptFile = path.join(temporaryDirectory, "intl-data.rc");
-
-  try {
-    fs.writeFileSync(resourceDataFile, resourceBytes);
-    fs.writeFileSync(
-      resourceScriptFile,
-      `${RESOURCE_NAME} RCDATA "${resourceDataFile.replaceAll("\\", "\\\\")}"\n`,
-      "utf8",
-    );
-    execFileSync("fpcres", ["-of", "res", resourceScriptFile, "-o", outputResourceFile], {
-      stdio: "inherit",
-    });
-  } finally {
-    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
-  }
-}
-
 function generatePascalUnit(cldrVersion, sectionCount, blobByteCount, unitName, resourceReference) {
   return `unit ${unitName};
 
@@ -771,6 +670,7 @@ function main() {
 
     const { indexedEntries, blob } = packSections(sections);
     const resource = buildResourceContainer(
+      RESOURCE_MAGIC,
       cldrVersion,
       indexedEntries,
       blob,
@@ -785,7 +685,11 @@ function main() {
 
     fs.mkdirSync(path.dirname(outputFile), { recursive: true });
     fs.writeFileSync(outputFile, pascal, "utf8");
-    generateResourceFile(resource, outputResourceFile);
+    generateResourceFile(resource, outputResourceFile, RESOURCE_NAME, {
+      temporaryDirectoryPrefix: "goccia-cldrresource-",
+      dataFileName: "intl-data.bin",
+      scriptFileName: "intl-data.rc",
+    });
 
     console.log(
       `Generated ${path.relative(REPO_ROOT, outputFile)} and ${path.relative(REPO_ROOT, outputResourceFile)} with ${indexedEntries.length} sections, ${blob.length} bytes, CLDR ${cldrVersion}`,

--- a/scripts/generate-timezone-data.js
+++ b/scripts/generate-timezone-data.js
@@ -1,11 +1,17 @@
 #!/usr/bin/env node
 
 const fs = require("fs");
-const http = require("http");
-const https = require("https");
 const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
+const {
+  buildResourceContainer,
+  downloadFileToDisk,
+  generateResourceFile,
+  isUrl,
+  pascalUnitNameForOutput,
+  resourceFileForOutput,
+} = require("./lib/resource-container");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const DEFAULT_OUTPUT = path.join(
@@ -32,12 +38,6 @@ const SKIPPED_FILES = new Set(["localtime", "posixrules"]);
 const TZIF_MAGIC = Buffer.from("TZif");
 const RESOURCE_NAME = "GOCCIA_TZDATA";
 const RESOURCE_MAGIC = Buffer.from("GOCCIATZ", "ascii");
-const RESOURCE_FORMAT_VERSION = 1;
-const RESOURCE_HEADER_SIZE = RESOURCE_MAGIC.length + 6 * 4;
-const RESOURCE_ENTRY_SIZE = 4 * 4;
-const MAX_REDIRECTS = 5;
-const DOWNLOAD_TIMEOUT_MS = 30000;
-const PASCAL_UNIT_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function usage() {
   console.error("Usage: node scripts/generate-timezone-data.js [zoneinfo-dir|tzdata.tar.gz|url] [output-file]");
@@ -51,35 +51,14 @@ function parseArguments() {
 
   const source = process.argv[2] || IANA_TZDATA_LATEST_URL;
   const outputFile = process.argv[3] ? path.resolve(process.argv[3]) : DEFAULT_OUTPUT;
-  const outputResourceFile = resourceFileForOutput(outputFile);
-  const unitName = pascalUnitNameForOutput(outputFile);
+  const outputResourceFile = resourceFileForOutput(outputFile, "Timezone data");
+  const unitName = pascalUnitNameForOutput(outputFile, "Timezone data");
 
   if (path.resolve(outputFile) === path.resolve(outputResourceFile)) {
     throw new Error(`Refusing to use ${outputFile} for both Pascal and resource output`);
   }
 
   return { source, outputFile, outputResourceFile, unitName };
-}
-
-function pascalUnitNameForOutput(outputFile) {
-  if (path.extname(outputFile).toLowerCase() !== ".pas") {
-    throw new Error(`Timezone data output must be a .pas file: ${outputFile}`);
-  }
-
-  const unitName = path.basename(outputFile, path.extname(outputFile));
-  if (unitName.length === 0) {
-    throw new Error(`Timezone data output must have a non-empty Pascal unit name: ${outputFile}`);
-  }
-
-  const unitNameParts = unitName.split(".");
-  if (
-    unitNameParts.length === 0 ||
-    unitNameParts.some((unitNamePart) => !PASCAL_UNIT_IDENTIFIER_PATTERN.test(unitNamePart))
-  ) {
-    throw new Error(`Timezone data output basename is not a valid Pascal unit name: ${unitName}`);
-  }
-
-  return unitName;
 }
 
 function isTimeZoneInformationFile(buffer) {
@@ -107,149 +86,6 @@ function readVersion(zoneInfoDir) {
   }
 
   return "unknown";
-}
-
-function isUrl(source) {
-  return /^https?:\/\//.test(source);
-}
-
-function downloadFile(url, outputFile) {
-  return new Promise((resolve, reject) => {
-    function get(currentUrl, redirectsLeft) {
-      if (redirectsLeft < 0) {
-        reject(new Error(`Too many redirects while downloading ${currentUrl}`));
-        return;
-      }
-
-      const protocol = new URL(currentUrl).protocol;
-      const client = protocol === "http:" ? http : protocol === "https:" ? https : null;
-      if (!client) {
-        reject(new Error(`Unsupported URL protocol ${protocol} while downloading ${currentUrl}`));
-        return;
-      }
-
-      let file = null;
-      let response = null;
-      let req = null;
-      let settled = false;
-
-      function cleanup() {
-        if (req) {
-          req.setTimeout(0);
-          req.removeListener("timeout", onTimeout);
-          req.removeListener("error", onRequestError);
-        }
-
-        if (response && response.socket) {
-          response.socket.setTimeout(0);
-          response.socket.removeListener("timeout", onTimeout);
-        }
-
-        if (response) {
-          response.removeListener("error", onResponseError);
-        }
-
-        if (file) {
-          file.removeListener("finish", onFileFinish);
-          file.removeListener("error", onFileError);
-        }
-      }
-
-      function abortRequest() {
-        req.once("error", () => {});
-        req.abort();
-      }
-
-      function fail(error) {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        cleanup();
-        if (file) {
-          file.destroy();
-        }
-        reject(error);
-      }
-
-      function onTimeout() {
-        abortRequest();
-        fail(new Error(`Timeout downloading ${currentUrl}`));
-      }
-
-      function onRequestError(error) {
-        fail(error);
-      }
-
-      function onResponseError(error) {
-        fail(error);
-      }
-
-      function onFileError(error) {
-        abortRequest();
-        fail(error);
-      }
-
-      function onFileFinish() {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        cleanup();
-        file.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-
-          resolve();
-        });
-      }
-
-      req = client
-        .get(currentUrl, (downloadResponse) => {
-          response = downloadResponse;
-          response.on("error", onResponseError);
-          if (response.socket) {
-            response.socket.setTimeout(DOWNLOAD_TIMEOUT_MS, onTimeout);
-          }
-
-          if (
-            response.statusCode >= 300 &&
-            response.statusCode < 400 &&
-            response.headers.location
-          ) {
-            cleanup();
-            response.resume();
-            if (redirectsLeft <= 0) {
-              reject(new Error(`Too many redirects while downloading ${currentUrl}`));
-              return;
-            }
-            get(new URL(response.headers.location, currentUrl).toString(), redirectsLeft - 1);
-            return;
-          }
-
-          if (response.statusCode !== 200) {
-            cleanup();
-            response.resume();
-            reject(new Error(`HTTP ${response.statusCode} while downloading ${currentUrl}`));
-            return;
-          }
-
-          file = fs.createWriteStream(outputFile);
-          response.pipe(file);
-          file.on("finish", onFileFinish);
-          file.on("error", onFileError);
-        })
-        .on("error", onRequestError);
-
-      req.setTimeout(DOWNLOAD_TIMEOUT_MS, onTimeout);
-    }
-
-    get(url, MAX_REDIRECTS);
-  });
 }
 
 function extractTarball(tarballPath, outputDirectory) {
@@ -300,7 +136,7 @@ async function prepareZoneInfoSource(source) {
 
   try {
     if (isUrl(source)) {
-      await downloadFile(source, tarballPath);
+      await downloadFileToDisk(source, tarballPath);
     } else {
       fs.copyFileSync(path.resolve(source), tarballPath);
     }
@@ -416,89 +252,6 @@ function packEntries(entries) {
   };
 }
 
-function writeUInt32LE(buffer, value, offset) {
-  if (value < 0 || value > 0xffffffff) {
-    throw new Error(`Resource integer ${value} is outside UInt32 range`);
-  }
-
-  buffer.writeUInt32LE(value, offset);
-}
-
-function buildResourceContainer(version, entries, blob) {
-  const versionBuffer = Buffer.from(version, "utf8");
-  const nameBuffers = entries.map((entry) => Buffer.from(entry.name, "utf8"));
-  const namesByteCount = nameBuffers.reduce((total, nameBuffer) => total + nameBuffer.length, 0);
-  const entryTableByteCount = entries.length * RESOURCE_ENTRY_SIZE;
-  const totalByteCount =
-    RESOURCE_HEADER_SIZE +
-    versionBuffer.length +
-    entryTableByteCount +
-    namesByteCount +
-    blob.length;
-
-  const resource = Buffer.alloc(totalByteCount);
-  let offset = 0;
-
-  RESOURCE_MAGIC.copy(resource, offset);
-  offset += RESOURCE_MAGIC.length;
-  writeUInt32LE(resource, RESOURCE_FORMAT_VERSION, offset); offset += 4;
-  writeUInt32LE(resource, versionBuffer.length, offset); offset += 4;
-  writeUInt32LE(resource, entries.length, offset); offset += 4;
-  writeUInt32LE(resource, namesByteCount, offset); offset += 4;
-  writeUInt32LE(resource, blob.length, offset); offset += 4;
-  writeUInt32LE(resource, 0, offset); offset += 4;
-
-  versionBuffer.copy(resource, offset);
-  offset += versionBuffer.length;
-
-  let nameOffset = 0;
-  const namesOffset = RESOURCE_HEADER_SIZE + versionBuffer.length + entryTableByteCount;
-  for (let index = 0; index < entries.length; index += 1) {
-    const entry = entries[index];
-    const nameBuffer = nameBuffers[index];
-    writeUInt32LE(resource, nameOffset, offset); offset += 4;
-    writeUInt32LE(resource, nameBuffer.length, offset); offset += 4;
-    writeUInt32LE(resource, entry.offset, offset); offset += 4;
-    writeUInt32LE(resource, entry.length, offset); offset += 4;
-    nameBuffer.copy(resource, namesOffset + nameOffset);
-    nameOffset += nameBuffer.length;
-  }
-
-  blob.copy(resource, namesOffset + namesByteCount);
-  return resource;
-}
-
-function resourceFileForOutput(outputFile) {
-  if (path.extname(outputFile).toLowerCase() !== ".pas") {
-    throw new Error(`Timezone data output must be a .pas file: ${outputFile}`);
-  }
-
-  return path.join(
-    path.dirname(outputFile),
-    `${path.basename(outputFile, path.extname(outputFile))}.res`,
-  );
-}
-
-function generateResourceFile(resourceBytes, outputResourceFile) {
-  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "goccia-tzresource-"));
-  const resourceDataFile = path.join(temporaryDirectory, "timezone-data.bin");
-  const resourceScriptFile = path.join(temporaryDirectory, "timezone-data.rc");
-
-  try {
-    fs.writeFileSync(resourceDataFile, resourceBytes);
-    fs.writeFileSync(
-      resourceScriptFile,
-      `${RESOURCE_NAME} RCDATA "${resourceDataFile.replaceAll("\\", "\\\\")}"\n`,
-      "utf8",
-    );
-    execFileSync("fpcres", ["-of", "res", resourceScriptFile, "-o", outputResourceFile], {
-      stdio: "inherit",
-    });
-  } finally {
-    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
-  }
-}
-
 function generatePascalUnit(sourceDescription, version, entryCount, blobByteCount, unitName, resourceReference) {
   return `unit ${unitName};
 
@@ -540,6 +293,7 @@ async function main() {
 
     const { indexedEntries, blob } = packEntries(entries);
     const resource = buildResourceContainer(
+      RESOURCE_MAGIC,
       preparedSource.version,
       indexedEntries,
       blob,
@@ -555,7 +309,11 @@ async function main() {
 
     fs.mkdirSync(path.dirname(outputFile), { recursive: true });
     fs.writeFileSync(outputFile, pascal, "utf8");
-    generateResourceFile(resource, outputResourceFile);
+    generateResourceFile(resource, outputResourceFile, RESOURCE_NAME, {
+      temporaryDirectoryPrefix: "goccia-tzresource-",
+      dataFileName: "timezone-data.bin",
+      scriptFileName: "timezone-data.rc",
+    });
 
     console.log(
       `Generated ${path.relative(REPO_ROOT, outputFile)} and ${path.relative(REPO_ROOT, outputResourceFile)} with ${indexedEntries.length} zones, ${blob.length} bytes, tzdata ${preparedSource.version}`,

--- a/scripts/generate-unicode-data.js
+++ b/scripts/generate-unicode-data.js
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 
 const fs = require("fs");
-const https = require("https");
 const os = require("os");
 const path = require("path");
-const { execFileSync } = require("child_process");
+const {
+  buildResourceContainer,
+  downloadText,
+  generateResourceFile,
+  pascalUnitNameForOutput,
+  resourceFileForOutput,
+} = require("./lib/resource-container");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const DEFAULT_OUTPUT = path.join(
@@ -15,8 +20,6 @@ const DEFAULT_OUTPUT = path.join(
 );
 const DEFAULT_UNICODE_VERSION = "16.0.0";
 const UCD_BASE_URL = "https://www.unicode.org/Public";
-const DOWNLOAD_TIMEOUT_MS = 30000;
-const MAX_REDIRECTS = 5;
 
 const UCD_FILES = [
   "extracted/DerivedGeneralCategory.txt",
@@ -34,10 +37,6 @@ const UCD_FILES = [
 
 const RESOURCE_NAME = "GOCCIA_UCD";
 const RESOURCE_MAGIC = Buffer.from("GOCCIAUC", "ascii");
-const RESOURCE_FORMAT_VERSION = 1;
-const RESOURCE_HEADER_SIZE = RESOURCE_MAGIC.length + 6 * 4;
-const RESOURCE_ENTRY_SIZE = 4 * 4;
-const PASCAL_UNIT_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const GC_GROUPS = {
   LC: ["Lu", "Ll", "Lt"],
@@ -66,8 +65,8 @@ function parseArguments() {
   const outputFile = process.argv[3]
     ? path.resolve(process.argv[3])
     : DEFAULT_OUTPUT;
-  const outputResourceFile = resourceFileForOutput(outputFile);
-  const unitName = pascalUnitNameForOutput(outputFile);
+  const outputResourceFile = resourceFileForOutput(outputFile, "Unicode data");
+  const unitName = pascalUnitNameForOutput(outputFile, "Unicode data");
 
   if (path.resolve(outputFile) === path.resolve(outputResourceFile)) {
     throw new Error(
@@ -78,81 +77,10 @@ function parseArguments() {
   return { unicodeVersion, outputFile, outputResourceFile, unitName };
 }
 
-function pascalUnitNameForOutput(outputFile) {
-  if (path.extname(outputFile).toLowerCase() !== ".pas") {
-    throw new Error(
-      `Unicode data output must be a .pas file: ${outputFile}`,
-    );
-  }
-
-  const unitName = path.basename(outputFile, path.extname(outputFile));
-  if (unitName.length === 0) {
-    throw new Error(
-      `Unicode data output must have a non-empty Pascal unit name: ${outputFile}`,
-    );
-  }
-
-  const unitNameParts = unitName.split(".");
-  if (
-    unitNameParts.length === 0 ||
-    unitNameParts.some(
-      (unitNamePart) => !PASCAL_UNIT_IDENTIFIER_PATTERN.test(unitNamePart),
-    )
-  ) {
-    throw new Error(
-      `Unicode data output basename is not a valid Pascal unit name: ${unitName}`,
-    );
-  }
-
-  return unitName;
-}
-
-function resourceFileForOutput(outputFile) {
-  const directory = path.dirname(outputFile);
-  const base = path.basename(outputFile, path.extname(outputFile));
-  return path.join(directory, base + ".res");
-}
-
-function downloadFile(url, redirectCount) {
-  if (redirectCount === undefined) {
-    redirectCount = 0;
-  }
-
-  return new Promise((resolve, reject) => {
-    if (redirectCount > MAX_REDIRECTS) {
-      reject(new Error(`Too many redirects downloading ${url}`));
-      return;
-    }
-
-    const request = https.get(url, { timeout: DOWNLOAD_TIMEOUT_MS }, (response) => {
-      if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
-        resolve(downloadFile(response.headers.location, redirectCount + 1));
-        return;
-      }
-
-      if (response.statusCode !== 200) {
-        reject(new Error(`HTTP ${response.statusCode} downloading ${url}`));
-        return;
-      }
-
-      const chunks = [];
-      response.on("data", (chunk) => chunks.push(chunk));
-      response.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-      response.on("error", reject);
-    });
-
-    request.on("error", reject);
-    request.on("timeout", () => {
-      request.destroy();
-      reject(new Error(`Timeout downloading ${url}`));
-    });
-  });
-}
-
 async function downloadUCDFile(unicodeVersion, filePath) {
   const url = `${UCD_BASE_URL}/${unicodeVersion}/ucd/${filePath}`;
   console.log(`  Downloading ${filePath}...`);
-  return downloadFile(url);
+  return downloadText(url);
 }
 
 function parseRange(rangePart) {
@@ -332,85 +260,6 @@ function buildRangeDataBlob(ranges) {
     buffer.writeUInt32LE(ranges[i].hi, i * 8 + 4);
   }
   return buffer;
-}
-
-function writeUInt32LE(buffer, value, offset) {
-  if (value < 0 || value > 0xffffffff) {
-    throw new Error(`Resource integer ${value} is outside UInt32 range`);
-  }
-  buffer.writeUInt32LE(value, offset);
-}
-
-function buildResourceContainer(version, entries, blob) {
-  const versionBuffer = Buffer.from(version, "utf8");
-  const nameBuffers = entries.map((entry) => Buffer.from(entry.name, "utf8"));
-  const namesByteCount = nameBuffers.reduce(
-    (total, nameBuffer) => total + nameBuffer.length,
-    0,
-  );
-  const entryTableByteCount = entries.length * RESOURCE_ENTRY_SIZE;
-  const totalByteCount =
-    RESOURCE_HEADER_SIZE +
-    versionBuffer.length +
-    entryTableByteCount +
-    namesByteCount +
-    blob.length;
-
-  const resource = Buffer.alloc(totalByteCount);
-  let offset = 0;
-
-  RESOURCE_MAGIC.copy(resource, offset);
-  offset += RESOURCE_MAGIC.length;
-  writeUInt32LE(resource, RESOURCE_FORMAT_VERSION, offset); offset += 4;
-  writeUInt32LE(resource, versionBuffer.length, offset); offset += 4;
-  writeUInt32LE(resource, entries.length, offset); offset += 4;
-  writeUInt32LE(resource, namesByteCount, offset); offset += 4;
-  writeUInt32LE(resource, blob.length, offset); offset += 4;
-  writeUInt32LE(resource, 0, offset); offset += 4;
-
-  versionBuffer.copy(resource, offset);
-  offset += versionBuffer.length;
-
-  let nameOffset = 0;
-  const namesOffset =
-    RESOURCE_HEADER_SIZE + versionBuffer.length + entryTableByteCount;
-  for (let index = 0; index < entries.length; index += 1) {
-    const entry = entries[index];
-    const nameBuffer = nameBuffers[index];
-    writeUInt32LE(resource, nameOffset, offset); offset += 4;
-    writeUInt32LE(resource, nameBuffer.length, offset); offset += 4;
-    writeUInt32LE(resource, entry.offset, offset); offset += 4;
-    writeUInt32LE(resource, entry.length, offset); offset += 4;
-    nameBuffer.copy(resource, namesOffset + nameOffset);
-    nameOffset += nameBuffer.length;
-  }
-
-  blob.copy(resource, namesOffset + namesByteCount);
-  return resource;
-}
-
-function generateResourceFile(resourceBytes, outputResourceFile) {
-  const temporaryDirectory = fs.mkdtempSync(
-    path.join(os.tmpdir(), "goccia-ucdresource-"),
-  );
-  const resourceDataFile = path.join(temporaryDirectory, "unicode-data.bin");
-  const resourceScriptFile = path.join(temporaryDirectory, "unicode-data.rc");
-
-  try {
-    fs.writeFileSync(resourceDataFile, resourceBytes);
-    fs.writeFileSync(
-      resourceScriptFile,
-      `${RESOURCE_NAME} RCDATA "${resourceDataFile.replaceAll("\\", "\\\\")}"\n`,
-      "utf8",
-    );
-    execFileSync(
-      "fpcres",
-      ["-of", "res", resourceScriptFile, "-o", outputResourceFile],
-      { stdio: "inherit" },
-    );
-  } finally {
-    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
-  }
 }
 
 function generatePascalUnit(
@@ -705,6 +554,7 @@ async function main() {
   console.log("Building resource...");
   const { indexedEntries, blob } = buildResourceFromEntries(allEntries);
   const resource = buildResourceContainer(
+    RESOURCE_MAGIC,
     unicodeVersion,
     indexedEntries,
     blob,
@@ -712,7 +562,11 @@ async function main() {
 
   const resourceReference = path.basename(outputResourceFile);
   console.log(`Writing ${resourceReference}...`);
-  generateResourceFile(resource, outputResourceFile);
+  generateResourceFile(resource, outputResourceFile, RESOURCE_NAME, {
+    temporaryDirectoryPrefix: "goccia-ucdresource-",
+    dataFileName: "unicode-data.bin",
+    scriptFileName: "unicode-data.rc",
+  });
 
   console.log(`Writing ${path.basename(outputFile)}...`);
   const pascalSource = generatePascalUnit(

--- a/scripts/lib/resource-container.js
+++ b/scripts/lib/resource-container.js
@@ -223,6 +223,43 @@ function writeUInt32LE(buffer, value, offset) {
 }
 
 function buildResourceContainer(resourceMagic, version, entries, blob) {
+  if (!Buffer.isBuffer(resourceMagic) || resourceMagic.length !== 8) {
+    throw new Error("Resource magic must be an 8-byte Buffer");
+  }
+
+  if (RESOURCE_ENTRY_SIZE !== 16) {
+    throw new Error(`Resource entry size must be 16 bytes, got ${RESOURCE_ENTRY_SIZE}`);
+  }
+
+  if (!Buffer.isBuffer(blob)) {
+    throw new Error("Resource blob must be a Buffer");
+  }
+
+  let previousName = null;
+  for (const entry of entries) {
+    if (typeof entry.name !== "string" || entry.name.length === 0) {
+      throw new Error("Resource entry name must be a non-empty string");
+    }
+
+    if (previousName !== null && entry.name < previousName) {
+      throw new Error(
+        `Resource entries must be sorted by name: ${entry.name} appears after ${previousName}`,
+      );
+    }
+
+    if (
+      !Number.isInteger(entry.offset) ||
+      !Number.isInteger(entry.length) ||
+      entry.offset < 0 ||
+      entry.length < 0 ||
+      entry.offset > blob.length - entry.length
+    ) {
+      throw new Error(`Invalid resource entry bounds for ${entry.name}`);
+    }
+
+    previousName = entry.name;
+  }
+
   const versionBuffer = Buffer.from(version, "utf8");
   const nameBuffers = entries.map((entry) => Buffer.from(entry.name, "utf8"));
   const namesByteCount = nameBuffers.reduce((total, nameBuffer) => total + nameBuffer.length, 0);

--- a/scripts/lib/resource-container.js
+++ b/scripts/lib/resource-container.js
@@ -1,0 +1,305 @@
+const fs = require("fs");
+const http = require("http");
+const https = require("https");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const RESOURCE_FORMAT_VERSION = 1;
+const RESOURCE_HEADER_FIELD_SIZE = 4;
+const RESOURCE_HEADER_FIELD_COUNT = 6;
+const RESOURCE_ENTRY_SIZE = 4 * RESOURCE_HEADER_FIELD_SIZE;
+const DEFAULT_MAX_REDIRECTS = 5;
+const DEFAULT_DOWNLOAD_TIMEOUT_MS = 30000;
+const PASCAL_UNIT_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function isUrl(source) {
+  return /^https?:\/\//.test(source);
+}
+
+function getClient(url) {
+  const protocol = new URL(url).protocol;
+  if (protocol === "http:") {
+    return http;
+  }
+  if (protocol === "https:") {
+    return https;
+  }
+  throw new Error(`Unsupported URL protocol ${protocol} while downloading ${url}`);
+}
+
+function fetchUrl(url, handler, options) {
+  const timeoutMs = options && options.timeoutMs !== undefined
+    ? options.timeoutMs
+    : DEFAULT_DOWNLOAD_TIMEOUT_MS;
+  const maxRedirects = options && options.maxRedirects !== undefined
+    ? options.maxRedirects
+    : DEFAULT_MAX_REDIRECTS;
+
+  return new Promise((resolve, reject) => {
+    function get(currentUrl, redirectsLeft) {
+      if (redirectsLeft < 0) {
+        reject(new Error(`Too many redirects while downloading ${currentUrl}`));
+        return;
+      }
+
+      let settled = false;
+      let response = null;
+      let request = null;
+
+      function cleanup() {
+        if (request) {
+          request.setTimeout(0);
+          request.removeListener("timeout", onTimeout);
+          request.removeListener("error", onRequestError);
+        }
+        if (response) {
+          response.removeListener("error", onResponseError);
+        }
+      }
+
+      function fail(error) {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(error);
+      }
+
+      function finish(value) {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(value);
+      }
+
+      function onTimeout() {
+        request.destroy();
+        fail(new Error(`Timeout downloading ${currentUrl}`));
+      }
+
+      function onRequestError(error) {
+        fail(error);
+      }
+
+      function onResponseError(error) {
+        fail(error);
+      }
+
+      try {
+        request = getClient(currentUrl)
+          .get(currentUrl, (downloadResponse) => {
+            response = downloadResponse;
+            response.on("error", onResponseError);
+
+            if (
+              response.statusCode >= 300 &&
+              response.statusCode < 400 &&
+              response.headers.location
+            ) {
+              cleanup();
+              response.resume();
+              get(new URL(response.headers.location, currentUrl).toString(), redirectsLeft - 1);
+              return;
+            }
+
+            if (response.statusCode !== 200) {
+              cleanup();
+              response.resume();
+              fail(new Error(`HTTP ${response.statusCode} while downloading ${currentUrl}`));
+              return;
+            }
+
+            Promise.resolve(handler(response, currentUrl, request))
+              .then(finish)
+              .catch(fail);
+          })
+          .on("error", onRequestError);
+
+        request.setTimeout(timeoutMs, onTimeout);
+      } catch (error) {
+        fail(error);
+      }
+    }
+
+    get(url, maxRedirects);
+  });
+}
+
+function downloadText(url, options) {
+  return fetchUrl(
+    url,
+    (response) => new Promise((resolve, reject) => {
+      const chunks = [];
+      response.on("data", (chunk) => chunks.push(chunk));
+      response.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+      response.on("error", reject);
+    }),
+    options,
+  );
+}
+
+function downloadFileToDisk(url, outputFile, options) {
+  return fetchUrl(
+    url,
+    (response, currentUrl, request) => new Promise((resolve, reject) => {
+      const file = fs.createWriteStream(outputFile);
+
+      function cleanup() {
+        file.removeListener("finish", onFinish);
+        file.removeListener("error", onFileError);
+      }
+
+      function onFinish() {
+        cleanup();
+        file.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }
+
+      function onFileError(error) {
+        cleanup();
+        request.destroy();
+        reject(error);
+      }
+
+      file.on("finish", onFinish);
+      file.on("error", onFileError);
+      response.pipe(file);
+    }),
+    options,
+  );
+}
+
+function pascalUnitNameForOutput(outputFile, outputDescription) {
+  if (path.extname(outputFile).toLowerCase() !== ".pas") {
+    throw new Error(`${outputDescription} output must be a .pas file: ${outputFile}`);
+  }
+
+  const unitName = path.basename(outputFile, path.extname(outputFile));
+  if (unitName.length === 0) {
+    throw new Error(
+      `${outputDescription} output must have a non-empty Pascal unit name: ${outputFile}`,
+    );
+  }
+
+  const unitNameParts = unitName.split(".");
+  if (
+    unitNameParts.length === 0 ||
+    unitNameParts.some((unitNamePart) => !PASCAL_UNIT_IDENTIFIER_PATTERN.test(unitNamePart))
+  ) {
+    throw new Error(
+      `${outputDescription} output basename is not a valid Pascal unit name: ${unitName}`,
+    );
+  }
+
+  return unitName;
+}
+
+function resourceFileForOutput(outputFile, outputDescription) {
+  if (path.extname(outputFile).toLowerCase() !== ".pas") {
+    throw new Error(`${outputDescription} output must be a .pas file: ${outputFile}`);
+  }
+
+  return path.join(
+    path.dirname(outputFile),
+    `${path.basename(outputFile, path.extname(outputFile))}.res`,
+  );
+}
+
+function writeUInt32LE(buffer, value, offset) {
+  if (value < 0 || value > 0xffffffff) {
+    throw new Error(`Resource integer ${value} is outside UInt32 range`);
+  }
+
+  buffer.writeUInt32LE(value, offset);
+}
+
+function buildResourceContainer(resourceMagic, version, entries, blob) {
+  const versionBuffer = Buffer.from(version, "utf8");
+  const nameBuffers = entries.map((entry) => Buffer.from(entry.name, "utf8"));
+  const namesByteCount = nameBuffers.reduce((total, nameBuffer) => total + nameBuffer.length, 0);
+  const entryTableByteCount = entries.length * RESOURCE_ENTRY_SIZE;
+  const headerSize = resourceMagic.length + RESOURCE_HEADER_FIELD_COUNT * RESOURCE_HEADER_FIELD_SIZE;
+  const totalByteCount =
+    headerSize +
+    versionBuffer.length +
+    entryTableByteCount +
+    namesByteCount +
+    blob.length;
+
+  const resource = Buffer.alloc(totalByteCount);
+  let offset = 0;
+
+  resourceMagic.copy(resource, offset);
+  offset += resourceMagic.length;
+  writeUInt32LE(resource, RESOURCE_FORMAT_VERSION, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+  writeUInt32LE(resource, versionBuffer.length, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+  writeUInt32LE(resource, entries.length, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+  writeUInt32LE(resource, namesByteCount, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+  writeUInt32LE(resource, blob.length, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+  writeUInt32LE(resource, 0, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+
+  versionBuffer.copy(resource, offset);
+  offset += versionBuffer.length;
+
+  let nameOffset = 0;
+  const namesOffset = headerSize + versionBuffer.length + entryTableByteCount;
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    const nameBuffer = nameBuffers[index];
+    writeUInt32LE(resource, nameOffset, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+    writeUInt32LE(resource, nameBuffer.length, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+    writeUInt32LE(resource, entry.offset, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+    writeUInt32LE(resource, entry.length, offset); offset += RESOURCE_HEADER_FIELD_SIZE;
+    nameBuffer.copy(resource, namesOffset + nameOffset);
+    nameOffset += nameBuffer.length;
+  }
+
+  blob.copy(resource, namesOffset + namesByteCount);
+  return resource;
+}
+
+function generateResourceFile(resourceBytes, outputResourceFile, resourceName, options) {
+  const temporaryDirectoryPrefix = options && options.temporaryDirectoryPrefix
+    ? options.temporaryDirectoryPrefix
+    : "goccia-resource-";
+  const dataFileName = options && options.dataFileName ? options.dataFileName : "resource.bin";
+  const scriptFileName = options && options.scriptFileName ? options.scriptFileName : "resource.rc";
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), temporaryDirectoryPrefix));
+  const resourceDataFile = path.join(temporaryDirectory, dataFileName);
+  const resourceScriptFile = path.join(temporaryDirectory, scriptFileName);
+
+  try {
+    fs.writeFileSync(resourceDataFile, resourceBytes);
+    fs.writeFileSync(
+      resourceScriptFile,
+      `${resourceName} RCDATA "${resourceDataFile.replaceAll("\\", "\\\\")}"\n`,
+      "utf8",
+    );
+    execFileSync("fpcres", ["-of", "res", resourceScriptFile, "-o", outputResourceFile], {
+      stdio: "inherit",
+    });
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+module.exports = {
+  DEFAULT_DOWNLOAD_TIMEOUT_MS,
+  DEFAULT_MAX_REDIRECTS,
+  buildResourceContainer,
+  downloadFileToDisk,
+  downloadText,
+  generateResourceFile,
+  isUrl,
+  pascalUnitNameForOutput,
+  resourceFileForOutput,
+};

--- a/scripts/test-cli-embedded-resources.ts
+++ b/scripts/test-cli-embedded-resources.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * test-cli-embedded-resources.ts
+ *
+ * Smoke-checks that generated resource payloads are linked into the shipped
+ * CLI binary and that the same binary can use the runtime features backed by
+ * those resources.
+ */
+
+import { readFileSync } from "fs";
+
+import { LOADER } from "./test-cli/binaries";
+import { runLoaderJson } from "./test-cli/assertions";
+
+type EmbeddedResourceMarker = {
+  label: string;
+  magic: string;
+  resourceName: string;
+};
+
+const embeddedResources: EmbeddedResourceMarker[] = [
+  { label: "timezone data", magic: "GOCCIATZ", resourceName: "GOCCIA_TZDATA" },
+  { label: "CLDR data", magic: "GOCCIACL", resourceName: "GOCCIA_CLDR" },
+  { label: "Unicode data", magic: "GOCCIAUC", resourceName: "GOCCIA_UCD" },
+];
+
+function assertBinaryContains(buffer: Buffer, marker: string, label: string): void {
+  if (buffer.indexOf(Buffer.from(marker, "ascii")) < 0) {
+    throw new Error(`${LOADER} is missing ${label} marker ${marker}`);
+  }
+}
+
+function assertLoaderReturnsTrue(source: string, label: string, extraArgs: string[] = []): void {
+  const { exitCode, json, stderr } = runLoaderJson(source, extraArgs);
+  if (exitCode !== 0) {
+    throw new Error(`${label} exited ${exitCode}: ${stderr}`);
+  }
+
+  const result = json.files?.[0]?.result;
+  if (result !== true) {
+    throw new Error(`${label} expected true, got ${JSON.stringify(result)}`);
+  }
+}
+
+console.log("Embedded resource payload markers...");
+{
+  const loaderBytes = readFileSync(LOADER);
+  for (const resource of embeddedResources) {
+    assertBinaryContains(loaderBytes, resource.magic, `${resource.label} payload`);
+    assertBinaryContains(loaderBytes, resource.resourceName, `${resource.label} resource name`);
+  }
+}
+
+const behaviorProbes = [
+  {
+    label: "Temporal named timezone data",
+    source: String.raw`
+const summer = Temporal.ZonedDateTime.from("2024-07-01T12:00-04:00[America/New_York]");
+const winter = Temporal.ZonedDateTime.from("2024-01-01T12:00-05:00[America/New_York]");
+summer.timeZoneId === "America/New_York" &&
+  summer.offset === "-04:00" &&
+  winter.offset === "-05:00";
+`,
+  },
+  {
+    label: "Intl locale CLDR data",
+    source: String.raw`
+const usZones = new Intl.Locale("en-US").getTimeZones();
+Array.isArray(usZones) &&
+  usZones[0] === "America/Adak" &&
+  usZones.includes("America/New_York") &&
+  new Intl.Locale("ar").getTextInfo().direction === "rtl" &&
+  new Intl.PluralRules("pl").select(2) === "few";
+`,
+  },
+  {
+    label: "RegExp Unicode property data",
+    source: String.raw`
+const greek = new RegExp("\\p{Script=Greek}", "u");
+const emoji = new RegExp("\\p{Emoji}", "u");
+greek.test("\u03A9") &&
+  !greek.test("A") &&
+  emoji.test("\u231A") &&
+  !emoji.test("A");
+`,
+  },
+];
+
+for (const probe of behaviorProbes) {
+  console.log(`${probe.label} (interpreted)...`);
+  assertLoaderReturnsTrue(probe.source, probe.label);
+
+  console.log(`${probe.label} (bytecode)...`);
+  assertLoaderReturnsTrue(probe.source, `${probe.label} bytecode`, ["--mode=bytecode"]);
+}

--- a/source/shared/EmbeddedResourceReader.Test.pas
+++ b/source/shared/EmbeddedResourceReader.Test.pas
@@ -1,0 +1,178 @@
+program EmbeddedResourceReader.Test;
+
+{$I Shared.inc}
+
+uses
+  SysUtils,
+
+  EmbeddedResourceReader,
+  TestingPascalLibrary;
+
+type
+  TEmbeddedResourceReaderTests = class(TTestSuite)
+  private
+    function CreateContainer: TBytes;
+    procedure WriteUInt32LE(var ABuffer: TBytes; const AValue: UInt32;
+      const AOffset: Integer);
+    procedure CopyAscii(const AText: string; var ABuffer: TBytes;
+      const AOffset: Integer);
+
+    procedure TestReadsContainerAndFindsEntry;
+    procedure TestMissingEntryReturnsFalse;
+    procedure TestWrongMagicIsRejected;
+    procedure TestWrongFormatVersionIsRejected;
+    procedure TestOutOfRangeEntryDataIsRejected;
+  public
+    procedure SetupTests; override;
+  end;
+
+const
+  TEST_MAGIC: TEmbeddedResourceMagic =
+    (Ord('T'), Ord('E'), Ord('S'), Ord('T'), Ord('D'), Ord('A'), Ord('T'), Ord('A'));
+  HEADER_SIZE = 32;
+  VERSION_OFFSET = 8;
+  VERSION_LENGTH = 2;
+  ENTRY_TABLE_OFFSET = HEADER_SIZE + VERSION_LENGTH;
+  ENTRY_SIZE = 16;
+  NAME_SECTION_OFFSET = ENTRY_TABLE_OFFSET + 2 * ENTRY_SIZE;
+  DATA_SECTION_OFFSET = NAME_SECTION_OFFSET + 11;
+  TOTAL_SIZE = DATA_SECTION_OFFSET + 9;
+
+procedure TEmbeddedResourceReaderTests.SetupTests;
+begin
+  Test('Reads container metadata and finds entry data', TestReadsContainerAndFindsEntry);
+  Test('Missing entry returns false', TestMissingEntryReturnsFalse);
+  Test('Wrong magic is rejected', TestWrongMagicIsRejected);
+  Test('Wrong format version is rejected', TestWrongFormatVersionIsRejected);
+  Test('Out-of-range entry data is rejected', TestOutOfRangeEntryDataIsRejected);
+end;
+
+procedure TEmbeddedResourceReaderTests.WriteUInt32LE(var ABuffer: TBytes;
+  const AValue: UInt32; const AOffset: Integer);
+begin
+  ABuffer[AOffset] := Byte(AValue and $ff);
+  ABuffer[AOffset + 1] := Byte((AValue shr 8) and $ff);
+  ABuffer[AOffset + 2] := Byte((AValue shr 16) and $ff);
+  ABuffer[AOffset + 3] := Byte((AValue shr 24) and $ff);
+end;
+
+procedure TEmbeddedResourceReaderTests.CopyAscii(const AText: string;
+  var ABuffer: TBytes; const AOffset: Integer);
+var
+  Index: Integer;
+begin
+  for Index := 1 to Length(AText) do
+    ABuffer[AOffset + Index - 1] := Byte(AText[Index]);
+end;
+
+function TEmbeddedResourceReaderTests.CreateContainer: TBytes;
+var
+  Index: Integer;
+begin
+  SetLength(Result, TOTAL_SIZE);
+  for Index := 0 to Length(TEST_MAGIC) - 1 do
+    Result[Index] := TEST_MAGIC[Index];
+
+  WriteUInt32LE(Result, 1, VERSION_OFFSET);
+  WriteUInt32LE(Result, VERSION_LENGTH, VERSION_OFFSET + 4);
+  WriteUInt32LE(Result, 2, VERSION_OFFSET + 8);
+  WriteUInt32LE(Result, 11, VERSION_OFFSET + 12);
+  WriteUInt32LE(Result, 9, VERSION_OFFSET + 16);
+  WriteUInt32LE(Result, 0, VERSION_OFFSET + 20);
+
+  CopyAscii('v1', Result, HEADER_SIZE);
+
+  WriteUInt32LE(Result, 0, ENTRY_TABLE_OFFSET);
+  WriteUInt32LE(Result, 5, ENTRY_TABLE_OFFSET + 4);
+  WriteUInt32LE(Result, 0, ENTRY_TABLE_OFFSET + 8);
+  WriteUInt32LE(Result, 3, ENTRY_TABLE_OFFSET + 12);
+
+  WriteUInt32LE(Result, 5, ENTRY_TABLE_OFFSET + ENTRY_SIZE);
+  WriteUInt32LE(Result, 6, ENTRY_TABLE_OFFSET + ENTRY_SIZE + 4);
+  WriteUInt32LE(Result, 3, ENTRY_TABLE_OFFSET + ENTRY_SIZE + 8);
+  WriteUInt32LE(Result, 6, ENTRY_TABLE_OFFSET + ENTRY_SIZE + 12);
+
+  CopyAscii('applebanana', Result, NAME_SECTION_OFFSET);
+  CopyAscii('redyellow', Result, DATA_SECTION_OFFSET);
+end;
+
+procedure TEmbeddedResourceReaderTests.TestReadsContainerAndFindsEntry;
+var
+  Buffer, Bytes: TBytes;
+  Container: TEmbeddedResourceContainer;
+  Entry: TEmbeddedResourceEntry;
+  DataOffset, DataLength: Integer;
+begin
+  Buffer := CreateContainer;
+
+  Expect<Boolean>(TryReadEmbeddedResourceContainer(Buffer, TEST_MAGIC, Container)).ToBe(True);
+  Expect<Integer>(Container.EntryCount).ToBe(2);
+  Expect<Integer>(Container.EntryTableOffset).ToBe(ENTRY_TABLE_OFFSET);
+  Expect<Integer>(Container.NamesOffset).ToBe(NAME_SECTION_OFFSET);
+  Expect<Integer>(Container.DataOffset).ToBe(DATA_SECTION_OFFSET);
+
+  Expect<Boolean>(TryFindEmbeddedResourceEntry(Buffer, 'banana', Container, Entry)).ToBe(True);
+  Expect<Boolean>(TryGetEmbeddedResourceEntryDataBounds(Buffer, Container, Entry,
+    DataOffset, DataLength)).ToBe(True);
+  Expect<string>(CopyStringFromBytes(Buffer, DataOffset, DataLength)).ToBe('yellow');
+
+  Expect<Boolean>(TryFindEmbeddedResourceEntry(Buffer, 'apple', Container, Entry)).ToBe(True);
+  Expect<Boolean>(TryCopyEmbeddedResourceEntryData(Buffer, Container, Entry, Bytes)).ToBe(True);
+  Expect<string>(CopyStringFromBytes(Bytes, 0, Length(Bytes))).ToBe('red');
+end;
+
+procedure TEmbeddedResourceReaderTests.TestMissingEntryReturnsFalse;
+var
+  Buffer: TBytes;
+  Container: TEmbeddedResourceContainer;
+  Entry: TEmbeddedResourceEntry;
+begin
+  Buffer := CreateContainer;
+
+  Expect<Boolean>(TryReadEmbeddedResourceContainer(Buffer, TEST_MAGIC, Container)).ToBe(True);
+  Expect<Boolean>(TryFindEmbeddedResourceEntry(Buffer, 'cherry', Container, Entry)).ToBe(False);
+end;
+
+procedure TEmbeddedResourceReaderTests.TestWrongMagicIsRejected;
+var
+  Buffer: TBytes;
+  Container: TEmbeddedResourceContainer;
+begin
+  Buffer := CreateContainer;
+  Buffer[0] := Ord('X');
+
+  Expect<Boolean>(TryReadEmbeddedResourceContainer(Buffer, TEST_MAGIC, Container)).ToBe(False);
+end;
+
+procedure TEmbeddedResourceReaderTests.TestWrongFormatVersionIsRejected;
+var
+  Buffer: TBytes;
+  Container: TEmbeddedResourceContainer;
+begin
+  Buffer := CreateContainer;
+  WriteUInt32LE(Buffer, 2, VERSION_OFFSET);
+
+  Expect<Boolean>(TryReadEmbeddedResourceContainer(Buffer, TEST_MAGIC, Container)).ToBe(False);
+end;
+
+procedure TEmbeddedResourceReaderTests.TestOutOfRangeEntryDataIsRejected;
+var
+  Buffer: TBytes;
+  Container: TEmbeddedResourceContainer;
+  Entry: TEmbeddedResourceEntry;
+  DataOffset, DataLength: Integer;
+begin
+  Buffer := CreateContainer;
+  WriteUInt32LE(Buffer, 100, ENTRY_TABLE_OFFSET + 12);
+
+  Expect<Boolean>(TryReadEmbeddedResourceContainer(Buffer, TEST_MAGIC, Container)).ToBe(True);
+  Expect<Boolean>(TryFindEmbeddedResourceEntry(Buffer, 'apple', Container, Entry)).ToBe(True);
+  Expect<Boolean>(TryGetEmbeddedResourceEntryDataBounds(Buffer, Container, Entry,
+    DataOffset, DataLength)).ToBe(False);
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TEmbeddedResourceReaderTests.Create('EmbeddedResourceReader'));
+  TestRunnerProgram.Run;
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/shared/EmbeddedResourceReader.pas
+++ b/source/shared/EmbeddedResourceReader.pas
@@ -7,13 +7,61 @@ interface
 uses
   SysUtils;
 
+type
+  TEmbeddedResourceMagic = array[0..7] of Byte;
+
+  TEmbeddedResourceContainer = record
+    EntryCount: Integer;
+    EntryTableOffset: Integer;
+    NamesOffset: Integer;
+    DataOffset: Integer;
+    NamesByteCount: Integer;
+    DataByteCount: Integer;
+  end;
+
+  TEmbeddedResourceEntry = record
+    NameOffset: Integer;
+    NameLength: Integer;
+    DataOffset: Integer;
+    DataLength: Integer;
+  end;
+
 function HasBytesAvailable(const ABuffer: TBytes; const AOffset, ALength: Integer): Boolean;
 function TryUInt32ToInteger(const AValue: UInt32; out AInteger: Integer): Boolean;
 function ReadUInt32LE(const ABuffer: TBytes; const AOffset: Integer): UInt32;
 function CopyStringFromBytes(const ABuffer: TBytes; const AOffset,
   ALength: Integer): string;
+function HasEmbeddedResourceMagic(const ABuffer: TBytes;
+  const AMagic: TEmbeddedResourceMagic): Boolean;
+function TryReadEmbeddedResourceContainer(const ABuffer: TBytes;
+  const AMagic: TEmbeddedResourceMagic;
+  out AContainer: TEmbeddedResourceContainer): Boolean;
+function TryReadEmbeddedResourceEntry(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer; const AEntryIndex: Integer;
+  out AEntry: TEmbeddedResourceEntry): Boolean;
+function TryCompareEmbeddedResourceEntryName(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer; const AEntry: TEmbeddedResourceEntry;
+  const AKey: string; out ACompareResult: Integer): Boolean;
+function TryFindEmbeddedResourceEntry(const ABuffer: TBytes;
+  const AKey: string; const AContainer: TEmbeddedResourceContainer;
+  out AEntry: TEmbeddedResourceEntry): Boolean;
+function TryGetEmbeddedResourceEntryDataBounds(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer; const AEntry: TEmbeddedResourceEntry;
+  out ADataOffset, ADataLength: Integer): Boolean;
+function TryCopyEmbeddedResourceEntryData(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer; const AEntry: TEmbeddedResourceEntry;
+  out ABytes: TBytes): Boolean;
 
 implementation
+
+const
+  EMBEDDED_RESOURCE_MAGIC_LENGTH = 8;
+  EMBEDDED_RESOURCE_HEADER_FIELD_SIZE = 4;
+  EMBEDDED_RESOURCE_HEADER_FIELD_COUNT = 6;
+  EMBEDDED_RESOURCE_HEADER_SIZE = EMBEDDED_RESOURCE_MAGIC_LENGTH +
+    EMBEDDED_RESOURCE_HEADER_FIELD_COUNT * EMBEDDED_RESOURCE_HEADER_FIELD_SIZE;
+  EMBEDDED_RESOURCE_ENTRY_SIZE = 16;
+  EMBEDDED_RESOURCE_FORMAT_VERSION = 1;
 
 function HasBytesAvailable(const ABuffer: TBytes; const AOffset, ALength: Integer): Boolean;
 begin
@@ -51,6 +99,273 @@ begin
   SetLength(Result, ALength);
   if ALength > 0 then
     Move(ABuffer[AOffset], Result[1], ALength);
+end;
+
+function HasEmbeddedResourceMagic(const ABuffer: TBytes;
+  const AMagic: TEmbeddedResourceMagic): Boolean;
+var
+  Index: Integer;
+begin
+  Result := HasBytesAvailable(ABuffer, 0, EMBEDDED_RESOURCE_MAGIC_LENGTH);
+  if not Result then
+    Exit;
+
+  for Index := 0 to EMBEDDED_RESOURCE_MAGIC_LENGTH - 1 do
+  begin
+    if ABuffer[Index] <> AMagic[Index] then
+    begin
+      Result := False;
+      Exit;
+    end;
+  end;
+end;
+
+function TryReadEmbeddedResourceContainer(const ABuffer: TBytes;
+  const AMagic: TEmbeddedResourceMagic;
+  out AContainer: TEmbeddedResourceContainer): Boolean;
+var
+  Offset: Integer;
+  FormatVersion, Reserved: UInt32;
+  VersionLength, EntryCount, NamesByteCount, DataByteCount: Integer;
+  EntryTableOffset, EntryTableByteCount, NamesOffset, DataOffset, TotalSize: Int64;
+begin
+  Result := False;
+  AContainer.EntryCount := 0;
+  AContainer.EntryTableOffset := 0;
+  AContainer.NamesOffset := 0;
+  AContainer.DataOffset := 0;
+  AContainer.NamesByteCount := 0;
+  AContainer.DataByteCount := 0;
+
+  if not HasBytesAvailable(ABuffer, 0, EMBEDDED_RESOURCE_HEADER_SIZE) then
+    Exit;
+
+  if not HasEmbeddedResourceMagic(ABuffer, AMagic) then
+    Exit;
+
+  Offset := EMBEDDED_RESOURCE_MAGIC_LENGTH;
+  FormatVersion := ReadUInt32LE(ABuffer, Offset);
+  Inc(Offset, EMBEDDED_RESOURCE_HEADER_FIELD_SIZE);
+  if FormatVersion <> EMBEDDED_RESOURCE_FORMAT_VERSION then
+    Exit;
+
+  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), VersionLength) then
+    Exit;
+  Inc(Offset, EMBEDDED_RESOURCE_HEADER_FIELD_SIZE);
+
+  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), EntryCount) then
+    Exit;
+  Inc(Offset, EMBEDDED_RESOURCE_HEADER_FIELD_SIZE);
+
+  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), NamesByteCount) then
+    Exit;
+  Inc(Offset, EMBEDDED_RESOURCE_HEADER_FIELD_SIZE);
+
+  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), DataByteCount) then
+    Exit;
+  Inc(Offset, EMBEDDED_RESOURCE_HEADER_FIELD_SIZE);
+
+  Reserved := ReadUInt32LE(ABuffer, Offset);
+  if Reserved <> 0 then
+    Exit;
+
+  EntryTableByteCount := Int64(EntryCount) * EMBEDDED_RESOURCE_ENTRY_SIZE;
+  if (EntryTableByteCount < 0) or (EntryTableByteCount > High(Integer)) then
+    Exit;
+
+  EntryTableOffset := Int64(EMBEDDED_RESOURCE_HEADER_SIZE) + VersionLength;
+  NamesOffset := EntryTableOffset + EntryTableByteCount;
+  DataOffset := NamesOffset + NamesByteCount;
+  TotalSize := DataOffset + DataByteCount;
+  if (EntryTableOffset < 0) or (EntryTableOffset > High(Integer)) or
+     (TotalSize < 0) or (TotalSize > High(Integer)) then
+    Exit;
+
+  if not HasBytesAvailable(ABuffer, 0, Integer(TotalSize)) then
+    Exit;
+
+  AContainer.EntryCount := EntryCount;
+  AContainer.EntryTableOffset := Integer(EntryTableOffset);
+  AContainer.NamesOffset := Integer(NamesOffset);
+  AContainer.DataOffset := Integer(DataOffset);
+  AContainer.NamesByteCount := NamesByteCount;
+  AContainer.DataByteCount := DataByteCount;
+  Result := True;
+end;
+
+function TryReadEmbeddedResourceEntry(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer; const AEntryIndex: Integer;
+  out AEntry: TEmbeddedResourceEntry): Boolean;
+var
+  EntryOffset: Int64;
+  Offset: Integer;
+begin
+  Result := False;
+  AEntry.NameOffset := 0;
+  AEntry.NameLength := 0;
+  AEntry.DataOffset := 0;
+  AEntry.DataLength := 0;
+
+  if (AEntryIndex < 0) or (AEntryIndex >= AContainer.EntryCount) then
+    Exit;
+
+  EntryOffset := Int64(AContainer.EntryTableOffset) +
+    Int64(AEntryIndex) * EMBEDDED_RESOURCE_ENTRY_SIZE;
+  if (EntryOffset < 0) or (EntryOffset > High(Integer)) then
+    Exit;
+
+  Offset := Integer(EntryOffset);
+  if not HasBytesAvailable(ABuffer, Offset, EMBEDDED_RESOURCE_ENTRY_SIZE) then
+    Exit;
+
+  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.NameOffset) then
+    Exit;
+  Inc(Offset, EMBEDDED_RESOURCE_HEADER_FIELD_SIZE);
+
+  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.NameLength) then
+    Exit;
+  Inc(Offset, EMBEDDED_RESOURCE_HEADER_FIELD_SIZE);
+
+  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.DataOffset) then
+    Exit;
+  Inc(Offset, EMBEDDED_RESOURCE_HEADER_FIELD_SIZE);
+
+  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.DataLength) then
+    Exit;
+
+  Result := True;
+end;
+
+function TryCompareEmbeddedResourceEntryName(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer; const AEntry: TEmbeddedResourceEntry;
+  const AKey: string; out ACompareResult: Integer): Boolean;
+var
+  AbsoluteOffset, EntryEnd: Int64;
+  KeyLength, EntryLength, MinimumLength, Index: Integer;
+  KeyByte, EntryByte: Byte;
+begin
+  Result := False;
+  ACompareResult := 0;
+
+  if not HasBytesAvailable(ABuffer, AContainer.NamesOffset,
+     AContainer.NamesByteCount) then
+    Exit;
+
+  AbsoluteOffset := Int64(AContainer.NamesOffset) + AEntry.NameOffset;
+  EntryEnd := Int64(AEntry.NameOffset) + AEntry.NameLength;
+  if (AbsoluteOffset < 0) or (AbsoluteOffset > High(Integer)) or
+     (EntryEnd < 0) or (EntryEnd > AContainer.NamesByteCount) then
+    Exit;
+
+  if not HasBytesAvailable(ABuffer, Integer(AbsoluteOffset), AEntry.NameLength) then
+    Exit;
+
+  KeyLength := Length(AKey);
+  EntryLength := AEntry.NameLength;
+  if KeyLength < EntryLength then
+    MinimumLength := KeyLength
+  else
+    MinimumLength := EntryLength;
+
+  for Index := 0 to MinimumLength - 1 do
+  begin
+    KeyByte := Byte(AKey[Index + 1]);
+    EntryByte := ABuffer[Integer(AbsoluteOffset) + Index];
+    if KeyByte <> EntryByte then
+    begin
+      if KeyByte < EntryByte then
+        ACompareResult := -1
+      else
+        ACompareResult := 1;
+      Result := True;
+      Exit;
+    end;
+  end;
+
+  if KeyLength < EntryLength then
+    ACompareResult := -1
+  else if KeyLength > EntryLength then
+    ACompareResult := 1
+  else
+    ACompareResult := 0;
+  Result := True;
+end;
+
+function TryFindEmbeddedResourceEntry(const ABuffer: TBytes;
+  const AKey: string; const AContainer: TEmbeddedResourceContainer;
+  out AEntry: TEmbeddedResourceEntry): Boolean;
+var
+  LowIndex, HighIndex, MiddleIndex, CompareResult: Integer;
+begin
+  Result := False;
+  LowIndex := 0;
+  HighIndex := AContainer.EntryCount - 1;
+
+  while LowIndex <= HighIndex do
+  begin
+    MiddleIndex := LowIndex + (HighIndex - LowIndex) div 2;
+    if not TryReadEmbeddedResourceEntry(ABuffer, AContainer, MiddleIndex, AEntry) then
+      Exit;
+
+    if not TryCompareEmbeddedResourceEntryName(ABuffer, AContainer, AEntry,
+       AKey, CompareResult) then
+      Exit;
+
+    if CompareResult = 0 then
+    begin
+      Result := True;
+      Exit;
+    end;
+
+    if CompareResult < 0 then
+      HighIndex := MiddleIndex - 1
+    else
+      LowIndex := MiddleIndex + 1;
+  end;
+end;
+
+function TryGetEmbeddedResourceEntryDataBounds(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer; const AEntry: TEmbeddedResourceEntry;
+  out ADataOffset, ADataLength: Integer): Boolean;
+var
+  AbsoluteDataOffset, EntryDataEnd: Int64;
+begin
+  Result := False;
+  ADataOffset := 0;
+  ADataLength := 0;
+
+  AbsoluteDataOffset := Int64(AContainer.DataOffset) + AEntry.DataOffset;
+  EntryDataEnd := Int64(AEntry.DataOffset) + AEntry.DataLength;
+  if (AbsoluteDataOffset < 0) or (AbsoluteDataOffset > High(Integer)) or
+     (EntryDataEnd < 0) or (EntryDataEnd > AContainer.DataByteCount) then
+    Exit;
+
+  if not HasBytesAvailable(ABuffer, Integer(AbsoluteDataOffset),
+     AEntry.DataLength) then
+    Exit;
+
+  ADataOffset := Integer(AbsoluteDataOffset);
+  ADataLength := AEntry.DataLength;
+  Result := True;
+end;
+
+function TryCopyEmbeddedResourceEntryData(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer; const AEntry: TEmbeddedResourceEntry;
+  out ABytes: TBytes): Boolean;
+var
+  DataOffset, DataLength: Integer;
+begin
+  Result := False;
+  SetLength(ABytes, 0);
+
+  if not TryGetEmbeddedResourceEntryDataBounds(ABuffer, AContainer, AEntry,
+     DataOffset, DataLength) then
+    Exit;
+
+  SetLength(ABytes, DataLength);
+  if DataLength > 0 then
+    Move(ABuffer[DataOffset], ABytes[0], DataLength);
+  Result := True;
 end;
 
 end.

--- a/source/units/Goccia.Intl.CLDRData.pas
+++ b/source/units/Goccia.Intl.CLDRData.pas
@@ -49,206 +49,10 @@ uses
   EmbeddedResourceReader,
   Generated.IntlData;
 
-type
-  TEmbeddedCLDRDataEntry = record
-    NameOffset: Integer;
-    NameLength: Integer;
-    DataOffset: Integer;
-    DataLength: Integer;
-  end;
-
 const
-  CLDR_DATA_MAGIC_LENGTH = 8;
-  CLDR_DATA_HEADER_FIELD_SIZE = 4;
-  CLDR_DATA_HEADER_FIELD_COUNT = 6;
-  CLDR_DATA_HEADER_SIZE = CLDR_DATA_MAGIC_LENGTH +
-    CLDR_DATA_HEADER_FIELD_COUNT * CLDR_DATA_HEADER_FIELD_SIZE;
-  CLDR_DATA_ENTRY_SIZE = 16;
-  CLDR_DATA_FORMAT_VERSION = 1;
   CLDR_RCDATA_RESOURCE_TYPE = MAKEINTRESOURCE(10);
-  CLDR_DATA_MAGIC: array[0..CLDR_DATA_MAGIC_LENGTH - 1] of Byte =
+  CLDR_DATA_MAGIC: TEmbeddedResourceMagic =
     (Ord('G'), Ord('O'), Ord('C'), Ord('C'), Ord('I'), Ord('A'), Ord('C'), Ord('L'));
-
-function HasExpectedMagic(const ABuffer: TBytes): Boolean;
-var
-  Index: Integer;
-begin
-  Result := HasBytesAvailable(ABuffer, 0, CLDR_DATA_MAGIC_LENGTH);
-  if not Result then
-    Exit;
-
-  for Index := 0 to CLDR_DATA_MAGIC_LENGTH - 1 do
-  begin
-    if ABuffer[Index] <> CLDR_DATA_MAGIC[Index] then
-    begin
-      Result := False;
-      Exit;
-    end;
-  end;
-end;
-
-function TryReadEmbeddedHeader(const ABuffer: TBytes; out AEntryCount,
-  AEntryTableOffset, ANamesOffset, ADataOffset, ANamesByteCount,
-  ADataByteCount: Integer): Boolean;
-var
-  Offset: Integer;
-  FormatVersion, Reserved: UInt32;
-  VersionLength, EntryCount, NamesByteCount, DataByteCount: Integer;
-  EntryTableOffset, EntryTableByteCount, NamesOffset, DataOffset, TotalSize: Int64;
-begin
-  Result := False;
-  AEntryCount := 0;
-  AEntryTableOffset := 0;
-  ANamesOffset := 0;
-  ADataOffset := 0;
-  ANamesByteCount := 0;
-  ADataByteCount := 0;
-
-  if not HasBytesAvailable(ABuffer, 0, CLDR_DATA_HEADER_SIZE) then
-    Exit;
-
-  if not HasExpectedMagic(ABuffer) then
-    Exit;
-
-  Offset := CLDR_DATA_MAGIC_LENGTH;
-  FormatVersion := ReadUInt32LE(ABuffer, Offset); Inc(Offset, CLDR_DATA_HEADER_FIELD_SIZE);
-  if FormatVersion <> CLDR_DATA_FORMAT_VERSION then
-    Exit;
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), VersionLength) then
-    Exit;
-  Inc(Offset, CLDR_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), EntryCount) then
-    Exit;
-  Inc(Offset, CLDR_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), NamesByteCount) then
-    Exit;
-  Inc(Offset, CLDR_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), DataByteCount) then
-    Exit;
-  Inc(Offset, CLDR_DATA_HEADER_FIELD_SIZE);
-
-  Reserved := ReadUInt32LE(ABuffer, Offset);
-  if Reserved <> 0 then
-    Exit;
-
-  EntryTableByteCount := Int64(EntryCount) * CLDR_DATA_ENTRY_SIZE;
-  if (EntryTableByteCount < 0) or (EntryTableByteCount > High(Integer)) then
-    Exit;
-
-  EntryTableOffset := Int64(CLDR_DATA_HEADER_SIZE) + VersionLength;
-  NamesOffset := EntryTableOffset + EntryTableByteCount;
-  DataOffset := NamesOffset + NamesByteCount;
-  TotalSize := DataOffset + DataByteCount;
-  if (EntryTableOffset < 0) or (EntryTableOffset > High(Integer)) or
-     (TotalSize < 0) or (TotalSize > High(Integer)) then
-    Exit;
-
-  if not HasBytesAvailable(ABuffer, 0, Integer(TotalSize)) then
-    Exit;
-
-  AEntryCount := EntryCount;
-  AEntryTableOffset := Integer(EntryTableOffset);
-  ANamesOffset := Integer(NamesOffset);
-  ADataOffset := Integer(DataOffset);
-  ANamesByteCount := NamesByteCount;
-  ADataByteCount := DataByteCount;
-  Result := True;
-end;
-
-function TryReadEmbeddedEntry(const ABuffer: TBytes; const AEntryTableOffset,
-  AEntryIndex: Integer; out AEntry: TEmbeddedCLDRDataEntry): Boolean;
-var
-  Offset: Integer;
-begin
-  Result := False;
-  AEntry.NameOffset := 0;
-  AEntry.NameLength := 0;
-  AEntry.DataOffset := 0;
-  AEntry.DataLength := 0;
-
-  Offset := AEntryTableOffset + AEntryIndex * CLDR_DATA_ENTRY_SIZE;
-  if not HasBytesAvailable(ABuffer, Offset, CLDR_DATA_ENTRY_SIZE) then
-    Exit;
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.NameOffset) then
-    Exit;
-  Inc(Offset, CLDR_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.NameLength) then
-    Exit;
-  Inc(Offset, CLDR_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.DataOffset) then
-    Exit;
-  Inc(Offset, CLDR_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.DataLength) then
-    Exit;
-
-  Result := True;
-end;
-
-function TryGetEntryName(const ABuffer: TBytes; const AEntry: TEmbeddedCLDRDataEntry;
-  const ANamesOffset, ANamesByteCount: Integer; out AName: string): Boolean;
-var
-  AbsoluteOffset, EntryEnd: Int64;
-begin
-  Result := False;
-  AName := '';
-
-  if not HasBytesAvailable(ABuffer, ANamesOffset, ANamesByteCount) then
-    Exit;
-
-  AbsoluteOffset := Int64(ANamesOffset) + AEntry.NameOffset;
-  EntryEnd := Int64(AEntry.NameOffset) + AEntry.NameLength;
-  if (AbsoluteOffset < 0) or (AbsoluteOffset > High(Integer)) or
-     (EntryEnd < 0) or (EntryEnd > ANamesByteCount) then
-    Exit;
-
-  if not HasBytesAvailable(ABuffer, Integer(AbsoluteOffset), AEntry.NameLength) then
-    Exit;
-
-  AName := CopyStringFromBytes(ABuffer, Integer(AbsoluteOffset), AEntry.NameLength);
-  Result := True;
-end;
-
-function TryFindEmbeddedEntry(const ABuffer: TBytes; const AKey: string;
-  const AEntryCount, AEntryTableOffset, ANamesOffset, ANamesByteCount: Integer;
-  out AEntry: TEmbeddedCLDRDataEntry): Boolean;
-var
-  LowIndex, HighIndex, MiddleIndex, CompareResult: Integer;
-  EntryName: string;
-begin
-  Result := False;
-  LowIndex := 0;
-  HighIndex := AEntryCount - 1;
-
-  while LowIndex <= HighIndex do
-  begin
-    MiddleIndex := LowIndex + (HighIndex - LowIndex) div 2;
-    if not TryReadEmbeddedEntry(ABuffer, AEntryTableOffset, MiddleIndex, AEntry) then
-      Exit;
-
-    if not TryGetEntryName(ABuffer, AEntry, ANamesOffset, ANamesByteCount, EntryName) then
-      Exit;
-
-    CompareResult := CompareStr(AKey, EntryName);
-    if CompareResult = 0 then
-    begin
-      Result := True;
-      Exit;
-    end;
-
-    if CompareResult < 0 then
-      HighIndex := MiddleIndex - 1
-    else
-      LowIndex := MiddleIndex + 1;
-  end;
-end;
 
 var
   CachedCLDRResource: TBytes;
@@ -295,10 +99,8 @@ end;
 function TryGetSectionData(const ASectionName: string;
   out AResource: TBytes; out ADataOffset, ADataLength: Integer): Boolean;
 var
-  Entry: TEmbeddedCLDRDataEntry;
-  EntryCount, EntryTableOffset, NamesOffset, DataOffset: Integer;
-  NamesByteCount, DataByteCount: Integer;
-  AbsoluteDataOffset, EntryDataEnd: Int64;
+  Container: TEmbeddedResourceContainer;
+  Entry: TEmbeddedResourceEntry;
 begin
   Result := False;
   ADataOffset := 0;
@@ -308,26 +110,16 @@ begin
   if not TryReadEmbeddedResource(AResource) then
     Exit;
 
-  if not TryReadEmbeddedHeader(AResource, EntryCount, EntryTableOffset,
-    NamesOffset, DataOffset, NamesByteCount, DataByteCount) then
+  if not TryReadEmbeddedResourceContainer(AResource, CLDR_DATA_MAGIC,
+     Container) then
     Exit;
 
-  if not TryFindEmbeddedEntry(AResource, ASectionName, EntryCount,
-    EntryTableOffset, NamesOffset, NamesByteCount, Entry) then
+  if not TryFindEmbeddedResourceEntry(AResource, ASectionName, Container,
+     Entry) then
     Exit;
 
-  AbsoluteDataOffset := Int64(DataOffset) + Entry.DataOffset;
-  EntryDataEnd := Int64(Entry.DataOffset) + Entry.DataLength;
-  if (AbsoluteDataOffset < 0) or (AbsoluteDataOffset > High(Integer)) or
-     (EntryDataEnd < 0) or (EntryDataEnd > DataByteCount) then
-    Exit;
-
-  if not HasBytesAvailable(AResource, Integer(AbsoluteDataOffset), Entry.DataLength) then
-    Exit;
-
-  ADataOffset := Integer(AbsoluteDataOffset);
-  ADataLength := Entry.DataLength;
-  Result := True;
+  Result := TryGetEmbeddedResourceEntryDataBounds(AResource, Container, Entry,
+    ADataOffset, ADataLength);
 end;
 
 function TryGetSectionDataWithFallback(const APrefix, ALocale: string;

--- a/source/units/Goccia.RegExp.UnicodeData.pas
+++ b/source/units/Goccia.RegExp.UnicodeData.pas
@@ -31,13 +31,6 @@ uses
   Generated.UnicodeData;
 
 type
-  TEmbeddedUCDEntry = record
-    NameOffset: Integer;
-    NameLength: Integer;
-    DataOffset: Integer;
-    DataLength: Integer;
-  end;
-
   TCodePointPair = record
     Source: Cardinal;
     Target: Cardinal;
@@ -46,252 +39,34 @@ type
   TCodePointPairArray = array of TCodePointPair;
 
 const
-  UCD_MAGIC_LENGTH = 8;
-  UCD_HEADER_FIELD_SIZE = 4;
-  UCD_HEADER_FIELD_COUNT = 6;
-  UCD_HEADER_SIZE = UCD_MAGIC_LENGTH +
-    UCD_HEADER_FIELD_COUNT * UCD_HEADER_FIELD_SIZE;
-  UCD_ENTRY_SIZE = 16;
-  UCD_FORMAT_VERSION = 1;
   UCD_RANGE_SIZE = 8;
   CASE_FOLDING_ENTRY_KEY = 'CaseFolding/Simple';
   NON_UNICODE_UPPERCASE_ENTRY_KEY = 'CaseMapping/RegExpNonUnicodeUppercase';
   UCD_RCDATA_RESOURCE_TYPE = MAKEINTRESOURCE(10);
-  UCD_MAGIC: array[0..UCD_MAGIC_LENGTH - 1] of Byte =
+  UCD_MAGIC: TEmbeddedResourceMagic =
     (Ord('G'), Ord('O'), Ord('C'), Ord('C'), Ord('I'), Ord('A'), Ord('U'), Ord('C'));
 
-function HasExpectedMagic(const ABuffer: TBytes): Boolean;
-var
-  Index: Integer;
-begin
-  Result := HasBytesAvailable(ABuffer, 0, UCD_MAGIC_LENGTH);
-  if not Result then
-    Exit;
-
-  for Index := 0 to UCD_MAGIC_LENGTH - 1 do
-  begin
-    if ABuffer[Index] <> UCD_MAGIC[Index] then
-    begin
-      Result := False;
-      Exit;
-    end;
-  end;
-end;
-
-function TryReadEmbeddedHeader(const ABuffer: TBytes; out AEntryCount,
-  AEntryTableOffset, ANamesOffset, ADataOffset, ANamesByteCount,
-  ADataByteCount: Integer): Boolean;
-var
-  Offset: Integer;
-  FormatVersion, Reserved: UInt32;
-  VersionLength, EntryCount, NamesByteCount, DataByteCount: Integer;
-  EntryTableOffset, EntryTableByteCount, NamesOffset, DataOffset, TotalSize: Int64;
-begin
-  Result := False;
-  AEntryCount := 0;
-  AEntryTableOffset := 0;
-  ANamesOffset := 0;
-  ADataOffset := 0;
-  ANamesByteCount := 0;
-  ADataByteCount := 0;
-
-  if not HasBytesAvailable(ABuffer, 0, UCD_HEADER_SIZE) then
-    Exit;
-
-  if not HasExpectedMagic(ABuffer) then
-    Exit;
-
-  Offset := UCD_MAGIC_LENGTH;
-  FormatVersion := ReadUInt32LE(ABuffer, Offset); Inc(Offset, UCD_HEADER_FIELD_SIZE);
-  if FormatVersion <> UCD_FORMAT_VERSION then
-    Exit;
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), VersionLength) then
-    Exit;
-  Inc(Offset, UCD_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), EntryCount) then
-    Exit;
-  Inc(Offset, UCD_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), NamesByteCount) then
-    Exit;
-  Inc(Offset, UCD_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), DataByteCount) then
-    Exit;
-  Inc(Offset, UCD_HEADER_FIELD_SIZE);
-
-  Reserved := ReadUInt32LE(ABuffer, Offset);
-  if Reserved <> 0 then
-    Exit;
-
-  EntryTableByteCount := Int64(EntryCount) * UCD_ENTRY_SIZE;
-  if (EntryTableByteCount < 0) or (EntryTableByteCount > High(Integer)) then
-    Exit;
-
-  EntryTableOffset := Int64(UCD_HEADER_SIZE) + VersionLength;
-  NamesOffset := EntryTableOffset + EntryTableByteCount;
-  DataOffset := NamesOffset + NamesByteCount;
-  TotalSize := DataOffset + DataByteCount;
-  if (EntryTableOffset < 0) or (EntryTableOffset > High(Integer)) or
-     (TotalSize < 0) or (TotalSize > High(Integer)) then
-    Exit;
-
-  if not HasBytesAvailable(ABuffer, 0, Integer(TotalSize)) then
-    Exit;
-
-  AEntryCount := EntryCount;
-  AEntryTableOffset := Integer(EntryTableOffset);
-  ANamesOffset := Integer(NamesOffset);
-  ADataOffset := Integer(DataOffset);
-  ANamesByteCount := NamesByteCount;
-  ADataByteCount := DataByteCount;
-  Result := True;
-end;
-
-function TryReadEmbeddedEntry(const ABuffer: TBytes; const AEntryTableOffset,
-  AEntryIndex: Integer; out AEntry: TEmbeddedUCDEntry): Boolean;
-var
-  Offset: Integer;
-begin
-  Result := False;
-  AEntry.NameOffset := 0;
-  AEntry.NameLength := 0;
-  AEntry.DataOffset := 0;
-  AEntry.DataLength := 0;
-
-  Offset := AEntryTableOffset + AEntryIndex * UCD_ENTRY_SIZE;
-  if not HasBytesAvailable(ABuffer, Offset, UCD_ENTRY_SIZE) then
-    Exit;
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.NameOffset) then
-    Exit;
-  Inc(Offset, UCD_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.NameLength) then
-    Exit;
-  Inc(Offset, UCD_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.DataOffset) then
-    Exit;
-  Inc(Offset, UCD_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.DataLength) then
-    Exit;
-
-  Result := True;
-end;
-
-function TryCompareEntryName(const ABuffer: TBytes; const AEntry: TEmbeddedUCDEntry;
-  const ANamesOffset, ANamesByteCount: Integer; const AKey: string;
-  out ACompareResult: Integer): Boolean;
-var
-  AbsoluteOffset, EntryEnd: Int64;
-  KeyLen, EntryLen, MinLen, I: Integer;
-  KeyByte, EntryByte: Byte;
-begin
-  Result := False;
-  ACompareResult := 0;
-
-  AbsoluteOffset := Int64(ANamesOffset) + AEntry.NameOffset;
-  EntryEnd := Int64(AEntry.NameOffset) + AEntry.NameLength;
-  if (AbsoluteOffset < 0) or (AbsoluteOffset > High(Integer)) or
-     (EntryEnd < 0) or (EntryEnd > ANamesByteCount) then
-    Exit;
-
-  if not HasBytesAvailable(ABuffer, Integer(AbsoluteOffset), AEntry.NameLength) then
-    Exit;
-
-  KeyLen := Length(AKey);
-  EntryLen := AEntry.NameLength;
-  if KeyLen < EntryLen then
-    MinLen := KeyLen
-  else
-    MinLen := EntryLen;
-
-  for I := 0 to MinLen - 1 do
-  begin
-    KeyByte := Byte(AKey[I + 1]);
-    EntryByte := ABuffer[Integer(AbsoluteOffset) + I];
-    if KeyByte <> EntryByte then
-    begin
-      if KeyByte < EntryByte then
-        ACompareResult := -1
-      else
-        ACompareResult := 1;
-      Result := True;
-      Exit;
-    end;
-  end;
-
-  if KeyLen < EntryLen then
-    ACompareResult := -1
-  else if KeyLen > EntryLen then
-    ACompareResult := 1
-  else
-    ACompareResult := 0;
-  Result := True;
-end;
-
-function TryFindEmbeddedEntry(const ABuffer: TBytes; const AKey: string;
-  const AEntryCount, AEntryTableOffset, ANamesOffset, ANamesByteCount: Integer;
-  out AEntry: TEmbeddedUCDEntry): Boolean;
-var
-  LowIndex, HighIndex, MiddleIndex, CompareResult: Integer;
-begin
-  Result := False;
-  LowIndex := 0;
-  HighIndex := AEntryCount - 1;
-
-  while LowIndex <= HighIndex do
-  begin
-    MiddleIndex := LowIndex + (HighIndex - LowIndex) div 2;
-    if not TryReadEmbeddedEntry(ABuffer, AEntryTableOffset, MiddleIndex, AEntry) then
-      Exit;
-
-    if not TryCompareEntryName(ABuffer, AEntry, ANamesOffset, ANamesByteCount,
-      AKey, CompareResult) then
-      Exit;
-
-    if CompareResult = 0 then
-    begin
-      Result := True;
-      Exit;
-    end;
-
-    if CompareResult < 0 then
-      HighIndex := MiddleIndex - 1
-    else
-      LowIndex := MiddleIndex + 1;
-  end;
-end;
-
-function TryExtractRanges(const ABuffer: TBytes; const AEntry: TEmbeddedUCDEntry;
-  const ADataOffset, ADataByteCount: Integer;
+function TryExtractRanges(const ABuffer: TBytes;
+  const AContainer: TEmbeddedResourceContainer;
+  const AEntry: TEmbeddedResourceEntry;
   out ARanges: TUnicodePropertyRangeArray): Boolean;
 var
-  AbsoluteDataOffset, EntryDataEnd: Int64;
+  DataOffset, DataLength: Integer;
   RangeCount, I, Offset: Integer;
 begin
   Result := False;
   SetLength(ARanges, 0);
 
-  AbsoluteDataOffset := Int64(ADataOffset) + AEntry.DataOffset;
-  EntryDataEnd := Int64(AEntry.DataOffset) + AEntry.DataLength;
-  if (AbsoluteDataOffset < 0) or (AbsoluteDataOffset > High(Integer)) or
-     (EntryDataEnd < 0) or (EntryDataEnd > ADataByteCount) then
+  if not TryGetEmbeddedResourceEntryDataBounds(ABuffer, AContainer, AEntry,
+     DataOffset, DataLength) then
     Exit;
 
-  if not HasBytesAvailable(ABuffer, Integer(AbsoluteDataOffset), AEntry.DataLength) then
+  if (DataLength mod UCD_RANGE_SIZE) <> 0 then
     Exit;
 
-  if (AEntry.DataLength mod UCD_RANGE_SIZE) <> 0 then
-    Exit;
-
-  RangeCount := AEntry.DataLength div UCD_RANGE_SIZE;
+  RangeCount := DataLength div UCD_RANGE_SIZE;
   SetLength(ARanges, RangeCount);
-  Offset := Integer(AbsoluteDataOffset);
+  Offset := DataOffset;
 
   for I := 0 to RangeCount - 1 do
   begin
@@ -304,31 +79,26 @@ begin
 end;
 
 function TryExtractCaseFoldPairs(const ABuffer: TBytes;
-  const AEntry: TEmbeddedUCDEntry; const ADataOffset, ADataByteCount: Integer;
+  const AContainer: TEmbeddedResourceContainer;
+  const AEntry: TEmbeddedResourceEntry;
   out APairs: TCodePointPairArray): Boolean;
 var
-  AbsoluteDataOffset, EntryDataEnd: Int64;
+  DataOffset, DataLength: Integer;
   PairCount, I, Offset: Integer;
 begin
   Result := False;
   SetLength(APairs, 0);
 
-  AbsoluteDataOffset := Int64(ADataOffset) + AEntry.DataOffset;
-  EntryDataEnd := Int64(AEntry.DataOffset) + AEntry.DataLength;
-  if (AbsoluteDataOffset < 0) or (AbsoluteDataOffset > High(Integer)) or
-     (EntryDataEnd < 0) or (EntryDataEnd > ADataByteCount) then
+  if not TryGetEmbeddedResourceEntryDataBounds(ABuffer, AContainer, AEntry,
+     DataOffset, DataLength) then
     Exit;
 
-  if not HasBytesAvailable(ABuffer, Integer(AbsoluteDataOffset),
-     AEntry.DataLength) then
+  if (DataLength mod UCD_RANGE_SIZE) <> 0 then
     Exit;
 
-  if (AEntry.DataLength mod UCD_RANGE_SIZE) <> 0 then
-    Exit;
-
-  PairCount := AEntry.DataLength div UCD_RANGE_SIZE;
+  PairCount := DataLength div UCD_RANGE_SIZE;
   SetLength(APairs, PairCount);
-  Offset := Integer(AbsoluteDataOffset);
+  Offset := DataOffset;
 
   for I := 0 to PairCount - 1 do
   begin
@@ -400,9 +170,8 @@ function TryGetEmbeddedPropertyRanges(const AKey: string;
   out ARanges: TUnicodePropertyRangeArray): Boolean;
 var
   Resource: TBytes;
-  Entry: TEmbeddedUCDEntry;
-  EntryCount, EntryTableOffset, NamesOffset, DataOffset: Integer;
-  NamesByteCount, DataByteCount: Integer;
+  Container: TEmbeddedResourceContainer;
+  Entry: TEmbeddedResourceEntry;
 begin
   Result := False;
   SetLength(ARanges, 0);
@@ -410,15 +179,13 @@ begin
   if not TryReadEmbeddedResource(Resource) then
     Exit;
 
-  if not TryReadEmbeddedHeader(Resource, EntryCount, EntryTableOffset, NamesOffset,
-    DataOffset, NamesByteCount, DataByteCount) then
+  if not TryReadEmbeddedResourceContainer(Resource, UCD_MAGIC, Container) then
     Exit;
 
-  if not TryFindEmbeddedEntry(Resource, AKey, EntryCount, EntryTableOffset,
-    NamesOffset, NamesByteCount, Entry) then
+  if not TryFindEmbeddedResourceEntry(Resource, AKey, Container, Entry) then
     Exit;
 
-  Result := TryExtractRanges(Resource, Entry, DataOffset, DataByteCount, ARanges);
+  Result := TryExtractRanges(Resource, Container, Entry, ARanges);
 end;
 
 function TryGetEmbeddedPairs(const AKey: string; var ACachedPairs:
@@ -427,9 +194,8 @@ function TryGetEmbeddedPairs(const AKey: string; var ACachedPairs:
   out APairs: TCodePointPairArray): Boolean;
 var
   Resource: TBytes;
-  Entry: TEmbeddedUCDEntry;
-  EntryCount, EntryTableOffset, NamesOffset, DataOffset: Integer;
-  NamesByteCount, DataByteCount: Integer;
+  Container: TEmbeddedResourceContainer;
+  Entry: TEmbeddedResourceEntry;
 begin
   EnterCriticalSection(ACachedPairsLock);
   try
@@ -448,16 +214,13 @@ begin
     if not TryReadEmbeddedResource(Resource) then
       Exit;
 
-    if not TryReadEmbeddedHeader(Resource, EntryCount, EntryTableOffset,
-       NamesOffset, DataOffset, NamesByteCount, DataByteCount) then
+    if not TryReadEmbeddedResourceContainer(Resource, UCD_MAGIC, Container) then
       Exit;
 
-    if not TryFindEmbeddedEntry(Resource, AKey, EntryCount, EntryTableOffset,
-       NamesOffset, NamesByteCount, Entry) then
+    if not TryFindEmbeddedResourceEntry(Resource, AKey, Container, Entry) then
       Exit;
 
-    if not TryExtractCaseFoldPairs(Resource, Entry, DataOffset, DataByteCount,
-       ACachedPairs) then
+    if not TryExtractCaseFoldPairs(Resource, Container, Entry, ACachedPairs) then
       Exit;
 
     APairs := ACachedPairs;

--- a/source/units/Goccia.Temporal.TimeZoneData.pas
+++ b/source/units/Goccia.Temporal.TimeZoneData.pas
@@ -18,206 +18,10 @@ uses
   EmbeddedResourceReader,
   Generated.TimeZoneData;
 
-type
-  TEmbeddedTimeZoneDataEntry = record
-    NameOffset: Integer;
-    NameLength: Integer;
-    DataOffset: Integer;
-    DataLength: Integer;
-  end;
-
 const
-  TIME_ZONE_DATA_MAGIC_LENGTH = 8;
-  TIME_ZONE_DATA_HEADER_FIELD_SIZE = 4;
-  TIME_ZONE_DATA_HEADER_FIELD_COUNT = 6;
-  TIME_ZONE_DATA_HEADER_SIZE = TIME_ZONE_DATA_MAGIC_LENGTH +
-    TIME_ZONE_DATA_HEADER_FIELD_COUNT * TIME_ZONE_DATA_HEADER_FIELD_SIZE;
-  TIME_ZONE_DATA_ENTRY_SIZE = 16;
-  TIME_ZONE_DATA_FORMAT_VERSION = 1;
   TIME_ZONE_RCDATA_RESOURCE_TYPE = MAKEINTRESOURCE(10);
-  TIME_ZONE_DATA_MAGIC: array[0..TIME_ZONE_DATA_MAGIC_LENGTH - 1] of Byte =
+  TIME_ZONE_DATA_MAGIC: TEmbeddedResourceMagic =
     (Ord('G'), Ord('O'), Ord('C'), Ord('C'), Ord('I'), Ord('A'), Ord('T'), Ord('Z'));
-
-function HasExpectedMagic(const ABuffer: TBytes): Boolean;
-var
-  Index: Integer;
-begin
-  Result := HasBytesAvailable(ABuffer, 0, TIME_ZONE_DATA_MAGIC_LENGTH);
-  if not Result then
-    Exit;
-
-  for Index := 0 to TIME_ZONE_DATA_MAGIC_LENGTH - 1 do
-  begin
-    if ABuffer[Index] <> TIME_ZONE_DATA_MAGIC[Index] then
-    begin
-      Result := False;
-      Exit;
-    end;
-  end;
-end;
-
-function TryReadEmbeddedHeader(const ABuffer: TBytes; out AEntryCount,
-  AEntryTableOffset, ANamesOffset, ADataOffset, ANamesByteCount,
-  ADataByteCount: Integer): Boolean;
-var
-  Offset: Integer;
-  FormatVersion, Reserved: UInt32;
-  VersionLength, EntryCount, NamesByteCount, DataByteCount: Integer;
-  EntryTableOffset, EntryTableByteCount, NamesOffset, DataOffset, TotalSize: Int64;
-begin
-  Result := False;
-  AEntryCount := 0;
-  AEntryTableOffset := 0;
-  ANamesOffset := 0;
-  ADataOffset := 0;
-  ANamesByteCount := 0;
-  ADataByteCount := 0;
-
-  if not HasBytesAvailable(ABuffer, 0, TIME_ZONE_DATA_HEADER_SIZE) then
-    Exit;
-
-  if not HasExpectedMagic(ABuffer) then
-    Exit;
-
-  Offset := TIME_ZONE_DATA_MAGIC_LENGTH;
-  FormatVersion := ReadUInt32LE(ABuffer, Offset); Inc(Offset, TIME_ZONE_DATA_HEADER_FIELD_SIZE);
-  if FormatVersion <> TIME_ZONE_DATA_FORMAT_VERSION then
-    Exit;
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), VersionLength) then
-    Exit;
-  Inc(Offset, TIME_ZONE_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), EntryCount) then
-    Exit;
-  Inc(Offset, TIME_ZONE_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), NamesByteCount) then
-    Exit;
-  Inc(Offset, TIME_ZONE_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), DataByteCount) then
-    Exit;
-  Inc(Offset, TIME_ZONE_DATA_HEADER_FIELD_SIZE);
-
-  Reserved := ReadUInt32LE(ABuffer, Offset);
-  if Reserved <> 0 then
-    Exit;
-
-  EntryTableByteCount := Int64(EntryCount) * TIME_ZONE_DATA_ENTRY_SIZE;
-  if (EntryTableByteCount < 0) or (EntryTableByteCount > High(Integer)) then
-    Exit;
-
-  EntryTableOffset := Int64(TIME_ZONE_DATA_HEADER_SIZE) + VersionLength;
-  NamesOffset := EntryTableOffset + EntryTableByteCount;
-  DataOffset := NamesOffset + NamesByteCount;
-  TotalSize := DataOffset + DataByteCount;
-  if (EntryTableOffset < 0) or (EntryTableOffset > High(Integer)) or
-     (TotalSize < 0) or (TotalSize > High(Integer)) then
-    Exit;
-
-  if not HasBytesAvailable(ABuffer, 0, Integer(TotalSize)) then
-    Exit;
-
-  AEntryCount := EntryCount;
-  AEntryTableOffset := Integer(EntryTableOffset);
-  ANamesOffset := Integer(NamesOffset);
-  ADataOffset := Integer(DataOffset);
-  ANamesByteCount := NamesByteCount;
-  ADataByteCount := DataByteCount;
-  Result := True;
-end;
-
-function TryReadEmbeddedEntry(const ABuffer: TBytes; const AEntryTableOffset,
-  AEntryIndex: Integer; out AEntry: TEmbeddedTimeZoneDataEntry): Boolean;
-var
-  Offset: Integer;
-begin
-  Result := False;
-  AEntry.NameOffset := 0;
-  AEntry.NameLength := 0;
-  AEntry.DataOffset := 0;
-  AEntry.DataLength := 0;
-
-  Offset := AEntryTableOffset + AEntryIndex * TIME_ZONE_DATA_ENTRY_SIZE;
-  if not HasBytesAvailable(ABuffer, Offset, TIME_ZONE_DATA_ENTRY_SIZE) then
-    Exit;
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.NameOffset) then
-    Exit;
-  Inc(Offset, TIME_ZONE_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.NameLength) then
-    Exit;
-  Inc(Offset, TIME_ZONE_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.DataOffset) then
-    Exit;
-  Inc(Offset, TIME_ZONE_DATA_HEADER_FIELD_SIZE);
-
-  if not TryUInt32ToInteger(ReadUInt32LE(ABuffer, Offset), AEntry.DataLength) then
-    Exit;
-
-  Result := True;
-end;
-
-function TryGetEntryName(const ABuffer: TBytes; const AEntry: TEmbeddedTimeZoneDataEntry;
-  const ANamesOffset, ANamesByteCount: Integer; out AName: string): Boolean;
-var
-  AbsoluteOffset, EntryEnd: Int64;
-begin
-  Result := False;
-  AName := '';
-
-  if not HasBytesAvailable(ABuffer, ANamesOffset, ANamesByteCount) then
-    Exit;
-
-  AbsoluteOffset := Int64(ANamesOffset) + AEntry.NameOffset;
-  EntryEnd := Int64(AEntry.NameOffset) + AEntry.NameLength;
-  if (AbsoluteOffset < 0) or (AbsoluteOffset > High(Integer)) or
-     (EntryEnd < 0) or (EntryEnd > ANamesByteCount) then
-    Exit;
-
-  if not HasBytesAvailable(ABuffer, Integer(AbsoluteOffset), AEntry.NameLength) then
-    Exit;
-
-  AName := CopyStringFromBytes(ABuffer, Integer(AbsoluteOffset), AEntry.NameLength);
-  Result := True;
-end;
-
-function TryFindEmbeddedEntry(const ABuffer: TBytes; const ATimeZone: string;
-  const AEntryCount, AEntryTableOffset, ANamesOffset, ANamesByteCount: Integer;
-  out AEntry: TEmbeddedTimeZoneDataEntry): Boolean;
-var
-  LowIndex, HighIndex, MiddleIndex, CompareResult: Integer;
-  EntryName: string;
-begin
-  Result := False;
-  LowIndex := 0;
-  HighIndex := AEntryCount - 1;
-
-  while LowIndex <= HighIndex do
-  begin
-    MiddleIndex := LowIndex + (HighIndex - LowIndex) div 2;
-    if not TryReadEmbeddedEntry(ABuffer, AEntryTableOffset, MiddleIndex, AEntry) then
-      Exit;
-
-    if not TryGetEntryName(ABuffer, AEntry, ANamesOffset, ANamesByteCount, EntryName) then
-      Exit;
-
-    CompareResult := CompareStr(ATimeZone, EntryName);
-    if CompareResult = 0 then
-    begin
-      Result := True;
-      Exit;
-    end;
-
-    if CompareResult < 0 then
-      HighIndex := MiddleIndex - 1
-    else
-      LowIndex := MiddleIndex + 1;
-  end;
-end;
 
 var
   CachedTZResource: TBytes;
@@ -264,10 +68,8 @@ end;
 function TryGetEmbeddedTimeZoneFile(const ATimeZone: string; out ABytes: TBytes): Boolean;
 var
   Resource: TBytes;
-  Entry: TEmbeddedTimeZoneDataEntry;
-  EntryCount, EntryTableOffset, NamesOffset, DataOffset: Integer;
-  NamesByteCount, DataByteCount: Integer;
-  AbsoluteDataOffset, EntryDataEnd: Int64;
+  Container: TEmbeddedResourceContainer;
+  Entry: TEmbeddedResourceEntry;
 begin
   Result := False;
   SetLength(ABytes, 0);
@@ -275,27 +77,14 @@ begin
   if not TryReadEmbeddedResource(Resource) then
     Exit;
 
-  if not TryReadEmbeddedHeader(Resource, EntryCount, EntryTableOffset, NamesOffset,
-    DataOffset, NamesByteCount, DataByteCount) then
+  if not TryReadEmbeddedResourceContainer(Resource, TIME_ZONE_DATA_MAGIC,
+     Container) then
     Exit;
 
-  if not TryFindEmbeddedEntry(Resource, ATimeZone, EntryCount, EntryTableOffset,
-    NamesOffset, NamesByteCount, Entry) then
+  if not TryFindEmbeddedResourceEntry(Resource, ATimeZone, Container, Entry) then
     Exit;
 
-  AbsoluteDataOffset := Int64(DataOffset) + Entry.DataOffset;
-  EntryDataEnd := Int64(Entry.DataOffset) + Entry.DataLength;
-  if (AbsoluteDataOffset < 0) or (AbsoluteDataOffset > High(Integer)) or
-     (EntryDataEnd < 0) or (EntryDataEnd > DataByteCount) then
-    Exit;
-
-  if not HasBytesAvailable(Resource, Integer(AbsoluteDataOffset), Entry.DataLength) then
-    Exit;
-
-  SetLength(ABytes, Entry.DataLength);
-  if Entry.DataLength > 0 then
-    Move(Resource[Integer(AbsoluteDataOffset)], ABytes[0], Entry.DataLength);
-  Result := True;
+  Result := TryCopyEmbeddedResourceEntryData(Resource, Container, Entry, ABytes);
 end;
 
 {$ELSE}


### PR DESCRIPTION
## Summary

- Extract shared generated-resource container building, resource emission, Pascal unit/resource path validation, and HTTP download helpers into `scripts/lib/resource-container.js`.
- Extend `EmbeddedResourceReader` with shared binary container parsing, entry lookup, and data-bounds/copy helpers used by Temporal, Intl, and RegExp resource loaders.
- Add native coverage for the shared embedded resource reader.
- Closes #636

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `node --check scripts/lib/resource-container.js && node --check scripts/generate-timezone-data.js && node --check scripts/generate-intl-data.js && node --check scripts/generate-unicode-data.js`
  - Local HTTP smoke test for redirected `downloadText` / `downloadFileToDisk`
  - `./fixtures/ffi/build.sh`
  - `./build.pas testrunner && ./build/GocciaTestRunner tests --no-progress`
- [x] Updated documentation
  - No docs change needed; reviewed `docs/built-ins-temporal.md` and this is an internal resource-loading refactor with no user-facing behavior change.
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./build.pas tests`
  - `./build/EmbeddedResourceReader.Test`
  - `for t in build/*.Test; do "$t" >/tmp/native-test.log 2>&1 || { cat /tmp/native-test.log; echo "FAILED: $t"; exit 1; }; done`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change