### PR TITLE
docs: sync release claims to shipped reality (test262 %, runtime size, unit-test count)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See [Bytecode VM](docs/bytecode-vm.md) for the current bytecode executor archite
 
 ### Run Tests
 
-GocciaScript has 8000+ JavaScript unit tests covering language features, built-in objects, and edge cases.
+GocciaScript has 11,000+ JavaScript unit tests covering language features, built-in objects, and edge cases.
 
 ```bash
 ./build.pas testrunner

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -1015,11 +1015,13 @@ export function Landing({
               </AnchorH3>
               <p className="text-ink-2 mb-4">
                 Dynamic code construction and scope-changing syntax are left out
-                to keep execution predictable in embedded runtimes. Coercive or
-                legacy forms such as <code className={inlineCodeClass}>==</code>
-                , <code className={inlineCodeClass}>var</code>, and{" "}
-                <code className={inlineCodeClass}>arguments</code> have explicit
-                alternatives. See{" "}
+                of the recommended defaults to keep execution predictable in
+                embedded runtimes. Coercive or legacy forms such as{" "}
+                <code className={inlineCodeClass}>==</code>,{" "}
+                <code className={inlineCodeClass}>var</code>, and{" "}
+                <code className={inlineCodeClass}>arguments</code> stay off by
+                default but remain available behind explicit compatibility flags
+                — a curated default, not a language ceiling. See{" "}
                 <Link href="/docs/language" className="link-button">
                   Language
                 </Link>{" "}
@@ -1059,10 +1061,11 @@ export function Landing({
               </div>
               <p className="compat-note">
                 Compatibility flags primarily exist for ECMAScript conformance
-                and legacy code. They can opt back into syntax such as{" "}
+                and legacy code. They opt back into excluded syntax such as{" "}
                 <code className={inlineCodeClass}>var</code>,{" "}
-                <code className={inlineCodeClass}>function</code>, and ASI via
-                CLI or config flags.
+                <code className={inlineCodeClass}>function</code>, loose
+                equality, <code className={inlineCodeClass}>arguments</code>, and
+                ASI via CLI or config flags.
               </p>
               <div className="mt-10">
                 <p className="text-ink-2 mb-0 text-[0.92rem]">

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -965,7 +965,7 @@ export function Landing({
                 className="info-term info-term-button"
                 aria-describedby="portable-runtime-tip"
               >
-                portable runtime under 6MB
+                portable runtime under 10MB
                 <span
                   id="portable-runtime-tip"
                   role="tooltip"

--- a/website/src/components/landing.tsx
+++ b/website/src/components/landing.tsx
@@ -812,8 +812,17 @@ const FAQ_ITEMS: { question: string; answer: ReactNode }[] = [
   },
   {
     question: "Is GocciaScript production-ready?",
-    answer:
-      "GocciaScript is still pre-1.0, so APIs and compatibility behavior can change between releases. With more than 80% of test262 passing, it is ready for serious experiments and bounded production embedding where the supported surface matches your needs.",
+    answer: (
+      <>
+        GocciaScript is still pre-1.0, so APIs and compatibility behavior can
+        change between releases. Its current{" "}
+        <Link href="/compatibility" className="link-button">
+          test262 conformance
+        </Link>{" "}
+        already makes it suitable for serious experiments and bounded production
+        embedding where the supported surface matches your needs.
+      </>
+    ),
   },
   {
     question: "How does the sandbox model work?",

--- a/website/src/lib/site-markdown.ts
+++ b/website/src/lib/site-markdown.ts
@@ -163,7 +163,7 @@ async function homeMarkdown(): Promise<string> {
     "",
     "## Intentionally excluded",
     "",
-    "Dynamic code construction and scope-changing syntax are left out of the recommended defaults to keep execution predictable in embedded runtimes. Compatibility flags primarily exist for ECMAScript conformance and legacy code; they can opt back into selected syntax such as `var`, `function`, and ASI via CLI or config flags.",
+    "Dynamic code construction and scope-changing syntax are left out of the recommended defaults to keep execution predictable in embedded runtimes. Coercive or legacy forms such as `==`, `var`, and `arguments` stay off by default but remain available behind explicit compatibility flags — a curated default, not a language ceiling. Those flags primarily exist for ECMAScript conformance and legacy code, opting back into excluded syntax such as `var`, `function`, loose equality, `arguments`, and ASI via CLI or config flags.",
     "",
     list(EXCLUDED.map((item) => `\`${item.name}\` - ${item.why}`)),
     "",


### PR DESCRIPTION
## Summary

Release-prep truth-sync (`/prepare-release`): hand-maintained marketing claims that had drifted from what the engine ships, plus one framing fix. No code behavior changes.

**Stale numbers**
- **`landing.tsx` FAQ** — dropped hardcoded **"more than 80% of test262 passing"** (current rate ~97.3%); replaced with a link to the `/compatibility` dashboard so the figure is always generated, never re-typed.
- **`landing.tsx` design principles** — "portable runtime under 6MB" → **"under 10MB"**. Shipped `0.8.0` binaries measure **7.1–8.8 MiB** across every platform; 6MB had been false since ≥`0.8.0`.
- **`README.md`** — "8000+ JavaScript unit tests" → **"11,000+"** (suite now runs 11,062).

**Framing**
- **`landing.tsx` + `site-markdown.ts` "Intentionally excluded"** — the copy read as a permanent subset ceiling: legacy forms "have explicit alternatives" and only var/function/ASI listed as recoverable. Reframed to "off by default but available behind explicit compatibility flags — a curated default, not a language ceiling", matching CONTEXT.md ("recommended defaults" ≠ ceiling) and every other page. Both the component and its markdown mirror updated in lockstep.

Verified clean during the sweep (no change): test262 up vs `0.8.0` (97.317% / 50889, +11, no regressions, from CI artifacts); generated-data provenance intact (CLDR 45.0.0, tzdata 2026b, Unicode 17.0.0); `git-cliff --unreleased` categorization clean.

Stops before `/create-release` — version, changelog section, and tag remain that skill's responsibility.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Gate: `tests` 11062/11062, `tests --mode=bytecode` 11062/11062, `format --check` clean, `check-doc-links` 0 broken, website `biome check` on `landing.tsx`/`site-markdown.ts` exit 0. Docs/website-only diff — no Pascal touched.