### PR TITLE
Speed up global reads, lex regexes in template interpolations, make --timeout a hard deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,16 +609,16 @@ jobs:
 
       - name: Run test262 conformance suite
         continue-on-error: true
-        # --jobs=2 (not 4): higher concurrency tripped false-positive
-        # watchdog stalls on GH-hosted runners under the previous
-        # chunked-runner architecture.  Per-test subprocess is more
-        # forgiving but the 2-CPU GH runner doesn't actually benefit
-        # from more.
+        # --jobs=4 matches the 4 vCPUs on GH-hosted ubuntu-latest runners
+        # for public repos.  The old --jobs=2 ceiling guarded against
+        # watchdog stalls in the retired chunked-runner architecture;
+        # per-test subprocesses tolerate scheduler jitter, so the only
+        # remaining limit is core count.
         run: |
           bun scripts/run_test262_suite.ts \
             --suite-dir test262-suite \
             --mode=bytecode \
-            --jobs=2 \
+            --jobs=4 \
             --output=test262-results.json
 
       - name: Stage test262 baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,10 @@ jobs:
 
       - name: Run test262 conformance suite
         continue-on-error: true
+        # --timeout-ms=20000: the per-test deadline is wall-clock, and at
+        # --jobs=4 the workers fully subscribe the runner, inflating each
+        # test's wall time ~30-40% vs the old --jobs=2 baseline; borderline
+        # 7-9s tests must not trip the deadline purely from contention.
         # --jobs=4 matches the 4 vCPUs on GH-hosted ubuntu-latest runners
         # for public repos.  The old --jobs=2 ceiling guarded against
         # watchdog stalls in the retired chunked-runner architecture;
@@ -619,6 +623,7 @@ jobs:
             --suite-dir test262-suite \
             --mode=bytecode \
             --jobs=4 \
+            --timeout-ms=20000 \
             --output=test262-results.json
 
       - name: Stage test262 baseline

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -318,6 +318,10 @@ jobs:
 
       - name: Run test262 conformance suite
         continue-on-error: true
+        # --timeout-ms=20000: the per-test deadline is wall-clock, and at
+        # --jobs=4 the workers fully subscribe the runner, inflating each
+        # test's wall time ~30-40% vs the old --jobs=2 baseline; borderline
+        # 7-9s tests must not trip the deadline purely from contention.
         # --jobs=4 matches the 4 vCPUs on GH-hosted ubuntu-latest runners
         # for public repos.  Per-test subprocesses tolerate scheduler
         # jitter (each test gets its own engine-side deadline), so the
@@ -327,6 +331,7 @@ jobs:
             --suite-dir test262-suite \
             --mode=bytecode \
             --jobs=4 \
+            --timeout-ms=20000 \
             --output=test262-results.json
 
       - name: Upload test262 results

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -318,15 +318,15 @@ jobs:
 
       - name: Run test262 conformance suite
         continue-on-error: true
-        # --jobs=2 (not 4): GH-hosted runners share the host CPU with
-        # neighbour VMs, and at higher concurrency scheduler jitter trips
-        # per-test deadlines.  Two workers leaves enough CPU headroom
-        # while still halving wall time vs sequential execution.
+        # --jobs=4 matches the 4 vCPUs on GH-hosted ubuntu-latest runners
+        # for public repos.  Per-test subprocesses tolerate scheduler
+        # jitter (each test gets its own engine-side deadline), so the
+        # only remaining limit is core count.
         run: |
           bun scripts/run_test262_suite.ts \
             --suite-dir test262-suite \
             --mode=bytecode \
-            --jobs=2 \
+            --jobs=4 \
             --output=test262-results.json
 
       - name: Upload test262 results

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -502,6 +502,74 @@ console.log("--timeout (bytecode)...");
   if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);
 }
 
+// -- --timeout inside long-running NATIVE operations ----------------------------
+//
+// A single JS statement can stall inside one native call (dense hole-fill for
+// a huge array index, or an unanchored regex scan over a long subject).  The
+// deadline must interrupt those loops too, not just the dispatch loop between
+// JS-level steps.
+
+console.log("--timeout (native sparse-array fill, interpreted)...");
+{
+  const fill = "const x = []; x[2 ** 31 - 2] = 1;\n";
+  const { exitCode, json } = runLoaderJson(fill, ["--timeout=50"], { timeout: 10_000 });
+  if (exitCode !== 1) throw new Error(`Array-fill timeout exit code should be 1, got ${exitCode}`);
+  if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);
+}
+
+console.log("--timeout (native sparse-array fill, bytecode)...");
+{
+  const fill = "const x = []; x[2 ** 31 - 2] = 1;\n";
+  const { exitCode, json } = runLoaderJson(fill, ["--timeout=50", "--mode=bytecode"], { timeout: 10_000 });
+  if (exitCode !== 1) throw new Error(`Bytecode array-fill timeout exit code should be 1, got ${exitCode}`);
+  if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);
+}
+
+console.log("--timeout (native regex scan, interpreted)...");
+{
+  const scan = 'const s = "a".repeat(20000000); /zz/.test(s);\n';
+  const { exitCode, json } = runLoaderJson(scan, ["--timeout=50"], { timeout: 10_000 });
+  if (exitCode !== 1) throw new Error(`Regex-scan timeout exit code should be 1, got ${exitCode}`);
+  if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);
+}
+
+console.log("--timeout (native regex scan, bytecode)...");
+{
+  const scan = 'const s = "a".repeat(20000000); /zz/.test(s);\n';
+  const { exitCode, json } = runLoaderJson(scan, ["--timeout=50", "--mode=bytecode"], { timeout: 10_000 });
+  if (exitCode !== 1) throw new Error(`Bytecode regex-scan timeout exit code should be 1, got ${exitCode}`);
+  if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);
+}
+
+// -- --timeout must escape promise boundaries (dynamic import) ------------------
+//
+// The deadline abort must not be convertible into a JS-catchable rejection:
+// a module that stalls inside import() previously surfaced as a caught
+// rejection and the script "succeeded" with exit 0, defeating --timeout.
+
+for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+  const label = modeArgs.length ? "bytecode" : "interpreted";
+  console.log(`--timeout (dynamic import stall, ${label})...`);
+  const tmp = mkdtemp("goccia-timeout-import-");
+  try {
+    const dep = join(tmp, "dep.js");
+    writeFileSync(dep, 'const s = "a".repeat(20000000); /zz/.test(s);\nexport const ready = true;\n');
+    const main = join(tmp, "main.js");
+    writeFileSync(main, 'import("./dep.js").then(() => console.log("LOADED")).catch((e) => console.log("CAUGHT: " + e));\n');
+    const proc = Bun.spawnSync(
+      [LOADER, main, "--output=json", "--timeout=100", ...modeArgs],
+      { stdout: "pipe", stderr: "pipe", timeout: 10_000 },
+    );
+    const json = JSON.parse(proc.stdout.toString());
+    if (proc.exitCode !== 1) throw new Error(`Dynamic-import timeout (${label}) exit code should be 1, got ${proc.exitCode}`);
+    if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError (${label}), got ${json.error?.type}`);
+    const printed = (json.stdout ?? "") + proc.stdout.toString();
+    if (printed.includes("CAUGHT")) throw new Error(`Timeout was swallowed by JS .catch() (${label})`);
+  } finally {
+    clean(tmp);
+  }
+}
+
 // -- --max-instructions (Loader: infinite loop, both execution modes) -----------
 
 console.log("--max-instructions (interpreted)...");

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -511,7 +511,9 @@ console.log("--timeout (bytecode)...");
 
 console.log("--timeout (native sparse-array fill, interpreted)...");
 {
-  const fill = "const x = []; x[2 ** 31 - 2] = 1;\n";
+  // Far single-index writes route to sparse storage and complete instantly;
+  // the Array constructor still materializes dense holes, so it stalls.
+  const fill = "const x = new Array(2 ** 30); x.length;\n";
   const { exitCode, json } = runLoaderJson(fill, ["--timeout=50"], { timeout: 10_000 });
   if (exitCode !== 1) throw new Error(`Array-fill timeout exit code should be 1, got ${exitCode}`);
   if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);
@@ -519,7 +521,9 @@ console.log("--timeout (native sparse-array fill, interpreted)...");
 
 console.log("--timeout (native sparse-array fill, bytecode)...");
 {
-  const fill = "const x = []; x[2 ** 31 - 2] = 1;\n";
+  // Far single-index writes route to sparse storage and complete instantly;
+  // the Array constructor still materializes dense holes, so it stalls.
+  const fill = "const x = new Array(2 ** 30); x.length;\n";
   const { exitCode, json } = runLoaderJson(fill, ["--timeout=50", "--mode=bytecode"], { timeout: 10_000 });
   if (exitCode !== 1) throw new Error(`Bytecode array-fill timeout exit code should be 1, got ${exitCode}`);
   if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);

--- a/source/shared/OrderedStringMap.pas
+++ b/source/shared/OrderedStringMap.pas
@@ -58,6 +58,18 @@ type
     FDeletedCount: Integer;
     FEntryCount: Integer;
     FBucketCount: Integer;
+    // Monotonic stamp for entry-index inline caches.  Unique across all map
+    // instances of this instantiation (seeded from the shared class counter)
+    // and re-stamped by every operation that can invalidate a previously
+    // observed entry index (Remove, Compact, Clear).  Adds never invalidate:
+    // entries append.
+    FEntryVersion: Cardinal;
+    class var FEntryVersionCounter: LongInt;
+    // Interlocked so maps created on worker threads (parallel test runner)
+    // still receive unique stamps; a stamp recorded against one map instance
+    // can therefore never validate against a different instance that happens
+    // to reuse the same address.
+    class function NextEntryVersion: Cardinal; static; inline;
 
     class function HashKey(const AKey: string): Cardinal; static; inline;
     class function KeysEqual(const A, B: string): Boolean; static; inline;
@@ -90,8 +102,17 @@ type
     function GetEnumerator: TEnumerator; inline;
     function EntryAt(AIndex: Integer): TBaseMap<string, TValue>.TKeyValuePair;
 
+    // Entry-index access for version-validated inline caches: look up an
+    // entry index once, then re-read its value directly while EntryVersion
+    // is unchanged.
+    function TryGetEntryIndex(const AKey: string; out AIndex: Integer): Boolean;
+    function TryGetValueAtEntry(const AIndex: Integer;
+      out AValue: TValue): Boolean; inline;
+    function KeyAtEntry(const AIndex: Integer): string;
+
     property Capacity: Integer read FBucketCount;
     property DeletedCount: Integer read FDeletedCount;
+    property EntryVersion: Cardinal read FEntryVersion;
   end;
 
   TStringStringMap = TOrderedStringMap<string>;
@@ -101,6 +122,11 @@ implementation
 { Hash / Equality — static inline: DJB2 on string characters }
 
 {$PUSH}{$R-}{$Q-}
+class function TOrderedStringMap<TValue>.NextEntryVersion: Cardinal;
+begin
+  Result := Cardinal(InterLockedIncrement(FEntryVersionCounter));
+end;
+
 class function TOrderedStringMap<TValue>.HashKey(const AKey: string): Cardinal;
 var
   I: Integer;
@@ -211,6 +237,7 @@ begin
     end;
   FEntries := NewEntries;
   FEntryCount := FCount;
+  FEntryVersion := NextEntryVersion;
   Rehash(FBucketCount);
 end;
 
@@ -229,6 +256,7 @@ begin
   FCount := 0;
   FDeletedCount := 0;
   FEntryCount := 0;
+  FEntryVersion := NextEntryVersion;
 
   if AInitialCapacity <= 0 then
   begin
@@ -357,6 +385,7 @@ begin
   FBuckets[BucketIdx] := DELETED_SLOT;
   Inc(FDeletedCount);
   Dec(FCount);
+  FEntryVersion := NextEntryVersion;
 end;
 
 procedure TOrderedStringMap<TValue>.Clear;
@@ -369,6 +398,7 @@ begin
   FCount := 0;
   FDeletedCount := 0;
   FEntryCount := 0;
+  FEntryVersion := NextEntryVersion;
 end;
 
 { Accessors }
@@ -468,6 +498,42 @@ begin
       end;
       Inc(J);
     end;
+end;
+
+function TOrderedStringMap<TValue>.TryGetEntryIndex(const AKey: string;
+  out AIndex: Integer): Boolean;
+var
+  Hash: Cardinal;
+  BucketIdx: Integer;
+begin
+  AIndex := -1;
+  if FBucketCount = 0 then
+    Exit(False);
+  Hash := HashKey(AKey);
+  Result := FindBucket(AKey, Hash, BucketIdx);
+  if Result then
+    AIndex := FBuckets[BucketIdx];
+end;
+
+function TOrderedStringMap<TValue>.TryGetValueAtEntry(const AIndex: Integer;
+  out AValue: TValue): Boolean;
+begin
+  // Callers must pair this with an EntryVersion check; while the version is
+  // unchanged an index obtained from TryGetEntryIndex stays active and keeps
+  // its key (Remove/Compact/Clear re-stamp the version).
+  Result := (AIndex >= 0) and (AIndex < FEntryCount) and FEntries[AIndex].Active;
+  if Result then
+    AValue := FEntries[AIndex].Value
+  else
+    AValue := Default(TValue);
+end;
+
+function TOrderedStringMap<TValue>.KeyAtEntry(const AIndex: Integer): string;
+begin
+  if (AIndex >= 0) and (AIndex < FEntryCount) then
+    Result := FEntries[AIndex].Key
+  else
+    Result := '';
 end;
 
 end.

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -892,8 +892,10 @@ uses
   Goccia.Evaluator.PatternMatching,
   Goccia.GarbageCollector,
   Goccia.ImportMeta,
+  Goccia.InstructionLimit,
   Goccia.RegExp.Runtime,
   Goccia.Scope,
+  Goccia.Timeout,
   Goccia.Values.BigIntValue,
   Goccia.Values.ClassHelper,
   Goccia.Values.ClassValue,
@@ -2339,6 +2341,10 @@ begin
         Promise.Reject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
       on E: TGocciaReferenceError do
         Promise.Reject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+      on E: TGocciaTimeoutError do
+        raise;
+      on E: TGocciaInstructionLimitError do
+        raise;
       on E: Exception do
         Promise.Reject(CreateErrorObject(ERROR_NAME, E.Message));
     end;

--- a/source/units/Goccia.Builtins.GlobalFetch.pas
+++ b/source/units/Goccia.Builtins.GlobalFetch.pas
@@ -45,6 +45,8 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.FetchManager,
+  Goccia.InstructionLimit,
+  Goccia.Timeout,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HeadersValue,
   Goccia.Values.NativeFunction,
@@ -222,6 +224,10 @@ begin
     TGocciaFetchManager.Instance.StartFetch(URLStr, Method, RequestHeaders,
       Promise);
   except
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       Promise.Reject(CreateErrorObject('TypeError', 'fetch failed: ' + E.Message));
   end;

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -49,7 +49,9 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.MicrotaskQueue,
+  Goccia.Timeout,
   Goccia.Utils,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
@@ -1058,6 +1060,10 @@ begin
     on E: TGocciaThrowValue do
       { Step 5: Abrupt completion — Call(reject, status.[[Value]]) }
       Promise.Reject(E.Value);
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       Promise.Reject(CreateErrorObject(ERROR_NAME, E.Message));
   end;

--- a/source/units/Goccia.Bytecode.Chunk.pas
+++ b/source/units/Goccia.Bytecode.Chunk.pas
@@ -95,6 +95,17 @@ type
     sltReference
   );
 
+  // Runtime-only inline cache for OP_GET_GLOBAL sites, indexed by the
+  // instruction's name-constant index.  Scope is a weak pointer compared for
+  // identity only (never dereferenced); Version/EntryIndex validate against
+  // the scope's lexical binding map.  Not serialised to .gbc.
+  TGocciaGlobalReadCacheEntry = record
+    Scope: Pointer;
+    Version: Cardinal;
+    EntryIndex: Integer;
+  end;
+  PGocciaGlobalReadCacheEntry = ^TGocciaGlobalReadCacheEntry;
+
   TGocciaFunctionTemplate = class
   private
     FName: string;
@@ -137,6 +148,7 @@ type
     FTemplateObjectCacheCount: Integer;
     FRegExpProgramCaches: array of TObject;
     FRegExpProgramCacheCount: Integer;
+    FGlobalReadCaches: array of TGocciaGlobalReadCacheEntry;
     function GetFunctionCount: Integer;
   public
     constructor Create(const AName: string);
@@ -160,6 +172,8 @@ type
     procedure SetTemplateObjectCache(const ASlot: Integer; const AValue: TObject);
     function GetRegExpProgramCache(const ASlot: Integer): TObject;
     procedure SetRegExpProgramCache(const ASlot: Integer; const AValue: TObject);
+    function GlobalReadCacheSlot(
+      const AConstIndex: Integer): PGocciaGlobalReadCacheEntry; inline;
     function AddFunction(const AFunction: TGocciaFunctionTemplate): UInt16;
     procedure AddUpvalueDescriptor(const AIsLocal: Boolean; const AIndex: UInt8;
       const AName: string = '');
@@ -521,6 +535,23 @@ procedure TGocciaFunctionTemplate.SetRegExpProgramCache(const ASlot: Integer;
 begin
   if (ASlot >= 0) and (ASlot < FRegExpProgramCacheCount) then
     FRegExpProgramCaches[ASlot] := AValue;
+end;
+
+function TGocciaFunctionTemplate.GlobalReadCacheSlot(
+  const AConstIndex: Integer): PGocciaGlobalReadCacheEntry;
+begin
+  // Out-of-range constant indices (possible only with corrupt or hostile
+  // .gbc input) must not yield a pointer past the array end — the VM writes
+  // through this pointer, so that would be a wild heap write in production
+  // builds.  nil tells the caller to run uncached.
+  if (AConstIndex < 0) or (AConstIndex >= FConstantCount) then
+    Exit(nil);
+  // Lazily sized to the constant pool on first use; constants are fixed by
+  // the time the VM executes, so the array never needs to grow again.
+  // SetLength zero-fills, so fresh slots have Scope = nil and always miss.
+  if AConstIndex >= Length(FGlobalReadCaches) then
+    SetLength(FGlobalReadCaches, FConstantCount);
+  Result := @FGlobalReadCaches[AConstIndex];
 end;
 
 function TGocciaFunctionTemplate.AddFunction(

--- a/source/units/Goccia.Generator.Continuation.pas
+++ b/source/units/Goccia.Generator.Continuation.pas
@@ -169,6 +169,8 @@ uses
   Goccia.Error,
   Goccia.Evaluator,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
+  Goccia.Timeout,
   Goccia.Values.Await,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
@@ -345,6 +347,10 @@ begin
         Promise.Reject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
       on E: TGocciaSyntaxError do
         Promise.Reject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+      on E: TGocciaTimeoutError do
+        raise;
+      on E: TGocciaInstructionLimitError do
+        raise;
       on E: Exception do
         Promise.Reject(CreateErrorObject(ERROR_NAME, E.Message));
     end;
@@ -401,6 +407,10 @@ begin
       Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
     on E: TGocciaSyntaxError do
       Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -437,6 +447,10 @@ begin
       Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
     on E: TGocciaSyntaxError do
       Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -473,6 +487,10 @@ begin
       Result := PromiseReject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
     on E: TGocciaSyntaxError do
       Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -903,33 +903,214 @@ end;
 //   - Nested braces {…}
 //   - String literals '…' and "…" (with \ escapes)
 //   - Template literals `…` (with nested ${…} via mutual recursion)
+//   - Regex literals /…/ (with [\ ] classes and \ escapes), so quotes and
+//     braces inside a pattern cannot flip the string/brace tracking
 //   - Line comments //…
 //   - Block comments /*…*/
 //   - Line terminators (CR, CRLF, LF, LS, PS) with line/column tracking
+//
+// Regex-vs-division uses the same classification as UpdateRegexContext: a
+// slash after a completed primary expression (identifier, literal, `]`,
+// closing quote/backtick, postfix ++/--) divides; everywhere else it starts
+// a regex.  The scanner tracks the last significant character and the last
+// word so keyword boundaries (`return /re/`) classify like the main lexer.
 procedure TGocciaLexer.ScanInterpolationExpression(var ASB, ARawSB: TStringBuffer);
 var
   BraceCount: Integer;
   C, Quote: Char;
+  LastSignificant, PrevSignificant: Char;
+  LastWord: string;
+  WordActive: Boolean;
+  // Mirrors the main lexer's paren-regex context: each '(' records whether
+  // it opens an if/while/for head, so the matching ')' can re-allow a regex.
+  ParenAllowsRegex: array of Boolean;
+  ParenDepth: Integer;
+  LastParenAllowsRegex: Boolean;
+
+  procedure PushParenContext(const AAllowsRegexAfter: Boolean);
+  begin
+    if ParenDepth >= Length(ParenAllowsRegex) then
+      SetLength(ParenAllowsRegex, ParenDepth * 2 + 8);
+    ParenAllowsRegex[ParenDepth] := AAllowsRegexAfter;
+    Inc(ParenDepth);
+  end;
+
+  function PopParenContext: Boolean;
+  begin
+    if ParenDepth = 0 then
+      Exit(False);
+    Dec(ParenDepth);
+    Result := ParenAllowsRegex[ParenDepth];
+  end;
+
+  function WordIsStatementHeadKeyword: Boolean;
+  var
+    KeywordType: TGocciaTokenType;
+  begin
+    Result := (LastSignificant in ['a'..'z', 'A'..'Z']) and
+      TryKeywordToken(LastWord, KeywordType) and
+      (KeywordType in [gttIf, gttWhile, gttFor]);
+  end;
+
+  procedure NoteSignificant(const AChar: Char);
+  begin
+    PrevSignificant := LastSignificant;
+    LastSignificant := AChar;
+    if (AChar in ['a'..'z', 'A'..'Z', '0'..'9', '_', '$']) or
+       (AChar > #127) then
+    begin
+      if WordActive then
+        LastWord := LastWord + AChar
+      else
+        LastWord := AChar;
+      WordActive := True;
+    end
+    else
+      WordActive := False;
+  end;
+
+  function SlashStartsRegex: Boolean;
+  var
+    KeywordType: TGocciaTokenType;
+  begin
+    if LastSignificant = #0 then
+      Exit(True); // expression start
+    if (LastSignificant in ['a'..'z', 'A'..'Z', '0'..'9', '_', '$']) or
+       (LastSignificant > #127) then
+    begin
+      // Mirror UpdateRegexContext: keywords allow a regex except the
+      // identifier-like ones that end a primary expression.
+      if TryKeywordToken(LastWord, KeywordType) then
+        Exit(not (KeywordType in [gttTrue, gttFalse, gttNull, gttAs,
+          gttFrom, gttStatic, gttThis, gttSuper]));
+      Exit(False);
+    end;
+    // A trailing-dot numeric literal (`1.`) is one Number token in the real
+    // lexer, so a slash after it divides; a bare member-access dot keeps the
+    // regex-allowed default the main lexer uses for gttDot.
+    if (LastSignificant = '.') and (PrevSignificant in ['0'..'9']) then
+      Exit(False);
+    if (LastSignificant in ['+', '-']) and
+       (PrevSignificant = LastSignificant) then
+      Exit(False); // postfix ++/-- ends a primary expression
+    // Mirror PushParenRegexContext: the ')' closing an if/while/for head
+    // allows a regex statement to follow; any other ')' ends a primary
+    // expression and divides.
+    if LastSignificant = ')' then
+      Exit(LastParenAllowsRegex);
+    Result := not (LastSignificant in [']', '''', '"', '`']);
+  end;
+
+  // Pure lookahead from the character after the already-consumed '/': does a
+  // regex literal body (with \ escapes and [..] classes) close with '/' on
+  // this line?  Misclassified division would otherwise swallow state-bearing
+  // characters ('}', quotes) up to end of line; when no same-line closing
+  // slash exists we keep the slash as division and degrade gracefully.
+  function RegexBodyClosesOnLine: Boolean;
+  var
+    Idx: Integer;
+    InClass: Boolean;
+  begin
+    Result := False;
+    InClass := False;
+    Idx := FCurrent;
+    while Idx <= Length(FSource) do
+    begin
+      case FSource[Idx] of
+        #10, #13:
+          Exit(False);
+        UTF8_LINE_TERMINATOR_LEAD_BYTE:
+          if (Idx + 2 <= Length(FSource)) and
+             (FSource[Idx + 1] = UTF8_LINE_TERMINATOR_CONTINUATION_BYTE) and
+             ((FSource[Idx + 2] = UTF8_LINE_SEPARATOR_FINAL_BYTE) or
+              (FSource[Idx + 2] = UTF8_PARAGRAPH_SEPARATOR_FINAL_BYTE)) then
+            Exit(False);
+        '\':
+          Inc(Idx); // skip the escaped character
+        '[':
+          InClass := True;
+        ']':
+          InClass := False;
+        '/':
+          if not InClass then
+            Exit(True);
+      end;
+      Inc(Idx);
+    end;
+  end;
+
+  // Called with the opening / already appended.  Consumes the regex body
+  // verbatim.  Bails at a line terminator: regex literals cannot span
+  // lines, so a misclassified division degrades to ordinary character
+  // scanning instead of swallowing the rest of the source.
+  procedure ScanRegexBody;
+  var
+    R: Char;
+    InClass: Boolean;
+  begin
+    InClass := False;
+    while not IsAtEnd and not IsLineTerminator do
+    begin
+      R := Peek;
+      if R = '\' then
+      begin
+        AppendCurrent(ASB, ARawSB);
+        if not IsAtEnd and not IsLineTerminator then
+          AppendCurrent(ASB, ARawSB);
+        Continue;
+      end;
+      if InClass then
+      begin
+        if R = ']' then
+          InClass := False;
+        AppendCurrent(ASB, ARawSB);
+        Continue;
+      end;
+      if R = '[' then
+      begin
+        InClass := True;
+        AppendCurrent(ASB, ARawSB);
+        Continue;
+      end;
+      AppendCurrent(ASB, ARawSB);
+      if R = '/' then
+        Exit; // closing delimiter; flags are scanned by the main loop
+    end;
+  end;
+
 begin
   BraceCount := 1;
+  LastSignificant := #0;
+  PrevSignificant := #0;
+  LastWord := '';
+  WordActive := False;
+  ParenDepth := 0;
+  LastParenAllowsRegex := False;
   while (BraceCount > 0) and not IsAtEnd do
   begin
     C := Peek;
     if ((C = #13) or (C = #10) or (C = UTF8_LINE_TERMINATOR_LEAD_BYTE)) and
        AppendLineTerminator(ASB, ARawSB) then
+    begin
+      WordActive := False;
       Continue;
+    end;
 
     case C of
       '{':
       begin
         Inc(BraceCount);
         AppendCurrent(ASB, ARawSB);
+        NoteSignificant('{');
       end;
       '}':
       begin
         Dec(BraceCount);
         if BraceCount > 0 then
+        begin
           AppendCurrent(ASB, ARawSB);
+          NoteSignificant('}');
+        end;
         // When BraceCount = 0, leave the closing } unconsumed for the caller
       end;
       '''', '"':
@@ -959,12 +1140,14 @@ begin
           else
             AppendCurrent(ASB, ARawSB);
         end;
+        NoteSignificant(Quote);
       end;
       '`':
       begin
         // Nested template literal — delegate to mutual recursion
         AppendCurrent(ASB, ARawSB);
         ScanNestedTemplateInExpression(ASB, ARawSB);
+        NoteSignificant('`');
       end;
       '/':
       begin
@@ -1001,12 +1184,35 @@ begin
               else
                 AppendCurrent(ASB, ARawSB);
             end;
-          end;
-          // If neither // nor /*, the / was already appended — continue
-        end;
+          end
+          else if SlashStartsRegex and RegexBodyClosesOnLine then
+          begin
+            ScanRegexBody;
+            // A regex is a completed primary expression; ')' marks that, and
+            // clearing the paren flag keeps a following slash as division.
+            LastParenAllowsRegex := False;
+            NoteSignificant(')');
+          end
+          else
+            NoteSignificant('/');
+        end
+        else
+          NoteSignificant('/');
       end;
     else
-      AppendCurrent(ASB, ARawSB);
+      begin
+        AppendCurrent(ASB, ARawSB);
+        // Capture the paren-regex context before NoteSignificant resets the
+        // word state: '(' records whether it opens an if/while/for head.
+        if C = '(' then
+          PushParenContext(WordIsStatementHeadKeyword)
+        else if C = ')' then
+          LastParenAllowsRegex := PopParenContext;
+        if C > ' ' then
+          NoteSignificant(C)
+        else
+          WordActive := False;
+      end;
     end;
   end;
 end;

--- a/source/units/Goccia.OrderedStringMap.Test.pas
+++ b/source/units/Goccia.OrderedStringMap.Test.pas
@@ -17,6 +17,9 @@ type
 
     procedure TestReuseDeletedBucketClearsDeletedCount;
     procedure TestDeleteHeavyInsertCompactsTombstones;
+    procedure TestEntryIndexSurvivesAddsAndSeesUpdates;
+    procedure TestEntryVersionInvalidatesOnRemoveCompactClear;
+    procedure TestEntryVersionsDifferAcrossInstances;
   end;
 
 procedure TTestOrderedStringMap.SetupTests;
@@ -25,6 +28,12 @@ begin
     TestReuseDeletedBucketClearsDeletedCount);
   Test('Delete-heavy insert compacts tombstones',
     TestDeleteHeavyInsertCompactsTombstones);
+  Test('Entry index survives adds and sees value updates',
+    TestEntryIndexSurvivesAddsAndSeesUpdates);
+  Test('Entry version invalidates on remove, compact, and clear',
+    TestEntryVersionInvalidatesOnRemoveCompactClear);
+  Test('Entry versions differ across instances',
+    TestEntryVersionsDifferAcrossInstances);
 end;
 
 procedure TTestOrderedStringMap.TestReuseDeletedBucketClearsDeletedCount;
@@ -76,6 +85,88 @@ begin
     Expect<string>(Map.EntryAt(1).Key).ToBe('new-key');
   finally
     Map.Free;
+  end;
+end;
+
+procedure TTestOrderedStringMap.TestEntryIndexSurvivesAddsAndSeesUpdates;
+var
+  Map: TOrderedStringMap<Integer>;
+  Index: Integer;
+  Version: Cardinal;
+  Value, I: Integer;
+begin
+  Map := TOrderedStringMap<Integer>.Create(16);
+  try
+    Map.Add('cached', 1);
+    Expect<Boolean>(Map.TryGetEntryIndex('cached', Index)).ToBe(True);
+    Version := Map.EntryVersion;
+    Expect<string>(Map.KeyAtEntry(Index)).ToBe('cached');
+
+    // Adds (including bucket growth) never invalidate an entry index.
+    for I := 0 to 99 do
+      Map.Add('filler' + IntToStr(I), I);
+    Expect<Boolean>(Map.EntryVersion = Version).ToBe(True);
+    Expect<Boolean>(Map.TryGetValueAtEntry(Index, Value)).ToBe(True);
+    Expect<Integer>(Value).ToBe(1);
+
+    // Value updates through the same key are visible at the cached index.
+    Map.Add('cached', 2);
+    Expect<Boolean>(Map.TryGetValueAtEntry(Index, Value)).ToBe(True);
+    Expect<Integer>(Value).ToBe(2);
+  finally
+    Map.Free;
+  end;
+end;
+
+procedure TTestOrderedStringMap.TestEntryVersionInvalidatesOnRemoveCompactClear;
+var
+  Map: TOrderedStringMap<Integer>;
+  Version: Cardinal;
+  I: Integer;
+begin
+  Map := TOrderedStringMap<Integer>.Create(16);
+  try
+    Map.Add('a', 1);
+    Map.Add('b', 2);
+
+    Version := Map.EntryVersion;
+    Expect<Boolean>(Map.Remove('a')).ToBe(True);
+    Expect<Boolean>(Map.EntryVersion <> Version).ToBe(True);
+
+    // Delete-heavy insert triggers Compact, which shifts entry indices.
+    for I := 0 to 9 do
+      Map.Add('key' + IntToStr(I), I);
+    for I := 0 to 8 do
+      Map.Remove('key' + IntToStr(I));
+    Version := Map.EntryVersion;
+    Map.Add('compact-trigger', 99);
+    Expect<Boolean>(Map.EntryVersion <> Version).ToBe(True);
+
+    Version := Map.EntryVersion;
+    Map.Clear;
+    Expect<Boolean>(Map.EntryVersion <> Version).ToBe(True);
+  finally
+    Map.Free;
+  end;
+end;
+
+procedure TTestOrderedStringMap.TestEntryVersionsDifferAcrossInstances;
+var
+  First, Second: TOrderedStringMap<Integer>;
+begin
+  // A version stamp recorded against one instance must never validate
+  // against another instance (e.g. after free + reallocation at the same
+  // address), so every instance starts from a fresh stamp.
+  First := TOrderedStringMap<Integer>.Create(16);
+  try
+    Second := TOrderedStringMap<Integer>.Create(16);
+    try
+      Expect<Boolean>(First.EntryVersion <> Second.EntryVersion).ToBe(True);
+    finally
+      Second.Free;
+    end;
+  finally
+    First.Free;
   end;
 end;
 

--- a/source/units/Goccia.RegExp.VM.pas
+++ b/source/units/Goccia.RegExp.VM.pas
@@ -27,7 +27,8 @@ implementation
 uses
   TextSemantics,
 
-  Goccia.RegExp.UnicodeData;
+  Goccia.RegExp.UnicodeData,
+  Goccia.Timeout;
 
 const
   MIN_STEP_LIMIT = 10000000;
@@ -410,6 +411,13 @@ begin
     Inc(StepCount);
     if StepCount > StepLimit then
       raise ERegExpRuntimeError.Create('Maximum regular expression backtrack stack size exceeded');
+    // Catastrophic backtracking can spin here for seconds inside a single
+    // exec/test call; poll the cooperative engine deadline periodically.
+    // The 255 mask composes with CheckExecutionTimeout's internal 1/1024
+    // throttle: the clock is read once per ~262K steps, bounding deadline
+    // overshoot to low milliseconds at typical step costs.
+    if (StepCount and 255) = 0 then
+      CheckExecutionTimeout;
 
     Instr := AProgram.Code[PC];
     Op := TRegExpOpCode(Instr and $FF);
@@ -862,6 +870,13 @@ begin
   end;
   while StartPos <= Input.Length do
   begin
+    // Unanchored scans re-run the VM at every input position; on a long
+    // non-matching subject this loop runs millions of times inside one
+    // exec/test call, so poll the cooperative engine deadline here too.
+    // Deliberately unmasked: CheckExecutionTimeout's internal 1/1024 counter
+    // throttles deadlines > 16ms, and the always-check mode for <= 16ms
+    // deadlines is self-limiting (the expensive window lasts at most 16ms).
+    CheckExecutionTimeout;
     FillChar(Slots[0], SlotCount * SizeOf(Integer), $FF);
     if RunVM(AProgram, Input, StartPos, Slots, SlotCount) then
     begin

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -97,6 +97,13 @@ type
     // with the unbound-name raise, and TryGetBindingValue extracts the value.
     function TryGetBinding(const AName: string; out ABinding: TLexicalBinding;
       const ALine: Integer = 0; const AColumn: Integer = 0): Boolean; virtual;
+    // Own-scope read (own lexical, then own var) with no virtual dispatch
+    // and no parent walk — for adapter scopes that must read their own
+    // storage even when their TryGetBinding override resolves elsewhere
+    // first (e.g. direct-eval scopes whose override consults with-object
+    // bindings before the scope's own var environment).
+    function TryGetOwnBinding(const AName: string;
+      out ABinding: TLexicalBinding): Boolean;
     function GetBinding(const AName: string; const ALine: Integer = 0; const AColumn: Integer = 0): TLexicalBinding; virtual;
     function GetValue(const AName: string): TGocciaValue; virtual;
     function TryGetBindingValue(const AName: string;
@@ -936,6 +943,21 @@ begin
     Exit(True);
   end;
   Result := TryGetBindingSkipLexical(AName, ABinding);
+end;
+
+function TGocciaScope.TryGetOwnBinding(const AName: string;
+  out ABinding: TLexicalBinding): Boolean;
+begin
+  if FLexicalBindings.TryGetValue(AName, ABinding) then
+  begin
+    if not ABinding.IsAccessible then
+      RaiseBindingNotInitialized(AName, 0, 0);
+    Exit(True);
+  end;
+  if Assigned(FVarBindings) and FVarBindings.TryGetValue(AName, ABinding) then
+    Exit(True);
+  ABinding := Default(TLexicalBinding);
+  Result := False;
 end;
 
 function TGocciaScope.TryGetBindingValue(const AName: string;

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -41,6 +41,14 @@ type
     FNonStrictMode: Boolean;
     FArgumentsObjectEnabled: Boolean;
     FRejectArgumentsReferenceInDirectEval: Boolean;
+    // Shared tail of TryGetBinding / TryGetBindingValueFillCache:
+    // resolution after the own lexical map has already been consulted.
+    function TryGetBindingSkipLexical(const AName: string;
+      out ABinding: TLexicalBinding): Boolean;
+    procedure RaiseBindingNotInitialized(const AName: string;
+      const ALine, AColumn: Integer);
+    procedure RaiseUndefinedVariable(const AName: string;
+      const ALine, AColumn: Integer);
   protected
     function GetThisValue: TGocciaValue; virtual;
     function GetOwningClass: TGocciaValue; virtual;
@@ -84,9 +92,35 @@ type
     // Helper methods for token-based declarations
     procedure DefineFromToken(const AName: string; const AValue: TGocciaValue; const ATokenType: TGocciaTokenType);
 
-    // Core methods
+    // Core methods.  TryGetBinding is the single source of truth for read
+    // resolution (TDZ still raises; False when unbound); GetBinding wraps it
+    // with the unbound-name raise, and TryGetBindingValue extracts the value.
+    function TryGetBinding(const AName: string; out ABinding: TLexicalBinding;
+      const ALine: Integer = 0; const AColumn: Integer = 0): Boolean; virtual;
     function GetBinding(const AName: string; const ALine: Integer = 0; const AColumn: Integer = 0): TLexicalBinding; virtual;
     function GetValue(const AName: string): TGocciaValue; virtual;
+    function TryGetBindingValue(const AName: string;
+      out AValue: TGocciaValue): Boolean;
+    // Inline-cache fast path: re-read an own lexical binding by the entry
+    // index obtained from TryGetBindingValueFillCache, validated against the
+    // binding map's entry version.  TDZ still raises.  Returns False on any
+    // stale cache so the caller can fall back to the named lookup.
+    function TryGetLexicalValueAt(const AEntryIndex: Integer;
+      const AVersion: Cardinal; out AValue: TGocciaValue): Boolean; inline;
+    // Named lookup that reports the own-lexical entry index and map version
+    // for inline caching.  AEntryIndex is -1 when the value was resolved
+    // through the global this-object, var bindings, or the parent chain —
+    // those resolutions are not cacheable.
+    function TryGetBindingValueFillCache(const AName: string;
+      out AEntryIndex: Integer; out AVersion: Cardinal;
+      out AValue: TGocciaValue): Boolean;
+    // Single source of truth for assignment resolution (TDZ, const, and
+    // strict-type errors still raise); returns False when the name is
+    // unbound anywhere on the chain and never creates a binding.
+    // AssignBinding wraps it with the sloppy-global-create / raise outcome.
+    function TryAssignExistingBinding(const AName: string;
+      const AValue: TGocciaValue; const ANonStrictMode: Boolean = False;
+      const ALine: Integer = 0; const AColumn: Integer = 0): Boolean; virtual;
     function DeleteBinding(const AName: string): Boolean; virtual;
 
     function ResolveIdentifier(const AName: string): TGocciaValue; virtual;
@@ -211,9 +245,9 @@ type
     FCatchParameter: string;  // Track the catch parameter name for proper shadowing
   public
     constructor Create(const AParent: TGocciaScope; const ACatchParameter: string);
-    procedure AssignBinding(const AName: string; const AValue: TGocciaValue;
-      const ALine: Integer = 0; const AColumn: Integer = 0;
-      const ANonStrictMode: Boolean = False); override;
+    function TryAssignExistingBinding(const AName: string;
+      const AValue: TGocciaValue; const ANonStrictMode: Boolean = False;
+      const ALine: Integer = 0; const AColumn: Integer = 0): Boolean; override;
   end;
 
   TGocciaWithScope = class(TGocciaScope)
@@ -224,11 +258,11 @@ type
     constructor Create(const AParent: TGocciaScope;
       const ABindingObject: TGocciaObjectValue);
     procedure MarkReferences; override;
-    procedure AssignBinding(const AName: string; const AValue: TGocciaValue;
-      const ALine: Integer = 0; const AColumn: Integer = 0;
-      const ANonStrictMode: Boolean = False); override;
-    function GetBinding(const AName: string; const ALine: Integer = 0;
-      const AColumn: Integer = 0): TLexicalBinding; override;
+    function TryGetBinding(const AName: string; out ABinding: TLexicalBinding;
+      const ALine: Integer = 0; const AColumn: Integer = 0): Boolean; override;
+    function TryAssignExistingBinding(const AName: string;
+      const AValue: TGocciaValue; const ANonStrictMode: Boolean = False;
+      const ALine: Integer = 0; const AColumn: Integer = 0): Boolean; override;
     function DeleteBinding(const AName: string): Boolean; override;
     procedure ResolveIdentifierReference(const AName: string;
       out AValue, AThisValue: TGocciaValue; const ALine: Integer = 0;
@@ -769,10 +803,43 @@ end;
 
 procedure TGocciaScope.AssignBinding(const AName: string; const AValue: TGocciaValue; const ALine: Integer = 0; const AColumn: Integer = 0; const ANonStrictMode: Boolean = False);
 var
+  Root: TGocciaScope;
+  GlobalObject: TGocciaObjectValue;
+begin
+  // Single source of truth for assignment semantics is the virtual
+  // TryAssignExistingBinding; this wrapper only owns the unbound-name
+  // outcome: sloppy assignments create a property on the root global
+  // this-object, strict assignments raise.
+  if TryAssignExistingBinding(AName, AValue, ANonStrictMode, ALine, AColumn) then
+    Exit;
+
+  Root := Self;
+  while Assigned(Root.FParent) do
+    Root := Root.FParent;
+  if ANonStrictMode and (Root.FScopeKind = skGlobal) and
+     (Root.FThisValue is TGocciaObjectValue) then
+  begin
+    GlobalObject := TGocciaObjectValue(Root.FThisValue);
+    GlobalObject.AssignPropertyWithReceiver(AName, AValue, GlobalObject);
+    Exit;
+  end;
+
+  RaiseUndefinedVariable(AName, ALine, AColumn);
+end;
+
+function TGocciaScope.TryAssignExistingBinding(const AName: string;
+  const AValue: TGocciaValue; const ANonStrictMode: Boolean = False;
+  const ALine: Integer = 0; const AColumn: Integer = 0): Boolean;
+var
   LexicalBinding: TLexicalBinding;
   StrictActive: Boolean;
   GlobalObject: TGocciaObjectValue;
 begin
+  // Assignment resolution order: own lexical (TDZ, const, and strict-type
+  // errors still raise), global this-object property, own var binding, then
+  // parent chain.  Unbound names return False; the caller decides whether
+  // that is a ReferenceError or a sloppy global create (see AssignBinding).
+  //
   // Type hints recorded on bindings persist for the lifetime of the
   // binding; the live --strict-types flag (read from the root scope)
   // gates whether they enforce.  This mirrors the function-entry
@@ -781,34 +848,21 @@ begin
   // continuing to throw based on stale state.
   StrictActive := EffectiveStrictTypes;
 
-  // Try to find variable in current scope first
   if FLexicalBindings.TryGetValue(AName, LexicalBinding) then
   begin
-    // Check if variable is initialized (temporal dead zone for let/const)
     if not LexicalBinding.IsAccessible then
-      raise TGocciaReferenceError.Create(
-        Format(SErrorCannotAccessBeforeInit, [AName]),
-        ALine, AColumn, '', nil,
-        SSuggestTemporalDeadZone);
-
-    // Check if variable is writable
+      RaiseBindingNotInitialized(AName, ALine, AColumn);
     if not LexicalBinding.Writable then
       raise TGocciaTypeError.Create(
         Format(SErrorAssignToConstant, [AName]),
         ALine, AColumn, '', nil,
         SSuggestUseLetNotConst);
-
-    // Strict-types enforcement: when this binding has a recorded type
-    // hint and the live strict-types flag is on, throw a TypeError if
-    // the assigned value does not match.
     if StrictActive and (LexicalBinding.TypeHint <> sltUntyped) then
       EnforceStrictType(AValue, LexicalBinding.TypeHint);
-
-    // Update the value and mark as initialized
     LexicalBinding.Value := AValue;
     LexicalBinding.Initialized := True;
     FLexicalBindings.AddOrSetValue(AName, LexicalBinding);
-    Exit;
+    Exit(True);
   end;
 
   if (FScopeKind = skGlobal) and (FThisValue is TGocciaObjectValue) and
@@ -816,85 +870,147 @@ begin
   begin
     GlobalObject := TGocciaObjectValue(FThisValue);
     if ANonStrictMode then
-    begin
-      GlobalObject.AssignPropertyWithReceiver(AName, AValue, GlobalObject);
-      Exit;
-    end;
-    GlobalObject.AssignProperty(AName, AValue);
-    Exit;
+      GlobalObject.AssignPropertyWithReceiver(AName, AValue, GlobalObject)
+    else
+      GlobalObject.AssignProperty(AName, AValue);
+    Exit(True);
   end;
 
-  // Check var bindings on this scope
   if Assigned(FVarBindings) and FVarBindings.TryGetValue(AName, LexicalBinding) then
   begin
     if StrictActive and (LexicalBinding.TypeHint <> sltUntyped) then
       EnforceStrictType(AValue, LexicalBinding.TypeHint);
     LexicalBinding.Value := AValue;
     FVarBindings.AddOrSetValue(AName, LexicalBinding);
-    Exit;
+    Exit(True);
   end;
 
-  // Variable not found in current scope, try parent scope
   if Assigned(FParent) then
-  begin
-    FParent.AssignBinding(AName, AValue, ALine, AColumn, ANonStrictMode);
-    Exit;
-  end;
+    Exit(FParent.TryAssignExistingBinding(AName, AValue, ANonStrictMode,
+      ALine, AColumn));
 
-  if ANonStrictMode and (FScopeKind = skGlobal) and
-     (FThisValue is TGocciaObjectValue) then
-  begin
-    GlobalObject := TGocciaObjectValue(FThisValue);
-    GlobalObject.AssignPropertyWithReceiver(AName, AValue, GlobalObject);
-    Exit;
-  end;
+  Result := False;
+end;
 
+function TGocciaScope.GetBinding(const AName: string; const ALine: Integer = 0; const AColumn: Integer = 0): TLexicalBinding;
+begin
+  // Single source of truth for read resolution is the virtual
+  // TryGetBinding; this wrapper only owns the unbound-name raise.
+  if not TryGetBinding(AName, Result, ALine, AColumn) then
+    RaiseUndefinedVariable(AName, ALine, AColumn);
+end;
+
+procedure TGocciaScope.RaiseBindingNotInitialized(const AName: string;
+  const ALine, AColumn: Integer);
+begin
+  raise TGocciaReferenceError.Create(
+    Format(SErrorCannotAccessBeforeInit, [AName]),
+    ALine, AColumn, '', nil,
+    SSuggestTemporalDeadZone);
+end;
+
+procedure TGocciaScope.RaiseUndefinedVariable(const AName: string;
+  const ALine, AColumn: Integer);
+begin
   raise TGocciaReferenceError.Create(
     Format(SErrorUndefinedVariable, [AName]),
     ALine, AColumn, '', nil,
     SSuggestDeclareBeforeUse);
 end;
 
-function TGocciaScope.GetBinding(const AName: string; const ALine: Integer = 0; const AColumn: Integer = 0): TLexicalBinding;
-var
-  LexicalBinding: TLexicalBinding;
-begin
-  if FLexicalBindings.TryGetValue(AName, LexicalBinding) then
-  begin
-    if not LexicalBinding.IsAccessible then
-      raise TGocciaReferenceError.Create(
-        Format(SErrorCannotAccessBeforeInit, [AName]),
-        ALine, AColumn, '', nil,
-        SSuggestTemporalDeadZone);
-    Result := LexicalBinding;
-  end
-  else
-  begin
-    if (FScopeKind = skGlobal) and (FThisValue is TGocciaObjectValue) and
-       TGocciaObjectValue(FThisValue).HasProperty(AName) then
-    begin
-      Result.Value := TGocciaObjectValue(FThisValue).GetProperty(AName);
-      Result.DeclarationType := dtVar;
-      Result.Initialized := True;
-      Result.BuiltIn := False;
-      Result.CanDelete := False;
-      Result.TypeHint := sltUntyped;
-      Exit;
-    end;
-    if Assigned(FVarBindings) and FVarBindings.TryGetValue(AName, LexicalBinding) then
-      Exit(LexicalBinding);
-    if Assigned(FParent) then
-      Exit(FParent.GetBinding(AName, ALine, AColumn));
-    raise TGocciaReferenceError.Create(
-      Format(SErrorUndefinedVariable, [AName]),
-      ALine, AColumn, '', nil,
-      SSuggestDeclareBeforeUse);
-  end;
-end;
-
 function TGocciaScope.GetValue(const AName: string): TGocciaValue;
 begin
   Result := GetBinding(AName).Value;
+end;
+
+function TGocciaScope.TryGetBinding(const AName: string;
+  out ABinding: TLexicalBinding; const ALine: Integer = 0;
+  const AColumn: Integer = 0): Boolean;
+begin
+  // Resolution order: own lexical (with TDZ check), global this-object
+  // property, own var binding, then parent chain.
+  if FLexicalBindings.TryGetValue(AName, ABinding) then
+  begin
+    if not ABinding.IsAccessible then
+      RaiseBindingNotInitialized(AName, ALine, AColumn);
+    Exit(True);
+  end;
+  Result := TryGetBindingSkipLexical(AName, ABinding);
+end;
+
+function TGocciaScope.TryGetBindingValue(const AName: string;
+  out AValue: TGocciaValue): Boolean;
+var
+  LexicalBinding: TLexicalBinding;
+begin
+  Result := TryGetBinding(AName, LexicalBinding);
+  if Result then
+    AValue := LexicalBinding.Value
+  else
+    AValue := nil;
+end;
+
+function TGocciaScope.TryGetBindingSkipLexical(const AName: string;
+  out ABinding: TLexicalBinding): Boolean;
+begin
+  if (FScopeKind = skGlobal) and (FThisValue is TGocciaObjectValue) and
+     TGocciaObjectValue(FThisValue).HasProperty(AName) then
+  begin
+    ABinding.Value := TGocciaObjectValue(FThisValue).GetProperty(AName);
+    ABinding.DeclarationType := dtVar;
+    ABinding.Initialized := True;
+    ABinding.BuiltIn := False;
+    ABinding.CanDelete := False;
+    ABinding.TypeHint := sltUntyped;
+    Exit(True);
+  end;
+  if Assigned(FVarBindings) and FVarBindings.TryGetValue(AName, ABinding) then
+    Exit(True);
+  if Assigned(FParent) then
+    Exit(FParent.TryGetBinding(AName, ABinding));
+  ABinding := Default(TLexicalBinding);
+  Result := False;
+end;
+
+function TGocciaScope.TryGetLexicalValueAt(const AEntryIndex: Integer;
+  const AVersion: Cardinal; out AValue: TGocciaValue): Boolean;
+var
+  LexicalBinding: TLexicalBinding;
+begin
+  if (AVersion <> FLexicalBindings.EntryVersion) or
+     not FLexicalBindings.TryGetValueAtEntry(AEntryIndex, LexicalBinding) then
+  begin
+    AValue := nil;
+    Exit(False);
+  end;
+  if not LexicalBinding.IsAccessible then
+    RaiseBindingNotInitialized(FLexicalBindings.KeyAtEntry(AEntryIndex), 0, 0);
+  AValue := LexicalBinding.Value;
+  Result := True;
+end;
+
+function TGocciaScope.TryGetBindingValueFillCache(const AName: string;
+  out AEntryIndex: Integer; out AVersion: Cardinal;
+  out AValue: TGocciaValue): Boolean;
+var
+  LexicalBinding: TLexicalBinding;
+begin
+  if FLexicalBindings.TryGetEntryIndex(AName, AEntryIndex) then
+  begin
+    AVersion := FLexicalBindings.EntryVersion;
+    FLexicalBindings.TryGetValueAtEntry(AEntryIndex, LexicalBinding);
+    if not LexicalBinding.IsAccessible then
+      RaiseBindingNotInitialized(AName, 0, 0);
+    AValue := LexicalBinding.Value;
+    Exit(True);
+  end;
+  AEntryIndex := -1;
+  AVersion := 0;
+  Result := TryGetBindingSkipLexical(AName, LexicalBinding);
+  if Result then
+    AValue := LexicalBinding.Value
+  else
+    AValue := nil;
 end;
 
 function TGocciaScope.DeleteBinding(const AName: string): Boolean;
@@ -1157,21 +1273,20 @@ begin
   FCatchParameter := ACatchParameter;
 end;
 
-procedure TGocciaCatchScope.AssignBinding(const AName: string; const AValue: TGocciaValue; const ALine: Integer = 0; const AColumn: Integer = 0; const ANonStrictMode: Boolean = False);
+function TGocciaCatchScope.TryAssignExistingBinding(const AName: string;
+  const AValue: TGocciaValue; const ANonStrictMode: Boolean = False;
+  const ALine: Integer = 0; const AColumn: Integer = 0): Boolean;
 begin
-  // Surgical fix for catch parameter scopes: assignments to non-parameter variables
-  // should propagate to parent scope, but catch parameters should stay for proper shadowing
-  if (AName <> FCatchParameter) and (not FLexicalBindings.ContainsKey(AName)) and Assigned(FParent) then
-  begin
-    // This is a catch parameter scope and the variable isn't the catch parameter.
-    // Delegate directly to parent to ensure assignment propagation
-    FParent.AssignBinding(AName, AValue, ALine, AColumn, ANonStrictMode);
-  end
+  // Catch parameter shadowing: assignments to non-parameter names not bound
+  // on this scope propagate straight to the parent; the catch parameter
+  // itself (and anything declared here) uses base behavior.
+  if (AName <> FCatchParameter) and
+     (not FLexicalBindings.ContainsKey(AName)) and Assigned(FParent) then
+    Result := FParent.TryAssignExistingBinding(AName, AValue, ANonStrictMode,
+      ALine, AColumn)
   else
-  begin
-    // Either it's the catch parameter or it exists in current scope - use base behavior
-    inherited AssignBinding(AName, AValue, ALine, AColumn, ANonStrictMode);
-  end;
+    Result := inherited TryAssignExistingBinding(AName, AValue, ANonStrictMode,
+      ALine, AColumn);
 end;
 
 { TGocciaWithScope }
@@ -1211,39 +1326,38 @@ begin
     FBindingObject.MarkReferences;
 end;
 
-procedure TGocciaWithScope.AssignBinding(const AName: string;
-  const AValue: TGocciaValue; const ALine: Integer = 0;
-  const AColumn: Integer = 0; const ANonStrictMode: Boolean = False);
+function TGocciaWithScope.TryGetBinding(const AName: string;
+  out ABinding: TLexicalBinding; const ALine: Integer = 0;
+  const AColumn: Integer = 0): Boolean;
+begin
+  // Object-environment lookups come first.
+  if HasObjectBinding(AName) then
+  begin
+    ABinding.Value := FBindingObject.GetProperty(AName);
+    ABinding.DeclarationType := dtVar;
+    ABinding.Initialized := True;
+    ABinding.BuiltIn := False;
+    ABinding.CanDelete := False;
+    ABinding.TypeHint := sltUntyped;
+    Exit(True);
+  end;
+  Result := inherited TryGetBinding(AName, ABinding, ALine, AColumn);
+end;
+
+function TGocciaWithScope.TryAssignExistingBinding(const AName: string;
+  const AValue: TGocciaValue; const ANonStrictMode: Boolean = False;
+  const ALine: Integer = 0; const AColumn: Integer = 0): Boolean;
 begin
   if HasObjectBinding(AName) then
   begin
     if ANonStrictMode then
-    begin
-      FBindingObject.AssignPropertyWithReceiver(AName, AValue, FBindingObject);
-      Exit;
-    end;
-    FBindingObject.AssignProperty(AName, AValue);
-    Exit;
+      FBindingObject.AssignPropertyWithReceiver(AName, AValue, FBindingObject)
+    else
+      FBindingObject.AssignProperty(AName, AValue);
+    Exit(True);
   end;
-
-  inherited AssignBinding(AName, AValue, ALine, AColumn, ANonStrictMode);
-end;
-
-function TGocciaWithScope.GetBinding(const AName: string; const ALine: Integer = 0;
-  const AColumn: Integer = 0): TLexicalBinding;
-begin
-  if HasObjectBinding(AName) then
-  begin
-    Result.Value := FBindingObject.GetProperty(AName);
-    Result.DeclarationType := dtVar;
-    Result.Initialized := True;
-    Result.BuiltIn := False;
-    Result.CanDelete := False;
-    Result.TypeHint := sltUntyped;
-    Exit;
-  end;
-
-  Result := inherited GetBinding(AName, ALine, AColumn);
+  Result := inherited TryAssignExistingBinding(AName, AValue, ANonStrictMode,
+    ALine, AColumn);
 end;
 
 function TGocciaWithScope.DeleteBinding(const AName: string): Boolean;

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -44,7 +44,8 @@ type
     // Shared tail of TryGetBinding / TryGetBindingValueFillCache:
     // resolution after the own lexical map has already been consulted.
     function TryGetBindingSkipLexical(const AName: string;
-      out ABinding: TLexicalBinding): Boolean;
+      out ABinding: TLexicalBinding; const ALine: Integer = 0;
+      const AColumn: Integer = 0): Boolean;
     procedure RaiseBindingNotInitialized(const AName: string;
       const ALine, AColumn: Integer);
     procedure RaiseUndefinedVariable(const AName: string;
@@ -942,7 +943,7 @@ begin
       RaiseBindingNotInitialized(AName, ALine, AColumn);
     Exit(True);
   end;
-  Result := TryGetBindingSkipLexical(AName, ABinding);
+  Result := TryGetBindingSkipLexical(AName, ABinding, ALine, AColumn);
 end;
 
 function TGocciaScope.TryGetOwnBinding(const AName: string;
@@ -973,7 +974,8 @@ begin
 end;
 
 function TGocciaScope.TryGetBindingSkipLexical(const AName: string;
-  out ABinding: TLexicalBinding): Boolean;
+  out ABinding: TLexicalBinding; const ALine: Integer = 0;
+  const AColumn: Integer = 0): Boolean;
 begin
   if (FScopeKind = skGlobal) and (FThisValue is TGocciaObjectValue) and
      TGocciaObjectValue(FThisValue).HasProperty(AName) then
@@ -989,7 +991,7 @@ begin
   if Assigned(FVarBindings) and FVarBindings.TryGetValue(AName, ABinding) then
     Exit(True);
   if Assigned(FParent) then
-    Exit(FParent.TryGetBinding(AName, ABinding));
+    Exit(FParent.TryGetBinding(AName, ABinding, ALine, AColumn));
   ABinding := Default(TLexicalBinding);
   Result := False;
 end;

--- a/source/units/Goccia.Timeout.pas
+++ b/source/units/Goccia.Timeout.pas
@@ -44,7 +44,22 @@ procedure PopTimeoutScope;
 
 { Polled by the bytecode VM and other long-running loops. Raises
   TGocciaTimeoutError tagged with the soonest-deadline scope when
-  the deadline has elapsed. }
+  the deadline has elapsed.
+
+  Chokepoint rule for native loops: any native loop whose iteration count
+  scales with a JS-controlled value (array index/length, string length,
+  regex subject length, element count) must poll this between iterations —
+  the dispatch-loop polls cannot fire while a single native call runs.
+  Self-throttling makes an unmasked per-iteration call cheap (1023 of 1024
+  calls are a counter increment); loops too hot even for that should use a
+  small local mask (and 255), never larger — local masks COMPOSE with the
+  internal 1/1024 throttle, so a 4096 local mask would stretch real clock
+  reads to one per ~4.2M iterations and let deadlines overshoot by seconds.
+  Loops that mutate JS-visible state must restore consistency before the
+  raise propagates (see ExtendElementsWithHoles in Goccia.Values.HoleValue
+  for the rollback pattern).  Known not-yet-covered stalls: TypedArray
+  sort/fill over huge views, JSON parse/stringify of huge structures, and
+  String.prototype.repeat/pad building multi-GB strings in one call. }
 procedure CheckExecutionTimeout;
 
 implementation

--- a/source/units/Goccia.Utils.Arrays.pas
+++ b/source/units/Goccia.Utils.Arrays.pas
@@ -30,8 +30,7 @@ begin
     AArray.Elements[AIndex] := AValue
   else
   begin
-    while AArray.Elements.Count < AIndex do
-      AArray.Elements.Add(TGocciaHoleValue.HoleValue);
+    ExtendElementsWithHoles(AArray.Elements, AIndex);
     AArray.Elements.Add(AValue);
   end;
 end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1073,6 +1073,13 @@ begin
 
   if TryFindBinding(AName, Binding) then
   begin
+    // TDZ: a captured lexical binding still holding the hole sentinel has
+    // not been initialized yet; assignment through direct eval must raise
+    // the same ReferenceError the ordinary local/upvalue paths produce.
+    if BindingValue(Binding) = TGocciaHoleValue.HoleValue then
+      raise TGocciaReferenceError.Create(
+        Format(SErrorCannotAccessBeforeInit, [AName]),
+        ALine, AColumn, '', nil, SSuggestTemporalDeadZone);
     if Binding.IsConst then
       raise TGocciaTypeError.Create(
         Format(SErrorAssignToConstant, [AName]),

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -472,11 +472,11 @@ type
       const ALexicalClosure: TGocciaBytecodeClosure;
       const ANewTarget: TGocciaValue);
     procedure MarkReferences; override;
-    procedure AssignBinding(const AName: string; const AValue: TGocciaValue;
-      const ALine: Integer = 0; const AColumn: Integer = 0;
-      const ANonStrictMode: Boolean = False); override;
-    function GetBinding(const AName: string; const ALine: Integer = 0;
-      const AColumn: Integer = 0): TLexicalBinding; override;
+    function TryGetBinding(const AName: string; out ABinding: TLexicalBinding;
+      const ALine: Integer = 0; const AColumn: Integer = 0): Boolean; override;
+    function TryAssignExistingBinding(const AName: string;
+      const AValue: TGocciaValue; const ANonStrictMode: Boolean = False;
+      const ALine: Integer = 0; const AColumn: Integer = 0): Boolean; override;
     function DeleteBinding(const AName: string): Boolean; override;
     procedure ResolveIdentifierReference(const AName: string;
       out AValue, AThisValue: TGocciaValue; const ALine: Integer = 0;
@@ -1009,9 +1009,51 @@ begin
   Result := False;
 end;
 
-procedure TGocciaVMDirectEvalScope.AssignBinding(const AName: string;
-  const AValue: TGocciaValue; const ALine: Integer; const AColumn: Integer;
-  const ANonStrictMode: Boolean);
+// Direct-eval environments resolve through their own binding table before
+// the ordinary scope walk, so the Try* core must consult the with-object
+// bindings and the captured binding table first and only then fall through
+// to the inherited resolution.  GetBinding/AssignBinding need no overrides:
+// the base wrappers over these Try* methods reproduce them exactly.
+function TGocciaVMDirectEvalScope.TryGetBinding(const AName: string;
+  out ABinding: TLexicalBinding; const ALine: Integer = 0;
+  const AColumn: Integer = 0): Boolean;
+var
+  Binding: TGocciaDirectEvalBindingInfo;
+  WithObject: TGocciaObjectValue;
+begin
+  if TryFindWithObjectBinding(AName, WithObject) then
+  begin
+    ABinding.Value := WithObject.GetProperty(AName);
+    ABinding.DeclarationType := dtVar;
+    ABinding.Initialized := True;
+    ABinding.BuiltIn := False;
+    ABinding.CanDelete := False;
+    ABinding.TypeHint := sltUntyped;
+    Exit(True);
+  end;
+
+  if TryFindBinding(AName, Binding) then
+  begin
+    if (not Binding.IsConst) and ContainsOwnVarBinding(AName) then
+      Exit(inherited TryGetBinding(AName, ABinding, ALine, AColumn));
+    ABinding.Value := BindingValue(Binding);
+    if Binding.IsConst then
+      ABinding.DeclarationType := dtConst
+    else
+      ABinding.DeclarationType := dtVar;
+    ABinding.Initialized := True;
+    ABinding.BuiltIn := False;
+    ABinding.CanDelete := False;
+    ABinding.TypeHint := sltUntyped;
+    Exit(True);
+  end;
+
+  Result := inherited TryGetBinding(AName, ABinding, ALine, AColumn);
+end;
+
+function TGocciaVMDirectEvalScope.TryAssignExistingBinding(const AName: string;
+  const AValue: TGocciaValue; const ANonStrictMode: Boolean = False;
+  const ALine: Integer = 0; const AColumn: Integer = 0): Boolean;
 var
   Binding: TGocciaDirectEvalBindingInfo;
   WithObject: TGocciaObjectValue;
@@ -1022,14 +1064,12 @@ begin
       WithObject.AssignPropertyWithReceiver(AName, AValue, WithObject)
     else
       WithObject.AssignProperty(AName, AValue);
-    Exit;
+    Exit(True);
   end;
 
   if ContainsOwnVarBinding(AName) then
-  begin
-    inherited AssignBinding(AName, AValue, ALine, AColumn, ANonStrictMode);
-    Exit;
-  end;
+    Exit(inherited TryAssignExistingBinding(AName, AValue, ANonStrictMode,
+      ALine, AColumn));
 
   if TryFindBinding(AName, Binding) then
   begin
@@ -1043,44 +1083,11 @@ begin
     // environment, so assignments update the captured slot/upvalue directly
     // instead of creating a local var shadow in this adapter scope.
     SetBindingValue(Binding, AValue);
-    Exit;
-  end;
-  inherited AssignBinding(AName, AValue, ALine, AColumn, ANonStrictMode);
-end;
-
-function TGocciaVMDirectEvalScope.GetBinding(const AName: string;
-  const ALine: Integer; const AColumn: Integer): TLexicalBinding;
-var
-  Binding: TGocciaDirectEvalBindingInfo;
-  WithObject: TGocciaObjectValue;
-begin
-  if TryFindWithObjectBinding(AName, WithObject) then
-  begin
-    Result.Value := WithObject.GetProperty(AName);
-    Result.DeclarationType := dtVar;
-    Result.Initialized := True;
-    Result.BuiltIn := False;
-    Result.CanDelete := False;
-    Result.TypeHint := sltUntyped;
-    Exit;
+    Exit(True);
   end;
 
-  if TryFindBinding(AName, Binding) then
-  begin
-    if (not Binding.IsConst) and ContainsOwnVarBinding(AName) then
-      Exit(inherited GetBinding(AName, ALine, AColumn));
-    Result.Value := BindingValue(Binding);
-    if Binding.IsConst then
-      Result.DeclarationType := dtConst
-    else
-      Result.DeclarationType := dtVar;
-    Result.Initialized := True;
-    Result.BuiltIn := False;
-    Result.CanDelete := False;
-    Result.TypeHint := sltUntyped;
-    Exit;
-  end;
-  Result := inherited GetBinding(AName, ALine, AColumn);
+  Result := inherited TryAssignExistingBinding(AName, AValue, ANonStrictMode,
+    ALine, AColumn);
 end;
 
 function TGocciaVMDirectEvalScope.DeleteBinding(const AName: string): Boolean;
@@ -2786,6 +2793,10 @@ begin
       Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
     on E: TGocciaRuntimeError do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -2862,6 +2873,10 @@ begin
       Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
     on E: TGocciaRuntimeError do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -2955,6 +2970,10 @@ begin
       Result := PromiseReject(CreateErrorObject(SYNTAX_ERROR_NAME, E.Message));
     on E: TGocciaRuntimeError do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -3771,6 +3790,10 @@ begin
       FPromise.Reject(CreateErrorObject(TYPE_ERROR_NAME, E.Message));
     on E: TGocciaReferenceError do
       FPromise.Reject(CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
     on E: Exception do
       FPromise.Reject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -10683,6 +10706,8 @@ var
   CallArgs: TGocciaArgumentsCollection;
   I: Integer;
   GlobalName: string;
+  GlobalBindingValue: TGocciaValue;
+  GlobalReadCache: PGocciaGlobalReadCacheEntry;
   AttributeType: string;
   SpecifierString: string;
   Upvalue: TGocciaBytecodeUpvalue;
@@ -13433,14 +13458,55 @@ begin
 
       OP_GET_GLOBAL:
       begin
-        GlobalName := Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue;
-        if HasDynamicVarBinding(FCurrentDynamicVarScope, GlobalName) then
-          FRegisters[A] := VMValueToRegisterFast(
-            FCurrentDynamicVarScope.GetValue(GlobalName))
-        else if Assigned(FGlobalScope) and FGlobalScope.Contains(GlobalName) then
-          FRegisters[A] := VMValueToRegisterFast(FGlobalScope.GetValue(GlobalName))
+        if Assigned(FCurrentDynamicVarScope) or not Assigned(FGlobalScope) then
+        begin
+          GlobalName := Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue;
+          if HasDynamicVarBinding(FCurrentDynamicVarScope, GlobalName) then
+            FRegisters[A] := VMValueToRegisterFast(
+              FCurrentDynamicVarScope.GetValue(GlobalName))
+          else if Assigned(FGlobalScope) and
+                  FGlobalScope.TryGetBindingValue(GlobalName, GlobalBindingValue) then
+            FRegisters[A] := VMValueToRegisterFast(GlobalBindingValue)
+          else
+            FRegisters[A] := RegisterUndefined;
+        end
         else
-          FRegisters[A] := RegisterUndefined;
+        begin
+          // Hot shape: per-site inline cache keyed by the name-constant
+          // index, validated against (scope identity, binding-map version).
+          // A nil slot (out-of-range constant index in corrupt bytecode)
+          // degrades to the uncached single-lookup read.  A miss leaves
+          // Scope untouched: EntryIndex = -1 alone guarantees the next
+          // validation fails.
+          GlobalReadCache := Template.GlobalReadCacheSlot(DecodeBx(Instruction));
+          if Assigned(GlobalReadCache) and
+             (GlobalReadCache^.Scope = Pointer(FGlobalScope)) and
+             FGlobalScope.TryGetLexicalValueAt(GlobalReadCache^.EntryIndex,
+               GlobalReadCache^.Version, GlobalBindingValue) then
+            FRegisters[A] := VMValueToRegisterFast(GlobalBindingValue)
+          else
+          begin
+            GlobalName := Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue;
+            if Assigned(GlobalReadCache) then
+            begin
+              if FGlobalScope.TryGetBindingValueFillCache(GlobalName,
+                GlobalReadCache^.EntryIndex, GlobalReadCache^.Version,
+                GlobalBindingValue) then
+              begin
+                if GlobalReadCache^.EntryIndex >= 0 then
+                  GlobalReadCache^.Scope := Pointer(FGlobalScope);
+                FRegisters[A] := VMValueToRegisterFast(GlobalBindingValue);
+              end
+              else
+                FRegisters[A] := RegisterUndefined;
+            end
+            else if FGlobalScope.TryGetBindingValue(GlobalName,
+              GlobalBindingValue) then
+              FRegisters[A] := VMValueToRegisterFast(GlobalBindingValue)
+            else
+              FRegisters[A] := RegisterUndefined;
+          end;
+        end;
       end;
 
       OP_SET_GLOBAL:
@@ -13451,9 +13517,8 @@ begin
             RegisterToValue(FRegisters[A]))
         else if Assigned(FGlobalScope) then
         begin
-          if FGlobalScope.Contains(GlobalName) then
-            FGlobalScope.AssignBinding(GlobalName, RegisterToValue(FRegisters[A]))
-          else
+          if not FGlobalScope.TryAssignExistingBinding(GlobalName,
+            RegisterToValue(FRegisters[A])) then
             ThrowReferenceError(GlobalName + ' is not defined');
         end;
       end;
@@ -13466,10 +13531,9 @@ begin
             RegisterToValue(FRegisters[A]), 0, 0, True)
         else if Assigned(FGlobalScope) then
         begin
-          if FGlobalScope.Contains(GlobalName) then
-            FGlobalScope.AssignBinding(GlobalName,
-              RegisterToValue(FRegisters[A]), 0, 0, True)
-          else if FGlobalScope.ThisValue is TGocciaObjectValue then
+          if (not FGlobalScope.TryAssignExistingBinding(GlobalName,
+            RegisterToValue(FRegisters[A]), True)) and
+             (FGlobalScope.ThisValue is TGocciaObjectValue) then
             TGocciaObjectValue(FGlobalScope.ThisValue).AssignPropertyWithReceiver(
               GlobalName, RegisterToValue(FRegisters[A]), FGlobalScope.ThisValue);
         end;
@@ -13614,6 +13678,10 @@ begin
             on E: TGocciaReferenceError do
               DynImportPromise.Reject(
                 CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+            on E: TGocciaTimeoutError do
+              raise;
+            on E: TGocciaInstructionLimitError do
+              raise;
             on E: Exception do
               DynImportPromise.Reject(
                 CreateErrorObject(ERROR_NAME, E.Message));
@@ -13682,6 +13750,10 @@ begin
             on E: TGocciaReferenceError do
               DynImportPromise.Reject(
                 CreateErrorObject(REFERENCE_ERROR_NAME, E.Message));
+            on E: TGocciaTimeoutError do
+              raise;
+            on E: TGocciaInstructionLimitError do
+              raise;
             on E: Exception do
               DynImportPromise.Reject(
                 CreateErrorObject(ERROR_NAME, E.Message));
@@ -13801,6 +13873,10 @@ begin
               else
                 SetRegister(A, E.Value);
             end;
+            on E: TGocciaTimeoutError do
+              raise;
+            on E: TGocciaInstructionLimitError do
+              raise;
             on E: Exception do
             begin
               // Preserve typed error names for native Goccia exceptions

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1175,8 +1175,12 @@ begin
       Continue;
     if ContainsOwnVarBinding(Binding.Name) and (Binding.Kind <> debUpvalue) then
     begin
-      LexicalBinding := inherited GetBinding(Binding.Name);
-      SetBindingValue(Binding, LexicalBinding.Value);
+      // Read this scope's own var environment directly: GetBinding would
+      // dispatch back through this scope's TryGetBinding override, whose
+      // with-object head shadows the var binding being copied back
+      // (Annex B function-in-block hoisting inside `with`).
+      if TryGetOwnBinding(Binding.Name, LexicalBinding) then
+        SetBindingValue(Binding, LexicalBinding.Value);
     end;
   end;
 end;
@@ -1195,7 +1199,8 @@ begin
   begin
     if not ContainsOwnVarBinding(Name) then
       Continue;
-    Binding := inherited GetBinding(Name);
+    if not TryGetOwnBinding(Name, Binding) then
+      Continue;
     Parent.DefineVariableBinding(Name, Binding.Value, True, True);
   end;
 end;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -461,8 +461,7 @@ begin
   begin
     while Arr.Elements.Count > ANewLen do
       Arr.Elements.Delete(Arr.Elements.Count - 1);
-    while Arr.Elements.Count < ANewLen do
-      Arr.Elements.Add(TGocciaHoleValue.HoleValue);
+    ExtendElementsWithHoles(Arr.Elements, ANewLen);
     Arr.FLength := ANewLen;
   end
   else
@@ -526,11 +525,22 @@ begin
     (AIndex < MAX_ARRAY_LENGTH);
 end;
 
-function CanStoreDenseElementIndex(const AIndex: Int64): Boolean;
+// Largest hole-pad a single index assignment may add to dense storage.
+// A write within this gap of the current element count stays dense (the
+// pad is at most ~8 MB of pointers); a farther jump routes to the ordinary
+// property map — the same sparse storage indices >= MaxInt always use —
+// so `x[2 ** 31 - 2] = v` no longer materializes billions of dense slots.
+const
+  MAX_DENSE_EXTENSION_GAP = 1024 * 1024;
+
+function CanStoreDenseElementIndex(const AIndex: Int64;
+  const ACurrentCount: Integer): Boolean;
 begin
   // FElements is backed by Integer-indexed TList; keep the final legal dense
   // slot below MaxInt so growing Count never needs MaxInt + 1 entries.
-  Result := (AIndex >= 0) and (AIndex < MaxInt);
+  // Indices below ACurrentCount always pass (existing dense storage).
+  Result := (AIndex >= 0) and (AIndex < MaxInt) and
+    (AIndex <= Int64(ACurrentCount) + MAX_DENSE_EXTENSION_GAP);
 end;
 
 function CompareInt64(constref A, B: Int64): Integer;
@@ -655,11 +665,18 @@ begin
     if (NewLen <> AArray.FLength) and not AArray.FLengthWritable then
       Exit(False);
 
-    if NewLen >= AArray.FElements.Count then
+    // Grow/keep vs shrink must compare against the spec-visible length, not
+    // the dense element count: sparse arrays (property-map indices) keep
+    // FLength above FElements.Count, and a shrink must still delete those
+    // map-stored indices via DeleteArrayIndexesAtOrAbove below.
+    if NewLen >= AArray.FLength then
     begin
-      if NewLen <= MaxInt then
-        while AArray.FElements.Count < NewLen do
-          AArray.FElements.Add(TGocciaHoleValue.HoleValue);
+      // Only materialize dense holes when the new length stays within the
+      // dense extension gap; a far-out length leaves the tail sparse, the
+      // same storage a far index assignment uses.
+      if (NewLen <= MaxInt) and
+         (NewLen <= Int64(AArray.FElements.Count) + MAX_DENSE_EXTENSION_GAP) then
+        ExtendElementsWithHoles(AArray.FElements, NewLen);
       AArray.FLength := NewLen;
       if ADescriptor.HasWritableField and not ADescriptor.Writable then
         AArray.FLengthWritable := False;
@@ -669,8 +686,8 @@ begin
     NewWritable := not (ADescriptor.HasWritableField and not ADescriptor.Writable);
     if not DeleteArrayIndexesAtOrAbove(AArray, NewLen, FailedIndex) then
     begin
-      while (FailedIndex < MaxInt) and (AArray.FElements.Count <= FailedIndex) do
-        AArray.FElements.Add(TGocciaHoleValue.HoleValue);
+      if FailedIndex < MaxInt then
+        ExtendElementsWithHoles(AArray.FElements, FailedIndex + 1);
       AArray.FLength := FailedIndex + 1;
       if not NewWritable then
         AArray.FLengthWritable := False;
@@ -1139,10 +1156,7 @@ begin
       FLength := IntLen;
       if IntLen > MaxInt then
         Exit;
-      // FPC rejects Int64 as a for-loop counter on 32-bit targets; IntLen
-      // is bounded by MaxInt above, so the Integer narrowing is safe.
-      for I := 0 to Integer(IntLen) - 1 do
-        FElements.Add(TGocciaHoleValue.HoleValue);
+      ExtendElementsWithHoles(FElements, IntLen);
     end
     else
     begin
@@ -1225,8 +1239,7 @@ begin
   end;
 
   // Extend array if necessary
-  while FElements.Count <= AIndex do
-    FElements.Add(TGocciaHoleValue.HoleValue);
+  ExtendElementsWithHoles(FElements, Int64(AIndex) + 1);
 
   FElements[AIndex] := AValue;
   if AIndex + 1 > FLength then
@@ -1311,8 +1324,7 @@ begin
     end;
 
     // Ensure result has correct length (preserve trailing holes)
-    while ResultArray.Elements.Count < View.Len do
-      ResultArray.Elements.Add(TGocciaHoleValue.HoleValue);
+    ExtendElementsWithHoles(ResultArray.Elements, View.Len);
 
     Result := ResultArray;
   finally
@@ -2143,8 +2155,7 @@ begin
   end;
 
   // Ensure result has correct length (preserve trailing holes)
-  while ResultArray.Elements.Count < N do
-    ResultArray.Elements.Add(TGocciaHoleValue.HoleValue);
+  ExtendElementsWithHoles(ResultArray.Elements, N);
 
   // Step 11: Return A
   Result := ResultArray;
@@ -2732,8 +2743,7 @@ begin
     Inc(N);
   end;
   // Ensure result reflects trailing holes from this spread
-  while AResult.Elements.Count < N do
-    AResult.Elements.Add(TGocciaHoleValue.HoleValue);
+  ExtendElementsWithHoles(AResult.Elements, N);
 end;
 
 // ES2026 §23.1.3.1 Array.prototype.concat(...arguments)
@@ -3120,7 +3130,7 @@ begin
   // Check if property name is a numeric index
   if TryParseArrayElementIndex(AName, Index) then
   begin
-    if CanStoreDenseElementIndex(Index) and
+    if CanStoreDenseElementIndex(Index, FElements.Count) and
        (Index < FElements.Count) and
        not IsArrayHole(FElements[Integer(Index)]) then
     begin
@@ -3158,11 +3168,10 @@ begin
       ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [AName]),
         SSuggestCannotDeleteNonConfigurable);
 
-    if CanStoreDenseElementIndex(Index) then
+    if CanStoreDenseElementIndex(Index, FElements.Count) then
     begin
       // Expand array if necessary
-      while FElements.Count <= Index do
-        FElements.Add(TGocciaHoleValue.HoleValue);
+      ExtendElementsWithHoles(FElements, Int64(Index) + 1);
 
       // Set the element
       FElements[Integer(Index)] := AValue;
@@ -3198,7 +3207,7 @@ var
   Index: Int64;
 begin
   if TryParseArrayElementIndex(AName, Index) and
-     CanStoreDenseElementIndex(Index) and
+     CanStoreDenseElementIndex(Index, FElements.Count) and
      (Index < FElements.Count) and
      not IsArrayHole(FElements[Integer(Index)]) then
     Result := True
@@ -3277,7 +3286,7 @@ var
   Index: Int64;
 begin
   if TryParseArrayElementIndex(AName, Index) and
-     CanStoreDenseElementIndex(Index) and
+     CanStoreDenseElementIndex(Index, FElements.Count) and
      (Index < FElements.Count) and
      not IsArrayHole(FElements[Integer(Index)]) then
     Result := TGocciaPropertyDescriptorData.Create(FElements[Integer(Index)], [pfEnumerable, pfConfigurable, pfWritable])
@@ -3323,7 +3332,7 @@ begin
       ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [AName]),
         SSuggestCannotDeleteNonConfigurable);
 
-    if CanStoreDenseElementIndex(Index) and
+    if CanStoreDenseElementIndex(Index, FElements.Count) and
        (Index < FElements.Count) and
        (FElements[Integer(Index)] <> TGocciaHoleValue.HoleValue) then
     begin
@@ -3350,11 +3359,10 @@ begin
       Exit;
     end;
 
-    if CanStoreDenseElementIndex(Index) and
+    if CanStoreDenseElementIndex(Index, FElements.Count) and
        CanCreateDenseArrayElement(ADescriptor) then
     begin
-      while FElements.Count <= Index do
-        FElements.Add(TGocciaHoleValue.HoleValue);
+      ExtendElementsWithHoles(FElements, Int64(Index) + 1);
       FElements[Integer(Index)] := TGocciaPropertyDescriptorData(ADescriptor).Value;
       if Index + 1 > FLength then
         FLength := Index + 1;
@@ -3365,12 +3373,11 @@ begin
     // Non-dense descriptors must be stored in the ordinary property map so
     // missing/defaulted attributes keep their spec values.
     inherited DefineProperty(AName, ADescriptor);
-    if CanStoreDenseElementIndex(Index) then
-      while FElements.Count <= Index do
-        FElements.Add(TGocciaHoleValue.HoleValue);
+    if CanStoreDenseElementIndex(Index, FElements.Count) then
+      ExtendElementsWithHoles(FElements, Int64(Index) + 1);
     if Index + 1 > FLength then
       FLength := Index + 1;
-    if CanStoreDenseElementIndex(Index) and
+    if CanStoreDenseElementIndex(Index, FElements.Count) and
        not IsArrayHole(FElements[Integer(Index)]) then
       FElements[Integer(Index)] := TGocciaHoleValue.HoleValue;
     Exit;
@@ -3404,7 +3411,7 @@ begin
       Exit(False);
     end;
 
-    if CanStoreDenseElementIndex(Index) and
+    if CanStoreDenseElementIndex(Index, FElements.Count) and
        (Index < FElements.Count) and
        (FElements[Integer(Index)] <> TGocciaHoleValue.HoleValue) then
     begin
@@ -3431,11 +3438,10 @@ begin
       Exit;
     end;
 
-    if CanStoreDenseElementIndex(Index) and
+    if CanStoreDenseElementIndex(Index, FElements.Count) and
        CanCreateDenseArrayElement(ADescriptor) then
     begin
-      while FElements.Count <= Index do
-        FElements.Add(TGocciaHoleValue.HoleValue);
+      ExtendElementsWithHoles(FElements, Int64(Index) + 1);
       FElements[Integer(Index)] := TGocciaPropertyDescriptorData(ADescriptor).Value;
       if Index + 1 > FLength then
         FLength := Index + 1;
@@ -3449,12 +3455,11 @@ begin
     Result := inherited TryDefineProperty(AName, ADescriptor);
     if Result then
     begin
-      if CanStoreDenseElementIndex(Index) then
-        while FElements.Count <= Index do
-          FElements.Add(TGocciaHoleValue.HoleValue);
+      if CanStoreDenseElementIndex(Index, FElements.Count) then
+        ExtendElementsWithHoles(FElements, Int64(Index) + 1);
       if Index + 1 > FLength then
         FLength := Index + 1;
-      if CanStoreDenseElementIndex(Index) and
+      if CanStoreDenseElementIndex(Index, FElements.Count) and
          not IsArrayHole(FElements[Integer(Index)]) then
         FElements[Integer(Index)] := TGocciaHoleValue.HoleValue;
     end;
@@ -3741,8 +3746,7 @@ begin
   end;
 
   // Ensure removed array has correct length (preserve trailing holes)
-  while Removed.Elements.Count < DeleteCount do
-    Removed.Elements.Add(TGocciaHoleValue.HoleValue);
+  ExtendElementsWithHoles(Removed.Elements, DeleteCount);
 
   // Step 17: Return A
   Result := Removed;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -686,7 +686,7 @@ begin
     NewWritable := not (ADescriptor.HasWritableField and not ADescriptor.Writable);
     if not DeleteArrayIndexesAtOrAbove(AArray, NewLen, FailedIndex) then
     begin
-      if FailedIndex < MaxInt then
+      if CanStoreDenseElementIndex(FailedIndex, AArray.FElements.Count) then
         ExtendElementsWithHoles(AArray.FElements, FailedIndex + 1);
       AArray.FLength := FailedIndex + 1;
       if not NewWritable then

--- a/source/units/Goccia.Values.Await.pas
+++ b/source/units/Goccia.Values.Await.pas
@@ -23,7 +23,9 @@ uses
   Goccia.Error.Suggestions,
   Goccia.FetchManager,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.MicrotaskQueue,
+  Goccia.Timeout,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -114,6 +116,10 @@ begin
             try
               TGocciaFunctionBase(ThenMethod).Call(ThenArgs, AValue);
             except
+              on E: TGocciaTimeoutError do
+                raise;
+              on E: TGocciaInstructionLimitError do
+                raise;
               on E: Exception do
                 RejectPromiseWithException(Promise, E);
             end;
@@ -130,6 +136,10 @@ begin
           Exit;
         end;
       except
+        on E: TGocciaTimeoutError do
+          raise;
+        on E: TGocciaInstructionLimitError do
+          raise;
         on E: Exception do
           RejectPromiseWithException(Promise, E);
       end;

--- a/source/units/Goccia.Values.HoleValue.pas
+++ b/source/units/Goccia.Values.HoleValue.pas
@@ -46,6 +46,16 @@ var
   StartCount: Integer;
 begin
   StartCount := AElements.Count;
+  // Fast path: small extensions skip both the poll and the rollback frame.
+  // Sequential element writes extend by one slot at a time, and an FPC
+  // try/except frame per append is a measurable tax on every array-building
+  // loop; a bounded extension cannot stall, so neither is needed.
+  if ACount - StartCount <= 1024 then
+  begin
+    while AElements.Count < ACount do
+      AElements.Add(TGocciaHoleValue.HoleValue);
+    Exit;
+  end;
   try
     while AElements.Count < ACount do
     begin

--- a/source/units/Goccia.Values.HoleValue.pas
+++ b/source/units/Goccia.Values.HoleValue.pas
@@ -24,10 +24,40 @@ type
     function ToStringLiteral: TGocciaStringLiteralValue; override;
   end;
 
+// Dense hole-fill: extend AElements with holes until it holds ACount
+// entries.  A single huge index (e.g. `x[2 ** 24] = v`) fills millions of
+// slots in one native call, so the loop mask-polls the cooperative timeout
+// to keep the engine deadline reachable.  If the deadline (or any other
+// exception) fires mid-fill, the list is truncated back to its pre-fill
+// count before re-raising, so callers never observe a partially extended
+// list — extension stays atomic with respect to JS-visible state.
+procedure ExtendElementsWithHoles(const AElements: TGocciaValueList;
+  const ACount: Int64);
+
 implementation
 
 uses
-  Goccia.Constants.TypeNames;
+  Goccia.Constants.TypeNames,
+  Goccia.Timeout;
+
+procedure ExtendElementsWithHoles(const AElements: TGocciaValueList;
+  const ACount: Int64);
+var
+  StartCount: Integer;
+begin
+  StartCount := AElements.Count;
+  try
+    while AElements.Count < ACount do
+    begin
+      AElements.Add(TGocciaHoleValue.HoleValue);
+      if (AElements.Count and 1023) = 0 then
+        CheckExecutionTimeout;
+    end;
+  except
+    AElements.Count := StartCount;
+    raise;
+  end;
+end;
 
 class function TGocciaHoleValue.HoleValue: TGocciaHoleValue;
 begin

--- a/tests/built-ins/Array/far-index-assignment.js
+++ b/tests/built-ins/Array/far-index-assignment.js
@@ -1,0 +1,47 @@
+test("assignment to a far index completes without materializing dense storage", () => {
+  const arr = [];
+  arr[2 ** 31 - 2] = 7;
+  expect(arr.length).toBe(2 ** 31 - 1);
+  expect(arr[2 ** 31 - 2]).toBe(7);
+  expect(arr[0]).toBeUndefined();
+  expect(arr[2 ** 30]).toBeUndefined();
+});
+
+test("far index after existing elements preserves both", () => {
+  const arr = [1, 2, 3];
+  arr[2 ** 30] = "far";
+  expect(arr.length).toBe(2 ** 30 + 1);
+  expect(arr[0]).toBe(1);
+  expect(arr[2]).toBe(3);
+  expect(arr[2 ** 30]).toBe("far");
+  expect(arr[2 ** 29]).toBeUndefined();
+});
+
+test("power-of-two index sweep stays fast", () => {
+  const arr = [];
+  let k = 1;
+  for (const _ of Array(31).keys()) {
+    k = k * 2;
+    arr[k - 2] = k;
+  }
+  expect(arr.length).toBe(k - 1);
+  expect(arr[k - 2]).toBe(k);
+  expect(arr[2]).toBe(4);
+  expect(arr[0]).toBe(2);
+});
+
+test("near-gap assignment stays within dense growth", () => {
+  const arr = [];
+  arr[1000] = "near";
+  expect(arr.length).toBe(1001);
+  expect(arr[1000]).toBe("near");
+  expect(arr[999]).toBeUndefined();
+});
+
+test("far index then truncating length removes the element", () => {
+  const arr = [];
+  arr[2 ** 30] = "far";
+  arr.length = 10;
+  expect(arr.length).toBe(10);
+  expect(arr[2 ** 30]).toBeUndefined();
+});

--- a/tests/language/expressions/string/template-interpolation-regex.js
+++ b/tests/language/expressions/string/template-interpolation-regex.js
@@ -1,0 +1,124 @@
+/*---
+description: Regex literals inside ${...} template interpolation expressions
+features: [template-literals, interpolation-boundaries, regexp]
+---*/
+
+describe("template interpolation regex literal scanning", () => {
+  test("regex with single quote inside interpolation", () => {
+    const x = `${"a'b".replace(/'/g, "-")}`;
+    expect(x).toBe("a-b");
+  });
+
+  test("regex with single quote and escaped-quote replacement string", () => {
+    const x = `${"a'b".replace(/'/g, "\\'")}`;
+    expect(x).toBe("a\\'b");
+  });
+
+  test("regex with double quote inside interpolation", () => {
+    const x = `${'a"b'.replace(/"/g, "-")}`;
+    expect(x).toBe("a-b");
+  });
+
+  test("regex containing closing brace inside interpolation", () => {
+    const x = `${/x}/.test("x}")}`;
+    expect(x).toBe("true");
+  });
+
+  test("regex character class with quote and brace", () => {
+    const x = `${/['}]/.test("'")}`;
+    expect(x).toBe("true");
+  });
+
+  test("regex character class with unescaped slash", () => {
+    const x = `${/[/]/.test("/")}`;
+    expect(x).toBe("true");
+  });
+
+  test("regex at interpolation expression start", () => {
+    const x = `${/'/.source}`;
+    expect(x).toBe("'");
+  });
+
+  test("regex after ternary question mark", () => {
+    const x = `${true ? /q'/.test("q'") : false}`;
+    expect(x).toBe("true");
+  });
+
+  test("regex inside nested template interpolation", () => {
+    const x = `${`inner ${/n'/.test("n'")}`}`;
+    expect(x).toBe("inner true");
+  });
+
+  test("division after numeric literal is not a regex", () => {
+    const x = `${8 / 2}`;
+    expect(x).toBe("4");
+  });
+
+  test("division after parenthesized expression is not a regex", () => {
+    const x = `${(8) / 2}`;
+    expect(x).toBe("4");
+  });
+
+  test("division after array element access is not a regex", () => {
+    const x = `${[8][0] / 2}`;
+    expect(x).toBe("4");
+  });
+
+  test("division after identifier is not a regex", () => {
+    const n = 8;
+    const x = `${n / 2}`;
+    expect(x).toBe("4");
+  });
+
+  test("chained division stays division", () => {
+    const x = `${8 / 2 / 2}`;
+    expect(x).toBe("2");
+  });
+
+  test("regex with flags followed by method call", () => {
+    const x = `${"AbAb".replace(/ab/gi, "-")}`;
+    expect(x).toBe("--");
+  });
+
+  test("typeof keyword allows a regex operand", () => {
+    const x = `${typeof /k'/}`;
+    expect(x).toBe("object");
+  });
+
+  test("string then division then regex in one interpolation", () => {
+    const x = `${"a'a".split(/'/).length / 2}`;
+    expect(x).toBe("1");
+  });
+
+  test("division after trailing-dot numeric literal", () => {
+    const x = `${1. / 2}`;
+    expect(x).toBe("0.5");
+  });
+
+  test("division after trailing-dot numeric literal without spaces", () => {
+    const x = `${1./2}`;
+    expect(x).toBe("0.5");
+  });
+
+  test("chained division after trailing-dot numeric literal", () => {
+    const x = `${1./2/2}`;
+    expect(x).toBe("0.25");
+  });
+
+  test("regex after while-head close paren inside arrow body", () => {
+    const s = "x}";
+    const x = `${(() => { while (false) /[}]/.test(s); return 7; })()}`;
+    expect(x).toBe("7");
+  });
+
+  test("division after ordinary close paren still divides", () => {
+    const x = `${(() => 8)() / 2}`;
+    expect(x).toBe("4");
+  });
+
+  test("slash without same-line closing slash stays division", () => {
+    const total = 10;
+    const x = `${total / 2}`;
+    expect(x).toBe("5");
+  });
+});


### PR DESCRIPTION
## Summary

Performance and correctness batch from the test262 conformance/performance analysis, plus all 10 findings from the follow-up code review.

**Performance**

- CI test262 runs at `--jobs=4` (public-repo `ubuntu-latest` runners have 4 vCPUs); the old `--jobs=2` guard targeted the retired chunked-runner architecture.
- Fixes the #740 global-read regression: top-level lexical bindings became string-keyed global map reads (`Contains` + `GetValue`, 2–3 hash probes per access). Reads now use a single-lookup `TryGetBinding` plus a version-validated **inline cache** per `OP_GET_GLOBAL` site (entry-index API + uniquely-seeded `EntryVersion` stamps on `TOrderedStringMap`, invalidated by Remove/Compact/Clear; cached scope pointer is compared, never dereferenced). `fib(30)`: 2.78s → 2.42s user (pre-#740 floor 2.28s).
- Far-jump array indices route to the existing sparse property-map storage (`MAX_DENSE_EXTENSION_GAP` = 1M): `x[2**31 - 2] = v` drops from **62s / ~17GB to 0.02s**.

**Correctness**

- Template interpolations now lex regex literals: `ScanInterpolationExpression` classifies regex-vs-division like `UpdateRegexContext` (keyword set, digit-dot rule, paren-context stack) with a same-line closing-slash lookahead so misclassification degrades gracefully. Unblocks the ~2,800 Temporal test262 tests that failed to parse `temporalHelpers.js` (Temporal/Duration slice: 0 → 326/540). The pre-existing expression-context flaws shared with the main lexer are tracked in #743.
- `--timeout` is now a hard deadline: cooperative polls in dense array hole-fills (shared `ExtendElementsWithHoles` with rollback-on-abort so partial fills are never observable) and in the regex VM scan/step loops (255-step mask — local masks compose with `CheckExecutionTimeout`'s internal 1/1024 throttle); `TGocciaTimeoutError`/`TGocciaInstructionLimitError` re-raise arms at **every** promise boundary (VM dynamic import and async-from-sync iterators, interpreter `import()`, await, async generator continuations, Promise, fetch) so the abort can no longer be swallowed by a JS `catch` and reported as exit 0.
- Sparse-array length truncation now deletes property-map indices: the length-descriptor grow/shrink decision compared the dense element count instead of `FLength` (pre-existing for ≥ MaxInt indices).
- `GlobalReadCacheSlot` returns nil for out-of-range constant indices, so corrupt `.gbc` input degrades to an uncached read instead of an out-of-bounds heap write.

**Structure**

- Scope binding resolution consolidated onto virtual `TryGetBinding`/`TryAssignExistingBinding` cores; `GetBinding`/`AssignBinding` are thin wrappers and the Catch/With/direct-eval overrides implement the `Try*` protocol once (the direct-eval adapter mirrors its environment head and falls through to inherited tails — cycle-free under the wrappers' virtual dispatch).
- Native-loop timeout chokepoint rule documented in `Goccia.Timeout.pas`, including the known not-yet-covered stalls (TypedArray sort, JSON, `String.repeat`).

Related: #740 (regression source), #743 (main-lexer expression-context follow-up), #653 (paren/await regex-context precedent).

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Details: full JS suite 10,289/10,289 in both execution modes; all Pascal unit-test binaries pass (new `OrderedStringMap` entry-version invariant tests included); `./format.pas --check` clean; local test262 slices — `language` 23,041/23,711 with 0 wrapper-infra, `language/eval-code` 347/347, `built-ins/Array` 2,505/3,082 (+13 vs baseline, no PASS→non-PASS), Temporal/Duration 0 → 326/540; CLI timeout matrix (native array fill, regex scan, dynamic import, async function × interpreted/bytecode) all abort with `TimeoutError`; `fib(30)` benchmark re-measured after each layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
