### PR TITLE
fix(vm): resolve computed property access on primitive receivers

### DIFF
--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -1993,7 +1993,7 @@ var
     begin
       BoxedValue := AObj.Box;
       if Assigned(BoxedValue) then
-        Result := BoxedValue.GetSymbolProperty(ASymbol)
+        Result := BoxedValue.GetSymbolPropertyWithReceiver(ASymbol, AObj)
       else
         Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -3308,7 +3308,8 @@ begin
         BoxedValue := Obj.Box;
         if Assigned(BoxedValue) then
         begin
-          Result := BoxedValue.GetSymbolProperty(TGocciaSymbolValue(PropertyKey));
+          Result := BoxedValue.GetSymbolPropertyWithReceiver(
+            TGocciaSymbolValue(PropertyKey), Obj);
           Exit;
         end;
         Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -3331,7 +3332,7 @@ begin
     BoxedValue := Obj.Box;
     if Assigned(BoxedValue) then
     begin
-      Result := BoxedValue.GetProperty(PropertyName);
+      Result := BoxedValue.GetPropertyWithContext(PropertyName, Obj);
     end
     else if (Obj is TGocciaNullLiteralValue) or (Obj is TGocciaUndefinedLiteralValue) then
     begin

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -9585,7 +9585,7 @@ begin
 
   Boxed := AObject.Box;
   if Assigned(Boxed) then
-    Result := Boxed.GetProperty(AKey)
+    Result := Boxed.GetPropertyWithContext(AKey, AObject)
   else
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -9638,8 +9638,8 @@ begin
     begin
       Boxed := ReceiverValue.Box;
       if Assigned(Boxed) then
-        SetRegister(ADest, Boxed.GetSymbolProperty(
-          TGocciaSymbolValue(PropKeyValue)))
+        SetRegister(ADest, Boxed.GetSymbolPropertyWithReceiver(
+          TGocciaSymbolValue(PropKeyValue), ReceiverValue))
       else
         FRegisters[ADest] := RegisterUndefined;
     end;
@@ -9664,7 +9664,8 @@ begin
   begin
     Boxed := ReceiverValue.Box;
     if Assigned(Boxed) then
-      PropertyValue := Boxed.GetProperty(PropertyName)
+      PropertyValue := Boxed.GetPropertyWithContext(PropertyName,
+        ReceiverValue)
     else
       PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -168,6 +168,8 @@ type
     function TryResolveObjectKey(const AKeyReg: TGocciaRegister; out AResolved: TGocciaValue): Boolean; inline;
     procedure ExecGetComputedPropertyFallback(const ADest: Integer;
       const AReceiverReg, AKeyReg: TGocciaRegister);
+    function CoerceNonStrictThisRegister(
+      const AThisRegister: TGocciaRegister): TGocciaRegister;
     procedure SetFunctionNameFromKey(const AFunction, AKey: TGocciaValue;
       const APrefixKind: UInt8);
     function EnsureCurrentDynamicVarScope: TGocciaScope;
@@ -4381,13 +4383,10 @@ var
   EffectiveThis: TGocciaValue;
   PromiseRoot: TGocciaTempRoot;
 begin
-  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
-     (not Assigned(AThisValue) or
-      (AThisValue is TGocciaUndefinedLiteralValue) or
-      (AThisValue is TGocciaNullLiteralValue)) then
-    EffectiveThis := FVM.FGlobalThisValue
+  if FStrictThis then
+    EffectiveThis := AThisValue
   else
-    EffectiveThis := AThisValue;
+    EffectiveThis := CoerceNonStrictThis(AThisValue, FVM.FGlobalThisValue);
 
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
@@ -4461,13 +4460,10 @@ var
   EffectiveThis: TGocciaValue;
   PromiseRoot: TGocciaTempRoot;
 begin
-  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
-     (not Assigned(AThisValue) or
-      (AThisValue is TGocciaUndefinedLiteralValue) or
-      (AThisValue is TGocciaNullLiteralValue)) then
-    EffectiveThis := FVM.FGlobalThisValue
+  if FStrictThis then
+    EffectiveThis := AThisValue
   else
-    EffectiveThis := AThisValue;
+    EffectiveThis := CoerceNonStrictThis(AThisValue, FVM.FGlobalThisValue);
 
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
@@ -4527,13 +4523,10 @@ var
   EffectiveThis: TGocciaValue;
   PromiseRoot: TGocciaTempRoot;
 begin
-  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
-     (not Assigned(AThisValue) or
-      (AThisValue is TGocciaUndefinedLiteralValue) or
-      (AThisValue is TGocciaNullLiteralValue)) then
-    EffectiveThis := FVM.FGlobalThisValue
+  if FStrictThis then
+    EffectiveThis := AThisValue
   else
-    EffectiveThis := AThisValue;
+    EffectiveThis := CoerceNonStrictThis(AThisValue, FVM.FGlobalThisValue);
 
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
@@ -4595,13 +4588,10 @@ var
   EffectiveThis: TGocciaValue;
   PromiseRoot: TGocciaTempRoot;
 begin
-  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
-     (not Assigned(AThisValue) or
-      (AThisValue is TGocciaUndefinedLiteralValue) or
-      (AThisValue is TGocciaNullLiteralValue)) then
-    EffectiveThis := FVM.FGlobalThisValue
+  if FStrictThis then
+    EffectiveThis := AThisValue
   else
-    EffectiveThis := AThisValue;
+    EffectiveThis := CoerceNonStrictThis(AThisValue, FVM.FGlobalThisValue);
 
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
@@ -4667,13 +4657,10 @@ var
   EffectiveThis: TGocciaValue;
   PromiseRoot: TGocciaTempRoot;
 begin
-  if (not FStrictThis) and Assigned(FVM.FGlobalThisValue) and
-     (not Assigned(AThisValue) or
-      (AThisValue is TGocciaUndefinedLiteralValue) or
-      (AThisValue is TGocciaNullLiteralValue)) then
-    EffectiveThis := FVM.FGlobalThisValue
+  if FStrictThis then
+    EffectiveThis := AThisValue
   else
-    EffectiveThis := AThisValue;
+    EffectiveThis := CoerceNonStrictThis(AThisValue, FVM.FGlobalThisValue);
 
   if Assigned(FClosure) and Assigned(FClosure.Template) and FClosure.Template.IsGenerator then
   begin
@@ -9672,6 +9659,27 @@ begin
   SetRegister(ADest, PropertyValue);
 end;
 
+// ES2026 §10.2.1.2 OrdinaryCallBindThis steps 5–6 for non-strict callees,
+// operating on registers so the f.call/f.apply fast paths avoid a
+// register/value round trip for receivers that are already objects.
+function TGocciaVM.CoerceNonStrictThisRegister(
+  const AThisRegister: TGocciaRegister): TGocciaRegister;
+begin
+  if AThisRegister.Kind in [grkUndefined, grkNull] then
+  begin
+    if Assigned(FGlobalThisValue) then
+      Result := VMValueToRegisterFast(FGlobalThisValue)
+    else
+      Result := AThisRegister;
+  end
+  else if (AThisRegister.Kind = grkObject) and
+          (AThisRegister.ObjectValue is TGocciaObjectValue) then
+    Result := AThisRegister
+  else
+    Result := VMValueToRegisterFast(CoerceNonStrictThis(
+      RegisterToValue(AThisRegister), FGlobalThisValue));
+end;
+
 procedure TGocciaVM.SetPropertyValue(const AObject: TGocciaValue;
   const AKey: string; const AValue: TGocciaValue);
 var
@@ -13086,9 +13094,9 @@ begin
                     CallThisRegister := RegisterUndefined
                   else
                     CallThisRegister := FRegisters[A + 1];
-                  if (not BytecodeFunction.FStrictThis) and Assigned(FGlobalThisValue) and
-                     (CallThisRegister.Kind in [grkUndefined, grkNull]) then
-                    CallThisRegister := VMValueToRegisterFast(FGlobalThisValue);
+                  if not BytecodeFunction.FStrictThis then
+                    CallThisRegister := CoerceNonStrictThisRegister(
+                      CallThisRegister);
                   PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
                   case B of
                     0:
@@ -13135,9 +13143,9 @@ begin
                 begin
                   ArgsArray := TGocciaArrayValue(FRegisters[A + 2].ObjectValue);
                   CallThisRegister := FRegisters[A + 1];
-                  if (not BytecodeFunction.FStrictThis) and Assigned(FGlobalThisValue) and
-                     (CallThisRegister.Kind in [grkUndefined, grkNull]) then
-                    CallThisRegister := VMValueToRegisterFast(FGlobalThisValue);
+                  if not BytecodeFunction.FStrictThis then
+                    CallThisRegister := CoerceNonStrictThisRegister(
+                      CallThisRegister);
                   PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
                   case ArgsArray.Elements.Count of
                     0:

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -11365,8 +11365,18 @@ begin
             SetRegister(A, TGocciaStringLiteralValue.Create(
               UTF16CodeUnitAt(TGocciaStringLiteralValue(
                 FRegisters[B].ObjectValue).Value, KeyIndex)))
+          else if TryResolveObjectKey(FRegisters[C], PropKeyValue) then
+          begin
+            if PropKeyValue is TGocciaSymbolValue then
+              SetRegister(A, FRegisters[B].ObjectValue.Box.GetSymbolProperty(
+                TGocciaSymbolValue(PropKeyValue)))
+            else
+              SetRegister(A, GetPropertyValue(FRegisters[B].ObjectValue,
+                TGocciaStringLiteralValue(PropKeyValue).Value));
+          end
           else
-            FRegisters[A] := RegisterUndefined;
+            SetRegister(A, GetPropertyValue(FRegisters[B].ObjectValue,
+              KeyToPropertyNameRegister(FRegisters[C])));
         end
         else if (FRegisters[B].Kind = grkObject) and
                 (FRegisters[B].ObjectValue is TGocciaSymbolValue) then
@@ -12011,8 +12021,18 @@ begin
             SetRegister(A, TGocciaStringLiteralValue.Create(
               UTF16CodeUnitAt(TGocciaStringLiteralValue(
                 FRegisters[B].ObjectValue).Value, KeyIndex)))
+          else if TryResolveObjectKey(FRegisters[C], PropKeyValue) then
+          begin
+            if PropKeyValue is TGocciaSymbolValue then
+              SetRegister(A, FRegisters[B].ObjectValue.Box.GetSymbolProperty(
+                TGocciaSymbolValue(PropKeyValue)))
+            else
+              SetRegister(A, GetPropertyValue(FRegisters[B].ObjectValue,
+                TGocciaStringLiteralValue(PropKeyValue).Value));
+          end
           else
-            SetRegister(A, TGocciaUndefinedLiteralValue.UndefinedValue);
+            SetRegister(A, GetPropertyValue(FRegisters[B].ObjectValue,
+              KeyToPropertyNameRegister(FRegisters[C])));
         end
         else
           FRegisters[A] := RegisterUndefined;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -166,6 +166,8 @@ type
     function KeyToPropertyName(const AKey: TGocciaValue): string;
     function KeyToPropertyNameRegister(const AKey: TGocciaRegister): string;
     function TryResolveObjectKey(const AKeyReg: TGocciaRegister; out AResolved: TGocciaValue): Boolean; inline;
+    procedure ExecGetComputedPropertyFallback(const ADest: Integer;
+      const AReceiverReg, AKeyReg: TGocciaRegister);
     procedure SetFunctionNameFromKey(const AFunction, AKey: TGocciaValue;
       const APrefixKind: UInt8);
     function EnsureCurrentDynamicVarScope: TGocciaScope;
@@ -9588,6 +9590,87 @@ begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
+// Computed GET for receivers that are not arrays, classes, or objects:
+// string/number/boolean/bigint/symbol primitives resolve through their
+// boxed object per OrdinaryGet, mirroring the interpreter. Deliberately
+// bypasses GetPropertyValue so user string keys that collide with the
+// '#slot:' private-key mangling stay ordinary property names.
+procedure TGocciaVM.ExecGetComputedPropertyFallback(const ADest: Integer;
+  const AReceiverReg, AKeyReg: TGocciaRegister);
+var
+  ReceiverValue: TGocciaValue;
+  PropKeyValue: TGocciaValue;
+  PropertyValue: TGocciaValue;
+  Boxed: TGocciaObjectValue;
+  PropertyName: string;
+  StringValue: string;
+  KeyIndex: Integer;
+begin
+  if (AReceiverReg.Kind = grkObject) and
+     (AReceiverReg.ObjectValue is TGocciaStringLiteralValue) and
+     TryGetArrayIndexRegister(AKeyReg, KeyIndex) then
+  begin
+    StringValue := TGocciaStringLiteralValue(AReceiverReg.ObjectValue).Value;
+    if (KeyIndex >= 0) and (KeyIndex < UTF16CodeUnitLength(StringValue)) then
+    begin
+      SetRegister(ADest, TGocciaStringLiteralValue.Create(
+        UTF16CodeUnitAt(StringValue, KeyIndex)));
+      Exit;
+    end;
+  end;
+
+  ReceiverValue := RegisterToValue(AReceiverReg);
+
+  if (AKeyReg.Kind = grkObject) and
+     (AKeyReg.ObjectValue is TGocciaSymbolValue) then
+    PropKeyValue := AKeyReg.ObjectValue
+  else if not TryResolveObjectKey(AKeyReg, PropKeyValue) then
+    PropKeyValue := nil;
+
+  if PropKeyValue is TGocciaSymbolValue then
+  begin
+    if (ReceiverValue is TGocciaSymbolValue) and
+       Assigned(TGocciaSymbolValue.SharedPrototype) then
+      SetRegister(ADest, TGocciaObjectValue(TGocciaSymbolValue.SharedPrototype)
+        .GetSymbolPropertyWithReceiver(
+          TGocciaSymbolValue(PropKeyValue), ReceiverValue))
+    else
+    begin
+      Boxed := ReceiverValue.Box;
+      if Assigned(Boxed) then
+        SetRegister(ADest, Boxed.GetSymbolProperty(
+          TGocciaSymbolValue(PropKeyValue)))
+      else
+        FRegisters[ADest] := RegisterUndefined;
+    end;
+    Exit;
+  end;
+
+  if PropKeyValue is TGocciaStringLiteralValue then
+    PropertyName := TGocciaStringLiteralValue(PropKeyValue).Value
+  else
+    PropertyName := KeyToPropertyNameRegister(AKeyReg);
+
+  if (ReceiverValue is TGocciaStringLiteralValue) and
+     (PropertyName = PROP_LENGTH) then
+  begin
+    FRegisters[ADest] := VMNumberRegister(UTF16CodeUnitLength(
+      TGocciaStringLiteralValue(ReceiverValue).Value));
+    Exit;
+  end;
+
+  PropertyValue := ReceiverValue.GetProperty(PropertyName);
+  if not Assigned(PropertyValue) then
+  begin
+    Boxed := ReceiverValue.Box;
+    if Assigned(Boxed) then
+      PropertyValue := Boxed.GetProperty(PropertyName)
+    else
+      PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+  end;
+  SetRegister(ADest, PropertyValue);
+end;
+
 procedure TGocciaVM.SetPropertyValue(const AObject: TGocciaValue;
   const AKey: string; const AValue: TGocciaValue);
 var
@@ -11351,49 +11434,8 @@ begin
             SetRegister(A, TGocciaObjectValue(FRegisters[B].ObjectValue).GetProperty(
               KeyToPropertyNameRegister(FRegisters[C])));
         end
-        else if (FRegisters[B].Kind = grkObject) and
-                (FRegisters[B].ObjectValue is TGocciaStringLiteralValue) then
-        begin
-          if (FRegisters[C].Kind = grkObject) and
-             (FRegisters[C].ObjectValue is TGocciaSymbolValue) then
-            SetRegister(A, FRegisters[B].ObjectValue.Box.GetSymbolProperty(
-              TGocciaSymbolValue(FRegisters[C].ObjectValue)))
-          else if TryGetArrayIndexRegister(FRegisters[C], KeyIndex) and
-             (KeyIndex >= 0) and
-             (KeyIndex < UTF16CodeUnitLength(TGocciaStringLiteralValue(
-               FRegisters[B].ObjectValue).Value)) then
-            SetRegister(A, TGocciaStringLiteralValue.Create(
-              UTF16CodeUnitAt(TGocciaStringLiteralValue(
-                FRegisters[B].ObjectValue).Value, KeyIndex)))
-          else if TryResolveObjectKey(FRegisters[C], PropKeyValue) then
-          begin
-            if PropKeyValue is TGocciaSymbolValue then
-              SetRegister(A, FRegisters[B].ObjectValue.Box.GetSymbolProperty(
-                TGocciaSymbolValue(PropKeyValue)))
-            else
-              SetRegister(A, GetPropertyValue(FRegisters[B].ObjectValue,
-                TGocciaStringLiteralValue(PropKeyValue).Value));
-          end
-          else
-            SetRegister(A, GetPropertyValue(FRegisters[B].ObjectValue,
-              KeyToPropertyNameRegister(FRegisters[C])));
-        end
-        else if (FRegisters[B].Kind = grkObject) and
-                (FRegisters[B].ObjectValue is TGocciaSymbolValue) then
-        begin
-          if (FRegisters[C].Kind = grkObject) and
-             (FRegisters[C].ObjectValue is TGocciaSymbolValue) and
-             Assigned(TGocciaSymbolValue.SharedPrototype) then
-            SetRegister(A, TGocciaObjectValue(TGocciaSymbolValue.SharedPrototype)
-              .GetSymbolPropertyWithReceiver(
-                TGocciaSymbolValue(FRegisters[C].ObjectValue),
-                FRegisters[B].ObjectValue))
-          else
-            SetRegister(A, FRegisters[B].ObjectValue.GetProperty(
-              KeyToPropertyNameRegister(FRegisters[C])));
-        end
         else
-          FRegisters[A] := RegisterUndefined;
+          ExecGetComputedPropertyFallback(A, FRegisters[B], FRegisters[C]);
       end;
 
       OP_ARRAY_SET:
@@ -12007,35 +12049,8 @@ begin
                 GlobalName));
           end;
         end
-        else if (FRegisters[B].Kind = grkObject) and
-                (FRegisters[B].ObjectValue is TGocciaStringLiteralValue) then
-        begin
-          if (FRegisters[C].Kind = grkObject) and
-             (FRegisters[C].ObjectValue is TGocciaSymbolValue) then
-            SetRegister(A, FRegisters[B].ObjectValue.Box.GetSymbolProperty(
-              TGocciaSymbolValue(FRegisters[C].ObjectValue)))
-          else if TryGetArrayIndexRegister(FRegisters[C], KeyIndex) and
-             (KeyIndex >= 0) and
-             (KeyIndex < UTF16CodeUnitLength(TGocciaStringLiteralValue(
-               FRegisters[B].ObjectValue).Value)) then
-            SetRegister(A, TGocciaStringLiteralValue.Create(
-              UTF16CodeUnitAt(TGocciaStringLiteralValue(
-                FRegisters[B].ObjectValue).Value, KeyIndex)))
-          else if TryResolveObjectKey(FRegisters[C], PropKeyValue) then
-          begin
-            if PropKeyValue is TGocciaSymbolValue then
-              SetRegister(A, FRegisters[B].ObjectValue.Box.GetSymbolProperty(
-                TGocciaSymbolValue(PropKeyValue)))
-            else
-              SetRegister(A, GetPropertyValue(FRegisters[B].ObjectValue,
-                TGocciaStringLiteralValue(PropKeyValue).Value));
-          end
-          else
-            SetRegister(A, GetPropertyValue(FRegisters[B].ObjectValue,
-              KeyToPropertyNameRegister(FRegisters[C])));
-        end
         else
-          FRegisters[A] := RegisterUndefined;
+          ExecGetComputedPropertyFallback(A, FRegisters[B], FRegisters[C]);
       end;
 
       OP_SET_INDEX:

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -104,7 +104,8 @@ uses
   Goccia.Types.Enforcement,
   Goccia.Values.ArgumentsObjectValue,
   Goccia.Values.ArrayValue,
-  Goccia.Values.ErrorHelper;
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.ToObject;
 
 { TGocciaFunctionValue }
 
@@ -151,10 +152,11 @@ procedure TGocciaFunctionValue.BindThis(const ACallScope: TGocciaScope; const AT
 var
   Root: TGocciaScope;
 begin
-  if (not FStrictThis) and
-     (not Assigned(AThisValue) or
-      (AThisValue is TGocciaUndefinedLiteralValue) or
-      (AThisValue is TGocciaNullLiteralValue)) then
+  if FStrictThis then
+    ACallScope.ThisValue := AThisValue
+  else if not Assigned(AThisValue) or
+          (AThisValue is TGocciaUndefinedLiteralValue) or
+          (AThisValue is TGocciaNullLiteralValue) then
   begin
     Root := FClosure;
     while Assigned(Root.Parent) do
@@ -162,7 +164,7 @@ begin
     ACallScope.ThisValue := Root.ThisValue;
   end
   else
-    ACallScope.ThisValue := AThisValue;
+    ACallScope.ThisValue := CoerceNonStrictThis(AThisValue, nil);
 end;
 
 function TGocciaFunctionValue.CreateCallScope: TGocciaScope;

--- a/source/units/Goccia.Values.ToObject.pas
+++ b/source/units/Goccia.Values.ToObject.pas
@@ -16,6 +16,12 @@ function ToObject(const AValue: TGocciaValue): TGocciaObjectValue;
 // Throws TypeError for undefined/null and otherwise returns the original value.
 function RequireObjectCoercible(const AValue: TGocciaValue): TGocciaValue;
 
+// ES2026 §10.2.1.2 OrdinaryCallBindThis steps 5–6 for non-strict callees:
+// nullish this becomes AGlobalThis (or stays as-is when AGlobalThis is nil),
+// primitives are boxed via ToObject, objects pass through unchanged.
+function CoerceNonStrictThis(const AThisValue: TGocciaValue;
+  const AGlobalThis: TGocciaValue): TGocciaValue;
+
 // ES2026 §7.3.3 LengthOfArrayLike(obj)
 // Returns ToLength(? Get(obj, "length")).
 function LengthOfArrayLike(const AObj: TGocciaObjectValue): Integer;
@@ -70,6 +76,36 @@ begin
   if (AValue is TGocciaUndefinedLiteralValue) or (AValue is TGocciaNullLiteralValue) then
     ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
   Result := AValue;
+end;
+
+// ES2026 §10.2.1.2 OrdinaryCallBindThis steps 5–6 (non-strict callee)
+function CoerceNonStrictThis(const AThisValue: TGocciaValue;
+  const AGlobalThis: TGocciaValue): TGocciaValue;
+var
+  Boxed: TGocciaObjectValue;
+begin
+  if not Assigned(AThisValue) or
+     (AThisValue is TGocciaUndefinedLiteralValue) or
+     (AThisValue is TGocciaNullLiteralValue) then
+  begin
+    if Assigned(AGlobalThis) then
+      Result := AGlobalThis
+    else
+      Result := AThisValue;
+    Exit;
+  end;
+
+  if AThisValue is TGocciaObjectValue then
+  begin
+    Result := AThisValue;
+    Exit;
+  end;
+
+  Boxed := AThisValue.Box;
+  if Assigned(Boxed) then
+    Result := Boxed
+  else
+    Result := AThisValue;
 end;
 
 // ES2026 §7.3.3 LengthOfArrayLike(obj)

--- a/tests/language/expressions/member-access/primitive-receiver-accessor-this.js
+++ b/tests/language/expressions/member-access/primitive-receiver-accessor-this.js
@@ -1,0 +1,85 @@
+/*---
+description: Prototype accessors observe the primitive receiver as this on primitive property access
+features: [property-access, String.prototype, Number.prototype]
+---*/
+
+describe("prototype accessor receiver on primitive property access", () => {
+  test("String.prototype getter sees the string primitive on computed access", () => {
+    Object.defineProperty(String.prototype, "kindOfThis", {
+      get() {
+        return typeof this;
+      },
+      configurable: true,
+    });
+    try {
+      const s = "abc";
+      const k = "kindOfThis";
+      expect(s[k]).toBe("string");
+    } finally {
+      delete String.prototype.kindOfThis;
+    }
+  });
+
+  test("String.prototype getter sees the string primitive on static access", () => {
+    Object.defineProperty(String.prototype, "kindOfThis", {
+      get() {
+        return typeof this;
+      },
+      configurable: true,
+    });
+    try {
+      const s = "abc";
+      expect(s.kindOfThis).toBe("string");
+    } finally {
+      delete String.prototype.kindOfThis;
+    }
+  });
+
+  test("String.prototype getter receives the primitive value itself", () => {
+    Object.defineProperty(String.prototype, "self", {
+      get() {
+        return this;
+      },
+      configurable: true,
+    });
+    try {
+      const s = "abc";
+      const k = "self";
+      expect(s[k]).toBe("abc");
+    } finally {
+      delete String.prototype.self;
+    }
+  });
+
+  test("Number.prototype getter sees the number primitive on computed access", () => {
+    Object.defineProperty(Number.prototype, "kindOfThis", {
+      get() {
+        return typeof this;
+      },
+      configurable: true,
+    });
+    try {
+      const n = 5;
+      const k = "kindOfThis";
+      expect(n[k]).toBe("number");
+    } finally {
+      delete Number.prototype.kindOfThis;
+    }
+  });
+
+  test("symbol-keyed String.prototype getter sees the string primitive", () => {
+    const key = Symbol("kindOfThis");
+    Object.defineProperty(String.prototype, key, {
+      get() {
+        return typeof this;
+      },
+      configurable: true,
+    });
+    try {
+      const s = "abc";
+      expect(s[key]).toBe("string");
+    } finally {
+      delete String.prototype[key];
+    }
+  });
+});

--- a/tests/language/expressions/member-access/primitive-receiver-computed-keys.js
+++ b/tests/language/expressions/member-access/primitive-receiver-computed-keys.js
@@ -1,0 +1,54 @@
+/*---
+description: Computed property access on number, boolean, bigint, and symbol primitive receivers
+features: [property-access, Number.prototype, Boolean.prototype, BigInt.prototype, Symbol.prototype]
+---*/
+
+describe("computed property access on non-string primitives", () => {
+  test("computed key resolves Number.prototype methods", () => {
+    const n = 5;
+    const k = "toFixed";
+    expect(n[k](2)).toBe("5.00");
+  });
+
+  test("computed key resolves Boolean.prototype methods", () => {
+    const b = true;
+    const k = "toString";
+    expect(b[k]()).toBe("true");
+  });
+
+  test("computed key resolves BigInt.prototype methods", () => {
+    const x = 255n;
+    const k = "toString";
+    expect(x[k](16)).toBe("ff");
+  });
+
+  test("computed key resolves Symbol.prototype accessors", () => {
+    const s = Symbol("hello");
+    const k = "description";
+    expect(s[k]).toBe("hello");
+  });
+
+  test("computed well-known symbol key resolves on a symbol primitive", () => {
+    const s = Symbol("hello");
+    const k = Symbol.toPrimitive;
+    expect(typeof s[k]).toBe("function");
+  });
+
+  test("computed unknown name key on a number returns undefined", () => {
+    const n = 5;
+    const k = "noSuchProperty";
+    expect(n[k]).toBeUndefined();
+  });
+
+  test("computed key colliding with internal private-slot naming returns undefined on a number", () => {
+    const n = 5;
+    const k = "#slot:x";
+    expect(n[k]).toBeUndefined();
+  });
+
+  test("computed well-known symbol key missing from Number.prototype returns undefined", () => {
+    const n = 5;
+    const k = Symbol.iterator;
+    expect(n[k]).toBeUndefined();
+  });
+});

--- a/tests/language/expressions/member-access/string-primitive-computed-keys.js
+++ b/tests/language/expressions/member-access/string-primitive-computed-keys.js
@@ -1,0 +1,81 @@
+/*---
+description: Computed property access on string primitive receivers
+features: [property-access, String.prototype]
+---*/
+
+describe("computed property access on string primitives", () => {
+  test("computed 'length' key resolves on a string primitive", () => {
+    const s = "abc";
+    const k = "length";
+    expect(s[k]).toBe(3);
+  });
+
+  test("computed key resolves String.prototype methods", () => {
+    const s = "abc";
+    const k = "toUpperCase";
+    expect(s[k]()).toBe("ABC");
+  });
+
+  test("computed integer key returns the code unit", () => {
+    const s = "abc";
+    const k = 1;
+    expect(s[k]).toBe("b");
+  });
+
+  test("computed numeric string key returns the code unit", () => {
+    const s = "abc";
+    const k = "1";
+    expect(s[k]).toBe("b");
+  });
+
+  test("computed out-of-range index returns undefined", () => {
+    const s = "abc";
+    expect(s[5]).toBeUndefined();
+  });
+
+  test("computed negative index returns undefined", () => {
+    const s = "abc";
+    expect(s[-1]).toBeUndefined();
+  });
+
+  test("computed unknown name key returns undefined", () => {
+    const s = "abc";
+    const k = "noSuchProperty";
+    expect(s[k]).toBeUndefined();
+  });
+
+  test("computed well-known symbol key resolves on a string primitive", () => {
+    const s = "abc";
+    const k = Symbol.iterator;
+    expect(typeof s[k]).toBe("function");
+  });
+
+  test("computed key resolving via a non-identifier name returns undefined", () => {
+    const s = "abc";
+    const k = "1.5";
+    expect(s[k]).toBeUndefined();
+  });
+
+  test("computed assignment to 'length' on a string primitive throws", () => {
+    const s = "abc";
+    const k = "length";
+    expect(() => {
+      s[k] = 5;
+    }).toThrow(TypeError);
+  });
+
+  test("computed assignment to an index on a string primitive throws", () => {
+    const s = "abc";
+    expect(() => {
+      s[0] = "z";
+    }).toThrow(TypeError);
+  });
+
+  test("computed assignment to a fresh name on a string primitive throws", () => {
+    const s = "abc";
+    const k = "foo";
+    expect(() => {
+      s[k] = 1;
+    }).toThrow(TypeError);
+  });
+});

--- a/tests/language/expressions/member-access/string-primitive-computed-keys.js
+++ b/tests/language/expressions/member-access/string-primitive-computed-keys.js
@@ -56,6 +56,12 @@ describe("computed property access on string primitives", () => {
     expect(s[k]).toBeUndefined();
   });
 
+  test("computed key colliding with internal private-slot naming returns undefined", () => {
+    const s = "abc";
+    const k = "#slot:x";
+    expect(s[k]).toBeUndefined();
+  });
+
   test("computed assignment to 'length' on a string primitive throws", () => {
     const s = "abc";
     const k = "length";

--- a/tests/language/non-strict-mode/this-binding.js
+++ b/tests/language/non-strict-mode/this-binding.js
@@ -23,6 +23,50 @@ describe("non-strict function this binding", () => {
     expect(f.apply(null, [])).toBe(globalThis);
   });
 
+  test("call boxes a primitive this to its wrapper object", () => {
+    function f() {
+      return this;
+    }
+
+    const bound = f.call(5);
+    expect(typeof bound).toBe("object");
+    expect(bound.valueOf()).toBe(5);
+  });
+
+  test("apply boxes a primitive this to its wrapper object", () => {
+    function f() {
+      return this;
+    }
+
+    const bound = f.apply("abc", []);
+    expect(typeof bound).toBe("object");
+    expect(bound.valueOf()).toBe("abc");
+  });
+
+  test("prototype getter on a primitive receiver sees the boxed this", () => {
+    Object.defineProperty(Object.prototype, "boxedSelf", {
+      get() {
+        return this;
+      },
+      configurable: true,
+    });
+    try {
+      expect((5).boxedSelf === 5).toBe(false);
+      expect(typeof (5).boxedSelf).toBe("object");
+    } finally {
+      delete Object.prototype.boxedSelf;
+    }
+  });
+
+  test("use strict directive keeps a primitive this unboxed", () => {
+    function f() {
+      "use strict";
+      return this;
+    }
+
+    expect(f.call(5)).toBe(5);
+  });
+
   test("arrow functions keep lexical this", () => {
     function outer() {
       const arrow = () => this;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fixes computed property access (`receiver[key]`) on primitive receivers in the bytecode VM, which diverged from the interpreter. `s[k]` with `k = "length"` returned `undefined` in `--mode=bytecode` while the interpreter correctly returned `3`; the same gap applied to `String.prototype` method lookups and to number, boolean, and bigint receivers (`(5)["toFixed"]`, `true["toString"]`, `(255n)["toString"]`).
- Root cause: the string-receiver arms of `OP_ARRAY_GET` and `OP_GET_INDEX` only handled direct symbol keys and in-range integer indices, and all other primitive receivers fell through to `undefined` without consulting the boxed object per ES2026 OrdinaryGet.
- The fix extracts one shared `ExecGetComputedPropertyFallback` used by both opcodes for every non-array/class/object receiver. It keeps the unboxed string code-unit fast path, adds an unboxed string `length` read, preserves the symbol-receiver shared-prototype semantics (`OP_GET_INDEX` now gains them too), and resolves name keys via `GetProperty` → boxed lookup directly — deliberately bypassing `GetPropertyValue`'s `'#slot:'` private-key branch so user string keys that collide with the internal mangling resolve as ordinary names instead of throwing.
- Follow-up from review (coderabbitai): all six box-and-read sites (interpreter member access, interpreter symbol-key assignment read, VM `GetPropertyValue`, and the VM computed-get fallback) now pass the primitive receiver to prototype accessors via `GetPropertyWithContext` / `GetSymbolPropertyWithReceiver`, so a strict getter on `String.prototype` / `Number.prototype` observes `typeof this` as `"string"` / `"number"` per ES2026 GetValue, in both executors.
- Follow-up from conformance CI: the receiver-aware change exposed that non-strict `this` binding only implemented the nullish→`globalThis` half of ES2026 §10.2.1.2 OrdinaryCallBindThis (test262 `language/function-code/10.4.3-1-105.js` had passed by accident of two compensating gaps). A new shared `CoerceNonStrictThis` (in `Goccia.Values.ToObject`) now also boxes primitive `this` for non-strict callees, wired through the five bytecode call entry points, the `f.call`/`f.apply` opcode fast paths (register-level wrapper), and the interpreter's `BindThis`. Strict callees are untouched, so default GocciaScript behavior is unchanged; the coercion only applies under `--compat-non-strict-mode`.
- Non-goals: computed SET on primitive receivers already agreed between modes (TypeError) and is covered by tests but unchanged; `OP_GET_INDEX` keeps its historical return-`undefined` contract for nullish receivers (plain `o[k]` compiles to `OP_ARRAY_GET`, which still throws).

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Full suite passes 10,319/10,319 in both interpreter and bytecode modes (clean builds). `./format.pas --check` clean. test262 spot-checks: zero regressions vs the main baseline across `built-ins/{String,Number,Boolean,BigInt,Symbol}` and `language/function-code`; net newly passing includes 18 in function-code (the `10.4.3-1-*-s`/`-gs` strict-this family, with `10.4.3-1-105` restored), 15 in Symbol, and 1 each in Number/Boolean/BigInt. The only String deltas vs baseline are a pre-existing dev-build range-check issue in `String.fromCharCode(Infinity)` (`-Cr` builds only), tracked separately. New JS tests: `tests/language/expressions/member-access/string-primitive-computed-keys.js` (13 tests), `primitive-receiver-computed-keys.js` (8 tests), `primitive-receiver-accessor-this.js` (5 tests), and 4 new sloppy-this boxing tests in `tests/language/non-strict-mode/this-binding.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
