### PR TITLE
fix(json): spec-conformant boxed Number/String coercion during stringify serialization

### DIFF
--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -53,6 +53,8 @@ uses
   Math,
   SysUtils,
 
+  TextSemantics,
+
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
@@ -342,12 +344,14 @@ begin
       SpaceCount := Trunc(SpaceNumber);
     Result := StringOfChar(' ', SpaceCount);
   end
-  // Step 8: Else if space is a String, let gap be the first 10 characters.
+  // Step 8: Else if space is a String, let gap be the first 10 code units.
+  // Length() counts bytes, so it can only overestimate the code-unit count;
+  // UTF16Substring then truncates without splitting a UTF-8 sequence.
   else if Space is TGocciaStringLiteralValue then
   begin
     Result := Space.ToStringLiteral.Value;
     if Length(Result) > 10 then
-      Result := Copy(Result, 1, 10);
+      Result := UTF16Substring(Result, 0, 10);
   end;
   // Step 9: Else let gap be the empty string (already default).
 end;

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -60,9 +60,7 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
-  Goccia.Values.NumberObjectValue,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.WrapperPrimitives,
   Goccia.VM.Exception;
@@ -176,7 +174,7 @@ begin
       Result := InvokeCallable(AReviver, Args, AHolder);
     except
       on E: EGocciaBytecodeThrow do
-        raise TGocciaThrowValue.Create(E.ThrownValue);
+        ReraiseBytecodeThrow(E);
     end;
   finally
     Args.Free;
@@ -325,15 +323,11 @@ var
   SpaceCount: Integer;
 begin
   Result := '';
-  Space := ASpaceArg;
   // Step 6: If space is an Object with a [[NumberData]] slot, set space to
   // ? ToNumber(space); with a [[StringData]] slot, to ? ToString(space).
-  // The object-level ToNumberLiteral/ToStringLiteral route through ToPrimitive,
-  // so user-defined valueOf/toString are honored.
-  if Space is TGocciaNumberObjectValue then
-    Space := Space.ToNumberLiteral
-  else if Space is TGocciaStringObjectValue then
-    Space := Space.ToStringLiteral;
+  // A boxed Boolean unwraps to a boolean primitive, which matches neither
+  // branch below — same empty gap as leaving it boxed.
+  Space := CoerceWrappedPrimitive(ASpaceArg);
   // Step 7: If space is a Number, let gap be min(10, ToIntegerOrInfinity(space))
   // spaces. Clamp before Trunc so NaN, ±Infinity, and doubles beyond Integer
   // range never reach Trunc.
@@ -426,8 +420,7 @@ begin
     Exit;
   end;
 
-  // Steps 4.b-4.d: coerce Number/String wrappers via ToNumber/ToString;
-  // Boolean wrappers read [[BooleanData]].
+  // Steps 4.b-4.d: unwrap boxed primitives.
   Replaced := CoerceWrappedPrimitive(Replaced);
 
   // Step 4: If result is an Array, recursively serialize each element (SerializeJSONArray).
@@ -586,12 +579,13 @@ begin
     // Step 10-12: Create wrapper, set wrapper[""] = value, return SerializeJSONProperty(state, "", wrapper).
     Result := TGocciaStringLiteralValue.Create(FStringifier.Stringify(Value, Gap));
   except
-    on E: EGocciaBytecodeThrow do
-      raise TGocciaThrowValue.Create(E.ThrownValue);
     on E: TGocciaThrowValue do
       raise;
     on E: Exception do
+    begin
+      ReraiseBytecodeThrow(E);
       ThrowTypeError(Format(SErrorJSONStringifyError, [E.Message]), SSuggestJSONFormat);
+    end;
   end;
 end;
 

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -64,6 +64,7 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.WrapperPrimitives,
   Goccia.VM.Exception;
 
 threadvar
@@ -424,6 +425,10 @@ begin
     Result := Replaced;
     Exit;
   end;
+
+  // Steps 4.b-4.d: coerce Number/String wrappers via ToNumber/ToString;
+  // Boolean wrappers read [[BooleanData]].
+  Replaced := CoerceWrappedPrimitive(Replaced);
 
   // Step 4: If result is an Array, recursively serialize each element (SerializeJSONArray).
   if Replaced is TGocciaArrayValue then

--- a/source/units/Goccia.Builtins.JSON5.pas
+++ b/source/units/Goccia.Builtins.JSON5.pas
@@ -78,7 +78,8 @@ uses
   Goccia.Values.HoleValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
-  Goccia.Values.WrapperPrimitives;
+  Goccia.Values.WrapperPrimitives,
+  Goccia.VM.Exception;
 
 threadvar
   FStaticMembers: TArray<TGocciaMemberDefinition>;
@@ -268,7 +269,9 @@ var
 begin
   Replaced := ApplyToJSON(AValue, AKey);
   Replaced := ApplyReplacer(AHolder, AKey, Replaced, AReplacer);
-  Replaced := UnboxWrappedPrimitive(Replaced);
+  // ES2026 §25.5.4.2 steps 4.b-4.d: coerce Number/String wrappers via
+  // ToNumber/ToString; Boolean wrappers read [[BooleanData]].
+  Replaced := CoerceWrappedPrimitive(Replaced);
 
   if Replaced is TGocciaUndefinedLiteralValue then
   begin
@@ -469,7 +472,9 @@ var
   TransformedValue: TGocciaValue;
 begin
   TransformedValue := ApplyToJSON(AValue, AKey);
-  TransformedValue := UnboxWrappedPrimitive(TransformedValue);
+  // ES2026 §25.5.4.2 steps 4.b-4.d: coerce Number/String wrappers via
+  // ToNumber/ToString; Boolean wrappers read [[BooleanData]].
+  TransformedValue := CoerceWrappedPrimitive(TransformedValue);
 
   if TransformedValue is TGocciaUndefinedLiteralValue then
     Exit(TransformedValue);
@@ -663,6 +668,8 @@ begin
       Result := TGocciaStringLiteralValue.Create(
         FStringifier.Stringify(Value, Gap, QuoteChar));
   except
+    on E: EGocciaBytecodeThrow do
+      raise TGocciaThrowValue.Create(E.ThrownValue);
     on E: TGocciaThrowValue do
       raise;
     on E: Exception do

--- a/source/units/Goccia.Builtins.JSON5.pas
+++ b/source/units/Goccia.Builtins.JSON5.pas
@@ -269,8 +269,7 @@ var
 begin
   Replaced := ApplyToJSON(AValue, AKey);
   Replaced := ApplyReplacer(AHolder, AKey, Replaced, AReplacer);
-  // ES2026 §25.5.4.2 steps 4.b-4.d: coerce Number/String wrappers via
-  // ToNumber/ToString; Boolean wrappers read [[BooleanData]].
+  // ES2026 §25.5.4.2 steps 4.b-4.d: unwrap boxed primitives.
   Replaced := CoerceWrappedPrimitive(Replaced);
 
   if Replaced is TGocciaUndefinedLiteralValue then
@@ -472,8 +471,7 @@ var
   TransformedValue: TGocciaValue;
 begin
   TransformedValue := ApplyToJSON(AValue, AKey);
-  // ES2026 §25.5.4.2 steps 4.b-4.d: coerce Number/String wrappers via
-  // ToNumber/ToString; Boolean wrappers read [[BooleanData]].
+  // ES2026 §25.5.4.2 steps 4.b-4.d: unwrap boxed primitives.
   TransformedValue := CoerceWrappedPrimitive(TransformedValue);
 
   if TransformedValue is TGocciaUndefinedLiteralValue then
@@ -668,12 +666,13 @@ begin
       Result := TGocciaStringLiteralValue.Create(
         FStringifier.Stringify(Value, Gap, QuoteChar));
   except
-    on E: EGocciaBytecodeThrow do
-      raise TGocciaThrowValue.Create(E.ThrownValue);
     on E: TGocciaThrowValue do
       raise;
     on E: Exception do
+    begin
+      ReraiseBytecodeThrow(E);
       ThrowTypeError(Format(SErrorJSON5StringifyError, [E.Message]), SSuggestJSONFormat);
+    end;
   end;
 end;
 

--- a/source/units/Goccia.JSON.pas
+++ b/source/units/Goccia.JSON.pas
@@ -713,7 +713,9 @@ begin
   if AValue is TGocciaRawJSONValue then
     Exit(TGocciaRawJSONValue(AValue).RawText);
 
-  EffectiveValue := UnboxWrappedPrimitive(AValue);
+  // ES2026 §25.5.4.2 steps 4.b-4.d: coerce Number/String wrappers via
+  // ToNumber/ToString; Boolean wrappers read [[BooleanData]].
+  EffectiveValue := CoerceWrappedPrimitive(AValue);
 
   if EffectiveValue is TGocciaNullLiteralValue then
     Result := 'null'

--- a/source/units/Goccia.JSON.pas
+++ b/source/units/Goccia.JSON.pas
@@ -713,8 +713,7 @@ begin
   if AValue is TGocciaRawJSONValue then
     Exit(TGocciaRawJSONValue(AValue).RawText);
 
-  // ES2026 §25.5.4.2 steps 4.b-4.d: coerce Number/String wrappers via
-  // ToNumber/ToString; Boolean wrappers read [[BooleanData]].
+  // ES2026 §25.5.4.2 steps 4.b-4.d: unwrap boxed primitives.
   EffectiveValue := CoerceWrappedPrimitive(AValue);
 
   if EffectiveValue is TGocciaNullLiteralValue then

--- a/source/units/Goccia.VM.Exception.pas
+++ b/source/units/Goccia.VM.Exception.pas
@@ -43,11 +43,25 @@ type
     property ThrownValue: TGocciaValue read FThrownValue;
   end;
 
+// A JS throw escaping the bytecode VM through a native builtin arrives as
+// EGocciaBytecodeThrow, which a builtin's generic Exception→TypeError
+// normalization would misclassify as an engine error. Call this first in
+// such handlers: it re-raises a bytecode throw as the catchable
+// TGocciaThrowValue and does nothing for any other exception.
+procedure ReraiseBytecodeThrow(const AException: Exception);
+
 implementation
 
 uses
   Goccia.Constants.PropertyNames,
+  Goccia.Values.Error,
   Goccia.Values.ObjectValue;
+
+procedure ReraiseBytecodeThrow(const AException: Exception);
+begin
+  if AException is EGocciaBytecodeThrow then
+    raise TGocciaThrowValue.Create(EGocciaBytecodeThrow(AException).ThrownValue);
+end;
 
 procedure TGocciaBytecodeHandlerStack.Push(const ACatchIP: Integer;
   const ACatchRegister: UInt8; const AFrameDepth: Integer);

--- a/source/units/Goccia.Values.WrapperPrimitives.pas
+++ b/source/units/Goccia.Values.WrapperPrimitives.pas
@@ -9,6 +9,12 @@ uses
 
 function UnboxWrappedPrimitive(const AValue: TGocciaValue): TGocciaValue;
 
+// ES2026 §25.5.4.2 SerializeJSONProperty steps 4.b-4.d: Number wrappers
+// coerce via ToNumber and String wrappers via ToString — both route through
+// ToPrimitive, so user-defined valueOf/toString are honored and may throw —
+// while Boolean wrappers read [[BooleanData]] directly.
+function CoerceWrappedPrimitive(const AValue: TGocciaValue): TGocciaValue;
+
 implementation
 
 uses
@@ -22,6 +28,18 @@ begin
     Result := TGocciaNumberObjectValue(AValue).Primitive
   else if AValue is TGocciaStringObjectValue then
     Result := TGocciaStringObjectValue(AValue).Primitive
+  else if AValue is TGocciaBooleanObjectValue then
+    Result := TGocciaBooleanObjectValue(AValue).Primitive
+  else
+    Result := AValue;
+end;
+
+function CoerceWrappedPrimitive(const AValue: TGocciaValue): TGocciaValue;
+begin
+  if AValue is TGocciaNumberObjectValue then
+    Result := AValue.ToNumberLiteral
+  else if AValue is TGocciaStringObjectValue then
+    Result := AValue.ToStringLiteral
   else if AValue is TGocciaBooleanObjectValue then
     Result := TGocciaBooleanObjectValue(AValue).Primitive
   else

--- a/source/units/Goccia.Values.WrapperPrimitives.pas
+++ b/source/units/Goccia.Values.WrapperPrimitives.pas
@@ -40,10 +40,8 @@ begin
     Result := AValue.ToNumberLiteral
   else if AValue is TGocciaStringObjectValue then
     Result := AValue.ToStringLiteral
-  else if AValue is TGocciaBooleanObjectValue then
-    Result := TGocciaBooleanObjectValue(AValue).Primitive
   else
-    Result := AValue;
+    Result := UnboxWrappedPrimitive(AValue);
 end;
 
 end.

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -379,3 +379,61 @@ test("JSON.stringify preserves enumerable property order", () => {
 
   expect(JSON.stringify(obj)).toBe('{"beta":2,"alpha":1,"gamma":3}');
 });
+
+test("JSON.stringify value as boxed Number uses an overridden valueOf", () => {
+  const boxed = new Number(1);
+  boxed.valueOf = () => 4;
+
+  expect(JSON.stringify({ a: boxed })).toBe('{"a":4}');
+  expect(JSON.stringify(boxed)).toBe("4");
+});
+
+test("JSON.stringify value as boxed Number uses an overridden valueOf with a replacer function", () => {
+  const boxed = new Number(1);
+  boxed.valueOf = () => 4;
+
+  expect(JSON.stringify({ a: boxed }, (key, value) => value)).toBe('{"a":4}');
+});
+
+test("JSON.stringify value as boxed Number uses an overridden valueOf with an array replacer", () => {
+  const boxed = new Number(1);
+  boxed.valueOf = () => 4;
+
+  expect(JSON.stringify({ a: boxed, b: 2 }, ["a"])).toBe('{"a":4}');
+});
+
+test("JSON.stringify value as boxed String uses an overridden toString without calling valueOf", () => {
+  const boxed = new String("ab");
+  boxed.toString = () => "zz";
+  boxed.valueOf = () => {
+    throw new TypeError("valueOf must not be called");
+  };
+
+  expect(JSON.stringify([boxed])).toBe('["zz"]');
+});
+
+test("JSON.stringify value as boxed Boolean ignores valueOf and toString", () => {
+  const boxed = new Boolean(false);
+  boxed.valueOf = () => true;
+  boxed.toString = () => "true";
+
+  expect(JSON.stringify([boxed])).toBe("[false]");
+});
+
+test("JSON.stringify value as boxed Number propagates valueOf exceptions", () => {
+  const boxed = new Number(1);
+  boxed.valueOf = () => {
+    throw new RangeError("abrupt valueOf");
+  };
+
+  expect(() => JSON.stringify({ a: boxed })).toThrow(RangeError);
+});
+
+test("JSON.stringify value as boxed String propagates toString exceptions", () => {
+  const boxed = new String("ab");
+  boxed.toString = () => {
+    throw new RangeError("abrupt toString");
+  };
+
+  expect(() => JSON.stringify([boxed])).toThrow(RangeError);
+});

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -437,3 +437,19 @@ test("JSON.stringify value as boxed String propagates toString exceptions", () =
 
   expect(() => JSON.stringify([boxed])).toThrow(RangeError);
 });
+
+test("JSON.stringify keeps a short multibyte string space intact", () => {
+  const obj = { a: 1 };
+
+  expect(JSON.stringify(obj, null, "ααααααα")).toBe(
+    '{\n' + "ααααααα" + '"a": 1\n}',
+  );
+});
+
+test("JSON.stringify truncates a long multibyte string space to 10 characters", () => {
+  const obj = { a: 1 };
+
+  expect(JSON.stringify(obj, null, "あ".repeat(12))).toBe(
+    JSON.stringify(obj, null, "あ".repeat(10)),
+  );
+});

--- a/tests/built-ins/JSON5/stringify.js
+++ b/tests/built-ins/JSON5/stringify.js
@@ -171,6 +171,64 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
     expect(JSON5.stringify({ ["a" + nbsp + "b"]: 1 })).toBe(`{'a${nbsp}b':1}`);
   });
 
+  test("uses an overridden valueOf on boxed Number values", () => {
+    const boxed = new Number(1);
+    boxed.valueOf = () => 4;
+
+    expect(JSON5.stringify({ a: boxed })).toBe("{a:4}");
+    expect(JSON5.stringify(boxed)).toBe("4");
+  });
+
+  test("uses an overridden valueOf on boxed Number values with a replacer function", () => {
+    const boxed = new Number(1);
+    boxed.valueOf = () => 4;
+
+    expect(JSON5.stringify({ a: boxed }, (key, value) => value)).toBe("{a:4}");
+  });
+
+  test("uses an overridden valueOf on boxed Number values with an array replacer", () => {
+    const boxed = new Number(1);
+    boxed.valueOf = () => 4;
+
+    expect(JSON5.stringify({ a: boxed, b: 2 }, ["a"])).toBe("{a:4}");
+  });
+
+  test("uses an overridden toString on boxed String values without calling valueOf", () => {
+    const boxed = new String("ab");
+    boxed.toString = () => "zz";
+    boxed.valueOf = () => {
+      throw new TypeError("valueOf must not be called");
+    };
+
+    expect(JSON5.stringify([boxed])).toBe("['zz']");
+  });
+
+  test("reads boxed Boolean values directly, ignoring valueOf and toString", () => {
+    const boxed = new Boolean(false);
+    boxed.valueOf = () => true;
+    boxed.toString = () => "true";
+
+    expect(JSON5.stringify([boxed])).toBe("[false]");
+  });
+
+  test("propagates valueOf exceptions from boxed Number values", () => {
+    const boxed = new Number(1);
+    boxed.valueOf = () => {
+      throw new RangeError("abrupt valueOf");
+    };
+
+    expect(() => JSON5.stringify({ a: boxed })).toThrow(RangeError);
+  });
+
+  test("propagates toString exceptions from boxed String values", () => {
+    const boxed = new String("ab");
+    boxed.toString = () => {
+      throw new RangeError("abrupt toString");
+    };
+
+    expect(() => JSON5.stringify([boxed])).toThrow(RangeError);
+  });
+
   test("throws on circular structures", () => {
     const objectValue = {};
     objectValue.self = objectValue;


### PR DESCRIPTION
## Summary

- `JSON.stringify` and `JSON5.stringify` unwrapped boxed `Number`/`String` values via raw internal-slot reads, ignoring user-defined `valueOf`/`toString`: `const v = new Number(1); v.valueOf = () => 4; JSON.stringify({a: v})` returned `{"a":1}` instead of `{"a":4}`. Per ES2026 SerializeJSONProperty (`sec-serializejsonproperty`, §25.5.4.2 steps 4.b–4.c), wrappers with `[[NumberData]]` coerce via `ToNumber` and wrappers with `[[StringData]]` via `ToString`, both routing through `ToPrimitive` so overridden methods are honored and abrupt completions propagate as catchable JS errors. Boxed `Boolean` keeps reading `[[BooleanData]]` directly (step 4.d). This also matches the upstream json5 reference implementation (`serializeProperty` uses `Number(value)`/`String(value)`).
- Adds `CoerceWrappedPrimitive` alongside `UnboxWrappedPrimitive` and uses it in the shared stringifier (`StringifyPreparedValue`, covering the no-replacer and JSON allow-list paths) and in the replacer/allow-list transforms of both builtins. The JSON function-replacer path previously recursed into wrappers as plain objects (producing `{"a":{}}`); it now coerces at the spec's step order (toJSON → replacer → IsRawJSON → wrapper coercion → recursion). JSON's `ResolveGap` reuses the new helper instead of inlining the identical coercion.
- Fixes a review finding in JSON's `ResolveGap`: the string space argument was truncated with a byte-based `Copy(Result, 1, 10)`, losing characters from multibyte spaces (7 two-byte characters became 5) and able to emit invalid UTF-8 by splitting a sequence. It now takes the first 10 code units via the shared `UTF16Substring` (sec-json.stringify step 8 semantics).
- Abrupt `valueOf`/`toString` completions stay catchable in both engine modes: the bytecode-VM carrier conversion (`EGocciaBytecodeThrow` → `TGocciaThrowValue`) now lives in one shared `ReraiseBytecodeThrow` procedure in `Goccia.VM.Exception`, replacing the per-builtin copies in `JSONStringify`, `JSON5Stringify`, and JSON's `ApplyReviver`. The branch is merged up with main's JSON5 argument-coercion work (#755-era changes), and `JSON5Stringify`'s except block is consolidated onto the shared helper.
- Non-goals: deeper normalization of the bytecode-throw carrier (in `InvokeCallable` or via exception-class subclassing) was evaluated and deliberately avoided — the former adds an exception frame to the native→JS callback hot path, the latter changes handler-matching semantics across the VM's except blocks.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — 7 new tests each in `tests/built-ins/JSON/stringify.js` and `tests/built-ins/JSON5/stringify.js` for boxed-value serialization (overridden `valueOf` across no-replacer/function-replacer/array-replacer paths, `toString` without `valueOf`, Boolean slot read ignoring both, abrupt-completion propagation; scenarios mirror test262's `value-number-object.js` / `value-string-object.js` / `value-boolean-object.js`), plus 2 regression tests for multibyte string spaces. Full suite passes 10,365/10,365 in both default and `--mode=bytecode` after a clean build (post-merge with main), with the FFI fixture built.
- [ ] Updated documentation — not applicable: no API surface or behavior contract documented in `docs/` changes; this is a conformance fix to documented JSON/JSON5 semantics.
- [ ] Optional: native Pascal tests — not applicable (no AST, scope, evaluator, or value-type structural changes; the new helpers are exercised through the JS suite).
- [ ] Optional: benchmarks — not applicable: the non-wrapper fast path is unchanged (same `is`-check sequence as before); coercion work only runs for boxed wrappers, where it is spec-required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
