### PR TITLE
perf(engine): trim Date shim slot fan-out and binary-search timezone lookup

### DIFF
--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -438,7 +438,7 @@ const
         'const __GocciaDateIsObject = (value: any): boolean =>'#10 +
         '  (typeof value === "object" && value !== null) || typeof value === "function";'#10 +
         'const __GocciaDateHasSlot = (date: any): boolean =>'#10 +
-        '  __GocciaDateIsObject(date) && __GocciaDateSlots.has(date);'#10 +
+        '  __GocciaDateSlots.get(date) !== undefined;'#10 +
         'const __GocciaDateOrdinaryToPrimitive = (object: any, hint: string): any => {'#10 +
         '  const first: string = hint === "string" ? "toString" : "valueOf";'#10 +
         '  const second: string = hint === "string" ? "valueOf" : "toString";'#10 +
@@ -480,6 +480,7 @@ const
         '    (year < 0 ? "-" : "+") + __GocciaDatePad(year, 6);'#10 +
         'const __GocciaDateOffsetString = (offset: string): string => offset.replace(":", "");'#10 +
         'const __GocciaDateFromSingleArgument = (value: any): number => {'#10 +
+        '  if (typeof value === "number") return __GocciaDateTimeClip(value);'#10 +
         '  if (__GocciaDateHasSlot(value)) return __GocciaDateGetSlot(value);'#10 +
         '  const primitive: any = __GocciaDateToPrimitive(value);'#10 +
         '  return typeof primitive === "string" ? parseDateStringToEpoch(primitive) : __GocciaDateTimeClip(primitive);'#10 +
@@ -494,12 +495,16 @@ const
         '  } catch (e) {}'#10 +
         '  return __GocciaDateClass.prototype;'#10 +
         '};'#10 +
+        '// A Date slot only ever stores a number (never undefined), so a missing'#10 +
+        '// entry reads back as undefined and doubles as the brand check. This keeps'#10 +
+        '// the hot accessors to a single WeakMap lookup instead of has()+get().'#10 +
         'const __GocciaDateRequire = (date: any): void => {'#10 +
-        '  if (!__GocciaDateHasSlot(date)) throw new TypeError("Date object expected");'#10 +
+        '  if (__GocciaDateSlots.get(date) === undefined) throw new TypeError("Date object expected");'#10 +
         '};'#10 +
         'const __GocciaDateGetSlot = (date: any): number => {'#10 +
-        '  __GocciaDateRequire(date);'#10 +
-        '  return __GocciaDateSlots.get(date);'#10 +
+        '  const value: any = __GocciaDateSlots.get(date);'#10 +
+        '  if (value === undefined) throw new TypeError("Date object expected");'#10 +
+        '  return value;'#10 +
         '};'#10 +
         'const __GocciaDateSetSlot = (date: any, value: number): number => {'#10 +
         '  __GocciaDateSlots.set(date, value);'#10 +
@@ -557,8 +562,8 @@ const
         '  static #get(date: any): number { return __GocciaDateGetSlot(date); }'#10 +
         '  static #set(date: any, value: number): number { return __GocciaDateSetSlot(date, value); }'#10 +
         '  static #valid(date: any): boolean { return Number.isFinite(Date.#get(date)); }'#10 +
-        '  static #local(date: any): any { return Date.#valid(date) ? new Temporal.ZonedDateTime(BigInt(Date.#get(date)) * 1000000n, Temporal.Now.timeZoneId()) : null; }'#10 +
-        '  static #utc(date: any): any { return Date.#valid(date) ? new Temporal.ZonedDateTime(BigInt(Date.#get(date)) * 1000000n, "UTC") : null; }'#10 +
+        '  static #local(date: any): any { const ms: number = Date.#get(date); return Number.isFinite(ms) ? new Temporal.ZonedDateTime(BigInt(ms) * 1000000n, Temporal.Now.timeZoneId()) : null; }'#10 +
+        '  static #utc(date: any): any { const ms: number = Date.#get(date); return Number.isFinite(ms) ? new Temporal.ZonedDateTime(BigInt(ms) * 1000000n, "UTC") : null; }'#10 +
         '  getTime(): number { return __GocciaDateGetSlot(this); }'#10 +
         '  valueOf(): number { return __GocciaDateGetSlot(this); }'#10 +
         '  [Symbol.toPrimitive](hint: string): any {'#10 +

--- a/source/units/Goccia.Temporal.TimeZone.pas
+++ b/source/units/Goccia.Temporal.TimeZone.pas
@@ -1093,12 +1093,26 @@ end;
 function IsSupportedCanonicalTimeZoneIdentifier(const ATimeZone: string): Boolean;
 var
   AvailableTimeZones: TTemporalTimeZoneIdentifierArray;
-  Index: Integer;
+  Low, High, Mid, Cmp: Integer;
 begin
+  // GetAvailablePrimaryTimeZoneIdentifiers returns a list sorted ascending by
+  // CompareStr (see SortTimeZoneIdentifiers). Probe it with a binary search
+  // instead of an O(n) scan: this runs on every ZonedDateTime time-zone
+  // canonicalization, and the available-zone list has several hundred entries.
   AvailableTimeZones := GetAvailablePrimaryTimeZoneIdentifiers;
-  for Index := 0 to Length(AvailableTimeZones) - 1 do
-    if AvailableTimeZones[Index] = ATimeZone then
-      Exit(True);
+  Low := 0;
+  High := Length(AvailableTimeZones) - 1;
+  while Low <= High do
+  begin
+    Mid := Low + (High - Low) div 2;
+    Cmp := CompareStr(AvailableTimeZones[Mid], ATimeZone);
+    if Cmp = 0 then
+      Exit(True)
+    else if Cmp < 0 then
+      Low := Mid + 1
+    else
+      High := Mid - 1;
+  end;
 
   Result := False;
 end;

--- a/tests/built-ins/Date/methods.js
+++ b/tests/built-ins/Date/methods.js
@@ -250,6 +250,34 @@ describe("Date methods", () => {
     }
   });
 
+  test("slot-requiring methods reject a plain non-Date object receiver", () => {
+    const slotMethods = [
+      "getTime",
+      "valueOf",
+      "getFullYear",
+      "getUTCFullYear",
+      "getTimezoneOffset",
+      "setTime",
+      "setFullYear",
+      "toISOString",
+      "toString",
+    ];
+
+    for (const method of slotMethods) {
+      const fn = Date.prototype[method];
+      expect(() => fn.call({})).toThrow(TypeError);
+      expect(() => fn.call(Object.create(Date.prototype))).toThrow(TypeError);
+    }
+  });
+
+  test("constructor reads the time value from a Date argument and clips numbers", () => {
+    const source = new Date(1718451045123);
+    expect(new Date(source).getTime()).toBe(1718451045123);
+    expect(new Date(2000).getTime()).toBe(2000);
+    expect(Number.isNaN(new Date(NaN).getTime())).toBe(true);
+    expect(Number.isNaN(new Date(NaN).getTimezoneOffset())).toBe(true);
+  });
+
   test("toJSON remains generic for object receivers", () => {
     const receiver = {
       valueOf() { return 1; },

--- a/tests/built-ins/Temporal/ZonedDateTime/constructor.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/constructor.js
@@ -24,6 +24,21 @@ describe.runIf(isTemporal)("Temporal.ZonedDateTime constructor", () => {
     expect(zdt.calendarId).toBe("iso8601");
   });
 
+  test("canonical named time zones are accepted and preserved", () => {
+    const zones = [
+      "Africa/Cairo",
+      "America/Los_Angeles",
+      "Asia/Tokyo",
+      "Europe/London",
+      "Pacific/Auckland",
+      "UTC",
+    ];
+    for (const id of zones) {
+      expect(new Temporal.ZonedDateTime(0n, id).timeZoneId).toBe(id);
+    }
+    expect(() => new Temporal.ZonedDateTime(0n, "Not/AZone")).toThrow(RangeError);
+  });
+
   test("constructor stores non-ISO calendarId", () => {
     const zdt = new Temporal.ZonedDateTime(0n, "Europe/Madrid", "gregory");
     expect(zdt.calendarId).toBe("gregory");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- **RCA first.** Issue #829 hypothesised the `staging/sm/Date/dst-offset-caching-*-of-8.js` timeouts came from uncached DST-offset recomputation in `Goccia.Temporal.TimeZone.pas`. Profiling (macOS `sample`, prod bytecode build, pinned test262 SHA) **refuted** that: `GetUtcOffsetSeconds` / `GetSystemTimeZoneId` / `BinarySearchTransitions` appear in **0** of ~9,800 samples, and on a UTC host (GitHub runners) the offset path short-circuits to 0 entirely. The test is the SpiderMonkey SunSpider DST-cache stress test — a 4-deep nested loop doing ~3M `new Date(NaN); setTime; getTimezoneOffset` per shard — so the cost is the JS `Date` shim's per-call machinery, not the offset code. Per maintainer direction: fix the genuinely-ineffective machinery, keep `Date` in JS (hard line), no plaster.
- **Date shim slot fan-out (`source/units/Goccia.Shims.pas`).** The `[[DateValue]]` stays in a WeakMap — the only non-observable slot store (a private field isn't viable: the exported `Date` is a function constructor so instances aren't class-private-bearing, and a symbol key would leak via `getOwnPropertySymbols`). Collapsed the helper fan-out: hot accessors now do a single `WeakMap.get` with `=== undefined` as the brand check (a slot is always a number, never `undefined`), plus a numeric fast-path in `__GocciaDateFromSingleArgument` and a single-read `#local`/`#utc`. **~1.52×** on the test's exact inner call (`new Date(NaN); setTime; getTimezoneOffset`: 114.0 → 74.7 µs/call; rigorous `git stash` A/B with an identical `m1` normalizer).
- **Timezone canonicalization (`source/units/Goccia.Temporal.TimeZone.pas`).** `IsSupportedCanonicalTimeZoneIdentifier` linearly scanned the ~446-entry available-zone list on **every** ZonedDateTime time-zone canonicalization. The list is already `CompareStr`-sorted (`SortTimeZoneIdentifiers`), so it now binary-searches (O(n) → O(log n)). **~1.20×** on named-zone construction (9.10 → 7.52 µs/call). Matches the project's existing O(1)/O(k) lookup pattern (#888 / #890).
- **Non-goal / constraint:** `Date` is **not** moved native (maintainer hard line). This does **not** make the 8 dst shards pass — see below.
- Refs #819, #829. (Deliberately not `Closes #829` — see the divergence note.)

### ⚠️ Divergence from the literal issue

Clearing the 20 s deadline needs **~15×**, but the test's intrinsic `new Date; setTime` is already ~67 µs/call **before any timezone work**, and the residual is diffuse, inherent interpreter overhead (`is`/`InheritsFrom` type dispatch ~15%, scope-binding lookups ~8.5%, allocation ~12%, exception-frame setup ~8.5%) — already largely optimised by prior PRs. Closing the gap would need either native `Date` hot-ops (excluded) or a larger interpreter-throughput effort (e.g. a value-kind type tag, a global-binding inline cache). The shards still **cleanly time out** (Wrapper-infra 0, no crash). **Recommend** tracking the interpreter-throughput residual as a follow-up under the #819 perf umbrella, and leaving the close decision on #829 to the maintainer.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation — _no docs change needed: internal perf only, no observable behaviour/API change (Date semantics and time-zone canonicalization are identical; brand-check and `RangeError` paths preserved)._
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — _N/A: no AST/scope/evaluator/value-type changes; the touched Pascal is a leaf canonicalization helper._
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

**Details**

- Full JS suite: **interpreter 10990 / 0 failed**, **bytecode 10990 / 0 failed**.
- `./format.pas --check`: clean (372 files). Pre-commit hooks (trunc-guards, format) pass.
- Benchmarks `benchmarks/temporal.js` both modes (incl. `ZonedDateTime.from named time zone` and `since across DST`, which exercise the binary search): run clean, no regression.
- Targeted Date + Temporal: 546 / 546 both modes.
- New regression tests:
  - `tests/built-ins/Date/methods.js` — slot-requiring methods reject a plain non-Date receiver (`{}` and `Object.create(Date.prototype)`, which has the prototype but no slot) → `TypeError`; constructor reads the time value from a `Date` argument and clips numbers / `NaN`.
  - `tests/built-ins/Temporal/ZonedDateTime/constructor.js` — canonical named zones across the sorted lookup are preserved; a bad zone throws `RangeError`.
- Under the canonical test262 harness (`run_test262_suite.ts`, `--mode=bytecode --timeout-ms=20000`), dst shard 1 still classifies as timeout/FAIL with **Wrapper-infra 0** (no crash) — expected per the divergence note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)