### PR TITLE
test(benchmarks): add temporal intl atomics coverage

### DIFF
--- a/benchmarks/atomics.js
+++ b/benchmarks/atomics.js
@@ -1,0 +1,66 @@
+/*---
+description: Atomics and SharedArrayBuffer operation benchmarks
+---*/
+
+suite("Atomics integer operations", () => {
+  bench("load and store Int32Array", {
+    setup: () => new Int32Array(new SharedArrayBuffer(4)),
+    run: (view) => {
+      Atomics.store(view, 0, 41);
+      const value = Atomics.load(view, 0);
+    },
+  });
+
+  bench("read-modify-write Int32Array", {
+    setup: () => new Int32Array(new SharedArrayBuffer(4)),
+    run: (view) => {
+      Atomics.add(view, 0, 1);
+      Atomics.sub(view, 0, 1);
+      Atomics.exchange(view, 0, 7);
+    },
+  });
+
+  bench("compareExchange hit and miss", {
+    setup: () => {
+      const view = new Int32Array(new SharedArrayBuffer(4));
+      view[0] = 1;
+      return view;
+    },
+    run: (view) => {
+      Atomics.compareExchange(view, 0, 1, 2);
+      Atomics.compareExchange(view, 0, 1, 3);
+      Atomics.compareExchange(view, 0, 2, 1);
+    },
+  });
+});
+
+suite("Atomics wait and notify", () => {
+  bench("wait with zero timeout", {
+    setup: () => {
+      const view = new Int32Array(new SharedArrayBuffer(4));
+      view[0] = 1;
+      return view;
+    },
+    run: (view) => {
+      const result = Atomics.wait(view, 0, 1, 0);
+    },
+  });
+
+  bench("waitAsync synchronous not-equal", {
+    setup: () => {
+      const view = new Int32Array(new SharedArrayBuffer(4));
+      view[0] = 1;
+      return view;
+    },
+    run: (view) => {
+      const result = Atomics.waitAsync(view, 0, 2, 10);
+    },
+  });
+
+  bench("notify with no waiters", {
+    setup: () => new Int32Array(new SharedArrayBuffer(4)),
+    run: (view) => {
+      const count = Atomics.notify(view, 0, 1);
+    },
+  });
+});

--- a/benchmarks/intl.js
+++ b/benchmarks/intl.js
@@ -1,0 +1,69 @@
+/*---
+description: Intl operation benchmarks
+---*/
+
+suite("Intl.NumberFormat", () => {
+  bench("format decimal", {
+    setup: () => new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }),
+    run: (format) => {
+      const result = format.format(1234567.89);
+    },
+  });
+
+  bench("format currency", {
+    setup: () => new Intl.NumberFormat("de-DE", { style: "currency", currency: "EUR" }),
+    run: (format) => {
+      const result = format.format(1234567.89);
+    },
+  });
+});
+
+suite("Intl.DateTimeFormat", () => {
+  bench("format UTC date", {
+    setup: () => ({
+      format: new Intl.DateTimeFormat("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+        timeZone: "UTC",
+      }),
+      date: new Date(1710510330000),
+    }),
+    run: (ctx) => {
+      const result = ctx.format.format(ctx.date);
+    },
+  });
+
+  bench("formatRange UTC dates", {
+    setup: () => ({
+      format: new Intl.DateTimeFormat("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+        timeZone: "UTC",
+      }),
+      start: new Date(1710510330000),
+      end: new Date(1710513930000),
+    }),
+    run: (ctx) => {
+      const result = ctx.format.formatRange(ctx.start, ctx.end);
+    },
+  });
+});
+
+suite("Intl.Collator", () => {
+  bench("compare numeric strings", {
+    setup: () => new Intl.Collator("en", { numeric: true }),
+    run: (collator) => {
+      const result = collator.compare("item 9", "item 10");
+    },
+  });
+
+  bench("sort short string list", {
+    setup: () => ({
+      collator: new Intl.Collator("en", { sensitivity: "base" }),
+      values: ["zebra", "angstrom", "apple", "Algebra", "banana"],
+    }),
+    run: (ctx) => {
+      const sorted = ctx.values.slice().sort(ctx.collator.compare);
+    },
+  });
+});

--- a/benchmarks/temporal.js
+++ b/benchmarks/temporal.js
@@ -1,0 +1,56 @@
+/*---
+description: Temporal operation benchmarks
+---*/
+
+suite("Temporal.PlainDate arithmetic", () => {
+  bench("PlainDate.add({ months: 1 })", {
+    setup: () => Temporal.PlainDate.from("2024-01-31"),
+    run: (date) => {
+      const next = date.add({ months: 1 });
+    },
+  });
+
+  bench("PlainDate.until(..., { largestUnit: 'months' })", {
+    setup: () => ({
+      start: Temporal.PlainDate.from("2024-01-01"),
+      end: Temporal.PlainDate.from("2025-07-15"),
+    }),
+    run: (ctx) => {
+      const duration = ctx.start.until(ctx.end, { largestUnit: "months" });
+    },
+  });
+});
+
+suite("Temporal.Duration balancing", () => {
+  bench("Duration.total days relative to PlainDate", {
+    setup: () => Temporal.Duration.from({ years: 1, months: 6, days: 3 }),
+    run: (duration) => {
+      const days = duration.total({ unit: "days", relativeTo: "2024-01-01" });
+    },
+  });
+
+  bench("Duration.round to hours", {
+    setup: () => Temporal.Duration.from({ hours: 1, minutes: 45, seconds: 30 }),
+    run: (duration) => {
+      const rounded = duration.round({ smallestUnit: "hours", roundingMode: "halfExpand" });
+    },
+  });
+});
+
+suite("Temporal.ZonedDateTime", () => {
+  bench("ZonedDateTime.from named time zone", {
+    run: () => {
+      const zdt = Temporal.ZonedDateTime.from("2024-03-10T12:30:00-04:00[America/New_York]");
+    },
+  });
+
+  bench("ZonedDateTime.since across DST", {
+    setup: () => ({
+      start: Temporal.ZonedDateTime.from("2024-03-09T00:00:00-05:00[America/New_York]"),
+      end: Temporal.ZonedDateTime.from("2024-03-10T12:30:00-04:00[America/New_York]"),
+    }),
+    run: (ctx) => {
+      const duration = ctx.end.since(ctx.start, { largestUnit: "days" });
+    },
+  });
+});

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -203,10 +203,13 @@ The non-zero exit code ensures CI pipelines fail when benchmarks crash or produc
 | File | Covers |
 |------|--------|
 | `benchmarks/fibonacci.js` | Recursive vs iterative computation |
+| `benchmarks/atomics.js` | Atomics load/store, read-modify-write operations, compareExchange, wait/notify, waitAsync synchronous path |
 | `benchmarks/arrays.js` | Array.from, map, filter, reduce, forEach, find, sort, flat, flatMap |
 | `benchmarks/objects.js` | Object creation, property access, Object.keys/entries, spread |
 | `benchmarks/strings.js` | Concatenation, template literals, split/join, indexOf, trim, replace, pad |
 | `benchmarks/regexp.js` | RegExp construction, prototype methods, and string integration hooks |
+| `benchmarks/intl.js` | Intl.NumberFormat, Intl.DateTimeFormat, and Intl.Collator construction-free hot formatting/comparison paths |
+| `benchmarks/temporal.js` | Temporal PlainDate arithmetic, Duration balancing, ZonedDateTime construction, and DST-aware difference paths |
 | `benchmarks/classes.js` | Instantiation, method dispatch, inheritance, private fields, getters/setters, decorators (class, method, field, getter/setter, static, private, auto-accessor, metadata) |
 | `benchmarks/closures.js` | Closure capture, higher-order functions, call/apply/bind, recursion |
 | `benchmarks/collections.js` | Set add/has/delete/forEach, Map set/get/has/delete/forEach/keys/values |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add focused benchmark coverage for Temporal, Intl, and Atomics hot paths that were absent from `benchmarks/` and `docs/benchmarks.md`.
- Keep the additions minimal: three benchmark files, six benchmarks per file, no engine behavior changes.
- Update the benchmark catalog so retained benchmark/profile reports have named coverage for these surfaces.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas testrunner`
  - `./build/GocciaTestRunner tests` -> 10737/10737 passing
  - `./build/GocciaTestRunner tests --mode=bytecode` -> 10737/10737 passing
- [x] Updated documentation
  - `docs/benchmarks.md`
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - Not applicable; no Pascal source changed.
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - `./build.pas benchmarkrunner`
  - `GOCCIA_BENCH_CALIBRATION_MS=1 GOCCIA_BENCH_ROUNDS=1 GOCCIA_BENCH_WARMUP=1 ./build/GocciaBenchmarkRunner benchmarks/temporal.js benchmarks/intl.js benchmarks/atomics.js --no-progress --format=compact-json --output=/tmp/goccia-targeted-bench-interpreted.json`
  - `GOCCIA_BENCH_CALIBRATION_MS=1 GOCCIA_BENCH_ROUNDS=1 GOCCIA_BENCH_WARMUP=1 ./build/GocciaBenchmarkRunner benchmarks/temporal.js benchmarks/intl.js benchmarks/atomics.js --mode=bytecode --no-progress --format=compact-json --output=/tmp/goccia-targeted-bench-bytecode.json`
  - `GOCCIA_BENCH_CALIBRATION_MS=1 GOCCIA_BENCH_ROUNDS=1 GOCCIA_BENCH_WARMUP=1 ./build/GocciaBenchmarkRunner benchmarks/temporal.js benchmarks/intl.js benchmarks/atomics.js --profile-deterministic --profile-output=/tmp/goccia-targeted-bench-profile.json --no-progress --format=compact-json --output=/tmp/goccia-targeted-bench-profile-report.json`
  - JSON reports confirmed 18 benchmarks total: six each for Temporal, Intl, and Atomics.
- [x] Additional checks
  - `./format.pas --check`
  - `git diff --check`