### PR TITLE
fix(reflect): close remaining test262 conformance gaps

### DIFF
--- a/source/units/Goccia.Arguments.ArrayLike.pas
+++ b/source/units/Goccia.Arguments.ArrayLike.pas
@@ -22,6 +22,7 @@ uses
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.HoleValue,
   Goccia.Values.ObjectValue;
 
 const
@@ -49,7 +50,12 @@ begin
     ArrVal := TGocciaArrayValue(AValue);
     Result := TGocciaArgumentsCollection.CreateWithCapacity(ArrVal.Elements.Count);
     for I := 0 to ArrVal.Elements.Count - 1 do
-      Result.Add(ArrVal.Elements[I]);
+    begin
+      Element := ArrVal.Elements[I];
+      if Element = TGocciaHoleValue.HoleValue then
+        Element := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Result.Add(Element);
+    end;
     Exit;
   end;
 

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -205,6 +205,10 @@ begin
 
   // Step 2: Let key be ? ToPropertyKey(propertyKey)
   PropKey := ToPropertyKey(AArgs.GetElement(1));
+  Attrs := AArgs.GetElement(2);
+  if not (Attrs is TGocciaObjectValue) then
+    ThrowTypeError(SErrorReflectDefinePropertyAttrsMustBeObject, SSuggestPropertyDescriptorObject);
+
   IsSymbolKey := PropKey is TGocciaSymbolValue;
   SymbolKey := nil;
   PropertyName := '';
@@ -223,10 +227,6 @@ begin
   end;
 
   // Step 3: Let desc be ? ToPropertyDescriptor(Attributes)
-  Attrs := AArgs.GetElement(2);
-  if not (Attrs is TGocciaObjectValue) then
-    ThrowTypeError(SErrorReflectDefinePropertyAttrsMustBeObject, SSuggestPropertyDescriptorObject);
-
   DescriptorObject := TGocciaObjectValue(Attrs);
   Descriptor := ToPropertyDescriptor(DescriptorObject, ExistingDescriptor);
 

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -118,8 +118,6 @@ var
   ArgsList: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 3, 'Reflect.apply', ThrowError);
-
   Target := AArgs.GetElement(0);
   ThisArg := AArgs.GetElement(1);
   ArgsList := AArgs.GetElement(2);
@@ -200,26 +198,18 @@ var
   SymbolKey: TGocciaSymbolValue;
   Success: Boolean;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 3, 'Reflect.defineProperty', ThrowError);
-
   Target := AArgs.GetElement(0);
-  PropKey := ToPropertyKey(AArgs.GetElement(1));
-  Attrs := AArgs.GetElement(2);
 
   // Step 1: If target is not an Object, throw a TypeError exception
   RequireObjectTarget(Target, 'Reflect.defineProperty');
 
-  if not (Attrs is TGocciaObjectValue) then
-    ThrowTypeError(SErrorReflectDefinePropertyAttrsMustBeObject, SSuggestPropertyDescriptorObject);
-
-  Obj := TGocciaObjectValue(Target);
-  DescriptorObject := TGocciaObjectValue(Attrs);
-
   // Step 2: Let key be ? ToPropertyKey(propertyKey)
+  PropKey := ToPropertyKey(AArgs.GetElement(1));
   IsSymbolKey := PropKey is TGocciaSymbolValue;
   SymbolKey := nil;
   PropertyName := '';
   ExistingDescriptor := nil;
+  Obj := TGocciaObjectValue(Target);
 
   if IsSymbolKey then
   begin
@@ -233,6 +223,11 @@ begin
   end;
 
   // Step 3: Let desc be ? ToPropertyDescriptor(Attributes)
+  Attrs := AArgs.GetElement(2);
+  if not (Attrs is TGocciaObjectValue) then
+    ThrowTypeError(SErrorReflectDefinePropertyAttrsMustBeObject, SSuggestPropertyDescriptorObject);
+
+  DescriptorObject := TGocciaObjectValue(Attrs);
   Descriptor := ToPropertyDescriptor(DescriptorObject, ExistingDescriptor);
 
   // Step 4: Return target.[[DefineOwnProperty]](key, desc) — returns boolean.
@@ -356,21 +351,6 @@ begin
   end;
 
   DescriptorObj := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-  if Descriptor.HasEnumerableField then
-  begin
-    if Descriptor.Enumerable then
-      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
-  end;
-  if Descriptor.HasConfigurableField then
-  begin
-    if Descriptor.Configurable then
-      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
-    else
-      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
-  end;
-
   if Descriptor is TGocciaPropertyDescriptorData then
   begin
     if Descriptor.HasValue then
@@ -400,6 +380,20 @@ begin
         DescriptorObj.AssignProperty(PROP_SET, TGocciaUndefinedLiteralValue.UndefinedValue);
     end;
   end;
+  if Descriptor.HasEnumerableField then
+  begin
+    if Descriptor.Enumerable then
+      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      DescriptorObj.AssignProperty(PROP_ENUMERABLE, TGocciaBooleanLiteralValue.FalseValue);
+  end;
+  if Descriptor.HasConfigurableField then
+  begin
+    if Descriptor.Configurable then
+      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.TrueValue)
+    else
+      DescriptorObj.AssignProperty(PROP_CONFIGURABLE, TGocciaBooleanLiteralValue.FalseValue);
+  end;
 
   Result := DescriptorObj;
 end;
@@ -417,6 +411,12 @@ begin
   RequireObjectTarget(Target, 'Reflect.getPrototypeOf');
 
   // Step 2: Return ? target.[[GetPrototypeOf]]()
+  if Target is TGocciaProxyValue then
+  begin
+    Result := TGocciaProxyValue(Target).GetPrototypeTrap;
+    Exit;
+  end;
+
   if Assigned(TGocciaObjectValue(Target).Prototype) then
     Result := TGocciaObjectValue(Target).Prototype
   else
@@ -472,6 +472,15 @@ begin
   RequireObjectTarget(Target, 'Reflect.isExtensible');
 
   // Step 2: Return ? target.[[IsExtensible]]()
+  if Target is TGocciaProxyValue then
+  begin
+    if TGocciaProxyValue(Target).IsExtensibleTrap then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+
   if TGocciaObjectValue(Target).Extensible then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
@@ -535,8 +544,10 @@ begin
   RequireObjectTarget(Target, 'Reflect.preventExtensions');
 
   // Step 2: Return ? target.[[PreventExtensions]]()
-  TGocciaObjectValue(Target).PreventExtensions;
-  Result := TGocciaBooleanLiteralValue.TrueValue;
+  if TGocciaObjectValue(Target).TryPreventExtensions then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
 end;
 
 // ES2026 §28.1.12 Reflect.set(target, propertyKey, V [, receiver])
@@ -599,6 +610,15 @@ begin
     ThrowTypeError(SErrorReflectSetPrototypeOfProtoType, SSuggestReflectObjectArg);
 
   // Step 3: Return ? target.[[SetPrototypeOf]](proto)
+  if Target is TGocciaProxyValue then
+  begin
+    if TGocciaProxyValue(Target).SetPrototypeTrap(ProtoArg) then
+      Result := TGocciaBooleanLiteralValue.TrueValue
+    else
+      Result := TGocciaBooleanLiteralValue.FalseValue;
+    Exit;
+  end;
+
   // ES2026 §10.1.2 OrdinarySetPrototypeOf step 2: If SameValue(V, current) return true
   if ProtoArg is TGocciaNullLiteralValue then
   begin

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -66,6 +66,9 @@ resourcestring
   // Type errors — delete
   SErrorCannotDeletePropertyOf = 'Cannot delete property ''%s'' of %s';
 
+  // Type errors — object integrity
+  SErrorCannotPreventExtensions = 'Cannot prevent extensions on this object';
+
   // Array errors
   SErrorSpeciesNotConstructor = 'Species is not a constructor';
   SErrorInvalidArrayLength = 'Invalid array length';

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -109,6 +109,7 @@ type
 
     procedure Freeze; virtual;
     procedure Seal; virtual;
+    function TryPreventExtensions: Boolean; virtual;
     procedure PreventExtensions; virtual;
 
     // ES2026 §7.3.16 TestIntegrityLevel(O, level)
@@ -1975,9 +1976,16 @@ begin
   FExtensible := False;
 end;
 
-procedure TGocciaObjectValue.PreventExtensions;
+function TGocciaObjectValue.TryPreventExtensions: Boolean;
 begin
   FExtensible := False;
+  Result := True;
+end;
+
+procedure TGocciaObjectValue.PreventExtensions;
+begin
+  if not TryPreventExtensions then
+    ThrowTypeError(SErrorCannotPreventExtensions, SSuggestObjectNotExtensible);
 end;
 
 // ES2026 §7.3.16 TestIntegrityLevel(O, frozen)

--- a/source/units/Goccia.Values.ProxyValue.pas
+++ b/source/units/Goccia.Values.ProxyValue.pas
@@ -96,7 +96,8 @@ type
     // ES2026 §28.1.1 [[IsExtensible]]()
     function IsExtensibleTrap: Boolean;
 
-    // ES2026 §28.1.1 [[PreventExtensions]]()
+    // ES2026 §10.5.4 [[PreventExtensions]]()
+    function TryPreventExtensions: Boolean; override;
     procedure PreventExtensions; override;
 
     // ES2026 §28.1.1 [[Call]](thisArgument, argumentsList)
@@ -1675,8 +1676,8 @@ begin
   end;
 end;
 
-// ES2026 §28.1.1 [[PreventExtensions]]()
-procedure TGocciaProxyValue.PreventExtensions;
+// ES2026 §10.5.4 [[PreventExtensions]]()
+function TGocciaProxyValue.TryPreventExtensions: Boolean;
 var
   Trap: TGocciaValue;
   Args: TGocciaArgumentsCollection;
@@ -1691,7 +1692,7 @@ begin
       Args.Add(FTarget);
       TrapResult := InvokeTrap(Trap, Args);
       if not TrapResult.ToBooleanLiteral.Value then
-        ThrowTypeError(SErrorProxyPreventExtensionsFalse, SSuggestProxyTrapInvariant);
+        Exit(False);
     finally
       Args.Free;
     end;
@@ -1701,12 +1702,21 @@ begin
     if (FTarget is TGocciaObjectValue) and
        TGocciaObjectValue(FTarget).Extensible then
       ThrowTypeError(SErrorProxyPreventExtensionsStillExtensible, SSuggestProxyTrapInvariant);
+    Result := True;
   end
   else
   begin
     if FTarget is TGocciaObjectValue then
-      TGocciaObjectValue(FTarget).PreventExtensions;
+      Result := TGocciaObjectValue(FTarget).TryPreventExtensions
+    else
+      Result := False;
   end;
+end;
+
+procedure TGocciaProxyValue.PreventExtensions;
+begin
+  if not TryPreventExtensions then
+    ThrowTypeError(SErrorProxyPreventExtensionsFalse, SSuggestProxyTrapInvariant);
 end;
 
 // ES2026 §28.1.1 [[Call]](thisArgument, argumentsList)

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -82,6 +82,7 @@ type
     function GetOwnPropertyKeys: TArray<string>; override;
     function GetAllPropertyNames: TArray<string>; override;
     function ToStringTag: string; override;
+    function TryPreventExtensions: Boolean; override;
 
     procedure MarkReferences; override;
 
@@ -831,7 +832,7 @@ begin
   FBufferData := ASharedBuffer.Data;
   FByteOffset := AByteOffset;
   BPE := BytesPerElement(AKind);
-  FAutoLength := False;
+  FAutoLength := (ALength < 0) and (ASharedBuffer.MaxByteLength >= 0);
 
   if ALength >= 0 then
     FLength := ALength
@@ -1138,6 +1139,17 @@ begin
   end;
 
   Result := inherited GetOwnPropertyDescriptor(AName);
+end;
+
+function TGocciaTypedArrayValue.TryPreventExtensions: Boolean;
+begin
+  if (FBufferValue is TGocciaArrayBufferValue) and
+     (TGocciaArrayBufferValue(FBufferValue).MaxByteLength >= 0) then
+    Exit(False);
+  if (FBufferValue is TGocciaSharedArrayBufferValue) and FAutoLength then
+    Exit(False);
+
+  Result := inherited TryPreventExtensions;
 end;
 
 // ES2026 §10.4.5.7 [[Delete]](P)
@@ -2990,7 +3002,8 @@ begin
   if FirstArg is TGocciaArrayBufferValue then
   begin
     Buf := TGocciaArrayBufferValue(FirstArg);
-    if AArguments.Length > 1 then
+    if (AArguments.Length > 1) and
+       not (AArguments.GetElement(1) is TGocciaUndefinedLiteralValue) then
       ByteOff := ToIntegerOrInfinityBounded(AArguments.GetElement(1))
     else
       ByteOff := 0;
@@ -3042,7 +3055,8 @@ begin
   if FirstArg is TGocciaSharedArrayBufferValue then
   begin
     SAB := TGocciaSharedArrayBufferValue(FirstArg);
-    if AArguments.Length > 1 then
+    if (AArguments.Length > 1) and
+       not (AArguments.GetElement(1) is TGocciaUndefinedLiteralValue) then
       ByteOff := ToIntegerOrInfinityBounded(AArguments.GetElement(1))
     else
       ByteOff := 0;
@@ -3072,6 +3086,8 @@ begin
       if Int64(ByteOff) + Int64(ElemLen) * Int64(BPE) > Int64(BufferByteLength) then
         ThrowRangeError(SErrorInvalidTypedArrayLength, SSuggestTypedArrayLength);
     end
+    else if SAB.MaxByteLength >= 0 then
+      ElemLen := -1
     else
     begin
       if ((Int64(BufferByteLength) - Int64(ByteOff)) mod Int64(BPE)) <> 0 then

--- a/tests/built-ins/Object/preventExtensions.js
+++ b/tests/built-ins/Object/preventExtensions.js
@@ -18,6 +18,12 @@ describe("Object.preventExtensions", () => {
     expect(result).toBe(obj);
   });
 
+  test("throws when the object internal method returns false", () => {
+    const buffer = new ArrayBuffer(4, { maxByteLength: 8 });
+
+    expect(() => Object.preventExtensions(new Uint8Array(buffer))).toThrow(TypeError);
+  });
+
   test("non-objects are returned as-is", () => {
     expect(Object.preventExtensions(42)).toBe(42);
   });

--- a/tests/built-ins/Reflect/apply.js
+++ b/tests/built-ins/Reflect/apply.js
@@ -52,6 +52,12 @@ describe("Reflect.apply", () => {
     expect(result[1]).toBe(undefined);
   });
 
+  test("array holes in argumentsList are passed as undefined", () => {
+    const fn = (a, b, c, d) => [a, b, c, d];
+    const result = Reflect.apply(fn, undefined, ["arg1", 2, , null]);
+    expect(result).toEqual(["arg1", 2, undefined, null]);
+  });
+
   test("works with array-like object with string length", () => {
     const fn = (a) => a;
     const arrayLike = { 0: "hello", length: "1" };
@@ -63,5 +69,10 @@ describe("Reflect.apply", () => {
     expect(() => Reflect.apply(fn, undefined, "not-array")).toThrow(TypeError);
     expect(() => Reflect.apply(fn, undefined, 42)).toThrow(TypeError);
     expect(() => Reflect.apply(fn, undefined, true)).toThrow(TypeError);
+  });
+
+  test("throws TypeError when argumentsList is missing", () => {
+    const fn = () => {};
+    expect(() => Reflect.apply(fn, undefined)).toThrow(TypeError);
   });
 });

--- a/tests/built-ins/Reflect/defineProperty.js
+++ b/tests/built-ins/Reflect/defineProperty.js
@@ -71,6 +71,20 @@ describe("Reflect.defineProperty", () => {
     expect(() => Reflect.defineProperty(obj, "v", undefined)).toThrow(TypeError);
   });
 
+  test("propagates abrupt completion from property key before validating descriptor", () => {
+    const obj = {};
+    let propertyKeyWasConverted = false;
+    const propertyKey = {
+      toString() {
+        propertyKeyWasConverted = true;
+        throw new Error("property key failure");
+      },
+    };
+
+    expect(() => Reflect.defineProperty(obj, propertyKey)).toThrow(Error);
+    expect(propertyKeyWasConverted).toBe(true);
+  });
+
   test("throws TypeError for mixed data and accessor descriptors", () => {
     const obj = {};
 

--- a/tests/built-ins/Reflect/defineProperty.js
+++ b/tests/built-ins/Reflect/defineProperty.js
@@ -71,6 +71,19 @@ describe("Reflect.defineProperty", () => {
     expect(() => Reflect.defineProperty(obj, "v", undefined)).toThrow(TypeError);
   });
 
+  test("throws for invalid descriptor before target descriptor lookup", () => {
+    let trapCalled = false;
+    const proxy = new Proxy({}, {
+      getOwnPropertyDescriptor() {
+        trapCalled = true;
+        throw new Error("trap should not be called");
+      },
+    });
+
+    expect(() => Reflect.defineProperty(proxy, "x", undefined)).toThrow(TypeError);
+    expect(trapCalled).toBe(false);
+  });
+
   test("propagates abrupt completion from property key before validating descriptor", () => {
     const obj = {};
     let propertyKeyWasConverted = false;

--- a/tests/built-ins/Reflect/getOwnPropertyDescriptor.js
+++ b/tests/built-ins/Reflect/getOwnPropertyDescriptor.js
@@ -19,6 +19,23 @@ describe("Reflect.getOwnPropertyDescriptor", () => {
     expect(desc.configurable).toBe(true);
   });
 
+  test("returns data descriptor keys in FromPropertyDescriptor order", () => {
+    const obj = {};
+    Object.defineProperty(obj, "x", {
+      value: 42,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+
+    expect(Object.keys(Reflect.getOwnPropertyDescriptor(obj, "x"))).toEqual([
+      "value",
+      "writable",
+      "enumerable",
+      "configurable",
+    ]);
+  });
+
   test("returns descriptor for accessor property", () => {
     const obj = {};
     const getter = () => 10;
@@ -31,6 +48,43 @@ describe("Reflect.getOwnPropertyDescriptor", () => {
     expect(desc.get).toBe(getter);
     expect(desc.enumerable).toBe(true);
     expect(desc.configurable).toBe(true);
+  });
+
+  test("returns accessor descriptor keys in FromPropertyDescriptor order", () => {
+    const obj = {};
+    const getter = () => 10;
+    const setter = () => {};
+    Object.defineProperty(obj, "y", {
+      get: getter,
+      set: setter,
+      enumerable: true,
+      configurable: true,
+    });
+
+    expect(Object.keys(Reflect.getOwnPropertyDescriptor(obj, "y"))).toEqual([
+      "get",
+      "set",
+      "enumerable",
+      "configurable",
+    ]);
+  });
+
+  test("returns symbol data descriptor keys in FromPropertyDescriptor order", () => {
+    const sym = Symbol("x");
+    const obj = {};
+    Object.defineProperty(obj, sym, {
+      value: 1,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+
+    expect(Object.keys(Reflect.getOwnPropertyDescriptor(obj, sym))).toEqual([
+      "value",
+      "writable",
+      "enumerable",
+      "configurable",
+    ]);
   });
 
   test("returns undefined for non-existent property", () => {

--- a/tests/built-ins/Reflect/getPrototypeOf.js
+++ b/tests/built-ins/Reflect/getPrototypeOf.js
@@ -25,6 +25,16 @@ describe("Reflect.getPrototypeOf", () => {
     expect(Reflect.getPrototypeOf(a)).toBe(Animal.prototype);
   });
 
+  test("uses proxy getPrototypeOf trap and propagates abrupt completion", () => {
+    const proxy = new Proxy({}, {
+      getPrototypeOf() {
+        throw new Error("getPrototypeOf trap failed");
+      },
+    });
+
+    expect(() => Reflect.getPrototypeOf(proxy)).toThrow(Error);
+  });
+
   test("throws TypeError if target is not an object", () => {
     expect(() => Reflect.getPrototypeOf(42)).toThrow(TypeError);
     expect(() => Reflect.getPrototypeOf("str")).toThrow(TypeError);

--- a/tests/built-ins/Reflect/isExtensible.js
+++ b/tests/built-ins/Reflect/isExtensible.js
@@ -27,6 +27,16 @@ describe("Reflect.isExtensible", () => {
     expect(Reflect.isExtensible(obj)).toBe(false);
   });
 
+  test("uses proxy isExtensible trap and propagates abrupt completion", () => {
+    const proxy = new Proxy({}, {
+      isExtensible() {
+        throw new Error("isExtensible trap failed");
+      },
+    });
+
+    expect(() => Reflect.isExtensible(proxy)).toThrow(Error);
+  });
+
   test("throws TypeError if target is not an object", () => {
     expect(() => Reflect.isExtensible(42)).toThrow(TypeError);
     expect(() => Reflect.isExtensible("str")).toThrow(TypeError);

--- a/tests/built-ins/Reflect/preventExtensions.js
+++ b/tests/built-ins/Reflect/preventExtensions.js
@@ -17,6 +17,43 @@ describe("Reflect.preventExtensions", () => {
     expect(obj.x).toBe(42);
   });
 
+  test("returns false when proxy preventExtensions trap returns false", () => {
+    const proxy = new Proxy({}, {
+      preventExtensions() {
+        return false;
+      },
+    });
+
+    expect(Reflect.preventExtensions(proxy)).toBe(false);
+  });
+
+  test("returns true when proxy preventExtensions trap prevents target extensions", () => {
+    const target = {};
+    const proxy = new Proxy(target, {
+      preventExtensions(t) {
+        Object.preventExtensions(t);
+        return true;
+      },
+    });
+
+    expect(Reflect.preventExtensions(proxy)).toBe(true);
+    expect(Reflect.isExtensible(target)).toBe(false);
+  });
+
+  test("returns false for resizable ArrayBuffer typed array views", () => {
+    const buffer = new ArrayBuffer(4, { maxByteLength: 8 });
+
+    expect(Reflect.preventExtensions(new Uint8Array(buffer, 0, 4))).toBe(false);
+    expect(Reflect.preventExtensions(new Uint8Array(buffer))).toBe(false);
+  });
+
+  test("returns false for growable SharedArrayBuffer length-tracking views", () => {
+    const buffer = new SharedArrayBuffer(4, { maxByteLength: 8 });
+
+    expect(Reflect.preventExtensions(new Uint8Array(buffer, 0, 4))).toBe(true);
+    expect(Reflect.preventExtensions(new Uint8Array(buffer))).toBe(false);
+  });
+
   test("throws TypeError if target is not an object", () => {
     expect(() => Reflect.preventExtensions(42)).toThrow(TypeError);
     expect(() => Reflect.preventExtensions("str")).toThrow(TypeError);

--- a/tests/built-ins/Reflect/setPrototypeOf.js
+++ b/tests/built-ins/Reflect/setPrototypeOf.js
@@ -48,6 +48,16 @@ describe("Reflect.setPrototypeOf", () => {
     expect(Reflect.getPrototypeOf(b)).toBe(Object.getPrototypeOf({}));
   });
 
+  test("uses proxy setPrototypeOf trap and propagates abrupt completion", () => {
+    const proxy = new Proxy({}, {
+      setPrototypeOf() {
+        throw new Error("setPrototypeOf trap failed");
+      },
+    });
+
+    expect(() => Reflect.setPrototypeOf(proxy, {})).toThrow(Error);
+  });
+
   test("throws TypeError if target is not an object", () => {
     expect(() => Reflect.setPrototypeOf(42, {})).toThrow(TypeError);
     expect(() => Reflect.setPrototypeOf("str", {})).toThrow(TypeError);


### PR DESCRIPTION
## Summary

- Closes #848.
- Route Reflect operations through proxy/internal-method paths for getPrototypeOf, isExtensible, preventExtensions, and setPrototypeOf.
- Align Reflect.apply, Reflect.defineProperty, descriptor key order, sparse argument arrays, and resizable/growable buffer typed-array preventExtensions behavior with test262 expectations.
- Add focused local regressions for the fixed Reflect cases plus the Object.preventExtensions throwing path when [[PreventExtensions]] returns false.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas --clean loaderbare`
  - `bun scripts/run_test262_suite.ts --suite-dir /Users/jstein/.t3/worktrees/GocciaScript/t3code-1b8b43db/test262-suite --categories built-ins,staging,intl402 --filter 'built-ins/Reflect/**' --mode bytecode --jobs 1 --timeout-ms 20000 --output /tmp/goccia-reflect-848-builtins-results-final.json`
  - `./build.pas testrunner`
  - `./build/GocciaTestRunner tests/built-ins/Object/preventExtensions.js tests/built-ins/Reflect`
  - `./build/GocciaTestRunner tests/built-ins/Object/preventExtensions.js tests/built-ins/Reflect --mode=bytecode`
  - `./build/GocciaTestRunner tests`
  - `./build/GocciaTestRunner tests --mode=bytecode`
  - `./build.pas bundler`
  - `./build/GocciaBundler examples/basic.js`
  - `./format.pas --check`
- [ ] Updated documentation (not applicable; conformance/runtime fix only)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change