### PR TITLE
docs(agents): document source layout search paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Assistants should treat CONTRIBUTING as authoritative for contribution requireme
 - **Match the project's workflow**: branch from `main`, focused diffs, tests and docs updated per CONTRIBUTING.
 - **Treat project-local skills as external playbooks**: files under `.agents/skills/` are not normal repo documentation. Do not edit them unless the user explicitly asks to change that skill. Put repo-specific assistant expectations in this file, or create/update a separate skill only when explicitly requested.
 - **Infer architecture boundaries during planning**: when a change touches website routes, API handlers, generated reports, external services, credentials, artifacts, caches, CI outputs, or deployment/build steps, identify where the work belongs (build time, request time, client time, CI/scheduled time) and compare against existing project patterns before implementing. Do not rely on the user or a skill checklist to spell this out.
+- **Search the real source layout**: when prompts, automations, or audits search this repo, target `source/units`, `source/shared`, `source/app`, `tests`, `scripts`, and `website/src` explicitly. Do not assume a generic root `src/` tree; `source/generated` is generated data and should only be inspected or regenerated when the task specifically requires it.
 - **Clean first for stale FPC failures**: after a merge, branch switch, PR sync,
   generated resource change, or unexplained compiler/resource error, retry with
   `./build.pas --clean <target>` (or `./build.pas --clean`) before diagnosing the


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Document the explicit search paths prompts, automations, and audits should use for GocciaScript.
- Clarify that the repo does not have a generic root `src/` tree and that `source/generated` is generated data.

## Testing

- [ ] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation run: `git diff --check`; pre-commit hooks (`check-doc-duplication`, `check-doc-length`, `check-doc-links`, `check-doc-symbols`, `lint-markdown`). The duplication checker reported existing fuzzy warnings only and exited successfully.