### PR TITLE
ci(workflows): scope GitHub Actions token permissions to jobs that need them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   FPC_VERSION: "3.2.2"
@@ -49,6 +48,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Restore toolchain cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -281,6 +281,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -405,6 +406,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -486,6 +488,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -572,6 +575,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -606,6 +610,7 @@ jobs:
           ref: ${{ steps.test262-pin.outputs.sha }}
           path: test262-suite
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run test262 conformance suite
         continue-on-error: true
@@ -755,6 +760,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -911,6 +917,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -970,6 +977,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -994,6 +1002,8 @@ jobs:
       group: nightly-release
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash
@@ -1001,6 +1011,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check if nightly already published today
         id: check
@@ -1088,6 +1099,9 @@ jobs:
     needs: [test, toml-compliance, json5-compliance, benchmark, cli]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     defaults:
       run:
         shell: bash
@@ -1095,6 +1109,9 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          # Keep the GITHUB_TOKEN persisted: the changelog step below pushes
+          # a branch via `git push --force-with-lease`.
+          persist-credentials: true
 
       - name: Download all build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   build:
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install FPC
         run: sudo apt-get update && sudo apt-get install fpc -qq > /dev/null
@@ -42,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Lint Markdown
         uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23
@@ -72,6 +75,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -173,6 +177,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -240,6 +245,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
@@ -281,6 +287,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -315,6 +322,7 @@ jobs:
           ref: ${{ steps.test262-pin.outputs.sha }}
           path: test262-suite
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run test262 conformance suite
         continue-on-error: true
@@ -345,11 +353,16 @@ jobs:
   benchmark-comment:
     needs: benchmark
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Download interpreted results
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -649,6 +662,8 @@ jobs:
     needs: [test, benchmark]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     defaults:
       run:
         shell: bash
@@ -855,11 +870,16 @@ jobs:
     needs: test262
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 


### PR DESCRIPTION
## Summary

Tightens GitHub Actions `GITHUB_TOKEN` permissions in `ci.yml` and `pr.yml` so write scopes live only on the jobs that publish releases, push the changelog branch, or post PR comments. Every compile / test / benchmark / compliance / artifact job now runs read-only. This applies the least-privilege pattern already used by the four `*-bump.yml` workflows.

**Permission changes**

| Workflow / job | Before | After |
|---|---|---|
| `ci.yml` workflow default | `contents: write` + `pull-requests: write` | `contents: read` |
| `ci.yml` `nightly` | inherited write | `contents: write` (gh release delete/create) |
| `ci.yml` `release` | inherited write | `contents: write` + `pull-requests: write` (release upload, `git push`, `gh pr create`) |
| `pr.yml` workflow default | `pull-requests: write` | `contents: read` |
| `pr.yml` `benchmark-comment`, `test262-comment` | inherited write | `contents: read` + `pull-requests: write` |
| `pr.yml` `timing-comment` | inherited write | `pull-requests: write` only (no checkout) |

**Checkout hardening** — `persist-credentials: false` added to every non-pushing checkout (10 in `ci.yml`, 9 in `pr.yml`), matching the bump-workflow pattern. The `release` job's checkout keeps `persist-credentials: true` (with an inline comment) because it runs `git push --force-with-lease` for the changelog branch.

**Key constraints / non-goals**

- The PR-comment jobs need only `pull-requests: write`, **not** `issues: write` (the issue's open question): GitHub's "Create an issue comment" endpoint accepts either scope, and these jobs only ever comment on PRs.
- Job-level `permissions` blocks *replace* (not merge with) the workflow default, so each checkout-bearing comment job explicitly keeps `contents: read`.
- `actions/cache`, same-run artifact upload/download, and the Vercel-Blob publish steps don't consume `GITHUB_TOKEN` write scopes (they use the runtime token / `BLOB_READ_WRITE_TOKEN`), so the affected jobs are safe read-only.
- The four `*-bump.yml` workflows and the reusable `toolchain.yml` (which inherits the new read-only default) are intentionally untouched.
- No ADR and no doc change: ADRs in this repo are engine/runtime decisions only, no doc describes the token-permission model, and the bump workflows set this precedent without one.

Closes #785

## Testing

- [x] Verified no regressions in end-to-end JavaScript tests — clean build + full JS suite gate (Definition of Done): `GocciaTestRunner tests` and `--mode=bytecode` → **10,799 / 10,799 passed, 0 failed, 0 skipped** in both modes. (A CI-config change cannot affect the engine; run per the project's "always run" gate.)
- [ ] Updated documentation — N/A; no documentation describes the workflow token-permission model (confirmed during a `grill-with-docs` session).
- [ ] Native Pascal tests — N/A; no AST, scope, evaluator, or value-type change.
- [ ] Benchmarks — N/A; no engine change.

**Workflow-specific verification**

- `ruby -ryaml` parse: both files load OK.
- `actionlint ci.yml pr.yml`: finding signatures **byte-identical to the `HEAD` baseline** — zero new findings. actionlint exits 1 solely because of the pre-existing `SC2012` / `SC2044` / `SC2086` shellcheck info/warnings in `ci.yml`'s build `run:` script (~line 64), which the issue documented and this PR deliberately leaves unchanged.
- `./format.pas --check`: 366 files, all formatted correctly.
- Independent diff review (scope-sufficiency, credential-correctness, removed-behavior): zero findings — no job is under-scoped, and the sole `persist-credentials: true` checkout is the only one that runs an authenticated `git push`.
