### PR TITLE
fix(intl): cache supported locale resolution

### DIFF
--- a/source/shared/IntlLocaleResolver.pas
+++ b/source/shared/IntlLocaleResolver.pas
@@ -50,17 +50,17 @@ begin
 end;
 
 // ECMA-402 ES2026 §9.2.3 LookupMatchingLocaleByPrefix(availableLocales, requestedLocales)
-function LocaleWithoutUnicodeExtension(const ALocale: string): string;
+function LocaleWithoutUnicodeExtension(const AParsed: TBcp47Tag): string; overload;
 var
   Parsed: TBcp47Tag;
   FilteredExtensions: TBcp47ExtensionArray;
   I, Count: Integer;
 begin
   Result := '';
-  Parsed := ParseBcp47Tag(ALocale);
-  if not Parsed.IsValid then
+  if not AParsed.IsValid then
     Exit;
 
+  Parsed := AParsed;
   Count := 0;
   SetLength(FilteredExtensions, Length(Parsed.Extensions));
   for I := 0 to High(Parsed.Extensions) do
@@ -74,6 +74,14 @@ begin
   Parsed.Extensions := FilteredExtensions;
 
   Result := CanonicalizeBcp47Tag(Parsed);
+end;
+
+function LocaleWithoutUnicodeExtension(const ALocale: string): string; overload;
+var
+  Parsed: TBcp47Tag;
+begin
+  Parsed := ParseBcp47Tag(ALocale);
+  Result := LocaleWithoutUnicodeExtension(Parsed);
 end;
 
 // ECMA-402 ES2026 supportedLocalesOf constructors use [[AvailableLocales]].
@@ -301,7 +309,7 @@ begin
     if not Parsed.IsValid then
       Continue;
 
-    NoExtensionTag := LocaleWithoutUnicodeExtension(ARequestedLocales[I]);
+    NoExtensionTag := LocaleWithoutUnicodeExtension(Parsed);
     if NoExtensionTag = '' then
       Continue;
 

--- a/source/shared/IntlLocaleResolver.pas
+++ b/source/shared/IntlLocaleResolver.pas
@@ -9,6 +9,7 @@ uses
 
 function CanonicalizeUnicodeLocaleId(const ATag: string): string;
 function CanonicalizeLocaleList(const ATags: IntlTypes.TStringArray): IntlTypes.TStringArray;
+function SupportedLocalesOf(const ARequestedLocales: IntlTypes.TStringArray): IntlTypes.TStringArray;
 function BestAvailableLocale(const AAvailableLocales: IntlTypes.TStringArray;
   const ALocale: string): string;
 function LookupMatcher(const AAvailableLocales, ARequestedLocales: IntlTypes.TStringArray): TIntlResolvedLocale;
@@ -25,6 +26,89 @@ uses
 
   Goccia.Intl.CLDRData;
 
+var
+  AvailableLocalesCache: IntlTypes.TStringArray;
+  AvailableLocalesLoaded: Boolean;
+  AvailableLocalesLock: TRTLCriticalSection;
+
+procedure AppendUniqueLocale(var ALocales: IntlTypes.TStringArray;
+  var ACount: Integer; const ALocale: string);
+var
+  I: Integer;
+begin
+  if ALocale = '' then
+    Exit;
+
+  for I := 0 to ACount - 1 do
+    if CompareText(ALocales[I], ALocale) = 0 then
+      Exit;
+
+  if ACount >= Length(ALocales) then
+    SetLength(ALocales, ACount + 16);
+  ALocales[ACount] := ALocale;
+  Inc(ACount);
+end;
+
+// ECMA-402 ES2026 §9.2.3 LookupMatchingLocaleByPrefix(availableLocales, requestedLocales)
+function LocaleWithoutUnicodeExtension(const ALocale: string): string;
+var
+  Parsed: TBcp47Tag;
+  FilteredExtensions: TBcp47ExtensionArray;
+  I, Count: Integer;
+begin
+  Result := '';
+  Parsed := ParseBcp47Tag(ALocale);
+  if not Parsed.IsValid then
+    Exit;
+
+  Count := 0;
+  SetLength(FilteredExtensions, Length(Parsed.Extensions));
+  for I := 0 to High(Parsed.Extensions) do
+  begin
+    if Parsed.Extensions[I].Singleton = 'u' then
+      Continue;
+    FilteredExtensions[Count] := Parsed.Extensions[I];
+    Inc(Count);
+  end;
+  SetLength(FilteredExtensions, Count);
+  Parsed.Extensions := FilteredExtensions;
+
+  Result := CanonicalizeBcp47Tag(Parsed);
+end;
+
+// ECMA-402 ES2026 supportedLocalesOf constructors use [[AvailableLocales]].
+function AvailableLocaleList: IntlTypes.TStringArray;
+var
+  Available: IntlTypes.TStringArray;
+  Canonical: string;
+  I, Count: Integer;
+begin
+  EnterCriticalSection(AvailableLocalesLock);
+  try
+    if not AvailableLocalesLoaded then
+    begin
+      SetLength(AvailableLocalesCache, 0);
+      if TryICUGetAvailableLocales(Available) then
+      begin
+        Count := 0;
+        SetLength(AvailableLocalesCache, Length(Available));
+        for I := 0 to High(Available) do
+        begin
+          Canonical := CanonicalizeUnicodeLocaleId(Available[I]);
+          AppendUniqueLocale(AvailableLocalesCache, Count, Canonical);
+        end;
+        SetLength(AvailableLocalesCache, Count);
+      end;
+      AvailableLocalesLoaded := True;
+    end;
+
+    Result := AvailableLocalesCache;
+  finally
+    LeaveCriticalSection(AvailableLocalesLock);
+  end;
+end;
+
+// ECMA-402 ES2026 §6.2.2 CanonicalizeUnicodeLocaleId(locale)
 function CanonicalizeUnicodeLocaleId(const ATag: string): string;
 var
   Parsed: TBcp47Tag;
@@ -39,12 +123,6 @@ begin
   if not Parsed.IsValid then
     Exit;
 
-  if TryICUCanonicalizeLocale(ATag, ICUCanonical) then
-  begin
-    Result := ICUCanonical;
-    Exit;
-  end;
-
   if TryGetGrandfatheredTag(LowerCase(ATag), CLDRReplacement) then
   begin
     Parsed := ParseBcp47Tag(CLDRReplacement);
@@ -53,6 +131,12 @@ begin
       Result := CanonicalizeBcp47Tag(Parsed);
       Exit;
     end;
+  end;
+
+  if TryICUCanonicalizeLocale(ATag, ICUCanonical) then
+  begin
+    Result := ICUCanonical;
+    Exit;
   end;
 
   if Parsed.Language <> '' then
@@ -79,6 +163,7 @@ begin
   Result := CanonicalizeBcp47Tag(Parsed);
 end;
 
+// ECMA-402 ES2026 §9.2.1 CanonicalizeLocaleList(locales)
 function CanonicalizeLocaleList(const ATags: IntlTypes.TStringArray): IntlTypes.TStringArray;
 var
   I, Count: Integer;
@@ -117,6 +202,31 @@ begin
     Result[Count] := Canonical;
     Seen[Count] := Canonical;
     Inc(Count);
+  end;
+
+  SetLength(Result, Count);
+end;
+
+// ECMA-402 ES2026 §9.2.9 FilterLocales(availableLocales, requestedLocales, options)
+function SupportedLocalesOf(const ARequestedLocales: IntlTypes.TStringArray): IntlTypes.TStringArray;
+var
+  AvailableLocales: IntlTypes.TStringArray;
+  LookupLocale: string;
+  I, Count: Integer;
+begin
+  AvailableLocales := AvailableLocaleList;
+  Count := 0;
+  SetLength(Result, Length(ARequestedLocales));
+
+  for I := 0 to High(ARequestedLocales) do
+  begin
+    LookupLocale := LocaleWithoutUnicodeExtension(ARequestedLocales[I]);
+    if (LookupLocale <> '') and
+       (BestAvailableLocale(AvailableLocales, LookupLocale) <> '') then
+    begin
+      Result[Count] := ARequestedLocales[I];
+      Inc(Count);
+    end;
   end;
 
   SetLength(Result, Count);
@@ -191,8 +301,7 @@ begin
     if not Parsed.IsValid then
       Continue;
 
-    SetLength(Parsed.Extensions, 0);
-    NoExtensionTag := CanonicalizeBcp47Tag(Parsed);
+    NoExtensionTag := LocaleWithoutUnicodeExtension(ARequestedLocales[I]);
     if NoExtensionTag = '' then
       Continue;
 
@@ -221,5 +330,13 @@ begin
 
   Result := 'en';
 end;
+
+initialization
+  InitCriticalSection(AvailableLocalesLock);
+  AvailableLocalesLoaded := False;
+
+finalization
+  DoneCriticalSection(AvailableLocalesLock);
+  SetLength(AvailableLocalesCache, 0);
 
 end.

--- a/source/units/Goccia.Builtins.Intl.pas
+++ b/source/units/Goccia.Builtins.Intl.pas
@@ -52,7 +52,6 @@ implementation
 uses
   SysUtils,
 
-  IntlICU,
   IntlLocaleResolver,
   IntlTypes,
 
@@ -592,11 +591,9 @@ var
   Arg, OptionsArg, V: TGocciaValue;
   Tags: TStringArray;
   Canonical: TStringArray;
-  Available: TStringArray;
-  AvailableTags: TStringArray;
+  Supported: TStringArray;
   ResultArr: TGocciaArrayValue;
-  I, Len, AvailCount: Integer;
-  AvailTag: string;
+  I, Len: Integer;
 begin
   Arg := AArgs.GetElement(0);
 
@@ -639,30 +636,11 @@ begin
   end;
 
   Canonical := CanonicalizeLocaleList(Tags);
-
-  // Get available locales from ICU and convert to BCP 47 tags
-  SetLength(AvailableTags, 0);
-  if TryICUGetAvailableLocales(Available) then
-  begin
-    AvailCount := 0;
-    SetLength(AvailableTags, Length(Available));
-    for I := 0 to High(Available) do
-    begin
-      if TryICUCanonicalizeLocale(Available[I], AvailTag) then
-      begin
-        AvailableTags[AvailCount] := AvailTag;
-        Inc(AvailCount);
-      end;
-    end;
-    SetLength(AvailableTags, AvailCount);
-  end;
+  Supported := SupportedLocalesOf(Canonical);
 
   ResultArr := TGocciaArrayValue.Create;
-  for I := 0 to High(Canonical) do
-  begin
-    if BestAvailableLocale(AvailableTags, Canonical[I]) <> '' then
-      ResultArr.Elements.Add(TGocciaStringLiteralValue.Create(Canonical[I]));
-  end;
+  for I := 0 to High(Supported) do
+    ResultArr.Elements.Add(TGocciaStringLiteralValue.Create(Supported[I]));
 
   Result := ResultArr;
 end;

--- a/tests/built-ins/Intl/getCanonicalLocales.js
+++ b/tests/built-ins/Intl/getCanonicalLocales.js
@@ -28,6 +28,10 @@ describe.runIf(isIntl)("Intl.getCanonicalLocales", () => {
     expect(result[1]).toBe("fr-FR");
   });
 
+  test("canonicalises grandfathered tags through CLDR aliases", () => {
+    expect(Intl.getCanonicalLocales("zh-guoyu")[0]).toBe("zh");
+  });
+
   test("throws RangeError for structurally invalid locale tag", () => {
     expect(() => Intl.getCanonicalLocales("!")).toThrow(RangeError);
   });

--- a/tests/built-ins/Intl/supportedLocalesOf.js
+++ b/tests/built-ins/Intl/supportedLocalesOf.js
@@ -12,6 +12,7 @@ describe.runIf(isIntl)("Intl constructor supportedLocalesOf", () => {
     Intl.DisplayNames,
     Intl.DurationFormat,
     Intl.ListFormat,
+    Intl.Locale,
     Intl.NumberFormat,
     Intl.PluralRules,
     Intl.RelativeTimeFormat,

--- a/tests/built-ins/Intl/supportedLocalesOf.js
+++ b/tests/built-ins/Intl/supportedLocalesOf.js
@@ -1,0 +1,28 @@
+/*---
+description: Intl constructor supportedLocalesOf
+features: [Intl]
+---*/
+
+const isIntl = typeof Intl !== "undefined";
+
+describe.runIf(isIntl)("Intl constructor supportedLocalesOf", () => {
+  const constructors = [
+    Intl.Collator,
+    Intl.DateTimeFormat,
+    Intl.DisplayNames,
+    Intl.DurationFormat,
+    Intl.ListFormat,
+    Intl.NumberFormat,
+    Intl.PluralRules,
+    Intl.RelativeTimeFormat,
+    Intl.Segmenter,
+  ].filter((constructor) => typeof constructor !== "undefined");
+
+  test("ignores Unicode extensions when matching available locales", () => {
+    for (const constructor of constructors) {
+      const result = constructor.supportedLocalesOf(["de-u-co-phonebk"]);
+      expect(result.length).toBe(1);
+      expect(result[0]).toBe("de-u-co-phonebk");
+    }
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Apply CLDR grandfathered locale aliases before ICU canonicalization so Linux ICU 76 does not return ICU-only aliases such as `cmn` for `zh-guoyu`.
- Move constructor `supportedLocalesOf` filtering into `IntlLocaleResolver`, strip Unicode extensions only for the availability lookup, and cache the canonical ICU available locale list once per process.
- Closes #639.

Spec/test262 context: ECMA-402 ES2026 `CanonicalizeUnicodeLocaleId` (§6.2.2), `CanonicalizeLocaleList` (§9.2.1), `LookupMatchingLocaleByPrefix` (§9.2.3), and `FilterLocales` (§9.2.9). TC39 MCP snapshot for ECMA-402 ES2026: `8ea5ed5bab7165d1ef8ca2612a88582bf2b1ac94`; test262 index SHA: `05bb032907160d66c212589d345fa0e335e2738c`.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Commands run:

- `./build/GocciaTestRunner tests/built-ins/Intl --no-progress --exit-on-first-failure`
- `./format.pas --check`
- `./build.pas testrunner && ./build/GocciaTestRunner tests --no-progress --exit-on-first-failure`
- OrbStack Ubuntu 25.04 / ICU 76: `./build.pas --clean loaderbare` plus targeted `bun scripts/run_test262_suite.ts --suite-dir /tmp/test262-suite --mode=bytecode --jobs=1 --timeout-ms=10000 --max-memory=2147483648 --verbose` for all seven issue #639 paths; all passed.

Documentation note: no docs update because this fixes existing Intl behavior without adding public API surface.