### PR TITLE
Fix concrete iterator prototype ancestry

### DIFF
--- a/source/units/Goccia.Values.Iterator.Concrete.pas
+++ b/source/units/Goccia.Values.Iterator.Concrete.pas
@@ -107,32 +107,20 @@ uses
 
   TextSemantics,
 
-  Goccia.GarbageCollector,
   Goccia.Realm,
   Goccia.Values.ArrayValue,
   Goccia.Values.HeadersValue,
   Goccia.Values.HoleValue,
   Goccia.Values.MapValue,
-  Goccia.Values.NativeFunction,
-  Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SetValue,
-  Goccia.Values.SymbolValue,
   Goccia.Values.ToObject,
   Goccia.Values.URLSearchParamsValue;
 
 var
   GArrayIteratorPrototypeSlot: TGocciaRealmSlotId;
-
-threadvar
-  FArrayIteratorMethodHost: TGocciaIteratorValue;
-
-function GetSharedArrayIteratorPrototype: TGocciaObjectValue; inline;
-begin
-  if Assigned(CurrentRealm) then
-    Result := TGocciaObjectValue(CurrentRealm.GetSlot(GArrayIteratorPrototypeSlot))
-  else
-    Result := nil;
-end;
+  GStringIteratorPrototypeSlot: TGocciaRealmSlotId;
+  GMapIteratorPrototypeSlot: TGocciaRealmSlotId;
+  GSetIteratorPrototypeSlot: TGocciaRealmSlotId;
 
 { TGocciaArrayIteratorValue }
 
@@ -141,27 +129,8 @@ var
   SharedPrototype: TGocciaObjectValue;
 begin
   inherited Create;
-  SharedPrototype := GetSharedArrayIteratorPrototype;
-  if (not Assigned(SharedPrototype)) and Assigned(CurrentRealm) then
-  begin
-    SharedPrototype := TGocciaObjectValue.Create(FPrototype);
-    if not Assigned(FArrayIteratorMethodHost) then
-    begin
-      FArrayIteratorMethodHost := TGocciaIteratorValue.Create;
-      if Assigned(TGarbageCollector.Instance) then
-        TGarbageCollector.Instance.PinObject(FArrayIteratorMethodHost);
-    end;
-    SharedPrototype.DefineProperty('next',
-      TGocciaPropertyDescriptorData.Create(
-        TGocciaNativeFunctionValue.CreateWithoutPrototype(
-          FArrayIteratorMethodHost.IteratorNext, 'next', 0),
-        [pfConfigurable, pfWritable]));
-    SharedPrototype.DefineSymbolProperty(
-      TGocciaSymbolValue.WellKnownToStringTag,
-      TGocciaPropertyDescriptorData.Create(
-        TGocciaStringLiteralValue.Create('Array Iterator'), [pfConfigurable]));
-    CurrentRealm.SetSlot(GArrayIteratorPrototypeSlot, SharedPrototype);
-  end;
+  SharedPrototype := EnsureConcreteIteratorPrototype(
+    GArrayIteratorPrototypeSlot, 'Array Iterator');
   if Assigned(SharedPrototype) then
     FPrototype := SharedPrototype;
   FSource := ASource;
@@ -285,8 +254,14 @@ end;
 { TGocciaStringIteratorValue }
 
 constructor TGocciaStringIteratorValue.Create(const ASource: TGocciaValue);
+var
+  SharedPrototype: TGocciaObjectValue;
 begin
   inherited Create;
+  SharedPrototype := EnsureConcreteIteratorPrototype(
+    GStringIteratorPrototypeSlot, 'String Iterator');
+  if Assigned(SharedPrototype) then
+    FPrototype := SharedPrototype;
   FSource := ASource;
   FIndex := 0;
 end;
@@ -361,8 +336,14 @@ end;
 { TGocciaMapIteratorValue }
 
 constructor TGocciaMapIteratorValue.Create(const ASource: TGocciaValue; const AKind: TGocciaMapIteratorKind);
+var
+  SharedPrototype: TGocciaObjectValue;
 begin
   inherited Create;
+  SharedPrototype := EnsureConcreteIteratorPrototype(
+    GMapIteratorPrototypeSlot, 'Map Iterator');
+  if Assigned(SharedPrototype) then
+    FPrototype := SharedPrototype;
   FSource := ASource;
   FIndex := 0;
   FKind := AKind;
@@ -457,8 +438,14 @@ end;
 { TGocciaSetIteratorValue }
 
 constructor TGocciaSetIteratorValue.Create(const ASource: TGocciaValue; const AKind: TGocciaSetIteratorKind);
+var
+  SharedPrototype: TGocciaObjectValue;
 begin
   inherited Create;
+  SharedPrototype := EnsureConcreteIteratorPrototype(
+    GSetIteratorPrototypeSlot, 'Set Iterator');
+  if Assigned(SharedPrototype) then
+    FPrototype := SharedPrototype;
   FSource := ASource;
   FIndex := 0;
   FKind := AKind;
@@ -754,5 +741,8 @@ end;
 
 initialization
   GArrayIteratorPrototypeSlot := RegisterRealmSlot('ArrayIterator.prototype');
+  GStringIteratorPrototypeSlot := RegisterRealmSlot('StringIterator.prototype');
+  GMapIteratorPrototypeSlot := RegisterRealmSlot('MapIterator.prototype');
+  GSetIteratorPrototypeSlot := RegisterRealmSlot('SetIterator.prototype');
 
 end.

--- a/source/units/Goccia.Values.Iterator.RegExp.pas
+++ b/source/units/Goccia.Values.Iterator.RegExp.pas
@@ -29,19 +29,29 @@ type
 implementation
 
 uses
+  Goccia.Realm,
   Goccia.RegExp.Runtime;
 
 const
   REGEXP_STRING_ITERATOR_TAG = 'RegExp String Iterator';
   MATCH_TEXT_PROPERTY = '0';
 
+var
+  GRegExpStringIteratorPrototypeSlot: TGocciaRealmSlotId;
+
 { TGocciaRegExpMatchAllIteratorValue }
 
 constructor TGocciaRegExpMatchAllIteratorValue.Create(
   const ARegExp: TGocciaObjectValue; const AInput: string;
   const AGlobal, AUnicode: Boolean);
+var
+  SharedPrototype: TGocciaObjectValue;
 begin
   inherited Create;
+  SharedPrototype := EnsureConcreteIteratorPrototype(
+    GRegExpStringIteratorPrototypeSlot, REGEXP_STRING_ITERATOR_TAG);
+  if Assigned(SharedPrototype) then
+    FPrototype := SharedPrototype;
   FRegExp := ARegExp;
   FInput := AInput;
   FGlobal := AGlobal;
@@ -142,5 +152,9 @@ begin
   if Assigned(FRegExp) then
     FRegExp.MarkReferences;
 end;
+
+initialization
+  GRegExpStringIteratorPrototypeSlot := RegisterRealmSlot(
+    'RegExpStringIterator.prototype');
 
 end.

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -7,11 +7,16 @@ interface
 uses
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
 type
   TGocciaIteratorValue = class(TGocciaObjectValue)
+  protected
+    class function EnsureConcreteIteratorPrototype(
+      const ASlotId: TGocciaRealmSlotId;
+      const AToStringTag: string): TGocciaObjectValue; static;
   public
     function IteratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorSelf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -75,7 +80,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Realm,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -221,6 +225,34 @@ class procedure TGocciaIteratorValue.EnsurePrototypeInitialized;
 begin
   if Assigned(GetSharedIteratorPrototype) then Exit;
   TGocciaIteratorValue.Create;
+end;
+
+class function TGocciaIteratorValue.EnsureConcreteIteratorPrototype(
+  const ASlotId: TGocciaRealmSlotId;
+  const AToStringTag: string): TGocciaObjectValue;
+var
+  IteratorPrototype: TGocciaObjectValue;
+begin
+  if not Assigned(CurrentRealm) then
+    Exit(nil);
+
+  Result := TGocciaObjectValue(CurrentRealm.GetSlot(ASlotId));
+  if Assigned(Result) then
+    Exit;
+
+  EnsurePrototypeInitialized;
+  IteratorPrototype := GetSharedIteratorPrototype;
+  Result := TGocciaObjectValue.Create(IteratorPrototype);
+  Result.DefineProperty('next',
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(
+        FPrototypeMethodHost.IteratorNext, 'next', 0),
+      [pfConfigurable, pfWritable]));
+  Result.DefineSymbolProperty(
+    TGocciaSymbolValue.WellKnownToStringTag,
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaStringLiteralValue.Create(AToStringTag), [pfConfigurable]));
+  CurrentRealm.SetSlot(ASlotId, Result);
 end;
 
 procedure TGocciaIteratorValue.InitializePrototype;

--- a/tests/built-ins/Map/prototype/entries.js
+++ b/tests/built-ins/Map/prototype/entries.js
@@ -55,3 +55,20 @@ test("[Symbol.iterator] throws TypeError when called on non-Map", () => {
   expect(() => iter.call(Map.prototype)).toThrow(TypeError);
   expect(() => iter.call({})).toThrow(TypeError);
 });
+
+test("Map iterator prototype inherits from Iterator.prototype", () => {
+  const iteratorPrototype = Object.getPrototypeOf(
+    Object.getPrototypeOf([][Symbol.iterator]())
+  );
+  const mapIteratorPrototype = Object.getPrototypeOf(new Map().entries());
+  const tagDescriptor = Object.getOwnPropertyDescriptor(
+    mapIteratorPrototype,
+    Symbol.toStringTag
+  );
+
+  expect(Object.getPrototypeOf(mapIteratorPrototype)).toBe(iteratorPrototype);
+  expect(tagDescriptor.value).toBe("Map Iterator");
+  expect(tagDescriptor.writable).toBe(false);
+  expect(tagDescriptor.enumerable).toBe(false);
+  expect(tagDescriptor.configurable).toBe(true);
+});

--- a/tests/built-ins/Set/prototype/values.js
+++ b/tests/built-ins/Set/prototype/values.js
@@ -91,3 +91,20 @@ test("[Symbol.iterator] throws TypeError when called on non-Set", () => {
   expect(() => iter.call(Set.prototype)).toThrow(TypeError);
   expect(() => iter.call({})).toThrow(TypeError);
 });
+
+test("Set iterator prototype inherits from Iterator.prototype", () => {
+  const iteratorPrototype = Object.getPrototypeOf(
+    Object.getPrototypeOf([][Symbol.iterator]())
+  );
+  const setIteratorPrototype = Object.getPrototypeOf(new Set().values());
+  const tagDescriptor = Object.getOwnPropertyDescriptor(
+    setIteratorPrototype,
+    Symbol.toStringTag
+  );
+
+  expect(Object.getPrototypeOf(setIteratorPrototype)).toBe(iteratorPrototype);
+  expect(tagDescriptor.value).toBe("Set Iterator");
+  expect(tagDescriptor.writable).toBe(false);
+  expect(tagDescriptor.enumerable).toBe(false);
+  expect(tagDescriptor.configurable).toBe(true);
+});

--- a/tests/built-ins/String/prototype/matchAll.js
+++ b/tests/built-ins/String/prototype/matchAll.js
@@ -1,6 +1,6 @@
 /*---
 description: String.prototype.matchAll with regex arguments
-features: [String.prototype.matchAll]
+features: [String.prototype.matchAll, Iterator]
 ---*/
 
 test("matchAll returns an iterator of match arrays", () => {

--- a/tests/built-ins/String/prototype/matchAll.js
+++ b/tests/built-ins/String/prototype/matchAll.js
@@ -176,3 +176,24 @@ test("matchAll throws TypeError when IsRegExp object has undefined flags", () =>
     "abc".matchAll({ [Symbol.match]: true });
   }).toThrow(TypeError);
 });
+
+test("RegExp string iterator prototype inherits from Iterator.prototype", () => {
+  const iteratorPrototype = Object.getPrototypeOf(
+    Object.getPrototypeOf([][Symbol.iterator]())
+  );
+  const regexpStringIteratorPrototype = Object.getPrototypeOf(
+    "abc".matchAll(/a/g)
+  );
+  const tagDescriptor = Object.getOwnPropertyDescriptor(
+    regexpStringIteratorPrototype,
+    Symbol.toStringTag
+  );
+
+  expect(Object.getPrototypeOf(regexpStringIteratorPrototype)).toBe(
+    iteratorPrototype
+  );
+  expect(tagDescriptor.value).toBe("RegExp String Iterator");
+  expect(tagDescriptor.writable).toBe(false);
+  expect(tagDescriptor.enumerable).toBe(false);
+  expect(tagDescriptor.configurable).toBe(true);
+});

--- a/tests/built-ins/String/prototype/symbol-iterator.js
+++ b/tests/built-ins/String/prototype/symbol-iterator.js
@@ -37,3 +37,20 @@ test("rest pattern with string destructuring", () => {
   expect(first).toBe("a");
   expect(rest).toEqual(["b", "c", "d"]);
 });
+
+test("String iterator prototype inherits from Iterator.prototype", () => {
+  const iteratorPrototype = Object.getPrototypeOf(
+    Object.getPrototypeOf([][Symbol.iterator]())
+  );
+  const stringIteratorPrototype = Object.getPrototypeOf(""[Symbol.iterator]());
+  const tagDescriptor = Object.getOwnPropertyDescriptor(
+    stringIteratorPrototype,
+    Symbol.toStringTag
+  );
+
+  expect(Object.getPrototypeOf(stringIteratorPrototype)).toBe(iteratorPrototype);
+  expect(tagDescriptor.value).toBe("String Iterator");
+  expect(tagDescriptor.writable).toBe(false);
+  expect(tagDescriptor.enumerable).toBe(false);
+  expect(tagDescriptor.configurable).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Fix concrete String and RegExp string iterator prototypes so they inherit from `%Iterator.prototype%`.
- Move concrete iterator prototype creation into a shared private helper and use it for Array, String, RegExp string, Map, and Set iterator prototypes.
- Add regression coverage for String, RegExp string, Map, and Set iterator prototype ancestry plus `Symbol.toStringTag` descriptors.
- Non-goal: #721 is separate; it covers function prototype identity for public/private methods, not concrete iterator prototype ancestry.
- Closes #720.

Spec reference: ECMA-262 ES2026, §27.1.3.3 `%Iterator.prototype%` object, snapshot `0248456c758431e4bb8e5d26333ff1865123c9cd`.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas testrunner && ./build/GocciaTestRunner tests`
  - `./build/GocciaTestRunner tests/built-ins/String/prototype/symbol-iterator.js tests/built-ins/String/prototype/matchAll.js tests/built-ins/Map/prototype/entries.js tests/built-ins/Set/prototype/values.js`
  - `./build/GocciaTestRunner tests/built-ins/String/prototype/symbol-iterator.js --mode=bytecode`
  - `./build/GocciaTestRunner tests/built-ins/String/prototype/matchAll.js --mode=bytecode`
  - `./build/GocciaTestRunner tests/built-ins/Map/prototype/entries.js --mode=bytecode`
  - `./build/GocciaTestRunner tests/built-ins/Set/prototype/values.js --mode=bytecode`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --mode bytecode --jobs 1 --filter 'built-ins/StringIteratorPrototype/ancestry.js'`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --mode bytecode --jobs 1 --filter 'built-ins/RegExpStringIteratorPrototype/ancestry.js'`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --mode bytecode --jobs 1 --filter 'built-ins/MapIteratorPrototype/Symbol.toStringTag.js'`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-d0c1b4555b03dd404873fd6422a4b5da00136500 --mode bytecode --jobs 1 --filter 'built-ins/SetIteratorPrototype/Symbol.toStringTag.js'`
- [ ] Updated documentation
  - Not applicable; this is a narrow spec-compliance bug fix and the existing value-system docs already describe realm-slot prototype singletons.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - Not run; coverage is through the public JavaScript behavior and test262 conformance checks.
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Not run; no performance-sensitive path or benchmark surface changed.

Additional checks:

- `./format.pas --check`
- `git diff --check`