### PR TITLE
fix(json): conform JSON.stringify array replacer to ES2026 §25.5.4 step 5

### DIFF
--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -493,10 +493,11 @@ var
   I: Integer;
   Item: string;
   PropertyList: TStringList;
+  Seen: TDictionary<string, Boolean>;
 begin
   PropertyList := TStringList.Create;
+  Seen := TDictionary<string, Boolean>.Create;
   try
-    PropertyList.CaseSensitive := True;
     for I := 0 to AAllowList.Elements.Count - 1 do
     begin
       // Step 5.b.ii: item stays undefined unless the element is a String or
@@ -512,12 +513,16 @@ begin
       if HasItem then
         Item := Element.ToStringLiteral.Value;
       // Step 5.b.ii: append only if PropertyList does not contain item.
-      if HasItem and (PropertyList.IndexOf(Item) = -1) then
+      if HasItem and not Seen.ContainsKey(Item) then
+      begin
+        Seen.Add(Item, True);
         PropertyList.Add(Item);
+      end;
     end;
 
     Result := FStringifier.Stringify(AValue, AGap, #0, PropertyList);
   finally
+    Seen.Free;
     PropertyList.Free;
   end;
 end;

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -62,7 +62,9 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
+  Goccia.Values.NumberObjectValue,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.WrapperPrimitives,
   Goccia.VM.Exception;

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -59,7 +59,9 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
+  Goccia.Values.NumberObjectValue,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.VM.Exception;
 
@@ -481,38 +483,43 @@ begin
   Result := FStringifier.Stringify(Transformed, AGap);
 end;
 
-// §25.5.2 steps 4-5: Stringify with an Array replacer (PropertyList filter).
-// When the replacer is an Array, only properties whose names appear in the
-// allow-list are included in the output (SerializeJSONObject step 6a).
+// §25.5.4 step 5: Stringify with an Array replacer (PropertyList filter).
+// PropertyList is part of the serializer state, so it filters every object
+// at every depth (SerializeJSONObject step 5), not just the root.
 function TGocciaJSONBuiltin.StringifyWithAllowList(const AValue: TGocciaValue; const AAllowList: TGocciaArrayValue; const AGap: string): string;
 var
-  Obj: TGocciaObjectValue;
-  Filtered: TGocciaObjectValue;
+  Element: TGocciaValue;
+  HasItem: Boolean;
   I: Integer;
-  Key: string;
-  PropValue: TGocciaValue;
+  Item: string;
+  PropertyList: TStringList;
 begin
-  // Non-object or Array values are serialized directly (PropertyList is ignored).
-  if not (AValue is TGocciaObjectValue) or (AValue is TGocciaArrayValue) then
-  begin
-    Result := FStringifier.Stringify(AValue, AGap);
-    Exit;
+  PropertyList := TStringList.Create;
+  try
+    PropertyList.CaseSensitive := True;
+    for I := 0 to AAllowList.Elements.Count - 1 do
+    begin
+      // Step 5.b.ii: item stays undefined unless the element is a String or
+      // Number primitive, or a String/Number wrapper object — converted via
+      // ? ToString(v), which may invoke a user-defined toString. Booleans,
+      // null, undefined, and plain objects are skipped.
+      Element := AAllowList.Elements[I];
+      Item := '';
+      HasItem := (Element is TGocciaStringLiteralValue) or
+        (Element is TGocciaNumberLiteralValue) or
+        (Element is TGocciaStringObjectValue) or
+        (Element is TGocciaNumberObjectValue);
+      if HasItem then
+        Item := Element.ToStringLiteral.Value;
+      // Step 5.b.ii: append only if PropertyList does not contain item.
+      if HasItem and (PropertyList.IndexOf(Item) = -1) then
+        PropertyList.Add(Item);
+    end;
+
+    Result := FStringifier.Stringify(AValue, AGap, #0, PropertyList);
+  finally
+    PropertyList.Free;
   end;
-
-  // Step 4b: Build PropertyList from the Array replacer elements.
-  Obj := TGocciaObjectValue(AValue);
-  Filtered := TGocciaObjectValue.Create;
-
-  // Step 5: For each element in PropertyList, include the property if it exists.
-  for I := 0 to AAllowList.Elements.Count - 1 do
-  begin
-    Key := AAllowList.Elements[I].ToStringLiteral.Value;
-    PropValue := Obj.GetProperty(Key);
-    if (PropValue <> nil) and not (PropValue is TGocciaUndefinedLiteralValue) then
-      Filtered.AssignProperty(Key, PropValue);
-  end;
-
-  Result := FStringifier.Stringify(Filtered, AGap);
 end;
 
 // §25.5.2 JSON.stringify ( value [ , replacer [ , space ] ] )

--- a/source/units/Goccia.Builtins.JSON5.pas
+++ b/source/units/Goccia.Builtins.JSON5.pas
@@ -46,7 +46,7 @@ type
       const APreferredQuoteChar: Char): string;
     function TransformWithAllowList(const AHolder: TGocciaValue;
       const AKey: string; const AValue: TGocciaValue;
-      const AAllowList: TGocciaArrayValue): TGocciaValue;
+      const AKeys: TStringList): TGocciaValue;
     function TransformWithReplacer(const AHolder: TGocciaValue;
       const AKey: string; const AValue: TGocciaValue;
       const AReplacer: TGocciaValue): TGocciaValue;
@@ -76,7 +76,9 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
+  Goccia.Values.NumberObjectValue,
   Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.WrapperPrimitives;
 
@@ -386,14 +388,16 @@ end;
 
 function TGocciaJSON5Builtin.TryExtractAllowListKey(const AValue: TGocciaValue;
   out AKey: string): Boolean;
-var
-  KeyValue: TGocciaValue;
 begin
-  KeyValue := UnboxWrappedPrimitive(AValue);
-  Result := (KeyValue is TGocciaStringLiteralValue) or
-    (KeyValue is TGocciaNumberLiteralValue);
+  // Upstream json5 reference: string/number primitives and String/Number
+  // wrapper objects contribute keys; String(v) on a wrapper honors a
+  // user-defined toString.
+  Result := (AValue is TGocciaStringLiteralValue) or
+    (AValue is TGocciaNumberLiteralValue) or
+    (AValue is TGocciaStringObjectValue) or
+    (AValue is TGocciaNumberObjectValue);
   if Result then
-    AKey := KeyValue.ToStringLiteral.Value
+    AKey := AValue.ToStringLiteral.Value
   else
     AKey := '';
 end;
@@ -430,33 +434,56 @@ function TGocciaJSON5Builtin.StringifyWithAllowList(const AValue: TGocciaValue;
   const AAllowList: TGocciaArrayValue; const AGap: string;
   const APreferredQuoteChar: Char): string;
 var
+  I: Integer;
+  Key: string;
+  Keys: TStringList;
   PreviousTraversalStack: TList<TGocciaObjectValue>;
   Root: TGocciaObjectValue;
+  Seen: TDictionary<string, Boolean>;
   Transformed: TGocciaValue;
 begin
-  Root := TGocciaObjectValue.Create;
-  Root.AssignProperty('', AValue);
-  PreviousTraversalStack := FReplacerTraversalStack;
-  FReplacerTraversalStack := TList<TGocciaObjectValue>.Create;
+  // Upstream json5 reference: the property list is extracted and de-duplicated
+  // once, before serialization, so a wrapper's toString runs once per element.
+  Keys := TStringList.Create;
+  Seen := TDictionary<string, Boolean>.Create;
   try
-    Transformed := TransformWithAllowList(Root, '', AValue, AAllowList);
-
-    if RootResultShouldBeUndefined(Transformed) then
+    for I := 0 to AAllowList.Elements.Count - 1 do
     begin
-      Result := '';
-      Exit;
+      if not TryExtractAllowListKey(AAllowList.Elements[I], Key) then
+        Continue;
+      if Seen.ContainsKey(Key) then
+        Continue;
+      Seen.Add(Key, True);
+      Keys.Add(Key);
     end;
 
-    Result := FStringifier.Stringify(Transformed, AGap, APreferredQuoteChar);
+    Root := TGocciaObjectValue.Create;
+    Root.AssignProperty('', AValue);
+    PreviousTraversalStack := FReplacerTraversalStack;
+    FReplacerTraversalStack := TList<TGocciaObjectValue>.Create;
+    try
+      Transformed := TransformWithAllowList(Root, '', AValue, Keys);
+
+      if RootResultShouldBeUndefined(Transformed) then
+      begin
+        Result := '';
+        Exit;
+      end;
+
+      Result := FStringifier.Stringify(Transformed, AGap, APreferredQuoteChar);
+    finally
+      FReplacerTraversalStack.Free;
+      FReplacerTraversalStack := PreviousTraversalStack;
+    end;
   finally
-    FReplacerTraversalStack.Free;
-    FReplacerTraversalStack := PreviousTraversalStack;
+    Seen.Free;
+    Keys.Free;
   end;
 end;
 
 function TGocciaJSON5Builtin.TransformWithAllowList(const AHolder: TGocciaValue;
   const AKey: string; const AValue: TGocciaValue;
-  const AAllowList: TGocciaArrayValue): TGocciaValue;
+  const AKeys: TStringList): TGocciaValue;
 var
   Arr: TGocciaArrayValue;
   I: Integer;
@@ -487,7 +514,7 @@ begin
       begin
         PropValue := Arr.Elements[I];
         TransformedProp := TransformWithAllowList(Arr, IntToStr(I), PropValue,
-          AAllowList);
+          AKeys);
         NewArr.Elements.Add(TransformedProp);
       end;
     finally
@@ -506,14 +533,13 @@ begin
     Obj := TGocciaObjectValue(TransformedValue);
     NewObj := TGocciaObjectValue.Create;
     try
-      for I := 0 to AAllowList.Elements.Count - 1 do
+      for I := 0 to AKeys.Count - 1 do
       begin
-        if not TryExtractAllowListKey(AAllowList.Elements[I], Key) then
-          Continue;
+        Key := AKeys[I];
         PropValue := Obj.GetProperty(Key);
         if PropValue = nil then
           Continue;
-        TransformedProp := TransformWithAllowList(Obj, Key, PropValue, AAllowList);
+        TransformedProp := TransformWithAllowList(Obj, Key, PropValue, AKeys);
         if not (TransformedProp is TGocciaUndefinedLiteralValue) then
           NewObj.AssignProperty(Key, TransformedProp);
       end;

--- a/source/units/Goccia.JSON.pas
+++ b/source/units/Goccia.JSON.pas
@@ -34,8 +34,10 @@ type
   TGocciaJSONStringifier = class
   private
     FGap: string;
+    FHasPropertyList: Boolean;
     FMode: TJSONStringifyMode;
     FPreferredQuoteChar: Char;
+    FPropertyList: TArray<string>;
     FTraversalStack: TList<TGocciaObjectValue>;
     class function IsIdentifierContinueText(const AText: string): Boolean; static;
     class function IsIdentifierStartText(const AText: string): Boolean; static;
@@ -56,7 +58,8 @@ type
     constructor Create; overload;
     constructor Create(const AMode: TJSONStringifyMode); overload;
     function Stringify(const AValue: TGocciaValue; const AGap: string = '';
-      const APreferredQuoteChar: Char = #0): string;
+      const APreferredQuoteChar: Char = #0;
+      const APropertyList: TStringList = nil): string;
   end;
 
 implementation
@@ -443,18 +446,34 @@ begin
 end;
 
 function TGocciaJSONStringifier.Stringify(const AValue: TGocciaValue;
-  const AGap: string; const APreferredQuoteChar: Char): string;
+  const AGap: string; const APreferredQuoteChar: Char;
+  const APropertyList: TStringList): string;
 var
+  I: Integer;
   PreviousGap: string;
+  PreviousHasPropertyList: Boolean;
   PreviousPreferredQuoteChar: Char;
+  PreviousPropertyList: TArray<string>;
   PreviousTraversalStack: TList<TGocciaObjectValue>;
 begin
   PreviousGap := FGap;
+  PreviousHasPropertyList := FHasPropertyList;
   PreviousPreferredQuoteChar := FPreferredQuoteChar;
+  PreviousPropertyList := FPropertyList;
   PreviousTraversalStack := FTraversalStack;
 
   FGap := AGap;
   FPreferredQuoteChar := APreferredQuoteChar;
+  // ES2026 §25.5.4 step 12: PropertyList lives in the JSON Serialization
+  // Record, so it applies to every object at every depth.
+  FHasPropertyList := Assigned(APropertyList);
+  FPropertyList := nil;
+  if FHasPropertyList then
+  begin
+    SetLength(FPropertyList, APropertyList.Count);
+    for I := 0 to APropertyList.Count - 1 do
+      FPropertyList[I] := APropertyList[I];
+  end;
   FTraversalStack := TList<TGocciaObjectValue>.Create;
   try
     Result := StringifyValue(AValue);
@@ -462,6 +481,8 @@ begin
     FTraversalStack.Free;
     FTraversalStack := PreviousTraversalStack;
     FPreferredQuoteChar := PreviousPreferredQuoteChar;
+    FPropertyList := PreviousPropertyList;
+    FHasPropertyList := PreviousHasPropertyList;
     FGap := PreviousGap;
   end;
 end;
@@ -781,6 +802,8 @@ function TGocciaJSONStringifier.StringifyObject(const AObj: TGocciaObjectValue; 
 var
   SB: TStringBuffer;
   Key: string;
+  Keys: TArray<string>;
+  PropValue: TGocciaValue;
   Value: TGocciaValue;
   HasProperties: Boolean;
   Separator, ChildIndent, CloseIndent: string;
@@ -807,9 +830,20 @@ begin
         CloseIndent := '';
       end;
 
-      for Key in AObj.GetEnumerablePropertyNames do
+      // ES2026 §25.5.4.5 SerializeJSONObject step 5: PropertyList replaces
+      // own-key enumeration; keys absent from the object serialize as
+      // undefined and are omitted below.
+      if FHasPropertyList then
+        Keys := FPropertyList
+      else
+        Keys := AObj.GetEnumerablePropertyNames;
+
+      for Key in Keys do
       begin
-        Value := ApplyToJSON(AObj.GetProperty(Key), Key);
+        PropValue := AObj.GetProperty(Key);
+        if PropValue = nil then
+          Continue;
+        Value := ApplyToJSON(PropValue, Key);
         if ShouldOmitObjectProperty(Value) then
           Continue;
 

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -277,3 +277,92 @@ test("JSON.stringify preserves enumerable property order", () => {
 
   expect(JSON.stringify(obj)).toBe('{"beta":2,"alpha":1,"gamma":3}');
 });
+
+test("JSON.stringify array replacer ignores boolean, null, undefined, and plain object elements", () => {
+  expect(JSON.stringify({ true: 1, a: 2 }, [true])).toBe("{}");
+  expect(JSON.stringify({ false: 1, a: 2 }, [false])).toBe("{}");
+  expect(JSON.stringify({ null: 1, a: 2 }, [null])).toBe("{}");
+  expect(JSON.stringify({ undefined: 1, a: 2 }, [undefined])).toBe("{}");
+  expect(JSON.stringify({ "[object Object]": 1, a: 2 }, [{}])).toBe("{}");
+});
+
+test("JSON.stringify array replacer does not call toString on plain object elements", () => {
+  const element = {
+    toString() {
+      return "toString";
+    },
+  };
+  expect(JSON.stringify({ toString: 1, a: 2 }, [element])).toBe("{}");
+});
+
+test("JSON.stringify array replacer filters nested objects at every depth", () => {
+  expect(JSON.stringify({ a: { a: 1, b: 2 }, b: 3 }, ["a"])).toBe(
+    '{"a":{"a":1}}',
+  );
+  expect(JSON.stringify({ a: { b: { a: 1, c: 2 }, a: 3 }, c: 4 }, ["a", "b"])).toBe(
+    '{"a":{"a":3,"b":{"a":1}}}',
+  );
+});
+
+test("JSON.stringify array replacer filters objects inside arrays", () => {
+  expect(JSON.stringify([{ a: 1, b: 2 }, { b: 3 }], ["a"])).toBe(
+    '[{"a":1},{}]',
+  );
+});
+
+test("JSON.stringify array replacer determines key order at every depth", () => {
+  expect(JSON.stringify({ a: { b: 2, c: 3 } }, ["c", "b", "a"])).toBe(
+    '{"a":{"c":3,"b":2}}',
+  );
+});
+
+test("JSON.stringify array replacer de-duplicates keys and reads each property once", () => {
+  let getCalls = 0;
+  const value = {
+    get key() {
+      getCalls += 1;
+      return true;
+    },
+  };
+  expect(JSON.stringify(value, ["key", "key"])).toBe('{"key":true}');
+  expect(getCalls).toBe(1);
+});
+
+test("JSON.stringify array replacer converts number elements with number-to-string semantics", () => {
+  const obj = { 0: 0, 1: 1, "-4": 2, 0.3: 3, "-Infinity": 4, NaN: 5 };
+  expect(JSON.stringify(obj, [-0, 1, -4, 0.3, -Infinity, NaN])).toBe(
+    '{"0":0,"1":1,"-4":2,"0.3":3,"-Infinity":4,"NaN":5}',
+  );
+});
+
+test("JSON.stringify array replacer converts String and Number wrapper elements via toString", () => {
+  const num = new Number(10);
+  num.toString = () => "toString";
+  num.valueOf = () => {
+    throw new Error("valueOf should not be called");
+  };
+  expect(JSON.stringify({ 10: 1, toString: 2 }, [num])).toBe('{"toString":2}');
+
+  const str = new String("str");
+  str.toString = () => "toString";
+  str.valueOf = () => {
+    throw new Error("valueOf should not be called");
+  };
+  expect(JSON.stringify({ str: 1, toString: 2 }, [str])).toBe('{"toString":2}');
+});
+
+test("JSON.stringify array replacer treats keys case-sensitively", () => {
+  expect(JSON.stringify({ a: 1, A: 2 }, ["A"])).toBe('{"A":2}');
+  expect(JSON.stringify({ a: 1, A: 2 }, ["a", "A"])).toBe('{"a":1,"A":2}');
+});
+
+test("JSON.stringify empty array replacer serializes objects as empty", () => {
+  expect(JSON.stringify({ a: 1 }, [])).toBe("{}");
+  expect(JSON.stringify({ a: { b: 1 } }, [])).toBe("{}");
+});
+
+test("JSON.stringify array replacer composes with indentation", () => {
+  expect(JSON.stringify({ a: { a: 1, b: 2 }, b: 3 }, ["a"], 2)).toBe(
+    '{\n  "a": {\n    "a": 1\n  }\n}',
+  );
+});

--- a/tests/built-ins/JSON5/stringify.js
+++ b/tests/built-ins/JSON5/stringify.js
@@ -181,4 +181,49 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
     expect(() => JSON5.stringify(objectValue)).toThrow(TypeError);
     expect(() => JSON5.stringify(arrayValue)).toThrow(TypeError);
   });
+
+  test("array replacer converts String and Number wrapper elements via toString", () => {
+    const num = new Number(10);
+    num.toString = () => "toString";
+    num.valueOf = () => {
+      throw new Error("valueOf should not be called");
+    };
+    expect(JSON5.stringify({ 10: 1, toString: 2 }, [num])).toBe(
+      "{toString:2}",
+    );
+
+    const str = new String("str");
+    str.toString = () => "toString";
+    str.valueOf = () => {
+      throw new Error("valueOf should not be called");
+    };
+    expect(JSON5.stringify({ str: 1, toString: 2 }, [str])).toBe(
+      "{toString:2}",
+    );
+  });
+
+  test("array replacer extracts each element key once even for nested objects", () => {
+    let calls = 0;
+    const key = new String("a");
+    key.toString = () => {
+      calls += 1;
+      return "a";
+    };
+    expect(JSON5.stringify({ a: { a: 1, b: 2 }, b: 3 }, [key])).toBe(
+      "{a:{a:1}}",
+    );
+    expect(calls).toBe(1);
+  });
+
+  test("array replacer de-duplicates keys and reads each property once", () => {
+    let getCalls = 0;
+    const value = {
+      get key() {
+        getCalls += 1;
+        return true;
+      },
+    };
+    expect(JSON5.stringify(value, ["key", "key"])).toBe("{key:true}");
+    expect(getCalls).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes two verified ES2026 §25.5.4 step 5 conformance gaps in `JSON.stringify`'s array-replacer path:
  - **Element-type filtering (step 5.b.ii):** PropertyList now contains only String/Number primitives and String/Number wrapper objects (converted via `? ToString(v)`, honoring a user-defined `toString` and never calling `valueOf`). Booleans, `null`, `undefined`, holes, and plain objects are skipped — `JSON.stringify({true:1,a:2}, [true])` now returns `'{}'` instead of `'{"true":1}'`.
  - **Nesting (steps 12–13 + SerializeJSONObject step 5):** PropertyList is threaded through `TGocciaJSONStringifier` state the way the spec's JSON Serialization Record does, so it filters every object at every depth instead of only a copy of the root — `JSON.stringify({a:{a:1,b:2},b:3}, ["a"])` now returns `'{"a":{"a":1}}'`.
  - PropertyList is also de-duplicated before any `Get` (each property getter is read once) and its order determines output key order at every depth, matching test262 `replacer-array-*` expectations.
- Follow-up review fixes: `JSON5.stringify`'s allow-list now matches the upstream json5 reference implementation (`String(v)` on a wrapper honors a user-defined `toString`; the key list is extracted and de-duplicated once before serialization instead of once per nested object), and PropertyList dedup in both builders uses a seen-set (O(n) instead of O(n²) on a user-controlled replacer array, order preserved).
- Merged `origin/main` twice, picking up the overlapping #749/#753/#756 boxed-argument coercion fixes. Main's `TryExtractAllowListKey` wrapper-`toString` fix was behaviorally equivalent; conflicts were resolved in favor of this branch's version, which additionally extracts the JSON5 key list once up front (so a wrapper's `toString` runs once per element rather than once per nested object). Both sides' new tests are kept and pass unchanged.
- Non-goals: the function-replacer path keeps its existing pre-transform approach; the pre-existing root-level `JSON.stringify(function(){})` → `"null"` (should be `undefined`) behavior is untouched.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — 12 new `test()` scenarios in `tests/built-ins/JSON/stringify.js` and 3 in `tests/built-ins/JSON5/stringify.js`; full suite passes 10,379/10,379 in both interpreted and `--mode=bytecode` after a clean rebuild following each merge
- [x] Updated documentation — reviewed `docs/built-ins-data-formats.md` / `docs/built-ins.md`; the existing replacer descriptions remain accurate, no changes needed
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — not applicable, no AST/scope/evaluator/value-type changes
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — not applicable, serialization changes only affect the array-replacer path

Spec basis: ES2026 §25.5.4 `JSON.stringify` step 5 and §25.5.4.5 `SerializeJSONObject` step 5 (via tc39-mcp); conformance scenarios mirrored from test262 `test/built-ins/JSON/stringify/replacer-array-*` (index SHA `05bb0329`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
