### PR TITLE
fix(test262): close language conformance gaps

### DIFF
--- a/scripts/run_test262_suite.ts
+++ b/scripts/run_test262_suite.ts
@@ -505,7 +505,6 @@ function walkJs(
 ): void {
   const entries = readdirSync(dir, { withFileTypes: true });
   for (const ent of entries) {
-    if (ent.name.startsWith("_")) continue;
     const full = join(dir, ent.name);
     if (ent.isDirectory()) {
       walkJs(full, base, filterGlob, out);

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -794,6 +794,87 @@ console.log("Bare Loader: --test262-host eval validates destructuring pattern ea
   }
 }
 
+console.log("Bare Loader: --test262-host eval rejects arguments in class field initializers...");
+{
+  const source = [
+    "let instanceExecuted = false;",
+    "try {",
+    "  class C { x = eval('instanceExecuted = true; arguments;'); }",
+    "  new C();",
+    "  print('instance:none');",
+    "} catch (e) {",
+    "  print('instance:' + e.name);",
+    "}",
+    "print(instanceExecuted);",
+    "",
+    "let privateExecuted = false;",
+    "try {",
+    "  class C { #x = eval('privateExecuted = true; arguments;'); }",
+    "  new C();",
+    "  print('private:none');",
+    "} catch (e) {",
+    "  print('private:' + e.name);",
+    "}",
+    "print(privateExecuted);",
+    "",
+    "let arrowExecuted = false;",
+    "class ArrowField { x = () => eval('arrowExecuted = true; arguments;'); }",
+    "try {",
+    "  new ArrowField().x();",
+    "  print('arrow:none');",
+    "} catch (e) {",
+    "  print('arrow:' + e.name);",
+    "}",
+    "print(arrowExecuted);",
+    "",
+    "let staticExecuted = false;",
+    "try {",
+    "  class StaticField { static x = eval('staticExecuted = true; arguments;'); }",
+    "  print('static:none');",
+    "} catch (e) {",
+    "  print('static:' + e.name);",
+    "}",
+    "print(staticExecuted);",
+    "",
+    "let staticArrowExecuted = false;",
+    "class StaticArrowField { static x = () => eval('staticArrowExecuted = true; arguments;'); }",
+    "try {",
+    "  StaticArrowField.x();",
+    "  print('static-arrow:none');",
+    "} catch (e) {",
+    "  print('static-arrow:' + e.name);",
+    "}",
+    "print(staticArrowExecuted);",
+    "",
+  ].join("\n");
+  const expected = [
+    "instance:SyntaxError",
+    "false",
+    "private:SyntaxError",
+    "false",
+    "arrow:SyntaxError",
+    "false",
+    "static:SyntaxError",
+    "false",
+    "static-arrow:SyntaxError",
+    "false",
+  ].join("\n");
+  for (const mode of [
+    { label: "interpreted", args: [BARE, "--test262-host"] },
+    { label: "bytecode", args: [BARE, "--test262-host", "--mode=bytecode"] },
+  ]) {
+    const proc = Bun.spawnSync(mode.args, {
+      stdin: new TextEncoder().encode(source),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (proc.exitCode !== 0)
+      throw new Error(`Bare ${mode.label} eval class-field arguments probe exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+    if (normalizeLineEndings(proc.stdout.toString()).trim() !== expected)
+      throw new Error(`Bare ${mode.label} eval class-field arguments got: ${proc.stdout.toString()}`);
+  }
+}
+
 console.log("Bare Loader: --test262-host eval super permissions stop at ordinary function boundary...");
 {
   const source = [

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -875,6 +875,43 @@ console.log("Bare Loader: --test262-host eval rejects arguments in class field i
   }
 }
 
+console.log("Bare Loader: --test262-host eval rejects arguments in generator method defaults...");
+{
+  const source = [
+    "const cases = [",
+    "  { label: 'generator', run: () => ({ *method(value = eval('var value = 42')) { yield value; } }).method() },",
+    "  { label: 'async-generator', run: () => ({ async *method(value = eval('var value = 42')) { yield value; } }).method() }",
+    "];",
+    "for (const item of cases) {",
+    "  try {",
+    "    item.run();",
+    "    print(item.label + ':none');",
+    "  } catch (e) {",
+    "    print(item.label + ':' + e.name);",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+  const expected = [
+    "generator:SyntaxError",
+    "async-generator:SyntaxError",
+  ].join("\n");
+  for (const mode of [
+    { label: "interpreted", args: [BARE, "--test262-host", "--compat-var", "--compat-non-strict-mode"] },
+    { label: "bytecode", args: [BARE, "--test262-host", "--mode=bytecode", "--compat-var", "--compat-non-strict-mode"] },
+  ]) {
+    const proc = Bun.spawnSync(mode.args, {
+      stdin: new TextEncoder().encode(source),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (proc.exitCode !== 0)
+      throw new Error(`Bare ${mode.label} eval generator-method arguments probe exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+    if (normalizeLineEndings(proc.stdout.toString()).trim() !== expected)
+      throw new Error(`Bare ${mode.label} eval generator-method arguments got: ${proc.stdout.toString()}`);
+  }
+}
+
 console.log("Bare Loader: --test262-host eval super permissions stop at ordinary function boundary...");
 {
   const source = [

--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -48,33 +48,13 @@ console.log("Error display (bytecode SyntaxError)...");
   if (typeof json.error?.column !== "number") throw new Error(`Bytecode JSON error should include numeric column, got ${json.error?.column}`);
 }
 
-// -- Optional private field access ----------------------------------------------
+// -- Malformed optional private field access ------------------------------------
 
-console.log("Optional private field access...");
+console.log("Malformed optional private field access...");
 {
-  const source = [
-    "class Box {",
-    "  #value = 1;",
-    "  read(obj) {",
-    "    return obj?.#value;",
-    "  }",
-    "}",
-    "const box = new Box();",
-    "if (box.read(box) !== 1) throw new Error('expected branded access');",
-    "if (box.read(null) !== undefined) throw new Error('expected nullish short-circuit');",
-    "try {",
-    "  box.read({});",
-    "  throw new Error('expected private brand check');",
-    "} catch (error) {",
-    "  if (!(error instanceof TypeError)) throw error;",
-    "}",
-    "",
-  ].join("\n");
-  for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
-    const res = runLoaderJson(source, modeArgs);
-    if (res.exitCode !== 0) throw new Error(`Optional private field access should pass, got: ${JSON.stringify(res.json)}`);
-    if (res.json.ok !== true) throw new Error(`Optional private field access should be ok, got: ${JSON.stringify(res.json)}`);
-  }
+  const source = "class Box { #value = 1; read(obj) { return obj?.#; } }\n";
+  assertSyntaxError(source, "optional private access without name");
+  assertSyntaxError(source, "optional private access without name (bytecode)", ["--mode=bytecode"]);
 }
 
 // -- Malformed literal class accessors ------------------------------------------

--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -48,9 +48,9 @@ console.log("Error display (bytecode SyntaxError)...");
   if (typeof json.error?.column !== "number") throw new Error(`Bytecode JSON error should include numeric column, got ${json.error?.column}`);
 }
 
-// -- Unsupported optional private field access ----------------------------------
+// -- Optional private field access ----------------------------------------------
 
-console.log("Unsupported optional private field access...");
+console.log("Optional private field access...");
 {
   const source = [
     "class Box {",
@@ -59,14 +59,21 @@ console.log("Unsupported optional private field access...");
     "    return obj?.#value;",
     "  }",
     "}",
+    "const box = new Box();",
+    "if (box.read(box) !== 1) throw new Error('expected branded access');",
+    "if (box.read(null) !== undefined) throw new Error('expected nullish short-circuit');",
+    "try {",
+    "  box.read({});",
+    "  throw new Error('expected private brand check');",
+    "} catch (error) {",
+    "  if (!(error instanceof TypeError)) throw error;",
+    "}",
     "",
   ].join("\n");
-  const res = runLoaderJson(source);
-  if (res.exitCode === 0) throw new Error(`Optional private field access should fail`);
-  if (res.json.ok !== false) throw new Error(`Optional private field access should fail, got: ${JSON.stringify(res.json)}`);
-  if (res.json.error?.type !== "SyntaxError") throw new Error(`Expected SyntaxError for optional private access, got: ${res.json.error?.type}`);
-  if (!String(res.json.error?.message).includes("Optional chaining with private fields is not supported")) {
-    throw new Error(`Expected optional-private error message, got: ${JSON.stringify(res.json.error)}`);
+  for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+    const res = runLoaderJson(source, modeArgs);
+    if (res.exitCode !== 0) throw new Error(`Optional private field access should pass, got: ${JSON.stringify(res.json)}`);
+    if (res.json.ok !== true) throw new Error(`Optional private field access should be ok, got: ${JSON.stringify(res.json)}`);
   }
 }
 

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -241,8 +241,8 @@ begin
             else
               VarScope := FEngine.Interpreter.GlobalScope;
             Result := EvaluateEvalProgram(PipelineResult.ProgramNode,
-              EvalContext, VarScope, EvalScope, StrictEval, False, False, False,
-              False);
+              EvalContext, VarScope, EvalScope, StrictEval, False, nil, False,
+              False, False);
           finally
             if Assigned(TGarbageCollector.Instance) then
               TGarbageCollector.Instance.RemoveTempRoot(EvalScope);

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -2092,6 +2092,25 @@ begin
   else if Operand is TGocciaMemberExpression then
   begin
     MemberExpr := TGocciaMemberExpression(Operand);
+    if MemberExpr.ObjectExpr is TGocciaSuperExpression then
+    begin
+      if MemberExpr.Computed then
+        PropertyKeyValue := ToPropertyKey(
+          MemberExpr.PropertyExpression.Evaluate(AContext))
+      else
+        PropertyKeyValue := TGocciaStringLiteralValue.Create(
+          MemberExpr.PropertyName);
+      OldValue := ToNumericValue(NormalizeAssignmentValue(
+        GetSuperProperty(AContext, PropertyKeyValue)));
+      NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
+      AssignSuperProperty(AContext, PropertyKeyValue, NewValue);
+      if IsPrefix then
+        Result := NewValue
+      else
+        Result := OldValue;
+      Exit;
+    end;
+
     Obj := MemberExpr.ObjectExpr.Evaluate(AContext);
     if MemberExpr.Computed then
     begin

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -535,12 +535,15 @@ type
   TGocciaSetterExpression = class(TGocciaExpression)
   private
     FParameter: string;
+    FParameters: TGocciaParameterArray;
     FBody: TGocciaASTNode;
     FSourceText: string;
   public
-    constructor Create(const AParameter: string; const ABody: TGocciaASTNode; const ALine, AColumn: Integer);
+    constructor Create(const AParameter: string; const ABody: TGocciaASTNode; const ALine, AColumn: Integer); overload;
+    constructor Create(const AParameters: TGocciaParameterArray; const ABody: TGocciaASTNode; const ALine, AColumn: Integer); overload;
     function Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue; override;
     property Parameter: string read FParameter;
+    property Parameters: TGocciaParameterArray read FParameters;
     property Body: TGocciaASTNode read FBody;
     property SourceText: string read FSourceText write FSourceText;
   end;
@@ -834,11 +837,13 @@ type
   private
     FObject: TGocciaExpression;
     FPrivateName: string;
+    FOptional: Boolean;
   public
-    constructor Create(const AObject: TGocciaExpression; const APrivateName: string; const ALine, AColumn: Integer);
+    constructor Create(const AObject: TGocciaExpression; const APrivateName: string; const ALine, AColumn: Integer; const AOptional: Boolean = False);
     function Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue; override;
     property ObjectExpr: TGocciaExpression read FObject;
     property PrivateName: string read FPrivateName;
+    property Optional: Boolean read FOptional;
   end;
 
   TGocciaPrivatePropertyAssignmentExpression = class(TGocciaExpression)
@@ -1365,11 +1370,12 @@ end;
 
 { TGocciaPrivateMemberExpression }
 
-constructor TGocciaPrivateMemberExpression.Create(const AObject: TGocciaExpression; const APrivateName: string; const ALine, AColumn: Integer);
+constructor TGocciaPrivateMemberExpression.Create(const AObject: TGocciaExpression; const APrivateName: string; const ALine, AColumn: Integer; const AOptional: Boolean = False);
 begin
   inherited Create(ALine, AColumn);
   FObject := AObject;
   FPrivateName := APrivateName;
+  FOptional := AOptional;
 end;
 
 { TGocciaPrivatePropertyAssignmentExpression }
@@ -1422,6 +1428,25 @@ constructor TGocciaSetterExpression.Create(const AParameter: string; const ABody
 begin
   inherited Create(ALine, AColumn);
   FParameter := AParameter;
+  SetLength(FParameters, 1);
+  FParameters[0].Name := AParameter;
+  FParameters[0].DefaultValue := nil;
+  FParameters[0].IsPattern := False;
+  FParameters[0].Pattern := nil;
+  FParameters[0].IsRest := False;
+  FParameters[0].IsOptional := False;
+  FParameters[0].TypeAnnotation := '';
+  FBody := ABody;
+end;
+
+constructor TGocciaSetterExpression.Create(const AParameters: TGocciaParameterArray; const ABody: TGocciaASTNode; const ALine, AColumn: Integer);
+begin
+  inherited Create(ALine, AColumn);
+  FParameters := AParameters;
+  if Length(FParameters) > 0 then
+    FParameter := FParameters[0].Name
+  else
+    FParameter := '';
   FBody := ABody;
 end;
 

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -1762,6 +1762,14 @@ function TGocciaPropertyAssignmentExpression.Evaluate(const AContext: TGocciaEva
 var
   Obj: TGocciaValue;
 begin
+  if ObjectExpr is TGocciaSuperExpression then
+  begin
+    Result := Value.Evaluate(AContext);
+    AssignSuperProperty(AContext,
+      TGocciaStringLiteralValue.Create(PropertyName), Result);
+    Exit;
+  end;
+
   Obj := ObjectExpr.Evaluate(AContext);
   Result := Value.Evaluate(AContext);
   AssignProperty(Obj, PropertyName, Result, AContext.OnError, Line, Column,
@@ -1773,6 +1781,14 @@ var
   Obj, PropertyValue: TGocciaValue;
   PropName: string;
 begin
+  if ObjectExpr is TGocciaSuperExpression then
+  begin
+    PropertyValue := ToPropertyKey(PropertyExpression.Evaluate(AContext));
+    Result := Value.Evaluate(AContext);
+    AssignSuperProperty(AContext, PropertyValue, Result);
+    Exit;
+  end;
+
   Obj := ObjectExpr.Evaluate(AContext);
   PropertyValue := ToPropertyKey(PropertyExpression.Evaluate(AContext));
   Result := Value.Evaluate(AContext);
@@ -1840,8 +1856,50 @@ end;
 // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression
 function TGocciaPropertyCompoundAssignmentExpression.Evaluate(const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
-  Obj, CurrentValue, RhsValue: TGocciaValue;
+  Obj, PropertyKeyValue, CurrentValue, RhsValue: TGocciaValue;
 begin
+  if ObjectExpr is TGocciaSuperExpression then
+  begin
+    PropertyKeyValue := TGocciaStringLiteralValue.Create(PropertyName);
+    CurrentValue := NormalizeAssignmentValue(GetSuperProperty(AContext,
+      PropertyKeyValue));
+    if Operator = gttNullishCoalescingAssign then
+    begin
+      if not IsNullishAssignmentValue(CurrentValue) then
+        Exit(CurrentValue);
+
+      Result := Value.Evaluate(AContext);
+      AssignSuperProperty(AContext, PropertyKeyValue, Result);
+      Exit;
+    end;
+
+    if Operator = gttLogicalAndAssign then
+    begin
+      if not CurrentValue.ToBooleanLiteral.Value then
+        Exit(CurrentValue);
+
+      Result := Value.Evaluate(AContext);
+      AssignSuperProperty(AContext, PropertyKeyValue, Result);
+      Exit;
+    end;
+
+    if Operator = gttLogicalOrAssign then
+    begin
+      if CurrentValue.ToBooleanLiteral.Value then
+        Exit(CurrentValue);
+
+      Result := Value.Evaluate(AContext);
+      AssignSuperProperty(AContext, PropertyKeyValue, Result);
+      Exit;
+    end;
+
+    RhsValue := Value.Evaluate(AContext);
+    Result := Goccia.Arithmetic.CompoundOperations(CurrentValue, RhsValue,
+      Operator);
+    AssignSuperProperty(AContext, PropertyKeyValue, Result);
+    Exit;
+  end;
+
   Obj := ObjectExpr.Evaluate(AContext);
   CurrentValue := NormalizeAssignmentValue(Obj.GetProperty(PropertyName));
   // ES2026 §13.15.2 step 3: ??=
@@ -1940,6 +1998,29 @@ var
   end;
 
 begin
+  if ObjectExpr is TGocciaSuperExpression then
+  begin
+    PropertyKeyValue := ToPropertyKey(PropertyExpression.Evaluate(AContext));
+    CurrentValue := NormalizeAssignmentValue(GetSuperProperty(AContext,
+      PropertyKeyValue));
+
+    if IsShortCircuitOperator then
+    begin
+      if ShortCircuits then
+        Exit(CurrentValue);
+
+      Result := Value.Evaluate(AContext);
+      AssignSuperProperty(AContext, PropertyKeyValue, Result);
+      Exit;
+    end;
+
+    RhsValue := Value.Evaluate(AContext);
+    Result := Goccia.Arithmetic.CompoundOperations(CurrentValue, RhsValue,
+      Operator);
+    AssignSuperProperty(AContext, PropertyKeyValue, Result);
+    Exit;
+  end;
+
   Obj := ObjectExpr.Evaluate(AContext);
   PropertyKeyValue := ToPropertyKey(PropertyExpression.Evaluate(AContext));
   if PropertyKeyValue is TGocciaSymbolValue then

--- a/source/units/Goccia.AST.Statements.pas
+++ b/source/units/Goccia.AST.Statements.pas
@@ -344,6 +344,7 @@ type
   public
     FName: string;
     FSuperClass: string;
+    FSuperClassExpression: TGocciaExpression;
     FMethods: TGocciaClassMethodMap;
     FStaticMethods: TGocciaClassMethodMap;
     FGetters: TGocciaGetterExpressionMap;
@@ -375,10 +376,12 @@ type
       const AInstanceProperties: TGocciaExpressionMap;
       const APrivateInstanceProperties: TGocciaExpressionMap;
       const APrivateMethods: TGocciaClassMethodMap = nil;
-      const APrivateStaticProperties: TGocciaExpressionMap = nil);
+      const APrivateStaticProperties: TGocciaExpressionMap = nil;
+      const ASuperClassExpression: TGocciaExpression = nil);
     destructor Destroy; override;
     property Name: string read FName;
     property SuperClass: string read FSuperClass;
+    property SuperClassExpression: TGocciaExpression read FSuperClassExpression;
     property Methods: TGocciaClassMethodMap read FMethods;
     property StaticMethods: TGocciaClassMethodMap read FStaticMethods;
     property Getters: TGocciaGetterExpressionMap read FGetters;
@@ -739,10 +742,12 @@ end;
     const AInstanceProperties: TGocciaExpressionMap;
     const APrivateInstanceProperties: TGocciaExpressionMap;
     const APrivateMethods: TGocciaClassMethodMap = nil;
-    const APrivateStaticProperties: TGocciaExpressionMap = nil);
+    const APrivateStaticProperties: TGocciaExpressionMap = nil;
+    const ASuperClassExpression: TGocciaExpression = nil);
   begin
     FName := AName;
     FSuperClass := ASuperClass;
+    FSuperClassExpression := ASuperClassExpression;
     FMethods := AMethods;
     FStaticMethods := AStaticMethods;
     FGetters := AGetters;
@@ -783,6 +788,7 @@ end;
     FStaticProperties.Free;
     FInstanceProperties.Free;
     FPrivateInstanceProperties.Free;
+    FSuperClassExpression.Free;
     FInstancePropertyTypes.Free;
     if Assigned(FPrivateMethods) then
       FPrivateMethods.Free;
@@ -1323,7 +1329,8 @@ end;
 
   function TGocciaClassDeclaration.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
   begin
-    Result := TGocciaControlFlow.Normal(EvaluateClass(Self, AContext));
+    EvaluateClass(Self, AContext);
+    Result := TGocciaControlFlow.Normal(nil);
   end;
 
   function TGocciaEnumDeclaration.Execute(const AContext: TGocciaEvaluationContext): TGocciaControlFlow;

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -91,6 +91,7 @@ uses
 
   HashMap,
 
+  Goccia.CallStack,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
@@ -415,15 +416,29 @@ end;
 
 function TGocciaGlobals.BuildErrorObject(const AName: string; const AProto: TGocciaObjectValue; const AArgs: TGocciaArgumentsCollection): TGocciaObjectValue;
 var
-  Message: string;
+  MessageText: string;
+  MessageValue: TGocciaValue;
 begin
-  if AArgs.Length > 0 then
-    Message := AArgs.GetElement(0).ToStringLiteral.Value
-  else
-    Message := '';
+  Result := TGocciaObjectValue.Create(AProto);
+  Result.HasErrorData := True;
+  MessageText := '';
 
-  Result := CreateErrorObject(AName, Message, 1);
-  Result.Prototype := AProto;
+  if (AArgs.Length > 0) and
+     not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
+  begin
+    MessageText := AArgs.GetElement(0).ToStringLiteral.Value;
+    MessageValue := TGocciaStringLiteralValue.Create(
+      MessageText);
+    Result.DefineProperty(PROP_MESSAGE,
+      TGocciaPropertyDescriptorData.Create(MessageValue, [pfConfigurable, pfWritable]));
+  end;
+
+  if Assigned(TGocciaCallStack.Instance) then
+    Result.DefineProperty(PROP_STACK,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaStringLiteralValue.Create(
+          TGocciaCallStack.Instance.CaptureStackTrace(AName, MessageText, 1)),
+        [pfConfigurable, pfWritable]));
 
   if AArgs.Length > 1 then
     InstallErrorCause(Result, AArgs.GetElement(1));

--- a/source/units/Goccia.Bytecode.Binary.pas
+++ b/source/units/Goccia.Bytecode.Binary.pas
@@ -194,6 +194,7 @@ begin
   begin
     EvalEnv := AProto.GetDirectEvalEnvironment(I);
     WriteUInt32(EvalEnv.PC);
+    WriteBoolean(EvalEnv.RejectArgumentsReference);
     WriteUInt16(UInt16(Length(EvalEnv.Bindings)));
     for J := 0 to High(EvalEnv.Bindings) do
     begin
@@ -363,6 +364,7 @@ var
   I, J: Integer;
   ConstKind: UInt8;
   EvalPC: UInt32;
+  EvalRejectArgumentsReference: Boolean;
   EvalBindings: TGocciaDirectEvalBindingArray;
   EvalBinding: TGocciaDirectEvalBindingInfo;
   UpvalueIsLocal: Boolean;
@@ -445,6 +447,7 @@ begin
   for I := 0 to EvalEnvCount - 1 do
   begin
     EvalPC := ReadUInt32;
+    EvalRejectArgumentsReference := ReadBoolean;
     EvalBindingCount := ReadUInt16;
     SetLength(EvalBindings, EvalBindingCount);
     for J := 0 to EvalBindingCount - 1 do
@@ -457,7 +460,8 @@ begin
       EvalBinding.IsEvalSyntheticArguments := ReadBoolean;
       EvalBindings[J] := EvalBinding;
     end;
-    Result.AddDirectEvalEnvironment(EvalPC, EvalBindings);
+    Result.AddDirectEvalEnvironment(EvalPC, EvalRejectArgumentsReference,
+      EvalBindings);
   end;
 
   HandlerCount := ReadUInt16;

--- a/source/units/Goccia.Bytecode.Binary.pas
+++ b/source/units/Goccia.Bytecode.Binary.pas
@@ -186,6 +186,7 @@ begin
     Descriptor := AProto.GetUpvalueDescriptor(I);
     WriteBoolean(Descriptor.IsLocal);
     WriteUInt8(Descriptor.Index);
+    WriteString(Descriptor.Name);
   end;
 
   WriteUInt16(UInt16(AProto.DirectEvalEnvironmentCount));
@@ -256,6 +257,7 @@ begin
     WriteUInt16(High(UInt16))
   else
     WriteUInt16(UInt16(AProto.DirectEvalSyntheticArgumentsSlot));
+  WriteBoolean(AProto.RejectArgumentsInDirectEval);
 end;
 
 procedure TGocciaBytecodeWriter.WriteModule(
@@ -363,6 +365,9 @@ var
   EvalPC: UInt32;
   EvalBindings: TGocciaDirectEvalBindingArray;
   EvalBinding: TGocciaDirectEvalBindingInfo;
+  UpvalueIsLocal: Boolean;
+  UpvalueIndex: UInt8;
+  UpvalueName: string;
   HasDebug: Boolean;
   DebugInfo: TGocciaDebugInfo;
   SourceFile, RegExpPattern, RegExpFlags: string;
@@ -429,7 +434,12 @@ begin
   end;
 
   for I := 0 to UpvalueCount - 1 do
-    Result.AddUpvalueDescriptor(ReadBoolean, ReadUInt8);
+  begin
+    UpvalueIsLocal := ReadBoolean;
+    UpvalueIndex := ReadUInt8;
+    UpvalueName := ReadString;
+    Result.AddUpvalueDescriptor(UpvalueIsLocal, UpvalueIndex, UpvalueName);
+  end;
 
   EvalEnvCount := ReadUInt16;
   for I := 0 to EvalEnvCount - 1 do
@@ -491,6 +501,7 @@ begin
     Result.DirectEvalSyntheticArgumentsSlot := -1
   else
     Result.DirectEvalSyntheticArgumentsSlot := I;
+  Result.RejectArgumentsInDirectEval := ReadBoolean;
 end;
 
 function TGocciaBytecodeReader.ReadModule: TGocciaBytecodeModule;

--- a/source/units/Goccia.Bytecode.Chunk.pas
+++ b/source/units/Goccia.Bytecode.Chunk.pas
@@ -48,6 +48,7 @@ type
   end;
 
   TGocciaUpvalueDescriptor = record
+    Name: string;
     IsLocal: Boolean;
     Index: UInt8;
   end;
@@ -124,6 +125,7 @@ type
     FParameterPreambleSize: UInt16;
     FTypeCheckPreambleSize: UInt8;
     FDirectEvalSyntheticArgumentsSlot: Integer;
+    FRejectArgumentsInDirectEval: Boolean;
     FProfileIndex: Integer;
     FSourceText: string;
     FTemplateSiteId: UInt64;
@@ -158,7 +160,8 @@ type
     function GetRegExpProgramCache(const ASlot: Integer): TObject;
     procedure SetRegExpProgramCache(const ASlot: Integer; const AValue: TObject);
     function AddFunction(const AFunction: TGocciaFunctionTemplate): UInt16;
-    procedure AddUpvalueDescriptor(const AIsLocal: Boolean; const AIndex: UInt8);
+    procedure AddUpvalueDescriptor(const AIsLocal: Boolean; const AIndex: UInt8;
+      const AName: string = '');
     procedure AddDirectEvalEnvironment(const APC: UInt32;
       const ABindings: TGocciaDirectEvalBindingArray);
     procedure AddExceptionHandler(const ATryStart, ATryEnd, ACatchTarget,
@@ -211,6 +214,7 @@ type
     property ParameterPreambleSize: UInt16 read FParameterPreambleSize write FParameterPreambleSize;
     property TypeCheckPreambleSize: UInt8 read FTypeCheckPreambleSize write FTypeCheckPreambleSize;
     property DirectEvalSyntheticArgumentsSlot: Integer read FDirectEvalSyntheticArgumentsSlot write FDirectEvalSyntheticArgumentsSlot;
+    property RejectArgumentsInDirectEval: Boolean read FRejectArgumentsInDirectEval write FRejectArgumentsInDirectEval;
     property ProfileIndex: Integer read FProfileIndex write FProfileIndex;
     property SourceText: string read FSourceText write FSourceText;
     property TemplateSiteId: UInt64 read FTemplateSiteId;
@@ -271,6 +275,7 @@ begin
   FParameterPreambleSize := 0;
   FTypeCheckPreambleSize := 0;
   FDirectEvalSyntheticArgumentsSlot := -1;
+  FRejectArgumentsInDirectEval := False;
   FProfileIndex := -1;
   FTemplateSiteId := AllocateTemplateSiteId;
   FRegExpProgramCacheCount := 0;
@@ -526,12 +531,13 @@ begin
 end;
 
 procedure TGocciaFunctionTemplate.AddUpvalueDescriptor(
-  const AIsLocal: Boolean; const AIndex: UInt8);
+  const AIsLocal: Boolean; const AIndex: UInt8; const AName: string);
 begin
   if FUpvalueCount >= High(UInt8) then
     raise Exception.Create('Upvalue descriptor overflow: exceeds 255 entries');
   if FUpvalueCount >= Length(FUpvalueDescriptors) then
     SetLength(FUpvalueDescriptors, FUpvalueCount * 2 + 4);
+  FUpvalueDescriptors[FUpvalueCount].Name := AName;
   FUpvalueDescriptors[FUpvalueCount].IsLocal := AIsLocal;
   FUpvalueDescriptors[FUpvalueCount].Index := AIndex;
   Inc(FUpvalueCount);

--- a/source/units/Goccia.Bytecode.Chunk.pas
+++ b/source/units/Goccia.Bytecode.Chunk.pas
@@ -74,6 +74,7 @@ type
 
   TGocciaDirectEvalEnvironment = record
     PC: UInt32;
+    RejectArgumentsReference: Boolean;
     Bindings: TGocciaDirectEvalBindingArray;
   end;
 
@@ -163,6 +164,7 @@ type
     procedure AddUpvalueDescriptor(const AIsLocal: Boolean; const AIndex: UInt8;
       const AName: string = '');
     procedure AddDirectEvalEnvironment(const APC: UInt32;
+      const ARejectArgumentsReference: Boolean;
       const ABindings: TGocciaDirectEvalBindingArray);
     procedure AddExceptionHandler(const ATryStart, ATryEnd, ACatchTarget,
       AFinallyTarget: UInt32; const ACatchRegister: UInt8);
@@ -544,6 +546,7 @@ begin
 end;
 
 procedure TGocciaFunctionTemplate.AddDirectEvalEnvironment(const APC: UInt32;
+  const ARejectArgumentsReference: Boolean;
   const ABindings: TGocciaDirectEvalBindingArray);
 var
   I: Integer;
@@ -553,6 +556,8 @@ begin
   if FDirectEvalEnvironmentCount >= Length(FDirectEvalEnvironments) then
     SetLength(FDirectEvalEnvironments, FDirectEvalEnvironmentCount * 2 + 4);
   FDirectEvalEnvironments[FDirectEvalEnvironmentCount].PC := APC;
+  FDirectEvalEnvironments[FDirectEvalEnvironmentCount].RejectArgumentsReference :=
+    ARejectArgumentsReference;
   SetLength(FDirectEvalEnvironments[FDirectEvalEnvironmentCount].Bindings,
     Length(ABindings));
   for I := 0 to High(ABindings) do

--- a/source/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/source/units/Goccia.Bytecode.OpCodeNames.pas
@@ -181,6 +181,7 @@ begin
     OP_SET_FUNCTION_NAME:              Result := 'OP_SET_FUNCTION_NAME';
     OP_LOAD_ARGUMENT:                  Result := 'OP_LOAD_ARGUMENT';
     OP_CHECK_DERIVED_THIS:             Result := 'OP_CHECK_DERIVED_THIS';
+    OP_SUPER_SET:                      Result := 'OP_SUPER_SET';
     OP_INC:                            Result := 'OP_INC';
     OP_DEC:                            Result := 'OP_DEC';
     OP_TO_NUMERIC:                     Result := 'OP_TO_NUMERIC';

--- a/source/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/source/units/Goccia.Bytecode.OpCodeNames.pas
@@ -176,6 +176,11 @@ begin
     OP_TO_PROPERTY_KEY:                Result := 'OP_TO_PROPERTY_KEY';
     OP_ENUM_KEYS:                      Result := 'OP_ENUM_KEYS';
     OP_ENUM_ENTRY:                     Result := 'OP_ENUM_ENTRY';
+    OP_ASYNC_ITER_NEXT:                Result := 'OP_ASYNC_ITER_NEXT';
+    OP_ITER_UNPACK:                    Result := 'OP_ITER_UNPACK';
+    OP_SET_FUNCTION_NAME:              Result := 'OP_SET_FUNCTION_NAME';
+    OP_LOAD_ARGUMENT:                  Result := 'OP_LOAD_ARGUMENT';
+    OP_CHECK_DERIVED_THIS:             Result := 'OP_CHECK_DERIVED_THIS';
     OP_INC:                            Result := 'OP_INC';
     OP_DEC:                            Result := 'OP_DEC';
     OP_TO_NUMERIC:                     Result := 'OP_TO_NUMERIC';

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -96,7 +96,11 @@ const
   //   v50 -> v51: added OP_SUPER_SET so super property writes use the
   //               super base with the actual receiver instead of ordinary
   //               assignment to this.
-  GOCCIA_FORMAT_VERSION = 51;
+  //   v51 -> v52: serialized class-field direct-eval `arguments`
+  //               rejection at each direct-eval call site, so static
+  //               field initializers compiled into enclosing templates do
+  //               not affect unrelated eval calls.
+  GOCCIA_FORMAT_VERSION = 52;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -80,7 +80,20 @@ const
   //   v44 -> v45: added bckRegExpLiteral constants so bytecode regexp
   //               literals create fresh RegExp objects from cached compiled
   //               programs instead of calling the global RegExp constructor.
-  GOCCIA_FORMAT_VERSION = 45;
+  //   v45 -> v46: split for-await-of iteration into OP_ASYNC_ITER_NEXT,
+  //               OP_AWAIT, and OP_ITER_UNPACK so IteratorResult promises
+  //               are awaited before done/value extraction.
+  //   v46 -> v47: added OP_SET_FUNCTION_NAME so computed class elements can
+  //               derive method/accessor names from runtime property keys.
+  //   v47 -> v48: added OP_LOAD_ARGUMENT so default-parameter preambles can
+  //               restore actual argument values while enforcing TDZ for
+  //               later parameters during earlier default initializers, and
+  //               OP_CHECK_DERIVED_THIS for derived constructor `this` TDZ.
+  //   v48 -> v49: serialized the class-field-initializer direct-eval
+  //               `arguments` rejection flag on function templates.
+  //   v49 -> v50: serialized upvalue descriptor names for bytecode
+  //               direct-eval dynamic-scope lookups.
+  GOCCIA_FORMAT_VERSION = 50;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;
@@ -88,6 +101,9 @@ const
   GOCCIA_NULLISH_MATCH_ANY = 255;
   ACCESSOR_FLAG_SETTER = 1;
   ACCESSOR_FLAG_STATIC = 2;
+  FUNCTION_NAME_PREFIX_NONE = 0;
+  FUNCTION_NAME_PREFIX_GET  = 1;
+  FUNCTION_NAME_PREFIX_SET  = 2;
   COLLECTION_OP_SPREAD_OBJECT = 0;
   COLLECTION_OP_OBJECT_REST = 1;
   COLLECTION_OP_SPREAD_ITERABLE_INTO_ARRAY = 2;
@@ -283,7 +299,12 @@ type
     OP_HAS_WITH_BINDING = 184,
     OP_TO_PROPERTY_KEY = 185,
     OP_ENUM_KEYS     = 186,
-    OP_ENUM_ENTRY    = 187
+    OP_ENUM_ENTRY    = 187,
+    OP_ASYNC_ITER_NEXT = 188,
+    OP_ITER_UNPACK   = 189,
+    OP_SET_FUNCTION_NAME = 190,
+    OP_LOAD_ARGUMENT = 191,
+    OP_CHECK_DERIVED_THIS = 192
   );
 
 function EncodeABC(const AOp: TGocciaOpCode; const A, B, C: UInt8): UInt32; inline;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -93,7 +93,10 @@ const
   //               `arguments` rejection flag on function templates.
   //   v49 -> v50: serialized upvalue descriptor names for bytecode
   //               direct-eval dynamic-scope lookups.
-  GOCCIA_FORMAT_VERSION = 50;
+  //   v50 -> v51: added OP_SUPER_SET so super property writes use the
+  //               super base with the actual receiver instead of ordinary
+  //               assignment to this.
+  GOCCIA_FORMAT_VERSION = 51;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;
@@ -304,7 +307,8 @@ type
     OP_ITER_UNPACK   = 189,
     OP_SET_FUNCTION_NAME = 190,
     OP_LOAD_ARGUMENT = 191,
-    OP_CHECK_DERIVED_THIS = 192
+    OP_CHECK_DERIVED_THIS = 192,
+    OP_SUPER_SET     = 193
   );
 
 function EncodeABC(const AOp: TGocciaOpCode; const A, B, C: UInt8): UInt32; inline;

--- a/source/units/Goccia.Compiler.Context.pas
+++ b/source/units/Goccia.Compiler.Context.pas
@@ -24,6 +24,8 @@ type
   TCompileFunctionBodyProc = procedure(const ABody: TGocciaASTNode) of object;
   TSwapStateProc = procedure(const ATemplate: TGocciaFunctionTemplate;
     const AScope: TGocciaCompilerScope) of object;
+  TSetDerivedConstructorThisGuardProc = procedure(
+    const AGuard: Boolean) of object;
 
   TFormalParameterCountMap = THashMap<TGocciaFunctionTemplate, Integer>;
 
@@ -36,11 +38,13 @@ type
     StrictTypes: Boolean;
     CompatibilityNonStrictMode: Boolean;
     NonStrictMode: Boolean;
+    DerivedConstructorThisGuard: Boolean;
     OptimizationOptions: TGocciaCompilerOptimizationOptions;
     CompileExpression: TCompileExpressionProc;
     CompileStatement: TCompileStatementProc;
     CompileFunctionBody: TCompileFunctionBodyProc;
     SwapState: TSwapStateProc;
+    SetDerivedConstructorThisGuard: TSetDerivedConstructorThisGuardProc;
   end;
 
 function EmitInstruction(const ACtx: TGocciaCompilationContext;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -965,6 +965,180 @@ begin
   Result := False;
 end;
 
+function ExpressionContainsSuspension(const AExpr: TGocciaExpression): Boolean;
+var
+  CallExpr: TGocciaCallExpression;
+  MemberExpr: TGocciaMemberExpression;
+  ArrayExpr: TGocciaArrayExpression;
+  ObjectExpr: TGocciaObjectExpression;
+  NewExpr: TGocciaNewExpression;
+  ImportExpr: TGocciaImportCallExpression;
+  Pair: TPair<TGocciaExpression, TGocciaExpression>;
+  I: Integer;
+begin
+  if not Assigned(AExpr) then
+    Exit(False);
+
+  if (AExpr is TGocciaYieldExpression) or
+     (AExpr is TGocciaAwaitExpression) then
+    Exit(True);
+
+  if (AExpr is TGocciaFunctionExpression) or
+     (AExpr is TGocciaArrowFunctionExpression) then
+    Exit(False);
+
+  if AExpr is TGocciaCallExpression then
+  begin
+    CallExpr := TGocciaCallExpression(AExpr);
+    if ExpressionContainsSuspension(CallExpr.Callee) then
+      Exit(True);
+    for I := 0 to CallExpr.Arguments.Count - 1 do
+      if ExpressionContainsSuspension(CallExpr.Arguments[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaMemberExpression then
+  begin
+    MemberExpr := TGocciaMemberExpression(AExpr);
+    if ExpressionContainsSuspension(MemberExpr.ObjectExpr) then
+      Exit(True);
+    if MemberExpr.Computed and
+       ExpressionContainsSuspension(MemberExpr.PropertyExpression) then
+      Exit(True);
+  end
+  else if AExpr is TGocciaBinaryExpression then
+    Exit(ExpressionContainsSuspension(TGocciaBinaryExpression(AExpr).Left) or
+      ExpressionContainsSuspension(TGocciaBinaryExpression(AExpr).Right))
+  else if AExpr is TGocciaSequenceExpression then
+  begin
+    for I := 0 to TGocciaSequenceExpression(AExpr).Expressions.Count - 1 do
+      if ExpressionContainsSuspension(
+        TGocciaSequenceExpression(AExpr).Expressions[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaUnaryExpression then
+    Exit(ExpressionContainsSuspension(TGocciaUnaryExpression(AExpr).Operand))
+  else if AExpr is TGocciaAssignmentExpression then
+    Exit(ExpressionContainsSuspension(TGocciaAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaPropertyAssignmentExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaPropertyAssignmentExpression(AExpr).ObjectExpr) or
+      ExpressionContainsSuspension(
+        TGocciaPropertyAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaComputedPropertyAssignmentExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaComputedPropertyAssignmentExpression(AExpr).ObjectExpr) or
+      ExpressionContainsSuspension(
+        TGocciaComputedPropertyAssignmentExpression(AExpr).PropertyExpression) or
+      ExpressionContainsSuspension(
+        TGocciaComputedPropertyAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaCompoundAssignmentExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaCompoundAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaPropertyCompoundAssignmentExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaPropertyCompoundAssignmentExpression(AExpr).ObjectExpr) or
+      ExpressionContainsSuspension(
+        TGocciaPropertyCompoundAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaComputedPropertyCompoundAssignmentExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).ObjectExpr) or
+      ExpressionContainsSuspension(
+        TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).PropertyExpression) or
+      ExpressionContainsSuspension(
+        TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaIncrementExpression then
+    Exit(ExpressionContainsSuspension(TGocciaIncrementExpression(AExpr).Operand))
+  else if AExpr is TGocciaArrayExpression then
+  begin
+    ArrayExpr := TGocciaArrayExpression(AExpr);
+    for I := 0 to ArrayExpr.Elements.Count - 1 do
+      if ExpressionContainsSuspension(ArrayExpr.Elements[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaObjectExpression then
+  begin
+    ObjectExpr := TGocciaObjectExpression(AExpr);
+    for I := 0 to High(ObjectExpr.PropertySourceOrder) do
+      case ObjectExpr.PropertySourceOrder[I].PropertyType of
+        pstStatic:
+          if ExpressionContainsSuspension(
+            ObjectExpr.PropertySourceOrder[I].Expression) then
+            Exit(True);
+        pstComputed:
+          begin
+            Pair := ObjectExpr.ComputedPropertiesInOrder[
+              ObjectExpr.PropertySourceOrder[I].ComputedIndex];
+            if ExpressionContainsSuspension(Pair.Key) or
+               ExpressionContainsSuspension(Pair.Value) then
+              Exit(True);
+          end;
+        pstComputedGetter,
+        pstComputedSetter:
+          begin
+            Pair := ObjectExpr.ComputedPropertiesInOrder[
+              ObjectExpr.PropertySourceOrder[I].ComputedIndex];
+            if ExpressionContainsSuspension(Pair.Key) then
+              Exit(True);
+          end;
+      end;
+  end
+  else if AExpr is TGocciaConditionalExpression then
+    Exit(ExpressionContainsSuspension(TGocciaConditionalExpression(AExpr).Condition) or
+      ExpressionContainsSuspension(TGocciaConditionalExpression(AExpr).Consequent) or
+      ExpressionContainsSuspension(TGocciaConditionalExpression(AExpr).Alternate))
+  else if AExpr is TGocciaNewExpression then
+  begin
+    NewExpr := TGocciaNewExpression(AExpr);
+    if ExpressionContainsSuspension(NewExpr.Callee) then
+      Exit(True);
+    for I := 0 to NewExpr.Arguments.Count - 1 do
+      if ExpressionContainsSuspension(NewExpr.Arguments[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaImportCallExpression then
+  begin
+    ImportExpr := TGocciaImportCallExpression(AExpr);
+    Exit(ExpressionContainsSuspension(ImportExpr.Specifier) or
+      ExpressionContainsSuspension(ImportExpr.Options));
+  end
+  else if AExpr is TGocciaSpreadExpression then
+    Exit(ExpressionContainsSuspension(TGocciaSpreadExpression(AExpr).Argument))
+  else if AExpr is TGocciaTemplateWithInterpolationExpression then
+  begin
+    for I := 0 to TGocciaTemplateWithInterpolationExpression(AExpr).Parts.Count - 1 do
+      if ExpressionContainsSuspension(
+        TGocciaTemplateWithInterpolationExpression(AExpr).Parts[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaTaggedTemplateExpression then
+  begin
+    if ExpressionContainsSuspension(TGocciaTaggedTemplateExpression(AExpr).Tag) then
+      Exit(True);
+    for I := 0 to TGocciaTaggedTemplateExpression(AExpr).Expressions.Count - 1 do
+      if ExpressionContainsSuspension(
+        TGocciaTaggedTemplateExpression(AExpr).Expressions[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaDestructuringAssignmentExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaDestructuringAssignmentExpression(AExpr).Right))
+  else if AExpr is TGocciaPrivateMemberExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaPrivateMemberExpression(AExpr).ObjectExpr))
+  else if AExpr is TGocciaPrivatePropertyAssignmentExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaPrivatePropertyAssignmentExpression(AExpr).ObjectExpr) or
+      ExpressionContainsSuspension(
+        TGocciaPrivatePropertyAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaPrivatePropertyCompoundAssignmentExpression then
+    Exit(ExpressionContainsSuspension(
+      TGocciaPrivatePropertyCompoundAssignmentExpression(AExpr).ObjectExpr) or
+      ExpressionContainsSuspension(
+        TGocciaPrivatePropertyCompoundAssignmentExpression(AExpr).Value));
+
+  Result := False;
+end;
+
 function ParameterDefaultsContainDirectEval(
   const AParams: TGocciaParameterArray): Boolean;
 var
@@ -1868,8 +2042,7 @@ begin
   if APattern is TGocciaAssignmentDestructuringPattern then
   begin
     AssignPat := TGocciaAssignmentDestructuringPattern(APattern);
-    if (AssignPat.Right is TGocciaYieldExpression) or
-       (AssignPat.Right is TGocciaAwaitExpression) then
+    if ExpressionContainsSuspension(AssignPat.Right) then
       Exit(True);
     Exit(DestructuringPatternHasSuspendingDefault(AssignPat.Left));
   end;
@@ -2368,9 +2541,11 @@ var
   RestParamIndex: Integer;
   RestReg: Integer;
   I: Integer;
+  OldDerivedGuard: Boolean;
 begin
   OldTemplate := ACtx.Template;
   OldScope := ACtx.Scope;
+  OldDerivedGuard := ACtx.DerivedConstructorThisGuard;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('<arrow>');
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
@@ -2425,12 +2600,15 @@ begin
     ACtx.FormalParameterCounts.AddOrSetValue(ChildTemplate, FormalCount);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
+  if Assigned(ACtx.SetDerivedConstructorThisGuard) then
+    ACtx.SetDerivedConstructorThisGuard(OldDerivedGuard);
   try
     ChildCtx := ACtx;
     ChildCtx.Template := ChildTemplate;
     ChildCtx.Scope := ChildScope;
     ChildCtx.NonStrictMode := ACtx.NonStrictMode and
       not ChildTemplate.StrictCode;
+    ChildCtx.DerivedConstructorThisGuard := OldDerivedGuard;
 
     if (RestParamIndex >= 0) and
        not ParameterListHasDefaultValues(AExpr.Parameters) then
@@ -3182,6 +3360,7 @@ begin
     ChildCtx.Scope := ChildScope;
     ChildCtx.NonStrictMode := ACtx.NonStrictMode and
       not ChildTemplate.StrictCode;
+    ChildCtx.DerivedConstructorThisGuard := False;
     EmitLineMapping(ChildCtx, AGetter.Line, AGetter.Column);
     EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
     ACtx.CompileFunctionBody(AGetter.Body);
@@ -3249,6 +3428,7 @@ begin
     ChildCtx.Scope := ChildScope;
     ChildCtx.NonStrictMode := ACtx.NonStrictMode and
       not ChildTemplate.StrictCode;
+    ChildCtx.DerivedConstructorThisGuard := False;
     EmitLineMapping(ChildCtx, ASetter.Line, ASetter.Column);
     EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
     ACtx.CompileFunctionBody(ASetter.Body);
@@ -3313,6 +3493,7 @@ begin
     ChildCtx.Scope := ChildScope;
     ChildCtx.NonStrictMode := ACtx.NonStrictMode and
       not ChildTemplate.StrictCode;
+    ChildCtx.DerivedConstructorThisGuard := False;
     EmitLineMapping(ChildCtx, AGetter.Line, AGetter.Column);
     EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
     ACtx.CompileFunctionBody(AGetter.Body);
@@ -3379,6 +3560,7 @@ begin
     ChildCtx.Scope := ChildScope;
     ChildCtx.NonStrictMode := ACtx.NonStrictMode and
       not ChildTemplate.StrictCode;
+    ChildCtx.DerivedConstructorThisGuard := False;
     EmitLineMapping(ChildCtx, ASetter.Line, ASetter.Column);
     EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
     ACtx.CompileFunctionBody(ASetter.Body);
@@ -3957,6 +4139,7 @@ begin
     ChildCtx.Scope := ChildScope;
     ChildCtx.NonStrictMode := ACtx.NonStrictMode and
       not ChildTemplate.StrictCode;
+    ChildCtx.DerivedConstructorThisGuard := False;
 
     EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
 
@@ -4512,8 +4695,31 @@ procedure CompileIncrementMember(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaIncrementExpression; const AMember: TGocciaMemberExpression;
   const ADest: UInt8; const AOp: TGocciaOpCode);
 var
-  ObjReg, CurReg: UInt8;
+  ObjReg, CurReg, KeyReg, SuperReg, ThisReg: UInt8;
+  PropIdx: UInt16;
 begin
+  if AMember.ObjectExpr is TGocciaSuperExpression then
+  begin
+    PrepareSuperPropertyBase(ACtx, ThisReg, CurReg, SuperReg);
+    KeyReg := ACtx.Scope.AllocateRegister;
+    PropIdx := ACtx.Template.AddConstantString(AMember.PropertyName);
+    EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, KeyReg, PropIdx));
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_GET, CurReg, 0, KeyReg));
+    EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, CurReg, CurReg, 0));
+    if not AExpr.IsPrefix then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+    EmitInstruction(ACtx, EncodeABC(AOp, CurReg, CurReg, 0));
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, CurReg, KeyReg, CurReg));
+    if AExpr.IsPrefix then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   ObjReg := ACtx.Scope.AllocateRegister;
   CurReg := ACtx.Scope.AllocateRegister;
 
@@ -4535,8 +4741,30 @@ procedure CompileIncrementComputedMember(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaIncrementExpression; const AMember: TGocciaMemberExpression;
   const ADest: UInt8; const AOp: TGocciaOpCode);
 var
-  ObjReg, KeyReg, CurReg: UInt8;
+  ObjReg, KeyReg, CurReg, SuperReg, ThisReg: UInt8;
 begin
+  if AMember.ObjectExpr is TGocciaSuperExpression then
+  begin
+    PrepareSuperPropertyBase(ACtx, ThisReg, CurReg, SuperReg);
+    KeyReg := ACtx.Scope.AllocateRegister;
+    ACtx.CompileExpression(AMember.PropertyExpression, KeyReg);
+    EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_GET, CurReg, 0, KeyReg));
+    EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, CurReg, CurReg, 0));
+    if not AExpr.IsPrefix then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+    EmitInstruction(ACtx, EncodeABC(AOp, CurReg, CurReg, 0));
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, CurReg, KeyReg, CurReg));
+    if AExpr.IsPrefix then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, CurReg, 0));
+
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   ObjReg := ACtx.Scope.AllocateRegister;
   KeyReg := ACtx.Scope.AllocateRegister;
   CurReg := ACtx.Scope.AllocateRegister;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -1102,7 +1102,8 @@ begin
       ScopeCursor := ScopeCursor.Parent;
     end;
 
-    ACtx.Template.AddDirectEvalEnvironment(APC, Bindings);
+    ACtx.Template.AddDirectEvalEnvironment(APC,
+      ACtx.Template.RejectArgumentsInDirectEval, Bindings);
   finally
     Names.Free;
   end;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -373,6 +373,18 @@ begin
   end;
 end;
 
+procedure PrepareSuperPropertyBase(const ACtx: TGocciaCompilationContext;
+  out AThisReg, ABaseReg, ASuperReg: UInt8);
+begin
+  AThisReg := ACtx.Scope.AllocateRegister;
+  CompileThis(ACtx, AThisReg);
+  ABaseReg := ACtx.Scope.AllocateRegister;
+  ASuperReg := ACtx.Scope.AllocateRegister;
+  CompileSuperAccess(ACtx, ASuperReg);
+  if ASuperReg <> ABaseReg + 1 then
+    EmitInstruction(ACtx, EncodeABC(OP_MOVE, ABaseReg + 1, ASuperReg, 0));
+end;
+
 procedure EmitConstAssignmentError(const ACtx: TGocciaCompilationContext);
 var
   MsgIdx: UInt16;
@@ -1615,16 +1627,36 @@ end;
 procedure CompilePropertyAssignment(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaPropertyAssignmentExpression; const ADest: UInt8);
 var
-  ObjReg, ValReg: UInt8;
+  BaseReg, KeyReg, ObjReg, SuperReg, ThisReg, ValReg: UInt8;
   KeyIdx: UInt16;
 begin
+  if AExpr.ObjectExpr is TGocciaSuperExpression then
+  begin
+    PrepareSuperPropertyBase(ACtx, ThisReg, BaseReg, SuperReg);
+    KeyReg := ACtx.Scope.AllocateRegister;
+    ValReg := ACtx.Scope.AllocateRegister;
+    KeyIdx := ACtx.Template.AddConstantString(AExpr.PropertyName);
+    EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, KeyReg, KeyIdx));
+    // PutValue(super reference, RHS): RHS is evaluated before a null super base
+    // throws, so tests observe RHS side effects exactly once.
+    ACtx.CompileExpression(AExpr.Value, ValReg);
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, BaseReg, KeyReg, ValReg));
+
+    if ADest <> ValReg then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, ValReg, 0));
+
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   ObjReg := ACtx.Scope.AllocateRegister;
   ValReg := ACtx.Scope.AllocateRegister;
 
-  if AExpr.ObjectExpr is TGocciaSuperExpression then
-    CompileThis(ACtx, ObjReg)
-  else
-    ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
+  ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
   ACtx.CompileExpression(AExpr.Value, ValReg);
 
   EmitStorePropertyByName(ACtx, ObjReg, AExpr.PropertyName, ValReg);
@@ -3797,16 +3829,34 @@ end;
 procedure CompileComputedPropertyAssignment(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaComputedPropertyAssignmentExpression; const ADest: UInt8);
 var
-  ObjReg, KeyReg, ValReg: UInt8;
+  BaseReg, KeyReg, ObjReg, SuperReg, ThisReg, ValReg: UInt8;
 begin
+  if AExpr.ObjectExpr is TGocciaSuperExpression then
+  begin
+    PrepareSuperPropertyBase(ACtx, ThisReg, BaseReg, SuperReg);
+    KeyReg := ACtx.Scope.AllocateRegister;
+    ValReg := ACtx.Scope.AllocateRegister;
+    ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
+    EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
+    ACtx.CompileExpression(AExpr.Value, ValReg);
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, BaseReg, KeyReg, ValReg));
+
+    if ADest <> ValReg then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, ValReg, 0));
+
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   ObjReg := ACtx.Scope.AllocateRegister;
   KeyReg := ACtx.Scope.AllocateRegister;
   ValReg := ACtx.Scope.AllocateRegister;
 
-  if AExpr.ObjectExpr is TGocciaSuperExpression then
-    CompileThis(ACtx, ObjReg)
-  else
-    ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
+  ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
   ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
   ACtx.CompileExpression(AExpr.Value, ValReg);
 
@@ -4261,11 +4311,55 @@ end;
 procedure CompilePropertyCompoundAssignment(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaPropertyCompoundAssignmentExpression; const ADest: UInt8);
 var
-  ObjReg, CurReg, ValReg: UInt8;
+  BaseReg, CurReg, KeyReg, ObjReg, SuperReg, ThisReg, ValReg: UInt8;
   Op: TGocciaOpCode;
   PropIdx: UInt16;
   JumpIdx: Integer;
 begin
+  if AExpr.ObjectExpr is TGocciaSuperExpression then
+  begin
+    PrepareSuperPropertyBase(ACtx, ThisReg, BaseReg, SuperReg);
+    KeyReg := ACtx.Scope.AllocateRegister;
+    PropIdx := ACtx.Template.AddConstantString(AExpr.PropertyName);
+    EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, KeyReg, PropIdx));
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_GET, BaseReg, 0, KeyReg));
+
+    if IsShortCircuitAssignment(AExpr.Operator) then
+    begin
+      JumpIdx := EmitJumpInstruction(ACtx,
+        ShortCircuitJumpOp(AExpr.Operator), BaseReg);
+      ACtx.CompileExpression(AExpr.Value, BaseReg);
+      EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, BaseReg, KeyReg,
+        BaseReg));
+      PatchJumpTarget(ACtx, JumpIdx);
+
+      if ADest <> BaseReg then
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, BaseReg, 0));
+
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      Exit;
+    end;
+
+    Op := CompoundOpToRuntimeOp(AExpr.Operator);
+    ValReg := ACtx.Scope.AllocateRegister;
+    ACtx.CompileExpression(AExpr.Value, ValReg);
+    EmitInstruction(ACtx, EncodeABC(Op, BaseReg, BaseReg, ValReg));
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, BaseReg, KeyReg, BaseReg));
+
+    if ADest <> BaseReg then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, BaseReg, 0));
+
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??=/&&=/||= AssignmentExpression
   if IsShortCircuitAssignment(AExpr.Operator) then
   begin
@@ -4311,10 +4405,54 @@ procedure CompileComputedPropertyCompoundAssignment(
   const AExpr: TGocciaComputedPropertyCompoundAssignmentExpression;
   const ADest: UInt8);
 var
-  ObjReg, KeyReg, CurReg, ValReg: UInt8;
+  BaseReg, ObjReg, KeyReg, CurReg, SuperReg, ThisReg, ValReg: UInt8;
   Op: TGocciaOpCode;
   JumpIdx: Integer;
 begin
+  if AExpr.ObjectExpr is TGocciaSuperExpression then
+  begin
+    PrepareSuperPropertyBase(ACtx, ThisReg, BaseReg, SuperReg);
+    KeyReg := ACtx.Scope.AllocateRegister;
+    ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
+    EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_GET, BaseReg, 0, KeyReg));
+
+    if IsShortCircuitAssignment(AExpr.Operator) then
+    begin
+      JumpIdx := EmitJumpInstruction(ACtx,
+        ShortCircuitJumpOp(AExpr.Operator), BaseReg);
+      ACtx.CompileExpression(AExpr.Value, BaseReg);
+      EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, BaseReg, KeyReg,
+        BaseReg));
+      PatchJumpTarget(ACtx, JumpIdx);
+
+      if ADest <> BaseReg then
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, BaseReg, 0));
+
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      Exit;
+    end;
+
+    Op := CompoundOpToRuntimeOp(AExpr.Operator);
+    ValReg := ACtx.Scope.AllocateRegister;
+    ACtx.CompileExpression(AExpr.Value, ValReg);
+    EmitInstruction(ACtx, EncodeABC(Op, BaseReg, BaseReg, ValReg));
+    EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, BaseReg, KeyReg, BaseReg));
+
+    if ADest <> BaseReg then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, BaseReg, 0));
+
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
   // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??=/&&=/||= AssignmentExpression
   if IsShortCircuitAssignment(AExpr.Operator) then
   begin
@@ -4490,6 +4628,8 @@ begin
       Exit;
     end;
     Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
+    if ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_GET_LOCAL, Slot, UInt16(Slot)));
     EmitInstruction(ACtx, EncodeABC(OP_TO_NUMERIC, Slot, Slot, 0));
     if not AExpr.IsPrefix then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -65,6 +65,9 @@ procedure CompileComputedPropertyCompoundAssignment(
 procedure CompileFunctionExpression(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaFunctionExpression; const ADest: UInt8;
   const ATemplateName: string = '<function>');
+procedure CompileExpressionWithInferredName(const ACtx: TGocciaCompilationContext;
+  const AExpr: TGocciaExpression; const ADest: UInt8;
+  const AInferredName: string);
 procedure CompileIncrement(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaIncrementExpression; const ADest: UInt8);
 procedure CompilePrivateMember(const ACtx: TGocciaCompilationContext;
@@ -90,6 +93,8 @@ procedure CompileYield(const ACtx: TGocciaCompilationContext;
 
 procedure EmitDefaultParameters(const ACtx: TGocciaCompilationContext;
   const AParams: TGocciaParameterArray);
+function ParameterListHasDefaultValues(
+  const AParams: TGocciaParameterArray): Boolean;
 function SyntheticParamLocalName(const AIndex: Integer): string;
 function DeclareArgumentsObjectLocal(const ACtx: TGocciaCompilationContext;
   const AScope: TGocciaCompilerScope; const AParams: TGocciaParameterArray): Integer;
@@ -130,6 +135,9 @@ uses
   Goccia.Types.Enforcement,
   Goccia.Values.BigIntValue,
   Goccia.Values.Primitives;
+
+type
+  TGocciaCompilerJumpArray = array of Integer;
 
 function PrivateKey(const AScope: TGocciaCompilerScope;
   const AName: string): string;
@@ -957,6 +965,17 @@ begin
   Result := False;
 end;
 
+function ParameterListHasDefaultValues(
+  const AParams: TGocciaParameterArray): Boolean;
+var
+  I: Integer;
+begin
+  for I := 0 to High(AParams) do
+    if Assigned(AParams[I].DefaultValue) then
+      Exit(True);
+  Result := False;
+end;
+
 function IsDirectEvalVisibleCompilerName(const AName: string): Boolean;
 begin
   Result := (AName <> '') and
@@ -983,6 +1002,7 @@ var
   BindingIndex: Integer;
 begin
   if (AKind <> debWithLocal) and (AKind <> debWithUpvalue) and
+     (AName <> KEYWORD_THIS) and
      not IsDirectEvalVisibleCompilerName(AName) then
     Exit;
   if DirectEvalBindingNameSeen(ANames, AName) then
@@ -1050,7 +1070,8 @@ begin
               UInt8(UpvalueIdx), False);
           Continue;
         end;
-        if not IsDirectEvalVisibleCompilerName(Local.Name) then
+        if (Local.Name <> KEYWORD_THIS) and
+           not IsDirectEvalVisibleCompilerName(Local.Name) then
           Continue;
         if Local.IsGlobalBacked then
           AddDirectEvalBinding(Bindings, Names, Local.Name, debGlobal, 0,
@@ -1600,7 +1621,10 @@ begin
   ObjReg := ACtx.Scope.AllocateRegister;
   ValReg := ACtx.Scope.AllocateRegister;
 
-  ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
+  if AExpr.ObjectExpr is TGocciaSuperExpression then
+    CompileThis(ACtx, ObjReg)
+  else
+    ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
   ACtx.CompileExpression(AExpr.Value, ValReg);
 
   EmitStorePropertyByName(ACtx, ObjReg, AExpr.PropertyName, ValReg);
@@ -1650,34 +1674,56 @@ var
   I, LocalIdx: Integer;
   Slot: UInt8;
   JumpIdx: Integer;
+  IsCaptured: Boolean;
 begin
+  if not ParameterListHasDefaultValues(AParams) then
+    Exit;
+
   for I := 0 to High(AParams) do
   begin
-    if not Assigned(AParams[I].DefaultValue) then
-      Continue;
     if AParams[I].IsPattern then
-    begin
-      LocalIdx := ACtx.Scope.ResolveLocal(SyntheticParamLocalName(I));
-      if LocalIdx < 0 then
-        Continue;
-      Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
-      EmitUndefinedCheck(ACtx, Slot, JumpIdx);
-      ACtx.CompileExpression(AParams[I].DefaultValue, Slot);
-      if ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
-        EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
-      PatchJumpTarget(ACtx, JumpIdx);
-      Continue;
-    end;
-
-    LocalIdx := ACtx.Scope.ResolveLocal(AParams[I].Name);
+      LocalIdx := ACtx.Scope.ResolveLocal(SyntheticParamLocalName(I))
+    else
+      LocalIdx := ACtx.Scope.ResolveLocal(AParams[I].Name);
     if LocalIdx < 0 then
       Continue;
-
     Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
-    EmitUndefinedCheck(ACtx, Slot, JumpIdx);
-    CompileExpressionWithInferredName(ACtx, AParams[I].DefaultValue, Slot,
-      AParams[I].Name);
+    EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, Slot, 0, 0));
     if ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
+  end;
+
+  for I := 0 to High(AParams) do
+  begin
+    if AParams[I].IsPattern then
+      LocalIdx := ACtx.Scope.ResolveLocal(SyntheticParamLocalName(I))
+    else
+      LocalIdx := ACtx.Scope.ResolveLocal(AParams[I].Name);
+    if LocalIdx < 0 then
+      Continue;
+    Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
+    IsCaptured := ACtx.Scope.GetLocal(LocalIdx).IsCaptured;
+
+    if AParams[I].IsRest then
+      EmitInstruction(ACtx, EncodeABC(OP_PACK_ARGS, Slot, UInt8(I), 0))
+    else
+      EmitInstruction(ACtx, EncodeABC(OP_LOAD_ARGUMENT, Slot, UInt8(I), 0));
+    if IsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
+
+    if not Assigned(AParams[I].DefaultValue) then
+      Continue;
+
+    EmitUndefinedCheck(ACtx, Slot, JumpIdx);
+    EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, Slot, 0, 0));
+    if IsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
+    if AParams[I].IsPattern then
+      ACtx.CompileExpression(AParams[I].DefaultValue, Slot)
+    else
+      CompileExpressionWithInferredName(ACtx, AParams[I].DefaultValue, Slot,
+        AParams[I].Name);
+    if IsCaptured then
       EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
     PatchJumpTarget(ACtx, JumpIdx);
   end;
@@ -1774,6 +1820,93 @@ begin
   EmitSetGlobalByName(ACtx, AValueReg, AName);
 end;
 
+function DestructuringPatternHasSuspendingDefault(
+  const APattern: TGocciaDestructuringPattern): Boolean;
+var
+  ArrPat: TGocciaArrayDestructuringPattern;
+  ObjPat: TGocciaObjectDestructuringPattern;
+  AssignPat: TGocciaAssignmentDestructuringPattern;
+  I: Integer;
+begin
+  Result := False;
+  if not Assigned(APattern) then
+    Exit;
+
+  if APattern is TGocciaAssignmentDestructuringPattern then
+  begin
+    AssignPat := TGocciaAssignmentDestructuringPattern(APattern);
+    if (AssignPat.Right is TGocciaYieldExpression) or
+       (AssignPat.Right is TGocciaAwaitExpression) then
+      Exit(True);
+    Exit(DestructuringPatternHasSuspendingDefault(AssignPat.Left));
+  end;
+
+  if APattern is TGocciaArrayDestructuringPattern then
+  begin
+    ArrPat := TGocciaArrayDestructuringPattern(APattern);
+    for I := 0 to ArrPat.Elements.Count - 1 do
+      if DestructuringPatternHasSuspendingDefault(ArrPat.Elements[I]) then
+        Exit(True);
+    Exit;
+  end;
+
+  if APattern is TGocciaObjectDestructuringPattern then
+  begin
+    ObjPat := TGocciaObjectDestructuringPattern(APattern);
+    for I := 0 to ObjPat.Properties.Count - 1 do
+      if DestructuringPatternHasSuspendingDefault(ObjPat.Properties[I].Pattern) then
+        Exit(True);
+  end;
+end;
+
+procedure EmitStreamingArrayDestructuring(const ACtx: TGocciaCompilationContext;
+  const APattern: TGocciaArrayDestructuringPattern; const ASrcReg: UInt8;
+  const AAssignmentMode: Boolean);
+var
+  IterReg, ValueReg, DoneReg, ErrorReg: UInt8;
+  I: Integer;
+  HandlerJump, AfterHandlerJump, SkipCloseJump: Integer;
+begin
+  IterReg := ACtx.Scope.AllocateRegister;
+  ValueReg := ACtx.Scope.AllocateRegister;
+  DoneReg := ACtx.Scope.AllocateRegister;
+  ErrorReg := ACtx.Scope.AllocateRegister;
+  try
+    EmitInstruction(ACtx, EncodeABC(OP_GET_ITER, IterReg, ASrcReg, 0));
+
+    for I := 0 to APattern.Elements.Count - 1 do
+    begin
+      EmitInstruction(ACtx, EncodeABC(OP_ITER_NEXT, ValueReg, DoneReg,
+        IterReg));
+      if not Assigned(APattern.Elements[I]) then
+        Continue;
+
+      HandlerJump := EmitJumpInstruction(ACtx, OP_PUSH_HANDLER, ErrorReg);
+      EmitDestructuring(ACtx, APattern.Elements[I], ValueReg,
+        AAssignmentMode);
+      EmitInstruction(ACtx, EncodeABC(OP_POP_HANDLER, 0, 0, 0));
+      AfterHandlerJump := EmitJumpInstruction(ACtx, OP_JUMP, 0);
+
+      PatchJumpTarget(ACtx, HandlerJump);
+      SkipCloseJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, DoneReg);
+      EmitInstruction(ACtx, EncodeABC(OP_ITER_CLOSE, IterReg, 0, 1));
+      PatchJumpTarget(ACtx, SkipCloseJump);
+      EmitInstruction(ACtx, EncodeABC(OP_THROW, ErrorReg, 0, 0));
+
+      PatchJumpTarget(ACtx, AfterHandlerJump);
+    end;
+
+    SkipCloseJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, DoneReg);
+    EmitInstruction(ACtx, EncodeABC(OP_ITER_CLOSE, IterReg, 0, 0));
+    PatchJumpTarget(ACtx, SkipCloseJump);
+  finally
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+    ACtx.Scope.FreeRegister;
+  end;
+end;
+
 procedure EmitDestructuring(const ACtx: TGocciaCompilationContext;
   const APattern: TGocciaDestructuringPattern; const ASrcReg: UInt8;
   const AAssignmentMode: Boolean);
@@ -1782,8 +1915,9 @@ var
   ArrPat: TGocciaArrayDestructuringPattern;
   AssignPat: TGocciaAssignmentDestructuringPattern;
   IdentPat: TGocciaIdentifierDestructuringPattern;
+  PrivatePat: TGocciaPrivateMemberExpressionDestructuringPattern;
   Prop: TGocciaDestructuringProperty;
-  DestSlot, IdxReg: UInt8;
+  DestSlot, IdxReg, TargetSlot, ValueSlot: UInt8;
   PropIdx: UInt16;
   JumpIdx, I: Integer;
   HasRest: Boolean;
@@ -1854,6 +1988,52 @@ begin
         Break;
       end;
 
+      if AAssignmentMode and
+         (Prop.Pattern is TGocciaPrivateMemberExpressionDestructuringPattern) then
+      begin
+        PrivatePat := TGocciaPrivateMemberExpressionDestructuringPattern(
+          Prop.Pattern);
+        TargetSlot := ACtx.Scope.AllocateRegister;
+        ACtx.CompileExpression(PrivatePat.Expression.ObjectExpr, TargetSlot);
+
+        if Prop.Computed and Assigned(Prop.KeyExpression) then
+        begin
+          if (RestIndex >= 0) and (I < RestIndex) then
+          begin
+            ComputedKeySlot := ACtx.Scope.DeclareLocal(
+              '#object-rest-key:' + IntToStr(ACtx.Template.CodeCount) + ':' +
+              IntToStr(ACtx.Scope.NextSlot) + ':' + IntToStr(I), False);
+            ACtx.CompileExpression(Prop.KeyExpression, UInt8(ComputedKeySlot));
+            EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY,
+              UInt8(ComputedKeySlot), UInt8(ComputedKeySlot), 0));
+            ComputedKeySlots[I] := ComputedKeySlot;
+            ValueSlot := ACtx.Scope.AllocateRegister;
+            EmitInstruction(ACtx, EncodeABC(OP_GET_INDEX, ValueSlot, ASrcReg,
+              UInt8(ComputedKeySlot)));
+          end
+          else
+          begin
+            ValueSlot := ACtx.Scope.AllocateRegister;
+            IdxReg := ACtx.Scope.AllocateRegister;
+            ACtx.CompileExpression(Prop.KeyExpression, IdxReg);
+            EmitInstruction(ACtx, EncodeABC(OP_GET_INDEX, ValueSlot, ASrcReg,
+              IdxReg));
+            ACtx.Scope.FreeRegister;
+          end;
+        end
+        else
+        begin
+          ValueSlot := ACtx.Scope.AllocateRegister;
+          EmitLoadPropertyByName(ACtx, ValueSlot, ASrcReg, Prop.Key);
+        end;
+
+        EmitStorePropertyByName(ACtx, TargetSlot,
+          PrivateKey(ACtx.Scope, PrivatePat.Expression.PrivateName), ValueSlot);
+        ACtx.Scope.FreeRegister;
+        ACtx.Scope.FreeRegister;
+        Continue;
+      end;
+
       if Prop.Computed and Assigned(Prop.KeyExpression) then
       begin
         if (RestIndex >= 0) and (I < RestIndex) then
@@ -1920,6 +2100,11 @@ begin
         RestIndex := I;
         Break;
       end;
+    if (not HasRest) and DestructuringPatternHasSuspendingDefault(ArrPat) then
+    begin
+      EmitStreamingArrayDestructuring(ACtx, ArrPat, ASrcReg, AAssignmentMode);
+      Exit;
+    end;
     // Only HasRest collapses to the unbounded sentinel.  A fixed-size
     // pattern with >= 255 elements would otherwise silently change
     // semantics from "consume exactly N then close" to "drain the whole
@@ -2159,6 +2344,8 @@ begin
   ChildTemplate.IsAsync := AExpr.IsAsync;
   ChildTemplate.IsArrow := True;
   ChildTemplate.StrictCode := ChildBodyIsStrictCode(ACtx, AExpr.Body);
+  ChildTemplate.RejectArgumentsInDirectEval :=
+    OldTemplate.RejectArgumentsInDirectEval;
   ChildTemplate.SourceText := AExpr.SourceText;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
   ChildScope.IsArrow := True;
@@ -2212,7 +2399,8 @@ begin
     ChildCtx.NonStrictMode := ACtx.NonStrictMode and
       not ChildTemplate.StrictCode;
 
-    if RestParamIndex >= 0 then
+    if (RestParamIndex >= 0) and
+       not ParameterListHasDefaultValues(AExpr.Parameters) then
     begin
       RestReg := ChildScope.ResolveLocal(AExpr.Parameters[RestParamIndex].Name);
       EmitInstruction(ChildCtx,
@@ -2233,7 +2421,8 @@ begin
     for I := 0 to ChildScope.UpvalueCount - 1 do
       ChildTemplate.AddUpvalueDescriptor(
         ChildScope.GetUpvalue(I).IsLocal,
-        ChildScope.GetUpvalue(I).Index);
+        ChildScope.GetUpvalue(I).Index,
+        ChildScope.GetUpvalue(I).Name);
   finally
     ACtx.SwapState(OldTemplate, OldScope);
     ChildScope.Free;
@@ -2426,7 +2615,22 @@ begin
   if AExpr.Callee is TGocciaSuperExpression then
   begin
     ObjReg := ACtx.Scope.AllocateRegister;
-    CompileThis(ACtx, ObjReg);
+    ThisLocalIdx := ACtx.Scope.ResolveLocal(KEYWORD_THIS);
+    if ThisLocalIdx >= 0 then
+    begin
+      ThisLocal := ACtx.Scope.GetLocal(ThisLocalIdx);
+      if ThisLocal.Slot <> ObjReg then
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, ObjReg, ThisLocal.Slot, 0));
+    end
+    else
+    begin
+      ThisUpvalIdx := ACtx.Scope.ResolveUpvalue(KEYWORD_THIS);
+      if ThisUpvalIdx >= 0 then
+        EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, ObjReg,
+          UInt16(ThisUpvalIdx)))
+      else
+        CompileThis(ACtx, ObjReg);
+    end;
     BaseReg := ACtx.Scope.AllocateRegister;
     SuperReg := ACtx.Scope.AllocateRegister;
     CompileSuperAccess(ACtx, SuperReg);
@@ -2953,7 +3157,8 @@ begin
     for I := 0 to ChildScope.UpvalueCount - 1 do
       ChildTemplate.AddUpvalueDescriptor(
         ChildScope.GetUpvalue(I).IsLocal,
-        ChildScope.GetUpvalue(I).Index);
+        ChildScope.GetUpvalue(I).Index,
+        ChildScope.GetUpvalue(I).Name);
   finally
     ACtx.SwapState(OldTemplate, OldScope);
     ChildScope.Free;
@@ -3019,7 +3224,8 @@ begin
     for I := 0 to ChildScope.UpvalueCount - 1 do
       ChildTemplate.AddUpvalueDescriptor(
         ChildScope.GetUpvalue(I).IsLocal,
-        ChildScope.GetUpvalue(I).Index);
+        ChildScope.GetUpvalue(I).Index,
+        ChildScope.GetUpvalue(I).Name);
   finally
     ACtx.SwapState(OldTemplate, OldScope);
     ChildScope.Free;
@@ -3082,7 +3288,8 @@ begin
     for I := 0 to ChildScope.UpvalueCount - 1 do
       ChildTemplate.AddUpvalueDescriptor(
         ChildScope.GetUpvalue(I).IsLocal,
-        ChildScope.GetUpvalue(I).Index);
+        ChildScope.GetUpvalue(I).Index,
+        ChildScope.GetUpvalue(I).Name);
   finally
     ACtx.SwapState(OldTemplate, OldScope);
     ChildScope.Free;
@@ -3147,7 +3354,8 @@ begin
     for I := 0 to ChildScope.UpvalueCount - 1 do
       ChildTemplate.AddUpvalueDescriptor(
         ChildScope.GetUpvalue(I).IsLocal,
-        ChildScope.GetUpvalue(I).Index);
+        ChildScope.GetUpvalue(I).Index,
+        ChildScope.GetUpvalue(I).Name);
   finally
     ACtx.SwapState(OldTemplate, OldScope);
     ChildScope.Free;
@@ -3595,7 +3803,10 @@ begin
   KeyReg := ACtx.Scope.AllocateRegister;
   ValReg := ACtx.Scope.AllocateRegister;
 
-  ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
+  if AExpr.ObjectExpr is TGocciaSuperExpression then
+    CompileThis(ACtx, ObjReg)
+  else
+    ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
   ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
   ACtx.CompileExpression(AExpr.Value, ValReg);
 
@@ -3698,7 +3909,8 @@ begin
 
     EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
 
-    if RestParamIndex >= 0 then
+    if (RestParamIndex >= 0) and
+       not ParameterListHasDefaultValues(AExpr.Parameters) then
     begin
       RestReg := ChildScope.ResolveLocal(AExpr.Parameters[RestParamIndex].Name);
       EmitInstruction(ChildCtx,
@@ -3719,7 +3931,8 @@ begin
     for I := 0 to ChildScope.UpvalueCount - 1 do
       ChildTemplate.AddUpvalueDescriptor(
         ChildScope.GetUpvalue(I).IsLocal,
-        ChildScope.GetUpvalue(I).Index);
+        ChildScope.GetUpvalue(I).Index,
+        ChildScope.GetUpvalue(I).Name);
   finally
     ACtx.SwapState(OldTemplate, OldScope);
     ChildScope.Free;
@@ -3741,12 +3954,13 @@ procedure CompileCompoundAssignment(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaCompoundAssignmentExpression; const ADest: UInt8);
 var
   LocalIdx, UpvalIdx: Integer;
-  Slot, RegVal, RegResult, RegTemp, CondReg, ArgReg: UInt8;
+  Slot, RegVal, RegResult, RegTemp, CondReg, ArgReg, ObjReg, KeyReg: UInt8;
   NameIdx: UInt16;
   Op, FloatOp: TGocciaOpCode;
   LocalType, ValType, ResultType: TGocciaLocalType;
   ArithOp: TGocciaTokenType;
-  JumpIdx, OkJump: Integer;
+  I, EndCount, JumpIdx, MissJump, OkJump: Integer;
+  EndJumps: array of Integer;
 begin
   // ES2026 §13.15.2 AssignmentExpression : LeftHandSideExpression ??=/&&=/||= AssignmentExpression
   if IsShortCircuitAssignment(AExpr.Operator) then
@@ -3874,14 +4088,61 @@ begin
 
   if ShouldTryWithBinding(ACtx.Scope, AExpr.Name) then
   begin
+    ObjReg := ACtx.Scope.AllocateRegister;
+    KeyReg := ACtx.Scope.AllocateRegister;
+    CondReg := ACtx.Scope.AllocateRegister;
     RegVal := ACtx.Scope.AllocateRegister;
     RegResult := ACtx.Scope.AllocateRegister;
-    EmitLoadBindingByName(ACtx, AExpr.Name, RegResult, False);
-    ACtx.CompileExpression(AExpr.Value, RegVal);
-    EmitInstruction(ACtx, EncodeABC(Op, ADest, RegResult, RegVal));
-    EmitWithAssignmentOrFallback(ACtx, AExpr.Name, ADest);
-    ACtx.Scope.FreeRegister;
-    ACtx.Scope.FreeRegister;
+    EndCount := 0;
+    SetLength(EndJumps, ACtx.Scope.WithBindingCount);
+    try
+      NameIdx := ACtx.Template.AddConstantString(AExpr.Name);
+      EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, KeyReg, NameIdx));
+
+      for I := ACtx.Scope.WithBindingCount - 1 downto 0 do
+      begin
+        EmitLoadHiddenWithObject(ACtx, ACtx.Scope.GetWithBindingName(I), ObjReg);
+        EmitInstruction(ACtx, EncodeABC(OP_HAS_WITH_BINDING, CondReg, ObjReg,
+          KeyReg));
+        MissJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_FALSE, CondReg);
+        EmitInstruction(ACtx, EncodeABC(OP_GET_INDEX, RegResult, ObjReg,
+          KeyReg));
+        ACtx.CompileExpression(AExpr.Value, RegVal);
+        EmitInstruction(ACtx, EncodeABC(Op, ADest, RegResult, RegVal));
+        if not ACtx.NonStrictMode then
+        begin
+          EmitInstruction(ACtx, EncodeABC(OP_HAS_WITH_BINDING, CondReg,
+            ObjReg, KeyReg));
+          OkJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, CondReg);
+          EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, CondReg,
+            ACtx.Template.AddConstantString(REFERENCE_ERROR_NAME)));
+          EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, RegVal,
+            ACtx.Template.AddConstantString(AExpr.Name + ' is not defined')));
+          EmitInstruction(ACtx, EncodeABC(OP_CONSTRUCT, CondReg, CondReg, 1));
+          EmitInstruction(ACtx, EncodeABC(OP_THROW, CondReg, 0, 0));
+          PatchJumpTarget(ACtx, OkJump);
+        end;
+        EmitInstruction(ACtx, EncodeABC(StoreByKeyOpcode(ACtx), ObjReg, KeyReg,
+          ADest));
+        EndJumps[EndCount] := EmitJumpInstruction(ACtx, OP_JUMP, 0);
+        Inc(EndCount);
+        PatchJumpTarget(ACtx, MissJump);
+      end;
+
+      EmitLoadBindingByName(ACtx, AExpr.Name, RegResult, False);
+      ACtx.CompileExpression(AExpr.Value, RegVal);
+      EmitInstruction(ACtx, EncodeABC(Op, ADest, RegResult, RegVal));
+      EmitWithAssignmentOrFallback(ACtx, AExpr.Name, ADest);
+
+      for I := 0 to EndCount - 1 do
+        PatchJumpTarget(ACtx, EndJumps[I]);
+    finally
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+    end;
     Exit;
   end;
 
@@ -3989,8 +4250,7 @@ begin
 
   RegVal := ACtx.Scope.AllocateRegister;
   RegResult := ACtx.Scope.AllocateRegister;
-  EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, RegResult,
-    ACtx.Template.AddConstantString(AExpr.Name)));
+  EmitLoadBindingByName(ACtx, AExpr.Name, RegResult, False);
   ACtx.CompileExpression(AExpr.Value, RegVal);
   EmitInstruction(ACtx, EncodeABC(Op, ADest, RegResult, RegVal));
   EmitSetGlobalByName(ACtx, ADest, AExpr.Name);
@@ -4064,6 +4324,9 @@ begin
 
     ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
     ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
+    EmitInstruction(ACtx, EncodeABC(OP_VALIDATE_VALUE, ObjReg,
+      VALIDATE_OP_REQUIRE_OBJECT, 0));
+    EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
     EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
     JumpIdx := EmitJumpInstruction(ACtx, ShortCircuitJumpOp(AExpr.Operator), CurReg);
     ACtx.CompileExpression(AExpr.Value, CurReg);
@@ -4088,6 +4351,9 @@ begin
 
   ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
   ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
+  EmitInstruction(ACtx, EncodeABC(OP_VALIDATE_VALUE, ObjReg,
+    VALIDATE_OP_REQUIRE_OBJECT, 0));
+  EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
   EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
   ACtx.CompileExpression(AExpr.Value, ValReg);
   EmitInstruction(ACtx, EncodeABC(Op, CurReg, CurReg, ValReg));
@@ -4276,15 +4542,92 @@ begin
   ACtx.Scope.FreeRegister;
 end;
 
+procedure AddOptionalChainJump(const ACtx: TGocciaCompilationContext;
+  var AJumps: TGocciaCompilerJumpArray; var AJumpCount: Integer;
+  const AReg: UInt8);
+begin
+  if AJumpCount >= Length(AJumps) then
+    SetLength(AJumps, AJumpCount * 2 + 4);
+  AJumps[AJumpCount] := EmitJumpInstruction(ACtx, OP_JUMP_IF_NULLISH, AReg);
+  Inc(AJumpCount);
+end;
+
+procedure CompileExpressionWithOptionalChainJumps(
+  const ACtx: TGocciaCompilationContext; const AExpr: TGocciaExpression;
+  const ADest: UInt8; var AJumps: TGocciaCompilerJumpArray;
+  var AJumpCount: Integer);
+var
+  MemberExpr: TGocciaMemberExpression;
+  PrivateExpr: TGocciaPrivateMemberExpression;
+  ObjReg, IdxReg: UInt8;
+begin
+  if AExpr is TGocciaMemberExpression then
+  begin
+    MemberExpr := TGocciaMemberExpression(AExpr);
+    ObjReg := ACtx.Scope.AllocateRegister;
+    CompileExpressionWithOptionalChainJumps(ACtx, MemberExpr.ObjectExpr,
+      ObjReg, AJumps, AJumpCount);
+    if MemberExpr.Optional then
+      AddOptionalChainJump(ACtx, AJumps, AJumpCount, ObjReg);
+
+    if MemberExpr.Computed then
+    begin
+      IdxReg := ACtx.Scope.AllocateRegister;
+      ACtx.CompileExpression(MemberExpr.PropertyExpression, IdxReg);
+      EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, ADest, ObjReg, IdxReg));
+      ACtx.Scope.FreeRegister;
+    end
+    else
+      EmitLoadPropertyByName(ACtx, ADest, ObjReg, MemberExpr.PropertyName);
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
+  if AExpr is TGocciaPrivateMemberExpression then
+  begin
+    PrivateExpr := TGocciaPrivateMemberExpression(AExpr);
+    ObjReg := ACtx.Scope.AllocateRegister;
+    CompileExpressionWithOptionalChainJumps(ACtx, PrivateExpr.ObjectExpr,
+      ObjReg, AJumps, AJumpCount);
+    if PrivateExpr.Optional then
+      AddOptionalChainJump(ACtx, AJumps, AJumpCount, ObjReg);
+    EmitLoadPropertyByName(ACtx, ADest, ObjReg,
+      PrivateKey(ACtx.Scope, PrivateExpr.PrivateName));
+    ACtx.Scope.FreeRegister;
+    Exit;
+  end;
+
+  ACtx.CompileExpression(AExpr, ADest);
+end;
+
 procedure CompilePrivateMember(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaPrivateMemberExpression; const ADest: UInt8);
 var
   ObjReg: UInt8;
+  EndJump: Integer;
+  NullishJumps: TGocciaCompilerJumpArray;
+  NullishJumpCount: Integer;
+  I: Integer;
 begin
   ObjReg := ACtx.Scope.AllocateRegister;
-  ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
+  NullishJumpCount := 0;
+  CompileExpressionWithOptionalChainJumps(ACtx, AExpr.ObjectExpr, ObjReg,
+    NullishJumps, NullishJumpCount);
+  if AExpr.Optional then
+    AddOptionalChainJump(ACtx, NullishJumps, NullishJumpCount, ObjReg);
+
   EmitLoadPropertyByName(ACtx, ADest, ObjReg,
     PrivateKey(ACtx.Scope, AExpr.PrivateName));
+  if NullishJumpCount > 0 then
+  begin
+    EndJump := EmitJumpInstruction(ACtx, OP_JUMP, 0);
+    for I := 0 to NullishJumpCount - 1 do
+      PatchJumpTarget(ACtx, NullishJumps[I]);
+    EmitInstruction(ACtx, EncodeABC(OP_LOAD_UNDEFINED, ADest, 0, 0));
+    PatchJumpTarget(ACtx, EndJump);
+  end
+  else
+    SetLength(NullishJumps, 0);
   ACtx.Scope.FreeRegister;
 end;
 
@@ -4361,6 +4704,8 @@ begin
   if LocalIdx >= 0 then
   begin
     Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
+    if ACtx.DerivedConstructorThisGuard then
+      EmitInstruction(ACtx, EncodeABC(OP_CHECK_DERIVED_THIS, 0, 0, 0));
     if Slot <> ADest then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));
     Exit;
@@ -4369,6 +4714,8 @@ begin
   UpvalIdx := ACtx.Scope.ResolveUpvalue(KEYWORD_THIS);
   if UpvalIdx >= 0 then
   begin
+    if ACtx.DerivedConstructorThisGuard then
+      EmitInstruction(ACtx, EncodeABC(OP_CHECK_DERIVED_THIS, 0, 0, 0));
     EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, ADest, UInt16(UpvalIdx)));
     Exit;
   end;

--- a/source/units/Goccia.Compiler.Scope.pas
+++ b/source/units/Goccia.Compiler.Scope.pas
@@ -35,6 +35,7 @@ type
   end;
 
   TGocciaCompilerUpvalue = record
+    Name: string;
     Index: UInt8;
     IsLocal: Boolean;
     IsConst: Boolean;
@@ -78,7 +79,7 @@ type
     function DeclareVarLocal(const AName: string): UInt8;
     function ResolveLocal(const AName: string): Integer;
     function ResolveUpvalue(const AName: string): Integer;
-    function AddUpvalue(const AIndex: UInt8;
+    function AddUpvalue(const AName: string; const AIndex: UInt8;
       const AIsLocal: Boolean; const AIsConst: Boolean = False;
       const AIsVar: Boolean = False): Integer;
 
@@ -324,7 +325,7 @@ begin
   if LocalIdx >= 0 then
   begin
     FParent.MarkCaptured(LocalIdx);
-    Idx := AddUpvalue(FParent.FLocals[LocalIdx].Slot, True,
+    Idx := AddUpvalue(AName, FParent.FLocals[LocalIdx].Slot, True,
       FParent.FLocals[LocalIdx].IsConst, FParent.FLocals[LocalIdx].IsVar);
     FUpvalues[Idx].IsGlobalBacked := FParent.FLocals[LocalIdx].IsGlobalBacked;
     FUpvalues[Idx].TypeHint := FParent.FLocals[LocalIdx].TypeHint;
@@ -342,7 +343,7 @@ begin
   begin
     if UpvalueIdx > High(UInt8) then
       raise Exception.Create('Compiler error: upvalue index overflow (>255)');
-    Idx := AddUpvalue(UInt8(UpvalueIdx), False,
+    Idx := AddUpvalue(AName, UInt8(UpvalueIdx), False,
       FParent.FUpvalues[UpvalueIdx].IsConst,
       FParent.FUpvalues[UpvalueIdx].IsVar);
     FUpvalues[Idx].IsGlobalBacked := FParent.FUpvalues[UpvalueIdx].IsGlobalBacked;
@@ -356,7 +357,7 @@ begin
   Result := -1;
 end;
 
-function TGocciaCompilerScope.AddUpvalue(const AIndex: UInt8;
+function TGocciaCompilerScope.AddUpvalue(const AName: string; const AIndex: UInt8;
   const AIsLocal: Boolean; const AIsConst: Boolean;
   const AIsVar: Boolean): Integer;
 var
@@ -370,6 +371,7 @@ begin
     raise Exception.Create('Compiler error: upvalue count overflow (>255)');
   if FUpvalueCount >= Length(FUpvalues) then
     SetLength(FUpvalues, FUpvalueCount * 2 + 4);
+  FUpvalues[FUpvalueCount].Name := AName;
   FUpvalues[FUpvalueCount].Index := AIndex;
   FUpvalues[FUpvalueCount].IsLocal := AIsLocal;
   FUpvalues[FUpvalueCount].IsConst := AIsConst;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -847,12 +847,6 @@ begin
 
     if IsTopLevelGlobalBacked then
     begin
-      if not AStmt.IsVar then
-      begin
-        LocalIdx := FindLocalBySlot(ACtx.Scope, Info.Name, Slot);
-        if LocalIdx >= 0 then
-          ACtx.Scope.MarkGlobalBacked(LocalIdx);
-      end;
       EmitGlobalDefine(ACtx, Slot, Info.Name, AStmt.IsConst, AStmt.IsVar,
         HasInitializer);
     end;
@@ -1297,7 +1291,7 @@ begin
       AEmitInitializers)
   else if ANode is TGocciaClassDeclaration then
     PredeclareBlockNamedLexicalLocal(ACtx,
-      TGocciaClassDeclaration(ANode).ClassDefinition.Name, True,
+      TGocciaClassDeclaration(ANode).ClassDefinition.Name, False,
       AEmitInitializers)
   else if ANode is TGocciaEnumDeclaration then
     PredeclareBlockNamedLexicalLocal(ACtx,
@@ -2578,9 +2572,10 @@ begin
     LoopStart := CurrentCodePosition(ACtx);
     MismatchJump := -1;
 
-    EmitInstruction(ACtx, EncodeABC(OP_ITER_NEXT, ValueReg, DoneReg, IterReg));
-    ExitJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, DoneReg);
+    EmitInstruction(ACtx, EncodeABC(OP_ASYNC_ITER_NEXT, ValueReg, 0, IterReg));
     EmitInstruction(ACtx, EncodeABC(OP_AWAIT, ValueReg, ValueReg, 0));
+    EmitInstruction(ACtx, EncodeABC(OP_ITER_UNPACK, ValueReg, DoneReg, ValueReg));
+    ExitJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, DoneReg);
 
     ACtx.Scope.BeginScope;
     SetLoopContinueScopeDepth(ACtx);
@@ -3987,9 +3982,29 @@ begin
   GContinueJumps.Add(EmitJumpInstruction(ACtx, OP_JUMP, 0));
 end;
 
+function DisplayClassElementName(const AStorageName: string): string;
+var
+  I, SeparatorIndex: Integer;
+begin
+  if Pos('#slot:', AStorageName) = 1 then
+  begin
+    SeparatorIndex := 0;
+    for I := Length(AStorageName) downto 1 do
+      if AStorageName[I] = '$' then
+      begin
+        SeparatorIndex := I;
+        Break;
+      end;
+    if SeparatorIndex > 0 then
+      Exit('#' + Copy(AStorageName, SeparatorIndex + 1, MaxInt));
+  end;
+  Result := AStorageName;
+end;
+
 procedure CompileMethodBody(const ACtx: TGocciaCompilationContext;
   const AClassReg: UInt8; const AMethodName: string;
-  const AMethod: TGocciaClassMethod; const AStoreOpcode: TGocciaOpCode);
+  const AMethod: TGocciaClassMethod; const AStoreOpcode: TGocciaOpCode;
+  const AGuardDerivedThis: Boolean = False);
 var
   OldTemplate: TGocciaFunctionTemplate;
   OldScope: TGocciaCompilerScope;
@@ -4001,12 +4016,15 @@ var
   MethodNameIdx: UInt16;
   FormalCount, RestParamIndex, I: Integer;
   ArgumentsSlot: Integer;
+  DisplayName: string;
+  OldDerivedGuard: Boolean;
 begin
   OldTemplate := ACtx.Template;
   OldScope := ACtx.Scope;
+  OldDerivedGuard := ACtx.DerivedConstructorThisGuard;
+  DisplayName := DisplayClassElementName(AMethodName);
 
-  ChildTemplate := TGocciaFunctionTemplate.Create(
-    '<method ' + AMethodName + '>');
+  ChildTemplate := TGocciaFunctionTemplate.Create(DisplayName);
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
   ChildTemplate.IsAsync := AMethod.IsAsync;
   ChildTemplate.IsGenerator := AMethod.IsGenerator;
@@ -4044,6 +4062,8 @@ begin
     ACtx.FormalParameterCounts.AddOrSetValue(ChildTemplate, FormalCount);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
+  if Assigned(ACtx.SetDerivedConstructorThisGuard) then
+    ACtx.SetDerivedConstructorThisGuard(AGuardDerivedThis);
   EmitLineMapping(ACtx, AMethod.Line, AMethod.Column);
 
   ChildCtx := ACtx;
@@ -4051,10 +4071,12 @@ begin
   ChildCtx.Scope := ChildScope;
   ChildCtx.NonStrictMode := ACtx.NonStrictMode and
     not ChildTemplate.StrictCode;
+  ChildCtx.DerivedConstructorThisGuard := AGuardDerivedThis;
 
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
 
-  if RestParamIndex >= 0 then
+  if (RestParamIndex >= 0) and
+     not ParameterListHasDefaultValues(AMethod.Parameters) then
     EmitInstruction(ChildCtx, EncodeABC(OP_PACK_ARGS,
       UInt8(ChildScope.ResolveLocal(
         AMethod.Parameters[RestParamIndex].Name)),
@@ -4072,8 +4094,11 @@ begin
   for I := 0 to ChildScope.UpvalueCount - 1 do
     ChildTemplate.AddUpvalueDescriptor(
       ChildScope.GetUpvalue(I).IsLocal,
-      ChildScope.GetUpvalue(I).Index);
+      ChildScope.GetUpvalue(I).Index,
+      ChildScope.GetUpvalue(I).Name);
 
+  if Assigned(ACtx.SetDerivedConstructorThisGuard) then
+    ACtx.SetDerivedConstructorThisGuard(OldDerivedGuard);
   ACtx.SwapState(OldTemplate, OldScope);
   ChildScope.Free;
 
@@ -4105,11 +4130,13 @@ var
   EmptyParams: TGocciaParameterArray;
   ArgumentsSlot: Integer;
   I: Integer;
+  DisplayName: string;
 begin
   OldTemplate := ACtx.Template;
   OldScope := ACtx.Scope;
+  DisplayName := DisplayClassElementName(AName);
 
-  ChildTemplate := TGocciaFunctionTemplate.Create('<get ' + AName + '>');
+  ChildTemplate := TGocciaFunctionTemplate.Create('get ' + DisplayName);
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
   ChildTemplate.SourceText := AGetter.SourceText;
   ChildTemplate.ParameterCount := 0;
@@ -4132,7 +4159,8 @@ begin
   for I := 0 to ChildScope.UpvalueCount - 1 do
     ChildTemplate.AddUpvalueDescriptor(
       ChildScope.GetUpvalue(I).IsLocal,
-      ChildScope.GetUpvalue(I).Index);
+      ChildScope.GetUpvalue(I).Index,
+      ChildScope.GetUpvalue(I).Name);
 
   ACtx.SwapState(OldTemplate, OldScope);
   ChildScope.Free;
@@ -4171,20 +4199,40 @@ var
   NameIdx: UInt16;
   SetterParams: TGocciaParameterArray;
   ArgumentsSlot: Integer;
-  I: Integer;
+  FormalCount, I: Integer;
+  DisplayName: string;
 begin
   OldTemplate := ACtx.Template;
   OldScope := ACtx.Scope;
+  DisplayName := DisplayClassElementName(AName);
 
-  ChildTemplate := TGocciaFunctionTemplate.Create('<set ' + AName + '>');
+  ChildTemplate := TGocciaFunctionTemplate.Create('set ' + DisplayName);
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
   ChildTemplate.SourceText := ASetter.SourceText;
-  ChildTemplate.ParameterCount := 1;
+  SetterParams := ASetter.Parameters;
+  if Length(SetterParams) = 0 then
+  begin
+    SetLength(SetterParams, 1);
+    SetterParams[0].Name := ASetter.Parameter;
+  end;
+  ChildTemplate.ParameterCount := Length(SetterParams);
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
-  ChildScope.DeclareLocal(ASetter.Parameter, False);
-  SetLength(SetterParams, 1);
-  SetterParams[0].Name := ASetter.Parameter;
+  for I := 0 to High(SetterParams) do
+    if SetterParams[I].IsPattern then
+      ChildScope.DeclareLocal(SyntheticParamLocalName(I), False)
+    else
+      ChildScope.DeclareLocal(SetterParams[I].Name, False);
+  for I := 0 to High(SetterParams) do
+    if SetterParams[I].IsPattern and Assigned(SetterParams[I].Pattern) then
+      CollectDestructuringBindings(SetterParams[I].Pattern, ChildScope);
+  FormalCount := Length(SetterParams);
+  if (Length(SetterParams) > 0) and
+     (SetterParams[0].IsRest or Assigned(SetterParams[0].DefaultValue)) then
+    FormalCount := 0;
+  ChildTemplate.FormalParameterCount := UInt8(FormalCount);
+  if Assigned(ACtx.FormalParameterCounts) then
+    ACtx.FormalParameterCounts.AddOrSetValue(ChildTemplate, FormalCount);
   ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
@@ -4195,13 +4243,19 @@ begin
     not ChildTemplate.StrictCode;
   EmitLineMapping(ChildCtx, ASetter.Line, ASetter.Column);
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
+  EmitDefaultParameters(ChildCtx, SetterParams);
+  EmitDestructuringParameters(ChildCtx, SetterParams);
+  if ChildTemplate.CodeCount > High(UInt16) then
+    raise Exception.Create('Parameter preamble is too large to encode');
+  ChildTemplate.ParameterPreambleSize := UInt16(ChildTemplate.CodeCount);
   ACtx.CompileFunctionBody(ASetter.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
 
   for I := 0 to ChildScope.UpvalueCount - 1 do
     ChildTemplate.AddUpvalueDescriptor(
       ChildScope.GetUpvalue(I).IsLocal,
-      ChildScope.GetUpvalue(I).Index);
+      ChildScope.GetUpvalue(I).Index,
+      ChildScope.GetUpvalue(I).Name);
 
   ACtx.SwapState(OldTemplate, OldScope);
   ChildScope.Free;
@@ -4266,7 +4320,8 @@ begin
   for I := 0 to ChildScope.UpvalueCount - 1 do
     ChildTemplate.AddUpvalueDescriptor(
       ChildScope.GetUpvalue(I).IsLocal,
-      ChildScope.GetUpvalue(I).Index);
+      ChildScope.GetUpvalue(I).Index,
+      ChildScope.GetUpvalue(I).Name);
 
   ACtx.SwapState(OldTemplate, OldScope);
   ChildScope.Free;
@@ -4274,6 +4329,8 @@ begin
   FuncIdx := OldTemplate.AddFunction(ChildTemplate);
   FnReg := ACtx.Scope.AllocateRegister;
   EmitInstruction(ACtx, EncodeABx(OP_CLOSURE, FnReg, FuncIdx));
+  EmitInstruction(ACtx, EncodeABC(OP_SET_FUNCTION_NAME, FnReg, AKeyReg,
+    FUNCTION_NAME_PREFIX_GET));
 
   TargetReg := ACtx.Scope.AllocateRegister;
   AccessorReg := ACtx.Scope.AllocateRegister;
@@ -4301,19 +4358,37 @@ var
   FnReg, TargetReg, AccessorReg: UInt8;
   SetterParams: TGocciaParameterArray;
   ArgumentsSlot: Integer;
-  I: Integer;
+  FormalCount, I: Integer;
 begin
   OldTemplate := ACtx.Template;
   OldScope := ACtx.Scope;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('<set [computed]>');
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
-  ChildTemplate.ParameterCount := 1;
+  SetterParams := ASetter.Parameters;
+  if Length(SetterParams) = 0 then
+  begin
+    SetLength(SetterParams, 1);
+    SetterParams[0].Name := ASetter.Parameter;
+  end;
+  ChildTemplate.ParameterCount := Length(SetterParams);
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
-  ChildScope.DeclareLocal(ASetter.Parameter, False);
-  SetLength(SetterParams, 1);
-  SetterParams[0].Name := ASetter.Parameter;
+  for I := 0 to High(SetterParams) do
+    if SetterParams[I].IsPattern then
+      ChildScope.DeclareLocal(SyntheticParamLocalName(I), False)
+    else
+      ChildScope.DeclareLocal(SetterParams[I].Name, False);
+  for I := 0 to High(SetterParams) do
+    if SetterParams[I].IsPattern and Assigned(SetterParams[I].Pattern) then
+      CollectDestructuringBindings(SetterParams[I].Pattern, ChildScope);
+  FormalCount := Length(SetterParams);
+  if (Length(SetterParams) > 0) and
+     (SetterParams[0].IsRest or Assigned(SetterParams[0].DefaultValue)) then
+    FormalCount := 0;
+  ChildTemplate.FormalParameterCount := UInt8(FormalCount);
+  if Assigned(ACtx.FormalParameterCounts) then
+    ACtx.FormalParameterCounts.AddOrSetValue(ChildTemplate, FormalCount);
   ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
@@ -4324,13 +4399,19 @@ begin
     not ChildTemplate.StrictCode;
   EmitLineMapping(ChildCtx, ASetter.Line, ASetter.Column);
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
+  EmitDefaultParameters(ChildCtx, SetterParams);
+  EmitDestructuringParameters(ChildCtx, SetterParams);
+  if ChildTemplate.CodeCount > High(UInt16) then
+    raise Exception.Create('Parameter preamble is too large to encode');
+  ChildTemplate.ParameterPreambleSize := UInt16(ChildTemplate.CodeCount);
   ACtx.CompileFunctionBody(ASetter.Body);
   ChildTemplate.MaxRegisters := ChildScope.MaxSlot;
 
   for I := 0 to ChildScope.UpvalueCount - 1 do
     ChildTemplate.AddUpvalueDescriptor(
       ChildScope.GetUpvalue(I).IsLocal,
-      ChildScope.GetUpvalue(I).Index);
+      ChildScope.GetUpvalue(I).Index,
+      ChildScope.GetUpvalue(I).Name);
 
   ACtx.SwapState(OldTemplate, OldScope);
   ChildScope.Free;
@@ -4338,6 +4419,8 @@ begin
   FuncIdx := OldTemplate.AddFunction(ChildTemplate);
   FnReg := ACtx.Scope.AllocateRegister;
   EmitInstruction(ACtx, EncodeABx(OP_CLOSURE, FnReg, FuncIdx));
+  EmitInstruction(ACtx, EncodeABC(OP_SET_FUNCTION_NAME, FnReg, AKeyReg,
+    FUNCTION_NAME_PREFIX_SET));
 
   TargetReg := ACtx.Scope.AllocateRegister;
   AccessorReg := ACtx.Scope.AllocateRegister;
@@ -4417,7 +4500,8 @@ begin
 
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
 
-  if RestParamIndex >= 0 then
+  if (RestParamIndex >= 0) and
+     not ParameterListHasDefaultValues(AMethod.Parameters) then
     EmitInstruction(ChildCtx, EncodeABC(OP_PACK_ARGS,
       UInt8(ChildScope.ResolveLocal(
         AMethod.Parameters[RestParamIndex].Name)),
@@ -4435,7 +4519,8 @@ begin
   for I := 0 to ChildScope.UpvalueCount - 1 do
     ChildTemplate.AddUpvalueDescriptor(
       ChildScope.GetUpvalue(I).IsLocal,
-      ChildScope.GetUpvalue(I).Index);
+      ChildScope.GetUpvalue(I).Index,
+      ChildScope.GetUpvalue(I).Name);
 
   ACtx.SwapState(OldTemplate, OldScope);
   ChildScope.Free;
@@ -4443,6 +4528,8 @@ begin
   FuncIdx := OldTemplate.AddFunction(ChildTemplate);
   FnReg := ACtx.Scope.AllocateRegister;
   EmitInstruction(ACtx, EncodeABx(OP_CLOSURE, FnReg, FuncIdx));
+  EmitInstruction(ACtx, EncodeABC(OP_SET_FUNCTION_NAME, FnReg, AKeyReg,
+    FUNCTION_NAME_PREFIX_NONE));
 
   if AIsStatic then
     // Static: class[key] = method
@@ -4570,6 +4657,57 @@ begin
   Result := False;
 end;
 
+function IsAnonymousFunctionNameInitializer(
+  const AExpression: TGocciaExpression): Boolean;
+begin
+  Result := (AExpression is TGocciaArrowFunctionExpression) or
+    ((AExpression is TGocciaFunctionExpression) and
+     (TGocciaFunctionExpression(AExpression).Name = '')) or
+    ((AExpression is TGocciaClassExpression) and
+     (TGocciaClassExpression(AExpression).ClassDefinition.Name = ''));
+end;
+
+function ClassFieldInferredName(const AElement: TGocciaClassElement): string;
+begin
+  if AElement.IsComputed then
+    Exit('');
+  if AElement.IsPrivate then
+    Exit('#' + AElement.Name);
+  Result := AElement.Name;
+end;
+
+procedure CompileFieldValueWithInferredName(
+  const ACtx: TGocciaCompilationContext; const AExpression: TGocciaExpression;
+  const ADest: UInt8; const AInferredName: string);
+begin
+  if not Assigned(AExpression) then
+  begin
+    EmitInstruction(ACtx, EncodeABx(OP_LOAD_UNDEFINED, ADest, 0));
+    Exit;
+  end;
+
+  Goccia.Compiler.Expressions.CompileExpressionWithInferredName(
+    ACtx, AExpression, ADest, AInferredName);
+end;
+
+procedure CompileStaticFieldInitializerExpression(
+  const ACtx: TGocciaCompilationContext; const AClassReg: UInt8;
+  const AExpression: TGocciaExpression; const ADest: UInt8;
+  const AInferredName: string = '');
+var
+  ClosedLocals: array[0..0] of UInt8;
+  ClosedCount, I: Integer;
+  ThisReg: UInt8;
+begin
+  ACtx.Scope.BeginScope;
+  ThisReg := ACtx.Scope.DeclareLocal(KEYWORD_THIS, False);
+  EmitInstruction(ACtx, EncodeABC(OP_MOVE, ThisReg, AClassReg, 0));
+  CompileFieldValueWithInferredName(ACtx, AExpression, ADest, AInferredName);
+  ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
+  for I := 0 to ClosedCount - 1 do
+    EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+end;
+
 procedure RegisterPrivateName(const AScope: TGocciaCompilerScope;
   const AName, APrefix: string);
 begin
@@ -4630,9 +4768,9 @@ var
   I, UpvalueIdx: Integer;
   Entry: TGocciaExpressionMap.TKeyValuePair;
   Elem: TGocciaClassElement;
-  FieldExpr: TGocciaExpression;
   ComputedKeyName: string;
   AccessorBackingName: string;
+  StoreOpcode: TGocciaOpCode;
 begin
   OldTemplate := ACtx.Template;
   OldScope := ACtx.Scope;
@@ -4640,6 +4778,7 @@ begin
   ChildTemplate := TGocciaFunctionTemplate.Create('<fields>');
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
   ChildTemplate.ParameterCount := 0;
+  ChildTemplate.RejectArgumentsInDirectEval := True;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
 
   ThisReg := ChildScope.DeclareLocal(KEYWORD_THIS, False);
@@ -4659,10 +4798,8 @@ begin
       ValReg := ChildScope.AllocateRegister;
       if AClassDef.FFieldOrder[I].IsComputed then
       begin
-        if Assigned(AClassDef.FFieldOrder[I].FieldInitializer) then
-          ACtx.CompileExpression(AClassDef.FFieldOrder[I].FieldInitializer, ValReg)
-        else
-          EmitInstruction(ChildCtx, EncodeABx(OP_LOAD_UNDEFINED, ValReg, 0));
+        CompileFieldValueWithInferredName(ChildCtx,
+          AClassDef.FFieldOrder[I].FieldInitializer, ValReg, '');
         KeyReg := ChildScope.AllocateRegister;
         ComputedKeyName := FindComputedFieldKeyLocalName(
           AComputedFieldKeyLocals, AClassDef.FFieldOrder[I].ElementIndex);
@@ -4671,6 +4808,10 @@ begin
           raise Exception.Create('Compiler error: computed class field key was not captured');
         EmitInstruction(ChildCtx, EncodeABx(OP_GET_UPVALUE, KeyReg,
           UInt16(UpvalueIdx)));
+        if IsAnonymousFunctionNameInitializer(
+           AClassDef.FFieldOrder[I].FieldInitializer) then
+          EmitInstruction(ChildCtx, EncodeABC(OP_SET_FUNCTION_NAME, ValReg,
+            KeyReg, 0));
         EmitInstruction(ChildCtx, EncodeABC(OP_DEFINE_PROP_DYNAMIC, ThisReg,
           KeyReg, ValReg));
         ChildScope.FreeRegister;
@@ -4679,22 +4820,24 @@ begin
       end
       else if AClassDef.FFieldOrder[I].IsPrivate then
       begin
-        if AClassDef.PrivateInstanceProperties.TryGetValue(
-            AClassDef.FFieldOrder[I].Name, FieldExpr) then
-          ACtx.CompileExpression(FieldExpr, ValReg);
+        CompileFieldValueWithInferredName(ChildCtx,
+          AClassDef.FFieldOrder[I].FieldInitializer, ValReg,
+          '#' + AClassDef.FFieldOrder[I].Name);
         KeyIdx := ChildTemplate.AddConstantString(
           '#slot:' + ChildScope.ResolvePrivatePrefix + AClassDef.FFieldOrder[I].Name);
+        StoreOpcode := OP_DEFINE_STATIC_PROP_CONST;
       end
       else
       begin
-        if AClassDef.InstanceProperties.TryGetValue(
-            AClassDef.FFieldOrder[I].Name, FieldExpr) then
-          ACtx.CompileExpression(FieldExpr, ValReg);
+        CompileFieldValueWithInferredName(ChildCtx,
+          AClassDef.FFieldOrder[I].FieldInitializer, ValReg,
+          AClassDef.FFieldOrder[I].Name);
         KeyIdx := ChildTemplate.AddConstantString(AClassDef.FFieldOrder[I].Name);
+        StoreOpcode := OP_DEFINE_STATIC_PROP_CONST;
       end;
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: field name index exceeds 255');
-      EmitInstruction(ChildCtx, EncodeABC(OP_SET_PROP_CONST, ThisReg,
+      EmitInstruction(ChildCtx, EncodeABC(StoreOpcode, ThisReg,
         UInt8(KeyIdx), ValReg));
       ChildScope.FreeRegister;
     end;
@@ -4709,7 +4852,7 @@ begin
       KeyIdx := ChildTemplate.AddConstantString(Entry.Key);
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: field name index exceeds 255');
-      EmitInstruction(ChildCtx, EncodeABC(OP_SET_PROP_CONST, ThisReg,
+      EmitInstruction(ChildCtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ThisReg,
         UInt8(KeyIdx), ValReg));
       ChildScope.FreeRegister;
     end;
@@ -4722,7 +4865,7 @@ begin
       KeyIdx := ChildTemplate.AddConstantString('#slot:' + ChildScope.ResolvePrivatePrefix + Entry.Key);
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: field name index exceeds 255');
-      EmitInstruction(ChildCtx, EncodeABC(OP_SET_PROP_CONST, ThisReg,
+      EmitInstruction(ChildCtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ThisReg,
         UInt8(KeyIdx), ValReg));
       ChildScope.FreeRegister;
     end;
@@ -4752,7 +4895,8 @@ begin
   for I := 0 to ChildScope.UpvalueCount - 1 do
     ChildTemplate.AddUpvalueDescriptor(
       ChildScope.GetUpvalue(I).IsLocal,
-      ChildScope.GetUpvalue(I).Index);
+      ChildScope.GetUpvalue(I).Index,
+      ChildScope.GetUpvalue(I).Name);
 
   ACtx.SwapState(OldTemplate, OldScope);
   ChildScope.Free;
@@ -4807,7 +4951,8 @@ begin
   for I := 0 to ChildScope.UpvalueCount - 1 do
     ChildTemplate.AddUpvalueDescriptor(
       ChildScope.GetUpvalue(I).IsLocal,
-      ChildScope.GetUpvalue(I).Index);
+      ChildScope.GetUpvalue(I).Index,
+      ChildScope.GetUpvalue(I).Name);
 
   ACtx.SwapState(OldTemplate, OldScope);
   ChildScope.Free;
@@ -5055,15 +5200,20 @@ var
   GetterPair: TGocciaGetterExpressionMap.TKeyValuePair;
   SetterPair: TGocciaSetterExpressionMap.TKeyValuePair;
   StaticPropPair: TGocciaExpressionMap.TKeyValuePair;
-  I, LocalIdx, UpvalIdx: Integer;
+  I, ClassLocalIdx, LocalIdx, UpvalIdx: Integer;
   HasSuper: Boolean;
   PrivPrefix: string;
   PrivateNameMark: Integer;
   ComputedFieldKeyLocals: TComputedFieldKeyLocals;
   ComputedKeyName: string;
+  InnerNameSlot: UInt8;
+  HasInnerNameBinding: Boolean;
+  ClosedLocals: array[0..255] of UInt8;
+  ClosedCount: Integer;
 begin
   ClassDef := AStmt.ClassDefinition;
-  HasSuper := ClassDef.SuperClass <> '';
+  HasSuper := Assigned(ClassDef.SuperClassExpression) or
+    (ClassDef.SuperClass <> '');
 
   PrivPrefix := NextClassPrivatePrefix;
   PrivateNameMark := ACtx.Scope.PrivateNameMark;
@@ -5077,41 +5227,60 @@ begin
      (ACtx.Scope.GetLocal(LocalIdx).Depth = ACtx.Scope.Depth) then
     ClassReg := ACtx.Scope.GetLocal(LocalIdx).Slot
   else
-    ClassReg := ACtx.Scope.DeclareLocal(ClassDef.Name, True);
-  if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) then
   begin
+    ClassReg := ACtx.Scope.DeclareLocal(ClassDef.Name, False);
     LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.Name);
-    if LocalIdx >= 0 then
-      ACtx.Scope.MarkGlobalBacked(LocalIdx);
   end;
+  ClassLocalIdx := LocalIdx;
   NameIdx := ACtx.Template.AddConstantString(ClassDef.Name);
   EmitInstruction(ACtx, EncodeABx(OP_NEW_CLASS, ClassReg, NameIdx));
+
+  HasInnerNameBinding := ClassDef.Name <> '';
+  InnerNameSlot := 0;
+  if HasInnerNameBinding then
+  begin
+    ACtx.Scope.BeginScope;
+    InnerNameSlot := ACtx.Scope.DeclareLocal(ClassDef.Name, True);
+    if HasSuper then
+      EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, InnerNameSlot, 0, 0))
+    else
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, InnerNameSlot, ClassReg, 0));
+  end;
 
   if HasSuper then
   begin
     SuperReg := ACtx.Scope.DeclareLocal('__super__', False);
 
-    LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.SuperClass);
-    if LocalIdx >= 0 then
-      EmitInstruction(ACtx, EncodeABC(OP_MOVE, SuperReg,
-        ACtx.Scope.GetLocal(LocalIdx).Slot, 0))
+    if Assigned(ClassDef.SuperClassExpression) then
+      ACtx.CompileExpression(ClassDef.SuperClassExpression, SuperReg)
     else
     begin
-      UpvalIdx := ACtx.Scope.ResolveUpvalue(ClassDef.SuperClass);
-      if UpvalIdx >= 0 then
-        EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, SuperReg,
-          UInt16(UpvalIdx)))
+      LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.SuperClass);
+      if LocalIdx >= 0 then
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, SuperReg,
+          ACtx.Scope.GetLocal(LocalIdx).Slot, 0))
       else
-        EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, SuperReg,
-          ACtx.Template.AddConstantString(ClassDef.SuperClass)));
+      begin
+        UpvalIdx := ACtx.Scope.ResolveUpvalue(ClassDef.SuperClass);
+        if UpvalIdx >= 0 then
+          EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, SuperReg,
+            UInt16(UpvalIdx)))
+        else
+          EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, SuperReg,
+            ACtx.Template.AddConstantString(ClassDef.SuperClass)));
+      end;
     end;
 
     EmitInstruction(ACtx, EncodeABC(OP_CLASS_SET_SUPER, ClassReg, SuperReg, 0));
   end;
 
+  if HasInnerNameBinding and HasSuper then
+    EmitInstruction(ACtx, EncodeABC(OP_MOVE, InnerNameSlot, ClassReg, 0));
+
   for MethodPair in ClassDef.Methods do
     CompileMethodBody(ACtx, ClassReg, MethodPair.Key,
-      MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
+      MethodPair.Value, OP_CLASS_ADD_METHOD_CONST,
+      HasSuper and (MethodPair.Key = PROP_CONSTRUCTOR));
 
   for MethodPair in ClassDef.StaticMethods do
     CompileMethodBody(ACtx, ClassReg, MethodPair.Key,
@@ -5185,7 +5354,8 @@ begin
     for StaticPropPair in ClassDef.StaticProperties do
     begin
       ValReg := ACtx.Scope.AllocateRegister;
-      ACtx.CompileExpression(StaticPropPair.Value, ValReg);
+      CompileStaticFieldInitializerExpression(
+        ACtx, ClassReg, StaticPropPair.Value, ValReg, StaticPropPair.Key);
       KeyIdx := ACtx.Template.AddConstantString(StaticPropPair.Key);
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
@@ -5197,13 +5367,15 @@ begin
     for StaticPropPair in ClassDef.PrivateStaticProperties do
     begin
       ValReg := ACtx.Scope.AllocateRegister;
-      ACtx.CompileExpression(StaticPropPair.Value, ValReg);
+      CompileStaticFieldInitializerExpression(
+        ACtx, ClassReg, StaticPropPair.Value, ValReg,
+        '#' + StaticPropPair.Key);
       KeyIdx := ACtx.Template.AddConstantString('#slot:' + PrivPrefix + StaticPropPair.Key);
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
       EmitInstruction(ACtx, EncodeABC(OP_CLASS_DECLARE_PRIVATE_STATIC_CONST,
         ClassReg, UInt8(KeyIdx), 0));
-      EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ClassReg,
+      EmitInstruction(ACtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ClassReg,
         UInt8(KeyIdx), ValReg));
       ACtx.Scope.FreeRegister;
     end;
@@ -5229,9 +5401,16 @@ begin
       else
         KeyReg := 0;
       if Assigned(ClassDef.FElements[I].FieldInitializer) then
-        ACtx.CompileExpression(ClassDef.FElements[I].FieldInitializer, ValReg)
+        CompileStaticFieldInitializerExpression(
+          ACtx, ClassReg, ClassDef.FElements[I].FieldInitializer, ValReg,
+          ClassFieldInferredName(ClassDef.FElements[I]))
       else
         EmitInstruction(ACtx, EncodeABx(OP_LOAD_UNDEFINED, ValReg, 0));
+      if ClassDef.FElements[I].IsComputed and
+         IsAnonymousFunctionNameInitializer(
+           ClassDef.FElements[I].FieldInitializer) then
+        EmitInstruction(ACtx, EncodeABC(OP_SET_FUNCTION_NAME, ValReg,
+          KeyReg, 0));
       if ClassDef.FElements[I].IsPrivate then
       begin
         KeyIdx := ACtx.Template.AddConstantString(
@@ -5240,7 +5419,7 @@ begin
           raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
         EmitInstruction(ACtx, EncodeABC(OP_CLASS_DECLARE_PRIVATE_STATIC_CONST,
           ClassReg, UInt8(KeyIdx), 0));
-        EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ClassReg,
+        EmitInstruction(ACtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ClassReg,
           UInt8(KeyIdx), ValReg));
       end
       else if ClassDef.FElements[I].IsComputed then
@@ -5267,12 +5446,19 @@ begin
 
   // Sync cell if the class local was pre-declared and captured by a hoisted
   // function (see CompileVariableDeclaration for the full explanation)
-  LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.Name);
-  if (LocalIdx >= 0) and ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
+  if (ClassLocalIdx >= 0) and
+     ACtx.Scope.GetLocal(ClassLocalIdx).IsCaptured then
     EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, ClassReg, UInt16(ClassReg)));
 
   if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) then
-    EmitGlobalDefine(ACtx, ClassReg, ClassDef.Name, True);
+    EmitGlobalDefine(ACtx, ClassReg, ClassDef.Name, False);
+
+  if HasInnerNameBinding then
+  begin
+    ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
+    for I := 0 to ClosedCount - 1 do
+      EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+  end;
 
   ACtx.Scope.PrivatePrefix := '';
   ACtx.Scope.RestorePrivateNameMark(PrivateNameMark);
@@ -5294,13 +5480,15 @@ var
   PrivPrefix: string;
   PrivateNameMark: Integer;
   HasNameBinding: Boolean;
-  ClosedLocals: array[0..0] of UInt8;
+  ClosedLocals: array[0..255] of UInt8;
   ClosedCount, I: Integer;
   ComputedFieldKeyLocals: TComputedFieldKeyLocals;
   ComputedKeyName: string;
+  NameSlot: UInt8;
 begin
   ClassDef := AClassDef;
-  HasSuper := ClassDef.SuperClass <> '';
+  HasSuper := Assigned(ClassDef.SuperClassExpression) or
+    (ClassDef.SuperClass <> '');
   HasNameBinding := ClassDef.Name <> '';
 
   PrivPrefix := NextClassPrivatePrefix;
@@ -5321,35 +5509,47 @@ begin
   if HasNameBinding then
   begin
     ACtx.Scope.BeginScope;
-    ACtx.Scope.DeclareLocal(ClassDef.Name, True);
-    EmitInstruction(ACtx, EncodeABC(OP_MOVE, ACtx.Scope.NextSlot - 1, ADest, 0));
+    NameSlot := ACtx.Scope.DeclareLocal(ClassDef.Name, True);
+    if HasSuper then
+      EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, NameSlot, 0, 0))
+    else
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, NameSlot, ADest, 0));
   end;
 
   if HasSuper then
   begin
     SuperReg := ACtx.Scope.DeclareLocal('__super__', False);
 
-    LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.SuperClass);
-    if LocalIdx >= 0 then
-      EmitInstruction(ACtx, EncodeABC(OP_MOVE, SuperReg,
-        ACtx.Scope.GetLocal(LocalIdx).Slot, 0))
+    if Assigned(ClassDef.SuperClassExpression) then
+      ACtx.CompileExpression(ClassDef.SuperClassExpression, SuperReg)
     else
     begin
-      UpvalIdx := ACtx.Scope.ResolveUpvalue(ClassDef.SuperClass);
-      if UpvalIdx >= 0 then
-        EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, SuperReg,
-          UInt16(UpvalIdx)))
+      LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.SuperClass);
+      if LocalIdx >= 0 then
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, SuperReg,
+          ACtx.Scope.GetLocal(LocalIdx).Slot, 0))
       else
-        EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, SuperReg,
-          ACtx.Template.AddConstantString(ClassDef.SuperClass)));
+      begin
+        UpvalIdx := ACtx.Scope.ResolveUpvalue(ClassDef.SuperClass);
+        if UpvalIdx >= 0 then
+          EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, SuperReg,
+            UInt16(UpvalIdx)))
+        else
+          EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, SuperReg,
+            ACtx.Template.AddConstantString(ClassDef.SuperClass)));
+      end;
     end;
 
     EmitInstruction(ACtx, EncodeABC(OP_CLASS_SET_SUPER, ADest, SuperReg, 0));
   end;
 
+  if HasNameBinding and HasSuper then
+    EmitInstruction(ACtx, EncodeABC(OP_MOVE, NameSlot, ADest, 0));
+
   for MethodPair in ClassDef.Methods do
     CompileMethodBody(ACtx, ADest, MethodPair.Key,
-      MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
+      MethodPair.Value, OP_CLASS_ADD_METHOD_CONST,
+      HasSuper and (MethodPair.Key = PROP_CONSTRUCTOR));
 
   for MethodPair in ClassDef.StaticMethods do
     CompileMethodBody(ACtx, ADest, MethodPair.Key,
@@ -5423,7 +5623,8 @@ begin
     for StaticPropPair in ClassDef.StaticProperties do
     begin
       ValReg := ACtx.Scope.AllocateRegister;
-      ACtx.CompileExpression(StaticPropPair.Value, ValReg);
+      CompileStaticFieldInitializerExpression(
+        ACtx, ADest, StaticPropPair.Value, ValReg, StaticPropPair.Key);
       KeyIdx := ACtx.Template.AddConstantString(StaticPropPair.Key);
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
@@ -5435,13 +5636,15 @@ begin
     for StaticPropPair in ClassDef.PrivateStaticProperties do
     begin
       ValReg := ACtx.Scope.AllocateRegister;
-      ACtx.CompileExpression(StaticPropPair.Value, ValReg);
+      CompileStaticFieldInitializerExpression(
+        ACtx, ADest, StaticPropPair.Value, ValReg,
+        '#' + StaticPropPair.Key);
       KeyIdx := ACtx.Template.AddConstantString('#slot:' + PrivPrefix + StaticPropPair.Key);
       if KeyIdx > High(UInt8) then
         raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
       EmitInstruction(ACtx, EncodeABC(OP_CLASS_DECLARE_PRIVATE_STATIC_CONST,
         ADest, UInt8(KeyIdx), 0));
-      EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ADest,
+      EmitInstruction(ACtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ADest,
         UInt8(KeyIdx), ValReg));
       ACtx.Scope.FreeRegister;
     end;
@@ -5467,9 +5670,16 @@ begin
       else
         KeyReg := 0;
       if Assigned(ClassDef.FElements[I].FieldInitializer) then
-        ACtx.CompileExpression(ClassDef.FElements[I].FieldInitializer, ValReg)
+        CompileStaticFieldInitializerExpression(
+          ACtx, ADest, ClassDef.FElements[I].FieldInitializer, ValReg,
+          ClassFieldInferredName(ClassDef.FElements[I]))
       else
         EmitInstruction(ACtx, EncodeABx(OP_LOAD_UNDEFINED, ValReg, 0));
+      if ClassDef.FElements[I].IsComputed and
+         IsAnonymousFunctionNameInitializer(
+           ClassDef.FElements[I].FieldInitializer) then
+        EmitInstruction(ACtx, EncodeABC(OP_SET_FUNCTION_NAME, ValReg,
+          KeyReg, 0));
       if ClassDef.FElements[I].IsPrivate then
       begin
         KeyIdx := ACtx.Template.AddConstantString(
@@ -5478,7 +5688,7 @@ begin
           raise Exception.Create('Constant pool overflow: static property name index exceeds 255');
         EmitInstruction(ACtx, EncodeABC(OP_CLASS_DECLARE_PRIVATE_STATIC_CONST,
           ADest, UInt8(KeyIdx), 0));
-        EmitInstruction(ACtx, EncodeABC(OP_SET_PROP_CONST, ADest,
+        EmitInstruction(ACtx, EncodeABC(OP_DEFINE_STATIC_PROP_CONST, ADest,
           UInt8(KeyIdx), ValReg));
       end
       else if ClassDef.FElements[I].IsComputed then
@@ -5622,7 +5832,6 @@ begin
       begin
         Local := ACtx.Scope.GetLocal(I);
         EmitGlobalDefine(ACtx, Local.Slot, Local.Name, AStmt.IsConst);
-        ACtx.Scope.MarkGlobalBacked(I);
       end;
   end;
 end;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -4003,7 +4003,7 @@ begin
   if Pos('#slot:', AStorageName) = 1 then
   begin
     SeparatorIndex := 0;
-    for I := Length(AStorageName) downto 1 do
+    for I := Length('#slot:') + 1 to Length(AStorageName) do
       if AStorageName[I] = '$' then
       begin
         SeparatorIndex := I;
@@ -4165,6 +4165,7 @@ begin
   ChildCtx.Scope := ChildScope;
   ChildCtx.NonStrictMode := ACtx.NonStrictMode and
     not ChildTemplate.StrictCode;
+  ChildCtx.DerivedConstructorThisGuard := False;
   EmitLineMapping(ChildCtx, AGetter.Line, AGetter.Column);
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
   ACtx.CompileFunctionBody(AGetter.Body);
@@ -4255,6 +4256,7 @@ begin
   ChildCtx.Scope := ChildScope;
   ChildCtx.NonStrictMode := ACtx.NonStrictMode and
     not ChildTemplate.StrictCode;
+  ChildCtx.DerivedConstructorThisGuard := False;
   EmitLineMapping(ChildCtx, ASetter.Line, ASetter.Column);
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
   EmitDefaultParameters(ChildCtx, SetterParams);
@@ -4326,6 +4328,7 @@ begin
   ChildCtx.Scope := ChildScope;
   ChildCtx.NonStrictMode := ACtx.NonStrictMode and
     not ChildTemplate.StrictCode;
+  ChildCtx.DerivedConstructorThisGuard := False;
   EmitLineMapping(ChildCtx, AGetter.Line, AGetter.Column);
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
   ACtx.CompileFunctionBody(AGetter.Body);
@@ -4411,6 +4414,7 @@ begin
   ChildCtx.Scope := ChildScope;
   ChildCtx.NonStrictMode := ACtx.NonStrictMode and
     not ChildTemplate.StrictCode;
+  ChildCtx.DerivedConstructorThisGuard := False;
   EmitLineMapping(ChildCtx, ASetter.Line, ASetter.Column);
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
   EmitDefaultParameters(ChildCtx, SetterParams);
@@ -4511,6 +4515,7 @@ begin
   ChildCtx.Scope := ChildScope;
   ChildCtx.NonStrictMode := ACtx.NonStrictMode and
     not ChildTemplate.StrictCode;
+  ChildCtx.DerivedConstructorThisGuard := False;
 
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot);
 
@@ -4814,6 +4819,7 @@ begin
   ChildCtx.Scope := ChildScope;
   ChildCtx.NonStrictMode := ACtx.NonStrictMode and
     not ChildTemplate.StrictCode;
+  ChildCtx.DerivedConstructorThisGuard := False;
 
   if Length(AClassDef.FFieldOrder) > 0 then
   begin
@@ -4964,6 +4970,7 @@ begin
   ChildCtx.Scope := ChildScope;
   ChildCtx.NonStrictMode := ACtx.NonStrictMode and
     not ChildTemplate.StrictCode;
+  ChildCtx.DerivedConstructorThisGuard := False;
 
   CompileBlockStatement(ChildCtx, ABody);
 

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -4712,14 +4712,24 @@ var
   ClosedLocals: array[0..0] of UInt8;
   ClosedCount, I: Integer;
   ThisReg: UInt8;
+  OldRejectArgumentsInDirectEval: Boolean;
 begin
+  OldRejectArgumentsInDirectEval := ACtx.Template.RejectArgumentsInDirectEval;
+  ACtx.Template.RejectArgumentsInDirectEval := True;
   ACtx.Scope.BeginScope;
-  ThisReg := ACtx.Scope.DeclareLocal(KEYWORD_THIS, False);
-  EmitInstruction(ACtx, EncodeABC(OP_MOVE, ThisReg, AClassReg, 0));
-  CompileFieldValueWithInferredName(ACtx, AExpression, ADest, AInferredName);
-  ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
-  for I := 0 to ClosedCount - 1 do
-    EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+  try
+    ThisReg := ACtx.Scope.DeclareLocal(KEYWORD_THIS, False);
+    EmitInstruction(ACtx, EncodeABC(OP_MOVE, ThisReg, AClassReg, 0));
+    CompileFieldValueWithInferredName(ACtx, AExpression, ADest,
+      AInferredName);
+    ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
+    for I := 0 to ClosedCount - 1 do
+      EmitInstruction(ACtx,
+        EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+  finally
+    ACtx.Template.RejectArgumentsInDirectEval :=
+      OldRejectArgumentsInDirectEval;
+  end;
 end;
 
 procedure RegisterPrivateName(const AScope: TGocciaCompilerScope;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -849,6 +849,9 @@ begin
     begin
       EmitGlobalDefine(ACtx, Slot, Info.Name, AStmt.IsConst, AStmt.IsVar,
         HasInitializer);
+      LocalIdx := FindLocalBySlot(ACtx.Scope, Info.Name, Slot);
+      if LocalIdx >= 0 then
+        ACtx.Scope.MarkGlobalBacked(LocalIdx);
     end;
   end;
 end;
@@ -3413,17 +3416,28 @@ procedure CompileExportDeclaration(const ACtx: TGocciaCompilationContext;
 var
   Pair: TStringStringMap.TKeyValuePair;
   LocalIdx: Integer;
+  Local: TGocciaCompilerLocal;
   Reg: UInt8;
-  NameIdx: UInt16;
+  NameIdx, SourceNameIdx: UInt16;
 begin
   for Pair in AStmt.ExportsTable do
   begin
     LocalIdx := ACtx.Scope.ResolveLocal(Pair.Value);
     if LocalIdx >= 0 then
     begin
-      Reg := ACtx.Scope.GetLocal(LocalIdx).Slot;
+      Local := ACtx.Scope.GetLocal(LocalIdx);
+      if Local.IsGlobalBacked then
+      begin
+        Reg := ACtx.Scope.AllocateRegister;
+        SourceNameIdx := ACtx.Template.AddConstantString(Pair.Value);
+        EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, Reg, SourceNameIdx));
+      end
+      else
+        Reg := Local.Slot;
       NameIdx := ACtx.Template.AddConstantString(Pair.Key);
       EmitInstruction(ACtx, EncodeABx(OP_EXPORT, Reg, NameIdx));
+      if Local.IsGlobalBacked then
+        ACtx.Scope.FreeRegister;
     end;
   end;
 end;
@@ -5202,6 +5216,7 @@ var
   StaticPropPair: TGocciaExpressionMap.TKeyValuePair;
   I, ClassLocalIdx, LocalIdx, UpvalIdx: Integer;
   HasSuper: Boolean;
+  IsTopLevelGlobalBacked: Boolean;
   PrivPrefix: string;
   PrivateNameMark: Integer;
   ComputedFieldKeyLocals: TComputedFieldKeyLocals;
@@ -5214,6 +5229,8 @@ begin
   ClassDef := AStmt.ClassDefinition;
   HasSuper := Assigned(ClassDef.SuperClassExpression) or
     (ClassDef.SuperClass <> '');
+  IsTopLevelGlobalBacked := ACtx.GlobalBackedTopLevel and
+    (ACtx.Scope.Depth = 0);
 
   PrivPrefix := NextClassPrivatePrefix;
   PrivateNameMark := ACtx.Scope.PrivateNameMark;
@@ -5232,6 +5249,8 @@ begin
     LocalIdx := ACtx.Scope.ResolveLocal(ClassDef.Name);
   end;
   ClassLocalIdx := LocalIdx;
+  if IsTopLevelGlobalBacked and (ClassLocalIdx >= 0) then
+    ACtx.Scope.MarkGlobalBacked(ClassLocalIdx);
   NameIdx := ACtx.Template.AddConstantString(ClassDef.Name);
   EmitInstruction(ACtx, EncodeABx(OP_NEW_CLASS, ClassReg, NameIdx));
 
@@ -5450,7 +5469,7 @@ begin
      ACtx.Scope.GetLocal(ClassLocalIdx).IsCaptured then
     EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, ClassReg, UInt16(ClassReg)));
 
-  if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) then
+  if IsTopLevelGlobalBacked then
     EmitGlobalDefine(ACtx, ClassReg, ClassDef.Name, False);
 
   if HasInnerNameBinding then
@@ -5832,6 +5851,7 @@ begin
       begin
         Local := ACtx.Scope.GetLocal(I);
         EmitGlobalDefine(ACtx, Local.Slot, Local.Name, AStmt.IsConst);
+        ACtx.Scope.MarkGlobalBacked(I);
       end;
   end;
 end;

--- a/source/units/Goccia.Compiler.Test.pas
+++ b/source/units/Goccia.Compiler.Test.pas
@@ -66,6 +66,7 @@ type
     procedure TestCompileVariable;
     procedure TestCompileFunction;
     procedure TestBinaryRoundTrip;
+    procedure TestBinaryRoundTripUpvalueNames;
     procedure TestBinaryLittleEndian;
     procedure TestBinaryRoundTripConstants;
     procedure TestUndeclaredPrivateNameRaisesSyntaxError;
@@ -108,6 +109,7 @@ begin
   Test('Compile variable', TestCompileVariable);
   Test('Compile function', TestCompileFunction);
   Test('Binary round-trip', TestBinaryRoundTrip);
+  Test('Binary round-trip upvalue names', TestBinaryRoundTripUpvalueNames);
   Test('Binary little-endian format', TestBinaryLittleEndian);
   Test('Binary round-trip constants', TestBinaryRoundTripConstants);
   Test('Undeclared private name raises SyntaxError', TestUndeclaredPrivateNameRaisesSyntaxError);
@@ -429,6 +431,41 @@ begin
       Expect<Integer>(Loaded.TopLevel.CodeCount).ToBe(Original.TopLevel.CodeCount);
       Expect<Integer>(Loaded.TopLevel.ConstantCount).ToBe(Original.TopLevel.ConstantCount);
       Expect<Integer>(Loaded.TopLevel.FunctionCount).ToBe(Original.TopLevel.FunctionCount);
+    finally
+      Loaded.Free;
+    end;
+  finally
+    Original.Free;
+    DeleteFile(TempFile);
+  end;
+end;
+
+procedure TTestCompiler.TestBinaryRoundTripUpvalueNames;
+var
+  Original, Loaded: TGocciaBytecodeModule;
+  OriginalFunc, LoadedFunc: TGocciaFunctionTemplate;
+  OriginalDesc, LoadedDesc: TGocciaUpvalueDescriptor;
+  TempFile: string;
+begin
+  Original := CompileSource(
+    'let x = 1; const f = () => x; x = 2;',
+    False, False, False, False, False, False);
+  TempFile := GetTempFileName + '.gbc';
+  try
+    OriginalFunc := FindFunctionWithOp(Original.TopLevel, OP_GET_UPVALUE);
+    Expect<Boolean>(Assigned(OriginalFunc)).ToBe(True);
+    Expect<Integer>(OriginalFunc.UpvalueCount).ToBe(1);
+    OriginalDesc := OriginalFunc.GetUpvalueDescriptor(0);
+    Expect<string>(OriginalDesc.Name).ToBe('x');
+
+    SaveModuleToFile(Original, TempFile);
+    Loaded := LoadModuleFromFile(TempFile);
+    try
+      LoadedFunc := FindFunctionWithOp(Loaded.TopLevel, OP_GET_UPVALUE);
+      Expect<Boolean>(Assigned(LoadedFunc)).ToBe(True);
+      Expect<Integer>(LoadedFunc.UpvalueCount).ToBe(1);
+      LoadedDesc := LoadedFunc.GetUpvalueDescriptor(0);
+      Expect<string>(LoadedDesc.Name).ToBe(OriginalDesc.Name);
     finally
       Loaded.Free;
     end;

--- a/source/units/Goccia.Compiler.pas
+++ b/source/units/Goccia.Compiler.pas
@@ -5,6 +5,8 @@ unit Goccia.Compiler;
 interface
 
 uses
+  Generics.Collections,
+
   Goccia.AST.Expressions,
   Goccia.AST.Node,
   Goccia.AST.Statements,
@@ -29,6 +31,7 @@ type
     FLabelReentryStatement: TGocciaStatement;
     FOptimizationOptions: TGocciaCompilerOptimizationOptions;
     FDerivedConstructorThisGuard: Boolean;
+    FTemplateDerivedConstructorThisGuards: TDictionary<TGocciaFunctionTemplate, Boolean>;
     procedure DoCompileExpression(const AExpr: TGocciaExpression;
       const ADest: UInt8);
     function DoCompileStatement(const AStmt: TGocciaStatement): Boolean;
@@ -58,7 +61,6 @@ const
 implementation
 
 uses
-  Generics.Collections,
   SysUtils,
 
   Goccia.Bytecode,
@@ -75,6 +77,8 @@ begin
   inherited Create;
   FSourcePath := ASourcePath;
   FFormalParameterCounts := TFormalParameterCountMap.Create;
+  FTemplateDerivedConstructorThisGuards :=
+    TDictionary<TGocciaFunctionTemplate, Boolean>.Create;
   FDerivedConstructorThisGuard := False;
   FModule := nil;
   FCurrentTemplate := nil;
@@ -85,6 +89,7 @@ end;
 
 destructor TGocciaCompiler.Destroy;
 begin
+  FTemplateDerivedConstructorThisGuards.Free;
   FFormalParameterCounts.Free;
   inherited;
 end;
@@ -113,14 +118,24 @@ procedure TGocciaCompiler.DoSetDerivedConstructorThisGuard(
   const AGuard: Boolean);
 begin
   FDerivedConstructorThisGuard := AGuard;
+  if Assigned(FCurrentTemplate) then
+    FTemplateDerivedConstructorThisGuards.AddOrSetValue(
+      FCurrentTemplate, AGuard);
 end;
 
 procedure TGocciaCompiler.DoSwapState(
   const ATemplate: TGocciaFunctionTemplate;
   const AScope: TGocciaCompilerScope);
 begin
+  if Assigned(FCurrentTemplate) then
+    FTemplateDerivedConstructorThisGuards.AddOrSetValue(
+      FCurrentTemplate, FDerivedConstructorThisGuard);
   FCurrentTemplate := ATemplate;
   FCurrentScope := AScope;
+  if not Assigned(FCurrentTemplate) or
+     not FTemplateDerivedConstructorThisGuards.TryGetValue(
+       FCurrentTemplate, FDerivedConstructorThisGuard) then
+    FDerivedConstructorThisGuard := False;
 end;
 
 procedure TGocciaCompiler.DoCompileExpression(

--- a/source/units/Goccia.Compiler.pas
+++ b/source/units/Goccia.Compiler.pas
@@ -28,12 +28,14 @@ type
     FNonStrictMode: Boolean;
     FLabelReentryStatement: TGocciaStatement;
     FOptimizationOptions: TGocciaCompilerOptimizationOptions;
+    FDerivedConstructorThisGuard: Boolean;
     procedure DoCompileExpression(const AExpr: TGocciaExpression;
       const ADest: UInt8);
     function DoCompileStatement(const AStmt: TGocciaStatement): Boolean;
     procedure DoCompileFunctionBody(const ABody: TGocciaASTNode);
     procedure DoSwapState(const ATemplate: TGocciaFunctionTemplate;
       const AScope: TGocciaCompilerScope);
+    procedure DoSetDerivedConstructorThisGuard(const AGuard: Boolean);
     function BuildContext: TGocciaCompilationContext;
   public
     constructor Create(const ASourcePath: string);
@@ -73,6 +75,7 @@ begin
   inherited Create;
   FSourcePath := ASourcePath;
   FFormalParameterCounts := TFormalParameterCountMap.Create;
+  FDerivedConstructorThisGuard := False;
   FModule := nil;
   FCurrentTemplate := nil;
   FTopLevelTemplate := nil;
@@ -97,11 +100,19 @@ begin
   Result.StrictTypes := FStrictTypes;
   Result.CompatibilityNonStrictMode := FNonStrictMode;
   Result.NonStrictMode := FNonStrictMode and not FCurrentTemplate.StrictCode;
+  Result.DerivedConstructorThisGuard := FDerivedConstructorThisGuard;
   Result.OptimizationOptions := FOptimizationOptions;
   Result.CompileExpression := DoCompileExpression;
   Result.CompileStatement := DoCompileStatement;
   Result.CompileFunctionBody := DoCompileFunctionBody;
   Result.SwapState := DoSwapState;
+  Result.SetDerivedConstructorThisGuard := DoSetDerivedConstructorThisGuard;
+end;
+
+procedure TGocciaCompiler.DoSetDerivedConstructorThisGuard(
+  const AGuard: Boolean);
+begin
+  FDerivedConstructorThisGuard := AGuard;
 end;
 
 procedure TGocciaCompiler.DoSwapState(
@@ -407,7 +418,7 @@ begin
   else if ANode is TGocciaClassDeclaration then
   begin
     if AScope.ResolveLocal(TGocciaClassDeclaration(ANode).ClassDefinition.Name) < 0 then
-      AScope.DeclareLocal(TGocciaClassDeclaration(ANode).ClassDefinition.Name, True);
+      AScope.DeclareLocal(TGocciaClassDeclaration(ANode).ClassDefinition.Name, False);
   end
   else if (ANode is TGocciaExportDefaultDeclaration) and
           (TGocciaExportDefaultDeclaration(ANode).LocalName <> GOCCIA_DEFAULT_EXPORT_BINDING) then

--- a/source/units/Goccia.Constants.PropertyNames.pas
+++ b/source/units/Goccia.Constants.PropertyNames.pas
@@ -16,6 +16,8 @@ const
   PROP_STACK        = 'stack';
   PROP_ERRORS       = 'errors';
   PROP_ERROR        = 'error';
+  PROP_CALLER       = 'caller';
+  PROP_ARGUMENTS    = 'arguments';
   PROP_CALLEE       = 'callee';
   PROP_CONSTRUCTOR  = 'constructor';
   PROP_PROTOTYPE    = 'prototype';

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -533,7 +533,9 @@ begin
   for I := 0 to DefaultShimCount - 1 do
   begin
     Shim := DefaultShim(I);
-    if Shim.Name = 'hasOwnProperty' then
+    if (Shim.Name = 'hasOwnProperty') or (Shim.Name = '__proto__') or
+       (Shim.Name = 'defineGetter') or (Shim.Name = 'defineSetter') or
+       (Shim.Name = 'lookupGetter') or (Shim.Name = 'lookupSetter') then
       LoadShimValue(FInterpreter, Shim)
     else
       FInterpreter.GlobalScope.DefineLexicalBinding(Shim.Name,
@@ -800,6 +802,8 @@ begin
   TypeDef.AddSpeciesGetter := False;
   RegisterTypeDefinition(FInterpreter.GlobalScope, TypeDef, SpeciesGetter, ObjectConstructor);
   FObjectConstructor := ObjectConstructor;
+  if Assigned(GetErrorProto) and not Assigned(GetErrorProto.Prototype) then
+    GetErrorProto.Prototype := ObjectConstructor.Prototype;
 
   TypeDef.ConstructorName := CONSTRUCTOR_ARRAY;
   TypeDef.Kind := gtdkNativeInstanceType;
@@ -882,6 +886,12 @@ begin
   ArrayBufferConstructor := TGocciaArrayBufferClassValue.Create(CONSTRUCTOR_ARRAY_BUFFER, nil);
   TGocciaArrayBufferValue.ExposePrototype(ArrayBufferConstructor);
   ArrayBufferConstructor.Prototype.Prototype := ObjectConstructor.Prototype;
+  ArrayBufferConstructor.DefineSymbolProperty(
+    TGocciaSymbolValue.WellKnownSpecies,
+    TGocciaPropertyDescriptorAccessor.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(
+        SpeciesGetter, 'get [Symbol.species]', 0),
+      nil, [pfConfigurable]));
   if Assigned(FBuiltinArrayBuffer) then
     for Key in FBuiltinArrayBuffer.BuiltinObject.GetAllPropertyNames do
       ArrayBufferConstructor.SetProperty(Key, FBuiltinArrayBuffer.BuiltinObject.GetProperty(Key));
@@ -890,6 +900,12 @@ begin
   SharedArrayBufferConstructor := TGocciaSharedArrayBufferClassValue.Create(CONSTRUCTOR_SHARED_ARRAY_BUFFER, nil);
   TGocciaSharedArrayBufferValue.ExposePrototype(SharedArrayBufferConstructor);
   SharedArrayBufferConstructor.Prototype.Prototype := ObjectConstructor.Prototype;
+  SharedArrayBufferConstructor.DefineSymbolProperty(
+    TGocciaSymbolValue.WellKnownSpecies,
+    TGocciaPropertyDescriptorAccessor.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(
+        SpeciesGetter, 'get [Symbol.species]', 0),
+      nil, [pfConfigurable]));
   FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_SHARED_ARRAY_BUFFER, SharedArrayBufferConstructor, dtConst, True);
 
   DataViewConstructor := TGocciaDataViewClassValue.Create(CONSTRUCTOR_DATA_VIEW, nil);

--- a/source/units/Goccia.Evaluator.Context.pas
+++ b/source/units/Goccia.Evaluator.Context.pas
@@ -11,6 +11,8 @@ uses
   Goccia.Scope;
 
 type
+  TGocciaEvalRejectNameArray = array of string;
+
   TGocciaEvaluationContext = record
     Realm: TGocciaRealm;
     Scope: TGocciaScope;
@@ -23,6 +25,7 @@ type
     NonStrictMode: Boolean;
     InEvalCode: Boolean;
     RejectArgumentsVarDeclarationInEval: Boolean;
+    RejectVarDeclarationNamesInEval: TGocciaEvalRejectNameArray;
     DisposalTracker: TObject; // TGocciaDisposalTracker or nil
   end;
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2878,7 +2878,9 @@ begin
 end;
 
 function EvaluateMemberCore(const AMemberExpression: TGocciaMemberExpression; const AContext: TGocciaEvaluationContext; const AOutObjectValue: PGocciaValue): TGocciaValue; forward;
-function ResolveSuperPropertyBase(const AContext: TGocciaEvaluationContext): TGocciaValue; forward;
+function ResolveSuperThisValue(const AContext: TGocciaEvaluationContext): TGocciaValue; forward;
+function ResolveSuperPropertyBase(const AContext: TGocciaEvaluationContext;
+  const AThisValue: TGocciaValue): TGocciaValue; forward;
 
 procedure AssignSuperProperty(const AContext: TGocciaEvaluationContext;
   const APropertyKey, AValue: TGocciaValue);
@@ -2887,9 +2889,11 @@ var
   BaseValue: TGocciaValue;
   KeyValue: TGocciaValue;
   PropertyName: string;
+  ThisValue: TGocciaValue;
   Success: Boolean;
 begin
-  BaseValue := ResolveSuperPropertyBase(AContext);
+  ThisValue := ResolveSuperThisValue(AContext);
+  BaseValue := ResolveSuperPropertyBase(AContext, ThisValue);
   KeyValue := ToPropertyKey(APropertyKey);
   if KeyValue is TGocciaSymbolValue then
     PropertyName := TGocciaSymbolValue(KeyValue).ToDisplayString.Value
@@ -2903,17 +2907,40 @@ begin
   BaseObject := TGocciaObjectValue(BaseValue);
   if KeyValue is TGocciaSymbolValue then
     Success := BaseObject.AssignSymbolPropertyWithReceiver(
-      TGocciaSymbolValue(KeyValue), AValue, AContext.Scope.ThisValue)
+      TGocciaSymbolValue(KeyValue), AValue, ThisValue)
   else
     Success := BaseObject.AssignPropertyWithReceiver(PropertyName, AValue,
-      AContext.Scope.ThisValue);
+      ThisValue);
 
   if not Success then
     ThrowTypeError(Format(SErrorCannotAssignReadOnly, [PropertyName]),
       SSuggestCannotDeleteNonConfigurable);
 end;
 
-function ResolveSuperPropertyBase(const AContext: TGocciaEvaluationContext): TGocciaValue;
+function ResolveSuperThisValue(const AContext: TGocciaEvaluationContext): TGocciaValue;
+var
+  ScopeCursor: TGocciaScope;
+begin
+  ScopeCursor := AContext.Scope;
+  while Assigned(ScopeCursor) do
+  begin
+    if ScopeCursor is TGocciaMethodCallScope then
+    begin
+      if (ScopeCursor.CustomLabel = PROP_CONSTRUCTOR) and
+         Assigned(TGocciaMethodCallScope(ScopeCursor).SuperClass) and
+         not TGocciaMethodCallScope(ScopeCursor).SuperConstructorCalled then
+        ThrowReferenceError(
+          'Must call super constructor before accessing this',
+          'call super() before reading this or super properties');
+      Break;
+    end;
+    ScopeCursor := ScopeCursor.Parent;
+  end;
+  Result := AContext.Scope.ThisValue;
+end;
+
+function ResolveSuperPropertyBase(const AContext: TGocciaEvaluationContext;
+  const AThisValue: TGocciaValue): TGocciaValue;
 var
   OwningClass: TGocciaClassValue;
   OwningClassValue: TGocciaValue;
@@ -2922,7 +2949,7 @@ begin
   Result := nil;
   OwningClassValue := AContext.Scope.FindOwningClass;
 
-  if AContext.Scope.ThisValue is TGocciaClassValue then
+  if AThisValue is TGocciaClassValue then
   begin
     if OwningClassValue is TGocciaObjectValue then
       Exit(TGocciaObjectValue(OwningClassValue).Prototype);
@@ -2954,8 +2981,10 @@ var
   BaseValue: TGocciaValue;
   KeyValue: TGocciaValue;
   PropertyName: string;
+  ThisValue: TGocciaValue;
 begin
-  BaseValue := ResolveSuperPropertyBase(AContext);
+  ThisValue := ResolveSuperThisValue(AContext);
+  BaseValue := ResolveSuperPropertyBase(AContext, ThisValue);
   KeyValue := ToPropertyKey(APropertyKey);
   if KeyValue is TGocciaSymbolValue then
     PropertyName := TGocciaSymbolValue(KeyValue).ToDisplayString.Value
@@ -2969,10 +2998,10 @@ begin
   BaseObject := TGocciaObjectValue(BaseValue);
   if KeyValue is TGocciaSymbolValue then
     Result := BaseObject.GetSymbolPropertyWithReceiver(
-      TGocciaSymbolValue(KeyValue), AContext.Scope.ThisValue)
+      TGocciaSymbolValue(KeyValue), ThisValue)
   else
     Result := BaseObject.GetPropertyWithContext(PropertyName,
-      AContext.Scope.ThisValue);
+      ThisValue);
 end;
 
 function EvaluateMember(const AMemberExpression: TGocciaMemberExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
@@ -3021,28 +3050,6 @@ var
 
     Result := nil;
   end;
-
-  function ResolveSuperThisValue: TGocciaValue;
-  var
-    ScopeCursor: TGocciaScope;
-  begin
-    ScopeCursor := AContext.Scope;
-    while Assigned(ScopeCursor) do
-    begin
-      if ScopeCursor is TGocciaMethodCallScope then
-      begin
-        if (ScopeCursor.CustomLabel = PROP_CONSTRUCTOR) and
-           Assigned(TGocciaMethodCallScope(ScopeCursor).SuperClass) and
-           not TGocciaMethodCallScope(ScopeCursor).SuperConstructorCalled then
-          ThrowReferenceError(
-            'Must call super constructor before accessing this',
-            'call super() before reading this or super properties');
-        Break;
-      end;
-      ScopeCursor := ScopeCursor.Parent;
-    end;
-    Result := AContext.Scope.ThisValue;
-  end;
 begin
   ObjectEvaluated := False;
 
@@ -3063,7 +3070,7 @@ begin
   // Handle super.method() specially
   if AMemberExpression.ObjectExpr is TGocciaSuperExpression then
   begin
-    ThisValue := ResolveSuperThisValue;
+    ThisValue := ResolveSuperThisValue(AContext);
     SuperClassValue := EvaluateExpression(AMemberExpression.ObjectExpr, AContext);
     if SuperClassValue is TGocciaClassValue then
       SuperClass := TGocciaClassValue(SuperClassValue)

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -2429,6 +2429,26 @@ begin
     Assigned(TGocciaMethodCallScope(CallerFunctionScope).SuperClass);
 end;
 
+function DirectEvalRejectsArgumentsReference(
+  const AScope: TGocciaScope): Boolean;
+var
+  Current: TGocciaScope;
+begin
+  Current := AScope;
+  while Assigned(Current) do
+  begin
+    if (Current is TGocciaCallScope) and
+       not (Current is TGocciaArrowCallScope) then
+      Exit(False);
+    if Current.RejectArgumentsReferenceInDirectEval then
+      Exit(True);
+    if Current.ScopeKind in [skGlobal, skModule] then
+      Exit(False);
+    Current := Current.Parent;
+  end;
+  Result := False;
+end;
+
 function TryEvaluateInterpreterDirectEval(
   const ACallExpression: TGocciaCallExpression;
   const AContext: TGocciaEvaluationContext;
@@ -2518,7 +2538,8 @@ begin
           EvalContext, VarScope, EvalScope, StrictEval,
           EvalContext.RejectArgumentsVarDeclarationInEval,
           EvalContext.RejectVarDeclarationNamesInEval, AllowNewTarget,
-          AllowSuperProperty, AllowSuperCall, False);
+          AllowSuperProperty, AllowSuperCall,
+          DirectEvalRejectsArgumentsReference(AContext.Scope));
       finally
         if Assigned(TGarbageCollector.Instance) then
           TGarbageCollector.Instance.RemoveTempRoot(EvalScope);
@@ -6620,6 +6641,8 @@ var
   InitializerResults: TArray<TGocciaValue>;
   AccessorBackingName: string;
   ExistingDescriptor: TGocciaPropertyDescriptor;
+  StaticFieldContext: TGocciaEvaluationContext;
+  StaticFieldScope: TGocciaScope;
 
   function BuildClassGetter(const AGetterExpression: TGocciaGetterExpression): TGocciaFunctionValue;
   begin
@@ -7072,7 +7095,15 @@ begin
     else if (Elem.Kind = cekField) and Elem.IsStatic then
     begin
       if Assigned(Elem.FieldInitializer) then
-        PropertyValue := EvaluateExpression(Elem.FieldInitializer, AContext)
+      begin
+        StaticFieldContext := AContext;
+        StaticFieldScope := TGocciaClassInitScope.Create(AContext.Scope,
+          ClassValue);
+        StaticFieldScope.ThisValue := ClassValue;
+        StaticFieldContext.Scope := StaticFieldScope;
+        PropertyValue := EvaluateExpression(Elem.FieldInitializer,
+          StaticFieldContext);
+      end
       else
         PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Elem.IsPrivate then

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -40,6 +40,10 @@ function EvaluateDelete(const AOperand: TGocciaExpression; const AContext: TGocc
 function EvaluateCall(const ACallExpression: TGocciaCallExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateMember(const AMemberExpression: TGocciaMemberExpression; const AContext: TGocciaEvaluationContext): TGocciaValue; overload;
 function EvaluateMember(const AMemberExpression: TGocciaMemberExpression; const AContext: TGocciaEvaluationContext; out AObjectValue: TGocciaValue): TGocciaValue; overload;
+function GetSuperProperty(const AContext: TGocciaEvaluationContext;
+  const APropertyKey: TGocciaValue): TGocciaValue;
+procedure AssignSuperProperty(const AContext: TGocciaEvaluationContext;
+  const APropertyKey, AValue: TGocciaValue);
 function EvaluateArray(const AArrayExpression: TGocciaArrayExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateObject(const AObjectExpression: TGocciaObjectExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateGetter(const AGetterExpression: TGocciaGetterExpression; const AContext: TGocciaEvaluationContext; const ASuperClass: TGocciaValue = nil; const AAsMethod: Boolean = False): TGocciaValue;
@@ -102,6 +106,7 @@ function EvaluateEvalProgram(const AProgram: TGocciaProgram;
   const AContext: TGocciaEvaluationContext; const AVarScope,
   ALexicalScope: TGocciaScope; const AStrictEval: Boolean;
   const ARejectArgumentsVarDeclaration: Boolean;
+  const ARejectVarDeclarationNames: TGocciaEvalRejectNameArray;
   const AAllowNewTarget: Boolean = False;
   const AAllowSuperProperty: Boolean = False;
   const AAllowSuperCall: Boolean = False;
@@ -1570,7 +1575,8 @@ end;
 procedure EvalDeclarationInstantiation(const AProgram: TGocciaProgram;
   const AContext: TGocciaEvaluationContext; const AVarScope,
   ALexicalScope: TGocciaScope; const AStrictEval: Boolean;
-  const ARejectArgumentsVarDeclaration: Boolean);
+  const ARejectArgumentsVarDeclaration: Boolean;
+  const ARejectVarDeclarationNames: TGocciaEvalRejectNameArray);
 var
   VarNames: TStringList;
   LexNames: TStringList;
@@ -1584,6 +1590,15 @@ var
   FunctionValue: TGocciaValue;
   Name: string;
   I: Integer;
+  function RejectsVarDeclarationName(const AName: string): Boolean;
+  var
+    J: Integer;
+  begin
+    for J := 0 to High(ARejectVarDeclarationNames) do
+      if ARejectVarDeclarationNames[J] = AName then
+        Exit(True);
+    Result := False;
+  end;
 begin
   VarNames := TStringList.Create;
   LexNames := TStringList.Create;
@@ -1631,7 +1646,15 @@ begin
               [VarNames[I]]), SSuggestAlreadyDeclared);
     end;
 
-    if ARejectArgumentsVarDeclaration and
+    if (not AStrictEval) then
+    begin
+      for I := 0 to VarNames.Count - 1 do
+        if RejectsVarDeclarationName(VarNames[I]) then
+          ThrowSyntaxError(Format(SErrorIdentifierAlreadyDeclared,
+            [VarNames[I]]), SSuggestAlreadyDeclared);
+    end;
+
+    if (not AStrictEval) and ARejectArgumentsVarDeclaration and
        (VarNames.IndexOf(IDENTIFIER_ARGUMENTS) >= 0) then
       ThrowSyntaxError(Format(SErrorIdentifierAlreadyDeclared,
         [IDENTIFIER_ARGUMENTS]), SSuggestAlreadyDeclared);
@@ -1713,6 +1736,7 @@ function EvaluateEvalProgram(const AProgram: TGocciaProgram;
   const AContext: TGocciaEvaluationContext; const AVarScope,
   ALexicalScope: TGocciaScope; const AStrictEval: Boolean;
   const ARejectArgumentsVarDeclaration: Boolean;
+  const ARejectVarDeclarationNames: TGocciaEvalRejectNameArray;
   const AAllowNewTarget: Boolean; const AAllowSuperProperty: Boolean;
   const AAllowSuperCall: Boolean;
   const ARejectArgumentsReference: Boolean): TGocciaValue;
@@ -1736,7 +1760,7 @@ begin
   AVarScope.NonStrictMode := not AStrictEval;
 
   EvalDeclarationInstantiation(AProgram, EvalContext, AVarScope, ALexicalScope,
-    AStrictEval, ARejectArgumentsVarDeclaration);
+    AStrictEval, ARejectArgumentsVarDeclaration, ARejectVarDeclarationNames);
 
   LastValue := TGocciaUndefinedLiteralValue.UndefinedValue;
   CF := TGocciaControlFlow.Normal(LastValue);
@@ -2492,7 +2516,8 @@ begin
         AllowSuperCall := DirectEvalAllowsSuperCall(CallerFunctionScope);
         AResult := EvaluateEvalProgram(PipelineResult.ProgramNode,
           EvalContext, VarScope, EvalScope, StrictEval,
-          EvalContext.RejectArgumentsVarDeclarationInEval, AllowNewTarget,
+          EvalContext.RejectArgumentsVarDeclarationInEval,
+          EvalContext.RejectVarDeclarationNamesInEval, AllowNewTarget,
           AllowSuperProperty, AllowSuperCall, False);
       finally
         if Assigned(TGarbageCollector.Instance) then
@@ -2832,6 +2857,102 @@ begin
 end;
 
 function EvaluateMemberCore(const AMemberExpression: TGocciaMemberExpression; const AContext: TGocciaEvaluationContext; const AOutObjectValue: PGocciaValue): TGocciaValue; forward;
+function ResolveSuperPropertyBase(const AContext: TGocciaEvaluationContext): TGocciaValue; forward;
+
+procedure AssignSuperProperty(const AContext: TGocciaEvaluationContext;
+  const APropertyKey, AValue: TGocciaValue);
+var
+  BaseObject: TGocciaObjectValue;
+  BaseValue: TGocciaValue;
+  KeyValue: TGocciaValue;
+  PropertyName: string;
+  Success: Boolean;
+begin
+  BaseValue := ResolveSuperPropertyBase(AContext);
+  KeyValue := ToPropertyKey(APropertyKey);
+  if KeyValue is TGocciaSymbolValue then
+    PropertyName := TGocciaSymbolValue(KeyValue).ToDisplayString.Value
+  else
+    PropertyName := TGocciaStringLiteralValue(KeyValue).Value;
+
+  if not (BaseValue is TGocciaObjectValue) then
+    ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, [PropertyName]),
+      SSuggestCheckNullBeforeAccess);
+
+  BaseObject := TGocciaObjectValue(BaseValue);
+  if KeyValue is TGocciaSymbolValue then
+    Success := BaseObject.AssignSymbolPropertyWithReceiver(
+      TGocciaSymbolValue(KeyValue), AValue, AContext.Scope.ThisValue)
+  else
+    Success := BaseObject.AssignPropertyWithReceiver(PropertyName, AValue,
+      AContext.Scope.ThisValue);
+
+  if not Success then
+    ThrowTypeError(Format(SErrorCannotAssignReadOnly, [PropertyName]),
+      SSuggestCannotDeleteNonConfigurable);
+end;
+
+function ResolveSuperPropertyBase(const AContext: TGocciaEvaluationContext): TGocciaValue;
+var
+  OwningClass: TGocciaClassValue;
+  OwningClassValue: TGocciaValue;
+  SuperClassValue: TGocciaValue;
+begin
+  Result := nil;
+  OwningClassValue := AContext.Scope.FindOwningClass;
+
+  if AContext.Scope.ThisValue is TGocciaClassValue then
+  begin
+    if OwningClassValue is TGocciaObjectValue then
+      Exit(TGocciaObjectValue(OwningClassValue).Prototype);
+
+    SuperClassValue := AContext.Scope.FindSuperClass;
+    if SuperClassValue is TGocciaObjectValue then
+      Exit(SuperClassValue);
+    Exit(nil);
+  end;
+
+  if OwningClassValue is TGocciaClassValue then
+  begin
+    OwningClass := TGocciaClassValue(OwningClassValue);
+    if Assigned(OwningClass.Prototype) then
+      Exit(OwningClass.Prototype.Prototype);
+  end;
+
+  SuperClassValue := AContext.Scope.FindSuperClass;
+  if SuperClassValue is TGocciaClassValue then
+    Exit(TGocciaClassValue(SuperClassValue).Prototype);
+  if SuperClassValue is TGocciaObjectValue then
+    Exit(TGocciaObjectValue(SuperClassValue).Prototype);
+end;
+
+function GetSuperProperty(const AContext: TGocciaEvaluationContext;
+  const APropertyKey: TGocciaValue): TGocciaValue;
+var
+  BaseObject: TGocciaObjectValue;
+  BaseValue: TGocciaValue;
+  KeyValue: TGocciaValue;
+  PropertyName: string;
+begin
+  BaseValue := ResolveSuperPropertyBase(AContext);
+  KeyValue := ToPropertyKey(APropertyKey);
+  if KeyValue is TGocciaSymbolValue then
+    PropertyName := TGocciaSymbolValue(KeyValue).ToDisplayString.Value
+  else
+    PropertyName := TGocciaStringLiteralValue(KeyValue).Value;
+
+  if not (BaseValue is TGocciaObjectValue) then
+    ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull, [PropertyName]),
+      SSuggestCheckNullBeforeAccess);
+
+  BaseObject := TGocciaObjectValue(BaseValue);
+  if KeyValue is TGocciaSymbolValue then
+    Result := BaseObject.GetSymbolPropertyWithReceiver(
+      TGocciaSymbolValue(KeyValue), AContext.Scope.ThisValue)
+  else
+    Result := BaseObject.GetPropertyWithContext(PropertyName,
+      AContext.Scope.ThisValue);
+end;
 
 function EvaluateMember(const AMemberExpression: TGocciaMemberExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 begin
@@ -2846,6 +2967,7 @@ end;
 function EvaluateMemberCore(const AMemberExpression: TGocciaMemberExpression; const AContext: TGocciaEvaluationContext; const AOutObjectValue: PGocciaValue): TGocciaValue;
 var
   Obj: TGocciaValue;
+  ThisValue: TGocciaValue;
   PropertyName: string;
   PropertyValue: TGocciaValue;
   PropertyKey: TGocciaValue;
@@ -2878,6 +3000,28 @@ var
 
     Result := nil;
   end;
+
+  function ResolveSuperThisValue: TGocciaValue;
+  var
+    ScopeCursor: TGocciaScope;
+  begin
+    ScopeCursor := AContext.Scope;
+    while Assigned(ScopeCursor) do
+    begin
+      if ScopeCursor is TGocciaMethodCallScope then
+      begin
+        if (ScopeCursor.CustomLabel = PROP_CONSTRUCTOR) and
+           Assigned(TGocciaMethodCallScope(ScopeCursor).SuperClass) and
+           not TGocciaMethodCallScope(ScopeCursor).SuperConstructorCalled then
+          ThrowReferenceError(
+            'Must call super constructor before accessing this',
+            'call super() before reading this or super properties');
+        Break;
+      end;
+      ScopeCursor := ScopeCursor.Parent;
+    end;
+    Result := AContext.Scope.ThisValue;
+  end;
 begin
   ObjectEvaluated := False;
 
@@ -2898,6 +3042,7 @@ begin
   // Handle super.method() specially
   if AMemberExpression.ObjectExpr is TGocciaSuperExpression then
   begin
+    ThisValue := ResolveSuperThisValue;
     SuperClassValue := EvaluateExpression(AMemberExpression.ObjectExpr, AContext);
     if SuperClassValue is TGocciaClassValue then
       SuperClass := TGocciaClassValue(SuperClassValue)
@@ -2922,14 +3067,14 @@ begin
       PropertyKey := ToPropertyKey(PropertyValue);
       if PropertyKey is TGocciaSymbolValue then
       begin
-        if AContext.Scope.ThisValue is TGocciaClassValue then
+        if ThisValue is TGocciaClassValue then
         begin
           if Assigned(SuperClass) then
             Result := SuperClass.GetSymbolPropertyWithReceiver(
-              TGocciaSymbolValue(PropertyKey), AContext.Scope.ThisValue)
+              TGocciaSymbolValue(PropertyKey), ThisValue)
           else
             Result := SuperObject.GetSymbolPropertyWithReceiver(
-              TGocciaSymbolValue(PropertyKey), AContext.Scope.ThisValue);
+              TGocciaSymbolValue(PropertyKey), ThisValue);
         end
         else
         begin
@@ -2937,7 +3082,7 @@ begin
 
           if SuperPrototype is TGocciaObjectValue then
             Result := TGocciaObjectValue(SuperPrototype).GetSymbolPropertyWithReceiver(
-              TGocciaSymbolValue(PropertyKey), AContext.Scope.ThisValue)
+              TGocciaSymbolValue(PropertyKey), ThisValue)
           else
             Result := TGocciaUndefinedLiteralValue.UndefinedValue;
         end;
@@ -2951,15 +3096,15 @@ begin
     end;
 
     // Check if we're in a static method context or instance method context
-    if AContext.Scope.ThisValue is TGocciaClassValue then
+    if ThisValue is TGocciaClassValue then
     begin
       // Static method context: look for static methods using GetProperty
       if Assigned(SuperClass) then
         Result := SuperClass.GetPropertyWithContext(
-          PropertyName, AContext.Scope.ThisValue)
+          PropertyName, ThisValue)
       else
         Result := SuperObject.GetPropertyWithContext(
-          PropertyName, AContext.Scope.ThisValue);
+          PropertyName, ThisValue);
     end
     else
     begin
@@ -2968,7 +3113,7 @@ begin
       begin
         if Assigned(SuperClass.Prototype) then
           Result := SuperClass.Prototype.GetPropertyWithContext(
-            PropertyName, AContext.Scope.ThisValue)
+            PropertyName, ThisValue)
         else
           Result := TGocciaUndefinedLiteralValue.UndefinedValue;
       end
@@ -2977,7 +3122,7 @@ begin
         SuperPrototype := ResolveInstanceSuperPrototype;
         if SuperPrototype is TGocciaObjectValue then
           Result := TGocciaObjectValue(SuperPrototype).GetPropertyWithContext(
-            PropertyName, AContext.Scope.ThisValue)
+            PropertyName, ThisValue)
         else
           Result := TGocciaUndefinedLiteralValue.UndefinedValue;
       end;
@@ -9306,6 +9451,7 @@ var
   ElementValue: TGocciaValue;
   RestElements: TGocciaArrayValue;
   Exhausted: Boolean;
+  ShouldCloseIterator: Boolean;
 begin
   if (AValue is TGocciaNullLiteralValue) or (AValue is TGocciaUndefinedLiteralValue) then
     ThrowTypeError(
@@ -9333,12 +9479,14 @@ begin
       // an already-done iterator is observable when the user's next()
       // has side effects.
       Exhausted := False;
+      ShouldCloseIterator := False;
       for I := 0 to APattern.Elements.Count - 1 do
       begin
         if APattern.Elements[I] = nil then
         begin
           if not Exhausted then
           begin
+            ShouldCloseIterator := False;
             IterResult := Iterator.AdvanceNext;
             if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
               Exhausted := True;
@@ -9353,6 +9501,7 @@ begin
           try
             if not Exhausted then
             begin
+              ShouldCloseIterator := False;
               IterResult := Iterator.AdvanceNext;
               while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
               begin
@@ -9360,10 +9509,12 @@ begin
                 if not Assigned(ElementValue) then
                   ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
                 RestElements.Elements.Add(ElementValue);
+                ShouldCloseIterator := False;
                 IterResult := Iterator.AdvanceNext;
               end;
               Exhausted := True;
             end;
+            ShouldCloseIterator := False;
             AssignPattern(TGocciaRestDestructuringPattern(APattern.Elements[I]).Argument, RestElements, AContext, AIsDeclaration, ADeclarationType);
           finally
             TGarbageCollector.Instance.RemoveTempRoot(RestElements);
@@ -9376,26 +9527,31 @@ begin
             ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue
           else
           begin
+            ShouldCloseIterator := False;
             IterResult := Iterator.AdvanceNext;
             if IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
             begin
               Exhausted := True;
               ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+              ShouldCloseIterator := False;
             end
             else
             begin
               ElementValue := IterResult.GetProperty(PROP_VALUE);
               if not Assigned(ElementValue) then
                 ElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+              ShouldCloseIterator := True;
             end;
           end;
 
           AssignPattern(APattern.Elements[I], ElementValue, AContext, AIsDeclaration, ADeclarationType);
+          ShouldCloseIterator := False;
         end;
       end;
     except
       AcquireExceptionObject;
-      CloseIteratorPreservingError(Iterator);
+      if ShouldCloseIterator then
+        CloseIteratorPreservingError(Iterator);
       raise;
     end;
     CloseIterator(Iterator);

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -104,7 +104,8 @@ function EvaluateEvalProgram(const AProgram: TGocciaProgram;
   const ARejectArgumentsVarDeclaration: Boolean;
   const AAllowNewTarget: Boolean = False;
   const AAllowSuperProperty: Boolean = False;
-  const AAllowSuperCall: Boolean = False): TGocciaValue;
+  const AAllowSuperCall: Boolean = False;
+  const ARejectArgumentsReference: Boolean = False): TGocciaValue;
 
 implementation
 
@@ -644,6 +645,425 @@ begin
   end;
 end;
 
+function EvalExpressionContainsArgumentsReference(
+  const AExpr: TGocciaExpression): Boolean; forward;
+function EvalPatternContainsArgumentsReference(
+  const APattern: TGocciaDestructuringPattern): Boolean; forward;
+function EvalStatementContainsArgumentsReference(
+  const AStmt: TGocciaStatement): Boolean; forward;
+
+function EvalParameterListContainsArgumentsReference(
+  const AParameters: TGocciaParameterArray): Boolean;
+var
+  I: Integer;
+begin
+  for I := 0 to High(AParameters) do
+  begin
+    if AParameters[I].IsPattern and
+       EvalPatternContainsArgumentsReference(AParameters[I].Pattern) then
+      Exit(True);
+    if EvalExpressionContainsArgumentsReference(AParameters[I].DefaultValue) then
+      Exit(True);
+  end;
+  Result := False;
+end;
+
+function EvalASTNodeContainsArgumentsReference(
+  const ANode: TGocciaASTNode): Boolean;
+begin
+  if ANode is TGocciaStatement then
+    Exit(EvalStatementContainsArgumentsReference(TGocciaStatement(ANode)));
+  if ANode is TGocciaExpression then
+    Exit(EvalExpressionContainsArgumentsReference(TGocciaExpression(ANode)));
+  Result := False;
+end;
+
+function EvalExpressionContainsArgumentsReference(
+  const AExpr: TGocciaExpression): Boolean;
+var
+  CallExpr: TGocciaCallExpression;
+  MemberExpr: TGocciaMemberExpression;
+  ArrayExpr: TGocciaArrayExpression;
+  ObjectExpr: TGocciaObjectExpression;
+  ArrowExpr: TGocciaArrowFunctionExpression;
+  NewExpr: TGocciaNewExpression;
+  Pair: TPair<TGocciaExpression, TGocciaExpression>;
+  I: Integer;
+begin
+  if not Assigned(AExpr) then
+    Exit(False);
+
+  if AExpr is TGocciaIdentifierExpression then
+    Exit(TGocciaIdentifierExpression(AExpr).Name = IDENTIFIER_ARGUMENTS)
+  else if AExpr is TGocciaArrowFunctionExpression then
+  begin
+    ArrowExpr := TGocciaArrowFunctionExpression(AExpr);
+    if EvalParameterListContainsArgumentsReference(ArrowExpr.Parameters) then
+      Exit(True);
+    Exit(EvalASTNodeContainsArgumentsReference(ArrowExpr.Body));
+  end
+  else if AExpr is TGocciaFunctionExpression then
+    Exit(False)
+  else if AExpr is TGocciaCallExpression then
+  begin
+    CallExpr := TGocciaCallExpression(AExpr);
+    if EvalExpressionContainsArgumentsReference(CallExpr.Callee) then
+      Exit(True);
+    for I := 0 to CallExpr.Arguments.Count - 1 do
+      if EvalExpressionContainsArgumentsReference(CallExpr.Arguments[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaMemberExpression then
+  begin
+    MemberExpr := TGocciaMemberExpression(AExpr);
+    if EvalExpressionContainsArgumentsReference(MemberExpr.ObjectExpr) then
+      Exit(True);
+    if MemberExpr.Computed and
+       EvalExpressionContainsArgumentsReference(MemberExpr.PropertyExpression) then
+      Exit(True);
+  end
+  else if AExpr is TGocciaBinaryExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaBinaryExpression(AExpr).Left) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaBinaryExpression(AExpr).Right))
+  else if AExpr is TGocciaSequenceExpression then
+  begin
+    for I := 0 to TGocciaSequenceExpression(AExpr).Expressions.Count - 1 do
+      if EvalExpressionContainsArgumentsReference(
+        TGocciaSequenceExpression(AExpr).Expressions[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaUnaryExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaUnaryExpression(AExpr).Operand))
+  else if AExpr is TGocciaAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaPropertyAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaPropertyAssignmentExpression(AExpr).ObjectExpr) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaPropertyAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaComputedPropertyAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaComputedPropertyAssignmentExpression(AExpr).ObjectExpr) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaComputedPropertyAssignmentExpression(AExpr).PropertyExpression) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaComputedPropertyAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaCompoundAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaCompoundAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaPropertyCompoundAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaPropertyCompoundAssignmentExpression(AExpr).ObjectExpr) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaPropertyCompoundAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaComputedPropertyCompoundAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).ObjectExpr) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).PropertyExpression) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaIncrementExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaIncrementExpression(AExpr).Operand))
+  else if AExpr is TGocciaArrayExpression then
+  begin
+    ArrayExpr := TGocciaArrayExpression(AExpr);
+    for I := 0 to ArrayExpr.Elements.Count - 1 do
+      if EvalExpressionContainsArgumentsReference(ArrayExpr.Elements[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaObjectExpression then
+  begin
+    ObjectExpr := TGocciaObjectExpression(AExpr);
+    for I := 0 to High(ObjectExpr.PropertySourceOrder) do
+      case ObjectExpr.PropertySourceOrder[I].PropertyType of
+        pstStatic:
+          if EvalExpressionContainsArgumentsReference(
+              ObjectExpr.PropertySourceOrder[I].Expression) then
+            Exit(True);
+        pstComputed:
+          begin
+            Pair := ObjectExpr.ComputedPropertiesInOrder[
+              ObjectExpr.PropertySourceOrder[I].ComputedIndex];
+            if EvalExpressionContainsArgumentsReference(Pair.Key) or
+               EvalExpressionContainsArgumentsReference(Pair.Value) then
+              Exit(True);
+          end;
+        pstComputedGetter,
+        pstComputedSetter:
+          begin
+            Pair := ObjectExpr.ComputedPropertiesInOrder[
+              ObjectExpr.PropertySourceOrder[I].ComputedIndex];
+            if EvalExpressionContainsArgumentsReference(Pair.Key) then
+              Exit(True);
+          end;
+      end;
+  end
+  else if AExpr is TGocciaYieldExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaYieldExpression(AExpr).Operand))
+  else if AExpr is TGocciaAwaitExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaAwaitExpression(AExpr).Operand))
+  else if AExpr is TGocciaConditionalExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaConditionalExpression(AExpr).Condition) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaConditionalExpression(AExpr).Consequent) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaConditionalExpression(AExpr).Alternate))
+  else if AExpr is TGocciaNewExpression then
+  begin
+    NewExpr := TGocciaNewExpression(AExpr);
+    if EvalExpressionContainsArgumentsReference(NewExpr.Callee) then
+      Exit(True);
+    for I := 0 to NewExpr.Arguments.Count - 1 do
+      if EvalExpressionContainsArgumentsReference(NewExpr.Arguments[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaSpreadExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaSpreadExpression(AExpr).Argument))
+  else if AExpr is TGocciaTemplateWithInterpolationExpression then
+  begin
+    for I := 0 to TGocciaTemplateWithInterpolationExpression(AExpr).Parts.Count - 1 do
+      if EvalExpressionContainsArgumentsReference(
+        TGocciaTemplateWithInterpolationExpression(AExpr).Parts[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaTaggedTemplateExpression then
+  begin
+    if EvalExpressionContainsArgumentsReference(
+        TGocciaTaggedTemplateExpression(AExpr).Tag) then
+      Exit(True);
+    for I := 0 to TGocciaTaggedTemplateExpression(AExpr).Expressions.Count - 1 do
+      if EvalExpressionContainsArgumentsReference(
+        TGocciaTaggedTemplateExpression(AExpr).Expressions[I]) then
+        Exit(True);
+  end
+  else if AExpr is TGocciaDestructuringAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaDestructuringAssignmentExpression(AExpr).Right))
+  else if AExpr is TGocciaPrivateMemberExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaPrivateMemberExpression(AExpr).ObjectExpr))
+  else if AExpr is TGocciaPrivatePropertyAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaPrivatePropertyAssignmentExpression(AExpr).ObjectExpr) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaPrivatePropertyAssignmentExpression(AExpr).Value))
+  else if AExpr is TGocciaPrivatePropertyCompoundAssignmentExpression then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaPrivatePropertyCompoundAssignmentExpression(AExpr).ObjectExpr) or
+      EvalExpressionContainsArgumentsReference(
+        TGocciaPrivatePropertyCompoundAssignmentExpression(AExpr).Value));
+
+  Result := False;
+end;
+
+function EvalPatternContainsArgumentsReference(
+  const APattern: TGocciaDestructuringPattern): Boolean;
+var
+  ArrayPattern: TGocciaArrayDestructuringPattern;
+  ObjectPattern: TGocciaObjectDestructuringPattern;
+  AssignmentPattern: TGocciaAssignmentDestructuringPattern;
+  Prop: TGocciaDestructuringProperty;
+  I: Integer;
+begin
+  if not Assigned(APattern) then
+    Exit(False);
+
+  if APattern is TGocciaArrayDestructuringPattern then
+  begin
+    ArrayPattern := TGocciaArrayDestructuringPattern(APattern);
+    for I := 0 to ArrayPattern.Elements.Count - 1 do
+      if EvalPatternContainsArgumentsReference(ArrayPattern.Elements[I]) then
+        Exit(True);
+  end
+  else if APattern is TGocciaObjectDestructuringPattern then
+  begin
+    ObjectPattern := TGocciaObjectDestructuringPattern(APattern);
+    for I := 0 to ObjectPattern.Properties.Count - 1 do
+    begin
+      Prop := ObjectPattern.Properties[I];
+      if Prop.Computed and
+         EvalExpressionContainsArgumentsReference(Prop.KeyExpression) then
+        Exit(True);
+      if EvalPatternContainsArgumentsReference(Prop.Pattern) then
+        Exit(True);
+    end;
+  end
+  else if APattern is TGocciaAssignmentDestructuringPattern then
+  begin
+    AssignmentPattern := TGocciaAssignmentDestructuringPattern(APattern);
+    Exit(EvalPatternContainsArgumentsReference(AssignmentPattern.Left) or
+      EvalExpressionContainsArgumentsReference(AssignmentPattern.Right));
+  end
+  else if APattern is TGocciaRestDestructuringPattern then
+    Exit(EvalPatternContainsArgumentsReference(
+      TGocciaRestDestructuringPattern(APattern).Argument))
+  else if APattern is TGocciaMemberExpressionDestructuringPattern then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaMemberExpressionDestructuringPattern(APattern).Expression))
+  else if APattern is TGocciaPrivateMemberExpressionDestructuringPattern then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaPrivateMemberExpressionDestructuringPattern(APattern).Expression));
+
+  Result := False;
+end;
+
+function EvalStatementContainsArgumentsReference(
+  const AStmt: TGocciaStatement): Boolean;
+var
+  VarDecl: TGocciaVariableDeclaration;
+  DestructDecl: TGocciaDestructuringDeclaration;
+  BlockStmt: TGocciaBlockStatement;
+  IfStmt: TGocciaIfStatement;
+  ForStmt: TGocciaForStatement;
+  ForOfStmt: TGocciaForOfStatement;
+  ForInStmt: TGocciaForInStatement;
+  WhileStmt: TGocciaWhileStatement;
+  DoWhileStmt: TGocciaDoWhileStatement;
+  WithStmt: TGocciaWithStatement;
+  ReturnStmt: TGocciaReturnStatement;
+  ThrowStmt: TGocciaThrowStatement;
+  TryStmt: TGocciaTryStatement;
+  SwitchStmt: TGocciaSwitchStatement;
+  UsingDecl: TGocciaUsingDeclaration;
+  I, J: Integer;
+begin
+  if not Assigned(AStmt) then
+    Exit(False);
+
+  if AStmt is TGocciaExpressionStatement then
+    Exit(EvalExpressionContainsArgumentsReference(
+      TGocciaExpressionStatement(AStmt).Expression))
+  else if AStmt is TGocciaVariableDeclaration then
+  begin
+    VarDecl := TGocciaVariableDeclaration(AStmt);
+    for I := 0 to High(VarDecl.Variables) do
+      if EvalExpressionContainsArgumentsReference(
+          VarDecl.Variables[I].Initializer) then
+        Exit(True);
+  end
+  else if AStmt is TGocciaDestructuringDeclaration then
+  begin
+    DestructDecl := TGocciaDestructuringDeclaration(AStmt);
+    Exit(EvalPatternContainsArgumentsReference(DestructDecl.Pattern) or
+      EvalExpressionContainsArgumentsReference(DestructDecl.Initializer));
+  end
+  else if AStmt is TGocciaBlockStatement then
+  begin
+    BlockStmt := TGocciaBlockStatement(AStmt);
+    for I := 0 to BlockStmt.Nodes.Count - 1 do
+      if EvalASTNodeContainsArgumentsReference(BlockStmt.Nodes[I]) then
+        Exit(True);
+  end
+  else if AStmt is TGocciaIfStatement then
+  begin
+    IfStmt := TGocciaIfStatement(AStmt);
+    Exit(EvalExpressionContainsArgumentsReference(IfStmt.Condition) or
+      EvalStatementContainsArgumentsReference(IfStmt.Consequent) or
+      EvalStatementContainsArgumentsReference(IfStmt.Alternate));
+  end
+  else if AStmt is TGocciaForStatement then
+  begin
+    ForStmt := TGocciaForStatement(AStmt);
+    Exit(EvalStatementContainsArgumentsReference(ForStmt.Init) or
+      EvalExpressionContainsArgumentsReference(ForStmt.Condition) or
+      EvalExpressionContainsArgumentsReference(ForStmt.Update) or
+      EvalStatementContainsArgumentsReference(ForStmt.Body));
+  end
+  else if AStmt is TGocciaForOfStatement then
+  begin
+    ForOfStmt := TGocciaForOfStatement(AStmt);
+    Exit(EvalExpressionContainsArgumentsReference(ForOfStmt.Iterable) or
+      EvalStatementContainsArgumentsReference(ForOfStmt.Body));
+  end
+  else if AStmt is TGocciaForInStatement then
+  begin
+    ForInStmt := TGocciaForInStatement(AStmt);
+    Exit(EvalExpressionContainsArgumentsReference(ForInStmt.ObjectExpression) or
+      EvalStatementContainsArgumentsReference(ForInStmt.Body));
+  end
+  else if AStmt is TGocciaWhileStatement then
+  begin
+    WhileStmt := TGocciaWhileStatement(AStmt);
+    Exit(EvalExpressionContainsArgumentsReference(WhileStmt.Condition) or
+      EvalStatementContainsArgumentsReference(WhileStmt.Body));
+  end
+  else if AStmt is TGocciaDoWhileStatement then
+  begin
+    DoWhileStmt := TGocciaDoWhileStatement(AStmt);
+    Exit(EvalStatementContainsArgumentsReference(DoWhileStmt.Body) or
+      EvalExpressionContainsArgumentsReference(DoWhileStmt.Condition));
+  end
+  else if AStmt is TGocciaWithStatement then
+  begin
+    WithStmt := TGocciaWithStatement(AStmt);
+    Exit(EvalExpressionContainsArgumentsReference(WithStmt.ObjectExpression) or
+      EvalStatementContainsArgumentsReference(WithStmt.Body));
+  end
+  else if AStmt is TGocciaReturnStatement then
+  begin
+    ReturnStmt := TGocciaReturnStatement(AStmt);
+    Exit(EvalExpressionContainsArgumentsReference(ReturnStmt.Value));
+  end
+  else if AStmt is TGocciaThrowStatement then
+  begin
+    ThrowStmt := TGocciaThrowStatement(AStmt);
+    Exit(EvalExpressionContainsArgumentsReference(ThrowStmt.Value));
+  end
+  else if AStmt is TGocciaTryStatement then
+  begin
+    TryStmt := TGocciaTryStatement(AStmt);
+    Exit(EvalStatementContainsArgumentsReference(TryStmt.Block) or
+      EvalStatementContainsArgumentsReference(TryStmt.CatchBlock) or
+      EvalStatementContainsArgumentsReference(TryStmt.FinallyBlock));
+  end
+  else if AStmt is TGocciaSwitchStatement then
+  begin
+    SwitchStmt := TGocciaSwitchStatement(AStmt);
+    if EvalExpressionContainsArgumentsReference(SwitchStmt.Discriminant) then
+      Exit(True);
+    for I := 0 to SwitchStmt.Cases.Count - 1 do
+    begin
+      if EvalExpressionContainsArgumentsReference(SwitchStmt.Cases[I].Test) then
+        Exit(True);
+      for J := 0 to SwitchStmt.Cases[I].Consequent.Count - 1 do
+        if EvalStatementContainsArgumentsReference(
+            SwitchStmt.Cases[I].Consequent[J]) then
+          Exit(True);
+    end;
+  end
+  else if AStmt is TGocciaUsingDeclaration then
+  begin
+    UsingDecl := TGocciaUsingDeclaration(AStmt);
+    for I := 0 to High(UsingDecl.Variables) do
+      if EvalExpressionContainsArgumentsReference(
+          UsingDecl.Variables[I].Initializer) then
+        Exit(True);
+  end;
+
+  Result := False;
+end;
+
+function EvalProgramContainsArgumentsReference(
+  const AProgram: TGocciaProgram): Boolean;
+var
+  I: Integer;
+begin
+  for I := 0 to AProgram.Body.Count - 1 do
+    if EvalStatementContainsArgumentsReference(AProgram.Body[I]) then
+      Exit(True);
+  Result := False;
+end;
+
 procedure ValidateEvalEarlyErrorExpression(const AExpr: TGocciaExpression;
   const AAllowNewTarget, AAllowSuperProperty, AAllowSuperCall: Boolean); forward;
 procedure ValidateEvalEarlyErrorPattern(
@@ -830,6 +1250,7 @@ var
   MemberExpr: TGocciaMemberExpression;
   ArrayExpr: TGocciaArrayExpression;
   ObjectExpr: TGocciaObjectExpression;
+  ArrowExpr: TGocciaArrowFunctionExpression;
   NewExpr: TGocciaNewExpression;
   Pair: TPair<TGocciaExpression, TGocciaExpression>;
   I: Integer;
@@ -844,7 +1265,25 @@ begin
     Exit;
   end;
 
-  if AExpr is TGocciaCallExpression then
+  if AExpr is TGocciaArrowFunctionExpression then
+  begin
+    ArrowExpr := TGocciaArrowFunctionExpression(AExpr);
+    for I := 0 to High(ArrowExpr.Parameters) do
+    begin
+      if ArrowExpr.Parameters[I].IsPattern then
+        ValidateEvalEarlyErrorPattern(ArrowExpr.Parameters[I].Pattern,
+          AAllowNewTarget, AAllowSuperProperty, AAllowSuperCall);
+      ValidateEvalEarlyErrorExpression(ArrowExpr.Parameters[I].DefaultValue,
+        AAllowNewTarget, AAllowSuperProperty, AAllowSuperCall);
+    end;
+    if ArrowExpr.Body is TGocciaStatement then
+      ValidateEvalEarlyErrorStatement(TGocciaStatement(ArrowExpr.Body),
+        False, AAllowNewTarget, AAllowSuperProperty, AAllowSuperCall)
+    else if ArrowExpr.Body is TGocciaExpression then
+      ValidateEvalEarlyErrorExpression(TGocciaExpression(ArrowExpr.Body),
+        AAllowNewTarget, AAllowSuperProperty, AAllowSuperCall);
+  end
+  else if AExpr is TGocciaCallExpression then
   begin
     CallExpr := TGocciaCallExpression(AExpr);
     if CallExpr.Callee is TGocciaSuperExpression then
@@ -1275,13 +1714,18 @@ function EvaluateEvalProgram(const AProgram: TGocciaProgram;
   ALexicalScope: TGocciaScope; const AStrictEval: Boolean;
   const ARejectArgumentsVarDeclaration: Boolean;
   const AAllowNewTarget: Boolean; const AAllowSuperProperty: Boolean;
-  const AAllowSuperCall: Boolean): TGocciaValue;
+  const AAllowSuperCall: Boolean;
+  const ARejectArgumentsReference: Boolean): TGocciaValue;
 var
   EvalContext: TGocciaEvaluationContext;
   CF: TGocciaControlFlow;
   I: Integer;
+  LastValue: TGocciaValue;
 begin
   ValidateEvalScriptBody(AProgram.Body);
+  if ARejectArgumentsReference and
+     EvalProgramContainsArgumentsReference(AProgram) then
+    ThrowSyntaxError('arguments is not allowed in this eval context');
   ValidateEvalEarlyErrors(AProgram, AStrictEval, AAllowNewTarget,
     AAllowSuperProperty, AAllowSuperCall);
   EvalContext := AContext;
@@ -1294,20 +1738,20 @@ begin
   EvalDeclarationInstantiation(AProgram, EvalContext, AVarScope, ALexicalScope,
     AStrictEval, ARejectArgumentsVarDeclaration);
 
-  CF := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
+  LastValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+  CF := TGocciaControlFlow.Normal(LastValue);
   for I := 0 to AProgram.Body.Count - 1 do
   begin
     CF := EvaluateStatement(AProgram.Body[I], EvalContext);
+    if (CF.Kind = cfkNormal) and Assigned(CF.Value) then
+      LastValue := CF.Value;
     if CF.Kind <> cfkNormal then
       Break;
   end;
 
   case CF.Kind of
     cfkNormal:
-      if Assigned(CF.Value) then
-        Result := CF.Value
-      else
-        Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Result := LastValue;
     cfkReturn:
       ThrowSyntaxError('Illegal return statement', SSuggestExpressionExpected);
     cfkBreak:
@@ -2049,7 +2493,7 @@ begin
         AResult := EvaluateEvalProgram(PipelineResult.ProgramNode,
           EvalContext, VarScope, EvalScope, StrictEval,
           EvalContext.RejectArgumentsVarDeclarationInEval, AllowNewTarget,
-          AllowSuperProperty, AllowSuperCall);
+          AllowSuperProperty, AllowSuperCall, False);
       finally
         if Assigned(TGarbageCollector.Instance) then
           TGarbageCollector.Instance.RemoveTempRoot(EvalScope);
@@ -5322,9 +5766,13 @@ begin
       end
       else if FOEntry.IsPrivate then
       begin
-        if AClassValue.PrivateInstancePropertyDefs.TryGetValue(FOEntry.Name, Expr) and Assigned(Expr) then
+        if AClassValue.PrivateInstancePropertyDefs.TryGetValue(
+          FOEntry.Name, Expr) then
         begin
-          PropertyValue := EvaluateExpression(Expr, LocalContext);
+          if Assigned(Expr) then
+            PropertyValue := EvaluateExpression(Expr, LocalContext)
+          else
+            PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
           AInstance.SetPrivateProperty(FOEntry.Name, PropertyValue, AClassValue);
         end;
       end
@@ -5405,9 +5853,13 @@ begin
       end
       else if FOEntry.IsPrivate then
       begin
-        if AClassValue.PrivateInstancePropertyDefs.TryGetValue(FOEntry.Name, Expr) and Assigned(Expr) then
+        if AClassValue.PrivateInstancePropertyDefs.TryGetValue(
+          FOEntry.Name, Expr) then
         begin
-          PropertyValue := EvaluateExpression(Expr, AContext);
+          if Assigned(Expr) then
+            PropertyValue := EvaluateExpression(Expr, AContext)
+          else
+            PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
           InitializeRawPrivateInstanceProperty(AInstance, FOEntry.Name,
             PropertyValue, AClassValue, AInitializationMode = iimReplay);
         end;
@@ -7049,6 +7501,65 @@ begin
     SSuggestPrivateFieldAccess);
 end;
 
+function PrivateLookupName(const AAccessClass: TGocciaClassValue;
+  const APrivateName: string): string;
+var
+  InternalKey: string;
+begin
+  Result := APrivateName;
+  if Assigned(AAccessClass) and
+     AAccessClass.ResolveDeclaredPrivateKey(APrivateName, InternalKey) then
+    Result := InternalKey;
+end;
+
+function BytecodePrivateBrandKeyForLookup(const APrivateLookupName: string;
+  const AAccessClass: TGocciaClassValue): string;
+var
+  Body: string;
+  DelimiterPos: SizeInt;
+  BrandToken: string;
+begin
+  Result := '';
+  if Copy(APrivateLookupName, 1, Length('#slot:')) <> '#slot:' then
+    Exit;
+
+  BrandToken := '';
+  Body := Copy(APrivateLookupName, Length('#slot:') + 1, MaxInt);
+  DelimiterPos := Pos(':', Body);
+  if DelimiterPos > 1 then
+    BrandToken := Copy(Body, 1, DelimiterPos - 1)
+  else if Assigned(AAccessClass) then
+    BrandToken := AAccessClass.PrivateBrandToken
+  else if (Body <> '') and (Pos('$', Body) = 0) then
+    BrandToken := Body;
+  if BrandToken <> '' then
+    Result := '#brand:' + BrandToken + ':' + APrivateLookupName;
+end;
+
+procedure EnsureBytecodePrivateBrand(const AReceiver: TGocciaObjectValue;
+  const APrivateName, APrivateLookupName: string;
+  const AAccessClass: TGocciaClassValue);
+var
+  BrandKey: string;
+  BrandValue: TGocciaValue;
+begin
+  BrandKey := BytecodePrivateBrandKeyForLookup(APrivateLookupName,
+    AAccessClass);
+  if BrandKey = '' then
+    ThrowPrivateBrandError(APrivateName);
+
+  if AReceiver is TGocciaInstanceValue then
+  begin
+    if not TGocciaInstanceValue(AReceiver).TryGetRawPrivateProperty(
+      BrandKey, BrandValue) then
+      ThrowPrivateBrandError(APrivateName);
+    Exit;
+  end;
+
+  if not (AReceiver.GetOwnPropertyDescriptor(BrandKey) is TGocciaPropertyDescriptorData) then
+    ThrowPrivateBrandError(APrivateName);
+end;
+
 procedure EnsurePrivateStaticBrand(const AReceiver,
   AAccessClass: TGocciaClassValue; const APrivateName: string);
 begin
@@ -7186,13 +7697,19 @@ var
   AccessClass: TGocciaClassValue;
   GetterFn: TGocciaFunctionBase;
   EmptyArgs: TGocciaArgumentsCollection;
+  PrivateName: string;
+  Descriptor: TGocciaPropertyDescriptor;
 begin
   AccessClass := ResolveOwningClass(AInstance, AContext, APrivateName);
+  PrivateName := PrivateLookupName(AccessClass, APrivateName);
 
   // Check if this is a private getter
-  if AccessClass.HasPrivateGetter(APrivateName) then
+  if AccessClass.HasPrivateGetter(PrivateName) then
   begin
-    GetterFn := AccessClass.PrivatePropertyGetter[APrivateName];
+    if PrivateName <> APrivateName then
+      EnsureBytecodePrivateBrand(AInstance, APrivateName, PrivateName,
+        AccessClass);
+    GetterFn := AccessClass.PrivatePropertyGetter[PrivateName];
     EmptyArgs := TGocciaArgumentsCollection.Create;
     try
       Result := GetterFn.Call(EmptyArgs, AInstance);
@@ -7202,18 +7719,64 @@ begin
     Exit;
   end;
 
-  if AccessClass.HasPrivateSetter(APrivateName) then
+  if AccessClass.HasPrivateSetter(PrivateName) then
     ThrowPrivateGetterMissingError(APrivateName);
 
   // Check if this is a private method call
-  if AccessClass.PrivateMethods.ContainsKey(APrivateName) then
+  if AccessClass.PrivateMethods.ContainsKey(PrivateName) then
   begin
-    Result := AccessClass.GetPrivateMethod(APrivateName);
+    if PrivateName <> APrivateName then
+      EnsureBytecodePrivateBrand(AInstance, APrivateName, PrivateName,
+        AccessClass);
+    Result := AccessClass.GetPrivateMethod(PrivateName);
     if Result = nil then
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   end
   else
   begin
+    if (PrivateName <> APrivateName) and Assigned(AccessClass.Prototype) then
+    begin
+      Descriptor := AccessClass.Prototype.GetOwnPropertyDescriptor(PrivateName);
+      if Descriptor is TGocciaPropertyDescriptorAccessor then
+      begin
+        EnsureBytecodePrivateBrand(AInstance, APrivateName, PrivateName,
+          AccessClass);
+        if Assigned(TGocciaPropertyDescriptorAccessor(Descriptor).Getter) then
+        begin
+          EmptyArgs := TGocciaArgumentsCollection.Create;
+          try
+            Result := TGocciaFunctionBase(
+              TGocciaPropertyDescriptorAccessor(Descriptor).Getter).Call(
+                EmptyArgs, AInstance);
+          finally
+            EmptyArgs.Free;
+          end;
+          Exit;
+        end;
+        ThrowPrivateGetterMissingError(APrivateName);
+      end
+      else if Descriptor is TGocciaPropertyDescriptorData then
+      begin
+        EnsureBytecodePrivateBrand(AInstance, APrivateName, PrivateName,
+          AccessClass);
+        Result := TGocciaPropertyDescriptorData(Descriptor).Value;
+        Exit;
+      end;
+    end;
+
+    if PrivateName <> APrivateName then
+    begin
+      EnsureBytecodePrivateBrand(AInstance, APrivateName, PrivateName,
+        AccessClass);
+      if AInstance.TryGetRawPrivateProperty(PrivateName, Result) then
+        Exit;
+      Descriptor := AInstance.GetOwnPropertyDescriptor(PrivateName);
+      if Descriptor is TGocciaPropertyDescriptorData then
+      begin
+        Result := TGocciaPropertyDescriptorData(Descriptor).Value;
+        Exit;
+      end;
+    end;
     // It's a private property access
     Result := AInstance.GetPrivateProperty(APrivateName, AccessClass);
   end;
@@ -7225,16 +7788,23 @@ var
   AccessClass: TGocciaClassValue;
   GetterFn: TGocciaFunctionBase;
   EmptyArgs: TGocciaArgumentsCollection;
+  PrivateName: string;
+  Descriptor: TGocciaPropertyDescriptor;
 begin
   AccessClass := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
   if not Assigned(AccessClass) then
     ThrowPrivateBrandError(APrivateName);
+  PrivateName := PrivateLookupName(AccessClass, APrivateName);
 
-  EnsureRawPrivateInstanceBrand(AReceiver, APrivateName, AccessClass);
+  if PrivateName <> APrivateName then
+    EnsureBytecodePrivateBrand(AReceiver, APrivateName, PrivateName,
+      AccessClass)
+  else
+    EnsureRawPrivateInstanceBrand(AReceiver, APrivateName, AccessClass);
 
-  if AccessClass.HasPrivateGetter(APrivateName) then
+  if AccessClass.HasPrivateGetter(PrivateName) then
   begin
-    GetterFn := AccessClass.PrivatePropertyGetter[APrivateName];
+    GetterFn := AccessClass.PrivatePropertyGetter[PrivateName];
     EmptyArgs := TGocciaArgumentsCollection.Create;
     try
       Result := GetterFn.Call(EmptyArgs, AReceiver);
@@ -7244,15 +7814,29 @@ begin
     Exit;
   end;
 
-  if AccessClass.HasPrivateSetter(APrivateName) then
+  if AccessClass.HasPrivateSetter(PrivateName) then
     ThrowPrivateGetterMissingError(APrivateName);
 
-  if AccessClass.PrivateMethods.ContainsKey(APrivateName) then
+  if AccessClass.PrivateMethods.ContainsKey(PrivateName) then
   begin
-    Result := AccessClass.GetPrivateMethod(APrivateName);
+    Result := AccessClass.GetPrivateMethod(PrivateName);
     if Result = nil then
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
+  end;
+
+  if PrivateName <> APrivateName then
+  begin
+    if (AReceiver is TGocciaInstanceValue) and
+       TGocciaInstanceValue(AReceiver).TryGetRawPrivateProperty(
+         PrivateName, Result) then
+      Exit;
+    Descriptor := AReceiver.GetOwnPropertyDescriptor(PrivateName);
+    if Descriptor is TGocciaPropertyDescriptorData then
+    begin
+      Result := TGocciaPropertyDescriptorData(Descriptor).Value;
+      Exit;
+    end;
   end;
 
   if TryGetRawPrivateInstanceProperty(
@@ -7269,16 +7853,18 @@ var
   AccessClass: TGocciaClassValue;
   GetterFn: TGocciaFunctionBase;
   EmptyArgs: TGocciaArgumentsCollection;
+  PrivateName: string;
 begin
   AccessClass := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
   if not Assigned(AccessClass) then
     AccessClass := AClassValue;
+  PrivateName := PrivateLookupName(AccessClass, APrivateName);
 
   EnsurePrivateStaticBrand(AClassValue, AccessClass, APrivateName);
 
-  if AccessClass.HasOwnPrivateGetter(APrivateName) then
+  if AccessClass.HasOwnPrivateGetter(PrivateName) then
   begin
-    GetterFn := AccessClass.GetOwnPrivatePropertyGetter(APrivateName);
+    GetterFn := AccessClass.GetOwnPrivatePropertyGetter(PrivateName);
     EmptyArgs := TGocciaArgumentsCollection.Create;
     try
       Result := GetterFn.Call(EmptyArgs, AClassValue);
@@ -7288,13 +7874,13 @@ begin
     Exit;
   end;
 
-  if AccessClass.HasOwnPrivateSetter(APrivateName) then
+  if AccessClass.HasOwnPrivateSetter(PrivateName) then
     ThrowPrivateGetterMissingError(APrivateName);
 
-  if AccessClass.PrivateStaticMethods.TryGetValue(APrivateName, Result) then
+  if AccessClass.PrivateStaticMethods.TryGetValue(PrivateName, Result) then
     Exit;
 
-  if not AccessClass.PrivateStaticProperties.TryGetValue(APrivateName, Result) then
+  if not AccessClass.PrivateStaticProperties.TryGetValue(PrivateName, Result) then
     ThrowPrivateBrandError(APrivateName);
 end;
 
@@ -7305,16 +7891,19 @@ var
   AccessClass: TGocciaClassValue;
   SetterFn: TGocciaFunctionBase;
   SetterArgs: TGocciaArgumentsCollection;
+  PrivateName: string;
+  Descriptor: TGocciaPropertyDescriptor;
 begin
   AccessClass := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
   if not Assigned(AccessClass) then
     AccessClass := AClassValue;
+  PrivateName := PrivateLookupName(AccessClass, APrivateName);
 
   EnsurePrivateStaticBrand(AClassValue, AccessClass, APrivateName);
 
-  if AccessClass.HasOwnPrivateSetter(APrivateName) then
+  if AccessClass.HasOwnPrivateSetter(PrivateName) then
   begin
-    SetterFn := AccessClass.GetOwnPrivatePropertySetter(APrivateName);
+    SetterFn := AccessClass.GetOwnPrivatePropertySetter(PrivateName);
     SetterArgs := TGocciaArgumentsCollection.Create;
     try
       SetterArgs.Add(AValue);
@@ -7325,17 +7914,17 @@ begin
     Exit;
   end;
 
-  if AccessClass.HasOwnPrivateGetter(APrivateName) then
+  if AccessClass.HasOwnPrivateGetter(PrivateName) then
     ThrowPrivateSetterMissingError(APrivateName);
 
-  if AccessClass.HasOwnPrivateStaticMethod(APrivateName) then
+  if AccessClass.HasOwnPrivateStaticMethod(PrivateName) then
     ThrowTypeError(Format('Private method #%s is not writable', [APrivateName]),
       SSuggestPrivateFieldAccess);
 
-  if not AccessClass.HasOwnPrivateStaticProperty(APrivateName) then
+  if not AccessClass.HasOwnPrivateStaticProperty(PrivateName) then
     ThrowPrivateBrandError(APrivateName);
 
-  AccessClass.AddPrivateStaticProperty(APrivateName, AValue);
+  AccessClass.AddPrivateStaticProperty(PrivateName, AValue);
 end;
 
 procedure AssignPrivateMemberOnInstance(const AInstance: TGocciaInstanceValue;
@@ -7345,12 +7934,18 @@ var
   AccessClass: TGocciaClassValue;
   SetterFn: TGocciaFunctionBase;
   SetterArgs: TGocciaArgumentsCollection;
+  PrivateName: string;
+  Descriptor: TGocciaPropertyDescriptor;
 begin
   AccessClass := ResolveOwningClass(AInstance, AContext, APrivateName);
+  PrivateName := PrivateLookupName(AccessClass, APrivateName);
 
-  if AccessClass.HasPrivateSetter(APrivateName) then
+  if AccessClass.HasPrivateSetter(PrivateName) then
   begin
-    SetterFn := AccessClass.PrivatePropertySetter[APrivateName];
+    if PrivateName <> APrivateName then
+      EnsureBytecodePrivateBrand(AInstance, APrivateName, PrivateName,
+        AccessClass);
+    SetterFn := AccessClass.PrivatePropertySetter[PrivateName];
     SetterArgs := TGocciaArgumentsCollection.Create;
     try
       SetterArgs.Add(AValue);
@@ -7361,12 +7956,47 @@ begin
     Exit;
   end;
 
-  if AccessClass.HasPrivateGetter(APrivateName) then
+  if AccessClass.HasPrivateGetter(PrivateName) then
     ThrowPrivateSetterMissingError(APrivateName);
 
-  if AccessClass.PrivateMethods.ContainsKey(APrivateName) then
+  if AccessClass.PrivateMethods.ContainsKey(PrivateName) then
     ThrowTypeError(Format('Private method #%s is not writable', [APrivateName]),
       SSuggestPrivateFieldAccess);
+
+  if (PrivateName <> APrivateName) and Assigned(AccessClass.Prototype) then
+  begin
+    Descriptor := AccessClass.Prototype.GetOwnPropertyDescriptor(PrivateName);
+    if Descriptor is TGocciaPropertyDescriptorAccessor then
+    begin
+      EnsureBytecodePrivateBrand(AInstance, APrivateName, PrivateName,
+        AccessClass);
+      if Assigned(TGocciaPropertyDescriptorAccessor(Descriptor).Setter) then
+      begin
+        SetterArgs := TGocciaArgumentsCollection.Create;
+        try
+          SetterArgs.Add(AValue);
+          TGocciaFunctionBase(
+            TGocciaPropertyDescriptorAccessor(Descriptor).Setter).Call(
+              SetterArgs, AInstance);
+        finally
+          SetterArgs.Free;
+        end;
+        Exit;
+      end;
+      ThrowPrivateSetterMissingError(APrivateName);
+    end
+    else if Descriptor is TGocciaPropertyDescriptorData then
+      ThrowTypeError(Format('Private method #%s is not writable', [APrivateName]),
+        SSuggestPrivateFieldAccess);
+  end;
+
+  if PrivateName <> APrivateName then
+  begin
+    EnsureBytecodePrivateBrand(AInstance, APrivateName, PrivateName,
+      AccessClass);
+    AInstance.SetRawPrivateProperty(PrivateName, AValue);
+    Exit;
+  end;
 
   AInstance.SetPrivateProperty(APrivateName, AValue, AccessClass);
 end;
@@ -7380,12 +8010,19 @@ var
   SetterArgs: TGocciaArgumentsCollection;
   PendingNewTarget: TGocciaValue;
   FieldInitializer: TGocciaExpression;
+  PrivateName: string;
 begin
   AccessClass := ResolveLexicalPrivateAccessClass(AContext, APrivateName);
   if not Assigned(AccessClass) then
     ThrowPrivateBrandError(APrivateName);
+  PrivateName := PrivateLookupName(AccessClass, APrivateName);
 
-  if not HasRawPrivateInstanceBrand(AReceiver, AccessClass) then
+  if PrivateName <> APrivateName then
+  begin
+    EnsureBytecodePrivateBrand(AReceiver, APrivateName, PrivateName,
+      AccessClass);
+  end
+  else if not HasRawPrivateInstanceBrand(AReceiver, AccessClass) then
   begin
     PendingNewTarget := AContext.Scope.FindNewTarget;
     if (AReceiver = AContext.Scope.ThisValue) and
@@ -7402,9 +8039,9 @@ begin
     ThrowPrivateBrandError(APrivateName);
   end;
 
-  if AccessClass.HasPrivateSetter(APrivateName) then
+  if AccessClass.HasPrivateSetter(PrivateName) then
   begin
-    SetterFn := AccessClass.PrivatePropertySetter[APrivateName];
+    SetterFn := AccessClass.PrivatePropertySetter[PrivateName];
     SetterArgs := TGocciaArgumentsCollection.Create;
     try
       SetterArgs.Add(AValue);
@@ -7415,12 +8052,22 @@ begin
     Exit;
   end;
 
-  if AccessClass.HasPrivateGetter(APrivateName) then
+  if AccessClass.HasPrivateGetter(PrivateName) then
     ThrowPrivateSetterMissingError(APrivateName);
 
-  if AccessClass.PrivateMethods.ContainsKey(APrivateName) then
+  if AccessClass.PrivateMethods.ContainsKey(PrivateName) then
     ThrowTypeError(Format('Private method #%s is not writable', [APrivateName]),
       SSuggestPrivateFieldAccess);
+
+  if PrivateName <> APrivateName then
+  begin
+    if AReceiver is TGocciaInstanceValue then
+      TGocciaInstanceValue(AReceiver).SetRawPrivateProperty(PrivateName, AValue)
+    else
+      AReceiver.DefineProperty(PrivateName,
+        TGocciaPropertyDescriptorData.Create(AValue, [pfWritable, pfConfigurable]));
+    Exit;
+  end;
 
   SetRawPrivateInstanceProperty(AReceiver, APrivateName, AValue, AccessClass);
 end;
@@ -7433,6 +8080,13 @@ var
 begin
   // Evaluate the object expression
   ObjectValue := EvaluateExpression(APrivateMemberExpression.ObjectExpr, AContext);
+  if APrivateMemberExpression.Optional and
+     ((ObjectValue is TGocciaNullLiteralValue) or
+      (ObjectValue is TGocciaUndefinedLiteralValue)) then
+  begin
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
 
   if ObjectValue is TGocciaInstanceValue then
   begin
@@ -7464,6 +8118,13 @@ var
 begin
   // Evaluate the object expression and store it for this binding
   AObjectValue := EvaluateExpression(APrivateMemberExpression.ObjectExpr, AContext);
+  if APrivateMemberExpression.Optional and
+     ((AObjectValue is TGocciaNullLiteralValue) or
+      (AObjectValue is TGocciaUndefinedLiteralValue)) then
+  begin
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+    Exit;
+  end;
 
   if AObjectValue is TGocciaInstanceValue then
   begin
@@ -7645,7 +8306,10 @@ begin
   for I := 0 to AClassValue.PrivateInstancePropertyDefs.Count - 1 do
   begin
     Entry := AClassValue.PrivateInstancePropertyDefs.EntryAt(I);
-    PropertyValue := EvaluateExpression(Entry.Value, AContext);
+    if Assigned(Entry.Value) then
+      PropertyValue := EvaluateExpression(Entry.Value, AContext)
+    else
+      PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
     if AInstance is TGocciaInstanceValue then
       TGocciaInstanceValue(AInstance).SetPrivateProperty(
         Entry.Key, PropertyValue, AClassValue)

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -108,6 +108,10 @@ const
   UTF8_LINE_SEPARATOR_FINAL_BYTE = #$A8;
   UTF8_PARAGRAPH_SEPARATOR_FINAL_BYTE = #$A9;
   UTF8_LINE_TERMINATOR_BYTE_LENGTH = 3;
+  UTF8_NO_BREAK_SPACE_LEAD_BYTE = #$C2;
+  UTF8_NO_BREAK_SPACE_FINAL_BYTE = #$A0;
+  NO_BREAK_SPACE_CODE_POINT = $00A0;
+  ZERO_WIDTH_NO_BREAK_SPACE_CODE_POINT = $FEFF;
 
 type
   TKeywordTokenEntry = record
@@ -446,8 +450,18 @@ begin
   while not IsAtEnd do
   begin
     case Peek of
-      ' ', #9:
+      ' ', #9, #11, #12:
         Advance;
+      // ES2026 §12.2 White Space — NBSP (U+00A0)
+      UTF8_NO_BREAK_SPACE_LEAD_BYTE:
+        if (FCurrent < Length(FSource)) and
+           (FSource[FCurrent + 1] = UTF8_NO_BREAK_SPACE_FINAL_BYTE) then
+        begin
+          Inc(FCurrent, 2);
+          Inc(FColumn, 2);
+        end
+        else
+          Break;
       // ES2026 §12.3 LineTerminator — CR and CRLF
       #13, #10:
         ConsumeLineTerminator;
@@ -1412,6 +1426,10 @@ end;
 function TGocciaLexer.IsSourceIdentifierStartCodePoint(
   ACodePoint: Cardinal): Boolean;
 begin
+  if (ACodePoint = NO_BREAK_SPACE_CODE_POINT) or
+     (ACodePoint = ZERO_WIDTH_NO_BREAK_SPACE_CODE_POINT) then
+    Exit(False);
+
   // GocciaScript intentionally keeps its historical non-ASCII identifier
   // extension, including emoji identifiers, while using the standard helper
   // for ordinary Unicode identifier code points.
@@ -1421,6 +1439,10 @@ end;
 function TGocciaLexer.IsSourceIdentifierPartCodePoint(
   ACodePoint: Cardinal): Boolean;
 begin
+  if (ACodePoint = NO_BREAK_SPACE_CODE_POINT) or
+     (ACodePoint = ZERO_WIDTH_NO_BREAK_SPACE_CODE_POINT) then
+    Exit(False);
+
   Result := IsIdentifierPartCodePoint(ACodePoint) or (ACodePoint > $7F);
 end;
 

--- a/source/units/Goccia.ObjectModel.Engine.pas
+++ b/source/units/Goccia.ObjectModel.Engine.pas
@@ -60,6 +60,9 @@ begin
 
   for Key in ASource.GetAllPropertyNames do
   begin
+    if Key = PROP_PROTOTYPE then
+      Continue;
+
     Descriptor := ASource.GetOwnPropertyDescriptor(Key);
     if not Assigned(Descriptor) then
       Continue;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -5455,9 +5455,13 @@ begin
       end
       else
       begin
-        PropertyName := Consume(gttIdentifier,
-          'Expected property name after "."',
-          SSuggestPropertyNameIdentifier).Lexeme;
+        if IsIdentifierNameToken(Peek.TokenType) then
+          PropertyName := Advance.Lexeme
+        else
+          raise TGocciaSyntaxError.Create(
+            'Expected property name after "."',
+            Peek.Line, Peek.Column, FFileName, FSourceLines,
+            SSuggestPropertyNameIdentifier);
         Result := TGocciaMemberExpression.Create(
           Result, PropertyName, False, Line, Column);
       end;
@@ -6060,7 +6064,7 @@ begin
 
   if Match(gttExtends) then
   begin
-    SuperClassExpression := Expression;
+    SuperClassExpression := Call;
     if not Assigned(SuperClassExpression) then
       raise TGocciaSyntaxError.Create('Expected superclass expression',
         Previous.Line, Previous.Column, FFileName, FSourceLines,
@@ -6144,8 +6148,8 @@ begin
       end;
 
       if IsStatic and
-         (Check(gttAssign) or Check(gttSemicolon) or Check(gttColon) or
-          Check(gttQuestion) or
+         (Check(gttLeftParen) or Check(gttLess) or Check(gttAssign) or
+          Check(gttSemicolon) or Check(gttColon) or Check(gttQuestion) or
           (FAutomaticSemicolonInsertion and (Previous.Line < Peek.Line))) then
       begin
         IsStatic := False;
@@ -6165,6 +6169,7 @@ begin
          (FCurrent + 1 < FTokens.Count) and
          (FTokens[FCurrent + 1].Line = Peek.Line) and
          not CheckNext(gttLeftParen) and not CheckNext(gttColon) and
+         not CheckNext(gttLess) and
          not CheckNext(gttSemicolon) and not CheckNext(gttAssign) then
       begin
         Advance;
@@ -6209,7 +6214,7 @@ begin
         MemberName := Advance.Lexeme;
         PresetMemberName := True;
       end
-      else if not IsAccessor and CheckUnescapedIdentifierKeyword(KEYWORD_GET) and not CheckNext(gttColon) and not CheckNext(gttLeftParen) and not CheckNext(gttComma) and not CheckNext(gttRightBrace) and not CheckNext(gttSemicolon) and not CheckNext(gttAssign) and not CheckNext(gttQuestion) then
+      else if not IsAccessor and CheckUnescapedIdentifierKeyword(KEYWORD_GET) and not CheckNext(gttColon) and not CheckNext(gttLeftParen) and not CheckNext(gttLess) and not CheckNext(gttComma) and not CheckNext(gttRightBrace) and not CheckNext(gttSemicolon) and not CheckNext(gttAssign) and not CheckNext(gttQuestion) then
       begin
         Advance;
         IsGetter := True;
@@ -6235,7 +6240,7 @@ begin
             'Expected property name after "get"',
             SSuggestProvideGetterPropertyName);
       end
-      else if not IsAccessor and CheckUnescapedIdentifierKeyword(KEYWORD_SET) and not CheckNext(gttColon) and not CheckNext(gttLeftParen) and not CheckNext(gttComma) and not CheckNext(gttRightBrace) and not CheckNext(gttSemicolon) and not CheckNext(gttAssign) and not CheckNext(gttQuestion) then
+      else if not IsAccessor and CheckUnescapedIdentifierKeyword(KEYWORD_SET) and not CheckNext(gttColon) and not CheckNext(gttLeftParen) and not CheckNext(gttLess) and not CheckNext(gttComma) and not CheckNext(gttRightBrace) and not CheckNext(gttSemicolon) and not CheckNext(gttAssign) and not CheckNext(gttQuestion) then
       begin
         Advance;
         IsSetter := True;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -271,6 +271,7 @@ type
     destructor Destroy; override;
     function Parse: TGocciaProgram;
     function ParseUnchecked: TGocciaProgram;
+    function ParseWithPrivateNames(const ADeclaredNames: TStrings): TGocciaProgram;
     function ParseExpressionWithPrivateNames(const ADeclaredNames: TStrings): TGocciaExpression;
     function ParseExpressionUnchecked: TGocciaExpression;
     function Expression: TGocciaExpression;
@@ -578,6 +579,23 @@ begin
         DeclarePrivateName(ADeclaredNames[I]);
 
     Result := Expression;
+    ValidateCurrentPrivateClassContext;
+  finally
+    PopPrivateClassContext;
+  end;
+end;
+
+function TGocciaParser.ParseWithPrivateNames(const ADeclaredNames: TStrings): TGocciaProgram;
+var
+  I: Integer;
+begin
+  PushPrivateClassContext;
+  try
+    if Assigned(ADeclaredNames) then
+      for I := 0 to ADeclaredNames.Count - 1 do
+        DeclarePrivateName(ADeclaredNames[I]);
+
+    Result := Parse;
     ValidateCurrentPrivateClassContext;
   finally
     PopPrivateClassContext;
@@ -1216,7 +1234,8 @@ begin
     if Match(gttStar) then
       Result := TGocciaYieldExpression.Create(Assignment, True, Operator.Line, Operator.Column)
     else if CheckSemicolonOrASI or Check(gttRightBrace) or
-      Check(gttRightParen) or Check(gttRightBracket) or Check(gttComma) then
+      Check(gttRightParen) or Check(gttRightBracket) or Check(gttComma) or
+      Check(gttColon) or Check(gttQuestion) then
       Result := TGocciaYieldExpression.Create(nil, False, Operator.Line, Operator.Column)
     else
       Result := TGocciaYieldExpression.Create(Assignment, False, Operator.Line, Operator.Column);
@@ -1303,15 +1322,13 @@ begin
           // Check if this is a private field access (this.#field)
           if Check(gttHash) then
           begin
-            if IsOptionalChain then
-              raise TGocciaSyntaxError.Create('Optional chaining with private fields is not supported',
-                Peek.Line, Peek.Column, FFileName, FSourceLines);
             Advance; // consume the #
             Token := Consume(gttIdentifier, 'Expected private field name after "#"',
               SSuggestPrivateFieldMustFollow);
             PropertyName := Token.Lexeme;
             RecordPrivateNameReference(PropertyName, Token.Line, Token.Column);
-            Result := TGocciaPrivateMemberExpression.Create(Result, PropertyName, Line, Column);
+            Result := TGocciaPrivateMemberExpression.Create(
+              Result, PropertyName, Line, Column, IsOptionalChain);
           end
           else if Check(gttLeftBracket) and IsOptionalChain then
           begin
@@ -3380,7 +3397,7 @@ end;
 
 function TGocciaParser.ParseSetterExpression: TGocciaSetterExpression;
 var
-  ParamName: string;
+  Params: TGocciaParameterArray;
   Line, Column: Integer;
   SavedActiveLabels, SavedActiveIterationLabels: TStringList;
   SavedDirectLabelStart: Integer;
@@ -3393,13 +3410,11 @@ begin
     raise TGocciaSyntaxError.Create('Setter must have exactly one parameter',
       Peek.Line, Peek.Column, FFileName, FSourceLines,
       SSuggestSetterOneParameter);
-  ParamName := ConsumeIdentifierBinding('Expected parameter name in setter',
-    SSuggestProvideSetterParameterName).Lexeme;
-  if Check(gttColon) then
-  begin
-    Advance;
-    CollectTypeAnnotation([gttRightParen]);
-  end;
+  Params := ParseParameterList;
+  if Length(Params) <> 1 then
+    raise TGocciaSyntaxError.Create('Setter must have exactly one parameter',
+      Previous.Line, Previous.Column, FFileName, FSourceLines,
+      SSuggestSetterOneParameter);
   Consume(gttRightParen, 'Expected ")" after setter parameter',
     SSuggestCloseParenSetterParameter);
   if Check(gttColon) then
@@ -3413,7 +3428,8 @@ begin
   EnterFunctionLabelScope(SavedActiveLabels, SavedActiveIterationLabels,
     SavedDirectLabelStart);
   try
-    Result := TGocciaSetterExpression.Create(ParamName, BlockStatement, Line, Column);
+    Result := TGocciaSetterExpression.Create(Params, BlockStatement, Line,
+      Column);
   finally
     LeaveFunctionLabelScope(SavedActiveLabels, SavedActiveIterationLabels,
       SavedDirectLabelStart);
@@ -5424,9 +5440,23 @@ begin
     begin
       Line := Previous.Line;
       Column := Previous.Column;
-      PropertyName := Consume(gttIdentifier, 'Expected property name after "."',
-        SSuggestPropertyNameIdentifier).Lexeme;
-      Result := TGocciaMemberExpression.Create(Result, PropertyName, False, Line, Column);
+      if Match(gttHash) then
+      begin
+        PropertyName := Consume(gttIdentifier,
+          'Expected private field name after "#"',
+          SSuggestPrivateFieldMustFollow).Lexeme;
+        RecordPrivateNameReference(PropertyName, Previous.Line, Previous.Column);
+        Result := TGocciaPrivateMemberExpression.Create(
+          Result, PropertyName, Line, Column);
+      end
+      else
+      begin
+        PropertyName := Consume(gttIdentifier,
+          'Expected property name after "."',
+          SSuggestPropertyNameIdentifier).Lexeme;
+        Result := TGocciaMemberExpression.Create(
+          Result, PropertyName, False, Line, Column);
+      end;
     end
     else
       Break;
@@ -5979,6 +6009,7 @@ end;
 function TGocciaParser.ParseClassBody(const AClassName: string): TGocciaClassDefinition;
 var
   SuperClass: string;
+  SuperClassExpression: TGocciaExpression;
   Methods: TGocciaClassMethodMap;
   StaticMethods: TGocciaClassMethodMap;
   Getters: TGocciaGetterExpressionMap;
@@ -6013,6 +6044,7 @@ var
   IsAccessor: Boolean;
   IsAsync: Boolean;
   IsGenerator: Boolean;
+  PresetMemberName: Boolean;
   MemberStartLine, MemberStartColumn: Integer;
   TypePair: TStringStringMap.TKeyValuePair;
   SavedStrictModeActive: Boolean;
@@ -6020,11 +6052,19 @@ begin
   SetLength(Elements, 0);
   SetLength(FieldOrder, 0);
   ClassGenericParams := CollectGenericParameters;
+  SuperClassExpression := nil;
 
   if Match(gttExtends) then
   begin
-    SuperClass := Consume(gttIdentifier, 'Expected superclass name',
-      SSuggestProvideSuperclassName).Lexeme;
+    SuperClassExpression := Expression;
+    if not Assigned(SuperClassExpression) then
+      raise TGocciaSyntaxError.Create('Expected superclass expression',
+        Previous.Line, Previous.Column, FFileName, FSourceLines,
+        SSuggestProvideSuperclassName);
+    if SuperClassExpression is TGocciaIdentifierExpression then
+      SuperClass := TGocciaIdentifierExpression(SuperClassExpression).Name
+    else
+      SuperClass := '';
     CollectGenericParameters;
   end
   else
@@ -6075,6 +6115,7 @@ begin
       MemberStartColumn := Peek.Column;
 
       IsStatic := Match(gttStatic);
+      PresetMemberName := False;
 
       // ES2022 §15.7.14 ClassStaticBlockDefinition: static { ... }
       if IsStatic and Check(gttLeftBrace) then
@@ -6098,6 +6139,16 @@ begin
         Continue;
       end;
 
+      if IsStatic and
+         (Check(gttAssign) or Check(gttSemicolon) or Check(gttColon) or
+          Check(gttQuestion) or
+          (FAutomaticSemicolonInsertion and (Previous.Line < Peek.Line))) then
+      begin
+        IsStatic := False;
+        MemberName := KEYWORD_STATIC;
+        PresetMemberName := True;
+      end;
+
       while Check(gttIdentifier) and not Peek.ContainsEscape and
         ((Peek.Lexeme = KEYWORD_PUBLIC) or (Peek.Lexeme = KEYWORD_PROTECTED) or (Peek.Lexeme = KEYWORD_PRIVATE) or
          (Peek.Lexeme = KEYWORD_READONLY) or (Peek.Lexeme = KEYWORD_OVERRIDE) or (Peek.Lexeme = KEYWORD_ABSTRACT)) do
@@ -6106,7 +6157,11 @@ begin
       if not IsStatic and Check(gttStatic) then
         IsStatic := Match(gttStatic);
 
-      if CheckUnescapedIdentifierKeyword(KEYWORD_ACCESSOR) and not CheckNext(gttLeftParen) and not CheckNext(gttColon) and not CheckNext(gttSemicolon) and not CheckNext(gttAssign) then
+      if CheckUnescapedIdentifierKeyword(KEYWORD_ACCESSOR) and
+         (FCurrent + 1 < FTokens.Count) and
+         (FTokens[FCurrent + 1].Line = Peek.Line) and
+         not CheckNext(gttLeftParen) and not CheckNext(gttColon) and
+         not CheckNext(gttSemicolon) and not CheckNext(gttAssign) then
       begin
         Advance;
         IsAccessor := True;
@@ -6133,7 +6188,24 @@ begin
       IsComputed := False;
       ComputedKeyExpression := nil;
 
-      if not IsAccessor and CheckUnescapedIdentifierKeyword(KEYWORD_GET) and not CheckNext(gttColon) and not CheckNext(gttLeftParen) and not CheckNext(gttComma) and not CheckNext(gttRightBrace) and not CheckNext(gttSemicolon) and not CheckNext(gttAssign) and not CheckNext(gttQuestion) then
+      if PresetMemberName then
+      begin
+      end
+      else if not IsAccessor and CheckUnescapedIdentifierKeyword(KEYWORD_GET) and
+        CheckNext(gttStar) and (FCurrent + 1 < FTokens.Count) and
+        (FTokens[FCurrent + 1].Line > Peek.Line) then
+      begin
+        MemberName := Advance.Lexeme;
+        PresetMemberName := True;
+      end
+      else if not IsAccessor and CheckUnescapedIdentifierKeyword(KEYWORD_SET) and
+        CheckNext(gttStar) and (FCurrent + 1 < FTokens.Count) and
+        (FTokens[FCurrent + 1].Line > Peek.Line) then
+      begin
+        MemberName := Advance.Lexeme;
+        PresetMemberName := True;
+      end
+      else if not IsAccessor and CheckUnescapedIdentifierKeyword(KEYWORD_GET) and not CheckNext(gttColon) and not CheckNext(gttLeftParen) and not CheckNext(gttComma) and not CheckNext(gttRightBrace) and not CheckNext(gttSemicolon) and not CheckNext(gttAssign) and not CheckNext(gttQuestion) then
       begin
         Advance;
         IsGetter := True;
@@ -6281,7 +6353,7 @@ begin
           FieldOrder[High(FieldOrder)].IsComputed := False;
           FieldOrder[High(FieldOrder)].ElementIndex := -1;
           FieldOrder[High(FieldOrder)].ComputedKeyExpression := nil;
-          FieldOrder[High(FieldOrder)].FieldInitializer := nil;
+          FieldOrder[High(FieldOrder)].FieldInitializer := PropertyValue;
         end
         else if IsStatic then
           StaticProperties.Add(MemberName, PropertyValue)
@@ -6294,7 +6366,7 @@ begin
           FieldOrder[High(FieldOrder)].IsComputed := False;
           FieldOrder[High(FieldOrder)].ElementIndex := -1;
           FieldOrder[High(FieldOrder)].ComputedKeyExpression := nil;
-          FieldOrder[High(FieldOrder)].FieldInitializer := nil;
+          FieldOrder[High(FieldOrder)].FieldInitializer := PropertyValue;
           if FieldType <> '' then
             InstancePropertyTypes.Add(MemberName, FieldType);
         end;
@@ -6343,7 +6415,7 @@ begin
           FieldOrder[High(FieldOrder)].IsComputed := False;
           FieldOrder[High(FieldOrder)].ElementIndex := -1;
           FieldOrder[High(FieldOrder)].ComputedKeyExpression := nil;
-          FieldOrder[High(FieldOrder)].FieldInitializer := nil;
+          FieldOrder[High(FieldOrder)].FieldInitializer := PropertyValue;
         end
         else if IsStatic then
           StaticProperties.Add(MemberName, PropertyValue)
@@ -6356,7 +6428,7 @@ begin
           FieldOrder[High(FieldOrder)].IsComputed := False;
           FieldOrder[High(FieldOrder)].ElementIndex := -1;
           FieldOrder[High(FieldOrder)].ComputedKeyExpression := nil;
-          FieldOrder[High(FieldOrder)].FieldInitializer := nil;
+          FieldOrder[High(FieldOrder)].FieldInitializer := PropertyValue;
           if FieldType <> '' then
             InstancePropertyTypes.Add(MemberName, FieldType);
         end;
@@ -6493,7 +6565,7 @@ begin
     PopPrivateClassContext;
   end;
 
-  Result := TGocciaClassDefinition.Create(AClassName, SuperClass, Methods, StaticMethods, Getters, Setters, StaticProperties, InstanceProperties, PrivateInstanceProperties, PrivateMethods, PrivateStaticProperties);
+  Result := TGocciaClassDefinition.Create(AClassName, SuperClass, Methods, StaticMethods, Getters, Setters, StaticProperties, InstanceProperties, PrivateInstanceProperties, PrivateMethods, PrivateStaticProperties, SuperClassExpression);
   Result.GenericParams := ClassGenericParams;
   Result.ImplementsClause := ClassImplementsClause;
   for TypePair in InstancePropertyTypes do

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -1322,11 +1322,6 @@ begin
           // Check if this is a private field access (this.#field)
           if Check(gttHash) then
           begin
-            if IsOptionalChain then
-              raise TGocciaSyntaxError.Create(
-                'Optional chaining with private fields is not supported',
-                Line, Column, FFileName, FSourceLines,
-                SSuggestPrivateFieldMustFollow);
             Advance; // consume the #
             Token := Consume(gttIdentifier, 'Expected private field name after "#"',
               SSuggestPrivateFieldMustFollow);

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -1322,6 +1322,11 @@ begin
           // Check if this is a private field access (this.#field)
           if Check(gttHash) then
           begin
+            if IsOptionalChain then
+              raise TGocciaSyntaxError.Create(
+                'Optional chaining with private fields is not supported',
+                Line, Column, FFileName, FSourceLines,
+                SSuggestPrivateFieldMustFollow);
             Advance; // consume the #
             Token := Consume(gttIdentifier, 'Expected private field name after "#"',
               SSuggestPrivateFieldMustFollow);
@@ -3413,6 +3418,10 @@ begin
   Params := ParseParameterList;
   if Length(Params) <> 1 then
     raise TGocciaSyntaxError.Create('Setter must have exactly one parameter',
+      Previous.Line, Previous.Column, FFileName, FSourceLines,
+      SSuggestSetterOneParameter);
+  if Params[0].IsRest then
+    raise TGocciaSyntaxError.Create('Setter parameter cannot be a rest parameter',
       Previous.Line, Previous.Column, FFileName, FSourceLines,
       SSuggestSetterOneParameter);
   Consume(gttRightParen, 'Expected ")" after setter parameter',

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -192,6 +192,7 @@ type
   protected
     function GetThisValue: TGocciaValue; override;
     function GetOwningClass: TGocciaValue; override;
+    function GetSuperClass: TGocciaValue; override;
   public
     constructor Create(const AParent: TGocciaScope; const AOwningClass: TGocciaValue);
     procedure MarkReferences; override;
@@ -247,6 +248,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.Keywords.Reserved,
   Goccia.Types.Enforcement,
+  Goccia.Values.ClassValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -1090,6 +1092,21 @@ end;
 function TGocciaClassInitScope.GetOwningClass: TGocciaValue;
 begin
   Result := FOwningClass;
+end;
+
+function TGocciaClassInitScope.GetSuperClass: TGocciaValue;
+var
+  ClassValue: TGocciaClassValue;
+begin
+  Result := nil;
+  if not (FOwningClass is TGocciaClassValue) then
+    Exit;
+
+  ClassValue := TGocciaClassValue(FOwningClass);
+  if Assigned(ClassValue.SuperClass) then
+    Result := ClassValue.SuperClass
+  else if Assigned(ClassValue.NativeSuperConstructor) then
+    Result := ClassValue.NativeSuperConstructor;
 end;
 
 procedure TGocciaClassInitScope.MarkReferences;

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -39,6 +39,7 @@ type
     FLoadDeferredModule: TLoadDeferredModuleCallback;
     FStrictTypes: Boolean;
     FNonStrictMode: Boolean;
+    FRejectArgumentsReferenceInDirectEval: Boolean;
   protected
     function GetThisValue: TGocciaValue; virtual;
     function GetOwningClass: TGocciaValue; virtual;
@@ -135,6 +136,7 @@ type
       EffectiveStrictTypes, which always reads the root scope. }
     property StrictTypes: Boolean read FStrictTypes write FStrictTypes;
     property NonStrictMode: Boolean read FNonStrictMode write FNonStrictMode;
+    property RejectArgumentsReferenceInDirectEval: Boolean read FRejectArgumentsReferenceInDirectEval write FRejectArgumentsReferenceInDirectEval;
   end;
 
   // Root scope with no parent -- used by the interpreter/engine
@@ -270,6 +272,8 @@ begin
     FLoadDeferredModule := AParent.FLoadDeferredModule;
     FStrictTypes := AParent.FStrictTypes;
     FNonStrictMode := AParent.FNonStrictMode;
+    FRejectArgumentsReferenceInDirectEval :=
+      AParent.FRejectArgumentsReferenceInDirectEval;
   end;
 
   if Assigned(TGarbageCollector.Instance) then
@@ -1082,6 +1086,7 @@ constructor TGocciaClassInitScope.Create(const AParent: TGocciaScope; const AOwn
 begin
   inherited Create(AParent, skBlock, 'ClassInit');
   FOwningClass := AOwningClass;
+  RejectArgumentsReferenceInDirectEval := True;
 end;
 
 function TGocciaClassInitScope.GetThisValue: TGocciaValue;

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -50,7 +50,7 @@ uses
   Goccia.SourcePipeline;
 
 const
-  DEFAULT_SHIMS: array[0..7] of TGocciaShimDefinition = (
+  DEFAULT_SHIMS: array[0..12] of TGocciaShimDefinition = (
     ( // WHATWG HTML spec §8.3 — legacy btoa(data) via Uint8Array.toBase64
       Name: 'btoa';
       FileName: '<shim:btoa>';
@@ -347,6 +347,112 @@ const
         '    writable: true, enumerable: false, configurable: true'#10 +
         '  });'#10 +
         '  return proto.hasOwnProperty;'#10 +
+        '})(Object.getPrototypeOf({}));'
+    ),
+    ( // ES2026 §20.1.3.8 Object.prototype.__proto__
+      Name: '__proto__';
+      FileName: '<shim:__proto__>';
+      Source:
+        'export const __proto__ = ((objectPrototype) => {'#10 +
+        '  Object.defineProperty(objectPrototype, "__proto__", {'#10 +
+        '    get() { return Object.getPrototypeOf(this); },'#10 +
+        '    set(value) {'#10 +
+        '      if (this === null || this === undefined) throw new TypeError("Object.prototype.__proto__ called on null or undefined");'#10 +
+        '      if (value !== null && typeof value !== "object" && typeof value !== "function") return undefined;'#10 +
+        '      if (typeof this !== "object" && typeof this !== "function") return undefined;'#10 +
+        '      Object.setPrototypeOf(this, value);'#10 +
+        '      return undefined;'#10 +
+        '    },'#10 +
+        '    enumerable: false, configurable: true'#10 +
+        '  });'#10 +
+        '  const descriptor = Object.getOwnPropertyDescriptor(objectPrototype, "__proto__");'#10 +
+        '  Object.defineProperty(descriptor.get, "name", { value: "get __proto__", configurable: true });'#10 +
+        '  Object.defineProperty(descriptor.set, "name", { value: "set __proto__", configurable: true });'#10 +
+        '  return descriptor;'#10 +
+        '})(Object.getPrototypeOf({}));'
+    ),
+    ( // ES2026 §20.1.3.9.1 Object.prototype.__defineGetter__(P, getter)
+      Name: 'defineGetter';
+      FileName: '<shim:defineGetter>';
+      Source:
+        'export const defineGetter = ((proto) => {'#10 +
+        '  Object.defineProperty(proto, "__defineGetter__", {'#10 +
+        '    value(prop, getter) {'#10 +
+        '      if (this === null || this === undefined) throw new TypeError("__defineGetter__ called on null or undefined");'#10 +
+        '      if (typeof getter !== "function") throw new TypeError("Object.prototype.__defineGetter__ getter must be callable");'#10 +
+        '      Object.defineProperty(Object(this), prop, { get: getter, enumerable: true, configurable: true });'#10 +
+        '      return undefined;'#10 +
+        '    },'#10 +
+        '    writable: true, enumerable: false, configurable: true'#10 +
+        '  });'#10 +
+        '  Object.defineProperty(proto.__defineGetter__, "name", { value: "__defineGetter__", configurable: true });'#10 +
+        '  Object.defineProperty(proto.__defineGetter__, "length", { value: 2, configurable: true });'#10 +
+        '  return proto.__defineGetter__;'#10 +
+        '})(Object.getPrototypeOf({}));'
+    ),
+    ( // ES2026 §20.1.3.9.2 Object.prototype.__defineSetter__(P, setter)
+      Name: 'defineSetter';
+      FileName: '<shim:defineSetter>';
+      Source:
+        'export const defineSetter = ((proto) => {'#10 +
+        '  Object.defineProperty(proto, "__defineSetter__", {'#10 +
+        '    value(prop, setter) {'#10 +
+        '      if (this === null || this === undefined) throw new TypeError("__defineSetter__ called on null or undefined");'#10 +
+        '      if (typeof setter !== "function") throw new TypeError("Object.prototype.__defineSetter__ setter must be callable");'#10 +
+        '      Object.defineProperty(Object(this), prop, { set: setter, enumerable: true, configurable: true });'#10 +
+        '      return undefined;'#10 +
+        '    },'#10 +
+        '    writable: true, enumerable: false, configurable: true'#10 +
+        '  });'#10 +
+        '  Object.defineProperty(proto.__defineSetter__, "name", { value: "__defineSetter__", configurable: true });'#10 +
+        '  Object.defineProperty(proto.__defineSetter__, "length", { value: 2, configurable: true });'#10 +
+        '  return proto.__defineSetter__;'#10 +
+        '})(Object.getPrototypeOf({}));'
+    ),
+    ( // ES2026 Annex B §B.2.2.4 Object.prototype.__lookupGetter__(P)
+      Name: 'lookupGetter';
+      FileName: '<shim:lookupGetter>';
+      Source:
+        'export const lookupGetter = ((proto) => {'#10 +
+        '  Object.defineProperty(proto, "__lookupGetter__", {'#10 +
+        '    value(prop) {'#10 +
+        '      if (this === null || this === undefined) throw new TypeError("__lookupGetter__ called on null or undefined");'#10 +
+        '      const key = Reflect.ownKeys(Object.defineProperty({}, prop, { value: undefined }))[0];'#10 +
+        '      const find = (object) => {'#10 +
+        '        if (object === null) return undefined;'#10 +
+        '        const descriptor = Object.getOwnPropertyDescriptor(object, key);'#10 +
+        '        if (descriptor !== undefined) return descriptor.get;'#10 +
+        '        return find(Object.getPrototypeOf(object));'#10 +
+        '      };'#10 +
+        '      return find(this);'#10 +
+        '    },'#10 +
+        '    writable: true, enumerable: false, configurable: true'#10 +
+        '  });'#10 +
+        '  Object.defineProperty(proto.__lookupGetter__, "name", { value: "__lookupGetter__", configurable: true });'#10 +
+        '  return proto.__lookupGetter__;'#10 +
+        '})(Object.getPrototypeOf({}));'
+    ),
+    ( // ES2026 Annex B §B.2.2.5 Object.prototype.__lookupSetter__(P)
+      Name: 'lookupSetter';
+      FileName: '<shim:lookupSetter>';
+      Source:
+        'export const lookupSetter = ((proto) => {'#10 +
+        '  Object.defineProperty(proto, "__lookupSetter__", {'#10 +
+        '    value(prop) {'#10 +
+        '      if (this === null || this === undefined) throw new TypeError("__lookupSetter__ called on null or undefined");'#10 +
+        '      const key = Reflect.ownKeys(Object.defineProperty({}, prop, { value: undefined }))[0];'#10 +
+        '      const find = (object) => {'#10 +
+        '        if (object === null) return undefined;'#10 +
+        '        const descriptor = Object.getOwnPropertyDescriptor(object, key);'#10 +
+        '        if (descriptor !== undefined) return descriptor.set;'#10 +
+        '        return find(Object.getPrototypeOf(object));'#10 +
+        '      };'#10 +
+        '      return find(this);'#10 +
+        '    },'#10 +
+        '    writable: true, enumerable: false, configurable: true'#10 +
+        '  });'#10 +
+        '  Object.defineProperty(proto.__lookupSetter__, "name", { value: "__lookupSetter__", configurable: true });'#10 +
+        '  return proto.__lookupSetter__;'#10 +
         '})(Object.getPrototypeOf({}));'
     )
   );

--- a/source/units/Goccia.SourcePipeline.pas
+++ b/source/units/Goccia.SourcePipeline.pas
@@ -110,7 +110,8 @@ type
     class function ActivateOptions(
       const AOptions: TGocciaSourcePipelineOptions): TGocciaSourcePipelineOptionsScope; static;
     class function Parse(const ASource: TStringList; const AFileName: string;
-      const AOptions: TGocciaSourcePipelineOptions): TGocciaSourcePipelineResult; static;
+      const AOptions: TGocciaSourcePipelineOptions;
+      const ADeclaredPrivateNames: TStrings = nil): TGocciaSourcePipelineResult; static;
     class function ParseModuleSource(const ASource: UTF8String;
       const AFileName: string;
       const AOptions: TGocciaSourcePipelineOptions): TGocciaSourcePipelineModuleResult; static;
@@ -367,7 +368,8 @@ end;
 
 class function TGocciaSourcePipeline.Parse(const ASource: TStringList;
   const AFileName: string;
-  const AOptions: TGocciaSourcePipelineOptions): TGocciaSourcePipelineResult;
+  const AOptions: TGocciaSourcePipelineOptions;
+  const ADeclaredPrivateNames: TStrings): TGocciaSourcePipelineResult;
 var
   SourceText, OriginalSourceText: string;
   Lexer: TGocciaLexer;
@@ -410,7 +412,11 @@ begin
         Parser := TGocciaParser.Create(Tokens, AFileName, Lexer.SourceLines);
         ConfigureParser(Parser, AOptions);
         try
-          Result.FProgramNode := Parser.Parse;
+          if Assigned(ADeclaredPrivateNames) then
+            Result.FProgramNode :=
+              Parser.ParseWithPrivateNames(ADeclaredPrivateNames)
+          else
+            Result.FProgramNode := Parser.Parse;
           ParseEnd := GetNanoseconds;
           Result.FParseTimeNanoseconds := ParseEnd - LexEnd;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -248,6 +248,8 @@ type
       const AName: string; const AUseSuperConstructor: Boolean): TGocciaValue;
     function GetSuperPropertyValueByKey(const ASuperValue, AThisValue,
       AKey: TGocciaValue; const AUseSuperConstructor: Boolean): TGocciaValue;
+    procedure SetSuperPropertyValueByKey(const ASuperValue, AThisValue,
+      AKey, AValue: TGocciaValue);
     function ResolveBytecodePrivateBrandToken(const AKey: string;
       const AObject: TGocciaValue): string;
     function GetPropertyValue(const AObject: TGocciaValue; const AKey: string): TGocciaValue;
@@ -4531,28 +4533,32 @@ var
         SSuggestNotConstructorType);
   end;
   procedure InitializeCurrentCtorReceiver(const AReceiver: TGocciaValue);
+  var
+    CurrentVM: TGocciaVM;
   begin
     if (AReceiver is TGocciaObjectValue) and
        (FCurrentCtorClass is TGocciaVMClassValue) then
     begin
+      CurrentVM := TGocciaVMClassValue(FCurrentCtorClass).FVM;
+      CurrentVM.SetLocal(0, AReceiver);
+      CurrentVM.FLastClosureThisValue := VMValueToRegisterFast(AReceiver);
       if HasBytecodePrivateInitializersApplied(AReceiver,
         TGocciaClassValue(FCurrentCtorClass)) then
         ThrowTypeError('Cannot initialize private elements twice',
           SSuggestPrivateFieldAccess);
-      TGocciaVMClassValue(FCurrentCtorClass).FVM.RunClassInitializers(
-        FCurrentCtorClass, AReceiver, False);
+      CurrentVM.RunClassInitializers(FCurrentCtorClass, AReceiver, False);
       StampBytecodePrivateInitializersApplied(AReceiver,
         FCurrentCtorClass);
     end;
   end;
   procedure MarkCurrentConstructorSuperCalled;
   begin
-    if FCurrentCtorClass is TGocciaVMClassValue then
-      TGocciaVMClassValue(FCurrentCtorClass).FVM.FCurrentConstructorSuperCalled :=
-        True;
     if WasSuperAlreadyCalled then
       ThrowReferenceError(
         'Super constructor may only be called once');
+    if FCurrentCtorClass is TGocciaVMClassValue then
+      TGocciaVMClassValue(FCurrentCtorClass).FVM.FCurrentConstructorSuperCalled :=
+        True;
   end;
 begin
   WasSuperAlreadyCalled := (FCurrentCtorClass is TGocciaVMClassValue) and
@@ -4970,66 +4976,71 @@ begin
     InitializerReplayReceiver := nil;
     TGarbageCollector.Instance.AddTempRoot(RootedInstance);
     try
-      ConstructorToCall := nil;
-      if (SuperClass is TGocciaVMClassValue) and
-         Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
-      begin
-        TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
-          SuperClass, Instance);
-        if Assigned(ANewTarget) then
-          TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := ANewTarget
-        else
-          TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := Self;
-        ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
-          TGocciaVMClassValue(SuperClass).FConstructorValue,
-          AArguments, Instance);
-        if TGocciaVMClassValue(SuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
-          ConstructorThisValue := RegisterToValue(
-            TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue)
-        else
-          ConstructorThisValue := Instance;
-        ValidateClassConstructorReturn(SuperClass, ConstructedValue);
-        if IsUndefinedConstructedValue(ConstructedValue) then
-          ApplyReplacementResult(ConstructorThisValue)
-        else
-          ApplyReplacementResult(ConstructedValue);
-      end
-      else
-      begin
-        if Assigned(SuperClass) then
-          ConstructorToCall := SuperClass.ConstructorMethod;
-
-        if Assigned(ConstructorToCall) then
+      PreviousConstructorSuperCalled := FVM.FCurrentConstructorSuperCalled;
+      FVM.FCurrentConstructorSuperCalled := False;
+      try
+        ConstructorToCall := nil;
+        if (SuperClass is TGocciaVMClassValue) and
+           Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
         begin
           FVM.RunClassInitializers(SuperClass, Instance);
           if Assigned(ANewTarget) then
-            ConstructedValue := ConstructorToCall.CallWithThisValue(
-              AArguments, Instance, ConstructorThisValue, ANewTarget)
+            TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := ANewTarget
           else
-            ConstructedValue := ConstructorToCall.CallWithThisValue(
-              AArguments, Instance, ConstructorThisValue, Self);
+            TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := Self;
+          ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
+            TGocciaVMClassValue(SuperClass).FConstructorValue,
+            AArguments, Instance);
+          if TGocciaVMClassValue(SuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
+            ConstructorThisValue := RegisterToValue(
+              TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue)
+          else
+            ConstructorThisValue := Instance;
           ValidateClassConstructorReturn(SuperClass, ConstructedValue);
           if IsUndefinedConstructedValue(ConstructedValue) then
             ApplyReplacementResult(ConstructorThisValue)
           else
             ApplyReplacementResult(ConstructedValue);
         end
-        else if Assigned(SuperClass) then
+        else
         begin
-          ConstructedValue := FVM.InvokeImplicitSuperInitialization(
-            SuperClass, Instance, AArguments);
-          ApplyReplacementResult(ConstructedValue);
-        end
-        else if Assigned(NativeSuperConstructor) and
-                (NativeSuperConstructor is TGocciaFunctionBase) and
-                not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
-        begin
-          ConstructedValue := InvokeConstructableWithReceiver(
-            NativeSuperConstructor, AArguments, Instance);
-          ApplyReplacementResult(ConstructedValue);
-        end
-        else if Instance is TGocciaInstanceValue then
-          TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
+          if Assigned(SuperClass) then
+            ConstructorToCall := SuperClass.ConstructorMethod;
+
+          if Assigned(ConstructorToCall) then
+          begin
+            FVM.RunClassInitializers(SuperClass, Instance);
+            if Assigned(ANewTarget) then
+              ConstructedValue := ConstructorToCall.CallWithThisValue(
+                AArguments, Instance, ConstructorThisValue, ANewTarget)
+            else
+              ConstructedValue := ConstructorToCall.CallWithThisValue(
+                AArguments, Instance, ConstructorThisValue, Self);
+            ValidateClassConstructorReturn(SuperClass, ConstructedValue);
+            if IsUndefinedConstructedValue(ConstructedValue) then
+              ApplyReplacementResult(ConstructorThisValue)
+            else
+              ApplyReplacementResult(ConstructedValue);
+          end
+          else if Assigned(SuperClass) then
+          begin
+            ConstructedValue := FVM.InvokeImplicitSuperInitialization(
+              SuperClass, Instance, AArguments);
+            ApplyReplacementResult(ConstructedValue);
+          end
+          else if Assigned(NativeSuperConstructor) and
+                  (NativeSuperConstructor is TGocciaFunctionBase) and
+                  not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
+          begin
+            ConstructedValue := InvokeConstructableWithReceiver(
+              NativeSuperConstructor, AArguments, Instance);
+            ApplyReplacementResult(ConstructedValue);
+          end
+          else if Instance is TGocciaInstanceValue then
+            TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
+        end;
+      finally
+        FVM.FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
       end;
 
       if not Assigned(InitializerReplayReceiver) or
@@ -5328,32 +5339,50 @@ begin
       end
       else
       begin
-        ConstructorToCall := nil;
+        PreviousConstructorSuperCalled := FVM.FCurrentConstructorSuperCalled;
+        FVM.FCurrentConstructorSuperCalled := False;
+        try
+          ConstructorToCall := nil;
 
-        if (SuperClass is TGocciaVMClassValue) and
-           Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
-        begin
-          TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
-            SuperClass, Instance);
-          TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := Self;
-          if TGocciaVMClassValue(SuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
+          if (SuperClass is TGocciaVMClassValue) and
+             Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
           begin
-            BytecodeSuperConstructor := TGocciaBytecodeFunctionValue(
-              TGocciaVMClassValue(SuperClass).FConstructorValue);
-            if Assigned(BytecodeSuperConstructor.FClosure) and
-               Assigned(BytecodeSuperConstructor.FClosure.Template) and
-               (not BytecodeSuperConstructor.FClosure.Template.IsAsync) then
+            TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
+              SuperClass, Instance);
+            TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := Self;
+            if TGocciaVMClassValue(SuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
             begin
-              ReturnRegister := TGocciaVMClassValue(SuperClass).FVM.ExecuteClosureRegisters(
-                BytecodeSuperConstructor.FClosure,
-                RegisterObject(Instance), AArguments);
-              ConstructorThisRegister :=
-                TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue;
-              ValidateClassConstructorRegister(SuperClass, ReturnRegister);
-              if IsUndefinedConstructedRegister(ReturnRegister) then
-                ApplyReplacementRegister(ConstructorThisRegister)
+              BytecodeSuperConstructor := TGocciaBytecodeFunctionValue(
+                TGocciaVMClassValue(SuperClass).FConstructorValue);
+              if Assigned(BytecodeSuperConstructor.FClosure) and
+                 Assigned(BytecodeSuperConstructor.FClosure.Template) and
+                 (not BytecodeSuperConstructor.FClosure.Template.IsAsync) then
+              begin
+                ReturnRegister := TGocciaVMClassValue(SuperClass).FVM.ExecuteClosureRegisters(
+                  BytecodeSuperConstructor.FClosure,
+                  RegisterObject(Instance), AArguments);
+                ConstructorThisRegister :=
+                  TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue;
+                ValidateClassConstructorRegister(SuperClass, ReturnRegister);
+                if IsUndefinedConstructedRegister(ReturnRegister) then
+                  ApplyReplacementRegister(ConstructorThisRegister)
+                else
+                  ApplyReplacementRegister(ReturnRegister);
+              end
               else
-                ApplyReplacementRegister(ReturnRegister);
+              begin
+                EnsureBoxedArgs;
+                ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
+                  TGocciaVMClassValue(SuperClass).FConstructorValue,
+                  BoxedArgs, Instance);
+                ConstructorThisRegister :=
+                  TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue;
+                ValidateClassConstructorReturn(SuperClass, ConstructedValue);
+                if IsUndefinedConstructedValue(ConstructedValue) then
+                  ApplyReplacementRegister(ConstructorThisRegister)
+                else
+                  ApplyReplacementResult(ConstructedValue);
+              end;
             end
             else
             begin
@@ -5361,63 +5390,51 @@ begin
               ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
                 TGocciaVMClassValue(SuperClass).FConstructorValue,
                 BoxedArgs, Instance);
-              ConstructorThisRegister :=
-                TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue;
               ValidateClassConstructorReturn(SuperClass, ConstructedValue);
-              if IsUndefinedConstructedValue(ConstructedValue) then
-                ApplyReplacementRegister(ConstructorThisRegister)
-              else
-                ApplyReplacementResult(ConstructedValue);
+              ApplyReplacementResult(ConstructedValue);
             end;
           end
           else
           begin
-            EnsureBoxedArgs;
-            ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
-              TGocciaVMClassValue(SuperClass).FConstructorValue,
-              BoxedArgs, Instance);
-            ValidateClassConstructorReturn(SuperClass, ConstructedValue);
-            ApplyReplacementResult(ConstructedValue);
-          end;
-        end
-        else
-        begin
-          if Assigned(SuperClass) then
-            ConstructorToCall := SuperClass.ConstructorMethod;
+            if Assigned(SuperClass) then
+              ConstructorToCall := SuperClass.ConstructorMethod;
 
-          if Assigned(ConstructorToCall) then
-          begin
-            EnsureBoxedArgs;
-            FVM.RunClassInitializers(SuperClass, Instance);
-            ConstructedValue := ConstructorToCall.CallWithThisValue(
-              BoxedArgs, Instance, ConstructorThisValue, Self);
-            ValidateClassConstructorReturn(SuperClass, ConstructedValue);
-            if IsUndefinedConstructedValue(ConstructedValue) then
-              ApplyReplacementResult(ConstructorThisValue)
-            else
+            if Assigned(ConstructorToCall) then
+            begin
+              EnsureBoxedArgs;
+              FVM.RunClassInitializers(SuperClass, Instance);
+              ConstructedValue := ConstructorToCall.CallWithThisValue(
+                BoxedArgs, Instance, ConstructorThisValue, Self);
+              ValidateClassConstructorReturn(SuperClass, ConstructedValue);
+              if IsUndefinedConstructedValue(ConstructedValue) then
+                ApplyReplacementResult(ConstructorThisValue)
+              else
+                ApplyReplacementResult(ConstructedValue);
+            end
+            else if Assigned(SuperClass) then
+            begin
+              ConstructedValue := FVM.InvokeImplicitSuperInitializationRegisters(
+                SuperClass, Instance, AArguments);
               ApplyReplacementResult(ConstructedValue);
-          end
-          else if Assigned(SuperClass) then
-          begin
-            ConstructedValue := FVM.InvokeImplicitSuperInitializationRegisters(
-              SuperClass, Instance, AArguments);
-            ApplyReplacementResult(ConstructedValue);
-          end
-          else if Assigned(NativeSuperConstructor) and
-                  (NativeSuperConstructor is TGocciaFunctionBase) and
-                  not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
-          begin
-            EnsureBoxedArgs;
-            ConstructedValue := InvokeConstructableWithReceiver(
-              NativeSuperConstructor, BoxedArgs, Instance);
-            ApplyReplacementResult(ConstructedValue);
-          end
-          else
-          begin
-            EnsureBoxedArgs;
-            if Instance is TGocciaInstanceValue then
-              TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
+            end
+            else if Assigned(NativeSuperConstructor) and
+                    (NativeSuperConstructor is TGocciaFunctionBase) and
+                    not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
+            begin
+              EnsureBoxedArgs;
+              ConstructedValue := InvokeConstructableWithReceiver(
+                NativeSuperConstructor, BoxedArgs, Instance);
+              ApplyReplacementResult(ConstructedValue);
+            end
+            else
+            begin
+              EnsureBoxedArgs;
+              if Instance is TGocciaInstanceValue then
+                TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
+            end;
           end;
+        finally
+          FVM.FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
         end;
 
         if not Assigned(InitializerReplayReceiver) or
@@ -5889,7 +5906,7 @@ begin
 end;
 
 procedure SetBytecodeHomeObject(const AFunctionValue: TGocciaValue;
-  const AHomeObject: TGocciaValue);
+  const AHomeObject: TGocciaValue; const AStaticHome: Boolean = False);
 var
   EffectiveHomeObject: TGocciaObjectValue;
   EffectiveHomeClass: TGocciaClassValue;
@@ -5897,7 +5914,10 @@ var
 begin
   if AHomeObject is TGocciaClassValue then
   begin
-    EffectiveHomeObject := TGocciaClassValue(AHomeObject).Prototype;
+    if AStaticHome then
+      EffectiveHomeObject := TGocciaObjectValue(AHomeObject)
+    else
+      EffectiveHomeObject := TGocciaClassValue(AHomeObject).Prototype;
     EffectiveHomeClass := TGocciaClassValue(AHomeObject);
   end
   else if AHomeObject is TGocciaObjectValue then
@@ -7241,7 +7261,10 @@ begin
   else
     Exit;
 
-  SetBytecodeHomeObject(AGetter, TargetObject);
+  if ATarget is TGocciaVMClassValue then
+    SetBytecodeHomeObject(AGetter, ATarget)
+  else
+    SetBytecodeHomeObject(AGetter, TargetObject);
   ExistingDescriptor := TargetObject.GetOwnPropertyDescriptor(AName);
   ExistingSetter := nil;
   if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
@@ -7272,7 +7295,10 @@ begin
   else
     Exit;
 
-  SetBytecodeHomeObject(ASetter, TargetObject);
+  if ATarget is TGocciaVMClassValue then
+    SetBytecodeHomeObject(ASetter, ATarget)
+  else
+    SetBytecodeHomeObject(ASetter, TargetObject);
   ExistingDescriptor := TargetObject.GetOwnPropertyDescriptor(AName);
   ExistingGetter := nil;
   if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
@@ -7289,7 +7315,7 @@ var
 begin
   if ATarget is TGocciaClassValue then
   begin
-    SetBytecodeHomeObject(AGetter, ATarget);
+    SetBytecodeHomeObject(AGetter, ATarget, True);
     if IsBytecodePrivateKey(AName) then
     begin
       PrivateBrandToken := BytecodePrivateTokenForKey(AName,
@@ -7310,7 +7336,7 @@ var
 begin
   if ATarget is TGocciaClassValue then
   begin
-    SetBytecodeHomeObject(ASetter, ATarget);
+    SetBytecodeHomeObject(ASetter, ATarget, True);
     if IsBytecodePrivateKey(AName) then
     begin
       PrivateBrandToken := BytecodePrivateTokenForKey(AName,
@@ -7335,7 +7361,7 @@ begin
   begin
     if ATarget is TGocciaVMClassValue then
     begin
-      SetBytecodeHomeObject(AGetter, TGocciaVMClassValue(ATarget).Prototype);
+      SetBytecodeHomeObject(AGetter, ATarget);
       DescriptorFlags := [pfConfigurable];
       ExistingDescriptor := TGocciaVMClassValue(ATarget).Prototype
         .GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(AKey));
@@ -7380,7 +7406,7 @@ begin
   begin
     if ATarget is TGocciaVMClassValue then
     begin
-      SetBytecodeHomeObject(ASetter, TGocciaVMClassValue(ATarget).Prototype);
+      SetBytecodeHomeObject(ASetter, ATarget);
       DescriptorFlags := [pfConfigurable];
       ExistingDescriptor := TGocciaVMClassValue(ATarget).Prototype
         .GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(AKey));
@@ -7422,7 +7448,7 @@ var
 begin
   if (ATarget is TGocciaClassValue) and (AKey is TGocciaSymbolValue) then
   begin
-    SetBytecodeHomeObject(AGetter, ATarget);
+    SetBytecodeHomeObject(AGetter, ATarget, True);
     ExistingDescriptor := TGocciaClassValue(ATarget)
       .GetOwnStaticSymbolDescriptor(TGocciaSymbolValue(AKey));
     ExistingSetter := nil;
@@ -7447,7 +7473,7 @@ var
 begin
   if (ATarget is TGocciaClassValue) and (AKey is TGocciaSymbolValue) then
   begin
-    SetBytecodeHomeObject(ASetter, ATarget);
+    SetBytecodeHomeObject(ASetter, ATarget, True);
     ExistingDescriptor := TGocciaClassValue(ATarget)
       .GetOwnStaticSymbolDescriptor(TGocciaSymbolValue(AKey));
     ExistingGetter := nil;
@@ -7480,6 +7506,14 @@ begin
     FCurrentDynamicVarScope.ThisValue := FGlobalThisValue;
   FCurrentDynamicVarScope.NonStrictMode := True;
   Result := FCurrentDynamicVarScope;
+end;
+
+function HasDynamicVarBinding(const AScope: TGocciaScope;
+  const AName: string): Boolean; inline;
+begin
+  Result := Assigned(AScope) and
+    (AScope.ContainsOwnVarBinding(AName) or
+     AScope.ContainsOwnLexicalBinding(AName));
 end;
 
 procedure TGocciaVM.DefineGlobalBinding(const AName: string;
@@ -8440,7 +8474,7 @@ var
     else
       KeyValue := TGocciaStringLiteralValue.Create(AName);
     if AIsStatic then
-      SetBytecodeHomeObject(AValue, TGocciaClassValue(ClassVal))
+      SetBytecodeHomeObject(AValue, TGocciaClassValue(ClassVal), True)
     else
       SetBytecodeHomeObject(AValue, TargetObject);
     if KeyValue is TGocciaSymbolValue then
@@ -8492,7 +8526,7 @@ var
       KeyValue := TGocciaStringLiteralValue.Create(AName);
 
     if AIsStatic then
-      SetBytecodeHomeObject(AGetter, TGocciaClassValue(ClassVal))
+      SetBytecodeHomeObject(AGetter, TGocciaClassValue(ClassVal), True)
     else
       SetBytecodeHomeObject(AGetter, TargetObject);
     if KeyValue is TGocciaSymbolValue then
@@ -8543,7 +8577,7 @@ var
       KeyValue := TGocciaStringLiteralValue.Create(AName);
 
     if AIsStatic then
-      SetBytecodeHomeObject(ASetter, TGocciaClassValue(ClassVal))
+      SetBytecodeHomeObject(ASetter, TGocciaClassValue(ClassVal), True)
     else
       SetBytecodeHomeObject(ASetter, TargetObject);
     if KeyValue is TGocciaSymbolValue then
@@ -9079,6 +9113,56 @@ begin
       TGocciaSymbolValue(AKey), AThisValue));
 
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+procedure TGocciaVM.SetSuperPropertyValueByKey(const ASuperValue, AThisValue,
+  AKey, AValue: TGocciaValue);
+var
+  BaseObject: TGocciaObjectValue;
+  BaseValue: TGocciaValue;
+  HomeObject: TGocciaObjectValue;
+  KeyValue: TGocciaValue;
+  PropertyName: string;
+  Success: Boolean;
+begin
+  BaseValue := nil;
+  HomeObject := nil;
+  if Assigned(FCurrentClosure) then
+    HomeObject := FCurrentClosure.HomeObject;
+
+  if Assigned(HomeObject) then
+    BaseValue := HomeObject.Prototype
+  else if AThisValue is TGocciaClassValue then
+  begin
+    if ASuperValue is TGocciaObjectValue then
+      BaseValue := ASuperValue;
+  end
+  else if ASuperValue is TGocciaClassValue then
+    BaseValue := TGocciaClassValue(ASuperValue).Prototype
+  else if ASuperValue is TGocciaObjectValue then
+    BaseValue := TGocciaObjectValue(ASuperValue).Prototype;
+
+  KeyValue := ToPropertyKey(AKey);
+  if KeyValue is TGocciaSymbolValue then
+    PropertyName := TGocciaSymbolValue(KeyValue).ToDisplayString.Value
+  else
+    PropertyName := TGocciaStringLiteralValue(KeyValue).Value;
+
+  if not (BaseValue is TGocciaObjectValue) then
+    ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, [PropertyName]),
+      SSuggestCheckNullBeforeAccess);
+
+  BaseObject := TGocciaObjectValue(BaseValue);
+  if KeyValue is TGocciaSymbolValue then
+    Success := BaseObject.AssignSymbolPropertyWithReceiver(
+      TGocciaSymbolValue(KeyValue), AValue, AThisValue)
+  else
+    Success := BaseObject.AssignPropertyWithReceiver(PropertyName, AValue,
+      AThisValue);
+
+  if not Success then
+    ThrowTypeError(Format(SErrorCannotAssignReadOnly, [PropertyName]),
+      SSuggestCannotDeleteNonConfigurable);
 end;
 
 function TGocciaVM.GetPropertyValue(const AObject: TGocciaValue;
@@ -9754,6 +9838,58 @@ begin
   Result := not ATemplate.IsArrow;
 end;
 
+function DirectEvalParameterPreambleVarRejectNames(
+  const ATemplate: TGocciaFunctionTemplate; const AEnvironmentIndex: Integer;
+  const APC: UInt32): TGocciaEvalRejectNameArray;
+var
+  Env: TGocciaDirectEvalEnvironment;
+  Binding: TGocciaDirectEvalBindingInfo;
+  Names: TGocciaEvalRejectNameArray;
+  I, Len: Integer;
+  function IsVisibleParameterBindingName(const AName: string): Boolean;
+  begin
+    Result := (AName <> '') and
+      (AName <> KEYWORD_THIS) and
+      (AName <> '__receiver') and
+      (AName <> '__super__') and
+      (Copy(AName, 1, 1) <> '#') and
+      (Copy(AName, 1, 7) <> '__param') and
+      (Copy(AName, 1, 8) <> '`#param`') and
+      (Copy(AName, 1, 19) <> '__accessor_computed');
+  end;
+  function NameSeen(const AName: string): Boolean;
+  var
+    J: Integer;
+  begin
+    for J := 0 to High(Names) do
+      if Names[J] = AName then
+        Exit(True);
+    Result := False;
+  end;
+  procedure AddName(const AName: string);
+  begin
+    if (not IsVisibleParameterBindingName(AName)) or NameSeen(AName) then
+      Exit;
+    Len := Length(Names);
+    SetLength(Names, Len + 1);
+    Names[Len] := AName;
+  end;
+begin
+  Names := nil;
+  if (not Assigned(ATemplate)) or (AEnvironmentIndex < 0) or
+     (APC >= ATemplate.ParameterPreambleSize) then
+    Exit(nil);
+
+  Env := ATemplate.GetDirectEvalEnvironment(AEnvironmentIndex);
+  for I := 0 to High(Env.Bindings) do
+  begin
+    Binding := Env.Bindings[I];
+    if (Binding.Kind = debLocal) and not Binding.IsVarEnvironmentBinding then
+      AddName(Binding.Name);
+  end;
+  Result := Names;
+end;
+
 function TGocciaVM.ExecuteDirectEval(const ASourceValue: TGocciaValue;
   const ATemplate: TGocciaFunctionTemplate; const APC: UInt32;
   const ACallerStrict: Boolean): TGocciaValue;
@@ -9776,6 +9912,7 @@ var
   CurrentFunctionValue: TGocciaValue;
   CurrentCtorClass: TGocciaClassValue;
   RejectArgumentsVarDeclaration: Boolean;
+  RejectVarDeclarationNames: TGocciaEvalRejectNameArray;
   RejectArgumentsReference: Boolean;
   AllowNewTarget: Boolean;
   AllowSuperProperty: Boolean;
@@ -9875,11 +10012,15 @@ begin
           try
             RejectArgumentsVarDeclaration :=
               DirectEvalRejectsArgumentsVarDeclaration(ATemplate, APC);
+            RejectVarDeclarationNames :=
+              DirectEvalParameterPreambleVarRejectNames(
+                ATemplate, EnvIndex, APC);
             RejectArgumentsReference := ATemplate.RejectArgumentsInDirectEval;
             try
               Result := EvaluateEvalProgram(PipelineResult.ProgramNode,
                 EvalContext, VarScope, ActiveScope, StrictEval,
-                RejectArgumentsVarDeclaration, AllowNewTarget,
+                RejectArgumentsVarDeclaration, RejectVarDeclarationNames,
+                AllowNewTarget,
                 AllowSuperProperty, AllowSuperCall, RejectArgumentsReference);
             finally
               CallerScope.CopyBackVariableBindings;
@@ -10463,8 +10604,8 @@ begin
         if Assigned(FCurrentClosure) then
         begin
           Desc := Template.GetUpvalueDescriptor(DecodeBx(Instruction));
-          if (Desc.Name <> '') and Assigned(FCurrentDynamicVarScope) and
-             FCurrentDynamicVarScope.Contains(Desc.Name) then
+          if (Desc.Name <> '') and
+             HasDynamicVarBinding(FCurrentDynamicVarScope, Desc.Name) then
           begin
             FRegisters[A] := VMValueToRegisterFast(
               FCurrentDynamicVarScope.GetValue(Desc.Name));
@@ -11217,7 +11358,8 @@ begin
            (FRegisters[A].ObjectValue is TGocciaObjectValue) then
         begin
           if FRegisters[A].ObjectValue is TGocciaVMClassValue then
-            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
+            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]),
+              True);
           if IsBytecodePrivateKey(GlobalName) then
           begin
             if (FRegisters[A].ObjectValue is TGocciaInstanceValue) then
@@ -11302,13 +11444,15 @@ begin
           begin
             DeclareBytecodePrivateNameForClass(FRegisters[A].ObjectValue,
               GlobalName);
-            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
+            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]),
+              True);
             TGocciaVMClassValue(FRegisters[A].ObjectValue).AddPrivateStaticMethod(
               GlobalName, RightValue);
             Continue;
           end;
           if FRegisters[A].ObjectValue is TGocciaVMClassValue then
-            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
+            SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]),
+              True);
           TGocciaObjectValue(FRegisters[A].ObjectValue).DefineProperty(
             GlobalName,
             TGocciaPropertyDescriptorData.Create(
@@ -12949,8 +13093,7 @@ begin
       OP_GET_GLOBAL:
       begin
         GlobalName := Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue;
-        if Assigned(FCurrentDynamicVarScope) and
-           FCurrentDynamicVarScope.Contains(GlobalName) then
+        if HasDynamicVarBinding(FCurrentDynamicVarScope, GlobalName) then
           FRegisters[A] := VMValueToRegisterFast(
             FCurrentDynamicVarScope.GetValue(GlobalName))
         else if Assigned(FGlobalScope) and FGlobalScope.Contains(GlobalName) then
@@ -12962,8 +13105,7 @@ begin
       OP_SET_GLOBAL:
       begin
         GlobalName := Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue;
-        if Assigned(FCurrentDynamicVarScope) and
-           FCurrentDynamicVarScope.Contains(GlobalName) then
+        if HasDynamicVarBinding(FCurrentDynamicVarScope, GlobalName) then
           FCurrentDynamicVarScope.AssignBinding(GlobalName,
             RegisterToValue(FRegisters[A]))
         else if Assigned(FGlobalScope) then
@@ -12978,8 +13120,7 @@ begin
       OP_SET_GLOBAL_LOOSE:
       begin
         GlobalName := Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue;
-        if Assigned(FCurrentDynamicVarScope) and
-           FCurrentDynamicVarScope.Contains(GlobalName) then
+        if HasDynamicVarBinding(FCurrentDynamicVarScope, GlobalName) then
           FCurrentDynamicVarScope.AssignBinding(GlobalName,
             RegisterToValue(FRegisters[A]), 0, 0, True)
         else if Assigned(FGlobalScope) then
@@ -12996,8 +13137,7 @@ begin
       OP_HAS_GLOBAL:
       begin
         GlobalName := Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue;
-        if Assigned(FCurrentDynamicVarScope) and
-           FCurrentDynamicVarScope.Contains(GlobalName) then
+        if HasDynamicVarBinding(FCurrentDynamicVarScope, GlobalName) then
           FRegisters[A] := RegisterBoolean(True)
         else if Assigned(FGlobalScope) and FGlobalScope.Contains(GlobalName) then
           FRegisters[A] := RegisterBoolean(True)
@@ -13008,8 +13148,7 @@ begin
       OP_DELETE_GLOBAL:
       begin
         GlobalName := Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue;
-        if Assigned(FCurrentDynamicVarScope) and
-           FCurrentDynamicVarScope.Contains(GlobalName) then
+        if HasDynamicVarBinding(FCurrentDynamicVarScope, GlobalName) then
           FRegisters[A] := RegisterBoolean(
             FCurrentDynamicVarScope.DeleteBinding(GlobalName))
         else if Assigned(FGlobalScope) then
@@ -13398,6 +13537,14 @@ begin
             GetRegister(A - 1), GetRegister(C), B <> 0))
         else
           SetRegister(A, TGocciaUndefinedLiteralValue.UndefinedValue);
+
+      OP_SUPER_SET:
+        if A > 0 then
+          SetSuperPropertyValueByKey(GetRegister(A + 1), GetRegister(A - 1),
+            GetRegister(B), GetRegister(C))
+        else
+          ThrowTypeError(SErrorCannotSetPropertyOnNonObject,
+            SSuggestCheckNullBeforeAccess);
 
       OP_RETURN:
       begin

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -9899,6 +9899,7 @@ var
   EvalOptions: TGocciaSourcePipelineOptions;
   PipelineResult: TGocciaSourcePipelineResult;
   EnvIndex: Integer;
+  DirectEvalEnv: TGocciaDirectEvalEnvironment;
   StrictEval: Boolean;
   CallerScope, EvalScope: TGocciaVMDirectEvalScope;
   CallerParentScope: TGocciaScope;
@@ -10016,6 +10017,12 @@ begin
               DirectEvalParameterPreambleVarRejectNames(
                 ATemplate, EnvIndex, APC);
             RejectArgumentsReference := ATemplate.RejectArgumentsInDirectEval;
+            if EnvIndex >= 0 then
+            begin
+              DirectEvalEnv := ATemplate.GetDirectEvalEnvironment(EnvIndex);
+              RejectArgumentsReference := RejectArgumentsReference or
+                DirectEvalEnv.RejectArgumentsReference;
+            end;
             try
               Result := EvaluateEvalProgram(PipelineResult.ProgramNode,
                 EvalContext, VarScope, ActiveScope, StrictEval,

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -16,6 +16,7 @@ uses
   Goccia.ExecutionContext,
   Goccia.GarbageCollector,
   Goccia.Intrinsics.FunctionObjects,
+  Goccia.Keywords.Reserved,
   Goccia.Modules,
   Goccia.Realm,
   Goccia.Scope,
@@ -164,6 +165,8 @@ type
     function KeyToPropertyName(const AKey: TGocciaValue): string;
     function KeyToPropertyNameRegister(const AKey: TGocciaRegister): string;
     function TryResolveObjectKey(const AKeyReg: TGocciaRegister; out AResolved: TGocciaValue): Boolean; inline;
+    procedure SetFunctionNameFromKey(const AFunction, AKey: TGocciaValue;
+      const APrefixKind: UInt8);
     function EnsureCurrentDynamicVarScope: TGocciaScope;
     function KeyDisplaySafe(const AKey: TGocciaRegister): string;
     // ALimit semantics:
@@ -184,6 +187,8 @@ type
       const AExclusionKeys: TGocciaArrayValue): TGocciaObjectValue;
     function ForInEntriesArray(const AValue: TGocciaValue): TGocciaArrayValue;
     function TryForInEntryKey(const AEntry: TGocciaValue; out AKey: string): Boolean;
+    function PromiseConstructorIntrinsic: TGocciaValue;
+    function PromiseResolveIntrinsic(const AValue: TGocciaValue): TGocciaPromiseValue;
     function GetIteratorValue(const AIterable: TGocciaValue;
       const ATryAsync: Boolean): TGocciaValue;
     function ConstructValue(const AConstructor: TGocciaValue;
@@ -218,7 +223,8 @@ type
       const ADeclarationType: TGocciaDeclarationType);
     function FinalizeEnumValue(const AValue: TGocciaValue; const AName: string): TGocciaValue;
     procedure StampBytecodePrivateBrands(const AClassValue: TGocciaClassValue;
-      const AInstance: TGocciaValue);
+      const AInstance: TGocciaValue;
+      const APreserveExistingPrivateSlots: Boolean);
     procedure SetupAutoAccessorValue(const AName: string; const AIsStatic: Boolean);
     procedure SetupAutoAccessorValueByKey(const AKey: TGocciaValue;
       const ABackingName: string; const AIsStatic: Boolean);
@@ -242,6 +248,8 @@ type
       const AName: string; const AUseSuperConstructor: Boolean): TGocciaValue;
     function GetSuperPropertyValueByKey(const ASuperValue, AThisValue,
       AKey: TGocciaValue; const AUseSuperConstructor: Boolean): TGocciaValue;
+    function ResolveBytecodePrivateBrandToken(const AKey: string;
+      const AObject: TGocciaValue): string;
     function GetPropertyValue(const AObject: TGocciaValue; const AKey: string): TGocciaValue;
     procedure SetPropertyValue(const AObject: TGocciaValue; const AKey: string;
       const AValue: TGocciaValue);
@@ -424,6 +432,9 @@ type
     FVM: TGocciaVM;
     FTemplate: TGocciaFunctionTemplate;
     FEnvironmentIndex: Integer;
+    FHomeObject: TGocciaValue;
+    FHomeClass: TGocciaValue;
+    FNewTarget: TGocciaValue;
     function TryFindBinding(const AName: string;
       out ABinding: TGocciaDirectEvalBindingInfo): Boolean;
     function BindingValue(
@@ -435,6 +446,7 @@ type
     procedure SetBindingValue(const ABinding: TGocciaDirectEvalBindingInfo;
       const AValue: TGocciaValue);
   protected
+    function GetOwningClass: TGocciaValue; override;
     function GetSuperClass: TGocciaValue; override;
     function GetSuperConstructor: TGocciaValue; override;
     function GetNewTarget: TGocciaValue; override;
@@ -444,7 +456,10 @@ type
   public
     constructor Create(const AParent: TGocciaScope; const AVM: TGocciaVM;
       const ATemplate: TGocciaFunctionTemplate; const AEnvironmentIndex: Integer;
-      const AUseGlobalVarEnvironment: Boolean);
+      const AUseGlobalVarEnvironment: Boolean;
+      const ALexicalClosure: TGocciaBytecodeClosure;
+      const ANewTarget: TGocciaValue);
+    procedure MarkReferences; override;
     procedure AssignBinding(const AName: string; const AValue: TGocciaValue;
       const ALine: Integer = 0; const AColumn: Integer = 0;
       const ANonStrictMode: Boolean = False); override;
@@ -520,6 +535,7 @@ procedure StampBytecodePrivateInitializersApplied(const AInstance: TGocciaValue;
   const AClassValue: TGocciaClassValue); forward;
 function NormalizeBytecodePrivateKey(const AName,
   APrivateBrandToken: string): string; forward;
+function BytecodePrivateSourceName(const AName: string): string; forward;
 function BytecodePrivateBrandKey(const AKey,
   APrivateBrandToken: string): string; forward;
 function BytecodePrivateTokenForKey(const AKey,
@@ -531,10 +547,14 @@ function BytecodePrivateReceiverBrandToken(
 
 constructor TGocciaVMDirectEvalScope.Create(const AParent: TGocciaScope;
   const AVM: TGocciaVM; const ATemplate: TGocciaFunctionTemplate;
-  const AEnvironmentIndex: Integer; const AUseGlobalVarEnvironment: Boolean);
+  const AEnvironmentIndex: Integer; const AUseGlobalVarEnvironment: Boolean;
+  const ALexicalClosure: TGocciaBytecodeClosure;
+  const ANewTarget: TGocciaValue);
 var
   Env: TGocciaDirectEvalEnvironment;
   Binding: TGocciaDirectEvalBindingInfo;
+  BindingRuntimeValue: TGocciaValue;
+  ThisBindingValue: TGocciaValue;
   I: Integer;
 begin
   if AUseGlobalVarEnvironment then
@@ -544,6 +564,12 @@ begin
   FVM := AVM;
   FTemplate := ATemplate;
   FEnvironmentIndex := AEnvironmentIndex;
+  FNewTarget := ANewTarget;
+  if Assigned(ALexicalClosure) then
+  begin
+    FHomeObject := ALexicalClosure.HomeObject;
+    FHomeClass := ALexicalClosure.HomeClass;
+  end;
   if Assigned(FVM) and Assigned(FVM.FGlobalThisValue) then
     ThisValue := FVM.FGlobalThisValue;
   if (FEnvironmentIndex < 0) or not Assigned(FTemplate) then
@@ -553,15 +579,41 @@ begin
   for I := 0 to High(Env.Bindings) do
   begin
     Binding := Env.Bindings[I];
+    if Binding.Name = KEYWORD_THIS then
+    begin
+      if Binding.Kind <> debGlobal then
+      begin
+        ThisBindingValue := BindingValue(Binding);
+        if ThisBindingValue <> TGocciaHoleValue.HoleValue then
+          ThisValue := ThisBindingValue;
+      end;
+      Continue;
+    end;
     if Binding.IsVarEnvironmentBinding then
       Continue;
     if Binding.Kind in [debWithLocal, debWithUpvalue] then
       Continue;
+    if Binding.Kind = debGlobal then
+      Continue;
+    BindingRuntimeValue := BindingValue(Binding);
+    if BindingRuntimeValue = TGocciaHoleValue.HoleValue then
+      Continue;
     if Binding.IsConst then
-      DefineLexicalBinding(Binding.Name, BindingValue(Binding), dtConst)
+      DefineLexicalBinding(Binding.Name, BindingRuntimeValue, dtConst)
     else
-      DefineLexicalBinding(Binding.Name, BindingValue(Binding), dtLet);
+      DefineLexicalBinding(Binding.Name, BindingRuntimeValue, dtLet);
   end;
+end;
+
+procedure TGocciaVMDirectEvalScope.MarkReferences;
+begin
+  inherited;
+  if Assigned(FHomeObject) then
+    FHomeObject.MarkReferences;
+  if Assigned(FHomeClass) then
+    FHomeClass.MarkReferences;
+  if Assigned(FNewTarget) then
+    FNewTarget.MarkReferences;
 end;
 
 function TGocciaVMDirectEvalScope.TryFindBinding(const AName: string;
@@ -735,12 +787,97 @@ begin
   end;
 end;
 
+function CollectBytecodeDirectEvalPrivateNames(
+  const AVM: TGocciaVM): TStringList;
+var
+  Closure: TGocciaBytecodeClosure;
+  RawNames: TStringList;
+  SourceName: string;
+  I: Integer;
+begin
+  Result := TStringList.Create;
+  Result.CaseSensitive := True;
+  Result.Sorted := False;
+  Result.Duplicates := dupIgnore;
+
+  Closure := DirectEvalLexicalClosure(AVM);
+  if not (Assigned(Closure) and (Closure.HomeClass is TGocciaClassValue)) then
+    Exit;
+
+  RawNames := TStringList.Create;
+  try
+    RawNames.CaseSensitive := True;
+    RawNames.Sorted := False;
+    RawNames.Duplicates := dupIgnore;
+    TGocciaClassValue(Closure.HomeClass).AppendOwnPrivateNames(RawNames);
+
+    for I := 0 to RawNames.Count - 1 do
+    begin
+      SourceName := BytecodePrivateSourceName(RawNames[I]);
+      if (SourceName <> '') and (Result.IndexOf(SourceName) < 0) then
+        Result.Add(SourceName);
+    end;
+  finally
+    RawNames.Free;
+  end;
+end;
+
+function DirectEvalCapturedThisValue(const AVM: TGocciaVM;
+  const ATemplate: TGocciaFunctionTemplate;
+  const AEnvironmentIndex: Integer; out AValue: TGocciaValue): Boolean;
+var
+  Env: TGocciaDirectEvalEnvironment;
+  Binding: TGocciaDirectEvalBindingInfo;
+  Upvalue: TGocciaBytecodeUpvalue;
+  I: Integer;
+begin
+  Result := False;
+  if (not Assigned(AVM)) or (not Assigned(ATemplate)) or
+     (AEnvironmentIndex < 0) then
+    Exit;
+
+  Env := ATemplate.GetDirectEvalEnvironment(AEnvironmentIndex);
+  for I := 0 to High(Env.Bindings) do
+  begin
+    Binding := Env.Bindings[I];
+    if Binding.Name <> KEYWORD_THIS then
+      Continue;
+
+    case Binding.Kind of
+      debLocal:
+        AValue := AVM.GetLocal(Binding.Index);
+      debUpvalue:
+      begin
+        AValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+        if Assigned(AVM.FCurrentClosure) then
+        begin
+          Upvalue := AVM.FCurrentClosure.GetUpvalue(Binding.Index);
+          if Assigned(Upvalue) and Assigned(Upvalue.Cell) then
+            AValue := RegisterToValue(Upvalue.Cell.Value);
+        end;
+      end;
+      debGlobal:
+        Exit(False);
+    else
+      AValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+    end;
+    if AValue = TGocciaHoleValue.HoleValue then
+      Exit(False);
+    Exit(True);
+  end;
+end;
+
 function DirectEvalLexicalThisValue(const AVM: TGocciaVM;
-  const AUseGlobalVarEnvironment: Boolean): TGocciaValue;
+  const AUseGlobalVarEnvironment: Boolean;
+  const ATemplate: TGocciaFunctionTemplate;
+  const AEnvironmentIndex: Integer): TGocciaValue;
 var
   Candidate: TGocciaBytecodeClosure;
   I, Slot: Integer;
 begin
+  if DirectEvalCapturedThisValue(AVM, ATemplate, AEnvironmentIndex, Result) then
+    Exit;
+
   if Assigned(AVM) and Assigned(AVM.FCurrentClosure) and
      Assigned(AVM.FCurrentClosure.Template) and
      AVM.FCurrentClosure.Template.IsArrow then
@@ -790,40 +927,38 @@ end;
 
 function TGocciaVMDirectEvalScope.GetSuperClass: TGocciaValue;
 var
-  Closure: TGocciaBytecodeClosure;
   HomeClass: TGocciaClassValue;
 begin
   Result := nil;
-  Closure := DirectEvalLexicalClosure(FVM);
-  if not Assigned(Closure) then
-    Exit;
 
-  if Closure.HomeClass is TGocciaClassValue then
+  if FHomeClass is TGocciaClassValue then
   begin
-    HomeClass := TGocciaClassValue(Closure.HomeClass);
+    HomeClass := TGocciaClassValue(FHomeClass);
     if Assigned(HomeClass.SuperClass) then
       Exit(HomeClass.SuperClass);
     if Assigned(HomeClass.NativeSuperConstructor) then
       Exit(HomeClass.NativeSuperConstructor);
   end;
 
-  if Assigned(Closure.HomeObject) then
-    Result := Closure.HomeObject;
+  if Assigned(FHomeObject) then
+    Result := FHomeObject;
+end;
+
+function TGocciaVMDirectEvalScope.GetOwningClass: TGocciaValue;
+begin
+  Result := FHomeClass;
 end;
 
 function TGocciaVMDirectEvalScope.GetSuperConstructor: TGocciaValue;
 var
-  Closure: TGocciaBytecodeClosure;
   HomeClass: TGocciaClassValue;
   SuperConstructor: TGocciaValue;
 begin
   Result := nil;
-  Closure := DirectEvalLexicalClosure(FVM);
-  if not (Assigned(FVM) and Assigned(Closure) and
-     (Closure.HomeClass is TGocciaClassValue)) then
+  if not (Assigned(FVM) and (FHomeClass is TGocciaClassValue)) then
     Exit;
 
-  HomeClass := TGocciaClassValue(Closure.HomeClass);
+  HomeClass := TGocciaClassValue(FHomeClass);
   if Assigned(HomeClass.SuperClass) then
     SuperConstructor := HomeClass.SuperClass
   else if Assigned(HomeClass.NativeSuperConstructor) then
@@ -832,15 +967,12 @@ begin
     Exit;
 
   Result := TGocciaVMSuperConstructorValue.Create(SuperConstructor,
-    FVM.FCurrentNewTarget, HomeClass);
+    FNewTarget, HomeClass);
 end;
 
 function TGocciaVMDirectEvalScope.GetNewTarget: TGocciaValue;
 begin
-  if Assigned(FVM) then
-    Result := FVM.FCurrentNewTarget
-  else
-    Result := nil;
+  Result := FNewTarget;
 end;
 
 function TGocciaVMDirectEvalScope.GetThisValue: TGocciaValue;
@@ -862,7 +994,7 @@ end;
 
 function TGocciaVMDirectEvalScope.IsFunctionBoundary: Boolean;
 begin
-  Result := True;
+  Result := False;
 end;
 
 procedure TGocciaVMDirectEvalScope.AssignBinding(const AName: string;
@@ -878,6 +1010,12 @@ begin
       WithObject.AssignPropertyWithReceiver(AName, AValue, WithObject)
     else
       WithObject.AssignProperty(AName, AValue);
+    Exit;
+  end;
+
+  if ContainsOwnVarBinding(AName) then
+  begin
+    inherited AssignBinding(AName, AValue, ALine, AColumn, ANonStrictMode);
     Exit;
   end;
 
@@ -973,6 +1111,13 @@ begin
     Exit;
   end;
 
+  if ContainsOwnVarBinding(AName) then
+  begin
+    AObjectBinding := nil;
+    AScopeBinding := Self;
+    Exit;
+  end;
+
   if TryFindBinding(AName, Binding) then
   begin
     AObjectBinding := nil;
@@ -987,8 +1132,10 @@ var
   Binding: TGocciaDirectEvalBindingInfo;
   WithObject: TGocciaObjectValue;
 begin
-  Result := TryFindWithObjectBinding(AName, WithObject) or
-    TryFindBinding(AName, Binding) or inherited Contains(AName);
+  if TryFindWithObjectBinding(AName, WithObject) or inherited Contains(AName) then
+    Exit(True);
+  Result := TryFindBinding(AName, Binding) and
+    (Binding.Kind in [debLocal, debGlobal]);
 end;
 
 procedure TGocciaVMDirectEvalScope.CopyBackVariableBindings;
@@ -1007,7 +1154,7 @@ begin
     if Binding.IsConst or (Binding.Kind in [debGlobal, debWithLocal,
        debWithUpvalue]) then
       Continue;
-    if ContainsOwnVarBinding(Binding.Name) then
+    if ContainsOwnVarBinding(Binding.Name) and (Binding.Kind <> debUpvalue) then
     begin
       LexicalBinding := inherited GetBinding(Binding.Name);
       SetBindingValue(Binding, LexicalBinding.Value);
@@ -1967,12 +2114,29 @@ end;
 
 function TGocciaVMLiteralObjectValue.TrySetLiteralDataPropertyFast(
   const AName: string; const AValue: TGocciaValue): Boolean;
+var
+  Current: TGocciaObjectValue;
+  Descriptor: TGocciaPropertyDescriptor;
+  ChainDepth: Integer;
 begin
   if not FFastLiteralMode then
     Exit(False);
 
   if VMSetOwnWritableDataDescriptorValue(Self, AName, AValue) then
     Exit(True);
+
+  Current := FPrototype;
+  ChainDepth := 0;
+  while Assigned(Current) do
+  begin
+    Inc(ChainDepth);
+    if ChainDepth > FOR_IN_MAX_PROTOTYPE_CHAIN_DEPTH then
+      Exit(False);
+    Descriptor := Current.GetOwnPropertyDescriptor(AName);
+    if Assigned(Descriptor) then
+      Exit(False);
+    Current := Current.Prototype;
+  end;
 
   inherited DefineProperty(AName, TGocciaPropertyDescriptorData.Create(AValue,
     [pfEnumerable, pfConfigurable, pfWritable]));
@@ -2050,6 +2214,9 @@ begin
   Result := inherited CreateNativeInstance(AArguments);
   if Assigned(Result) or not Assigned(NativeSuperConstructor) then
     Exit;
+
+  if NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype then
+    Exit(nil);
 
   if (NativeSuperConstructor is TGocciaFunctionBase) and
      not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
@@ -2151,28 +2318,187 @@ threadvar
   GActiveBytecodeGenerator: TGocciaBytecodeGeneratorObjectValue;
 
 type
+  TGocciaVMAsyncIteratorRecordValue = class(TGocciaObjectValue)
+  private
+    FIteratorValue: TGocciaValue;
+    FNextMethod: TGocciaValue;
+    function Next(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ReturnValue(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ThrowValue(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AIteratorValue, ANextMethod: TGocciaValue);
+    procedure MarkReferences; override;
+  end;
+
   TGocciaVMAsyncFromSyncIteratorValue = class(TGocciaObjectValue)
   private
+    FVM: TGocciaVM;
     FIteratorValue: TGocciaValue;
     FNextMethod: TGocciaValue;
     function PromiseResolve(const AValue: TGocciaValue): TGocciaValue;
     function PromiseReject(const AValue: TGocciaValue): TGocciaValue;
     procedure ClearIteratorState;
     procedure CloseIteratorAfterRejectedValue;
+    function AsyncFromSyncIteratorContinuation(const AValue: TGocciaValue;
+      const ADone, ACloseOnRejection: Boolean): TGocciaValue;
     function AwaitIteratorValue(const AValue: TGocciaValue;
       const ADone, ACloseOnRejection: Boolean): TGocciaValue;
     function Next(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ReturnValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ThrowValue(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
-    constructor Create(const AIteratorValue, ANextMethod: TGocciaValue);
+    constructor Create(const AVM: TGocciaVM; const AIteratorValue,
+      ANextMethod: TGocciaValue);
     procedure MarkReferences; override;
   end;
 
-constructor TGocciaVMAsyncFromSyncIteratorValue.Create(
+  TGocciaVMAsyncFromSyncFulfillValue = class(TGocciaObjectValue)
+  private
+    FDone: Boolean;
+  public
+    constructor Create(const ADone: Boolean);
+    function Invoke(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+  TGocciaVMAsyncFromSyncRejectValue = class(TGocciaObjectValue)
+  private
+    FIterator: TGocciaVMAsyncFromSyncIteratorValue;
+  public
+    constructor Create(const AIterator: TGocciaVMAsyncFromSyncIteratorValue);
+    function Invoke(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    procedure MarkReferences; override;
+  end;
+
+constructor TGocciaVMAsyncIteratorRecordValue.Create(
   const AIteratorValue, ANextMethod: TGocciaValue);
 begin
   inherited Create;
+  FIteratorValue := AIteratorValue;
+  FNextMethod := ANextMethod;
+  AssignProperty(PROP_NEXT, TGocciaNativeFunctionValue.Create(Next, PROP_NEXT, 1));
+  AssignProperty(PROP_RETURN,
+    TGocciaNativeFunctionValue.Create(ReturnValue, PROP_RETURN, 1));
+  AssignProperty(PROP_THROW,
+    TGocciaNativeFunctionValue.Create(ThrowValue, PROP_THROW, 1));
+end;
+
+function TGocciaVMAsyncIteratorRecordValue.Next(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not Assigned(FNextMethod) or
+     (FNextMethod is TGocciaUndefinedLiteralValue) or
+     not FNextMethod.IsCallable then
+    ThrowTypeError(SErrorAsyncIteratorNextNotCallable,
+      SSuggestAsyncIteratorProtocol);
+  Result := TGocciaFunctionBase(FNextMethod).Call(AArgs, FIteratorValue);
+end;
+
+function TGocciaVMAsyncIteratorRecordValue.ReturnValue(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  ReturnMethod: TGocciaValue;
+  Value: TGocciaValue;
+begin
+  if Assigned(AArgs) and (AArgs.Length > 0) then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not Assigned(FIteratorValue) then
+    Exit(CreateIteratorResult(Value, True));
+
+  ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);
+  if not Assigned(ReturnMethod) or
+     (ReturnMethod is TGocciaUndefinedLiteralValue) or
+     (ReturnMethod is TGocciaNullLiteralValue) then
+    Exit(CreateIteratorResult(Value, True));
+  if not ReturnMethod.IsCallable then
+    ThrowTypeError('Iterator return is not callable');
+
+  CallArgs := TGocciaArgumentsCollection.Create([Value]);
+  try
+    Result := TGocciaFunctionBase(ReturnMethod).Call(CallArgs, FIteratorValue);
+  finally
+    CallArgs.Free;
+  end;
+end;
+
+function TGocciaVMAsyncIteratorRecordValue.ThrowValue(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  ReturnResult: TGocciaValue;
+  ReturnMethod: TGocciaValue;
+  ThrowMethod: TGocciaValue;
+  Value: TGocciaValue;
+begin
+  if Assigned(AArgs) and (AArgs.Length > 0) then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not Assigned(FIteratorValue) then
+    raise TGocciaThrowValue.Create(Value);
+
+  ThrowMethod := FIteratorValue.GetProperty(PROP_THROW);
+  if Assigned(ThrowMethod) and
+     not (ThrowMethod is TGocciaUndefinedLiteralValue) and
+     not (ThrowMethod is TGocciaNullLiteralValue) then
+  begin
+    if not ThrowMethod.IsCallable then
+      ThrowTypeError('Iterator throw is not callable');
+    CallArgs := TGocciaArgumentsCollection.Create([Value]);
+    try
+      Exit(TGocciaFunctionBase(ThrowMethod).Call(CallArgs, FIteratorValue));
+    finally
+      CallArgs.Free;
+    end;
+  end;
+
+  ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);
+  if Assigned(ReturnMethod) and
+     not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+     not (ReturnMethod is TGocciaNullLiteralValue) then
+  begin
+    if not ReturnMethod.IsCallable then
+      ThrowTypeError('Iterator return is not callable');
+    CallArgs := TGocciaArgumentsCollection.Create;
+    try
+      ReturnResult := AwaitValue(TGocciaFunctionBase(ReturnMethod).Call(
+        CallArgs, FIteratorValue));
+    finally
+      CallArgs.Free;
+    end;
+    if not (ReturnResult is TGocciaObjectValue) then
+      ThrowTypeError('Iterator return result is not an object');
+  end;
+
+  ThrowTypeError('Iterator throw is not callable');
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+procedure TGocciaVMAsyncIteratorRecordValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FIteratorValue) then
+    FIteratorValue.MarkReferences;
+  if Assigned(FNextMethod) then
+    FNextMethod.MarkReferences;
+end;
+
+constructor TGocciaVMAsyncFromSyncIteratorValue.Create(const AVM: TGocciaVM;
+  const AIteratorValue, ANextMethod: TGocciaValue);
+begin
+  inherited Create;
+  FVM := AVM;
   FIteratorValue := AIteratorValue;
   FNextMethod := ANextMethod;
   AssignProperty(PROP_NEXT, TGocciaNativeFunctionValue.Create(Next, PROP_NEXT, 1));
@@ -2219,6 +2545,35 @@ begin
   ClearIteratorState;
 end;
 
+function TGocciaVMAsyncFromSyncIteratorValue.AsyncFromSyncIteratorContinuation(
+  const AValue: TGocciaValue; const ADone,
+  ACloseOnRejection: Boolean): TGocciaValue;
+var
+  FulfillHandler: TGocciaVMAsyncFromSyncFulfillValue;
+  FulfillFunction: TGocciaNativeFunctionValue;
+  RejectHandler: TGocciaVMAsyncFromSyncRejectValue;
+  RejectFunction: TGocciaNativeFunctionValue;
+  ValueWrapper: TGocciaPromiseValue;
+begin
+  ValueWrapper := TGocciaPromiseValue(PromiseResolve(AValue));
+
+  FulfillHandler := TGocciaVMAsyncFromSyncFulfillValue.Create(ADone);
+  FulfillFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    FulfillHandler.Invoke, 'async-from-sync-fulfill', 1);
+  FulfillFunction.CapturedRoot := FulfillHandler;
+
+  RejectFunction := nil;
+  if ACloseOnRejection and not ADone then
+  begin
+    RejectHandler := TGocciaVMAsyncFromSyncRejectValue.Create(Self);
+    RejectFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      RejectHandler.Invoke, 'async-from-sync-reject', 1);
+    RejectFunction.CapturedRoot := RejectHandler;
+  end;
+
+  Result := ValueWrapper.InvokeThen(FulfillFunction, RejectFunction);
+end;
+
 function TGocciaVMAsyncFromSyncIteratorValue.AwaitIteratorValue(
   const AValue: TGocciaValue; const ADone, ACloseOnRejection: Boolean): TGocciaValue;
 begin
@@ -2231,30 +2586,62 @@ begin
   end;
 end;
 
+constructor TGocciaVMAsyncFromSyncFulfillValue.Create(const ADone: Boolean);
+begin
+  inherited Create;
+  FDone := ADone;
+end;
+
+function TGocciaVMAsyncFromSyncFulfillValue.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Value: TGocciaValue;
+begin
+  if Assigned(AArgs) and (AArgs.Length > 0) then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Result := CreateIteratorResult(Value, FDone);
+end;
+
+constructor TGocciaVMAsyncFromSyncRejectValue.Create(
+  const AIterator: TGocciaVMAsyncFromSyncIteratorValue);
+begin
+  inherited Create;
+  FIterator := AIterator;
+end;
+
+function TGocciaVMAsyncFromSyncRejectValue.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Reason: TGocciaValue;
+begin
+  if Assigned(FIterator) then
+    FIterator.CloseIteratorAfterRejectedValue;
+  if Assigned(AArgs) and (AArgs.Length > 0) then
+    Reason := AArgs.GetElement(0)
+  else
+    Reason := TGocciaUndefinedLiteralValue.UndefinedValue;
+  raise TGocciaThrowValue.Create(Reason);
+end;
+
+procedure TGocciaVMAsyncFromSyncRejectValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FIterator) then
+    FIterator.MarkReferences;
+end;
+
 function TGocciaVMAsyncFromSyncIteratorValue.PromiseResolve(
   const AValue: TGocciaValue): TGocciaValue;
-var
-  IsRooted: Boolean;
-  Promise: TGocciaPromiseValue;
 begin
-  Promise := TGocciaPromiseValue.Create;
-  IsRooted := Assigned(TGarbageCollector.Instance);
-  if IsRooted then
-    TGarbageCollector.Instance.AddTempRoot(Promise);
-  try
-    Promise.Resolve(AValue);
-  except
-    if IsRooted then
-    begin
-      TGarbageCollector.Instance.RemoveTempRoot(Promise);
-      IsRooted := False;
-    end;
-    Promise.Free;
-    raise;
-  end;
-  if IsRooted then
-    TGarbageCollector.Instance.RemoveTempRoot(Promise);
-  Result := Promise;
+  if Assigned(FVM) then
+    Result := FVM.PromiseResolveIntrinsic(AValue)
+  else
+    Result := AValue;
 end;
 
 function TGocciaVMAsyncFromSyncIteratorValue.PromiseReject(
@@ -2290,7 +2677,6 @@ var
   Done: Boolean;
   DoneValue: TGocciaValue;
   IteratorResult: TGocciaValue;
-  UnwrappedValue: TGocciaValue;
   Value: TGocciaValue;
 begin
   try
@@ -2307,9 +2693,7 @@ begin
         Value := TGocciaIteratorValue(FIteratorValue).DirectNext(Done);
       if Done then
         ClearIteratorState;
-      UnwrappedValue := AwaitIteratorValue(Value, Done, True);
-      IteratorResult := CreateIteratorResult(UnwrappedValue, Done);
-      Exit(PromiseResolve(IteratorResult));
+      Exit(AsyncFromSyncIteratorContinuation(Value, Done, True));
     end;
 
     if AArgs.Length > 0 then
@@ -2333,8 +2717,7 @@ begin
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
     if Done then
       ClearIteratorState;
-    UnwrappedValue := AwaitIteratorValue(Value, Done, True);
-    Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
+    Result := AsyncFromSyncIteratorContinuation(Value, Done, True);
   except
     on E: EGocciaBytecodeThrow do
       Result := PromiseReject(E.ThrownValue);
@@ -2361,7 +2744,6 @@ var
   DoneValue: TGocciaValue;
   IteratorResult: TGocciaValue;
   ReturnMethod: TGocciaValue;
-  UnwrappedValue: TGocciaValue;
   Value: TGocciaValue;
 begin
   if Assigned(AArgs) and (AArgs.Length > 0) then
@@ -2370,10 +2752,7 @@ begin
     Value := TGocciaUndefinedLiteralValue.UndefinedValue;
   try
     if not Assigned(FIteratorValue) then
-    begin
-      UnwrappedValue := AwaitIteratorValue(Value, True, False);
-      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, True)));
-    end;
+      Exit(AsyncFromSyncIteratorContinuation(Value, True, False));
 
     if FIteratorValue is TGocciaIteratorValue then
     begin
@@ -2385,8 +2764,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Done then
         ClearIteratorState;
-      UnwrappedValue := AwaitIteratorValue(Value, Done, False);
-      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
+      Exit(AsyncFromSyncIteratorContinuation(Value, Done, False));
     end;
 
     ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);
@@ -2395,8 +2773,7 @@ begin
        (ReturnMethod is TGocciaNullLiteralValue) then
     begin
       ClearIteratorState;
-      UnwrappedValue := AwaitIteratorValue(Value, True, False);
-      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, True)));
+      Exit(AsyncFromSyncIteratorContinuation(Value, True, False));
     end;
     if not ReturnMethod.IsCallable then
       ThrowTypeError('Iterator return is not callable');
@@ -2416,8 +2793,7 @@ begin
       Value := TGocciaUndefinedLiteralValue.UndefinedValue;
     if Done then
       ClearIteratorState;
-    UnwrappedValue := AwaitIteratorValue(Value, Done, False);
-    Result := PromiseResolve(CreateIteratorResult(UnwrappedValue, Done));
+    Result := AsyncFromSyncIteratorContinuation(Value, Done, False);
   except
     on E: EGocciaBytecodeThrow do
       Result := PromiseReject(E.ThrownValue);
@@ -2445,7 +2821,6 @@ var
   IteratorResult: TGocciaValue;
   ReturnMethod: TGocciaValue;
   ThrowMethod: TGocciaValue;
-  UnwrappedValue: TGocciaValue;
   Value: TGocciaValue;
 begin
   if Assigned(AArgs) and (AArgs.Length > 0) then
@@ -2466,8 +2841,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Done then
         ClearIteratorState;
-      UnwrappedValue := AwaitIteratorValue(Value, Done, True);
-      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
+      Exit(AsyncFromSyncIteratorContinuation(Value, Done, True));
     end;
 
     ThrowMethod := FIteratorValue.GetProperty(PROP_THROW);
@@ -2492,8 +2866,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Done then
         ClearIteratorState;
-      UnwrappedValue := AwaitIteratorValue(Value, Done, True);
-      Exit(PromiseResolve(CreateIteratorResult(UnwrappedValue, Done)));
+      Exit(AsyncFromSyncIteratorContinuation(Value, Done, True));
     end;
 
     ReturnMethod := FIteratorValue.GetProperty(PROP_RETURN);
@@ -2778,6 +3151,7 @@ var
   ReturnMethod: TGocciaValue;
   YieldedValue: TGocciaValue;
   HadDelegateContinuation: Boolean;
+  NextArgument: TGocciaValue;
 
   procedure ClearDelegateAndThrowTypeError(const AMessage: string);
   begin
@@ -2965,22 +3339,20 @@ begin
 
     while True do
     begin
+      if HadDelegateContinuation and (FResumeKind = bgrkNext) then
+        NextArgument := RegisterToValue(FResumeValue)
+      else
+        NextArgument := TGocciaUndefinedLiteralValue.UndefinedValue;
+
       if Assigned(FDelegateIterator) then
       begin
-        if HadDelegateContinuation and (FResumeKind = bgrkNext) then
-          YieldedValue := FDelegateIterator.DirectNextValue(
-            RegisterToValue(FResumeValue), Done)
-        else
-          YieldedValue := FDelegateIterator.DirectNext(Done);
+        YieldedValue := FDelegateIterator.DirectNextValue(NextArgument, Done);
       end
       else
       begin
         if not Assigned(FDelegateNextMethod) or not FDelegateNextMethod.IsCallable then
           ClearDelegateAndThrowTypeError('Iterator.next is not a function');
-        if HadDelegateContinuation and (FResumeKind = bgrkNext) then
-          CallArgs := TGocciaArgumentsCollection.Create([RegisterToValue(FResumeValue)])
-        else
-          CallArgs := TGocciaArgumentsCollection.Create;
+        CallArgs := TGocciaArgumentsCollection.Create([NextArgument]);
         try
           NextResult := CallDelegateMethod(FDelegateNextMethod,
             FDelegateIteratorValue, CallArgs);
@@ -4143,6 +4515,8 @@ var
   SuperResult: TGocciaValue;
   ConstructorThisValue: TGocciaValue;
   ImplicitSuperInitialized: Boolean;
+  WasSuperAlreadyCalled: Boolean;
+  ReceiverPrototype: TGocciaObjectValue;
   function IsUndefinedConstructedValue(const AValue: TGocciaValue): Boolean;
   begin
     Result := (not Assigned(AValue)) or (AValue is TGocciaUndefinedLiteralValue);
@@ -4156,15 +4530,18 @@ var
         'Derived constructor returned non-object',
         SSuggestNotConstructorType);
   end;
-  procedure InitializeCurrentCtorReplacement(const AReplacement: TGocciaValue);
+  procedure InitializeCurrentCtorReceiver(const AReceiver: TGocciaValue);
   begin
-    if (AReplacement is TGocciaObjectValue) and
-       (AReplacement <> AThisValue) and
+    if (AReceiver is TGocciaObjectValue) and
        (FCurrentCtorClass is TGocciaVMClassValue) then
     begin
+      if HasBytecodePrivateInitializersApplied(AReceiver,
+        TGocciaClassValue(FCurrentCtorClass)) then
+        ThrowTypeError('Cannot initialize private elements twice',
+          SSuggestPrivateFieldAccess);
       TGocciaVMClassValue(FCurrentCtorClass).FVM.RunClassInitializers(
-        FCurrentCtorClass, AReplacement, False);
-      StampBytecodePrivateInitializersApplied(AReplacement,
+        FCurrentCtorClass, AReceiver, False);
+      StampBytecodePrivateInitializersApplied(AReceiver,
         FCurrentCtorClass);
     end;
   end;
@@ -4173,16 +4550,25 @@ var
     if FCurrentCtorClass is TGocciaVMClassValue then
       TGocciaVMClassValue(FCurrentCtorClass).FVM.FCurrentConstructorSuperCalled :=
         True;
+    if WasSuperAlreadyCalled then
+      ThrowReferenceError(
+        'Super constructor may only be called once');
   end;
 begin
+  WasSuperAlreadyCalled := (FCurrentCtorClass is TGocciaVMClassValue) and
+    TGocciaVMClassValue(FCurrentCtorClass).FVM.FCurrentConstructorSuperCalled;
+
   if (FSuperClass is TGocciaObjectValue) and
      (not (FSuperClass is TGocciaClassValue)) and
      FSuperClass.IsConstructable then
   begin
     SuperResult := InvokeConstructableWithReceiver(FSuperClass, AArguments,
       AThisValue, FNewTarget);
-    InitializeCurrentCtorReplacement(SuperResult);
     MarkCurrentConstructorSuperCalled;
+    if SuperResult is TGocciaObjectValue then
+      InitializeCurrentCtorReceiver(SuperResult)
+    else
+      InitializeCurrentCtorReceiver(AThisValue);
     Exit(SuperResult);
   end;
 
@@ -4208,8 +4594,8 @@ begin
            not HasBytecodePrivateInitializersApplied(SuperResult, SuperClass) then
           TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
             SuperClass, SuperResult);
-        InitializeCurrentCtorReplacement(SuperResult);
         MarkCurrentConstructorSuperCalled;
+        InitializeCurrentCtorReceiver(SuperResult);
         Exit(SuperResult);
       end;
     ValidateSuperConstructorResult(SuperResult);
@@ -4225,12 +4611,13 @@ begin
            not HasBytecodePrivateInitializersApplied(ConstructorThisValue, SuperClass) then
           TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
             SuperClass, ConstructorThisValue);
-        InitializeCurrentCtorReplacement(ConstructorThisValue);
         MarkCurrentConstructorSuperCalled;
+        InitializeCurrentCtorReceiver(ConstructorThisValue);
         Exit(ConstructorThisValue);
       end;
     end;
     MarkCurrentConstructorSuperCalled;
+    InitializeCurrentCtorReceiver(AThisValue);
     Exit(AThisValue);
   end;
 
@@ -4248,8 +4635,8 @@ begin
            not HasBytecodePrivateInitializersApplied(SuperResult, SuperClass) then
           TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
             SuperClass, SuperResult);
-        InitializeCurrentCtorReplacement(SuperResult);
         MarkCurrentConstructorSuperCalled;
+        InitializeCurrentCtorReceiver(SuperResult);
         Exit(SuperResult);
       end;
     ValidateSuperConstructorResult(SuperResult);
@@ -4260,12 +4647,32 @@ begin
            not HasBytecodePrivateInitializersApplied(ConstructorThisValue, SuperClass) then
           TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
             SuperClass, ConstructorThisValue);
-        InitializeCurrentCtorReplacement(ConstructorThisValue);
         MarkCurrentConstructorSuperCalled;
+        InitializeCurrentCtorReceiver(ConstructorThisValue);
         Exit(ConstructorThisValue);
       end;
     MarkCurrentConstructorSuperCalled;
+    InitializeCurrentCtorReceiver(AThisValue);
     Exit(AThisValue);
+  end;
+
+  if Assigned(SuperClass.NativeInstanceDefaultPrototype) then
+  begin
+    NewThis := SuperClass.CreateNativeInstance(AArguments);
+    if not (NewThis is TGocciaObjectValue) then
+      ThrowTypeError(
+        'Superclass constructor did not return an object',
+        SSuggestNotConstructorType);
+    ReceiverPrototype := GetProtoFromConstructor(FNewTarget);
+    TGocciaObjectValue(NewThis).Prototype := ReceiverPrototype;
+    if NewThis is TGocciaInstanceValue then
+    begin
+      TGocciaInstanceValue(NewThis).ClassValue := FCurrentCtorClass;
+      TGocciaInstanceValue(NewThis).InitializeNativeFromArguments(AArguments);
+    end;
+    MarkCurrentConstructorSuperCalled;
+    InitializeCurrentCtorReceiver(NewThis);
+    Exit(NewThis);
   end;
 
   if Assigned(SuperClass.SuperClass) and
@@ -4295,11 +4702,12 @@ begin
       TGocciaInstanceValue(NewThis).InitializeNativeFromArguments(AArguments);
     if NewThis is TGocciaObjectValue then
     begin
-      InitializeCurrentCtorReplacement(NewThis);
       MarkCurrentConstructorSuperCalled;
+      InitializeCurrentCtorReceiver(NewThis);
       Exit(NewThis);
     end;
     MarkCurrentConstructorSuperCalled;
+    InitializeCurrentCtorReceiver(AThisValue);
     Exit(AThisValue);
   end;
 
@@ -4491,13 +4899,16 @@ begin
     InstancePrototype := Prototype;
 
   NativeInstance := nil;
-  WalkClass := Self;
-  while Assigned(WalkClass) do
+  if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
   begin
-    NativeInstance := WalkClass.CreateNativeInstance(AArguments);
-    if Assigned(NativeInstance) then
-      Break;
-    WalkClass := WalkClass.SuperClass;
+    WalkClass := Self;
+    while Assigned(WalkClass) do
+    begin
+      NativeInstance := WalkClass.CreateNativeInstance(AArguments);
+      if Assigned(NativeInstance) then
+        Break;
+      WalkClass := WalkClass.SuperClass;
+    end;
   end;
 
   // ES2026 §10.2.2 step 6: Set proto on the instance before constructor runs
@@ -4520,7 +4931,8 @@ begin
     InitializerReplayReceiver := nil;
     TGarbageCollector.Instance.AddTempRoot(RootedInstance);
     try
-      FVM.RunClassInitializers(Self, Instance);
+      if not HasDerivedConstructorReturnRestriction then
+        FVM.RunClassInitializers(Self, Instance);
       FVM.FPendingNewTarget := ANewTarget;
       if not Assigned(FVM.FPendingNewTarget) then
         FVM.FPendingNewTarget := Self;
@@ -4540,9 +4952,14 @@ begin
       ApplyOwnConstructorResult(ConstructedValue, ConstructorThisValue);
       RequireDerivedConstructorThisInitialized(ConstructedValue);
       if Assigned(InitializerReplayReceiver) and
-         (Instance = InitializerReplayReceiver) and
-         not HasBytecodePrivateInitializersApplied(Instance, Self) then
-        FVM.RunClassInitializers(Self, Instance, True);
+         (Instance = InitializerReplayReceiver) then
+      begin
+        if not HasBytecodePrivateInitializersApplied(Instance, Self) then
+        begin
+          FVM.RunClassInitializers(Self, Instance, False);
+          StampBytecodePrivateInitializersApplied(Instance, Self);
+        end;
+      end;
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
     end;
@@ -4617,12 +5034,24 @@ begin
 
       if not Assigned(InitializerReplayReceiver) or
          (Instance <> InitializerReplayReceiver) then
-        FVM.RunClassInitializers(Self, Instance);
+        if not HasDerivedConstructorReturnRestriction then
+          FVM.RunClassInitializers(Self, Instance);
 
       if Assigned(InitializerReplayReceiver) and
-         (Instance = InitializerReplayReceiver) and
-         not HasBytecodePrivateInitializersApplied(Instance, Self) then
-        FVM.RunClassInitializers(Self, Instance, True);
+         (Instance = InitializerReplayReceiver) then
+      begin
+        if HasBytecodePrivateInitializersApplied(Instance, Self) then
+        begin
+          if not Assigned(FConstructorValue) then
+            ThrowTypeError('Cannot initialize private elements twice',
+              SSuggestPrivateFieldAccess);
+        end
+        else
+        begin
+          FVM.RunClassInitializers(Self, Instance, False);
+          StampBytecodePrivateInitializersApplied(Instance, Self);
+        end;
+      end;
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
     end;
@@ -4802,22 +5231,25 @@ begin
   BoxedArgs := nil;
   try
     NativeInstance := nil;
-    WalkClass := Self;
-    while Assigned(WalkClass) do
+    if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
     begin
-      if not (WalkClass is TGocciaVMClassValue) then
+      WalkClass := Self;
+      while Assigned(WalkClass) do
       begin
-        EnsureBoxedArgs;
-        NativeInstance := WalkClass.CreateNativeInstance(BoxedArgs);
-      end
-      else if Assigned(TGocciaVMClassValue(WalkClass).NativeSuperConstructor) then
-      begin
-        EnsureBoxedArgs;
-        NativeInstance := WalkClass.CreateNativeInstance(BoxedArgs);
+        if not (WalkClass is TGocciaVMClassValue) then
+        begin
+          EnsureBoxedArgs;
+          NativeInstance := WalkClass.CreateNativeInstance(BoxedArgs);
+        end
+        else if Assigned(TGocciaVMClassValue(WalkClass).NativeSuperConstructor) then
+        begin
+          EnsureBoxedArgs;
+          NativeInstance := WalkClass.CreateNativeInstance(BoxedArgs);
+        end;
+        if Assigned(NativeInstance) then
+          Break;
+        WalkClass := WalkClass.SuperClass;
       end;
-      if Assigned(NativeInstance) then
-        Break;
-      WalkClass := WalkClass.SuperClass;
     end;
 
     if Assigned(NativeInstance) then
@@ -4839,7 +5271,8 @@ begin
     try
       if Assigned(FConstructorValue) then
       begin
-        FVM.RunClassInitializers(Self, Instance);
+        if not HasDerivedConstructorReturnRestriction then
+          FVM.RunClassInitializers(Self, Instance);
         FVM.FPendingNewTarget := Self;
         PreviousConstructorSuperCalled := FVM.FCurrentConstructorSuperCalled;
         FVM.FCurrentConstructorSuperCalled := False;
@@ -4992,9 +5425,20 @@ begin
           FVM.RunClassInitializers(Self, Instance);
       end;
       if Assigned(InitializerReplayReceiver) and
-         (Instance = InitializerReplayReceiver) and
-         not HasBytecodePrivateInitializersApplied(Instance, Self) then
-        FVM.RunClassInitializers(Self, Instance, True);
+         (Instance = InitializerReplayReceiver) then
+      begin
+        if HasBytecodePrivateInitializersApplied(Instance, Self) then
+        begin
+          if not Assigned(FConstructorValue) then
+            ThrowTypeError('Cannot initialize private elements twice',
+              SSuggestPrivateFieldAccess);
+        end
+        else
+        begin
+          FVM.RunClassInitializers(Self, Instance, False);
+          StampBytecodePrivateInitializersApplied(Instance, Self);
+        end;
+      end;
     finally
       TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
     end;
@@ -5482,6 +5926,40 @@ begin
     Closure.HomeClass := EffectiveHomeClass;
 end;
 
+procedure DeclareBytecodePrivateNameForClass(const AClassValue: TGocciaValue;
+  const AName: string);
+var
+  SourceName: string;
+begin
+  if not (AClassValue is TGocciaClassValue) then
+    Exit;
+  SourceName := BytecodePrivateSourceName(AName);
+  if SourceName <> '' then
+    TGocciaClassValue(AClassValue).DeclarePrivateName(SourceName, AName);
+end;
+
+procedure DeclareBytecodePrivateNamesFromTemplate(
+  const AClassValue: TGocciaValue; const ATemplate: TGocciaFunctionTemplate);
+var
+  ConstantValue: TGocciaBytecodeConstant;
+  I: Integer;
+begin
+  if not (Assigned(ATemplate) and (AClassValue is TGocciaClassValue)) then
+    Exit;
+
+  for I := 0 to ATemplate.ConstantCount - 1 do
+  begin
+    ConstantValue := ATemplate.GetConstantUnchecked(I);
+    if (ConstantValue.Kind = bckString) and
+       IsBytecodePrivateKey(ConstantValue.StringValue) then
+      DeclareBytecodePrivateNameForClass(AClassValue, ConstantValue.StringValue);
+  end;
+
+  for I := 0 to ATemplate.FunctionCount - 1 do
+    DeclareBytecodePrivateNamesFromTemplate(
+      AClassValue, ATemplate.GetFunctionUnchecked(I));
+end;
+
 function TGocciaVM.GetLocal(const AIndex: Integer): TGocciaValue;
 begin
   if (AIndex >= 0) and (AIndex < FLocalCellCount) and Assigned(FLocalCells[AIndex]) then
@@ -5641,6 +6119,44 @@ begin
   Result := (AKeyReg.Kind = grkObject) and (AKeyReg.ObjectValue is TGocciaObjectValue);
   if Result then
     AResolved := ToPropertyKey(AKeyReg.ObjectValue);
+end;
+
+procedure TGocciaVM.SetFunctionNameFromKey(const AFunction, AKey: TGocciaValue;
+  const APrefixKind: UInt8);
+var
+  Name: string;
+  Prefix: string;
+  Symbol: TGocciaSymbolValue;
+begin
+  if not (AFunction is TGocciaObjectValue) then
+    Exit;
+
+  if AKey is TGocciaSymbolValue then
+  begin
+    Symbol := TGocciaSymbolValue(AKey);
+    if Symbol.HasDescription then
+      Name := '[' + Symbol.Description + ']'
+    else
+      Name := '';
+  end
+  else
+    Name := KeyToPropertyName(AKey);
+
+  case APrefixKind of
+    FUNCTION_NAME_PREFIX_GET:
+      Prefix := 'get';
+    FUNCTION_NAME_PREFIX_SET:
+      Prefix := 'set';
+  else
+    Prefix := '';
+  end;
+
+  if Prefix <> '' then
+    Name := Prefix + ' ' + Name;
+
+  TGocciaObjectValue(AFunction).DefineProperty(PROP_NAME,
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaStringLiteralValue.Create(Name), [pfConfigurable]));
 end;
 
 function TGocciaVM.KeyDisplaySafe(const AKey: TGocciaRegister): string;
@@ -5855,11 +6371,11 @@ begin
           end;
         until DoneFlag;
       except
-        // §7.4.10 step 5 abrupt-completion path: DirectNext (and any
-        // user code it calls) can throw.  Close the iterator, swallow
-        // any error from iter.return(), and re-raise the original.
+        // If IteratorStep/IteratorNext itself throws, array destructuring
+        // propagates that abrupt completion without calling return().
+        // IteratorClose is only for abrupt completions after a step has
+        // successfully produced a non-done value.
         AcquireExceptionObject;
-        CloseIteratorPreservingError(TGocciaIteratorValue(IteratorValue));
         raise;
       end;
       Exit;
@@ -5935,13 +6451,11 @@ begin
           end;
         until DoneFlag;
       except
-        // §7.4.10 step 5 abrupt-completion path covering the
-        // SErrorIteratorNextMustBeCallable throw above, the
-        // SErrorIteratorResultNotObject throw, AwaitValue rejections,
-        // and any error raised by user-supplied next().  iter.return()
-        // is best-effort and must not replace the original error.
+        // If IteratorStep/IteratorNext itself throws, array destructuring
+        // propagates that abrupt completion without calling return().
+        // IteratorClose is only for abrupt completions after a step has
+        // successfully produced a non-done value.
         AcquireExceptionObject;
-        CloseRawIteratorPreservingError(IteratorValue);
         raise;
       end;
       Exit;
@@ -6033,12 +6547,8 @@ begin
             AArray.Elements.Add(NextResult);
         until DoneFlag;
       except
-        // §7.4.10 step 5 abrupt-completion path: DirectNext can throw
-        // (user next() / wrapped iterator may execute arbitrary code).
-        // Close the iterator while preserving the original error per
-        // ES2024 IteratorClose semantics.
+        // If IteratorStep/IteratorNext itself throws, do not call return().
         AcquireExceptionObject;
-        CloseIteratorPreservingError(TGocciaIteratorValue(IteratorValue));
         raise;
       end;
       Exit(True);
@@ -6074,11 +6584,8 @@ begin
         end;
       until DoneFlag;
     except
-      // §7.4.10 step 5 abrupt-completion path: covers user next()
-      // throws and our SErrorIteratorResultNotObject TypeError.  Call
-      // iter.return() best-effort and surface the original exception.
+      // If IteratorStep/IteratorNext itself throws, do not call return().
       AcquireExceptionObject;
-      CloseRawIteratorPreservingError(IteratorValue);
       raise;
     end;
     Result := True;
@@ -6294,6 +6801,48 @@ begin
   Result := Assigned(Descriptor) and Descriptor.Enumerable;
 end;
 
+function TGocciaVM.PromiseConstructorIntrinsic: TGocciaValue;
+begin
+  Result := nil;
+  if Assigned(FGlobalScope) and FGlobalScope.Contains(CONSTRUCTOR_PROMISE) then
+    Result := FGlobalScope.GetValue(CONSTRUCTOR_PROMISE);
+  if not Assigned(Result) then
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaVM.PromiseResolveIntrinsic(
+  const AValue: TGocciaValue): TGocciaPromiseValue;
+var
+  ConstructorValue, ValueConstructor: TGocciaValue;
+  IsRooted: Boolean;
+begin
+  ConstructorValue := PromiseConstructorIntrinsic;
+  if AValue is TGocciaPromiseValue then
+  begin
+    ValueConstructor := TGocciaPromiseValue(AValue).GetProperty(PROP_CONSTRUCTOR);
+    if IsSameValue(ValueConstructor, ConstructorValue) then
+      Exit(TGocciaPromiseValue(AValue));
+  end;
+
+  Result := TGocciaPromiseValue.Create;
+  IsRooted := Assigned(TGarbageCollector.Instance);
+  if IsRooted then
+    TGarbageCollector.Instance.AddTempRoot(Result);
+  try
+    Result.Resolve(AValue);
+  except
+    if IsRooted then
+    begin
+      TGarbageCollector.Instance.RemoveTempRoot(Result);
+      IsRooted := False;
+    end;
+    Result.Free;
+    raise;
+  end;
+  if IsRooted then
+    TGarbageCollector.Instance.RemoveTempRoot(Result);
+end;
+
 function TGocciaVM.GetIteratorValue(const AIterable: TGocciaValue;
   const ATryAsync: Boolean): TGocciaValue;
 var
@@ -6337,6 +6886,7 @@ begin
       // that exists, downstream consumers (for-await-of dispatch)
       // re-resolve PROP_NEXT per iteration.  The §7.4.2 validation
       // above still ensures `next` is callable at acquisition time.
+      Result := TGocciaVMAsyncIteratorRecordValue.Create(Result, NextMethod);
       Exit;
     end
     else if Assigned(IteratorMethod) and
@@ -6379,7 +6929,7 @@ begin
       if IteratorObject is TGocciaIteratorValue then
       begin
         if ATryAsync then
-          Exit(TGocciaVMAsyncFromSyncIteratorValue.Create(IteratorObject,
+          Exit(TGocciaVMAsyncFromSyncIteratorValue.Create(Self, IteratorObject,
             IteratorObject.GetProperty(PROP_NEXT)));
         Exit(IteratorObject);
       end;
@@ -6392,7 +6942,7 @@ begin
            NextMethod.IsCallable then
         begin
           if ATryAsync then
-            Exit(TGocciaVMAsyncFromSyncIteratorValue.Create(IteratorObject,
+            Exit(TGocciaVMAsyncFromSyncIteratorValue.Create(Self, IteratorObject,
               NextMethod));
           // Wrap the raw iterator object in a TGocciaGenericIteratorValue
           // so callers (OP_ITER_NEXT, IterableToArray, etc.) get a
@@ -6676,11 +7226,18 @@ var
   TargetObject: TGocciaObjectValue;
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingSetter: TGocciaValue;
+  DescriptorFlags: TPropertyFlags;
 begin
   if ATarget is TGocciaVMClassValue then
-    TargetObject := TGocciaVMClassValue(ATarget).Prototype
+  begin
+    TargetObject := TGocciaVMClassValue(ATarget).Prototype;
+    DescriptorFlags := [pfConfigurable];
+  end
   else if ATarget is TGocciaObjectValue then
-    TargetObject := TGocciaObjectValue(ATarget)
+  begin
+    TargetObject := TGocciaObjectValue(ATarget);
+    DescriptorFlags := [pfEnumerable, pfConfigurable, pfWritable];
+  end
   else
     Exit;
 
@@ -6691,7 +7248,7 @@ begin
      Assigned(TGocciaPropertyDescriptorAccessor(ExistingDescriptor).Setter) then
     ExistingSetter := TGocciaPropertyDescriptorAccessor(ExistingDescriptor).Setter;
   TargetObject.DefineProperty(AName, TGocciaPropertyDescriptorAccessor.Create(
-    AGetter, ExistingSetter, [pfEnumerable, pfConfigurable, pfWritable]));
+    AGetter, ExistingSetter, DescriptorFlags));
 end;
 
 procedure TGocciaVM.DefineSetterProperty(const ATarget: TGocciaValue;
@@ -6700,11 +7257,18 @@ var
   TargetObject: TGocciaObjectValue;
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingGetter: TGocciaValue;
+  DescriptorFlags: TPropertyFlags;
 begin
   if ATarget is TGocciaVMClassValue then
-    TargetObject := TGocciaVMClassValue(ATarget).Prototype
+  begin
+    TargetObject := TGocciaVMClassValue(ATarget).Prototype;
+    DescriptorFlags := [pfConfigurable];
+  end
   else if ATarget is TGocciaObjectValue then
-    TargetObject := TGocciaObjectValue(ATarget)
+  begin
+    TargetObject := TGocciaObjectValue(ATarget);
+    DescriptorFlags := [pfEnumerable, pfConfigurable, pfWritable];
+  end
   else
     Exit;
 
@@ -6715,7 +7279,7 @@ begin
      Assigned(TGocciaPropertyDescriptorAccessor(ExistingDescriptor).Getter) then
     ExistingGetter := TGocciaPropertyDescriptorAccessor(ExistingDescriptor).Getter;
   TargetObject.DefineProperty(AName, TGocciaPropertyDescriptorAccessor.Create(
-    ExistingGetter, ASetter, [pfEnumerable, pfConfigurable, pfWritable]));
+    ExistingGetter, ASetter, DescriptorFlags));
 end;
 
 procedure TGocciaVM.DefineStaticGetterProperty(const ATarget: TGocciaValue;
@@ -6765,12 +7329,14 @@ procedure TGocciaVM.DefineGetterPropertyByKey(const ATarget, AKey,
 var
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingSetter: TGocciaValue;
+  DescriptorFlags: TPropertyFlags;
 begin
   if AKey is TGocciaSymbolValue then
   begin
     if ATarget is TGocciaVMClassValue then
     begin
       SetBytecodeHomeObject(AGetter, TGocciaVMClassValue(ATarget).Prototype);
+      DescriptorFlags := [pfConfigurable];
       ExistingDescriptor := TGocciaVMClassValue(ATarget).Prototype
         .GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(AKey));
       ExistingSetter := nil;
@@ -6780,11 +7346,12 @@ begin
       TGocciaVMClassValue(ATarget).Prototype.DefineSymbolProperty(
         TGocciaSymbolValue(AKey),
         TGocciaPropertyDescriptorAccessor.Create(
-          AGetter, ExistingSetter, [pfEnumerable, pfConfigurable, pfWritable]));
+          AGetter, ExistingSetter, DescriptorFlags));
     end
     else if ATarget is TGocciaObjectValue then
     begin
       SetBytecodeHomeObject(AGetter, TGocciaObjectValue(ATarget));
+      DescriptorFlags := [pfEnumerable, pfConfigurable, pfWritable];
       ExistingDescriptor := TGocciaObjectValue(ATarget)
         .GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(AKey));
       ExistingSetter := nil;
@@ -6794,7 +7361,7 @@ begin
       TGocciaObjectValue(ATarget).DefineSymbolProperty(
         TGocciaSymbolValue(AKey),
         TGocciaPropertyDescriptorAccessor.Create(
-          AGetter, ExistingSetter, [pfEnumerable, pfConfigurable, pfWritable]));
+          AGetter, ExistingSetter, DescriptorFlags));
     end;
     Exit;
   end;
@@ -6807,12 +7374,14 @@ procedure TGocciaVM.DefineSetterPropertyByKey(const ATarget, AKey,
 var
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingGetter: TGocciaValue;
+  DescriptorFlags: TPropertyFlags;
 begin
   if AKey is TGocciaSymbolValue then
   begin
     if ATarget is TGocciaVMClassValue then
     begin
       SetBytecodeHomeObject(ASetter, TGocciaVMClassValue(ATarget).Prototype);
+      DescriptorFlags := [pfConfigurable];
       ExistingDescriptor := TGocciaVMClassValue(ATarget).Prototype
         .GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(AKey));
       ExistingGetter := nil;
@@ -6822,11 +7391,12 @@ begin
       TGocciaVMClassValue(ATarget).Prototype.DefineSymbolProperty(
         TGocciaSymbolValue(AKey),
         TGocciaPropertyDescriptorAccessor.Create(
-          ExistingGetter, ASetter, [pfEnumerable, pfConfigurable, pfWritable]));
+          ExistingGetter, ASetter, DescriptorFlags));
     end
     else if ATarget is TGocciaObjectValue then
     begin
       SetBytecodeHomeObject(ASetter, TGocciaObjectValue(ATarget));
+      DescriptorFlags := [pfEnumerable, pfConfigurable, pfWritable];
       ExistingDescriptor := TGocciaObjectValue(ATarget)
         .GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(AKey));
       ExistingGetter := nil;
@@ -6836,7 +7406,7 @@ begin
       TGocciaObjectValue(ATarget).DefineSymbolProperty(
         TGocciaSymbolValue(AKey),
         TGocciaPropertyDescriptorAccessor.Create(
-          ExistingGetter, ASetter, [pfEnumerable, pfConfigurable, pfWritable]));
+          ExistingGetter, ASetter, DescriptorFlags));
     end;
     Exit;
   end;
@@ -7003,9 +7573,34 @@ begin
     DelimiterPos := Pos(':', KeyBody);
     if DelimiterPos > 1 then
       Result := Copy(KeyBody, 1, DelimiterPos - 1)
-    else if KeyBody <> '' then
+    else if (KeyBody <> '') and (Pos('$', KeyBody) = 0) then
       Result := KeyBody;
   end;
+end;
+
+function BytecodePrivateSourceName(const AName: string): string;
+var
+  Body: string;
+  DelimiterPos: SizeInt;
+begin
+  Result := AName;
+  if IsBytecodePrivateKey(Result) then
+  begin
+    Body := Copy(Result, Length(BYTECODE_PRIVATE_SLOT_PREFIX) + 1, MaxInt);
+    DelimiterPos := Pos('$', Body);
+    if DelimiterPos > 0 then
+      Result := Copy(Body, DelimiterPos + 1, MaxInt)
+    else
+    begin
+      DelimiterPos := Pos(':', Body);
+      if DelimiterPos > 0 then
+        Result := Copy(Body, DelimiterPos + 1, MaxInt)
+      else
+        Result := Body;
+    end;
+  end;
+  if (Result <> '') and (Result[1] = '#') then
+    Result := Copy(Result, 2, MaxInt);
 end;
 
 function BytecodePrivateReceiverBrandToken(
@@ -7043,6 +7638,72 @@ begin
       NormalizeBytecodePrivateKey(AKey, APrivateBrandToken);
 end;
 
+function TGocciaVM.ResolveBytecodePrivateBrandToken(const AKey: string;
+  const AObject: TGocciaValue): string;
+var
+  HomeClass: TGocciaClassValue;
+  CandidateClass: TGocciaClassValue;
+  ExactReceiverClass: TGocciaClassValue;
+  SourceName: string;
+  DeclaredKey: string;
+
+  function IsSuperclassOfHome(const AClassValue: TGocciaClassValue): Boolean;
+  var
+    CurrentClass: TGocciaClassValue;
+  begin
+    Result := False;
+    if (not Assigned(HomeClass)) or not Assigned(AClassValue) then
+      Exit;
+    CurrentClass := HomeClass.SuperClass;
+    while Assigned(CurrentClass) do
+    begin
+      if CurrentClass = AClassValue then
+        Exit(True);
+      CurrentClass := CurrentClass.SuperClass;
+    end;
+  end;
+begin
+  Result := BytecodePrivateTokenForKey(AKey,
+    BytecodePrivateReceiverBrandToken(AObject));
+
+  SourceName := BytecodePrivateSourceName(AKey);
+  HomeClass := nil;
+  if Assigned(FCurrentClosure) and
+     (FCurrentClosure.HomeClass is TGocciaClassValue) then
+    HomeClass := TGocciaClassValue(FCurrentClosure.HomeClass);
+
+  CandidateClass := nil;
+  if AObject is TGocciaClassValue then
+    CandidateClass := TGocciaClassValue(AObject)
+  else if (AObject is TGocciaInstanceValue) and
+          Assigned(TGocciaInstanceValue(AObject).ClassValue) then
+    CandidateClass := TGocciaInstanceValue(AObject).ClassValue;
+
+  ExactReceiverClass := nil;
+  while Assigned(CandidateClass) do
+  begin
+    if (SourceName <> '') and
+       CandidateClass.ResolveDeclaredPrivateKey(SourceName, DeclaredKey) and
+       (DeclaredKey = AKey) then
+    begin
+      ExactReceiverClass := CandidateClass;
+      Break;
+    end;
+    CandidateClass := CandidateClass.SuperClass;
+  end;
+
+  if Assigned(HomeClass) and (SourceName <> '') and
+     HomeClass.ResolveDeclaredPrivateKey(SourceName, DeclaredKey) then
+  begin
+    if Assigned(ExactReceiverClass) and IsSuperclassOfHome(ExactReceiverClass) then
+      Exit(ExactReceiverClass.PrivateBrandToken);
+    Exit(HomeClass.PrivateBrandToken);
+  end;
+
+  if Assigned(ExactReceiverClass) then
+    Exit(ExactReceiverClass.PrivateBrandToken);
+end;
+
 function BytecodePrivateInitializedKey(
   const APrivateBrandToken: string): string;
 begin
@@ -7058,34 +7719,71 @@ begin
   if (not Assigned(AClassValue)) or
      not (AInstance is TGocciaObjectValue) then
     Exit;
-  Descriptor := TGocciaObjectValue(AInstance).GetOwnPropertyDescriptor(
-    BytecodePrivateInitializedKey(AClassValue.PrivateBrandToken));
+  Descriptor := nil;
+  TGocciaObjectValue(AInstance).Properties.TryGetValue(
+    BytecodePrivateInitializedKey(AClassValue.PrivateBrandToken), Descriptor);
   Result := Descriptor is TGocciaPropertyDescriptorData;
+end;
+
+function TryGetRawObjectPrivateDescriptor(const AObject: TGocciaObjectValue;
+  const AKey: string; out ADescriptor: TGocciaPropertyDescriptor): Boolean;
+begin
+  ADescriptor := nil;
+  Result := Assigned(AObject) and AObject.Properties.TryGetValue(AKey,
+    ADescriptor);
+end;
+
+procedure DefineRawObjectPrivateProperty(const AObject: TGocciaObjectValue;
+  const AKey: string; const AValue: TGocciaValue;
+  const AFlags: TPropertyFlags);
+var
+  Descriptor: TGocciaPropertyDescriptor;
+begin
+  if AObject.Properties.TryGetValue(AKey, Descriptor) then
+    Descriptor.Free;
+  AObject.Properties.Add(AKey,
+    TGocciaPropertyDescriptorData.Create(AValue, AFlags));
+end;
+
+procedure DefineRawObjectPrivateDescriptor(const AObject: TGocciaObjectValue;
+  const AKey: string; const ADescriptor: TGocciaPropertyDescriptor);
+var
+  ExistingDescriptor: TGocciaPropertyDescriptor;
+begin
+  if not Assigned(ADescriptor) then
+    Exit;
+  if AObject.Properties.TryGetValue(AKey, ExistingDescriptor) then
+    ExistingDescriptor.Free;
+  AObject.Properties.Add(AKey, ADescriptor);
 end;
 
 procedure StampBytecodePrivateInitializersApplied(const AInstance: TGocciaValue;
   const AClassValue: TGocciaClassValue);
 begin
   if (not Assigned(AClassValue)) or
-     (not AClassValue.HasInstanceInitializerWork) or
      HasBytecodePrivateInitializersApplied(AInstance, AClassValue) then
     Exit;
   if AInstance is TGocciaObjectValue then
-    TGocciaObjectValue(AInstance).DefineProperty(
-    BytecodePrivateInitializedKey(AClassValue.PrivateBrandToken),
-    TGocciaPropertyDescriptorData.Create(
-      TGocciaBooleanLiteralValue.TrueValue, []));
+    DefineRawObjectPrivateProperty(TGocciaObjectValue(AInstance),
+      BytecodePrivateInitializedKey(AClassValue.PrivateBrandToken),
+      TGocciaBooleanLiteralValue.TrueValue, []);
 end;
 
 procedure TGocciaVM.StampBytecodePrivateBrands(
-  const AClassValue: TGocciaClassValue; const AInstance: TGocciaValue);
+  const AClassValue: TGocciaClassValue; const AInstance: TGocciaValue;
+  const APreserveExistingPrivateSlots: Boolean);
 var
   Names: TStringList;
   PrototypeNames: TArray<string>;
   PrototypeName: string;
   PrivateBrandToken: string;
+  BrandKey: string;
+  ExistingValue: TGocciaValue;
   PrototypeDescriptor: TGocciaPropertyDescriptor;
   ReceiverObject: TGocciaObjectValue;
+  SeenBrandKeys: TStringList;
+  SourcePrivateName: string;
+  IsPrivateFieldBrand: Boolean;
   I: Integer;
 begin
   if (not Assigned(AClassValue)) or
@@ -7095,10 +7793,14 @@ begin
   ReceiverObject := TGocciaObjectValue(AInstance);
 
   Names := TStringList.Create;
+  SeenBrandKeys := TStringList.Create;
   try
     Names.CaseSensitive := True;
     Names.Sorted := False;
     Names.Duplicates := dupIgnore;
+    SeenBrandKeys.CaseSensitive := True;
+    SeenBrandKeys.Sorted := False;
+    SeenBrandKeys.Duplicates := dupIgnore;
     AClassValue.AppendOwnPrivateNames(Names);
     if Assigned(AClassValue.Prototype) then
     begin
@@ -7108,13 +7810,77 @@ begin
            (Names.IndexOf(PrototypeName) < 0) then
           Names.Add(PrototypeName);
     end;
+    if (Names.Count > 0) and not ReceiverObject.Extensible then
+      ThrowTypeError('Cannot add private elements to a non-extensible object',
+        SSuggestObjectNotExtensible);
     for I := 0 to Names.Count - 1 do
     begin
       PrivateBrandToken := BytecodePrivateTokenForKey(Names[I],
         AClassValue.PrivateBrandToken);
-      SetRawPrivateValue(AInstance, BytecodePrivateBrandKey(
+      BrandKey := BytecodePrivateBrandKey(
         NormalizeBytecodePrivateKey(Names[I], PrivateBrandToken),
-        PrivateBrandToken),
+        PrivateBrandToken);
+      if SeenBrandKeys.IndexOf(BrandKey) >= 0 then
+        Continue;
+      if TryGetRawObjectPrivateDescriptor(ReceiverObject, Names[I],
+         PrototypeDescriptor) and
+         not HasBytecodePrivateInitializersApplied(AInstance, AClassValue) then
+      begin
+        if not ReceiverObject.Extensible then
+          ThrowTypeError(
+            'Cannot add private elements to a non-extensible object',
+            SSuggestObjectNotExtensible);
+        if not ((AClassValue is TGocciaVMClassValue) and
+           Assigned(TGocciaVMClassValue(AClassValue).FConstructorValue)) then
+          ThrowTypeError('Cannot initialize private elements twice',
+            SSuggestPrivateFieldAccess);
+        Continue;
+      end;
+      if TryGetRawPrivateValue(AInstance, BrandKey, ExistingValue) then
+      begin
+        if not HasBytecodePrivateInitializersApplied(AInstance, AClassValue) then
+        begin
+          if not ReceiverObject.Extensible then
+            ThrowTypeError(
+              'Cannot add private elements to a non-extensible object',
+              SSuggestObjectNotExtensible);
+          if (AClassValue is TGocciaVMClassValue) and
+             Assigned(TGocciaVMClassValue(AClassValue).FConstructorValue) then
+            Continue;
+        end;
+        SourcePrivateName := NormalizeBytecodePrivateKey(Names[I],
+          PrivateBrandToken);
+        if IsBytecodePrivateKey(SourcePrivateName) then
+        begin
+          SourcePrivateName := Copy(SourcePrivateName,
+            Length(BYTECODE_PRIVATE_SLOT_PREFIX) + 1, MaxInt);
+          if Pos('$', SourcePrivateName) > 0 then
+            SourcePrivateName := Copy(SourcePrivateName,
+              Pos('$', SourcePrivateName) + 1, MaxInt)
+          else if Pos(':', SourcePrivateName) > 0 then
+            SourcePrivateName := Copy(SourcePrivateName,
+              Pos(':', SourcePrivateName) + 1, MaxInt);
+        end;
+        IsPrivateFieldBrand :=
+          (AClassValue.PrivateInstancePropertyDefs.Count > 0) or
+          (AClassValue.FieldOrderCount > 0) or
+          AClassValue.PrivateInstancePropertyDefs.ContainsKey(Names[I]) or
+          AClassValue.PrivateInstancePropertyDefs.ContainsKey(SourcePrivateName);
+        if IsPrivateFieldBrand then
+        begin
+          if not ReceiverObject.Extensible then
+            ThrowTypeError(
+              'Cannot add private elements to a non-extensible object',
+              SSuggestObjectNotExtensible);
+          Continue;
+        end;
+        if APreserveExistingPrivateSlots then
+          Continue;
+        ThrowTypeError('Cannot initialize private elements twice',
+          SSuggestPrivateFieldAccess);
+      end;
+      SeenBrandKeys.Add(BrandKey);
+      SetRawPrivateValue(AInstance, BrandKey,
         TGocciaBooleanLiteralValue.TrueValue);
 
       if (not (AInstance is TGocciaInstanceValue)) and
@@ -7124,11 +7890,12 @@ begin
         PrototypeDescriptor := AClassValue.Prototype.GetOwnPropertyDescriptor(
           Names[I]);
         if Assigned(PrototypeDescriptor) then
-          ReceiverObject.DefineProperty(Names[I],
+          DefineRawObjectPrivateDescriptor(ReceiverObject, Names[I],
             ClonePropertyDescriptor(PrototypeDescriptor));
       end;
     end;
   finally
+    SeenBrandKeys.Free;
     Names.Free;
   end;
 end;
@@ -7140,7 +7907,8 @@ var
   PreviousPrivateInitializerReceiver: TGocciaValue;
   PreviousPrivateInitializerPreserveExisting: Boolean;
 begin
-  StampBytecodePrivateBrands(AClassValue, AInstance);
+  StampBytecodePrivateBrands(AClassValue, AInstance,
+    APreserveExistingPrivateSlots);
   PreviousPrivateInitializerReceiver := FPrivateInitializerReceiver;
   PreviousPrivateInitializerPreserveExisting :=
     FPrivateInitializerPreserveExisting;
@@ -8204,7 +8972,16 @@ begin
   end;
 
   if not (ASuperValue is TGocciaClassValue) then
+  begin
+    if Assigned(HomeObject) then
+    begin
+      SuperPrototype := HomeObject.Prototype;
+      if SuperPrototype is TGocciaObjectValue then
+        Exit(TGocciaObjectValue(SuperPrototype).GetPropertyWithContext(
+          AName, AThisValue));
+    end;
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  end;
 
   SuperClass := TGocciaClassValue(ASuperValue);
   if AUseSuperConstructor and (AName = PROP_CONSTRUCTOR) then
@@ -8272,7 +9049,16 @@ begin
   end;
 
   if not (ASuperValue is TGocciaClassValue) then
+  begin
+    if Assigned(HomeObject) then
+    begin
+      SuperPrototype := HomeObject.Prototype;
+      if SuperPrototype is TGocciaObjectValue then
+        Exit(TGocciaObjectValue(SuperPrototype).GetSymbolPropertyWithReceiver(
+          TGocciaSymbolValue(AKey), AThisValue));
+    end;
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  end;
 
   SuperClass := TGocciaClassValue(ASuperValue);
   if AThisValue is TGocciaClassValue then
@@ -8315,8 +9101,7 @@ begin
 
   if IsBytecodePrivateKey(AKey) then
   begin
-    PrivateBrandToken := BytecodePrivateTokenForKey(AKey,
-      BytecodePrivateReceiverBrandToken(AObject));
+    PrivateBrandToken := ResolveBytecodePrivateBrandToken(AKey, AObject);
     PrivateName := NormalizeBytecodePrivateKey(AKey, PrivateBrandToken);
     if AObject is TGocciaClassValue then
     begin
@@ -8348,7 +9133,8 @@ begin
       Current := TGocciaObjectValue(AObject);
       while Assigned(Current) do
       begin
-        Descriptor := Current.GetOwnPropertyDescriptor(AKey);
+        if not TryGetRawObjectPrivateDescriptor(Current, AKey, Descriptor) then
+          Descriptor := Current.GetOwnPropertyDescriptor(AKey);
         if Descriptor is TGocciaPropertyDescriptorAccessor then
         begin
           if not TryGetRawPrivateValue(
@@ -8357,7 +9143,16 @@ begin
             ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
               SSuggestPrivateFieldAccess);
           if Assigned(TGocciaPropertyDescriptorAccessor(Descriptor).Getter) then
-            Exit(AObject.GetProperty(AKey));
+          begin
+            EmptyArgs := TGocciaArgumentsCollection.Create;
+            try
+              Exit(InvokeFunctionValue(
+                TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
+                EmptyArgs, AObject));
+            finally
+              EmptyArgs.Free;
+            end;
+          end;
           ThrowTypeError(Format(SErrorPrivateAccessorNoGetter, [AKey]),
             SSuggestPrivateFieldAccess);
         end;
@@ -8403,7 +9198,6 @@ var
   BoxedValue: TGocciaObjectValue;
   PrivateBrandToken: string;
   ExistingValue: TGocciaValue;
-  CurrentClass: TGocciaClassValue;
 begin
   if AObject is TGocciaNullLiteralValue then
     ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, [AKey]),
@@ -8413,8 +9207,7 @@ begin
       SSuggestCheckNullBeforeAccess);
   if IsBytecodePrivateKey(AKey) then
   begin
-    PrivateBrandToken := BytecodePrivateTokenForKey(AKey,
-      BytecodePrivateReceiverBrandToken(AObject));
+    PrivateBrandToken := ResolveBytecodePrivateBrandToken(AKey, AObject);
     PrivateName := NormalizeBytecodePrivateKey(AKey, PrivateBrandToken);
     if AObject is TGocciaClassValue then
     begin
@@ -8450,7 +9243,8 @@ begin
       Current := TGocciaObjectValue(AObject);
       while Assigned(Current) do
       begin
-        Descriptor := Current.GetOwnPropertyDescriptor(AKey);
+        if not TryGetRawObjectPrivateDescriptor(Current, AKey, Descriptor) then
+          Descriptor := Current.GetOwnPropertyDescriptor(AKey);
         if (Descriptor is TGocciaPropertyDescriptorAccessor) and
            Assigned(TGocciaPropertyDescriptorAccessor(Descriptor).Setter) then
         begin
@@ -8459,7 +9253,14 @@ begin
             ExistingValue) then
             ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
               SSuggestPrivateFieldAccess);
-          AObject.SetProperty(AKey, AValue);
+          SetterArgs := TGocciaArgumentsCollection.Create([AValue]);
+          try
+            InvokeFunctionValue(
+              TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
+              SetterArgs, AObject);
+          finally
+            SetterArgs.Free;
+          end;
           Exit;
         end;
         if Descriptor is TGocciaPropertyDescriptorData then
@@ -8477,26 +9278,8 @@ begin
         Exit;
     end
     else
-    begin
-      if AObject <> FPrivateInitializerReceiver then
-      begin
-        if (AObject = RegisterToValue(GetLocalRegister(0))) and
-           (FCurrentNewTarget is TGocciaClassValue) then
-        begin
-          CurrentClass := TGocciaClassValue(FCurrentNewTarget);
-          if Assigned(CurrentClass.Prototype) and
-             Assigned(CurrentClass.Prototype.GetOwnPropertyDescriptor(AKey)) then
-            ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
-              SSuggestPrivateFieldAccess);
-        end
-        else
-          ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
-            SSuggestPrivateFieldAccess);
-      end;
-      SetRawPrivateValue(AObject, BytecodePrivateBrandKey(AKey,
-        PrivateBrandToken),
-        TGocciaBooleanLiteralValue.TrueValue);
-    end;
+      ThrowTypeError(Format(SErrorPrivateFieldNotAccessible, [AKey]),
+        SSuggestPrivateFieldAccess);
     SetRawPrivateValue(AObject, AKey, AValue);
     Exit;
   end;
@@ -8645,8 +9428,7 @@ begin
     InstanceValue := TGocciaInstanceValue(AObject);
     if InstanceValue.TryGetRawPrivateProperty(AKey, AValue) then
     begin
-      PrivateBrandToken := BytecodePrivateTokenForKey(AKey,
-        BytecodePrivateReceiverBrandToken(AObject));
+      PrivateBrandToken := ResolveBytecodePrivateBrandToken(AKey, AObject);
       Result := IsBytecodePrivateBrandKey(AKey) or
         InstanceValue.TryGetRawPrivateProperty(
           BytecodePrivateBrandKey(AKey, PrivateBrandToken), BrandValue);
@@ -8665,15 +9447,15 @@ begin
   begin
     if not IsBytecodePrivateBrandKey(AKey) then
     begin
-      PrivateBrandToken := BytecodePrivateTokenForKey(AKey,
-        BytecodePrivateReceiverBrandToken(AObject));
-      BrandDescriptor := TGocciaObjectValue(AObject).GetOwnPropertyDescriptor(
-        BytecodePrivateBrandKey(AKey, PrivateBrandToken));
+      PrivateBrandToken := ResolveBytecodePrivateBrandToken(AKey, AObject);
+      TryGetRawObjectPrivateDescriptor(TGocciaObjectValue(AObject),
+        BytecodePrivateBrandKey(AKey, PrivateBrandToken), BrandDescriptor);
       if not (BrandDescriptor is TGocciaPropertyDescriptorData) then
         Exit;
     end;
 
-    Descriptor := TGocciaObjectValue(AObject).GetOwnPropertyDescriptor(AKey);
+    TryGetRawObjectPrivateDescriptor(TGocciaObjectValue(AObject), AKey,
+      Descriptor);
     if Descriptor is TGocciaPropertyDescriptorData then
     begin
       AValue := TGocciaPropertyDescriptorData(Descriptor).Value;
@@ -8699,9 +9481,8 @@ begin
 
   if AObject is TGocciaObjectValue then
   begin
-    TGocciaObjectValue(AObject).DefineProperty(
-      AKey, TGocciaPropertyDescriptorData.Create(
-        AValue, [pfWritable, pfConfigurable]));
+    DefineRawObjectPrivateProperty(TGocciaObjectValue(AObject), AKey,
+      AValue, [pfWritable, pfConfigurable]);
     Exit;
   end;
 
@@ -8991,9 +9772,11 @@ var
   ExecutionContext: TGocciaExecutionContextScope;
   SourceName: string;
   CallerClosure: TGocciaBytecodeClosure;
+  DeclaredPrivateNames: TStringList;
   CurrentFunctionValue: TGocciaValue;
   CurrentCtorClass: TGocciaClassValue;
   RejectArgumentsVarDeclaration: Boolean;
+  RejectArgumentsReference: Boolean;
   AllowNewTarget: Boolean;
   AllowSuperProperty: Boolean;
   AllowSuperCall: Boolean;
@@ -9011,8 +9794,13 @@ begin
     EvalOptions.SourceType := stScript;
     if ACallerStrict then
       Exclude(EvalOptions.Compatibility, cfNonStrictMode);
-    PipelineResult := TGocciaSourcePipeline.Parse(EvalSource, SourceName,
-      EvalOptions);
+    DeclaredPrivateNames := CollectBytecodeDirectEvalPrivateNames(Self);
+    try
+      PipelineResult := TGocciaSourcePipeline.Parse(EvalSource, SourceName,
+        EvalOptions, DeclaredPrivateNames);
+    finally
+      DeclaredPrivateNames.Free;
+    end;
     try
       if HasDirectEvalTopLevelUsingDeclaration(PipelineResult.ProgramNode) then
         ThrowSyntaxError(
@@ -9022,15 +9810,17 @@ begin
         EnvIndex := -1;
       StrictEval := ACallerStrict or HasUseStrictDirective(PipelineResult.ProgramNode);
       UseGlobalVarEnvironment := TemplateUsesGlobalEvalEnvironment(ATemplate);
+      CallerClosure := DirectEvalLexicalClosure(Self);
       if UseGlobalVarEnvironment then
         CallerParentScope := FGlobalScope
       else
         CallerParentScope := EnsureCurrentDynamicVarScope;
 
       CallerScope := TGocciaVMDirectEvalScope.Create(CallerParentScope, Self,
-        ATemplate, EnvIndex, UseGlobalVarEnvironment);
+        ATemplate, EnvIndex, UseGlobalVarEnvironment, CallerClosure,
+        FCurrentNewTarget);
       CallerScope.ThisValue := DirectEvalLexicalThisValue(Self,
-        UseGlobalVarEnvironment);
+        UseGlobalVarEnvironment, ATemplate, EnvIndex);
 
       if Assigned(TGarbageCollector.Instance) then
         TGarbageCollector.Instance.AddTempRoot(CallerScope);
@@ -9063,7 +9853,6 @@ begin
             EvalContext.StrictTypes := FGlobalScope.EffectiveStrictTypes;
           EvalContext.NonStrictMode := not StrictEval;
 
-          CallerClosure := DirectEvalLexicalClosure(Self);
           if Assigned(CallerClosure) then
             CurrentFunctionValue := CallerClosure.FunctionValue
           else
@@ -9086,11 +9875,12 @@ begin
           try
             RejectArgumentsVarDeclaration :=
               DirectEvalRejectsArgumentsVarDeclaration(ATemplate, APC);
+            RejectArgumentsReference := ATemplate.RejectArgumentsInDirectEval;
             try
               Result := EvaluateEvalProgram(PipelineResult.ProgramNode,
                 EvalContext, VarScope, ActiveScope, StrictEval,
                 RejectArgumentsVarDeclaration, AllowNewTarget,
-                AllowSuperProperty, AllowSuperCall);
+                AllowSuperProperty, AllowSuperCall, RejectArgumentsReference);
             finally
               CallerScope.CopyBackVariableBindings;
               if not UseGlobalVarEnvironment then
@@ -9450,6 +10240,7 @@ var
   Desc: TGocciaUpvalueDescriptor;
   Handler: TGocciaBytecodeHandlerEntry;
   DoneValue: TGocciaValue;
+  IteratorElementValue: TGocciaValue;
   IterResult: TGocciaValue;
   NextMethod: TGocciaValue;
   DoneFlag: Boolean;
@@ -9457,6 +10248,7 @@ var
   Template: TGocciaFunctionTemplate;
   ChildTemplate: TGocciaFunctionTemplate;
   LeftValue, RightValue, TargetValue, PropKeyValue, EvalSourceValue: TGocciaValue;
+  PrivateDescriptor: TGocciaPropertyDescriptor;
   FunctionConstructorValue, ObjectConstructorValue: TGocciaValue;
   CustomMatcherValue, MatchResultValue: TGocciaValue;
   MatchHintObject: TGocciaObjectValue;
@@ -9670,6 +10462,15 @@ begin
       begin
         if Assigned(FCurrentClosure) then
         begin
+          Desc := Template.GetUpvalueDescriptor(DecodeBx(Instruction));
+          if (Desc.Name <> '') and Assigned(FCurrentDynamicVarScope) and
+             FCurrentDynamicVarScope.Contains(Desc.Name) then
+          begin
+            FRegisters[A] := VMValueToRegisterFast(
+              FCurrentDynamicVarScope.GetValue(Desc.Name));
+            Continue;
+          end;
+
           Upvalue := FCurrentClosure.GetUpvalue(DecodeBx(Instruction));
           if Assigned(Upvalue) and Assigned(Upvalue.Cell) then
           begin
@@ -9704,6 +10505,17 @@ begin
 
       OP_ARG_COUNT:
         FRegisters[A] := RegisterInt(FArgCount);
+
+      OP_LOAD_ARGUMENT:
+        if (B < Length(FCurrentArguments)) then
+          SetRegisterRaw(A, FCurrentArguments[B])
+        else
+          FRegisters[A] := RegisterUndefined;
+
+      OP_CHECK_DERIVED_THIS:
+        if not FCurrentConstructorSuperCalled then
+          ThrowReferenceError(
+            'Must call super constructor before accessing this');
 
       OP_CREATE_ARGUMENTS:
         SetRegister(A, CreateArgumentsObjectFromCurrentFrame);
@@ -9971,7 +10783,10 @@ begin
 
       OP_ARRAY_GET:
       begin
-        if (FRegisters[B].Kind = grkObject) and
+        if FRegisters[B].Kind in [grkUndefined, grkNull] then
+          ThrowTypeError(SErrorCannotConvertNullOrUndefined,
+            SSuggestCheckNullBeforeAccess)
+        else if (FRegisters[B].Kind = grkObject) and
            (FRegisters[B].ObjectValue is TGocciaArrayValue) then
         begin
           if (FRegisters[C].Kind = grkObject) and
@@ -10215,6 +11030,17 @@ begin
         end
         else if (FRegisters[A].Kind = grkObject) and
                 (FRegisters[A].ObjectValue is TGocciaVMClassValue) and
+                (FRegisters[B].Kind = grkNull) then
+        begin
+          TGocciaVMClassValue(FRegisters[A].ObjectValue).SuperClass := nil;
+          TGocciaVMClassValue(FRegisters[A].ObjectValue).NativeSuperConstructor :=
+            TGocciaFunctionBase.GetSharedPrototype;
+          TGocciaVMClassValue(FRegisters[A].ObjectValue).SetConstructorPrototype(
+            TGocciaFunctionBase.GetSharedPrototype);
+          TGocciaVMClassValue(FRegisters[A].ObjectValue).Prototype.Prototype := nil;
+        end
+        else if (FRegisters[A].Kind = grkObject) and
+                (FRegisters[A].ObjectValue is TGocciaVMClassValue) and
                 (FRegisters[B].Kind = grkObject) and
                 (FRegisters[B].ObjectValue is TGocciaObjectValue) and
                 FRegisters[B].ObjectValue.IsConstructable then
@@ -10247,6 +11073,9 @@ begin
         if (FRegisters[A].Kind = grkObject) and
            (FRegisters[A].ObjectValue is TGocciaVMClassValue) then
         begin
+          if IsBytecodePrivateKey(GlobalName) then
+            DeclareBytecodePrivateNameForClass(
+              FRegisters[A].ObjectValue, GlobalName);
           SetBytecodeHomeObject(RegisterToValue(FRegisters[C]),
             FRegisters[A].ObjectValue);
           if GlobalName = PROP_CONSTRUCTOR then
@@ -10273,8 +11102,17 @@ begin
       begin
         if (FRegisters[A].Kind = grkObject) and
            (FRegisters[A].ObjectValue is TGocciaVMClassValue) then
+        begin
+          SetBytecodeHomeObject(RegisterToValue(FRegisters[B]),
+            FRegisters[A].ObjectValue);
+          if RegisterToValue(FRegisters[B]) is TGocciaBytecodeFunctionValue then
+            DeclareBytecodePrivateNamesFromTemplate(
+              FRegisters[A].ObjectValue,
+              TGocciaBytecodeFunctionValue(RegisterToValue(FRegisters[B]))
+                .FClosure.Template);
           TGocciaVMClassValue(FRegisters[A].ObjectValue).SetMethodInitializers(
             [RegisterToValue(FRegisters[B])]);
+        end;
       end;
 
       OP_CLASS_DECLARE_PRIVATE_STATIC_CONST:
@@ -10282,8 +11120,12 @@ begin
         GlobalName := Template.GetConstantUnchecked(B).StringValue;
         if (FRegisters[A].Kind = grkObject) and
            (FRegisters[A].ObjectValue is TGocciaVMClassValue) then
+        begin
+          DeclareBytecodePrivateNameForClass(FRegisters[A].ObjectValue,
+            GlobalName);
           TGocciaVMClassValue(FRegisters[A].ObjectValue).AddPrivateStaticProperty(
             GlobalName, TGocciaUndefinedLiteralValue.UndefinedValue);
+        end;
       end;
 
       // ES2022 §15.7.14: execute static block closure with this = class
@@ -10292,6 +11134,8 @@ begin
         if (FRegisters[B].Kind = grkObject) and
            (FRegisters[B].ObjectValue is TGocciaBytecodeFunctionValue) then
         begin
+          SetBytecodeHomeObject(RegisterToValue(FRegisters[B]),
+            FRegisters[A].ObjectValue);
           PushFrame(B, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
           SetupNewFrame(
             TGocciaBytecodeFunctionValue(FRegisters[B].ObjectValue).FClosure,
@@ -10374,6 +11218,31 @@ begin
         begin
           if FRegisters[A].ObjectValue is TGocciaVMClassValue then
             SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
+          if IsBytecodePrivateKey(GlobalName) then
+          begin
+            if (FRegisters[A].ObjectValue is TGocciaInstanceValue) then
+            begin
+              if (not TGocciaInstanceValue(FRegisters[A].ObjectValue)
+                    .TryGetRawPrivateProperty(GlobalName, TargetValue)) and
+                 (not TGocciaInstanceValue(FRegisters[A].ObjectValue)
+                    .Extensible) then
+                ThrowTypeError(
+                  'Cannot add private elements to a non-extensible object',
+                  SSuggestObjectNotExtensible);
+            end
+            else if (FRegisters[A].ObjectValue is TGocciaObjectValue) and
+                    (not TryGetRawObjectPrivateDescriptor(
+                      TGocciaObjectValue(FRegisters[A].ObjectValue),
+                      GlobalName, PrivateDescriptor)) and
+                    (not TGocciaObjectValue(FRegisters[A].ObjectValue)
+                      .Extensible) then
+              ThrowTypeError(
+                'Cannot add private elements to a non-extensible object',
+                SSuggestObjectNotExtensible);
+            SetRawPrivateValue(FRegisters[A].ObjectValue, GlobalName,
+              RightValue);
+            Continue;
+          end;
           TGocciaObjectValue(FRegisters[A].ObjectValue).DefineProperty(
             GlobalName,
             TGocciaPropertyDescriptorData.Create(
@@ -10431,6 +11300,8 @@ begin
           if IsBytecodePrivateKey(GlobalName) and
              (FRegisters[A].ObjectValue is TGocciaVMClassValue) then
           begin
+            DeclareBytecodePrivateNameForClass(FRegisters[A].ObjectValue,
+              GlobalName);
             SetBytecodeHomeObject(RightValue, RegisterToValue(FRegisters[A]));
             TGocciaVMClassValue(FRegisters[A].ObjectValue).AddPrivateStaticMethod(
               GlobalName, RightValue);
@@ -11931,6 +12802,64 @@ begin
         end;
       end;
 
+      OP_ASYNC_ITER_NEXT:
+      begin
+        if (FRegisters[C].Kind = grkObject) and
+           (FRegisters[C].ObjectValue is TGocciaIteratorValue) then
+        begin
+          IterResult := TGocciaIteratorValue(FRegisters[C].ObjectValue).DirectNext(DoneFlag);
+          SetRegister(A, CreateIteratorResult(IterResult, DoneFlag));
+        end
+        else if (FRegisters[C].Kind = grkObject) and
+                (FRegisters[C].ObjectValue is TGocciaObjectValue) then
+        begin
+          IterResult := FRegisters[C].ObjectValue;
+          NextMethod := IterResult.GetProperty(PROP_NEXT);
+          if not Assigned(NextMethod) or
+             (NextMethod is TGocciaUndefinedLiteralValue) or
+             not NextMethod.IsCallable then
+            ThrowTypeError(SErrorAsyncIteratorNextNotCallable,
+              SSuggestAsyncIteratorProtocol);
+
+          CallArgs := AcquireArguments;
+          try
+            IterResult := TGocciaFunctionBase(NextMethod).Call(CallArgs, IterResult);
+          finally
+            ReleaseArguments(CallArgs);
+          end;
+          SetRegister(A, IterResult);
+        end
+        else
+          SetRegister(A, CreateIteratorResult(
+            TGocciaUndefinedLiteralValue.UndefinedValue, True));
+      end;
+
+      OP_ITER_UNPACK:
+      begin
+        IterResult := GetRegister(C);
+        if IterResult.IsPrimitive then
+          ThrowTypeError(Format(SErrorIteratorResultNotObject,
+            [IterResult.ToStringLiteral.Value]), SSuggestIteratorResultObject);
+
+        DoneValue := IterResult.GetProperty(PROP_DONE);
+        if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+        begin
+          FRegisters[A] := RegisterUndefined;
+          FRegisters[B] := RegisterBoolean(True);
+        end
+        else
+        begin
+          IteratorElementValue := IterResult.GetProperty(PROP_VALUE);
+          if not Assigned(IteratorElementValue) then
+            IteratorElementValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+          FRegisters[A] := VMValueToRegisterFast(IteratorElementValue);
+          FRegisters[B] := RegisterBoolean(False);
+        end;
+      end;
+
+      OP_SET_FUNCTION_NAME:
+        SetFunctionNameFromKey(GetRegister(A), GetRegister(B), C);
+
       OP_ITER_CLOSE:
         if FRegisters[A].Kind = grkObject then
         begin
@@ -11960,8 +12889,7 @@ begin
             AwaitContinuation.CaptureContinuation(Frame, SavedHandlerCount,
               PrevCovLine, A, Frame.IP);
             AwaitContinuation.FState := bgsSuspendedYield;
-            AwaitPromise := TGocciaPromiseValue.Create;
-            AwaitPromise.Resolve(GetRegister(B));
+            AwaitPromise := PromiseResolveIntrinsic(GetRegister(B));
             AwaitPromise.InvokeThen(
               TGocciaVMAsyncAwaitContinuationValue.Create(Self,
                 AwaitContinuation, FCurrentAsyncPromise, bgrkNext,
@@ -12307,6 +13235,9 @@ begin
       OP_DEFINE_ACCESSOR_CONST:
       begin
         GlobalName := Template.GetConstantUnchecked(C).StringValue;
+        if IsBytecodePrivateKey(GlobalName) then
+          DeclareBytecodePrivateNameForClass(
+            RegisterToValue(FRegisters[A]), GlobalName);
         if (B and ACCESSOR_FLAG_STATIC) <> 0 then
         begin
           if (B and ACCESSOR_FLAG_SETTER) <> 0 then

--- a/source/units/Goccia.Values.ArrayBufferValue.pas
+++ b/source/units/Goccia.Values.ArrayBufferValue.pas
@@ -154,7 +154,7 @@ function ToArrayBufferSliceIndex(const AValue: TGocciaValue;
   const ALength: Integer): Integer;
 var
   Num: TGocciaNumberLiteralValue;
-  RawIndex: Double;
+  IntegerIndex: Double;
 begin
   Num := AValue.ToNumberLiteral;
   if Num.IsNaN or Num.IsNegativeInfinity then
@@ -162,17 +162,17 @@ begin
   if Num.IsInfinity then
     Exit(ALength);
 
-  RawIndex := Num.Value;
-  if RawIndex < 0 then
+  IntegerIndex := Trunc(Num.Value);
+  if IntegerIndex < 0 then
   begin
-    if RawIndex <= -ALength then
+    if IntegerIndex <= -ALength then
       Exit(0);
-    Exit(Max(ALength + Trunc(RawIndex), 0));
+    Exit(Max(ALength + Trunc(IntegerIndex), 0));
   end;
 
-  if RawIndex >= ALength then
+  if IntegerIndex >= ALength then
     Exit(ALength);
-  Result := Trunc(RawIndex);
+  Result := Trunc(IntegerIndex);
 end;
 
 function TGocciaArrayBufferValue.GetByteLength: Integer;

--- a/source/units/Goccia.Values.ArrayBufferValue.pas
+++ b/source/units/Goccia.Values.ArrayBufferValue.pas
@@ -68,6 +68,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.Realm,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -90,6 +91,27 @@ begin
   if not (AThisValue is TGocciaArrayBufferValue) then
     ThrowTypeError(Format(SErrorRequiresArrayBuffer, [AMethodName]), SSuggestArrayBufferThisType);
   Result := TGocciaArrayBufferValue(AThisValue);
+end;
+
+function ArrayBufferSpeciesConstructor(const ABuffer: TGocciaArrayBufferValue): TGocciaValue;
+var
+  ConstructorValue, SpeciesValue: TGocciaValue;
+begin
+  // ES2026 §7.3.22 SpeciesConstructor(O, defaultConstructor)
+  ConstructorValue := ABuffer.GetProperty(PROP_CONSTRUCTOR);
+  if ConstructorValue is TGocciaUndefinedLiteralValue then
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  if not (ConstructorValue is TGocciaObjectValue) then
+    ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+
+  SpeciesValue := TGocciaObjectValue(ConstructorValue).GetSymbolProperty(
+    TGocciaSymbolValue.WellKnownSpecies);
+  if (SpeciesValue is TGocciaUndefinedLiteralValue) or
+     (SpeciesValue is TGocciaNullLiteralValue) then
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  if not SpeciesValue.IsConstructable then
+    ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+  Result := SpeciesValue;
 end;
 
 procedure EnsureArrayBufferAttached(const ABuffer: TGocciaArrayBufferValue; const AErrorMessage: string);
@@ -126,6 +148,31 @@ begin
     ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
 
   Result := Trunc(IntegerIndex);
+end;
+
+function ToArrayBufferSliceIndex(const AValue: TGocciaValue;
+  const ALength: Integer): Integer;
+var
+  Num: TGocciaNumberLiteralValue;
+  RawIndex: Double;
+begin
+  Num := AValue.ToNumberLiteral;
+  if Num.IsNaN or Num.IsNegativeInfinity then
+    Exit(0);
+  if Num.IsInfinity then
+    Exit(ALength);
+
+  RawIndex := Num.Value;
+  if RawIndex < 0 then
+  begin
+    if RawIndex <= -ALength then
+      Exit(0);
+    Exit(Max(ALength + Trunc(RawIndex), 0));
+  end;
+
+  if RawIndex >= ALength then
+    Exit(ALength);
+  Result := Trunc(RawIndex);
 end;
 
 function TGocciaArrayBufferValue.GetByteLength: Integer;
@@ -508,8 +555,10 @@ end;
 function TGocciaArrayBufferValue.ArrayBufferSlice(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Buf: TGocciaArrayBufferValue;
-  Len, First, Final, NewLen: Integer;
-  StartNum, EndNum: TGocciaNumberLiteralValue;
+  Len, First, Final, NewLen, CurrentLen, CopyCount: Integer;
+  SpeciesConstructor: TGocciaValue;
+  ConstructedValue: TGocciaValue;
+  ConstructorArgs: TGocciaArgumentsCollection;
   NewBuf: TGocciaArrayBufferValue;
 begin
   Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.slice');
@@ -520,41 +569,17 @@ begin
 
   Len := Length(Buf.FData);
 
-  // Step 7: Let relativeStart be ToIntegerOrInfinity(start)
-  if AArgs.Length > 0 then
-  begin
-    StartNum := AArgs.GetElement(0).ToNumberLiteral;
-    if StartNum.IsNaN then
-      First := 0
-    else
-      First := Trunc(StartNum.Value);
-  end
+  // Step 7-10: Let relativeStart be ToIntegerOrInfinity(start), then clamp.
+  if AArgs.Length = 0 then
+    First := 0
   else
-    First := 0;
-
-  // Step 8-10: Clamp start
-  if First < 0 then
-    First := Max(Len + First, 0)
-  else
-    First := Min(First, Len);
+    First := ToArrayBufferSliceIndex(AArgs.GetElement(0), Len);
 
   // ES2026 §25.1.6.8 step 11: If end is undefined, let relativeEnd be len
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
-  begin
-    EndNum := AArgs.GetElement(1).ToNumberLiteral;
-    if EndNum.IsNaN then
-      Final := 0
-    else
-      Final := Trunc(EndNum.Value);
-  end
+    Final := ToArrayBufferSliceIndex(AArgs.GetElement(1), Len)
   else
     Final := Len;
-
-  // Step 12-14: Clamp end
-  if Final < 0 then
-    Final := Max(Len + Final, 0)
-  else
-    Final := Min(Final, Len);
 
   // Side effects from argument coercion may have detached the receiver.
   EnsureArrayBufferAttached(Buf, SErrorCannotSliceDetachedArrayBuffer);
@@ -562,10 +587,40 @@ begin
   // Step 15: Let newLen be max(final - first, 0)
   NewLen := Max(Final - First, 0);
 
-  // Step 16-17: Create new ArrayBuffer and copy data
-  NewBuf := TGocciaArrayBufferValue.Create(NewLen);
-  if NewLen > 0 then
-    Move(Buf.FData[First], NewBuf.FData[0], NewLen);
+  SpeciesConstructor := ArrayBufferSpeciesConstructor(Buf);
+  if SpeciesConstructor is TGocciaUndefinedLiteralValue then
+    NewBuf := TGocciaArrayBufferValue.Create(NewLen)
+  else
+  begin
+    ConstructorArgs := TGocciaArgumentsCollection.Create(
+      [TGocciaNumberLiteralValue.Create(NewLen)]);
+    try
+      ConstructedValue := ConstructValue(SpeciesConstructor, ConstructorArgs,
+        SpeciesConstructor);
+    finally
+      ConstructorArgs.Free;
+    end;
+    if not (ConstructedValue is TGocciaArrayBufferValue) then
+      ThrowTypeError('ArrayBuffer species constructor did not return an ArrayBuffer',
+        SSuggestArrayBufferThisType);
+    if ConstructedValue = Buf then
+      ThrowTypeError('ArrayBuffer species constructor returned this',
+        SSuggestArrayBufferThisType);
+    NewBuf := TGocciaArrayBufferValue(ConstructedValue);
+    if Length(NewBuf.FData) < NewLen then
+      ThrowTypeError('ArrayBuffer species constructor returned a buffer that is too small',
+        SSuggestArrayBufferThisType);
+  end;
+
+  // Species construction can run user code that detaches or resizes O.
+  EnsureArrayBufferAttached(Buf, SErrorCannotSliceDetachedArrayBuffer);
+  CurrentLen := Length(Buf.FData);
+  if First < CurrentLen then
+  begin
+    CopyCount := Min(NewLen, CurrentLen - First);
+    if CopyCount > 0 then
+      Move(Buf.FData[First], NewBuf.FData[0], CopyCount);
+  end;
 
   Result := NewBuf;
 end;

--- a/source/units/Goccia.Values.ArrayBufferValue.pas
+++ b/source/units/Goccia.Values.ArrayBufferValue.pas
@@ -603,6 +603,9 @@ begin
     if not (ConstructedValue is TGocciaArrayBufferValue) then
       ThrowTypeError('ArrayBuffer species constructor did not return an ArrayBuffer',
         SSuggestArrayBufferThisType);
+    if TGocciaArrayBufferValue(ConstructedValue).Detached then
+      ThrowTypeError(SErrorCannotSliceDetachedArrayBuffer,
+        SSuggestArrayBufferDetached);
     if ConstructedValue = Buf then
       ThrowTypeError('ArrayBuffer species constructor returned this',
         SSuggestArrayBufferThisType);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -58,6 +58,8 @@ type
     FPrivateMethods: TOrderedStringMap<TGocciaMethodValue>;
     FPrivateGetters: TOrderedStringMap<TGocciaFunctionBase>;
     FPrivateSetters: TOrderedStringMap<TGocciaFunctionBase>;
+    FDeclaredPrivateNames: TStringList;
+    FDeclaredPrivateKeys: TStringList;
     FNativeSuperConstructor: TGocciaObjectValue;
     FPrivateBrandToken: string;
     FMethodInitializers: array of TGocciaValue;
@@ -109,6 +111,10 @@ type
     procedure AddPrivateStaticMethod(const AName: string; const AValue: TGocciaValue);
     procedure AddPrivateMethod(const AName: string; const AMethod: TGocciaMethodValue);
     function GetPrivateMethod(const AName: string): TGocciaMethodValue;
+    procedure DeclarePrivateName(const AName: string;
+      const AInternalKey: string = '');
+    function ResolveDeclaredPrivateKey(const AName: string;
+      out AInternalKey: string): Boolean;
     procedure AppendOwnPrivateNames(const ANames: TStrings);
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; virtual;
     function NativeInstanceDefaultPrototype: TGocciaObjectValue; virtual;
@@ -126,6 +132,7 @@ type
     function TryDefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor): Boolean; override;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
+    function GetAllPropertyNames: TArray<string>; override;
     function HasOwnProperty(const AName: string): Boolean; override;
     function DeleteProperty(const AName: string): Boolean; override;
     function Call(const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; virtual;
@@ -321,6 +328,7 @@ uses
   Generics.Collections,
   SysUtils,
 
+  Goccia.Arithmetic,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
@@ -377,6 +385,36 @@ begin
     AClassValue.FPrototype := FunctionPrototype;
 end;
 
+function ClassPrototypeDescriptorChangeAllowed(
+  const APrototype: TGocciaObjectValue;
+  const ADescriptor: TGocciaPropertyDescriptor): Boolean;
+var
+  DataDescriptor: TGocciaPropertyDescriptorData;
+begin
+  Result := False;
+  if not Assigned(ADescriptor) then
+    Exit(True);
+
+  if ADescriptor.HasConfigurableField and ADescriptor.Configurable then
+    Exit;
+  if ADescriptor.HasEnumerableField and ADescriptor.Enumerable then
+    Exit;
+  if IsAccessorDescriptor(ADescriptor) then
+    Exit;
+
+  if IsDataDescriptor(ADescriptor) then
+  begin
+    DataDescriptor := TGocciaPropertyDescriptorData(ADescriptor);
+    if ADescriptor.HasWritableField and DataDescriptor.Writable then
+      Exit;
+    if ADescriptor.HasValue and
+       not IsSameValue(APrototype, DataDescriptor.Value) then
+      Exit;
+  end;
+
+  Result := True;
+end;
+
 constructor TGocciaClassValue.Create(const AName: string; const ASuperClass: TGocciaClassValue);
 begin
   inherited Create;
@@ -399,6 +437,13 @@ begin
   FPrivateMethods := TOrderedStringMap<TGocciaMethodValue>.Create;
   FPrivateGetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
   FPrivateSetters := TOrderedStringMap<TGocciaFunctionBase>.Create;
+  FDeclaredPrivateNames := TStringList.Create;
+  FDeclaredPrivateNames.CaseSensitive := True;
+  FDeclaredPrivateNames.Sorted := False;
+  FDeclaredPrivateNames.Duplicates := dupIgnore;
+  FDeclaredPrivateKeys := TStringList.Create;
+  FDeclaredPrivateKeys.CaseSensitive := True;
+  FDeclaredPrivateKeys.Sorted := False;
   FNativeSuperConstructor := nil;
   FClassPrototype := TGocciaObjectValue.Create;
   FConstructorMethod := nil;
@@ -426,6 +471,8 @@ begin
   FPrivateMethods.Free;
   FPrivateGetters.Free;
   FPrivateSetters.Free;
+  FDeclaredPrivateNames.Free;
+  FDeclaredPrivateKeys.Free;
   // Don't free FClassPrototype - it's GC-managed
   inherited;
 end;
@@ -618,6 +665,10 @@ var
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingSetter: TGocciaValue;
 begin
+  if AName = PROP_PROTOTYPE then
+    ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [AName]),
+      SSuggestCannotDeleteNonConfigurable);
+
   ExistingDescriptor := inherited GetOwnPropertyDescriptor(AName);
   ExistingSetter := nil;
   if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
@@ -634,6 +685,10 @@ var
   ExistingDescriptor: TGocciaPropertyDescriptor;
   ExistingGetter: TGocciaValue;
 begin
+  if AName = PROP_PROTOTYPE then
+    ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [AName]),
+      SSuggestCannotDeleteNonConfigurable);
+
   ExistingDescriptor := inherited GetOwnPropertyDescriptor(AName);
   ExistingGetter := nil;
   if (ExistingDescriptor is TGocciaPropertyDescriptorAccessor) and
@@ -693,7 +748,8 @@ end;
 
 function TGocciaClassValue.HasOwnPrivateName(const AName: string): Boolean;
 begin
-  Result := FPrivateInstancePropertyDefs.ContainsKey(AName) or
+  Result := (FDeclaredPrivateNames.IndexOf(AName) >= 0) or
+    FPrivateInstancePropertyDefs.ContainsKey(AName) or
     FPrivateStaticProperties.ContainsKey(AName) or
     FPrivateStaticMethods.ContainsKey(AName) or
     FPrivateMethods.ContainsKey(AName) or
@@ -1031,21 +1087,28 @@ end;
 
 procedure TGocciaClassValue.AddPrivateInstanceProperty(const AName: string; const AExpression: TGocciaExpression);
 begin
+  DeclarePrivateName(AName);
   FPrivateInstancePropertyDefs.Add(AName, AExpression);
 end;
 
 procedure TGocciaClassValue.AddPrivateStaticProperty(const AName: string; const AValue: TGocciaValue);
 begin
+  DeclarePrivateName(AName);
+  if (not FPrivateStaticProperties.ContainsKey(AName)) and not Extensible then
+    ThrowTypeError('Cannot add private elements to a non-extensible object',
+      SSuggestObjectNotExtensible);
   FPrivateStaticProperties.AddOrSetValue(AName, AValue);
 end;
 
 procedure TGocciaClassValue.AddPrivateStaticMethod(const AName: string; const AValue: TGocciaValue);
 begin
+  DeclarePrivateName(AName);
   FPrivateStaticMethods.AddOrSetValue(AName, AValue);
 end;
 
 procedure TGocciaClassValue.AddPrivateMethod(const AName: string; const AMethod: TGocciaMethodValue);
 begin
+  DeclarePrivateName(AName);
   FPrivateMethods.AddOrSetValue(AName, AMethod);
 end;
 
@@ -1055,8 +1118,29 @@ begin
     Result := nil;
 end;
 
+procedure TGocciaClassValue.DeclarePrivateName(const AName: string;
+  const AInternalKey: string);
+begin
+  if AName = '' then
+    Exit;
+  if FDeclaredPrivateNames.IndexOf(AName) < 0 then
+    FDeclaredPrivateNames.Add(AName);
+  if AInternalKey <> '' then
+    FDeclaredPrivateKeys.Values[AName] := AInternalKey;
+end;
+
+function TGocciaClassValue.ResolveDeclaredPrivateKey(const AName: string;
+  out AInternalKey: string): Boolean;
+begin
+  AInternalKey := FDeclaredPrivateKeys.Values[AName];
+  Result := AInternalKey <> '';
+end;
+
 procedure TGocciaClassValue.AppendOwnPrivateNames(const ANames: TStrings);
 var
+  I: Integer;
+  DeclaredName: string;
+  DeclaredKey: string;
   PropertyPair: TGocciaExpressionMap.TKeyValuePair;
   StaticPair: TGocciaValueMap.TKeyValuePair;
   MethodPair: TOrderedStringMap<TGocciaMethodValue>.TKeyValuePair;
@@ -1064,6 +1148,16 @@ var
 begin
   if not Assigned(ANames) then
     Exit;
+
+  for I := 0 to FDeclaredPrivateNames.Count - 1 do
+  begin
+    DeclaredName := FDeclaredPrivateNames[I];
+    DeclaredKey := FDeclaredPrivateKeys.Values[DeclaredName];
+    if DeclaredKey = '' then
+      DeclaredKey := DeclaredName;
+    if ANames.IndexOf(DeclaredKey) < 0 then
+      ANames.Add(DeclaredKey);
+  end;
 
   for PropertyPair in FPrivateInstancePropertyDefs do
     if ANames.IndexOf(PropertyPair.Key) < 0 then
@@ -1399,6 +1493,18 @@ end;
 procedure TGocciaClassValue.DefineProperty(const AName: string;
   const ADescriptor: TGocciaPropertyDescriptor);
 begin
+  if AName = PROP_PROTOTYPE then
+  begin
+    if ClassPrototypeDescriptorChangeAllowed(FClassPrototype, ADescriptor) then
+    begin
+      ADescriptor.Free;
+      Exit;
+    end;
+    ADescriptor.Free;
+    ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [AName]),
+      SSuggestCannotDeleteNonConfigurable);
+  end;
+
   if AName = PROP_NAME then
     FNameDeleted := False
   else if AName = PROP_LENGTH then
@@ -1409,6 +1515,17 @@ end;
 function TGocciaClassValue.TryDefineProperty(const AName: string;
   const ADescriptor: TGocciaPropertyDescriptor): Boolean;
 begin
+  if AName = PROP_PROTOTYPE then
+  begin
+    if ClassPrototypeDescriptorChangeAllowed(FClassPrototype, ADescriptor) then
+    begin
+      ADescriptor.Free;
+      Exit(True);
+    end;
+    ADescriptor.Free;
+    Exit(False);
+  end;
+
   Result := inherited TryDefineProperty(AName, ADescriptor);
   if Result then
   begin
@@ -1496,6 +1613,42 @@ begin
   end
   else
     Result := inherited GetOwnPropertyDescriptor(AName);
+end;
+
+function TGocciaClassValue.GetAllPropertyNames: TArray<string>;
+var
+  OwnNames: TArray<string>;
+  Count: Integer;
+  I: Integer;
+
+  procedure AppendName(const AName: string);
+  var
+    J: Integer;
+  begin
+    for J := 0 to Count - 1 do
+      if Result[J] = AName then
+        Exit;
+    if Count >= Length(Result) then
+      SetLength(Result, Count + 8);
+    Result[Count] := AName;
+    Inc(Count);
+  end;
+
+begin
+  OwnNames := inherited GetAllPropertyNames;
+  SetLength(Result, Length(OwnNames) + 3);
+  Count := 0;
+
+  if not FLengthDeleted then
+    AppendName(PROP_LENGTH);
+  if not FNameDeleted then
+    AppendName(PROP_NAME);
+  AppendName(PROP_PROTOTYPE);
+
+  for I := 0 to High(OwnNames) do
+    AppendName(OwnNames[I]);
+
+  SetLength(Result, Count);
 end;
 
 function TGocciaClassValue.HasOwnProperty(const AName: string): Boolean;

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -26,12 +26,6 @@ type
     function FunctionToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
-  TFunctionRestrictedPropertyHost = class
-  public
-    function ThrowTypeError(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
-  end;
-
   // Base class for all callable functions
   TGocciaFunctionBase = class(TGocciaObjectValue)
   protected
@@ -180,7 +174,6 @@ uses
 // (Function.prototype.foo = ...) must not leak across engine recreation.
 var
   GFunctionPrototypeSlot: TGocciaRealmSlotId;
-  GFunctionRestrictedPropertyHost: TFunctionRestrictedPropertyHost;
 
 function GetSharedFunctionPrototype: TGocciaFunctionSharedPrototype; inline;
 begin
@@ -188,23 +181,6 @@ begin
     Result := TGocciaFunctionSharedPrototype(CurrentRealm.GetSlot(GFunctionPrototypeSlot))
   else
     Result := nil;
-end;
-
-function TFunctionRestrictedPropertyHost.ThrowTypeError(
-  const AArgs: TGocciaArgumentsCollection;
-  const AThisValue: TGocciaValue): TGocciaValue;
-begin
-  Goccia.Values.ErrorHelper.ThrowTypeError(
-    '''caller'' and ''arguments'' properties may not be accessed');
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-end;
-
-function CreateFunctionRestrictedThrower: TGocciaNativeFunctionValue;
-begin
-  if not Assigned(GFunctionRestrictedPropertyHost) then
-    GFunctionRestrictedPropertyHost := TFunctionRestrictedPropertyHost.Create;
-  Result := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-    GFunctionRestrictedPropertyHost.ThrowTypeError, 'ThrowTypeError', 0);
 end;
 
 function GetProtoFromConstructor(const ANewTarget: TGocciaValue): TGocciaObjectValue;
@@ -645,7 +621,6 @@ end;
 constructor TGocciaFunctionSharedPrototype.Create;
 var
   Members: array[0..3] of TGocciaMemberDefinition;
-  Thrower: TGocciaNativeFunctionValue;
 begin
   inherited Create;
 
@@ -661,11 +636,6 @@ begin
       TGocciaNumberLiteralValue.ZeroValue, [pfConfigurable]));
     DefineProperty(PROP_NAME, TGocciaPropertyDescriptorData.Create(
       TGocciaStringLiteralValue.Create(''), [pfConfigurable]));
-    Thrower := CreateFunctionRestrictedThrower;
-    DefineProperty(PROP_CALLER, TGocciaPropertyDescriptorAccessor.Create(
-      Thrower, Thrower, []));
-    DefineProperty(PROP_ARGUMENTS, TGocciaPropertyDescriptorAccessor.Create(
-      Thrower, Thrower, []));
     Members[0] := DefineNamedMethod('call', FunctionCall, 1);
     Members[1] := DefineNamedMethod('apply', FunctionApply, 2);
     Members[2] := DefineNamedMethod('bind', FunctionBind, 1);
@@ -1117,8 +1087,5 @@ end;
 
 initialization
   GFunctionPrototypeSlot := RegisterRealmSlot('Function.prototype');
-
-finalization
-  GFunctionRestrictedPropertyHost.Free;
 
 end.

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -26,6 +26,12 @@ type
     function FunctionToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
+  TFunctionRestrictedPropertyHost = class
+  public
+    function ThrowTypeError(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
   // Base class for all callable functions
   TGocciaFunctionBase = class(TGocciaObjectValue)
   protected
@@ -174,6 +180,7 @@ uses
 // (Function.prototype.foo = ...) must not leak across engine recreation.
 var
   GFunctionPrototypeSlot: TGocciaRealmSlotId;
+  GFunctionRestrictedPropertyHost: TFunctionRestrictedPropertyHost;
 
 function GetSharedFunctionPrototype: TGocciaFunctionSharedPrototype; inline;
 begin
@@ -181,6 +188,23 @@ begin
     Result := TGocciaFunctionSharedPrototype(CurrentRealm.GetSlot(GFunctionPrototypeSlot))
   else
     Result := nil;
+end;
+
+function TFunctionRestrictedPropertyHost.ThrowTypeError(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Goccia.Values.ErrorHelper.ThrowTypeError(
+    '''caller'' and ''arguments'' properties may not be accessed');
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function CreateFunctionRestrictedThrower: TGocciaNativeFunctionValue;
+begin
+  if not Assigned(GFunctionRestrictedPropertyHost) then
+    GFunctionRestrictedPropertyHost := TFunctionRestrictedPropertyHost.Create;
+  Result := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    GFunctionRestrictedPropertyHost.ThrowTypeError, 'ThrowTypeError', 0);
 end;
 
 function GetProtoFromConstructor(const ANewTarget: TGocciaValue): TGocciaObjectValue;
@@ -515,10 +539,11 @@ end;
 
 function TGocciaFunctionBase.IsConstructable: Boolean;
 begin
-  Result := HasOwnProperty(PROP_PROTOTYPE);
-  if (not Result) and (Self is TGocciaBoundFunctionValue) and
+  if (Self is TGocciaBoundFunctionValue) and
      Assigned(TGocciaBoundFunctionValue(Self).OriginalFunction) then
-    Result := TGocciaBoundFunctionValue(Self).OriginalFunction.IsConstructable;
+    Exit(TGocciaBoundFunctionValue(Self).OriginalFunction.IsConstructable);
+
+  Result := HasOwnProperty(PROP_PROTOTYPE);
 end;
 
 function TGocciaFunctionBase.TypeName: string;
@@ -620,6 +645,7 @@ end;
 constructor TGocciaFunctionSharedPrototype.Create;
 var
   Members: array[0..3] of TGocciaMemberDefinition;
+  Thrower: TGocciaNativeFunctionValue;
 begin
   inherited Create;
 
@@ -635,6 +661,11 @@ begin
       TGocciaNumberLiteralValue.ZeroValue, [pfConfigurable]));
     DefineProperty(PROP_NAME, TGocciaPropertyDescriptorData.Create(
       TGocciaStringLiteralValue.Create(''), [pfConfigurable]));
+    Thrower := CreateFunctionRestrictedThrower;
+    DefineProperty(PROP_CALLER, TGocciaPropertyDescriptorAccessor.Create(
+      Thrower, Thrower, []));
+    DefineProperty(PROP_ARGUMENTS, TGocciaPropertyDescriptorAccessor.Create(
+      Thrower, Thrower, []));
     Members[0] := DefineNamedMethod('call', FunctionCall, 1);
     Members[1] := DefineNamedMethod('apply', FunctionApply, 2);
     Members[2] := DefineNamedMethod('bind', FunctionBind, 1);
@@ -1086,5 +1117,8 @@ end;
 
 initialization
   GFunctionPrototypeSlot := RegisterRealmSlot('Function.prototype');
+
+finalization
+  GFunctionRestrictedPropertyHost.Free;
 
 end.

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -13,6 +13,7 @@ uses
   Goccia.Arguments.Collection,
   Goccia.AST.Expressions,
   Goccia.AST.Node,
+  Goccia.Evaluator.Context,
   Goccia.Scope,
   Goccia.Values.FunctionBase,
   Goccia.Values.Primitives;
@@ -35,6 +36,8 @@ type
     procedure BindThis(const ACallScope: TGocciaScope; const AThisValue: TGocciaValue); virtual;
     function CreateCallScope: TGocciaScope; virtual;
     function CreatesArgumentsObject: Boolean; virtual;
+    function BuildParameterEvalVarDeclarationRejectNames(
+      const AIncludeArgumentsObject: Boolean): TGocciaEvalRejectNameArray;
     function ExecuteBody(const ACallScope: TGocciaScope; const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AParameters: TGocciaParameterArray; const ABodyStatements: TObjectList<TGocciaASTNode>; const AClosure: TGocciaScope; const AName: string = '');
@@ -84,6 +87,7 @@ type
 implementation
 
 uses
+  Classes,
   SysUtils,
 
   Goccia.AST.BindingPatterns,
@@ -95,7 +99,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Evaluator,
-  Goccia.Evaluator.Context,
   Goccia.GarbageCollector,
   Goccia.Realm,
   Goccia.Types.Enforcement,
@@ -172,10 +175,43 @@ begin
   Result := True;
 end;
 
+function TGocciaFunctionValue.BuildParameterEvalVarDeclarationRejectNames(
+  const AIncludeArgumentsObject: Boolean): TGocciaEvalRejectNameArray;
+var
+  Names: TStringList;
+  I, J: Integer;
+  procedure AddName(const AName: string);
+  begin
+    if (AName <> '') and (Names.IndexOf(AName) < 0) then
+      Names.Add(AName);
+  end;
+begin
+  Names := TStringList.Create;
+  try
+    Names.CaseSensitive := True;
+    if AIncludeArgumentsObject then
+      AddName(IDENTIFIER_ARGUMENTS);
+    for I := 0 to High(FParameters) do
+    begin
+      if FParameters[I].IsPattern then
+        CollectPatternBindingNames(FParameters[I].Pattern, Names, True)
+      else
+        AddName(FParameters[I].Name);
+    end;
+
+    SetLength(Result, Names.Count);
+    for J := 0 to Names.Count - 1 do
+      Result[J] := Names[J];
+  finally
+    Names.Free;
+  end;
+end;
+
 function TGocciaFunctionValue.ExecuteBody(const ACallScope: TGocciaScope; const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   I, J: Integer;
   CompatibilityNonStrictMode: Boolean;
+  EvalRejectNames, SavedEvalRejectNames: TGocciaEvalRejectNameArray;
   ReturnValue: TGocciaValue;
   CF: TGocciaControlFlow;
   Context: TGocciaEvaluationContext;
@@ -187,12 +223,15 @@ var
   begin
     SavedRejectArgumentsVarDeclaration :=
       Context.RejectArgumentsVarDeclarationInEval;
+    SavedEvalRejectNames := Context.RejectVarDeclarationNamesInEval;
     Context.RejectArgumentsVarDeclarationInEval := CreatesArgumentsObject;
+    Context.RejectVarDeclarationNamesInEval := EvalRejectNames;
     try
       Result := EvaluateExpression(AExpression, Context);
     finally
       Context.RejectArgumentsVarDeclarationInEval :=
         SavedRejectArgumentsVarDeclaration;
+      Context.RejectVarDeclarationNamesInEval := SavedEvalRejectNames;
     end;
   end;
 begin
@@ -215,6 +254,9 @@ begin
   CompatibilityNonStrictMode := FClosure.EffectiveNonStrictMode;
   Context.NonStrictMode := CompatibilityNonStrictMode and not FStrictCode;
   Context.DisposalTracker := nil;
+  EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
+    CompatibilityNonStrictMode and CreatesArgumentsObject and
+    not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS));
 
   // Record coverage hit on the declaration line (get/set/constructor/method)
   if Context.CoverageEnabled and (FSourceLine > 0) and (FSourceFilePath <> '') then

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -94,6 +94,7 @@ uses
   SysUtils,
 
   Goccia.AST.BindingPatterns,
+  Goccia.AST.Expressions,
   Goccia.AST.Statements,
   Goccia.Bytecode.Chunk,
   Goccia.Constants,
@@ -622,6 +623,25 @@ var
   Context: TGocciaEvaluationContext;
   ParamTypeHint: TGocciaLocalType;
   CompatibilityNonStrictMode: Boolean;
+  EvalRejectNames, SavedEvalRejectNames: TGocciaEvalRejectNameArray;
+  function EvaluateParameterDefault(
+    const AExpression: TGocciaExpression): TGocciaValue;
+  var
+    SavedRejectArgumentsVarDeclaration: Boolean;
+  begin
+    SavedRejectArgumentsVarDeclaration :=
+      Context.RejectArgumentsVarDeclarationInEval;
+    SavedEvalRejectNames := Context.RejectVarDeclarationNamesInEval;
+    Context.RejectArgumentsVarDeclarationInEval := CreatesArgumentsObject;
+    Context.RejectVarDeclarationNamesInEval := EvalRejectNames;
+    try
+      Result := EvaluateExpression(AExpression, Context);
+    finally
+      Context.RejectArgumentsVarDeclarationInEval :=
+        SavedRejectArgumentsVarDeclaration;
+      Context.RejectVarDeclarationNamesInEval := SavedEvalRejectNames;
+    end;
+  end;
 begin
   CallScope := CreateCallScope;
   BindThis(CallScope, AThisValue);
@@ -641,6 +661,9 @@ begin
   CompatibilityNonStrictMode := FClosure.EffectiveNonStrictMode;
   Context.NonStrictMode := CompatibilityNonStrictMode and not FStrictCode;
   Context.DisposalTracker := nil;
+  EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
+    CompatibilityNonStrictMode and CreatesArgumentsObject and
+    not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS));
 
   if CompatibilityNonStrictMode and CreatesArgumentsObject and
      not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS) and
@@ -679,7 +702,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Assigned(FParameters[I].DefaultValue) and
          (Value is TGocciaUndefinedLiteralValue) then
-        Value := EvaluateExpression(FParameters[I].DefaultValue, Context);
+        Value := EvaluateParameterDefault(FParameters[I].DefaultValue);
 
       // Mirrors TGocciaFunctionValue.ExecuteBody's IsPattern branch:
       // enforce on the raw pre-destructured value (defaults and
@@ -705,7 +728,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Assigned(FParameters[I].DefaultValue) and
          (Value is TGocciaUndefinedLiteralValue) then
-        Value := EvaluateExpression(FParameters[I].DefaultValue, Context);
+        Value := EvaluateParameterDefault(FParameters[I].DefaultValue);
       CallScope.DefineLexicalBinding(FParameters[I].Name, Value, dtParameter);
     end;
   end;

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -813,6 +813,25 @@ var
   Context: TGocciaEvaluationContext;
   ParamTypeHint: TGocciaLocalType;
   CompatibilityNonStrictMode: Boolean;
+  EvalRejectNames, SavedEvalRejectNames: TGocciaEvalRejectNameArray;
+  function EvaluateParameterDefault(
+    const AExpression: TGocciaExpression): TGocciaValue;
+  var
+    SavedRejectArgumentsVarDeclaration: Boolean;
+  begin
+    SavedRejectArgumentsVarDeclaration :=
+      Context.RejectArgumentsVarDeclarationInEval;
+    SavedEvalRejectNames := Context.RejectVarDeclarationNamesInEval;
+    Context.RejectArgumentsVarDeclarationInEval := CreatesArgumentsObject;
+    Context.RejectVarDeclarationNamesInEval := EvalRejectNames;
+    try
+      Result := EvaluateExpression(AExpression, Context);
+    finally
+      Context.RejectArgumentsVarDeclarationInEval :=
+        SavedRejectArgumentsVarDeclaration;
+      Context.RejectVarDeclarationNamesInEval := SavedEvalRejectNames;
+    end;
+  end;
 begin
   CallScope := CreateCallScope;
   BindThis(CallScope, AThisValue);
@@ -830,6 +849,9 @@ begin
   CompatibilityNonStrictMode := FClosure.EffectiveNonStrictMode;
   Context.NonStrictMode := CompatibilityNonStrictMode and not FStrictCode;
   Context.DisposalTracker := nil;
+  EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
+    CompatibilityNonStrictMode and CreatesArgumentsObject and
+    not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS));
 
   if CompatibilityNonStrictMode and CreatesArgumentsObject and
      not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS) and
@@ -866,7 +888,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Assigned(FParameters[I].DefaultValue) and
          (Value is TGocciaUndefinedLiteralValue) then
-        Value := EvaluateExpression(FParameters[I].DefaultValue, Context);
+        Value := EvaluateParameterDefault(FParameters[I].DefaultValue);
 
       // Mirrors TGocciaFunctionValue.ExecuteBody's IsPattern branch.
       if Context.StrictTypes
@@ -889,7 +911,7 @@ begin
         Value := TGocciaUndefinedLiteralValue.UndefinedValue;
       if Assigned(FParameters[I].DefaultValue) and
          (Value is TGocciaUndefinedLiteralValue) then
-        Value := EvaluateExpression(FParameters[I].DefaultValue, Context);
+        Value := EvaluateParameterDefault(FParameters[I].DefaultValue);
       CallScope.DefineLexicalBinding(FParameters[I].Name, Value, dtParameter);
     end;
   end;

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -270,7 +270,8 @@ begin
   if not Assigned(CurrentRealm) then Exit;
   if Assigned(GetSharedIteratorPrototype) then Exit;
 
-  SharedPrototype := TGocciaObjectValue.Create;
+  SharedPrototype := TGocciaObjectValue.Create(
+    TGocciaObjectValue.SharedObjectPrototype);
   CurrentRealm.SetSlot(GIteratorPrototypeSlot, SharedPrototype);
   if Length(FPrototypeMembers) = 0 then
   begin

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -169,6 +169,7 @@ var
   InitArg: TGocciaValue;
   ArrValue: TGocciaArrayValue;
   EntryArr: TGocciaArrayValue;
+  EntryObj: TGocciaObjectValue;
   I: Integer;
 begin
   if AArguments.Length = 0 then
@@ -184,6 +185,12 @@ begin
         EntryArr := TGocciaArrayValue(ArrValue.Elements[I]);
         if EntryArr.Elements.Count >= 2 then
           SetEntry(EntryArr.Elements[0], EntryArr.Elements[1]);
+      end
+      else if Assigned(ArrValue.Elements[I]) and
+              (ArrValue.Elements[I] is TGocciaObjectValue) then
+      begin
+        EntryObj := TGocciaObjectValue(ArrValue.Elements[I]);
+        SetEntry(EntryObj.GetProperty('0'), EntryObj.GetProperty('1'));
       end;
     end;
   end;

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -920,8 +920,20 @@ begin
 end;
 
 function TGocciaObjectValue.GetOwnPropertyKeys: TArray<string>;
+var
+  Key: string;
+  Count: Integer;
 begin
-  Result := FProperties.Keys;
+  SetLength(Result, FProperties.Count);
+  Count := 0;
+  for Key in FProperties.Keys do
+  begin
+    if IsBytecodePrivateInitializerMarker(Key) then
+      Continue;
+    Result[Count] := Key;
+    Inc(Count);
+  end;
+  SetLength(Result, Count);
 end;
 
 

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -144,6 +144,13 @@ threadvar
 
 const
   MAX_PROTOTYPE_CHAIN_DEPTH = 256;
+  BYTECODE_PRIVATE_INITIALIZED_PREFIX = '#initialized:';
+
+function IsBytecodePrivateInitializerMarker(const AName: string): Boolean;
+begin
+  Result := Copy(AName, 1, Length(BYTECODE_PRIVATE_INITIALIZED_PREFIX)) =
+    BYTECODE_PRIVATE_INITIALIZED_PREFIX;
+end;
 
 // Local ToObject variant for Object.prototype methods.  Keeping this here
 // avoids a unit cycle with the shared ToObject unit.
@@ -1120,8 +1127,20 @@ begin
 end;
 
 function TGocciaObjectValue.GetAllPropertyNames: TArray<string>;
+var
+  Key: string;
+  Count: Integer;
 begin
-  Result := FProperties.Keys;
+  SetLength(Result, FProperties.Count);
+  Count := 0;
+  for Key in FProperties.Keys do
+  begin
+    if IsBytecodePrivateInitializerMarker(Key) then
+      Continue;
+    Result[Count] := Key;
+    Inc(Count);
+  end;
+  SetLength(Result, Count);
 end;
 
 { Symbol property methods }

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -405,6 +405,9 @@ begin
     Exit(TGocciaStringLiteralValue.Create(
       UTF16CodeUnitAt(StringValue, Index)));
 
+  if AName = PROP_LENGTH then
+    Exit(TGocciaNumberLiteralValue.Create(UTF16CodeUnitLength(StringValue)));
+
   Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -73,6 +73,7 @@ type
     procedure AssignProperty(const AName: string; const AValue: TGocciaValue; const ACanCreate: Boolean = True); override;
     function AssignPropertyWithReceiver(const AName: string; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean; override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
+    function HasProperty(const AName: string): Boolean; override;
     function HasOwnProperty(const AName: string): Boolean; override;
     function ToStringTag: string; override;
 
@@ -986,6 +987,18 @@ begin
   end;
 
   Result := inherited GetOwnPropertyDescriptor(AName);
+end;
+
+function TGocciaTypedArrayValue.HasProperty(const AName: string): Boolean;
+var
+  IsNegativeZero: Boolean;
+  Index: Integer;
+  NumericIndex: Double;
+begin
+  if TryCanonicalNumericIndexString(AName, NumericIndex, IsNegativeZero) then
+    Exit(IsValidIntegerIndexedElement(NumericIndex, IsNegativeZero, Index));
+
+  Result := inherited HasProperty(AName);
 end;
 
 function TGocciaTypedArrayValue.HasOwnProperty(const AName: string): Boolean;

--- a/tests/built-ins/ArrayBuffer/prototype/slice.js
+++ b/tests/built-ins/ArrayBuffer/prototype/slice.js
@@ -179,4 +179,19 @@ describe("ArrayBuffer.prototype.slice edge cases", () => {
     expect(sliced instanceof ArrayBuffer).toBe(true);
     expect(sliced.byteLength).toBe(4);
   });
+
+  test("throws when species constructor returns a detached ArrayBuffer", () => {
+    class DetachedArrayBuffer {
+      constructor(length) {
+        const buffer = new ArrayBuffer(length);
+        buffer.transfer();
+        return buffer;
+      }
+    }
+
+    const buf = new ArrayBuffer(8);
+    buf.constructor = { [Symbol.species]: DetachedArrayBuffer };
+
+    expect(() => buf.slice(0, 0)).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/ArrayBuffer/prototype/slice.js
+++ b/tests/built-ins/ArrayBuffer/prototype/slice.js
@@ -165,4 +165,18 @@ describe("ArrayBuffer.prototype.slice edge cases", () => {
     const sliced = buf.slice(0, 4);
     expect(sliced instanceof SharedArrayBuffer).toBe(false);
   });
+
+  test("uses constructor Symbol.species override", () => {
+    class DerivedArrayBuffer extends ArrayBuffer {
+      static get [Symbol.species]() {
+        return ArrayBuffer;
+      }
+    }
+
+    const buf = new DerivedArrayBuffer(8);
+    const sliced = buf.slice(0, 4);
+    expect(sliced instanceof DerivedArrayBuffer).toBe(false);
+    expect(sliced instanceof ArrayBuffer).toBe(true);
+    expect(sliced.byteLength).toBe(4);
+  });
 });

--- a/tests/built-ins/ArrayBuffer/prototype/slice.js
+++ b/tests/built-ins/ArrayBuffer/prototype/slice.js
@@ -148,6 +148,14 @@ describe("ArrayBuffer.prototype.slice edge cases", () => {
     expect(buf.slice(0, NaN).byteLength).toBe(0);
   });
 
+  test("negative fractional indexes truncate toward zero before clamping", () => {
+    const buf = new ArrayBuffer(8);
+    expect(buf.slice(-0.5).byteLength).toBe(8);
+    expect(buf.slice(0, -0.5).byteLength).toBe(0);
+    expect(buf.slice(-1.5).byteLength).toBe(1);
+    expect(buf.slice(0, -1.5).byteLength).toBe(7);
+  });
+
   test("both NaN gives empty buffer", () => {
     const buf = new ArrayBuffer(8);
     expect(buf.slice(NaN, NaN).byteLength).toBe(0);

--- a/tests/built-ins/Goccia/shims.js
+++ b/tests/built-ins/Goccia/shims.js
@@ -16,6 +16,12 @@ describe.runIf(hasGoccia)("Goccia.shims", () => {
     expect(Goccia.shims).toContain("parseInt");
     expect(Goccia.shims).toContain("parseFloat");
     expect(Goccia.shims).toContain("Date");
+    expect(Goccia.shims).toContain("hasOwnProperty");
+    expect(Goccia.shims).toContain("__proto__");
+    expect(Goccia.shims).toContain("defineGetter");
+    expect(Goccia.shims).toContain("defineSetter");
+    expect(Goccia.shims).toContain("lookupGetter");
+    expect(Goccia.shims).toContain("lookupSetter");
   });
 
   test("shims is read-only", () => {

--- a/tests/built-ins/Object/prototype/defineGetter-defineSetter.js
+++ b/tests/built-ins/Object/prototype/defineGetter-defineSetter.js
@@ -1,0 +1,59 @@
+/*---
+description: Object.prototype.__defineGetter__ and __defineSetter__
+features: [Object.prototype.__defineGetter__, Object.prototype.__defineSetter__]
+---*/
+
+const hasDefineAccessors =
+  typeof Object !== 'undefined' &&
+  typeof Object.prototype.__defineGetter__ === 'function' &&
+  typeof Object.prototype.__defineSetter__ === 'function';
+
+describe.runIf(hasDefineAccessors)('Object.prototype.__defineGetter__ and __defineSetter__', () => {
+  test('defines enumerable configurable accessors', () => {
+    const obj = {};
+    const getter = () => 1;
+    const setter = (value) => value;
+
+    expect(obj.__defineGetter__('value', getter)).toBe(undefined);
+    expect(obj.__defineSetter__('value', setter)).toBe(undefined);
+
+    const descriptor = Object.getOwnPropertyDescriptor(obj, 'value');
+    expect(descriptor.get).toBe(getter);
+    expect(descriptor.set).toBe(setter);
+    expect(descriptor.enumerable).toBe(true);
+    expect(descriptor.configurable).toBe(true);
+  });
+
+  test('preserves symbol property keys', () => {
+    const key = Symbol('value');
+    const obj = {};
+    const getter = () => 2;
+    const setter = (value) => value;
+
+    obj.__defineGetter__(key, getter);
+    obj.__defineSetter__(key, setter);
+
+    const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+    expect(descriptor.get).toBe(getter);
+    expect(descriptor.set).toBe(setter);
+  });
+
+  test('rejects non-callable accessors before coercing the key', () => {
+    const obj = {};
+    const key = {
+      toString() {
+        throw new Error('key should not be coerced');
+      }
+    };
+
+    expect(() => obj.__defineGetter__(key, 1)).toThrow(TypeError);
+    expect(() => obj.__defineSetter__(key, 1)).toThrow(TypeError);
+  });
+
+  test('has standard function metadata', () => {
+    expect(Object.prototype.__defineGetter__.name).toBe('__defineGetter__');
+    expect(Object.prototype.__defineGetter__.length).toBe(2);
+    expect(Object.prototype.__defineSetter__.name).toBe('__defineSetter__');
+    expect(Object.prototype.__defineSetter__.length).toBe(2);
+  });
+});

--- a/tests/built-ins/Object/prototype/lookupGetter-lookupSetter.js
+++ b/tests/built-ins/Object/prototype/lookupGetter-lookupSetter.js
@@ -1,0 +1,99 @@
+/*---
+description: Object.prototype.__lookupGetter__ and __lookupSetter__
+features: [Object.prototype.__lookupGetter__, Object.prototype.__lookupSetter__]
+---*/
+
+const hasLookupAccessors =
+  typeof Object !== 'undefined' &&
+  typeof Object.prototype.__lookupGetter__ === 'function' &&
+  typeof Object.prototype.__lookupSetter__ === 'function';
+
+describe.runIf(hasLookupAccessors)('Object.prototype.__lookupGetter__ and __lookupSetter__', () => {
+  test('finds own string accessors', () => {
+    const obj = {};
+    const getter = () => 1;
+    const setter = (value) => value;
+    Object.defineProperty(obj, 'value', {
+      get: getter,
+      set: setter,
+      configurable: true
+    });
+
+    expect(obj.__lookupGetter__('value')).toBe(getter);
+    expect(obj.__lookupSetter__('value')).toBe(setter);
+  });
+
+  test('finds inherited accessors', () => {
+    const parent = {};
+    const child = Object.create(parent);
+    const getter = () => 2;
+    const setter = (value) => value;
+    Object.defineProperty(parent, 'value', {
+      get: getter,
+      set: setter,
+      configurable: true
+    });
+
+    expect(child.__lookupGetter__('value')).toBe(getter);
+    expect(child.__lookupSetter__('value')).toBe(setter);
+  });
+
+  test('preserves symbol property keys', () => {
+    const key = Symbol('value');
+    const obj = {};
+    const getter = () => 3;
+    const setter = (value) => value;
+    Object.defineProperty(obj, key, {
+      get: getter,
+      set: setter,
+      configurable: true
+    });
+
+    expect(obj.__lookupGetter__(key)).toBe(getter);
+    expect(obj.__lookupSetter__(key)).toBe(setter);
+  });
+
+  test('coerces property keys once before walking prototypes', () => {
+    let getterCoercions = 0;
+    let setterCoercions = 0;
+    const getterKey = {
+      toString() {
+        getterCoercions++;
+        return 'getterValue';
+      }
+    };
+    const setterKey = {
+      toString() {
+        setterCoercions++;
+        return 'setterValue';
+      }
+    };
+    const parent = {};
+    const child = Object.create(parent);
+    const getter = () => 5;
+    const setter = (value) => value;
+
+    Object.defineProperty(parent, 'getterValue', {
+      get: getter,
+      configurable: true
+    });
+    Object.defineProperty(parent, 'setterValue', {
+      set: setter,
+      configurable: true
+    });
+
+    expect(child.__lookupGetter__(getterKey)).toBe(getter);
+    expect(child.__lookupSetter__(setterKey)).toBe(setter);
+    expect(getterCoercions).toBe(1);
+    expect(setterCoercions).toBe(1);
+  });
+
+  test('returns undefined for data descriptors and missing properties', () => {
+    const obj = { value: 4 };
+
+    expect(obj.__lookupGetter__('value')).toBe(undefined);
+    expect(obj.__lookupSetter__('value')).toBe(undefined);
+    expect(obj.__lookupGetter__('missing')).toBe(undefined);
+    expect(obj.__lookupSetter__('missing')).toBe(undefined);
+  });
+});

--- a/tests/built-ins/Object/prototype/proto.js
+++ b/tests/built-ins/Object/prototype/proto.js
@@ -1,0 +1,64 @@
+/*---
+description: Object.prototype.__proto__
+features: [Object.prototype.__proto__]
+---*/
+
+const hasProtoAccessor =
+  typeof Object !== 'undefined' &&
+  Object.getOwnPropertyDescriptor(Object.prototype, '__proto__') !== undefined;
+
+describe.runIf(hasProtoAccessor)('Object.prototype.__proto__', () => {
+  test('is a configurable non-enumerable accessor', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, '__proto__');
+
+    expect(typeof descriptor.get).toBe('function');
+    expect(typeof descriptor.set).toBe('function');
+    expect(descriptor.enumerable).toBe(false);
+    expect(descriptor.configurable).toBe(true);
+  });
+
+  test('getter returns the receiver prototype', () => {
+    const proto = { marker: true };
+    const obj = Object.create(proto);
+
+    expect(obj.__proto__).toBe(proto);
+  });
+
+  test('setter changes the receiver prototype', () => {
+    const proto = { marker: true };
+    const obj = {};
+
+    obj.__proto__ = proto;
+
+    expect(Object.getPrototypeOf(obj)).toBe(proto);
+    expect(obj.marker).toBe(true);
+  });
+
+  test('setter accepts null', () => {
+    const obj = {};
+
+    obj.__proto__ = null;
+
+    expect(Object.getPrototypeOf(obj)).toBe(null);
+  });
+
+  test('setter ignores non-object prototype values', () => {
+    const obj = {};
+    const original = Object.getPrototypeOf(obj);
+
+    obj.__proto__ = 1;
+    expect(Object.getPrototypeOf(obj)).toBe(original);
+
+    obj.__proto__ = 'not a prototype';
+    expect(Object.getPrototypeOf(obj)).toBe(original);
+  });
+
+  test('accessor rejects nullish receivers', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, '__proto__');
+
+    expect(() => descriptor.get.call(null)).toThrow(TypeError);
+    expect(() => descriptor.get.call(undefined)).toThrow(TypeError);
+    expect(() => descriptor.set.call(null, {})).toThrow(TypeError);
+    expect(() => descriptor.set.call(undefined, {})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Reflect/construct/native-constructors.js
+++ b/tests/built-ins/Reflect/construct/native-constructors.js
@@ -109,7 +109,7 @@ describe("Reflect.construct with native RegExp constructor", () => {
   test("RegExp source captured before newTarget prototype getter fires", () => {
     let getterFired = false;
     const re = Reflect.construct(RegExp, [/abc/],
-      Object.defineProperty(function Target() {}.bind(null), "prototype", {
+      Object.defineProperty((class Target {}).bind(null), "prototype", {
         get() { getterFired = true; return RegExp.prototype; },
       }));
     expect(getterFired).toBe(true);
@@ -123,7 +123,7 @@ describe("Reflect.construct with native RegExp constructor", () => {
       return "g";
     }};
     const re = Reflect.construct(RegExp, [/abc/, flags],
-      Object.defineProperty(function Target() {}.bind(null), "prototype", {
+      Object.defineProperty((class Target {}).bind(null), "prototype", {
         get() { didLookup = true; return RegExp.prototype; },
       }));
     expect(re.flags).toBe("g");

--- a/tests/built-ins/Reflect/construct/native-constructors.js
+++ b/tests/built-ins/Reflect/construct/native-constructors.js
@@ -109,7 +109,7 @@ describe("Reflect.construct with native RegExp constructor", () => {
   test("RegExp source captured before newTarget prototype getter fires", () => {
     let getterFired = false;
     const re = Reflect.construct(RegExp, [/abc/],
-      Object.defineProperty((() => {}).bind(null), "prototype", {
+      Object.defineProperty(function Target() {}.bind(null), "prototype", {
         get() { getterFired = true; return RegExp.prototype; },
       }));
     expect(getterFired).toBe(true);
@@ -123,7 +123,7 @@ describe("Reflect.construct with native RegExp constructor", () => {
       return "g";
     }};
     const re = Reflect.construct(RegExp, [/abc/, flags],
-      Object.defineProperty((() => {}).bind(null), "prototype", {
+      Object.defineProperty(function Target() {}.bind(null), "prototype", {
         get() { didLookup = true; return RegExp.prototype; },
       }));
     expect(re.flags).toBe("g");

--- a/tests/language/classes/basic-class-declaration.js
+++ b/tests/language/classes/basic-class-declaration.js
@@ -129,3 +129,44 @@ test("instance auto-accessor installs on prototype not constructor", () => {
   const ctorDesc = Object.getOwnPropertyDescriptor(C, "y");
   expect(ctorDesc).toBe(undefined);
 });
+
+test("class member names that look like modifiers can be generic methods", () => {
+  class C {
+    static<T>() {
+      return "static";
+    }
+
+    get<T>() {
+      return "get";
+    }
+
+    set<T>() {
+      return "set";
+    }
+
+    accessor<T>() {
+      return "accessor";
+    }
+  }
+
+  const c = new C();
+  expect(c.static()).toBe("static");
+  expect(c.get()).toBe("get");
+  expect(c.set()).toBe("set");
+  expect(c.accessor()).toBe("accessor");
+});
+
+test("private initializer markers are not observable own keys", () => {
+  class C {
+    #value = 42;
+
+    read() {
+      return this.#value;
+    }
+  }
+
+  const c = new C();
+  expect(c.read()).toBe(42);
+  expect(Reflect.ownKeys(c).some(key => String(key).indexOf("#initialized:") === 0)).toBe(false);
+  expect(Object.getOwnPropertyNames(c).some(key => key.indexOf("#initialized:") === 0)).toBe(false);
+});

--- a/tests/language/classes/class-inheritance.js
+++ b/tests/language/classes/class-inheritance.js
@@ -98,6 +98,64 @@ test("super() in constructor arrow initializes replacement receiver fields", () 
   expect(derived instanceof Derived).toBeTruthy();
 });
 
+test("super property update uses receiver for instance accessors", () => {
+  let setterReceiver;
+
+  class Base {
+    get count() {
+      return this._count === undefined ? 0 : this._count;
+    }
+
+    set count(value) {
+      setterReceiver = this;
+      this._count = value;
+    }
+  }
+
+  class Derived extends Base {
+    incrementPostfix() {
+      return super.count++;
+    }
+
+    incrementPrefixComputed() {
+      return ++super["count"];
+    }
+  }
+
+  const d = new Derived();
+  expect(d.incrementPostfix()).toBe(0);
+  expect(d._count).toBe(1);
+  expect(setterReceiver).toBe(d);
+  expect(d.incrementPrefixComputed()).toBe(2);
+  expect(d._count).toBe(2);
+});
+
+test("static super property update writes through the derived constructor receiver", () => {
+  let setterReceiver;
+
+  class Base {
+    static get value() {
+      return this._value === undefined ? 0 : this._value;
+    }
+
+    static set value(next) {
+      setterReceiver = this;
+      this._value = next;
+    }
+  }
+
+  class Derived extends Base {
+    static bump() {
+      return super.value++;
+    }
+  }
+
+  expect(Derived.bump()).toBe(0);
+  expect(Derived._value).toBe(1);
+  expect(Base._value).toBeUndefined();
+  expect(setterReceiver).toBe(Derived);
+});
+
 test("new.target flows through superclass constructors", () => {
   class Base {
     constructor() {

--- a/tests/language/classes/class-inheritance.js
+++ b/tests/language/classes/class-inheritance.js
@@ -573,8 +573,8 @@ test("super.constructor member calls are ordinary class calls", () => {
     }
   }
 
-  expect(() => new DotDerived()).toThrow(TypeError);
-  expect(() => new ComputedDerived()).toThrow(TypeError);
+  expect(() => new DotDerived()).toThrow(ReferenceError);
+  expect(() => new ComputedDerived()).toThrow(ReferenceError);
 });
 
 test("static super observes ordinary own properties on intermediate constructors", () => {

--- a/tests/language/decorators/decorator-expressions.js
+++ b/tests/language/decorators/decorator-expressions.js
@@ -30,6 +30,20 @@ describe("decorator expressions", () => {
     expect(called).toBe(true);
   });
 
+  test("@obj.default accepts keyword property names", () => {
+    let called = false;
+    const decorators = {
+      default: (value, context) => { called = true; },
+    };
+
+    class C {
+      @decorators.default
+      foo() {}
+    }
+
+    expect(called).toBe(true);
+  });
+
   test("@factory(arg)", () => {
     let receivedArg;
 

--- a/tests/language/expressions/destructuring/iterator-protocol-errors.js
+++ b/tests/language/expressions/destructuring/iterator-protocol-errors.js
@@ -5,15 +5,16 @@ description: |
   source IS iterable (its [@@iterator] returned an object), the
   iterator returned just doesn't satisfy the protocol.
 
-  Also covers the abrupt-completion IteratorClose path: when user
-  next() throws, iter.return() must run best-effort before the
-  original error propagates (ES2024 §7.4.10 step 5).
+  Also covers the abrupt-completion IteratorStepValue path: when user
+  next() throws, the original error propagates without calling
+  iter.return() (ES2026 §7.4.10).
 
   Guards against:
     - GetIteratorValue (Goccia.VM.pas) previously falling through to
       SErrorNotIterable when the inner next was non-callable.
-    - TryIterableToArray (Goccia.VM.pas) previously not invoking
-      iter.return() when DirectNext or NextMethod.Call threw.
+    - TryIterableToArray (Goccia.VM.pas) must not invoke iter.return()
+      when DirectNext or NextMethod.Call throws before producing an
+      IteratorResult.
 features: [iterators]
 ---*/
 
@@ -44,7 +45,7 @@ test("[@@iterator]() returning null throws TypeError", () => {
   expect(() => [...iter]).toThrow(TypeError);
 });
 
-test("destructuring with user next() that throws closes the iterator (abrupt completion)", () => {
+test("destructuring with user next() that throws does not close the iterator", () => {
   let returnCalled = 0;
   const iter = {
     [Symbol.iterator]() {
@@ -71,10 +72,10 @@ test("destructuring with user next() that throws closes the iterator (abrupt com
   }
   expect(caught instanceof Error).toBe(true);
   expect(caught.message).toBe("user-next-threw");
-  expect(returnCalled).toBe(1);
+  expect(returnCalled).toBe(0);
 });
 
-test("destructuring with primitive IteratorResult throws TypeError + closes iterator", () => {
+test("destructuring with primitive IteratorResult throws TypeError without closing", () => {
   let returnCalled = 0;
   const iter = {
     [Symbol.iterator]() {
@@ -94,7 +95,7 @@ test("destructuring with primitive IteratorResult throws TypeError + closes iter
     caught = e;
   }
   expect(caught instanceof TypeError).toBe(true);
-  expect(returnCalled).toBe(1);
+  expect(returnCalled).toBe(0);
 });
 
 test("missing IteratorResult.value normalizes to undefined in rest pattern", () => {

--- a/tests/language/expressions/optional-chaining/optional-chaining.js
+++ b/tests/language/expressions/optional-chaining/optional-chaining.js
@@ -157,4 +157,34 @@ describe('Optional Chaining', () => {
 
     expect(obj.getValue?.()).toBe(42);
   });
+
+  test('supports optional access to private fields', () => {
+    class Box {
+      #value = 42;
+
+      read(obj) {
+        return obj?.#value;
+      }
+    }
+
+    const box = new Box();
+
+    expect(box.read(box)).toBe(42);
+    expect(box.read(null)).toBe(undefined);
+    expect(box.read(undefined)).toBe(undefined);
+  });
+
+  test('optional private field access still checks private brand', () => {
+    class Box {
+      #value = 42;
+
+      read(obj) {
+        return obj?.#value;
+      }
+    }
+
+    const box = new Box();
+
+    expect(() => box.read({})).toThrow(TypeError);
+  });
 });

--- a/tests/language/function-keyword/derived-constructor-this.js
+++ b/tests/language/function-keyword/derived-constructor-this.js
@@ -1,0 +1,40 @@
+/*---
+description: Function bodies created in derived constructors do not inherit the derived this guard
+features: [compat-function, class-inheritance]
+---*/
+
+test("function declaration inside derived constructor can read its own this before super", () => {
+  class Base {}
+
+  class Derived extends Base {
+    constructor() {
+      function nested() {
+        return this;
+      }
+
+      const beforeSuper = nested();
+      super();
+      this.beforeSuper = beforeSuper;
+    }
+  }
+
+  expect(new Derived().beforeSuper).toBeUndefined();
+});
+
+test("function expression inside derived constructor can read its own this before super", () => {
+  class Base {}
+
+  class Derived extends Base {
+    constructor() {
+      const nested = function() {
+        return this;
+      };
+
+      const beforeSuper = nested();
+      super();
+      this.beforeSuper = beforeSuper;
+    }
+  }
+
+  expect(new Derived().beforeSuper).toBeUndefined();
+});

--- a/tests/language/types-as-comments/class-annotations.js
+++ b/tests/language/types-as-comments/class-annotations.js
@@ -76,6 +76,24 @@ test("class with extends and implements", () => {
   expect(d.serialize()).toBe("base");
 });
 
+test("class heritage with generic type arguments stops before the body", () => {
+  class Base<T> {
+    value: T;
+    constructor(value: T) {
+      this.value = value;
+    }
+  }
+
+  class Derived<T> extends Base<T> {
+    read(): T {
+      return this.value;
+    }
+  }
+
+  const d = new Derived(42);
+  expect(d.read()).toBe(42);
+});
+
 test("access modifiers are parsed", () => {
   class Person {
     public name: string;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Bring the targeted test262 language clusters to 100% for `language/statements/for-await-of`, `language/statements/class`, and `language/expressions/compound-assignment`.
- Add the supporting bytecode/interpreter semantics for async iteration, class construction/defaults/private access, compound assignments, direct eval metadata serialization, and module-fixture filtering.
- Add Annex B Object prototype shims/tests for `__proto__`, `__defineGetter__`, `__defineSetter__`, `__lookupGetter__`, and `__lookupSetter__`, plus ArrayBuffer species handling needed by subclassing coverage.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build/GocciaTestRunner tests/built-ins/ArrayBuffer/prototype/slice.js --output=json` → 24/24
  - `./build/GocciaTestRunner tests/built-ins/ArrayBuffer/prototype/slice.js --mode=bytecode --output=json` → 24/24
  - `./build/GocciaTestRunner tests/built-ins/Object/prototype --output=json` → 121/121
  - `./build/GocciaTestRunner tests/built-ins/Object/prototype --mode=bytecode --output=json` → 121/121
  - `bun scripts/run_test262_suite.ts --suite-dir test262-suite --categories language --filter 'language/statements/for-await-of/**' --output /tmp/t262-for-await-of-pr.json` → 1234/1234
  - `bun scripts/run_test262_suite.ts --suite-dir test262-suite --categories language --filter 'language/statements/class/**' --output /tmp/t262-class-pr2.json` → 4367/4367
  - `bun scripts/run_test262_suite.ts --suite-dir test262-suite --categories language --filter 'language/expressions/compound-assignment/**' --output /tmp/t262-compound-assignment-pr.json` → 454/454
  - `bun scripts/run_test262_suite.ts --suite-dir test262-suite --categories built-ins --filter 'built-ins/ArrayBuffer/prototype/slice/**' --output /tmp/t262-arraybuffer-slice-pr.json` → 33/33
  - `bun scripts/run_test262_suite.ts --suite-dir test262-suite --categories built-ins --filter 'built-ins/Object/prototype/__*__/**' --output /tmp/t262-object-legacy-pr.json` → 69/69
  - `bun scripts/run_test262_suite.ts --suite-dir test262-suite --categories language --filter 'language/module-code/**/*_FIXTURE.js' --output /tmp/t262-module-fixture-filter-pr.json` → 0 discovered
- [ ] Updated documentation
  - Not applicable; this is conformance/runtime behavior with focused tests.
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./build.pas tests testrunner loaderbare loader bundler`
  - `./build/Goccia.Compiler.Test` → 37/37
  - `./format.pas --check`
  - `git diff --staged --check`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Not run; no benchmark-sensitive path was targeted.