### PR TITLE
fix(engine): deduplicate string-to-number across runtime and compiler

### DIFF
--- a/docs/adr/0070-shared-string-to-number.md
+++ b/docs/adr/0070-shared-string-to-number.md
@@ -1,0 +1,55 @@
+# 0070 - Shared string-to-number conversion
+
+## Status
+
+Accepted.
+
+## Context
+
+ECMAScript `StringToNumber` (ECMA-262 §7.1.4.1.1) was implemented twice. Runtime
+primitive coercion lived in `TGocciaStringLiteralValue.ToNumberLiteral`
+(`Goccia.Values.Primitives`), and compile-time constant folding had its own
+`StringToCompileTimeNumber` (`Goccia.Compiler.ConstantValue`). Each kept a
+partial copy of the `StringNumericLiteral` grammar, so the interpreter and the
+bytecode constant optimizer (ADR 0040) could fold the same string source to
+different values. A `+Infinity` divergence had already been fixed in one path
+but not the other, and both copies shared latent gaps: binary/octal prefixes
+returned `NaN`, large hex wrapped through a fixed-width `StrToInt`, and
+`TryStrToFloat` over-accepted inputs such as `"Inf"`.
+
+The compiler must reuse the parser without instantiating a `TGocciaValue`, so
+the shared implementation cannot return a runtime value object.
+
+## Decision
+
+Introduce `source/shared/NumericText.pas` with a single side-effect-free
+`StringToNumber(const AText: string): Double`, and route both paths through it:
+`ToNumberLiteral` wraps the result with `TGocciaNumberLiteralValue.Create`, and
+`TryCompileTimeValueToNumber` calls it directly. The helper implements the
+`StringNumericLiteral` grammar in one place — ECMAScript whitespace trimming,
+empty `→ +0`, signed `Infinity`, `NonDecimalIntegerLiteral` (`0b`/`0o`/`0x`,
+no sign, digits accumulated into a `Double` so large magnitudes round instead of
+wrapping), a grammar-gated `StrDecimalLiteral` (overflow `→ ±Infinity`, signed
+zero preserved), and `NaN` for everything else.
+
+The helper lives in `source/shared/` rather than in `Goccia.Values.Primitives`
+or `TextSemantics`:
+
+- It returns a raw `Double` and depends only on text, so it stays free of the
+  GocciaScript value types — the compiler reuses it with no allocation.
+- A dedicated unit gives textual numeric conversion a clear home with room to
+  absorb related parsing (`parseInt`, `parseFloat`) later, rather than growing
+  `TextSemantics` (UTF/whitespace semantics) or `Goccia.Values.Primitives`
+  (value classes) with an unrelated concern.
+
+No bytecode format or opcode changes; the compiler optimizer design from
+ADR 0040 is unchanged.
+
+## Consequences
+
+Runtime `Number(...)`/unary `+` and bytecode constant folding now share one
+parser and cannot drift. Fixing the parser once also closed the shared
+conformance gaps: binary/octal literals, full-magnitude hex, rejection of
+`"Inf"` and bare punctuation, and sign rejection on non-decimal literals are now
+correct in both execution modes. Future string↔number conversions should extend
+`NumericText` instead of adding a second parser.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,3 +79,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0067 — Cross-realm shape dictionary mode](0067-cross-realm-shape-dictionary-mode.md)
 - [0068 — GocciaSandboxRunner with explicit seed baselines](0068-goccia-sandbox-runner.md)
 - [0069 — Nested sandbox virtual filesystems](0069-nested-sandbox-virtual-filesystems.md)
+- [0070 — Shared string-to-number conversion](0070-shared-string-to-number.md)

--- a/source/shared/NumericText.Test.pas
+++ b/source/shared/NumericText.Test.pas
@@ -1,0 +1,139 @@
+program NumericText.Test;
+
+{$I Shared.inc}
+
+uses
+  Classes,
+  Math,
+  SysUtils,
+
+  NumericText,
+  TestingPascalLibrary;
+
+type
+  TNumericTextTests = class(TTestSuite)
+  private
+    procedure TestWhitespaceAndEmpty;
+    procedure TestSignedInfinity;
+    procedure TestNonDecimalIntegerLiterals;
+    procedure TestNonDecimalRejections;
+    procedure TestDecimalLiterals;
+    procedure TestSignedZero;
+    procedure TestInvalidInput;
+  public
+    procedure SetupTests; override;
+  end;
+
+function IsNegativeZero(const AValue: Double): Boolean;
+var
+  Value: Double;
+  Bits: Int64 absolute Value;
+begin
+  Value := AValue;
+  Result := (Value = 0.0) and (Bits < 0);
+end;
+
+function IsPositiveZero(const AValue: Double): Boolean;
+var
+  Value: Double;
+  Bits: Int64 absolute Value;
+begin
+  Value := AValue;
+  Result := (Value = 0.0) and (Bits >= 0);
+end;
+
+procedure TNumericTextTests.SetupTests;
+begin
+  Test('whitespace and empty input convert to +0',
+    TestWhitespaceAndEmpty);
+  Test('signed Infinity converts; abbreviations do not',
+    TestSignedInfinity);
+  Test('hex, binary, and octal literals convert in either letter case',
+    TestNonDecimalIntegerLiterals);
+  Test('non-decimal literals reject signs, empty digits, and bad radix digits',
+    TestNonDecimalRejections);
+  Test('decimal literals convert and overflow to signed Infinity',
+    TestDecimalLiterals);
+  Test('negative-zero strings preserve -0',
+    TestSignedZero);
+  Test('inputs that are not StringNumericLiterals convert to NaN',
+    TestInvalidInput);
+end;
+
+procedure TNumericTextTests.TestWhitespaceAndEmpty;
+begin
+  Expect<Boolean>(IsPositiveZero(StringToNumber(''))).ToBe(True);
+  Expect<Boolean>(IsPositiveZero(StringToNumber('   '))).ToBe(True);
+  Expect<Boolean>(IsPositiveZero(StringToNumber(#9#10#13' '))).ToBe(True);
+  Expect<Double>(StringToNumber('  42  ')).ToBe(42.0);
+  Expect<Double>(StringToNumber(#9' 42 '#10)).ToBe(42.0);
+end;
+
+procedure TNumericTextTests.TestSignedInfinity;
+begin
+  Expect<Boolean>(StringToNumber('Infinity') = Infinity).ToBe(True);
+  Expect<Boolean>(StringToNumber('+Infinity') = Infinity).ToBe(True);
+  Expect<Boolean>(StringToNumber('-Infinity') = NegInfinity).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('Inf'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('Infinityy'))).ToBe(True);
+end;
+
+procedure TNumericTextTests.TestNonDecimalIntegerLiterals;
+begin
+  Expect<Double>(StringToNumber('0xFF')).ToBe(255.0);
+  Expect<Double>(StringToNumber('0X10')).ToBe(16.0);
+  Expect<Double>(StringToNumber('0b101')).ToBe(5.0);
+  Expect<Double>(StringToNumber('0B11')).ToBe(3.0);
+  Expect<Double>(StringToNumber('0o17')).ToBe(15.0);
+  Expect<Double>(StringToNumber('0O20')).ToBe(16.0);
+  // Large hex must round to the nearest Double, not wrap a fixed-width integer.
+  Expect<Double>(StringToNumber('0xABCDEF12345')).ToBe(11806310474565.0);
+end;
+
+procedure TNumericTextTests.TestNonDecimalRejections;
+begin
+  Expect<Boolean>(IsNan(StringToNumber('+0x10'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('-0x10'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('0x'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('0b'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('0o'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('0b12'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('0o18'))).ToBe(True);
+end;
+
+procedure TNumericTextTests.TestDecimalLiterals;
+begin
+  Expect<Double>(StringToNumber('00123')).ToBe(123.0);
+  Expect<Double>(StringToNumber('.5e3')).ToBe(500.0);
+  Expect<Double>(StringToNumber('5.')).ToBe(5.0);
+  Expect<Double>(StringToNumber('+.5')).ToBe(0.5);
+  Expect<Boolean>(StringToNumber('1e400') = Infinity).ToBe(True);
+  Expect<Boolean>(StringToNumber('-1e400') = NegInfinity).ToBe(True);
+end;
+
+procedure TNumericTextTests.TestSignedZero;
+begin
+  Expect<Boolean>(IsNegativeZero(StringToNumber('-0'))).ToBe(True);
+  Expect<Boolean>(IsNegativeZero(StringToNumber('-0.00'))).ToBe(True);
+  Expect<Boolean>(IsPositiveZero(StringToNumber('+0'))).ToBe(True);
+  Expect<Boolean>(IsPositiveZero(StringToNumber('0'))).ToBe(True);
+end;
+
+procedure TNumericTextTests.TestInvalidInput;
+begin
+  Expect<Boolean>(IsNan(StringToNumber('abc'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('.'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('+'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('-'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('1_000'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('1,000'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('1.5d'))).ToBe(True);
+  Expect<Boolean>(IsNan(StringToNumber('0x1p4'))).ToBe(True);
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TNumericTextTests.Create('NumericText'));
+  TestRunnerProgram.Run;
+
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/shared/NumericText.pas
+++ b/source/shared/NumericText.pas
@@ -1,0 +1,214 @@
+unit NumericText;
+
+{$I Shared.inc}
+
+interface
+
+// Converts a String to a Number following the ECMA-262 StringToNumber
+// abstract operation and the StringNumericLiteral grammar. Returns a raw
+// Double (NaN for any input that is not a StringNumericLiteral) and performs
+// no value-object allocation, so runtime primitive coercion and compile-time
+// constant folding can share a single implementation instead of each keeping
+// its own partial parser.
+function StringToNumber(const AText: string): Double;
+
+implementation
+
+uses
+  Math,
+  SysUtils,
+
+  TextSemantics;
+
+const
+  INFINITY_TEXT = 'Infinity';
+
+function HexDigitValue(const AChar: Char): Integer;
+begin
+  case AChar of
+    '0'..'9': Result := Ord(AChar) - Ord('0');
+    'a'..'f': Result := Ord(AChar) - Ord('a') + 10;
+    'A'..'F': Result := Ord(AChar) - Ord('A') + 10;
+  else
+    Result := -1;
+  end;
+end;
+
+// ES2026 §7.1.4.1 NonDecimalIntegerLiteral (BinaryIntegerLiteral,
+// OctalIntegerLiteral, HexIntegerLiteral). These never carry a leading sign.
+// Returns True when AText has a 0b / 0o / 0x prefix and therefore belongs to
+// the non-decimal space; ANumber is then the parsed value, or NaN when the
+// digits after the prefix are missing or invalid for the radix.
+function TryNonDecimalIntegerToNumber(const AText: string;
+  out ANumber: Double): Boolean;
+var
+  Radix: Integer;
+  Index: Integer;
+  DigitValue: Integer;
+begin
+  Result := False;
+  if (Length(AText) < 2) or (AText[1] <> '0') then
+    Exit;
+
+  case AText[2] of
+    'b', 'B': Radix := 2;
+    'o', 'O': Radix := 8;
+    'x', 'X': Radix := 16;
+  else
+    Exit;
+  end;
+
+  Result := True;
+
+  if Length(AText) < 3 then
+  begin
+    ANumber := NaN;
+    Exit;
+  end;
+
+  ANumber := 0.0;
+  for Index := 3 to Length(AText) do
+  begin
+    DigitValue := HexDigitValue(AText[Index]);
+    if (DigitValue < 0) or (DigitValue >= Radix) then
+    begin
+      ANumber := NaN;
+      Exit;
+    end;
+    // Accumulate in Double so very large magnitudes round to the nearest
+    // Double (matching StringNumericValue) rather than wrapping a fixed-width
+    // integer the way a base-aware StrToInt would.
+    ANumber := ANumber * Radix + DigitValue;
+  end;
+end;
+
+// ES2026 §7.1.4.1 StrDecimalLiteral grammar check: an optional sign followed by
+// a StrUnsignedDecimalLiteral (integer and/or fraction digits with an optional
+// exponent part). Reports the sign so the caller can pick the correct signed
+// Infinity when a grammar-valid literal overflows the Double range.
+function IsStrDecimalLiteral(const AText: string;
+  out ANegative: Boolean): Boolean;
+var
+  Index: Integer;
+  HasDigit: Boolean;
+  HasIntegerOrFractionDigit: Boolean;
+  HasExponentDigit: Boolean;
+begin
+  ANegative := False;
+  HasIntegerOrFractionDigit := False;
+  Index := 1;
+
+  if Index <= Length(AText) then
+  begin
+    if AText[Index] = '-' then
+    begin
+      ANegative := True;
+      Inc(Index);
+    end
+    else if AText[Index] = '+' then
+      Inc(Index);
+  end;
+
+  HasDigit := False;
+  while (Index <= Length(AText)) and (AText[Index] >= '0') and
+        (AText[Index] <= '9') do
+  begin
+    HasDigit := True;
+    Inc(Index);
+  end;
+  HasIntegerOrFractionDigit := HasIntegerOrFractionDigit or HasDigit;
+
+  if (Index <= Length(AText)) and (AText[Index] = '.') then
+  begin
+    Inc(Index);
+    HasDigit := False;
+    while (Index <= Length(AText)) and (AText[Index] >= '0') and
+          (AText[Index] <= '9') do
+    begin
+      HasDigit := True;
+      Inc(Index);
+    end;
+    HasIntegerOrFractionDigit := HasIntegerOrFractionDigit or HasDigit;
+  end;
+
+  if not HasIntegerOrFractionDigit then
+    Exit(False);
+
+  if (Index <= Length(AText)) and
+     ((AText[Index] = 'e') or (AText[Index] = 'E')) then
+  begin
+    Inc(Index);
+    if (Index <= Length(AText)) and
+       ((AText[Index] = '+') or (AText[Index] = '-')) then
+      Inc(Index);
+
+    HasExponentDigit := False;
+    while (Index <= Length(AText)) and (AText[Index] >= '0') and
+          (AText[Index] <= '9') do
+    begin
+      HasExponentDigit := True;
+      Inc(Index);
+    end;
+
+    if not HasExponentDigit then
+      Exit(False);
+  end;
+
+  Result := Index > Length(AText);
+end;
+
+function StrDecimalLiteralToNumber(const AText: string): Double;
+var
+  Negative: Boolean;
+  FormatSettings: TFormatSettings;
+  Parsed: Double;
+begin
+  if not IsStrDecimalLiteral(AText, Negative) then
+    Exit(NaN);
+
+  // source/shared cannot import Goccia.Values.Primitives, so build the
+  // invariant '.' decimal settings inline (see code-style.md § Source layout).
+  FormatSettings := DefaultFormatSettings;
+  FormatSettings.DecimalSeparator := '.';
+  if TryStrToFloat(AText, Parsed, FormatSettings) then
+    Exit(Parsed);
+
+  // Grammar-valid but not representable as a finite Double: the only way a
+  // StrDecimalLiteral fails to parse is overflow, whose StringNumericValue
+  // rounds to +/-Infinity. (A zero magnitude is always representable, so it
+  // never reaches this branch.)
+  if Negative then
+    Result := NegInfinity
+  else
+    Result := Infinity;
+end;
+
+// ES2026 §7.1.4.1.1 StringToNumber ( str )
+function StringToNumber(const AText: string): Double;
+var
+  Trimmed: string;
+begin
+  // StringNumericLiteral allows leading and trailing ECMAScript whitespace.
+  Trimmed := TrimECMAScriptWhitespace(AText);
+
+  // StringNumericLiteral ::: [empty] evaluates to +0.
+  if Trimmed = '' then
+    Exit(0.0);
+
+  // StrDecimalLiteral ::: (+ | -)? Infinity
+  if Trimmed = INFINITY_TEXT then
+    Exit(Infinity);
+  if Trimmed = '+' + INFINITY_TEXT then
+    Exit(Infinity);
+  if Trimmed = '-' + INFINITY_TEXT then
+    Exit(NegInfinity);
+
+  // NonDecimalIntegerLiteral ::: 0b... | 0o... | 0x...  (no sign permitted)
+  if TryNonDecimalIntegerToNumber(Trimmed, Result) then
+    Exit;
+
+  // StrDecimalLiteral, or NaN when the text is not a StringNumericLiteral.
+  Result := StrDecimalLiteralToNumber(Trimmed);
+end;
+
+end.

--- a/source/units/Goccia.Compiler.ConstantValue.pas
+++ b/source/units/Goccia.Compiler.ConstantValue.pas
@@ -63,9 +63,8 @@ implementation
 
 uses
   Math,
-  SysUtils,
 
-  TextSemantics,
+  NumericText,
 
   Goccia.Constants,
   Goccia.Values.BigIntValue;
@@ -243,42 +242,6 @@ begin
   end;
 end;
 
-function StringToCompileTimeNumber(const AValue: string): Double;
-var
-  FormatSettings: TFormatSettings;
-  Trimmed: string;
-  TempValue: Double;
-begin
-  Trimmed := TrimECMAScriptWhitespace(AValue);
-
-  if Trimmed = '' then
-    Exit(0.0);
-
-  if Trimmed = 'Infinity' then
-    Exit(Infinity);
-  if Trimmed = '+Infinity' then
-    Exit(Infinity);
-  if Trimmed = '-Infinity' then
-    Exit(NegInfinity);
-
-  if (Length(Trimmed) > 2) and (Trimmed[1] = '0') and
-     ((Trimmed[2] = 'x') or (Trimmed[2] = 'X')) then
-  begin
-    try
-      Exit(StrToInt(Trimmed));
-    except
-      Exit(NaN);
-    end;
-  end;
-
-  FormatSettings := DefaultFormatSettings;
-  FormatSettings.DecimalSeparator := '.';
-  if TryStrToFloat(Trimmed, TempValue, FormatSettings) then
-    Result := TempValue
-  else
-    Result := NaN;
-end;
-
 function TryCompileTimeValueToNumber(const AValue: TGocciaCompileTimeValue;
   out ANumber: Double): Boolean;
 begin
@@ -296,7 +259,9 @@ begin
     ctvkNumber:
       ANumber := AValue.NumberValue;
     ctvkString:
-      ANumber := StringToCompileTimeNumber(AValue.StringValue);
+      // ES2026 §7.1.4.1.1 StringToNumber: shared with runtime coercion
+      // (Goccia.Values.Primitives) so folding cannot diverge from execution.
+      ANumber := StringToNumber(AValue.StringValue);
   else
   begin
     ANumber := 0.0;

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -171,6 +171,7 @@ implementation
 uses
   Math,
 
+  NumericText,
   TextSemantics,
 
   Goccia.Constants,
@@ -795,140 +796,13 @@ begin
     Result := TGocciaBooleanLiteralValue.FalseValue;
 end;
 
-function TryClassifyDecimalNumericString(const AValue: string; out ANegative: Boolean;
-  out AHasNonZeroDigit: Boolean): Boolean;
-var
-  Index: Integer;
-  HasDigit: Boolean;
-  HasIntegerOrFractionDigit: Boolean;
-  HasExponentDigit: Boolean;
-begin
-  ANegative := False;
-  AHasNonZeroDigit := False;
-  HasIntegerOrFractionDigit := False;
-  Index := 1;
-
-  if Index <= Length(AValue) then
-  begin
-    if AValue[Index] = '-' then
-    begin
-      ANegative := True;
-      Inc(Index);
-    end
-    else if AValue[Index] = '+' then
-      Inc(Index);
-  end;
-
-  HasDigit := False;
-  while (Index <= Length(AValue)) and CharInSet(AValue[Index], ['0'..'9']) do
-  begin
-    HasDigit := True;
-    if AValue[Index] <> '0' then
-      AHasNonZeroDigit := True;
-    Inc(Index);
-  end;
-  HasIntegerOrFractionDigit := HasIntegerOrFractionDigit or HasDigit;
-
-  if (Index <= Length(AValue)) and (AValue[Index] = '.') then
-  begin
-    Inc(Index);
-    HasDigit := False;
-    while (Index <= Length(AValue)) and CharInSet(AValue[Index], ['0'..'9']) do
-    begin
-      HasDigit := True;
-      if AValue[Index] <> '0' then
-        AHasNonZeroDigit := True;
-      Inc(Index);
-    end;
-    HasIntegerOrFractionDigit := HasIntegerOrFractionDigit or HasDigit;
-  end;
-
-  if not HasIntegerOrFractionDigit then
-    Exit(False);
-
-  if (Index <= Length(AValue)) and ((AValue[Index] = 'e') or (AValue[Index] = 'E')) then
-  begin
-    Inc(Index);
-    if (Index <= Length(AValue)) and ((AValue[Index] = '+') or (AValue[Index] = '-')) then
-      Inc(Index);
-
-    HasExponentDigit := False;
-    while (Index <= Length(AValue)) and CharInSet(AValue[Index], ['0'..'9']) do
-    begin
-      HasExponentDigit := True;
-      Inc(Index);
-    end;
-
-    if not HasExponentDigit then
-      Exit(False);
-  end;
-
-  Result := Index > Length(AValue);
-end;
-
 function TGocciaStringLiteralValue.ToNumberLiteral: TGocciaNumberLiteralValue;
-var
-  TempValue: Double;
-  Trimmed: string;
-  HasNonZeroDigit: Boolean;
-  IsNegativeDecimal: Boolean;
 begin
-  Trimmed := TrimECMAScriptWhitespace(FValue);
-
-  // Empty string (after trim) converts to 0
-  if Trimmed = '' then
-  begin
-    Result := TGocciaNumberLiteralValue.ZeroValue;
-    Exit;
-  end;
-
-  // Handle Infinity / -Infinity
-  if Trimmed = 'Infinity' then
-  begin
-    Result := TGocciaNumberLiteralValue.Create(Infinity);
-    Exit;
-  end;
-  if Trimmed = '-Infinity' then
-  begin
-    Result := TGocciaNumberLiteralValue.Create(NegInfinity);
-    Exit;
-  end;
-  if Trimmed = '+Infinity' then
-  begin
-    Result := TGocciaNumberLiteralValue.Create(Infinity);
-    Exit;
-  end;
-
-  // Handle hex strings 0x / 0X
-  if (Length(Trimmed) > 2) and (Trimmed[1] = '0') and ((Trimmed[2] = 'x') or (Trimmed[2] = 'X')) then
-  begin
-    try
-      TempValue := StrToInt(Trimmed);
-      Result := TGocciaNumberLiteralValue.Create(TempValue);
-    except
-      Result := TGocciaNumberLiteralValue.NaNValue;
-    end;
-    Exit;
-  end;
-
-  if TryStrToFloat(Trimmed, TempValue, InvariantFormatSettings) then
-    Result := TGocciaNumberLiteralValue.Create(TempValue)
-  else if TryClassifyDecimalNumericString(Trimmed, IsNegativeDecimal, HasNonZeroDigit) then
-  begin
-    if HasNonZeroDigit then
-    begin
-      if IsNegativeDecimal then
-        Result := TGocciaNumberLiteralValue.Create(NegInfinity)
-      else
-        Result := TGocciaNumberLiteralValue.Create(Infinity);
-    end
-    else if IsNegativeDecimal then
-      Result := TGocciaNumberLiteralValue.NegativeZeroValue
-    else
-      Result := TGocciaNumberLiteralValue.ZeroValue;
-  end
-  else
-    Result := TGocciaNumberLiteralValue.NaNValue;
+  // ES2026 §7.1.4.1.1 ToNumber applied to the String type. Delegates to the
+  // shared NumericText.StringToNumber so this runtime coercion path and the
+  // compiler's constant folding (Goccia.Compiler.ConstantValue) cannot drift.
+  // Create stores the raw Double verbatim, preserving NaN, +/-Infinity, and -0.
+  Result := TGocciaNumberLiteralValue.Create(StringToNumber(FValue));
 end;
 
 function TGocciaStringLiteralValue.ToStringLiteral: TGocciaStringLiteralValue;

--- a/tests/language/expressions/string-to-number/string-numeric-literal.js
+++ b/tests/language/expressions/string-to-number/string-numeric-literal.js
@@ -1,0 +1,142 @@
+/*---
+description: StringNumericLiteral conversion agrees across runtime coercion and bytecode constant folding
+features: [type-coercion, unary-plus]
+---*/
+
+// `+"literal"` is constant-folded by the bytecode compiler and evaluated at
+// runtime by the interpreter, so the same assertion guards both paths once the
+// suite runs in --mode=bytecode as well. `dyn` takes its operand as a parameter
+// that cannot be folded, pinning the runtime VM path even in bytecode mode.
+const dyn = (s) => Number(s);
+
+describe('StringNumericLiteral conversion', () => {
+  describe('whitespace and empty input', () => {
+    test('empty string converts to +0', () => {
+      expect(+"").toBe(0);
+      expect(dyn("")).toBe(0);
+    });
+
+    test('whitespace-only string converts to +0', () => {
+      expect(+" \t\n\r ").toBe(0);
+      expect(dyn(" \t\n\r ")).toBe(0);
+    });
+
+    test('leading and trailing whitespace is trimmed', () => {
+      expect(+"  42  ").toBe(42);
+      expect(dyn("\t 42 \n")).toBe(42);
+    });
+  });
+
+  describe('signed Infinity', () => {
+    test('Infinity converts to Infinity', () => {
+      expect(+"Infinity").toBe(Infinity);
+      expect(dyn("Infinity")).toBe(Infinity);
+    });
+
+    test('+Infinity converts to Infinity', () => {
+      expect(+"+Infinity").toBe(Infinity);
+      expect(dyn("+Infinity")).toBe(Infinity);
+    });
+
+    test('-Infinity converts to -Infinity', () => {
+      expect(+"-Infinity").toBe(-Infinity);
+      expect(dyn("-Infinity")).toBe(-Infinity);
+    });
+
+    test('abbreviated Inf is not a numeric literal', () => {
+      expect(Number.isNaN(+"Inf")).toBe(true);
+      expect(Number.isNaN(dyn("Inf"))).toBe(true);
+    });
+  });
+
+  describe('non-decimal integer literals', () => {
+    test('hex prefix converts in either case', () => {
+      expect(+"0xFF").toBe(255);
+      expect(+"0X10").toBe(16);
+      expect(dyn("0xff")).toBe(255);
+    });
+
+    test('binary prefix converts in either case', () => {
+      expect(+"0b101").toBe(5);
+      expect(+"0B11").toBe(3);
+      expect(dyn("0b101")).toBe(5);
+    });
+
+    test('octal prefix converts in either case', () => {
+      expect(+"0o17").toBe(15);
+      expect(+"0O20").toBe(16);
+      expect(dyn("0o17")).toBe(15);
+    });
+
+    test('large hex keeps full magnitude without wrapping', () => {
+      expect(+"0xABCDEF12345").toBe(11806310474565);
+      expect(dyn("0xABCDEF12345")).toBe(11806310474565);
+    });
+
+    test('non-decimal literals reject a leading sign', () => {
+      expect(Number.isNaN(+"+0x10")).toBe(true);
+      expect(Number.isNaN(+"-0x10")).toBe(true);
+      expect(Number.isNaN(dyn("+0b1"))).toBe(true);
+    });
+
+    test('a prefix with no digits is NaN', () => {
+      expect(Number.isNaN(+"0x")).toBe(true);
+      expect(Number.isNaN(+"0b")).toBe(true);
+      expect(Number.isNaN(+"0o")).toBe(true);
+    });
+
+    test('digits out of range for the radix are NaN', () => {
+      expect(Number.isNaN(+"0b12")).toBe(true);
+      expect(Number.isNaN(+"0o18")).toBe(true);
+    });
+  });
+
+  describe('decimal literals', () => {
+    test('integers, fractions, and exponents', () => {
+      expect(+"00123").toBe(123);
+      expect(+".5e3").toBe(500);
+      expect(+"5.").toBe(5);
+      expect(dyn("+.5")).toBe(0.5);
+    });
+
+    test('magnitude overflow becomes signed Infinity', () => {
+      expect(+"1e400").toBe(Infinity);
+      expect(+"-1e400").toBe(-Infinity);
+    });
+  });
+
+  describe('signed zero', () => {
+    test('a negative-zero string preserves -0', () => {
+      expect(Object.is(+"-0", -0)).toBe(true);
+      expect(Object.is(+"-0.00", -0)).toBe(true);
+      expect(Object.is(dyn("-0"), -0)).toBe(true);
+    });
+
+    test('positive and unsigned zero stay +0', () => {
+      expect(Object.is(+"0", 0)).toBe(true);
+      expect(Object.is(+"+0", 0)).toBe(true);
+    });
+  });
+
+  describe('inputs that are not numeric literals', () => {
+    test('letters convert to NaN', () => {
+      expect(Number.isNaN(+"abc")).toBe(true);
+    });
+
+    test('lone punctuation converts to NaN', () => {
+      expect(Number.isNaN(+".")).toBe(true);
+      expect(Number.isNaN(+"+")).toBe(true);
+      expect(Number.isNaN(+"-")).toBe(true);
+    });
+
+    test('numeric separators and grouping convert to NaN', () => {
+      expect(Number.isNaN(+"1_000")).toBe(true);
+      expect(Number.isNaN(+"1,000")).toBe(true);
+    });
+
+    test('trailing garbage converts to NaN', () => {
+      expect(Number.isNaN(+"1.5d")).toBe(true);
+      expect(Number.isNaN(+"0x1p4")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- ECMA-262 `StringToNumber` (§7.1.4.1.1) was implemented twice — runtime coercion in `TGocciaStringLiteralValue.ToNumberLiteral` (`Goccia.Values.Primitives`) and compile-time folding in `StringToCompileTimeNumber` (`Goccia.Compiler.ConstantValue`) — so the interpreter and the bytecode constant optimizer could fold the same string source to different values (the `+Infinity` regression class).
- Centralizes the logic in a new **side-effect-free** `source/shared/NumericText.pas` → `StringToNumber(const AText: string): Double`, used by both paths. It returns a raw `Double`, so the compiler reuses it without instantiating a JS value (per the issue's allocation requirement). Net **−171/+10** across the two units.
- **Scope note / divergence from the original issue text:** the issue is framed as a pure dedup, but its *Expected behavior* lists hex/binary/octal prefixes, signed `Infinity`, invalid→`NaN`, and signed-zero as cases that must agree. Those were latently broken **identically in both paths**, so (confirmed during planning) implementing the `StringNumericLiteral` grammar once makes them correct rather than consistently wrong. Now fixed and verified identical in both execution modes:
  - `+"0b101"`→`5`, `+"0o17"`→`15` (binary/octal were `NaN`)
  - `+"0xABCDEF12345"`→`11806310474565` (was a 32-bit-wrapped `-554622139` via `StrToInt`)
  - `+"Inf"`→`NaN`, `+"."`→`NaN` (were `Infinity`/`0`)
  - `+"+0x10"`/`+"-0x10"`→`NaN` (no sign on non-decimal); whitespace trimming and `-0` preserved
- **Constraints / non-goals:** no bytecode format or opcode change — the ADR 0040 compiler-optimizer design is unchanged; JSON/JSON5/TOML data-format parsers are out of scope.
- New ADR **[0070 — Shared string-to-number conversion](docs/adr/0070-shared-string-to-number.md)** records the centralization and the new-shared-unit home decision.

Closes #787

## Testing

- [x] Verified no regressions and confirmed the bugfix in end-to-end JavaScript/TypeScript tests — full suite **10821/10821** pass in **both** interpreter and `--mode=bytecode`; new `tests/language/expressions/string-to-number/string-numeric-literal.js` exercises the full matrix and asserts both the constant-folded (`+"literal"`) and runtime (`Number(s)`) paths.
- [x] Updated documentation — ADR 0070 added + indexed; no `language.md`/`built-ins.md` change (internal helper + conformance fix, no new public API surface).
- [x] Optional: native Pascal tests — value types (`Primitives`) changed; added co-located `source/shared/NumericText.Test.pas` (7/7, incl. bit-level `-0`/`NaN`/large-hex); full `./build.pas tests` clean-builds green.
- [ ] Optional: benchmarks — not applicable (no hot-path or allocation regression; runtime now allocates a fresh number per string coercion as the decimal path already did).