### PR TITLE
fix(scripts): avoid FPC ICE 200611011 in run_json5_test_suite.py builds

### DIFF
--- a/docs/contributing/tooling.md
+++ b/docs/contributing/tooling.md
@@ -105,6 +105,17 @@ Treat messages such as `Compilation raised exception internally` and
 investigate the reported Pascal source line after the same target still fails
 from a clean build.
 
+### Shared `-FU` Directories Across Programs — Internal Error 200611011
+
+FPC 3.2.2 aborts with `Fatal: Internal error 200611011` when a second program
+is compiled against the `.ppu` files another program left in a shared `-FU`
+unit-output directory (the inliner trips while recompiling a unit it loaded
+from the first program's build). This is why `build.pas` compiles every target
+into its own `build/compiled/targets/<target>` directory, and why
+`scripts/run_json5_test_suite.py` gives each program its own subdirectory of
+its build dir. Any script that compiles more than one program with
+`fpc @config.cfg` must use a separate `-FU` directory per program.
+
 ### `Int64` to `Double` Conversion on FPC 3.2.2
 
 FPC 3.2.2 has **two bugs** affecting `Int64` -> `Double` conversion. Bug A is a Delphi-mode front-end issue that affects **all platforms**. Bug B is an AArch64-specific codegen issue.

--- a/scripts/run_json5_test_suite.py
+++ b/scripts/run_json5_test_suite.py
@@ -76,42 +76,36 @@ def find_node_executable(explicit: str | None) -> str:
   raise FileNotFoundError("Node.js executable not found. Install `node` or pass --node.")
 
 
-def compile_harness(repo_root: Path, build_dir: Path) -> Path:
-  build_dir.mkdir(parents=True, exist_ok=True)
-  harness_source = repo_root / HARNESS_SOURCE_PATH
+def compile_program(repo_root: Path, build_dir: Path, source_path: Path) -> Path:
+  # Each program gets its own unit-output directory, mirroring build.pas:
+  # FPC 3.2.2 aborts with internal error 200611011 when a second program is
+  # compiled against the .ppu files another program left in a shared -FU dir.
+  # FPC names the binary after the .dpr stem, so the stem also names the dir.
+  program_name = source_path.stem
+  target_dir = build_dir / program_name
+  target_dir.mkdir(parents=True, exist_ok=True)
 
   run(
     [
       "fpc",
       "@config.cfg",
-      f"-FU{build_dir}",
-      f"-FE{build_dir}",
-      str(harness_source),
+      f"-FU{target_dir}",
+      f"-FE{target_dir}",
+      str(repo_root / source_path),
     ],
     cwd=repo_root,
   )
 
-  harness_name = "GocciaJSON5Check.exe" if sys.platform.startswith("win") else "GocciaJSON5Check"
-  return build_dir / harness_name
+  binary_name = f"{program_name}.exe" if sys.platform.startswith("win") else program_name
+  return target_dir / binary_name
+
+
+def compile_harness(repo_root: Path, build_dir: Path) -> Path:
+  return compile_program(repo_root, build_dir, HARNESS_SOURCE_PATH)
 
 
 def compile_test_runner(repo_root: Path, build_dir: Path) -> Path:
-  build_dir.mkdir(parents=True, exist_ok=True)
-  runner_source = repo_root / TEST_RUNNER_SOURCE_PATH
-
-  run(
-    [
-      "fpc",
-      "@config.cfg",
-      f"-FU{build_dir}",
-      f"-FE{build_dir}",
-      str(runner_source),
-    ],
-    cwd=repo_root,
-  )
-
-  runner_name = "GocciaTestRunner.exe" if sys.platform.startswith("win") else "GocciaTestRunner"
-  return build_dir / runner_name
+  return compile_program(repo_root, build_dir, TEST_RUNNER_SOURCE_PATH)
 
 
 def load_cases(repo_root: Path, suite_dir: Path, node_executable: str) -> list[dict]:


### PR DESCRIPTION
## Summary

- `python3 scripts/run_json5_test_suite.py` was broken: it compiled `GocciaJSON5Check` and `GocciaTestRunner` into one shared `-FU`/`-FE` directory, and FPC 3.2.2 aborts with `Internal error 200611011` when the second program recompiles `Goccia.Values.ClassHelper.pas` against the `.ppu` files the first program left behind (an inliner defect on cross-program ppu reuse — each program compiles fine alone with the same flags).
- The fix mirrors `build.pas`, which already isolates every target in its own `build/compiled/targets/<target>` unit-output dir: the script's two compiles were collapsed into one `compile_program` helper that gives each program its own subdirectory named after the `.dpr` stem (which FPC also uses for the binary name, so no separate program-name parameter).
- The shared-`-FU` pitfall is now documented in `docs/contributing/tooling.md` under Platform-Specific Pitfalls so other multi-program scripts don't re-trip it.
- Non-goals: no flag changes and no behavior changes for CI — the `json5-compliance` job passes prebuilt `--harness`/`--test-runner` binaries and never reaches the script's compile path.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — `python3 scripts/run_json5_test_suite.py` now builds and passes end to end: 84/84 upstream `json5/json5` parser cases, 10/10 stringify tests (46 assertions), exit 0
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — not applicable, no Pascal source changes
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — not applicable, tooling-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)