### PR TITLE
fix(string): complete String test262 conformance

### DIFF
--- a/scripts/test-cli-lexer.ts
+++ b/scripts/test-cli-lexer.ts
@@ -79,6 +79,27 @@ console.log("String line continuation...");
   }
 }
 
+// -- Large padded braced Unicode escapes ----------------------------------------
+
+console.log("String braced Unicode escapes with large padding...");
+{
+  const padding = "0".repeat(65536);
+  const cases: [string, string][] = [
+    [`"\\u{${padding}1234}".charCodeAt(0);\n`, "string literal"],
+  ];
+
+  for (const [source, desc] of cases) {
+    const { exitCode, json, stderr } = runLoaderJson(source, ["--print"], { timeout: 10000 });
+    if (exitCode !== 0) {
+      throw new Error(`Large padded ${desc} escape should succeed, but failed: ${stderr.trim()}`);
+    }
+    const result = json.files?.[0]?.result;
+    if (result !== 0x1234) {
+      throw new Error(`Large padded ${desc} escape should produce 0x1234, got ${JSON.stringify(result)}`);
+    }
+  }
+}
+
 // -- Lexer errors surface as SyntaxError (#626) ---------------------------------
 
 console.log("Lexer errors are SyntaxError...");

--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -79,6 +79,7 @@ function TryICUFormatRelativeTimeToParts(const ALocale: string; AValue: Double;
 
 function TryICUGetDefaultLocale(out ALocale: string): Boolean;
 
+function TryICUNormalize(const AForm, AStr: string; out AResult: string): Boolean;
 function TryICUUpperCase(const ALocale, AStr: string; out AResult: string): Boolean;
 function TryICULowerCase(const ALocale, AStr: string; out AResult: string): Boolean;
 
@@ -433,11 +434,14 @@ type
   TUcasemapOpen = function(const ALocale: PAnsiChar; AOptions: LongInt;
     var AStatus: TICUErrorCode): TUCaseMap; cdecl;
   TUcasemapClose = procedure(ACsm: TUCaseMap); cdecl;
-  TUcasemapUtf8ToUpper = function(ACsm: TUCaseMap; ADest: PAnsiChar;
+  TUcasemapUtf8Map = function(ACsm: TUCaseMap; ADest: PAnsiChar;
     ADestCapacity: LongInt; const ASrc: PAnsiChar; ASrcLength: LongInt;
     var AStatus: TICUErrorCode): LongInt; cdecl;
-  TUcasemapUtf8ToLower = function(ACsm: TUCaseMap; ADest: PAnsiChar;
-    ADestCapacity: LongInt; const ASrc: PAnsiChar; ASrcLength: LongInt;
+  TUcasemapUtf8ToUpper = TUcasemapUtf8Map;
+  TUcasemapUtf8ToLower = TUcasemapUtf8Map;
+  TUnorm2GetInstance = function(var AStatus: TICUErrorCode): Pointer; cdecl;
+  TUnorm2Normalize = function(ANormalizer: Pointer; const ASrc: PUChar;
+    ASrcLength: LongInt; ADest: PUChar; ADestCapacity: LongInt;
     var AStatus: TICUErrorCode): LongInt; cdecl;
   TIntlICUFunctions = record
     UlocGetDefault: TUlocGetDefault;
@@ -536,6 +540,11 @@ type
     UcasemapClose: TUcasemapClose;
     UcasemapUtf8ToUpper: TUcasemapUtf8ToUpper;
     UcasemapUtf8ToLower: TUcasemapUtf8ToLower;
+    Unorm2GetNFCInstance: TUnorm2GetInstance;
+    Unorm2GetNFDInstance: TUnorm2GetInstance;
+    Unorm2GetNFKCInstance: TUnorm2GetInstance;
+    Unorm2GetNFKDInstance: TUnorm2GetInstance;
+    Unorm2Normalize: TUnorm2Normalize;
   end;
 
   TICUFieldSpan = record
@@ -812,6 +821,16 @@ begin
   if Assigned(S) then F.UcasemapUtf8ToUpper := TUcasemapUtf8ToUpper(S);
   S := ResolveSymbol(AHandle, 'ucasemap_utf8ToLower');
   if Assigned(S) then F.UcasemapUtf8ToLower := TUcasemapUtf8ToLower(S);
+  S := ResolveSymbol(AHandle, 'unorm2_getNFCInstance');
+  if Assigned(S) then F.Unorm2GetNFCInstance := TUnorm2GetInstance(S);
+  S := ResolveSymbol(AHandle, 'unorm2_getNFDInstance');
+  if Assigned(S) then F.Unorm2GetNFDInstance := TUnorm2GetInstance(S);
+  S := ResolveSymbol(AHandle, 'unorm2_getNFKCInstance');
+  if Assigned(S) then F.Unorm2GetNFKCInstance := TUnorm2GetInstance(S);
+  S := ResolveSymbol(AHandle, 'unorm2_getNFKDInstance');
+  if Assigned(S) then F.Unorm2GetNFKDInstance := TUnorm2GetInstance(S);
+  S := ResolveSymbol(AHandle, 'unorm2_normalize');
+  if Assigned(S) then F.Unorm2Normalize := TUnorm2Normalize(S);
 
   IntlFunctions := F;
   Result := True;
@@ -3867,11 +3886,76 @@ begin
   Result := ALocale <> '';
 end;
 
-function TryICUUpperCase(const ALocale, AStr: string; out AResult: string): Boolean;
+function TryICUNormalize(const AForm, AStr: string; out AResult: string): Boolean;
+var
+  Getter: TUnorm2GetInstance;
+  Normalizer: Pointer;
+  Status: TICUErrorCode;
+  Source, Normalized: UnicodeString;
+  Buffer: array of WideChar;
+  Capacity, ResultLen: LongInt;
+begin
+  Result := False;
+  AResult := AStr;
+
+  if not EnsureLoaded then
+    Exit;
+
+  if not Assigned(IntlFunctions.Unorm2Normalize) then
+    Exit;
+
+  Getter := nil;
+  if AForm = 'NFC' then
+    Getter := IntlFunctions.Unorm2GetNFCInstance
+  else if AForm = 'NFD' then
+    Getter := IntlFunctions.Unorm2GetNFDInstance
+  else if AForm = 'NFKC' then
+    Getter := IntlFunctions.Unorm2GetNFKCInstance
+  else if AForm = 'NFKD' then
+    Getter := IntlFunctions.Unorm2GetNFKDInstance;
+
+  if not Assigned(Getter) then
+    Exit;
+
+  Status := ICU_SUCCESS;
+  Normalizer := Getter(Status);
+  if not ICUSucceeded(Status) or not Assigned(Normalizer) then
+    Exit;
+
+  Source := UnicodeString(AStr);
+  Capacity := Max(Length(Source) * 4 + 8, 8);
+  repeat
+    SetLength(Buffer, Capacity);
+    Status := ICU_SUCCESS;
+    ResultLen := IntlFunctions.Unorm2Normalize(Normalizer,
+      PWideChar(Source), Length(Source), @Buffer[0], Capacity, Status);
+    if (Status = ICU_BUFFER_OVERFLOW) or (ResultLen > Capacity) then
+      Capacity := Max(ResultLen, Capacity * 2)
+    else
+      Break;
+  until False;
+
+  if not ICUSucceeded(Status) or (ResultLen < 0) then
+    Exit;
+
+  if ResultLen = 0 then
+    AResult := ''
+  else
+  begin
+    SetLength(Normalized, ResultLen);
+    Move(Buffer[0], Normalized[1], ResultLen * SizeOf(WideChar));
+    AResult := string(Normalized);
+  end;
+  Result := True;
+end;
+
+function TryICUCaseMapUTF8(const ALocale, AStr: string;
+  AMap: TUcasemapUtf8ToUpper; out AResult: string): Boolean;
 var
   Status: TICUErrorCode;
   CaseMap: TUCaseMap;
-  DestBuf: array[0..1023] of AnsiChar;
+  DestBuf: array of AnsiChar;
+  DestCapacity: LongInt;
   ResultLen: LongInt;
   LocaleAnsi, SrcAnsi: AnsiString;
   ResultUtf8: UTF8String;
@@ -3883,8 +3967,7 @@ begin
     Exit;
 
   if not Assigned(IntlFunctions.UcasemapOpen) or
-     not Assigned(IntlFunctions.UcasemapClose) or
-     not Assigned(IntlFunctions.UcasemapUtf8ToUpper) then
+     not Assigned(IntlFunctions.UcasemapClose) or not Assigned(AMap) then
     Exit;
 
   LocaleAnsi := AnsiString(ALocale);
@@ -3896,11 +3979,19 @@ begin
     Exit;
 
   try
-    FillChar(DestBuf, SizeOf(DestBuf), 0);
-    Status := ICU_SUCCESS;
-    ResultLen := IntlFunctions.UcasemapUtf8ToUpper(CaseMap,
-      @DestBuf[0], 1024, PAnsiChar(SrcAnsi), Length(SrcAnsi), Status);
-    if not ICUSucceeded(Status) or (ResultLen <= 0) then
+    DestCapacity := Max(Length(SrcAnsi) * 4 + 8, 8);
+    repeat
+      SetLength(DestBuf, DestCapacity);
+      Status := ICU_SUCCESS;
+      ResultLen := AMap(CaseMap, @DestBuf[0], DestCapacity,
+        PAnsiChar(SrcAnsi), Length(SrcAnsi), Status);
+      if (Status = ICU_BUFFER_OVERFLOW) or (ResultLen > DestCapacity) then
+        DestCapacity := Max(ResultLen, DestCapacity * 2)
+      else
+        Break;
+    until False;
+
+    if not ICUSucceeded(Status) or (ResultLen < 0) then
       Exit;
 
     SetLength(ResultUtf8, ResultLen);
@@ -3913,50 +4004,26 @@ begin
   end;
 end;
 
-function TryICULowerCase(const ALocale, AStr: string; out AResult: string): Boolean;
-var
-  Status: TICUErrorCode;
-  CaseMap: TUCaseMap;
-  DestBuf: array[0..1023] of AnsiChar;
-  ResultLen: LongInt;
-  LocaleAnsi, SrcAnsi: AnsiString;
-  ResultUtf8: UTF8String;
+function TryICUUpperCase(const ALocale, AStr: string; out AResult: string): Boolean;
 begin
-  Result := False;
-  AResult := AStr;
-
   if not EnsureLoaded then
-    Exit;
-
-  if not Assigned(IntlFunctions.UcasemapOpen) or
-     not Assigned(IntlFunctions.UcasemapClose) or
-     not Assigned(IntlFunctions.UcasemapUtf8ToLower) then
-    Exit;
-
-  LocaleAnsi := AnsiString(ALocale);
-  SrcAnsi := AnsiString(UTF8Encode(UnicodeString(AStr)));
-
-  Status := ICU_SUCCESS;
-  CaseMap := IntlFunctions.UcasemapOpen(PAnsiChar(LocaleAnsi), 0, Status);
-  if not ICUSucceeded(Status) or not Assigned(CaseMap) then
-    Exit;
-
-  try
-    FillChar(DestBuf, SizeOf(DestBuf), 0);
-    Status := ICU_SUCCESS;
-    ResultLen := IntlFunctions.UcasemapUtf8ToLower(CaseMap,
-      @DestBuf[0], 1024, PAnsiChar(SrcAnsi), Length(SrcAnsi), Status);
-    if not ICUSucceeded(Status) or (ResultLen <= 0) then
-      Exit;
-
-    SetLength(ResultUtf8, ResultLen);
-    if ResultLen > 0 then
-      Move(DestBuf[0], ResultUtf8[1], ResultLen);
-    AResult := string(UTF8Decode(ResultUtf8));
-    Result := True;
-  finally
-    IntlFunctions.UcasemapClose(CaseMap);
+  begin
+    AResult := AStr;
+    Exit(False);
   end;
+  Result := TryICUCaseMapUTF8(ALocale, AStr,
+    IntlFunctions.UcasemapUtf8ToUpper, AResult);
+end;
+
+function TryICULowerCase(const ALocale, AStr: string; out AResult: string): Boolean;
+begin
+  if not EnsureLoaded then
+  begin
+    AResult := AStr;
+    Exit(False);
+  end;
+  Result := TryICUCaseMapUTF8(ALocale, AStr,
+    IntlFunctions.UcasemapUtf8ToLower, AResult);
 end;
 
 initialization

--- a/source/shared/TextSemantics.Test.pas
+++ b/source/shared/TextSemantics.Test.pas
@@ -69,12 +69,17 @@ procedure TTextSemanticsTests.TestUnicodeCaseMapping;
 const
   UPPER_TEXT = #$C3#$89 + #$C3#$96 + #$CE#$A3;
   LOWER_TEXT = #$C3#$A9 + #$C3#$B6 + #$CF#$82;
+  NONCHARACTER = #$EF#$B7#$90;
 begin
   Expect<string>(UnicodeLowerCaseUTF8(UPPER_TEXT)).ToBe(LOWER_TEXT);
   Expect<string>(UnicodeUpperCaseUTF8(LOWER_TEXT)).ToBe(UPPER_TEXT);
   Expect<string>(UnicodeLowerCaseUTF8(#$C4#$B0)).ToBe('i' + #$CC#$87);
   Expect<string>(UnicodeLowerCaseUTF8('A' + #$CE#$A3)).ToBe(
     'a' + #$CF#$82);
+  Expect<string>(UnicodeUpperCaseUTF8('a' + NONCHARACTER + #$C3#$9F)).ToBe(
+    'A' + NONCHARACTER + 'SS');
+  Expect<string>(UnicodeLowerCaseUTF8('A' + NONCHARACTER + #$C4#$B0)).ToBe(
+    'a' + NONCHARACTER + 'i' + #$CC#$87);
 end;
 
 procedure TTextSemanticsTests.TestUTF8WellFormedChecks;

--- a/source/shared/TextSemantics.Test.pas
+++ b/source/shared/TextSemantics.Test.pas
@@ -70,6 +70,7 @@ const
   UPPER_TEXT = #$C3#$89 + #$C3#$96 + #$CE#$A3;
   LOWER_TEXT = #$C3#$A9 + #$C3#$B6 + #$CF#$82;
   NONCHARACTER = #$EF#$B7#$90;
+  UTF8_HIGH_SURROGATE = #$ED#$A0#$80;
 begin
   Expect<string>(UnicodeLowerCaseUTF8(UPPER_TEXT)).ToBe(LOWER_TEXT);
   Expect<string>(UnicodeUpperCaseUTF8(LOWER_TEXT)).ToBe(UPPER_TEXT);
@@ -80,6 +81,10 @@ begin
     'A' + NONCHARACTER + 'SS');
   Expect<string>(UnicodeLowerCaseUTF8('A' + NONCHARACTER + #$C4#$B0)).ToBe(
     'a' + NONCHARACTER + 'i' + #$CC#$87);
+  Expect<string>(UnicodeLowerCaseUTF8('A' + UTF8_HIGH_SURROGATE)).ToBe(
+    'a' + UTF8_HIGH_SURROGATE);
+  Expect<string>(UnicodeUpperCaseUTF8('a' + UTF8_HIGH_SURROGATE)).ToBe(
+    'A' + UTF8_HIGH_SURROGATE);
 end;
 
 procedure TTextSemanticsTests.TestUTF8WellFormedChecks;

--- a/source/shared/TextSemantics.Test.pas
+++ b/source/shared/TextSemantics.Test.pas
@@ -15,6 +15,7 @@ type
     procedure TestTrimECMAScriptWhitespace;
     procedure TestUnicodeCaseMapping;
     procedure TestUTF8WellFormedChecks;
+    procedure TestUTF16WellFormedChecks;
     procedure TestUTF8CodePointIndexing;
     procedure TestUTF16CodeUnitIndexing;
     procedure TestReplacementPatternExpansion;
@@ -32,6 +33,8 @@ begin
     TestUnicodeCaseMapping);
   Test('UTF-8 well-formed helpers reject invalid sequences',
     TestUTF8WellFormedChecks);
+  Test('UTF-16 well-formed helpers follow surrogate pairing',
+    TestUTF16WellFormedChecks);
   Test('UTF-8 code point helpers index multibyte characters',
     TestUTF8CodePointIndexing);
   Test('UTF-16 code unit helpers count astral characters as surrogate pairs',
@@ -65,10 +68,13 @@ end;
 procedure TTextSemanticsTests.TestUnicodeCaseMapping;
 const
   UPPER_TEXT = #$C3#$89 + #$C3#$96 + #$CE#$A3;
-  LOWER_TEXT = #$C3#$A9 + #$C3#$B6 + #$CF#$83;
+  LOWER_TEXT = #$C3#$A9 + #$C3#$B6 + #$CF#$82;
 begin
   Expect<string>(UnicodeLowerCaseUTF8(UPPER_TEXT)).ToBe(LOWER_TEXT);
   Expect<string>(UnicodeUpperCaseUTF8(LOWER_TEXT)).ToBe(UPPER_TEXT);
+  Expect<string>(UnicodeLowerCaseUTF8(#$C4#$B0)).ToBe('i' + #$CC#$87);
+  Expect<string>(UnicodeLowerCaseUTF8('A' + #$CE#$A3)).ToBe(
+    'a' + #$CF#$82);
 end;
 
 procedure TTextSemanticsTests.TestUTF8WellFormedChecks;
@@ -86,6 +92,29 @@ begin
     UTF8_REPLACEMENT_CHARACTER + 'AB');
   Expect<string>(ToWellFormedUTF8(#$E2#$80 + 'A')).ToBe(
     UTF8_REPLACEMENT_CHARACTER + 'A');
+end;
+
+procedure TTextSemanticsTests.TestUTF16WellFormedChecks;
+const
+  UTF8_HIGH_SURROGATE = #$ED#$A0#$BD;
+  UTF8_LOW_SURROGATE = #$ED#$B2#$A9;
+  UTF8_PILE_OF_POO = #$F0#$9F#$92#$A9;
+begin
+  Expect<Boolean>(IsWellFormedUTF16('a' + UTF8_HIGH_SURROGATE +
+    UTF8_LOW_SURROGATE + 'd')).ToBe(True);
+  Expect<Boolean>(IsWellFormedUTF16(UTF8_PILE_OF_POO)).ToBe(True);
+  Expect<Boolean>(IsWellFormedUTF16(UTF8_HIGH_SURROGATE)).ToBe(False);
+  Expect<Boolean>(IsWellFormedUTF16(UTF8_LOW_SURROGATE)).ToBe(False);
+  Expect<Boolean>(IsWellFormedUTF16(UTF8_HIGH_SURROGATE +
+    UTF8_HIGH_SURROGATE)).ToBe(False);
+  Expect<string>(ToWellFormedUTF16('a' + UTF8_HIGH_SURROGATE +
+    UTF8_LOW_SURROGATE + 'd')).ToBe(
+    'a' + UTF8_HIGH_SURROGATE + UTF8_LOW_SURROGATE + 'd');
+  Expect<string>(ToWellFormedUTF16('a' + UTF8_HIGH_SURROGATE + 'd')).ToBe(
+    'a' + UTF8_REPLACEMENT_CHARACTER + 'd');
+  Expect<string>(ToWellFormedUTF16(UTF8_LOW_SURROGATE +
+    UTF8_HIGH_SURROGATE)).ToBe(
+    UTF8_REPLACEMENT_CHARACTER + UTF8_REPLACEMENT_CHARACTER);
 end;
 
 procedure TTextSemanticsTests.TestUTF8CodePointIndexing;

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -1020,33 +1020,9 @@ begin
   Result := RetagUTF8Text(Bytes);
 end;
 
-function ContainsUnicodeNonCharacter(const AText: string): Boolean;
-var
-  ByteLength: Integer;
-  CodePoint: Cardinal;
-  Index: Integer;
-begin
-  Index := 1;
-  while Index <= Length(AText) do
-  begin
-    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
-      ByteLength) then
-    begin
-      if ((CodePoint >= $FDD0) and (CodePoint <= $FDEF)) or
-         (((CodePoint and $FFFE) = $FFFE) and
-          (CodePoint <= $10FFFF)) then
-        Exit(True);
-      Inc(Index, ByteLength);
-    end
-    else
-      Inc(Index);
-  end;
-  Result := False;
-end;
-
 function UnicodeLowerCaseUTF8(const AText: string): string;
 begin
-  if (not IsWellFormedUTF16(AText)) or ContainsUnicodeNonCharacter(AText) then
+  if not IsWellFormedUTF16(AText) then
     Exit(AText);
   if TryICULowerCase('', AText, Result) then
     Exit;
@@ -1056,7 +1032,7 @@ end;
 
 function UnicodeUpperCaseUTF8(const AText: string): string;
 begin
-  if (not IsWellFormedUTF16(AText)) or ContainsUnicodeNonCharacter(AText) then
+  if not IsWellFormedUTF16(AText) then
     Exit(AText);
   if TryICUUpperCase('', AText, Result) then
     Exit;

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -22,6 +22,7 @@ type
   end;
 
 const
+  MAX_UNICODE_CODE_POINT = $10FFFF;
   UNICODE_REPLACEMENT_CODE_POINT = $FFFD;
   UTF8_REPLACEMENT_CHARACTER = #$EF#$BF#$BD;
 
@@ -42,8 +43,11 @@ function TrimECMAScriptWhitespaceStart(const AText: string): string;
 function TrimECMAScriptWhitespaceEnd(const AText: string): string;
 function IsWellFormedUTF8(const AText: string): Boolean;
 function ToWellFormedUTF8(const AText: string): string;
+function IsWellFormedUTF16(const AText: AnsiString): Boolean;
+function ToWellFormedUTF16(const AText: AnsiString): AnsiString;
 function UTF8CodePointLength(const AText: string): Integer;
 function UTF8CodePointAt(const AText: string; const AIndex: Integer): string;
+function UTF16CodeUnitToUTF8(const ACodeUnit: Cardinal): string;
 function UTF16CodeUnitLength(const AText: string): Integer;
 function UTF16CodeUnitAt(const AText: string; const AIndex: Integer): string;
 function TryUTF16CodePointValueAt(const AText: string; const AIndex: Integer;
@@ -86,6 +90,7 @@ uses
   Math,
 
   fpwidestring,
+  IntlICU,
   StringBuffer;
 
 function RetagUTF8Text(const ABytes: RawByteString): string;
@@ -388,6 +393,122 @@ begin
         InvalidLength := Length(AText) - Index + 1;
       Inc(Index, InvalidLength);
     end;
+  end;
+  Result := Buffer.ToString;
+end;
+
+function IsHighSurrogateCodeUnit(const ACodeUnit: Cardinal): Boolean; inline;
+begin
+  Result := (ACodeUnit >= $D800) and (ACodeUnit <= $DBFF);
+end;
+
+function IsLowSurrogateCodeUnit(const ACodeUnit: Cardinal): Boolean; inline;
+begin
+  Result := (ACodeUnit >= $DC00) and (ACodeUnit <= $DFFF);
+end;
+
+function ReadUTF16EncodedUnitAt(const AText: string; const AIndex: Integer;
+  out ACodeUnit: Cardinal; out AByteLength: Integer): Boolean;
+begin
+  Result := TryReadUTF8CodePointAllowSurrogates(AText, AIndex,
+    ACodeUnit, AByteLength);
+  if Result then
+  begin
+    if ACodeUnit <= $FFFF then
+      Exit(True);
+    Exit(True);
+  end;
+  if (AIndex >= 1) and (AIndex <= Length(AText)) then
+  begin
+    ACodeUnit := Ord(AText[AIndex]);
+    AByteLength := 1;
+    Exit(False);
+  end;
+  ACodeUnit := 0;
+  AByteLength := 0;
+end;
+
+function IsWellFormedUTF16(const AText: AnsiString): Boolean;
+var
+  ByteLength, NextByteLength: Integer;
+  CodeUnit, NextCodeUnit: Cardinal;
+  Index: Integer;
+begin
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if not ReadUTF16EncodedUnitAt(AText, Index, CodeUnit, ByteLength) then
+      Exit(False);
+    if CodeUnit > $FFFF then
+    begin
+      Inc(Index, ByteLength);
+      Continue;
+    end;
+    if IsLowSurrogateCodeUnit(CodeUnit) then
+      Exit(False);
+    if IsHighSurrogateCodeUnit(CodeUnit) then
+    begin
+      if (Index + ByteLength > Length(AText)) or
+         not ReadUTF16EncodedUnitAt(AText, Index + ByteLength,
+           NextCodeUnit, NextByteLength) or
+         not IsLowSurrogateCodeUnit(NextCodeUnit) then
+        Exit(False);
+      Inc(Index, ByteLength + NextByteLength);
+      Continue;
+    end;
+    Inc(Index, ByteLength);
+  end;
+  Result := True;
+end;
+
+function ToWellFormedUTF16(const AText: AnsiString): AnsiString;
+var
+  Buffer: TStringBuffer;
+  ByteLength, NextByteLength: Integer;
+  CodeUnit, NextCodeUnit: Cardinal;
+  Index: Integer;
+begin
+  Buffer := TStringBuffer.Create(Length(AText));
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if not ReadUTF16EncodedUnitAt(AText, Index, CodeUnit, ByteLength) then
+    begin
+      Buffer.Append(UTF8_REPLACEMENT_CHARACTER);
+      Inc(Index, Max(ByteLength, 1));
+      Continue;
+    end;
+    if CodeUnit > $FFFF then
+    begin
+      Buffer.Append(Copy(AText, Index, ByteLength));
+      Inc(Index, ByteLength);
+      Continue;
+    end;
+    if IsLowSurrogateCodeUnit(CodeUnit) then
+    begin
+      Buffer.Append(UTF8_REPLACEMENT_CHARACTER);
+      Inc(Index, ByteLength);
+      Continue;
+    end;
+    if IsHighSurrogateCodeUnit(CodeUnit) then
+    begin
+      if (Index + ByteLength <= Length(AText)) and
+         ReadUTF16EncodedUnitAt(AText, Index + ByteLength,
+           NextCodeUnit, NextByteLength) and
+         IsLowSurrogateCodeUnit(NextCodeUnit) then
+      begin
+        Buffer.Append(Copy(AText, Index, ByteLength + NextByteLength));
+        Inc(Index, ByteLength + NextByteLength);
+      end
+      else
+      begin
+        Buffer.Append(UTF8_REPLACEMENT_CHARACTER);
+        Inc(Index, ByteLength);
+      end;
+      Continue;
+    end;
+    Buffer.Append(Copy(AText, Index, ByteLength));
+    Inc(Index, ByteLength);
   end;
   Result := Buffer.ToString;
 end;
@@ -899,14 +1020,46 @@ begin
   Result := RetagUTF8Text(Bytes);
 end;
 
+function ContainsUnicodeNonCharacter(const AText: string): Boolean;
+var
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  Index: Integer;
+begin
+  Index := 1;
+  while Index <= Length(AText) do
+  begin
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
+    begin
+      if ((CodePoint >= $FDD0) and (CodePoint <= $FDEF)) or
+         (((CodePoint and $FFFE) = $FFFE) and
+          (CodePoint <= $10FFFF)) then
+        Exit(True);
+      Inc(Index, ByteLength);
+    end
+    else
+      Inc(Index);
+  end;
+  Result := False;
+end;
+
 function UnicodeLowerCaseUTF8(const AText: string): string;
 begin
+  if (not IsWellFormedUTF16(AText)) or ContainsUnicodeNonCharacter(AText) then
+    Exit(AText);
+  if TryICULowerCase('', AText, Result) then
+    Exit;
   Result := UnicodeStringToUTF8Text(
     UnicodeLowerCase(UTF8TextToUnicodeString(AText)));
 end;
 
 function UnicodeUpperCaseUTF8(const AText: string): string;
 begin
+  if (not IsWellFormedUTF16(AText)) or ContainsUnicodeNonCharacter(AText) then
+    Exit(AText);
+  if TryICUUpperCase('', AText, Result) then
+    Exit;
   Result := UnicodeStringToUTF8Text(
     UnicodeUpperCase(UTF8TextToUnicodeString(AText)));
 end;

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -1020,24 +1020,72 @@ begin
   Result := RetagUTF8Text(Bytes);
 end;
 
+function UnicodeCaseMapFallbackUTF8(const AText: string;
+  const AUpperCase: Boolean): string;
+var
+  Buffer: TStringBuffer;
+  ByteLength: Integer;
+  CodePoint: Cardinal;
+  Index: Integer;
+  Segment: string;
+  SegmentStart: Integer;
+
+  procedure AppendMappedSegment(const AEndIndex: Integer);
+  begin
+    if AEndIndex <= SegmentStart then
+      Exit;
+    Segment := Copy(AText, SegmentStart, AEndIndex - SegmentStart);
+    if AUpperCase then
+      Buffer.Append(UnicodeStringToUTF8Text(
+        UnicodeUpperCase(UTF8TextToUnicodeString(Segment))))
+    else
+      Buffer.Append(UnicodeStringToUTF8Text(
+        UnicodeLowerCase(UTF8TextToUnicodeString(Segment))));
+  end;
+
+begin
+  Buffer := TStringBuffer.Create(Length(AText));
+  Index := 1;
+  SegmentStart := 1;
+  while Index <= Length(AText) do
+  begin
+    if TryReadUTF8CodePointAllowSurrogates(AText, Index, CodePoint,
+      ByteLength) then
+    begin
+      if IsUnicodeSurrogateCodePoint(CodePoint) then
+      begin
+        AppendMappedSegment(Index);
+        Buffer.Append(Copy(AText, Index, ByteLength));
+        Inc(Index, ByteLength);
+        SegmentStart := Index;
+      end
+      else
+        Inc(Index, ByteLength);
+    end
+    else
+    begin
+      AppendMappedSegment(Index);
+      Buffer.AppendChar(AText[Index]);
+      Inc(Index);
+      SegmentStart := Index;
+    end;
+  end;
+  AppendMappedSegment(Index);
+  Result := RetagUTF8Text(Buffer.ToString);
+end;
+
 function UnicodeLowerCaseUTF8(const AText: string): string;
 begin
-  if not IsWellFormedUTF16(AText) then
-    Exit(AText);
-  if TryICULowerCase('', AText, Result) then
+  if IsWellFormedUTF16(AText) and TryICULowerCase('', AText, Result) then
     Exit;
-  Result := UnicodeStringToUTF8Text(
-    UnicodeLowerCase(UTF8TextToUnicodeString(AText)));
+  Result := UnicodeCaseMapFallbackUTF8(AText, False);
 end;
 
 function UnicodeUpperCaseUTF8(const AText: string): string;
 begin
-  if not IsWellFormedUTF16(AText) then
-    Exit(AText);
-  if TryICUUpperCase('', AText, Result) then
+  if IsWellFormedUTF16(AText) and TryICUUpperCase('', AText, Result) then
     Exit;
-  Result := UnicodeStringToUTF8Text(
-    UnicodeUpperCase(UTF8TextToUnicodeString(AText)));
+  Result := UnicodeCaseMapFallbackUTF8(AText, True);
 end;
 
 function AdvanceUTF16StringIndex(const AText: string; const AIndex: Integer;

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -413,11 +413,7 @@ begin
   Result := TryReadUTF8CodePointAllowSurrogates(AText, AIndex,
     ACodeUnit, AByteLength);
   if Result then
-  begin
-    if ACodeUnit <= $FFFF then
-      Exit(True);
     Exit(True);
-  end;
   if (AIndex >= 1) and (AIndex <= Length(AText)) then
   begin
     ACodeUnit := Ord(AText[AIndex]);

--- a/source/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/source/units/Goccia.Builtins.GlobalRegExp.pas
@@ -1048,7 +1048,8 @@ begin
     end
     else
     begin
-      Pattern := PatternArg.ToStringLiteral.Value;
+      if not (PatternArg is TGocciaUndefinedLiteralValue) then
+        Pattern := PatternArg.ToStringLiteral.Value;
       if (AArgs.Length > 1) and
          not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
         Flags := AArgs.GetElement(1).ToStringLiteral.Value;
@@ -1107,7 +1108,8 @@ begin
     GRegExpPrototypeSlot);
 
   // §22.2.4.1 step 7: RegExpInitialize — remaining ToString coercions
-  if not PatternIsRegExp and (AArgs.Length > 0) then
+  if not PatternIsRegExp and (AArgs.Length > 0) and
+     not (PatternArg is TGocciaUndefinedLiteralValue) then
     Pattern := PatternArg.ToStringLiteral.Value;
   if FlagsProvided then
     Flags := AArgs.GetElement(1).ToStringLiteral.Value;
@@ -1184,7 +1186,7 @@ begin
   else
     Input := TGocciaUndefinedLiteralValue.UndefinedValue.ToStringLiteral.Value;
 
-  if MatchRegExpObjectOnce(AThisValue, Input, MatchValue) then
+  if MatchRegExpBuiltinObjectOnce(AThisValue, Input, MatchValue) then
     Result := MatchValue
   else
     Result := TGocciaNullLiteralValue.NullValue;

--- a/source/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/source/units/Goccia.Bytecode.OpCodeNames.pas
@@ -212,6 +212,7 @@ begin
     OP_DEFINE_GLOBAL_FUNCTION_LONG:    Result := 'OP_DEFINE_GLOBAL_FUNCTION_LONG';
     OP_PREDECLARE_GLOBAL_LET_LONG:     Result := 'OP_PREDECLARE_GLOBAL_LET_LONG';
     OP_PREDECLARE_GLOBAL_CONST_LONG:   Result := 'OP_PREDECLARE_GLOBAL_CONST_LONG';
+    OP_LOAD_CHAR:                      Result := 'OP_LOAD_CHAR';
   else
     Result := Format('OP_UNKNOWN_%d', [AOp]);
   end;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -141,7 +141,10 @@ const
   //   v67 -> v68: added long-name global define/predeclare opcodes so
   //               generated sources with more than 255 global names can keep
   //               using 16-bit constant-pool indices.
-  GOCCIA_FORMAT_VERSION = 68;
+  //   v68 -> v69: added OP_LOAD_CHAR so generated sources with many distinct
+  //               one-code-unit string literals do not exhaust the 16-bit
+  //               constant pool.
+  GOCCIA_FORMAT_VERSION = 69;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;
@@ -387,7 +390,8 @@ type
     OP_DEFINE_GLOBAL_CONST_LONG = 216,
     OP_DEFINE_GLOBAL_FUNCTION_LONG = 217,
     OP_PREDECLARE_GLOBAL_LET_LONG = 218,
-    OP_PREDECLARE_GLOBAL_CONST_LONG = 219
+    OP_PREDECLARE_GLOBAL_CONST_LONG = 219,
+    OP_LOAD_CHAR     = 220
   );
 
 function EncodeABC(const AOp: TGocciaOpCode; const A, B, C: UInt8): UInt32; inline;

--- a/source/units/Goccia.Compiler.ConstantFolding.pas
+++ b/source/units/Goccia.Compiler.ConstantFolding.pas
@@ -114,10 +114,7 @@ begin
     ctvkNumber:
       EmitFoldedNumber(ACtx, AValue.NumberValue, ADest);
     ctvkString:
-    begin
-      Idx := ACtx.Template.AddConstantString(AValue.StringValue);
-      EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, ADest, Idx));
-    end;
+      EmitLoadStringLiteral(ACtx, ADest, AValue.StringValue);
     ctvkBigInt:
     begin
       Idx := ACtx.Template.AddConstantBigInt(AValue.BigIntValue.ToString);

--- a/source/units/Goccia.Compiler.Context.pas
+++ b/source/units/Goccia.Compiler.Context.pas
@@ -51,6 +51,8 @@ type
 
 function EmitInstruction(const ACtx: TGocciaCompilationContext;
   const AInstruction: UInt32): Integer; inline;
+procedure EmitLoadStringLiteral(const ACtx: TGocciaCompilationContext;
+  const ADest: UInt8; const AValue: string);
 procedure EmitLineMapping(const ACtx: TGocciaCompilationContext;
   const ALine, AColumn: Integer);
 function EmitJumpInstruction(const ACtx: TGocciaCompilationContext;
@@ -72,10 +74,36 @@ function ShortCircuitJumpOp(
 
 implementation
 
+uses
+  TextSemantics;
+
 function EmitInstruction(const ACtx: TGocciaCompilationContext;
   const AInstruction: UInt32): Integer;
 begin
   Result := ACtx.Template.EmitInstruction(AInstruction);
+end;
+
+function TrySingleUTF16CodeUnitString(const AValue: string;
+  out ACodeUnit: Cardinal): Boolean;
+begin
+  Result := (UTF16CodeUnitLength(AValue) = 1) and
+    TryUTF16CodePointValueAt(AValue, 0, ACodeUnit) and
+    (ACodeUnit <= High(UInt16));
+end;
+
+procedure EmitLoadStringLiteral(const ACtx: TGocciaCompilationContext;
+  const ADest: UInt8; const AValue: string);
+var
+  CodeUnit: Cardinal;
+  ConstantIndex: UInt16;
+begin
+  if TrySingleUTF16CodeUnitString(AValue, CodeUnit) then
+    EmitInstruction(ACtx, EncodeABx(OP_LOAD_CHAR, ADest, UInt16(CodeUnit)))
+  else
+  begin
+    ConstantIndex := ACtx.Template.AddConstantString(AValue);
+    EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, ADest, ConstantIndex));
+  end;
 end;
 
 procedure EmitLineMapping(const ACtx: TGocciaCompilationContext;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -566,11 +566,7 @@ begin
     end;
   end
   else if Value is TGocciaStringLiteralValue then
-  begin
-    Idx := ACtx.Template.AddConstantString(
-      TGocciaStringLiteralValue(Value).Value);
-    EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, ADest, Idx));
-  end
+    EmitLoadStringLiteral(ACtx, ADest, TGocciaStringLiteralValue(Value).Value)
   else if Value is TGocciaBigIntValue then
   begin
     Idx := ACtx.Template.AddConstantBigInt(

--- a/source/units/Goccia.Compiler.Test.pas
+++ b/source/units/Goccia.Compiler.Test.pas
@@ -48,6 +48,8 @@ type
       const ATemplate: TGocciaFunctionTemplate): Integer;
     function HasLoadInt(const ATemplate: TGocciaFunctionTemplate;
       const AValue: Int16): Boolean;
+    function HasLoadChar(const ATemplate: TGocciaFunctionTemplate;
+      const ACodeUnit: UInt16): Boolean;
     function HasNaNFloatConstant(
       const ATemplate: TGocciaFunctionTemplate): Boolean;
     function HasInfinityFloatConstant(
@@ -61,6 +63,7 @@ type
     function NegativeZero: Double;
 
     procedure TestCompileLiteral;
+    procedure TestSingleCodeUnitStringLiteralsUseImmediateOpcode;
     procedure TestCompileRegExpLiteral;
     procedure TestCompileArithmetic;
     procedure TestCompileVariable;
@@ -104,6 +107,8 @@ type
 procedure TTestCompiler.SetupTests;
 begin
   Test('Compile literal', TestCompileLiteral);
+  Test('Single-code-unit string literals use immediate opcode',
+    TestSingleCodeUnitStringLiteralsUseImmediateOpcode);
   Test('Compile RegExp literal', TestCompileRegExpLiteral);
   Test('Compile arithmetic', TestCompileArithmetic);
   Test('Compile variable', TestCompileVariable);
@@ -251,6 +256,22 @@ begin
   Result := False;
 end;
 
+function TTestCompiler.HasLoadChar(const ATemplate: TGocciaFunctionTemplate;
+  const ACodeUnit: UInt16): Boolean;
+var
+  I: Integer;
+  Instruction: UInt32;
+begin
+  for I := 0 to ATemplate.CodeCount - 1 do
+  begin
+    Instruction := ATemplate.GetInstruction(I);
+    if (TGocciaOpCode(DecodeOp(Instruction)) = OP_LOAD_CHAR) and
+       (DecodeBx(Instruction) = ACodeUnit) then
+      Exit(True);
+  end;
+  Result := False;
+end;
+
 function TTestCompiler.HasNaNFloatConstant(
   const ATemplate: TGocciaFunctionTemplate): Boolean;
 var
@@ -336,6 +357,22 @@ begin
     Expect<Boolean>(Assigned(Module)).ToBe(True);
     Expect<Boolean>(Assigned(Module.TopLevel)).ToBe(True);
     Expect<Boolean>(Module.TopLevel.CodeCount > 0).ToBe(True);
+  finally
+    Module.Free;
+  end;
+end;
+
+procedure TTestCompiler.TestSingleCodeUnitStringLiteralsUseImmediateOpcode;
+var
+  Module: TGocciaBytecodeModule;
+begin
+  Module := CompileSource('const a = "A"; const b = "\u0800"; const c = "ab";');
+  try
+    Expect<Boolean>(HasLoadChar(Module.TopLevel, Ord('A'))).ToBe(True);
+    Expect<Boolean>(HasLoadChar(Module.TopLevel, $0800)).ToBe(True);
+    Expect<Integer>(CountOp(Module.TopLevel, OP_LOAD_CHAR)).ToBe(2);
+    Expect<Integer>(Module.TopLevel.ConstantCount).ToBe(1);
+    Expect<string>(Module.TopLevel.GetConstant(0).StringValue).ToBe('ab');
   finally
     Module.Free;
   end;

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -131,6 +131,7 @@ const
   CARRIAGE_RETURN_CODE_POINT = $000D;
   LINE_SEPARATOR_CODE_POINT = $2028;
   PARAGRAPH_SEPARATOR_CODE_POINT = $2029;
+  MAX_UNICODE_CODE_POINT = $10FFFF;
 
 type
   TKeywordTokenEntry = record
@@ -230,6 +231,31 @@ begin
     if not CharInSet(AValue[I], ['0'..'9', 'a'..'f', 'A'..'F']) then
       Exit(False);
   Result := True;
+end;
+
+function TryParseUnicodeCodePointHex(const AValue: string;
+  out ACodePoint: Cardinal): Boolean;
+var
+  CodePointValue: QWord;
+  SignificantHex: string;
+  StartIndex: Integer;
+begin
+  ACodePoint := 0;
+  StartIndex := 1;
+  while (StartIndex <= Length(AValue)) and (AValue[StartIndex] = '0') do
+    Inc(StartIndex);
+
+  if StartIndex > Length(AValue) then
+    Exit(True);
+
+  SignificantHex := Copy(AValue, StartIndex, Length(AValue) - StartIndex + 1);
+  if Length(SignificantHex) > 6 then
+    Exit(False);
+
+  Result := TryStrToQWord('$' + SignificantHex, CodePointValue) and
+    (CodePointValue <= MAX_UNICODE_CODE_POINT);
+  if Result then
+    ACodePoint := Cardinal(CodePointValue);
 end;
 
 function TryKeywordToken(const AText: string; out ATokenType: TGocciaTokenType): Boolean; inline;
@@ -643,7 +669,6 @@ end;
 function TGocciaLexer.ScanUnicodeEscape: string;
 var
   CodePoint, LowSurrogate: Cardinal;
-  CodePointValue: QWord;
   HexStr: string;
   I, HexStart, SavedCurrent, SavedColumn: Integer;
 begin
@@ -662,11 +687,9 @@ begin
       raise TGocciaLexerError.Create('Invalid unicode escape', FLine, FColumn, FFileName, GetSourceLines,
         SSuggestUnicodeHexDigits);
     Advance; // consume '}'
-    if not TryStrToQWord('$' + HexStr, CodePointValue) or
-       (CodePointValue > $10FFFF) then
+    if not TryParseUnicodeCodePointHex(HexStr, CodePoint) then
       raise TGocciaLexerError.Create('Invalid unicode code point', FLine, FColumn, FFileName, GetSourceLines,
         SSuggestUnicodeCodePointRange);
-    CodePoint := Cardinal(CodePointValue);
   end
   else
   begin
@@ -717,7 +740,7 @@ begin
     end;
   end;
 
-  if CodePoint > $10FFFF then
+  if CodePoint > MAX_UNICODE_CODE_POINT then
     raise TGocciaLexerError.Create('Invalid unicode code point', FLine, FColumn, FFileName, GetSourceLines,
       SSuggestUnicodeCodePointRange);
   Result := TextSemantics.CodePointToUTF8(CodePoint);
@@ -745,7 +768,7 @@ begin
       SSuggestHexEscapeFormat);
 
   CodePoint := StrToInt('$' + HexStr);
-  Result := Chr(CodePoint);
+  Result := TextSemantics.CodePointToUTF8(CodePoint);
 end;
 
 procedure TGocciaLexer.ProcessEscapeSequence(var ASB: TStringBuffer);
@@ -789,7 +812,7 @@ begin
           OctalValue := OctalValue * 8 + Ord(Peek) - Ord('0');
           Advance;
         end;
-        ASB.AppendChar(Chr(OctalValue));
+        ASB.Append(TextSemantics.CodePointToUTF8(OctalValue));
       end;
     'u': begin Advance; ASB.Append(ScanUnicodeEscape); end;
     'x': begin Advance; ASB.Append(ScanHexEscape); end;
@@ -806,7 +829,6 @@ end;
 function TGocciaLexer.ScanUnicodeEscapeForTemplate(var ASB: TStringBuffer): Boolean;
 var
   CodePoint, LowSurrogate: Cardinal;
-  CodePointValue: QWord;
   HexStr: string;
   I, HexStart, SavedCurrent, SavedColumn: Integer;
 begin
@@ -829,12 +851,8 @@ begin
     if not IsValidHexString(HexStr) then
       Exit(False);
     Advance; // consume '}'
-    // Use TryStrToQWord to safely handle arbitrarily long hex payloads
-    // without raising on overflow (e.g. \u{FFFFFFFF}).
-    if not TryStrToQWord('$' + HexStr, CodePointValue) or
-       (CodePointValue > $10FFFF) then
+    if not TryParseUnicodeCodePointHex(HexStr, CodePoint) then
       Exit(False);
-    CodePoint := Cardinal(CodePointValue);
   end
   else
   begin
@@ -890,7 +908,7 @@ begin
     end;
   end;
 
-  if CodePoint > $10FFFF then
+  if CodePoint > MAX_UNICODE_CODE_POINT then
     Exit(False);
   ASB.Append(TextSemantics.CodePointToUTF8(CodePoint));
   Result := True;

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -936,7 +936,7 @@ begin
     Exit(False);
 
   CodePoint := StrToInt('$' + HexStr);
-  ASB.AppendChar(Chr(CodePoint));
+  ASB.Append(TextSemantics.CodePointToUTF8(CodePoint));
   Result := True;
 end;
 

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -2032,7 +2032,7 @@ begin
     Exit(False);
   Inc(APos, 2);
   CodePoint := StrToInt('$' + HexStr);
-  ASB.AppendChar(Chr(CodePoint));
+  ASB.Append(TextSemantics.CodePointToUTF8(CodePoint));
   Result := True;
 end;
 

--- a/source/units/Goccia.RegExp.Compiler.pas
+++ b/source/units/Goccia.RegExp.Compiler.pas
@@ -2176,8 +2176,17 @@ begin
               Inc(GroupCount);
             end;
           if BackrefIdx < 0 then
-            raise EConvertError.Create(
-              'Invalid named backreference: ' + GroupName);
+          begin
+            if FUnicode or (Length(FNamedGroups) > 0) then
+              raise EConvertError.Create(
+                'Invalid named backreference: ' + GroupName);
+            EmitCharMatch(Ord('k'));
+            EmitCharMatch(Ord('<'));
+            for I := 1 to Length(GroupName) do
+              EmitCharMatch(Ord(GroupName[I]));
+            EmitCharMatch(Ord('>'));
+            Exit;
+          end;
           if GroupCount <= 1 then
             Emit(EncodeOpBx(RX_BACKREF, BackrefIdx or BackrefFlags))
           else
@@ -2214,7 +2223,24 @@ begin
         else
           EmitCharMatch(0);
       end;
-    'x': EmitCharMatch(ParseHexEscape(2));
+    'x':
+      begin
+        if FUnicode then
+          EmitCharMatch(ParseHexEscape(2))
+        else
+        begin
+          I := FPos;
+          try
+            EmitCharMatch(ParseHexEscape(2));
+          except
+            on E: EConvertError do
+            begin
+              FPos := I;
+              EmitCharMatch(Ord('x'));
+            end;
+          end;
+        end;
+      end;
     'u':
       begin
         if (not FUnicode) and (Peek = '{') then
@@ -2275,7 +2301,21 @@ begin
       end;
     'x':
       begin
-        CodePoint := ParseHexEscape(2);
+        if FUnicode then
+          CodePoint := ParseHexEscape(2)
+        else
+        begin
+          I := FPos;
+          try
+            CodePoint := ParseHexEscape(2);
+          except
+            on E: EConvertError do
+            begin
+              FPos := I;
+              CodePoint := Ord('x');
+            end;
+          end;
+        end;
         AddRange(ARanges, ARangeCount, CodePoint, CodePoint);
       end;
     'u':

--- a/source/units/Goccia.RegExp.Compiler.pas
+++ b/source/units/Goccia.RegExp.Compiler.pas
@@ -2182,8 +2182,12 @@ begin
                 'Invalid named backreference: ' + GroupName);
             EmitCharMatch(Ord('k'));
             EmitCharMatch(Ord('<'));
-            for I := 1 to Length(GroupName) do
-              EmitCharMatch(Ord(GroupName[I]));
+            I := 1;
+            while I <= Length(GroupName) do
+            begin
+              CodePoint := ReadRegExpGroupNameLiteralCodePoint(GroupName, I);
+              EmitCharMatch(CodePoint);
+            end;
             EmitCharMatch(Ord('>'));
             Exit;
           end;

--- a/source/units/Goccia.RegExp.Runtime.pas
+++ b/source/units/Goccia.RegExp.Runtime.pas
@@ -9,6 +9,7 @@ uses
   Goccia.Values.Primitives;
 
 function GetRegExpPrototype: TGocciaValue;
+function GetRegExpBuiltinExec: TGocciaValue;
 procedure SetRegExpPrototype(const APrototype: TGocciaValue);
 procedure SetRegExpBuiltinExec(const AExec: TGocciaValue);
 
@@ -24,10 +25,12 @@ function GetRegExpInternalSource(const AValue: TGocciaValue): string;
 function GetRegExpInternalFlags(const AValue: TGocciaValue): string;
 function MatchRegExpObjectOnce(const AValue: TGocciaValue; const AInput: string;
   out AMatchArray: TGocciaValue): Boolean;
+function MatchRegExpBuiltinObjectOnce(const AValue: TGocciaValue;
+  const AInput: string; out AMatchArray: TGocciaValue): Boolean;
 function MatchRegExpObject(const AValue: TGocciaValue; const AInput: string;
   const AStartIndex: Integer; const ARequireStart, AUpdateLastIndex: Boolean;
   out AMatchArray: TGocciaValue; out AMatchIndex, AMatchEnd,
-  ANextIndex: Integer): Boolean;
+  ANextIndex: Integer; const AUseCustomExec: Boolean = True): Boolean;
 function HasUnicodeRegExpFlag(const AFlags: string): Boolean;
 function GetRegExpLastIndexLength(const AValue: TGocciaValue): Double;
 function GetClampedLastIndex(const AValue: TGocciaValue;
@@ -49,6 +52,8 @@ uses
   Goccia.Constants.NumericLimits,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
+  Goccia.GarbageCollector,
+  Goccia.Realm,
   Goccia.RegExp.&Program,
   Goccia.RegExp.VM,
   Goccia.Utils,
@@ -89,6 +94,10 @@ threadvar
   GRegExpPrototype: TGocciaObjectValue;
   GRegExpBuiltinExec: TGocciaValue;
 
+var
+  GRegExpRuntimePrototypeSlot: TGocciaRealmSlotId;
+  GRegExpRuntimeBuiltinExecSlot: TGocciaRealmSlotId;
+
 constructor TGocciaRegExpProgramData.Create(const AProgram: TRegExpProgram;
   const AOriginalSource, AOriginalFlags: string);
 begin
@@ -108,17 +117,34 @@ end;
 
 function GetRegExpPrototype: TGocciaValue;
 begin
+  if Assigned(CurrentRealm) and
+     CurrentRealm.HasSlot(GRegExpRuntimePrototypeSlot) then
+    Exit(TGocciaValue(CurrentRealm.GetSlot(GRegExpRuntimePrototypeSlot)));
   Result := GRegExpPrototype;
+end;
+
+function GetRegExpBuiltinExec: TGocciaValue;
+begin
+  if Assigned(CurrentRealm) and
+     CurrentRealm.HasSlot(GRegExpRuntimeBuiltinExecSlot) then
+    Exit(TGocciaValue(CurrentRealm.GetSlot(GRegExpRuntimeBuiltinExecSlot)));
+  Result := GRegExpBuiltinExec;
 end;
 
 procedure SetRegExpPrototype(const APrototype: TGocciaValue);
 begin
   GRegExpPrototype := TGocciaObjectValue(APrototype);
+  if Assigned(CurrentRealm) then
+    CurrentRealm.SetSlot(GRegExpRuntimePrototypeSlot,
+      TGocciaObjectValue(APrototype));
 end;
 
 procedure SetRegExpBuiltinExec(const AExec: TGocciaValue);
 begin
   GRegExpBuiltinExec := AExec;
+  if Assigned(CurrentRealm) then
+    CurrentRealm.SetSlot(GRegExpRuntimeBuiltinExecSlot,
+      TGCManagedObject(AExec));
 end;
 
 function CreateRegExpObjectFromProgram(const APattern, AFlags: string;
@@ -145,19 +171,11 @@ begin
 end;
 
 function IsDefaultRegExpExecMethod(const AMethod: TGocciaValue): Boolean;
-begin
-  Result := Assigned(GRegExpBuiltinExec) and (AMethod = GRegExpBuiltinExec);
-end;
-
-function HasCustomRegExpExecMethod(const AObject: TGocciaObjectValue): Boolean;
 var
-  ExecMethod: TGocciaValue;
+  BuiltinExec: TGocciaValue;
 begin
-  ExecMethod := AObject.GetProperty(PROP_EXEC);
-  Result := Assigned(ExecMethod) and
-    (not (ExecMethod is TGocciaUndefinedLiteralValue)) and
-    ExecMethod.IsCallable and
-    (not IsDefaultRegExpExecMethod(ExecMethod));
+  BuiltinExec := GetRegExpBuiltinExec;
+  Result := Assigned(BuiltinExec) and (AMethod = BuiltinExec);
 end;
 
 function ToLengthIndex(const AValue: TGocciaValue): Double;
@@ -401,7 +419,7 @@ var
   Source: string;
 begin
   Source := NormalizeRegExpSource(APattern);
-  Obj := TGocciaObjectValue.Create(GRegExpPrototype);
+  Obj := TGocciaObjectValue.Create(TGocciaObjectValue(GetRegExpPrototype));
   Obj.HasRegExpData := True;
   Obj.RegExpData := TGocciaRegExpProgramData.Create(ACompiledProgram, Source,
     AFlags);
@@ -471,13 +489,6 @@ begin
     Exit;
   end;
 
-  if HasCustomRegExpExecMethod(Obj) then
-  begin
-    Result := MatchRegExpObject(AValue, AInput, 0, False, False, AMatchArray,
-      MatchIndex, MatchEnd, NextIndex);
-    Exit;
-  end;
-
   Flags := GetRegExpInternalFlags(AValue);
   LastIndex := GetRegExpLastIndexLength(AValue);
   if HasRegExpFlag(Flags, 'g') or HasRegExpFlag(Flags, 'y') then
@@ -500,10 +511,44 @@ begin
     MatchEnd, NextIndex);
 end;
 
+function MatchRegExpBuiltinObjectOnce(const AValue: TGocciaValue;
+  const AInput: string; out AMatchArray: TGocciaValue): Boolean;
+var
+  Flags: string;
+  StartIndex, MatchIndex, MatchEnd, NextIndex: Integer;
+  InputLength: Integer;
+  LastIndex: Double;
+begin
+  if not IsRegExpInstance(AValue) then
+    ThrowTypeError(SErrorRegExpExecNonRegExp);
+
+  Flags := GetRegExpInternalFlags(AValue);
+  LastIndex := GetRegExpLastIndexLength(AValue);
+  if HasRegExpFlag(Flags, 'g') or HasRegExpFlag(Flags, 'y') then
+  begin
+    InputLength := UTF16CodeUnitLength(AInput);
+    if LastIndex > InputLength then
+    begin
+      if InputLength < MaxInt then
+        StartIndex := InputLength + 1
+      else
+        StartIndex := MaxInt;
+    end
+    else
+      StartIndex := Trunc(LastIndex);
+  end
+  else
+    StartIndex := 0;
+
+  Result := MatchRegExpObject(AValue, AInput, StartIndex,
+    HasRegExpFlag(Flags, 'y'), True, AMatchArray, MatchIndex,
+    MatchEnd, NextIndex, False);
+end;
+
 function MatchRegExpObject(const AValue: TGocciaValue; const AInput: string;
   const AStartIndex: Integer; const ARequireStart, AUpdateLastIndex: Boolean;
   out AMatchArray: TGocciaValue; out AMatchIndex, AMatchEnd,
-  ANextIndex: Integer): Boolean;
+  ANextIndex: Integer; const AUseCustomExec: Boolean): Boolean;
 var
   Obj: TGocciaObjectValue;
   ExecMethod: TGocciaValue;
@@ -514,44 +559,47 @@ var
   ShouldUpdate: Boolean;
 begin
   Obj := TGocciaObjectValue(AValue);
-  ExecMethod := Obj.GetProperty(PROP_EXEC);
-  if Assigned(ExecMethod) and
-     (not (ExecMethod is TGocciaUndefinedLiteralValue)) and
-     (not IsDefaultRegExpExecMethod(ExecMethod)) then
+  if AUseCustomExec then
   begin
-    if not ExecMethod.IsCallable then
+    ExecMethod := Obj.GetProperty(PROP_EXEC);
+    if Assigned(ExecMethod) and
+       (not (ExecMethod is TGocciaUndefinedLiteralValue)) and
+       (not IsDefaultRegExpExecMethod(ExecMethod)) then
     begin
-      if not IsRegExpInstance(AValue) then
-        ThrowTypeError(SErrorRegExpExecNotCallable);
-    end
-    else
-    begin
-      ExecArgs := TGocciaArgumentsCollection.Create([
-        TGocciaStringLiteralValue.Create(AInput)
-      ]);
-      try
-        ExecResult := InvokeCallable(ExecMethod, ExecArgs, Obj);
-      finally
-        ExecArgs.Free;
-      end;
-
-      if ExecResult is TGocciaNullLiteralValue then
+      if not ExecMethod.IsCallable then
       begin
-        AMatchArray := nil;
-        AMatchIndex := -1;
-        AMatchEnd := -1;
-        ANextIndex := -1;
-        Exit(False);
+        if not IsRegExpInstance(AValue) then
+          ThrowTypeError(SErrorRegExpExecNotCallable);
+      end
+      else
+      begin
+        ExecArgs := TGocciaArgumentsCollection.Create([
+          TGocciaStringLiteralValue.Create(AInput)
+        ]);
+        try
+          ExecResult := InvokeCallable(ExecMethod, ExecArgs, Obj);
+        finally
+          ExecArgs.Free;
+        end;
+
+        if ExecResult is TGocciaNullLiteralValue then
+        begin
+          AMatchArray := nil;
+          AMatchIndex := -1;
+          AMatchEnd := -1;
+          ANextIndex := -1;
+          Exit(False);
+        end;
+
+        if not (ExecResult is TGocciaObjectValue) then
+          ThrowTypeError(SErrorRegExpExecReturnType);
+
+        AMatchArray := ExecResult;
+        AMatchIndex := 0;
+        AMatchEnd := 0;
+        ANextIndex := 0;
+        Exit(True);
       end;
-
-      if not (ExecResult is TGocciaObjectValue) then
-        ThrowTypeError(SErrorRegExpExecReturnType);
-
-      AMatchArray := ExecResult;
-      AMatchIndex := 0;
-      AMatchEnd := 0;
-      ANextIndex := 0;
-      Exit(True);
     end;
   end;
 
@@ -613,5 +661,11 @@ begin
     GetRegExpInternalSource(AValue),
     GetRegExpInternalFlags(AValue));
 end;
+
+initialization
+  GRegExpRuntimePrototypeSlot := RegisterRealmSlot(
+    'RegExp.runtime.prototype');
+  GRegExpRuntimeBuiltinExecSlot := RegisterRealmSlot(
+    'RegExp.runtime.builtinExec');
 
 end.

--- a/source/units/Goccia.RegExp.Runtime.pas
+++ b/source/units/Goccia.RegExp.Runtime.pas
@@ -206,6 +206,62 @@ begin
   Result := Trunc(Index.Value);
 end;
 
+function TryRunRegExpCustomExec(const AValue: TGocciaValue;
+  const AInput: string; out AMatchArray: TGocciaValue; out AMatchIndex,
+  AMatchEnd, ANextIndex: Integer; out AHandled: Boolean): Boolean;
+var
+  ExecArgs: TGocciaArgumentsCollection;
+  ExecMethod: TGocciaValue;
+  ExecResult: TGocciaValue;
+  Obj: TGocciaObjectValue;
+begin
+  Obj := TGocciaObjectValue(AValue);
+  AHandled := False;
+
+  ExecMethod := Obj.GetProperty(PROP_EXEC);
+  if Assigned(ExecMethod) and
+     (not (ExecMethod is TGocciaUndefinedLiteralValue)) and
+     (not IsDefaultRegExpExecMethod(ExecMethod)) then
+  begin
+    if not ExecMethod.IsCallable then
+    begin
+      if not IsRegExpInstance(AValue) then
+        ThrowTypeError(SErrorRegExpExecNotCallable);
+      Exit(False);
+    end;
+
+    AHandled := True;
+    ExecArgs := TGocciaArgumentsCollection.Create([
+      TGocciaStringLiteralValue.Create(AInput)
+    ]);
+    try
+      ExecResult := InvokeCallable(ExecMethod, ExecArgs, Obj);
+    finally
+      ExecArgs.Free;
+    end;
+
+    if ExecResult is TGocciaNullLiteralValue then
+    begin
+      AMatchArray := nil;
+      AMatchIndex := -1;
+      AMatchEnd := -1;
+      ANextIndex := -1;
+      Exit(False);
+    end;
+
+    if not (ExecResult is TGocciaObjectValue) then
+      ThrowTypeError(SErrorRegExpExecReturnType);
+
+    AMatchArray := ExecResult;
+    AMatchIndex := 0;
+    AMatchEnd := 0;
+    ANextIndex := 0;
+    Exit(True);
+  end;
+
+  Result := False;
+end;
+
 function HasUnicodeRegExpFlag(const AFlags: string): Boolean;
 begin
   Result := HasRegExpFlag(AFlags, 'u') or HasRegExpFlag(AFlags, 'v');
@@ -480,6 +536,7 @@ var
   StartIndex, MatchIndex, MatchEnd, NextIndex: Integer;
   InputLength: Integer;
   LastIndex: Double;
+  HandledCustomExec: Boolean;
 begin
   Obj := TGocciaObjectValue(AValue);
   if not IsRegExpInstance(AValue) then
@@ -488,6 +545,11 @@ begin
       MatchIndex, MatchEnd, NextIndex);
     Exit;
   end;
+
+  Result := TryRunRegExpCustomExec(AValue, AInput, AMatchArray, MatchIndex,
+    MatchEnd, NextIndex, HandledCustomExec);
+  if HandledCustomExec then
+    Exit;
 
   Flags := GetRegExpInternalFlags(AValue);
   LastIndex := GetRegExpLastIndexLength(AValue);
@@ -551,9 +613,7 @@ function MatchRegExpObject(const AValue: TGocciaValue; const AInput: string;
   ANextIndex: Integer; const AUseCustomExec: Boolean): Boolean;
 var
   Obj: TGocciaObjectValue;
-  ExecMethod: TGocciaValue;
-  ExecArgs: TGocciaArgumentsCollection;
-  ExecResult: TGocciaValue;
+  HandledCustomExec: Boolean;
   MatchResult: TGocciaRegExpMatchResult;
   ProgramData: TGocciaRegExpProgramData;
   ShouldUpdate: Boolean;
@@ -561,46 +621,10 @@ begin
   Obj := TGocciaObjectValue(AValue);
   if AUseCustomExec then
   begin
-    ExecMethod := Obj.GetProperty(PROP_EXEC);
-    if Assigned(ExecMethod) and
-       (not (ExecMethod is TGocciaUndefinedLiteralValue)) and
-       (not IsDefaultRegExpExecMethod(ExecMethod)) then
-    begin
-      if not ExecMethod.IsCallable then
-      begin
-        if not IsRegExpInstance(AValue) then
-          ThrowTypeError(SErrorRegExpExecNotCallable);
-      end
-      else
-      begin
-        ExecArgs := TGocciaArgumentsCollection.Create([
-          TGocciaStringLiteralValue.Create(AInput)
-        ]);
-        try
-          ExecResult := InvokeCallable(ExecMethod, ExecArgs, Obj);
-        finally
-          ExecArgs.Free;
-        end;
-
-        if ExecResult is TGocciaNullLiteralValue then
-        begin
-          AMatchArray := nil;
-          AMatchIndex := -1;
-          AMatchEnd := -1;
-          ANextIndex := -1;
-          Exit(False);
-        end;
-
-        if not (ExecResult is TGocciaObjectValue) then
-          ThrowTypeError(SErrorRegExpExecReturnType);
-
-        AMatchArray := ExecResult;
-        AMatchIndex := 0;
-        AMatchEnd := 0;
-        ANextIndex := 0;
-        Exit(True);
-      end;
-    end;
+    Result := TryRunRegExpCustomExec(AValue, AInput, AMatchArray,
+      AMatchIndex, AMatchEnd, ANextIndex, HandledCustomExec);
+    if HandledCustomExec then
+      Exit;
   end;
 
   if not IsRegExpInstance(AValue) then

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -704,6 +704,19 @@ function BytecodePrivateTokenForKey(const AKey,
 function BytecodePrivateReceiverBrandToken(
   const AObject: TGocciaValue): string; forward;
 
+function UTF16CodeUnitImmediateToUTF8(const ACodeUnit: UInt16): string;
+begin
+  if ACodeUnit <= $7F then
+    Result := Chr(ACodeUnit)
+  else if ACodeUnit <= $7FF then
+    Result := Chr($C0 or (ACodeUnit shr 6)) +
+      Chr($80 or (ACodeUnit and $3F))
+  else
+    Result := Chr($E0 or (ACodeUnit shr 12)) +
+      Chr($80 or ((ACodeUnit shr 6) and $3F)) +
+      Chr($80 or (ACodeUnit and $3F));
+end;
+
 { TGocciaVMDirectEvalScope }
 
 constructor TGocciaVMDirectEvalScope.Create(const AParent: TGocciaScope;
@@ -12908,6 +12921,10 @@ begin
         else
           FRegisters[A] := ValueToRegister(
             ConstantToValue(Template.GetConstantUnchecked(DecodeBx(Instruction))));
+
+      OP_LOAD_CHAR:
+        FRegisters[A] := ValueToRegister(TGocciaStringLiteralValue.Create(
+          UTF16CodeUnitImmediateToUTF8(DecodeBx(Instruction))));
 
       OP_LOAD_REGEXP:
         FRegisters[A] := ValueToRegister(

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -214,6 +214,8 @@ type
 
   TGocciaStringClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function DefaultPrototypeForNewTarget(const ANewTarget: TGocciaValue;
+      const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
     // ECMAScript 22.1.1.1: String constructor length is 1.
     function GetClassLength: Integer; override;
   end;
@@ -358,6 +360,7 @@ uses
   Goccia.Values.ResponseValue,
   Goccia.Values.SetValue,
   Goccia.Values.SharedArrayBufferValue,
+  Goccia.Values.StringObjectValue,
   Goccia.Values.TextDecoderValue,
   Goccia.Values.TextEncoderValue,
   Goccia.Values.ToPrimitive,
@@ -377,6 +380,27 @@ begin
     Exit(TGocciaNumberLiteralValue.Create(
       TGocciaBigIntValue(AValue).Value.ToDouble));
   Result := AValue.ToNumberLiteral;
+end;
+
+function ToStringConstructorValue(const AValue: TGocciaValue;
+  const AAllowSymbol: Boolean): TGocciaStringLiteralValue;
+var
+  Prim: TGocciaValue;
+begin
+  if AValue is TGocciaSymbolValue then
+  begin
+    if AAllowSymbol then
+      Exit(TGocciaSymbolValue(AValue).ToDisplayString);
+    ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion);
+  end;
+
+  if AValue is TGocciaObjectValue then
+  begin
+    Prim := ToPrimitive(AValue, tphString);
+    Exit(Prim.ToStringLiteral);
+  end;
+
+  Result := AValue.ToStringLiteral;
 end;
 
 function GetTypedArrayPrototypeFromConstructor(
@@ -438,6 +462,9 @@ begin
     if AConstructorName = CONSTRUCTOR_NUMBER then
       FallbackPrototype :=
         TGocciaNumberObjectValue.GetSharedPrototypeForRealm(FallbackRealm)
+    else if AConstructorName = CONSTRUCTOR_STRING then
+      FallbackPrototype :=
+        TGocciaStringObjectValue.GetSharedPrototypeForRealm(FallbackRealm)
     else if AConstructorName = CONSTRUCTOR_BOOLEAN then
       FallbackPrototype :=
         TGocciaBooleanObjectValue.GetSharedPrototypeForRealm(FallbackRealm)
@@ -1456,6 +1483,9 @@ begin
       else if NativeClass is TGocciaArrayClassValue then
         InstancePrototype := GetArrayPrototypeFromConstructor(ANewTarget,
           NativeIntrinsicPrototype)
+      else if NativeClass is TGocciaStringClassValue then
+        InstancePrototype := TGocciaStringClassValue(NativeClass).
+          DefaultPrototypeForNewTarget(ANewTarget, NativeIntrinsicPrototype)
       else if NativeClass is TGocciaNumberClassValue then
         InstancePrototype := TGocciaNumberClassValue(NativeClass).
           DefaultPrototypeForNewTarget(ANewTarget, NativeIntrinsicPrototype)
@@ -1896,10 +1926,8 @@ begin
   begin
     if AArguments.Length = 0 then
       Result := TGocciaStringLiteralValue.Create('')
-    else if AArguments.GetElement(0) is TGocciaSymbolValue then
-      Result := TGocciaSymbolValue(AArguments.GetElement(0)).ToDisplayString
     else
-      Result := AArguments.GetElement(0).ToStringLiteral;
+      Result := ToStringConstructorValue(AArguments.GetElement(0), True);
   end
   else if FName = CONSTRUCTOR_NUMBER then
   begin
@@ -2106,11 +2134,17 @@ var
 begin
   if AArguments.Length = 0 then
     Prim := TGocciaStringLiteralValue.Create('')
-  else if AArguments.GetElement(0) is TGocciaSymbolValue then
-    Prim := TGocciaSymbolValue(AArguments.GetElement(0)).ToDisplayString
   else
-    Prim := AArguments.GetElement(0).ToStringLiteral;
+    Prim := ToStringConstructorValue(AArguments.GetElement(0), False);
   Result := Prim.Box;
+end;
+
+function TGocciaStringClassValue.DefaultPrototypeForNewTarget(
+  const ANewTarget: TGocciaValue;
+  const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
+begin
+  Result := DefaultNativePrototypeForNewTarget(ANewTarget,
+    ACurrentRealmDefault, CONSTRUCTOR_STRING);
 end;
 
 function TGocciaStringClassValue.GetClassLength: Integer;

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -9,6 +9,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.Values.ClassValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
@@ -33,11 +34,16 @@ type
     function GetAllPropertyNames: TArray<string>; override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
     function HasOwnProperty(const AName: string): Boolean; override;
+    function DeleteProperty(const AName: string): Boolean; override;
 
+    procedure InitializeNativeFromArguments(
+      const AArguments: TGocciaArgumentsCollection); override;
     procedure InitializePrototype;
     procedure MarkReferences; override;
 
     class function GetSharedPrototype: TGocciaObjectValue;
+    class function GetSharedPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; static;
 
     property Primitive: TGocciaStringLiteralValue read FPrimitive;
 
@@ -100,7 +106,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Realm,
   Goccia.RegExp.Runtime,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
@@ -315,6 +320,20 @@ begin
     Result := TGocciaClassValue(AValue).GetSymbolProperty(ASymbol)
   else
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  if (Result is TGocciaNullLiteralValue) or (Result = nil) then
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function ThisStringValue(const AValue: TGocciaValue): string;
+begin
+  if AValue is TGocciaStringLiteralValue then
+    Result := TGocciaStringLiteralValue(AValue).Value
+  else if AValue is TGocciaStringObjectValue then
+    Result := TGocciaStringObjectValue(AValue).Primitive.Value
+  else
+    ThrowTypeError(SErrorStringPrototypeRequiresNonNullish,
+      SSuggestCheckNullBeforeAccess);
 end;
 
 function RegexReplacementCapture(const AMatchArray: TGocciaArrayValue;
@@ -647,6 +666,41 @@ begin
   Result := inherited HasOwnProperty(AName);
 end;
 
+function TGocciaStringObjectValue.DeleteProperty(const AName: string): Boolean;
+var
+  Index: Integer;
+  StringValue: string;
+begin
+  if AName = PROP_LENGTH then
+    Exit(False);
+
+  if TryStrToInt(AName, Index) and (AName = IntToStr(Index)) then
+  begin
+    StringValue := FPrimitive.ToStringLiteral.Value;
+    if (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue)) then
+      Exit(False);
+  end;
+
+  Result := inherited DeleteProperty(AName);
+end;
+
+procedure TGocciaStringObjectValue.InitializeNativeFromArguments(
+  const AArguments: TGocciaArgumentsCollection);
+var
+  Arg: TGocciaValue;
+begin
+  if AArguments.Length = 0 then
+    FPrimitive := TGocciaStringLiteralValue.Create('')
+  else
+  begin
+    Arg := AArguments.GetElement(0);
+    if Arg is TGocciaSymbolValue then
+      ThrowTypeError(SErrorSymbolToString, SSuggestSymbolNoImplicitConversion)
+    else
+      FPrimitive := Arg.ToStringLiteral;
+  end;
+end;
+
 procedure TGocciaStringObjectValue.InitializePrototype;
 var
   Members: TGocciaMemberCollection;
@@ -682,7 +736,7 @@ begin
     Members.AddMethod(StringTrimEnd, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('replace', StringReplaceMethod, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('replaceAll', StringReplaceAllMethod, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddMethod(StringSplit, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddMethod(StringSplit, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(StringMatch, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(StringMatchAll, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(StringSearch, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -716,6 +770,15 @@ begin
   if not Assigned(GetSharedStringPrototype) then
     TGocciaStringObjectValue.Create(TGocciaStringLiteralValue.Create(''));
   Result := GetSharedStringPrototype;
+end;
+
+class function TGocciaStringObjectValue.GetSharedPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+begin
+  if Assigned(ARealm) then
+    Result := TGocciaObjectValue(ARealm.GetSlot(GStringPrototypeSlot))
+  else
+    Result := nil;
 end;
 
 // ES2026 §22.1.3 String.prototype.length (accessor)
@@ -863,7 +926,10 @@ begin
   StartIndex := NormalizeRelativeIndex(StartIndex, Len);
 
   // Step 6: If end is undefined, let intEnd be len; else let intEnd be ToIntegerOrInfinity(end)
-  EndIndex := ToIntegerFromArgs(AArgs, 1, Len);
+  if (AArgs.Length <= 1) or (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
+    EndIndex := Len
+  else
+    EndIndex := ToIntegerFromArgs(AArgs, 1, Len);
 
   // Step 7: If intEnd < 0, let to be max(len + intEnd, 0); else let to be min(intEnd, len)
   EndIndex := NormalizeRelativeIndex(EndIndex, Len);
@@ -896,7 +962,10 @@ begin
   else
     StartIndex := Min(StartIndex, Len);
 
-  RequestedLength := ToIntegerFromArgs(AArgs, 1, Len);
+  if (AArgs.Length <= 1) or (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
+    RequestedLength := Len
+  else
+    RequestedLength := ToIntegerFromArgs(AArgs, 1, Len);
   ResultLength := Min(Max(RequestedLength, 0), Len - StartIndex);
 
   if ResultLength > 0 then
@@ -925,7 +994,10 @@ begin
   StartIndex := ToIntegerFromArgs(AArgs);
 
   // Step 5: If end is undefined, let intEnd be len; else let intEnd be ToIntegerOrInfinity(end)
-  EndIndex := ToIntegerFromArgs(AArgs, 1, Len);
+  if (AArgs.Length <= 1) or (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
+    EndIndex := Len
+  else
+    EndIndex := ToIntegerFromArgs(AArgs, 1, Len);
 
   // Step 6: Let finalStart be min(max(intStart, 0), len)
   // Step 7: Let finalEnd be min(max(intEnd, 0), len)
@@ -1571,52 +1643,59 @@ begin
   else
     SeparatorArg := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  HasLimit := (AArgs.Length > 1) and
-    not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue);
-  if HasLimit then
-  begin
-    Limit := ToUint32Value(AArgs.GetElement(1));
-    if Limit = 0 then
-    begin
-      Result := TGocciaArrayValue.Create;
-      Exit;
-    end;
-  end;
-
   ResultArray := TGocciaArrayValue.Create;
   TGarbageCollector.Instance.AddTempRoot(ResultArray);
   try
-    SplitMethod := GetMethodBySymbol(SeparatorArg,
-      TGocciaSymbolValue.WellKnownSplit);
-    if not (SplitMethod is TGocciaUndefinedLiteralValue) then
+    if not ((SeparatorArg is TGocciaUndefinedLiteralValue) or
+            (SeparatorArg is TGocciaNullLiteralValue)) then
     begin
-      if not SplitMethod.IsCallable then
-        ThrowTypeError(SErrorSymbolSplitNotCallable, SSuggestWellKnownSymbolCallable);
-      // Spec passes O directly to the @@split callable, not a stringified copy.
-      if HasLimit then
+      SplitMethod := GetMethodBySymbol(SeparatorArg,
+        TGocciaSymbolValue.WellKnownSplit);
+      if not (SplitMethod is TGocciaUndefinedLiteralValue) then
+      begin
+        if not SplitMethod.IsCallable then
+          ThrowTypeError(SErrorSymbolSplitNotCallable, SSuggestWellKnownSymbolCallable);
+        // Spec passes O directly to the @@split callable, not a stringified copy.
         CallArgs := TGocciaArgumentsCollection.Create([
           AThisValue,
           AArgs.GetElement(1)
-        ])
-      else
-        CallArgs := TGocciaArgumentsCollection.Create([
-          AThisValue
         ]);
-      try
-        Result := InvokeCallable(SplitMethod, CallArgs, SeparatorArg);
-      finally
-        CallArgs.Free;
+        try
+          Result := InvokeCallable(SplitMethod, CallArgs, SeparatorArg);
+        finally
+          CallArgs.Free;
+        end;
+        Exit;
       end;
-      Exit;
     end;
 
     // Step 3 (spec): Let S be ? ToString(O). Only reached when no @@split.
     StringValue := ExtractStringValue(AThisValue);
 
-    // §22.1.3.23 step 5: Let R be ? ToString(separator).
+    HasLimit := (AArgs.Length > 1) and
+      not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue);
+    if HasLimit then
+      Limit := ToUint32Value(AArgs.GetElement(1))
+    else
+      Limit := High(Cardinal);
+
+    // §22.1.3.23 step 7: Let R be ? ToString(separator).
     Separator := SeparatorArg.ToStringLiteral.Value;
 
-    // Step 5: If separator is undefined, return [S]
+    if Limit = 0 then
+    begin
+      Result := ResultArray;
+      Exit;
+    end;
+
+    // Step 9: If separator is undefined, return [S].
+    if SeparatorArg is TGocciaUndefinedLiteralValue then
+    begin
+      ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(StringValue));
+      Result := ResultArray;
+      Exit;
+    end;
+
     if StringValue = '' then
     begin
       if Separator <> '' then
@@ -1729,6 +1808,24 @@ begin
 
   TGarbageCollector.Instance.AddTempRoot(RegexValue);
   try
+    MatchMethod := GetMethodBySymbol(RegexValue,
+      TGocciaSymbolValue.WellKnownMatch);
+    if not (MatchMethod is TGocciaUndefinedLiteralValue) then
+    begin
+      if not MatchMethod.IsCallable then
+        ThrowTypeError(SErrorSymbolMatchNotCallable, SSuggestWellKnownSymbolCallable);
+      CallArgs := TGocciaArgumentsCollection.Create([
+        TGocciaStringLiteralValue.Create(StringValue)
+      ]);
+      try
+        Result := InvokeCallable(MatchMethod, CallArgs, RegexValue);
+      finally
+        CallArgs.Free;
+      end;
+      Exit;
+    end;
+    ThrowTypeError(SErrorSymbolMatchNotCallable, SSuggestWellKnownSymbolCallable);
+
     if GetRegExpBooleanProperty(RegexValue, PROP_GLOBAL) then
     begin
       ResultArray := TGocciaArrayValue.Create;
@@ -1822,9 +1919,32 @@ begin
     RegexValue := CoerceRegExpValue(TGocciaUndefinedLiteralValue.UndefinedValue,
       'g');
 
-  Result := TGocciaRegExpMatchAllIteratorValue.Create(RegexValue, StringValue,
-    True, HasUnicodeRegExpFlag(RegexValue.GetProperty(PROP_FLAGS)
-    .ToStringLiteral.Value));
+  TGarbageCollector.Instance.AddTempRoot(RegexValue);
+  try
+    MatchAllMethod := GetMethodBySymbol(RegexValue,
+      TGocciaSymbolValue.WellKnownMatchAll);
+    if not (MatchAllMethod is TGocciaUndefinedLiteralValue) then
+    begin
+      if not MatchAllMethod.IsCallable then
+        ThrowTypeError(SErrorSymbolMatchAllNotCallable, SSuggestWellKnownSymbolCallable);
+      CallArgs := TGocciaArgumentsCollection.Create([
+        TGocciaStringLiteralValue.Create(StringValue)
+      ]);
+      try
+        Result := InvokeCallable(MatchAllMethod, CallArgs, RegexValue);
+      finally
+        CallArgs.Free;
+      end;
+      Exit;
+    end;
+    ThrowTypeError(SErrorSymbolMatchAllNotCallable, SSuggestWellKnownSymbolCallable);
+
+    Result := TGocciaRegExpMatchAllIteratorValue.Create(RegexValue, StringValue,
+      True, HasUnicodeRegExpFlag(RegexValue.GetProperty(PROP_FLAGS)
+      .ToStringLiteral.Value));
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(RegexValue);
+  end;
 end;
 
 // ES2026 §22.1.3.27 String.prototype.search(regexp)
@@ -1877,6 +1997,24 @@ begin
 
   TGarbageCollector.Instance.AddTempRoot(RegexValue);
   try
+    SearchMethod := GetMethodBySymbol(RegexValue,
+      TGocciaSymbolValue.WellKnownSearch);
+    if not (SearchMethod is TGocciaUndefinedLiteralValue) then
+    begin
+      if not SearchMethod.IsCallable then
+        ThrowTypeError(SErrorSymbolSearchNotCallable, SSuggestWellKnownSymbolCallable);
+      CallArgs := TGocciaArgumentsCollection.Create([
+        TGocciaStringLiteralValue.Create(StringValue)
+      ]);
+      try
+        Result := InvokeCallable(SearchMethod, CallArgs, RegexValue);
+      finally
+        CallArgs.Free;
+      end;
+      Exit;
+    end;
+    ThrowTypeError(SErrorSymbolSearchNotCallable, SSuggestWellKnownSymbolCallable);
+
     if MatchRegExpObjectValue(RegexValue, StringValue, 0, False, False,
       MatchArray,
       MatchIndex, MatchEnd, NextIndex) then
@@ -2071,14 +2209,14 @@ end;
 function TGocciaStringObjectValue.StringValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Return the [[StringData]] internal slot of this value
-  Result := TGocciaStringLiteralValue.Create(ExtractStringValue(AThisValue));
+  Result := TGocciaStringLiteralValue.Create(ThisStringValue(AThisValue));
 end;
 
 // ES2026 §22.1.3.27 String.prototype.toString()
 function TGocciaStringObjectValue.StringToString(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   // Step 1: Return the [[StringData]] internal slot of this value (same as valueOf)
-  Result := TGocciaStringLiteralValue.Create(ExtractStringValue(AThisValue));
+  Result := TGocciaStringLiteralValue.Create(ThisStringValue(AThisValue));
 end;
 
 // ES2026 §22.1.3.34 String.prototype[@@iterator]()
@@ -2147,7 +2285,7 @@ end;
 // ES2026 §22.1.3.13 String.prototype.normalize([form])
 function TGocciaStringObjectValue.StringNormalize(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  StringValue, Form: string;
+  StringValue, Form, NormalizedValue: string;
 begin
   // Step 1: Let O be RequireObjectCoercible(this value)
   // Step 2: Let S be ToString(O)
@@ -2164,7 +2302,10 @@ begin
     ThrowRangeError(SErrorInvalidNormalizationForm, SSuggestNormalizationForm);
 
   // Step 5: Return the Unicode Normalization Form f of S
-  Result := TGocciaStringLiteralValue.Create(StringValue);
+  if TryICUNormalize(Form, StringValue, NormalizedValue) then
+    Result := TGocciaStringLiteralValue.Create(NormalizedValue)
+  else
+    Result := TGocciaStringLiteralValue.Create(StringValue);
 end;
 
 // ES2026 §22.1.3.8 String.prototype.isWellFormed()
@@ -2178,7 +2319,7 @@ begin
   // Step 2: Let S be ToString(O)
   StringValue := ExtractStringValue(AThisValue);
   // Step 3: Return IsStringWellFormedUnicode(S)
-  Result := TGocciaBooleanLiteralValue.Create(IsWellFormedUTF8(StringValue));
+  Result := TGocciaBooleanLiteralValue.Create(IsWellFormedUTF16(StringValue));
 end;
 
 // ES2026 §22.1.3.33 String.prototype.toWellFormed()
@@ -2192,7 +2333,7 @@ begin
   // Step 2: Let S be ToString(O)
   StringValue := ExtractStringValue(AThisValue);
   // Step 3-5: Replace ill-formed Unicode sequences with U+FFFD.
-  Result := TGocciaStringLiteralValue.Create(ToWellFormedUTF8(StringValue));
+  Result := TGocciaStringLiteralValue.Create(ToWellFormedUTF16(StringValue));
 end;
 
 initialization

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -689,6 +689,9 @@ procedure TGocciaStringObjectValue.InitializeNativeFromArguments(
 var
   Arg: TGocciaValue;
 begin
+  if Assigned(FPrimitive) then
+    Exit;
+
   if AArguments.Length = 0 then
     FPrimitive := TGocciaStringLiteralValue.Create('')
   else

--- a/tests/built-ins/RegExp/prototype/named-groups.js
+++ b/tests/built-ins/RegExp/prototype/named-groups.js
@@ -123,8 +123,13 @@ test("forward backreference resolves correctly", () => {
   expect(result.groups.word).toBe("hello");
 });
 
-test("invalid named backreference throws", () => {
+test("unknown named backreference is legacy literal when no named groups exist", () => {
+  const re = new RegExp("\\k<nosuchgroup>");
+  expect(re.test("k<nosuchgroup>")).toBe(true);
+});
+
+test("invalid named backreference throws when named groups exist", () => {
   expect(() => {
-    new RegExp("\\k<nosuchgroup>");
+    new RegExp("(?<x>a)\\k<nosuchgroup>");
   }).toThrow();
 });

--- a/tests/built-ins/RegExp/prototype/named-groups.js
+++ b/tests/built-ins/RegExp/prototype/named-groups.js
@@ -128,8 +128,13 @@ test("unknown named backreference is legacy literal when no named groups exist",
   expect(re.test("k<nosuchgroup>")).toBe(true);
 });
 
+test("unknown unicode named backreference is legacy literal when no named groups exist", () => {
+  const re = new RegExp("\\k<π>");
+  expect(re.test("k<π>")).toBe(true);
+});
+
 test("invalid named backreference throws when named groups exist", () => {
   expect(() => {
     new RegExp("(?<x>a)\\k<nosuchgroup>");
-  }).toThrow();
+  }).toThrow(SyntaxError);
 });

--- a/tests/built-ins/RegExp/prototype/symbol-match.js
+++ b/tests/built-ins/RegExp/prototype/symbol-match.js
@@ -62,3 +62,28 @@ test("Symbol.match uses ToLength when advancing lastIndex after empty global mat
     "set-lastIndex:1",
   ]);
 });
+
+test("Symbol.match does not coerce lastIndex after non-empty custom exec matches", () => {
+  const regex = /./g;
+  let nextMatch = "a non-empty string";
+
+  regex.exec = () => {
+    const thisMatch = nextMatch;
+    if (thisMatch === null) {
+      return null;
+    }
+    nextMatch = null;
+    return {
+      get 0() {
+        regex.lastIndex = {
+          valueOf() {
+            throw new Error("lastIndex should not be coerced");
+          },
+        };
+        return thisMatch;
+      },
+    };
+  };
+
+  expect(regex[Symbol.match]("")).toEqual(["a non-empty string"]);
+});

--- a/tests/built-ins/String/constructor.js
+++ b/tests/built-ins/String/constructor.js
@@ -89,6 +89,20 @@ describe("String constructor", () => {
     expect(s.valueOf()).toBe("wrapped");
   });
 
+  test("new String(obj) coerces the argument once", () => {
+    let calls = 0;
+    const obj = {
+      toString() {
+        calls += 1;
+        return "wrapped once";
+      },
+    };
+
+    const s = new String(obj);
+    expect(s.valueOf()).toBe("wrapped once");
+    expect(calls).toBe(1);
+  });
+
   test("String(stringWrapper) unwraps via toString()", () => {
     const wrapped = new String("hi");
     expect(String(wrapped)).toBe("hi");

--- a/tests/built-ins/String/constructor.js
+++ b/tests/built-ins/String/constructor.js
@@ -44,10 +44,9 @@ describe("String constructor", () => {
     expect(s instanceof String).toBe(true);
   });
 
-  test("new String(symbol) wraps display string (ES2026 §22.1.1.1)", () => {
-    const s = new String(Symbol("x"));
-    expect(typeof s).toBe("object");
-    expect(s.valueOf()).toBe("Symbol(x)");
+  test("new String(symbol) throws TypeError (ES2026 §22.1.1.1)", () => {
+    expect(() => new String(Symbol("x"))).toThrow(TypeError);
+    expect(String(Symbol("x"))).toBe("Symbol(x)");
   });
 
   test("String(obj) invokes user toString() (ES2026 §7.1.17 ToString)", () => {

--- a/tests/built-ins/String/prototype/isWellFormed.js
+++ b/tests/built-ins/String/prototype/isWellFormed.js
@@ -20,6 +20,10 @@ describe("String.prototype.isWellFormed", () => {
     expect("\uD83D\uDE00".isWellFormed()).toBe(true);
   });
 
+  test("surrogate pair formed by concatenation is well-formed", () => {
+    expect(("\uD83D" + "\uDCA9").isWellFormed()).toBe(true);
+  });
+
   test("lone high surrogate is not well-formed", () => {
     expect("\uD800".isWellFormed()).toBe(false);
   });

--- a/tests/built-ins/String/prototype/normalize.js
+++ b/tests/built-ins/String/prototype/normalize.js
@@ -14,6 +14,16 @@ describe("String.prototype.normalize", () => {
     expect("abc".normalize("NFKD")).toBe("abc");
   });
 
+  test("normalizes canonical forms", () => {
+    expect("e\u0301".normalize("NFC")).toBe("\u00E9");
+    expect("\u00E9".normalize("NFD")).toBe("e\u0301");
+  });
+
+  test("normalizes compatibility forms", () => {
+    expect("\uFB01".normalize("NFKD")).toBe("fi");
+    expect("\u212B".normalize("NFKC")).toBe("\u00C5");
+  });
+
   test("throws RangeError for invalid form", () => {
     expect(() => "abc".normalize("INVALID")).toThrow(RangeError);
   });

--- a/tests/built-ins/String/prototype/toLowerCase.js
+++ b/tests/built-ins/String/prototype/toLowerCase.js
@@ -10,7 +10,13 @@ test("String.prototype.toLowerCase converts to lowercase", () => {
 });
 
 test("String.prototype.toLowerCase maps Unicode characters", () => {
-  expect("ÉÖΣ".toLowerCase()).toBe("éöσ");
+  expect("ÉÖΣ".toLowerCase()).toBe("éöς");
+});
+
+test("String.prototype.toLowerCase applies Unicode special casing", () => {
+  expect("\u0130".toLowerCase()).toBe("i\u0307");
+  expect("A\u03A3".toLowerCase()).toBe("a\u03C2");
+  expect("A\u03A3B".toLowerCase()).toBe("a\u03C3b");
 });
 
 test("String.prototype.toLowerCase coerces non-string receivers", () => {

--- a/tests/built-ins/String/prototype/toUpperCase.js
+++ b/tests/built-ins/String/prototype/toUpperCase.js
@@ -13,6 +13,10 @@ test("String.prototype.toUpperCase maps Unicode characters", () => {
   expect("éöσ".toUpperCase()).toBe("ÉÖΣ");
 });
 
+test("String.prototype.toUpperCase applies Unicode special casing", () => {
+  expect("\u00DF".toUpperCase()).toBe("SS");
+});
+
 test("String.prototype.toUpperCase coerces non-string receivers", () => {
   expect(String.prototype.toUpperCase.call(true)).toBe("TRUE");
 });

--- a/tests/built-ins/String/prototype/toWellFormed.js
+++ b/tests/built-ins/String/prototype/toWellFormed.js
@@ -21,6 +21,11 @@ describe("String.prototype.toWellFormed", () => {
     expect(emoji.toWellFormed()).toBe(emoji);
   });
 
+  test("surrogate pair formed by concatenation is preserved", () => {
+    const emoji = "\uD83D" + "\uDCA9";
+    expect(("a" + emoji + "d").toWellFormed()).toBe("a" + emoji + "d");
+  });
+
   test("lone high surrogate is replaced with U+FFFD", () => {
     expect("\uD800".toWellFormed()).toBe("\uFFFD");
   });

--- a/tests/language/expressions/string-literals.js
+++ b/tests/language/expressions/string-literals.js
@@ -20,3 +20,21 @@ test("LS and PS are valid in string literals (ES2019)", () => {
   expect("hello world").toBe("hello" + String.fromCharCode(0x2028) + "world");
   expect('hello world').toBe("hello" + String.fromCharCode(0x2029) + "world");
 });
+
+test("braced unicode escapes accept padded code points", () => {
+  expect("\u{00000000000001000}".charCodeAt(0)).toBe(0x1000);
+  expect("\u{00000000000000000}".charCodeAt(0)).toBe(0x0000);
+  expect("\u{0000000000010FFFF}").toBe(String.fromCodePoint(0x10ffff));
+});
+
+test("braced unicode escapes can produce lone surrogate code units", () => {
+  expect("\u{D800}".length).toBe(1);
+  expect("\u{D800}".charCodeAt(0)).toBe(0xd800);
+  expect("\u{DFFF}".charCodeAt(0)).toBe(0xdfff);
+});
+
+test("template braced unicode escapes accept padded code points", () => {
+  expect(`\u{00000000000001000}`.charCodeAt(0)).toBe(0x1000);
+  expect(`\u{0000000000010FFFF}`).toBe(String.fromCodePoint(0x10ffff));
+  expect(`\u{D800}`.charCodeAt(0)).toBe(0xd800);
+});

--- a/tests/language/expressions/string-literals.js
+++ b/tests/language/expressions/string-literals.js
@@ -38,3 +38,7 @@ test("template braced unicode escapes accept padded code points", () => {
   expect(`\u{0000000000010FFFF}`).toBe(String.fromCodePoint(0x10ffff));
   expect(`\u{D800}`.charCodeAt(0)).toBe(0xd800);
 });
+
+test("template hex escapes above ASCII are cooked as UTF-8", () => {
+  expect(`\xA9`).toBe(String.fromCharCode(0x00a9));
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Bring `built-ins/String/**` to 100% on the pinned test262 checkout in both bytecode and interpreted modes.
- Close the remaining String failures across String wrapper semantics, Unicode/ICU text handling, lexer escape decoding, RegExp fallback/matchAll behavior, and bytecode single-code-unit string loading.
- Add focused local regressions for the corrected behavior.

Closes #836.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation run:

- `./build.pas testrunner && ./build.pas loaderbare && ./build.pas loader`
- `./build/GocciaTestRunner tests`
- `./build/GocciaTestRunner tests --mode=bytecode`
- `./build/TextSemantics.Test`
- `./build/Goccia.Compiler.Test`
- `bun scripts/test-cli-lexer.ts`
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --categories built-ins --filter 'built-ins/String/**' --mode=bytecode --jobs=4 --timeout-ms=20000 --output=/tmp/goccia-string-builtins-bytecode-final-rerun2.json` -> 1223/1223 passed
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --categories staging,intl402 --filter '**/String/**' --mode=bytecode --jobs=4 --timeout-ms=20000 --output=/tmp/goccia-string-staging-intl402-bytecode-final-rerun2.json` -> 66/66 passed
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --categories built-ins --filter 'built-ins/String/**' --mode=interpreted --jobs=4 --timeout-ms=20000 --output=/tmp/goccia-string-builtins-interpreted-final-rerun3.json` -> 1223/1223 passed
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --categories staging,intl402 --filter '**/String/**' --mode=interpreted --jobs=4 --timeout-ms=20000 --output=/tmp/goccia-string-staging-intl402-interpreted-final-rerun3.json` -> 66/66 passed
- `./format.pas --check`
- `git diff --check`