### PR TITLE
fix(json5): coerce boxed space, quote, and allow-list arguments in JSON5.stringify

### DIFF
--- a/source/units/Goccia.Builtins.JSON5.pas
+++ b/source/units/Goccia.Builtins.JSON5.pas
@@ -76,9 +76,12 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
+  Goccia.Values.NumberObjectValue,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
-  Goccia.Values.WrapperPrimitives;
+  Goccia.Values.WrapperPrimitives,
+  Goccia.VM.Exception;
 
 threadvar
   FStaticMembers: TArray<TGocciaMemberDefinition>;
@@ -323,13 +326,20 @@ begin
     Result := Replaced;
 end;
 
+// The upstream json5 stringifier never coerces quote explicitly, but every
+// use site (string concatenation, property-key lookup) applies ToString, so a
+// quote with a [[StringData]] slot honors a user-defined toString. Other
+// objects stay ignored: Goccia validates quote strictly to a single ' or ",
+// and no non-String wrapper can satisfy that.
 function TGocciaJSON5Builtin.ResolveQuoteChar(const AQuoteArg: TGocciaValue): Char;
 var
   QuoteText: string;
   QuoteValue: TGocciaValue;
 begin
   Result := #0;
-  QuoteValue := UnboxWrappedPrimitive(AQuoteArg);
+  QuoteValue := AQuoteArg;
+  if QuoteValue is TGocciaStringObjectValue then
+    QuoteValue := QuoteValue.ToStringLiteral;
   if not (QuoteValue is TGocciaStringLiteralValue) then
     Exit;
 
@@ -338,6 +348,10 @@ begin
     Result := QuoteText[1];
 end;
 
+// The upstream json5 stringifier coerces a space with a [[NumberData]] slot
+// via Number(space) and one with a [[StringData]] slot via String(space). The
+// object-level ToNumberLiteral/ToStringLiteral route through ToPrimitive, so
+// user-defined valueOf/toString are honored, matching JSON.stringify.
 function TGocciaJSON5Builtin.ResolveGap(const ASpaceArg: TGocciaValue): string;
 var
   SpaceNumber: Double;
@@ -345,25 +359,22 @@ var
   SpaceValue: TGocciaValue;
 begin
   Result := '';
-  SpaceValue := UnboxWrappedPrimitive(ASpaceArg);
+  SpaceValue := ASpaceArg;
+  if SpaceValue is TGocciaNumberObjectValue then
+    SpaceValue := SpaceValue.ToNumberLiteral
+  else if SpaceValue is TGocciaStringObjectValue then
+    SpaceValue := SpaceValue.ToStringLiteral;
+  // Clamp before Trunc so NaN, ±Infinity, and doubles beyond Integer range
+  // never reach Trunc.
   if SpaceValue is TGocciaNumberLiteralValue then
   begin
     SpaceNumber := SpaceValue.ToNumberLiteral.Value;
-    if Math.IsNaN(SpaceNumber) then
+    if Math.IsNaN(SpaceNumber) or (SpaceNumber < 1) then
       Exit;
-    if Math.IsInfinite(SpaceNumber) then
-    begin
-      if SpaceNumber > 0 then
-        SpaceCount := 10
-      else
-        Exit;
-    end
+    if SpaceNumber > 10 then
+      SpaceCount := 10
     else
       SpaceCount := Trunc(SpaceNumber);
-    if SpaceCount < 1 then
-      Exit;
-    if SpaceCount > 10 then
-      SpaceCount := 10;
     Result := StringOfChar(' ', SpaceCount);
   end
   else if SpaceValue is TGocciaStringLiteralValue then
@@ -384,12 +395,18 @@ begin
     (RootValue is TGocciaSymbolValue);
 end;
 
+// The upstream json5 stringifier admits primitive strings and numbers plus
+// Number/String wrappers as allow-list entries, coercing wrappers with
+// String(v) — so a user-defined toString is honored, never a raw slot read.
 function TGocciaJSON5Builtin.TryExtractAllowListKey(const AValue: TGocciaValue;
   out AKey: string): Boolean;
 var
   KeyValue: TGocciaValue;
 begin
-  KeyValue := UnboxWrappedPrimitive(AValue);
+  KeyValue := AValue;
+  if (KeyValue is TGocciaNumberObjectValue) or
+    (KeyValue is TGocciaStringObjectValue) then
+    KeyValue := KeyValue.ToStringLiteral;
   Result := (KeyValue is TGocciaStringLiteralValue) or
     (KeyValue is TGocciaNumberLiteralValue);
   if Result then
@@ -609,30 +626,30 @@ begin
   ReplacerArg := TGocciaUndefinedLiteralValue.UndefinedValue;
   SpaceArg := TGocciaUndefinedLiteralValue.UndefinedValue;
   UseOptionsObject := False;
-  if AArgs.Length >= 2 then
-  begin
-    ReplacerArg := AArgs.GetElement(1);
-    UseOptionsObject := (ReplacerArg is TGocciaObjectValue) and
-      not (ReplacerArg is TGocciaArrayValue) and
-      not ReplacerArg.IsCallable;
-    if UseOptionsObject then
-    begin
-      Options := TGocciaObjectValue(ReplacerArg);
-      ReplacerArg := Options.GetProperty(PROP_REPLACER);
-      SpaceArg := Options.GetProperty(PROP_SPACE);
-      QuoteChar := ResolveQuoteChar(Options.GetProperty(PROP_QUOTE));
-    end;
-  end;
-
-  if not UseOptionsObject and (AArgs.Length >= 3) then
-  begin
-    SpaceArg := AArgs.GetElement(2);
-  end;
-  Gap := ResolveGap(SpaceArg);
 
   try
-    if not UseOptionsObject and (AArgs.Length >= 2) then
+    // Quote/space coercion can run user valueOf/toString, so it must stay
+    // inside the error-normalization block.
+    if AArgs.Length >= 2 then
+    begin
       ReplacerArg := AArgs.GetElement(1);
+      UseOptionsObject := (ReplacerArg is TGocciaObjectValue) and
+        not (ReplacerArg is TGocciaArrayValue) and
+        not ReplacerArg.IsCallable;
+      if UseOptionsObject then
+      begin
+        Options := TGocciaObjectValue(ReplacerArg);
+        ReplacerArg := Options.GetProperty(PROP_REPLACER);
+        SpaceArg := Options.GetProperty(PROP_SPACE);
+        QuoteChar := ResolveQuoteChar(Options.GetProperty(PROP_QUOTE));
+      end;
+    end;
+
+    if not UseOptionsObject and (AArgs.Length >= 3) then
+    begin
+      SpaceArg := AArgs.GetElement(2);
+    end;
+    Gap := ResolveGap(SpaceArg);
 
     if not (ReplacerArg is TGocciaUndefinedLiteralValue) then
     begin
@@ -663,6 +680,8 @@ begin
       Result := TGocciaStringLiteralValue.Create(
         FStringifier.Stringify(Value, Gap, QuoteChar));
   except
+    on E: EGocciaBytecodeThrow do
+      raise TGocciaThrowValue.Create(E.ThrownValue);
     on E: TGocciaThrowValue do
       raise;
     on E: Exception do

--- a/tests/built-ins/JSON5/stringify.js
+++ b/tests/built-ins/JSON5/stringify.js
@@ -274,6 +274,15 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
     );
   });
 
+  test("quote as boxed String propagates toString exceptions", () => {
+    const quote = new String('"');
+    quote.toString = () => {
+      throw new RangeError("abrupt quote toString");
+    };
+
+    expect(() => JSON5.stringify({ a: 1 }, { quote })).toThrow(RangeError);
+  });
+
   test("allow-list boxed Number uses an overridden toString", () => {
     const key = new Number(3);
     key.toString = () => "a";
@@ -286,6 +295,24 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
     key.toString = () => "b";
 
     expect(JSON5.stringify({ a: 1, b: 2 }, [key])).toBe("{b:2}");
+  });
+
+  test("allow-list boxed Number propagates toString exceptions", () => {
+    const key = new Number(3);
+    key.toString = () => {
+      throw new RangeError("abrupt allow-list toString");
+    };
+
+    expect(() => JSON5.stringify({ a: 1, 3: 3 }, [key])).toThrow(RangeError);
+  });
+
+  test("allow-list boxed String propagates toString exceptions", () => {
+    const key = new String("a");
+    key.toString = () => {
+      throw new RangeError("abrupt allow-list toString");
+    };
+
+    expect(() => JSON5.stringify({ a: 1, b: 2 }, [key])).toThrow(RangeError);
   });
 
   test("throws on circular structures", () => {

--- a/tests/built-ins/JSON5/stringify.js
+++ b/tests/built-ins/JSON5/stringify.js
@@ -171,6 +171,123 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
     expect(JSON5.stringify({ ["a" + nbsp + "b"]: 1 })).toBe(`{'a${nbsp}b':1}`);
   });
 
+  test("space as boxed Number indents like the primitive", () => {
+    const obj = { a: 1, b: [1, 2] };
+
+    expect(JSON5.stringify(obj, null, new Number(2))).toBe(
+      JSON5.stringify(obj, null, 2),
+    );
+  });
+
+  test("space as boxed Number uses an overridden valueOf", () => {
+    const space = new Number(1);
+    space.valueOf = () => 4;
+
+    expect(JSON5.stringify({ a: 1 }, null, space)).toBe(
+      JSON5.stringify({ a: 1 }, null, 4),
+    );
+  });
+
+  test("space as boxed Number propagates valueOf exceptions", () => {
+    const space = new Number(4);
+    space.valueOf = () => {
+      throw new RangeError("abrupt valueOf");
+    };
+
+    expect(() => JSON5.stringify({ a: 1 }, null, space)).toThrow(RangeError);
+  });
+
+  test("space as boxed String indents like the primitive", () => {
+    const obj = { a: 1, b: [1, 2] };
+
+    expect(JSON5.stringify(obj, null, new String("xx"))).toBe(
+      JSON5.stringify(obj, null, "xx"),
+    );
+  });
+
+  test("space as boxed String uses an overridden toString without calling valueOf", () => {
+    const space = new String("xx");
+    space.toString = () => "--";
+    space.valueOf = () => {
+      throw new RangeError("valueOf must not be called");
+    };
+
+    expect(JSON5.stringify({ a: 1 }, null, space)).toBe(
+      JSON5.stringify({ a: 1 }, null, "--"),
+    );
+  });
+
+  test("space as boxed String propagates toString exceptions", () => {
+    const space = new String("xx");
+    space.toString = () => {
+      throw new RangeError("abrupt toString");
+    };
+
+    expect(() => JSON5.stringify({ a: 1 }, null, space)).toThrow(RangeError);
+  });
+
+  test("truncates a fractional space", () => {
+    const obj = { a: 1, b: [1, 2] };
+
+    expect(JSON5.stringify(obj, null, 5.99999)).toBe(
+      JSON5.stringify(obj, null, 5),
+    );
+  });
+
+  test("treats non-positive space as no indentation", () => {
+    expect(JSON5.stringify({ a: 1 }, null, 0)).toBe("{a:1}");
+    expect(JSON5.stringify({ a: 1 }, null, -4)).toBe("{a:1}");
+    expect(JSON5.stringify({ a: 1 }, null, -Infinity)).toBe("{a:1}");
+  });
+
+  test("clamps huge finite space to 10 spaces", () => {
+    const obj = { a: 1, b: [1, 2] };
+
+    expect(JSON5.stringify(obj, null, 2147483648)).toBe(
+      JSON5.stringify(obj, null, 10),
+    );
+    expect(JSON5.stringify(obj, null, 1e15)).toBe(
+      JSON5.stringify(obj, null, 10),
+    );
+  });
+
+  test("clamps boxed Number Infinity space to 10 spaces", () => {
+    const obj = { a: 1, b: [1, 2] };
+
+    expect(JSON5.stringify(obj, null, new Number(Infinity))).toBe(
+      JSON5.stringify(obj, null, 10),
+    );
+  });
+
+  test("quote as boxed String behaves like the primitive", () => {
+    expect(JSON5.stringify({ "a'": "1'" }, { quote: new String('"') })).toBe(
+      JSON5.stringify({ "a'": "1'" }, { quote: '"' }),
+    );
+  });
+
+  test("quote as boxed String uses an overridden toString", () => {
+    const quote = new String('"');
+    quote.toString = () => "'";
+
+    expect(JSON5.stringify({ "a'": "1'" }, { quote })).toBe(
+      JSON5.stringify({ "a'": "1'" }, { quote: "'" }),
+    );
+  });
+
+  test("allow-list boxed Number uses an overridden toString", () => {
+    const key = new Number(3);
+    key.toString = () => "a";
+
+    expect(JSON5.stringify({ a: 1, 3: 3 }, [key])).toBe("{a:1}");
+  });
+
+  test("allow-list boxed String uses an overridden toString", () => {
+    const key = new String("a");
+    key.toString = () => "b";
+
+    expect(JSON5.stringify({ a: 1, b: 2 }, [key])).toBe("{b:2}");
+  });
+
   test("throws on circular structures", () => {
     const objectValue = {};
     objectValue.self = objectValue;


### PR DESCRIPTION
## Summary

- `JSON5.stringify` unboxed Number/String wrapper arguments with a raw `[[NumberData]]`/`[[StringData]]` slot read, ignoring user-defined `valueOf`/`toString`. The upstream json5 reference coerces space with `Number(space)`/`String(space)`, allow-list entries with `String(v)`, and applies ToString to the quote option at every use site — so all three now route through the object-level `ToNumberLiteral`/`ToStringLiteral` (ToPrimitive), honoring user overrides and propagating their abrupt completions. Verified divergence before the fix: `const s = new Number(1); s.valueOf = () => 4;` indented 1 space instead of 4, and a throwing `valueOf` was silently ignored.
- `ResolveGap` now clamps before `Trunc` per the upstream `Math.min(10, Math.floor(space))`: NaN and values below 1 produce no indentation, anything above 10 clamps to 10. Previously a huge finite space (`2^31`, `1e15`) — or a `valueOf` returning one — reached Trunc-to-Integer and raised a fatal range-check error in dev builds.
- Quote and allow-list semantics were decided deliberately against the upstream reference (documented in unit comments): `ResolveQuoteChar` coerces `[[StringData]]` wrappers only (Goccia validates quote strictly to a single `'` or `"`, which no non-String wrapper can satisfy); `TryExtractAllowListKey` coerces both wrapper kinds via ToString, mirroring upstream `String(v)`.
- Argument coercion now runs user code, so it moved inside `JSON5Stringify`'s error-normalization block, which additionally rethrows `EGocciaBytecodeThrow` as `TGocciaThrowValue` so bytecode-mode user exceptions surface unmangled instead of as a generic TypeError (the propagation tests throw `RangeError` specifically so a mangled `TypeError` cannot pass).
- Non-goal: the value-serialization path (`TransformWithReplacer`/`TransformWithAllowList`/the shared stringifier) still slot-reads boxed values in both JSON and JSON5; that is a confirmed sibling divergence tracked as a separate follow-up. This mirrors the scope of the JSON-side fix on `claude/condescending-napier-a628b4` and has no code dependency on it.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — 13 new scenarios in `tests/built-ins/JSON5/stringify.js`; full suite 10,303/10,303 in both default and `--mode=bytecode`; `./format.pas --check` clean
- [x] Updated documentation — no doc changes needed: `docs/built-ins-data-formats.md` already states JSON5 has the same replacer/space semantics as JSON, which this fix makes true; the quote/allow-list decisions are documented as code comments at the decision sites
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)