### PR TITLE
Make destructuring parameter binding spec-compliant

### DIFF
--- a/source/units/Goccia.Bytecode.Binary.pas
+++ b/source/units/Goccia.Bytecode.Binary.pas
@@ -226,6 +226,7 @@ begin
     WriteBoolean(AProto.GetLocalStrictFlag(UInt8(I)));
 
   WriteUInt8(AProto.TypeCheckPreambleSize);
+  WriteUInt16(AProto.ParameterPreambleSize);
 end;
 
 procedure TGocciaBytecodeWriter.WriteModule(
@@ -426,6 +427,7 @@ begin
     Result.SetLocalStrictFlag(UInt8(I), ReadBoolean);
 
   Result.TypeCheckPreambleSize := ReadUInt8;
+  Result.ParameterPreambleSize := ReadUInt16;
 end;
 
 function TGocciaBytecodeReader.ReadModule: TGocciaBytecodeModule;

--- a/source/units/Goccia.Bytecode.Chunk.pas
+++ b/source/units/Goccia.Bytecode.Chunk.pas
@@ -90,6 +90,7 @@ type
     FHasOwnPrototype: Boolean;
     FStrictThis: Boolean;
     FStrictCode: Boolean;
+    FParameterPreambleSize: UInt16;
     FTypeCheckPreambleSize: UInt8;
     FProfileIndex: Integer;
     FSourceText: string;
@@ -163,6 +164,7 @@ type
     // time pointing at a fresh ordinary object whose `constructor` is the
     // function itself.
     property HasOwnPrototype: Boolean read FHasOwnPrototype write FHasOwnPrototype;
+    property ParameterPreambleSize: UInt16 read FParameterPreambleSize write FParameterPreambleSize;
     property TypeCheckPreambleSize: UInt8 read FTypeCheckPreambleSize write FTypeCheckPreambleSize;
     property ProfileIndex: Integer read FProfileIndex write FProfileIndex;
     property SourceText: string read FSourceText write FSourceText;
@@ -220,6 +222,8 @@ begin
   FHasOwnPrototype := False;
   FStrictThis := True;
   FStrictCode := True;
+  FParameterPreambleSize := 0;
+  FTypeCheckPreambleSize := 0;
   FProfileIndex := -1;
   FTemplateSiteId := AllocateTemplateSiteId;
 end;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -66,7 +66,10 @@ const
   //   v37 -> v38: added OP_ENUM_KEYS for --compat-for-in-loop bytecode.
   //   v38 -> v39: OP_ENUM_KEYS now creates revalidating for-in entry arrays,
   //               and OP_ENUM_ENTRY validates entries.
-  GOCCIA_FORMAT_VERSION = 39;
+  //   v39 -> v40: serialized ParameterPreambleSize so bytecode generators
+  //               run FunctionDeclarationInstantiation-side parameter
+  //               binding at call time while keeping the body suspended.
+  GOCCIA_FORMAT_VERSION = 40;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -1349,6 +1349,8 @@ begin
       Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
       EmitUndefinedCheck(ACtx, Slot, JumpIdx);
       ACtx.CompileExpression(AParams[I].DefaultValue, Slot);
+      if ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
+        EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
       PatchJumpTarget(ACtx, JumpIdx);
       Continue;
     end;
@@ -1361,6 +1363,8 @@ begin
     EmitUndefinedCheck(ACtx, Slot, JumpIdx);
     CompileExpressionWithInferredName(ACtx, AParams[I].DefaultValue, Slot,
       AParams[I].Name);
+    if ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
     PatchJumpTarget(ACtx, JumpIdx);
   end;
 end;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -148,6 +148,50 @@ begin
     Result := InferLocalType(AExpr);
 end;
 
+procedure CompileExpressionWithInferredName(const ACtx: TGocciaCompilationContext;
+  const AExpr: TGocciaExpression; const ADest: UInt8;
+  const AInferredName: string);
+var
+  FuncCount: Integer;
+  InferredTemplate: TGocciaFunctionTemplate;
+begin
+  if AInferredName = '' then
+  begin
+    ACtx.CompileExpression(AExpr, ADest);
+    Exit;
+  end;
+
+  FuncCount := ACtx.Template.FunctionCount;
+  if (AExpr is TGocciaClassExpression) and
+     (TGocciaClassExpression(AExpr).ClassDefinition.Name = '') then
+  begin
+    Goccia.Compiler.Statements.CompileClassExpression(ACtx,
+      TGocciaClassExpression(AExpr).ClassDefinition, ADest, AInferredName);
+    Exit;
+  end;
+
+  ACtx.CompileExpression(AExpr, ADest);
+  if ((AExpr is TGocciaArrowFunctionExpression) or
+      (AExpr is TGocciaFunctionExpression)) and
+     (ACtx.Template.FunctionCount > FuncCount) then
+  begin
+    InferredTemplate := ACtx.Template.GetFunction(
+      ACtx.Template.FunctionCount - 1);
+    if (InferredTemplate.Name = '<arrow>') or
+       (InferredTemplate.Name = '<function>') or
+       (InferredTemplate.Name = '<method>') then
+      InferredTemplate.Name := AInferredName;
+  end;
+end;
+
+function SingleIdentifierPatternName(
+  const APattern: TGocciaDestructuringPattern): string;
+begin
+  if APattern is TGocciaIdentifierDestructuringPattern then
+    Exit(TGocciaIdentifierDestructuringPattern(APattern).Name);
+  Result := '';
+end;
+
 procedure SetNonStrictLocalTypeHint(const ACtx: TGocciaCompilationContext;
   const ALocalIdx: Integer; const ATypeHint: TGocciaLocalType);
 var
@@ -1315,7 +1359,8 @@ begin
 
     Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
     EmitUndefinedCheck(ACtx, Slot, JumpIdx);
-    ACtx.CompileExpression(AParams[I].DefaultValue, Slot);
+    CompileExpressionWithInferredName(ACtx, AParams[I].DefaultValue, Slot,
+      AParams[I].Name);
     PatchJumpTarget(ACtx, JumpIdx);
   end;
 end;
@@ -1582,7 +1627,8 @@ begin
   begin
     AssignPat := TGocciaAssignmentDestructuringPattern(APattern);
     EmitUndefinedCheck(ACtx, ASrcReg, JumpIdx);
-    ACtx.CompileExpression(AssignPat.Right, ASrcReg);
+    CompileExpressionWithInferredName(ACtx, AssignPat.Right, ASrcReg,
+      SingleIdentifierPatternName(AssignPat.Left));
     PatchJumpTarget(ACtx, JumpIdx);
     EmitDestructuring(ACtx, AssignPat.Left, ASrcReg, AAssignmentMode);
   end
@@ -1807,6 +1853,9 @@ begin
     EmitDefaultParameters(ChildCtx, AExpr.Parameters);
     EmitDestructuringParameters(ChildCtx, AExpr.Parameters);
     EmitParameterTypeChecks(ChildCtx, AExpr.Parameters);
+    if ChildTemplate.CodeCount > High(UInt16) then
+      raise Exception.Create('Parameter preamble is too large to encode');
+    ChildTemplate.ParameterPreambleSize := UInt16(ChildTemplate.CodeCount);
 
     ACtx.CompileFunctionBody(AExpr.Body);
 
@@ -3130,6 +3179,9 @@ begin
     EmitDefaultParameters(ChildCtx, AExpr.Parameters);
     EmitDestructuringParameters(ChildCtx, AExpr.Parameters);
     EmitParameterTypeChecks(ChildCtx, AExpr.Parameters);
+    if ChildTemplate.CodeCount > High(UInt16) then
+      raise Exception.Create('Parameter preamble is too large to encode');
+    ChildTemplate.ParameterPreambleSize := UInt16(ChildTemplate.CodeCount);
 
     ACtx.CompileFunctionBody(AExpr.Body);
 

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -3781,6 +3781,9 @@ begin
 
   EmitDefaultParameters(ChildCtx, AMethod.Parameters);
   EmitDestructuringParameters(ChildCtx, AMethod.Parameters);
+  if ChildTemplate.CodeCount > High(UInt16) then
+    raise Exception.Create('Parameter preamble is too large to encode');
+  ChildTemplate.ParameterPreambleSize := UInt16(ChildTemplate.CodeCount);
 
   ACtx.CompileFunctionBody(AMethod.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
@@ -4141,6 +4144,9 @@ begin
 
   EmitDefaultParameters(ChildCtx, AMethod.Parameters);
   EmitDestructuringParameters(ChildCtx, AMethod.Parameters);
+  if ChildTemplate.CodeCount > High(UInt16) then
+    raise Exception.Create('Parameter preamble is too large to encode');
+  ChildTemplate.ParameterPreambleSize := UInt16(ChildTemplate.CodeCount);
 
   ACtx.CompileFunctionBody(AMethod.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
@@ -4806,8 +4812,14 @@ begin
   end;
 
   for MethodPair in ClassDef.PrivateMethods do
-    CompileMethodBody(ACtx, ClassReg, '#slot:' + PrivPrefix + MethodPair.Key,
-      MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
+  begin
+    if MethodPair.Value.IsStatic then
+      CompileMethodBody(ACtx, ClassReg, '#slot:' + PrivPrefix + MethodPair.Key,
+        MethodPair.Value, OP_DEFINE_STATIC_METHOD_CONST)
+    else
+      CompileMethodBody(ACtx, ClassReg, '#slot:' + PrivPrefix + MethodPair.Key,
+        MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
+  end;
 
   for GetterPair in ClassDef.Getters do
   begin
@@ -5036,8 +5048,14 @@ begin
   end;
 
   for MethodPair in ClassDef.PrivateMethods do
-    CompileMethodBody(ACtx, ADest, '#slot:' + PrivPrefix + MethodPair.Key,
-      MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
+  begin
+    if MethodPair.Value.IsStatic then
+      CompileMethodBody(ACtx, ADest, '#slot:' + PrivPrefix + MethodPair.Key,
+        MethodPair.Value, OP_DEFINE_STATIC_METHOD_CONST)
+    else
+      CompileMethodBody(ACtx, ADest, '#slot:' + PrivPrefix + MethodPair.Key,
+        MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
+  end;
 
   for GetterPair in ClassDef.Getters do
   begin

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -4818,6 +4818,27 @@ var
       Result := ClassValue.Prototype.GetProperty(AName);
   end;
 
+  function GetPrivateMethodValue(const AName: string;
+    const AIsStatic: Boolean): TGocciaValue;
+  begin
+    if AIsStatic then
+    begin
+      if not ClassValue.PrivateStaticProperties.TryGetValue(AName, Result) then
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    end
+    else
+      Result := ClassValue.GetPrivateMethod(AName);
+  end;
+
+  procedure DefinePrivateMethodValue(const AName: string;
+    const AIsStatic: Boolean; const AValue: TGocciaValue);
+  begin
+    if AIsStatic then
+      ClassValue.AddPrivateStaticProperty(AName, AValue)
+    else if AValue is TGocciaMethodValue then
+      ClassValue.AddPrivateMethod(AName, TGocciaMethodValue(AValue));
+  end;
+
   procedure DefineDecoratedDataProperty(const AIsStatic: Boolean;
     const AName: string; const AKey, AValue: TGocciaValue);
   begin
@@ -4982,7 +5003,10 @@ begin
   begin
     Method := TGocciaMethodValue(EvaluateClassMethod(MethodPair.Value, AContext, MethodSuperClass));
     Method.OwningClass := ClassValue;
-    ClassValue.AddPrivateMethod(MethodPair.Key, Method);
+    if MethodPair.Value.IsStatic then
+      ClassValue.AddPrivateStaticProperty(MethodPair.Key, Method)
+    else
+      ClassValue.AddPrivateMethod(MethodPair.Key, Method);
   end;
 
   // Handle getters and setters
@@ -5346,7 +5370,8 @@ begin
           cekMethod:
           begin
             if Elem.IsPrivate then
-              CurrentMethod := ClassValue.GetPrivateMethod(ElementName)
+              CurrentMethod := GetPrivateMethodValue(
+                ElementName, Elem.IsStatic)
             else
               CurrentMethod := GetDecoratedDataProperty(
                 Elem.IsStatic, ElementName, ElementKey);
@@ -5431,7 +5456,8 @@ begin
             cekMethod:
             begin
               if Elem.IsPrivate then
-                DecoratorArgs.Add(ClassValue.GetPrivateMethod(ElementName))
+                DecoratorArgs.Add(GetPrivateMethodValue(
+                  ElementName, Elem.IsStatic))
               else
                 DecoratorArgs.Add(GetDecoratedDataProperty(
                   Elem.IsStatic, ElementName, ElementKey));
@@ -5445,10 +5471,8 @@ begin
                   AContext.OnError('Method decorator must return a function or undefined', ALine, AColumn);
 
                 if Elem.IsPrivate then
-                begin
-                  if DecoratorResult is TGocciaMethodValue then
-                    ClassValue.AddPrivateMethod(ElementName, TGocciaMethodValue(DecoratorResult));
-                end
+                  DefinePrivateMethodValue(
+                    ElementName, Elem.IsStatic, DecoratorResult)
                 else
                   DefineDecoratedDataProperty(
                     Elem.IsStatic, ElementName, ElementKey, DecoratorResult);
@@ -7062,6 +7086,28 @@ begin
   Result := Value;
 end;
 
+function SingleIdentifierPatternName(
+  const APattern: TGocciaDestructuringPattern): string;
+begin
+  if APattern is TGocciaIdentifierDestructuringPattern then
+    Exit(TGocciaIdentifierDestructuringPattern(APattern).Name);
+  Result := '';
+end;
+
+procedure ApplyInferredNameForDefaultInitializer(
+  const APattern: TGocciaDestructuringPattern; const AValue: TGocciaValue);
+var
+  Name: string;
+begin
+  Name := SingleIdentifierPatternName(APattern);
+  if Name = '' then
+    Exit;
+  if AValue is TGocciaFunctionValue then
+    TGocciaFunctionValue(AValue).SetInferredName(Name)
+  else if AValue is TGocciaClassValue then
+    TGocciaClassValue(AValue).SetInferredName(Name);
+end;
+
 // AssignVariablePattern: walk a destructuring pattern and call DefineVariableBinding
 // for each leaf identifier. Uses the same value-extraction logic as AssignPattern
 // but targets the var binding map on the function/module scope.
@@ -7072,13 +7118,12 @@ var
   AssignPat: TGocciaAssignmentDestructuringPattern;
   RestPat: TGocciaRestDestructuringPattern;
   ObjectValue: TGocciaObjectValue;
-  ArrayValue: TGocciaArrayValue;
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
   PropValue, ElementValue, DefaultValue: TGocciaValue;
   PropertyKey: TGocciaValue;
   RestElements: TGocciaArrayValue;
-  I, J: Integer;
+  I: Integer;
   Exhausted: Boolean;
 begin
   if APattern is TGocciaIdentifierDestructuringPattern then
@@ -7124,171 +7169,95 @@ begin
         Format(SErrorCannotDestructure, [AValue.ToStringLiteral.Value]),
         SSuggestDestructureRequiresIterable);
     ArrPat := TGocciaArrayDestructuringPattern(APattern);
-    if AValue is TGocciaArrayValue then
-    begin
-      ArrayValue := TGocciaArrayValue(AValue);
-      for I := 0 to ArrPat.Elements.Count - 1 do
-      begin
-        if ArrPat.Elements[I] = nil then Continue;
-        if ArrPat.Elements[I] is TGocciaRestDestructuringPattern then
-        begin
-          RestElements := TGocciaArrayValue.Create;
-          for J := I to ArrayValue.Elements.Count - 1 do
-            RestElements.Elements.Add(ArrayValue.Elements[J]);
-          AssignVariablePattern(
-            TGocciaRestDestructuringPattern(ArrPat.Elements[I]).Argument,
-            RestElements, AContext);
-          Break;
-        end
-        else
-        begin
-          if I < ArrayValue.Elements.Count then
-            ElementValue := ArrayValue.Elements[I]
-          else
-            ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-          AssignVariablePattern(ArrPat.Elements[I], ElementValue, AContext);
-        end;
-      end;
-    end
-    else if AValue is TGocciaStringLiteralValue then
-    begin
-      for I := 0 to ArrPat.Elements.Count - 1 do
-      begin
-        if ArrPat.Elements[I] = nil then Continue;
-        if ArrPat.Elements[I] is TGocciaRestDestructuringPattern then
-        begin
-          RestElements := TGocciaArrayValue.Create;
-          for J := I to Length(TGocciaStringLiteralValue(AValue).Value) - 1 do
-            RestElements.Elements.Add(TGocciaStringLiteralValue.Create(
-              TGocciaStringLiteralValue(AValue).Value[J + 1]));
-          AssignVariablePattern(
-            TGocciaRestDestructuringPattern(ArrPat.Elements[I]).Argument,
-            RestElements, AContext);
-          Break;
-        end
-        else
-        begin
-          if I < Length(TGocciaStringLiteralValue(AValue).Value) then
-            ElementValue := TGocciaStringLiteralValue.Create(
-              TGocciaStringLiteralValue(AValue).Value[I + 1])
-          else
-            ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-          AssignVariablePattern(ArrPat.Elements[I], ElementValue, AContext);
-        end;
-      end;
-    end
-    else
-    begin
-      // Generic iterable fallback.  Same IteratorClose contract as
-      // AssignArrayPattern (ES2024 §8.5.3 IteratorBindingInitialization
-      // step 4 / §7.4.10 IteratorClose):
-      //   - normal completion → CloseIterator (errors from iter.return()
-      //     propagate as the new completion);
-      //   - abrupt completion → CloseIteratorPreservingError (the
-      //     original abrupt completion wins).
-      // RestElements is also temp-rooted across AdvanceNext so a
-      // re-entrant GC can't reclaim it mid-drain.
-      Iterator := GetIteratorFromValue(AValue);
-      if not Assigned(Iterator) then
-        ThrowTypeError(
-          Format(SErrorNotIterable, [AValue.TypeName]),
-          SSuggestDestructureRequiresIterable);
-      TGarbageCollector.Instance.AddTempRoot(Iterator);
+    // ES2024 §13.3.3.6 IteratorBindingInitialization always observes
+    // @@iterator, even for arrays and strings.
+    Iterator := GetIteratorFromValue(AValue);
+    if not Assigned(Iterator) then
+      ThrowTypeError(
+        Format(SErrorNotIterable, [AValue.TypeName]),
+        SSuggestDestructureRequiresIterable);
+    TGarbageCollector.Instance.AddTempRoot(Iterator);
+    try
       try
-        try
-          // Same exhaustion-tracking as AssignArrayPattern: once the
-          // iterator returns done:true, subsequent BindingElements take
-          // undefined (or an empty rest array) without re-invoking
-          // next() — see ES2024 §13.15.5.4 IteratorBindingInitialization
-          // for ArrayBindingPattern.
-          Exhausted := False;
-          for I := 0 to ArrPat.Elements.Count - 1 do
+        Exhausted := False;
+        for I := 0 to ArrPat.Elements.Count - 1 do
+        begin
+          if ArrPat.Elements[I] = nil then
           begin
-            if ArrPat.Elements[I] = nil then
+            if not Exhausted then
             begin
+              IterResult := Iterator.AdvanceNext;
+              if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
+                Exhausted := True;
+            end;
+            Continue;
+          end;
+          if ArrPat.Elements[I] is TGocciaRestDestructuringPattern then
+          begin
+            RestElements := TGocciaArrayValue.Create;
+            TGarbageCollector.Instance.AddTempRoot(RestElements);
+            try
               if not Exhausted then
               begin
                 IterResult := Iterator.AdvanceNext;
-                if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
-                  Exhausted := True;
-              end;
-              Continue;
-            end;
-            if ArrPat.Elements[I] is TGocciaRestDestructuringPattern then
-            begin
-              RestElements := TGocciaArrayValue.Create;
-              TGarbageCollector.Instance.AddTempRoot(RestElements);
-              try
-                if not Exhausted then
-                begin
-                  IterResult := Iterator.AdvanceNext;
-                  while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
-                  begin
-                    // Per ES2024 §7.4.4 IteratorValue, a missing
-                    // IteratorResult.value is implicitly undefined.
-                    // Most iterator implementations normalize inside
-                    // AdvanceNext (TGocciaGenericIteratorValue does, as
-                    // do all native iterators that route through
-                    // CreateIteratorResult), but defensive normalization
-                    // here keeps RestElements free of nil entries even
-                    // when an iterator subclass forwards a raw
-                    // GetProperty result.
-                    ElementValue := IterResult.GetProperty(PROP_VALUE);
-                    if not Assigned(ElementValue) then
-                      ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-                    RestElements.Elements.Add(ElementValue);
-                    IterResult := Iterator.AdvanceNext;
-                  end;
-                  Exhausted := True;
-                end;
-                AssignVariablePattern(
-                  TGocciaRestDestructuringPattern(ArrPat.Elements[I]).Argument,
-                  RestElements, AContext);
-              finally
-                TGarbageCollector.Instance.RemoveTempRoot(RestElements);
-              end;
-              Break;
-            end
-            else
-            begin
-              if Exhausted then
-                ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue
-              else
-              begin
-                IterResult := Iterator.AdvanceNext;
-                if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
-                begin
-                  Exhausted := True;
-                  ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-                end
-                else
+                while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
                 begin
                   ElementValue := IterResult.GetProperty(PROP_VALUE);
-                  // §7.4.4 IteratorValue normalization (see RestElement
-                  // branch above for the same reasoning).
                   if not Assigned(ElementValue) then
                     ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+                  RestElements.Elements.Add(ElementValue);
+                  IterResult := Iterator.AdvanceNext;
                 end;
+                Exhausted := True;
               end;
-              AssignVariablePattern(ArrPat.Elements[I], ElementValue, AContext);
+              AssignVariablePattern(
+                TGocciaRestDestructuringPattern(ArrPat.Elements[I]).Argument,
+                RestElements, AContext);
+            finally
+              TGarbageCollector.Instance.RemoveTempRoot(RestElements);
             end;
+            Break;
+          end
+          else
+          begin
+            if Exhausted then
+              ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue
+            else
+            begin
+              IterResult := Iterator.AdvanceNext;
+              if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
+              begin
+                Exhausted := True;
+                ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+              end
+              else
+              begin
+                ElementValue := IterResult.GetProperty(PROP_VALUE);
+                if not Assigned(ElementValue) then
+                  ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+              end;
+            end;
+            AssignVariablePattern(ArrPat.Elements[I], ElementValue, AContext);
           end;
-        except
-          AcquireExceptionObject;
-          CloseIteratorPreservingError(Iterator);
-          raise;
         end;
-        CloseIterator(Iterator);
-      finally
-        TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+      except
+        AcquireExceptionObject;
+        CloseIteratorPreservingError(Iterator);
+        raise;
       end;
+      CloseIterator(Iterator);
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(Iterator);
     end;
   end
   else if APattern is TGocciaAssignmentDestructuringPattern then
   begin
     AssignPat := TGocciaAssignmentDestructuringPattern(APattern);
     if AValue is TGocciaUndefinedLiteralValue then
-      DefaultValue := EvaluateExpression(AssignPat.Right, AContext)
+    begin
+      DefaultValue := EvaluateExpression(AssignPat.Right, AContext);
+      ApplyInferredNameForDefaultInitializer(AssignPat.Left, DefaultValue);
+    end
     else
       DefaultValue := AValue;
     AssignVariablePattern(AssignPat.Left, DefaultValue, AContext);
@@ -7405,13 +7374,11 @@ end;
 
 procedure AssignArrayPattern(const APattern: TGocciaArrayDestructuringPattern; const AValue: TGocciaValue; const AContext: TGocciaEvaluationContext; const AIsDeclaration: Boolean = False; const ADeclarationType: TGocciaDeclarationType = dtLet);
 var
-  ArrayValue: TGocciaArrayValue;
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
   I: Integer;
   ElementValue: TGocciaValue;
   RestElements: TGocciaArrayValue;
-  J: Integer;
   Exhausted: Boolean;
 begin
   if (AValue is TGocciaNullLiteralValue) or (AValue is TGocciaUndefinedLiteralValue) then
@@ -7419,183 +7386,95 @@ begin
       Format(SErrorCannotDestructure, [AValue.ToStringLiteral.Value]),
       SSuggestDestructureRequiresIterable);
 
-  if AValue is TGocciaArrayValue then
-  begin
-    ArrayValue := TGocciaArrayValue(AValue);
+  // ES2024 §13.15.5.4 IteratorDestructuringAssignmentEvaluation and
+  // §13.3.3.6 IteratorBindingInitialization always observe @@iterator,
+  // including for array and string values.
+  Iterator := GetIteratorFromValue(AValue);
+  if not Assigned(Iterator) then
+    ThrowTypeError(
+      Format(SErrorNotIterable, [AValue.TypeName]),
+      SSuggestDestructureRequiresIterable);
 
-    for I := 0 to APattern.Elements.Count - 1 do
-    begin
-      if APattern.Elements[I] = nil then
-        Continue;
-
-      if APattern.Elements[I] is TGocciaRestDestructuringPattern then
-      begin
-        RestElements := TGocciaArrayValue.Create;
-        for J := I to ArrayValue.Elements.Count - 1 do
-        begin
-          if ArrayValue.Elements[J] <> TGocciaHoleValue.HoleValue then
-            RestElements.Elements.Add(ArrayValue.Elements[J])
-          else
-            RestElements.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
-        end;
-        AssignPattern(TGocciaRestDestructuringPattern(APattern.Elements[I]).Argument, RestElements, AContext, AIsDeclaration, ADeclarationType);
-        Break;
-      end
-      else
-      begin
-        if (I < ArrayValue.Elements.Count) and (ArrayValue.Elements[I] <> TGocciaHoleValue.HoleValue) then
-          ElementValue := ArrayValue.Elements[I]
-        else
-          ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-
-        AssignPattern(APattern.Elements[I], ElementValue, AContext, AIsDeclaration, ADeclarationType);
-      end;
-    end;
-  end
-  else if AValue is TGocciaStringLiteralValue then
-  begin
-    for I := 0 to APattern.Elements.Count - 1 do
-    begin
-      if APattern.Elements[I] = nil then
-        Continue;
-
-      if APattern.Elements[I] is TGocciaRestDestructuringPattern then
-      begin
-        RestElements := TGocciaArrayValue.Create;
-        for J := I + 1 to Length(AValue.ToStringLiteral.Value) do
-          RestElements.Elements.Add(TGocciaStringLiteralValue.Create(AValue.ToStringLiteral.Value[J]));
-        AssignPattern(TGocciaRestDestructuringPattern(APattern.Elements[I]).Argument, RestElements, AContext, AIsDeclaration, ADeclarationType);
-        Break;
-      end
-      else
-      begin
-        if I + 1 <= Length(AValue.ToStringLiteral.Value) then
-          ElementValue := TGocciaStringLiteralValue.Create(AValue.ToStringLiteral.Value[I + 1])
-        else
-          ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-
-        AssignPattern(APattern.Elements[I], ElementValue, AContext, AIsDeclaration, ADeclarationType);
-      end;
-    end;
-  end
-  else
-  begin
-    Iterator := GetIteratorFromValue(AValue);
-    if not Assigned(Iterator) then
-      ThrowTypeError(
-        Format(SErrorNotIterable, [AValue.TypeName]),
-        SSuggestDestructureRequiresIterable);
-
-    TGarbageCollector.Instance.AddTempRoot(Iterator);
+  TGarbageCollector.Instance.AddTempRoot(Iterator);
+  try
     try
-      try
-        // Track iterator exhaustion so we don't keep calling next()
-        // past done:true.  Per ES2024 §13.15.5.4
-        // IteratorBindingInitialization for ArrayBindingPattern: once
-        // iteratorRecord.[[Done]] becomes true, subsequent
-        // BindingElements get undefined (or an empty rest array)
-        // without invoking the iterator again.  Calling AdvanceNext on
-        // an already-done iterator is observable when the user's next()
-        // has side effects.
-        Exhausted := False;
-        for I := 0 to APattern.Elements.Count - 1 do
+      // Track iterator exhaustion so we don't keep calling next()
+      // past done:true.  Per ES2024 §13.15.5.4
+      // IteratorBindingInitialization for ArrayBindingPattern: once
+      // iteratorRecord.[[Done]] becomes true, subsequent
+      // BindingElements get undefined (or an empty rest array)
+      // without invoking the iterator again.  Calling AdvanceNext on
+      // an already-done iterator is observable when the user's next()
+      // has side effects.
+      Exhausted := False;
+      for I := 0 to APattern.Elements.Count - 1 do
+      begin
+        if APattern.Elements[I] = nil then
         begin
-          if APattern.Elements[I] = nil then
+          if not Exhausted then
           begin
+            IterResult := Iterator.AdvanceNext;
+            if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
+              Exhausted := True;
+          end;
+          Continue;
+        end;
+
+        if APattern.Elements[I] is TGocciaRestDestructuringPattern then
+        begin
+          RestElements := TGocciaArrayValue.Create;
+          TGarbageCollector.Instance.AddTempRoot(RestElements);
+          try
             if not Exhausted then
             begin
               IterResult := Iterator.AdvanceNext;
-              if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
-                Exhausted := True;
-            end;
-            Continue;
-          end;
-
-          if APattern.Elements[I] is TGocciaRestDestructuringPattern then
-          begin
-            // Iterator.AdvanceNext re-enters the engine (calls user
-            // next()), which can trigger GC.  Temp-root RestElements
-            // for the duration of the drain so a re-entrant collection
-            // can't reclaim it.  The root is removed once AssignPattern
-            // has stored the array into a reachable binding.
-            RestElements := TGocciaArrayValue.Create;
-            TGarbageCollector.Instance.AddTempRoot(RestElements);
-            try
-              if not Exhausted then
-              begin
-                IterResult := Iterator.AdvanceNext;
-                while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
-                begin
-                  // §7.4.4 IteratorValue: missing value is undefined.
-                  // Defensive normalization mirroring AssignArrayPattern
-                  // — most AdvanceNext implementations already
-                  // normalize, but a subclass that forwards a raw
-                  // GetProperty result must not seed nil into
-                  // RestElements.
-                  ElementValue := IterResult.GetProperty(PROP_VALUE);
-                  if not Assigned(ElementValue) then
-                    ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-                  RestElements.Elements.Add(ElementValue);
-                  IterResult := Iterator.AdvanceNext;
-                end;
-                Exhausted := True;
-              end;
-              AssignPattern(TGocciaRestDestructuringPattern(APattern.Elements[I]).Argument, RestElements, AContext, AIsDeclaration, ADeclarationType);
-            finally
-              TGarbageCollector.Instance.RemoveTempRoot(RestElements);
-            end;
-            Break;
-          end
-          else
-          begin
-            if Exhausted then
-              ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue
-            else
-            begin
-              IterResult := Iterator.AdvanceNext;
-              if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
-              begin
-                Exhausted := True;
-                ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-              end
-              else
+              while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
               begin
                 ElementValue := IterResult.GetProperty(PROP_VALUE);
-                // §7.4.4 IteratorValue normalization.
                 if not Assigned(ElementValue) then
                   ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+                RestElements.Elements.Add(ElementValue);
+                IterResult := Iterator.AdvanceNext;
               end;
+              Exhausted := True;
             end;
-
-            AssignPattern(APattern.Elements[I], ElementValue, AContext, AIsDeclaration, ADeclarationType);
+            AssignPattern(TGocciaRestDestructuringPattern(APattern.Elements[I]).Argument, RestElements, AContext, AIsDeclaration, ADeclarationType);
+          finally
+            TGarbageCollector.Instance.RemoveTempRoot(RestElements);
           end;
+          Break;
+        end
+        else
+        begin
+          if Exhausted then
+            ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue
+          else
+          begin
+            IterResult := Iterator.AdvanceNext;
+            if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
+            begin
+              Exhausted := True;
+              ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+            end
+            else
+            begin
+              ElementValue := IterResult.GetProperty(PROP_VALUE);
+              if not Assigned(ElementValue) then
+                ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+            end;
+          end;
+
+          AssignPattern(APattern.Elements[I], ElementValue, AContext, AIsDeclaration, ADeclarationType);
         end;
-      except
-        // ES2024 §8.5.3 IteratorBindingInitialization: an abrupt
-        // completion during destructuring must still close the iterator
-        // before propagating.  CloseIteratorPreservingError swallows any
-        // error from iter.return() so the original abrupt completion
-        // wins (IteratorClose §7.4.10 step 4: completion's [[Type]] is
-        // throw, return ? completion).
-        AcquireExceptionObject;
-        CloseIteratorPreservingError(Iterator);
-        raise;
       end;
-      // ES2024 §8.5.3 step 4 (normal completion): close the iterator
-      // after consuming the binding elements.  The rest-pattern branch
-      // already drained to done; Close on a done iterator is a no-op
-      // for TGocciaGenericIteratorValue.  CloseIterator (not
-      // PreservingError) is the §7.4.10 step 5 path: a normal
-      // destructuring completion lets iter.return() exceptions
-      // propagate to the caller as the new completion.  Without this
-      // call, destructuring an iterator that returns done:false
-      // indefinitely would never invoke iter.return(), and the bytecode
-      // VM's pre-conversion step (IterableToArray) would allocate
-      // unboundedly.
-      CloseIterator(Iterator);
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(Iterator);
+      raise;
     end;
+    CloseIterator(Iterator);
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(Iterator);
   end;
 end;
 
@@ -7677,6 +7556,7 @@ begin
   if AValue is TGocciaUndefinedLiteralValue then
   begin
     DefaultValue := EvaluateExpression(APattern.Right, AContext);
+    ApplyInferredNameForDefaultInitializer(APattern.Left, DefaultValue);
     AssignPattern(APattern.Left, DefaultValue, AContext, AIsDeclaration, ADeclarationType);
   end
   else

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -4823,7 +4823,7 @@ var
   begin
     if AIsStatic then
     begin
-      if not ClassValue.PrivateStaticProperties.TryGetValue(AName, Result) then
+      if not ClassValue.PrivateStaticMethods.TryGetValue(AName, Result) then
         Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     end
     else
@@ -4834,7 +4834,7 @@ var
     const AIsStatic: Boolean; const AValue: TGocciaValue);
   begin
     if AIsStatic then
-      ClassValue.AddPrivateStaticProperty(AName, AValue)
+      ClassValue.AddPrivateStaticMethod(AName, AValue)
     else if AValue is TGocciaMethodValue then
       ClassValue.AddPrivateMethod(AName, TGocciaMethodValue(AValue));
   end;
@@ -5004,7 +5004,7 @@ begin
     Method := TGocciaMethodValue(EvaluateClassMethod(MethodPair.Value, AContext, MethodSuperClass));
     Method.OwningClass := ClassValue;
     if MethodPair.Value.IsStatic then
-      ClassValue.AddPrivateStaticProperty(MethodPair.Key, Method)
+      ClassValue.AddPrivateStaticMethod(MethodPair.Key, Method)
     else
       ClassValue.AddPrivateMethod(MethodPair.Key, Method);
   end;
@@ -6021,6 +6021,9 @@ begin
   if AccessClass.HasOwnPrivateSetter(APrivateName) then
     ThrowPrivateGetterMissingError(APrivateName);
 
+  if AccessClass.PrivateStaticMethods.TryGetValue(APrivateName, Result) then
+    Exit;
+
   if not AccessClass.PrivateStaticProperties.TryGetValue(APrivateName, Result) then
     ThrowPrivateBrandError(APrivateName);
 end;
@@ -6055,10 +6058,47 @@ begin
   if AccessClass.HasOwnPrivateGetter(APrivateName) then
     ThrowPrivateSetterMissingError(APrivateName);
 
+  if AccessClass.HasOwnPrivateStaticMethod(APrivateName) then
+    ThrowTypeError(Format('Private method #%s is not writable', [APrivateName]),
+      SSuggestPrivateFieldAccess);
+
   if not AccessClass.HasOwnPrivateStaticProperty(APrivateName) then
     ThrowPrivateBrandError(APrivateName);
 
   AccessClass.AddPrivateStaticProperty(APrivateName, AValue);
+end;
+
+procedure AssignPrivateMemberOnInstance(const AInstance: TGocciaInstanceValue;
+  const APrivateName: string; const AValue: TGocciaValue;
+  const AContext: TGocciaEvaluationContext);
+var
+  AccessClass: TGocciaClassValue;
+  SetterFn: TGocciaFunctionBase;
+  SetterArgs: TGocciaArgumentsCollection;
+begin
+  AccessClass := ResolveOwningClass(AInstance, AContext);
+
+  if AccessClass.HasPrivateSetter(APrivateName) then
+  begin
+    SetterFn := AccessClass.PrivatePropertySetter[APrivateName];
+    SetterArgs := TGocciaArgumentsCollection.Create;
+    try
+      SetterArgs.Add(AValue);
+      SetterFn.Call(SetterArgs, AInstance);
+    finally
+      SetterArgs.Free;
+    end;
+    Exit;
+  end;
+
+  if AccessClass.HasPrivateGetter(APrivateName) then
+    ThrowPrivateSetterMissingError(APrivateName);
+
+  if AccessClass.PrivateMethods.ContainsKey(APrivateName) then
+    ThrowTypeError(Format('Private method #%s is not writable', [APrivateName]),
+      SSuggestPrivateFieldAccess);
+
+  AInstance.SetPrivateProperty(APrivateName, AValue, AccessClass);
 end;
 
 procedure AssignPrivateMemberOnObject(const AReceiver: TGocciaObjectValue;
@@ -6107,6 +6147,10 @@ begin
 
   if AccessClass.HasPrivateGetter(APrivateName) then
     ThrowPrivateSetterMissingError(APrivateName);
+
+  if AccessClass.PrivateMethods.ContainsKey(APrivateName) then
+    ThrowTypeError(Format('Private method #%s is not writable', [APrivateName]),
+      SSuggestPrivateFieldAccess);
 
   SetRawPrivateInstanceProperty(AReceiver, APrivateName, AValue, AccessClass);
 end;
@@ -6180,10 +6224,7 @@ var
   ObjectValue: TGocciaValue;
   Instance: TGocciaInstanceValue;
   ClassValue: TGocciaClassValue;
-  AccessClass: TGocciaClassValue;
   Value: TGocciaValue;
-  SetterFn: TGocciaFunctionBase;
-  SetterArgs: TGocciaArgumentsCollection;
 begin
   // Evaluate the object expression
   ObjectValue := EvaluateExpression(APrivatePropertyAssignmentExpression.ObjectExpr, AContext);
@@ -6193,31 +6234,10 @@ begin
 
   if ObjectValue is TGocciaInstanceValue then
   begin
-    // Private field assignment on instance
     Instance := TGocciaInstanceValue(ObjectValue);
-
-    // Determine the access class from the owning class of the current method
-    AccessClass := ResolveOwningClass(Instance, AContext);
-
-    // Check if this is a private setter
-    if AccessClass.HasPrivateSetter(APrivatePropertyAssignmentExpression.PrivateName) then
-    begin
-      SetterFn := AccessClass.PrivatePropertySetter[APrivatePropertyAssignmentExpression.PrivateName];
-      SetterArgs := TGocciaArgumentsCollection.Create;
-      try
-        SetterArgs.Add(Value);
-        SetterFn.Call(SetterArgs, Instance);
-      finally
-        SetterArgs.Free;
-      end;
-    end
-    else if AccessClass.HasPrivateGetter(APrivatePropertyAssignmentExpression.PrivateName) then
-      ThrowPrivateSetterMissingError(APrivatePropertyAssignmentExpression.PrivateName)
-    else
-    begin
-      // Set the private property
-      Instance.SetPrivateProperty(APrivatePropertyAssignmentExpression.PrivateName, Value, AccessClass);
-    end;
+    AssignPrivateMemberOnInstance(
+      Instance, APrivatePropertyAssignmentExpression.PrivateName, Value,
+      AContext);
   end
   else if ObjectValue is TGocciaClassValue then
   begin
@@ -6247,11 +6267,8 @@ var
   ObjectValue: TGocciaValue;
   Instance: TGocciaInstanceValue;
   ClassValue: TGocciaClassValue;
-  AccessClass: TGocciaClassValue;
   CurrentValue: TGocciaValue;
   Value: TGocciaValue;
-  SetterFn: TGocciaFunctionBase;
-  SetterArgs: TGocciaArgumentsCollection;
 begin
   // Evaluate the object expression
   ObjectValue := EvaluateExpression(APrivatePropertyCompoundAssignmentExpression.ObjectExpr, AContext);
@@ -6259,7 +6276,6 @@ begin
   if ObjectValue is TGocciaInstanceValue then
   begin
     Instance := TGocciaInstanceValue(ObjectValue);
-    AccessClass := ResolveOwningClass(Instance, AContext);
     CurrentValue := EvaluatePrivateMemberOnInstance(
       Instance, APrivatePropertyCompoundAssignmentExpression.PrivateName, AContext);
   end
@@ -6312,23 +6328,9 @@ begin
     Result := Value;
 
     if ObjectValue is TGocciaInstanceValue then
-    begin
-      if AccessClass.HasPrivateSetter(APrivatePropertyCompoundAssignmentExpression.PrivateName) then
-      begin
-        SetterFn := AccessClass.PrivatePropertySetter[APrivatePropertyCompoundAssignmentExpression.PrivateName];
-        SetterArgs := TGocciaArgumentsCollection.Create;
-        try
-          SetterArgs.Add(Value);
-          SetterFn.Call(SetterArgs, Instance);
-        finally
-          SetterArgs.Free;
-        end;
-      end
-      else if AccessClass.HasPrivateGetter(APrivatePropertyCompoundAssignmentExpression.PrivateName) then
-        ThrowPrivateSetterMissingError(APrivatePropertyCompoundAssignmentExpression.PrivateName)
-      else
-        Instance.SetPrivateProperty(APrivatePropertyCompoundAssignmentExpression.PrivateName, Result, AccessClass);
-    end
+      AssignPrivateMemberOnInstance(
+        Instance, APrivatePropertyCompoundAssignmentExpression.PrivateName,
+        Result, AContext)
     else if ObjectValue is TGocciaClassValue then
       AssignPrivateMemberOnClass(
         ClassValue, APrivatePropertyCompoundAssignmentExpression.PrivateName,
@@ -6350,25 +6352,9 @@ begin
 
   // Set the new value
   if ObjectValue is TGocciaInstanceValue then
-  begin
-    if AccessClass.HasPrivateSetter(APrivatePropertyCompoundAssignmentExpression.PrivateName) then
-    begin
-      SetterFn := AccessClass.PrivatePropertySetter[
-        APrivatePropertyCompoundAssignmentExpression.PrivateName];
-      SetterArgs := TGocciaArgumentsCollection.Create;
-      try
-        SetterArgs.Add(Result);
-        SetterFn.Call(SetterArgs, Instance);
-      finally
-        SetterArgs.Free;
-      end;
-    end
-    else if AccessClass.HasPrivateGetter(APrivatePropertyCompoundAssignmentExpression.PrivateName) then
-      ThrowPrivateSetterMissingError(APrivatePropertyCompoundAssignmentExpression.PrivateName)
-    else
-      Instance.SetPrivateProperty(
-        APrivatePropertyCompoundAssignmentExpression.PrivateName, Result, AccessClass);
-  end
+    AssignPrivateMemberOnInstance(
+      Instance, APrivatePropertyCompoundAssignmentExpression.PrivateName,
+      Result, AContext)
   else if ObjectValue is TGocciaClassValue then
     AssignPrivateMemberOnClass(
       ClassValue, APrivatePropertyCompoundAssignmentExpression.PrivateName,
@@ -7327,8 +7313,8 @@ begin
     else if AccessClass.HasPrivateGetter(APattern.Expression.PrivateName) then
       ThrowPrivateSetterMissingError(APattern.Expression.PrivateName)
     else
-      Instance.SetPrivateProperty(APattern.Expression.PrivateName, AValue,
-        AccessClass);
+      AssignPrivateMemberOnInstance(Instance, APattern.Expression.PrivateName,
+        AValue, AContext);
   end
   else if ObjectValue is TGocciaClassValue then
   begin

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -6753,6 +6753,8 @@ var
   Prop: TGocciaDestructuringProperty;
   Line, Column: Integer;
   IsComputed: Boolean;
+  CanUseShorthand: Boolean;
+  NumericValue: Double;
   KeyExpression: TGocciaExpression;
 begin
   Line := Previous.Line;
@@ -6762,6 +6764,7 @@ begin
   while not Check(gttRightBrace) and not IsAtEnd do
   begin
     IsComputed := False;
+    CanUseShorthand := False;
     KeyExpression := nil;
 
     if Match(gttSpread) then
@@ -6785,6 +6788,7 @@ begin
       end
       else if Check(gttIdentifier) then
       begin
+        CanUseShorthand := True;
         Key := Advance.Lexeme;
       end
       else if Check(gttString) then
@@ -6793,7 +6797,8 @@ begin
       end
       else if Check(gttNumber) then
       begin
-        Key := Advance.Lexeme;
+        NumericValue := ConvertNumberLiteral(Advance.Lexeme);
+        Key := FormatDouble(NumericValue);
       end
       else
         raise TGocciaSyntaxError.Create('Expected property name in object pattern', Peek.Line, Peek.Column, FFileName, FSourceLines,
@@ -6813,6 +6818,11 @@ begin
       end
       else
       begin
+        if not CanUseShorthand then
+          raise TGocciaSyntaxError.Create(
+            'Object pattern shorthand requires an identifier property name',
+            Previous.Line, Previous.Column, FFileName, FSourceLines,
+            'Use "key: binding" for string, numeric, or computed keys');
         // Shorthand syntax: {name} means {name: name}
         Pattern := TGocciaIdentifierDestructuringPattern.Create(Key, Previous.Line, Previous.Column);
 

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -6791,6 +6791,10 @@ begin
       begin
         Key := Advance.Lexeme;
       end
+      else if Check(gttNumber) then
+      begin
+        Key := Advance.Lexeme;
+      end
       else
         raise TGocciaSyntaxError.Create('Expected property name in object pattern', Peek.Line, Peek.Column, FFileName, FSourceLines,
           SSuggestObjectPatternPropertyName);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -6406,11 +6406,11 @@ var
   begin
     Result := NormalizeBytecodePrivateKey(
       AName, TGocciaClassValue(ClassVal).PrivateBrandToken);
-    if TGocciaClassValue(ClassVal).PrivateStaticProperties.ContainsKey(Result) then
+    if TGocciaClassValue(ClassVal).PrivateStaticMethods.ContainsKey(Result) then
       Exit;
 
     KeySuffix := '$' + AName;
-    for Pair in TGocciaClassValue(ClassVal).PrivateStaticProperties do
+    for Pair in TGocciaClassValue(ClassVal).PrivateStaticMethods do
       if (Length(Pair.Key) >= Length(KeySuffix)) and
          (Copy(Pair.Key, Length(Pair.Key) - Length(KeySuffix) + 1,
            Length(KeySuffix)) = KeySuffix) then
@@ -6422,7 +6422,7 @@ var
   begin
     if AIsStatic then
     begin
-      if not TGocciaClassValue(ClassVal).PrivateStaticProperties.TryGetValue(
+      if not TGocciaClassValue(ClassVal).PrivateStaticMethods.TryGetValue(
         PrivateStaticKey(AName), Result) then
         Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     end
@@ -6434,7 +6434,7 @@ var
     const AIsStatic: Boolean; const AValue: TGocciaValue);
   begin
     if AIsStatic then
-      TGocciaClassValue(ClassVal).AddPrivateStaticProperty(
+      TGocciaClassValue(ClassVal).AddPrivateStaticMethod(
         PrivateStaticKey(AName), AValue)
     else if AValue is TGocciaMethodValue then
       TGocciaClassValue(ClassVal).AddPrivateMethod(
@@ -7116,6 +7116,9 @@ begin
       if TGocciaClassValue(AObject).HasOwnPrivateSetter(PrivateName) then
         ThrowTypeError(Format(SErrorPrivateAccessorNoGetter, [AKey]),
           SSuggestPrivateFieldAccess);
+      if TGocciaClassValue(AObject).PrivateStaticMethods.TryGetValue(
+        AKey, Result) then
+        Exit;
       if TryGetRawPrivateValue(AObject, AKey, Result) then
         Exit;
       ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
@@ -7211,6 +7214,9 @@ begin
       end;
       if TGocciaClassValue(AObject).HasOwnPrivateGetter(PrivateName) then
         ThrowTypeError(Format(SErrorPrivateAccessorNoSetter, [AKey]),
+          SSuggestPrivateFieldAccess);
+      if TGocciaClassValue(AObject).HasOwnPrivateStaticMethod(AKey) then
+        ThrowTypeError(Format('Private method %s is not writable', [AKey]),
           SSuggestPrivateFieldAccess);
       if TGocciaClassValue(AObject).HasOwnPrivateStaticProperty(AKey) then
       begin
@@ -9026,7 +9032,7 @@ begin
              (FRegisters[A].ObjectValue is TGocciaVMClassValue) then
           begin
             SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
-            TGocciaVMClassValue(FRegisters[A].ObjectValue).AddPrivateStaticProperty(
+            TGocciaVMClassValue(FRegisters[A].ObjectValue).AddPrivateStaticMethod(
               GlobalName, RightValue);
             Continue;
           end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -269,11 +269,14 @@ type
       const AInitialFrameStackCount, ASavedHandlerCount: Integer;
       var AFrame: TGocciaVMCallFrame; var ATemplate: TGocciaFunctionTemplate;
       var APrevCovLine: UInt32; var AProfileTimestamp: Int64);
+    procedure ExecuteGeneratorParameterPreamble(const AGenerator: TObject);
     function ExecuteClosureRegistersInternal(const AClosure: TGocciaBytecodeClosure;
       const AThisValue: TGocciaRegister; const AArguments: TGocciaRegisterArray;
       const AArgCount: Integer; const AArg0, AArg1, AArg2: TGocciaRegister;
       const AUseFixedArgs: Boolean;
-      const APushExecutionContext: Boolean): TGocciaRegister;
+      const APushExecutionContext: Boolean;
+      const AStopAtIP: Integer = -1;
+      const AStopGenerator: TObject = nil): TGocciaRegister;
     function ExecuteClosureRegisters0(const AClosure: TGocciaBytecodeClosure;
       const AThisValue: TGocciaRegister;
       const APushExecutionContext: Boolean = True): TGocciaRegister;
@@ -891,11 +894,15 @@ type
     FDelegateIteratorValue: TGocciaValue;
     FDelegateIterator: TGocciaIteratorValue;
     FDelegateNextMethod: TGocciaValue;
+    FIgnoreNextResume: Boolean;
     function ResumeRaw(const AKind: TGocciaBytecodeGeneratorResumeKind;
       const AValue: TGocciaValue; out ADone: Boolean): TGocciaValue;
     procedure CaptureContinuation(const AFrame: TGocciaVMCallFrame;
       const AHandlerBaseCount: Integer; const APrevCovLine: UInt32;
       const AResumeRegister: UInt8; const AContinuationIP: Integer);
+    procedure CaptureInitialContinuation(const AFrame: TGocciaVMCallFrame;
+      const AHandlerBaseCount: Integer; const APrevCovLine: UInt32;
+      const AContinuationIP: Integer);
     function RestoreContinuation(var AFrame: TGocciaVMCallFrame;
       const AHandlerBaseCount: Integer; out APrevCovLine: UInt32): Boolean;
     procedure ClearDelegateState;
@@ -1807,6 +1814,7 @@ begin
   end;
   FState := bgsSuspendedStart;
   FResumeValue := RegisterUndefined;
+  FIgnoreNextResume := False;
   DefineProperty(PROP_NEXT, TGocciaPropertyDescriptorData.Create(
     TGocciaNativeFunctionValue.Create(GeneratorNext, PROP_NEXT, 1),
     [pfConfigurable, pfWritable]));
@@ -1816,6 +1824,8 @@ begin
   DefineProperty(PROP_THROW, TGocciaPropertyDescriptorData.Create(
     TGocciaNativeFunctionValue.Create(GeneratorThrow, PROP_THROW, 1),
     [pfConfigurable, pfWritable]));
+  if Assigned(FClosure.Template) and (FClosure.Template.ParameterPreambleSize > 0) then
+    FVM.ExecuteGeneratorParameterPreamble(Self);
 end;
 
 destructor TGocciaBytecodeGeneratorObjectValue.Destroy;
@@ -1839,6 +1849,7 @@ begin
     FArguments[I] := AArguments[I];
   FState := bgsSuspendedStart;
   FResumeValue := RegisterUndefined;
+  FIgnoreNextResume := False;
   DefineProperty(PROP_NEXT, TGocciaPropertyDescriptorData.Create(
     TGocciaNativeFunctionValue.Create(GeneratorNext, PROP_NEXT, 1),
     [pfConfigurable, pfWritable]));
@@ -1848,6 +1859,8 @@ begin
   DefineProperty(PROP_THROW, TGocciaPropertyDescriptorData.Create(
     TGocciaNativeFunctionValue.Create(GeneratorThrow, PROP_THROW, 1),
     [pfConfigurable, pfWritable]));
+  if Assigned(FClosure.Template) and (FClosure.Template.ParameterPreambleSize > 0) then
+    FVM.ExecuteGeneratorParameterPreamble(Self);
 end;
 
 procedure TGocciaBytecodeGeneratorObjectValue.CaptureContinuation(
@@ -1884,6 +1897,15 @@ begin
     FContinuationLocalCells[I] := FVM.FLocalCells[I];
 
   FVM.FHandlerStack.CopyFrom(AHandlerBaseCount, FContinuationHandlers);
+end;
+
+procedure TGocciaBytecodeGeneratorObjectValue.CaptureInitialContinuation(
+  const AFrame: TGocciaVMCallFrame; const AHandlerBaseCount: Integer;
+  const APrevCovLine: UInt32; const AContinuationIP: Integer);
+begin
+  CaptureContinuation(AFrame, AHandlerBaseCount, APrevCovLine, 0,
+    AContinuationIP);
+  FIgnoreNextResume := True;
 end;
 
 function TGocciaBytecodeGeneratorObjectValue.RestoreContinuation(
@@ -4916,8 +4938,9 @@ function TGocciaVM.ObjectRestValue(const ASource: TGocciaValue;
   const AExclusionKeys: TGocciaArrayValue): TGocciaObjectValue;
 var
   SourceObject: TGocciaObjectValue;
-  Entry: TPair<string, TGocciaValue>;
-  SymbolEntry: TPair<TGocciaSymbolValue, TGocciaValue>;
+  Key: string;
+  Symbol: TGocciaSymbolValue;
+  SymbolDescriptor: TGocciaPropertyDescriptor;
   ExclusionKey: TGocciaValue;
   J: Integer;
   Excluded: Boolean;
@@ -4930,7 +4953,7 @@ begin
   if not Assigned(SourceObject) then
     Exit;
 
-  for Entry in SourceObject.GetEnumerablePropertyEntries do
+  for Key in SourceObject.GetEnumerablePropertyNames do
   begin
     Excluded := False;
     if Assigned(AExclusionKeys) then
@@ -4939,32 +4962,36 @@ begin
         ExclusionKey := AExclusionKeys.GetElement(J);
         if (ExclusionKey is TGocciaSymbolValue) then
           Continue;
-        if ExclusionKey.ToStringLiteral.Value = Entry.Key then
+        if ExclusionKey.ToStringLiteral.Value = Key then
         begin
           Excluded := True;
           Break;
         end;
       end;
     if not Excluded then
-      Result.SetProperty(Entry.Key, Entry.Value);
+      DefineDataPropertyOnObject(Result, Key, SourceObject.GetProperty(Key));
   end;
 
-  for SymbolEntry in SourceObject.GetEnumerableSymbolProperties do
+  for Symbol in SourceObject.GetOwnSymbols do
   begin
+    SymbolDescriptor := SourceObject.GetOwnSymbolPropertyDescriptor(Symbol);
+    if not Assigned(SymbolDescriptor) or not SymbolDescriptor.Enumerable then
+      Continue;
     Excluded := False;
     if Assigned(AExclusionKeys) then
       for J := 0 to AExclusionKeys.Elements.Count - 1 do
       begin
         ExclusionKey := AExclusionKeys.GetElement(J);
         if (ExclusionKey is TGocciaSymbolValue) and
-           (ExclusionKey = SymbolEntry.Key) then
+           (ExclusionKey = Symbol) then
         begin
           Excluded := True;
           Break;
         end;
       end;
     if not Excluded then
-      Result.AssignSymbolProperty(SymbolEntry.Key, SymbolEntry.Value);
+      DefineSymbolDataPropertyOnObject(Result, Symbol,
+        SourceObject.GetSymbolProperty(Symbol));
   end;
 end;
 
@@ -5072,6 +5099,7 @@ end;
 function TGocciaVM.GetIteratorValue(const AIterable: TGocciaValue;
   const ATryAsync: Boolean): TGocciaValue;
 var
+  IteratorSource: TGocciaObjectValue;
   IteratorMethod: TGocciaValue;
   IteratorObject: TGocciaValue;
   NextMethod: TGocciaValue;
@@ -5119,43 +5147,33 @@ begin
       ThrowTypeError('Async iterator method is not callable');
   end;
 
-  if AIterable is TGocciaIteratorValue then
-  begin
-    if ATryAsync then
-      Exit(TGocciaVMAsyncFromSyncIteratorValue.Create(AIterable,
-        AIterable.GetProperty(PROP_NEXT)));
-    Exit(AIterable);
-  end;
-
-  if AIterable is TGocciaArrayValue then
-  begin
-    Result := TGocciaArrayIteratorValue.Create(AIterable, akValues);
-    if ATryAsync then
-      Exit(TGocciaVMAsyncFromSyncIteratorValue.Create(Result,
-        Result.GetProperty(PROP_NEXT)));
-    Exit;
-  end;
-
-  if AIterable is TGocciaStringLiteralValue then
-  begin
-    Result := TGocciaStringIteratorValue.Create(AIterable);
-    if ATryAsync then
-      Exit(TGocciaVMAsyncFromSyncIteratorValue.Create(Result,
-        Result.GetProperty(PROP_NEXT)));
-    Exit;
-  end;
-
   if AIterable is TGocciaObjectValue then
+    IteratorSource := TGocciaObjectValue(AIterable)
+  else if not (AIterable is TGocciaNullLiteralValue) and
+          not (AIterable is TGocciaUndefinedLiteralValue) then
+    IteratorSource := ToObject(AIterable)
+  else
+    IteratorSource := nil;
+
+  if Assigned(IteratorSource) then
   begin
-    IteratorMethod := TGocciaObjectValue(AIterable).GetSymbolProperty(
+    // ES2024 §7.4.1 GetIterator resolves @@iterator through ordinary
+    // property lookup.  Do not special-case arrays, strings, or native
+    // iterator values here: deleting or replacing their iterator methods
+    // must be observable in bytecode just as it is in the interpreter.
+    IteratorMethod := IteratorSource.GetSymbolProperty(
       TGocciaSymbolValue.WellKnownIterator);
     if Assigned(IteratorMethod) and
        not (IteratorMethod is TGocciaUndefinedLiteralValue) and
-       IteratorMethod.IsCallable then
+       not (IteratorMethod is TGocciaNullLiteralValue) then
     begin
+      if not IteratorMethod.IsCallable then
+        ThrowTypeError(Format(SErrorValueNotFunction, ['[Symbol.iterator]']),
+          SSuggestIteratorProtocol);
       CallArgs := AcquireArguments;
       try
-        IteratorObject := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, AIterable);
+        IteratorObject := TGocciaFunctionBase(IteratorMethod).Call(CallArgs,
+          AIterable);
       finally
         ReleaseArguments(CallArgs);
       end;
@@ -6381,6 +6399,48 @@ var
       Result := TGocciaClassValue(ClassVal).Prototype.GetProperty(AName);
   end;
 
+  function PrivateStaticKey(const AName: string): string;
+  var
+    Pair: TGocciaValueMap.TKeyValuePair;
+    KeySuffix: string;
+  begin
+    Result := NormalizeBytecodePrivateKey(
+      AName, TGocciaClassValue(ClassVal).PrivateBrandToken);
+    if TGocciaClassValue(ClassVal).PrivateStaticProperties.ContainsKey(Result) then
+      Exit;
+
+    KeySuffix := '$' + AName;
+    for Pair in TGocciaClassValue(ClassVal).PrivateStaticProperties do
+      if (Length(Pair.Key) >= Length(KeySuffix)) and
+         (Copy(Pair.Key, Length(Pair.Key) - Length(KeySuffix) + 1,
+           Length(KeySuffix)) = KeySuffix) then
+        Exit(Pair.Key);
+  end;
+
+  function GetPrivateMethodValue(const AName: string;
+    const AIsStatic: Boolean): TGocciaValue;
+  begin
+    if AIsStatic then
+    begin
+      if not TGocciaClassValue(ClassVal).PrivateStaticProperties.TryGetValue(
+        PrivateStaticKey(AName), Result) then
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    end
+    else
+      Result := TGocciaClassValue(ClassVal).GetPrivateMethod(AName);
+  end;
+
+  procedure DefinePrivateMethodValue(const AName: string;
+    const AIsStatic: Boolean; const AValue: TGocciaValue);
+  begin
+    if AIsStatic then
+      TGocciaClassValue(ClassVal).AddPrivateStaticProperty(
+        PrivateStaticKey(AName), AValue)
+    else if AValue is TGocciaMethodValue then
+      TGocciaClassValue(ClassVal).AddPrivateMethod(
+        AName, TGocciaMethodValue(AValue));
+  end;
+
   procedure DefineDecoratedMethodProperty(const AIsStatic: Boolean;
     const AName: string; const AKey, AValue: TGocciaValue);
   var
@@ -6598,7 +6658,7 @@ begin
     'm':
       begin
         if IsPrivate then
-          ElementValue := TGocciaClassValue(ClassVal).GetPrivateMethod(Name)
+          ElementValue := GetPrivateMethodValue(Name, IsStatic)
         else
           ElementValue := GetDecoratedDataProperty(
             IsStatic, ElementName, ElementKey);
@@ -6752,8 +6812,7 @@ begin
         if not DecoratorResult.IsCallable then
           ThrowTypeError(SErrorMethodDecoratorReturn, SSuggestDecoratorFunction);
         if IsPrivate then
-          TGocciaClassValue(ClassVal).Prototype.AssignProperty(
-            '#' + Name, DecoratorResult)
+          DefinePrivateMethodValue(Name, IsStatic, DecoratorResult)
         else
           DefineDecoratedMethodProperty(
             IsStatic, ElementName, ElementKey, DecoratorResult);
@@ -7930,11 +7989,39 @@ begin
   end;
 end;
 
+procedure TGocciaVM.ExecuteGeneratorParameterPreamble(const AGenerator: TObject);
+var
+  Generator: TGocciaBytecodeGeneratorObjectValue;
+begin
+  if not (AGenerator is TGocciaBytecodeGeneratorObjectValue) then
+    Exit;
+
+  Generator := TGocciaBytecodeGeneratorObjectValue(AGenerator);
+  if not Assigned(Generator.FClosure) or
+     not Assigned(Generator.FClosure.Template) or
+     (Generator.FClosure.Template.ParameterPreambleSize = 0) then
+    Exit;
+
+  ExecuteClosureRegistersInternal(
+    Generator.FClosure,
+    Generator.FThisValue,
+    Generator.FArguments,
+    Length(Generator.FArguments),
+    RegisterUndefined,
+    RegisterUndefined,
+    RegisterUndefined,
+    False,
+    True,
+    Generator.FClosure.Template.ParameterPreambleSize,
+    Generator);
+end;
+
 function TGocciaVM.ExecuteClosureRegistersInternal(
   const AClosure: TGocciaBytecodeClosure; const AThisValue: TGocciaRegister;
   const AArguments: TGocciaRegisterArray; const AArgCount: Integer;
   const AArg0, AArg1, AArg2: TGocciaRegister; const AUseFixedArgs: Boolean;
-  const APushExecutionContext: Boolean): TGocciaRegister;
+  const APushExecutionContext: Boolean; const AStopAtIP: Integer;
+  const AStopGenerator: TObject): TGocciaRegister;
 var
   Frame: TGocciaVMCallFrame;
   SavedRegisterBase: Integer;
@@ -8023,8 +8110,13 @@ begin
       begin
         case GActiveBytecodeGenerator.FResumeKind of
           bgrkNext:
-            SetRegisterRaw(GActiveBytecodeGenerator.FResumeRegister,
-              GActiveBytecodeGenerator.FResumeValue);
+            begin
+              if GActiveBytecodeGenerator.FIgnoreNextResume then
+                GActiveBytecodeGenerator.FIgnoreNextResume := False
+              else
+                SetRegisterRaw(GActiveBytecodeGenerator.FResumeRegister,
+                  GActiveBytecodeGenerator.FResumeValue);
+            end;
           bgrkThrow:
             HandleExceptionUnwind(
               RegisterToValue(GActiveBytecodeGenerator.FResumeValue),
@@ -8046,6 +8138,16 @@ begin
     Running := True;
     while Running and (Frame.IP < Template.CodeCount) do
     begin
+      if (AStopAtIP >= 0) and (Frame.IP >= AStopAtIP) and
+         Assigned(AStopGenerator) then
+      begin
+        TGocciaBytecodeGeneratorObjectValue(AStopGenerator).
+          CaptureInitialContinuation(Frame, SavedHandlerCount, PrevCovLine,
+            Frame.IP);
+        Result := RegisterUndefined;
+        Exit;
+      end;
+
       try
         CheckInstructionLimit;
         Instruction := Template.GetInstructionUnchecked(Frame.IP);
@@ -8920,6 +9022,14 @@ begin
         if (FRegisters[A].Kind = grkObject) and
            (FRegisters[A].ObjectValue is TGocciaObjectValue) then
         begin
+          if IsBytecodePrivateKey(GlobalName) and
+             (FRegisters[A].ObjectValue is TGocciaVMClassValue) then
+          begin
+            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
+            TGocciaVMClassValue(FRegisters[A].ObjectValue).AddPrivateStaticProperty(
+              GlobalName, RightValue);
+            Continue;
+          end;
           if FRegisters[A].ObjectValue is TGocciaVMClassValue then
             SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
           TGocciaObjectValue(FRegisters[A].ObjectValue).DefineProperty(

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -53,6 +53,7 @@ type
     FPrivateInstancePropertyDefs: TGocciaExpressionMap;
     FFieldOrder: array of TGocciaClassFieldOrderEntry;
     FPrivateStaticProperties: TGocciaValueMap;
+    FPrivateStaticMethods: TGocciaValueMap;
     FPrivateMethods: TOrderedStringMap<TGocciaMethodValue>;
     FPrivateGetters: TOrderedStringMap<TGocciaFunctionBase>;
     FPrivateSetters: TOrderedStringMap<TGocciaFunctionBase>;
@@ -94,6 +95,7 @@ type
     function HasOwnPrivateGetter(const AName: string): Boolean;
     function HasOwnPrivateSetter(const AName: string): Boolean;
     function HasOwnPrivateStaticProperty(const AName: string): Boolean;
+    function HasOwnPrivateStaticMethod(const AName: string): Boolean;
     function HasPrivateInstanceElements: Boolean;
     function GetOwnPrivatePropertyGetter(
       const AName: string): TGocciaFunctionBase;
@@ -102,6 +104,7 @@ type
     procedure AddInstanceProperty(const AName: string; const AExpression: TGocciaExpression);
     procedure AddPrivateInstanceProperty(const AName: string; const AExpression: TGocciaExpression);
     procedure AddPrivateStaticProperty(const AName: string; const AValue: TGocciaValue);
+    procedure AddPrivateStaticMethod(const AName: string; const AValue: TGocciaValue);
     procedure AddPrivateMethod(const AName: string; const AMethod: TGocciaMethodValue);
     function GetPrivateMethod(const AName: string): TGocciaMethodValue;
     procedure AppendOwnPrivateNames(const ANames: TStrings);
@@ -143,6 +146,7 @@ type
     function FieldOrderCount: Integer;
     function FieldOrderEntry(const AIndex: Integer): TGocciaClassFieldOrderEntry;
     property PrivateStaticProperties: TGocciaValueMap read FPrivateStaticProperties;
+    property PrivateStaticMethods: TGocciaValueMap read FPrivateStaticMethods;
     property PrivateMethods: TOrderedStringMap<TGocciaMethodValue> read FPrivateMethods;
     property PropertyGetter[const AName: string]: TGocciaFunctionBase read GetPropertyGetter;
     property PropertySetter[const AName: string]: TGocciaFunctionBase read GetPropertySetter;
@@ -386,6 +390,7 @@ begin
   FInstancePropertyDefs := TGocciaExpressionMap.Create;
   FPrivateInstancePropertyDefs := TGocciaExpressionMap.Create;
   FPrivateStaticProperties := TGocciaValueMap.Create;
+  FPrivateStaticMethods := TGocciaValueMap.Create;
   FPrivateMethods := TOrderedStringMap<TGocciaMethodValue>.Create;
   FPrivateGetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
   FPrivateSetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
@@ -412,6 +417,7 @@ begin
   FInstancePropertyDefs.Free;
   FPrivateInstancePropertyDefs.Free;
   FPrivateStaticProperties.Free;
+  FPrivateStaticMethods.Free;
   FPrivateMethods.Free;
   FPrivateGetters.Free;
   FPrivateSetters.Free;
@@ -454,6 +460,10 @@ begin
       ValPair.Value.MarkReferences;
 
   for ValPair in FPrivateStaticProperties do
+    if Assigned(ValPair.Value) then
+      ValPair.Value.MarkReferences;
+
+  for ValPair in FPrivateStaticMethods do
     if Assigned(ValPair.Value) then
       ValPair.Value.MarkReferences;
 
@@ -667,6 +677,12 @@ function TGocciaClassValue.HasOwnPrivateStaticProperty(
   const AName: string): Boolean;
 begin
   Result := FPrivateStaticProperties.ContainsKey(AName);
+end;
+
+function TGocciaClassValue.HasOwnPrivateStaticMethod(
+  const AName: string): Boolean;
+begin
+  Result := FPrivateStaticMethods.ContainsKey(AName);
 end;
 
 function TGocciaClassValue.HasPrivateInstanceElements: Boolean;
@@ -1007,6 +1023,11 @@ begin
   FPrivateStaticProperties.AddOrSetValue(AName, AValue);
 end;
 
+procedure TGocciaClassValue.AddPrivateStaticMethod(const AName: string; const AValue: TGocciaValue);
+begin
+  FPrivateStaticMethods.AddOrSetValue(AName, AValue);
+end;
+
 procedure TGocciaClassValue.AddPrivateMethod(const AName: string; const AMethod: TGocciaMethodValue);
 begin
   FPrivateMethods.AddOrSetValue(AName, AMethod);
@@ -1033,6 +1054,10 @@ begin
       ANames.Add(PropertyPair.Key);
 
   for StaticPair in FPrivateStaticProperties do
+    if ANames.IndexOf(StaticPair.Key) < 0 then
+      ANames.Add(StaticPair.Key);
+
+  for StaticPair in FPrivateStaticMethods do
     if ANames.IndexOf(StaticPair.Key) < 0 then
       ANames.Add(StaticPair.Key);
 

--- a/source/units/Goccia.Values.IteratorSupport.pas
+++ b/source/units/Goccia.Values.IteratorSupport.pas
@@ -124,17 +124,6 @@ begin
     end;
   end;
 
-  if AValue is TGocciaStringLiteralValue then
-  begin
-    WasSourceRooted := AddRootIfNeeded(AValue);
-    try
-      Result := TGocciaStringIteratorValue.Create(AValue);
-    finally
-      RemoveRootIfNeeded(AValue, WasSourceRooted);
-    end;
-    Exit;
-  end;
-
   Result := nil;
 end;
 

--- a/tests/language/classes/private-fields.js
+++ b/tests/language/classes/private-fields.js
@@ -85,6 +85,21 @@ test("private methods", () => {
   expect(calc.validate).toBeUndefined();
 });
 
+test("assigning to private methods throws TypeError", () => {
+  class TestClass {
+    #method() {
+      return 1;
+    }
+
+    assign() {
+      this.#method = 0;
+    }
+  }
+
+  const instance = new TestClass();
+  expect(() => instance.assign()).toThrow(TypeError);
+});
+
 test("comprehensive private fields with inheritance", () => {
   class Counter {
     #count = 0;

--- a/tests/language/classes/private-static-fields.js
+++ b/tests/language/classes/private-static-fields.js
@@ -160,3 +160,17 @@ test("reading from setter-only private static accessors throws TypeError", () =>
     expect(e.message).toContain("was defined without a getter");
   }
 });
+
+test("assigning to private static methods throws TypeError", () => {
+  class TestClass {
+    static #method() {
+      return 1;
+    }
+
+    static assign() {
+      this.#method = 0;
+    }
+  }
+
+  expect(() => TestClass.assign()).toThrow(TypeError);
+});

--- a/tests/language/decorators/private-decorators.js
+++ b/tests/language/decorators/private-decorators.js
@@ -29,4 +29,33 @@ describe("private element decorators", () => {
     expect(receivedContext.name).toBe("#greet");
     expect(receivedContext.private).toBe(true);
   });
+
+  test("static private method decorator receives and replaces method", () => {
+    let receivedContext;
+    let receivedValueType = "unset";
+
+    const wrap = (method, context) => {
+      receivedContext = context;
+      receivedValueType = typeof method;
+      return () => "wrapped:" + method();
+    };
+
+    class C {
+      @wrap
+      static #greet() {
+        return "hello";
+      }
+
+      static callGreet() {
+        return this.#greet();
+      }
+    }
+
+    expect(C.callGreet()).toBe("wrapped:hello");
+    expect(receivedValueType).toBe("function");
+    expect(receivedContext.kind).toBe("method");
+    expect(receivedContext.name).toBe("#greet");
+    expect(receivedContext.static).toBe(true);
+    expect(receivedContext.private).toBe(true);
+  });
 });

--- a/tests/language/expressions/destructuring/defaults.js
+++ b/tests/language/expressions/destructuring/defaults.js
@@ -37,6 +37,18 @@ test("object destructuring with defaults triggered", () => {
   expect(c).toBe(3);
 });
 
+test("object destructuring numeric keys use canonical property names", () => {
+  let { 0x10: hex, 1e2: exp, 1.0: one } = {
+    16: "hex",
+    100: "exp",
+    1: "one"
+  };
+
+  expect(hex).toBe("hex");
+  expect(exp).toBe("exp");
+  expect(one).toBe("one");
+});
+
 test("array destructuring with defaults and rest", () => {
   let [a = 1, b = 2, c = 3, ...rest] = [4, 5, 6, 7, 8];
   expect(a).toBe(4);

--- a/tests/language/function-keyword/hoisting-upvalue-capture.js
+++ b/tests/language/function-keyword/hoisting-upvalue-capture.js
@@ -33,6 +33,14 @@ test("hoisted function captures destructured with default", () => {
   expect(inner()).toBe(55);
 });
 
+test("default parameter function captures initialized parameter binding", () => {
+  function inner(value = () => value) {
+    return value() === value;
+  }
+
+  expect(inner()).toBe(true);
+});
+
 test("hoisted function captures class declaration", () => {
   function inner() { return new MyClass().value; }
   class MyClass {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Make array destructuring binding/assignment observe `@@iterator` for arrays, strings, and iterator objects instead of using direct fast paths.
- Serialize and run bytecode function parameter preambles so generator and async-generator parameter binding/defaults happen at call time while the body remains suspended.
- Align default initializer name inference, object rest getter reads, numeric object pattern keys, and static private method decorator replacement across interpreter and bytecode mode.
- Documentation not updated: this is a conformance correction for existing language features rather than new user-facing surface.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas clean loaderbare testrunner`
  - `./build/GocciaTestRunner tests/language/decorators --mode=bytecode --no-progress`
  - `./build/GocciaTestRunner tests/language/decorators --no-progress`
  - `./build/GocciaTestRunner tests/language/expressions/destructuring tests/language/classes/destructuring-parameters.js tests/language/generators tests/language/async-generators tests/language/for-of/for-of-destructuring.js --mode=bytecode --no-progress`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-current --filter 'language/**/function/dstr/*.js' --mode bytecode --output /tmp/goccia-test262-results/function-dstr-bc-pr.json` (`372/372`)
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-current --filter 'language/**/generators/dstr/*.js' --mode bytecode --output /tmp/goccia-test262-results/generators-dstr-bc-pr.json` (`372/372`)
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-current --filter 'language/**/async-generator/dstr/*.js' --mode bytecode --output /tmp/goccia-test262-results/async-generator-dstr-bc-pr.json` (`558/558`)
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-current --filter 'language/**/class/dstr/*.js' --mode bytecode --output /tmp/goccia-test262-results/class-dstr-bc-pr.json` (`3840/3840`)
  - `./build/GocciaTestRunner tests --no-progress` (`10107/10112`; remaining 5 fail because `./fixtures/ffi/libfixture.dylib` is missing for FFI fixture tests)
  - `./format.pas --check`
  - `git diff --check`
- [ ] Updated documentation
  - Not applicable; existing feature conformance correction only.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change