### PR TITLE
fix(typedarray): close buffer conformance gaps

### DIFF
--- a/scripts/test262_harness/$262.js
+++ b/scripts/test262_harness/$262.js
@@ -21,12 +21,34 @@ const AbstractModuleSource = () => {
 };
 const IsHTMLDDA = Goccia.test262.isHTMLDDA;
 
+function installRealm262(realm) {
+  const realm262 = {
+    global: realm.global,
+
+    detachArrayBuffer(buffer) {
+      if (buffer.detached) return;
+      buffer.transfer();
+    },
+
+    evalScript(sourceText) {
+      return realm.evalScript(sourceText);
+    },
+
+    createRealm() {
+      return installRealm262(realm.createRealm());
+    },
+  };
+  realm.global.$262 = realm262;
+  return realm;
+}
+
 var $262 = {
   global: globalThis,
   AbstractModuleSource,
   IsHTMLDDA,
 
   detachArrayBuffer(buffer) {
+    if (buffer.detached) return;
     buffer.transfer();
   },
 
@@ -39,7 +61,7 @@ var $262 = {
   },
 
   createRealm() {
-    return Goccia.test262.createRealm();
+    return installRealm262(Goccia.test262.createRealm());
   },
 
   agent: {

--- a/scripts/test262_harness/$262.js
+++ b/scripts/test262_harness/$262.js
@@ -24,6 +24,8 @@ const IsHTMLDDA = Goccia.test262.isHTMLDDA;
 function installRealm262(realm) {
   const realm262 = {
     global: realm.global,
+    AbstractModuleSource,
+    IsHTMLDDA,
 
     detachArrayBuffer(buffer) {
       if (buffer.detached) return;
@@ -39,7 +41,7 @@ function installRealm262(realm) {
     },
   };
   realm.global.$262 = realm262;
-  return realm;
+  return realm262;
 }
 
 var $262 = {

--- a/source/units/Goccia.Builtins.GlobalArrayBuffer.pas
+++ b/source/units/Goccia.Builtins.GlobalArrayBuffer.pas
@@ -148,8 +148,8 @@ var
   Proto: TGocciaObjectValue;
   AB: TGocciaArrayBufferValue;
 begin
-  Proto := GetProtoFromConstructorWithIntrinsic(ANewTarget, FArrayBufferIntrinsicProto);
   AB := TGocciaArrayBufferValue(ArrayBufferConstructorFn(AArgs, TGocciaHoleValue.HoleValue));
+  Proto := GetProtoFromConstructorWithIntrinsic(ANewTarget, FArrayBufferIntrinsicProto);
   AB.Prototype := Proto;
   Result := AB;
 end;

--- a/source/units/Goccia.Constants.PropertyNames.pas
+++ b/source/units/Goccia.Constants.PropertyNames.pas
@@ -46,6 +46,7 @@ const
   PROP_GOCCIA       = 'Goccia';
   PROP_GLOBAL_THIS  = 'globalThis';
   PROP_SLICE        = 'slice';
+  PROP_SLICE_TO_IMMUTABLE = 'sliceToImmutable';
   PROP_TAG_NAME     = 'tagName';
   PROP_NEXT         = 'next';
   PROP_RETURN       = 'return';

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1072,7 +1072,10 @@ begin
       nil, [pfConfigurable]));
   if Assigned(FBuiltinArrayBuffer) then
     for Key in FBuiltinArrayBuffer.BuiltinObject.GetAllPropertyNames do
-      ArrayBufferConstructor.SetProperty(Key, FBuiltinArrayBuffer.BuiltinObject.GetProperty(Key));
+      ArrayBufferConstructor.DefineProperty(Key,
+        TGocciaPropertyDescriptorData.Create(
+          FBuiltinArrayBuffer.BuiltinObject.GetProperty(Key),
+          [pfConfigurable, pfWritable]));
   FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_ARRAY_BUFFER, ArrayBufferConstructor, dtConst, True);
 
   SharedArrayBufferConstructor := TGocciaSharedArrayBufferClassValue.Create(CONSTRUCTOR_SHARED_ARRAY_BUFFER, nil);
@@ -1092,7 +1095,7 @@ begin
   FInterpreter.GlobalScope.DefineLexicalBinding(CONSTRUCTOR_DATA_VIEW, DataViewConstructor, dtConst, True);
 
   // Create %TypedArray% intrinsic (not globally exposed per spec §23.2.1)
-  FTypedArrayIntrinsic := TGocciaClassValue.Create('TypedArray', nil);
+  FTypedArrayIntrinsic := TGocciaTypedArrayIntrinsicClassValue.Create('TypedArray', nil);
   // §17: built-in name/length are {writable: false, enumerable: false, configurable: true}
   FTypedArrayIntrinsic.DefineProperty(PROP_NAME,
     TGocciaPropertyDescriptorData.Create(TGocciaStringLiteralValue.Create('TypedArray'), [pfConfigurable]));

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -10674,6 +10674,7 @@ var
   ConstructedValue: TGocciaValue;
   ConstructorThisValue: TGocciaValue;
   EffectiveNewTarget: TGocciaValue;
+  InstancePrototype: TGocciaObjectValue;
   InitializerReplayReceiver: TGocciaObjectValue;
   function ConstructNativeSuperInstance(
     const AConstructor: TGocciaObjectValue): TGocciaObjectValue;
@@ -10700,6 +10701,7 @@ var
     begin
       Result := TGocciaInstanceValue.Create(AClassValue,
         AClassValue.EstimatedInstancePropertyCapacity);
+      Result.Prototype := GetProtoFromConstructor(EffectiveNewTarget);
       Exit;
     end
     else
@@ -10782,6 +10784,10 @@ begin
     EffectiveNewTarget := ANewTarget
   else
     EffectiveNewTarget := AClassValue;
+  if Assigned(ANewTarget) then
+    InstancePrototype := GetProtoFromConstructor(ANewTarget)
+  else
+    InstancePrototype := AClassValue.Prototype;
 
   // ES2026 §20.1.1.1 Object(value): direct Object construction with a
   // non-nullish argument returns that object or ToObject(value).
@@ -10818,14 +10824,14 @@ begin
   if Assigned(NativeInstance) then
   begin
     Instance := NativeInstance;
-    Instance.Prototype := AClassValue.Prototype;
+    Instance.Prototype := InstancePrototype;
     if NativeInstance is TGocciaInstanceValue then
       TGocciaInstanceValue(NativeInstance).ClassValue := AClassValue;
   end
   else
   begin
     Instance := TGocciaInstanceValue.Create(AClassValue);
-    Instance.Prototype := AClassValue.Prototype;
+    Instance.Prototype := InstancePrototype;
   end;
 
   RootedInstance := Instance;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -232,7 +232,8 @@ uses
   Goccia.Values.SetValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.ToObject,
-  Goccia.Values.ToPrimitive;
+  Goccia.Values.ToPrimitive,
+  Goccia.Values.TypedArrayValue;
 
 procedure RunClassInstanceInitializers(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaObjectValue;
@@ -245,6 +246,13 @@ function DisposeTrackedResourcesAsync(const ATracker: TGocciaDisposalTracker;
 function HasAsyncDisposals(const ATracker: TGocciaDisposalTracker): Boolean; forward;
 function CollectDeclaredPrivateNames(
   const AContext: TGocciaEvaluationContext): TStringList; forward;
+
+function ShouldUseNativeClassInstantiation(
+  const AClassValue: TGocciaClassValue): Boolean; inline;
+begin
+  Result := (AClassValue is TGocciaTypedArrayClassValue) or
+    (AClassValue is TGocciaTypedArrayIntrinsicClassValue);
+end;
 
 const
   FOR_IN_ENTRY_OWNER = '__gocciaForInOwner';
@@ -3624,10 +3632,27 @@ var
   I: Integer;
 
   function InvokeImplicitClassConstructor: TGocciaValue;
+  var
+    NativeInstance: TGocciaObjectValue;
+    ReceiverPrototype: TGocciaObjectValue;
   begin
     Result := AReceiver;
 
-    if Assigned(ClassConstructor.SuperClass) then
+    if Assigned(ClassConstructor.NativeInstanceDefaultPrototype) then
+    begin
+      NativeInstance := ClassConstructor.CreateNativeInstance(AArguments);
+      if not Assigned(NativeInstance) then
+        ThrowTypeError('Superclass constructor did not return an object',
+          SSuggestNotConstructorType);
+      if NativeInstance is TGocciaInstanceValue then
+        TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+      ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
+      NativeInstance.Prototype := ReceiverPrototype;
+      if NativeInstance is TGocciaInstanceValue then
+        TGocciaInstanceValue(NativeInstance).FinalizeNativeFromArguments(AArguments);
+      Result := NativeInstance;
+    end
+    else if Assigned(ClassConstructor.SuperClass) then
       Result := InvokeConstructableWithReceiver(ClassConstructor.SuperClass,
         AArguments, AReceiver, AContext, EffectiveNewTarget)
     else if Assigned(ClassConstructor.NativeSuperConstructor) then
@@ -8093,7 +8118,13 @@ begin
     else if Target is TGocciaProxyValue then
       Result := TGocciaProxyValue(Target).ConstructTrap(BoundArgs)
     else if Target is TGocciaClassValue then
-      Result := InstantiateClass(TGocciaClassValue(Target), BoundArgs, AContext)
+    begin
+      if ShouldUseNativeClassInstantiation(TGocciaClassValue(Target)) then
+        Result := TGocciaClassValue(Target).Instantiate(BoundArgs)
+      else
+        Result := InstantiateClass(TGocciaClassValue(Target), BoundArgs,
+          AContext);
+    end
     else if Target is TGocciaNativeFunctionValue then
     begin
       if TGocciaNativeFunctionValue(Target).NotConstructable then
@@ -8190,7 +8221,11 @@ begin
       end
       else if Callee is TGocciaClassValue then
       begin
-        Result := InstantiateClass(TGocciaClassValue(Callee), Arguments, AContext);
+        if ShouldUseNativeClassInstantiation(TGocciaClassValue(Callee)) then
+          Result := TGocciaClassValue(Callee).Instantiate(Arguments)
+        else
+          Result := InstantiateClass(TGocciaClassValue(Callee), Arguments,
+            AContext);
       end
       else if Callee is TGocciaNativeFunctionValue then
       begin
@@ -10658,6 +10693,9 @@ var
       ConstructedValue := TGocciaNativeFunctionValue(AConstructor).Construct(
         AArguments, EffectiveNewTarget);
     end
+    else if AConstructor is TGocciaClassValue then
+      ConstructedValue := ConstructValue(AConstructor, AArguments,
+        EffectiveNewTarget)
     else if AConstructor is TGocciaFunctionBase then
     begin
       Result := TGocciaInstanceValue.Create(AClassValue,
@@ -10838,7 +10876,10 @@ begin
         ApplyReplacementResult(ConstructedValue);
       end
       else if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then
+      begin
         TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+        TGocciaInstanceValue(NativeInstance).FinalizeNativeFromArguments(AArguments);
+      end;
     end;
 
     if Assigned(InitializerReplayReceiver) and

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -3634,43 +3634,54 @@ var
   function InvokeImplicitClassConstructor: TGocciaValue;
   var
     NativeInstance: TGocciaObjectValue;
+    NativeInstanceRooted: Boolean;
     ReceiverPrototype: TGocciaObjectValue;
   begin
-    Result := AReceiver;
-
-    if Assigned(ClassConstructor.NativeInstanceDefaultPrototype) then
-    begin
-      NativeInstance := ClassConstructor.CreateNativeInstance(AArguments);
-      if not Assigned(NativeInstance) then
-        ThrowTypeError('Superclass constructor did not return an object',
-          SSuggestNotConstructorType);
-      if NativeInstance is TGocciaInstanceValue then
-        TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
-      ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
-      NativeInstance.Prototype := ReceiverPrototype;
-      if NativeInstance is TGocciaInstanceValue then
-        TGocciaInstanceValue(NativeInstance).FinalizeNativeFromArguments(AArguments);
-      Result := NativeInstance;
-    end
-    else if Assigned(ClassConstructor.SuperClass) then
-      Result := InvokeConstructableWithReceiver(ClassConstructor.SuperClass,
-        AArguments, AReceiver, AContext, EffectiveNewTarget)
-    else if Assigned(ClassConstructor.NativeSuperConstructor) then
-      Result := InvokeConstructableWithReceiver(
-        ClassConstructor.NativeSuperConstructor, AArguments, AReceiver,
-        AContext, EffectiveNewTarget)
-    else if AReceiver is TGocciaInstanceValue then
-      TGocciaInstanceValue(AReceiver).InitializeNativeFromArguments(AArguments);
-
-    ValidateClassConstructorReturn(ClassConstructor, Result);
-    if Result is TGocciaObjectValue then
-      RunClassInstanceInitializers(ClassConstructor,
-        TGocciaObjectValue(Result), AContext, iimFirstPass)
-    else if AReceiver is TGocciaObjectValue then
-    begin
-      RunClassInstanceInitializers(ClassConstructor,
-        TGocciaObjectValue(AReceiver), AContext, iimFirstPass);
+    NativeInstance := nil;
+    NativeInstanceRooted := False;
+    try
       Result := AReceiver;
+
+      if Assigned(ClassConstructor.NativeInstanceDefaultPrototype) then
+      begin
+        NativeInstance := ClassConstructor.CreateNativeInstance(AArguments);
+        if not Assigned(NativeInstance) then
+          ThrowTypeError('Superclass constructor did not return an object',
+            SSuggestNotConstructorType);
+        TGarbageCollector.Instance.AddTempRoot(NativeInstance);
+        NativeInstanceRooted := True;
+        if NativeInstance is TGocciaInstanceValue then
+          TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+        ReceiverPrototype := GetNativePrototypeFromConstructor(ClassConstructor,
+          EffectiveNewTarget, ClassConstructor.NativeInstanceDefaultPrototype);
+        NativeInstance.Prototype := ReceiverPrototype;
+        if NativeInstance is TGocciaInstanceValue then
+          TGocciaInstanceValue(NativeInstance).FinalizeNativeFromArguments(AArguments);
+        Result := NativeInstance;
+      end
+      else if Assigned(ClassConstructor.SuperClass) then
+        Result := InvokeConstructableWithReceiver(ClassConstructor.SuperClass,
+          AArguments, AReceiver, AContext, EffectiveNewTarget)
+      else if Assigned(ClassConstructor.NativeSuperConstructor) then
+        Result := InvokeConstructableWithReceiver(
+          ClassConstructor.NativeSuperConstructor, AArguments, AReceiver,
+          AContext, EffectiveNewTarget)
+      else if AReceiver is TGocciaInstanceValue then
+        TGocciaInstanceValue(AReceiver).InitializeNativeFromArguments(AArguments);
+
+      ValidateClassConstructorReturn(ClassConstructor, Result);
+      if Result is TGocciaObjectValue then
+        RunClassInstanceInitializers(ClassConstructor,
+          TGocciaObjectValue(Result), AContext, iimFirstPass)
+      else if AReceiver is TGocciaObjectValue then
+      begin
+        RunClassInstanceInitializers(ClassConstructor,
+          TGocciaObjectValue(AReceiver), AContext, iimFirstPass);
+        Result := AReceiver;
+      end;
+    finally
+      if NativeInstanceRooted then
+        TGarbageCollector.Instance.RemoveTempRoot(NativeInstance);
     end;
   end;
 begin

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -2643,25 +2643,36 @@ begin
         // Parse the callee: class name with optional member access (e.g. new a.B.C())
         // but NOT call expressions — those belong to the outer Call loop.
         Expr := Primary;
-        while Check(gttDot) do
+        while Check(gttDot) or Check(gttLeftBracket) do
         begin
-          Advance;
-          if Check(gttIdentifier) then
-            Expr := TGocciaMemberExpression.Create(Expr, Advance.Lexeme, False, Previous.Line, Previous.Column, False)
-          else if Peek.TokenType in [gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
-                                     gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
-                                     gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
-                                     gttTrue, gttFalse, gttNull, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttVar, gttWith,
-                                     gttFunction] then
+          if Match(gttLeftBracket) then
           begin
-            Token := Advance;
-            // Reserved words are valid property names after "." per ES spec
-            Expr := TGocciaMemberExpression.Create(Expr, Token.Lexeme, False,
-              Token.Line, Token.Column, False);
+            Token := Previous;
+            Expr := TGocciaMemberExpression.Create(Expr, Expression,
+              Token.Line, Token.Column);
+            Consume(gttRightBracket, 'Expected "]" after computed member expression',
+              SSuggestCloseBracketComputedProperty);
           end
           else
-            raise TGocciaSyntaxError.Create('Expected property name after "."', Peek.Line, Peek.Column, FFileName, FSourceLines,
-              SSuggestPropertyNameIdentifier);
+          begin
+            Advance;
+            if Check(gttIdentifier) then
+              Expr := TGocciaMemberExpression.Create(Expr, Advance.Lexeme, False, Previous.Line, Previous.Column, False)
+            else if Peek.TokenType in [gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
+                                       gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
+                                       gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
+                                       gttTrue, gttFalse, gttNull, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttVar, gttWith,
+                                       gttFunction] then
+            begin
+              Token := Advance;
+              // Reserved words are valid property names after "." per ES spec
+              Expr := TGocciaMemberExpression.Create(Expr, Token.Lexeme, False,
+                Token.Line, Token.Column, False);
+            end
+            else
+              raise TGocciaSyntaxError.Create('Expected property name after "."', Peek.Line, Peek.Column, FFileName, FSourceLines,
+                SSuggestPropertyNameIdentifier);
+          end;
         end;
         while Check(gttTemplate) or Check(gttTemplateHead) do
         begin
@@ -8386,7 +8397,7 @@ begin
         Consume(gttRightBracket, 'Expected "]" after computed property key',
           SSuggestCloseBracketComputedPropertyKey);
       end
-      else if Check(gttIdentifier) then
+      else if IsIdentifierNameToken(Peek.TokenType) then
       begin
         CanUseShorthand := True;
         Key := Advance.Lexeme;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -2656,7 +2656,20 @@ begin
           else
           begin
             Advance;
-            if Check(gttIdentifier) then
+            Line := Previous.Line;
+            Column := Previous.Column;
+            if Check(gttHash) then
+            begin
+              Advance;
+              Token := Consume(gttIdentifier,
+                'Expected private field name after "#"',
+                SSuggestPrivateFieldMustFollow);
+              Name := Token.Lexeme;
+              RecordPrivateNameReference(Name, Token.Line, Token.Column);
+              Expr := TGocciaPrivateMemberExpression.Create(Expr, Name,
+                Line, Column);
+            end
+            else if Check(gttIdentifier) then
               Expr := TGocciaMemberExpression.Create(Expr, Advance.Lexeme, False, Previous.Line, Previous.Column, False)
             else if Peek.TokenType in [gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
                                        gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -203,6 +203,9 @@ type
     function LogicalOr: TGocciaExpression;
     function NullishCoalescing: TGocciaExpression;
     function LogicalAnd: TGocciaExpression;
+    function ParseMemberAccessSegment(const AReceiver: TGocciaExpression;
+      const AUsePropertyNameLocation, AAllowOptionalCall: Boolean;
+      out ASegmentLine, ASegmentColumn: Integer): TGocciaExpression;
 
     // Parameter list parsing (shared by arrow functions, class methods, object methods)
     function ParseParameterList: TGocciaParameterArray;
@@ -1764,14 +1767,128 @@ begin
   end;
 end;
 
+function TGocciaParser.ParseMemberAccessSegment(
+  const AReceiver: TGocciaExpression; const AUsePropertyNameLocation,
+  AAllowOptionalCall: Boolean; out ASegmentLine,
+  ASegmentColumn: Integer): TGocciaExpression;
+var
+  Arguments: TObjectList<TGocciaExpression>;
+  Argument: TGocciaExpression;
+  PropertyName: string;
+  Token: TGocciaToken;
+  PropertyLine, PropertyColumn: Integer;
+  IsOptionalChain: Boolean;
+  CurrentType: TGocciaTokenType;
+begin
+  CurrentType := PeekWithLexicalGoal(glgInputElementDiv).TokenType;
+  Token := Advance;
+  ASegmentLine := Token.Line;
+  ASegmentColumn := Token.Column;
+  IsOptionalChain := CurrentType = gttOptionalChaining;
+
+  case CurrentType of
+    gttDot, gttOptionalChaining:
+      begin
+        if Check(gttHash) then
+        begin
+          Advance;
+          Token := Consume(gttIdentifier, 'Expected private field name after "#"',
+            SSuggestPrivateFieldMustFollow);
+          PropertyName := Token.Lexeme;
+          RecordPrivateNameReference(PropertyName, Token.Line, Token.Column);
+          Result := TGocciaPrivateMemberExpression.Create(
+            AReceiver, PropertyName, ASegmentLine, ASegmentColumn,
+            IsOptionalChain);
+        end
+        else if Check(gttLeftBracket) and IsOptionalChain then
+        begin
+          Advance;
+          Argument := Expression;
+          Consume(gttRightBracket, 'Expected "]" after computed member expression',
+            SSuggestCloseBracketComputedProperty);
+          Result := TGocciaMemberExpression.Create(AReceiver, Argument,
+            ASegmentLine, ASegmentColumn, True);
+        end
+        else if Check(gttLeftParen) and IsOptionalChain and AAllowOptionalCall then
+        begin
+          Advance;
+          Arguments := TObjectList<TGocciaExpression>.Create(True);
+          try
+            if not Check(gttRightParen) then
+            begin
+              repeat
+                if Match(gttSpread) then
+                  Argument := TGocciaSpreadExpression.Create(Assignment,
+                    Previous.Line, Previous.Column)
+                else
+                  Argument := Assignment;
+                Arguments.Add(Argument);
+              until not MatchWithLexicalGoal(gttComma, glgInputElementDiv) or Check(gttRightParen);
+            end;
+            Consume(gttRightParen, 'Expected ")" after arguments',
+              SSuggestCloseParenArguments);
+            Result := TGocciaCallExpression.Create(AReceiver, Arguments,
+              ASegmentLine, ASegmentColumn, True);
+          except
+            Arguments.Free;
+            raise;
+          end;
+        end
+        else
+        begin
+          if IsIdentifierNameToken(Peek.TokenType) then
+          begin
+            Token := Advance;
+            PropertyName := Token.Lexeme;
+            if AUsePropertyNameLocation then
+            begin
+              PropertyLine := Token.Line;
+              PropertyColumn := Token.Column;
+            end
+            else
+            begin
+              PropertyLine := ASegmentLine;
+              PropertyColumn := ASegmentColumn;
+            end;
+          end
+          else
+            raise TGocciaSyntaxError.Create('Expected property name after "."',
+              Peek.Line, Peek.Column, FFileName, FSourceLines,
+              SSuggestPropertyNameIdentifier);
+
+          Result := TGocciaMemberExpression.Create(AReceiver, PropertyName,
+            False, PropertyLine, PropertyColumn, IsOptionalChain);
+        end;
+      end;
+    gttHash:
+      begin
+        Token := Consume(gttIdentifier, 'Expected private field name after "#"',
+          SSuggestPrivateFieldMustFollow);
+        PropertyName := Token.Lexeme;
+        RecordPrivateNameReference(PropertyName, Token.Line, Token.Column);
+        Result := TGocciaPrivateMemberExpression.Create(AReceiver, PropertyName,
+          ASegmentLine, ASegmentColumn);
+      end;
+    gttLeftBracket:
+      begin
+        Argument := Expression;
+        Consume(gttRightBracket, 'Expected "]" after computed member expression',
+          SSuggestCloseBracketComputedProperty);
+        Result := TGocciaMemberExpression.Create(AReceiver, Argument,
+          ASegmentLine, ASegmentColumn);
+      end;
+  else
+    raise TGocciaSyntaxError.Create('Expected member access',
+      Token.Line, Token.Column, FFileName, FSourceLines);
+  end;
+end;
+
 function TGocciaParser.Call: TGocciaExpression;
 var
   Arguments: TObjectList<TGocciaExpression>;
   Arg: TGocciaExpression;
-  PropertyName: string;
   Token: TGocciaToken;
   Line, Column: Integer;
-  IsOptionalChain: Boolean;
   CurrentType: TGocciaTokenType;
 begin
   Result := Primary;
@@ -1808,94 +1925,15 @@ begin
         end;
       gttDot, gttOptionalChaining:
         begin
-          Token := Advance;
-          Line := Token.Line;
-          Column := Token.Column;
-          IsOptionalChain := CurrentType = gttOptionalChaining;
-
-          // Check if this is a private field access (this.#field)
-          if Check(gttHash) then
-          begin
-            Advance; // consume the #
-            Token := Consume(gttIdentifier, 'Expected private field name after "#"',
-              SSuggestPrivateFieldMustFollow);
-            PropertyName := Token.Lexeme;
-            RecordPrivateNameReference(PropertyName, Token.Line, Token.Column);
-            Result := TGocciaPrivateMemberExpression.Create(
-              Result, PropertyName, Line, Column, IsOptionalChain);
-          end
-          else if Check(gttLeftBracket) and IsOptionalChain then
-          begin
-            // Optional chaining with computed property: obj?.[expr]
-            Advance; // consume [
-            Arg := Expression;
-            Consume(gttRightBracket, 'Expected "]" after computed member expression',
-              SSuggestCloseBracketComputedProperty);
-            Result := TGocciaMemberExpression.Create(Result, Arg, Line, Column, True);
-          end
-          else if Check(gttLeftParen) and IsOptionalChain then
-          begin
-            // Optional chaining with call: func?.()
-            Advance; // consume (
-            Arguments := TObjectList<TGocciaExpression>.Create(True);
-            try
-              if not Check(gttRightParen) then
-              begin
-                repeat
-                  if Match(gttSpread) then
-                    Arg := TGocciaSpreadExpression.Create(Assignment, Previous.Line, Previous.Column)
-                  else
-                    Arg := Assignment;
-                  Arguments.Add(Arg);
-                until not MatchWithLexicalGoal(gttComma, glgInputElementDiv) or Check(gttRightParen);
-              end;
-              Consume(gttRightParen, 'Expected ")" after arguments',
-                SSuggestCloseParenArguments);
-              Result := TGocciaCallExpression.Create(Result, Arguments, Line, Column, True);
-            except
-              Arguments.Free;
-              raise;
-            end;
-          end
-          else
-          begin
-            if Check(gttIdentifier) then
-              PropertyName := Advance.Lexeme
-            else if Peek.TokenType in [gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
-                                       gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
-                                       gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
-                                       gttTrue, gttFalse, gttNull, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttVar, gttWith,
-                                       gttFunction] then
-              PropertyName := Advance.Lexeme  // Reserved words are allowed as property names
-            else
-              raise TGocciaSyntaxError.Create('Expected property name after "."', Peek.Line, Peek.Column, FFileName, FSourceLines,
-                SSuggestPropertyNameIdentifier);
-
-            Result := TGocciaMemberExpression.Create(Result, PropertyName, False,
-              Line, Column, IsOptionalChain);
-          end;
+          Result := ParseMemberAccessSegment(Result, False, True, Line, Column);
         end;
       gttHash:
         begin
-          Token := Advance;
-          Line := Token.Line;
-          Column := Token.Column;
-          Token := Consume(gttIdentifier, 'Expected private field name after "#"',
-            SSuggestPrivateFieldMustFollow);
-          PropertyName := Token.Lexeme;
-          RecordPrivateNameReference(PropertyName, Token.Line, Token.Column);
-          Result := TGocciaPrivateMemberExpression.Create(Result, PropertyName, Line, Column);
+          Result := ParseMemberAccessSegment(Result, False, True, Line, Column);
         end;
       gttLeftBracket:
         begin
-          Token := Advance;
-          Line := Token.Line;
-          Column := Token.Column;
-          Arg := Expression;
-          Consume(gttRightBracket, 'Expected "]" after computed member expression',
-            SSuggestCloseBracketComputedProperty);
-          // For computed access, store the expression directly to be evaluated at runtime
-          Result := TGocciaMemberExpression.Create(Result, Arg, Line, Column);
+          Result := ParseMemberAccessSegment(Result, False, True, Line, Column);
         end;
       gttIncrement, gttDecrement:
         begin
@@ -2644,49 +2682,7 @@ begin
         // but NOT call expressions — those belong to the outer Call loop.
         Expr := Primary;
         while Check(gttDot) or Check(gttLeftBracket) do
-        begin
-          if Match(gttLeftBracket) then
-          begin
-            Token := Previous;
-            Expr := TGocciaMemberExpression.Create(Expr, Expression,
-              Token.Line, Token.Column);
-            Consume(gttRightBracket, 'Expected "]" after computed member expression',
-              SSuggestCloseBracketComputedProperty);
-          end
-          else
-          begin
-            Advance;
-            Line := Previous.Line;
-            Column := Previous.Column;
-            if Check(gttHash) then
-            begin
-              Advance;
-              Token := Consume(gttIdentifier,
-                'Expected private field name after "#"',
-                SSuggestPrivateFieldMustFollow);
-              Name := Token.Lexeme;
-              RecordPrivateNameReference(Name, Token.Line, Token.Column);
-              Expr := TGocciaPrivateMemberExpression.Create(Expr, Name,
-                Line, Column);
-            end
-            else if Check(gttIdentifier) then
-              Expr := TGocciaMemberExpression.Create(Expr, Advance.Lexeme, False, Previous.Line, Previous.Column, False)
-            else if Peek.TokenType in [gttIf, gttElse, gttConst, gttLet, gttClass, gttEnum, gttExtends, gttNew, gttThis, gttSuper, gttStatic,
-                                       gttReturn, gttFor, gttWhile, gttDo, gttSwitch, gttCase, gttDefault, gttBreak, gttContinue,
-                                       gttThrow, gttTry, gttCatch, gttFinally, gttImport, gttExport, gttFrom, gttAs,
-                                       gttTrue, gttFalse, gttNull, gttTypeof, gttVoid, gttInstanceof, gttIn, gttDelete, gttVar, gttWith,
-                                       gttFunction] then
-            begin
-              Token := Advance;
-              // Reserved words are valid property names after "." per ES spec
-              Expr := TGocciaMemberExpression.Create(Expr, Token.Lexeme, False,
-                Token.Line, Token.Column, False);
-            end
-            else
-              raise TGocciaSyntaxError.Create('Expected property name after "."', Peek.Line, Peek.Column, FFileName, FSourceLines,
-                SSuggestPropertyNameIdentifier);
-          end;
-        end;
+          Expr := ParseMemberAccessSegment(Expr, True, False, Line, Column);
         while Check(gttTemplate) or Check(gttTemplateHead) do
         begin
           Token := Advance;
@@ -8414,7 +8410,7 @@ begin
       else if IsIdentifierNameToken(Peek.TokenType) then
       begin
         KeyToken := Advance;
-        CanUseShorthand := IsIdentifierBindingToken(KeyToken.TokenType);
+        CanUseShorthand := True;
         Key := KeyToken.Lexeme;
       end
       else if Check(gttString) then

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -8367,6 +8367,7 @@ var
   CanUseShorthand: Boolean;
   NumericValue: Double;
   KeyExpression: TGocciaExpression;
+  KeyToken: TGocciaToken;
 begin
   Line := Previous.Line;
   Column := Previous.Column;
@@ -8400,7 +8401,8 @@ begin
       else if IsIdentifierNameToken(Peek.TokenType) then
       begin
         CanUseShorthand := True;
-        Key := Advance.Lexeme;
+        KeyToken := Advance;
+        Key := KeyToken.Lexeme;
       end
       else if Check(gttString) then
       begin
@@ -8438,8 +8440,15 @@ begin
             'Object pattern shorthand requires an identifier property name',
             Previous.Line, Previous.Column, FFileName, FSourceLines,
             'Use "key: binding" for string, numeric, or computed keys');
+        if not IsIdentifierBindingToken(KeyToken.TokenType) then
+          raise TGocciaSyntaxError.Create(
+            'Object pattern shorthand requires an identifier binding',
+            KeyToken.Line, KeyToken.Column, FFileName, FSourceLines,
+            'Use "key: binding" when the property name is a keyword');
+        ValidateIdentifierBinding(KeyToken);
         // Shorthand syntax: {name} means {name: name}
-        Pattern := TGocciaIdentifierDestructuringPattern.Create(Key, Previous.Line, Previous.Column);
+        Pattern := TGocciaIdentifierDestructuringPattern.Create(Key,
+          KeyToken.Line, KeyToken.Column);
 
         // Check for default value in shorthand
         if Match(gttAssign) then

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2407,6 +2407,7 @@ type
   TGocciaBytecodeFunctionValue = class(TGocciaFunctionBase)
   private
     FClosure: TGocciaBytecodeClosure;
+    FConstructClassValue: TGocciaValue;
     FVM: TGocciaVM;
   protected
     function GetFunctionLength: Integer; override;
@@ -2869,6 +2870,7 @@ begin
   inherited Create;
   FVM := AVM;
   FClosure := AClosure;
+  FConstructClassValue := nil;
   if Assigned(FClosure) then
     FClosure.FunctionValue := Self;
   if Assigned(AClosure) and Assigned(AClosure.Template) then
@@ -6263,6 +6265,7 @@ var
   ImplicitSuperClass: TGocciaClassValue;
   NativeClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
+  NativeSuperConstructorForPrototype: TGocciaObjectValue;
   NativeIntrinsicPrototype: TGocciaObjectValue;
   ConstructorToCall: TGocciaMethodValue;
   InstancePrototype: TGocciaObjectValue;
@@ -6272,6 +6275,7 @@ var
   PreviousConstructorSuperCalled: Boolean;
   ConstructorSuperCalled: Boolean;
   DelayNativePrototypeLookup: Boolean;
+  NativeInstanceInitialized: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
   function IsUndefinedConstructedValue(const AValue: TGocciaValue): Boolean;
   begin
@@ -6364,6 +6368,7 @@ var
   end;
 begin
   NativeClass := nil;
+  NativeSuperConstructorForPrototype := nil;
   NativeIntrinsicPrototype := nil;
   WalkClass := Self;
   while Assigned(WalkClass) do
@@ -6375,12 +6380,20 @@ begin
       Break;
     end;
     if Assigned(WalkClass.NativeSuperConstructor) then
+    begin
+      NativeSuperConstructorForPrototype := WalkClass.NativeSuperConstructor;
+      if WalkClass.NativeSuperConstructor is TGocciaClassValue then
+      begin
+        NativeClass := TGocciaClassValue(WalkClass.NativeSuperConstructor);
+        NativeIntrinsicPrototype := NativeClass.NativeInstanceDefaultPrototype;
+      end;
       Break;
+    end;
     WalkClass := WalkClass.SuperClass;
   end;
   DelayNativePrototypeLookup :=
-    not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) and
-    ShouldDelayTypedArrayPrototypeLookup(NativeClass, AArguments);
+    ShouldDelayNativePrototypeLookup(NativeClass, AArguments) or
+    ShouldDelayNativeSuperPrototypeLookup(NativeSuperConstructorForPrototype);
 
   // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
   if Assigned(ANewTarget) and not DelayNativePrototypeLookup then
@@ -6389,6 +6402,7 @@ begin
     InstancePrototype := Prototype;
 
   NativeInstance := nil;
+  NativeInstanceInitialized := False;
   NativeInstanceConstructedByNativeSuper := False;
   if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
   begin
@@ -6413,17 +6427,31 @@ begin
     end;
   end;
 
-  if Assigned(NativeInstance) and Assigned(ANewTarget) and DelayNativePrototypeLookup and
-     (WalkClass is TGocciaTypedArrayClassValue) then
-    InstancePrototype :=
-      TGocciaTypedArrayClassValue(WalkClass).DefaultPrototypeForNewTarget(
-        ANewTarget, NativeIntrinsicPrototype);
+  if Assigned(NativeInstance) and DelayNativePrototypeLookup and
+     (not NativeInstanceConstructedByNativeSuper) and
+     (NativeInstance is TGocciaInstanceValue) then
+  begin
+    TGarbageCollector.Instance.AddTempRoot(NativeInstance);
+    try
+      TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(
+        AArguments);
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(NativeInstance);
+    end;
+    NativeInstanceInitialized := True;
+  end;
+
+  if Assigned(NativeInstance) and Assigned(NativeClass) and
+     Assigned(ANewTarget) and DelayNativePrototypeLookup then
+    InstancePrototype := GetNativePrototypeFromConstructor(WalkClass,
+      ANewTarget, NativeIntrinsicPrototype);
 
   // ES2026 §10.2.2 step 6: Set proto on the instance before constructor runs
   if Assigned(NativeInstance) then
   begin
     Instance := NativeInstance;
-    Instance.Prototype := InstancePrototype;
+    if Assigned(NativeClass) or not DelayNativePrototypeLookup then
+      Instance.Prototype := InstancePrototype;
     if NativeInstance is TGocciaInstanceValue then
       TGocciaInstanceValue(NativeInstance).ClassValue := Self;
   end
@@ -6431,6 +6459,17 @@ begin
   begin
     Instance := TGocciaInstanceValue.Create(Self);
     Instance.Prototype := InstancePrototype;
+  end;
+
+  if NativeInstanceInitialized and (NativeInstance is TGocciaInstanceValue) then
+  begin
+    TGarbageCollector.Instance.AddTempRoot(Instance);
+    try
+      TGocciaInstanceValue(NativeInstance).FinalizeNativeFromArguments(
+        AArguments);
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(Instance);
+    end;
   end;
 
   if Assigned(FConstructorValue) then
@@ -6491,8 +6530,13 @@ begin
           if (Instance is TGocciaInstanceValue) and
              not NativeInstanceConstructedByNativeSuper then
           begin
-            TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
-            TGocciaInstanceValue(Instance).FinalizeNativeFromArguments(AArguments);
+            if not NativeInstanceInitialized then
+            begin
+              TGocciaInstanceValue(Instance).InitializeNativeFromArguments(
+                AArguments);
+              TGocciaInstanceValue(Instance).FinalizeNativeFromArguments(
+                AArguments);
+            end;
           end;
         end
         else
@@ -7123,6 +7167,8 @@ end;
 procedure TGocciaVMClassValue.SetVMConstructor(const AValue: TGocciaValue);
 begin
   FConstructorValue := AValue;
+  if AValue is TGocciaBytecodeFunctionValue then
+    TGocciaBytecodeFunctionValue(AValue).FConstructClassValue := Self;
 end;
 
 procedure TGocciaVMClassValue.MarkReferences;
@@ -7166,6 +7212,8 @@ begin
     FClosure.NewTarget.MarkReferences;
   if Assigned(FClosure.GlobalScope) then
     FClosure.GlobalScope.MarkReferences;
+  if Assigned(FConstructClassValue) then
+    FConstructClassValue.MarkReferences;
 
   for I := 0 to FClosure.UpvalueCount - 1 do
   begin
@@ -8972,6 +9020,14 @@ begin
       ThrowTypeError(Format(SErrorNotConstructor,
         [BytecodeFunction.GetProperty(PROP_NAME).ToStringLiteral.Value]),
         SSuggestNotConstructorType);
+    if (BytecodeFunction.FConstructClassValue is TGocciaVMClassValue) and
+       (TGocciaVMClassValue(BytecodeFunction.FConstructClassValue)
+          .FConstructorValue = AConstructor) then
+    begin
+      Result := TGocciaVMClassValue(BytecodeFunction.FConstructClassValue)
+        .Instantiate(AArguments, EffectiveNewTarget);
+      Exit;
+    end;
   end;
 
   if AConstructor is TGocciaFunctionBase then
@@ -16504,5 +16560,33 @@ begin
     EmptyArgs.Free;
   end;
 end;
+
+function RedirectBytecodeClassConstruct(
+  const ATarget: TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue;
+  out AResult: TGocciaValue): Boolean;
+var
+  BytecodeFunction: TGocciaBytecodeFunctionValue;
+  ClassValue: TGocciaVMClassValue;
+begin
+  Result := False;
+  if not (ATarget is TGocciaBytecodeFunctionValue) then
+    Exit;
+
+  BytecodeFunction := TGocciaBytecodeFunctionValue(ATarget);
+  if not (BytecodeFunction.FConstructClassValue is TGocciaVMClassValue) then
+    Exit;
+
+  ClassValue := TGocciaVMClassValue(BytecodeFunction.FConstructClassValue);
+  if ClassValue.FConstructorValue <> ATarget then
+    Exit;
+
+  AResult := ClassValue.Instantiate(AArguments, ANewTarget);
+  Result := True;
+end;
+
+initialization
+  RegisterFunctionConstructRedirectHook(RedirectBytecodeClassConstruct);
 
 end.

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -6094,13 +6094,15 @@ begin
       ThrowTypeError(
         'Superclass constructor did not return an object',
         SSuggestNotConstructorType);
-    ReceiverPrototype := GetProtoFromConstructor(FNewTarget);
-    TGocciaObjectValue(NewThis).Prototype := ReceiverPrototype;
     if NewThis is TGocciaInstanceValue then
     begin
       TGocciaInstanceValue(NewThis).ClassValue := FCurrentCtorClass;
       TGocciaInstanceValue(NewThis).InitializeNativeFromArguments(AArguments);
     end;
+    ReceiverPrototype := GetProtoFromConstructor(FNewTarget);
+    TGocciaObjectValue(NewThis).Prototype := ReceiverPrototype;
+    if NewThis is TGocciaInstanceValue then
+      TGocciaInstanceValue(NewThis).FinalizeNativeFromArguments(AArguments);
     MarkCurrentConstructorSuperCalled;
     InitializeCurrentCtorReceiver(NewThis);
     Exit(NewThis);
@@ -6259,7 +6261,9 @@ var
   RootedInstance: TGocciaObjectValue;
   WalkClass: TGocciaClassValue;
   ImplicitSuperClass: TGocciaClassValue;
+  NativeClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
+  NativeIntrinsicPrototype: TGocciaObjectValue;
   ConstructorToCall: TGocciaMethodValue;
   InstancePrototype: TGocciaObjectValue;
   ConstructedValue: TGocciaValue;
@@ -6267,6 +6271,7 @@ var
   InitializerReplayReceiver: TGocciaObjectValue;
   PreviousConstructorSuperCalled: Boolean;
   ConstructorSuperCalled: Boolean;
+  DelayNativePrototypeLookup: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
   function IsUndefinedConstructedValue(const AValue: TGocciaValue): Boolean;
   begin
@@ -6358,8 +6363,27 @@ var
     end;
   end;
 begin
+  NativeClass := nil;
+  NativeIntrinsicPrototype := nil;
+  WalkClass := Self;
+  while Assigned(WalkClass) do
+  begin
+    NativeIntrinsicPrototype := WalkClass.NativeInstanceDefaultPrototype;
+    if Assigned(NativeIntrinsicPrototype) then
+    begin
+      NativeClass := WalkClass;
+      Break;
+    end;
+    if Assigned(WalkClass.NativeSuperConstructor) then
+      Break;
+    WalkClass := WalkClass.SuperClass;
+  end;
+  DelayNativePrototypeLookup :=
+    not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) and
+    ShouldDelayTypedArrayPrototypeLookup(NativeClass, AArguments);
+
   // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
-  if Assigned(ANewTarget) then
+  if Assigned(ANewTarget) and not DelayNativePrototypeLookup then
     InstancePrototype := GetProtoFromConstructor(ANewTarget)
   else
     InstancePrototype := Prototype;
@@ -6388,6 +6412,12 @@ begin
       WalkClass := WalkClass.SuperClass;
     end;
   end;
+
+  if Assigned(NativeInstance) and Assigned(ANewTarget) and DelayNativePrototypeLookup and
+     (WalkClass is TGocciaTypedArrayClassValue) then
+    InstancePrototype :=
+      TGocciaTypedArrayClassValue(WalkClass).DefaultPrototypeForNewTarget(
+        ANewTarget, NativeIntrinsicPrototype);
 
   // ES2026 §10.2.2 step 6: Set proto on the instance before constructor runs
   if Assigned(NativeInstance) then
@@ -6460,7 +6490,10 @@ begin
           // as newTarget and replace the derived instance.
           if (Instance is TGocciaInstanceValue) and
              not NativeInstanceConstructedByNativeSuper then
+          begin
             TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
+            TGocciaInstanceValue(Instance).FinalizeNativeFromArguments(AArguments);
+          end;
         end
         else
         begin
@@ -6534,7 +6567,10 @@ begin
               ThrowTypeError('Super constructor is not a constructor',
                 SSuggestNotConstructorType)
             else if Instance is TGocciaInstanceValue then
+            begin
               TGocciaInstanceValue(Instance).InitializeNativeFromArguments(AArguments);
+              TGocciaInstanceValue(Instance).FinalizeNativeFromArguments(AArguments);
+            end;
           end;
         end;
       finally
@@ -6858,7 +6894,10 @@ begin
             EnsureBoxedArgs;
             if (Instance is TGocciaInstanceValue) and
                not NativeInstanceConstructedByNativeSuper then
+            begin
               TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
+              TGocciaInstanceValue(Instance).FinalizeNativeFromArguments(BoxedArgs);
+            end;
           end
           else
           begin
@@ -6961,7 +7000,10 @@ begin
                     SSuggestNotConstructorType);
                 EnsureBoxedArgs;
                 if Instance is TGocciaInstanceValue then
+                begin
                   TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
+                  TGocciaInstanceValue(Instance).FinalizeNativeFromArguments(BoxedArgs);
+                end;
               end;
             end;
           end;
@@ -8846,7 +8888,6 @@ var
   BytecodeFunction: TGocciaBytecodeFunctionValue;
   BoundArgs: TGocciaArgumentsCollection;
   BoundFunction: TGocciaBoundFunctionValue;
-  Context: TGocciaEvaluationContext;
   ConstructorName: string;
   EffectiveNewTarget: TGocciaValue;
   I: Integer;
@@ -8874,11 +8915,8 @@ begin
 
   if AConstructor is TGocciaClassValue then
   begin
-    FillChar(Context, SizeOf(Context), 0);
-    Context.Realm := FRealm;
-    Context.Scope := FGlobalScope;
-    Result := InstantiateClass(TGocciaClassValue(AConstructor), AArguments,
-      Context);
+    Result := TGocciaClassValue(AConstructor).Instantiate(AArguments,
+      EffectiveNewTarget);
     Exit;
   end;
 
@@ -10030,8 +10068,6 @@ begin
       ThrowTypeError(
         'Superclass constructor did not return an object',
         SSuggestNotConstructorType);
-    ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
-    TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
     if TargetInstance is TGocciaInstanceValue then
     begin
       if AInstance is TGocciaInstanceValue then
@@ -10041,6 +10077,10 @@ begin
         TGocciaInstanceValue(TargetInstance).ClassValue := AClassValue;
       TGocciaInstanceValue(TargetInstance).InitializeNativeFromArguments(AArguments);
     end;
+    ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
+    TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+    if TargetInstance is TGocciaInstanceValue then
+      TGocciaInstanceValue(TargetInstance).FinalizeNativeFromArguments(AArguments);
     Exit(TargetInstance);
   end;
 
@@ -10185,8 +10225,6 @@ begin
         ThrowTypeError(
           'Superclass constructor did not return an object',
           SSuggestNotConstructorType);
-      ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
-      TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
       if TargetInstance is TGocciaInstanceValue then
       begin
         if AInstance is TGocciaInstanceValue then
@@ -10196,6 +10234,10 @@ begin
           TGocciaInstanceValue(TargetInstance).ClassValue := AClassValue;
         TGocciaInstanceValue(TargetInstance).InitializeNativeFromArguments(BoxedArgs);
       end;
+      ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
+      TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+      if TargetInstance is TGocciaInstanceValue then
+        TGocciaInstanceValue(TargetInstance).FinalizeNativeFromArguments(BoxedArgs);
       Exit(TargetInstance);
     finally
       ReleaseArguments(BoxedArgs);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -8936,7 +8936,9 @@ var
   BytecodeFunction: TGocciaBytecodeFunctionValue;
   BoundArgs: TGocciaArgumentsCollection;
   BoundFunction: TGocciaBoundFunctionValue;
+  ClassConstructor: TGocciaClassValue;
   ConstructorName: string;
+  EvalContext: TGocciaEvaluationContext;
   EffectiveNewTarget: TGocciaValue;
   I: Integer;
   ReceiverPrototype, ReceiverInstance: TGocciaObjectValue;
@@ -8963,8 +8965,37 @@ begin
 
   if AConstructor is TGocciaClassValue then
   begin
-    Result := TGocciaClassValue(AConstructor).Instantiate(AArguments,
-      EffectiveNewTarget);
+    ClassConstructor := TGocciaClassValue(AConstructor);
+    if (ClassConstructor.SourceText <> '') and
+       (ClassConstructor.NativeInstanceDefaultPrototype = nil) and
+       (ClassConstructor.NativeSuperConstructor = nil) then
+    begin
+      EvalContext := Default(TGocciaEvaluationContext);
+      EvalContext.Realm := FRealm;
+      if Assigned(FCurrentDynamicVarScope) then
+        EvalContext.Scope := FCurrentDynamicVarScope
+      else
+        EvalContext.Scope := FGlobalScope;
+      EvalContext.OnError := ThrowError;
+      EvalContext.LoadModule := FLoadModule;
+      EvalContext.LoadModuleSource := FLoadModuleSource;
+      EvalContext.CurrentFilePath := FCurrentModuleSourcePath;
+      EvalContext.CoverageEnabled := FCoverageEnabled;
+      EvalContext.StrictTypes := False;
+      if Assigned(FGlobalScope) then
+      begin
+        EvalContext.StrictTypes := FGlobalScope.EffectiveStrictTypes;
+        EvalContext.CompatibilityNonStrictMode :=
+          FGlobalScope.EffectiveNonStrictMode;
+      end;
+      EvalContext.NonStrictMode := not (Assigned(FCurrentClosure) and
+        Assigned(FCurrentClosure.Template) and
+        FCurrentClosure.Template.StrictCode);
+      Result := InstantiateClass(ClassConstructor, AArguments, EvalContext,
+        EffectiveNewTarget);
+    end
+    else
+      Result := ClassConstructor.Instantiate(AArguments, EffectiveNewTarget);
     Exit;
   end;
 

--- a/source/units/Goccia.Values.ArrayBufferValue.pas
+++ b/source/units/Goccia.Values.ArrayBufferValue.pas
@@ -9,6 +9,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ClassValue,
   Goccia.Values.ObjectValue,
@@ -23,6 +24,9 @@ type
     FDetached: Boolean;
     FImmutable: Boolean;
     FMaxByteLength: Integer;
+    FHasPendingAllocation: Boolean;
+    FPendingByteLength: Double;
+    FPendingMaxByteLength: Double;
 
     function GetByteLength: Integer;
 
@@ -44,10 +48,13 @@ type
     function BuiltinTagFallback: Boolean; override;
 
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
+    procedure FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
     procedure MarkReferences; override;
     procedure Detach;
 
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function GetSharedPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; static;
 
     property Data: TBytes read FData write FData;
     property Detached: Boolean read FDetached;
@@ -60,6 +67,7 @@ type
     function ArrayBufferTransfer(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferTransferToFixedLength(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferTransferToImmutable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ArrayBufferSliceToImmutable(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferMaxByteLengthGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ArrayBufferResizableGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -77,7 +85,6 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.Realm,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -158,6 +165,24 @@ begin
   Result := Trunc(IntegerIndex);
 end;
 
+function ToArrayBufferConstructorIndex(const AValue: TGocciaValue): Double;
+var
+  Num: TGocciaNumberLiteralValue;
+begin
+  if (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue) then
+    Exit(0);
+
+  Num := AValue.ToNumberLiteral;
+  if Num.IsNaN then
+    Exit(0);
+  if Num.IsInfinite then
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
+
+  Result := Trunc(Num.Value);
+  if (Result < 0) or (Result > MAX_SAFE_INTEGER_F) then
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
+end;
+
 function ToArrayBufferSliceIndex(const AValue: TGocciaValue;
   const ALength: Integer): Integer;
 var
@@ -199,6 +224,9 @@ begin
   FDetached := False;
   FImmutable := False;
   FMaxByteLength := NO_MAX_BYTE_LENGTH;
+  FHasPendingAllocation := False;
+  FPendingByteLength := 0;
+  FPendingMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, AByteLength);
   if AByteLength > 0 then
     FillChar(FData[0], AByteLength, 0);
@@ -215,6 +243,9 @@ begin
   inherited Create(nil);
   FDetached := False;
   FImmutable := False;
+  FHasPendingAllocation := False;
+  FPendingByteLength := 0;
+  FPendingMaxByteLength := NO_MAX_BYTE_LENGTH;
   if AMaxByteLength >= 0 then
   begin
     if AByteLength > AMaxByteLength then
@@ -240,6 +271,9 @@ begin
   FDetached := False;
   FImmutable := False;
   FMaxByteLength := NO_MAX_BYTE_LENGTH;
+  FHasPendingAllocation := False;
+  FPendingByteLength := 0;
+  FPendingMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, 0);
   InitializePrototype;
   Shared := GetArrayBufferShared;
@@ -276,6 +310,9 @@ begin
     Members.AddMethod(ArrayBufferTransfer, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(ArrayBufferTransferToFixedLength, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddMethod(ArrayBufferTransferToImmutable, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddNamedMethod(PROP_SLICE_TO_IMMUTABLE,
+      ArrayBufferSliceToImmutable, 2, gmkPrototypeMethod,
+      [gmfNoFunctionPrototype]);
     Members.AddAccessor(PROP_BYTE_LENGTH, ArrayBufferByteLengthGetter, nil, [pfConfigurable]);
     Members.AddAccessor(PROP_MAX_BYTE_LENGTH, ArrayBufferMaxByteLengthGetter, nil, [pfConfigurable]);
     Members.AddAccessor(PROP_RESIZABLE, ArrayBufferResizableGetter, nil, [pfConfigurable]);
@@ -306,18 +343,31 @@ begin
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
 end;
 
+class function TGocciaArrayBufferValue.GetSharedPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GArrayBufferSharedSlot));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
+end;
+
 // ES2026 §25.1.4.1 ArrayBuffer(length [, options])
 procedure TGocciaArrayBufferValue.InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
 var
-  Len: Integer;
+  Len: Double;
   OptionsArg, MaxByteLengthValue: TGocciaValue;
-  RequestedMaxByteLength: Integer;
+  RequestedMaxByteLength: Double;
 begin
   // ES2026 §6.2.4.2 ToIndex(value)
   if AArguments.Length = 0 then
     Len := 0
   else
-    Len := ToIndex(AArguments.GetElement(0));
+    Len := ToArrayBufferConstructorIndex(AArguments.GetElement(0));
 
   // ES2026 §25.1.4.1 step 3: GetArrayBufferMaxByteLengthOption(options)
   RequestedMaxByteLength := NO_MAX_BYTE_LENGTH;
@@ -331,7 +381,7 @@ begin
     begin
       MaxByteLengthValue := OptionsArg.GetProperty(PROP_MAX_BYTE_LENGTH);
       if Assigned(MaxByteLengthValue) and not (MaxByteLengthValue is TGocciaUndefinedLiteralValue) then
-        RequestedMaxByteLength := ToIndex(MaxByteLengthValue);
+        RequestedMaxByteLength := ToArrayBufferConstructorIndex(MaxByteLengthValue);
     end;
   end;
 
@@ -340,14 +390,36 @@ begin
   begin
     if Len > RequestedMaxByteLength then
       ThrowRangeError(SErrorArrayBufferExceedsMaxByteLength, SSuggestArrayBufferResizable);
-    FMaxByteLength := RequestedMaxByteLength;
   end
+  else
+    RequestedMaxByteLength := NO_MAX_BYTE_LENGTH;
+
+  FHasPendingAllocation := True;
+  FPendingByteLength := Len;
+  FPendingMaxByteLength := RequestedMaxByteLength;
+end;
+
+procedure TGocciaArrayBufferValue.FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
+var
+  Len: Integer;
+begin
+  if not FHasPendingAllocation then
+    Exit;
+
+  if (FPendingByteLength > High(Integer)) or
+     ((FPendingMaxByteLength >= 0) and (FPendingMaxByteLength > High(Integer))) then
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
+
+  Len := Trunc(FPendingByteLength);
+  if FPendingMaxByteLength >= 0 then
+    FMaxByteLength := Trunc(FPendingMaxByteLength)
   else
     FMaxByteLength := NO_MAX_BYTE_LENGTH;
 
   SetLength(FData, Len);
   if Len > 0 then
     FillChar(FData[0], Len, 0);
+  FHasPendingAllocation := False;
 end;
 
 procedure TGocciaArrayBufferValue.Detach;
@@ -369,6 +441,15 @@ end;
 
 function TGocciaArrayBufferValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 begin
+  if ((AName = PROP_BYTE_LENGTH) or
+      (AName = PROP_MAX_BYTE_LENGTH) or
+      (AName = PROP_RESIZABLE) or
+      (AName = PROP_DETACHED) or
+      (AName = PROP_IMMUTABLE)) and
+     ((AThisContext <> Self) or HasOwnProperty(AName) or
+      (Assigned(Prototype) and Prototype.HasProperty(AName))) then
+    Exit(inherited GetPropertyWithContext(AName, AThisContext));
+
   if AName = PROP_BYTE_LENGTH then
   begin
     if FDetached then
@@ -497,6 +578,14 @@ var
 begin
   Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.resize');
 
+  if Buf.FImmutable then
+    ThrowTypeError('Cannot resize an immutable ArrayBuffer',
+      SSuggestArrayBufferResizable);
+
+  // ES2026 §25.1.6.5 step 5: If IsFixedLengthArrayBuffer(O), throw TypeError
+  if Buf.FMaxByteLength < 0 then
+    ThrowTypeError(SErrorCannotResizeFixedLengthArrayBuffer, SSuggestArrayBufferResizable);
+
   // ES2026 §25.1.6.5: ToIndex(newLength) can detach the receiver.
   if AArgs.Length > 0 then
     NewByteLength := ToIndex(AArgs.GetElement(0))
@@ -505,10 +594,6 @@ begin
 
   // Revalidate before checking fixed/resizable state or touching storage.
   EnsureArrayBufferAttached(Buf, SErrorCannotResizeDetachedArrayBuffer);
-
-  // ES2026 §25.1.6.5 step 5: If IsFixedLengthArrayBuffer(O), throw TypeError
-  if Buf.FMaxByteLength < 0 then
-    ThrowTypeError(SErrorCannotResizeFixedLengthArrayBuffer, SSuggestArrayBufferResizable);
 
   // ES2026 §25.1.6.5 step 7: If newByteLength > maxByteLength, throw RangeError
   if NewByteLength > Buf.FMaxByteLength then
@@ -620,6 +705,41 @@ begin
   Result := ArrayBufferCopyAndDetach(Buf, NewByteLength, False, True);
 end;
 
+// Immutable ArrayBuffers proposal § ArrayBuffer.prototype.sliceToImmutable(start, end)
+function TGocciaArrayBufferValue.ArrayBufferSliceToImmutable(
+  const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Buf: TGocciaArrayBufferValue;
+  Bytes: TBytes;
+  CurrentLen, Final, First, Len, NewLen: Integer;
+begin
+  Buf := RequireArrayBuffer(AThisValue, 'ArrayBuffer.prototype.sliceToImmutable');
+  EnsureArrayBufferAttached(Buf, SErrorCannotSliceDetachedArrayBuffer);
+
+  Len := Length(Buf.FData);
+  if AArgs.Length = 0 then
+    First := 0
+  else
+    First := ToArrayBufferSliceIndex(AArgs.GetElement(0), Len);
+
+  if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
+    Final := ToArrayBufferSliceIndex(AArgs.GetElement(1), Len)
+  else
+    Final := Len;
+
+  EnsureArrayBufferAttached(Buf, SErrorCannotSliceDetachedArrayBuffer);
+  CurrentLen := Length(Buf.FData);
+  if CurrentLen < Final then
+    ThrowRangeError(SErrorInvalidArrayBufferLength, SSuggestArrayLengthRange);
+
+  NewLen := Max(Final - First, 0);
+  SetLength(Bytes, NewLen);
+  if NewLen > 0 then
+    Move(Buf.FData[First], Bytes[0], NewLen);
+
+  Result := TGocciaArrayBufferValue.CreateImmutableFromBytes(Bytes);
+end;
+
 // ES2026 §25.1.6.8 ArrayBuffer.prototype.slice(start, end)
 function TGocciaArrayBufferValue.ArrayBufferSlice(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
@@ -679,6 +799,9 @@ begin
       ThrowTypeError('ArrayBuffer species constructor returned this',
         SSuggestArrayBufferThisType);
     NewBuf := TGocciaArrayBufferValue(ConstructedValue);
+    if NewBuf.FImmutable then
+      ThrowTypeError('ArrayBuffer species constructor returned an immutable ArrayBuffer',
+        SSuggestArrayBufferThisType);
     if Length(NewBuf.FData) < NewLen then
       ThrowTypeError('ArrayBuffer species constructor returned a buffer that is too small',
         SSuggestArrayBufferThisType);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -464,7 +464,10 @@ function ShouldDelayNativeSuperPrototypeLookup(
   const ANativeSuperConstructor: TGocciaObjectValue): Boolean;
 begin
   Result := Assigned(ANativeSuperConstructor) and
-    (ANativeSuperConstructor <> TGocciaFunctionBase.GetSharedPrototype);
+    (ANativeSuperConstructor <> TGocciaFunctionBase.GetSharedPrototype) and
+    (ANativeSuperConstructor is TGocciaClassValue) and
+    Assigned(TGocciaClassValue(ANativeSuperConstructor).
+      NativeInstanceDefaultPrototype);
 end;
 
 function GetArrayPrototypeFromConstructor(

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -444,8 +444,7 @@ begin
     Exit;
 
   FirstArg := AArguments.GetElement(0);
-  Result := (FirstArg is TGocciaObjectValue) and
-    not (FirstArg is TGocciaArrayBufferValue) and
+  Result := not (FirstArg is TGocciaArrayBufferValue) and
     not (FirstArg is TGocciaSharedArrayBufferValue) and
     not (FirstArg is TGocciaTypedArrayValue);
 end;
@@ -1548,6 +1547,7 @@ var
   FinalThis: TGocciaValue;
   ConstructResult: TGocciaValue;
   EffectiveNewTarget: TGocciaValue;
+  PreviousRealm: TGocciaRealm;
   DelayNativePrototypeLookup: Boolean;
   NativeInstanceInitialized: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
@@ -1578,6 +1578,30 @@ begin
     EffectiveNewTarget := ANewTarget
   else
     EffectiveNewTarget := Self;
+
+  // ES2026 §20.1.1.1 Object(value): direct Object construction boxes
+  // primitive inputs and returns object inputs unchanged.  Derived Object
+  // subclasses still allocate through NewTarget below.
+  if (FName = CONSTRUCTOR_OBJECT) and (EffectiveNewTarget = Self) and
+     (AArguments.Length > 0) and
+     not (AArguments.GetElement(0) is TGocciaUndefinedLiteralValue) and
+     not (AArguments.GetElement(0) is TGocciaNullLiteralValue) then
+  begin
+    if AArguments.GetElement(0).IsPrimitive then
+    begin
+      PreviousRealm := CurrentRealm;
+      if Assigned(FCreationRealm) and (FCreationRealm <> PreviousRealm) then
+        SetCurrentRealm(FCreationRealm);
+      try
+        Exit(TGocciaObjectValue(AArguments.GetElement(0).Box));
+      finally
+        if Assigned(FCreationRealm) and (FCreationRealm <> PreviousRealm) then
+          SetCurrentRealm(PreviousRealm);
+      end;
+    end;
+    if AArguments.GetElement(0) is TGocciaObjectValue then
+      Exit(TGocciaObjectValue(AArguments.GetElement(0)));
+  end;
 
   NativeClass := nil;
   NativeInstance := nil;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -329,10 +329,15 @@ type
     procedure SetRawPrivateProperty(const AKey: string; const AValue: TGocciaValue);
     function IsInstanceOf(const AClass: TGocciaClassValue): Boolean; inline;
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); virtual;
+    procedure FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); virtual;
     procedure MarkReferences; override;
 
     property ClassValue: TGocciaClassValue read FClass write FClass;
   end;
+
+function ShouldDelayTypedArrayPrototypeLookup(
+  const ANativeClass: TGocciaClassValue;
+  const AArguments: TGocciaArgumentsCollection): Boolean;
 
 implementation
 
@@ -417,6 +422,25 @@ begin
     ACurrentRealmDefault);
 end;
 
+function ShouldDelayTypedArrayPrototypeLookup(
+  const ANativeClass: TGocciaClassValue;
+  const AArguments: TGocciaArgumentsCollection): Boolean;
+var
+  FirstArg: TGocciaValue;
+begin
+  Result := False;
+  if not (ANativeClass is TGocciaTypedArrayClassValue) or
+     (AArguments = nil) or
+     (AArguments.Length = 0) then
+    Exit;
+
+  FirstArg := AArguments.GetElement(0);
+  Result := (FirstArg is TGocciaObjectValue) and
+    not (FirstArg is TGocciaArrayBufferValue) and
+    not (FirstArg is TGocciaSharedArrayBufferValue) and
+    not (FirstArg is TGocciaTypedArrayValue);
+end;
+
 function GetArrayPrototypeFromConstructor(
   const ANewTarget: TGocciaValue;
   const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
@@ -473,6 +497,15 @@ begin
     else if AConstructorName = CONSTRUCTOR_BOOLEAN then
       FallbackPrototype :=
         TGocciaBooleanObjectValue.GetSharedPrototypeForRealm(FallbackRealm)
+    else if AConstructorName = CONSTRUCTOR_ARRAY_BUFFER then
+      FallbackPrototype :=
+        TGocciaArrayBufferValue.GetSharedPrototypeForRealm(FallbackRealm)
+    else if AConstructorName = CONSTRUCTOR_SHARED_ARRAY_BUFFER then
+      FallbackPrototype :=
+        TGocciaSharedArrayBufferValue.GetSharedPrototypeForRealm(FallbackRealm)
+    else if AConstructorName = CONSTRUCTOR_DATA_VIEW then
+      FallbackPrototype :=
+        TGocciaDataViewValue.GetSharedPrototypeForRealm(FallbackRealm)
     else
       FallbackPrototype := nil;
 
@@ -1466,6 +1499,7 @@ var
   ConstructResult: TGocciaValue;
   EffectiveNewTarget: TGocciaValue;
   DelayNativePrototypeLookup: Boolean;
+  NativeInstanceInitialized: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
   function IsUndefinedConstructResult(const AValue: TGocciaValue): Boolean;
   begin
@@ -1500,6 +1534,7 @@ begin
   NativeSuperConstructor := nil;
   NativeIntrinsicPrototype := nil;
   DelayNativePrototypeLookup := False;
+  NativeInstanceInitialized := False;
   NativeInstanceConstructedByNativeSuper := False;
   WalkClass := Self;
   while Assigned(WalkClass) do
@@ -1518,10 +1553,15 @@ begin
     WalkClass := WalkClass.SuperClass;
   end;
 
-  // TypedArray constructors perform observable argument coercion before
-  // AllocateTypedArray reaches GetPrototypeFromConstructor.
+  // These constructors perform observable validation/coercion before
+  // OrdinaryCreateFromConstructor reaches GetPrototypeFromConstructor. TypedArray
+  // does so only for object sources that are neither ArrayBuffer-backed nor
+  // typed-array-backed.
   DelayNativePrototypeLookup := Assigned(NativeClass) and
-    (NativeClass is TGocciaTypedArrayClassValue);
+    (ShouldDelayTypedArrayPrototypeLookup(NativeClass, AArguments) or
+     (NativeClass is TGocciaArrayBufferClassValue) or
+     (NativeClass is TGocciaSharedArrayBufferClassValue) or
+     (NativeClass is TGocciaDataViewClassValue));
 
   // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
   if Assigned(ANewTarget) and not DelayNativePrototypeLookup then
@@ -1544,6 +1584,15 @@ begin
       else if NativeClass is TGocciaBooleanClassValue then
         InstancePrototype := TGocciaBooleanClassValue(NativeClass).
           DefaultPrototypeForNewTarget(ANewTarget, NativeIntrinsicPrototype)
+      else if NativeClass is TGocciaArrayBufferClassValue then
+        InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
+          NativeIntrinsicPrototype, CONSTRUCTOR_ARRAY_BUFFER)
+      else if NativeClass is TGocciaSharedArrayBufferClassValue then
+        InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
+          NativeIntrinsicPrototype, CONSTRUCTOR_SHARED_ARRAY_BUFFER)
+      else if NativeClass is TGocciaDataViewClassValue then
+        InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
+          NativeIntrinsicPrototype, CONSTRUCTOR_DATA_VIEW)
       else
         InstancePrototype := GetProtoFromConstructorWithIntrinsic(ANewTarget,
           NativeIntrinsicPrototype);
@@ -1555,12 +1604,37 @@ begin
     InstancePrototype := FClassPrototype;
 
   if Assigned(NativeClass) then
+  begin
     NativeInstance := NativeClass.CreateNativeInstance(AArguments);
+    if DelayNativePrototypeLookup and
+       (NativeInstance is TGocciaInstanceValue) then
+    begin
+      TGarbageCollector.Instance.AddTempRoot(NativeInstance);
+      try
+        TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+      finally
+        TGarbageCollector.Instance.RemoveTempRoot(NativeInstance);
+      end;
+      NativeInstanceInitialized := True;
+    end;
+  end;
 
   if Assigned(ANewTarget) and DelayNativePrototypeLookup then
-    InstancePrototype := GetTypedArrayPrototypeFromConstructor(
-      TGocciaTypedArrayClassValue(NativeClass), ANewTarget,
-      NativeIntrinsicPrototype);
+  begin
+    if NativeClass is TGocciaTypedArrayClassValue then
+      InstancePrototype := GetTypedArrayPrototypeFromConstructor(
+        TGocciaTypedArrayClassValue(NativeClass), ANewTarget,
+        NativeIntrinsicPrototype)
+    else if NativeClass is TGocciaArrayBufferClassValue then
+      InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
+        NativeIntrinsicPrototype, CONSTRUCTOR_ARRAY_BUFFER)
+    else if NativeClass is TGocciaSharedArrayBufferClassValue then
+      InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
+        NativeIntrinsicPrototype, CONSTRUCTOR_SHARED_ARRAY_BUFFER)
+    else if NativeClass is TGocciaDataViewClassValue then
+      InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
+        NativeIntrinsicPrototype, CONSTRUCTOR_DATA_VIEW);
+  end;
 
   // ES2026 §10.2.2 step 6: Set proto on the instance before constructor runs
   if Assigned(NativeInstance) then
@@ -1575,6 +1649,16 @@ begin
     Instance := TGocciaInstanceValue.Create(Self,
       EstimatedInstancePropertyCapacity);
     Instance.Prototype := InstancePrototype;
+  end;
+
+  if NativeInstanceInitialized and (NativeInstance is TGocciaInstanceValue) then
+  begin
+    TGarbageCollector.Instance.AddTempRoot(Instance);
+    try
+      TGocciaInstanceValue(NativeInstance).FinalizeNativeFromArguments(AArguments);
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(Instance);
+    end;
   end;
 
   ConstructorToCall := FConstructorMethod;
@@ -1640,7 +1724,8 @@ begin
 
     if Assigned(NativeInstance) and (NativeInstance is TGocciaInstanceValue) then
       if not NativeInstanceConstructedByNativeSuper then
-        TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+        if not NativeInstanceInitialized then
+          TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
   end;
 
   Result := Instance;
@@ -2485,6 +2570,11 @@ end;
 procedure TGocciaInstanceValue.InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
 begin
   // No-op by default; native subclasses override to handle constructor arguments
+end;
+
+procedure TGocciaInstanceValue.FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
+begin
+  // No-op by default; native subclasses override when setup must finish after prototype lookup
 end;
 
 function TGocciaInstanceValue.IsInstanceOf(const AClass: TGocciaClassValue): Boolean; inline;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -338,6 +338,15 @@ type
 function ShouldDelayTypedArrayPrototypeLookup(
   const ANativeClass: TGocciaClassValue;
   const AArguments: TGocciaArgumentsCollection): Boolean;
+function ShouldDelayNativePrototypeLookup(
+  const ANativeClass: TGocciaClassValue;
+  const AArguments: TGocciaArgumentsCollection): Boolean;
+function ShouldDelayNativeSuperPrototypeLookup(
+  const ANativeSuperConstructor: TGocciaObjectValue): Boolean;
+function GetNativePrototypeFromConstructor(
+  const ANativeClass: TGocciaClassValue;
+  const ANewTarget: TGocciaValue;
+  const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
 
 implementation
 
@@ -441,6 +450,24 @@ begin
     not (FirstArg is TGocciaTypedArrayValue);
 end;
 
+function ShouldDelayNativePrototypeLookup(
+  const ANativeClass: TGocciaClassValue;
+  const AArguments: TGocciaArgumentsCollection): Boolean;
+begin
+  Result := Assigned(ANativeClass) and
+    (ShouldDelayTypedArrayPrototypeLookup(ANativeClass, AArguments) or
+     (ANativeClass is TGocciaArrayBufferClassValue) or
+     (ANativeClass is TGocciaSharedArrayBufferClassValue) or
+     (ANativeClass is TGocciaDataViewClassValue));
+end;
+
+function ShouldDelayNativeSuperPrototypeLookup(
+  const ANativeSuperConstructor: TGocciaObjectValue): Boolean;
+begin
+  Result := Assigned(ANativeSuperConstructor) and
+    (ANativeSuperConstructor <> TGocciaFunctionBase.GetSharedPrototype);
+end;
+
 function GetArrayPrototypeFromConstructor(
   const ANewTarget: TGocciaValue;
   const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
@@ -514,6 +541,29 @@ begin
   end;
 
   Result := ACurrentRealmDefault;
+end;
+
+function GetNativePrototypeFromConstructor(
+  const ANativeClass: TGocciaClassValue;
+  const ANewTarget: TGocciaValue;
+  const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
+begin
+  if ANativeClass is TGocciaTypedArrayClassValue then
+    Result := GetTypedArrayPrototypeFromConstructor(
+      TGocciaTypedArrayClassValue(ANativeClass), ANewTarget,
+      ACurrentRealmDefault)
+  else if ANativeClass is TGocciaArrayBufferClassValue then
+    Result := DefaultNativePrototypeForNewTarget(ANewTarget,
+      ACurrentRealmDefault, CONSTRUCTOR_ARRAY_BUFFER)
+  else if ANativeClass is TGocciaSharedArrayBufferClassValue then
+    Result := DefaultNativePrototypeForNewTarget(ANewTarget,
+      ACurrentRealmDefault, CONSTRUCTOR_SHARED_ARRAY_BUFFER)
+  else if ANativeClass is TGocciaDataViewClassValue then
+    Result := DefaultNativePrototypeForNewTarget(ANewTarget,
+      ACurrentRealmDefault, CONSTRUCTOR_DATA_VIEW)
+  else
+    Result := GetProtoFromConstructorWithIntrinsic(ANewTarget,
+      ACurrentRealmDefault);
 end;
 
 // SetDefaultPrototype / PatchDefaultPrototype previously cached the
@@ -1547,6 +1597,11 @@ begin
     end;
     if Assigned(WalkClass.NativeSuperConstructor) then
     begin
+      if WalkClass.NativeSuperConstructor is TGocciaClassValue then
+      begin
+        NativeClass := TGocciaClassValue(WalkClass.NativeSuperConstructor);
+        NativeIntrinsicPrototype := NativeClass.NativeInstanceDefaultPrototype;
+      end;
       NativeSuperConstructor := WalkClass.NativeSuperConstructor;
       Break;
     end;
@@ -1557,11 +1612,8 @@ begin
   // OrdinaryCreateFromConstructor reaches GetPrototypeFromConstructor. TypedArray
   // does so only for object sources that are neither ArrayBuffer-backed nor
   // typed-array-backed.
-  DelayNativePrototypeLookup := Assigned(NativeClass) and
-    (ShouldDelayTypedArrayPrototypeLookup(NativeClass, AArguments) or
-     (NativeClass is TGocciaArrayBufferClassValue) or
-     (NativeClass is TGocciaSharedArrayBufferClassValue) or
-     (NativeClass is TGocciaDataViewClassValue));
+  DelayNativePrototypeLookup := ShouldDelayNativePrototypeLookup(NativeClass,
+    AArguments) or ShouldDelayNativeSuperPrototypeLookup(NativeSuperConstructor);
 
   // ES2026 §10.2.2 step 5: Let proto be ? GetPrototypeFromConstructor(newTarget)
   if Assigned(ANewTarget) and not DelayNativePrototypeLookup then
@@ -1619,22 +1671,10 @@ begin
     end;
   end;
 
-  if Assigned(ANewTarget) and DelayNativePrototypeLookup then
-  begin
-    if NativeClass is TGocciaTypedArrayClassValue then
-      InstancePrototype := GetTypedArrayPrototypeFromConstructor(
-        TGocciaTypedArrayClassValue(NativeClass), ANewTarget,
-        NativeIntrinsicPrototype)
-    else if NativeClass is TGocciaArrayBufferClassValue then
-      InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
-        NativeIntrinsicPrototype, CONSTRUCTOR_ARRAY_BUFFER)
-    else if NativeClass is TGocciaSharedArrayBufferClassValue then
-      InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
-        NativeIntrinsicPrototype, CONSTRUCTOR_SHARED_ARRAY_BUFFER)
-    else if NativeClass is TGocciaDataViewClassValue then
-      InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
-        NativeIntrinsicPrototype, CONSTRUCTOR_DATA_VIEW);
-  end;
+  if Assigned(NativeClass) and Assigned(ANewTarget) and
+     DelayNativePrototypeLookup then
+    InstancePrototype := GetNativePrototypeFromConstructor(NativeClass,
+      ANewTarget, NativeIntrinsicPrototype);
 
   // ES2026 §10.2.2 step 6: Set proto on the instance before constructor runs
   if Assigned(NativeInstance) then
@@ -1716,7 +1756,8 @@ begin
       if Assigned(NativeInstance) then
       begin
         Instance := NativeInstance;
-        Instance.Prototype := InstancePrototype;
+        if Assigned(NativeClass) or not DelayNativePrototypeLookup then
+          Instance.Prototype := InstancePrototype;
         if NativeInstance is TGocciaInstanceValue then
           TGocciaInstanceValue(NativeInstance).ClassValue := Self;
       end;

--- a/source/units/Goccia.Values.DataViewValue.pas
+++ b/source/units/Goccia.Values.DataViewValue.pas
@@ -12,6 +12,7 @@ uses
   Goccia.Arguments.Collection,
   Goccia.BinaryData,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ClassValue,
@@ -51,9 +52,12 @@ type
     function BuiltinTagFallback: Boolean; override;
 
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
+    procedure FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
     procedure MarkReferences; override;
 
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function GetSharedPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; static;
 
     property BufferValue: TGocciaValue read FBufferValue;
     property ByteOffset: Integer read FByteOffset;
@@ -95,7 +99,6 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.Realm,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -141,9 +144,10 @@ begin
   else
     IntegerIndex := Trunc(Num.Value);
 
-  if (IntegerIndex < 0) or (IntegerIndex > MAX_SAFE_INTEGER_F) or
-     (IntegerIndex > High(Integer)) then
+  if (IntegerIndex < 0) or (IntegerIndex > MAX_SAFE_INTEGER_F) then
     ThrowRangeError(SErrorInvalidDataViewOffset, SSuggestTypedArrayLength);
+  if IntegerIndex > High(Integer) then
+    Exit(High(Integer));
 
   Result := Trunc(IntegerIndex);
 end;
@@ -315,6 +319,19 @@ begin
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
 end;
 
+class function TGocciaDataViewValue.GetSharedPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GDataViewSharedSlot));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
+end;
+
 procedure TGocciaDataViewValue.SyncBufferData;
 begin
   if FBufferValue is TGocciaArrayBufferValue then
@@ -419,7 +436,10 @@ begin
 
   FByteOffset := Offset;
   FByteLength := ViewByteLength;
+end;
 
+procedure TGocciaDataViewValue.FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
+begin
   if IsDetachedBuffer then
     ThrowTypeError(SErrorCannotUseDetachedDataView, SSuggestArrayBufferDetached);
   if IsViewOutOfBounds then

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -24,6 +24,11 @@ type
     const ANewTarget: TGocciaValue): TGocciaValue;
   TGocciaProxyGetPrototypeHook = function(
     const AProxy: TGocciaObjectValue): TGocciaValue;
+  TGocciaFunctionConstructRedirectHook = function(
+    const ATarget: TGocciaValue;
+    const AArguments: TGocciaArgumentsCollection;
+    const ANewTarget: TGocciaValue;
+    out AResult: TGocciaValue): Boolean;
 
   TGocciaFunctionSharedPrototype = class(TGocciaObjectValue)
   public
@@ -185,6 +190,8 @@ procedure RegisterProxyDispatchHooks(
   const AApply: TGocciaProxyApplyHook;
   const AConstruct: TGocciaProxyConstructHook;
   const AGetPrototype: TGocciaProxyGetPrototypeHook);
+procedure RegisterFunctionConstructRedirectHook(
+  const AHook: TGocciaFunctionConstructRedirectHook);
 
 // ES2026 §10.2.9 SetFunctionName property-key formatting shared by
 // interpreter and bytecode named-evaluation paths.
@@ -226,6 +233,7 @@ var
   GProxyApplyHook: TGocciaProxyApplyHook;
   GProxyConstructHook: TGocciaProxyConstructHook;
   GProxyGetPrototypeHook: TGocciaProxyGetPrototypeHook;
+  GFunctionConstructRedirectHook: TGocciaFunctionConstructRedirectHook;
 
 procedure RegisterProxyDispatchHooks(
   const APredicate: TGocciaProxyPredicate;
@@ -237,6 +245,12 @@ begin
   GProxyApplyHook := AApply;
   GProxyConstructHook := AConstruct;
   GProxyGetPrototypeHook := AGetPrototype;
+end;
+
+procedure RegisterFunctionConstructRedirectHook(
+  const AHook: TGocciaFunctionConstructRedirectHook);
+begin
+  GFunctionConstructRedirectHook := AHook;
 end;
 
 function IsRegisteredProxyValue(const AValue: TGocciaValue): Boolean; inline;
@@ -410,6 +424,10 @@ begin
     else if EffectiveTarget is TGocciaNativeFunctionValue then
       Result := TGocciaNativeFunctionValue(EffectiveTarget).Construct(WorkingArgs,
         EffectiveNewTarget)
+    else if Assigned(GFunctionConstructRedirectHook) and
+            GFunctionConstructRedirectHook(EffectiveTarget, WorkingArgs,
+              EffectiveNewTarget, Result) then
+      Exit
     else if EffectiveTarget is TGocciaFunctionBase then
       Result := ConstructOrdinaryWithReceiver(TGocciaFunctionBase(EffectiveTarget),
         WorkingArgs,

--- a/source/units/Goccia.Values.SharedArrayBufferValue.pas
+++ b/source/units/Goccia.Values.SharedArrayBufferValue.pas
@@ -9,6 +9,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ClassValue,
   Goccia.Values.ObjectValue,
@@ -21,6 +22,9 @@ type
   private
     FData: TBytes;
     FMaxByteLength: Integer;
+    FHasPendingAllocation: Boolean;
+    FPendingByteLength: Double;
+    FPendingMaxByteLength: Double;
 
     function GetByteLength: Integer;
 
@@ -36,9 +40,12 @@ type
     function BuiltinTagFallback: Boolean; override;
 
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
+    procedure FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); override;
     procedure MarkReferences; override;
 
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function GetSharedPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; static;
 
     property Data: TBytes read FData write FData;
     property MaxByteLength: Integer read FMaxByteLength;
@@ -61,8 +68,8 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.Realm,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
@@ -103,6 +110,74 @@ begin
   Result := Trunc(IntegerIndex);
 end;
 
+function ToSharedArrayBufferConstructorIndex(const AValue: TGocciaValue): Double;
+var
+  IntegerIndex: Double;
+  Num: TGocciaNumberLiteralValue;
+begin
+  if (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue) then
+    Exit(0);
+
+  Num := AValue.ToNumberLiteral;
+  if Num.IsNaN then
+    Exit(0);
+  if Num.IsInfinite then
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+
+  IntegerIndex := Trunc(Num.Value);
+  if (IntegerIndex < 0) or (IntegerIndex > MAX_SAFE_INTEGER_F) then
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+
+  Result := IntegerIndex;
+end;
+
+function ToSharedArrayBufferSliceIndex(const AValue: TGocciaValue;
+  const ALength: Integer): Integer;
+var
+  IntegerIndex: Double;
+  Num: TGocciaNumberLiteralValue;
+begin
+  Num := AValue.ToNumberLiteral;
+  if Num.IsNaN or Num.IsNegativeInfinity then
+    Exit(0);
+  if Num.IsInfinity then
+    Exit(ALength);
+
+  IntegerIndex := Trunc(Num.Value);
+  if IntegerIndex < 0 then
+  begin
+    if IntegerIndex <= -ALength then
+      Exit(0);
+    Exit(Max(ALength + Trunc(IntegerIndex), 0));
+  end;
+
+  if IntegerIndex >= ALength then
+    Exit(ALength);
+  Result := Trunc(IntegerIndex);
+end;
+
+function SharedArrayBufferSpeciesConstructor(
+  const ABuffer: TGocciaSharedArrayBufferValue): TGocciaValue;
+var
+  ConstructorValue, SpeciesValue: TGocciaValue;
+begin
+  // ES2026 §7.3.22 SpeciesConstructor(O, defaultConstructor)
+  ConstructorValue := ABuffer.GetProperty(PROP_CONSTRUCTOR);
+  if ConstructorValue is TGocciaUndefinedLiteralValue then
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  if not (ConstructorValue is TGocciaObjectValue) then
+    ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+
+  SpeciesValue := TGocciaObjectValue(ConstructorValue).GetSymbolProperty(
+    TGocciaSymbolValue.WellKnownSpecies);
+  if (SpeciesValue is TGocciaUndefinedLiteralValue) or
+     (SpeciesValue is TGocciaNullLiteralValue) then
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  if not SpeciesValue.IsConstructable then
+    ThrowTypeError(SErrorSpeciesNotConstructor, SSuggestSpeciesConstructor);
+  Result := SpeciesValue;
+end;
+
 function TGocciaSharedArrayBufferValue.GetByteLength: Integer;
 begin
   Result := Length(FData);
@@ -114,6 +189,9 @@ var
 begin
   inherited Create(nil);
   FMaxByteLength := NO_MAX_BYTE_LENGTH;
+  FHasPendingAllocation := False;
+  FPendingByteLength := 0;
+  FPendingMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, AByteLength);
   if AByteLength > 0 then
     FillChar(FData[0], AByteLength, 0);
@@ -128,6 +206,9 @@ var
   Shared: TGocciaSharedPrototype;
 begin
   inherited Create(nil);
+  FHasPendingAllocation := False;
+  FPendingByteLength := 0;
+  FPendingMaxByteLength := NO_MAX_BYTE_LENGTH;
   if AMaxByteLength >= 0 then
   begin
     if AByteLength > AMaxByteLength then
@@ -151,6 +232,9 @@ var
 begin
   inherited Create(AClass);
   FMaxByteLength := NO_MAX_BYTE_LENGTH;
+  FHasPendingAllocation := False;
+  FPendingByteLength := 0;
+  FPendingMaxByteLength := NO_MAX_BYTE_LENGTH;
   SetLength(FData, 0);
   InitializePrototype;
   Shared := GetSharedArrayBufferShared;
@@ -201,18 +285,31 @@ begin
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
 end;
 
+class function TGocciaSharedArrayBufferValue.GetSharedPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GSharedArrayBufferSharedSlot));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
+end;
+
 // ES2026 §25.2.3.1 SharedArrayBuffer(length [, options])
 procedure TGocciaSharedArrayBufferValue.InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
 var
-  Len: Integer;
+  Len: Double;
   MaxByteLengthValue: TGocciaValue;
   OptionsArg: TGocciaValue;
-  RequestedMaxByteLength: Integer;
+  RequestedMaxByteLength: Double;
 begin
   if AArguments.Length = 0 then
     Len := 0
   else
-    Len := ToSharedArrayBufferIndex(AArguments.GetElement(0));
+    Len := ToSharedArrayBufferConstructorIndex(AArguments.GetElement(0));
 
   RequestedMaxByteLength := NO_MAX_BYTE_LENGTH;
   if AArguments.Length > 1 then
@@ -224,7 +321,7 @@ begin
       MaxByteLengthValue := OptionsArg.GetProperty(PROP_MAX_BYTE_LENGTH);
       if Assigned(MaxByteLengthValue) and
          not (MaxByteLengthValue is TGocciaUndefinedLiteralValue) then
-        RequestedMaxByteLength := ToSharedArrayBufferIndex(MaxByteLengthValue);
+        RequestedMaxByteLength := ToSharedArrayBufferConstructorIndex(MaxByteLengthValue);
     end;
   end;
 
@@ -232,14 +329,36 @@ begin
   begin
     if Len > RequestedMaxByteLength then
       ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
-    FMaxByteLength := RequestedMaxByteLength;
   end
+  else
+    RequestedMaxByteLength := NO_MAX_BYTE_LENGTH;
+
+  FHasPendingAllocation := True;
+  FPendingByteLength := Len;
+  FPendingMaxByteLength := RequestedMaxByteLength;
+end;
+
+procedure TGocciaSharedArrayBufferValue.FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
+var
+  Len: Integer;
+begin
+  if not FHasPendingAllocation then
+    Exit;
+
+  if (FPendingByteLength > High(Integer)) or
+     ((FPendingMaxByteLength >= 0) and (FPendingMaxByteLength > High(Integer))) then
+    ThrowRangeError(SErrorInvalidSharedArrayBufferLength, SSuggestArrayLengthRange);
+
+  Len := Trunc(FPendingByteLength);
+  if FPendingMaxByteLength >= 0 then
+    FMaxByteLength := Trunc(FPendingMaxByteLength)
   else
     FMaxByteLength := NO_MAX_BYTE_LENGTH;
 
   SetLength(FData, Len);
   if Len > 0 then
     FillChar(FData[0], Len, 0);
+  FHasPendingAllocation := False;
 end;
 
 procedure TGocciaSharedArrayBufferValue.MarkReferences;
@@ -255,6 +374,13 @@ end;
 
 function TGocciaSharedArrayBufferValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
 begin
+  if ((AName = PROP_BYTE_LENGTH) or
+      (AName = PROP_MAX_BYTE_LENGTH) or
+      (AName = PROP_GROWABLE)) and
+     ((AThisContext <> Self) or HasOwnProperty(AName) or
+      (Assigned(Prototype) and Prototype.HasProperty(AName))) then
+    Exit(inherited GetPropertyWithContext(AName, AThisContext));
+
   if (AName = PROP_MAX_BYTE_LENGTH) and HasOwnProperty(AName) then
     Exit(inherited GetPropertyWithContext(AName, AThisContext));
 
@@ -369,7 +495,9 @@ function TGocciaSharedArrayBufferValue.SharedArrayBufferSlice(const AArgs: TGocc
 var
   Buf: TGocciaSharedArrayBufferValue;
   Len, First, Final, NewLen: Integer;
-  StartNum, EndNum: TGocciaNumberLiteralValue;
+  SpeciesConstructor: TGocciaValue;
+  ConstructedValue: TGocciaValue;
+  ConstructorArgs: TGocciaArgumentsCollection;
   NewBuf: TGocciaSharedArrayBufferValue;
 begin
   if not (AThisValue is TGocciaSharedArrayBufferValue) then
@@ -380,42 +508,42 @@ begin
   Buf := TGocciaSharedArrayBufferValue(AThisValue);
   Len := Length(Buf.FData);
 
-  if AArgs.Length > 0 then
-  begin
-    StartNum := AArgs.GetElement(0).ToNumberLiteral;
-    if StartNum.IsNaN then
-      First := 0
-    else
-      First := Trunc(StartNum.Value);
-  end
+  if AArgs.Length = 0 then
+    First := 0
   else
-    First := 0;
-
-  if First < 0 then
-    First := Max(Len + First, 0)
-  else
-    First := Min(First, Len);
+    First := ToSharedArrayBufferSliceIndex(AArgs.GetElement(0), Len);
 
   // ES2026 §25.2.5.6 step 15: If end is undefined, let relativeEnd be len
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
-  begin
-    EndNum := AArgs.GetElement(1).ToNumberLiteral;
-    if EndNum.IsNaN then
-      Final := 0
-    else
-      Final := Trunc(EndNum.Value);
-  end
+    Final := ToSharedArrayBufferSliceIndex(AArgs.GetElement(1), Len)
   else
     Final := Len;
 
-  if Final < 0 then
-    Final := Max(Len + Final, 0)
-  else
-    Final := Min(Final, Len);
-
   NewLen := Max(Final - First, 0);
 
-  NewBuf := TGocciaSharedArrayBufferValue.Create(NewLen);
+  SpeciesConstructor := SharedArrayBufferSpeciesConstructor(Buf);
+  if SpeciesConstructor is TGocciaUndefinedLiteralValue then
+    NewBuf := TGocciaSharedArrayBufferValue.Create(NewLen)
+  else
+  begin
+    ConstructorArgs := TGocciaArgumentsCollection.Create(
+      [TGocciaNumberLiteralValue.Create(NewLen)]);
+    try
+      ConstructedValue := ConstructValue(SpeciesConstructor, ConstructorArgs,
+        SpeciesConstructor);
+    finally
+      ConstructorArgs.Free;
+    end;
+    if not (ConstructedValue is TGocciaSharedArrayBufferValue) then
+      ThrowTypeError('SharedArrayBuffer species constructor did not return a SharedArrayBuffer',
+        SSuggestSharedArrayBufferThisType);
+    NewBuf := TGocciaSharedArrayBufferValue(ConstructedValue);
+    if NewBuf = Buf then
+      ThrowTypeError(SErrorSharedArrayBufferSpeciesReturnedThis, SSuggestSpeciesConstructor);
+    if Length(NewBuf.FData) < NewLen then
+      ThrowTypeError('SharedArrayBuffer species constructor returned a buffer that is too small',
+        SSuggestSharedArrayBufferThisType);
+  end;
 
   // ES2026 §25.2.5.6 step 11: If new.[[ArrayBufferData]] is O.[[ArrayBufferData]], throw TypeError
   if Pointer(NewBuf.FData) = Pointer(Buf.FData) then

--- a/source/units/Goccia.Values.SharedArrayBufferValue.pas
+++ b/source/units/Goccia.Values.SharedArrayBufferValue.pas
@@ -545,8 +545,10 @@ begin
         SSuggestSharedArrayBufferThisType);
   end;
 
-  // ES2026 §25.2.5.6 step 11: If new.[[ArrayBufferData]] is O.[[ArrayBufferData]], throw TypeError
-  if Pointer(NewBuf.FData) = Pointer(Buf.FData) then
+  // ES2026 §25.2.5.6 step 11: If new.[[ArrayBufferData]] is O.[[ArrayBufferData]], throw TypeError.
+  // Zero-length Pascal dynamic arrays may both have nil storage; that does not
+  // represent the same ECMAScript data block.
+  if (NewLen > 0) and (Pointer(NewBuf.FData) = Pointer(Buf.FData)) then
     ThrowTypeError(SErrorSharedArrayBufferSpeciesReturnedThis, SSuggestSpeciesConstructor);
 
   if NewLen > 0 then

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -164,6 +164,14 @@ type
     property Kind: TGocciaTypedArrayKind read FKind;
   end;
 
+  TGocciaTypedArrayIntrinsicClassValue = class(TGocciaClassValue)
+  public
+    function Call(const AArguments: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
+    function Instantiate(const AArguments: TGocciaArgumentsCollection;
+      const ANewTarget: TGocciaValue = nil): TGocciaValue; override;
+  end;
+
   TGocciaTypedArrayStaticFrom = class
   public
     constructor Create;
@@ -1726,7 +1734,8 @@ end;
 function TGocciaTypedArrayValue.TypedArraySlice(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   TA, NewTA: TGocciaTypedArrayValue;
-  First, Final, NewLen, SourceLength, I: Integer;
+  BPE, CopyBytes, CopyElements, CurrentLength, First, Final, NewLen,
+    SourceByteIndex, SourceLength, TargetByteIndex, I: Integer;
   ConstructorArgs: TGocciaArgumentsCollection;
 begin
   TA := RequireAttachedTypedArray(AThisValue, 'TypedArray.prototype.slice');
@@ -1761,16 +1770,30 @@ begin
     EnsureTypedArrayAttached(TA, 'TypedArray.prototype.slice');
   if NewTA.FBufferValue <> TA.FBufferValue then
     EnsureTypedArrayWritable(NewTA, 'TypedArray.prototype.slice');
-  if IsBigIntKind(TA.FKind) then
+  CurrentLength := TA.Length;
+  CopyElements := Max(Min(Final, CurrentLength) - First, 0);
+  if CopyElements > NewLen then
+    CopyElements := NewLen;
+  if (CopyElements > 0) and (NewTA.FKind = TA.FKind) then
   begin
-    for I := 0 to NewLen - 1 do
-      if First + I < TA.Length then
+    BPE := BytesPerElement(TA.FKind);
+    CopyBytes := CopyElements * BPE;
+    SourceByteIndex := TA.FByteOffset + First * BPE;
+    TargetByteIndex := NewTA.FByteOffset;
+    for I := 0 to CopyBytes - 1 do
+      NewTA.FBufferData[TargetByteIndex + I] :=
+        TA.FBufferData[SourceByteIndex + I];
+  end
+  else if IsBigIntKind(TA.FKind) then
+  begin
+    for I := 0 to CopyElements - 1 do
+      if First + I < CurrentLength then
         NewTA.WriteValueToElement(I, TA.GetElementAsValue(First + I));
   end
   else
   begin
-    for I := 0 to NewLen - 1 do
-      if First + I < TA.Length then
+    for I := 0 to CopyElements - 1 do
+      if First + I < CurrentLength then
         NewTA.WriteValueToElement(I, TA.GetElementAsValue(First + I));
   end;
   Result := NewTA;
@@ -1830,15 +1853,15 @@ function TGocciaTypedArrayValue.TypedArraySet(const AArgs: TGocciaArgumentsColle
 var
   TA, SrcTA: TGocciaTypedArrayValue;
   TargetOffset, I, SrcLen, TargetLen, SourceLen: Integer;
-  SrcArray: TGocciaArrayValue;
   SrcObj: TGocciaObjectValue;
   NumberSnapshot: array of Double;
   BigIntSnapshot: array of Int64;
 begin
   TA := RequireTypedArray(AThisValue, 'TypedArray.prototype.set');
-  EnsureTypedArrayWritable(TA, 'TypedArray.prototype.set');
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorTypedArraySetRequiresArg, SSuggestTypedArraySetSource);
+  if IsTypedArrayBackedByImmutableArrayBuffer(TA) then
+    ThrowTypeError('TypedArray.prototype.set cannot write to an immutable ArrayBuffer');
 
   if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
   begin
@@ -1850,6 +1873,7 @@ begin
     TargetOffset := 0;
 
   EnsureTypedArrayAttached(TA, 'TypedArray.prototype.set');
+  EnsureTypedArrayWritable(TA, 'TypedArray.prototype.set');
   TargetLen := TA.Length;
 
   if AArgs.GetElement(0) is TGocciaTypedArrayValue then
@@ -1880,15 +1904,6 @@ begin
         TA.WriteElement(TargetOffset + I, NumberSnapshot[I]);
     end;
   end
-  else if AArgs.GetElement(0) is TGocciaArrayValue then
-  begin
-    SrcArray := TGocciaArrayValue(AArgs.GetElement(0));
-    if (TargetOffset > TargetLen) or
-       (SrcArray.Elements.Count > TargetLen - TargetOffset) then
-      ThrowRangeError(SErrorTypedArraySourceTooLarge, SSuggestTypedArrayLength);
-    for I := 0 to SrcArray.Elements.Count - 1 do
-      TA.WriteValueToElement(TargetOffset + I, SrcArray.Elements[I]);
-  end
   else
   begin
     // ES2026 §23.2.3.25.2 SetTypedArrayFromArrayLike
@@ -1898,7 +1913,8 @@ begin
        (SrcLen > TargetLen - TargetOffset) then
       ThrowRangeError(SErrorTypedArraySourceTooLarge, SSuggestTypedArrayLength);
     for I := 0 to SrcLen - 1 do
-      TA.WriteValueToElement(TargetOffset + I, SrcObj.GetProperty(IntToStr(I)));
+      TA.SetIntegerIndexedElement(TargetOffset + I, False,
+        SrcObj.GetProperty(IntToStr(I)));
   end;
 
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -2880,6 +2896,22 @@ begin
 end;
 
 { TGocciaTypedArrayClassValue }
+
+function TGocciaTypedArrayIntrinsicClassValue.Call(
+  const AArguments: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  ThrowTypeError('TypedArray cannot be called directly', SSuggestIllegalConstructor);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaTypedArrayIntrinsicClassValue.Instantiate(
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
+begin
+  ThrowTypeError('TypedArray cannot be constructed directly', SSuggestIllegalConstructor);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
 
 constructor TGocciaTypedArrayClassValue.Create(const AName: string; const ASuperClass: TGocciaClassValue; const AKind: TGocciaTypedArrayKind);
 begin

--- a/source/units/Goccia.Values.Uint8ArrayEncoding.pas
+++ b/source/units/Goccia.Values.Uint8ArrayEncoding.pas
@@ -31,6 +31,7 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
+  Goccia.Values.ArrayBufferValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue,
   Goccia.Values.TypedArrayValue;
@@ -108,6 +109,21 @@ begin
     ThrowTypeError(Format(SErrorRequiresUint8Array, [AMethod]),
       SSuggestUint8ArrayThisType);
   Result := TGocciaTypedArrayValue(AThisValue);
+end;
+
+procedure EnsureUint8ArrayInBounds(const AArray: TGocciaTypedArrayValue; const AMethod: string);
+begin
+  if IsTypedArrayOutOfBounds(AArray) then
+    ThrowTypeError(Format(SErrorCannotUseDetachedTypedArray, [AMethod]),
+      SSuggestArrayBufferDetached);
+end;
+
+procedure EnsureUint8ArrayWritable(const AArray: TGocciaTypedArrayValue; const AMethod: string);
+begin
+  EnsureUint8ArrayInBounds(AArray, AMethod);
+  if (AArray.BufferValue is TGocciaArrayBufferValue) and
+     TGocciaArrayBufferValue(AArray.BufferValue).Immutable then
+    ThrowTypeError(AMethod + ' cannot write to an immutable ArrayBuffer');
 end;
 
 function ReadAlphabetOption(const AOptions: TGocciaValue): string;
@@ -259,27 +275,131 @@ end;
 { ---- Base64 decoding ---- }
 
 type
+  TBase64DecodeError = (
+    bdeNone,
+    bdeInvalidCharacter,
+    bdeIncompleteChunk,
+    bdeNonZeroPaddingBits,
+    bdeMalformedPadding,
+    bdeIncompleteChunkStrict,
+    bdeUnexpectedPadding
+  );
+
   TBase64DecodeResult = record
     Bytes: TBytes;
     ByteLength: Integer;
     CharsRead: Integer;
+    Error: TBase64DecodeError;
   end;
+
+procedure RaiseBase64DecodeError(const AError: TBase64DecodeError);
+begin
+  case AError of
+    bdeInvalidCharacter:
+      ThrowSyntaxError(SErrorInvalidBase64Character, SSuggestBase64Format);
+    bdeIncompleteChunk:
+      ThrowSyntaxError(SErrorBase64IncompleteChunk, SSuggestBase64Format);
+    bdeNonZeroPaddingBits:
+      ThrowSyntaxError(SErrorBase64NonZeroPaddingBits, SSuggestBase64Format);
+    bdeMalformedPadding:
+      ThrowSyntaxError(SErrorBase64MalformedPadding, SSuggestBase64Format);
+    bdeIncompleteChunkStrict:
+      ThrowSyntaxError(SErrorBase64IncompleteChunkStrict, SSuggestBase64Format);
+    bdeUnexpectedPadding:
+      ThrowSyntaxError(SErrorBase64UnexpectedPadding, SSuggestBase64Format);
+  else
+  end;
+end;
 
 function DecodeBase64(const AInput: string; const AAlphabet: string;
   const ALastChunkHandling: string; const AMaxBytes: Integer): TBase64DecodeResult;
 var
   DecodeTable: TBase64DecodeTable;
-  Cleaned: string;
-  CleanedLen, I, ChunkLen: Integer;
+  Chunk: string;
+  Index, InputLength, ChunkLength, Capacity: Integer;
   Ch: Char;
-  HasPadding: Boolean;
-  PadStart, FullChunks, Remainder: Integer;
-  Pos, OutPos: Integer;
   V0, V1, V2, V3: Byte;
-  CharsConsumed: Integer;
+  ThrowOnExtraBits: Boolean;
 
-  { Map cleaned index back to original input index }
-  CleanedToOriginal: array of Integer;
+  function SkipAsciiWhitespaceFrom(const AIndex: Integer): Integer;
+  begin
+    Result := AIndex;
+    while (Result <= InputLength) and IsAsciiWhitespace(AInput[Result]) do
+      Inc(Result);
+  end;
+
+  procedure FinishWithError(const AError: TBase64DecodeError);
+  begin
+    Result.Error := AError;
+    SetLength(Result.Bytes, Result.ByteLength);
+  end;
+
+  procedure FinishSuccessfully(const ARead: Integer);
+  begin
+    Result.CharsRead := ARead;
+    Result.Error := bdeNone;
+    SetLength(Result.Bytes, Result.ByteLength);
+  end;
+
+  procedure AppendByte(const AByte: Byte);
+  begin
+    Result.Bytes[Result.ByteLength] := AByte;
+    Inc(Result.ByteLength);
+  end;
+
+  procedure DecodeFinalChunk(const AThrowOnExtraBits: Boolean;
+    out AError: TBase64DecodeError; out ASucceeded: Boolean);
+  begin
+    ASucceeded := False;
+    AError := bdeNone;
+    if ChunkLength < 2 then
+    begin
+      AError := bdeIncompleteChunk;
+      Exit;
+    end;
+
+    V0 := DecodeTable[Ord(Chunk[1])];
+    V1 := DecodeTable[Ord(Chunk[2])];
+    if AThrowOnExtraBits and (ChunkLength = 2) and ((V1 and $0F) <> 0) then
+    begin
+      AError := bdeNonZeroPaddingBits;
+      Exit;
+    end;
+
+    AppendByte(Byte((V0 shl 2) or (V1 shr 4)));
+
+    if ChunkLength >= 3 then
+    begin
+      V2 := DecodeTable[Ord(Chunk[3])];
+      if AThrowOnExtraBits and ((V2 and $03) <> 0) then
+      begin
+        Dec(Result.ByteLength);
+        AError := bdeNonZeroPaddingBits;
+        Exit;
+      end;
+      AppendByte(Byte(((V1 and $0F) shl 4) or (V2 shr 2)));
+    end;
+
+    ASucceeded := True;
+  end;
+
+  procedure DecodeFullChunk;
+  begin
+    V0 := DecodeTable[Ord(Chunk[1])];
+    V1 := DecodeTable[Ord(Chunk[2])];
+    V2 := DecodeTable[Ord(Chunk[3])];
+    V3 := DecodeTable[Ord(Chunk[4])];
+    AppendByte(Byte((V0 shl 2) or (V1 shr 4)));
+    AppendByte(Byte(((V1 and $0F) shl 4) or (V2 shr 2)));
+    AppendByte(Byte(((V2 and $03) shl 6) or V3));
+    Chunk := '';
+    ChunkLength := 0;
+  end;
+
+var
+  DecodeError: TBase64DecodeError;
+  DecodeSucceeded: Boolean;
+  Remaining: Integer;
 begin
   InitDecodeTables;
   if AAlphabet = ALPHABET_BASE64URL then
@@ -287,190 +407,137 @@ begin
   else
     DecodeTable := Base64StandardDecode;
 
-  // Step 1: Strip ASCII whitespace and track original positions
-  SetLength(Cleaned, Length(AInput));
-  SetLength(CleanedToOriginal, Length(AInput) + 1);
-  CleanedLen := 0;
-  for I := 1 to Length(AInput) do
+  Result.ByteLength := 0;
+  Result.CharsRead := 0;
+  Result.Error := bdeNone;
+
+  if AMaxBytes = 0 then
   begin
-    Ch := AInput[I];
-    if not IsAsciiWhitespace(Ch) then
+    SetLength(Result.Bytes, 0);
+    Exit;
+  end;
+
+  InputLength := Length(AInput);
+  Capacity := InputLength;
+  if (AMaxBytes >= 0) and (AMaxBytes < Capacity) then
+    Capacity := AMaxBytes;
+  SetLength(Result.Bytes, Capacity);
+
+  Chunk := '';
+  ChunkLength := 0;
+  Index := 1;
+
+  while True do
+  begin
+    Index := SkipAsciiWhitespaceFrom(Index);
+    if Index > InputLength then
     begin
-      Inc(CleanedLen);
-      Cleaned[CleanedLen] := Ch;
-      CleanedToOriginal[CleanedLen] := I;
-    end;
-  end;
-  SetLength(Cleaned, CleanedLen);
-
-  // Step 2: Handle padding — remove trailing '=' and record
-  HasPadding := False;
-  PadStart := CleanedLen;
-  if (CleanedLen >= 1) and (Cleaned[CleanedLen] = BASE64_PAD_CHAR) then
-  begin
-    HasPadding := True;
-    Dec(PadStart);
-    if (PadStart >= 1) and (Cleaned[PadStart] = BASE64_PAD_CHAR) then
-      Dec(PadStart);
-  end;
-
-  if HasPadding then
-    ChunkLen := PadStart
-  else
-    ChunkLen := CleanedLen;
-
-  // Step 3: Validate all non-padding characters
-  for I := 1 to ChunkLen do
-  begin
-    Ch := Cleaned[I];
-    if (Ord(Ch) > 127) or (DecodeTable[Ord(Ch)] = INVALID_BASE64_VALUE) then
-      ThrowSyntaxError(SErrorInvalidBase64Character, SSuggestBase64Format);
-  end;
-
-  // Step 4: Compute full chunks and remainder
-  FullChunks := ChunkLen div 4;
-  Remainder := ChunkLen mod 4;
-
-  // Step 5: Handle last chunk based on mode
-  if Remainder = 1 then
-  begin
-    // A single trailing character is never valid
-    if ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL then
-    begin
-      // Just ignore the last char, treat only full chunks
-      Dec(ChunkLen, 1);
-      Remainder := 0;
-    end
-    else
-      ThrowSyntaxError(SErrorBase64IncompleteChunk, SSuggestBase64Format);
-  end;
-
-  if Remainder > 0 then
-  begin
-    if ALastChunkHandling = LAST_CHUNK_STRICT then
-    begin
-      if HasPadding then
+      if ChunkLength > 0 then
       begin
-        // In strict mode with padding, the padded chunk must be exactly 4 chars
-        // Check that the padding makes it a complete 4-char chunk
-        if (Remainder = 2) and (CleanedLen - PadStart = 2) then
+        if ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL then
         begin
-          // 2 data + 2 pad = 4: OK, check overflow bits
-          V0 := DecodeTable[Ord(Cleaned[PadStart - 1])];
-          V1 := DecodeTable[Ord(Cleaned[PadStart])];
-          if (V1 and $0F) <> 0 then
-            ThrowSyntaxError(SErrorBase64NonZeroPaddingBits, SSuggestBase64Format);
-        end
-        else if (Remainder = 3) and (CleanedLen - PadStart = 1) then
+          FinishSuccessfully(Result.CharsRead);
+          Exit;
+        end;
+        if ALastChunkHandling = LAST_CHUNK_STRICT then
         begin
-          // 3 data + 1 pad = 4: OK, check overflow bits
-          V0 := DecodeTable[Ord(Cleaned[PadStart])];
-          if (V0 and $03) <> 0 then
-            ThrowSyntaxError(SErrorBase64NonZeroPaddingBits, SSuggestBase64Format);
-        end
-        else
-          ThrowSyntaxError(SErrorBase64MalformedPadding, SSuggestBase64Format);
-      end
-      else
-      begin
-        // In strict mode without padding, partial chunks are invalid
-        ThrowSyntaxError(SErrorBase64IncompleteChunkStrict, SSuggestBase64Format);
+          FinishWithError(bdeIncompleteChunkStrict);
+          Exit;
+        end;
+        if ChunkLength = 1 then
+        begin
+          FinishWithError(bdeIncompleteChunk);
+          Exit;
+        end;
+        DecodeFinalChunk(False, DecodeError, DecodeSucceeded);
+        if not DecodeSucceeded then
+        begin
+          FinishWithError(DecodeError);
+          Exit;
+        end;
       end;
-    end
-    else if ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL then
-    begin
-      // Don't decode the partial last chunk
-      Dec(ChunkLen, Remainder);
-      Remainder := 0;
-      FullChunks := ChunkLen div 4;
+      FinishSuccessfully(InputLength);
+      Exit;
     end;
-    // 'loose' mode: decode the partial chunk normally
-  end
-  else if HasPadding and (ALastChunkHandling = LAST_CHUNK_STRICT) then
-  begin
-    // Padding present but no remainder means the padding was part of a complete chunk
-    // Validate the padding makes sense
-    // (This case occurs when e.g., "AAAA==" — the padding overflows a complete chunk)
-    // Actually if Remainder = 0 and HasPadding, the padding was stripped from a complete set
-    // which means padding was erroneous
-    if PadStart <> CleanedLen then
-      ThrowSyntaxError(SErrorBase64UnexpectedPadding, SSuggestBase64Format);
-  end;
 
-  // Step 6: Compute output size
-  Result.ByteLength := FullChunks * 3;
-  case Remainder of
-    2: Inc(Result.ByteLength, 1);
-    3: Inc(Result.ByteLength, 2);
-  end;
+    Ch := AInput[Index];
+    Inc(Index);
 
-  if (AMaxBytes >= 0) and (Result.ByteLength > AMaxBytes) then
-    Result.ByteLength := AMaxBytes;
-
-  SetLength(Result.Bytes, Result.ByteLength);
-
-  // Step 7: Decode full 4-char chunks — only consume when all 3 output bytes fit
-  Pos := 1;
-  OutPos := 0;
-  for I := 0 to FullChunks - 1 do
-  begin
-    if OutPos + 3 > Result.ByteLength then Break;
-    V0 := DecodeTable[Ord(Cleaned[Pos])];
-    V1 := DecodeTable[Ord(Cleaned[Pos + 1])];
-    V2 := DecodeTable[Ord(Cleaned[Pos + 2])];
-    V3 := DecodeTable[Ord(Cleaned[Pos + 3])];
-    Result.Bytes[OutPos]     := (V0 shl 2) or (V1 shr 4);
-    Result.Bytes[OutPos + 1] := ((V1 and $0F) shl 4) or (V2 shr 2);
-    Result.Bytes[OutPos + 2] := ((V2 and $03) shl 6) or V3;
-    Inc(OutPos, 3);
-    Inc(Pos, 4);
-  end;
-
-  // Step 8: Decode remainder — only consume when all output bytes fit
-  // 2 trailing chars → 1 byte; 3 trailing chars → 2 bytes
-  if (Remainder >= 2) and (OutPos + (Remainder - 1) <= Result.ByteLength) then
-  begin
-    V0 := DecodeTable[Ord(Cleaned[Pos])];
-    V1 := DecodeTable[Ord(Cleaned[Pos + 1])];
-    Result.Bytes[OutPos] := (V0 shl 2) or (V1 shr 4);
-    Inc(OutPos);
-    if Remainder >= 3 then
+    if Ch = BASE64_PAD_CHAR then
     begin
-      V2 := DecodeTable[Ord(Cleaned[Pos + 2])];
-      Result.Bytes[OutPos] := ((V1 and $0F) shl 4) or (V2 shr 2);
-      Inc(OutPos);
+      if ChunkLength < 2 then
+      begin
+        FinishWithError(bdeMalformedPadding);
+        Exit;
+      end;
+
+      Index := SkipAsciiWhitespaceFrom(Index);
+      if ChunkLength = 2 then
+      begin
+        if Index > InputLength then
+        begin
+          if ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL then
+          begin
+            FinishSuccessfully(Result.CharsRead);
+            Exit;
+          end;
+          FinishWithError(bdeIncompleteChunk);
+          Exit;
+        end;
+
+        Ch := AInput[Index];
+        if Ch = BASE64_PAD_CHAR then
+          Index := SkipAsciiWhitespaceFrom(Index + 1);
+      end;
+
+      if Index <= InputLength then
+      begin
+        FinishWithError(bdeUnexpectedPadding);
+        Exit;
+      end;
+
+      ThrowOnExtraBits := ALastChunkHandling = LAST_CHUNK_STRICT;
+      DecodeFinalChunk(ThrowOnExtraBits, DecodeError, DecodeSucceeded);
+      if not DecodeSucceeded then
+      begin
+        FinishWithError(DecodeError);
+        Exit;
+      end;
+      FinishSuccessfully(InputLength);
+      Exit;
     end;
-    Inc(Pos, Remainder);
-  end;
 
-  Result.ByteLength := OutPos;
-  SetLength(Result.Bytes, Result.ByteLength);
+    if (Ord(Ch) > 127) or (DecodeTable[Ord(Ch)] = INVALID_BASE64_VALUE) then
+    begin
+      FinishWithError(bdeInvalidCharacter);
+      Exit;
+    end;
 
-  // Compute characters read from the original input
-  // After successful decode, all characters (including padding) were consumed
-  if (Pos > ChunkLen) then
-  begin
-    // All data chars were decoded — consumed everything including padding
-    if CleanedLen > 0 then
-      CharsConsumed := CleanedToOriginal[CleanedLen]
+    if AMaxBytes < 0 then
+      Remaining := MaxInt
     else
-      CharsConsumed := 0;
-  end
-  else if Pos > 1 then
-    CharsConsumed := CleanedToOriginal[Pos - 1]
-  else
-    CharsConsumed := 0;
+      Remaining := AMaxBytes - Result.ByteLength;
+    if ((Remaining = 1) and (ChunkLength = 2)) or
+       ((Remaining = 2) and (ChunkLength = 3)) then
+    begin
+      FinishSuccessfully(Result.CharsRead);
+      Exit;
+    end;
 
-  // For stop-before-partial, report only up to the chars that were actually decoded
-  if (ALastChunkHandling = LAST_CHUNK_STOP_BEFORE_PARTIAL) and (ChunkLen < PadStart) then
-  begin
-    if ChunkLen > 0 then
-      CharsConsumed := CleanedToOriginal[ChunkLen]
-    else
-      CharsConsumed := 0;
+    Chunk := Chunk + Ch;
+    ChunkLength := Length(Chunk);
+
+    if ChunkLength = 4 then
+    begin
+      DecodeFullChunk;
+      Result.CharsRead := Index - 1;
+      if (AMaxBytes >= 0) and (Result.ByteLength = AMaxBytes) then
+      begin
+        FinishSuccessfully(Result.CharsRead);
+        Exit;
+      end;
+    end;
   end;
-
-  Result.CharsRead := CharsConsumed;
 end;
 
 { ---- Public methods ---- }
@@ -501,6 +568,7 @@ begin
     end;
   end;
 
+  EnsureUint8ArrayInBounds(TA, 'Uint8Array.prototype.toBase64');
   Encoded := EncodeBase64(TA.BufferData, TA.ByteOffset, TA.Length, Alphabet, OmitPadding);
   Result := TGocciaStringLiteralValue.Create(Encoded);
 end;
@@ -515,6 +583,7 @@ var
   B: Byte;
 begin
   TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.toHex');
+  EnsureUint8ArrayInBounds(TA, 'Uint8Array.prototype.toHex');
 
   SetLength(Hex, TA.Length * 2);
   Offset := TA.ByteOffset;
@@ -539,6 +608,7 @@ var
   ResultObj: TGocciaObjectValue;
 begin
   TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.setFromBase64');
+  EnsureUint8ArrayWritable(TA, 'Uint8Array.prototype.setFromBase64');
 
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorSetFromBase64RequiresString, SSuggestStringArgRequired);
@@ -561,6 +631,7 @@ begin
     end;
   end;
 
+  EnsureUint8ArrayInBounds(TA, 'Uint8Array.prototype.setFromBase64');
   DecResult := DecodeBase64(Input, Alphabet, LastChunkHandling, TA.Length);
 
   Written := DecResult.ByteLength;
@@ -569,6 +640,9 @@ begin
 
   for I := 0 to Written - 1 do
     TA.BufferData[TA.ByteOffset + I] := DecResult.Bytes[I];
+
+  if DecResult.Error <> bdeNone then
+    RaiseBase64DecodeError(DecResult.Error);
 
   ResultObj := TGocciaObjectValue.Create;
   TGarbageCollector.Instance.AddTempRoot(ResultObj);
@@ -592,6 +666,7 @@ var
   CharsRead: Integer;
 begin
   TA := RequireUint8Array(AThisValue, 'Uint8Array.prototype.setFromHex');
+  EnsureUint8ArrayWritable(TA, 'Uint8Array.prototype.setFromHex');
 
   if AArgs.Length = 0 then
     ThrowTypeError(SErrorSetFromHexRequiresString, SSuggestStringArgRequired);
@@ -664,6 +739,8 @@ begin
   end;
 
   DecResult := DecodeBase64(Input, Alphabet, LastChunkHandling, -1);
+  if DecResult.Error <> bdeNone then
+    RaiseBase64DecodeError(DecResult.Error);
 
   NewTA := TGocciaTypedArrayValue.Create(takUint8, DecResult.ByteLength);
   for I := 0 to DecResult.ByteLength - 1 do

--- a/tests/built-ins/ArrayBuffer/constructor.js
+++ b/tests/built-ins/ArrayBuffer/constructor.js
@@ -56,6 +56,24 @@ describe("ArrayBuffer constructor error cases", () => {
   test("throws RangeError for -Infinity", () => {
     expect(() => new ArrayBuffer(-Infinity)).toThrow(RangeError);
   });
+
+  test("subclass validates length before resolving newTarget prototype", () => {
+    const events = [];
+    class Sub extends ArrayBuffer {}
+    class NewTargetBase {}
+    const NewTarget = new Proxy(NewTargetBase, {
+      get(target, property) {
+        if (property === "prototype") {
+          events.push("prototype");
+          throw new Error("prototype");
+        }
+        return target[property];
+      },
+    });
+
+    expect(() => Reflect.construct(Sub, [-1], NewTarget)).toThrow(RangeError);
+    expect(events).toEqual([]);
+  });
 });
 
 describe("ArrayBuffer constructor ToIndex coercion (ES2026 §6.2.4.2)", () => {

--- a/tests/built-ins/DataView/constructor.js
+++ b/tests/built-ins/DataView/constructor.js
@@ -60,6 +60,24 @@ describe("DataView constructor error cases", () => {
     expect(() => new DataView(buffer, 5)).toThrow(RangeError);
   });
 
+  test("validates offset before resolving newTarget prototype", () => {
+    const buffer = new ArrayBuffer(0, { maxByteLength: 1 });
+    const events = [];
+    class NewTargetBase {}
+    const NewTarget = new Proxy(NewTargetBase, {
+      get(target, property) {
+        if (property === "prototype") {
+          events.push("prototype");
+          throw new Error("prototype");
+        }
+        return target[property];
+      },
+    });
+
+    expect(() => Reflect.construct(DataView, [buffer, 1], NewTarget)).toThrow(RangeError);
+    expect(events).toEqual([]);
+  });
+
   test("throws RangeError when byteLength extends past the buffer", () => {
     const buffer = new ArrayBuffer(4);
     expect(() => new DataView(buffer, 2, 3)).toThrow(RangeError);

--- a/tests/built-ins/DataView/constructor.js
+++ b/tests/built-ins/DataView/constructor.js
@@ -78,6 +78,25 @@ describe("DataView constructor error cases", () => {
     expect(events).toEqual([]);
   });
 
+  test("subclass validates offset before resolving newTarget prototype", () => {
+    const buffer = new ArrayBuffer(0, { maxByteLength: 1 });
+    const events = [];
+    class Sub extends DataView {}
+    class NewTargetBase {}
+    const NewTarget = new Proxy(NewTargetBase, {
+      get(target, property) {
+        if (property === "prototype") {
+          events.push("prototype");
+          throw new Error("prototype");
+        }
+        return target[property];
+      },
+    });
+
+    expect(() => Reflect.construct(Sub, [buffer, 1], NewTarget)).toThrow(RangeError);
+    expect(events).toEqual([]);
+  });
+
   test("throws RangeError when byteLength extends past the buffer", () => {
     const buffer = new ArrayBuffer(4);
     expect(() => new DataView(buffer, 2, 3)).toThrow(RangeError);

--- a/tests/built-ins/DataView/prototype/getInt8.js
+++ b/tests/built-ins/DataView/prototype/getInt8.js
@@ -9,4 +9,13 @@ describe("DataView.prototype.getInt8", () => {
     view.setUint8(0, 255);
     expect(view.getInt8(0)).toBe(-1);
   });
+
+  test("detached buffer is checked after ToIndex accepts MAX_SAFE_INTEGER", () => {
+    const buffer = new ArrayBuffer(1);
+    const view = new DataView(buffer);
+    buffer.transfer();
+
+    expect(() => view.getInt8(Math.pow(2, 53) - 1)).toThrow(TypeError);
+    expect(() => view.getInt8(Math.pow(2, 53))).toThrow(RangeError);
+  });
 });

--- a/tests/built-ins/Reflect/construct/function-keyword.js
+++ b/tests/built-ins/Reflect/construct/function-keyword.js
@@ -68,6 +68,21 @@ describe("Reflect.construct on function-keyword targets", () => {
     expect(obj instanceof Foo).toBe(false);
   });
 
+  test("derived class extending a function honors function newTarget.prototype", () => {
+    function Base() {}
+    function NewTarget() {}
+    class Derived extends Base {
+      constructor() {
+        super();
+      }
+    }
+
+    const obj = Reflect.construct(Derived, [], NewTarget);
+    expect(Object.getPrototypeOf(obj)).toBe(NewTarget.prototype);
+    expect(obj instanceof NewTarget).toBe(true);
+    expect(obj instanceof Derived).toBe(false);
+  });
+
   test("when newTarget.prototype is non-object, the instance falls back to Object.prototype", () => {
     function Foo() {
       this.x = 1;
@@ -77,6 +92,21 @@ describe("Reflect.construct on function-keyword targets", () => {
     const obj = Reflect.construct(Foo, [], Bar);
     expect(obj.x).toBe(1);
     expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+  });
+
+  test("derived class extending a function falls back from non-object function newTarget.prototype", () => {
+    function Base() {}
+    function NewTarget() {}
+    NewTarget.prototype = null;
+    class Derived extends Base {
+      constructor() {
+        super();
+      }
+    }
+
+    const obj = Reflect.construct(Derived, [], NewTarget);
+    expect(Object.getPrototypeOf(obj)).toBe(Object.prototype);
+    expect(obj instanceof Derived).toBe(false);
   });
 
   test("instanceof against newTarget is observable from inside the constructor body", () => {

--- a/tests/built-ins/SharedArrayBuffer/constructor.js
+++ b/tests/built-ins/SharedArrayBuffer/constructor.js
@@ -57,6 +57,24 @@ describe("SharedArrayBuffer constructor error cases", () => {
     expect(() => new SharedArrayBuffer(-Infinity)).toThrow(RangeError);
   });
 
+  test("subclass validates length before resolving newTarget prototype", () => {
+    const events = [];
+    class Sub extends SharedArrayBuffer {}
+    class NewTargetBase {}
+    const NewTarget = new Proxy(NewTargetBase, {
+      get(target, property) {
+        if (property === "prototype") {
+          events.push("prototype");
+          throw new Error("prototype");
+        }
+        return target[property];
+      },
+    });
+
+    expect(() => Reflect.construct(Sub, [-1], NewTarget)).toThrow(RangeError);
+    expect(events).toEqual([]);
+  });
+
   test("throws RangeError when length is 2^31 (one past High(Integer))", () => {
     expect(() => new SharedArrayBuffer(2147483648)).toThrow(RangeError);
   });

--- a/tests/built-ins/SharedArrayBuffer/prototype/slice.js
+++ b/tests/built-ins/SharedArrayBuffer/prototype/slice.js
@@ -54,11 +54,12 @@ describe("SharedArrayBuffer.prototype.slice", () => {
     expect(sliced.byteLength).toBe(8);
   });
 
-  // ES2026 §25.2.5.6 step 11: If new.[[ArrayBufferData]] is O.[[ArrayBufferData]], throw TypeError
-  // Zero-length SharedArrayBuffers share the same backing data block, triggering the identity check.
-  test("slicing a zero-length buffer throws TypeError", () => {
+  test("slicing a zero-length buffer returns a distinct empty buffer", () => {
     const sab = new SharedArrayBuffer(0);
-    expect(() => sab.slice()).toThrow(TypeError);
+    const sliced = sab.slice();
+    expect(sliced).not.toBe(sab);
+    expect(sliced instanceof SharedArrayBuffer).toBe(true);
+    expect(sliced.byteLength).toBe(0);
   });
 
   test("result is a new SharedArrayBuffer instance", () => {

--- a/tests/built-ins/TypedArray/constructors.js
+++ b/tests/built-ins/TypedArray/constructors.js
@@ -12,6 +12,16 @@ describe("TypedArray constructors", () => {
     test("Float64Array is defined", () => { expect(Float64Array).toBeDefined(); });
   });
 
+  describe("%TypedArray% intrinsic", () => {
+    test("is not directly callable or constructable", () => {
+      const TypedArray = Object.getPrototypeOf(Int8Array);
+
+      expect(() => TypedArray()).toThrow(TypeError);
+      expect(() => new TypedArray()).toThrow(TypeError);
+      expect(Object.getPrototypeOf(Uint8Array)).toBe(TypedArray);
+    });
+  });
+
   describe("new TypedArray() — zero-length", () => {
     test("new Int8Array()", () => {
       const ta = new Int8Array();

--- a/tests/built-ins/TypedArray/fromBase64.js
+++ b/tests/built-ins/TypedArray/fromBase64.js
@@ -80,6 +80,23 @@ describe("Uint8Array.fromBase64", () => {
     expect(result.length).toBe(5);
   });
 
+  test("decodes padded final chunks in all modes", () => {
+    const loose = Uint8Array.fromBase64("ZXhhZg==");
+    const strict = Uint8Array.fromBase64("ZXhhZg==", {
+      lastChunkHandling: "strict"
+    });
+    const stopBeforePartial = Uint8Array.fromBase64("ZXhhZg==", {
+      lastChunkHandling: "stop-before-partial"
+    });
+
+    expect(loose.length).toBe(4);
+    expect(loose[3]).toBe(102);
+    expect(strict.length).toBe(4);
+    expect(strict[3]).toBe(102);
+    expect(stopBeforePartial.length).toBe(4);
+    expect(stopBeforePartial[3]).toBe(102);
+  });
+
   test("strict mode rejects non-zero padding bits", () => {
     // "AR==" has non-zero padding bits (the R encodes 0x11, trailing bits are non-zero)
     expect(() => Uint8Array.fromBase64("AR==", {
@@ -95,6 +112,22 @@ describe("Uint8Array.fromBase64", () => {
     expect(result[0]).toBe(65);
     expect(result[1]).toBe(66);
     expect(result[2]).toBe(67);
+  });
+
+  test("stop-before-partial skips incomplete padding", () => {
+    const result = Uint8Array.fromBase64("ZXhhZg=", {
+      lastChunkHandling: "stop-before-partial"
+    });
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(101);
+    expect(result[1]).toBe(120);
+    expect(result[2]).toBe(97);
+  });
+
+  test("throws SyntaxError for malformed padding", () => {
+    expect(() => Uint8Array.fromBase64("AA=")).toThrow(SyntaxError);
+    expect(() => Uint8Array.fromBase64("AAAA=")).toThrow(SyntaxError);
+    expect(() => Uint8Array.fromBase64("ZXhhZg===")).toThrow(SyntaxError);
   });
 
   test("throws TypeError for invalid alphabet option", () => {

--- a/tests/built-ins/TypedArray/prototype/setFromBase64.js
+++ b/tests/built-ins/TypedArray/prototype/setFromBase64.js
@@ -93,4 +93,69 @@ describe("Uint8Array.prototype.setFromBase64", () => {
     const target = new Uint8Array(5);
     expect(() => target.setFromBase64("SGVsbG8", { lastChunkHandling: "strict" })).toThrow(SyntaxError);
   });
+
+  test("writes decoded bytes before throwing on later invalid data", () => {
+    const target = new Uint8Array([255, 255, 255, 255, 255]);
+    expect(() => target.setFromBase64("MjYyZm.9v")).toThrow(SyntaxError);
+    expect(target[0]).toBe(50);
+    expect(target[1]).toBe(54);
+    expect(target[2]).toBe(50);
+    expect(target[3]).toBe(255);
+    expect(target[4]).toBe(255);
+  });
+
+  test("does not scan trailing garbage after target is full", () => {
+    const target = new Uint8Array(3);
+    const result = target.setFromBase64("aaaa#");
+    expect(result.read).toBe(4);
+    expect(result.written).toBe(3);
+    expect(target[0]).toBe(105);
+    expect(target[1]).toBe(166);
+    expect(target[2]).toBe(154);
+  });
+
+  test("zero-length target ignores malformed input", () => {
+    const target = new Uint8Array(0);
+    const result = target.setFromBase64("#", {
+      lastChunkHandling: "strict"
+    });
+    expect(result.read).toBe(0);
+    expect(result.written).toBe(0);
+  });
+
+  test("throws TypeError when options detach the target before decoding", () => {
+    const buffer = new ArrayBuffer(3);
+    const target = new Uint8Array(buffer);
+    let getterCalls = 0;
+    const options = {};
+    Object.defineProperty(options, "alphabet", {
+      get() {
+        getterCalls += 1;
+        buffer.transfer();
+        return "base64";
+      }
+    });
+
+    expect(() => target.setFromBase64("Zg==", options)).toThrow(TypeError);
+    expect(getterCalls).toBe(1);
+  });
+
+  test("throws TypeError on immutable targets before reading options", () => {
+    const buffer = new ArrayBuffer(3);
+    const seed = new Uint8Array(buffer);
+    seed[0] = 1;
+    const target = new Uint8Array(buffer.transferToImmutable());
+    let getterCalls = 0;
+    const options = {};
+    Object.defineProperty(options, "alphabet", {
+      get() {
+        getterCalls += 1;
+        return "base64";
+      }
+    });
+
+    expect(() => target.setFromBase64("Zg==", options)).toThrow(TypeError);
+    expect(getterCalls).toBe(0);
+    expect(target[0]).toBe(1);
+  });
 });

--- a/tests/built-ins/TypedArray/prototype/setFromHex.js
+++ b/tests/built-ins/TypedArray/prototype/setFromHex.js
@@ -75,4 +75,30 @@ describe("Uint8Array.prototype.setFromHex", () => {
     const target = new Uint8Array(5);
     expect(() => target.setFromHex("zzzz")).toThrow(SyntaxError);
   });
+
+  test("writes decoded bytes before throwing on later invalid data", () => {
+    const target = new Uint8Array([255, 255, 255]);
+    expect(() => target.setFromHex("aaag")).toThrow(SyntaxError);
+    expect(target[0]).toBe(0xAA);
+    expect(target[1]).toBe(255);
+    expect(target[2]).toBe(255);
+  });
+
+  test("throws TypeError on detached targets", () => {
+    const buffer = new ArrayBuffer(2);
+    const target = new Uint8Array(buffer);
+    buffer.transfer();
+
+    expect(() => target.setFromHex("aa")).toThrow(TypeError);
+  });
+
+  test("throws TypeError on immutable targets before reading the string", () => {
+    const buffer = new ArrayBuffer(2);
+    const seed = new Uint8Array(buffer);
+    seed[0] = 1;
+    const target = new Uint8Array(buffer.transferToImmutable());
+
+    expect(() => target.setFromHex("aa")).toThrow(TypeError);
+    expect(target[0]).toBe(1);
+  });
 });

--- a/tests/built-ins/TypedArray/prototype/toBase64.js
+++ b/tests/built-ins/TypedArray/prototype/toBase64.js
@@ -68,6 +68,31 @@ describe("Uint8Array.prototype.toBase64", () => {
     expect(() => bytes.toBase64("bad")).toThrow(TypeError);
   });
 
+  test("throws TypeError when options detach the buffer before encoding", () => {
+    const buffer = new ArrayBuffer(2);
+    const bytes = new Uint8Array(buffer);
+    let getterCalls = 0;
+    const options = {};
+    Object.defineProperty(options, "alphabet", {
+      get() {
+        getterCalls += 1;
+        buffer.transfer();
+        return "base64";
+      }
+    });
+
+    expect(() => bytes.toBase64(options)).toThrow(TypeError);
+    expect(getterCalls).toBe(1);
+  });
+
+  test("throws TypeError on detached buffers", () => {
+    const buffer = new ArrayBuffer(2);
+    const bytes = new Uint8Array(buffer);
+    buffer.transfer();
+
+    expect(() => bytes.toBase64()).toThrow(TypeError);
+  });
+
   test("works with buffer offset", () => {
     const buffer = new ArrayBuffer(8);
     const full = new Uint8Array(buffer);

--- a/tests/built-ins/TypedArray/prototype/toHex.js
+++ b/tests/built-ins/TypedArray/prototype/toHex.js
@@ -39,6 +39,14 @@ describe("Uint8Array.prototype.toHex", () => {
     expect(() => fn.call(new Int32Array(1))).toThrow(TypeError);
   });
 
+  test("throws TypeError on detached buffers", () => {
+    const buffer = new ArrayBuffer(2);
+    const bytes = new Uint8Array(buffer);
+    buffer.transfer();
+
+    expect(() => bytes.toHex()).toThrow(TypeError);
+  });
+
   test("works with buffer offset", () => {
     const buffer = new ArrayBuffer(8);
     const full = new Uint8Array(buffer);

--- a/tests/language/classes/private-getter-call.js
+++ b/tests/language/classes/private-getter-call.js
@@ -64,6 +64,22 @@ test("private methods can validate and transform values", () => {
   expect(instance.getValue()).toBe(10);
 });
 
+test("new expression callee supports private constructor members", () => {
+  class Factory {
+    #Ctor = class {
+      constructor(value) {
+        this.value = value;
+      }
+    };
+
+    create(value) {
+      return new this.#Ctor(value);
+    }
+  }
+
+  expect(new Factory().create(42).value).toBe(42);
+});
+
 test("private getters can derive values from private fields", () => {
   class TestClass {
     #value = 10;

--- a/tests/language/identifiers/reserved-words-as-properties.js
+++ b/tests/language/identifiers/reserved-words-as-properties.js
@@ -62,6 +62,15 @@ test("reserved words as object property names", () => {
   expect(obj.with).toBe("scope");
 });
 
+test("reserved words in object patterns require explicit binding names", () => {
+  const readKeywordProperty = new Function(
+    "const { if: value } = { if: 1 }; return value;"
+  );
+
+  expect(readKeywordProperty()).toBe(1);
+  expect(() => new Function("const { if } = { if: 1 };")).toThrow(SyntaxError);
+});
+
 test("reserved words as object property names with bracket notation", () => {
   const obj = {};
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Complete the TypedArray, ArrayBuffer, SharedArrayBuffer, DataView, and Uint8Array edge cases needed for the pinned issue #840 conformance slice.
- Align native constructor finalization/prototype lookup ordering across interpreter and bytecode paths, including `Reflect.construct`/`newTarget` cases and delayed ArrayBuffer/DataView allocation checks.
- Add ArrayBuffer immutable/sliceToImmutable behavior, SharedArrayBuffer species slicing, DataView detached/index ordering, TypedArray slice/set semantics, Uint8Array base64/hex decoding edge cases, and missing test262 realm host hooks.
- Follow-up audit fixes: bytecode native subclasses now validate ArrayBuffer/SharedArrayBuffer lengths and DataView offsets before touching `newTarget.prototype`; zero-length `SharedArrayBuffer.prototype.slice()` now returns a distinct empty buffer.
- Final failure sweep: direct bytecode `Object(value)` construction boxes primitives, VM class construction preserves private brand initialization for eval-authored classes, typed-array prototype lookup ordering matches test262, object-pattern shorthand now rejects keyword bindings while allowing explicit keyword property aliases, and function-super derived classes preserve explicit `newTarget` prototype/realm fallback.
- Review cleanup: `$262.createRealm()` now returns the child `$262` host object with mirrored hooks, native implicit constructors keep the allocated native instance rooted through initialization/finalization, and `new this.#Ctor()` parses private constructor member callees.
- Parser nitpick cleanup: `Call()` and `new` callee parsing now share the same member-access segment parser, while object-pattern keyword shorthand still reaches the precise binding-validation error path.
- Closes #840.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas --clean testrunner`
  - `./build.pas --clean loaderbare`
  - `./build/GocciaTestRunner tests` -> 11196/11196
  - `./build/GocciaTestRunner tests --mode=bytecode` -> 11196/11196
  - `./build/GocciaTestRunner tests/built-ins/ArrayBuffer/constructor.js tests/built-ins/SharedArrayBuffer/constructor.js tests/built-ins/DataView/constructor.js tests/built-ins/SharedArrayBuffer/prototype/slice.js tests/language/identifiers/reserved-words-as-properties.js` -> 101/101
  - `./build/GocciaTestRunner tests/built-ins/ArrayBuffer/constructor.js tests/built-ins/SharedArrayBuffer/constructor.js tests/built-ins/DataView/constructor.js tests/built-ins/SharedArrayBuffer/prototype/slice.js tests/language/identifiers/reserved-words-as-properties.js --mode=bytecode` -> 101/101
  - `./build/GocciaTestRunner tests/built-ins/Reflect/construct.js tests/built-ins/Reflect/construct/function-keyword.js tests/built-ins/Reflect/construct/class-constructor-return.js` -> 72/72
  - `./build/GocciaTestRunner tests/built-ins/Reflect/construct.js tests/built-ins/Reflect/construct/function-keyword.js tests/built-ins/Reflect/construct/class-constructor-return.js --mode=bytecode` -> 72/72
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/TypedArray/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-typedarray.json` -> 1446/1446
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/ArrayBuffer/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-arraybuffer.json` -> 221/221
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/SharedArrayBuffer/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-sharedarraybuffer.json` -> 104/104
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/DataView/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-dataview.json` -> 561/561
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/Uint8Array/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-uint8array.json` -> 70/70
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories staging --filter 'staging/**/TypedArray/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-staging-typedarray.json` -> 96/96
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories staging --filter 'staging/**/ArrayBuffer/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-staging-arraybuffer.json` -> 5/5
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories staging --filter 'staging/**/DataView/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-staging-dataview.json` -> 3/3
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories staging --filter 'staging/Uint8Array/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-staging-uint8array.json` -> 1/1
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories intl402 --filter 'intl402/TypedArray/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-intl402-typedarray.json` -> 1/1
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/Object/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-object-after.json` -> 3411/3411
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/String/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-string-after.json` -> 1223/1223
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/TypedArrayConstructors/ctors/typedarray-arg/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-typedarray-arg-post-super-fix.json` -> 14/14
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories language --filter 'language/expressions/class/**' --mode bytecode --jobs 4 --output /tmp/goccia-test262-class-expr-post-super-fix.json` -> 4059/4059
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories language --filter 'language/expressions/super/realm.js' --mode bytecode --jobs 1 --output /tmp/goccia-test262-super-realm-final.json` -> 1/1
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories staging --filter 'staging/sm/regress/regress-694306.js' --mode bytecode --jobs 1 --output /tmp/goccia-test262-sm-694306-post-super-fix.json` -> 1/1
  - `./format.pas --check`
  - `git diff --check`
  - `./build/GocciaTestRunner tests/language/classes/private-getter-call.js tests/built-ins/Reflect/construct/function-keyword.js tests/built-ins/Reflect/construct/class-constructor-return.js` -> 54/54
  - `./build/GocciaTestRunner tests/language/classes/private-getter-call.js tests/built-ins/Reflect/construct/function-keyword.js tests/built-ins/Reflect/construct/class-constructor-return.js --mode=bytecode` -> 54/54
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories staging --filter 'staging/goccia/create-realm-host-hooks.js' --mode bytecode --jobs 1 --output /tmp/goccia-test262-review-create-realm.json` -> 1/1
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories staging --filter 'staging/sm/TypedArray/set-wrapped.js' --mode bytecode --jobs 1 --output /tmp/goccia-test262-review-set-wrapped.json` -> 1/1
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/ArrayBuffer/options-maxbytelength-compared-before-object-creation.js' --mode bytecode --jobs 1` -> 1/1
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/SharedArrayBuffer/options-maxbytelength-compared-before-object-creation.js' --mode bytecode --jobs 1` -> 1/1
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/DataView/proto-from-ctor-realm.js' --mode bytecode --jobs 1` -> 1/1
  - `bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-020cb740 --categories built-ins --filter 'built-ins/DataView/proto-from-ctor-realm-sab.js' --mode bytecode --jobs 1` -> 1/1
- [ ] Updated documentation
  - N/A: runtime conformance/test coverage only; no user-facing docs changed.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - Not run separately; covered by full JS runner gates and focused test262 conformance filters.
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Not run locally; this change targets correctness/conformance rather than a benchmarked hot path.

## Review Evidence

- Post-main-merge validation: `./build.pas --clean testrunner`, full interpreted/bytecode JS suites (11196/11196 each; 24463 assertions), `./format.pas --check`, and `git diff --check` all passed.
- Parser nitpick validation: `./build.pas --clean testrunner`, `./build/GocciaTestRunner tests/language/identifiers/reserved-words-as-properties.js`, full interpreted/bytecode JS suites (11196/11196 each; 24463 assertions), `./format.pas --check`, and `git diff --check` all passed.
- Manual diff review after the follow-up audit covered native subclass construction, bytecode constructor redirects, delayed native receiver initialization, direct `Object(value)` bytecode construction, eval-authored private class construction, object-pattern keyword shorthand validation, function-super `newTarget` prototype/realm fallback, zero-length SharedArrayBuffer slice identity, `$262.createRealm()` host-object shape, native constructor GC rooting, and private-member `new` callees.
- Parallel audit agents identified the earlier native-constructor and SharedArrayBuffer follow-up findings; both now have regression coverage and pass in interpreter and bytecode modes.
- The final failure sweep was validated against pinned test262 checkout `020cb74075849d1e404bbcdb62feb7a02e6966db`.


