### PR TITLE
fix(parser): skip interpolated templates in disabled-feature recovery

### DIFF
--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -178,19 +178,22 @@ console.log("Unsupported var recovery (ASI and compat-var flags)...");
   if (compatVarNoAsiRes.json.error?.type !== "SyntaxError") throw new Error(`Expected SyntaxError without ASI, got: ${compatVarNoAsiRes.json.error?.type}`);
 }
 
-// -- Disabled traditional for-loop with interpolated template literal -----------
-// Regression: error recovery for a disabled `for (;;)` loop must skip a
-// `${ ... }` substitution as part of its template literal. Previously the
-// substitution's closing brace was miscounted as the structural brace that ends
-// the skipped region, and the trailing backtick was then re-scanned as a fresh,
-// unterminated template literal -- surfacing "Unterminated template literal" at
-// EOF instead of the real "enable --compat-traditional-for-loop" diagnostic.
+// -- Disabled-feature recovery with interpolated template literals --------------
+// Regression: error recovery for a disabled construct must skip a `${ ... }`
+// substitution as part of its template literal. Previously the substitution's
+// closing brace was miscounted as the structural brace that ends the skipped
+// region, and the trailing backtick was then re-scanned as a fresh, unterminated
+// template literal -- surfacing "Unterminated template literal" at EOF instead of
+// the real compat-flag diagnostic. The for, while, and do...while recovery paths
+// all share the SkipBalancedParens/SkipBlock/SkipUntilSemicolon + SkipTemplate-
+// Literal flow, so each is covered here.
 
-console.log("Disabled traditional for-loop with interpolated template literal...");
+console.log("Disabled-feature recovery with interpolated template literals...");
 {
   const recoveryCases = [
     {
-      desc: "interpolated template in block body",
+      desc: "for-loop, interpolated template in block body",
+      compatFlag: "--compat-traditional-for-loop",
       source: [
         "const obj = {};",
         "for (let level = 0; level < 2; level++) {",
@@ -202,7 +205,8 @@ console.log("Disabled traditional for-loop with interpolated template literal...
       expected: "{}\n",
     },
     {
-      desc: "interpolated template in non-block body",
+      desc: "for-loop, interpolated template in non-block body",
+      compatFlag: "--compat-traditional-for-loop",
       source: [
         "const obj = {};",
         "for (let i = 0; i < 2; i++) obj[`u${i}`] = i;",
@@ -212,7 +216,8 @@ console.log("Disabled traditional for-loop with interpolated template literal...
       expected: "after\n",
     },
     {
-      desc: "interpolated template in loop header",
+      desc: "for-loop, interpolated template in loop header",
+      compatFlag: "--compat-traditional-for-loop",
       source: [
         "let x = 1;",
         "for (let i = `s${0}`.length; i < 2; i++) { x = 99; }",
@@ -221,16 +226,38 @@ console.log("Disabled traditional for-loop with interpolated template literal...
       ].join("\n"),
       expected: "1\n",
     },
+    {
+      desc: "while-loop, interpolated template in condition",
+      compatFlag: "--compat-while-loops",
+      source: [
+        "let n = 0;",
+        "while (`v${n}`.length > 99) { n = 99; }",
+        'console.log("while-after");',
+        "",
+      ].join("\n"),
+      expected: "while-after\n",
+    },
+    {
+      desc: "do...while loop, interpolated template in body",
+      compatFlag: "--compat-while-loops",
+      source: [
+        "let n = 0;",
+        "do { const s = `d${n}`; } while (n > 99);",
+        'console.log("do-after");',
+        "",
+      ].join("\n"),
+      expected: "do-after\n",
+    },
   ];
 
-  for (const { desc, source, expected } of recoveryCases) {
+  for (const { desc, compatFlag, source, expected } of recoveryCases) {
     for (const args of [[] as string[], ["--mode=bytecode"]]) {
       const label = args.length ? `${desc} (bytecode)` : desc;
       const { exitCode, json } = runLoaderJson(source, args);
       if (json.ok !== true) {
         if (json.error?.message === "Unterminated template literal")
           throw new Error(
-            `${label}: regressed -- a disabled traditional for-loop with a template literal surfaced "Unterminated template literal" instead of recovering`,
+            `${label}: regressed -- a disabled construct with a template literal surfaced "Unterminated template literal" instead of recovering`,
           );
         throw new Error(`${label}: should recover, got ok=${json.ok} error=${JSON.stringify(json.error)}`);
       }
@@ -238,20 +265,20 @@ console.log("Disabled traditional for-loop with interpolated template literal...
       if (normalizeLineEndings(json.output) !== expected)
         throw new Error(`${label}: expected output ${JSON.stringify(expected)}, got ${JSON.stringify(json.output)}`);
     }
-  }
 
-  // The human-readable diagnostic must name the compat flag, not the lexer's
-  // unterminated-template error.
-  const diag = Bun.spawnSync([LOADER], {
-    stdin: new TextEncoder().encode(recoveryCases[0].source),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const diagOut = `${diag.stdout.toString()}${diag.stderr.toString()}`;
-  if (!diagOut.includes("--compat-traditional-for-loop"))
-    throw new Error(`Expected the diagnostic to reference --compat-traditional-for-loop, got: ${diagOut}`);
-  if (diagOut.includes("Unterminated template literal"))
-    throw new Error(`Diagnostic should not mention an unterminated template literal, got: ${diagOut}`);
+    // The human-readable diagnostic must name the compat flag, not the lexer's
+    // unterminated-template error. Parsing is shared across modes, so check once.
+    const diag = Bun.spawnSync([LOADER], {
+      stdin: new TextEncoder().encode(source),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const diagOut = `${diag.stdout.toString()}${diag.stderr.toString()}`;
+    if (!diagOut.includes(compatFlag))
+      throw new Error(`${desc}: expected the diagnostic to reference ${compatFlag}, got: ${diagOut}`);
+    if (diagOut.includes("Unterminated template literal"))
+      throw new Error(`${desc}: diagnostic should not mention an unterminated template literal, got: ${diagOut}`);
+  }
 }
 
 console.log("\nAll test-cli-parser.ts tests passed.");

--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -178,4 +178,80 @@ console.log("Unsupported var recovery (ASI and compat-var flags)...");
   if (compatVarNoAsiRes.json.error?.type !== "SyntaxError") throw new Error(`Expected SyntaxError without ASI, got: ${compatVarNoAsiRes.json.error?.type}`);
 }
 
+// -- Disabled traditional for-loop with interpolated template literal -----------
+// Regression: error recovery for a disabled `for (;;)` loop must skip a
+// `${ ... }` substitution as part of its template literal. Previously the
+// substitution's closing brace was miscounted as the structural brace that ends
+// the skipped region, and the trailing backtick was then re-scanned as a fresh,
+// unterminated template literal -- surfacing "Unterminated template literal" at
+// EOF instead of the real "enable --compat-traditional-for-loop" diagnostic.
+
+console.log("Disabled traditional for-loop with interpolated template literal...");
+{
+  const recoveryCases = [
+    {
+      desc: "interpolated template in block body",
+      source: [
+        "const obj = {};",
+        "for (let level = 0; level < 2; level++) {",
+        "  obj[`u${level}`] = level;",
+        "}",
+        "console.log(JSON.stringify(obj));",
+        "",
+      ].join("\n"),
+      expected: "{}\n",
+    },
+    {
+      desc: "interpolated template in non-block body",
+      source: [
+        "const obj = {};",
+        "for (let i = 0; i < 2; i++) obj[`u${i}`] = i;",
+        'console.log("after");',
+        "",
+      ].join("\n"),
+      expected: "after\n",
+    },
+    {
+      desc: "interpolated template in loop header",
+      source: [
+        "let x = 1;",
+        "for (let i = `s${0}`.length; i < 2; i++) { x = 99; }",
+        "console.log(x);",
+        "",
+      ].join("\n"),
+      expected: "1\n",
+    },
+  ];
+
+  for (const { desc, source, expected } of recoveryCases) {
+    for (const args of [[] as string[], ["--mode=bytecode"]]) {
+      const label = args.length ? `${desc} (bytecode)` : desc;
+      const { exitCode, json } = runLoaderJson(source, args);
+      if (json.ok !== true) {
+        if (json.error?.message === "Unterminated template literal")
+          throw new Error(
+            `${label}: regressed -- a disabled traditional for-loop with a template literal surfaced "Unterminated template literal" instead of recovering`,
+          );
+        throw new Error(`${label}: should recover, got ok=${json.ok} error=${JSON.stringify(json.error)}`);
+      }
+      if (exitCode !== 0) throw new Error(`${label}: should exit 0, got ${exitCode}`);
+      if (normalizeLineEndings(json.output) !== expected)
+        throw new Error(`${label}: expected output ${JSON.stringify(expected)}, got ${JSON.stringify(json.output)}`);
+    }
+  }
+
+  // The human-readable diagnostic must name the compat flag, not the lexer's
+  // unterminated-template error.
+  const diag = Bun.spawnSync([LOADER], {
+    stdin: new TextEncoder().encode(recoveryCases[0].source),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const diagOut = `${diag.stdout.toString()}${diag.stderr.toString()}`;
+  if (!diagOut.includes("--compat-traditional-for-loop"))
+    throw new Error(`Expected the diagnostic to reference --compat-traditional-for-loop, got: ${diagOut}`);
+  if (diagOut.includes("Unterminated template literal"))
+    throw new Error(`Diagnostic should not mention an unterminated template literal, got: ${diagOut}`);
+}
+
 console.log("\nAll test-cli-parser.ts tests passed.");

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -232,6 +232,7 @@ type
     procedure SkipBlock;
     procedure SkipBalancedParens;
     procedure SkipStatementOrBlock;
+    procedure SkipTemplateLiteral;
     procedure SkipUnsupportedFunctionSignature;
     // Centralized 'async function' check: enforces same-line constraint,
     // handles disabled-mode fallback.  Call after consuming the 'async' token.
@@ -4723,6 +4724,58 @@ begin
     Line, Column);
 end;
 
+// Skips a complete template literal whose leading token (gttTemplate or
+// gttTemplateHead) is at the cursor, leaving the cursor just past the closing
+// backtick.  The error-recovery skips below (SkipBlock, SkipBalancedParens,
+// SkipUntilSemicolon) must route templates through here: the '}' that closes a
+// '${ ... }' substitution is lexed as a plain gttRightBrace under the default
+// goal, so naive brace/paren counting would miscount it as a structural brace,
+// stop early, and then re-scan the trailing span as a fresh, unterminated
+// template literal.  After consuming that '}', the continuation span must be
+// re-lexed with the template-tail goal, exactly as ParseTemplateLiteral does.
+procedure TGocciaParser.SkipTemplateLiteral;
+var
+  Depth: Integer;
+begin
+  // A template with no substitutions is a single token.
+  if Check(gttTemplate) then
+  begin
+    Advance;
+    Exit;
+  end;
+
+  Advance; // gttTemplateHead: `...${
+  repeat
+    // Skip the substitution expression up to the '}' that closes it, treating
+    // nested templates as units and balancing any inner object/block braces.
+    Depth := 0;
+    while not IsAtEnd do
+    begin
+      if Check(gttTemplateHead) or Check(gttTemplate) then
+        SkipTemplateLiteral
+      else if Check(gttLeftBrace) then
+      begin
+        Inc(Depth);
+        Advance;
+      end
+      else if Check(gttRightBrace) then
+      begin
+        if Depth = 0 then
+          Break;
+        Dec(Depth);
+        Advance;
+      end
+      else
+        Advance;
+    end;
+    if IsAtEnd then
+      Exit;
+    Advance; // gttRightBrace closing the substitution
+    // Re-lex the following span with the template-tail goal so it becomes a
+    // TemplateMiddle/TemplateTail token instead of a stray template start.
+  until ConsumeTemplateContinuation.TokenType = gttTemplateTail;
+end;
+
 procedure TGocciaParser.SkipBlock;
 var
   Depth: Integer;
@@ -4732,9 +4785,14 @@ begin
   Depth := 1;
   while not IsAtEnd and (Depth > 0) do
   begin
-    if Check(gttLeftBrace) then Inc(Depth)
-    else if Check(gttRightBrace) then Dec(Depth);
-    if Depth > 0 then Advance;
+    if Check(gttTemplateHead) or Check(gttTemplate) then
+      SkipTemplateLiteral
+    else
+    begin
+      if Check(gttLeftBrace) then Inc(Depth)
+      else if Check(gttRightBrace) then Dec(Depth);
+      if Depth > 0 then Advance;
+    end;
   end;
   Consume(gttRightBrace, 'Expected "}"',
     SSuggestCloseBlock);
@@ -4749,9 +4807,14 @@ begin
   Depth := 1;
   while not IsAtEnd and (Depth > 0) do
   begin
-    if Check(gttLeftParen) then Inc(Depth)
-    else if Check(gttRightParen) then Dec(Depth);
-    if Depth > 0 then Advance;
+    if Check(gttTemplateHead) or Check(gttTemplate) then
+      SkipTemplateLiteral
+    else
+    begin
+      if Check(gttLeftParen) then Inc(Depth)
+      else if Check(gttRightParen) then Dec(Depth);
+      if Depth > 0 then Advance;
+    end;
   end;
   Consume(gttRightParen, 'Expected ")"',
     SSuggestCloseParenExpression);
@@ -7609,6 +7672,14 @@ begin
     if (Depth = 0) and FAutomaticSemicolonInsertion and
       (Previous.Line < Peek.Line) then
       Exit;
+
+    // Skip template literals whole so a substitution's closing '}' is not
+    // miscounted as a structural brace (see SkipTemplateLiteral).
+    if Check(gttTemplateHead) or Check(gttTemplate) then
+    begin
+      SkipTemplateLiteral;
+      Continue;
+    end;
 
     case Peek.TokenType of
       gttLeftParen, gttLeftBracket, gttLeftBrace, gttLess: Inc(Depth);

--- a/tests/language/statements/unsupported-features.js
+++ b/tests/language/statements/unsupported-features.js
@@ -43,6 +43,32 @@ describe.runIf(hasGoccia)("unsupported features are skipped", () => {
     expect(x).toBe(1);
   });
 
+  test("for loop with interpolated template literal in block body is skipped", () => {
+    const obj = {};
+    for (let level = 0; level < 2; level++) {
+      obj[`u${level}`] = level;
+    }
+    expect(Object.keys(obj).length).toBe(0);
+  });
+
+  test("for loop with interpolated template literal in non-block body is skipped", () => {
+    const obj = {};
+    for (let i = 0; i < 2; i++) obj[`u${i}`] = i;
+    expect(Object.keys(obj).length).toBe(0);
+  });
+
+  test("for loop with interpolated template literal in its header is skipped", () => {
+    let x = 1;
+    for (let i = `s${0}`.length; i < 2; i++) { x = 99; }
+    expect(x).toBe(1);
+  });
+
+  test("for loop with nested interpolated template literals is skipped", () => {
+    const parts = [];
+    for (let i = 0; i < 2; i++) { parts.push(`a${`b${i}c`}d`); }
+    expect(parts.length).toBe(0);
+  });
+
   test("code after skipped while loop executes", () => {
     let x = 1;
     while (x < 10) { x = 99; }


### PR DESCRIPTION
## Summary

- A disabled traditional `for (;;)` loop containing an **interpolated** template literal (e.g. `` obj[`u${level}`] = level; ``) reported a misleading `SyntaxError: Unterminated template literal` at EOF instead of the real "enable `--compat-traditional-for-loop`" diagnostic at the `for` keyword.
- Root cause is in the parser's error-recovery token-skipping. When a disabled feature is rejected, the parser skips its header and body via `SkipBalancedParens` / `SkipBlock` / `SkipUntilSemicolon`. These counted braces naively, but the `}` that closes a `${ … }` substitution is lexed as a plain `RightBrace` under the default goal (the `TemplateMiddle`/`TemplateTail` span is only produced when the lexer runs with the template-tail goal *after* that `}`). The skip miscounted the substitution's `}` as the structural brace ending the region, stopped early, and the trailing backtick was re-scanned as a fresh, unterminated template literal running to EOF.
- Fix: add a shared `SkipTemplateLiteral` helper that skips a complete template literal as a unit — recursing through nested substitutions/templates, balancing inner object/block braces, and re-lexing each continuation span with the template-tail goal (mirroring `ParseTemplateLiteral`). Route the three recovery skips through it.
- This is the correct scope: the same root cause affected the whole class of disabled-feature recovery skips. Verified fixed for the for-loop block body, non-block body, header, nested templates, object literals inside `${}`, and the sibling `while` / `do-while` constructs, while the enabled `--compat-traditional-for-loop` path still parses and executes templates correctly.
- Non-goal: this does not change the recovery design (disabled constructs remain non-fatal warnings parsed as no-ops); it only makes the token skip template-aware.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Added tests (both verified **red** without the parser change):

- `tests/language/statements/unsupported-features.js` — a disabled for-loop with an interpolated template (block body, non-block body, header, nested) is skipped as a clean no-op and subsequent code runs.
- `scripts/test-cli-parser.ts` — recovery succeeds in interpreter **and** bytecode mode, never regresses to `Unterminated template literal`, and the human-readable diagnostic references `--compat-traditional-for-loop`.

Verification run:

| Check | Result |
|---|---|
| Full JS suite (interpreter) | 10960 passed, 0 failed |
| Full JS suite (bytecode) | 10960 passed, 0 failed |
| `bun scripts/test-cli-parser.ts` | All passed |
| `./format.pas --check` | 370 files, all formatted correctly |
| Without the fix (stashed) | File fails with `SyntaxError: Unterminated template literal` (0 passed / 1 failed) — confirms a genuine regression test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)