### PR TITLE
perf(engine): replace O(F^2) EntryAt(I) class-field loops with the enumerator

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -253,7 +253,9 @@ The codebase provides purpose-built hash maps that replace `TDictionary` on hot 
 
 **Never use** `TFPDataHashTable` — it has catastrophic insert performance (400,000 ns/insert vs 50 ns for `TOrderedStringMap` at N=20). See [spikes/fpc-hashmap-performance.md](../spikes/fpc-hashmap-performance.md) for the full benchmark analysis.
 
-**API compatibility:** All custom maps share the same core API as `TDictionary`: `Add`, `AddOrSetValue`, `TryGetValue`, `ContainsKey`, `Remove`, `Clear`. Iteration uses `Keys`, `Values`, or `ToArray` returning dynamic arrays (not enumerators), so use indexed `for` loops instead of `for...in`.
+**API compatibility:** All custom maps share the same core API as `TDictionary`: `Add`, `AddOrSetValue`, `TryGetValue`, `ContainsKey`, `Remove`, `Clear`. The `Keys`, `Values`, and `ToArray` accessors return dynamic arrays, so index those with a `for` loop rather than `for...in`.
+
+**Sequential iteration:** `TOrderedStringMap` and `TOrderedMap` also expose a key/value-pair enumerator — prefer `for Pair in Map do`, which yields entries in declaration order at O(1) amortized per step (this is how the class, scope, and module code iterate these maps). Do **not** iterate by driving the random-access `EntryAt(Index)` from a `for Index := 0 to Count - 1` loop: `EntryAt` scans active entries from the start (O(Index)), so the loop is O(N²).
 
 ### Function and Method Names
 

--- a/source/shared/OrderedMap.pas
+++ b/source/shared/OrderedMap.pas
@@ -97,6 +97,10 @@ type
     procedure Clear; override;
 
     function GetEnumerator: TEnumerator; inline;
+    // Random-access lookup by active-entry position: O(AIndex), since it scans
+    // active entries from the start. For sequential iteration use the enumerator
+    // (`for Pair in Map do`); driving EntryAt from a `for I := 0 to Count - 1`
+    // loop re-scans the prefix on every call and is O(Count^2).
     function EntryAt(AIndex: Integer): TBaseMap<TKey, TValue>.TKeyValuePair;
 
     // Number of physical entry slots, including tombstones — the upper bound of

--- a/source/shared/OrderedStringMap.pas
+++ b/source/shared/OrderedStringMap.pas
@@ -100,6 +100,10 @@ type
     procedure Clear; override;
 
     function GetEnumerator: TEnumerator; inline;
+    // Random-access lookup by active-entry position: O(AIndex), since it scans
+    // active entries from the start. For sequential iteration use the enumerator
+    // (`for Pair in Map do`); driving EntryAt from a `for I := 0 to Count - 1`
+    // loop re-scans the prefix on every call and is O(Count^2).
     function EntryAt(AIndex: Integer): TBaseMap<string, TValue>.TKeyValuePair;
 
     // Non-virtual live-entry count for hot validation paths (the Count

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -5857,18 +5857,16 @@ begin
   end
   else
   begin
-    for I := 0 to AClassDef.InstanceProperties.Count - 1 do
+    for Entry in AClassDef.InstanceProperties do
     begin
-      Entry := AClassDef.InstanceProperties.EntryAt(I);
       ValReg := ChildScope.AllocateRegister;
       ACtx.CompileExpression(Entry.Value, ValReg);
       EmitDefineStaticPropertyByName(ChildCtx, ThisReg, ValReg, Entry.Key);
       ChildScope.FreeRegister;
     end;
 
-    for I := 0 to AClassDef.PrivateInstanceProperties.Count - 1 do
+    for Entry in AClassDef.PrivateInstanceProperties do
     begin
-      Entry := AClassDef.PrivateInstanceProperties.EntryAt(I);
       ValReg := ChildScope.AllocateRegister;
       ACtx.CompileExpression(Entry.Value, ValReg);
       EmitDefineStaticPropertyByName(ChildCtx, ThisReg, ValReg,

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -7590,9 +7590,8 @@ begin
   end
   else
   begin
-    for I := 0 to AClassValue.InstancePropertyDefs.Count - 1 do
+    for Entry in AClassValue.InstancePropertyDefs do
     begin
-      Entry := AClassValue.InstancePropertyDefs.EntryAt(I);
       PropertyValue := EvaluateExpression(Entry.Value, LocalContext);
       AInstance.AssignProperty(Entry.Key, PropertyValue);
     end;
@@ -7675,9 +7674,8 @@ begin
   end
   else
   begin
-    for I := 0 to AClassValue.InstancePropertyDefs.Count - 1 do
+    for Entry in AClassValue.InstancePropertyDefs do
     begin
-      Entry := AClassValue.InstancePropertyDefs.EntryAt(I);
       PropertyValue := EvaluateExpression(Entry.Value, AContext);
       AInstance.AssignProperty(Entry.Key, PropertyValue);
     end;
@@ -8849,18 +8847,12 @@ begin
   end;
 
   // Store instance property definitions on the class in declaration order
-  for I := 0 to AClassDef.InstanceProperties.Count - 1 do
-  begin
-    PropertyEntry := AClassDef.InstanceProperties.EntryAt(I);
+  for PropertyEntry in AClassDef.InstanceProperties do
     ClassValue.AddInstanceProperty(PropertyEntry.Key, PropertyEntry.Value);
-  end;
 
   // Store private instance property definitions on the class in declaration order
-  for I := 0 to AClassDef.PrivateInstanceProperties.Count - 1 do
-  begin
-    PropertyEntry := AClassDef.PrivateInstanceProperties.EntryAt(I);
+  for PropertyEntry in AClassDef.PrivateInstanceProperties do
     ClassValue.AddPrivateInstanceProperty(PropertyEntry.Key, PropertyEntry.Value);
-  end;
 
   if Length(AClassDef.FElements) = 0 then
   begin
@@ -10440,11 +10432,9 @@ procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValu
 var
   PropertyValue: TGocciaValue;
   Entry: TGocciaExpressionMap.TKeyValuePair;
-  I: Integer;
 begin
-  for I := 0 to AClassValue.PrivateInstancePropertyDefs.Count - 1 do
+  for Entry in AClassValue.PrivateInstancePropertyDefs do
   begin
-    Entry := AClassValue.PrivateInstancePropertyDefs.EntryAt(I);
     if Assigned(Entry.Value) then
       PropertyValue := EvaluateExpression(Entry.Value, AContext)
     else

--- a/tests/language/classes/field-initializer-order.js
+++ b/tests/language/classes/field-initializer-order.js
@@ -18,3 +18,37 @@ test("field initializers run in source order", () => {
   expect(order[1]).toBe("b");
   expect(order[2]).toBe("c");
 });
+
+test("many public, private, and inherited field initializers run in declaration order", () => {
+  const order = [];
+
+  class Base {
+    a = order.push("a");
+    #b = order.push("b");
+    c = order.push("c");
+    baseB() {
+      return this.#b;
+    }
+  }
+
+  class Derived extends Base {
+    d = order.push("d");
+    #e = order.push("e");
+    f = order.push("f");
+    g = order.push("g");
+    derivedE() {
+      return this.#e;
+    }
+  }
+
+  const obj = new Derived();
+
+  expect(order).toEqual(["a", "b", "c", "d", "e", "f", "g"]);
+  expect(obj.a).toBe(1);
+  expect(obj.baseB()).toBe(2);
+  expect(obj.c).toBe(3);
+  expect(obj.d).toBe(4);
+  expect(obj.derivedE()).toBe(5);
+  expect(obj.f).toBe(6);
+  expect(obj.g).toBe(7);
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Driving the ordered-map `EntryAt(I)` random-access lookup from a `for I := 0 to Count - 1` loop re-scans the active-entry prefix on every call, so iterating a class's instance/private-field **definition** maps was **O(F²)** in the field count. This converts all seven such loops to the in-order pair enumerator (`for Entry in Map do`), which yields the same active entries in the same declaration order at O(1) amortized per step — matching how the sibling method/getter/setter maps in these same functions are already iterated.
  - Interpreter paths (`source/units/Goccia.Evaluator.pas`): the class-definition store loops, plus `InitializeInstanceProperties`, `InitializeObjectInstanceProperties`, and `InitializePrivateInstanceProperties`.
  - Bytecode field-initializer compiler (`source/units/Goccia.Compiler.Statements.pas`): the two `else`-branch loops.
- **Behavior-preserving.** The enumerator yields the identical `(key, value)` pairs in the same order as `EntryAt(0..Count-1)`; no ECMAScript semantics change. Full suite is unchanged in both modes.
- To stop the anti-pattern from being reintroduced: document `EntryAt` as random-access-only on both `TOrderedMap` and `TOrderedStringMap`, and clarify the ordered-map iteration guidance in `docs/contributing/code-style.md` (the previous wording — "use indexed `for` loops instead of `for...in`" — is what bred the O(F²) pattern; the maps do expose a pair enumerator).

### Scope note for reviewers (intentional divergence from the issue text)

The issue framed this as "O(F²) on **every `new`**." Investigation showed that's not what current code does: the parser appends a `FieldOrder` entry for every field **in lockstep** with these maps, so the per-`new` interpreter loops (sites in `InitializeInstanceProperties`/`InitializeObjectInstanceProperties`/`InitializePrivateInstanceProperties`) and the bytecode-compile loops all sit in `FieldOrder = 0` else-branches that run **zero iterations** today. The genuinely reachable O(F²) loops are the two class-definition **store** loops, which run **once per class declaration**, not per `new`. The payoff is therefore bounded (this is the watch-tier item deferred from a measured perf sweep) — primarily an anti-pattern/clarity fix with a bounded complexity improvement, not a hot-path `new` speedup. All seven loops were still converted (per agreement) so the pattern is gone everywhere and is defensive if the `FieldOrder` invariant ever changes.

Closes #810

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Run on a clean build, from the worktree:

| Check | Result |
|-------|--------|
| `./build/GocciaTestRunner tests` (interpreter) | 10,988 / 10,988 pass |
| `./build/GocciaTestRunner tests --mode=bytecode` | 10,988 / 10,988 pass |
| New `tests/language/classes/field-initializer-order.js` case (many public + private + inherited fields, declaration order) | passes both modes |
| `OrderedMap.Test` / `Goccia.OrderedStringMap.Test` (cover the documented `EntryAt` random-access API) | 41 / 5 pass |
| `./format.pas --check` | 374 files, all clean |

A separate `/code-review` pass (correctness + cross-file + conventions) found no issues; in particular it confirmed no converted loop body mutates the map it iterates, so the enumerator's snapshot semantics cannot diverge from `EntryAt`. Benchmarks were not run (bounded once-per-class-declaration change; no behavior or allocation change).
