### PR TITLE
fix(generators): align generator prototype methods

### DIFF
--- a/source/units/Goccia.Generator.Continuation.pas
+++ b/source/units/Goccia.Generator.Continuation.pas
@@ -1443,7 +1443,9 @@ end;
 function EvaluateGeneratorAwait(const AAwaitExpression: TGocciaAwaitExpression;
   const AContext: TGocciaEvaluationContext): TGocciaValue;
 begin
-  if not Assigned(GCurrentContinuation) or GCurrentContinuation.IsAsyncGenerator then
+  if not Assigned(GCurrentContinuation) or
+     (GCurrentContinuation.IsAsyncGenerator and
+      not AsyncAwaitSuspensionEnabled) then
     Result := AwaitValue(EvaluateExpression(AAwaitExpression.Operand, AContext))
   else
     Result := GCurrentContinuation.AwaitExpressionValue(

--- a/source/units/Goccia.Intrinsics.FunctionObjects.pas
+++ b/source/units/Goccia.Intrinsics.FunctionObjects.pas
@@ -76,6 +76,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Realm,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.GeneratorValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -216,6 +217,7 @@ begin
     GeneratorPrototype.DefineProperty(PROP_CONSTRUCTOR,
       TGocciaPropertyDescriptorData.Create(FunctionPrototype,
         [pfConfigurable]));
+    EnsureGeneratorPrototypeMethods(GeneratorPrototype);
     DefineToStringTag(GeneratorPrototype, 'Generator');
 
     CurrentRealm.SetSlot(GGeneratorFunctionPrototypeSlot, FunctionPrototype);
@@ -226,6 +228,7 @@ begin
     ConstructorFunction := FunctionPrototype.GetProperty(PROP_CONSTRUCTOR) as
       TGocciaFunctionConstructorClassValue;
   end;
+  EnsureGeneratorPrototypeMethods(GeneratorPrototype);
   FGeneratorFunctionConstructor := ConstructorFunction;
   FGeneratorFunctionPrototype := FunctionPrototype;
   FGeneratorPrototype := GeneratorPrototype;
@@ -280,6 +283,7 @@ begin
     AsyncGeneratorPrototype.DefineProperty(PROP_CONSTRUCTOR,
       TGocciaPropertyDescriptorData.Create(FunctionPrototype,
         [pfConfigurable]));
+    EnsureAsyncGeneratorPrototypeMethods(AsyncGeneratorPrototype);
     DefineToStringTag(AsyncGeneratorPrototype, 'AsyncGenerator');
 
     CurrentRealm.SetSlot(GAsyncGeneratorFunctionPrototypeSlot,
@@ -292,6 +296,7 @@ begin
     ConstructorFunction := FunctionPrototype.GetProperty(PROP_CONSTRUCTOR) as
       TGocciaFunctionConstructorClassValue;
   end;
+  EnsureAsyncGeneratorPrototypeMethods(AsyncGeneratorPrototype);
   FAsyncGeneratorFunctionConstructor := ConstructorFunction;
   FAsyncGeneratorFunctionPrototype := FunctionPrototype;
   FAsyncIteratorPrototype := AsyncIteratorPrototype;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -668,7 +668,9 @@ begin
       TGocciaObjectValue.SharedObjectPrototype,
       IteratorPrototype);
     if AKind = foikGenerator then
-      EnsureGeneratorPrototypeMethods(Result);
+      EnsureGeneratorPrototypeMethods(Result)
+    else if AKind = foikAsyncGenerator then
+      EnsureAsyncGeneratorPrototypeMethods(Result);
   finally
     if ShouldSwitchRealm then
       SetCurrentRealm(PreviousRealm);
@@ -2522,7 +2524,7 @@ type
     property Value: TGocciaValue read FValue;
   end;
 
-  TGocciaBytecodeGeneratorObjectValue = class(TGocciaIteratorValue)
+  TGocciaBytecodeGeneratorObjectValue = class(TGocciaGeneratorBaseValue)
   private
     FVM: TGocciaVM;
     FClosure: TGocciaBytecodeClosure;
@@ -2535,6 +2537,7 @@ type
     FReturnSentinel: TGocciaValue;
     FReturnValue: TGocciaValue;
     FReturnRequiresAwait: Boolean;
+    FReturnResumeValueAwaited: Boolean;
     FHasContinuation: Boolean;
     FContinuationIP: Integer;
     FContinuationRegisters: TGocciaRegisterArray;
@@ -2577,11 +2580,11 @@ type
     function ThrowValue(const AValue: TGocciaValue): TGocciaObjectValue; override;
     procedure Close; override;
     function GeneratorNext(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
     function GeneratorReturn(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
     function GeneratorThrow(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
     procedure HandleYield(const AValue: TGocciaRegister;
       const AResumeRegister: UInt8; const AFrame: TGocciaVMCallFrame;
       const AHandlerBaseCount: Integer; const APrevCovLine: UInt32;
@@ -2595,7 +2598,7 @@ type
     function BuiltinTagFallback: Boolean; override;
   end;
 
-  TGocciaBytecodeAsyncGeneratorObjectValue = class(TGocciaObjectValue)
+  TGocciaBytecodeAsyncGeneratorObjectValue = class(TGocciaAsyncGeneratorBaseValue)
   private
     FInner: TGocciaBytecodeGeneratorObjectValue;
     FQueue: array of TGocciaBytecodeAsyncGeneratorRequest;
@@ -2612,9 +2615,15 @@ type
     procedure ContinueWhenPromiseSettles(const APromise: TGocciaPromiseValue);
     procedure AwaitYieldValue(const ARequestPromise: TGocciaPromiseValue;
       const AValue: TGocciaValue);
+    procedure AwaitReturnValue(const ARequestPromise: TGocciaPromiseValue;
+      const AValue: TGocciaValue);
     procedure ResolveAwaitedYield(const ARequestPromise: TGocciaPromiseValue;
       const AValue: TGocciaValue);
     procedure RejectAwaitedYield(const ARequestPromise: TGocciaPromiseValue;
+      const AReason: TGocciaValue);
+    procedure ResolveAwaitedReturn(const ARequestPromise: TGocciaPromiseValue;
+      const AValue: TGocciaValue);
+    procedure RejectAwaitedReturn(const ARequestPromise: TGocciaPromiseValue;
       const AReason: TGocciaValue);
     procedure ProcessQueue;
     function ResumeAsPromise(const AKind: TGocciaBytecodeGeneratorResumeKind;
@@ -2627,11 +2636,11 @@ type
       const AClosure: TGocciaBytecodeClosure; const AThisValue: TGocciaRegister;
       const AArguments: TGocciaRegisterArray);
     function AsyncGeneratorNext(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
     function AsyncGeneratorReturn(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
     function AsyncGeneratorThrow(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
     function AsyncIteratorSelf(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     procedure MarkReferences; override;
@@ -2644,9 +2653,11 @@ type
     FGenerator: TGocciaBytecodeAsyncGeneratorObjectValue;
     FRequestPromise: TGocciaPromiseValue;
     FReject: Boolean;
+    FReturn: Boolean;
   public
     constructor Create(const AGenerator: TGocciaBytecodeAsyncGeneratorObjectValue;
-      const ARequestPromise: TGocciaPromiseValue; const AReject: Boolean);
+      const ARequestPromise: TGocciaPromiseValue; const AReject: Boolean;
+      const AReturn: Boolean = False);
     function Invoke(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     procedure MarkReferences; override;
@@ -3928,15 +3939,7 @@ begin
   FResumeValue := RegisterUndefined;
   FIgnoreNextResume := False;
   FReturnRequiresAwait := False;
-  DefineProperty(PROP_NEXT, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(GeneratorNext, PROP_NEXT, 1),
-    [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_RETURN, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(GeneratorReturn, PROP_RETURN, 1),
-    [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_THROW, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(GeneratorThrow, PROP_THROW, 1),
-    [pfConfigurable, pfWritable]));
+  FReturnResumeValueAwaited := False;
   if Assigned(FClosure.Template) and (FClosure.Template.ParameterPreambleSize > 0) then
     FVM.ExecuteGeneratorParameterPreamble(Self);
 end;
@@ -3966,15 +3969,7 @@ begin
   FResumeValue := RegisterUndefined;
   FIgnoreNextResume := False;
   FReturnRequiresAwait := False;
-  DefineProperty(PROP_NEXT, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(GeneratorNext, PROP_NEXT, 1),
-    [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_RETURN, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(GeneratorReturn, PROP_RETURN, 1),
-    [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_THROW, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(GeneratorThrow, PROP_THROW, 1),
-    [pfConfigurable, pfWritable]));
+  FReturnResumeValueAwaited := False;
   if ARunParameterPreamble and Assigned(FClosure.Template) and
      (FClosure.Template.ParameterPreambleSize > 0) then
     FVM.ExecuteGeneratorParameterPreamble(Self);
@@ -4451,6 +4446,8 @@ begin
   FResumeKind := AKind;
   FResumeValue := VMValueToRegisterFast(AValue);
   FReturnRequiresAwait := False;
+  if AKind <> bgrkReturn then
+    FReturnResumeValueAwaited := False;
   FState := bgsExecuting;
 
   PreviousGenerator := GActiveBytecodeGenerator;
@@ -4618,7 +4615,9 @@ begin
   try
     try
       ResultValue := FContinuation.ResumeRaw(FResumeKind, ResumeValue, Done);
-      if FAsyncGeneratorResult then
+      if FAsyncGeneratorResult and (FResumeKind = bgrkReturn) then
+        FPromise.Resolve(CreateIteratorResult(ResultValue, Done))
+      else if FAsyncGeneratorResult then
         FPromise.Resolve(CreateIteratorResult(AwaitValue(ResultValue), Done))
       else if Done then
         FPromise.Resolve(ResultValue);
@@ -4886,19 +4885,6 @@ begin
   Prototype := VMGeneratorObjectPrototype(foikAsyncGenerator);
   FInner := TGocciaBytecodeGeneratorObjectValue.Create(AVM, AClosure,
     AThisValue, AArguments);
-  DefineProperty(PROP_NEXT, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(AsyncGeneratorNext, PROP_NEXT, 1),
-    [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_RETURN, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(AsyncGeneratorReturn, PROP_RETURN, 1),
-    [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_THROW, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(AsyncGeneratorThrow, PROP_THROW, 1),
-    [pfConfigurable, pfWritable]));
-  DefineSymbolProperty(TGocciaSymbolValue.WellKnownAsyncIterator,
-    TGocciaPropertyDescriptorData.Create(
-      TGocciaNativeFunctionValue.Create(AsyncIteratorSelf, '[Symbol.asyncIterator]', 0),
-      [pfConfigurable, pfWritable]));
 end;
 
 constructor TGocciaBytecodeAsyncGeneratorObjectValue.CreateRegisters(
@@ -4909,19 +4895,6 @@ begin
   Prototype := VMGeneratorObjectPrototype(foikAsyncGenerator);
   FInner := TGocciaBytecodeGeneratorObjectValue.CreateRegisters(AVM, AClosure,
     AThisValue, AArguments);
-  DefineProperty(PROP_NEXT, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(AsyncGeneratorNext, PROP_NEXT, 1),
-    [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_RETURN, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(AsyncGeneratorReturn, PROP_RETURN, 1),
-    [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_THROW, TGocciaPropertyDescriptorData.Create(
-    TGocciaNativeFunctionValue.Create(AsyncGeneratorThrow, PROP_THROW, 1),
-    [pfConfigurable, pfWritable]));
-  DefineSymbolProperty(TGocciaSymbolValue.WellKnownAsyncIterator,
-    TGocciaPropertyDescriptorData.Create(
-      TGocciaNativeFunctionValue.Create(AsyncIteratorSelf, '[Symbol.asyncIterator]', 0),
-      [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaBytecodeAsyncGeneratorObjectValue.ResumeAsPromise(
@@ -5029,6 +5002,33 @@ begin
   AwaitPromise.InvokeThen(FulfillFunction, RejectFunction);
 end;
 
+// ES2026 §27.6.3.9 AsyncGeneratorAwaitReturn(gen)
+procedure TGocciaBytecodeAsyncGeneratorObjectValue.AwaitReturnValue(
+  const ARequestPromise: TGocciaPromiseValue; const AValue: TGocciaValue);
+var
+  AwaitPromise: TGocciaPromiseValue;
+  FulfillFunction: TGocciaNativeFunctionValue;
+  FulfillHandler: TGocciaVMAsyncGeneratorYieldAwaitHandler;
+  RejectFunction: TGocciaNativeFunctionValue;
+  RejectHandler: TGocciaVMAsyncGeneratorYieldAwaitHandler;
+begin
+  AwaitPromise := FInner.FVM.PromiseResolveIntrinsic(AValue);
+
+  FulfillHandler := TGocciaVMAsyncGeneratorYieldAwaitHandler.Create(
+    Self, ARequestPromise, False, True);
+  FulfillFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    FulfillHandler.Invoke, 'async-generator-return-fulfill', 1);
+  FulfillFunction.CapturedRoot := FulfillHandler;
+
+  RejectHandler := TGocciaVMAsyncGeneratorYieldAwaitHandler.Create(
+    Self, ARequestPromise, True, True);
+  RejectFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    RejectHandler.Invoke, 'async-generator-return-reject', 1);
+  RejectFunction.CapturedRoot := RejectHandler;
+
+  AwaitPromise.InvokeThen(FulfillFunction, RejectFunction);
+end;
+
 procedure TGocciaBytecodeAsyncGeneratorObjectValue.ResolveAwaitedYield(
   const ARequestPromise: TGocciaPromiseValue; const AValue: TGocciaValue);
 begin
@@ -5052,9 +5052,11 @@ begin
       if Done then
       begin
         if FInner.FReturnRequiresAwait then
-          UnwrappedValue := AwaitValue(ResultValue)
-        else
-          UnwrappedValue := ResultValue;
+        begin
+          AwaitReturnValue(ARequestPromise, ResultValue);
+          Exit;
+        end;
+        UnwrappedValue := ResultValue;
         ARequestPromise.Resolve(CreateIteratorResult(UnwrappedValue, True));
         FinishRequest;
       end
@@ -5082,6 +5084,20 @@ begin
   finally
     FInner.FVM.FCurrentAsyncPromise := PreviousAsyncPromise;
   end;
+end;
+
+procedure TGocciaBytecodeAsyncGeneratorObjectValue.ResolveAwaitedReturn(
+  const ARequestPromise: TGocciaPromiseValue; const AValue: TGocciaValue);
+begin
+  ARequestPromise.Resolve(CreateIteratorResult(AValue, True));
+  FinishRequest;
+end;
+
+procedure TGocciaBytecodeAsyncGeneratorObjectValue.RejectAwaitedReturn(
+  const ARequestPromise: TGocciaPromiseValue; const AReason: TGocciaValue);
+begin
+  ARequestPromise.Reject(AReason);
+  FinishRequest;
 end;
 
 procedure TGocciaBytecodeAsyncGeneratorObjectValue.ProcessQueue;
@@ -5116,6 +5132,14 @@ begin
         FInner.FVM.FCurrentAsyncPromise := ARequest.Promise;
         try
           try
+            if (ARequest.Kind = bgrkReturn) and
+               (FInner.FState in [bgsSuspendedStart, bgsCompleted]) then
+            begin
+              FInner.FState := bgsCompleted;
+              AwaitReturnValue(ARequest.Promise, ARequest.Value);
+              Exit;
+            end;
+
             if FInner.FState = bgsCompleted then
             begin
               case ARequest.Kind of
@@ -5134,10 +5158,7 @@ begin
 	                  end;
 	              else
 	                begin
-	                  UnwrappedValue := AwaitValue(ARequest.Value);
-	                  ARequest.Promise.Resolve(CreateIteratorResult(
-	                    UnwrappedValue, True));
-                    FinishRequest;
+	                  AwaitReturnValue(ARequest.Promise, ARequest.Value);
 	                  Exit;
 	                end;
               end;
@@ -5148,9 +5169,11 @@ begin
               if Done then
               begin
                 if FInner.FReturnRequiresAwait then
-                  UnwrappedValue := AwaitValue(Value)
-                else
-                  UnwrappedValue := Value;
+                begin
+                  AwaitReturnValue(ARequest.Promise, Value);
+                  Exit;
+                end;
+                UnwrappedValue := Value;
               end
               else if FInner.FDelegateActive then
                 UnwrappedValue := Value
@@ -5208,12 +5231,14 @@ end;
 
 constructor TGocciaVMAsyncGeneratorYieldAwaitHandler.Create(
   const AGenerator: TGocciaBytecodeAsyncGeneratorObjectValue;
-  const ARequestPromise: TGocciaPromiseValue; const AReject: Boolean);
+  const ARequestPromise: TGocciaPromiseValue; const AReject: Boolean;
+  const AReturn: Boolean = False);
 begin
   inherited Create(nil);
   FGenerator := AGenerator;
   FRequestPromise := ARequestPromise;
   FReject := AReject;
+  FReturn := AReturn;
 end;
 
 function TGocciaVMAsyncGeneratorYieldAwaitHandler.Invoke(
@@ -5227,7 +5252,11 @@ begin
     Exit;
 
   Value := VMArgumentOrUndefined(AArgs);
-  if FReject then
+  if FReturn and FReject then
+    FGenerator.RejectAwaitedReturn(FRequestPromise, Value)
+  else if FReturn then
+    FGenerator.ResolveAwaitedReturn(FRequestPromise, Value)
+  else if FReject then
     FGenerator.RejectAwaitedYield(FRequestPromise, Value)
   else
     FGenerator.ResolveAwaitedYield(FRequestPromise, Value);
@@ -12764,6 +12793,7 @@ var
   AwaitContinuation: TGocciaBytecodeGeneratorObjectValue;
   SpreadArray: TGocciaArrayValue;
   RestoredContinuation: Boolean;
+  ReturnAwaitAbrupt: Boolean;
   ForInKey: string;
   PreviousRealm: TGocciaRealm;
   ExecutionRealm: TGocciaRealm;
@@ -12850,15 +12880,56 @@ begin
             begin
               GActiveBytecodeGenerator.FReturnValue :=
                 RegisterToValue(GActiveBytecodeGenerator.FResumeValue);
+              ReturnAwaitAbrupt := False;
               if Assigned(Template) and Template.IsAsync and
-                 Template.IsGenerator then
-                GActiveBytecodeGenerator.FReturnValue :=
-                  AwaitValue(GActiveBytecodeGenerator.FReturnValue);
-              if not Assigned(GActiveBytecodeGenerator.FReturnSentinel) then
-                GActiveBytecodeGenerator.FReturnSentinel := TGocciaObjectValue.Create;
-              HandleExceptionUnwind(GActiveBytecodeGenerator.FReturnSentinel,
-                InitialFrameStackCount, SavedHandlerCount,
-                Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                 Template.IsGenerator and
+                 not GActiveBytecodeGenerator.FReturnResumeValueAwaited then
+              begin
+                try
+                  AwaitPromise := PromiseResolveIntrinsic(
+                    GActiveBytecodeGenerator.FReturnValue);
+                except
+                  on E: EGocciaBytecodeThrow do
+                  begin
+                    HandleExceptionUnwind(E.ThrownValue,
+                      InitialFrameStackCount, SavedHandlerCount,
+                      Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                    ReturnAwaitAbrupt := True;
+                  end;
+                  on E: TGocciaThrowValue do
+                  begin
+                    HandleExceptionUnwind(E.Value,
+                      InitialFrameStackCount, SavedHandlerCount,
+                      Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                    ReturnAwaitAbrupt := True;
+                  end;
+                end;
+                if not ReturnAwaitAbrupt then
+                begin
+                  GActiveBytecodeGenerator.FReturnResumeValueAwaited := True;
+                  GActiveBytecodeGenerator.CaptureContinuation(Frame,
+                    SavedHandlerCount, PrevCovLine,
+                    GActiveBytecodeGenerator.FResumeRegister, Frame.IP);
+                  GActiveBytecodeGenerator.FState := bgsSuspendedYield;
+                  AwaitPromise.InvokeThen(
+                    TGocciaVMAsyncAwaitContinuationValue.Create(Self,
+                      GActiveBytecodeGenerator, FCurrentAsyncPromise, bgrkReturn,
+                      True),
+                    TGocciaVMAsyncAwaitContinuationValue.Create(Self,
+                      GActiveBytecodeGenerator, FCurrentAsyncPromise, bgrkThrow,
+                      True));
+                  raise EGocciaBytecodeAsyncSuspend.Create('');
+                end;
+              end;
+              if not ReturnAwaitAbrupt then
+              begin
+                GActiveBytecodeGenerator.FReturnResumeValueAwaited := False;
+                if not Assigned(GActiveBytecodeGenerator.FReturnSentinel) then
+                  GActiveBytecodeGenerator.FReturnSentinel := TGocciaObjectValue.Create;
+                HandleExceptionUnwind(GActiveBytecodeGenerator.FReturnSentinel,
+                  InitialFrameStackCount, SavedHandlerCount,
+                  Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+              end;
             end;
         end;
       end;

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -818,16 +818,11 @@ var
   Request: TGocciaAsyncGeneratorRequest;
 begin
   Promise := TGocciaPromiseValue.Create;
-  try
-    Request.Kind := AKind;
-    Request.Value := AValue;
-    Request.Promise := Promise;
-    EnqueueRequest(Request);
-    ProcessQueue;
-  except
-    Promise.Free;
-    raise;
-  end;
+  Request.Kind := AKind;
+  Request.Value := AValue;
+  Request.Promise := Promise;
+  EnqueueRequest(Request);
+  ProcessQueue;
   Result := Promise;
 end;
 

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -89,7 +89,8 @@ type
       const AIsThrow: Boolean);
     procedure AwaitYieldValue(const AValue: TGocciaValue);
     procedure AwaitReturnValue(const AValue: TGocciaValue;
-      const AThrowIntoGenerator: Boolean = False);
+      const AThrowIntoGenerator: Boolean = False;
+      const AResolvedPromise: TGocciaPromiseValue = nil);
     procedure CompleteCurrentRequest(const AValue: TGocciaValue;
       const AIsThrow, ADone: Boolean);
     procedure ResolveAwaitedYield(const AValue: TGocciaValue);
@@ -1001,7 +1002,8 @@ end;
 
 // ES2026 §27.6.3.9 AsyncGeneratorAwaitReturn(gen)
 procedure TGocciaAsyncGeneratorObjectValue.AwaitReturnValue(
-  const AValue: TGocciaValue; const AThrowIntoGenerator: Boolean = False);
+  const AValue: TGocciaValue; const AThrowIntoGenerator: Boolean = False;
+  const AResolvedPromise: TGocciaPromiseValue = nil);
 var
   AwaitPromise: TGocciaPromiseValue;
   FulfillFunction: TGocciaNativeFunctionValue;
@@ -1009,24 +1011,29 @@ var
   RejectFunction: TGocciaNativeFunctionValue;
   RejectHandler: TGocciaAsyncGeneratorAwaitReturnHandler;
 begin
-  try
-    AwaitPromise := AsyncGeneratorPromiseResolve(AValue);
-  except
-    on E: TGocciaThrowValue do
-    begin
-      if AThrowIntoGenerator then
-        RejectAwaitedYield(E.Value)
-      else
-        RejectAwaitedReturn(E.Value);
-      Exit;
-    end;
-    on E: Exception do
-    begin
-      if AThrowIntoGenerator then
-        RejectAwaitedYield(ExceptionToErrorValue(E))
-      else
-        RejectAwaitedReturn(ExceptionToErrorValue(E));
-      Exit;
+  if Assigned(AResolvedPromise) then
+    AwaitPromise := AResolvedPromise
+  else
+  begin
+    try
+      AwaitPromise := AsyncGeneratorPromiseResolve(AValue);
+    except
+      on E: TGocciaThrowValue do
+      begin
+        if AThrowIntoGenerator then
+          RejectAwaitedYield(E.Value)
+        else
+          RejectAwaitedReturn(E.Value);
+        Exit;
+      end;
+      on E: Exception do
+      begin
+        if AThrowIntoGenerator then
+          RejectAwaitedYield(ExceptionToErrorValue(E))
+        else
+          RejectAwaitedReturn(ExceptionToErrorValue(E));
+        Exit;
+      end;
     end;
   end;
 
@@ -1128,11 +1135,12 @@ end;
 procedure TGocciaAsyncGeneratorObjectValue.StartRequest(
   const ARequest: TGocciaAsyncGeneratorRequest);
 var
-  CheckedPromise: TGocciaPromiseValue;
+  CheckedReturnPromise: TGocciaPromiseValue;
   Done: Boolean;
   UnwrappedValue: TGocciaValue;
   Value: TGocciaValue;
 begin
+  CheckedReturnPromise := nil;
   try
     if (ARequest.Kind = grkReturn) and
        (FState in [gsSuspendedStart, gsCompleted]) then
@@ -1169,8 +1177,7 @@ begin
        (ARequest.Value is TGocciaPromiseValue) then
     begin
       try
-        CheckedPromise := AsyncGeneratorPromiseResolve(ARequest.Value);
-        CheckedPromise := nil;
+        CheckedReturnPromise := AsyncGeneratorPromiseResolve(ARequest.Value);
       except
         on E: TGocciaThrowValue do
         begin
@@ -1201,7 +1208,11 @@ begin
     begin
       if FContinuation.ReturnRequiresAwait then
       begin
-        AwaitReturnValue(Value, True);
+        if Assigned(CheckedReturnPromise) and
+           IsSameValue(Value, ARequest.Value) then
+          AwaitReturnValue(Value, True, CheckedReturnPromise)
+        else
+          AwaitReturnValue(Value, True);
         Exit;
       end;
       UnwrappedValue := Value;

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -14,12 +14,29 @@ uses
   Goccia.Values.FunctionValue,
   Goccia.Values.IteratorValue,
   Goccia.Values.ObjectValue,
-  Goccia.Values.Primitives;
+  Goccia.Values.Primitives,
+  Goccia.Values.PromiseValue;
 
 type
   TGocciaGeneratorState = (gsSuspendedStart, gsSuspendedYield, gsExecuting, gsCompleted);
 
-  TGocciaGeneratorObjectValue = class(TGocciaIteratorValue)
+  TGocciaAsyncGeneratorRequest = record
+    Kind: TGocciaGeneratorResumeKind;
+    Value: TGocciaValue;
+    Promise: TGocciaPromiseValue;
+  end;
+
+  TGocciaGeneratorBaseValue = class(TGocciaIteratorValue)
+  public
+    function GeneratorNext(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; virtual; abstract;
+    function GeneratorReturn(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; virtual; abstract;
+    function GeneratorThrow(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; virtual; abstract;
+  end;
+
+  TGocciaGeneratorObjectValue = class(TGocciaGeneratorBaseValue)
   private
     FContinuation: TGocciaGeneratorContinuation;
     FState: TGocciaGeneratorState;
@@ -36,26 +53,58 @@ type
     procedure MarkReferences; override;
     function ToStringTag: string; override;
     function BuiltinTagFallback: Boolean; override;
-    function GeneratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-    function GeneratorReturn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-    function GeneratorThrow(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function GeneratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
+    function GeneratorReturn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
+    function GeneratorThrow(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
   end;
 
-  TGocciaAsyncGeneratorObjectValue = class(TGocciaObjectValue)
+  TGocciaAsyncGeneratorBaseValue = class(TGocciaObjectValue)
+  public
+    function AsyncGeneratorNext(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; virtual; abstract;
+    function AsyncGeneratorReturn(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; virtual; abstract;
+    function AsyncGeneratorThrow(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; virtual; abstract;
+  end;
+
+  TGocciaAsyncGeneratorObjectValue = class(TGocciaAsyncGeneratorBaseValue)
   private
     FContinuation: TGocciaGeneratorContinuation;
     FState: TGocciaGeneratorState;
+    FQueue: array of TGocciaAsyncGeneratorRequest;
+    FQueueHead: Integer;
+    FQueueCount: Integer;
+    FQueueRunning: Boolean;
     function ResumeAsPromise(const AKind: TGocciaGeneratorResumeKind;
       const AValue: TGocciaValue): TGocciaValue;
+    function DequeueRequest(out ARequest: TGocciaAsyncGeneratorRequest): Boolean;
+    function PeekRequest(out ARequest: TGocciaAsyncGeneratorRequest): Boolean;
+    procedure EnqueueRequest(const ARequest: TGocciaAsyncGeneratorRequest);
+    procedure FinishRequest;
+    procedure ProcessQueue;
+    procedure StartRequest(const ARequest: TGocciaAsyncGeneratorRequest);
+    procedure AttachBodyAwait(const ASuspension: EGocciaAsyncAwaitSuspend);
+    procedure ContinueBodyAwait(const AValue: TGocciaValue;
+      const AIsThrow: Boolean);
+    procedure AwaitYieldValue(const AValue: TGocciaValue);
+    procedure AwaitReturnValue(const AValue: TGocciaValue;
+      const AThrowIntoGenerator: Boolean = False);
+    procedure CompleteCurrentRequest(const AValue: TGocciaValue;
+      const AIsThrow, ADone: Boolean);
+    procedure ResolveAwaitedYield(const AValue: TGocciaValue);
+    procedure RejectAwaitedYield(const AReason: TGocciaValue);
+    procedure ResolveAwaitedReturn(const AValue: TGocciaValue);
+    procedure RejectAwaitedReturn(const AReason: TGocciaValue);
   public
     constructor Create(const AContinuation: TGocciaGeneratorContinuation);
     destructor Destroy; override;
     procedure MarkReferences; override;
     function ToStringTag: string; override;
     function BuiltinTagFallback: Boolean; override;
-    function AsyncGeneratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-    function AsyncGeneratorReturn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-    function AsyncGeneratorThrow(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function AsyncGeneratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
+    function AsyncGeneratorReturn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
+    function AsyncGeneratorThrow(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; override;
     function AsyncIteratorSelf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
@@ -89,17 +138,20 @@ type
   end;
 
 procedure EnsureGeneratorPrototypeMethods(const APrototype: TGocciaObjectValue);
+procedure EnsureAsyncGeneratorPrototypeMethods(const APrototype: TGocciaObjectValue);
 
 implementation
 
 uses
   SysUtils,
 
+  Goccia.Arithmetic,
   Goccia.AST.BindingPatterns,
   Goccia.AST.Expressions,
   Goccia.AST.Statements,
   Goccia.Bytecode.Chunk,
   Goccia.Constants,
+  Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Evaluator,
@@ -110,13 +162,11 @@ uses
   Goccia.Types.Enforcement,
   Goccia.Values.ArgumentsObjectValue,
   Goccia.Values.ArrayValue,
-  Goccia.Values.Await,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.PromiseValue,
   Goccia.Values.SymbolValue;
 
 type
@@ -130,8 +180,44 @@ type
       const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
+  TGocciaAsyncGeneratorPrototypeMethodHost = class
+  public
+    function AsyncGeneratorNext(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AsyncGeneratorReturn(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function AsyncGeneratorThrow(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+  TGocciaAsyncGeneratorAwaitReturnHandler = class(TGocciaObjectValue)
+  private
+    FGenerator: TGocciaAsyncGeneratorObjectValue;
+    FReject: Boolean;
+    FReturn: Boolean;
+  public
+    constructor Create(const AGenerator: TGocciaAsyncGeneratorObjectValue;
+      const AReject: Boolean; const AReturn: Boolean = False);
+    function Invoke(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    procedure MarkReferences; override;
+  end;
+
+  TGocciaAsyncGeneratorBodyAwaitHandler = class(TGocciaObjectValue)
+  private
+    FGenerator: TGocciaAsyncGeneratorObjectValue;
+    FReject: Boolean;
+  public
+    constructor Create(const AGenerator: TGocciaAsyncGeneratorObjectValue;
+      const AReject: Boolean);
+    function Invoke(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    procedure MarkReferences; override;
+  end;
+
 var
   GGeneratorPrototypeMethodHostSlot: TGocciaRealmOwnedSlotId;
+  GAsyncGeneratorPrototypeMethodHostSlot: TGocciaRealmOwnedSlotId;
 
 function GeneratorObjectIntrinsicParent(
   const AKind: TGocciaFunctionObjectIntrinsicKind;
@@ -156,7 +242,9 @@ begin
       TGocciaObjectValue.SharedObjectPrototype,
       IteratorPrototype);
     if AKind = foikGenerator then
-      EnsureGeneratorPrototypeMethods(Result);
+      EnsureGeneratorPrototypeMethods(Result)
+    else if AKind = foikAsyncGenerator then
+      EnsureAsyncGeneratorPrototypeMethods(Result);
   finally
     if ShouldSwitchRealm then
       SetCurrentRealm(PreviousRealm);
@@ -193,6 +281,65 @@ begin
   end;
 end;
 
+function PromiseConstructorIntrinsic: TGocciaValue;
+var
+  GlobalScope: TGocciaScope;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not Assigned(CurrentRealm) or
+     not (CurrentRealm.GlobalEnv is TGocciaScope) then
+    Exit;
+
+  GlobalScope := TGocciaScope(CurrentRealm.GlobalEnv);
+  if GlobalScope.Contains(CONSTRUCTOR_PROMISE) then
+    Result := GlobalScope.GetValue(CONSTRUCTOR_PROMISE);
+end;
+
+function AsyncGeneratorPromiseResolve(
+  const AValue: TGocciaValue): TGocciaPromiseValue;
+var
+  ConstructorValue: TGocciaValue;
+  IsRooted: Boolean;
+  ValueConstructor: TGocciaValue;
+begin
+  ConstructorValue := PromiseConstructorIntrinsic;
+  if AValue is TGocciaPromiseValue then
+  begin
+    ValueConstructor := TGocciaPromiseValue(AValue).GetProperty(
+      PROP_CONSTRUCTOR);
+    if IsSameValue(ValueConstructor, ConstructorValue) then
+      Exit(TGocciaPromiseValue(AValue));
+  end;
+
+  Result := TGocciaPromiseValue.Create;
+  IsRooted := Assigned(TGarbageCollector.Instance);
+  if IsRooted then
+    TGarbageCollector.Instance.AddTempRoot(Result);
+  try
+    Result.Resolve(AValue);
+  except
+    if IsRooted then
+    begin
+      TGarbageCollector.Instance.RemoveTempRoot(Result);
+      IsRooted := False;
+    end;
+    Result.Free;
+    raise;
+  end;
+  if IsRooted then
+    TGarbageCollector.Instance.RemoveTempRoot(Result);
+end;
+
+function ExceptionToErrorValue(const AException: Exception): TGocciaValue;
+var
+  MessageText: string;
+begin
+  MessageText := AException.Message;
+  if Copy(MessageText, 1, 7) = 'Error: ' then
+    Delete(MessageText, 1, 7);
+  Result := CreateErrorObject(ERROR_NAME, MessageText);
+end;
+
 function GeneratorPrototypeMethodHost: TGocciaGeneratorPrototypeMethodHost;
 begin
   if not Assigned(CurrentRealm) then
@@ -205,13 +352,25 @@ begin
   CurrentRealm.SetOwnedSlot(GGeneratorPrototypeMethodHostSlot, Result);
 end;
 
+function AsyncGeneratorPrototypeMethodHost: TGocciaAsyncGeneratorPrototypeMethodHost;
+begin
+  if not Assigned(CurrentRealm) then
+    raise Exception.Create('AsyncGenerator prototype methods require an active realm');
+  Result := TGocciaAsyncGeneratorPrototypeMethodHost(
+    CurrentRealm.GetOwnedSlot(GAsyncGeneratorPrototypeMethodHostSlot));
+  if Assigned(Result) then
+    Exit;
+  Result := TGocciaAsyncGeneratorPrototypeMethodHost.Create;
+  CurrentRealm.SetOwnedSlot(GAsyncGeneratorPrototypeMethodHostSlot, Result);
+end;
+
 function TGocciaGeneratorPrototypeMethodHost.GeneratorNext(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  if not (AThisValue is TGocciaGeneratorObjectValue) then
+  if not (AThisValue is TGocciaGeneratorBaseValue) then
     raise TGocciaThrowValue.Create(GeneratorIncompatibleReceiverError);
-  Result := TGocciaGeneratorObjectValue(AThisValue).GeneratorNext(AArgs,
+  Result := TGocciaGeneratorBaseValue(AThisValue).GeneratorNext(AArgs,
     AThisValue);
 end;
 
@@ -219,9 +378,9 @@ function TGocciaGeneratorPrototypeMethodHost.GeneratorReturn(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  if not (AThisValue is TGocciaGeneratorObjectValue) then
+  if not (AThisValue is TGocciaGeneratorBaseValue) then
     raise TGocciaThrowValue.Create(GeneratorIncompatibleReceiverError);
-  Result := TGocciaGeneratorObjectValue(AThisValue).GeneratorReturn(AArgs,
+  Result := TGocciaGeneratorBaseValue(AThisValue).GeneratorReturn(AArgs,
     AThisValue);
 end;
 
@@ -229,10 +388,106 @@ function TGocciaGeneratorPrototypeMethodHost.GeneratorThrow(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  if not (AThisValue is TGocciaGeneratorObjectValue) then
+  if not (AThisValue is TGocciaGeneratorBaseValue) then
     raise TGocciaThrowValue.Create(GeneratorIncompatibleReceiverError);
-  Result := TGocciaGeneratorObjectValue(AThisValue).GeneratorThrow(AArgs,
+  Result := TGocciaGeneratorBaseValue(AThisValue).GeneratorThrow(AArgs,
     AThisValue);
+end;
+
+function TGocciaAsyncGeneratorPrototypeMethodHost.AsyncGeneratorNext(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaAsyncGeneratorBaseValue) then
+    Exit(RejectedTypeErrorPromise('AsyncGenerator method called on incompatible receiver'));
+  Result := TGocciaAsyncGeneratorBaseValue(AThisValue).AsyncGeneratorNext(
+    AArgs, AThisValue);
+end;
+
+function TGocciaAsyncGeneratorPrototypeMethodHost.AsyncGeneratorReturn(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaAsyncGeneratorBaseValue) then
+    Exit(RejectedTypeErrorPromise('AsyncGenerator method called on incompatible receiver'));
+  Result := TGocciaAsyncGeneratorBaseValue(AThisValue).AsyncGeneratorReturn(
+    AArgs, AThisValue);
+end;
+
+function TGocciaAsyncGeneratorPrototypeMethodHost.AsyncGeneratorThrow(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaAsyncGeneratorBaseValue) then
+    Exit(RejectedTypeErrorPromise('AsyncGenerator method called on incompatible receiver'));
+  Result := TGocciaAsyncGeneratorBaseValue(AThisValue).AsyncGeneratorThrow(
+    AArgs, AThisValue);
+end;
+
+constructor TGocciaAsyncGeneratorAwaitReturnHandler.Create(
+  const AGenerator: TGocciaAsyncGeneratorObjectValue; const AReject: Boolean;
+  const AReturn: Boolean = False);
+begin
+  inherited Create(nil);
+  FGenerator := AGenerator;
+  FReject := AReject;
+  FReturn := AReturn;
+end;
+
+function TGocciaAsyncGeneratorAwaitReturnHandler.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Value: TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not Assigned(FGenerator) then
+    Exit;
+
+  Value := ArgumentOrUndefined(AArgs);
+  if FReturn and FReject then
+    FGenerator.RejectAwaitedReturn(Value)
+  else if FReturn then
+    FGenerator.ResolveAwaitedReturn(Value)
+  else if FReject then
+    FGenerator.RejectAwaitedYield(Value)
+  else
+    FGenerator.ResolveAwaitedYield(Value);
+end;
+
+procedure TGocciaAsyncGeneratorAwaitReturnHandler.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FGenerator) then
+    FGenerator.MarkReferences;
+end;
+
+constructor TGocciaAsyncGeneratorBodyAwaitHandler.Create(
+  const AGenerator: TGocciaAsyncGeneratorObjectValue; const AReject: Boolean);
+begin
+  inherited Create(nil);
+  FGenerator := AGenerator;
+  FReject := AReject;
+end;
+
+function TGocciaAsyncGeneratorBodyAwaitHandler.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if not Assigned(FGenerator) then
+    Exit;
+
+  FGenerator.ContinueBodyAwait(ArgumentOrUndefined(AArgs), FReject);
+end;
+
+procedure TGocciaAsyncGeneratorBodyAwaitHandler.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FGenerator) then
+    FGenerator.MarkReferences;
 end;
 
 procedure EnsureGeneratorPrototypeMethods(const APrototype: TGocciaObjectValue);
@@ -271,6 +526,46 @@ begin
       TGocciaPropertyDescriptorData.Create(
         TGocciaNativeFunctionValue.CreateWithoutPrototype(
           Host.GeneratorThrow, PROP_THROW, 1),
+        [pfConfigurable, pfWritable]));
+  end;
+end;
+
+procedure EnsureAsyncGeneratorPrototypeMethods(const APrototype: TGocciaObjectValue);
+var
+  Host: TGocciaAsyncGeneratorPrototypeMethodHost;
+begin
+  if not Assigned(APrototype) then
+    Exit;
+
+  Host := nil;
+  if not APrototype.HasOwnProperty(PROP_NEXT) then
+  begin
+    if not Assigned(Host) then
+      Host := AsyncGeneratorPrototypeMethodHost;
+    APrototype.DefineProperty(PROP_NEXT,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Host.AsyncGeneratorNext, PROP_NEXT, 1),
+        [pfConfigurable, pfWritable]));
+  end;
+  if not APrototype.HasOwnProperty(PROP_RETURN) then
+  begin
+    if not Assigned(Host) then
+      Host := AsyncGeneratorPrototypeMethodHost;
+    APrototype.DefineProperty(PROP_RETURN,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Host.AsyncGeneratorReturn, PROP_RETURN, 1),
+        [pfConfigurable, pfWritable]));
+  end;
+  if not APrototype.HasOwnProperty(PROP_THROW) then
+  begin
+    if not Assigned(Host) then
+      Host := AsyncGeneratorPrototypeMethodHost;
+    APrototype.DefineProperty(PROP_THROW,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          Host.AsyncGeneratorThrow, PROP_THROW, 1),
         [pfConfigurable, pfWritable]));
   end;
 end;
@@ -507,22 +802,6 @@ begin
   FContinuation := AContinuation;
   FState := gsSuspendedStart;
   Prototype := GeneratorObjectIntrinsicParent(foikAsyncGenerator);
-  DefineProperty(PROP_NEXT,
-    TGocciaPropertyDescriptorData.Create(
-      TGocciaNativeFunctionValue.Create(AsyncGeneratorNext, PROP_NEXT, 1),
-      [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_RETURN,
-    TGocciaPropertyDescriptorData.Create(
-      TGocciaNativeFunctionValue.Create(AsyncGeneratorReturn, PROP_RETURN, 1),
-      [pfConfigurable, pfWritable]));
-  DefineProperty(PROP_THROW,
-    TGocciaPropertyDescriptorData.Create(
-      TGocciaNativeFunctionValue.Create(AsyncGeneratorThrow, PROP_THROW, 1),
-      [pfConfigurable, pfWritable]));
-  DefineSymbolProperty(TGocciaSymbolValue.WellKnownAsyncIterator,
-    TGocciaPropertyDescriptorData.Create(
-      TGocciaNativeFunctionValue.Create(AsyncIteratorSelf, '[Symbol.asyncIterator]', 0),
-      [pfConfigurable, pfWritable]));
 end;
 
 destructor TGocciaAsyncGeneratorObjectValue.Destroy;
@@ -535,63 +814,15 @@ function TGocciaAsyncGeneratorObjectValue.ResumeAsPromise(
   const AKind: TGocciaGeneratorResumeKind; const AValue: TGocciaValue): TGocciaValue;
 var
   Promise: TGocciaPromiseValue;
-  Done: Boolean;
-  UnwrappedValue: TGocciaValue;
-  Value: TGocciaValue;
+  Request: TGocciaAsyncGeneratorRequest;
 begin
   Promise := TGocciaPromiseValue.Create;
   try
-    try
-      if FState = gsCompleted then
-      begin
-        case AKind of
-          grkNext:
-            begin
-              Promise.Resolve(CreateIteratorResult(
-                TGocciaUndefinedLiteralValue.UndefinedValue, True));
-              Exit(Promise);
-            end;
-          grkThrow:
-            begin
-              Promise.Reject(AValue);
-              Exit(Promise);
-            end;
-        else
-          begin
-            UnwrappedValue := AwaitValue(AValue);
-            Promise.Resolve(CreateIteratorResult(UnwrappedValue, True));
-            Exit(Promise);
-          end;
-        end;
-      end
-      else
-      begin
-        FState := gsExecuting;
-        Value := FContinuation.Resume(AKind, AValue, Done);
-        if Done then
-          FState := gsCompleted
-        else
-          FState := gsSuspendedYield;
-      end;
-      if Done then
-      begin
-        if FContinuation.ReturnRequiresAwait then
-          UnwrappedValue := AwaitValue(Value)
-        else
-          UnwrappedValue := Value;
-      end
-      else if FContinuation.LastYieldWasDelegate then
-        UnwrappedValue := Value
-      else
-        UnwrappedValue := AwaitValue(Value);
-      Promise.Resolve(CreateIteratorResult(UnwrappedValue, Done));
-    except
-      on E: TGocciaThrowValue do
-      begin
-        FState := gsCompleted;
-        Promise.Reject(E.Value);
-      end;
-    end;
+    Request.Kind := AKind;
+    Request.Value := AValue;
+    Request.Promise := Promise;
+    EnqueueRequest(Request);
+    ProcessQueue;
   except
     Promise.Free;
     raise;
@@ -599,12 +830,433 @@ begin
   Result := Promise;
 end;
 
+function TGocciaAsyncGeneratorObjectValue.DequeueRequest(
+  out ARequest: TGocciaAsyncGeneratorRequest): Boolean;
+begin
+  Result := FQueueCount > 0;
+  if not Result then
+    Exit;
+
+  ARequest := FQueue[FQueueHead];
+  FQueue[FQueueHead].Value := nil;
+  FQueue[FQueueHead].Promise := nil;
+  Inc(FQueueHead);
+  Dec(FQueueCount);
+  if FQueueCount = 0 then
+    FQueueHead := 0;
+end;
+
+function TGocciaAsyncGeneratorObjectValue.PeekRequest(
+  out ARequest: TGocciaAsyncGeneratorRequest): Boolean;
+begin
+  Result := FQueueCount > 0;
+  if Result then
+    ARequest := FQueue[FQueueHead];
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.EnqueueRequest(
+  const ARequest: TGocciaAsyncGeneratorRequest);
+var
+  I: Integer;
+begin
+  if FQueueHead > 0 then
+  begin
+    for I := 0 to FQueueCount - 1 do
+      FQueue[I] := FQueue[FQueueHead + I];
+    for I := FQueueCount to High(FQueue) do
+    begin
+      FQueue[I].Value := nil;
+      FQueue[I].Promise := nil;
+    end;
+    FQueueHead := 0;
+  end;
+
+  if FQueueCount >= Length(FQueue) then
+    SetLength(FQueue, FQueueCount * 2 + 4);
+
+  FQueue[FQueueCount] := ARequest;
+  Inc(FQueueCount);
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.FinishRequest;
+begin
+  FQueueRunning := False;
+  ProcessQueue;
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.ProcessQueue;
+var
+  Request: TGocciaAsyncGeneratorRequest;
+begin
+  if FQueueRunning then
+    Exit;
+  if not PeekRequest(Request) then
+    Exit;
+
+  FQueueRunning := True;
+  StartRequest(Request);
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.AttachBodyAwait(
+  const ASuspension: EGocciaAsyncAwaitSuspend);
+var
+  FulfillFunction: TGocciaNativeFunctionValue;
+  FulfillHandler: TGocciaAsyncGeneratorBodyAwaitHandler;
+  RejectFunction: TGocciaNativeFunctionValue;
+  RejectHandler: TGocciaAsyncGeneratorBodyAwaitHandler;
+begin
+  FulfillHandler := TGocciaAsyncGeneratorBodyAwaitHandler.Create(Self, False);
+  FulfillFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    FulfillHandler.Invoke, 'async-generator-body-await-fulfill', 1);
+  FulfillFunction.CapturedRoot := FulfillHandler;
+
+  RejectHandler := TGocciaAsyncGeneratorBodyAwaitHandler.Create(Self, True);
+  RejectFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    RejectHandler.Invoke, 'async-generator-body-await-reject', 1);
+  RejectFunction.CapturedRoot := RejectHandler;
+
+  ASuspension.Promise.InvokeThen(FulfillFunction, RejectFunction);
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.ContinueBodyAwait(
+  const AValue: TGocciaValue; const AIsThrow: Boolean);
+var
+  Done: Boolean;
+  ResultValue: TGocciaValue;
+begin
+  try
+    FState := gsExecuting;
+    PushAsyncAwaitSuspension;
+    try
+      if AIsThrow then
+        ResultValue := FContinuation.Resume(grkThrow, AValue, Done)
+      else
+        ResultValue := FContinuation.Resume(grkNext, AValue, Done);
+    finally
+      PopAsyncAwaitSuspension;
+    end;
+
+    if Done then
+      FState := gsCompleted
+    else
+      FState := gsSuspendedYield;
+
+    if Done then
+    begin
+      if FContinuation.ReturnRequiresAwait then
+      begin
+        AwaitReturnValue(ResultValue, True);
+        Exit;
+      end;
+      CompleteCurrentRequest(ResultValue, False, True);
+    end
+    else if FContinuation.LastYieldWasDelegate then
+      CompleteCurrentRequest(ResultValue, False, False)
+    else
+      AwaitYieldValue(ResultValue);
+  except
+    on E: EGocciaAsyncAwaitSuspend do
+      AttachBodyAwait(E);
+    on E: TGocciaThrowValue do
+    begin
+      FState := gsCompleted;
+      CompleteCurrentRequest(E.Value, True, True);
+    end;
+  end;
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.AwaitYieldValue(
+  const AValue: TGocciaValue);
+var
+  AwaitPromise: TGocciaPromiseValue;
+  FulfillFunction: TGocciaNativeFunctionValue;
+  FulfillHandler: TGocciaAsyncGeneratorAwaitReturnHandler;
+  RejectFunction: TGocciaNativeFunctionValue;
+  RejectHandler: TGocciaAsyncGeneratorAwaitReturnHandler;
+begin
+  try
+    AwaitPromise := AsyncGeneratorPromiseResolve(AValue);
+  except
+    on E: TGocciaThrowValue do
+    begin
+      RejectAwaitedYield(E.Value);
+      Exit;
+    end;
+  end;
+
+  FulfillHandler := TGocciaAsyncGeneratorAwaitReturnHandler.Create(
+    Self, False, False);
+  FulfillFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    FulfillHandler.Invoke, 'async-generator-yield-fulfill', 1);
+  FulfillFunction.CapturedRoot := FulfillHandler;
+
+  RejectHandler := TGocciaAsyncGeneratorAwaitReturnHandler.Create(
+    Self, True, False);
+  RejectFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    RejectHandler.Invoke, 'async-generator-yield-reject', 1);
+  RejectFunction.CapturedRoot := RejectHandler;
+
+  AwaitPromise.InvokeThen(FulfillFunction, RejectFunction);
+end;
+
+// ES2026 §27.6.3.9 AsyncGeneratorAwaitReturn(gen)
+procedure TGocciaAsyncGeneratorObjectValue.AwaitReturnValue(
+  const AValue: TGocciaValue; const AThrowIntoGenerator: Boolean = False);
+var
+  AwaitPromise: TGocciaPromiseValue;
+  FulfillFunction: TGocciaNativeFunctionValue;
+  FulfillHandler: TGocciaAsyncGeneratorAwaitReturnHandler;
+  RejectFunction: TGocciaNativeFunctionValue;
+  RejectHandler: TGocciaAsyncGeneratorAwaitReturnHandler;
+begin
+  try
+    AwaitPromise := AsyncGeneratorPromiseResolve(AValue);
+  except
+    on E: TGocciaThrowValue do
+    begin
+      if AThrowIntoGenerator then
+        RejectAwaitedYield(E.Value)
+      else
+        RejectAwaitedReturn(E.Value);
+      Exit;
+    end;
+    on E: Exception do
+    begin
+      if AThrowIntoGenerator then
+        RejectAwaitedYield(ExceptionToErrorValue(E))
+      else
+        RejectAwaitedReturn(ExceptionToErrorValue(E));
+      Exit;
+    end;
+  end;
+
+  FulfillHandler := TGocciaAsyncGeneratorAwaitReturnHandler.Create(
+    Self, False, True);
+  FulfillFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    FulfillHandler.Invoke, 'async-generator-return-fulfill', 1);
+  FulfillFunction.CapturedRoot := FulfillHandler;
+
+  RejectHandler := TGocciaAsyncGeneratorAwaitReturnHandler.Create(
+    Self, True, True);
+  RejectFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    RejectHandler.Invoke, 'async-generator-return-reject', 1);
+  RejectFunction.CapturedRoot := RejectHandler;
+
+  AwaitPromise.InvokeThen(FulfillFunction, RejectFunction);
+end;
+
+// ES2026 §27.6.3.5 AsyncGeneratorCompleteStep(gen, completion, done)
+procedure TGocciaAsyncGeneratorObjectValue.CompleteCurrentRequest(
+  const AValue: TGocciaValue; const AIsThrow, ADone: Boolean);
+var
+  Request: TGocciaAsyncGeneratorRequest;
+begin
+  if not DequeueRequest(Request) then
+  begin
+    FQueueRunning := False;
+    Exit;
+  end;
+
+  if AIsThrow then
+    Request.Promise.Reject(AValue)
+  else
+  Request.Promise.Resolve(CreateIteratorResult(AValue, ADone));
+  FinishRequest;
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.ResolveAwaitedYield(
+  const AValue: TGocciaValue);
+begin
+  CompleteCurrentRequest(AValue, False, False);
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.RejectAwaitedYield(
+  const AReason: TGocciaValue);
+var
+  Done: Boolean;
+  ResultValue: TGocciaValue;
+begin
+  try
+    FState := gsExecuting;
+    PushAsyncAwaitSuspension;
+    try
+      ResultValue := FContinuation.Resume(grkThrow, AReason, Done);
+    finally
+      PopAsyncAwaitSuspension;
+    end;
+    if Done then
+      FState := gsCompleted
+    else
+      FState := gsSuspendedYield;
+
+    if Done then
+    begin
+      if FContinuation.ReturnRequiresAwait then
+      begin
+        AwaitReturnValue(ResultValue, True);
+        Exit;
+      end;
+      CompleteCurrentRequest(ResultValue, False, True);
+    end
+    else if FContinuation.LastYieldWasDelegate then
+      CompleteCurrentRequest(ResultValue, False, False)
+    else
+      AwaitYieldValue(ResultValue);
+  except
+    on E: EGocciaAsyncAwaitSuspend do
+      AttachBodyAwait(E);
+    on E: TGocciaThrowValue do
+    begin
+      FState := gsCompleted;
+      CompleteCurrentRequest(E.Value, True, True);
+    end;
+  end;
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.ResolveAwaitedReturn(
+  const AValue: TGocciaValue);
+begin
+  CompleteCurrentRequest(AValue, False, True);
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.RejectAwaitedReturn(
+  const AReason: TGocciaValue);
+begin
+  CompleteCurrentRequest(AReason, True, True);
+end;
+
+procedure TGocciaAsyncGeneratorObjectValue.StartRequest(
+  const ARequest: TGocciaAsyncGeneratorRequest);
+var
+  CheckedPromise: TGocciaPromiseValue;
+  Done: Boolean;
+  UnwrappedValue: TGocciaValue;
+  Value: TGocciaValue;
+begin
+  try
+    if (ARequest.Kind = grkReturn) and
+       (FState in [gsSuspendedStart, gsCompleted]) then
+    begin
+      FState := gsCompleted;
+      AwaitReturnValue(ARequest.Value);
+      Exit;
+    end;
+
+    if FState = gsCompleted then
+    begin
+      case ARequest.Kind of
+        grkNext:
+          begin
+            CompleteCurrentRequest(TGocciaUndefinedLiteralValue.UndefinedValue,
+              False, True);
+            Exit;
+          end;
+        grkThrow:
+          begin
+            CompleteCurrentRequest(ARequest.Value, True, True);
+            Exit;
+          end;
+      else
+        begin
+          AwaitReturnValue(ARequest.Value);
+          Exit;
+        end;
+      end;
+    end;
+
+    if (ARequest.Kind = grkReturn) and
+       (FState = gsSuspendedYield) and
+       (ARequest.Value is TGocciaPromiseValue) then
+    begin
+      try
+        CheckedPromise := AsyncGeneratorPromiseResolve(ARequest.Value);
+        CheckedPromise := nil;
+      except
+        on E: TGocciaThrowValue do
+        begin
+          RejectAwaitedYield(E.Value);
+          Exit;
+        end;
+        on E: Exception do
+        begin
+          RejectAwaitedYield(ExceptionToErrorValue(E));
+          Exit;
+        end;
+      end;
+    end;
+
+    FState := gsExecuting;
+    PushAsyncAwaitSuspension;
+    try
+      Value := FContinuation.Resume(ARequest.Kind, ARequest.Value, Done);
+    finally
+      PopAsyncAwaitSuspension;
+    end;
+    if Done then
+      FState := gsCompleted
+    else
+      FState := gsSuspendedYield;
+
+    if Done then
+    begin
+      if FContinuation.ReturnRequiresAwait then
+      begin
+        AwaitReturnValue(Value, True);
+        Exit;
+      end;
+      UnwrappedValue := Value;
+    end
+    else if FContinuation.LastYieldWasDelegate then
+      UnwrappedValue := Value
+    else
+    begin
+      AwaitYieldValue(Value);
+      Exit;
+    end;
+
+    CompleteCurrentRequest(UnwrappedValue, False, Done);
+  except
+    on E: EGocciaAsyncAwaitSuspend do
+    begin
+      AttachBodyAwait(E);
+    end;
+    on E: TGocciaThrowValue do
+    begin
+      FState := gsCompleted;
+      CompleteCurrentRequest(E.Value, True, True);
+    end;
+    on E: Exception do
+    begin
+      if ARequest.Kind = grkReturn then
+      begin
+        FState := gsCompleted;
+        CompleteCurrentRequest(ExceptionToErrorValue(E), True, True);
+        Exit;
+      end;
+      raise;
+    end;
+  end;
+end;
+
 procedure TGocciaAsyncGeneratorObjectValue.MarkReferences;
+var
+  I: Integer;
+  Index: Integer;
 begin
   if GCMarked then Exit;
   inherited;
   if Assigned(FContinuation) then
     FContinuation.MarkReferences;
+  for I := 0 to FQueueCount - 1 do
+  begin
+    Index := FQueueHead + I;
+    if (Index < 0) or (Index > High(FQueue)) then
+      Continue;
+    if Assigned(FQueue[Index].Value) then
+      FQueue[Index].Value.MarkReferences;
+    if Assigned(FQueue[Index].Promise) then
+      FQueue[Index].Promise.MarkReferences;
+  end;
 end;
 
 function TGocciaAsyncGeneratorObjectValue.ToStringTag: string;
@@ -1085,5 +1737,7 @@ end;
 initialization
   GGeneratorPrototypeMethodHostSlot := RegisterRealmOwnedSlot(
     'Generator prototype method host');
+  GAsyncGeneratorPrototypeMethodHostSlot := RegisterRealmOwnedSlot(
+    'AsyncGenerator prototype method host');
 
 end.

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -334,7 +334,7 @@ begin
   if ValueWasRooted then
     GC.AddTempRoot(AValue);
   try
-    Result := TGocciaObjectValue.Create;
+    Result := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
     ResultWasRooted := Assigned(GC) and not GC.IsTempRoot(Result);
     if ResultWasRooted then
       GC.AddTempRoot(Result);

--- a/tests/language/function-keyword/prototype-property.js
+++ b/tests/language/function-keyword/prototype-property.js
@@ -406,6 +406,208 @@ test("async generator prototype assignment updates the own prototype property", 
   expect(g.prototype).toBe(replacement);
 });
 
+const expectWritableNonEnumerableConfigurableMethod = (descriptor) => {
+  expect(descriptor).toBeDefined();
+  if (descriptor !== undefined) {
+    expect(typeof descriptor.value).toBe("function");
+    expect(descriptor.writable).toBe(true);
+    expect(descriptor.enumerable).toBe(false);
+    expect(descriptor.configurable).toBe(true);
+  }
+};
+
+test("generator prototype exposes inherited next return and throw methods", () => {
+  function* values() {
+    yield 1;
+  }
+
+  const iterator = values();
+  const generatorPrototype = Object.getPrototypeOf(values.prototype);
+  expect(Object.getPrototypeOf(Object.getPrototypeOf(iterator))).toBe(generatorPrototype);
+  expect(Object.getOwnPropertyDescriptor(iterator, "next")).toBeUndefined();
+  expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(iterator), "next")).toBeUndefined();
+
+  expectWritableNonEnumerableConfigurableMethod(
+    Object.getOwnPropertyDescriptor(generatorPrototype, "next"),
+  );
+  expectWritableNonEnumerableConfigurableMethod(
+    Object.getOwnPropertyDescriptor(generatorPrototype, "return"),
+  );
+  expectWritableNonEnumerableConfigurableMethod(
+    Object.getOwnPropertyDescriptor(generatorPrototype, "throw"),
+  );
+});
+
+test("generator next and return create ordinary iterator result objects", () => {
+  function* values() {
+    yield 1;
+  }
+
+  const iterator = values();
+  const nextResult = iterator.next();
+  const returnResult = iterator.return(2);
+
+  expect(Object.getPrototypeOf(nextResult)).toBe(Object.prototype);
+  expect(Object.getOwnPropertyDescriptor(nextResult, "value")).toEqual({
+    value: 1,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  expect(Object.getOwnPropertyDescriptor(nextResult, "done")).toEqual({
+    value: false,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  expect(Object.getPrototypeOf(returnResult)).toBe(Object.prototype);
+  expect(Object.getOwnPropertyDescriptor(returnResult, "value")).toEqual({
+    value: 2,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  expect(Object.getOwnPropertyDescriptor(returnResult, "done")).toEqual({
+    value: true,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+});
+
+test("async generator prototype exposes inherited next return and throw methods", () => {
+  async function* values() {
+    yield 1;
+  }
+
+  const iterator = values();
+  const asyncGeneratorPrototype = Object.getPrototypeOf(values.prototype);
+  expect(Object.getPrototypeOf(Object.getPrototypeOf(iterator))).toBe(asyncGeneratorPrototype);
+  expect(Object.getOwnPropertyDescriptor(iterator, "next")).toBeUndefined();
+  expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(iterator), "next")).toBeUndefined();
+
+  expectWritableNonEnumerableConfigurableMethod(
+    Object.getOwnPropertyDescriptor(asyncGeneratorPrototype, "next"),
+  );
+  expectWritableNonEnumerableConfigurableMethod(
+    Object.getOwnPropertyDescriptor(asyncGeneratorPrototype, "return"),
+  );
+  expectWritableNonEnumerableConfigurableMethod(
+    Object.getOwnPropertyDescriptor(asyncGeneratorPrototype, "throw"),
+  );
+});
+
+test("async generator next and return create ordinary iterator result objects", async () => {
+  async function* values() {
+    yield 1;
+  }
+
+  const iterator = values();
+  const nextResult = await iterator.next();
+  const returnResult = await iterator.return(2);
+
+  expect(Object.getPrototypeOf(nextResult)).toBe(Object.prototype);
+  expect(Object.getOwnPropertyDescriptor(nextResult, "value")).toEqual({
+    value: 1,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  expect(Object.getOwnPropertyDescriptor(nextResult, "done")).toEqual({
+    value: false,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  expect(Object.getPrototypeOf(returnResult)).toBe(Object.prototype);
+  expect(Object.getOwnPropertyDescriptor(returnResult, "value")).toEqual({
+    value: 2,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  expect(Object.getOwnPropertyDescriptor(returnResult, "done")).toEqual({
+    value: true,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+});
+
+test("async generator return awaits fulfilled and rejected promise values", async () => {
+  async function* empty() {}
+  async function* values() {
+    yield 1;
+  }
+
+  await expect(empty().return(Promise.resolve("done"))).resolves.toEqual({
+    value: "done",
+    done: true,
+  });
+  await expect(empty().return(Promise.reject("boom"))).rejects.toBe("boom");
+
+  const iterator = values();
+  await expect(iterator.next()).resolves.toEqual({ value: 1, done: false });
+  await expect(iterator.return(Promise.resolve(2))).resolves.toEqual({
+    value: 2,
+    done: true,
+  });
+});
+
+test("async generator queued requests wait behind awaited return fulfillment", async () => {
+  const events = [];
+  async function* values() {
+    yield 1;
+  }
+
+  const iterator = values();
+  await iterator.next();
+  const returnValue = Promise.resolve().then(() => {
+    events.push("return value");
+    return 2;
+  });
+  const returned = iterator.return(returnValue).then((result) => {
+    events.push("return:" + result.value + ":" + result.done);
+  });
+  const nexted = iterator.next().then((result) => {
+    events.push("next:" + result.value + ":" + result.done);
+  });
+
+  const tick = Promise.resolve().then(() => events.push("tick"));
+  await Promise.all([returned, nexted, tick]);
+  expect(events).toEqual([
+    "return value",
+    "tick",
+    "return:2:true",
+    "next:undefined:true",
+  ]);
+});
+
+test("async generator queued requests drain after awaited return rejection", async () => {
+  const events = [];
+  async function* values() {
+    yield 1;
+  }
+
+  const iterator = values();
+  await iterator.next();
+  const returned = iterator.return(Promise.reject("boom")).then(
+    () => events.push("return fulfilled"),
+    (reason) => events.push("return rejected:" + reason),
+  );
+  const nexted = iterator.next().then((result) => {
+    events.push("next:" + result.value + ":" + result.done);
+  });
+
+  await Promise.all([returned, nexted]);
+  expect(events).toEqual([
+    "return rejected:boom",
+    "next:undefined:true",
+  ]);
+});
+
 test("arrow function does NOT have own prototype property", () => {
   const f = () => 42;
   expect(f.prototype).toBeUndefined();

--- a/tests/language/function-keyword/prototype-property.js
+++ b/tests/language/function-keyword/prototype-property.js
@@ -556,6 +556,33 @@ test("async generator return awaits fulfilled and rejected promise values", asyn
   });
 });
 
+test("async generator return resolves promised value once before finally", async () => {
+  const events = [];
+  const returnedValue = Promise.resolve("done");
+  Object.defineProperty(returnedValue, "constructor", {
+    get() {
+      events.push("constructor");
+      return Promise;
+    },
+  });
+
+  async function* values() {
+    try {
+      yield 1;
+    } finally {
+      events.push("finally");
+    }
+  }
+
+  const iterator = values();
+  await iterator.next();
+  await expect(iterator.return(returnedValue)).resolves.toEqual({
+    value: "done",
+    done: true,
+  });
+  expect(events).toEqual(["constructor", "finally"]);
+});
+
 test("async generator queued requests wait behind awaited return fulfillment", async () => {
   const events = [];
   async function* values() {


### PR DESCRIPTION
## Summary

- Move generator and async generator `next`/`return`/`throw` methods from instances onto `%GeneratorPrototype%` and `%AsyncGeneratorPrototype%` for both interpreter and bytecode objects.
- Return ordinary iterator result objects and add async generator request queue/await-return handling so `return()` awaits values and drains queued requests correctly.
- Keep interpreted async generator request promises queue-managed after enqueueing, matching the bytecode path and avoiding dangling queued promise references if queue processing propagates.
- Add focused regressions for inherited prototype methods, ordinary iterator results, and async generator awaited return fulfillment/rejection.
- Closes #844.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation run:

- `./build.pas testrunner`
- `./build.pas loaderbare`
- `./build/GocciaTestRunner tests`
- `./build/GocciaTestRunner tests --mode=bytecode`
- `./build/GocciaTestRunner tests/language/function-keyword/prototype-property.js`
- `./build/GocciaTestRunner tests/language/function-keyword/prototype-property.js --mode=bytecode`
- `./format.pas --check`
- `git diff --check`
- `git diff --staged --check`
- `bun scripts/run_test262_suite.ts --suite-dir tmp/test262-suite --categories built-ins --filter 'built-ins/GeneratorPrototype/**' --mode interpreted --jobs 4 --timeout-ms 20000 --output tmp/test262-generator-prototype-interpreted-final3.json`
- `bun scripts/run_test262_suite.ts --suite-dir tmp/test262-suite --categories built-ins --filter 'built-ins/GeneratorPrototype/**' --mode bytecode --jobs 4 --timeout-ms 20000 --output tmp/test262-generator-prototype-bytecode-final3.json`
- `bun scripts/run_test262_suite.ts --suite-dir tmp/test262-suite --categories built-ins --filter 'built-ins/AsyncGeneratorPrototype/**' --mode interpreted --jobs 4 --timeout-ms 20000 --output tmp/test262-async-generator-prototype-interpreted-final4.json`
- `bun scripts/run_test262_suite.ts --suite-dir tmp/test262-suite --categories built-ins --filter 'built-ins/AsyncGeneratorPrototype/**' --mode bytecode --jobs 4 --timeout-ms 20000 --output tmp/test262-async-generator-prototype-bytecode-final4.json`
- `bun scripts/run_test262_suite.ts --suite-dir tmp/test262-suite --categories staging,intl402 --filter '**/*Generator*.js' --mode interpreted --jobs 4 --timeout-ms 20000 --output tmp/test262-generator-staging-intl402-interpreted-final3.json`
- `bun scripts/run_test262_suite.ts --suite-dir tmp/test262-suite --categories staging,intl402 --filter '**/*Generator*.js' --mode bytecode --jobs 4 --timeout-ms 20000 --output tmp/test262-generator-staging-intl402-bytecode-final3.json`

Review fix validation:

- `./build.pas testrunner`
- `./format.pas --check`
- `git diff --check`
- `git diff --staged --check`
- `./build/GocciaTestRunner tests/language/function-keyword/prototype-property.js`
- `./build/GocciaTestRunner tests/language/function-keyword/prototype-property.js --mode=bytecode`
- `./build/GocciaTestRunner tests/language/async-generators/object-method.js`
- `./build/GocciaTestRunner tests/language/async-generators/object-method.js --mode=bytecode`
- `./build/GocciaTestRunner tests`
- `./build/GocciaTestRunner tests --mode=bytecode`
