### PR TITLE
Implement Atomics for SharedArrayBuffer

### DIFF
--- a/docs/built-ins-binary-data.md
+++ b/docs/built-ins-binary-data.md
@@ -1,11 +1,12 @@
 # Binary Data Built-ins
 
-*ArrayBuffer, SharedArrayBuffer, DataView, and TypedArray API reference.*
+*ArrayBuffer, SharedArrayBuffer, Atomics, DataView, and TypedArray API reference.*
 
 ## Executive Summary
 
 - **ArrayBuffer** — raw binary data buffers with fixed-length and resizable modes, transfer semantics, and detachment
 - **SharedArrayBuffer** — fixed-length binary buffer with the same API shape as ArrayBuffer but as a distinct type
+- **Atomics** — atomic read-modify-write, wait/notify, waitAsync, and pause operations over shared integer TypedArray views
 - **DataView** — endian-aware typed reads and writes over ArrayBuffer and SharedArrayBuffer storage
 - **TypedArrays** — array-like views over buffer data with 12 element types (Int8 through Float64, BigInt64, BigUint64)
 - **Uint8Array encoding** — Base64 and hex encoding/decoding
@@ -23,6 +24,14 @@ Internally backed by a zero-initialized `TBytes` array. ArrayBuffer instances ar
 Implements the [ECMAScript SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer). See [MDN SharedArrayBuffer reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) for the full API.
 
 **Full standard compliance.** In GocciaScript, `SharedArrayBuffer` has the same API as `ArrayBuffer` but is a distinct type (not an instance of `ArrayBuffer`). SharedArrayBuffer instances are cloneable via `structuredClone`.
+
+## Atomics (`Goccia.Builtins.Atomics.pas`)
+
+Implements the [ECMAScript Atomics](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics) namespace for shared integer TypedArray views.
+
+Supported operations: `add`, `and`, `compareExchange`, `exchange`, `isLockFree`, `load`, `notify`, `or`, `pause`, `store`, `sub`, `wait`, `waitAsync`, and `xor`.
+
+Atomic memory operations require an integer TypedArray backed by `SharedArrayBuffer`. `wait`, `waitAsync`, and `notify` require `Int32Array` or `BigInt64Array` views.
 
 ## DataView (`Goccia.Values.DataViewValue.pas`)
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-- **Core vs runtime registration** — `TGocciaEngine` always registers core language built-ins (Math, Object, Array, String, Number, RegExp, JSON, Symbol, Set, Map, Promise, Temporal, Intl, ArrayBuffer, TypedArrays, Proxy, Reflect, Iterator, DisposableStack, etc.); `Goccia.Runtime` provides optional runtime globals (Console, JSON5, JSONL, TOML, YAML, CSV, TSV, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, SemVer)
+- **Core vs runtime registration** — `TGocciaEngine` always registers core language built-ins (Math, Object, Array, String, Number, RegExp, JSON, Symbol, Set, Map, Promise, Temporal, Intl, ArrayBuffer, SharedArrayBuffer, Atomics, TypedArrays, Proxy, Reflect, Iterator, DisposableStack, etc.); `Goccia.Runtime` provides optional runtime globals (Console, JSON5, JSONL, TOML, YAML, CSV, TSV, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, SemVer)
 - **Runtime opt-ins** — Testing, benchmarking, FFI, and data-format APIs extend the runtime surface through concrete runtime extension classes
 - **Adding new built-ins** — See [Adding Built-in Types](adding-built-in-types.md) for the step-by-step recipe
 - **Always-present globals** — `globalThis` and `Goccia` namespace are registered after all built-ins
@@ -15,7 +15,7 @@ GocciaScript provides a set of built-in global objects that mirror JavaScript's 
 
 ## Registration System
 
-Core language built-ins (Math, Object, Array, Number, JSON, Symbol, Set, Map, WeakSet, WeakMap, Promise, Temporal, Intl, ArrayBuffer, Proxy, Reflect, etc.) are always registered unconditionally by the engine.
+Core language built-ins (Math, Object, Array, Number, JSON, Symbol, Set, Map, WeakSet, WeakMap, Promise, Temporal, Intl, ArrayBuffer, SharedArrayBuffer, Atomics, Proxy, Reflect, etc.) are always registered unconditionally by the engine.
 
 Runtime globals (Console, JSON5, JSONL, TOML, YAML, CSV, TSV, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, SemVer) are registered by runtime extension classes under `source/units/Goccia.RuntimeExtensions.*.pas`. CLI hosts such as `GocciaScriptLoader` and `GocciaREPL` apply `TGocciaLoaderRuntimeProfile`; `GocciaTestRunner` applies the loader runtime profile plus `TGocciaTestingLibraryRuntimeExtension`; `GocciaBenchmarkRunner` applies the loader runtime profile plus `TGocciaBenchmarkRuntimeExtension`. `GocciaScriptLoaderBare` does not attach a runtime and exposes only a CLI-local `print(...args)` helper by default; the test262 conformance runner may opt into private test262 host capabilities with `--test262-host`.
 
@@ -637,9 +637,9 @@ Core High Resolution Time API:
 
 See [Temporal Built-ins](built-ins-temporal.md) for the complete Temporal API reference (PlainDate, PlainTime, PlainDateTime, Duration, Instant, ZonedDateTime, and more).
 
-### Binary Data (ArrayBuffer, SharedArrayBuffer, DataView, TypedArrays)
+### Binary Data (ArrayBuffer, SharedArrayBuffer, Atomics, DataView, TypedArrays)
 
-See [Binary Data Built-ins](built-ins-binary-data.md) for the complete ArrayBuffer, SharedArrayBuffer, DataView, and TypedArray API reference.
+See [Binary Data Built-ins](built-ins-binary-data.md) for the complete ArrayBuffer, SharedArrayBuffer, Atomics, DataView, and TypedArray API reference.
 
 ### FFI (`Goccia.Builtins.GlobalFFI.pas`)
 

--- a/source/units/Goccia.Builtins.Atomics.pas
+++ b/source/units/Goccia.Builtins.Atomics.pas
@@ -272,10 +272,9 @@ begin
   Result := Trunc(CountNumber);
 end;
 
-procedure ValidateAtomicAccess(const AArgs: TGocciaArgumentsCollection;
+procedure ValidateAtomicTypedArrayAccess(const AArgs: TGocciaArgumentsCollection;
   const AMethodName: string; ARequireWaitable: Boolean;
-  out ATypedArray: TGocciaTypedArrayValue;
-  out ABuffer: TGocciaSharedArrayBufferValue; out AIndex, AByteOffset: Integer);
+  out ATypedArray: TGocciaTypedArrayValue; out AIndex, AByteOffset: Integer);
 var
   Bpe: Integer;
   IndexValue: TGocciaValue;
@@ -296,11 +295,6 @@ begin
     ThrowTypeError(AtomicsErrorMessage(AMethodName,
       'typedArray must be an Int32Array or BigInt64Array'));
 
-  if not (ATypedArray.BufferValue is TGocciaSharedArrayBufferValue) then
-    ThrowTypeError(AtomicsErrorMessage(AMethodName,
-      SErrorRequiresSharedArrayBuffer));
-
-  ABuffer := TGocciaSharedArrayBufferValue(ATypedArray.BufferValue);
   IndexValue := GetArgumentOrUndefined(AArgs, 1);
   AIndex := ToIndexForAtomics(IndexValue, AMethodName);
   if AIndex >= ATypedArray.Length then
@@ -309,6 +303,21 @@ begin
 
   Bpe := TGocciaTypedArrayValue.BytesPerElement(ATypedArray.Kind);
   AByteOffset := ATypedArray.ByteOffset + AIndex * Bpe;
+end;
+
+procedure ValidateAtomicAccess(const AArgs: TGocciaArgumentsCollection;
+  const AMethodName: string; ARequireWaitable: Boolean;
+  out ATypedArray: TGocciaTypedArrayValue;
+  out ABuffer: TGocciaSharedArrayBufferValue; out AIndex, AByteOffset: Integer);
+begin
+  ValidateAtomicTypedArrayAccess(AArgs, AMethodName, ARequireWaitable,
+    ATypedArray, AIndex, AByteOffset);
+
+  if not (ATypedArray.BufferValue is TGocciaSharedArrayBufferValue) then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      SErrorRequiresSharedArrayBuffer));
+
+  ABuffer := TGocciaSharedArrayBufferValue(ATypedArray.BufferValue);
 end;
 
 function ReadNumberElement(ATypedArray: TGocciaTypedArrayValue;
@@ -870,17 +879,20 @@ var
   Count: Integer;
   Index: Integer;
   NotifiedCount: Integer;
-  Promise: TGocciaPromiseValue;
-  ResolvePromises: TList<TGocciaPromiseValue>;
+  ResolveWaiters: TList<TAtomicsWaiter>;
   TypedArray: TGocciaTypedArrayValue;
   Waiter: TAtomicsWaiter;
   WaiterIndex: Integer;
 begin
-  ValidateAtomicAccess(AArgs, 'notify', True, TypedArray, Buffer, Index,
+  ValidateAtomicTypedArrayAccess(AArgs, 'notify', True, TypedArray, Index,
     ByteOffset);
   Count := ToWaiterCount(GetArgumentOrUndefined(AArgs, 2));
+  if not (TypedArray.BufferValue is TGocciaSharedArrayBufferValue) then
+    Exit(TGocciaNumberLiteralValue.Create(0));
+
+  Buffer := TGocciaSharedArrayBufferValue(TypedArray.BufferValue);
   NotifiedCount := 0;
-  ResolvePromises := TList<TGocciaPromiseValue>.Create;
+  ResolveWaiters := TList<TAtomicsWaiter>.Create;
   try
     EnterCriticalSection(GAtomicsLock);
     try
@@ -895,11 +907,7 @@ begin
           GAtomicsWaiters.Delete(WaiterIndex);
           Inc(NotifiedCount);
           if Waiter.Async then
-          begin
-            Promise := Waiter.Promise;
-            ResolvePromises.Add(Promise);
-            Waiter.Free;
-          end
+            ResolveWaiters.Add(Waiter)
           else
             Waiter.Event.SetEvent;
         end
@@ -910,10 +918,13 @@ begin
       LeaveCriticalSection(GAtomicsLock);
     end;
 
-    for Promise in ResolvePromises do
-      Promise.Resolve(TGocciaStringLiteralValue.Create(ATOMICS_WAIT_OK));
+    for Waiter in ResolveWaiters do
+    begin
+      Waiter.Promise.Resolve(TGocciaStringLiteralValue.Create(ATOMICS_WAIT_OK));
+      Waiter.Free;
+    end;
   finally
-    ResolvePromises.Free;
+    ResolveWaiters.Free;
   end;
 
   Result := TGocciaNumberLiteralValue.Create(NotifiedCount);

--- a/source/units/Goccia.Builtins.Atomics.pas
+++ b/source/units/Goccia.Builtins.Atomics.pas
@@ -11,7 +11,11 @@ uses
   Goccia.ObjectModel,
   Goccia.Scope,
   Goccia.Values.ObjectValue,
-  Goccia.Values.Primitives;
+  Goccia.Values.Primitives,
+  Goccia.Values.PromiseValue;
+
+function PumpAtomicsWaitAsyncCompletions: Integer;
+function WaitForAtomicsPromise(const APromise: TGocciaPromiseValue): Boolean;
 
 type
   TGocciaAtomics = class(TGocciaBuiltin)
@@ -69,7 +73,6 @@ uses
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.PromiseValue,
   Goccia.Values.SharedArrayBufferValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.ToPrimitive,
@@ -89,18 +92,23 @@ type
     FAsync: Boolean;
     FBuffer: TGocciaSharedArrayBufferValue;
     FByteOffset: Integer;
+    FDeadlineMilliseconds: QWord;
     FEvent: TEvent;
+    FHasDeadline: Boolean;
     FInList: Boolean;
     FPromise: TGocciaPromiseValue;
   public
     constructor Create(ABuffer: TGocciaSharedArrayBufferValue; AByteOffset: Integer;
-      AAsync: Boolean; APromise: TGocciaPromiseValue);
+      AAsync: Boolean; APromise: TGocciaPromiseValue;
+      ADeadlineMilliseconds: QWord = 0; AHasDeadline: Boolean = False);
     destructor Destroy; override;
 
     property Async: Boolean read FAsync;
     property Buffer: TGocciaSharedArrayBufferValue read FBuffer;
     property ByteOffset: Integer read FByteOffset;
+    property DeadlineMilliseconds: QWord read FDeadlineMilliseconds;
     property Event: TEvent read FEvent;
+    property HasDeadline: Boolean read FHasDeadline;
     property InList: Boolean read FInList write FInList;
     property Promise: TGocciaPromiseValue read FPromise;
   end;
@@ -110,13 +118,16 @@ var
   GAtomicsWaiters: TObjectList<TAtomicsWaiter>;
 
 constructor TAtomicsWaiter.Create(ABuffer: TGocciaSharedArrayBufferValue;
-  AByteOffset: Integer; AAsync: Boolean; APromise: TGocciaPromiseValue);
+  AByteOffset: Integer; AAsync: Boolean; APromise: TGocciaPromiseValue;
+  ADeadlineMilliseconds: QWord; AHasDeadline: Boolean);
 begin
   inherited Create;
   FAsync := AAsync;
   FBuffer := ABuffer;
   FByteOffset := AByteOffset;
+  FDeadlineMilliseconds := ADeadlineMilliseconds;
   FPromise := APromise;
+  FHasDeadline := AHasDeadline;
   FEvent := TEvent.Create(nil, True, False, '');
   FInList := False;
 
@@ -568,6 +579,86 @@ begin
   AWaiter.InList := False;
 end;
 
+function PromiseHasAtomicsWaiter(const APromise: TGocciaPromiseValue): Boolean;
+var
+  I: Integer;
+begin
+  Result := False;
+  EnterCriticalSection(GAtomicsLock);
+  try
+    for I := 0 to GAtomicsWaiters.Count - 1 do
+      if GAtomicsWaiters[I].Async and (GAtomicsWaiters[I].Promise = APromise) then
+        Exit(True);
+  finally
+    LeaveCriticalSection(GAtomicsLock);
+  end;
+end;
+
+function PumpAtomicsWaitAsyncCompletions: Integer;
+var
+  DueWaiters: TList<TAtomicsWaiter>;
+  I: Integer;
+  NowMilliseconds: QWord;
+  Waiter: TAtomicsWaiter;
+begin
+  Result := 0;
+  DueWaiters := TList<TAtomicsWaiter>.Create;
+  try
+    NowMilliseconds := GetTickCount64;
+    EnterCriticalSection(GAtomicsLock);
+    try
+      I := 0;
+      while I < GAtomicsWaiters.Count do
+      begin
+        Waiter := GAtomicsWaiters[I];
+        if Waiter.Async and Waiter.HasDeadline and
+          (NowMilliseconds >= Waiter.DeadlineMilliseconds) then
+        begin
+          Waiter.InList := False;
+          GAtomicsWaiters.Delete(I);
+          DueWaiters.Add(Waiter);
+        end
+        else
+          Inc(I);
+      end;
+    finally
+      LeaveCriticalSection(GAtomicsLock);
+    end;
+
+    for Waiter in DueWaiters do
+    begin
+      Waiter.Promise.Resolve(TGocciaStringLiteralValue.Create(
+        ATOMICS_WAIT_TIMED_OUT));
+      Waiter.Free;
+      Inc(Result);
+    end;
+  finally
+    DueWaiters.Free;
+  end;
+end;
+
+function WaitForAtomicsPromise(const APromise: TGocciaPromiseValue): Boolean;
+begin
+  if not Assigned(APromise) then
+    Exit(False);
+
+  while APromise.State = gpsPending do
+  begin
+    PumpAtomicsWaitAsyncCompletions;
+    if APromise.State <> gpsPending then
+      Exit(True);
+
+    if not PromiseHasAtomicsWaiter(APromise) then
+      Exit(False);
+
+    CheckInstructionLimit;
+    CheckExecutionTimeout;
+    Sleep(1);
+  end;
+
+  Result := True;
+end;
+
 function CurrentWaitValueMatches(ATypedArray: TGocciaTypedArrayValue;
   AByteOffset: Integer; const AExpected: TGocciaValue): Boolean;
 var
@@ -947,6 +1038,8 @@ function TGocciaAtomics.AtomicsWaitAsync(const AArgs: TGocciaArgumentsCollection
 var
   Buffer: TGocciaSharedArrayBufferValue;
   ByteOffset: Integer;
+  DeadlineMilliseconds: QWord;
+  HasDeadline: Boolean;
   Index: Integer;
   Promise: TGocciaPromiseValue;
   TimeoutMilliseconds: Int64;
@@ -968,8 +1061,15 @@ begin
       Exit(CreateWaitAsyncResult(False,
         TGocciaStringLiteralValue.Create(ATOMICS_WAIT_TIMED_OUT)));
 
+    HasDeadline := TimeoutMilliseconds >= 0;
+    if HasDeadline then
+      DeadlineMilliseconds := GetTickCount64 + QWord(TimeoutMilliseconds)
+    else
+      DeadlineMilliseconds := 0;
+
     Promise := TGocciaPromiseValue.Create;
-    Waiter := TAtomicsWaiter.Create(Buffer, ByteOffset, True, Promise);
+    Waiter := TAtomicsWaiter.Create(Buffer, ByteOffset, True, Promise,
+      DeadlineMilliseconds, HasDeadline);
     AddWaiter(Waiter);
     Result := CreateWaitAsyncResult(True, Promise);
   finally

--- a/source/units/Goccia.Builtins.Atomics.pas
+++ b/source/units/Goccia.Builtins.Atomics.pas
@@ -16,6 +16,7 @@ uses
 
 function PumpAtomicsWaitAsyncCompletions: Integer;
 function WaitForAtomicsPromise(const APromise: TGocciaPromiseValue): Boolean;
+procedure ShutdownAtomicsWaiters;
 
 type
   TGocciaAtomics = class(TGocciaBuiltin)
@@ -119,7 +120,16 @@ type
 
 var
   GAtomicsLock: TRTLCriticalSection;
+
+threadvar
   GAtomicsWaiters: TObjectList<TAtomicsWaiter>;
+
+function GetAtomicsWaiters: TObjectList<TAtomicsWaiter>;
+begin
+  if not Assigned(GAtomicsWaiters) then
+    GAtomicsWaiters := TObjectList<TAtomicsWaiter>.Create(False);
+  Result := GAtomicsWaiters;
+end;
 
 constructor TAtomicsWaiter.Create(AOwner: TGocciaAtomics;
   ABuffer: TGocciaSharedArrayBufferValue; AByteOffset: Integer; AAsync: Boolean;
@@ -578,31 +588,35 @@ end;
 procedure AddWaiter(AWaiter: TAtomicsWaiter);
 begin
   AWaiter.InList := True;
-  GAtomicsWaiters.Add(AWaiter);
+  GetAtomicsWaiters.Add(AWaiter);
 end;
 
 procedure RemoveWaiter(AWaiter: TAtomicsWaiter);
 var
   Index: Integer;
+  Waiters: TObjectList<TAtomicsWaiter>;
 begin
   if not AWaiter.InList then
     Exit;
 
-  Index := GAtomicsWaiters.IndexOf(AWaiter);
+  Waiters := GetAtomicsWaiters;
+  Index := Waiters.IndexOf(AWaiter);
   if Index >= 0 then
-    GAtomicsWaiters.Delete(Index);
+    Waiters.Delete(Index);
   AWaiter.InList := False;
 end;
 
 function PromiseHasAtomicsWaiter(const APromise: TGocciaPromiseValue): Boolean;
 var
   I: Integer;
+  Waiters: TObjectList<TAtomicsWaiter>;
 begin
   Result := False;
   EnterCriticalSection(GAtomicsLock);
   try
-    for I := 0 to GAtomicsWaiters.Count - 1 do
-      if GAtomicsWaiters[I].Async and (GAtomicsWaiters[I].Promise = APromise) then
+    Waiters := GetAtomicsWaiters;
+    for I := 0 to Waiters.Count - 1 do
+      if Waiters[I].Async and (Waiters[I].Promise = APromise) then
         Exit(True);
   finally
     LeaveCriticalSection(GAtomicsLock);
@@ -615,6 +629,7 @@ var
   I: Integer;
   NowMilliseconds: QWord;
   Waiter: TAtomicsWaiter;
+  Waiters: TObjectList<TAtomicsWaiter>;
 begin
   Result := 0;
   DueWaiters := TList<TAtomicsWaiter>.Create;
@@ -622,15 +637,16 @@ begin
     NowMilliseconds := GetTickCount64;
     EnterCriticalSection(GAtomicsLock);
     try
+      Waiters := GetAtomicsWaiters;
       I := 0;
-      while I < GAtomicsWaiters.Count do
+      while I < Waiters.Count do
       begin
-        Waiter := GAtomicsWaiters[I];
+        Waiter := Waiters[I];
         if Waiter.Async and Waiter.HasDeadline and
           (NowMilliseconds >= Waiter.DeadlineMilliseconds) then
         begin
           Waiter.InList := False;
-          GAtomicsWaiters.Delete(I);
+          Waiters.Delete(I);
           DueWaiters.Add(Waiter);
         end
         else
@@ -733,6 +749,7 @@ var
   CancelledWaiters: TList<TAtomicsWaiter>;
   I: Integer;
   Waiter: TAtomicsWaiter;
+  Waiters: TObjectList<TAtomicsWaiter>;
 begin
   if not Assigned(GAtomicsWaiters) then
     Exit;
@@ -741,14 +758,15 @@ begin
   try
     EnterCriticalSection(GAtomicsLock);
     try
+      Waiters := GetAtomicsWaiters;
       I := 0;
-      while I < GAtomicsWaiters.Count do
+      while I < Waiters.Count do
       begin
-        Waiter := GAtomicsWaiters[I];
+        Waiter := Waiters[I];
         if Waiter.Async and (Waiter.Owner = AOwner) then
         begin
           Waiter.InList := False;
-          GAtomicsWaiters.Delete(I);
+          Waiters.Delete(I);
           CancelledWaiters.Add(Waiter);
         end
         else
@@ -763,6 +781,23 @@ begin
   finally
     CancelledWaiters.Free;
   end;
+end;
+
+procedure ShutdownAtomicsWaiters;
+var
+  Waiter: TAtomicsWaiter;
+begin
+  if not Assigned(GAtomicsWaiters) then
+    Exit;
+
+  while GAtomicsWaiters.Count > 0 do
+  begin
+    Waiter := GAtomicsWaiters[GAtomicsWaiters.Count - 1];
+    Waiter.InList := False;
+    GAtomicsWaiters.Delete(GAtomicsWaiters.Count - 1);
+    Waiter.Free;
+  end;
+  FreeAndNil(GAtomicsWaiters);
 end;
 
 constructor TGocciaAtomics.Create(const AName: string; AScope: TGocciaScope;
@@ -932,6 +967,7 @@ var
   TypedArray: TGocciaTypedArrayValue;
   Waiter: TAtomicsWaiter;
   WaiterIndex: Integer;
+  Waiters: TObjectList<TAtomicsWaiter>;
 begin
   ValidateAtomicTypedArrayAccess(AArgs, 'notify', True, TypedArray, Index,
     ByteOffset);
@@ -945,15 +981,16 @@ begin
   try
     EnterCriticalSection(GAtomicsLock);
     try
+      Waiters := GetAtomicsWaiters;
       WaiterIndex := 0;
-      while WaiterIndex < GAtomicsWaiters.Count do
+      while WaiterIndex < Waiters.Count do
       begin
-        Waiter := GAtomicsWaiters[WaiterIndex];
+        Waiter := Waiters[WaiterIndex];
         if (Waiter.Buffer = Buffer) and (Waiter.ByteOffset = ByteOffset) and
           ((Count < 0) or (NotifiedCount < Count)) then
         begin
           Waiter.InList := False;
-          GAtomicsWaiters.Delete(WaiterIndex);
+          Waiters.Delete(WaiterIndex);
           Inc(NotifiedCount);
           if Waiter.Async then
             ResolveWaiters.Add(Waiter)
@@ -1145,10 +1182,9 @@ end;
 
 initialization
   InitCriticalSection(GAtomicsLock);
-  GAtomicsWaiters := TObjectList<TAtomicsWaiter>.Create(False);
 
 finalization
-  GAtomicsWaiters.Free;
+  ShutdownAtomicsWaiters;
   DoneCriticalSection(GAtomicsLock);
 
 end.

--- a/source/units/Goccia.Builtins.Atomics.pas
+++ b/source/units/Goccia.Builtins.Atomics.pas
@@ -22,6 +22,7 @@ type
   public
     constructor Create(const AName: string; AScope: TGocciaScope;
       AThrowError: TGocciaThrowErrorCallback);
+    destructor Destroy; override;
   published
     function AtomicsAdd(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -96,9 +97,11 @@ type
     FEvent: TEvent;
     FHasDeadline: Boolean;
     FInList: Boolean;
+    FOwner: TGocciaAtomics;
     FPromise: TGocciaPromiseValue;
   public
-    constructor Create(ABuffer: TGocciaSharedArrayBufferValue; AByteOffset: Integer;
+    constructor Create(AOwner: TGocciaAtomics;
+      ABuffer: TGocciaSharedArrayBufferValue; AByteOffset: Integer;
       AAsync: Boolean; APromise: TGocciaPromiseValue;
       ADeadlineMilliseconds: QWord = 0; AHasDeadline: Boolean = False);
     destructor Destroy; override;
@@ -110,6 +113,7 @@ type
     property Event: TEvent read FEvent;
     property HasDeadline: Boolean read FHasDeadline;
     property InList: Boolean read FInList write FInList;
+    property Owner: TGocciaAtomics read FOwner;
     property Promise: TGocciaPromiseValue read FPromise;
   end;
 
@@ -117,11 +121,13 @@ var
   GAtomicsLock: TRTLCriticalSection;
   GAtomicsWaiters: TObjectList<TAtomicsWaiter>;
 
-constructor TAtomicsWaiter.Create(ABuffer: TGocciaSharedArrayBufferValue;
-  AByteOffset: Integer; AAsync: Boolean; APromise: TGocciaPromiseValue;
-  ADeadlineMilliseconds: QWord; AHasDeadline: Boolean);
+constructor TAtomicsWaiter.Create(AOwner: TGocciaAtomics;
+  ABuffer: TGocciaSharedArrayBufferValue; AByteOffset: Integer; AAsync: Boolean;
+  APromise: TGocciaPromiseValue; ADeadlineMilliseconds: QWord;
+  AHasDeadline: Boolean);
 begin
   inherited Create;
+  FOwner := AOwner;
   FAsync := AAsync;
   FBuffer := ABuffer;
   FByteOffset := AByteOffset;
@@ -722,6 +728,43 @@ begin
   until False;
 end;
 
+procedure CancelAtomicsWaitAsyncForOwner(AOwner: TGocciaAtomics);
+var
+  CancelledWaiters: TList<TAtomicsWaiter>;
+  I: Integer;
+  Waiter: TAtomicsWaiter;
+begin
+  if not Assigned(GAtomicsWaiters) then
+    Exit;
+
+  CancelledWaiters := TList<TAtomicsWaiter>.Create;
+  try
+    EnterCriticalSection(GAtomicsLock);
+    try
+      I := 0;
+      while I < GAtomicsWaiters.Count do
+      begin
+        Waiter := GAtomicsWaiters[I];
+        if Waiter.Async and (Waiter.Owner = AOwner) then
+        begin
+          Waiter.InList := False;
+          GAtomicsWaiters.Delete(I);
+          CancelledWaiters.Add(Waiter);
+        end
+        else
+          Inc(I);
+      end;
+    finally
+      LeaveCriticalSection(GAtomicsLock);
+    end;
+
+    for Waiter in CancelledWaiters do
+      Waiter.Free;
+  finally
+    CancelledWaiters.Free;
+  end;
+end;
+
 constructor TGocciaAtomics.Create(const AName: string; AScope: TGocciaScope;
   AThrowError: TGocciaThrowErrorCallback);
 var
@@ -771,6 +814,12 @@ begin
 
   RegisterMemberDefinitions(FBuiltinObject, StaticMembers);
   AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
+end;
+
+destructor TGocciaAtomics.Destroy;
+begin
+  CancelAtomicsWaitAsyncForOwner(Self);
+  inherited Destroy;
 end;
 
 function TGocciaAtomics.AtomicsAdd(const AArgs: TGocciaArgumentsCollection;
@@ -1024,7 +1073,7 @@ begin
     if TimeoutMilliseconds = 0 then
       Exit(TGocciaStringLiteralValue.Create(ATOMICS_WAIT_TIMED_OUT));
 
-    Waiter := TAtomicsWaiter.Create(Buffer, ByteOffset, False, nil);
+    Waiter := TAtomicsWaiter.Create(Self, Buffer, ByteOffset, False, nil);
     AddWaiter(Waiter);
   finally
     LeaveCriticalSection(GAtomicsLock);
@@ -1079,7 +1128,7 @@ begin
       DeadlineMilliseconds := 0;
 
     Promise := TGocciaPromiseValue.Create;
-    Waiter := TAtomicsWaiter.Create(Buffer, ByteOffset, True, Promise,
+    Waiter := TAtomicsWaiter.Create(Self, Buffer, ByteOffset, True, Promise,
       DeadlineMilliseconds, HasDeadline);
     AddWaiter(Waiter);
     Result := CreateWaitAsyncResult(True, Promise);

--- a/source/units/Goccia.Builtins.Atomics.pas
+++ b/source/units/Goccia.Builtins.Atomics.pas
@@ -1,0 +1,994 @@
+unit Goccia.Builtins.Atomics;
+
+{$mode Delphi}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Builtins.Base,
+  Goccia.Error.ThrowErrorCallback,
+  Goccia.ObjectModel,
+  Goccia.Scope,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaAtomics = class(TGocciaBuiltin)
+  public
+    constructor Create(const AName: string; AScope: TGocciaScope;
+      AThrowError: TGocciaThrowErrorCallback);
+  published
+    function AtomicsAdd(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsAnd(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsCompareExchange(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsExchange(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsIsLockFree(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsLoad(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsNotify(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsOr(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsPause(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsStore(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsSub(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsWait(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsWaitAsync(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AtomicsXor(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+implementation
+
+uses
+  Generics.Collections,
+  Math,
+  SyncObjs,
+  SysUtils,
+
+  BigInteger,
+
+  Goccia.BinaryData,
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.NumericLimits,
+  Goccia.Error.Messages,
+  Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
+  Goccia.Timeout,
+  Goccia.Values.BigIntValue,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.PromiseValue,
+  Goccia.Values.SharedArrayBufferValue,
+  Goccia.Values.SymbolValue,
+  Goccia.Values.ToPrimitive,
+  Goccia.Values.TypedArrayValue;
+
+const
+  ATOMICS_LITTLE_ENDIAN = True;
+  ATOMICS_WAIT_OK = 'ok';
+  ATOMICS_WAIT_NOT_EQUAL = 'not-equal';
+  ATOMICS_WAIT_TIMED_OUT = 'timed-out';
+
+type
+  TGocciaAtomicsOperation = (aoAdd, aoAnd, aoExchange, aoOr, aoSub, aoXor);
+
+  TAtomicsWaiter = class
+  private
+    FAsync: Boolean;
+    FBuffer: TGocciaSharedArrayBufferValue;
+    FByteOffset: Integer;
+    FEvent: TEvent;
+    FInList: Boolean;
+    FPromise: TGocciaPromiseValue;
+  public
+    constructor Create(ABuffer: TGocciaSharedArrayBufferValue; AByteOffset: Integer;
+      AAsync: Boolean; APromise: TGocciaPromiseValue);
+    destructor Destroy; override;
+
+    property Async: Boolean read FAsync;
+    property Buffer: TGocciaSharedArrayBufferValue read FBuffer;
+    property ByteOffset: Integer read FByteOffset;
+    property Event: TEvent read FEvent;
+    property InList: Boolean read FInList write FInList;
+    property Promise: TGocciaPromiseValue read FPromise;
+  end;
+
+var
+  GAtomicsLock: TRTLCriticalSection;
+  GAtomicsWaiters: TObjectList<TAtomicsWaiter>;
+
+constructor TAtomicsWaiter.Create(ABuffer: TGocciaSharedArrayBufferValue;
+  AByteOffset: Integer; AAsync: Boolean; APromise: TGocciaPromiseValue);
+begin
+  inherited Create;
+  FAsync := AAsync;
+  FBuffer := ABuffer;
+  FByteOffset := AByteOffset;
+  FPromise := APromise;
+  FEvent := TEvent.Create(nil, True, False, '');
+  FInList := False;
+
+  if FAsync then
+  begin
+    TGarbageCollector.Instance.AddQueuedRoot(FBuffer);
+    TGarbageCollector.Instance.AddQueuedRoot(FPromise);
+  end;
+end;
+
+destructor TAtomicsWaiter.Destroy;
+begin
+  if FAsync then
+  begin
+    TGarbageCollector.Instance.RemoveQueuedRoot(FPromise);
+    TGarbageCollector.Instance.RemoveQueuedRoot(FBuffer);
+  end;
+  FEvent.Free;
+  inherited Destroy;
+end;
+
+function AtomicsErrorMessage(const AMethodName, AMessage: string): string;
+begin
+  Result := Format('Atomics.%s: %s', [AMethodName, AMessage]);
+end;
+
+function GetArgumentOrUndefined(const AArgs: TGocciaArgumentsCollection;
+  AIndex: Integer): TGocciaValue;
+begin
+  if AIndex < AArgs.Length then
+    Result := AArgs.GetElement(AIndex)
+  else
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function BinaryKindForTypedArray(AKind: TGocciaTypedArrayKind):
+  TGocciaBinaryElementKind;
+begin
+  case AKind of
+    takInt8:
+      Result := bekInt8;
+    takUint8:
+      Result := bekUint8;
+    takUint8Clamped:
+      Result := bekUint8Clamped;
+    takInt16:
+      Result := bekInt16;
+    takUint16:
+      Result := bekUint16;
+    takInt32:
+      Result := bekInt32;
+    takUint32:
+      Result := bekUint32;
+    takBigInt64:
+      Result := bekBigInt64;
+    takBigUint64:
+      Result := bekBigUint64;
+    takFloat16:
+      Result := bekFloat16;
+    takFloat32:
+      Result := bekFloat32;
+    takFloat64:
+      Result := bekFloat64;
+  else
+    Result := bekUint8;
+  end;
+end;
+
+function IsAtomicIntegerKind(AKind: TGocciaTypedArrayKind): Boolean;
+begin
+  Result := AKind in [takInt8, takUint8, takInt16, takUint16, takInt32,
+    takUint32, takBigInt64, takBigUint64];
+end;
+
+function IsWaitableKind(AKind: TGocciaTypedArrayKind): Boolean;
+begin
+  Result := AKind in [takInt32, takBigInt64];
+end;
+
+function IsBigIntKind(AKind: TGocciaTypedArrayKind): Boolean;
+begin
+  Result := AKind in [takBigInt64, takBigUint64];
+end;
+
+function ToIndexForAtomics(const AValue: TGocciaValue;
+  const AMethodName: string): Integer;
+var
+  IndexNumber: Double;
+  IntegerIndex: Double;
+begin
+  IndexNumber := AValue.ToNumberLiteral.Value;
+  if IsNan(IndexNumber) then
+    IndexNumber := 0;
+
+  if IsInfinite(IndexNumber) or
+    (IndexNumber > MAX_SAFE_INTEGER_F) or (IndexNumber > High(Integer)) then
+    ThrowRangeError(AtomicsErrorMessage(AMethodName,
+      'index must be a non-negative integer'));
+
+  IntegerIndex := Trunc(IndexNumber);
+  if IntegerIndex < 0 then
+    ThrowRangeError(AtomicsErrorMessage(AMethodName,
+      'index must be a non-negative integer'));
+
+  Result := Trunc(IntegerIndex);
+end;
+
+function ToTimeoutMilliseconds(const AValue: TGocciaValue): Int64;
+var
+  TimeoutNumber: Double;
+begin
+  if AValue is TGocciaUndefinedLiteralValue then
+    Exit(-1);
+
+  TimeoutNumber := AValue.ToNumberLiteral.Value;
+  if IsNan(TimeoutNumber) or IsInfinite(TimeoutNumber) then
+    Exit(-1);
+
+  if TimeoutNumber <= 0 then
+    Exit(0);
+
+  if TimeoutNumber > High(Int64) then
+    Exit(-1);
+
+  Result := Trunc(TimeoutNumber);
+end;
+
+function ToWaiterCount(const AValue: TGocciaValue): Integer;
+var
+  CountNumber: Double;
+begin
+  if AValue is TGocciaUndefinedLiteralValue then
+    Exit(-1);
+
+  CountNumber := AValue.ToNumberLiteral.Value;
+  if IsNan(CountNumber) or (CountNumber <= 0) then
+    Exit(0);
+
+  if IsInfinite(CountNumber) or (CountNumber > High(Integer)) then
+    Exit(-1);
+
+  Result := Trunc(CountNumber);
+end;
+
+procedure ValidateAtomicAccess(const AArgs: TGocciaArgumentsCollection;
+  const AMethodName: string; ARequireWaitable: Boolean;
+  out ATypedArray: TGocciaTypedArrayValue;
+  out ABuffer: TGocciaSharedArrayBufferValue; out AIndex, AByteOffset: Integer);
+var
+  Bpe: Integer;
+  IndexValue: TGocciaValue;
+  TypedArrayValue: TGocciaValue;
+begin
+  TypedArrayValue := GetArgumentOrUndefined(AArgs, 0);
+  if not (TypedArrayValue is TGocciaTypedArrayValue) then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      'typedArray must be an integer TypedArray'));
+
+  ATypedArray := TGocciaTypedArrayValue(TypedArrayValue);
+
+  if not IsAtomicIntegerKind(ATypedArray.Kind) then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      'typedArray must be an integer TypedArray'));
+
+  if ARequireWaitable and not IsWaitableKind(ATypedArray.Kind) then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      'typedArray must be an Int32Array or BigInt64Array'));
+
+  if not (ATypedArray.BufferValue is TGocciaSharedArrayBufferValue) then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      SErrorRequiresSharedArrayBuffer));
+
+  ABuffer := TGocciaSharedArrayBufferValue(ATypedArray.BufferValue);
+  IndexValue := GetArgumentOrUndefined(AArgs, 1);
+  AIndex := ToIndexForAtomics(IndexValue, AMethodName);
+  if AIndex >= ATypedArray.Length then
+    ThrowRangeError(AtomicsErrorMessage(AMethodName,
+      SErrorInvalidTypedArrayIndex));
+
+  Bpe := TGocciaTypedArrayValue.BytesPerElement(ATypedArray.Kind);
+  AByteOffset := ATypedArray.ByteOffset + AIndex * Bpe;
+end;
+
+function ReadNumberElement(ATypedArray: TGocciaTypedArrayValue;
+  AByteOffset: Integer): Double;
+begin
+  Result := ReadBinaryNumberElement(ATypedArray.BufferData, AByteOffset,
+    BinaryKindForTypedArray(ATypedArray.Kind), ATOMICS_LITTLE_ENDIAN);
+end;
+
+procedure WriteNumberElement(ATypedArray: TGocciaTypedArrayValue;
+  AByteOffset: Integer; AValue: Double);
+var
+  BufferData: TBytes;
+begin
+  BufferData := ATypedArray.BufferData;
+  WriteBinaryNumberElement(BufferData, AByteOffset,
+    BinaryKindForTypedArray(ATypedArray.Kind), AValue, ATOMICS_LITTLE_ENDIAN);
+end;
+
+function ConvertNumberForKind(AKind: TGocciaTypedArrayKind;
+  AValue: TGocciaValue): Double;
+var
+  BufferData: TBytes;
+begin
+  SetLength(BufferData, TGocciaTypedArrayValue.BytesPerElement(AKind));
+  WriteBinaryNumberElement(BufferData, 0, BinaryKindForTypedArray(AKind),
+    AValue.ToNumberLiteral.Value, ATOMICS_LITTLE_ENDIAN);
+  Result := ReadBinaryNumberElement(BufferData, 0, BinaryKindForTypedArray(AKind),
+    ATOMICS_LITTLE_ENDIAN);
+end;
+
+function ToIntegerOrInfinityNumber(const AValue: TGocciaValue): Double;
+var
+  NumberValue: Double;
+begin
+  NumberValue := AValue.ToNumberLiteral.Value;
+  if IsNan(NumberValue) then
+    Exit(0);
+  if (NumberValue = 0) or IsInfinite(NumberValue) then
+    Exit(NumberValue);
+  if NumberValue < 0 then
+    Exit(-Floor(Abs(NumberValue)));
+  Result := Floor(NumberValue);
+end;
+
+function ReadBigIntRawElement(ATypedArray: TGocciaTypedArrayValue;
+  AByteOffset: Integer): Int64;
+begin
+  Result := ReadBinaryBigIntElement(ATypedArray.BufferData, AByteOffset,
+    BinaryKindForTypedArray(ATypedArray.Kind), ATOMICS_LITTLE_ENDIAN);
+end;
+
+procedure WriteBigIntRawElement(ATypedArray: TGocciaTypedArrayValue;
+  AByteOffset: Integer; AValue: Int64);
+var
+  BufferData: TBytes;
+begin
+  BufferData := ATypedArray.BufferData;
+  WriteBinaryBigIntElement(BufferData, AByteOffset, AValue, ATOMICS_LITTLE_ENDIAN);
+end;
+
+function ToBigIntValueForAtomics(const AValue: TGocciaValue): TBigInteger;
+var
+  Primitive: TGocciaValue;
+  TextValue: string;
+  Parsed: TBigInteger;
+begin
+  Primitive := ToPrimitive(AValue, tphNumber);
+  if Primitive is TGocciaBigIntValue then
+    Exit(TGocciaBigIntValue(Primitive).Value);
+
+  if Primitive is TGocciaBooleanLiteralValue then
+  begin
+    if TGocciaBooleanLiteralValue(Primitive).Value then
+      Exit(TGocciaBigIntValue.BigIntOne.Value)
+    else
+      Exit(TGocciaBigIntValue.BigIntZero.Value);
+  end;
+
+  if Primitive is TGocciaStringLiteralValue then
+  begin
+    TextValue := Trim(TGocciaStringLiteralValue(Primitive).Value);
+    if TryStringToBigInt(TextValue, Parsed) then
+      Exit(Parsed);
+  end;
+
+  ThrowTypeError(SErrorBigIntTypedArrayRequiresBigInt);
+  Result := TBigInteger.Zero;
+end;
+
+function ConvertBigIntRawForKind(AKind: TGocciaTypedArrayKind;
+  const AValue: TGocciaValue): Int64; overload;
+var
+  BigIntValue: TBigInteger;
+begin
+  BigIntValue := ToBigIntValueForAtomics(AValue);
+  case AKind of
+    takBigInt64:
+      Result := BigIntValue.AsIntN(64).ToInt64;
+    takBigUint64:
+      Result := BigIntValue.AsUintN(64).ToInt64;
+  else
+    Result := 0;
+  end;
+end;
+
+function ConvertBigIntRawForKind(AKind: TGocciaTypedArrayKind;
+  const ABigIntValue: TBigInteger): Int64; overload;
+begin
+  case AKind of
+    takBigInt64:
+      Result := ABigIntValue.AsIntN(64).ToInt64;
+    takBigUint64:
+      Result := ABigIntValue.AsUintN(64).ToInt64;
+  else
+    Result := 0;
+  end;
+end;
+
+function BigIntFromUInt64(AValue: UInt64): TBigInteger;
+var
+  HighPart: TBigInteger;
+  LowPart: TBigInteger;
+begin
+  HighPart := TBigInteger.FromInt64(Int64(AValue shr 32)).
+    Multiply(TBigInteger.FromInt64($100000000));
+  LowPart := TBigInteger.FromInt64(Int64(AValue and $FFFFFFFF));
+  Result := HighPart.Add(LowPart);
+end;
+
+function BigIntValueFromRaw(AKind: TGocciaTypedArrayKind;
+  AValue: Int64): TGocciaBigIntValue;
+begin
+  if AKind = takBigUint64 then
+    Result := TGocciaBigIntValue.Create(BigIntFromUInt64(UInt64(AValue)))
+  else
+    Result := TGocciaBigIntValue.Create(TBigInteger.FromInt64(AValue));
+end;
+
+function ApplyNumberOperation(AOperation: TGocciaAtomicsOperation; AOldValue,
+  AOperand: Double): Double;
+var
+  OldInteger: Int64;
+  OperandInteger: Int64;
+begin
+  case AOperation of
+    aoAdd:
+      Result := AOldValue + AOperand;
+    aoExchange:
+      Result := AOperand;
+    aoSub:
+      Result := AOldValue - AOperand;
+    aoAnd, aoOr, aoXor:
+      begin
+        OldInteger := Trunc(AOldValue);
+        OperandInteger := Trunc(AOperand);
+        case AOperation of
+          aoAnd:
+            Result := OldInteger and OperandInteger;
+          aoOr:
+            Result := OldInteger or OperandInteger;
+          aoXor:
+            Result := OldInteger xor OperandInteger;
+        else
+          Result := AOldValue;
+        end;
+      end;
+  else
+    Result := AOldValue;
+  end;
+end;
+
+function ApplyBigIntOperation(AOperation: TGocciaAtomicsOperation; AOldValue,
+  AOperand: Int64): Int64;
+var
+  NewValue: UInt64;
+  OldValue: UInt64;
+  OperandValue: UInt64;
+begin
+  OldValue := UInt64(AOldValue);
+  OperandValue := UInt64(AOperand);
+  case AOperation of
+    aoAdd:
+      NewValue := OldValue + OperandValue;
+    aoAnd:
+      NewValue := OldValue and OperandValue;
+    aoExchange:
+      NewValue := OperandValue;
+    aoOr:
+      NewValue := OldValue or OperandValue;
+    aoSub:
+      NewValue := OldValue - OperandValue;
+    aoXor:
+      NewValue := OldValue xor OperandValue;
+  else
+    NewValue := OldValue;
+  end;
+  Result := Int64(NewValue);
+end;
+
+function AtomicReadModifyWrite(const AArgs: TGocciaArgumentsCollection;
+  const AMethodName: string; AOperation: TGocciaAtomicsOperation): TGocciaValue;
+var
+  Buffer: TGocciaSharedArrayBufferValue;
+  ByteOffset: Integer;
+  Index: Integer;
+  NewBigIntRaw: Int64;
+  NewNumber: Double;
+  OldBigIntRaw: Int64;
+  OldNumber: Double;
+  OperandBigIntRaw: Int64;
+  OperandNumber: Double;
+  TypedArray: TGocciaTypedArrayValue;
+begin
+  ValidateAtomicAccess(AArgs, AMethodName, False, TypedArray, Buffer, Index,
+    ByteOffset);
+
+  EnterCriticalSection(GAtomicsLock);
+  try
+    if IsBigIntKind(TypedArray.Kind) then
+    begin
+      OldBigIntRaw := ReadBigIntRawElement(TypedArray, ByteOffset);
+      OperandBigIntRaw := ConvertBigIntRawForKind(TypedArray.Kind,
+        GetArgumentOrUndefined(AArgs, 2));
+      NewBigIntRaw := ApplyBigIntOperation(AOperation, OldBigIntRaw,
+        OperandBigIntRaw);
+      WriteBigIntRawElement(TypedArray, ByteOffset, NewBigIntRaw);
+      Result := BigIntValueFromRaw(TypedArray.Kind, OldBigIntRaw);
+    end
+    else
+    begin
+      OldNumber := ReadNumberElement(TypedArray, ByteOffset);
+      OperandNumber := ToIntegerOrInfinityNumber(GetArgumentOrUndefined(AArgs,
+        2));
+      NewNumber := ApplyNumberOperation(AOperation, OldNumber, OperandNumber);
+      WriteNumberElement(TypedArray, ByteOffset, NewNumber);
+      Result := TGocciaNumberLiteralValue.Create(OldNumber);
+    end;
+  finally
+    LeaveCriticalSection(GAtomicsLock);
+  end;
+end;
+
+function CreateWaitAsyncResult(AAsync: Boolean;
+  const AValue: TGocciaValue): TGocciaObjectValue;
+begin
+  Result := TGocciaObjectValue.Create;
+  Result.AssignProperty('async', TGocciaBooleanLiteralValue.Create(AAsync));
+  Result.AssignProperty('value', AValue);
+end;
+
+procedure AddWaiter(AWaiter: TAtomicsWaiter);
+begin
+  AWaiter.InList := True;
+  GAtomicsWaiters.Add(AWaiter);
+end;
+
+procedure RemoveWaiter(AWaiter: TAtomicsWaiter);
+var
+  Index: Integer;
+begin
+  if not AWaiter.InList then
+    Exit;
+
+  Index := GAtomicsWaiters.IndexOf(AWaiter);
+  if Index >= 0 then
+    GAtomicsWaiters.Delete(Index);
+  AWaiter.InList := False;
+end;
+
+function CurrentWaitValueMatches(ATypedArray: TGocciaTypedArrayValue;
+  AByteOffset: Integer; const AExpected: TGocciaValue): Boolean;
+var
+  ExpectedBigIntRaw: Int64;
+  ExpectedNumber: Double;
+begin
+  if ATypedArray.Kind = takBigInt64 then
+  begin
+    ExpectedBigIntRaw := ConvertBigIntRawForKind(ATypedArray.Kind, AExpected);
+    Result := ReadBigIntRawElement(ATypedArray, AByteOffset) = ExpectedBigIntRaw;
+  end
+  else
+  begin
+    ExpectedNumber := ConvertNumberForKind(ATypedArray.Kind, AExpected);
+    Result := ReadNumberElement(ATypedArray, AByteOffset) = ExpectedNumber;
+  end;
+end;
+
+function WaitForSynchronousWaiter(AWaiter: TAtomicsWaiter;
+  ATimeoutMilliseconds: Int64): string;
+var
+  Deadline: QWord;
+  Remaining: Int64;
+  Slice: LongWord;
+  WaitResult: TWaitResult;
+begin
+  Result := ATOMICS_WAIT_TIMED_OUT;
+  Deadline := 0;
+  if ATimeoutMilliseconds >= 0 then
+    Deadline := GetTickCount64 + QWord(ATimeoutMilliseconds);
+
+  repeat
+    CheckInstructionLimit;
+    CheckExecutionTimeout;
+
+    if ATimeoutMilliseconds < 0 then
+      Slice := 50
+    else
+    begin
+      Remaining := Int64(Deadline - GetTickCount64);
+      if Remaining <= 0 then
+        Break;
+      if Remaining > 50 then
+        Slice := 50
+      else
+        Slice := LongWord(Remaining);
+    end;
+
+    WaitResult := AWaiter.Event.WaitFor(Slice);
+    if WaitResult = wrSignaled then
+      Exit(ATOMICS_WAIT_OK);
+  until False;
+end;
+
+constructor TGocciaAtomics.Create(const AName: string; AScope: TGocciaScope;
+  AThrowError: TGocciaThrowErrorCallback);
+var
+  Members: TGocciaMemberCollection;
+  StaticMembers: TArray<TGocciaMemberDefinition>;
+begin
+  inherited Create(AName, AScope, AThrowError);
+
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddNamedMethod('add', AtomicsAdd, 3, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('and', AtomicsAnd, 3, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('compareExchange', AtomicsCompareExchange, 4,
+      gmkStaticMethod, [gmfNotConstructable]);
+    Members.AddNamedMethod('exchange', AtomicsExchange, 3, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('isLockFree', AtomicsIsLockFree, 1,
+      gmkStaticMethod, [gmfNotConstructable]);
+    Members.AddNamedMethod('load', AtomicsLoad, 2, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('notify', AtomicsNotify, 3, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('or', AtomicsOr, 3, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('pause', AtomicsPause, 0, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('store', AtomicsStore, 3, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('sub', AtomicsSub, 3, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('wait', AtomicsWait, 4, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('waitAsync', AtomicsWaitAsync, 4, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddNamedMethod('xor', AtomicsXor, 3, gmkStaticMethod,
+      [gmfNotConstructable]);
+    Members.AddSymbolDataProperty(
+      TGocciaSymbolValue.WellKnownToStringTag,
+      TGocciaStringLiteralValue.Create('Atomics'),
+      [pfConfigurable]);
+    StaticMembers := Members.ToDefinitions;
+  finally
+    Members.Free;
+  end;
+
+  RegisterMemberDefinitions(FBuiltinObject, StaticMembers);
+  AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
+end;
+
+function TGocciaAtomics.AtomicsAdd(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := AtomicReadModifyWrite(AArgs, 'add', aoAdd);
+end;
+
+function TGocciaAtomics.AtomicsAnd(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := AtomicReadModifyWrite(AArgs, 'and', aoAnd);
+end;
+
+function TGocciaAtomics.AtomicsCompareExchange(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buffer: TGocciaSharedArrayBufferValue;
+  ByteOffset: Integer;
+  ExpectedBigIntRaw: Int64;
+  ExpectedNumber: Double;
+  Index: Integer;
+  OldBigIntRaw: Int64;
+  OldNumber: Double;
+  ReplacementBigIntRaw: Int64;
+  ReplacementNumber: Double;
+  TypedArray: TGocciaTypedArrayValue;
+begin
+  ValidateAtomicAccess(AArgs, 'compareExchange', False, TypedArray, Buffer,
+    Index, ByteOffset);
+
+  EnterCriticalSection(GAtomicsLock);
+  try
+    if IsBigIntKind(TypedArray.Kind) then
+    begin
+      ExpectedBigIntRaw := ConvertBigIntRawForKind(TypedArray.Kind,
+        GetArgumentOrUndefined(AArgs, 2));
+      ReplacementBigIntRaw := ConvertBigIntRawForKind(TypedArray.Kind,
+        GetArgumentOrUndefined(AArgs, 3));
+      OldBigIntRaw := ReadBigIntRawElement(TypedArray, ByteOffset);
+      if OldBigIntRaw = ExpectedBigIntRaw then
+        WriteBigIntRawElement(TypedArray, ByteOffset, ReplacementBigIntRaw);
+      Result := BigIntValueFromRaw(TypedArray.Kind, OldBigIntRaw);
+    end
+    else
+    begin
+      ExpectedNumber := ConvertNumberForKind(TypedArray.Kind,
+        GetArgumentOrUndefined(AArgs, 2));
+      ReplacementNumber := ToIntegerOrInfinityNumber(GetArgumentOrUndefined(
+        AArgs, 3));
+      OldNumber := ReadNumberElement(TypedArray, ByteOffset);
+      if OldNumber = ExpectedNumber then
+        WriteNumberElement(TypedArray, ByteOffset, ReplacementNumber);
+      Result := TGocciaNumberLiteralValue.Create(OldNumber);
+    end;
+  finally
+    LeaveCriticalSection(GAtomicsLock);
+  end;
+end;
+
+function TGocciaAtomics.AtomicsExchange(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := AtomicReadModifyWrite(AArgs, 'exchange', aoExchange);
+end;
+
+function TGocciaAtomics.AtomicsIsLockFree(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Size: Double;
+begin
+  Size := GetArgumentOrUndefined(AArgs, 0).ToNumberLiteral.Value;
+  Result := TGocciaBooleanLiteralValue.Create((Size = 1) or (Size = 2) or
+    (Size = 4) or (Size = 8));
+end;
+
+function TGocciaAtomics.AtomicsLoad(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buffer: TGocciaSharedArrayBufferValue;
+  ByteOffset: Integer;
+  Index: Integer;
+  TypedArray: TGocciaTypedArrayValue;
+begin
+  ValidateAtomicAccess(AArgs, 'load', False, TypedArray, Buffer, Index,
+    ByteOffset);
+
+  EnterCriticalSection(GAtomicsLock);
+  try
+    if IsBigIntKind(TypedArray.Kind) then
+      Result := BigIntValueFromRaw(TypedArray.Kind,
+        ReadBigIntRawElement(TypedArray, ByteOffset))
+    else
+      Result := TGocciaNumberLiteralValue.Create(ReadNumberElement(TypedArray,
+        ByteOffset));
+  finally
+    LeaveCriticalSection(GAtomicsLock);
+  end;
+end;
+
+function TGocciaAtomics.AtomicsNotify(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buffer: TGocciaSharedArrayBufferValue;
+  ByteOffset: Integer;
+  Count: Integer;
+  Index: Integer;
+  NotifiedCount: Integer;
+  Promise: TGocciaPromiseValue;
+  ResolvePromises: TList<TGocciaPromiseValue>;
+  TypedArray: TGocciaTypedArrayValue;
+  Waiter: TAtomicsWaiter;
+  WaiterIndex: Integer;
+begin
+  ValidateAtomicAccess(AArgs, 'notify', True, TypedArray, Buffer, Index,
+    ByteOffset);
+  Count := ToWaiterCount(GetArgumentOrUndefined(AArgs, 2));
+  NotifiedCount := 0;
+  ResolvePromises := TList<TGocciaPromiseValue>.Create;
+  try
+    EnterCriticalSection(GAtomicsLock);
+    try
+      WaiterIndex := 0;
+      while WaiterIndex < GAtomicsWaiters.Count do
+      begin
+        Waiter := GAtomicsWaiters[WaiterIndex];
+        if (Waiter.Buffer = Buffer) and (Waiter.ByteOffset = ByteOffset) and
+          ((Count < 0) or (NotifiedCount < Count)) then
+        begin
+          Waiter.InList := False;
+          GAtomicsWaiters.Delete(WaiterIndex);
+          Inc(NotifiedCount);
+          if Waiter.Async then
+          begin
+            Promise := Waiter.Promise;
+            ResolvePromises.Add(Promise);
+            Waiter.Free;
+          end
+          else
+            Waiter.Event.SetEvent;
+        end
+        else
+          Inc(WaiterIndex);
+      end;
+    finally
+      LeaveCriticalSection(GAtomicsLock);
+    end;
+
+    for Promise in ResolvePromises do
+      Promise.Resolve(TGocciaStringLiteralValue.Create(ATOMICS_WAIT_OK));
+  finally
+    ResolvePromises.Free;
+  end;
+
+  Result := TGocciaNumberLiteralValue.Create(NotifiedCount);
+end;
+
+function TGocciaAtomics.AtomicsOr(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := AtomicReadModifyWrite(AArgs, 'or', aoOr);
+end;
+
+function TGocciaAtomics.AtomicsPause(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  IterationValue: TGocciaValue;
+  Iterations: Double;
+begin
+  IterationValue := GetArgumentOrUndefined(AArgs, 0);
+  if IterationValue is TGocciaUndefinedLiteralValue then
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+
+  if not (IterationValue is TGocciaNumberLiteralValue) then
+    ThrowTypeError(AtomicsErrorMessage('pause',
+      'iterationNumber must be an integral Number'));
+
+  Iterations := TGocciaNumberLiteralValue(IterationValue).Value;
+  if IsNan(Iterations) or IsInfinite(Iterations) or (Frac(Iterations) <> 0) or
+    (Iterations < 0) or (Iterations > MAX_SAFE_INTEGER_F) then
+    ThrowTypeError(AtomicsErrorMessage('pause',
+      'iterationNumber must be an integral Number'));
+
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaAtomics.AtomicsStore(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buffer: TGocciaSharedArrayBufferValue;
+  ByteOffset: Integer;
+  Index: Integer;
+  NewBigIntValue: TBigInteger;
+  NewBigIntRaw: Int64;
+  NewNumber: Double;
+  TypedArray: TGocciaTypedArrayValue;
+begin
+  ValidateAtomicAccess(AArgs, 'store', False, TypedArray, Buffer, Index,
+    ByteOffset);
+
+  EnterCriticalSection(GAtomicsLock);
+  try
+    if IsBigIntKind(TypedArray.Kind) then
+    begin
+      NewBigIntValue := ToBigIntValueForAtomics(GetArgumentOrUndefined(AArgs,
+        2));
+      NewBigIntRaw := ConvertBigIntRawForKind(TypedArray.Kind, NewBigIntValue);
+      WriteBigIntRawElement(TypedArray, ByteOffset, NewBigIntRaw);
+      Result := TGocciaBigIntValue.Create(NewBigIntValue);
+    end
+    else
+    begin
+      NewNumber := ToIntegerOrInfinityNumber(GetArgumentOrUndefined(AArgs, 2));
+      WriteNumberElement(TypedArray, ByteOffset, NewNumber);
+      Result := TGocciaNumberLiteralValue.Create(NewNumber);
+    end;
+  finally
+    LeaveCriticalSection(GAtomicsLock);
+  end;
+end;
+
+function TGocciaAtomics.AtomicsSub(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := AtomicReadModifyWrite(AArgs, 'sub', aoSub);
+end;
+
+function TGocciaAtomics.AtomicsWait(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buffer: TGocciaSharedArrayBufferValue;
+  ByteOffset: Integer;
+  Index: Integer;
+  TimeoutMilliseconds: Int64;
+  TypedArray: TGocciaTypedArrayValue;
+  Waiter: TAtomicsWaiter;
+  WaitResult: string;
+begin
+  ValidateAtomicAccess(AArgs, 'wait', True, TypedArray, Buffer, Index,
+    ByteOffset);
+  TimeoutMilliseconds := ToTimeoutMilliseconds(GetArgumentOrUndefined(AArgs, 3));
+
+  EnterCriticalSection(GAtomicsLock);
+  try
+    if not CurrentWaitValueMatches(TypedArray, ByteOffset,
+      GetArgumentOrUndefined(AArgs, 2)) then
+      Exit(TGocciaStringLiteralValue.Create(ATOMICS_WAIT_NOT_EQUAL));
+
+    if TimeoutMilliseconds = 0 then
+      Exit(TGocciaStringLiteralValue.Create(ATOMICS_WAIT_TIMED_OUT));
+
+    Waiter := TAtomicsWaiter.Create(Buffer, ByteOffset, False, nil);
+    AddWaiter(Waiter);
+  finally
+    LeaveCriticalSection(GAtomicsLock);
+  end;
+
+  try
+    WaitResult := WaitForSynchronousWaiter(Waiter, TimeoutMilliseconds);
+    EnterCriticalSection(GAtomicsLock);
+    try
+      RemoveWaiter(Waiter);
+    finally
+      LeaveCriticalSection(GAtomicsLock);
+    end;
+    Result := TGocciaStringLiteralValue.Create(WaitResult);
+  finally
+    Waiter.Free;
+  end;
+end;
+
+function TGocciaAtomics.AtomicsWaitAsync(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buffer: TGocciaSharedArrayBufferValue;
+  ByteOffset: Integer;
+  Index: Integer;
+  Promise: TGocciaPromiseValue;
+  TimeoutMilliseconds: Int64;
+  TypedArray: TGocciaTypedArrayValue;
+  Waiter: TAtomicsWaiter;
+begin
+  ValidateAtomicAccess(AArgs, 'waitAsync', True, TypedArray, Buffer, Index,
+    ByteOffset);
+  TimeoutMilliseconds := ToTimeoutMilliseconds(GetArgumentOrUndefined(AArgs, 3));
+
+  EnterCriticalSection(GAtomicsLock);
+  try
+    if not CurrentWaitValueMatches(TypedArray, ByteOffset,
+      GetArgumentOrUndefined(AArgs, 2)) then
+      Exit(CreateWaitAsyncResult(False,
+        TGocciaStringLiteralValue.Create(ATOMICS_WAIT_NOT_EQUAL)));
+
+    if TimeoutMilliseconds = 0 then
+      Exit(CreateWaitAsyncResult(False,
+        TGocciaStringLiteralValue.Create(ATOMICS_WAIT_TIMED_OUT)));
+
+    Promise := TGocciaPromiseValue.Create;
+    Waiter := TAtomicsWaiter.Create(Buffer, ByteOffset, True, Promise);
+    AddWaiter(Waiter);
+    Result := CreateWaitAsyncResult(True, Promise);
+  finally
+    LeaveCriticalSection(GAtomicsLock);
+  end;
+end;
+
+function TGocciaAtomics.AtomicsXor(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := AtomicReadModifyWrite(AArgs, 'xor', aoXor);
+end;
+
+initialization
+  InitCriticalSection(GAtomicsLock);
+  GAtomicsWaiters := TObjectList<TAtomicsWaiter>.Create(False);
+
+finalization
+  GAtomicsWaiters.Free;
+  DoneCriticalSection(GAtomicsLock);
+
+end.

--- a/source/units/Goccia.Builtins.GlobalBigInt.pas
+++ b/source/units/Goccia.Builtins.GlobalBigInt.pas
@@ -119,6 +119,8 @@ begin
       SSuggestBigIntNoImplicitConversion);
 
   Arg := AArgs.GetElement(0);
+  if Arg is TGocciaObjectValue then
+    Arg := ToPrimitive(Arg, tphNumber);
 
   // Already a BigInt — return as-is
   if Arg is TGocciaBigIntValue then

--- a/source/units/Goccia.Constants.ConstructorNames.pas
+++ b/source/units/Goccia.Constants.ConstructorNames.pas
@@ -24,6 +24,7 @@ const
   CONSTRUCTOR_PERFORMANCE  = 'Performance';
   CONSTRUCTOR_PROMISE      = 'Promise';
   CONSTRUCTOR_ITERATOR     = 'Iterator';
+  CONSTRUCTOR_ATOMICS             = 'Atomics';
   CONSTRUCTOR_ARRAY_BUFFER        = 'ArrayBuffer';
   CONSTRUCTOR_SHARED_ARRAY_BUFFER = 'SharedArrayBuffer';
   CONSTRUCTOR_DATA_VIEW           = 'DataView';

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -11,6 +11,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.AST.Node,
+  Goccia.Builtins.Atomics,
   Goccia.Builtins.Base,
   Goccia.Builtins.DisposableStack,
   Goccia.Builtins.GlobalArray,
@@ -147,6 +148,7 @@ type
     FBuiltinPromise: TGocciaGlobalPromise;
     FBuiltinTemporal: TGocciaTemporalBuiltin;
     FBuiltinIntl: TGocciaIntlBuiltin;
+    FBuiltinAtomics: TGocciaAtomics;
     FBuiltinArrayBuffer: TGocciaGlobalArrayBuffer;
     FBuiltinProxy: TGocciaGlobalProxy;
     FBuiltinReflect: TGocciaGlobalReflect;
@@ -268,6 +270,7 @@ type
     property BuiltinPromise: TGocciaGlobalPromise read FBuiltinPromise;
     property BuiltinTemporal: TGocciaTemporalBuiltin read FBuiltinTemporal;
     property BuiltinIntl: TGocciaIntlBuiltin read FBuiltinIntl;
+    property BuiltinAtomics: TGocciaAtomics read FBuiltinAtomics;
     property BuiltinArrayBuffer: TGocciaGlobalArrayBuffer read FBuiltinArrayBuffer;
     property BuiltinProxy: TGocciaGlobalProxy read FBuiltinProxy;
     property BuiltinReflect: TGocciaGlobalReflect read FBuiltinReflect;
@@ -626,6 +629,7 @@ begin
     FBuiltinPromise.Free;
     FBuiltinTemporal.Free;
     FBuiltinIntl.Free;
+    FBuiltinAtomics.Free;
     FBuiltinArrayBuffer.Free;
     FBuiltinProxy.Free;
     FBuiltinReflect.Free;
@@ -686,6 +690,7 @@ begin
   FBuiltinPromise := TGocciaGlobalPromise.Create(CONSTRUCTOR_PROMISE, Scope, ThrowError);
   FBuiltinTemporal := TGocciaTemporalBuiltin.Create('Temporal', Scope, ThrowError);
   FBuiltinIntl := TGocciaIntlBuiltin.Create('Intl', Scope, ThrowError);
+  FBuiltinAtomics := TGocciaAtomics.Create(CONSTRUCTOR_ATOMICS, Scope, ThrowError);
   FBuiltinArrayBuffer := TGocciaGlobalArrayBuffer.Create(CONSTRUCTOR_ARRAY_BUFFER, Scope, ThrowError);
   FBuiltinProxy := TGocciaGlobalProxy.Create(Scope);
   FBuiltinReflect := TGocciaGlobalReflect.Create('Reflect', Scope, ThrowError);

--- a/source/units/Goccia.FetchManager.pas
+++ b/source/units/Goccia.FetchManager.pas
@@ -38,6 +38,7 @@ uses
   SyncObjs,
   SysUtils,
 
+  Goccia.Builtins.Atomics,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.Values.ErrorHelper,
@@ -598,6 +599,9 @@ begin
       Manager := TGocciaFetchManager.Instance;
       if Assigned(Manager) and Manager.HasPending and
          (Manager.PumpCompletions > 0) then
+        DidWork := True;
+
+      if PumpAtomicsWaitAsyncCompletions > 0 then
         DidWork := True;
     until not DidWork;
   finally

--- a/source/units/Goccia.Threading.pas
+++ b/source/units/Goccia.Threading.pas
@@ -189,6 +189,7 @@ uses
 
   TimingUtils,
 
+  Goccia.Builtins.Atomics,
   Goccia.Builtins.DisposableStack,
   Goccia.Builtins.Semver,
   Goccia.CallStack,
@@ -229,6 +230,7 @@ begin
   // Coverage tracker is NOT shut down here — the main thread reads it
   // after workers complete, then merges into the main tracker.
   ClearImportMetaCache;
+  ShutdownAtomicsWaiters;
   ClearDisposableStackSlotMap;
   ClearSemverHosts;
   ClearTimeZoneCache;

--- a/source/units/Goccia.Values.Await.pas
+++ b/source/units/Goccia.Values.Await.pas
@@ -15,6 +15,7 @@ uses
   SysUtils,
 
   Goccia.Arguments.Collection,
+  Goccia.Builtins.Atomics,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Error,
@@ -144,6 +145,8 @@ begin
     end;
 
     WaitForFetchPromise(Promise);
+    if Promise.State = gpsPending then
+      WaitForAtomicsPromise(Promise);
 
     if Promise.State = gpsFulfilled then
       Result := Promise.PromiseResult

--- a/tests/built-ins/Atomics/add.js
+++ b/tests/built-ins/Atomics/add.js
@@ -1,0 +1,46 @@
+describe("Atomics.add", () => {
+  test("is exposed on the Atomics namespace object", () => {
+    expect(typeof Atomics).toBe("object");
+    expect(typeof Atomics.add).toBe("function");
+    expect(Object.prototype.toString.call(Atomics)).toBe("[object Atomics]");
+  });
+
+  test("returns the old value and writes the sum", () => {
+    const sab = new SharedArrayBuffer(8);
+    const i32 = new Int32Array(sab);
+    i32[0] = 5;
+
+    expect(Atomics.add(i32, 0, 7)).toBe(5);
+    expect(i32[0]).toBe(12);
+  });
+
+  test("wraps according to the target integer typed array kind", () => {
+    const sab = new SharedArrayBuffer(1);
+    const i8 = new Int8Array(sab);
+    i8[0] = 127;
+
+    expect(Atomics.add(i8, 0, 1)).toBe(127);
+    expect(i8[0]).toBe(-128);
+  });
+
+  test("throws RangeError for out-of-bounds index", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+
+    expect(() => Atomics.add(i32, 1, 1)).toThrow(RangeError);
+  });
+
+  test("throws TypeError for non-shared ArrayBuffer views", () => {
+    const buffer = new ArrayBuffer(4);
+    const i32 = new Int32Array(buffer);
+
+    expect(() => Atomics.add(i32, 0, 1)).toThrow(TypeError);
+  });
+
+  test("throws TypeError for non-integer typed arrays", () => {
+    const sab = new SharedArrayBuffer(4);
+    const f32 = new Float32Array(sab);
+
+    expect(() => Atomics.add(f32, 0, 1)).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Atomics/bigint.js
+++ b/tests/built-ins/Atomics/bigint.js
@@ -1,0 +1,30 @@
+describe("Atomics with BigInt typed arrays", () => {
+  test("load, store, add, and compareExchange use BigInt values", () => {
+    const sab = new SharedArrayBuffer(8);
+    const big = new BigInt64Array(sab);
+
+    expect(Atomics.store(big, 0, 5n)).toBe(5n);
+    expect(Atomics.load(big, 0)).toBe(5n);
+    expect(Atomics.add(big, 0, 3n)).toBe(5n);
+    expect(big[0]).toBe(8n);
+    expect(Atomics.compareExchange(big, 0, 8n, -1n)).toBe(8n);
+    expect(big[0]).toBe(-1n);
+  });
+
+  test("throws TypeError when BigInt atomics receive Number values", () => {
+    const sab = new SharedArrayBuffer(8);
+    const big = new BigInt64Array(sab);
+
+    expect(() => Atomics.store(big, 0, 1)).toThrow(TypeError);
+  });
+
+  test("store returns BigInt(value) before typed-array storage wrapping", () => {
+    const sab = new SharedArrayBuffer(8);
+    const big = new BigInt64Array(sab);
+    const value = { valueOf() { return 33n; } };
+
+    expect(Atomics.store(big, 0, value)).toBe(33n);
+    expect(big[0]).toBe(33n);
+    expect(BigInt(value)).toBe(33n);
+  });
+});

--- a/tests/built-ins/Atomics/isLockFree.js
+++ b/tests/built-ins/Atomics/isLockFree.js
@@ -1,0 +1,13 @@
+describe("Atomics.isLockFree", () => {
+  test("reports lock-free element sizes", () => {
+    expect(Atomics.isLockFree(1)).toBe(true);
+    expect(Atomics.isLockFree(2)).toBe(true);
+    expect(Atomics.isLockFree(4)).toBe(true);
+    expect(Atomics.isLockFree(8)).toBe(true);
+  });
+
+  test("reports non-element sizes as not lock-free", () => {
+    expect(Atomics.isLockFree(3)).toBe(false);
+    expect(Atomics.isLockFree(16)).toBe(false);
+  });
+});

--- a/tests/built-ins/Atomics/load-store-compare-exchange.js
+++ b/tests/built-ins/Atomics/load-store-compare-exchange.js
@@ -1,0 +1,30 @@
+describe("Atomics load, store, and compareExchange", () => {
+  test("load and store read and write shared integer data", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+
+    expect(Atomics.store(i32, 0, 41)).toBe(41);
+    expect(Atomics.load(i32, 0)).toBe(41);
+    expect(i32[0]).toBe(41);
+  });
+
+  test("store returns ToIntegerOrInfinity before typed-array storage wrapping", () => {
+    const sab = new SharedArrayBuffer(1);
+    const i8 = new Int8Array(sab);
+
+    expect(Atomics.store(i8, 0, 12345)).toBe(12345);
+    expect(i8[0]).toBe(57);
+  });
+
+  test("compareExchange writes replacement only when expected matches", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+    i32[0] = 10;
+
+    expect(Atomics.compareExchange(i32, 0, 5, 20)).toBe(10);
+    expect(i32[0]).toBe(10);
+
+    expect(Atomics.compareExchange(i32, 0, 10, 20)).toBe(10);
+    expect(i32[0]).toBe(20);
+  });
+});

--- a/tests/built-ins/Atomics/pause.js
+++ b/tests/built-ins/Atomics/pause.js
@@ -1,0 +1,21 @@
+describe("Atomics.pause", () => {
+  test("returns undefined for omitted and integral Number arguments", () => {
+    expect(Atomics.pause()).toBe(undefined);
+    expect(Atomics.pause(undefined)).toBe(undefined);
+    expect(Atomics.pause(0)).toBe(undefined);
+    expect(Atomics.pause(-0)).toBe(undefined);
+    expect(Atomics.pause(42)).toBe(undefined);
+    expect(Atomics.pause(Number.MAX_SAFE_INTEGER)).toBe(undefined);
+  });
+
+  test("throws TypeError for non-integral or non-Number arguments", () => {
+    expect(() => Atomics.pause(42.42)).toThrow(TypeError);
+    expect(() => Atomics.pause(NaN)).toThrow(TypeError);
+    expect(() => Atomics.pause(Infinity)).toThrow(TypeError);
+    expect(() => Atomics.pause("42")).toThrow(TypeError);
+    expect(() => Atomics.pause(42n)).toThrow(TypeError);
+    expect(() => Atomics.pause({ valueOf() { return 42; } })).toThrow(
+      TypeError,
+    );
+  });
+});

--- a/tests/built-ins/Atomics/read-modify-write.js
+++ b/tests/built-ins/Atomics/read-modify-write.js
@@ -1,0 +1,22 @@
+describe("Atomics read-modify-write methods", () => {
+  test("and, or, xor, sub, and exchange operate atomically", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+
+    i32[0] = 0b1100;
+    expect(Atomics.and(i32, 0, 0b1010)).toBe(0b1100);
+    expect(i32[0]).toBe(0b1000);
+
+    expect(Atomics.or(i32, 0, 0b0011)).toBe(0b1000);
+    expect(i32[0]).toBe(0b1011);
+
+    expect(Atomics.xor(i32, 0, 0b1111)).toBe(0b1011);
+    expect(i32[0]).toBe(0b0100);
+
+    expect(Atomics.sub(i32, 0, 2)).toBe(4);
+    expect(i32[0]).toBe(2);
+
+    expect(Atomics.exchange(i32, 0, 99)).toBe(2);
+    expect(i32[0]).toBe(99);
+  });
+});

--- a/tests/built-ins/Atomics/wait-notify.js
+++ b/tests/built-ins/Atomics/wait-notify.js
@@ -22,6 +22,14 @@ describe("Atomics.wait and Atomics.notify", () => {
     expect(Atomics.notify(i32, 0)).toBe(0);
   });
 
+  test("notify returns zero for non-shared waitable arrays", () => {
+    const i32 = new Int32Array(1);
+    const i64 = new BigInt64Array(1);
+
+    expect(Atomics.notify(i32, 0)).toBe(0);
+    expect(Atomics.notify(i64, 0)).toBe(0);
+  });
+
   test("wait only accepts Int32Array and BigInt64Array", () => {
     const sab = new SharedArrayBuffer(4);
     const u32 = new Uint32Array(sab);

--- a/tests/built-ins/Atomics/wait-notify.js
+++ b/tests/built-ins/Atomics/wait-notify.js
@@ -1,0 +1,31 @@
+describe("Atomics.wait and Atomics.notify", () => {
+  test("wait returns not-equal when current value differs", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+    i32[0] = 1;
+
+    expect(Atomics.wait(i32, 0, 2, 10)).toBe("not-equal");
+  });
+
+  test("wait with zero timeout returns timed-out", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+    i32[0] = 1;
+
+    expect(Atomics.wait(i32, 0, 1, 0)).toBe("timed-out");
+  });
+
+  test("notify returns zero when there are no waiters", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+
+    expect(Atomics.notify(i32, 0)).toBe(0);
+  });
+
+  test("wait only accepts Int32Array and BigInt64Array", () => {
+    const sab = new SharedArrayBuffer(4);
+    const u32 = new Uint32Array(sab);
+
+    expect(() => Atomics.wait(u32, 0, 0, 0)).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Atomics/waitAsync.js
+++ b/tests/built-ins/Atomics/waitAsync.js
@@ -29,4 +29,14 @@ describe("Atomics.waitAsync", () => {
     expect(result.value instanceof Promise).toBe(true);
     expect(Atomics.notify(i32, 0, 1)).toBe(1);
   });
+
+  test("finite timeout promise resolves to timed-out", async () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+    i32[0] = 1;
+
+    const result = Atomics.waitAsync(i32, 0, 1, 1);
+    expect(result.async).toBe(true);
+    expect(await result.value).toBe("timed-out");
+  });
 });

--- a/tests/built-ins/Atomics/waitAsync.js
+++ b/tests/built-ins/Atomics/waitAsync.js
@@ -30,6 +30,17 @@ describe("Atomics.waitAsync", () => {
     expect(Atomics.notify(i32, 0, 1)).toBe(1);
   });
 
+  test("notify resolves an asynchronous waiter promise", async () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+    i32[0] = 1;
+
+    const result = Atomics.waitAsync(i32, 0, 1);
+    expect(result.async).toBe(true);
+    expect(Atomics.notify(i32, 0, 1)).toBe(1);
+    expect(await result.value).toBe("ok");
+  });
+
   test("finite timeout promise resolves to timed-out", async () => {
     const sab = new SharedArrayBuffer(4);
     const i32 = new Int32Array(sab);

--- a/tests/built-ins/Atomics/waitAsync.js
+++ b/tests/built-ins/Atomics/waitAsync.js
@@ -1,0 +1,32 @@
+describe("Atomics.waitAsync", () => {
+  test("returns synchronous not-equal result when current value differs", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+    i32[0] = 1;
+
+    const result = Atomics.waitAsync(i32, 0, 2, 10);
+    expect(result.async).toBe(false);
+    expect(result.value).toBe("not-equal");
+  });
+
+  test("returns synchronous timed-out result for zero timeout", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+    i32[0] = 1;
+
+    const result = Atomics.waitAsync(i32, 0, 1, 0);
+    expect(result.async).toBe(false);
+    expect(result.value).toBe("timed-out");
+  });
+
+  test("returns a pending promise when the wait is asynchronous", () => {
+    const sab = new SharedArrayBuffer(4);
+    const i32 = new Int32Array(sab);
+    i32[0] = 1;
+
+    const result = Atomics.waitAsync(i32, 0, 1);
+    expect(result.async).toBe(true);
+    expect(result.value instanceof Promise).toBe(true);
+    expect(Atomics.notify(i32, 0, 1)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the core `Atomics` namespace for `SharedArrayBuffer`-backed integer TypedArray views, including read-modify-write methods, `load`, `store`, `compareExchange`, `wait`, `waitAsync`, `notify`, `isLockFree`, and ES2026 `pause`.
- Adds waiter-list support keyed by shared buffer storage and byte offset, with synchronous `wait`, `notify` wakeups, lifecycle cleanup, thread-local worker isolation, and a main-thread pump for finite `waitAsync` timeouts.
- Fixes `BigInt()` object-to-primitive coercion needed by BigInt Atomics conformance.
- Documents Atomics in the built-ins index and binary-data API reference.
- Closes #541.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas testrunner`
  - `./build/GocciaTestRunner tests --no-progress --jobs=4`
  - `./build/GocciaTestRunner tests --silent --no-progress --output=/tmp/goccia-test-results-interpreted.json`
  - `./build/GocciaTestRunner tests/built-ins/global-properties/goccia.js --no-progress --silent`
  - `./build/GocciaTestRunner tests/built-ins/Atomics --no-progress`
  - `./build.pas loaderbare`
  - `./format.pas --check`
  - Selected pinned test262 Atomics bad-range, good-views, and pause files using `/tmp/goccia-test262-d0c1b455`
  - `bun scripts/run_test262_suite.ts --filter "built-ins/Atomics/notify/non-shared-bufferdata-returns-0.js" --jobs=1`
  - `bun scripts/run_test262_suite.ts --filter "built-ins/Atomics/notify/bigint/non-shared-bufferdata-returns-0.js" --jobs=1`
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change