### PR TITLE
fix(proxy): close Proxy conformance gaps

### DIFF
--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -131,21 +131,6 @@ end;
 function FromPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor): TGocciaObjectValue;
 begin
   Result := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-  if ADescriptor.HasEnumerableField then
-  begin
-    if ADescriptor.Enumerable then
-      Result.CreateDataPropertyOrThrow(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      Result.CreateDataPropertyOrThrow(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
-  end;
-  if ADescriptor.HasConfigurableField then
-  begin
-    if ADescriptor.Configurable then
-      Result.CreateDataPropertyOrThrow(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      Result.CreateDataPropertyOrThrow(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
-  end;
-
   if ADescriptor is TGocciaPropertyDescriptorData then
   begin
     if ADescriptor.HasValue then
@@ -180,6 +165,21 @@ begin
         Result.CreateDataPropertyOrThrow(PROP_SET,
           TGocciaUndefinedLiteralValue.UndefinedValue);
     end;
+  end;
+
+  if ADescriptor.HasEnumerableField then
+  begin
+    if ADescriptor.Enumerable then
+      Result.CreateDataPropertyOrThrow(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      Result.CreateDataPropertyOrThrow(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
+  end;
+  if ADescriptor.HasConfigurableField then
+  begin
+    if ADescriptor.Configurable then
+      Result.CreateDataPropertyOrThrow(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      Result.CreateDataPropertyOrThrow(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
   end;
 end;
 
@@ -648,7 +648,7 @@ var
   PropertyName: string;
   KeyValue: TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.getOwnPropertyDescriptor', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.getOwnPropertyDescriptor', ThrowError);
 
   // Step 1: Let obj be ? ToObject(O)
   Obj := ToObject(AArgs.GetElement(0));
@@ -781,12 +781,14 @@ begin
   if IsSymbolKey then
   begin
     SymbolKey := TGocciaSymbolValue(KeyValue);
-    ExistingDescriptor := Obj.GetOwnSymbolPropertyDescriptor(SymbolKey);
+    if not (Obj is TGocciaProxyValue) then
+      ExistingDescriptor := Obj.GetOwnSymbolPropertyDescriptor(SymbolKey);
   end
   else
   begin
     PropertyName := TGocciaStringLiteralValue(KeyValue).Value;
-    ExistingDescriptor := Obj.GetOwnPropertyDescriptor(PropertyName);
+    if not (Obj is TGocciaProxyValue) then
+      ExistingDescriptor := Obj.GetOwnPropertyDescriptor(PropertyName);
   end;
 
   // Step 3: Let desc be ? ToPropertyDescriptor(Attributes)

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -498,9 +498,7 @@ begin
   if ProtoValue is TGocciaObjectValue then
     Exit(TGocciaObjectValue(ProtoValue));
 
-  FallbackRealm := nil;
-  if ANewTarget is TGocciaFunctionBase then
-    FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
+  FallbackRealm := GetFunctionRealm(ANewTarget);
 
   if Assigned(FallbackRealm) then
   begin

--- a/source/units/Goccia.Builtins.GlobalProxy.pas
+++ b/source/units/Goccia.Builtins.GlobalProxy.pas
@@ -124,7 +124,7 @@ begin
   ResultObj.AssignProperty(PROP_PROXY, ProxyInstance);
   ResultObj.AssignProperty(PROP_REVOKE,
     TGocciaNativeFunctionValue.CreateWithoutPrototype(
-      Revoker.RevokeCallback, PROP_REVOKE, 0));
+      Revoker.RevokeCallback, '', 0));
 
   Result := ResultObj;
 end;

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -224,12 +224,14 @@ begin
   if IsSymbolKey then
   begin
     SymbolKey := TGocciaSymbolValue(PropKey);
-    ExistingDescriptor := Obj.GetOwnSymbolPropertyDescriptor(SymbolKey);
+    if not (Obj is TGocciaProxyValue) then
+      ExistingDescriptor := Obj.GetOwnSymbolPropertyDescriptor(SymbolKey);
   end
   else
   begin
     PropertyName := TGocciaStringLiteralValue(PropKey).Value;
-    ExistingDescriptor := Obj.GetOwnPropertyDescriptor(PropertyName);
+    if not (Obj is TGocciaProxyValue) then
+      ExistingDescriptor := Obj.GetOwnPropertyDescriptor(PropertyName);
   end;
 
   // Step 3: Let desc be ? ToPropertyDescriptor(Attributes)
@@ -356,21 +358,6 @@ begin
   end;
 
   DescriptorObj := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-  if Descriptor.HasEnumerableField then
-  begin
-    if Descriptor.Enumerable then
-      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
-  end;
-  if Descriptor.HasConfigurableField then
-  begin
-    if Descriptor.Configurable then
-      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
-  end;
-
   if Descriptor is TGocciaPropertyDescriptorData then
   begin
     if Descriptor.HasValue then
@@ -401,6 +388,21 @@ begin
     end;
   end;
 
+  if Descriptor.HasEnumerableField then
+  begin
+    if Descriptor.Enumerable then
+      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
+  end;
+  if Descriptor.HasConfigurableField then
+  begin
+    if Descriptor.Configurable then
+      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
+  end;
+
   Result := DescriptorObj;
 end;
 
@@ -417,6 +419,12 @@ begin
   RequireObjectTarget(Target, 'Reflect.getPrototypeOf');
 
   // Step 2: Return ? target.[[GetPrototypeOf]]()
+  if Target is TGocciaProxyValue then
+  begin
+    Result := TGocciaProxyValue(Target).GetPrototypeTrap;
+    Exit;
+  end;
+
   if Assigned(TGocciaObjectValue(Target).Prototype) then
     Result := TGocciaObjectValue(Target).Prototype
   else
@@ -472,6 +480,15 @@ begin
   RequireObjectTarget(Target, 'Reflect.isExtensible');
 
   // Step 2: Return ? target.[[IsExtensible]]()
+  if Target is TGocciaProxyValue then
+  begin
+    if TGocciaProxyValue(Target).IsExtensibleTrap then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+
   if TGocciaObjectValue(Target).Extensible then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
@@ -535,6 +552,15 @@ begin
   RequireObjectTarget(Target, 'Reflect.preventExtensions');
 
   // Step 2: Return ? target.[[PreventExtensions]]()
+  if Target is TGocciaProxyValue then
+  begin
+    if TGocciaProxyValue(Target).TryPreventExtensionsTrap then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+
   TGocciaObjectValue(Target).PreventExtensions;
   Result := TGocciaBooleanLiteralValue.TrueValue;
 end;
@@ -599,6 +625,15 @@ begin
     ThrowTypeError(SErrorReflectSetPrototypeOfProtoType, SSuggestReflectObjectArg);
 
   // Step 3: Return ? target.[[SetPrototypeOf]](proto)
+  if Target is TGocciaProxyValue then
+  begin
+    if TGocciaProxyValue(Target).SetPrototypeTrap(ProtoArg) then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+
   // ES2026 §10.1.2 OrdinarySetPrototypeOf step 2: If SameValue(V, current) return true
   if ProtoArg is TGocciaNullLiteralValue then
   begin

--- a/source/units/Goccia.Builtins.Intl.pas
+++ b/source/units/Goccia.Builtins.Intl.pas
@@ -195,9 +195,7 @@ begin
   if PrototypeValue is TGocciaObjectValue then
     Exit(TGocciaObjectValue(PrototypeValue));
 
-  FallbackRealm := nil;
-  if ANewTarget is TGocciaFunctionBase then
-    FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
+  FallbackRealm := GetFunctionRealm(ANewTarget);
 
   Result := IntlConstructorPrototypeFromRealm(FallbackRealm, AConstructorName);
   if Assigned(Result) then

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -432,9 +432,7 @@ begin
   if ProtoValue is TGocciaObjectValue then
     Exit(TGocciaObjectValue(ProtoValue));
 
-  FallbackRealm := nil;
-  if ANewTarget is TGocciaFunctionBase then
-    FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
+  FallbackRealm := GetFunctionRealm(ANewTarget);
 
   Result := GetSharedArrayPrototypeForRealm(FallbackRealm);
   if not Assigned(Result) then
@@ -458,9 +456,7 @@ begin
   if ProtoValue is TGocciaObjectValue then
     Exit(TGocciaObjectValue(ProtoValue));
 
-  FallbackRealm := nil;
-  if ANewTarget is TGocciaFunctionBase then
-    FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
+  FallbackRealm := GetFunctionRealm(ANewTarget);
 
   if Assigned(FallbackRealm) then
   begin

--- a/source/units/Goccia.Values.FunctionBase.Test.pas
+++ b/source/units/Goccia.Values.FunctionBase.Test.pas
@@ -1,0 +1,48 @@
+program Goccia.Values.FunctionBase.Test;
+
+{$I Goccia.inc}
+
+uses
+  TestingPascalLibrary,
+
+  Goccia.Realm,
+  Goccia.TestSetup,
+  Goccia.Values.ClassValue,
+  Goccia.Values.FunctionBase;
+
+type
+  TTestFunctionBase = class(TTestSuite)
+  public
+    procedure SetupTests; override;
+
+    procedure TestGetFunctionRealmReturnsClassCreationRealm;
+  end;
+
+procedure TTestFunctionBase.SetupTests;
+begin
+  Test('GetFunctionRealm returns a class creation realm',
+    TestGetFunctionRealmReturnsClassCreationRealm);
+end;
+
+procedure TTestFunctionBase.TestGetFunctionRealmReturnsClassCreationRealm;
+var
+  PreviousRealm: TGocciaRealm;
+  Realm: TGocciaRealm;
+  ClassValue: TGocciaClassValue;
+begin
+  PreviousRealm := CurrentRealm;
+  Realm := TGocciaRealm.Create('function-base-test');
+  SetCurrentRealm(Realm);
+  try
+    ClassValue := TGocciaClassValue.Create('RealmClass', nil);
+    Expect<TGocciaRealm>(GetFunctionRealm(ClassValue)).ToBe(Realm);
+  finally
+    SetCurrentRealm(PreviousRealm);
+    Realm.Free;
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TTestFunctionBase.Create('Function Base'));
+  TestRunnerProgram.Run;
+end.

--- a/source/units/Goccia.Values.FunctionBase.Test.pas
+++ b/source/units/Goccia.Values.FunctionBase.Test.pas
@@ -6,9 +6,15 @@ uses
   TestingPascalLibrary,
 
   Goccia.Arguments.Collection,
+  Goccia.Constants.ErrorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
   Goccia.Realm,
   Goccia.TestSetup,
   Goccia.Values.ClassValue,
+  Goccia.Values.Error,
+  Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectValue,
@@ -25,12 +31,14 @@ type
     procedure TestGetFunctionRealmReturnsClassCreationRealm;
     procedure TestGetFunctionRealmReturnsFunctionCreationRealm;
     procedure TestGetFunctionRealmUsesRegisteredProxyHook;
+    procedure TestGetFunctionRealmPropagatesRevokedProxyTypeError;
     procedure TestGetFunctionRealmReturnsNilForOtherValues;
   end;
 
 var
   GProxyRealmTestValue: TGocciaValue;
   GProxyRealmTestRealm: TGocciaRealm;
+  GProxyRealmTestRevoked: Boolean;
 
 function TestProxyPredicate(const AValue: TGocciaValue): Boolean;
 begin
@@ -59,6 +67,9 @@ end;
 
 function TestProxyGetFunctionRealm(const AProxy: TGocciaValue): TGocciaRealm;
 begin
+  if GProxyRealmTestRevoked then
+    ThrowTypeError(SErrorProxyRevoked, SSuggestProxyRevoked);
+
   Result := GProxyRealmTestRealm;
 end;
 
@@ -70,6 +81,8 @@ begin
     TestGetFunctionRealmReturnsFunctionCreationRealm);
   Test('GetFunctionRealm uses the registered proxy hook',
     TestGetFunctionRealmUsesRegisteredProxyHook);
+  Test('GetFunctionRealm propagates revoked proxy TypeError',
+    TestGetFunctionRealmPropagatesRevokedProxyTypeError);
   Test('GetFunctionRealm returns nil for other values',
     TestGetFunctionRealmReturnsNilForOtherValues);
 end;
@@ -135,7 +148,58 @@ begin
     RegisterProxyDispatchHooks(nil, nil, nil, nil, nil);
     GProxyRealmTestValue := nil;
     GProxyRealmTestRealm := nil;
+    GProxyRealmTestRevoked := False;
     Realm.Free;
+  end;
+end;
+
+procedure TTestFunctionBase.TestGetFunctionRealmPropagatesRevokedProxyTypeError;
+var
+  ProxyValue: TGocciaObjectValue;
+  RaisedExpected: Boolean;
+  ThrownMessage: string;
+  ThrownName: string;
+  ThrownNameValue: TGocciaValue;
+  ThrownMessageValue: TGocciaValue;
+begin
+  ProxyValue := TGocciaObjectValue.Create(nil);
+  GProxyRealmTestValue := ProxyValue;
+  GProxyRealmTestRevoked := True;
+  RegisterProxyDispatchHooks(TestProxyPredicate, TestProxyApply,
+    TestProxyConstruct, TestProxyGetPrototype, TestProxyGetFunctionRealm);
+
+  RaisedExpected := False;
+  ThrownName := '';
+  ThrownMessage := '';
+  try
+    try
+      GetFunctionRealm(ProxyValue);
+    except
+      on E: TGocciaThrowValue do
+      begin
+        RaisedExpected := True;
+        ThrownNameValue := nil;
+        ThrownMessageValue := nil;
+        if E.Value is TGocciaObjectValue then
+        begin
+          ThrownNameValue := TGocciaObjectValue(E.Value).GetProperty(PROP_NAME);
+          ThrownMessageValue := TGocciaObjectValue(E.Value).GetProperty(PROP_MESSAGE);
+        end;
+        if ThrownNameValue is TGocciaStringLiteralValue then
+          ThrownName := TGocciaStringLiteralValue(ThrownNameValue).Value;
+        if ThrownMessageValue is TGocciaStringLiteralValue then
+          ThrownMessage := TGocciaStringLiteralValue(ThrownMessageValue).Value;
+      end;
+    end;
+
+    Expect<Boolean>(RaisedExpected).ToBe(True);
+    Expect<string>(ThrownName).ToBe(TYPE_ERROR_NAME);
+    Expect<string>(ThrownMessage).ToBe(SErrorProxyRevoked);
+  finally
+    RegisterProxyDispatchHooks(nil, nil, nil, nil, nil);
+    GProxyRealmTestValue := nil;
+    GProxyRealmTestRealm := nil;
+    GProxyRealmTestRevoked := False;
   end;
 end;
 
@@ -144,6 +208,7 @@ var
   Value: TGocciaObjectValue;
 begin
   RegisterProxyDispatchHooks(nil, nil, nil, nil, nil);
+  GProxyRealmTestRevoked := False;
   Value := TGocciaObjectValue.Create(nil);
   Expect<TGocciaRealm>(GetFunctionRealm(Value)).ToBe(nil);
 end;

--- a/source/units/Goccia.Values.FunctionBase.Test.pas
+++ b/source/units/Goccia.Values.FunctionBase.Test.pas
@@ -5,23 +5,80 @@ program Goccia.Values.FunctionBase.Test;
 uses
   TestingPascalLibrary,
 
+  Goccia.Arguments.Collection,
   Goccia.Realm,
   Goccia.TestSetup,
   Goccia.Values.ClassValue,
-  Goccia.Values.FunctionBase;
+  Goccia.Values.FunctionBase,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
 
 type
   TTestFunctionBase = class(TTestSuite)
+  private
+    function NativeNoOp(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
   public
     procedure SetupTests; override;
 
     procedure TestGetFunctionRealmReturnsClassCreationRealm;
+    procedure TestGetFunctionRealmReturnsFunctionCreationRealm;
+    procedure TestGetFunctionRealmUsesRegisteredProxyHook;
+    procedure TestGetFunctionRealmReturnsNilForOtherValues;
   end;
+
+var
+  GProxyRealmTestValue: TGocciaValue;
+  GProxyRealmTestRealm: TGocciaRealm;
+
+function TestProxyPredicate(const AValue: TGocciaValue): Boolean;
+begin
+  Result := AValue = GProxyRealmTestValue;
+end;
+
+function TestProxyApply(const AProxy: TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TestProxyConstruct(const AProxy: TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TestProxyGetPrototype(
+  const AProxy: TGocciaObjectValue): TGocciaValue;
+begin
+  Result := nil;
+end;
+
+function TestProxyGetFunctionRealm(const AProxy: TGocciaValue): TGocciaRealm;
+begin
+  Result := GProxyRealmTestRealm;
+end;
 
 procedure TTestFunctionBase.SetupTests;
 begin
   Test('GetFunctionRealm returns a class creation realm',
     TestGetFunctionRealmReturnsClassCreationRealm);
+  Test('GetFunctionRealm returns a function creation realm',
+    TestGetFunctionRealmReturnsFunctionCreationRealm);
+  Test('GetFunctionRealm uses the registered proxy hook',
+    TestGetFunctionRealmUsesRegisteredProxyHook);
+  Test('GetFunctionRealm returns nil for other values',
+    TestGetFunctionRealmReturnsNilForOtherValues);
+end;
+
+function TTestFunctionBase.NativeNoOp(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 procedure TTestFunctionBase.TestGetFunctionRealmReturnsClassCreationRealm;
@@ -40,6 +97,55 @@ begin
     SetCurrentRealm(PreviousRealm);
     Realm.Free;
   end;
+end;
+
+procedure TTestFunctionBase.TestGetFunctionRealmReturnsFunctionCreationRealm;
+var
+  PreviousRealm: TGocciaRealm;
+  Realm: TGocciaRealm;
+  FunctionValue: TGocciaNativeFunctionValue;
+begin
+  PreviousRealm := CurrentRealm;
+  Realm := TGocciaRealm.Create('function-base-function-test');
+  SetCurrentRealm(Realm);
+  try
+    FunctionValue := TGocciaNativeFunctionValue.Create(NativeNoOp,
+      'realmFunction', 0);
+    Expect<TGocciaRealm>(GetFunctionRealm(FunctionValue)).ToBe(Realm);
+  finally
+    SetCurrentRealm(PreviousRealm);
+    Realm.Free;
+  end;
+end;
+
+procedure TTestFunctionBase.TestGetFunctionRealmUsesRegisteredProxyHook;
+var
+  Realm: TGocciaRealm;
+  ProxyValue: TGocciaObjectValue;
+begin
+  Realm := TGocciaRealm.Create('function-base-proxy-test');
+  ProxyValue := TGocciaObjectValue.Create(nil);
+  GProxyRealmTestValue := ProxyValue;
+  GProxyRealmTestRealm := Realm;
+  RegisterProxyDispatchHooks(TestProxyPredicate, TestProxyApply,
+    TestProxyConstruct, TestProxyGetPrototype, TestProxyGetFunctionRealm);
+  try
+    Expect<TGocciaRealm>(GetFunctionRealm(ProxyValue)).ToBe(Realm);
+  finally
+    RegisterProxyDispatchHooks(nil, nil, nil, nil, nil);
+    GProxyRealmTestValue := nil;
+    GProxyRealmTestRealm := nil;
+    Realm.Free;
+  end;
+end;
+
+procedure TTestFunctionBase.TestGetFunctionRealmReturnsNilForOtherValues;
+var
+  Value: TGocciaObjectValue;
+begin
+  RegisterProxyDispatchHooks(nil, nil, nil, nil, nil);
+  Value := TGocciaObjectValue.Create(nil);
+  Expect<TGocciaRealm>(GetFunctionRealm(Value)).ToBe(nil);
 end;
 
 begin

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -320,6 +320,9 @@ begin
   if AValue is TGocciaFunctionBase then
     Exit(TGocciaFunctionBase(AValue).CreationRealm);
 
+  if AValue is TGocciaClassValue then
+    Exit(TGocciaClassValue(AValue).CreationRealm);
+
   if IsRegisteredProxyValue(AValue) and Assigned(GProxyGetFunctionRealmHook) then
     Exit(GProxyGetFunctionRealmHook(AValue));
 

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -24,6 +24,8 @@ type
     const ANewTarget: TGocciaValue): TGocciaValue;
   TGocciaProxyGetPrototypeHook = function(
     const AProxy: TGocciaObjectValue): TGocciaValue;
+  TGocciaProxyGetFunctionRealmHook = function(
+    const AProxy: TGocciaValue): TGocciaRealm;
 
   TGocciaFunctionSharedPrototype = class(TGocciaObjectValue)
   public
@@ -154,6 +156,7 @@ function GetProtoFromConstructor(const ANewTarget: TGocciaValue): TGocciaObjectV
 function GetProtoFromConstructorWithIntrinsic(const ANewTarget: TGocciaValue;
   const AIntrinsicDefault: TGocciaObjectValue;
   const AIntrinsicSlot: TGocciaRealmSlotId = -1): TGocciaObjectValue;
+function GetFunctionRealm(const AValue: TGocciaValue): TGocciaRealm;
 
 // ES2026 §10.2.4.1 %ThrowTypeError%: one frozen thrower per realm, reused by
 // AddRestrictedFunctionProperties and unmapped arguments objects.
@@ -184,7 +187,8 @@ procedure RegisterProxyDispatchHooks(
   const APredicate: TGocciaProxyPredicate;
   const AApply: TGocciaProxyApplyHook;
   const AConstruct: TGocciaProxyConstructHook;
-  const AGetPrototype: TGocciaProxyGetPrototypeHook);
+  const AGetPrototype: TGocciaProxyGetPrototypeHook;
+  const AGetFunctionRealm: TGocciaProxyGetFunctionRealmHook);
 
 // ES2026 §10.2.9 SetFunctionName property-key formatting shared by
 // interpreter and bytecode named-evaluation paths.
@@ -226,17 +230,20 @@ var
   GProxyApplyHook: TGocciaProxyApplyHook;
   GProxyConstructHook: TGocciaProxyConstructHook;
   GProxyGetPrototypeHook: TGocciaProxyGetPrototypeHook;
+  GProxyGetFunctionRealmHook: TGocciaProxyGetFunctionRealmHook;
 
 procedure RegisterProxyDispatchHooks(
   const APredicate: TGocciaProxyPredicate;
   const AApply: TGocciaProxyApplyHook;
   const AConstruct: TGocciaProxyConstructHook;
-  const AGetPrototype: TGocciaProxyGetPrototypeHook);
+  const AGetPrototype: TGocciaProxyGetPrototypeHook;
+  const AGetFunctionRealm: TGocciaProxyGetFunctionRealmHook);
 begin
   GProxyPredicate := APredicate;
   GProxyApplyHook := AApply;
   GProxyConstructHook := AConstruct;
   GProxyGetPrototypeHook := AGetPrototype;
+  GProxyGetFunctionRealmHook := AGetFunctionRealm;
 end;
 
 function IsRegisteredProxyValue(const AValue: TGocciaValue): Boolean; inline;
@@ -266,9 +273,7 @@ begin
     Result := TGocciaObjectValue(ProtoValue)
   else
   begin
-    FallbackRealm := nil;
-    if ANewTarget is TGocciaFunctionBase then
-      FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
+    FallbackRealm := GetFunctionRealm(ANewTarget);
     Result := TGocciaObjectValue.GetSharedObjectPrototypeForRealm(
       FallbackRealm);
     if Assigned(Result) then
@@ -296,9 +301,9 @@ begin
     Result := TGocciaObjectValue(ProtoValue)
   else
   begin
-    if (AIntrinsicSlot >= 0) and (ANewTarget is TGocciaFunctionBase) then
+    FallbackRealm := GetFunctionRealm(ANewTarget);
+    if AIntrinsicSlot >= 0 then
     begin
-      FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
       if Assigned(FallbackRealm) then
       begin
         Result := TGocciaObjectValue(FallbackRealm.GetSlot(AIntrinsicSlot));
@@ -308,6 +313,17 @@ begin
     end;
     Result := AIntrinsicDefault;
   end;
+end;
+
+function GetFunctionRealm(const AValue: TGocciaValue): TGocciaRealm;
+begin
+  if AValue is TGocciaFunctionBase then
+    Exit(TGocciaFunctionBase(AValue).CreationRealm);
+
+  if IsRegisteredProxyValue(AValue) and Assigned(GProxyGetFunctionRealmHook) then
+    Exit(GProxyGetFunctionRealmHook(AValue));
+
+  Result := nil;
 end;
 
 function GetThrowTypeErrorIntrinsic: TGocciaFunctionBase;

--- a/source/units/Goccia.Values.ObjectPropertyDescriptor.pas
+++ b/source/units/Goccia.Values.ObjectPropertyDescriptor.pas
@@ -341,24 +341,26 @@ begin
   Getter := nil;
   Setter := nil;
 
-  // ES2026 §6.2.5.5 steps 3–9: extract descriptor fields
+  // ES2026 §6.2.5.5 steps 3-9: extract descriptor fields. The has/get
+  // pairs are observably ordered when Desc is a Proxy.
   HasEnumerableField := DescObj.HasProperty(PROP_ENUMERABLE);
-  HasConfigurableField := DescObj.HasProperty(PROP_CONFIGURABLE);
-  HasValue := DescObj.HasProperty(PROP_VALUE);
-  HasGet := DescObj.HasProperty(PROP_GET);
-  HasSet := DescObj.HasProperty(PROP_SET);
-  HasWritableField := DescObj.HasProperty(PROP_WRITABLE);
-
   if HasEnumerableField then
     Enumerable := DescObj.GetProperty(PROP_ENUMERABLE).ToBooleanLiteral.Value;
+
+  HasConfigurableField := DescObj.HasProperty(PROP_CONFIGURABLE);
   if HasConfigurableField then
     Configurable := DescObj.GetProperty(PROP_CONFIGURABLE).ToBooleanLiteral.Value;
+
+  HasValue := DescObj.HasProperty(PROP_VALUE);
   if HasValue then
     Value := DescObj.GetProperty(PROP_VALUE);
+
+  HasWritableField := DescObj.HasProperty(PROP_WRITABLE);
   if HasWritableField then
     Writable := DescObj.GetProperty(PROP_WRITABLE).ToBooleanLiteral.Value;
 
   // ES2026 §6.2.5.5 step 7: validate getter
+  HasGet := DescObj.HasProperty(PROP_GET);
   if HasGet then
   begin
     Getter := DescObj.GetProperty(PROP_GET);
@@ -369,6 +371,7 @@ begin
   end;
 
   // ES2026 §6.2.5.5 step 8: validate setter
+  HasSet := DescObj.HasProperty(PROP_SET);
   if HasSet then
   begin
     Setter := DescObj.GetProperty(PROP_SET);

--- a/source/units/Goccia.Values.ProxyValue.pas
+++ b/source/units/Goccia.Values.ProxyValue.pas
@@ -586,10 +586,10 @@ begin
 end;
 
 procedure ValidateProxyGetOwnTrapDescriptor(const APropertyLabel: string;
-  const ATargetObject: TGocciaObjectValue;
+  const AExtensibleTarget: Boolean;
   const ATargetDesc, AResultDesc: TGocciaPropertyDescriptor);
 begin
-  if not IsCompatibleProxyTrapPropertyDescriptor(ATargetObject.Extensible,
+  if not IsCompatibleProxyTrapPropertyDescriptor(AExtensibleTarget,
     AResultDesc, ATargetDesc) then
     ThrowTypeError(Format(SErrorProxyGetOwnIncompatible, [APropertyLabel]),
       SSuggestProxyTrapInvariant);
@@ -780,7 +780,7 @@ begin
     end;
   end;
 
-  if TargetObj.Extensible then
+  if ProxyTargetIsExtensible(FTarget) then
     Exit;
 
   for I := 0 to Length(TargetKeys) - 1 do
@@ -1357,8 +1357,8 @@ begin
     end;
     try
       if Assigned(TargetObject) then
-        ValidateProxyGetOwnTrapDescriptor(AName, TargetObject, TargetDesc,
-          CompletedDesc);
+        ValidateProxyGetOwnTrapDescriptor(AName,
+          ProxyTargetIsExtensible(FTarget), TargetDesc, CompletedDesc);
       Result := CompletedDesc;
     except
       CompletedDesc.Free;
@@ -1434,8 +1434,8 @@ begin
     end;
     try
       if Assigned(TargetObject) then
-        ValidateProxyGetOwnTrapDescriptor(PropertyLabel, TargetObject,
-          TargetDesc, CompletedDesc);
+        ValidateProxyGetOwnTrapDescriptor(PropertyLabel,
+          ProxyTargetIsExtensible(FTarget), TargetDesc, CompletedDesc);
       Result := CompletedDesc;
     except
       CompletedDesc.Free;

--- a/source/units/Goccia.Values.ProxyValue.pas
+++ b/source/units/Goccia.Values.ProxyValue.pas
@@ -97,6 +97,7 @@ type
     function IsExtensibleTrap: Boolean;
 
     // ES2026 §28.1.1 [[PreventExtensions]]()
+    function TryPreventExtensionsTrap: Boolean;
     procedure PreventExtensions; override;
 
     // ES2026 §28.1.1 [[Call]](thisArgument, argumentsList)
@@ -157,6 +158,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.Realm,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
   Goccia.Values.ErrorHelper,
@@ -294,6 +296,295 @@ begin
   Result := True;
 end;
 
+function IsCompatibleProxyDefineDescriptor(const AExtensible: Boolean;
+  const ADescriptor: TGocciaPropertyDescriptor;
+  const ATargetDesc: TGocciaPropertyDescriptor): Boolean;
+var
+  DescriptorAccessor: TGocciaPropertyDescriptorAccessor;
+  DescriptorData: TGocciaPropertyDescriptorData;
+  TargetAccessor: TGocciaPropertyDescriptorAccessor;
+  TargetData: TGocciaPropertyDescriptorData;
+begin
+  if not Assigned(ATargetDesc) then
+    Exit(AExtensible);
+
+  if ADescriptor.Fields = [] then
+    Exit(True);
+
+  if ATargetDesc.Configurable then
+    Exit(True);
+
+  if ADescriptor.HasConfigurableField and ADescriptor.Configurable then
+    Exit(False);
+
+  if ADescriptor.HasEnumerableField and
+     (ATargetDesc.Enumerable <> ADescriptor.Enumerable) then
+    Exit(False);
+
+  if IsGenericDescriptor(ADescriptor) then
+    Exit(True);
+
+  if IsDataDescriptor(ATargetDesc) <> IsDataDescriptor(ADescriptor) then
+    Exit(False);
+
+  if IsAccessorDescriptor(ATargetDesc) and IsAccessorDescriptor(ADescriptor) then
+  begin
+    TargetAccessor := TGocciaPropertyDescriptorAccessor(ATargetDesc);
+    DescriptorAccessor := TGocciaPropertyDescriptorAccessor(ADescriptor);
+    if ADescriptor.HasGet and
+       (TargetAccessor.Getter <> DescriptorAccessor.Getter) then
+      Exit(False);
+    if ADescriptor.HasSet and
+       (TargetAccessor.Setter <> DescriptorAccessor.Setter) then
+      Exit(False);
+  end;
+
+  if IsDataDescriptor(ATargetDesc) and IsDataDescriptor(ADescriptor) then
+  begin
+    TargetData := TGocciaPropertyDescriptorData(ATargetDesc);
+    DescriptorData := TGocciaPropertyDescriptorData(ADescriptor);
+    if not TargetData.Writable then
+    begin
+      if ADescriptor.HasWritableField and DescriptorData.Writable then
+        Exit(False);
+      if ADescriptor.HasValue and
+         not IsSameValue(TargetData.Value, DescriptorData.Value) then
+        Exit(False);
+    end;
+  end;
+
+  Result := True;
+end;
+
+function ProxyTargetIsExtensible(const ATarget: TGocciaValue): Boolean;
+begin
+  if ATarget is TGocciaProxyValue then
+    Result := TGocciaProxyValue(ATarget).IsExtensibleTrap
+  else if ATarget is TGocciaObjectValue then
+    Result := TGocciaObjectValue(ATarget).Extensible
+  else
+    Result := False;
+end;
+
+function ProxyTargetGetPrototype(const ATarget: TGocciaValue): TGocciaValue;
+begin
+  if ATarget is TGocciaProxyValue then
+    Exit(TGocciaProxyValue(ATarget).GetPrototypeTrap);
+
+  if ATarget is TGocciaObjectValue then
+  begin
+    if Assigned(TGocciaObjectValue(ATarget).Prototype) then
+      Exit(TGocciaObjectValue(ATarget).Prototype);
+    Exit(TGocciaNullLiteralValue.NullValue);
+  end;
+
+  Result := TGocciaNullLiteralValue.NullValue;
+end;
+
+function ProxyTargetSetPrototype(const ATarget, AProto: TGocciaValue): Boolean;
+var
+  TargetObject: TGocciaObjectValue;
+  Walker: TGocciaObjectValue;
+begin
+  if ATarget is TGocciaProxyValue then
+    Exit(TGocciaProxyValue(ATarget).SetPrototypeTrap(AProto));
+
+  if not (ATarget is TGocciaObjectValue) then
+    Exit(False);
+
+  TargetObject := TGocciaObjectValue(ATarget);
+
+  if AProto is TGocciaObjectValue then
+  begin
+    if TargetObject.Prototype = TGocciaObjectValue(AProto) then
+      Exit(True);
+  end
+  else if AProto is TGocciaNullLiteralValue then
+  begin
+    if not Assigned(TargetObject.Prototype) then
+      Exit(True);
+  end
+  else
+    Exit(False);
+
+  if TargetObject = TGocciaObjectValue.SharedObjectPrototype then
+    Exit(False);
+
+  if not TargetObject.Extensible then
+    Exit(False);
+
+  if AProto is TGocciaObjectValue then
+  begin
+    Walker := TGocciaObjectValue(AProto);
+    while Assigned(Walker) do
+    begin
+      if Walker = TargetObject then
+        Exit(False);
+      if Walker is TGocciaProxyValue then
+        Break;
+      Walker := Walker.Prototype;
+    end;
+  end;
+
+  if AProto is TGocciaObjectValue then
+    TargetObject.Prototype := TGocciaObjectValue(AProto)
+  else
+    TargetObject.Prototype := nil;
+
+  Result := True;
+end;
+
+function ProxyTargetHasSymbolProperty(
+  const ATarget: TGocciaValue;
+  const ASymbol: TGocciaSymbolValue): Boolean;
+var
+  Current: TGocciaObjectValue;
+begin
+  if ATarget is TGocciaProxyValue then
+    Exit(TGocciaProxyValue(ATarget).HasSymbolTrap(ASymbol));
+
+  if not (ATarget is TGocciaObjectValue) then
+    Exit(False);
+
+  Current := TGocciaObjectValue(ATarget);
+  while Assigned(Current) do
+  begin
+    if Current is TGocciaProxyValue then
+      Exit(TGocciaProxyValue(Current).HasSymbolTrap(ASymbol));
+    if Current.HasSymbolProperty(ASymbol) then
+      Exit(True);
+    Current := Current.Prototype;
+  end;
+
+  Result := False;
+end;
+
+function CreateProxyTrapDescriptorObject(
+  const ADescriptor: TGocciaPropertyDescriptor): TGocciaObjectValue;
+begin
+  Result := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
+  if ADescriptor is TGocciaPropertyDescriptorAccessor then
+  begin
+    if ADescriptor.HasGet then
+    begin
+      if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Getter) then
+        Result.AssignProperty(PROP_GET,
+          TGocciaPropertyDescriptorAccessor(ADescriptor).Getter)
+      else
+        Result.AssignProperty(PROP_GET,
+          TGocciaUndefinedLiteralValue.UndefinedValue);
+    end;
+    if ADescriptor.HasSet then
+    begin
+      if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Setter) then
+        Result.AssignProperty(PROP_SET,
+          TGocciaPropertyDescriptorAccessor(ADescriptor).Setter)
+      else
+        Result.AssignProperty(PROP_SET,
+          TGocciaUndefinedLiteralValue.UndefinedValue);
+    end;
+  end
+  else if ADescriptor is TGocciaPropertyDescriptorData then
+  begin
+    if ADescriptor.HasValue then
+      Result.AssignProperty(PROP_VALUE,
+        TGocciaPropertyDescriptorData(ADescriptor).Value);
+    if ADescriptor.HasWritableField then
+      Result.AssignProperty(PROP_WRITABLE,
+        TGocciaBooleanLiteralValue.Create(ADescriptor.Writable));
+  end;
+  if ADescriptor.HasEnumerableField then
+    Result.AssignProperty(PROP_ENUMERABLE,
+      TGocciaBooleanLiteralValue.Create(ADescriptor.Enumerable));
+  if ADescriptor.HasConfigurableField then
+    Result.AssignProperty(PROP_CONFIGURABLE,
+      TGocciaBooleanLiteralValue.Create(ADescriptor.Configurable));
+end;
+
+procedure ValidateProxyDefineTrapResult(const APropertyLabel: string;
+  const ATarget: TGocciaValue;
+  const ADescriptor: TGocciaPropertyDescriptor);
+var
+  ExtensibleTarget: Boolean;
+  SettingConfigFalse: Boolean;
+  TargetDesc: TGocciaPropertyDescriptor;
+begin
+  TargetDesc := nil;
+  if ATarget is TGocciaObjectValue then
+    TargetDesc := TGocciaObjectValue(ATarget).GetOwnPropertyDescriptor(
+      APropertyLabel);
+
+  ExtensibleTarget := ProxyTargetIsExtensible(ATarget);
+  SettingConfigFalse := ADescriptor.HasConfigurableField and
+    not ADescriptor.Configurable;
+
+  if not Assigned(TargetDesc) then
+  begin
+    if (not ExtensibleTarget) or SettingConfigFalse then
+      ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [APropertyLabel]),
+        SSuggestProxyTrapInvariant);
+    Exit;
+  end;
+
+  if not IsCompatibleProxyDefineDescriptor(ExtensibleTarget, ADescriptor,
+    TargetDesc) then
+    ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [APropertyLabel]),
+      SSuggestProxyTrapInvariant);
+
+  if SettingConfigFalse and TargetDesc.Configurable then
+    ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [APropertyLabel]),
+      SSuggestProxyTrapInvariant);
+
+  if IsDataDescriptor(TargetDesc) and not TargetDesc.Configurable and
+     TargetDesc.Writable and ADescriptor.HasWritableField and
+     not ADescriptor.Writable then
+    ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [APropertyLabel]),
+      SSuggestProxyTrapInvariant);
+end;
+
+procedure ValidateProxyDefineSymbolTrapResult(
+  const ASymbol: TGocciaSymbolValue; const ATarget: TGocciaValue;
+  const ADescriptor: TGocciaPropertyDescriptor);
+var
+  ExtensibleTarget: Boolean;
+  PropertyLabel: string;
+  SettingConfigFalse: Boolean;
+  TargetDesc: TGocciaPropertyDescriptor;
+begin
+  TargetDesc := nil;
+  if ATarget is TGocciaObjectValue then
+    TargetDesc := TGocciaObjectValue(ATarget).GetOwnSymbolPropertyDescriptor(
+      ASymbol);
+
+  PropertyLabel := ASymbol.ToDisplayString.Value;
+  ExtensibleTarget := ProxyTargetIsExtensible(ATarget);
+  SettingConfigFalse := ADescriptor.HasConfigurableField and
+    not ADescriptor.Configurable;
+
+  if not Assigned(TargetDesc) then
+  begin
+    if (not ExtensibleTarget) or SettingConfigFalse then
+      ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [PropertyLabel]),
+        SSuggestProxyTrapInvariant);
+    Exit;
+  end;
+
+  if not IsCompatibleProxyDefineDescriptor(ExtensibleTarget, ADescriptor,
+    TargetDesc) then
+    ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [PropertyLabel]),
+      SSuggestProxyTrapInvariant);
+
+  if SettingConfigFalse and TargetDesc.Configurable then
+    ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [PropertyLabel]),
+      SSuggestProxyTrapInvariant);
+
+  if IsDataDescriptor(TargetDesc) and not TargetDesc.Configurable and
+     TargetDesc.Writable and ADescriptor.HasWritableField and
+     not ADescriptor.Writable then
+    ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [PropertyLabel]),
+      SSuggestProxyTrapInvariant);
+end;
+
 procedure ValidateProxyGetOwnTrapDescriptor(const APropertyLabel: string;
   const ATargetObject: TGocciaObjectValue;
   const ATargetDesc, AResultDesc: TGocciaPropertyDescriptor);
@@ -348,7 +639,31 @@ begin
   Trap := GetTrap(PROP_OWN_KEYS);
   if not Assigned(Trap) then
   begin
-    if FTarget is TGocciaObjectValue then
+    if FTarget is TGocciaProxyValue then
+    begin
+      AOrderedKeys := TGocciaProxyValue(FTarget).GetOwnPropertyKeyValues;
+      SetLength(AStringKeys, Length(AOrderedKeys));
+      SetLength(ASymbolKeys, Length(AOrderedKeys));
+      Count := 0;
+      SymbolCount := 0;
+      for I := 0 to High(AOrderedKeys) do
+      begin
+        if AOrderedKeys[I] is TGocciaStringLiteralValue then
+        begin
+          AStringKeys[Count] :=
+            TGocciaStringLiteralValue(AOrderedKeys[I]).Value;
+          Inc(Count);
+        end
+        else if AOrderedKeys[I] is TGocciaSymbolValue then
+        begin
+          ASymbolKeys[SymbolCount] := TGocciaSymbolValue(AOrderedKeys[I]);
+          Inc(SymbolCount);
+        end;
+      end;
+      SetLength(AStringKeys, Count);
+      SetLength(ASymbolKeys, SymbolCount);
+    end
+    else if FTarget is TGocciaObjectValue then
     begin
       TargetObj := TGocciaObjectValue(FTarget);
       AStringKeys := TargetObj.GetOwnPropertyKeys;
@@ -766,10 +1081,7 @@ begin
   end
   else
   begin
-    if FTarget is TGocciaObjectValue then
-      Result := TGocciaObjectValue(FTarget).HasSymbolProperty(ASymbol)
-    else
-      Result := False;
+    Result := ProxyTargetHasSymbolProperty(FTarget, ASymbol);
   end;
 end;
 
@@ -1152,45 +1464,7 @@ begin
   Trap := GetTrap(PROP_DEFINE_PROPERTY);
   if Assigned(Trap) then
   begin
-    // Build descriptor object — preserve descriptor field presence.
-    DescObj := TGocciaObjectValue.Create;
-    if ADescriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      if ADescriptor.HasGet then
-      begin
-        if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Getter) then
-          DescObj.AssignProperty(PROP_GET,
-            TGocciaPropertyDescriptorAccessor(ADescriptor).Getter)
-        else
-          DescObj.AssignProperty(PROP_GET,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-      end;
-      if ADescriptor.HasSet then
-      begin
-        if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Setter) then
-          DescObj.AssignProperty(PROP_SET,
-            TGocciaPropertyDescriptorAccessor(ADescriptor).Setter)
-        else
-          DescObj.AssignProperty(PROP_SET,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-      end;
-    end
-    else if ADescriptor is TGocciaPropertyDescriptorData then
-    begin
-      if ADescriptor.HasValue then
-        DescObj.AssignProperty(PROP_VALUE,
-          TGocciaPropertyDescriptorData(ADescriptor).Value);
-      if ADescriptor.HasWritableField then
-        DescObj.AssignProperty(PROP_WRITABLE,
-          TGocciaBooleanLiteralValue.Create(ADescriptor.Writable));
-    end;
-    if ADescriptor.HasEnumerableField then
-      DescObj.AssignProperty(PROP_ENUMERABLE,
-        TGocciaBooleanLiteralValue.Create(ADescriptor.Enumerable));
-    if ADescriptor.HasConfigurableField then
-      DescObj.AssignProperty(PROP_CONFIGURABLE,
-        TGocciaBooleanLiteralValue.Create(ADescriptor.Configurable));
-
+    DescObj := CreateProxyTrapDescriptorObject(ADescriptor);
     Args := TGocciaArgumentsCollection.Create;
     try
       Args.Add(FTarget);
@@ -1199,6 +1473,7 @@ begin
       TrapResult := InvokeTrap(Trap, Args);
       if not TrapResult.ToBooleanLiteral.Value then
         ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [AName]), SSuggestProxyTrapInvariant);
+      ValidateProxyDefineTrapResult(AName, FTarget, ADescriptor);
       ADescriptor.Free;
     finally
       Args.Free;
@@ -1227,45 +1502,7 @@ begin
   Trap := GetTrap(PROP_DEFINE_PROPERTY);
   if Assigned(Trap) then
   begin
-    // Build descriptor object — preserve descriptor field presence.
-    DescObj := TGocciaObjectValue.Create;
-    if ADescriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      if ADescriptor.HasGet then
-      begin
-        if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Getter) then
-          DescObj.AssignProperty(PROP_GET,
-            TGocciaPropertyDescriptorAccessor(ADescriptor).Getter)
-        else
-          DescObj.AssignProperty(PROP_GET,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-      end;
-      if ADescriptor.HasSet then
-      begin
-        if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Setter) then
-          DescObj.AssignProperty(PROP_SET,
-            TGocciaPropertyDescriptorAccessor(ADescriptor).Setter)
-        else
-          DescObj.AssignProperty(PROP_SET,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-      end;
-    end
-    else if ADescriptor is TGocciaPropertyDescriptorData then
-    begin
-      if ADescriptor.HasValue then
-        DescObj.AssignProperty(PROP_VALUE,
-          TGocciaPropertyDescriptorData(ADescriptor).Value);
-      if ADescriptor.HasWritableField then
-        DescObj.AssignProperty(PROP_WRITABLE,
-          TGocciaBooleanLiteralValue.Create(ADescriptor.Writable));
-    end;
-    if ADescriptor.HasEnumerableField then
-      DescObj.AssignProperty(PROP_ENUMERABLE,
-        TGocciaBooleanLiteralValue.Create(ADescriptor.Enumerable));
-    if ADescriptor.HasConfigurableField then
-      DescObj.AssignProperty(PROP_CONFIGURABLE,
-        TGocciaBooleanLiteralValue.Create(ADescriptor.Configurable));
-
+    DescObj := CreateProxyTrapDescriptorObject(ADescriptor);
     Args := TGocciaArgumentsCollection.Create;
     try
       Args.Add(FTarget);
@@ -1274,6 +1511,7 @@ begin
       TrapResult := InvokeTrap(Trap, Args);
       if not TrapResult.ToBooleanLiteral.Value then
         ThrowTypeError(Format(SErrorProxyDefineReturnedFalse, [ASymbol.ToDisplayString.Value]), SSuggestProxyTrapInvariant);
+      ValidateProxyDefineSymbolTrapResult(ASymbol, FTarget, ADescriptor);
       ADescriptor.Free;
     finally
       Args.Free;
@@ -1302,45 +1540,7 @@ begin
   Trap := GetTrap(PROP_DEFINE_PROPERTY);
   if Assigned(Trap) then
   begin
-    // Build descriptor object — preserve descriptor field presence.
-    DescObj := TGocciaObjectValue.Create;
-    if ADescriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      if ADescriptor.HasGet then
-      begin
-        if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Getter) then
-          DescObj.AssignProperty(PROP_GET,
-            TGocciaPropertyDescriptorAccessor(ADescriptor).Getter)
-        else
-          DescObj.AssignProperty(PROP_GET,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-      end;
-      if ADescriptor.HasSet then
-      begin
-        if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Setter) then
-          DescObj.AssignProperty(PROP_SET,
-            TGocciaPropertyDescriptorAccessor(ADescriptor).Setter)
-        else
-          DescObj.AssignProperty(PROP_SET,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-      end;
-    end
-    else if ADescriptor is TGocciaPropertyDescriptorData then
-    begin
-      if ADescriptor.HasValue then
-        DescObj.AssignProperty(PROP_VALUE,
-          TGocciaPropertyDescriptorData(ADescriptor).Value);
-      if ADescriptor.HasWritableField then
-        DescObj.AssignProperty(PROP_WRITABLE,
-          TGocciaBooleanLiteralValue.Create(ADescriptor.Writable));
-    end;
-    if ADescriptor.HasEnumerableField then
-      DescObj.AssignProperty(PROP_ENUMERABLE,
-        TGocciaBooleanLiteralValue.Create(ADescriptor.Enumerable));
-    if ADescriptor.HasConfigurableField then
-      DescObj.AssignProperty(PROP_CONFIGURABLE,
-        TGocciaBooleanLiteralValue.Create(ADescriptor.Configurable));
-
+    DescObj := CreateProxyTrapDescriptorObject(ADescriptor);
     Args := TGocciaArgumentsCollection.Create;
     try
       try
@@ -1349,6 +1549,8 @@ begin
         Args.Add(DescObj);
         TrapResult := InvokeTrap(Trap, Args);
         Result := TrapResult.ToBooleanLiteral.Value;
+        if Result then
+          ValidateProxyDefineTrapResult(AName, FTarget, ADescriptor);
       finally
         ADescriptor.Free;
       end;
@@ -1382,45 +1584,7 @@ begin
   Trap := GetTrap(PROP_DEFINE_PROPERTY);
   if Assigned(Trap) then
   begin
-    // Build descriptor object — preserve descriptor field presence.
-    DescObj := TGocciaObjectValue.Create;
-    if ADescriptor is TGocciaPropertyDescriptorAccessor then
-    begin
-      if ADescriptor.HasGet then
-      begin
-        if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Getter) then
-          DescObj.AssignProperty(PROP_GET,
-            TGocciaPropertyDescriptorAccessor(ADescriptor).Getter)
-        else
-          DescObj.AssignProperty(PROP_GET,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-      end;
-      if ADescriptor.HasSet then
-      begin
-        if Assigned(TGocciaPropertyDescriptorAccessor(ADescriptor).Setter) then
-          DescObj.AssignProperty(PROP_SET,
-            TGocciaPropertyDescriptorAccessor(ADescriptor).Setter)
-        else
-          DescObj.AssignProperty(PROP_SET,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-      end;
-    end
-    else if ADescriptor is TGocciaPropertyDescriptorData then
-    begin
-      if ADescriptor.HasValue then
-        DescObj.AssignProperty(PROP_VALUE,
-          TGocciaPropertyDescriptorData(ADescriptor).Value);
-      if ADescriptor.HasWritableField then
-        DescObj.AssignProperty(PROP_WRITABLE,
-          TGocciaBooleanLiteralValue.Create(ADescriptor.Writable));
-    end;
-    if ADescriptor.HasEnumerableField then
-      DescObj.AssignProperty(PROP_ENUMERABLE,
-        TGocciaBooleanLiteralValue.Create(ADescriptor.Enumerable));
-    if ADescriptor.HasConfigurableField then
-      DescObj.AssignProperty(PROP_CONFIGURABLE,
-        TGocciaBooleanLiteralValue.Create(ADescriptor.Configurable));
-
+    DescObj := CreateProxyTrapDescriptorObject(ADescriptor);
     Args := TGocciaArgumentsCollection.Create;
     try
       try
@@ -1429,6 +1593,8 @@ begin
         Args.Add(DescObj);
         TrapResult := InvokeTrap(Trap, Args);
         Result := TrapResult.ToBooleanLiteral.Value;
+        if Result then
+          ValidateProxyDefineSymbolTrapResult(ASymbol, FTarget, ADescriptor);
       finally
         ADescriptor.Free;
       end;
@@ -1544,29 +1710,15 @@ begin
 
     // ES2026 §28.1.1 step 8: If target is non-extensible, trap result
     // must be the same as the target's actual prototype.
-    if (FTarget is TGocciaObjectValue) and
-       not TGocciaObjectValue(FTarget).Extensible then
+    if not ProxyTargetIsExtensible(FTarget) then
     begin
-      if Assigned(TGocciaObjectValue(FTarget).Prototype) then
-        TargetProto := TGocciaObjectValue(FTarget).Prototype
-      else
-        TargetProto := TGocciaNullLiteralValue.NullValue;
+      TargetProto := ProxyTargetGetPrototype(FTarget);
       if Result <> TargetProto then
         ThrowTypeError(SErrorProxyGetProtoMismatch, SSuggestProxyTrapInvariant);
     end;
   end
   else
-  begin
-    if FTarget is TGocciaObjectValue then
-    begin
-      if Assigned(TGocciaObjectValue(FTarget).Prototype) then
-        Result := TGocciaObjectValue(FTarget).Prototype
-      else
-        Result := TGocciaNullLiteralValue.NullValue;
-    end
-    else
-      Result := TGocciaNullLiteralValue.NullValue;
-  end;
+    Result := ProxyTargetGetPrototype(FTarget);
 end;
 
 // ES2026 §28.1.1 [[SetPrototypeOf]](V)
@@ -1593,48 +1745,14 @@ begin
 
     // ES2026 §28.1.1 step 12: If trap returns true and target is
     // non-extensible, the new prototype must match the target's current one.
-    if Result and (FTarget is TGocciaObjectValue) and
-       not TGocciaObjectValue(FTarget).Extensible then
+    if Result and not ProxyTargetIsExtensible(FTarget) then
     begin
-      if AProto is TGocciaObjectValue then
-      begin
-        if TGocciaObjectValue(FTarget).Prototype <> TGocciaObjectValue(AProto) then
-          ThrowTypeError(SErrorProxySetProtoNonExtensible, SSuggestProxyTrapInvariant);
-      end
-      else if AProto is TGocciaNullLiteralValue then
-      begin
-        if Assigned(TGocciaObjectValue(FTarget).Prototype) then
-          ThrowTypeError(SErrorProxySetProtoNonExtensible, SSuggestProxyTrapInvariant);
-      end;
+      if ProxyTargetGetPrototype(FTarget) <> AProto then
+        ThrowTypeError(SErrorProxySetProtoNonExtensible, SSuggestProxyTrapInvariant);
     end;
   end
   else
-  begin
-    if FTarget is TGocciaObjectValue then
-    begin
-      // ES2026 §10.1.2 step 4: If target is not extensible and the new
-      // prototype differs from the current one, return false.
-      if not TGocciaObjectValue(FTarget).Extensible then
-      begin
-        if AProto is TGocciaObjectValue then
-          Result := TGocciaObjectValue(FTarget).Prototype = TGocciaObjectValue(AProto)
-        else if AProto is TGocciaNullLiteralValue then
-          Result := not Assigned(TGocciaObjectValue(FTarget).Prototype)
-        else
-          Result := False;
-      end
-      else
-      begin
-        if AProto is TGocciaObjectValue then
-          TGocciaObjectValue(FTarget).Prototype := TGocciaObjectValue(AProto)
-        else if (AProto is TGocciaNullLiteralValue) then
-          TGocciaObjectValue(FTarget).Prototype := nil;
-        Result := True;
-      end;
-    end
-    else
-      Result := False;
-  end;
+    Result := ProxyTargetSetPrototype(FTarget, AProto);
 end;
 
 // ES2026 §28.1.1 [[IsExtensible]]()
@@ -1659,24 +1777,16 @@ begin
     end;
 
     // ES2026 §28.1.1 step 7: Validate against target extensibility
-    if FTarget is TGocciaObjectValue then
-      TargetExtensible := TGocciaObjectValue(FTarget).Extensible
-    else
-      TargetExtensible := False;
+    TargetExtensible := ProxyTargetIsExtensible(FTarget);
     if Result <> TargetExtensible then
       ThrowTypeError(SErrorProxyIsExtensibleMismatch, SSuggestProxyTrapInvariant);
   end
   else
-  begin
-    if FTarget is TGocciaObjectValue then
-      Result := TGocciaObjectValue(FTarget).Extensible
-    else
-      Result := False;
-  end;
+    Result := ProxyTargetIsExtensible(FTarget);
 end;
 
 // ES2026 §28.1.1 [[PreventExtensions]]()
-procedure TGocciaProxyValue.PreventExtensions;
+function TGocciaProxyValue.TryPreventExtensionsTrap: Boolean;
 var
   Trap: TGocciaValue;
   Args: TGocciaArgumentsCollection;
@@ -1690,23 +1800,30 @@ begin
     try
       Args.Add(FTarget);
       TrapResult := InvokeTrap(Trap, Args);
-      if not TrapResult.ToBooleanLiteral.Value then
-        ThrowTypeError(SErrorProxyPreventExtensionsFalse, SSuggestProxyTrapInvariant);
+      Result := TrapResult.ToBooleanLiteral.Value;
     finally
       Args.Free;
     end;
 
-    // ES2026 §28.1.1 step 8: Invariant — if trap returned true, target
-    // must actually be non-extensible now.
-    if (FTarget is TGocciaObjectValue) and
-       TGocciaObjectValue(FTarget).Extensible then
+    if Result and ProxyTargetIsExtensible(FTarget) then
       ThrowTypeError(SErrorProxyPreventExtensionsStillExtensible, SSuggestProxyTrapInvariant);
   end
   else
   begin
-    if FTarget is TGocciaObjectValue then
-      TGocciaObjectValue(FTarget).PreventExtensions;
+    if FTarget is TGocciaProxyValue then
+      Exit(TGocciaProxyValue(FTarget).TryPreventExtensionsTrap);
+    if not (FTarget is TGocciaObjectValue) then
+      Exit(False);
+    TGocciaObjectValue(FTarget).PreventExtensions;
+    Result := True;
   end;
+end;
+
+procedure TGocciaProxyValue.PreventExtensions;
+begin
+  if not TryPreventExtensionsTrap then
+    ThrowTypeError(SErrorProxyPreventExtensionsFalse,
+      SSuggestProxyTrapInvariant);
 end;
 
 // ES2026 §28.1.1 [[Call]](thisArgument, argumentsList)
@@ -1917,8 +2034,29 @@ begin
   Result := TGocciaProxyValue(AProxy).GetPrototypeTrap;
 end;
 
+function DispatchProxyGetFunctionRealm(
+  const AProxy: TGocciaValue): TGocciaRealm;
+var
+  Proxy: TGocciaProxyValue;
+begin
+  Proxy := TGocciaProxyValue(AProxy);
+  Proxy.CheckRevoked;
+
+  if Proxy.FTarget is TGocciaProxyValue then
+    Exit(DispatchProxyGetFunctionRealm(Proxy.FTarget));
+
+  if Proxy.FTarget is TGocciaFunctionBase then
+    Exit(TGocciaFunctionBase(Proxy.FTarget).CreationRealm);
+
+  if Proxy.FTarget is TGocciaClassValue then
+    Exit(TGocciaClassValue(Proxy.FTarget).CreationRealm);
+
+  Result := nil;
+end;
+
 initialization
   RegisterProxyDispatchHooks(IsProxyDispatchValue, DispatchProxyApply,
-    DispatchProxyConstruct, DispatchProxyGetPrototype);
+    DispatchProxyConstruct, DispatchProxyGetPrototype,
+    DispatchProxyGetFunctionRealm);
 
 end.

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -203,6 +203,20 @@ begin
   end;
 end;
 
+function CreateStringLengthDescriptor(
+  const APrimitive: TGocciaStringLiteralValue;
+  const AName: string): TGocciaPropertyDescriptor;
+begin
+  Result := nil;
+  if AName <> PROP_LENGTH then
+    Exit;
+
+  Result := TGocciaPropertyDescriptorData.Create(
+    TGocciaNumberLiteralValue.Create(
+      UTF16CodeUnitLength(APrimitive.ToStringLiteral.Value)),
+    []);
+end;
+
 function LocaleCompareArgumentToLocale(const AArg: TGocciaValue): string;
 var
   Element: TGocciaValue;
@@ -714,6 +728,8 @@ var
   ExistingDescriptor: TGocciaPropertyDescriptor;
 begin
   ExistingDescriptor := CreateStringIndexDescriptor(FPrimitive, AName);
+  if not Assigned(ExistingDescriptor) then
+    ExistingDescriptor := CreateStringLengthDescriptor(FPrimitive, AName);
   try
     if Assigned(ExistingDescriptor) and
        not IsCompatibleStringDefineDescriptor(ExistingDescriptor,
@@ -740,6 +756,8 @@ var
   ExistingDescriptor: TGocciaPropertyDescriptor;
 begin
   ExistingDescriptor := CreateStringIndexDescriptor(FPrimitive, AName);
+  if not Assigned(ExistingDescriptor) then
+    ExistingDescriptor := CreateStringLengthDescriptor(FPrimitive, AName);
   try
     if Assigned(ExistingDescriptor) and
        not IsCompatibleStringDefineDescriptor(ExistingDescriptor,
@@ -835,7 +853,6 @@ begin
 
   Members := TGocciaMemberCollection.Create;
   try
-    Members.AddAccessor(PROP_LENGTH, StringLength, nil, []);
     Members.AddMethod(StringCharAt, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(StringCharCodeAt, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(StringToUpperCase, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -32,7 +32,12 @@ type
     function GetEnumerablePropertyValues: TArray<TGocciaValue>; override;
     function GetEnumerablePropertyEntries: TArray<TPair<string, TGocciaValue>>; override;
     function GetAllPropertyNames: TArray<string>; override;
+    function GetOwnPropertyKeys: TArray<string>; override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
+    procedure DefineProperty(const AName: string;
+      const ADescriptor: TGocciaPropertyDescriptor); override;
+    function TryDefineProperty(const AName: string;
+      const ADescriptor: TGocciaPropertyDescriptor): Boolean; override;
     function HasOwnProperty(const AName: string): Boolean; override;
     function DeleteProperty(const AName: string): Boolean; override;
 
@@ -101,6 +106,7 @@ uses
   IntlTypes,
   TextSemantics,
 
+  Goccia.Arithmetic,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
@@ -132,6 +138,69 @@ begin
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GStringPrototypeSlot))
   else
     Result := nil;
+end;
+
+function IsCompatibleStringDefineDescriptor(
+  const ACurrent: TGocciaPropertyDescriptor;
+  const ADescriptor: TGocciaPropertyDescriptor): Boolean;
+var
+  CurrentData: TGocciaPropertyDescriptorData;
+  DescriptorData: TGocciaPropertyDescriptorData;
+begin
+  if not Assigned(ACurrent) then
+    Exit(True);
+
+  if ADescriptor.Fields = [] then
+    Exit(True);
+
+  if ADescriptor.HasConfigurableField and ADescriptor.Configurable then
+    Exit(False);
+
+  if ADescriptor.HasEnumerableField and
+     (ACurrent.Enumerable <> ADescriptor.Enumerable) then
+    Exit(False);
+
+  if IsGenericDescriptor(ADescriptor) then
+    Exit(True);
+
+  if IsDataDescriptor(ACurrent) <> IsDataDescriptor(ADescriptor) then
+    Exit(False);
+
+  if IsAccessorDescriptor(ACurrent) then
+    Exit(False);
+
+  CurrentData := TGocciaPropertyDescriptorData(ACurrent);
+  DescriptorData := TGocciaPropertyDescriptorData(ADescriptor);
+  if not CurrentData.Writable then
+  begin
+    if ADescriptor.HasWritableField and DescriptorData.Writable then
+      Exit(False);
+    if ADescriptor.HasValue and
+       not IsSameValue(CurrentData.Value, DescriptorData.Value) then
+      Exit(False);
+  end;
+
+  Result := True;
+end;
+
+function CreateStringIndexDescriptor(
+  const APrimitive: TGocciaStringLiteralValue;
+  const AName: string): TGocciaPropertyDescriptor;
+var
+  Index: Integer;
+  StringValue: string;
+begin
+  Result := nil;
+  // Canonical decimal string indices only; StringGetOwnProperty does not cover
+  // "length", which is an ordinary own property created separately.
+  if TryStrToInt(AName, Index) and (AName = IntToStr(Index)) then
+  begin
+    StringValue := APrimitive.ToStringLiteral.Value;
+    if (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue)) then
+      Result := TGocciaPropertyDescriptorData.Create(
+        TGocciaStringLiteralValue.Create(UTF16CodeUnitAt(StringValue, Index)),
+        [pfEnumerable]);
+  end;
 end;
 
 function LocaleCompareArgumentToLocale(const AArg: TGocciaValue): string;
@@ -611,26 +680,21 @@ begin
   end;
 end;
 
+function TGocciaStringObjectValue.GetOwnPropertyKeys: TArray<string>;
+begin
+  Result := GetAllPropertyNames;
+end;
+
 // ES2026 §10.4.3.1 StringExoticObject [[GetOwnProperty]](P)
 function TGocciaStringObjectValue.GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor;
-var
-  Index: Integer;
-  StringValue: string;
 begin
-  // Only canonical non-negative decimal integers are string indices (e.g. "0", "1",
-  // not "01" or "-0"). AName = IntToStr(Index) ensures round-trip canonicality.
-  if TryStrToInt(AName, Index) and (AName = IntToStr(Index)) then
-  begin
-    StringValue := FPrimitive.ToStringLiteral.Value;
-    if (Index >= 0) and (Index < UTF16CodeUnitLength(StringValue)) then
-    begin
-      // String character indices: enumerable, non-writable, non-configurable
-      Result := TGocciaPropertyDescriptorData.Create(
-        TGocciaStringLiteralValue.Create(UTF16CodeUnitAt(StringValue, Index)),
-        [pfEnumerable]);
-      Exit;
-    end;
-  end;
+  Result := inherited GetOwnPropertyDescriptor(AName);
+  if Assigned(Result) then
+    Exit;
+
+  Result := CreateStringIndexDescriptor(FPrimitive, AName);
+  if Assigned(Result) then
+    Exit;
 
   if AName = PROP_LENGTH then
   begin
@@ -641,8 +705,60 @@ begin
       []);
     Exit;
   end;
+end;
 
-  Result := inherited GetOwnPropertyDescriptor(AName);
+// ES2026 §10.4.3.2 StringExoticObject [[DefineOwnProperty]](P, Desc)
+procedure TGocciaStringObjectValue.DefineProperty(const AName: string;
+  const ADescriptor: TGocciaPropertyDescriptor);
+var
+  ExistingDescriptor: TGocciaPropertyDescriptor;
+begin
+  ExistingDescriptor := CreateStringIndexDescriptor(FPrimitive, AName);
+  try
+    if Assigned(ExistingDescriptor) and
+       not IsCompatibleStringDefineDescriptor(ExistingDescriptor,
+         ADescriptor) then
+      ThrowTypeError(Format(SErrorCannotRedefineNonConfigurable, [AName]),
+        SSuggestCannotDeleteNonConfigurable);
+    if Assigned(ExistingDescriptor) then
+    begin
+      ADescriptor.Free;
+      Exit;
+    end;
+  finally
+    if Assigned(ExistingDescriptor) then
+      ExistingDescriptor.Free;
+  end;
+
+  inherited DefineProperty(AName, ADescriptor);
+end;
+
+// ES2026 §10.4.3.2 StringExoticObject [[DefineOwnProperty]](P, Desc)
+function TGocciaStringObjectValue.TryDefineProperty(const AName: string;
+  const ADescriptor: TGocciaPropertyDescriptor): Boolean;
+var
+  ExistingDescriptor: TGocciaPropertyDescriptor;
+begin
+  ExistingDescriptor := CreateStringIndexDescriptor(FPrimitive, AName);
+  try
+    if Assigned(ExistingDescriptor) and
+       not IsCompatibleStringDefineDescriptor(ExistingDescriptor,
+         ADescriptor) then
+    begin
+      ADescriptor.Free;
+      Exit(False);
+    end;
+    if Assigned(ExistingDescriptor) then
+    begin
+      ADescriptor.Free;
+      Exit(True);
+    end;
+  finally
+    if Assigned(ExistingDescriptor) then
+      ExistingDescriptor.Free;
+  end;
+
+  Result := inherited TryDefineProperty(AName, ADescriptor);
 end;
 
 // ES2026 §10.4.3.1 StringExoticObject [[GetOwnProperty]](P) — existence check

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -2908,9 +2908,7 @@ begin
   if ProtoValue is TGocciaObjectValue then
     Exit(TGocciaObjectValue(ProtoValue));
 
-  FallbackRealm := nil;
-  if ANewTarget is TGocciaFunctionBase then
-    FallbackRealm := TGocciaFunctionBase(ANewTarget).CreationRealm;
+  FallbackRealm := GetFunctionRealm(ANewTarget);
 
   if Assigned(FallbackRealm) and
      (FallbackRealm.GlobalEnv is TGocciaScope) then

--- a/tests/built-ins/Object/freeze.js
+++ b/tests/built-ins/Object/freeze.js
@@ -135,6 +135,30 @@ describe("Object.freeze", () => {
     expect(arr[0]).toBe("a");
   });
 
+  test("freezing String objects preserves virtual indices and length", () => {
+    const str = new String("abc");
+    str.foo = 10;
+
+    Object.freeze(str);
+
+    const index = Object.getOwnPropertyDescriptor(str, "0");
+    const length = Object.getOwnPropertyDescriptor(str, "length");
+    const foo = Object.getOwnPropertyDescriptor(str, "foo");
+
+    expect(Object.isFrozen(str)).toBe(true);
+    expect(index.value).toBe("a");
+    expect(index.writable).toBe(false);
+    expect(index.enumerable).toBe(true);
+    expect(index.configurable).toBe(false);
+    expect(length.value).toBe(3);
+    expect(length.writable).toBe(false);
+    expect(length.enumerable).toBe(false);
+    expect(length.configurable).toBe(false);
+    expect(foo.value).toBe(10);
+    expect(foo.writable).toBe(false);
+    expect(foo.configurable).toBe(false);
+  });
+
   test("proxy freeze does not pass a value field in data descriptors", () => {
     const seen = [];
     const target = { value: 1 };

--- a/tests/built-ins/Object/seal.js
+++ b/tests/built-ins/Object/seal.js
@@ -28,4 +28,28 @@ describe("Object.seal", () => {
     Object.seal(obj);
     expect(Object.isExtensible(obj)).toBe(false);
   });
+
+  test("sealing String objects preserves virtual indices and length", () => {
+    const str = new String("abc");
+    str.foo = 10;
+
+    Object.seal(str);
+
+    const index = Object.getOwnPropertyDescriptor(str, "0");
+    const length = Object.getOwnPropertyDescriptor(str, "length");
+    const foo = Object.getOwnPropertyDescriptor(str, "foo");
+
+    expect(Object.isSealed(str)).toBe(true);
+    expect(index.value).toBe("a");
+    expect(index.writable).toBe(false);
+    expect(index.enumerable).toBe(true);
+    expect(index.configurable).toBe(false);
+    expect(length.value).toBe(3);
+    expect(length.writable).toBe(false);
+    expect(length.enumerable).toBe(false);
+    expect(length.configurable).toBe(false);
+    expect(foo.value).toBe(10);
+    expect(foo.writable).toBe(true);
+    expect(foo.configurable).toBe(false);
+  });
 });

--- a/tests/built-ins/Proxy/defineProperty.js
+++ b/tests/built-ins/Proxy/defineProperty.js
@@ -53,12 +53,12 @@ describe("Proxy defineProperty trap", () => {
       value: 123,
       writable: false,
       enumerable: true,
-      configurable: false,
+      configurable: true,
     });
     expect(receivedDescriptor.value).toBe(123);
     expect(receivedDescriptor.writable).toBe(false);
     expect(receivedDescriptor.enumerable).toBe(true);
-    expect(receivedDescriptor.configurable).toBe(false);
+    expect(receivedDescriptor.configurable).toBe(true);
   });
 
   test("preserves omitted descriptor fields", () => {

--- a/tests/built-ins/Proxy/getOwnPropertyDescriptor.js
+++ b/tests/built-ins/Proxy/getOwnPropertyDescriptor.js
@@ -67,6 +67,29 @@ describe("Proxy getOwnPropertyDescriptor trap", () => {
     expect(() => Object.getOwnPropertyDescriptor(proxy, "x")).toThrow(TypeError);
   });
 
+  test("applies non-extensible target invariants through nested proxies", () => {
+    const target = {};
+    Object.preventExtensions(target);
+
+    const inner = new Proxy(target, {
+      isExtensible() {
+        return false;
+      },
+    });
+    const outer = new Proxy(inner, {
+      getOwnPropertyDescriptor() {
+        return {
+          value: 1,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        };
+      },
+    });
+
+    expect(() => Object.getOwnPropertyDescriptor(outer, "x")).toThrow(TypeError);
+  });
+
   test("rejects incompatible descriptors for non-configurable target properties", () => {
     const target = {};
     Object.defineProperty(target, "x", {

--- a/tests/built-ins/Proxy/ownKeys.js
+++ b/tests/built-ins/Proxy/ownKeys.js
@@ -48,6 +48,24 @@ describe("Proxy ownKeys trap", () => {
     expect(keys).toEqual(["virtual1", "virtual2"]);
   });
 
+  test("rejects extra keys through nested non-extensible proxy targets", () => {
+    const target = {};
+    Object.preventExtensions(target);
+
+    const inner = new Proxy(target, {
+      isExtensible() {
+        return false;
+      },
+    });
+    const outer = new Proxy(inner, {
+      ownKeys() {
+        return ["x"];
+      },
+    });
+
+    expect(() => Reflect.ownKeys(outer)).toThrow(TypeError);
+  });
+
   test("rejects duplicate symbol entries even when caller filters strings", () => {
     const symbol = Symbol("duplicate");
     const proxy = new Proxy({}, {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Implement missing Proxy internal-method forwarding and invariant checks for `defineProperty`, prototype/extensibility operations, own-key forwarding, symbols, revocation, and recursive function realm lookup.
- Align String exotic own-property behavior so Proxy targets expose virtual string indices and `Object.freeze`/`Object.seal` handle boxed String virtual `length` descriptors without trying to add properties after `PreventExtensions`.
- Keep descriptor conversion/result ordering observable through proxies, including nested proxy extensibility invariants for `getOwnPropertyDescriptor` and `ownKeys`.
- Sync with `origin/main` after the Reflect/Object and Iterator conformance follow-ups.
- Preserve class newTarget creation realms in `GetFunctionRealm`, including a Pascal regression for direct class realm lookup.
- Add native coverage for the TGocciaFunctionBase, registered proxy hook, and nil fallback paths in `GetFunctionRealm`.
- Extend native `GetFunctionRealm` coverage so revoked proxy realm lookup propagates a JS `TypeError` instead of returning a realm.
- Closes #842.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation run:

- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH ./build.pas tests` -> Tests built successfully
- `./build/Goccia.Values.FunctionBase.Test` -> 5/5 passed
- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH ./build.pas testrunner` -> built successfully
- `./build/GocciaTestRunner tests/built-ins/Reflect/construct/native-constructors.js tests/built-ins/Proxy/construct.js tests/built-ins/Proxy/defineProperty.js tests/built-ins/Proxy/getOwnPropertyDescriptor.js tests/built-ins/Proxy/ownKeys.js tests/built-ins/Object/freeze.js tests/built-ins/Object/seal.js` -> 77/77 passed
- `./build/GocciaTestRunner tests/built-ins/Reflect/construct/native-constructors.js tests/built-ins/Proxy/construct.js tests/built-ins/Proxy/defineProperty.js tests/built-ins/Proxy/getOwnPropertyDescriptor.js tests/built-ins/Proxy/ownKeys.js tests/built-ins/Object/freeze.js tests/built-ins/Object/seal.js --mode=bytecode` -> 77/77 passed
- `./build/GocciaTestRunner tests` -> 11176/11176 passed
- `./build/GocciaTestRunner tests --mode=bytecode` -> 11176/11176 passed
- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH ./format.pas --check` -> 379 files checked, all formatted correctly

Latest refresh after revoked-proxy review nitpick:

- `./build.pas --clean tests` -> Tests built successfully
- `./build/Goccia.Values.FunctionBase.Test` -> 5/5 passed
- `./format.pas --check` -> 379 files checked, all formatted correctly
- `git diff --check` -> no whitespace errors

Latest refresh after review nitpick:

- `./build.pas --clean tests` -> Tests built successfully
- `./build/Goccia.Values.FunctionBase.Test` -> 5/5 passed
- `./format.pas --check` -> 379 files checked, all formatted correctly
- `git diff --check` -> no whitespace errors
- `./build.pas testrunner` -> GocciaTestRunner built successfully
- `./build/GocciaTestRunner tests` -> 11200/11200 passed
- `./build/GocciaTestRunner tests --mode=bytecode` -> 11200/11200 passed

- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH ./build.pas --clean testrunner`
- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH ./build/GocciaTestRunner tests` -> 11176/11176 passed
- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH ./build/GocciaTestRunner tests --mode=bytecode` -> 11176/11176 passed
- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH ./format.pas --check` -> 378 files checked, all formatted correctly
- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH ./build.pas loaderbare`
- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-main --filter "built-ins/Object/freeze/15.2.3.9-2-a-12.js" --jobs=1 --timeout-ms=20000 --output /tmp/goccia-test262-freeze-a12-pr.json` -> 1/1 passed, 0 wrapper infra
- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-main --filter "built-ins/Object/freeze/15.2.3.9-2-a-8.js" --jobs=1 --timeout-ms=20000 --output /tmp/goccia-test262-freeze-a8-pr.json` -> 1/1 passed, 0 wrapper infra
- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-main --filter "built-ins/Object/freeze/15.2.3.9-2-d-3.js" --jobs=1 --timeout-ms=20000 --output /tmp/goccia-test262-freeze-d3-pr.json` -> 1/1 passed, 0 wrapper infra
- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-main --filter "built-ins/Object/seal/object-seal-o-is-a-string-object.js" --jobs=1 --timeout-ms=20000 --output /tmp/goccia-test262-seal-o-string-pr.json` -> 1/1 passed, 0 wrapper infra
- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-main --filter "built-ins/Object/seal/object-seal-p-is-own-property-of-a-string-object-which-implements-its-own-get-own-property.js" --jobs=1 --timeout-ms=20000 --output /tmp/goccia-test262-seal-p-string-pr.json` -> 1/1 passed, 0 wrapper infra
- `PATH=/Users/jstein/.bun/bin:/usr/local/bin:/opt/homebrew/bin:$PATH bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-main --filter "built-ins/Object/seal/seal-string.js" --jobs=1 --timeout-ms=20000 --output /tmp/goccia-test262-seal-string-pr.json` -> 1/1 passed, 0 wrapper infra
- Earlier Proxy-focused validation: `bun scripts/run_test262_suite.ts --filter "built-ins/Proxy/**" --mode=bytecode --jobs=4 --timeout-ms=20000 --output=/tmp/goccia-proxy-builtins-update-pr.json` -> 311/311 passed, 0 wrapper infra
- Earlier Proxy-focused validation: `bun scripts/run_test262_suite.ts --filter "staging/sm/Proxy/**" --mode=bytecode --jobs=4 --timeout-ms=20000 --output=/tmp/goccia-proxy-staging-update-pr.json` -> 24/24 passed, 0 wrapper infra
- Review repros for nested proxy `getOwnPropertyDescriptor` and `ownKeys` non-extensible target invariants now throw `TypeError`
- Earlier broader Proxy-adjacent mini-suite: `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-proxy-mini --mode=bytecode --jobs=4 --timeout-ms=20000 --output=/tmp/goccia-proxy-body-beyond-direct-results-postlocal.json` -> 305/334 passed; remaining failures are outside the direct Proxy issue surface (Iterator helpers, Set methods, Reflect/Object SpiderMonkey behavior gaps, RegExp escaping, TypedArray expected-error shape, Math.sin arity)

