### PR TITLE
perf(engine): elide unused arguments objects and speed typed-array element-set

### DIFF
--- a/source/units/Goccia.AST.Node.pas
+++ b/source/units/Goccia.AST.Node.pas
@@ -60,13 +60,19 @@ type
 // object (only relevant under --compat-arguments-object). The arguments object
 // is observable only through the identifier `arguments` or through direct
 // `eval`, and a function's source text spans its whole body — including any
-// nested arrow functions, which share the enclosing `arguments` — so a body
-// containing neither substring can never reference the object and the costly
-// allocation can be skipped. Substring matching over-approximates: a comment,
-// string literal, or longer identifier that merely contains "arguments"/"eval"
-// forces creation. That is always safe (it may keep a needless object but never
-// drops a needed one). Empty source (synthetic functions) is treated
-// conservatively as "may reference".
+// nested arrow functions, which share the enclosing `arguments`. A body that
+// references neither can skip the costly allocation.
+//
+// The scan must account for Unicode-escaped identifiers: the lexer decodes
+// escape sequences inside identifiers, so an escaped spelling of `arguments` or
+// `eval` references the object even though the decoded word never appears
+// literally in the raw source. Every IdentifierName escape is a \uXXXX /
+// \u{...} sequence, so the presence of \u anywhere forces creation. All three
+// substring checks
+// over-approximate (a comment, string literal, regex, or longer identifier that
+// merely contains "arguments"/"eval"/"\u" forces creation), which is always
+// safe: it may keep a needless object but never drops a needed one. Empty
+// source (synthetic functions) is treated conservatively as "may reference".
 function FunctionSourceMayReferenceArgumentsObject(
   const ASourceText: string): Boolean;
 
@@ -77,7 +83,8 @@ function FunctionSourceMayReferenceArgumentsObject(
 begin
   Result := (ASourceText = '') or
             (Pos('arguments', ASourceText) > 0) or
-            (Pos('eval', ASourceText) > 0);
+            (Pos('eval', ASourceText) > 0) or
+            (Pos('\u', ASourceText) > 0);
 end;
 
 constructor TGocciaASTNode.Create(const ALine, AColumn: Integer);

--- a/source/units/Goccia.AST.Node.pas
+++ b/source/units/Goccia.AST.Node.pas
@@ -55,7 +55,30 @@ type
     property HasTopLevelAwait: Boolean read FHasTopLevelAwait write FHasTopLevelAwait;
   end;
 
+// Conservative pre-scan shared by the interpreter and the bytecode compiler to
+// decide whether a non-arrow function must materialize an implicit arguments
+// object (only relevant under --compat-arguments-object). The arguments object
+// is observable only through the identifier `arguments` or through direct
+// `eval`, and a function's source text spans its whole body — including any
+// nested arrow functions, which share the enclosing `arguments` — so a body
+// containing neither substring can never reference the object and the costly
+// allocation can be skipped. Substring matching over-approximates: a comment,
+// string literal, or longer identifier that merely contains "arguments"/"eval"
+// forces creation. That is always safe (it may keep a needless object but never
+// drops a needed one). Empty source (synthetic functions) is treated
+// conservatively as "may reference".
+function FunctionSourceMayReferenceArgumentsObject(
+  const ASourceText: string): Boolean;
+
 implementation
+
+function FunctionSourceMayReferenceArgumentsObject(
+  const ASourceText: string): Boolean;
+begin
+  Result := (ASourceText = '') or
+            (Pos('arguments', ASourceText) > 0) or
+            (Pos('eval', ASourceText) > 0);
+end;
 
 constructor TGocciaASTNode.Create(const ALine, AColumn: Integer);
 begin

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -115,7 +115,8 @@ function ParameterListHasDefaultValues(
 function ParameterListIsSimple(const AParams: TGocciaParameterArray): Boolean;
 function SyntheticParamLocalName(const AIndex: Integer): string;
 function DeclareArgumentsObjectLocal(const ACtx: TGocciaCompilationContext;
-  const AScope: TGocciaCompilerScope; const AParams: TGocciaParameterArray): Integer;
+  const AScope: TGocciaCompilerScope; const AParams: TGocciaParameterArray;
+  const ASourceText: string): Integer;
 procedure EmitCreateArgumentsObject(const ACtx: TGocciaCompilationContext;
   const AArgumentsSlot: Integer; const AUseMappedArguments: Boolean;
   const AFormalParameterCount: Integer);
@@ -2384,12 +2385,19 @@ begin
 end;
 
 function DeclareArgumentsObjectLocal(const ACtx: TGocciaCompilationContext;
-  const AScope: TGocciaCompilerScope; const AParams: TGocciaParameterArray): Integer;
+  const AScope: TGocciaCompilerScope; const AParams: TGocciaParameterArray;
+  const ASourceText: string): Integer;
 begin
   if not ACtx.ArgumentsObjectEnabled then
     Exit(-1);
 
   if ParameterListBindsName(AParams, IDENTIFIER_ARGUMENTS) then
+    Exit(-1);
+
+  // Skip the arguments local (and the OP_CREATE_ARGUMENTS it would trigger)
+  // when the function body provably never references it; see
+  // FunctionSourceMayReferenceArgumentsObject.
+  if not FunctionSourceMayReferenceArgumentsObject(ASourceText) then
     Exit(-1);
 
   Result := AScope.DeclareVarLocal(IDENTIFIER_ARGUMENTS);
@@ -4488,7 +4496,8 @@ begin
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   ChildTemplate.ParameterCount := 0;
   SetLength(EmptyParams, 0);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams,
+    ChildTemplate.SourceText);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
   try
@@ -4571,7 +4580,8 @@ begin
   for I := 0 to High(SetterParams) do
     if SetterParams[I].IsPattern and Assigned(SetterParams[I].Pattern) then
       CollectDestructuringBindings(SetterParams[I].Pattern, ChildScope);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams,
+    ChildTemplate.SourceText);
   ApplyParameterTypeAnnotations(ChildScope, ChildTemplate, SetterParams,
     ACtx.StrictTypes);
 
@@ -4646,7 +4656,8 @@ begin
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   ChildTemplate.ParameterCount := 0;
   SetLength(EmptyParams, 0);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams,
+    ChildTemplate.SourceText);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
   try
@@ -4730,7 +4741,8 @@ begin
   for I := 0 to High(SetterParams) do
     if SetterParams[I].IsPattern and Assigned(SetterParams[I].Pattern) then
       CollectDestructuringBindings(SetterParams[I].Pattern, ChildScope);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams,
+    ChildTemplate.SourceText);
   ApplyParameterTypeAnnotations(ChildScope, ChildTemplate, SetterParams,
     ACtx.StrictTypes);
 
@@ -5423,7 +5435,8 @@ begin
     if AExpr.Parameters[I].IsPattern and Assigned(AExpr.Parameters[I].Pattern) then
       CollectDestructuringBindings(AExpr.Parameters[I].Pattern, ChildScope);
 
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AExpr.Parameters);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AExpr.Parameters,
+    ChildTemplate.SourceText);
 
   ApplyParameterTypeAnnotations(ChildScope, ChildTemplate, AExpr.Parameters,
     ACtx.StrictTypes);

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -4764,7 +4764,8 @@ begin
   for I := 0 to High(AMethod.Parameters) do
     if AMethod.Parameters[I].IsPattern and Assigned(AMethod.Parameters[I].Pattern) then
       CollectDestructuringBindings(AMethod.Parameters[I].Pattern, ChildScope);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AMethod.Parameters);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AMethod.Parameters,
+    ChildTemplate.SourceText);
   if FormalCount < 0 then
     FormalCount := Length(AMethod.Parameters);
   ChildTemplate.FormalParameterCount := UInt8(FormalCount);
@@ -4855,7 +4856,8 @@ begin
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   SetLength(EmptyParams, 0);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams,
+    ChildTemplate.SourceText);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
   ChildCtx := ACtx;
@@ -4948,7 +4950,8 @@ begin
   ChildTemplate.FormalParameterCount := UInt8(FormalCount);
   if Assigned(ACtx.FormalParameterCounts) then
     ACtx.FormalParameterCounts.AddOrSetValue(ChildTemplate, FormalCount);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams,
+    ChildTemplate.SourceText);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
   ChildCtx := ACtx;
@@ -5022,7 +5025,8 @@ begin
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   SetLength(EmptyParams, 0);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams,
+    ChildTemplate.SourceText);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
   ChildCtx := ACtx;
@@ -5110,7 +5114,8 @@ begin
   ChildTemplate.FormalParameterCount := UInt8(FormalCount);
   if Assigned(ACtx.FormalParameterCounts) then
     ACtx.FormalParameterCounts.AddOrSetValue(ChildTemplate, FormalCount);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, SetterParams,
+    ChildTemplate.SourceText);
 
   ACtx.SwapState(ChildTemplate, ChildScope);
   ChildCtx := ACtx;
@@ -5207,7 +5212,8 @@ begin
   for I := 0 to High(AMethod.Parameters) do
     if AMethod.Parameters[I].IsPattern and Assigned(AMethod.Parameters[I].Pattern) then
       CollectDestructuringBindings(AMethod.Parameters[I].Pattern, ChildScope);
-  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AMethod.Parameters);
+  ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AMethod.Parameters,
+    ChildTemplate.SourceText);
   if FormalCount < 0 then
     FormalCount := Length(AMethod.Parameters);
   ChildTemplate.FormalParameterCount := UInt8(FormalCount);

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -5021,6 +5021,10 @@ begin
 
   ChildTemplate := TGocciaFunctionTemplate.Create('<get [computed]>');
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  // Propagate the accessor source so DeclareArgumentsObjectLocal below can elide
+  // the arguments object when the body never references it, matching the other
+  // (non-computed) accessor and method body builders.
+  ChildTemplate.SourceText := AGetter.SourceText;
   ChildTemplate.ParameterCount := 0;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
@@ -5090,6 +5094,10 @@ begin
 
   ChildTemplate := TGocciaFunctionTemplate.Create('<set [computed]>');
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  // Propagate the accessor source so DeclareArgumentsObjectLocal below can elide
+  // the arguments object when the body never references it, matching the other
+  // (non-computed) accessor and method body builders.
+  ChildTemplate.SourceText := ASetter.SourceText;
   SetterParams := ASetter.Parameters;
   if Length(SetterParams) = 0 then
   begin

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -30,9 +30,14 @@ type
     FSourceText: string;
     FIsExpressionBody: Boolean;
     FIsSimpleParams: Boolean;
+    // Memoized arguments-object decision: 0 = not yet computed, 1 = may
+    // reference (create the object), 2 = provably unused (elide). Reset by
+    // SetSourceText so the lazy scan re-runs if the source span changes.
+    FArgumentsObjectState: Byte;
     function GetFunctionLength: Integer; override;
     function GetFunctionName: string; override;
     function GetSourceText: string; override;
+    procedure SetSourceText(const AValue: string);
     procedure BindThis(const ACallScope: TGocciaScope; const AThisValue: TGocciaValue); virtual;
     function CreateCallScope: TGocciaScope; virtual;
     function CreatesArgumentsObject: Boolean; virtual;
@@ -62,7 +67,7 @@ type
     property IsExpressionBody: Boolean read FIsExpressionBody write FIsExpressionBody;
     property SourceFilePath: string read FSourceFilePath write FSourceFilePath;
     property SourceLine: Integer read FSourceLine write FSourceLine;
-    property SourceText: string read FSourceText write FSourceText;
+    property SourceText: string read FSourceText write SetSourceText;
   end;
 
   TGocciaArrowFunctionValue = class(TGocciaFunctionValue)
@@ -376,9 +381,26 @@ begin
   Result := TGocciaCallScope.Create(FClosure, FName, Length(FParameters) + 2);
 end;
 
+procedure TGocciaFunctionValue.SetSourceText(const AValue: string);
+begin
+  FSourceText := AValue;
+  FArgumentsObjectState := 0;
+end;
+
 function TGocciaFunctionValue.CreatesArgumentsObject: Boolean;
 begin
-  Result := True;
+  // A non-arrow function only needs an implicit arguments object when its body
+  // can reference one. Decide once from the source span (memoized) so the
+  // ~per-call cost is a single byte test; see
+  // FunctionSourceMayReferenceArgumentsObject for why the scan is sound.
+  if FArgumentsObjectState = 0 then
+  begin
+    if FunctionSourceMayReferenceArgumentsObject(FSourceText) then
+      FArgumentsObjectState := 1
+    else
+      FArgumentsObjectState := 2;
+  end;
+  Result := FArgumentsObjectState = 1;
 end;
 
 function DestructuringPatternHasParameterExpression(

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -424,51 +424,37 @@ end;
 procedure TGocciaTypedArrayValue.WriteNumberLiteral(const AIndex: Integer; const ANum: TGocciaNumberLiteralValue);
 var
   Offset: Integer;
+  ToWrite: Double;
 begin
   if not HasValidElementIndex(AIndex) then
     Exit;
 
-  SyncBufferData;
-  if ANum.IsNaN then
-  begin
-    if IsFloatKind(FKind) then
-    begin
-      Offset := FByteOffset + AIndex * BytesPerElement(FKind);
-      WriteBinaryNumberElement(FBufferData, Offset, ToBinaryElementKind(FKind),
-        ANum.Value, TYPED_ARRAY_LITTLE_ENDIAN);
-    end
-    else
-      WriteElement(AIndex, 0);
-  end
+  // Map the coerced ToNumber result to the value SetValueInBuffer stores: float
+  // kinds keep the value (including NaN/+/-Infinity) verbatim, while integer
+  // kinds store 0 for any non-finite input, except Uint8Clamped which clamps
+  // +Infinity to 255. Selecting the value first lets the index validation, the
+  // backing-store sync, and the byte-offset computation run exactly once per
+  // store instead of being repeated by a nested WriteElement re-dispatch.
+  if IsFloatKind(FKind) then
+    ToWrite := ANum.Value
+  else if ANum.IsNaN then
+    ToWrite := 0
   else if ANum.IsInfinity then
   begin
-    case FKind of
-      takUint8Clamped: WriteElement(AIndex, 255);
-      takFloat16, takFloat32, takFloat64:
-      begin
-        Offset := FByteOffset + AIndex * BytesPerElement(FKind);
-        WriteBinaryNumberElement(FBufferData, Offset, ToBinaryElementKind(FKind),
-          ANum.Value, TYPED_ARRAY_LITTLE_ENDIAN);
-      end;
+    if FKind = takUint8Clamped then
+      ToWrite := 255
     else
-      WriteElement(AIndex, 0);
-    end;
+      ToWrite := 0;
   end
   else if ANum.IsNegativeInfinity then
-  begin
-    case FKind of
-      takFloat16, takFloat32, takFloat64:
-      begin
-        Offset := FByteOffset + AIndex * BytesPerElement(FKind);
-        WriteBinaryNumberElement(FBufferData, Offset, ToBinaryElementKind(FKind),
-          ANum.Value, TYPED_ARRAY_LITTLE_ENDIAN);
-      end;
-    else
-      WriteElement(AIndex, 0);
-    end;
-  end
+    ToWrite := 0
   else
-    WriteElement(AIndex, ANum.Value);
+    ToWrite := ANum.Value;
+
+  SyncBufferData;
+  Offset := FByteOffset + AIndex * BytesPerElement(FKind);
+  WriteBinaryNumberElement(FBufferData, Offset, ToBinaryElementKind(FKind),
+    ToWrite, TYPED_ARRAY_LITTLE_ENDIAN);
 end;
 
 function TGocciaTypedArrayValue.ReadBigIntElement(const AIndex: Integer): Int64;
@@ -552,12 +538,56 @@ begin
   Result := nil;
 end;
 
+// Hot path for CanonicalNumericIndexString: a non-negative integer string with
+// no leading zeros (e.g. "0", "1234") is canonical by construction, because
+// ToString(ToNumber(s)) reproduces s exactly. Up to 15 digits stays below 2^53,
+// so the Double is exact and Number::toString uses plain (non-exponential)
+// notation, guaranteeing the round-trip. Anything else (signs, leading zeros,
+// fractions, exponents, "-0", out-of-range) returns False and defers to the
+// allocation-heavy String->Number->String validation in the caller.
+function TryFastCanonicalIntegerIndex(const AName: string;
+  out ANumericIndex: Double): Boolean;
+var
+  Len, I: Integer;
+  Acc: Int64;
+  C: Char;
+begin
+  Len := Length(AName);
+  if (Len < 1) or (Len > 15) then
+    Exit(False);
+
+  C := AName[1];
+  if (C < '1') or (C > '9') then
+  begin
+    if (Len = 1) and (C = '0') then
+    begin
+      ANumericIndex := 0;
+      Exit(True);
+    end;
+    Exit(False);
+  end;
+
+  Acc := Ord(C) - Ord('0');
+  for I := 2 to Len do
+  begin
+    C := AName[I];
+    if (C < '0') or (C > '9') then
+      Exit(False);
+    Acc := Acc * 10 + (Ord(C) - Ord('0'));
+  end;
+
+  ANumericIndex := Acc;
+  Result := True;
+end;
+
 function TryCanonicalNumericIndexString(const AName: string;
   out ANumericIndex: Double; out AIsNegativeZero: Boolean): Boolean;
 var
   NumberValue: TGocciaNumberLiteralValue;
 begin
   AIsNegativeZero := False;
+  if TryFastCanonicalIntegerIndex(AName, ANumericIndex) then
+    Exit(True);
   if AName = '-0' then
   begin
     ANumericIndex := 0;

--- a/tests/language/arguments-explicit/arguments-elision.js
+++ b/tests/language/arguments-explicit/arguments-elision.js
@@ -1,0 +1,61 @@
+describe("implicit arguments object is materialized only when referenced", () => {
+  test("function that never names arguments still binds its parameters", () => {
+    function add(a, b) {
+      return a + b;
+    }
+
+    expect(add(3, 4)).toBe(7);
+  });
+
+  test("direct reference still sees every passed argument", () => {
+    function collect() {
+      return [arguments.length, arguments[0], arguments[2]];
+    }
+
+    expect(collect(10, 20, 30)).toEqual([3, 10, 30]);
+  });
+
+  test("reference only inside a nested arrow keeps the enclosing arguments", () => {
+    function viaArrow() {
+      const read = () => arguments.length + ":" + arguments[1];
+      return read();
+    }
+
+    expect(viaArrow("x", "y", "z")).toBe("3:y");
+  });
+
+  test("a nested non-arrow function has its own arguments", () => {
+    function outer() {
+      function inner() {
+        return inner.name + arguments.length;
+      }
+      return inner(1, 2, 3, 4);
+    }
+
+    expect(outer("ignored")).toBe("inner4");
+  });
+
+  test("arguments referenced after several statements is still available", () => {
+    function late(seed) {
+      let total = seed;
+      total += 1;
+      total += 2;
+      return total + arguments.length;
+    }
+
+    expect(late(100, "extra")).toBe(105);
+  });
+
+  test("elided and non-elided functions interleave correctly", () => {
+    function plain(a) {
+      return a * 2;
+    }
+    function counted() {
+      return arguments.length;
+    }
+
+    expect(plain(5)).toBe(10);
+    expect(counted(1, 2, 3)).toBe(3);
+    expect(plain(counted(9))).toBe(2);
+  });
+});

--- a/tests/language/arguments-explicit/arguments-elision.js
+++ b/tests/language/arguments-explicit/arguments-elision.js
@@ -58,4 +58,12 @@ describe("implicit arguments object is materialized only when referenced", () =>
     expect(counted(1, 2, 3)).toBe(3);
     expect(plain(counted(9))).toBe(2);
   });
+
+  test("a Unicode-escaped arguments identifier is still materialized", () => {
+    function viaEscape() {
+      return \u0061rguments.length;
+    }
+
+    expect(viaEscape("a", "b")).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the 10s-cap timeout of test262 `staging/sm/TypedArray/element-setting-converts-using-ToNumber.js` in **both** interpreter and bytecode modes. Profiling (not the obvious reading) showed the dominant cost was **not** the element-set `ToNumberLiteral` allocation — `ta[0]=17` allocates nothing yet was just as slow — but **per-call implicit `arguments`-object creation** under `--compat-arguments-object`. Every non-arrow call materialized an arguments object (indexed props + length + iterator) even when the body never referenced `arguments`; this test makes ~1.4M such calls across 20 TypedArray constructors.

- **Arguments-object elision** — new shared `FunctionSourceMayReferenceArgumentsObject` (`Goccia.AST.Node`). The interpreter (`TGocciaFunctionValue.CreatesArgumentsObject`, memoized) and the bytecode compiler (`DeclareArgumentsObjectLocal`) now skip the arguments object when the function source contains none of `arguments`, `eval`, or `\u` (the latter covers Unicode-escaped identifier spellings such as `\u0061rguments`, since the lexer decodes them). A function's source spans its whole body — including nested arrows, which share the enclosing `arguments` — so the scan has **no false negatives** (it can over-create but never wrongly elide).
- **Typed-array index-set fast path** — `TryFastCanonicalIntegerIndex` short-circuits the `String→Number→String` round-trip in `TryCanonicalNumericIndexString` for canonical non-negative integer indices. Behaviorally identical to the slow path by construction; benefits both element get and set.
- **Store-path dedup** — `WriteNumberLiteral` no longer re-dispatches through `WriteElement` (which re-validated the index and re-synced the backing store); it selects the value then does one sync + write. Zero behavior change.

Results on a production build (what CI/conformance use): **bytecode 9.8s → 4.2s, interpreter 14.3s → 8.6s** — both pass the runner's default 10s cap in both modes.

**Non-goals / notes:** Pure performance change; no spec/behavior change (the added test only guards the elision boundary). The interpreter has a thinner margin than bytecode; a *guaranteed* sub-10s interpreter on slower hardware would need interpreter-core work (e.g. `is`-check elimination, per-call arg-collection pooling) and is out of scope here. test262 is CI-gated bytecode-only at 20s, where this now has ~5× headroom.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation (prod build):
- Full JS suite **10944/10944 (100%)** in **both** interpreter and bytecode modes (includes the new `tests/language/arguments-explicit/arguments-elision.js`, 7/7 both modes, with an escaped-identifier guard case).
- test262 `built-ins/TypedArray`: **0 regressions** vs `origin/main`, and **+2 fixed** (the target test and `sort_large_countingsort.js`, another perf timeout); `built-ins/TypedArrayConstructors` 738/738; `language/arguments-object` 263/263.
- `./format.pas --check` clean; pre-commit hooks (incl. `check-trunc-guards`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
