### PR TITLE
perf(interpreter): skip redundant per-call hoisting work for function bodies

### DIFF
--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -570,10 +570,17 @@ begin
   Context.NonStrictMode := CompatibilityNonStrictMode and not FStrictCode;
   Context.CompatibilityNonStrictMode := CompatibilityNonStrictMode;
   Context.DisposalTracker := nil;
-  EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
-    ArgumentsObjectEnabled and CreatesArgumentsObject and
-    not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS));
   HasParamExpressions := HasParameterExpressions;
+  // EvalRejectNames is only read while evaluating a parameter default, so
+  // only build it when a parameter actually has a default or pattern
+  // expression. Simple-parameter functions skip the allocation and the
+  // O(n^2) name dedup entirely.
+  if HasParamExpressions then
+    EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
+      ArgumentsObjectEnabled and CreatesArgumentsObject and
+      not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS))
+  else
+    EvalRejectNames := nil;
 
   // Record coverage hit on the declaration line (get/set/constructor/method)
   if Context.CoverageEnabled and (FSourceLine > 0) and (FSourceFilePath <> '') then
@@ -722,6 +729,15 @@ begin
     end;
   end;
 
+  // Expression-body fast path: an expression body cannot contain var,
+  // function, or lexical declarations, so the hoisting passes below are
+  // no-ops for it. Evaluate the single expression directly and skip them.
+  if FIsExpressionBody and (FBodyStatements.Count = 1) then
+  begin
+    Result := EvaluateExpression(TGocciaExpression(FBodyStatements[0]), Context);
+    Exit;
+  end;
+
   // Hoist var declarations to function scope
   HoistVarDeclarations(FBodyStatements, BodyScope, Context);
 
@@ -731,13 +747,6 @@ begin
 
   // Hoist function declarations (both name and value) to function scope
   HoistFunctionDeclarations(FBodyStatements, Context);
-
-  // Expression-body fast path: expression bodies cannot contain return/break
-  if FIsExpressionBody and (FBodyStatements.Count = 1) then
-  begin
-    Result := EvaluateExpression(TGocciaExpression(FBodyStatements[0]), Context);
-    Exit;
-  end;
 
   // Single-return fast path: (x) => { return expr; } — evaluate the return
   // expression directly, bypassing the statement loop
@@ -895,10 +904,13 @@ begin
     Context.NonStrictMode := CompatibilityNonStrictMode and not FStrictCode;
     Context.CompatibilityNonStrictMode := CompatibilityNonStrictMode;
     Context.DisposalTracker := nil;
-    EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
-      ArgumentsObjectEnabled and CreatesArgumentsObject and
-      not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS));
     HasParamExpressions := HasParameterExpressions;
+    if HasParamExpressions then
+      EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
+        ArgumentsObjectEnabled and CreatesArgumentsObject and
+        not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS))
+    else
+      EvalRejectNames := nil;
 
     if Context.CoverageEnabled and (FSourceLine > 0) and
        (FSourceFilePath <> '') then
@@ -1042,9 +1054,13 @@ begin
       end;
     end;
 
-    HoistVarDeclarations(FBodyStatements, BodyScope, Context);
-    PredeclareFunctionBodyLexicalDeclarations(FBodyStatements, BodyScope);
-    HoistFunctionDeclarations(FBodyStatements, Context);
+    // An expression body has no declarations to hoist; skip the no-op passes.
+    if not (FIsExpressionBody and (FBodyStatements.Count = 1)) then
+    begin
+      HoistVarDeclarations(FBodyStatements, BodyScope, Context);
+      PredeclareFunctionBodyLexicalDeclarations(FBodyStatements, BodyScope);
+      HoistFunctionDeclarations(FBodyStatements, Context);
+    end;
 
     AsyncBodyStatements := TObjectList<TGocciaASTNode>.Create(False);
     if FIsExpressionBody and (FBodyStatements.Count = 1) then

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -710,10 +710,16 @@ begin
   Context.NonStrictMode := CompatibilityNonStrictMode and not FStrictCode;
   Context.CompatibilityNonStrictMode := CompatibilityNonStrictMode;
   Context.DisposalTracker := nil;
-  EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
-    ArgumentsObjectEnabled and CreatesArgumentsObject and
-    not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS));
   HasParamExpressions := HasParameterExpressions;
+  // EvalRejectNames is only read while evaluating a parameter default, so
+  // only build it when a parameter actually has a default or pattern
+  // expression (parity with TGocciaFunctionValue.ExecuteBody).
+  if HasParamExpressions then
+    EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
+      ArgumentsObjectEnabled and CreatesArgumentsObject and
+      not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS))
+  else
+    EvalRejectNames := nil;
 
   if ArgumentsObjectEnabled and CreatesArgumentsObject and
      not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS) and
@@ -936,10 +942,16 @@ begin
   Context.NonStrictMode := CompatibilityNonStrictMode and not FStrictCode;
   Context.CompatibilityNonStrictMode := CompatibilityNonStrictMode;
   Context.DisposalTracker := nil;
-  EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
-    ArgumentsObjectEnabled and CreatesArgumentsObject and
-    not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS));
   HasParamExpressions := HasParameterExpressions;
+  // EvalRejectNames is only read while evaluating a parameter default, so
+  // only build it when a parameter actually has a default or pattern
+  // expression (parity with TGocciaFunctionValue.ExecuteBody).
+  if HasParamExpressions then
+    EvalRejectNames := BuildParameterEvalVarDeclarationRejectNames(
+      ArgumentsObjectEnabled and CreatesArgumentsObject and
+      not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS))
+  else
+    EvalRejectNames := nil;
 
   if ArgumentsObjectEnabled and CreatesArgumentsObject and
      not ParameterListBindsName(FParameters, IDENTIFIER_ARGUMENTS) and


### PR DESCRIPTION
## Summary

The tree-walking interpreter recomputed parse-derived hoisting work on **every function call**. Two provably-redundant per-call operations are eliminated here:

- **`EvalRejectNames` built unconditionally.** `ExecuteBody` always built `EvalRejectNames` — a `TStringList` allocation plus an O(n²) name dedup — even though that value is only read while evaluating a **parameter default** (`EvaluateParameterDefault`). It is now guarded behind `HasParameterExpressions`, so simple-parameter functions (the common case) skip the allocation and dedup entirely. `HasParameterExpressions` is `True` whenever any parameter has a default, so the value is never read while `nil`.
- **Hoisting passes ran before the expression-body fast path.** `HoistVarDeclarations` / `PredeclareFunctionBodyLexicalDeclarations` / `HoistFunctionDeclarations` ran *before* the `x => expr` fast path, even though an expression body grammatically cannot contain var/function/lexical declarations — making all three no-ops for it. The fast path now runs first (sync: early `Exit`; async: the three passes are skipped for expression bodies).

Applied across all three interpreter function-execution paths: sync `ExecuteBody`, async `CallAsync`, and the generator value (parity — generators paid the identical `EvalRejectNames` cost; surfaced in review).

Both changes are behavior-preserving — pure eliminations of redundant per-call work.

**Non-goal:** caching the var-name list for *block*-body hoisting (a third swept finding) is not included — the expression-body reorder already removes hoisting for the dominant arrow case, and block-body caching is a separate, unmeasured optimization the conformance-first vision does not prioritize speculatively.

### Measured impact (interpreter mode, before → after)

| Benchmark | Before | After | Δ |
|---|--:|--:|--:|
| `recursive fib(15)` | 169 ops/sec | **247** | **+46%** |
| `recursive fib(20)` | 15 | **22** | **+47%** |
| `closure over single variable` | 66,008 | **75,154** | **+14%** |
| `closure over multiple variables` | 71,064 | **87,196** | **+23%** |
| `nested closures` | 79,940 | **104,807** | **+31%** |

Bytecode mode is unaffected — the change is in the tree-walk paths, not the VM.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full suite **10,910/10,910 in both interpreter and bytecode modes** under `--prod`. This is a behavior-preserving refactor, so the existing arrow / parameter-default / var-hoisting / async / generator suites are the regression oracle (no new test — no observable behavior changed).
- [ ] Updated documentation — N/A (internal interpreter fast paths; no documented behavior changed).
- [x] Optional: native Pascal tests — N/A.
- [x] Optional: no benchmark regressions — interpreter `fibonacci`/`closures` improve +14–47%; bytecode unchanged; the PR benchmark comparison runs in CI.

`./format.pas --check` clean. Reviewed via `/code-review`: both changes verified correct (`EvalRejectNames` is never read while `nil`; the skipped hoisting passes are no-ops for expression bodies; `finally` cleanup is preserved on the fast-path `Exit`). The review's altitude finding — the same unguarded setup in the generator path — is addressed in this PR rather than deferred.

### Validated impact (full-suite re-measurement)

Re-measured vs `main`: the full **test262 suite (52,293 tests) is ±0pp in every category, both modes** — no conformance change, no regression. Two caveats so the table above isn't over-read:

- **This is interpreter-only** (tree-walk `ExecuteBody`). test262 and the everyday bytecode path run the VM, which this change does not touch — so the test262/bytecode impact is **zero**.
- The `fib +46%` figures are specific micro-benchmarks; the *aggregate* interpreter improvement on call-heavy code, measured with warm-up + alternating reps, is closer to **+11–17%** (same-binary noise floor is ±11–15%).

The CI "Benchmark Results" deltas are dominated by cross-runner baseline variance and are not a reliable measure (tracked in #815) — it even reports a +9.4% *bytecode* gain for this interpreter-only change.
