### PR TITLE
Fix class method destructuring params in bytecode

### DIFF
--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -102,6 +102,8 @@ procedure EmitBindingAssignmentFromRegister(const ACtx: TGocciaCompilationContex
 procedure EmitDestructuring(const ACtx: TGocciaCompilationContext;
   const APattern: TGocciaDestructuringPattern; const ASrcReg: UInt8;
   const AAssignmentMode: Boolean = False);
+procedure EmitDestructuringParameters(const ACtx: TGocciaCompilationContext;
+  const AParams: TGocciaParameterArray);
 procedure CompileDestructuringAssignment(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaDestructuringAssignmentExpression; const ADest: UInt8);
 

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -90,6 +90,7 @@ procedure CompileYield(const ACtx: TGocciaCompilationContext;
 
 procedure EmitDefaultParameters(const ACtx: TGocciaCompilationContext;
   const AParams: TGocciaParameterArray);
+function SyntheticParamLocalName(const AIndex: Integer): string;
 function DeclareArgumentsObjectLocal(const ACtx: TGocciaCompilationContext;
   const AScope: TGocciaCompilerScope; const AParams: TGocciaParameterArray): Integer;
 procedure EmitCreateArgumentsObject(const ACtx: TGocciaCompilationContext;
@@ -1272,6 +1273,11 @@ begin
   Result := AScope.DeclareLocal(IDENTIFIER_ARGUMENTS, False);
 end;
 
+function SyntheticParamLocalName(const AIndex: Integer): string;
+begin
+  Result := '`#param`:' + IntToStr(AIndex);
+end;
+
 procedure EmitCreateArgumentsObject(const ACtx: TGocciaCompilationContext;
   const AArgumentsSlot: Integer);
 begin
@@ -1293,7 +1299,7 @@ begin
       Continue;
     if AParams[I].IsPattern then
     begin
-      LocalIdx := ACtx.Scope.ResolveLocal('__param' + IntToStr(I));
+      LocalIdx := ACtx.Scope.ResolveLocal(SyntheticParamLocalName(I));
       if LocalIdx < 0 then
         Continue;
       Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
@@ -1644,7 +1650,7 @@ begin
     if not Assigned(AParams[I].Pattern) then
       Continue;
 
-    LocalIdx := ACtx.Scope.ResolveLocal('__param' + IntToStr(I));
+    LocalIdx := ACtx.Scope.ResolveLocal(SyntheticParamLocalName(I));
     if LocalIdx < 0 then
       Continue;
     ParamSlot := ACtx.Scope.GetLocal(LocalIdx).Slot;
@@ -1677,7 +1683,7 @@ begin
     if AnnotationType = sltUntyped then
       Continue;
     if AParameters[I].IsPattern then
-      ParamName := '__param' + IntToStr(I)
+      ParamName := SyntheticParamLocalName(I)
     else
       ParamName := AParameters[I].Name;
     LocalIdx := AScope.ResolveLocal(ParamName);
@@ -1708,7 +1714,7 @@ begin
     if AParameters[I].IsRest then
       Continue;
     if AParameters[I].IsPattern then
-      ParamName := '__param' + IntToStr(I)
+      ParamName := SyntheticParamLocalName(I)
     else
       ParamName := AParameters[I].Name;
     LocalIdx := ACtx.Scope.ResolveLocal(ParamName);
@@ -1766,7 +1772,7 @@ begin
         RestParamIndex := I;
     end;
     if AExpr.Parameters[I].IsPattern then
-      ChildScope.DeclareLocal('__param' + IntToStr(I), False)
+      ChildScope.DeclareLocal(SyntheticParamLocalName(I), False)
     else
       ChildScope.DeclareLocal(AExpr.Parameters[I].Name, False);
   end;
@@ -3085,7 +3091,7 @@ begin
         RestParamIndex := I;
     end;
     if AExpr.Parameters[I].IsPattern then
-      ChildScope.DeclareLocal('__param' + IntToStr(I), False)
+      ChildScope.DeclareLocal(SyntheticParamLocalName(I), False)
     else
       ChildScope.DeclareLocal(AExpr.Parameters[I].Name, False);
   end;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -3748,7 +3748,7 @@ begin
         RestParamIndex := I;
     end;
     if AMethod.Parameters[I].IsPattern then
-      ChildScope.DeclareLocal('__param' + IntToStr(I), False)
+      ChildScope.DeclareLocal(SyntheticParamLocalName(I), False)
     else
       ChildScope.DeclareLocal(AMethod.Parameters[I].Name, False);
   end;
@@ -4108,7 +4108,7 @@ begin
         RestParamIndex := I;
     end;
     if AMethod.Parameters[I].IsPattern then
-      ChildScope.DeclareLocal('__param' + IntToStr(I), False)
+      ChildScope.DeclareLocal(SyntheticParamLocalName(I), False)
     else
       ChildScope.DeclareLocal(AMethod.Parameters[I].Name, False);
   end;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -3747,8 +3747,14 @@ begin
       if AMethod.Parameters[I].IsRest then
         RestParamIndex := I;
     end;
-    ChildScope.DeclareLocal(AMethod.Parameters[I].Name, False);
+    if AMethod.Parameters[I].IsPattern then
+      ChildScope.DeclareLocal('__param' + IntToStr(I), False)
+    else
+      ChildScope.DeclareLocal(AMethod.Parameters[I].Name, False);
   end;
+  for I := 0 to High(AMethod.Parameters) do
+    if AMethod.Parameters[I].IsPattern and Assigned(AMethod.Parameters[I].Pattern) then
+      CollectDestructuringBindings(AMethod.Parameters[I].Pattern, ChildScope);
   ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AMethod.Parameters);
   if FormalCount < 0 then
     FormalCount := Length(AMethod.Parameters);
@@ -3774,6 +3780,7 @@ begin
       UInt8(RestParamIndex), 0));
 
   EmitDefaultParameters(ChildCtx, AMethod.Parameters);
+  EmitDestructuringParameters(ChildCtx, AMethod.Parameters);
 
   ACtx.CompileFunctionBody(AMethod.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
@@ -4100,8 +4107,14 @@ begin
       if AMethod.Parameters[I].IsRest then
         RestParamIndex := I;
     end;
-    ChildScope.DeclareLocal(AMethod.Parameters[I].Name, False);
+    if AMethod.Parameters[I].IsPattern then
+      ChildScope.DeclareLocal('__param' + IntToStr(I), False)
+    else
+      ChildScope.DeclareLocal(AMethod.Parameters[I].Name, False);
   end;
+  for I := 0 to High(AMethod.Parameters) do
+    if AMethod.Parameters[I].IsPattern and Assigned(AMethod.Parameters[I].Pattern) then
+      CollectDestructuringBindings(AMethod.Parameters[I].Pattern, ChildScope);
   ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AMethod.Parameters);
   if FormalCount < 0 then
     FormalCount := Length(AMethod.Parameters);
@@ -4127,6 +4140,7 @@ begin
       UInt8(RestParamIndex), 0));
 
   EmitDefaultParameters(ChildCtx, AMethod.Parameters);
+  EmitDestructuringParameters(ChildCtx, AMethod.Parameters);
 
   ACtx.CompileFunctionBody(AMethod.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;

--- a/tests/language/classes/destructuring-parameters.js
+++ b/tests/language/classes/destructuring-parameters.js
@@ -44,4 +44,21 @@ describe("class method destructuring parameters", () => {
 
     expect(new Calculator().count([10, 20, 30, 40])).toBe(13);
   });
+
+  test("synthetic pattern parameter locals do not shadow source parameters", () => {
+    class Calculator {
+      beforePattern(__param1, [value]) {
+        return __param1 + value;
+      }
+
+      afterPattern([value], __param0) {
+        return value + __param0;
+      }
+    }
+
+    const calculator = new Calculator();
+
+    expect(calculator.beforePattern(3, [4])).toBe(7);
+    expect(calculator.afterPattern([5], 6)).toBe(11);
+  });
 });

--- a/tests/language/classes/destructuring-parameters.js
+++ b/tests/language/classes/destructuring-parameters.js
@@ -1,0 +1,47 @@
+/*---
+description: Class methods support destructuring parameters
+features: [class-declaration, destructuring, default-parameters]
+---*/
+
+describe("class method destructuring parameters", () => {
+  test("instance methods bind array destructuring parameters", () => {
+    class Calculator {
+      sum([a, b, c]) {
+        return a + b + c;
+      }
+    }
+
+    expect(new Calculator().sum([1, 2, 3])).toBe(6);
+  });
+
+  test("computed instance methods bind object destructuring parameters", () => {
+    class Calculator {
+      ["sum"]({ left, right }) {
+        return left + right;
+      }
+    }
+
+    expect(new Calculator().sum({ left: 2, right: 5 })).toBe(7);
+  });
+
+  test("static methods bind nested destructuring parameters with defaults", () => {
+    class Calculator {
+      static sum({ values: [a, b = 10] }) {
+        return a + b;
+      }
+    }
+
+    expect(Calculator.sum({ values: [4] })).toBe(14);
+    expect(Calculator.sum({ values: [4, 6] })).toBe(10);
+  });
+
+  test("methods bind rest elements in destructuring parameters", () => {
+    class Calculator {
+      count([first, ...rest]) {
+        return first + rest.length;
+      }
+    }
+
+    expect(new Calculator().count([10, 20, 30, 40])).toBe(13);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Compile class method destructuring parameters through the shared bytecode parameter destructuring path.
- Covers normal, computed, static, defaulted, nested, rest, and synthetic-name collision cases for destructuring method parameters.
- Keeps the fix in compiler lowering for bytecode while preserving interpreter behavior; no new opcode/runtime concept is introduced.
- Uses a hidden shared synthetic local name for bytecode destructuring parameter backing slots so generated locals cannot collide with source parameters such as `__param0`.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Verification run:

- `./build.pas testrunner`
- `./build/GocciaTestRunner tests/language/classes/destructuring-parameters.js`
- `./build/GocciaTestRunner tests/language/classes/destructuring-parameters.js --mode=bytecode`
- `./build/GocciaTestRunner tests/language/classes`
- `./build/GocciaTestRunner tests/language/classes --mode=bytecode`
- `./fixtures/ffi/build.sh`
- `./build/GocciaTestRunner tests --no-progress` (`10113/10113`)
- `./build/GocciaTestRunner tests --mode=bytecode --no-progress` (`10113/10113`)
- `./format.pas --check`
- `git diff --check`

Test262 impact, bytecode mode:

- Combined class slices: `3948/8426` to `5660/8426`, `46.9%` to `67.2%`, `+1712` passes
- `class/dstr`: `504/3840` to `2216/3840`, `13.1%` to `57.7%`
- Wrapper infra failures: `0`
