### PR TITLE
fix(website): expand test262 chart tooltips

### DIFF
--- a/website/src/__tests__/test262-dashboard.test.ts
+++ b/website/src/__tests__/test262-dashboard.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { deflateRawSync } from "node:zlib";
+import {
+  formatTest262CategoryLabel,
+  formatTest262DurationTooltip,
+  formatTest262TimelineTooltip,
+} from "@/components/test262-dashboard";
 import type { Test262BlobRun } from "@/lib/test262-blob-store";
 import {
   extractJsonFromZip,
@@ -164,5 +169,97 @@ describe("test262 dashboard data helpers", () => {
 
     expect(result.latestReport?.summary.totalRun).toBe(1);
     expect(result.usableTimeline.map((run) => run.artifactId)).toEqual([1001]);
+  });
+});
+
+describe("test262 dashboard component helpers", () => {
+  test("formats timeline tooltips from generated category summaries", () => {
+    const point = {
+      runId: 622,
+      runNumber: 622,
+      title: "CI",
+      headSha: "1699f7b7abcdef",
+      shortSha: "1699f7b7",
+      runUrl: "https://example.test/runs/622",
+      createdAt: "2026-06-09T12:00:00.000Z",
+      updatedAt: "2026-06-09T12:21:00.000Z",
+      artifactId: 262622,
+      artifactCreatedAt: "2026-06-09T12:21:00.000Z",
+      jsonUrl: "/api/test262/results/262622",
+      summary: {
+        totalDiscovered: 52_233,
+        totalRun: 52_233,
+        passed: 41_765,
+        failed: 10_460,
+        wrapperInfraFailures: 0,
+        timeouts: 8,
+        durationSeconds: 1_242,
+        byCategory: [
+          {
+            category: "built-ins",
+            run: 20_000,
+            passed: 15_000,
+            failed: 4_997,
+            wrapperInfra: 0,
+            timeouts: 3,
+          },
+          {
+            category: "future-category",
+            run: 25,
+            passed: 5,
+            failed: 20,
+            wrapperInfra: 0,
+            timeouts: 0,
+          },
+        ],
+      },
+    };
+    const tooltip = formatTest262TimelineTooltip(point);
+
+    expect(tooltip).toBe(
+      [
+        "Jun 9, 2026 - run #622 - 1699f7b7",
+        "Total: 80.0% (41,765 passed / 52,233 run)",
+        "Built-ins: 75.0% (15,000 passed / 20,000 run)",
+        "Future-Category: 20.0% (5 passed / 25 run)",
+      ].join("\n"),
+    );
+  });
+
+  test("keeps runtime chart tooltip focused on duration", () => {
+    const tooltip = formatTest262DurationTooltip({
+      runId: 622,
+      runNumber: 622,
+      title: "CI",
+      headSha: "1699f7b7abcdef",
+      shortSha: "1699f7b7",
+      runUrl: "https://example.test/runs/622",
+      createdAt: "2026-06-09T12:00:00.000Z",
+      updatedAt: "2026-06-09T12:21:00.000Z",
+      artifactId: 262622,
+      artifactCreatedAt: "2026-06-09T12:21:00.000Z",
+      jsonUrl: "/api/test262/results/262622",
+      summary: {
+        totalDiscovered: 52_233,
+        totalRun: 52_233,
+        passed: 41_765,
+        failed: 10_460,
+        wrapperInfraFailures: 0,
+        timeouts: 8,
+        durationSeconds: 1_242,
+        byCategory: [],
+      },
+    });
+
+    expect(tooltip).toContain("Duration 20.7 min");
+    expect(tooltip).toContain("10,460 failed, 8 timeouts");
+  });
+
+  test("humanizes generated top-level test262 category names", () => {
+    expect(formatTest262CategoryLabel("built-ins")).toBe("Built-ins");
+    expect(formatTest262CategoryLabel("intl402")).toBe("Intl402");
+    expect(formatTest262CategoryLabel("future-category")).toBe(
+      "Future-Category",
+    );
   });
 });

--- a/website/src/components/test262-dashboard.tsx
+++ b/website/src/components/test262-dashboard.tsx
@@ -2,12 +2,13 @@
 
 import { type CSSProperties, useMemo, useRef, useState } from "react";
 import type {
+  Test262CategorySummary,
   Test262DashboardData,
   Test262GroupCoverage,
   Test262TimelinePoint,
 } from "@/lib/test262-dashboard";
 
-const CATEGORY_COLORS: Record<string, string> = {
+const CATEGORY_COLORS: Record<string, string | undefined> = {
   total: "#2d4a2b",
   "built-ins": "#b8651b",
   language: "#4d7fb8",
@@ -15,6 +16,17 @@ const CATEGORY_COLORS: Record<string, string> = {
   staging: "#b45f67",
   harness: "#6f7d42",
 };
+
+const GENERATED_CATEGORY_COLORS = [
+  "#2f6f73",
+  "#8a6f2a",
+  "#9a5d7a",
+  "#5f6ea6",
+  "#7d6b4f",
+  "#627a33",
+  "#9b5c40",
+  "#4f7b5d",
+];
 
 type TimelineRange = "14d" | "30d" | "all";
 
@@ -39,6 +51,29 @@ function minutes(seconds: number): string {
 
 function passRate(passed: number, run: number): number {
   return run > 0 ? passed / run : 0;
+}
+
+export function formatTest262CategoryLabel(category: string): string {
+  return category
+    .split("-")
+    .filter(Boolean)
+    .map((part, index) =>
+      index > 0 && part.length <= 3
+        ? part
+        : `${part.charAt(0).toUpperCase()}${part.slice(1)}`,
+    )
+    .join("-");
+}
+
+function categoryColor(category: string): string {
+  const known = CATEGORY_COLORS[category];
+  if (known) return known;
+
+  let hash = 0;
+  for (let i = 0; i < category.length; i++) {
+    hash = (hash * 31 + category.charCodeAt(i)) >>> 0;
+  }
+  return GENERATED_CATEGORY_COLORS[hash % GENERATED_CATEGORY_COLORS.length];
 }
 
 function dateLabel(value: string): string {
@@ -111,7 +146,35 @@ function xForPoint(
     : padX + (usableW * index) / (points.length - 1);
 }
 
-function dayTooltip(point: Test262TimelinePoint): string {
+function coverageLine(label: string, passed: number, run: number): string {
+  return `${label}: ${percent(passRate(passed, run))} (${fmt(passed)} passed / ${fmt(run)} run)`;
+}
+
+function categoryCoverageLine(category: Test262CategorySummary): string {
+  return coverageLine(
+    formatTest262CategoryLabel(category.category),
+    category.passed,
+    category.run,
+  );
+}
+
+function coverageTooltipLines(point: Test262TimelinePoint): string[] {
+  return [
+    `${dateLabel(point.createdAt)} - run #${point.runNumber} - ${point.shortSha}`,
+    coverageLine("Total", point.summary.passed, point.summary.totalRun),
+    ...point.summary.byCategory.map(categoryCoverageLine),
+  ];
+}
+
+export function formatTest262TimelineTooltip(
+  point: Test262TimelinePoint,
+): string {
+  return coverageTooltipLines(point).join("\n");
+}
+
+export function formatTest262DurationTooltip(
+  point: Test262TimelinePoint,
+): string {
   return [
     `${dateLabel(point.createdAt)} - run #${point.runNumber}`,
     `Commit ${point.shortSha}`,
@@ -122,7 +185,20 @@ function dayTooltip(point: Test262TimelinePoint): string {
   ].join("\n");
 }
 
-function DayTooltipContent({ point }: { point: Test262TimelinePoint }) {
+function CoverageTooltipContent({ point }: { point: Test262TimelinePoint }) {
+  const lines = coverageTooltipLines(point);
+  const [title, ...coverageLines] = lines;
+  return (
+    <>
+      <strong>{title}</strong>
+      {coverageLines.map((line) => (
+        <span key={line}>{line}</span>
+      ))}
+    </>
+  );
+}
+
+function DurationTooltipContent({ point }: { point: Test262TimelinePoint }) {
   return (
     <>
       <strong>
@@ -171,6 +247,7 @@ function ChartHoverTargets({
   padX,
   padY,
   tooltipId,
+  labelForPoint,
   onActivate,
   onDeactivate,
 }: {
@@ -180,6 +257,7 @@ function ChartHoverTargets({
   padX: number;
   padY: number;
   tooltipId: string;
+  labelForPoint: (point: Test262TimelinePoint) => string;
   onActivate: (index: number, target: HTMLElement) => void;
   onDeactivate: () => void;
 }) {
@@ -208,7 +286,7 @@ function ChartHoverTargets({
               } as CSSProperties
             }
             aria-describedby={tooltipId}
-            aria-label={dayTooltip(point)}
+            aria-label={labelForPoint(point)}
             onPointerEnter={(event) => onActivate(index, event.currentTarget)}
             onPointerLeave={onDeactivate}
             onFocus={(event) => onActivate(index, event.currentTarget)}
@@ -226,11 +304,13 @@ function ChartTooltip({
   point,
   left,
   top,
+  variant,
 }: {
   id: string;
   point: Test262TimelinePoint | null;
   left: number;
   top: number;
+  variant: "coverage" | "duration";
 }) {
   if (!point) return null;
   return (
@@ -246,7 +326,11 @@ function ChartTooltip({
         } as CSSProperties
       }
     >
-      <DayTooltipContent point={point} />
+      {variant === "coverage" ? (
+        <CoverageTooltipContent point={point} />
+      ) : (
+        <DurationTooltipContent point={point} />
+      )}
     </div>
   );
 }
@@ -375,8 +459,7 @@ function CoverageTimeline({ points }: { points: Test262TimelinePoint[] }) {
                   className="compat-chart-line"
                   style={
                     {
-                      "--series-color":
-                        CATEGORY_COLORS[category] ?? CATEGORY_COLORS.total,
+                      "--series-color": categoryColor(category),
                     } as CSSProperties
                   }
                 />
@@ -396,8 +479,7 @@ function CoverageTimeline({ points }: { points: Test262TimelinePoint[] }) {
                       className="compat-chart-point"
                       style={
                         {
-                          "--series-color":
-                            CATEGORY_COLORS[category] ?? CATEGORY_COLORS.total,
+                          "--series-color": categoryColor(category),
                         } as CSSProperties
                       }
                     />
@@ -412,6 +494,7 @@ function CoverageTimeline({ points }: { points: Test262TimelinePoint[] }) {
               padX={padX}
               padY={padY}
               tooltipId={tooltipId}
+              labelForPoint={formatTest262TimelineTooltip}
               onActivate={activatePoint}
               onDeactivate={() => setActiveIndex(null)}
             />
@@ -422,6 +505,7 @@ function CoverageTimeline({ points }: { points: Test262TimelinePoint[] }) {
           point={activePoint}
           left={activeLeft}
           top={activeY}
+          variant="coverage"
         />
       </div>
       <ul className="compat-legend" aria-label="Chart series">
@@ -430,13 +514,12 @@ function CoverageTimeline({ points }: { points: Test262TimelinePoint[] }) {
             key={category}
             style={
               {
-                "--series-color":
-                  CATEGORY_COLORS[category] ?? CATEGORY_COLORS.total,
+                "--series-color": categoryColor(category),
               } as CSSProperties
             }
           >
             <span aria-hidden="true" />
-            {category}
+            {formatTest262CategoryLabel(category)}
           </li>
         ))}
       </ul>
@@ -580,6 +663,7 @@ function DurationTimeline({ points }: { points: Test262TimelinePoint[] }) {
               padX={padX}
               padY={padY}
               tooltipId={tooltipId}
+              labelForPoint={formatTest262DurationTooltip}
               onActivate={activatePoint}
               onDeactivate={() => setActiveIndex(null)}
             />
@@ -590,6 +674,7 @@ function DurationTimeline({ points }: { points: Test262TimelinePoint[] }) {
           point={activePoint}
           left={activeLeft}
           top={activeY}
+          variant="duration"
         />
       </div>
     </section>
@@ -664,7 +749,7 @@ function CategorySplit({ point }: { point: Test262TimelinePoint }) {
           return (
             <div className="compat-category" key={category.category}>
               <div className="compat-category-head">
-                <h3>{category.category}</h3>
+                <h3>{formatTest262CategoryLabel(category.category)}</h3>
                 <strong>{percent(rate)}</strong>
               </div>
               <div

--- a/website/src/components/test262-dashboard.tsx
+++ b/website/src/components/test262-dashboard.tsx
@@ -191,8 +191,8 @@ function CoverageTooltipContent({ point }: { point: Test262TimelinePoint }) {
   return (
     <>
       <strong>{title}</strong>
-      {coverageLines.map((line) => (
-        <span key={line}>{line}</span>
+      {coverageLines.map((line, index) => (
+        <span key={index}>{line}</span>
       ))}
     </>
   );


### PR DESCRIPTION
## Summary

- Updates the test262 pass-rate chart tooltip to show the requested compact run header plus total and generated category pass-rate rows.
- Humanizes generated test262 category names across the chart legend and top-level category cards, with deterministic fallback colors for future categories so new generated categories appear without code changes.
- Keeps the runtime chart on its duration-focused tooltip path so this pass-rate polish does not regress the performance diagram.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `cd website && bun test src/__tests__/test262-dashboard.test.ts`
  - `cd website && bun test`
  - `cd website && bun run lint`
  - `cd website && bun run build`
- [x] Updated documentation — not needed; this is existing dashboard UI behavior only.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

## Visual Evidence

- Rendered the real `Test262Dashboard` component locally with representative generated test262 data, including a synthetic `future-category` entry, via a temporary fixture route that was removed before commit.
- Verified hover and focus snapshots show: `Jun 9, 2026 - run #622 - 1699f7b7`, `Total: 80.0% (41,765 passed / 52,233 run)`, current generated categories, and `Future-Category: 20.0% (5 passed / 25 run)`.
- Captured local screenshots for review in this worktree:
  - `output/playwright/test262-tooltip-hover-desktop.png`
  - `output/playwright/test262-tooltip-hover-mobile.png`