### PR TITLE
fix(json): spec-conformant space argument coercion in JSON.stringify

### DIFF
--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -50,6 +50,7 @@ type
 implementation
 
 uses
+  Math,
   SysUtils,
 
   Goccia.Constants.PropertyNames,
@@ -63,7 +64,6 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
-  Goccia.Values.ToPrimitive,
   Goccia.VM.Exception;
 
 threadvar
@@ -182,7 +182,7 @@ begin
   end;
 end;
 
-// ES2026 §25.5.2.3 JSON.isRawJSON ( O )
+// ES2026 §25.5.1 JSON.isRawJSON ( O )
 function TGocciaJSONBuiltin.JSONIsRawJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Value: TGocciaValue;
@@ -264,7 +264,7 @@ begin
   end;
 end;
 
-// ES2026 §25.5.2.4 JSON.rawJSON ( text )
+// ES2026 §25.5.3 JSON.rawJSON ( text )
 function TGocciaJSONBuiltin.JSONRawJSON(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 const
   JSON_WHITESPACE_TAB = #9;
@@ -320,28 +320,32 @@ end;
 function TGocciaJSONBuiltin.ResolveGap(const ASpaceArg: TGocciaValue): string;
 var
   Space: TGocciaValue;
+  SpaceNumber: Double;
   SpaceCount: Integer;
-  I: Integer;
 begin
   Result := '';
   Space := ASpaceArg;
   // Step 6: If space is an Object with a [[NumberData]] slot, set space to
   // ? ToNumber(space); with a [[StringData]] slot, to ? ToString(space).
-  // Both go through ToPrimitive so user-defined valueOf/toString are honored.
+  // The object-level ToNumberLiteral/ToStringLiteral route through ToPrimitive,
+  // so user-defined valueOf/toString are honored.
   if Space is TGocciaNumberObjectValue then
-    Space := ToPrimitive(Space, tphNumber).ToNumberLiteral
+    Space := Space.ToNumberLiteral
   else if Space is TGocciaStringObjectValue then
-    Space := ToPrimitive(Space, tphString).ToStringLiteral;
-  // Step 7: If space is a Number, let gap be min(10, ToIntegerOrInfinity(space)) spaces.
+    Space := Space.ToStringLiteral;
+  // Step 7: If space is a Number, let gap be min(10, ToIntegerOrInfinity(space))
+  // spaces. Clamp before Trunc so NaN, ±Infinity, and doubles beyond Integer
+  // range never reach Trunc.
   if Space is TGocciaNumberLiteralValue then
   begin
-    SpaceCount := Trunc(Space.ToNumberLiteral.Value);
-    if SpaceCount > 10 then
-      SpaceCount := 10;
-    if SpaceCount < 1 then
+    SpaceNumber := Space.ToNumberLiteral.Value;
+    if Math.IsNaN(SpaceNumber) or (SpaceNumber < 1) then
       Exit;
-    for I := 1 to SpaceCount do
-      Result := Result + ' ';
+    if SpaceNumber > 10 then
+      SpaceCount := 10
+    else
+      SpaceCount := Trunc(SpaceNumber);
+    Result := StringOfChar(' ', SpaceCount);
   end
   // Step 8: Else if space is a String, let gap be the first 10 characters.
   else if Space is TGocciaStringLiteralValue then
@@ -353,7 +357,7 @@ begin
   // Step 9: Else let gap be the empty string (already default).
 end;
 
-// ES2026 §25.5.2.2 SerializeJSONProperty ( state, key, holder ) step 1: toJSON hook.
+// ES2026 §25.5.4.2 SerializeJSONProperty ( state, key, holder ) step 2: toJSON hook.
 function TGocciaJSONBuiltin.ApplyToJSON(const AValue: TGocciaValue; const AKey: string): TGocciaValue;
 var
   ToJSONMethod: TGocciaValue;
@@ -376,7 +380,7 @@ begin
   end;
 end;
 
-// §25.5.2.1 SerializeJSONProperty — Step 2: Call replacer function.
+// §25.5.4.2 SerializeJSONProperty — step 3: Call replacer function.
 // Invokes the replacer with (key, value) bound to the holder object.
 function TGocciaJSONBuiltin.ApplyReplacer(const AHolder: TGocciaValue; const AKey: string; const AValue: TGocciaValue; const AReplacer: TGocciaValue): TGocciaValue;
 var
@@ -389,7 +393,7 @@ begin
   Result := InvokeCallable(AReplacer, Args, AHolder);
 end;
 
-// §25.5.2.1 SerializeJSONProperty ( state, key, holder ) — recursive transformation.
+// §25.5.4.2 SerializeJSONProperty ( state, key, holder ) — recursive transformation.
 // Applies the replacer function then recursively transforms nested objects/arrays.
 function TGocciaJSONBuiltin.TransformWithReplacer(const AHolder: TGocciaValue; const AKey: string; const AValue: TGocciaValue; const AReplacer: TGocciaValue): TGocciaValue;
 var
@@ -414,7 +418,7 @@ begin
     Exit;
   end;
 
-  // ES2026 §25.5.2.2 step 4a: If result has [[IsRawJSON]], pass through directly.
+  // ES2026 §25.5.4.2 step 4.a: If result has [[IsRawJSON]], pass through directly.
   if Replaced is TGocciaRawJSONValue then
   begin
     Result := Replaced;
@@ -470,7 +474,7 @@ begin
     Result := Replaced;
 end;
 
-// §25.5.2 steps 10-11: Stringify with a replacer function.
+// §25.5.4 steps 10-13: Stringify with a replacer function.
 // Wraps the value in a root object, applies the replacer recursively, then serializes.
 function TGocciaJSONBuiltin.StringifyWithReplacer(const AValue: TGocciaValue; const AReplacer: TGocciaValue; const AGap: string): string;
 var
@@ -494,7 +498,7 @@ begin
   Result := FStringifier.Stringify(Transformed, AGap);
 end;
 
-// §25.5.2 steps 4-5: Stringify with an Array replacer (PropertyList filter).
+// §25.5.4 step 5: Stringify with an Array replacer (PropertyList filter).
 // When the replacer is an Array, only properties whose names appear in the
 // allow-list are included in the output (SerializeJSONObject step 6a).
 function TGocciaJSONBuiltin.StringifyWithAllowList(const AValue: TGocciaValue; const AAllowList: TGocciaArrayValue; const AGap: string): string;
@@ -528,7 +532,7 @@ begin
   Result := FStringifier.Stringify(Filtered, AGap);
 end;
 
-// §25.5.2 JSON.stringify ( value [ , replacer [ , space ] ] )
+// §25.5.4 JSON.stringify ( value [ , replacer [ , space ] ] )
 function TGocciaJSONBuiltin.JSONStringify(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Value, ReplacerArg, SpaceArg: TGocciaValue;
@@ -546,15 +550,17 @@ begin
     Exit;
   end;
 
-  // Steps 7-9: Resolve the gap/indent string from the space argument.
   Gap := '';
-  if AArgs.Length >= 3 then
-  begin
-    SpaceArg := AArgs.GetElement(2);
-    Gap := ResolveGap(SpaceArg);
-  end;
-
   try
+    // Steps 6-9: Resolve the gap/indent string from the space argument. Space
+    // coercion can run user valueOf/toString, so it must stay inside the
+    // error-normalization block.
+    if AArgs.Length >= 3 then
+    begin
+      SpaceArg := AArgs.GetElement(2);
+      Gap := ResolveGap(SpaceArg);
+    end;
+
     if AArgs.Length >= 2 then
     begin
       ReplacerArg := AArgs.GetElement(1);

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -59,8 +59,11 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
+  Goccia.Values.NumberObjectValue,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.ToPrimitive,
   Goccia.VM.Exception;
 
 threadvar
@@ -312,17 +315,27 @@ begin
   Result := TGocciaRawJSONValue.Create(JSONString);
 end;
 
-// §25.5.2 steps 7-8: Resolve the gap (indentation) string from the space argument.
+// ES2026 §25.5.4 (sec-json.stringify) steps 6-9: Resolve the gap (indentation)
+// string from the space argument.
 function TGocciaJSONBuiltin.ResolveGap(const ASpaceArg: TGocciaValue): string;
 var
+  Space: TGocciaValue;
   SpaceCount: Integer;
   I: Integer;
 begin
   Result := '';
-  // Step 7: If space is a Number, let gap be min(10, ToInteger(space)) spaces.
-  if ASpaceArg is TGocciaNumberLiteralValue then
+  Space := ASpaceArg;
+  // Step 6: If space is an Object with a [[NumberData]] slot, set space to
+  // ? ToNumber(space); with a [[StringData]] slot, to ? ToString(space).
+  // Both go through ToPrimitive so user-defined valueOf/toString are honored.
+  if Space is TGocciaNumberObjectValue then
+    Space := ToPrimitive(Space, tphNumber).ToNumberLiteral
+  else if Space is TGocciaStringObjectValue then
+    Space := ToPrimitive(Space, tphString).ToStringLiteral;
+  // Step 7: If space is a Number, let gap be min(10, ToIntegerOrInfinity(space)) spaces.
+  if Space is TGocciaNumberLiteralValue then
   begin
-    SpaceCount := Trunc(ASpaceArg.ToNumberLiteral.Value);
+    SpaceCount := Trunc(Space.ToNumberLiteral.Value);
     if SpaceCount > 10 then
       SpaceCount := 10;
     if SpaceCount < 1 then
@@ -331,9 +344,9 @@ begin
       Result := Result + ' ';
   end
   // Step 8: Else if space is a String, let gap be the first 10 characters.
-  else if ASpaceArg is TGocciaStringLiteralValue then
+  else if Space is TGocciaStringLiteralValue then
   begin
-    Result := ASpaceArg.ToStringLiteral.Value;
+    Result := Space.ToStringLiteral.Value;
     if Length(Result) > 10 then
       Result := Copy(Result, 1, 10);
   end;

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -266,9 +266,6 @@ test("JSON.stringify space as boxed Number propagates valueOf exceptions", () =>
   space.valueOf = () => {
     throw new TypeError("abrupt valueOf");
   };
-  space.toString = () => {
-    throw new TypeError("abrupt toString");
-  };
 
   expect(() => JSON.stringify({ a: 1 }, null, space)).toThrow(TypeError);
 });
@@ -299,11 +296,47 @@ test("JSON.stringify space as boxed String propagates toString exceptions", () =
   space.toString = () => {
     throw new TypeError("abrupt toString");
   };
-  space.valueOf = () => {
-    throw new TypeError("abrupt valueOf");
-  };
 
   expect(() => JSON.stringify({ a: 1 }, null, space)).toThrow(TypeError);
+});
+
+test("JSON.stringify truncates a fractional primitive space", () => {
+  const obj = { a: 1, b: [1, 2] };
+
+  expect(JSON.stringify(obj, null, 5.99999)).toBe(JSON.stringify(obj, null, 5));
+});
+
+test("JSON.stringify treats NaN space as no indentation", () => {
+  expect(JSON.stringify({ a: 1 }, null, NaN)).toBe('{"a":1}');
+});
+
+test("JSON.stringify clamps Infinity space to 10 spaces", () => {
+  const obj = { a: 1, b: [1, 2] };
+
+  expect(JSON.stringify(obj, null, Infinity)).toBe(
+    JSON.stringify(obj, null, 10),
+  );
+});
+
+test("JSON.stringify treats -Infinity space as no indentation", () => {
+  expect(JSON.stringify({ a: 1 }, null, -Infinity)).toBe('{"a":1}');
+});
+
+test("JSON.stringify clamps huge finite space to 10 spaces", () => {
+  const obj = { a: 1, b: [1, 2] };
+
+  expect(JSON.stringify(obj, null, 2147483648)).toBe(
+    JSON.stringify(obj, null, 10),
+  );
+  expect(JSON.stringify(obj, null, 1e15)).toBe(JSON.stringify(obj, null, 10));
+});
+
+test("JSON.stringify clamps boxed Number Infinity space to 10 spaces", () => {
+  const obj = { a: 1, b: [1, 2] };
+
+  expect(JSON.stringify(obj, null, new Number(Infinity))).toBe(
+    JSON.stringify(obj, null, 10),
+  );
 });
 
 test("JSON.stringify serializes sparse array holes as null", () => {

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -237,6 +237,75 @@ test("JSON.stringify treats non-positive space as no indentation", () => {
   expect(JSON.stringify(obj, null, -4)).toBe('{"a":1}');
 });
 
+test("JSON.stringify space as boxed Number indents like the primitive", () => {
+  const obj = { a: 1, b: [1, 2] };
+
+  expect(JSON.stringify(obj, null, new Number(2))).toBe(
+    JSON.stringify(obj, null, 2),
+  );
+});
+
+test("JSON.stringify space as boxed Number truncates fractional values", () => {
+  const obj = { a: 1, b: [1, 2] };
+
+  expect(JSON.stringify(obj, null, new Number(5.11111))).toBe(
+    JSON.stringify(obj, null, 5),
+  );
+});
+
+test("JSON.stringify space as boxed Number uses an overridden valueOf", () => {
+  const obj = { a: 1 };
+  const space = new Number(1);
+  space.valueOf = () => 3;
+
+  expect(JSON.stringify(obj, null, space)).toBe(JSON.stringify(obj, null, 3));
+});
+
+test("JSON.stringify space as boxed Number propagates valueOf exceptions", () => {
+  const space = new Number(4);
+  space.valueOf = () => {
+    throw new TypeError("abrupt valueOf");
+  };
+  space.toString = () => {
+    throw new TypeError("abrupt toString");
+  };
+
+  expect(() => JSON.stringify({ a: 1 }, null, space)).toThrow(TypeError);
+});
+
+test("JSON.stringify space as boxed String indents like the primitive", () => {
+  const obj = { a: 1, b: [1, 2] };
+
+  expect(JSON.stringify(obj, null, new String("xx"))).toBe(
+    JSON.stringify(obj, null, "xx"),
+  );
+});
+
+test("JSON.stringify space as boxed String uses an overridden toString without calling valueOf", () => {
+  const obj = { a: 1 };
+  const space = new String("xx");
+  space.toString = () => "--";
+  space.valueOf = () => {
+    throw new TypeError("valueOf must not be called");
+  };
+
+  expect(JSON.stringify(obj, null, space)).toBe(
+    JSON.stringify(obj, null, "--"),
+  );
+});
+
+test("JSON.stringify space as boxed String propagates toString exceptions", () => {
+  const space = new String("xx");
+  space.toString = () => {
+    throw new TypeError("abrupt toString");
+  };
+  space.valueOf = () => {
+    throw new TypeError("abrupt valueOf");
+  };
+
+  expect(() => JSON.stringify({ a: 1 }, null, space)).toThrow(TypeError);
+});
+
 test("JSON.stringify serializes sparse array holes as null", () => {
   expect(JSON.stringify([1, , 3])).toBe("[1,null,3]");
 });


### PR DESCRIPTION
## Summary

- `JSON.stringify`'s `space` argument now follows ES2026 §25.5.4 step 6: a boxed `Number`/`String` object is coerced with ToNumber/ToString (via the canonical `TGocciaObjectValue.ToNumberLiteral`/`ToStringLiteral` helpers), so `new Number(5)` / `new String("  ")` indent like their primitives, user-overridden `valueOf`/`toString` are honored with correct hint ordering, and abrupt completions propagate.
- The numeric gap path now implements ToIntegerOrInfinity semantics (step 7): NaN and values below 1 produce no indentation, and anything above 10 — including `Infinity` and doubles beyond `Integer` range — clamps to 10 *before* `Trunc`. Previously `Infinity`, `-Infinity`, `2^31`, or `1e15` as space (and, once boxed objects coerce, any `valueOf` returning those) raised a fatal uncatchable range-check error in dev builds and silently produced the wrong gap in production builds.
- `ResolveGap` moved inside `JSONStringify`'s error-normalization `try/except`, since space coercion can now run user code; native failures surface as catchable JS errors like every other stringify step.
- Stale spec clause references in the unit were corrected to ES2026 numbering verified against tc39-mcp (JSON.isRawJSON §25.5.1, rawJSON §25.5.3, stringify §25.5.4, SerializeJSONProperty §25.5.4.2).
- Fixes test262 `built-ins/JSON/stringify/space-number-float.js`, `space-number-object.js`, and `space-string-object.js`; all 8 `space*` tests pass via the project harness against the pinned suite SHA `05bb0329` (negative check confirmed exactly those three failed before the fix).
- Non-goals (verified, filed as follow-ups): the replacer-before-space observable ordering inversion, the JSON5 sibling's slot-read space coercion and its own `Trunc` range bug, and the PropertyList element-filtering/nesting conformance gaps.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — 13 new `test()` scenarios in `tests/built-ins/JSON/stringify.js` (boxed Number/String spaces, hook overrides, exception propagation, fractional/NaN/±Infinity/huge-finite spaces); full suite 10,302/10,302 in both default and `--mode=bytecode` after `./build.pas --clean`; `./format.pas --check` clean.
- [ ] Updated documentation — not needed: conformance bug fix with no documented-API surface change (`docs/built-ins-data-formats.md` documents `space` at the API level only, per project policy).
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — no AST/scope/evaluator/value-type changes; the change is contained to the JSON builtin and covered by the JS suite.
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — `ResolveGap` runs once per stringify call, not on the per-node hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)