### PR TITLE
fix(builtins): guard script-controlled Trunc sites per spec integer coercions

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,9 @@ pre-commit:
     check-swimmies:
       glob: "**/*.{pas,dpr}"
       run: bun check-swimmies.ts {staged_files}
+    check-trunc-guards:
+      glob: "**/*.{pas,dpr}"
+      run: npx tsx scripts/check-trunc-guards.ts
     lint-markdown:
       glob: "**/*.md"
       run: npx markdownlint-cli2 {staged_files}

--- a/scripts/check-trunc-guards.ts
+++ b/scripts/check-trunc-guards.ts
@@ -63,7 +63,8 @@ for (const dir of SOURCE_DIRS) walkPas(dir, files);
 
 let failures = 0;
 for (const file of files) {
-  const rel = relative(ROOT, file);
+  // Normalize to forward slashes so allowlist keys match on Windows too.
+  const rel = relative(ROOT, file).split("\\").join("/");
   const text = readFileSync(file, "utf8");
   const matches = [...text.matchAll(PATTERN)];
   const allowed = ALLOWLIST[rel]?.count ?? 0;

--- a/scripts/check-trunc-guards.ts
+++ b/scripts/check-trunc-guards.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env npx tsx
+/**
+ * check-trunc-guards.ts
+ *
+ * Rejects new `Trunc(<expr>.ToNumberLiteral...)` call sites in Pascal source.
+ *
+ * FPC's Trunc() raises a range-check error on NaN/±Infinity under -Cr (dev
+ * builds) and silently produces garbage on aarch64, so script-controlled
+ * numbers must never reach a bare Trunc. Route coercions through the helpers
+ * in Goccia.Utils instead:
+ *   - ToIntegerValue / ToIntegerFromArgs   (ToIntegerOrInfinity, saturating)
+ *   - ToLengthValue                        (ToLength)
+ *   - ToIntegerWithTruncationValue / ...64Value (RangeError on non-finite)
+ *   - ToInt64Value                         (host/FFI marshaling, NaN/±∞ → 0)
+ *   - ToInt32Value / ToUint32Value / ToUint16Value (modular wrapping)
+ *
+ * Allowlisted sites are pre-guarded or operate on engine-internal values;
+ * adding to the allowlist requires demonstrating a non-finite guard in scope.
+ *
+ * Usage:
+ *   npx tsx scripts/check-trunc-guards.ts
+ *   npx tsx scripts/check-trunc-guards.ts --verbose
+ */
+
+import { readFileSync, readdirSync } from "fs";
+import { join, relative, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const SOURCE_DIRS = [
+  join(ROOT, "source", "units"),
+  join(ROOT, "source", "shared"),
+  join(ROOT, "source", "app"),
+];
+const VERBOSE = process.argv.includes("--verbose");
+
+// Bare Trunc on a freshly-coerced script value, including wrapped multi-line
+// forms (the pattern is matched on the whole file with line tracking below).
+const PATTERN = /Trunc\s*\(\s*[A-Za-z_][\w.()\s]*?\.ToNumberLiteral/g;
+
+// file (relative to repo root) → number of allowed matches, with the reason
+// the site is safe. Counts are exact so removals are noticed too.
+const ALLOWLIST: Record<string, { count: number; reason: string }> = {
+  "source/units/Goccia.Builtins.Console.pas": {
+    count: 1,
+    reason:
+      "console.count counter map is engine-internal; values are always engine-created finite numbers",
+  },
+};
+
+const walkPas = (dir: string, out: string[]): void => {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walkPas(full, out);
+    else if (entry.name.endsWith(".pas") || entry.name.endsWith(".dpr"))
+      out.push(full);
+  }
+};
+
+const files: string[] = [];
+for (const dir of SOURCE_DIRS) walkPas(dir, files);
+
+let failures = 0;
+for (const file of files) {
+  const rel = relative(ROOT, file);
+  const text = readFileSync(file, "utf8");
+  const matches = [...text.matchAll(PATTERN)];
+  const allowed = ALLOWLIST[rel]?.count ?? 0;
+
+  if (matches.length === allowed) {
+    if (VERBOSE && matches.length > 0)
+      console.log(`ok (allowlisted ×${allowed}): ${rel}`);
+    continue;
+  }
+
+  failures++;
+  console.error(
+    `${rel}: ${matches.length} bare Trunc(...ToNumberLiteral...) site(s), ` +
+      `${allowed} allowed`,
+  );
+  for (const m of matches) {
+    const line = text.slice(0, m.index).split("\n").length;
+    console.error(`  ${rel}:${line}: ${m[0].replace(/\s+/g, " ")}...`);
+  }
+}
+
+if (failures > 0) {
+  console.error(
+    "\nBare Trunc on script-controlled numbers crashes dev builds on " +
+      "NaN/±Infinity. Use the coercion helpers in Goccia.Utils (see header " +
+      "of scripts/check-trunc-guards.ts), or extend the allowlist with a " +
+      "documented guard.",
+  );
+  process.exit(1);
+}
+
+console.log(`${files.length} Pascal file(s) checked. No unguarded Trunc-on-ToNumberLiteral sites.`);

--- a/source/shared/BigInteger.pas
+++ b/source/shared/BigInteger.pas
@@ -363,10 +363,8 @@ end;
 
 class function TBigInteger.FromDouble(const AValue: Double): TBigInteger;
 var
-  V: Double;
-  Limb: Cardinal;
-  DecStr: string;
-  FS: TFormatSettings;
+  Bits, Mantissa: QWord;
+  Exponent: Integer;
 begin
   if IsNaN(AValue) or IsInfinite(AValue) then
     raise Exception.Create('Cannot convert non-finite number to BigInt');
@@ -382,13 +380,17 @@ begin
   if (AValue >= -9007199254740992.0) and (AValue <= 9007199254740992.0) then
     Exit(FromInt64(Trunc(AValue)));
 
-  // For values above 2^53 (representable as aligned integers in IEEE 754),
-  // convert via decimal string to avoid FPC AArch64 FMod precision bugs.
-  // FormatFloat('0', v) renders the exact integer without scientific notation.
-  FS := DefaultFormatSettings;
-  FS.DecimalSeparator := '.';
-  DecStr := FormatFloat('0', AValue, FS);
-  Result := FromDecimalString(DecStr);
+  // Above 2^53 the double's exact integer value is mantissa × 2^exponent.
+  // Decompose the IEEE 754 bits directly: decimal-string round-trips (Str,
+  // FormatFloat) emit at most ~17 significant digits and silently round the
+  // rest, corrupting values like 9007199254740991475711 → ...992000000.
+  Bits := PQWord(@AValue)^;
+  Mantissa := (Bits and QWord($000FFFFFFFFFFFFF)) or QWord($0010000000000000);
+  Exponent := Integer((Bits shr 52) and $7FF) - 1075;
+  // |AValue| > 2^53 implies a normal double with Exponent > 0 here.
+  Result := FromInt64(Int64(Mantissa)).ShiftLeft(Exponent);
+  if AValue < 0 then
+    Result := Result.Negate;
 end;
 
 class function TBigInteger.FromDecimalString(const AValue: string): TBigInteger;
@@ -604,18 +606,49 @@ end;
 
 function TBigInteger.ToDouble: Double;
 var
-  I: Integer;
-  Base: Double;
+  BitLen, Shift: Integer;
+  TopLimb: Cardinal;
+  Mag64, Mantissa: QWord;
+  Shifted: TBigInteger;
+  RoundBit, Sticky: Boolean;
 begin
   if IsZero then
     Exit(0.0);
-  Result := 0.0;
-  Base := 1.0;
-  for I := 0 to High(FLimbs) do
+
+  // Bit length of the magnitude (limbs are little-endian, top limb non-zero).
+  TopLimb := FLimbs[High(FLimbs)];
+  BitLen := High(FLimbs) * LIMB_BITS;
+  while TopLimb > 0 do
   begin
-    Result := Result + FLimbs[I] * Base;
-    Base := Base * LIMB_BASE;
+    Inc(BitLen);
+    TopLimb := TopLimb shr 1;
   end;
+
+  if BitLen <= 63 then
+  begin
+    // Fits a QWord; the hardware QWord → Double conversion rounds correctly.
+    Mag64 := QWord(FLimbs[0]);
+    if Length(FLimbs) > 1 then
+      Mag64 := Mag64 or (QWord(FLimbs[1]) shl LIMB_BITS);
+    Result := Mag64;
+  end
+  else
+  begin
+    // Round to nearest, ties to even: keep the top 53 bits as the mantissa,
+    // the next bit as the round bit, and OR the rest into a sticky bit.
+    // Limb-by-limb floating accumulation (the previous implementation)
+    // rounds at every step and can drift several ulp.
+    Shift := BitLen - 54;
+    Shifted := AbsValue.ShiftRight(Shift);
+    Mag64 := QWord(Shifted.ToInt64);
+    RoundBit := (Mag64 and 1) = 1;
+    Mantissa := Mag64 shr 1;
+    Sticky := not AbsValue.Equal(Shifted.ShiftLeft(Shift));
+    if RoundBit and (Sticky or ((Mantissa and 1) = 1)) then
+      Inc(Mantissa);
+    Result := Ldexp(Mantissa, Shift + 1);
+  end;
+
   if FNegative then
     Result := -Result;
 end;

--- a/source/units/Goccia.Arguments.ArrayLike.pas
+++ b/source/units/Goccia.Arguments.ArrayLike.pas
@@ -16,10 +16,10 @@ function CreateListFromArrayLike(const AValue: TGocciaValue; const AMethodName: 
 implementation
 
 uses
-  Math,
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue;
@@ -36,7 +36,6 @@ var
   ArrVal: TGocciaArrayValue;
   ArrayObj: TGocciaObjectValue;
   LengthProp: TGocciaValue;
-  LengthValue: Double;
   Len, I: Integer;
   Element: TGocciaValue;
 begin
@@ -64,16 +63,7 @@ begin
      (LengthProp is TGocciaNullLiteralValue) then
     Len := 0
   else
-  begin
-    LengthValue := LengthProp.ToNumberLiteral.Value;
-    // Trunc raises EInvalidOp for NaN/Infinity in FPC 3.2.2
-    if IsNan(LengthValue) or (LengthValue <= 0) then
-      Len := 0
-    else if LengthValue >= MaxInt then
-      Len := MaxInt
-    else
-      Len := Trunc(LengthValue);
-  end;
+    Len := ToLengthValue(LengthProp);
 
   // Guard against pathological lengths before allocating
   if Len > MAX_ARGUMENTS_LIST_LENGTH then

--- a/source/units/Goccia.Builtins.CSV.pas
+++ b/source/units/Goccia.Builtins.CSV.pas
@@ -317,9 +317,9 @@ begin
   EndOffset := TextLength;
 
   if AArgs.Length >= 3 then
-    StartOffset := Trunc(AArgs.GetElement(2).ToNumberLiteral.Value);
+    StartOffset := ToIntegerFromArgs(AArgs, 2);
   if AArgs.Length >= 4 then
-    EndOffset := Trunc(AArgs.GetElement(3).ToNumberLiteral.Value);
+    EndOffset := ToIntegerFromArgs(AArgs, 3);
 
   try
     ChunkResult := FParser.ParseChunk(Text, Delimiter, Headers,

--- a/source/units/Goccia.Builtins.GlobalArray.pas
+++ b/source/units/Goccia.Builtins.GlobalArray.pas
@@ -308,7 +308,11 @@ begin
         LengthVal := Source.GetProperty(PROP_LENGTH);
         if Assigned(LengthVal) and not (LengthVal is TGocciaUndefinedLiteralValue) then
         begin
-          Len := Trunc(LengthVal.ToNumberLiteral.Value);
+          Len := ToLengthValue(LengthVal);
+          // ArrayCreate rejects lengths beyond what Integer-indexed storage
+          // can hold (spec caps at 2^32-1; ToLengthValue saturates at MaxInt).
+          if Len = MaxInt then
+            ThrowRangeError(SErrorInvalidArrayLength, SSuggestArrayLengthRange);
           // Step 9-10: If IsConstructor(C), Construct(C, « len »); else ArrayCreate(len)
           ResultObj := ConstructOrCreate(0);
           AddTempRootIfNeeded(ResultRoot, ResultObj);
@@ -638,7 +642,9 @@ begin
             LengthValue := Source.GetProperty(PROP_LENGTH);
             if Assigned(LengthValue) and not (LengthValue is TGocciaUndefinedLiteralValue) then
             begin
-              Len := Trunc(LengthValue.ToNumberLiteral.Value);
+              Len := ToLengthValue(LengthValue);
+              if Len = MaxInt then
+                ThrowRangeError(SErrorInvalidArrayLength, SSuggestArrayLengthRange);
               K := 0;
               // TC39 Array.fromAsync §2.1.1.1 step 5.e: Repeat, while k < len
               while K < Len do

--- a/source/units/Goccia.Builtins.GlobalString.pas
+++ b/source/units/Goccia.Builtins.GlobalString.pas
@@ -25,7 +25,6 @@ type
 implementation
 
 uses
-  Math,
   SysUtils,
 
   StringBuffer,
@@ -122,7 +121,6 @@ function TGocciaGlobalString.StringRaw(const AArgs: TGocciaArgumentsCollection; 
 var
   TemplateObj, RawValue, RawElement: TGocciaValue;
   RawObj: TGocciaValue;
-  LengthValue: Double;
   LiteralSegments: Integer;
   SB: TStringBuffer;
   I: Integer;
@@ -145,21 +143,11 @@ begin
   RawObj := RawValue;
 
   // ES2026 §22.1.2.4 step 4: Let literalSegments be LengthOfArrayLike(raw)
-  // ES2026 §7.1.22 ToLength: NaN/negative → 0, spec caps at 2^53−1.
-  // Trunc raises a range-check error for NaN/±∞ in FPC, so guard first.
   RawElement := RawObj.GetProperty(PROP_LENGTH);
   if not Assigned(RawElement) or (RawElement is TGocciaUndefinedLiteralValue) then
     LiteralSegments := 0
   else
-  begin
-    LengthValue := RawElement.ToNumberLiteral.Value;
-    if IsNan(LengthValue) or (LengthValue <= 0) then
-      LiteralSegments := 0
-    else if LengthValue >= MaxInt then
-      LiteralSegments := MaxInt
-    else
-      LiteralSegments := Trunc(LengthValue);
-  end;
+    LiteralSegments := ToLengthValue(RawElement);
 
   // ES2026 §22.1.2.4 step 5: If literalSegments <= 0, return ""
   if LiteralSegments <= 0 then

--- a/source/units/Goccia.Builtins.GlobalString.pas
+++ b/source/units/Goccia.Builtins.GlobalString.pas
@@ -25,6 +25,7 @@ type
 implementation
 
 uses
+  Math,
   SysUtils,
 
   StringBuffer,
@@ -32,6 +33,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -68,8 +70,8 @@ begin
   I := 0;
   while I < AArgs.Length do
   begin
-    CodeUnit := Trunc(AArgs.GetElement(I).ToNumberLiteral.Value);
-    CodeUnit := CodeUnit and $FFFF;
+    // ES2026 §7.1.10 ToUint16: NaN/±0/±∞ → 0, otherwise truncate mod 2^16.
+    CodeUnit := ToUint16Value(AArgs.GetElement(I));
     if CodeUnit < $80 then
       ResultStr := ResultStr + Chr(CodeUnit)
     else if CodeUnit < $800 then
@@ -120,6 +122,7 @@ function TGocciaGlobalString.StringRaw(const AArgs: TGocciaArgumentsCollection; 
 var
   TemplateObj, RawValue, RawElement: TGocciaValue;
   RawObj: TGocciaValue;
+  LengthValue: Double;
   LiteralSegments: Integer;
   SB: TStringBuffer;
   I: Integer;
@@ -142,11 +145,21 @@ begin
   RawObj := RawValue;
 
   // ES2026 §22.1.2.4 step 4: Let literalSegments be LengthOfArrayLike(raw)
+  // ES2026 §7.1.22 ToLength: NaN/negative → 0, spec caps at 2^53−1.
+  // Trunc raises a range-check error for NaN/±∞ in FPC, so guard first.
   RawElement := RawObj.GetProperty(PROP_LENGTH);
   if not Assigned(RawElement) or (RawElement is TGocciaUndefinedLiteralValue) then
     LiteralSegments := 0
   else
-    LiteralSegments := Trunc(RawElement.ToNumberLiteral.Value);
+  begin
+    LengthValue := RawElement.ToNumberLiteral.Value;
+    if IsNan(LengthValue) or (LengthValue <= 0) then
+      LiteralSegments := 0
+    else if LengthValue >= MaxInt then
+      LiteralSegments := MaxInt
+    else
+      LiteralSegments := Trunc(LengthValue);
+  end;
 
   // ES2026 §22.1.2.4 step 5: If literalSegments <= 0, return ""
   if LiteralSegments <= 0 then

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -322,7 +322,7 @@ begin
   // Step 7: If space is a Number, let gap be min(10, ToInteger(space)) spaces.
   if ASpaceArg is TGocciaNumberLiteralValue then
   begin
-    SpaceCount := Trunc(ASpaceArg.ToNumberLiteral.Value);
+    SpaceCount := ToIntegerValue(ASpaceArg);
     if SpaceCount > 10 then
       SpaceCount := 10;
     if SpaceCount < 1 then

--- a/source/units/Goccia.Builtins.TSV.pas
+++ b/source/units/Goccia.Builtins.TSV.pas
@@ -313,10 +313,9 @@ begin
   EndOffset := TextLength;
 
   if AArgs.Length > BaseIndex then
-    StartOffset := Trunc(AArgs.GetElement(BaseIndex).ToNumberLiteral.Value);
+    StartOffset := ToIntegerFromArgs(AArgs, BaseIndex);
   if AArgs.Length > BaseIndex + 1 then
-    EndOffset := Trunc(
-      AArgs.GetElement(BaseIndex + 1).ToNumberLiteral.Value);
+    EndOffset := ToIntegerFromArgs(AArgs, BaseIndex + 1);
 
   try
     ChunkResult := FParser.ParseChunk(Text, Headers, SkipEmptyLines,

--- a/source/units/Goccia.Builtins.Temporal.pas
+++ b/source/units/Goccia.Builtins.Temporal.pas
@@ -168,10 +168,10 @@ begin
 end;
 
 function TGocciaTemporalBuiltin.DurationConstructorFn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-var
-  Y, Mo, W, D, H, Mi, S, Ms, Us, Ns: Int64;
 
-  function GetArgOr(const AIndex: Integer; const ADefault: Int64): Int64;
+  // Components may exceed Int64 (the spec allows any float64 integer whose
+  // normalized total stays under 2^53 seconds), so read into TBigInteger.
+  function GetArgOr(const AIndex: Integer): TBigInteger;
   var
     V: TGocciaValue;
   begin
@@ -179,27 +179,18 @@ var
     begin
       V := AArgs.GetElement(AIndex);
       if (V is TGocciaUndefinedLiteralValue) then
-        Result := ADefault
+        Result := TBigInteger.Zero
       else
-        Result := ToIntegerWithTruncation64Value(V);
+        Result := DurationFieldToBigInteger(V);
     end
     else
-      Result := ADefault;
+      Result := TBigInteger.Zero;
   end;
 
 begin
-  Y := GetArgOr(0, 0);
-  Mo := GetArgOr(1, 0);
-  W := GetArgOr(2, 0);
-  D := GetArgOr(3, 0);
-  H := GetArgOr(4, 0);
-  Mi := GetArgOr(5, 0);
-  S := GetArgOr(6, 0);
-  Ms := GetArgOr(7, 0);
-  Us := GetArgOr(8, 0);
-  Ns := GetArgOr(9, 0);
-
-  Result := TGocciaTemporalDurationValue.Create(Y, Mo, W, D, H, Mi, S, Ms, Us, Ns);
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    GetArgOr(0), GetArgOr(1), GetArgOr(2), GetArgOr(3), GetArgOr(4),
+    GetArgOr(5), GetArgOr(6), GetArgOr(7), GetArgOr(8), GetArgOr(9));
 end;
 
 function TGocciaTemporalBuiltin.DurationFrom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -207,19 +198,6 @@ var
   Arg: TGocciaValue;
   D: TGocciaTemporalDurationValue;
   DurRec: TTemporalDurationRecord;
-  Obj: TGocciaObjectValue;
-
-  function GetFieldOr(const AName: string; const ADefault: Int64): Int64;
-  var
-    V: TGocciaValue;
-  begin
-    V := Obj.GetProperty(AName);
-    if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-      Result := ADefault
-    else
-      Result := ToIntegerWithTruncation64Value(V);
-  end;
-
 begin
   Arg := AArgs.GetElement(0);
 
@@ -240,14 +218,7 @@ begin
       DurRec.Milliseconds, DurRec.Microseconds, DurRec.Nanoseconds);
   end
   else if Arg is TGocciaObjectValue then
-  begin
-    Obj := TGocciaObjectValue(Arg);
-    Result := TGocciaTemporalDurationValue.Create(
-      GetFieldOr('years', 0), GetFieldOr('months', 0), GetFieldOr('weeks', 0),
-      GetFieldOr('days', 0), GetFieldOr('hours', 0), GetFieldOr('minutes', 0),
-      GetFieldOr('seconds', 0), GetFieldOr('milliseconds', 0),
-      GetFieldOr('microseconds', 0), GetFieldOr('nanoseconds', 0));
-  end
+    Result := DurationFromObject(TGocciaObjectValue(Arg))
   else
   begin
     ThrowTypeError(SErrorTemporalDurationFromArg, SSuggestTemporalFromArg);
@@ -263,19 +234,6 @@ var
   function CoerceDuration(const AArg: TGocciaValue): TGocciaTemporalDurationValue;
   var
     DurRec: TTemporalDurationRecord;
-    Obj: TGocciaObjectValue;
-
-    function GetFieldOr(const AName: string; const ADefault: Int64): Int64;
-    var
-      V: TGocciaValue;
-    begin
-      V := Obj.GetProperty(AName);
-      if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
-        Result := ADefault
-      else
-        Result := ToIntegerWithTruncation64Value(V);
-    end;
-
   begin
     if AArg is TGocciaTemporalDurationValue then
       Result := TGocciaTemporalDurationValue(AArg)
@@ -289,14 +247,7 @@ var
         DurRec.Milliseconds, DurRec.Microseconds, DurRec.Nanoseconds);
     end
     else if AArg is TGocciaObjectValue then
-    begin
-      Obj := TGocciaObjectValue(AArg);
-      Result := TGocciaTemporalDurationValue.Create(
-        GetFieldOr('years', 0), GetFieldOr('months', 0), GetFieldOr('weeks', 0),
-        GetFieldOr('days', 0), GetFieldOr('hours', 0), GetFieldOr('minutes', 0),
-        GetFieldOr('seconds', 0), GetFieldOr('milliseconds', 0),
-        GetFieldOr('microseconds', 0), GetFieldOr('nanoseconds', 0));
-    end
+      Result := DurationFromObject(TGocciaObjectValue(AArg))
     else
     begin
       ThrowTypeError(SErrorTemporalDurationCompareArg, SSuggestTemporalCompareArg);

--- a/source/units/Goccia.Builtins.Temporal.pas
+++ b/source/units/Goccia.Builtins.Temporal.pas
@@ -98,6 +98,7 @@ uses
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -180,7 +181,7 @@ var
       if (V is TGocciaUndefinedLiteralValue) then
         Result := ADefault
       else
-        Result := Trunc(V.ToNumberLiteral.Value);
+        Result := ToIntegerWithTruncation64Value(V);
     end
     else
       Result := ADefault;
@@ -216,7 +217,7 @@ var
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(V.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncation64Value(V);
   end;
 
 begin
@@ -272,7 +273,7 @@ var
       if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
         Result := ADefault
       else
-        Result := Trunc(V.ToNumberLiteral.Value);
+        Result := ToIntegerWithTruncation64Value(V);
     end;
 
   begin
@@ -422,7 +423,7 @@ begin
   if AArgs.Length < 1 then
     ThrowTypeError(SErrorTemporalInstantFromEpochMillis, SSuggestTemporalFromArg);
   Result := TGocciaTemporalInstantValue.Create(
-    Trunc(AArgs.GetElement(0).ToNumberLiteral.Value), 0);
+    ToIntegerWithTruncation64Value(AArgs.GetElement(0)), 0);
 end;
 
 function TGocciaTemporalBuiltin.InstantFromEpochNanoseconds(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -524,9 +525,9 @@ begin
     ThrowTypeError(SErrorTemporalPlainDateArgs, SSuggestTemporalDateRange);
 
   Result := TGocciaTemporalPlainDateValue.Create(
-    Trunc(AArgs.GetElement(0).ToNumberLiteral.Value),
-    Trunc(AArgs.GetElement(1).ToNumberLiteral.Value),
-    Trunc(AArgs.GetElement(2).ToNumberLiteral.Value));
+    ToIntegerWithTruncationValue(AArgs.GetElement(0)),
+    ToIntegerWithTruncationValue(AArgs.GetElement(1)),
+    ToIntegerWithTruncationValue(AArgs.GetElement(2)));
 end;
 
 function TGocciaTemporalBuiltin.PlainDateFrom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -566,11 +567,11 @@ begin
     V := Obj.GetProperty(PROP_YEAR);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       ThrowTypeError(SErrorTemporalPlainDateFromProps, SSuggestTemporalFromArg);
-    Y := Trunc(V.ToNumberLiteral.Value);
+    Y := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty(PROP_MONTH);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       ThrowTypeError(SErrorTemporalPlainDateFromProps, SSuggestTemporalFromArg);
-    Mo := Trunc(V.ToNumberLiteral.Value);
+    Mo := ToIntegerWithTruncationValue(V);
     if (Mo < 1) or (Mo > 12) then
     begin
       if Overflow = toReject then
@@ -583,7 +584,7 @@ begin
     V := Obj.GetProperty(PROP_DAY);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       ThrowTypeError(SErrorTemporalPlainDateFromProps, SSuggestTemporalFromArg);
-    Dy := Trunc(V.ToNumberLiteral.Value);
+    Dy := ToIntegerWithTruncationValue(V);
     if Dy < 1 then
     begin
       if Overflow = toReject then
@@ -645,9 +646,9 @@ var
       end
       else
         Result := TGocciaTemporalPlainDateValue.Create(
-          Trunc(VY.ToNumberLiteral.Value),
-          Trunc(VM.ToNumberLiteral.Value),
-          Trunc(VD.ToNumberLiteral.Value));
+          ToIntegerWithTruncationValue(VY),
+          ToIntegerWithTruncationValue(VM),
+          ToIntegerWithTruncationValue(VD));
     end
     else
     begin
@@ -696,7 +697,7 @@ function TGocciaTemporalBuiltin.PlainTimeConstructorFn(const AArgs: TGocciaArgum
       if V is TGocciaUndefinedLiteralValue then
         Result := ADefault
       else
-        Result := Trunc(V.ToNumberLiteral.Value);
+        Result := ToIntegerWithTruncationValue(V);
     end
     else
       Result := ADefault;
@@ -738,17 +739,17 @@ begin
     Obj := TGocciaObjectValue(Arg);
     H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
     V := Obj.GetProperty(PROP_HOUR);
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty(PROP_MINUTE);
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty(PROP_SECOND);
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty(PROP_MILLISECOND);
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty(PROP_MICROSECOND);
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty(PROP_NANOSECOND);
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(V);
     Result := TGocciaTemporalPlainTimeValue.Create(H, Mi, S, Ms, Us, Ns);
   end
   else
@@ -788,17 +789,17 @@ var
       Obj := TGocciaObjectValue(AArg);
       H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
       V := Obj.GetProperty(PROP_HOUR);
-      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := Trunc(V.ToNumberLiteral.Value);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty(PROP_MINUTE);
-      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := Trunc(V.ToNumberLiteral.Value);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty(PROP_SECOND);
-      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := Trunc(V.ToNumberLiteral.Value);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty(PROP_MILLISECOND);
-      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := Trunc(V.ToNumberLiteral.Value);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty(PROP_MICROSECOND);
-      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := Trunc(V.ToNumberLiteral.Value);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty(PROP_NANOSECOND);
-      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := Trunc(V.ToNumberLiteral.Value);
+      if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(V);
       Result := TGocciaTemporalPlainTimeValue.Create(H, Mi, S, Ms, Us, Ns);
     end
     else
@@ -849,7 +850,7 @@ function TGocciaTemporalBuiltin.PlainDateTimeConstructorFn(const AArgs: TGocciaA
       if V is TGocciaUndefinedLiteralValue then
         Result := ADefault
       else
-        Result := Trunc(V.ToNumberLiteral.Value);
+        Result := ToIntegerWithTruncationValue(V);
     end
     else
       Result := ADefault;
@@ -896,15 +897,15 @@ begin
   begin
     Obj := TGocciaObjectValue(Arg);
     Y := 0; Mo := 0; D := 0; H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
-    V := Obj.GetProperty(PROP_YEAR); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Y := Trunc(V.ToNumberLiteral.Value);
-    V := Obj.GetProperty(PROP_MONTH); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mo := Trunc(V.ToNumberLiteral.Value);
-    V := Obj.GetProperty(PROP_DAY); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then D := Trunc(V.ToNumberLiteral.Value);
-    V := Obj.GetProperty(PROP_HOUR); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := Trunc(V.ToNumberLiteral.Value);
-    V := Obj.GetProperty(PROP_MINUTE); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := Trunc(V.ToNumberLiteral.Value);
-    V := Obj.GetProperty(PROP_SECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := Trunc(V.ToNumberLiteral.Value);
-    V := Obj.GetProperty(PROP_MILLISECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := Trunc(V.ToNumberLiteral.Value);
-    V := Obj.GetProperty(PROP_MICROSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := Trunc(V.ToNumberLiteral.Value);
-    V := Obj.GetProperty(PROP_NANOSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := Trunc(V.ToNumberLiteral.Value);
+    V := Obj.GetProperty(PROP_YEAR); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Y := ToIntegerWithTruncationValue(V);
+    V := Obj.GetProperty(PROP_MONTH); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mo := ToIntegerWithTruncationValue(V);
+    V := Obj.GetProperty(PROP_DAY); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then D := ToIntegerWithTruncationValue(V);
+    V := Obj.GetProperty(PROP_HOUR); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(V);
+    V := Obj.GetProperty(PROP_MINUTE); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(V);
+    V := Obj.GetProperty(PROP_SECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(V);
+    V := Obj.GetProperty(PROP_MILLISECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(V);
+    V := Obj.GetProperty(PROP_MICROSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(V);
+    V := Obj.GetProperty(PROP_NANOSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(V);
     Result := TGocciaTemporalPlainDateTimeValue.Create(Y, Mo, D, H, Mi, S, Ms, Us, Ns);
   end
   else
@@ -952,7 +953,7 @@ var
         Result := nil;
         Exit;
       end;
-      Y := Trunc(V.ToNumberLiteral.Value);
+      Y := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty(PROP_MONTH);
       if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       begin
@@ -960,7 +961,7 @@ var
         Result := nil;
         Exit;
       end;
-      Mo := Trunc(V.ToNumberLiteral.Value);
+      Mo := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty(PROP_DAY);
       if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       begin
@@ -968,14 +969,14 @@ var
         Result := nil;
         Exit;
       end;
-      D := Trunc(V.ToNumberLiteral.Value);
+      D := ToIntegerWithTruncationValue(V);
       H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
-      V := Obj.GetProperty(PROP_HOUR); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := Trunc(V.ToNumberLiteral.Value);
-      V := Obj.GetProperty(PROP_MINUTE); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := Trunc(V.ToNumberLiteral.Value);
-      V := Obj.GetProperty(PROP_SECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := Trunc(V.ToNumberLiteral.Value);
-      V := Obj.GetProperty(PROP_MILLISECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := Trunc(V.ToNumberLiteral.Value);
-      V := Obj.GetProperty(PROP_MICROSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := Trunc(V.ToNumberLiteral.Value);
-      V := Obj.GetProperty(PROP_NANOSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := Trunc(V.ToNumberLiteral.Value);
+      V := Obj.GetProperty(PROP_HOUR); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(V);
+      V := Obj.GetProperty(PROP_MINUTE); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(V);
+      V := Obj.GetProperty(PROP_SECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(V);
+      V := Obj.GetProperty(PROP_MILLISECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(V);
+      V := Obj.GetProperty(PROP_MICROSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(V);
+      V := Obj.GetProperty(PROP_NANOSECOND); if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(V);
       Result := TGocciaTemporalPlainDateTimeValue.Create(Y, Mo, D, H, Mi, S, Ms, Us, Ns);
     end
     else
@@ -1025,13 +1026,15 @@ begin
   if AArgs.Length < 2 then
     ThrowTypeError(SErrorTemporalPlainYearMonthArgs, SSuggestTemporalDateRange);
 
+  // Temporal §9.1.1 PlainYearMonth(isoYear, isoMonth, calendarLike,
+  // referenceISODay) — argument 2 is the calendar, the reference day is 3.
   RefDay := 1;
-  if (AArgs.Length >= 3) and not (AArgs.GetElement(2) is TGocciaUndefinedLiteralValue) then
-    RefDay := Trunc(AArgs.GetElement(2).ToNumberLiteral.Value);
+  if (AArgs.Length >= 4) and not (AArgs.GetElement(3) is TGocciaUndefinedLiteralValue) then
+    RefDay := ToIntegerWithTruncationValue(AArgs.GetElement(3));
 
   Result := TGocciaTemporalPlainYearMonthValue.Create(
-    Trunc(AArgs.GetElement(0).ToNumberLiteral.Value),
-    Trunc(AArgs.GetElement(1).ToNumberLiteral.Value),
+    ToIntegerWithTruncationValue(AArgs.GetElement(0)),
+    ToIntegerWithTruncationValue(AArgs.GetElement(1)),
     RefDay);
 end;
 
@@ -1063,7 +1066,7 @@ begin
     V := Obj.GetProperty(PROP_YEAR);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       ThrowTypeError(SErrorTemporalPlainYearMonthFromYear, SSuggestTemporalFromArg);
-    Y := Trunc(V.ToNumberLiteral.Value);
+    Y := ToIntegerWithTruncationValue(V);
     // Support both monthCode and month, consistent with PlainMonthDay.from
     VMonthCode := Obj.GetProperty(PROP_MONTH_CODE);
     if Assigned(VMonthCode) and not (VMonthCode is TGocciaUndefinedLiteralValue) then
@@ -1079,7 +1082,7 @@ begin
       // Check consistency if both month and monthCode are provided
       V := Obj.GetProperty(PROP_MONTH);
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        if Trunc(V.ToNumberLiteral.Value) <> MonthPart then
+        if ToIntegerWithTruncationValue(V) <> MonthPart then
           ThrowRangeError(SErrorMonthCodeMismatch, SSuggestTemporalMonthCode);
       M := MonthPart;
     end
@@ -1088,7 +1091,7 @@ begin
       V := Obj.GetProperty(PROP_MONTH);
       if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
         ThrowTypeError(SErrorTemporalPlainYearMonthFromMonth, SSuggestTemporalFromArg);
-      M := Trunc(V.ToNumberLiteral.Value);
+      M := ToIntegerWithTruncationValue(V);
     end;
     Result := TGocciaTemporalPlainYearMonthValue.Create(Y, M);
   end
@@ -1170,8 +1173,8 @@ begin
     ThrowTypeError(SErrorTemporalPlainMonthDayArgs, SSuggestTemporalDateRange);
 
   Result := TGocciaTemporalPlainMonthDayValue.Create(
-    Trunc(AArgs.GetElement(0).ToNumberLiteral.Value),
-    Trunc(AArgs.GetElement(1).ToNumberLiteral.Value));
+    ToIntegerWithTruncationValue(AArgs.GetElement(0)),
+    ToIntegerWithTruncationValue(AArgs.GetElement(1)));
 end;
 
 function TGocciaTemporalBuiltin.PlainMonthDayFrom(const AArgs: TGocciaArgumentsCollection;
@@ -1202,7 +1205,7 @@ begin
     V := Obj.GetProperty(PROP_DAY);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       ThrowTypeError(SErrorTemporalPlainMonthDayFromDay, SSuggestTemporalFromArg);
-    D := Trunc(V.ToNumberLiteral.Value);
+    D := ToIntegerWithTruncationValue(V);
     // Support both monthCode (e.g., "M07") and month (numeric)
     V := Obj.GetProperty(PROP_MONTH_CODE);
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
@@ -1219,7 +1222,7 @@ begin
     begin
       V := Obj.GetProperty(PROP_MONTH);
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        M := Trunc(V.ToNumberLiteral.Value)
+        M := ToIntegerWithTruncationValue(V)
       else
         M := 0;
     end;

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -2619,21 +2619,24 @@ var
 
   function FormatPlaceholder(const AValue: TGocciaValue;
     const AToken: Char): string;
+  var
+    NumVal: TGocciaNumberLiteralValue;
   begin
     if not Assigned(AValue) then
       Exit('%' + AToken);
 
     case AToken of
       'd', 'i':
+      begin
         // NaN/±∞ and doubles beyond Integer cannot be Trunc'd; render them
         // like %f so test.each("%d") titles never crash on non-finite rows.
-        if AValue.ToNumberLiteral.IsNaN or
-           AValue.ToNumberLiteral.IsInfinity or
-           AValue.ToNumberLiteral.IsNegativeInfinity or
-           (Abs(AValue.ToNumberLiteral.Value) >= MaxInt) then
-          Result := FormatDouble(AValue.ToNumberLiteral.Value)
+        NumVal := AValue.ToNumberLiteral;
+        if NumVal.IsNaN or NumVal.IsInfinity or NumVal.IsNegativeInfinity or
+           (Abs(NumVal.Value) >= MaxInt) then
+          Result := FormatDouble(NumVal.Value)
         else
-          Result := IntToStr(Trunc(AValue.ToNumberLiteral.Value));
+          Result := IntToStr(Trunc(NumVal.Value));
+      end;
       'f':
         Result := FormatDouble(AValue.ToNumberLiteral.Value);
       'j', 'o', 's':

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -295,6 +295,7 @@ uses
   Goccia.MicrotaskQueue,
   Goccia.RegExp.Runtime,
   Goccia.Timeout,
+  Goccia.Utils,
   Goccia.Values.ClassHelper,
   Goccia.Values.ClassValue,
   Goccia.Values.Error,
@@ -1676,7 +1677,7 @@ begin
 
   // Default precision to 2 decimal places if not specified
   if AArgs.Length >= 2 then
-    Precision := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value)
+    Precision := ToIntegerFromArgs(AArgs, 1)
   else
     Precision := 2;
 
@@ -2624,7 +2625,15 @@ var
 
     case AToken of
       'd', 'i':
-        Result := IntToStr(Trunc(AValue.ToNumberLiteral.Value));
+        // NaN/±∞ and doubles beyond Integer cannot be Trunc'd; render them
+        // like %f so test.each("%d") titles never crash on non-finite rows.
+        if AValue.ToNumberLiteral.IsNaN or
+           AValue.ToNumberLiteral.IsInfinity or
+           AValue.ToNumberLiteral.IsNegativeInfinity or
+           (Abs(AValue.ToNumberLiteral.Value) >= MaxInt) then
+          Result := FormatDouble(AValue.ToNumberLiteral.Value)
+        else
+          Result := IntToStr(Trunc(AValue.ToNumberLiteral.Value));
       'f':
         Result := FormatDouble(AValue.ToNumberLiteral.Value);
       'j', 'o', 's':

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -2632,7 +2632,7 @@ var
         // like %f so test.each("%d") titles never crash on non-finite rows.
         NumVal := AValue.ToNumberLiteral;
         if NumVal.IsNaN or NumVal.IsInfinity or NumVal.IsNegativeInfinity or
-           (Abs(NumVal.Value) >= MaxInt) then
+           (Abs(NumVal.Value) > MaxInt) then
           Result := FormatDouble(NumVal.Value)
         else
           Result := IntToStr(Trunc(NumVal.Value));

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -645,6 +645,7 @@ resourcestring
   SErrorToPrimitiveNotCallable = 'Symbol.toPrimitive is not a function';
 
   // Number method errors
+  SErrorNumberNotFinite = 'Value must be finite';
   SErrorToExponentialArgRange = 'toExponential() argument must be between 0 and 100';
   SErrorToFixedArgRange = 'toFixed() digits argument must be between 0 and 100';
   SErrorToPrecisionArgRange = 'toPrecision() argument must be between 1 and 100';

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -206,6 +206,7 @@ resourcestring
   SErrorTemporalInvalidISOStringFor = 'Invalid ISO %s string for %s';
 
   // Temporal prototype errors — Duration
+  SErrorDurationCalendarUnitsArith = 'Durations with years, months, or weeks cannot be added or subtracted';
   SErrorDurationMixedSigns = 'Duration fields must not have mixed signs';
   SErrorDurationCalendarOutOfRange = 'Duration calendar fields (years, months, weeks) must have absolute value less than 2^32';
   SErrorDurationTimeOutOfRange = 'Duration time fields out of range: normalized seconds must have absolute value less than 2^53';

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -646,6 +646,8 @@ resourcestring
 
   // Number method errors
   SErrorToExponentialArgRange = 'toExponential() argument must be between 0 and 100';
+  SErrorToFixedArgRange = 'toFixed() digits argument must be between 0 and 100';
+  SErrorToPrecisionArgRange = 'toPrecision() argument must be between 1 and 100';
 
   // Set brand-check errors
   SErrorSetHasNonSet = 'Set.prototype.has called on non-Set object';

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -7198,6 +7198,19 @@ begin
     end;
   end;
 
+  // Plain integer literals past ~15 digits: FPC's TryStrToFloat is not
+  // correctly rounded near the 53-bit boundary (e.g. 9007199254740991475711
+  // parses one ulp high), so convert exactly via BigInteger and round once.
+  if Length(NormalizedLexeme) > 15 then
+  begin
+    I := 1;
+    while (I <= Length(NormalizedLexeme)) and
+          (NormalizedLexeme[I] in ['0'..'9']) do
+      Inc(I);
+    if I > Length(NormalizedLexeme) then
+      Exit(TBigInteger.FromDecimalString(NormalizedLexeme).ToDouble);
+  end;
+
   // Regular decimal numbers (including scientific notation)
   if TryStrToFloat(NormalizedLexeme, Value) then
     Exit(Value);

--- a/source/units/Goccia.Utils.pas
+++ b/source/units/Goccia.Utils.pas
@@ -12,6 +12,10 @@ uses
 // Returns Trunc(ToNumber(AArgs[AIndex])) or ADefault if index out of range.
 function ToIntegerFromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer = 0; const ADefault: Integer = 0): Integer; inline;
 
+// Value-level variant of ToIntegerFromArgs: ES2026 §7.1.6 ToIntegerOrInfinity
+// saturated to Integer.  NaN → 0, ±∞ and out-of-range doubles → ±MaxInt.
+function ToIntegerValue(const AValue: TGocciaValue): Integer; inline;
+
 // 64-bit variant of ToIntegerFromArgs.  Used by Array prototype methods that
 // must reach indices above MaxInt when the receiver is a generic array-like
 // with a length up to 2^53 - 1 (e.g. test262
@@ -39,6 +43,10 @@ function ToInt32Value(const AValue: TGocciaValue): Int32; inline;
 // ES2026 §7.1.7 ToUint32(argument)
 function ToUint32Value(const AValue: TGocciaValue): Cardinal; inline;
 
+// ES2026 §7.1.10 ToUint16(argument)
+// NaN, ±0, ±∞ → 0; otherwise truncate and reduce modulo 2^16.
+function ToUint16Value(const AValue: TGocciaValue): Word; inline;
+
 // ES2026 relative index normalization (used by slice, splice, at, with, copyWithin, fill, etc.)
 // If ARelative < 0, returns max(ALength + ARelative, 0); else min(ARelative, ALength).
 function NormalizeRelativeIndex(const ARelative, ALength: Integer): Integer; inline;
@@ -61,26 +69,29 @@ uses
   Goccia.Values.FunctionBase;
 
 function ToIntegerFromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer; const ADefault: Integer): Integer;
+begin
+  if AArgs.Length > AIndex then
+    Result := ToIntegerValue(AArgs.GetElement(AIndex))
+  else
+    Result := ADefault;
+end;
+
+function ToIntegerValue(const AValue: TGocciaValue): Integer;
 var
   NumberValue: TGocciaNumberLiteralValue;
 begin
-  if AArgs.Length > AIndex then
-  begin
-    NumberValue := AArgs.GetElement(AIndex).ToNumberLiteral;
-    if NumberValue.IsNaN then
-      Exit(0);
-    if NumberValue.IsInfinity then
-      Exit(MaxInt);
-    if NumberValue.IsNegativeInfinity then
-      Exit(-MaxInt);
-    if NumberValue.Value >= MaxInt then
-      Exit(MaxInt);
-    if NumberValue.Value <= -MaxInt then
-      Exit(-MaxInt);
-    Result := Trunc(NumberValue.Value);
-    Exit;
-  end;
-  Result := ADefault;
+  NumberValue := AValue.ToNumberLiteral;
+  if NumberValue.IsNaN then
+    Exit(0);
+  if NumberValue.IsInfinity then
+    Exit(MaxInt);
+  if NumberValue.IsNegativeInfinity then
+    Exit(-MaxInt);
+  if NumberValue.Value >= MaxInt then
+    Exit(MaxInt);
+  if NumberValue.Value <= -MaxInt then
+    Exit(-MaxInt);
+  Result := Trunc(NumberValue.Value);
 end;
 
 function ToInteger64FromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer; const ADefault: Int64): Int64;
@@ -137,6 +148,14 @@ begin
   // directly without any FP path that could trip Trunc(NaN).
   AsUint := ToUint32Value(AValue);
   Result := Int32(AsUint);
+end;
+
+function ToUint16Value(const AValue: TGocciaValue): Word;
+begin
+  // ToUint16 differs from ToUint32 only in the modulus (2^16 vs 2^32), and
+  // 2^16 divides 2^32, so the low 16 bits of the ToUint32 result are exactly
+  // the ToUint16 result.  Reuses the NaN/Infinity-safe path above.
+  Result := Word(ToUint32Value(AValue));
 end;
 
 function NormalizeRelativeIndex(const ARelative, ALength: Integer): Integer;

--- a/source/units/Goccia.Utils.pas
+++ b/source/units/Goccia.Utils.pas
@@ -16,6 +16,22 @@ function ToIntegerFromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex
 // saturated to Integer.  NaN → 0, ±∞ and out-of-range doubles → ±MaxInt.
 function ToIntegerValue(const AValue: TGocciaValue): Integer; inline;
 
+// ES2026 §7.1.22 ToLength saturated to Integer: NaN and values ≤ 0 → 0,
+// values ≥ MaxInt (incl. +∞) → MaxInt, else truncate.
+function ToLengthValue(const AValue: TGocciaValue): Integer; inline;
+
+// Temporal §13.21 ToIntegerWithTruncation: throws RangeError for NaN/±∞
+// (also matches ECMA-402 §9.2.15 DefaultNumberOption's rejection of
+// non-finite option values), saturates out-of-range doubles to ±MaxInt.
+// Use only where the target is a range-validated Integer field.
+function ToIntegerWithTruncationValue(const AValue: TGocciaValue): Integer;
+
+// 64-bit ToIntegerWithTruncation for targets that carry the full JS integer
+// range (duration components, epoch milliseconds): throws RangeError for
+// NaN/±∞, saturates at the Int64 limits so out-of-range magnitudes stay
+// above downstream validation boundaries (e.g. Duration's 2^53 check).
+function ToIntegerWithTruncation64Value(const AValue: TGocciaValue): Int64;
+
 // 64-bit variant of ToIntegerFromArgs.  Used by Array prototype methods that
 // must reach indices above MaxInt when the receiver is a generic array-like
 // with a length up to 2^53 - 1 (e.g. test262
@@ -43,6 +59,10 @@ function ToInt32Value(const AValue: TGocciaValue): Int32; inline;
 // ES2026 §7.1.7 ToUint32(argument)
 function ToUint32Value(const AValue: TGocciaValue): Cardinal; inline;
 
+// JS Number → Int64 for host/FFI marshaling: NaN/±∞ → 0, saturates at the
+// Int64 limits, otherwise truncates toward zero.
+function ToInt64Value(const AValue: TGocciaValue): Int64; inline;
+
 // ES2026 §7.1.10 ToUint16(argument)
 // NaN, ±0, ±∞ → 0; otherwise truncate and reduce modulo 2^16.
 function ToUint16Value(const AValue: TGocciaValue): Word; inline;
@@ -63,19 +83,14 @@ uses
   SysUtils,
 
   Goccia.Constants.NumericLimits,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Values.ClassValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase;
 
-function ToIntegerFromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer; const ADefault: Integer): Integer;
-begin
-  if AArgs.Length > AIndex then
-    Result := ToIntegerValue(AArgs.GetElement(AIndex))
-  else
-    Result := ADefault;
-end;
-
+// ToIntegerValue precedes its callers below so FPC can inline-expand it.
 function ToIntegerValue(const AValue: TGocciaValue): Integer;
 var
   NumberValue: TGocciaNumberLiteralValue;
@@ -91,6 +106,76 @@ begin
     Exit(MaxInt);
   if NumberValue.Value <= -MaxInt then
     Exit(-MaxInt);
+  Result := Trunc(NumberValue.Value);
+end;
+
+function ToIntegerFromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer; const ADefault: Integer): Integer;
+begin
+  if AArgs.Length > AIndex then
+    Result := ToIntegerValue(AArgs.GetElement(AIndex))
+  else
+    Result := ADefault;
+end;
+
+function ToLengthValue(const AValue: TGocciaValue): Integer;
+var
+  NumberValue: TGocciaNumberLiteralValue;
+begin
+  NumberValue := AValue.ToNumberLiteral;
+  if NumberValue.IsNaN or NumberValue.IsNegativeInfinity or
+     (NumberValue.Value <= 0) then
+    Exit(0);
+  if NumberValue.IsInfinity or (NumberValue.Value >= MaxInt) then
+    Exit(MaxInt);
+  Result := Trunc(NumberValue.Value);
+end;
+
+function ToIntegerWithTruncationValue(const AValue: TGocciaValue): Integer;
+var
+  NumberValue: TGocciaNumberLiteralValue;
+begin
+  NumberValue := AValue.ToNumberLiteral;
+  if NumberValue.IsNaN or NumberValue.IsInfinity or
+     NumberValue.IsNegativeInfinity then
+    ThrowRangeError(SErrorNumberNotFinite, SSuggestNumberRange);
+  if NumberValue.Value >= MaxInt then
+    Exit(MaxInt);
+  if NumberValue.Value <= -MaxInt then
+    Exit(-MaxInt);
+  Result := Trunc(NumberValue.Value);
+end;
+
+function ToInt64Value(const AValue: TGocciaValue): Int64;
+const
+  INT64_BOUND_F = 9.2233720368547758E18; // 2^63
+var
+  NumberValue: TGocciaNumberLiteralValue;
+begin
+  NumberValue := AValue.ToNumberLiteral;
+  if NumberValue.IsNaN or NumberValue.IsInfinity or
+     NumberValue.IsNegativeInfinity then
+    Exit(0);
+  if NumberValue.Value >= INT64_BOUND_F then
+    Exit(High(Int64));
+  if NumberValue.Value < -INT64_BOUND_F then
+    Exit(Low(Int64));
+  Result := Trunc(NumberValue.Value);
+end;
+
+function ToIntegerWithTruncation64Value(const AValue: TGocciaValue): Int64;
+const
+  INT64_BOUND_F = 9.2233720368547758E18; // 2^63
+var
+  NumberValue: TGocciaNumberLiteralValue;
+begin
+  NumberValue := AValue.ToNumberLiteral;
+  if NumberValue.IsNaN or NumberValue.IsInfinity or
+     NumberValue.IsNegativeInfinity then
+    ThrowRangeError(SErrorNumberNotFinite, SSuggestNumberRange);
+  if NumberValue.Value >= INT64_BOUND_F then
+    Exit(High(Int64));
+  if NumberValue.Value < -INT64_BOUND_F then
+    Exit(Low(Int64));
   Result := Trunc(NumberValue.Value);
 end;
 

--- a/source/units/Goccia.Utils.pas
+++ b/source/units/Goccia.Utils.pas
@@ -145,9 +145,21 @@ begin
   Result := Trunc(NumberValue.Value);
 end;
 
-function ToInt64Value(const AValue: TGocciaValue): Int64;
+// Shared finite-double → Int64 saturation for the two 64-bit coercers below.
+// Callers handle NaN/±∞ first (they differ: marshaling maps them to 0,
+// ToIntegerWithTruncation throws).
+function SaturateFiniteToInt64(const AFiniteValue: Double): Int64;
 const
   INT64_BOUND_F = 9.2233720368547758E18; // 2^63
+begin
+  if AFiniteValue >= INT64_BOUND_F then
+    Exit(High(Int64));
+  if AFiniteValue < -INT64_BOUND_F then
+    Exit(Low(Int64));
+  Result := Trunc(AFiniteValue);
+end;
+
+function ToInt64Value(const AValue: TGocciaValue): Int64;
 var
   NumberValue: TGocciaNumberLiteralValue;
 begin
@@ -155,16 +167,10 @@ begin
   if NumberValue.IsNaN or NumberValue.IsInfinity or
      NumberValue.IsNegativeInfinity then
     Exit(0);
-  if NumberValue.Value >= INT64_BOUND_F then
-    Exit(High(Int64));
-  if NumberValue.Value < -INT64_BOUND_F then
-    Exit(Low(Int64));
-  Result := Trunc(NumberValue.Value);
+  Result := SaturateFiniteToInt64(NumberValue.Value);
 end;
 
 function ToIntegerWithTruncation64Value(const AValue: TGocciaValue): Int64;
-const
-  INT64_BOUND_F = 9.2233720368547758E18; // 2^63
 var
   NumberValue: TGocciaNumberLiteralValue;
 begin
@@ -172,11 +178,7 @@ begin
   if NumberValue.IsNaN or NumberValue.IsInfinity or
      NumberValue.IsNegativeInfinity then
     ThrowRangeError(SErrorNumberNotFinite, SSuggestNumberRange);
-  if NumberValue.Value >= INT64_BOUND_F then
-    Exit(High(Int64));
-  if NumberValue.Value < -INT64_BOUND_F then
-    Exit(Low(Int64));
-  Result := Trunc(NumberValue.Value);
+  Result := SaturateFiniteToInt64(NumberValue.Value);
 end;
 
 function ToInteger64FromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer; const ADefault: Int64): Int64;

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -3873,13 +3873,8 @@ begin
   // Step 1: Let O be ToObject(this value)
   View.Init(AThisValue);
 
-  if AArgs.Length < 1 then
-  begin
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Exit;
-  end;
-
   // Step 3: Let relativeIndex be ToIntegerOrInfinity(index)
+  // A missing index coerces to 0, not undefined.
   Index := ToIntegerFromArgs(AArgs, 0);
 
   // Step 4: If relativeIndex >= 0, let k be relativeIndex; else len + relativeIndex

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -3868,25 +3868,27 @@ end;
 function TGocciaArrayValue.ArrayAt(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   View: TArrayLikeView;
-  Index: Integer;
+  Index64, Len64Val: Int64;
 begin
   // Step 1: Let O be ToObject(this value)
   View.Init(AThisValue);
 
   // Step 3: Let relativeIndex be ToIntegerOrInfinity(index)
-  // A missing index coerces to 0, not undefined.
-  Index := ToIntegerFromArgs(AArgs, 0);
+  // A missing index coerces to 0, not undefined. 64-bit math so generic
+  // array-likes with length beyond MaxInt index correctly (Len64/Get64).
+  Index64 := ToInteger64FromArgs(AArgs, 0);
+  Len64Val := View.Len64;
 
   // Step 4: If relativeIndex >= 0, let k be relativeIndex; else len + relativeIndex
-  if Index < 0 then
-    Index := View.Len + Index;
+  if Index64 < 0 then
+    Index64 := Len64Val + Index64;
 
   // Step 5: If k < 0 or k >= len, return undefined
-  if (Index < 0) or (Index >= View.Len) then
+  if (Index64 < 0) or (Index64 >= Len64Val) then
     Result := TGocciaUndefinedLiteralValue.UndefinedValue
   else
     // Step 6: Return Get(O, ToString(k))
-    Result := View.Get(Index);
+    Result := View.Get64(Index64);
 end;
 
 // ES2026 §23.1.3.36 Array.prototype.values()

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -3880,7 +3880,7 @@ begin
   end;
 
   // Step 3: Let relativeIndex be ToIntegerOrInfinity(index)
-  Index := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+  Index := ToIntegerFromArgs(AArgs, 0);
 
   // Step 4: If relativeIndex >= 0, let k be relativeIndex; else len + relativeIndex
   if Index < 0 then

--- a/source/units/Goccia.Values.BigIntObjectValue.pas
+++ b/source/units/Goccia.Values.BigIntObjectValue.pas
@@ -40,6 +40,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -123,7 +124,7 @@ begin
     RadixValue := AArgs.GetElement(0);
     if not (RadixValue is TGocciaUndefinedLiteralValue) then
     begin
-      Radix := Trunc(RadixValue.ToNumberLiteral.Value);
+      Radix := ToIntegerValue(RadixValue);
       if (Radix < 2) or (Radix > 36) then
         ThrowRangeError(SErrorBigIntInvalidRadix, SSuggestBigIntInvalidRadix);
     end;

--- a/source/units/Goccia.Values.BigIntValue.pas
+++ b/source/units/Goccia.Values.BigIntValue.pas
@@ -64,6 +64,7 @@ uses
   Goccia.ObjectModel,
   Goccia.Realm,
   Goccia.Threading,
+  Goccia.Utils,
   Goccia.Values.BigIntObjectValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.IntlNumberFormat,
@@ -287,7 +288,7 @@ begin
     RadixValue := AArgs.GetElement(0);
     if not (RadixValue is TGocciaUndefinedLiteralValue) then
     begin
-      Radix := Trunc(RadixValue.ToNumberLiteral.Value);
+      Radix := ToIntegerValue(RadixValue);
       if (Radix < 2) or (Radix > 36) then
         ThrowRangeError(SErrorBigIntInvalidRadix, SSuggestBigIntInvalidRadix);
     end;

--- a/source/units/Goccia.Values.FFILibrary.pas
+++ b/source/units/Goccia.Values.FFILibrary.pas
@@ -49,6 +49,7 @@ uses
   Goccia.FFI.Types,
   Goccia.GarbageCollector,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -151,22 +152,22 @@ begin
           fftI8, fftI16, fftI32:
           begin
             NumValue := ArgValue.ToNumberLiteral;
-            IntArgs[I] := PtrInt(Trunc(NumValue.Value));
+            IntArgs[I] := PtrInt(ToInt32Value(NumValue));
           end;
           fftI64:
           begin
             NumValue := ArgValue.ToNumberLiteral;
-            IntArgs[I] := PtrInt(Int64(Trunc(NumValue.Value)));
+            IntArgs[I] := PtrInt(ToInt64Value(NumValue));
           end;
           fftU8, fftU16, fftU32:
           begin
             NumValue := ArgValue.ToNumberLiteral;
-            IntArgs[I] := PtrInt(PtrUInt(Trunc(NumValue.Value)));
+            IntArgs[I] := PtrInt(PtrUInt(ToUint32Value(NumValue)));
           end;
           fftU64:
           begin
             NumValue := ArgValue.ToNumberLiteral;
-            IntArgs[I] := PtrInt(QWord(Trunc(NumValue.Value)));
+            IntArgs[I] := PtrInt(QWord(ToInt64Value(NumValue)));
           end;
           fftPointer:
           begin
@@ -265,22 +266,22 @@ begin
             fftI8, fftI16, fftI32:
             begin
               NumValue := ArgValue.ToNumberLiteral;
-              {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := PtrInt(Trunc(NumValue.Value));
+              {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := PtrInt(ToInt32Value(NumValue));
             end;
             fftI64:
             begin
               NumValue := ArgValue.ToNumberLiteral;
-              {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := PtrInt(Int64(Trunc(NumValue.Value)));
+              {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := PtrInt(ToInt64Value(NumValue));
             end;
             fftU8, fftU16, fftU32:
             begin
               NumValue := ArgValue.ToNumberLiteral;
-              {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := PtrInt(PtrUInt(Trunc(NumValue.Value)));
+              {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := PtrInt(PtrUInt(ToUint32Value(NumValue)));
             end;
             fftU64:
             begin
               NumValue := ArgValue.ToNumberLiteral;
-              {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := PtrInt(QWord(Trunc(NumValue.Value)));
+              {$IFDEF MSWINDOWS}State.Gpr[I]{$ELSE}State.Gpr[GprIdx]{$ENDIF} := PtrInt(QWord(ToInt64Value(NumValue)));
             end;
             fftPointer:
             begin
@@ -358,9 +359,9 @@ begin
               else
                 IntVal := 0;
             fftI8, fftI16, fftI32:
-              IntVal := LongInt(Trunc(ArgValue.ToNumberLiteral.Value));
+              IntVal := ToInt32Value(ArgValue);
             fftU8, fftU16, fftU32:
-              IntVal := LongInt(LongWord(Trunc(ArgValue.ToNumberLiteral.Value)));
+              IntVal := LongInt(ToUint32Value(ArgValue));
             fftPointer:
             begin
               if ArgValue is TGocciaFFIPointerValue then
@@ -400,7 +401,7 @@ begin
               Inc(TempCount);
             end;
           else
-            IntVal := LongInt(Trunc(ArgValue.ToNumberLiteral.Value));
+            IntVal := ToInt32Value(ArgValue);
           end;
           Move(IntVal, State.StackBuf[StackOffset], 4);
           Inc(StackOffset, 4);

--- a/source/units/Goccia.Values.IntlDateTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlDateTimeFormat.pas
@@ -71,6 +71,7 @@ uses
   Goccia.ObjectModel.Types,
   Goccia.Realm,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -982,7 +983,7 @@ begin
   ReadValidatedStringOption(AOptions, 'second', FSecond);
   V := AOptions.GetProperty('fractionalSecondDigits');
   if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-    FFractionalSecondDigits := Trunc(V.ToNumberLiteral.Value);
+    FFractionalSecondDigits := ToIntegerWithTruncationValue(V);
   TryReadStringOption(AOptions, 'timeZoneName', FTimeZoneName);
 end;
 

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -72,6 +72,7 @@ uses
   Goccia.Intl.Helpers,
   Goccia.ObjectModel.Types,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.BigIntObjectValue,
   Goccia.Values.BigIntValue,
@@ -828,22 +829,22 @@ begin
   TryReadStringOption(AOptions, 'roundingMode', FRoundingMode);
   V := AOptions.GetProperty('minimumIntegerDigits');
   if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-    FMinimumIntegerDigits := Trunc(V.ToNumberLiteral.Value);
+    FMinimumIntegerDigits := ToIntegerWithTruncationValue(V);
   V := AOptions.GetProperty('minimumFractionDigits');
   if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-    FMinimumFractionDigits := Trunc(V.ToNumberLiteral.Value);
+    FMinimumFractionDigits := ToIntegerWithTruncationValue(V);
   V := AOptions.GetProperty('maximumFractionDigits');
   if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-    FMaximumFractionDigits := Trunc(V.ToNumberLiteral.Value);
+    FMaximumFractionDigits := ToIntegerWithTruncationValue(V);
   V := AOptions.GetProperty('minimumSignificantDigits');
   if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-    FMinimumSignificantDigits := Trunc(V.ToNumberLiteral.Value);
+    FMinimumSignificantDigits := ToIntegerWithTruncationValue(V);
   V := AOptions.GetProperty('maximumSignificantDigits');
   if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-    FMaximumSignificantDigits := Trunc(V.ToNumberLiteral.Value);
+    FMaximumSignificantDigits := ToIntegerWithTruncationValue(V);
   V := AOptions.GetProperty('roundingIncrement');
   if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-    FRoundingIncrement := Trunc(V.ToNumberLiteral.Value);
+    FRoundingIncrement := ToIntegerWithTruncationValue(V);
   TryReadStringOption(AOptions, 'roundingPriority', FRoundingPriority);
   TryReadStringOption(AOptions, 'trailingZeroDisplay', FTrailingZeroDisplay);
   TryReadStringOption(AOptions, 'numberingSystem', FNumberingSystem);

--- a/source/units/Goccia.Values.IntlPluralRules.pas
+++ b/source/units/Goccia.Values.IntlPluralRules.pas
@@ -126,6 +126,7 @@ constructor TGocciaIntlPluralRulesValue.Create(const ALocale: string; const AOpt
 var
   Canonical: string;
   V: TGocciaValue;
+  HasMinFrac, HasMaxFrac, HasMinSig, HasMaxSig: Boolean;
 begin
   inherited Create;
   Canonical := CanonicalizeUnicodeLocaleId(ALocale);
@@ -141,6 +142,10 @@ begin
   FMaximumFractionDigits := -1;
   FMinimumSignificantDigits := -1;
   FMaximumSignificantDigits := -1;
+  HasMinFrac := False;
+  HasMaxFrac := False;
+  HasMinSig := False;
+  HasMaxSig := False;
 
   if Assigned(AOptions) then
   begin
@@ -162,48 +167,68 @@ begin
       FMinimumIntegerDigits := ToIntegerWithTruncationValue(V);
     V := AOptions.GetProperty('minimumFractionDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
+    begin
       FMinimumFractionDigits := ToIntegerWithTruncationValue(V);
+      HasMinFrac := True;
+    end;
     V := AOptions.GetProperty('maximumFractionDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
+    begin
       FMaximumFractionDigits := ToIntegerWithTruncationValue(V);
+      HasMaxFrac := True;
+    end;
     V := AOptions.GetProperty('minimumSignificantDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
+    begin
       FMinimumSignificantDigits := ToIntegerWithTruncationValue(V);
+      HasMinSig := True;
+    end;
     V := AOptions.GetProperty('maximumSignificantDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
+    begin
       FMaximumSignificantDigits := ToIntegerWithTruncationValue(V);
+      HasMaxSig := True;
+    end;
   end;
 
-  // ECMA-402 §16.1.2 / §15.1.6 SetNumberFormatDigitOptions: validate digit
-  // ranges before defaulting, matching Intl.NumberFormat.
+  // ECMA-402 §15.1.6 SetNumberFormatDigitOptions: every explicitly provided
+  // value is range-validated (presence tracked separately so negative inputs
+  // are rejected rather than mistaken for the unset sentinel), and provided
+  // minimum/maximum pairs must be ordered.
   if (FMinimumIntegerDigits < 1) or (FMinimumIntegerDigits > 21) then
     ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['minimumIntegerDigits', 1, 21]));
-  if (FMinimumFractionDigits >= 0) and (FMinimumFractionDigits > 100) then
+  if HasMinFrac and ((FMinimumFractionDigits < 0) or (FMinimumFractionDigits > 100)) then
     ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['minimumFractionDigits', 0, 100]));
-  if (FMaximumFractionDigits >= 0) and (FMaximumFractionDigits > 100) then
+  if HasMaxFrac and ((FMaximumFractionDigits < 0) or (FMaximumFractionDigits > 100)) then
     ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['maximumFractionDigits', 0, 100]));
-  if (FMinimumSignificantDigits >= 0) and
+  if HasMinSig and
      ((FMinimumSignificantDigits < 1) or (FMinimumSignificantDigits > 21)) then
     ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['minimumSignificantDigits', 1, 21]));
-  if (FMaximumSignificantDigits >= 0) and
+  if HasMaxSig and
      ((FMaximumSignificantDigits < 1) or (FMaximumSignificantDigits > 21)) then
     ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['maximumSignificantDigits', 1, 21]));
+  if HasMinFrac and HasMaxFrac and
+     (FMinimumFractionDigits > FMaximumFractionDigits) then
+    ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['maximumFractionDigits', FMinimumFractionDigits, 100]));
+  if HasMinSig and HasMaxSig and
+     (FMinimumSignificantDigits > FMaximumSignificantDigits) then
+    ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['maximumSignificantDigits', FMinimumSignificantDigits, 21]));
 
-  if (FMinimumSignificantDigits >= 0) or (FMaximumSignificantDigits >= 0) then
+  if HasMinSig or HasMaxSig then
   begin
-    if FMinimumSignificantDigits < 0 then
+    if not HasMinSig then
       FMinimumSignificantDigits := 1;
-    if FMaximumSignificantDigits < 0 then
+    if not HasMaxSig then
       FMaximumSignificantDigits := 21;
     FMinimumFractionDigits := -1;
     FMaximumFractionDigits := -1;
   end
   else
   begin
-    if FMinimumFractionDigits < 0 then
+    if not HasMinFrac then
       FMinimumFractionDigits := 0;
-    if FMaximumFractionDigits < 0 then
-      FMaximumFractionDigits := 3;
+    if not HasMaxFrac then
+      FMaximumFractionDigits := Max(3, FMinimumFractionDigits);
   end;
 
   InitializePrototype;

--- a/source/units/Goccia.Values.IntlPluralRules.pas
+++ b/source/units/Goccia.Values.IntlPluralRules.pas
@@ -174,6 +174,21 @@ begin
       FMaximumSignificantDigits := ToIntegerWithTruncationValue(V);
   end;
 
+  // ECMA-402 §16.1.2 / §15.1.6 SetNumberFormatDigitOptions: validate digit
+  // ranges before defaulting, matching Intl.NumberFormat.
+  if (FMinimumIntegerDigits < 1) or (FMinimumIntegerDigits > 21) then
+    ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['minimumIntegerDigits', 1, 21]));
+  if (FMinimumFractionDigits >= 0) and (FMinimumFractionDigits > 100) then
+    ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['minimumFractionDigits', 0, 100]));
+  if (FMaximumFractionDigits >= 0) and (FMaximumFractionDigits > 100) then
+    ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['maximumFractionDigits', 0, 100]));
+  if (FMinimumSignificantDigits >= 0) and
+     ((FMinimumSignificantDigits < 1) or (FMinimumSignificantDigits > 21)) then
+    ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['minimumSignificantDigits', 1, 21]));
+  if (FMaximumSignificantDigits >= 0) and
+     ((FMaximumSignificantDigits < 1) or (FMaximumSignificantDigits > 21)) then
+    ThrowRangeError(Format(SErrorIntlDigitsOutOfRange, ['maximumSignificantDigits', 1, 21]));
+
   if (FMinimumSignificantDigits >= 0) or (FMaximumSignificantDigits >= 0) then
   begin
     if FMinimumSignificantDigits < 0 then

--- a/source/units/Goccia.Values.IntlPluralRules.pas
+++ b/source/units/Goccia.Values.IntlPluralRules.pas
@@ -48,6 +48,7 @@ uses
   Goccia.Intl.CLDRData,
   Goccia.ObjectModel.Types,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -158,19 +159,19 @@ begin
     end;
     V := AOptions.GetProperty('minimumIntegerDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-      FMinimumIntegerDigits := Trunc(V.ToNumberLiteral.Value);
+      FMinimumIntegerDigits := ToIntegerWithTruncationValue(V);
     V := AOptions.GetProperty('minimumFractionDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-      FMinimumFractionDigits := Trunc(V.ToNumberLiteral.Value);
+      FMinimumFractionDigits := ToIntegerWithTruncationValue(V);
     V := AOptions.GetProperty('maximumFractionDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-      FMaximumFractionDigits := Trunc(V.ToNumberLiteral.Value);
+      FMaximumFractionDigits := ToIntegerWithTruncationValue(V);
     V := AOptions.GetProperty('minimumSignificantDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-      FMinimumSignificantDigits := Trunc(V.ToNumberLiteral.Value);
+      FMinimumSignificantDigits := ToIntegerWithTruncationValue(V);
     V := AOptions.GetProperty('maximumSignificantDigits');
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-      FMaximumSignificantDigits := Trunc(V.ToNumberLiteral.Value);
+      FMaximumSignificantDigits := ToIntegerWithTruncationValue(V);
   end;
 
   if (FMinimumSignificantDigits >= 0) or (FMaximumSignificantDigits >= 0) then

--- a/source/units/Goccia.Values.IntlSegmenter.pas
+++ b/source/units/Goccia.Values.IntlSegmenter.pas
@@ -81,6 +81,7 @@ uses
   Goccia.Error.Messages,
   Goccia.ObjectModel.Types,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -321,7 +322,7 @@ begin
   if AArgs.Length < 1 then
     Idx := 0
   else
-    Idx := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+    Idx := ToIntegerFromArgs(AArgs, 0);
 
   // Build all segments and find the one containing the index
   Iter := TGocciaIntlSegmentIteratorValue.Create(Segs.FLocale, Segs.FGranularity,

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -379,6 +379,7 @@ end;
 
 function TGocciaIteratorValue.IteratorTake(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
+  NumArg: TGocciaNumberLiteralValue;
   Limit: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
@@ -386,7 +387,13 @@ begin
   if AArgs.Length < 1 then
     ThrowRangeError(SErrorIteratorTakeRequiresArg, SSuggestIteratorNonNegative);
 
-  Limit := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+  // ES2026 §27.1.4.2 steps 4-7: NaN and negative (incl. -∞) limits throw
+  // RangeError; +∞ takes everything (saturated to MaxInt here).
+  NumArg := AArgs.GetElement(0).ToNumberLiteral;
+  if NumArg.IsNaN then
+    ThrowRangeError(SErrorIteratorTakeNonNegative,
+      SSuggestIteratorNonNegative);
+  Limit := ToIntegerValue(NumArg);
   if Limit < 0 then
     ThrowRangeError(SErrorIteratorTakeNonNegative,
       SSuggestIteratorNonNegative);
@@ -398,6 +405,7 @@ end;
 
 function TGocciaIteratorValue.IteratorDrop(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
+  NumArg: TGocciaNumberLiteralValue;
   DropCount: Integer;
 begin
   if not (AThisValue is TGocciaIteratorValue) then
@@ -405,7 +413,13 @@ begin
   if AArgs.Length < 1 then
     ThrowRangeError(SErrorIteratorDropRequiresArg, SSuggestIteratorNonNegative);
 
-  DropCount := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+  // ES2026 §27.1.4.1 steps 4-7: NaN and negative (incl. -∞) counts throw
+  // RangeError; +∞ drops everything (saturated to MaxInt here).
+  NumArg := AArgs.GetElement(0).ToNumberLiteral;
+  if NumArg.IsNaN then
+    ThrowRangeError(SErrorIteratorDropNonNegative,
+      SSuggestIteratorNonNegative);
+  DropCount := ToIntegerValue(NumArg);
   if DropCount < 0 then
     ThrowRangeError(SErrorIteratorDropNonNegative,
       SSuggestIteratorNonNegative);

--- a/source/units/Goccia.Values.NumberObjectValue.pas
+++ b/source/units/Goccia.Values.NumberObjectValue.pas
@@ -48,6 +48,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction;
 
@@ -162,16 +163,26 @@ var
   Prim: TGocciaNumberLiteralValue;
   Digits: Integer;
 begin
-  // Step 3: Let x be ? thisNumberValue(this value)
+  // Step 1: Let x be ? thisNumberValue(this value)
   Prim := ExtractPrimitive(AThisValue);
 
-  // Step 4: If x is NaN, return "NaN"
+  // Step 2: Let f be ? ToIntegerOrInfinity(fractionDigits)
+  if AArgs.Length > 0 then
+    Digits := ToIntegerFromArgs(AArgs, 0)
+  else
+    Digits := 0;
+
+  // Step 4: If f < 0 or f > 100, throw a RangeError exception
+  // (precedes the non-finite returns below, so (NaN).toFixed(101) throws)
+  if (Digits < 0) or (Digits > 100) then
+    ThrowRangeError(SErrorToFixedArgRange, SSuggestNumberRange);
+
+  // Step 5: If x is not finite, return Number::toString(x, 10)
   if Prim.IsNaN then
   begin
     Result := TGocciaStringLiteralValue.Create('NaN');
     Exit;
   end;
-  // Step 5: If x is +∞𝔽 or -∞𝔽, return the string representation
   if Prim.IsInfinity then
   begin
     Result := TGocciaStringLiteralValue.Create('Infinity');
@@ -180,19 +191,6 @@ begin
   if Prim.IsNegativeInfinity then
   begin
     Result := TGocciaStringLiteralValue.Create('-Infinity');
-    Exit;
-  end;
-
-  // Step 1: Let f be ? ToIntegerOrInfinity(fractionDigits)
-  if AArgs.Length > 0 then
-    Digits := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value)
-  else
-    Digits := 0;
-
-  // Step 2: If f < 0 or f > 100, throw a RangeError exception
-  if (Digits < 0) or (Digits > 100) then
-  begin
-    Result := TGocciaStringLiteralValue.Create('');
     Exit;
   end;
 
@@ -299,7 +297,7 @@ begin
   // Step 2: If radix is undefined, let radixMV be 10
   if (AArgs.Length > 0) and not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
   begin
-    Radix := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+    Radix := ToIntegerFromArgs(AArgs, 0);
     // Step 3: If radixMV < 2 or radixMV > 36, throw a RangeError exception
     if (Radix < 2) or (Radix > 36) then
       ThrowRangeError(SErrorBigIntInvalidRadix, SSuggestBigIntInvalidRadix);
@@ -373,14 +371,11 @@ begin
   end;
 
   // Step 3: Let p be ? ToIntegerOrInfinity(precision)
-  Precision := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+  Precision := ToIntegerFromArgs(AArgs, 0);
 
   // Step 6: If p < 1 or p > 100, throw a RangeError exception
   if (Precision < 1) or (Precision > 100) then
-  begin
-    Result := TGocciaStringLiteralValue.Create('');
-    Exit;
-  end;
+    ThrowRangeError(SErrorToPrecisionArgRange, SSuggestNumberRange);
 
   // Step 7: Format x with p significant digits
   Result := TGocciaStringLiteralValue.Create(FloatToStrF(Prim.Value, ffGeneral, Precision, 0, InvariantFormatSettings));
@@ -420,7 +415,7 @@ begin
   HasExplicitDigits := (AArgs.Length > 0) and not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue);
   if HasExplicitDigits then
   begin
-    FractionDigits := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+    FractionDigits := ToIntegerFromArgs(AArgs, 0);
     // Step 5: If f < 0 or f > 100, throw a RangeError exception
     if (FractionDigits < 0) or (FractionDigits > 100) then
       ThrowRangeError(SErrorToExponentialArgRange, SSuggestNumberRange);

--- a/source/units/Goccia.Values.NumberObjectValue.pas
+++ b/source/units/Goccia.Values.NumberObjectValue.pas
@@ -383,21 +383,10 @@ begin
   // Step 1: Let x be ? thisNumberValue(this value)
   Prim := ExtractPrimitive(AThisValue);
 
-  // Step 3: If x is NaN, return "NaN"
-  if Prim.IsNaN then
+  // Steps 3-4: If x is not finite, return Number::toString(x, 10)
+  if Prim.IsNaN or Prim.IsInfinity or Prim.IsNegativeInfinity then
   begin
-    Result := TGocciaStringLiteralValue.Create('NaN');
-    Exit;
-  end;
-  // Step 4: If x is +∞𝔽 or -∞𝔽, return the string representation
-  if Prim.IsInfinity then
-  begin
-    Result := TGocciaStringLiteralValue.Create('Infinity');
-    Exit;
-  end;
-  if Prim.IsNegativeInfinity then
-  begin
-    Result := TGocciaStringLiteralValue.Create('-Infinity');
+    Result := Prim.ToStringLiteral;
     Exit;
   end;
 

--- a/source/units/Goccia.Values.NumberObjectValue.pas
+++ b/source/units/Goccia.Values.NumberObjectValue.pas
@@ -178,19 +178,9 @@ begin
     ThrowRangeError(SErrorToFixedArgRange, SSuggestNumberRange);
 
   // Step 5: If x is not finite, return Number::toString(x, 10)
-  if Prim.IsNaN then
+  if Prim.IsNaN or Prim.IsInfinity or Prim.IsNegativeInfinity then
   begin
-    Result := TGocciaStringLiteralValue.Create('NaN');
-    Exit;
-  end;
-  if Prim.IsInfinity then
-  begin
-    Result := TGocciaStringLiteralValue.Create('Infinity');
-    Exit;
-  end;
-  if Prim.IsNegativeInfinity then
-  begin
-    Result := TGocciaStringLiteralValue.Create('-Infinity');
+    Result := Prim.ToStringLiteral;
     Exit;
   end;
 

--- a/source/units/Goccia.Values.ResponseValue.pas
+++ b/source/units/Goccia.Values.ResponseValue.pas
@@ -84,6 +84,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.JSON,
   Goccia.Realm,
+  Goccia.Utils,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -430,7 +431,7 @@ begin
   PropVal := InitObj.GetProperty(PROP_STATUS);
   if Assigned(PropVal) and not (PropVal is TGocciaUndefinedLiteralValue) then
   begin
-    StatusVal := Trunc(PropVal.ToNumberLiteral.Value);
+    StatusVal := ToIntegerValue(PropVal);
     if (StatusVal < 200) or (StatusVal > 599) then
       ThrowRangeError('Response status must be in the range 200-599');
     FStatus := StatusVal;

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -116,6 +116,7 @@ uses
   Goccia.Temporal.DurationMath,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
@@ -1084,15 +1085,15 @@ begin
   V := AObj.GetProperty(PROP_YEAR);
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
     Exit;
-  ADate.Year := Trunc(V.ToNumberLiteral.Value);
+  ADate.Year := ToIntegerWithTruncationValue(V);
   V := AObj.GetProperty(PROP_MONTH);
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
     Exit;
-  ADate.Month := Trunc(V.ToNumberLiteral.Value);
+  ADate.Month := ToIntegerWithTruncationValue(V);
   V := AObj.GetProperty(PROP_DAY);
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
     Exit;
-  ADate.Day := Trunc(V.ToNumberLiteral.Value);
+  ADate.Day := ToIntegerWithTruncationValue(V);
   if not IsValidDate(ADate.Year, ADate.Month, ADate.Day) then
     Exit;
   Result := True;

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -103,6 +103,17 @@ type
     function DurationToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
+// Temporal §13.20 ToIntegerIfIntegral for a Duration field: throws RangeError
+// for non-finite or non-integral numbers, preserves the full float64 integer
+// range via TBigInteger (duration components may exceed Int64, e.g.
+// nanoseconds up to ~9e24 within the 2^53-second cap).
+function DurationFieldToBigInteger(const AValue: TGocciaValue): TBigInteger;
+
+// Builds a Duration from a property-bag object, reading every component with
+// DurationFieldToBigInteger. Shared by Duration.prototype.with/add/subtract
+// and the Temporal.Duration constructor/from/compare entry points.
+function DurationFromObject(const AObj: TGocciaObjectValue): TGocciaTemporalDurationValue;
+
 implementation
 
 uses
@@ -145,7 +156,6 @@ begin
 end;
 
 function ParseRelativeTo(const AValue: TGocciaValue; const AMethod: string): TTemporalDateRecord; forward;
-function ValueToBigInteger(const AValue: TGocciaValue): TBigInteger; forward;
 
 function DurationFromObject(const AObj: TGocciaObjectValue): TGocciaTemporalDurationValue;
 
@@ -158,7 +168,7 @@ function DurationFromObject(const AObj: TGocciaObjectValue): TGocciaTemporalDura
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := ValueToBigInteger(V);
+      Result := DurationFieldToBigInteger(V);
   end;
 
 begin
@@ -202,8 +212,6 @@ begin
 end;
 
 function NumberToBigInteger(const AValue: Double): TBigInteger;
-var
-  DecStr: string;
 begin
   if IsNaN(AValue) or IsInfinite(AValue) then
     ThrowRangeError('Temporal.Duration field must be a finite integer',
@@ -211,11 +219,12 @@ begin
   if Frac(AValue) <> 0 then
     ThrowRangeError('Temporal.Duration field must be an integer',
       SSuggestTemporalDurationRange);
-  Str(AValue:0:0, DecStr);
-  Result := TBigInteger.FromDecimalString(DecStr);
+  // FromDouble decomposes the IEEE 754 bits, so integers beyond ~17
+  // significant decimal digits convert exactly (Str/FormatFloat round).
+  Result := TBigInteger.FromDouble(AValue);
 end;
 
-function ValueToBigInteger(const AValue: TGocciaValue): TBigInteger;
+function DurationFieldToBigInteger(const AValue: TGocciaValue): TBigInteger;
 begin
   if AValue is TGocciaNumberLiteralValue then
     Result := NumberToBigInteger(TGocciaNumberLiteralValue(AValue).Value)
@@ -244,6 +253,66 @@ begin
   Result := DurationSubDayNanosecondsBig(D)
     .Add(D.FDaysBig.Multiply(BigIntUnit(NANOSECONDS_PER_DAY)))
     .Add(D.FWeeksBig.Multiply(BigIntUnit(7)).Multiply(BigIntUnit(NANOSECONDS_PER_DAY)));
+end;
+
+// TC39 Temporal §7.5.4 DefaultTemporalLargestUnit: the unit of the largest
+// non-zero component, defaulting to nanosecond for the zero duration.
+function DurationDefaultLargestUnit(const D: TGocciaTemporalDurationValue): TTemporalUnit;
+begin
+  if not D.FYearsBig.IsZero then Exit(tuYear);
+  if not D.FMonthsBig.IsZero then Exit(tuMonth);
+  if not D.FWeeksBig.IsZero then Exit(tuWeek);
+  if not D.FDaysBig.IsZero then Exit(tuDay);
+  if not D.FHoursBig.IsZero then Exit(tuHour);
+  if not D.FMinutesBig.IsZero then Exit(tuMinute);
+  if not D.FSecondsBig.IsZero then Exit(tuSecond);
+  if not D.FMillisecondsBig.IsZero then Exit(tuMillisecond);
+  if not D.FMicrosecondsBig.IsZero then Exit(tuMicrosecond);
+  Result := tuNanosecond;
+end;
+
+// TC39 Temporal §7.5.26 TemporalDurationFromInternal step 12: each balanced
+// component is converted to a float64 Number before CreateTemporalDuration,
+// so values that round up past a validation boundary must reject (test262
+// Duration/prototype/add/result-out-of-range-3.js).
+function RoundBigToFloat64(const AValue: TBigInteger): TBigInteger;
+begin
+  Result := TBigInteger.FromDouble(AValue.ToDouble);
+end;
+
+// TC39 Temporal §7.5.24 AddDurations: reject calendar units, sum the exact
+// time durations, then rebalance to the larger of both default largest units.
+// ASign is +1 for add and -1 for subtract (subtract adds the negation).
+function AddDurationsCommon(const D, AOther: TGocciaTemporalDurationValue;
+  const ASign: Integer): TGocciaTemporalDurationValue;
+var
+  LargestUnit, OtherLargest: TTemporalUnit;
+  TotalNs, H, Mi, S, Ms, Us, Ns: TBigInteger;
+  Days: Int64;
+begin
+  LargestUnit := DurationDefaultLargestUnit(D);
+  OtherLargest := DurationDefaultLargestUnit(AOther);
+  if Ord(OtherLargest) < Ord(LargestUnit) then
+    LargestUnit := OtherLargest;
+  if LargestUnit in [tuYear, tuMonth, tuWeek] then
+    ThrowRangeError(SErrorDurationCalendarUnitsArith, SSuggestTemporalDurationArg);
+
+  TotalNs := DurationTotalNanosecondsBig(D);
+  if ASign >= 0 then
+    TotalNs := TotalNs.Add(DurationTotalNanosecondsBig(AOther))
+  else
+    TotalNs := TotalNs.Subtract(DurationTotalNanosecondsBig(AOther));
+
+  // §7.5.23 AddTimeDuration step 3: combined time beyond ±(2^53 s − 1 ns)
+  if not IsValidTimeDuration(TotalNs) then
+    ThrowRangeError(SErrorDurationTimeOutOfRange, SSuggestTemporalDurationRange);
+
+  BalanceTimeDurationToFields(TotalNs, LargestUnit, H, Mi, S, Ms, Us, Ns, Days);
+  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
+    TBigInteger.Zero, TBigInteger.Zero, TBigInteger.Zero,
+    TBigInteger.FromInt64(Days),
+    RoundBigToFloat64(H), RoundBigToFloat64(Mi), RoundBigToFloat64(S),
+    RoundBigToFloat64(Ms), RoundBigToFloat64(Us), RoundBigToFloat64(Ns));
 end;
 
 function RoundingDivisorBig(const ASmallestUnit: TTemporalUnit; const AIncrement: Integer): TBigInteger;
@@ -647,12 +716,7 @@ begin
     Other := nil;
   end;
 
-  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
-    D.FYearsBig.Add(Other.FYearsBig), D.FMonthsBig.Add(Other.FMonthsBig),
-    D.FWeeksBig.Add(Other.FWeeksBig), D.FDaysBig.Add(Other.FDaysBig),
-    D.FHoursBig.Add(Other.FHoursBig), D.FMinutesBig.Add(Other.FMinutesBig),
-    D.FSecondsBig.Add(Other.FSecondsBig), D.FMillisecondsBig.Add(Other.FMillisecondsBig),
-    D.FMicrosecondsBig.Add(Other.FMicrosecondsBig), D.FNanosecondsBig.Add(Other.FNanosecondsBig));
+  Result := AddDurationsCommon(D, Other, 1);
 end;
 
 function TGocciaTemporalDurationValue.DurationSubtract(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -685,12 +749,7 @@ begin
     Other := nil;
   end;
 
-  Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(
-    D.FYearsBig.Subtract(Other.FYearsBig), D.FMonthsBig.Subtract(Other.FMonthsBig),
-    D.FWeeksBig.Subtract(Other.FWeeksBig), D.FDaysBig.Subtract(Other.FDaysBig),
-    D.FHoursBig.Subtract(Other.FHoursBig), D.FMinutesBig.Subtract(Other.FMinutesBig),
-    D.FSecondsBig.Subtract(Other.FSecondsBig), D.FMillisecondsBig.Subtract(Other.FMillisecondsBig),
-    D.FMicrosecondsBig.Subtract(Other.FMicrosecondsBig), D.FNanosecondsBig.Subtract(Other.FNanosecondsBig));
+  Result := AddDurationsCommon(D, Other, -1);
 end;
 
 function TGocciaTemporalDurationValue.DurationWith(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -709,7 +768,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := ValueToBigInteger(Val);
+      Result := DurationFieldToBigInteger(Val);
   end;
 
 begin

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -74,6 +74,7 @@ uses
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
@@ -106,7 +107,7 @@ begin
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
     Result := ADefault
   else
-    Result := Trunc(V.ToNumberLiteral.Value);
+    Result := ToIntegerWithTruncation64Value(V);
 end;
 
 function AsPlainDate(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalPlainDateValue;
@@ -145,9 +146,9 @@ begin
     if (VDay = nil) or (VDay is TGocciaUndefinedLiteralValue) then
       ThrowTypeError(RequiredFieldsMsg, SSuggestTemporalFromArg);
     Result := TGocciaTemporalPlainDateValue.Create(
-      Trunc(V.ToNumberLiteral.Value),
-      Trunc(VMonth.ToNumberLiteral.Value),
-      Trunc(VDay.ToNumberLiteral.Value));
+      ToIntegerWithTruncationValue(V),
+      ToIntegerWithTruncationValue(VMonth),
+      ToIntegerWithTruncationValue(VDay));
   end
   else
   begin
@@ -369,7 +370,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncationValue(Val);
   end;
 
 begin
@@ -683,22 +684,22 @@ begin
       Obj := TGocciaObjectValue(Arg);
       V := Obj.GetProperty('hour');
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        Hour := Trunc(V.ToNumberLiteral.Value);
+        Hour := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty('minute');
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        Minute := Trunc(V.ToNumberLiteral.Value);
+        Minute := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty('second');
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        Second := Trunc(V.ToNumberLiteral.Value);
+        Second := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty('millisecond');
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        Ms := Trunc(V.ToNumberLiteral.Value);
+        Ms := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty('microsecond');
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        Us := Trunc(V.ToNumberLiteral.Value);
+        Us := ToIntegerWithTruncationValue(V);
       V := Obj.GetProperty('nanosecond');
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        Ns := Trunc(V.ToNumberLiteral.Value);
+        Ns := ToIntegerWithTruncationValue(V);
     end;
   end;
 

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -94,6 +94,7 @@ uses
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
@@ -138,7 +139,7 @@ var
     V := Obj.GetProperty(AName);
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       ThrowTypeError(AMethod + ' requires ' + AName + ' property', SSuggestTemporalFromArg);
-    Result := Trunc(V.ToNumberLiteral.Value);
+    Result := ToIntegerWithTruncationValue(V);
   end;
 
   function GetOptionalField(const AName: string; const ADefault: Integer): Integer;
@@ -147,7 +148,7 @@ var
     if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(V.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncationValue(V);
   end;
 
 begin
@@ -429,7 +430,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncationValue(Val);
   end;
 
 begin
@@ -513,16 +514,16 @@ begin
   begin
     ObjArg := TGocciaObjectValue(Arg);
     Y := 0; Mo := 0; W := 0; Da := 0; H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
-    VF := ObjArg.GetProperty('years'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Y := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('months'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mo := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('weeks'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then W := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('days'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Da := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('hours'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then H := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('minutes'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mi := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('seconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then S := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('milliseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ms := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('microseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Us := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('nanoseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ns := Trunc(VF.ToNumberLiteral.Value);
+    VF := ObjArg.GetProperty('years'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Y := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('months'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mo := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('weeks'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then W := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('days'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Da := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('hours'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('minutes'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('seconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('milliseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('microseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('nanoseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncation64Value(VF);
     Dur := TGocciaTemporalDurationValue.Create(Y, Mo, W, Da, H, Mi, S, Ms, Us, Ns);
   end
   else
@@ -587,16 +588,16 @@ begin
   begin
     ObjArg := TGocciaObjectValue(Arg);
     Y := 0; Mo := 0; W := 0; Da := 0; H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
-    VF := ObjArg.GetProperty('years'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Y := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('months'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mo := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('weeks'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then W := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('days'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Da := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('hours'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then H := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('minutes'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mi := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('seconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then S := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('milliseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ms := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('microseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Us := Trunc(VF.ToNumberLiteral.Value);
-    VF := ObjArg.GetProperty('nanoseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ns := Trunc(VF.ToNumberLiteral.Value);
+    VF := ObjArg.GetProperty('years'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Y := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('months'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mo := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('weeks'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then W := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('days'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Da := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('hours'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('minutes'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('seconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('milliseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('microseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncation64Value(VF);
+    VF := ObjArg.GetProperty('nanoseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncation64Value(VF);
     Dur := TGocciaTemporalDurationValue.Create(Y, Mo, W, Da, H, Mi, S, Ms, Us, Ns);
   end
   else

--- a/source/units/Goccia.Values.TemporalPlainMonthDay.pas
+++ b/source/units/Goccia.Values.TemporalPlainMonthDay.pas
@@ -54,6 +54,7 @@ uses
   Goccia.Realm,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
@@ -121,19 +122,19 @@ begin
       // Validate month/monthCode consistency when both are provided
       V := Obj.GetProperty(PROP_MONTH);
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        if Trunc(V.ToNumberLiteral.Value) <> MonthPart then
+        if ToIntegerWithTruncationValue(V) <> MonthPart then
           ThrowRangeError(Format(SErrorMonthCodeMismatchIn, [AMethod]), SSuggestTemporalMonthCode);
     end
     else
     begin
       V := Obj.GetProperty(PROP_MONTH);
       if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-        MonthPart := Trunc(V.ToNumberLiteral.Value)
+        MonthPart := ToIntegerWithTruncationValue(V)
       else
         ThrowTypeError(AMethod + ' requires monthCode or month property', SSuggestTemporalFromArg);
     end;
     Result := TGocciaTemporalPlainMonthDayValue.Create(
-      MonthPart, Trunc(VDay.ToNumberLiteral.Value));
+      MonthPart, ToIntegerWithTruncationValue(VDay));
   end
   else
   begin
@@ -259,7 +260,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncationValue(Val);
   end;
 
 begin
@@ -284,14 +285,14 @@ begin
     // Validate month/monthCode consistency when both are provided
     V := Obj.GetProperty(PROP_MONTH);
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-      if Trunc(V.ToNumberLiteral.Value) <> NewMonth then
+      if ToIntegerWithTruncationValue(V) <> NewMonth then
         ThrowRangeError(Format(SErrorMonthCodeMismatchIn, ['PlainMonthDay.prototype.with']), SSuggestTemporalMonthCode);
   end
   else
   begin
     V := Obj.GetProperty(PROP_MONTH);
     if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then
-      NewMonth := Trunc(V.ToNumberLiteral.Value);
+      NewMonth := ToIntegerWithTruncationValue(V);
   end;
 
   NewDay := GetDayFieldOr(MD.FDay);
@@ -373,7 +374,7 @@ begin
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
     ThrowTypeError(SErrorPlainMonthDayToPlainDateRequiresYear, SSuggestTemporalToPlainDateYear);
 
-  YearValue := Trunc(V.ToNumberLiteral.Value);
+  YearValue := ToIntegerWithTruncationValue(V);
   Result := TGocciaTemporalPlainDateValue.Create(YearValue, MD.FMonth, MD.FDay);
 end;
 

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -65,6 +65,7 @@ uses
   Goccia.Realm,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
@@ -113,17 +114,17 @@ begin
     Obj := TGocciaObjectValue(AValue);
     H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
     V := Obj.GetProperty('hour');
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty('minute');
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty('second');
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty('millisecond');
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty('microsecond');
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(V);
     V := Obj.GetProperty('nanosecond');
-    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := Trunc(V.ToNumberLiteral.Value);
+    if Assigned(V) and not (V is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(V);
     Result := TGocciaTemporalPlainTimeValue.Create(H, Mi, S, Ms, Us, Ns);
   end
   else
@@ -275,7 +276,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncationValue(Val);
   end;
 
 begin
@@ -326,17 +327,17 @@ begin
     Obj := TGocciaObjectValue(Arg);
     H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
     VH := Obj.GetProperty('hours');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then H := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('minutes');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Mi := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('seconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then S := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('milliseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ms := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('microseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Us := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('nanoseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ns := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(VH);
     Dur := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, H, Mi, S, Ms, Us, Ns);
   end
   else
@@ -395,17 +396,17 @@ begin
     Obj := TGocciaObjectValue(Arg);
     H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
     VH := Obj.GetProperty('hours');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then H := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('minutes');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Mi := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('seconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then S := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('milliseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ms := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('microseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Us := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(VH);
     VH := Obj.GetProperty('nanoseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ns := Trunc(VH.ToNumberLiteral.Value);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(VH);
     Dur := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, H, Mi, S, Ms, Us, Ns);
   end
   else

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -60,9 +60,12 @@ implementation
 uses
   SysUtils,
 
+  BigInteger,
+
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Realm,
+  Goccia.Temporal.DurationMath,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
   Goccia.Utils,
@@ -303,6 +306,7 @@ var
   DurRec: TTemporalDurationRecord;
   ExtraDays: Int64;
   Balanced: TTemporalTimeRecord;
+  DurTimeNs: TBigInteger;
   Obj: TGocciaObjectValue;
   VH: TGocciaValue;
   H, Mi, S, Ms, Us, Ns: Int64;
@@ -327,17 +331,17 @@ begin
     Obj := TGocciaObjectValue(Arg);
     H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
     VH := Obj.GetProperty('hours');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('minutes');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('seconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('milliseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('microseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('nanoseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncation64Value(VH);
     Dur := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, H, Mi, S, Ms, Us, Ns);
   end
   else
@@ -346,13 +350,16 @@ begin
     Dur := nil;
   end;
 
+  // PlainTime arithmetic is modulo one day, so reduce the duration's exact
+  // sub-day time (BigInteger — components may exceed Int64) before balancing;
+  // summing per-component Int64 values would overflow for large durations.
+  DurTimeNs := TimeDurationFromComponents(Dur.HoursBig, Dur.MinutesBig,
+    Dur.SecondsBig, Dur.MillisecondsBig, Dur.MicrosecondsBig,
+    Dur.NanosecondsBig).Modulo(TBigInteger.FromInt64(NANOSECONDS_PER_DAY));
+
   Balanced := BalanceTime(
-    T.FHour + Dur.Hours,
-    T.FMinute + Dur.Minutes,
-    T.FSecond + Dur.Seconds,
-    T.FMillisecond + Dur.Milliseconds,
-    T.FMicrosecond + Dur.Microseconds,
-    T.FNanosecond + Dur.Nanoseconds,
+    T.FHour, T.FMinute, T.FSecond, T.FMillisecond, T.FMicrosecond,
+    T.FNanosecond + DurTimeNs.ToInt64,
     ExtraDays);
 
   Result := TGocciaTemporalPlainTimeValue.Create(
@@ -372,6 +379,7 @@ var
   DurRec: TTemporalDurationRecord;
   ExtraDays: Int64;
   Balanced: TTemporalTimeRecord;
+  DurTimeNs: TBigInteger;
   Obj: TGocciaObjectValue;
   VH: TGocciaValue;
   H, Mi, S, Ms, Us, Ns: Int64;
@@ -396,17 +404,17 @@ begin
     Obj := TGocciaObjectValue(Arg);
     H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
     VH := Obj.GetProperty('hours');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('minutes');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('seconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('milliseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('microseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncation64Value(VH);
     VH := Obj.GetProperty('nanoseconds');
-    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncationValue(VH);
+    if Assigned(VH) and not (VH is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncation64Value(VH);
     Dur := TGocciaTemporalDurationValue.Create(0, 0, 0, 0, H, Mi, S, Ms, Us, Ns);
   end
   else
@@ -415,13 +423,14 @@ begin
     Dur := nil;
   end;
 
+  // See TimeAdd: reduce the exact sub-day time before balancing.
+  DurTimeNs := TimeDurationFromComponents(Dur.HoursBig, Dur.MinutesBig,
+    Dur.SecondsBig, Dur.MillisecondsBig, Dur.MicrosecondsBig,
+    Dur.NanosecondsBig).Modulo(TBigInteger.FromInt64(NANOSECONDS_PER_DAY));
+
   Balanced := BalanceTime(
-    T.FHour - Dur.Hours,
-    T.FMinute - Dur.Minutes,
-    T.FSecond - Dur.Seconds,
-    T.FMillisecond - Dur.Milliseconds,
-    T.FMicrosecond - Dur.Microseconds,
-    T.FNanosecond - Dur.Nanoseconds,
+    T.FHour, T.FMinute, T.FSecond, T.FMillisecond, T.FMicrosecond,
+    T.FNanosecond - DurTimeNs.ToInt64,
     ExtraDays);
 
   Result := TGocciaTemporalPlainTimeValue.Create(
@@ -542,6 +551,7 @@ var
   TotalNs, Divisor, Rounded: Int64;
   ExtraDays: Int64;
   Balanced: TTemporalTimeRecord;
+  DurTimeNs: TBigInteger;
   SmallestUnit: TTemporalUnit;
   Mode: TTemporalRoundingMode;
   Increment: Integer;

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -61,6 +61,7 @@ uses
   Goccia.Realm,
   Goccia.Temporal.Options,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
@@ -117,8 +118,8 @@ begin
     if (VMonth = nil) or (VMonth is TGocciaUndefinedLiteralValue) then
       ThrowTypeError(AMethod + ' requires year and month properties', SSuggestTemporalFromArg);
     Result := TGocciaTemporalPlainYearMonthValue.Create(
-      Trunc(V.ToNumberLiteral.Value),
-      Trunc(VMonth.ToNumberLiteral.Value));
+      ToIntegerWithTruncationValue(V),
+      ToIntegerWithTruncationValue(VMonth));
   end
   else
   begin
@@ -296,7 +297,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncationValue(Val);
   end;
 
 begin
@@ -329,7 +330,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncation64Value(Val);
   end;
 
 begin
@@ -403,7 +404,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncation64Value(Val);
   end;
 
 begin
@@ -640,7 +641,7 @@ begin
   if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
     ThrowTypeError(SErrorPlainYearMonthToPlainDateRequiresDay, SSuggestTemporalFromArg);
 
-  Day := Trunc(V.ToNumberLiteral.Value);
+  Day := ToIntegerWithTruncationValue(V);
   Result := TGocciaTemporalPlainDateValue.Create(YM.FYear, YM.FMonth, Day);
 end;
 

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -92,6 +92,7 @@ uses
   Goccia.Temporal.Options,
   Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
+  Goccia.Utils,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -272,16 +273,16 @@ begin
   begin
     Obj := TGocciaObjectValue(AArg);
     Y := 0; Mo := 0; W := 0; Da := 0; H := 0; Mi := 0; S := 0; Ms := 0; Us := 0; Ns := 0;
-    VF := Obj.GetProperty('years'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Y := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('months'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mo := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('weeks'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then W := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('days'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Da := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('hours'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then H := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('minutes'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mi := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('seconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then S := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('milliseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ms := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('microseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Us := Trunc(VF.ToNumberLiteral.Value);
-    VF := Obj.GetProperty('nanoseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ns := Trunc(VF.ToNumberLiteral.Value);
+    VF := Obj.GetProperty('years'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Y := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('months'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mo := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('weeks'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then W := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('days'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Da := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('hours'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then H := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('minutes'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Mi := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('seconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then S := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('milliseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ms := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('microseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Us := ToIntegerWithTruncation64Value(VF);
+    VF := Obj.GetProperty('nanoseconds'); if Assigned(VF) and not (VF is TGocciaUndefinedLiteralValue) then Ns := ToIntegerWithTruncation64Value(VF);
     Result := TGocciaTemporalDurationValue.Create(Y, Mo, W, Da, H, Mi, S, Ms, Us, Ns);
   end
   else
@@ -688,7 +689,7 @@ var
     if (Val = nil) or (Val is TGocciaUndefinedLiteralValue) then
       Result := ADefault
     else
-      Result := Trunc(Val.ToNumberLiteral.Value);
+      Result := ToIntegerWithTruncationValue(Val);
   end;
 
 begin

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -1161,7 +1161,7 @@ begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.at');
   if AArgs.Length = 0 then
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
-  RelIndex := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+  RelIndex := ToIntegerFromArgs(AArgs, 0);
   if RelIndex >= 0 then
     ActualIndex := RelIndex
   else
@@ -1199,7 +1199,7 @@ begin
   // ES2026 §23.2.3.8 step 5-6: RelativeIndex → clamp
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
   begin
-    RelStart := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value);
+    RelStart := ToIntegerFromArgs(AArgs, 1);
     if RelStart < 0 then
       First := Max(TA.FLength + RelStart, 0)
     else
@@ -1211,7 +1211,7 @@ begin
   // ES2026 §23.2.3.8 step 7-8
   if (AArgs.Length > 2) and not (AArgs.GetElement(2) is TGocciaUndefinedLiteralValue) then
   begin
-    RelEnd := Trunc(AArgs.GetElement(2).ToNumberLiteral.Value);
+    RelEnd := ToIntegerFromArgs(AArgs, 2);
     if RelEnd < 0 then
       Final := Max(TA.FLength + RelEnd, 0)
     else
@@ -1247,15 +1247,15 @@ begin
   if AArgs.Length < 2 then
     Exit(AThisValue);
 
-  Target := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
-  Start := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value);
+  Target := ToIntegerFromArgs(AArgs, 0);
+  Start := ToIntegerFromArgs(AArgs, 1);
 
   if Target < 0 then Target := Max(TA.FLength + Target, 0) else Target := Min(Target, TA.FLength);
   if Start < 0 then Start := Max(TA.FLength + Start, 0) else Start := Min(Start, TA.FLength);
 
   if (AArgs.Length > 2) and not (AArgs.GetElement(2) is TGocciaUndefinedLiteralValue) then
   begin
-    Final := Trunc(AArgs.GetElement(2).ToNumberLiteral.Value);
+    Final := ToIntegerFromArgs(AArgs, 2);
     if Final < 0 then Final := Max(TA.FLength + Final, 0) else Final := Min(Final, TA.FLength);
   end
   else
@@ -1286,7 +1286,7 @@ begin
 
   if AArgs.Length > 0 then
   begin
-    First := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+    First := ToIntegerFromArgs(AArgs, 0);
     if First < 0 then First := Max(TA.FLength + First, 0) else First := Min(First, TA.FLength);
   end
   else
@@ -1294,7 +1294,7 @@ begin
 
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
   begin
-    Final := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value);
+    Final := ToIntegerFromArgs(AArgs, 1);
     if Final < 0 then Final := Max(TA.FLength + Final, 0) else Final := Min(Final, TA.FLength);
   end
   else
@@ -1328,7 +1328,7 @@ begin
 
   if AArgs.Length > 0 then
   begin
-    BeginIdx := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value);
+    BeginIdx := ToIntegerFromArgs(AArgs, 0);
     if BeginIdx < 0 then BeginIdx := Max(TA.FLength + BeginIdx, 0) else BeginIdx := Min(BeginIdx, TA.FLength);
   end
   else
@@ -1336,7 +1336,7 @@ begin
 
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
   begin
-    EndIdx := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value);
+    EndIdx := ToIntegerFromArgs(AArgs, 1);
     if EndIdx < 0 then EndIdx := Max(TA.FLength + EndIdx, 0) else EndIdx := Min(EndIdx, TA.FLength);
   end
   else
@@ -1638,7 +1638,7 @@ begin
 
   if AArgs.Length > 1 then
   begin
-    StartIdx := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value);
+    StartIdx := ToIntegerFromArgs(AArgs, 1);
     if StartIdx < 0 then StartIdx := Max(TA.FLength + StartIdx, 0);
   end
   else
@@ -1668,7 +1668,7 @@ begin
     Exit(TGocciaNumberLiteralValue.Create(-1));
   if AArgs.Length > 1 then
   begin
-    StartIdx := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value);
+    StartIdx := ToIntegerFromArgs(AArgs, 1);
     if StartIdx < 0 then StartIdx := TA.FLength + StartIdx;
   end
   else
@@ -1698,7 +1698,7 @@ begin
     Exit(TGocciaBooleanLiteralValue.FalseValue);
   if AArgs.Length > 1 then
   begin
-    StartIdx := Trunc(AArgs.GetElement(1).ToNumberLiteral.Value);
+    StartIdx := ToIntegerFromArgs(AArgs, 1);
     if StartIdx < 0 then StartIdx := Max(TA.FLength + StartIdx, 0);
   end
   else
@@ -2175,7 +2175,7 @@ begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.with');
   // ES2026 §23.2.3.36 step 3: Let relativeIndex be ? ToIntegerOrInfinity(index)
   if AArgs.Length > 0 then
-    ActualIndex := Trunc(AArgs.GetElement(0).ToNumberLiteral.Value)
+    ActualIndex := ToIntegerFromArgs(AArgs, 0)
   else
     ActualIndex := 0;
   if ActualIndex < 0 then

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -1159,8 +1159,7 @@ var
   RelIndex, ActualIndex: Integer;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.at');
-  if AArgs.Length = 0 then
-    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  // ES2026 §23.2.3.1 step 4: a missing index coerces to 0, not undefined
   RelIndex := ToIntegerFromArgs(AArgs, 0);
   if RelIndex >= 0 then
     ActualIndex := RelIndex

--- a/tests/built-ins/Array/from.js
+++ b/tests/built-ins/Array/from.js
@@ -153,3 +153,17 @@ describe("Array.from", () => {
     expect(Array.from.length).toBe(1);
   });
 });
+
+describe("Array.from non-finite array-like lengths", () => {
+  test("length Infinity throws RangeError", () => {
+    expect(() => Array.from({ length: Infinity })).toThrow(RangeError);
+  });
+
+  test("length NaN yields empty array", () => {
+    expect(Array.from({ length: NaN }).length).toBe(0);
+  });
+
+  test("length -Infinity yields empty array", () => {
+    expect(Array.from({ length: -Infinity }).length).toBe(0);
+  });
+});

--- a/tests/built-ins/Array/fromAsync.js
+++ b/tests/built-ins/Array/fromAsync.js
@@ -288,3 +288,14 @@ describe("Array.fromAsync", () => {
     await expect(Array.fromAsync(bad)).rejects.toThrow(TypeError);
   });
 });
+
+describe("Array.fromAsync non-finite array-like lengths", () => {
+  test("length Infinity rejects with RangeError", async () => {
+    await expect(Array.fromAsync({ length: Infinity })).rejects.toThrow(RangeError);
+  });
+
+  test("length NaN resolves to empty array", async () => {
+    const result = await Array.fromAsync({ length: NaN });
+    expect(result.length).toBe(0);
+  });
+});

--- a/tests/built-ins/Array/prototype/at.js
+++ b/tests/built-ins/Array/prototype/at.js
@@ -39,3 +39,13 @@ describe("Array.prototype.at", () => {
     expect(Array.prototype.at.call(arrayLike, -1)).toBe('c');
   });
 });
+
+describe("Array.prototype.at non-finite index", () => {
+  test("Infinity returns undefined", () => {
+    expect([1, 2].at(Infinity)).toBeUndefined();
+  });
+
+  test("-Infinity returns undefined", () => {
+    expect([1, 2].at(-Infinity)).toBeUndefined();
+  });
+});

--- a/tests/built-ins/Array/prototype/at.js
+++ b/tests/built-ins/Array/prototype/at.js
@@ -55,3 +55,15 @@ describe("Array.prototype.at without an argument", () => {
     expect([5, 6].at()).toBe(5);
   });
 });
+
+describe("Array.prototype.at on oversized array-likes", () => {
+  test("negative index resolves against a length beyond MaxInt", () => {
+    const arrayLike = { length: 2 ** 32 + 2, [2 ** 32 + 1]: "x" };
+    expect(Array.prototype.at.call(arrayLike, -1)).toBe("x");
+  });
+
+  test("positive index beyond MaxInt reads the indexed property", () => {
+    const arrayLike = { length: 2 ** 32 + 2, [2 ** 32 + 1]: "x" };
+    expect(Array.prototype.at.call(arrayLike, 2 ** 32 + 1)).toBe("x");
+  });
+});

--- a/tests/built-ins/Array/prototype/at.js
+++ b/tests/built-ins/Array/prototype/at.js
@@ -49,3 +49,9 @@ describe("Array.prototype.at non-finite index", () => {
     expect([1, 2].at(-Infinity)).toBeUndefined();
   });
 });
+
+describe("Array.prototype.at without an argument", () => {
+  test("missing index coerces to 0", () => {
+    expect([5, 6].at()).toBe(5);
+  });
+});

--- a/tests/built-ins/BigInt/coercion.js
+++ b/tests/built-ins/BigInt/coercion.js
@@ -67,3 +67,13 @@ test("Object() boxed BigInt in arithmetic", () => {
   expect(Object(1n) - 1n === 0n).toBe(true);
   expect(Object(2n) * 3n === 6n).toBe(true);
 });
+
+describe("BigInt from large integral doubles is exact", () => {
+  test("values beyond 17 significant decimal digits convert without rounding drift", () => {
+    expect(BigInt(9007199254740991475711)).toBe(9007199254740990951424n);
+  });
+
+  test("negative large integral doubles convert exactly", () => {
+    expect(BigInt(-9007199254740991475711)).toBe(-9007199254740990951424n);
+  });
+});

--- a/tests/built-ins/BigInt/prototype-methods.js
+++ b/tests/built-ins/BigInt/prototype-methods.js
@@ -45,3 +45,13 @@ test("toLocaleString(locales, options)", () => {
 test("toLocaleString rejects null options", () => {
   expect(() => (1234n).toLocaleString("en-US", null)).toThrow(TypeError);
 });
+
+describe("BigInt.prototype.toString non-finite radix", () => {
+  test("Infinity radix throws RangeError", () => {
+    expect(() => (5n).toString(Infinity)).toThrow(RangeError);
+  });
+
+  test("NaN radix throws RangeError", () => {
+    expect(() => (5n).toString(NaN)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/CSV/parseChunk.js
+++ b/tests/built-ins/CSV/parseChunk.js
@@ -53,7 +53,7 @@ describe.runIf(hasCSV)("CSV.parseChunk", () => {
   });
 });
 
-describe("CSV.parseChunk non-finite offsets", () => {
+describe.runIf(hasCSV)("CSV.parseChunk non-finite offsets", () => {
   test("Infinity start offset does not crash", () => {
     expect(typeof CSV.parseChunk("a,b\n1,2", ",", Infinity)).toBe("object");
   });

--- a/tests/built-ins/CSV/parseChunk.js
+++ b/tests/built-ins/CSV/parseChunk.js
@@ -52,3 +52,9 @@ describe.runIf(hasCSV)("CSV.parseChunk", () => {
     expect(() => CSV.parseChunk()).toThrow();
   });
 });
+
+describe("CSV.parseChunk non-finite offsets", () => {
+  test("Infinity start offset does not crash", () => {
+    expect(typeof CSV.parseChunk("a,b\n1,2", ",", Infinity)).toBe("object");
+  });
+});

--- a/tests/built-ins/FFI/prototype/bind.js
+++ b/tests/built-ins/FFI/prototype/bind.js
@@ -104,3 +104,18 @@ describe("FFILibrary.prototype.bind", () => {
     expect(() => closed.bind("get_answer", { args: [], returns: "i32" })).toThrow(TypeError);
   });
 });
+
+describe("FFILibrary.prototype.bind non-finite integer arguments", () => {
+  const lib = FFI.open("./fixtures/ffi/libfixture" + FFI.suffix);
+  afterAll(() => lib.close());
+
+  test("Infinity i32 argument wraps to 0 per ToInt32", () => {
+    const add = lib.bind("add_i32", { args: ["i32", "i32"], returns: "i32" });
+    expect(add(Infinity, 5)).toBe(5);
+  });
+
+  test("NaN i32 argument wraps to 0 per ToInt32", () => {
+    const add = lib.bind("add_i32", { args: ["i32", "i32"], returns: "i32" });
+    expect(add(NaN, 5)).toBe(5);
+  });
+});

--- a/tests/built-ins/Goccia/testing-library.js
+++ b/tests/built-ins/Goccia/testing-library.js
@@ -13,3 +13,9 @@ describe("test.each title formatting with non-finite numbers", () => {
     expect(typeof value).toBe("number");
   });
 });
+
+describe("toBeCloseTo -Infinity precision", () => {
+  test("-Infinity precision means infinite tolerance", () => {
+    expect(0.1).toBeCloseTo(99999, -Infinity);
+  });
+});

--- a/tests/built-ins/Goccia/testing-library.js
+++ b/tests/built-ins/Goccia/testing-library.js
@@ -1,0 +1,15 @@
+describe("toBeCloseTo non-finite precision", () => {
+  test("Infinity precision means zero tolerance", () => {
+    expect(0.1).not.toBeCloseTo(0.2, Infinity);
+  });
+
+  test("NaN precision counts as 0", () => {
+    expect(0.1).toBeCloseTo(0.2, NaN);
+  });
+});
+
+describe("test.each title formatting with non-finite numbers", () => {
+  test.each([[Infinity], [-Infinity], [NaN]])("renders %d without crashing", (value) => {
+    expect(typeof value).toBe("number");
+  });
+});

--- a/tests/built-ins/Intl/DateTimeFormat/constructor.js
+++ b/tests/built-ins/Intl/DateTimeFormat/constructor.js
@@ -36,7 +36,7 @@ describe.runIf(isIntl)("Intl.DateTimeFormat constructor", () => {
   });
 });
 
-describe("Intl.DateTimeFormat non-finite fractionalSecondDigits", () => {
+describe.runIf(isIntl)("Intl.DateTimeFormat non-finite fractionalSecondDigits", () => {
   test("Infinity throws RangeError", () => {
     expect(() => new Intl.DateTimeFormat("en", { fractionalSecondDigits: Infinity })).toThrow(RangeError);
   });

--- a/tests/built-ins/Intl/DateTimeFormat/constructor.js
+++ b/tests/built-ins/Intl/DateTimeFormat/constructor.js
@@ -35,3 +35,13 @@ describe.runIf(isIntl)("Intl.DateTimeFormat constructor", () => {
     expect(typeof options.timeZone).toBe("string");
   });
 });
+
+describe("Intl.DateTimeFormat non-finite fractionalSecondDigits", () => {
+  test("Infinity throws RangeError", () => {
+    expect(() => new Intl.DateTimeFormat("en", { fractionalSecondDigits: Infinity })).toThrow(RangeError);
+  });
+
+  test("NaN throws RangeError", () => {
+    expect(() => new Intl.DateTimeFormat("en", { fractionalSecondDigits: NaN })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Intl/NumberFormat/constructor.js
+++ b/tests/built-ins/Intl/NumberFormat/constructor.js
@@ -27,3 +27,17 @@ describe.runIf(isIntl)("Intl.NumberFormat constructor", () => {
     expect(typeof options.locale).toBe("string");
   });
 });
+
+describe("Intl.NumberFormat non-finite digit options", () => {
+  test("maximumFractionDigits Infinity throws RangeError", () => {
+    expect(() => new Intl.NumberFormat("en", { maximumFractionDigits: Infinity })).toThrow(RangeError);
+  });
+
+  test("maximumFractionDigits NaN throws RangeError", () => {
+    expect(() => new Intl.NumberFormat("en", { maximumFractionDigits: NaN })).toThrow(RangeError);
+  });
+
+  test("minimumIntegerDigits -Infinity throws RangeError", () => {
+    expect(() => new Intl.NumberFormat("en", { minimumIntegerDigits: -Infinity })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Intl/NumberFormat/constructor.js
+++ b/tests/built-ins/Intl/NumberFormat/constructor.js
@@ -28,7 +28,7 @@ describe.runIf(isIntl)("Intl.NumberFormat constructor", () => {
   });
 });
 
-describe("Intl.NumberFormat non-finite digit options", () => {
+describe.runIf(isIntl)("Intl.NumberFormat non-finite digit options", () => {
   test("maximumFractionDigits Infinity throws RangeError", () => {
     expect(() => new Intl.NumberFormat("en", { maximumFractionDigits: Infinity })).toThrow(RangeError);
   });

--- a/tests/built-ins/Intl/PluralRules/constructor.js
+++ b/tests/built-ins/Intl/PluralRules/constructor.js
@@ -27,3 +27,13 @@ describe.runIf(isIntl)("Intl.PluralRules constructor", () => {
     expect(typeof options.locale).toBe("string");
   });
 });
+
+describe("Intl.PluralRules non-finite digit options", () => {
+  test("minimumIntegerDigits Infinity throws RangeError", () => {
+    expect(() => new Intl.PluralRules("en", { minimumIntegerDigits: Infinity })).toThrow(RangeError);
+  });
+
+  test("maximumSignificantDigits NaN throws RangeError", () => {
+    expect(() => new Intl.PluralRules("en", { maximumSignificantDigits: NaN })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Intl/PluralRules/constructor.js
+++ b/tests/built-ins/Intl/PluralRules/constructor.js
@@ -47,3 +47,22 @@ describe.runIf(isIntl)("Intl.PluralRules finite digit range validation", () => {
     expect(() => new Intl.PluralRules("en", { maximumFractionDigits: 101 })).toThrow(RangeError);
   });
 });
+
+describe.runIf(isIntl)("Intl.PluralRules digit option edge validation", () => {
+  test("negative minimumFractionDigits throws RangeError", () => {
+    expect(() => new Intl.PluralRules("en", { minimumFractionDigits: -1 })).toThrow(RangeError);
+  });
+
+  test("minimumFractionDigits above maximumFractionDigits throws RangeError", () => {
+    expect(() => new Intl.PluralRules("en", { minimumFractionDigits: 5, maximumFractionDigits: 2 })).toThrow(RangeError);
+  });
+
+  test("minimumSignificantDigits above maximumSignificantDigits throws RangeError", () => {
+    expect(() => new Intl.PluralRules("en", { minimumSignificantDigits: 10, maximumSignificantDigits: 5 })).toThrow(RangeError);
+  });
+
+  test("minimumFractionDigits alone raises the maximum to match", () => {
+    const rules = new Intl.PluralRules("en", { minimumFractionDigits: 7 });
+    expect(typeof rules.select(1)).toBe("string");
+  });
+});

--- a/tests/built-ins/Intl/PluralRules/constructor.js
+++ b/tests/built-ins/Intl/PluralRules/constructor.js
@@ -28,12 +28,22 @@ describe.runIf(isIntl)("Intl.PluralRules constructor", () => {
   });
 });
 
-describe("Intl.PluralRules non-finite digit options", () => {
+describe.runIf(isIntl)("Intl.PluralRules non-finite digit options", () => {
   test("minimumIntegerDigits Infinity throws RangeError", () => {
     expect(() => new Intl.PluralRules("en", { minimumIntegerDigits: Infinity })).toThrow(RangeError);
   });
 
   test("maximumSignificantDigits NaN throws RangeError", () => {
     expect(() => new Intl.PluralRules("en", { maximumSignificantDigits: NaN })).toThrow(RangeError);
+  });
+});
+
+describe.runIf(isIntl)("Intl.PluralRules finite digit range validation", () => {
+  test("minimumIntegerDigits above 21 throws RangeError", () => {
+    expect(() => new Intl.PluralRules("en", { minimumIntegerDigits: 22 })).toThrow(RangeError);
+  });
+
+  test("maximumFractionDigits above 100 throws RangeError", () => {
+    expect(() => new Intl.PluralRules("en", { maximumFractionDigits: 101 })).toThrow(RangeError);
   });
 });

--- a/tests/built-ins/Intl/Segmenter/prototype/segment.js
+++ b/tests/built-ins/Intl/Segmenter/prototype/segment.js
@@ -33,7 +33,7 @@ describe.runIf(isIntl && typeof Intl.Segmenter !== "undefined")("Intl.Segmenter.
   });
 });
 
-describe("Segments.prototype.containing non-finite index", () => {
+describe.runIf(isIntl && typeof Intl.Segmenter !== "undefined")("Segments.prototype.containing non-finite index", () => {
   test("Infinity returns undefined", () => {
     expect(new Intl.Segmenter().segment("ab").containing(Infinity)).toBeUndefined();
   });

--- a/tests/built-ins/Intl/Segmenter/prototype/segment.js
+++ b/tests/built-ins/Intl/Segmenter/prototype/segment.js
@@ -32,3 +32,13 @@ describe.runIf(isIntl && typeof Intl.Segmenter !== "undefined")("Intl.Segmenter.
     expect(words.length).toBe(2);
   });
 });
+
+describe("Segments.prototype.containing non-finite index", () => {
+  test("Infinity returns undefined", () => {
+    expect(new Intl.Segmenter().segment("ab").containing(Infinity)).toBeUndefined();
+  });
+
+  test("-Infinity returns undefined", () => {
+    expect(new Intl.Segmenter().segment("ab").containing(-Infinity)).toBeUndefined();
+  });
+});

--- a/tests/built-ins/Iterator/prototype/drop.js
+++ b/tests/built-ins/Iterator/prototype/drop.js
@@ -30,3 +30,17 @@ describe("Iterator.prototype.drop()", () => {
     expect(dropped.next().done).toBe(true);
   });
 });
+
+describe("Iterator.prototype.drop non-finite counts", () => {
+  test("Infinity drops all values", () => {
+    expect([1, 2].values().drop(Infinity).toArray()).toEqual([]);
+  });
+
+  test("NaN throws RangeError", () => {
+    expect(() => [1, 2].values().drop(NaN)).toThrow(RangeError);
+  });
+
+  test("-Infinity throws RangeError", () => {
+    expect(() => [1, 2].values().drop(-Infinity)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Iterator/prototype/take.js
+++ b/tests/built-ins/Iterator/prototype/take.js
@@ -154,3 +154,17 @@ describe("Iterator.prototype.take()", () => {
     expect(result).toEqual([[1, 2, 3], [1, 2, 3], [1, 2, 3]]);
   });
 });
+
+describe("Iterator.prototype.take non-finite limits", () => {
+  test("Infinity takes all remaining values", () => {
+    expect([1, 2].values().take(Infinity).toArray()).toEqual([1, 2]);
+  });
+
+  test("NaN throws RangeError", () => {
+    expect(() => [1, 2].values().take(NaN)).toThrow(RangeError);
+  });
+
+  test("-Infinity throws RangeError", () => {
+    expect(() => [1, 2].values().take(-Infinity)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -380,20 +380,6 @@ test("JSON.stringify preserves enumerable property order", () => {
   expect(JSON.stringify(obj)).toBe('{"beta":2,"alpha":1,"gamma":3}');
 });
 
-describe("JSON.stringify non-finite space argument", () => {
-  test("Infinity space is capped at 10 spaces", () => {
-    expect(JSON.stringify({ a: 1 }, null, Infinity)).toBe(JSON.stringify({ a: 1 }, null, 10));
-  });
-
-  test("-Infinity space produces no indentation", () => {
-    expect(JSON.stringify({ a: 1 }, null, -Infinity)).toBe(JSON.stringify({ a: 1 }));
-  });
-
-  test("NaN space produces no indentation", () => {
-    expect(JSON.stringify({ a: 1 }, null, NaN)).toBe(JSON.stringify({ a: 1 }));
-  });
-});
-
 test("JSON.stringify array replacer ignores boolean, null, undefined, and plain object elements", () => {
   expect(JSON.stringify({ true: 1, a: 2 }, [true])).toBe("{}");
   expect(JSON.stringify({ false: 1, a: 2 }, [false])).toBe("{}");

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -277,3 +277,17 @@ test("JSON.stringify preserves enumerable property order", () => {
 
   expect(JSON.stringify(obj)).toBe('{"beta":2,"alpha":1,"gamma":3}');
 });
+
+describe("JSON.stringify non-finite space argument", () => {
+  test("Infinity space is capped at 10 spaces", () => {
+    expect(JSON.stringify({ a: 1 }, null, Infinity)).toBe(JSON.stringify({ a: 1 }, null, 10));
+  });
+
+  test("-Infinity space produces no indentation", () => {
+    expect(JSON.stringify({ a: 1 }, null, -Infinity)).toBe(JSON.stringify({ a: 1 }));
+  });
+
+  test("NaN space produces no indentation", () => {
+    expect(JSON.stringify({ a: 1 }, null, NaN)).toBe(JSON.stringify({ a: 1 }));
+  });
+});

--- a/tests/built-ins/Number/prototype/toExponential.js
+++ b/tests/built-ins/Number/prototype/toExponential.js
@@ -39,3 +39,13 @@ describe("Number.prototype.toExponential", () => {
     expect(() => (1).toExponential(101)).toThrow(RangeError);
   });
 });
+
+describe("Number.prototype.toExponential non-finite digits", () => {
+  test("Infinity digits throws RangeError", () => {
+    expect(() => (5).toExponential(Infinity)).toThrow(RangeError);
+  });
+
+  test("-Infinity digits throws RangeError", () => {
+    expect(() => (5).toExponential(-Infinity)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Number/prototype/toFixed.js
+++ b/tests/built-ins/Number/prototype/toFixed.js
@@ -47,3 +47,21 @@ describe("Number.prototype.toFixed", () => {
     expect(`$${total.toFixed(2)}`).toBe("$6.50");
   });
 });
+
+describe("Number.prototype.toFixed digits range", () => {
+  test("Infinity digits throws RangeError", () => {
+    expect(() => (5).toFixed(Infinity)).toThrow(RangeError);
+  });
+
+  test("-Infinity digits throws RangeError", () => {
+    expect(() => (5).toFixed(-Infinity)).toThrow(RangeError);
+  });
+
+  test("out-of-range digits throw even when this value is NaN", () => {
+    expect(() => NaN.toFixed(101)).toThrow(RangeError);
+  });
+
+  test("NaN digits count as 0", () => {
+    expect((5).toFixed(NaN)).toBe("5");
+  });
+});

--- a/tests/built-ins/Number/prototype/toPrecision.js
+++ b/tests/built-ins/Number/prototype/toPrecision.js
@@ -28,3 +28,17 @@ describe("Number.prototype.toPrecision", () => {
     expect(Infinity.toPrecision(5)).toBe("Infinity");
   });
 });
+
+describe("Number.prototype.toPrecision precision range", () => {
+  test("Infinity precision throws RangeError", () => {
+    expect(() => (5).toPrecision(Infinity)).toThrow(RangeError);
+  });
+
+  test("NaN this value returns NaN before the range check", () => {
+    expect(NaN.toPrecision(Infinity)).toBe("NaN");
+  });
+
+  test("NaN precision counts as 0 and throws RangeError", () => {
+    expect(() => (5).toPrecision(NaN)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Number/prototype/toString.js
+++ b/tests/built-ins/Number/prototype/toString.js
@@ -113,3 +113,13 @@ describe("Number.prototype.toString", () => {
     expect("" + 1e21).toBe("1e+21");
   });
 });
+
+describe("Number.prototype.toString non-finite radix", () => {
+  test("Infinity radix throws RangeError", () => {
+    expect(() => (5).toString(Infinity)).toThrow(RangeError);
+  });
+
+  test("NaN radix throws RangeError", () => {
+    expect(() => (5).toString(NaN)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Response/constructor.js
+++ b/tests/built-ins/Response/constructor.js
@@ -99,3 +99,13 @@ describe("Response constructor", () => {
     expect(text).toBe("ok");
   });
 });
+
+describe("Response init non-finite status", () => {
+  test("status Infinity throws RangeError", () => {
+    expect(() => new Response(null, { status: Infinity })).toThrow(RangeError);
+  });
+
+  test("status NaN throws RangeError", () => {
+    expect(() => new Response(null, { status: NaN })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/String/fromCharCode.js
+++ b/tests/built-ins/String/fromCharCode.js
@@ -22,3 +22,27 @@ describe("String.fromCharCode", () => {
     expect(String.fromCharCode(-1)).toBe(String.fromCharCode(65535));
   });
 });
+
+describe("String.fromCharCode ToUint16 non-finite code units", () => {
+  test("Infinity maps to code unit 0", () => {
+    const s = String.fromCharCode(Infinity);
+    expect(s.length).toBe(1);
+    expect(s.charCodeAt(0)).toBe(0);
+  });
+
+  test("-Infinity maps to code unit 0", () => {
+    expect(String.fromCharCode(-Infinity).charCodeAt(0)).toBe(0);
+  });
+
+  test("NaN maps to code unit 0", () => {
+    expect(String.fromCharCode(NaN).charCodeAt(0)).toBe(0);
+  });
+
+  test("huge positive double reduces modulo 2^16", () => {
+    expect(String.fromCharCode(1e30).charCodeAt(0)).toBe(0);
+  });
+
+  test("huge negative double reduces modulo 2^16", () => {
+    expect(String.fromCharCode(-1e30).charCodeAt(0)).toBe(0);
+  });
+});

--- a/tests/built-ins/String/raw.js
+++ b/tests/built-ins/String/raw.js
@@ -69,3 +69,17 @@ describe("String.raw", () => {
     expect(() => String.raw(null)).toThrow(TypeError);
   });
 });
+
+describe("String.raw non-finite raw lengths", () => {
+  test("length -Infinity yields empty string", () => {
+    expect(String.raw({ raw: { length: -Infinity } })).toBe("");
+  });
+
+  test("length NaN yields empty string", () => {
+    expect(String.raw({ raw: { length: NaN } })).toBe("");
+  });
+
+  test("negative length yields empty string", () => {
+    expect(String.raw({ raw: { length: -5 } })).toBe("");
+  });
+});

--- a/tests/built-ins/TSV/parseChunk.js
+++ b/tests/built-ins/TSV/parseChunk.js
@@ -47,7 +47,7 @@ describe.runIf(hasTSV)("TSV.parseChunk", () => {
   });
 });
 
-describe("TSV.parseChunk non-finite offsets", () => {
+describe.runIf(hasTSV)("TSV.parseChunk non-finite offsets", () => {
   test("Infinity start offset does not crash", () => {
     expect(typeof TSV.parseChunk("a\tb\n1\t2", Infinity)).toBe("object");
   });

--- a/tests/built-ins/TSV/parseChunk.js
+++ b/tests/built-ins/TSV/parseChunk.js
@@ -46,3 +46,9 @@ describe.runIf(hasTSV)("TSV.parseChunk", () => {
     expect(() => TSV.parseChunk()).toThrow();
   });
 });
+
+describe("TSV.parseChunk non-finite offsets", () => {
+  test("Infinity start offset does not crash", () => {
+    expect(typeof TSV.parseChunk("a\tb\n1\t2", Infinity)).toBe("object");
+  });
+});

--- a/tests/built-ins/Temporal/Duration/from.js
+++ b/tests/built-ins/Temporal/Duration/from.js
@@ -30,3 +30,18 @@ describe.runIf(isTemporal)("Temporal.Duration.from", () => {
     expect(Temporal.Duration.from(d).toString()).toBe("PT17280000000000S");
   });
 });
+
+describe.runIf(typeof Temporal !== "undefined")("Temporal.Duration.from components beyond Int64", () => {
+  test("nanoseconds near the 2^53-second cap are preserved exactly", () => {
+    const d = Temporal.Duration.from({ nanoseconds: 9.007199254740991e24 });
+    expect(d.nanoseconds).toBe(9.007199254740991e24);
+  });
+
+  test("nanoseconds past the 2^53-second cap throw RangeError", () => {
+    expect(() => Temporal.Duration.from({ nanoseconds: 1e30 })).toThrow(RangeError);
+  });
+
+  test("non-integral fields throw RangeError", () => {
+    expect(() => Temporal.Duration.from({ seconds: 1.5 })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Temporal/Duration/prototype/add.js
+++ b/tests/built-ins/Temporal/Duration/prototype/add.js
@@ -7,10 +7,26 @@ const isTemporal = typeof Temporal !== "undefined";
 
 describe.runIf(isTemporal)("Temporal.Duration.prototype.add", () => {
   test("add()", () => {
-    const d1 = new Temporal.Duration(1, 0, 0, 5);
+    const d1 = new Temporal.Duration(0, 0, 0, 5);
     const d2 = new Temporal.Duration(0, 0, 0, 10);
     const sum = d1.add(d2);
-    expect(sum.years).toBe(1);
     expect(sum.days).toBe(15);
+  });
+
+  test("calendar units in either duration throw RangeError", () => {
+    expect(() => new Temporal.Duration(1).add({ days: 1 })).toThrow(RangeError);
+    expect(() => new Temporal.Duration(0, 0, 0, 1).add({ months: 1 })).toThrow(RangeError);
+  });
+
+  test("result is rebalanced to the larger of both largest units", () => {
+    const sum = Temporal.Duration.from({ seconds: 90 }).add({ milliseconds: 5500 });
+    expect(sum.seconds).toBe(95);
+    expect(sum.milliseconds).toBe(500);
+  });
+
+  test("rebalanced component rounding past 2^53 seconds throws RangeError", () => {
+    const one = Temporal.Duration.from({ nanoseconds: 9.007199254740991e24 });
+    const two = Temporal.Duration.from({ microseconds: 1_000_000 });
+    expect(() => one.add(two)).toThrow(RangeError);
   });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -202,3 +202,14 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(() => d.round({ smallestUnit: "months", relativeTo: { year: 2024, month: 2, day: 30 } })).toThrow();
   });
 });
+
+describe.runIf(typeof Temporal !== "undefined")("Temporal.Duration.prototype.round at the duration maximum", () => {
+  test("largest valid single-component durations round to day with zoned relativeTo throws RangeError", () => {
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
+    const options = { smallestUnit: "day", largestUnit: "day", relativeTo: zdt };
+    const maxUs = 9_007_199_254_740_991_475_711;
+    const d = Temporal.Duration.from({ microseconds: maxUs });
+    expect(d.microseconds).toBe(maxUs);
+    expect(() => d.round(options)).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Temporal/PlainDate/from.js
+++ b/tests/built-ins/Temporal/PlainDate/from.js
@@ -50,7 +50,7 @@ describe.runIf(isTemporal)("Temporal.PlainDate.from", () => {
   });
 });
 
-describe("Temporal.PlainDate.from non-finite fields", () => {
+describe.runIf(isTemporal)("Temporal.PlainDate.from non-finite fields", () => {
   test("year Infinity throws RangeError", () => {
     expect(() => Temporal.PlainDate.from({ year: Infinity, month: 1, day: 1 })).toThrow(RangeError);
   });

--- a/tests/built-ins/Temporal/PlainDate/from.js
+++ b/tests/built-ins/Temporal/PlainDate/from.js
@@ -49,3 +49,13 @@ describe.runIf(isTemporal)("Temporal.PlainDate.from", () => {
     expect(d.day).toBe(31);
   });
 });
+
+describe("Temporal.PlainDate.from non-finite fields", () => {
+  test("year Infinity throws RangeError", () => {
+    expect(() => Temporal.PlainDate.from({ year: Infinity, month: 1, day: 1 })).toThrow(RangeError);
+  });
+
+  test("year NaN throws RangeError", () => {
+    expect(() => Temporal.PlainDate.from({ year: NaN, month: 1, day: 1 })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Temporal/PlainDateTime/from.js
+++ b/tests/built-ins/Temporal/PlainDateTime/from.js
@@ -32,3 +32,9 @@ describe.runIf(isTemporal)("Temporal.PlainDateTime.from", () => {
     expect(dt.minute).toBe(45);
   });
 });
+
+describe("Temporal.PlainDateTime.from non-finite fields", () => {
+  test("hour Infinity throws RangeError", () => {
+    expect(() => Temporal.PlainDateTime.from({ year: 2026, month: 6, day: 11, hour: Infinity })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Temporal/PlainDateTime/from.js
+++ b/tests/built-ins/Temporal/PlainDateTime/from.js
@@ -33,7 +33,7 @@ describe.runIf(isTemporal)("Temporal.PlainDateTime.from", () => {
   });
 });
 
-describe("Temporal.PlainDateTime.from non-finite fields", () => {
+describe.runIf(isTemporal)("Temporal.PlainDateTime.from non-finite fields", () => {
   test("hour Infinity throws RangeError", () => {
     expect(() => Temporal.PlainDateTime.from({ year: 2026, month: 6, day: 11, hour: Infinity })).toThrow(RangeError);
   });

--- a/tests/built-ins/Temporal/PlainTime/from.js
+++ b/tests/built-ins/Temporal/PlainTime/from.js
@@ -19,3 +19,13 @@ describe.runIf(isTemporal)("Temporal.PlainTime.from", () => {
     expect(t.minute).toBe(30);
   });
 });
+
+describe("Temporal.PlainTime.from non-finite fields", () => {
+  test("hour Infinity throws RangeError", () => {
+    expect(() => Temporal.PlainTime.from({ hour: Infinity })).toThrow(RangeError);
+  });
+
+  test("minute NaN throws RangeError", () => {
+    expect(() => Temporal.PlainTime.from({ hour: 1, minute: NaN })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/Temporal/PlainTime/from.js
+++ b/tests/built-ins/Temporal/PlainTime/from.js
@@ -20,12 +20,19 @@ describe.runIf(isTemporal)("Temporal.PlainTime.from", () => {
   });
 });
 
-describe("Temporal.PlainTime.from non-finite fields", () => {
+describe.runIf(isTemporal)("Temporal.PlainTime.from non-finite fields", () => {
   test("hour Infinity throws RangeError", () => {
     expect(() => Temporal.PlainTime.from({ hour: Infinity })).toThrow(RangeError);
   });
 
   test("minute NaN throws RangeError", () => {
     expect(() => Temporal.PlainTime.from({ hour: 1, minute: NaN })).toThrow(RangeError);
+  });
+});
+
+describe.runIf(isTemporal)("Temporal.PlainTime.prototype.add large duration components", () => {
+  test("hours beyond Int32 wrap correctly into the clock", () => {
+    const t = Temporal.PlainTime.from({ hour: 0 }).add({ hours: 3000000001 });
+    expect(t.hour).toBe(1);
   });
 });

--- a/tests/built-ins/Temporal/PlainYearMonth/constructor.js
+++ b/tests/built-ins/Temporal/PlainYearMonth/constructor.js
@@ -48,7 +48,7 @@ describe.runIf(isTemporal)("Temporal.PlainYearMonth constructor", () => {
   });
 });
 
-describe("Temporal.PlainYearMonth constructor calendar argument position", () => {
+describe.runIf(isTemporal)("Temporal.PlainYearMonth constructor calendar argument position", () => {
   test("third argument is the calendar, not the reference day", () => {
     expect(new Temporal.PlainYearMonth(2000, 5, "iso8601").toString()).toBe("2000-05");
   });

--- a/tests/built-ins/Temporal/PlainYearMonth/constructor.js
+++ b/tests/built-ins/Temporal/PlainYearMonth/constructor.js
@@ -47,3 +47,13 @@ describe.runIf(isTemporal)("Temporal.PlainYearMonth constructor", () => {
     expect(() => new Temporal.PlainYearMonth(2024, 13)).toThrow(RangeError);
   });
 });
+
+describe("Temporal.PlainYearMonth constructor calendar argument position", () => {
+  test("third argument is the calendar, not the reference day", () => {
+    expect(new Temporal.PlainYearMonth(2000, 5, "iso8601").toString()).toBe("2000-05");
+  });
+
+  test("fourth argument is the reference ISO day", () => {
+    expect(new Temporal.PlainYearMonth(2000, 5, "iso8601", 7).toString()).toBe("2000-05");
+  });
+});

--- a/tests/built-ins/Temporal/PlainYearMonth/from.js
+++ b/tests/built-ins/Temporal/PlainYearMonth/from.js
@@ -62,7 +62,7 @@ describe.runIf(isTemporal)("Temporal.PlainYearMonth.from", () => {
   });
 });
 
-describe("Temporal.PlainYearMonth.from non-finite fields", () => {
+describe.runIf(isTemporal)("Temporal.PlainYearMonth.from non-finite fields", () => {
   test("year Infinity throws RangeError", () => {
     expect(() => Temporal.PlainYearMonth.from({ year: Infinity, month: 1 })).toThrow(RangeError);
   });

--- a/tests/built-ins/Temporal/PlainYearMonth/from.js
+++ b/tests/built-ins/Temporal/PlainYearMonth/from.js
@@ -61,3 +61,9 @@ describe.runIf(isTemporal)("Temporal.PlainYearMonth.from", () => {
     expect(ym.month).toBe(3);
   });
 });
+
+describe("Temporal.PlainYearMonth.from non-finite fields", () => {
+  test("year Infinity throws RangeError", () => {
+    expect(() => Temporal.PlainYearMonth.from({ year: Infinity, month: 1 })).toThrow(RangeError);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/at.js
+++ b/tests/built-ins/TypedArray/prototype/at.js
@@ -40,3 +40,9 @@ describe("TypedArray.prototype.at non-finite index", () => {
     expect(new Int8Array([1, 2]).at(-Infinity)).toBeUndefined();
   });
 });
+
+describe("TypedArray.prototype.at without an argument", () => {
+  test("missing index coerces to 0", () => {
+    expect(new Int8Array([5, 6]).at()).toBe(5);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/at.js
+++ b/tests/built-ins/TypedArray/prototype/at.js
@@ -30,3 +30,13 @@ describe("TypedArray.prototype.at", () => {
     expect(ta.at(-1)).toBe(30n);
   });
 });
+
+describe("TypedArray.prototype.at non-finite index", () => {
+  test("Infinity returns undefined", () => {
+    expect(new Int8Array([1, 2]).at(Infinity)).toBeUndefined();
+  });
+
+  test("-Infinity returns undefined", () => {
+    expect(new Int8Array([1, 2]).at(-Infinity)).toBeUndefined();
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/copyWithin.js
+++ b/tests/built-ins/TypedArray/prototype/copyWithin.js
@@ -56,3 +56,17 @@ describe("TypedArray.prototype.copyWithin", () => {
     expect(ta[4]).toBe(5n);
   });
 });
+
+describe("TypedArray.prototype.copyWithin non-finite arguments", () => {
+  test("Infinity target leaves the array unchanged", () => {
+    const ta = new Int8Array([1, 2, 3]);
+    ta.copyWithin(Infinity, 0);
+    expect(Array.from(ta)).toEqual([1, 2, 3]);
+  });
+
+  test("Infinity start leaves the array unchanged", () => {
+    const ta = new Int8Array([1, 2, 3]);
+    ta.copyWithin(0, Infinity);
+    expect(Array.from(ta)).toEqual([1, 2, 3]);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/fill.js
+++ b/tests/built-ins/TypedArray/prototype/fill.js
@@ -74,3 +74,17 @@ describe("TypedArray.prototype.fill", () => {
     });
   });
 });
+
+describe("TypedArray.prototype.fill non-finite range arguments", () => {
+  test("Infinity start leaves the array unchanged", () => {
+    const ta = new Int8Array([1, 2]);
+    ta.fill(9, Infinity);
+    expect(Array.from(ta)).toEqual([1, 2]);
+  });
+
+  test("-Infinity end leaves the array unchanged", () => {
+    const ta = new Int8Array([1, 2]);
+    ta.fill(9, 0, -Infinity);
+    expect(Array.from(ta)).toEqual([1, 2]);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/includes.js
+++ b/tests/built-ins/TypedArray/prototype/includes.js
@@ -60,3 +60,13 @@ describe("TypedArray.prototype.includes", () => {
     expect(ta.includes(undefined, fromIndex)).toBe(true);
   });
 });
+
+describe("TypedArray.prototype.includes non-finite fromIndex", () => {
+  test("Infinity fromIndex finds nothing", () => {
+    expect(new Int8Array([1, 2]).includes(1, Infinity)).toBe(false);
+  });
+
+  test("-Infinity fromIndex searches from the start", () => {
+    expect(new Int8Array([1, 2]).includes(2, -Infinity)).toBe(true);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/indexOf.js
+++ b/tests/built-ins/TypedArray/prototype/indexOf.js
@@ -58,3 +58,13 @@ describe("TypedArray.prototype.indexOf", () => {
     expect(ta.indexOf(2)).toBe(-1);
   });
 });
+
+describe("TypedArray.prototype.indexOf non-finite fromIndex", () => {
+  test("Infinity fromIndex finds nothing", () => {
+    expect(new Int8Array([1, 2]).indexOf(1, Infinity)).toBe(-1);
+  });
+
+  test("-Infinity fromIndex searches from the start", () => {
+    expect(new Int8Array([1, 2]).indexOf(2, -Infinity)).toBe(1);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/lastIndexOf.js
+++ b/tests/built-ins/TypedArray/prototype/lastIndexOf.js
@@ -43,3 +43,13 @@ describe("TypedArray.prototype.lastIndexOf", () => {
     expect(ta.lastIndexOf(undefined, fromIndex)).toBe(-1);
   });
 });
+
+describe("TypedArray.prototype.lastIndexOf non-finite fromIndex", () => {
+  test("-Infinity fromIndex finds nothing", () => {
+    expect(new Int8Array([1, 2]).lastIndexOf(1, -Infinity)).toBe(-1);
+  });
+
+  test("Infinity fromIndex searches from the end", () => {
+    expect(new Int8Array([1, 2]).lastIndexOf(1, Infinity)).toBe(0);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/slice.js
+++ b/tests/built-ins/TypedArray/prototype/slice.js
@@ -121,3 +121,13 @@ describe("TypedArray.prototype.slice", () => {
     expect(ta.slice(start).length).toBe(0);
   });
 });
+
+describe("TypedArray.prototype.slice non-finite range arguments", () => {
+  test("Infinity start yields an empty copy", () => {
+    expect(new Int8Array([1, 2]).slice(Infinity).length).toBe(0);
+  });
+
+  test("-Infinity start copies the whole array", () => {
+    expect(Array.from(new Int8Array([1, 2]).slice(-Infinity))).toEqual([1, 2]);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/subarray.js
+++ b/tests/built-ins/TypedArray/prototype/subarray.js
@@ -64,3 +64,13 @@ describe("TypedArray.prototype.subarray", () => {
     expect(sub[0]).toBe(99n);
   });
 });
+
+describe("TypedArray.prototype.subarray non-finite range arguments", () => {
+  test("Infinity begin yields an empty view", () => {
+    expect(new Int8Array([1, 2]).subarray(Infinity).length).toBe(0);
+  });
+
+  test("-Infinity begin keeps the full view", () => {
+    expect(new Int8Array([1, 2]).subarray(-Infinity).length).toBe(2);
+  });
+});

--- a/tests/built-ins/TypedArray/prototype/with.js
+++ b/tests/built-ins/TypedArray/prototype/with.js
@@ -62,3 +62,13 @@ describe("TypedArray.prototype.with", () => {
     });
   });
 });
+
+describe("TypedArray.prototype.with non-finite index", () => {
+  test("Infinity index throws RangeError", () => {
+    expect(() => new Int8Array([1, 2]).with(Infinity, 9)).toThrow(RangeError);
+  });
+
+  test("-Infinity index throws RangeError", () => {
+    expect(() => new Int8Array([1, 2]).with(-Infinity, 9)).toThrow(RangeError);
+  });
+});

--- a/tests/language/expressions/numeric-separators.js
+++ b/tests/language/expressions/numeric-separators.js
@@ -90,3 +90,13 @@ describe("numeric separators", () => {
   // decimal point or exponent) is rejected at lex time. These are tested via
   // the "Check numeric separator rejection" CI step in ci.yml and pr.yml.
 });
+
+describe("long integer literals are correctly rounded", () => {
+  test("literal one below the rounding midpoint rounds down", () => {
+    expect(9_007_199_254_740_991_475_711 === 9_007_199_254_740_990_951_424).toBe(true);
+  });
+
+  test("literal at the next representable double stays put", () => {
+    expect(9_007_199_254_740_992_000_000 - 9_007_199_254_740_990_951_424).toBe(1048576);
+  });
+});


### PR DESCRIPTION
## Summary

- Eliminates the "bare `Trunc()` on a script-controlled number" crash class: FPC's `Trunc` raises a range-check error on NaN/±Infinity in dev builds (`-Cr`) and silently produces garbage on aarch64/x86_64. `String.fromCharCode(Infinity)`, `String.raw({raw:{length:-Infinity}})`, `new Int8Array(2).at(Infinity)`, `Array.from({length: Infinity})`, `Temporal.PlainTime.from({hour: Infinity})`, and ~150 sibling call sites crashed or mis-evaluated.
- Adds spec-shaped coercion helpers to `Goccia.Utils` and routes every site through them: `ToUint16Value` (ES2026 §7.1.10), `ToIntegerValue`/`ToIntegerFromArgs` (§7.1.6, saturating), `ToLengthValue` (§7.1.22), `ToIntegerWithTruncationValue`/`...64Value` (Temporal §13.21 / ECMA-402 DefaultNumberOption — RangeError on non-finite), and `ToInt64Value` (FFI marshaling, NaN/±∞ → 0).
- Fixes the spec divergences the sweep unearthed: `Number.prototype.toFixed`/`toPrecision` throw `RangeError` instead of returning `''`; `Iterator.take`/`drop` reject NaN/−∞ limits; `Temporal.PlainYearMonth`'s constructor read `referenceISODay` from the calendar's argument slot; FFI integer marshaling uses ToInt32/ToUint32/Int64 wrapping on both the stack and GPR paths.
- Investigating the CI-reported `Duration/prototype/add/result-out-of-range-3.js` transition showed its old pass was platform-garbage luck and exposed three deeper gaps, all fixed: `Temporal.Duration`'s constructor/`from`/`compare` clipped components to Int64 (now BigInteger-backed via the shared `DurationFromObject` reader, preserving the full float64 range with `ToIntegerIfIntegral` semantics); `add`/`subtract` were component-wise (now spec `AddDurations`: calendar units throw, exact time summation, rebalancing to the larger default largest unit, float64 rounding of each balanced component); and `TBigInteger.FromDouble`/`ToDouble` plus long numeric-literal parsing were not exactly/correctly rounded (`BigInt(9e21)` crashed; `9007199254740991475711` parsed one ulp high — fixed with IEEE 754 bit decomposition, round-to-nearest-even, and an exact BigInteger path for >15-digit integer literals).
- Adds a `check-trunc-guards` pre-commit checker (lefthook) that rejects new `Trunc(...ToNumberLiteral...)` sites so the class cannot regrow; the one engine-internal remainder (`console.count`) is allowlisted with its guarantee documented.
- Non-goals: per-option range clamps for Intl digit options beyond non-finite rejection, and correctly-rounded parsing for fractional/exponent literals (only long integer literals are exact; the rest still go through FPC's `TryStrToFloat`).

- Review follow-ups: all 12 CodeRabbit threads addressed (`f9404e8f`, `98632506`) — notable real catches now fixed: `at()` without an argument returned undefined instead of element 0 (TypedArray and Array), `Array.prototype.at` ignored array-like lengths beyond MaxInt, PlainTime add/subtract overflowed Int64 for large duration components (now exact BigInteger math reduced modulo one day), and Intl.PluralRules was missing NumberFormat-style digit validation incl. negative values and min>max pairs.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full suite 10485/10485 (100%) in both interpreter and `--mode=bytecode` runs; every fixed surface has new `test()` scenarios in the same commits (String, TypedArray, Array, Iterator, Number, BigInt, JSON, Intl, Temporal incl. Duration add/round maxima, Response, CSV/TSV, FFI, numeric literals, testing library)
- [x] Updated documentation — no doc updates needed: behaviors now match the MDN/spec semantics the docs defer to; checker scripts are intentionally undocumented like their `check-doc-*` siblings
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — all unit-test binaries green after rebuild (BigInteger conversions, parser, value types)
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — hot-path coercions keep their inline expansion; the exact-literal path only triggers for integer literals longer than 15 digits

test262, diffed against the main-branch CI x86_64 baseline report (run 27371457946) and a clean local main build: **zero regressions anywhere; built-ins/Temporal +52, built-ins/Number +5, plus the original +34 across String/TypedArray/Iterator/intl402** — including `String/fromCharCode/S9.7_A1.js`, `S9.7_A2.1.js`, `String/raw/return-empty-string-if-length-is-negative-infinity.js`, `Duration/prototype/{add,subtract}/result-out-of-range-{1,3}.js`, `Instant/prototype/{add,subtract}/result-out-of-range.js`, and the `total-duration-nanoseconds-too-large` family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

