### PR TITLE
fix(test262): close built-ins conformance clusters

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -87,7 +87,7 @@ Implements the [ECMAScript Object](https://developer.mozilla.org/en-US/docs/Web/
 
 ### Array (`Goccia.Builtins.GlobalArray.pas`)
 
-Implements the [ECMAScript Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array). **Not implemented:** `Array.prototype.reduceRight`.
+Implements the [ECMAScript Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
 
 **Static methods:**
 
@@ -105,6 +105,7 @@ Implements the [ECMAScript Array](https://developer.mozilla.org/en-US/docs/Web/J
 | `map(callback)` | Transform each element |
 | `filter(callback)` | Filter elements by predicate |
 | `reduce(callback, initial?)` | Reduce to single value |
+| `reduceRight(callback, initial?)` | Reduce to single value from right to left |
 | `forEach(callback)` | Execute callback for each element |
 | `some(callback)` | Test if any element passes |
 | `every(callback)` | Test if all elements pass |

--- a/docs/test262.md
+++ b/docs/test262.md
@@ -250,6 +250,9 @@ Bodies see only the identifiers stock test262 expects:
 - `print` (Goccia engine global; stock `doneprintHandle.js` uses it for async markers)
 - `$262` helpers implemented by Goccia's bundled host object:
   `detachArrayBuffer`, `evalScript`, `gc`, `global`, and `createRealm`
+- `$262.agent` helpers used by Atomics tests: `start`, `broadcast`,
+  `receiveBroadcast`, `report`, `getReport`, `sleep`, `monotonicNow`, and
+  `leaving`
 - `test262Host`, a private marker on the `Goccia` namespace exposed only by
   `GocciaScriptLoaderBare --test262-host` so `$262.js` can reject accidental
   use outside the conformance host.
@@ -291,6 +294,12 @@ the official test262 host eval only for conformance runs; default Bare
 execution does not expose it. Bytecode direct calls to that host eval preserve
 the caller realm and caller lexical bindings, while shadowed or indirect eval
 calls use ordinary function-call semantics.
+
+`$262.agent` is host-gated in the same way. Agent `start` runs the supplied
+source in a test262-host-enabled bare-loader thread with the bundled `$262`
+object installed; `broadcast`/`receiveBroadcast` share the provided value with
+agent threads, and `report`/`getReport` provide the report queue used by
+Atomics wait/notify tests.
 
 ## Strict mode
 

--- a/scripts/test262_harness/$262.js
+++ b/scripts/test262_harness/$262.js
@@ -35,6 +35,40 @@ var $262 = {
   createRealm() {
     return Goccia.test262.createRealm();
   },
+
+  agent: {
+    broadcast(value) {
+      return Goccia.test262.agent.broadcast(value);
+    },
+
+    getReport() {
+      return Goccia.test262.agent.getReport();
+    },
+
+    leaving() {
+      return Goccia.test262.agent.leaving();
+    },
+
+    monotonicNow() {
+      return Goccia.test262.agent.monotonicNow();
+    },
+
+    receiveBroadcast(callback) {
+      return Goccia.test262.agent.receiveBroadcast(callback);
+    },
+
+    report(value) {
+      return Goccia.test262.agent.report(value);
+    },
+
+    sleep(ms) {
+      return Goccia.test262.agent.sleep(ms);
+    },
+
+    start(sourceText) {
+      return Goccia.test262.agent.start(sourceText);
+    },
+  },
 };
 
 $262.AbstractModuleSource.prototype = Goccia.test262.abstractModuleSourcePrototype;

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -3,9 +3,11 @@ program GocciaScriptLoaderBare;
 {$I Goccia.inc}
 
 uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
   Classes,
   Generics.Collections,
   StrUtils,
+  SyncObjs,
   SysUtils,
 
   TextSemantics,
@@ -13,6 +15,7 @@ uses
   Goccia.Arguments.Collection,
   Goccia.AST.Node,
   Goccia.AST.Statements,
+  Goccia.Builtins.Atomics,
   Goccia.CLI.Options,
   Goccia.Engine,
   Goccia.Error,
@@ -26,6 +29,7 @@ uses
   Goccia.FileExtensions,
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
+  Goccia.MicrotaskQueue,
   Goccia.Modules,
   Goccia.Modules.ContentProvider,
   Goccia.Profiler,
@@ -36,9 +40,12 @@ uses
   Goccia.SourcePipeline,
   Goccia.Terminal.Colors,
   Goccia.TextFiles,
+  Goccia.Threading,
   Goccia.Timeout,
+  Goccia.Utils,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
@@ -59,6 +66,7 @@ type
     StrictTypes: Boolean;
     UnsafeFunctionConstructor: Boolean;
     Test262Host: Boolean;
+    Test262AgentCanSuspend: Boolean;
     Print: Boolean;
     Mode: TBareExecutionMode;
     SourceType: TGocciaSourceType;
@@ -74,6 +82,8 @@ type
   end;
 
   TBareTest262Realm = class;
+  TBareTest262AgentHost = class;
+  TBareTest262AgentThread = class;
   TBareTest262Host = class;
 
   TBareTest262EvalHost = class
@@ -105,13 +115,62 @@ type
 
   TBareTest262Host = class
   private
+    FAgentHost: TBareTest262AgentHost;
     FOptions: TBareOptions;
     FRealms: TObjectList<TBareTest262Realm>;
   public
     constructor Create(const AOptions: TBareOptions);
     destructor Destroy; override;
+    function CreateAgentObject: TGocciaObjectValue;
     function CreateRealm(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
+    property AgentHost: TBareTest262AgentHost read FAgentHost;
+  end;
+
+  TBareTest262AgentHost = class
+  private
+    FBroadcastGeneration: Integer;
+    FBroadcastValue: TGocciaValue;
+    FLock: TRTLCriticalSection;
+    FOptions: TBareOptions;
+    FReports: TStringList;
+    FShuttingDown: Boolean;
+    FTest262Host: TBareTest262Host;
+    procedure PumpCurrentThreadWork;
+  public
+    constructor Create(const AOptions: TBareOptions;
+      const ATest262Host: TBareTest262Host);
+    destructor Destroy; override;
+
+    function Broadcast(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function GetReport(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function Leaving(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function MonotonicNow(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ReceiveBroadcast(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function Report(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function SleepAgent(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function Start(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+  TBareTest262AgentThread = class(TThread)
+  private
+    FHost: TBareTest262Host;
+    FOptions: TBareOptions;
+    FSourceText: string;
+    procedure WaitForAsyncAgentWork;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(const AHost: TBareTest262Host;
+      const AOptions: TBareOptions; const ASourceText: string);
   end;
 
   TBareTest262ModuleContentProvider = class(TGocciaFileSystemModuleContentProvider)
@@ -165,6 +224,7 @@ begin
       ATest262EvalHost.EvalScript, 'evalScript', 1));
   Test262Obj.AssignProperty('abstractModuleSourcePrototype',
     TGocciaModuleSourceValue.SharedPrototype);
+  Test262Obj.AssignProperty('agent', ATest262Host.CreateAgentObject);
   AEngine.GocciaGlobal.AssignProperty('test262', Test262Obj);
 end;
 
@@ -393,13 +453,44 @@ constructor TBareTest262Host.Create(const AOptions: TBareOptions);
 begin
   inherited Create;
   FOptions := AOptions;
+  FAgentHost := TBareTest262AgentHost.Create(AOptions, Self);
   FRealms := TObjectList<TBareTest262Realm>.Create(True);
 end;
 
 destructor TBareTest262Host.Destroy;
 begin
   FRealms.Free;
+  FAgentHost.Free;
   inherited;
+end;
+
+function TBareTest262Host.CreateAgentObject: TGocciaObjectValue;
+begin
+  Result := TGocciaObjectValue.Create;
+  Result.AssignProperty('broadcast',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      FAgentHost.Broadcast, 'broadcast', 1));
+  Result.AssignProperty('getReport',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      FAgentHost.GetReport, 'getReport', 0));
+  Result.AssignProperty('leaving',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      FAgentHost.Leaving, 'leaving', 0));
+  Result.AssignProperty('monotonicNow',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      FAgentHost.MonotonicNow, 'monotonicNow', 0));
+  Result.AssignProperty('receiveBroadcast',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      FAgentHost.ReceiveBroadcast, 'receiveBroadcast', 1));
+  Result.AssignProperty('report',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      FAgentHost.Report, 'report', 1));
+  Result.AssignProperty('sleep',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      FAgentHost.SleepAgent, 'sleep', 1));
+  Result.AssignProperty('start',
+    TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      FAgentHost.Start, 'start', 1));
 end;
 
 function TBareTest262Host.CreateRealm(
@@ -421,6 +512,293 @@ begin
     TGocciaNativeFunctionValue.CreateWithoutPrototype(
       CreateRealm, 'createRealm', 0));
   Result := RealmRecord;
+end;
+
+constructor TBareTest262AgentHost.Create(const AOptions: TBareOptions;
+  const ATest262Host: TBareTest262Host);
+begin
+  inherited Create;
+  FOptions := AOptions;
+  FTest262Host := ATest262Host;
+  FReports := TStringList.Create;
+  FBroadcastGeneration := 0;
+  FBroadcastValue := nil;
+  FShuttingDown := False;
+  InitCriticalSection(FLock);
+end;
+
+destructor TBareTest262AgentHost.Destroy;
+begin
+  EnterCriticalSection(FLock);
+  try
+    FShuttingDown := True;
+    if Assigned(FBroadcastValue) and Assigned(TGarbageCollector.Instance) then
+      TGarbageCollector.Instance.RemoveQueuedRoot(FBroadcastValue);
+    FBroadcastValue := nil;
+  finally
+    LeaveCriticalSection(FLock);
+  end;
+  DoneCriticalSection(FLock);
+  FReports.Free;
+  inherited;
+end;
+
+procedure TBareTest262AgentHost.PumpCurrentThreadWork;
+var
+  Queue: TGocciaMicrotaskQueue;
+begin
+  PumpAtomicsWaitAsyncCompletions;
+  Queue := TGocciaMicrotaskQueue.Instance;
+  if Assigned(Queue) and Queue.HasPending then
+    Queue.DrainOneJob;
+end;
+
+function TBareTest262AgentHost.Broadcast(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Value: TGocciaValue;
+begin
+  if AArgs.Length > 0 then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  EnterCriticalSection(FLock);
+  try
+    if Assigned(FBroadcastValue) and Assigned(TGarbageCollector.Instance) then
+      TGarbageCollector.Instance.RemoveQueuedRoot(FBroadcastValue);
+    FBroadcastValue := Value;
+    if Assigned(FBroadcastValue) and Assigned(TGarbageCollector.Instance) then
+      TGarbageCollector.Instance.AddQueuedRoot(FBroadcastValue);
+    Inc(FBroadcastGeneration);
+  finally
+    LeaveCriticalSection(FLock);
+  end;
+
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TBareTest262AgentHost.GetReport(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  ReportText: string;
+begin
+  PumpCurrentThreadWork;
+  EnterCriticalSection(FLock);
+  try
+    if FReports.Count = 0 then
+      Exit(TGocciaNullLiteralValue.NullValue);
+    ReportText := FReports[0];
+    FReports.Delete(0);
+  finally
+    LeaveCriticalSection(FLock);
+  end;
+  Result := TGocciaStringLiteralValue.Create(ReportText);
+end;
+
+function TBareTest262AgentHost.Leaving(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  PumpCurrentThreadWork;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TBareTest262AgentHost.MonotonicNow(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaNumberLiteralValue.Create(GetTickCount64);
+end;
+
+function TBareTest262AgentHost.ReceiveBroadcast(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  BroadcastValue: TGocciaValue;
+  Callback: TGocciaValue;
+  CallbackArgs: TGocciaArgumentsCollection;
+begin
+  if (AArgs.Length = 0) or (not AArgs.GetElement(0).IsCallable) then
+    ThrowTypeError('$262.agent.receiveBroadcast callback must be callable');
+
+  Callback := AArgs.GetElement(0);
+  BroadcastValue := nil;
+  repeat
+    EnterCriticalSection(FLock);
+    try
+      if FShuttingDown then
+        Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+      if FBroadcastGeneration > 0 then
+      begin
+        BroadcastValue := FBroadcastValue;
+        Break;
+      end;
+    finally
+      LeaveCriticalSection(FLock);
+    end;
+
+    PumpCurrentThreadWork;
+    Sleep(1);
+  until False;
+
+  CallbackArgs := TGocciaArgumentsCollection.Create([BroadcastValue]);
+  try
+    Result := TGocciaFunctionBase(Callback).Call(CallbackArgs,
+      TGocciaUndefinedLiteralValue.UndefinedValue);
+  finally
+    CallbackArgs.Free;
+  end;
+end;
+
+function TBareTest262AgentHost.Report(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  ReportText: string;
+begin
+  if AArgs.Length > 0 then
+    ReportText := AArgs.GetElement(0).ToStringLiteral.Value
+  else
+    ReportText := TGocciaUndefinedLiteralValue.UndefinedValue.ToStringLiteral.Value;
+
+  EnterCriticalSection(FLock);
+  try
+    FReports.Add(ReportText);
+  finally
+    LeaveCriticalSection(FLock);
+  end;
+
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TBareTest262AgentHost.SleepAgent(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Deadline: QWord;
+  Milliseconds: Int64;
+  NowMilliseconds: QWord;
+  Remaining: Int64;
+begin
+  if AArgs.Length = 0 then
+    Milliseconds := 0
+  else
+    Milliseconds := ToInt64Value(AArgs.GetElement(0));
+  if Milliseconds < 0 then
+    Milliseconds := 0;
+
+  Deadline := GetTickCount64 + QWord(Milliseconds);
+  repeat
+    PumpCurrentThreadWork;
+    NowMilliseconds := GetTickCount64;
+    if NowMilliseconds >= Deadline then
+      Break;
+    Remaining := Int64(Deadline - NowMilliseconds);
+    if Remaining > 5 then
+      Sleep(5)
+    else
+      Sleep(LongWord(Remaining));
+  until False;
+
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TBareTest262AgentHost.Start(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  SourceText: string;
+  Worker: TBareTest262AgentThread;
+begin
+  if (AArgs.Length = 0) or
+     (not (AArgs.GetElement(0) is TGocciaStringLiteralValue)) then
+    ThrowTypeError('$262.agent.start source must be a string');
+
+  SourceText := TGocciaStringLiteralValue(AArgs.GetElement(0)).Value;
+  Worker := TBareTest262AgentThread.Create(FTest262Host, FOptions, SourceText);
+  Worker.Start;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+constructor TBareTest262AgentThread.Create(const AHost: TBareTest262Host;
+  const AOptions: TBareOptions; const ASourceText: string);
+const
+  AGENT_STACK_SIZE = 8 * 1024 * 1024;
+begin
+  inherited Create(True, AGENT_STACK_SIZE);
+  FreeOnTerminate := True;
+  FHost := AHost;
+  FOptions := AOptions;
+  FSourceText := ASourceText;
+end;
+
+procedure TBareTest262AgentThread.WaitForAsyncAgentWork;
+var
+  Queue: TGocciaMicrotaskQueue;
+begin
+  Queue := TGocciaMicrotaskQueue.Instance;
+  repeat
+    PumpAtomicsWaitAsyncCompletions;
+    if Assigned(Queue) and Queue.HasPending then
+    begin
+      Queue.DrainQueue;
+      Continue;
+    end;
+
+    if not HasPendingAtomicsWaitAsyncCompletions then
+      Break;
+
+    CheckInstructionLimit;
+    CheckExecutionTimeout;
+    Sleep(1);
+  until False;
+end;
+
+procedure TBareTest262AgentThread.Execute;
+var
+  AgentOptions: TBareOptions;
+  Engine: TGocciaEngine;
+  EvalHost: TBareTest262EvalHost;
+  Executor: TGocciaExecutor;
+  Source: TStringList;
+begin
+  InitThreadRuntime(False, FOptions.MaxMemoryBytes);
+  Source := TStringList.Create;
+  try
+    Source.Text := ReadUTF8FileText(ExpandFileName('scripts' + PathDelim +
+      'test262_harness' + PathDelim + '$262.js')) + LineEnding + FSourceText;
+    Executor := CreateExecutorForMode(FOptions.Mode);
+    try
+      Engine := TGocciaEngine.Create('<test262-agent>', Source, Executor);
+      try
+        AgentOptions := FOptions;
+        AgentOptions.SourceType := stScript;
+        AgentOptions.Test262Host := True;
+        ConfigureEngine(Engine, Executor, AgentOptions);
+        EvalHost := TBareTest262EvalHost.Create(Engine);
+        try
+          InstallTest262HostGlobals(Engine, FHost, EvalHost);
+          Engine.RefreshGlobalThis;
+          InstallTest262EvalGlobal(Engine, EvalHost);
+          Engine.SuspendRealmExecutionContext;
+          Engine.Execute;
+          WaitForAsyncAgentWork;
+        finally
+          EvalHost.Free;
+        end;
+      finally
+        Engine.Free;
+      end;
+    finally
+      Executor.Free;
+    end;
+  finally
+    Source.Free;
+    ShutdownThreadRuntime;
+  end;
 end;
 
 function NormalizeTest262ListItem(const AValue: string): string;
@@ -535,6 +913,80 @@ begin
           ARaw := ARaw or (NormalizeTest262ListItem(Value) = 'raw')
         else
           AddTest262ListItem(AIncludes, Value);
+      end;
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
+function Test262SourceCanSuspendAgent(const APath: string): Boolean;
+var
+  Block: string;
+  ClosePos: SizeInt;
+  ColonPos: SizeInt;
+  InFlags: Boolean;
+  Key: string;
+  Line: string;
+  Lines: TStringList;
+  OpenPos: SizeInt;
+  Source: UTF8String;
+  Trimmed: string;
+  Value: string;
+begin
+  Result := True;
+  if (APath = '') or (not FileExists(APath)) then
+    Exit;
+
+  Source := ReadUTF8FileText(APath);
+  OpenPos := Pos('/*---', string(Source));
+  if OpenPos <= 0 then
+    Exit;
+  ClosePos := PosEx('---*/', string(Source), OpenPos + Length('/*---'));
+  if ClosePos <= OpenPos then
+    Exit;
+
+  Block := Copy(string(Source), OpenPos + Length('/*---'),
+    ClosePos - OpenPos - Length('/*---'));
+  Lines := TStringList.Create;
+  try
+    Lines.Text := Block;
+    InFlags := False;
+    for Line in Lines do
+    begin
+      Trimmed := Trim(Line);
+      if Trimmed = '' then
+        Continue;
+
+      if (Line[1] <> ' ') and (Line[1] <> #9) then
+      begin
+        ColonPos := Pos(':', Line);
+        if ColonPos <= 0 then
+        begin
+          InFlags := False;
+          Continue;
+        end;
+
+        Key := Trim(Copy(Line, 1, ColonPos - 1));
+        Value := Trim(Copy(Line, ColonPos + 1, MaxInt));
+        InFlags := Key = 'flags';
+        if InFlags then
+        begin
+          if Pos('CanBlockIsFalse', Value) > 0 then
+            Exit(False);
+          if Pos('CanBlockIsTrue', Value) > 0 then
+            Exit(True);
+        end;
+        Continue;
+      end;
+
+      if InFlags and StartsStr('-', Trimmed) then
+      begin
+        Value := NormalizeTest262ListItem(Trim(Copy(Trimmed, 2, MaxInt)));
+        if Value = 'CanBlockIsFalse' then
+          Exit(False);
+        if Value = 'CanBlockIsTrue' then
+          Exit(True);
       end;
     end;
   finally
@@ -803,6 +1255,7 @@ begin
   Result.StrictTypes := False;
   Result.UnsafeFunctionConstructor := False;
   Result.Test262Host := False;
+  Result.Test262AgentCanSuspend := True;
   Result.Print := False;
   Result.Mode := bemInterpreted;
   Result.SourceType := stScript;
@@ -872,6 +1325,10 @@ begin
   if (Result.ProfileOutputPath <> '') and not Result.ProfileModePresent then
     raise Exception.Create(
       '--profile-output requires --profile=opcodes|functions|all');
+
+  if Result.Test262Host and (Result.SourceName <> '') then
+    Result.Test262AgentCanSuspend :=
+      Test262SourceCanSuspendAgent(Result.SourceName);
 end;
 
 function ReadBareSource(const AFileName: string): TStringList;
@@ -889,6 +1346,7 @@ begin
   AEngine.StrictTypes := AOptions.StrictTypes;
   AEngine.SourceType := AOptions.SourceType;
   AEngine.FunctionConstructor.Enabled := AOptions.UnsafeFunctionConstructor;
+  SetAtomicsAgentCanSuspend(AOptions.Test262AgentCanSuspend);
   if AOptions.Test262Host then
     AEngine.ModuleLoader.SetContentProvider(
       TBareTest262ModuleContentProvider.Create, True);

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -655,6 +655,8 @@ begin
     end;
 
     PumpCurrentThreadWork;
+    CheckInstructionLimit;
+    CheckExecutionTimeout;
     Sleep(1);
   until False;
 
@@ -707,6 +709,8 @@ begin
   Deadline := GetTickCount64 + QWord(Milliseconds);
   repeat
     PumpCurrentThreadWork;
+    CheckInstructionLimit;
+    CheckExecutionTimeout;
     NowMilliseconds := GetTickCount64;
     if NowMilliseconds >= Deadline then
       Break;
@@ -788,6 +792,8 @@ var
   Source: TStringList;
 begin
   InitThreadRuntime(False, FOptions.MaxMemoryBytes);
+  StartExecutionTimeout(FOptions.TimeoutMs);
+  StartInstructionLimit(FOptions.MaxInstructions);
   Source := TStringList.Create;
   try
     Source.Text := ReadUTF8FileText(ExpandFileName('scripts' + PathDelim +
@@ -1272,6 +1278,7 @@ function ParseOptions: TBareOptions;
 var
   I: Integer;
   Arg: string;
+  SourceMetadataPath: string;
 begin
   Result.Compatibility := [];
   Result.StrictTypes := False;
@@ -1348,9 +1355,15 @@ begin
     raise Exception.Create(
       '--profile-output requires --profile=opcodes|functions|all');
 
-  if Result.Test262Host and (Result.SourceName <> '') then
+  if Result.Test262Host then
+  begin
+    if Result.SourceName <> '' then
+      SourceMetadataPath := Result.SourceName
+    else
+      SourceMetadataPath := Result.FileName;
     Result.Test262AgentCanSuspend :=
-      Test262SourceCanSuspendAgent(Result.SourceName);
+      Test262SourceCanSuspendAgent(SourceMetadataPath);
+  end;
 end;
 
 function ReadBareSource(const AFileName: string): TStringList;

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -136,6 +136,7 @@ type
     FReports: TStringList;
     FShuttingDown: Boolean;
     FTest262Host: TBareTest262Host;
+    FWorkers: TObjectList<TBareTest262AgentThread>;
     procedure PumpCurrentThreadWork;
   public
     constructor Create(const AOptions: TBareOptions;
@@ -459,8 +460,8 @@ end;
 
 destructor TBareTest262Host.Destroy;
 begin
-  FRealms.Free;
   FAgentHost.Free;
+  FRealms.Free;
   inherited;
 end;
 
@@ -521,6 +522,7 @@ begin
   FOptions := AOptions;
   FTest262Host := ATest262Host;
   FReports := TStringList.Create;
+  FWorkers := TObjectList<TBareTest262AgentThread>.Create(True);
   FBroadcastGeneration := 0;
   FBroadcastValue := nil;
   FShuttingDown := False;
@@ -528,16 +530,28 @@ begin
 end;
 
 destructor TBareTest262AgentHost.Destroy;
+var
+  Worker: TBareTest262AgentThread;
 begin
   EnterCriticalSection(FLock);
   try
     FShuttingDown := True;
+  finally
+    LeaveCriticalSection(FLock);
+  end;
+
+  for Worker in FWorkers do
+    Worker.WaitFor;
+
+  EnterCriticalSection(FLock);
+  try
     if Assigned(FBroadcastValue) and Assigned(TGarbageCollector.Instance) then
       TGarbageCollector.Instance.RemoveQueuedRoot(FBroadcastValue);
     FBroadcastValue := nil;
   finally
     LeaveCriticalSection(FLock);
   end;
+  FWorkers.Free;
   DoneCriticalSection(FLock);
   FReports.Free;
   inherited;
@@ -718,8 +732,16 @@ begin
     ThrowTypeError('$262.agent.start source must be a string');
 
   SourceText := TGocciaStringLiteralValue(AArgs.GetElement(0)).Value;
-  Worker := TBareTest262AgentThread.Create(FTest262Host, FOptions, SourceText);
-  Worker.Start;
+  EnterCriticalSection(FLock);
+  try
+    if FShuttingDown then
+      Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+    Worker := TBareTest262AgentThread.Create(FTest262Host, FOptions, SourceText);
+    FWorkers.Add(Worker);
+    Worker.Start;
+  finally
+    LeaveCriticalSection(FLock);
+  end;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
@@ -729,7 +751,7 @@ const
   AGENT_STACK_SIZE = 8 * 1024 * 1024;
 begin
   inherited Create(True, AGENT_STACK_SIZE);
-  FreeOnTerminate := True;
+  FreeOnTerminate := False;
   FHost := AHost;
   FOptions := AOptions;
   FSourceText := ASourceText;

--- a/source/units/Goccia.Builtins.Atomics.pas
+++ b/source/units/Goccia.Builtins.Atomics.pas
@@ -17,7 +17,9 @@ uses
 function PumpAtomicsWaitAsyncCompletions: Integer;
 function HasPendingAtomicsWaitAsyncCompletions: Boolean;
 function WaitForAtomicsPromise(const APromise: TGocciaPromiseValue): Boolean;
+procedure SetAtomicsAgentCanSuspend(AValue: Boolean);
 procedure ShutdownAtomicsWaiters;
+procedure ShutdownAtomicsWaitersForCurrentThread;
 
 type
   TGocciaAtomics = class(TGocciaBuiltin)
@@ -59,6 +61,7 @@ type
 implementation
 
 uses
+  Classes,
   Generics.Collections,
   Math,
   SyncObjs,
@@ -73,6 +76,7 @@ uses
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
   Goccia.Timeout,
+  Goccia.Values.ArrayBufferValue,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -100,7 +104,10 @@ type
     FHasDeadline: Boolean;
     FInList: Boolean;
     FOwner: TGocciaAtomics;
+    FOwnerThreadId: TThreadID;
     FPromise: TGocciaPromiseValue;
+    FReady: Boolean;
+    FResult: string;
   public
     constructor Create(AOwner: TGocciaAtomics;
       ABuffer: TGocciaSharedArrayBufferValue; AByteOffset: Integer;
@@ -116,14 +123,32 @@ type
     property HasDeadline: Boolean read FHasDeadline;
     property InList: Boolean read FInList write FInList;
     property Owner: TGocciaAtomics read FOwner;
+    property OwnerThreadId: TThreadID read FOwnerThreadId;
     property Promise: TGocciaPromiseValue read FPromise;
+    property Ready: Boolean read FReady write FReady;
+    property ResultText: string read FResult write FResult;
   end;
 
 var
   GAtomicsLock: TRTLCriticalSection;
+  GAtomicsWaiters: TObjectList<TAtomicsWaiter>;
 
 threadvar
-  GAtomicsWaiters: TObjectList<TAtomicsWaiter>;
+  GAtomicsAgentCanSuspend: Boolean;
+  GAtomicsAgentCanSuspendConfigured: Boolean;
+
+function AtomicsAgentCanSuspend: Boolean;
+begin
+  if not GAtomicsAgentCanSuspendConfigured then
+    Exit(True);
+  Result := GAtomicsAgentCanSuspend;
+end;
+
+procedure SetAtomicsAgentCanSuspend(AValue: Boolean);
+begin
+  GAtomicsAgentCanSuspend := AValue;
+  GAtomicsAgentCanSuspendConfigured := True;
+end;
 
 function GetAtomicsWaiters: TObjectList<TAtomicsWaiter>;
 begin
@@ -139,11 +164,14 @@ constructor TAtomicsWaiter.Create(AOwner: TGocciaAtomics;
 begin
   inherited Create;
   FOwner := AOwner;
+  FOwnerThreadId := GetCurrentThreadId;
   FAsync := AAsync;
   FBuffer := ABuffer;
   FByteOffset := AByteOffset;
   FDeadlineMilliseconds := ADeadlineMilliseconds;
   FPromise := APromise;
+  FReady := False;
+  FResult := ATOMICS_WAIT_OK;
   FHasDeadline := AHasDeadline;
   FEvent := TEvent.Create(nil, True, False, '');
   FInList := False;
@@ -169,6 +197,11 @@ end;
 function AtomicsErrorMessage(const AMethodName, AMessage: string): string;
 begin
   Result := Format('Atomics.%s: %s', [AMethodName, AMessage]);
+end;
+
+function AtomicsSharedArrayBufferErrorMessage(const AMethodName: string): string;
+begin
+  Result := Format(SErrorRequiresSharedArrayBuffer, ['Atomics.' + AMethodName]);
 end;
 
 function GetArgumentOrUndefined(const AArgs: TGocciaArgumentsCollection;
@@ -289,10 +322,24 @@ begin
   Result := Trunc(CountNumber);
 end;
 
+procedure EnsureAtomicTypedArrayUsable(const ATypedArray: TGocciaTypedArrayValue;
+  const AMethodName: string; AWriteAccess: Boolean);
+begin
+  if (ATypedArray.BufferValue is TGocciaArrayBufferValue) and
+     TGocciaArrayBufferValue(ATypedArray.BufferValue).Detached then
+    ThrowTypeError(Format(SErrorCannotUseDetachedTypedArray,
+      ['Atomics.' + AMethodName]));
+  if AWriteAccess and (ATypedArray.BufferValue is TGocciaArrayBufferValue) and
+     TGocciaArrayBufferValue(ATypedArray.BufferValue).Immutable then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      'cannot write to an immutable ArrayBuffer'));
+end;
+
 procedure ValidateAtomicTypedArrayAccess(const AArgs: TGocciaArgumentsCollection;
-  const AMethodName: string; ARequireWaitable: Boolean;
+  const AMethodName: string; ARequireWaitable, AWriteAccess: Boolean;
   out ATypedArray: TGocciaTypedArrayValue; out AIndex, AByteOffset: Integer);
 var
+  ArrayLength: Integer;
   Bpe: Integer;
   IndexValue: TGocciaValue;
   TypedArrayValue: TGocciaValue;
@@ -312,9 +359,11 @@ begin
     ThrowTypeError(AtomicsErrorMessage(AMethodName,
       'typedArray must be an Int32Array or BigInt64Array'));
 
+  EnsureAtomicTypedArrayUsable(ATypedArray, AMethodName, AWriteAccess);
+  ArrayLength := ATypedArray.Length;
   IndexValue := GetArgumentOrUndefined(AArgs, 1);
   AIndex := ToIndexForAtomics(IndexValue, AMethodName);
-  if AIndex >= ATypedArray.Length then
+  if AIndex >= ArrayLength then
     ThrowRangeError(AtomicsErrorMessage(AMethodName,
       SErrorInvalidTypedArrayIndex));
 
@@ -323,18 +372,53 @@ begin
 end;
 
 procedure ValidateAtomicAccess(const AArgs: TGocciaArgumentsCollection;
-  const AMethodName: string; ARequireWaitable: Boolean;
+  const AMethodName: string; ARequireWaitable, AWriteAccess: Boolean;
   out ATypedArray: TGocciaTypedArrayValue;
-  out ABuffer: TGocciaSharedArrayBufferValue; out AIndex, AByteOffset: Integer);
+  out ABuffer: TGocciaValue; out AIndex, AByteOffset: Integer);
 begin
-  ValidateAtomicTypedArrayAccess(AArgs, AMethodName, ARequireWaitable,
+  ValidateAtomicTypedArrayAccess(AArgs, AMethodName, ARequireWaitable, AWriteAccess,
     ATypedArray, AIndex, AByteOffset);
+  ABuffer := ATypedArray.BufferValue;
+end;
+
+procedure ValidateAtomicsWaitAccess(const AArgs: TGocciaArgumentsCollection;
+  const AMethodName: string; out ATypedArray: TGocciaTypedArrayValue;
+  out ABuffer: TGocciaSharedArrayBufferValue; out AIndex,
+  AByteOffset: Integer);
+var
+  ArrayLength: Integer;
+  Bpe: Integer;
+  IndexValue: TGocciaValue;
+  TypedArrayValue: TGocciaValue;
+begin
+  TypedArrayValue := GetArgumentOrUndefined(AArgs, 0);
+  if not (TypedArrayValue is TGocciaTypedArrayValue) then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      'typedArray must be an integer TypedArray'));
+
+  ATypedArray := TGocciaTypedArrayValue(TypedArrayValue);
+
+  if not IsAtomicIntegerKind(ATypedArray.Kind) then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      'typedArray must be an integer TypedArray'));
+
+  if not IsWaitableKind(ATypedArray.Kind) then
+    ThrowTypeError(AtomicsErrorMessage(AMethodName,
+      'typedArray must be an Int32Array or BigInt64Array'));
 
   if not (ATypedArray.BufferValue is TGocciaSharedArrayBufferValue) then
-    ThrowTypeError(AtomicsErrorMessage(AMethodName,
-      SErrorRequiresSharedArrayBuffer));
+    ThrowTypeError(AtomicsSharedArrayBufferErrorMessage(AMethodName));
 
   ABuffer := TGocciaSharedArrayBufferValue(ATypedArray.BufferValue);
+  ArrayLength := ATypedArray.Length;
+  IndexValue := GetArgumentOrUndefined(AArgs, 1);
+  AIndex := ToIndexForAtomics(IndexValue, AMethodName);
+  if AIndex >= ArrayLength then
+    ThrowRangeError(AtomicsErrorMessage(AMethodName,
+      SErrorInvalidTypedArrayIndex));
+
+  Bpe := TGocciaTypedArrayValue.BytesPerElement(ATypedArray.Kind);
+  AByteOffset := ATypedArray.ByteOffset + AIndex * Bpe;
 end;
 
 function ReadNumberElement(ATypedArray: TGocciaTypedArrayValue;
@@ -538,7 +622,7 @@ end;
 function AtomicReadModifyWrite(const AArgs: TGocciaArgumentsCollection;
   const AMethodName: string; AOperation: TGocciaAtomicsOperation): TGocciaValue;
 var
-  Buffer: TGocciaSharedArrayBufferValue;
+  Buffer: TGocciaValue;
   ByteOffset: Integer;
   Index: Integer;
   NewBigIntRaw: Int64;
@@ -549,7 +633,7 @@ var
   OperandNumber: Double;
   TypedArray: TGocciaTypedArrayValue;
 begin
-  ValidateAtomicAccess(AArgs, AMethodName, False, TypedArray, Buffer, Index,
+  ValidateAtomicAccess(AArgs, AMethodName, False, True, TypedArray, Buffer, Index,
     ByteOffset);
 
   EnterCriticalSection(GAtomicsLock);
@@ -629,6 +713,7 @@ var
   DueWaiters: TList<TAtomicsWaiter>;
   I: Integer;
   NowMilliseconds: QWord;
+  OwnerThreadId: TThreadID;
   Waiter: TAtomicsWaiter;
   Waiters: TObjectList<TAtomicsWaiter>;
 begin
@@ -636,6 +721,7 @@ begin
   DueWaiters := TList<TAtomicsWaiter>.Create;
   try
     NowMilliseconds := GetTickCount64;
+    OwnerThreadId := GetCurrentThreadId;
     EnterCriticalSection(GAtomicsLock);
     try
       Waiters := GetAtomicsWaiters;
@@ -643,9 +729,12 @@ begin
       while I < Waiters.Count do
       begin
         Waiter := Waiters[I];
-        if Waiter.Async and Waiter.HasDeadline and
-          (NowMilliseconds >= Waiter.DeadlineMilliseconds) then
+        if Waiter.Async and (Waiter.OwnerThreadId = OwnerThreadId) and
+          (Waiter.Ready or (Waiter.HasDeadline and
+          (NowMilliseconds >= Waiter.DeadlineMilliseconds))) then
         begin
+          if not Waiter.Ready then
+            Waiter.ResultText := ATOMICS_WAIT_TIMED_OUT;
           Waiter.InList := False;
           Waiters.Delete(I);
           DueWaiters.Add(Waiter);
@@ -660,7 +749,7 @@ begin
     for Waiter in DueWaiters do
     begin
       Waiter.Promise.Resolve(TGocciaStringLiteralValue.Create(
-        ATOMICS_WAIT_TIMED_OUT));
+        Waiter.ResultText));
       Waiter.Free;
       Inc(Result);
     end;
@@ -679,7 +768,7 @@ begin
   try
     Waiters := GetAtomicsWaiters;
     for I := 0 to Waiters.Count - 1 do
-      if Waiters[I].Async then
+      if Waiters[I].Async and (Waiters[I].OwnerThreadId = GetCurrentThreadId) then
         Exit(True);
   finally
     LeaveCriticalSection(GAtomicsLock);
@@ -708,28 +797,11 @@ begin
   Result := True;
 end;
 
-function CurrentWaitValueMatches(ATypedArray: TGocciaTypedArrayValue;
-  AByteOffset: Integer; const AExpected: TGocciaValue): Boolean;
-var
-  ExpectedBigIntRaw: Int64;
-  ExpectedNumber: Double;
-begin
-  if ATypedArray.Kind = takBigInt64 then
-  begin
-    ExpectedBigIntRaw := ConvertBigIntRawForKind(ATypedArray.Kind, AExpected);
-    Result := ReadBigIntRawElement(ATypedArray, AByteOffset) = ExpectedBigIntRaw;
-  end
-  else
-  begin
-    ExpectedNumber := ConvertNumberForKind(ATypedArray.Kind, AExpected);
-    Result := ReadNumberElement(ATypedArray, AByteOffset) = ExpectedNumber;
-  end;
-end;
-
 function WaitForSynchronousWaiter(AWaiter: TAtomicsWaiter;
   ATimeoutMilliseconds: Int64): string;
 var
   Deadline: QWord;
+  NowMilliseconds: QWord;
   Remaining: Int64;
   Slice: LongWord;
   WaitResult: TWaitResult;
@@ -747,9 +819,10 @@ begin
       Slice := 50
     else
     begin
-      Remaining := Int64(Deadline - GetTickCount64);
-      if Remaining <= 0 then
+      NowMilliseconds := GetTickCount64;
+      if NowMilliseconds >= Deadline then
         Break;
+      Remaining := Int64(Deadline - NowMilliseconds);
       if Remaining > 50 then
         Slice := 50
       else
@@ -804,18 +877,68 @@ end;
 procedure ShutdownAtomicsWaiters;
 var
   Waiter: TAtomicsWaiter;
+  Waiters: TObjectList<TAtomicsWaiter>;
 begin
-  if not Assigned(GAtomicsWaiters) then
-    Exit;
+  Waiters := nil;
+  EnterCriticalSection(GAtomicsLock);
+  try
+    if not Assigned(GAtomicsWaiters) then
+      Exit;
+    Waiters := GAtomicsWaiters;
+    GAtomicsWaiters := nil;
+  finally
+    LeaveCriticalSection(GAtomicsLock);
+  end;
 
-  while GAtomicsWaiters.Count > 0 do
+  while Assigned(Waiters) and (Waiters.Count > 0) do
   begin
-    Waiter := GAtomicsWaiters[GAtomicsWaiters.Count - 1];
+    Waiter := Waiters[Waiters.Count - 1];
     Waiter.InList := False;
-    GAtomicsWaiters.Delete(GAtomicsWaiters.Count - 1);
+    Waiters.Delete(Waiters.Count - 1);
     Waiter.Free;
   end;
-  FreeAndNil(GAtomicsWaiters);
+  Waiters.Free;
+end;
+
+procedure ShutdownAtomicsWaitersForCurrentThread;
+var
+  CurrentThreadId: TThreadID;
+  I: Integer;
+  RemovedWaiters: TList<TAtomicsWaiter>;
+  Waiter: TAtomicsWaiter;
+  Waiters: TObjectList<TAtomicsWaiter>;
+begin
+  RemovedWaiters := TList<TAtomicsWaiter>.Create;
+  try
+    CurrentThreadId := GetCurrentThreadId;
+    EnterCriticalSection(GAtomicsLock);
+    try
+      if not Assigned(GAtomicsWaiters) then
+        Exit;
+
+      Waiters := GAtomicsWaiters;
+      I := 0;
+      while I < Waiters.Count do
+      begin
+        Waiter := Waiters[I];
+        if Waiter.OwnerThreadId = CurrentThreadId then
+        begin
+          Waiter.InList := False;
+          Waiters.Delete(I);
+          RemovedWaiters.Add(Waiter);
+        end
+        else
+          Inc(I);
+      end;
+    finally
+      LeaveCriticalSection(GAtomicsLock);
+    end;
+
+    for Waiter in RemovedWaiters do
+      Waiter.Free;
+  finally
+    RemovedWaiters.Free;
+  end;
 end;
 
 constructor TGocciaAtomics.Create(const AName: string; AScope: TGocciaScope;
@@ -890,7 +1013,7 @@ end;
 function TGocciaAtomics.AtomicsCompareExchange(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Buffer: TGocciaSharedArrayBufferValue;
+  Buffer: TGocciaValue;
   ByteOffset: Integer;
   ExpectedBigIntRaw: Int64;
   ExpectedNumber: Double;
@@ -901,7 +1024,7 @@ var
   ReplacementNumber: Double;
   TypedArray: TGocciaTypedArrayValue;
 begin
-  ValidateAtomicAccess(AArgs, 'compareExchange', False, TypedArray, Buffer,
+  ValidateAtomicAccess(AArgs, 'compareExchange', False, True, TypedArray, Buffer,
     Index, ByteOffset);
 
   EnterCriticalSection(GAtomicsLock);
@@ -952,12 +1075,12 @@ end;
 function TGocciaAtomics.AtomicsLoad(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Buffer: TGocciaSharedArrayBufferValue;
+  Buffer: TGocciaValue;
   ByteOffset: Integer;
   Index: Integer;
   TypedArray: TGocciaTypedArrayValue;
 begin
-  ValidateAtomicAccess(AArgs, 'load', False, TypedArray, Buffer, Index,
+  ValidateAtomicAccess(AArgs, 'load', False, False, TypedArray, Buffer, Index,
     ByteOffset);
 
   EnterCriticalSection(GAtomicsLock);
@@ -976,7 +1099,7 @@ end;
 function TGocciaAtomics.AtomicsNotify(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Buffer: TGocciaSharedArrayBufferValue;
+  Buffer: TGocciaValue;
   ByteOffset: Integer;
   Count: Integer;
   Index: Integer;
@@ -987,7 +1110,7 @@ var
   WaiterIndex: Integer;
   Waiters: TObjectList<TAtomicsWaiter>;
 begin
-  ValidateAtomicTypedArrayAccess(AArgs, 'notify', True, TypedArray, Index,
+  ValidateAtomicTypedArrayAccess(AArgs, 'notify', True, False, TypedArray, Index,
     ByteOffset);
   Count := ToWaiterCount(GetArgumentOrUndefined(AArgs, 2));
   if not (TypedArray.BufferValue is TGocciaSharedArrayBufferValue) then
@@ -1004,16 +1127,30 @@ begin
       while WaiterIndex < Waiters.Count do
       begin
         Waiter := Waiters[WaiterIndex];
-        if (Waiter.Buffer = Buffer) and (Waiter.ByteOffset = ByteOffset) and
+        if (not Waiter.Ready) and (Waiter.Buffer = Buffer) and
+          (Waiter.ByteOffset = ByteOffset) and
           ((Count < 0) or (NotifiedCount < Count)) then
         begin
-          Waiter.InList := False;
-          Waiters.Delete(WaiterIndex);
           Inc(NotifiedCount);
           if Waiter.Async then
-            ResolveWaiters.Add(Waiter)
+          begin
+            Waiter.Ready := True;
+            Waiter.ResultText := ATOMICS_WAIT_OK;
+            if Waiter.OwnerThreadId = GetCurrentThreadId then
+            begin
+              Waiter.InList := False;
+              Waiters.Delete(WaiterIndex);
+              ResolveWaiters.Add(Waiter);
+            end
+            else
+              Inc(WaiterIndex);
+          end
           else
+          begin
+            Waiter.InList := False;
+            Waiters.Delete(WaiterIndex);
             Waiter.Event.SetEvent;
+          end;
         end
         else
           Inc(WaiterIndex);
@@ -1066,7 +1203,7 @@ end;
 function TGocciaAtomics.AtomicsStore(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Buffer: TGocciaSharedArrayBufferValue;
+  Buffer: TGocciaValue;
   ByteOffset: Integer;
   Index: Integer;
   NewBigIntValue: TBigInteger;
@@ -1074,7 +1211,7 @@ var
   NewNumber: Double;
   TypedArray: TGocciaTypedArrayValue;
 begin
-  ValidateAtomicAccess(AArgs, 'store', False, TypedArray, Buffer, Index,
+  ValidateAtomicAccess(AArgs, 'store', False, True, TypedArray, Buffer, Index,
     ByteOffset);
 
   EnterCriticalSection(GAtomicsLock);
@@ -1090,6 +1227,8 @@ begin
     else
     begin
       NewNumber := ToIntegerOrInfinityNumber(GetArgumentOrUndefined(AArgs, 2));
+      if NewNumber = 0 then
+        NewNumber := 0.0;
       WriteNumberElement(TypedArray, ByteOffset, NewNumber);
       Result := TGocciaNumberLiteralValue.Create(NewNumber);
     end;
@@ -1109,21 +1248,39 @@ function TGocciaAtomics.AtomicsWait(const AArgs: TGocciaArgumentsCollection;
 var
   Buffer: TGocciaSharedArrayBufferValue;
   ByteOffset: Integer;
+  ExpectedBigIntRaw: Int64;
+  ExpectedNumber: Double;
   Index: Integer;
   TimeoutMilliseconds: Int64;
   TypedArray: TGocciaTypedArrayValue;
   Waiter: TAtomicsWaiter;
+  WaitValueMatches: Boolean;
   WaitResult: string;
 begin
-  ValidateAtomicAccess(AArgs, 'wait', True, TypedArray, Buffer, Index,
+  ValidateAtomicsWaitAccess(AArgs, 'wait', TypedArray, Buffer, Index,
     ByteOffset);
+  if TypedArray.Kind = takBigInt64 then
+    ExpectedBigIntRaw := ConvertBigIntRawForKind(TypedArray.Kind,
+      GetArgumentOrUndefined(AArgs, 2))
+  else
+    ExpectedNumber := ConvertNumberForKind(TypedArray.Kind,
+      GetArgumentOrUndefined(AArgs, 2));
   TimeoutMilliseconds := ToTimeoutMilliseconds(GetArgumentOrUndefined(AArgs, 3));
 
   EnterCriticalSection(GAtomicsLock);
   try
-    if not CurrentWaitValueMatches(TypedArray, ByteOffset,
-      GetArgumentOrUndefined(AArgs, 2)) then
+    if TypedArray.Kind = takBigInt64 then
+      WaitValueMatches := ReadBigIntRawElement(TypedArray, ByteOffset) =
+        ExpectedBigIntRaw
+    else
+      WaitValueMatches := ReadNumberElement(TypedArray, ByteOffset) =
+        ExpectedNumber;
+
+    if not WaitValueMatches then
       Exit(TGocciaStringLiteralValue.Create(ATOMICS_WAIT_NOT_EQUAL));
+
+    if not AtomicsAgentCanSuspend then
+      ThrowTypeError('Atomics.wait cannot suspend in this host context');
 
     if TimeoutMilliseconds = 0 then
       Exit(TGocciaStringLiteralValue.Create(ATOMICS_WAIT_TIMED_OUT));
@@ -1154,21 +1311,36 @@ var
   Buffer: TGocciaSharedArrayBufferValue;
   ByteOffset: Integer;
   DeadlineMilliseconds: QWord;
+  ExpectedBigIntRaw: Int64;
+  ExpectedNumber: Double;
   HasDeadline: Boolean;
   Index: Integer;
   Promise: TGocciaPromiseValue;
   TimeoutMilliseconds: Int64;
   TypedArray: TGocciaTypedArrayValue;
   Waiter: TAtomicsWaiter;
+  WaitValueMatches: Boolean;
 begin
-  ValidateAtomicAccess(AArgs, 'waitAsync', True, TypedArray, Buffer, Index,
+  ValidateAtomicsWaitAccess(AArgs, 'waitAsync', TypedArray, Buffer, Index,
     ByteOffset);
+  if TypedArray.Kind = takBigInt64 then
+    ExpectedBigIntRaw := ConvertBigIntRawForKind(TypedArray.Kind,
+      GetArgumentOrUndefined(AArgs, 2))
+  else
+    ExpectedNumber := ConvertNumberForKind(TypedArray.Kind,
+      GetArgumentOrUndefined(AArgs, 2));
   TimeoutMilliseconds := ToTimeoutMilliseconds(GetArgumentOrUndefined(AArgs, 3));
 
   EnterCriticalSection(GAtomicsLock);
   try
-    if not CurrentWaitValueMatches(TypedArray, ByteOffset,
-      GetArgumentOrUndefined(AArgs, 2)) then
+    if TypedArray.Kind = takBigInt64 then
+      WaitValueMatches := ReadBigIntRawElement(TypedArray, ByteOffset) =
+        ExpectedBigIntRaw
+    else
+      WaitValueMatches := ReadNumberElement(TypedArray, ByteOffset) =
+        ExpectedNumber;
+
+    if not WaitValueMatches then
       Exit(CreateWaitAsyncResult(False,
         TGocciaStringLiteralValue.Create(ATOMICS_WAIT_NOT_EQUAL)));
 

--- a/source/units/Goccia.Builtins.GlobalArray.pas
+++ b/source/units/Goccia.Builtins.GlobalArray.pas
@@ -47,6 +47,7 @@ uses
   Goccia.Values.FunctionValue,
   Goccia.Values.Iterator.Concrete,
   Goccia.Values.Iterator.Generic,
+  Goccia.Values.IteratorSupport,
   Goccia.Values.IteratorValue,
   Goccia.Values.PromiseValue,
   Goccia.Values.SymbolValue,
@@ -239,34 +240,44 @@ begin
     else
     begin
       // Step 4: Let usingIterator = GetMethod(items, @@iterator)
+      Iterator := nil;
       IteratorMethod := nil;
       if Source is TGocciaObjectValue then
-        IteratorMethod := TGocciaObjectValue(Source).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
+        IteratorMethod := TGocciaObjectValue(Source).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator)
+      else if not (Source is TGocciaNullLiteralValue) and
+              not (Source is TGocciaUndefinedLiteralValue) then
+        Iterator := GetIteratorFromValue(Source);
 
       // Step 5: If usingIterator is not undefined
-      if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
+      if Assigned(Iterator) or
+         (Assigned(IteratorMethod) and
+          not (IteratorMethod is TGocciaUndefinedLiteralValue) and
+          IteratorMethod.IsCallable) then
       begin
-        // Step 5c: Let iteratorRecord = GetIteratorFromMethod(items, usingIterator)
-        CallArgs := TGocciaArgumentsCollection.Create;
-        try
-          IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, Source);
-        finally
-          CallArgs.Free;
-        end;
-
-        if IteratorObj is TGocciaIteratorValue then
-          Iterator := TGocciaIteratorValue(IteratorObj)
-        else if IteratorObj is TGocciaObjectValue then
+        if not Assigned(Iterator) then
         begin
-          NextMethod := IteratorObj.GetProperty(PROP_NEXT);
-          if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
-            // Capture-once per ES2024 §7.4.2 GetIteratorDirect.
-            Iterator := TGocciaGenericIteratorValue.Create(IteratorObj, NextMethod)
+          // Step 5c: Let iteratorRecord = GetIteratorFromMethod(items, usingIterator)
+          CallArgs := TGocciaArgumentsCollection.Create;
+          try
+            IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, Source);
+          finally
+            CallArgs.Free;
+          end;
+
+          if IteratorObj is TGocciaIteratorValue then
+            Iterator := TGocciaIteratorValue(IteratorObj)
+          else if IteratorObj is TGocciaObjectValue then
+          begin
+            NextMethod := IteratorObj.GetProperty(PROP_NEXT);
+            if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
+              // Capture-once per ES2024 §7.4.2 GetIteratorDirect.
+              Iterator := TGocciaGenericIteratorValue.Create(IteratorObj, NextMethod)
+            else
+              Iterator := nil;
+          end
           else
             Iterator := nil;
-        end
-        else
-          Iterator := nil;
+        end;
 
         if not Assigned(Iterator) then
           ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);

--- a/source/units/Goccia.Builtins.GlobalArray.pas
+++ b/source/units/Goccia.Builtins.GlobalArray.pas
@@ -248,70 +248,78 @@ begin
               not (Source is TGocciaUndefinedLiteralValue) then
         Iterator := GetIteratorFromValue(Source);
 
+      if Assigned(IteratorMethod) and
+         not (IteratorMethod is TGocciaUndefinedLiteralValue) and
+         not (IteratorMethod is TGocciaNullLiteralValue) and
+         not IteratorMethod.IsCallable then
+        ThrowTypeError(Format(SErrorValueNotFunction, ['[Symbol.iterator]']),
+          SSuggestIteratorProtocol);
+
       // Step 5: If usingIterator is not undefined
       if Assigned(Iterator) or
          (Assigned(IteratorMethod) and
           not (IteratorMethod is TGocciaUndefinedLiteralValue) and
           IteratorMethod.IsCallable) then
       begin
-        if not Assigned(Iterator) then
-        begin
-          // Step 5c: Let iteratorRecord = GetIteratorFromMethod(items, usingIterator)
-          CallArgs := TGocciaArgumentsCollection.Create;
-          try
-            IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, Source);
-          finally
-            CallArgs.Free;
-          end;
-
-          if IteratorObj is TGocciaIteratorValue then
-            Iterator := TGocciaIteratorValue(IteratorObj)
-          else if IteratorObj is TGocciaObjectValue then
-          begin
-            NextMethod := IteratorObj.GetProperty(PROP_NEXT);
-            if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
-              // Capture-once per ES2024 §7.4.2 GetIteratorDirect.
-              Iterator := TGocciaGenericIteratorValue.Create(IteratorObj, NextMethod)
-            else
-              Iterator := nil;
-          end
-          else
-            Iterator := nil;
-        end;
-
-        if not Assigned(Iterator) then
-          ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
-
         // Step 5a-b: If IsConstructor(C), Construct(C, « »); else ArrayCreate(0)
         ResultObj := ConstructOrCreate(0);
-        TGarbageCollector.Instance.AddTempRoot(Iterator);
         AddTempRootIfNeeded(ResultRoot, ResultObj);
         try
-          // Step 5d-e: Iterate
-          K := 0;
-          IterResult := Iterator.AdvanceNext;
-          while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
+          if not Assigned(Iterator) then
           begin
-            KValue := IterResult.GetProperty(PROP_VALUE);
-            if Mapping then
-            begin
-              MapArgs.SetElement(0, KValue);
-              MapArgs.SetElement(1, TGocciaNumberLiteralValue.Create(K));
-              KValue := InvokeCallable(MapCallback, MapArgs, ThisArg);
+            // Step 5c: Let iteratorRecord = GetIteratorFromMethod(items, usingIterator)
+            CallArgs := TGocciaArgumentsCollection.Create;
+            try
+              IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, Source);
+            finally
+              CallArgs.Free;
             end;
-            // Step 5e-v: CreateDataPropertyOrThrow(A, ToString(k), mappedValue)
-            CreateDataProperty(K, KValue);
-            Inc(K);
-            IterResult := Iterator.AdvanceNext;
+
+            if IteratorObj is TGocciaIteratorValue then
+              Iterator := TGocciaIteratorValue(IteratorObj)
+            else if IteratorObj is TGocciaObjectValue then
+            begin
+              NextMethod := IteratorObj.GetProperty(PROP_NEXT);
+              if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
+                // Capture-once per ES2024 §7.4.2 GetIteratorDirect.
+                Iterator := TGocciaGenericIteratorValue.Create(IteratorObj, NextMethod)
+              else
+                Iterator := nil;
+            end;
           end;
+
+          if not Assigned(Iterator) then
+            ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
+
+          TGarbageCollector.Instance.AddTempRoot(Iterator);
+          try
+            // Step 5d-e: Iterate
+            K := 0;
+            IterResult := Iterator.AdvanceNext;
+            while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
+            begin
+              KValue := IterResult.GetProperty(PROP_VALUE);
+              if Mapping then
+              begin
+                MapArgs.SetElement(0, KValue);
+                MapArgs.SetElement(1, TGocciaNumberLiteralValue.Create(K));
+                KValue := InvokeCallable(MapCallback, MapArgs, ThisArg);
+              end;
+              // Step 5e-v: CreateDataPropertyOrThrow(A, ToString(k), mappedValue)
+              CreateDataProperty(K, KValue);
+              Inc(K);
+              IterResult := Iterator.AdvanceNext;
+            end;
+          finally
+            TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+          end;
+          // Step 5e-iii: Set A.[[length]] to k
+          if UseConstructor and not (ResultObj is TGocciaArrayValue) then
+            ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(K));
+          Result := ResultObj;
         finally
           RemoveTempRootIfNeeded(ResultRoot);
-          TGarbageCollector.Instance.RemoveTempRoot(Iterator);
         end;
-        // Step 5e-iii: Set A.[[length]] to k
-        if UseConstructor and not (ResultObj is TGocciaArrayValue) then
-          ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(K));
-        Result := ResultObj;
       end
       else
       begin

--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -50,6 +50,9 @@ implementation
 
 uses
   Generics.Collections,
+  SysUtils,
+
+  TextSemantics,
 
   Goccia.Arguments.Validator,
   Goccia.Arithmetic,
@@ -58,19 +61,65 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Utils,
+  Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassHelper,
   Goccia.Values.ClassValue,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.IteratorSupport,
+  Goccia.Values.IteratorValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ProxyValue,
+  Goccia.Values.StringObjectValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.ToObject,
-  Goccia.Values.ToPrimitive;
+  Goccia.Values.ToPrimitive,
+  Goccia.Values.TypedArrayValue;
 
 threadvar
   FStaticMembers: TArray<TGocciaMemberDefinition>;
+
+type
+  TPendingDefineProperty = record
+    Name: string;
+    Symbol: TGocciaSymbolValue;
+    IsSymbol: Boolean;
+    Descriptor: TGocciaPropertyDescriptor;
+  end;
+
+  TPendingDefinePropertyArray = array of TPendingDefineProperty;
+
+procedure AppendPendingDefineProperty(
+  var APendingProperties: TPendingDefinePropertyArray;
+  const AName: string; const ASymbol: TGocciaSymbolValue;
+  const AIsSymbol: Boolean; const ADescriptor: TGocciaPropertyDescriptor);
+var
+  Index: Integer;
+begin
+  Index := Length(APendingProperties);
+  SetLength(APendingProperties, Index + 1);
+  APendingProperties[Index].Name := AName;
+  APendingProperties[Index].Symbol := ASymbol;
+  APendingProperties[Index].IsSymbol := AIsSymbol;
+  APendingProperties[Index].Descriptor := ADescriptor;
+end;
+
+procedure ReleasePendingDefineProperties(
+  var APendingProperties: TPendingDefinePropertyArray);
+var
+  I: Integer;
+begin
+  for I := 0 to High(APendingProperties) do
+  begin
+    if Assigned(APendingProperties[I].Descriptor) then
+    begin
+      APendingProperties[I].Descriptor.Free;
+      APendingProperties[I].Descriptor := nil;
+    end;
+  end;
+  SetLength(APendingProperties, 0);
+end;
 
 // ES2026 §6.2.6.4 FromPropertyDescriptor(Desc)
 function FromPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor): TGocciaObjectValue;
@@ -164,6 +213,9 @@ begin
     Members.Free;
   end;
   RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
+  FBuiltinObject.DefineProperty(PROP_LENGTH,
+    TGocciaPropertyDescriptorData.Create(TGocciaNumberLiteralValue.Create(1),
+      [pfConfigurable]));
 end;
 
 // ES2026 §20.1.2.10 Object.is(value1, value2)
@@ -171,10 +223,14 @@ function TGocciaGlobalObject.ObjectIs(const AArgs: TGocciaArgumentsCollection; c
 var
   Left, Right: TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.is', ThrowError);
-
-  Left := AArgs.GetElement(0);
-  Right := AArgs.GetElement(1);
+  if AArgs.Length > 0 then
+    Left := AArgs.GetElement(0)
+  else
+    Left := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if AArgs.Length > 1 then
+    Right := AArgs.GetElement(1)
+  else
+    Right := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   // Step 1: Return SameValue(value1, value2)
   if IsSameValue(Left, Right) then
@@ -190,6 +246,7 @@ var
   Obj: TGocciaObjectValue;
   Keys: TGocciaArrayValue;
   Names: TArray<string>;
+  Descriptor: TGocciaPropertyDescriptor;
   I: Integer;
 begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.keys', ThrowError);
@@ -202,11 +259,18 @@ begin
   try
     Keys := TGocciaArrayValue.Create;
 
-    // Step 2: Let nameList be ? EnumerableOwnProperties(obj, key)
-    Names := Obj.GetEnumerablePropertyNames;
-    // Step 3: Return CreateArrayFromList(nameList)
+    // Step 2: Let nameList be ? EnumerableOwnProperties(obj, key).
+    if Obj is TGocciaStringObjectValue then
+      Names := TGocciaStringObjectValue(Obj).GetAllPropertyNames
+    else
+      Names := Obj.GetOwnPropertyKeys;
+
     for I := 0 to High(Names) do
-      Keys.Elements.Add(TGocciaStringLiteralValue.Create(Names[I]));
+    begin
+      Descriptor := Obj.GetOwnPropertyDescriptor(Names[I]);
+      if Assigned(Descriptor) and Descriptor.Enumerable then
+        Keys.Elements.Add(TGocciaStringLiteralValue.Create(Names[I]));
+    end;
 
     Result := Keys;
   finally
@@ -221,7 +285,8 @@ function TGocciaGlobalObject.ObjectValues(const AArgs: TGocciaArgumentsCollectio
 var
   Obj: TGocciaObjectValue;
   Values: TGocciaArrayValue;
-  PropertyValues: TArray<TGocciaValue>;
+  PropertyNames: TArray<string>;
+  Descriptor: TGocciaPropertyDescriptor;
   I: Integer;
 begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.values', ThrowError);
@@ -234,11 +299,18 @@ begin
   try
     Values := TGocciaArrayValue.Create;
 
-    // Step 2: Let nameList be ? EnumerableOwnProperties(obj, value)
-    PropertyValues := Obj.GetEnumerablePropertyValues;
-    // Step 3: Return CreateArrayFromList(nameList)
-    for I := 0 to High(PropertyValues) do
-      Values.Elements.Add(PropertyValues[I]);
+    // Step 2: Let valueList be ? EnumerableOwnProperties(obj, value).
+    if Obj is TGocciaStringObjectValue then
+      PropertyNames := TGocciaStringObjectValue(Obj).GetAllPropertyNames
+    else
+      PropertyNames := Obj.GetOwnPropertyKeys;
+
+    for I := 0 to High(PropertyNames) do
+    begin
+      Descriptor := Obj.GetOwnPropertyDescriptor(PropertyNames[I]);
+      if Assigned(Descriptor) and Descriptor.Enumerable then
+        Values.Elements.Add(Obj.GetProperty(PropertyNames[I]));
+    end;
 
     Result := Values;
   finally
@@ -254,7 +326,8 @@ var
   Obj: TGocciaObjectValue;
   Entries: TGocciaArrayValue;
   Entry: TGocciaArrayValue;
-  PropertyEntries: TArray<TPair<string, TGocciaValue>>;
+  PropertyNames: TArray<string>;
+  Descriptor: TGocciaPropertyDescriptor;
   I: Integer;
 begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.entries', ThrowError);
@@ -267,14 +340,21 @@ begin
   try
     Entries := TGocciaArrayValue.Create;
 
-    // Step 2: Let nameList be ? EnumerableOwnProperties(obj, key+value)
-    PropertyEntries := Obj.GetEnumerablePropertyEntries;
-    // Step 3: Return CreateArrayFromList(nameList) — each entry is a [key, value] pair
-    for I := 0 to High(PropertyEntries) do
+    // Step 2: Let entryList be ? EnumerableOwnProperties(obj, key+value).
+    if Obj is TGocciaStringObjectValue then
+      PropertyNames := TGocciaStringObjectValue(Obj).GetAllPropertyNames
+    else
+      PropertyNames := Obj.GetOwnPropertyKeys;
+
+    for I := 0 to High(PropertyNames) do
     begin
+      Descriptor := Obj.GetOwnPropertyDescriptor(PropertyNames[I]);
+      if not (Assigned(Descriptor) and Descriptor.Enumerable) then
+        Continue;
+
       Entry := TGocciaArrayValue.Create;
-      Entry.Elements.Add(TGocciaStringLiteralValue.Create(PropertyEntries[I].Key));
-      Entry.Elements.Add(PropertyEntries[I].Value);
+      Entry.Elements.Add(TGocciaStringLiteralValue.Create(PropertyNames[I]));
+      Entry.Elements.Add(Obj.GetProperty(PropertyNames[I]));
       Entries.Elements.Add(Entry);
     end;
 
@@ -291,38 +371,122 @@ function TGocciaGlobalObject.ObjectAssign(const AArgs: TGocciaArgumentsCollectio
 var
   InitialObj: TGocciaObjectValue;
   Source: TGocciaObjectValue;
-  PropertyEntries: TArray<TPair<string, TGocciaValue>>;
+  PropertyNames: TArray<string>;
+  PropertyKeyValues: TArray<TGocciaValue>;
+  SymbolKeys: TArray<TGocciaSymbolValue>;
+  Descriptor: TGocciaPropertyDescriptor;
+  PropValue: TGocciaValue;
+  SourceArg: TGocciaValue;
+  GC: TGarbageCollector;
   I, J: Integer;
-begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.assign', ThrowError);
 
-  // Step 1: Let to be ? ToObject(target)
-  InitialObj := ToObject(AArgs.GetElement(0));
-  if Assigned(TGarbageCollector.Instance) and
-     not (AArgs.GetElement(0) is TGocciaObjectValue) then
-    TGarbageCollector.Instance.AddTempRoot(InitialObj);
+  function IsReadonlyStringExoticKey(const ATarget: TGocciaObjectValue;
+    const AName: string): Boolean;
+  var
+    Index: Integer;
+    StringValue: string;
+  begin
+    Result := False;
+    if not (ATarget is TGocciaStringObjectValue) then
+      Exit;
+
+    if AName = PROP_LENGTH then
+      Exit(True);
+
+    if TryStrToInt(AName, Index) and (AName = IntToStr(Index)) then
+    begin
+      StringValue := TGocciaStringObjectValue(ATarget).Primitive.ToStringLiteral.Value;
+      Result := (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue));
+    end;
+  end;
+
+  procedure AssignStringKey(const AName: string);
+  begin
+    Descriptor := Source.GetOwnPropertyDescriptor(AName);
+    if Assigned(Descriptor) and Descriptor.Enumerable then
+    begin
+      PropValue := Source.GetProperty(AName);
+      if IsReadonlyStringExoticKey(InitialObj, AName) then
+        ThrowTypeError(Format(SErrorCannotAssignReadOnly, [AName]),
+          SSuggestCannotDeleteNonConfigurable);
+      InitialObj.SetProperty(AName, PropValue);
+    end;
+  end;
+
+  procedure AssignSymbolKey(const ASymbol: TGocciaSymbolValue);
+  begin
+    Descriptor := Source.GetOwnSymbolPropertyDescriptor(ASymbol);
+    if Assigned(Descriptor) and Descriptor.Enumerable then
+    begin
+      PropValue := Source.GetSymbolProperty(ASymbol);
+      InitialObj.AssignSymbolProperty(ASymbol, PropValue);
+    end;
+  end;
+begin
+  GC := TGarbageCollector.Instance;
+
+  // Step 1: Let to be ? ToObject(target).
+  if AArgs.Length > 0 then
+    InitialObj := ToObject(AArgs.GetElement(0))
+  else
+    InitialObj := ToObject(TGocciaUndefinedLiteralValue.UndefinedValue);
+  if Assigned(GC) and ((AArgs.Length = 0) or
+     not (AArgs.GetElement(0) is TGocciaObjectValue)) then
+    GC.AddTempRoot(InitialObj);
   try
-    // Step 2: For each element nextSource of sources
+    // Step 2: If only one argument was passed, return to.
+    if AArgs.Length <= 1 then
+      Exit(InitialObj);
+
+    // Step 3: For each element nextSource of sources.
     for I := 1 to AArgs.Length - 1 do
     begin
-      if (AArgs.GetElement(I) is TGocciaObjectValue) then
-      begin
-        Source := TGocciaObjectValue(AArgs.GetElement(I));
+      SourceArg := AArgs.GetElement(I);
+      if (SourceArg is TGocciaUndefinedLiteralValue) or
+         (SourceArg is TGocciaNullLiteralValue) then
+        Continue;
 
-        // Step 3: Let keys be ? EnumerableOwnProperties(nextSource, key+value)
-        PropertyEntries := Source.GetEnumerablePropertyEntries;
-        // Step 4: For each element key, Get value and Set on target
-        for J := 0 to High(PropertyEntries) do
-          InitialObj.AssignProperty(PropertyEntries[J].Key, PropertyEntries[J].Value);
+      Source := ToObject(SourceArg);
+      if Assigned(GC) and not (SourceArg is TGocciaObjectValue) then
+        GC.AddTempRoot(Source);
+      try
+        // ES2026 §20.1.2.1 step 3.a.ii: [[OwnPropertyKeys]].
+        if Source is TGocciaProxyValue then
+        begin
+          PropertyKeyValues := TGocciaProxyValue(Source).GetOwnPropertyKeyValues;
+          for J := 0 to High(PropertyKeyValues) do
+          begin
+            if PropertyKeyValues[J] is TGocciaSymbolValue then
+              AssignSymbolKey(TGocciaSymbolValue(PropertyKeyValues[J]))
+            else
+              AssignStringKey(PropertyKeyValues[J].ToStringLiteral.Value);
+          end;
+        end
+        else
+        begin
+          if Source is TGocciaStringObjectValue then
+            PropertyNames := TGocciaStringObjectValue(Source).GetAllPropertyNames
+          else
+            PropertyNames := Source.GetOwnPropertyKeys;
+          for J := 0 to High(PropertyNames) do
+            AssignStringKey(PropertyNames[J]);
+
+          SymbolKeys := Source.GetOwnSymbols;
+          for J := 0 to High(SymbolKeys) do
+            AssignSymbolKey(SymbolKeys[J]);
+        end;
+      finally
+        if Assigned(GC) and not (SourceArg is TGocciaObjectValue) then
+          GC.RemoveTempRoot(Source);
       end;
     end;
 
-    // Step 5: Return to
+    // Step 4: Return to.
     Result := InitialObj;
   finally
-    if Assigned(TGarbageCollector.Instance) and
-       not (AArgs.GetElement(0) is TGocciaObjectValue) then
-      TGarbageCollector.Instance.RemoveTempRoot(InitialObj);
+    if Assigned(GC) and ((AArgs.Length = 0) or
+       not (AArgs.GetElement(0) is TGocciaObjectValue)) then
+      GC.RemoveTempRoot(InitialObj);
   end;
 end;
 
@@ -643,61 +807,107 @@ end;
 function TGocciaGlobalObject.ObjectDefineProperties(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Obj: TGocciaObjectValue;
-  PropertiesDescriptor: TGocciaObjectValue;
-  PropertyEntries: TArray<TPair<string, TGocciaValue>>;
+  PropertiesObject: TGocciaObjectValue;
+  PropertyNames: TArray<string>;
+  PropertyKeyValues: TArray<TGocciaValue>;
   SymbolKeys: TArray<TGocciaSymbolValue>;
-  SymbolDesc: TGocciaPropertyDescriptor;
-  CallArgs: TGocciaArgumentsCollection;
+  PendingProperties: TPendingDefinePropertyArray;
+  PropertyDescriptor: TGocciaPropertyDescriptor;
+  DescriptorValue: TGocciaValue;
+  KeyValue: TGocciaValue;
+  GC: TGarbageCollector;
   I: Integer;
+
+  procedure CaptureStringDescriptor(const AName: string);
+  begin
+    PropertyDescriptor := PropertiesObject.GetOwnPropertyDescriptor(AName);
+    if Assigned(PropertyDescriptor) and PropertyDescriptor.Enumerable then
+    begin
+      DescriptorValue := PropertiesObject.GetProperty(AName);
+      AppendPendingDefineProperty(PendingProperties, AName, nil, False,
+        ToPropertyDescriptor(DescriptorValue, nil));
+    end;
+  end;
+
+  procedure CaptureSymbolDescriptor(const ASymbol: TGocciaSymbolValue);
+  begin
+    PropertyDescriptor := PropertiesObject.GetOwnSymbolPropertyDescriptor(ASymbol);
+    if Assigned(PropertyDescriptor) and PropertyDescriptor.Enumerable then
+    begin
+      DescriptorValue := PropertiesObject.GetSymbolProperty(ASymbol);
+      AppendPendingDefineProperty(PendingProperties, '', ASymbol, True,
+        ToPropertyDescriptor(DescriptorValue, nil));
+    end;
+  end;
 begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.defineProperties', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
     ThrowTypeError(SErrorObjectDefinePropertiesCalledOnNonObject, SSuggestObjectArgType);
 
-  // Step 1: Let props be ? ToObject(Properties)
-  if not (AArgs.GetElement(1) is TGocciaObjectValue) then
-    ThrowTypeError(SErrorObjectDefinePropertiesMustBeObject, SSuggestObjectArgType);
-
   Obj := TGocciaObjectValue(AArgs.GetElement(0));
-  PropertiesDescriptor := TGocciaObjectValue(AArgs.GetElement(1));
-  // Step 2: Let keys be ? props.[[OwnPropertyKeys]]()
-  PropertyEntries := PropertiesDescriptor.GetEnumerablePropertyEntries;
-
-  // Step 3: For each string key, ToPropertyDescriptor and DefinePropertyOrThrow
-  for I := 0 to High(PropertyEntries) do
-  begin
-    CallArgs := TGocciaArgumentsCollection.Create;
+  // ES2026 §20.1.2.3.1 step 1: Let props be ? ToObject(Properties).
+  PropertiesObject := ToObject(AArgs.GetElement(1));
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) and not (AArgs.GetElement(1) is TGocciaObjectValue) then
+    GC.AddTempRoot(PropertiesObject);
+  try
     try
-      CallArgs.Add(Obj);
-      CallArgs.Add(TGocciaStringLiteralValue.Create(PropertyEntries[I].Key));
-      CallArgs.Add(PropertyEntries[I].Value);
-      ObjectDefineProperty(CallArgs, AThisValue);
-    finally
-      CallArgs.Free;
-    end;
-  end;
+      // ES2026 §20.1.2.3.1 steps 2-4: collect descriptors before
+      // defining any target property.
+      if PropertiesObject is TGocciaProxyValue then
+      begin
+        PropertyKeyValues := TGocciaProxyValue(PropertiesObject).GetOwnPropertyKeyValues;
+        for KeyValue in PropertyKeyValues do
+        begin
+          if KeyValue is TGocciaSymbolValue then
+            CaptureSymbolDescriptor(TGocciaSymbolValue(KeyValue))
+          else
+            CaptureStringDescriptor(KeyValue.ToStringLiteral.Value);
+        end;
+      end
+      else
+      begin
+        if PropertiesObject is TGocciaStringObjectValue then
+          PropertyNames := TGocciaStringObjectValue(PropertiesObject).GetAllPropertyNames
+        else
+          PropertyNames := PropertiesObject.GetOwnPropertyKeys;
+        for I := 0 to High(PropertyNames) do
+          CaptureStringDescriptor(PropertyNames[I]);
 
-  // Step 3 (cont): Also process symbol-keyed descriptors per §20.1.2.3
-  // Use Get(props, key) to obtain the descriptor value — handles both data
-  // properties and accessor properties (invoking the getter if present).
-  SymbolKeys := PropertiesDescriptor.GetOwnSymbols;
-  for I := 0 to High(SymbolKeys) do
-  begin
-    SymbolDesc := PropertiesDescriptor.GetOwnSymbolPropertyDescriptor(SymbolKeys[I]);
-    if Assigned(SymbolDesc) and SymbolDesc.Enumerable then
-    begin
-      CallArgs := TGocciaArgumentsCollection.Create;
-      try
-        CallArgs.Add(Obj);
-        CallArgs.Add(SymbolKeys[I]);
-        // Get(props, key): invoke getter for accessors, read value for data
-        CallArgs.Add(PropertiesDescriptor.GetSymbolProperty(SymbolKeys[I]));
-        ObjectDefineProperty(CallArgs, AThisValue);
-      finally
-        CallArgs.Free;
+        SymbolKeys := PropertiesObject.GetOwnSymbols;
+        for I := 0 to High(SymbolKeys) do
+          CaptureSymbolDescriptor(SymbolKeys[I]);
       end;
+
+      // ES2026 §20.1.2.3.1 step 5: apply the collected descriptors.
+      for I := 0 to High(PendingProperties) do
+      begin
+        try
+          if PendingProperties[I].IsSymbol then
+            Obj.DefineSymbolProperty(PendingProperties[I].Symbol,
+              PendingProperties[I].Descriptor)
+          else
+            Obj.DefineProperty(PendingProperties[I].Name,
+              PendingProperties[I].Descriptor);
+          PendingProperties[I].Descriptor := nil;
+        except
+          if Assigned(PendingProperties[I].Descriptor) then
+          begin
+            PendingProperties[I].Descriptor.Free;
+            PendingProperties[I].Descriptor := nil;
+          end;
+          raise;
+        end;
+      end;
+    except
+      ReleasePendingDefineProperties(PendingProperties);
+      raise;
     end;
+  finally
+    ReleasePendingDefineProperties(PendingProperties);
+    if Assigned(GC) and not (AArgs.GetElement(1) is TGocciaObjectValue) then
+      GC.RemoveTempRoot(PropertiesObject);
   end;
 
   Result := Obj;
@@ -736,20 +946,35 @@ end;
 
 // ES2026 §20.1.2.6 Object.freeze(O)
 function TGocciaGlobalObject.ObjectFreeze(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Obj: TGocciaValue;
+  TypedArray: TGocciaTypedArrayValue;
 begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.freeze', ThrowError);
 
+  Obj := AArgs.GetElement(0);
+
   // Step 1: If Type(O) is not Object, return O
-  if not (AArgs.GetElement(0) is TGocciaObjectValue) then
+  if not (Obj is TGocciaObjectValue) then
   begin
-    Result := AArgs.GetElement(0);
+    Result := Obj;
     Exit;
   end;
 
+  if Obj is TGocciaTypedArrayValue then
+  begin
+    TypedArray := TGocciaTypedArrayValue(Obj);
+    if (TypedArray.BufferValue is TGocciaArrayBufferValue) and
+       (TGocciaArrayBufferValue(TypedArray.BufferValue).MaxByteLength >= 0) then
+      ThrowTypeError(
+        'Cannot freeze a typed array backed by a resizable ArrayBuffer',
+        'copy it to a fixed-length ArrayBuffer before freezing');
+  end;
+
   // Step 2: Let status be ? SetIntegrityLevel(O, frozen)
-  TGocciaObjectValue(AArgs.GetElement(0)).Freeze;
+  TGocciaObjectValue(Obj).Freeze;
   // Step 3: Return O
-  Result := AArgs.GetElement(0);
+  Result := Obj;
 end;
 
 // ES2026 §20.1.2.13 Object.isFrozen(O)
@@ -777,12 +1002,13 @@ var
   Obj: TGocciaObjectValue;
   Arg: TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.getPrototypeOf', ThrowError);
-
-  Arg := AArgs.GetElement(0);
+  if AArgs.Length > 0 then
+    Arg := AArgs.GetElement(0)
+  else
+    Arg := TGocciaUndefinedLiteralValue.UndefinedValue;
   Obj := ToObject(Arg);
   if Assigned(TGarbageCollector.Instance) and
-     not (AArgs.GetElement(0) is TGocciaObjectValue) then
+     not (Arg is TGocciaObjectValue) then
     TGarbageCollector.Instance.AddTempRoot(Obj);
   try
     // Proxy intercept: delegate to getPrototypeOf trap
@@ -799,7 +1025,7 @@ begin
       Result := TGocciaNullLiteralValue.NullValue;
   finally
     if Assigned(TGarbageCollector.Instance) and
-       not (AArgs.GetElement(0) is TGocciaObjectValue) then
+       not (Arg is TGocciaObjectValue) then
       TGarbageCollector.Instance.RemoveTempRoot(Obj);
   end;
 end;
@@ -808,41 +1034,57 @@ end;
 function TGocciaGlobalObject.ObjectFromEntries(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Obj: TGocciaObjectValue;
-  Entries: TGocciaArrayValue;
-  Entry: TGocciaArrayValue;
-  I: Integer;
+  Entry: TGocciaValue;
+  EntryObject: TGocciaObjectValue;
+  Iterable: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
+  Done: Boolean;
   Key: TGocciaValue;
+  PropertyKey: TGocciaValue;
   Value: TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.fromEntries', ThrowError);
+  if AArgs.Length > 0 then
+    Iterable := AArgs.GetElement(0)
+  else
+    Iterable := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  // Step 1: Perform ? RequireObjectCoercible(iterable)
-  if not (AArgs.GetElement(0) is TGocciaArrayValue) then
+  // Step 1: Perform ? RequireObjectCoercible(iterable).
+  RequireObjectCoercible(Iterable);
+
+  Iterator := GetIteratorFromValue(Iterable);
+  if not Assigned(Iterator) then
     ThrowTypeError(SErrorObjectFromEntriesRequiresIterable, SSuggestNotIterable);
 
-  Entries := TGocciaArrayValue(AArgs.GetElement(0));
-  // Step 2: Let obj be OrdinaryObjectCreate(%Object.prototype%)
+  // Step 2: Let obj be OrdinaryObjectCreate(%Object.prototype%).
   Obj := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
 
-  // Step 3: For each entry of iterable
-  for I := 0 to Entries.Elements.Count - 1 do
+  while True do
   begin
-    if not (Entries.Elements[I] is TGocciaArrayValue) then
-      ThrowTypeError(SErrorObjectFromEntriesRequiresIterable, SSuggestNotIterable);
+    Entry := Iterator.DirectNext(Done);
+    if Done then
+      Exit(Obj);
 
-    Entry := TGocciaArrayValue(Entries.Elements[I]);
-    if Entry.Elements.Count < 2 then
-      ThrowTypeError(SErrorObjectFromEntriesRequiresPairs, SSuggestNotIterable);
+    try
+      if not (Entry is TGocciaObjectValue) then
+        ThrowTypeError(SErrorObjectFromEntriesRequiresPairs, SSuggestNotIterable);
+      EntryObject := TGocciaObjectValue(Entry);
 
-    // Step 3a: Let key be entry[0], let value be entry[1]
-    Key := ToPropertyKey(Entry.Elements[0]);
-    Value := Entry.Elements[1];
-    // Step 3b: Perform ! CreateDataPropertyOrThrow(obj, key, value)
-    Obj.CreateDataPropertyOrThrow(Key, Value);
+      // ES2026 §24.1.1.2 steps 2.d-f: Get(entry, "0") and Get(entry, "1").
+      Key := EntryObject.GetProperty('0');
+      if not Assigned(Key) then
+        Key := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Value := EntryObject.GetProperty('1');
+      if not Assigned(Value) then
+        Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+      // ES2026 §20.1.2.7 steps 4.a-b: ToPropertyKey and CreateDataProperty.
+      PropertyKey := ToPropertyKey(Key);
+      Obj.CreateDataPropertyOrThrow(PropertyKey, Value);
+    except
+      CloseIteratorPreservingError(Iterator);
+      raise;
+    end;
   end;
-
-  // Step 4: Return obj
-  Result := Obj;
 end;
 
 // ES2026 §20.1.2.20 Object.seal(O)
@@ -932,30 +1174,37 @@ end;
 // ES2026 §20.1.2.21 Object.setPrototypeOf(O, proto)
 function TGocciaGlobalObject.ObjectSetPrototypeOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
+  TargetArg: TGocciaValue;
   ProtoArg: TGocciaValue;
   Target: TGocciaObjectValue;
   Walker: TGocciaObjectValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.setPrototypeOf', ThrowError);
+  if AArgs.Length > 0 then
+    TargetArg := AArgs.GetElement(0)
+  else
+    TargetArg := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if AArgs.Length > 1 then
+    ProtoArg := AArgs.GetElement(1)
+  else
+    ProtoArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   // Step 1: Perform ? RequireObjectCoercible(O) — throws for undefined/null
-  if (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) or
-     (AArgs.GetElement(0) is TGocciaNullLiteralValue) then
+  if (TargetArg is TGocciaUndefinedLiteralValue) or
+     (TargetArg is TGocciaNullLiteralValue) then
     ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
 
   // Step 2: If Type(proto) is neither Object nor Null, throw a TypeError exception
-  ProtoArg := AArgs.GetElement(1);
   if not (ProtoArg is TGocciaObjectValue) and not (ProtoArg is TGocciaNullLiteralValue) then
     ThrowTypeError(SErrorObjectPrototypeMustBeObjectOrNull, SSuggestObjectArgType);
 
   // Step 3: If Type(O) is not Object, return O (primitives are immutable)
-  if not (AArgs.GetElement(0) is TGocciaObjectValue) then
+  if not (TargetArg is TGocciaObjectValue) then
   begin
-    Result := AArgs.GetElement(0);
+    Result := TargetArg;
     Exit;
   end;
 
-  Target := TGocciaObjectValue(AArgs.GetElement(0));
+  Target := TGocciaObjectValue(TargetArg);
 
   // Proxy intercept: delegate to setPrototypeOf trap
   if Target is TGocciaProxyValue then
@@ -1022,7 +1271,9 @@ end;
 // ES2026 §20.1.2.8 Object.groupBy(items, callbackfn)
 function TGocciaGlobalObject.ObjectGroupBy(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Items: TGocciaArrayValue;
+  Item: TGocciaValue;
+  Items: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
   Callback: TGocciaValue;
   ResultObj: TGocciaObjectValue;
   GroupKey: string;
@@ -1031,79 +1282,96 @@ var
   GroupArray: TGocciaArrayValue;
   CallArgs: TGocciaArgumentsCollection;
   KeyValue: TGocciaValue;
+  Done: Boolean;
   I: Integer;
-  ItemsRoot, ResultRoot: TGocciaTempRoot;
+  ItemsRoot, IteratorRoot, CallbackRoot, ResultRoot: TGocciaTempRoot;
 begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.groupBy', ThrowError);
 
-  if not (AArgs.GetElement(0) is TGocciaArrayValue) then
-    ThrowTypeError(SErrorObjectGroupByRequiresIterable, SSuggestNotIterable);
+  Items := AArgs.GetElement(0);
   if not AArgs.GetElement(1).IsCallable then
     ThrowTypeError(SErrorObjectGroupByRequiresCallback, SSuggestCallbackRequired);
+  Iterator := GetIteratorFromValue(Items);
+  if not Assigned(Iterator) then
+    ThrowTypeError(SErrorObjectGroupByRequiresIterable, SSuggestNotIterable);
 
-  // Step 1: Let groups be ? GroupBy(items, callbackfn, property)
-  Items := TGocciaArrayValue(AArgs.GetElement(0));
   Callback := AArgs.GetElement(1);
   // Step 2: Let obj be OrdinaryObjectCreate(null)
   ResultObj := TGocciaObjectValue.Create;
   ResultObj.Prototype := nil;
   InitializeTempRoot(ItemsRoot);
+  InitializeTempRoot(IteratorRoot);
+  InitializeTempRoot(CallbackRoot);
   InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ItemsRoot, Items);
+  AddTempRootIfNeeded(IteratorRoot, Iterator);
+  AddTempRootIfNeeded(CallbackRoot, Callback);
   AddTempRootIfNeeded(ResultRoot, ResultObj);
   try
 
     // Step 3: For each Record { [[Key]], [[Elements]] } g of groups
     I := 0;
-    while I < Items.Elements.Count do
+    while True do
     begin
-      CallArgs := TGocciaArgumentsCollection.Create;
+      Item := Iterator.DirectNext(Done);
+      if Done then
+        Break;
+
       try
-        CallArgs.Add(Items.Elements[I]);
-        CallArgs.Add(TGocciaNumberLiteralValue.Create(I));
+        CallArgs := TGocciaArgumentsCollection.Create;
+        try
+          CallArgs.Add(Item);
+          CallArgs.Add(TGocciaNumberLiteralValue.Create(I));
 
-        KeyValue := InvokeCallable(Callback, CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
-      finally
-        CallArgs.Free;
-      end;
+          KeyValue := InvokeCallable(Callback, CallArgs,
+            TGocciaUndefinedLiteralValue.UndefinedValue);
+        finally
+          CallArgs.Free;
+        end;
 
-      PropertyKey := ToPropertyKey(KeyValue);
+        PropertyKey := ToPropertyKey(KeyValue);
 
-      if PropertyKey is TGocciaSymbolValue then
-      begin
-        SymbolKey := TGocciaSymbolValue(PropertyKey);
-        if ResultObj.HasSymbolProperty(SymbolKey) then
-          GroupArray := TGocciaArrayValue(ResultObj.GetSymbolProperty(SymbolKey))
+        if PropertyKey is TGocciaSymbolValue then
+        begin
+          SymbolKey := TGocciaSymbolValue(PropertyKey);
+          if ResultObj.HasSymbolProperty(SymbolKey) then
+            GroupArray := TGocciaArrayValue(ResultObj.GetSymbolProperty(SymbolKey))
+          else
+          begin
+            // Step 3a: Let elements be CreateArrayFromList(g.[[Elements]])
+            GroupArray := TGocciaArrayValue.Create;
+            // Step 3b: Perform ! CreateDataPropertyOrThrow(obj, g.[[Key]], elements)
+            ResultObj.CreateDataPropertyOrThrow(SymbolKey, GroupArray);
+          end;
+        end
         else
         begin
-          // Step 3a: Let elements be CreateArrayFromList(g.[[Elements]])
-          GroupArray := TGocciaArrayValue.Create;
-          // Step 3b: Perform ! CreateDataPropertyOrThrow(obj, g.[[Key]], elements)
-          ResultObj.CreateDataPropertyOrThrow(SymbolKey, GroupArray);
+          GroupKey := TGocciaStringLiteralValue(PropertyKey).Value;
+          if ResultObj.HasOwnProperty(GroupKey) then
+            GroupArray := TGocciaArrayValue(ResultObj.GetProperty(GroupKey))
+          else
+          begin
+            // Step 3a: Let elements be CreateArrayFromList(g.[[Elements]])
+            GroupArray := TGocciaArrayValue.Create;
+            // Step 3b: Perform ! CreateDataPropertyOrThrow(obj, g.[[Key]], elements)
+            ResultObj.CreateDataPropertyOrThrow(GroupKey, GroupArray);
+          end;
         end;
-      end
-      else
-      begin
-        GroupKey := TGocciaStringLiteralValue(PropertyKey).Value;
-        if ResultObj.HasOwnProperty(GroupKey) then
-          GroupArray := TGocciaArrayValue(ResultObj.GetProperty(GroupKey))
-        else
-        begin
-          // Step 3a: Let elements be CreateArrayFromList(g.[[Elements]])
-          GroupArray := TGocciaArrayValue.Create;
-          // Step 3b: Perform ! CreateDataPropertyOrThrow(obj, g.[[Key]], elements)
-          ResultObj.CreateDataPropertyOrThrow(GroupKey, GroupArray);
-        end;
-      end;
 
-      GroupArray.Elements.Add(Items.Elements[I]);
-      Inc(I);
+        GroupArray.Elements.Add(Item);
+        Inc(I);
+      except
+        CloseIteratorPreservingError(Iterator);
+        raise;
+      end;
     end;
 
     // Step 4: Return obj
     Result := ResultObj;
   finally
     RemoveTempRootIfNeeded(ResultRoot);
+    RemoveTempRootIfNeeded(CallbackRoot);
+    RemoveTempRootIfNeeded(IteratorRoot);
     RemoveTempRootIfNeeded(ItemsRoot);
   end;
 end;

--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -408,7 +408,7 @@ var
       PropValue := Source.GetProperty(AName);
       if IsReadonlyStringExoticKey(InitialObj, AName) then
         ThrowTypeError(Format(SErrorCannotAssignReadOnly, [AName]),
-          SSuggestCannotDeleteNonConfigurable);
+          SSuggestReadOnlyProperty);
       InitialObj.SetProperty(AName, PropValue);
     end;
   end;
@@ -1042,6 +1042,7 @@ var
   Key: TGocciaValue;
   PropertyKey: TGocciaValue;
   Value: TGocciaValue;
+  IteratorRoot, ResultRoot: TGocciaTempRoot;
 begin
   if AArgs.Length > 0 then
     Iterable := AArgs.GetElement(0)
@@ -1055,35 +1056,47 @@ begin
   if not Assigned(Iterator) then
     ThrowTypeError(SErrorObjectFromEntriesRequiresIterable, SSuggestNotIterable);
 
-  // Step 2: Let obj be OrdinaryObjectCreate(%Object.prototype%).
-  Obj := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-
-  while True do
-  begin
-    Entry := Iterator.DirectNext(Done);
-    if Done then
-      Exit(Obj);
+  InitializeTempRoot(IteratorRoot);
+  InitializeTempRoot(ResultRoot);
+  AddTempRootIfNeeded(IteratorRoot, Iterator);
+  try
+    // Step 2: Let obj be OrdinaryObjectCreate(%Object.prototype%).
+    Obj := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
+    AddTempRootIfNeeded(ResultRoot, Obj);
 
     try
-      if not (Entry is TGocciaObjectValue) then
-        ThrowTypeError(SErrorObjectFromEntriesRequiresPairs, SSuggestNotIterable);
-      EntryObject := TGocciaObjectValue(Entry);
+      while True do
+      begin
+        Entry := Iterator.DirectNext(Done);
+        if Done then
+          Exit(Obj);
 
-      // ES2026 §24.1.1.2 steps 2.d-f: Get(entry, "0") and Get(entry, "1").
-      Key := EntryObject.GetProperty('0');
-      if not Assigned(Key) then
-        Key := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Value := EntryObject.GetProperty('1');
-      if not Assigned(Value) then
-        Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+        try
+          if not (Entry is TGocciaObjectValue) then
+            ThrowTypeError(SErrorObjectFromEntriesRequiresPairs, SSuggestNotIterable);
+          EntryObject := TGocciaObjectValue(Entry);
 
-      // ES2026 §20.1.2.7 steps 4.a-b: ToPropertyKey and CreateDataProperty.
-      PropertyKey := ToPropertyKey(Key);
-      Obj.CreateDataPropertyOrThrow(PropertyKey, Value);
-    except
-      CloseIteratorPreservingError(Iterator);
-      raise;
+          // ES2026 §24.1.1.2 steps 2.d-f: Get(entry, "0") and Get(entry, "1").
+          Key := EntryObject.GetProperty('0');
+          if not Assigned(Key) then
+            Key := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Value := EntryObject.GetProperty('1');
+          if not Assigned(Value) then
+            Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+          // ES2026 §20.1.2.7 steps 4.a-b: ToPropertyKey and CreateDataProperty.
+          PropertyKey := ToPropertyKey(Key);
+          Obj.CreateDataPropertyOrThrow(PropertyKey, Value);
+        except
+          CloseIteratorPreservingError(Iterator);
+          raise;
+        end;
+      end;
+    finally
+      RemoveTempRootIfNeeded(ResultRoot);
     end;
+  finally
+    RemoveTempRootIfNeeded(IteratorRoot);
   end;
 end;
 

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -95,6 +95,7 @@ type
   private
     FResolve: TGocciaValue;
     FReject: TGocciaValue;
+    FInvoked: Boolean;
   public
     function Invoke(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -143,13 +144,21 @@ type
     procedure MarkReferences; override;
   end;
 
+  TPromiseAlreadyCalledCell = class(TGocciaObjectValue)
+  private
+    FCalled: Boolean;
+  public
+    property Called: Boolean read FCalled write FCalled;
+  end;
+
   TPromiseAllSettledFulfillHandler = class(TGocciaObjectValue)
   private
     FState: TPromiseAllState;
     FIndex: Integer;
-    FAlreadyCalled: Boolean;
+    FAlreadyCalled: TPromiseAlreadyCalledCell;
   public
-    constructor Create(const AState: TPromiseAllState; const AIndex: Integer);
+    constructor Create(const AState: TPromiseAllState; const AIndex: Integer;
+      const AAlreadyCalled: TPromiseAlreadyCalledCell);
     function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure MarkReferences; override;
   end;
@@ -158,9 +167,10 @@ type
   private
     FState: TPromiseAllState;
     FIndex: Integer;
-    FAlreadyCalled: Boolean;
+    FAlreadyCalled: TPromiseAlreadyCalledCell;
   public
-    constructor Create(const AState: TPromiseAllState; const AIndex: Integer);
+    constructor Create(const AState: TPromiseAllState; const AIndex: Integer;
+      const AAlreadyCalled: TPromiseAlreadyCalledCell);
     function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure MarkReferences; override;
   end;
@@ -267,16 +277,13 @@ type
 function TPromiseCapabilityExecutor.Invoke(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
-  function HasNonUndefinedValue(const AValue: TGocciaValue): Boolean;
-  begin
-    Result := Assigned(AValue) and not (AValue is TGocciaUndefinedLiteralValue);
-  end;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  if HasNonUndefinedValue(FResolve) or HasNonUndefinedValue(FReject) then
+  if FInvoked then
     ThrowTypeError(SErrorPromiseResolverNotFunction, SSuggestPromiseResolver);
 
+  FInvoked := True;
   FResolve := AArgs.GetElement(0);
   FReject := AArgs.GetElement(1);
 end;
@@ -471,9 +478,9 @@ end;
 function PromiseDefaultPrototypeForNewTarget(const ANewTarget: TGocciaValue;
   const AIntrinsicDefault: TGocciaObjectValue): TGocciaObjectValue;
 var
-  ConstructorPrototype, ConstructorValue, ProtoValue: TGocciaValue;
+  ProtoValue: TGocciaValue;
   FallbackRealm: TGocciaRealm;
-  GlobalScope: TGocciaScope;
+  FallbackPrototype: TGocciaObjectValue;
 begin
   if ANewTarget is TGocciaObjectValue then
     ProtoValue := TGocciaObjectValue(ANewTarget).GetProperty(PROP_PROTOTYPE)
@@ -487,18 +494,11 @@ begin
   if ANewTarget is TGocciaFunctionBase then
     FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
 
-  if Assigned(FallbackRealm) and
-     (FallbackRealm.GlobalEnv is TGocciaScope) then
+  if Assigned(FallbackRealm) then
   begin
-    GlobalScope := TGocciaScope(FallbackRealm.GlobalEnv);
-    if GlobalScope.TryGetBindingValue('Promise', ConstructorValue) and
-       (ConstructorValue is TGocciaObjectValue) then
-    begin
-      ConstructorPrototype :=
-        TGocciaObjectValue(ConstructorValue).GetProperty(PROP_PROTOTYPE);
-      if ConstructorPrototype is TGocciaObjectValue then
-        Exit(TGocciaObjectValue(ConstructorPrototype));
-    end;
+    FallbackPrototype := GetPromiseIntrinsicPrototypeForRealm(FallbackRealm);
+    if Assigned(FallbackPrototype) then
+      Exit(FallbackPrototype);
   end;
 
   Result := AIntrinsicDefault;
@@ -629,12 +629,14 @@ end;
 
 { TPromiseAllSettledFulfillHandler }
 
-constructor TPromiseAllSettledFulfillHandler.Create(const AState: TPromiseAllState; const AIndex: Integer);
+constructor TPromiseAllSettledFulfillHandler.Create(
+  const AState: TPromiseAllState; const AIndex: Integer;
+  const AAlreadyCalled: TPromiseAlreadyCalledCell);
 begin
   inherited Create(nil);
   FState := AState;
   FIndex := AIndex;
-  FAlreadyCalled := False;
+  FAlreadyCalled := AAlreadyCalled;
 end;
 
 function TPromiseAllSettledFulfillHandler.Invoke(const AArgs: TGocciaArgumentsCollection;
@@ -643,8 +645,9 @@ var
   Entry: TGocciaObjectValue;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  if FAlreadyCalled then Exit;
-  FAlreadyCalled := True;
+  if Assigned(FAlreadyCalled) and FAlreadyCalled.Called then Exit;
+  if Assigned(FAlreadyCalled) then
+    FAlreadyCalled.Called := True;
   if FState.Settled then Exit;
 
   Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
@@ -666,16 +669,19 @@ begin
   if GCMarked then Exit;
   inherited;
   if Assigned(FState) then FState.MarkReferences;
+  if Assigned(FAlreadyCalled) then FAlreadyCalled.MarkReferences;
 end;
 
 { TPromiseAllSettledRejectHandler }
 
-constructor TPromiseAllSettledRejectHandler.Create(const AState: TPromiseAllState; const AIndex: Integer);
+constructor TPromiseAllSettledRejectHandler.Create(
+  const AState: TPromiseAllState; const AIndex: Integer;
+  const AAlreadyCalled: TPromiseAlreadyCalledCell);
 begin
   inherited Create(nil);
   FState := AState;
   FIndex := AIndex;
-  FAlreadyCalled := False;
+  FAlreadyCalled := AAlreadyCalled;
 end;
 
 function TPromiseAllSettledRejectHandler.Invoke(const AArgs: TGocciaArgumentsCollection;
@@ -684,8 +690,9 @@ var
   Entry: TGocciaObjectValue;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  if FAlreadyCalled then Exit;
-  FAlreadyCalled := True;
+  if Assigned(FAlreadyCalled) and FAlreadyCalled.Called then Exit;
+  if Assigned(FAlreadyCalled) then
+    FAlreadyCalled.Called := True;
   if FState.Settled then Exit;
 
   Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
@@ -707,6 +714,7 @@ begin
   if GCMarked then Exit;
   inherited;
   if Assigned(FState) then FState.MarkReferences;
+  if Assigned(FAlreadyCalled) then FAlreadyCalled.MarkReferences;
 end;
 
 { TPromiseRaceHandler }
@@ -1467,6 +1475,7 @@ begin
       except
         on E: Exception do
         begin
+          CloseIteratorPreservingError(Iterator);
           Result := RejectPromiseCapabilityWithException(Capability, E);
           Exit;
         end;
@@ -1548,6 +1557,7 @@ var
   FulfillHandler: TPromiseAllSettledFulfillHandler;
   RejectHandler: TPromiseAllSettledRejectHandler;
   FulfillFn, RejectFn: TGocciaNativeFunctionValue;
+  AlreadyCalled: TPromiseAlreadyCalledCell;
   Done: Boolean;
   Index: Integer;
 begin
@@ -1567,15 +1577,10 @@ begin
       try
         NextValue := Iterator.DirectNext(Done);
       except
-        on E: EGocciaBytecodeThrow do
+        on E: Exception do
         begin
-          Result := RejectPromiseCapabilityWithReason(Capability,
-            E.ThrownValue);
-          Exit;
-        end;
-        on E: TGocciaThrowValue do
-        begin
-          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithException(Capability, E);
           Exit;
         end;
       end;
@@ -1593,9 +1598,11 @@ begin
         State.Results.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
         PromiseLike := CallPromiseResolveMethod(PromiseResolve, AThisValue,
           NextValue);
+        AlreadyCalled := TPromiseAlreadyCalledCell.Create(nil);
         FulfillHandler := TPromiseAllSettledFulfillHandler.Create(State,
-          Index);
-        RejectHandler := TPromiseAllSettledRejectHandler.Create(State, Index);
+          Index, AlreadyCalled);
+        RejectHandler := TPromiseAllSettledRejectHandler.Create(State, Index,
+          AlreadyCalled);
 
         FulfillFn := CreatePromiseElementFunction(FulfillHandler.Invoke,
           FulfillHandler);
@@ -1670,15 +1677,10 @@ begin
       try
         NextValue := Iterator.DirectNext(Done);
       except
-        on E: EGocciaBytecodeThrow do
+        on E: Exception do
         begin
-          Result := RejectPromiseCapabilityWithReason(Capability,
-            E.ThrownValue);
-          Exit;
-        end;
-        on E: TGocciaThrowValue do
-        begin
-          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithException(Capability, E);
           Exit;
         end;
       end;
@@ -1756,15 +1758,10 @@ begin
       try
         NextValue := Iterator.DirectNext(Done);
       except
-        on E: EGocciaBytecodeThrow do
+        on E: Exception do
         begin
-          Result := RejectPromiseCapabilityWithReason(Capability,
-            E.ThrownValue);
-          Exit;
-        end;
-        on E: TGocciaThrowValue do
-        begin
-          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithException(Capability, E);
           Exit;
         end;
       end;
@@ -1920,8 +1917,8 @@ begin
     on E: TGocciaInstructionLimitError do
       raise;
     on E: Exception do
-      CallPromiseCapability(Capability.Reject, CreateErrorObject(ERROR_NAME,
-        E.Message));
+      CallPromiseCapability(Capability.Reject,
+        PromiseRejectionReasonFromException(E));
   end;
 
   { Step 7: Return promiseCapability.[[Promise]] }

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -23,6 +23,8 @@ type
     FPromiseIntrinsicProto: TGocciaObjectValue;
 
     function ExtractPromiseArray(const AArgs: TGocciaArgumentsCollection): TGocciaArrayValue;
+    function PromiseKeyed(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue; const AAllSettled: Boolean): TGocciaValue;
     function PromiseConstruct(const AArgs: TGocciaArgumentsCollection; const ANewTarget: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
@@ -35,6 +37,8 @@ type
     function PromiseAllSettled(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function PromiseRace(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function PromiseAny(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function PromiseAllKeyed(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function PromiseAllSettledKeyed(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function PromiseWithResolvers(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function PromiseTry(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
@@ -47,19 +51,24 @@ uses
   Goccia.Arithmetic,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
   Goccia.MicrotaskQueue,
+  Goccia.Realm,
   Goccia.Timeout,
   Goccia.Utils,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
+  Goccia.Values.IteratorSupport,
+  Goccia.Values.IteratorValue,
   Goccia.Values.MapValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.PromiseValue,
+  Goccia.Values.ProxyValue,
   Goccia.Values.SetValue,
   Goccia.Values.SymbolValue,
   Goccia.VM.Exception;
@@ -73,6 +82,14 @@ type
     Resolve: TGocciaValue;
     Reject: TGocciaValue;
   end;
+
+  TPromiseKeyRecord = record
+    Name: string;
+    Symbol: TGocciaSymbolValue;
+    IsSymbol: Boolean;
+  end;
+
+  TPromiseKeyRecordArray = array of TPromiseKeyRecord;
 
   TPromiseCapabilityExecutor = class(TGocciaObjectValue)
   private
@@ -110,6 +127,7 @@ type
   private
     FState: TPromiseAllState;
     FIndex: Integer;
+    FAlreadyCalled: Boolean;
   public
     constructor Create(const AState: TPromiseAllState; const AIndex: Integer);
     function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -129,6 +147,7 @@ type
   private
     FState: TPromiseAllState;
     FIndex: Integer;
+    FAlreadyCalled: Boolean;
   public
     constructor Create(const AState: TPromiseAllState; const AIndex: Integer);
     function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -139,6 +158,7 @@ type
   private
     FState: TPromiseAllState;
     FIndex: Integer;
+    FAlreadyCalled: Boolean;
   public
     constructor Create(const AState: TPromiseAllState; const AIndex: Integer);
     function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -188,8 +208,57 @@ type
   private
     FState: TPromiseAnyState;
     FIndex: Integer;
+    FAlreadyCalled: Boolean;
   public
     constructor Create(const AState: TPromiseAnyState; const AIndex: Integer);
+    function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    procedure MarkReferences; override;
+  end;
+
+  TPromiseKeyedState = class(TGocciaObjectValue)
+  private
+    FResultObject: TGocciaObjectValue;
+    FRemaining: Integer;
+    FResolve: TGocciaValue;
+    FReject: TGocciaValue;
+    FSettled: Boolean;
+  public
+    constructor Create(const AResultObject: TGocciaObjectValue;
+      const AResolve, AReject: TGocciaValue; const ACount: Integer);
+    procedure MarkReferences; override;
+    property ResultObject: TGocciaObjectValue read FResultObject;
+    property Remaining: Integer read FRemaining write FRemaining;
+    property Resolve: TGocciaValue read FResolve;
+    property Reject: TGocciaValue read FReject;
+    property Settled: Boolean read FSettled write FSettled;
+  end;
+
+  TPromiseKeyedFulfillHandler = class(TGocciaObjectValue)
+  private
+    FState: TPromiseKeyedState;
+    FName: string;
+    FSymbol: TGocciaSymbolValue;
+    FIsSymbol: Boolean;
+    FAllSettled: Boolean;
+    FAlreadyCalled: Boolean;
+  public
+    constructor Create(const AState: TPromiseKeyedState; const AName: string;
+      const ASymbol: TGocciaSymbolValue; const AIsSymbol, AAllSettled: Boolean);
+    function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    procedure MarkReferences; override;
+  end;
+
+  TPromiseKeyedRejectHandler = class(TGocciaObjectValue)
+  private
+    FState: TPromiseKeyedState;
+    FName: string;
+    FSymbol: TGocciaSymbolValue;
+    FIsSymbol: Boolean;
+    FAllSettled: Boolean;
+    FAlreadyCalled: Boolean;
+  public
+    constructor Create(const AState: TPromiseKeyedState; const AName: string;
+      const ASymbol: TGocciaSymbolValue; const AIsSymbol, AAllSettled: Boolean);
     function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure MarkReferences; override;
   end;
@@ -198,10 +267,14 @@ type
 function TPromiseCapabilityExecutor.Invoke(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
+  function HasNonUndefinedValue(const AValue: TGocciaValue): Boolean;
+  begin
+    Result := Assigned(AValue) and not (AValue is TGocciaUndefinedLiteralValue);
+  end;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  if Assigned(FResolve) or Assigned(FReject) then
+  if HasNonUndefinedValue(FResolve) or HasNonUndefinedValue(FReject) then
     ThrowTypeError(SErrorPromiseResolverNotFunction, SSuggestPromiseResolver);
 
   FResolve := AArgs.GetElement(0);
@@ -240,6 +313,53 @@ begin
   Result := ACapability.Promise;
 end;
 
+function PromiseRejectionReasonFromException(
+  const AException: Exception): TGocciaValue;
+begin
+  if AException is EGocciaBytecodeThrow then
+    Result := EGocciaBytecodeThrow(AException).ThrownValue
+  else if AException is TGocciaThrowValue then
+    Result := TGocciaThrowValue(AException).Value
+  else if AException is TGocciaTypeError then
+    Result := CreateErrorObject(TYPE_ERROR_NAME, AException.Message)
+  else if AException is TGocciaReferenceError then
+    Result := CreateErrorObject(REFERENCE_ERROR_NAME, AException.Message)
+  else if AException is TGocciaSyntaxError then
+    Result := CreateErrorObject(SYNTAX_ERROR_NAME, AException.Message)
+  else if AException is TGocciaRuntimeError then
+    Result := CreateErrorObject(ERROR_NAME, AException.Message)
+  else
+    raise AException;
+end;
+
+function RejectPromiseCapabilityWithException(
+  const ACapability: TPromiseCapability;
+  const AException: Exception): TGocciaValue;
+begin
+  Result := RejectPromiseCapabilityWithReason(ACapability,
+    PromiseRejectionReasonFromException(AException));
+end;
+
+function CreateAnonymousPromiseBuiltinFunction(
+  const AFunction: TGocciaNativeFunctionCallback;
+  const ACapturedRoot: TGocciaValue; const AArity: Integer): TGocciaNativeFunctionValue;
+begin
+  Result := TGocciaNativeFunctionValue.CreateWithoutPrototype(AFunction, '',
+    AArity);
+  Result.CapturedRoot := ACapturedRoot;
+  Result.DefineProperty(PROP_LENGTH, TGocciaPropertyDescriptorData.Create(
+    TGocciaNumberLiteralValue.Create(AArity), [pfConfigurable]));
+  Result.DefineProperty(PROP_NAME, TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(''), [pfConfigurable]));
+end;
+
+function CreatePromiseElementFunction(
+  const AFunction: TGocciaNativeFunctionCallback;
+  const ACapturedRoot: TGocciaValue): TGocciaNativeFunctionValue;
+begin
+  Result := CreateAnonymousPromiseBuiltinFunction(AFunction, ACapturedRoot, 1);
+end;
+
 function NewPromiseCapability(const AConstructor: TGocciaValue;
   const ANativeConstructor: TGocciaNativeFunctionValue): TPromiseCapability;
 var
@@ -253,12 +373,10 @@ begin
   if AConstructor = ANativeConstructor then
   begin
     Promise := TGocciaPromiseValue.Create;
-    ResolveFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-      Promise.DoResolve, 'resolve', 1);
-    RejectFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-      Promise.DoReject, 'reject', 1);
-    ResolveFn.CapturedRoot := Promise;
-    RejectFn.CapturedRoot := Promise;
+    ResolveFn := CreateAnonymousPromiseBuiltinFunction(Promise.DoResolve,
+      Promise, 1);
+    RejectFn := CreateAnonymousPromiseBuiltinFunction(Promise.DoReject,
+      Promise, 1);
     Result.Promise := Promise;
     Result.Resolve := ResolveFn;
     Result.Reject := RejectFn;
@@ -269,9 +387,8 @@ begin
     ThrowTypeError(SErrorValueNotConstructor, SSuggestNotConstructorType);
 
   ExecutorHost := TPromiseCapabilityExecutor.Create;
-  ExecutorFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-    ExecutorHost.Invoke, '', 2);
-  ExecutorFn.CapturedRoot := ExecutorHost;
+  ExecutorFn := CreateAnonymousPromiseBuiltinFunction(ExecutorHost.Invoke,
+    ExecutorHost, 2);
   ConstructArgs := TGocciaArgumentsCollection.Create([ExecutorFn]);
   GC := TGarbageCollector.Instance;
   try
@@ -317,6 +434,74 @@ begin
   finally
     Args.Free;
   end;
+end;
+
+function GetPromiseResolveMethod(const AConstructor: TGocciaValue): TGocciaValue;
+begin
+  if not (AConstructor is TGocciaObjectValue) then
+    ThrowTypeError(SErrorValueNotConstructor, SSuggestNotConstructorType);
+
+  Result := TGocciaObjectValue(AConstructor).GetProperty(PROP_RESOLVE);
+  if not Assigned(Result) or not Result.IsCallable then
+    ThrowTypeError(SErrorPromiseResolverNotFunction, SSuggestPromiseResolver);
+end;
+
+function CallPromiseResolveMethod(const APromiseResolve, AConstructor,
+  AValue: TGocciaValue): TGocciaValue;
+var
+  Args: TGocciaArgumentsCollection;
+begin
+  Args := TGocciaArgumentsCollection.Create([AValue]);
+  try
+    Result := DispatchCall(APromiseResolve, Args, AConstructor);
+  finally
+    Args.Free;
+  end;
+end;
+
+function GetPromiseIterator(const AIterable: TGocciaValue): TGocciaIteratorValue;
+begin
+  Result := GetIteratorFromValue(AIterable);
+  if not Assigned(Result) then
+    Goccia.Values.ErrorHelper.ThrowTypeError(
+      AIterable.ToStringLiteral.Value + ' is not iterable',
+      SSuggestNotIterable);
+end;
+
+function PromiseDefaultPrototypeForNewTarget(const ANewTarget: TGocciaValue;
+  const AIntrinsicDefault: TGocciaObjectValue): TGocciaObjectValue;
+var
+  ConstructorPrototype, ConstructorValue, ProtoValue: TGocciaValue;
+  FallbackRealm: TGocciaRealm;
+  GlobalScope: TGocciaScope;
+begin
+  if ANewTarget is TGocciaObjectValue then
+    ProtoValue := TGocciaObjectValue(ANewTarget).GetProperty(PROP_PROTOTYPE)
+  else
+    ProtoValue := nil;
+
+  if ProtoValue is TGocciaObjectValue then
+    Exit(TGocciaObjectValue(ProtoValue));
+
+  FallbackRealm := nil;
+  if ANewTarget is TGocciaFunctionBase then
+    FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
+
+  if Assigned(FallbackRealm) and
+     (FallbackRealm.GlobalEnv is TGocciaScope) then
+  begin
+    GlobalScope := TGocciaScope(FallbackRealm.GlobalEnv);
+    if GlobalScope.TryGetBindingValue('Promise', ConstructorValue) and
+       (ConstructorValue is TGocciaObjectValue) then
+    begin
+      ConstructorPrototype :=
+        TGocciaObjectValue(ConstructorValue).GetProperty(PROP_PROTOTYPE);
+      if ConstructorPrototype is TGocciaObjectValue then
+        Exit(TGocciaObjectValue(ConstructorPrototype));
+    end;
+  end;
+
+  Result := AIntrinsicDefault;
 end;
 
 procedure InvokePromiseLikeThen(const APromiseLike, AOnFulfilled,
@@ -389,12 +574,15 @@ begin
   inherited Create(nil);
   FState := AState;
   FIndex := AIndex;
+  FAlreadyCalled := False;
 end;
 
 function TPromiseAllHandler.Invoke(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if FAlreadyCalled then Exit;
+  FAlreadyCalled := True;
   if FState.Settled then Exit;
 
   FState.Results.Elements[FIndex] := AArgs.GetElement(0);
@@ -446,6 +634,7 @@ begin
   inherited Create(nil);
   FState := AState;
   FIndex := AIndex;
+  FAlreadyCalled := False;
 end;
 
 function TPromiseAllSettledFulfillHandler.Invoke(const AArgs: TGocciaArgumentsCollection;
@@ -454,6 +643,8 @@ var
   Entry: TGocciaObjectValue;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if FAlreadyCalled then Exit;
+  FAlreadyCalled := True;
   if FState.Settled then Exit;
 
   Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
@@ -484,6 +675,7 @@ begin
   inherited Create(nil);
   FState := AState;
   FIndex := AIndex;
+  FAlreadyCalled := False;
 end;
 
 function TPromiseAllSettledRejectHandler.Invoke(const AArgs: TGocciaArgumentsCollection;
@@ -492,6 +684,8 @@ var
   Entry: TGocciaObjectValue;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if FAlreadyCalled then Exit;
+  FAlreadyCalled := True;
   if FState.Settled then Exit;
 
   Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
@@ -601,6 +795,7 @@ begin
   inherited Create(nil);
   FState := AState;
   FIndex := AIndex;
+  FAlreadyCalled := False;
 end;
 
 function TPromiseAnyRejectHandler.Invoke(const AArgs: TGocciaArgumentsCollection;
@@ -609,6 +804,8 @@ var
   ErrorObj: TGocciaObjectValue;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if FAlreadyCalled then Exit;
+  FAlreadyCalled := True;
   if FState.Settled then Exit;
 
   FState.Errors.Elements[FIndex] := AArgs.GetElement(0);
@@ -631,6 +828,148 @@ begin
   if Assigned(FState) then FState.MarkReferences;
 end;
 
+{ TPromiseKeyedState }
+
+constructor TPromiseKeyedState.Create(const AResultObject: TGocciaObjectValue;
+  const AResolve, AReject: TGocciaValue; const ACount: Integer);
+begin
+  inherited Create(nil);
+  FResultObject := AResultObject;
+  FResolve := AResolve;
+  FReject := AReject;
+  FRemaining := ACount;
+  FSettled := False;
+end;
+
+procedure TPromiseKeyedState.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FResultObject) then FResultObject.MarkReferences;
+  if Assigned(FResolve) then FResolve.MarkReferences;
+  if Assigned(FReject) then FReject.MarkReferences;
+end;
+
+procedure SetKeyedResultValue(const AObject: TGocciaObjectValue;
+  const AName: string; const ASymbol: TGocciaSymbolValue;
+  const AIsSymbol: Boolean; const AValue: TGocciaValue);
+begin
+  if AIsSymbol then
+    AObject.AssignSymbolProperty(ASymbol, AValue)
+  else
+    AObject.AssignProperty(AName, AValue);
+end;
+
+function CreateAllSettledEntry(const AStatus, APropertyName: string;
+  const AValue: TGocciaValue): TGocciaObjectValue;
+begin
+  Result := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
+  Result.CreateDataPropertyOrThrow('status',
+    TGocciaStringLiteralValue.Create(AStatus));
+  Result.CreateDataPropertyOrThrow(APropertyName, AValue);
+end;
+
+{ TPromiseKeyedFulfillHandler }
+
+constructor TPromiseKeyedFulfillHandler.Create(
+  const AState: TPromiseKeyedState; const AName: string;
+  const ASymbol: TGocciaSymbolValue; const AIsSymbol, AAllSettled: Boolean);
+begin
+  inherited Create(nil);
+  FState := AState;
+  FName := AName;
+  FSymbol := ASymbol;
+  FIsSymbol := AIsSymbol;
+  FAllSettled := AAllSettled;
+  FAlreadyCalled := False;
+end;
+
+function TPromiseKeyedFulfillHandler.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Value: TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if FAlreadyCalled then Exit;
+  FAlreadyCalled := True;
+  if FState.Settled then Exit;
+
+  if FAllSettled then
+    Value := CreateAllSettledEntry('fulfilled', PROP_VALUE, AArgs.GetElement(0))
+  else
+    Value := AArgs.GetElement(0);
+  SetKeyedResultValue(FState.ResultObject, FName, FSymbol, FIsSymbol, Value);
+  FState.Remaining := FState.Remaining - 1;
+
+  if FState.Remaining = 0 then
+  begin
+    FState.Settled := True;
+    CallPromiseCapability(FState.Resolve, FState.ResultObject);
+  end;
+end;
+
+procedure TPromiseKeyedFulfillHandler.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FState) then FState.MarkReferences;
+  if Assigned(FSymbol) then FSymbol.MarkReferences;
+end;
+
+{ TPromiseKeyedRejectHandler }
+
+constructor TPromiseKeyedRejectHandler.Create(
+  const AState: TPromiseKeyedState; const AName: string;
+  const ASymbol: TGocciaSymbolValue; const AIsSymbol, AAllSettled: Boolean);
+begin
+  inherited Create(nil);
+  FState := AState;
+  FName := AName;
+  FSymbol := ASymbol;
+  FIsSymbol := AIsSymbol;
+  FAllSettled := AAllSettled;
+  FAlreadyCalled := False;
+end;
+
+function TPromiseKeyedRejectHandler.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Value: TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if FAlreadyCalled then Exit;
+  FAlreadyCalled := True;
+  if FState.Settled then Exit;
+
+  if FAllSettled then
+  begin
+    Value := CreateAllSettledEntry('rejected', 'reason', AArgs.GetElement(0));
+    SetKeyedResultValue(FState.ResultObject, FName, FSymbol, FIsSymbol, Value);
+    FState.Remaining := FState.Remaining - 1;
+
+    if FState.Remaining = 0 then
+    begin
+      FState.Settled := True;
+      CallPromiseCapability(FState.Resolve, FState.ResultObject);
+    end;
+  end
+  else
+  begin
+    FState.Settled := True;
+    CallPromiseCapability(FState.Reject, AArgs.GetElement(0));
+  end;
+end;
+
+procedure TPromiseKeyedRejectHandler.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FState) then FState.MarkReferences;
+  if Assigned(FSymbol) then FSymbol.MarkReferences;
+end;
+
 { TGocciaGlobalPromise }
 
 constructor TGocciaGlobalPromise.Create(const AName: string; const AScope: TGocciaScope;
@@ -642,6 +981,12 @@ begin
 
   FPromiseConstructor := TGocciaNativeFunctionValue.Create(PromiseConstructorFn, 'Promise', 1);
   FPromiseConstructor.ConstructCallback := PromiseConstruct;
+  FPromiseConstructor.DefineProperty(PROP_LENGTH,
+    TGocciaPropertyDescriptorData.Create(TGocciaNumberLiteralValue.Create(1),
+      [pfConfigurable]));
+  FPromiseConstructor.DefineProperty(PROP_NAME,
+    TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create('Promise'),
+      [pfConfigurable]));
   FPromiseConstructor.DefineSymbolProperty(TGocciaSymbolValue.WellKnownSpecies,
     TGocciaPropertyDescriptorAccessor.Create(
       TGocciaNativeFunctionValue.CreateWithoutPrototype(
@@ -658,6 +1003,8 @@ begin
     Members.AddMethod(PromiseAllSettled, 1, gmkStaticMethod);
     Members.AddMethod(PromiseRace, 1, gmkStaticMethod);
     Members.AddMethod(PromiseAny, 1, gmkStaticMethod);
+    Members.AddMethod(PromiseAllKeyed, 1, gmkStaticMethod);
+    Members.AddMethod(PromiseAllSettledKeyed, 1, gmkStaticMethod);
     Members.AddMethod(PromiseWithResolvers, 0, gmkStaticMethod);
     Members.AddMethod(PromiseTry, 1, gmkStaticMethod);
     FStaticMembers := Members.ToDefinitions;
@@ -697,6 +1044,10 @@ var
   ResolveFn, RejectFn: TGocciaNativeFunctionValue;
   ExecutorArgs, RejectArgs: TGocciaArgumentsCollection;
 begin
+  Goccia.Values.ErrorHelper.ThrowTypeError(
+    'Promise constructor cannot be invoked without ''new''',
+    SSuggestPromiseResolver);
+
   { Step 2: If IsCallable(executor) is false, throw a TypeError }
   if AArgs.Length = 0 then
     Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseResolverUndefinedNotFunction, SSuggestPromiseResolver);
@@ -708,10 +1059,10 @@ begin
   { Steps 3-4: Let promise = OrdinaryCreateFromConstructor; set state to pending }
   Promise := TGocciaPromiseValue.Create;
   { Step 7: Let resolvingFunctions = CreateResolvingFunctions(promise) }
-  ResolveFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(Promise.DoResolve, 'resolve', 1);
-  RejectFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(Promise.DoReject, 'reject', 1);
-  ResolveFn.CapturedRoot := Promise;
-  RejectFn.CapturedRoot := Promise;
+  ResolveFn := CreateAnonymousPromiseBuiltinFunction(Promise.DoResolve,
+    Promise, 1);
+  RejectFn := CreateAnonymousPromiseBuiltinFunction(Promise.DoReject,
+    Promise, 1);
 
   { Step 8: Let completion = Call(executor, undefined, « resolve, reject ») }
   ExecutorArgs := TGocciaArgumentsCollection.Create([ResolveFn, RejectFn]);
@@ -762,15 +1113,16 @@ begin
   if not Executor.IsCallable then
     Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseResolverNotFunction, SSuggestPromiseResolver);
 
-  Proto := GetProtoFromConstructorWithIntrinsic(ANewTarget, FPromiseIntrinsicProto);
+  Proto := PromiseDefaultPrototypeForNewTarget(ANewTarget,
+    FPromiseIntrinsicProto);
 
   Promise := TGocciaPromiseValue.Create;
   Promise.Prototype := Proto;
 
-  ResolveFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(Promise.DoResolve, 'resolve', 1);
-  RejectFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(Promise.DoReject, 'reject', 1);
-  ResolveFn.CapturedRoot := Promise;
-  RejectFn.CapturedRoot := Promise;
+  ResolveFn := CreateAnonymousPromiseBuiltinFunction(Promise.DoResolve,
+    Promise, 1);
+  RejectFn := CreateAnonymousPromiseBuiltinFunction(Promise.DoReject,
+    Promise, 1);
 
   ExecutorArgs := TGocciaArgumentsCollection.Create([ResolveFn, RejectFn]);
   try
@@ -819,6 +1171,10 @@ var
   Capability: TPromiseCapability;
   ResolveArgs: TGocciaArgumentsCollection;
 begin
+  if not (AThisValue is TGocciaObjectValue) then
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorValueNotConstructor,
+      SSuggestNotConstructorType);
+
   Value := AArgs.GetElement(0);
 
   { Step 2: If x is already a Promise created by C, return it directly. }
@@ -903,6 +1259,172 @@ begin
   end;
 end;
 
+function GetPromiseKeyedOwnKeys(
+  const AObject: TGocciaObjectValue): TPromiseKeyRecordArray;
+var
+  KeyValues: TArray<TGocciaValue>;
+  StringKeys: TArray<string>;
+  SymbolKeys: TArray<TGocciaSymbolValue>;
+  I, Index: Integer;
+begin
+  if AObject is TGocciaProxyValue then
+  begin
+    KeyValues := TGocciaProxyValue(AObject).GetOwnPropertyKeyValues;
+    SetLength(Result, Length(KeyValues));
+    for I := 0 to High(KeyValues) do
+    begin
+      if KeyValues[I] is TGocciaSymbolValue then
+      begin
+        Result[I].IsSymbol := True;
+        Result[I].Symbol := TGocciaSymbolValue(KeyValues[I]);
+        Result[I].Name := '';
+      end
+      else
+      begin
+        Result[I].IsSymbol := False;
+        Result[I].Symbol := nil;
+        Result[I].Name := KeyValues[I].ToStringLiteral.Value;
+      end;
+    end;
+    Exit;
+  end;
+
+  StringKeys := AObject.GetOwnPropertyKeys;
+  SymbolKeys := AObject.GetOwnSymbols;
+  SetLength(Result, Length(StringKeys) + Length(SymbolKeys));
+  Index := 0;
+  for I := 0 to High(StringKeys) do
+  begin
+    Result[Index].IsSymbol := False;
+    Result[Index].Symbol := nil;
+    Result[Index].Name := StringKeys[I];
+    Inc(Index);
+  end;
+  for I := 0 to High(SymbolKeys) do
+  begin
+    Result[Index].IsSymbol := True;
+    Result[Index].Symbol := SymbolKeys[I];
+    Result[Index].Name := '';
+    Inc(Index);
+  end;
+end;
+
+function GetPromiseKeyedDescriptor(const AObject: TGocciaObjectValue;
+  const AKey: TPromiseKeyRecord): TGocciaPropertyDescriptor;
+begin
+  if AKey.IsSymbol then
+    Result := AObject.GetOwnSymbolPropertyDescriptor(AKey.Symbol)
+  else
+    Result := AObject.GetOwnPropertyDescriptor(AKey.Name);
+end;
+
+function GetPromiseKeyedValue(const AObject: TGocciaObjectValue;
+  const AKey: TPromiseKeyRecord): TGocciaValue;
+begin
+  if AKey.IsSymbol then
+    Result := AObject.GetSymbolProperty(AKey.Symbol)
+  else
+    Result := AObject.GetProperty(AKey.Name);
+end;
+
+procedure CreatePromiseKeyedPlaceholder(const AObject: TGocciaObjectValue;
+  const AKey: TPromiseKeyRecord);
+begin
+  if AKey.IsSymbol then
+    AObject.CreateDataPropertyOrThrow(AKey.Symbol,
+      TGocciaUndefinedLiteralValue.UndefinedValue)
+  else
+    AObject.CreateDataPropertyOrThrow(AKey.Name,
+      TGocciaUndefinedLiteralValue.UndefinedValue);
+end;
+
+// TC39 await-dictionary proposal: Promise.allKeyed / allSettledKeyed.
+function TGocciaGlobalPromise.PromiseKeyed(
+  const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue;
+  const AAllSettled: Boolean): TGocciaValue;
+var
+  Capability: TPromiseCapability;
+  InputValue: TGocciaValue;
+  InputObject: TGocciaObjectValue;
+  ResultObject: TGocciaObjectValue;
+  State: TPromiseKeyedState;
+  Keys: TPromiseKeyRecordArray;
+  Descriptor: TGocciaPropertyDescriptor;
+  PromiseLike: TGocciaValue;
+  FulfillHandler: TPromiseKeyedFulfillHandler;
+  RejectHandler: TPromiseKeyedRejectHandler;
+  FulfillFn, RejectFn: TGocciaNativeFunctionValue;
+  ResultRoot, StateRoot: TGocciaTempRoot;
+  I: Integer;
+begin
+  Capability := NewPromiseCapability(AThisValue, FPromiseConstructor);
+  InitializeTempRoot(ResultRoot);
+  InitializeTempRoot(StateRoot);
+  ResultObject := nil;
+  State := nil;
+  try
+    try
+      InputValue := AArgs.GetElement(0);
+      if not (InputValue is TGocciaObjectValue) then
+        Goccia.Values.ErrorHelper.ThrowTypeError(
+          SErrorCannotConvertValueToObject, SSuggestObjectArgType);
+      InputObject := TGocciaObjectValue(InputValue);
+
+      ResultObject := TGocciaObjectValue.Create(nil);
+      AddTempRootIfNeeded(ResultRoot, ResultObject);
+      State := TPromiseKeyedState.Create(ResultObject, Capability.Resolve,
+        Capability.Reject, 1);
+      AddTempRootIfNeeded(StateRoot, State);
+
+      Keys := GetPromiseKeyedOwnKeys(InputObject);
+      for I := 0 to High(Keys) do
+      begin
+        Descriptor := GetPromiseKeyedDescriptor(InputObject, Keys[I]);
+        if not Assigned(Descriptor) or not Descriptor.Enumerable then
+          Continue;
+
+        CreatePromiseKeyedPlaceholder(ResultObject, Keys[I]);
+        State.Remaining := State.Remaining + 1;
+
+        PromiseLike := PromiseResolveForConstructor(AThisValue,
+          GetPromiseKeyedValue(InputObject, Keys[I]));
+        FulfillHandler := TPromiseKeyedFulfillHandler.Create(State,
+          Keys[I].Name, Keys[I].Symbol, Keys[I].IsSymbol, AAllSettled);
+        RejectHandler := TPromiseKeyedRejectHandler.Create(State,
+          Keys[I].Name, Keys[I].Symbol, Keys[I].IsSymbol, AAllSettled);
+        FulfillFn := CreatePromiseElementFunction(FulfillHandler.Invoke,
+          FulfillHandler);
+        RejectFn := CreatePromiseElementFunction(RejectHandler.Invoke,
+          RejectHandler);
+        InvokePromiseLikeThen(PromiseLike, FulfillFn, RejectFn);
+      end;
+
+      State.Remaining := State.Remaining - 1;
+      if State.Remaining = 0 then
+      begin
+        State.Settled := True;
+        CallPromiseCapability(State.Resolve, ResultObject);
+      end;
+    except
+      on E: EGocciaBytecodeThrow do
+      begin
+        Result := RejectPromiseCapabilityWithReason(Capability, E.ThrownValue);
+        Exit;
+      end;
+      on E: TGocciaThrowValue do
+      begin
+        Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+        Exit;
+      end;
+    end;
+  finally
+    RemoveTempRootIfNeeded(StateRoot);
+    RemoveTempRootIfNeeded(ResultRoot);
+  end;
+
+  Result := Capability.Promise;
+end;
+
 { Promise.all ( iterable ) — §27.2.4.1
   1. Let C be the this value.
   2. Let promiseCapability be ? NewPromiseCapability(C).
@@ -918,41 +1440,73 @@ end;
 function TGocciaGlobalPromise.PromiseAll(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  InputArray: TGocciaArrayValue;
   Capability: TPromiseCapability;
   State: TPromiseAllState;
-  I: Integer;
-  PromiseLike: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
+  PromiseResolve, Iterable, NextValue, PromiseLike: TGocciaValue;
   FulfillHandler: TPromiseAllHandler;
   FulfillFn: TGocciaNativeFunctionValue;
+  Done: Boolean;
+  Index: Integer;
 begin
   { Step 2: Let promiseCapability = NewPromiseCapability(C) }
   Capability := NewPromiseCapability(AThisValue, FPromiseConstructor);
   try
-    { Step 4: Let iteratorRecord = GetIterator(iterable) }
-    InputArray := ExtractPromiseArray(AArgs);
-
-    { Empty iterable: resolve immediately with empty array }
-    if InputArray.Elements.Count = 0 then
-    begin
-      CallPromiseCapability(Capability.Resolve, TGocciaArrayValue.Create);
-      Result := Capability.Promise;
-      Exit;
-    end;
-
-    { Step 5: PerformPromiseAll — set up per-element handlers }
+    PromiseResolve := GetPromiseResolveMethod(AThisValue);
+    Iterable := AArgs.GetElement(0);
+    Iterator := GetPromiseIterator(Iterable);
     State := TPromiseAllState.Create(Capability.Promise, Capability.Resolve,
-      Capability.Reject, InputArray.Elements.Count);
+      Capability.Reject, 0);
+    State.Remaining := 1;
+    Index := 0;
 
-    for I := 0 to InputArray.Elements.Count - 1 do
+    while True do
     begin
-      { Wrap each element as a Promise via PromiseResolve(C, nextValue) }
-      PromiseLike := PromiseResolveForConstructor(AThisValue, InputArray.Elements[I]);
-      FulfillHandler := TPromiseAllHandler.Create(State, I);
-      FulfillFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-        FulfillHandler.Invoke, 'all-resolve', 1);
-      FulfillFn.CapturedRoot := FulfillHandler;
-      InvokePromiseLikeThen(PromiseLike, FulfillFn, Capability.Reject);
+      try
+        NextValue := Iterator.DirectNext(Done);
+      except
+        on E: Exception do
+        begin
+          Result := RejectPromiseCapabilityWithException(Capability, E);
+          Exit;
+        end;
+      end;
+
+      if Done then
+      begin
+        State.Remaining := State.Remaining - 1;
+        if State.Remaining = 0 then
+          CallPromiseCapability(State.Resolve, State.Results);
+        Result := Capability.Promise;
+        Exit;
+      end;
+
+      try
+        State.Results.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+        PromiseLike := CallPromiseResolveMethod(PromiseResolve, AThisValue,
+          NextValue);
+        FulfillHandler := TPromiseAllHandler.Create(State, Index);
+        FulfillFn := CreatePromiseElementFunction(FulfillHandler.Invoke,
+          FulfillHandler);
+        State.Remaining := State.Remaining + 1;
+        InvokePromiseLikeThen(PromiseLike, FulfillFn, Capability.Reject);
+      except
+        on E: EGocciaBytecodeThrow do
+        begin
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithReason(Capability,
+            E.ThrownValue);
+          Exit;
+        end;
+        on E: TGocciaThrowValue do
+        begin
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          Exit;
+        end;
+      end;
+
+      Inc(Index);
     end;
   except
     on E: EGocciaBytecodeThrow do
@@ -987,48 +1541,85 @@ end;
 function TGocciaGlobalPromise.PromiseAllSettled(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  InputArray: TGocciaArrayValue;
   Capability: TPromiseCapability;
   State: TPromiseAllState;
-  I: Integer;
-  PromiseLike: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
+  PromiseResolve, Iterable, NextValue, PromiseLike: TGocciaValue;
   FulfillHandler: TPromiseAllSettledFulfillHandler;
   RejectHandler: TPromiseAllSettledRejectHandler;
   FulfillFn, RejectFn: TGocciaNativeFunctionValue;
+  Done: Boolean;
+  Index: Integer;
 begin
   { Step 2: Let promiseCapability = NewPromiseCapability(C) }
   Capability := NewPromiseCapability(AThisValue, FPromiseConstructor);
   try
-    { Step 4: Let iteratorRecord = GetIterator(iterable) }
-    InputArray := ExtractPromiseArray(AArgs);
-
-    { Empty iterable: resolve immediately with empty array }
-    if InputArray.Elements.Count = 0 then
-    begin
-      CallPromiseCapability(Capability.Resolve, TGocciaArrayValue.Create);
-      Result := Capability.Promise;
-      Exit;
-    end;
-
-    { Step 5: PerformPromiseAllSettled — set up per-element handlers }
+    PromiseResolve := GetPromiseResolveMethod(AThisValue);
+    Iterable := AArgs.GetElement(0);
+    Iterator := GetPromiseIterator(Iterable);
     State := TPromiseAllState.Create(Capability.Promise, Capability.Resolve,
-      Capability.Reject, InputArray.Elements.Count);
+      Capability.Reject, 0);
+    State.Remaining := 1;
+    Index := 0;
 
-    for I := 0 to InputArray.Elements.Count - 1 do
+    while True do
     begin
-      { Wrap each element as a Promise via PromiseResolve(C, nextValue) }
-      PromiseLike := PromiseResolveForConstructor(AThisValue, InputArray.Elements[I]);
-      FulfillHandler := TPromiseAllSettledFulfillHandler.Create(State, I);
-      RejectHandler := TPromiseAllSettledRejectHandler.Create(State, I);
+      try
+        NextValue := Iterator.DirectNext(Done);
+      except
+        on E: EGocciaBytecodeThrow do
+        begin
+          Result := RejectPromiseCapabilityWithReason(Capability,
+            E.ThrownValue);
+          Exit;
+        end;
+        on E: TGocciaThrowValue do
+        begin
+          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          Exit;
+        end;
+      end;
 
-      { Invoke then(onFulfilled, onRejected) — both handlers record status }
-      FulfillFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-        FulfillHandler.Invoke, 'allSettled-fulfill', 1);
-      RejectFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-        RejectHandler.Invoke, 'allSettled-reject', 1);
-      FulfillFn.CapturedRoot := FulfillHandler;
-      RejectFn.CapturedRoot := RejectHandler;
-      InvokePromiseLikeThen(PromiseLike, FulfillFn, RejectFn);
+      if Done then
+      begin
+        State.Remaining := State.Remaining - 1;
+        if State.Remaining = 0 then
+          CallPromiseCapability(State.Resolve, State.Results);
+        Result := Capability.Promise;
+        Exit;
+      end;
+
+      try
+        State.Results.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+        PromiseLike := CallPromiseResolveMethod(PromiseResolve, AThisValue,
+          NextValue);
+        FulfillHandler := TPromiseAllSettledFulfillHandler.Create(State,
+          Index);
+        RejectHandler := TPromiseAllSettledRejectHandler.Create(State, Index);
+
+        FulfillFn := CreatePromiseElementFunction(FulfillHandler.Invoke,
+          FulfillHandler);
+        RejectFn := CreatePromiseElementFunction(RejectHandler.Invoke,
+          RejectHandler);
+        State.Remaining := State.Remaining + 1;
+        InvokePromiseLikeThen(PromiseLike, FulfillFn, RejectFn);
+      except
+        on E: EGocciaBytecodeThrow do
+        begin
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithReason(Capability,
+            E.ThrownValue);
+          Exit;
+        end;
+        on E: TGocciaThrowValue do
+        begin
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          Exit;
+        end;
+      end;
+
+      Inc(Index);
     end;
   except
     on E: EGocciaBytecodeThrow do
@@ -1062,33 +1653,60 @@ end;
 function TGocciaGlobalPromise.PromiseRace(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  InputArray: TGocciaArrayValue;
   Capability: TPromiseCapability;
-  I: Integer;
-  PromiseLike: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
+  PromiseResolve, Iterable, NextValue, PromiseLike: TGocciaValue;
+  Done: Boolean;
 begin
   { Step 2: Let promiseCapability = NewPromiseCapability(C) }
   Capability := NewPromiseCapability(AThisValue, FPromiseConstructor);
   try
-    { Step 4: Let iteratorRecord = GetIterator(iterable) }
-    InputArray := ExtractPromiseArray(AArgs);
+    PromiseResolve := GetPromiseResolveMethod(AThisValue);
+    Iterable := AArgs.GetElement(0);
+    Iterator := GetPromiseIterator(Iterable);
 
-    { Step 5: PerformPromiseRace — first to settle wins }
-    for I := 0 to InputArray.Elements.Count - 1 do
+    while True do
     begin
-      { Wrap each element as a Promise via PromiseResolve(C, nextValue) }
-      PromiseLike := PromiseResolveForConstructor(AThisValue, InputArray.Elements[I]);
-      InvokePromiseLikeThen(PromiseLike, Capability.Resolve, Capability.Reject);
+      try
+        NextValue := Iterator.DirectNext(Done);
+      except
+        on E: EGocciaBytecodeThrow do
+        begin
+          Result := RejectPromiseCapabilityWithReason(Capability,
+            E.ThrownValue);
+          Exit;
+        end;
+        on E: TGocciaThrowValue do
+        begin
+          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          Exit;
+        end;
+      end;
+
+      if Done then
+      begin
+        Result := Capability.Promise;
+        Exit;
+      end;
+
+      try
+        PromiseLike := CallPromiseResolveMethod(PromiseResolve, AThisValue,
+          NextValue);
+        InvokePromiseLikeThen(PromiseLike, Capability.Resolve,
+          Capability.Reject);
+      except
+        on E: Exception do
+        begin
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithException(Capability, E);
+          Exit;
+        end;
+      end;
     end;
   except
-    on E: EGocciaBytecodeThrow do
+    on E: Exception do
     begin
-      Result := RejectPromiseCapabilityWithReason(Capability, E.ThrownValue);
-      Exit;
-    end;
-    on E: TGocciaThrowValue do
-    begin
-      Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+      Result := RejectPromiseCapabilityWithException(Capability, E);
       Exit;
     end;
   end;
@@ -1112,47 +1730,86 @@ end;
 function TGocciaGlobalPromise.PromiseAny(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  InputArray: TGocciaArrayValue;
   Capability: TPromiseCapability;
   State: TPromiseAnyState;
-  I: Integer;
-  PromiseLike: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
+  PromiseResolve, Iterable, NextValue, PromiseLike: TGocciaValue;
   RejectHandler: TPromiseAnyRejectHandler;
   RejectFn: TGocciaNativeFunctionValue;
   ErrorObj: TGocciaObjectValue;
+  Done: Boolean;
+  Index: Integer;
 begin
   { Step 2: Let promiseCapability = NewPromiseCapability(C) }
   Capability := NewPromiseCapability(AThisValue, FPromiseConstructor);
   try
-    { Step 4: Let iteratorRecord = GetIterator(iterable) }
-    InputArray := ExtractPromiseArray(AArgs);
-
-    { Empty iterable: reject with AggregateError (all zero promises rejected) }
-    if InputArray.Elements.Count = 0 then
-    begin
-      ErrorObj := Goccia.Values.ErrorHelper.CreateErrorObject(AGGREGATE_ERROR_NAME,
-        SErrorAllPromisesRejected);
-      ErrorObj.AssignProperty(PROP_ERRORS, TGocciaArrayValue.Create);
-      CallPromiseCapability(Capability.Reject, ErrorObj);
-      Result := Capability.Promise;
-      Exit;
-    end;
-
-    { Step 5: PerformPromiseAny — first fulfillment wins }
+    PromiseResolve := GetPromiseResolveMethod(AThisValue);
+    Iterable := AArgs.GetElement(0);
+    Iterator := GetPromiseIterator(Iterable);
     State := TPromiseAnyState.Create(Capability.Promise, Capability.Resolve,
-      Capability.Reject, InputArray.Elements.Count);
+      Capability.Reject, 0);
+    State.Remaining := 1;
+    Index := 0;
 
-    for I := 0 to InputArray.Elements.Count - 1 do
+    while True do
     begin
-      { Wrap each element as a Promise via PromiseResolve(C, nextValue) }
-      PromiseLike := PromiseResolveForConstructor(AThisValue, InputArray.Elements[I]);
-      RejectHandler := TPromiseAnyRejectHandler.Create(State, I);
+      try
+        NextValue := Iterator.DirectNext(Done);
+      except
+        on E: EGocciaBytecodeThrow do
+        begin
+          Result := RejectPromiseCapabilityWithReason(Capability,
+            E.ThrownValue);
+          Exit;
+        end;
+        on E: TGocciaThrowValue do
+        begin
+          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          Exit;
+        end;
+      end;
 
-      { Invoke then(onFulfilled, onRejected) — fulfill resolves, reject collects }
-      RejectFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-        RejectHandler.Invoke, 'any-reject', 1);
-      RejectFn.CapturedRoot := RejectHandler;
-      InvokePromiseLikeThen(PromiseLike, Capability.Resolve, RejectFn);
+      if Done then
+      begin
+        State.Remaining := State.Remaining - 1;
+        if State.Remaining = 0 then
+        begin
+          ErrorObj := Goccia.Values.ErrorHelper.CreateErrorObject(
+            AGGREGATE_ERROR_NAME, SErrorAllPromisesRejected);
+          ErrorObj.AssignProperty(PROP_ERRORS, State.Errors);
+          CallPromiseCapability(State.Reject, ErrorObj);
+        end;
+        Result := Capability.Promise;
+        Exit;
+      end;
+
+      try
+        State.Errors.Elements.Add(TGocciaUndefinedLiteralValue.UndefinedValue);
+        PromiseLike := CallPromiseResolveMethod(PromiseResolve, AThisValue,
+          NextValue);
+        RejectHandler := TPromiseAnyRejectHandler.Create(State, Index);
+
+        RejectFn := CreatePromiseElementFunction(RejectHandler.Invoke,
+          RejectHandler);
+        State.Remaining := State.Remaining + 1;
+        InvokePromiseLikeThen(PromiseLike, Capability.Resolve, RejectFn);
+      except
+        on E: EGocciaBytecodeThrow do
+        begin
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithReason(Capability,
+            E.ThrownValue);
+          Exit;
+        end;
+        on E: TGocciaThrowValue do
+        begin
+          CloseIteratorPreservingError(Iterator);
+          Result := RejectPromiseCapabilityWithReason(Capability, E.Value);
+          Exit;
+        end;
+      end;
+
+      Inc(Index);
     end;
   except
     on E: EGocciaBytecodeThrow do
@@ -1171,6 +1828,20 @@ begin
   Result := Capability.Promise;
 end;
 
+function TGocciaGlobalPromise.PromiseAllKeyed(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := PromiseKeyed(AArgs, AThisValue, False);
+end;
+
+function TGocciaGlobalPromise.PromiseAllSettledKeyed(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := PromiseKeyed(AArgs, AThisValue, True);
+end;
+
 { Promise.withResolvers ( ) — §27.2.4.8
   1. Let C be the this value.
   2. Let promiseCapability be ? NewPromiseCapability(C).
@@ -1181,22 +1852,17 @@ end;
   7. Return obj. }
 function TGocciaGlobalPromise.PromiseWithResolvers(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Promise: TGocciaPromiseValue;
-  ResolveFn, RejectFn: TGocciaNativeFunctionValue;
+  Capability: TPromiseCapability;
   ResultObj: TGocciaObjectValue;
 begin
   { Step 2: Let promiseCapability = NewPromiseCapability(C) }
-  Promise := TGocciaPromiseValue.Create;
-  ResolveFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(Promise.DoResolve, 'resolve', 1);
-  RejectFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(Promise.DoReject, 'reject', 1);
-  ResolveFn.CapturedRoot := Promise;
-  RejectFn.CapturedRoot := Promise;
+  Capability := NewPromiseCapability(AThisValue, FPromiseConstructor);
 
   { Steps 3-6: Create result object with promise, resolve, reject properties }
   ResultObj := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-  ResultObj.CreateDataPropertyOrThrow('promise', Promise);
-  ResultObj.CreateDataPropertyOrThrow('resolve', ResolveFn);
-  ResultObj.CreateDataPropertyOrThrow('reject', RejectFn);
+  ResultObj.CreateDataPropertyOrThrow('promise', Capability.Promise);
+  ResultObj.CreateDataPropertyOrThrow('resolve', Capability.Resolve);
+  ResultObj.CreateDataPropertyOrThrow('reject', Capability.Reject);
 
   { Step 7: Return obj }
   Result := ResultObj;
@@ -1214,48 +1880,52 @@ end;
   7. Return promiseCapability.[[Promise]]. }
 function TGocciaGlobalPromise.PromiseTry(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Promise: TGocciaPromiseValue;
+  Capability: TPromiseCapability;
   Callback: TGocciaValue;
   CallbackResult: TGocciaValue;
-  EmptyArgs: TGocciaArgumentsCollection;
+  CallbackArgs: TGocciaArgumentsCollection;
+  CallbackArgCount: Integer;
+  I: Integer;
 begin
   { Step 3: Let promiseCapability = NewPromiseCapability(C) }
-  Promise := TGocciaPromiseValue.Create;
+  Capability := NewPromiseCapability(AThisValue, FPromiseConstructor);
 
-  { Step 2: If IsCallable(callbackfn) is false, throw a TypeError }
-  if AArgs.Length = 0 then
-    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseTryRequiresCallback, SSuggestCallbackRequired);
-
+  { Step 4: Let status = Call(callbackfn, undefined, args) }
   Callback := AArgs.GetElement(0);
-  if not Callback.IsCallable then
-    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseTryRequiresCallback, SSuggestCallbackRequired);
-
-  { Step 4: Let status = Call(callbackfn, undefined) }
   try
-    EmptyArgs := TGocciaArgumentsCollection.Create;
+    if AArgs.Length > 0 then
+      CallbackArgCount := AArgs.Length - 1
+    else
+      CallbackArgCount := 0;
+    CallbackArgs := TGocciaArgumentsCollection.CreateWithCapacity(
+      CallbackArgCount);
     try
-      CallbackResult := InvokeCallable(Callback, EmptyArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+      for I := 1 to AArgs.Length - 1 do
+        CallbackArgs.Add(AArgs.GetElement(I));
+      CallbackResult := InvokeCallable(Callback, CallbackArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue);
     finally
-      EmptyArgs.Free;
+      CallbackArgs.Free;
     end;
     { Step 6: Normal completion — Call(resolve, status.[[Value]]) }
-    Promise.Resolve(CallbackResult);
+    CallPromiseCapability(Capability.Resolve, CallbackResult);
   except
     on E: EGocciaBytecodeThrow do
-      Promise.Reject(E.ThrownValue);
+      CallPromiseCapability(Capability.Reject, E.ThrownValue);
     on E: TGocciaThrowValue do
       { Step 5: Abrupt completion — Call(reject, status.[[Value]]) }
-      Promise.Reject(E.Value);
+      CallPromiseCapability(Capability.Reject, E.Value);
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
       raise;
     on E: Exception do
-      Promise.Reject(CreateErrorObject(ERROR_NAME, E.Message));
+      CallPromiseCapability(Capability.Reject, CreateErrorObject(ERROR_NAME,
+        E.Message));
   end;
 
   { Step 7: Return promiseCapability.[[Promise]] }
-  Result := Promise;
+  Result := Capability.Promise;
 end;
 
 end.

--- a/source/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/source/units/Goccia.Builtins.GlobalRegExp.pas
@@ -611,8 +611,6 @@ begin
         [pfConfigurable]);
       Members.AddAccessor(PROP_HAS_INDICES, RegExpHasIndicesGetter, nil,
         [pfConfigurable]);
-      Members.AddSymbolDataProperty(TGocciaSymbolValue.WellKnownToStringTag,
-        TGocciaStringLiteralValue.Create(CONSTRUCTOR_REGEXP), [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -625,7 +623,8 @@ begin
   FRegExpConstructor := TGocciaNativeFunctionValue.Create(RegExpConstructorFn,
     CONSTRUCTOR_REGEXP, 2);
   FRegExpConstructor.ConstructCallback := RegExpConstruct;
-  FRegExpConstructor.AssignProperty(PROP_PROTOTYPE, FRegExpPrototype);
+  FRegExpConstructor.DefineProperty(PROP_PROTOTYPE,
+    TGocciaPropertyDescriptorData.Create(FRegExpPrototype, []));
   FRegExpConstructor.DefineSymbolProperty(TGocciaSymbolValue.WellKnownSpecies,
     TGocciaPropertyDescriptorAccessor.Create(
       TGocciaNativeFunctionValue.CreateWithoutPrototype(

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -319,6 +319,15 @@ begin
   DOMExceptionConstructorFunc := TGocciaNativeFunctionValue.Create(DOMExceptionConstructor, DOM_EXCEPTION_NAME, 2);
   DOMExceptionConstructorFunc.ConstructCallback := DOMExceptionConstruct;
 
+  EvalErrorConstructorFunc.Prototype := ErrorConstructorFunc;
+  TypeErrorConstructorFunc.Prototype := ErrorConstructorFunc;
+  ReferenceErrorConstructorFunc.Prototype := ErrorConstructorFunc;
+  RangeErrorConstructorFunc.Prototype := ErrorConstructorFunc;
+  SyntaxErrorConstructorFunc.Prototype := ErrorConstructorFunc;
+  URIErrorConstructorFunc.Prototype := ErrorConstructorFunc;
+  AggregateErrorConstructorFunc.Prototype := ErrorConstructorFunc;
+  SuppressedErrorConstructorFunc.Prototype := ErrorConstructorFunc;
+
   ErrorConstructorFunc.DefineProperty(PROP_PROTOTYPE, TGocciaPropertyDescriptorData.Create(FErrorProto, []));
   with TGocciaMemberCollection.Create do
   try

--- a/source/units/Goccia.Builtins.Temporal.pas
+++ b/source/units/Goccia.Builtins.Temporal.pas
@@ -1286,90 +1286,20 @@ function TGocciaTemporalBuiltin.ZonedDateTimeFrom(const AArgs: TGocciaArgumentsC
 var
   Arg: TGocciaValue;
   ZDT: TGocciaTemporalZonedDateTimeValue;
-  DateRec: TTemporalDateRecord;
-  TimeRec: TTemporalTimeRecord;
-  TZ: string;
-  EpochMs: Int64;
-  SubMs, OffsetSeconds: Integer;
 begin
   Arg := AArgs.GetElement(0);
-
-  if Arg is TGocciaTemporalZonedDateTimeValue then
-  begin
-    ZDT := TGocciaTemporalZonedDateTimeValue(Arg);
-    Result := TGocciaTemporalZonedDateTimeValue.Create(
-      ZDT.EpochMilliseconds, ZDT.SubMillisecondNanoseconds, ZDT.TimeZone);
-  end
-  else if Arg is TGocciaStringLiteralValue then
-  begin
-    if not TryParseISODateTimeWithOffset(TGocciaStringLiteralValue(Arg).Value,
-        DateRec, TimeRec, OffsetSeconds, TZ) then
-      ThrowRangeError(SErrorInvalidISOZonedDateTime, SSuggestTemporalISOFormat);
-
-    // Compute UTC epoch from wall-clock time
-    EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * Int64(86400000) +
-               Int64(TimeRec.Hour) * 3600000 + Int64(TimeRec.Minute) * 60000 +
-               Int64(TimeRec.Second) * 1000 + TimeRec.Millisecond;
-    SubMs := TimeRec.Microsecond * 1000 + TimeRec.Nanosecond;
-
-    // Apply offset to convert wall-clock to UTC
-    EpochMs := EpochMs - Int64(OffsetSeconds) * 1000;
-
-    if TZ = '' then
-      ThrowRangeError(SErrorTemporalZonedDateTimeRequiresTZ, SSuggestTemporalTimezone);
-
-    Result := TGocciaTemporalZonedDateTimeValue.Create(EpochMs, SubMs, TZ);
-  end
-  else
-  begin
-    ThrowTypeError(SErrorTemporalZonedDateTimeFromArg, SSuggestTemporalFromArg);
-    Result := nil;
-  end;
+  ZDT := CoerceTemporalZonedDateTime(Arg, 'Temporal.ZonedDateTime.from', AArgs.GetElement(1));
+  Result := TGocciaTemporalZonedDateTimeValue.Create(
+    ZDT.EpochMilliseconds, ZDT.SubMillisecondNanoseconds, ZDT.TimeZone);
 end;
 
 function TGocciaTemporalBuiltin.ZonedDateTimeCompare(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   Z1, Z2: TGocciaTemporalZonedDateTimeValue;
-
-  function CoerceZDT(const AArg: TGocciaValue): TGocciaTemporalZonedDateTimeValue;
-  var
-    CoerceDateRec: TTemporalDateRecord;
-    CoerceTimeRec: TTemporalTimeRecord;
-    CoerceOffsetSeconds: Integer;
-    CoerceTZ: string;
-    CoerceEpochMs: Int64;
-    CoerceSubMs: Integer;
-  begin
-    if AArg is TGocciaTemporalZonedDateTimeValue then
-      Result := TGocciaTemporalZonedDateTimeValue(AArg)
-    else if AArg is TGocciaStringLiteralValue then
-    begin
-      if not TryParseISODateTimeWithOffset(TGocciaStringLiteralValue(AArg).Value,
-          CoerceDateRec, CoerceTimeRec, CoerceOffsetSeconds, CoerceTZ) then
-        ThrowRangeError(SErrorInvalidISOZonedDateTime, SSuggestTemporalISOFormat);
-
-      CoerceEpochMs := DateToEpochDays(CoerceDateRec.Year, CoerceDateRec.Month, CoerceDateRec.Day) * Int64(86400000) +
-                       Int64(CoerceTimeRec.Hour) * 3600000 + Int64(CoerceTimeRec.Minute) * 60000 +
-                       Int64(CoerceTimeRec.Second) * 1000 + CoerceTimeRec.Millisecond;
-      CoerceSubMs := CoerceTimeRec.Microsecond * 1000 + CoerceTimeRec.Nanosecond;
-      CoerceEpochMs := CoerceEpochMs - Int64(CoerceOffsetSeconds) * 1000;
-
-      if CoerceTZ = '' then
-        ThrowRangeError(SErrorTemporalZonedDateTimeCompareTZ, SSuggestTemporalTimezone);
-
-      Result := TGocciaTemporalZonedDateTimeValue.Create(CoerceEpochMs, CoerceSubMs, CoerceTZ);
-    end
-    else
-    begin
-      ThrowTypeError(SErrorTemporalZonedDateTimeCompareArg, SSuggestTemporalCompareArg);
-      Result := nil;
-    end;
-  end;
-
 begin
-  Z1 := CoerceZDT(AArgs.GetElement(0));
-  Z2 := CoerceZDT(AArgs.GetElement(1));
+  Z1 := CoerceTemporalZonedDateTime(AArgs.GetElement(0), 'Temporal.ZonedDateTime.compare');
+  Z2 := CoerceTemporalZonedDateTime(AArgs.GetElement(1), 'Temporal.ZonedDateTime.compare');
 
   if Z1.EpochMilliseconds < Z2.EpochMilliseconds then
     Result := TGocciaNumberLiteralValue.Create(-1)

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -961,9 +961,14 @@ begin
     // a cell that copied the register's initial (undefined) value.  The
     // initializer wrote directly to the register (e.g. OP_LOAD_INT) bypassing
     // the cell.  Emit OP_SET_LOCAL to sync the cell with the register.
-    if (not AStmt.IsVar) or HasInitializer then
+    if AStmt.IsVar and HasInitializer and not UseWithVarInitializer then
+      EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)))
+    else if (not AStmt.IsVar) or HasInitializer then
     begin
-      LocalIdx := ACtx.Scope.ResolveLocal(Info.Name);
+      if AStmt.IsVar then
+        LocalIdx := FindVarLocalIndex(ACtx.Scope, Info.Name)
+      else
+        LocalIdx := ACtx.Scope.ResolveLocal(Info.Name);
       if (LocalIdx >= 0) and ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
         EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
     end;

--- a/source/units/Goccia.Constants.PropertyNames.pas
+++ b/source/units/Goccia.Constants.PropertyNames.pas
@@ -68,6 +68,7 @@ const
   PROP_BUFFER           = 'buffer';
   PROP_MAX_BYTE_LENGTH  = 'maxByteLength';
   PROP_RESIZABLE        = 'resizable';
+  PROP_GROWABLE         = 'growable';
   PROP_DETACHED         = 'detached';
   PROP_BYTES_PER_ELEMENT = 'BYTES_PER_ELEMENT';
   PROP_FROM             = 'from';

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -934,6 +934,12 @@ begin
       TGocciaNativeFunctionValue.CreateWithoutPrototype(
         TypedArrayStatic.TypedArrayOf, PROP_OF, 0),
       [pfConfigurable, pfWritable]));
+  FTypedArrayIntrinsic.DefineSymbolProperty(
+    TGocciaSymbolValue.WellKnownSpecies,
+    TGocciaPropertyDescriptorAccessor.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(
+        SpeciesGetter, 'get [Symbol.species]', 0),
+      nil, [pfConfigurable]));
 
   RegisterTypedArrayConstructor(CONSTRUCTOR_INT8_ARRAY, takInt8, ObjectConstructor);
   RegisterTypedArrayConstructor(CONSTRUCTOR_UINT8_ARRAY, takUint8, ObjectConstructor);
@@ -955,6 +961,12 @@ begin
     // §23.2.3: %TypedArray%.prototype.constructor = %TypedArray%
     TGocciaTypedArrayValue.GetSharedPrototypeObject.DefineProperty(PROP_CONSTRUCTOR,
       TGocciaPropertyDescriptorData.Create(FTypedArrayIntrinsic, [pfConfigurable, pfWritable]));
+    // §23.2.3.33: %TypedArray%.prototype.toString is the same function object
+    // as Array.prototype.toString.
+    TGocciaTypedArrayValue.GetSharedPrototypeObject.DefineProperty(PROP_TO_STRING,
+      TGocciaPropertyDescriptorData.Create(
+        ArrayConstructor.Prototype.GetProperty(PROP_TO_STRING),
+        [pfConfigurable, pfWritable]));
   end;
 
   TypeDef.ConstructorName := CONSTRUCTOR_STRING;
@@ -1245,8 +1257,17 @@ begin
     if Assigned(GC) then
       GC.ClearKeptObjects;
     Queue := TGocciaMicrotaskQueue.Instance;
-    if Assigned(Queue) and Queue.HasPending then
-      Queue.DrainQueue;
+    repeat
+      if PumpAtomicsWaitAsyncCompletions = 0 then
+      begin
+        if Assigned(Queue) and Queue.HasPending then
+          Queue.DrainQueue
+        else
+          Break;
+      end
+      else if Assigned(Queue) and Queue.HasPending then
+        Queue.DrainQueue;
+    until False;
   finally
     GC := TGarbageCollector.Instance;
     if Assigned(GC) then

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1136,6 +1136,7 @@ begin
       Flags := [pfWritable, pfConfigurable];
     GlobalThisObj.DefineProperty(Name,
       TGocciaPropertyDescriptorData.Create(Scope.GetValue(Name), Flags));
+    Scope.MarkGlobalObjectBackedBinding(Name);
   end;
 
   GlobalThisObj.DefineProperty('globalThis',
@@ -1144,6 +1145,7 @@ begin
     Scope.ForceUpdateBinding('globalThis', GlobalThisObj)
   else
     Scope.DefineLexicalBinding('globalThis', GlobalThisObj, dtConst, True);
+  Scope.MarkGlobalObjectBackedBinding('globalThis');
 
   // ES2026 §9.1.2.5 NewGlobalEnvironment: a global Environment Record's
   // [[GlobalThisValue]] is the global object. Top-level `this` resolves

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -101,7 +101,7 @@ procedure StampRawPrivateInstanceBrand(const AReceiver: TGocciaObjectValue;
 
 procedure InitializeInstanceProperties(const AInstance: TGocciaInstanceValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const AInitializationMode: TGocciaInstanceInitializationMode = iimFirstPass);
-function InstantiateClass(const AClassValue: TGocciaClassValue; const AArguments: TGocciaArgumentsCollection; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function InstantiateClass(const AClassValue: TGocciaClassValue; const AArguments: TGocciaArgumentsCollection; const AContext: TGocciaEvaluationContext; const ANewTarget: TGocciaValue = nil): TGocciaValue;
 procedure ValidateClassConstructorReturn(const AClassValue: TGocciaClassValue; const AValue: TGocciaValue);
 
 function IsObjectInstanceOfClass(const AObj: TGocciaObjectValue; const AClassValue: TGocciaClassValue): Boolean;
@@ -149,6 +149,7 @@ uses
   Goccia.Bytecode.Chunk,
   Goccia.CallStack,
   Goccia.Constants,
+  Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.NumericLimits,
   Goccia.Constants.PropertyNames,
@@ -2959,6 +2960,7 @@ var
   SpreadArray: TGocciaArrayValue;
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
+  Value: TGocciaValue;
   J: Integer;
 begin
   if ASpreadValue is TGocciaArrayValue then
@@ -2966,10 +2968,11 @@ begin
     SpreadArray := TGocciaArrayValue(ASpreadValue);
     for J := 0 to SpreadArray.Elements.Count - 1 do
     begin
-      if SpreadArray.Elements[J] = TGocciaHoleValue.HoleValue then
+      Value := SpreadArray.GetProperty(IntToStr(J));
+      if not Assigned(Value) then
         ATarget.Add(TGocciaUndefinedLiteralValue.UndefinedValue)
       else
-        ATarget.Add(SpreadArray.Elements[J]);
+        ATarget.Add(Value);
     end;
   end
   else
@@ -10285,7 +10288,8 @@ end;
 
 function InstantiateClass(const AClassValue: TGocciaClassValue;
   const AArguments: TGocciaArgumentsCollection;
-  const AContext: TGocciaEvaluationContext): TGocciaValue;
+  const AContext: TGocciaEvaluationContext;
+  const ANewTarget: TGocciaValue = nil): TGocciaValue;
 var
   Instance: TGocciaObjectValue;
   RootedInstance: TGocciaObjectValue;
@@ -10293,6 +10297,7 @@ var
   NativeInstance: TGocciaObjectValue;
   ConstructedValue: TGocciaValue;
   ConstructorThisValue: TGocciaValue;
+  EffectiveNewTarget: TGocciaValue;
   InitializerReplayReceiver: TGocciaObjectValue;
   function ConstructNativeSuperInstance(
     const AConstructor: TGocciaObjectValue): TGocciaObjectValue;
@@ -10310,7 +10315,7 @@ var
           Format('''%s'' is not a constructor',
             [TGocciaNativeFunctionValue(AConstructor).Name]));
       ConstructedValue := TGocciaNativeFunctionValue(AConstructor).Construct(
-        AArguments, AConstructor);
+        AArguments, EffectiveNewTarget);
     end
     else if AConstructor is TGocciaFunctionBase then
     begin
@@ -10394,6 +10399,25 @@ begin
   CheckExecutionTimeout;
   IncrementInstructionCounter;
   CheckInstructionLimit;
+  if Assigned(ANewTarget) then
+    EffectiveNewTarget := ANewTarget
+  else
+    EffectiveNewTarget := AClassValue;
+
+  // ES2026 §20.1.1.1 Object(value): direct Object construction with a
+  // non-nullish argument returns that object or ToObject(value).
+  if (AClassValue.Name = CONSTRUCTOR_OBJECT) and
+     (EffectiveNewTarget = AClassValue) and
+     (AArguments.Length > 0) and
+     not (AArguments.GetElement(0) is TGocciaUndefinedLiteralValue) and
+     not (AArguments.GetElement(0) is TGocciaNullLiteralValue) then
+  begin
+    if AArguments.GetElement(0) is TGocciaObjectValue then
+      Exit(AArguments.GetElement(0));
+    if AArguments.GetElement(0).IsPrimitive then
+      Exit(AArguments.GetElement(0).Box);
+  end;
+
   NativeInstance := nil;
   WalkClass := AClassValue;
   while Assigned(WalkClass) do
@@ -10434,7 +10458,7 @@ begin
     if Assigned(AClassValue.ConstructorMethod) then
     begin
       ConstructedValue := AClassValue.ConstructorMethod.CallWithThisValue(
-        AArguments, Instance, ConstructorThisValue, AClassValue);
+        AArguments, Instance, ConstructorThisValue, EffectiveNewTarget);
       ApplyOwnConstructorResult(ConstructedValue, ConstructorThisValue);
       if HasDerivedConstructorReturnRestriction and
          IsUndefinedConstructedValue(ConstructedValue) and
@@ -10445,7 +10469,7 @@ begin
     else if Assigned(AClassValue.SuperClass) and Assigned(AClassValue.SuperClass.ConstructorMethod) then
     begin
       ConstructedValue := AClassValue.SuperClass.ConstructorMethod.CallWithThisValue(
-        AArguments, Instance, ConstructorThisValue, AClassValue);
+        AArguments, Instance, ConstructorThisValue, EffectiveNewTarget);
       ValidateClassConstructorReturn(AClassValue.SuperClass, ConstructedValue);
       if IsUndefinedConstructedValue(ConstructedValue) then
         ApplyReplacementResult(ConstructorThisValue)
@@ -10457,7 +10481,8 @@ begin
             not (AClassValue.NativeSuperConstructor is TGocciaNativeFunctionValue) then
     begin
       ConstructedValue := InvokeConstructableWithReceiver(
-        AClassValue.NativeSuperConstructor, AArguments, Instance, AContext);
+        AClassValue.NativeSuperConstructor, AArguments, Instance, AContext,
+        EffectiveNewTarget);
       ApplyReplacementResult(ConstructedValue);
     end
     else if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then

--- a/source/units/Goccia.Generator.Continuation.pas
+++ b/source/units/Goccia.Generator.Continuation.pas
@@ -129,6 +129,7 @@ type
     FForLoopStates: TDictionary<TObject, TGocciaGeneratorForLoopState>;
     FIsAsyncGenerator: Boolean;
     FLastYieldWasDelegate: Boolean;
+    FLastYieldWasIteratorResult: Boolean;
     FReturnRequiresAwait: Boolean;
     procedure ClearDelegateState;
   public
@@ -181,6 +182,7 @@ type
     property Completed: Boolean read FCompleted;
     property IsAsyncGenerator: Boolean read FIsAsyncGenerator;
     property LastYieldWasDelegate: Boolean read FLastYieldWasDelegate;
+    property LastYieldWasIteratorResult: Boolean read FLastYieldWasIteratorResult;
     property ReturnRequiresAwait: Boolean read FReturnRequiresAwait;
   end;
 
@@ -597,6 +599,7 @@ begin
   FLoopStates := TDictionary<TObject, TGocciaGeneratorLoopState>.Create;
   FForLoopStates := TDictionary<TObject, TGocciaGeneratorForLoopState>.Create;
   FLastYieldWasDelegate := False;
+  FLastYieldWasIteratorResult := False;
   FReturnRequiresAwait := False;
 end;
 
@@ -665,6 +668,7 @@ begin
   FPendingValue := AValue;
   FStarted := True;
   FLastYieldWasDelegate := False;
+  FLastYieldWasIteratorResult := False;
   FReturnRequiresAwait := False;
 
   PreviousContinuation := GCurrentContinuation;
@@ -917,9 +921,19 @@ begin
         IteratorResult := TGocciaObjectValue(RawIteratorResult);
         if not IteratorResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value then
         begin
-          YieldedValue := IteratorResult.GetProperty(PROP_VALUE);
-          if not Assigned(YieldedValue) then
-            YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+          if FIsAsyncGenerator then
+          begin
+            YieldedValue := IteratorResult.GetProperty(PROP_VALUE);
+            if not Assigned(YieldedValue) then
+              YieldedValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+          end
+          else
+          begin
+            // ES2026 §15.5.5 YieldExpression : yield * AssignmentExpression:
+            // sync return() with done:false yields innerReturnResult itself.
+            YieldedValue := IteratorResult;
+            FLastYieldWasIteratorResult := True;
+          end;
           FLastYieldWasDelegate := True;
           FSuspendedYield := AYieldExpression;
           raise EGocciaGeneratorYield.Create(YieldedValue);

--- a/source/units/Goccia.MicrotaskQueue.pas
+++ b/source/units/Goccia.MicrotaskQueue.pas
@@ -52,6 +52,7 @@ uses
   SysUtils,
 
   Goccia.Arguments.Collection,
+  Goccia.Builtins.Atomics,
   Goccia.Constants.ErrorNames,
   Goccia.Error,
   Goccia.GarbageCollector,
@@ -310,10 +311,31 @@ procedure TGocciaMicrotaskQueue.ExecuteTask(
   const ATask: TGocciaMicrotask);
 var
   Promise: TGocciaPromiseValue;
+  Capability: TGocciaPromiseReactionCapability;
   HandlerResult: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
+  procedure ResolveResult(const AValue: TGocciaValue);
+  begin
+    if Assigned(Capability) then
+      Capability.Resolve(AValue)
+    else if Assigned(Promise) then
+      Promise.Resolve(AValue);
+  end;
+
+  procedure RejectResult(const AValue: TGocciaValue);
+  begin
+    if Assigned(Capability) then
+      Capability.Reject(AValue)
+    else if Assigned(Promise) then
+      Promise.Reject(AValue);
+  end;
 begin
-  Promise := TGocciaPromiseValue(ATask.ResultPromise);
+  Promise := nil;
+  Capability := nil;
+  if ATask.ResultPromise is TGocciaPromiseValue then
+    Promise := TGocciaPromiseValue(ATask.ResultPromise)
+  else if ATask.ResultPromise is TGocciaPromiseReactionCapability then
+    Capability := TGocciaPromiseReactionCapability(ATask.ResultPromise);
 
   if ATask.ReactionType = prtThenableResolve then
   begin
@@ -332,19 +354,18 @@ begin
     CallArgs := TGocciaArgumentsCollection.Create([ATask.Value]);
     try
       try
-        HandlerResult := TGocciaFunctionBase(ATask.Handler).Call(
-          CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
-        if Assigned(Promise) then
-          Promise.Resolve(HandlerResult);
+        HandlerResult := DispatchCall(ATask.Handler, CallArgs,
+          TGocciaUndefinedLiteralValue.UndefinedValue);
+        ResolveResult(HandlerResult);
       except
         on E: EGocciaBytecodeThrow do
-          if Assigned(Promise) then
-            Promise.Reject(E.ThrownValue)
+          if Assigned(Promise) or Assigned(Capability) then
+            RejectResult(E.ThrownValue)
           else
             raise;
         on E: TGocciaThrowValue do
-          if Assigned(Promise) then
-            Promise.Reject(E.Value)
+          if Assigned(Promise) or Assigned(Capability) then
+            RejectResult(E.Value)
           else
             raise;
       end;
@@ -354,11 +375,11 @@ begin
   end
   else
   begin
-    if Assigned(Promise) then
+    if Assigned(Promise) or Assigned(Capability) then
     begin
       case ATask.ReactionType of
-        prtFulfill: Promise.Resolve(ATask.Value);
-        prtReject: Promise.Reject(ATask.Value);
+        prtFulfill: ResolveResult(ATask.Value);
+        prtReject: RejectResult(ATask.Value);
         prtThenableResolve:;
       end;
     end;
@@ -398,6 +419,7 @@ begin
       ExecuteTask(Task);
     finally
       RemoveQueuedRoots(Task);
+      PumpAtomicsWaitAsyncCompletions;
       if Assigned(TGarbageCollector.Instance) then
         TGarbageCollector.Instance.ClearKeptObjects;
     end;
@@ -415,6 +437,7 @@ begin
       ExecuteTask(Task);
     finally
       RemoveQueuedRoots(Task);
+      PumpAtomicsWaitAsyncCompletions;
       if Assigned(TGarbageCollector.Instance) then
         TGarbageCollector.Instance.ClearKeptObjects;
     end;
@@ -455,6 +478,7 @@ begin
         ExecuteTask(Task);
       finally
         RemoveQueuedRoots(Task);
+        PumpAtomicsWaitAsyncCompletions;
         if Assigned(TGarbageCollector.Instance) then
           TGarbageCollector.Instance.ClearKeptObjects;
       end;
@@ -471,6 +495,7 @@ begin
         ExecuteTask(Task);
       finally
         RemoveQueuedRoots(Task);
+        PumpAtomicsWaitAsyncCompletions;
         if Assigned(TGarbageCollector.Instance) then
           TGarbageCollector.Instance.ClearKeptObjects;
       end;

--- a/source/units/Goccia.MicrotaskQueue.pas
+++ b/source/units/Goccia.MicrotaskQueue.pas
@@ -329,6 +329,18 @@ var
     else if Assigned(Promise) then
       Promise.Reject(AValue);
   end;
+
+  procedure RejectExceptionResult(const AException: Exception);
+  begin
+    if AException is TGocciaTypeError then
+      RejectResult(CreateErrorObject(TYPE_ERROR_NAME, AException.Message))
+    else if AException is TGocciaReferenceError then
+      RejectResult(CreateErrorObject(REFERENCE_ERROR_NAME, AException.Message))
+    else if AException is TGocciaSyntaxError then
+      RejectResult(CreateErrorObject(SYNTAX_ERROR_NAME, AException.Message))
+    else
+      RejectResult(CreateErrorObject(ERROR_NAME, AException.Message));
+  end;
 begin
   Promise := nil;
   Capability := nil;
@@ -366,6 +378,30 @@ begin
         on E: TGocciaThrowValue do
           if Assigned(Promise) or Assigned(Capability) then
             RejectResult(E.Value)
+          else
+            raise;
+        on E: TGocciaTimeoutError do
+          raise;
+        on E: TGocciaInstructionLimitError do
+          raise;
+        on E: TGocciaTypeError do
+          if Assigned(Promise) or Assigned(Capability) then
+            RejectExceptionResult(E)
+          else
+            raise;
+        on E: TGocciaReferenceError do
+          if Assigned(Promise) or Assigned(Capability) then
+            RejectExceptionResult(E)
+          else
+            raise;
+        on E: TGocciaSyntaxError do
+          if Assigned(Promise) or Assigned(Capability) then
+            RejectExceptionResult(E)
+          else
+            raise;
+        on E: Exception do
+          if Assigned(Promise) or Assigned(Capability) then
+            RejectExceptionResult(E)
           else
             raise;
       end;

--- a/source/units/Goccia.Modules.pas
+++ b/source/units/Goccia.Modules.pas
@@ -1003,7 +1003,9 @@ begin
   DefineSymbolProperty(TGocciaSymbolValue.WellKnownToStringTag,
     TGocciaPropertyDescriptorData.Create(
       TGocciaStringLiteralValue.Create('Deferred Module'), []));
-  Freeze;
+  FExtensible := False;
+  FSealed := True;
+  FFrozen := True;
 end;
 
 function TGocciaDeferredModuleNamespaceObject.EnsureNamespaceObject: TGocciaObjectValue;

--- a/source/units/Goccia.Scope.BindingMap.pas
+++ b/source/units/Goccia.Scope.BindingMap.pas
@@ -24,6 +24,7 @@ type
     DeclarationType: TGocciaDeclarationType;
     Initialized: Boolean;
     BuiltIn: Boolean;
+    GlobalObjectBacked: Boolean;
     CanDelete: Boolean;
     { Strict-types annotation enforced on every assignment.  Default
       sltUntyped means no enforcement (typical untyped binding). }

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -44,6 +44,8 @@ type
     FRejectArgumentsReferenceInDirectEval: Boolean;
     // Shared tail of TryGetBinding / TryGetBindingValueFillCache:
     // resolution after the own lexical map has already been consulted.
+    function IsGlobalBuiltInObjectBinding(
+      const ALexicalBinding: TLexicalBinding): Boolean;
     function TryGetGlobalBuiltInObjectBinding(const AName: string;
       const ALexicalBinding: TLexicalBinding;
       out ABinding: TLexicalBinding): Boolean;
@@ -76,6 +78,7 @@ type
       const ALine: Integer = 0; const AColumn: Integer = 0;
       const ANonStrictMode: Boolean = False); virtual;
     procedure ForceUpdateBinding(const AName: string; const AValue: TGocciaValue);
+    procedure MarkGlobalObjectBackedBinding(const AName: string);
 
     // Var binding support (separate map on function/module/global scopes)
     procedure DefineVariableBinding(const AName: string; const AValue: TGocciaValue;
@@ -617,6 +620,7 @@ begin
   LexicalBinding.DeclarationType := ADeclarationType;
   LexicalBinding.Initialized := False;
   LexicalBinding.BuiltIn := False;
+  LexicalBinding.GlobalObjectBacked := False;
   LexicalBinding.CanDelete := False;
   LexicalBinding.TypeHint := sltUntyped;
   FLexicalBindings.Add(AName, LexicalBinding);
@@ -637,6 +641,7 @@ begin
       ExistingLexicalBinding.DeclarationType := ADeclarationType;
       ExistingLexicalBinding.Initialized := True;
       ExistingLexicalBinding.BuiltIn := ABuiltIn;
+      ExistingLexicalBinding.GlobalObjectBacked := False;
       FLexicalBindings.AddOrSetValue(AName, ExistingLexicalBinding);
       Exit;
     end;
@@ -671,6 +676,7 @@ begin
   // - dtParameter: parameters have no TDZ
   LexicalBinding.Initialized := True;
   LexicalBinding.BuiltIn := ABuiltIn;
+  LexicalBinding.GlobalObjectBacked := False;
   LexicalBinding.CanDelete := False;
   LexicalBinding.TypeHint := sltUntyped;
 
@@ -708,6 +714,25 @@ begin
   begin
     LexicalBinding.Value := AValue;
     LexicalBinding.Initialized := True;
+    FVarBindings.AddOrSetValue(AName, LexicalBinding);
+  end;
+end;
+
+procedure TGocciaScope.MarkGlobalObjectBackedBinding(const AName: string);
+var
+  LexicalBinding: TLexicalBinding;
+begin
+  if FLexicalBindings.TryGetValue(AName, LexicalBinding) then
+  begin
+    LexicalBinding.GlobalObjectBacked := True;
+    FLexicalBindings.AddOrSetValue(AName, LexicalBinding);
+    Exit;
+  end;
+
+  if Assigned(FVarBindings) and FVarBindings.TryGetValue(AName,
+     LexicalBinding) then
+  begin
+    LexicalBinding.GlobalObjectBacked := True;
     FVarBindings.AddOrSetValue(AName, LexicalBinding);
   end;
 end;
@@ -777,6 +802,7 @@ begin
     Binding.DeclarationType := dtVar;
     Binding.Initialized := True;
     Binding.BuiltIn := False;
+    Binding.GlobalObjectBacked := False;
     Binding.CanDelete := ACanDelete;
     Binding.TypeHint := sltUntyped;
     TargetScope.FVarBindings.AddOrSetValue(AName, Binding);
@@ -968,19 +994,22 @@ begin
   begin
     if not LexicalBinding.IsAccessible then
       RaiseBindingNotInitialized(AName, ALine, AColumn);
-    if LexicalBinding.BuiltIn and LexicalBinding.Writable and
-       (FScopeKind = skGlobal) and (FThisValue is TGocciaObjectValue) and
-       TGocciaObjectValue(FThisValue).HasProperty(AName) then
+    if IsGlobalBuiltInObjectBinding(LexicalBinding) then
     begin
       GlobalObject := TGocciaObjectValue(FThisValue);
-      if ANonStrictMode then
-        GlobalObject.AssignPropertyWithReceiver(AName, AValue, GlobalObject)
-      else
-        GlobalObject.AssignProperty(AName, AValue);
-      LexicalBinding.Value := GlobalObject.GetProperty(AName);
-      LexicalBinding.Initialized := True;
-      FLexicalBindings.AddOrSetValue(AName, LexicalBinding);
-      Exit(True);
+      if not GlobalObject.HasProperty(AName) then
+        Exit(False);
+      if LexicalBinding.Writable then
+      begin
+        if ANonStrictMode then
+          GlobalObject.AssignPropertyWithReceiver(AName, AValue, GlobalObject)
+        else
+          GlobalObject.AssignProperty(AName, AValue);
+        LexicalBinding.Value := GlobalObject.GetProperty(AName);
+        LexicalBinding.Initialized := True;
+        FLexicalBindings.AddOrSetValue(AName, LexicalBinding);
+        Exit(True);
+      end;
     end;
     if not LexicalBinding.Writable then
       raise TGocciaTypeError.Create(
@@ -1063,8 +1092,13 @@ begin
   begin
     if not ABinding.IsAccessible then
       RaiseBindingNotInitialized(AName, ALine, AColumn);
-    if TryGetGlobalBuiltInObjectBinding(AName, ABinding, ABinding) then
-      Exit(True);
+    if IsGlobalBuiltInObjectBinding(ABinding) then
+    begin
+      if TryGetGlobalBuiltInObjectBinding(AName, ABinding, ABinding) then
+        Exit(True);
+      ABinding := Default(TLexicalBinding);
+      Exit(False);
+    end;
     Exit(True);
   end;
   Result := TryGetBindingSkipLexical(AName, ABinding, ALine, AColumn);
@@ -1097,14 +1131,20 @@ begin
     AValue := nil;
 end;
 
+function TGocciaScope.IsGlobalBuiltInObjectBinding(
+  const ALexicalBinding: TLexicalBinding): Boolean;
+begin
+  Result := ALexicalBinding.BuiltIn and ALexicalBinding.GlobalObjectBacked and
+    (FScopeKind = skGlobal) and (FThisValue is TGocciaObjectValue);
+end;
+
 function TGocciaScope.TryGetGlobalBuiltInObjectBinding(const AName: string;
   const ALexicalBinding: TLexicalBinding;
   out ABinding: TLexicalBinding): Boolean;
 var
   GlobalObject: TGocciaObjectValue;
 begin
-  if (not ALexicalBinding.BuiltIn) or (FScopeKind <> skGlobal) or
-     not (FThisValue is TGocciaObjectValue) then
+  if not IsGlobalBuiltInObjectBinding(ALexicalBinding) then
     Exit(False);
 
   GlobalObject := TGocciaObjectValue(FThisValue);
@@ -1127,6 +1167,7 @@ begin
     ABinding.DeclarationType := dtVar;
     ABinding.Initialized := True;
     ABinding.BuiltIn := False;
+    ABinding.GlobalObjectBacked := False;
     ABinding.CanDelete := False;
     ABinding.TypeHint := sltUntyped;
     Exit(True);
@@ -1152,11 +1193,16 @@ begin
   end;
   if not LexicalBinding.IsAccessible then
     RaiseBindingNotInitialized(FLexicalBindings.KeyAtEntry(AEntryIndex), 0, 0);
-  if TryGetGlobalBuiltInObjectBinding(FLexicalBindings.KeyAtEntry(AEntryIndex),
-     LexicalBinding, LexicalBinding) then
+  if IsGlobalBuiltInObjectBinding(LexicalBinding) then
   begin
-    AValue := LexicalBinding.Value;
-    Exit(True);
+    if TryGetGlobalBuiltInObjectBinding(FLexicalBindings.KeyAtEntry(AEntryIndex),
+       LexicalBinding, LexicalBinding) then
+    begin
+      AValue := LexicalBinding.Value;
+      Exit(True);
+    end;
+    AValue := nil;
+    Exit(False);
   end;
   AValue := LexicalBinding.Value;
   Result := True;
@@ -1174,11 +1220,18 @@ begin
     FLexicalBindings.TryGetValueAtEntry(AEntryIndex, LexicalBinding);
     if not LexicalBinding.IsAccessible then
       RaiseBindingNotInitialized(AName, 0, 0);
-    if TryGetGlobalBuiltInObjectBinding(AName, LexicalBinding,
-       LexicalBinding) then
+    if IsGlobalBuiltInObjectBinding(LexicalBinding) then
     begin
-      AValue := LexicalBinding.Value;
-      Exit(True);
+      if TryGetGlobalBuiltInObjectBinding(AName, LexicalBinding,
+         LexicalBinding) then
+      begin
+        AValue := LexicalBinding.Value;
+        Exit(True);
+      end;
+      AEntryIndex := -1;
+      AVersion := 0;
+      AValue := nil;
+      Exit(False);
     end;
     AValue := LexicalBinding.Value;
     Exit(True);
@@ -1588,6 +1641,7 @@ begin
     ABinding.DeclarationType := dtVar;
     ABinding.Initialized := True;
     ABinding.BuiltIn := False;
+    ABinding.GlobalObjectBacked := False;
     ABinding.CanDelete := False;
     ABinding.TypeHint := sltUntyped;
     Exit(True);

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -44,6 +44,9 @@ type
     FRejectArgumentsReferenceInDirectEval: Boolean;
     // Shared tail of TryGetBinding / TryGetBindingValueFillCache:
     // resolution after the own lexical map has already been consulted.
+    function TryGetGlobalBuiltInObjectBinding(const AName: string;
+      const ALexicalBinding: TLexicalBinding;
+      out ABinding: TLexicalBinding): Boolean;
     function TryGetBindingSkipLexical(const AName: string;
       out ABinding: TLexicalBinding; const ALine: Integer = 0;
       const AColumn: Integer = 0): Boolean;
@@ -965,6 +968,20 @@ begin
   begin
     if not LexicalBinding.IsAccessible then
       RaiseBindingNotInitialized(AName, ALine, AColumn);
+    if LexicalBinding.BuiltIn and LexicalBinding.Writable and
+       (FScopeKind = skGlobal) and (FThisValue is TGocciaObjectValue) and
+       TGocciaObjectValue(FThisValue).HasProperty(AName) then
+    begin
+      GlobalObject := TGocciaObjectValue(FThisValue);
+      if ANonStrictMode then
+        GlobalObject.AssignPropertyWithReceiver(AName, AValue, GlobalObject)
+      else
+        GlobalObject.AssignProperty(AName, AValue);
+      LexicalBinding.Value := GlobalObject.GetProperty(AName);
+      LexicalBinding.Initialized := True;
+      FLexicalBindings.AddOrSetValue(AName, LexicalBinding);
+      Exit(True);
+    end;
     if not LexicalBinding.Writable then
       raise TGocciaTypeError.Create(
         Format(SErrorAssignToConstant, [AName]),
@@ -1046,6 +1063,8 @@ begin
   begin
     if not ABinding.IsAccessible then
       RaiseBindingNotInitialized(AName, ALine, AColumn);
+    if TryGetGlobalBuiltInObjectBinding(AName, ABinding, ABinding) then
+      Exit(True);
     Exit(True);
   end;
   Result := TryGetBindingSkipLexical(AName, ABinding, ALine, AColumn);
@@ -1076,6 +1095,25 @@ begin
     AValue := LexicalBinding.Value
   else
     AValue := nil;
+end;
+
+function TGocciaScope.TryGetGlobalBuiltInObjectBinding(const AName: string;
+  const ALexicalBinding: TLexicalBinding;
+  out ABinding: TLexicalBinding): Boolean;
+var
+  GlobalObject: TGocciaObjectValue;
+begin
+  if (not ALexicalBinding.BuiltIn) or (FScopeKind <> skGlobal) or
+     not (FThisValue is TGocciaObjectValue) then
+    Exit(False);
+
+  GlobalObject := TGocciaObjectValue(FThisValue);
+  if not GlobalObject.HasProperty(AName) then
+    Exit(False);
+
+  ABinding := ALexicalBinding;
+  ABinding.Value := GlobalObject.GetProperty(AName);
+  Result := True;
 end;
 
 function TGocciaScope.TryGetBindingSkipLexical(const AName: string;
@@ -1114,6 +1152,12 @@ begin
   end;
   if not LexicalBinding.IsAccessible then
     RaiseBindingNotInitialized(FLexicalBindings.KeyAtEntry(AEntryIndex), 0, 0);
+  if TryGetGlobalBuiltInObjectBinding(FLexicalBindings.KeyAtEntry(AEntryIndex),
+     LexicalBinding, LexicalBinding) then
+  begin
+    AValue := LexicalBinding.Value;
+    Exit(True);
+  end;
   AValue := LexicalBinding.Value;
   Result := True;
 end;
@@ -1130,6 +1174,12 @@ begin
     FLexicalBindings.TryGetValueAtEntry(AEntryIndex, LexicalBinding);
     if not LexicalBinding.IsAccessible then
       RaiseBindingNotInitialized(AName, 0, 0);
+    if TryGetGlobalBuiltInObjectBinding(AName, LexicalBinding,
+       LexicalBinding) then
+    begin
+      AValue := LexicalBinding.Value;
+      Exit(True);
+    end;
     AValue := LexicalBinding.Value;
     Exit(True);
   end;

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -317,6 +317,7 @@ const
         '    }.toLocaleString;'#10 +
         '    Object.defineProperty(Number.prototype, "toLocaleString", { value: numberLocale, writable: true, configurable: true });'#10 +
         '    Object.defineProperty(Array.prototype, "toLocaleString", { value: arrayLocale, writable: true, configurable: true });'#10 +
+        '    Object.defineProperty(this.prototype, Symbol.toStringTag, { value: "Date", writable: true, configurable: true });'#10 +
         '  }'#10 +
         '  static now(): number { return Temporal.Now.instant().epochMilliseconds; }'#10 +
         '  static parse(str: string): number { return parseDateStringToEpoch(str); }'#10 +
@@ -508,6 +509,22 @@ const
         '    return days[z.dayOfWeek % 7] + " " + months[z.month - 1] + " " + pad(z.day) + " " +'#10 +
         '      String(z.year) + " " + pad(z.hour) + ":" + pad(z.minute) + ":" + pad(z.second) + " GMT" + z.offset;'#10 +
         '  }'#10 +
+        '  toDateString(): string {'#10 +
+        '    Date.#require(this);'#10 +
+        '    const z = Date.#local(this);'#10 +
+        '    if (!z) return "Invalid Date";'#10 +
+        '    const pad = (n: number): string => n < 10 ? "0" + String(n) : String(n);'#10 +
+        '    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];'#10 +
+        '    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];'#10 +
+        '    return days[z.dayOfWeek % 7] + " " + months[z.month - 1] + " " + pad(z.day) + " " + String(z.year);'#10 +
+        '  }'#10 +
+        '  toTimeString(): string {'#10 +
+        '    Date.#require(this);'#10 +
+        '    const z = Date.#local(this);'#10 +
+        '    if (!z) return "Invalid Date";'#10 +
+        '    const pad = (n: number): string => n < 10 ? "0" + String(n) : String(n);'#10 +
+        '    return pad(z.hour) + ":" + pad(z.minute) + ":" + pad(z.second) + " GMT" + z.offset;'#10 +
+        '  }'#10 +
         '  toUTCString(): string {'#10 +
         '    Date.#require(this);'#10 +
         '    const z = Date.#utc(this);'#10 +
@@ -581,10 +598,12 @@ const
       FileName: '<shim:hasOwnProperty>';
       Source:
         'export const hasOwnProperty = ((proto) => {'#10 +
-        '  Object.defineProperty(proto, "hasOwnProperty", {'#10 +
-        '    value(prop) { return Object.hasOwn(this, prop); },'#10 +
-        '    writable: true, enumerable: false, configurable: true'#10 +
-        '  });'#10 +
+        '  if (!proto.hasOwnProperty) {'#10 +
+        '    Object.defineProperty(proto, "hasOwnProperty", {'#10 +
+        '      value(prop) { return Object.hasOwn(this, prop); },'#10 +
+        '      writable: true, enumerable: false, configurable: true'#10 +
+        '    });'#10 +
+        '  }'#10 +
         '  return proto.hasOwnProperty;'#10 +
         '})(Object.getPrototypeOf({}));'
     ),

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -277,7 +277,7 @@ begin
     Exit; // year/month/week/day — no fixed maximum
   end;
 
-  if (AIncrement >= MaxVal) or (MaxVal mod AIncrement <> 0) then
+  if (AIncrement > MaxVal) or (MaxVal mod AIncrement <> 0) then
     ThrowRangeError(Format(SErrorRoundingIncrementDivisor, [AIncrement, MaxVal]),
       SSuggestTemporalRoundArg);
 end;

--- a/source/units/Goccia.Temporal.Options.pas
+++ b/source/units/Goccia.Temporal.Options.pas
@@ -277,7 +277,7 @@ begin
     Exit; // year/month/week/day — no fixed maximum
   end;
 
-  if MaxVal mod AIncrement <> 0 then
+  if (AIncrement >= MaxVal) or (MaxVal mod AIncrement <> 0) then
     ThrowRangeError(Format(SErrorRoundingIncrementDivisor, [AIncrement, MaxVal]),
       SSuggestTemporalRoundArg);
 end;

--- a/source/units/Goccia.Threading.pas
+++ b/source/units/Goccia.Threading.pas
@@ -230,7 +230,7 @@ begin
   // Coverage tracker is NOT shut down here — the main thread reads it
   // after workers complete, then merges into the main tracker.
   ClearImportMetaCache;
-  ShutdownAtomicsWaiters;
+  ShutdownAtomicsWaitersForCurrentThread;
   ClearDisposableStackSlotMap;
   ClearSemverHosts;
   ClearTimeZoneCache;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -1179,6 +1179,7 @@ begin
     ABinding.DeclarationType := dtVar;
     ABinding.Initialized := True;
     ABinding.BuiltIn := False;
+    ABinding.GlobalObjectBacked := False;
     ABinding.CanDelete := False;
     ABinding.TypeHint := sltUntyped;
     Exit(True);
@@ -1203,6 +1204,7 @@ begin
       ABinding.DeclarationType := dtVar;
     ABinding.Initialized := True;
     ABinding.BuiltIn := False;
+    ABinding.GlobalObjectBacked := False;
     ABinding.CanDelete := False;
     ABinding.TypeHint := sltUntyped;
     Exit(True);
@@ -2617,6 +2619,10 @@ type
   private
     FVM: TGocciaVM;
     FConstructorValue: TGocciaValue;
+    FNativeInstanceNewTarget: TGocciaValue;
+    function CreateNativeInstanceWithNewTarget(
+      const AArguments: TGocciaArgumentsCollection;
+      const ANewTarget: TGocciaValue): TGocciaObjectValue;
   public
     constructor Create(const AVM: TGocciaVM; const AName: string;
       const ASuperClass: TGocciaClassValue);
@@ -2994,6 +3000,7 @@ begin
   inherited Create(AName, ASuperClass);
   FVM := AVM;
   FConstructorValue := nil;
+  FNativeInstanceNewTarget := nil;
 end;
 
 function TGocciaVMClassValue.GetClassLength: Integer;
@@ -3017,6 +3024,7 @@ function TGocciaVMClassValue.CreateNativeInstance(
   const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
 var
   ConstructedValue: TGocciaValue;
+  EffectiveNewTarget: TGocciaValue;
 begin
   Result := inherited CreateNativeInstance(AArguments);
   if Assigned(Result) or not Assigned(NativeSuperConstructor) then
@@ -3025,8 +3033,12 @@ begin
   if NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype then
     Exit(nil);
 
+  if Assigned(FNativeInstanceNewTarget) then
+    EffectiveNewTarget := FNativeInstanceNewTarget
+  else
+    EffectiveNewTarget := Self;
   ConstructedValue := FVM.ConstructValue(NativeSuperConstructor, AArguments,
-    Self);
+    EffectiveNewTarget);
   if ConstructedValue is TGocciaObjectValue then
     Result := TGocciaObjectValue(ConstructedValue)
   else
@@ -3034,6 +3046,21 @@ begin
     ThrowTypeError('Superclass constructor did not return an object',
       SSuggestNotConstructorType);
     Result := nil;
+  end;
+end;
+
+function TGocciaVMClassValue.CreateNativeInstanceWithNewTarget(
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaObjectValue;
+var
+  PreviousNewTarget: TGocciaValue;
+begin
+  PreviousNewTarget := FNativeInstanceNewTarget;
+  FNativeInstanceNewTarget := ANewTarget;
+  try
+    Result := CreateNativeInstance(AArguments);
+  finally
+    FNativeInstanceNewTarget := PreviousNewTarget;
   end;
 end;
 
@@ -6070,6 +6097,7 @@ var
   InitializerReplayReceiver: TGocciaObjectValue;
   PreviousConstructorSuperCalled: Boolean;
   ConstructorSuperCalled: Boolean;
+  NativeInstanceConstructedByNativeSuper: Boolean;
   function IsUndefinedConstructedValue(const AValue: TGocciaValue): Boolean;
   begin
     Result := (not Assigned(AValue)) or (AValue is TGocciaUndefinedLiteralValue);
@@ -6077,6 +6105,12 @@ var
   function HasDerivedConstructorReturnRestriction: Boolean;
   begin
     Result := Assigned(SuperClass) or Assigned(NativeSuperConstructor);
+  end;
+  function EffectiveNewTarget: TGocciaValue;
+  begin
+    if Assigned(ANewTarget) then
+      Exit(ANewTarget);
+    Result := Self;
   end;
   function ClassRequiresObjectConstructorReturn(
     const AClassValue: TGocciaClassValue): Boolean;
@@ -6161,12 +6195,24 @@ begin
     InstancePrototype := Prototype;
 
   NativeInstance := nil;
+  NativeInstanceConstructedByNativeSuper := False;
   if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
   begin
     WalkClass := Self;
     while Assigned(WalkClass) do
     begin
-      NativeInstance := WalkClass.CreateNativeInstance(AArguments);
+      if WalkClass is TGocciaVMClassValue then
+      begin
+        NativeInstance := TGocciaVMClassValue(WalkClass)
+          .CreateNativeInstanceWithNewTarget(AArguments, EffectiveNewTarget);
+        NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance) and
+          Assigned(TGocciaVMClassValue(WalkClass).NativeSuperConstructor);
+      end
+      else
+      begin
+        NativeInstance := WalkClass.CreateNativeInstance(AArguments);
+        NativeInstanceConstructedByNativeSuper := False;
+      end;
       if Assigned(NativeInstance) then
         Break;
       WalkClass := WalkClass.SuperClass;
@@ -6242,7 +6288,8 @@ begin
           // selected the correct exotic receiver above. Re-entering implicit
           // super here would allocate a second receiver using the superclass
           // as newTarget and replace the derived instance.
-          if Instance is TGocciaInstanceValue then
+          if (Instance is TGocciaInstanceValue) and
+             not NativeInstanceConstructedByNativeSuper then
             TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
         end
         else if (SuperClass is TGocciaVMClassValue) and
@@ -6310,7 +6357,8 @@ begin
 
       if not Assigned(InitializerReplayReceiver) or
          (Instance <> InitializerReplayReceiver) then
-        if not HasDerivedConstructorReturnRestriction then
+        if (not HasDerivedConstructorReturnRestriction) or
+           Assigned(NativeInstance) then
           FVM.RunClassInitializers(Self, Instance);
 
       if Assigned(InitializerReplayReceiver) and
@@ -6354,6 +6402,7 @@ var
   InitializerReplayReceiver: TGocciaObjectValue;
   PreviousConstructorSuperCalled: Boolean;
   ConstructorSuperCalled: Boolean;
+  NativeInstanceConstructedByNativeSuper: Boolean;
   procedure EnsureBoxedArgs;
   begin
     if not Assigned(BoxedArgs) then
@@ -6507,6 +6556,7 @@ begin
   BoxedArgs := nil;
   try
     NativeInstance := nil;
+    NativeInstanceConstructedByNativeSuper := False;
     if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
     begin
       WalkClass := Self;
@@ -6516,11 +6566,14 @@ begin
         begin
           EnsureBoxedArgs;
           NativeInstance := WalkClass.CreateNativeInstance(BoxedArgs);
+          NativeInstanceConstructedByNativeSuper := False;
         end
         else if Assigned(TGocciaVMClassValue(WalkClass).NativeSuperConstructor) then
         begin
           EnsureBoxedArgs;
-          NativeInstance := WalkClass.CreateNativeInstance(BoxedArgs);
+          NativeInstance := TGocciaVMClassValue(WalkClass)
+            .CreateNativeInstanceWithNewTarget(BoxedArgs, Self);
+          NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance);
         end;
         if Assigned(NativeInstance) then
           Break;
@@ -6616,7 +6669,8 @@ begin
             // super here would allocate a second receiver using the superclass
             // as newTarget and replace the derived instance.
             EnsureBoxedArgs;
-            if Instance is TGocciaInstanceValue then
+            if (Instance is TGocciaInstanceValue) and
+               not NativeInstanceConstructedByNativeSuper then
               TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
           end
           else if (SuperClass is TGocciaVMClassValue) and
@@ -6832,6 +6886,8 @@ begin
   inherited;
   if Assigned(FConstructorValue) then
     FConstructorValue.MarkReferences;
+  if Assigned(FNativeInstanceNewTarget) then
+    FNativeInstanceNewTarget.MarkReferences;
 end;
 
 procedure TGocciaVMSuperConstructorValue.MarkReferences;
@@ -9716,6 +9772,15 @@ begin
         SSuggestNotConstructorType);
     ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
     TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+    if TargetInstance is TGocciaInstanceValue then
+    begin
+      if AInstance is TGocciaInstanceValue then
+        TGocciaInstanceValue(TargetInstance).ClassValue :=
+          TGocciaInstanceValue(AInstance).ClassValue
+      else
+        TGocciaInstanceValue(TargetInstance).ClassValue := AClassValue;
+      TGocciaInstanceValue(TargetInstance).InitializeNativeFromArguments(AArguments);
+    end;
     Exit(TargetInstance);
   end;
 
@@ -9856,16 +9921,25 @@ begin
     BoxedArgs := MaterializeArguments(AArguments);
     try
       TargetInstance := AClassValue.CreateNativeInstance(BoxedArgs);
+      if not (TargetInstance is TGocciaObjectValue) then
+        ThrowTypeError(
+          'Superclass constructor did not return an object',
+          SSuggestNotConstructorType);
+      ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
+      TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+      if TargetInstance is TGocciaInstanceValue then
+      begin
+        if AInstance is TGocciaInstanceValue then
+          TGocciaInstanceValue(TargetInstance).ClassValue :=
+            TGocciaInstanceValue(AInstance).ClassValue
+        else
+          TGocciaInstanceValue(TargetInstance).ClassValue := AClassValue;
+        TGocciaInstanceValue(TargetInstance).InitializeNativeFromArguments(BoxedArgs);
+      end;
+      Exit(TargetInstance);
     finally
       ReleaseArguments(BoxedArgs);
     end;
-    if not (TargetInstance is TGocciaObjectValue) then
-      ThrowTypeError(
-        'Superclass constructor did not return an object',
-        SSuggestNotConstructorType);
-    ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
-    TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
-    Exit(TargetInstance);
   end;
 
   if (AClassValue is TGocciaVMClassValue) and
@@ -14713,7 +14787,7 @@ begin
           begin
             if GetRegister(B) is TGocciaArrayValue then
               for I := 0 to TGocciaArrayValue(GetRegister(B)).Elements.Count - 1 do
-                CallArgs.Add(TGocciaArrayValue(GetRegister(B)).GetElement(I));
+                CallArgs.Add(TGocciaArrayValue(GetRegister(B)).GetProperty(IntToStr(I)));
           end
           else
             for I := 0 to B - 1 do

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -263,7 +263,8 @@ type
     function GetIteratorValue(const AIterable: TGocciaValue;
       const ATryAsync: Boolean): TGocciaValue;
     function ConstructValue(const AConstructor: TGocciaValue;
-      const AArguments: TGocciaArgumentsCollection): TGocciaValue;
+      const AArguments: TGocciaArgumentsCollection;
+      const ANewTarget: TGocciaValue = nil): TGocciaValue;
     function ImportModuleValue(const APath: string): TGocciaValue; overload;
     function ImportModuleValue(const APath, AReferrer: string): TGocciaValue; overload;
     procedure ResolveDynamicImportPromise(const APromise: TGocciaPromiseValue;
@@ -3024,14 +3025,8 @@ begin
   if NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype then
     Exit(nil);
 
-  if (NativeSuperConstructor is TGocciaFunctionBase) and
-     not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
-  begin
-    Result := TGocciaInstanceValue.Create(Self);
-    Exit;
-  end;
-
-  ConstructedValue := FVM.ConstructValue(NativeSuperConstructor, AArguments);
+  ConstructedValue := FVM.ConstructValue(NativeSuperConstructor, AArguments,
+    Self);
   if ConstructedValue is TGocciaObjectValue then
     Result := TGocciaObjectValue(ConstructedValue)
   else
@@ -6241,8 +6236,17 @@ begin
       FVM.FCurrentConstructorSuperCalled := False;
       try
         ConstructorToCall := nil;
-        if (SuperClass is TGocciaVMClassValue) and
-           Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
+        if Assigned(NativeInstance) then
+        begin
+          // The native superclass constructor has already allocated and
+          // selected the correct exotic receiver above. Re-entering implicit
+          // super here would allocate a second receiver using the superclass
+          // as newTarget and replace the derived instance.
+          if Instance is TGocciaInstanceValue then
+            TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
+        end
+        else if (SuperClass is TGocciaVMClassValue) and
+                Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
         begin
           FVM.RunClassInitializers(SuperClass, Instance);
           if Assigned(ANewTarget) then
@@ -6605,8 +6609,18 @@ begin
         try
           ConstructorToCall := nil;
 
-          if (SuperClass is TGocciaVMClassValue) and
-             Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
+          if Assigned(NativeInstance) then
+          begin
+            // The native superclass constructor has already allocated and
+            // selected the correct exotic receiver above. Re-entering implicit
+            // super here would allocate a second receiver using the superclass
+            // as newTarget and replace the derived instance.
+            EnsureBoxedArgs;
+            if Instance is TGocciaInstanceValue then
+              TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
+          end
+          else if (SuperClass is TGocciaVMClassValue) and
+                  Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
           begin
             TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
               SuperClass, Instance);
@@ -8507,28 +8521,35 @@ begin
 end;
 
 function TGocciaVM.ConstructValue(const AConstructor: TGocciaValue;
-  const AArguments: TGocciaArgumentsCollection): TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
 var
   BytecodeFunction: TGocciaBytecodeFunctionValue;
   BoundArgs: TGocciaArgumentsCollection;
   BoundFunction: TGocciaBoundFunctionValue;
   Context: TGocciaEvaluationContext;
   ConstructorName: string;
+  EffectiveNewTarget: TGocciaValue;
   I: Integer;
-  PrototypeTarget: TGocciaValue;
-  PrototypeValue: TGocciaValue;
   ReceiverPrototype, ReceiverInstance: TGocciaObjectValue;
 begin
   // ES2026 §28.1.1 [[Construct]](argumentsList, newTarget)
+  if Assigned(ANewTarget) then
+    EffectiveNewTarget := ANewTarget
+  else
+    EffectiveNewTarget := AConstructor;
+
   if AConstructor is TGocciaProxyValue then
   begin
-    Result := TGocciaProxyValue(AConstructor).ConstructTrap(AArguments);
+    Result := TGocciaProxyValue(AConstructor).ConstructTrap(AArguments,
+      EffectiveNewTarget);
     Exit;
   end;
 
   if AConstructor is TGocciaVMClassValue then
   begin
-    Result := TGocciaVMClassValue(AConstructor).Instantiate(AArguments);
+    Result := TGocciaVMClassValue(AConstructor).Instantiate(AArguments,
+      EffectiveNewTarget);
     Exit;
   end;
 
@@ -8537,13 +8558,16 @@ begin
     FillChar(Context, SizeOf(Context), 0);
     Context.Realm := FRealm;
     Context.Scope := FGlobalScope;
-    Result := InstantiateClass(TGocciaClassValue(AConstructor), AArguments, Context);
+    Result := InstantiateClass(TGocciaClassValue(AConstructor), AArguments,
+      Context);
     Exit;
   end;
 
   if AConstructor is TGocciaBoundFunctionValue then
   begin
     BoundFunction := TGocciaBoundFunctionValue(AConstructor);
+    if IsSameValue(BoundFunction, EffectiveNewTarget) then
+      EffectiveNewTarget := BoundFunction.OriginalFunction;
     BoundArgs := TGocciaArgumentsCollection.CreateWithCapacity(
       BoundFunction.BoundArgCount + AArguments.Length);
     try
@@ -8551,7 +8575,8 @@ begin
         BoundArgs.Add(BoundFunction.GetBoundArg(I));
       for I := 0 to AArguments.Length - 1 do
         BoundArgs.Add(AArguments.GetElement(I));
-      Result := ConstructValue(BoundFunction.OriginalFunction, BoundArgs);
+      Result := ConstructValue(BoundFunction.OriginalFunction, BoundArgs,
+        EffectiveNewTarget);
     finally
       BoundArgs.Free;
     end;
@@ -8571,7 +8596,7 @@ begin
       TGocciaCallStack.Instance.Push(ConstructorName, '', 0, 0);
     try
       Result := TGocciaNativeFunctionValue(AConstructor).Construct(
-        AArguments, AConstructor);
+        AArguments, EffectiveNewTarget);
     finally
       if Assigned(TGocciaCallStack.Instance) then
         TGocciaCallStack.Instance.Pop;
@@ -8610,24 +8635,7 @@ begin
     // that property is not an Object — §10.1.14 GetPrototypeFromConstructor),
     // then calls the body with the new object bound as `this`.  Iff the body
     // explicitly returns an Object, that becomes the call result.
-    // For bound function exotic objects (§10.4.1.2) the receiver's
-    // [[Prototype]] comes from the underlying [[BoundTargetFunction]] —
-    // the bound wrapper itself has no own `prototype` data property.
-    PrototypeTarget := AConstructor;
-    while PrototypeTarget is TGocciaBoundFunctionValue do
-      PrototypeTarget := TGocciaBoundFunctionValue(PrototypeTarget).OriginalFunction;
-    if PrototypeTarget is TGocciaObjectValue then
-      PrototypeValue := TGocciaObjectValue(PrototypeTarget).GetProperty(PROP_PROTOTYPE)
-    else
-      PrototypeValue := nil;
-    if PrototypeValue is TGocciaObjectValue then
-      ReceiverPrototype := TGocciaObjectValue(PrototypeValue)
-    else
-    begin
-      if not Assigned(TGocciaObjectValue.SharedObjectPrototype) then
-        TGocciaObjectValue.InitializeSharedPrototype;
-      ReceiverPrototype := TGocciaObjectValue.SharedObjectPrototype;
-    end;
+    ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
     ReceiverInstance := TGocciaObjectValue.Create(ReceiverPrototype);
     TGarbageCollector.Instance.AddTempRoot(ReceiverInstance);
     try
@@ -8638,7 +8646,7 @@ begin
         // the underlying target, and applies the spec return rules
         // (explicit Object return wins; otherwise the receiver).
         Result := InvokeConstructableWithReceiver(AConstructor, AArguments,
-          ReceiverInstance);
+          ReceiverInstance, EffectiveNewTarget);
       finally
         if Assigned(TGocciaCallStack.Instance) then
           TGocciaCallStack.Instance.Pop;
@@ -9655,8 +9663,17 @@ function TGocciaVM.InvokeImplicitSuperInitialization(
   const AArguments: TGocciaArgumentsCollection): TGocciaValue;
 var
   ConstructorThisValue: TGocciaValue;
+  ReceiverPrototype: TGocciaObjectValue;
   SuperResult: TGocciaValue;
   TargetInstance: TGocciaValue;
+  function EffectiveNewTarget: TGocciaValue;
+  begin
+    if Assigned(FPendingNewTarget) then
+      Exit(FPendingNewTarget);
+    if Assigned(FCurrentNewTarget) then
+      Exit(FCurrentNewTarget);
+    Result := AClassValue;
+  end;
   function IsUndefinedConstructedValue(const AValue: TGocciaValue): Boolean;
   begin
     Result := (not Assigned(AValue)) or (AValue is TGocciaUndefinedLiteralValue);
@@ -9689,6 +9706,18 @@ begin
   Result := AInstance;
   if not Assigned(AClassValue) then
     Exit;
+
+  if Assigned(AClassValue.NativeInstanceDefaultPrototype) then
+  begin
+    TargetInstance := AClassValue.CreateNativeInstance(AArguments);
+    if not (TargetInstance is TGocciaObjectValue) then
+      ThrowTypeError(
+        'Superclass constructor did not return an object',
+        SSuggestNotConstructorType);
+    ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
+    TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+    Exit(TargetInstance);
+  end;
 
   if (AClassValue is TGocciaVMClassValue) and
      Assigned(TGocciaVMClassValue(AClassValue).FConstructorValue) then
@@ -9762,9 +9791,18 @@ var
   BoxedArgs: TGocciaArgumentsCollection;
   BytecodeConstructor: TGocciaBytecodeFunctionValue;
   ConstructorThisValue: TGocciaValue;
+  ReceiverPrototype: TGocciaObjectValue;
   SuperResult: TGocciaValue;
   SuperResultRegister: TGocciaRegister;
   TargetInstance: TGocciaValue;
+  function EffectiveNewTarget: TGocciaValue;
+  begin
+    if Assigned(FPendingNewTarget) then
+      Exit(FPendingNewTarget);
+    if Assigned(FCurrentNewTarget) then
+      Exit(FCurrentNewTarget);
+    Result := AClassValue;
+  end;
   function IsUndefinedConstructedValue(const AValue: TGocciaValue): Boolean;
   begin
     Result := (not Assigned(AValue)) or (AValue is TGocciaUndefinedLiteralValue);
@@ -9812,6 +9850,23 @@ begin
   Result := AInstance;
   if not Assigned(AClassValue) then
     Exit;
+
+  if Assigned(AClassValue.NativeInstanceDefaultPrototype) then
+  begin
+    BoxedArgs := MaterializeArguments(AArguments);
+    try
+      TargetInstance := AClassValue.CreateNativeInstance(BoxedArgs);
+    finally
+      ReleaseArguments(BoxedArgs);
+    end;
+    if not (TargetInstance is TGocciaObjectValue) then
+      ThrowTypeError(
+        'Superclass constructor did not return an object',
+        SSuggestNotConstructorType);
+    ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
+    TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+    Exit(TargetInstance);
+  end;
 
   if (AClassValue is TGocciaVMClassValue) and
      Assigned(TGocciaVMClassValue(AClassValue).FConstructorValue) then
@@ -14328,10 +14383,10 @@ begin
           EvalSourceValue := TGocciaUndefinedLiteralValue.UndefinedValue;
           if (C and CALL_FLAG_SPREAD) <> 0 then
           begin
-            if (FRegisters[B].Kind = grkObject) and
-               (FRegisters[B].ObjectValue is TGocciaArrayValue) and
-               (TGocciaArrayValue(FRegisters[B].ObjectValue).Elements.Count > 0) then
-              EvalSourceValue := TGocciaArrayValue(FRegisters[B].ObjectValue).GetElement(0);
+	            if (FRegisters[B].Kind = grkObject) and
+	               (FRegisters[B].ObjectValue is TGocciaArrayValue) and
+	               (TGocciaArrayValue(FRegisters[B].ObjectValue).Elements.Count > 0) then
+	              EvalSourceValue := TGocciaArrayValue(FRegisters[B].ObjectValue).GetProperty('0');
           end
           else if B > 0 then
             EvalSourceValue := GetRegister(A + 1);
@@ -14378,9 +14433,9 @@ begin
                   TGocciaArrayValue(FRegisters[B].ObjectValue).Elements.Count);
                 for I := 0 to BoundFunction.BoundArgCount - 1 do
                   RegisterArgs[I] := VMValueToRegisterFast(BoundFunction.GetBoundArg(I));
-                for I := 0 to TGocciaArrayValue(FRegisters[B].ObjectValue).Elements.Count - 1 do
-                  RegisterArgs[BoundFunction.BoundArgCount + I] := VMValueToRegisterFast(
-                    TGocciaArrayValue(FRegisters[B].ObjectValue).Elements[I]);
+	                for I := 0 to TGocciaArrayValue(FRegisters[B].ObjectValue).Elements.Count - 1 do
+	                  RegisterArgs[BoundFunction.BoundArgCount + I] := VMValueToRegisterFast(
+	                    TGocciaArrayValue(FRegisters[B].ObjectValue).GetProperty(IntToStr(I)));
                 CallThisRegister := ValueToRegister(BoundFunction.BoundThis);
                 if not BytecodeFunction.FStrictThis then
                   CallThisRegister := CoerceNonStrictThisRegister(
@@ -14427,9 +14482,9 @@ begin
             begin
               SetLength(RegisterArgs,
                 TGocciaArrayValue(FRegisters[B].ObjectValue).Elements.Count);
-              for I := 0 to High(RegisterArgs) do
-                RegisterArgs[I] := ValueToRegister(
-                  TGocciaArrayValue(FRegisters[B].ObjectValue).Elements[I]);
+	              for I := 0 to High(RegisterArgs) do
+	                RegisterArgs[I] := ValueToRegister(
+	                  TGocciaArrayValue(FRegisters[B].ObjectValue).GetProperty(IntToStr(I)));
               PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
               SetupNewFrame(BytecodeFunction.FClosure,
                 CallThisRegister, RegisterArgs, Length(RegisterArgs),
@@ -14447,9 +14502,9 @@ begin
         try
           if (C and 1) = 1 then
           begin
-            if GetRegister(B) is TGocciaArrayValue then
-              for I := 0 to TGocciaArrayValue(GetRegister(B)).Elements.Count - 1 do
-                CallArgs.Add(TGocciaArrayValue(GetRegister(B)).GetElement(I));
+	            if GetRegister(B) is TGocciaArrayValue then
+	              for I := 0 to TGocciaArrayValue(GetRegister(B)).Elements.Count - 1 do
+	                CallArgs.Add(TGocciaArrayValue(GetRegister(B)).GetProperty(IntToStr(I)));
           end
           else
             for I := 0 to B - 1 do
@@ -14573,29 +14628,30 @@ begin
                         True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     1:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        CallThisRegister, TGocciaRegisterArray(nil), 1,
-                        VMValueToRegisterFast(ArgsArray.Elements[0]),
-                        RegisterUndefined, RegisterUndefined,
+	                        CallThisRegister, TGocciaRegisterArray(nil), 1,
+	                        VMValueToRegisterFast(ArgsArray.GetProperty('0')),
+	                        RegisterUndefined, RegisterUndefined,
                         True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     2:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        CallThisRegister, TGocciaRegisterArray(nil), 2,
-                        VMValueToRegisterFast(ArgsArray.Elements[0]),
-                        VMValueToRegisterFast(ArgsArray.Elements[1]),
-                        RegisterUndefined,
+	                        CallThisRegister, TGocciaRegisterArray(nil), 2,
+	                        VMValueToRegisterFast(ArgsArray.GetProperty('0')),
+	                        VMValueToRegisterFast(ArgsArray.GetProperty('1')),
+	                        RegisterUndefined,
                         True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     3:
                       SetupNewFrame(BytecodeFunction.FClosure,
-                        CallThisRegister, TGocciaRegisterArray(nil), 3,
-                        VMValueToRegisterFast(ArgsArray.Elements[0]),
-                        VMValueToRegisterFast(ArgsArray.Elements[1]),
-                        VMValueToRegisterFast(ArgsArray.Elements[2]),
+	                        CallThisRegister, TGocciaRegisterArray(nil), 3,
+	                        VMValueToRegisterFast(ArgsArray.GetProperty('0')),
+	                        VMValueToRegisterFast(ArgsArray.GetProperty('1')),
+	                        VMValueToRegisterFast(ArgsArray.GetProperty('2')),
                         True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                   else
                     begin
-                      SetLength(RegisterArgs, ArgsArray.Elements.Count);
-                      for I := 0 to High(RegisterArgs) do
-                        RegisterArgs[I] := VMValueToRegisterFast(ArgsArray.Elements[I]);
+	                      SetLength(RegisterArgs, ArgsArray.Elements.Count);
+	                      for I := 0 to High(RegisterArgs) do
+	                        RegisterArgs[I] := VMValueToRegisterFast(
+	                          ArgsArray.GetProperty(IntToStr(I)));
                       SetupNewFrame(BytecodeFunction.FClosure,
                         CallThisRegister, RegisterArgs, Length(RegisterArgs),
                         RegisterUndefined, RegisterUndefined, RegisterUndefined,
@@ -14635,9 +14691,9 @@ begin
             begin
               SetLength(RegisterArgs,
                 TGocciaArrayValue(FRegisters[B].ObjectValue).Elements.Count);
-              for I := 0 to High(RegisterArgs) do
-                RegisterArgs[I] := VMValueToRegisterFast(
-                  TGocciaArrayValue(FRegisters[B].ObjectValue).Elements[I]);
+	              for I := 0 to High(RegisterArgs) do
+	                RegisterArgs[I] := VMValueToRegisterFast(
+	                  TGocciaArrayValue(FRegisters[B].ObjectValue).GetProperty(IntToStr(I)));
               PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
               SetupNewFrame(BytecodeFunction.FClosure,
                 FRegisters[A - 1], RegisterArgs, Length(RegisterArgs),
@@ -14702,9 +14758,10 @@ begin
           if (FRegisters[B].Kind = grkObject) and
              (FRegisters[B].ObjectValue is TGocciaVMClassValue) then
           begin
-            SetLength(RegisterArgs, SpreadArray.Elements.Count);
-            for I := 0 to SpreadArray.Elements.Count - 1 do
-              RegisterArgs[I] := VMValueToRegisterFast(SpreadArray.GetElement(I));
+	            SetLength(RegisterArgs, SpreadArray.Elements.Count);
+	            for I := 0 to SpreadArray.Elements.Count - 1 do
+	              RegisterArgs[I] := VMValueToRegisterFast(
+	                SpreadArray.GetProperty(IntToStr(I)));
             FRegisters[A] := TGocciaVMClassValue(FRegisters[B].ObjectValue)
               .InstantiateRegisters(RegisterArgs);
           end
@@ -14712,8 +14769,8 @@ begin
           begin
             CallArgs := AcquireArguments(SpreadArray.Elements.Count);
             try
-              for I := 0 to SpreadArray.Elements.Count - 1 do
-                CallArgs.Add(SpreadArray.GetElement(I));
+	              for I := 0 to SpreadArray.Elements.Count - 1 do
+	                CallArgs.Add(SpreadArray.GetProperty(IntToStr(I)));
               SetRegister(A, ConstructValue(GetRegister(B), CallArgs));
             finally
               ReleaseArguments(CallArgs);
@@ -15470,9 +15527,9 @@ begin
               if (FRegisters[A].Kind = grkObject) and
                  (FRegisters[A].ObjectValue is TGocciaArrayValue) and
                  (DoneValue is TGocciaArrayValue) then
-                for I := 0 to TGocciaArrayValue(DoneValue).Elements.Count - 1 do
-                  TGocciaArrayValue(FRegisters[A].ObjectValue).Elements.Add(
-                    TGocciaArrayValue(DoneValue).GetElement(I));
+	                for I := 0 to TGocciaArrayValue(DoneValue).Elements.Count - 1 do
+	                  TGocciaArrayValue(FRegisters[A].ObjectValue).Elements.Add(
+	                    TGocciaArrayValue(DoneValue).GetProperty(IntToStr(I)));
             end;
 
           COLLECTION_OP_TRY_ITERABLE_TO_ARRAY:

--- a/source/units/Goccia.Values.ArgumentsObjectValue.pas
+++ b/source/units/Goccia.Values.ArgumentsObjectValue.pas
@@ -45,7 +45,12 @@ type
     ParameterCell: TGocciaBytecodeCell;
   end;
 
-  TGocciaMappedArgumentsObjectValue = class(TGocciaObjectValue)
+  TGocciaArgumentsObjectValue = class(TGocciaObjectValue)
+  public
+    function ToStringTag: string; override;
+  end;
+
+  TGocciaMappedArgumentsObjectValue = class(TGocciaArgumentsObjectValue)
   private
     FEnvironment: TGocciaScope;
     FMappings: array of TGocciaArgumentMapping;
@@ -100,6 +105,11 @@ begin
   Goccia.Values.ErrorHelper.ThrowTypeError(
     '''caller'', ''callee'', and ''arguments'' properties may not be accessed');
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaArgumentsObjectValue.ToStringTag: string;
+begin
+  Result := 'Arguments';
 end;
 
 function CreateThrowTypeErrorFunction: TGocciaNativeFunctionValue;
@@ -437,7 +447,7 @@ function CreateUnmappedArgumentsObject(
 var
   Thrower: TGocciaNativeFunctionValue;
 begin
-  Result := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype,
+  Result := TGocciaArgumentsObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype,
     AArguments.Length + 2);
 
   DefineArgumentsLengthAndIterator(Result, AArguments);

--- a/source/units/Goccia.Values.ArrayBufferValue.pas
+++ b/source/units/Goccia.Values.ArrayBufferValue.pas
@@ -21,6 +21,7 @@ type
   private
     FData: TBytes;
     FDetached: Boolean;
+    FImmutable: Boolean;
     FMaxByteLength: Integer;
 
     function GetByteLength: Integer;
@@ -43,6 +44,7 @@ type
 
     property Data: TBytes read FData write FData;
     property Detached: Boolean read FDetached;
+    property Immutable: Boolean read FImmutable;
     property MaxByteLength: Integer read FMaxByteLength;
   published
     property ByteLength: Integer read GetByteLength;
@@ -50,6 +52,7 @@ type
     function ArrayBufferResize(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferTransfer(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferTransferToFixedLength(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayBufferTransferToImmutable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferMaxByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferResizableGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -189,6 +192,7 @@ var
 begin
   inherited Create(nil);
   FDetached := False;
+  FImmutable := False;
   FMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, AByteLength);
   if AByteLength > 0 then
@@ -205,6 +209,7 @@ var
 begin
   inherited Create(nil);
   FDetached := False;
+  FImmutable := False;
   if AMaxByteLength >= 0 then
   begin
     if AByteLength > AMaxByteLength then
@@ -228,6 +233,7 @@ var
 begin
   inherited Create(AClass);
   FDetached := False;
+  FImmutable := False;
   FMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, 0);
   InitializePrototype;
@@ -254,6 +260,7 @@ begin
       Members.AddMethod(ArrayBufferResize, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ArrayBufferTransfer, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ArrayBufferTransferToFixedLength, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(ArrayBufferTransferToImmutable, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddAccessor(PROP_BYTE_LENGTH, ArrayBufferByteLengthGetter, nil, [pfConfigurable]);
       Members.AddAccessor(PROP_MAX_BYTE_LENGTH, ArrayBufferMaxByteLengthGetter, nil, [pfConfigurable]);
       Members.AddAccessor(PROP_RESIZABLE, ArrayBufferResizableGetter, nil, [pfConfigurable]);
@@ -484,7 +491,8 @@ end;
 
 // ES2026 §25.1.2.4 ArrayBufferCopyAndDetach(O, newLength, preserveResizability)
 function ArrayBufferCopyAndDetach(const ABuf: TGocciaArrayBufferValue;
-  const ANewLength: Integer; const APreserveResizability: Boolean): TGocciaArrayBufferValue;
+  const ANewLength: Integer; const APreserveResizability: Boolean;
+  const AMakeImmutable: Boolean = False): TGocciaArrayBufferValue;
 var
   NewMaxByteLength, CopyLength: Integer;
 begin
@@ -510,6 +518,7 @@ begin
   // ES2026 §25.1.2.4 step 12: CopyDataBlockBytes
   if CopyLength > 0 then
     Move(ABuf.FData[0], Result.FData[0], CopyLength);
+  Result.FImmutable := AMakeImmutable;
 
   // ES2026 §25.1.2.4 step 14: DetachArrayBuffer(O)
   ABuf.Detach;
@@ -549,6 +558,22 @@ begin
 
   // ES2026 §25.1.6.7 step 3: ArrayBufferCopyAndDetach(O, newLength, FIXED-LENGTH)
   Result := ArrayBufferCopyAndDetach(Buf, NewByteLength, False);
+end;
+
+// Immutable ArrayBuffers proposal: ArrayBuffer.prototype.transferToImmutable([newLength])
+function TGocciaArrayBufferValue.ArrayBufferTransferToImmutable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
+  NewByteLength: Integer;
+begin
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.transferToImmutable');
+
+  if (AArgs.Length = 0) or (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
+    NewByteLength := Length(Buf.FData)
+  else
+    NewByteLength := ToIndex(AArgs.GetElement(0));
+
+  Result := ArrayBufferCopyAndDetach(Buf, NewByteLength, False, True);
 end;
 
 // ES2026 §25.1.6.8 ArrayBuffer.prototype.slice(start, end)

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -69,6 +69,7 @@ type
     function ArrayMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayFilter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayReduce(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayReduceRight(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayForEach(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArraySome(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayEvery(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -1089,6 +1090,7 @@ begin
       Members.AddMethod(ArrayMap, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ArrayFilter, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ArrayReduce, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(ArrayReduceRight, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ArrayForEach, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ArraySome, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(ArrayEvery, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -1216,8 +1218,8 @@ end;
 
 procedure TGocciaArrayValue.Freeze;
 begin
-  FLengthWritable := False;
   inherited Freeze;
+  FLengthWritable := False;
 end;
 
 function TGocciaArrayValue.ToStringTag: string;
@@ -1271,8 +1273,50 @@ begin
 end;
 
 function TGocciaArrayValue.SetElement(const AIndex: Integer; const AValue: TGocciaValue): Boolean;
+var
+  Accessor: TGocciaPropertyDescriptorAccessor;
+  Args: TGocciaArgumentsCollection;
+  Descriptor: TGocciaPropertyDescriptor;
+  IndexName: string;
 begin
   if AIndex < 0 then
+  begin
+    Result := False;
+    Exit;
+  end;
+
+  IndexName := IntToStr(AIndex);
+  Descriptor := GetOwnPropertyDescriptor(IndexName);
+  if Descriptor is TGocciaPropertyDescriptorAccessor then
+  begin
+    Accessor := TGocciaPropertyDescriptorAccessor(Descriptor);
+    if Assigned(Accessor.Setter) and Accessor.Setter.IsCallable then
+    begin
+      Args := TGocciaArgumentsCollection.Create([AValue]);
+      try
+        InvokeCallable(Accessor.Setter, Args, Self);
+      finally
+        Args.Free;
+      end;
+      Result := True;
+      Exit;
+    end;
+    ThrowTypeError(Format(SErrorSetPropertyOnlyGetter, [IndexName, ToStringTag]),
+      SSuggestPropertyHasOnlyGetter);
+  end;
+
+  Descriptor := inherited GetOwnPropertyDescriptor(IndexName);
+  if Assigned(Descriptor) then
+  begin
+    inherited AssignProperty(IndexName, AValue);
+    if AIndex + 1 > FLength then
+      FLength := AIndex + 1;
+    Result := True;
+    Exit;
+  end;
+
+  if (not Extensible) and
+     not ((AIndex < FElements.Count) and not IsArrayHole(FElements[AIndex])) then
   begin
     Result := False;
     Exit;
@@ -1292,6 +1336,9 @@ end;
 
 procedure TGocciaArrayValue.SetIndexProperty(const AIndex: Integer; const AValue: TGocciaValue);
 var
+  Accessor: TGocciaPropertyDescriptorAccessor;
+  Args: TGocciaArgumentsCollection;
+  Descriptor: TGocciaPropertyDescriptor;
   IndexName: string;
 begin
   if AIndex < 0 then
@@ -1300,16 +1347,32 @@ begin
     Exit;
   end;
 
-  if FProperties.Count > 0 then
+  IndexName := IntToStr(AIndex);
+  Descriptor := GetOwnPropertyDescriptor(IndexName);
+  if Descriptor is TGocciaPropertyDescriptorAccessor then
   begin
-    IndexName := IntToStr(AIndex);
-    if FProperties.ContainsKey(IndexName) then
+    Accessor := TGocciaPropertyDescriptorAccessor(Descriptor);
+    if Assigned(Accessor.Setter) and Accessor.Setter.IsCallable then
     begin
-      inherited AssignProperty(IndexName, AValue);
-      if Int64(AIndex) + 1 > FLength then
-        FLength := Int64(AIndex) + 1;
+      Args := TGocciaArgumentsCollection.Create([AValue]);
+      try
+        InvokeCallable(Accessor.Setter, Args, Self);
+      finally
+        Args.Free;
+      end;
       Exit;
     end;
+    ThrowTypeError(Format(SErrorSetPropertyOnlyGetter, [IndexName, ToStringTag]),
+      SSuggestPropertyHasOnlyGetter);
+  end;
+
+  Descriptor := inherited GetOwnPropertyDescriptor(IndexName);
+  if Assigned(Descriptor) then
+  begin
+    inherited AssignProperty(IndexName, AValue);
+    if Int64(AIndex) + 1 > FLength then
+      FLength := Int64(AIndex) + 1;
+    Exit;
   end;
 
   if FFrozen and (AIndex < FElements.Count) and
@@ -1320,6 +1383,13 @@ begin
   if (AIndex >= FLength) and not FLengthWritable then
     ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [IntToStr(AIndex)]),
       SSuggestCannotDeleteNonConfigurable);
+
+  if (not Extensible) and
+     not (CanStoreDenseElementIndex(AIndex, FElements.Count) and
+          (AIndex < FElements.Count) and
+          not IsArrayHole(FElements[AIndex])) then
+    ThrowTypeError(Format(SErrorCannotAddPropertyNotExtensible,
+      [IntToStr(AIndex)]), SSuggestObjectNotExtensible);
 
   if CanStoreDenseElementIndex(AIndex, FElements.Count) then
   begin
@@ -1347,19 +1417,19 @@ begin
   // type guard here so that generic receivers are accepted per ES spec.
 
   if AArgs.Length < 1 then
-    ThrowError(SErrorArrayMethodExpectsCallback, [AMethodName], SSuggestIteratorCallable);
+    ThrowTypeError(Format(SErrorArrayMethodExpectsCallback, [AMethodName]), SSuggestIteratorCallable);
 
   Result := AArgs.GetElement(0);
 
   if ARequiresCallback then
   begin
     if not Result.IsCallable then
-      ThrowError(SErrorCallbackMustBeFunction, [], SSuggestIteratorCallable);
+      ThrowTypeError(SErrorCallbackMustBeFunction, SSuggestIteratorCallable);
   end
   else
   begin
     if Result is TGocciaUndefinedLiteralValue then
-      ThrowError(SErrorCallbackMustNotBeUndefined, [], SSuggestIteratorCallable);
+      ThrowTypeError(SErrorCallbackMustNotBeUndefined, SSuggestIteratorCallable);
   end;
 end;
 
@@ -1594,6 +1664,104 @@ begin
   Result := Accumulator;
 end;
 
+// ES2026 §23.1.3.25 Array.prototype.reduceRight(callbackfn [, initialValue])
+function TGocciaArrayValue.ArrayReduceRight(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  View: TArrayLikeView;
+  Callback: TGocciaValue;
+  TypedCallback: TGocciaFunctionBase;
+  Accumulator: TGocciaValue;
+  CallArgs: TGocciaReduceCallbackArgs;
+  I, StartIndex: Integer;
+  Sparse: TArray<Int64>;
+  SparseEnd: Integer;
+  J: Integer;
+begin
+  View.Init(AThisValue);
+  Callback := ValidateArrayMethodCall('reduceRight', AArgs, AThisValue, True);
+
+  TypedCallback := nil;
+  if Callback is TGocciaFunctionBase then
+    TypedCallback := TGocciaFunctionBase(Callback);
+
+  if View.NeedsSparsePath then
+  begin
+    Sparse := CollectSparseIndicesInRange(View.Obj, 0, View.Len64);
+    if AArgs.Length >= 2 then
+    begin
+      Accumulator := AArgs.GetElement(1);
+      SparseEnd := High(Sparse);
+    end
+    else
+    begin
+      if Length(Sparse) = 0 then
+        ThrowTypeError(SErrorReduceEmptyArray,
+          SSuggestReduceInitialValue);
+      Accumulator := View.Get64(Sparse[High(Sparse)]);
+      SparseEnd := High(Sparse) - 1;
+    end;
+
+    CallArgs := TGocciaReduceCallbackArgs.Create(View.Obj);
+    try
+      for J := SparseEnd downto 0 do
+      begin
+        CallArgs.Accumulator := Accumulator;
+        CallArgs.Element := View.Get64(Sparse[J]);
+        CallArgs.Index := TGocciaNumberLiteralValue.Create(Int64ToDouble(Sparse[J]));
+        Accumulator := InvokeArrayCallback(Callback, TypedCallback, CallArgs,
+          TGocciaUndefinedLiteralValue.UndefinedValue);
+      end;
+    finally
+      CallArgs.Free;
+    end;
+
+    Result := Accumulator;
+    Exit;
+  end;
+
+  if AArgs.Length >= 2 then
+  begin
+    Accumulator := AArgs.GetElement(1);
+    StartIndex := View.Len - 1;
+  end
+  else
+  begin
+    // ES2026 §23.1.3.25 steps 6-8: scan for last present element
+    StartIndex := -2;
+    for I := View.Len - 1 downto 0 do
+    begin
+      if View.HasIndex(I) then
+      begin
+        Accumulator := View.Get(I);
+        StartIndex := I - 1;
+        Break;
+      end;
+    end;
+    if StartIndex = -2 then
+      ThrowTypeError(SErrorReduceEmptyArray,
+        SSuggestReduceInitialValue);
+  end;
+
+  CallArgs := TGocciaReduceCallbackArgs.Create(View.Obj);
+  try
+    for I := StartIndex downto 0 do
+    begin
+      if not View.HasIndex(I) then
+        Continue;
+
+      CallArgs.Accumulator := Accumulator;
+      CallArgs.Element := View.Get(I);
+      CallArgs.Index := TGocciaNumberLiteralValue.Create(I);
+      Accumulator := InvokeArrayCallback(Callback, TypedCallback, CallArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue);
+    end;
+  finally
+    CallArgs.Free;
+  end;
+
+  Result := Accumulator;
+end;
+
 // ES2026 §23.1.3.12 Array.prototype.forEach(callbackfn [, thisArg])
 function TGocciaArrayValue.ArrayForEach(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
@@ -1688,10 +1856,17 @@ end;
 function TGocciaArrayValue.ArrayToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   EmptyArgs: TGocciaArgumentsCollection;
+  Obj: TGocciaObjectValue;
+  JoinMethod: TGocciaValue;
 begin
+  Obj := ToObject(AThisValue);
   EmptyArgs := TGocciaArgumentsCollection.Create([]);
   try
-    Result := ArrayJoin(EmptyArgs, AThisValue);
+    JoinMethod := Obj.GetPropertyWithContext('join', AThisValue);
+    if Assigned(JoinMethod) and JoinMethod.IsCallable then
+      Result := InvokeCallable(JoinMethod, EmptyArgs, AThisValue)
+    else
+      Result := ArrayJoin(EmptyArgs, AThisValue);
   finally
     EmptyArgs.Free;
   end;
@@ -3243,13 +3418,35 @@ end;
 
 procedure TGocciaArrayValue.SetProperty(const AName: string; const AValue: TGocciaValue);
 var
+  Accessor: TGocciaPropertyDescriptorAccessor;
+  Args: TGocciaArgumentsCollection;
+  Descriptor: TGocciaPropertyDescriptor;
   Index: Int64;
   Desc: TGocciaPropertyDescriptorData;
 begin
   // Check if property name is a numeric index
   if TryParseArrayElementIndex(AName, Index) then
   begin
-    if FProperties.ContainsKey(AName) then
+    Descriptor := GetOwnPropertyDescriptor(AName);
+    if Descriptor is TGocciaPropertyDescriptorAccessor then
+    begin
+      Accessor := TGocciaPropertyDescriptorAccessor(Descriptor);
+      if Assigned(Accessor.Setter) and Accessor.Setter.IsCallable then
+      begin
+        Args := TGocciaArgumentsCollection.Create([AValue]);
+        try
+          InvokeCallable(Accessor.Setter, Args, Self);
+        finally
+          Args.Free;
+        end;
+        Exit;
+      end;
+      ThrowTypeError(Format(SErrorSetPropertyOnlyGetter, [AName, ToStringTag]),
+        SSuggestPropertyHasOnlyGetter);
+    end;
+
+    Descriptor := inherited GetOwnPropertyDescriptor(AName);
+    if Assigned(Descriptor) then
     begin
       inherited AssignProperty(AName, AValue);
       if Index + 1 > FLength then
@@ -3266,6 +3463,13 @@ begin
     if (Index >= FLength) and not FLengthWritable then
       ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [AName]),
         SSuggestCannotDeleteNonConfigurable);
+
+    if (not Extensible) and
+       not (CanStoreDenseElementIndex(Index, FElements.Count) and
+            (Index < FElements.Count) and
+            not IsArrayHole(FElements[Integer(Index)])) then
+      ThrowTypeError(Format(SErrorCannotAddPropertyNotExtensible, [AName]),
+        SSuggestObjectNotExtensible);
 
     if CanStoreDenseElementIndex(Index, FElements.Count) then
     begin
@@ -3404,7 +3608,15 @@ end;
 function TGocciaArrayValue.GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor;
 var
   Index: Int64;
+  Descriptor: TGocciaPropertyDescriptor;
 begin
+  if TryParseArrayElementIndex(AName, Index) then
+  begin
+    Descriptor := inherited GetOwnPropertyDescriptor(AName);
+    if Assigned(Descriptor) then
+      Exit(Descriptor);
+  end;
+
   if TryParseArrayElementIndex(AName, Index) and
      CanStoreDenseElementIndex(Index, FElements.Count) and
      (Index < FElements.Count) and
@@ -3489,6 +3701,10 @@ begin
       Exit;
     end;
 
+    if not Extensible then
+      ThrowTypeError(Format(SErrorCannotAddPropertyNotExtensible, [AName]),
+        SSuggestObjectNotExtensible);
+
     if CanStoreDenseElementIndex(Index, FElements.Count) and
        CanCreateDenseArrayElement(ADescriptor) then
     begin
@@ -3566,6 +3782,12 @@ begin
       if Result and (Index + 1 > FLength) then
         FLength := Index + 1;
       Exit;
+    end;
+
+    if not Extensible then
+    begin
+      ADescriptor.Free;
+      Exit(False);
     end;
 
     if CanStoreDenseElementIndex(Index, FElements.Count) and

--- a/source/units/Goccia.Values.BooleanObjectValue.pas
+++ b/source/units/Goccia.Values.BooleanObjectValue.pas
@@ -20,6 +20,7 @@ type
   public
     constructor Create(const APrimitive: TGocciaBooleanLiteralValue; const AClass: TGocciaClassValue = nil);
     procedure InitializePrototype;
+    function ToStringTag: string; override;
     function GetProperty(const AName: string): TGocciaValue; override;
     function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     procedure MarkReferences; override;
@@ -115,6 +116,11 @@ end;
 function TGocciaBooleanObjectValue.GetProperty(const AName: string): TGocciaValue;
 begin
   Result := GetPropertyWithContext(AName, Self);
+end;
+
+function TGocciaBooleanObjectValue.ToStringTag: string;
+begin
+  Result := 'Boolean';
 end;
 
 function TGocciaBooleanObjectValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -355,6 +355,7 @@ uses
   Goccia.Values.TextDecoderValue,
   Goccia.Values.TextEncoderValue,
   Goccia.Values.ToPrimitive,
+  Goccia.Values.TypedArrayValue,
   Goccia.Values.URLSearchParamsValue,
   Goccia.Values.URLValue,
   Goccia.Values.WeakMapValue,
@@ -370,6 +371,15 @@ begin
     Exit(TGocciaNumberLiteralValue.Create(
       TGocciaBigIntValue(AValue).Value.ToDouble));
   Result := AValue.ToNumberLiteral;
+end;
+
+function GetTypedArrayPrototypeFromConstructor(
+  const ATypedArrayClass: TGocciaTypedArrayClassValue;
+  const ANewTarget: TGocciaValue;
+  const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
+begin
+  Result := ATypedArrayClass.DefaultPrototypeForNewTarget(ANewTarget,
+    ACurrentRealmDefault);
 end;
 
 // SetDefaultPrototype / PatchDefaultPrototype previously cached the
@@ -1300,20 +1310,47 @@ var
   WalkClass: TGocciaClassValue;
   NativeClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
+  NativeSuperConstructor: TGocciaObjectValue;
   NativeIntrinsicPrototype: TGocciaObjectValue;
   ConstructorToCall: TGocciaMethodValue;
   InstancePrototype: TGocciaObjectValue;
   FinalThis: TGocciaValue;
   ConstructResult: TGocciaValue;
+  EffectiveNewTarget: TGocciaValue;
+  DelayNativePrototypeLookup: Boolean;
   function IsUndefinedConstructResult(const AValue: TGocciaValue): Boolean;
   begin
     Result := (not Assigned(AValue)) or
       (AValue is TGocciaUndefinedLiteralValue);
   end;
+  function ConstructNativeSuperInstance(
+    const AConstructor: TGocciaObjectValue): TGocciaObjectValue;
+  var
+    SuperResult: TGocciaValue;
+  begin
+    if AConstructor = TGocciaFunctionBase.GetSharedPrototype then
+      Exit(nil);
+
+    SuperResult := ConstructValue(AConstructor, AArguments,
+      EffectiveNewTarget);
+    if SuperResult is TGocciaObjectValue then
+      Exit(TGocciaObjectValue(SuperResult));
+
+    ThrowTypeError('Superclass constructor did not return an object',
+      SSuggestNotConstructorType);
+    Result := nil;
+  end;
 begin
+  if Assigned(ANewTarget) then
+    EffectiveNewTarget := ANewTarget
+  else
+    EffectiveNewTarget := Self;
+
   NativeClass := nil;
   NativeInstance := nil;
+  NativeSuperConstructor := nil;
   NativeIntrinsicPrototype := nil;
+  DelayNativePrototypeLookup := False;
   WalkClass := Self;
   while Assigned(WalkClass) do
   begin
@@ -1323,15 +1360,32 @@ begin
       NativeClass := WalkClass;
       Break;
     end;
+    if Assigned(WalkClass.NativeSuperConstructor) then
+    begin
+      NativeSuperConstructor := WalkClass.NativeSuperConstructor;
+      Break;
+    end;
     WalkClass := WalkClass.SuperClass;
   end;
 
+  // TypedArray constructors perform observable argument coercion before
+  // AllocateTypedArray reaches GetPrototypeFromConstructor.
+  DelayNativePrototypeLookup := Assigned(NativeClass) and
+    (NativeClass is TGocciaTypedArrayClassValue);
+
   // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
-  if Assigned(ANewTarget) then
+  if Assigned(ANewTarget) and not DelayNativePrototypeLookup then
   begin
     if Assigned(NativeClass) then
-      InstancePrototype := GetProtoFromConstructorWithIntrinsic(ANewTarget,
-        NativeIntrinsicPrototype)
+    begin
+      if NativeClass is TGocciaTypedArrayClassValue then
+        InstancePrototype := GetTypedArrayPrototypeFromConstructor(
+          TGocciaTypedArrayClassValue(NativeClass), ANewTarget,
+          NativeIntrinsicPrototype)
+      else
+        InstancePrototype := GetProtoFromConstructorWithIntrinsic(ANewTarget,
+          NativeIntrinsicPrototype);
+    end
     else
       InstancePrototype := GetProtoFromConstructor(ANewTarget);
   end
@@ -1340,6 +1394,11 @@ begin
 
   if Assigned(NativeClass) then
     NativeInstance := NativeClass.CreateNativeInstance(AArguments);
+
+  if Assigned(ANewTarget) and DelayNativePrototypeLookup then
+    InstancePrototype := GetTypedArrayPrototypeFromConstructor(
+      TGocciaTypedArrayClassValue(NativeClass), ANewTarget,
+      NativeIntrinsicPrototype);
 
   // ES2026 §10.2.2 step 6: Set proto on the instance before constructor runs
   if Assigned(NativeInstance) then
@@ -1396,8 +1455,23 @@ begin
           'Must call super constructor before returning from derived constructor');
     end;
   end
-  else if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then
-    TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+  else
+  begin
+    if (not Assigned(NativeInstance)) and Assigned(NativeSuperConstructor) then
+    begin
+      NativeInstance := ConstructNativeSuperInstance(NativeSuperConstructor);
+      if Assigned(NativeInstance) then
+      begin
+        Instance := NativeInstance;
+        Instance.Prototype := InstancePrototype;
+        if NativeInstance is TGocciaInstanceValue then
+          TGocciaInstanceValue(NativeInstance).ClassValue := Self;
+      end;
+    end;
+
+    if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then
+      TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+  end;
 
   Result := Instance;
 end;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -1318,6 +1318,7 @@ var
   ConstructResult: TGocciaValue;
   EffectiveNewTarget: TGocciaValue;
   DelayNativePrototypeLookup: Boolean;
+  NativeInstanceConstructedByNativeSuper: Boolean;
   function IsUndefinedConstructResult(const AValue: TGocciaValue): Boolean;
   begin
     Result := (not Assigned(AValue)) or
@@ -1351,6 +1352,7 @@ begin
   NativeSuperConstructor := nil;
   NativeIntrinsicPrototype := nil;
   DelayNativePrototypeLookup := False;
+  NativeInstanceConstructedByNativeSuper := False;
   WalkClass := Self;
   while Assigned(WalkClass) do
   begin
@@ -1460,6 +1462,7 @@ begin
     if (not Assigned(NativeInstance)) and Assigned(NativeSuperConstructor) then
     begin
       NativeInstance := ConstructNativeSuperInstance(NativeSuperConstructor);
+      NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance);
       if Assigned(NativeInstance) then
       begin
         Instance := NativeInstance;
@@ -1470,7 +1473,8 @@ begin
     end;
 
     if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then
-      TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+      if not NativeInstanceConstructedByNativeSuper then
+        TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
   end;
 
   Result := Instance;

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -15,6 +15,16 @@ type
   // Forward declarations
   TGocciaBoundFunctionValue = class;
 
+  TGocciaProxyPredicate = function(const AValue: TGocciaValue): Boolean;
+  TGocciaProxyApplyHook = function(const AProxy: TGocciaValue;
+    const AArguments: TGocciaArgumentsCollection;
+    const AThisValue: TGocciaValue): TGocciaValue;
+  TGocciaProxyConstructHook = function(const AProxy: TGocciaValue;
+    const AArguments: TGocciaArgumentsCollection;
+    const ANewTarget: TGocciaValue): TGocciaValue;
+  TGocciaProxyGetPrototypeHook = function(
+    const AProxy: TGocciaObjectValue): TGocciaValue;
+
   TGocciaFunctionSharedPrototype = class(TGocciaObjectValue)
   public
     constructor Create;
@@ -68,6 +78,8 @@ type
     // name/length as own properties per ECMAScript spec
     function HasOwnProperty(const AName: string): Boolean; override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
+    function GetOwnPropertyKeys: TArray<string>; override;
+    function GetAllPropertyNames: TArray<string>; override;
     function DeleteProperty(const AName: string): Boolean; override;
     procedure DefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor); override;
     function TryDefineProperty(const AName: string; const ADescriptor: TGocciaPropertyDescriptor): Boolean; override;
@@ -163,6 +175,11 @@ function ConstructOrdinaryWithReceiver(const ATarget: TGocciaFunctionBase;
 function ConstructValue(const ATarget: TGocciaValue;
   const AArguments: TGocciaArgumentsCollection;
   const ANewTarget: TGocciaValue): TGocciaValue;
+procedure RegisterProxyDispatchHooks(
+  const APredicate: TGocciaProxyPredicate;
+  const AApply: TGocciaProxyApplyHook;
+  const AConstruct: TGocciaProxyConstructHook;
+  const AGetPrototype: TGocciaProxyGetPrototypeHook);
 
 // ES2026 §10.2.9 SetFunctionName property-key formatting shared by
 // interpreter and bytecode named-evaluation paths.
@@ -190,7 +207,6 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
   Goccia.Values.NativeFunction,
-  Goccia.Values.ProxyValue,
   Goccia.Values.SymbolValue;
 
 const
@@ -200,6 +216,27 @@ const
 // (Function.prototype.foo = ...) must not leak across engine recreation.
 var
   GFunctionPrototypeSlot: TGocciaRealmSlotId;
+  GProxyPredicate: TGocciaProxyPredicate;
+  GProxyApplyHook: TGocciaProxyApplyHook;
+  GProxyConstructHook: TGocciaProxyConstructHook;
+  GProxyGetPrototypeHook: TGocciaProxyGetPrototypeHook;
+
+procedure RegisterProxyDispatchHooks(
+  const APredicate: TGocciaProxyPredicate;
+  const AApply: TGocciaProxyApplyHook;
+  const AConstruct: TGocciaProxyConstructHook;
+  const AGetPrototype: TGocciaProxyGetPrototypeHook);
+begin
+  GProxyPredicate := APredicate;
+  GProxyApplyHook := AApply;
+  GProxyConstructHook := AConstruct;
+  GProxyGetPrototypeHook := AGetPrototype;
+end;
+
+function IsRegisteredProxyValue(const AValue: TGocciaValue): Boolean; inline;
+begin
+  Result := Assigned(GProxyPredicate) and GProxyPredicate(AValue);
+end;
 
 function GetSharedFunctionPrototype: TGocciaFunctionSharedPrototype; inline;
 begin
@@ -312,8 +349,8 @@ begin
       EffectiveTarget := BoundFn.OriginalFunction;
     end;
 
-    if EffectiveTarget is TGocciaProxyValue then
-      Result := TGocciaProxyValue(EffectiveTarget).ConstructTrap(WorkingArgs,
+    if IsRegisteredProxyValue(EffectiveTarget) then
+      Result := GProxyConstructHook(EffectiveTarget, WorkingArgs,
         EffectiveNewTarget)
     else if EffectiveTarget is TGocciaClassValue then
       Result := TGocciaClassValue(EffectiveTarget).Instantiate(WorkingArgs,
@@ -341,8 +378,8 @@ end;
 
 function GetPrototypeOfObject(const AObject: TGocciaObjectValue): TGocciaValue;
 begin
-  if AObject is TGocciaProxyValue then
-    Result := TGocciaProxyValue(AObject).GetPrototypeTrap
+  if IsRegisteredProxyValue(AObject) then
+    Result := GProxyGetPrototypeHook(AObject)
   else if Assigned(AObject.Prototype) then
     Result := AObject.Prototype
   else
@@ -608,6 +645,73 @@ begin
     Result := nil;
 end;
 
+function TGocciaFunctionBase.GetAllPropertyNames: TArray<string>;
+var
+  OwnNames: TArray<string>;
+  Count, I: Integer;
+
+  function IsArrayIndexKey(const AName: string): Boolean;
+  var
+    Digit, Index: UInt64;
+    K: Integer;
+  begin
+    Index := 0;
+    Result := False;
+    if AName = '' then
+      Exit;
+    if (Length(AName) > 1) and (AName[1] = '0') then
+      Exit;
+    for K := 1 to Length(AName) do
+    begin
+      if (AName[K] < '0') or (AName[K] > '9') then
+        Exit;
+      Digit := Ord(AName[K]) - Ord('0');
+      if Index > (High(UInt32) - Digit) div 10 then
+        Exit;
+      Index := Index * 10 + Digit;
+    end;
+    Result := Index < High(UInt32);
+  end;
+
+  procedure AppendName(const AName: string);
+  var
+    J: Integer;
+  begin
+    for J := 0 to Count - 1 do
+      if Result[J] = AName then
+        Exit;
+    if Count >= Length(Result) then
+      SetLength(Result, Count + 8);
+    Result[Count] := AName;
+    Inc(Count);
+  end;
+
+begin
+  OwnNames := inherited GetAllPropertyNames;
+  SetLength(Result, Length(OwnNames) + 2);
+  Count := 0;
+
+  for I := 0 to High(OwnNames) do
+    if IsArrayIndexKey(OwnNames[I]) then
+      AppendName(OwnNames[I]);
+
+  if FHasOwnLengthProperty then
+    AppendName(PROP_LENGTH);
+  if FHasOwnNameProperty then
+    AppendName(PROP_NAME);
+
+  for I := 0 to High(OwnNames) do
+    if not IsArrayIndexKey(OwnNames[I]) then
+      AppendName(OwnNames[I]);
+
+  SetLength(Result, Count);
+end;
+
+function TGocciaFunctionBase.GetOwnPropertyKeys: TArray<string>;
+begin
+  Result := GetAllPropertyNames;
+end;
+
 procedure TGocciaFunctionBase.MaterializeIntrinsicProperty(
   const AName: string);
 begin
@@ -870,8 +974,8 @@ begin
     Result := TGocciaFunctionSharedPrototype(ACallee).Call(AArgs, AThisValue)
   else if ACallee is TGocciaClassValue then
     Result := TGocciaClassValue(ACallee).Call(AArgs, AThisValue)
-  else if (ACallee is TGocciaProxyValue) and ACallee.IsCallable then
-    Result := TGocciaProxyValue(ACallee).ApplyTrap(AArgs, AThisValue)
+  else if IsRegisteredProxyValue(ACallee) and ACallee.IsCallable then
+    Result := GProxyApplyHook(ACallee, AArgs, AThisValue)
   else
     raise TGocciaError.Create('not callable', 0, 0, '', nil);
 end;

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -456,6 +456,9 @@ begin
         raise;
       end;
     end;
+    if (not Done) and FContinuation.LastYieldWasIteratorResult and
+       (Value is TGocciaObjectValue) then
+      Exit(Value);
     Result := CreateIteratorResult(Value, Done);
   end;
 end;

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -354,6 +354,9 @@ begin
     FState := gsCompleted;
     raise;
   end;
+  if (not Done) and FContinuation.LastYieldWasIteratorResult and
+     (ResultValue is TGocciaObjectValue) then
+    Exit(TGocciaObjectValue(ResultValue));
   Result := CreateIteratorResult(ResultValue, Done);
 end;
 

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -202,7 +202,6 @@ function TGocciaGenericIteratorValue.ReturnInternal(
   const AValue: TGocciaValue; const AHasValue: Boolean): TGocciaObjectValue;
 var
   ReturnMethod: TGocciaValue;
-  DoneVal: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
   ReturnResult: TGocciaValue;
 begin
@@ -220,7 +219,6 @@ begin
      (ReturnMethod is TGocciaUndefinedLiteralValue) or
      (ReturnMethod is TGocciaNullLiteralValue) then
   begin
-    FDone := True;
     if AHasValue then
       Result := CreateIteratorResult(AValue, True)
     else
@@ -238,9 +236,7 @@ begin
     ReturnResult := TGocciaFunctionBase(ReturnMethod).Call(CallArgs, FSource);
     if not (ReturnResult is TGocciaObjectValue) then
       ThrowTypeError(SErrorIteratorReturnObject, SSuggestIteratorResultObject);
-    DoneVal := TGocciaObjectValue(ReturnResult).GetProperty(PROP_DONE);
-    if Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value then
-      FDone := True;
+    FDone := True;
     Result := TGocciaObjectValue(ReturnResult);
   finally
     CallArgs.Free;
@@ -295,11 +291,9 @@ end;
 
 procedure TGocciaGenericIteratorValue.Close;
 begin
-  try
-    ReturnInternal(nil, False);
-  finally
-    FDone := True;
-  end;
+  if FDone then
+    Exit;
+  ReturnInternal(nil, False);
 end;
 
 procedure TGocciaGenericIteratorValue.MarkReferences;

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -202,6 +202,7 @@ function TGocciaGenericIteratorValue.ReturnInternal(
   const AValue: TGocciaValue; const AHasValue: Boolean): TGocciaObjectValue;
 var
   ReturnMethod: TGocciaValue;
+  DoneValue: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
   ReturnResult: TGocciaValue;
 begin
@@ -236,7 +237,11 @@ begin
     ReturnResult := TGocciaFunctionBase(ReturnMethod).Call(CallArgs, FSource);
     if not (ReturnResult is TGocciaObjectValue) then
       ThrowTypeError(SErrorIteratorReturnObject, SSuggestIteratorResultObject);
-    FDone := True;
+    // ES2026 §15.5.5 YieldExpression : yield * AssignmentExpression:
+    // return() results with done:false are yielded and may resume delegation.
+    DoneValue := TGocciaObjectValue(ReturnResult).GetProperty(PROP_DONE);
+    if Assigned(DoneValue) and DoneValue.ToBooleanLiteral.Value then
+      FDone := True;
     Result := TGocciaObjectValue(ReturnResult);
   finally
     CallArgs.Free;

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -220,6 +220,16 @@ begin
      (ReturnMethod is TGocciaUndefinedLiteralValue) or
      (ReturnMethod is TGocciaNullLiteralValue) then
   begin
+    FDone := True;
+    if FSource is TGocciaIteratorValue then
+    begin
+      if AHasValue then
+        Result := TGocciaIteratorValue(FSource).ReturnValue(AValue)
+      else
+        Result := TGocciaIteratorValue(FSource).ReturnValue(
+          TGocciaUndefinedLiteralValue.UndefinedValue);
+      Exit;
+    end;
     if AHasValue then
       Result := CreateIteratorResult(AValue, True)
     else

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -103,7 +103,12 @@ begin
     ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue
   else
   begin
-    ValueVal := NextResult.GetProperty(PROP_VALUE);
+    try
+      ValueVal := NextResult.GetProperty(PROP_VALUE);
+    except
+      FDone := True;
+      raise;
+    end;
     if not Assigned(ValueVal) then
       ValueVal := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
@@ -149,8 +154,13 @@ begin
   if not (NextResult is TGocciaObjectValue) then
     ThrowTypeError(Format(SErrorIteratorResultNotObject, [NextResult.TypeName]), SSuggestIteratorResultObject);
 
-  DoneVal := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
-  ADone := Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value;
+  try
+    DoneVal := TGocciaObjectValue(NextResult).GetProperty(PROP_DONE);
+    ADone := Assigned(DoneVal) and DoneVal.ToBooleanLiteral.Value;
+  except
+    FDone := True;
+    raise;
+  end;
   if ADone then
     FDone := True;
   Result := TGocciaObjectValue(NextResult);
@@ -182,7 +192,12 @@ begin
   IteratorResult := AdvanceNextResultInternal(nil, False, ADone);
   if ADone then
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
-  Result := IteratorResult.GetProperty(PROP_VALUE);
+  try
+    Result := IteratorResult.GetProperty(PROP_VALUE);
+  except
+    FDone := True;
+    raise;
+  end;
   if not Assigned(Result) then
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
@@ -193,7 +208,12 @@ var
   IteratorResult: TGocciaObjectValue;
 begin
   IteratorResult := AdvanceNextResultInternal(AValue, True, ADone);
-  Result := IteratorResult.GetProperty(PROP_VALUE);
+  try
+    Result := IteratorResult.GetProperty(PROP_VALUE);
+  except
+    FDone := True;
+    raise;
+  end;
   if not Assigned(Result) then
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;

--- a/source/units/Goccia.Values.Iterator.Lazy.pas
+++ b/source/units/Goccia.Values.Iterator.Lazy.pas
@@ -92,10 +92,8 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
-  Goccia.Values.Iterator.Concrete,
   Goccia.Values.Iterator.Generic,
   Goccia.Values.IteratorSupport,
   Goccia.Values.SymbolValue;
@@ -157,6 +155,8 @@ end;
 
 procedure TGocciaLazyMapIteratorValue.Close;
 begin
+  if FDone then
+    Exit;
   inherited;
   if Assigned(FSourceIterator) then
     FSourceIterator.Close;
@@ -242,6 +242,8 @@ end;
 
 procedure TGocciaLazyFilterIteratorValue.Close;
 begin
+  if FDone then
+    Exit;
   inherited;
   if Assigned(FSourceIterator) then
     FSourceIterator.Close;
@@ -311,6 +313,8 @@ end;
 
 procedure TGocciaLazyTakeIteratorValue.Close;
 begin
+  if FDone then
+    Exit;
   inherited;
   if Assigned(FSourceIterator) then
     FSourceIterator.Close;
@@ -384,6 +388,8 @@ end;
 
 procedure TGocciaLazyDropIteratorValue.Close;
 begin
+  if FDone then
+    Exit;
   inherited;
   if Assigned(FSourceIterator) then
     FSourceIterator.Close;
@@ -413,58 +419,54 @@ var
   IteratorMethod, IteratorObj, NextMethod: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
 begin
-  if AValue is TGocciaIteratorValue then
-  begin
-    Result := TGocciaIteratorValue(AValue);
-    Exit;
-  end;
+  // Iterator.prototype.flatMap uses GetIteratorFlattenable(...,
+  // reject-primitives): primitives, including strings, are mapper errors.
+  if not (AValue is TGocciaObjectValue) then
+    ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable,
+      SSuggestIteratorFlatMapCallable);
 
-  if AValue is TGocciaArrayValue then
+  IteratorObj := AValue;
+  IteratorMethod := TGocciaObjectValue(AValue).GetSymbolProperty(
+    TGocciaSymbolValue.WellKnownIterator);
+  if Assigned(IteratorMethod) and
+     not (IteratorMethod is TGocciaUndefinedLiteralValue) and
+     not (IteratorMethod is TGocciaNullLiteralValue) then
   begin
-    Result := TGocciaArrayIteratorValue.Create(AValue, akValues);
-    Exit;
-  end;
+    if not IteratorMethod.IsCallable then
+      ThrowTypeError(Format(SErrorValueNotFunction, ['[Symbol.iterator]']),
+        SSuggestIteratorProtocol);
 
-  if AValue is TGocciaStringLiteralValue then
-  begin
-    Result := TGocciaStringIteratorValue.Create(AValue);
-    Exit;
-  end;
-
-  if AValue is TGocciaObjectValue then
-  begin
-    IteratorMethod := TGocciaObjectValue(AValue).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
-    if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
-    begin
-      TGarbageCollector.Instance.AddTempRoot(AValue);
+    TGarbageCollector.Instance.AddTempRoot(AValue);
+    try
+      CallArgs := TGocciaArgumentsCollection.Create;
       try
-        CallArgs := TGocciaArgumentsCollection.Create;
-        try
-          IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs, AValue);
-        finally
-          CallArgs.Free;
-        end;
+        IteratorObj := TGocciaFunctionBase(IteratorMethod).Call(CallArgs,
+          AValue);
       finally
-        TGarbageCollector.Instance.RemoveTempRoot(AValue);
+        CallArgs.Free;
       end;
-      if IteratorObj is TGocciaIteratorValue then
-      begin
-        Result := TGocciaIteratorValue(IteratorObj);
-        Exit;
-      end;
-      if IteratorObj is TGocciaObjectValue then
-      begin
-        NextMethod := IteratorObj.GetProperty(PROP_NEXT);
-        if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
-        begin
-          // Capture-once per ES2024 §7.4.2 GetIteratorDirect.
-          Result := TGocciaGenericIteratorValue.Create(IteratorObj, NextMethod);
-          Exit;
-        end;
-      end;
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(AValue);
     end;
+
+    if not (IteratorObj is TGocciaObjectValue) then
+      ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
   end;
 
+  if IteratorObj is TGocciaIteratorValue then
+  begin
+    Result := TGocciaIteratorValue(IteratorObj);
+    Exit;
+  end;
+
+  if IteratorObj is TGocciaObjectValue then
+  begin
+    NextMethod := TGocciaObjectValue(IteratorObj).GetProperty(PROP_NEXT);
+    Result := TGocciaGenericIteratorValue.Create(IteratorObj, NextMethod);
+    Exit;
+  end;
+
+  ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
   Result := nil;
 end;
 
@@ -475,7 +477,13 @@ var
 begin
   if Assigned(FInnerIterator) then
   begin
-    InnerResult := FInnerIterator.AdvanceNext;
+    try
+      InnerResult := FInnerIterator.AdvanceNext;
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(FSourceIterator);
+      raise;
+    end;
     if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
     begin
       Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
@@ -505,19 +513,14 @@ begin
     end;
     Inc(FIndex);
 
-    FInnerIterator := ResolveIterator(MappedValue);
-    if not Assigned(FInnerIterator) then
-    begin
-      try
-        ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
-      except
-        AcquireExceptionObject;
-        CloseIteratorPreservingError(FSourceIterator);
-        raise;
-      end;
+    try
+      FInnerIterator := ResolveIterator(MappedValue);
+      InnerResult := FInnerIterator.AdvanceNext;
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(FSourceIterator);
+      raise;
     end;
-
-    InnerResult := FInnerIterator.AdvanceNext;
     if not TGocciaBooleanLiteralValue(InnerResult.GetProperty(PROP_DONE)).Value then
     begin
       Result := CreateIteratorResult(InnerResult.GetProperty(PROP_VALUE), False);
@@ -534,7 +537,13 @@ var
 begin
   if Assigned(FInnerIterator) then
   begin
-    InnerValue := FInnerIterator.DirectNext(InnerDone);
+    try
+      InnerValue := FInnerIterator.DirectNext(InnerDone);
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(FSourceIterator);
+      raise;
+    end;
     if not InnerDone then
     begin
       ADone := False;
@@ -564,19 +573,14 @@ begin
     end;
     Inc(FIndex);
 
-    FInnerIterator := ResolveIterator(MappedValue);
-    if not Assigned(FInnerIterator) then
-    begin
-      try
-        ThrowTypeError(SErrorIteratorFlatMapMustReturnIterable, SSuggestIteratorFlatMapCallable);
-      except
-        AcquireExceptionObject;
-        CloseIteratorPreservingError(FSourceIterator);
-        raise;
-      end;
+    try
+      FInnerIterator := ResolveIterator(MappedValue);
+      InnerValue := FInnerIterator.DirectNext(InnerDone);
+    except
+      AcquireExceptionObject;
+      CloseIteratorPreservingError(FSourceIterator);
+      raise;
     end;
-
-    InnerValue := FInnerIterator.DirectNext(InnerDone);
     if not InnerDone then
     begin
       ADone := False;
@@ -589,6 +593,8 @@ end;
 
 procedure TGocciaLazyFlatMapIteratorValue.Close;
 begin
+  if FDone then
+    Exit;
   inherited;
   if Assigned(FInnerIterator) then
     FInnerIterator.Close;

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -151,12 +151,6 @@ begin
   if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(Format('Iterator.prototype.%s called on non-object', [AMethodName]));
 
-  if AThisValue is TGocciaIteratorValue then
-  begin
-    Result := TGocciaIteratorValue(AThisValue);
-    Exit;
-  end;
-
   // ES2026 §7.4.2 GetIteratorDirect(obj): capture "next" once.  The
   // generic iterator reports a missing/non-callable next on first use.
   NextMethod := TGocciaObjectValue(AThisValue).GetProperty(PROP_NEXT);
@@ -658,6 +652,7 @@ function TGocciaIteratorValue.IteratorDispose(
 var
   CallArgs: TGocciaArgumentsCollection;
   ReturnMethod: TGocciaValue;
+  ReturnResult: TGocciaValue;
 begin
   if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError('Iterator.prototype[Symbol.dispose] called on non-object');
@@ -672,7 +667,9 @@ begin
         SSuggestIteratorProtocol);
     CallArgs := TGocciaArgumentsCollection.Create;
     try
-      InvokeCallable(ReturnMethod, CallArgs, AThisValue);
+      ReturnResult := InvokeCallable(ReturnMethod, CallArgs, AThisValue);
+      if not (ReturnResult is TGocciaObjectValue) then
+        ThrowTypeError(SErrorIteratorReturnObject, SSuggestIteratorResultObject);
     finally
       CallArgs.Free;
     end;
@@ -705,9 +702,14 @@ begin
     SErrorIteratorMapCallable, SSuggestIteratorCallable);
   Iterator := IteratorThisToDirectIterator(AThisValue, 'map');
 
-  Result := TGocciaLazyMapIteratorValue.Create(
-    Iterator, Callback
-  );
+  TGarbageCollector.Instance.AddTempRoot(Iterator);
+  try
+    Result := TGocciaLazyMapIteratorValue.Create(
+      Iterator, Callback
+    );
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+  end;
 end;
 
 function TGocciaIteratorValue.IteratorFilter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -721,9 +723,14 @@ begin
     SErrorIteratorFilterCallable, SSuggestIteratorCallable);
   Iterator := IteratorThisToDirectIterator(AThisValue, 'filter');
 
-  Result := TGocciaLazyFilterIteratorValue.Create(
-    Iterator, Callback
-  );
+  TGarbageCollector.Instance.AddTempRoot(Iterator);
+  try
+    Result := TGocciaLazyFilterIteratorValue.Create(
+      Iterator, Callback
+    );
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+  end;
 end;
 
 function TGocciaIteratorValue.IteratorTake(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -740,9 +747,14 @@ begin
     SErrorIteratorTakeRequiresArg, SErrorIteratorTakeNonNegative);
   Iterator := IteratorThisToDirectIterator(AThisValue, 'take');
 
-  Result := TGocciaLazyTakeIteratorValue.Create(
-    Iterator, Limit
-  );
+  TGarbageCollector.Instance.AddTempRoot(Iterator);
+  try
+    Result := TGocciaLazyTakeIteratorValue.Create(
+      Iterator, Limit
+    );
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+  end;
 end;
 
 function TGocciaIteratorValue.IteratorDrop(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -759,9 +771,14 @@ begin
     SErrorIteratorDropRequiresArg, SErrorIteratorDropNonNegative);
   Iterator := IteratorThisToDirectIterator(AThisValue, 'drop');
 
-  Result := TGocciaLazyDropIteratorValue.Create(
-    Iterator, DropCount
-  );
+  TGarbageCollector.Instance.AddTempRoot(Iterator);
+  try
+    Result := TGocciaLazyDropIteratorValue.Create(
+      Iterator, DropCount
+    );
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+  end;
 end;
 
 function TGocciaIteratorValue.IteratorFlatMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -775,9 +792,14 @@ begin
     SErrorIteratorFlatMapCallable, SSuggestIteratorFlatMapCallable);
   Iterator := IteratorThisToDirectIterator(AThisValue, 'flatMap');
 
-  Result := TGocciaLazyFlatMapIteratorValue.Create(
-    Iterator, Callback
-  );
+  TGarbageCollector.Instance.AddTempRoot(Iterator);
+  try
+    Result := TGocciaLazyFlatMapIteratorValue.Create(
+      Iterator, Callback
+    );
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+  end;
 end;
 
 { Consuming helper methods — eagerly drain the iterator }
@@ -899,11 +921,16 @@ begin
   TGarbageCollector.Instance.AddTempRoot(Iterator);
   TGarbageCollector.Instance.AddTempRoot(ResultArray);
   try
-    Value := Iterator.DirectNext(Done);
-    while not Done do
-    begin
-      ResultArray.Elements.Add(Value);
+    try
       Value := Iterator.DirectNext(Done);
+      while not Done do
+      begin
+        ResultArray.Elements.Add(Value);
+        Value := Iterator.DirectNext(Done);
+      end;
+    except
+      CloseIteratorPreservingError(Iterator);
+      raise;
     end;
 
     Result := ResultArray;

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -75,6 +75,7 @@ type
     constructor Create;
     function AdvanceNext: TGocciaObjectValue; override;
     function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    function ReturnValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
     procedure Close; override;
   end;
 
@@ -1521,6 +1522,22 @@ begin
   finally
     FExecuting := False;
   end;
+end;
+
+function TGocciaIteratorHelperValue.ReturnValue(
+  const AValue: TGocciaValue): TGocciaObjectValue;
+begin
+  if FExecuting then
+    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
+  if FDone then
+    Exit(CreateIteratorResult(AValue, True));
+  FExecuting := True;
+  try
+    Close;
+  finally
+    FExecuting := False;
+  end;
+  Result := CreateIteratorResult(AValue, True);
 end;
 
 procedure TGocciaIteratorHelperValue.Close;

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -20,6 +20,8 @@ type
   public
     function IteratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorSelf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorDispose(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorHelperReturn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     function IteratorMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorFilter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -36,6 +38,12 @@ type
     function IteratorConcat(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorZip(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorZipKeyed(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorConstructorCall(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorConstruct(const AArgs: TGocciaArgumentsCollection; const ANewTarget: TGocciaValue): TGocciaValue;
+    function IteratorGetConstructor(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorSetConstructor(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorGetToStringTag(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorSetToStringTag(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     class procedure EnsurePrototypeInitialized;
     class function SharedPrototype: TGocciaObjectValue; static;
@@ -64,8 +72,10 @@ type
     function DoAdvanceNext: TGocciaObjectValue; virtual; abstract;
     function DoDirectNext(out ADone: Boolean): TGocciaValue; virtual; abstract;
   public
+    constructor Create;
     function AdvanceNext: TGocciaObjectValue; override;
     function DirectNext(out ADone: Boolean): TGocciaValue; override;
+    procedure Close; override;
   end;
 
 function CreateIteratorResult(const AValue: TGocciaValue; const ADone: Boolean): TGocciaObjectValue;
@@ -100,10 +110,13 @@ uses
 // (immutable across realms) — same pattern as Number.prototype.
 var
   GIteratorPrototypeSlot: TGocciaRealmSlotId;
+  GIteratorHelperPrototypeSlot: TGocciaRealmSlotId;
+  GIteratorConstructorSlot: TGocciaRealmSlotId;
 
 threadvar
   FPrototypeMethodHost: TGocciaIteratorValue;
   FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+  FHelperPrototypeMembers: TArray<TGocciaMemberDefinition>;
   FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 function GetSharedIteratorPrototype: TGocciaObjectValue; inline;
@@ -112,6 +125,155 @@ begin
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GIteratorPrototypeSlot))
   else
     Result := nil;
+end;
+
+function GetSharedIteratorConstructor: TGocciaObjectValue; inline;
+begin
+  if Assigned(CurrentRealm) then
+    Result := TGocciaObjectValue(CurrentRealm.GetSlot(GIteratorConstructorSlot))
+  else
+    Result := nil;
+end;
+
+function GetSharedIteratorHelperPrototype: TGocciaObjectValue; inline;
+begin
+  if Assigned(CurrentRealm) then
+    Result := TGocciaObjectValue(CurrentRealm.GetSlot(GIteratorHelperPrototypeSlot))
+  else
+    Result := nil;
+end;
+
+function IteratorThisToDirectIterator(
+  const AThisValue: TGocciaValue; const AMethodName: string): TGocciaIteratorValue;
+var
+  NextMethod: TGocciaValue;
+begin
+  if not (AThisValue is TGocciaObjectValue) then
+    ThrowTypeError(Format('Iterator.prototype.%s called on non-object', [AMethodName]));
+
+  if AThisValue is TGocciaIteratorValue then
+  begin
+    Result := TGocciaIteratorValue(AThisValue);
+    Exit;
+  end;
+
+  // ES2026 §7.4.2 GetIteratorDirect(obj): capture "next" once.  The
+  // generic iterator reports a missing/non-callable next on first use.
+  NextMethod := TGocciaObjectValue(AThisValue).GetProperty(PROP_NEXT);
+  Result := TGocciaGenericIteratorValue.Create(AThisValue, NextMethod);
+end;
+
+function IteratorThisHasCallableReturn(const AThisValue: TGocciaValue): Boolean;
+var
+  ReturnMethod: TGocciaValue;
+begin
+  Result := False;
+  if not (AThisValue is TGocciaObjectValue) then
+    Exit;
+  ReturnMethod := TGocciaObjectValue(AThisValue).GetProperty(PROP_RETURN);
+  Result := Assigned(ReturnMethod) and
+    not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+    not (ReturnMethod is TGocciaNullLiteralValue) and
+    ReturnMethod.IsCallable;
+end;
+
+procedure CloseIteratorThisPreservingError(const AThisValue: TGocciaValue);
+var
+  Iterator: TGocciaIteratorValue;
+begin
+  if AThisValue is TGocciaIteratorValue then
+  begin
+    CloseIteratorPreservingError(TGocciaIteratorValue(AThisValue));
+    Exit;
+  end;
+
+  if not IteratorThisHasCallableReturn(AThisValue) then
+    Exit;
+
+  Iterator := TGocciaGenericIteratorValue.Create(AThisValue,
+    TGocciaUndefinedLiteralValue.UndefinedValue);
+  if Assigned(TGarbageCollector.Instance) then
+    TGarbageCollector.Instance.AddTempRoot(Iterator);
+  try
+    CloseIteratorPreservingError(Iterator);
+  finally
+    if Assigned(TGarbageCollector.Instance) then
+      TGarbageCollector.Instance.RemoveTempRoot(Iterator);
+  end;
+end;
+
+function IteratorCallbackArgOrClose(
+  const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue;
+  const AErrorMessage, ASuggestion: string): TGocciaValue;
+begin
+  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
+  begin
+    CloseIteratorThisPreservingError(AThisValue);
+    ThrowTypeError(AErrorMessage, ASuggestion);
+  end;
+  Result := AArgs.GetElement(0);
+end;
+
+function IteratorLimitArgOrClose(
+  const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue;
+  const AMissingMessage, ANegativeMessage: string): Integer;
+var
+  NumArg: TGocciaNumberLiteralValue;
+begin
+  if AArgs.Length < 1 then
+  begin
+    CloseIteratorThisPreservingError(AThisValue);
+    ThrowRangeError(AMissingMessage, SSuggestIteratorNonNegative);
+  end;
+
+  try
+    NumArg := AArgs.GetElement(0).ToNumberLiteral;
+  except
+    CloseIteratorThisPreservingError(AThisValue);
+    raise;
+  end;
+  if NumArg.IsNaN then
+  begin
+    CloseIteratorThisPreservingError(AThisValue);
+    ThrowRangeError(ANegativeMessage, SSuggestIteratorNonNegative);
+  end;
+
+  Result := ToIntegerValue(NumArg);
+  if Result < 0 then
+  begin
+    CloseIteratorThisPreservingError(AThisValue);
+    ThrowRangeError(ANegativeMessage, SSuggestIteratorNonNegative);
+  end;
+end;
+
+procedure SetterThatIgnoresPrototypeStringProperty(
+  const AThisValue: TGocciaValue; const AHome: TGocciaObjectValue;
+  const APropertyKey: string; const AValue: TGocciaValue);
+begin
+  // ES2026 §7.3.37 SetterThatIgnoresPrototypeProperties(thisValue, home, propertyKey, value)
+  if not (AThisValue is TGocciaObjectValue) then
+    ThrowTypeError('Iterator accessor setter requires an object receiver');
+  if AThisValue = AHome then
+    ThrowTypeError('Cannot assign Iterator intrinsic accessor on its home object');
+  if not Assigned(TGocciaObjectValue(AThisValue).GetOwnPropertyDescriptor(APropertyKey)) then
+    TGocciaObjectValue(AThisValue).CreateDataPropertyOrThrow(APropertyKey, AValue)
+  else
+    TGocciaObjectValue(AThisValue).AssignProperty(APropertyKey, AValue);
+end;
+
+procedure SetterThatIgnoresPrototypeSymbolProperty(
+  const AThisValue: TGocciaValue; const AHome: TGocciaObjectValue;
+  const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue);
+begin
+  // ES2026 §7.3.37 SetterThatIgnoresPrototypeProperties(thisValue, home, propertyKey, value)
+  if not (AThisValue is TGocciaObjectValue) then
+    ThrowTypeError('Iterator accessor setter requires an object receiver');
+  if AThisValue = AHome then
+    ThrowTypeError('Cannot assign Iterator intrinsic accessor on its home object');
+  if not Assigned(TGocciaObjectValue(AThisValue).GetOwnSymbolPropertyDescriptor(ASymbol)) then
+    TGocciaObjectValue(AThisValue).CreateDataPropertyOrThrow(ASymbol, AValue)
+  else
+    TGocciaObjectValue(AThisValue).AssignSymbolProperty(ASymbol, AValue);
 end;
 
 procedure CloseIteratorPreservingError(const AIterator: TGocciaIteratorValue);
@@ -123,6 +285,40 @@ begin
   except
     // Preserve the original abrupt-completion error when cleanup also throws.
   end;
+end;
+
+procedure EnsureIteratorHelperPrototypeInitialized;
+var
+  Members: TGocciaMemberCollection;
+  HelperPrototype: TGocciaObjectValue;
+begin
+  if not Assigned(CurrentRealm) then
+    Exit;
+  if Assigned(GetSharedIteratorHelperPrototype) then
+    Exit;
+
+  TGocciaIteratorValue.EnsurePrototypeInitialized;
+  HelperPrototype := TGocciaObjectValue.Create(GetSharedIteratorPrototype);
+  CurrentRealm.SetSlot(GIteratorHelperPrototypeSlot, HelperPrototype);
+
+  if Length(FHelperPrototypeMembers) = 0 then
+  begin
+    Members := TGocciaMemberCollection.Create;
+    try
+      Members.AddNamedMethod('next', FPrototypeMethodHost.IteratorNext, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddNamedMethod(PROP_RETURN, FPrototypeMethodHost.IteratorHelperReturn, 0,
+        gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Iterator Helper'), [pfConfigurable]);
+      FHelperPrototypeMembers := Members.ToDefinitions;
+    finally
+      Members.Free;
+    end;
+  end;
+
+  RegisterMemberDefinitions(HelperPrototype, FHelperPrototypeMembers);
 end;
 
 function CreateIteratorResult(const AValue: TGocciaValue; const ADone: Boolean): TGocciaObjectValue;
@@ -221,7 +417,6 @@ end;
 
 procedure TGocciaIteratorValue.Close;
 begin
-  FDone := True;
 end;
 
 function TGocciaIteratorValue.ToStringTag: string;
@@ -293,9 +488,19 @@ begin
     Members := TGocciaMemberCollection.Create;
     try
       Members.AddNamedMethod('next', IteratorNext, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddAccessor(PROP_CONSTRUCTOR, IteratorGetConstructor,
+        IteratorSetConstructor, [pfConfigurable], gmkPrototypeGetter);
       Members.AddSymbolMethod(
         TGocciaSymbolValue.WellKnownIterator, '[Symbol.iterator]',
         IteratorSelf, 0, [pfConfigurable, pfWritable]);
+      Members.AddSymbolMethod(
+        TGocciaSymbolValue.WellKnownDispose, '[Symbol.dispose]',
+        IteratorDispose, 0, [pfConfigurable, pfWritable],
+        [gmfNoFunctionPrototype]);
+      Members.AddSymbolAccessor(
+        TGocciaSymbolValue.WellKnownToStringTag, '[Symbol.toStringTag]',
+        IteratorGetToStringTag, IteratorSetToStringTag,
+        [pfConfigurable]);
       Members.AddNamedMethod('map', IteratorMap, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddNamedMethod('filter', IteratorFilter, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddNamedMethod('take', IteratorTake, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -318,11 +523,21 @@ end;
 class function TGocciaIteratorValue.CreateGlobalObject: TGocciaObjectValue;
 var
   Members: TGocciaMemberCollection;
+  IteratorConstructor: TGocciaNativeFunctionValue;
   SharedPrototype: TGocciaObjectValue;
 begin
   EnsurePrototypeInitialized;
 
-  Result := TGocciaObjectValue.Create;
+  if Assigned(GetSharedIteratorConstructor) then
+    Exit(GetSharedIteratorConstructor);
+
+  IteratorConstructor := TGocciaNativeFunctionValue.Create(
+    FPrototypeMethodHost.IteratorConstructorCall, CONSTRUCTOR_ITERATOR, 0);
+  IteratorConstructor.ConstructCallback := FPrototypeMethodHost.IteratorConstruct;
+  if Assigned(CurrentRealm) then
+    CurrentRealm.SetSlot(GIteratorConstructorSlot, IteratorConstructor);
+
+  Result := IteratorConstructor;
   if Length(FStaticMembers) = 0 then
   begin
     Members := TGocciaMemberCollection.Create;
@@ -339,7 +554,87 @@ begin
   RegisterMemberDefinitions(Result, FStaticMembers);
   SharedPrototype := GetSharedIteratorPrototype;
   if Assigned(SharedPrototype) then
-    Result.AssignProperty(PROP_PROTOTYPE, SharedPrototype);
+    Result.DefineProperty(PROP_PROTOTYPE,
+      TGocciaPropertyDescriptorData.Create(SharedPrototype, []));
+end;
+
+// ES2026 §27.1.3.1.1 Iterator()
+function TGocciaIteratorValue.IteratorConstructorCall(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  ThrowTypeError(SErrorIllegalConstructor);
+  Result := nil;
+end;
+
+// ES2026 §27.1.3.1.1 Iterator()
+function TGocciaIteratorValue.IteratorConstruct(
+  const AArgs: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
+var
+  IteratorConstructor: TGocciaObjectValue;
+  SharedPrototype: TGocciaObjectValue;
+begin
+  IteratorConstructor := GetSharedIteratorConstructor;
+  if (not Assigned(ANewTarget)) or (ANewTarget = IteratorConstructor) then
+    ThrowTypeError(SErrorIllegalConstructor);
+
+  SharedPrototype := GetSharedIteratorPrototype;
+  Result := TGocciaObjectValue.Create(
+    GetProtoFromConstructorWithIntrinsic(ANewTarget, SharedPrototype));
+end;
+
+// ES2026 §27.1.3.3.1.1 get Iterator.prototype.constructor
+function TGocciaIteratorValue.IteratorGetConstructor(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := GetSharedIteratorConstructor;
+  if not Assigned(Result) then
+    Result := TGocciaIteratorValue.CreateGlobalObject;
+end;
+
+// ES2026 §27.1.3.3.1.2 set Iterator.prototype.constructor
+function TGocciaIteratorValue.IteratorSetConstructor(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Value: TGocciaValue;
+begin
+  if AArgs.Length > 0 then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  SetterThatIgnoresPrototypeStringProperty(AThisValue,
+    GetSharedIteratorPrototype, PROP_CONSTRUCTOR, Value);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+// ES2026 §27.1.3.3.14.1 get Iterator.prototype [ %Symbol.toStringTag% ]
+function TGocciaIteratorValue.IteratorGetToStringTag(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaStringLiteralValue.Create(CONSTRUCTOR_ITERATOR);
+end;
+
+// ES2026 §27.1.3.3.14.2 set Iterator.prototype [ %Symbol.toStringTag% ]
+function TGocciaIteratorValue.IteratorSetToStringTag(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Value: TGocciaValue;
+begin
+  if AArgs.Length > 0 then
+    Value := AArgs.GetElement(0)
+  else
+    Value := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  SetterThatIgnoresPrototypeSymbolProperty(AThisValue,
+    GetSharedIteratorPrototype, TGocciaSymbolValue.WellKnownToStringTag,
+    Value);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 { Protocol methods }
@@ -356,96 +651,132 @@ begin
   Result := AThisValue;
 end;
 
+// ES2026 §27.1.3.3.2 Iterator.prototype [ %Symbol.dispose% ] ()
+function TGocciaIteratorValue.IteratorDispose(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  ReturnMethod: TGocciaValue;
+begin
+  if not (AThisValue is TGocciaObjectValue) then
+    ThrowTypeError('Iterator.prototype[Symbol.dispose] called on non-object');
+
+  ReturnMethod := TGocciaObjectValue(AThisValue).GetProperty(PROP_RETURN);
+  if Assigned(ReturnMethod) and
+     not (ReturnMethod is TGocciaUndefinedLiteralValue) and
+     not (ReturnMethod is TGocciaNullLiteralValue) then
+  begin
+    if not ReturnMethod.IsCallable then
+      ThrowTypeError(SErrorIteratorReturnMustBeCallable,
+        SSuggestIteratorProtocol);
+    CallArgs := TGocciaArgumentsCollection.Create;
+    try
+      InvokeCallable(ReturnMethod, CallArgs, AThisValue);
+    finally
+      CallArgs.Free;
+    end;
+  end;
+
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+// ES2026 §27.1.5.2.2 %IteratorHelperPrototype%.return()
+function TGocciaIteratorValue.IteratorHelperReturn(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaIteratorHelperValue) then
+    ThrowTypeError('Iterator helper return called on non-helper');
+  Result := TGocciaIteratorHelperValue(AThisValue).ReturnValue(
+    TGocciaUndefinedLiteralValue.UndefinedValue);
+end;
+
 { Lazy helper methods — return new lazy iterators }
 
 function TGocciaIteratorValue.IteratorMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Callback: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorMapNonIterator, SSuggestIteratorThisType);
-  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError(SErrorIteratorMapCallable,
-      SSuggestIteratorCallable);
+  Callback := IteratorCallbackArgOrClose(AArgs, AThisValue,
+    SErrorIteratorMapCallable, SSuggestIteratorCallable);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'map');
 
   Result := TGocciaLazyMapIteratorValue.Create(
-    TGocciaIteratorValue(AThisValue), AArgs.GetElement(0)
+    Iterator, Callback
   );
 end;
 
 function TGocciaIteratorValue.IteratorFilter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Callback: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorFilterNonIterator, SSuggestIteratorThisType);
-  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError(SErrorIteratorFilterCallable,
-      SSuggestIteratorCallable);
+  Callback := IteratorCallbackArgOrClose(AArgs, AThisValue,
+    SErrorIteratorFilterCallable, SSuggestIteratorCallable);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'filter');
 
   Result := TGocciaLazyFilterIteratorValue.Create(
-    TGocciaIteratorValue(AThisValue), AArgs.GetElement(0)
+    Iterator, Callback
   );
 end;
 
 function TGocciaIteratorValue.IteratorTake(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  NumArg: TGocciaNumberLiteralValue;
+  Iterator: TGocciaIteratorValue;
   Limit: Integer;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorTakeNonIterator, SSuggestIteratorThisType);
-  if AArgs.Length < 1 then
-    ThrowRangeError(SErrorIteratorTakeRequiresArg, SSuggestIteratorNonNegative);
 
-  // ES2026 §27.1.4.2 steps 4-7: NaN and negative (incl. -∞) limits throw
+  // ES2026 §27.1.3.3.11 steps 4-7: NaN and negative (incl. -∞) limits throw
   // RangeError; +∞ takes everything (saturated to MaxInt here).
-  NumArg := AArgs.GetElement(0).ToNumberLiteral;
-  if NumArg.IsNaN then
-    ThrowRangeError(SErrorIteratorTakeNonNegative,
-      SSuggestIteratorNonNegative);
-  Limit := ToIntegerValue(NumArg);
-  if Limit < 0 then
-    ThrowRangeError(SErrorIteratorTakeNonNegative,
-      SSuggestIteratorNonNegative);
+  Limit := IteratorLimitArgOrClose(AArgs, AThisValue,
+    SErrorIteratorTakeRequiresArg, SErrorIteratorTakeNonNegative);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'take');
 
   Result := TGocciaLazyTakeIteratorValue.Create(
-    TGocciaIteratorValue(AThisValue), Limit
+    Iterator, Limit
   );
 end;
 
 function TGocciaIteratorValue.IteratorDrop(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  NumArg: TGocciaNumberLiteralValue;
+  Iterator: TGocciaIteratorValue;
   DropCount: Integer;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorDropNonIterator, SSuggestIteratorThisType);
-  if AArgs.Length < 1 then
-    ThrowRangeError(SErrorIteratorDropRequiresArg, SSuggestIteratorNonNegative);
 
-  // ES2026 §27.1.4.1 steps 4-7: NaN and negative (incl. -∞) counts throw
+  // ES2026 §27.1.3.3.3 steps 4-7: NaN and negative (incl. -∞) counts throw
   // RangeError; +∞ drops everything (saturated to MaxInt here).
-  NumArg := AArgs.GetElement(0).ToNumberLiteral;
-  if NumArg.IsNaN then
-    ThrowRangeError(SErrorIteratorDropNonNegative,
-      SSuggestIteratorNonNegative);
-  DropCount := ToIntegerValue(NumArg);
-  if DropCount < 0 then
-    ThrowRangeError(SErrorIteratorDropNonNegative,
-      SSuggestIteratorNonNegative);
+  DropCount := IteratorLimitArgOrClose(AArgs, AThisValue,
+    SErrorIteratorDropRequiresArg, SErrorIteratorDropNonNegative);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'drop');
 
   Result := TGocciaLazyDropIteratorValue.Create(
-    TGocciaIteratorValue(AThisValue), DropCount
+    Iterator, DropCount
   );
 end;
 
 function TGocciaIteratorValue.IteratorFlatMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Callback: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorFlatMapNonIterator, SSuggestIteratorThisType);
-  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError(SErrorIteratorFlatMapCallable,
-      SSuggestIteratorFlatMapCallable);
+  Callback := IteratorCallbackArgOrClose(AArgs, AThisValue,
+    SErrorIteratorFlatMapCallable, SSuggestIteratorFlatMapCallable);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'flatMap');
 
   Result := TGocciaLazyFlatMapIteratorValue.Create(
-    TGocciaIteratorValue(AThisValue), AArgs.GetElement(0)
+    Iterator, Callback
   );
 end;
 
@@ -458,14 +789,12 @@ var
   Done: Boolean;
   Index: Integer;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorForEachNonIterator, SSuggestIteratorThisType);
-  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError(SErrorIteratorForEachCallable,
-      SSuggestIteratorCallable);
+  Callback := IteratorCallbackArgOrClose(AArgs, AThisValue,
+    SErrorIteratorForEachCallable, SSuggestIteratorCallable);
 
-  Iterator := TGocciaIteratorValue(AThisValue);
-  Callback := AArgs.GetElement(0);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'forEach');
   Index := 0;
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
@@ -479,7 +808,7 @@ begin
         Value := Iterator.DirectNext(Done);
       end;
     except
-      Iterator.Close;
+      CloseIteratorPreservingError(Iterator);
       raise;
     end;
   finally
@@ -498,14 +827,12 @@ var
   CallArgs: TGocciaArgumentsCollection;
   Index: Integer;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorReduceNonIterator, SSuggestIteratorThisType);
-  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError(SErrorIteratorReduceCallable,
-      SSuggestIteratorCallable);
+  Callback := IteratorCallbackArgOrClose(AArgs, AThisValue,
+    SErrorIteratorReduceCallable, SSuggestIteratorCallable);
 
-  Iterator := TGocciaIteratorValue(AThisValue);
-  Callback := AArgs.GetElement(0);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'reduce');
   HasInitial := AArgs.Length >= 2;
   Index := 0;
   Done := False;
@@ -548,7 +875,7 @@ begin
         TGarbageCollector.Instance.RemoveTempRoot(Accumulator);
       end;
     except
-      Iterator.Close;
+      CloseIteratorPreservingError(Iterator);
       raise;
     end;
   finally
@@ -563,10 +890,10 @@ var
   Value: TGocciaValue;
   Done: Boolean;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorToArrayNonIterator, SSuggestIteratorThisType);
 
-  Iterator := TGocciaIteratorValue(AThisValue);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'toArray');
   ResultArray := TGocciaArrayValue.Create;
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
@@ -593,14 +920,12 @@ var
   Done: Boolean;
   Index: Integer;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorSomeNonIterator, SSuggestIteratorThisType);
-  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError(SErrorIteratorSomeCallable,
-      SSuggestIteratorCallable);
+  Callback := IteratorCallbackArgOrClose(AArgs, AThisValue,
+    SErrorIteratorSomeCallable, SSuggestIteratorCallable);
 
-  Iterator := TGocciaIteratorValue(AThisValue);
-  Callback := AArgs.GetElement(0);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'some');
   Index := 0;
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
@@ -621,7 +946,7 @@ begin
 
       Result := TGocciaBooleanLiteralValue.FalseValue;
     except
-      Iterator.Close;
+      CloseIteratorPreservingError(Iterator);
       raise;
     end;
   finally
@@ -636,14 +961,12 @@ var
   Done: Boolean;
   Index: Integer;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorEveryNonIterator, SSuggestIteratorThisType);
-  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError(SErrorIteratorEveryCallable,
-      SSuggestIteratorCallable);
+  Callback := IteratorCallbackArgOrClose(AArgs, AThisValue,
+    SErrorIteratorEveryCallable, SSuggestIteratorCallable);
 
-  Iterator := TGocciaIteratorValue(AThisValue);
-  Callback := AArgs.GetElement(0);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'every');
   Index := 0;
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
@@ -664,7 +987,7 @@ begin
 
       Result := TGocciaBooleanLiteralValue.TrueValue;
     except
-      Iterator.Close;
+      CloseIteratorPreservingError(Iterator);
       raise;
     end;
   finally
@@ -679,14 +1002,12 @@ var
   Done: Boolean;
   Index: Integer;
 begin
-  if not (AThisValue is TGocciaIteratorValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorIteratorFindNonIterator, SSuggestIteratorThisType);
-  if (AArgs.Length < 1) or not AArgs.GetElement(0).IsCallable then
-    ThrowTypeError(SErrorIteratorFindCallable,
-      SSuggestIteratorCallable);
+  Callback := IteratorCallbackArgOrClose(AArgs, AThisValue,
+    SErrorIteratorFindCallable, SSuggestIteratorCallable);
 
-  Iterator := TGocciaIteratorValue(AThisValue);
-  Callback := AArgs.GetElement(0);
+  Iterator := IteratorThisToDirectIterator(AThisValue, 'find');
   Index := 0;
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
@@ -707,7 +1028,7 @@ begin
 
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     except
-      Iterator.Close;
+      CloseIteratorPreservingError(Iterator);
       raise;
     end;
   finally
@@ -1129,6 +1450,17 @@ end;
 
 { TGocciaIteratorHelperValue }
 
+constructor TGocciaIteratorHelperValue.Create;
+var
+  HelperPrototype: TGocciaObjectValue;
+begin
+  inherited Create;
+  EnsureIteratorHelperPrototypeInitialized;
+  HelperPrototype := GetSharedIteratorHelperPrototype;
+  if Assigned(HelperPrototype) then
+    FPrototype := HelperPrototype;
+end;
+
 function TGocciaIteratorHelperValue.AdvanceNext: TGocciaObjectValue;
 begin
   if FDone then
@@ -1164,7 +1496,14 @@ begin
   end;
 end;
 
+procedure TGocciaIteratorHelperValue.Close;
+begin
+  FDone := True;
+end;
+
 initialization
   GIteratorPrototypeSlot := RegisterRealmSlot('Iterator.prototype');
+  GIteratorHelperPrototypeSlot := RegisterRealmSlot('IteratorHelper.prototype');
+  GIteratorConstructorSlot := RegisterRealmSlot('Iterator');
 
 end.

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -135,6 +135,10 @@ begin
         MapSymbolIterator,
         0,
         [pfConfigurable, pfWritable]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create(CONSTRUCTOR_MAP),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;

--- a/source/units/Goccia.Values.NumberObjectValue.pas
+++ b/source/units/Goccia.Values.NumberObjectValue.pas
@@ -19,6 +19,7 @@ type
     function ExtractPrimitive(const AValue: TGocciaValue): TGocciaNumberLiteralValue;
   public
     constructor Create(const APrimitive: TGocciaNumberLiteralValue; const AClass: TGocciaClassValue = nil);
+    function ToStringTag: string; override;
     function GetProperty(const AName: string): TGocciaValue; override;
     function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     procedure InitializePrototype;
@@ -90,6 +91,11 @@ begin
   SharedPrototype := GetSharedNumberPrototype;
   if not Assigned(AClass) and Assigned(SharedPrototype) then
     FPrototype := SharedPrototype;
+end;
+
+function TGocciaNumberObjectValue.ToStringTag: string;
+begin
+  Result := 'Number';
 end;
 
 function TGocciaNumberObjectValue.GetProperty(const AName: string): TGocciaValue;

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -118,6 +118,7 @@ type
     property RegExpData: TObject read FRegExpData write SetRegExpData;
   published
     function ObjectPrototypeToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ObjectPrototypeHasOwnProperty(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectPrototypeIsPrototypeOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectPrototypePropertyIsEnumerable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ObjectPrototypeToLocaleString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -138,6 +139,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.ObjectModel,
+  Goccia.Values.ArrayValue,
   Goccia.Values.ClassHelper,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -166,6 +168,13 @@ function IsBytecodePrivateInitializerMarker(const AName: string): Boolean;
 begin
   Result := Copy(AName, 1, Length(BYTECODE_PRIVATE_INITIALIZED_PREFIX)) =
     BYTECODE_PRIVATE_INITIALIZED_PREFIX;
+end;
+
+function IsHiddenRegExpDataProperty(const AObject: TGocciaObjectValue;
+  const AName: string): Boolean;
+begin
+  Result := AObject.HasRegExpData and
+    ((AName = PROP_SOURCE) or (AName = PROP_FLAGS));
 end;
 
 function TryParseArrayIndexKey(const AKey: string; out AIndex: UInt64): Boolean;
@@ -276,6 +285,58 @@ begin
     Result := TGocciaNullLiteralValue.NullValue;
 end;
 
+function OwnPropertyKeyValues(const AObject: TGocciaObjectValue): TArray<TGocciaValue>;
+var
+  Count: Integer;
+  I: Integer;
+  StringKeys: TArray<string>;
+  SymbolKeys: TArray<TGocciaSymbolValue>;
+begin
+  if AObject is TGocciaProxyValue then
+    Exit(TGocciaProxyValue(AObject).GetOwnPropertyKeyValues);
+
+  StringKeys := AObject.GetOwnPropertyKeys;
+  SymbolKeys := AObject.GetOwnSymbols;
+  SetLength(Result, Length(StringKeys) + Length(SymbolKeys));
+  Count := 0;
+  for I := 0 to High(StringKeys) do
+  begin
+    Result[Count] := TGocciaStringLiteralValue.Create(StringKeys[I]);
+    Inc(Count);
+  end;
+  for I := 0 to High(SymbolKeys) do
+  begin
+    Result[Count] := SymbolKeys[I];
+    Inc(Count);
+  end;
+end;
+
+function OwnPropertyDescriptorForKey(
+  const AObject: TGocciaObjectValue;
+  const AKey: TGocciaValue): TGocciaPropertyDescriptor;
+begin
+  if AKey is TGocciaSymbolValue then
+    Result := AObject.GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(AKey))
+  else
+    Result := AObject.GetOwnPropertyDescriptor(AKey.ToStringLiteral.Value);
+end;
+
+procedure DefineOwnPropertyOrThrowForKey(
+  const AObject: TGocciaObjectValue;
+  const AKey: TGocciaValue;
+  const ADescriptor: TGocciaPropertyDescriptor);
+begin
+  try
+    if AKey is TGocciaSymbolValue then
+      AObject.DefineSymbolProperty(TGocciaSymbolValue(AKey), ADescriptor)
+    else
+      AObject.DefineProperty(AKey.ToStringLiteral.Value, ADescriptor);
+  except
+    ADescriptor.Free;
+    raise;
+  end;
+end;
+
 procedure MarkPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor);
 begin
   ADescriptor.MarkValues;
@@ -331,35 +392,98 @@ var
   Tag: string;
   SymbolTag: TGocciaValue;
   Obj: TGocciaObjectValue;
+
+  function IsArrayObject(const AObject: TGocciaObjectValue): Boolean;
+  var
+    Proxy: TGocciaProxyValue;
+  begin
+    if AObject is TGocciaArrayValue then
+      Exit(True);
+    if AObject is TGocciaProxyValue then
+    begin
+      Proxy := TGocciaProxyValue(AObject);
+      if Proxy.Revoked then
+        ThrowTypeError(SErrorProxyRevoked, SSuggestProxyRevoked);
+      if Proxy.Target is TGocciaObjectValue then
+        Exit(IsArrayObject(TGocciaObjectValue(Proxy.Target)));
+    end;
+    Result := False;
+  end;
+
+  function LegacyBuiltinTagForObject(const AObject: TGocciaObjectValue): string;
+  begin
+    Result := AObject.ToStringTag;
+  end;
+
 begin
   if AThisValue is TGocciaUndefinedLiteralValue then
     Exit(TGocciaStringLiteralValue.Create('[object Undefined]'));
   if AThisValue is TGocciaNullLiteralValue then
     Exit(TGocciaStringLiteralValue.Create('[object Null]'));
 
-  if AThisValue is TGocciaObjectValue then
-  begin
-    Obj := TGocciaObjectValue(AThisValue);
-    SymbolTag := Obj.GetSymbolProperty(TGocciaSymbolValue.WellKnownToStringTag);
-    if Assigned(SymbolTag) and (SymbolTag is TGocciaStringLiteralValue) then
-      Tag := TGocciaStringLiteralValue(SymbolTag).Value
-    else if AThisValue.IsCallable then
+  Obj := ObjectPrototypeToObject(AThisValue);
+  if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
+    TGarbageCollector.Instance.AddTempRoot(Obj);
+  try
+    if IsArrayObject(Obj) then
+      Tag := CONSTRUCTOR_ARRAY
+    else if Obj.IsCallable then
       Tag := 'Function'
+    else if Obj.HasErrorData then
+      Tag := 'Error'
+    else if Obj.HasRegExpData then
+      Tag := 'RegExp'
+    else if (Obj is TGocciaProxyValue) then
+      Tag := CONSTRUCTOR_OBJECT
     else
-      Tag := Obj.ToStringTag;
-  end
-  else if AThisValue is TGocciaBooleanLiteralValue then
-    Tag := CONSTRUCTOR_BOOLEAN
-  else if AThisValue is TGocciaNumberLiteralValue then
-    Tag := CONSTRUCTOR_NUMBER
-  else if AThisValue is TGocciaStringLiteralValue then
-    Tag := CONSTRUCTOR_STRING
-  else if AThisValue is TGocciaSymbolValue then
-    Tag := CONSTRUCTOR_SYMBOL
-  else
-    Tag := CONSTRUCTOR_OBJECT;
+      Tag := LegacyBuiltinTagForObject(Obj);
+
+    SymbolTag := Obj.GetSymbolPropertyWithReceiver(
+      TGocciaSymbolValue.WellKnownToStringTag, AThisValue);
+    if Assigned(SymbolTag) and (SymbolTag is TGocciaStringLiteralValue) then
+      Tag := TGocciaStringLiteralValue(SymbolTag).Value;
+  finally
+    if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
+      TGarbageCollector.Instance.RemoveTempRoot(Obj);
+  end;
 
   Result := TGocciaStringLiteralValue.Create('[object ' + Tag + ']');
+end;
+
+// ES2026 §20.1.3.2 Object.prototype.hasOwnProperty(V)
+function TGocciaObjectValue.ObjectPrototypeHasOwnProperty(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  KeyValue: TGocciaValue;
+  Obj: TGocciaObjectValue;
+  Own: Boolean;
+  PropertyArg: TGocciaValue;
+begin
+  // Step 1: Let P be ? ToPropertyKey(V)
+  if AArgs.Length = 0 then
+    PropertyArg := TGocciaUndefinedLiteralValue.UndefinedValue
+  else
+    PropertyArg := AArgs.GetElement(0);
+  KeyValue := ToPropertyKey(PropertyArg);
+
+  // Step 2: Let O be ? ToObject(this value)
+  Obj := ObjectPrototypeToObject(AThisValue);
+  if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
+    TGarbageCollector.Instance.AddTempRoot(Obj);
+  try
+    // Step 3: Return ? HasOwnProperty(O, P)
+    if KeyValue is TGocciaSymbolValue then
+      Own := Obj.HasSymbolProperty(TGocciaSymbolValue(KeyValue))
+    else
+      Own := Obj.HasOwnProperty(KeyValue.ToStringLiteral.Value);
+
+    if Own then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+  finally
+    if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
+      TGarbageCollector.Instance.RemoveTempRoot(Obj);
+  end;
 end;
 
 // ES2026 §20.1.3.3 Object.prototype.isPrototypeOf(V)
@@ -395,41 +519,28 @@ end;
 // ES2026 §20.1.3.4 Object.prototype.propertyIsEnumerable(V)
 function TGocciaObjectValue.ObjectPrototypePropertyIsEnumerable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Key: string;
+  KeyValue: TGocciaValue;
   Obj: TGocciaObjectValue;
   Descriptor: TGocciaPropertyDescriptor;
   PropertyArg: TGocciaValue;
 begin
-  // Step 2: Let O be ? ToObject(this value)
-  if (AThisValue is TGocciaUndefinedLiteralValue) or (AThisValue is TGocciaNullLiteralValue) then
-    ThrowTypeError(SErrorCannotConvertNullOrUndefined, SSuggestCheckNullBeforeAccess);
-
-  if not (AThisValue is TGocciaObjectValue) then
-    Exit(TGocciaBooleanLiteralValue.FalseValue);
-
-  Obj := TGocciaObjectValue(AThisValue);
-
   // Step 1: Let P be ? ToPropertyKey(V)
   if AArgs.Length = 0 then
     PropertyArg := TGocciaUndefinedLiteralValue.UndefinedValue
   else
     PropertyArg := AArgs.GetElement(0);
+  KeyValue := ToPropertyKey(PropertyArg);
 
-  if PropertyArg is TGocciaSymbolValue then
-  begin
-    Descriptor := Obj.GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(PropertyArg));
-    if not Assigned(Descriptor) then
-      Exit(TGocciaBooleanLiteralValue.FalseValue);
-    if Descriptor.Enumerable then
-      Result := TGocciaBooleanLiteralValue.TrueValue
+  // Step 2: Let O be ? ToObject(this value)
+  Obj := ObjectPrototypeToObject(AThisValue);
+  if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
+    TGarbageCollector.Instance.AddTempRoot(Obj);
+  try
+    if KeyValue is TGocciaSymbolValue then
+      Descriptor := Obj.GetOwnSymbolPropertyDescriptor(TGocciaSymbolValue(KeyValue))
     else
-      Result := TGocciaBooleanLiteralValue.FalseValue;
-  end
-  else
-  begin
-    Key := PropertyArg.ToStringLiteral.Value;
-    // Step 3: Let desc be ? O.[[GetOwnProperty]](P)
-    Descriptor := Obj.GetOwnPropertyDescriptor(Key);
+      Descriptor := Obj.GetOwnPropertyDescriptor(KeyValue.ToStringLiteral.Value);
+
     // Step 4: If desc is undefined, return false
     if not Assigned(Descriptor) then
       Exit(TGocciaBooleanLiteralValue.FalseValue);
@@ -438,6 +549,9 @@ begin
       Result := TGocciaBooleanLiteralValue.TrueValue
     else
       Result := TGocciaBooleanLiteralValue.FalseValue;
+  finally
+    if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
+      TGarbageCollector.Instance.RemoveTempRoot(Obj);
   end;
 end;
 
@@ -454,7 +568,7 @@ begin
   if Assigned(TGarbageCollector.Instance) and not (AThisValue is TGocciaObjectValue) then
     TGarbageCollector.Instance.AddTempRoot(Obj);
   try
-    ToStringMethod := Obj.GetProperty(PROP_TO_STRING);
+    ToStringMethod := Obj.GetPropertyWithContext(PROP_TO_STRING, AThisValue);
     if not Assigned(ToStringMethod) or not ToStringMethod.IsCallable then
       ThrowTypeError(Format(SErrorValueNotFunction, [PROP_TO_STRING]), SSuggestNotFunctionType);
 
@@ -496,6 +610,7 @@ begin
     Members := TGocciaMemberCollection.Create;
     try
       Members.AddMethod(FPrototypeMethodHost.ObjectPrototypeToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(FPrototypeMethodHost.ObjectPrototypeHasOwnProperty, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(FPrototypeMethodHost.ObjectPrototypeIsPrototypeOf, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(FPrototypeMethodHost.ObjectPrototypePropertyIsEnumerable, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(FPrototypeMethodHost.ObjectPrototypeToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -505,10 +620,11 @@ begin
       Members.Free;
     end;
     FPrototypeMembers[0].ExposedName := PROP_TO_STRING;
-    FPrototypeMembers[1].ExposedName := PROP_IS_PROTOTYPE_OF;
-    FPrototypeMembers[2].ExposedName := PROP_PROPERTY_IS_ENUMERABLE;
-    FPrototypeMembers[3].ExposedName := PROP_TO_LOCALE_STRING;
-    FPrototypeMembers[4].ExposedName := PROP_VALUE_OF;
+    FPrototypeMembers[1].ExposedName := 'hasOwnProperty';
+    FPrototypeMembers[2].ExposedName := PROP_IS_PROTOTYPE_OF;
+    FPrototypeMembers[3].ExposedName := PROP_PROPERTY_IS_ENUMERABLE;
+    FPrototypeMembers[4].ExposedName := PROP_TO_LOCALE_STRING;
+    FPrototypeMembers[5].ExposedName := PROP_VALUE_OF;
   end;
   RegisterMemberDefinitions(SharedPrototype, FPrototypeMembers);
 
@@ -617,9 +733,6 @@ var
   Proto: TGocciaObjectValue;
   ChainDepth: Integer;
 begin
-  if FFrozen then
-    ThrowTypeError(Format(SErrorReadOnlyPropertyFrozen, [AName]), SSuggestCannotDeleteNonConfigurable);
-
   if FProperties.TryGetValue(AName, Descriptor) then
   begin
     if Descriptor is TGocciaPropertyDescriptorAccessor then
@@ -1089,7 +1202,8 @@ begin
   Count := 0;
   for Key in FProperties.Keys do
   begin
-    if IsBytecodePrivateInitializerMarker(Key) then
+    if IsBytecodePrivateInitializerMarker(Key) or
+       IsHiddenRegExpDataProperty(Self, Key) then
       Continue;
     Keys[Count] := Key;
     Inc(Count);
@@ -1266,16 +1380,18 @@ var
   I, Count: Integer;
 begin
   Names := GetEnumerablePropertyNames;
-  SetLength(Values, FProperties.Count);
+  SetLength(Values, Length(Names));
   Count := 0;
 
   for I := 0 to High(Names) do
-    if FProperties.TryGetValue(Names[I], Descriptor) and
-       Descriptor.Enumerable and (Descriptor is TGocciaPropertyDescriptorData) then
+  begin
+    Descriptor := GetOwnPropertyDescriptor(Names[I]);
+    if Assigned(Descriptor) and Descriptor.Enumerable then
     begin
-      Values[Count] := TGocciaPropertyDescriptorData(Descriptor).Value;
+      Values[Count] := GetProperty(Names[I]);
       Inc(Count);
     end;
+  end;
 
   SetLength(Values, Count);
   Result := Values;
@@ -1290,18 +1406,20 @@ var
   Entry: TPair<string, TGocciaValue>;
 begin
   Names := GetEnumerablePropertyNames;
-  SetLength(Entries, FProperties.Count);
+  SetLength(Entries, Length(Names));
   Count := 0;
 
   for I := 0 to High(Names) do
-    if FProperties.TryGetValue(Names[I], Descriptor) and
-       Descriptor.Enumerable and (Descriptor is TGocciaPropertyDescriptorData) then
+  begin
+    Descriptor := GetOwnPropertyDescriptor(Names[I]);
+    if Assigned(Descriptor) and Descriptor.Enumerable then
     begin
       Entry.Key := Names[I];
-      Entry.Value := TGocciaPropertyDescriptorData(Descriptor).Value;
+      Entry.Value := GetProperty(Names[I]);
       Entries[Count] := Entry;
       Inc(Count);
     end;
+  end;
 
   SetLength(Entries, Count);
   Result := Entries;
@@ -1317,7 +1435,8 @@ begin
   Count := 0;
   for Key in FProperties.Keys do
   begin
-    if IsBytecodePrivateInitializerMarker(Key) then
+    if IsBytecodePrivateInitializerMarker(Key) or
+       IsHiddenRegExpDataProperty(Self, Key) then
       Continue;
     Names[Count] := Key;
     Inc(Count);
@@ -1386,9 +1505,6 @@ var
   Args: TGocciaArgumentsCollection;
   Current: TGocciaObjectValue;
 begin
-  if FFrozen then
-    ThrowTypeError(SErrorCannotAssignFrozenObject, SSuggestCannotDeleteNonConfigurable);
-
   if FSymbolDescriptors.TryGetValue(ASymbol, Descriptor) then
   begin
     if Descriptor is TGocciaPropertyDescriptorAccessor then
@@ -1677,68 +1793,29 @@ end;
 
 procedure TGocciaObjectValue.Freeze;
 var
-  Pair: TGocciaPropertyMap.TKeyValuePair;
-  SymPair: TSymbolDescriptorMap.TKeyValuePair;
   Descriptor: TGocciaPropertyDescriptor;
   NewDescriptor: TGocciaPropertyDescriptor;
+  I: Integer;
+  Keys: TArray<TGocciaValue>;
 begin
-  for Pair in FProperties do
+  PreventExtensions;
+  Keys := OwnPropertyKeyValues(Self);
+  for I := 0 to High(Keys) do
   begin
-    Descriptor := Pair.Value;
-    if Descriptor is TGocciaPropertyDescriptorData then
-    begin
-      if Descriptor.Enumerable then
-        NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, [pfEnumerable])
-      else
-        NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, []);
-      FProperties.Add(Pair.Key, NewDescriptor);
-      Descriptor.Free;
-    end
-    else if Descriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      if Descriptor.Enumerable then
-        NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
-          TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
-          TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
-          [pfEnumerable])
-      else
-        NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
-          TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
-          TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
-          []);
-      FProperties.Add(Pair.Key, NewDescriptor);
-      Descriptor.Free;
-    end;
-  end;
-  // ES2026 §7.3.15 SetIntegrityLevel must apply to symbol-keyed properties
-  // too — same pattern as Seal above.
-  for SymPair in FSymbolDescriptors do
-  begin
-    Descriptor := SymPair.Value;
-    if Descriptor is TGocciaPropertyDescriptorData then
-    begin
-      if Descriptor.Enumerable then
-        NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, [pfEnumerable])
-      else
-        NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, []);
-      FSymbolDescriptors.AddOrSetValue(SymPair.Key, NewDescriptor);
-      Descriptor.Free;
-    end
-    else if Descriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      if Descriptor.Enumerable then
-        NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
-          TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
-          TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
-          [pfEnumerable])
-      else
-        NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
-          TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
-          TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
-          []);
-      FSymbolDescriptors.AddOrSetValue(SymPair.Key, NewDescriptor);
-      Descriptor.Free;
-    end;
+    Descriptor := OwnPropertyDescriptorForKey(Self, Keys[I]);
+    if not Assigned(Descriptor) then
+      Continue;
+    if IsAccessorDescriptor(Descriptor) then
+      NewDescriptor := TGocciaPropertyDescriptor.Create([],
+        [pdfConfigurable])
+    else if IsDataDescriptor(Descriptor) then
+      NewDescriptor := TGocciaPropertyDescriptorData.CreatePartial(
+        TGocciaPropertyDescriptorData(Descriptor).Value, [],
+        [pdfValue, pdfConfigurable, pdfWritable])
+    else
+      NewDescriptor := TGocciaPropertyDescriptor.Create([],
+        [pdfConfigurable]);
+    DefineOwnPropertyOrThrowForKey(Self, Keys[I], NewDescriptor);
   end;
   FFrozen := True;
   FSealed := True;
@@ -1747,63 +1824,14 @@ end;
 
 procedure TGocciaObjectValue.Seal;
 var
-  Pair: TGocciaPropertyMap.TKeyValuePair;
-  SymPair: TSymbolDescriptorMap.TKeyValuePair;
-  Descriptor: TGocciaPropertyDescriptor;
-  NewDescriptor: TGocciaPropertyDescriptor;
-  Flags: TPropertyFlags;
+  I: Integer;
+  Keys: TArray<TGocciaValue>;
 begin
-  for Pair in FProperties do
-  begin
-    Descriptor := Pair.Value;
-    Flags := [];
-    if Descriptor.Enumerable then
-      Include(Flags, pfEnumerable);
-    if Descriptor is TGocciaPropertyDescriptorData then
-    begin
-      if Descriptor.Writable then
-        Include(Flags, pfWritable);
-      NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, Flags);
-      FProperties.Add(Pair.Key, NewDescriptor);
-      Descriptor.Free;
-    end
-    else if Descriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
-        TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
-        TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
-        Flags);
-      FProperties.Add(Pair.Key, NewDescriptor);
-      Descriptor.Free;
-    end;
-  end;
-  // ES2026 §7.3.15 SetIntegrityLevel must apply to symbol-keyed properties
-  // too — they live in a separate descriptor table in Goccia but are still
-  // own properties of O, so seal/freeze must clear pfConfigurable here.
-  for SymPair in FSymbolDescriptors do
-  begin
-    Descriptor := SymPair.Value;
-    Flags := [];
-    if Descriptor.Enumerable then
-      Include(Flags, pfEnumerable);
-    if Descriptor is TGocciaPropertyDescriptorData then
-    begin
-      if Descriptor.Writable then
-        Include(Flags, pfWritable);
-      NewDescriptor := TGocciaPropertyDescriptorData.Create(TGocciaPropertyDescriptorData(Descriptor).Value, Flags);
-      FSymbolDescriptors.AddOrSetValue(SymPair.Key, NewDescriptor);
-      Descriptor.Free;
-    end
-    else if Descriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      NewDescriptor := TGocciaPropertyDescriptorAccessor.Create(
-        TGocciaPropertyDescriptorAccessor(Descriptor).Getter,
-        TGocciaPropertyDescriptorAccessor(Descriptor).Setter,
-        Flags);
-      FSymbolDescriptors.AddOrSetValue(SymPair.Key, NewDescriptor);
-      Descriptor.Free;
-    end;
-  end;
+  PreventExtensions;
+  Keys := OwnPropertyKeyValues(Self);
+  for I := 0 to High(Keys) do
+    DefineOwnPropertyOrThrowForKey(Self, Keys[I],
+      TGocciaPropertyDescriptor.Create([], [pdfConfigurable]));
   FSealed := True;
   FExtensible := False;
 end;
@@ -1816,27 +1844,30 @@ end;
 // ES2026 §7.3.16 TestIntegrityLevel(O, frozen)
 function TGocciaObjectValue.TestIntegrityFrozen: Boolean;
 var
-  Pair: TGocciaPropertyMap.TKeyValuePair;
-  SymPair: TSymbolDescriptorMap.TKeyValuePair;
+  Descriptor: TGocciaPropertyDescriptor;
+  ExtensibleCheck: Boolean;
+  I: Integer;
+  Keys: TArray<TGocciaValue>;
 begin
+  if Self is TGocciaProxyValue then
+    ExtensibleCheck := TGocciaProxyValue(Self).IsExtensibleTrap
+  else
+    ExtensibleCheck := FExtensible;
+
   // Step 3: If extensible is true, return false
-  if FExtensible then
+  if ExtensibleCheck then
     Exit(False);
 
   // Step 5: For each element key of keys
-  for Pair in FProperties do
+  Keys := OwnPropertyKeyValues(Self);
+  for I := 0 to High(Keys) do
   begin
-    if Pair.Value.Configurable then
+    Descriptor := OwnPropertyDescriptorForKey(Self, Keys[I]);
+    if not Assigned(Descriptor) then
+      Continue;
+    if Descriptor.Configurable then
       Exit(False);
-    if (Pair.Value is TGocciaPropertyDescriptorData) and Pair.Value.Writable then
-      Exit(False);
-  end;
-
-  for SymPair in FSymbolDescriptors do
-  begin
-    if SymPair.Value.Configurable then
-      Exit(False);
-    if (SymPair.Value is TGocciaPropertyDescriptorData) and SymPair.Value.Writable then
+    if IsDataDescriptor(Descriptor) and Descriptor.Writable then
       Exit(False);
   end;
 
@@ -1847,23 +1878,26 @@ end;
 // ES2026 §7.3.16 TestIntegrityLevel(O, sealed)
 function TGocciaObjectValue.TestIntegritySealed: Boolean;
 var
-  Pair: TGocciaPropertyMap.TKeyValuePair;
-  SymPair: TSymbolDescriptorMap.TKeyValuePair;
+  Descriptor: TGocciaPropertyDescriptor;
+  ExtensibleCheck: Boolean;
+  I: Integer;
+  Keys: TArray<TGocciaValue>;
 begin
+  if Self is TGocciaProxyValue then
+    ExtensibleCheck := TGocciaProxyValue(Self).IsExtensibleTrap
+  else
+    ExtensibleCheck := FExtensible;
+
   // Step 3: If extensible is true, return false
-  if FExtensible then
+  if ExtensibleCheck then
     Exit(False);
 
   // Step 5: For each element key of keys
-  for Pair in FProperties do
+  Keys := OwnPropertyKeyValues(Self);
+  for I := 0 to High(Keys) do
   begin
-    if Pair.Value.Configurable then
-      Exit(False);
-  end;
-
-  for SymPair in FSymbolDescriptors do
-  begin
-    if SymPair.Value.Configurable then
+    Descriptor := OwnPropertyDescriptorForKey(Self, Keys[I]);
+    if Assigned(Descriptor) and Descriptor.Configurable then
       Exit(False);
   end;
 

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -172,9 +172,19 @@ end;
 
 function IsHiddenRegExpDataProperty(const AObject: TGocciaObjectValue;
   const AName: string): Boolean;
+var
+  Descriptor: TGocciaPropertyDescriptor;
 begin
-  Result := AObject.HasRegExpData and
-    ((AName = PROP_SOURCE) or (AName = PROP_FLAGS));
+  Result := False;
+  if (not AObject.HasRegExpData) or
+     ((AName <> PROP_SOURCE) and (AName <> PROP_FLAGS)) then
+    Exit;
+
+  Descriptor := AObject.GetOwnPropertyDescriptor(AName);
+  Result := (Descriptor is TGocciaPropertyDescriptorData) and
+    (not Descriptor.Enumerable) and
+    (not Descriptor.Configurable) and
+    (not TGocciaPropertyDescriptorData(Descriptor).Writable);
 end;
 
 function TryParseArrayIndexKey(const AKey: string; out AIndex: UInt64): Boolean;

--- a/source/units/Goccia.Values.PromiseValue.pas
+++ b/source/units/Goccia.Values.PromiseValue.pas
@@ -9,6 +9,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
@@ -90,6 +91,9 @@ type
     function PromiseFinally(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
+function GetPromiseIntrinsicPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+
 implementation
 
 uses
@@ -100,7 +104,6 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
-  Goccia.Realm,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -113,15 +116,49 @@ uses
 
 var
   GPromiseSharedSlot: TGocciaRealmOwnedSlotId;
+  GPromiseDefaultConstructorSlot: TGocciaRealmSlotId;
 
 threadvar
   FPrototypeMembers: TArray<TGocciaMemberDefinition>;
-  FPromiseDefaultConstructor: TGocciaValue;
+
+function GetPromiseSharedForRealm(
+  const ARealm: TGocciaRealm): TGocciaSharedPrototype; inline;
+begin
+  if Assigned(ARealm) then
+    Result := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GPromiseSharedSlot))
+  else
+    Result := nil;
+end;
 
 function GetPromiseShared: TGocciaSharedPrototype; inline;
 begin
-  if Assigned(CurrentRealm) then
-    Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GPromiseSharedSlot))
+  Result := GetPromiseSharedForRealm(CurrentRealm);
+end;
+
+function GetPromiseDefaultConstructorForRealm(
+  const ARealm: TGocciaRealm): TGocciaValue; inline;
+begin
+  if Assigned(ARealm) then
+    Result := TGocciaValue(ARealm.GetSlot(GPromiseDefaultConstructorSlot))
+  else
+    Result := nil;
+end;
+
+procedure SetPromiseDefaultConstructorForRealm(const ARealm: TGocciaRealm;
+  const AConstructor: TGocciaValue); inline;
+begin
+  if Assigned(ARealm) then
+    ARealm.SetSlot(GPromiseDefaultConstructorSlot, AConstructor);
+end;
+
+function GetPromiseIntrinsicPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Shared := GetPromiseSharedForRealm(ARealm);
+  if Assigned(Shared) then
+    Result := Shared.Prototype
   else
     Result := nil;
 end;
@@ -137,6 +174,7 @@ type
   private
     FResolve: TGocciaValue;
     FReject: TGocciaValue;
+    FInvoked: Boolean;
   public
     function Invoke(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -158,15 +196,12 @@ type
 function TPromiseCapabilityExecutor.Invoke(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
-  function HasNonUndefinedValue(const AValue: TGocciaValue): Boolean;
-  begin
-    Result := Assigned(AValue) and not (AValue is TGocciaUndefinedLiteralValue);
-  end;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  if HasNonUndefinedValue(FResolve) or HasNonUndefinedValue(FReject) then
+  if FInvoked then
     ThrowTypeError(SErrorPromiseResolverNotFunction, SSuggestPromiseResolver);
 
+  FInvoked := True;
   FResolve := AArgs.GetElement(0);
   FReject := AArgs.GetElement(1);
 end;
@@ -237,7 +272,7 @@ end;
 
 function GetPromiseDefaultConstructor: TGocciaValue;
 begin
-  Result := FPromiseDefaultConstructor;
+  Result := GetPromiseDefaultConstructorForRealm(CurrentRealm);
   if not Assigned(Result) and Assigned(GetPromiseShared) then
     Result := GetPromiseShared.Prototype.GetProperty(PROP_CONSTRUCTOR);
 end;
@@ -515,7 +550,7 @@ begin
   end;
   if Assigned(Shared) then
   begin
-    FPromiseDefaultConstructor := AConstructor;
+    SetPromiseDefaultConstructorForRealm(CurrentRealm, AConstructor);
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
     AConstructor.DefineProperty(PROP_PROTOTYPE,
       TGocciaPropertyDescriptorData.Create(Shared.Prototype, []));
@@ -898,5 +933,6 @@ end;
 
 initialization
   GPromiseSharedSlot := RegisterRealmOwnedSlot('Promise.shared');
+  GPromiseDefaultConstructorSlot := RegisterRealmSlot('Promise.defaultConstructor');
 
 end.

--- a/source/units/Goccia.Values.PromiseValue.pas
+++ b/source/units/Goccia.Values.PromiseValue.pas
@@ -17,21 +17,38 @@ type
   TGocciaPromiseState = (gpsPending, gpsFulfilled, gpsRejected);
 
   TGocciaPromiseValue = class;
+  TGocciaPromiseReactionCapability = class;
 
   TGocciaPromiseReaction = record
     OnFulfilled: TGocciaValue;
     OnRejected: TGocciaValue;
-    ResultPromise: TGocciaPromiseValue;
+    ResultPromise: TGocciaValue;
   end;
 
   TGocciaPromiseFinallyWrapper = class(TGocciaObjectValue)
   private
     FOnFinally: TGocciaValue;
+    FConstructor: TGocciaValue;
     FIsFulfill: Boolean;
   public
-    constructor Create(const AOnFinally: TGocciaValue; const AIsFulfill: Boolean);
+    constructor Create(const AOnFinally, AConstructor: TGocciaValue;
+      const AIsFulfill: Boolean);
     function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure MarkReferences; override;
+  end;
+
+  TGocciaPromiseReactionCapability = class(TGocciaObjectValue)
+  private
+    FPromise: TGocciaValue;
+    FResolve: TGocciaValue;
+    FReject: TGocciaValue;
+    procedure CallCapability(const AFunction, AValue: TGocciaValue);
+  public
+    constructor Create(const APromise, AResolve, AReject: TGocciaValue);
+    procedure Resolve(const AValue: TGocciaValue);
+    procedure Reject(const AValue: TGocciaValue);
+    procedure MarkReferences; override;
+    property Promise: TGocciaValue read FPromise;
   end;
 
   TGocciaPromiseValue = class(TGocciaObjectValue)
@@ -76,16 +93,22 @@ type
 implementation
 
 uses
+  Goccia.Arithmetic,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.Realm,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.NativeFunction,
+  Goccia.Values.NativeFunctionCallback,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.SymbolValue,
+  Goccia.Values.ToObject,
   Goccia.VM.Exception;
 
 var
@@ -93,6 +116,7 @@ var
 
 threadvar
   FPrototypeMembers: TArray<TGocciaMemberDefinition>;
+  FPromiseDefaultConstructor: TGocciaValue;
 
 function GetPromiseShared: TGocciaSharedPrototype; inline;
 begin
@@ -103,6 +127,24 @@ begin
 end;
 
 type
+  TPromiseCapability = record
+    Promise: TGocciaValue;
+    Resolve: TGocciaValue;
+    Reject: TGocciaValue;
+  end;
+
+  TPromiseCapabilityExecutor = class(TGocciaObjectValue)
+  private
+    FResolve: TGocciaValue;
+    FReject: TGocciaValue;
+  public
+    function Invoke(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    procedure MarkReferences; override;
+    property Resolve: TGocciaValue read FResolve;
+    property Reject: TGocciaValue read FReject;
+  end;
+
   TGocciaFinallyPassthrough = class(TGocciaObjectValue)
   private
     FOriginalValue: TGocciaValue;
@@ -112,6 +154,232 @@ type
     function Invoke(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure MarkReferences; override;
   end;
+
+function TPromiseCapabilityExecutor.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+  function HasNonUndefinedValue(const AValue: TGocciaValue): Boolean;
+  begin
+    Result := Assigned(AValue) and not (AValue is TGocciaUndefinedLiteralValue);
+  end;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if HasNonUndefinedValue(FResolve) or HasNonUndefinedValue(FReject) then
+    ThrowTypeError(SErrorPromiseResolverNotFunction, SSuggestPromiseResolver);
+
+  FResolve := AArgs.GetElement(0);
+  FReject := AArgs.GetElement(1);
+end;
+
+procedure TPromiseCapabilityExecutor.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FResolve) then
+    FResolve.MarkReferences;
+  if Assigned(FReject) then
+    FReject.MarkReferences;
+end;
+
+function CreateAnonymousPromiseBuiltinFunction(
+  const AFunction: TGocciaNativeFunctionCallback;
+  const ACapturedRoot: TGocciaValue; const AArity: Integer): TGocciaNativeFunctionValue;
+begin
+  Result := TGocciaNativeFunctionValue.CreateWithoutPrototype(AFunction, '',
+    AArity);
+  Result.CapturedRoot := ACapturedRoot;
+  Result.DefineProperty(PROP_LENGTH, TGocciaPropertyDescriptorData.Create(
+    TGocciaNumberLiteralValue.Create(AArity), [pfConfigurable]));
+  Result.DefineProperty(PROP_NAME, TGocciaPropertyDescriptorData.Create(
+    TGocciaStringLiteralValue.Create(''), [pfConfigurable]));
+end;
+
+function NewPromiseCapability(
+  const AConstructor: TGocciaValue): TPromiseCapability;
+var
+  ExecutorHost: TPromiseCapabilityExecutor;
+  ExecutorFn: TGocciaNativeFunctionValue;
+  ConstructArgs: TGocciaArgumentsCollection;
+  GC: TGarbageCollector;
+begin
+  if not Assigned(AConstructor) or not AConstructor.IsConstructable then
+    ThrowTypeError(SErrorValueNotConstructor, SSuggestNotConstructorType);
+
+  ExecutorHost := TPromiseCapabilityExecutor.Create;
+  ExecutorFn := CreateAnonymousPromiseBuiltinFunction(ExecutorHost.Invoke,
+    ExecutorHost, 2);
+  ConstructArgs := TGocciaArgumentsCollection.Create([ExecutorFn]);
+  GC := TGarbageCollector.Instance;
+  try
+    if Assigned(GC) then
+    begin
+      GC.AddTempRoot(ExecutorHost);
+      GC.AddTempRoot(ExecutorFn);
+    end;
+
+    Result.Promise := ConstructValue(AConstructor, ConstructArgs,
+      AConstructor);
+    Result.Resolve := ExecutorHost.Resolve;
+    Result.Reject := ExecutorHost.Reject;
+
+    if not Assigned(Result.Resolve) or not Result.Resolve.IsCallable or
+       not Assigned(Result.Reject) or not Result.Reject.IsCallable then
+      ThrowTypeError(SErrorPromiseResolverNotFunction, SSuggestPromiseResolver);
+  finally
+    if Assigned(GC) then
+    begin
+      GC.RemoveTempRoot(ExecutorFn);
+      GC.RemoveTempRoot(ExecutorHost);
+    end;
+    ConstructArgs.Free;
+  end;
+end;
+
+function GetPromiseDefaultConstructor: TGocciaValue;
+begin
+  Result := FPromiseDefaultConstructor;
+  if not Assigned(Result) and Assigned(GetPromiseShared) then
+    Result := GetPromiseShared.Prototype.GetProperty(PROP_CONSTRUCTOR);
+end;
+
+function PromiseSpeciesConstructor(
+  const APromise: TGocciaObjectValue): TGocciaValue;
+var
+  ConstructorValue, SpeciesValue: TGocciaValue;
+begin
+  Result := GetPromiseDefaultConstructor;
+  ConstructorValue := APromise.GetProperty(PROP_CONSTRUCTOR);
+  if ConstructorValue is TGocciaUndefinedLiteralValue then
+    Exit;
+  if not (ConstructorValue is TGocciaObjectValue) then
+    ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+
+  SpeciesValue := TGocciaObjectValue(ConstructorValue).GetSymbolProperty(
+    TGocciaSymbolValue.WellKnownSpecies);
+  if (SpeciesValue is TGocciaUndefinedLiteralValue) or
+     (SpeciesValue is TGocciaNullLiteralValue) then
+    Exit;
+  if SpeciesValue.IsConstructable then
+    Exit(SpeciesValue);
+
+  ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+end;
+
+function PromiseResolveForConstructor(const AConstructor,
+  AValue: TGocciaValue): TGocciaValue;
+var
+  ValueConstructor: TGocciaValue;
+  Capability: TPromiseCapability;
+  ResolveArgs: TGocciaArgumentsCollection;
+begin
+  if not (AConstructor is TGocciaObjectValue) then
+    ThrowTypeError(SErrorValueNotConstructor, SSuggestNotConstructorType);
+
+  if AValue is TGocciaPromiseValue then
+  begin
+    ValueConstructor := TGocciaPromiseValue(AValue).GetProperty(
+      PROP_CONSTRUCTOR);
+    if IsSameValue(ValueConstructor, AConstructor) then
+      Exit(AValue);
+  end;
+
+  Capability := NewPromiseCapability(AConstructor);
+  ResolveArgs := TGocciaArgumentsCollection.Create([AValue]);
+  try
+    DispatchCall(Capability.Resolve, ResolveArgs,
+      TGocciaUndefinedLiteralValue.UndefinedValue);
+  finally
+    ResolveArgs.Free;
+  end;
+  Result := Capability.Promise;
+end;
+
+function InvokeThenMethod(const AReceiver, AOnFulfilled,
+  AOnRejected: TGocciaValue): TGocciaValue;
+var
+  ReceiverObject: TGocciaObjectValue;
+  ThenMethod: TGocciaValue;
+  ThenArgs: TGocciaArgumentsCollection;
+begin
+  ReceiverObject := ToObject(AReceiver);
+  ThenMethod := ReceiverObject.GetPropertyWithContext(PROP_THEN, AReceiver);
+  if not Assigned(ThenMethod) or not ThenMethod.IsCallable then
+    ThrowTypeError(SErrorThenNotFunction, SSuggestPromiseThisType);
+
+  ThenArgs := TGocciaArgumentsCollection.Create([AOnFulfilled, AOnRejected]);
+  try
+    Result := DispatchCall(ThenMethod, ThenArgs, AReceiver);
+  finally
+    ThenArgs.Free;
+  end;
+end;
+
+function InvokeThenMethodOneArg(const AReceiver,
+  AOnFulfilled: TGocciaValue): TGocciaValue;
+var
+  ReceiverObject: TGocciaObjectValue;
+  ThenMethod: TGocciaValue;
+  ThenArgs: TGocciaArgumentsCollection;
+begin
+  ReceiverObject := ToObject(AReceiver);
+  ThenMethod := ReceiverObject.GetPropertyWithContext(PROP_THEN, AReceiver);
+  if not Assigned(ThenMethod) or not ThenMethod.IsCallable then
+    ThrowTypeError(SErrorThenNotFunction, SSuggestPromiseThisType);
+
+  ThenArgs := TGocciaArgumentsCollection.Create([AOnFulfilled]);
+  try
+    Result := DispatchCall(ThenMethod, ThenArgs, AReceiver);
+  finally
+    ThenArgs.Free;
+  end;
+end;
+
+{ TGocciaPromiseReactionCapability }
+
+constructor TGocciaPromiseReactionCapability.Create(
+  const APromise, AResolve, AReject: TGocciaValue);
+begin
+  inherited Create(nil);
+  FPromise := APromise;
+  FResolve := AResolve;
+  FReject := AReject;
+end;
+
+procedure TGocciaPromiseReactionCapability.CallCapability(
+  const AFunction, AValue: TGocciaValue);
+var
+  Args: TGocciaArgumentsCollection;
+begin
+  if not Assigned(AFunction) or not AFunction.IsCallable then Exit;
+  Args := TGocciaArgumentsCollection.Create([AValue]);
+  try
+    DispatchCall(AFunction, Args, TGocciaUndefinedLiteralValue.UndefinedValue);
+  finally
+    Args.Free;
+  end;
+end;
+
+procedure TGocciaPromiseReactionCapability.Resolve(const AValue: TGocciaValue);
+begin
+  CallCapability(FResolve, AValue);
+end;
+
+procedure TGocciaPromiseReactionCapability.Reject(const AValue: TGocciaValue);
+begin
+  CallCapability(FReject, AValue);
+end;
+
+procedure TGocciaPromiseReactionCapability.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FPromise) then
+    FPromise.MarkReferences;
+  if Assigned(FResolve) then
+    FResolve.MarkReferences;
+  if Assigned(FReject) then
+    FReject.MarkReferences;
+end;
 
 { TGocciaFinallyPassthrough }
 
@@ -141,10 +409,12 @@ end;
 
 { TGocciaPromiseFinallyWrapper }
 
-constructor TGocciaPromiseFinallyWrapper.Create(const AOnFinally: TGocciaValue; const AIsFulfill: Boolean);
+constructor TGocciaPromiseFinallyWrapper.Create(const AOnFinally,
+  AConstructor: TGocciaValue; const AIsFulfill: Boolean);
 begin
   inherited Create(nil);
   FOnFinally := AOnFinally;
+  FConstructor := AConstructor;
   FIsFulfill := AIsFulfill;
 end;
 
@@ -153,61 +423,26 @@ function TGocciaPromiseFinallyWrapper.Invoke(const AArgs: TGocciaArgumentsCollec
 var
   OriginalValue, CallbackResult: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
-  CallbackPromise, IntermediatePromise: TGocciaPromiseValue;
+  CallbackPromise: TGocciaValue;
   Passthrough: TGocciaFinallyPassthrough;
   PassthroughFn: TGocciaNativeFunctionValue;
-  Reaction: TGocciaPromiseReaction;
 begin
   OriginalValue := AArgs.GetElement(0);
 
   CallArgs := TGocciaArgumentsCollection.Create;
   try
-    CallbackResult := TGocciaFunctionBase(FOnFinally).Call(
-      CallArgs, TGocciaUndefinedLiteralValue.UndefinedValue);
+    CallbackResult := DispatchCall(FOnFinally, CallArgs,
+      TGocciaUndefinedLiteralValue.UndefinedValue);
   finally
     CallArgs.Free;
   end;
 
-  if CallbackResult is TGocciaPromiseValue then
-  begin
-    CallbackPromise := TGocciaPromiseValue(CallbackResult);
-
-    case CallbackPromise.State of
-      gpsFulfilled:
-      begin
-        if FIsFulfill then
-          Result := OriginalValue
-        else
-          raise TGocciaThrowValue.Create(OriginalValue);
-      end;
-      gpsRejected:
-        raise TGocciaThrowValue.Create(CallbackPromise.PromiseResult);
-      gpsPending:
-      begin
-        IntermediatePromise := TGocciaPromiseValue.Create;
-
-        Passthrough := TGocciaFinallyPassthrough.Create(OriginalValue, FIsFulfill);
-        PassthroughFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-          Passthrough.Invoke, 'finally-passthrough', 1);
-
-        Reaction.OnFulfilled := PassthroughFn;
-        Reaction.OnRejected := nil;
-        Reaction.ResultPromise := IntermediatePromise;
-        if not Assigned(CallbackPromise.FReactions) then
-          CallbackPromise.FReactions := TList<TGocciaPromiseReaction>.Create;
-        CallbackPromise.FReactions.Add(Reaction);
-
-        Result := IntermediatePromise;
-      end;
-    end;
-  end
-  else
-  begin
-    if FIsFulfill then
-      Result := OriginalValue
-    else
-      raise TGocciaThrowValue.Create(OriginalValue);
-  end;
+  CallbackPromise := PromiseResolveForConstructor(FConstructor,
+    CallbackResult);
+  Passthrough := TGocciaFinallyPassthrough.Create(OriginalValue, FIsFulfill);
+  PassthroughFn := CreateAnonymousPromiseBuiltinFunction(Passthrough.Invoke,
+    Passthrough, 0);
+  Result := InvokeThenMethodOneArg(CallbackPromise, PassthroughFn);
 end;
 
 procedure TGocciaPromiseFinallyWrapper.MarkReferences;
@@ -216,6 +451,8 @@ begin
   inherited;
   if Assigned(FOnFinally) then
     FOnFinally.MarkReferences;
+  if Assigned(FConstructor) then
+    FConstructor.MarkReferences;
 end;
 
 { TGocciaPromiseValue }
@@ -244,6 +481,9 @@ begin
 
   Shared := TGocciaSharedPrototype.Create(Self);
   CurrentRealm.SetOwnedSlot(GPromiseSharedSlot, Shared);
+  if not Assigned(TGocciaObjectValue.SharedObjectPrototype) then
+    TGocciaObjectValue.InitializeSharedPrototype;
+  Shared.Prototype.Prototype := TGocciaObjectValue.SharedObjectPrototype;
   if Length(FPrototypeMembers) = 0 then
   begin
     Members := TGocciaMemberCollection.Create;
@@ -251,6 +491,10 @@ begin
       Members.AddMethod(PromiseThen, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(PromiseCatch, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddMethod(PromiseFinally, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create('Promise'),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;
@@ -270,7 +514,12 @@ begin
     Shared := GetPromiseShared;
   end;
   if Assigned(Shared) then
+  begin
+    FPromiseDefaultConstructor := AConstructor;
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+    AConstructor.DefineProperty(PROP_PROTOTYPE,
+      TGocciaPropertyDescriptorData.Create(Shared.Prototype, []));
+  end;
 end;
 
 destructor TGocciaPromiseValue.Destroy;
@@ -318,20 +567,6 @@ begin
     FResult := Goccia.Values.ErrorHelper.CreateErrorObject(TYPE_ERROR_NAME,
       SErrorPromiseChainingCycle);
     TriggerReactions;
-    Exit;
-  end;
-
-  if AValue is TGocciaPromiseValue then
-  begin
-    Queue := TGocciaMicrotaskQueue.Instance;
-    if Assigned(Queue) then
-    begin
-      Task.Handler := nil;
-      Task.Value := AValue;
-      Task.ResultPromise := Self;
-      Task.ReactionType := prtThenableResolve;
-      Queue.Enqueue(Task);
-    end;
     Exit;
   end;
 
@@ -483,32 +718,34 @@ end;
 
 { Public helper — core then logic without TGocciaArgumentsCollection overhead }
 
-function TGocciaPromiseValue.InvokeThen(
-  const AOnFulfilled, AOnRejected: TGocciaValue): TGocciaPromiseValue;
+function PerformPromiseThen(const APromise: TGocciaPromiseValue;
+  const AOnFulfilled, AOnRejected: TGocciaValue;
+  const ACapability: TPromiseCapability): TGocciaValue;
 var
-  ChildPromise: TGocciaPromiseValue;
+  CapabilityHost: TGocciaPromiseReactionCapability;
   Reaction: TGocciaPromiseReaction;
   Task: TGocciaMicrotask;
   Queue: TGocciaMicrotaskQueue;
 begin
-  ChildPromise := TGocciaPromiseValue.Create;
+  CapabilityHost := TGocciaPromiseReactionCapability.Create(
+    ACapability.Promise, ACapability.Resolve, ACapability.Reject);
   Queue := TGocciaMicrotaskQueue.Instance;
 
-  case FState of
+  case APromise.FState of
     gpsPending:
     begin
       Reaction.OnFulfilled := AOnFulfilled;
       Reaction.OnRejected := AOnRejected;
-      Reaction.ResultPromise := ChildPromise;
-      if not Assigned(FReactions) then
-        FReactions := TList<TGocciaPromiseReaction>.Create;
-      FReactions.Add(Reaction);
+      Reaction.ResultPromise := CapabilityHost;
+      if not Assigned(APromise.FReactions) then
+        APromise.FReactions := TList<TGocciaPromiseReaction>.Create;
+      APromise.FReactions.Add(Reaction);
     end;
     gpsFulfilled:
     begin
       Task.Handler := AOnFulfilled;
-      Task.Value := FResult;
-      Task.ResultPromise := ChildPromise;
+      Task.Value := APromise.FResult;
+      Task.ResultPromise := CapabilityHost;
       Task.ReactionType := prtFulfill;
       if Assigned(Queue) then
         Queue.Enqueue(Task);
@@ -516,15 +753,31 @@ begin
     gpsRejected:
     begin
       Task.Handler := AOnRejected;
-      Task.Value := FResult;
-      Task.ResultPromise := ChildPromise;
+      Task.Value := APromise.FResult;
+      Task.ResultPromise := CapabilityHost;
       Task.ReactionType := prtReject;
       if Assigned(Queue) then
         Queue.Enqueue(Task);
     end;
   end;
 
-  Result := ChildPromise;
+  Result := ACapability.Promise;
+end;
+
+function TGocciaPromiseValue.InvokeThen(
+  const AOnFulfilled, AOnRejected: TGocciaValue): TGocciaPromiseValue;
+var
+  Capability: TPromiseCapability;
+  ChildPromise: TGocciaPromiseValue;
+begin
+  ChildPromise := TGocciaPromiseValue.Create;
+  Capability.Promise := ChildPromise;
+  Capability.Resolve := CreateAnonymousPromiseBuiltinFunction(
+    ChildPromise.DoResolve, ChildPromise, 1);
+  Capability.Reject := CreateAnonymousPromiseBuiltinFunction(
+    ChildPromise.DoReject, ChildPromise, 1);
+  Result := TGocciaPromiseValue(PerformPromiseThen(Self, AOnFulfilled,
+    AOnRejected, Capability));
 end;
 
 { Public helper — core finally logic without TGocciaArgumentsCollection overhead }
@@ -532,18 +785,22 @@ end;
 function TGocciaPromiseValue.InvokeFinally(
   const AOnFinally: TGocciaValue): TGocciaPromiseValue;
 var
+  ConstructorValue: TGocciaValue;
   WrapFulfilled, WrapRejected: TGocciaPromiseFinallyWrapper;
   WrapFulfilledFn, WrapRejectedFn: TGocciaNativeFunctionValue;
 begin
   if not Assigned(AOnFinally) or not AOnFinally.IsCallable then
     Exit(InvokeThen(nil, nil));
 
-  WrapFulfilled := TGocciaPromiseFinallyWrapper.Create(AOnFinally, True);
-  WrapRejected := TGocciaPromiseFinallyWrapper.Create(AOnFinally, False);
-  WrapFulfilledFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-    WrapFulfilled.Invoke, 'finally-fulfill', 1);
-  WrapRejectedFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-    WrapRejected.Invoke, 'finally-reject', 1);
+  ConstructorValue := PromiseSpeciesConstructor(Self);
+  WrapFulfilled := TGocciaPromiseFinallyWrapper.Create(AOnFinally,
+    ConstructorValue, True);
+  WrapRejected := TGocciaPromiseFinallyWrapper.Create(AOnFinally,
+    ConstructorValue, False);
+  WrapFulfilledFn := CreateAnonymousPromiseBuiltinFunction(
+    WrapFulfilled.Invoke, WrapFulfilled, 1);
+  WrapRejectedFn := CreateAnonymousPromiseBuiltinFunction(
+    WrapRejected.Invoke, WrapRejected, 1);
   Result := InvokeThen(WrapFulfilledFn, WrapRejectedFn);
 end;
 
@@ -554,11 +811,15 @@ function TGocciaPromiseValue.PromiseThen(const AArgs: TGocciaArgumentsCollection
 var
   P: TGocciaPromiseValue;
   OnFulfilled, OnRejected: TGocciaValue;
+  ConstructorValue: TGocciaValue;
+  Capability: TPromiseCapability;
 begin
   if not (AThisValue is TGocciaPromiseValue) then
     Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseThenNonPromise, SSuggestPromiseThisType);
 
   P := TGocciaPromiseValue(AThisValue);
+  ConstructorValue := PromiseSpeciesConstructor(P);
+  Capability := NewPromiseCapability(ConstructorValue);
 
   OnFulfilled := nil;
   OnRejected := nil;
@@ -567,7 +828,7 @@ begin
   if (AArgs.Length > 1) and AArgs.GetElement(1).IsCallable then
     OnRejected := AArgs.GetElement(1);
 
-  Result := P.InvokeThen(OnFulfilled, OnRejected);
+  Result := PerformPromiseThen(P, OnFulfilled, OnRejected, Capability);
 end;
 
 function TGocciaPromiseValue.PromiseCatch(const AArgs: TGocciaArgumentsCollection;
@@ -580,7 +841,8 @@ begin
     AArgs.GetElement(0)
   ]);
   try
-    Result := PromiseThen(ThenArgs, AThisValue);
+    Result := InvokeThenMethod(AThisValue, ThenArgs.GetElement(0),
+      ThenArgs.GetElement(1));
   finally
     ThenArgs.Free;
   end;
@@ -590,15 +852,33 @@ function TGocciaPromiseValue.PromiseFinally(const AArgs: TGocciaArgumentsCollect
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   OnFinally: TGocciaValue;
+  ConstructorValue: TGocciaValue;
+  ThenFinally, CatchFinally: TGocciaValue;
+  WrapFulfilled, WrapRejected: TGocciaPromiseFinallyWrapper;
 begin
-  if not (AThisValue is TGocciaPromiseValue) then
+  if not (AThisValue is TGocciaObjectValue) then
     Goccia.Values.ErrorHelper.ThrowTypeError(SErrorPromiseFinallyNonPromise, SSuggestPromiseThisType);
 
-  OnFinally := nil;
-  if (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable then
-    OnFinally := AArgs.GetElement(0);
+  ConstructorValue := PromiseSpeciesConstructor(TGocciaObjectValue(AThisValue));
+  OnFinally := AArgs.GetElement(0);
+  if Assigned(OnFinally) and OnFinally.IsCallable then
+  begin
+    WrapFulfilled := TGocciaPromiseFinallyWrapper.Create(OnFinally,
+      ConstructorValue, True);
+    WrapRejected := TGocciaPromiseFinallyWrapper.Create(OnFinally,
+      ConstructorValue, False);
+    ThenFinally := CreateAnonymousPromiseBuiltinFunction(
+      WrapFulfilled.Invoke, WrapFulfilled, 1);
+    CatchFinally := CreateAnonymousPromiseBuiltinFunction(
+      WrapRejected.Invoke, WrapRejected, 1);
+  end
+  else
+  begin
+    ThenFinally := OnFinally;
+    CatchFinally := OnFinally;
+  end;
 
-  Result := TGocciaPromiseValue(AThisValue).InvokeFinally(OnFinally);
+  Result := InvokeThenMethod(AThisValue, ThenFinally, CatchFinally);
 end;
 
 function TGocciaPromiseValue.GetProperty(const AName: string): TGocciaValue;

--- a/source/units/Goccia.Values.ProxyValue.pas
+++ b/source/units/Goccia.Values.ProxyValue.pas
@@ -160,7 +160,8 @@ uses
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
   Goccia.Values.ErrorHelper,
-  Goccia.Values.FunctionBase;
+  Goccia.Values.FunctionBase,
+  Goccia.Values.ToObject;
 
 { TGocciaProxyValue }
 
@@ -329,6 +330,8 @@ var
   I, J: Integer;
   OrderedCount: Integer;
   ResultArray: TGocciaArrayValue;
+  ResultObject: TGocciaObjectValue;
+  ResultLength: Integer;
   SymbolCount: Integer;
   SymbolElement: TGocciaSymbolValue;
   TargetDesc: TGocciaPropertyDescriptor;
@@ -376,19 +379,33 @@ begin
     Args.Free;
   end;
 
-  if not (TrapResult is TGocciaArrayValue) then
+  if not (TrapResult is TGocciaObjectValue) then
     ThrowTypeError(SErrorProxyOwnKeysArray, SSuggestProxyTrapReturnType);
 
-  ResultArray := TGocciaArrayValue(TrapResult);
-  SetLength(AStringKeys, ResultArray.Elements.Count);
-  SetLength(ASymbolKeys, ResultArray.Elements.Count);
-  SetLength(AOrderedKeys, ResultArray.Elements.Count);
+  ResultObject := TGocciaObjectValue(TrapResult);
+  if TrapResult is TGocciaArrayValue then
+  begin
+    ResultArray := TGocciaArrayValue(TrapResult);
+    ResultLength := ResultArray.Elements.Count;
+  end
+  else
+  begin
+    ResultArray := nil;
+    ResultLength := LengthOfArrayLike(ResultObject);
+  end;
+
+  SetLength(AStringKeys, ResultLength);
+  SetLength(ASymbolKeys, ResultLength);
+  SetLength(AOrderedKeys, ResultLength);
   Count := 0;
   SymbolCount := 0;
   OrderedCount := 0;
-  for I := 0 to ResultArray.Elements.Count - 1 do
+  for I := 0 to ResultLength - 1 do
   begin
-    Element := ResultArray.Elements[I];
+    if Assigned(ResultArray) then
+      Element := ResultArray.Elements[I]
+    else
+      Element := ResultObject.GetProperty(IntToStr(I));
     if not (Element is TGocciaStringLiteralValue) and
        not (Element is TGocciaSymbolValue) then
       ThrowTypeError(SErrorProxyOwnKeysTypes, SSuggestProxyTrapReturnType);
@@ -1888,5 +1905,33 @@ begin
   if Assigned(FRevoker) then
     FRevoker.MarkReferences;
 end;
+
+function IsProxyDispatchValue(const AValue: TGocciaValue): Boolean;
+begin
+  Result := AValue is TGocciaProxyValue;
+end;
+
+function DispatchProxyApply(const AProxy: TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaProxyValue(AProxy).ApplyTrap(AArguments, AThisValue);
+end;
+
+function DispatchProxyConstruct(const AProxy: TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaProxyValue(AProxy).ConstructTrap(AArguments, ANewTarget);
+end;
+
+function DispatchProxyGetPrototype(const AProxy: TGocciaObjectValue): TGocciaValue;
+begin
+  Result := TGocciaProxyValue(AProxy).GetPrototypeTrap;
+end;
+
+initialization
+  RegisterProxyDispatchHooks(IsProxyDispatchValue, DispatchProxyApply,
+    DispatchProxyConstruct, DispatchProxyGetPrototype);
 
 end.

--- a/source/units/Goccia.Values.ProxyValue.pas
+++ b/source/units/Goccia.Values.ProxyValue.pas
@@ -329,7 +329,6 @@ var
   Found: Boolean;
   I, J: Integer;
   OrderedCount: Integer;
-  ResultArray: TGocciaArrayValue;
   ResultObject: TGocciaObjectValue;
   ResultLength: Integer;
   SymbolCount: Integer;
@@ -383,16 +382,7 @@ begin
     ThrowTypeError(SErrorProxyOwnKeysArray, SSuggestProxyTrapReturnType);
 
   ResultObject := TGocciaObjectValue(TrapResult);
-  if TrapResult is TGocciaArrayValue then
-  begin
-    ResultArray := TGocciaArrayValue(TrapResult);
-    ResultLength := ResultArray.Elements.Count;
-  end
-  else
-  begin
-    ResultArray := nil;
-    ResultLength := LengthOfArrayLike(ResultObject);
-  end;
+  ResultLength := LengthOfArrayLike(ResultObject);
 
   SetLength(AStringKeys, ResultLength);
   SetLength(ASymbolKeys, ResultLength);
@@ -402,10 +392,7 @@ begin
   OrderedCount := 0;
   for I := 0 to ResultLength - 1 do
   begin
-    if Assigned(ResultArray) then
-      Element := ResultArray.Elements[I]
-    else
-      Element := ResultObject.GetProperty(IntToStr(I));
+    Element := ResultObject.GetProperty(IntToStr(I));
     if not (Element is TGocciaStringLiteralValue) and
        not (Element is TGocciaSymbolValue) then
       ThrowTypeError(SErrorProxyOwnKeysTypes, SSuggestProxyTrapReturnType);

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -237,6 +237,10 @@ begin
         SetSymbolIterator,
         0,
         [pfConfigurable, pfWritable]);
+      Members.AddSymbolDataProperty(
+        TGocciaSymbolValue.WellKnownToStringTag,
+        TGocciaStringLiteralValue.Create(CONSTRUCTOR_SET),
+        [pfConfigurable]);
       FPrototypeMembers := Members.ToDefinitions;
     finally
       Members.Free;

--- a/source/units/Goccia.Values.SharedArrayBufferValue.pas
+++ b/source/units/Goccia.Values.SharedArrayBufferValue.pas
@@ -17,13 +17,17 @@ uses
 type
   TGocciaSharedArrayBufferValue = class(TGocciaInstanceValue)
   private
+    const NO_MAX_BYTE_LENGTH = -1;
+  private
     FData: TBytes;
+    FMaxByteLength: Integer;
 
     function GetByteLength: Integer;
 
     procedure InitializePrototype;
   public
     constructor Create(const AByteLength: Integer = 0); overload;
+    constructor Create(const AByteLength: Integer; const AMaxByteLength: Integer); overload;
     constructor Create(const AClass: TGocciaClassValue); overload;
 
     function GetProperty(const AName: string): TGocciaValue; override;
@@ -36,10 +40,14 @@ type
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
 
     property Data: TBytes read FData write FData;
+    property MaxByteLength: Integer read FMaxByteLength;
   published
     property ByteLength: Integer read GetByteLength;
     function SharedArrayBufferSlice(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function SharedArrayBufferGrow(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function SharedArrayBufferByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function SharedArrayBufferMaxByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function SharedArrayBufferGrowableGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
 implementation
@@ -71,6 +79,32 @@ begin
     Result := nil;
 end;
 
+function ToSharedArrayBufferIndex(const AValue: TGocciaValue): Integer;
+var
+  IntegerIndex: Double;
+  Num: TGocciaNumberLiteralValue;
+begin
+  if (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue) then
+    Exit(0);
+
+  Num := AValue.ToNumberLiteral;
+  if Num.IsNaN then
+    IntegerIndex := 0
+  else if Num.IsInfinite then
+  begin
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+    Exit(0);
+  end
+  else
+    IntegerIndex := Trunc(Num.Value);
+
+  if (IntegerIndex < 0) or (IntegerIndex > MAX_SAFE_INTEGER_F) or
+     (IntegerIndex > High(Integer)) then
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+
+  Result := Trunc(IntegerIndex);
+end;
+
 function TGocciaSharedArrayBufferValue.GetByteLength: Integer;
 begin
   Result := Length(FData);
@@ -81,6 +115,29 @@ var
   Shared: TGocciaSharedPrototype;
 begin
   inherited Create(nil);
+  FMaxByteLength := NO_MAX_BYTE_LENGTH;
+  SetLength(FData, AByteLength);
+  if AByteLength > 0 then
+    FillChar(FData[0], AByteLength, 0);
+  InitializePrototype;
+  Shared := GetSharedArrayBufferShared;
+  if Assigned(Shared) then
+    FPrototype := Shared.Prototype;
+end;
+
+constructor TGocciaSharedArrayBufferValue.Create(const AByteLength: Integer; const AMaxByteLength: Integer);
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  inherited Create(nil);
+  if AMaxByteLength >= 0 then
+  begin
+    if AByteLength > AMaxByteLength then
+      ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+    FMaxByteLength := AMaxByteLength;
+  end
+  else
+    FMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, AByteLength);
   if AByteLength > 0 then
     FillChar(FData[0], AByteLength, 0);
@@ -95,6 +152,7 @@ var
   Shared: TGocciaSharedPrototype;
 begin
   inherited Create(AClass);
+  FMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, 0);
   InitializePrototype;
   Shared := GetSharedArrayBufferShared;
@@ -117,8 +175,11 @@ begin
     Members := TGocciaMemberCollection.Create;
     try
       Members.AddMethod(SharedArrayBufferSlice, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+      Members.AddMethod(SharedArrayBufferGrow, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
       Members.AddPublishedGetter(
         TGocciaSharedArrayBufferValue, 'ByteLength', PROP_BYTE_LENGTH, [pfConfigurable]);
+      Members.AddAccessor(PROP_MAX_BYTE_LENGTH, SharedArrayBufferMaxByteLengthGetter, nil, [pfConfigurable]);
+      Members.AddAccessor(PROP_GROWABLE, SharedArrayBufferGrowableGetter, nil, [pfConfigurable]);
       Members.AddSymbolDataProperty(
         TGocciaSymbolValue.WellKnownToStringTag,
         TGocciaStringLiteralValue.Create(CONSTRUCTOR_SHARED_ARRAY_BUFFER),
@@ -148,47 +209,39 @@ end;
 // ES2026 §25.2.3.1 SharedArrayBuffer(length [, options])
 procedure TGocciaSharedArrayBufferValue.InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
 var
-  LengthArg: TGocciaValue;
-  Num: TGocciaNumberLiteralValue;
-  IntegerIndex: Double;
   Len: Integer;
+  MaxByteLengthValue: TGocciaValue;
+  OptionsArg: TGocciaValue;
+  RequestedMaxByteLength: Integer;
 begin
-  // ES2026 §6.2.4.2 ToIndex(value)
-  // Step 1: If value is undefined, let integerIndex be 0
   if AArguments.Length = 0 then
+    Len := 0
+  else
+    Len := ToSharedArrayBufferIndex(AArguments.GetElement(0));
+
+  RequestedMaxByteLength := NO_MAX_BYTE_LENGTH;
+  if AArguments.Length > 1 then
   begin
-    SetLength(FData, 0);
-    Exit;
+    OptionsArg := AArguments.GetElement(1);
+    if not (OptionsArg is TGocciaUndefinedLiteralValue) and
+       not OptionsArg.IsPrimitive then
+    begin
+      MaxByteLengthValue := OptionsArg.GetProperty(PROP_MAX_BYTE_LENGTH);
+      if Assigned(MaxByteLengthValue) and
+         not (MaxByteLengthValue is TGocciaUndefinedLiteralValue) then
+        RequestedMaxByteLength := ToSharedArrayBufferIndex(MaxByteLengthValue);
+    end;
   end;
 
-  LengthArg := AArguments.GetElement(0);
-  if LengthArg is TGocciaUndefinedLiteralValue then
+  if RequestedMaxByteLength >= 0 then
   begin
-    SetLength(FData, 0);
-    Exit;
-  end;
-
-  // Step 2: Let integerIndex be ToIntegerOrInfinity(value) (ES2026 §7.1.5)
-  Num := LengthArg.ToNumberLiteral;
-  if Num.IsNaN then
-    IntegerIndex := 0
-  else if Num.IsInfinite then
-  begin
-    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
-    Exit;
+    if Len > RequestedMaxByteLength then
+      ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+    FMaxByteLength := RequestedMaxByteLength;
   end
   else
-    IntegerIndex := Trunc(Num.Value);
+    FMaxByteLength := NO_MAX_BYTE_LENGTH;
 
-  // Step 3: If integerIndex is not in [0, 2^53-1], throw RangeError.  Also
-  // reject anything above High(Integer): FData is a 32-bit-indexed dynamic
-  // array, so values in (High(Integer), 2^53-1] would silently overflow on
-  // truncation.  Mirrors the extra check in TGocciaArrayBufferValue.ToIndex.
-  if (IntegerIndex < 0) or (IntegerIndex > MAX_SAFE_INTEGER_F) or
-     (IntegerIndex > High(Integer)) then
-    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
-
-  Len := Trunc(IntegerIndex);
   SetLength(FData, Len);
   if Len > 0 then
     FillChar(FData[0], Len, 0);
@@ -209,6 +262,20 @@ function TGocciaSharedArrayBufferValue.GetPropertyWithContext(const AName: strin
 begin
   if AName = PROP_BYTE_LENGTH then
     Result := TGocciaNumberLiteralValue.Create(Length(FData))
+  else if AName = PROP_MAX_BYTE_LENGTH then
+  begin
+    if FMaxByteLength >= 0 then
+      Result := TGocciaNumberLiteralValue.Create(FMaxByteLength)
+    else
+      Result := TGocciaNumberLiteralValue.Create(Length(FData));
+  end
+  else if AName = PROP_GROWABLE then
+  begin
+    if FMaxByteLength >= 0 then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+  end
   else
     Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
@@ -226,6 +293,72 @@ begin
       ['SharedArrayBuffer.prototype.byteLength']),
       SSuggestSharedArrayBufferThisType);
   Result := TGocciaNumberLiteralValue.Create(Length(TGocciaSharedArrayBufferValue(AThisValue).FData));
+end;
+
+function TGocciaSharedArrayBufferValue.SharedArrayBufferMaxByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaSharedArrayBufferValue;
+begin
+  if not (AThisValue is TGocciaSharedArrayBufferValue) then
+    ThrowTypeError(Format(SErrorRequiresSharedArrayBuffer,
+      ['SharedArrayBuffer.prototype.maxByteLength']),
+      SSuggestSharedArrayBufferThisType);
+  Buf := TGocciaSharedArrayBufferValue(AThisValue);
+  if Buf.FMaxByteLength >= 0 then
+    Result := TGocciaNumberLiteralValue.Create(Buf.FMaxByteLength)
+  else
+    Result := TGocciaNumberLiteralValue.Create(Length(Buf.FData));
+end;
+
+function TGocciaSharedArrayBufferValue.SharedArrayBufferGrowableGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaSharedArrayBufferValue) then
+    ThrowTypeError(Format(SErrorRequiresSharedArrayBuffer,
+      ['SharedArrayBuffer.prototype.growable']),
+      SSuggestSharedArrayBufferThisType);
+  if TGocciaSharedArrayBufferValue(AThisValue).FMaxByteLength >= 0 then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+function TGocciaSharedArrayBufferValue.SharedArrayBufferGrow(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaSharedArrayBufferValue;
+  CopyLength: Integer;
+  NewByteLength: Integer;
+  NewData: TBytes;
+  OldByteLength: Integer;
+begin
+  if not (AThisValue is TGocciaSharedArrayBufferValue) then
+    ThrowTypeError(Format(SErrorRequiresSharedArrayBuffer,
+      ['SharedArrayBuffer.prototype.grow']),
+      SSuggestSharedArrayBufferThisType);
+
+  Buf := TGocciaSharedArrayBufferValue(AThisValue);
+  if AArgs.Length = 0 then
+    NewByteLength := 0
+  else
+    NewByteLength := ToSharedArrayBufferIndex(AArgs.GetElement(0));
+
+  if Buf.FMaxByteLength < 0 then
+    ThrowTypeError('Cannot grow a fixed-length SharedArrayBuffer',
+      SSuggestArrayLengthRange);
+
+  OldByteLength := Length(Buf.FData);
+  if NewByteLength < OldByteLength then
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+  if NewByteLength > Buf.FMaxByteLength then
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+
+  CopyLength := Min(OldByteLength, NewByteLength);
+  SetLength(NewData, NewByteLength);
+  if NewByteLength > 0 then
+    FillChar(NewData[0], NewByteLength, 0);
+  if CopyLength > 0 then
+    Move(Buf.FData[0], NewData[0], CopyLength);
+  Buf.FData := NewData;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 // ES2026 §25.2.5.6 SharedArrayBuffer.prototype.slice(start, end)

--- a/source/units/Goccia.Values.SharedArrayBufferValue.pas
+++ b/source/units/Goccia.Values.SharedArrayBufferValue.pas
@@ -260,6 +260,9 @@ end;
 
 function TGocciaSharedArrayBufferValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 begin
+  if (AName = PROP_MAX_BYTE_LENGTH) and HasOwnProperty(AName) then
+    Exit(inherited GetPropertyWithContext(AName, AThisContext));
+
   if AName = PROP_BYTE_LENGTH then
     Result := TGocciaNumberLiteralValue.Create(Length(FData))
   else if AName = PROP_MAX_BYTE_LENGTH then

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -469,22 +469,59 @@ begin
 end;
 
 // ES2026 §10.4.3.6 StringExoticObject [[OwnPropertyKeys]] (all own string keys)
-// Indices first, then 'length', then any expando own properties.
+// String indices first, then other numeric own keys, then 'length', then other
+// expando own properties.
 function TGocciaStringObjectValue.GetAllPropertyNames: TArray<string>;
 var
   StringValue: string;
   InheritedNames: TArray<string>;
-  I: Integer;
+  NumericNames, OtherNames: TArray<string>;
+  I, Index, LengthValue, NumericCount, OtherCount, ResultIndex: Integer;
 begin
   StringValue := FPrimitive.ToStringLiteral.Value;
+  LengthValue := UTF16CodeUnitLength(StringValue);
   InheritedNames := inherited GetAllPropertyNames;
-  SetLength(Result, UTF16CodeUnitLength(StringValue) + 1 +
-    Length(InheritedNames));
-  for I := 0 to UTF16CodeUnitLength(StringValue) - 1 do
-    Result[I] := IntToStr(I);
-  Result[UTF16CodeUnitLength(StringValue)] := PROP_LENGTH;
+
+  SetLength(NumericNames, Length(InheritedNames));
+  SetLength(OtherNames, Length(InheritedNames));
+  NumericCount := 0;
+  OtherCount := 0;
   for I := 0 to High(InheritedNames) do
-    Result[UTF16CodeUnitLength(StringValue) + 1 + I] := InheritedNames[I];
+  begin
+    if InheritedNames[I] = PROP_LENGTH then
+      Continue;
+    if TryStrToInt(InheritedNames[I], Index) and
+       (InheritedNames[I] = IntToStr(Index)) and (Index >= LengthValue) then
+    begin
+      NumericNames[NumericCount] := InheritedNames[I];
+      Inc(NumericCount);
+    end
+    else
+    begin
+      OtherNames[OtherCount] := InheritedNames[I];
+      Inc(OtherCount);
+    end;
+  end;
+
+  SetLength(Result, LengthValue + NumericCount + 1 + OtherCount);
+  ResultIndex := 0;
+  for I := 0 to LengthValue - 1 do
+  begin
+    Result[ResultIndex] := IntToStr(I);
+    Inc(ResultIndex);
+  end;
+  for I := 0 to NumericCount - 1 do
+  begin
+    Result[ResultIndex] := NumericNames[I];
+    Inc(ResultIndex);
+  end;
+  Result[ResultIndex] := PROP_LENGTH;
+  Inc(ResultIndex);
+  for I := 0 to OtherCount - 1 do
+  begin
+    Result[ResultIndex] := OtherNames[I];
+    Inc(ResultIndex);
+  end;
 end;
 
 // ES2026 §10.4.3.1 StringExoticObject [[GetOwnProperty]](P)
@@ -531,8 +568,8 @@ begin
   if TryStrToInt(AName, Index) and (AName = IntToStr(Index)) then
   begin
     StringValue := FPrimitive.ToStringLiteral.Value;
-    Result := (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue));
-    Exit;
+    if (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue)) then
+      Exit(True);
   end;
   if AName = PROP_LENGTH then
   begin

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -1637,6 +1637,37 @@ begin
     ThrowTypeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
 end;
 
+function DurationExactTimeZonedEndOutOfRange(const D: TGocciaTemporalDurationValue;
+  const ARelativeTo: TGocciaValue; const AMethod: string): Boolean;
+var
+  EndEpochNanoseconds: TBigInteger;
+  StartEpochNanoseconds: TBigInteger;
+  TotalNanoseconds: TBigInteger;
+  ZonedDateTime: TGocciaTemporalZonedDateTimeValue;
+begin
+  Result := False;
+  if not D.FYearsBig.IsZero or not D.FMonthsBig.IsZero or
+     not D.FWeeksBig.IsZero or not D.FDaysBig.IsZero then
+    Exit;
+
+  TotalNanoseconds := DurationTotalNanosecondsBig(D);
+  if TotalNanoseconds.IsZero then
+    Exit;
+
+  if ARelativeTo is TGocciaTemporalZonedDateTimeValue then
+    ZonedDateTime := TGocciaTemporalZonedDateTimeValue(ARelativeTo)
+  else if (ARelativeTo is TGocciaStringLiteralValue) and
+          (System.Pos('[', TGocciaStringLiteralValue(ARelativeTo).Value) > 0) then
+    ZonedDateTime := CoerceTemporalZonedDateTime(ARelativeTo, AMethod)
+  else
+    Exit;
+
+  StartEpochNanoseconds := EpochNanosecondsFromParts(
+    ZonedDateTime.EpochMilliseconds, ZonedDateTime.SubMillisecondNanoseconds);
+  EndEpochNanoseconds := StartEpochNanoseconds.Add(TotalNanoseconds);
+  Result := not IsValidEpochNanoseconds(EndEpochNanoseconds);
+end;
+
 // Add AMonths calendar months to a date, clamping the day if needed.
 function AddMonthsToDate(const ADate: TTemporalDateRecord; const AMonths: Int64): TTemporalDateRecord;
 var
@@ -1660,6 +1691,36 @@ begin
   Result.Year := Integer(Y);
   Result.Month := M;
   Result.Day := D;
+end;
+
+// TC39 Temporal §7.5.33 ComputeNudgeWindow(sign, duration, originEpochNs, isoDateTime, timeZone, calendar, increment, unit, additionalShift)
+procedure ValidateZonedRelativeToTotalCalendarWindow(
+  const ADuration: TGocciaTemporalDurationValue;
+  const ARelDate: TTemporalDateRecord; const ATargetUnit: TTemporalUnit);
+const
+  MONTHS_PER_YEAR = 12;
+var
+  Sign: Integer;
+  CalendarStepMonths: Int64;
+  WindowDate: TTemporalDateRecord;
+begin
+  Sign := ADuration.ComputeSign;
+  if Sign = 0 then
+    Exit;
+
+  case ATargetUnit of
+    tuYear:
+      CalendarStepMonths := MONTHS_PER_YEAR;
+    tuMonth:
+      CalendarStepMonths := 1;
+  else
+    Exit;
+  end;
+
+  WindowDate := AddMonthsToDate(ARelDate, CalendarStepMonths * Sign);
+  if not DurationDateInTemporalRange(WindowDate) then
+    ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, ['Duration.prototype.total']),
+      SSuggestTemporalRelativeTo);
 end;
 
 // Compute the end date of a duration applied from a reference date using
@@ -1793,6 +1854,7 @@ var
   Arg, RelToArg: TGocciaValue;
   OptionsObj: TGocciaObjectValue;
   HasRelativeTo: Boolean;
+  HasZonedRelativeTo: Boolean;
   RelDate: TTemporalDateRecord;
   ResolvedDays: Int64;
   TotalNsBig: TBigInteger;
@@ -1801,6 +1863,7 @@ begin
   D := AsDuration(AThisValue, 'Duration.prototype.total');
   Arg := AArgs.GetElement(0);
   HasRelativeTo := False;
+  HasZonedRelativeTo := False;
 
   if Arg is TGocciaStringLiteralValue then
     UnitStr := TGocciaStringLiteralValue(Arg).Value
@@ -1815,6 +1878,8 @@ begin
 
     RelToArg := OptionsObj.GetProperty('relativeTo');
     HasRelativeTo := (RelToArg <> nil) and not (RelToArg is TGocciaUndefinedLiteralValue);
+    if HasRelativeTo then
+      HasZonedRelativeTo := IsDurationZonedRelativeToValue(RelToArg);
   end
   else
   begin
@@ -1835,7 +1900,13 @@ begin
   begin
     if not HasRelativeTo then
       ThrowRangeError(SErrorDurationTotalRequiresRelativeTo, SSuggestTemporalRelativeTo);
+    if DurationExactTimeZonedEndOutOfRange(D, RelToArg,
+      'Duration.prototype.total') then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo,
+        ['Duration.prototype.total']), SSuggestTemporalRelativeTo);
     RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.total');
+    if HasZonedRelativeTo then
+      ValidateZonedRelativeToTotalCalendarWindow(D, RelDate, TargetUnit);
     if TargetUnit = tuMonth then
       Result := TotalInMonths(D, RelDate)
     else

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -126,12 +126,16 @@ uses
   Goccia.Realm,
   Goccia.Temporal.DurationMath,
   Goccia.Temporal.Options,
+  Goccia.Temporal.TimeZone,
   Goccia.Temporal.Utils,
   Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue,
   Goccia.Values.TemporalPlainDate,
+  Goccia.Values.TemporalPlainDateTime,
+  Goccia.Values.TemporalPlainMonthDay,
+  Goccia.Values.TemporalPlainYearMonth,
   Goccia.Values.TemporalZonedDateTime;
 
 var
@@ -270,6 +274,22 @@ begin
   if not D.FMicrosecondsBig.IsZero then Exit(tuMicrosecond);
   Result := tuNanosecond;
 end;
+
+function IsDurationCalendarUnit(const AUnit: TTemporalUnit): Boolean; inline;
+begin
+  Result := AUnit in [tuYear, tuMonth, tuWeek];
+end;
+
+function IsDurationDateUnit(const AUnit: TTemporalUnit): Boolean; inline;
+begin
+  Result := AUnit in [tuYear, tuMonth, tuWeek, tuDay];
+end;
+
+function DurationDateBefore(const AY, AM, AD, ABY, ABM, ABD: Integer): Boolean; forward;
+function DurationDateInTemporalRange(const ADate: TTemporalDateRecord): Boolean; forward;
+function DurationDateAtLowerZonedLimit(const ADate: TTemporalDateRecord): Boolean; forward;
+function DurationDateAtUpperLimit(const ADate: TTemporalDateRecord): Boolean; forward;
+function IsDurationZonedRelativeToValue(const AValue: TGocciaValue): Boolean; forward;
 
 // TC39 Temporal §7.5.26 TemporalDurationFromInternal step 12: each balanced
 // component is converted to a float64 Number before CreateTemporalDuration,
@@ -800,10 +820,10 @@ var
   D: TGocciaTemporalDurationValue;
   Arg, RelToArg: TGocciaValue;
   OptionsObj: TGocciaObjectValue;
-  SmallestUnit, LargestUnit: TTemporalUnit;
+  SmallestUnit, LargestUnit, ExistingLargestUnit, DefaultLargestUnit: TTemporalUnit;
   Mode: TTemporalRoundingMode;
   Increment: Integer;
-  HasRelativeTo: Boolean;
+  HasRelativeTo, HasZonedRelativeTo: Boolean;
   RelDate: TTemporalDateRecord;
   TotalNsBig, DivisorBig, TimeNsBig, CarryDaysBig: TBigInteger;
   ResultHoursBig, ResultMinutesBig, ResultSecondsBig: TBigInteger;
@@ -829,6 +849,7 @@ begin
   Mode := rmHalfExpand;
   Increment := 1;
   HasRelativeTo := False;
+  HasZonedRelativeTo := False;
 
   if Arg is TGocciaStringLiteralValue then
   begin
@@ -838,17 +859,17 @@ begin
   else if Arg is TGocciaObjectValue then
   begin
     OptionsObj := TGocciaObjectValue(Arg);
-    SmallestUnit := GetSmallestUnit(OptionsObj, tuNone);
     LargestUnit := GetLargestUnit(OptionsObj, tuNone);
-    Mode := GetRoundingMode(OptionsObj, rmHalfExpand);
-    Increment := GetRoundingIncrement(OptionsObj, 1);
-
     RelToArg := OptionsObj.GetProperty('relativeTo');
     if (RelToArg <> nil) and not (RelToArg is TGocciaUndefinedLiteralValue) then
     begin
+      HasZonedRelativeTo := IsDurationZonedRelativeToValue(RelToArg);
       RelDate := ParseRelativeTo(RelToArg, 'Duration.prototype.round');
       HasRelativeTo := True;
     end;
+    Increment := GetRoundingIncrement(OptionsObj, 1);
+    Mode := GetRoundingMode(OptionsObj, rmHalfExpand);
+    SmallestUnit := GetSmallestUnit(OptionsObj, tuNone);
   end
   else
     ThrowTypeError(Format(SErrorTemporalRoundRequiresStringOrOptions, ['Duration']), SSuggestTemporalRoundArg);
@@ -858,31 +879,60 @@ begin
     ThrowRangeError(SErrorDurationRoundRequiresUnit, SSuggestTemporalRoundArg);
   if SmallestUnit = tuNone then
     SmallestUnit := tuNanosecond;
-  if LargestUnit = tuNone then
+  if SmallestUnit = tuAuto then
+    ThrowRangeError(Format(SErrorTemporalInvalidUnitFor, ['Duration.prototype.round', 'smallestUnit']),
+      SSuggestTemporalValidUnits);
+
+  ExistingLargestUnit := DurationDefaultLargestUnit(D);
+  DefaultLargestUnit := ExistingLargestUnit;
+  if Ord(SmallestUnit) < Ord(DefaultLargestUnit) then
+    DefaultLargestUnit := SmallestUnit;
+  if (LargestUnit = tuNone) or (LargestUnit = tuAuto) then
   begin
-    if not D.FYearsBig.IsZero then LargestUnit := tuYear
-    else if not D.FMonthsBig.IsZero then LargestUnit := tuMonth
-    else if not D.FWeeksBig.IsZero then LargestUnit := tuWeek
-    else if not D.FDaysBig.IsZero then LargestUnit := tuDay
-    else if not D.FHoursBig.IsZero then LargestUnit := tuHour
-    else if not D.FMinutesBig.IsZero then LargestUnit := tuMinute
-    else if not D.FSecondsBig.IsZero then LargestUnit := tuSecond
-    else if not D.FMillisecondsBig.IsZero then LargestUnit := tuMillisecond
-    else if not D.FMicrosecondsBig.IsZero then LargestUnit := tuMicrosecond
-    else LargestUnit := SmallestUnit;
-    if Ord(LargestUnit) > Ord(SmallestUnit) then
-      LargestUnit := SmallestUnit;
+    LargestUnit := DefaultLargestUnit;
   end;
 
   if Ord(LargestUnit) > Ord(SmallestUnit) then
     ThrowRangeError(SErrorDurationRoundLargestSmallerThanSmallest, SSuggestTemporalRoundArg);
+  ValidateRoundingIncrement(Increment, SmallestUnit, LargestUnit);
+  if (Increment > 1) and (LargestUnit <> SmallestUnit) and IsDurationDateUnit(SmallestUnit) then
+    ThrowRangeError('roundingIncrement must be 1 when rounding a calendar unit into a larger unit',
+      SSuggestTemporalRoundArg);
 
   // Determine if calendar-relative computation is needed
-  NeedCalendar := (not D.FYearsBig.IsZero) or (not D.FMonthsBig.IsZero) or
-    (Ord(SmallestUnit) <= Ord(tuMonth)) or (Ord(LargestUnit) <= Ord(tuMonth));
+  NeedCalendar := IsDurationCalendarUnit(ExistingLargestUnit) or
+    IsDurationCalendarUnit(SmallestUnit) or IsDurationCalendarUnit(LargestUnit);
 
   if NeedCalendar and not HasRelativeTo then
     ThrowRangeError(SErrorDurationRoundRequiresRelativeTo, SSuggestTemporalRelativeTo);
+
+  if HasZonedRelativeTo then
+  begin
+    Sign := D.ComputeSign;
+    if ((Sign > 0) and DurationDateAtUpperLimit(RelDate)) or
+       ((Sign < 0) and DurationDateAtLowerZonedLimit(RelDate)) or
+       ((Sign = 0) and DurationDateAtUpperLimit(RelDate) and
+        ((LargestUnit = tuDay) or (SmallestUnit = tuDay))) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, ['Duration.prototype.round']),
+        SSuggestTemporalRelativeTo);
+    if D.FYearsBig.IsZero and D.FMonthsBig.IsZero and D.FWeeksBig.IsZero and
+       D.FDaysBig.IsZero then
+    begin
+      TotalNsBig := DurationTotalNanosecondsBig(D);
+      if TotalNsBig.AbsValue.Compare(
+        TBigInteger.FromDecimalString('8640000000000000000000')) > 0 then
+        ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, ['Duration.prototype.round']),
+          SSuggestTemporalRelativeTo);
+    end;
+  end;
+  if HasRelativeTo and not HasZonedRelativeTo then
+  begin
+    Sign := D.ComputeSign;
+    if (Sign > 0) and DurationDateBefore(RelDate.Year, RelDate.Month,
+      RelDate.Day, -271821, 4, 20) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, ['Duration.prototype.round']),
+        SSuggestTemporalRelativeTo);
+  end;
 
   // --- Calendar-relative path ---
   if NeedCalendar then
@@ -909,6 +959,9 @@ begin
     if not D.FMonthsBig.IsZero then
       IntermDate := AddMonthsToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
         CalendarMonths);
+    if not DurationDateInTemporalRange(IntermDate) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, ['Duration.prototype.round']),
+        SSuggestTemporalRelativeTo);
     TimeNsBig := DurationSubDayNanosecondsBig(D);
     CarryDaysBig := TimeNsBig.Divide(BigIntUnit(NANOSECONDS_PER_DAY));
     TimeNsBig := TimeNsBig.Modulo(BigIntUnit(NANOSECONDS_PER_DAY));
@@ -917,6 +970,9 @@ begin
 
     EndDate := AddDaysToDate(IntermDate.Year, IntermDate.Month, IntermDate.Day,
       CalendarWeeks * 7 + CalendarDays + CarryDays);
+    if not DurationDateInTemporalRange(EndDate) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, ['Duration.prototype.round']),
+        SSuggestTemporalRelativeTo);
     StartEpoch := DateToEpochDays(RelDate.Year, RelDate.Month, RelDate.Day);
     EndEpoch := DateToEpochDays(EndDate.Year, EndDate.Month, EndDate.Day);
 
@@ -962,8 +1018,8 @@ begin
         NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
         PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
         RoundedValue := RoundWithMode(
-          Abs((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs), PeriodNs, Mode);
-        if RoundedValue >= PeriodNs then
+          (EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs, PeriodNs, Mode);
+        if Abs(RoundedValue) >= PeriodNs then
           WholeUnits := ScaledValue + Sign * Increment
         else
           WholeUnits := ScaledValue;
@@ -1007,8 +1063,8 @@ begin
         NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
         PeriodNs := Abs(NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
         RoundedValue := RoundWithMode(
-          Abs((EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs), PeriodNs, Mode);
-        if RoundedValue >= PeriodNs then
+          (EndEpoch - WalkEpoch) * NANOSECONDS_PER_DAY + TimeNs, PeriodNs, Mode);
+        if Abs(RoundedValue) >= PeriodNs then
           WholeUnits := ScaledValue + Sign * Increment
         else
           WholeUnits := ScaledValue;
@@ -1034,28 +1090,16 @@ begin
       .Multiply(BigIntUnit(NANOSECONDS_PER_DAY))
       .Add(BigIntUnit(TimeNs));
 
-    if SmallestUnit <> tuNanosecond then
-    begin
-      DivisorBig := RoundingDivisorBig(SmallestUnit, Increment);
-      TotalNsBig := RoundTimeDurationToIncrement(TotalNsBig, DivisorBig, Mode);
-    end;
-
     // --- Rebalance to year/month if needed ---
     if Ord(LargestUnit) <= Ord(tuMonth) then
     begin
-      ResultDays := BigIntToCheckedInt64(
-        TotalNsBig.Divide(BigIntUnit(NANOSECONDS_PER_DAY)), 'days');
-      RemNs := BigIntToCheckedInt64(
-        TotalNsBig.Modulo(BigIntUnit(NANOSECONDS_PER_DAY)), 'sub-day nanoseconds');
-
-      EndEpoch := StartEpoch + ResultDays;
       WholeUnits := 0;
       if Sign > 0 then
       begin
         repeat
           NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits + 1);
           NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
-          if NextEpoch > EndEpoch then Break;
+          if (NextEpoch > EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs < 0)) then Break;
           Inc(WholeUnits);
         until False;
       end
@@ -1064,14 +1108,53 @@ begin
         repeat
           NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits - 1);
           NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
-          if NextEpoch < EndEpoch then Break;
+          if (NextEpoch < EndEpoch) or ((NextEpoch = EndEpoch) and (TimeNs > 0)) then Break;
           Dec(WholeUnits);
         until False;
       end;
 
       WalkDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits);
       WalkEpoch := DateToEpochDays(WalkDate.Year, WalkDate.Month, WalkDate.Day);
-      ResultDays := EndEpoch - WalkEpoch;
+      TotalNsBig := BigIntUnit(EndEpoch - WalkEpoch)
+        .Multiply(BigIntUnit(NANOSECONDS_PER_DAY))
+        .Add(BigIntUnit(TimeNs));
+
+      if (SmallestUnit <> tuNanosecond) or (Increment <> 1) then
+      begin
+        DivisorBig := RoundingDivisorBig(SmallestUnit, Increment);
+        TotalNsBig := RoundTimeDurationToIncrement(TotalNsBig, DivisorBig, Mode);
+      end;
+
+      RemNs := BigIntToCheckedInt64(TotalNsBig, 'calendar remainder nanoseconds');
+      if Sign > 0 then
+      begin
+        repeat
+          NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits + 1);
+          NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+          PeriodNs := (NextEpoch - WalkEpoch) * NANOSECONDS_PER_DAY;
+          if RemNs < PeriodNs then Break;
+          Inc(WholeUnits);
+          Dec(RemNs, PeriodNs);
+          WalkDate := NextDate;
+          WalkEpoch := NextEpoch;
+        until False;
+      end
+      else
+      begin
+        repeat
+          NextDate := AddMonthsToDate(RelDate.Year, RelDate.Month, RelDate.Day, WholeUnits - 1);
+          NextEpoch := DateToEpochDays(NextDate.Year, NextDate.Month, NextDate.Day);
+          PeriodNs := (WalkEpoch - NextEpoch) * NANOSECONDS_PER_DAY;
+          if RemNs > -PeriodNs then Break;
+          Dec(WholeUnits);
+          Inc(RemNs, PeriodNs);
+          WalkDate := NextDate;
+          WalkEpoch := NextEpoch;
+        until False;
+      end;
+
+      ResultDays := RemNs div NANOSECONDS_PER_DAY;
+      RemNs := RemNs mod NANOSECONDS_PER_DAY;
 
       if Ord(LargestUnit) <= Ord(tuYear) then
       begin
@@ -1095,7 +1178,7 @@ begin
       ResultUs := RemNs div NANOSECONDS_PER_MICROSECOND;
       ResultNs := RemNs mod NANOSECONDS_PER_MICROSECOND;
 
-      if Ord(LargestUnit) <= Ord(tuWeek) then
+      if (LargestUnit = tuWeek) or (SmallestUnit = tuWeek) then
         Result := TGocciaTemporalDurationValue.Create(ResultYears, ResultMonths,
           ResultDays div 7, ResultDays mod 7,
           ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs)
@@ -1104,13 +1187,47 @@ begin
           ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs);
       Exit;
     end;
+
+    if (SmallestUnit <> tuNanosecond) or (Increment <> 1) then
+    begin
+      DivisorBig := RoundingDivisorBig(SmallestUnit, Increment);
+      TotalNsBig := RoundTimeDurationToIncrement(TotalNsBig, DivisorBig, Mode);
+    end;
     // Fall through to non-calendar breakdown below
   end
   else
   begin
+    if HasZonedRelativeTo and D.FYearsBig.IsZero and D.FMonthsBig.IsZero and
+       D.FWeeksBig.IsZero and not D.FDaysBig.IsZero and (LargestUnit = tuDay) and
+       (SmallestUnit in [tuHour, tuMinute, tuSecond, tuMillisecond,
+        tuMicrosecond, tuNanosecond]) then
+    begin
+      TimeNsBig := DurationSubDayNanosecondsBig(D);
+      if (SmallestUnit <> tuNanosecond) or (Increment <> 1) then
+      begin
+        DivisorBig := RoundingDivisorBig(SmallestUnit, Increment);
+        TimeNsBig := RoundTimeDurationToIncrement(TimeNsBig, DivisorBig, Mode);
+      end;
+      RemNs := BigIntToCheckedInt64(TimeNsBig, 'sub-day nanoseconds');
+      ResultDays := BigIntToCheckedInt64(D.FDaysBig, 'days');
+      ResultHours := RemNs div NANOSECONDS_PER_HOUR;
+      RemNs := RemNs mod NANOSECONDS_PER_HOUR;
+      ResultMinutes := RemNs div NANOSECONDS_PER_MINUTE;
+      RemNs := RemNs mod NANOSECONDS_PER_MINUTE;
+      ResultSeconds := RemNs div NANOSECONDS_PER_SECOND;
+      RemNs := RemNs mod NANOSECONDS_PER_SECOND;
+      ResultMs := RemNs div NANOSECONDS_PER_MILLISECOND;
+      RemNs := RemNs mod NANOSECONDS_PER_MILLISECOND;
+      ResultUs := RemNs div NANOSECONDS_PER_MICROSECOND;
+      ResultNs := RemNs mod NANOSECONDS_PER_MICROSECOND;
+      Result := TGocciaTemporalDurationValue.Create(0, 0, 0, ResultDays,
+        ResultHours, ResultMinutes, ResultSeconds, ResultMs, ResultUs, ResultNs);
+      Exit;
+    end;
+
     TotalNsBig := DurationTotalNanosecondsBig(D);
 
-    if SmallestUnit <> tuNanosecond then
+    if (SmallestUnit <> tuNanosecond) or (Increment <> 1) then
     begin
       DivisorBig := RoundingDivisorBig(SmallestUnit, Increment);
       TotalNsBig := RoundTimeDurationToIncrement(TotalNsBig, DivisorBig, Mode);
@@ -1121,47 +1238,354 @@ begin
     ResultMinutesBig, ResultSecondsBig, ResultMsBig, ResultUsBig, ResultNsBig,
     ResultDays);
 
-  if Ord(LargestUnit) <= Ord(tuWeek) then
+  if (LargestUnit = tuWeek) or (SmallestUnit = tuWeek) then
     Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(TBigInteger.Zero, TBigInteger.Zero,
       BigIntUnit(ResultDays div 7), BigIntUnit(ResultDays mod 7),
-      ResultHoursBig, ResultMinutesBig, ResultSecondsBig, ResultMsBig, ResultUsBig, ResultNsBig)
+      RoundBigToFloat64(ResultHoursBig), RoundBigToFloat64(ResultMinutesBig),
+      RoundBigToFloat64(ResultSecondsBig), RoundBigToFloat64(ResultMsBig),
+      RoundBigToFloat64(ResultUsBig), RoundBigToFloat64(ResultNsBig))
   else
     Result := TGocciaTemporalDurationValue.CreateFromBigIntegers(TBigInteger.Zero, TBigInteger.Zero,
       TBigInteger.Zero, BigIntUnit(ResultDays),
-      ResultHoursBig, ResultMinutesBig, ResultSecondsBig, ResultMsBig, ResultUsBig, ResultNsBig);
+      RoundBigToFloat64(ResultHoursBig), RoundBigToFloat64(ResultMinutesBig),
+      RoundBigToFloat64(ResultSecondsBig), RoundBigToFloat64(ResultMsBig),
+      RoundBigToFloat64(ResultUsBig), RoundBigToFloat64(ResultNsBig));
   except
     on E: ETemporalDurationInt64Overflow do
       ThrowRangeError(E.Message, SSuggestTemporalDurationRange);
   end;
 end;
 
-function TryParseDateFromPropertyBag(const AObj: TGocciaObjectValue;
-  out ADate: TTemporalDateRecord): Boolean;
+function DurationIsUndefinedValue(const AValue: TGocciaValue): Boolean; inline;
+begin
+  Result := (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue);
+end;
+
+function DurationASCIIEqualsIgnoreCase(const ALeft, ARight: string): Boolean;
 var
-  V: TGocciaValue;
+  I: Integer;
+  L, R: Char;
+
+  function UpperASCII(const AChar: Char): Char; inline;
+  begin
+    if (AChar >= 'a') and (AChar <= 'z') then
+      Result := Chr(Ord(AChar) - Ord('a') + Ord('A'))
+    else
+      Result := AChar;
+  end;
+begin
+  if Length(ALeft) <> Length(ARight) then
+    Exit(False);
+  for I := 1 to Length(ALeft) do
+  begin
+    L := UpperASCII(ALeft[I]);
+    R := UpperASCII(ARight[I]);
+    if L <> R then
+      Exit(False);
+  end;
+  Result := True;
+end;
+
+function DurationDateBefore(const AY, AM, AD, ABY, ABM, ABD: Integer): Boolean;
+begin
+  Result := (AY < ABY) or ((AY = ABY) and
+    ((AM < ABM) or ((AM = ABM) and (AD < ABD))));
+end;
+
+function DurationDateInTemporalRange(const ADate: TTemporalDateRecord): Boolean;
+begin
+  Result := not DurationDateBefore(ADate.Year, ADate.Month, ADate.Day, -271821, 4, 19) and
+    not DurationDateBefore(275760, 9, 13, ADate.Year, ADate.Month, ADate.Day);
+end;
+
+function DurationDateAtLowerZonedLimit(const ADate: TTemporalDateRecord): Boolean;
+begin
+  Result := (ADate.Year = -271821) and (ADate.Month = 4) and (ADate.Day = 20);
+end;
+
+function DurationDateAtUpperLimit(const ADate: TTemporalDateRecord): Boolean;
+begin
+  Result := (ADate.Year = 275760) and (ADate.Month = 9) and (ADate.Day = 13);
+end;
+
+function IsDurationZonedRelativeToValue(const AValue: TGocciaValue): Boolean;
+begin
+  if AValue is TGocciaTemporalZonedDateTimeValue then
+    Exit(True);
+  if AValue is TGocciaStringLiteralValue then
+    Exit(System.Pos('[', TGocciaStringLiteralValue(AValue).Value) > 0);
+  Result := False;
+end;
+
+function DurationRelativeToHasInvalidPlainDateTimeOffset(const AValue: string): Boolean;
+var
+  TPos, I, OffsetSeconds: Integer;
+  OffsetPart: string;
+  HasUTCDesignator, HasSubMinuteSyntax: Boolean;
 begin
   Result := False;
-  V := AObj.GetProperty(PROP_YEAR);
-  if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+  TPos := System.Pos('T', AValue);
+  if TPos = 0 then
+    TPos := System.Pos('t', AValue);
+  if TPos = 0 then
+    TPos := System.Pos(' ', AValue);
+  if TPos = 0 then
     Exit;
-  ADate.Year := ToIntegerWithTruncationValue(V);
-  V := AObj.GetProperty(PROP_MONTH);
-  if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+
+  for I := TPos + 1 to Length(AValue) do
+  begin
+    if AValue[I] = '[' then
+      Exit;
+    if (AValue[I] = '+') or (AValue[I] = '-') then
+    begin
+      OffsetPart := Copy(AValue, I, Length(AValue) - I + 1);
+      Result := not TryParseTemporalOffsetString(OffsetPart, OffsetSeconds,
+        HasUTCDesignator, HasSubMinuteSyntax) or HasUTCDesignator;
+      Exit;
+    end;
+  end;
+end;
+
+function DurationMonthCodeSyntaxValid(const AMonthCode: string): Boolean;
+begin
+  Result := ((Length(AMonthCode) = 3) or (Length(AMonthCode) = 4)) and
+    (AMonthCode[1] = 'M') and
+    (AMonthCode[2] in ['0'..'9']) and
+    (AMonthCode[3] in ['0'..'9']) and
+    ((Length(AMonthCode) = 3) or (AMonthCode[4] = 'L'));
+end;
+
+function DurationMonthFromMonthCode(const AMonthCode: string; out AMonth: Integer): Boolean;
+var
+  MonthPart: Integer;
+begin
+  Result := False;
+  AMonth := 0;
+  if (Length(AMonthCode) <> 3) or not TryStrToInt(Copy(AMonthCode, 2, 2), MonthPart) then
     Exit;
-  ADate.Month := ToIntegerWithTruncationValue(V);
-  V := AObj.GetProperty(PROP_DAY);
-  if (V = nil) or (V is TGocciaUndefinedLiteralValue) then
+  if (MonthPart < 1) or (MonthPart > 12) then
     Exit;
-  ADate.Day := ToIntegerWithTruncationValue(V);
-  if not IsValidDate(ADate.Year, ADate.Month, ADate.Day) then
-    Exit;
+  AMonth := MonthPart;
   Result := True;
+end;
+
+procedure ValidateRelativeToCalendar(const AValue: TGocciaValue; const AMethod: string);
+var
+  Calendar: string;
+begin
+  if DurationIsUndefinedValue(AValue) then
+    Exit;
+  if (AValue is TGocciaTemporalPlainDateValue) or
+     (AValue is TGocciaTemporalPlainDateTimeValue) or
+     (AValue is TGocciaTemporalPlainMonthDayValue) or
+     (AValue is TGocciaTemporalPlainYearMonthValue) or
+     (AValue is TGocciaTemporalZonedDateTimeValue) then
+    Exit;
+  if not (AValue is TGocciaStringLiteralValue) then
+    ThrowTypeError(AMethod + ' relativeTo.calendar must be a string',
+      SSuggestTemporalRelativeTo);
+  Calendar := TGocciaStringLiteralValue(AValue).Value;
+  if not DurationASCIIEqualsIgnoreCase(Calendar, 'iso8601') then
+    ThrowRangeError(AMethod + ' relativeTo calendar must be iso8601',
+      SSuggestTemporalRelativeTo);
+end;
+
+function RequiredRelativeToIntegerField(const AValue: TGocciaValue;
+  const AMethod, AName: string): Integer;
+begin
+  if DurationIsUndefinedValue(AValue) then
+    ThrowTypeError(AMethod + ' relativeTo requires ' + AName + ' property',
+      SSuggestTemporalRelativeTo);
+  Result := ToIntegerWithTruncationValue(AValue);
+end;
+
+function OptionalRelativeToIntegerField(const AValue: TGocciaValue;
+  const ADefault: Integer): Integer;
+begin
+  if DurationIsUndefinedValue(AValue) then
+    Result := ADefault
+  else
+    Result := ToIntegerWithTruncationValue(AValue);
+end;
+
+function RelativeToOffsetString(const AValue: TGocciaValue; const AMethod: string): string;
+begin
+  if (AValue is TGocciaStringLiteralValue) or (AValue is TGocciaObjectValue) then
+    Exit(AValue.ToStringLiteral.Value);
+  ThrowTypeError(AMethod + ' relativeTo.offset must be a string',
+    SSuggestTemporalRelativeTo);
+end;
+
+function RelativeToTimeZoneString(const AValue: TGocciaValue; const AMethod: string): string;
+begin
+  if AValue is TGocciaStringLiteralValue then
+    Exit(TGocciaStringLiteralValue(AValue).Value);
+  ThrowTypeError(AMethod + ' relativeTo.timeZone must be a string',
+    SSuggestTemporalRelativeTo);
+end;
+
+function ZonedDateTimeToRelativeDate(const AZdt: TGocciaTemporalZonedDateTimeValue): TTemporalDateRecord;
+const
+  MS_PER_SECOND = 1000;
+  MS_PER_DAY = Int64(86400000);
+var
+  OffsetSeconds: Integer;
+  LocalMs, EpochDays, RemainingMs: Int64;
+begin
+  OffsetSeconds := GetUtcOffsetSeconds(AZdt.TimeZone,
+    AZdt.EpochMilliseconds div MS_PER_SECOND);
+  LocalMs := AZdt.EpochMilliseconds + Int64(OffsetSeconds) * MS_PER_SECOND;
+  EpochDays := LocalMs div MS_PER_DAY;
+  RemainingMs := LocalMs mod MS_PER_DAY;
+  if RemainingMs < 0 then
+    Dec(EpochDays);
+  Result := EpochDaysToDate(EpochDays);
+end;
+
+function TryParseBasicISODateForRelativeTo(const AValue: string; out ADate: TTemporalDateRecord): Boolean;
+var
+  I, Year, Month, Day: Integer;
+begin
+  Result := False;
+  if Length(AValue) <> 8 then
+    Exit;
+  for I := 1 to Length(AValue) do
+    if not (AValue[I] in ['0'..'9']) then
+      Exit;
+  Year := StrToInt(Copy(AValue, 1, 4));
+  Month := StrToInt(Copy(AValue, 5, 2));
+  Day := StrToInt(Copy(AValue, 7, 2));
+  if not IsValidDate(Year, Month, Day) then
+    Exit;
+  ADate.Year := Year;
+  ADate.Month := Month;
+  ADate.Day := Day;
+  Result := True;
+end;
+
+function ParseRelativeToPropertyBag(const AObj: TGocciaObjectValue;
+  const AMethod: string): TTemporalDateRecord;
+const
+  MS_PER_SECOND = 1000;
+  MS_PER_MINUTE = 60000;
+  MS_PER_HOUR = 3600000;
+  MS_PER_DAY = Int64(86400000);
+var
+  VCalendar, VDay, VHour, VMicrosecond, VMillisecond, VMinute, VMonth,
+  VMonthCode, VNanosecond, VOffset, VSecond, VTimeZone, VYear: TGocciaValue;
+  Year, Month, Day, Hour, Minute, Second, Millisecond, Microsecond, Nanosecond: Integer;
+  MonthCode, OffsetString, TimeZoneString: string;
+  HasMonth, HasMonthCode, HasOffset, HasTimeZone: Boolean;
+  MonthFromCode, OffsetSeconds: Integer;
+  OffsetHasUTCDesignator, OffsetHasSubMinuteSyntax: Boolean;
+  OffsetEpochMs: Int64;
+  ActualOffsetSeconds: Integer;
+begin
+  VCalendar := AObj.GetProperty('calendar');
+  ValidateRelativeToCalendar(VCalendar, AMethod);
+
+  VDay := AObj.GetProperty(PROP_DAY);
+  Day := RequiredRelativeToIntegerField(VDay, AMethod, PROP_DAY);
+  VHour := AObj.GetProperty(PROP_HOUR);
+  Hour := OptionalRelativeToIntegerField(VHour, 0);
+  VMicrosecond := AObj.GetProperty(PROP_MICROSECOND);
+  Microsecond := OptionalRelativeToIntegerField(VMicrosecond, 0);
+  VMillisecond := AObj.GetProperty(PROP_MILLISECOND);
+  Millisecond := OptionalRelativeToIntegerField(VMillisecond, 0);
+  VMinute := AObj.GetProperty(PROP_MINUTE);
+  Minute := OptionalRelativeToIntegerField(VMinute, 0);
+  VMonth := AObj.GetProperty(PROP_MONTH);
+  HasMonth := not DurationIsUndefinedValue(VMonth);
+  if HasMonth then
+    Month := ToIntegerWithTruncationValue(VMonth)
+  else
+    Month := 0;
+  VMonthCode := AObj.GetProperty(PROP_MONTH_CODE);
+  HasMonthCode := not DurationIsUndefinedValue(VMonthCode);
+  MonthCode := '';
+  if HasMonthCode then
+  begin
+    MonthCode := VMonthCode.ToStringLiteral.Value;
+    if not DurationMonthCodeSyntaxValid(MonthCode) then
+      ThrowRangeError(Format(SErrorInvalidMonthCodeFor, [AMethod]),
+        SSuggestTemporalMonthCode);
+  end;
+  VNanosecond := AObj.GetProperty(PROP_NANOSECOND);
+  Nanosecond := OptionalRelativeToIntegerField(VNanosecond, 0);
+  VOffset := AObj.GetProperty('offset');
+  HasOffset := not DurationIsUndefinedValue(VOffset);
+  OffsetSeconds := 0;
+  if HasOffset then
+  begin
+    OffsetString := RelativeToOffsetString(VOffset, AMethod);
+    if (not TryParseTemporalOffsetString(OffsetString, OffsetSeconds,
+      OffsetHasUTCDesignator, OffsetHasSubMinuteSyntax)) or OffsetHasUTCDesignator then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]),
+        SSuggestTemporalRelativeTo);
+  end;
+  VSecond := AObj.GetProperty(PROP_SECOND);
+  Second := OptionalRelativeToIntegerField(VSecond, 0);
+  if Second = 60 then
+    Second := 59;
+  VTimeZone := AObj.GetProperty('timeZone');
+  HasTimeZone := not DurationIsUndefinedValue(VTimeZone);
+  VYear := AObj.GetProperty(PROP_YEAR);
+  Year := RequiredRelativeToIntegerField(VYear, AMethod, PROP_YEAR);
+
+  if HasMonthCode then
+  begin
+    if not DurationMonthFromMonthCode(MonthCode, MonthFromCode) then
+      ThrowRangeError(Format(SErrorMonthCodeOutOfRangeIn, [AMethod]),
+        SSuggestTemporalMonthCode);
+    if HasMonth and (Month <> MonthFromCode) then
+      ThrowRangeError(Format(SErrorMonthCodeMismatchIn, [AMethod]),
+        SSuggestTemporalMonthCode);
+    Month := MonthFromCode;
+  end
+  else if not HasMonth then
+    ThrowTypeError(AMethod + ' relativeTo requires month property',
+      SSuggestTemporalRelativeTo);
+
+  if not IsValidDate(Year, Month, Day) then
+    ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]),
+      SSuggestTemporalRelativeTo);
+  if not IsValidTime(Hour, Minute, Second, Millisecond, Microsecond, Nanosecond) then
+    ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]),
+      SSuggestTemporalRelativeTo);
+
+  if HasTimeZone then
+  begin
+    TimeZoneString := CanonicalizeTemporalTimeZoneIdentifier(
+      RelativeToTimeZoneString(VTimeZone, AMethod));
+    if HasOffset then
+    begin
+      OffsetEpochMs := DateToEpochDays(Year, Month, Day) * MS_PER_DAY +
+        Int64(Hour) * MS_PER_HOUR + Int64(Minute) * MS_PER_MINUTE +
+        Int64(Second) * MS_PER_SECOND + Millisecond -
+        Int64(OffsetSeconds) * MS_PER_SECOND;
+      ActualOffsetSeconds := GetUtcOffsetSeconds(TimeZoneString,
+        OffsetEpochMs div MS_PER_SECOND);
+      if ActualOffsetSeconds <> OffsetSeconds then
+        ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]),
+          SSuggestTemporalRelativeTo);
+    end;
+  end;
+
+  Result.Year := Year;
+  Result.Month := Month;
+  Result.Day := Day;
+  if not DurationDateInTemporalRange(Result) then
+    ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]),
+      SSuggestTemporalRelativeTo);
 end;
 
 function ParseRelativeTo(const AValue: TGocciaValue; const AMethod: string): TTemporalDateRecord;
 var
   DateRec: TTemporalDateRecord;
   PlainDate: TGocciaTemporalPlainDateValue;
+  PlainDateTime: TGocciaTemporalPlainDateTimeValue;
+  ZonedDateTime: TGocciaTemporalZonedDateTimeValue;
+  Source: string;
 begin
   if AValue is TGocciaTemporalPlainDateValue then
   begin
@@ -1170,26 +1594,47 @@ begin
     Result.Month := PlainDate.Month;
     Result.Day := PlainDate.Day;
   end
+  else if AValue is TGocciaTemporalPlainDateTimeValue then
+  begin
+    PlainDateTime := TGocciaTemporalPlainDateTimeValue(AValue);
+    Result.Year := PlainDateTime.Year;
+    Result.Month := PlainDateTime.Month;
+    Result.Day := PlainDateTime.Day;
+  end
   else if AValue is TGocciaTemporalZonedDateTimeValue then
   begin
-    // ZonedDateTime relativeTo needs timezone-aware DST handling. Reject it
-    // until Duration round/total can route through that aware path.
-    ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
+    Result := ZonedDateTimeToRelativeDate(TGocciaTemporalZonedDateTimeValue(AValue));
   end
   else if AValue is TGocciaStringLiteralValue then
   begin
-    if not CoerceToISODate(TGocciaStringLiteralValue(AValue).Value, DateRec) then
+    Source := TGocciaStringLiteralValue(AValue).Value;
+    if System.Pos('[', Source) > 0 then
+    begin
+      ZonedDateTime := CoerceTemporalZonedDateTime(AValue, AMethod);
+      Result := ZonedDateTimeToRelativeDate(ZonedDateTime);
+      Exit;
+    end;
+    if DurationRelativeToHasInvalidPlainDateTimeOffset(Source) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]),
+        SSuggestTemporalRelativeTo);
+    if ((System.Pos('T', Source) > 0) or (System.Pos('t', Source) > 0) or
+        (System.Pos(' ', Source) > 0)) and
+       ((Length(Source) > 0) and ((Source[Length(Source)] = 'Z') or
+        (Source[Length(Source)] = 'z'))) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]),
+        SSuggestTemporalRelativeTo);
+    Source := StringReplace(Source, ':60', ':59', []);
+    if not (CoerceToISODate(Source, DateRec) or
+      TryParseBasicISODateForRelativeTo(Source, DateRec)) then
+      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
+    if not DurationDateInTemporalRange(DateRec) then
       ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
     Result := DateRec;
   end
   else if AValue is TGocciaObjectValue then
-  begin
-    if not TryParseDateFromPropertyBag(TGocciaObjectValue(AValue), DateRec) then
-      ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
-    Result := DateRec;
-  end
+    Result := ParseRelativeToPropertyBag(TGocciaObjectValue(AValue), AMethod)
   else
-    ThrowRangeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
+    ThrowTypeError(Format(SErrorTemporalInvalidRelativeTo, [AMethod]), SSuggestTemporalRelativeTo);
 end;
 
 // Add AMonths calendar months to a date, clamping the day if needed.

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -78,6 +78,12 @@ type
     property TimeZone: string read FTimeZone;
   end;
 
+function CoerceTemporalZonedDateTime(const AValue: TGocciaValue;
+  const AMethod: string; const AOptions: TGocciaValue = nil): TGocciaTemporalZonedDateTimeValue;
+function CanonicalizeTemporalTimeZoneIdentifier(const AValue: string): string;
+function TryParseTemporalOffsetString(const AValue: string; out AOffsetSeconds: Integer;
+  out AHasUTCDesignator, AHasSubMinuteSyntax: Boolean): Boolean;
+
 implementation
 
 uses
@@ -101,7 +107,9 @@ uses
   Goccia.Values.TemporalInstant,
   Goccia.Values.TemporalPlainDate,
   Goccia.Values.TemporalPlainDateTime,
-  Goccia.Values.TemporalPlainTime;
+  Goccia.Values.TemporalPlainMonthDay,
+  Goccia.Values.TemporalPlainTime,
+  Goccia.Values.TemporalPlainYearMonth;
 
 var
   GTemporalZonedDateTimeSharedSlot: TGocciaRealmOwnedSlotId;
@@ -126,6 +134,22 @@ const
   HOURS_PER_DAY = 24;
   MONTHS_PER_YEAR = 12;
   DAYS_PER_WEEK = 7;
+  PROPERTY_TIME_ZONE = 'timeZone';
+  PROPERTY_OFFSET = 'offset';
+
+type
+  TTemporalDisambiguationOption = (tdoCompatible, tdoEarlier, tdoLater, tdoReject);
+  TTemporalOffsetOption = (tooPrefer, tooUse, tooIgnore, tooReject);
+  TZonedDateTimeParseResult = record
+    Date: TTemporalDateRecord;
+    Time: TTemporalTimeRecord;
+    TimeZone: string;
+    OffsetSeconds: Integer;
+    HasOffset: Boolean;
+    HasUTCDesignator: Boolean;
+    OffsetHasSubMinuteSyntax: Boolean;
+    TimeZoneFromOffset: Boolean;
+  end;
 
 function AsZonedDateTime(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalZonedDateTimeValue;
 begin
@@ -134,40 +158,1046 @@ begin
   Result := TGocciaTemporalZonedDateTimeValue(AValue);
 end;
 
-function CoerceZonedDateTime(const AValue: TGocciaValue; const AMethod: string): TGocciaTemporalZonedDateTimeValue;
+function LocalToEpochMs(const AYear, AMonth, ADay, AHour, AMinute, ASecond, AMs: Integer;
+  const ATimeZone: string): Int64; forward;
+function FormatOffsetString(const AOffsetSeconds: Integer): string; forward;
+
+function IsUndefinedValue(const AValue: TGocciaValue): Boolean; inline;
+begin
+  Result := (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue);
+end;
+
+function ASCIIEqualsIgnoreCase(const ALeft, ARight: string): Boolean;
+var
+  I: Integer;
+  LeftChar, RightChar: Char;
+
+  function UpperASCII(const AChar: Char): Char; inline;
+  begin
+    if (AChar >= 'a') and (AChar <= 'z') then
+      Result := Chr(Ord(AChar) - Ord('a') + Ord('A'))
+    else
+      Result := AChar;
+  end;
+begin
+  if Length(ALeft) <> Length(ARight) then
+    Exit(False);
+
+  for I := 1 to Length(ALeft) do
+  begin
+    LeftChar := UpperASCII(ALeft[I]);
+    RightChar := UpperASCII(ARight[I]);
+    if LeftChar <> RightChar then
+      Exit(False);
+  end;
+
+  Result := True;
+end;
+
+function ASCIIIsLowercaseKey(const AValue: string): Boolean;
+var
+  I: Integer;
+  C: Char;
+begin
+  Result := AValue <> '';
+  for I := 1 to Length(AValue) do
+  begin
+    C := AValue[I];
+    if (C >= 'A') and (C <= 'Z') then
+      Exit(False);
+  end;
+end;
+
+function RequireOptionsObject(const AOptions: TGocciaValue; const AMethod: string): TGocciaObjectValue;
+begin
+  if IsUndefinedValue(AOptions) then
+    Exit(nil);
+  if not (AOptions is TGocciaObjectValue) then
+    ThrowTypeError(AMethod + ' options must be an object', SSuggestTemporalFromArg);
+  Result := TGocciaObjectValue(AOptions);
+end;
+
+function GetDisambiguationOption(const AOptions: TGocciaObjectValue;
+  const AMethod: string): TTemporalDisambiguationOption;
+var
+  Value: string;
+begin
+  Value := GetOptionString(AOptions, 'disambiguation', 'compatible');
+  if Value = 'compatible' then
+    Result := tdoCompatible
+  else if Value = 'earlier' then
+    Result := tdoEarlier
+  else if Value = 'later' then
+    Result := tdoLater
+  else if Value = 'reject' then
+    Result := tdoReject
+  else
+    ThrowRangeError(AMethod + ' invalid disambiguation option: ' + Value,
+      SSuggestTemporalRoundArg);
+end;
+
+function GetOffsetOption(const AOptions: TGocciaObjectValue;
+  const AMethod: string): TTemporalOffsetOption;
+var
+  Value: string;
+begin
+  Value := GetOptionString(AOptions, 'offset', 'reject');
+  if Value = 'prefer' then
+    Result := tooPrefer
+  else if Value = 'use' then
+    Result := tooUse
+  else if Value = 'ignore' then
+    Result := tooIgnore
+  else if Value = 'reject' then
+    Result := tooReject
+  else
+    ThrowRangeError(AMethod + ' invalid offset option: ' + Value,
+      SSuggestTemporalRoundArg);
+end;
+
+procedure ReadZonedDateTimeOptions(const AOptions: TGocciaValue; const AMethod: string;
+  out AOverflow: TTemporalOverflow; out AOffsetOption: TTemporalOffsetOption);
+var
+  OptionsObj: TGocciaObjectValue;
+  IgnoredDisambiguation: TTemporalDisambiguationOption;
+begin
+  OptionsObj := RequireOptionsObject(AOptions, AMethod);
+  IgnoredDisambiguation := GetDisambiguationOption(OptionsObj, AMethod);
+  AOffsetOption := GetOffsetOption(OptionsObj, AMethod);
+  AOverflow := GetOverflowOption(OptionsObj);
+end;
+
+function NormalizeLeapSecondForTemporalDateTime(const AValue: string): string;
+begin
+  Result := StringReplace(AValue, ':60', ':59', []);
+end;
+
+function IsASCIIDigit(const AChar: Char): Boolean; inline;
+begin
+  Result := (AChar >= '0') and (AChar <= '9');
+end;
+
+function ReadFixedDigits(const AValue: string; var APos: Integer;
+  const ACount: Integer; out ANumber: Integer): Boolean;
+var
+  I: Integer;
+begin
+  Result := False;
+  ANumber := 0;
+  if APos + ACount - 1 > Length(AValue) then
+    Exit;
+
+  for I := 0 to ACount - 1 do
+  begin
+    if not IsASCIIDigit(AValue[APos + I]) then
+      Exit;
+    ANumber := ANumber * 10 + Ord(AValue[APos + I]) - Ord('0');
+  end;
+  Inc(APos, ACount);
+  Result := True;
+end;
+
+function ReadFractionalNanoseconds(const AValue: string; var APos: Integer;
+  out AMillisecond, AMicrosecond, ANanosecond: Integer): Boolean;
+var
+  Digits: Integer;
+  Fraction: Int64;
+begin
+  Result := False;
+  AMillisecond := 0;
+  AMicrosecond := 0;
+  ANanosecond := 0;
+
+  if (APos > Length(AValue)) or ((AValue[APos] <> '.') and (AValue[APos] <> ',')) then
+  begin
+    Result := True;
+    Exit;
+  end;
+
+  Inc(APos);
+  Digits := 0;
+  Fraction := 0;
+  while (APos <= Length(AValue)) and IsASCIIDigit(AValue[APos]) do
+  begin
+    if Digits >= 9 then
+      Exit;
+    Fraction := Fraction * 10 + Ord(AValue[APos]) - Ord('0');
+    Inc(Digits);
+    Inc(APos);
+  end;
+
+  if Digits = 0 then
+    Exit;
+  while Digits < 9 do
+  begin
+    Fraction := Fraction * 10;
+    Inc(Digits);
+  end;
+
+  AMillisecond := Integer(Fraction div 1000000);
+  AMicrosecond := Integer((Fraction div 1000) mod 1000);
+  ANanosecond := Integer(Fraction mod 1000);
+  Result := True;
+end;
+
+function ParseZonedDateTimeDatePart(const AValue: string; out ADate: TTemporalDateRecord): Boolean;
+var
+  Pos, Sign, Year, Month, Day: Integer;
+  Extended: Boolean;
+begin
+  Result := False;
+  Pos := 1;
+  Sign := 1;
+
+  if Pos > Length(AValue) then
+    Exit;
+
+  if AValue[Pos] = '+' then
+  begin
+    Inc(Pos);
+    if not ReadFixedDigits(AValue, Pos, 6, Year) then
+      Exit;
+  end
+  else if AValue[Pos] = '-' then
+  begin
+    Inc(Pos);
+    Sign := -1;
+    if not ReadFixedDigits(AValue, Pos, 6, Year) then
+      Exit;
+    if Year = 0 then
+      Exit;
+  end
+  else if not ReadFixedDigits(AValue, Pos, 4, Year) then
+    Exit;
+
+  Year := Year * Sign;
+  Extended := (Pos <= Length(AValue)) and (AValue[Pos] = '-');
+  if Extended then
+    Inc(Pos);
+  if not ReadFixedDigits(AValue, Pos, 2, Month) then
+    Exit;
+  if Extended then
+  begin
+    if (Pos > Length(AValue)) or (AValue[Pos] <> '-') then
+      Exit;
+    Inc(Pos);
+  end;
+  if not ReadFixedDigits(AValue, Pos, 2, Day) then
+    Exit;
+  if Pos <= Length(AValue) then
+    Exit;
+  if not IsValidDate(Year, Month, Day) then
+    Exit;
+
+  ADate.Year := Year;
+  ADate.Month := Month;
+  ADate.Day := Day;
+  Result := True;
+end;
+
+function ParseZonedDateTimeTimePart(const AValue: string; out ATime: TTemporalTimeRecord): Boolean;
+var
+  Pos, Hour, Minute, Second: Integer;
+  Extended: Boolean;
+begin
+  Result := False;
+  FillChar(ATime, SizeOf(ATime), 0);
+  Pos := 1;
+
+  if not ReadFixedDigits(AValue, Pos, 2, Hour) then
+    Exit;
+  Minute := 0;
+  Second := 0;
+
+  if Pos <= Length(AValue) then
+  begin
+    Extended := AValue[Pos] = ':';
+    if Extended then
+      Inc(Pos);
+
+    if not ReadFixedDigits(AValue, Pos, 2, Minute) then
+      Exit;
+
+    if Pos <= Length(AValue) then
+    begin
+      if Extended then
+      begin
+        if AValue[Pos] = ':' then
+          Inc(Pos)
+        else if (AValue[Pos] = '.') or (AValue[Pos] = ',') then
+        begin
+          if not ReadFractionalNanoseconds(AValue, Pos,
+            ATime.Millisecond, ATime.Microsecond, ATime.Nanosecond) then
+            Exit;
+          if Pos <= Length(AValue) then
+            Exit;
+          if not IsValidTime(Hour, Minute, Second, ATime.Millisecond,
+            ATime.Microsecond, ATime.Nanosecond) then
+            Exit;
+          ATime.Hour := Hour;
+          ATime.Minute := Minute;
+          ATime.Second := Second;
+          Result := True;
+          Exit;
+        end
+        else
+          Exit;
+      end
+      else if (AValue[Pos] = '.') or (AValue[Pos] = ',') then
+      begin
+        if not ReadFractionalNanoseconds(AValue, Pos,
+          ATime.Millisecond, ATime.Microsecond, ATime.Nanosecond) then
+          Exit;
+        if Pos <= Length(AValue) then
+          Exit;
+        if not IsValidTime(Hour, Minute, Second, ATime.Millisecond,
+          ATime.Microsecond, ATime.Nanosecond) then
+          Exit;
+        ATime.Hour := Hour;
+        ATime.Minute := Minute;
+        ATime.Second := Second;
+        Result := True;
+        Exit;
+      end;
+
+      if not ReadFixedDigits(AValue, Pos, 2, Second) then
+        Exit;
+      if not ReadFractionalNanoseconds(AValue, Pos,
+        ATime.Millisecond, ATime.Microsecond, ATime.Nanosecond) then
+        Exit;
+    end;
+  end;
+
+  if Pos <= Length(AValue) then
+    Exit;
+  if Second = 60 then
+    Second := 59;
+  if not IsValidTime(Hour, Minute, Second, ATime.Millisecond,
+    ATime.Microsecond, ATime.Nanosecond) then
+    Exit;
+
+  ATime.Hour := Hour;
+  ATime.Minute := Minute;
+  ATime.Second := Second;
+  Result := True;
+end;
+
+function ParseZonedDateTimeOffsetPart(const AValue: string; out AOffsetSeconds: Integer;
+  out AHasUTCDesignator, AHasSubMinuteSyntax: Boolean): Boolean;
+var
+  Pos, Sign, Hour, Minute, Second, Ms, Us, Ns: Integer;
+  Extended: Boolean;
+begin
+  Result := False;
+  AOffsetSeconds := 0;
+  AHasUTCDesignator := False;
+  AHasSubMinuteSyntax := False;
+
+  if (AValue = 'Z') or (AValue = 'z') then
+  begin
+    AHasUTCDesignator := True;
+    Result := True;
+    Exit;
+  end;
+
+  if Length(AValue) = 0 then
+    Exit;
+  case AValue[1] of
+    '+': Sign := 1;
+    '-': Sign := -1;
+  else
+    Exit;
+  end;
+
+  Pos := 2;
+  if not ReadFixedDigits(AValue, Pos, 2, Hour) then
+    Exit;
+  Minute := 0;
+  Second := 0;
+  Extended := (Pos <= Length(AValue)) and (AValue[Pos] = ':');
+  if Extended then
+    Inc(Pos);
+
+  if Pos <= Length(AValue) then
+  begin
+    if not ReadFixedDigits(AValue, Pos, 2, Minute) then
+      Exit;
+    if Pos <= Length(AValue) then
+    begin
+      if Extended then
+      begin
+        if AValue[Pos] <> ':' then
+          Exit;
+        Inc(Pos);
+      end;
+      if not ReadFixedDigits(AValue, Pos, 2, Second) then
+        Exit;
+      AHasSubMinuteSyntax := True;
+      Ms := 0;
+      Us := 0;
+      Ns := 0;
+      if not ReadFractionalNanoseconds(AValue, Pos, Ms, Us, Ns) then
+        Exit;
+      if (Ms <> 0) or (Us <> 0) or (Ns <> 0) then
+        Exit;
+    end;
+  end;
+
+  if Pos <= Length(AValue) then
+    Exit;
+  if (Hour > 23) or (Minute > 59) or (Second > 59) then
+    Exit;
+
+  AOffsetSeconds := Sign * (Hour * 3600 + Minute * 60 + Second);
+  Result := True;
+end;
+
+function SplitZonedDateTimeOffset(const AValue: string; out ATimePart, AOffsetPart: string): Boolean;
+var
+  I: Integer;
+begin
+  ATimePart := AValue;
+  AOffsetPart := '';
+  Result := True;
+
+  if Length(AValue) = 0 then
+    Exit(False);
+
+  if (AValue[Length(AValue)] = 'Z') or (AValue[Length(AValue)] = 'z') then
+  begin
+    ATimePart := Copy(AValue, 1, Length(AValue) - 1);
+    AOffsetPart := Copy(AValue, Length(AValue), 1);
+    Exit;
+  end;
+
+  for I := 1 to Length(AValue) do
+  begin
+    if (AValue[I] = '+') or (AValue[I] = '-') then
+    begin
+      ATimePart := Copy(AValue, 1, I - 1);
+      AOffsetPart := Copy(AValue, I, Length(AValue) - I + 1);
+      Exit;
+    end;
+  end;
+end;
+
+function ExtractZonedDateTimeAnnotations(var AValue: string; out ATimeZone: string): Boolean;
+var
+  BracketStart, BracketEnd: Integer;
+  Annotation, Key, Value, Calendar: string;
+  EqualsPos: Integer;
+  Critical, CalendarCriticalSeen: Boolean;
+  CalendarCount: Integer;
+begin
+  Result := False;
+  ATimeZone := '';
+  CalendarCount := 0;
+  CalendarCriticalSeen := False;
+
+  while (Length(AValue) > 0) and (AValue[Length(AValue)] = ']') do
+  begin
+    BracketEnd := Length(AValue);
+    BracketStart := BracketEnd - 1;
+    while (BracketStart > 0) and (AValue[BracketStart] <> '[') do
+      Dec(BracketStart);
+    if BracketStart = 0 then
+      Exit;
+
+    Annotation := Copy(AValue, BracketStart + 1, BracketEnd - BracketStart - 1);
+    Critical := (Length(Annotation) > 0) and (Annotation[1] = '!');
+    if Critical then
+      Annotation := Copy(Annotation, 2, Length(Annotation) - 1);
+    if Annotation = '' then
+      Exit;
+
+    EqualsPos := System.Pos('=', Annotation);
+    if EqualsPos > 0 then
+    begin
+      Key := Copy(Annotation, 1, EqualsPos - 1);
+      Value := Copy(Annotation, EqualsPos + 1, Length(Annotation) - EqualsPos);
+      if not ASCIIIsLowercaseKey(Key) then
+        Exit;
+
+      if Key = 'u-ca' then
+      begin
+        Inc(CalendarCount);
+        if Critical then
+          CalendarCriticalSeen := True;
+        if (CalendarCount > 1) and (CalendarCriticalSeen or Critical) then
+          Exit;
+        Calendar := Value;
+      end
+      else if Critical then
+        Exit;
+    end
+    else
+    begin
+      if ATimeZone <> '' then
+        Exit;
+      ATimeZone := Annotation;
+    end;
+
+    AValue := Copy(AValue, 1, BracketStart - 1);
+  end;
+
+  if (Calendar <> '') and not ASCIIEqualsIgnoreCase(Calendar, 'iso8601') then
+    Exit;
+
+  Result := True;
+end;
+
+function TryParseZonedDateTimeString(const AValue: string; out AParsed: TZonedDateTimeParseResult): Boolean;
+var
+  Base, DatePart, TimeAndOffset, TimePart, OffsetPart: string;
+  SepPos, I: Integer;
+begin
+  Result := False;
+  AParsed.Date.Year := 0;
+  AParsed.Date.Month := 0;
+  AParsed.Date.Day := 0;
+  AParsed.Time.Hour := 0;
+  AParsed.Time.Minute := 0;
+  AParsed.Time.Second := 0;
+  AParsed.Time.Millisecond := 0;
+  AParsed.Time.Microsecond := 0;
+  AParsed.Time.Nanosecond := 0;
+  AParsed.TimeZone := '';
+  AParsed.OffsetSeconds := 0;
+  AParsed.HasOffset := False;
+  AParsed.HasUTCDesignator := False;
+  AParsed.OffsetHasSubMinuteSyntax := False;
+  AParsed.TimeZoneFromOffset := False;
+  Base := AValue;
+  if Base = '' then
+    Exit;
+  if not ExtractZonedDateTimeAnnotations(Base, AParsed.TimeZone) then
+    Exit;
+
+  SepPos := 0;
+  for I := 1 to Length(Base) do
+  begin
+    if (Base[I] = 'T') or (Base[I] = 't') or (Base[I] = ' ') then
+    begin
+      SepPos := I;
+      Break;
+    end;
+  end;
+
+  if SepPos = 0 then
+  begin
+    if not ParseZonedDateTimeDatePart(Base, AParsed.Date) then
+      Exit;
+    AParsed.Time.Hour := 0;
+    AParsed.Time.Minute := 0;
+    AParsed.Time.Second := 0;
+    AParsed.Time.Millisecond := 0;
+    AParsed.Time.Microsecond := 0;
+    AParsed.Time.Nanosecond := 0;
+  end
+  else
+  begin
+    DatePart := Copy(Base, 1, SepPos - 1);
+    TimeAndOffset := Copy(Base, SepPos + 1, Length(Base) - SepPos);
+    if not ParseZonedDateTimeDatePart(DatePart, AParsed.Date) then
+      Exit;
+    if not SplitZonedDateTimeOffset(TimeAndOffset, TimePart, OffsetPart) then
+      Exit;
+    if TimePart = '' then
+      Exit;
+    if OffsetPart <> '' then
+    begin
+      if not ParseZonedDateTimeOffsetPart(OffsetPart, AParsed.OffsetSeconds,
+        AParsed.HasUTCDesignator, AParsed.OffsetHasSubMinuteSyntax) then
+        Exit;
+      AParsed.HasOffset := True;
+      if (AParsed.TimeZone = '') and AParsed.HasUTCDesignator then
+      begin
+        AParsed.TimeZone := 'UTC';
+        AParsed.TimeZoneFromOffset := True;
+      end
+      else if AParsed.TimeZone = '' then
+      begin
+        AParsed.TimeZone := FormatOffsetString(AParsed.OffsetSeconds);
+        AParsed.TimeZoneFromOffset := True;
+      end;
+    end;
+    if not ParseZonedDateTimeTimePart(TimePart, AParsed.Time) then
+      Exit;
+  end;
+
+  if AParsed.TimeZone = '' then
+    Exit;
+  Result := True;
+end;
+
+procedure ValidateZonedDateTimeEpoch(const AEpochMilliseconds: Int64;
+  const ASubMillisecondNanoseconds: Integer; const AMethod: string);
+var
+  EpochNs: TBigInteger;
+begin
+  EpochNs := EpochNanosecondsFromParts(AEpochMilliseconds, ASubMillisecondNanoseconds);
+  if not IsValidEpochNanoseconds(EpochNs) then
+    ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['ZonedDateTime', AMethod]),
+      SSuggestTemporalDateRange);
+end;
+
+procedure ValidateZonedDateTimeLocalRange(const AYear, AMonth, ADay: Integer;
+  const ATime: TTemporalTimeRecord; const ASubMillisecondNanoseconds: Integer;
+  const AMethod: string);
+
+  function DateBefore(const AY, AM, AD, ABY, ABM, ABD: Integer): Boolean;
+  begin
+    Result := (AY < ABY) or ((AY = ABY) and
+      ((AM < ABM) or ((AM = ABM) and (AD < ABD))));
+  end;
+
+begin
+  if DateBefore(AYear, AMonth, ADay, -271821, 4, 20) or
+     DateBefore(275760, 9, 13, AYear, AMonth, ADay) then
+    ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['ZonedDateTime', AMethod]),
+      SSuggestTemporalDateRange);
+end;
+
+function CalendarStringHasNonISOAnnotation(const AValue: string): Boolean;
+var
+  BracketStart, BracketEnd: Integer;
+  Annotation: string;
+begin
+  Result := False;
+  BracketEnd := Length(AValue);
+  while BracketEnd > 0 do
+  begin
+    while (BracketEnd > 0) and (AValue[BracketEnd] <> ']') do
+      Dec(BracketEnd);
+    if BracketEnd = 0 then
+      Exit;
+
+    BracketStart := BracketEnd - 1;
+    while (BracketStart > 0) and (AValue[BracketStart] <> '[') do
+      Dec(BracketStart);
+    if BracketStart = 0 then
+      Exit;
+
+    Annotation := Copy(AValue, BracketStart + 1, BracketEnd - BracketStart - 1);
+    if (Length(Annotation) > 0) and (Annotation[1] = '!') then
+      Annotation := Copy(Annotation, 2, Length(Annotation) - 1);
+    if Copy(Annotation, 1, 5) = 'u-ca=' then
+    begin
+      if not ASCIIEqualsIgnoreCase(Copy(Annotation, 6, Length(Annotation) - 5), 'iso8601') then
+        Exit(True);
+    end;
+    BracketEnd := BracketStart - 1;
+  end;
+end;
+
+function CalendarStringIsISO(const AValue: string): Boolean;
 var
   DateRec: TTemporalDateRecord;
+  TimeRec: TTemporalTimeRecord;
+  Year, Month, Day: Integer;
+  OffsetSeconds: Integer;
+  TimeZone: string;
+  Normalized: string;
+begin
+  if AValue = '' then
+    Exit(False);
+  if Copy(AValue, 1, 7) = '-000000' then
+    Exit(False);
+  if ASCIIEqualsIgnoreCase(AValue, 'iso8601') then
+    Exit(True);
+  if CalendarStringHasNonISOAnnotation(AValue) then
+    Exit(False);
+
+  Normalized := NormalizeLeapSecondForTemporalDateTime(AValue);
+  Result := CoerceToISODate(Normalized, DateRec) or
+    CoerceToISODateTime(Normalized, DateRec, TimeRec) or
+    CoerceToISOYearMonth(Normalized, Year, Month) or
+    CoerceToISOMonthDay(Normalized, Month, Day) or
+    TryParseISODateTimeWithOffset(Normalized, DateRec, TimeRec, OffsetSeconds, TimeZone);
+end;
+
+function CalendarFromProperty(const AValue: TGocciaValue): string;
+var
+  CalendarString: string;
+begin
+  if IsUndefinedValue(AValue) then
+    Exit('iso8601');
+
+  if (AValue is TGocciaTemporalPlainDateValue) or
+     (AValue is TGocciaTemporalPlainDateTimeValue) or
+     (AValue is TGocciaTemporalPlainMonthDayValue) or
+     (AValue is TGocciaTemporalPlainYearMonthValue) or
+     (AValue is TGocciaTemporalZonedDateTimeValue) then
+    Exit('iso8601');
+
+  if not (AValue is TGocciaStringLiteralValue) then
+    ThrowTypeError('Temporal.ZonedDateTime calendar must be a string or Temporal calendar-carrying object',
+      SSuggestTemporalFromArg);
+
+  CalendarString := TGocciaStringLiteralValue(AValue).Value;
+  if not CalendarStringIsISO(CalendarString) then
+    ThrowRangeError('Temporal.ZonedDateTime calendar must identify the iso8601 calendar',
+      SSuggestTemporalDateRange);
+  Result := 'iso8601';
+end;
+
+function CanonicalizeTimeZoneIdentifier(const AValue: string): string; forward;
+
+function TryDateTimeStringTimeZoneIdentifier(const AValue: string; out ATimeZone: string): Boolean;
+var
+  Parsed: TZonedDateTimeParseResult;
+begin
+  ATimeZone := '';
+  if (System.Pos('T', AValue) = 0) and (System.Pos('t', AValue) = 0) and
+     (System.Pos(' ', AValue) = 0) then
+    Exit(False);
+
+  if not TryParseZonedDateTimeString(AValue, Parsed) then
+    Exit(False);
+  if Parsed.TimeZone = '' then
+    Exit(False);
+  if Parsed.TimeZoneFromOffset and Parsed.OffsetHasSubMinuteSyntax then
+    Exit(False);
+
+  ATimeZone := CanonicalizeTimeZoneIdentifier(Parsed.TimeZone);
+  Result := True;
+end;
+
+function CanonicalizeTimeZoneIdentifier(const AValue: string): string;
+var
+  OffsetSeconds: Integer;
+begin
+  if AValue = '' then
+    ThrowRangeError(Format(SErrorUnknownTimezone, [AValue]), SSuggestTemporalTimezone);
+
+  if TryDateTimeStringTimeZoneIdentifier(AValue, Result) then
+    Exit;
+
+  if ASCIIEqualsIgnoreCase(AValue, 'UTC') then
+    Exit('UTC');
+
+  if ParseOffsetString(AValue, OffsetSeconds) then
+    Exit(FormatOffsetString(OffsetSeconds));
+
+  if IsValidTimeZone(AValue) then
+    Exit(AValue);
+
+  ThrowRangeError(Format(SErrorUnknownTimezone, [AValue]), SSuggestTemporalTimezone);
+end;
+
+function TimeZoneFromProperty(const AValue: TGocciaValue; const AMethod: string): string;
+begin
+  if IsUndefinedValue(AValue) then
+    ThrowTypeError(AMethod + ' requires timeZone property', SSuggestTemporalTimezone);
+
+  if AValue is TGocciaTemporalZonedDateTimeValue then
+    Exit(TGocciaTemporalZonedDateTimeValue(AValue).TimeZone);
+
+  if not (AValue is TGocciaStringLiteralValue) then
+    ThrowTypeError(AMethod + ' timeZone must be a string or ZonedDateTime',
+      SSuggestTemporalTimezone);
+
+  Result := CanonicalizeTimeZoneIdentifier(TGocciaStringLiteralValue(AValue).Value);
+end;
+
+function CanonicalizeTemporalTimeZoneIdentifier(const AValue: string): string;
+begin
+  Result := CanonicalizeTimeZoneIdentifier(AValue);
+end;
+
+function TryParseTemporalOffsetString(const AValue: string; out AOffsetSeconds: Integer;
+  out AHasUTCDesignator, AHasSubMinuteSyntax: Boolean): Boolean;
+begin
+  Result := ParseZonedDateTimeOffsetPart(AValue, AOffsetSeconds,
+    AHasUTCDesignator, AHasSubMinuteSyntax);
+end;
+
+function IsMonthCodeSyntaxValid(const AMonthCode: string): Boolean; forward;
+
+function OffsetStringFromProperty(const AValue: TGocciaValue; const AMethod: string): string;
+begin
+  if AValue is TGocciaStringLiteralValue then
+    Exit(TGocciaStringLiteralValue(AValue).Value);
+  if AValue is TGocciaObjectValue then
+    Exit(AValue.ToStringLiteral.Value);
+
+  ThrowTypeError(AMethod + ' offset must be a string', SSuggestTemporalTimezone);
+end;
+
+function MonthCodeStringFromProperty(const AValue: TGocciaValue;
+  const AMethod: string): string;
+begin
+  Result := AValue.ToStringLiteral.Value;
+  if not (AValue is TGocciaStringLiteralValue) and not IsMonthCodeSyntaxValid(Result) then
+    ThrowTypeError(AMethod + ' monthCode must be a string', SSuggestTemporalMonthCode);
+end;
+
+function IsMonthCodeSyntaxValid(const AMonthCode: string): Boolean;
+begin
+  Result := ((Length(AMonthCode) = 3) or (Length(AMonthCode) = 4)) and
+    (AMonthCode[1] = 'M') and
+    (AMonthCode[2] in ['0'..'9']) and
+    (AMonthCode[3] in ['0'..'9']) and
+    ((Length(AMonthCode) = 3) or (AMonthCode[4] = 'L'));
+end;
+
+function MonthFromMonthCode(const AMonthCode: string; out AMonth: Integer): Boolean;
+var
+  MonthPart: Integer;
+begin
+  Result := False;
+  AMonth := 0;
+  if (Length(AMonthCode) <> 3) or not TryStrToInt(Copy(AMonthCode, 2, 2), MonthPart) then
+    Exit;
+  if (MonthPart < 1) or (MonthPart > 12) then
+    Exit;
+  AMonth := MonthPart;
+  Result := True;
+end;
+
+function EpochFromLocalAndOffset(const AYear, AMonth, ADay: Integer;
+  const ATime: TTemporalTimeRecord; const AOffsetSeconds: Integer): Int64;
+begin
+  Result := DateToEpochDays(AYear, AMonth, ADay) * MILLISECONDS_PER_DAY +
+            Int64(ATime.Hour) * MILLISECONDS_PER_HOUR +
+            Int64(ATime.Minute) * MILLISECONDS_PER_MINUTE +
+            Int64(ATime.Second) * MILLISECONDS_PER_SECOND +
+            ATime.Millisecond -
+            Int64(AOffsetSeconds) * MILLISECONDS_PER_SECOND;
+end;
+
+function ApplyOffsetOption(const AYear, AMonth, ADay: Integer;
+  const ATime: TTemporalTimeRecord; const ATimeZone: string;
+  const AHasOffset: Boolean; const AOffsetSeconds: Integer;
+  const AHasUTCDesignator: Boolean;
+  const AOffsetOption: TTemporalOffsetOption; const AMethod: string): Int64;
+var
+  OffsetEpochMs: Int64;
+  ActualOffsetSeconds: Integer;
+begin
+  if AHasOffset then
+  begin
+    OffsetEpochMs := EpochFromLocalAndOffset(AYear, AMonth, ADay, ATime, AOffsetSeconds);
+    if AHasUTCDesignator then
+      Exit(OffsetEpochMs);
+  end
+  else
+    OffsetEpochMs := 0;
+
+  if not AHasOffset or (AOffsetOption = tooIgnore) then
+    Exit(LocalToEpochMs(AYear, AMonth, ADay, ATime.Hour, ATime.Minute,
+      ATime.Second, ATime.Millisecond, ATimeZone));
+
+  if AOffsetOption = tooUse then
+    Exit(OffsetEpochMs);
+
+  ActualOffsetSeconds := GetUtcOffsetSeconds(ATimeZone, OffsetEpochMs div MILLISECONDS_PER_SECOND);
+  if ActualOffsetSeconds = AOffsetSeconds then
+    Exit(OffsetEpochMs);
+
+  if AOffsetOption = tooReject then
+    ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['ZonedDateTime', AMethod]),
+      SSuggestTemporalTimezone);
+
+  Result := LocalToEpochMs(AYear, AMonth, ADay, ATime.Hour, ATime.Minute,
+    ATime.Second, ATime.Millisecond, ATimeZone);
+end;
+
+function HasDateTimeOffsetDesignator(const AValue: string): Boolean;
+var
+  TPos, I: Integer;
+  Rest: string;
+begin
+  TPos := System.Pos('T', AValue);
+  if TPos = 0 then
+    TPos := System.Pos('t', AValue);
+  if TPos = 0 then
+    Exit(False);
+
+  Rest := Copy(AValue, TPos + 1, Length(AValue) - TPos);
+  for I := 1 to Length(Rest) do
+  begin
+    if Rest[I] = '[' then
+      Break;
+    if (Rest[I] = 'Z') or (Rest[I] = 'z') or (Rest[I] = '+') or (Rest[I] = '-') then
+      Exit(True);
+  end;
+  Result := False;
+end;
+
+function CoerceTemporalZonedDateTime(const AValue: TGocciaValue;
+  const AMethod: string; const AOptions: TGocciaValue): TGocciaTemporalZonedDateTimeValue;
+var
   TimeRec: TTemporalTimeRecord;
   OffsetSeconds: Integer;
   TimeZoneStr: string;
   EpochMs: Int64;
   SubMs: Integer;
+  Obj: TGocciaObjectValue;
+  VCalendar, VDay, VHour, VMicrosecond, VMillisecond, VMinute, VMonth,
+  VMonthCode, VNanosecond, VOffset, VSecond, VTimeZone, VYear: TGocciaValue;
+  Overflow: TTemporalOverflow;
+  Year, Month, Day, MaxDay: Integer;
+  MonthPart: Integer;
+  MonthCodeStr, OffsetStr: string;
+  HasMonth, HasMonthCode, HasOffset: Boolean;
+  OffsetOption: TTemporalOffsetOption;
+  OffsetHasUTCDesignator, OffsetHasSubMinuteSyntax: Boolean;
+  Parsed: TZonedDateTimeParseResult;
+
+  function RequiredIntegerField(const AValue: TGocciaValue; const AName: string): Integer;
+  begin
+    if IsUndefinedValue(AValue) then
+      ThrowTypeError(AMethod + ' requires ' + AName + ' property', SSuggestTemporalFromArg);
+    Result := ToIntegerWithTruncationValue(AValue);
+  end;
+
+  function OptionalIntegerField(const AValue: TGocciaValue; const ADefault: Integer): Integer;
+  begin
+    if IsUndefinedValue(AValue) then
+      Result := ADefault
+    else
+      Result := ToIntegerWithTruncationValue(AValue);
+  end;
 begin
   if AValue is TGocciaTemporalZonedDateTimeValue then
-    Result := TGocciaTemporalZonedDateTimeValue(AValue)
+  begin
+    ReadZonedDateTimeOptions(AOptions, AMethod, Overflow, OffsetOption);
+    Result := TGocciaTemporalZonedDateTimeValue(AValue);
+  end
   else if AValue is TGocciaStringLiteralValue then
   begin
-    // Parse ISO with timezone annotation: 2024-03-15T13:45:30+05:30[Asia/Kolkata]
-    if not TryParseISODateTimeWithOffset(TGocciaStringLiteralValue(AValue).Value,
-      DateRec, TimeRec, OffsetSeconds, TimeZoneStr) then
+    if not TryParseZonedDateTimeString(
+      NormalizeLeapSecondForTemporalDateTime(TGocciaStringLiteralValue(AValue).Value), Parsed) then
       ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['ZonedDateTime', AMethod]), SSuggestTemporalISOFormat);
-    if TimeZoneStr = '' then
-      ThrowRangeError(SErrorZonedDateTimeRequiresTZAnnotation, SSuggestTemporalTimezone);
+    if Parsed.TimeZoneFromOffset then
+      ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['ZonedDateTime', AMethod]), SSuggestTemporalISOFormat);
+    TimeZoneStr := CanonicalizeTimeZoneIdentifier(Parsed.TimeZone);
 
-    // Convert parsed local time to epoch ms using the parsed offset
-    EpochMs := DateToEpochDays(DateRec.Year, DateRec.Month, DateRec.Day) * MILLISECONDS_PER_DAY +
-               Int64(TimeRec.Hour) * MILLISECONDS_PER_HOUR +
-               Int64(TimeRec.Minute) * MILLISECONDS_PER_MINUTE +
-               Int64(TimeRec.Second) * MILLISECONDS_PER_SECOND +
-               TimeRec.Millisecond;
-    // Subtract offset to get UTC epoch ms
-    EpochMs := EpochMs - Int64(OffsetSeconds) * MILLISECONDS_PER_SECOND;
+    ReadZonedDateTimeOptions(AOptions, AMethod, Overflow, OffsetOption);
+    if Parsed.HasOffset and not (OffsetOption in [tooUse, tooIgnore]) then
+      ValidateZonedDateTimeLocalRange(Parsed.Date.Year, Parsed.Date.Month,
+        Parsed.Date.Day, Parsed.Time,
+        Parsed.Time.Microsecond * 1000 + Parsed.Time.Nanosecond, AMethod);
+    EpochMs := ApplyOffsetOption(Parsed.Date.Year, Parsed.Date.Month, Parsed.Date.Day,
+      Parsed.Time, TimeZoneStr, Parsed.HasOffset, Parsed.OffsetSeconds,
+      Parsed.HasUTCDesignator, OffsetOption, AMethod);
+    SubMs := Parsed.Time.Microsecond * 1000 + Parsed.Time.Nanosecond;
+    ValidateZonedDateTimeEpoch(EpochMs, SubMs, AMethod);
+    Result := TGocciaTemporalZonedDateTimeValue.Create(EpochMs, SubMs, TimeZoneStr);
+  end
+  else if AValue is TGocciaObjectValue then
+  begin
+    Obj := TGocciaObjectValue(AValue);
+
+    VCalendar := Obj.GetProperty('calendar');
+    CalendarFromProperty(VCalendar);
+
+    VDay := Obj.GetProperty('day');
+    Day := RequiredIntegerField(VDay, 'day');
+    VHour := Obj.GetProperty('hour');
+    TimeRec.Hour := OptionalIntegerField(VHour, 0);
+    VMicrosecond := Obj.GetProperty('microsecond');
+    TimeRec.Microsecond := OptionalIntegerField(VMicrosecond, 0);
+    VMillisecond := Obj.GetProperty('millisecond');
+    TimeRec.Millisecond := OptionalIntegerField(VMillisecond, 0);
+    VMinute := Obj.GetProperty('minute');
+    TimeRec.Minute := OptionalIntegerField(VMinute, 0);
+    VMonth := Obj.GetProperty('month');
+    HasMonth := not IsUndefinedValue(VMonth);
+    if HasMonth then
+      Month := ToIntegerWithTruncationValue(VMonth)
+    else
+      Month := 0;
+
+    VMonthCode := Obj.GetProperty('monthCode');
+    HasMonthCode := not IsUndefinedValue(VMonthCode);
+    MonthCodeStr := '';
+    if HasMonthCode then
+    begin
+      MonthCodeStr := MonthCodeStringFromProperty(VMonthCode, AMethod);
+      if not IsMonthCodeSyntaxValid(MonthCodeStr) then
+        ThrowRangeError(SErrorInvalidMonthCodeYearMonth, SSuggestTemporalMonthCode);
+    end;
+
+    VNanosecond := Obj.GetProperty('nanosecond');
+    TimeRec.Nanosecond := OptionalIntegerField(VNanosecond, 0);
+    VOffset := Obj.GetProperty(PROPERTY_OFFSET);
+    HasOffset := not IsUndefinedValue(VOffset);
+    OffsetStr := '';
+    if HasOffset then
+    begin
+      OffsetStr := OffsetStringFromProperty(VOffset, AMethod);
+      if (not ParseZonedDateTimeOffsetPart(OffsetStr, OffsetSeconds,
+        OffsetHasUTCDesignator, OffsetHasSubMinuteSyntax)) or OffsetHasUTCDesignator then
+        ThrowRangeError(Format(SErrorTemporalInvalidISOStringFor, ['ZonedDateTime', AMethod]), SSuggestTemporalISOFormat);
+    end
+    else
+      OffsetSeconds := 0;
+    VSecond := Obj.GetProperty('second');
+    TimeRec.Second := OptionalIntegerField(VSecond, 0);
+    VTimeZone := Obj.GetProperty(PROPERTY_TIME_ZONE);
+    TimeZoneStr := TimeZoneFromProperty(VTimeZone, AMethod);
+    VYear := Obj.GetProperty('year');
+    Year := RequiredIntegerField(VYear, 'year');
+
+    ReadZonedDateTimeOptions(AOptions, AMethod, Overflow, OffsetOption);
+
+    if HasMonthCode then
+    begin
+      if not MonthFromMonthCode(MonthCodeStr, MonthPart) then
+        ThrowRangeError(SErrorMonthCodeOutOfRange, SSuggestTemporalMonthCode);
+      if HasMonth and (Month <> MonthPart) then
+        ThrowRangeError(SErrorMonthCodeMismatch, SSuggestTemporalMonthCode);
+      Month := MonthPart;
+    end
+    else if not HasMonth then
+      ThrowTypeError(AMethod + ' requires month property', SSuggestTemporalFromArg);
+
+    if Month < 0 then
+      ThrowRangeError(Format(SErrorTemporalMonthOutOfRange, [Month]), SSuggestTemporalDateRange);
+    if (Month < 1) or (Month > 12) then
+    begin
+      if Overflow = toReject then
+        ThrowRangeError(Format(SErrorTemporalMonthOutOfRange, [Month]), SSuggestTemporalDateRange);
+      if Month < 1 then
+        Month := 1
+      else
+        Month := 12;
+    end;
+
+    if Day < 0 then
+      ThrowRangeError(Format(SErrorTemporalDayOutOfRange, [Day]), SSuggestTemporalDateRange);
+    if Day < 1 then
+    begin
+      if Overflow = toReject then
+        ThrowRangeError(Format(SErrorTemporalDayOutOfRange, [Day]), SSuggestTemporalDateRange);
+      Day := 1;
+    end;
+    MaxDay := DaysInMonth(Year, Month);
+    if Day > MaxDay then
+    begin
+      if Overflow = toReject then
+        ThrowRangeError(Format(SErrorTemporalDayOutOfRangeForMonth, [Day, Month]), SSuggestTemporalDateRange);
+      Day := MaxDay;
+    end;
+
+    if not IsValidTime(TimeRec.Hour, TimeRec.Minute, TimeRec.Second,
+      TimeRec.Millisecond, TimeRec.Microsecond, TimeRec.Nanosecond) then
+      ThrowRangeError(SErrorInvalidISOTime, SSuggestTemporalDateRange);
+
+    EpochMs := ApplyOffsetOption(Year, Month, Day, TimeRec, TimeZoneStr,
+      HasOffset, OffsetSeconds, False, OffsetOption, AMethod);
+
     SubMs := TimeRec.Microsecond * 1000 + TimeRec.Nanosecond;
+    if HasOffset and not (OffsetOption in [tooUse, tooIgnore]) then
+      ValidateZonedDateTimeLocalRange(Year, Month, Day, TimeRec, SubMs, AMethod);
+    ValidateZonedDateTimeEpoch(EpochMs, SubMs, AMethod);
     Result := TGocciaTemporalZonedDateTimeValue.Create(EpochMs, SubMs, TimeZoneStr);
   end
   else
   begin
-    ThrowTypeError(AMethod + ' requires a ZonedDateTime or string', SSuggestTemporalFromArg);
+    ThrowTypeError(AMethod + ' requires a ZonedDateTime, string, or object', SSuggestTemporalFromArg);
     Result := nil;
   end;
 end;
@@ -1331,7 +2361,7 @@ var
   RH, RM, RS, RMs, RUs, RNs: Int64;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.until');
-  Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.until');
+  Other := CoerceTemporalZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.until');
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
@@ -1390,7 +2420,7 @@ var
   RH, RM, RS, RMs, RUs, RNs: Int64;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.since');
-  Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.since');
+  Other := CoerceTemporalZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.since');
 
   OptionsObj := GetDiffOptions(AArgs, 1);
   LargestUnit := GetLargestUnit(OptionsObj, tuHour);
@@ -1562,7 +2592,7 @@ var
   Zdt, Other: TGocciaTemporalZonedDateTimeValue;
 begin
   Zdt := AsZonedDateTime(AThisValue, 'ZonedDateTime.prototype.equals');
-  Other := CoerceZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.equals');
+  Other := CoerceTemporalZonedDateTime(AArgs.GetElement(0), 'ZonedDateTime.prototype.equals');
 
   if (Zdt.FEpochMilliseconds = Other.FEpochMilliseconds) and
      (Zdt.FSubMillisecondNanoseconds = Other.FSubMillisecondNanoseconds) and

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -134,8 +134,19 @@ const
   HOURS_PER_DAY = 24;
   MONTHS_PER_YEAR = 12;
   DAYS_PER_WEEK = 7;
+  PROPERTY_CALENDAR = 'calendar';
+  PROPERTY_DAY = 'day';
+  PROPERTY_HOUR = 'hour';
+  PROPERTY_MICROSECOND = 'microsecond';
+  PROPERTY_MILLISECOND = 'millisecond';
+  PROPERTY_MINUTE = 'minute';
+  PROPERTY_MONTH = 'month';
+  PROPERTY_MONTH_CODE = 'monthCode';
+  PROPERTY_NANOSECOND = 'nanosecond';
   PROPERTY_TIME_ZONE = 'timeZone';
   PROPERTY_OFFSET = 'offset';
+  PROPERTY_SECOND = 'second';
+  PROPERTY_YEAR = 'year';
 
 type
   TTemporalDisambiguationOption = (tdoCompatible, tdoEarlier, tdoLater, tdoReject);
@@ -268,8 +279,27 @@ begin
 end;
 
 function NormalizeLeapSecondForTemporalDateTime(const AValue: string): string;
+var
+  SecondsSeparator: Integer;
+  TimeSeparator: Integer;
 begin
-  Result := StringReplace(AValue, ':60', ':59', []);
+  Result := AValue;
+  TimeSeparator := Pos('T', Result);
+  if TimeSeparator = 0 then
+    TimeSeparator := Pos('t', Result);
+  if TimeSeparator = 0 then
+    Exit;
+
+  SecondsSeparator := TimeSeparator + 6;
+  if (Length(Result) >= SecondsSeparator + 2) and
+     (Result[TimeSeparator + 3] = ':') and
+     (Result[SecondsSeparator] = ':') and
+     (Result[SecondsSeparator + 1] = '6') and
+     (Result[SecondsSeparator + 2] = '0') then
+  begin
+    Result[SecondsSeparator + 1] := '5';
+    Result[SecondsSeparator + 2] := '9';
+  end;
 end;
 
 function IsASCIIDigit(const AChar: Char): Boolean; inline;
@@ -1090,27 +1120,27 @@ begin
   begin
     Obj := TGocciaObjectValue(AValue);
 
-    VCalendar := Obj.GetProperty('calendar');
+    VCalendar := Obj.GetProperty(PROPERTY_CALENDAR);
     CalendarFromProperty(VCalendar);
 
-    VDay := Obj.GetProperty('day');
-    Day := RequiredIntegerField(VDay, 'day');
-    VHour := Obj.GetProperty('hour');
+    VDay := Obj.GetProperty(PROPERTY_DAY);
+    Day := RequiredIntegerField(VDay, PROPERTY_DAY);
+    VHour := Obj.GetProperty(PROPERTY_HOUR);
     TimeRec.Hour := OptionalIntegerField(VHour, 0);
-    VMicrosecond := Obj.GetProperty('microsecond');
+    VMicrosecond := Obj.GetProperty(PROPERTY_MICROSECOND);
     TimeRec.Microsecond := OptionalIntegerField(VMicrosecond, 0);
-    VMillisecond := Obj.GetProperty('millisecond');
+    VMillisecond := Obj.GetProperty(PROPERTY_MILLISECOND);
     TimeRec.Millisecond := OptionalIntegerField(VMillisecond, 0);
-    VMinute := Obj.GetProperty('minute');
+    VMinute := Obj.GetProperty(PROPERTY_MINUTE);
     TimeRec.Minute := OptionalIntegerField(VMinute, 0);
-    VMonth := Obj.GetProperty('month');
+    VMonth := Obj.GetProperty(PROPERTY_MONTH);
     HasMonth := not IsUndefinedValue(VMonth);
     if HasMonth then
       Month := ToIntegerWithTruncationValue(VMonth)
     else
       Month := 0;
 
-    VMonthCode := Obj.GetProperty('monthCode');
+    VMonthCode := Obj.GetProperty(PROPERTY_MONTH_CODE);
     HasMonthCode := not IsUndefinedValue(VMonthCode);
     MonthCodeStr := '';
     if HasMonthCode then
@@ -1120,7 +1150,7 @@ begin
         ThrowRangeError(SErrorInvalidMonthCodeYearMonth, SSuggestTemporalMonthCode);
     end;
 
-    VNanosecond := Obj.GetProperty('nanosecond');
+    VNanosecond := Obj.GetProperty(PROPERTY_NANOSECOND);
     TimeRec.Nanosecond := OptionalIntegerField(VNanosecond, 0);
     VOffset := Obj.GetProperty(PROPERTY_OFFSET);
     HasOffset := not IsUndefinedValue(VOffset);
@@ -1134,12 +1164,12 @@ begin
     end
     else
       OffsetSeconds := 0;
-    VSecond := Obj.GetProperty('second');
+    VSecond := Obj.GetProperty(PROPERTY_SECOND);
     TimeRec.Second := OptionalIntegerField(VSecond, 0);
     VTimeZone := Obj.GetProperty(PROPERTY_TIME_ZONE);
     TimeZoneStr := TimeZoneFromProperty(VTimeZone, AMethod);
-    VYear := Obj.GetProperty('year');
-    Year := RequiredIntegerField(VYear, 'year');
+    VYear := Obj.GetProperty(PROPERTY_YEAR);
+    Year := RequiredIntegerField(VYear, PROPERTY_YEAR);
 
     ReadZonedDateTimeOptions(AOptions, AMethod, Overflow, OffsetOption);
 

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -2563,7 +2563,7 @@ end;
 function TGocciaTypedArrayValue.TypedArrayToSorted(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA, NewTA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, Len: Integer;
   SortArgs: TGocciaArgumentsCollection;
   ResultRoot: TGocciaTempRoot;
 begin
@@ -2572,18 +2572,19 @@ begin
      not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) and
      not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorCustomSortMustBeFunction, SSuggestCallbackRequired);
-  NewTA := CreateSameKindArray(TA, TA.FLength);
+  Len := TA.Length;
+  NewTA := CreateSameKindArray(TA, Len);
   InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ResultRoot, NewTA);
   try
     if IsBigIntKind(TA.FKind) then
     begin
-      for I := 0 to TA.FLength - 1 do
+      for I := 0 to Len - 1 do
         NewTA.WriteBigIntElement(I, TA.ReadBigIntElement(I));
     end
     else
     begin
-      for I := 0 to TA.FLength - 1 do
+      for I := 0 to Len - 1 do
         NewTA.WriteElement(I, TA.ReadElement(I));
     end;
     SortArgs := TGocciaArgumentsCollection.Create;
@@ -2758,6 +2759,10 @@ var
   BufferByteLength: Integer;
   HasLength: Boolean;
   RawLen: Double;
+  Val: TGocciaValue;
+  ResultRoot: TGocciaTempRoot;
+  ValueRoots: array of TGocciaTempRoot;
+  ValueRootCount: Integer;
 begin
   BPE := TGocciaTypedArrayValue.BytesPerElement(FKind);
 
@@ -2896,6 +2901,8 @@ begin
         Iterator := TGocciaGenericIteratorValue.Create(Iterator,
           Iterator.GetProperty(PROP_NEXT));
       Values := TGocciaValueList.Create(False);
+      ValueRootCount := 0;
+      InitializeTempRoot(ResultRoot);
       try
         TGarbageCollector.Instance.AddTempRoot(Iterator);
         try
@@ -2903,7 +2910,13 @@ begin
             IterResult := Iterator.AdvanceNext;
             while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
             begin
-              Values.Add(IterResult.GetProperty(PROP_VALUE));
+              Val := IterResult.GetProperty(PROP_VALUE);
+              Values.Add(Val);
+              if ValueRootCount >= Length(ValueRoots) then
+                SetLength(ValueRoots, ValueRootCount * 2 + 4);
+              InitializeTempRoot(ValueRoots[ValueRootCount]);
+              AddTempRootIfNeeded(ValueRoots[ValueRootCount], Val);
+              Inc(ValueRootCount);
               IterResult := Iterator.AdvanceNext;
             end;
           except
@@ -2915,9 +2928,17 @@ begin
           TGarbageCollector.Instance.RemoveTempRoot(Iterator);
         end;
         NewTA := TGocciaTypedArrayValue.Create(FKind, Values.Count);
-        for I := 0 to Values.Count - 1 do
-          NewTA.WriteValueToElement(I, Values[I]);
+        AddTempRootIfNeeded(ResultRoot, NewTA);
+        try
+          for I := 0 to Values.Count - 1 do
+            NewTA.WriteValueToElement(I, Values[I]);
+        finally
+          RemoveTempRootIfNeeded(ResultRoot);
+        end;
       finally
+        for I := ValueRootCount - 1 downto 0 do
+          RemoveTempRootIfNeeded(ValueRoots[I]);
+        SetLength(ValueRoots, 0);
         Values.Free;
       end;
       Exit(NewTA);
@@ -3182,6 +3203,7 @@ var
   NewTA: TGocciaTypedArrayValue;
   ConstructorValue: TGocciaValue;
   I: Integer;
+  ResultRoot: TGocciaTempRoot;
 begin
   ConstructorValue := AThisValue;
   if (not Assigned(ConstructorValue)) or (not ConstructorValue.IsConstructable) then
@@ -3189,9 +3211,15 @@ begin
       SSuggestTypedArrayConstructorReceiver);
   NewTA := CreateTypedArrayFromConstructor(ConstructorValue,
     'TypedArray.of', AArgs.Length);
-  for I := 0 to AArgs.Length - 1 do
-    NewTA.WriteValueToElement(I, AArgs.GetElement(I));
-  Result := NewTA;
+  InitializeTempRoot(ResultRoot);
+  AddTempRootIfNeeded(ResultRoot, NewTA);
+  try
+    for I := 0 to AArgs.Length - 1 do
+      NewTA.WriteValueToElement(I, AArgs.GetElement(I));
+    Result := NewTA;
+  finally
+    RemoveTempRootIfNeeded(ResultRoot);
+  end;
 end;
 
 initialization

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -11,6 +11,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ClassValue,
@@ -73,6 +74,7 @@ type
     procedure AssignProperty(const AName: string; const AValue: TGocciaValue; const ACanCreate: Boolean = True); override;
     function AssignPropertyWithReceiver(const AName: string; const AValue: TGocciaValue; const AReceiver: TGocciaValue): Boolean; override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
+    function DeleteProperty(const AName: string): Boolean; override;
     function HasProperty(const AName: string): Boolean; override;
     function HasOwnProperty(const AName: string): Boolean; override;
     function GetOwnPropertyKeys: TArray<string>; override;
@@ -88,6 +90,7 @@ type
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
     class procedure SetSharedPrototypeParent(const AParent: TGocciaObjectValue);
     class function GetSharedPrototypeObject: TGocciaObjectValue; static;
+    class function GetSharedPrototypeObjectForRealm(const ARealm: TGocciaRealm): TGocciaObjectValue; static;
     class procedure SetUint8Prototype(const APrototype: TGocciaObjectValue);
 
     property BufferValue: TGocciaValue read FBufferValue;
@@ -141,6 +144,9 @@ type
     constructor Create(const AName: string; const ASuperClass: TGocciaClassValue; const AKind: TGocciaTypedArrayKind);
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
     function NativeInstanceDefaultPrototype: TGocciaObjectValue; override;
+    function DefaultPrototypeForNewTarget(const ANewTarget: TGocciaValue;
+      const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
+    function GetClassLength: Integer; override;
     property Kind: TGocciaTypedArrayKind read FKind;
   end;
 
@@ -163,13 +169,14 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Realm,
+  Goccia.Scope,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.Iterator.Concrete,
+  Goccia.Values.Iterator.Generic,
   Goccia.Values.IteratorSupport,
   Goccia.Values.IteratorValue,
   Goccia.Values.NativeFunction,
@@ -213,6 +220,11 @@ begin
     Result := nil;
 end;
 
+function IsTypedArrayOutOfBounds(const AArray: TGocciaTypedArrayValue): Boolean; forward;
+
+function IsTypedArrayBackedByImmutableArrayBuffer(
+  const AArray: TGocciaTypedArrayValue): Boolean; forward;
+
 function RequireTypedArrayConstructor(
   const AThisValue: TGocciaValue;
   const AMethod: string): TGocciaClassValue;
@@ -238,7 +250,7 @@ begin
   Result := nil;
 end;
 
-function CreateTypedArrayFromConstructor(const AConstructor: TGocciaClassValue;
+function CreateTypedArrayFromConstructor(const AConstructor: TGocciaValue;
   const AMethod: string; const ALength: Integer): TGocciaTypedArrayValue;
 var
   ConstructArgs: TGocciaArgumentsCollection;
@@ -247,7 +259,7 @@ begin
   ConstructArgs := TGocciaArgumentsCollection.Create;
   try
     ConstructArgs.Add(TGocciaNumberLiteralValue.Create(ALength));
-    Constructed := AConstructor.Instantiate(ConstructArgs, AConstructor);
+    Constructed := ConstructValue(AConstructor, ConstructArgs, AConstructor);
   finally
     ConstructArgs.Free;
   end;
@@ -257,8 +269,11 @@ begin
       SSuggestTypedArrayConstructorReceiver);
 
   Result := TGocciaTypedArrayValue(Constructed);
-  if Result.Length < ALength then
+  if IsTypedArrayOutOfBounds(Result) or (Result.Length < ALength) then
     ThrowTypeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
+  if IsTypedArrayBackedByImmutableArrayBuffer(Result) then
+    ThrowTypeError('TypedArray constructor returned an immutable ArrayBuffer-backed view',
+      SSuggestTypedArrayLength);
 end;
 
 function ToBinaryElementKind(const AKind: TGocciaTypedArrayKind): TGocciaBinaryElementKind;
@@ -671,6 +686,7 @@ end;
 constructor TGocciaTypedArrayValue.Create(const AKind: TGocciaTypedArrayKind; const ALength: Integer);
 var
   ByteLen: Integer;
+  ByteLen64: Int64;
   Buf: TGocciaArrayBufferValue;
   Shared: TGocciaSharedPrototype;
 begin
@@ -679,7 +695,10 @@ begin
   FByteOffset := 0;
   FLength := ALength;
   FAutoLength := False;
-  ByteLen := ALength * BytesPerElement(AKind);
+  ByteLen64 := Int64(ALength) * Int64(BytesPerElement(AKind));
+  if (ALength < 0) or (ByteLen64 > High(Integer)) then
+    ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
+  ByteLen := Integer(ByteLen64);
   Buf := TGocciaArrayBufferValue.Create(ByteLen);
   FBufferValue := Buf;
   FBufferData := Buf.Data;
@@ -751,6 +770,7 @@ procedure TGocciaTypedArrayValue.InitializePrototype;
 var
   Members: TGocciaMemberCollection;
   Shared: TGocciaSharedPrototype;
+  ValuesMethod: TGocciaValue;
 begin
   if not Assigned(CurrentRealm) then Exit;
   if Assigned(GetTypedArrayShared) then Exit;
@@ -764,16 +784,16 @@ begin
   Members := TGocciaMemberCollection.Create;
   try
     Members.AddMethod(TypedArrayAt, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(TypedArrayFill, 3, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(TypedArrayCopyWithin, 3, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(TypedArrayFill, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(TypedArrayCopyWithin, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArraySlice, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArraySubarray, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(TypedArraySet, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(TypedArraySet, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArrayReverse, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArraySort, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(TypedArrayIndexOf, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(TypedArrayLastIndexOf, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(TypedArrayIncludes, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(TypedArrayIndexOf, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(TypedArrayLastIndexOf, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(TypedArrayIncludes, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArrayFind, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArrayFindIndex, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArrayFindLast, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -783,8 +803,8 @@ begin
     Members.AddMethod(TypedArrayForEach, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArrayMap, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArrayFilter, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(TypedArrayReduce, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(TypedArrayReduceRight, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(TypedArrayReduce, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(TypedArrayReduceRight, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArrayJoin, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod(PROP_TO_LOCALE_STRING, TypedArrayToLocaleString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(TypedArrayToString, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -809,6 +829,10 @@ begin
     Members.Free;
   end;
   RegisterMemberDefinitions(Shared.Prototype, FPrototypeMembers);
+  ValuesMethod := Shared.Prototype.GetProperty('values');
+  Shared.Prototype.DefineSymbolProperty(
+    TGocciaSymbolValue.WellKnownIterator,
+    TGocciaPropertyDescriptorData.Create(ValuesMethod, [pfConfigurable, pfWritable]));
 end;
 
 class procedure TGocciaTypedArrayValue.ExposePrototype(const AConstructor: TGocciaValue);
@@ -851,6 +875,20 @@ begin
     Result := nil;
 end;
 
+class function TGocciaTypedArrayValue.GetSharedPrototypeObjectForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GTypedArraySharedSlot));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
+end;
+
 class procedure TGocciaTypedArrayValue.SetUint8Prototype(const APrototype: TGocciaObjectValue);
 begin
   FUint8Prototype := APrototype;
@@ -878,8 +916,7 @@ begin
     Exit(TGocciaNumberLiteralValue.Create(GetLength * BytesPerElement(FKind)));
   if AName = PROP_BYTE_OFFSET then
   begin
-    if (FBufferValue is TGocciaArrayBufferValue) and
-       TGocciaArrayBufferValue(FBufferValue).Detached then
+    if IsTypedArrayOutOfBounds(Self) then
       Exit(TGocciaNumberLiteralValue.Create(0));
     Exit(TGocciaNumberLiteralValue.Create(FByteOffset));
   end;
@@ -1009,6 +1046,19 @@ begin
   Result := inherited GetOwnPropertyDescriptor(AName);
 end;
 
+// ES2026 §10.4.5.7 [[Delete]](P)
+function TGocciaTypedArrayValue.DeleteProperty(const AName: string): Boolean;
+var
+  IsNegativeZero: Boolean;
+  Index: Integer;
+  NumericIndex: Double;
+begin
+  if TryCanonicalNumericIndexString(AName, NumericIndex, IsNegativeZero) then
+    Exit(not IsValidIntegerIndexedElement(NumericIndex, IsNegativeZero, Index));
+
+  Result := inherited DeleteProperty(AName);
+end;
+
 function TGocciaTypedArrayValue.HasProperty(const AName: string): Boolean;
 var
   IsNegativeZero: Boolean;
@@ -1101,16 +1151,119 @@ begin
     TGocciaArrayBufferValue(AArray.FBufferValue).Detached;
 end;
 
-procedure EnsureTypedArrayAttached(const AArray: TGocciaTypedArrayValue; const AMethod: string);
+// ES2026 §23.2.4.4 ValidateTypedArray(obj, order)
+function IsTypedArrayOutOfBounds(const AArray: TGocciaTypedArrayValue): Boolean;
+var
+  BufferByteLength, ByteOffsetEnd: Int64;
 begin
   if IsDetachedTypedArray(AArray) then
+    Exit(True);
+
+  AArray.SyncBufferData;
+  BufferByteLength := System.Length(AArray.FBufferData);
+  if AArray.FAutoLength then
+    Exit(AArray.FByteOffset > BufferByteLength);
+
+  ByteOffsetEnd := Int64(AArray.FByteOffset) +
+    Int64(AArray.FLength) * Int64(TGocciaTypedArrayValue.BytesPerElement(AArray.FKind));
+  Result := (AArray.FByteOffset > BufferByteLength) or
+    (ByteOffsetEnd > BufferByteLength);
+end;
+
+function IsTypedArrayBackedByImmutableArrayBuffer(
+  const AArray: TGocciaTypedArrayValue): Boolean;
+begin
+  Result := (AArray.FBufferValue is TGocciaArrayBufferValue) and
+    TGocciaArrayBufferValue(AArray.FBufferValue).Immutable;
+end;
+
+procedure EnsureTypedArrayAttached(const AArray: TGocciaTypedArrayValue; const AMethod: string);
+begin
+  if IsTypedArrayOutOfBounds(AArray) then
     ThrowTypeError(Format(SErrorCannotUseDetachedTypedArray, [AMethod]), SSuggestArrayBufferDetached);
+end;
+
+procedure EnsureTypedArrayWritable(const AArray: TGocciaTypedArrayValue; const AMethod: string);
+begin
+  EnsureTypedArrayAttached(AArray, AMethod);
+  if IsTypedArrayBackedByImmutableArrayBuffer(AArray) then
+    ThrowTypeError(AMethod + ' cannot write to an immutable ArrayBuffer');
 end;
 
 function RequireAttachedTypedArray(const AThisValue: TGocciaValue; const AMethod: string): TGocciaTypedArrayValue;
 begin
   Result := RequireTypedArray(AThisValue, AMethod);
   EnsureTypedArrayAttached(Result, AMethod);
+end;
+
+function DefaultTypedArrayConstructor(const AKind: TGocciaTypedArrayKind): TGocciaValue;
+var
+  GlobalScope: TGocciaScope;
+begin
+  if Assigned(CurrentRealm) and (CurrentRealm.GlobalEnv is TGocciaScope) then
+  begin
+    GlobalScope := TGocciaScope(CurrentRealm.GlobalEnv);
+    if GlobalScope.TryGetBindingValue(TGocciaTypedArrayValue.KindName(AKind), Result) and
+       Assigned(Result) and Result.IsConstructable then
+      Exit;
+  end;
+
+  ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+  Result := nil;
+end;
+
+// ES2026 §7.3.22 SpeciesConstructor(O, defaultConstructor)
+function TypedArraySpeciesConstructor(const AArray: TGocciaTypedArrayValue): TGocciaValue;
+var
+  ConstructorValue, SpeciesValue: TGocciaValue;
+begin
+  Result := DefaultTypedArrayConstructor(AArray.FKind);
+  ConstructorValue := AArray.GetProperty(PROP_CONSTRUCTOR);
+  if ConstructorValue is TGocciaUndefinedLiteralValue then
+    Exit;
+
+  if not (ConstructorValue is TGocciaObjectValue) then
+    ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+
+  if (ConstructorValue is TGocciaClassValue) and
+     (TGocciaClassValue(ConstructorValue).Name = 'TypedArray') then
+    Exit;
+
+  SpeciesValue := TGocciaObjectValue(ConstructorValue).GetSymbolProperty(
+    TGocciaSymbolValue.WellKnownSpecies);
+  if (SpeciesValue is TGocciaUndefinedLiteralValue) or
+     (SpeciesValue is TGocciaNullLiteralValue) then
+    Exit;
+  if not SpeciesValue.IsConstructable then
+    ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+  Result := SpeciesValue;
+end;
+
+// ES2026 §23.2.4.3 TypedArraySpeciesCreate(exemplar, argumentList)
+function TypedArraySpeciesCreate(const AExemplar: TGocciaTypedArrayValue;
+  const AArguments: TGocciaArgumentsCollection): TGocciaTypedArrayValue;
+var
+  ConstructorValue, ConstructedValue: TGocciaValue;
+  ExpectedLength: Integer;
+begin
+  ConstructorValue := TypedArraySpeciesConstructor(AExemplar);
+  ConstructedValue := ConstructValue(ConstructorValue, AArguments, ConstructorValue);
+  if not (ConstructedValue is TGocciaTypedArrayValue) then
+    ThrowTypeError(Format(SErrorTypedArrayRequiresTypedArray,
+      ['TypedArraySpeciesCreate']), SSuggestTypedArrayConstructorReceiver);
+
+  Result := TGocciaTypedArrayValue(ConstructedValue);
+  if TGocciaTypedArrayValue.IsBigIntKind(Result.FKind) <>
+     TGocciaTypedArrayValue.IsBigIntKind(AExemplar.FKind) then
+    ThrowTypeError(SErrorBigIntTypedArrayCannotMix, SSuggestBigIntTypedArrayValue);
+
+  if (AArguments.Length = 1) and
+     (AArguments.GetElement(0) is TGocciaNumberLiteralValue) then
+  begin
+    ExpectedLength := Trunc(TGocciaNumberLiteralValue(AArguments.GetElement(0)).Value);
+    if IsTypedArrayOutOfBounds(Result) or (Result.Length < ExpectedLength) then
+      ThrowTypeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
+  end;
 end;
 
 function ToIntegerOrInfinityBounded(const AValue: TGocciaValue): Integer;
@@ -1214,8 +1367,14 @@ var
   EntryArray: TGocciaArrayValue;
   Len: Integer;
 begin
+  if FDone then
+  begin
+    ADone := True;
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  end;
+
   Len := CurrentLengthOrThrow;
-  if FDone or (FIndex >= Len) then
+  if FIndex >= Len then
   begin
     FDone := True;
     ADone := True;
@@ -1310,7 +1469,7 @@ var
   TA: TGocciaTypedArrayValue;
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.byteOffset');
-  if IsDetachedTypedArray(TA) then
+  if IsTypedArrayOutOfBounds(TA) then
     Exit(TGocciaNumberLiteralValue.Create(0));
   Result := TGocciaNumberLiteralValue.Create(TA.FByteOffset);
 end;
@@ -1334,16 +1493,17 @@ end;
 function TGocciaTypedArrayValue.TypedArrayAt(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  RelIndex, ActualIndex: Integer;
+  RelIndex, ActualIndex, Len: Integer;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.at');
+  Len := TA.Length;
   // ES2026 §23.2.3.1 step 4: a missing index coerces to 0, not undefined
   RelIndex := ToIntegerFromArgs(AArgs, 0);
   if RelIndex >= 0 then
     ActualIndex := RelIndex
   else
-    ActualIndex := TA.FLength + RelIndex;
-  if (ActualIndex < 0) or (ActualIndex >= TA.FLength) then
+    ActualIndex := Len + RelIndex;
+  if (ActualIndex < 0) or (ActualIndex >= Len) then
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
   Result := TA.GetElementAsValue(ActualIndex);
 end;
@@ -1354,16 +1514,21 @@ var
   TA: TGocciaTypedArrayValue;
   FillNum: TGocciaNumberLiteralValue;
   FillBigInt: Int64;
-  First, Final, I, RelStart, RelEnd: Integer;
+  First, Final, I, RelStart, RelEnd, Len: Integer;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.fill');
+  EnsureTypedArrayWritable(TA, 'TypedArray.prototype.fill');
+  Len := TA.Length;
   FillBigInt := 0;
   FillNum := nil;
   if IsBigIntKind(TA.FKind) then
   begin
-    if (AArgs.Length = 0) or not (AArgs.GetElement(0) is TGocciaBigIntValue) then
-      ThrowTypeError(SErrorBigIntTypedArrayRequiresBigInt, SSuggestBigIntTypedArrayValue);
-    FillBigInt := TGocciaBigIntValue(AArgs.GetElement(0)).Value.ToInt64;
+    if AArgs.Length = 0 then
+      FillBigInt := RawBigIntForKind(TA.FKind,
+        ToBigIntForTypedArray(TGocciaUndefinedLiteralValue.UndefinedValue))
+    else
+      FillBigInt := RawBigIntForKind(TA.FKind,
+        ToBigIntForTypedArray(AArgs.GetElement(0)));
   end
   else
   begin
@@ -1378,9 +1543,9 @@ begin
   begin
     RelStart := ToIntegerFromArgs(AArgs, 1);
     if RelStart < 0 then
-      First := Max(TA.FLength + RelStart, 0)
+      First := Max(Len + RelStart, 0)
     else
-      First := Min(RelStart, TA.FLength);
+      First := Min(RelStart, Len);
   end
   else
     First := 0;
@@ -1390,12 +1555,12 @@ begin
   begin
     RelEnd := ToIntegerFromArgs(AArgs, 2);
     if RelEnd < 0 then
-      Final := Max(TA.FLength + RelEnd, 0)
+      Final := Max(Len + RelEnd, 0)
     else
-      Final := Min(RelEnd, TA.FLength);
+      Final := Min(RelEnd, Len);
   end
   else
-    Final := TA.FLength;
+    Final := Len;
 
   EnsureTypedArrayAttached(TA, 'TypedArray.prototype.fill');
 
@@ -1416,32 +1581,37 @@ end;
 function TGocciaTypedArrayValue.TypedArrayCopyWithin(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  Target, Start, Final, Count, Direction, From, To_: Integer;
+  Target, Start, Final, Count, Direction, From, To_, Len, CurrentLen: Integer;
   BPE: Integer;
   TempBuf: TBytes;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.copyWithin');
-  if AArgs.Length < 2 then
-    Exit(AThisValue);
+  EnsureTypedArrayWritable(TA, 'TypedArray.prototype.copyWithin');
+  Len := TA.Length;
 
   Target := ToIntegerFromArgs(AArgs, 0);
   Start := ToIntegerFromArgs(AArgs, 1);
 
-  if Target < 0 then Target := Max(TA.FLength + Target, 0) else Target := Min(Target, TA.FLength);
-  if Start < 0 then Start := Max(TA.FLength + Start, 0) else Start := Min(Start, TA.FLength);
+  if Target < 0 then Target := Max(Len + Target, 0) else Target := Min(Target, Len);
+  if Start < 0 then Start := Max(Len + Start, 0) else Start := Min(Start, Len);
 
   if (AArgs.Length > 2) and not (AArgs.GetElement(2) is TGocciaUndefinedLiteralValue) then
   begin
     Final := ToIntegerFromArgs(AArgs, 2);
-    if Final < 0 then Final := Max(TA.FLength + Final, 0) else Final := Min(Final, TA.FLength);
+    if Final < 0 then Final := Max(Len + Final, 0) else Final := Min(Final, Len);
   end
   else
-    Final := TA.FLength;
+    Final := Len;
 
-  Count := Min(Final - Start, TA.FLength - Target);
+  Count := Min(Final - Start, Len - Target);
   if Count <= 0 then
     Exit(AThisValue);
   EnsureTypedArrayAttached(TA, 'TypedArray.prototype.copyWithin');
+  CurrentLen := TA.Length;
+  Count := Min(Count, Max(CurrentLen - Target, 0));
+  Count := Min(Count, Max(CurrentLen - Start, 0));
+  if Count <= 0 then
+    Exit(AThisValue);
 
   BPE := BytesPerElement(TA.FKind);
   SetLength(TempBuf, Count * BPE);
@@ -1457,14 +1627,16 @@ end;
 function TGocciaTypedArrayValue.TypedArraySlice(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA, NewTA: TGocciaTypedArrayValue;
-  First, Final, NewLen, I: Integer;
+  First, Final, NewLen, SourceLength, I: Integer;
+  ConstructorArgs: TGocciaArgumentsCollection;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.slice');
+  SourceLength := TA.Length;
 
   if AArgs.Length > 0 then
   begin
     First := ToIntegerFromArgs(AArgs, 0);
-    if First < 0 then First := Max(TA.FLength + First, 0) else First := Min(First, TA.FLength);
+    if First < 0 then First := Max(SourceLength + First, 0) else First := Min(First, SourceLength);
   end
   else
     First := 0;
@@ -1472,24 +1644,35 @@ begin
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
   begin
     Final := ToIntegerFromArgs(AArgs, 1);
-    if Final < 0 then Final := Max(TA.FLength + Final, 0) else Final := Min(Final, TA.FLength);
+    if Final < 0 then Final := Max(SourceLength + Final, 0) else Final := Min(Final, SourceLength);
   end
   else
-    Final := TA.FLength;
+    Final := SourceLength;
 
   NewLen := Max(Final - First, 0);
+  ConstructorArgs := TGocciaArgumentsCollection.Create(
+    [TGocciaNumberLiteralValue.Create(NewLen)]);
+  try
+    NewTA := TypedArraySpeciesCreate(TA, ConstructorArgs);
+  finally
+    ConstructorArgs.Free;
+  end;
+
   if NewLen > 0 then
     EnsureTypedArrayAttached(TA, 'TypedArray.prototype.slice');
-  NewTA := CreateSameKindArray(TA, NewLen);
+  if NewTA.FBufferValue <> TA.FBufferValue then
+    EnsureTypedArrayWritable(NewTA, 'TypedArray.prototype.slice');
   if IsBigIntKind(TA.FKind) then
   begin
     for I := 0 to NewLen - 1 do
-      NewTA.WriteBigIntElement(I, TA.ReadBigIntElement(First + I));
+      if First + I < TA.Length then
+        NewTA.WriteValueToElement(I, TA.GetElementAsValue(First + I));
   end
   else
   begin
     for I := 0 to NewLen - 1 do
-      NewTA.WriteElement(I, TA.ReadElement(First + I));
+      if First + I < TA.Length then
+        NewTA.WriteValueToElement(I, TA.GetElementAsValue(First + I));
   end;
   Result := NewTA;
 end;
@@ -1497,47 +1680,64 @@ end;
 // ES2026 §23.2.3.30 %TypedArray%.prototype.subarray(begin, end)
 function TGocciaTypedArrayValue.TypedArraySubarray(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  TA: TGocciaTypedArrayValue;
-  BeginIdx, EndIdx, NewLen, BPE: Integer;
+  TA, NewTA: TGocciaTypedArrayValue;
+  BeginIdx, EndIdx, NewLen, SourceLength, BPE: Integer;
+  EndIsUndefined, UseAutoLengthResult: Boolean;
+  ConstructorArgs: TGocciaArgumentsCollection;
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.subarray');
+  if IsTypedArrayOutOfBounds(TA) then
+    SourceLength := 0
+  else
+    SourceLength := TA.Length;
   BPE := BytesPerElement(TA.FKind);
 
   if AArgs.Length > 0 then
   begin
     BeginIdx := ToIntegerFromArgs(AArgs, 0);
-    if BeginIdx < 0 then BeginIdx := Max(TA.FLength + BeginIdx, 0) else BeginIdx := Min(BeginIdx, TA.FLength);
+    if BeginIdx < 0 then BeginIdx := Max(SourceLength + BeginIdx, 0) else BeginIdx := Min(BeginIdx, SourceLength);
   end
   else
     BeginIdx := 0;
 
-  if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
+  EndIsUndefined := (AArgs.Length <= 1) or
+    (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue);
+  if not EndIsUndefined then
   begin
     EndIdx := ToIntegerFromArgs(AArgs, 1);
-    if EndIdx < 0 then EndIdx := Max(TA.FLength + EndIdx, 0) else EndIdx := Min(EndIdx, TA.FLength);
+    if EndIdx < 0 then EndIdx := Max(SourceLength + EndIdx, 0) else EndIdx := Min(EndIdx, SourceLength);
   end
   else
-    EndIdx := TA.FLength;
+    EndIdx := SourceLength;
 
   NewLen := Max(EndIdx - BeginIdx, 0);
-  if NewLen > 0 then
-    EnsureTypedArrayAttached(TA, 'TypedArray.prototype.subarray');
-  if TA.FBufferValue is TGocciaSharedArrayBufferValue then
-    Result := TGocciaTypedArrayValue.Create(TA.FKind, TGocciaSharedArrayBufferValue(TA.FBufferValue), TA.FByteOffset + BeginIdx * BPE, NewLen)
-  else
-    Result := TGocciaTypedArrayValue.Create(TA.FKind, TGocciaArrayBufferValue(TA.FBufferValue), TA.FByteOffset + BeginIdx * BPE, NewLen);
-  TGocciaTypedArrayValue(Result).Prototype := TA.Prototype;
+  UseAutoLengthResult := TA.FAutoLength and EndIsUndefined;
+  ConstructorArgs := TGocciaArgumentsCollection.Create;
+  try
+    ConstructorArgs.Add(TA.FBufferValue);
+    ConstructorArgs.Add(TGocciaNumberLiteralValue.Create(
+      TA.FByteOffset + BeginIdx * BPE));
+    if not UseAutoLengthResult then
+      ConstructorArgs.Add(TGocciaNumberLiteralValue.Create(NewLen));
+    NewTA := TypedArraySpeciesCreate(TA, ConstructorArgs);
+  finally
+    ConstructorArgs.Free;
+  end;
+  Result := NewTA;
 end;
 
 // ES2026 §23.2.3.25 %TypedArray%.prototype.set(source [, offset])
 function TGocciaTypedArrayValue.TypedArraySet(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA, SrcTA: TGocciaTypedArrayValue;
-  TargetOffset, I, SrcLen: Integer;
+  TargetOffset, I, SrcLen, TargetLen, SourceLen: Integer;
   SrcArray: TGocciaArrayValue;
   SrcObj: TGocciaObjectValue;
+  NumberSnapshot: array of Double;
+  BigIntSnapshot: array of Int64;
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.set');
+  EnsureTypedArrayWritable(TA, 'TypedArray.prototype.set');
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorTypedArraySetRequiresArg, SSuggestTypedArraySetSource);
 
@@ -1551,33 +1751,41 @@ begin
     TargetOffset := 0;
 
   EnsureTypedArrayAttached(TA, 'TypedArray.prototype.set');
+  TargetLen := TA.Length;
 
   if AArgs.GetElement(0) is TGocciaTypedArrayValue then
   begin
     SrcTA := TGocciaTypedArrayValue(AArgs.GetElement(0));
     EnsureTypedArrayAttached(SrcTA, 'TypedArray.prototype.set');
-    if (TargetOffset > TA.FLength) or
-       (SrcTA.FLength > TA.FLength - TargetOffset) then
+    SourceLen := SrcTA.Length;
+    if (TargetOffset > TargetLen) or
+       (SourceLen > TargetLen - TargetOffset) then
       ThrowRangeError(SErrorTypedArraySourceTooLarge, SSuggestTypedArrayLength);
     // ES2026 §23.2.3.25.1 step 1.b: mixed BigInt/Number content types throw
     if IsBigIntKind(TA.FKind) <> IsBigIntKind(SrcTA.FKind) then
       ThrowTypeError(SErrorBigIntTypedArrayRequiresBigInt, SSuggestBigIntTypedArrayValue);
     if IsBigIntKind(TA.FKind) then
     begin
-      for I := 0 to SrcTA.FLength - 1 do
-        TA.WriteBigIntElement(TargetOffset + I, SrcTA.ReadBigIntElement(I));
+      SetLength(BigIntSnapshot, SourceLen);
+      for I := 0 to SourceLen - 1 do
+        BigIntSnapshot[I] := SrcTA.ReadBigIntElement(I);
+      for I := 0 to SourceLen - 1 do
+        TA.WriteBigIntElement(TargetOffset + I, BigIntSnapshot[I]);
     end
     else
     begin
-      for I := 0 to SrcTA.FLength - 1 do
-        TA.WriteElement(TargetOffset + I, SrcTA.ReadElement(I));
+      SetLength(NumberSnapshot, SourceLen);
+      for I := 0 to SourceLen - 1 do
+        NumberSnapshot[I] := SrcTA.ReadElement(I);
+      for I := 0 to SourceLen - 1 do
+        TA.WriteElement(TargetOffset + I, NumberSnapshot[I]);
     end;
   end
   else if AArgs.GetElement(0) is TGocciaArrayValue then
   begin
     SrcArray := TGocciaArrayValue(AArgs.GetElement(0));
-    if (TargetOffset > TA.FLength) or
-       (SrcArray.Elements.Count > TA.FLength - TargetOffset) then
+    if (TargetOffset > TargetLen) or
+       (SrcArray.Elements.Count > TargetLen - TargetOffset) then
       ThrowRangeError(SErrorTypedArraySourceTooLarge, SSuggestTypedArrayLength);
     for I := 0 to SrcArray.Elements.Count - 1 do
       TA.WriteValueToElement(TargetOffset + I, SrcArray.Elements[I]);
@@ -1587,8 +1795,8 @@ begin
     // ES2026 §23.2.3.25.2 SetTypedArrayFromArrayLike
     SrcObj := ToObject(AArgs.GetElement(0));
     SrcLen := LengthOfArrayLike(SrcObj);
-    if (TargetOffset > TA.FLength) or
-       (SrcLen > TA.FLength - TargetOffset) then
+    if (TargetOffset > TargetLen) or
+       (SrcLen > TargetLen - TargetOffset) then
       ThrowRangeError(SErrorTypedArraySourceTooLarge, SSuggestTypedArrayLength);
     for I := 0 to SrcLen - 1 do
       TA.WriteValueToElement(TargetOffset + I, SrcObj.GetProperty(IntToStr(I)));
@@ -1601,27 +1809,29 @@ end;
 function TGocciaTypedArrayValue.TypedArrayReverse(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, Len: Integer;
   Tmp: Double;
   TmpBig: Int64;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.reverse');
+  EnsureTypedArrayWritable(TA, 'TypedArray.prototype.reverse');
+  Len := TA.Length;
   if IsBigIntKind(TA.FKind) then
   begin
-    for I := 0 to (TA.FLength div 2) - 1 do
+    for I := 0 to (Len div 2) - 1 do
     begin
       TmpBig := TA.ReadBigIntElement(I);
-      TA.WriteBigIntElement(I, TA.ReadBigIntElement(TA.FLength - 1 - I));
-      TA.WriteBigIntElement(TA.FLength - 1 - I, TmpBig);
+      TA.WriteBigIntElement(I, TA.ReadBigIntElement(Len - 1 - I));
+      TA.WriteBigIntElement(Len - 1 - I, TmpBig);
     end;
   end
   else
   begin
-    for I := 0 to (TA.FLength div 2) - 1 do
+    for I := 0 to (Len div 2) - 1 do
     begin
       Tmp := TA.ReadElement(I);
-      TA.WriteElement(I, TA.ReadElement(TA.FLength - 1 - I));
-      TA.WriteElement(TA.FLength - 1 - I, Tmp);
+      TA.WriteElement(I, TA.ReadElement(Len - 1 - I));
+      TA.WriteElement(Len - 1 - I, Tmp);
     end;
   end;
   Result := AThisValue;
@@ -1631,172 +1841,177 @@ end;
 function TGocciaTypedArrayValue.TypedArraySort(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I, J, SortLen, NaNCount: Integer;
-  Tmp, CompResult: Double;
-  TmpBig: Int64;
+  I, J, SortLen: Integer;
+  NumberValues: array of Double;
+  BigIntValues: array of Int64;
+  TmpNumber, CompResult: Double;
+  TmpBigInt: Int64;
   HasCompare: Boolean;
-  CompareArgs: TGocciaArgumentsCollection;
-  CompareResult: TGocciaValue;
-  IsFloat: Boolean;
-  ZeroJ: Double;
-  ZeroJBits: Int64 absolute ZeroJ;
-  TmpZeroBits: Int64 absolute Tmp;
-  ArrayRoot: TGocciaTempRoot;
+  AbortSortWriteback: Boolean;
+  Comparator: TGocciaValue;
+
+  function NumberBits(const AValue: Double): Int64;
+  begin
+    Move(AValue, Result, SizeOf(Result));
+  end;
+
+  function BigIntValueFromRaw(const ARaw: Int64): TGocciaBigIntValue;
+  begin
+    if TA.FKind = takBigUint64 then
+      Result := TGocciaBigIntValue.Create(BigIntFromQWord(QWord(ARaw)))
+    else
+      Result := TGocciaBigIntValue.Create(TBigInteger.FromInt64(ARaw));
+  end;
+
+  function CallComparator(const ALeft, ARight: TGocciaValue): Double;
+  var
+    CompareArgs: TGocciaArgumentsCollection;
+    CompareResult: TGocciaValue;
+  begin
+    CompareArgs := TGocciaArgumentsCollection.Create;
+    try
+      CompareArgs.Add(ALeft);
+      CompareArgs.Add(ARight);
+      CompareResult := InvokeCallable(Comparator, CompareArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue);
+      Result := CompareResult.ToNumberLiteral.Value;
+      if Math.IsNaN(Result) then
+        Result := 0;
+      AbortSortWriteback := IsTypedArrayOutOfBounds(TA);
+    finally
+      CompareArgs.Free;
+    end;
+  end;
+
+  function CompareNumbers(const ALeft, ARight: Double): Double;
+  var
+    LeftBits, RightBits: Int64;
+  begin
+    if HasCompare then
+      Exit(CallComparator(TGocciaNumberLiteralValue.Create(ALeft),
+        TGocciaNumberLiteralValue.Create(ARight)));
+
+    if Math.IsNaN(ALeft) then
+    begin
+      if Math.IsNaN(ARight) then
+        Exit(0);
+      Exit(1);
+    end;
+    if Math.IsNaN(ARight) then
+      Exit(-1);
+
+    if ALeft < ARight then
+      Exit(-1);
+    if ALeft > ARight then
+      Exit(1);
+
+    if (ALeft = 0) and (ARight = 0) then
+    begin
+      LeftBits := NumberBits(ALeft);
+      RightBits := NumberBits(ARight);
+      if (LeftBits < 0) and (RightBits >= 0) then
+        Exit(-1);
+      if (LeftBits >= 0) and (RightBits < 0) then
+        Exit(1);
+    end;
+
+    Result := 0;
+  end;
+
+  function CompareBigInts(const ALeft, ARight: Int64): Double;
+  begin
+    if HasCompare then
+      Exit(CallComparator(BigIntValueFromRaw(ALeft), BigIntValueFromRaw(ARight)));
+
+    if TA.FKind = takBigUint64 then
+    begin
+      if QWord(ALeft) < QWord(ARight) then
+        Exit(-1);
+      if QWord(ALeft) > QWord(ARight) then
+        Exit(1);
+    end
+    else
+    begin
+      if ALeft < ARight then
+        Exit(-1);
+      if ALeft > ARight then
+        Exit(1);
+    end;
+
+    Result := 0;
+  end;
+
 begin
+  Comparator := TGocciaUndefinedLiteralValue.UndefinedValue;
+  HasCompare := False;
+  AbortSortWriteback := False;
+  if AArgs.Length > 0 then
+  begin
+    if not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
+    begin
+      if not AArgs.GetElement(0).IsCallable then
+        ThrowTypeError(SErrorCustomSortMustBeFunction, SSuggestCallbackRequired);
+      Comparator := AArgs.GetElement(0);
+      HasCompare := True;
+    end;
+  end;
+
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.sort');
-  HasCompare := (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable;
-  SortLen := TA.FLength;
-  InitializeTempRoot(ArrayRoot);
+  EnsureTypedArrayWritable(TA, 'TypedArray.prototype.sort');
+  SortLen := TA.Length;
 
   // BigInt sort path
   if IsBigIntKind(TA.FKind) then
   begin
+    SetLength(BigIntValues, SortLen);
+    for I := 0 to SortLen - 1 do
+      BigIntValues[I] := TA.ReadBigIntElement(I);
+
     for I := 1 to SortLen - 1 do
     begin
-      TmpBig := TA.ReadBigIntElement(I);
+      TmpBigInt := BigIntValues[I];
       J := I - 1;
       while J >= 0 do
       begin
-        if HasCompare then
-        begin
-          CompareArgs := TGocciaArgumentsCollection.Create;
-          try
-            if TA.FKind = takBigUint64 then
-            begin
-              CompareArgs.Add(TGocciaBigIntValue.Create(BigIntFromQWord(QWord(TA.ReadBigIntElement(J)))));
-              CompareArgs.Add(TGocciaBigIntValue.Create(BigIntFromQWord(QWord(TmpBig))));
-            end
-            else
-            begin
-              CompareArgs.Add(TGocciaBigIntValue.Create(TBigInteger.FromInt64(TA.ReadBigIntElement(J))));
-              CompareArgs.Add(TGocciaBigIntValue.Create(TBigInteger.FromInt64(TmpBig)));
-            end;
-            AddTempRootIfNeeded(ArrayRoot, TA);
-            try
-              CompareResult := InvokeCallable(AArgs.GetElement(0), CompareArgs,
-                TGocciaUndefinedLiteralValue.UndefinedValue);
-            finally
-              RemoveTempRootIfNeeded(ArrayRoot);
-            end;
-            CompResult := CompareResult.ToNumberLiteral.Value;
-          finally
-            CompareArgs.Free;
-          end;
-        end
-        else
-        begin
-          if TA.FKind = takBigUint64 then
-          begin
-            // Unsigned comparison to avoid sign confusion for values >= 2^63
-            if QWord(TA.ReadBigIntElement(J)) > QWord(TmpBig) then
-              CompResult := 1
-            else if QWord(TA.ReadBigIntElement(J)) < QWord(TmpBig) then
-              CompResult := -1
-            else
-              CompResult := 0;
-          end
-          else
-          begin
-            if TA.ReadBigIntElement(J) > TmpBig then
-              CompResult := 1
-            else if TA.ReadBigIntElement(J) < TmpBig then
-              CompResult := -1
-            else
-              CompResult := 0;
-          end;
-        end;
-
-        if CompResult > 0 then
-        begin
-          TA.WriteBigIntElement(J + 1, TA.ReadBigIntElement(J));
-          Dec(J);
-        end
-        else
+        CompResult := CompareBigInts(BigIntValues[J], TmpBigInt);
+        if AbortSortWriteback then
+          Exit(AThisValue);
+        if CompResult <= 0 then
           Break;
+        BigIntValues[J + 1] := BigIntValues[J];
+        Dec(J);
       end;
-      TA.WriteBigIntElement(J + 1, TmpBig);
+      BigIntValues[J + 1] := TmpBigInt;
     end;
+
+    for I := 0 to SortLen - 1 do
+      TA.WriteBigIntElement(I, BigIntValues[I]);
     Exit(AThisValue);
   end;
 
-  // For float kinds, partition NaN values to the end before sorting
-  IsFloat := IsFloatKind(TA.FKind);
-  if IsFloat and not HasCompare then
-  begin
-    NaNCount := 0;
-    J := 0;
-    for I := 0 to SortLen - 1 do
-    begin
-      Tmp := TA.ReadElement(I);
-      if Math.IsNaN(Tmp) then
-        Inc(NaNCount)
-      else
-      begin
-        if J <> I then
-          TA.WriteElement(J, Tmp);
-        Inc(J);
-      end;
-    end;
-    SortLen := SortLen - NaNCount;
-    for I := SortLen to SortLen + NaNCount - 1 do
-      TA.WriteElement(I, Math.NaN);
-  end;
+  SetLength(NumberValues, SortLen);
+  for I := 0 to SortLen - 1 do
+    NumberValues[I] := TA.ReadElement(I);
 
   for I := 1 to SortLen - 1 do
   begin
-    Tmp := TA.ReadElement(I);
+    TmpNumber := NumberValues[I];
     J := I - 1;
     while J >= 0 do
     begin
-      if HasCompare then
-      begin
-        CompareArgs := TGocciaArgumentsCollection.Create;
-        try
-          CompareArgs.Add(TGocciaNumberLiteralValue.Create(TA.ReadElement(J)));
-          CompareArgs.Add(TGocciaNumberLiteralValue.Create(Tmp));
-          AddTempRootIfNeeded(ArrayRoot, TA);
-          try
-            CompareResult := InvokeCallable(AArgs.GetElement(0), CompareArgs,
-              TGocciaUndefinedLiteralValue.UndefinedValue);
-          finally
-            RemoveTempRootIfNeeded(ArrayRoot);
-          end;
-          CompResult := CompareResult.ToNumberLiteral.Value;
-        finally
-          CompareArgs.Free;
-        end;
-      end
-      else
-      begin
-        if TA.ReadElement(J) > Tmp then
-          CompResult := 1
-        else if TA.ReadElement(J) < Tmp then
-          CompResult := -1
-        else if IsFloat and (Tmp = 0) then
-        begin
-          // Distinguish -0 from +0: spec requires -0 < +0
-          ZeroJ := TA.ReadElement(J);
-          if (ZeroJBits >= 0) and (TmpZeroBits < 0) then
-            CompResult := 1  // J is +0, Tmp is -0: +0 > -0
-          else if (ZeroJBits < 0) and (TmpZeroBits >= 0) then
-            CompResult := -1  // J is -0, Tmp is +0: -0 < +0
-          else
-            CompResult := 0;
-        end
-        else
-          CompResult := 0;
-      end;
-
-      if CompResult > 0 then
-      begin
-        TA.WriteElement(J + 1, TA.ReadElement(J));
-        Dec(J);
-      end
-      else
+      CompResult := CompareNumbers(NumberValues[J], TmpNumber);
+      if AbortSortWriteback then
+        Exit(AThisValue);
+      if CompResult <= 0 then
         Break;
+      NumberValues[J + 1] := NumberValues[J];
+      Dec(J);
     end;
-    TA.WriteElement(J + 1, Tmp);
+    NumberValues[J + 1] := TmpNumber;
   end;
+
+  for I := 0 to SortLen - 1 do
+    TA.WriteElement(I, NumberValues[I]);
   Result := AThisValue;
 end;
 
@@ -1805,10 +2020,11 @@ function TGocciaTypedArrayValue.TypedArrayIndexOf(const AArgs: TGocciaArgumentsC
 var
   TA: TGocciaTypedArrayValue;
   SearchValue: TGocciaValue;
-  I, StartIdx: Integer;
+  I, StartIdx, Len: Integer;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.indexOf');
-  if TA.FLength = 0 then
+  Len := TA.Length;
+  if Len = 0 then
     Exit(TGocciaNumberLiteralValue.Create(-1));
   if AArgs.Length = 0 then
     Exit(TGocciaNumberLiteralValue.Create(-1));
@@ -1816,16 +2032,16 @@ begin
   if AArgs.Length > 1 then
   begin
     StartIdx := ToIntegerFromArgs(AArgs, 1);
-    if StartIdx < 0 then StartIdx := Max(TA.FLength + StartIdx, 0);
+    if StartIdx < 0 then StartIdx := Max(Len + StartIdx, 0);
   end
   else
     StartIdx := 0;
 
-  if IsDetachedTypedArray(TA) then
+  if IsTypedArrayOutOfBounds(TA) then
     Exit(TGocciaNumberLiteralValue.Create(-1));
 
   SearchValue := AArgs.GetElement(0);
-  for I := StartIdx to TA.FLength - 1 do
+  for I := StartIdx to Len - 1 do
     if IsStrictEqual(TA.GetElementAsValue(I), SearchValue) then
       Exit(TGocciaNumberLiteralValue.Create(I));
   Result := TGocciaNumberLiteralValue.Create(-1);
@@ -1836,26 +2052,27 @@ function TGocciaTypedArrayValue.TypedArrayLastIndexOf(const AArgs: TGocciaArgume
 var
   TA: TGocciaTypedArrayValue;
   SearchValue: TGocciaValue;
-  I, StartIdx: Integer;
+  I, StartIdx, Len: Integer;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.lastIndexOf');
-  if TA.FLength = 0 then
+  Len := TA.Length;
+  if Len = 0 then
     Exit(TGocciaNumberLiteralValue.Create(-1));
   if AArgs.Length = 0 then
     Exit(TGocciaNumberLiteralValue.Create(-1));
   if AArgs.Length > 1 then
   begin
     StartIdx := ToIntegerFromArgs(AArgs, 1);
-    if StartIdx < 0 then StartIdx := TA.FLength + StartIdx;
+    if StartIdx < 0 then StartIdx := Len + StartIdx;
   end
   else
-    StartIdx := TA.FLength - 1;
+    StartIdx := Len - 1;
 
-  if IsDetachedTypedArray(TA) then
+  if IsTypedArrayOutOfBounds(TA) then
     Exit(TGocciaNumberLiteralValue.Create(-1));
 
   SearchValue := AArgs.GetElement(0);
-  for I := Min(StartIdx, TA.FLength - 1) downto 0 do
+  for I := Min(StartIdx, Len - 1) downto 0 do
     if IsStrictEqual(TA.GetElementAsValue(I), SearchValue) then
       Exit(TGocciaNumberLiteralValue.Create(I));
   Result := TGocciaNumberLiteralValue.Create(-1);
@@ -1866,23 +2083,24 @@ function TGocciaTypedArrayValue.TypedArrayIncludes(const AArgs: TGocciaArguments
 var
   TA: TGocciaTypedArrayValue;
   SearchValue: TGocciaValue;
-  I, StartIdx: Integer;
+  I, StartIdx, Len: Integer;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.includes');
-  if TA.FLength = 0 then
+  Len := TA.Length;
+  if Len = 0 then
     Exit(TGocciaBooleanLiteralValue.FalseValue);
   if AArgs.Length = 0 then
     Exit(TGocciaBooleanLiteralValue.FalseValue);
   if AArgs.Length > 1 then
   begin
     StartIdx := ToIntegerFromArgs(AArgs, 1);
-    if StartIdx < 0 then StartIdx := Max(TA.FLength + StartIdx, 0);
+    if StartIdx < 0 then StartIdx := Max(Len + StartIdx, 0);
   end
   else
     StartIdx := 0;
 
   SearchValue := AArgs.GetElement(0);
-  for I := StartIdx to TA.FLength - 1 do
+  for I := StartIdx to Len - 1 do
     if IsSameValueZero(TA.GetElementAsValue(I), SearchValue) then
       Exit(TGocciaBooleanLiteralValue.TrueValue);
   Result := TGocciaBooleanLiteralValue.FalseValue;
@@ -1892,17 +2110,18 @@ end;
 function TGocciaTypedArrayValue.TypedArrayFind(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   Element, CallResult, ThisArg: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.find');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFindCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
-  for I := 0 to TA.FLength - 1 do
+  for I := 0 to SourceLength - 1 do
   begin
     Element := TA.GetElementAsValue(I);
     CallResult := InvokeCallback(AArgs.GetElement(0), Element, TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
@@ -1916,17 +2135,18 @@ end;
 function TGocciaTypedArrayValue.TypedArrayFindIndex(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   Element, CallResult, ThisArg: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.findIndex');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFindIndexCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
-  for I := 0 to TA.FLength - 1 do
+  for I := 0 to SourceLength - 1 do
   begin
     Element := TA.GetElementAsValue(I);
     CallResult := InvokeCallback(AArgs.GetElement(0), Element, TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
@@ -1940,17 +2160,18 @@ end;
 function TGocciaTypedArrayValue.TypedArrayFindLast(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   Element, CallResult, ThisArg: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.findLast');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFindLastCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
-  for I := TA.FLength - 1 downto 0 do
+  for I := SourceLength - 1 downto 0 do
   begin
     Element := TA.GetElementAsValue(I);
     CallResult := InvokeCallback(AArgs.GetElement(0), Element, TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
@@ -1964,17 +2185,18 @@ end;
 function TGocciaTypedArrayValue.TypedArrayFindLastIndex(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   Element, CallResult, ThisArg: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.findLastIndex');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFindLastIndexCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
-  for I := TA.FLength - 1 downto 0 do
+  for I := SourceLength - 1 downto 0 do
   begin
     Element := TA.GetElementAsValue(I);
     CallResult := InvokeCallback(AArgs.GetElement(0), Element, TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
@@ -1988,17 +2210,18 @@ end;
 function TGocciaTypedArrayValue.TypedArrayEvery(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   CallResult, ThisArg: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.every');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayEveryCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
-  for I := 0 to TA.FLength - 1 do
+  for I := 0 to SourceLength - 1 do
   begin
     CallResult := InvokeCallback(AArgs.GetElement(0),
       TA.GetElementAsValue(I),
@@ -2013,17 +2236,18 @@ end;
 function TGocciaTypedArrayValue.TypedArraySome(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   CallResult, ThisArg: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.some');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArraySomeCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
-  for I := 0 to TA.FLength - 1 do
+  for I := 0 to SourceLength - 1 do
   begin
     CallResult := InvokeCallback(AArgs.GetElement(0),
       TA.GetElementAsValue(I),
@@ -2038,17 +2262,18 @@ end;
 function TGocciaTypedArrayValue.TypedArrayForEach(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   ThisArg: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.forEach');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayForEachCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
-  for I := 0 to TA.FLength - 1 do
+  for I := 0 to SourceLength - 1 do
     InvokeCallback(AArgs.GetElement(0),
       TA.GetElementAsValue(I),
       TGocciaNumberLiteralValue.Create(I), AThisValue, ThisArg);
@@ -2059,22 +2284,31 @@ end;
 function TGocciaTypedArrayValue.TypedArrayMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA, NewTA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   CallResult, ThisArg: TGocciaValue;
   ResultRoot: TGocciaTempRoot;
+  ConstructorArgs: TGocciaArgumentsCollection;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.map');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayMapCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
     ThisArg := AArgs.GetElement(1)
   else
     ThisArg := TGocciaUndefinedLiteralValue.UndefinedValue;
-  NewTA := CreateSameKindArray(TA, TA.FLength);
+  ConstructorArgs := TGocciaArgumentsCollection.Create(
+    [TGocciaNumberLiteralValue.Create(SourceLength)]);
+  try
+    NewTA := TypedArraySpeciesCreate(TA, ConstructorArgs);
+  finally
+    ConstructorArgs.Free;
+  end;
+  EnsureTypedArrayWritable(NewTA, 'TypedArray.prototype.map');
   InitializeTempRoot(ResultRoot);
   AddTempRootIfNeeded(ResultRoot, NewTA);
   try
-    for I := 0 to TA.FLength - 1 do
+    for I := 0 to SourceLength - 1 do
     begin
       CallResult := InvokeCallback(AArgs.GetElement(0),
         TA.GetElementAsValue(I),
@@ -2091,11 +2325,13 @@ end;
 function TGocciaTypedArrayValue.TypedArrayFilter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA, NewTA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   CallResult, ThisArg, Element: TGocciaValue;
   Kept: TGocciaValueList;
+  ConstructorArgs: TGocciaArgumentsCollection;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.filter');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayFilterCallable, SSuggestTypedArrayCallable);
   if AArgs.Length > 1 then
@@ -2105,7 +2341,7 @@ begin
 
   Kept := TGocciaValueList.Create(False);
   try
-    for I := 0 to TA.FLength - 1 do
+    for I := 0 to SourceLength - 1 do
     begin
       Element := TA.GetElementAsValue(I);
       CallResult := InvokeCallback(AArgs.GetElement(0),
@@ -2114,10 +2350,17 @@ begin
       begin
         Kept.Add(Element);
         if Assigned(TGarbageCollector.Instance) then
-          TGarbageCollector.Instance.AddTempRoot(Element);
+        TGarbageCollector.Instance.AddTempRoot(Element);
       end;
     end;
-    NewTA := CreateSameKindArray(TA, Kept.Count);
+    ConstructorArgs := TGocciaArgumentsCollection.Create(
+      [TGocciaNumberLiteralValue.Create(Kept.Count)]);
+    try
+      NewTA := TypedArraySpeciesCreate(TA, ConstructorArgs);
+    finally
+      ConstructorArgs.Free;
+    end;
+    EnsureTypedArrayWritable(NewTA, 'TypedArray.prototype.filter');
     for I := 0 to Kept.Count - 1 do
       NewTA.WriteValueToElement(I, Kept[I]);
     Result := NewTA;
@@ -2133,11 +2376,12 @@ end;
 function TGocciaTypedArrayValue.TypedArrayReduce(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   Accumulator: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.reduce');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayReduceCallable, SSuggestTypedArrayCallable);
 
@@ -2148,13 +2392,13 @@ begin
   end
   else
   begin
-    if TA.FLength = 0 then
+    if SourceLength = 0 then
       ThrowTypeError(SErrorReduceEmptyTypedArray, SSuggestReduceInitialValue);
     Accumulator := TA.GetElementAsValue(0);
     I := 1;
   end;
 
-  while I < TA.FLength do
+  while I < SourceLength do
   begin
     CallArgs := TGocciaArgumentsCollection.Create;
     try
@@ -2176,25 +2420,26 @@ end;
 function TGocciaTypedArrayValue.TypedArrayReduceRight(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I: Integer;
+  I, SourceLength: Integer;
   Accumulator: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.reduceRight');
+  SourceLength := TA.Length;
   if (AArgs.Length = 0) or not AArgs.GetElement(0).IsCallable then
     ThrowTypeError(SErrorTypedArrayReduceRightCallable, SSuggestTypedArrayCallable);
 
   if AArgs.Length >= 2 then
   begin
     Accumulator := AArgs.GetElement(1);
-    I := TA.FLength - 1;
+    I := SourceLength - 1;
   end
   else
   begin
-    if TA.FLength = 0 then
+    if SourceLength = 0 then
       ThrowTypeError(SErrorReduceEmptyTypedArray, SSuggestReduceInitialValue);
-    Accumulator := TA.GetElementAsValue(TA.FLength - 1);
-    I := TA.FLength - 2;
+    Accumulator := TA.GetElementAsValue(SourceLength - 1);
+    I := SourceLength - 2;
   end;
 
   while I >= 0 do
@@ -2220,17 +2465,18 @@ function TGocciaTypedArrayValue.TypedArrayJoin(const AArgs: TGocciaArgumentsColl
 var
   TA: TGocciaTypedArrayValue;
   Sep: string;
-  I: Integer;
+  I, Len: Integer;
   S: string;
   Element: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.join');
+  Len := TA.Length;
   if (AArgs.Length > 0) and not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) then
     Sep := AArgs.GetElement(0).ToStringLiteral.Value
   else
     Sep := ',';
   S := '';
-  for I := 0 to TA.FLength - 1 do
+  for I := 0 to Len - 1 do
   begin
     if I > 0 then S := S + Sep;
     Element := TA.GetElementAsValue(I);
@@ -2253,12 +2499,15 @@ var
   CallArgs: TGocciaArgumentsCollection;
 begin
   TA := RequireAttachedTypedArray(AThisValue, '%TypedArray%.prototype.toLocaleString');
-  Len := TA.FLength;
+  Len := TA.Length;
   S := '';
   for I := 0 to Len - 1 do
   begin
     if I > 0 then S := S + ',';
     Element := TA.GetElementAsValue(I);
+    if (Element is TGocciaUndefinedLiteralValue) or
+       (Element is TGocciaNullLiteralValue) then
+      Continue;
     ElementObject := ToObject(Element);
     Method := ElementObject.GetPropertyWithContext(PROP_TO_LOCALE_STRING, Element);
     if (Method = nil) or not Method.IsCallable then
@@ -2316,49 +2565,59 @@ var
   TA, NewTA: TGocciaTypedArrayValue;
   I: Integer;
   SortArgs: TGocciaArgumentsCollection;
+  ResultRoot: TGocciaTempRoot;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.toSorted');
+  if (AArgs.Length > 0) and
+     not (AArgs.GetElement(0) is TGocciaUndefinedLiteralValue) and
+     not AArgs.GetElement(0).IsCallable then
+    ThrowTypeError(SErrorCustomSortMustBeFunction, SSuggestCallbackRequired);
   NewTA := CreateSameKindArray(TA, TA.FLength);
-  if IsBigIntKind(TA.FKind) then
-  begin
-    for I := 0 to TA.FLength - 1 do
-      NewTA.WriteBigIntElement(I, TA.ReadBigIntElement(I));
-  end
-  else
-  begin
-    for I := 0 to TA.FLength - 1 do
-      NewTA.WriteElement(I, TA.ReadElement(I));
-  end;
-  SortArgs := TGocciaArgumentsCollection.Create;
+  InitializeTempRoot(ResultRoot);
+  AddTempRootIfNeeded(ResultRoot, NewTA);
   try
-    if (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable then
-      SortArgs.Add(AArgs.GetElement(0));
-    TypedArraySort(SortArgs, NewTA);
+    if IsBigIntKind(TA.FKind) then
+    begin
+      for I := 0 to TA.FLength - 1 do
+        NewTA.WriteBigIntElement(I, TA.ReadBigIntElement(I));
+    end
+    else
+    begin
+      for I := 0 to TA.FLength - 1 do
+        NewTA.WriteElement(I, TA.ReadElement(I));
+    end;
+    SortArgs := TGocciaArgumentsCollection.Create;
+    try
+      if (AArgs.Length > 0) and AArgs.GetElement(0).IsCallable then
+        SortArgs.Add(AArgs.GetElement(0));
+      TypedArraySort(SortArgs, NewTA);
+    finally
+      SortArgs.Free;
+    end;
+    Result := NewTA;
   finally
-    SortArgs.Free;
+    RemoveTempRootIfNeeded(ResultRoot);
   end;
-  Result := NewTA;
 end;
 
 // ES2026 §23.2.3.36 %TypedArray%.prototype.with(index, value)
 function TGocciaTypedArrayValue.TypedArrayWith(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA, NewTA: TGocciaTypedArrayValue;
-  I, ActualIndex: Integer;
+  I, ActualIndex, Len, ValidIndex: Integer;
   NewNum: TGocciaNumberLiteralValue;
   NewBigInt: Int64;
   NewVal: TGocciaValue;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.with');
+  Len := TA.Length;
   // ES2026 §23.2.3.36 step 3: Let relativeIndex be ? ToIntegerOrInfinity(index)
   if AArgs.Length > 0 then
     ActualIndex := ToIntegerFromArgs(AArgs, 0)
   else
     ActualIndex := 0;
   if ActualIndex < 0 then
-    ActualIndex := TA.FLength + ActualIndex;
-  if (ActualIndex < 0) or (ActualIndex >= TA.FLength) then
-    ThrowRangeError(SErrorInvalidTypedArrayIndex, SSuggestTypedArrayLength);
+    ActualIndex := Len + ActualIndex;
 
   if IsBigIntKind(TA.FKind) then
   begin
@@ -2366,11 +2625,11 @@ begin
       NewVal := AArgs.GetElement(1)
     else
       NewVal := TGocciaUndefinedLiteralValue.UndefinedValue;
-    if not (NewVal is TGocciaBigIntValue) then
-      ThrowTypeError(SErrorBigIntTypedArrayRequiresBigInt, SSuggestBigIntTypedArrayValue);
-    NewBigInt := TGocciaBigIntValue(NewVal).Value.ToInt64;
-    NewTA := CreateSameKindArray(TA, TA.FLength);
-    for I := 0 to TA.FLength - 1 do
+    NewBigInt := RawBigIntForKind(TA.FKind, ToBigIntForTypedArray(NewVal));
+    if not TA.IsValidIntegerIndexedElement(ActualIndex, False, ValidIndex) then
+      ThrowRangeError(SErrorInvalidTypedArrayIndex, SSuggestTypedArrayLength);
+    NewTA := CreateSameKindArray(TA, Len);
+    for I := 0 to Len - 1 do
     begin
       if I = ActualIndex then
         NewTA.WriteBigIntElement(I, NewBigInt)
@@ -2385,8 +2644,10 @@ begin
       NewNum := AArgs.GetElement(1).ToNumberLiteral
     else
       NewNum := TGocciaNumberLiteralValue.NaNValue;
-    NewTA := CreateSameKindArray(TA, TA.FLength);
-    for I := 0 to TA.FLength - 1 do
+    if not TA.IsValidIntegerIndexedElement(ActualIndex, False, ValidIndex) then
+      ThrowRangeError(SErrorInvalidTypedArrayIndex, SSuggestTypedArrayLength);
+    NewTA := CreateSameKindArray(TA, Len);
+    for I := 0 to Len - 1 do
     begin
       if I = ActualIndex then
         NewTA.WriteNumberLiteral(I, NewNum)
@@ -2437,6 +2698,49 @@ begin
   Result := Prototype;
 end;
 
+function TGocciaTypedArrayClassValue.DefaultPrototypeForNewTarget(
+  const ANewTarget: TGocciaValue;
+  const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
+var
+  ConstructorPrototype, ConstructorValue, ProtoValue: TGocciaValue;
+  FallbackRealm: TGocciaRealm;
+  GlobalScope: TGocciaScope;
+begin
+  if ANewTarget is TGocciaObjectValue then
+    ProtoValue := TGocciaObjectValue(ANewTarget).GetProperty(PROP_PROTOTYPE)
+  else
+    ProtoValue := nil;
+
+  if ProtoValue is TGocciaObjectValue then
+    Exit(TGocciaObjectValue(ProtoValue));
+
+  FallbackRealm := nil;
+  if ANewTarget is TGocciaFunctionBase then
+    FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
+
+  if Assigned(FallbackRealm) and
+     (FallbackRealm.GlobalEnv is TGocciaScope) then
+  begin
+    GlobalScope := TGocciaScope(FallbackRealm.GlobalEnv);
+    if GlobalScope.TryGetBindingValue(TGocciaTypedArrayValue.KindName(FKind),
+       ConstructorValue) and
+       (ConstructorValue is TGocciaObjectValue) then
+    begin
+      ConstructorPrototype :=
+        TGocciaObjectValue(ConstructorValue).GetProperty(PROP_PROTOTYPE);
+      if ConstructorPrototype is TGocciaObjectValue then
+        Exit(TGocciaObjectValue(ConstructorPrototype));
+    end;
+  end;
+
+  Result := ACurrentRealmDefault;
+end;
+
+function TGocciaTypedArrayClassValue.GetClassLength: Integer;
+begin
+  Result := 3;
+end;
+
 function TGocciaTypedArrayClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
 var
   FirstArg: TGocciaValue;
@@ -2451,6 +2755,9 @@ var
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
   Values: TGocciaValueList;
+  BufferByteLength: Integer;
+  HasLength: Boolean;
+  RawLen: Double;
 begin
   BPE := TGocciaTypedArrayValue.BytesPerElement(FKind);
 
@@ -2463,21 +2770,15 @@ begin
   if FirstArg is TGocciaTypedArrayValue then
   begin
     SrcTA := TGocciaTypedArrayValue(FirstArg);
+    EnsureTypedArrayAttached(SrcTA, TGocciaTypedArrayValue.KindName(SrcTA.Kind));
+    if TGocciaTypedArrayValue.IsBigIntKind(FKind) <>
+       TGocciaTypedArrayValue.IsBigIntKind(SrcTA.Kind) then
+      ThrowTypeError(SErrorBigIntTypedArrayCannotMix, SSuggestBigIntTypedArrayValue);
     NewTA := TGocciaTypedArrayValue.Create(FKind, SrcTA.Length);
-    if TGocciaTypedArrayValue.IsBigIntKind(FKind) and TGocciaTypedArrayValue.IsBigIntKind(SrcTA.Kind) then
+    if TGocciaTypedArrayValue.IsBigIntKind(FKind) then
     begin
       for I := 0 to SrcTA.Length - 1 do
         NewTA.WriteBigIntElement(I, SrcTA.ReadBigIntElement(I));
-    end
-    else if TGocciaTypedArrayValue.IsBigIntKind(FKind) then
-    begin
-      for I := 0 to SrcTA.Length - 1 do
-        NewTA.WriteBigIntElement(I, Trunc(SrcTA.ReadElement(I)));
-    end
-    else if TGocciaTypedArrayValue.IsBigIntKind(SrcTA.Kind) then
-    begin
-      for I := 0 to SrcTA.Length - 1 do
-        NewTA.WriteElement(I, SrcTA.ReadBigIntElement(I));
     end
     else
     begin
@@ -2500,24 +2801,40 @@ begin
       ThrowRangeError(Format(SErrorTypedArrayStartOffsetNonNegative, [TGocciaTypedArrayValue.KindName(FKind)]), SSuggestTypedArrayLength);
     if (ByteOff mod BPE) <> 0 then
       ThrowRangeError(Format(SErrorTypedArrayStartOffsetMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
-    if ByteOff > System.Length(Buf.Data) then
-      ThrowRangeError(SErrorTypedArrayStartOffsetBounds, SSuggestTypedArrayLength);
 
-    if AArguments.Length > 2 then
+    HasLength := (AArguments.Length > 2) and
+      not (AArguments.GetElement(2) is TGocciaUndefinedLiteralValue);
+    if HasLength then
     begin
       ElemLen := ToIntegerOrInfinityBounded(AArguments.GetElement(2));
       if ElemLen < 0 then
         ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
-      if Int64(ByteOff) + Int64(ElemLen) * Int64(BPE) > Int64(System.Length(Buf.Data)) then
-        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     end
     else
-    begin
-      if ((Int64(System.Length(Buf.Data)) - Int64(ByteOff)) mod Int64(BPE)) <> 0 then
-        ThrowRangeError(Format(SErrorTypedArrayByteLengthMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
-      if (System.Length(Buf.Data) - ByteOff) < 0 then
-        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
       ElemLen := -1;
+
+    if Buf.Detached then
+      ThrowTypeError(Format(SErrorCannotUseDetachedTypedArray,
+        [TGocciaTypedArrayValue.KindName(FKind)]), SSuggestArrayBufferDetached);
+
+    BufferByteLength := System.Length(Buf.Data);
+    if ByteOff > BufferByteLength then
+      ThrowRangeError(SErrorTypedArrayStartOffsetBounds, SSuggestTypedArrayLength);
+
+    if HasLength then
+    begin
+      if Int64(ByteOff) + Int64(ElemLen) * Int64(BPE) > Int64(BufferByteLength) then
+        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
+    end
+    else if Buf.MaxByteLength >= 0 then
+      ElemLen := -1
+    else
+    begin
+      if ((Int64(BufferByteLength) - Int64(ByteOff)) mod Int64(BPE)) <> 0 then
+        ThrowRangeError(Format(SErrorTypedArrayByteLengthMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
+      if (BufferByteLength - ByteOff) < 0 then
+        ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
+      ElemLen := (BufferByteLength - ByteOff) div BPE;
     end;
 
     Exit(TGocciaTypedArrayValue.Create(FKind, Buf, ByteOff, ElemLen));
@@ -2536,22 +2853,32 @@ begin
       ThrowRangeError(Format(SErrorTypedArrayStartOffsetNonNegative, [TGocciaTypedArrayValue.KindName(FKind)]), SSuggestTypedArrayLength);
     if (ByteOff mod BPE) <> 0 then
       ThrowRangeError(Format(SErrorTypedArrayStartOffsetMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
-    if ByteOff > System.Length(SAB.Data) then
-      ThrowRangeError(SErrorTypedArrayStartOffsetBounds, SSuggestTypedArrayLength);
 
-    if AArguments.Length > 2 then
+    HasLength := (AArguments.Length > 2) and
+      not (AArguments.GetElement(2) is TGocciaUndefinedLiteralValue);
+    if HasLength then
     begin
       ElemLen := ToIntegerOrInfinityBounded(AArguments.GetElement(2));
       if ElemLen < 0 then
         ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
-      if Int64(ByteOff) + Int64(ElemLen) * Int64(BPE) > Int64(System.Length(SAB.Data)) then
+    end
+    else
+      ElemLen := -1;
+
+    BufferByteLength := System.Length(SAB.Data);
+    if ByteOff > BufferByteLength then
+      ThrowRangeError(SErrorTypedArrayStartOffsetBounds, SSuggestTypedArrayLength);
+
+    if HasLength then
+    begin
+      if Int64(ByteOff) + Int64(ElemLen) * Int64(BPE) > Int64(BufferByteLength) then
         ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     end
     else
     begin
-      if ((Int64(System.Length(SAB.Data)) - Int64(ByteOff)) mod Int64(BPE)) <> 0 then
+      if ((Int64(BufferByteLength) - Int64(ByteOff)) mod Int64(BPE)) <> 0 then
         ThrowRangeError(Format(SErrorTypedArrayByteLengthMultiple, [TGocciaTypedArrayValue.KindName(FKind), BPE]), SSuggestTypedArrayAlignment);
-      ElemLen := Integer((Int64(System.Length(SAB.Data)) - Int64(ByteOff)) div Int64(BPE));
+      ElemLen := Integer((Int64(BufferByteLength) - Int64(ByteOff)) div Int64(BPE));
       if ElemLen < 0 then
         ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     end;
@@ -2565,6 +2892,9 @@ begin
     Iterator := GetIteratorFromValue(FirstArg);
     if Assigned(Iterator) then
     begin
+      if not (Iterator is TGocciaGenericIteratorValue) then
+        Iterator := TGocciaGenericIteratorValue.Create(Iterator,
+          Iterator.GetProperty(PROP_NEXT));
       Values := TGocciaValueList.Create(False);
       try
         TGarbageCollector.Instance.AddTempRoot(Iterator);
@@ -2602,7 +2932,9 @@ begin
       Exit(NewTA);
     end;
 
-    Len := LengthOfArrayLike(TGocciaObjectValue(FirstArg));
+    Len := LengthOfArrayLikeEx(TGocciaObjectValue(FirstArg), RawLen);
+    if RawLen > High(Integer) then
+      ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     NewTA := TGocciaTypedArrayValue.Create(FKind, Len);
     for I := 0 to Len - 1 do
       NewTA.WriteValueToElement(I, TGocciaObjectValue(FirstArg).GetProperty(IntToStr(I)));
@@ -2649,14 +2981,17 @@ var
   MapArgs: TGocciaArgumentsCollection;
   Iterator: TGocciaIteratorValue;
   IterResult: TGocciaObjectValue;
-  ConstructorValue: TGocciaClassValue;
+  ConstructorValue: TGocciaValue;
   Values: TGocciaValueList;
   SrcObj: TGocciaObjectValue;
   SourceRoot, MapFnRoot, ThisRoot, ResultRoot: TGocciaTempRoot;
   ValueRoots: array of TGocciaTempRoot;
   ValueRootCount: Integer;
 begin
-  ConstructorValue := RequireTypedArrayConstructor(AThisValue, 'TypedArray.from');
+  ConstructorValue := AThisValue;
+  if (not Assigned(ConstructorValue)) or (not ConstructorValue.IsConstructable) then
+    ThrowTypeError(Format(SErrorTypedArrayStaticReceiver, ['TypedArray.from']),
+      SSuggestTypedArrayConstructorReceiver);
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorTypedArrayFromRequiresArg, SSuggestTypedArraySetSource);
   Source := AArgs.GetElement(0);
@@ -2688,6 +3023,9 @@ begin
     Iterator := GetIteratorFromValue(Source);
     if Assigned(Iterator) then
     begin
+      if not (Iterator is TGocciaGenericIteratorValue) then
+        Iterator := TGocciaGenericIteratorValue.Create(Iterator,
+          Iterator.GetProperty(PROP_NEXT));
       Values := TGocciaValueList.Create(False);
       ValueRootCount := 0;
       try
@@ -2842,10 +3180,13 @@ end;
 function TGocciaTypedArrayStaticFrom.TypedArrayOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   NewTA: TGocciaTypedArrayValue;
-  ConstructorValue: TGocciaClassValue;
+  ConstructorValue: TGocciaValue;
   I: Integer;
 begin
-  ConstructorValue := RequireTypedArrayConstructor(AThisValue, 'TypedArray.of');
+  ConstructorValue := AThisValue;
+  if (not Assigned(ConstructorValue)) or (not ConstructorValue.IsConstructable) then
+    ThrowTypeError(Format(SErrorTypedArrayStaticReceiver, ['TypedArray.of']),
+      SSuggestTypedArrayConstructorReceiver);
   NewTA := CreateTypedArrayFromConstructor(ConstructorValue,
     'TypedArray.of', AArgs.Length);
   for I := 0 to AArgs.Length - 1 do

--- a/tests/built-ins/Array/prototype/reduceRight.js
+++ b/tests/built-ins/Array/prototype/reduceRight.js
@@ -1,0 +1,115 @@
+/*---
+description: Array.prototype.reduceRight reduces an array from right to left
+features: [Array.prototype.reduceRight]
+---*/
+
+test("Array.prototype.reduceRight reduces an array from right to left", () => {
+  const result = [1, 2, 3, 4].reduceRight((acc, value) => acc - value);
+  expect(result).toBe(-2);
+});
+
+test("reduceRight with initial value visits every present element from the end", () => {
+  const calls = [];
+  const arr = [10, 20, 30];
+  const callbackHolder = {
+    callback(acc, value, index, object) {
+      "use strict";
+      expect(this).toBe(undefined);
+      expect(object).toBe(arr);
+      calls.push({ acc, value, index, length: object.length });
+      return acc + value;
+    },
+  };
+  const result = arr.reduceRight(callbackHolder.callback, 0);
+
+  expect(result).toBe(60);
+  expect(calls.length).toBe(3);
+  expect(calls[0].acc).toBe(0);
+  expect(calls[0].value).toBe(30);
+  expect(calls[0].index).toBe(2);
+  expect(calls[1].index).toBe(1);
+  expect(calls[2].index).toBe(0);
+  expect(calls[2].length).toBe(3);
+});
+
+test("reduceRight without initial value seeds from last present element", () => {
+  const indices = [];
+  const result = [, , 1, , 3].reduceRight((acc, value, index) => {
+    indices.push(index);
+    return acc - value;
+  });
+
+  expect(result).toBe(2);
+  expect(indices).toEqual([2]);
+});
+
+test("reduceRight on a single present element without initial value does not call callback", () => {
+  let called = false;
+  const result = [, 42, ,].reduceRight(() => {
+    called = true;
+    return 0;
+  });
+
+  expect(result).toBe(42);
+  expect(called).toBe(false);
+});
+
+test("reduceRight on empty or all-hole arrays without initial value throws TypeError", () => {
+  expect(() => [].reduceRight((acc, value) => acc + value)).toThrow(TypeError);
+  expect(() => [, , ,].reduceRight((acc, value) => acc + value)).toThrow(TypeError);
+});
+
+test("reduceRight requires a callable callback after coercing the receiver", () => {
+  expect(() => Array.prototype.reduceRight.call(null, () => 0)).toThrow(TypeError);
+  expect(() => Array.prototype.reduceRight.call(undefined, () => 0)).toThrow(TypeError);
+  expect(() => [1, 2].reduceRight()).toThrow(TypeError);
+  expect(() => [1, 2].reduceRight(null)).toThrow(TypeError);
+});
+
+test("reduceRight is generic over array-like receivers", () => {
+  const arrayLike = { 0: "a", 2: "c", length: 3 };
+  const result = Array.prototype.reduceRight.call(arrayLike, (acc, value, index) => {
+    return acc + index + value;
+  }, "");
+
+  expect(result).toBe("2c0a");
+});
+
+test("reduceRight sees inherited properties through holes", () => {
+  const proto = { 1: "b" };
+  const arrayLike = Object.create(proto);
+  arrayLike[0] = "a";
+  arrayLike[2] = "c";
+  arrayLike.length = 3;
+
+  const values = [];
+  const result = Array.prototype.reduceRight.call(arrayLike, (acc, value, index) => {
+    values.push(index + value);
+    return acc + value;
+  }, "");
+
+  expect(result).toBe("cba");
+  expect(values).toEqual(["2c", "1b", "0a"]);
+});
+
+test("reduceRight skips elements deleted before they are visited and ignores appended elements", () => {
+  const arr = [1, 2, 3];
+  const seen = [];
+  const result = arr.reduceRight((acc, value, index, object) => {
+    seen.push(index);
+    if (index === 2) {
+      object.push(4);
+      delete object[1];
+    }
+    return acc + value;
+  }, 0);
+
+  expect(result).toBe(4);
+  expect(seen).toEqual([2, 0]);
+  expect(arr.length).toBe(4);
+});
+
+test("reduceRight has correct name and length", () => {
+  expect(Array.prototype.reduceRight.name).toBe("reduceRight");
+  expect(Array.prototype.reduceRight.length).toBe(1);
+});

--- a/tests/built-ins/ArrayBuffer/prototype/maxByteLength.js
+++ b/tests/built-ins/ArrayBuffer/prototype/maxByteLength.js
@@ -48,4 +48,11 @@ describe("get ArrayBuffer.prototype.maxByteLength", () => {
     const getter = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "maxByteLength").get;
     expect(() => getter.call({})).toThrow(TypeError);
   });
+
+  test("throws TypeError when copied as own accessor on SharedArrayBuffer", () => {
+    const sab = new SharedArrayBuffer(4);
+    const descriptor = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "maxByteLength");
+    Object.defineProperties(sab, { maxByteLength: descriptor });
+    expect(() => sab.maxByteLength).toThrow(TypeError);
+  });
 });

--- a/tests/built-ins/Atomics/add.js
+++ b/tests/built-ins/Atomics/add.js
@@ -30,11 +30,12 @@ describe("Atomics.add", () => {
     expect(() => Atomics.add(i32, 1, 1)).toThrow(RangeError);
   });
 
-  test("throws TypeError for non-shared ArrayBuffer views", () => {
+  test("works for non-shared ArrayBuffer views", () => {
     const buffer = new ArrayBuffer(4);
     const i32 = new Int32Array(buffer);
 
-    expect(() => Atomics.add(i32, 0, 1)).toThrow(TypeError);
+    expect(Atomics.add(i32, 0, 1)).toBe(0);
+    expect(Atomics.load(i32, 0)).toBe(1);
   });
 
   test("throws TypeError for non-integer typed arrays", () => {

--- a/tests/built-ins/Iterator/iterator-helper-reentrant.js
+++ b/tests/built-ins/Iterator/iterator-helper-reentrant.js
@@ -88,6 +88,33 @@ describe("Iterator helper re-entrancy guard", () => {
     const helper = factory();
     expect(() => helper.next()).toThrow(TypeError);
   });
+
+  test("Iterator.concat throws TypeError on re-entrant .return()", () => {
+    let enterCount = 0;
+    let helper;
+    const inner = {
+      next() {
+        return { done: false };
+      },
+      return() {
+        enterCount++;
+        helper.return();
+        return { done: false };
+      }
+    };
+
+    helper = Iterator.concat({
+      [Symbol.iterator]() {
+        return inner;
+      }
+    });
+
+    helper.next();
+
+    expect(enterCount).toBe(0);
+    expect(() => helper.return()).toThrow(TypeError);
+    expect(enterCount).toBe(1);
+  });
 });
 
 const makeChainedReentrant = (build) => {

--- a/tests/built-ins/Iterator/prototype/reduce.js
+++ b/tests/built-ins/Iterator/prototype/reduce.js
@@ -82,7 +82,7 @@ describe("Iterator.prototype.reduce()", () => {
     expect(closed).toBe(1);
   });
 
-  test("reduce throws when iterator return is present but not callable", () => {
+  test("reduce preserves the original error when return is not callable", () => {
     const source = Iterator.from({
       next() {
         return { value: 1, done: false };
@@ -92,7 +92,7 @@ describe("Iterator.prototype.reduce()", () => {
 
     expect(() => source.reduce(() => {
       throw new Error("boom");
-    }, 0)).toThrow(TypeError);
+    }, 0)).toThrow(Error);
   });
 
   test("reduce can consume nested iterators", () => {

--- a/tests/built-ins/Iterator/prototype/reduce.js
+++ b/tests/built-ins/Iterator/prototype/reduce.js
@@ -92,7 +92,7 @@ describe("Iterator.prototype.reduce()", () => {
 
     expect(() => source.reduce(() => {
       throw new Error("boom");
-    }, 0)).toThrow(Error);
+    }, 0)).toThrow("boom");
   });
 
   test("reduce can consume nested iterators", () => {

--- a/tests/built-ins/Iterator/prototype/take.js
+++ b/tests/built-ins/Iterator/prototype/take.js
@@ -20,14 +20,14 @@ describe("Iterator.prototype.take()", () => {
     expect(() => [1].values().take(-1)).toThrow(RangeError);
   });
 
-  test("take closes the source when the limit is reached", () => {
+  test("take does not exhaust a source with no return when the limit is reached", () => {
     const source = [10, 20, 30, 40, 50].values();
     const taken = source.take(2);
 
     expect(taken.next().value).toBe(10);
     expect(taken.next().value).toBe(20);
     expect(taken.next().done).toBe(true);
-    expect(source.next().done).toBe(true);
+    expect(source.next().value).toBe(30);
   });
 
   test("take composes after drop", () => {

--- a/tests/built-ins/Iterator/shape.js
+++ b/tests/built-ins/Iterator/shape.js
@@ -1,0 +1,59 @@
+/*---
+description: Iterator constructor and prototype object shape
+features: [Iterator, iterator-helpers]
+---*/
+
+describe("Iterator shape", () => {
+  test("Iterator is a function but not directly callable or constructible", () => {
+    expect(typeof Iterator).toBe("function");
+    expect(Object.getPrototypeOf(Iterator)).toBe(Function.prototype);
+    expect(() => Iterator()).toThrow(TypeError);
+    expect(() => new Iterator()).toThrow(TypeError);
+  });
+
+  test("Iterator.prototype.constructor is an accessor returning Iterator", () => {
+    const desc = Object.getOwnPropertyDescriptor(Iterator.prototype, "constructor");
+    expect(typeof desc.get).toBe("function");
+    expect(typeof desc.set).toBe("function");
+    expect(desc.enumerable).toBe(false);
+    expect(desc.configurable).toBe(true);
+    expect(desc.value).toBe(undefined);
+    expect(desc.writable).toBe(undefined);
+    expect(Iterator.prototype.constructor).toBe(Iterator);
+    expect(desc.get.call()).toBe(Iterator);
+  });
+
+  test("Iterator.prototype Symbol.toStringTag is an accessor", () => {
+    const desc = Object.getOwnPropertyDescriptor(Iterator.prototype, Symbol.toStringTag);
+    expect(typeof desc.get).toBe("function");
+    expect(typeof desc.set).toBe("function");
+    expect(desc.enumerable).toBe(false);
+    expect(desc.configurable).toBe(true);
+    expect(desc.value).toBe(undefined);
+    expect(desc.writable).toBe(undefined);
+    expect(Iterator.prototype[Symbol.toStringTag]).toBe("Iterator");
+    expect(Object.prototype.toString.call(Iterator.prototype)).toBe("[object Iterator]");
+  });
+
+  test("helper return values are instanceof Iterator", () => {
+    const mapped = [1, 2, 3].values().map((value) => value);
+    expect(mapped instanceof Iterator).toBe(true);
+  });
+
+  test("helpers accept plain iterator protocol objects", () => {
+    let count = 0;
+    const iter = {
+      next() {
+        count = count + 1;
+        if (count <= 3) {
+          return { value: count, done: false };
+        }
+        return { value: undefined, done: true };
+      },
+    };
+
+    const result = Iterator.prototype.map.call(iter, (value) => value * 2).toArray();
+    expect(result).toEqual([2, 4, 6]);
+  });
+
+});

--- a/tests/built-ins/Object/create.js
+++ b/tests/built-ins/Object/create.js
@@ -77,3 +77,30 @@ test("Object.create with symbol-keyed property descriptor", () => {
   });
   expect(obj[sym]).toBe(42);
 });
+
+test("Object.create coerces primitive Properties values to objects", () => {
+  const obj = Object.create(null, false);
+
+  expect(Object.getPrototypeOf(obj)).toBe(null);
+  expect(Object.keys(obj)).toEqual([]);
+});
+
+test("Object.create reads accessor descriptor properties from Properties", () => {
+  const properties = {};
+
+  Object.defineProperty(properties, "answer", {
+    get() {
+      return { value: 42, enumerable: true };
+    },
+    enumerable: true,
+  });
+
+  const obj = Object.create(null, properties);
+
+  expect(obj.answer).toBe(42);
+  expect(Object.keys(obj)).toEqual(["answer"]);
+});
+
+test("Object.create throws for non-empty string Properties", () => {
+  expect(() => Object.create({}, "hello")).toThrow(TypeError);
+});

--- a/tests/built-ins/Object/defineProperties.js
+++ b/tests/built-ins/Object/defineProperties.js
@@ -108,3 +108,56 @@ test("Object.defineProperties preserves array index descriptor attributes", () =
   expect(desc.configurable).toBe(false);
   expect(Object.keys(array)).not.toContain("2");
 });
+
+test("Object.defineProperties coerces primitive Properties values to objects", () => {
+  const target = { existing: 1 };
+
+  expect(Object.defineProperties(target, false)).toBe(target);
+  expect(Object.defineProperties(target, 12)).toBe(target);
+  expect(Object.defineProperties(target, "")).toBe(target);
+  expect(target.existing).toBe(1);
+});
+
+test("Object.defineProperties reads enumerable accessor properties from Properties", () => {
+  const target = {};
+  const properties = {};
+  let getterThis;
+
+  Object.defineProperty(properties, "value", {
+    get() {
+      getterThis = this;
+      return { value: 42, enumerable: true };
+    },
+    enumerable: true,
+  });
+
+  Object.defineProperties(target, properties);
+
+  expect(getterThis).toBe(properties);
+  expect(target.value).toBe(42);
+  expect(Object.keys(target)).toEqual(["value"]);
+});
+
+test("Object.defineProperties validates all descriptors before defining any property", () => {
+  const target = {};
+  const properties = {};
+
+  Object.defineProperty(properties, "valid", {
+    value: { value: 1 },
+    enumerable: true,
+  });
+  Object.defineProperty(properties, "invalid", {
+    value: { get: 1 },
+    enumerable: true,
+  });
+
+  expect(() => Object.defineProperties(target, properties)).toThrow(TypeError);
+  expect(Object.hasOwn(target, "valid")).toBe(false);
+});
+
+test("Object.defineProperties throws for non-empty string Properties", () => {
+  const target = {};
+
+  expect(() => Object.defineProperties(target, "hello")).toThrow(TypeError);
+  expect(Object.keys(target)).toEqual([]);
+});

--- a/tests/built-ins/Object/prototype/hasOwnProperty.js
+++ b/tests/built-ins/Object/prototype/hasOwnProperty.js
@@ -1,4 +1,12 @@
 describe('Object.prototype.hasOwnProperty', () => {
+  test('built-in function has the standard name', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object.prototype.hasOwnProperty, 'name');
+    expect(descriptor.value).toBe('hasOwnProperty');
+    expect(descriptor.writable).toBe(false);
+    expect(descriptor.enumerable).toBe(false);
+    expect(descriptor.configurable).toBe(true);
+  });
+
   test('returns true for own property', () => {
     const obj = { x: 1, y: 2 };
     expect(obj.hasOwnProperty('x')).toBe(true);
@@ -52,6 +60,19 @@ describe('Object.prototype.hasOwnProperty', () => {
     expect(obj.hasOwnProperty(1)).toBe(true);
     expect(obj.hasOwnProperty(true)).toBe(true);
     expect(obj.hasOwnProperty(null)).toBe(true);
+  });
+
+  test('coerces property key before rejecting null receiver', () => {
+    let called = false;
+    const key = {
+      [Symbol.toPrimitive]() {
+        called = true;
+        throw new Error('key conversion first');
+      },
+    };
+
+    expect(() => Object.prototype.hasOwnProperty.call(null, key)).toThrow('key conversion first');
+    expect(called).toBe(true);
   });
 
   test('works on arrays', () => {

--- a/tests/built-ins/Object/prototype/propertyIsEnumerable.js
+++ b/tests/built-ins/Object/prototype/propertyIsEnumerable.js
@@ -1,4 +1,17 @@
 describe('Object.prototype.propertyIsEnumerable', () => {
+  test('coerces property key before rejecting null receiver', () => {
+    let called = false;
+    const key = {
+      [Symbol.toPrimitive]() {
+        called = true;
+        throw new Error('key conversion first');
+      },
+    };
+
+    expect(() => Object.prototype.propertyIsEnumerable.call(null, key)).toThrow('key conversion first');
+    expect(called).toBe(true);
+  });
+
   test('returns true for own enumerable properties', () => {
     const obj = { x: 1, y: 2 };
     expect(obj.propertyIsEnumerable('x')).toBe(true);
@@ -59,6 +72,26 @@ describe('Object.prototype.propertyIsEnumerable', () => {
     const obj = { 1: 'one', true: 'yes' };
     expect(obj.propertyIsEnumerable(1)).toBe(true);
     expect(obj.propertyIsEnumerable(true)).toBe(true);
+  });
+
+  test('accepts property keys that coerce to symbols', () => {
+    let calls = 0;
+    const sym = Symbol('visible');
+    const obj = { [sym]: 1 };
+    const key = {
+      [Symbol.toPrimitive]() {
+        calls++;
+        return sym;
+      },
+    };
+
+    expect(obj.propertyIsEnumerable(key)).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  test('boxes string receivers before reading own descriptors', () => {
+    expect(Object.prototype.propertyIsEnumerable.call('hi', '0')).toBe(true);
+    expect(Object.prototype.propertyIsEnumerable.call('hi', 'length')).toBe(false);
   });
 
   test('class instance own properties are enumerable', () => {

--- a/tests/built-ins/Promise/all-settled.js
+++ b/tests/built-ins/Promise/all-settled.js
@@ -107,3 +107,80 @@ test("Promise.allSettled creates data properties for result records", () => {
     delete Object.prototype.reason;
   });
 });
+
+test("Promise.allSettled element functions are anonymous built-ins", () => {
+  let resolveElement;
+  let rejectElement;
+
+  class NotPromise {
+    constructor(executor) {
+      executor(() => {}, () => {});
+    }
+
+    static resolve(value) {
+      return value;
+    }
+  }
+
+  Promise.allSettled.call(NotPromise, [{
+    then(resolve, reject) {
+      resolveElement = resolve;
+      rejectElement = reject;
+    }
+  }]);
+
+  const resolveName = Object.getOwnPropertyDescriptor(resolveElement, "name");
+  const rejectName = Object.getOwnPropertyDescriptor(rejectElement, "name");
+  const resolveProperties = Object.getOwnPropertyNames(resolveElement);
+  const rejectProperties = Object.getOwnPropertyNames(rejectElement);
+
+  expect(resolveName.value).toBe("");
+  expect(resolveName.writable).toBe(false);
+  expect(resolveName.enumerable).toBe(false);
+  expect(resolveName.configurable).toBe(true);
+  expect(rejectName.value).toBe("");
+  expect(rejectName.writable).toBe(false);
+  expect(rejectName.enumerable).toBe(false);
+  expect(rejectName.configurable).toBe(true);
+  expect(resolveProperties.indexOf("name")).toBe(resolveProperties.indexOf("length") + 1);
+  expect(rejectProperties.indexOf("name")).toBe(rejectProperties.indexOf("length") + 1);
+});
+
+test("Promise.allSettled element functions ignore repeated calls", () => {
+  let callCount = 0;
+
+  class NotPromise {
+    constructor(executor) {
+      executor((values) => {
+        callCount += 1;
+        expect(values[0].status).toBe("fulfilled");
+        expect(values[0].value).toBe("first");
+        expect(values[1].status).toBe("fulfilled");
+        expect(values[1].value).toBe("second");
+      }, () => {
+        throw new Error("unexpected rejection");
+      });
+    }
+
+    static resolve(value) {
+      return value;
+    }
+  }
+
+  Promise.allSettled.call(NotPromise, [
+    {
+      then(resolve) {
+        resolve("first");
+        resolve("bad");
+      }
+    },
+    {
+      then(resolve) {
+        resolve("second");
+        resolve("worse");
+      }
+    }
+  ]);
+
+  expect(callCount).toBe(1);
+});

--- a/tests/built-ins/Promise/all.js
+++ b/tests/built-ins/Promise/all.js
@@ -123,3 +123,67 @@ test("Promise.all ignores late thenable rejection after resolve", () => {
     expect(result).toEqual([9]);
   });
 });
+
+test("Promise.all resolve element functions are anonymous built-ins", () => {
+  let resolveElement;
+
+  class NotPromise {
+    constructor(executor) {
+      executor(() => {}, () => {});
+    }
+
+    static resolve(value) {
+      return value;
+    }
+  }
+
+  Promise.all.call(NotPromise, [{
+    then(resolve) {
+      resolveElement = resolve;
+    }
+  }]);
+
+  const nameDescriptor = Object.getOwnPropertyDescriptor(resolveElement, "name");
+  const propertyNames = Object.getOwnPropertyNames(resolveElement);
+  expect(nameDescriptor.value).toBe("");
+  expect(nameDescriptor.writable).toBe(false);
+  expect(nameDescriptor.enumerable).toBe(false);
+  expect(nameDescriptor.configurable).toBe(true);
+  expect(propertyNames.indexOf("name")).toBe(propertyNames.indexOf("length") + 1);
+});
+
+test("Promise.all resolve element functions ignore repeated calls", () => {
+  let callCount = 0;
+
+  class NotPromise {
+    constructor(executor) {
+      executor((values) => {
+        callCount += 1;
+        expect(values).toEqual(["first", "second"]);
+      }, () => {
+        throw new Error("unexpected rejection");
+      });
+    }
+
+    static resolve(value) {
+      return value;
+    }
+  }
+
+  Promise.all.call(NotPromise, [
+    {
+      then(resolve) {
+        resolve("first");
+        resolve("bad");
+      }
+    },
+    {
+      then(resolve) {
+        resolve("second");
+        resolve("worse");
+      }
+    }
+  ]);
+
+  expect(callCount).toBe(1);
+});

--- a/tests/built-ins/Promise/error-cases.js
+++ b/tests/built-ins/Promise/error-cases.js
@@ -53,6 +53,66 @@ test("Promise.all with no arguments rejects with TypeError", () => {
   });
 });
 
+for (const method of ["all", "allSettled", "any", "race"]) {
+  test("Promise." + method + " skips IteratorClose when done getter throws", () => {
+    let returnCalled = 0;
+    const iterable = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            return {
+              get done() {
+                throw new Error("done-boom");
+              },
+              value: 1
+            };
+          },
+          return() {
+            returnCalled++;
+            return { done: true };
+          }
+        };
+      }
+    };
+
+    return Promise[method](iterable).then(() => {
+      throw new Error("Expected rejection");
+    }, (e) => {
+      expect(e.message).toBe("done-boom");
+      expect(returnCalled).toBe(0);
+    });
+  });
+
+  test("Promise." + method + " skips IteratorClose when value getter throws", () => {
+    let returnCalled = 0;
+    const iterable = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            return {
+              done: false,
+              get value() {
+                throw new Error("value-boom");
+              }
+            };
+          },
+          return() {
+            returnCalled++;
+            return { done: true };
+          }
+        };
+      }
+    };
+
+    return Promise[method](iterable).then(() => {
+      throw new Error("Expected rejection");
+    }, (e) => {
+      expect(e.message).toBe("value-boom");
+      expect(returnCalled).toBe(0);
+    });
+  });
+}
+
 // Promise.allSettled
 
 test("Promise.allSettled with number rejects with TypeError", () => {

--- a/tests/built-ins/Symbol/species.js
+++ b/tests/built-ins/Symbol/species.js
@@ -115,7 +115,6 @@ describe("Symbol.species", () => {
   });
 
   test("RegExp subclass instance super uses captured native prototype", () => {
-    const originalDescriptor = Object.getOwnPropertyDescriptor(RegExp, "prototype");
     const computedKey = "test";
 
     class MyRegExp extends RegExp {
@@ -132,23 +131,11 @@ describe("Symbol.species", () => {
       }
     }
 
-    try {
-      Object.defineProperty(RegExp, "prototype", {
-        value: {
-          test() {
-            return false;
-          }
-        },
-        configurable: true
-      });
-
-      const regex = new MyRegExp("a+");
-      expect(regex.matchesDirect("aa")).toBe(true);
-      expect(regex.matchesComputed("aa")).toBe(true);
-      expect(regex.matchFirst("aa")).toBe("aa");
-    } finally {
-      Object.defineProperty(RegExp, "prototype", originalDescriptor);
-    }
+    const regex = new MyRegExp("a+");
+    expect(regex.matchesDirect("aa")).toBe(true);
+    expect(regex.matchesComputed("aa")).toBe(true);
+    expect(regex.matchFirst("aa")).toBe("aa");
+    expect(Object.getOwnPropertyDescriptor(RegExp, "prototype").configurable).toBe(false);
   });
 
   test("Promise subclass inherits Symbol.species through constructor prototype chain", () => {
@@ -156,17 +143,15 @@ describe("Symbol.species", () => {
     expect(MyPromise[Symbol.species]).toBe(MyPromise);
   });
 
-  test("native constructor superclass prototype must be an object or null", () => {
-    const originalDescriptor = Object.getOwnPropertyDescriptor(RegExp, "prototype");
-    try {
+  test("native constructor prototype property is not reconfigurable", () => {
+    expect(Object.getOwnPropertyDescriptor(RegExp, "prototype")).toEqual({
+      value: RegExp.prototype,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+    expect(() => {
       Object.defineProperty(RegExp, "prototype", { value: null, configurable: true });
-      class NullPrototypeRegExp extends RegExp {}
-      expect(Object.getPrototypeOf(NullPrototypeRegExp.prototype)).toBe(null);
-
-      Object.defineProperty(RegExp, "prototype", { value: 1, configurable: true });
-      expect(() => { class InvalidPrototypeRegExp extends RegExp {} }).toThrow(TypeError);
-    } finally {
-      Object.defineProperty(RegExp, "prototype", originalDescriptor);
-    }
+    }).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Temporal/Duration/prototype/round.js
+++ b/tests/built-ins/Temporal/Duration/prototype/round.js
@@ -34,9 +34,18 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(rounded.hours).toBe(1);
   });
 
-  test("round with smallestUnit week", () => {
+  test("round with smallestUnit week requires relativeTo", () => {
     const d = Temporal.Duration.from({ days: 10 });
-    const rounded = d.round({ smallestUnit: "week", roundingMode: "trunc" });
+    expect(() => d.round({ smallestUnit: "week", roundingMode: "trunc" })).toThrow(RangeError);
+  });
+
+  test("round with smallestUnit week and relativeTo", () => {
+    const d = Temporal.Duration.from({ days: 10 });
+    const rounded = d.round({
+      smallestUnit: "week",
+      roundingMode: "trunc",
+      relativeTo: "2024-01-01"
+    });
     expect(rounded.weeks).toBe(1);
     expect(rounded.days).toBe(0);
   });
@@ -120,6 +129,16 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(() => d.round({ smallestUnit: "month", largestUnit: "day", relativeTo: "2024-01-01" })).toThrow();
   });
 
+  test("round rejects date-unit roundingIncrement with a larger largestUnit", () => {
+    const d = Temporal.Duration.from({ days: 10 });
+    expect(() => d.round({
+      largestUnit: "week",
+      smallestUnit: "day",
+      roundingIncrement: 2,
+      relativeTo: "2024-01-01"
+    })).toThrow(RangeError);
+  });
+
   test("round applies years and months as separate calendar steps", () => {
     // 2020-02-29 + 1Y = 2021-02-28 (day clamps), + 1M = 2021-03-28 = 393 days.
     // Collapsing to +13M gives 2021-03-29 = 394 days (wrong).
@@ -165,16 +184,27 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.round", () => {
     expect(rounded.months).toBe(18);
   });
 
-  test("round rejects relativeTo as ZonedDateTime", () => {
-    const d = Temporal.Duration.from({ years: 1, months: 6 });
-    const zdt = Temporal.ZonedDateTime.from("2024-01-01T00:00:00+00:00[UTC]");
-    expect(() => d.round({ smallestUnit: "months", relativeTo: zdt })).toThrow(RangeError);
+  test("round with largestUnit auto resolves to the default largest unit", () => {
+    const d = Temporal.Duration.from({ hours: 25, minutes: 30 });
+    const rounded = d.round({ largestUnit: "auto", smallestUnit: "hours" });
+    expect(rounded.days).toBe(0);
+    expect(rounded.hours).toBe(26);
+    expect(rounded.minutes).toBe(0);
   });
 
-  test("round rejects relativeTo as ZonedDateTime to days", () => {
+  test("round accepts relativeTo as ZonedDateTime", () => {
+    const d = Temporal.Duration.from({ years: 1, months: 6 });
+    const zdt = Temporal.ZonedDateTime.from("2024-01-01T00:00:00+00:00[UTC]");
+    const rounded = d.round({ smallestUnit: "months", relativeTo: zdt });
+    expect(rounded.years).toBe(1);
+    expect(rounded.months).toBe(6);
+  });
+
+  test("round accepts relativeTo as ZonedDateTime to days", () => {
     const d = Temporal.Duration.from({ years: 1, months: 1 });
     const zdt = Temporal.ZonedDateTime.from("2020-02-29T10:30:00+00:00[UTC]");
-    expect(() => d.round({ smallestUnit: "days", largestUnit: "days", relativeTo: zdt })).toThrow(RangeError);
+    const rounded = d.round({ smallestUnit: "days", largestUnit: "days", relativeTo: zdt });
+    expect(rounded.days).toBe(393);
   });
 
   test("round with relativeTo as property bag", () => {

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -155,6 +155,13 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     expect(d.total({ unit: "years", relativeTo: zdt })).toBe(2);
   });
 
+  test("total() rejects ZonedDateTime relativeTo when exact-time nudge exceeds range", () => {
+    const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+    const zdt = new Temporal.ZonedDateTime(864n * 10n ** 19n - 1n, "UTC");
+
+    expect(() => d.total({ unit: "years", relativeTo: zdt })).toThrow(RangeError);
+  });
+
   test("total() with relativeTo as property bag", () => {
     const d = Temporal.Duration.from({ months: 1 });
     const days = d.total({ unit: "days", relativeTo: { year: 2024, month: 2, day: 1 } });

--- a/tests/built-ins/Temporal/Duration/prototype/total.js
+++ b/tests/built-ins/Temporal/Duration/prototype/total.js
@@ -143,16 +143,16 @@ describe.runIf(isTemporal)("Temporal.Duration.prototype.total", () => {
     expect(days).toBe(393);
   });
 
-  test("total() rejects relativeTo as ZonedDateTime", () => {
+  test("total() accepts relativeTo as ZonedDateTime", () => {
     const d = Temporal.Duration.from({ months: 6 });
     const zdt = Temporal.ZonedDateTime.from("2024-01-01T00:00:00+00:00[UTC]");
-    expect(() => d.total({ unit: "days", relativeTo: zdt })).toThrow(RangeError);
+    expect(d.total({ unit: "days", relativeTo: zdt })).toBe(182);
   });
 
-  test("total() rejects relativeTo as ZonedDateTime for years", () => {
+  test("total() accepts relativeTo as ZonedDateTime for years", () => {
     const d = Temporal.Duration.from({ years: 2 });
     const zdt = Temporal.ZonedDateTime.from("2024-01-01T12:00:00+00:00[UTC]");
-    expect(() => d.total({ unit: "years", relativeTo: zdt })).toThrow(RangeError);
+    expect(d.total({ unit: "years", relativeTo: zdt })).toBe(2);
   });
 
   test("total() with relativeTo as property bag", () => {

--- a/tests/built-ins/Temporal/ZonedDateTime/compare.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/compare.js
@@ -21,4 +21,12 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.compare", () => {
     );
     expect(result).toBe(-1);
   });
+
+  test("compare accepts property bags", () => {
+    const result = Temporal.ZonedDateTime.compare(
+      { year: 2024, month: 3, day: 15, hour: 12, timeZone: "UTC" },
+      { year: 2024, month: 3, day: 15, hour: 13, timeZone: "UTC" }
+    );
+    expect(result).toBe(-1);
+  });
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/from.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/from.js
@@ -21,4 +21,23 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime.from", () => {
     expect(zdt.month).toBe(3);
     expect(zdt.day).toBe(31);
   });
+
+  test("from property bag with ISO time zone", () => {
+    const zdt = Temporal.ZonedDateTime.from({
+      year: 2024,
+      monthCode: "M03",
+      day: 15,
+      hour: 13,
+      minute: 45,
+      second: 30,
+      timeZone: "UTC"
+    });
+    expect(zdt.year).toBe(2024);
+    expect(zdt.month).toBe(3);
+    expect(zdt.day).toBe(15);
+    expect(zdt.hour).toBe(13);
+    expect(zdt.minute).toBe(45);
+    expect(zdt.second).toBe(30);
+    expect(zdt.timeZoneId).toBe("UTC");
+  });
 });

--- a/tests/built-ins/TypedArray/constructors.js
+++ b/tests/built-ins/TypedArray/constructors.js
@@ -144,10 +144,45 @@ describe("TypedArray constructors", () => {
       const buf = new ArrayBuffer(8);
       expect(() => new Int32Array(buf, 0, 3)).toThrow(RangeError);
     });
+    test("undefined length behaves like omitted length", () => {
+      const buf = new ArrayBuffer(8);
+      const view = new Int32Array(buf, 0, undefined);
+      expect(view.length).toBe(2);
+      expect(view.byteLength).toBe(8);
+    });
+    test("resizable buffer with non-multiple byteLength creates length-tracking view", () => {
+      const buf = new ArrayBuffer(3, { maxByteLength: 16 });
+      const view = new Float64Array(buf);
+      expect(view.length).toBe(0);
+      expect(view.byteLength).toBe(0);
+      buf.resize(8);
+      expect(view.length).toBe(1);
+      expect(view.byteLength).toBe(8);
+    });
+    test("detached buffer throws TypeError after offset and length coercion", () => {
+      const buf = new ArrayBuffer(8);
+      const events = [];
+      const offset = {
+        valueOf() {
+          events.push("offset");
+          return 0;
+        },
+      };
+      const length = {
+        valueOf() {
+          events.push("length");
+          buf.transfer();
+          return 1;
+        },
+      };
+
+      expect(() => new Int32Array(buf, offset, length)).toThrow(TypeError);
+      expect(events).toEqual(["offset", "length"]);
+    });
   });
 
   describe("new TypedArray(iterable)", () => {
-    test("Reflect.construct resolves newTarget prototype before reading iterable source", () => {
+    test("Reflect.construct reads iterable source before resolving newTarget prototype", () => {
       const events = [];
       class NewTargetBase {}
       const NewTarget = new Proxy(NewTargetBase, {
@@ -167,7 +202,7 @@ describe("TypedArray constructors", () => {
       };
 
       expect(() => Reflect.construct(Int8Array, [iterable], NewTarget)).toThrow(Error);
-      expect(events).toEqual(["prototype"]);
+      expect(events).toEqual(["iterator", "prototype"]);
     });
 
     test("Reflect.construct falls back to typed array prototype for non-object newTarget prototype", () => {

--- a/tests/built-ins/TypedArray/prototype/filter.js
+++ b/tests/built-ins/TypedArray/prototype/filter.js
@@ -72,6 +72,19 @@ describe("TypedArray.prototype.filter", () => {
     expect(filtered[1]).toBe(4n);
   });
 
+  test("uses constructor Symbol.species override", () => {
+    const ta = new Uint8Array([1, 2, 3]);
+    ta.constructor = { [Symbol.species]: Float32Array };
+
+    const filtered = ta.filter(x => x >= 2);
+
+    expect(Object.prototype.toString.call(filtered)).toBe("[object Float32Array]");
+    expect(filtered.length).toBe(2);
+    expect(filtered.byteLength).toBe(8);
+    expect(filtered[0]).toBe(2);
+    expect(filtered[1]).toBe(3);
+  });
+
   test.each([BigInt64Array, BigUint64Array])("%s continues after callback detaches buffer", (TA) => {
     const ta = new TA(2);
     const buffer = ta.buffer;

--- a/tests/built-ins/TypedArray/prototype/map.js
+++ b/tests/built-ins/TypedArray/prototype/map.js
@@ -74,6 +74,19 @@ describe("TypedArray.prototype.map", () => {
     expect(mapped[2]).toBe(6n);
   });
 
+  test("uses constructor Symbol.species override", () => {
+    const ta = new Uint8Array([1, 2]);
+    ta.constructor = { [Symbol.species]: Float32Array };
+
+    const mapped = ta.map(x => x + 0.5);
+
+    expect(Object.prototype.toString.call(mapped)).toBe("[object Float32Array]");
+    expect(mapped.length).toBe(2);
+    expect(mapped.byteLength).toBe(8);
+    expect(mapped[0]).toBe(1.5);
+    expect(mapped[1]).toBe(2.5);
+  });
+
   test.each([BigInt64Array, BigUint64Array])("%s continues after callback detaches buffer", (TA) => {
     const ta = new TA(2);
     const buffer = ta.buffer;

--- a/tests/built-ins/TypedArray/prototype/slice.js
+++ b/tests/built-ins/TypedArray/prototype/slice.js
@@ -79,6 +79,26 @@ describe("TypedArray.prototype.slice", () => {
     expect(sliced[1]).toBe(3n);
   });
 
+  test("uses constructor Symbol.species override", () => {
+    const ta = new Uint8Array([1, 2, 3]);
+    ta.constructor = { [Symbol.species]: Float32Array };
+
+    const sliced = ta.slice(0, 2);
+
+    expect(Object.prototype.toString.call(sliced)).toBe("[object Float32Array]");
+    expect(sliced.length).toBe(2);
+    expect(sliced.byteLength).toBe(8);
+    expect(sliced[0]).toBe(1);
+    expect(sliced[1]).toBe(2);
+  });
+
+  test("throws when species changes BigInt content type", () => {
+    const ta = new BigInt64Array([1n]);
+    ta.constructor = { [Symbol.species]: Float64Array };
+
+    expect(() => ta.slice()).toThrow(TypeError);
+  });
+
   test("throws on detached buffer", () => {
     const ta = new Int32Array([1, 2, 3]);
     ta.buffer.transfer();

--- a/tests/built-ins/TypedArray/prototype/subarray.js
+++ b/tests/built-ins/TypedArray/prototype/subarray.js
@@ -63,6 +63,62 @@ describe("TypedArray.prototype.subarray", () => {
     ta[1] = 99n;
     expect(sub[0]).toBe(99n);
   });
+
+  test("uses constructor Symbol.species override", () => {
+    const ta = new Uint16Array([0x0201, 0x0403, 0x0605]);
+    ta.constructor = { [Symbol.species]: Uint8Array };
+
+    const sub = ta.subarray(1, 3);
+
+    expect(Object.prototype.toString.call(sub)).toBe("[object Uint8Array]");
+    expect(sub.length).toBe(2);
+    expect(sub.byteOffset).toBe(2);
+    expect(sub[0]).toBe(3);
+    expect(sub[1]).toBe(4);
+  });
+
+  test("throws when species view is not byte-aligned", () => {
+    const ta = new Uint8Array([1, 2, 3, 4]);
+    ta.constructor = { [Symbol.species]: Uint16Array };
+
+    expect(() => ta.subarray(1, 2)).toThrow(RangeError);
+  });
+
+  test("omits length for length-tracking views when end is omitted", () => {
+    const buf = new ArrayBuffer(8, { maxByteLength: 16 });
+    const ta = new Uint8Array(buf, 2);
+    let args;
+    class Species extends Uint8Array {
+      constructor(...params) {
+        args = [params[0], params[1], params[2], params.length];
+        super(params[0], params[1]);
+      }
+    }
+    ta.constructor = {
+      [Symbol.species]: Species,
+    };
+
+    const sub = ta.subarray(1);
+
+    expect(args).toEqual([buf, 3, undefined, 2]);
+    expect(sub.length).toBe(5);
+  });
+
+  test("length-tracking result keeps byteOffset after begin coercion grows buffer", () => {
+    const buf = new ArrayBuffer(10, { maxByteLength: 10 });
+    const ta = new Int8Array(buf, 4);
+    buf.resize(0);
+
+    const result = ta.subarray({
+      valueOf() {
+        buf.resize(10);
+        return 1;
+      },
+    });
+
+    expect(result.byteOffset).toBe(4);
+    expect(result.length).toBe(6);
+  });
 });
 
 describe("TypedArray.prototype.subarray non-finite range arguments", () => {

--- a/tests/language/generators/object-method.js
+++ b/tests/language/generators/object-method.js
@@ -440,6 +440,45 @@ test("object generator yield delegation preserves delegated finally yields on re
   expect(iter.next()).toEqual({ value: undefined, done: true });
 });
 
+test("object generator yield delegation continues when iterator return result is not done", () => {
+  let callCount = 0;
+  const returnResult = Object.defineProperty({ done: false }, "value", {
+    get() {
+      callCount += 1;
+      return "done";
+    },
+  });
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: "next", done: false };
+        },
+        return() {
+          return returnResult;
+        },
+      };
+    },
+  };
+
+  const delegate = {
+    *values() {
+      yield* iterable;
+    },
+  };
+
+  const iterator = delegate.values();
+  expect(iterator.next()).toEqual({ value: "next", done: false });
+
+  const pendingReturn = iterator.return("stop");
+  expect(pendingReturn.done).toBe(false);
+  expect(callCount).toBe(0);
+
+  returnResult.done = true;
+  expect(iterator.return("stop")).toEqual({ value: "done", done: true });
+  expect(callCount).toBe(1);
+});
+
 test("object generator yield delegation rejects non-callable return and throw", () => {
   const nonCallableReturn = {
     [Symbol.iterator]() {


### PR DESCRIPTION
## Summary

- Close the targeted built-ins test262 clusters for Iterator, TypedArray, Promise, Object, Atomics, and Temporal on the pinned suite.
- Add loader-bare `$262.agent` host support, then retain/join agent worker threads during teardown to avoid dangling host callbacks.
- Fix the newly surfaced semantic regressions for ArrayBuffer/SAB `maxByteLength`, `Temporal.Duration.prototype.total` with ZonedDateTime `relativeTo`, and sync `yield*` return results with `done: false`.
- Keep the TypedArray timeout investigation separate from this PR follow-up.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas --clean testrunner loaderbare loader`
  - `./build/GocciaTestRunner tests --no-progress` (`10728/10728`)
  - `./build/GocciaTestRunner tests --mode=bytecode --no-progress` (`10728/10728`)
  - Exact pinned semantic regression test262 files pass in interpreted and bytecode mode
  - Pinned test262 `built-ins/Atomics/**` bytecode: `390/390`, wrapper infra `0`
  - `bun run scripts/test-cli-apps.ts`
  - `./format.pas --check`
  - `git diff --check`
- [x] Updated documentation
  - `docs/test262.md`
  - `docs/built-ins.md`
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./build.pas tests`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
