### PR TITLE
fix(website): unbreak test262 blob publish on public stores

### DIFF
--- a/website/scripts/test262-blob-store.ts
+++ b/website/scripts/test262-blob-store.ts
@@ -282,16 +282,6 @@ async function publishManifestWithRetry(
     }
 
     const manifest = createManifest([...merged.values()], prefix);
-    for (const run of manifest.daily) {
-      if (!changedDays.has(run.createdAt.slice(0, 10))) continue;
-      await put(dailyPathForPoint(run, prefix), JSON.stringify(run, null, 2), {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 60,
-        contentType: "application/json",
-      });
-    }
-
     try {
       await put(
         test262BlobManifestPath(prefix),
@@ -304,7 +294,6 @@ async function publishManifestWithRetry(
           ...(existing ? { ifMatch: existing.etag } : {}),
         },
       );
-      return manifest;
     } catch (err) {
       if (
         !isManifestWriteConflict(err) ||
@@ -312,7 +301,21 @@ async function publishManifestWithRetry(
       ) {
         throw err;
       }
+      continue;
     }
+
+    // Only materialize daily files for a manifest state that actually won
+    // the conditional write.
+    for (const run of manifest.daily) {
+      if (!changedDays.has(run.createdAt.slice(0, 10))) continue;
+      await put(dailyPathForPoint(run, prefix), JSON.stringify(run, null, 2), {
+        access,
+        allowOverwrite: true,
+        cacheControlMaxAge: 60,
+        contentType: "application/json",
+      });
+    }
+    return manifest;
   }
   throw new Error("failed to publish test262 Blob manifest");
 }

--- a/website/scripts/test262-blob-store.ts
+++ b/website/scripts/test262-blob-store.ts
@@ -1,5 +1,10 @@
 import { gunzipSync, gzipSync } from "node:zlib";
-import { BlobPreconditionFailedError, get, put } from "@vercel/blob";
+import {
+  BlobNotFoundError,
+  BlobPreconditionFailedError,
+  get,
+  put,
+} from "@vercel/blob";
 import {
   jsonUrlForArtifact,
   type Test262Report,
@@ -39,11 +44,6 @@ export type Test262BlobPublishEntry = {
 const DEFAULT_PREFIX = "test262";
 const DEFAULT_ACCESS: Test262BlobAccess = "public";
 const MANIFEST_WRITE_ATTEMPTS = 3;
-
-type ReadBlobTextOptions = {
-  access?: Test262BlobAccess;
-  useCache?: boolean;
-};
 
 function cleanPrefix(value: string | undefined): string {
   const trimmed = (value ?? DEFAULT_PREFIX).trim().replace(/^\/+|\/+$/g, "");
@@ -99,21 +99,17 @@ async function streamToBytes(stream: ReadableStream<Uint8Array>) {
 
 async function readBlobTextWithMeta(
   pathname: string,
-  options: ReadBlobTextOptions = {},
+  access = test262BlobAccess(),
 ): Promise<{ text: string; etag: string } | null> {
-  const access = options.access ?? test262BlobAccess();
   try {
-    const result = await get(pathname, {
-      access,
-      ...(options.useCache === undefined ? {} : { useCache: options.useCache }),
-    });
+    const result = await get(pathname, { access });
     if (!result || result.statusCode !== 200 || !result.stream) return null;
     return {
       text: new TextDecoder().decode(await streamToBytes(result.stream)),
       etag: result.blob.etag,
     };
   } catch (err) {
-    if (err instanceof Error && /not found/i.test(err.message)) return null;
+    if (err instanceof BlobNotFoundError) return null;
     throw err;
   }
 }
@@ -127,7 +123,7 @@ async function readBlobBytes(
     if (!result || result.statusCode !== 200 || !result.stream) return null;
     return await streamToBytes(result.stream);
   } catch (err) {
-    if (err instanceof Error && /not found/i.test(err.message)) return null;
+    if (err instanceof BlobNotFoundError) return null;
     throw err;
   }
 }
@@ -169,11 +165,11 @@ export async function loadTest262BlobManifest(
 
 async function loadTest262BlobManifestSnapshot(
   prefix = test262BlobPrefix(),
-  options: ReadBlobTextOptions = {},
+  access = test262BlobAccess(),
 ): Promise<{ manifest: Test262BlobManifest; etag: string } | null> {
   const result = await readBlobTextWithMeta(
     test262BlobManifestPath(prefix),
-    options,
+    access,
   );
   if (!result) return null;
   const manifest = normalizeManifest(JSON.parse(result.text), prefix);
@@ -273,10 +269,10 @@ async function publishManifestWithRetry(
     publishedRuns.map((run) => run.createdAt.slice(0, 10)),
   );
   for (let attempt = 1; attempt <= MANIFEST_WRITE_ATTEMPTS; attempt++) {
-    const existing = await loadTest262BlobManifestSnapshot(prefix, {
-      access,
-      useCache: false,
-    });
+    // The CDN may serve the manifest up to its cache TTL (~60s) stale; the
+    // ifMatch precondition below turns a stale read into a loud write
+    // conflict instead of a silently lost update.
+    const existing = await loadTest262BlobManifestSnapshot(prefix, access);
     const merged = new Map<number, Test262BlobRun>();
     for (const run of existing?.manifest.runs ?? []) {
       merged.set(run.artifactId, run);

--- a/website/src/__tests__/test262-blob-store.test.ts
+++ b/website/src/__tests__/test262-blob-store.test.ts
@@ -139,6 +139,10 @@ function manifestPuts() {
   return putCalls.filter((call) => call.pathname === MANIFEST_PATH);
 }
 
+function dailyPuts() {
+  return putCalls.filter((call) => call.pathname.startsWith("test262/daily/"));
+}
+
 function publishEntry() {
   const report: Test262Report = {
     summary: summary(2),
@@ -206,6 +210,7 @@ describe("test262 Blob publishing", () => {
 
     expect(manifestGets()).toHaveLength(2);
     expect(manifestPuts()).toHaveLength(2);
+    expect(dailyPuts()).toHaveLength(1);
     expect(manifest.runs.map((run) => run.artifactId)).toEqual([1001, 1002]);
   });
 
@@ -219,5 +224,6 @@ describe("test262 Blob publishing", () => {
     );
     expect(manifestGets()).toHaveLength(3);
     expect(manifestPuts()).toHaveLength(3);
+    expect(dailyPuts()).toHaveLength(0);
   });
 });

--- a/website/src/__tests__/test262-blob-store.test.ts
+++ b/website/src/__tests__/test262-blob-store.test.ts
@@ -17,8 +17,21 @@ type BlobPutCall = {
   options: Record<string, unknown>;
 };
 
+const MANIFEST_PATH = "test262/manifest.json";
+const MANIFEST_ETAG = '"origin-etag"';
+
 const getCalls: BlobGetCall[] = [];
 const putCalls: BlobPutCall[] = [];
+const state = {
+  manifestExists: true,
+  failManifestPuts: 0,
+};
+
+class BlobNotFoundError extends Error {
+  constructor() {
+    super("The requested blob does not exist");
+  }
+}
 
 class BlobPreconditionFailedError extends Error {
   constructor() {
@@ -66,14 +79,21 @@ const existingRun: Test262BlobRun = {
 };
 
 mock.module("@vercel/blob", () => ({
+  BlobNotFoundError,
   BlobPreconditionFailedError,
   get: async (pathname: string, options: Record<string, unknown>) => {
     getCalls.push({ pathname, options });
+    if (options.access === "public" && options.useCache === false) {
+      // The real public CDN rejects the SDK's cache=0 parameter.
+      throw new Error("Vercel Blob: Failed to fetch blob: 400 Bad Request");
+    }
+    // The real SDK signals a missing blob by returning null, not throwing.
+    if (pathname === MANIFEST_PATH && !state.manifestExists) return null;
     return {
       statusCode: 200,
       stream: textStream(JSON.stringify({ version: 1, runs: [existingRun] })),
       blob: {
-        etag: '"fresh-origin-etag"',
+        etag: MANIFEST_ETAG,
       },
     };
   },
@@ -83,8 +103,13 @@ mock.module("@vercel/blob", () => ({
     options: Record<string, unknown>,
   ) => {
     putCalls.push({ pathname, body, options });
-    if (pathname === "test262/manifest.json") {
-      if (options.ifMatch !== '"fresh-origin-etag"') {
+    if (pathname === MANIFEST_PATH) {
+      if (state.failManifestPuts > 0) {
+        state.failManifestPuts -= 1;
+        throw new BlobPreconditionFailedError();
+      }
+      const expectedIfMatch = state.manifestExists ? MANIFEST_ETAG : undefined;
+      if (options.ifMatch !== expectedIfMatch) {
         throw new BlobPreconditionFailedError();
       }
     }
@@ -99,53 +124,100 @@ mock.module("@vercel/blob", () => ({
   },
 }));
 
+function resetState() {
+  getCalls.length = 0;
+  putCalls.length = 0;
+  state.manifestExists = true;
+  state.failManifestPuts = 0;
+}
+
+function manifestGets() {
+  return getCalls.filter((call) => call.pathname === MANIFEST_PATH);
+}
+
+function manifestPuts() {
+  return putCalls.filter((call) => call.pathname === MANIFEST_PATH);
+}
+
+function publishEntry() {
+  const report: Test262Report = {
+    summary: summary(2),
+    results: [],
+  };
+  const point: Test262TimelinePoint = {
+    runId: 202,
+    runNumber: 2,
+    title: "CI",
+    headSha: "new-sha",
+    shortSha: "new-sha",
+    runUrl: "https://example.test/runs/202",
+    createdAt: "2026-06-11T01:00:00.000Z",
+    updatedAt: "2026-06-11T01:05:00.000Z",
+    artifactId: 1002,
+    artifactCreatedAt: "2026-06-11T01:05:00.000Z",
+    jsonUrl: "/api/test262/results/1002",
+    summary: report.summary,
+  };
+  return { point, report, reportJson: JSON.stringify(report) };
+}
+
+async function importPublish() {
+  const { publishTest262ReportsToBlob } = await import(
+    "../../scripts/test262-blob-store"
+  );
+  return publishTest262ReportsToBlob;
+}
+
 describe("test262 Blob publishing", () => {
-  test("bypasses manifest cache and preserves get ETags for conditional writes", async () => {
-    getCalls.length = 0;
-    putCalls.length = 0;
+  test("merges into the existing manifest with its ETag as ifMatch", async () => {
+    resetState();
+    const publish = await importPublish();
 
-    const { publishTest262ReportsToBlob } = await import(
-      "../../scripts/test262-blob-store"
-    );
-    const report: Test262Report = {
-      summary: summary(2),
-      results: [],
-    };
-    const point: Test262TimelinePoint = {
-      runId: 202,
-      runNumber: 2,
-      title: "CI",
-      headSha: "new-sha",
-      shortSha: "new-sha",
-      runUrl: "https://example.test/runs/202",
-      createdAt: "2026-06-11T01:00:00.000Z",
-      updatedAt: "2026-06-11T01:05:00.000Z",
-      artifactId: 1002,
-      artifactCreatedAt: "2026-06-11T01:05:00.000Z",
-      jsonUrl: "/api/test262/results/1002",
-      summary: report.summary,
-    };
+    const manifest = await publish([publishEntry()]);
 
-    const manifest = await publishTest262ReportsToBlob([
-      {
-        point,
-        report,
-        reportJson: JSON.stringify(report),
-      },
-    ]);
-
-    const manifestRead = getCalls.find(
-      (call) => call.pathname === "test262/manifest.json",
-    );
-    const manifestWrite = putCalls.find(
-      (call) => call.pathname === "test262/manifest.json",
-    );
-
-    expect(manifestRead?.options).toMatchObject({ useCache: false });
-    expect(manifestWrite?.options).toMatchObject({
+    const [manifestRead] = manifestGets();
+    expect(manifestRead?.options).toEqual({ access: "public" });
+    expect(manifestPuts().at(-1)?.options).toMatchObject({
       allowOverwrite: true,
-      ifMatch: '"fresh-origin-etag"',
+      ifMatch: MANIFEST_ETAG,
     });
     expect(manifest.runs.map((run) => run.artifactId)).toEqual([1001, 1002]);
+  });
+
+  test("creates the manifest without ifMatch when none exists", async () => {
+    resetState();
+    state.manifestExists = false;
+    const publish = await importPublish();
+
+    const manifest = await publish([publishEntry()]);
+
+    const manifestWrite = manifestPuts().at(-1);
+    expect(manifestWrite?.options).toMatchObject({ allowOverwrite: false });
+    expect(manifestWrite?.options.ifMatch).toBeUndefined();
+    expect(manifest.runs.map((run) => run.artifactId)).toEqual([1002]);
+  });
+
+  test("re-reads the manifest and retries when the conditional write conflicts", async () => {
+    resetState();
+    state.failManifestPuts = 1;
+    const publish = await importPublish();
+
+    const manifest = await publish([publishEntry()]);
+
+    expect(manifestGets()).toHaveLength(2);
+    expect(manifestPuts()).toHaveLength(2);
+    expect(manifest.runs.map((run) => run.artifactId)).toEqual([1001, 1002]);
+  });
+
+  test("gives up after repeated write conflicts", async () => {
+    resetState();
+    state.failManifestPuts = Number.POSITIVE_INFINITY;
+    const publish = await importPublish();
+
+    await expect(publish([publishEntry()])).rejects.toThrow(
+      /precondition failed/i,
+    );
+    expect(manifestGets()).toHaveLength(3);
+    expect(manifestPuts()).toHaveLength(3);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fixes the CI failure `Vercel Blob: Failed to fetch blob: 400 Bad Request` in `publish-test262-results.ts`, introduced by #742: passing `useCache: false` to `@vercel/blob`'s `get()` appends `cache=0` to the blob URL, and the **public** blob CDN rejects that parameter with 400 (`cache=0 is only available for private stores`). The SDK's own typedoc says `useCache` is "ignored for public blobs", but the implementation forwards it anyway — upstream docs/implementation mismatch.
- Removes the origin-freshness mechanism instead of replacing it. Cache-busting via query params was evaluated and ruled out empirically: the public CDN excludes the query string from its cache key (a guaranteed-unique `?v=...` param still returns `x-vercel-cache: HIT`). More importantly, freshness buys nothing here — correctness rests on the `ifMatch` precondition (a stale read within the ~60s CDN TTL fails the conditional write loudly rather than losing an update), and at the current publish cadence (a couple of runs per day, each 10+ minutes) sub-TTL write collisions do not occur. The dashboard consumes the manifest statically, so read-side freshness is moot.
- Replaces the message-regex not-found check with `instanceof BlobNotFoundError`. The regex approach would have classified `BlobStoreNotFoundError` ("This store does not exist.") as a missing blob, silently taking the first-publish path on a misconfigured store instead of failing loudly.
- Non-goal: restoring #742's "read from origin before optimistic writes" guarantee — it never worked in production (the `useCache: false` call 400'd immediately), and the `ifMatch` CAS already prevents lost updates.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Details: `cd website && bun test` (149 pass), `bunx tsc --noEmit`, `bun run lint` all clean. The reworked mock models real SDK/CDN behavior (`get()` returns `null` on 404; public store rejects `cache=0`), and the four tests cover manifest merge with `ifMatch`, first publish, conflict → re-read → retry, and conflict exhaustion. All four fail against the previous broken revision, so the original regression stays caught. No engine code touched, so Pascal tests and benchmarks are not applicable; no documented behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)