### PR TITLE
chore(ci): upgrade workflow actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1051,7 +1051,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: RELEASE_NOTES.md
           files: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,12 @@ jobs:
             cpu: i386
             os: win32
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Restore toolchain cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             fpc-cross
@@ -249,7 +249,7 @@ jobs:
           fi
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: gocciascript-${{ matrix.target }}
           retention-days: 1
@@ -278,12 +278,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -298,7 +298,7 @@ jobs:
 
       - name: Set up MSYS2 (MINGW32)
         if: matrix.target == 'i386-win32'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2
         with:
           msystem: MINGW32
           install: mingw-w64-i686-gcc
@@ -402,12 +402,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -454,7 +454,7 @@ jobs:
 
       - name: Upload TOML compliance report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: toml-test-results-${{ matrix.target }}
           retention-days: 1
@@ -483,12 +483,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -555,7 +555,7 @@ jobs:
 
       - name: Upload JSON5 compliance report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: json5-test-results-${{ matrix.target }}
           retention-days: 1
@@ -569,12 +569,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: gocciascript-x86_64-linux
           path: build/
@@ -582,7 +582,7 @@ jobs:
       - name: Make binaries executable
         run: chmod +x build/*
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Read test262 pin
         id: test262-pin
@@ -595,7 +595,7 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Checkout test262 suite
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: tc39/test262
           # Pin to an immutable SHA so the cached `main` baseline and a PR
@@ -630,14 +630,14 @@ jobs:
 
       - name: Cache test262 baseline
         if: github.ref == 'refs/heads/main' && hashFiles('test262-baseline.json') != ''
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: test262-baseline.json
           key: test262-baseline-${{ github.sha }}
 
       - name: Upload test262 results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test262-results
           retention-days: 30
@@ -690,12 +690,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -752,7 +752,7 @@ jobs:
 
       - name: Cache benchmark baseline
         if: github.ref == 'refs/heads/main' && matrix.target == 'x86_64-linux'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: benchmark-${{ matrix.mode }}-results.json
           key: benchmark-${{ matrix.mode }}-baseline-${{ github.sha }}
@@ -778,7 +778,7 @@ jobs:
 
       - name: Cache deterministic profile baseline
         if: github.ref == 'refs/heads/main' && matrix.target == 'x86_64-linux' && matrix.mode == 'bytecode'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: profile-baseline/
           key: profile-baseline-${{ github.sha }}
@@ -806,17 +806,17 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Make binaries executable
         if: runner.os != 'Windows'
@@ -865,12 +865,12 @@ jobs:
           - x86_64-win64
           - i386-win32
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: gocciascript-${{ matrix.target }}
           path: build/
@@ -879,7 +879,7 @@ jobs:
         run: bash ./.github/scripts/stage-build-artifacts.sh build release-artifacts
 
       - name: Upload release artifact bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: gocciascript-release-${{ matrix.target }}
           if-no-files-found: ignore
@@ -896,7 +896,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -916,7 +916,7 @@ jobs:
 
       - name: Download all build artifacts
         if: steps.check.outputs.skip != 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts/
 
@@ -990,12 +990,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts/
 
@@ -1041,7 +1041,7 @@ jobs:
           done
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         id: changelog
         with:
           config: cliff.toml
@@ -1051,7 +1051,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           body_path: RELEASE_NOTES.md
           files: |
@@ -1059,7 +1059,7 @@ jobs:
             gocciascript-*.zip
 
       - name: Generate full changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: -o CHANGELOG.md

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Lint Markdown
-        uses: DavidAnson/markdownlint-cli2-action@v19
+        uses: DavidAnson/markdownlint-cli2-action@v23
 
       - name: Check doc symbol references
         run: npx tsx scripts/check-doc-symbols.ts
@@ -398,7 +398,7 @@ jobs:
           fi
 
       - name: Compare benchmarks and comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -673,7 +673,7 @@ jobs:
           name: benchmark-bytecode
 
       - name: Post timing comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -905,7 +905,7 @@ jobs:
           fi
 
       - name: Post test262 comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
         run: bash ./.github/scripts/stage-build-artifacts.sh build pr-artifacts --include-tests
 
       - name: Upload build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-pr
           retention-days: 1
@@ -41,10 +41,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Lint Markdown
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23
 
       - name: Check doc symbol references
         run: npx tsx scripts/check-doc-symbols.ts
@@ -69,12 +69,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: build-pr
           path: build/
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-results-${{ matrix.mode }}
           retention-days: 1
@@ -170,12 +170,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: build-pr
           path: build/
@@ -216,7 +216,7 @@ jobs:
           grep -q '"jobCount":' benchmark-${{ matrix.mode }}.json
 
       - name: Upload results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-${{ matrix.mode }}
           retention-days: 1
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload deterministic profiles
         if: matrix.mode == 'bytecode'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: profile-current
           retention-days: 1
@@ -237,14 +237,14 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: build-pr
           path: build/
@@ -278,12 +278,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Download build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: build-pr
           path: build/
@@ -291,7 +291,7 @@ jobs:
       - name: Make binaries executable
         run: chmod +x build/*
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Read test262 pin
         id: test262-pin
@@ -304,7 +304,7 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Checkout test262 suite
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: tc39/test262
           # Pin to an immutable SHA so the cached `main` baseline and a PR
@@ -331,7 +331,7 @@ jobs:
 
       - name: Upload test262 results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test262-results
           retention-days: 7
@@ -344,41 +344,41 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Download interpreted results
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: benchmark-interpreted
 
       - name: Download bytecode results
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: benchmark-bytecode
 
       - name: Download deterministic profiles
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         continue-on-error: true
         with:
           name: profile-current
           path: profile-current/
 
       - name: Restore interpreted baseline
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: benchmark-interpreted-results.json
           key: benchmark-interpreted-baseline-will-not-match
           restore-keys: benchmark-interpreted-baseline-
 
       - name: Restore bytecode baseline
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: benchmark-bytecode-results.json
           key: benchmark-bytecode-baseline-will-not-match
           restore-keys: benchmark-bytecode-baseline-
 
       - name: Restore deterministic profile baseline
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: profile-baseline/
           key: profile-baseline-will-not-match
@@ -398,7 +398,7 @@ jobs:
           fi
 
       - name: Compare benchmarks and comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');
@@ -649,31 +649,31 @@ jobs:
         shell: bash
     steps:
       - name: Download test results (interpreted)
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         continue-on-error: true
         with:
           name: test-results-interpreted
 
       - name: Download test results (bytecode)
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         continue-on-error: true
         with:
           name: test-results-bytecode
 
       - name: Download benchmark results (interpreted)
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         continue-on-error: true
         with:
           name: benchmark-interpreted
 
       - name: Download benchmark results (bytecode)
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         continue-on-error: true
         with:
           name: benchmark-bytecode
 
       - name: Post timing comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');
@@ -854,18 +854,18 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Download test262 results
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         continue-on-error: true
         with:
           name: test262-results
 
       - name: Restore test262 baseline
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: test262-baseline.json
           key: test262-baseline-will-not-match
@@ -905,7 +905,7 @@ jobs:
           fi
 
       - name: Post test262 comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/tc39-mcp-bump.yml
+++ b/.github/workflows/tc39-mcp-bump.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/tc39-mcp-bump
           commit-message: "chore(tc39-mcp): bump pin to v${{ steps.latest.outputs.version }}"

--- a/.github/workflows/test262-bump.yml
+++ b/.github/workflows/test262-bump.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/test262-bump
           commit-message: "chore(test262): bump pin to ${{ steps.latest.outputs.short }}"

--- a/.github/workflows/toml-test-bump.yml
+++ b/.github/workflows/toml-test-bump.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/toml-test-bump
           commit-message: "chore(toml-test): bump pin to ${{ steps.latest.outputs.short }}"

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Check cache
         id: cache-check
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             fpc-cross
@@ -417,7 +417,7 @@ jobs:
 
       - name: Save to cache
         if: steps.cache-check.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             fpc-cross

--- a/.github/workflows/yaml-test-bump.yml
+++ b/.github/workflows/yaml-test-bump.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Open or update PR
         if: steps.changed.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/yaml-test-bump
           commit-message: "chore(yaml-test): bump pin to ${{ steps.latest.outputs.short }}"


### PR DESCRIPTION
## Summary

- Upgrade GitHub workflow actions that still used Node 20-backed releases to current Node 24-backed releases.
- Move `actions/github-script`, `markdownlint-cli2-action`, and `action-gh-release` to their latest major versions.
- Keep `peter-evans/create-pull-request` pinned by SHA while updating it to the latest `v8.1.1` release.
- Pin all remaining workflow action references to full commit SHAs with version comments for readability.

## Testing

- [ ] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - N/A: workflow dependency update only; no engine behavior changed.
- [ ] Updated documentation
  - N/A: no user-facing behavior or contribution docs changed.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - N/A: no Pascal source changed.
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - N/A: no runtime or benchmark behavior changed.

Additional workflow verification:

- Parsed all `.github/workflows/*.yml` files with Ruby YAML.
- Ran `git diff --check`.
- Confirmed no external workflow action refs remain on mutable `@v...` tags.
- Checked action metadata: all JavaScript actions in `.github/workflows` report `runs.using: node24`; `orhun/git-cliff-action@v4` remains composite and is now SHA-pinned too.