### PR TITLE
Improve test262 language feature coverage

### DIFF
--- a/source/units/Goccia.AST.Statements.pas
+++ b/source/units/Goccia.AST.Statements.pas
@@ -244,10 +244,12 @@ type
     FFinallyBlock: TGocciaBlockStatement;
     FCatchParamType: string;
     FCatchPattern: TGocciaMatchPattern;
+    FCatchBindingPattern: TGocciaDestructuringPattern;
   public
     constructor Create(const ABlock: TGocciaBlockStatement; const ACatchParam: string;
       const ACatchBlock, AFinallyBlock: TGocciaBlockStatement; const ALine, AColumn: Integer;
-      const ACatchPattern: TGocciaMatchPattern = nil);
+      const ACatchPattern: TGocciaMatchPattern = nil;
+      const ACatchBindingPattern: TGocciaDestructuringPattern = nil);
     function Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow; override;
     property Block: TGocciaBlockStatement read FBlock;
     property CatchParam: string read FCatchParam;
@@ -255,6 +257,7 @@ type
     property FinallyBlock: TGocciaBlockStatement read FFinallyBlock;
     property CatchParamType: string read FCatchParamType write FCatchParamType;
     property CatchPattern: TGocciaMatchPattern read FCatchPattern;
+    property CatchBindingPattern: TGocciaDestructuringPattern read FCatchBindingPattern;
   end;
 
   // Is this not a statement?
@@ -879,7 +882,8 @@ end;
 
   constructor TGocciaTryStatement.Create(const ABlock: TGocciaBlockStatement;
     const ACatchParam: string; const ACatchBlock, AFinallyBlock: TGocciaBlockStatement;
-    const ALine, AColumn: Integer; const ACatchPattern: TGocciaMatchPattern = nil);
+    const ALine, AColumn: Integer; const ACatchPattern: TGocciaMatchPattern = nil;
+    const ACatchBindingPattern: TGocciaDestructuringPattern = nil);
 begin
   inherited Create(ALine, AColumn);
   FBlock := ABlock;
@@ -887,6 +891,7 @@ begin
   FCatchBlock := ACatchBlock;
   FFinallyBlock := AFinallyBlock;
   FCatchPattern := ACatchPattern;
+  FCatchBindingPattern := ACatchBindingPattern;
 end;
 
   { TGocciaClassMethod }

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -1862,6 +1862,8 @@ begin
             '#object-rest-key:' + IntToStr(ACtx.Template.CodeCount) + ':' +
             IntToStr(ACtx.Scope.NextSlot) + ':' + IntToStr(I), False);
           ACtx.CompileExpression(Prop.KeyExpression, UInt8(ComputedKeySlot));
+          EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY,
+            UInt8(ComputedKeySlot), UInt8(ComputedKeySlot), 0));
           ComputedKeySlots[I] := ComputedKeySlot;
           IdxReg := UInt8(ComputedKeySlot);
           DestSlot := ACtx.Scope.AllocateRegister;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -136,7 +136,7 @@ function PrivateKey(const AScope: TGocciaCompilerScope;
 var
   Prefix: string;
 begin
-  Prefix := AScope.ResolvePrivatePrefix;
+  Prefix := AScope.ResolvePrivatePrefixForName(AName);
   Result := '#slot:' + Prefix + AName;
 end;
 
@@ -1789,6 +1789,8 @@ var
   HasRest: Boolean;
   Limit: Integer;
   RestIndex: Integer;
+  ComputedKeySlot: Integer;
+  ComputedKeySlots: array of Integer;
 begin
   if APattern is TGocciaIdentifierDestructuringPattern then
   begin
@@ -1801,6 +1803,17 @@ begin
     EmitInstruction(ACtx, EncodeABC(OP_VALIDATE_VALUE, ASrcReg,
       VALIDATE_OP_REQUIRE_OBJECT, 0));
     ObjPat := TGocciaObjectDestructuringPattern(APattern);
+    SetLength(ComputedKeySlots, ObjPat.Properties.Count);
+    for I := 0 to High(ComputedKeySlots) do
+      ComputedKeySlots[I] := -1;
+    RestIndex := -1;
+    for I := 0 to ObjPat.Properties.Count - 1 do
+      if ObjPat.Properties[I].Pattern is TGocciaRestDestructuringPattern then
+      begin
+        RestIndex := I;
+        Break;
+      end;
+
     for I := 0 to ObjPat.Properties.Count - 1 do
     begin
       Prop := ObjPat.Properties[I];
@@ -1811,11 +1824,22 @@ begin
         EmitInstruction(ACtx, EncodeABC(OP_NEW_ARRAY, IdxReg, UInt8(I), 0));
         for JumpIdx := 0 to I - 1 do
         begin
-          DestSlot := ACtx.Scope.AllocateRegister;
-          PropIdx := ACtx.Template.AddConstantString(ObjPat.Properties[JumpIdx].Key);
-          EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, DestSlot, PropIdx));
-          EmitInstruction(ACtx, EncodeABC(OP_ARRAY_PUSH, IdxReg, DestSlot, 0));
-          ACtx.Scope.FreeRegister;
+          if ObjPat.Properties[JumpIdx].Computed and
+             Assigned(ObjPat.Properties[JumpIdx].KeyExpression) then
+          begin
+            if ComputedKeySlots[JumpIdx] < 0 then
+              raise Exception.Create('Compiler error: computed object rest key was not preserved');
+            EmitInstruction(ACtx, EncodeABC(OP_ARRAY_PUSH, IdxReg,
+              UInt8(ComputedKeySlots[JumpIdx]), 0));
+          end
+          else
+          begin
+            DestSlot := ACtx.Scope.AllocateRegister;
+            PropIdx := ACtx.Template.AddConstantString(ObjPat.Properties[JumpIdx].Key);
+            EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, DestSlot, PropIdx));
+            EmitInstruction(ACtx, EncodeABC(OP_ARRAY_PUSH, IdxReg, DestSlot, 0));
+            ACtx.Scope.FreeRegister;
+          end;
         end;
         DestSlot := ACtx.Scope.AllocateRegister;
         if IdxReg <> DestSlot + 1 then
@@ -1830,17 +1854,33 @@ begin
         Break;
       end;
 
-      DestSlot := ACtx.Scope.AllocateRegister;
       if Prop.Computed and Assigned(Prop.KeyExpression) then
       begin
-        IdxReg := ACtx.Scope.AllocateRegister;
-        ACtx.CompileExpression(Prop.KeyExpression, IdxReg);
-        EmitInstruction(ACtx, EncodeABC(OP_GET_INDEX, DestSlot, ASrcReg,
-          IdxReg));
-        ACtx.Scope.FreeRegister;
+        if (RestIndex >= 0) and (I < RestIndex) then
+        begin
+          ComputedKeySlot := ACtx.Scope.DeclareLocal(
+            '#object-rest-key:' + IntToStr(ACtx.Template.CodeCount) + ':' +
+            IntToStr(ACtx.Scope.NextSlot) + ':' + IntToStr(I), False);
+          ACtx.CompileExpression(Prop.KeyExpression, UInt8(ComputedKeySlot));
+          ComputedKeySlots[I] := ComputedKeySlot;
+          IdxReg := UInt8(ComputedKeySlot);
+          DestSlot := ACtx.Scope.AllocateRegister;
+          EmitInstruction(ACtx, EncodeABC(OP_GET_INDEX, DestSlot, ASrcReg,
+            IdxReg));
+        end
+        else
+        begin
+          DestSlot := ACtx.Scope.AllocateRegister;
+          IdxReg := ACtx.Scope.AllocateRegister;
+          ACtx.CompileExpression(Prop.KeyExpression, IdxReg);
+          EmitInstruction(ACtx, EncodeABC(OP_GET_INDEX, DestSlot, ASrcReg,
+            IdxReg));
+          ACtx.Scope.FreeRegister;
+        end;
       end
       else
       begin
+        DestSlot := ACtx.Scope.AllocateRegister;
         EmitLoadPropertyByName(ACtx, DestSlot, ASrcReg, Prop.Key);
       end;
 
@@ -1995,9 +2035,9 @@ var
 begin
   SrcReg := ACtx.Scope.AllocateRegister;
   ACtx.CompileExpression(AExpr.Right, SrcReg);
-  EmitDestructuring(ACtx, AExpr.Left, SrcReg, True);
   if ADest <> SrcReg then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, SrcReg, 0));
+  EmitDestructuring(ACtx, AExpr.Left, SrcReg, True);
   ACtx.Scope.FreeRegister;
 end;
 

--- a/source/units/Goccia.Compiler.Scope.pas
+++ b/source/units/Goccia.Compiler.Scope.pas
@@ -58,6 +58,9 @@ type
     FNextSlot: UInt8;
     FMaxSlot: UInt8;
     FPrivatePrefix: string;
+    FPrivateNames: array of string;
+    FPrivatePrefixes: array of string;
+    FPrivateNameCount: Integer;
     FIsArrow: Boolean;
     FDirectEvalSyntheticArgumentsSlot: Integer;
     FWithBindingNames: array of string;
@@ -117,6 +120,10 @@ type
       out AValue: TGocciaCompileTimeValue): Boolean;
     function HasVisibleLocal(const AName: string): Boolean;
     function ResolvePrivatePrefix: string;
+    function ResolvePrivatePrefixForName(const AName: string): string;
+    procedure DeclarePrivateNamePrefix(const AName, APrefix: string);
+    function PrivateNameMark: Integer;
+    procedure RestorePrivateNameMark(const AMark: Integer);
     procedure PushWithBinding(const AHiddenName: string);
     procedure PopWithBinding;
     function GetWithBindingName(const AIndex: Integer): string;
@@ -187,6 +194,7 @@ begin
   FDepth := ADepth;
   FNextSlot := 0;
   FMaxSlot := 0;
+  FPrivateNameCount := 0;
   FDirectEvalSyntheticArgumentsSlot := -1;
   FWithBindingCount := 0;
   if Assigned(AParent) and (AParent.FWithBindingCount > 0) then
@@ -538,6 +546,47 @@ begin
     S := S.FParent;
   end;
   Result := '';
+end;
+
+function TGocciaCompilerScope.ResolvePrivatePrefixForName(
+  const AName: string): string;
+var
+  I: Integer;
+begin
+  for I := FPrivateNameCount - 1 downto 0 do
+    if FPrivateNames[I] = AName then
+      Exit(FPrivatePrefixes[I]);
+
+  if Assigned(FParent) then
+    Exit(FParent.ResolvePrivatePrefixForName(AName));
+
+  Result := ResolvePrivatePrefix;
+end;
+
+procedure TGocciaCompilerScope.DeclarePrivateNamePrefix(const AName,
+  APrefix: string);
+begin
+  if FPrivateNameCount >= Length(FPrivateNames) then
+  begin
+    SetLength(FPrivateNames, FPrivateNameCount * 2 + 8);
+    SetLength(FPrivatePrefixes, FPrivateNameCount * 2 + 8);
+  end;
+  FPrivateNames[FPrivateNameCount] := AName;
+  FPrivatePrefixes[FPrivateNameCount] := APrefix;
+  Inc(FPrivateNameCount);
+end;
+
+function TGocciaCompilerScope.PrivateNameMark: Integer;
+begin
+  Result := FPrivateNameCount;
+end;
+
+procedure TGocciaCompilerScope.RestorePrivateNameMark(const AMark: Integer);
+begin
+  if AMark < 0 then
+    Exit;
+  if AMark < FPrivateNameCount then
+    FPrivateNameCount := AMark;
 end;
 
 procedure TGocciaCompilerScope.PushWithBinding(const AHiddenName: string);

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -1921,9 +1921,11 @@ end;
 procedure CompileTryStatement(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaTryStatement);
 var
-  CatchReg, PatternTestReg: UInt8;
+  CatchReg, PatternTestReg, CatchInitErrorReg: UInt8;
   HandlerJump, EndJump, PatternMismatchJump, CatchSuccessJump: Integer;
+  CatchInitHandlerJump, CatchInitSuccessJump: Integer;
   HasCatch, HasFinally: Boolean;
+  HasCatchInitHandler: Boolean;
   I: Integer;
   ClosedLocals: array[0..255] of UInt8;
   ClosedCount: Integer;
@@ -1931,8 +1933,12 @@ var
 begin
   HasCatch := Assigned(AStmt.CatchBlock);
   HasFinally := Assigned(AStmt.FinallyBlock);
+  HasCatchInitHandler := Assigned(AStmt.CatchBindingPattern) and HasFinally;
 
   CatchReg := ACtx.Scope.AllocateRegister;
+  CatchInitErrorReg := 0;
+  CatchInitHandlerJump := -1;
+  CatchInitSuccessJump := -1;
   PatternTestReg := 0;
   HandlerJump := EmitJumpInstruction(ACtx, OP_PUSH_HANDLER, CatchReg);
 
@@ -1966,12 +1972,27 @@ begin
     PatternMismatchJump := -1;
     if Assigned(AStmt.CatchPattern) then
       PatternTestReg := ACtx.Scope.AllocateRegister;
+    if HasCatchInitHandler then
+      CatchInitErrorReg := ACtx.Scope.AllocateRegister;
 
-    if AStmt.CatchParam <> '' then
+    if (AStmt.CatchParam <> '') or Assigned(AStmt.CatchBindingPattern) then
     begin
       ACtx.Scope.BeginScope;
-      ACtx.Scope.DeclareLocal(AStmt.CatchParam, False);
-      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ACtx.Scope.NextSlot - 1, CatchReg, 0));
+      if AStmt.CatchParam <> '' then
+      begin
+        ACtx.Scope.DeclareLocal(AStmt.CatchParam, False);
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, ACtx.Scope.NextSlot - 1, CatchReg, 0));
+      end
+      else
+      begin
+        CollectDestructuringBindings(AStmt.CatchBindingPattern, ACtx.Scope);
+        if HasCatchInitHandler then
+          CatchInitHandlerJump := EmitJumpInstruction(ACtx, OP_PUSH_HANDLER,
+            CatchInitErrorReg);
+        EmitDestructuring(ACtx, AStmt.CatchBindingPattern, CatchReg);
+        if HasCatchInitHandler then
+          EmitInstruction(ACtx, EncodeABC(OP_POP_HANDLER, 0, 0, 0));
+      end;
     end;
 
     if Assigned(AStmt.CatchPattern) then
@@ -1984,7 +2005,7 @@ begin
 
     CompileBlockStatement(ACtx, AStmt.CatchBlock);
 
-    if AStmt.CatchParam <> '' then
+    if (AStmt.CatchParam <> '') or Assigned(AStmt.CatchBindingPattern) then
     begin
       ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
       for I := 0 to ClosedCount - 1 do
@@ -2001,13 +2022,25 @@ begin
     begin
       CatchSuccessJump := EmitJumpInstruction(ACtx, OP_JUMP, 0);
       PatchJumpTarget(ACtx, PatternMismatchJump);
-      if AStmt.CatchParam <> '' then
+      if (AStmt.CatchParam <> '') or Assigned(AStmt.CatchBindingPattern) then
         for I := 0 to ClosedCount - 1 do
           EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
       if HasFinally then
         CompileBlockStatement(ACtx, AStmt.FinallyBlock);
       EmitInstruction(ACtx, EncodeABC(OP_THROW, CatchReg, 0, 0));
       PatchJumpTarget(ACtx, CatchSuccessJump);
+      ACtx.Scope.FreeRegister;
+    end;
+
+    if HasCatchInitHandler then
+    begin
+      CatchInitSuccessJump := EmitJumpInstruction(ACtx, OP_JUMP, 0);
+      PatchJumpTarget(ACtx, CatchInitHandlerJump);
+      for I := 0 to ClosedCount - 1 do
+        EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+      CompileBlockStatement(ACtx, AStmt.FinallyBlock);
+      EmitInstruction(ACtx, EncodeABC(OP_THROW, CatchInitErrorReg, 0, 0));
+      PatchJumpTarget(ACtx, CatchInitSuccessJump);
       ACtx.Scope.FreeRegister;
     end;
   end
@@ -4496,6 +4529,50 @@ begin
   Result := False;
 end;
 
+procedure RegisterPrivateName(const AScope: TGocciaCompilerScope;
+  const AName, APrefix: string);
+begin
+  if AName = '' then
+    Exit;
+  if AName[1] = '#' then
+    AScope.DeclarePrivateNamePrefix(Copy(AName, 2, MaxInt), APrefix)
+  else
+    AScope.DeclarePrivateNamePrefix(AName, APrefix);
+end;
+
+procedure RegisterClassPrivateNames(const AScope: TGocciaCompilerScope;
+  const AClassDef: TGocciaClassDefinition; const APrefix: string);
+var
+  I: Integer;
+  MethodPair: TGocciaClassMethodMap.TKeyValuePair;
+  ExprPair: TGocciaExpressionMap.TKeyValuePair;
+  GetterPair: TGocciaGetterExpressionMap.TKeyValuePair;
+  SetterPair: TGocciaSetterExpressionMap.TKeyValuePair;
+begin
+  for I := 0 to High(AClassDef.FElements) do
+    if AClassDef.FElements[I].IsPrivate then
+      RegisterPrivateName(AScope, AClassDef.FElements[I].Name, APrefix);
+
+  for ExprPair in AClassDef.PrivateInstanceProperties do
+    RegisterPrivateName(AScope, ExprPair.Key, APrefix);
+  for ExprPair in AClassDef.PrivateStaticProperties do
+    RegisterPrivateName(AScope, ExprPair.Key, APrefix);
+  for MethodPair in AClassDef.PrivateMethods do
+    RegisterPrivateName(AScope, MethodPair.Key, APrefix);
+  for GetterPair in AClassDef.Getters do
+    if (GetterPair.Key <> '') and (GetterPair.Key[1] = '#') then
+      RegisterPrivateName(AScope, GetterPair.Key, APrefix);
+  for SetterPair in AClassDef.Setters do
+    if (SetterPair.Key <> '') and (SetterPair.Key[1] = '#') then
+      RegisterPrivateName(AScope, SetterPair.Key, APrefix);
+  for GetterPair in AClassDef.StaticGetters do
+    if (GetterPair.Key <> '') and (GetterPair.Key[1] = '#') then
+      RegisterPrivateName(AScope, GetterPair.Key, APrefix);
+  for SetterPair in AClassDef.StaticSetters do
+    if (SetterPair.Key <> '') and (SetterPair.Key[1] = '#') then
+      RegisterPrivateName(AScope, SetterPair.Key, APrefix);
+end;
+
 procedure CompileFieldInitializer(const ACtx: TGocciaCompilationContext;
   const AClassReg: UInt8; const AClassDef: TGocciaClassDefinition;
   const AComputedFieldKeyLocals: TComputedFieldKeyLocals);
@@ -4940,6 +5017,7 @@ var
   I, LocalIdx, UpvalIdx: Integer;
   HasSuper: Boolean;
   PrivPrefix: string;
+  PrivateNameMark: Integer;
   ComputedFieldKeyLocals: TComputedFieldKeyLocals;
   ComputedKeyName: string;
 begin
@@ -4947,7 +5025,9 @@ begin
   HasSuper := ClassDef.SuperClass <> '';
 
   PrivPrefix := NextClassPrivatePrefix;
+  PrivateNameMark := ACtx.Scope.PrivateNameMark;
   ACtx.Scope.PrivatePrefix := PrivPrefix;
+  RegisterClassPrivateNames(ACtx.Scope, ClassDef, PrivPrefix);
 
   // Reuse pre-declared slot if it exists at the same scope depth
   // (for function declaration upvalue resolution)
@@ -5154,6 +5234,7 @@ begin
     EmitGlobalDefine(ACtx, ClassReg, ClassDef.Name, True);
 
   ACtx.Scope.PrivatePrefix := '';
+  ACtx.Scope.RestorePrivateNameMark(PrivateNameMark);
 end;
 
 procedure CompileClassExpression(const ACtx: TGocciaCompilationContext;
@@ -5170,6 +5251,7 @@ var
   LocalIdx, UpvalIdx: Integer;
   HasSuper: Boolean;
   PrivPrefix: string;
+  PrivateNameMark: Integer;
   HasNameBinding: Boolean;
   ClosedLocals: array[0..0] of UInt8;
   ClosedCount, I: Integer;
@@ -5181,7 +5263,9 @@ begin
   HasNameBinding := ClassDef.Name <> '';
 
   PrivPrefix := NextClassPrivatePrefix;
+  PrivateNameMark := ACtx.Scope.PrivateNameMark;
   ACtx.Scope.PrivatePrefix := PrivPrefix;
+  RegisterClassPrivateNames(ACtx.Scope, ClassDef, PrivPrefix);
 
   if HasNameBinding then
     NameIdx := ACtx.Template.AddConstantString(ClassDef.Name)
@@ -5396,6 +5480,7 @@ begin
   end;
 
   ACtx.Scope.PrivatePrefix := '';
+  ACtx.Scope.RestorePrivateNameMark(PrivateNameMark);
 end;
 
 procedure CollectDestructuringVarBindings(const APattern: TGocciaDestructuringPattern;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -2022,6 +2022,7 @@ begin
       else
       begin
         CollectDestructuringBindings(AStmt.CatchBindingPattern, ACtx.Scope);
+        EmitBlockPatternHoleInitializers(ACtx, AStmt.CatchBindingPattern);
         if HasCatchInitHandler then
           CatchInitHandlerJump := EmitJumpInstruction(ACtx, OP_PUSH_HANDLER,
             CatchInitErrorReg);

--- a/source/units/Goccia.Compiler.pas
+++ b/source/units/Goccia.Compiler.pas
@@ -702,6 +702,8 @@ var
   RetReg: UInt8;
   Ctx: TGocciaCompilationContext;
   HasFunctionDecl, BodyAbrupt, StatementAbrupt: Boolean;
+  PredeclaredLexicalStart, PredeclaredLexicalIndex: Integer;
+  PredeclaredLocal: TGocciaCompilerLocal;
 begin
   FModule := TGocciaBytecodeModule.Create(GOCCIA_RUNTIME_TAG, FSourcePath);
   FCurrentTemplate := TGocciaFunctionTemplate.Create('<module>');
@@ -734,8 +736,18 @@ begin
     begin
       // Pre-declare lexical locals so function declarations can resolve
       // upvalue captures for let/const variables declared later in the body
+      PredeclaredLexicalStart := FCurrentScope.LocalCount;
       for I := 0 to AProgram.Body.Count - 1 do
         PredeclareLexicalLocals(AProgram.Body[I], FCurrentScope);
+      Ctx := BuildContext;
+      for PredeclaredLexicalIndex := PredeclaredLexicalStart to
+        FCurrentScope.LocalCount - 1 do
+      begin
+        PredeclaredLocal := FCurrentScope.GetLocal(PredeclaredLexicalIndex);
+        if not PredeclaredLocal.IsVar then
+          EmitInstruction(Ctx, EncodeABC(OP_LOAD_HOLE,
+            PredeclaredLocal.Slot, 0, 0));
+      end;
 
       // Hoist function declarations: compile initializers before other statements
       for I := 0 to AProgram.Body.Count - 1 do

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -4940,6 +4940,8 @@ function ExecuteCatchBlock(const ATryStatement: TGocciaTryStatement; const AErro
 var
   CatchScope: TGocciaScope;
   CatchContext, MatchContext: TGocciaEvaluationContext;
+  PatternNames: TStringList;
+  I: Integer;
 begin
   if ATryStatement.CatchParam <> '' then
   begin
@@ -4971,6 +4973,18 @@ begin
     try
       CatchContext := AContext;
       CatchContext.Scope := CatchScope;
+      PatternNames := TStringList.Create;
+      PatternNames.CaseSensitive := True;
+      try
+        CollectPatternBindingNames(ATryStatement.CatchBindingPattern,
+          PatternNames, True);
+        for I := 0 to PatternNames.Count - 1 do
+          if not CatchScope.ContainsOwnLexicalBinding(PatternNames[I]) then
+            CatchScope.PredeclareLexicalBinding(PatternNames[I], dtLet,
+              ATryStatement.Line, ATryStatement.Column);
+      finally
+        PatternNames.Free;
+      end;
       AssignPattern(ATryStatement.CatchBindingPattern, AErrorValue, CatchContext,
         True, dtParameter);
       Result := EvaluateBlock(ATryStatement.CatchBlock, CatchContext);
@@ -6948,15 +6962,36 @@ begin
   Result := ClassValue;
 end;
 
-function ResolveOwningClass(const AInstance: TGocciaInstanceValue; const AContext: TGocciaEvaluationContext): TGocciaClassValue;
+function ResolveLexicalPrivateAccessClass(
+  const AContext: TGocciaEvaluationContext;
+  const APrivateName: string): TGocciaClassValue;
 var
   OwningClassValue: TGocciaValue;
+  LastOwningClass: TGocciaValue;
+  CandidateClass: TGocciaClassValue;
 begin
-  // Walk the scope chain to find the owning class (set on TGocciaMethodCallScope or TGocciaClassInitScope)
-  OwningClassValue := AContext.Scope.FindOwningClass;
-  if (OwningClassValue is TGocciaClassValue) then
+  Result := nil;
+  LastOwningClass := nil;
+  repeat
+    OwningClassValue := AContext.Scope.FindOwningClassAfter(LastOwningClass);
+    if not (OwningClassValue is TGocciaClassValue) then
+      Exit;
+
+    CandidateClass := TGocciaClassValue(OwningClassValue);
+    if CandidateClass.HasOwnPrivateName(APrivateName) then
+      Exit(CandidateClass);
+
+    LastOwningClass := OwningClassValue;
+  until False;
+end;
+
+function ResolveOwningClass(const AInstance: TGocciaInstanceValue;
+  const AContext: TGocciaEvaluationContext;
+  const APrivateName: string): TGocciaClassValue;
+begin
+  Result := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
+  if Assigned(Result) then
   begin
-    Result := TGocciaClassValue(OwningClassValue);
     Exit;
   end;
   // Fallback: use the instance's class
@@ -6977,15 +7012,23 @@ end;
 function CollectDeclaredPrivateNames(const AContext: TGocciaEvaluationContext): TStringList;
 var
   OwningClassValue: TGocciaClassValue;
+  LastOwningClass: TGocciaValue;
+  CandidateClassValue: TGocciaValue;
 begin
   Result := TStringList.Create;
   Result.CaseSensitive := True;
   Result.Sorted := False;
   Result.Duplicates := dupIgnore;
 
-  OwningClassValue := ResolveLexicalOwningClass(AContext);
-  if Assigned(OwningClassValue) then
+  LastOwningClass := nil;
+  repeat
+    CandidateClassValue := AContext.Scope.FindOwningClassAfter(LastOwningClass);
+    if not (CandidateClassValue is TGocciaClassValue) then
+      Exit;
+    OwningClassValue := TGocciaClassValue(CandidateClassValue);
     OwningClassValue.AppendOwnPrivateNames(Result);
+    LastOwningClass := CandidateClassValue;
+  until False;
 end;
 
 procedure ThrowPrivateGetterMissingError(const APrivateName: string);
@@ -7144,8 +7187,7 @@ var
   GetterFn: TGocciaFunctionBase;
   EmptyArgs: TGocciaArgumentsCollection;
 begin
-  // Determine the access class from the owning class of the current method
-  AccessClass := ResolveOwningClass(AInstance, AContext);
+  AccessClass := ResolveOwningClass(AInstance, AContext, APrivateName);
 
   // Check if this is a private getter
   if AccessClass.HasPrivateGetter(APrivateName) then
@@ -7164,9 +7206,9 @@ begin
     ThrowPrivateGetterMissingError(APrivateName);
 
   // Check if this is a private method call
-  if AInstance.ClassValue.PrivateMethods.ContainsKey(APrivateName) then
+  if AccessClass.PrivateMethods.ContainsKey(APrivateName) then
   begin
-    Result := AInstance.ClassValue.GetPrivateMethod(APrivateName);
+    Result := AccessClass.GetPrivateMethod(APrivateName);
     if Result = nil then
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end
@@ -7184,7 +7226,7 @@ var
   GetterFn: TGocciaFunctionBase;
   EmptyArgs: TGocciaArgumentsCollection;
 begin
-  AccessClass := ResolveLexicalOwningClass(AContext);
+  AccessClass := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
   if not Assigned(AccessClass) then
     ThrowPrivateBrandError(APrivateName);
 
@@ -7228,7 +7270,7 @@ var
   GetterFn: TGocciaFunctionBase;
   EmptyArgs: TGocciaArgumentsCollection;
 begin
-  AccessClass := ResolveLexicalOwningClass(AContext);
+  AccessClass := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
   if not Assigned(AccessClass) then
     AccessClass := AClassValue;
 
@@ -7264,7 +7306,7 @@ var
   SetterFn: TGocciaFunctionBase;
   SetterArgs: TGocciaArgumentsCollection;
 begin
-  AccessClass := ResolveLexicalOwningClass(AContext);
+  AccessClass := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
   if not Assigned(AccessClass) then
     AccessClass := AClassValue;
 
@@ -7304,7 +7346,7 @@ var
   SetterFn: TGocciaFunctionBase;
   SetterArgs: TGocciaArgumentsCollection;
 begin
-  AccessClass := ResolveOwningClass(AInstance, AContext);
+  AccessClass := ResolveOwningClass(AInstance, AContext, APrivateName);
 
   if AccessClass.HasPrivateSetter(APrivateName) then
   begin
@@ -7339,7 +7381,7 @@ var
   PendingNewTarget: TGocciaValue;
   FieldInitializer: TGocciaExpression;
 begin
-  AccessClass := ResolveLexicalOwningClass(AContext);
+  AccessClass := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
   if not Assigned(AccessClass) then
     ThrowPrivateBrandError(APrivateName);
 
@@ -8530,7 +8572,8 @@ begin
   if ObjectValue is TGocciaInstanceValue then
   begin
     Instance := TGocciaInstanceValue(ObjectValue);
-    AccessClass := ResolveOwningClass(Instance, AContext);
+    AccessClass := ResolveOwningClass(Instance, AContext,
+      APattern.Expression.PrivateName);
 
     if AccessClass.HasPrivateSetter(APattern.Expression.PrivateName) then
     begin

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -4929,6 +4929,19 @@ begin
       CatchScope.Free;
     end;
   end
+  else if Assigned(ATryStatement.CatchBindingPattern) then
+  begin
+    CatchScope := AContext.Scope.CreateChild(skBlock, 'CatchBlock');
+    try
+      CatchContext := AContext;
+      CatchContext.Scope := CatchScope;
+      AssignPattern(ATryStatement.CatchBindingPattern, AErrorValue, CatchContext,
+        True, dtParameter);
+      Result := EvaluateBlock(ATryStatement.CatchBlock, CatchContext);
+    finally
+      CatchScope.Free;
+    end;
+  end
   else
     Result := EvaluateBlock(ATryStatement.CatchBlock, AContext);
 end;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -101,6 +101,7 @@ type
     procedure DeclarePrivateName(const AName: string);
     procedure RecordPrivateNameReference(const AName: string; const ALine, AColumn: Integer);
     function CurrentPrivateClassContext: TGocciaPrivateClassContext;
+    function HasVisiblePrivateNameDeclaration(const AName: string): Boolean;
     procedure EnterFunctionLabelScope(out ASavedActiveLabels, ASavedActiveIterationLabels: TStringList; out ASavedDirectLabelStart: Integer);
     procedure LeaveFunctionLabelScope(const ASavedActiveLabels, ASavedActiveIterationLabels: TStringList; const ASavedDirectLabelStart: Integer);
 
@@ -464,6 +465,16 @@ begin
   Result := FPrivateClassContexts[FPrivateClassContexts.Count - 1];
 end;
 
+function TGocciaParser.HasVisiblePrivateNameDeclaration(const AName: string): Boolean;
+var
+  I: Integer;
+begin
+  for I := FPrivateClassContexts.Count - 1 downto 0 do
+    if FPrivateClassContexts[I].HasDeclaration(AName) then
+      Exit(True);
+  Result := False;
+end;
+
 procedure TGocciaParser.EnterFunctionLabelScope(out ASavedActiveLabels,
   ASavedActiveIterationLabels: TStringList; out ASavedDirectLabelStart: Integer);
 begin
@@ -504,7 +515,7 @@ begin
   for I := 0 to Context.ReferenceCount - 1 do
   begin
     Ref := Context.GetReference(I);
-    if not Context.HasDeclaration(Ref.Name) then
+    if not HasVisiblePrivateNameDeclaration(Ref.Name) then
       raise TGocciaSyntaxError.Create(
         Format('Private field ''#%s'' must be declared in an enclosing class', [Ref.Name]),
         Ref.Line, Ref.Column, FFileName, FSourceLines,
@@ -1191,7 +1202,8 @@ begin
     Operator := Advance; // consume 'yield'
     if Match(gttStar) then
       Result := TGocciaYieldExpression.Create(Assignment, True, Operator.Line, Operator.Column)
-    else if CheckSemicolonOrASI or Check(gttRightBrace) or Check(gttRightParen) or Check(gttComma) then
+    else if CheckSemicolonOrASI or Check(gttRightBrace) or
+      Check(gttRightParen) or Check(gttRightBracket) or Check(gttComma) then
       Result := TGocciaYieldExpression.Create(nil, False, Operator.Line, Operator.Column)
     else
       Result := TGocciaYieldExpression.Create(Assignment, False, Operator.Line, Operator.Column);
@@ -5154,6 +5166,7 @@ var
   TryStmt: TGocciaTryStatement;
   CatchType: string;
   CatchPattern: TGocciaMatchPattern;
+  CatchBindingPattern: TGocciaDestructuringPattern;
 begin
   Line := Previous.Line;
   Column := Previous.Column;
@@ -5166,6 +5179,7 @@ begin
   FinallyBlock := nil;
   CatchType := '';
   CatchPattern := nil;
+  CatchBindingPattern := nil;
 
   if Match(gttCatch) then
   begin
@@ -5173,18 +5187,23 @@ begin
     begin
       Consume(gttLeftParen, 'Expected "(" after "catch"',
         SSuggestOpenParenCatchClause);
-      CatchParam := ConsumeIdentifierBinding('Expected catch parameter',
-        SSuggestProvideCatchParameter).Lexeme;
-      if Check(gttColon) then
+      if Check(gttLeftBracket) or Check(gttLeftBrace) then
+        CatchBindingPattern := ParsePattern
+      else
       begin
-        Advance;
-        CatchType := CollectTypeAnnotation([gttRightParen]);
-        if CatchType = '' then
-          raise TGocciaSyntaxError.Create('Expected type annotation after ":"',
-            Peek.Line, Peek.Column, FFileName, FSourceLines);
+        CatchParam := ConsumeIdentifierBinding('Expected catch parameter',
+          SSuggestProvideCatchParameter).Lexeme;
+        if Check(gttColon) then
+        begin
+          Advance;
+          CatchType := CollectTypeAnnotation([gttRightParen]);
+          if CatchType = '' then
+            raise TGocciaSyntaxError.Create('Expected type annotation after ":"',
+              Peek.Line, Peek.Column, FFileName, FSourceLines);
+        end;
+        if (CatchType = '') and MatchContextualKeyword(KEYWORD_IS) then
+          CatchPattern := ParseMatchPattern;
       end;
-      if (CatchType = '') and MatchContextualKeyword(KEYWORD_IS) then
-        CatchPattern := ParseMatchPattern;
       Consume(gttRightParen, 'Expected ")" after catch parameter',
         SSuggestCloseParenCatchClause);
     end
@@ -5209,7 +5228,7 @@ begin
       SSuggestMissingCatchOrFinally);
 
   TryStmt := TGocciaTryStatement.Create(Block, CatchParam, CatchBlock,
-    FinallyBlock, Line, Column, CatchPattern);
+    FinallyBlock, Line, Column, CatchPattern, CatchBindingPattern);
   TryStmt.CatchParamType := CatchType;
   Result := TryStmt;
 end;
@@ -7076,6 +7095,7 @@ var
   ObjectExpr: TGocciaObjectExpression;
   IdentifierExpr: TGocciaIdentifierExpression;
   AssignmentExpr: TGocciaAssignmentExpression;
+  DestructuringAssignmentExpr: TGocciaDestructuringAssignmentExpression;
   PrivateMemberExpr: TGocciaPrivateMemberExpression;
   Elements: TObjectList<TGocciaDestructuringPattern>;
   Properties: TObjectList<TGocciaDestructuringProperty>;
@@ -7100,6 +7120,16 @@ begin
       AExpr.Column
     );
   end
+  else if AExpr is TGocciaDestructuringAssignmentExpression then
+  begin
+    DestructuringAssignmentExpr := TGocciaDestructuringAssignmentExpression(AExpr);
+    Result := TGocciaAssignmentDestructuringPattern.Create(
+      DestructuringAssignmentExpr.Left,
+      DestructuringAssignmentExpr.Right,
+      AExpr.Line,
+      AExpr.Column
+    );
+  end
   else if AExpr is TGocciaArrayExpression then
   begin
     ArrayExpr := TGocciaArrayExpression(AExpr);
@@ -7107,7 +7137,8 @@ begin
 
     for I := 0 to ArrayExpr.Elements.Count - 1 do
     begin
-      if ArrayExpr.Elements[I] = nil then
+      if (ArrayExpr.Elements[I] = nil) or
+        (ArrayExpr.Elements[I] is TGocciaHoleExpression) then
         Elements.Add(nil)  // Hole
       else if ArrayExpr.Elements[I] is TGocciaSpreadExpression then
         Elements.Add(TGocciaRestDestructuringPattern.Create(

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -507,6 +507,7 @@ end;
 procedure TGocciaParser.ValidateCurrentPrivateClassContext;
 var
   Context: TGocciaPrivateClassContext;
+  ParentContext: TGocciaPrivateClassContext;
   Ref: TGocciaPrivateNameReference;
   I: Integer;
 begin
@@ -520,10 +521,18 @@ begin
   begin
     Ref := Context.GetReference(I);
     if not HasVisiblePrivateNameDeclaration(Ref.Name) then
+    begin
+      if FPrivateClassContexts.Count > 1 then
+      begin
+        ParentContext := FPrivateClassContexts[FPrivateClassContexts.Count - 2];
+        ParentContext.AddReference(Ref.Name, Ref.Line, Ref.Column);
+        Continue;
+      end;
       raise TGocciaSyntaxError.Create(
         Format('Private field ''#%s'' must be declared in an enclosing class', [Ref.Name]),
         Ref.Line, Ref.Column, FFileName, FSourceLines,
         SSuggestDeclarePrivateField);
+    end;
   end;
 end;
 

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -104,6 +104,7 @@ type
 
     // Walk the parent chain to find the nearest owning class / superclass
     function FindOwningClass: TGocciaValue;
+    function FindOwningClassAfter(const AAfter: TGocciaValue): TGocciaValue;
     function FindSuperClass: TGocciaValue;
     function FindSuperConstructor: TGocciaValue;
     function FindNewTarget: TGocciaValue;
@@ -371,6 +372,29 @@ begin
     if Assigned(Result) then Exit;
     if Current.IsFunctionBoundary then
       Exit(nil);
+    Current := Current.FParent;
+  end;
+  Result := nil;
+end;
+
+function TGocciaScope.FindOwningClassAfter(const AAfter: TGocciaValue): TGocciaValue;
+var
+  Current: TGocciaScope;
+  Candidate: TGocciaValue;
+  FoundAfter: Boolean;
+begin
+  Current := Self;
+  FoundAfter := not Assigned(AAfter);
+  while Assigned(Current) do
+  begin
+    Candidate := Current.GetOwningClass;
+    if Assigned(Candidate) then
+    begin
+      if FoundAfter and (Candidate <> AAfter) then
+        Exit(Candidate);
+      if Candidate = AAfter then
+        FoundAfter := True;
+    end;
     Current := Current.FParent;
   end;
   Result := nil;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -3483,7 +3483,17 @@ begin
             end;
 
             Value := FInner.ResumeRaw(ARequest.Kind, ARequest.Value, Done);
-            UnwrappedValue := AwaitValue(Value);
+            try
+              UnwrappedValue := AwaitValue(Value);
+            except
+              on E: TGocciaThrowValue do
+              begin
+                FInner.FState := bgsCompleted;
+                FInner.ClearDelegateState;
+                ARequest.Promise.Reject(E.Value);
+                Exit;
+              end;
+            end;
             ARequest.Promise.Resolve(CreateIteratorResult(UnwrappedValue, Done));
           except
             on E: EGocciaBytecodeAsyncSuspend do

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -97,6 +97,7 @@ type
     function HasOwnPrivateSetter(const AName: string): Boolean;
     function HasOwnPrivateStaticProperty(const AName: string): Boolean;
     function HasOwnPrivateStaticMethod(const AName: string): Boolean;
+    function HasOwnPrivateName(const AName: string): Boolean;
     function HasPrivateInstanceElements: Boolean;
     function GetOwnPrivatePropertyGetter(
       const AName: string): TGocciaFunctionBase;
@@ -688,6 +689,16 @@ function TGocciaClassValue.HasOwnPrivateStaticMethod(
   const AName: string): Boolean;
 begin
   Result := FPrivateStaticMethods.ContainsKey(AName);
+end;
+
+function TGocciaClassValue.HasOwnPrivateName(const AName: string): Boolean;
+begin
+  Result := FPrivateInstancePropertyDefs.ContainsKey(AName) or
+    FPrivateStaticProperties.ContainsKey(AName) or
+    FPrivateStaticMethods.ContainsKey(AName) or
+    FPrivateMethods.ContainsKey(AName) or
+    FPrivateGetters.ContainsKey(AName) or
+    FPrivateSetters.ContainsKey(AName);
 end;
 
 function TGocciaClassValue.HasPrivateInstanceElements: Boolean;

--- a/tests/language/async-generators/yield-rejected-promise.js
+++ b/tests/language/async-generators/yield-rejected-promise.js
@@ -8,11 +8,7 @@ test("calling next() from a rejection handler does not recurse infinitely", asyn
   // already-processed task during a recursive drain. An async generator
   // yielding a rejected promise rejects iter.next()'s outer promise inside
   // an AwaitValue, and any handler that called iter.next() again would loop
-  // until the call stack overflowed (observed as SIGSEGV). This test only
-  // requires the chain to terminate; the post-rejection iterator semantics
-  // (whether the generator is "completed" or resumes after the failed yield)
-  // are not asserted here because they depend on AsyncGeneratorYield handling
-  // tracked separately.
+  // until the call stack overflowed (observed as SIGSEGV).
   const source = {
     async *gen() {
       yield Promise.reject(0);
@@ -22,6 +18,7 @@ test("calling next() from a rejection handler does not recurse infinitely", asyn
   const iter = source.gen();
 
   let firstRejection;
+  let secondResult;
   let chainSettled = false;
   await new Promise((resolve, reject) => {
     iter.next().then(
@@ -29,7 +26,7 @@ test("calling next() from a rejection handler does not recurse infinitely", asyn
       (err) => {
         firstRejection = err;
         iter.next().then(
-          () => { chainSettled = true; resolve(); },
+          (result) => { secondResult = result; chainSettled = true; resolve(); },
           () => { chainSettled = true; resolve(); },
         );
       },
@@ -37,6 +34,7 @@ test("calling next() from a rejection handler does not recurse infinitely", asyn
   });
 
   expect(firstRejection).toBe(0);
+  expect(secondResult).toEqual({ value: undefined, done: true });
   expect(chainSettled).toBe(true);
 });
 

--- a/tests/language/classes/private-fields.js
+++ b/tests/language/classes/private-fields.js
@@ -489,3 +489,21 @@ test("forged bytecode private brand properties do not grant access", () => {
 
   expect(() => new TestClass().readFrom(forged)).toThrow(TypeError);
 });
+
+test("nested class methods can access private names from an enclosing class", () => {
+  class Outer {
+    #x = 42;
+
+    innerClass() {
+      const self = this;
+      return class extends Outer {
+        readOuter() {
+          return self.#x;
+        }
+      };
+    }
+  }
+
+  const Inner = new Outer().innerClass();
+  expect(new Inner().readOuter()).toBe(42);
+});

--- a/tests/language/classes/private-fields.js
+++ b/tests/language/classes/private-fields.js
@@ -507,3 +507,21 @@ test("nested class methods can access private names from an enclosing class", ()
   const Inner = new Outer().innerClass();
   expect(new Inner().readOuter()).toBe(42);
 });
+
+test("nested class methods can access later private names from an enclosing class", () => {
+  class Outer {
+    innerClass() {
+      const self = this;
+      return class {
+        readOuter() {
+          return self.#later;
+        }
+      };
+    }
+
+    #later = 7;
+  }
+
+  const Inner = new Outer().innerClass();
+  expect(new Inner().readOuter()).toBe(7);
+});

--- a/tests/language/expressions/destructuring/computed.js
+++ b/tests/language/expressions/destructuring/computed.js
@@ -116,3 +116,14 @@ test("destructuring with computed symbol key on class reaches static symbol-keye
   expect(typeof m).toBe("function");
   expect(m()).toBe("static-method-result");
 });
+
+test("object rest excludes the originally evaluated computed key", () => {
+  let index = 0;
+  let value, rest;
+
+  ({ [++index]: value, ...rest } = { 1: "one", 2: "two" });
+
+  expect(index).toBe(1);
+  expect(value).toBe("one");
+  expect(rest).toEqual({ 2: "two" });
+});

--- a/tests/language/expressions/destructuring/computed.js
+++ b/tests/language/expressions/destructuring/computed.js
@@ -127,3 +127,20 @@ test("object rest excludes the originally evaluated computed key", () => {
   expect(value).toBe("one");
   expect(rest).toEqual({ 2: "two" });
 });
+
+test("object rest excludes the canonical computed property key", () => {
+  let coercions = 0;
+  let value, rest;
+  const key = {
+    toString() {
+      coercions += 1;
+      return "1";
+    },
+  };
+
+  ({ [key]: value, ...rest } = { 1: "one", 2: "two" });
+
+  expect(coercions).toBe(1);
+  expect(value).toBe("one");
+  expect(rest).toEqual({ 2: "two" });
+});

--- a/tests/language/statements/try/catch-scoping.js
+++ b/tests/language/statements/try/catch-scoping.js
@@ -69,6 +69,16 @@ test("catch destructuring failure runs finally before rethrowing", () => {
   expect(log).toBe("finallyouter");
 });
 
+test("catch destructuring defaults observe catch parameter TDZ", () => {
+  expect(() => {
+    try {
+      throw [];
+    } catch ([x = x]) {
+      x;
+    }
+  }).toThrow(ReferenceError);
+});
+
 test("nested catch parameters with same name", () => {
   let finalResult = "";
   try {

--- a/tests/language/statements/try/catch-scoping.js
+++ b/tests/language/statements/try/catch-scoping.js
@@ -26,6 +26,49 @@ test("catch without parameter doesn't affect outer variables", () => {
   expect(outerVar2).toBe("original");
 });
 
+test("catch destructuring closes iterators before entering catch block", () => {
+  let doneCallCount = 0;
+  const iter = {};
+  iter[Symbol.iterator] = () => ({
+    next() {
+      return { value: null, done: false };
+    },
+    return() {
+      doneCallCount += 1;
+      return {};
+    },
+  });
+
+  let ranCatch = false;
+  try {
+    throw iter;
+  } catch ([x]) {
+    expect(x).toBe(null);
+    expect(doneCallCount).toBe(1);
+    ranCatch = true;
+  }
+
+  expect(ranCatch).toBe(true);
+});
+
+test("catch destructuring failure runs finally before rethrowing", () => {
+  let log = "";
+
+  try {
+    try {
+      throw null;
+    } catch ({ x }) {
+      log += "catch";
+    } finally {
+      log += "finally";
+    }
+  } catch {
+    log += "outer";
+  }
+
+  expect(log).toBe("finallyouter");
+});
+
 test("nested catch parameters with same name", () => {
   let finalResult = "";
   try {


### PR DESCRIPTION
## Summary

- Add bytecode/interpreter support for catch binding destructuring, including iterator-close behavior, TDZ-correct catch binding scope handling, and failure-through-`finally` behavior.
- Allow nested class methods to resolve private names from enclosing class contexts, including enclosing declarations that appear later in the class body.
- Fix bytecode language-conformance edge cases for async generator rejected yields, destructuring assignment result preservation, elisions in assignment-pattern conversion, top-level function hoist TDZ holes, and canonical computed object-rest exclusion keys.
- No user-facing documentation updates: this is conformance/runtime behavior for already-supported language surfaces.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Ran:

- `./build.pas --clean testrunner`
- `./build.pas testrunner`
- `./format.pas --check`
- `git diff --check`
- `./build/GocciaTestRunner tests/language/classes/private-fields.js --no-progress`
- `./build/GocciaTestRunner tests/language/classes/private-fields.js --no-progress --mode=bytecode`
- `./build/GocciaTestRunner tests/language/statements/try/catch-scoping.js --no-progress`
- `./build/GocciaTestRunner tests/language/statements/try/catch-scoping.js --no-progress --mode=bytecode`
- `./build/GocciaTestRunner tests/language/expressions/destructuring/computed.js --no-progress`
- `./build/GocciaTestRunner tests/language/expressions/destructuring/computed.js --no-progress --mode=bytecode`
- `./fixtures/ffi/build.sh && ./build/GocciaTestRunner tests --no-progress`
