### PR TITLE
fix(json): align stringify root and array semantics

### DIFF
--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -66,6 +66,7 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.ToObject,
   Goccia.Values.WrapperPrimitives,
   Goccia.VM.Exception;
 
@@ -405,6 +406,7 @@ var
   NewArr: TGocciaArrayValue;
   Key: string;
   I: Integer;
+  Len: Integer;
 begin
   // Step 1: Apply a toJSON hook before the replacer sees the value.
   Replaced := ApplyToJSON(AValue, AKey);
@@ -429,6 +431,12 @@ begin
   // Steps 4.b-4.d: unwrap boxed primitives.
   Replaced := CoerceWrappedPrimitive(Replaced);
 
+  if Replaced.IsCallable or (Replaced is TGocciaSymbolValue) then
+  begin
+    Result := Replaced;
+    Exit;
+  end;
+
   // Step 4: If result is an Array, recursively serialize each element (SerializeJSONArray).
   if Replaced is TGocciaArrayValue then
   begin
@@ -439,9 +447,10 @@ begin
     Arr := TGocciaArrayValue(Replaced);
     NewArr := TGocciaArrayValue.Create;
     try
-      for I := 0 to Arr.Elements.Count - 1 do
+      Len := LengthOfArrayLike(Arr);
+      for I := 0 to Len - 1 do
       begin
-        PropValue := Arr.Elements[I];
+        PropValue := Arr.GetProperty(IntToStr(I));
         TransformedProp := TransformWithReplacer(Arr, IntToStr(I), PropValue, AReplacer);
         NewArr.Elements.Add(TransformedProp);
       end;
@@ -464,8 +473,10 @@ begin
       begin
         PropValue := Obj.GetProperty(Key);
         TransformedProp := TransformWithReplacer(Obj, Key, PropValue, AReplacer);
-        // Omit properties whose replacer result is undefined.
-        if not (TransformedProp is TGocciaUndefinedLiteralValue) then
+        // Omit properties whose replacer result cannot appear in JSON objects.
+        if not ((TransformedProp is TGocciaUndefinedLiteralValue) or
+          TransformedProp.IsCallable or
+          (TransformedProp is TGocciaSymbolValue)) then
           NewObj.AssignProperty(Key, TransformedProp);
       end;
     finally
@@ -511,19 +522,21 @@ var
   HasItem: Boolean;
   I: Integer;
   Item: string;
+  Len: Integer;
   PropertyList: TStringList;
   Seen: TDictionary<string, Boolean>;
 begin
   PropertyList := TStringList.Create;
   Seen := TDictionary<string, Boolean>.Create;
   try
-    for I := 0 to AAllowList.Elements.Count - 1 do
+    Len := LengthOfArrayLike(AAllowList);
+    for I := 0 to Len - 1 do
     begin
       // Step 5.b.ii: item stays undefined unless the element is a String or
       // Number primitive, or a String/Number wrapper object — converted via
       // ? ToString(v), which may invoke a user-defined toString. Booleans,
       // null, undefined, and plain objects are skipped.
-      Element := AAllowList.Elements[I];
+      Element := AAllowList.GetProperty(IntToStr(I));
       Item := '';
       HasItem := (Element is TGocciaStringLiteralValue) or
         (Element is TGocciaNumberLiteralValue) or
@@ -551,18 +564,12 @@ function TGocciaJSONBuiltin.JSONStringify(const AArgs: TGocciaArgumentsCollectio
 var
   Value, ReplacerArg, SpaceArg: TGocciaValue;
   Gap: string;
+  Stringified: string;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON.stringify', ThrowError);
 
   // Step 1: Let state be { ReplacerFunction: undefined, PropertyList: undefined, Indent: "", Gap: "" }.
   Value := AArgs.GetElement(0);
-
-  // Undefined values produce undefined (not "undefined").
-  if Value is TGocciaUndefinedLiteralValue then
-  begin
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    Exit;
-  end;
 
   Gap := '';
   try
@@ -581,19 +588,31 @@ begin
       // Step 2: If replacer is callable, set state.ReplacerFunction.
       if ReplacerArg.IsCallable then
       begin
-        Result := TGocciaStringLiteralValue.Create(StringifyWithReplacer(Value, ReplacerArg, Gap));
+        Stringified := StringifyWithReplacer(Value, ReplacerArg, Gap);
+        if Stringified = '' then
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue
+        else
+          Result := TGocciaStringLiteralValue.Create(Stringified);
         Exit;
       end
       // Steps 4-5: If replacer is an Array, build state.PropertyList.
       else if ReplacerArg is TGocciaArrayValue then
       begin
-        Result := TGocciaStringLiteralValue.Create(StringifyWithAllowList(Value, TGocciaArrayValue(ReplacerArg), Gap));
+        Stringified := StringifyWithAllowList(Value, TGocciaArrayValue(ReplacerArg), Gap);
+        if Stringified = '' then
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue
+        else
+          Result := TGocciaStringLiteralValue.Create(Stringified);
         Exit;
       end;
     end;
 
     // Step 10-12: Create wrapper, set wrapper[""] = value, return SerializeJSONProperty(state, "", wrapper).
-    Result := TGocciaStringLiteralValue.Create(FStringifier.Stringify(Value, Gap));
+    Stringified := FStringifier.Stringify(Value, Gap);
+    if Stringified = '' then
+      Result := TGocciaUndefinedLiteralValue.UndefinedValue
+    else
+      Result := TGocciaStringLiteralValue.Create(Stringified);
   except
     on E: TGocciaThrowValue do
       raise;

--- a/source/units/Goccia.Builtins.JSON5.pas
+++ b/source/units/Goccia.Builtins.JSON5.pas
@@ -80,6 +80,7 @@ uses
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.ToObject,
   Goccia.Values.WrapperPrimitives,
   Goccia.VM.Exception;
 
@@ -268,6 +269,7 @@ var
   PropValue: TGocciaValue;
   Replaced: TGocciaValue;
   TransformedProp: TGocciaValue;
+  Len: Integer;
 begin
   Replaced := ApplyToJSON(AValue, AKey);
   Replaced := ApplyReplacer(AHolder, AKey, Replaced, AReplacer);
@@ -275,6 +277,12 @@ begin
   Replaced := CoerceWrappedPrimitive(Replaced);
 
   if Replaced is TGocciaUndefinedLiteralValue then
+  begin
+    Result := Replaced;
+    Exit;
+  end;
+
+  if Replaced.IsCallable or (Replaced is TGocciaSymbolValue) then
   begin
     Result := Replaced;
     Exit;
@@ -289,9 +297,10 @@ begin
     Arr := TGocciaArrayValue(Replaced);
     NewArr := TGocciaArrayValue.Create;
     try
-      for I := 0 to Arr.Elements.Count - 1 do
+      Len := LengthOfArrayLike(Arr);
+      for I := 0 to Len - 1 do
       begin
-        PropValue := Arr.Elements[I];
+        PropValue := Arr.GetProperty(IntToStr(I));
         TransformedProp := TransformWithReplacer(Arr, IntToStr(I), PropValue,
           AReplacer);
         NewArr.Elements.Add(TransformedProp);
@@ -315,7 +324,9 @@ begin
       begin
         PropValue := Obj.GetProperty(Key);
         TransformedProp := TransformWithReplacer(Obj, Key, PropValue, AReplacer);
-        if not (TransformedProp is TGocciaUndefinedLiteralValue) then
+        if not ((TransformedProp is TGocciaUndefinedLiteralValue) or
+          TransformedProp.IsCallable or
+          (TransformedProp is TGocciaSymbolValue)) then
           NewObj.AssignProperty(Key, TransformedProp);
       end;
     finally
@@ -447,6 +458,7 @@ var
   I: Integer;
   Key: string;
   Keys: TStringList;
+  Len: Integer;
   PreviousTraversalStack: TList<TGocciaObjectValue>;
   Root: TGocciaObjectValue;
   Seen: TDictionary<string, Boolean>;
@@ -457,9 +469,10 @@ begin
   Keys := TStringList.Create;
   Seen := TDictionary<string, Boolean>.Create;
   try
-    for I := 0 to AAllowList.Elements.Count - 1 do
+    Len := LengthOfArrayLike(AAllowList);
+    for I := 0 to Len - 1 do
     begin
-      if not TryExtractAllowListKey(AAllowList.Elements[I], Key) then
+      if not TryExtractAllowListKey(AAllowList.GetProperty(IntToStr(I)), Key) then
         Continue;
       if Seen.ContainsKey(Key) then
         Continue;
@@ -504,12 +517,16 @@ var
   PropValue: TGocciaValue;
   TransformedProp: TGocciaValue;
   TransformedValue: TGocciaValue;
+  Len: Integer;
 begin
   TransformedValue := ApplyToJSON(AValue, AKey);
   // ES2026 §25.5.4.2 steps 4.b-4.d: unwrap boxed primitives.
   TransformedValue := CoerceWrappedPrimitive(TransformedValue);
 
   if TransformedValue is TGocciaUndefinedLiteralValue then
+    Exit(TransformedValue);
+
+  if TransformedValue.IsCallable or (TransformedValue is TGocciaSymbolValue) then
     Exit(TransformedValue);
 
   if TransformedValue is TGocciaArrayValue then
@@ -521,9 +538,10 @@ begin
     Arr := TGocciaArrayValue(TransformedValue);
     NewArr := TGocciaArrayValue.Create;
     try
-      for I := 0 to Arr.Elements.Count - 1 do
+      Len := LengthOfArrayLike(Arr);
+      for I := 0 to Len - 1 do
       begin
-        PropValue := Arr.Elements[I];
+        PropValue := Arr.GetProperty(IntToStr(I));
         TransformedProp := TransformWithAllowList(Arr, IntToStr(I), PropValue,
           AKeys);
         NewArr.Elements.Add(TransformedProp);
@@ -551,7 +569,9 @@ begin
         if PropValue = nil then
           Continue;
         TransformedProp := TransformWithAllowList(Obj, Key, PropValue, AKeys);
-        if not (TransformedProp is TGocciaUndefinedLiteralValue) then
+        if not ((TransformedProp is TGocciaUndefinedLiteralValue) or
+          TransformedProp.IsCallable or
+          (TransformedProp is TGocciaSymbolValue)) then
           NewObj.AssignProperty(Key, TransformedProp);
       end;
     finally
@@ -697,8 +717,13 @@ begin
     if RootResultShouldBeUndefined(Value) then
       Result := TGocciaUndefinedLiteralValue.UndefinedValue
     else
-      Result := TGocciaStringLiteralValue.Create(
-        FStringifier.Stringify(Value, Gap, QuoteChar));
+    begin
+      Stringified := FStringifier.Stringify(Value, Gap, QuoteChar);
+      if Stringified = '' then
+        Result := TGocciaUndefinedLiteralValue.UndefinedValue
+      else
+        Result := TGocciaStringLiteralValue.Create(Stringified);
+    end;
   except
     on E: TGocciaThrowValue do
       raise;

--- a/source/units/Goccia.JSON.pas
+++ b/source/units/Goccia.JSON.pas
@@ -47,6 +47,7 @@ type
     function EscapeJSON5String(const AStr: string; const AQuote: Char): string;
     function IsJSON5IdentifierKey(const AKey: string): Boolean;
     function ShouldOmitObjectProperty(const AValue: TGocciaValue): Boolean;
+    function ShouldOmitRootValue(const AValue: TGocciaValue): Boolean;
     function QuoteJSON5String(const AStr: string): string;
     function SerializeObjectKey(const AKey: string): string;
     function StringifyPreparedValue(const AValue: TGocciaValue; const AIndent: Integer = 0): string;
@@ -79,6 +80,7 @@ uses
   Goccia.Values.RawJSON,
   Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
+  Goccia.Values.ToObject,
   Goccia.Values.WrapperPrimitives;
 
 type
@@ -455,6 +457,7 @@ var
   PreviousPreferredQuoteChar: Char;
   PreviousPropertyList: TArray<string>;
   PreviousTraversalStack: TList<TGocciaObjectValue>;
+  RootValue: TGocciaValue;
 begin
   PreviousGap := FGap;
   PreviousHasPropertyList := FHasPropertyList;
@@ -476,7 +479,11 @@ begin
   end;
   FTraversalStack := TList<TGocciaObjectValue>.Create;
   try
-    Result := StringifyValue(AValue);
+    RootValue := ApplyToJSON(AValue, '');
+    if ShouldOmitRootValue(RootValue) then
+      Result := ''
+    else
+      Result := StringifyPreparedValue(RootValue);
   finally
     FTraversalStack.Free;
     FTraversalStack := PreviousTraversalStack;
@@ -550,6 +557,17 @@ begin
   Result := (AValue is TGocciaUndefinedLiteralValue) or
             AValue.IsCallable or
             (AValue is TGocciaSymbolValue);
+end;
+
+function TGocciaJSONStringifier.ShouldOmitRootValue(
+  const AValue: TGocciaValue): Boolean;
+var
+  EffectiveValue: TGocciaValue;
+begin
+  EffectiveValue := UnboxWrappedPrimitive(AValue);
+  Result := (EffectiveValue is TGocciaUndefinedLiteralValue) or
+            EffectiveValue.IsCallable or
+            (EffectiveValue is TGocciaSymbolValue);
 end;
 
 class function TGocciaJSONStringifier.IsIdentifierStartText(
@@ -881,6 +899,7 @@ function TGocciaJSONStringifier.StringifyArray(const AArr: TGocciaArrayValue; co
 var
   SB: TStringBuffer;
   I: Integer;
+  Len: Integer;
   Value: TGocciaValue;
   Separator, ChildIndent, CloseIndent: string;
 begin
@@ -888,7 +907,8 @@ begin
     ThrowTypeError(CircularErrorName);
 
   FTraversalStack.Add(AArr);
-  if AArr.Elements.Count = 0 then
+  Len := LengthOfArrayLike(AArr);
+  if Len = 0 then
   begin
     Result := '[]';
     FTraversalStack.Delete(FTraversalStack.Count - 1);
@@ -911,12 +931,12 @@ begin
 
     SB := TStringBuffer.Create;
     try
-      for I := 0 to AArr.Elements.Count - 1 do
+      for I := 0 to Len - 1 do
       begin
         if I > 0 then
           SB.Append(Separator);
         SB.Append(ChildIndent);
-        Value := ApplyToJSON(AArr.Elements[I], IntToStr(I));
+        Value := ApplyToJSON(AArr.GetProperty(IntToStr(I)), IntToStr(I));
         SB.Append(StringifyPreparedValue(Value, AIndent + 1));
       end;
       if FGap <> '' then

--- a/source/units/Goccia.Values.WrapperPrimitives.pas
+++ b/source/units/Goccia.Values.WrapperPrimitives.pas
@@ -18,6 +18,7 @@ function CoerceWrappedPrimitive(const AValue: TGocciaValue): TGocciaValue;
 implementation
 
 uses
+  Goccia.Values.BigIntObjectValue,
   Goccia.Values.BooleanObjectValue,
   Goccia.Values.NumberObjectValue,
   Goccia.Values.StringObjectValue;
@@ -30,6 +31,8 @@ begin
     Result := TGocciaStringObjectValue(AValue).Primitive
   else if AValue is TGocciaBooleanObjectValue then
     Result := TGocciaBooleanObjectValue(AValue).Primitive
+  else if AValue is TGocciaBigIntObjectValue then
+    Result := TGocciaBigIntObjectValue(AValue).Primitive
   else
     Result := AValue;
 end;

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -13,7 +13,7 @@ test("JSON.stringify basic values", () => {
 });
 
 test("JSON.stringify omits root function and symbol values", () => {
-  expect(JSON.stringify(function noop() {})).toBeUndefined();
+  expect(JSON.stringify(() => {})).toBeUndefined();
   expect(JSON.stringify(Symbol("root"))).toBeUndefined();
 });
 
@@ -22,15 +22,15 @@ test("JSON.stringify replacer can transform otherwise omitted root values", () =
     key === "" ? replacement : value;
 
   expect(JSON.stringify(undefined, replaceRoot(1))).toBe("1");
-  expect(JSON.stringify(function noop() {}, replaceRoot("fn"))).toBe('"fn"');
+  expect(JSON.stringify(() => {}, replaceRoot("fn"))).toBe('"fn"');
   expect(JSON.stringify(Symbol("root"), replaceRoot(true))).toBe("true");
-  expect(JSON.stringify(1, replaceRoot(function noop() {}))).toBeUndefined();
+  expect(JSON.stringify(1, replaceRoot(() => {}))).toBeUndefined();
   expect(JSON.stringify(1, replaceRoot(Symbol("root")))).toBeUndefined();
 });
 
 test("JSON.stringify omits root values after toJSON", () => {
   expect(JSON.stringify({ toJSON() { return undefined; } })).toBeUndefined();
-  expect(JSON.stringify({ toJSON() { return function noop() {}; } })).toBeUndefined();
+  expect(JSON.stringify({ toJSON() { return () => {}; } })).toBeUndefined();
   expect(JSON.stringify({ toJSON() { return Symbol("root"); } })).toBeUndefined();
 });
 
@@ -136,14 +136,14 @@ test("JSON.stringify replacer function can exclude properties", () => {
 
 test("JSON.stringify replacer function omits function and symbol object properties", () => {
   expect(JSON.stringify({ a: 1, b: 2 }, (key, value) =>
-    key === "a" ? function noop() {} : value)).toBe('{"b":2}');
+    key === "a" ? () => {} : value)).toBe('{"b":2}');
   expect(JSON.stringify({ a: 1, b: 2 }, (key, value) =>
     key === "a" ? Symbol("a") : value)).toBe('{"b":2}');
 });
 
 test("JSON.stringify replacer function nullifies function and symbol array elements", () => {
   expect(JSON.stringify([1, 2], (key, value) =>
-    key === "0" ? function noop() {} : value)).toBe("[null,2]");
+    key === "0" ? () => {} : value)).toBe("[null,2]");
   expect(JSON.stringify([1, 2], (key, value) =>
     key === "0" ? Symbol("a") : value)).toBe("[null,2]");
 });

--- a/tests/built-ins/JSON/stringify.js
+++ b/tests/built-ins/JSON/stringify.js
@@ -12,6 +12,28 @@ test("JSON.stringify basic values", () => {
   expect(JSON.stringify(undefined)).toBeUndefined();
 });
 
+test("JSON.stringify omits root function and symbol values", () => {
+  expect(JSON.stringify(function noop() {})).toBeUndefined();
+  expect(JSON.stringify(Symbol("root"))).toBeUndefined();
+});
+
+test("JSON.stringify replacer can transform otherwise omitted root values", () => {
+  const replaceRoot = (replacement) => (key, value) =>
+    key === "" ? replacement : value;
+
+  expect(JSON.stringify(undefined, replaceRoot(1))).toBe("1");
+  expect(JSON.stringify(function noop() {}, replaceRoot("fn"))).toBe('"fn"');
+  expect(JSON.stringify(Symbol("root"), replaceRoot(true))).toBe("true");
+  expect(JSON.stringify(1, replaceRoot(function noop() {}))).toBeUndefined();
+  expect(JSON.stringify(1, replaceRoot(Symbol("root")))).toBeUndefined();
+});
+
+test("JSON.stringify omits root values after toJSON", () => {
+  expect(JSON.stringify({ toJSON() { return undefined; } })).toBeUndefined();
+  expect(JSON.stringify({ toJSON() { return function noop() {}; } })).toBeUndefined();
+  expect(JSON.stringify({ toJSON() { return Symbol("root"); } })).toBeUndefined();
+});
+
 test("JSON.stringify objects", () => {
   const obj = { name: "Alice", age: 30, active: true };
   const json = JSON.stringify(obj);
@@ -110,6 +132,20 @@ test("JSON.stringify replacer function can exclude properties", () => {
   expect(parsed.a).toBe(1);
   expect(parsed.c).toBe(3);
   expect(parsed.b).toBeUndefined();
+});
+
+test("JSON.stringify replacer function omits function and symbol object properties", () => {
+  expect(JSON.stringify({ a: 1, b: 2 }, (key, value) =>
+    key === "a" ? function noop() {} : value)).toBe('{"b":2}');
+  expect(JSON.stringify({ a: 1, b: 2 }, (key, value) =>
+    key === "a" ? Symbol("a") : value)).toBe('{"b":2}');
+});
+
+test("JSON.stringify replacer function nullifies function and symbol array elements", () => {
+  expect(JSON.stringify([1, 2], (key, value) =>
+    key === "0" ? function noop() {} : value)).toBe("[null,2]");
+  expect(JSON.stringify([1, 2], (key, value) =>
+    key === "0" ? Symbol("a") : value)).toBe("[null,2]");
 });
 
 test("JSON.stringify with array replacer", () => {
@@ -341,6 +377,29 @@ test("JSON.stringify clamps boxed Number Infinity space to 10 spaces", () => {
 
 test("JSON.stringify serializes sparse array holes as null", () => {
   expect(JSON.stringify([1, , 3])).toBe("[1,null,3]");
+  expect(JSON.stringify(new Array(3))).toBe("[null,null,null]");
+});
+
+test("JSON.stringify arrays read elements through property access", () => {
+  const arr = new Array(1);
+  Object.defineProperty(arr, "0", {
+    get() {
+      return 7;
+    },
+  });
+
+  expect(JSON.stringify(arr)).toBe("[7]");
+});
+
+test("JSON.stringify arrays propagate element accessor errors", () => {
+  const arr = new Array(1);
+  Object.defineProperty(arr, "0", {
+    get() {
+      throw new RangeError("abrupt element get");
+    },
+  });
+
+  expect(() => JSON.stringify(arr)).toThrow(RangeError);
 });
 
 test("JSON.stringify calls replacer with the holder as this", () => {
@@ -430,6 +489,28 @@ test("JSON.stringify array replacer de-duplicates keys and reads each property o
   expect(getCalls).toBe(1);
 });
 
+test("JSON.stringify array replacer reads elements through property access", () => {
+  const replacer = new Array(1);
+  Object.defineProperty(replacer, "0", {
+    get() {
+      return "a";
+    },
+  });
+
+  expect(JSON.stringify({ a: 1, b: 2 }, replacer)).toBe('{"a":1}');
+});
+
+test("JSON.stringify array replacer propagates element accessor errors", () => {
+  const replacer = new Array(1);
+  Object.defineProperty(replacer, "0", {
+    get() {
+      throw new RangeError("abrupt replacer get");
+    },
+  });
+
+  expect(() => JSON.stringify({ a: 1 }, replacer)).toThrow(RangeError);
+});
+
 test("JSON.stringify array replacer converts number elements with number-to-string semantics", () => {
   const obj = { 0: 0, 1: 1, "-4": 2, 0.3: 3, "-Infinity": 4, NaN: 5 };
   expect(JSON.stringify(obj, [-0, 1, -4, 0.3, -Infinity, NaN])).toBe(
@@ -477,6 +558,18 @@ test("JSON.stringify value as boxed Number uses an overridden valueOf", () => {
   expect(JSON.stringify(boxed)).toBe("4");
 });
 
+test("JSON.stringify root boxed Number calls valueOf once", () => {
+  let calls = 0;
+  const boxed = new Number(1);
+  boxed.valueOf = () => {
+    calls += 1;
+    return 4;
+  };
+
+  expect(JSON.stringify(boxed)).toBe("4");
+  expect(calls).toBe(1);
+});
+
 test("JSON.stringify value as boxed Number uses an overridden valueOf with a replacer function", () => {
   const boxed = new Number(1);
   boxed.valueOf = () => 4;
@@ -507,6 +600,14 @@ test("JSON.stringify value as boxed Boolean ignores valueOf and toString", () =>
   boxed.toString = () => "true";
 
   expect(JSON.stringify([boxed])).toBe("[false]");
+});
+
+test("JSON.stringify throws on BigInt and boxed BigInt values", () => {
+  expect(() => JSON.stringify(1n)).toThrow(TypeError);
+  expect(() => JSON.stringify(Object(1n))).toThrow(TypeError);
+  expect(() => JSON.stringify({ a: Object(1n) })).toThrow(TypeError);
+  expect(() => JSON.stringify([Object(1n)])).toThrow(TypeError);
+  expect(() => JSON.stringify({ a: 1 }, () => Object(1n))).toThrow(TypeError);
 });
 
 test("JSON.stringify value as boxed Number propagates valueOf exceptions", () => {

--- a/tests/built-ins/JSON5/stringify.js
+++ b/tests/built-ins/JSON5/stringify.js
@@ -124,6 +124,14 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
       }),
     ).toBe("{a:2,b:2}");
     expect(
+      JSON5.stringify({ a: 1, b: 2 }, (key, value) =>
+        key === "a" ? function noop() {} : value),
+    ).toBe("{b:2}");
+    expect(
+      JSON5.stringify([1, 2], (key, value) =>
+        key === "0" ? Symbol("a") : value),
+    ).toBe("[null,2]");
+    expect(
       JSON5.stringify(
         { a: 1 },
         (key, value) => {
@@ -165,8 +173,10 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
     expect(JSON5.stringify(() => {})).toBeUndefined();
     expect(JSON5.stringify(new String("abc"))).toBe("'abc'");
     expect(JSON5.stringify(new Boolean(true))).toBe("true");
+    expect(JSON5.stringify({ toJSON5() { return undefined; } })).toBeUndefined();
     expect(JSON5.stringify({ keep: 1, fn() {} })).toBe("{keep:1}");
     expect(JSON5.stringify([() => {}])).toBe("[null]");
+    expect(JSON5.stringify(new Array(2))).toBe("[null,null]");
     expect(JSON5.stringify({ keep: 1, missing: undefined })).toBe("{keep:1}");
     expect(JSON5.stringify({ ["a" + nbsp + "b"]: 1 })).toBe(`{'a${nbsp}b':1}`);
   });
@@ -177,6 +187,18 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
 
     expect(JSON5.stringify({ a: boxed })).toBe("{a:4}");
     expect(JSON5.stringify(boxed)).toBe("4");
+  });
+
+  test("root boxed Number calls valueOf once", () => {
+    let calls = 0;
+    const boxed = new Number(1);
+    boxed.valueOf = () => {
+      calls += 1;
+      return 4;
+    };
+
+    expect(JSON5.stringify(boxed)).toBe("4");
+    expect(calls).toBe(1);
   });
 
   test("uses an overridden valueOf on boxed Number values with a replacer function", () => {
@@ -209,6 +231,13 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
     boxed.toString = () => "true";
 
     expect(JSON5.stringify([boxed])).toBe("[false]");
+  });
+
+  test("throws on BigInt and boxed BigInt values", () => {
+    expect(() => JSON5.stringify(1n)).toThrow(TypeError);
+    expect(() => JSON5.stringify(Object(1n))).toThrow(TypeError);
+    expect(() => JSON5.stringify({ a: Object(1n) })).toThrow(TypeError);
+    expect(() => JSON5.stringify([Object(1n)])).toThrow(TypeError);
   });
 
   test("propagates valueOf exceptions from boxed Number values", () => {
@@ -427,5 +456,27 @@ describe.runIf(hasJSON5)("JSON5.stringify", () => {
     };
     expect(JSON5.stringify(value, ["key", "key"])).toBe("{key:true}");
     expect(getCalls).toBe(1);
+  });
+
+  test("array replacer reads elements through property access", () => {
+    const replacer = new Array(1);
+    Object.defineProperty(replacer, "0", {
+      get() {
+        return "a";
+      },
+    });
+
+    expect(JSON5.stringify({ a: 1, b: 2 }, replacer)).toBe("{a:1}");
+  });
+
+  test("arrays read elements through property access", () => {
+    const arr = new Array(1);
+    Object.defineProperty(arr, "0", {
+      get() {
+        return 7;
+      },
+    });
+
+    expect(JSON5.stringify(arr)).toBe("[7]");
   });
 });


### PR DESCRIPTION
## Summary

- Align JSON.stringify root handling with spec semantics so root undefined/function/symbol values return undefined, while replacers can still transform otherwise omitted root values.
- Read array elements and array replacer allow-lists through observable array-like property access for JSON and JSON5, including sparse lengths and accessor errors.
- Unbox boxed BigInt values through the shared wrapper primitive helper so JSON/JSON5 serialization throws TypeError like primitive BigInt.
- Keep scope to stringify conformance; no documentation update needed beyond existing data-format behavior docs.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation (not needed; behavior-only conformance fix)
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Commands run:

- `./build.pas --clean testrunner` (after a stale FPC internal-error build retry)
- `./build.pas testrunner`
- `./build/GocciaTestRunner tests/built-ins/JSON/stringify.js tests/built-ins/JSON5/stringify.js --no-progress`
- `./build/GocciaTestRunner tests/built-ins/JSON/stringify.js tests/built-ins/JSON5/stringify.js --mode=bytecode --no-progress`
- `./build/GocciaTestRunner $(find tests -name '*.js' ! -path 'tests/built-ins/FFI/*' | sort) --no-progress`
- `./build/GocciaTestRunner $(find tests -name '*.js' ! -path 'tests/built-ins/FFI/*' | sort) --mode=bytecode --no-progress`
- `./build/GocciaTestRunner tests --no-progress` (fails only because `tests/built-ins/FFI/fixtures/ffi/libfixture.dylib` is absent in this checkout)
- `./format.pas --check`
- `npx tsx scripts/check-trunc-guards.ts`
- `./build.pas tests`