### PR TITLE
fix(sandbox): normalize Windows-style virtual paths

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2367,6 +2367,61 @@ console.log("SandboxRunner: aliases and import maps resolve sandbox module paths
   }
 }
 
+console.log("SandboxRunner: Windows-style sandbox paths normalize to virtual paths...");
+{
+  const tmp = makeTmp();
+  try {
+    const seed = join(tmp, "seed.json");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: String.raw`\main.js`,
+          text: [
+            'import fs from "fs";',
+            'import { $, runScript } from "goccia";',
+            'fs.writeFileSync("\\\\hello.txt", "hello");',
+            'console.log(fs.readFileSync("/hello.txt", "utf8"));',
+            'console.log((await $("cat \'\\\\hello.txt\'").text()).trim());',
+            'const child = runScript("\\\\child.js", {',
+            '  sandbox: true,',
+            '  seed: ["\\\\child.js", { from: "\\\\hello.txt", to: "\\\\copied\\\\" }],',
+            '  diff: true,',
+            '});',
+            'console.log(child.stdout.trim());',
+            'const shellChild = await $("goccia \'\\\\child.js\'").text();',
+            'console.log(shellChild.trim());',
+          ].join("\n"),
+        },
+        {
+          path: String.raw`\child.js`,
+          text: [
+            'import fs from "fs";',
+            'if (fs.existsSync("\\\\copied\\\\hello.txt")) console.log(fs.readFileSync("\\\\copied\\\\hello.txt", "utf8"));',
+            'else console.log("child-shared");',
+          ].join("\n"),
+        },
+      ],
+    }));
+
+    const proc = Bun.spawnSync(
+      [SANDBOXRUNNER, String.raw`\main.js`, `--seed-config=${seed}`, "--source-type=module"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = normalizeLineEndings(proc.stdout.toString());
+    if (proc.exitCode !== 0)
+      throw new Error(`SandboxRunner Windows-style paths should exit 0, got ${proc.exitCode}: ${proc.stderr.toString()}`);
+    for (const expected of ["hello", "child-shared"]) {
+      if (!containsLine(`\n${stdout}`, expected))
+        throw new Error(`SandboxRunner Windows-style paths should include ${JSON.stringify(expected)}, got: ${stdout}`);
+    }
+    const helloCount = stdout.split("\n").filter((line) => line === "hello").length;
+    if (helloCount !== 3)
+      throw new Error(`SandboxRunner Windows-style paths should print hello three times, got ${helloCount} in: ${stdout}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
 console.log("SandboxRunner: seed config rejects null source values...");
 {
   const tmp = makeTmp();
@@ -2570,16 +2625,23 @@ console.log("SandboxRunner: seed config imports host paths relative to the confi
     const project = join(tmp, "project");
     mkdirSync(project, { recursive: true });
     writeFileSync(join(project, "data.txt"), "from-host");
+    writeFileSync(join(tmp, "target-file.txt"), "from-file-target");
+    writeFileSync(join(tmp, "existing-dir-file.txt"), "from-existing-dir");
     const seed = join(tmp, "seed.json");
     writeFileSync(seed, JSON.stringify({
       files: [
         { from: "./project", to: "/" },
+        { path: "/existing-dir/.keep", text: "" },
+        { from: "./target-file.txt", to: "/target-dir/" },
+        { from: "./existing-dir-file.txt", to: "/existing-dir" },
         { path: "/bin.dat", base64: "AQID" },
         {
           path: "/main.js",
           text: [
             'import fs from "fs";',
             'console.log(fs.readFileSync("/data.txt", "utf8"));',
+            'console.log(fs.readFileSync("/target-dir/target-file.txt", "utf8"));',
+            'console.log(fs.readFileSync("/existing-dir/existing-dir-file.txt", "utf8"));',
             'console.log(fs.readFileSync("/bin.dat").length);',
           ].join("\n"),
         },
@@ -2595,6 +2657,10 @@ console.log("SandboxRunner: seed config imports host paths relative to the confi
       throw new Error(`SandboxRunner host seed should exit 0, got ${proc.exitCode}: ${proc.stderr.toString()}`);
     if (!containsLine(`\n${stdout}`, "from-host"))
       throw new Error(`SandboxRunner host seed stdout should include imported host text, got: ${stdout}`);
+    if (!containsLine(`\n${stdout}`, "from-file-target"))
+      throw new Error(`SandboxRunner host seed stdout should include file copied under trailing slash target, got: ${stdout}`);
+    if (!containsLine(`\n${stdout}`, "from-existing-dir"))
+      throw new Error(`SandboxRunner host seed stdout should include file copied under existing target directory, got: ${stdout}`);
     if (!containsLine(`\n${stdout}`, "3"))
       throw new Error(`SandboxRunner host seed stdout should include base64 byte length, got: ${stdout}`);
   } finally {

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2321,7 +2321,7 @@ console.log("SandboxRunner: aliases and import maps resolve sandbox module paths
   try {
     const seed = join(tmp, "seed.json");
     const importMap = join(tmp, "import-map.json");
-    writeFileSync(importMap, JSON.stringify({ imports: { "#lib/": "/lib/" } }));
+    writeFileSync(importMap, JSON.stringify({ imports: { "#lib/": "/lib/", "#rel/": "./lib/" } }));
     writeFileSync(seed, JSON.stringify({
       files: [
         {
@@ -2335,11 +2335,14 @@ console.log("SandboxRunner: aliases and import maps resolve sandbox module paths
           path: "/map-main.js",
           text: [
             'import { label } from "#lib/map.js";',
+            'import { relativeLabel } from "#rel/relative.js";',
             'console.log(label);',
+            'console.log(relativeLabel);',
           ].join("\n"),
         },
         { path: "/lib/alias.js", text: 'export const label = "alias-ok";' },
         { path: "/lib/map.js", text: 'export const label = "map-ok";' },
+        { path: "/lib/relative.js", text: 'export const relativeLabel = "relative-ok";' },
       ],
     }));
 
@@ -2362,6 +2365,8 @@ console.log("SandboxRunner: aliases and import maps resolve sandbox module paths
       throw new Error(`SandboxRunner import map should exit 0, got ${importMapProc.exitCode}: ${importMapProc.stderr.toString()}`);
     if (!containsLine(`\n${importMapStdout}`, "map-ok"))
       throw new Error(`SandboxRunner import map should print map-ok, got: ${importMapStdout}`);
+    if (!containsLine(`\n${importMapStdout}`, "relative-ok"))
+      throw new Error(`SandboxRunner import map should print relative-ok, got: ${importMapStdout}`);
   } finally {
     clean(tmp);
   }

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -122,13 +122,16 @@ begin
 end;
 
 function EnsureSandboxAbsolute(const APath: string): string;
+var
+  Path: string;
 begin
-  if APath = '' then
+  Path := NormalizeSandboxPathSeparators(APath);
+  if Path = '' then
     Exit('/');
-  if APath[1] = '/' then
-    Result := APath
+  if Path[1] = '/' then
+    Result := Path
   else
-    Result := '/' + APath;
+    Result := '/' + Path;
 end;
 
 function HostPathFromConfig(const ABaseDirectory, APath: string): string;
@@ -142,37 +145,47 @@ end;
 
 function SandboxPathParent(const APath: string): string;
 var
+  Path: string;
   SlashIndex: Integer;
 begin
+  Path := NormalizeSandboxPathSeparators(APath);
   Result := '/';
-  SlashIndex := Length(APath);
-  while (SlashIndex > 1) and (APath[SlashIndex] <> '/') do
+  SlashIndex := Length(Path);
+  while (SlashIndex > 1) and (Path[SlashIndex] <> '/') do
     Dec(SlashIndex);
   if SlashIndex > 1 then
-    Result := Copy(APath, 1, SlashIndex - 1);
+    Result := Copy(Path, 1, SlashIndex - 1);
 end;
 
 function SandboxPathName(const APath: string): string;
 var
+  Path: string;
   SlashIndex: Integer;
 begin
-  SlashIndex := Length(APath);
-  while (SlashIndex > 0) and (APath[SlashIndex] <> '/') do
+  Path := NormalizeSandboxPathSeparators(APath);
+  SlashIndex := Length(Path);
+  while (SlashIndex > 0) and (Path[SlashIndex] <> '/') do
     Dec(SlashIndex);
-  Result := Copy(APath, SlashIndex + 1, MaxInt);
+  Result := Copy(Path, SlashIndex + 1, MaxInt);
 end;
 
 function SandboxPathHasTrailingSeparator(const APath: string): Boolean;
+var
+  Path: string;
 begin
-  Result := (APath <> '') and (APath[Length(APath)] = '/');
+  Path := NormalizeSandboxPathSeparators(APath);
+  Result := (Path <> '') and (Path[Length(Path)] = '/');
 end;
 
 function SandboxJoinPath(const ABase, AName: string): string;
+var
+  Base: string;
 begin
-  if ABase = '/' then
+  Base := NormalizeSandboxPathSeparators(ABase);
+  if Base = '/' then
     Result := '/' + AName
   else
-    Result := ABase + '/' + AName;
+    Result := Base + '/' + AName;
 end;
 
 destructor TSandboxRunnerApp.Destroy;
@@ -304,9 +317,12 @@ procedure TSandboxRunnerApp.ImportDirectoryContents(const AHostDirectory,
 var
   SearchRec: TSearchRec;
   HostChild: string;
+  SandboxDirectory: string;
   SandboxChild: string;
 begin
-  FContext.Fs.MakeDirectory(EnsureSandboxAbsolute(ASandboxDirectory), True);
+  SandboxDirectory := FContext.Fs.Normalize(EnsureSandboxAbsolute(
+    ASandboxDirectory));
+  FContext.Fs.MakeDirectory(SandboxDirectory, True);
   if FindFirst(IncludeTrailingPathDelimiter(AHostDirectory) + '*',
      faAnyFile, SearchRec) <> 0 then
     Exit;
@@ -315,12 +331,7 @@ begin
       if (SearchRec.Name = '.') or (SearchRec.Name = '..') then
         Continue;
       HostChild := IncludeTrailingPathDelimiter(AHostDirectory) + SearchRec.Name;
-      if ASandboxDirectory = '/' then
-        SandboxChild := '/' + SearchRec.Name
-      else
-        SandboxChild := IncludeTrailingPathDelimiter(ASandboxDirectory) +
-          SearchRec.Name;
-      SandboxChild := StringReplace(SandboxChild, PathDelim, '/', [rfReplaceAll]);
+      SandboxChild := SandboxJoinPath(SandboxDirectory, SearchRec.Name);
       if (SearchRec.Attr and faDirectory) <> 0 then
         ImportDirectoryContents(HostChild, SandboxChild)
       else
@@ -347,8 +358,10 @@ begin
     ImportDirectoryContents(HostPath, TargetPath)
   else
   begin
-    if (ASandboxPath = '') or (ASandboxPath = '/') then
-      TargetPath := '/' + ExtractFileName(HostPath);
+    if (TargetPath = '/') or SandboxPathHasTrailingSeparator(ASandboxPath) or
+       FContext.Fs.IsDirectory(TargetPath) then
+      TargetPath := FContext.Fs.Normalize(SandboxJoinPath(TargetPath,
+        ExtractFileName(HostPath)));
     ImportFile(HostPath, TargetPath);
   end;
 end;

--- a/source/shared/SandboxVirtualFileSystem.pas
+++ b/source/shared/SandboxVirtualFileSystem.pas
@@ -172,11 +172,19 @@ type
 
 function SandboxFsKindName(const AKind: TSandboxFsNodeKind): string;
 function SandboxHumanBytes(const ABytes: Int64): string;
+function NormalizeSandboxPathSeparators(const APath: string): string;
 
 implementation
 
 const
   PathSeparator = '/';
+  AlternatePathSeparator = '\';
+
+function NormalizeSandboxPathSeparators(const APath: string): string;
+begin
+  Result := StringReplace(APath, AlternatePathSeparator, PathSeparator,
+    [rfReplaceAll]);
+end;
 
 function SandboxFsKindName(const AKind: TSandboxFsNodeKind): string;
 begin
@@ -317,6 +325,8 @@ end;
 function TSandboxVirtualFileSystem.Normalize(const APath: string;
   const ABase: string): string;
 var
+  Path: string;
+  Base: string;
   Combined: string;
   Segments: TStringList;
   Segment: string;
@@ -338,14 +348,16 @@ var
   end;
 
 begin
-  if Pos(#0, APath) > 0 then
+  Path := NormalizeSandboxPathSeparators(APath);
+  Base := NormalizeSandboxPathSeparators(ABase);
+  if (Pos(#0, Path) > 0) or (Pos(#0, Base) > 0) then
     raise ESandboxFsInvalidPath.Create('path contains a NUL byte');
-  if (Length(APath) > 0) and (APath[1] = PathSeparator) then
-    Combined := APath
-  else if APath = '' then
-    Combined := ABase
+  if (Length(Path) > 0) and (Path[1] = PathSeparator) then
+    Combined := Path
+  else if Path = '' then
+    Combined := Base
   else
-    Combined := ABase + PathSeparator + APath;
+    Combined := Base + PathSeparator + Path;
 
   Segments := TStringList.Create;
   try

--- a/source/units/Goccia.Modules.Resolver.pas
+++ b/source/units/Goccia.Modules.Resolver.pas
@@ -13,6 +13,11 @@ uses
 
 type
   TGocciaModuleResolver = class(TModuleResolver)
+  protected
+    function IsAbsoluteImportMapPath(const APath: string): Boolean; virtual;
+    function IsRelativeImportMapPath(const APath: string): Boolean; virtual;
+    function NormalizeImportMapPath(const APath, ABaseDirectory: string): string;
+      virtual;
   public
     constructor Create(const ABaseDirectory: string = '');
     class function DiscoverProjectConfig(const AStartDirectory: string): string; static;
@@ -39,7 +44,8 @@ const
   CURRENT_DIRECTORY_PREFIX = './';
   PARENT_DIRECTORY_PREFIX = '../';
 
-function IsAbsoluteImportMapPath(const APath: string): Boolean;
+function TGocciaModuleResolver.IsAbsoluteImportMapPath(
+  const APath: string): Boolean;
 begin
   if Length(APath) = 0 then
     Exit(False);
@@ -50,7 +56,8 @@ begin
   Result := Copy(APath, 1, 2) = '\\';
 end;
 
-function IsRelativeImportMapPath(const APath: string): Boolean;
+function TGocciaModuleResolver.IsRelativeImportMapPath(
+  const APath: string): Boolean;
 begin
   Result := (Copy(APath, 1, Length(CURRENT_DIRECTORY_PREFIX)) =
       CURRENT_DIRECTORY_PREFIX) or
@@ -63,7 +70,8 @@ begin
   Result := (APath <> '') and (APath[Length(APath)] = '/');
 end;
 
-function NormalizeImportMapPath(const APath, ABaseDirectory: string): string;
+function TGocciaModuleResolver.NormalizeImportMapPath(const APath,
+  ABaseDirectory: string): string;
 begin
   if IsAbsoluteImportMapPath(APath) then
     Result := ExpandUTF8FileName(APath)

--- a/source/units/Goccia.Modules.Resolver.pas
+++ b/source/units/Goccia.Modules.Resolver.pas
@@ -16,6 +16,8 @@ type
   protected
     function IsAbsoluteImportMapPath(const APath: string): Boolean; virtual;
     function IsRelativeImportMapPath(const APath: string): Boolean; virtual;
+    function NormalizeImportMapBaseDirectory(
+      const AImportMapDirectory: string): string; virtual;
     function NormalizeImportMapPath(const APath, ABaseDirectory: string): string;
       virtual;
   public
@@ -68,6 +70,12 @@ end;
 function HasImportMapTrailingSlash(const APath: string): Boolean;
 begin
   Result := (APath <> '') and (APath[Length(APath)] = '/');
+end;
+
+function TGocciaModuleResolver.NormalizeImportMapBaseDirectory(
+  const AImportMapDirectory: string): string;
+begin
+  Result := AImportMapDirectory;
 end;
 
 function TGocciaModuleResolver.NormalizeImportMapPath(const APath,
@@ -131,7 +139,8 @@ end;
 
 procedure TGocciaModuleResolver.LoadImportMap(const APath: string);
 var
-  ImportMapDirectory, ImportMapPath, Key, NormalizedKey, NormalizedValue: string;
+  ImportMapBaseDirectory, ImportMapDirectory, ImportMapPath, Key: string;
+  NormalizedKey, NormalizedValue: string;
   Parser: TGocciaJSONParser;
   ParsedValue, ImportsValue, Value: TGocciaValue;
   ImportsObject, ImportMapObject: TGocciaObjectValue;
@@ -164,6 +173,8 @@ begin
     ImportsObject := TGocciaObjectValue(ImportsValue);
     ImportMapDirectory := IncludeTrailingPathDelimiter(
       ExtractFilePath(ImportMapPath));
+    ImportMapBaseDirectory := NormalizeImportMapBaseDirectory(
+      ImportMapDirectory);
 
     for Key in ImportsObject.GetOwnPropertyKeys do
     begin
@@ -184,9 +195,9 @@ begin
           'Import map entry "%s" must use an absolute or relative file path address.',
           [Key]);
 
-      NormalizedKey := NormalizeImportMapPath(Key, ImportMapDirectory);
+      NormalizedKey := NormalizeImportMapPath(Key, ImportMapBaseDirectory);
       NormalizedValue := NormalizeImportMapPath(
-        TGocciaStringLiteralValue(Value).Value, ImportMapDirectory);
+        TGocciaStringLiteralValue(Value).Value, ImportMapBaseDirectory);
       AddAlias(NormalizedKey, NormalizedValue);
     end;
   finally

--- a/source/units/Goccia.RuntimeExtensions.Sandbox.pas
+++ b/source/units/Goccia.RuntimeExtensions.Sandbox.pas
@@ -296,8 +296,11 @@ begin
 end;
 
 function IsDirectoryTargetPath(const APath: string): Boolean;
+var
+  Path: string;
 begin
-  Result := (APath = '/') or ((APath <> '') and (APath[Length(APath)] = '/'));
+  Path := NormalizeSandboxPathSeparators(APath);
+  Result := (Path = '/') or ((Path <> '') and (Path[Length(Path)] = '/'));
 end;
 
 function ObjectStringProperty(const AObject: TGocciaObjectValue;

--- a/source/units/Goccia.Sandbox.Context.pas
+++ b/source/units/Goccia.Sandbox.Context.pas
@@ -124,8 +124,11 @@ begin
 end;
 
 function IsDirectoryTargetPath(const APath: string): Boolean;
+var
+  Path: string;
 begin
-  Result := (APath = '/') or ((APath <> '') and (APath[Length(APath)] = '/'));
+  Path := NormalizeSandboxPathSeparators(APath);
+  Result := (Path = '/') or ((Path <> '') and (Path[Length(Path)] = '/'));
 end;
 
 { TGocciaSandboxContext }

--- a/source/units/Goccia.Sandbox.Modules.pas
+++ b/source/units/Goccia.Sandbox.Modules.pas
@@ -33,6 +33,11 @@ type
     function TryResolveWithSandboxExtensions(const ABasePath: string;
       out AResolvedPath: string): Boolean;
     function NormalizeImportBase(const AImportingFilePath: string): string;
+  protected
+    function IsAbsoluteImportMapPath(const APath: string): Boolean; override;
+    function IsRelativeImportMapPath(const APath: string): Boolean; override;
+    function NormalizeImportMapPath(const APath, ABaseDirectory: string): string;
+      override;
   public
     constructor Create(const AFs: TSandboxVirtualFileSystem;
       const ABaseDirectory: string = '/');
@@ -76,6 +81,22 @@ begin
     Result := '/' + Path
   else
     Result := Base + '/' + Path;
+end;
+
+function HasSandboxTrailingSeparator(const APath: string): Boolean;
+var
+  Path: string;
+begin
+  Path := NormalizeSandboxPathSeparators(APath);
+  Result := (Path <> '') and (Path[Length(Path)] = '/');
+end;
+
+function EnsureSandboxTrailingSeparatorIfNeeded(const APath: string;
+  const ANeedsTrailingSeparator: Boolean): string;
+begin
+  Result := APath;
+  if ANeedsTrailingSeparator and not HasSandboxTrailingSeparator(Result) then
+    Result := Result + '/';
 end;
 
 { TGocciaSandboxModuleContentProvider }
@@ -127,6 +148,35 @@ begin
   inherited Create(ABaseDirectory);
   FFs := AFs;
   BaseDirectory := ABaseDirectory;
+end;
+
+function TGocciaSandboxModuleResolver.IsAbsoluteImportMapPath(
+  const APath: string): Boolean;
+begin
+  Result := IsAbsoluteSandboxPath(APath);
+end;
+
+function TGocciaSandboxModuleResolver.IsRelativeImportMapPath(
+  const APath: string): Boolean;
+begin
+  Result := IsRelativeModuleSpecifier(APath);
+end;
+
+function TGocciaSandboxModuleResolver.NormalizeImportMapPath(const APath,
+  ABaseDirectory: string): string;
+var
+  Path: string;
+begin
+  Path := NormalizeSandboxPathSeparators(APath);
+  if IsAbsoluteSandboxPath(Path) then
+    Result := FFs.Normalize(Path)
+  else if IsRelativeModuleSpecifier(Path) then
+    Result := FFs.Normalize(Path, BaseDirectory)
+  else
+    Result := Path;
+
+  Result := EnsureSandboxTrailingSeparatorIfNeeded(Result,
+    HasSandboxTrailingSeparator(Path));
 end;
 
 function TGocciaSandboxModuleResolver.NormalizeImportBase(

--- a/source/units/Goccia.Sandbox.Modules.pas
+++ b/source/units/Goccia.Sandbox.Modules.pas
@@ -47,24 +47,35 @@ const
   PARENT_DIRECTORY_PREFIX = '../';
 
 function IsAbsoluteSandboxPath(const APath: string): Boolean;
+var
+  Path: string;
 begin
-  Result := (APath <> '') and (APath[1] = '/');
+  Path := NormalizeSandboxPathSeparators(APath);
+  Result := (Path <> '') and (Path[1] = '/');
 end;
 
 function IsRelativeModuleSpecifier(const AModulePath: string): Boolean;
+var
+  ModulePath: string;
 begin
-  Result := (Copy(AModulePath, 1, Length(CURRENT_DIRECTORY_PREFIX)) =
+  ModulePath := NormalizeSandboxPathSeparators(AModulePath);
+  Result := (Copy(ModulePath, 1, Length(CURRENT_DIRECTORY_PREFIX)) =
       CURRENT_DIRECTORY_PREFIX) or
-    (Copy(AModulePath, 1, Length(PARENT_DIRECTORY_PREFIX)) =
+    (Copy(ModulePath, 1, Length(PARENT_DIRECTORY_PREFIX)) =
       PARENT_DIRECTORY_PREFIX);
 end;
 
 function JoinSandboxPath(const ABase, APath: string): string;
+var
+  Base: string;
+  Path: string;
 begin
-  if ABase = '/' then
-    Result := '/' + APath
+  Base := NormalizeSandboxPathSeparators(ABase);
+  Path := NormalizeSandboxPathSeparators(APath);
+  if Base = '/' then
+    Result := '/' + Path
   else
-    Result := ABase + '/' + APath;
+    Result := Base + '/' + Path;
 end;
 
 { TGocciaSandboxModuleContentProvider }
@@ -203,7 +214,7 @@ begin
 
   if IsAbsoluteSandboxPath(AModulePath) then
   begin
-    Candidate := FFs.Normalize(AModulePath);
+    Candidate := FFs.Normalize(NormalizeSandboxPathSeparators(AModulePath));
     if TryResolveWithSandboxExtensions(Candidate, Result) then
       Exit;
     raise EModuleNotFound.CreateFmt('Module not found: "%s"', [AModulePath]);
@@ -212,7 +223,8 @@ begin
   if IsRelativeModuleSpecifier(AModulePath) then
   begin
     BaseDirectoryPath := NormalizeImportBase(AImportingFilePath);
-    Candidate := FFs.Normalize(AModulePath, BaseDirectoryPath);
+    Candidate := FFs.Normalize(NormalizeSandboxPathSeparators(AModulePath),
+      BaseDirectoryPath);
     if TryResolveWithSandboxExtensions(Candidate, Result) then
       Exit;
     raise EModuleNotFound.CreateFmt(

--- a/source/units/Goccia.Sandbox.Modules.pas
+++ b/source/units/Goccia.Sandbox.Modules.pas
@@ -36,6 +36,8 @@ type
   protected
     function IsAbsoluteImportMapPath(const APath: string): Boolean; override;
     function IsRelativeImportMapPath(const APath: string): Boolean; override;
+    function NormalizeImportMapBaseDirectory(
+      const AImportMapDirectory: string): string; override;
     function NormalizeImportMapPath(const APath, ABaseDirectory: string): string;
       override;
   public
@@ -162,6 +164,12 @@ begin
   Result := IsRelativeModuleSpecifier(APath);
 end;
 
+function TGocciaSandboxModuleResolver.NormalizeImportMapBaseDirectory(
+  const AImportMapDirectory: string): string;
+begin
+  Result := FFs.Normalize(BaseDirectory);
+end;
+
 function TGocciaSandboxModuleResolver.NormalizeImportMapPath(const APath,
   ABaseDirectory: string): string;
 var
@@ -171,7 +179,7 @@ begin
   if IsAbsoluteSandboxPath(Path) then
     Result := FFs.Normalize(Path)
   else if IsRelativeModuleSpecifier(Path) then
-    Result := FFs.Normalize(Path, BaseDirectory)
+    Result := FFs.Normalize(Path, NormalizeSandboxPathSeparators(ABaseDirectory))
   else
     Result := Path;
 


### PR DESCRIPTION
## Summary

- Normalize backslashes at sandbox path boundaries so Windows-style virtual paths remain inside the sandbox filesystem for runner entries, module imports, seed targets, and child sandbox calls.
- Keep sandbox import-map addresses as virtual paths instead of expanding them through the host filesystem, fixing `/lib/` import-map entries on Windows and relative entries such as `./lib/`.
- Treat host file seed destinations ending in a sandbox separator, or pointing at an existing sandbox directory, as directory targets.
- Builds on #772.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `bun scripts/test-cli-apps.ts`
- [x] Updated documentation
  - Not applicable; no docs change needed for this behavior fix.
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./build.pas tests`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Not applicable; path normalization change only.

Additional verification:

- `./build.pas sandboxrunner`
- `./format.pas --check`
- `git diff --check`