### PR TITLE
fix(class): close class super private conformance gaps

### DIFF
--- a/docs/test262.md
+++ b/docs/test262.md
@@ -250,7 +250,8 @@ Bodies see only the identifiers stock test262 expects:
 - `$DONE`, `$DONOTEVALUATE` (from `sta.js` / `doneprintHandle.js` when included)
 - `print` (Goccia engine global; stock `doneprintHandle.js` uses it for async markers)
 - `$262` helpers implemented by Goccia's bundled host object:
-  `detachArrayBuffer`, `evalScript`, `gc`, `global`, and `createRealm`
+  `detachArrayBuffer`, `evalScript`, `gc`, `global`, `createRealm`,
+  `AbstractModuleSource`, and `IsHTMLDDA`
 - `$262.agent` helpers used by Atomics tests: `start`, `broadcast`,
   `receiveBroadcast`, `report`, `getReport`, `sleep`, `monotonicNow`, and
   `leaving`

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -761,12 +761,18 @@ console.log("Bare Loader: test262 host marker is hidden by default...");
 
 console.log("Bare Loader: --test262-host exposes Goccia test262 hooks...");
 {
-  const proc = Bun.spawnSync([BARE, "--test262-host"], {
+  const proc = Bun.spawnSync([BARE, "--test262-host", "--compat-loose-equality"], {
     stdin: new TextEncoder().encode([
       "print(Goccia.test262Host);",
       "print(typeof Goccia.test262);",
       "print(typeof Goccia.test262.createRealm);",
       "print(typeof Goccia.test262.evalScript);",
+      "const htmlDDA = Goccia.test262.isHTMLDDA;",
+      "print(typeof htmlDDA);",
+      "print(Boolean(htmlDDA));",
+      "print(htmlDDA == null);",
+      "print(htmlDDA == undefined);",
+      "print(htmlDDA === undefined);",
       "const realm = Goccia.test262.createRealm();",
       "print(realm.global.Object !== Object);",
       "print(typeof realm.global.eval);",
@@ -776,7 +782,20 @@ console.log("Bare Loader: --test262-host exposes Goccia test262 hooks...");
     stdout: "pipe",
     stderr: "pipe",
   });
-  const expected = "true\nobject\nfunction\nfunction\ntrue\nfunction\n3";
+  const expected = [
+    "true",
+    "object",
+    "function",
+    "function",
+    "undefined",
+    "false",
+    "true",
+    "true",
+    "false",
+    "true",
+    "function",
+    "3",
+  ].join("\n");
   if (proc.exitCode !== 0)
     throw new Error(`Bare --test262-host hook probe exited ${proc.exitCode}: ${proc.stderr.toString()}`);
   if (normalizeLineEndings(proc.stdout.toString()).trim() !== expected)

--- a/scripts/test262_harness/$262.js
+++ b/scripts/test262_harness/$262.js
@@ -19,10 +19,12 @@ if (typeof Goccia === "undefined" || Goccia.test262Host !== true) {
 const AbstractModuleSource = () => {
   throw new TypeError("%AbstractModuleSource% is not a constructor");
 };
+const IsHTMLDDA = {};
 
 var $262 = {
   global: globalThis,
   AbstractModuleSource,
+  IsHTMLDDA,
 
   detachArrayBuffer(buffer) {
     buffer.transfer();

--- a/scripts/test262_harness/$262.js
+++ b/scripts/test262_harness/$262.js
@@ -19,7 +19,7 @@ if (typeof Goccia === "undefined" || Goccia.test262Host !== true) {
 const AbstractModuleSource = () => {
   throw new TypeError("%AbstractModuleSource% is not a constructor");
 };
-const IsHTMLDDA = {};
+const IsHTMLDDA = Goccia.test262.isHTMLDDA;
 
 var $262 = {
   global: globalThis,

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -90,6 +90,13 @@ type
   TBareTest262AgentThread = class;
   TBareTest262Host = class;
 
+  TGocciaTest262IsHTMLDDAValue = class(TGocciaObjectValue)
+  public
+    function HasHTMLDDAInternalSlot: Boolean; override;
+    function TypeOf: string; override;
+    function ToBooleanLiteral: TGocciaBooleanLiteralValue; override;
+  end;
+
   TBareTest262EvalHost = class
   private
     FEngine: TGocciaEngine;
@@ -237,8 +244,24 @@ begin
       ATest262EvalHost.EvalScript, 'evalScript', 1));
   Test262Obj.AssignProperty('abstractModuleSourcePrototype',
     TGocciaModuleSourceValue.SharedPrototype);
+  Test262Obj.AssignProperty('isHTMLDDA', TGocciaTest262IsHTMLDDAValue.Create);
   Test262Obj.AssignProperty('agent', ATest262Host.CreateAgentObject);
   AEngine.GocciaGlobal.AssignProperty('test262', Test262Obj);
+end;
+
+function TGocciaTest262IsHTMLDDAValue.HasHTMLDDAInternalSlot: Boolean;
+begin
+  Result := True;
+end;
+
+function TGocciaTest262IsHTMLDDAValue.TypeOf: string;
+begin
+  Result := 'undefined';
+end;
+
+function TGocciaTest262IsHTMLDDAValue.ToBooleanLiteral: TGocciaBooleanLiteralValue;
+begin
+  Result := TGocciaBooleanLiteralValue.FalseValue;
 end;
 
 function TBarePrintHost.Print(const AArgs: TGocciaArgumentsCollection;

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -2152,6 +2152,7 @@ function TGocciaIncrementExpression.Evaluate(const AContext: TGocciaEvaluationCo
 var
   Obj, OldValue, NewValue, PropertyKeyValue: TGocciaValue;
   MemberExpr: TGocciaMemberExpression;
+  PrivateExpr: TGocciaPrivateMemberExpression;
   PropName: string;
 begin
   if Operand is TGocciaIdentifierExpression then
@@ -2221,6 +2222,19 @@ begin
     NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
     AssignProperty(Obj, PropName, NewValue, AContext.OnError, Line, Column,
       AContext.NonStrictMode);
+    if IsPrefix then
+      Result := NewValue
+    else
+      Result := OldValue;
+  end
+  else if Operand is TGocciaPrivateMemberExpression then
+  begin
+    PrivateExpr := TGocciaPrivateMemberExpression(Operand);
+    OldValue := ToNumericValue(EvaluatePrivateMember(PrivateExpr, AContext,
+      Obj));
+    NewValue := PerformIncrement(OldValue, Operator = gttIncrement);
+    AssignPrivateMemberValue(Obj, PrivateExpr.PrivateName, NewValue, AContext,
+      Line, Column);
     if IsPrefix then
       Result := NewValue
     else

--- a/source/units/Goccia.AST.Statements.pas
+++ b/source/units/Goccia.AST.Statements.pas
@@ -369,6 +369,7 @@ type
     FDecorators: TGocciaDecoratorList;
     FElements: array of TGocciaClassElement;
     FFieldOrder: array of TGocciaFieldOrderEntry;
+    FSourceText: string;
 
     constructor Create(const AName, ASuperClass: string;
       const AMethods: TGocciaClassMethodMap;
@@ -384,6 +385,7 @@ type
     destructor Destroy; override;
     property Name: string read FName;
     property SuperClass: string read FSuperClass;
+    property SourceText: string read FSourceText write FSourceText;
     property SuperClassExpression: TGocciaExpression read FSuperClassExpression;
     property Methods: TGocciaClassMethodMap read FMethods;
     property StaticMethods: TGocciaClassMethodMap read FStaticMethods;

--- a/source/units/Goccia.Arithmetic.pas
+++ b/source/units/Goccia.Arithmetic.pas
@@ -683,6 +683,14 @@ begin
   if IsNullOrUndefined(ALeft) and IsNullOrUndefined(ARight) then
     Exit(True);
 
+  // ES2026 §7.2.13 IsLooselyEqual, Annex B web-compat insertion:
+  // objects with [[IsHTMLDDA]] compare loosely equal to null/undefined.
+  if IsNullOrUndefined(ALeft) and ARight.HasHTMLDDAInternalSlot then
+    Exit(True);
+
+  if ALeft.HasHTMLDDAInternalSlot and IsNullOrUndefined(ARight) then
+    Exit(True);
+
   if (ALeft is TGocciaNumberLiteralValue) and
      (ARight is TGocciaStringLiteralValue) then
     Exit(IsLooselyEqual(ALeft, ARight.ToNumberLiteral));

--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -1146,8 +1146,6 @@ end;
 // ES2026 §20.1.2.18 Object.preventExtensions(O)
 function TGocciaGlobalObject.ObjectPreventExtensions(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.preventExtensions', ThrowError);
-
   // Step 1: If Type(O) is not Object, return O
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
   begin

--- a/source/units/Goccia.Bytecode.Chunk.pas
+++ b/source/units/Goccia.Bytecode.Chunk.pas
@@ -178,6 +178,7 @@ type
     FParameterPreambleSize: UInt16;
     FTypeCheckPreambleSize: UInt8;
     FDirectEvalSyntheticArgumentsSlot: Integer;
+    FDerivedThisInitializedSlot: Integer;
     FRejectArgumentsInDirectEval: Boolean;
     FProfileIndex: Integer;
     FSourceText: string;
@@ -287,6 +288,7 @@ type
     property ParameterPreambleSize: UInt16 read FParameterPreambleSize write FParameterPreambleSize;
     property TypeCheckPreambleSize: UInt8 read FTypeCheckPreambleSize write FTypeCheckPreambleSize;
     property DirectEvalSyntheticArgumentsSlot: Integer read FDirectEvalSyntheticArgumentsSlot write FDirectEvalSyntheticArgumentsSlot;
+    property DerivedThisInitializedSlot: Integer read FDerivedThisInitializedSlot write FDerivedThisInitializedSlot;
     property RejectArgumentsInDirectEval: Boolean read FRejectArgumentsInDirectEval write FRejectArgumentsInDirectEval;
     property ProfileIndex: Integer read FProfileIndex write FProfileIndex;
     property SourceText: string read FSourceText write FSourceText;
@@ -348,6 +350,7 @@ begin
   FParameterPreambleSize := 0;
   FTypeCheckPreambleSize := 0;
   FDirectEvalSyntheticArgumentsSlot := -1;
+  FDerivedThisInitializedSlot := -1;
   FRejectArgumentsInDirectEval := False;
   FProfileIndex := -1;
   FTemplateSiteId := AllocateTemplateSiteId;

--- a/source/units/Goccia.Bytecode.OpCodeNames.pas
+++ b/source/units/Goccia.Bytecode.OpCodeNames.pas
@@ -148,6 +148,7 @@ begin
     OP_SET_OBJECT_PROTO:               Result := 'OP_SET_OBJECT_PROTO';
     OP_DEFINE_PROP_DYNAMIC:            Result := 'OP_DEFINE_PROP_DYNAMIC';
     OP_DEFINE_CLASS_METHOD_DYNAMIC:    Result := 'OP_DEFINE_CLASS_METHOD_DYNAMIC';
+    OP_SET_CLASS_SOURCE_CONST:         Result := 'OP_SET_CLASS_SOURCE_CONST';
     OP_ADD:                            Result := 'OP_ADD';
     OP_SUB:                            Result := 'OP_SUB';
     OP_MUL:                            Result := 'OP_MUL';

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -141,7 +141,9 @@ const
   //   v67 -> v68: added long-name global define/predeclare opcodes so
   //               generated sources with more than 255 global names can keep
   //               using 16-bit constant-pool indices.
-  GOCCIA_FORMAT_VERSION = 68;
+  //   v68 -> v69: added OP_SET_CLASS_SOURCE_CONST so Function.prototype.toString
+  //               can return exact class source text in bytecode mode.
+  GOCCIA_FORMAT_VERSION = 69;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;
@@ -335,6 +337,7 @@ type
     OP_SHR           = 140,
     OP_USHR          = 141,
     OP_DEFINE_CLASS_METHOD_DYNAMIC = 142,
+    OP_SET_CLASS_SOURCE_CONST = 143,
     OP_IMPORT        = 167,
     OP_EXPORT        = 168,
     OP_AWAIT         = 169,

--- a/source/units/Goccia.Compiler.Context.pas
+++ b/source/units/Goccia.Compiler.Context.pas
@@ -26,6 +26,7 @@ type
     const AScope: TGocciaCompilerScope) of object;
   TSetDerivedConstructorThisGuardProc = procedure(
     const AGuard: Boolean) of object;
+  TSetNonStrictModeProc = procedure(const AEnabled: Boolean) of object;
 
   TFormalParameterCountMap = THashMap<TGocciaFunctionTemplate, Integer>;
 
@@ -47,6 +48,7 @@ type
     CompileFunctionBody: TCompileFunctionBodyProc;
     SwapState: TSwapStateProc;
     SetDerivedConstructorThisGuard: TSetDerivedConstructorThisGuardProc;
+    SetNonStrictMode: TSetNonStrictModeProc;
   end;
 
 function EmitInstruction(const ACtx: TGocciaCompilationContext;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -161,6 +161,9 @@ uses
   Goccia.Values.BigIntValue,
   Goccia.Values.Primitives;
 
+const
+  DERIVED_THIS_INITIALIZED_LOCAL = '__derived_this_initialized';
+
 type
   TGocciaCompilerJumpArray = array of Integer;
   TPreparedDestructuringTargetKind = (
@@ -168,12 +171,16 @@ type
     pdtIdentifierWithBinding,
     pdtStringProperty,
     pdtComputedProperty,
+    pdtSuperStringProperty,
+    pdtSuperComputedProperty,
     pdtPrivateProperty
   );
   TPreparedDestructuringTarget = record
     Kind: TPreparedDestructuringTargetKind;
     ObjectReg: Integer;
     KeyReg: Integer;
+    ThisReg: Integer;
+    SuperReg: Integer;
     PropertyName: string;
   end;
 
@@ -853,7 +860,7 @@ procedure PrepareIdentifierWithBindingTarget(
   const ACtx: TGocciaCompilationContext; const AName: string;
   var ATarget: TPreparedDestructuringTarget);
 var
-  ObjReg, CondReg: UInt8;
+  ObjReg, CondReg, ThisReg, BaseReg, SuperReg: UInt8;
   NameIdx: UInt16;
   I, EndCount: Integer;
   MissJump: Integer;
@@ -1644,6 +1651,7 @@ begin
     (AName <> KEYWORD_THIS) and
     (AName <> '__receiver') and
     (AName <> '__super__') and
+    (AName <> DERIVED_THIS_INITIALIZED_LOCAL) and
     (Copy(AName, 1, 1) <> '#') and
     (Copy(AName, 1, 7) <> '__param') and
     (Copy(AName, 1, 19) <> '__accessor_computed');
@@ -1663,7 +1671,8 @@ procedure AddDirectEvalBinding(var ABindings: TGocciaDirectEvalBindingArray;
 var
   BindingIndex: Integer;
 begin
-  if (AKind <> debWithLocal) and (AKind <> debWithUpvalue) and
+  if (AName <> DERIVED_THIS_INITIALIZED_LOCAL) and
+     (AKind <> debWithLocal) and (AKind <> debWithUpvalue) and
      (AName <> KEYWORD_THIS) and
      not IsDirectEvalVisibleCompilerName(AName) then
     Exit;
@@ -1681,6 +1690,86 @@ begin
     AIsVarEnvironmentBinding;
   ABindings[BindingIndex].IsEvalSyntheticArguments :=
     AIsEvalSyntheticArguments;
+end;
+
+procedure EmitDerivedThisInitializedCheck(
+  const ACtx: TGocciaCompilationContext);
+var
+  FlagReg: UInt8;
+  LocalIdx, UpvalueIdx: Integer;
+  Local: TGocciaCompilerLocal;
+  OkJump: Integer;
+begin
+  if not ACtx.DerivedConstructorThisGuard then
+    Exit;
+
+  UpvalueIdx := -1;
+  FlagReg := ACtx.Scope.AllocateRegister;
+  try
+    LocalIdx := ACtx.Scope.ResolveLocal(DERIVED_THIS_INITIALIZED_LOCAL);
+    if LocalIdx >= 0 then
+    begin
+      Local := ACtx.Scope.GetLocal(LocalIdx);
+      if Local.IsCaptured then
+        EmitInstruction(ACtx, EncodeABx(OP_GET_LOCAL, FlagReg,
+          UInt16(Local.Slot)))
+      else if Local.Slot <> FlagReg then
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, FlagReg, Local.Slot, 0));
+    end
+    else
+    begin
+      UpvalueIdx := ACtx.Scope.ResolveUpvalue(DERIVED_THIS_INITIALIZED_LOCAL);
+      if UpvalueIdx >= 0 then
+        EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, FlagReg,
+          UInt16(UpvalueIdx)))
+      else
+        EmitInstruction(ACtx, EncodeABC(OP_CHECK_DERIVED_THIS, 0, 0, 0));
+    end;
+
+    if (LocalIdx >= 0) or (UpvalueIdx >= 0) then
+    begin
+      OkJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, FlagReg);
+      EmitReferenceError(ACtx,
+        'Must call super constructor before accessing this');
+      PatchJumpTarget(ACtx, OkJump);
+    end;
+  finally
+    ACtx.Scope.FreeRegister;
+  end;
+end;
+
+procedure EmitSetDerivedThisInitialized(
+  const ACtx: TGocciaCompilationContext);
+var
+  FlagReg: UInt8;
+  LocalIdx, UpvalueIdx: Integer;
+  Local: TGocciaCompilerLocal;
+begin
+  LocalIdx := ACtx.Scope.ResolveLocal(DERIVED_THIS_INITIALIZED_LOCAL);
+  UpvalueIdx := -1;
+  if LocalIdx < 0 then
+    UpvalueIdx := ACtx.Scope.ResolveUpvalue(DERIVED_THIS_INITIALIZED_LOCAL);
+  if (LocalIdx < 0) and (UpvalueIdx < 0) then
+    Exit;
+
+  FlagReg := ACtx.Scope.AllocateRegister;
+  try
+    EmitInstruction(ACtx, EncodeABC(OP_LOAD_TRUE, FlagReg, 0, 0));
+    if LocalIdx >= 0 then
+    begin
+      Local := ACtx.Scope.GetLocal(LocalIdx);
+      if Local.Slot <> FlagReg then
+        EmitInstruction(ACtx, EncodeABC(OP_MOVE, Local.Slot, FlagReg, 0));
+      if Local.IsCaptured then
+        EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Local.Slot,
+          UInt16(Local.Slot)));
+    end
+    else
+      EmitInstruction(ACtx, EncodeABx(OP_SET_UPVALUE, FlagReg,
+        UInt16(UpvalueIdx)));
+  finally
+    ACtx.Scope.FreeRegister;
+  end;
 end;
 
 procedure CaptureDirectEvalEnvironment(const ACtx: TGocciaCompilationContext;
@@ -1726,6 +1815,18 @@ begin
         Local := ScopeCursor.GetLocal(LocalIdx);
         if DirectEvalBindingNameSeen(Names, Local.Name) then
           Continue;
+        if Local.Name = DERIVED_THIS_INITIALIZED_LOCAL then
+        begin
+          UpvalueIdx := ACtx.Scope.ResolveUpvalue(Local.Name);
+          if UpvalueIdx >= 0 then
+          begin
+            UV := ACtx.Scope.GetUpvalue(UpvalueIdx);
+            AddDirectEvalBinding(Bindings, Names, Local.Name, debUpvalue,
+              UInt8(UpvalueIdx), UV.IsConst, UV.IsVar,
+              UV.IsNonStrictImmutable);
+          end;
+          Continue;
+        end;
         if HiddenWithBindingName(Local.Name) then
         begin
           UpvalueIdx := ACtx.Scope.ResolveUpvalue(Local.Name);
@@ -2033,6 +2134,8 @@ begin
       ObjReg := ACtx.Scope.AllocateRegister;
       try
         CompileThis(ACtx, ObjReg);
+        if MemberExpr.Computed and Assigned(MemberExpr.PropertyExpression) then
+          ACtx.CompileExpression(MemberExpr.PropertyExpression, ObjReg);
         EmitReferenceError(ACtx, 'Cannot delete super property');
         EmitInstruction(ACtx, EncodeABC(OP_LOAD_TRUE, ADest, 0, 0));
       finally
@@ -2646,6 +2749,8 @@ begin
   ATarget.Kind := pdtNone;
   ATarget.ObjectReg := -1;
   ATarget.KeyReg := -1;
+  ATarget.ThisReg := -1;
+  ATarget.SuperReg := -1;
   ATarget.PropertyName := '';
 end;
 
@@ -2655,7 +2760,11 @@ procedure ReleasePreparedDestructuringTarget(
 begin
   if ATarget.KeyReg >= 0 then
     ACtx.Scope.FreeRegister;
+  if ATarget.SuperReg >= 0 then
+    ACtx.Scope.FreeRegister;
   if ATarget.ObjectReg >= 0 then
+    ACtx.Scope.FreeRegister;
+  if ATarget.ThisReg >= 0 then
     ACtx.Scope.FreeRegister;
   InitPreparedDestructuringTarget(ATarget);
 end;
@@ -2670,7 +2779,7 @@ var
   IdentPat: TGocciaIdentifierDestructuringPattern;
   MemberPat: TGocciaMemberExpressionDestructuringPattern;
   PrivatePat: TGocciaPrivateMemberExpressionDestructuringPattern;
-  ObjReg, CondReg: UInt8;
+  ObjReg, CondReg, ThisReg, BaseReg, SuperReg: UInt8;
   NameIdx: UInt16;
   I, EndCount: Integer;
   MissJump: Integer;
@@ -2737,6 +2846,32 @@ begin
   if APattern is TGocciaMemberExpressionDestructuringPattern then
   begin
     MemberPat := TGocciaMemberExpressionDestructuringPattern(APattern);
+    if MemberPat.Expression.ObjectExpr is TGocciaSuperExpression then
+    begin
+      PrepareSuperPropertyBase(ACtx, ThisReg, BaseReg, SuperReg);
+      ATarget.ThisReg := ThisReg;
+      ATarget.ObjectReg := BaseReg;
+      ATarget.SuperReg := SuperReg;
+      ATarget.KeyReg := ACtx.Scope.AllocateRegister;
+      if MemberPat.Expression.Computed then
+      begin
+        ATarget.Kind := pdtSuperComputedProperty;
+        ACtx.CompileExpression(MemberPat.Expression.PropertyExpression,
+          UInt8(ATarget.KeyReg));
+        EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY,
+          UInt8(ATarget.KeyReg), UInt8(ATarget.KeyReg), 0));
+      end
+      else
+      begin
+        ATarget.Kind := pdtSuperStringProperty;
+        ATarget.PropertyName := MemberPat.Expression.PropertyName;
+        NameIdx := ACtx.Template.AddConstantString(ATarget.PropertyName);
+        EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST,
+          UInt8(ATarget.KeyReg), NameIdx));
+      end;
+      Exit;
+    end;
+
     ATarget.ObjectReg := ACtx.Scope.AllocateRegister;
     ACtx.CompileExpression(MemberPat.Expression.ObjectExpr,
       UInt8(ATarget.ObjectReg));
@@ -2792,6 +2927,9 @@ begin
     pdtComputedProperty:
       EmitInstruction(ACtx, EncodeABC(StoreByKeyOpcode(ACtx),
         UInt8(ATarget.ObjectReg), UInt8(ATarget.KeyReg), AValueReg));
+    pdtSuperStringProperty, pdtSuperComputedProperty:
+      EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, UInt8(ATarget.ObjectReg),
+        UInt8(ATarget.KeyReg), AValueReg));
   end;
 end;
 
@@ -2977,7 +3115,7 @@ var
   AssignPat: TGocciaAssignmentDestructuringPattern;
   IdentPat: TGocciaIdentifierDestructuringPattern;
   Prop: TGocciaDestructuringProperty;
-  DestSlot, IdxReg: UInt8;
+  DestSlot, IdxReg, ThisReg, BaseReg, SuperReg: UInt8;
   PropIdx: UInt16;
   JumpIdx, I: Integer;
   HasRest: Boolean;
@@ -3208,6 +3346,35 @@ begin
   end
   else if APattern is TGocciaMemberExpressionDestructuringPattern then
   begin
+    if TGocciaMemberExpressionDestructuringPattern(APattern)
+       .Expression.ObjectExpr is TGocciaSuperExpression then
+    begin
+      PrepareSuperPropertyBase(ACtx, ThisReg, BaseReg, SuperReg);
+      IdxReg := ACtx.Scope.AllocateRegister;
+      if TGocciaMemberExpressionDestructuringPattern(APattern).Expression.Computed then
+      begin
+        ACtx.CompileExpression(
+          TGocciaMemberExpressionDestructuringPattern(APattern)
+            .Expression.PropertyExpression,
+          IdxReg);
+        EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, IdxReg,
+          IdxReg, 0));
+      end
+      else
+      begin
+        PropIdx := ACtx.Template.AddConstantString(
+          TGocciaMemberExpressionDestructuringPattern(APattern)
+            .Expression.PropertyName);
+        EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, IdxReg, PropIdx));
+      end;
+      EmitInstruction(ACtx, EncodeABC(OP_SUPER_SET, BaseReg, IdxReg, ASrcReg));
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
+      Exit;
+    end;
+
     DestSlot := ACtx.Scope.AllocateRegister;
     ACtx.CompileExpression(
       TGocciaMemberExpressionDestructuringPattern(APattern).Expression.ObjectExpr,
@@ -3953,7 +4120,8 @@ begin
   // the nullish guard runs after the call, and super() writes `this` back after
   // the call, so neither is the last operation.  Only mark the plain and direct
   // member call forms.
-  if ATail and not AExpr.Optional then
+  if ATail and not AExpr.Optional and
+     not (AExpr.Callee is TGocciaSuperExpression) then
     MethodTailFlag := CALL_FLAG_TAIL
   else
     MethodTailFlag := 0;
@@ -4009,24 +4177,29 @@ begin
     begin
       ThisLocal := ACtx.Scope.GetLocal(ThisLocalIdx);
       ThisSlot := ThisLocal.Slot;
-      if ThisSlot <> BaseReg then
-        EmitInstruction(ACtx, EncodeABC(OP_MOVE, ThisSlot, BaseReg, 0));
-      if ThisLocal.IsCaptured then
-        EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, ThisSlot,
-          UInt16(ThisSlot)));
-    end
-    else
-    begin
+    if ThisSlot <> BaseReg then
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, ThisSlot, BaseReg, 0));
+    if ThisLocal.IsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, ThisSlot,
+        UInt16(ThisSlot)));
+    EmitSetDerivedThisInitialized(ACtx);
+  end
+  else
+  begin
       ThisUpvalIdx := ACtx.Scope.ResolveUpvalue(KEYWORD_THIS);
       if ThisUpvalIdx >= 0 then
+      begin
         EmitInstruction(ACtx, EncodeABx(OP_SET_UPVALUE, BaseReg,
-          UInt16(ThisUpvalIdx)))
+          UInt16(ThisUpvalIdx)));
+        EmitSetDerivedThisInitialized(ACtx);
+      end
       else
       begin
         EmitInstruction(ACtx, EncodeABC(OP_MOVE, 0, BaseReg, 0));
         EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, 0, 0));
+        EmitSetDerivedThisInitialized(ACtx);
       end;
-    end;
+  end;
 
     if AExpr.Optional then
     begin
@@ -6155,6 +6328,7 @@ var
   Op, NumericOp, PostNumericOp: TGocciaOpCode;
   Ident: TGocciaIdentifierExpression;
   MemberExpr: TGocciaMemberExpression;
+  PrivateExpr: TGocciaPrivateMemberExpression;
   ReservedDestRegister: Boolean;
   NameIdx: UInt16;
   I, EndCount: Integer;
@@ -6192,6 +6366,23 @@ begin
       else
         CompileIncrementMember(ACtx, AExpr, MemberExpr, ADest, Op,
           NumericOp, PostNumericOp, AKeepResult);
+      Exit;
+    end;
+
+    if AExpr.Operand is TGocciaPrivateMemberExpression then
+    begin
+      PrivateExpr := TGocciaPrivateMemberExpression(AExpr.Operand);
+      ObjReg := ACtx.Scope.AllocateRegister;
+      RegResult := ACtx.Scope.AllocateRegister;
+      ACtx.CompileExpression(PrivateExpr.ObjectExpr, ObjReg);
+      EmitLoadPropertyByName(ACtx, RegResult, ObjReg,
+        PrivateKey(ACtx.Scope, PrivateExpr.PrivateName));
+      EmitIncrementStep(ACtx, AExpr, ADest, RegResult, Op, NumericOp,
+        PostNumericOp, AKeepResult);
+      EmitStorePropertyByName(ACtx, ObjReg,
+        PrivateKey(ACtx.Scope, PrivateExpr.PrivateName), RegResult);
+      ACtx.Scope.FreeRegister;
+      ACtx.Scope.FreeRegister;
       Exit;
     end;
 
@@ -6569,15 +6760,18 @@ procedure CompileThis(const ACtx: TGocciaCompilationContext;
   const ADest: UInt8);
 var
   LocalIdx, UpvalIdx: Integer;
+  Local: TGocciaCompilerLocal;
   Slot: UInt8;
 begin
   LocalIdx := ACtx.Scope.ResolveLocal(KEYWORD_THIS);
   if LocalIdx >= 0 then
   begin
-    Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
-    if ACtx.DerivedConstructorThisGuard then
-      EmitInstruction(ACtx, EncodeABC(OP_CHECK_DERIVED_THIS, 0, 0, 0));
-    if Slot <> ADest then
+    Local := ACtx.Scope.GetLocal(LocalIdx);
+    Slot := Local.Slot;
+    EmitDerivedThisInitializedCheck(ACtx);
+    if Local.IsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_GET_LOCAL, ADest, UInt16(Slot)))
+    else if Slot <> ADest then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, Slot, 0));
     Exit;
   end;
@@ -6585,8 +6779,7 @@ begin
   UpvalIdx := ACtx.Scope.ResolveUpvalue(KEYWORD_THIS);
   if UpvalIdx >= 0 then
   begin
-    if ACtx.DerivedConstructorThisGuard then
-      EmitInstruction(ACtx, EncodeABC(OP_CHECK_DERIVED_THIS, 0, 0, 0));
+    EmitDerivedThisInitializedCheck(ACtx);
     EmitInstruction(ACtx, EncodeABx(OP_GET_UPVALUE, ADest, UInt16(UpvalIdx)));
     Exit;
   end;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -129,6 +129,9 @@ uses
   Goccia.Types.Enforcement,
   Goccia.Values.Primitives;
 
+const
+  DERIVED_THIS_INITIALIZED_LOCAL = '__derived_this_initialized';
+
 type
   TUsingResourceEntry = record
     ValueSlot: UInt8;
@@ -938,10 +941,27 @@ begin
     begin
       FuncCount := ACtx.Template.FunctionCount;
 
-      if (Info.Initializer is TGocciaClassExpression) and
-         (TGocciaClassExpression(Info.Initializer).ClassDefinition.Name = '') then
+      if (not AStmt.IsVar) and
+         (Info.Initializer is TGocciaClassExpression) then
+      begin
+        InitSlot := ACtx.Scope.AllocateRegister;
+        try
+          if TGocciaClassExpression(Info.Initializer).ClassDefinition.Name = '' then
+            CompileClassExpression(ACtx,
+              TGocciaClassExpression(Info.Initializer).ClassDefinition,
+              InitSlot, Info.Name)
+          else
+            ACtx.CompileExpression(Info.Initializer, InitSlot);
+          EmitInstruction(ACtx, EncodeABC(OP_MOVE, Slot, InitSlot, 0));
+        finally
+          ACtx.Scope.FreeRegister;
+        end;
+      end
+      else if (Info.Initializer is TGocciaClassExpression) and
+              (TGocciaClassExpression(Info.Initializer).ClassDefinition.Name = '') then
         CompileClassExpression(ACtx,
-          TGocciaClassExpression(Info.Initializer).ClassDefinition, Slot, Info.Name)
+          TGocciaClassExpression(Info.Initializer).ClassDefinition, Slot,
+          Info.Name)
       else
         ACtx.CompileExpression(Info.Initializer, Slot);
 
@@ -4707,7 +4727,8 @@ procedure EmitDefineStaticPropertyByName(const ACtx: TGocciaCompilationContext;
   const ATargetReg, AValueReg: UInt8; const AName: string);
 var
   KeyIdx: UInt16;
-  KeyReg: UInt8;
+  KeyReg, TargetReg: UInt8;
+  ProtoNameIdx: UInt16;
 begin
   KeyIdx := ACtx.Template.AddConstantString(AName);
   if KeyIdx <= High(UInt8) then
@@ -4757,6 +4778,7 @@ begin
   ChildTemplate.HasOwnPrototype := AMethod.IsGenerator;
   ChildTemplate.SourceText := AMethod.SourceText;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+  ChildScope.PrivatePrefix := OldScope.ResolvePrivatePrefix;
 
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   ChildTemplate.ParameterCount := Length(AMethod.Parameters);
@@ -4781,6 +4803,9 @@ begin
   for I := 0 to High(AMethod.Parameters) do
     if AMethod.Parameters[I].IsPattern and Assigned(AMethod.Parameters[I].Pattern) then
       CollectDestructuringBindings(AMethod.Parameters[I].Pattern, ChildScope);
+  if AGuardDerivedThis then
+    ChildTemplate.DerivedThisInitializedSlot :=
+      ChildScope.DeclareLocal(DERIVED_THIS_INITIALIZED_LOCAL, False);
   ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, AMethod.Parameters,
     ChildTemplate.SourceText);
   if FormalCount < 0 then
@@ -4804,6 +4829,10 @@ begin
   EmitCreateArgumentsObject(ChildCtx, ArgumentsSlot,
     ChildCtx.NonStrictMode and ParameterListIsSimple(AMethod.Parameters),
     Length(AMethod.Parameters));
+
+  if AGuardDerivedThis then
+    EmitInstruction(ChildCtx, EncodeABC(OP_LOAD_FALSE,
+      UInt8(ChildScope.ResolveLocal(DERIVED_THIS_INITIALIZED_LOCAL)), 0, 0));
 
   if (RestParamIndex >= 0) and
      not ParameterListHasDefaultValues(AMethod.Parameters) then
@@ -4871,6 +4900,7 @@ begin
   ChildTemplate.SourceText := AGetter.SourceText;
   ChildTemplate.ParameterCount := 0;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+  ChildScope.PrivatePrefix := OldScope.ResolvePrivatePrefix;
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   SetLength(EmptyParams, 0);
   ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams,
@@ -4951,6 +4981,7 @@ begin
   end;
   ChildTemplate.ParameterCount := Length(SetterParams);
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+  ChildScope.PrivatePrefix := OldScope.ResolvePrivatePrefix;
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   for I := 0 to High(SetterParams) do
     if SetterParams[I].IsPattern then
@@ -5044,6 +5075,7 @@ begin
   ChildTemplate.SourceText := AGetter.SourceText;
   ChildTemplate.ParameterCount := 0;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+  ChildScope.PrivatePrefix := OldScope.ResolvePrivatePrefix;
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   SetLength(EmptyParams, 0);
   ArgumentsSlot := DeclareArgumentsObjectLocal(ACtx, ChildScope, EmptyParams,
@@ -5123,6 +5155,7 @@ begin
   end;
   ChildTemplate.ParameterCount := Length(SetterParams);
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+  ChildScope.PrivatePrefix := OldScope.ResolvePrivatePrefix;
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   for I := 0 to High(SetterParams) do
     if SetterParams[I].IsPattern then
@@ -5213,6 +5246,7 @@ begin
   ChildTemplate.HasOwnPrototype := AMethod.IsGenerator;
   ChildTemplate.SourceText := AMethod.SourceText;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+  ChildScope.PrivatePrefix := OldScope.ResolvePrivatePrefix;
 
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
   ChildTemplate.ParameterCount := Length(AMethod.Parameters);
@@ -5420,7 +5454,8 @@ var
   MethodPair: TGocciaClassMethodMap.TKeyValuePair;
   GetterPair: TGocciaGetterExpressionMap.TKeyValuePair;
   SetterPair: TGocciaSetterExpressionMap.TKeyValuePair;
-  KeyReg: UInt8;
+  KeyReg, TargetReg: UInt8;
+  ProtoNameIdx: UInt16;
   ComputedKeyName: string;
   ClassKeyPrefix: string;
   NeedsKeyLocal: Boolean;
@@ -5430,56 +5465,56 @@ var
   StorageName: string;
 begin
   SetLength(AComputedFieldKeyLocals, 0);
-  if Length(AClassDef.FElements) = 0 then
-    Exit;
 
   SetLength(Entries, 0);
   Order := 0;
 
-  for MethodPair in AClassDef.Methods do
-    AddClassCallableSourceEntry(Entries, ccskMethod, MethodPair.Key, False,
-      False, MethodPair.Value.Line, MethodPair.Value.Column, Order, -1,
-      MethodPair.Value);
+  if Length(AClassDef.FElements) = 0 then
+  begin
+    for MethodPair in AClassDef.Methods do
+      AddClassCallableSourceEntry(Entries, ccskMethod, MethodPair.Key, False,
+        False, MethodPair.Value.Line, MethodPair.Value.Column, Order, -1,
+        MethodPair.Value);
 
-  for MethodPair in AClassDef.StaticMethods do
-    AddClassCallableSourceEntry(Entries, ccskMethod, MethodPair.Key, True,
-      False, MethodPair.Value.Line, MethodPair.Value.Column, Order, -1,
-      MethodPair.Value);
+    for MethodPair in AClassDef.StaticMethods do
+      AddClassCallableSourceEntry(Entries, ccskMethod, MethodPair.Key, True,
+        False, MethodPair.Value.Line, MethodPair.Value.Column, Order, -1,
+        MethodPair.Value);
 
-  for MethodPair in AClassDef.PrivateMethods do
-    AddClassCallableSourceEntry(Entries, ccskMethod, MethodPair.Key,
-      MethodPair.Value.IsStatic, True, MethodPair.Value.Line,
-      MethodPair.Value.Column, Order, -1, MethodPair.Value);
+    for MethodPair in AClassDef.PrivateMethods do
+      AddClassCallableSourceEntry(Entries, ccskMethod, MethodPair.Key,
+        MethodPair.Value.IsStatic, True, MethodPair.Value.Line,
+        MethodPair.Value.Column, Order, -1, MethodPair.Value);
 
-  for GetterPair in AClassDef.Getters do
-    AddClassCallableSourceEntry(Entries, ccskGetter, GetterPair.Key, False,
-      (GetterPair.Key <> '') and (GetterPair.Key[1] = '#'),
-      GetterPair.Value.Line, GetterPair.Value.Column, Order, -1, nil,
-      GetterPair.Value);
+    for GetterPair in AClassDef.Getters do
+      AddClassCallableSourceEntry(Entries, ccskGetter, GetterPair.Key, False,
+        (GetterPair.Key <> '') and (GetterPair.Key[1] = '#'),
+        GetterPair.Value.Line, GetterPair.Value.Column, Order, -1, nil,
+        GetterPair.Value);
 
-  for SetterPair in AClassDef.Setters do
-    AddClassCallableSourceEntry(Entries, ccskSetter, SetterPair.Key, False,
-      (SetterPair.Key <> '') and (SetterPair.Key[1] = '#'),
-      SetterPair.Value.Line, SetterPair.Value.Column, Order, -1, nil, nil,
-      SetterPair.Value);
+    for SetterPair in AClassDef.Setters do
+      AddClassCallableSourceEntry(Entries, ccskSetter, SetterPair.Key, False,
+        (SetterPair.Key <> '') and (SetterPair.Key[1] = '#'),
+        SetterPair.Value.Line, SetterPair.Value.Column, Order, -1, nil, nil,
+        SetterPair.Value);
 
-  for GetterPair in AClassDef.StaticGetters do
-    AddClassCallableSourceEntry(Entries, ccskGetter, GetterPair.Key, True,
-      (GetterPair.Key <> '') and (GetterPair.Key[1] = '#'),
-      GetterPair.Value.Line, GetterPair.Value.Column, Order, -1, nil,
-      GetterPair.Value);
+    for GetterPair in AClassDef.StaticGetters do
+      AddClassCallableSourceEntry(Entries, ccskGetter, GetterPair.Key, True,
+        (GetterPair.Key <> '') and (GetterPair.Key[1] = '#'),
+        GetterPair.Value.Line, GetterPair.Value.Column, Order, -1, nil,
+        GetterPair.Value);
 
-  for SetterPair in AClassDef.StaticSetters do
-    AddClassCallableSourceEntry(Entries, ccskSetter, SetterPair.Key, True,
-      (SetterPair.Key <> '') and (SetterPair.Key[1] = '#'),
-      SetterPair.Value.Line, SetterPair.Value.Column, Order, -1, nil, nil,
-      SetterPair.Value);
+    for SetterPair in AClassDef.StaticSetters do
+      AddClassCallableSourceEntry(Entries, ccskSetter, SetterPair.Key, True,
+        (SetterPair.Key <> '') and (SetterPair.Key[1] = '#'),
+        SetterPair.Value.Line, SetterPair.Value.Column, Order, -1, nil, nil,
+        SetterPair.Value);
+  end;
 
   for I := 0 to High(AClassDef.FElements) do
   begin
     Elem := AClassDef.FElements[I];
-    if Elem.IsComputed and
-       (Elem.Kind in [cekGetter, cekSetter, cekMethod, cekField, cekAccessor]) then
+    if Elem.Kind in [cekGetter, cekSetter, cekMethod, cekField, cekAccessor] then
       AddClassCallableSourceEntry(Entries, ccskElement, '', Elem.IsStatic,
         Elem.IsPrivate, ClassElementSourceLine(Elem),
         ClassElementSourceColumn(Elem), Order, I);
@@ -5558,7 +5593,14 @@ begin
       end
       else
         KeyReg := ACtx.Scope.AllocateRegister;
-      ACtx.CompileExpression(Elem.ComputedKeyExpression, KeyReg);
+      if Assigned(ACtx.SetNonStrictMode) then
+        ACtx.SetNonStrictMode(False);
+      try
+        ACtx.CompileExpression(Elem.ComputedKeyExpression, KeyReg);
+      finally
+        if Assigned(ACtx.SetNonStrictMode) then
+          ACtx.SetNonStrictMode(ACtx.CompatibilityNonStrictMode);
+      end;
       EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
     end
     else
@@ -5581,8 +5623,15 @@ begin
               Elem.GetterNode, OP_DEFINE_ACCESSOR_DYNAMIC,
               ACCESSOR_FLAG_STATIC)
           else
-            CompileComputedGetterBody(ACtx, ATargetReg, KeyReg,
+          begin
+            TargetReg := ACtx.Scope.AllocateRegister;
+            ProtoNameIdx := ACtx.Template.AddConstantString(PROP_PROTOTYPE);
+            EmitInstruction(ACtx, EncodeABC(OP_GET_PROP_CONST, TargetReg,
+              ATargetReg, UInt8(ProtoNameIdx)));
+            CompileComputedGetterBody(ACtx, TargetReg, KeyReg,
               Elem.GetterNode, OP_DEFINE_ACCESSOR_DYNAMIC, 0);
+            ACtx.Scope.FreeRegister;
+          end;
         end
         else if Elem.IsPrivate then
         begin
@@ -5607,9 +5656,16 @@ begin
               Elem.SetterNode, OP_DEFINE_ACCESSOR_DYNAMIC,
               ACCESSOR_FLAG_STATIC or ACCESSOR_FLAG_SETTER)
           else
-            CompileComputedSetterBody(ACtx, ATargetReg, KeyReg,
+          begin
+            TargetReg := ACtx.Scope.AllocateRegister;
+            ProtoNameIdx := ACtx.Template.AddConstantString(PROP_PROTOTYPE);
+            EmitInstruction(ACtx, EncodeABC(OP_GET_PROP_CONST, TargetReg,
+              ATargetReg, UInt8(ProtoNameIdx)));
+            CompileComputedSetterBody(ACtx, TargetReg, KeyReg,
               Elem.SetterNode, OP_DEFINE_ACCESSOR_DYNAMIC,
               ACCESSOR_FLAG_SETTER);
+            ACtx.Scope.FreeRegister;
+          end;
         end
         else if Elem.IsPrivate then
         begin
@@ -5665,7 +5721,8 @@ var
 begin
   for I := 0 to High(AClassDef.FElements) do
     if (AClassDef.FElements[I].Kind = cekAccessor) and
-       Assigned(AClassDef.FElements[I].FieldInitializer) then
+       (AClassDef.FElements[I].IsPrivate or
+        Assigned(AClassDef.FElements[I].FieldInitializer)) then
       Exit(True);
   Result := False;
 end;
@@ -5765,6 +5822,9 @@ begin
   for I := 0 to High(AClassDef.FElements) do
     if AClassDef.FElements[I].IsPrivate then
       RegisterPrivateName(AScope, AClassDef.FElements[I].Name, APrefix);
+  for I := 0 to High(AClassDef.FFieldOrder) do
+    if AClassDef.FFieldOrder[I].IsPrivate then
+      RegisterPrivateName(AScope, AClassDef.FFieldOrder[I].Name, APrefix);
 
   for ExprPair in AClassDef.PrivateInstanceProperties do
     RegisterPrivateName(AScope, ExprPair.Key, APrefix);
@@ -5813,6 +5873,7 @@ begin
   ChildTemplate.ParameterCount := 0;
   ChildTemplate.RejectArgumentsInDirectEval := True;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+  ChildScope.PrivatePrefix := OldScope.ResolvePrivatePrefix;
 
   ThisReg := ChildScope.DeclareLocal(KEYWORD_THIS, False);
 
@@ -5895,14 +5956,28 @@ begin
   for I := 0 to High(AClassDef.FElements) do
   begin
     Elem := AClassDef.FElements[I];
-    if (Elem.Kind <> cekAccessor) or not Assigned(Elem.FieldInitializer) then
+    if (Elem.Kind <> cekAccessor) or
+       ((not Elem.IsPrivate) and not Assigned(Elem.FieldInitializer)) then
       Continue;
     ValReg := ChildScope.AllocateRegister;
-    ACtx.CompileExpression(Elem.FieldInitializer, ValReg);
-    if Elem.IsComputed then
+    if Assigned(Elem.FieldInitializer) then
+      ACtx.CompileExpression(Elem.FieldInitializer, ValReg)
+    else
+      EmitInstruction(ChildCtx, EncodeABx(OP_LOAD_UNDEFINED, ValReg, 0));
+    if Elem.IsPrivate then
+      AccessorBackingName := '#slot:' + ChildScope.ResolvePrivatePrefix +
+        Elem.Name
+    else if Elem.IsComputed then
       AccessorBackingName := '__accessor_computed_' + IntToStr(I)
     else
       AccessorBackingName := '__accessor_' + Elem.Name;
+    if Elem.IsPrivate then
+    begin
+      EmitDefineStaticPropertyByName(ChildCtx, ThisReg, ValReg,
+        AccessorBackingName);
+      ChildScope.FreeRegister;
+      Continue;
+    end;
     KeyIdx := ChildTemplate.AddConstantString(AccessorBackingName);
     if KeyIdx <= High(UInt8) then
       EmitInstruction(ChildCtx, EncodeABC(OP_SET_PROP_CONST, ThisReg,
@@ -5958,6 +6033,7 @@ begin
   ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
   ChildTemplate.ParameterCount := 0;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
+  ChildScope.PrivatePrefix := OldScope.ResolvePrivatePrefix;
 
   ChildScope.DeclareLocal(KEYWORD_THIS, False);
 
@@ -6045,11 +6121,14 @@ var
   LocalIdx: Integer;
   ComputedKeyName: string;
   BackingName: string;
+  Flags: Integer;
 begin
   for I := 0 to High(AClassDef.FElements) do
   begin
     Elem := AClassDef.FElements[I];
     if Elem.Kind <> cekAccessor then
+      Continue;
+    if Elem.IsPrivate then
       Continue;
 
     if Elem.IsComputed then
@@ -6061,6 +6140,10 @@ begin
     if NameIdx > High(UInt8) then
       raise Exception.Create('Constant pool overflow: accessor name index exceeds 255');
 
+    Flags := 0;
+    if Elem.IsStatic then
+      Flags := Flags or 1;
+
     if Elem.IsComputed then
     begin
       ComputedKeyName := FindComputedFieldKeyLocalName(
@@ -6070,11 +6153,40 @@ begin
         raise Exception.Create('Compiler error: computed auto-accessor key was not captured');
       KeyReg := ACtx.Scope.GetLocal(LocalIdx).Slot;
       EmitInstruction(ACtx, EncodeABC(OP_SETUP_AUTO_ACCESSOR_DYNAMIC,
-        KeyReg, Ord(Elem.IsStatic), UInt8(NameIdx)));
+        KeyReg, Flags, UInt8(NameIdx)));
     end
     else
       EmitInstruction(ACtx, EncodeABC(OP_SETUP_AUTO_ACCESSOR_CONST,
-        0, Ord(Elem.IsStatic), UInt8(NameIdx)));
+        0, Flags, UInt8(NameIdx)));
+  end;
+end;
+
+procedure CompilePrivateAutoAccessorDeclarations(
+  const ACtx: TGocciaCompilationContext;
+  const AClassReg: UInt8; const AClassDef: TGocciaClassDefinition);
+var
+  I: Integer;
+  Elem: TGocciaClassElement;
+  NameIdx: UInt16;
+  Flags: Integer;
+  PrivateName: string;
+begin
+  for I := 0 to High(AClassDef.FElements) do
+  begin
+    Elem := AClassDef.FElements[I];
+    if (Elem.Kind <> cekAccessor) or not Elem.IsPrivate then
+      Continue;
+
+    PrivateName := '#slot:' + ACtx.Scope.ResolvePrivatePrefix + Elem.Name;
+    NameIdx := ACtx.Template.AddConstantString(PrivateName);
+    if NameIdx > High(UInt8) then
+      raise Exception.Create('Constant pool overflow: private accessor name index exceeds 255');
+
+    Flags := 2;
+    if Elem.IsStatic then
+      Flags := Flags or 1;
+    EmitInstruction(ACtx, EncodeABC(OP_SETUP_AUTO_ACCESSOR_CONST,
+      AClassReg, Flags, UInt8(NameIdx)));
   end;
 end;
 
@@ -6225,9 +6337,6 @@ var
   ClassDef: TGocciaClassDefinition;
   ClassReg, SuperReg, ValReg, KeyReg: UInt8;
   NameIdx, KeyIdx: UInt16;
-  MethodPair: TGocciaClassMethodMap.TKeyValuePair;
-  GetterPair: TGocciaGetterExpressionMap.TKeyValuePair;
-  SetterPair: TGocciaSetterExpressionMap.TKeyValuePair;
   StaticPropPair: TGocciaExpressionMap.TKeyValuePair;
   I, ClassLocalIdx, LocalIdx, UpvalIdx: Integer;
   HasSuper: Boolean;
@@ -6241,6 +6350,8 @@ var
   ClosedLocals: array[0..255] of UInt8;
   ClosedCount: Integer;
   HeritageCtx: TGocciaCompilationContext;
+  ComputedCtx: TGocciaCompilationContext;
+  OldPrivatePrefix: string;
 begin
   ClassDef := AStmt.ClassDefinition;
   HasSuper := Assigned(ClassDef.SuperClassExpression) or
@@ -6250,6 +6361,7 @@ begin
 
   PrivPrefix := NextClassPrivatePrefix;
   PrivateNameMark := ACtx.Scope.PrivateNameMark;
+  OldPrivatePrefix := ACtx.Scope.PrivatePrefix;
   ACtx.Scope.PrivatePrefix := PrivPrefix;
   RegisterClassPrivateNames(ACtx.Scope, ClassDef, PrivPrefix);
 
@@ -6269,6 +6381,8 @@ begin
     ACtx.Scope.MarkGlobalBacked(ClassLocalIdx);
   NameIdx := ACtx.Template.AddConstantString(ClassDef.Name);
   EmitInstruction(ACtx, EncodeABx(OP_NEW_CLASS, ClassReg, NameIdx));
+  KeyIdx := ACtx.Template.AddConstantString(ClassDef.SourceText);
+  EmitInstruction(ACtx, EncodeABx(OP_SET_CLASS_SOURCE_CONST, ClassReg, KeyIdx));
 
   HasInnerNameBinding := ClassDef.Name <> '';
   InnerNameSlot := 0;
@@ -6276,10 +6390,7 @@ begin
   begin
     ACtx.Scope.BeginScope;
     InnerNameSlot := ACtx.Scope.DeclareLocal(ClassDef.Name, True);
-    if HasSuper then
-      EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, InnerNameSlot, 0, 0))
-    else
-      EmitInstruction(ACtx, EncodeABC(OP_MOVE, InnerNameSlot, ClassReg, 0));
+    EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, InnerNameSlot, 0, 0));
   end;
 
   if HasSuper then
@@ -6313,77 +6424,16 @@ begin
     EmitInstruction(ACtx, EncodeABC(OP_CLASS_SET_SUPER, ClassReg, SuperReg, 0));
   end;
 
-  if HasInnerNameBinding and HasSuper then
+  ACtx.Scope.BeginScope;
+  ComputedCtx := ACtx;
+  ComputedCtx.NonStrictMode := False;
+  CompileComputedElements(ComputedCtx, ClassReg, ClassDef, PrivPrefix, HasSuper,
+    ComputedFieldKeyLocals);
+
+  if HasInnerNameBinding then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, InnerNameSlot, ClassReg, 0));
 
-  if Length(ClassDef.FElements) = 0 then
-  begin
-  for MethodPair in ClassDef.Methods do
-    CompileMethodBody(ACtx, ClassReg, MethodPair.Key,
-      MethodPair.Value, OP_CLASS_ADD_METHOD_CONST,
-      HasSuper and (MethodPair.Key = PROP_CONSTRUCTOR));
-
-  for MethodPair in ClassDef.StaticMethods do
-    CompileMethodBody(ACtx, ClassReg, MethodPair.Key,
-      MethodPair.Value, OP_DEFINE_STATIC_METHOD_CONST);
-
-  for MethodPair in ClassDef.PrivateMethods do
-  begin
-    if MethodPair.Value.IsStatic then
-      CompileMethodBody(ACtx, ClassReg, '#slot:' + PrivPrefix + MethodPair.Key,
-        MethodPair.Value, OP_DEFINE_STATIC_METHOD_CONST)
-    else
-      CompileMethodBody(ACtx, ClassReg, '#slot:' + PrivPrefix + MethodPair.Key,
-        MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
-  end;
-
-  for GetterPair in ClassDef.Getters do
-  begin
-    if (GetterPair.Key <> '') and (GetterPair.Key[1] = '#') then
-      CompileGetterBody(ACtx, ClassReg,
-        '#slot:' + PrivPrefix + Copy(GetterPair.Key, 2, MaxInt),
-        GetterPair.Value, OP_DEFINE_ACCESSOR_CONST, 0)
-    else
-      CompileGetterBody(ACtx, ClassReg, GetterPair.Key,
-        GetterPair.Value, OP_DEFINE_ACCESSOR_CONST, 0);
-  end;
-
-  for SetterPair in ClassDef.Setters do
-  begin
-    if (SetterPair.Key <> '') and (SetterPair.Key[1] = '#') then
-      CompileSetterBody(ACtx, ClassReg,
-        '#slot:' + PrivPrefix + Copy(SetterPair.Key, 2, MaxInt),
-        SetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_SETTER)
-    else
-      CompileSetterBody(ACtx, ClassReg, SetterPair.Key,
-        SetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_SETTER);
-  end;
-
-  for GetterPair in ClassDef.StaticGetters do
-  begin
-    if (GetterPair.Key <> '') and (GetterPair.Key[1] = '#') then
-      CompileGetterBody(ACtx, ClassReg,
-        '#slot:' + PrivPrefix + Copy(GetterPair.Key, 2, MaxInt),
-        GetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_STATIC)
-    else
-      CompileGetterBody(ACtx, ClassReg, GetterPair.Key,
-        GetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_STATIC);
-  end;
-
-  for SetterPair in ClassDef.StaticSetters do
-  begin
-    if (SetterPair.Key <> '') and (SetterPair.Key[1] = '#') then
-      CompileSetterBody(ACtx, ClassReg,
-        '#slot:' + PrivPrefix + Copy(SetterPair.Key, 2, MaxInt),
-        SetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_STATIC or ACCESSOR_FLAG_SETTER)
-    else
-      CompileSetterBody(ACtx, ClassReg, SetterPair.Key,
-        SetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_STATIC or ACCESSOR_FLAG_SETTER);
-  end;
-  end;
-
-  CompileComputedElements(ACtx, ClassReg, ClassDef, PrivPrefix, HasSuper,
-    ComputedFieldKeyLocals);
+  CompilePrivateAutoAccessorDeclarations(ACtx, ClassReg, ClassDef);
 
   if (ClassDef.InstanceProperties.Count > 0) or
      (ClassDef.PrivateInstanceProperties.Count > 0) or
@@ -6429,7 +6479,10 @@ begin
   begin
     if ClassDef.FElements[I].Kind = cekStaticBlock then
       CompileStaticBlock(ACtx, ClassReg, ClassDef.FElements[I].StaticBlockBody)
-    else if (ClassDef.FElements[I].Kind = cekField) and ClassDef.FElements[I].IsStatic then
+    else if ((ClassDef.FElements[I].Kind = cekField) or
+             ((ClassDef.FElements[I].Kind = cekAccessor) and
+              ClassDef.FElements[I].IsPrivate)) and
+            ClassDef.FElements[I].IsStatic then
     begin
       ValReg := ACtx.Scope.AllocateRegister;
       if ClassDef.FElements[I].IsComputed then
@@ -6487,6 +6540,10 @@ begin
     CompileDecoratorAndAccessorPass(ACtx, ClassReg, ClassDef, -1,
       ComputedFieldKeyLocals);
 
+  ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
+  for I := 0 to ClosedCount - 1 do
+    EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+
   // Sync cell if the class local was pre-declared and captured by a hoisted
   // function (see CompileVariableDeclaration for the full explanation)
   if (ClassLocalIdx >= 0) and
@@ -6503,7 +6560,7 @@ begin
       EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
   end;
 
-  ACtx.Scope.PrivatePrefix := '';
+  ACtx.Scope.PrivatePrefix := OldPrivatePrefix;
   ACtx.Scope.RestorePrivateNameMark(PrivateNameMark);
 end;
 
@@ -6514,9 +6571,6 @@ var
   ClassDef: TGocciaClassDefinition;
   SuperReg, ValReg, KeyReg: UInt8;
   NameIdx, KeyIdx: UInt16;
-  MethodPair: TGocciaClassMethodMap.TKeyValuePair;
-  GetterPair: TGocciaGetterExpressionMap.TKeyValuePair;
-  SetterPair: TGocciaSetterExpressionMap.TKeyValuePair;
   StaticPropPair: TGocciaExpressionMap.TKeyValuePair;
   LocalIdx, UpvalIdx: Integer;
   HasSuper: Boolean;
@@ -6529,6 +6583,8 @@ var
   ComputedKeyName: string;
   NameSlot: UInt8;
   HeritageCtx: TGocciaCompilationContext;
+  ComputedCtx: TGocciaCompilationContext;
+  OldPrivatePrefix: string;
 begin
   ClassDef := AClassDef;
   HasSuper := Assigned(ClassDef.SuperClassExpression) or
@@ -6537,6 +6593,7 @@ begin
 
   PrivPrefix := NextClassPrivatePrefix;
   PrivateNameMark := ACtx.Scope.PrivateNameMark;
+  OldPrivatePrefix := ACtx.Scope.PrivatePrefix;
   ACtx.Scope.PrivatePrefix := PrivPrefix;
   RegisterClassPrivateNames(ACtx.Scope, ClassDef, PrivPrefix);
 
@@ -6547,6 +6604,8 @@ begin
   else
     NameIdx := ACtx.Template.AddConstantString('<anonymous>');
   EmitInstruction(ACtx, EncodeABx(OP_NEW_CLASS, ADest, NameIdx));
+  KeyIdx := ACtx.Template.AddConstantString(ClassDef.SourceText);
+  EmitInstruction(ACtx, EncodeABx(OP_SET_CLASS_SOURCE_CONST, ADest, KeyIdx));
 
   // ES2026 §15.7.14: Named class expressions bind the name in an inner
   // block scope visible to methods/static initializers via upvalue capture
@@ -6554,10 +6613,7 @@ begin
   begin
     ACtx.Scope.BeginScope;
     NameSlot := ACtx.Scope.DeclareLocal(ClassDef.Name, True);
-    if HasSuper then
-      EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, NameSlot, 0, 0))
-    else
-      EmitInstruction(ACtx, EncodeABC(OP_MOVE, NameSlot, ADest, 0));
+    EmitInstruction(ACtx, EncodeABC(OP_LOAD_HOLE, NameSlot, 0, 0));
   end;
 
   if HasSuper then
@@ -6591,77 +6647,16 @@ begin
     EmitInstruction(ACtx, EncodeABC(OP_CLASS_SET_SUPER, ADest, SuperReg, 0));
   end;
 
-  if HasNameBinding and HasSuper then
+  ACtx.Scope.BeginScope;
+  ComputedCtx := ACtx;
+  ComputedCtx.NonStrictMode := False;
+  CompileComputedElements(ComputedCtx, ADest, ClassDef, PrivPrefix, HasSuper,
+    ComputedFieldKeyLocals);
+
+  if HasNameBinding then
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, NameSlot, ADest, 0));
 
-  if Length(ClassDef.FElements) = 0 then
-  begin
-  for MethodPair in ClassDef.Methods do
-    CompileMethodBody(ACtx, ADest, MethodPair.Key,
-      MethodPair.Value, OP_CLASS_ADD_METHOD_CONST,
-      HasSuper and (MethodPair.Key = PROP_CONSTRUCTOR));
-
-  for MethodPair in ClassDef.StaticMethods do
-    CompileMethodBody(ACtx, ADest, MethodPair.Key,
-      MethodPair.Value, OP_DEFINE_STATIC_METHOD_CONST);
-
-  for MethodPair in ClassDef.PrivateMethods do
-  begin
-    if MethodPair.Value.IsStatic then
-      CompileMethodBody(ACtx, ADest, '#slot:' + PrivPrefix + MethodPair.Key,
-        MethodPair.Value, OP_DEFINE_STATIC_METHOD_CONST)
-    else
-      CompileMethodBody(ACtx, ADest, '#slot:' + PrivPrefix + MethodPair.Key,
-        MethodPair.Value, OP_CLASS_ADD_METHOD_CONST);
-  end;
-
-  for GetterPair in ClassDef.Getters do
-  begin
-    if (GetterPair.Key <> '') and (GetterPair.Key[1] = '#') then
-      CompileGetterBody(ACtx, ADest,
-        '#slot:' + PrivPrefix + Copy(GetterPair.Key, 2, MaxInt),
-        GetterPair.Value, OP_DEFINE_ACCESSOR_CONST, 0)
-    else
-      CompileGetterBody(ACtx, ADest, GetterPair.Key,
-        GetterPair.Value, OP_DEFINE_ACCESSOR_CONST, 0);
-  end;
-
-  for SetterPair in ClassDef.Setters do
-  begin
-    if (SetterPair.Key <> '') and (SetterPair.Key[1] = '#') then
-      CompileSetterBody(ACtx, ADest,
-        '#slot:' + PrivPrefix + Copy(SetterPair.Key, 2, MaxInt),
-        SetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_SETTER)
-    else
-      CompileSetterBody(ACtx, ADest, SetterPair.Key,
-        SetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_SETTER);
-  end;
-
-  for GetterPair in ClassDef.StaticGetters do
-  begin
-    if (GetterPair.Key <> '') and (GetterPair.Key[1] = '#') then
-      CompileGetterBody(ACtx, ADest,
-        '#slot:' + PrivPrefix + Copy(GetterPair.Key, 2, MaxInt),
-        GetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_STATIC)
-    else
-      CompileGetterBody(ACtx, ADest, GetterPair.Key,
-        GetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_STATIC);
-  end;
-
-  for SetterPair in ClassDef.StaticSetters do
-  begin
-    if (SetterPair.Key <> '') and (SetterPair.Key[1] = '#') then
-      CompileSetterBody(ACtx, ADest,
-        '#slot:' + PrivPrefix + Copy(SetterPair.Key, 2, MaxInt),
-        SetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_STATIC or ACCESSOR_FLAG_SETTER)
-    else
-      CompileSetterBody(ACtx, ADest, SetterPair.Key,
-        SetterPair.Value, OP_DEFINE_ACCESSOR_CONST, ACCESSOR_FLAG_STATIC or ACCESSOR_FLAG_SETTER);
-  end;
-  end;
-
-  CompileComputedElements(ACtx, ADest, ClassDef, PrivPrefix, HasSuper,
-    ComputedFieldKeyLocals);
+  CompilePrivateAutoAccessorDeclarations(ACtx, ADest, ClassDef);
 
   if (ClassDef.InstanceProperties.Count > 0) or
      (ClassDef.PrivateInstanceProperties.Count > 0) or
@@ -6707,7 +6702,10 @@ begin
   begin
     if ClassDef.FElements[I].Kind = cekStaticBlock then
       CompileStaticBlock(ACtx, ADest, ClassDef.FElements[I].StaticBlockBody)
-    else if (ClassDef.FElements[I].Kind = cekField) and ClassDef.FElements[I].IsStatic then
+    else if ((ClassDef.FElements[I].Kind = cekField) or
+             ((ClassDef.FElements[I].Kind = cekAccessor) and
+              ClassDef.FElements[I].IsPrivate)) and
+            ClassDef.FElements[I].IsStatic then
     begin
       ValReg := ACtx.Scope.AllocateRegister;
       if ClassDef.FElements[I].IsComputed then
@@ -6759,21 +6757,24 @@ begin
   end;
 
   if HasSuper then
-  begin
     CompileDecoratorAndAccessorPass(ACtx, ADest, ClassDef, SuperReg,
-      ComputedFieldKeyLocals);
-    // Only free __super__ manually when there is no name binding scope —
-    // when HasNameBinding is true, __super__ lives inside the inner scope
-    // and EndScope below will free it together with the name binding local.
-    if not HasNameBinding then
-    begin
-      EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, SuperReg, 0, 0));
-      ACtx.Scope.FreeRegister;
-    end;
-  end
+      ComputedFieldKeyLocals)
   else
     CompileDecoratorAndAccessorPass(ACtx, ADest, ClassDef, -1,
       ComputedFieldKeyLocals);
+
+  ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
+  for I := 0 to ClosedCount - 1 do
+    EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
+
+  // Only free __super__ manually when there is no name binding scope — when
+  // HasNameBinding is true, __super__ lives inside the inner scope and EndScope
+  // below will free it together with the name binding local.
+  if HasSuper and not HasNameBinding then
+  begin
+    EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, SuperReg, 0, 0));
+    ACtx.Scope.FreeRegister;
+  end;
 
   if HasNameBinding then
   begin
@@ -6782,7 +6783,7 @@ begin
       EmitInstruction(ACtx, EncodeABC(OP_CLOSE_UPVALUE, ClosedLocals[I], 0, 0));
   end;
 
-  ACtx.Scope.PrivatePrefix := '';
+  ACtx.Scope.PrivatePrefix := OldPrivatePrefix;
   ACtx.Scope.RestorePrivateNameMark(PrivateNameMark);
 end;
 

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -5956,7 +5956,8 @@ begin
   for I := 0 to High(AClassDef.FElements) do
   begin
     Elem := AClassDef.FElements[I];
-    if (Elem.Kind <> cekAccessor) or
+    if Elem.IsStatic or
+       (Elem.Kind <> cekAccessor) or
        ((not Elem.IsPrivate) and not Assigned(Elem.FieldInitializer)) then
       Continue;
     ValReg := ChildScope.AllocateRegister;

--- a/source/units/Goccia.Compiler.pas
+++ b/source/units/Goccia.Compiler.pas
@@ -42,6 +42,7 @@ type
     procedure DoSwapState(const ATemplate: TGocciaFunctionTemplate;
       const AScope: TGocciaCompilerScope);
     procedure DoSetDerivedConstructorThisGuard(const AGuard: Boolean);
+    procedure DoSetNonStrictMode(const AEnabled: Boolean);
     function BuildContext: TGocciaCompilationContext;
     function NonStrictBlockFunctionVarBindingsEnabled: Boolean;
   public
@@ -129,6 +130,7 @@ begin
   Result.CompileFunctionBody := DoCompileFunctionBody;
   Result.SwapState := DoSwapState;
   Result.SetDerivedConstructorThisGuard := DoSetDerivedConstructorThisGuard;
+  Result.SetNonStrictMode := DoSetNonStrictMode;
 end;
 
 function TGocciaCompiler.NonStrictBlockFunctionVarBindingsEnabled: Boolean;
@@ -144,6 +146,11 @@ begin
   if Assigned(FCurrentTemplate) then
     FTemplateDerivedConstructorThisGuards.AddOrSetValue(
       FCurrentTemplate, AGuard);
+end;
+
+procedure TGocciaCompiler.DoSetNonStrictMode(const AEnabled: Boolean);
+begin
+  FNonStrictMode := AEnabled;
 end;
 
 procedure TGocciaCompiler.DoSwapState(

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -2884,7 +2884,161 @@ begin
       ValidateStrictDynamicExpression(
         TGocciaSequenceExpression(AExpr).Expressions[I])
   else if AExpr is TGocciaUnaryExpression then
-    ValidateStrictDynamicExpression(TGocciaUnaryExpression(AExpr).Operand);
+      ValidateStrictDynamicExpression(TGocciaUnaryExpression(AExpr).Operand);
+end;
+
+procedure ValidateDynamicFunctionSuperExpression(
+  const AExpr: TGocciaExpression); forward;
+procedure ValidateDynamicFunctionSuperStatement(
+  const AStmt: TGocciaStatement); forward;
+
+procedure ValidateDynamicFunctionSuperFunction(
+  const AFunction: TGocciaFunctionExpression);
+begin
+  if not Assigned(AFunction) then
+    Exit;
+  if AFunction.Body is TGocciaStatement then
+    ValidateDynamicFunctionSuperStatement(TGocciaStatement(AFunction.Body))
+  else if AFunction.Body is TGocciaExpression then
+    ValidateDynamicFunctionSuperExpression(TGocciaExpression(AFunction.Body));
+end;
+
+procedure ValidateDynamicFunctionSuperExpression(
+  const AExpr: TGocciaExpression);
+var
+  ArrowExpr: TGocciaArrowFunctionExpression;
+  BinaryExpr: TGocciaBinaryExpression;
+  CallExpr: TGocciaCallExpression;
+  ConditionalExpr: TGocciaConditionalExpression;
+  MemberExpr: TGocciaMemberExpression;
+  NewExpr: TGocciaNewExpression;
+  I: Integer;
+begin
+  if not Assigned(AExpr) then
+    Exit;
+
+  if AExpr is TGocciaSuperExpression then
+    ThrowSyntaxError('super is not allowed in this function context');
+
+  if AExpr is TGocciaFunctionExpression then
+    ValidateDynamicFunctionSuperFunction(TGocciaFunctionExpression(AExpr))
+  else if AExpr is TGocciaArrowFunctionExpression then
+  begin
+    ArrowExpr := TGocciaArrowFunctionExpression(AExpr);
+    for I := 0 to High(ArrowExpr.Parameters) do
+      ValidateDynamicFunctionSuperExpression(ArrowExpr.Parameters[I].DefaultValue);
+    if ArrowExpr.Body is TGocciaStatement then
+      ValidateDynamicFunctionSuperStatement(TGocciaStatement(ArrowExpr.Body))
+    else if ArrowExpr.Body is TGocciaExpression then
+      ValidateDynamicFunctionSuperExpression(TGocciaExpression(ArrowExpr.Body));
+  end
+  else if AExpr is TGocciaCallExpression then
+  begin
+    CallExpr := TGocciaCallExpression(AExpr);
+    if CallExpr.Callee is TGocciaSuperExpression then
+      ThrowSyntaxError('super() is not allowed in this function context');
+    ValidateDynamicFunctionSuperExpression(CallExpr.Callee);
+    for I := 0 to CallExpr.Arguments.Count - 1 do
+      ValidateDynamicFunctionSuperExpression(CallExpr.Arguments[I]);
+  end
+  else if AExpr is TGocciaMemberExpression then
+  begin
+    MemberExpr := TGocciaMemberExpression(AExpr);
+    if MemberExpr.ObjectExpr is TGocciaSuperExpression then
+      ThrowSyntaxError('super property access is not allowed in this function context');
+    ValidateDynamicFunctionSuperExpression(MemberExpr.ObjectExpr);
+    if MemberExpr.Computed then
+      ValidateDynamicFunctionSuperExpression(MemberExpr.PropertyExpression);
+  end
+  else if AExpr is TGocciaBinaryExpression then
+  begin
+    BinaryExpr := TGocciaBinaryExpression(AExpr);
+    ValidateDynamicFunctionSuperExpression(BinaryExpr.Left);
+    ValidateDynamicFunctionSuperExpression(BinaryExpr.Right);
+  end
+  else if AExpr is TGocciaSequenceExpression then
+    for I := 0 to TGocciaSequenceExpression(AExpr).Expressions.Count - 1 do
+      ValidateDynamicFunctionSuperExpression(
+        TGocciaSequenceExpression(AExpr).Expressions[I])
+  else if AExpr is TGocciaUnaryExpression then
+    ValidateDynamicFunctionSuperExpression(TGocciaUnaryExpression(AExpr).Operand)
+  else if AExpr is TGocciaAssignmentExpression then
+    ValidateDynamicFunctionSuperExpression(TGocciaAssignmentExpression(AExpr).Value)
+  else if AExpr is TGocciaCompoundAssignmentExpression then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaCompoundAssignmentExpression(AExpr).Value)
+  else if AExpr is TGocciaConditionalExpression then
+  begin
+    ConditionalExpr := TGocciaConditionalExpression(AExpr);
+    ValidateDynamicFunctionSuperExpression(ConditionalExpr.Condition);
+    ValidateDynamicFunctionSuperExpression(ConditionalExpr.Consequent);
+    ValidateDynamicFunctionSuperExpression(ConditionalExpr.Alternate);
+  end
+  else if AExpr is TGocciaNewExpression then
+  begin
+    NewExpr := TGocciaNewExpression(AExpr);
+    ValidateDynamicFunctionSuperExpression(NewExpr.Callee);
+    for I := 0 to NewExpr.Arguments.Count - 1 do
+      ValidateDynamicFunctionSuperExpression(NewExpr.Arguments[I]);
+  end;
+end;
+
+procedure ValidateDynamicFunctionSuperStatement(
+  const AStmt: TGocciaStatement);
+var
+  BlockStmt: TGocciaBlockStatement;
+  ExpressionStmt: TGocciaExpressionStatement;
+  IfStmt: TGocciaIfStatement;
+  ReturnStmt: TGocciaReturnStatement;
+  ThrowStmt: TGocciaThrowStatement;
+  VarDecl: TGocciaVariableDeclaration;
+  I: Integer;
+begin
+  if not Assigned(AStmt) then
+    Exit;
+  if AStmt is TGocciaExpressionStatement then
+  begin
+    ExpressionStmt := TGocciaExpressionStatement(AStmt);
+    ValidateDynamicFunctionSuperExpression(ExpressionStmt.Expression);
+  end
+  else if AStmt is TGocciaBlockStatement then
+  begin
+    BlockStmt := TGocciaBlockStatement(AStmt);
+    for I := 0 to BlockStmt.Nodes.Count - 1 do
+      if BlockStmt.Nodes[I] is TGocciaStatement then
+        ValidateDynamicFunctionSuperStatement(TGocciaStatement(BlockStmt.Nodes[I]))
+      else if BlockStmt.Nodes[I] is TGocciaExpression then
+        ValidateDynamicFunctionSuperExpression(TGocciaExpression(BlockStmt.Nodes[I]));
+  end
+  else if AStmt is TGocciaVariableDeclaration then
+  begin
+    VarDecl := TGocciaVariableDeclaration(AStmt);
+    for I := 0 to High(VarDecl.Variables) do
+      ValidateDynamicFunctionSuperExpression(VarDecl.Variables[I].Initializer);
+  end
+  else if AStmt is TGocciaDestructuringDeclaration then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaDestructuringDeclaration(AStmt).Initializer)
+  else if AStmt is TGocciaFunctionDeclaration then
+    ValidateDynamicFunctionSuperFunction(
+      TGocciaFunctionDeclaration(AStmt).FunctionExpression)
+  else if AStmt is TGocciaIfStatement then
+  begin
+    IfStmt := TGocciaIfStatement(AStmt);
+    ValidateDynamicFunctionSuperExpression(IfStmt.Condition);
+    ValidateDynamicFunctionSuperStatement(IfStmt.Consequent);
+    ValidateDynamicFunctionSuperStatement(IfStmt.Alternate);
+  end
+  else if AStmt is TGocciaReturnStatement then
+  begin
+    ReturnStmt := TGocciaReturnStatement(AStmt);
+    ValidateDynamicFunctionSuperExpression(ReturnStmt.Value);
+  end
+  else if AStmt is TGocciaThrowStatement then
+  begin
+    ThrowStmt := TGocciaThrowStatement(AStmt);
+    ValidateDynamicFunctionSuperExpression(ThrowStmt.Value);
+  end;
 end;
 
 function TGocciaEngine.CompileDynamicFunction(
@@ -2956,6 +3110,8 @@ begin
     if BodyParseResult.HasUseStrictDirective and
        Assigned(FunctionExpression) then
       ValidateStrictDynamicFunction(FunctionExpression);
+    if Assigned(FunctionExpression) then
+      ValidateDynamicFunctionSuperFunction(FunctionExpression);
 
     ResultValue := FExecutor.ExecuteDynamicFunction(ProgramNode);
     Result := TGocciaFunctionBase(ResultValue);

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -2891,27 +2891,161 @@ procedure ValidateDynamicFunctionSuperExpression(
   const AExpr: TGocciaExpression); forward;
 procedure ValidateDynamicFunctionSuperStatement(
   const AStmt: TGocciaStatement); forward;
+procedure ValidateDynamicFunctionSuperPattern(
+  const APattern: TGocciaDestructuringPattern); forward;
+procedure ValidateDynamicFunctionSuperMatchPattern(
+  const APattern: TGocciaMatchPattern); forward;
 
 procedure ValidateDynamicFunctionSuperFunction(
   const AFunction: TGocciaFunctionExpression);
+var
+  I: Integer;
 begin
   if not Assigned(AFunction) then
     Exit;
+  for I := 0 to High(AFunction.Parameters) do
+  begin
+    if AFunction.Parameters[I].IsPattern then
+      ValidateDynamicFunctionSuperPattern(AFunction.Parameters[I].Pattern);
+    ValidateDynamicFunctionSuperExpression(AFunction.Parameters[I].DefaultValue);
+  end;
   if AFunction.Body is TGocciaStatement then
     ValidateDynamicFunctionSuperStatement(TGocciaStatement(AFunction.Body))
   else if AFunction.Body is TGocciaExpression then
     ValidateDynamicFunctionSuperExpression(TGocciaExpression(AFunction.Body));
 end;
 
+procedure ValidateDynamicFunctionSuperPattern(
+  const APattern: TGocciaDestructuringPattern);
+var
+  ArrPat: TGocciaArrayDestructuringPattern;
+  AssignmentPattern: TGocciaAssignmentDestructuringPattern;
+  ObjPat: TGocciaObjectDestructuringPattern;
+  Prop: TGocciaDestructuringProperty;
+  RestPattern: TGocciaRestDestructuringPattern;
+  I: Integer;
+begin
+  if not Assigned(APattern) then
+    Exit;
+
+  if APattern is TGocciaArrayDestructuringPattern then
+  begin
+    ArrPat := TGocciaArrayDestructuringPattern(APattern);
+    for I := 0 to ArrPat.Elements.Count - 1 do
+      ValidateDynamicFunctionSuperPattern(ArrPat.Elements[I]);
+  end
+  else if APattern is TGocciaObjectDestructuringPattern then
+  begin
+    ObjPat := TGocciaObjectDestructuringPattern(APattern);
+    for I := 0 to ObjPat.Properties.Count - 1 do
+    begin
+      Prop := ObjPat.Properties[I];
+      if Prop.Computed then
+        ValidateDynamicFunctionSuperExpression(Prop.KeyExpression);
+      ValidateDynamicFunctionSuperPattern(Prop.Pattern);
+    end;
+  end
+  else if APattern is TGocciaAssignmentDestructuringPattern then
+  begin
+    AssignmentPattern := TGocciaAssignmentDestructuringPattern(APattern);
+    ValidateDynamicFunctionSuperPattern(AssignmentPattern.Left);
+    ValidateDynamicFunctionSuperExpression(AssignmentPattern.Right);
+  end
+  else if APattern is TGocciaRestDestructuringPattern then
+  begin
+    RestPattern := TGocciaRestDestructuringPattern(APattern);
+    ValidateDynamicFunctionSuperPattern(RestPattern.Argument);
+  end
+  else if APattern is TGocciaMemberExpressionDestructuringPattern then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaMemberExpressionDestructuringPattern(APattern).Expression)
+  else if APattern is TGocciaPrivateMemberExpressionDestructuringPattern then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPrivateMemberExpressionDestructuringPattern(APattern).Expression);
+end;
+
+procedure ValidateDynamicFunctionSuperMatchPattern(
+  const APattern: TGocciaMatchPattern);
+var
+  ArrayPattern: TGocciaArrayMatchPattern;
+  ObjectPattern: TGocciaObjectMatchPattern;
+  PatternList: TGocciaMatchPatternList;
+  ExtractorPattern: TGocciaExtractorMatchPattern;
+  I: Integer;
+begin
+  if not Assigned(APattern) then
+    Exit;
+
+  if APattern is TGocciaValueMatchPattern then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaValueMatchPattern(APattern).Expression)
+  else if APattern is TGocciaArrayMatchPattern then
+  begin
+    ArrayPattern := TGocciaArrayMatchPattern(APattern);
+    for I := 0 to ArrayPattern.Elements.Count - 1 do
+      ValidateDynamicFunctionSuperMatchPattern(ArrayPattern.Elements[I]);
+    ValidateDynamicFunctionSuperMatchPattern(ArrayPattern.RestPattern);
+  end
+  else if APattern is TGocciaObjectMatchPattern then
+  begin
+    ObjectPattern := TGocciaObjectMatchPattern(APattern);
+    for I := 0 to ObjectPattern.Properties.Count - 1 do
+    begin
+      if ObjectPattern.Properties[I].Computed then
+        ValidateDynamicFunctionSuperExpression(
+          ObjectPattern.Properties[I].KeyExpression);
+      ValidateDynamicFunctionSuperMatchPattern(
+        ObjectPattern.Properties[I].Pattern);
+    end;
+    ValidateDynamicFunctionSuperMatchPattern(ObjectPattern.RestPattern);
+  end
+  else if APattern is TGocciaRelationalMatchPattern then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaRelationalMatchPattern(APattern).Expression)
+  else if APattern is TGocciaGuardMatchPattern then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaGuardMatchPattern(APattern).Condition)
+  else if APattern is TGocciaAsMatchPattern then
+    ValidateDynamicFunctionSuperMatchPattern(
+      TGocciaAsMatchPattern(APattern).Pattern)
+  else if APattern is TGocciaAndMatchPattern then
+  begin
+    PatternList := TGocciaAndMatchPattern(APattern).Patterns;
+    for I := 0 to PatternList.Count - 1 do
+      ValidateDynamicFunctionSuperMatchPattern(PatternList[I]);
+  end
+  else if APattern is TGocciaOrMatchPattern then
+  begin
+    PatternList := TGocciaOrMatchPattern(APattern).Patterns;
+    for I := 0 to PatternList.Count - 1 do
+      ValidateDynamicFunctionSuperMatchPattern(PatternList[I]);
+  end
+  else if APattern is TGocciaNotMatchPattern then
+    ValidateDynamicFunctionSuperMatchPattern(
+      TGocciaNotMatchPattern(APattern).Pattern)
+  else if APattern is TGocciaExtractorMatchPattern then
+  begin
+    ExtractorPattern := TGocciaExtractorMatchPattern(APattern);
+    ValidateDynamicFunctionSuperExpression(ExtractorPattern.MatcherExpression);
+    for I := 0 to ExtractorPattern.Arguments.Count - 1 do
+      ValidateDynamicFunctionSuperMatchPattern(ExtractorPattern.Arguments[I]);
+    ValidateDynamicFunctionSuperMatchPattern(ExtractorPattern.RestPattern);
+  end;
+end;
+
 procedure ValidateDynamicFunctionSuperExpression(
   const AExpr: TGocciaExpression);
 var
+  ArrayExpr: TGocciaArrayExpression;
   ArrowExpr: TGocciaArrowFunctionExpression;
   BinaryExpr: TGocciaBinaryExpression;
   CallExpr: TGocciaCallExpression;
   ConditionalExpr: TGocciaConditionalExpression;
+  ImportExpr: TGocciaImportCallExpression;
   MemberExpr: TGocciaMemberExpression;
   NewExpr: TGocciaNewExpression;
+  ObjectExpr: TGocciaObjectExpression;
+  Pair: TPair<TGocciaExpression, TGocciaExpression>;
   I: Integer;
 begin
   if not Assigned(AExpr) then
@@ -2964,9 +3098,78 @@ begin
     ValidateDynamicFunctionSuperExpression(TGocciaUnaryExpression(AExpr).Operand)
   else if AExpr is TGocciaAssignmentExpression then
     ValidateDynamicFunctionSuperExpression(TGocciaAssignmentExpression(AExpr).Value)
+  else if AExpr is TGocciaPropertyAssignmentExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPropertyAssignmentExpression(AExpr).ObjectExpr);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPropertyAssignmentExpression(AExpr).Value);
+  end
+  else if AExpr is TGocciaComputedPropertyAssignmentExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaComputedPropertyAssignmentExpression(AExpr).ObjectExpr);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaComputedPropertyAssignmentExpression(AExpr).PropertyExpression);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaComputedPropertyAssignmentExpression(AExpr).Value);
+  end
   else if AExpr is TGocciaCompoundAssignmentExpression then
     ValidateDynamicFunctionSuperExpression(
       TGocciaCompoundAssignmentExpression(AExpr).Value)
+  else if AExpr is TGocciaPropertyCompoundAssignmentExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPropertyCompoundAssignmentExpression(AExpr).ObjectExpr);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPropertyCompoundAssignmentExpression(AExpr).Value);
+  end
+  else if AExpr is TGocciaComputedPropertyCompoundAssignmentExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).ObjectExpr);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).PropertyExpression);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaComputedPropertyCompoundAssignmentExpression(AExpr).Value);
+  end
+  else if AExpr is TGocciaIncrementExpression then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaIncrementExpression(AExpr).Operand)
+  else if AExpr is TGocciaArrayExpression then
+  begin
+    ArrayExpr := TGocciaArrayExpression(AExpr);
+    for I := 0 to ArrayExpr.Elements.Count - 1 do
+      ValidateDynamicFunctionSuperExpression(ArrayExpr.Elements[I]);
+  end
+  else if AExpr is TGocciaObjectExpression then
+  begin
+    ObjectExpr := TGocciaObjectExpression(AExpr);
+    for I := 0 to High(ObjectExpr.PropertySourceOrder) do
+      case ObjectExpr.PropertySourceOrder[I].PropertyType of
+        pstStatic:
+          ValidateDynamicFunctionSuperExpression(
+            ObjectExpr.PropertySourceOrder[I].Expression);
+        pstComputed:
+          begin
+            Pair := ObjectExpr.ComputedPropertiesInOrder[
+              ObjectExpr.PropertySourceOrder[I].ComputedIndex];
+            ValidateDynamicFunctionSuperExpression(Pair.Key);
+            ValidateDynamicFunctionSuperExpression(Pair.Value);
+          end;
+        pstComputedGetter,
+        pstComputedSetter:
+          begin
+            Pair := ObjectExpr.ComputedPropertiesInOrder[
+              ObjectExpr.PropertySourceOrder[I].ComputedIndex];
+            ValidateDynamicFunctionSuperExpression(Pair.Key);
+          end;
+      end;
+  end
+  else if AExpr is TGocciaYieldExpression then
+    ValidateDynamicFunctionSuperExpression(TGocciaYieldExpression(AExpr).Operand)
+  else if AExpr is TGocciaAwaitExpression then
+    ValidateDynamicFunctionSuperExpression(TGocciaAwaitExpression(AExpr).Operand)
   else if AExpr is TGocciaConditionalExpression then
   begin
     ConditionalExpr := TGocciaConditionalExpression(AExpr);
@@ -2980,6 +3183,71 @@ begin
     ValidateDynamicFunctionSuperExpression(NewExpr.Callee);
     for I := 0 to NewExpr.Arguments.Count - 1 do
       ValidateDynamicFunctionSuperExpression(NewExpr.Arguments[I]);
+  end
+  else if AExpr is TGocciaImportCallExpression then
+  begin
+    ImportExpr := TGocciaImportCallExpression(AExpr);
+    ValidateDynamicFunctionSuperExpression(ImportExpr.Specifier);
+    ValidateDynamicFunctionSuperExpression(ImportExpr.Options);
+  end
+  else if AExpr is TGocciaSpreadExpression then
+    ValidateDynamicFunctionSuperExpression(TGocciaSpreadExpression(AExpr).Argument)
+  else if AExpr is TGocciaTemplateWithInterpolationExpression then
+  begin
+    for I := 0 to TGocciaTemplateWithInterpolationExpression(AExpr).Parts.Count - 1 do
+      ValidateDynamicFunctionSuperExpression(
+        TGocciaTemplateWithInterpolationExpression(AExpr).Parts[I]);
+  end
+  else if AExpr is TGocciaTaggedTemplateExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaTaggedTemplateExpression(AExpr).Tag);
+    for I := 0 to TGocciaTaggedTemplateExpression(AExpr).Expressions.Count - 1 do
+      ValidateDynamicFunctionSuperExpression(
+        TGocciaTaggedTemplateExpression(AExpr).Expressions[I]);
+  end
+  else if AExpr is TGocciaDestructuringAssignmentExpression then
+  begin
+    ValidateDynamicFunctionSuperPattern(
+      TGocciaDestructuringAssignmentExpression(AExpr).Left);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaDestructuringAssignmentExpression(AExpr).Right);
+  end
+  else if AExpr is TGocciaPrivateMemberExpression then
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPrivateMemberExpression(AExpr).ObjectExpr)
+  else if AExpr is TGocciaPrivatePropertyAssignmentExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPrivatePropertyAssignmentExpression(AExpr).ObjectExpr);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPrivatePropertyAssignmentExpression(AExpr).Value);
+  end
+  else if AExpr is TGocciaPrivatePropertyCompoundAssignmentExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPrivatePropertyCompoundAssignmentExpression(AExpr).ObjectExpr);
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaPrivatePropertyCompoundAssignmentExpression(AExpr).Value);
+  end
+  else if AExpr is TGocciaIsExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(TGocciaIsExpression(AExpr).Subject);
+    ValidateDynamicFunctionSuperMatchPattern(TGocciaIsExpression(AExpr).Pattern);
+  end
+  else if AExpr is TGocciaMatchExpression then
+  begin
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaMatchExpression(AExpr).Subject);
+    for I := 0 to TGocciaMatchExpression(AExpr).Clauses.Count - 1 do
+    begin
+      ValidateDynamicFunctionSuperMatchPattern(
+        TGocciaMatchExpression(AExpr).Clauses[I].Pattern);
+      ValidateDynamicFunctionSuperExpression(
+        TGocciaMatchExpression(AExpr).Clauses[I].Expression);
+    end;
+    ValidateDynamicFunctionSuperExpression(
+      TGocciaMatchExpression(AExpr).DefaultExpression);
   end;
 end;
 
@@ -2987,12 +3255,22 @@ procedure ValidateDynamicFunctionSuperStatement(
   const AStmt: TGocciaStatement);
 var
   BlockStmt: TGocciaBlockStatement;
+  CaseClause: TGocciaCaseClause;
+  DoWhileStmt: TGocciaDoWhileStatement;
   ExpressionStmt: TGocciaExpressionStatement;
+  ForInStmt: TGocciaForInStatement;
+  ForOfStmt: TGocciaForOfStatement;
+  ForStmt: TGocciaForStatement;
   IfStmt: TGocciaIfStatement;
   ReturnStmt: TGocciaReturnStatement;
+  SwitchStmt: TGocciaSwitchStatement;
   ThrowStmt: TGocciaThrowStatement;
+  TryStmt: TGocciaTryStatement;
+  UsingDecl: TGocciaUsingDeclaration;
   VarDecl: TGocciaVariableDeclaration;
-  I: Integer;
+  WhileStmt: TGocciaWhileStatement;
+  WithStmt: TGocciaWithStatement;
+  I, J: Integer;
 begin
   if not Assigned(AStmt) then
     Exit;
@@ -3017,8 +3295,12 @@ begin
       ValidateDynamicFunctionSuperExpression(VarDecl.Variables[I].Initializer);
   end
   else if AStmt is TGocciaDestructuringDeclaration then
+  begin
+    ValidateDynamicFunctionSuperPattern(
+      TGocciaDestructuringDeclaration(AStmt).Pattern);
     ValidateDynamicFunctionSuperExpression(
-      TGocciaDestructuringDeclaration(AStmt).Initializer)
+      TGocciaDestructuringDeclaration(AStmt).Initializer);
+  end
   else if AStmt is TGocciaFunctionDeclaration then
     ValidateDynamicFunctionSuperFunction(
       TGocciaFunctionDeclaration(AStmt).FunctionExpression)
@@ -3038,6 +3320,77 @@ begin
   begin
     ThrowStmt := TGocciaThrowStatement(AStmt);
     ValidateDynamicFunctionSuperExpression(ThrowStmt.Value);
+  end
+  else if AStmt is TGocciaForStatement then
+  begin
+    ForStmt := TGocciaForStatement(AStmt);
+    ValidateDynamicFunctionSuperStatement(ForStmt.Init);
+    ValidateDynamicFunctionSuperExpression(ForStmt.Condition);
+    ValidateDynamicFunctionSuperExpression(ForStmt.Update);
+    ValidateDynamicFunctionSuperStatement(ForStmt.Body);
+  end
+  else if AStmt is TGocciaWhileStatement then
+  begin
+    WhileStmt := TGocciaWhileStatement(AStmt);
+    ValidateDynamicFunctionSuperExpression(WhileStmt.Condition);
+    ValidateDynamicFunctionSuperStatement(WhileStmt.Body);
+  end
+  else if AStmt is TGocciaDoWhileStatement then
+  begin
+    DoWhileStmt := TGocciaDoWhileStatement(AStmt);
+    ValidateDynamicFunctionSuperStatement(DoWhileStmt.Body);
+    ValidateDynamicFunctionSuperExpression(DoWhileStmt.Condition);
+  end
+  else if AStmt is TGocciaWithStatement then
+  begin
+    WithStmt := TGocciaWithStatement(AStmt);
+    ValidateDynamicFunctionSuperExpression(WithStmt.ObjectExpression);
+    ValidateDynamicFunctionSuperStatement(WithStmt.Body);
+  end
+  else if AStmt is TGocciaForOfStatement then
+  begin
+    ForOfStmt := TGocciaForOfStatement(AStmt);
+    ValidateDynamicFunctionSuperPattern(ForOfStmt.BindingPattern);
+    ValidateDynamicFunctionSuperPattern(ForOfStmt.AssignmentTarget);
+    ValidateDynamicFunctionSuperMatchPattern(ForOfStmt.MatchPattern);
+    ValidateDynamicFunctionSuperExpression(ForOfStmt.Iterable);
+    ValidateDynamicFunctionSuperStatement(ForOfStmt.Body);
+  end
+  else if AStmt is TGocciaForInStatement then
+  begin
+    ForInStmt := TGocciaForInStatement(AStmt);
+    ValidateDynamicFunctionSuperPattern(ForInStmt.BindingPattern);
+    ValidateDynamicFunctionSuperPattern(ForInStmt.AssignmentTarget);
+    ValidateDynamicFunctionSuperExpression(ForInStmt.ObjectExpression);
+    ValidateDynamicFunctionSuperStatement(ForInStmt.Body);
+  end
+  else if AStmt is TGocciaTryStatement then
+  begin
+    TryStmt := TGocciaTryStatement(AStmt);
+    ValidateDynamicFunctionSuperStatement(TryStmt.Block);
+    ValidateDynamicFunctionSuperMatchPattern(TryStmt.CatchPattern);
+    ValidateDynamicFunctionSuperPattern(TryStmt.CatchBindingPattern);
+    ValidateDynamicFunctionSuperStatement(TryStmt.CatchBlock);
+    ValidateDynamicFunctionSuperStatement(TryStmt.FinallyBlock);
+  end
+  else if AStmt is TGocciaSwitchStatement then
+  begin
+    SwitchStmt := TGocciaSwitchStatement(AStmt);
+    ValidateDynamicFunctionSuperExpression(SwitchStmt.Discriminant);
+    for I := 0 to SwitchStmt.Cases.Count - 1 do
+    begin
+      CaseClause := SwitchStmt.Cases[I];
+      ValidateDynamicFunctionSuperExpression(CaseClause.Test);
+      for J := 0 to CaseClause.Consequent.Count - 1 do
+        ValidateDynamicFunctionSuperStatement(CaseClause.Consequent[J]);
+    end;
+  end
+  else if AStmt is TGocciaUsingDeclaration then
+  begin
+    UsingDecl := TGocciaUsingDeclaration(AStmt);
+    for I := 0 to High(UsingDecl.Variables) do
+      ValidateDynamicFunctionSuperExpression(
+        UsingDecl.Variables[I].Initializer);
   end;
 end;
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -66,6 +66,9 @@ function EvaluateClassDefinition(const AClassDef: TGocciaClassDefinition; const 
 function EvaluateNewExpression(const ANewExpression: TGocciaNewExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluatePrivateMember(const APrivateMemberExpression: TGocciaPrivateMemberExpression; const AContext: TGocciaEvaluationContext): TGocciaValue; overload;
 function EvaluatePrivateMember(const APrivateMemberExpression: TGocciaPrivateMemberExpression; const AContext: TGocciaEvaluationContext; out AObjectValue: TGocciaValue): TGocciaValue; overload;
+procedure AssignPrivateMemberValue(const AObjectValue: TGocciaValue;
+  const APrivateName: string; const AValue: TGocciaValue;
+  const AContext: TGocciaEvaluationContext; const ALine, AColumn: Integer);
 function EvaluatePrivateInOperator(
   const APrivateMemberExpression: TGocciaPrivateMemberExpression;
   const ARightExpression: TGocciaExpression;
@@ -3731,6 +3734,9 @@ begin
     if (Current is TGocciaCallScope) and
        not (Current is TGocciaArrowCallScope) then
       Exit(Current);
+    if (Current.ScopeKind = skFunction) and
+       (Current.CustomLabel = 'BytecodeDirectEval') then
+      Exit(Current);
     if Current.ScopeKind in [skGlobal, skModule] then
       Exit(nil);
     Current := Current.Parent;
@@ -3743,9 +3749,13 @@ var
   CallerFunctionScope: TGocciaScope;
 begin
   CallerFunctionScope := FindDirectEvalCallerFunctionScope(AScope);
-  Result := (CallerFunctionScope is TGocciaMethodCallScope) and
-    (TGocciaMethodCallScope(CallerFunctionScope).CustomLabel = 'constructor') and
-    Assigned(TGocciaMethodCallScope(CallerFunctionScope).SuperClass);
+  if CallerFunctionScope is TGocciaMethodCallScope then
+    Exit((TGocciaMethodCallScope(CallerFunctionScope).CustomLabel = 'constructor') and
+      Assigned(TGocciaMethodCallScope(CallerFunctionScope).SuperClass));
+  Result := Assigned(CallerFunctionScope) and
+    (CallerFunctionScope.CustomLabel = 'BytecodeDirectEval') and
+    Assigned(CallerFunctionScope.FindSuperConstructor) and
+    Assigned(CallerFunctionScope.FindNewTarget);
 end;
 
 function DirectEvalRejectsArgumentsReference(
@@ -3885,7 +3895,7 @@ begin
         AllowNewTarget := Assigned(CallerFunctionScope);
         AllowSuperProperty := Assigned(CallerFunctionScope) and
           Assigned(CallerFunctionScope.FindSuperClass);
-        AllowSuperCall := DirectEvalAllowsSuperCall(CallerFunctionScope);
+        AllowSuperCall := DirectEvalAllowsSuperCall(AContext.Scope);
         AResult := EvaluateEvalProgram(PipelineResult.ProgramNode,
           EvalContext, VarScope, EvalScope, StrictEval,
           EvalContext.RejectArgumentsVarDeclarationInEval,
@@ -7508,12 +7518,27 @@ end;
 function EvaluateClass(const AClassDeclaration: TGocciaClassDeclaration; const AContext: TGocciaEvaluationContext): TGocciaValue;
 var
   ClassDef: TGocciaClassDefinition;
+  InnerContext: TGocciaEvaluationContext;
+  InnerScope: TGocciaScope;
 begin
   ClassDef := AClassDeclaration.ClassDefinition;
-  Result := EvaluateClassDefinition(ClassDef, AContext, AClassDeclaration.Line, AClassDeclaration.Column);
 
-  // For class declarations, bind the class name to the scope
-  AContext.Scope.DefineLexicalBinding(ClassDef.Name, Result, dtLet);
+  if ClassDef.Name <> '' then
+  begin
+    InnerScope := AContext.Scope.CreateChild(skBlock);
+    InnerScope.PredeclareLexicalBinding(ClassDef.Name, dtConst,
+      AClassDeclaration.Line, AClassDeclaration.Column);
+    InnerContext := AContext;
+    InnerContext.Scope := InnerScope;
+    Result := EvaluateClassDefinition(ClassDef, InnerContext,
+      AClassDeclaration.Line, AClassDeclaration.Column);
+  end
+  else
+    Result := EvaluateClassDefinition(ClassDef, AContext,
+      AClassDeclaration.Line, AClassDeclaration.Column);
+
+  // Publish the declaration binding after the class body has evaluated.
+  AContext.Scope.ForceUpdateBinding(ClassDef.Name, Result);
 end;
 
 // TC39 proposal-enum
@@ -8258,8 +8283,8 @@ begin
     // ES2026 §15.7.14: Named class expressions create an inner binding
     // visible only inside the class body
     InnerScope := AContext.Scope.CreateChild(skBlock);
-    InnerScope.DefineLexicalBinding(ClassDef.Name,
-      TGocciaUndefinedLiteralValue.UndefinedValue, dtConst);
+    InnerScope.PredeclareLexicalBinding(ClassDef.Name, dtConst,
+      AClassExpression.Line, AClassExpression.Column);
     InnerContext := AContext;
     InnerContext.Scope := InnerScope;
     Result := EvaluateClassDefinition(ClassDef, InnerContext,
@@ -8421,6 +8446,7 @@ var
   StaticFieldContext: TGocciaEvaluationContext;
   StaticFieldScope: TGocciaScope;
   HeritageContext: TGocciaEvaluationContext;
+  ClassStrictContext: TGocciaEvaluationContext;
 
   function BuildClassGetter(const AGetterExpression: TGocciaGetterExpression): TGocciaFunctionValue;
   begin
@@ -8552,50 +8578,52 @@ var
     SetLength(Entries, 0);
     Order := 0;
 
-    for MethodPair in AClassDef.Methods do
-      AddClassCallableEvalEntry(Entries, ccekMethod, MethodPair.Key, False,
-        False, MethodPair.Value.Line, MethodPair.Value.Column, Order, -1,
-        MethodPair.Value);
+    if Length(AClassDef.FElements) = 0 then
+    begin
+      for MethodPair in AClassDef.Methods do
+        AddClassCallableEvalEntry(Entries, ccekMethod, MethodPair.Key, False,
+          False, MethodPair.Value.Line, MethodPair.Value.Column, Order, -1,
+          MethodPair.Value);
 
-    for MethodPair in AClassDef.StaticMethods do
-      AddClassCallableEvalEntry(Entries, ccekMethod, MethodPair.Key, True,
-        False, MethodPair.Value.Line, MethodPair.Value.Column, Order, -1,
-        MethodPair.Value);
+      for MethodPair in AClassDef.StaticMethods do
+        AddClassCallableEvalEntry(Entries, ccekMethod, MethodPair.Key, True,
+          False, MethodPair.Value.Line, MethodPair.Value.Column, Order, -1,
+          MethodPair.Value);
 
-    for MethodPair in AClassDef.PrivateMethods do
-      AddClassCallableEvalEntry(Entries, ccekMethod, MethodPair.Key,
-        MethodPair.Value.IsStatic, True, MethodPair.Value.Line,
-        MethodPair.Value.Column, Order, -1, MethodPair.Value);
+      for MethodPair in AClassDef.PrivateMethods do
+        AddClassCallableEvalEntry(Entries, ccekMethod, MethodPair.Key,
+          MethodPair.Value.IsStatic, True, MethodPair.Value.Line,
+          MethodPair.Value.Column, Order, -1, MethodPair.Value);
 
-    for GetterPair in AClassDef.Getters do
-      AddClassCallableEvalEntry(Entries, ccekGetter, GetterPair.Key, False,
-        (GetterPair.Key <> '') and (GetterPair.Key[1] = '#'),
-        GetterPair.Value.Line, GetterPair.Value.Column, Order, -1, nil,
-        GetterPair.Value);
+      for GetterPair in AClassDef.Getters do
+        AddClassCallableEvalEntry(Entries, ccekGetter, GetterPair.Key, False,
+          (GetterPair.Key <> '') and (GetterPair.Key[1] = '#'),
+          GetterPair.Value.Line, GetterPair.Value.Column, Order, -1, nil,
+          GetterPair.Value);
 
-    for SetterPair in AClassDef.Setters do
-      AddClassCallableEvalEntry(Entries, ccekSetter, SetterPair.Key, False,
-        (SetterPair.Key <> '') and (SetterPair.Key[1] = '#'),
-        SetterPair.Value.Line, SetterPair.Value.Column, Order, -1, nil, nil,
-        SetterPair.Value);
+      for SetterPair in AClassDef.Setters do
+        AddClassCallableEvalEntry(Entries, ccekSetter, SetterPair.Key, False,
+          (SetterPair.Key <> '') and (SetterPair.Key[1] = '#'),
+          SetterPair.Value.Line, SetterPair.Value.Column, Order, -1, nil, nil,
+          SetterPair.Value);
 
-    for GetterPair in AClassDef.FStaticGetters do
-      AddClassCallableEvalEntry(Entries, ccekGetter, GetterPair.Key, True,
-        (GetterPair.Key <> '') and (GetterPair.Key[1] = '#'),
-        GetterPair.Value.Line, GetterPair.Value.Column, Order, -1, nil,
-        GetterPair.Value);
+      for GetterPair in AClassDef.FStaticGetters do
+        AddClassCallableEvalEntry(Entries, ccekGetter, GetterPair.Key, True,
+          (GetterPair.Key <> '') and (GetterPair.Key[1] = '#'),
+          GetterPair.Value.Line, GetterPair.Value.Column, Order, -1, nil,
+          GetterPair.Value);
 
-    for SetterPair in AClassDef.FStaticSetters do
-      AddClassCallableEvalEntry(Entries, ccekSetter, SetterPair.Key, True,
-        (SetterPair.Key <> '') and (SetterPair.Key[1] = '#'),
-        SetterPair.Value.Line, SetterPair.Value.Column, Order, -1, nil, nil,
-        SetterPair.Value);
+      for SetterPair in AClassDef.FStaticSetters do
+        AddClassCallableEvalEntry(Entries, ccekSetter, SetterPair.Key, True,
+          (SetterPair.Key <> '') and (SetterPair.Key[1] = '#'),
+          SetterPair.Value.Line, SetterPair.Value.Column, Order, -1, nil, nil,
+          SetterPair.Value);
+    end;
 
     for K := 0 to High(AClassDef.FElements) do
     begin
       Elem := AClassDef.FElements[K];
-      if Elem.IsComputed and
-         (Elem.Kind in [cekMethod, cekGetter, cekSetter, cekField, cekAccessor]) then
+      if Elem.Kind in [cekMethod, cekGetter, cekSetter, cekField, cekAccessor] then
         AddClassCallableEvalEntry(Entries, ccekElement, '', Elem.IsStatic,
           Elem.IsPrivate, ClassEvalElementSourceLine(Elem),
           ClassEvalElementSourceColumn(Elem), Order, K);
@@ -8658,7 +8686,52 @@ var
 
       Elem := AClassDef.FElements[Entry.ElementIndex];
       if not Elem.IsComputed then
+      begin
+        case Elem.Kind of
+          cekMethod:
+          begin
+            Method := TGocciaMethodValue(EvaluateClassMethod(
+              Elem.MethodNode, AContext, MethodSuperClass));
+            Method.OwningClass := ClassValue;
+            if Elem.IsPrivate then
+            begin
+              if Elem.IsStatic then
+                ClassValue.AddPrivateStaticMethod(Elem.Name, Method)
+              else
+                ClassValue.AddPrivateMethod(Elem.Name, Method);
+            end
+            else if Elem.IsStatic then
+              ClassValue.DefineProperty(Elem.Name,
+                TGocciaPropertyDescriptorData.Create(Method,
+                  [pfConfigurable, pfWritable]))
+            else
+              ClassValue.AddMethod(Elem.Name, Method);
+          end;
+          cekGetter:
+          begin
+            GetterFunction := BuildClassGetter(Elem.GetterNode);
+            GetterFunction.SetInferredName('get ' + Elem.Name);
+            if Elem.IsPrivate then
+              ClassValue.AddPrivateGetter(Elem.Name, GetterFunction)
+            else if Elem.IsStatic then
+              ClassValue.AddStaticGetter(Elem.Name, GetterFunction)
+            else
+              ClassValue.AddGetter(Elem.Name, GetterFunction);
+          end;
+          cekSetter:
+          begin
+            SetterFunction := BuildClassSetter(Elem.SetterNode);
+            SetterFunction.SetInferredName('set ' + Elem.Name);
+            if Elem.IsPrivate then
+              ClassValue.AddPrivateSetter(Elem.Name, SetterFunction)
+            else if Elem.IsStatic then
+              ClassValue.AddStaticSetter(Elem.Name, SetterFunction)
+            else
+              ClassValue.AddSetter(Elem.Name, SetterFunction);
+          end;
+        end;
         Continue;
+      end;
       if not (Elem.Kind in [cekMethod, cekGetter, cekSetter, cekField, cekAccessor]) then
         Continue;
 
@@ -8668,7 +8741,7 @@ var
           Elem.ComputedKeyExpression, ComputedKey);
       if not HasReplayedComputedKey then
         ComputedKey := ToPropertyKey(EvaluateExpression(
-          Elem.ComputedKeyExpression, AContext));
+          Elem.ComputedKeyExpression, ClassStrictContext));
       if Assigned(Continuation) then
         Continuation.SaveCompletedExpressionValue(
           Elem.ComputedKeyExpression, ComputedKey);
@@ -8704,7 +8777,9 @@ var
               TGocciaPropertyDescriptorData.Create(Method,
                 [pfConfigurable, pfWritable]))
           else
-            ClassValue.AddMethod(ComputedKey.ToStringLiteral.Value, Method);
+            ClassValue.Prototype.DefineProperty(ComputedKey.ToStringLiteral.Value,
+              TGocciaPropertyDescriptorData.Create(Method,
+                [pfConfigurable, pfWritable]));
         end;
         cekGetter:
         begin
@@ -8788,6 +8863,8 @@ var
   end;
 begin
   Continuation := CurrentGeneratorContinuation;
+  ClassStrictContext := AContext;
+  ClassStrictContext.NonStrictMode := False;
   SuperClass := nil;
   SuperClassValue := nil;
   MethodSuperClass := nil;
@@ -8802,6 +8879,8 @@ begin
       SuperClass := TGocciaClassValue(SuperClassValue);
       MethodSuperClass := SuperClass;
     end
+    else if SuperClassValue is TGocciaNullLiteralValue then
+      MethodSuperClass := TGocciaFunctionBase.GetSharedPrototype
     else if not ((SuperClassValue is TGocciaObjectValue) and
        SuperClassValue.IsConstructable) then
       ThrowTypeError(Format('Superclass expression is not a constructor (found %s)',
@@ -8834,7 +8913,13 @@ begin
     ClassName := '<anonymous>';
 
   ClassValue := TGocciaClassValue.Create(ClassName, SuperClass);
-  if (SuperClass = nil) and (SuperClassValue is TGocciaObjectValue) and
+  ClassValue.SetSourceText(AClassDef.SourceText);
+  if SuperClassValue is TGocciaNullLiteralValue then
+  begin
+    ClassValue.LinkNativeSuperConstructor(TGocciaFunctionBase.GetSharedPrototype);
+    ClassValue.Prototype.Prototype := nil;
+  end
+  else if (SuperClass = nil) and (SuperClassValue is TGocciaObjectValue) and
      SuperClassValue.IsConstructable then
   begin
     ClassValue.LinkNativeSuperConstructor(
@@ -8853,27 +8938,10 @@ begin
   ClassValue.Prototype.DefineProperty(PROP_CONSTRUCTOR,
     TGocciaPropertyDescriptorData.Create(ClassValue, [pfConfigurable, pfWritable]));
 
-  if Length(AClassDef.FElements) > 0 then
-    EvaluateClassCallableElements
-  else
-  begin
-  for MethodPair in AClassDef.Methods do
-  begin
-    Method := TGocciaMethodValue(EvaluateClassMethod(MethodPair.Value, AContext, MethodSuperClass));
-    Method.OwningClass := ClassValue;
+  EvaluateClassCallableElements;
 
-    ClassValue.AddMethod(MethodPair.Key, Method);
-  end;
-
-  for MethodPair in AClassDef.StaticMethods do
-  begin
-    Method := TGocciaMethodValue(EvaluateClassMethod(MethodPair.Value, AContext, MethodSuperClass));
-    Method.OwningClass := ClassValue;
-
-    ClassValue.DefineProperty(MethodPair.Key,
-      TGocciaPropertyDescriptorData.Create(Method, [pfConfigurable, pfWritable]));
-  end;
-  end;
+  if AClassDef.Name <> '' then
+    AContext.Scope.ForceUpdateBinding(AClassDef.Name, ClassValue);
 
   // Static fields without FElements entries (legacy / no static blocks)
   if Length(AClassDef.FElements) = 0 then
@@ -8990,12 +9058,21 @@ begin
           ComputedKey := ResolvedComputedElementKeys[I];
         if not Assigned(ComputedKey) then
           ComputedKey := ToPropertyKey(EvaluateExpression(
-            Elem.ComputedKeyExpression, AContext));
+            Elem.ComputedKeyExpression, ClassStrictContext));
         AccessorBackingName := '__accessor_computed_' + IntToStr(I);
       end;
 
+      if Elem.IsPrivate then
+      begin
+        if not Elem.IsStatic then
+          ClassValue.AddPrivateInstanceProperty(Elem.Name,
+            Elem.FieldInitializer);
+        Continue;
+      end;
+
       if Assigned(Elem.FieldInitializer) then
-        ClassValue.AddInstanceProperty(AccessorBackingName, Elem.FieldInitializer);
+        ClassValue.AddInstanceProperty(AccessorBackingName,
+          Elem.FieldInitializer);
 
       if Elem.IsComputed then
         ClassValue.AddAutoAccessorWithKey(
@@ -9011,7 +9088,9 @@ begin
     Elem := AClassDef.FElements[I];
     if Elem.Kind = cekStaticBlock then
       ExecuteStaticBlock(Elem.StaticBlockBody, AContext, ClassValue)
-    else if (Elem.Kind = cekField) and Elem.IsStatic then
+    else if ((Elem.Kind = cekField) or
+             ((Elem.Kind = cekAccessor) and Elem.IsPrivate)) and
+            Elem.IsStatic then
     begin
       if Assigned(Elem.FieldInitializer) then
       begin
@@ -9034,7 +9113,7 @@ begin
           ComputedKey := ResolvedComputedElementKeys[I];
         if not Assigned(ComputedKey) then
           ComputedKey := ToPropertyKey(EvaluateExpression(
-            Elem.ComputedKeyExpression, AContext));
+            Elem.ComputedKeyExpression, ClassStrictContext));
         if ComputedKey is TGocciaSymbolValue then
           ClassValue.DefineSymbolProperty(
             TGocciaSymbolValue(ComputedKey),
@@ -10555,6 +10634,7 @@ var
   Instance: TGocciaObjectValue;
   RootedInstance: TGocciaObjectValue;
   WalkClass: TGocciaClassValue;
+  ImplicitSuperClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
   ConstructedValue: TGocciaValue;
   ConstructorThisValue: TGocciaValue;
@@ -10727,27 +10807,39 @@ begin
         ThrowReferenceError(
           'Must call super constructor before returning from derived constructor');
     end
-    else if Assigned(AClassValue.SuperClass) and Assigned(AClassValue.SuperClass.ConstructorMethod) then
+    else
     begin
-      ConstructedValue := AClassValue.SuperClass.ConstructorMethod.CallWithThisValue(
-        AArguments, Instance, ConstructorThisValue, EffectiveNewTarget);
-      ValidateClassConstructorReturn(AClassValue.SuperClass, ConstructedValue);
-      if IsUndefinedConstructedValue(ConstructedValue) then
-        ApplyReplacementResult(ConstructorThisValue)
-      else
+      ImplicitSuperClass := AClassValue.SuperClass;
+      if AClassValue.GetConstructorPrototype is TGocciaClassValue then
+        ImplicitSuperClass := TGocciaClassValue(AClassValue.GetConstructorPrototype);
+
+      if Assigned(ImplicitSuperClass) and
+         Assigned(ImplicitSuperClass.ConstructorMethod) then
+      begin
+        ConstructedValue := ImplicitSuperClass.ConstructorMethod.CallWithThisValue(
+          AArguments, Instance, ConstructorThisValue, EffectiveNewTarget);
+        ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+        if IsUndefinedConstructedValue(ConstructedValue) then
+          ApplyReplacementResult(ConstructorThisValue)
+        else
+          ApplyReplacementResult(ConstructedValue);
+      end
+      else if Assigned(AClassValue.NativeSuperConstructor) and
+              (AClassValue.NativeSuperConstructor is TGocciaFunctionBase) and
+              not (AClassValue.NativeSuperConstructor is TGocciaNativeFunctionValue) then
+      begin
+        if AClassValue.NativeSuperConstructor =
+           TGocciaFunctionBase.GetSharedPrototype then
+          ThrowTypeError('Super constructor is not a constructor',
+            SSuggestNotConstructorType);
+        ConstructedValue := InvokeConstructableWithReceiver(
+          AClassValue.NativeSuperConstructor, AArguments, Instance, AContext,
+          EffectiveNewTarget);
         ApplyReplacementResult(ConstructedValue);
-    end
-    else if Assigned(AClassValue.NativeSuperConstructor) and
-            (AClassValue.NativeSuperConstructor is TGocciaFunctionBase) and
-            not (AClassValue.NativeSuperConstructor is TGocciaNativeFunctionValue) then
-    begin
-      ConstructedValue := InvokeConstructableWithReceiver(
-        AClassValue.NativeSuperConstructor, AArguments, Instance, AContext,
-        EffectiveNewTarget);
-      ApplyReplacementResult(ConstructedValue);
-    end
-    else if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then
-      TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+      end
+      else if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then
+        TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+    end;
 
     if Assigned(InitializerReplayReceiver) and
        (Instance = InitializerReplayReceiver) and

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -47,15 +47,29 @@ type
     Column: Integer;
   end;
 
+  TGocciaPrivateNameDeclarationKind = (
+    pndField,
+    pndMethod,
+    pndGetter,
+    pndSetter
+  );
+
   TGocciaPrivateClassContext = class
   private
     FDeclaredNames: TStringList;
     FReferences: array of TGocciaPrivateNameReference;
+    function DeclarationNameOf(const AEntry: string): string;
+    function DeclarationKindOf(const AEntry: string): TGocciaPrivateNameDeclarationKind;
+    function DeclarationStaticOf(const AEntry: string): Boolean;
+    function IsAccessorPair(const AExistingKind, ANewKind: TGocciaPrivateNameDeclarationKind;
+      const AExistingStatic, ANewStatic: Boolean): Boolean;
   public
     constructor Create;
     destructor Destroy; override;
 
-    procedure DeclareName(const AName: string);
+    function DeclareName(const AName: string;
+      const AKind: TGocciaPrivateNameDeclarationKind;
+      const AIsStatic: Boolean): Boolean;
     procedure AddReference(const AName: string; const ALine, AColumn: Integer);
     function HasDeclaration(const AName: string): Boolean;
     function ReferenceCount: Integer;
@@ -106,7 +120,9 @@ type
     procedure PushPrivateClassContext;
     procedure PopPrivateClassContext;
     procedure ValidateCurrentPrivateClassContext;
-    procedure DeclarePrivateName(const AName: string);
+    procedure DeclarePrivateName(const AName: string;
+      const AKind: TGocciaPrivateNameDeclarationKind = pndField;
+      const AIsStatic: Boolean = False);
     procedure RecordPrivateNameReference(const AName: string; const ALine, AColumn: Integer);
     function CurrentPrivateClassContext: TGocciaPrivateClassContext;
     function HasVisiblePrivateNameDeclaration(const AName: string): Boolean;
@@ -361,10 +377,70 @@ begin
   inherited;
 end;
 
-procedure TGocciaPrivateClassContext.DeclareName(const AName: string);
+function TGocciaPrivateClassContext.DeclarationNameOf(
+  const AEntry: string): string;
+var
+  FirstSep, SecondSep: Integer;
 begin
-  if FDeclaredNames.IndexOf(AName) < 0 then
-    FDeclaredNames.Add(AName);
+  FirstSep := Pos(':', AEntry);
+  SecondSep := Pos(':', Copy(AEntry, FirstSep + 1, MaxInt));
+  if SecondSep > 0 then
+    SecondSep := SecondSep + FirstSep;
+  if SecondSep > 0 then
+    Result := Copy(AEntry, SecondSep + 1, MaxInt)
+  else
+    Result := AEntry;
+end;
+
+function TGocciaPrivateClassContext.DeclarationKindOf(
+  const AEntry: string): TGocciaPrivateNameDeclarationKind;
+begin
+  if AEntry = '' then
+    Exit(pndField);
+  case AEntry[1] of
+    '1': Result := pndMethod;
+    '2': Result := pndGetter;
+    '3': Result := pndSetter;
+  else
+    Result := pndField;
+  end;
+end;
+
+function TGocciaPrivateClassContext.DeclarationStaticOf(
+  const AEntry: string): Boolean;
+begin
+  Result := (Length(AEntry) >= 3) and (AEntry[3] = '1');
+end;
+
+function TGocciaPrivateClassContext.IsAccessorPair(
+  const AExistingKind, ANewKind: TGocciaPrivateNameDeclarationKind;
+  const AExistingStatic, ANewStatic: Boolean): Boolean;
+begin
+  Result := (AExistingStatic = ANewStatic) and
+    (((AExistingKind = pndGetter) and (ANewKind = pndSetter)) or
+     ((AExistingKind = pndSetter) and (ANewKind = pndGetter)));
+end;
+
+function TGocciaPrivateClassContext.DeclareName(const AName: string;
+  const AKind: TGocciaPrivateNameDeclarationKind;
+  const AIsStatic: Boolean): Boolean;
+var
+  Entry: string;
+  I: Integer;
+begin
+  for I := 0 to FDeclaredNames.Count - 1 do
+    if DeclarationNameOf(FDeclaredNames[I]) = AName then
+    begin
+      if IsAccessorPair(DeclarationKindOf(FDeclaredNames[I]), AKind,
+        DeclarationStaticOf(FDeclaredNames[I]), AIsStatic) then
+        Continue;
+      Exit(False);
+    end;
+
+  Entry := Chr(Ord('0') + Ord(AKind)) + ':' +
+    Chr(Ord('0') + Ord(AIsStatic)) + ':' + AName;
+  FDeclaredNames.Add(Entry);
+  Result := True;
 end;
 
 procedure TGocciaPrivateClassContext.AddReference(const AName: string; const ALine, AColumn: Integer);
@@ -379,8 +455,13 @@ begin
 end;
 
 function TGocciaPrivateClassContext.HasDeclaration(const AName: string): Boolean;
+var
+  I: Integer;
 begin
-  Result := FDeclaredNames.IndexOf(AName) >= 0;
+  for I := 0 to FDeclaredNames.Count - 1 do
+    if DeclarationNameOf(FDeclaredNames[I]) = AName then
+      Exit(True);
+  Result := False;
 end;
 
 function TGocciaPrivateClassContext.ReferenceCount: Integer;
@@ -608,13 +689,17 @@ begin
   end;
 end;
 
-procedure TGocciaParser.DeclarePrivateName(const AName: string);
+procedure TGocciaParser.DeclarePrivateName(const AName: string;
+  const AKind: TGocciaPrivateNameDeclarationKind; const AIsStatic: Boolean);
 var
   Context: TGocciaPrivateClassContext;
 begin
   Context := CurrentPrivateClassContext;
-  if Assigned(Context) then
-    Context.DeclareName(AName);
+  if Assigned(Context) and not Context.DeclareName(AName, AKind, AIsStatic) then
+    raise TGocciaSyntaxError.Create(
+      Format('Duplicate private field ''#%s''', [AName]),
+      Previous.Line, Previous.Column, FFileName, FSourceLines,
+      SSuggestDeclarePrivateField);
 end;
 
 procedure TGocciaParser.RecordPrivateNameReference(const AName: string; const ALine, AColumn: Integer);
@@ -1492,6 +1577,8 @@ var
   Op: TGocciaToken;
   Pattern: TGocciaMatchPattern;
   TypeAnnotation: string;
+  PrivateToken: TGocciaToken;
+  PrivateName: string;
 
   procedure ParseIsExpressions;
   begin
@@ -1504,6 +1591,23 @@ var
     end;
   end;
 begin
+  if Check(gttHash) then
+  begin
+    PrivateToken := Advance;
+    PrivateName := Consume(gttIdentifier,
+      'Expected private field name after "#"',
+      SSuggestPrivateFieldMustFollow).Lexeme;
+    RecordPrivateNameReference(PrivateName, Previous.Line, Previous.Column);
+    Consume(gttIn, 'Expected "in" after private field name',
+      SSuggestExpressionExpected);
+    Result := TGocciaBinaryExpression.Create(
+      TGocciaPrivateMemberExpression.Create(
+        TGocciaThisExpression.Create(PrivateToken.Line, PrivateToken.Column),
+        PrivateName, PrivateToken.Line, PrivateToken.Column),
+      gttIn, Shift, PrivateToken.Line, PrivateToken.Column);
+    Exit;
+  end;
+
   Result := Shift;
   while PeekWithLexicalGoal(glgInputElementDiv).TokenType in [gttGreater, gttGreaterEqual, gttLess, gttLessEqual, gttInstanceof, gttIn] do
   begin
@@ -1582,6 +1686,8 @@ end;
 function TGocciaParser.Unary: TGocciaExpression;
 var
   Operator: TGocciaToken;
+  PrivateToken: TGocciaToken;
+  PrivateName: string;
   Right: TGocciaExpression;
 begin
   // ES2026 §16.1 top-level await / §15.8.2 AwaitExpression: await UnaryExpression
@@ -1592,7 +1698,18 @@ begin
     if FFunctionDepth = 0 then
       FHasTopLevelAwait := True;
     Operator := Advance; // consume 'await'
-    Right := Unary;
+    if Check(gttHash) then
+    begin
+      PrivateToken := Advance;
+      PrivateName := Consume(gttIdentifier, 'Expected private field name after "#"',
+        SSuggestPrivateFieldMustFollow).Lexeme;
+      RecordPrivateNameReference(PrivateName, Previous.Line, Previous.Column);
+      Right := TGocciaPrivateMemberExpression.Create(
+        TGocciaThisExpression.Create(PrivateToken.Line, PrivateToken.Column),
+        PrivateName, PrivateToken.Line, PrivateToken.Column);
+    end
+    else
+      Right := Unary;
     Result := TGocciaAwaitExpression.Create(Right, Operator.Line, Operator.Column);
     Exit;
   end;
@@ -1632,7 +1749,9 @@ begin
         Right := Unary;
 
         // Only allow on identifiers and member expressions
-        if not ((Right is TGocciaIdentifierExpression) or (Right is TGocciaMemberExpression)) then
+        if not ((Right is TGocciaIdentifierExpression) or
+                (Right is TGocciaMemberExpression) or
+                (Right is TGocciaPrivateMemberExpression)) then
           raise TGocciaSyntaxError.Create('Invalid target for increment/decrement',
             Operator.Line, Operator.Column, FFileName, FSourceLines,
             SSuggestValidIncrementTarget);
@@ -1794,7 +1913,9 @@ begin
           Column := Token.Column;
 
           // Only allow on identifiers and member expressions
-          if not ((Result is TGocciaIdentifierExpression) or (Result is TGocciaMemberExpression)) then
+          if not ((Result is TGocciaIdentifierExpression) or
+                  (Result is TGocciaMemberExpression) or
+                  (Result is TGocciaPrivateMemberExpression)) then
             raise TGocciaSyntaxError.Create('Invalid target for increment/decrement',
               Line, Column, FFileName, FSourceLines,
               SSuggestValidIncrementTarget);
@@ -2695,18 +2816,6 @@ begin
         Result := TGocciaIdentifierExpression.Create(Token.Lexeme,
           Token.Line, Token.Column);
       end;
-    gttHash:
-      begin
-        Advance;
-        Token := Consume(gttIdentifier, 'Expected private field name after "#"',
-          SSuggestPrivateFieldMustFollow);
-        Name := Token.Lexeme;
-        RecordPrivateNameReference(Name, Token.Line, Token.Column);
-        // Private field access is equivalent to this.#fieldName
-        Result := TGocciaPrivateMemberExpression.Create(
-          TGocciaThisExpression.Create(Token.Line, Token.Column),
-          Name, Token.Line, Token.Column);
-      end;
     gttLeftParen:
       begin
         Advance;
@@ -3550,6 +3659,10 @@ begin
     // Generator method syntax: *methodName() { ... } or async *methodName() { ... }
     if Check(gttStar) then
     begin
+      if IsGetter or IsSetter then
+        raise TGocciaSyntaxError.Create('Accessor methods cannot be generator methods',
+          Peek.Line, Peek.Column, FFileName, FSourceLines,
+          'Remove the "*" from the getter or setter declaration');
       Advance;
       IsGenerator := True;
     end;
@@ -3701,6 +3814,10 @@ begin
       // Check for shorthand property syntax: { name } means { name: name }
       if Check(gttColon) then
       begin
+        if IsGenerator then
+          raise TGocciaSyntaxError.Create('Generator method syntax requires a parameter list',
+            Peek.Line, Peek.Column, FFileName, FSourceLines,
+            'Use *name() { ... } for a generator method');
         // Regular property: key: value
         Consume(gttColon, 'Expected ":" after property key',
           SSuggestAddColonPropertyValue);
@@ -4284,12 +4401,95 @@ begin
     Name := ''; // Anonymous class
 
   ClassDef := ParseClassBody(Name);
+  ClassDef.SourceText := ExtractSourceRange(Line, Column);
   Result := TGocciaClassExpression.Create(ClassDef, Line, Column);
 end;
 
 function TGocciaParser.Statement: TGocciaStatement;
 var
   Line, Column: Integer;
+  function FindMatchingToken(const AStart: Integer; const AOpen,
+    AClose: TGocciaTokenType): Integer;
+  var
+    Depth: Integer;
+    I: Integer;
+  begin
+    Result := -1;
+    Depth := 0;
+    for I := AStart to FTokens.Count - 1 do
+    begin
+      if FTokens[I].TokenType = AOpen then
+        Inc(Depth)
+      else if FTokens[I].TokenType = AClose then
+      begin
+        Dec(Depth);
+        if Depth = 0 then
+          Exit(I);
+      end;
+    end;
+  end;
+
+  function IsPropertyNameStart(const AIndex: Integer): Boolean;
+  begin
+    if (AIndex < 0) or (AIndex >= FTokens.Count) then
+      Exit(False);
+    Result := FTokens[AIndex].TokenType in [
+      gttIdentifier, gttString, gttNumber, gttBigInt, gttLeftBracket,
+      gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends,
+      gttNew, gttThis, gttSuper, gttStatic, gttReturn, gttFor, gttWhile,
+      gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
+      gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport,
+      gttFrom, gttAs, gttTrue, gttFalse, gttNull, gttTypeof, gttVoid,
+      gttInstanceof, gttIn, gttDelete, gttVar, gttWith, gttFunction];
+  end;
+
+  function IsConciseMethodTail(const ANameIndex: Integer): Boolean;
+  var
+    NameEnd: Integer;
+    ParamOpen: Integer;
+    ParamClose: Integer;
+  begin
+    Result := False;
+    if not IsPropertyNameStart(ANameIndex) then
+      Exit;
+    if FTokens[ANameIndex].TokenType = gttLeftBracket then
+    begin
+      NameEnd := FindMatchingToken(ANameIndex, gttLeftBracket, gttRightBracket);
+      if NameEnd < 0 then
+        Exit;
+    end
+    else
+      NameEnd := ANameIndex;
+    ParamOpen := NameEnd + 1;
+    if (ParamOpen >= FTokens.Count) or
+       (FTokens[ParamOpen].TokenType <> gttLeftParen) then
+      Exit;
+    ParamClose := FindMatchingToken(ParamOpen, gttLeftParen, gttRightParen);
+    Result := (ParamClose >= 0) and (ParamClose + 1 < FTokens.Count) and
+      (FTokens[ParamClose + 1].TokenType = gttLeftBrace);
+  end;
+
+  function IsInvalidConciseMethodStatementStart: Boolean;
+  begin
+    Result := IsConciseMethodTail(FCurrent);
+    if Result then
+      Exit;
+
+    if Check(gttStar) then
+      Exit(IsConciseMethodTail(FCurrent + 1));
+
+    if CheckUnescapedIdentifierKeyword(KEYWORD_GET) or
+       CheckUnescapedIdentifierKeyword(KEYWORD_SET) then
+      Exit(IsPropertyNameStart(FCurrent + 1));
+
+    if CheckUnescapedIdentifierKeyword(KEYWORD_ASYNC) then
+    begin
+      if (FCurrent + 1 < FTokens.Count) and
+         (FTokens[FCurrent + 1].TokenType = gttStar) then
+        Exit(IsConciseMethodTail(FCurrent + 2));
+      Exit(IsConciseMethodTail(FCurrent + 1));
+    end;
+  end;
 begin
   if CheckUnescapedIdentifierKeyword(KEYWORD_TYPE) and IsTypeDeclaration then
   begin
@@ -4413,6 +4613,10 @@ begin
         'Wrap in an async function or use ''using'' for synchronous disposal');
     Result := UsingStatement;
   end
+  else if IsInvalidConciseMethodStatementStart then
+    raise TGocciaSyntaxError.Create('Method definitions are only valid inside object literals or class bodies',
+      Peek.Line, Peek.Column, FFileName, FSourceLines,
+      'Wrap the method in an object literal or declare a function instead')
   else if Check(gttIdentifier) and CheckNextWithLexicalGoal(gttColon, glgInputElementDiv) then
   begin
     if FLabelStatementsEnabled then
@@ -4687,6 +4891,16 @@ begin
   Expr := Expression;
   Line := Expr.Line;
   Column := Expr.Column;
+
+  if (Expr is TGocciaCallExpression) and Check(gttLeftBrace) and
+     (Previous.Line = Peek.Line) then
+    raise TGocciaSyntaxError.Create('Method definitions are only valid inside object literals or class bodies',
+      Peek.Line, Peek.Column, FFileName, FSourceLines,
+      'Wrap the method in an object literal or declare a function instead');
+  if Check(gttNumber) and (Previous.Line = Peek.Line) then
+    raise TGocciaSyntaxError.Create('Unexpected numeric literal after expression',
+      Peek.Line, Peek.Column, FFileName, FSourceLines,
+      'Insert an operator or separate the statements with a semicolon');
 
   // Only require semicolon if we're not in a class method
   if not Check(gttSemicolon) then
@@ -6107,6 +6321,7 @@ begin
   Name := ConsumeIdentifierBinding('Expected class name',
     SSuggestProvideClassName).Lexeme;
   ClassDef := ParseClassBody(Name);
+  ClassDef.SourceText := ExtractSourceRange(Line, Column);
   Result := TGocciaClassDeclaration.Create(ClassDef, Line, Column);
 end;
 
@@ -6210,6 +6425,7 @@ begin
   Name := ConsumeIdentifierBinding('Expected class name',
     SSuggestProvideClassName).Lexeme;
   ClassDef := ParseClassBody(Name);
+  ClassDef.SourceText := ExtractSourceRange(Line, Column);
   ClassDef.FDecorators := ADecorators;
   Result := TGocciaClassDeclaration.Create(ClassDef, Line, Column);
 end;
@@ -6922,6 +7138,7 @@ var
   IsGenerator: Boolean;
   PresetMemberName: Boolean;
   MemberStartLine, MemberStartColumn: Integer;
+  MemberSourceLine, MemberSourceColumn: Integer;
   TypePair: TStringStringMap.TKeyValuePair;
   SavedStrictModeActive: Boolean;
   SavedStrictModeSourceActive: Boolean;
@@ -7000,6 +7217,8 @@ begin
       IsAccessor := False;
       MemberStartLine := Peek.Line;
       MemberStartColumn := Peek.Column;
+      MemberSourceLine := MemberStartLine;
+      MemberSourceColumn := MemberStartColumn;
 
       IsStatic := Match(gttStatic);
       PresetMemberName := False;
@@ -7039,10 +7258,20 @@ begin
       while Check(gttIdentifier) and not Peek.ContainsEscape and
         ((Peek.Lexeme = KEYWORD_PUBLIC) or (Peek.Lexeme = KEYWORD_PROTECTED) or (Peek.Lexeme = KEYWORD_PRIVATE) or
          (Peek.Lexeme = KEYWORD_READONLY) or (Peek.Lexeme = KEYWORD_OVERRIDE) or (Peek.Lexeme = KEYWORD_ABSTRACT)) do
+      begin
+        if CheckNext(gttLeftParen) then
+          Break;
         Advance;
+      end;
 
       if not IsStatic and Check(gttStatic) then
         IsStatic := Match(gttStatic);
+
+      if not PresetMemberName then
+      begin
+        MemberSourceLine := Peek.Line;
+        MemberSourceColumn := Peek.Column;
+      end;
 
       if CheckUnescapedIdentifierKeyword(KEYWORD_ACCESSOR) then
         EnsureToken(FCurrent + 1, glgInputElementRegExp);
@@ -7149,6 +7378,11 @@ begin
       end
       else if Check(gttLeftBracket) then
       begin
+        if IsPrivate then
+          raise TGocciaSyntaxError.Create(
+            'Computed private fields are not allowed',
+            Peek.Line, Peek.Column, FFileName, FSourceLines,
+            SSuggestPrivateFieldMustFollow);
         Advance;
         ComputedKeyExpression := Assignment;
         Consume(gttRightBracket, 'Expected "]" after computed property name',
@@ -7162,9 +7396,6 @@ begin
           'Expected method or property name', SSuggestClassMemberSyntax);
       end;
 
-      if IsPrivate and not IsComputed and (MemberName <> '') then
-        DeclarePrivateName(MemberName);
-
       FieldType := '';
       if Check(gttQuestion) then
         Advance;
@@ -7176,6 +7407,9 @@ begin
 
       if IsAccessor then
       begin
+        if IsPrivate and not IsComputed and (MemberName <> '') then
+          DeclarePrivateName(MemberName, pndField, IsStatic);
+
         if Check(gttAssign) then
         begin
           Advance;
@@ -7199,6 +7433,9 @@ begin
       end
       else if (not IsGetter) and (not IsSetter) and Check(gttAssign) then
       begin
+        if IsPrivate and not IsComputed and (MemberName <> '') then
+          DeclarePrivateName(MemberName, pndField, IsStatic);
+
         Consume(gttAssign, 'Expected "=" in property',
           SSuggestAddPropertyInitializer);
         PropertyValue := Assignment;
@@ -7263,6 +7500,9 @@ begin
       end
       else if (not IsGetter) and (not IsSetter) and CheckSemicolonOrASI then
       begin
+        if IsPrivate and not IsComputed and (MemberName <> '') then
+          DeclarePrivateName(MemberName, pndField, IsStatic);
+
         if Check(gttSemicolon) then
           Advance;
         PropertyValue := TGocciaLiteralExpression.Create(TGocciaUndefinedLiteralValue.UndefinedValue, Peek.Line, Peek.Column);
@@ -7325,21 +7565,21 @@ begin
       end
       else if IsGetter then
       begin
-        Getter := ParseGetterExpression;
-        Getter.SourceText := ExtractSourceRange(MemberStartLine, MemberStartColumn);
+        if IsPrivate and not IsComputed and (MemberName <> '') then
+          DeclarePrivateName(MemberName, pndGetter, IsStatic);
 
-        if (Length(MemberDecorators) > 0) or IsComputed then
-        begin
-          SetLength(Elements, Length(Elements) + 1);
-          Elements[High(Elements)].Kind := cekGetter;
-          Elements[High(Elements)].Name := MemberName;
-          Elements[High(Elements)].IsStatic := IsStatic;
-          Elements[High(Elements)].IsPrivate := IsPrivate;
-          Elements[High(Elements)].IsComputed := IsComputed;
-          Elements[High(Elements)].ComputedKeyExpression := ComputedKeyExpression;
-          Elements[High(Elements)].Decorators := MemberDecorators;
-          Elements[High(Elements)].GetterNode := Getter;
-        end;
+        Getter := ParseGetterExpression;
+        Getter.SourceText := ExtractSourceRange(MemberSourceLine, MemberSourceColumn);
+
+        SetLength(Elements, Length(Elements) + 1);
+        Elements[High(Elements)].Kind := cekGetter;
+        Elements[High(Elements)].Name := MemberName;
+        Elements[High(Elements)].IsStatic := IsStatic;
+        Elements[High(Elements)].IsPrivate := IsPrivate;
+        Elements[High(Elements)].IsComputed := IsComputed;
+        Elements[High(Elements)].ComputedKeyExpression := ComputedKeyExpression;
+        Elements[High(Elements)].Decorators := MemberDecorators;
+        Elements[High(Elements)].GetterNode := Getter;
 
         if IsStatic then
         begin
@@ -7367,21 +7607,21 @@ begin
       end
       else if IsSetter then
       begin
-        Setter := ParseSetterExpression;
-        Setter.SourceText := ExtractSourceRange(MemberStartLine, MemberStartColumn);
+        if IsPrivate and not IsComputed and (MemberName <> '') then
+          DeclarePrivateName(MemberName, pndSetter, IsStatic);
 
-        if (Length(MemberDecorators) > 0) or IsComputed then
-        begin
-          SetLength(Elements, Length(Elements) + 1);
-          Elements[High(Elements)].Kind := cekSetter;
-          Elements[High(Elements)].Name := MemberName;
-          Elements[High(Elements)].IsStatic := IsStatic;
-          Elements[High(Elements)].IsPrivate := IsPrivate;
-          Elements[High(Elements)].IsComputed := IsComputed;
-          Elements[High(Elements)].ComputedKeyExpression := ComputedKeyExpression;
-          Elements[High(Elements)].Decorators := MemberDecorators;
-          Elements[High(Elements)].SetterNode := Setter;
-        end;
+        Setter := ParseSetterExpression;
+        Setter.SourceText := ExtractSourceRange(MemberSourceLine, MemberSourceColumn);
+
+        SetLength(Elements, Length(Elements) + 1);
+        Elements[High(Elements)].Kind := cekSetter;
+        Elements[High(Elements)].Name := MemberName;
+        Elements[High(Elements)].IsStatic := IsStatic;
+        Elements[High(Elements)].IsPrivate := IsPrivate;
+        Elements[High(Elements)].IsComputed := IsComputed;
+        Elements[High(Elements)].ComputedKeyExpression := ComputedKeyExpression;
+        Elements[High(Elements)].Decorators := MemberDecorators;
+        Elements[High(Elements)].SetterNode := Setter;
 
         if IsStatic then
         begin
@@ -7409,26 +7649,26 @@ begin
       end
       else if Check(gttLeftParen) or Check(gttLess) then
       begin
+        if IsPrivate and not IsComputed and (MemberName <> '') then
+          DeclarePrivateName(MemberName, pndMethod, IsStatic);
+
         Method := ClassMethod(IsStatic, IsAsync, IsGenerator);
         Method.Name := MemberName;
         Method.IsAsync := IsAsync;
         Method.IsGenerator := IsGenerator;
-        Method.SourceText := ExtractSourceRange(MemberStartLine, MemberStartColumn);
+        Method.SourceText := ExtractSourceRange(MemberSourceLine, MemberSourceColumn);
 
-        if (Length(MemberDecorators) > 0) or IsComputed then
-        begin
-          SetLength(Elements, Length(Elements) + 1);
-          Elements[High(Elements)].Kind := cekMethod;
-          Elements[High(Elements)].Name := MemberName;
-          Elements[High(Elements)].IsStatic := IsStatic;
-          Elements[High(Elements)].IsPrivate := IsPrivate;
-          Elements[High(Elements)].IsComputed := IsComputed;
-          Elements[High(Elements)].ComputedKeyExpression := ComputedKeyExpression;
-          Elements[High(Elements)].Decorators := MemberDecorators;
-          Elements[High(Elements)].MethodNode := Method;
-          Elements[High(Elements)].IsAsync := IsAsync;
-          Elements[High(Elements)].IsGenerator := IsGenerator;
-        end;
+        SetLength(Elements, Length(Elements) + 1);
+        Elements[High(Elements)].Kind := cekMethod;
+        Elements[High(Elements)].Name := MemberName;
+        Elements[High(Elements)].IsStatic := IsStatic;
+        Elements[High(Elements)].IsPrivate := IsPrivate;
+        Elements[High(Elements)].IsComputed := IsComputed;
+        Elements[High(Elements)].ComputedKeyExpression := ComputedKeyExpression;
+        Elements[High(Elements)].Decorators := MemberDecorators;
+        Elements[High(Elements)].MethodNode := Method;
+        Elements[High(Elements)].IsAsync := IsAsync;
+        Elements[High(Elements)].IsGenerator := IsGenerator;
 
         if IsComputed then
         begin

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -251,6 +251,7 @@ type
   protected
     function GetOwningClass: TGocciaValue; override;
     function GetSuperClass: TGocciaValue; override;
+    function GetSuperConstructor: TGocciaValue; override;
     function GetNewTarget: TGocciaValue; override;
     function MarkSuperConstructorCalled: Boolean; override;
   public
@@ -1551,6 +1552,17 @@ end;
 
 function TGocciaMethodCallScope.GetSuperClass: TGocciaValue;
 begin
+  Result := FSuperClass;
+end;
+
+function TGocciaMethodCallScope.GetSuperConstructor: TGocciaValue;
+begin
+  if FOwningClass is TGocciaClassValue then
+  begin
+    Result := TGocciaClassValue(FOwningClass).GetConstructorPrototype;
+    if Assigned(Result) then
+      Exit;
+  end;
   Result := FSuperClass;
 end;
 

--- a/source/units/Goccia.VM.Closure.pas
+++ b/source/units/Goccia.VM.Closure.pas
@@ -21,6 +21,7 @@ type
     FFunctionValue: TGocciaValue;
     FGlobalScope: TGocciaScope;
     FNewTarget: TGocciaValue;
+    FAllowsNewTarget: Boolean;
   public
     constructor Create(const ATemplate: TGocciaFunctionTemplate;
       const AUpvalueCount: Integer = 0);
@@ -36,6 +37,7 @@ type
     property FunctionValue: TGocciaValue read FFunctionValue write FFunctionValue;
     property GlobalScope: TGocciaScope read FGlobalScope write FGlobalScope;
     property NewTarget: TGocciaValue read FNewTarget write FNewTarget;
+    property AllowsNewTarget: Boolean read FAllowsNewTarget write FAllowsNewTarget;
   end;
 
 implementation
@@ -50,6 +52,7 @@ begin
   FFunctionValue := nil;
   FGlobalScope := nil;
   FNewTarget := nil;
+  FAllowsNewTarget := False;
   SetLength(FUpvalues, AUpvalueCount);
 end;
 
@@ -69,6 +72,7 @@ begin
   Result.FFunctionValue := FFunctionValue;
   Result.FGlobalScope := FGlobalScope;
   Result.FNewTarget := FNewTarget;
+  Result.FAllowsNewTarget := FAllowsNewTarget;
   for I := 0 to High(FUpvalues) do
     Result.FUpvalues[I] := FUpvalues[I];
 end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -320,9 +320,10 @@ type
     procedure StampBytecodePrivateBrands(const AClassValue: TGocciaClassValue;
       const AInstance: TGocciaValue;
       const APreserveExistingPrivateSlots: Boolean);
-    procedure SetupAutoAccessorValue(const AName: string; const AIsStatic: Boolean);
+    procedure SetupAutoAccessorValue(const AName: string; const AFlags: Integer;
+      const AClassValue: TGocciaValue = nil);
     procedure SetupAutoAccessorValueByKey(const AKey: TGocciaValue;
-      const ABackingName: string; const AIsStatic: Boolean);
+      const ABackingName: string; const AFlags: Integer);
     procedure RunClassInitializers(const AClassValue: TGocciaClassValue;
       const AInstance: TGocciaValue;
       const APreserveExistingPrivateSlots: Boolean = False);
@@ -531,6 +532,7 @@ const
   FOR_IN_ENTRY_OWNER = '__gocciaForInOwner';
   FOR_IN_ENTRY_KEY = '__gocciaForInKey';
   FOR_IN_MAX_PROTOTYPE_CHAIN_DEPTH = 256;
+  DERIVED_THIS_INITIALIZED_LOCAL = '__derived_this_initialized';
 
 type
   TGocciaVMSuperConstructorValue = class(TGocciaFunctionBase)
@@ -952,7 +954,6 @@ end;
 function DirectEvalLexicalClosure(const AVM: TGocciaVM): TGocciaBytecodeClosure;
 var
   Candidate: TGocciaBytecodeClosure;
-  I: Integer;
 begin
   Result := nil;
   if not Assigned(AVM) then
@@ -964,16 +965,10 @@ begin
 
   if not (Assigned(Candidate.Template) and Candidate.Template.IsArrow) then
     Exit(Candidate);
-  if Assigned(Candidate.HomeObject) or Assigned(Candidate.HomeClass) then
+  if Assigned(Candidate.HomeObject) or Assigned(Candidate.HomeClass) or
+     Candidate.AllowsNewTarget then
     Exit(Candidate);
-
-  for I := AVM.FFrameStackCount - 1 downto 0 do
-  begin
-    Candidate := AVM.FFrameStack[I].Closure;
-    if Assigned(Candidate) and Assigned(Candidate.Template) and
-       not Candidate.Template.IsArrow then
-      Exit(Candidate);
-  end;
+  Exit(nil);
 end;
 
 function CollectBytecodeDirectEvalPrivateNames(
@@ -1167,12 +1162,16 @@ begin
 end;
 
 function TGocciaVMDirectEvalScope.MarkSuperConstructorCalled: Boolean;
+var
+  Binding: TGocciaDirectEvalBindingInfo;
 begin
   Result := Assigned(FVM);
   if not Result then
     Exit;
 
   FVM.FCurrentConstructorSuperCalled := True;
+  if TryFindBinding(DERIVED_THIS_INITIALIZED_LOCAL, Binding) then
+    SetBindingValue(Binding, TGocciaBooleanLiteralValue.TrueValue);
   if FVM.FLocalCellCount > 0 then
     FVM.SetLocal(0, ThisValue);
   FVM.FLastClosureThisValue := ValueToRegister(ThisValue);
@@ -1193,6 +1192,7 @@ function TGocciaVMDirectEvalScope.TryGetBinding(const AName: string;
   const AColumn: Integer = 0): Boolean;
 var
   Binding: TGocciaDirectEvalBindingInfo;
+  BindingRuntimeValue: TGocciaValue;
   WithObject: TGocciaObjectValue;
 begin
   if TryFindWithObjectBinding(AName, WithObject) then
@@ -1219,7 +1219,12 @@ begin
   begin
     if (not Binding.IsConst) and ContainsOwnVarBinding(AName) then
       Exit(inherited TryGetBinding(AName, ABinding, ALine, AColumn));
-    ABinding.Value := BindingValue(Binding);
+    BindingRuntimeValue := BindingValue(Binding);
+    if BindingRuntimeValue = TGocciaHoleValue.HoleValue then
+      raise TGocciaReferenceError.Create(
+        Format(SErrorCannotAccessBeforeInit, [AName]),
+        ALine, AColumn, '', nil, SSuggestTemporalDeadZone);
+    ABinding.Value := BindingRuntimeValue;
     if Binding.IsConst then
       ABinding.DeclarationType := dtConst
     else
@@ -5884,12 +5889,34 @@ var
   procedure InitializeCurrentCtorReceiver(const AReceiver: TGocciaValue);
   var
     CurrentVM: TGocciaVM;
+    I: Integer;
+    Desc: TGocciaUpvalueDescriptor;
+    Upvalue: TGocciaBytecodeUpvalue;
   begin
     if (AReceiver is TGocciaObjectValue) and
        (FCurrentCtorClass is TGocciaVMClassValue) then
     begin
       CurrentVM := TGocciaVMClassValue(FCurrentCtorClass).FVM;
       CurrentVM.SetLocal(0, AReceiver);
+      if Assigned(CurrentVM.FCurrentClosure) and
+         Assigned(CurrentVM.FCurrentClosure.Template) then
+      begin
+        if CurrentVM.FCurrentClosure.Template.DerivedThisInitializedSlot >= 0 then
+          CurrentVM.SetLocal(
+            CurrentVM.FCurrentClosure.Template.DerivedThisInitializedSlot,
+            TGocciaBooleanLiteralValue.TrueValue);
+        for I := 0 to CurrentVM.FCurrentClosure.Template.UpvalueCount - 1 do
+        begin
+          Desc := CurrentVM.FCurrentClosure.Template.GetUpvalueDescriptor(I);
+          if Desc.Name = DERIVED_THIS_INITIALIZED_LOCAL then
+          begin
+            Upvalue := CurrentVM.FCurrentClosure.GetUpvalue(I);
+            if Assigned(Upvalue) and Assigned(Upvalue.Cell) then
+              Upvalue.Cell.Value := ValueToRegister(
+                TGocciaBooleanLiteralValue.TrueValue);
+          end;
+        end;
+      end;
       CurrentVM.FLastClosureThisValue := VMValueToRegisterFast(AReceiver);
       if HasBytecodePrivateInitializersApplied(AReceiver,
         TGocciaClassValue(FCurrentCtorClass)) then
@@ -6189,6 +6216,7 @@ var
   Instance: TGocciaObjectValue;
   RootedInstance: TGocciaObjectValue;
   WalkClass: TGocciaClassValue;
+  ImplicitSuperClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
   ConstructorToCall: TGocciaMethodValue;
   InstancePrototype: TGocciaObjectValue;
@@ -6392,64 +6420,80 @@ begin
              not NativeInstanceConstructedByNativeSuper then
             TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
         end
-        else if (SuperClass is TGocciaVMClassValue) and
-                Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
-        begin
-          FVM.RunClassInitializers(SuperClass, Instance);
-          if Assigned(ANewTarget) then
-            TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := ANewTarget
-          else
-            TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := Self;
-          ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
-            TGocciaVMClassValue(SuperClass).FConstructorValue,
-            AArguments, Instance);
-          if TGocciaVMClassValue(SuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
-            ConstructorThisValue := RegisterToValue(
-              TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue)
-          else
-            ConstructorThisValue := Instance;
-          ValidateClassConstructorReturn(SuperClass, ConstructedValue);
-          if IsUndefinedConstructedValue(ConstructedValue) then
-            ApplyReplacementResult(ConstructorThisValue)
-          else
-            ApplyReplacementResult(ConstructedValue);
-        end
         else
         begin
-          if Assigned(SuperClass) then
-            ConstructorToCall := SuperClass.ConstructorMethod;
+          ImplicitSuperClass := SuperClass;
+          if GetConstructorPrototype is TGocciaClassValue then
+            ImplicitSuperClass := TGocciaClassValue(GetConstructorPrototype);
 
-          if Assigned(ConstructorToCall) then
+          if (ImplicitSuperClass is TGocciaVMClassValue) and
+                  Assigned(TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue) then
           begin
-            FVM.RunClassInitializers(SuperClass, Instance);
+            FVM.RunClassInitializers(ImplicitSuperClass, Instance);
             if Assigned(ANewTarget) then
-              ConstructedValue := ConstructorToCall.CallWithThisValue(
-                AArguments, Instance, ConstructorThisValue, ANewTarget)
+              TGocciaVMClassValue(ImplicitSuperClass).FVM.FPendingNewTarget := ANewTarget
             else
-              ConstructedValue := ConstructorToCall.CallWithThisValue(
-                AArguments, Instance, ConstructorThisValue, Self);
-            ValidateClassConstructorReturn(SuperClass, ConstructedValue);
+              TGocciaVMClassValue(ImplicitSuperClass).FVM.FPendingNewTarget := Self;
+            ConstructedValue := TGocciaVMClassValue(ImplicitSuperClass).FVM.InvokeFunctionValue(
+              TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue,
+              AArguments, Instance);
+            if TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
+              ConstructorThisValue := RegisterToValue(
+                TGocciaVMClassValue(ImplicitSuperClass).FVM.FLastClosureThisValue)
+            else
+              ConstructorThisValue := Instance;
+            ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
             if IsUndefinedConstructedValue(ConstructedValue) then
               ApplyReplacementResult(ConstructorThisValue)
             else
               ApplyReplacementResult(ConstructedValue);
           end
-          else if Assigned(SuperClass) then
+          else
           begin
-            ConstructedValue := FVM.InvokeImplicitSuperInitialization(
-              SuperClass, Instance, AArguments);
-            ApplyReplacementResult(ConstructedValue);
-          end
-          else if Assigned(NativeSuperConstructor) and
-                  (NativeSuperConstructor is TGocciaFunctionBase) and
-                  not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
-          begin
-            ConstructedValue := InvokeConstructableWithReceiver(
-              NativeSuperConstructor, AArguments, Instance);
-            ApplyReplacementResult(ConstructedValue);
-          end
-          else if Instance is TGocciaInstanceValue then
-            TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
+            if Assigned(ImplicitSuperClass) then
+              ConstructorToCall := ImplicitSuperClass.ConstructorMethod;
+
+            if Assigned(ConstructorToCall) then
+            begin
+              FVM.RunClassInitializers(ImplicitSuperClass, Instance);
+              if Assigned(ANewTarget) then
+                ConstructedValue := ConstructorToCall.CallWithThisValue(
+                  AArguments, Instance, ConstructorThisValue, ANewTarget)
+              else
+                ConstructedValue := ConstructorToCall.CallWithThisValue(
+                  AArguments, Instance, ConstructorThisValue, Self);
+              ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+              if IsUndefinedConstructedValue(ConstructedValue) then
+                ApplyReplacementResult(ConstructorThisValue)
+              else
+                ApplyReplacementResult(ConstructedValue);
+            end
+            else if Assigned(ImplicitSuperClass) then
+            begin
+              ConstructedValue := FVM.InvokeImplicitSuperInitialization(
+                ImplicitSuperClass, Instance, AArguments);
+              ApplyReplacementResult(ConstructedValue);
+            end
+            else if Assigned(NativeSuperConstructor) and
+                    (NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype) then
+              ThrowTypeError('Super constructor is not a constructor',
+                SSuggestNotConstructorType)
+            else if Assigned(NativeSuperConstructor) and
+                    (NativeSuperConstructor is TGocciaFunctionBase) and
+                    not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
+            begin
+              ConstructedValue := InvokeConstructableWithReceiver(
+                NativeSuperConstructor, AArguments, Instance);
+              ApplyReplacementResult(ConstructedValue);
+            end
+            else if (not Assigned(SuperClass)) and
+                    (not Assigned(NativeSuperConstructor)) and
+                    (Prototype.Prototype = nil) then
+              ThrowTypeError('Super constructor is not a constructor',
+                SSuggestNotConstructorType)
+            else if Instance is TGocciaInstanceValue then
+              TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
+          end;
         end;
       finally
         FVM.FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
@@ -6490,6 +6534,7 @@ var
   Instance: TGocciaObjectValue;
   RootedInstance: TGocciaObjectValue;
   WalkClass: TGocciaClassValue;
+  ImplicitSuperClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
   ConstructorToCall: TGocciaMethodValue;
   BoxedArgs: TGocciaArgumentsCollection;
@@ -6773,93 +6818,109 @@ begin
                not NativeInstanceConstructedByNativeSuper then
               TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
           end
-          else if (SuperClass is TGocciaVMClassValue) and
-                  Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
+          else
           begin
-            TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
-              SuperClass, Instance);
-            TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := Self;
-            if TGocciaVMClassValue(SuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
+            ImplicitSuperClass := SuperClass;
+            if GetConstructorPrototype is TGocciaClassValue then
+              ImplicitSuperClass := TGocciaClassValue(GetConstructorPrototype);
+
+            if (ImplicitSuperClass is TGocciaVMClassValue) and
+                    Assigned(TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue) then
             begin
-              BytecodeSuperConstructor := TGocciaBytecodeFunctionValue(
-                TGocciaVMClassValue(SuperClass).FConstructorValue);
-              if Assigned(BytecodeSuperConstructor.FClosure) and
-                 Assigned(BytecodeSuperConstructor.FClosure.Template) and
-                 (not BytecodeSuperConstructor.FClosure.Template.IsAsync) then
+              TGocciaVMClassValue(ImplicitSuperClass).FVM.RunClassInitializers(
+                ImplicitSuperClass, Instance);
+              TGocciaVMClassValue(ImplicitSuperClass).FVM.FPendingNewTarget := Self;
+              if TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
               begin
-                ReturnRegister := TGocciaVMClassValue(SuperClass).FVM.ExecuteClosureRegisters(
-                  BytecodeSuperConstructor.FClosure,
-                  RegisterObject(Instance), AArguments);
-                ConstructorThisRegister :=
-                  TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue;
-                ValidateClassConstructorRegister(SuperClass, ReturnRegister);
-                if IsUndefinedConstructedRegister(ReturnRegister) then
-                  ApplyReplacementRegister(ConstructorThisRegister)
+                BytecodeSuperConstructor := TGocciaBytecodeFunctionValue(
+                  TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue);
+                if Assigned(BytecodeSuperConstructor.FClosure) and
+                   Assigned(BytecodeSuperConstructor.FClosure.Template) and
+                   (not BytecodeSuperConstructor.FClosure.Template.IsAsync) then
+                begin
+                  ReturnRegister := TGocciaVMClassValue(ImplicitSuperClass).FVM.ExecuteClosureRegisters(
+                    BytecodeSuperConstructor.FClosure,
+                    RegisterObject(Instance), AArguments);
+                  ConstructorThisRegister :=
+                    TGocciaVMClassValue(ImplicitSuperClass).FVM.FLastClosureThisValue;
+                  ValidateClassConstructorRegister(ImplicitSuperClass, ReturnRegister);
+                  if IsUndefinedConstructedRegister(ReturnRegister) then
+                    ApplyReplacementRegister(ConstructorThisRegister)
+                  else
+                    ApplyReplacementRegister(ReturnRegister);
+                end
                 else
-                  ApplyReplacementRegister(ReturnRegister);
+                begin
+                  EnsureBoxedArgs;
+                  ConstructedValue := TGocciaVMClassValue(ImplicitSuperClass).FVM.InvokeFunctionValue(
+                    TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue,
+                    BoxedArgs, Instance);
+                  ConstructorThisRegister :=
+                    TGocciaVMClassValue(ImplicitSuperClass).FVM.FLastClosureThisValue;
+                  ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+                  if IsUndefinedConstructedValue(ConstructedValue) then
+                    ApplyReplacementRegister(ConstructorThisRegister)
+                  else
+                    ApplyReplacementResult(ConstructedValue);
+                end;
               end
               else
               begin
                 EnsureBoxedArgs;
-                ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
-                  TGocciaVMClassValue(SuperClass).FConstructorValue,
+                ConstructedValue := TGocciaVMClassValue(ImplicitSuperClass).FVM.InvokeFunctionValue(
+                  TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue,
                   BoxedArgs, Instance);
-                ConstructorThisRegister :=
-                  TGocciaVMClassValue(SuperClass).FVM.FLastClosureThisValue;
-                ValidateClassConstructorReturn(SuperClass, ConstructedValue);
-                if IsUndefinedConstructedValue(ConstructedValue) then
-                  ApplyReplacementRegister(ConstructorThisRegister)
-                else
-                  ApplyReplacementResult(ConstructedValue);
+                ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+                ApplyReplacementResult(ConstructedValue);
               end;
             end
             else
             begin
-              EnsureBoxedArgs;
-              ConstructedValue := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
-                TGocciaVMClassValue(SuperClass).FConstructorValue,
-                BoxedArgs, Instance);
-              ValidateClassConstructorReturn(SuperClass, ConstructedValue);
-              ApplyReplacementResult(ConstructedValue);
-            end;
-          end
-          else
-          begin
-            if Assigned(SuperClass) then
-              ConstructorToCall := SuperClass.ConstructorMethod;
+              if Assigned(ImplicitSuperClass) then
+                ConstructorToCall := ImplicitSuperClass.ConstructorMethod;
 
-            if Assigned(ConstructorToCall) then
-            begin
-              EnsureBoxedArgs;
-              FVM.RunClassInitializers(SuperClass, Instance);
-              ConstructedValue := ConstructorToCall.CallWithThisValue(
-                BoxedArgs, Instance, ConstructorThisValue, Self);
-              ValidateClassConstructorReturn(SuperClass, ConstructedValue);
-              if IsUndefinedConstructedValue(ConstructedValue) then
-                ApplyReplacementResult(ConstructorThisValue)
-              else
+              if Assigned(ConstructorToCall) then
+              begin
+                EnsureBoxedArgs;
+                FVM.RunClassInitializers(ImplicitSuperClass, Instance);
+                ConstructedValue := ConstructorToCall.CallWithThisValue(
+                  BoxedArgs, Instance, ConstructorThisValue, Self);
+                ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+                if IsUndefinedConstructedValue(ConstructedValue) then
+                  ApplyReplacementResult(ConstructorThisValue)
+                else
+                  ApplyReplacementResult(ConstructedValue);
+              end
+              else if Assigned(ImplicitSuperClass) then
+              begin
+                ConstructedValue := FVM.InvokeImplicitSuperInitializationRegisters(
+                  ImplicitSuperClass, Instance, AArguments);
                 ApplyReplacementResult(ConstructedValue);
-            end
-            else if Assigned(SuperClass) then
-            begin
-              ConstructedValue := FVM.InvokeImplicitSuperInitializationRegisters(
-                SuperClass, Instance, AArguments);
-              ApplyReplacementResult(ConstructedValue);
-            end
-            else if Assigned(NativeSuperConstructor) and
-                    (NativeSuperConstructor is TGocciaFunctionBase) and
-                    not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
-            begin
-              EnsureBoxedArgs;
-              ConstructedValue := InvokeConstructableWithReceiver(
-                NativeSuperConstructor, BoxedArgs, Instance);
-              ApplyReplacementResult(ConstructedValue);
-            end
-            else
-            begin
-              EnsureBoxedArgs;
-              if Instance is TGocciaInstanceValue then
-                TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
+              end
+              else if Assigned(NativeSuperConstructor) and
+                      (NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype) then
+                ThrowTypeError('Super constructor is not a constructor',
+                  SSuggestNotConstructorType)
+              else if Assigned(NativeSuperConstructor) and
+                      (NativeSuperConstructor is TGocciaFunctionBase) and
+                      not (NativeSuperConstructor is TGocciaNativeFunctionValue) then
+              begin
+                EnsureBoxedArgs;
+                ConstructedValue := InvokeConstructableWithReceiver(
+                  NativeSuperConstructor, BoxedArgs, Instance);
+                ApplyReplacementResult(ConstructedValue);
+              end
+              else
+              begin
+                if (not Assigned(SuperClass)) and
+                   (not Assigned(NativeSuperConstructor)) and
+                   (Prototype.Prototype = nil) then
+                  ThrowTypeError('Super constructor is not a constructor',
+                    SSuggestNotConstructorType);
+                EnsureBoxedArgs;
+                if Instance is TGocciaInstanceValue then
+                  TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
+              end;
             end;
           end;
         finally
@@ -7456,10 +7517,6 @@ begin
        IsBytecodePrivateKey(ConstantValue.StringValue) then
       DeclareBytecodePrivateNameForClass(AClassValue, ConstantValue.StringValue);
   end;
-
-  for I := 0 to ATemplate.FunctionCount - 1 do
-    DeclareBytecodePrivateNamesFromTemplate(
-      AClassValue, ATemplate.GetFunctionUnchecked(I));
 end;
 
 function TGocciaVM.GetLocal(const AIndex: Integer): TGocciaValue;
@@ -10217,24 +10274,41 @@ begin
 end;
 
 procedure TGocciaVM.SetupAutoAccessorValue(const AName: string;
-  const AIsStatic: Boolean);
+  const AFlags: Integer; const AClassValue: TGocciaValue);
 var
   ClassVal: TGocciaClassValue;
+  IsStatic: Boolean;
+  IsPrivate: Boolean;
+  SourceName: string;
 begin
-  if not Assigned(FActiveDecoratorSession) then
+  if Assigned(FActiveDecoratorSession) then
+  begin
+    if not (TGocciaVMDecoratorSession(FActiveDecoratorSession).ClassValue is TGocciaClassValue) then
+      Exit;
+    ClassVal := TGocciaClassValue(
+      TGocciaVMDecoratorSession(FActiveDecoratorSession).ClassValue);
+  end
+  else if AClassValue is TGocciaClassValue then
+    ClassVal := TGocciaClassValue(AClassValue)
+  else
     Exit;
-  if not (TGocciaVMDecoratorSession(FActiveDecoratorSession).ClassValue is TGocciaClassValue) then
+  IsStatic := (AFlags and 1) <> 0;
+  IsPrivate := (AFlags and 2) <> 0;
+  if IsPrivate then
+  begin
+    SourceName := BytecodePrivateSourceName(AName);
+    if SourceName <> '' then
+      ClassVal.DeclarePrivateName(SourceName, AName);
     Exit;
-
-  ClassVal := TGocciaClassValue(
-    TGocciaVMDecoratorSession(FActiveDecoratorSession).ClassValue);
-  ClassVal.AddAutoAccessor(AName, '__accessor_' + AName, AIsStatic);
+  end;
+  ClassVal.AddAutoAccessor(AName, '__accessor_' + AName, IsStatic);
 end;
 
 procedure TGocciaVM.SetupAutoAccessorValueByKey(const AKey: TGocciaValue;
-  const ABackingName: string; const AIsStatic: Boolean);
+  const ABackingName: string; const AFlags: Integer);
 var
   ClassVal: TGocciaClassValue;
+  IsStatic: Boolean;
 begin
   if not Assigned(FActiveDecoratorSession) then
     Exit;
@@ -10243,7 +10317,8 @@ begin
 
   ClassVal := TGocciaClassValue(
     TGocciaVMDecoratorSession(FActiveDecoratorSession).ClassValue);
-  ClassVal.AddAutoAccessorWithKey('', AKey, ABackingName, AIsStatic);
+  IsStatic := (AFlags and 1) <> 0;
+  ClassVal.AddAutoAccessorWithKey('', AKey, ABackingName, IsStatic);
 end;
 
 procedure TGocciaVM.BeginDecorators(const AClassValue, ASuperValue: TGocciaValue);
@@ -12187,6 +12262,7 @@ var
   DeclaredPrivateNames: TStringList;
   CurrentFunctionValue: TGocciaValue;
   CurrentCtorClass: TGocciaClassValue;
+  LexicalNewTarget: TGocciaValue;
   RejectArgumentsVarDeclaration: Boolean;
   RejectVarDeclarationNames: TGocciaEvalRejectNameArray;
   RejectArgumentsReference: Boolean;
@@ -12228,6 +12304,11 @@ begin
       StrictEval := ACallerStrict or HasUseStrictDirective(PipelineResult.ProgramNode);
       UseGlobalVarEnvironment := TemplateUsesGlobalEvalEnvironment(ATemplate);
       CallerClosure := DirectEvalLexicalClosure(Self);
+      if Assigned(CallerClosure) and Assigned(CallerClosure.Template) and
+         CallerClosure.Template.IsArrow then
+        LexicalNewTarget := CallerClosure.NewTarget
+      else
+        LexicalNewTarget := FCurrentNewTarget;
       if UseGlobalVarEnvironment then
         CallerParentScope := FGlobalScope
       else
@@ -12235,7 +12316,7 @@ begin
 
       CallerScope := TGocciaVMDirectEvalScope.Create(CallerParentScope, Self,
         ATemplate, EnvIndex, UseGlobalVarEnvironment, CallerClosure,
-        FCurrentNewTarget);
+        LexicalNewTarget);
       CallerScope.ThisValue := DirectEvalLexicalThisValue(Self,
         UseGlobalVarEnvironment, ATemplate, EnvIndex);
 
@@ -12282,7 +12363,8 @@ begin
             CurrentCtorClass := TGocciaClassValue(CallerClosure.HomeClass)
           else
             CurrentCtorClass := nil;
-          AllowNewTarget := Assigned(CurrentFunctionValue);
+          AllowNewTarget := Assigned(CallerClosure) and
+            CallerClosure.AllowsNewTarget;
           AllowSuperProperty := Assigned(CallerClosure) and
             Assigned(CallerClosure.HomeObject);
           AllowSuperCall := Assigned(FCurrentNewTarget) and
@@ -13356,6 +13438,14 @@ begin
             FRegisters[A].ObjectValue, [pfConfigurable, pfWritable]));
       end;
 
+      OP_SET_CLASS_SOURCE_CONST:
+      begin
+        if (FRegisters[A].Kind = grkObject) and
+           (FRegisters[A].ObjectValue is TGocciaClassValue) then
+          TGocciaClassValue(FRegisters[A].ObjectValue).SetSourceText(
+            Template.GetConstantUnchecked(DecodeBx(Instruction)).StringValue);
+      end;
+
       OP_CLASS_SET_SUPER:
       begin
         if (FRegisters[A].Kind = grkObject) and
@@ -13428,9 +13518,6 @@ begin
           begin
             TGocciaVMClassValue(FRegisters[A].ObjectValue).SetVMConstructor(
               RegisterToValue(FRegisters[C]));
-            TGocciaVMClassValue(FRegisters[A].ObjectValue).Prototype.DefineProperty(
-              PROP_CONSTRUCTOR, TGocciaPropertyDescriptorData.Create(
-                FRegisters[A].ObjectValue, [pfConfigurable, pfWritable]));
           end
           else
             // ES §14.3.7: class prototype methods are non-enumerable
@@ -14637,7 +14724,16 @@ begin
           ChildClosure.HomeObject := FCurrentClosure.HomeObject;
           ChildClosure.HomeClass := FCurrentClosure.HomeClass;
           ChildClosure.NewTarget := FCurrentNewTarget;
-        end;
+          if Assigned(FCurrentClosure.Template) and
+             FCurrentClosure.Template.IsArrow then
+            ChildClosure.AllowsNewTarget := FCurrentClosure.AllowsNewTarget
+          else
+            ChildClosure.AllowsNewTarget :=
+              Assigned(FCurrentClosure.FunctionValue) and
+              not TemplateUsesGlobalEvalEnvironment(FCurrentClosure.Template);
+        end
+        else
+          ChildClosure.AllowsNewTarget := True;
         for I := 0 to ChildTemplate.UpvalueCount - 1 do
         begin
           Desc := ChildTemplate.GetUpvalueDescriptor(I);
@@ -15321,11 +15417,11 @@ begin
 
       OP_SETUP_AUTO_ACCESSOR_CONST:
         SetupAutoAccessorValue(Template.GetConstantUnchecked(C).StringValue,
-          B <> 0);
+          B, RegisterToValue(FRegisters[A]));
 
       OP_SETUP_AUTO_ACCESSOR_DYNAMIC:
         SetupAutoAccessorValueByKey(RegisterToValue(FRegisters[A]),
-          Template.GetConstantUnchecked(C).StringValue, B <> 0);
+          Template.GetConstantUnchecked(C).StringValue, B);
 
       OP_BEGIN_DECORATORS:
         BeginDecorators(RegisterToValue(FRegisters[A]), RegisterToValue(FRegisters[A + 1]));

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -539,6 +539,30 @@ begin
   Result := True;
 end;
 
+function TryGetNameValueExact(const AList: TStringList; const AName: string;
+  out AValue: string): Boolean;
+var
+  I, Sep: Integer;
+  Entry: string;
+begin
+  AValue := '';
+  if not Assigned(AList) then
+    Exit(False);
+
+  for I := 0 to AList.Count - 1 do
+  begin
+    Entry := AList[I];
+    Sep := Pos(AList.NameValueSeparator, Entry);
+    if (Sep > 0) and (Copy(Entry, 1, Sep - 1) = AName) then
+    begin
+      AValue := Copy(Entry, Sep + 1, MaxInt);
+      Exit(True);
+    end;
+  end;
+
+  Result := False;
+end;
+
 constructor TGocciaClassValue.Create(const AName: string; const ASuperClass: TGocciaClassValue);
 begin
   inherited Create;
@@ -1238,17 +1262,17 @@ begin
     FDeclaredPrivateNames.Add(AName);
   if AInternalKey <> '' then
   begin
-    ExistingInternalKey := FDeclaredPrivateKeys.Values[AName];
-    if ExistingInternalKey = '' then
-      FDeclaredPrivateKeys.Values[AName] := AInternalKey;
+    if not TryGetNameValueExact(FDeclaredPrivateKeys, AName,
+      ExistingInternalKey) then
+      FDeclaredPrivateKeys.Add(AName + FDeclaredPrivateKeys.NameValueSeparator +
+        AInternalKey);
   end;
 end;
 
 function TGocciaClassValue.ResolveDeclaredPrivateKey(const AName: string;
   out AInternalKey: string): Boolean;
 begin
-  AInternalKey := FDeclaredPrivateKeys.Values[AName];
-  Result := AInternalKey <> '';
+  Result := TryGetNameValueExact(FDeclaredPrivateKeys, AName, AInternalKey);
 end;
 
 procedure TGocciaClassValue.AppendOwnPrivateNames(const ANames: TStrings);
@@ -1267,8 +1291,8 @@ begin
   for I := 0 to FDeclaredPrivateNames.Count - 1 do
   begin
     DeclaredName := FDeclaredPrivateNames[I];
-    DeclaredKey := FDeclaredPrivateKeys.Values[DeclaredName];
-    if DeclaredKey = '' then
+    if not TryGetNameValueExact(FDeclaredPrivateKeys, DeclaredName,
+      DeclaredKey) then
       DeclaredKey := DeclaredName;
     if ANames.IndexOf(DeclaredKey) < 0 then
       ANames.Add(DeclaredKey);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -69,6 +69,7 @@ type
     FStaticDecoratorFieldInitializers: array of TGocciaDecoratorFieldInitializerEntry;
     FNameDeleted: Boolean;
     FLengthDeleted: Boolean;
+    FSourceText: string;
     function GetPropertyGetter(const AName: string): TGocciaFunctionBase; inline;
     function GetPropertySetter(const AName: string): TGocciaFunctionBase; inline;
     function GetStaticPropertyGetter(const AName: string): TGocciaFunctionBase; inline;
@@ -139,11 +140,15 @@ type
 
     procedure ReplacePrototype(const APrototype: TGocciaObjectValue);
     procedure SetConstructorPrototype(const APrototype: TGocciaObjectValue);
+    function GetConstructorPrototype: TGocciaObjectValue;
     procedure LinkNativeSuperConstructor(const ASuperConstructor: TGocciaObjectValue);
     procedure SetInferredName(const AName: string);
+    procedure SetSourceText(const ASourceText: string);
+    function GetSourceText: string;
     function GetOwnStaticSymbolDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor;
 
     property Name: string read FName;
+    property SourceText: string read FSourceText write FSourceText;
     property CreationRealm: TGocciaRealm read FCreationRealm;
     property PrivateBrandToken: string read FPrivateBrandToken;
     property SuperClass: TGocciaClassValue read FSuperClass write FSuperClass;
@@ -677,6 +682,7 @@ end;
 
 procedure TGocciaClassValue.AddMethod(const AName: string; const AMethod: TGocciaMethodValue);
 begin
+  AMethod.OwningClass := Self;
   // If this is the constructor, store it separately
   if AName = PROP_CONSTRUCTOR then
   begin
@@ -1196,13 +1202,19 @@ end;
 
 procedure TGocciaClassValue.DeclarePrivateName(const AName: string;
   const AInternalKey: string);
+var
+  ExistingInternalKey: string;
 begin
   if AName = '' then
     Exit;
   if FDeclaredPrivateNames.IndexOf(AName) < 0 then
     FDeclaredPrivateNames.Add(AName);
   if AInternalKey <> '' then
-    FDeclaredPrivateKeys.Values[AName] := AInternalKey;
+  begin
+    ExistingInternalKey := FDeclaredPrivateKeys.Values[AName];
+    if ExistingInternalKey = '' then
+      FDeclaredPrivateKeys.Values[AName] := AInternalKey;
+  end;
 end;
 
 function TGocciaClassValue.ResolveDeclaredPrivateKey(const AName: string;
@@ -1303,6 +1315,11 @@ begin
   FPrototype := APrototype;
 end;
 
+function TGocciaClassValue.GetConstructorPrototype: TGocciaObjectValue;
+begin
+  Result := FPrototype;
+end;
+
 procedure TGocciaClassValue.LinkNativeSuperConstructor(
   const ASuperConstructor: TGocciaObjectValue);
 begin
@@ -1316,6 +1333,16 @@ begin
   // FName update is sufficient; GetOwnPropertyDescriptor synthesizes the descriptor.
   if (FName = '') or (FName = '<anonymous>') then
     FName := AName;
+end;
+
+procedure TGocciaClassValue.SetSourceText(const ASourceText: string);
+begin
+  FSourceText := ASourceText;
+end;
+
+function TGocciaClassValue.GetSourceText: string;
+begin
+  Result := FSourceText;
 end;
 
 procedure TGocciaClassValue.SetFieldOrder(const AOrder: array of TGocciaClassFieldOrderEntry);
@@ -1377,6 +1404,7 @@ function TGocciaClassValue.Instantiate(const AArguments: TGocciaArgumentsCollect
 var
   Instance: TGocciaObjectValue;
   WalkClass: TGocciaClassValue;
+  ImplicitSuperClass: TGocciaClassValue;
   NativeClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
   NativeSuperConstructor: TGocciaObjectValue;
@@ -1496,8 +1524,11 @@ begin
   end;
 
   ConstructorToCall := FConstructorMethod;
-  if not Assigned(ConstructorToCall) and Assigned(FSuperClass) then
-    ConstructorToCall := FSuperClass.ConstructorMethod;
+  ImplicitSuperClass := FSuperClass;
+  if GetConstructorPrototype is TGocciaClassValue then
+    ImplicitSuperClass := TGocciaClassValue(GetConstructorPrototype);
+  if not Assigned(ConstructorToCall) and Assigned(ImplicitSuperClass) then
+    ConstructorToCall := ImplicitSuperClass.ConstructorMethod;
 
   if Assigned(ConstructorToCall) then
   begin
@@ -1539,6 +1570,9 @@ begin
   begin
     if (not Assigned(NativeInstance)) and Assigned(NativeSuperConstructor) then
     begin
+      if NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype then
+        ThrowTypeError('Super constructor is not a constructor',
+          SSuggestNotConstructorType);
       NativeInstance := ConstructNativeSuperInstance(NativeSuperConstructor);
       NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance);
       if Assigned(NativeInstance) then

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -1280,6 +1280,15 @@ begin
       Exit;
     end;
   end;
+  if AThisValue is TGocciaClassValue then
+  begin
+    SrcText := TGocciaClassValue(AThisValue).GetSourceText;
+    if SrcText <> '' then
+    begin
+      Result := TGocciaStringLiteralValue.Create(SrcText);
+      Exit;
+    end;
+  end;
 
   // Built-in functions and bound functions: NativeFunction string
   if AThisValue is TGocciaFunctionBase then
@@ -1365,6 +1374,8 @@ begin
   FBoundLength := SnapshotBoundFunctionLength(FOriginalFunction,
     FBoundArgCount);
   FBoundName := SnapshotBoundFunctionName(FOriginalFunction);
+  if FOriginalFunction is TGocciaObjectValue then
+    Self.Prototype := TGocciaObjectValue(FOriginalFunction).Prototype;
 
   FProperties.Add(PROP_LENGTH, TGocciaPropertyDescriptorData.Create(
     TGocciaNumberLiteralValue.Create(FBoundLength), [pfConfigurable]));

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -175,12 +175,19 @@ var
 
 const
   MAX_PROTOTYPE_CHAIN_DEPTH = 256;
+  BYTECODE_PRIVATE_SLOT_PREFIX = '#slot:';
+  BYTECODE_PRIVATE_BRAND_PREFIX = '#brand:';
   BYTECODE_PRIVATE_INITIALIZED_PREFIX = '#initialized:';
 
-function IsBytecodePrivateInitializerMarker(const AName: string): Boolean;
+function IsInternalPrivateStorageKey(const AName: string): Boolean;
 begin
-  Result := Copy(AName, 1, Length(BYTECODE_PRIVATE_INITIALIZED_PREFIX)) =
-    BYTECODE_PRIVATE_INITIALIZED_PREFIX;
+  Result :=
+    (Copy(AName, 1, Length(BYTECODE_PRIVATE_SLOT_PREFIX)) =
+      BYTECODE_PRIVATE_SLOT_PREFIX) or
+    (Copy(AName, 1, Length(BYTECODE_PRIVATE_BRAND_PREFIX)) =
+      BYTECODE_PRIVATE_BRAND_PREFIX) or
+    (Copy(AName, 1, Length(BYTECODE_PRIVATE_INITIALIZED_PREFIX)) =
+      BYTECODE_PRIVATE_INITIALIZED_PREFIX);
 end;
 
 function IsHiddenRegExpDataProperty(const AObject: TGocciaObjectValue;
@@ -1324,7 +1331,7 @@ begin
   Count := 0;
   for Key in FProperties.Keys do
   begin
-    if IsBytecodePrivateInitializerMarker(Key) or
+    if IsInternalPrivateStorageKey(Key) or
        IsHiddenRegExpDataProperty(Self, Key) then
       Continue;
     Keys[Count] := Key;
@@ -1493,7 +1500,7 @@ begin
 
   for Pair in FProperties do
     if Pair.Value.Enumerable and
-       not IsBytecodePrivateInitializerMarker(Pair.Key) then
+       not IsInternalPrivateStorageKey(Pair.Key) then
     begin
       Names[Count] := Pair.Key;
       Inc(Count);
@@ -1567,7 +1574,7 @@ begin
   Count := 0;
   for Key in FProperties.Keys do
   begin
-    if IsBytecodePrivateInitializerMarker(Key) or
+    if IsInternalPrivateStorageKey(Key) or
        IsHiddenRegExpDataProperty(Self, Key) then
       Continue;
     Names[Count] := Key;

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -29,6 +29,7 @@ type
     function ToNumberLiteral: TGocciaNumberLiteralValue; virtual; abstract;
     function ToStringLiteral: TGocciaStringLiteralValue; virtual; abstract;
 
+    function HasHTMLDDAInternalSlot: Boolean; virtual;
     function IsPrimitive: Boolean; virtual;
     function IsCallable: Boolean; virtual;
     function IsConstructable: Boolean; virtual;
@@ -394,6 +395,11 @@ function TGocciaValue.RuntimeCopy: TGocciaValue;
 begin
   // Default: return self (for singletons and complex values like objects/functions)
   Result := Self;
+end;
+
+function TGocciaValue.HasHTMLDDAInternalSlot: Boolean;
+begin
+  Result := False;
 end;
 
 function TGocciaValue.IsPrimitive: Boolean;

--- a/tests/built-ins/Function/constructor/errors.js
+++ b/tests/built-ins/Function/constructor/errors.js
@@ -15,4 +15,14 @@ describe("Function constructor errors", () => {
   test("strict body rejects future reserved identifier references", () => {
     expect(() => new Function('"use strict"; public = 1;')).toThrow(SyntaxError);
   });
+
+  test("super is rejected inside nested dynamic body containers", () => {
+    expect(() => new Function("for (; super.value; ) {}")).toThrow(SyntaxError);
+    expect(() => new Function("while (super.value) {}")).toThrow(SyntaxError);
+    expect(() => new Function("switch (0) { case super.value: break; }")).toThrow(SyntaxError);
+    expect(() => new Function("try {} finally { super.value; }")).toThrow(SyntaxError);
+    expect(() => new Function("return [super.value];")).toThrow(SyntaxError);
+    expect(() => new Function("return { [super.value]: 1 };")).toThrow(SyntaxError);
+    expect(() => new Function("return `${super.value}`;")).toThrow(SyntaxError);
+  });
 });

--- a/tests/built-ins/Function/constructor/goccia.json
+++ b/tests/built-ins/Function/constructor/goccia.json
@@ -1,3 +1,5 @@
 {
+  "compat-traditional-for-loop": true,
+  "compat-while-loops": true,
   "unsafe-function-constructor": true
 }

--- a/tests/built-ins/Function/prototype/toString.js
+++ b/tests/built-ins/Function/prototype/toString.js
@@ -82,6 +82,13 @@ describe("Function.prototype.toString", () => {
     expect(str.includes("return x * 2")).toBe(true);
   });
 
+  test("class static method source text excludes static modifier", () => {
+    class MathUtils {
+      static /* before */ triple /* name */ (x) { return x * 3; }
+    }
+    expect(MathUtils.triple.toString()).toBe("triple /* name */ (x) { return x * 3; }");
+  });
+
   test("object getter returns source text", () => {
     const obj = { get name() { return "hello"; } };
     const desc = Object.getOwnPropertyDescriptor(obj, "name");

--- a/tests/language/classes/private-elements-nonextensible-return-override.js
+++ b/tests/language/classes/private-elements-nonextensible-return-override.js
@@ -178,4 +178,26 @@ describe("Private elements on constructor return overrides", () => {
     new WithPrivateFieldInitializer(forged);
     expect(WithPrivateFieldInitializer.read(forged)).toBe(1);
   });
+
+  test("private fields remain writable on frozen replacement objects", () => {
+    class WithMutablePrivateField extends ReturnOverrideBase {
+      #value = 1;
+
+      static read(obj) {
+        return obj.#value;
+      }
+
+      static increment(obj) {
+        obj.#value++;
+      }
+    }
+
+    const obj = {};
+    new WithMutablePrivateField(obj);
+    Object.freeze(obj);
+    WithMutablePrivateField.increment(obj);
+
+    expect(WithMutablePrivateField.read(obj)).toBe(2);
+    expect(Object.isFrozen(obj)).toBe(true);
+  });
 });

--- a/tests/language/classes/private-fields.js
+++ b/tests/language/classes/private-fields.js
@@ -47,6 +47,32 @@ test("private fields", () => {
   expect(keys).not.toContain("balance");
 });
 
+test("private names are case-sensitive", () => {
+  class CaseSensitive {
+    #x = 1;
+    #X = 2;
+
+    get lower() {
+      return this.#x;
+    }
+
+    get upper() {
+      return this.#X;
+    }
+
+    set lower(value) {
+      this.#x = value;
+    }
+  }
+
+  const instance = new CaseSensitive();
+  expect(instance.lower).toBe(1);
+  expect(instance.upper).toBe(2);
+  instance.lower = 3;
+  expect(instance.lower).toBe(3);
+  expect(instance.upper).toBe(2);
+});
+
 test("private methods", () => {
   class Calculator {
     #result = 0;

--- a/tests/language/decorators/auto-accessor.js
+++ b/tests/language/decorators/auto-accessor.js
@@ -82,4 +82,23 @@ describe("auto-accessor", () => {
     c[key] = 2;
     expect(c[key]).toBe(2);
   });
+
+  test("static private auto-accessor initializer does not run per instance", () => {
+    let calls = 0;
+
+    class C {
+      static accessor #value = ++calls;
+
+      static read() {
+        return this.#value;
+      }
+    }
+
+    expect(calls).toBe(1);
+    expect(C.read()).toBe(1);
+    new C();
+    new C();
+    expect(calls).toBe(1);
+    expect(C.read()).toBe(1);
+  });
 });

--- a/tests/language/decorators/auto-accessor.js
+++ b/tests/language/decorators/auto-accessor.js
@@ -32,6 +32,31 @@ describe("auto-accessor", () => {
     expect(c.x).toBe(undefined);
   });
 
+  test("private auto-accessor uses private storage", () => {
+    class C {
+      accessor #x;
+
+      hasX() {
+        return #x in this;
+      }
+
+      read() {
+        return this.#x;
+      }
+
+      write(value) {
+        this.#x = value;
+      }
+    }
+
+    const c = new C();
+    expect(c.hasX()).toBe(true);
+    expect(c.read()).toBe(undefined);
+    c.write(42);
+    expect(c.read()).toBe(42);
+    expect(Object.getOwnPropertyNames(c).length).toBe(0);
+  });
+
   test("computed auto-accessor uses resolved property key", () => {
     const key = "x";
 


### PR DESCRIPTION
## Summary

- Bring the class/super/private conformance family to zero known bytecode failures, covering class definition evaluation, super reference handling, private fields/methods/accessors, auto-accessors, class source text, direct eval context, and computed class element ordering.
- Address review-found regressions: skip static accessors in instance initializer emission, make declared private-key lookup exact/case-sensitive, and expand dynamic `Function` `super` validation across nested containers.
- Keep accidental substring matches excluded from the issue family (`CharacterClassEscapes`, `isSupersetOf`) and keep Annex B scoped to the targeted class subclass slice.
- Closes #846.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas --clean testrunner`
  - `./build/GocciaTestRunner tests/built-ins/Function/constructor/errors.js`
  - `./build/GocciaTestRunner tests/built-ins/Function/constructor/errors.js --mode=bytecode`
  - `./build/GocciaTestRunner tests/language/decorators/auto-accessor.js`
  - `./build/GocciaTestRunner tests/language/decorators/auto-accessor.js --mode=bytecode`
  - `./build/GocciaTestRunner tests/language/classes/private-fields.js`
  - `./build/GocciaTestRunner tests/language/classes/private-fields.js --mode=bytecode`
  - `./build/GocciaTestRunner tests/language/decorators/auto-accessor.js tests/language/classes/private-fields.js tests/built-ins/Function/constructor/errors.js --mode=bytecode`
  - `./build/GocciaTestRunner tests`
  - `./build/GocciaTestRunner tests --mode=bytecode`
  - `./build.pas testrunner`
  - `./build.pas loaderbare`
  - Fresh bytecode test262 slices against `/tmp/goccia-test262-020cb740`:
    - `language/expressions/class/**`: 4059/4059
    - `language/statements/class/**`: 4367/4367
    - `language/expressions/super/**`: 94/94
    - `language/computed-property-names/class/**`: 29/29
    - `staging/sm/class/**`: 94/94
    - `staging/sm/PrivateName/**`: 17/17
    - `language/global-code/super*.js`: 4/4
    - `language/module-code/early-super.js`: 1/1
    - `annexB/language/statements/class/**`: 2/2
  - `rg -n "DEBUG capture|DEBUG getup|DEBUG private|DEBUG stamp|DEBUG descriptor|WriteLn\(StdErr, 'DEBUG" source scripts || true`
  - `git diff --check`
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - pre-commit `check-trunc-guards`
  - pre-commit `format-pascal`
  - `./format.pas --check`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
