### PR TITLE
Cache bytecode RegExp literal programs

### DIFF
--- a/source/units/Goccia.Bytecode.Binary.pas
+++ b/source/units/Goccia.Bytecode.Binary.pas
@@ -160,6 +160,11 @@ begin
         WriteDouble(Constant.FloatValue);
       bckString:
         WriteString(Constant.StringValue);
+      bckRegExpLiteral:
+      begin
+        WriteString(Constant.StringValue);
+        WriteString(Constant.RegExpFlags);
+      end;
       bckTemplateObject:
       begin
         // Serialise cooked and raw string arrays; CachedValue is runtime-only
@@ -360,7 +365,7 @@ var
   EvalBinding: TGocciaDirectEvalBindingInfo;
   HasDebug: Boolean;
   DebugInfo: TGocciaDebugInfo;
-  SourceFile: string;
+  SourceFile, RegExpPattern, RegExpFlags: string;
   LineMapCount, LocalCount: UInt32;
   CookedStrings, RawStrings: TGocciaBytecodeStringArray;
   CookedValid: TGocciaBytecodeTemplateCookedValid;
@@ -398,6 +403,12 @@ begin
       bckInteger: Result.AddConstantInteger(ReadInt64);
       bckFloat:   Result.AddConstantFloat(ReadDouble);
       bckString:  Result.AddConstantString(ReadString);
+      bckRegExpLiteral:
+      begin
+        RegExpPattern := ReadString;
+        RegExpFlags := ReadString;
+        Result.AddConstantRegExpLiteral(RegExpPattern, RegExpFlags);
+      end;
       bckTemplateObject:
       begin
         StrCount := ReadUInt16;

--- a/source/units/Goccia.Bytecode.Chunk.pas
+++ b/source/units/Goccia.Bytecode.Chunk.pas
@@ -25,6 +25,10 @@ type
     // runtime-only (starts nil, populated by the VM on first execution).
     // IntValue stores the cache slot index in TGocciaFunctionTemplate.
     bckTemplateObject,
+    // ES2026 §13.2.7.1: regexp literal payload. Each evaluation creates a
+    // fresh RegExp object, while IntValue identifies a runtime-only compiled
+    // program cache slot on the owning TGocciaFunctionTemplate.
+    bckRegExpLiteral,
     bckBigInt
   );
 
@@ -37,6 +41,7 @@ type
     IntValue: Int64;
     FloatValue: Double;
     StringValue: string;
+    RegExpFlags: string;                                  // for bckRegExpLiteral
     CookedStrings: TGocciaBytecodeStringArray;          // for bckTemplateObject
     RawStrings: TGocciaBytecodeStringArray;             // for bckTemplateObject
     CookedValid: TGocciaBytecodeTemplateCookedValid;    // for bckTemplateObject
@@ -127,6 +132,8 @@ type
     // number stored in the constant's IntValue field.  Not serialised to .gbc.
     FTemplateObjectCaches: array of TObject;  // TGocciaValue — typed as TObject to keep GC import out of interface
     FTemplateObjectCacheCount: Integer;
+    FRegExpProgramCaches: array of TObject;
+    FRegExpProgramCacheCount: Integer;
     function GetFunctionCount: Integer;
   public
     constructor Create(const AName: string);
@@ -145,8 +152,11 @@ type
     // no deduplication is performed.
     function AddConstantTemplateObject(const ACookedStrings, ARawStrings: array of string;
       const ACookedValid: array of Boolean): UInt16;
+    function AddConstantRegExpLiteral(const APattern, AFlags: string): UInt16;
     function GetTemplateObjectCache(const ASlot: Integer): TObject;
     procedure SetTemplateObjectCache(const ASlot: Integer; const AValue: TObject);
+    function GetRegExpProgramCache(const ASlot: Integer): TObject;
+    procedure SetRegExpProgramCache(const ASlot: Integer; const AValue: TObject);
     function AddFunction(const AFunction: TGocciaFunctionTemplate): UInt16;
     procedure AddUpvalueDescriptor(const AIsLocal: Boolean; const AIndex: UInt8);
     procedure AddDirectEvalEnvironment(const APC: UInt32;
@@ -263,6 +273,7 @@ begin
   FDirectEvalSyntheticArgumentsSlot := -1;
   FProfileIndex := -1;
   FTemplateSiteId := AllocateTemplateSiteId;
+  FRegExpProgramCacheCount := 0;
 end;
 
 destructor TGocciaFunctionTemplate.Destroy;
@@ -276,6 +287,8 @@ begin
       if Assigned(FTemplateObjectCaches[I]) then
         TGarbageCollector.Instance.UnpinObject(
           TGCManagedObject(FTemplateObjectCaches[I]));
+  for I := 0 to FRegExpProgramCacheCount - 1 do
+    FRegExpProgramCaches[I].Free;
   FStringConstantIndex.Free;
   FFunctions.Free;
   FDebugInfo.Free;
@@ -451,6 +464,27 @@ begin
   Inc(FConstantCount);
 end;
 
+// ES2026 §13.2.7.1 Runtime Semantics: Evaluation
+function TGocciaFunctionTemplate.AddConstantRegExpLiteral(
+  const APattern, AFlags: string): UInt16;
+begin
+  if FConstantCount > High(UInt16) then
+    raise Exception.Create('Constant pool overflow: exceeds 65535 entries');
+  if FConstantCount >= Length(FConstants) then
+    SetLength(FConstants, FConstantCount * 2 + 8);
+  FConstants[FConstantCount].Kind := bckRegExpLiteral;
+  FConstants[FConstantCount].StringValue := APattern;
+  FConstants[FConstantCount].RegExpFlags := AFlags;
+  FConstants[FConstantCount].IntValue := FRegExpProgramCacheCount;
+
+  if FRegExpProgramCacheCount >= Length(FRegExpProgramCaches) then
+    SetLength(FRegExpProgramCaches, FRegExpProgramCacheCount * 2 + 4);
+  Inc(FRegExpProgramCacheCount);
+
+  Result := UInt16(FConstantCount);
+  Inc(FConstantCount);
+end;
+
 function TGocciaFunctionTemplate.GetTemplateObjectCache(const ASlot: Integer): TObject;
 begin
   if (ASlot >= 0) and (ASlot < FTemplateObjectCacheCount) then
@@ -464,6 +498,22 @@ procedure TGocciaFunctionTemplate.SetTemplateObjectCache(const ASlot: Integer;
 begin
   if (ASlot >= 0) and (ASlot < FTemplateObjectCacheCount) then
     FTemplateObjectCaches[ASlot] := AValue;
+end;
+
+function TGocciaFunctionTemplate.GetRegExpProgramCache(
+  const ASlot: Integer): TObject;
+begin
+  if (ASlot >= 0) and (ASlot < FRegExpProgramCacheCount) then
+    Result := FRegExpProgramCaches[ASlot]
+  else
+    Result := nil;
+end;
+
+procedure TGocciaFunctionTemplate.SetRegExpProgramCache(const ASlot: Integer;
+  const AValue: TObject);
+begin
+  if (ASlot >= 0) and (ASlot < FRegExpProgramCacheCount) then
+    FRegExpProgramCaches[ASlot] := AValue;
 end;
 
 function TGocciaFunctionTemplate.AddFunction(

--- a/source/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/source/units/Goccia.Bytecode.OpCodeNames.pas
@@ -18,6 +18,7 @@ function OpCodeName(const AOp: UInt8): string;
 begin
   case TGocciaOpCode(AOp) of
     OP_LOAD_CONST:                     Result := 'OP_LOAD_CONST';
+    OP_LOAD_REGEXP:                    Result := 'OP_LOAD_REGEXP';
     OP_LOAD_TRUE:                      Result := 'OP_LOAD_TRUE';
     OP_LOAD_FALSE:                     Result := 'OP_LOAD_FALSE';
     OP_LOAD_INT:                       Result := 'OP_LOAD_INT';

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -77,7 +77,10 @@ const
   //               environment slots.
   //   v43 -> v44: direct-eval snapshots mark caller var-environment bindings
   //               separately from intervening lexical bindings.
-  GOCCIA_FORMAT_VERSION = 44;
+  //   v44 -> v45: added bckRegExpLiteral constants so bytecode regexp
+  //               literals create fresh RegExp objects from cached compiled
+  //               programs instead of calling the global RegExp constructor.
+  GOCCIA_FORMAT_VERSION = 45;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;
@@ -120,6 +123,7 @@ type
     semantic helper/orchestration ops in 167..255 }
   TGocciaOpCode = (
     OP_LOAD_CONST    = 0,
+    OP_LOAD_REGEXP   = 1,
     OP_LOAD_TRUE     = 2,
     OP_LOAD_FALSE    = 3,
     OP_LOAD_INT      = 4,

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -444,27 +444,10 @@ end;
 procedure CompileRegexLiteral(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaRegexLiteralExpression; const ADest: UInt8);
 var
-  BaseReg, PatternReg, FlagsReg: UInt8;
-  NameIdx: UInt16;
+  LiteralIdx: UInt16;
 begin
-  BaseReg := ACtx.Scope.AllocateRegister;
-
-  NameIdx := ACtx.Template.AddConstantString(CONSTRUCTOR_REGEXP);
-  EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, BaseReg, NameIdx));
-
-  PatternReg := ACtx.Scope.AllocateRegister;
-  FlagsReg := ACtx.Scope.AllocateRegister;
-  EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, PatternReg,
-    ACtx.Template.AddConstantString(AExpr.Pattern)));
-  EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, FlagsReg,
-    ACtx.Template.AddConstantString(AExpr.Flags)));
-  EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, 2, 0));
-  ACtx.Scope.FreeRegister;
-  ACtx.Scope.FreeRegister;
-
-  if BaseReg <> ADest then
-    EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, BaseReg, 0));
-  ACtx.Scope.FreeRegister;
+  LiteralIdx := ACtx.Template.AddConstantRegExpLiteral(AExpr.Pattern, AExpr.Flags);
+  EmitInstruction(ACtx, EncodeABx(OP_LOAD_REGEXP, ADest, LiteralIdx));
 end;
 
 procedure CompileIdentifier(const ACtx: TGocciaCompilationContext;

--- a/source/units/Goccia.Compiler.Test.pas
+++ b/source/units/Goccia.Compiler.Test.pas
@@ -344,12 +344,30 @@ end;
 procedure TTestCompiler.TestCompileRegExpLiteral;
 var
   Module: TGocciaBytecodeModule;
+  Constant: TGocciaBytecodeConstant;
+  I: Integer;
+  FoundLiteralConstant: Boolean;
 begin
   Module := CompileSource('const re = /ab+c/gi;');
   try
     Expect<Boolean>(Assigned(Module)).ToBe(True);
     Expect<Boolean>(Assigned(Module.TopLevel)).ToBe(True);
     Expect<Boolean>(Module.TopLevel.CodeCount > 0).ToBe(True);
+    Expect<Integer>(CountOp(Module.TopLevel, OP_LOAD_REGEXP)).ToBe(1);
+
+    FoundLiteralConstant := False;
+    for I := 0 to Module.TopLevel.ConstantCount - 1 do
+    begin
+      Constant := Module.TopLevel.GetConstant(I);
+      if (Constant.Kind = bckRegExpLiteral) and
+         (Constant.StringValue = 'ab+c') and
+         (Constant.RegExpFlags = 'gi') then
+      begin
+        FoundLiteralConstant := True;
+        Break;
+      end;
+    end;
+    Expect<Boolean>(FoundLiteralConstant).ToBe(True);
   finally
     Module.Free;
   end;
@@ -467,7 +485,8 @@ begin
     'const c = "hello world";' +
     'const d = true;' +
     'const e = null;' +
-    'const f = 9007199254740992;'
+    'const f = 9007199254740992;' +
+    'const g = /roundtrip/im;'
   );
   TempFile := GetTempFileName + '.gbc';
   try
@@ -494,6 +513,11 @@ begin
           end;
           bckString:
             Expect<string>(LoadConst.StringValue).ToBe(OrigConst.StringValue);
+          bckRegExpLiteral:
+          begin
+            Expect<string>(LoadConst.StringValue).ToBe(OrigConst.StringValue);
+            Expect<string>(LoadConst.RegExpFlags).ToBe(OrigConst.RegExpFlags);
+          end;
         end;
       end;
 

--- a/source/units/Goccia.RegExp.Runtime.pas
+++ b/source/units/Goccia.RegExp.Runtime.pas
@@ -14,6 +14,8 @@ procedure SetRegExpPrototype(const APrototype: TGocciaValue);
 function IsRegExpInstance(const AValue: TGocciaValue): Boolean;
 function IsRegExp(const AValue: TGocciaValue): Boolean;
 function CreateRegExpObject(const APattern, AFlags: string): TGocciaValue;
+function CreateRegExpLiteralObject(const APattern, AFlags: string;
+  const AProgramCache: TObject; out AUpdatedProgramCache: TObject): TGocciaValue;
 function CloneRegExpObject(const AValue: TGocciaValue): TGocciaValue;
 function MatchRegExpObjectOnce(const AValue: TGocciaValue; const AInput: string;
   out AMatchArray: TGocciaValue): Boolean;
@@ -60,6 +62,16 @@ type
     property CompiledProgram: TRegExpProgram read FCompiledProgram;
   end;
 
+  TGocciaCachedRegExpProgram = class
+  private
+    FFlags: string;
+    FProgram: TRegExpProgram;
+  public
+    constructor Create(const AProgram: TRegExpProgram; const AFlags: string);
+    property Flags: string read FFlags;
+    property Program_: TRegExpProgram read FProgram;
+  end;
+
 threadvar
   GRegExpPrototype: TGocciaObjectValue;
 
@@ -67,6 +79,14 @@ constructor TGocciaRegExpProgramData.Create(const AProgram: TRegExpProgram);
 begin
   inherited Create;
   FCompiledProgram := AProgram;
+end;
+
+constructor TGocciaCachedRegExpProgram.Create(const AProgram: TRegExpProgram;
+  const AFlags: string);
+begin
+  inherited Create;
+  FProgram := AProgram;
+  FFlags := AFlags;
 end;
 
 function GetRegExpPrototype: TGocciaValue;
@@ -78,6 +98,9 @@ procedure SetRegExpPrototype(const APrototype: TGocciaValue);
 begin
   GRegExpPrototype := TGocciaObjectValue(APrototype);
 end;
+
+function CreateRegExpObjectFromProgram(const APattern, AFlags: string;
+  const ACompiledProgram: TRegExpProgram): TGocciaValue; forward;
 
 function GetStringProperty(const AObject: TGocciaObjectValue;
   const AName: string): string;
@@ -296,8 +319,6 @@ end;
 
 function CreateRegExpObject(const APattern, AFlags: string): TGocciaValue;
 var
-  Obj: TGocciaObjectValue;
-  Source: string;
   CanonicalFlags: string;
   CompiledProgram: TRegExpProgram;
 begin
@@ -309,20 +330,53 @@ begin
       ThrowSyntaxError(E.Message);
   end;
 
+  Result := CreateRegExpObjectFromProgram(APattern, CanonicalFlags, CompiledProgram);
+end;
+
+function CreateRegExpObjectFromProgram(const APattern, AFlags: string;
+  const ACompiledProgram: TRegExpProgram): TGocciaValue;
+var
+  Obj: TGocciaObjectValue;
+  Source: string;
+begin
   Source := NormalizeRegExpSource(APattern);
   Obj := TGocciaObjectValue.Create(GRegExpPrototype);
   Obj.HasRegExpData := True;
-  Obj.RegExpData := TGocciaRegExpProgramData.Create(CompiledProgram);
+  Obj.RegExpData := TGocciaRegExpProgramData.Create(ACompiledProgram);
   Obj.DefineProperty(PROP_SOURCE,
     TGocciaPropertyDescriptorData.Create(
       TGocciaStringLiteralValue.Create(Source), []));
   Obj.DefineProperty(PROP_FLAGS,
     TGocciaPropertyDescriptorData.Create(
-      TGocciaStringLiteralValue.Create(CanonicalFlags), []));
+      TGocciaStringLiteralValue.Create(AFlags), []));
   Obj.DefineProperty(PROP_LAST_INDEX,
     TGocciaPropertyDescriptorData.Create(
       TGocciaNumberLiteralValue.Create(0), [pfWritable]));
   Result := Obj;
+end;
+
+function CreateRegExpLiteralObject(const APattern, AFlags: string;
+  const AProgramCache: TObject; out AUpdatedProgramCache: TObject): TGocciaValue;
+var
+  Cached: TGocciaCachedRegExpProgram;
+  CanonicalFlags: string;
+  CompiledProgram: TRegExpProgram;
+begin
+  Cached := TGocciaCachedRegExpProgram(AProgramCache);
+  if not Assigned(Cached) then
+  begin
+    try
+      CanonicalFlags := CanonicalizeRegExpFlags(AFlags);
+      CompiledProgram := CompileRegExpProgram(APattern, CanonicalFlags);
+    except
+      on E: Exception do
+        ThrowSyntaxError(E.Message);
+    end;
+    Cached := TGocciaCachedRegExpProgram.Create(CompiledProgram, CanonicalFlags);
+  end;
+
+  AUpdatedProgramCache := Cached;
+  Result := CreateRegExpObjectFromProgram(APattern, Cached.Flags, Cached.Program_);
 end;
 
 function CloneRegExpObject(const AValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -135,6 +135,8 @@ type
     // ES2026 §13.2.8.3 GetTemplateObject — lazy-build helper for bckTemplateObject constants.
     function BuildTemplateObjectConstant(const ATemplate: TGocciaFunctionTemplate;
       const AConstantIndex: Integer): TGocciaValue;
+    function BuildRegExpLiteralConstant(const ATemplate: TGocciaFunctionTemplate;
+      const AConstantIndex: Integer): TGocciaValue;
     function AcquireArguments(const ACapacity: Integer = 0): TGocciaArgumentsCollection;
     procedure ReleaseArguments(const AArguments: TGocciaArgumentsCollection);
     procedure AcquireRegisters(const ACount: Integer);
@@ -366,6 +368,7 @@ uses
   Goccia.InstructionLimit,
   Goccia.PatternMatching,
   Goccia.Profiler,
+  Goccia.RegExp.Runtime,
   Goccia.SourcePipeline,
   Goccia.StackLimit,
   Goccia.Timeout,
@@ -5217,6 +5220,22 @@ begin
   end;
 end;
 
+function TGocciaVM.BuildRegExpLiteralConstant(const ATemplate: TGocciaFunctionTemplate;
+  const AConstantIndex: Integer): TGocciaValue;
+var
+  Constant: TGocciaBytecodeConstant;
+  Slot: Integer;
+  Cached, UpdatedCache: TObject;
+begin
+  Constant := ATemplate.GetConstantUnchecked(AConstantIndex);
+  Slot := Integer(Constant.IntValue);
+  Cached := ATemplate.GetRegExpProgramCache(Slot);
+  Result := CreateRegExpLiteralObject(
+    Constant.StringValue, Constant.RegExpFlags, Cached, UpdatedCache);
+  if UpdatedCache <> Cached then
+    ATemplate.SetRegExpProgramCache(Slot, UpdatedCache);
+end;
+
 function TGocciaVM.AcquireArguments(
   const ACapacity: Integer): TGocciaArgumentsCollection;
 begin
@@ -9553,6 +9572,10 @@ begin
         else
           FRegisters[A] := ValueToRegister(
             ConstantToValue(Template.GetConstantUnchecked(DecodeBx(Instruction))));
+
+      OP_LOAD_REGEXP:
+        FRegisters[A] := ValueToRegister(
+          BuildRegExpLiteralConstant(Template, DecodeBx(Instruction)));
 
       OP_LOAD_UNDEFINED:
         FRegisters[A] := RegisterUndefined;

--- a/tests/language/expressions/regex/regex-literals.js
+++ b/tests/language/expressions/regex/regex-literals.js
@@ -11,6 +11,17 @@ test("regex literals create RegExp objects", () => {
   expect(regex.test("zABz")).toBe(true);
 });
 
+test("regex literals create a fresh object on each evaluation", () => {
+  const create = () => /ab/g;
+  const first = create();
+  const second = create();
+
+  first.lastIndex = 2;
+
+  expect(first === second).toBe(false);
+  expect(second.lastIndex).toBe(0);
+});
+
 test("regex literals coexist with division expressions", () => {
   expect(/ab/.test("zabz")).toBe(true);
   expect(8 / 2).toBe(4);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add a bytecode RegExp literal opcode and constant kind so literal sites cache compiled programs without calling the global `RegExp` constructor.
- Keep each literal evaluation observable as a fresh `RegExp` object with independent `lastIndex` state.
- Update bytecode serialization/versioning and add compiler, binary round-trip, runtime, and test262 regression coverage.

Closes #726

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build/GocciaTestRunner tests/language/expressions/regex/regex-literals.js --mode=bytecode --no-progress`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262.2CXxxZ --categories built-ins --filter built-ins/RegExp/character-class-escape-non-whitespace.js --mode=bytecode --jobs=2`
  - Note: full `./build/GocciaTestRunner tests --no-progress` currently fails in this worktree because `tests/built-ins/FFI/fixtures/ffi/libfixture.dylib` is absent; the observed failures are limited to FFI fixture loading.
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./format.pas --check`
  - `./build.pas --clean tests`
  - `./build.pas testrunner`
  - `./build/Goccia.Compiler.Test`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change