### PR TITLE
fix(iterator): complete iterator helper conformance

### DIFF
--- a/benchmarks/iterators.js
+++ b/benchmarks/iterators.js
@@ -233,9 +233,9 @@ suite("Iterator.concat", () => {
     },
   });
 
-  bench("concat strings (13 + 13 characters)", {
+  bench("concat boxed strings (13 + 13 characters)", {
     run: () => {
-      const result = Iterator.concat("abcdefghijklm", "nopqrstuvwxyz").toArray();
+      const result = Iterator.concat(Object("abcdefghijklm"), Object("nopqrstuvwxyz")).toArray();
     },
   });
 });

--- a/source/units/Goccia.Intrinsics.FunctionObjects.pas
+++ b/source/units/Goccia.Intrinsics.FunctionObjects.pas
@@ -34,6 +34,8 @@ type
 
     function AsyncIteratorSelf(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
+    function AsyncIteratorAsyncDispose(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
     function CreateHiddenFunctionConstructor(const AName: string;
       const AFunctionPrototype, AConstructorPrototype: TGocciaObjectValue;
       const AKind: TGocciaDynamicFunctionKind):
@@ -74,11 +76,16 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.GarbageCollector,
   Goccia.Realm,
+  Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
   Goccia.Values.GeneratorValue,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.SymbolValue;
+  Goccia.Values.PromiseValue,
+  Goccia.Values.SymbolValue,
+  Goccia.VM.Exception;
 
 var
   GFunctionObjectIntrinsicsSlot: TGocciaRealmOwnedSlotId;
@@ -88,6 +95,20 @@ var
   GAsyncIteratorPrototypeSlot: TGocciaRealmSlotId;
   GAsyncGeneratorFunctionPrototypeSlot: TGocciaRealmSlotId;
   GAsyncGeneratorPrototypeSlot: TGocciaRealmSlotId;
+
+type
+  TGocciaAsyncDisposeFulfillHandler = class(TGocciaObjectValue)
+  public
+    function Invoke(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+function TGocciaAsyncDisposeFulfillHandler.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
 
 procedure RequirePrototype(const APrototype: TGocciaObjectValue;
   const AName: string);
@@ -117,6 +138,78 @@ function TGocciaFunctionObjectIntrinsics.AsyncIteratorSelf(
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
   Result := AThisValue;
+end;
+
+function TGocciaFunctionObjectIntrinsics.AsyncIteratorAsyncDispose(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Promise: TGocciaPromiseValue;
+  Awaited: TGocciaPromiseValue;
+  ReturnMethod: TGocciaValue;
+  ReturnResult: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
+  FulfillHost: TGocciaAsyncDisposeFulfillHandler;
+  FulfillFn: TGocciaNativeFunctionValue;
+  GC: TGarbageCollector;
+begin
+  Promise := TGocciaPromiseValue.Create;
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) then
+    GC.AddTempRoot(Promise);
+  try
+    try
+      if not (AThisValue is TGocciaObjectValue) then
+        ThrowTypeError('AsyncIterator.prototype[Symbol.asyncDispose] called on non-object');
+
+      ReturnMethod := TGocciaObjectValue(AThisValue).GetProperty(PROP_RETURN);
+      if (not Assigned(ReturnMethod)) or
+         (ReturnMethod is TGocciaUndefinedLiteralValue) or
+         (ReturnMethod is TGocciaNullLiteralValue) then
+      begin
+        Promise.Resolve(TGocciaUndefinedLiteralValue.UndefinedValue);
+        Exit(Promise);
+      end;
+      if not ReturnMethod.IsCallable then
+        ThrowTypeError('Async iterator return must be callable');
+
+      CallArgs := TGocciaArgumentsCollection.Create;
+      try
+        ReturnResult := DispatchCall(ReturnMethod, CallArgs, AThisValue);
+      finally
+        CallArgs.Free;
+      end;
+    except
+      on E: EGocciaBytecodeThrow do
+      begin
+        Promise.Reject(E.ThrownValue);
+        Exit(Promise);
+      end;
+      on E: TGocciaThrowValue do
+      begin
+        Promise.Reject(E.Value);
+        Exit(Promise);
+      end;
+    end;
+
+    Awaited := TGocciaPromiseValue.Create;
+    if Assigned(GC) then
+      GC.AddTempRoot(Awaited);
+    try
+      Awaited.Resolve(ReturnResult);
+      FulfillHost := TGocciaAsyncDisposeFulfillHandler.Create;
+      FulfillFn := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+        FulfillHost.Invoke, '', 1);
+      FulfillFn.CapturedRoot := FulfillHost;
+      Result := Awaited.InvokeThen(FulfillFn, nil);
+    finally
+      if Assigned(GC) then
+        GC.RemoveTempRoot(Awaited);
+    end;
+  finally
+    if Assigned(GC) then
+      GC.RemoveTempRoot(Promise);
+  end;
 end;
 
 function TGocciaFunctionObjectIntrinsics.CreateHiddenFunctionConstructor(
@@ -271,6 +364,12 @@ begin
       TGocciaPropertyDescriptorData.Create(
         TGocciaNativeFunctionValue.CreateWithoutPrototype(
           AsyncIteratorSelf, '[Symbol.asyncIterator]', 0),
+        [pfConfigurable, pfWritable]));
+    AsyncIteratorPrototype.DefineSymbolProperty(
+      TGocciaSymbolValue.WellKnownAsyncDispose,
+      TGocciaPropertyDescriptorData.Create(
+        TGocciaNativeFunctionValue.CreateWithoutPrototype(
+          AsyncIteratorAsyncDispose, '[Symbol.asyncDispose]', 0),
         [pfConfigurable, pfWritable]));
 
     FunctionPrototype.DefineProperty(PROP_PROTOTYPE,

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -8386,9 +8386,9 @@ begin
         Consume(gttRightBracket, 'Expected "]" after computed property key',
           SSuggestCloseBracketComputedPropertyKey);
       end
-      else if Check(gttIdentifier) then
+      else if IsIdentifierNameToken(Peek.TokenType) then
       begin
-        CanUseShorthand := True;
+        CanUseShorthand := IsIdentifierBindingToken(Peek.TokenType);
         Key := Advance.Lexeme;
       end
       else if Check(gttString) then

--- a/source/units/Goccia.Values.Iterator.Concat.pas
+++ b/source/units/Goccia.Values.Iterator.Concat.pas
@@ -248,12 +248,14 @@ end;
 
 procedure TGocciaConcatIteratorValue.Close;
 begin
-  inherited;
+  if FDone then
+    Exit;
   if Assigned(FCurrentIterator) then
   begin
     FCurrentIterator.Close;
     FCurrentIterator := nil;
   end;
+  inherited;
 end;
 
 procedure TGocciaConcatIteratorValue.MarkReferences;

--- a/source/units/Goccia.Values.Iterator.Generic.pas
+++ b/source/units/Goccia.Values.Iterator.Generic.pas
@@ -11,7 +11,7 @@ uses
 
 type
   TGocciaGenericIteratorValue = class(TGocciaIteratorValue)
-  private
+  protected
     FSource: TGocciaValue;
     // Captured at construction per ES2024 §7.4.2 GetIteratorDirect:
     // the iterator record's [[NextMethod]] is the result of `GetV(obj,
@@ -367,6 +367,12 @@ begin
         ThrowTypeError(SErrorIteratorReturnObject, SSuggestIteratorResultObject);
       ReturnResultWasRooted := AddTempRootIfNeeded(ReturnResult);
       try
+        if not AHasValue then
+        begin
+          FDone := True;
+          Result := TGocciaObjectValue(ReturnResult);
+          Exit;
+        end;
         // ES2026 §15.5.5 YieldExpression : yield * AssignmentExpression:
         // return() results with done:false are yielded and may resume delegation.
         DoneValue := TGocciaObjectValue(ReturnResult).GetProperty(PROP_DONE);

--- a/source/units/Goccia.Values.Iterator.Zip.pas
+++ b/source/units/Goccia.Values.Iterator.Zip.pas
@@ -18,7 +18,9 @@ type
     FPadding: array of TGocciaValue;
     FMode: TGocciaZipMode;
     FExhausted: array of Boolean;
-    procedure CloseAllIterators;
+    FStarted: Boolean;
+    procedure CloseAllIterators(const APreserveError: Boolean = True;
+      const AExcludeIndex: Integer = -1);
   protected
     function DoAdvanceNext: TGocciaObjectValue; override;
     function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
@@ -31,17 +33,19 @@ type
 
   TGocciaZipKeyedIteratorValue = class(TGocciaIteratorHelperValue)
   private
-    FKeys: array of string;
+    FKeys: array of TGocciaValue;
     FIterators: array of TGocciaIteratorValue;
     FPadding: array of TGocciaValue;
     FMode: TGocciaZipMode;
     FExhausted: array of Boolean;
-    procedure CloseAllIterators;
+    FStarted: Boolean;
+    procedure CloseAllIterators(const APreserveError: Boolean = True;
+      const AExcludeIndex: Integer = -1);
   protected
     function DoAdvanceNext: TGocciaObjectValue; override;
     function DoDirectNext(out ADone: Boolean): TGocciaValue; override;
   public
-    constructor Create(const AKeys: array of string;
+    constructor Create(const AKeys: array of TGocciaValue;
       const AIterators: array of TGocciaIteratorValue;
       const APadding: array of TGocciaValue; const AMode: TGocciaZipMode);
     procedure Close; override;
@@ -53,12 +57,15 @@ function GetIteratorFromIterable(const AValue: TGocciaValue): TGocciaIteratorVal
 implementation
 
 uses
+  SysUtils,
+
   Goccia.Arguments.Collection,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
+  Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.Iterator.Concrete,
@@ -185,20 +192,46 @@ begin
   for I := 0 to High(APadding) do
     FPadding[I] := APadding[I];
   FMode := AMode;
+  FStarted := False;
   SetLength(FExhausted, Length(AIterators));
   for I := 0 to High(FExhausted) do
     FExhausted[I] := False;
 end;
 
-procedure TGocciaZipIteratorValue.CloseAllIterators;
+procedure TGocciaZipIteratorValue.CloseAllIterators(
+  const APreserveError: Boolean; const AExcludeIndex: Integer);
 var
   I: Integer;
+  FirstException: Exception;
+  HasFirstError: Boolean;
 begin
-  for I := 0 to High(FIterators) do
+  HasFirstError := False;
+  FirstException := nil;
+  for I := High(FIterators) downto 0 do
   begin
-    if not FExhausted[I] then
-      CloseIteratorPreservingError(FIterators[I]);
+    if (I <> AExcludeIndex) and not FExhausted[I] then
+    begin
+      if APreserveError then
+        CloseIteratorPreservingError(FIterators[I])
+      else
+      begin
+        try
+          FIterators[I].Close;
+        except
+          on E: Exception do
+          begin
+            if not HasFirstError then
+            begin
+              HasFirstError := True;
+              FirstException := Exception(AcquireExceptionObject);
+            end;
+          end;
+        end;
+      end;
+    end;
   end;
+  if HasFirstError then
+    raise FirstException;
 end;
 
 // TC39 Joint Iteration §1.1 Iterator.zip(iterables [, options])
@@ -221,10 +254,11 @@ end;
 function TGocciaZipIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 var
   ResultArray: TGocciaArrayValue;
+  InnerResult: TGocciaObjectValue;
   I: Integer;
   InnerValue: TGocciaValue;
   InnerDone: Boolean;
-  AnyDone, AllDone: Boolean;
+  AnyDone, AllDone, HadDoneBefore: Boolean;
 begin
   if Length(FIterators) = 0 then
   begin
@@ -233,6 +267,7 @@ begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
+  FStarted := True;
 
   ResultArray := TGocciaArrayValue.Create;
   TGarbageCollector.Instance.AddTempRoot(ResultArray);
@@ -253,19 +288,57 @@ begin
         Continue;
       end;
 
+      if (FMode = zmStrict) and AnyDone then
+      begin
+        try
+          InnerResult := FIterators[I].AdvanceNext;
+          InnerDone := IteratorResultDone(InnerResult);
+        except
+          AcquireExceptionObject;
+          CloseAllIterators(True, I);
+          FDone := True;
+          raise;
+        end;
+        if InnerDone then
+        begin
+          FExhausted[I] := True;
+          Continue;
+        end;
+        CloseAllIterators(True);
+        FDone := True;
+        ThrowTypeError(SErrorIteratorZipStrictLengthMismatch,
+          SSuggestIteratorZipMode);
+      end;
+
       try
         InnerValue := FIterators[I].DirectNext(InnerDone);
       except
         AcquireExceptionObject;
-        CloseAllIterators;
+        CloseAllIterators(True, I);
         FDone := True;
         raise;
       end;
 
       if InnerDone then
       begin
+        HadDoneBefore := AnyDone;
         FExhausted[I] := True;
         AnyDone := True;
+        if FMode = zmShortest then
+        begin
+          CloseAllIterators(False);
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+        if (FMode = zmStrict) and (I <> 0) and not HadDoneBefore then
+        begin
+          CloseAllIterators(True, I);
+          FDone := True;
+          ThrowTypeError(SErrorIteratorZipStrictLengthMismatch,
+            SSuggestIteratorZipMode);
+        end;
         if I < Length(FPadding) then
           ResultArray.Elements.Add(FPadding[I])
         else
@@ -286,7 +359,7 @@ begin
       begin
         if AnyDone then
         begin
-          CloseAllIterators;
+          CloseAllIterators(False);
           FDone := True;
           ADone := True;
           Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -307,7 +380,7 @@ begin
       begin
         if AnyDone and not AllDone then
         begin
-          CloseAllIterators;
+          CloseAllIterators(True);
           FDone := True;
           ThrowTypeError(SErrorIteratorZipStrictLengthMismatch, SSuggestIteratorZipMode);
         end;
@@ -331,8 +404,10 @@ end;
 procedure TGocciaZipIteratorValue.Close;
 begin
   if FDone then Exit;
+  if not FStarted then
+    FDone := True;
+  CloseAllIterators(False);
   FDone := True;
-  CloseAllIterators;
 end;
 
 procedure TGocciaZipIteratorValue.MarkReferences;
@@ -355,7 +430,7 @@ end;
 
 { TGocciaZipKeyedIteratorValue }
 
-constructor TGocciaZipKeyedIteratorValue.Create(const AKeys: array of string;
+constructor TGocciaZipKeyedIteratorValue.Create(const AKeys: array of TGocciaValue;
   const AIterators: array of TGocciaIteratorValue;
   const APadding: array of TGocciaValue; const AMode: TGocciaZipMode);
 var
@@ -372,20 +447,46 @@ begin
   for I := 0 to High(APadding) do
     FPadding[I] := APadding[I];
   FMode := AMode;
+  FStarted := False;
   SetLength(FExhausted, Length(AIterators));
   for I := 0 to High(FExhausted) do
     FExhausted[I] := False;
 end;
 
-procedure TGocciaZipKeyedIteratorValue.CloseAllIterators;
+procedure TGocciaZipKeyedIteratorValue.CloseAllIterators(
+  const APreserveError: Boolean; const AExcludeIndex: Integer);
 var
   I: Integer;
+  FirstException: Exception;
+  HasFirstError: Boolean;
 begin
-  for I := 0 to High(FIterators) do
+  HasFirstError := False;
+  FirstException := nil;
+  for I := High(FIterators) downto 0 do
   begin
-    if not FExhausted[I] then
-      CloseIteratorPreservingError(FIterators[I]);
+    if (I <> AExcludeIndex) and not FExhausted[I] then
+    begin
+      if APreserveError then
+        CloseIteratorPreservingError(FIterators[I])
+      else
+      begin
+        try
+          FIterators[I].Close;
+        except
+          on E: Exception do
+          begin
+            if not HasFirstError then
+            begin
+              HasFirstError := True;
+              FirstException := Exception(AcquireExceptionObject);
+            end;
+          end;
+        end;
+      end;
+    end;
   end;
+  if HasFirstError then
+    raise FirstException;
 end;
 
 // TC39 Joint Iteration §1.2 Iterator.zipKeyed(iterables [, options])
@@ -408,10 +509,11 @@ end;
 function TGocciaZipKeyedIteratorValue.DoDirectNext(out ADone: Boolean): TGocciaValue;
 var
   ResultObj: TGocciaObjectValue;
+  InnerResult: TGocciaObjectValue;
   I: Integer;
   InnerValue: TGocciaValue;
   InnerDone: Boolean;
-  AnyDone, AllDone: Boolean;
+  AnyDone, AllDone, HadDoneBefore: Boolean;
 begin
   if Length(FIterators) = 0 then
   begin
@@ -420,8 +522,9 @@ begin
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
+  FStarted := True;
 
-  ResultObj := TGocciaObjectValue.Create;
+  ResultObj := TGocciaObjectValue.Create(TGocciaObjectValue(nil));
   TGarbageCollector.Instance.AddTempRoot(ResultObj);
   try
     AnyDone := False;
@@ -433,35 +536,73 @@ begin
       if FExhausted[I] then
       begin
         if I < Length(FPadding) then
-          ResultObj.AssignProperty(FKeys[I], FPadding[I])
+      ResultObj.CreateDataPropertyOrThrow(FKeys[I], FPadding[I])
         else
-          ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
+          ResultObj.CreateDataPropertyOrThrow(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
         AnyDone := True;
         Continue;
+      end;
+
+      if (FMode = zmStrict) and AnyDone then
+      begin
+        try
+          InnerResult := FIterators[I].AdvanceNext;
+          InnerDone := IteratorResultDone(InnerResult);
+        except
+          AcquireExceptionObject;
+          CloseAllIterators(True, I);
+          FDone := True;
+          raise;
+        end;
+        if InnerDone then
+        begin
+          FExhausted[I] := True;
+          Continue;
+        end;
+        CloseAllIterators(True);
+        FDone := True;
+        ThrowTypeError(SErrorIteratorZipKeyedStrictLengthMismatch,
+          SSuggestIteratorZipMode);
       end;
 
       try
         InnerValue := FIterators[I].DirectNext(InnerDone);
       except
         AcquireExceptionObject;
-        CloseAllIterators;
+        CloseAllIterators(True, I);
         FDone := True;
         raise;
       end;
 
       if InnerDone then
       begin
+        HadDoneBefore := AnyDone;
         FExhausted[I] := True;
         AnyDone := True;
+        if FMode = zmShortest then
+        begin
+          CloseAllIterators(False);
+          FDone := True;
+          ADone := True;
+          Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+          Exit;
+        end;
+        if (FMode = zmStrict) and (I <> 0) and not HadDoneBefore then
+        begin
+          CloseAllIterators(True, I);
+          FDone := True;
+          ThrowTypeError(SErrorIteratorZipKeyedStrictLengthMismatch,
+            SSuggestIteratorZipMode);
+        end;
         if I < Length(FPadding) then
-          ResultObj.AssignProperty(FKeys[I], FPadding[I])
+          ResultObj.CreateDataPropertyOrThrow(FKeys[I], FPadding[I])
         else
-          ResultObj.AssignProperty(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
+          ResultObj.CreateDataPropertyOrThrow(FKeys[I], TGocciaUndefinedLiteralValue.UndefinedValue);
       end
       else
       begin
         AllDone := False;
-        ResultObj.AssignProperty(FKeys[I], InnerValue);
+        ResultObj.CreateDataPropertyOrThrow(FKeys[I], InnerValue);
       end;
     end;
 
@@ -473,7 +614,7 @@ begin
       begin
         if AnyDone then
         begin
-          CloseAllIterators;
+          CloseAllIterators(False);
           FDone := True;
           ADone := True;
           Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -494,7 +635,7 @@ begin
       begin
         if AnyDone and not AllDone then
         begin
-          CloseAllIterators;
+          CloseAllIterators(True);
           FDone := True;
           ThrowTypeError(SErrorIteratorZipKeyedStrictLengthMismatch, SSuggestIteratorZipMode);
         end;
@@ -518,8 +659,10 @@ end;
 procedure TGocciaZipKeyedIteratorValue.Close;
 begin
   if FDone then Exit;
+  if not FStarted then
+    FDone := True;
+  CloseAllIterators(False);
   FDone := True;
-  CloseAllIterators;
 end;
 
 procedure TGocciaZipKeyedIteratorValue.MarkReferences;
@@ -532,6 +675,11 @@ begin
   begin
     if Assigned(FIterators[I]) then
       FIterators[I].MarkReferences;
+  end;
+  for I := 0 to High(FKeys) do
+  begin
+    if Assigned(FKeys[I]) then
+      FKeys[I].MarkReferences;
   end;
   for I := 0 to High(FPadding) do
   begin

--- a/source/units/Goccia.Values.IteratorSupport.pas
+++ b/source/units/Goccia.Values.IteratorSupport.pas
@@ -8,7 +8,16 @@ uses
   Goccia.Values.IteratorValue,
   Goccia.Values.Primitives;
 
+type
+  TGocciaIteratorPrimitiveHandling = (
+    iphRejectPrimitives,
+    iphIterateStringPrimitives
+  );
+
 function GetIteratorFromValue(const AValue: TGocciaValue): TGocciaIteratorValue;
+function GetIteratorFlattenable(
+  const AValue: TGocciaValue;
+  const APrimitiveHandling: TGocciaIteratorPrimitiveHandling): TGocciaIteratorValue;
 // CloseIterator is the normal-completion variant per ES2024 §7.4.10
 // IteratorClose: errors from iter.return() propagate to the caller.  Use
 // this on success paths.  CloseIteratorPreservingError below swallows
@@ -126,6 +135,101 @@ begin
     end;
   end;
 
+  Result := nil;
+end;
+
+function GetIteratorFlattenable(
+  const AValue: TGocciaValue;
+  const APrimitiveHandling: TGocciaIteratorPrimitiveHandling): TGocciaIteratorValue;
+var
+  IteratorHost: TGocciaObjectValue;
+  IteratorReceiver: TGocciaValue;
+  IteratorMethod, IteratorObj, NextMethod: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
+  WasSourceRooted, WasMethodRooted, WasIteratorRooted: Boolean;
+  GC: TGarbageCollector;
+
+  function AddRootIfNeeded(const AValue: TGocciaValue): Boolean;
+  begin
+    Result := Assigned(GC) and Assigned(AValue) and not GC.IsTempRoot(AValue);
+    if Result then
+      GC.AddTempRoot(AValue);
+  end;
+
+  procedure RemoveRootIfNeeded(const AValue: TGocciaValue; const AWasAdded: Boolean);
+  begin
+    if AWasAdded then
+      GC.RemoveTempRoot(AValue);
+  end;
+
+begin
+  GC := TGarbageCollector.Instance;
+
+  if AValue is TGocciaIteratorValue then
+    Exit(TGocciaIteratorValue(AValue));
+
+  if AValue is TGocciaObjectValue then
+  begin
+    IteratorHost := TGocciaObjectValue(AValue);
+    IteratorReceiver := AValue;
+  end
+  else if (APrimitiveHandling = iphIterateStringPrimitives) and
+          (AValue is TGocciaStringLiteralValue) then
+  begin
+    IteratorHost := ToObject(AValue);
+    IteratorReceiver := AValue;
+  end
+  else
+    ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
+
+  WasSourceRooted := AddRootIfNeeded(IteratorHost);
+  try
+    IteratorMethod := IteratorHost.GetSymbolPropertyWithReceiver(
+      TGocciaSymbolValue.WellKnownIterator, IteratorReceiver);
+    if Assigned(IteratorMethod) and
+       not (IteratorMethod is TGocciaUndefinedLiteralValue) and
+       not (IteratorMethod is TGocciaNullLiteralValue) then
+    begin
+      if not IteratorMethod.IsCallable then
+        ThrowTypeError(Format(SErrorValueNotFunction, ['[Symbol.iterator]']),
+          SSuggestIteratorProtocol);
+
+      WasMethodRooted := AddRootIfNeeded(IteratorMethod);
+      try
+        CallArgs := TGocciaArgumentsCollection.Create;
+        try
+          IteratorObj := InvokeCallable(IteratorMethod, CallArgs,
+            IteratorReceiver);
+        finally
+          CallArgs.Free;
+        end;
+      finally
+        RemoveRootIfNeeded(IteratorMethod, WasMethodRooted);
+      end;
+
+      if not (IteratorObj is TGocciaObjectValue) then
+        ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
+
+      if IteratorObj is TGocciaIteratorValue then
+        Exit(TGocciaIteratorValue(IteratorObj));
+
+      WasIteratorRooted := AddRootIfNeeded(IteratorObj);
+      try
+        NextMethod := TGocciaObjectValue(IteratorObj).GetProperty(PROP_NEXT);
+        Result := CreateRootedGenericIterator(IteratorObj, NextMethod);
+      finally
+        RemoveRootIfNeeded(IteratorObj, WasIteratorRooted);
+      end;
+      Exit;
+    end;
+
+    NextMethod := IteratorHost.GetProperty(PROP_NEXT);
+    Exit(CreateRootedGenericIterator(IteratorHost, NextMethod));
+  finally
+    RemoveRootIfNeeded(IteratorHost, WasSourceRooted);
+  end;
+
+  ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
   Result := nil;
 end;
 

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -223,11 +223,6 @@ begin
   Prototype := GetSharedWrapForValidIteratorPrototype;
   if Assigned(Prototype) then
     FPrototype := Prototype;
-  DefineSymbolProperty(TGocciaSymbolValue.WellKnownIterator,
-    TGocciaPropertyDescriptorData.Create(
-      TGocciaNativeFunctionValue.CreateWithoutPrototype(
-        GetIteratorMethodHost.IteratorSelf, '[Symbol.iterator]', 0),
-      [pfConfigurable, pfWritable]));
 end;
 
 function TGocciaWrapForValidIteratorValue.RawNext: TGocciaValue;
@@ -1130,8 +1125,8 @@ function TGocciaIteratorValue.IteratorReduce(const AArgs: TGocciaArgumentsCollec
 var
   Iterator: TGocciaIteratorValue;
   Callback: TGocciaValue;
-  Accumulator, NewAccumulator, Value: TGocciaValue;
-  HasInitial, Done: Boolean;
+  Accumulator, NewAccumulator, Value, IndexValue: TGocciaValue;
+  HasInitial, Done, ValueWasRooted, IndexWasRooted: Boolean;
   CallArgs: TGocciaArgumentsCollection;
   Index: Integer;
 begin
@@ -1163,17 +1158,25 @@ begin
       Value := Iterator.DirectNext(Done);
       while not Done do
       begin
-        CallArgs := TGocciaArgumentsCollection.Create([Accumulator, Value, TGocciaNumberLiteralValue.Create(Index)]);
+        ValueWasRooted := AddTempRootIfNeeded(Value);
+        IndexValue := TGocciaNumberLiteralValue.Create(Index);
+        IndexWasRooted := AddTempRootIfNeeded(IndexValue);
         try
+          CallArgs := TGocciaArgumentsCollection.Create([Accumulator, Value, IndexValue]);
           try
-            NewAccumulator := InvokeCallable(Callback, CallArgs,
-              TGocciaUndefinedLiteralValue.UndefinedValue);
-          except
-            CloseIteratorPreservingError(Iterator);
-            raise;
+            try
+              NewAccumulator := InvokeCallable(Callback, CallArgs,
+                TGocciaUndefinedLiteralValue.UndefinedValue);
+            except
+              CloseIteratorPreservingError(Iterator);
+              raise;
+            end;
+          finally
+            CallArgs.Free;
           end;
         finally
-          CallArgs.Free;
+          RemoveTempRootIfNeeded(IndexValue, IndexWasRooted);
+          RemoveTempRootIfNeeded(Value, ValueWasRooted);
         end;
         TGarbageCollector.Instance.RemoveTempRoot(Accumulator);
         Accumulator := NewAccumulator;
@@ -1799,9 +1802,8 @@ begin
         Continue;
       PropValue := GetPropertyByKey(TGocciaObjectValue(IterablesArg),
         AllKeys[I]);
-      if (not Assigned(PropValue)) or
-         (PropValue is TGocciaUndefinedLiteralValue) then
-        Continue;
+      if not Assigned(PropValue) then
+        PropValue := TGocciaUndefinedLiteralValue.UndefinedValue;
       InnerIterator := GetIteratorFlattenable(PropValue, iphRejectPrimitives);
       if InnerIterator = nil then
         ThrowTypeError(Format(SErrorIteratorZipKeyedPropertyNotIterable,

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -19,9 +19,12 @@ type
       const AToStringTag: string): TGocciaObjectValue; static;
   public
     function IteratorNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorHelperNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorSelf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorDispose(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorHelperReturn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorWrapNext(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function IteratorWrapReturn(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     function IteratorMap(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function IteratorFilter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -110,9 +113,11 @@ uses
   Goccia.Values.Iterator.Generic,
   Goccia.Values.Iterator.Lazy,
   Goccia.Values.Iterator.Zip,
+  Goccia.Values.IteratorSupport,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.SymbolValue;
+  Goccia.Values.SymbolValue,
+  Goccia.Values.ToObject;
 
 // Iterator.prototype, its helper prototype, the Iterator constructor, and the
 // method host all live in per-realm slots, so the realm pins them on SetSlot and
@@ -122,6 +127,7 @@ uses
 var
   GIteratorPrototypeSlot: TGocciaRealmSlotId;
   GIteratorHelperPrototypeSlot: TGocciaRealmSlotId;
+  GWrapForValidIteratorPrototypeSlot: TGocciaRealmSlotId;
   GIteratorConstructorSlot: TGocciaRealmSlotId;
   GIteratorMethodHostSlot: TGocciaRealmSlotId;
 
@@ -149,6 +155,15 @@ begin
     Result := nil;
 end;
 
+function GetSharedWrapForValidIteratorPrototype: TGocciaObjectValue; inline;
+begin
+  if Assigned(CurrentRealm) then
+    Result := TGocciaObjectValue(CurrentRealm.GetSlot(
+      GWrapForValidIteratorPrototypeSlot))
+  else
+    Result := nil;
+end;
+
 // The per-realm method host (Self from InitializePrototype) that the helper,
 // constructor, and static methods bind to.  Populated by InitializePrototype,
 // which every entry point calls via EnsurePrototypeInitialized first. #892
@@ -158,6 +173,101 @@ begin
     Result := TGocciaIteratorValue(CurrentRealm.GetSlot(GIteratorMethodHostSlot))
   else
     Result := nil;
+end;
+
+type
+  TGocciaWrapForValidIteratorValue = class(TGocciaGenericIteratorValue)
+  public
+    constructor Create(const AIteratorObject, ANextMethod: TGocciaValue);
+    function RawNext: TGocciaValue;
+    function RawReturn: TGocciaValue;
+  end;
+
+procedure EnsureWrapForValidIteratorPrototypeInitialized;
+var
+  Members: TGocciaMemberCollection;
+  Prototype: TGocciaObjectValue;
+begin
+  if not Assigned(CurrentRealm) then
+    Exit;
+  if Assigned(GetSharedWrapForValidIteratorPrototype) then
+    Exit;
+
+  TGocciaIteratorValue.EnsurePrototypeInitialized;
+  Prototype := TGocciaObjectValue.Create(GetSharedIteratorPrototype);
+  CurrentRealm.SetSlot(GWrapForValidIteratorPrototypeSlot, Prototype);
+
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddNamedMethod('next', GetIteratorMethodHost.IteratorWrapNext, 0,
+      gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddNamedMethod(PROP_RETURN, GetIteratorMethodHost.IteratorWrapReturn, 0,
+      gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddSymbolMethod(
+      TGocciaSymbolValue.WellKnownIterator, '[Symbol.iterator]',
+      GetIteratorMethodHost.IteratorSelf, 0, [pfConfigurable, pfWritable],
+      [gmfNoFunctionPrototype]);
+    RegisterMemberDefinitions(Prototype, Members.ToDefinitions);
+  finally
+    Members.Free;
+  end;
+end;
+
+constructor TGocciaWrapForValidIteratorValue.Create(
+  const AIteratorObject, ANextMethod: TGocciaValue);
+var
+  Prototype: TGocciaObjectValue;
+begin
+  inherited Create(AIteratorObject, ANextMethod);
+  EnsureWrapForValidIteratorPrototypeInitialized;
+  Prototype := GetSharedWrapForValidIteratorPrototype;
+  if Assigned(Prototype) then
+    FPrototype := Prototype;
+  DefineSymbolProperty(TGocciaSymbolValue.WellKnownIterator,
+    TGocciaPropertyDescriptorData.Create(
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(
+        GetIteratorMethodHost.IteratorSelf, '[Symbol.iterator]', 0),
+      [pfConfigurable, pfWritable]));
+end;
+
+function TGocciaWrapForValidIteratorValue.RawNext: TGocciaValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+begin
+  if not Assigned(FNextMethod) or
+     (FNextMethod is TGocciaUndefinedLiteralValue) or
+     not FNextMethod.IsCallable then
+    ThrowTypeError(SErrorIteratorNextMustBeCallable, SSuggestIteratorProtocol);
+
+  CallArgs := TGocciaArgumentsCollection.Create;
+  try
+    Result := InvokeCallable(FNextMethod, CallArgs, FSource);
+  finally
+    CallArgs.Free;
+  end;
+end;
+
+function TGocciaWrapForValidIteratorValue.RawReturn: TGocciaValue;
+var
+  ReturnMethod: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
+begin
+  ReturnMethod := FSource.GetProperty(PROP_RETURN);
+  if not Assigned(ReturnMethod) or
+     (ReturnMethod is TGocciaUndefinedLiteralValue) or
+     (ReturnMethod is TGocciaNullLiteralValue) then
+    Exit(CreateIteratorResult(TGocciaUndefinedLiteralValue.UndefinedValue,
+      True));
+  if not ReturnMethod.IsCallable then
+    ThrowTypeError(SErrorIteratorReturnMustBeCallable,
+      SSuggestIteratorProtocol);
+
+  CallArgs := TGocciaArgumentsCollection.Create;
+  try
+    Result := InvokeCallable(ReturnMethod, CallArgs, FSource);
+  finally
+    CallArgs.Free;
+  end;
 end;
 
 function IteratorThisToDirectIterator(
@@ -311,7 +421,7 @@ begin
 
   Members := TGocciaMemberCollection.Create;
   try
-    Members.AddNamedMethod('next', GetIteratorMethodHost.IteratorNext, 0,
+    Members.AddNamedMethod('next', GetIteratorMethodHost.IteratorHelperNext, 0,
       gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod(PROP_RETURN, GetIteratorMethodHost.IteratorHelperReturn, 0,
       gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -679,7 +789,8 @@ begin
 
   SharedPrototype := GetSharedIteratorPrototype;
   Result := TGocciaObjectValue.Create(
-    GetProtoFromConstructorWithIntrinsic(ANewTarget, SharedPrototype));
+    GetProtoFromConstructorWithIntrinsic(ANewTarget, SharedPrototype,
+      GIteratorPrototypeSlot));
 end;
 
 // ES2026 §27.1.3.3.1.1 get Iterator.prototype.constructor
@@ -744,6 +855,15 @@ begin
   Result := TGocciaIteratorValue(AThisValue).AdvanceNext;
 end;
 
+function TGocciaIteratorValue.IteratorHelperNext(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaIteratorHelperValue) then
+    ThrowTypeError(SErrorIteratorNextNonIterator, SSuggestIteratorThisType);
+  Result := TGocciaIteratorHelperValue(AThisValue).AdvanceNext;
+end;
+
 function TGocciaIteratorValue.IteratorSelf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
   Result := AThisValue;
@@ -791,6 +911,26 @@ begin
     ThrowTypeError('Iterator helper return called on non-helper');
   Result := TGocciaIteratorHelperValue(AThisValue).ReturnValue(
     TGocciaUndefinedLiteralValue.UndefinedValue);
+end;
+
+// ES2026 §27.1.5.3.2 %WrapForValidIteratorPrototype%.next()
+function TGocciaIteratorValue.IteratorWrapNext(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaWrapForValidIteratorValue) then
+    ThrowTypeError('WrapForValidIterator next called on non-wrapper');
+  Result := TGocciaWrapForValidIteratorValue(AThisValue).RawNext;
+end;
+
+// ES2026 §27.1.5.3.1 %WrapForValidIteratorPrototype%.return()
+function TGocciaIteratorValue.IteratorWrapReturn(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaWrapForValidIteratorValue) then
+    ThrowTypeError('WrapForValidIterator return called on non-wrapper');
+  Result := TGocciaWrapForValidIteratorValue(AThisValue).RawReturn;
 end;
 
 { Lazy helper methods — return new lazy iterators }
@@ -967,17 +1107,17 @@ begin
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
   try
-    try
-      Value := Iterator.DirectNext(Done);
-      while not Done do
-      begin
+    Value := Iterator.DirectNext(Done);
+    while not Done do
+    begin
+      try
         InvokeIteratorCallback(Callback, Value, Index);
-        Inc(Index);
-        Value := Iterator.DirectNext(Done);
+      except
+        CloseIteratorPreservingError(Iterator);
+        raise;
       end;
-    except
-      CloseIteratorPreservingError(Iterator);
-      raise;
+      Inc(Index);
+      Value := Iterator.DirectNext(Done);
     end;
   finally
     TGarbageCollector.Instance.RemoveTempRoot(Iterator);
@@ -1007,44 +1147,44 @@ begin
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
   try
-    try
-      if HasInitial then
-        Accumulator := AArgs.GetElement(1)
-      else
-      begin
-        Accumulator := Iterator.DirectNext(Done);
-        if Done then
-          ThrowTypeError(SErrorReduceEmptyIterator,
-            SSuggestReduceInitialValue);
-        Index := 1;
-      end;
+    if HasInitial then
+      Accumulator := AArgs.GetElement(1)
+    else
+    begin
+      Accumulator := Iterator.DirectNext(Done);
+      if Done then
+        ThrowTypeError(SErrorReduceEmptyIterator,
+          SSuggestReduceInitialValue);
+      Index := 1;
+    end;
 
-      TGarbageCollector.Instance.AddTempRoot(Accumulator);
-      try
-        Value := Iterator.DirectNext(Done);
-        while not Done do
-        begin
-          CallArgs := TGocciaArgumentsCollection.Create([Accumulator, Value, TGocciaNumberLiteralValue.Create(Index)]);
+    TGarbageCollector.Instance.AddTempRoot(Accumulator);
+    try
+      Value := Iterator.DirectNext(Done);
+      while not Done do
+      begin
+        CallArgs := TGocciaArgumentsCollection.Create([Accumulator, Value, TGocciaNumberLiteralValue.Create(Index)]);
+        try
           try
             NewAccumulator := InvokeCallable(Callback, CallArgs,
               TGocciaUndefinedLiteralValue.UndefinedValue);
-          finally
-            CallArgs.Free;
+          except
+            CloseIteratorPreservingError(Iterator);
+            raise;
           end;
-          TGarbageCollector.Instance.RemoveTempRoot(Accumulator);
-          Accumulator := NewAccumulator;
-          TGarbageCollector.Instance.AddTempRoot(Accumulator);
-          Value := Iterator.DirectNext(Done);
-          Inc(Index);
+        finally
+          CallArgs.Free;
         end;
-
-        Result := Accumulator;
-      finally
         TGarbageCollector.Instance.RemoveTempRoot(Accumulator);
+        Accumulator := NewAccumulator;
+        TGarbageCollector.Instance.AddTempRoot(Accumulator);
+        Value := Iterator.DirectNext(Done);
+        Inc(Index);
       end;
-    except
-      CloseIteratorPreservingError(Iterator);
-      raise;
+
+      Result := Accumulator;
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(Accumulator);
     end;
   finally
     TGarbageCollector.Instance.RemoveTempRoot(Iterator);
@@ -1116,11 +1256,11 @@ begin
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
   try
-    try
-      Value := Iterator.DirectNext(Done);
-      while not Done do
-      begin
-        ValueWasRooted := AddTempRootIfNeeded(Value);
+    Value := Iterator.DirectNext(Done);
+    while not Done do
+    begin
+      ValueWasRooted := AddTempRootIfNeeded(Value);
+      try
         try
           PredicateValue := InvokeIteratorCallback(Callback, Value, Index);
           PredicateWasRooted := AddTempRootIfNeeded(PredicateValue);
@@ -1134,18 +1274,18 @@ begin
           finally
             RemoveTempRootIfNeeded(PredicateValue, PredicateWasRooted);
           end;
-        finally
-          RemoveTempRootIfNeeded(Value, ValueWasRooted);
+        except
+          CloseIteratorPreservingError(Iterator);
+          raise;
         end;
-        Inc(Index);
-        Value := Iterator.DirectNext(Done);
+      finally
+        RemoveTempRootIfNeeded(Value, ValueWasRooted);
       end;
-
-      Result := TGocciaBooleanLiteralValue.FalseValue;
-    except
-      CloseIteratorPreservingError(Iterator);
-      raise;
+      Inc(Index);
+      Value := Iterator.DirectNext(Done);
     end;
+
+    Result := TGocciaBooleanLiteralValue.FalseValue;
   finally
     TGarbageCollector.Instance.RemoveTempRoot(Iterator);
   end;
@@ -1169,11 +1309,11 @@ begin
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
   try
-    try
-      Value := Iterator.DirectNext(Done);
-      while not Done do
-      begin
-        ValueWasRooted := AddTempRootIfNeeded(Value);
+    Value := Iterator.DirectNext(Done);
+    while not Done do
+    begin
+      ValueWasRooted := AddTempRootIfNeeded(Value);
+      try
         try
           PredicateValue := InvokeIteratorCallback(Callback, Value, Index);
           PredicateWasRooted := AddTempRootIfNeeded(PredicateValue);
@@ -1187,18 +1327,18 @@ begin
           finally
             RemoveTempRootIfNeeded(PredicateValue, PredicateWasRooted);
           end;
-        finally
-          RemoveTempRootIfNeeded(Value, ValueWasRooted);
+        except
+          CloseIteratorPreservingError(Iterator);
+          raise;
         end;
-        Inc(Index);
-        Value := Iterator.DirectNext(Done);
+      finally
+        RemoveTempRootIfNeeded(Value, ValueWasRooted);
       end;
-
-      Result := TGocciaBooleanLiteralValue.TrueValue;
-    except
-      CloseIteratorPreservingError(Iterator);
-      raise;
+      Inc(Index);
+      Value := Iterator.DirectNext(Done);
     end;
+
+    Result := TGocciaBooleanLiteralValue.TrueValue;
   finally
     TGarbageCollector.Instance.RemoveTempRoot(Iterator);
   end;
@@ -1222,11 +1362,11 @@ begin
 
   TGarbageCollector.Instance.AddTempRoot(Iterator);
   try
-    try
-      Value := Iterator.DirectNext(Done);
-      while not Done do
-      begin
-        ValueWasRooted := AddTempRootIfNeeded(Value);
+    Value := Iterator.DirectNext(Done);
+    while not Done do
+    begin
+      ValueWasRooted := AddTempRootIfNeeded(Value);
+      try
         try
           PredicateValue := InvokeIteratorCallback(Callback, Value, Index);
           PredicateWasRooted := AddTempRootIfNeeded(PredicateValue);
@@ -1240,18 +1380,18 @@ begin
           finally
             RemoveTempRootIfNeeded(PredicateValue, PredicateWasRooted);
           end;
-        finally
-          RemoveTempRootIfNeeded(Value, ValueWasRooted);
+        except
+          CloseIteratorPreservingError(Iterator);
+          raise;
         end;
-        Inc(Index);
-        Value := Iterator.DirectNext(Done);
+      finally
+        RemoveTempRootIfNeeded(Value, ValueWasRooted);
       end;
-
-      Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-    except
-      CloseIteratorPreservingError(Iterator);
-      raise;
+      Inc(Index);
+      Value := Iterator.DirectNext(Done);
     end;
+
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   finally
     TGarbageCollector.Instance.RemoveTempRoot(Iterator);
   end;
@@ -1261,10 +1401,12 @@ end;
 
 function TGocciaIteratorValue.IteratorFrom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Value, IteratorMethod, IteratorObj, NextMethod: TGocciaValue;
+  Value, IteratorConstructor, IteratorMethod, IteratorObj, NextMethod: TGocciaValue;
+  IteratorHost: TGocciaObjectValue;
+  IteratorReceiver: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
   GC: TGarbageCollector;
-  ValueWasRooted, MethodWasRooted, IteratorWasRooted: Boolean;
+  HostWasRooted, MethodWasRooted, IteratorWasRooted: Boolean;
 
   function AddRootIfNeeded(const ARootValue: TGocciaValue): Boolean;
   begin
@@ -1288,94 +1430,70 @@ begin
   GC := TGarbageCollector.Instance;
   Value := AArgs.GetElement(0);
 
-  if Value is TGocciaIteratorValue then
-  begin
-    Result := Value;
-    Exit;
-  end;
-
   if Value is TGocciaObjectValue then
   begin
-    ValueWasRooted := AddRootIfNeeded(Value);
-    try
-      IteratorMethod := TGocciaObjectValue(Value).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
-      // Per ES2024 GetMethod: a present-but-non-callable @@iterator is
-      // a TypeError.  Falling through to the iterator-like (`next` on
-      // Value) branch when @@iterator was malformed would mask the
-      // protocol violation.
-      if Assigned(IteratorMethod) and
-         not (IteratorMethod is TGocciaUndefinedLiteralValue) and
-         not (IteratorMethod is TGocciaNullLiteralValue) and
-         not IteratorMethod.IsCallable then
-        ThrowTypeError(Format(SErrorValueNotFunction, ['[Symbol.iterator]']),
-          SSuggestIteratorProtocol);
-      if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
-      begin
-        MethodWasRooted := AddRootIfNeeded(IteratorMethod);
-        try
-          CallArgs := TGocciaArgumentsCollection.Create;
-          try
-            IteratorObj := InvokeCallable(IteratorMethod, CallArgs, Value);
-          finally
-            CallArgs.Free;
-          end;
-        finally
-          RemoveRootIfNeeded(IteratorMethod, MethodWasRooted);
-        end;
-
-        if IteratorObj is TGocciaIteratorValue then
-        begin
-          Result := IteratorObj;
-          Exit;
-        end;
-        // §7.4.3 GetIterator step 4 / TC39 Iterator Helpers
-        // GetIteratorFlattenable step 5: the value returned from
-        // [@@iterator]() must be an Object — anything else is a
-        // protocol violation, NOT a cue to fall back to iterator-like
-        // handling on the outer Value.
-        if not (IteratorObj is TGocciaObjectValue) then
-          ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
-        IteratorWasRooted := AddRootIfNeeded(IteratorObj);
-        try
-          NextMethod := IteratorObj.GetProperty(PROP_NEXT);
-          if not Assigned(NextMethod) or
-             (NextMethod is TGocciaUndefinedLiteralValue) or
-             not NextMethod.IsCallable then
-            // §7.4.2 GetIteratorDirect step 2: missing/non-callable next.
-            ThrowTypeError(SErrorIteratorNextMustBeCallable,
-              SSuggestIteratorProtocol);
-          // Capture-once per ES2024 §7.4.2 GetIteratorDirect.
-          Result := CreateRootedGenericIterator(IteratorObj, NextMethod);
-        finally
-          RemoveRootIfNeeded(IteratorObj, IteratorWasRooted);
-        end;
-        Exit;
-      end;
-
-      // No @@iterator (undefined/null): TC39 Iterator Helpers
-      // GetIteratorFlattenable iterator-like fallback — try the value
-      // itself as a duck-typed iterator (must have a callable next).
-      NextMethod := Value.GetProperty(PROP_NEXT);
-      if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
-      begin
-        // Capture-once per ES2024 §7.4.2 GetIteratorDirect.
-        Result := CreateRootedGenericIterator(Value, NextMethod);
-        Exit;
-      end;
-    finally
-      RemoveRootIfNeeded(Value, ValueWasRooted);
-    end;
+    IteratorHost := TGocciaObjectValue(Value);
+    IteratorReceiver := Value;
   end;
 
   if Value is TGocciaStringLiteralValue then
   begin
-    Result := TGocciaStringIteratorValue.Create(Value);
-    Exit;
-  end;
+    IteratorHost := ToObject(Value);
+    IteratorReceiver := Value;
+  end
+  else if not (Value is TGocciaObjectValue) then
+    ThrowTypeError(SErrorIteratorFromRequiresIterable,
+      SSuggestIteratorFromArg);
 
-  ThrowTypeError(SErrorIteratorFromRequiresIterable,
-    SSuggestIteratorFromArg);
-  Result := nil;
+  HostWasRooted := AddRootIfNeeded(IteratorHost);
+  try
+    IteratorMethod := IteratorHost.GetSymbolPropertyWithReceiver(
+      TGocciaSymbolValue.WellKnownIterator, IteratorReceiver);
+    if Assigned(IteratorMethod) and
+       not (IteratorMethod is TGocciaUndefinedLiteralValue) and
+       not (IteratorMethod is TGocciaNullLiteralValue) then
+    begin
+      if not IteratorMethod.IsCallable then
+        ThrowTypeError(Format(SErrorValueNotFunction, ['[Symbol.iterator]']),
+          SSuggestIteratorProtocol);
+      MethodWasRooted := AddRootIfNeeded(IteratorMethod);
+      try
+        CallArgs := TGocciaArgumentsCollection.Create;
+        try
+          IteratorObj := InvokeCallable(IteratorMethod, CallArgs,
+            IteratorReceiver);
+        finally
+          CallArgs.Free;
+        end;
+      finally
+        RemoveRootIfNeeded(IteratorMethod, MethodWasRooted);
+      end;
+    end
+    else
+      IteratorObj := IteratorHost;
+
+    if not (IteratorObj is TGocciaObjectValue) then
+      ThrowTypeError(SErrorIteratorInvalid, SSuggestIteratorProtocol);
+
+    IteratorWasRooted := AddRootIfNeeded(IteratorObj);
+    try
+      NextMethod := TGocciaObjectValue(IteratorObj).GetProperty(PROP_NEXT);
+      IteratorConstructor := GetSharedIteratorConstructor;
+      if not Assigned(IteratorConstructor) then
+        IteratorConstructor := TGocciaIteratorValue.CreateGlobalObject;
+      if OrdinaryHasInstance(IteratorConstructor, IteratorObj) then
+      begin
+        Result := IteratorObj;
+        Exit;
+      end;
+      Result := TGocciaWrapForValidIteratorValue.Create(IteratorObj,
+        NextMethod);
+    finally
+      RemoveRootIfNeeded(IteratorObj, IteratorWasRooted);
+    end;
+  finally
+    RemoveRootIfNeeded(IteratorHost, HostWasRooted);
+  end;
 end;
 
 { Iterator.concat() }
@@ -1395,13 +1513,7 @@ begin
   begin
     Item := AArgs.GetElement(I);
 
-    if Item is TGocciaStringLiteralValue then
-    begin
-      // Strings are iterable primitives — handle specially
-      Iterables[I].Iterable := Item;
-      Iterables[I].IteratorMethod := nil;
-    end
-    else if Item is TGocciaObjectValue then
+    if Item is TGocciaObjectValue then
     begin
       // TC39 Iterator Sequencing §1 step 2b: Let method be GetMethod(item, @@iterator)
       IteratorMethod := TGocciaObjectValue(Item).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
@@ -1429,14 +1541,12 @@ const
   ZIP_MODE_LONGEST = 'longest';
   ZIP_MODE_STRICT = 'strict';
 var
-  IterablesArg, OptionsArg, Item, ModeVal, PaddingVal, PaddingItem: TGocciaValue;
+  IterablesArg, OptionsArg, Item, ModeVal, PaddingOption, PaddingItem: TGocciaValue;
   OuterIterator, InnerIterator, PaddingIterator: TGocciaIteratorValue;
   OuterDone, PaddingDone: Boolean;
   Iterators: array of TGocciaIteratorValue;
   Padding: array of TGocciaValue;
   Mode: TGocciaZipMode;
-  Items: TGocciaValueList;
-  PaddingItems: TGocciaValueList;
   I, J, Count, Acquired: Integer;
   ModeStr: string;
   GC: TGarbageCollector;
@@ -1447,119 +1557,125 @@ begin
     ThrowTypeError(SErrorIteratorZipRequiresArg, SSuggestNotIterable);
 
   IterablesArg := AArgs.GetElement(0);
+  if not (IterablesArg is TGocciaObjectValue) then
+    ThrowTypeError(SErrorIteratorZipFirstIterable, SSuggestNotIterable);
   GC := TGarbageCollector.Instance;
 
-  // TC39 Joint Iteration §1.1 step 2: Get iterator from iterables
+  // TC39 Joint Iteration §1.1: options are read before iterables are touched.
+  Mode := zmShortest;
+  PaddingOption := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if AArgs.Length >= 2 then
+  begin
+    OptionsArg := AArgs.GetElement(1);
+    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    begin
+      if not (OptionsArg is TGocciaObjectValue) then
+        ThrowTypeError(SErrorIteratorZipOptionsObject, SSuggestIteratorZipOptions);
+
+      ModeVal := OptionsArg.GetProperty(PROP_MODE);
+      if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
+      begin
+        if not (ModeVal is TGocciaStringLiteralValue) then
+          ThrowTypeError(SErrorIteratorZipModeString, SSuggestIteratorZipMode);
+        ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
+        if ModeStr = ZIP_MODE_SHORTEST then
+          Mode := zmShortest
+        else if ModeStr = ZIP_MODE_LONGEST then
+          Mode := zmLongest
+        else if ModeStr = ZIP_MODE_STRICT then
+          Mode := zmStrict
+        else
+          ThrowTypeError(Format(SErrorIteratorZipInvalidMode, [ModeStr]),
+            SSuggestIteratorZipMode);
+      end;
+
+      if Mode = zmLongest then
+      begin
+        PaddingOption := OptionsArg.GetProperty(PROP_PADDING);
+        if Assigned(PaddingOption) and
+           not (PaddingOption is TGocciaUndefinedLiteralValue) and
+           not (PaddingOption is TGocciaObjectValue) then
+          ThrowTypeError(SErrorIteratorZipPaddingIterable, SSuggestNotIterable);
+      end;
+    end;
+  end;
+
   OuterIterator := GetIteratorFromIterable(IterablesArg);
   if OuterIterator = nil then
     ThrowTypeError(SErrorIteratorZipFirstIterable, SSuggestNotIterable);
 
   GC.AddTempRoot(OuterIterator);
   try
-    // TC39 Joint Iteration §1.1 step 3: Collect all inner iterables
-    Items := TGocciaValueList.Create(False);
-    try
-      Item := OuterIterator.DirectNext(OuterDone);
-      while not OuterDone do
-      begin
-        Items.Add(Item);
-        Item := OuterIterator.DirectNext(OuterDone);
-      end;
-
-      Count := Items.Count;
-      SetLength(Iterators, Count);
-      Acquired := 0;
-
-      // TC39 Joint Iteration §1.1 step 4: Get iterators from each iterable
+    Count := 0;
+    Acquired := 0;
+    SetLength(Iterators, 0);
+    while True do
+    begin
       try
-        for I := 0 to Count - 1 do
-        begin
-          InnerIterator := GetIteratorFromIterable(Items[I]);
-          if InnerIterator = nil then
-            ThrowTypeError(SErrorIteratorZipItemIterable, SSuggestNotIterable);
-          Iterators[I] := InnerIterator;
-          GC.AddTempRoot(InnerIterator);
-          Acquired := I + 1;
-        end;
+        Item := OuterIterator.DirectNext(OuterDone);
       except
-        // Close and unroot already-acquired iterators before re-raising
         AcquireExceptionObject;
-        for J := 0 to Acquired - 1 do
+        for J := Acquired - 1 downto 0 do
         begin
           CloseIteratorPreservingError(Iterators[J]);
           GC.RemoveTempRoot(Iterators[J]);
         end;
         raise;
       end;
-    finally
-      Items.Free;
+      if OuterDone then
+        Break;
+
+      try
+        InnerIterator := GetIteratorFlattenable(Item, iphRejectPrimitives);
+      except
+        AcquireExceptionObject;
+        for J := Acquired - 1 downto 0 do
+        begin
+          CloseIteratorPreservingError(Iterators[J]);
+          GC.RemoveTempRoot(Iterators[J]);
+        end;
+        CloseIteratorPreservingError(OuterIterator);
+        raise;
+      end;
+      if InnerIterator = nil then
+        ThrowTypeError(SErrorIteratorZipItemIterable, SSuggestNotIterable);
+      SetLength(Iterators, Count + 1);
+      Iterators[Count] := InnerIterator;
+      GC.AddTempRoot(InnerIterator);
+      Inc(Count);
+      Acquired := Count;
     end;
   finally
     GC.RemoveTempRoot(OuterIterator);
   end;
 
-  // TC39 Joint Iteration §1.1 step 5: Parse options
-  Mode := zmShortest;
   SetLength(Padding, Count);
   for I := 0 to Count - 1 do
     Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   Success := False;
   try
-    if AArgs.Length >= 2 then
+    if (Mode = zmLongest) and Assigned(PaddingOption) and
+       not (PaddingOption is TGocciaUndefinedLiteralValue) then
     begin
-      OptionsArg := AArgs.GetElement(1);
-      if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
-      begin
-        if not (OptionsArg is TGocciaObjectValue) then
-          ThrowTypeError(SErrorIteratorZipOptionsObject, SSuggestIteratorZipOptions);
-
-        // TC39 Joint Iteration §1.1 step 5a: Get mode
-        ModeVal := OptionsArg.GetProperty(PROP_MODE);
-        if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
+      PaddingIterator := GetIteratorFromIterable(PaddingOption);
+      if PaddingIterator = nil then
+        ThrowTypeError(SErrorIteratorZipPaddingIterable, SSuggestNotIterable);
+      GC.AddTempRoot(PaddingIterator);
+      try
+        PaddingDone := False;
+        for I := 0 to Count - 1 do
         begin
-          if not (ModeVal is TGocciaStringLiteralValue) then
-            ThrowTypeError(SErrorIteratorZipModeString, SSuggestIteratorZipMode);
-          ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
-          if ModeStr = ZIP_MODE_SHORTEST then
-            Mode := zmShortest
-          else if ModeStr = ZIP_MODE_LONGEST then
-            Mode := zmLongest
-          else if ModeStr = ZIP_MODE_STRICT then
-            Mode := zmStrict
-          else
-            ThrowRangeError(Format(SErrorIteratorZipInvalidMode, [ModeStr]), SSuggestIteratorZipMode);
+          if PaddingDone then
+            Break;
+          PaddingItem := PaddingIterator.DirectNext(PaddingDone);
+          if not PaddingDone then
+            Padding[I] := PaddingItem;
         end;
-
-        // TC39 Joint Iteration §1.1 step 5b: Get padding (only for longest mode)
-        if Mode = zmLongest then
-        begin
-          PaddingVal := OptionsArg.GetProperty(PROP_PADDING);
-          if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
-          begin
-            PaddingIterator := GetIteratorFromIterable(PaddingVal);
-            if PaddingIterator = nil then
-              ThrowTypeError(SErrorIteratorZipPaddingIterable, SSuggestNotIterable);
-            GC.AddTempRoot(PaddingIterator);
-            PaddingItems := TGocciaValueList.Create(False);
-            try
-              PaddingItem := PaddingIterator.DirectNext(PaddingDone);
-              while not PaddingDone do
-              begin
-                PaddingItems.Add(PaddingItem);
-                PaddingItem := PaddingIterator.DirectNext(PaddingDone);
-              end;
-              for I := 0 to Count - 1 do
-              begin
-                if I < PaddingItems.Count then
-                  Padding[I] := PaddingItems[I];
-              end;
-            finally
-              PaddingItems.Free;
-              GC.RemoveTempRoot(PaddingIterator);
-            end;
-          end;
-        end;
+        if not PaddingDone then
+          CloseIterator(PaddingIterator);
+      finally
+        GC.RemoveTempRoot(PaddingIterator);
       end;
     end;
 
@@ -1569,7 +1685,7 @@ begin
     // On error, close all iterators so generator finally blocks run
     if not Success then
     begin
-      for I := 0 to Count - 1 do
+      for I := Count - 1 downto 0 do
         CloseIteratorPreservingError(Iterators[I]);
     end;
     // Unroot iterators — the zip iterator now owns them via MarkReferences
@@ -1587,9 +1703,10 @@ const
   ZIP_MODE_LONGEST = 'longest';
   ZIP_MODE_STRICT = 'strict';
 var
-  IterablesArg, OptionsArg, ModeVal, PaddingVal, PropValue: TGocciaValue;
+  IterablesArg, OptionsArg, ModeVal, PaddingOption, PropValue: TGocciaValue;
+  Descriptor: TGocciaPropertyDescriptor;
   InnerIterator: TGocciaIteratorValue;
-  Keys: TArray<string>;
+  AllKeys, Keys: TArray<TGocciaValue>;
   Iterators: array of TGocciaIteratorValue;
   Padding: array of TGocciaValue;
   Mode: TGocciaZipMode;
@@ -1597,6 +1714,15 @@ var
   ModeStr: string;
   GC: TGarbageCollector;
   Success: Boolean;
+
+  function GetPropertyByKey(const AObject: TGocciaObjectValue;
+    const AKey: TGocciaValue): TGocciaValue;
+  begin
+    if AKey is TGocciaSymbolValue then
+      Result := AObject.GetSymbolProperty(TGocciaSymbolValue(AKey))
+    else
+      Result := AObject.GetProperty(AKey.ToStringLiteral.Value);
+  end;
 begin
   // TC39 Joint Iteration §1.2 step 1: If iterables is not an Object, throw TypeError
   if AArgs.Length < 1 then
@@ -1608,28 +1734,80 @@ begin
 
   GC := TGarbageCollector.Instance;
 
-  // TC39 Joint Iteration §1.2 step 2: Get own enumerable property keys
-  Keys := TGocciaObjectValue(IterablesArg).GetEnumerablePropertyNames;
-  Count := Length(Keys);
+  Mode := zmShortest;
+  PaddingOption := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if AArgs.Length >= 2 then
+  begin
+    OptionsArg := AArgs.GetElement(1);
+    if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+    begin
+      if not (OptionsArg is TGocciaObjectValue) then
+        ThrowTypeError(SErrorIteratorZipKeyedOptionsObject, SSuggestIteratorZipOptions);
 
-  // TC39 Joint Iteration §1.2 step 3: Get iterators from each property value
-  SetLength(Iterators, Count);
+      ModeVal := OptionsArg.GetProperty(PROP_MODE);
+      if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
+      begin
+        if not (ModeVal is TGocciaStringLiteralValue) then
+          ThrowTypeError(SErrorIteratorZipKeyedModeString,
+            SSuggestIteratorZipMode);
+        ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
+        if ModeStr = ZIP_MODE_SHORTEST then
+          Mode := zmShortest
+        else if ModeStr = ZIP_MODE_LONGEST then
+          Mode := zmLongest
+        else if ModeStr = ZIP_MODE_STRICT then
+          Mode := zmStrict
+        else
+          ThrowTypeError(Format(SErrorIteratorZipKeyedInvalidMode, [ModeStr]),
+            SSuggestIteratorZipMode);
+      end;
+
+      if Mode = zmLongest then
+      begin
+        PaddingOption := OptionsArg.GetProperty(PROP_PADDING);
+        if Assigned(PaddingOption) and
+           not (PaddingOption is TGocciaUndefinedLiteralValue) and
+           not (PaddingOption is TGocciaObjectValue) then
+          ThrowTypeError(SErrorIteratorZipKeyedPaddingObject,
+            SSuggestIteratorZipKeyedPadding);
+      end;
+    end;
+  end;
+
+  AllKeys := TGocciaObjectValue(IterablesArg).OwnPropertyKeyValues;
+  SetLength(Keys, Length(AllKeys));
+  SetLength(Iterators, Length(AllKeys));
+  Count := 0;
+
   Acquired := 0;
   try
-    for I := 0 to Count - 1 do
+    for I := 0 to High(AllKeys) do
     begin
-      PropValue := IterablesArg.GetProperty(Keys[I]);
-      InnerIterator := GetIteratorFromIterable(PropValue);
+      Descriptor := TGocciaObjectValue(IterablesArg).OwnPropertyDescriptorForKey(
+        AllKeys[I]);
+      if not Assigned(Descriptor) or not Descriptor.Enumerable then
+        Continue;
+      PropValue := GetPropertyByKey(TGocciaObjectValue(IterablesArg),
+        AllKeys[I]);
+      if (not Assigned(PropValue)) or
+         (PropValue is TGocciaUndefinedLiteralValue) then
+        Continue;
+      InnerIterator := GetIteratorFlattenable(PropValue, iphRejectPrimitives);
       if InnerIterator = nil then
-        ThrowTypeError(Format(SErrorIteratorZipKeyedPropertyNotIterable, [Keys[I]]), SSuggestNotIterable);
-      Iterators[I] := InnerIterator;
+        ThrowTypeError(Format(SErrorIteratorZipKeyedPropertyNotIterable,
+          [AllKeys[I].ToStringLiteral.Value]), SSuggestNotIterable);
+      Keys[Count] := AllKeys[I];
+      Iterators[Count] := InnerIterator;
       GC.AddTempRoot(InnerIterator);
-      Acquired := I + 1;
+      Inc(Count);
+      Acquired := Count;
     end;
+    SetLength(Keys, Count);
+    SetLength(Iterators, Count);
   except
     // Close and unroot already-acquired iterators before re-raising
     AcquireExceptionObject;
-    for J := 0 to Acquired - 1 do
+    for J := Acquired - 1 downto 0 do
     begin
       CloseIteratorPreservingError(Iterators[J]);
       GC.RemoveTempRoot(Iterators[J]);
@@ -1637,55 +1815,22 @@ begin
     raise;
   end;
 
-  // TC39 Joint Iteration §1.2 step 4: Parse options
-  Mode := zmShortest;
   SetLength(Padding, Count);
   for I := 0 to Count - 1 do
     Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
 
   Success := False;
   try
-    if AArgs.Length >= 2 then
+    if (Mode = zmLongest) and Assigned(PaddingOption) and
+       not (PaddingOption is TGocciaUndefinedLiteralValue) then
     begin
-      OptionsArg := AArgs.GetElement(1);
-      if Assigned(OptionsArg) and not (OptionsArg is TGocciaUndefinedLiteralValue) then
+      for I := 0 to Count - 1 do
       begin
-        if not (OptionsArg is TGocciaObjectValue) then
-          ThrowTypeError(SErrorIteratorZipKeyedOptionsObject, SSuggestIteratorZipOptions);
-
-        // TC39 Joint Iteration §1.2 step 4a: Get mode
-        ModeVal := OptionsArg.GetProperty(PROP_MODE);
-        if Assigned(ModeVal) and not (ModeVal is TGocciaUndefinedLiteralValue) then
-        begin
-          if not (ModeVal is TGocciaStringLiteralValue) then
-            ThrowTypeError(SErrorIteratorZipKeyedModeString, SSuggestIteratorZipMode);
-          ModeStr := TGocciaStringLiteralValue(ModeVal).Value;
-          if ModeStr = ZIP_MODE_SHORTEST then
-            Mode := zmShortest
-          else if ModeStr = ZIP_MODE_LONGEST then
-            Mode := zmLongest
-          else if ModeStr = ZIP_MODE_STRICT then
-            Mode := zmStrict
-          else
-            ThrowRangeError(Format(SErrorIteratorZipKeyedInvalidMode, [ModeStr]), SSuggestIteratorZipMode);
-        end;
-
-        // TC39 Joint Iteration §1.2 step 4b: Get padding (only for longest mode)
-        if Mode = zmLongest then
-        begin
-          PaddingVal := OptionsArg.GetProperty(PROP_PADDING);
-          if Assigned(PaddingVal) and not (PaddingVal is TGocciaUndefinedLiteralValue) then
-          begin
-            if not (PaddingVal is TGocciaObjectValue) then
-              ThrowTypeError(SErrorIteratorZipKeyedPaddingObject, SSuggestIteratorZipKeyedPadding);
-            for I := 0 to Count - 1 do
-            begin
-              PropValue := PaddingVal.GetProperty(Keys[I]);
-              if Assigned(PropValue) and not (PropValue is TGocciaUndefinedLiteralValue) then
-                Padding[I] := PropValue;
-            end;
-          end;
-        end;
+        PropValue := GetPropertyByKey(TGocciaObjectValue(PaddingOption),
+          Keys[I]);
+        if Assigned(PropValue) and
+           not (PropValue is TGocciaUndefinedLiteralValue) then
+          Padding[I] := PropValue;
       end;
     end;
 
@@ -1695,7 +1840,7 @@ begin
     // On error, close all iterators so generator finally blocks run
     if not Success then
     begin
-      for I := 0 to Count - 1 do
+      for I := Count - 1 downto 0 do
         CloseIteratorPreservingError(Iterators[I]);
     end;
     // Unroot iterators — the zipKeyed iterator now owns them via MarkReferences
@@ -1810,10 +1955,10 @@ end;
 function TGocciaIteratorHelperValue.ReturnValue(
   const AValue: TGocciaValue): TGocciaObjectValue;
 begin
-  if FExecuting then
-    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
   if FDone then
     Exit(CreateIteratorResult(AValue, True));
+  if FExecuting then
+    ThrowTypeError(SErrorIteratorHelperExecuting, SSuggestIteratorProtocol);
   FExecuting := True;
   try
     Close;
@@ -1837,6 +1982,8 @@ end;
 initialization
   GIteratorPrototypeSlot := RegisterRealmSlot('Iterator.prototype');
   GIteratorHelperPrototypeSlot := RegisterRealmSlot('IteratorHelper.prototype');
+  GWrapForValidIteratorPrototypeSlot := RegisterRealmSlot(
+    'WrapForValidIterator.prototype');
   GIteratorConstructorSlot := RegisterRealmSlot('Iterator');
   GIteratorMethodHostSlot := RegisterRealmSlot('Iterator.prototype.methodHost');
 

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -1546,6 +1546,7 @@ var
   OuterDone, PaddingDone: Boolean;
   Iterators: array of TGocciaIteratorValue;
   Padding: array of TGocciaValue;
+  PaddingRoots: array of Boolean;
   Mode: TGocciaZipMode;
   I, J, Count, Acquired: Integer;
   ModeStr: string;
@@ -1650,6 +1651,7 @@ begin
   end;
 
   SetLength(Padding, Count);
+  SetLength(PaddingRoots, Count);
   for I := 0 to Count - 1 do
     Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
 
@@ -1670,7 +1672,10 @@ begin
             Break;
           PaddingItem := PaddingIterator.DirectNext(PaddingDone);
           if not PaddingDone then
+          begin
+            PaddingRoots[I] := AddTempRootIfNeeded(PaddingItem);
             Padding[I] := PaddingItem;
+          end;
         end;
         if not PaddingDone then
           CloseIterator(PaddingIterator);
@@ -1691,6 +1696,8 @@ begin
     // Unroot iterators — the zip iterator now owns them via MarkReferences
     for I := 0 to Count - 1 do
       GC.RemoveTempRoot(Iterators[I]);
+    for I := 0 to Count - 1 do
+      RemoveTempRootIfNeeded(Padding[I], PaddingRoots[I]);
   end;
 end;
 
@@ -1707,8 +1714,10 @@ var
   Descriptor: TGocciaPropertyDescriptor;
   InnerIterator: TGocciaIteratorValue;
   AllKeys, Keys: TArray<TGocciaValue>;
+  KeyRoots: array of Boolean;
   Iterators: array of TGocciaIteratorValue;
   Padding: array of TGocciaValue;
+  PaddingRoots: array of Boolean;
   Mode: TGocciaZipMode;
   I, J, Count, Acquired: Integer;
   ModeStr: string;
@@ -1776,6 +1785,7 @@ begin
 
   AllKeys := TGocciaObjectValue(IterablesArg).OwnPropertyKeyValues;
   SetLength(Keys, Length(AllKeys));
+  SetLength(KeyRoots, Length(AllKeys));
   SetLength(Iterators, Length(AllKeys));
   Count := 0;
 
@@ -1797,6 +1807,7 @@ begin
         ThrowTypeError(Format(SErrorIteratorZipKeyedPropertyNotIterable,
           [AllKeys[I].ToStringLiteral.Value]), SSuggestNotIterable);
       Keys[Count] := AllKeys[I];
+      KeyRoots[Count] := AddTempRootIfNeeded(Keys[Count]);
       Iterators[Count] := InnerIterator;
       GC.AddTempRoot(InnerIterator);
       Inc(Count);
@@ -1811,11 +1822,13 @@ begin
     begin
       CloseIteratorPreservingError(Iterators[J]);
       GC.RemoveTempRoot(Iterators[J]);
+      RemoveTempRootIfNeeded(Keys[J], KeyRoots[J]);
     end;
     raise;
   end;
 
   SetLength(Padding, Count);
+  SetLength(PaddingRoots, Count);
   for I := 0 to Count - 1 do
     Padding[I] := TGocciaUndefinedLiteralValue.UndefinedValue;
 
@@ -1830,7 +1843,10 @@ begin
           Keys[I]);
         if Assigned(PropValue) and
            not (PropValue is TGocciaUndefinedLiteralValue) then
+        begin
+          PaddingRoots[I] := AddTempRootIfNeeded(PropValue);
           Padding[I] := PropValue;
+        end;
       end;
     end;
 
@@ -1846,6 +1862,10 @@ begin
     // Unroot iterators — the zipKeyed iterator now owns them via MarkReferences
     for I := 0 to Count - 1 do
       GC.RemoveTempRoot(Iterators[I]);
+    for I := 0 to Count - 1 do
+      RemoveTempRootIfNeeded(Keys[I], KeyRoots[I]);
+    for I := 0 to Count - 1 do
+      RemoveTempRootIfNeeded(Padding[I], PaddingRoots[I]);
   end;
 end;
 

--- a/source/units/Goccia.Values.ObjectPropertyDescriptor.pas
+++ b/source/units/Goccia.Values.ObjectPropertyDescriptor.pas
@@ -341,24 +341,25 @@ begin
   Getter := nil;
   Setter := nil;
 
-  // ES2026 §6.2.5.5 steps 3–9: extract descriptor fields
+  // ES2026 §6.2.5.5 steps 3-9: extract descriptor fields in observable order.
   HasEnumerableField := DescObj.HasProperty(PROP_ENUMERABLE);
-  HasConfigurableField := DescObj.HasProperty(PROP_CONFIGURABLE);
-  HasValue := DescObj.HasProperty(PROP_VALUE);
-  HasGet := DescObj.HasProperty(PROP_GET);
-  HasSet := DescObj.HasProperty(PROP_SET);
-  HasWritableField := DescObj.HasProperty(PROP_WRITABLE);
-
   if HasEnumerableField then
     Enumerable := DescObj.GetProperty(PROP_ENUMERABLE).ToBooleanLiteral.Value;
+
+  HasConfigurableField := DescObj.HasProperty(PROP_CONFIGURABLE);
   if HasConfigurableField then
     Configurable := DescObj.GetProperty(PROP_CONFIGURABLE).ToBooleanLiteral.Value;
+
+  HasValue := DescObj.HasProperty(PROP_VALUE);
   if HasValue then
     Value := DescObj.GetProperty(PROP_VALUE);
+
+  HasWritableField := DescObj.HasProperty(PROP_WRITABLE);
   if HasWritableField then
     Writable := DescObj.GetProperty(PROP_WRITABLE).ToBooleanLiteral.Value;
 
   // ES2026 §6.2.5.5 step 7: validate getter
+  HasGet := DescObj.HasProperty(PROP_GET);
   if HasGet then
   begin
     Getter := DescObj.GetProperty(PROP_GET);
@@ -369,6 +370,7 @@ begin
   end;
 
   // ES2026 §6.2.5.5 step 8: validate setter
+  HasSet := DescObj.HasProperty(PROP_SET);
   if HasSet then
   begin
     Setter := DescObj.GetProperty(PROP_SET);

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -95,6 +95,13 @@ type
     function GetOwnPropertyNames: TArray<string>; virtual;
     function GetOwnPropertyKeys: TArray<string>; virtual;
 
+    function OwnPropertyKeyValues: TArray<TGocciaValue>;
+    function OwnPropertyDescriptorForKey(
+      const AKey: TGocciaValue): TGocciaPropertyDescriptor;
+    procedure DefineOwnPropertyOrThrowForKey(
+      const AKey: TGocciaValue;
+      const ADescriptor: TGocciaPropertyDescriptor);
+
     procedure DefineSymbolProperty(const ASymbol: TGocciaSymbolValue; const ADescriptor: TGocciaPropertyDescriptor); virtual;
     function TryDefineSymbolProperty(const ASymbol: TGocciaSymbolValue; const ADescriptor: TGocciaPropertyDescriptor): Boolean; virtual;
     procedure AssignSymbolProperty(const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue);
@@ -365,6 +372,25 @@ begin
     ADescriptor.Free;
     raise;
   end;
+end;
+
+function TGocciaObjectValue.OwnPropertyKeyValues: TArray<TGocciaValue>;
+begin
+  Result := Goccia.Values.ObjectValue.OwnPropertyKeyValues(Self);
+end;
+
+function TGocciaObjectValue.OwnPropertyDescriptorForKey(
+  const AKey: TGocciaValue): TGocciaPropertyDescriptor;
+begin
+  Result := Goccia.Values.ObjectValue.OwnPropertyDescriptorForKey(Self, AKey);
+end;
+
+procedure TGocciaObjectValue.DefineOwnPropertyOrThrowForKey(
+  const AKey: TGocciaValue;
+  const ADescriptor: TGocciaPropertyDescriptor);
+begin
+  Goccia.Values.ObjectValue.DefineOwnPropertyOrThrowForKey(Self, AKey,
+    ADescriptor);
 end;
 
 procedure MarkPropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor);
@@ -1938,10 +1964,10 @@ var
   Keys: TArray<TGocciaValue>;
 begin
   PreventExtensions;
-  Keys := OwnPropertyKeyValues(Self);
+  Keys := Self.OwnPropertyKeyValues;
   for I := 0 to High(Keys) do
   begin
-    Descriptor := OwnPropertyDescriptorForKey(Self, Keys[I]);
+    Descriptor := Self.OwnPropertyDescriptorForKey(Keys[I]);
     if not Assigned(Descriptor) then
       Continue;
     if IsAccessorDescriptor(Descriptor) then
@@ -1954,7 +1980,7 @@ begin
     else
       NewDescriptor := TGocciaPropertyDescriptor.Create([],
         [pdfConfigurable]);
-    DefineOwnPropertyOrThrowForKey(Self, Keys[I], NewDescriptor);
+    Self.DefineOwnPropertyOrThrowForKey(Keys[I], NewDescriptor);
   end;
   FFrozen := True;
   FSealed := True;
@@ -1967,9 +1993,9 @@ var
   Keys: TArray<TGocciaValue>;
 begin
   PreventExtensions;
-  Keys := OwnPropertyKeyValues(Self);
+  Keys := Self.OwnPropertyKeyValues;
   for I := 0 to High(Keys) do
-    DefineOwnPropertyOrThrowForKey(Self, Keys[I],
+    Self.DefineOwnPropertyOrThrowForKey(Keys[I],
       TGocciaPropertyDescriptor.Create([], [pdfConfigurable]));
   FSealed := True;
   FExtensible := False;
@@ -1998,10 +2024,10 @@ begin
     Exit(False);
 
   // Step 5: For each element key of keys
-  Keys := OwnPropertyKeyValues(Self);
+  Keys := Self.OwnPropertyKeyValues;
   for I := 0 to High(Keys) do
   begin
-    Descriptor := OwnPropertyDescriptorForKey(Self, Keys[I]);
+    Descriptor := Self.OwnPropertyDescriptorForKey(Keys[I]);
     if not Assigned(Descriptor) then
       Continue;
     if Descriptor.Configurable then
@@ -2032,10 +2058,10 @@ begin
     Exit(False);
 
   // Step 5: For each element key of keys
-  Keys := OwnPropertyKeyValues(Self);
+  Keys := Self.OwnPropertyKeyValues;
   for I := 0 to High(Keys) do
   begin
-    Descriptor := OwnPropertyDescriptorForKey(Self, Keys[I]);
+    Descriptor := Self.OwnPropertyDescriptorForKey(Keys[I]);
     if Assigned(Descriptor) and Descriptor.Configurable then
       Exit(False);
   end;

--- a/tests/built-ins/Iterator/concat.js
+++ b/tests/built-ins/Iterator/concat.js
@@ -61,6 +61,11 @@ describe("Iterator.concat()", () => {
     expect(() => Iterator.concat("hi", [1, 2])).toThrow(TypeError);
   });
 
+  test("concatenates boxed string objects", () => {
+    const result = Iterator.concat(Object("ab"), Object("cd")).toArray();
+    expect(result).toEqual(["a", "b", "c", "d"]);
+  });
+
   test("is lazy — does not consume iterables until next() is called", () => {
     let opened = 0;
     const iterable1 = {

--- a/tests/built-ins/Iterator/concat.js
+++ b/tests/built-ins/Iterator/concat.js
@@ -53,14 +53,12 @@ describe("Iterator.concat()", () => {
     expect(result).toEqual([1, 2, 3, 4]);
   });
 
-  test("concatenates strings (character iteration)", () => {
-    const result = Iterator.concat("ab", "cd").toArray();
-    expect(result).toEqual(["a", "b", "c", "d"]);
+  test("throws TypeError for string primitive arguments", () => {
+    expect(() => Iterator.concat("ab", "cd")).toThrow(TypeError);
   });
 
-  test("concatenates string with array", () => {
-    const result = Iterator.concat("hi", [1, 2]).toArray();
-    expect(result).toEqual(["h", "i", 1, 2]);
+  test("throws TypeError when a string primitive is mixed with arrays", () => {
+    expect(() => Iterator.concat("hi", [1, 2])).toThrow(TypeError);
   });
 
   test("is lazy — does not consume iterables until next() is called", () => {

--- a/tests/built-ins/Iterator/from.js
+++ b/tests/built-ins/Iterator/from.js
@@ -74,14 +74,14 @@ describe("Iterator.from()", () => {
     expect(iter.next().done).toBe(true);
   });
 
-  test("wrapped iterator throws TypeError when next returns non-object", () => {
+  test("wrapped iterator next returns the underlying raw result", () => {
     const iteratorLike = {
       next() {
         return 1;
       }
     };
     const iter = Iterator.from(iteratorLike);
-    expect(() => iter.next()).toThrow(TypeError);
+    expect(iter.next()).toBe(1);
   });
 
   test("wrapped iterator has helper methods", () => {
@@ -134,11 +134,12 @@ describe("Iterator.from()", () => {
     expect(() => Iterator.from(bad)).toThrow(TypeError);
   });
 
-  test("throws TypeError when [Symbol.iterator]() result has non-callable next", () => {
+  test("wrapped iterator throws TypeError when [Symbol.iterator]() result has non-callable next", () => {
     const bad = {
       [Symbol.iterator]: () => ({ next: 42 }),
       next: () => ({ done: true }) // outer next is callable but must NOT be used
     };
-    expect(() => Iterator.from(bad)).toThrow(TypeError);
+    const iter = Iterator.from(bad);
+    expect(() => iter.next()).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Iterator/from.js
+++ b/tests/built-ins/Iterator/from.js
@@ -74,6 +74,18 @@ describe("Iterator.from()", () => {
     expect(iter.next().done).toBe(true);
   });
 
+  test("wrapped iterator inherits Symbol.iterator from the shared prototype", () => {
+    const iteratorLike = {
+      next() {
+        return { value: undefined, done: true };
+      }
+    };
+    const iter = Iterator.from(iteratorLike);
+
+    expect(Object.prototype.hasOwnProperty.call(iter, Symbol.iterator)).toBe(false);
+    expect(iter[Symbol.iterator]()).toBe(iter);
+  });
+
   test("wrapped iterator next returns the underlying raw result", () => {
     const iteratorLike = {
       next() {

--- a/tests/built-ins/Iterator/prototype/reduce.js
+++ b/tests/built-ins/Iterator/prototype/reduce.js
@@ -3,6 +3,8 @@ description: Iterator.prototype.reduce helper behavior
 features: [Iterator.prototype.reduce]
 ---*/
 
+const hasGoccia = typeof Goccia !== "undefined";
+
 describe("Iterator.prototype.reduce()", () => {
   test("reduces with an initial value", () => {
     expect([1, 2, 3].values().reduce((acc, x) => acc + x, 0)).toBe(6);
@@ -105,5 +107,28 @@ describe("Iterator.prototype.reduce()", () => {
       }, []);
 
     expect(result).toEqual([3, 4, 6, 3, 6, 9]);
+  });
+
+  describe.runIf(hasGoccia)("explicit GC", () => {
+    test("keeps callback value and index alive while reducer runs", () => {
+      let count = 0;
+      const source = Iterator.from({
+        next() {
+          count = count + 1;
+          if (count <= 2) {
+            return { value: { marker: "v" + count }, done: false };
+          }
+          return { value: undefined, done: true };
+        }
+      });
+
+      const result = source.reduce((acc, value, index) => {
+        Goccia.gc();
+        acc.push(value.marker + ":" + index);
+        return acc;
+      }, []);
+
+      expect(result).toEqual(["v1:0", "v2:1"]);
+    });
   });
 });

--- a/tests/built-ins/Iterator/prototype/reduce.js
+++ b/tests/built-ins/Iterator/prototype/reduce.js
@@ -61,7 +61,7 @@ describe("Iterator.prototype.reduce()", () => {
     expect(closed).toBe(1);
   });
 
-  test("reduce closes the source iterator when next() throws after iteration starts", () => {
+  test("reduce does not close the source iterator when next() throws after iteration starts", () => {
     let closed = 0;
     const source = Iterator.from({
       count: 0,
@@ -79,7 +79,7 @@ describe("Iterator.prototype.reduce()", () => {
     });
 
     expect(() => source.reduce((acc, x) => acc + x)).toThrow(Error);
-    expect(closed).toBe(1);
+    expect(closed).toBe(0);
   });
 
   test("reduce preserves the original error when return is not callable", () => {

--- a/tests/built-ins/Iterator/zip.js
+++ b/tests/built-ins/Iterator/zip.js
@@ -3,6 +3,8 @@ description: Iterator.zip() combines multiple iterables into an iterator of arra
 features: [Iterator, Iterator.zip]
 ---*/
 
+const hasGoccia = typeof Goccia !== "undefined";
+
 describe("Iterator.zip()", () => {
   test("zips two arrays of equal length", () => {
     const result = Iterator.zip([[1, 2, 3], ["a", "b", "c"]]).toArray();
@@ -198,6 +200,36 @@ describe("Iterator.zip() — longest mode", () => {
       { mode: "longest", padding: [99, 0] }
     ).toArray();
     expect(result).toEqual([[99, 1], [99, 2]]);
+  });
+
+  describe.runIf(hasGoccia)("explicit GC", () => {
+    test("keeps padding values alive until the zip iterator owns them", () => {
+      let index = 0;
+      const padding = {
+        [Symbol.iterator]() {
+          return {
+            next() {
+              index = index + 1;
+              if (index === 2) {
+                Goccia.gc();
+              }
+              if (index <= 2) {
+                return { value: { marker: "padding-" + index }, done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      };
+
+      const result = Iterator.zip(
+        [[1], [2, 3]],
+        { mode: "longest", padding }
+      ).toArray();
+
+      expect(result[1][0].marker).toBe("padding-1");
+      expect(result[1][1]).toBe(3);
+    });
   });
 });
 

--- a/tests/built-ins/Iterator/zip.js
+++ b/tests/built-ins/Iterator/zip.js
@@ -63,9 +63,8 @@ describe("Iterator.zip()", () => {
     expect(result).toEqual([[1, "a"], [2, "b"]]);
   });
 
-  test("zips strings (character iteration)", () => {
-    const result = Iterator.zip(["ab", "cd"]).toArray();
-    expect(result).toEqual([["a", "c"], ["b", "d"]]);
+  test("throws TypeError for string primitive iterable items", () => {
+    expect(() => Iterator.zip(["ab", "cd"])).toThrow(TypeError);
   });
 
   test("result is an iterator (has next and Symbol.iterator)", () => {
@@ -143,8 +142,8 @@ describe("Iterator.zip()", () => {
     expect(() => Iterator.zip()).toThrow(TypeError);
   });
 
-  test("throws RangeError for invalid mode", () => {
-    expect(() => Iterator.zip([[1]], { mode: "invalid" })).toThrow(RangeError);
+  test("throws TypeError for invalid mode", () => {
+    expect(() => Iterator.zip([[1]], { mode: "invalid" })).toThrow(TypeError);
   });
 
   test("ignores options if undefined", () => {

--- a/tests/built-ins/Iterator/zipKeyed.js
+++ b/tests/built-ins/Iterator/zipKeyed.js
@@ -102,15 +102,11 @@ describe("Iterator.zipKeyed()", () => {
     expect(result).toEqual([33, 44]);
   });
 
-  test("zips with string values (character iteration)", () => {
-    const result = Iterator.zipKeyed({
+  test("throws TypeError for string primitive property values", () => {
+    expect(() => Iterator.zipKeyed({
       first: "ab",
       second: "cd",
-    }).toArray();
-    expect(result).toEqual([
-      { first: "a", second: "c" },
-      { first: "b", second: "d" },
-    ]);
+    })).toThrow(TypeError);
   });
 
   test("throws TypeError for non-object first argument", () => {
@@ -129,8 +125,8 @@ describe("Iterator.zipKeyed()", () => {
     expect(() => Iterator.zipKeyed()).toThrow(TypeError);
   });
 
-  test("throws RangeError for invalid mode", () => {
-    expect(() => Iterator.zipKeyed({ x: [1] }, { mode: "bad" })).toThrow(RangeError);
+  test("throws TypeError for invalid mode", () => {
+    expect(() => Iterator.zipKeyed({ x: [1] }, { mode: "bad" })).toThrow(TypeError);
   });
 
   test("ignores options if undefined", () => {

--- a/tests/built-ins/Iterator/zipKeyed.js
+++ b/tests/built-ins/Iterator/zipKeyed.js
@@ -3,6 +3,8 @@ description: Iterator.zipKeyed() combines keyed iterables into an iterator of ob
 features: [Iterator, Iterator.zipKeyed]
 ---*/
 
+const hasGoccia = typeof Goccia !== "undefined";
+
 describe("Iterator.zipKeyed()", () => {
   test("zips keyed object with array values", () => {
     const result = Iterator.zipKeyed({
@@ -198,6 +200,28 @@ describe("Iterator.zipKeyed() — longest mode", () => {
       { mode: "longest" }
     ).toArray();
     expect(result).toEqual([]);
+  });
+
+  describe.runIf(hasGoccia)("explicit GC", () => {
+    test("keeps padding values alive until the zipKeyed iterator owns them", () => {
+      const padding = {
+        get x() {
+          return { marker: "padding-x" };
+        },
+        get y() {
+          Goccia.gc();
+          return { marker: "padding-y" };
+        },
+      };
+
+      const result = Iterator.zipKeyed(
+        { x: [1], y: [2, 3] },
+        { mode: "longest", padding }
+      ).toArray();
+
+      expect(result[1].x.marker).toBe("padding-x");
+      expect(result[1].y).toBe(3);
+    });
   });
 });
 

--- a/tests/built-ins/Iterator/zipKeyed.js
+++ b/tests/built-ins/Iterator/zipKeyed.js
@@ -121,6 +121,7 @@ describe("Iterator.zipKeyed()", () => {
   test("throws TypeError for non-iterable property value", () => {
     expect(() => Iterator.zipKeyed({ x: 42 }).toArray()).toThrow(TypeError);
     expect(() => Iterator.zipKeyed({ x: [1], y: null }).toArray()).toThrow(TypeError);
+    expect(() => Iterator.zipKeyed({ x: undefined }).toArray()).toThrow(TypeError);
   });
 
   test("throws TypeError with no arguments", () => {

--- a/tests/built-ins/Object/property-descriptor-order.js
+++ b/tests/built-ins/Object/property-descriptor-order.js
@@ -1,0 +1,38 @@
+/*---
+description: ToPropertyDescriptor observes descriptor fields in spec order
+features: [Object.defineProperty, Proxy]
+---*/
+
+test("Object.defineProperty interleaves descriptor has/get operations", () => {
+  const log = [];
+  const descriptor = new Proxy({
+    enumerable: true,
+    configurable: true,
+    value: 1,
+    writable: true,
+  }, {
+    has(target, key) {
+      log.push("has:" + key);
+      return Reflect.has(target, key);
+    },
+    get(target, key, receiver) {
+      log.push("get:" + key);
+      return Reflect.get(target, key, receiver);
+    },
+  });
+
+  Object.defineProperty({}, "value", descriptor);
+
+  expect(log).toEqual([
+    "has:enumerable",
+    "get:enumerable",
+    "has:configurable",
+    "get:configurable",
+    "has:value",
+    "get:value",
+    "has:writable",
+    "get:writable",
+    "has:get",
+    "has:set",
+  ]);
+});

--- a/tests/language/declarations/const/multiple-variables.js
+++ b/tests/language/declarations/const/multiple-variables.js
@@ -188,4 +188,9 @@ test("const with destructuring patterns", () => {
   } = sourceObject;
   expect(city).toBe("New York");
   expect(zip).toBe("10001");
+
+  // Full object binding syntax accepts IdentifierName property keys even when
+  // the key itself would be reserved as a binding name.
+  const { return: returnValue } = { return: "done" };
+  expect(returnValue).toBe("done");
 });


### PR DESCRIPTION
## Summary

- Complete #835 by aligning Iterator.from wrapper semantics, iterator helper close/return behavior, Iterator.concat, Iterator.zip, Iterator.zipKeyed, and AsyncIteratorPrototype[Symbol.asyncDispose] with the pinned test262 suite.
- Add shared GetIteratorFlattenable support, keyed/symbol zipKeyed handling, null-prototype keyed results, reverse-order iterator cleanup, and wrapper objects for valid iterator records.
- Fix two adjacent observable conformance gaps found by staging iterator tests: object binding pattern IdentifierName keys and ToPropertyDescriptor trap order.
- Keep the iterator benchmark suite aligned with Iterator.concat primitive rejection by benchmarking boxed string objects instead of string primitives.
- Address review feedback by rooting zip padding values, zipKeyed keys/padding, and reduce callback value/index inputs; wrap-for-valid iterators now inherit `[Symbol.iterator]`, and zipKeyed validates enumerable `undefined` property values through iterator acquisition.

Closes #835

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation run locally:

- `./format.pas --check`
- `./build.pas loaderbare`
- `./build.pas --clean benchmarkrunner testrunner`
- `./build.pas testrunner`
- `./build.pas benchmarkrunner`
- `./build/GocciaTestRunner tests` - 11172/11172 passed
- `./build/GocciaTestRunner tests --mode=bytecode` - 11172/11172 passed
- `./build/GocciaTestRunner tests/built-ins/Iterator/concat.js --no-progress --silent` - 21/21 passed
- `./build/GocciaTestRunner tests/built-ins/Iterator/concat.js --mode=bytecode --no-progress --silent` - 21/21 passed
- `./build/GocciaTestRunner tests/built-ins/Iterator/zip.js tests/built-ins/Iterator/zipKeyed.js --no-progress --silent` - 66/66 passed
- `./build/GocciaTestRunner tests/built-ins/Iterator/zip.js tests/built-ins/Iterator/zipKeyed.js --mode=bytecode --no-progress --silent` - 66/66 passed
- `./build/GocciaTestRunner tests/built-ins/Iterator/from.js tests/built-ins/Iterator/prototype/reduce.js tests/built-ins/Iterator/zipKeyed.js --no-progress --silent` - 56/56 passed
- `./build/GocciaTestRunner tests/built-ins/Iterator/from.js tests/built-ins/Iterator/prototype/reduce.js tests/built-ins/Iterator/zipKeyed.js --mode=bytecode --no-progress --silent` - 56/56 passed
- `./build/GocciaBenchmarkRunner benchmarks --no-progress --format=compact-json` - ok=true, 437/437 passed
- `./build/GocciaBenchmarkRunner benchmarks --mode=bytecode --no-progress --format=compact-json` - ok=true, 437/437 passed
- `GOCCIA_BENCH_CALIBRATION_MS=1 GOCCIA_BENCH_ROUNDS=1 GOCCIA_BENCH_WARMUP=1 ./build/GocciaBenchmarkRunner benchmarks --no-progress --jobs=1 --format=json --output=tmp/bench-interpreted-fixed-postmerge.json` - 437/437 passed
- `GOCCIA_BENCH_CALIBRATION_MS=1 GOCCIA_BENCH_ROUNDS=1 GOCCIA_BENCH_WARMUP=1 ./build/GocciaBenchmarkRunner benchmarks --mode=bytecode --no-progress --jobs=1 --format=json --output=tmp/bench-bytecode-fixed-postmerge.json` - 437/437 passed
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --filter "built-ins/Iterator/**/*.js" --mode=bytecode --jobs=6 --timeout-ms=20000` - 506/506 passed
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --filter "staging/sm/Iterator/**/*.js" --mode=bytecode --jobs=6 --timeout-ms=20000` - 166/166 passed
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --filter "built-ins/AsyncIteratorPrototype/**/*.js" --mode=bytecode --jobs=4 --timeout-ms=20000` - 13/13 passed
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --filter "intl402/ListFormat/prototype/format*/iterable-*.js" --mode=bytecode --jobs=4 --timeout-ms=20000` - 12/12 passed
- `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb74075849d1e404bbcdb62feb7a02e6966db --filter "intl402/Segmenter/prototype/segment/name_of_symbol_iterator.js" --mode=bytecode --jobs=2 --timeout-ms=20000` - 1/1 passed
