### PR TITLE
perf(engine): make for-in key dedup O(k) with a hash set

### DIFF
--- a/benchmarks/for-in/for-in.js
+++ b/benchmarks/for-in/for-in.js
@@ -1,0 +1,49 @@
+/*---
+description: for...in enumeration and prototype-chain key dedup benchmarks
+---*/
+
+suite("for...in", () => {
+  // Build a `levels`-deep prototype chain where every level redeclares the
+  // same `width` keys (plus one unique key per level). for...in must dedup
+  // the shared keys down the chain, which stresses the key-dedup set.
+  const buildChain = (levels, width) => {
+    const sharedKeys = Array.from({ length: width }, (_, i) => "k" + i);
+    return Array.from({ length: levels }).reduce((proto, _unused, level) => {
+      const obj = Object.create(proto);
+      for (const key of sharedKeys) obj[key] = level;
+      obj["unique" + level] = level;
+      return obj;
+    }, null);
+  };
+
+  const flat50 = Array.from({ length: 50 }).reduce((obj, _unused, i) => {
+    obj["k" + i] = i;
+    return obj;
+  }, {});
+
+  bench("for...in over 50 own keys", {
+    run: () => {
+      let count = 0;
+      for (const key in flat50) count = count + 1;
+      return count;
+    },
+  });
+
+  bench("for...in over an 8-level chain of 50 shared keys", {
+    setup: () => buildChain(8, 50),
+    run: (obj) => {
+      let count = 0;
+      for (const key in obj) count = count + 1;
+      return count;
+    },
+  });
+
+  bench("for...in over a 16-level chain of 100 shared keys", {
+    setup: () => buildChain(16, 100),
+    run: (obj) => {
+      let count = 0;
+      for (const key in obj) count = count + 1;
+      return count;
+    },
+  });
+});

--- a/benchmarks/for-in/goccia.json
+++ b/benchmarks/for-in/goccia.json
@@ -1,0 +1,3 @@
+{
+  "compat-for-in-loop": true
+}

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -5408,7 +5408,7 @@ var
   Keys: TArray<string>;
   Key: string;
   KeyValue: TGocciaStringLiteralValue;
-  Visited: TStringList;
+  Visited: TOrderedStringMap<Boolean>;
   GC: TGarbageCollector;
   ChainDepth: Integer;
 begin
@@ -5424,9 +5424,11 @@ begin
     Obj := ToObject(AValue);
     if Assigned(GC) then
       GC.AddTempRoot(Obj);
-    Visited := TStringList.Create;
+    // Dedup keys across the prototype chain via O(1) hash-set membership
+    // (native case-sensitive string equality); OrderForInPropertyKeys
+    // (above) owns per-level enumeration order.
+    Visited := TOrderedStringMap<Boolean>.Create;
     try
-      Visited.CaseSensitive := True;
       Current := Obj;
       ChainDepth := 0;
       while Assigned(Current) do
@@ -5439,10 +5441,10 @@ begin
         Keys := OrderForInPropertyKeys(Current.GetAllPropertyNames);
         for Key in Keys do
         begin
-          if Visited.IndexOf(Key) >= 0 then
+          if Visited.ContainsKey(Key) then
             Continue;
 
-          Visited.Add(Key);
+          Visited.Add(Key, True);
           EntryObj := TGocciaObjectValue.Create;
           if Assigned(GC) then
             GC.AddTempRoot(EntryObj);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -469,6 +469,7 @@ uses
   SysUtils,
 
   BigInteger,
+  OrderedStringMap,
   TextSemantics,
   TimingUtils,
 
@@ -8425,7 +8426,7 @@ var
   Keys: TArray<string>;
   Key: string;
   KeyValue: TGocciaStringLiteralValue;
-  Visited: TStringList;
+  Visited: TOrderedStringMap<Boolean>;
   GC: TGarbageCollector;
   ChainDepth: Integer;
 begin
@@ -8441,9 +8442,11 @@ begin
     Obj := ToObject(AValue);
     if Assigned(GC) then
       GC.AddTempRoot(Obj);
-    Visited := TStringList.Create;
+    // Dedup keys across the prototype chain via O(1) hash-set membership
+    // (native case-sensitive string equality); VMOrderOwnPropertyStringKeys
+    // (above) owns per-level enumeration order.
+    Visited := TOrderedStringMap<Boolean>.Create;
     try
-      Visited.CaseSensitive := True;
       Current := Obj;
       ChainDepth := 0;
       while Assigned(Current) do
@@ -8456,10 +8459,10 @@ begin
         Keys := VMOrderOwnPropertyStringKeys(Current.GetAllPropertyNames);
         for Key in Keys do
         begin
-          if Visited.IndexOf(Key) >= 0 then
+          if Visited.ContainsKey(Key) then
             Continue;
 
-          Visited.Add(Key);
+          Visited.Add(Key, True);
           EntryObj := TGocciaObjectValue.Create;
           if Assigned(GC) then
             GC.AddTempRoot(EntryObj);

--- a/tests/language/for-in-loop/basic-enumeration.js
+++ b/tests/language/for-in-loop/basic-enumeration.js
@@ -198,6 +198,11 @@ test("dedups same-named keys across a deep prototype chain at scale", () => {
   // All shared keys plus one unique key per level, no duplicates.
   expect(seen.length).toBe(SHARED + LEVELS);
 
+  // The inherited level-unique keys follow, ordered nearest (leaf) to
+  // farthest — one per level, guarding against prototype-level reordering.
+  const expectedUnique = Array.from({ length: LEVELS }, (_, i) => "unique" + (LEVELS - 1 - i));
+  expect(seen.slice(SHARED)).toEqual(expectedUnique);
+
   // Shared keys resolve to the leaf level's value.
   expect(leaf.k0).toBe(LEVELS - 1);
 });

--- a/tests/language/for-in-loop/basic-enumeration.js
+++ b/tests/language/for-in-loop/basic-enumeration.js
@@ -151,3 +151,53 @@ test("deleted own shadow does not expose inherited property", () => {
 
   expect(keys).toEqual(["a"]);
 });
+
+test("enumerable own key shadowing a same-named inherited key is yielded once", () => {
+  const proto = { shared: "proto", onlyProto: 1 };
+  const obj = Object.create(proto);
+  obj.shared = "own";
+  obj.onlyOwn = 2;
+
+  const keys = [];
+  for (const key in obj) keys.push(key);
+
+  // "shared" appears once, in its own (nearer) position; never re-yielded
+  // from the prototype.
+  expect(keys).toEqual(["shared", "onlyOwn", "onlyProto"]);
+});
+
+test("dedups same-named keys across a deep prototype chain at scale", () => {
+  // Build a 12-level chain where every level redeclares the same 40 keys,
+  // plus one level-unique key. Each shared key must be yielded exactly once
+  // (from the nearest level); per-level order is preserved.
+  const LEVELS = 12;
+  const SHARED = 40;
+  const sharedKeys = Array.from({ length: SHARED }, (_, i) => "k" + i);
+
+  const leaf = Array.from({ length: LEVELS }).reduce((proto, _unused, level) => {
+    const obj = Object.create(proto);
+    for (const key of sharedKeys) obj[key] = level;
+    obj["unique" + level] = level;
+    return obj;
+  }, null);
+
+  const seen = [];
+  const counts = {};
+  for (const key in leaf) {
+    seen.push(key);
+    counts[key] = (counts[key] || 0) + 1;
+  }
+
+  // Every key yielded exactly once.
+  for (const key of seen) expect(counts[key]).toBe(1);
+
+  // The nearest (leaf) level owns the shared keys, in their declared order,
+  // before any inherited level-unique keys.
+  expect(seen.slice(0, SHARED)).toEqual(sharedKeys);
+
+  // All shared keys plus one unique key per level, no duplicates.
+  expect(seen.length).toBe(SHARED + LEVELS);
+
+  // Shared keys resolve to the leaf level's value.
+  expect(leaf.k0).toBe(LEVELS - 1);
+});


### PR DESCRIPTION
## Summary

- `for...in` deduplicated keys across the prototype chain with `TStringList.IndexOf` on an **unsorted** list — an O(k) linear scan run once per key, making a full enumeration **O(k²)** in the total (own + inherited) enumerable key count `k`.
- Replaces the `TStringList` with a `TOrderedStringMap<Boolean>` hash set (`ContainsKey` + `Add`), the established string-set idiom in the codebase (cf. `Goccia.Modules.Loader.pas`). Dedup is now **O(k)**.
- **Both execution engines** are fixed: `CreateForInEntriesArray` (tree-walking interpreter, `source/units/Goccia.Evaluator.pas`) and the near-identical `ForInEntriesArray` (bytecode VM, `source/units/Goccia.VM.pas`). The issue text named only the interpreter site, but the same root cause exists in the VM and `for...in` runs through it in `--mode=bytecode`; fixing both was confirmed in scoping.
- **Behavior is identical** (membership-only change): membership stays case-sensitive (native string equality, matching the old `CaseSensitive := True`), and per-level enumeration order is unchanged — `OrderForInPropertyKeys` / `VMOrderOwnPropertyStringKeys` still own ordering; the `Visited` set never influenced output order (that comes from `Result.Elements.Add`).
- **Non-goals:** no `for...in` semantic changes; no cross-unit refactor of the two duplicated functions (kept tight to the perf fix); the `OrderForInPropertyKeys` insertion sort is untouched.

Closes #809

### Deferred follow-up (out of scope)

While testing I found a **pre-existing, unrelated** diagnostic bug: a disabled traditional `for(;;)` loop (requires `--compat-traditional-for-loop`) whose body contains an *interpolated* template literal reports a misleading `"Unterminated template literal"` at EOF instead of the correct "enable `--compat-traditional-for-loop`" suggestion. Flagged separately; not addressed here.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation — n/a (internal perf optimization, no user-facing behavior or language-surface change)
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — behavior is fully covered by the two-mode JS suite below; `TOrderedStringMap` has its own unit tests
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Commands run (all green):

- `./build.pas testrunner` → `./build/GocciaTestRunner tests` — **10,958/10,958 passed** (tree-walking)
- `./build/GocciaTestRunner tests --mode=bytecode` — **10,958/10,958 passed** (bytecode VM)
- `tests/language/for-in-loop` — **35/35** both modes (+2 new regression tests: same-name enumerable shadowing, and dedup + ordering across a 12-level / 40-shared-key prototype chain)
- `./format.pas --check` — 370 files, all formatted correctly
- `./build/GocciaBenchmarkRunner benchmarks` (whole-dir, **no** CLI flag, as CI runs it) — new `for...in` benchmark runs cleanly; its `--compat-for-in-loop` is picked up from the scoped `benchmarks/for-in/goccia.json` via per-file config discovery, so the benchmark lane stays green. Exit 0.