### PR TITLE
Improve test262 high-pass built-in coverage

### DIFF
--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -86,6 +86,31 @@ console.log("ASI at EOF...");
     throw new Error(`Non-ASI EOF declaration should succeed, got: ${JSON.stringify(noAsiRes.json)}`);
 }
 
+// -- ASI after do...while --------------------------------------------------------
+
+console.log("ASI after do...while...");
+{
+  const sameLine = runLoaderJson(
+    "do {} while (false) console.log('bad');\n",
+    ["--compat-asi", "--compat-while-loops"],
+  );
+  if (sameLine.exitCode === 0)
+    throw new Error(`do...while without semicolon or newline should fail under ASI`);
+  if (sameLine.json.ok !== false)
+    throw new Error(`do...while missing semicolon should report JSON failure, got: ${JSON.stringify(sameLine.json)}`);
+  if (sameLine.json.error?.type !== "SyntaxError")
+    throw new Error(`Expected SyntaxError for do...while missing semicolon, got: ${sameLine.json.error?.type}`);
+
+  const newline = runLoaderJson(
+    "do {} while (false)\nconsole.log('after');\n",
+    ["--compat-asi", "--compat-while-loops"],
+  );
+  if (newline.exitCode !== 0)
+    throw new Error(`do...while followed by newline should apply ASI, got: ${JSON.stringify(newline.json)}`);
+  if (normalizeLineEndings(newline.json.output) !== "after\n")
+    throw new Error(`Expected do...while newline ASI output after, got: ${newline.json.output}`);
+}
+
 // -- Unsupported var recovery (ASI and compat-var flags) ------------------------
 
 console.log("Unsupported var recovery (ASI and compat-var flags)...");

--- a/source/units/Goccia.Builtins.GlobalNumber.pas
+++ b/source/units/Goccia.Builtins.GlobalNumber.pas
@@ -82,7 +82,7 @@ var
   I, StartPos: Integer;
   C: Char;
   Sign: Integer;
-  ResultValue: Int64;
+  ResultValue: Double;
   ValidChars: string;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Number.parseInt', ThrowError);
@@ -105,7 +105,18 @@ begin
     if Math.IsNaN(RadixNum) or Math.IsInfinite(RadixNum) then
       Radix := 0
     else
+    begin
+      if RadixNum < 0 then
+        RadixNum := -Floor(Abs(RadixNum))
+      else
+        RadixNum := Floor(RadixNum);
+      RadixNum := FMod(RadixNum, 4294967296.0);
+      if RadixNum < 0 then
+        RadixNum := RadixNum + 4294967296.0;
+      if RadixNum >= 2147483648.0 then
+        RadixNum := RadixNum - 4294967296.0;
       Radix := Trunc(RadixNum);
+    end;
   end
   else
     Radix := 0;

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -360,16 +360,20 @@ begin
   AScope.DefineLexicalBinding(DOM_EXCEPTION_NAME, DOMExceptionConstructorFunc, dtConst, True);
 
   AScope.DefineLexicalBinding('encodeURI',
-    TGocciaNativeFunctionValue.Create(EncodeURICallback, 'encodeURI', 1), dtConst, True);
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      EncodeURICallback, 'encodeURI', 1), dtConst, True);
 
   AScope.DefineLexicalBinding('decodeURI',
-    TGocciaNativeFunctionValue.Create(DecodeURICallback, 'decodeURI', 1), dtConst, True);
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      DecodeURICallback, 'decodeURI', 1), dtConst, True);
 
   AScope.DefineLexicalBinding('encodeURIComponent',
-    TGocciaNativeFunctionValue.Create(EncodeURIComponentCallback, 'encodeURIComponent', 1), dtConst, True);
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      EncodeURIComponentCallback, 'encodeURIComponent', 1), dtConst, True);
 
   AScope.DefineLexicalBinding('decodeURIComponent',
-    TGocciaNativeFunctionValue.Create(DecodeURIComponentCallback, 'decodeURIComponent', 1), dtConst, True);
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      DecodeURIComponentCallback, 'decodeURIComponent', 1), dtConst, True);
 end;
 
 procedure TGocciaGlobals.RegisterUtilityRuntimeGlobals;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1080,6 +1080,10 @@ begin
   else
     GlobalThisObj := TGocciaObjectValue.Create;
 
+  if (not Assigned(GlobalThisObj.Prototype)) and
+     Assigned(TGocciaObjectValue.SharedObjectPrototype) then
+    GlobalThisObj.Prototype := TGocciaObjectValue.SharedObjectPrototype;
+
   for Name in Scope.GetOwnBindingNames do
   begin
     // ES2026 §19.1: Value properties (NaN, Infinity, undefined) are

--- a/source/units/Goccia.ObjectModel.pas
+++ b/source/units/Goccia.ObjectModel.pas
@@ -623,7 +623,8 @@ end;
 function CreateNativeFunctionFromDef(
   const ADefinition: TGocciaMemberDefinition): TGocciaNativeFunctionValue;
 begin
-  if gmfNoFunctionPrototype in ADefinition.MemberFlags then
+  if (ADefinition.Kind in [gmkPrototypeMethod, gmkStaticMethod]) or
+     (gmfNoFunctionPrototype in ADefinition.MemberFlags) then
     Result := TGocciaNativeFunctionValue.CreateWithoutPrototype(
       ADefinition.Callback, ADefinition.ExposedName, ADefinition.Arity)
   else

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -4799,14 +4799,8 @@ begin
   Condition := Expression;
   Consume(gttRightParen, 'Expected ")" after do-while condition',
     SSuggestCloseParenCondition);
-  if Check(gttSemicolon) then
-    Advance
-  else if Check(gttRightBrace) or Check(gttEOF) then
-  begin
-  end
-  else if not FAutomaticSemicolonInsertion then
-    Consume(gttSemicolon, 'Expected ";" after do-while statement',
-      SSuggestAddSemicolon);
+  ConsumeSemicolonOrASI('Expected ";" after do-while statement',
+    SSuggestAddSemicolon);
 
   Result := TGocciaDoWhileStatement.Create(BodyStmt, Condition, Line, Column);
 end;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -119,6 +119,8 @@ type
     function CheckSemicolonOrASI: Boolean;
     function IsIdentifierNameToken(
       const ATokenType: TGocciaTokenType): Boolean;
+    function IsIdentifierBindingToken(
+      const ATokenType: TGocciaTokenType): Boolean;
     function ConsumeModuleExportName(const AMessage: string): TGocciaToken; overload;
     function ConsumeModuleExportName(const AMessage, ASuggestion: string): TGocciaToken; overload;
     function IsReservedKeywordName(const AName: string): Boolean;
@@ -753,6 +755,17 @@ begin
   Result := False;
 end;
 
+function TGocciaParser.IsIdentifierBindingToken(
+  const ATokenType: TGocciaTokenType): Boolean;
+begin
+  case ATokenType of
+    gttIdentifier,
+    gttAs, gttFrom, gttStatic:
+      Exit(True);
+  end;
+  Result := False;
+end;
+
 function TGocciaParser.ConsumeModuleExportName(
   const AMessage: string): TGocciaToken;
 begin
@@ -824,7 +837,8 @@ begin
   if FAutomaticSemicolonInsertion and (Peek.Line < NextToken.Line) then
     Exit(False);
 
-  Result := NextToken.TokenType in [gttIdentifier, gttLeftBrace];
+  Result := IsIdentifierBindingToken(NextToken.TokenType) or
+    (NextToken.TokenType = gttLeftBrace);
 end;
 
 function TGocciaParser.StatementIsDirective(const AStatement: TGocciaStatement;
@@ -870,14 +884,26 @@ end;
 function TGocciaParser.ConsumeIdentifierBinding(
   const AMessage: string): TGocciaToken;
 begin
-  Result := Consume(gttIdentifier, AMessage);
+  if not IsIdentifierBindingToken(Peek.TokenType) then
+    raise TGocciaSyntaxError.Create(AMessage, Peek.Line, Peek.Column,
+      FFileName, FSourceLines);
+  Result := Advance;
   ValidateIdentifierBinding(Result);
 end;
 
 function TGocciaParser.ConsumeIdentifierBinding(const AMessage,
   ASuggestion: string): TGocciaToken;
+var
+  Error: TGocciaSyntaxError;
 begin
-  Result := Consume(gttIdentifier, AMessage, ASuggestion);
+  if not IsIdentifierBindingToken(Peek.TokenType) then
+  begin
+    Error := TGocciaSyntaxError.Create(AMessage, Peek.Line, Peek.Column,
+      FFileName, FSourceLines);
+    Error.Suggestion := ASuggestion;
+    raise Error;
+  end;
+  Result := Advance;
   ValidateIdentifierBinding(Result);
 end;
 
@@ -4773,8 +4799,14 @@ begin
   Condition := Expression;
   Consume(gttRightParen, 'Expected ")" after do-while condition',
     SSuggestCloseParenCondition);
-  ConsumeSemicolonOrASI('Expected ";" after do-while statement',
-    SSuggestAddSemicolon);
+  if Check(gttSemicolon) then
+    Advance
+  else if Check(gttRightBrace) or Check(gttEOF) then
+  begin
+  end
+  else if not FAutomaticSemicolonInsertion then
+    Consume(gttSemicolon, 'Expected ";" after do-while statement',
+      SSuggestAddSemicolon);
 
   Result := TGocciaDoWhileStatement.Create(BodyStmt, Condition, Line, Column);
 end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -9171,13 +9171,17 @@ begin
           SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
           if (FRegisters[B].Kind = grkObject) and
              (FRegisters[B].ObjectValue is TGocciaSymbolValue) then
-            TGocciaClassValue(FRegisters[A].ObjectValue).AssignSymbolProperty(
-              TGocciaSymbolValue(FRegisters[B].ObjectValue), RightValue)
+            TGocciaClassValue(FRegisters[A].ObjectValue).DefineSymbolProperty(
+              TGocciaSymbolValue(FRegisters[B].ObjectValue),
+              TGocciaPropertyDescriptorData.Create(
+                RightValue, [pfConfigurable, pfWritable]))
           else if TryResolveObjectKey(FRegisters[B], PropKeyValue) then
           begin
             if PropKeyValue is TGocciaSymbolValue then
-              TGocciaClassValue(FRegisters[A].ObjectValue).AssignSymbolProperty(
-                TGocciaSymbolValue(PropKeyValue), RightValue)
+              TGocciaClassValue(FRegisters[A].ObjectValue).DefineSymbolProperty(
+                TGocciaSymbolValue(PropKeyValue),
+                TGocciaPropertyDescriptorData.Create(
+                  RightValue, [pfConfigurable, pfWritable]))
             else
             begin
               GlobalName := TGocciaStringLiteralValue(PropKeyValue).Value;
@@ -9185,8 +9189,10 @@ begin
                 SetPropertyValue(FRegisters[A].ObjectValue, GlobalName,
                   RightValue)
               else
-                TGocciaClassValue(FRegisters[A].ObjectValue).SetProperty(
-                  GlobalName, RightValue);
+                TGocciaClassValue(FRegisters[A].ObjectValue).DefineProperty(
+                  GlobalName,
+                  TGocciaPropertyDescriptorData.Create(
+                    RightValue, [pfConfigurable, pfWritable]));
             end;
           end
           else
@@ -9196,8 +9202,10 @@ begin
               SetPropertyValue(FRegisters[A].ObjectValue, GlobalName,
                 RightValue)
             else
-              TGocciaClassValue(FRegisters[A].ObjectValue).SetProperty(
-                GlobalName, RightValue);
+              TGocciaClassValue(FRegisters[A].ObjectValue).DefineProperty(
+                GlobalName,
+                TGocciaPropertyDescriptorData.Create(
+                  RightValue, [pfConfigurable, pfWritable]));
           end;
         end
         else if (FRegisters[A].Kind = grkObject) and

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -3211,37 +3211,57 @@ end;
 function TGocciaArrayValue.GetOwnPropertyKeys: TArray<string>;
 var
   Keys: TArray<string>;
-  Count, I, J: Integer;
+  NumericKeys: TList<Int64>;
+  SeenNumericKeys: TDictionary<Int64, Boolean>;
+  OtherKeys: TList<string>;
+  Count, I: Integer;
   Key: string;
+  Index: Int64;
 begin
   Keys := inherited GetOwnPropertyKeys;
-  Count := 0;
-  SetLength(Result, FElements.Count + Length(Keys));
-
-  for I := 0 to FElements.Count - 1 do
-    if not IsArrayHole(FElements[I]) then
-    begin
-      Result[Count] := IntToStr(I);
-      Inc(Count);
-    end;
-
-  for I := 0 to Length(Keys) - 1 do
-  begin
-    Key := Keys[I];
-    for J := 0 to Count - 1 do
-      if Result[J] = Key then
+  NumericKeys := TList<Int64>.Create;
+  SeenNumericKeys := TDictionary<Int64, Boolean>.Create;
+  OtherKeys := TList<string>.Create;
+  try
+    for I := 0 to FElements.Count - 1 do
+      if not IsArrayHole(FElements[I]) then
       begin
-        Key := '';
-        Break;
+        NumericKeys.Add(I);
+        SeenNumericKeys.Add(I, True);
       end;
-    if Key <> '' then
+
+    for Key in Keys do
     begin
-      Result[Count] := Key;
+      if TryParseArrayElementIndex(Key, Index) then
+      begin
+        if not SeenNumericKeys.ContainsKey(Index) then
+        begin
+          NumericKeys.Add(Index);
+          SeenNumericKeys.Add(Index, True);
+        end;
+      end
+      else
+        OtherKeys.Add(Key);
+    end;
+
+    NumericKeys.Sort(TComparer<Int64>.Construct(CompareInt64));
+    SetLength(Result, NumericKeys.Count + OtherKeys.Count);
+    Count := 0;
+    for I := 0 to NumericKeys.Count - 1 do
+    begin
+      Result[Count] := IntToStr(NumericKeys[I]);
       Inc(Count);
     end;
+    for I := 0 to OtherKeys.Count - 1 do
+    begin
+      Result[Count] := OtherKeys[I];
+      Inc(Count);
+    end;
+  finally
+    OtherKeys.Free;
+    SeenNumericKeys.Free;
+    NumericKeys.Free;
   end;
-
-  SetLength(Result, Count);
 end;
 
 function TGocciaArrayValue.GetAllPropertyNames: TArray<string>;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -48,6 +48,8 @@ type
     function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); override;
     function HasOwnProperty(const AName: string): Boolean; override;
+    function GetOwnPropertyKeys: TArray<string>; override;
+    function GetAllPropertyNames: TArray<string>; override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
     procedure DefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor); override;
     function TryDefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor): Boolean; override;
@@ -3204,6 +3206,47 @@ begin
     Result := True
   else
     Result := inherited HasOwnProperty(AName);
+end;
+
+function TGocciaArrayValue.GetOwnPropertyKeys: TArray<string>;
+var
+  Keys: TArray<string>;
+  Count, I, J: Integer;
+  Key: string;
+begin
+  Keys := inherited GetOwnPropertyKeys;
+  Count := 0;
+  SetLength(Result, FElements.Count + Length(Keys));
+
+  for I := 0 to FElements.Count - 1 do
+    if not IsArrayHole(FElements[I]) then
+    begin
+      Result[Count] := IntToStr(I);
+      Inc(Count);
+    end;
+
+  for I := 0 to Length(Keys) - 1 do
+  begin
+    Key := Keys[I];
+    for J := 0 to Count - 1 do
+      if Result[J] = Key then
+      begin
+        Key := '';
+        Break;
+      end;
+    if Key <> '' then
+    begin
+      Result[Count] := Key;
+      Inc(Count);
+    end;
+  end;
+
+  SetLength(Result, Count);
+end;
+
+function TGocciaArrayValue.GetAllPropertyNames: TArray<string>;
+begin
+  Result := GetOwnPropertyKeys;
 end;
 
 function TGocciaArrayValue.GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -62,6 +62,8 @@ type
     FFieldInitializers: array of TGocciaValue;
     FDecoratorFieldInitializers: array of TGocciaDecoratorFieldInitializerEntry;
     FStaticDecoratorFieldInitializers: array of TGocciaDecoratorFieldInitializerEntry;
+    FNameDeleted: Boolean;
+    FLengthDeleted: Boolean;
     function GetPropertyGetter(const AName: string): TGocciaFunctionBase; inline;
     function GetPropertySetter(const AName: string): TGocciaFunctionBase; inline;
     function GetStaticPropertyGetter(const AName: string): TGocciaFunctionBase; inline;
@@ -104,6 +106,7 @@ type
     function GetPrivateMethod(const AName: string): TGocciaMethodValue;
     procedure AppendOwnPrivateNames(const ANames: TStrings);
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; virtual;
+    function NativeInstanceDefaultPrototype: TGocciaObjectValue; virtual;
     function Instantiate(const AArguments: TGocciaArgumentsCollection;
       const ANewTarget: TGocciaValue = nil): TGocciaValue; virtual;
     function EstimatedInstancePropertyCapacity: Integer;
@@ -114,9 +117,12 @@ type
     function GetClassLength: Integer; virtual;
     function GetProperty(const AName: string): TGocciaValue; override;
     function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
+    procedure DefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor); override;
+    function TryDefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor): Boolean; override;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
     function HasOwnProperty(const AName: string): Boolean; override;
+    function DeleteProperty(const AName: string): Boolean; override;
     function Call(const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; virtual;
 
     procedure ReplacePrototype(const APrototype: TGocciaObjectValue);
@@ -386,6 +392,8 @@ begin
   FNativeSuperConstructor := nil;
   FClassPrototype := TGocciaObjectValue.Create;
   FConstructorMethod := nil;
+  FNameDeleted := False;
+  FLengthDeleted := False;
   if Assigned(FSuperClass) then
     FClassPrototype.Prototype := FSuperClass.Prototype
   else if Assigned(TGocciaObjectValue.SharedObjectPrototype) then
@@ -1046,6 +1054,33 @@ begin
   Result := nil;
 end;
 
+function TGocciaClassValue.NativeInstanceDefaultPrototype: TGocciaObjectValue;
+begin
+  if (Self is TGocciaArrayClassValue) or
+     (Self is TGocciaMapClassValue) or
+     (Self is TGocciaSetClassValue) or
+     (Self is TGocciaWeakMapClassValue) or
+     (Self is TGocciaWeakSetClassValue) or
+     (Self is TGocciaWeakRefClassValue) or
+     (Self is TGocciaFinalizationRegistryClassValue) or
+     (Self is TGocciaStringClassValue) or
+     (Self is TGocciaNumberClassValue) or
+     (Self is TGocciaBooleanClassValue) or
+     (Self is TGocciaArrayBufferClassValue) or
+     (Self is TGocciaSharedArrayBufferClassValue) or
+     (Self is TGocciaDataViewClassValue) or
+     (Self is TGocciaTextEncoderClassValue) or
+     (Self is TGocciaTextDecoderClassValue) or
+     (Self is TGocciaURLClassValue) or
+     (Self is TGocciaURLSearchParamsClassValue) or
+     (Self is TGocciaHeadersClassValue) or
+     (Self is TGocciaResponseClassValue) or
+     (Self is TGocciaFunctionConstructorClassValue) then
+    Result := Prototype
+  else
+    Result := nil;
+end;
+
 procedure TGocciaClassValue.ReplacePrototype(const APrototype: TGocciaObjectValue);
 begin
   FClassPrototype := APrototype;
@@ -1131,27 +1166,43 @@ function TGocciaClassValue.Instantiate(const AArguments: TGocciaArgumentsCollect
 var
   Instance: TGocciaObjectValue;
   WalkClass: TGocciaClassValue;
+  NativeClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
+  NativeIntrinsicPrototype: TGocciaObjectValue;
   ConstructorToCall: TGocciaMethodValue;
   InstancePrototype: TGocciaObjectValue;
   FinalThis: TGocciaValue;
   ConstructResult: TGocciaValue;
 begin
-  // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
-  if Assigned(ANewTarget) then
-    InstancePrototype := GetProtoFromConstructor(ANewTarget)
-  else
-    InstancePrototype := FClassPrototype;
-
+  NativeClass := nil;
   NativeInstance := nil;
+  NativeIntrinsicPrototype := nil;
   WalkClass := Self;
   while Assigned(WalkClass) do
   begin
-    NativeInstance := WalkClass.CreateNativeInstance(AArguments);
-    if Assigned(NativeInstance) then
+    NativeIntrinsicPrototype := WalkClass.NativeInstanceDefaultPrototype;
+    if Assigned(NativeIntrinsicPrototype) then
+    begin
+      NativeClass := WalkClass;
       Break;
+    end;
     WalkClass := WalkClass.SuperClass;
   end;
+
+  // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
+  if Assigned(ANewTarget) then
+  begin
+    if Assigned(NativeClass) then
+      InstancePrototype := GetProtoFromConstructorWithIntrinsic(ANewTarget,
+        NativeIntrinsicPrototype)
+    else
+      InstancePrototype := GetProtoFromConstructor(ANewTarget);
+  end
+  else
+    InstancePrototype := FClassPrototype;
+
+  if Assigned(NativeClass) then
+    NativeInstance := NativeClass.CreateNativeInstance(AArguments);
 
   // ES2026 §10.2.2 step 6: Set proto on the instance before constructor runs
   if Assigned(NativeInstance) then
@@ -1246,6 +1297,12 @@ begin
 
   if AName = PROP_NAME then
   begin
+    if FNameDeleted then
+    begin
+      Result := inherited GetPropertyWithContext(AName, AThisContext);
+      Exit;
+    end;
+
     Descriptor := inherited GetOwnPropertyDescriptor(AName);
     if Assigned(Descriptor) then
     begin
@@ -1262,6 +1319,12 @@ begin
 
   if AName = PROP_LENGTH then
   begin
+    if FLengthDeleted then
+    begin
+      Result := inherited GetPropertyWithContext(AName, AThisContext);
+      Exit;
+    end;
+
     Descriptor := inherited GetOwnPropertyDescriptor(AName);
     if Assigned(Descriptor) then
     begin
@@ -1278,6 +1341,29 @@ begin
   Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
+procedure TGocciaClassValue.DefineProperty(const AName: string;
+  const ADescriptor: TGocciaPropertyDescriptor);
+begin
+  if AName = PROP_NAME then
+    FNameDeleted := False
+  else if AName = PROP_LENGTH then
+    FLengthDeleted := False;
+  inherited DefineProperty(AName, ADescriptor);
+end;
+
+function TGocciaClassValue.TryDefineProperty(const AName: string;
+  const ADescriptor: TGocciaPropertyDescriptor): Boolean;
+begin
+  Result := inherited TryDefineProperty(AName, ADescriptor);
+  if Result then
+  begin
+    if AName = PROP_NAME then
+      FNameDeleted := False
+    else if AName = PROP_LENGTH then
+      FLengthDeleted := False;
+  end;
+end;
+
 procedure TGocciaClassValue.SetProperty(const AName: string; const AValue: TGocciaValue);
 var
   Descriptor: TGocciaPropertyDescriptor;
@@ -1286,6 +1372,7 @@ begin
   // override the synthesized non-writable descriptor (which is configurable)
   if AName = PROP_NAME then
   begin
+    FNameDeleted := False;
     Descriptor := inherited GetOwnPropertyDescriptor(AName);
     if Assigned(Descriptor) then
     begin
@@ -1323,6 +1410,9 @@ begin
     Result := TGocciaPropertyDescriptorData.Create(FClassPrototype, [])
   else if AName = PROP_NAME then
   begin
+    if FNameDeleted then
+      Exit(nil);
+
     // Check if .name was explicitly set (e.g. static name = 'Custom')
     Result := inherited GetOwnPropertyDescriptor(AName);
     if not Assigned(Result) then
@@ -1338,6 +1428,9 @@ begin
   end
   else if AName = PROP_LENGTH then
   begin
+    if FLengthDeleted then
+      Exit(nil);
+
     // Honour explicit own-property redefinitions (length is configurable, so
     // userland may override via Object.defineProperty); fall back to a
     // synthesized descriptor only when no own descriptor exists.
@@ -1352,10 +1445,50 @@ end;
 
 function TGocciaClassValue.HasOwnProperty(const AName: string): Boolean;
 begin
-  if (AName = PROP_PROTOTYPE) or (AName = PROP_NAME) or (AName = PROP_LENGTH) then
+  if AName = PROP_PROTOTYPE then
     Result := True
+  else if AName = PROP_NAME then
+    Result := not FNameDeleted
+  else if AName = PROP_LENGTH then
+    Result := not FLengthDeleted
   else
     Result := inherited HasOwnProperty(AName);
+end;
+
+function TGocciaClassValue.DeleteProperty(const AName: string): Boolean;
+var
+  Descriptor: TGocciaPropertyDescriptor;
+begin
+  Descriptor := inherited GetOwnPropertyDescriptor(AName);
+  if Assigned(Descriptor) then
+  begin
+    Result := inherited DeleteProperty(AName);
+    if Result then
+    begin
+      if AName = PROP_NAME then
+        FNameDeleted := True
+      else if AName = PROP_LENGTH then
+        FLengthDeleted := True;
+    end;
+    Exit;
+  end;
+
+  if AName = PROP_PROTOTYPE then
+    Exit(False);
+
+  if AName = PROP_NAME then
+  begin
+    FNameDeleted := True;
+    Exit(True);
+  end;
+
+  if AName = PROP_LENGTH then
+  begin
+    FLengthDeleted := True;
+    Exit(True);
+  end;
+
+  Result := inherited DeleteProperty(AName);
 end;
 
 function TGocciaClassValue.GetOwnStaticSymbolDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor;

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -631,6 +631,10 @@ begin
   if Assigned(CurrentRealm) then
     CurrentRealm.SetSlot(GFunctionPrototypeSlot, Self);
   try
+    DefineProperty(PROP_LENGTH, TGocciaPropertyDescriptorData.Create(
+      TGocciaNumberLiteralValue.ZeroValue, [pfConfigurable]));
+    DefineProperty(PROP_NAME, TGocciaPropertyDescriptorData.Create(
+      TGocciaStringLiteralValue.Create(''), [pfConfigurable]));
     Members[0] := DefineNamedMethod('call', FunctionCall, 1);
     Members[1] := DefineNamedMethod('apply', FunctionApply, 2);
     Members[2] := DefineNamedMethod('bind', FunctionBind, 1);

--- a/source/units/Goccia.Values.Iterator.Concrete.pas
+++ b/source/units/Goccia.Values.Iterator.Concrete.pas
@@ -107,19 +107,47 @@ uses
 
   TextSemantics,
 
+  Goccia.Realm,
   Goccia.Values.ArrayValue,
   Goccia.Values.HeadersValue,
   Goccia.Values.HoleValue,
   Goccia.Values.MapValue,
+  Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SetValue,
+  Goccia.Values.SymbolValue,
   Goccia.Values.ToObject,
   Goccia.Values.URLSearchParamsValue;
+
+var
+  GArrayIteratorPrototypeSlot: TGocciaRealmSlotId;
+
+function GetSharedArrayIteratorPrototype: TGocciaObjectValue; inline;
+begin
+  if Assigned(CurrentRealm) then
+    Result := TGocciaObjectValue(CurrentRealm.GetSlot(GArrayIteratorPrototypeSlot))
+  else
+    Result := nil;
+end;
 
 { TGocciaArrayIteratorValue }
 
 constructor TGocciaArrayIteratorValue.Create(const ASource: TGocciaValue; const AKind: TGocciaArrayIteratorKind);
+var
+  SharedPrototype: TGocciaObjectValue;
 begin
   inherited Create;
+  SharedPrototype := GetSharedArrayIteratorPrototype;
+  if (not Assigned(SharedPrototype)) and Assigned(CurrentRealm) then
+  begin
+    SharedPrototype := TGocciaObjectValue.Create(FPrototype);
+    SharedPrototype.DefineSymbolProperty(
+      TGocciaSymbolValue.WellKnownToStringTag,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaStringLiteralValue.Create('Array Iterator'), [pfConfigurable]));
+    CurrentRealm.SetSlot(GArrayIteratorPrototypeSlot, SharedPrototype);
+  end;
+  if Assigned(SharedPrototype) then
+    FPrototype := SharedPrototype;
   FSource := ASource;
   FIndex := 0;
   FKind := AKind;
@@ -707,5 +735,8 @@ begin
   if Assigned(FSource) then
     FSource.MarkReferences;
 end;
+
+initialization
+  GArrayIteratorPrototypeSlot := RegisterRealmSlot('ArrayIterator.prototype');
 
 end.

--- a/source/units/Goccia.Values.Iterator.Concrete.pas
+++ b/source/units/Goccia.Values.Iterator.Concrete.pas
@@ -107,11 +107,13 @@ uses
 
   TextSemantics,
 
+  Goccia.GarbageCollector,
   Goccia.Realm,
   Goccia.Values.ArrayValue,
   Goccia.Values.HeadersValue,
   Goccia.Values.HoleValue,
   Goccia.Values.MapValue,
+  Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SetValue,
   Goccia.Values.SymbolValue,
@@ -120,6 +122,9 @@ uses
 
 var
   GArrayIteratorPrototypeSlot: TGocciaRealmSlotId;
+
+threadvar
+  FArrayIteratorMethodHost: TGocciaIteratorValue;
 
 function GetSharedArrayIteratorPrototype: TGocciaObjectValue; inline;
 begin
@@ -140,6 +145,17 @@ begin
   if (not Assigned(SharedPrototype)) and Assigned(CurrentRealm) then
   begin
     SharedPrototype := TGocciaObjectValue.Create(FPrototype);
+    if not Assigned(FArrayIteratorMethodHost) then
+    begin
+      FArrayIteratorMethodHost := TGocciaIteratorValue.Create;
+      if Assigned(TGarbageCollector.Instance) then
+        TGarbageCollector.Instance.PinObject(FArrayIteratorMethodHost);
+    end;
+    SharedPrototype.DefineProperty('next',
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          FArrayIteratorMethodHost.IteratorNext, 'next', 0),
+        [pfConfigurable, pfWritable]));
     SharedPrototype.DefineSymbolProperty(
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaPropertyDescriptorData.Create(

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -137,6 +137,7 @@ type
   public
     constructor Create(const AName: string; const ASuperClass: TGocciaClassValue; const AKind: TGocciaTypedArrayKind);
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function NativeInstanceDefaultPrototype: TGocciaObjectValue; override;
     property Kind: TGocciaTypedArrayKind read FKind;
   end;
 
@@ -2260,6 +2261,11 @@ constructor TGocciaTypedArrayClassValue.Create(const AName: string; const ASuper
 begin
   inherited Create(AName, ASuperClass);
   FKind := AKind;
+end;
+
+function TGocciaTypedArrayClassValue.NativeInstanceDefaultPrototype: TGocciaObjectValue;
+begin
+  Result := Prototype;
 end;
 
 function TGocciaTypedArrayClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;

--- a/tests/built-ins/Array/prototype/values.js
+++ b/tests/built-ins/Array/prototype/values.js
@@ -39,3 +39,14 @@ test("generic receiver iterates array-like values", () => {
   expect(iter.next().value).toBe('b');
   expect(iter.next().done).toBe(true);
 });
+
+test("array iterator prototype owns next with spec descriptor", () => {
+  const proto = Object.getPrototypeOf([].values());
+  const descriptor = Object.getOwnPropertyDescriptor(proto, "next");
+
+  expect(Object.prototype.hasOwnProperty.call(proto, "next")).toBe(true);
+  expect(typeof descriptor.value).toBe("function");
+  expect(descriptor.writable).toBe(true);
+  expect(descriptor.enumerable).toBe(false);
+  expect(descriptor.configurable).toBe(true);
+});

--- a/tests/built-ins/Object/getOwnPropertyNames.js
+++ b/tests/built-ins/Object/getOwnPropertyNames.js
@@ -110,7 +110,11 @@ describe("Object.getOwnPropertyNames", () => {
     });
 
     const names = Object.getOwnPropertyNames(array);
-    expect(names.indexOf("1")).toBeLessThan(names.indexOf("5"));
+    const descriptorIndex = names.indexOf("1");
+    const denseIndex = names.indexOf("5");
+    expect(descriptorIndex).not.toBe(-1);
+    expect(denseIndex).not.toBe(-1);
+    expect(descriptorIndex).toBeLessThan(denseIndex);
   });
 
   test("throws for null", () => {

--- a/tests/built-ins/Object/getOwnPropertyNames.js
+++ b/tests/built-ins/Object/getOwnPropertyNames.js
@@ -98,6 +98,21 @@ describe("Object.getOwnPropertyNames", () => {
     expect(names).toContain("length");
   });
 
+  test("array index names are sorted across dense and descriptor-backed elements", () => {
+    const array = [];
+    array[5] = "dense";
+    Object.defineProperty(array, "1", {
+      get() {
+        return "accessor";
+      },
+      configurable: true,
+      enumerable: true,
+    });
+
+    const names = Object.getOwnPropertyNames(array);
+    expect(names.indexOf("1")).toBeLessThan(names.indexOf("5"));
+  });
+
   test("throws for null", () => {
     expect(() => Object.getOwnPropertyNames(null)).toThrow(TypeError);
   });

--- a/tests/built-ins/TypedArray/constructors.js
+++ b/tests/built-ins/TypedArray/constructors.js
@@ -147,6 +147,45 @@ describe("TypedArray constructors", () => {
   });
 
   describe("new TypedArray(iterable)", () => {
+    test("Reflect.construct resolves newTarget prototype before reading iterable source", () => {
+      const events = [];
+      class NewTargetBase {}
+      const NewTarget = new Proxy(NewTargetBase, {
+        get(target, property) {
+          if (property === "prototype") {
+            events.push("prototype");
+            throw new Error("prototype");
+          }
+          return target[property];
+        },
+      });
+      const iterable = {
+        [Symbol.iterator]() {
+          events.push("iterator");
+          return [][Symbol.iterator]();
+        },
+      };
+
+      expect(() => Reflect.construct(Int8Array, [iterable], NewTarget)).toThrow(Error);
+      expect(events).toEqual(["prototype"]);
+    });
+
+    test("Reflect.construct falls back to typed array prototype for non-object newTarget prototype", () => {
+      const NewTargetBase = (class {}).bind(null);
+      const NewTarget = new Proxy(NewTargetBase, {
+        get(target, property) {
+          if (property === "prototype") {
+            return 1;
+          }
+          return target[property];
+        },
+      });
+
+      const typedArray = Reflect.construct(Int8Array, [2], NewTarget);
+
+      expect(Object.getPrototypeOf(typedArray)).toBe(Int8Array.prototype);
+    });
+
     test("construct from custom iterable", () => {
       const iterable = { [Symbol.iterator]() { let i = 0; const vals = [10, 20, 30]; return { next() { return i < vals.length ? { value: vals[i++], done: false } : { done: true }; } }; } };
       const ta = new Int32Array(iterable);

--- a/tests/language/classes/class-length-property.js
+++ b/tests/language/classes/class-length-property.js
@@ -102,4 +102,16 @@ describe("class length property", () => {
     const descriptor = Object.getOwnPropertyDescriptor(Foo, "length");
     expect(descriptor.value).toBe(99);
   });
+
+  test("computed static length method overrides constructor length", () => {
+    const key = "length";
+    class Foo {
+      static [key]() {
+        return "static length";
+      }
+    }
+
+    expect(typeof Foo.length).toBe("function");
+    expect(Foo.length()).toBe("static length");
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fix several high-pass test262 compatibility gaps across built-in metadata, parser binding tokens, ASI do-while parsing, array key ordering, ArrayIterator prototype metadata, and typed-array construction prototype ordering.
- Tighten built-in function shapes by omitting `.prototype` on built-in methods/global URI functions and add configurable `Function.prototype` metadata.
- Preserve the existing architecture: no new built-in type is introduced; native constructor allocation is reordered through a small prototype-default hook.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas loader testrunner`
  - `bun scripts/test-cli-parser.ts`
  - `./build/GocciaTestRunner tests/built-ins/Object/getOwnPropertyNames.js --no-progress`
  - `./build/GocciaTestRunner tests/built-ins/Object/getOwnPropertyNames.js --mode=bytecode --no-progress`
  - `./build/GocciaTestRunner tests/built-ins/TypedArray/constructors.js`
  - `./build/GocciaTestRunner tests/built-ins/TypedArray/constructors.js --mode=bytecode`
  - `./build/GocciaTestRunner tests --no-progress`
  - `./build/GocciaTestRunner tests --mode=bytecode --no-progress`
- [x] Updated documentation
  - No docs changes required; existing built-ins/language/value-system docs still describe the public surface.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional checks:

- `./format.pas --check`
- targeted pinned test262 checks for `ArrayIteratorPrototype/next/property-descriptor.js` and `class/definition/fn-length-static-precedence.js`
- `git diff --check`
