### PR TITLE
fix(website): refresh test262 blob manifest before publish

### DIFF
--- a/website/scripts/test262-blob-store.ts
+++ b/website/scripts/test262-blob-store.ts
@@ -40,6 +40,11 @@ const DEFAULT_PREFIX = "test262";
 const DEFAULT_ACCESS: Test262BlobAccess = "public";
 const MANIFEST_WRITE_ATTEMPTS = 3;
 
+type ReadBlobTextOptions = {
+  access?: Test262BlobAccess;
+  useCache?: boolean;
+};
+
 function cleanPrefix(value: string | undefined): string {
   const trimmed = (value ?? DEFAULT_PREFIX).trim().replace(/^\/+|\/+$/g, "");
   return trimmed || DEFAULT_PREFIX;
@@ -94,10 +99,14 @@ async function streamToBytes(stream: ReadableStream<Uint8Array>) {
 
 async function readBlobTextWithMeta(
   pathname: string,
-  access = test262BlobAccess(),
+  options: ReadBlobTextOptions = {},
 ): Promise<{ text: string; etag: string } | null> {
+  const access = options.access ?? test262BlobAccess();
   try {
-    const result = await get(pathname, { access });
+    const result = await get(pathname, {
+      access,
+      ...(options.useCache === undefined ? {} : { useCache: options.useCache }),
+    });
     if (!result || result.statusCode !== 200 || !result.stream) return null;
     return {
       text: new TextDecoder().decode(await streamToBytes(result.stream)),
@@ -160,8 +169,12 @@ export async function loadTest262BlobManifest(
 
 async function loadTest262BlobManifestSnapshot(
   prefix = test262BlobPrefix(),
+  options: ReadBlobTextOptions = {},
 ): Promise<{ manifest: Test262BlobManifest; etag: string } | null> {
-  const result = await readBlobTextWithMeta(test262BlobManifestPath(prefix));
+  const result = await readBlobTextWithMeta(
+    test262BlobManifestPath(prefix),
+    options,
+  );
   if (!result) return null;
   const manifest = normalizeManifest(JSON.parse(result.text), prefix);
   return manifest ? { manifest, etag: result.etag } : null;
@@ -260,7 +273,10 @@ async function publishManifestWithRetry(
     publishedRuns.map((run) => run.createdAt.slice(0, 10)),
   );
   for (let attempt = 1; attempt <= MANIFEST_WRITE_ATTEMPTS; attempt++) {
-    const existing = await loadTest262BlobManifestSnapshot(prefix);
+    const existing = await loadTest262BlobManifestSnapshot(prefix, {
+      access,
+      useCache: false,
+    });
     const merged = new Map<number, Test262BlobRun>();
     for (const run of existing?.manifest.runs ?? []) {
       merged.set(run.artifactId, run);

--- a/website/src/__tests__/test262-blob-store.test.ts
+++ b/website/src/__tests__/test262-blob-store.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  Test262Report,
+  Test262SuiteSummary,
+  Test262TimelinePoint,
+} from "@/lib/test262-dashboard";
+import type { Test262BlobRun } from "../../scripts/test262-blob-store";
+
+type BlobGetCall = {
+  pathname: string;
+  options: Record<string, unknown>;
+};
+
+type BlobPutCall = {
+  pathname: string;
+  body: unknown;
+  options: Record<string, unknown>;
+};
+
+const getCalls: BlobGetCall[] = [];
+const putCalls: BlobPutCall[] = [];
+
+class BlobPreconditionFailedError extends Error {
+  constructor() {
+    super("Vercel Blob: Precondition failed: ETag mismatch.");
+  }
+}
+
+function textStream(text: string): ReadableStream<Uint8Array> {
+  const stream = new Response(text).body;
+  if (!stream) throw new Error("expected response body stream");
+  return stream;
+}
+
+function summary(totalRun: number): Test262SuiteSummary {
+  return {
+    totalDiscovered: totalRun,
+    totalRun,
+    passed: totalRun,
+    failed: 0,
+    wrapperInfraFailures: 0,
+    timeouts: 0,
+    durationSeconds: 1,
+    byCategory: [],
+  };
+}
+
+const existingRun: Test262BlobRun = {
+  runId: 101,
+  runNumber: 1,
+  title: "CI",
+  headSha: "old-sha",
+  shortSha: "old-sha",
+  runUrl: "https://example.test/runs/101",
+  createdAt: "2026-06-10T01:00:00.000Z",
+  updatedAt: "2026-06-10T01:05:00.000Z",
+  artifactId: 1001,
+  artifactCreatedAt: "2026-06-10T01:05:00.000Z",
+  jsonUrl: "/api/test262/results/1001",
+  summary: summary(1),
+  reportPath: "test262/runs/1001.json.gz",
+  reportUrl: "https://blob.test/test262/runs/1001.json.gz",
+  reportDownloadUrl: "https://blob.test/test262/runs/1001.json.gz?download=1",
+  reportCompressedSize: 128,
+  publishedAt: "2026-06-10T01:06:00.000Z",
+};
+
+mock.module("@vercel/blob", () => ({
+  BlobPreconditionFailedError,
+  get: async (pathname: string, options: Record<string, unknown>) => {
+    getCalls.push({ pathname, options });
+    return {
+      statusCode: 200,
+      stream: textStream(JSON.stringify({ version: 1, runs: [existingRun] })),
+      blob: {
+        etag: '"fresh-origin-etag"',
+      },
+    };
+  },
+  put: async (
+    pathname: string,
+    body: unknown,
+    options: Record<string, unknown>,
+  ) => {
+    putCalls.push({ pathname, body, options });
+    if (pathname === "test262/manifest.json") {
+      if (options.ifMatch !== '"fresh-origin-etag"') {
+        throw new BlobPreconditionFailedError();
+      }
+    }
+    return {
+      url: `https://blob.test/${pathname}`,
+      downloadUrl: `https://blob.test/${pathname}?download=1`,
+      pathname,
+      contentType: String(options.contentType ?? "application/octet-stream"),
+      contentDisposition: "",
+      etag: "written-etag",
+    };
+  },
+}));
+
+describe("test262 Blob publishing", () => {
+  test("bypasses manifest cache and preserves get ETags for conditional writes", async () => {
+    getCalls.length = 0;
+    putCalls.length = 0;
+
+    const { publishTest262ReportsToBlob } = await import(
+      "../../scripts/test262-blob-store"
+    );
+    const report: Test262Report = {
+      summary: summary(2),
+      results: [],
+    };
+    const point: Test262TimelinePoint = {
+      runId: 202,
+      runNumber: 2,
+      title: "CI",
+      headSha: "new-sha",
+      shortSha: "new-sha",
+      runUrl: "https://example.test/runs/202",
+      createdAt: "2026-06-11T01:00:00.000Z",
+      updatedAt: "2026-06-11T01:05:00.000Z",
+      artifactId: 1002,
+      artifactCreatedAt: "2026-06-11T01:05:00.000Z",
+      jsonUrl: "/api/test262/results/1002",
+      summary: report.summary,
+    };
+
+    const manifest = await publishTest262ReportsToBlob([
+      {
+        point,
+        report,
+        reportJson: JSON.stringify(report),
+      },
+    ]);
+
+    const manifestRead = getCalls.find(
+      (call) => call.pathname === "test262/manifest.json",
+    );
+    const manifestWrite = putCalls.find(
+      (call) => call.pathname === "test262/manifest.json",
+    );
+
+    expect(manifestRead?.options).toMatchObject({ useCache: false });
+    expect(manifestWrite?.options).toMatchObject({
+      allowOverwrite: true,
+      ifMatch: '"fresh-origin-etag"',
+    });
+    expect(manifest.runs.map((run) => run.artifactId)).toEqual([1001, 1002]);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fix test262 Vercel Blob manifest publishing by bypassing cached manifest reads before optimistic `ifMatch` writes.
- Preserve the SDK-provided quoted ETag for conditional writes.
- Add a mocked Blob publishing regression test for the stale-manifest read path.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation (not needed; publish implementation only)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Commands run:

- `bun check-swimmies.ts website/scripts/test262-blob-store.ts website/src/__tests__/test262-blob-store.test.ts`
- `cd website && bun test src/__tests__/test262-blob-store.test.ts`
- `cd website && bun test`
- `cd website && bunx tsc --noEmit`
- `cd website && bun run lint`