### PR TITLE
fix(engine): eliminate test262 timeouts (tail calls, recursion bound, perf)

### DIFF
--- a/build.pas
+++ b/build.pas
@@ -249,18 +249,14 @@ begin
 
     if BuildMode = bmProd then
     begin
-      // -O3 with FASTMATH explicitly disabled. FPC's -O4 turns on the
-      // FASTMATH optimization, which reassociates and contracts floating-point
-      // operations and assumes no NaN/Inf — violating the strict IEEE-754
-      // double semantics that JavaScript mandates. That produced wrong results
-      // in the edge-case Temporal ZonedDateTime hoursInDay paths (sub-hour and
-      // discontiguous DST) in optimized builds only: correct at -O- and -O3,
-      // wrong as soon as FASTMATH is on (isolated via `-O3 -OoFASTMATH`, which
-      // reproduces, vs `-O3 -OoORDERFIELDS`, which does not). -O3 already
-      // excludes FASTMATH; -OoNOFASTMATH states the requirement explicitly and
-      // keeps it disabled even if the optimization level is raised later.
-      Args.Add('-O3');
-      Args.Add('-OoNOFASTMATH');
+      // -O4 for aggressive optimization. The one -O4 optimization that is
+      // unsafe for this engine, FASTMATH, is force-disabled at the source level
+      // in Shared.inc ({$OPTIMIZATION NOFASTMATH}) because it violates the
+      // IEEE-754 double semantics JavaScript requires (it miscompiled the
+      // edge-case Temporal hoursInDay DST math — PR #797). Keeping the guard in
+      // source rather than here makes it a compiler-enforced invariant that
+      // travels with the code regardless of how fpc is invoked.
+      Args.Add('-O4');
       Args.Add('-dPRODUCTION');
       Args.Add('-Xs');
       Args.Add('-CX');

--- a/build.pas
+++ b/build.pas
@@ -249,7 +249,12 @@ begin
 
     if BuildMode = bmProd then
     begin
-      Args.Add('-O4');
+      // -O3, not -O4: FPC's -O4 enables "uncertain" optimizations that
+      // assume away aliasing and miscompile some engine paths in optimized
+      // builds only (observed as wrong results in edge-case Temporal
+      // ZonedDateTime hoursInDay under sub-hour/discontiguous DST, passing
+      // at -O- and -O3 but failing at -O4). -O3 is the highest safe level.
+      Args.Add('-O3');
       Args.Add('-dPRODUCTION');
       Args.Add('-Xs');
       Args.Add('-CX');

--- a/build.pas
+++ b/build.pas
@@ -249,12 +249,18 @@ begin
 
     if BuildMode = bmProd then
     begin
-      // -O3, not -O4: FPC's -O4 enables "uncertain" optimizations that
-      // assume away aliasing and miscompile some engine paths in optimized
-      // builds only (observed as wrong results in edge-case Temporal
-      // ZonedDateTime hoursInDay under sub-hour/discontiguous DST, passing
-      // at -O- and -O3 but failing at -O4). -O3 is the highest safe level.
+      // -O3 with FASTMATH explicitly disabled. FPC's -O4 turns on the
+      // FASTMATH optimization, which reassociates and contracts floating-point
+      // operations and assumes no NaN/Inf — violating the strict IEEE-754
+      // double semantics that JavaScript mandates. That produced wrong results
+      // in the edge-case Temporal ZonedDateTime hoursInDay paths (sub-hour and
+      // discontiguous DST) in optimized builds only: correct at -O- and -O3,
+      // wrong as soon as FASTMATH is on (isolated via `-O3 -OoFASTMATH`, which
+      // reproduces, vs `-O3 -OoORDERFIELDS`, which does not). -O3 already
+      // excludes FASTMATH; -OoNOFASTMATH states the requirement explicitly and
+      // keeps it disabled even if the optimization level is raised later.
       Args.Add('-O3');
+      Args.Add('-OoNOFASTMATH');
       Args.Add('-dPRODUCTION');
       Args.Add('-Xs');
       Args.Add('-CX');

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -853,6 +853,8 @@ Raises `TGocciaInstructionLimitError` when the limit is reached. A value of zero
 
 In bytecode mode the VM uses a trampoline: bytecode-to-bytecode calls are dispatched iteratively via an explicit frame stack, so the Pascal call stack stays flat regardless of JS call depth. The interpreter mode uses Pascal recursion and relies on the depth check to prevent overflow.
 
+Native re-entries into the bytecode VM — generator resume, host `eval`, and native callbacks such as Array iteration methods or sort comparators — run the bytecode loop on a fresh Pascal stack frame instead of the trampoline. These are bounded separately by a fixed native re-entry cap (`MAX_NATIVE_REENTRY_DEPTH` in `Goccia.StackLimit`), which throws the same `RangeError` well before the native stack can overflow. This is independent of `SetMaxStackDepth`/`--stack-size`, which bounds the much cheaper trampolined frames; it ensures that, for example, infinite recursion mediated by a generator throws rather than crashing the engine.
+
 ```pascal
 uses
   Goccia.StackLimit;

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -531,6 +531,75 @@ console.log("Bare Loader: print global...");
   if (proc.stdout.toString().trim() !== "hello 7") throw new Error(`Bare print expected hello 7, got: ${proc.stdout.toString()}`);
 }
 
+console.log("Bare Loader: --stack-size bounds deep non-tail recursion with RangeError...");
+{
+  const src =
+    "const f = (n) => (n === 0 ? 0 : 1 + f(n - 1)); try { f(100000); print('NO THROW'); } catch (e) { print(e.constructor.name); }\n";
+  const proc = Bun.spawnSync([BARE, "--mode=bytecode", "--stack-size=1000"], {
+    stdin: new TextEncoder().encode(src),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) throw new Error(`Bare --stack-size exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+  if (proc.stdout.toString().trim() !== "RangeError")
+    throw new Error(`Bare --stack-size expected RangeError, got: ${proc.stdout.toString()}`);
+}
+
+console.log("Bare Loader: proper tail calls reuse the frame (deep strict tail recursion completes)...");
+{
+  // Without proper tail calls this 100k-deep recursion would exceed --stack-size;
+  // a tail call in strict-mode code reuses the current frame, so it runs in O(1)
+  // stack and completes well under the 1000-frame limit.
+  const src =
+    "const f = (n) => { 'use strict'; return n === 0 ? 'done' : f(n - 1); }; print(f(100000));\n";
+  const proc = Bun.spawnSync([BARE, "--mode=bytecode", "--stack-size=1000"], {
+    stdin: new TextEncoder().encode(src),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) throw new Error(`Bare tail-call exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+  if (proc.stdout.toString().trim() !== "done")
+    throw new Error(`Bare tail-call expected 'done', got: ${proc.stdout.toString()} / ${proc.stderr.toString()}`);
+}
+
+console.log("Bare Loader: tail-call optimization stays strict-mode only...");
+{
+  // The same tail recursion in sloppy-mode code is NOT a proper tail call, so it
+  // is bounded by --stack-size and throws RangeError.
+  const src =
+    "const f = (n) => (n === 0 ? 'done' : f(n - 1)); try { print(f(100000)); } catch (e) { print(e.constructor.name); }\n";
+  const proc = Bun.spawnSync([BARE, "--mode=bytecode", "--stack-size=1000"], {
+    stdin: new TextEncoder().encode(src),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) throw new Error(`Bare sloppy tail-call exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+  if (proc.stdout.toString().trim() !== "RangeError")
+    throw new Error(`Bare sloppy tail-call expected RangeError, got: ${proc.stdout.toString()}`);
+}
+
+console.log("Bare Loader: native re-entry recursion throws RangeError instead of crashing...");
+{
+  // Recursion through a native callback (Array.prototype.forEach) and through a
+  // generator resume re-enters the VM on a native stack frame. Both must be
+  // bounded (RangeError), not overflow the native stack (SIGSEGV / non-zero
+  // signal exit).
+  const cases = [
+    "let d = 0; const rec = () => { d++; [0].forEach(rec); }; try { rec(); print('NO THROW'); } catch (e) { print(e.constructor.name); }\n",
+    "let d = 0; function* g() { d++; for (const x of g()) {} yield 1; } try { for (const x of g()) {} print('NO THROW'); } catch (e) { print(e.constructor.name); }\n",
+  ];
+  for (const src of cases) {
+    const proc = Bun.spawnSync(
+      [BARE, "--mode=bytecode", "--compat-function", "--compat-traditional-for-loop"],
+      { stdin: new TextEncoder().encode(src), stdout: "pipe", stderr: "pipe" },
+    );
+    if (proc.exitCode !== 0)
+      throw new Error(`Bare native re-entry exited ${proc.exitCode} (signal ${proc.signalCode}): ${proc.stderr.toString()}`);
+    if (proc.stdout.toString().trim() !== "RangeError")
+      throw new Error(`Bare native re-entry expected RangeError, got: ${proc.stdout.toString()}`);
+  }
+}
+
 console.log("Bare Loader: no runtime globals...");
 {
   const source = [

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -38,6 +38,7 @@ uses
   Goccia.Scope.Redeclaration,
   Goccia.ScriptLoader.Input,
   Goccia.SourcePipeline,
+  Goccia.StackLimit,
   Goccia.Terminal.Colors,
   Goccia.TextFiles,
   Goccia.Threading,
@@ -76,6 +77,7 @@ type
     TimeoutMs: Integer;
     MaxMemoryBytes: Int64;
     MaxInstructions: Int64;
+    StackSize: Integer;
     ProfileModePresent: Boolean;
     ProfileMode: Goccia.CLI.Options.TGocciaProfileMode;
     ProfileOutputPath: string;
@@ -187,6 +189,12 @@ type
 
 const
   BARE_PRINT_GLOBAL_NAME = 'print';
+  // Finite default call-stack depth for the bare loader.  Without a bound,
+  // genuinely unbounded recursion runs until OOM or the (optional) instruction
+  // limit instead of throwing RangeError like a conforming engine.  Proper
+  // tail calls reuse their frame, so this limit only fences off deep *non-tail*
+  // recursion; the value is generous to avoid clipping legitimate recursion.
+  BARE_DEFAULT_MAX_STACK_DEPTH = 10000;
 
 procedure ConfigureEngine(const AEngine: TGocciaEngine;
   const AExecutor: TGocciaExecutor; const AOptions: TBareOptions); forward;
@@ -1171,6 +1179,7 @@ begin
   WriteLn('  --timeout=MS                  Per-file cooperative timeout in milliseconds');
   WriteLn('  --max-memory=BYTES            GC heap byte limit (RangeError on exceed)');
   WriteLn('  --max-instructions=N          Maximum bytecode steps before aborting');
+  WriteLn('  --stack-size=N                Maximum call stack depth (0 = no limit)');
   WriteLn('  --profile=opcodes|functions|all');
   WriteLn('                                Enable bytecode VM profiling (forces bytecode mode)');
   WriteLn('  --profile-output=PATH         Write profiler JSON to PATH');
@@ -1230,6 +1239,17 @@ begin
   if Parsed < 0 then
     raise Exception.Create('--max-instructions must be 0 or greater');
   AOptions.MaxInstructions := Parsed;
+end;
+
+procedure ParseStackSize(const AValue: string; var AOptions: TBareOptions);
+var
+  Parsed: Integer;
+begin
+  if not TryStrToInt(AValue, Parsed) then
+    raise Exception.Create('Invalid --stack-size value: ' + AValue);
+  if Parsed < 0 then
+    raise Exception.Create('--stack-size must be 0 or greater');
+  AOptions.StackSize := Parsed;
 end;
 
 procedure ParseProfileMode(const AValue: string; var AOptions: TBareOptions);
@@ -1294,6 +1314,7 @@ begin
   Result.TimeoutMs := 0;
   Result.MaxMemoryBytes := 0;
   Result.MaxInstructions := 0;
+  Result.StackSize := BARE_DEFAULT_MAX_STACK_DEPTH;
   Result.ProfileModePresent := False;
   Result.ProfileMode := Goccia.CLI.Options.pmAll;
   Result.ProfileOutputPath := '';
@@ -1331,6 +1352,8 @@ begin
     else if Copy(Arg, 1, Length('--max-instructions=')) = '--max-instructions=' then
       ParseMaxInstructions(Copy(Arg, Length('--max-instructions=') + 1, MaxInt),
         Result)
+    else if Copy(Arg, 1, Length('--stack-size=')) = '--stack-size=' then
+      ParseStackSize(Copy(Arg, Length('--stack-size=') + 1, MaxInt), Result)
     else if Copy(Arg, 1, Length('--profile=')) = '--profile=' then
       ParseProfileMode(Copy(Arg, Length('--profile=') + 1, MaxInt), Result)
     else if Copy(Arg, 1, Length('--profile-output=')) = '--profile-output=' then
@@ -1456,6 +1479,7 @@ begin
       and would otherwise overwrite any pre-engine value. }
     StartExecutionTimeout(AOptions.TimeoutMs);
     StartInstructionLimit(AOptions.MaxInstructions);
+    SetMaxStackDepth(AOptions.StackSize);
 
     PrintHost := TBarePrintHost.Create;
     try

--- a/source/shared/Shared.inc
+++ b/source/shared/Shared.inc
@@ -2,6 +2,13 @@
 {$M+}
 {$IFDEF PRODUCTION}
   {$optimization autoInline}
+  { Never enable FASTMATH. It reassociates and contracts floating-point
+    operations and assumes no NaN/Inf, violating the strict IEEE-754 double
+    semantics JavaScript requires. -O4 (used for production builds) would
+    otherwise turn it on and miscompile float-sensitive paths — e.g. the
+    edge-case Temporal ZonedDateTime.hoursInDay DST math (PR #797). This
+    source-level guard keeps it off regardless of the optimization level. }
+  {$OPTIMIZATION NOFASTMATH}
   {$overflowchecks off}
   {$rangechecks off}
   {$S-}

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -166,6 +166,10 @@ const
   CALL_FLAG_SPREAD = 1;
   CALL_FLAG_TRUSTED = 2;
   CALL_FLAG_DIRECT_EVAL = 4;
+  // ES2026 §15.10 Tail Position Calls: the call sits in tail position of its
+  // enclosing function, so the VM reuses the current call frame instead of
+  // pushing a new one (PrepareForTailCall).
+  CALL_FLAG_TAIL = 8;
 
   // Sentinel for the C operand of OP_VALIDATE_VALUE / VALIDATE_OP_REQUIRE_ITERABLE.
   //   0..254 = exact element count to consume (0 = empty pattern, drain

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -33,7 +33,8 @@ procedure CompilePropertyAssignment(const ACtx: TGocciaCompilationContext;
 procedure CompileArrowFunction(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaArrowFunctionExpression; const ADest: UInt8);
 procedure CompileCall(const ACtx: TGocciaCompilationContext;
-  const AExpr: TGocciaCallExpression; const ADest: UInt8);
+  const AExpr: TGocciaCallExpression; const ADest: UInt8;
+  const ATail: Boolean = False);
 procedure CompileMember(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaMemberExpression; const ADest: UInt8);
 procedure CompileConditional(const ACtx: TGocciaCompilationContext;
@@ -49,7 +50,18 @@ procedure CompileRegexLiteral(const ACtx: TGocciaCompilationContext;
 procedure CompileTemplateWithInterpolation(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaTemplateWithInterpolationExpression; const ADest: UInt8);
 procedure CompileTaggedTemplate(const ACtx: TGocciaCompilationContext;
-  const AExpr: TGocciaTaggedTemplateExpression; const ADest: UInt8);
+  const AExpr: TGocciaTaggedTemplateExpression; const ADest: UInt8;
+  const ATail: Boolean = False);
+// Compiles AExpr into ADest, marking any call that the static semantics place
+// in tail position (ES2026 §15.10.2 HasCallInTailPosition) with CALL_FLAG_TAIL
+// so the VM can reuse the current call frame.  The marked call is still emitted
+// as an ordinary call producing a value in ADest; the caller emits OP_RETURN as
+// usual.  When the VM honors the tail flag it returns directly and that trailing
+// store/return is simply never reached.  Descends only through the
+// tail-position-preserving forms (conditional, &&/||/??, comma); every other
+// form just compiles normally.
+procedure CompileReturnValueTailAware(const ACtx: TGocciaCompilationContext;
+  const AExpr: TGocciaExpression; const ADest: UInt8);
 procedure CompileNewExpression(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaNewExpression; const ADest: UInt8);
 procedure CompileComputedPropertyAssignment(const ACtx: TGocciaCompilationContext;
@@ -3497,7 +3509,8 @@ end;
 function TryCompileWithIdentifierCall(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaCallExpression; const ADest: UInt8;
   const AArgCount: Integer; const AUseSpread: Boolean;
-  var AJumps: TGocciaCompilerJumpArray; var AJumpCount: Integer): Boolean;
+  var AJumps: TGocciaCompilerJumpArray; var AJumpCount: Integer;
+  const ATail: Boolean = False): Boolean;
 var
   Ident: TGocciaIdentifierExpression;
   ObjReg, BaseReg, ArgsReg, KeyReg, CondReg: UInt8;
@@ -3505,11 +3518,17 @@ var
   I, EndCount: Integer;
   MissJump: Integer;
   EndJumps: array of Integer;
+  TailFlag: UInt8;
 
   procedure EmitBranchCall(const AIsMethodCall, AJumpAfter: Boolean);
   var
     ArgIndex: Integer;
   begin
+    // An optional call is not in tail position (the nullish guard runs after).
+    if ATail and not AExpr.Optional then
+      TailFlag := CALL_FLAG_TAIL
+    else
+      TailFlag := 0;
     if AExpr.Optional then
       AddOptionalChainJump(ACtx, AJumps, AJumpCount, BaseReg);
 
@@ -3518,10 +3537,11 @@ var
       ArgsReg := ACtx.Scope.AllocateRegister;
       CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
       if AIsMethodCall then
-        EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg, 1))
+        EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg,
+          CALL_FLAG_SPREAD or TailFlag))
       else
         EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, ArgsReg,
-          SpreadCallFlags(ACtx, AExpr, CurrentCodePosition(ACtx))));
+          SpreadCallFlags(ACtx, AExpr, CurrentCodePosition(ACtx)) or TailFlag));
       ACtx.Scope.FreeRegister;
     end
     else
@@ -3531,10 +3551,10 @@ var
           ACtx.Scope.AllocateRegister);
       if AIsMethodCall then
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg,
-          UInt8(AArgCount), 0))
+          UInt8(AArgCount), TailFlag))
       else
         EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, UInt8(AArgCount),
-        CallFlags(ACtx, AExpr, CurrentCodePosition(ACtx))));
+        CallFlags(ACtx, AExpr, CurrentCodePosition(ACtx)) or TailFlag));
       for ArgIndex := 0 to AArgCount - 1 do
         ACtx.Scope.FreeRegister;
     end;
@@ -3887,7 +3907,8 @@ begin
 end;
 
 procedure CompileCall(const ACtx: TGocciaCompilationContext;
-  const AExpr: TGocciaCallExpression; const ADest: UInt8);
+  const AExpr: TGocciaCallExpression; const ADest: UInt8;
+  const ATail: Boolean = False);
 var
   ArgCount, I: Integer;
   BaseReg, ObjReg, ArgsReg, SuperReg, KeyReg: UInt8;
@@ -3901,6 +3922,7 @@ var
   NilJump, CallNilJump, EndJump: Integer;
   IgnoredJumps: TGocciaCompilerJumpArray;
   IgnoredJumpCount: Integer;
+  MethodTailFlag: UInt8;
 begin
   if TryCompileOptionalChainCall(ACtx, AExpr, ADest) then
     Exit;
@@ -3911,6 +3933,14 @@ begin
   UseSpread := HasSpreadArgument(AExpr);
   CallNilJump := -1;
   IgnoredJumpCount := 0;
+  // ES2026 §15.10.2: an optional call cannot be in tail position here because
+  // the nullish guard runs after the call, and super() writes `this` back after
+  // the call, so neither is the last operation.  Only mark the plain and direct
+  // member call forms.
+  if ATail and not AExpr.Optional then
+    MethodTailFlag := CALL_FLAG_TAIL
+  else
+    MethodTailFlag := 0;
 
   if AExpr.Callee is TGocciaSuperExpression then
   begin
@@ -4026,14 +4056,16 @@ begin
     begin
       ArgsReg := ACtx.Scope.AllocateRegister;
       CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
-      EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg, 1));
+      EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg,
+        CALL_FLAG_SPREAD or MethodTailFlag));
       ACtx.Scope.FreeRegister;
     end
     else
     begin
       for I := 0 to ArgCount - 1 do
         ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
-      EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt8(ArgCount), 0));
+      EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt8(ArgCount),
+        MethodTailFlag));
       for I := 0 to ArgCount - 1 do
         ACtx.Scope.FreeRegister;
     end;
@@ -4154,14 +4186,16 @@ begin
       begin
         ArgsReg := ACtx.Scope.AllocateRegister;
         CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
-        EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg, 1));
+        EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg,
+          CALL_FLAG_SPREAD or MethodTailFlag));
         ACtx.Scope.FreeRegister;
       end
       else
       begin
         for I := 0 to ArgCount - 1 do
           ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
-        EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt8(ArgCount), 0));
+        EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt8(ArgCount),
+          MethodTailFlag));
         for I := 0 to ArgCount - 1 do
           ACtx.Scope.FreeRegister;
       end;
@@ -4187,7 +4221,7 @@ begin
   else
   begin
     if TryCompileWithIdentifierCall(ACtx, AExpr, ADest, ArgCount,
-       UseSpread, IgnoredJumps, IgnoredJumpCount) then
+       UseSpread, IgnoredJumps, IgnoredJumpCount, MethodTailFlag <> 0) then
       Exit;
 
     if (ADest + 1 = ACtx.Scope.NextSlot) and
@@ -4206,7 +4240,7 @@ begin
       ArgsReg := ACtx.Scope.AllocateRegister;
       CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
       EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, ArgsReg,
-        SpreadCallFlags(ACtx, AExpr, CurrentCodePosition(ACtx))));
+        SpreadCallFlags(ACtx, AExpr, CurrentCodePosition(ACtx)) or MethodTailFlag));
       ACtx.Scope.FreeRegister;
     end
     else
@@ -4214,7 +4248,7 @@ begin
       for I := 0 to ArgCount - 1 do
         ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
       EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, UInt8(ArgCount),
-        CallFlags(ACtx, AExpr, CurrentCodePosition(ACtx))));
+        CallFlags(ACtx, AExpr, CurrentCodePosition(ACtx)) or MethodTailFlag));
       for I := 0 to ArgCount - 1 do
         ACtx.Scope.FreeRegister;
     end;
@@ -5080,15 +5114,22 @@ end;
 
 // ES2026 §13.3.11 TaggedTemplate
 procedure CompileTaggedTemplate(const ACtx: TGocciaCompilationContext;
-  const AExpr: TGocciaTaggedTemplateExpression; const ADest: UInt8);
+  const AExpr: TGocciaTaggedTemplateExpression; const ADest: UInt8;
+  const ATail: Boolean = False);
 var
   ObjReg, BaseReg, Arg0Reg: UInt8;
   ArgCount, I: Integer;
   IsMethodCall: Boolean;
+  TailFlag: UInt8;
 begin
   ArgCount := 1 + AExpr.Expressions.Count; // template object + substitution values
   if ArgCount > High(UInt8) then
     raise Exception.Create('Compiler error: too many tagged template substitutions (>254)');
+
+  if ATail then
+    TailFlag := CALL_FLAG_TAIL
+  else
+    TailFlag := 0;
 
   CompileTagCalleeRegisters(ACtx, AExpr.Tag, BaseReg, ObjReg, IsMethodCall);
 
@@ -5107,9 +5148,10 @@ begin
     ACtx.CompileExpression(AExpr.Expressions[I], ACtx.Scope.AllocateRegister);
 
   if IsMethodCall then
-    EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt8(ArgCount), 0))
+    EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt8(ArgCount),
+      TailFlag))
   else
-    EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, UInt8(ArgCount), 0));
+    EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, UInt8(ArgCount), TailFlag));
 
   for I := 0 to AExpr.Expressions.Count - 1 do
     ACtx.Scope.FreeRegister;
@@ -5121,6 +5163,98 @@ begin
   ACtx.Scope.FreeRegister; // BaseReg
   if IsMethodCall then
     ACtx.Scope.FreeRegister; // ObjReg
+end;
+
+// ES2026 §15.10.2 HasCallInTailPosition.  Compiles AExpr into ADest, tagging the
+// call(s) the static semantics place in tail position so the VM may reuse the
+// current frame.  Only the tail-position-preserving expression forms recurse;
+// every other shape (including a call argument, the callee, or a logical
+// short-circuit operand that is returned directly) is compiled normally and is
+// therefore NOT a tail call.
+procedure CompileReturnValueTailAware(const ACtx: TGocciaCompilationContext;
+  const AExpr: TGocciaExpression; const ADest: UInt8);
+var
+  Conditional: TGocciaConditionalExpression;
+  Binary: TGocciaBinaryExpression;
+  Sequence: TGocciaSequenceExpression;
+  TempReg: UInt8;
+  ElseJump, EndJump, ShortCircuitJump, I: Integer;
+begin
+  // CallExpression Arguments / CallExpression TemplateLiteral: the call itself is
+  // in tail position.
+  if AExpr is TGocciaCallExpression then
+  begin
+    CompileCall(ACtx, TGocciaCallExpression(AExpr), ADest, True);
+    Exit;
+  end;
+  if AExpr is TGocciaTaggedTemplateExpression then
+  begin
+    CompileTaggedTemplate(ACtx, TGocciaTaggedTemplateExpression(AExpr), ADest,
+      True);
+    Exit;
+  end;
+
+  // ConditionalExpression: both branches inherit tail position.
+  if AExpr is TGocciaConditionalExpression then
+  begin
+    Conditional := TGocciaConditionalExpression(AExpr);
+    ACtx.CompileExpression(Conditional.Condition, ADest);
+    ElseJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_FALSE, ADest);
+    CompileReturnValueTailAware(ACtx, Conditional.Consequent, ADest);
+    EndJump := EmitJumpInstruction(ACtx, OP_JUMP, 0);
+    PatchJumpTarget(ACtx, ElseJump);
+    CompileReturnValueTailAware(ACtx, Conditional.Alternate, ADest);
+    PatchJumpTarget(ACtx, EndJump);
+    Exit;
+  end;
+
+  // LogicalANDExpression / LogicalORExpression / CoalesceExpression: only the
+  // right operand inherits tail position.  The short-circuit (left) result is
+  // produced as an ordinary value.
+  if AExpr is TGocciaBinaryExpression then
+  begin
+    Binary := TGocciaBinaryExpression(AExpr);
+    if (Binary.Operator = gttAnd) or (Binary.Operator = gttOr) or
+       (Binary.Operator = gttNullishCoalescing) then
+    begin
+      ACtx.CompileExpression(Binary.Left, ADest);
+      case Binary.Operator of
+        gttAnd:
+          ShortCircuitJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_FALSE, ADest);
+        gttOr:
+          ShortCircuitJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, ADest);
+      else
+        ShortCircuitJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_NOT_NULLISH,
+          ADest);
+      end;
+      CompileReturnValueTailAware(ACtx, Binary.Right, ADest);
+      PatchJumpTarget(ACtx, ShortCircuitJump);
+      Exit;
+    end;
+  end;
+
+  // Expression `,` AssignmentExpression: only the final operand inherits tail
+  // position.
+  if AExpr is TGocciaSequenceExpression then
+  begin
+    Sequence := TGocciaSequenceExpression(AExpr);
+    if Sequence.Expressions.Count >= 2 then
+    begin
+      TempReg := ACtx.Scope.AllocateRegister;
+      try
+        for I := 0 to Sequence.Expressions.Count - 2 do
+          ACtx.CompileExpression(Sequence.Expressions[I], TempReg);
+      finally
+        ACtx.Scope.FreeRegister;
+      end;
+      CompileReturnValueTailAware(ACtx,
+        Sequence.Expressions[Sequence.Expressions.Count - 1], ADest);
+      Exit;
+    end;
+  end;
+
+  // Any other production terminates tail position: compile as an ordinary value.
+  ACtx.CompileExpression(AExpr, ADest);
 end;
 
 function NewExprHasSpread(const AExpr: TGocciaNewExpression): Boolean;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -2160,6 +2160,23 @@ begin
     GPendingFinally.Insert(I, Entries[I]);
 end;
 
+// ES2026 §15.10 Tail Position Calls.  A call in tail position reuses the
+// caller's frame (PrepareForTailCall).  A `return <expr>` puts <expr> in tail
+// position, but only when no finally/using/iterator cleanup runs after it
+// (CurrentPendingFinallyBase = 0): e.g. `try { return f(); } finally {...}` is
+// NOT a tail call because the finally still runs, whereas `try {} finally {
+// return f(); }` IS.  Proper tail calls apply in strict-mode code only, and
+// generators/async functions are never candidates.
+function ReturnIsTailPositionEligible(
+  const ACtx: TGocciaCompilationContext): Boolean;
+begin
+  Result := (CurrentPendingFinallyBase = 0) and
+    Assigned(ACtx.Template) and
+    ACtx.Template.StrictCode and
+    (not ACtx.Template.IsGenerator) and
+    (not ACtx.Template.IsAsync);
+end;
+
 procedure CompileReturnStatement(const ACtx: TGocciaCompilationContext;
   const AStmt: TGocciaReturnStatement);
 var
@@ -2169,7 +2186,15 @@ begin
   if AStmt.HasExpression then
   begin
     Reg := ACtx.Scope.AllocateRegister;
-    ACtx.CompileExpression(AStmt.Value, Reg);
+    // Tag any tail-position call so the VM can reuse the current frame.  The
+    // call is still emitted as an ordinary value-producing call, so the
+    // OP_RETURN below stays correct whether or not the VM acts on the tail
+    // flag (when it does, it returns directly and the OP_RETURN is unreached).
+    if ReturnIsTailPositionEligible(ACtx) then
+      Goccia.Compiler.Expressions.CompileReturnValueTailAware(ACtx,
+        AStmt.Value, Reg)
+    else
+      ACtx.CompileExpression(AStmt.Value, Reg);
     EmitPendingCleanup(ACtx);
     ReturnNeedsAwait := Assigned(ACtx.Template) and ACtx.Template.IsAsync and
       ACtx.Template.IsGenerator;

--- a/source/units/Goccia.StackLimit.pas
+++ b/source/units/Goccia.StackLimit.pas
@@ -7,8 +7,20 @@ interface
 const
   DEFAULT_MAX_STACK_DEPTH = 2200;
 
+  // Native re-entry (generator resume, host eval, and native callbacks such as
+  // Array iteration methods or sort comparators) runs the VM on a fresh native
+  // stack frame instead of the trampolined frame stack. Each level therefore
+  // costs a real native stack frame (kilobytes), and the 8 MB thread stack is
+  // exhausted after roughly 1000-1500 levels -> SIGSEGV. This fixed cap fences
+  // that off well before the native stack runs out, independent of the
+  // configurable --stack-size limit (which bounds the much cheaper trampolined
+  // JS frames). Generator-mediated infinite recursion now throws a RangeError
+  // instead of crashing the engine.
+  MAX_NATIVE_REENTRY_DEPTH = 512;
+
 procedure SetMaxStackDepth(const AMaxDepth: Integer);
 procedure CheckStackDepth(const ACurrentDepth: Integer);
+procedure CheckNativeReentryDepth(const ADepth: Integer);
 
 implementation
 
@@ -27,6 +39,12 @@ end;
 procedure CheckStackDepth(const ACurrentDepth: Integer);
 begin
   if (GMaxStackDepth > 0) and (ACurrentDepth > GMaxStackDepth) then
+    ThrowRangeError(SErrorMaxCallStackExceeded);
+end;
+
+procedure CheckNativeReentryDepth(const ADepth: Integer);
+begin
+  if ADepth > MAX_NATIVE_REENTRY_DEPTH then
     ThrowRangeError(SErrorMaxCallStackExceeded);
 end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -145,6 +145,11 @@ type
     FCurrentClosure: TGocciaBytecodeClosure;
     FHandlerStack: TGocciaBytecodeHandlerStack;
     FFrameDepth: Integer;
+    // Depth of native VM re-entries (ExecuteClosureRegistersInternal invocations
+    // nested via generator resume, host eval, or native callbacks). Bounded
+    // separately from FFrameDepth because each native re-entry costs a real
+    // native stack frame; see CheckNativeReentryDepth in Goccia.StackLimit.
+    FNativeExecutionDepth: Integer;
     FFrameStack: array of TGocciaVMCallFrame;
     FFrameStackCount: Integer;
     FCurrentExecutionContextPushed: Boolean;
@@ -378,6 +383,9 @@ type
       out APrevCovLine: UInt32; out AProfileTimestamp: Int64): Integer;
     procedure TeardownCurrentFrame(const ATemplate: TGocciaFunctionTemplate;
       const AProfileTimestamp: Int64; const ATargetHandlerCount: Integer);
+    procedure PrepareTailCallFrameReuse(const ATemplate: TGocciaFunctionTemplate;
+      const AProfileTimestamp: Int64; const AInitialFrameStackCount,
+      ASavedHandlerCount: Integer);
     procedure PushSavedStateRoot(const AClosure: TGocciaBytecodeClosure;
       const ANewTarget: TGocciaValue; const AArguments: TGocciaRegisterArray);
     procedure PopSavedStateRoot;
@@ -12322,6 +12330,31 @@ begin
   Dec(FFrameDepth);
 end;
 
+// ES2026 §15.10.3 PrepareForTailCall.  Discards the current frame's resources so
+// the impending SetupNewFrame reuses this frame instead of stacking a new one.
+// The caller's saved frame slot (or the outermost return path) is left intact,
+// so the tail-called function returns directly to the current frame's caller.
+// Register and local-cell windows are collapsed in place: setting the live count
+// to 0 makes the next AcquireRegisters reuse the same memory region, so a chain
+// of tail calls grows neither the frame stack nor the register stack.
+procedure TGocciaVM.PrepareTailCallFrameReuse(
+  const ATemplate: TGocciaFunctionTemplate; const AProfileTimestamp: Int64;
+  const AInitialFrameStackCount, ASavedHandlerCount: Integer);
+var
+  TargetHandlerCount: Integer;
+begin
+  // The handler count active when the current frame began: the parent trampoline
+  // frame's saved count, or the entry handler count if this is the outermost
+  // frame of the running ExecuteClosureRegistersInternal invocation.
+  if FFrameStackCount > AInitialFrameStackCount then
+    TargetHandlerCount := FFrameStack[FFrameStackCount - 1].HandlerCount
+  else
+    TargetHandlerCount := ASavedHandlerCount;
+  TeardownCurrentFrame(ATemplate, AProfileTimestamp, TargetHandlerCount);
+  FRegisterCount := 0;
+  FLocalCellCount := 0;
+end;
+
 procedure TGocciaVM.PushSavedStateRoot(const AClosure: TGocciaBytecodeClosure;
   const ANewTarget: TGocciaValue; const AArguments: TGocciaRegisterArray);
 begin
@@ -12583,6 +12616,12 @@ var
   ExecutionRealm: TGocciaRealm;
   RealmSwitched: Boolean;
 begin
+  // This is a native VM re-entry: the bytecode loop runs on a fresh native stack
+  // frame. Bound the native re-entry depth before any state is saved so the
+  // throw unwinds cleanly (the matching Inc/Dec are paired with the try/finally
+  // below). Without this, generator resume / eval / native-callback recursion
+  // overflows the native stack (SIGSEGV) instead of throwing RangeError.
+  CheckNativeReentryDepth(FNativeExecutionDepth + 1);
   PreviousRealm := CurrentRealm;
   ExecutionRealm := BytecodeClosureExecutionRealm(AClosure, FRealm);
   RealmSwitched := Assigned(ExecutionRealm) and (ExecutionRealm <> PreviousRealm);
@@ -12605,6 +12644,7 @@ begin
   if RealmSwitched then
     SetCurrentRealm(ExecutionRealm);
   try
+    Inc(FNativeExecutionDepth);
     SetupNewFrame(AClosure, AThisValue, AArguments, AArgCount,
       AArg0, AArg1, AArg2, AUseFixedArgs, APushExecutionContext,
       Frame, Template, PrevCovLine, ProfileEntryTimestamp);
@@ -14491,7 +14531,12 @@ begin
                 if not BytecodeFunction.FStrictThis then
                   CallThisRegister := CoerceNonStrictThisRegister(
                     CallThisRegister);
-                PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
+                if (C and CALL_FLAG_TAIL) <> 0 then
+                  PrepareTailCallFrameReuse(Template, ProfileEntryTimestamp,
+                    InitialFrameStackCount, SavedHandlerCount)
+                else
+                  PushFrame(A, Frame.IP, Template, PrevCovLine,
+                    ProfileEntryTimestamp);
                 SetupNewFrame(BytecodeFunction.FClosure,
                   CallThisRegister, RegisterArgs,
                   Length(RegisterArgs), RegisterUndefined, RegisterUndefined,
@@ -14514,7 +14559,12 @@ begin
                 if not BytecodeFunction.FStrictThis then
                   CallThisRegister := CoerceNonStrictThisRegister(
                     CallThisRegister);
-                PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
+                if (C and CALL_FLAG_TAIL) <> 0 then
+                  PrepareTailCallFrameReuse(Template, ProfileEntryTimestamp,
+                    InitialFrameStackCount, SavedHandlerCount)
+                else
+                  PushFrame(A, Frame.IP, Template, PrevCovLine,
+                    ProfileEntryTimestamp);
                 SetupNewFrame(BytecodeFunction.FClosure,
                   CallThisRegister, RegisterArgs,
                   Length(RegisterArgs), RegisterUndefined, RegisterUndefined,
@@ -14544,7 +14594,12 @@ begin
               SetLength(RegisterArgs, B);
               for I := 0 to B - 1 do
                 RegisterArgs[I] := FRegisters[A + 1 + I];
-              PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
+              if (C and CALL_FLAG_TAIL) <> 0 then
+                PrepareTailCallFrameReuse(Template, ProfileEntryTimestamp,
+                  InitialFrameStackCount, SavedHandlerCount)
+              else
+                PushFrame(A, Frame.IP, Template, PrevCovLine,
+                  ProfileEntryTimestamp);
               SetupNewFrame(BytecodeFunction.FClosure,
                 CallThisRegister, RegisterArgs, B,
                 RegisterUndefined, RegisterUndefined, RegisterUndefined, False, True,
@@ -14559,7 +14614,12 @@ begin
 	              for I := 0 to High(RegisterArgs) do
 	                RegisterArgs[I] := ValueToRegister(
 	                  TGocciaArrayValue(FRegisters[B].ObjectValue).GetProperty(IntToStr(I)));
-              PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
+              if (C and CALL_FLAG_TAIL) <> 0 then
+                PrepareTailCallFrameReuse(Template, ProfileEntryTimestamp,
+                  InitialFrameStackCount, SavedHandlerCount)
+              else
+                PushFrame(A, Frame.IP, Template, PrevCovLine,
+                  ProfileEntryTimestamp);
               SetupNewFrame(BytecodeFunction.FClosure,
                 CallThisRegister, RegisterArgs, Length(RegisterArgs),
                 RegisterUndefined, RegisterUndefined, RegisterUndefined, False, True,
@@ -14753,9 +14813,15 @@ begin
               SetLength(RegisterArgs, B);
               for I := 0 to B - 1 do
                 RegisterArgs[I] := FRegisters[A + 1 + I];
-              PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
+              CallThisRegister := FRegisters[A - 1];
+              if (C and CALL_FLAG_TAIL) <> 0 then
+                PrepareTailCallFrameReuse(Template, ProfileEntryTimestamp,
+                  InitialFrameStackCount, SavedHandlerCount)
+              else
+                PushFrame(A, Frame.IP, Template, PrevCovLine,
+                  ProfileEntryTimestamp);
               SetupNewFrame(BytecodeFunction.FClosure,
-                FRegisters[A - 1], RegisterArgs, B,
+                CallThisRegister, RegisterArgs, B,
                 RegisterUndefined, RegisterUndefined, RegisterUndefined, False, True,
                 Frame, Template, PrevCovLine, ProfileEntryTimestamp);
               Continue;
@@ -14768,9 +14834,15 @@ begin
 	              for I := 0 to High(RegisterArgs) do
 	                RegisterArgs[I] := VMValueToRegisterFast(
 	                  TGocciaArrayValue(FRegisters[B].ObjectValue).GetProperty(IntToStr(I)));
-              PushFrame(A, Frame.IP, Template, PrevCovLine, ProfileEntryTimestamp);
+              CallThisRegister := FRegisters[A - 1];
+              if (C and CALL_FLAG_TAIL) <> 0 then
+                PrepareTailCallFrameReuse(Template, ProfileEntryTimestamp,
+                  InitialFrameStackCount, SavedHandlerCount)
+              else
+                PushFrame(A, Frame.IP, Template, PrevCovLine,
+                  ProfileEntryTimestamp);
               SetupNewFrame(BytecodeFunction.FClosure,
-                FRegisters[A - 1], RegisterArgs, Length(RegisterArgs),
+                CallThisRegister, RegisterArgs, Length(RegisterArgs),
                 RegisterUndefined, RegisterUndefined, RegisterUndefined, False, True,
                 Frame, Template, PrevCovLine, ProfileEntryTimestamp);
               Continue;
@@ -15802,6 +15874,7 @@ begin
     end;
     Result := RegisterUndefined;
   finally
+    Dec(FNativeExecutionDepth);
     try
       // Unwind any remaining trampoline frames (exception escape path)
       while FFrameStackCount > InitialFrameStackCount do

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -1945,7 +1945,12 @@ var
   // the buffer (AbortSortWriteback).
   procedure MergeSortNumbers;
   var
-    Width, Lo, Mid, Hi, Left, Right, Dest: Integer;
+    // Width and Lo are Int64 so doubling Width and computing Lo + 2 * Width
+    // cannot overflow Integer for very large (multi-GB) 1-byte typed arrays,
+    // where SortLen can approach High(Integer). Range checks are off in
+    // release builds, so an overflow would silently corrupt the merge bounds.
+    Width, Lo: Int64;
+    Mid, Hi, Left, Right, Dest: Integer;
   begin
     SetLength(NumberScratch, SortLen);
     Width := 1;
@@ -1954,15 +1959,12 @@ var
       Lo := 0;
       while Lo < SortLen do
       begin
-        Mid := Lo + Width;
-        if Mid > SortLen then
-          Mid := SortLen;
-        Hi := Lo + 2 * Width;
-        if Hi > SortLen then
-          Hi := SortLen;
-        Left := Lo;
+        // Clamp in Int64, then narrow: Mid and Hi are <= SortLen <= High(Integer).
+        Mid := Integer(Min(Lo + Width, Int64(SortLen)));
+        Hi := Integer(Min(Lo + 2 * Width, Int64(SortLen)));
+        Left := Integer(Lo);
         Right := Mid;
-        Dest := Lo;
+        Dest := Integer(Lo);
         while (Left < Mid) and (Right < Hi) do
         begin
           if CompareNumbers(NumberValues[Right], NumberValues[Left]) < 0 then
@@ -2003,7 +2005,12 @@ var
   // MergeSortNumbers for the structure; identical algorithm over Int64 keys.
   procedure MergeSortBigInts;
   var
-    Width, Lo, Mid, Hi, Left, Right, Dest: Integer;
+    // Width and Lo are Int64 so doubling Width and computing Lo + 2 * Width
+    // cannot overflow Integer for very large (multi-GB) 1-byte typed arrays,
+    // where SortLen can approach High(Integer). Range checks are off in
+    // release builds, so an overflow would silently corrupt the merge bounds.
+    Width, Lo: Int64;
+    Mid, Hi, Left, Right, Dest: Integer;
   begin
     SetLength(BigIntScratch, SortLen);
     Width := 1;
@@ -2012,15 +2019,12 @@ var
       Lo := 0;
       while Lo < SortLen do
       begin
-        Mid := Lo + Width;
-        if Mid > SortLen then
-          Mid := SortLen;
-        Hi := Lo + 2 * Width;
-        if Hi > SortLen then
-          Hi := SortLen;
-        Left := Lo;
+        // Clamp in Int64, then narrow: Mid and Hi are <= SortLen <= High(Integer).
+        Mid := Integer(Min(Lo + Width, Int64(SortLen)));
+        Hi := Integer(Min(Lo + 2 * Width, Int64(SortLen)));
+        Left := Integer(Lo);
         Right := Mid;
-        Dest := Lo;
+        Dest := Integer(Lo);
         while (Left < Mid) and (Right < Hi) do
         begin
           if CompareBigInts(BigIntValues[Right], BigIntValues[Left]) < 0 then

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -1841,11 +1841,9 @@ end;
 function TGocciaTypedArrayValue.TypedArraySort(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA: TGocciaTypedArrayValue;
-  I, J, SortLen: Integer;
-  NumberValues: array of Double;
-  BigIntValues: array of Int64;
-  TmpNumber, CompResult: Double;
-  TmpBigInt: Int64;
+  I, SortLen: Integer;
+  NumberValues, NumberScratch: array of Double;
+  BigIntValues, BigIntScratch: array of Int64;
   HasCompare: Boolean;
   AbortSortWriteback: Boolean;
   Comparator: TGocciaValue;
@@ -1941,6 +1939,124 @@ var
     Result := 0;
   end;
 
+  // Bottom-up merge sort over NumberValues using CompareNumbers. O(n log n);
+  // stable, so equal keys retain order (needed for -0/+0 and NaN runs to stay
+  // in CompareNumbers order). Bails out early when a comparator callback detaches
+  // the buffer (AbortSortWriteback).
+  procedure MergeSortNumbers;
+  var
+    Width, Lo, Mid, Hi, Left, Right, Dest: Integer;
+  begin
+    SetLength(NumberScratch, SortLen);
+    Width := 1;
+    while Width < SortLen do
+    begin
+      Lo := 0;
+      while Lo < SortLen do
+      begin
+        Mid := Lo + Width;
+        if Mid > SortLen then
+          Mid := SortLen;
+        Hi := Lo + 2 * Width;
+        if Hi > SortLen then
+          Hi := SortLen;
+        Left := Lo;
+        Right := Mid;
+        Dest := Lo;
+        while (Left < Mid) and (Right < Hi) do
+        begin
+          if CompareNumbers(NumberValues[Right], NumberValues[Left]) < 0 then
+          begin
+            NumberScratch[Dest] := NumberValues[Right];
+            Inc(Right);
+          end
+          else
+          begin
+            NumberScratch[Dest] := NumberValues[Left];
+            Inc(Left);
+          end;
+          if AbortSortWriteback then
+            Exit;
+          Inc(Dest);
+        end;
+        while Left < Mid do
+        begin
+          NumberScratch[Dest] := NumberValues[Left];
+          Inc(Left);
+          Inc(Dest);
+        end;
+        while Right < Hi do
+        begin
+          NumberScratch[Dest] := NumberValues[Right];
+          Inc(Right);
+          Inc(Dest);
+        end;
+        Lo := Lo + 2 * Width;
+      end;
+      for Dest := 0 to SortLen - 1 do
+        NumberValues[Dest] := NumberScratch[Dest];
+      Width := Width * 2;
+    end;
+  end;
+
+  // Bottom-up merge sort over BigIntValues using CompareBigInts. See
+  // MergeSortNumbers for the structure; identical algorithm over Int64 keys.
+  procedure MergeSortBigInts;
+  var
+    Width, Lo, Mid, Hi, Left, Right, Dest: Integer;
+  begin
+    SetLength(BigIntScratch, SortLen);
+    Width := 1;
+    while Width < SortLen do
+    begin
+      Lo := 0;
+      while Lo < SortLen do
+      begin
+        Mid := Lo + Width;
+        if Mid > SortLen then
+          Mid := SortLen;
+        Hi := Lo + 2 * Width;
+        if Hi > SortLen then
+          Hi := SortLen;
+        Left := Lo;
+        Right := Mid;
+        Dest := Lo;
+        while (Left < Mid) and (Right < Hi) do
+        begin
+          if CompareBigInts(BigIntValues[Right], BigIntValues[Left]) < 0 then
+          begin
+            BigIntScratch[Dest] := BigIntValues[Right];
+            Inc(Right);
+          end
+          else
+          begin
+            BigIntScratch[Dest] := BigIntValues[Left];
+            Inc(Left);
+          end;
+          if AbortSortWriteback then
+            Exit;
+          Inc(Dest);
+        end;
+        while Left < Mid do
+        begin
+          BigIntScratch[Dest] := BigIntValues[Left];
+          Inc(Left);
+          Inc(Dest);
+        end;
+        while Right < Hi do
+        begin
+          BigIntScratch[Dest] := BigIntValues[Right];
+          Inc(Right);
+          Inc(Dest);
+        end;
+        Lo := Lo + 2 * Width;
+      end;
+      for Dest := 0 to SortLen - 1 do
+        BigIntValues[Dest] := BigIntScratch[Dest];
+      Width := Width * 2;
+    end;
+  end;
+
 begin
   Comparator := TGocciaUndefinedLiteralValue.UndefinedValue;
   HasCompare := False;
@@ -1967,22 +2083,9 @@ begin
     for I := 0 to SortLen - 1 do
       BigIntValues[I] := TA.ReadBigIntElement(I);
 
-    for I := 1 to SortLen - 1 do
-    begin
-      TmpBigInt := BigIntValues[I];
-      J := I - 1;
-      while J >= 0 do
-      begin
-        CompResult := CompareBigInts(BigIntValues[J], TmpBigInt);
-        if AbortSortWriteback then
-          Exit(AThisValue);
-        if CompResult <= 0 then
-          Break;
-        BigIntValues[J + 1] := BigIntValues[J];
-        Dec(J);
-      end;
-      BigIntValues[J + 1] := TmpBigInt;
-    end;
+    MergeSortBigInts;
+    if AbortSortWriteback then
+      Exit(AThisValue);
 
     for I := 0 to SortLen - 1 do
       TA.WriteBigIntElement(I, BigIntValues[I]);
@@ -1993,22 +2096,9 @@ begin
   for I := 0 to SortLen - 1 do
     NumberValues[I] := TA.ReadElement(I);
 
-  for I := 1 to SortLen - 1 do
-  begin
-    TmpNumber := NumberValues[I];
-    J := I - 1;
-    while J >= 0 do
-    begin
-      CompResult := CompareNumbers(NumberValues[J], TmpNumber);
-      if AbortSortWriteback then
-        Exit(AThisValue);
-      if CompResult <= 0 then
-        Break;
-      NumberValues[J + 1] := NumberValues[J];
-      Dec(J);
-    end;
-    NumberValues[J + 1] := TmpNumber;
-  end;
+  MergeSortNumbers;
+  if AbortSortWriteback then
+    Exit(AThisValue);
 
   for I := 0 to SortLen - 1 do
     TA.WriteElement(I, NumberValues[I]);

--- a/source/units/Goccia.Values.WeakMapValue.pas
+++ b/source/units/Goccia.Values.WeakMapValue.pas
@@ -278,21 +278,51 @@ begin
   inherited;
 end;
 
+// ES2026 §9.9.3 WeakRef Execution: a WeakMap entry's value is live only while
+// its key is live. Marking a value can make it the key of another entry in the
+// same map (an ephemeron chain), so the live set must be propagated to a
+// fixpoint. A single full-slot scan per GC pass would make a chain of length N
+// cost O(N^2) (one link resolved per pass). Resolving the chain with a worklist
+// keyed by object identity makes the whole intra-map trace O(entries): the
+// initial scan seeds directly-reachable values, then each newly marked value is
+// looked up as a key in O(1) to extend the chain. Cross-map links are still
+// driven by the collector's outer trace loop.
 function TGocciaWeakMapValue.TraceWeakReferences: Boolean;
 var
   Pair: TGocciaWeakMapStorage.TKeyValuePair;
-  WasMarked: Boolean;
+  WorkList: array of TGocciaValue;
+  WorkCount: Integer;
+  Current, NextValue: TGocciaValue;
+
+  procedure MarkValue(const AValue: TGocciaValue);
+  begin
+    if not Assigned(AValue) or AValue.GCMarked then
+      Exit;
+    AValue.MarkReferences;
+    Result := True;
+    if WorkCount = Length(WorkList) then
+      SetLength(WorkList, (WorkCount * 2) + 1);
+    WorkList[WorkCount] := AValue;
+    Inc(WorkCount);
+  end;
+
 begin
   Result := False;
+  WorkCount := 0;
+
+  // Seed the worklist with the values of all entries whose key is currently live.
   for Pair in FEntries do
+    if Assigned(Pair.Key) and Pair.Key.GCMarked then
+      MarkValue(Pair.Value);
+
+  // Propagate: a freshly marked value may itself be a live key in this map,
+  // keeping the value of that entry live in turn.
+  while WorkCount > 0 do
   begin
-    if Assigned(Pair.Key) and Pair.Key.GCMarked and Assigned(Pair.Value) then
-    begin
-      WasMarked := Pair.Value.GCMarked;
-      Pair.Value.MarkReferences;
-      if not WasMarked and Pair.Value.GCMarked then
-        Result := True;
-    end;
+    Dec(WorkCount);
+    Current := WorkList[WorkCount];
+    if FEntries.TryGetValue(Current, NextValue) then
+      MarkValue(NextValue);
   end;
 end;
 

--- a/tests/built-ins/TypedArray/prototype/sort.js
+++ b/tests/built-ins/TypedArray/prototype/sort.js
@@ -9,6 +9,30 @@ describe("TypedArray.prototype.sort", () => {
     expect(ta[4]).toBe(4);
   });
 
+  test("sorts a large array correctly (guards against the O(n^2) sort regression)", () => {
+    const N = 60000;
+    // Strictly descending input is the worst case for the previous insertion
+    // sort; the bottom-up merge sort handles it in O(n log n).
+    const ta = new Uint16Array(Array.from({ length: N }, (_, i) => N - i));
+    ta.sort();
+    expect(ta[0]).toBe(1);
+    expect(ta[N - 1]).toBe(N);
+    const out = Array.from(ta);
+    expect(out.every((v, i) => i === 0 || out[i - 1] <= v)).toBe(true);
+  });
+
+  test("default sort orders -0 before +0 and places NaN last", () => {
+    const ta = new Float64Array([NaN, 3, -0, 2, 0, 1, NaN]);
+    ta.sort();
+    expect(1 / ta[0]).toBe(-Infinity); // -0 sorts first
+    expect(1 / ta[1]).toBe(Infinity); // +0 sorts second
+    expect(ta[2]).toBe(1);
+    expect(ta[3]).toBe(2);
+    expect(ta[4]).toBe(3);
+    expect(ta[5] !== ta[5]).toBe(true); // NaN
+    expect(ta[6] !== ta[6]).toBe(true); // NaN
+  });
+
   describe.each([Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float16Array, Float32Array, Float64Array])("%s", (TA) => {
     test("sorts numerically by default", () => {
       const ta = new TA([3, 1, 2]);

--- a/tests/built-ins/WeakMap/gc.js
+++ b/tests/built-ins/WeakMap/gc.js
@@ -29,6 +29,49 @@ describe.runIf(hasGoccia)("WeakMap GC behavior", () => {
     expect(map.get(liveKey).marker).toBe("live");
   });
 
+  test("walks a deep key-as-value chain after GC without quadratic blowup", () => {
+    const map = new WeakMap();
+    const head = {};
+    const length = 60000;
+    let key = head;
+    Array.from({ length }).forEach(() => {
+      const next = {};
+      map.set(key, next);
+      key = next;
+    });
+    Goccia.gc();
+
+    let walked = 0;
+    let node = head;
+    Array.from({ length: length + 1 }).forEach(() => {
+      if (node !== undefined) {
+        walked = walked + 1;
+        node = map.get(node);
+      }
+    });
+    expect(walked).toBe(length + 1);
+    expect(node).toBe(undefined);
+  });
+
+  test("collects an unreachable deep chain so keys are not retained", () => {
+    Goccia.gc();
+    const baseline = Goccia.gc.bytesAllocated;
+
+    (() => {
+      const map = new WeakMap();
+      let key = {};
+      Array.from({ length: 60000 }).forEach(() => {
+        const next = {};
+        map.set(key, next);
+        key = next;
+      });
+      expect(Goccia.gc.bytesAllocated).toBeGreaterThan(baseline);
+    })();
+
+    Goccia.gc();
+    expect(Goccia.gc.bytesAllocated).toBeLessThan(baseline + 1024 * 1024);
+  });
+
   test("constructor roots current set method across iterable user code", () => {
     const original = WeakMap.prototype.set;
     const key = {};


### PR DESCRIPTION
## Summary

Drives test262 timeouts from **37 → 0** by fixing three independent root causes across disjoint subsystems. The tail-call cluster surfaced only under CI memory pressure (passes in <1s on a fast dev machine but pinned to the 41s wall clock in CI); the WeakMap and TypedArray cases reproduce locally at 41s.

**Tail calls + recursion bounding** (bytecode VM / compiler / bare loader):

- Implement **proper tail-call optimization**: a `CALL_FLAG_TAIL` bit, strict-gated tail-position detection in `Goccia.Compiler.Expressions`/`Goccia.Compiler.Statements`, and in-place frame reuse (`PrepareTailCallFrameReuse`) in the VM. The 34 `language/**/tco-*.js` tests recurse 100k deep in tail position and ran to the wall-clock timeout; they now **pass**.
- Wire a finite call-stack limit (`--stack-size`, default 10000) into `GocciaScriptLoaderBare`, which previously had **none**.
- Bound native VM re-entry depth (`MAX_NATIVE_REENTRY_DEPTH` in `Goccia.StackLimit`). Generator resume, host `eval`, and native callbacks (Array iteration, sort comparators) re-enter the bytecode loop on a fresh Pascal stack frame and were previously unbounded → SIGSEGV. They now throw `RangeError`. Fixes `staging/sm/extensions/recursion.js` (infinite recursion mediated by a generator).

**WeakMap GC**: resolve ephemeron chains with an O(entries) worklist during the weak-reference trace instead of relying on the collector's fixpoint loop (one chain link per pass, O(entries²)). Fixes `staging/sm/regress/regress-1507322-deep-weakmap.js` (41s → <1s).

**TypedArray sort**: replace the O(n²) insertion sort with a stable bottom-up merge sort for the default-comparator numeric and BigInt paths (NaN-last and -0-before-+0 ordering preserved). Removes the `staging/sm/TypedArray/sort_large_countingsort.js` timeout.

Non-goal: `sort_large_countingsort.js` is no longer a timeout but still fails at ~20s locally because the test issues ~1.2M harness `assert.sameValue` calls — a separate call-path performance matter, not addressed here.

**Build correctness (FPC FASTMATH).** This PR's unrelated memory-layout changes exposed a pre-existing latent miscompilation: FPC `-O4` enables `FASTMATH`, which reassociates/contracts floating point and assumes no NaN/Inf, violating the IEEE-754 double semantics JavaScript requires. It produced wrong results in edge-case Temporal `hoursInDay` DST math (failing `intl402/Temporal/ZonedDateTime/prototype/hoursInDay/dst-less-than-hour` and `/same-date-starts-twice` on the x64 conformance run; `main` fails identically under `-O4`). Fixed by disabling only FASTMATH at the source level (`{$OPTIMIZATION NOFASTMATH}` in `source/shared/Shared.inc`) while keeping `-O4`. Also hardened the new merge sort against signed `Integer` overflow on multi-GB 1-byte typed arrays (`Int64` loop counters).

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation evidence:

- Full 52,293-test test262 sweep (bytecode): the original **37 timeouts → 0**, wrapper-infra **0**, **+136 net passes** vs the cached `main` baseline. Residual local deltas are jobs=8 contention on pre-existing slow tests plus aarch64-vs-x64 float/Unicode noise — each verified to behave identically (or faster) on the unmodified binary on the same machine.
- Project JS suite: **10,825 / 10,825** passing in **both** interpreted and bytecode modes.
- Production build (`-O4` + `{$OPTIMIZATION NOFASTMATH}`) full test262 sweep re-confirmed: **0 timeouts, 0 wrapper-infra**, and both `hoursInDay` tests pass.
- Native Pascal unit tests: 38/38 suites pass (incl. `Goccia.VM.Test`, `Goccia.GarbageCollector.Test`, value-type suites).
- New regression tests: `tests/built-ins/TypedArray/prototype/sort.js` (large array + NaN/-0 ordering), `scripts/test-cli-apps.ts` (`--stack-size` bound, TCO strict-gating, native re-entry → RangeError), and `tests/built-ins/WeakMap/gc.js` (deep-chain GC).
- `./format.pas --check`, doc symbol/link/length checks, and markdown lint all pass.

