### PR TITLE
fix(sandbox): reject host symlinks during seed imports

### DIFF
--- a/docs/adr/0070-reject-symlinks-in-sandbox-seed-imports.md
+++ b/docs/adr/0070-reject-symlinks-in-sandbox-seed-imports.md
@@ -1,0 +1,37 @@
+# 0070 - Reject symlinks in sandbox seed imports
+
+## Status
+
+Accepted.
+
+## Context
+
+ADR 0068 established that `GocciaSandboxRunner` seeds are import baselines, not mounts: `--seed` and `--seed-config` `from` paths copy host data into the virtual filesystem before execution, and the host path never becomes a live mount. The `TSandboxVirtualFileSystem` itself deliberately does not support symlinks (see its unit header), so the sandbox namespace has no way to address the host.
+
+The seed importer undermined that boundary. It read host files through `TFileStream`, which dereferences symlinks. A symlink encountered during import — the literal path passed to `--seed`, or any descendant inside a seeded directory — therefore copied the bytes of its *target* into the sandbox VFS. Because a symlink target can point anywhere on the host, a seed could pull data from outside the seed root into the sandbox without that ever being visible at the import site. This contradicts the sandbox-first, reduced-attack-surface posture in `VISION.md`, where the sandbox is meant to have no ambient host filesystem access.
+
+There is a genuine trade-off. The alternative is to give the VFS first-class symlink nodes plus path-resolution semantics, so a seeded symlink is preserved as a symlink rather than dereferenced. That is a larger surface — link nodes, resolution, loop detection, and a re-examination of the chroot-jail invariant — and it widens rather than reduces what the sandbox can express. The seed import contract from ADR 0068 only promises a baseline copy, so dereferencing was never a guaranteed behavior to preserve.
+
+## Decision
+
+Reject host symlinks during `--seed` and `--seed-config` host imports: the seed path's own leaf (the final component the host named) and every descendant discovered while walking a seeded directory. A cross-platform check (`HostPathIsSymlink` in the shared `FileUtils` unit; POSIX `lstat` + `S_ISLNK`, Windows reparse points / junctions via `faSymLink`) inspects each host node before it is read. The seed path's trailing separator is stripped before the check, because POSIX `lstat` follows a final symlink when the path ends in `/` — otherwise `--seed=linkdir` would be rejected while `--seed=linkdir/` was dereferenced.
+
+When a symlink is found, the import fails closed: the run aborts with exit code 1 and emits the error, naming the offending path:
+
+```text
+Seed path is a symlink (not supported): <path>
+```
+
+No VFS symlink node is added, and no bytes are copied. Symlink preservation — giving the VFS first-class symlink nodes with their own resolution semantics — is intentionally out of scope for this decision.
+
+Two cases are deliberately not covered. Symlinks that appear as **ancestor** directory components of a host-supplied seed path (for example `--seed=/a/linkdir/file`, where `linkdir` is a symlink above the named leaf) are not rejected: an ancestor is the host's explicit choice of where the seed lives, indistinguishable from benign system symlinks such as macOS `/var` → `/private/var` or `/tmp` → `/private/tmp`, so rejecting it would refuse ordinary temp paths. The threat this decision addresses is a symlink **at or inside** the requested seed root, not the location the host points at. Full real-path containment (canonicalizing the resolved path and confirming it stays within an intended root) is a larger, separate policy and is also out of scope.
+
+## Consequences
+
+A previously-working seed that relied on a symlink being dereferenced now errors instead of silently copying the link target. This is user-visible and intentional: the failure names the path so the cause is obvious, and the fix is to seed the real file or directory directly.
+
+On Windows, junctions and other reparse points are treated as symlinks and rejected on the same path.
+
+The guard lives in the shared `FileUtils` unit, so host-path symlink detection is a single cross-platform implementation reused by the runner rather than per-call-site logic.
+
+In-VFS operations and nested `runScript` semantics are unchanged. Nested child seeds copy from the parent virtual filesystem rather than the host (ADR 0069), so they never re-enter the host import path and are unaffected by this guard.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,3 +79,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0067 — Cross-realm shape dictionary mode](0067-cross-realm-shape-dictionary-mode.md)
 - [0068 — GocciaSandboxRunner with explicit seed baselines](0068-goccia-sandbox-runner.md)
 - [0069 — Nested sandbox virtual filesystems](0069-nested-sandbox-virtual-filesystems.md)
+- [0070 — Reject symlinks in sandbox seed imports](0070-reject-symlinks-in-sandbox-seed-imports.md)

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -427,6 +427,8 @@ GocciaSandboxRunner executes a sandbox entry path after populating an isolated v
 
 `--seed=<host>[=<sandbox>]` resolves the host path relative to the invocation current working directory. When the sandbox target is omitted, directories import their contents to `/` and files import as `/<filename>`.
 
+Host seed imports reject symlinks. A symlink in a `--seed` path or anywhere inside a `--seed-config` `from` directory aborts the run with exit code 1 and `Seed path is a symlink (not supported): <path>`, so seeding never dereferences host data from outside the seed root into the sandbox.
+
 `--seed-config=<file.json>` resolves each `from` path relative to the seed config file. The JSON shape is:
 
 ```json

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -18,6 +18,7 @@ import {
   existsSync,
   mkdirSync,
   chmodSync,
+  symlinkSync,
 } from "fs";
 import { join, resolve } from "path";
 import {
@@ -2732,6 +2733,143 @@ console.log("SandboxRunner: seed config imports host paths relative to the confi
       throw new Error(`SandboxRunner host seed stdout should include file copied under existing target directory, got: ${stdout}`);
     if (!containsLine(`\n${stdout}`, "3"))
       throw new Error(`SandboxRunner host seed stdout should include base64 byte length, got: ${stdout}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("SandboxRunner: seed directory rejects nested host symlink (no leak)...");
+{
+  const tmp = makeTmp();
+  try {
+    if (process.platform !== "win32") {
+      const seedDir = join(tmp, "seedDir");
+      mkdirSync(seedDir, { recursive: true });
+      writeFileSync(join(tmp, "outside.txt"), "outside-secret");
+      symlinkSync("../outside.txt", join(seedDir, "leak.txt"));
+      const mainJs = join(tmp, "main.js");
+      writeFileSync(mainJs, [
+        'import fs from "fs";',
+        'console.log(fs.readFileSync("/leak.txt", "utf8"));',
+      ].join("\n"));
+
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed=${seedDir}=/`, `--seed=${mainJs}=/`, "--source-type=module"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const output = proc.stdout.toString() + proc.stderr.toString();
+      if (proc.exitCode === 0)
+        throw new Error(`SandboxRunner nested symlink seed should fail, exited 0: ${output}`);
+      if (!output.includes("is a symlink (not supported)"))
+        throw new Error(`SandboxRunner nested symlink seed should report the symlink rejection, got: ${output}`);
+      if (output.includes("outside-secret"))
+        throw new Error(`SandboxRunner nested symlink seed leaked host contents, got: ${output}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("SandboxRunner: direct seed argument rejects host symlink (no leak)...");
+{
+  const tmp = makeTmp();
+  try {
+    if (process.platform !== "win32") {
+      writeFileSync(join(tmp, "outside.txt"), "outside-secret");
+      const link = join(tmp, "link.txt");
+      symlinkSync("outside.txt", link);
+      const mainJs = join(tmp, "main.js");
+      writeFileSync(mainJs, [
+        'import fs from "fs";',
+        'console.log(fs.readFileSync("/leak.txt", "utf8"));',
+      ].join("\n"));
+
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed=${link}=/leak.txt`, `--seed=${mainJs}=/`, "--source-type=module"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const output = proc.stdout.toString() + proc.stderr.toString();
+      if (proc.exitCode === 0)
+        throw new Error(`SandboxRunner direct symlink seed should fail, exited 0: ${output}`);
+      if (!output.includes("is a symlink (not supported)"))
+        throw new Error(`SandboxRunner direct symlink seed should report the symlink rejection, got: ${output}`);
+      if (output.includes("outside-secret"))
+        throw new Error(`SandboxRunner direct symlink seed leaked host contents, got: ${output}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("SandboxRunner: seed-config from directory rejects nested host symlink (no leak)...");
+{
+  const tmp = makeTmp();
+  try {
+    if (process.platform !== "win32") {
+      const seedDir = join(tmp, "seedDir");
+      mkdirSync(seedDir, { recursive: true });
+      writeFileSync(join(tmp, "outside.txt"), "outside-secret");
+      symlinkSync("../outside.txt", join(seedDir, "leak.txt"));
+      const seed = join(tmp, "seed.json");
+      writeFileSync(seed, JSON.stringify({
+        files: [
+          { from: "./seedDir", to: "/" },
+          {
+            path: "/main.js",
+            text: [
+              'import fs from "fs";',
+              'console.log(fs.readFileSync("/leak.txt", "utf8"));',
+            ].join("\n"),
+          },
+        ],
+      }));
+
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed-config=${seed}`, "--source-type=module"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const output = proc.stdout.toString() + proc.stderr.toString();
+      if (proc.exitCode === 0)
+        throw new Error(`SandboxRunner seed-config symlink should fail, exited 0: ${output}`);
+      if (!output.includes("is a symlink (not supported)"))
+        throw new Error(`SandboxRunner seed-config symlink should report the symlink rejection, got: ${output}`);
+      if (output.includes("outside-secret"))
+        throw new Error(`SandboxRunner seed-config symlink leaked host contents, got: ${output}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("SandboxRunner: trailing slash on a symlinked-directory seed is still rejected (no leak)...");
+{
+  const tmp = makeTmp();
+  try {
+    if (process.platform !== "win32") {
+      const outsideDir = join(tmp, "outsideDir");
+      mkdirSync(outsideDir, { recursive: true });
+      writeFileSync(join(outsideDir, "secret.txt"), "outside-secret");
+      const linkDir = join(tmp, "linkDir");
+      symlinkSync("./outsideDir", linkDir);
+      const mainJs = join(tmp, "main.js");
+      writeFileSync(mainJs, [
+        'import fs from "fs";',
+        'console.log(fs.readFileSync("/secret.txt", "utf8"));',
+      ].join("\n"));
+
+      // A trailing slash must not let POSIX lstat() follow the symlinked leaf.
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed=${linkDir}/=/`, `--seed=${mainJs}=/`, "--source-type=module"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const output = proc.stdout.toString() + proc.stderr.toString();
+      if (proc.exitCode === 0)
+        throw new Error(`SandboxRunner trailing-slash symlink seed should fail, exited 0: ${output}`);
+      if (!output.includes("is a symlink (not supported)"))
+        throw new Error(`SandboxRunner trailing-slash symlink seed should report the symlink rejection, got: ${output}`);
+      if (output.includes("outside-secret"))
+        throw new Error(`SandboxRunner trailing-slash symlink seed leaked host contents, got: ${output}`);
+    }
   } finally {
     clean(tmp);
   }

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2875,6 +2875,43 @@ console.log("SandboxRunner: trailing slash on a symlinked-directory seed is stil
   }
 }
 
+console.log("SandboxRunner: Windows directory junction seed is rejected (no leak)...");
+{
+  const tmp = makeTmp();
+  try {
+    // Windows-only: file symlinks need elevation on CI runners, but a directory
+    // junction is a reparse point that needs none, so it exercises the Windows
+    // branch of the guard (FileGetAttr + faSymLink) that the win32-skipped tests
+    // above cannot.
+    if (process.platform === "win32") {
+      const outsideDir = join(tmp, "outsideDir");
+      mkdirSync(outsideDir, { recursive: true });
+      writeFileSync(join(outsideDir, "secret.txt"), "outside-secret");
+      const junction = join(tmp, "junction");
+      symlinkSync(outsideDir, junction, "junction");
+      const mainJs = join(tmp, "main.js");
+      writeFileSync(mainJs, [
+        'import fs from "fs";',
+        'console.log(fs.readFileSync("/secret.txt", "utf8"));',
+      ].join("\n"));
+
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed=${junction}=/`, `--seed=${mainJs}=/`, "--source-type=module"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const output = proc.stdout.toString() + proc.stderr.toString();
+      if (proc.exitCode === 0)
+        throw new Error(`SandboxRunner junction seed should fail, exited 0: ${output}`);
+      if (!output.includes("is a symlink (not supported)"))
+        throw new Error(`SandboxRunner junction seed should report the symlink rejection, got: ${output}`);
+      if (output.includes("outside-secret"))
+        throw new Error(`SandboxRunner junction seed leaked host contents, got: ${output}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
 // ============================================================================
 // --allowed-host option
 // ============================================================================

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -331,6 +331,8 @@ begin
       if (SearchRec.Name = '.') or (SearchRec.Name = '..') then
         Continue;
       HostChild := IncludeTrailingPathDelimiter(AHostDirectory) + SearchRec.Name;
+      if HostPathIsSymlink(HostChild) then
+        raise Exception.Create('Seed path is a symlink (not supported): ' + HostChild);
       SandboxChild := SandboxJoinPath(SandboxDirectory, SearchRec.Name);
       if (SearchRec.Attr and faDirectory) <> 0 then
         ImportDirectoryContents(HostChild, SandboxChild)
@@ -348,7 +350,13 @@ var
   HostPath: string;
   TargetPath: string;
 begin
-  HostPath := ExpandFileName(AHostPath);
+  // Strip any trailing separator before the symlink check: POSIX lstat()
+  // follows a final symlink when the path ends in '/', so without this a
+  // symlinked seed leaf would be rejected as `linkdir` but dereferenced as
+  // `linkdir/`. Downstream directory/file imports are delimiter-agnostic.
+  HostPath := ExcludeTrailingPathDelimiter(ExpandFileName(AHostPath));
+  if HostPathIsSymlink(HostPath) then
+    raise Exception.Create('Seed path is a symlink (not supported): ' + HostPath);
   if not FileExists(HostPath) and not DirectoryExists(HostPath) then
     raise Exception.Create('Seed path does not exist: ' + HostPath);
 

--- a/source/shared/FileUtils.pas
+++ b/source/shared/FileUtils.pas
@@ -5,6 +5,7 @@ unit FileUtils;
 interface
 
 uses
+  {$IFDEF UNIX}BaseUnix,{$ENDIF}
   Classes,
   SysUtils;
 
@@ -13,6 +14,10 @@ function FindAllFiles(const ADirectory: string; const AFileExtensions: array of 
 function ExpandUTF8FileName(const APath: string): string;
 function UTF8DirectoryExists(const APath: string): Boolean;
 function UTF8FileExists(const APath: string): Boolean;
+
+{ True when APath itself is a symbolic link (UNIX) or a reparse
+  point / junction (Windows). Does not follow the link. }
+function HostPathIsSymlink(const APath: string): Boolean;
 
 { Read an entire file as raw bytes and tag the result as UTF-8.
   No BOM stripping or newline normalization is performed. }
@@ -53,6 +58,22 @@ function UTF8FileExists(const APath: string): Boolean;
 begin
   Result := FileExists(UTF8PathToUnicodeString(APath));
 end;
+
+function HostPathIsSymlink(const APath: string): Boolean;
+{$IFDEF UNIX}
+var
+  Info: Stat;
+begin
+  Result := (fpLStat(APath, Info) = 0) and fpS_ISLNK(Info.st_mode);
+end;
+{$ELSE}
+var
+  Attr: LongInt;
+begin
+  Attr := FileGetAttr(APath);
+  Result := (Attr <> -1) and ((Attr and faSymLink) <> 0);
+end;
+{$ENDIF}
 
 function MatchesExtension(const AName: string; const AExtensions: array of string): Boolean;
 var


### PR DESCRIPTION
## Summary

- `GocciaSandboxRunner` host seed imports (`--seed` and `--seed-config` `from`) read files through `TFileStream`, which dereferences symlinks. A symlink inside a seeded directory — or named directly as a seed — copied bytes from **outside** the requested seed root into the sandbox VFS, contrary to the sandbox-first, reduced-attack-surface posture in `VISION.md`. The VFS itself deliberately does not support symlinks.
- Adds a cross-platform `HostPathIsSymlink` helper to the shared `FileUtils` unit (POSIX `lstat` + `S_ISLNK`; Windows reparse points / junctions via `faSymLink`) and rejects host symlinks at two seams in `GocciaSandboxRunner.dpr`: the seed **leaf** (`SeedHostPath`) and every **descendant** of a seeded directory (`ImportDirectoryContents`). On encounter it **fails closed** — aborts with exit code 1 and an error naming the path: `Seed path is a symlink (not supported): <path>`.
- A trailing separator is stripped before the check, because POSIX `lstat` follows a final symlink when the path ends in `/` (so `--seed=linkdir/` is rejected just like `--seed=linkdir`). This bypass was caught by the pre-handoff `/code-review` pass and is covered by a dedicated regression test.
- **Non-goals (documented in ADR 0071):** preserving symlinks as first-class VFS nodes; rejecting symlinks that appear as **ancestor** components of a host-supplied seed path (indistinguishable from benign system symlinks such as macOS `/var` → `/private/var`, so rejecting them would refuse ordinary temp paths); and full real-path containment.
- **Windows:** the guard uses `FileGetAttr` + `faSymLink` (reparse points / junctions). File-symlink tests need elevation on `windows-latest`, so they are POSIX-guarded; a separate `win32`-only test seeds a **directory junction** (a reparse point that needs no elevation) and asserts the same rejection, so the Windows branch is exercised by the `cli` CI job on `windows-latest`. macOS validated empirically; Linux uses the same POSIX path.

Closes #786

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Details:

- `./build.pas sandboxrunner` + reproduced all four leak vectors → each rejects with exit 1, names the path, and leaks nothing: nested symlink in a seeded dir, direct symlink as `--seed`, `--seed-config` `from` dir with a symlink, and a trailing slash on a symlinked dir. The positive case (normal dir/file seed, including a trailing slash) still imports.
- `bun run scripts/test-cli-apps.ts` — all pass, including 5 new `GocciaSandboxRunner` symlink/junction regressions (4 POSIX-guarded + 1 `win32`-only junction; 13 SandboxRunner cases total; existing seed tests unchanged).
- DoD JS suite gate green after merging `origin/main`: `GocciaTestRunner tests` and `--mode=bytecode` both 10,821 passing (100%, no failed tests).
- `./format.pas --check` clean; pre-commit hooks (markdownlint, doc links/symbols, format) green.

### Reviewer notes

- Merged `origin/main`. This ADR was renumbered **0070 → 0071** because #792 landed `0070-shared-string-to-number.md` first; the `docs/adr/README.md` index and the ADR heading were updated to match.
- The CI test262 lane briefly showed 2 `ZonedDateTime/hoursInDay` DST deltas before the merge; these were baseline drift from #792's string-to-number engine change (which the pre-merge branch lacked) and are causally unrelated to this diff (no Temporal/Intl unit imports `FileUtils`; the change touches zero engine code). The merge brings #792 in.

No `tests/*.js` was added: this is a CLI host-app security guard with no JS-language API surface, so `docs/testing.md` routes coverage to `scripts/test-cli-apps.ts` alongside the existing sandbox seed tests.
