### PR TITLE
fix(test262): surface thrown object messages

### DIFF
--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -214,6 +214,29 @@ console.log("--compat-function (Loader) + Bare loader compat parsing...");
     const bareStdin = await $`cat ${bothSrc} | ${BARE} --print - --compat-var --compat-function 2>&1`.text();
     if (bareStdin.trim() !== "22") throw new Error(`Bare stdin --compat-var --compat-function expected 22, got: ${bareStdin}`);
 
+    const thrownObjectSrc = join(tmp, "throw-test262-object.js");
+    writeFileSync(
+      thrownObjectSrc,
+      [
+        "function Test262Error(message) {",
+        "  this.message = message || '';",
+        "}",
+        "Test262Error.prototype.toString = function () {",
+        "  return 'Test262Error: ' + this.message;",
+        "};",
+        "throw new Test262Error('issue 830 readable failure message');",
+        "",
+      ].join("\n"),
+    );
+    const thrownObject = await $`cat ${thrownObjectSrc} | ${BARE} --mode=bytecode - --compat-function 2>&1`.nothrow();
+    const thrownObjectOut = thrownObject.text();
+    if (thrownObject.exitCode === 0)
+      throw new Error("Bare thrown Test262Error-style object should fail");
+    if (!thrownObjectOut.includes("issue 830 readable failure message"))
+      throw new Error(`Bare thrown Test262Error-style object should report its message, got: ${thrownObjectOut}`);
+    if (thrownObjectOut.trim() === "[object Object]")
+      throw new Error("Bare thrown Test262Error-style object should not collapse to [object Object]");
+
     // --compat-all regression guard: the flag was removed and must now be
     // rejected as an unknown option.
     const bareCompatAll = await $`echo 'x;' | ${BARE} --compat-all - 2>&1`.nothrow();

--- a/source/units/Goccia.Error.Detail.pas
+++ b/source/units/Goccia.Error.Detail.pas
@@ -32,14 +32,47 @@ uses
 
   Goccia.Constants.PropertyNames,
   Goccia.Error,
+  Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
+
+function TryGetStringDataProperty(const AObject: TGocciaObjectValue;
+  const AName: string; out AValue: string): Boolean;
+var
+  Current: TGocciaObjectValue;
+  Descriptor: TGocciaPropertyDescriptor;
+  Value: TGocciaValue;
+begin
+  Result := False;
+  AValue := '';
+  Current := AObject;
+
+  while Assigned(Current) do
+  begin
+    Descriptor := Current.GetOwnPropertyDescriptor(AName);
+    if Assigned(Descriptor) then
+    begin
+      if Descriptor is TGocciaPropertyDescriptorData then
+      begin
+        Value := TGocciaPropertyDescriptorData(Descriptor).Value;
+        if Value is TGocciaStringLiteralValue then
+        begin
+          AValue := TGocciaStringLiteralValue(Value).Value;
+          Exit(True);
+        end;
+      end;
+      Exit(False);
+    end;
+
+    Current := Current.Prototype;
+  end;
+end;
 
 function ExtractThrowLocation(const AThrown: TGocciaValue;
   out AErrorName, AErrorMessage, AFrameFileName: string;
   out ALine, AColumn: Integer): Boolean;
 var
-  StackValue, MsgValue, NameValue: TGocciaValue;
+  TextValue: string;
   StackStr: string;
   AtPos, ParenPos, ColonPos1, ColonPos2, I: Integer;
 begin
@@ -52,18 +85,12 @@ begin
 
   if not (AThrown is TGocciaObjectValue) then Exit;
 
-  NameValue := TGocciaObjectValue(AThrown).GetProperty(PROP_NAME);
-  if Assigned(NameValue) and (NameValue is TGocciaStringLiteralValue) then
-    AErrorName := TGocciaStringLiteralValue(NameValue).Value;
+  if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_NAME, TextValue) then
+    AErrorName := TextValue;
+  if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_MESSAGE, TextValue) then
+    AErrorMessage := TextValue;
 
-  MsgValue := TGocciaObjectValue(AThrown).GetProperty(PROP_MESSAGE);
-  if Assigned(MsgValue) and (MsgValue is TGocciaStringLiteralValue) then
-    AErrorMessage := TGocciaStringLiteralValue(MsgValue).Value;
-
-  StackValue := TGocciaObjectValue(AThrown).GetProperty(PROP_STACK);
-  if not Assigned(StackValue) or not (StackValue is TGocciaStringLiteralValue) then Exit;
-
-  StackStr := TGocciaStringLiteralValue(StackValue).Value;
+  if not TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_STACK, StackStr) then Exit;
 
   // Find first "at ... (file:line:col)" frame
   AtPos := Pos('    at ', StackStr);
@@ -106,7 +133,7 @@ var
   ErrorName, ErrorMessage, FrameFileName: string;
   Line, Col: Integer;
   EffectiveFileName: string;
-  StackValue: TGocciaValue;
+  StackText, MessageText, NameText: string;
 begin
   if ExtractThrowLocation(AThrown, ErrorName, ErrorMessage, FrameFileName, Line, Col) and
      Assigned(ASourceLines) and (Line > 0) and (Line <= ASourceLines.Count) then
@@ -128,10 +155,18 @@ begin
     // unwound by the time this runs and re-entry is unsafe.
     if AThrown is TGocciaObjectValue then
     begin
-      StackValue := TGocciaObjectValue(AThrown).GetProperty(PROP_STACK);
-      if Assigned(StackValue) and (StackValue is TGocciaStringLiteralValue) and
-         (TGocciaStringLiteralValue(StackValue).Value <> '') then
-        Result := TGocciaStringLiteralValue(StackValue).Value
+      if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_STACK, StackText) and
+         (StackText <> '') then
+        Result := StackText
+      else if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_MESSAGE, MessageText) and
+              (MessageText <> '') then
+      begin
+        if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_NAME, NameText) and
+           (NameText <> '') then
+          Result := Format('%s: %s', [NameText, MessageText])
+        else
+          Result := MessageText;
+      end
       else
         Result := Format('[object %s]', [TGocciaObjectValue(AThrown).ToStringTag]);
     end


### PR DESCRIPTION
## Summary

- Surface safe string `stack`/`message` data from uncaught thrown objects before falling back to `[object Object]`.
- Keep ECMAScript throw semantics unchanged: this only changes host diagnostic formatting for top-level uncaught throws.
- Add a bare-loader regression for a stock test262 `Test262Error`-style object thrown through the same stdin path used by the test262 runner.
- Closes #830.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `bun run scripts/test-cli.ts`
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --mode=bytecode --jobs=1 --timeout-ms=8000 --filter 'built-ins/FinalizationRegistry/proto-from-ctor-realm.js' --output=/tmp/goccia-issue-830-single-after.json`
- [ ] Updated documentation
  - Not applicable: no user-facing behavior contract changed beyond diagnostics covered by the regression.
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./build.pas loaderbare`
  - `./build.pas loader testrunner bundler benchmarkrunner repl`
  - `./build.pas testrunner`
  - `./build/GocciaTestRunner tests`
  - `./build/GocciaTestRunner tests --mode=bytecode`
  - `./format.pas --check`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Not applicable: diagnostic formatting only.