### PR TITLE
fix(map): align collection constructor iteration

### DIFF
--- a/source/units/Goccia.Constants.PropertyNames.pas
+++ b/source/units/Goccia.Constants.PropertyNames.pas
@@ -56,6 +56,7 @@ const
   PROP_CONFIGURABLE = 'configurable';
   PROP_GET          = 'get';
   PROP_SET          = 'set';
+  PROP_ADD          = 'add';
   PROP_INIT         = 'init';
   PROP_KIND         = 'kind';
   PROP_STATIC       = 'static';

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -685,6 +685,8 @@ resourcestring
   SErrorMapIteratorNonMap = 'Map.prototype[Symbol.iterator] called on non-Map object';
   SErrorMapGetOrInsertNonMap = 'Map.prototype.getOrInsert called on non-Map object';
   SErrorMapGetOrInsertComputedNonMap = 'Map.prototype.getOrInsertComputed called on non-Map object';
+  SErrorMapConstructorEntryNotObject = 'Map constructor requires each entry to be an object';
+  SErrorMapConstructorNotIterable = '%s constructor requires an iterable';
 
   // WeakMap/WeakSet brand-check and key validation errors
   SErrorWeakMapGetNonWeakMap = 'WeakMap.prototype.get called on non-WeakMap object';

--- a/source/units/Goccia.Values.IteratorSupport.pas
+++ b/source/units/Goccia.Values.IteratorSupport.pas
@@ -61,12 +61,6 @@ var
 begin
   GC := TGarbageCollector.Instance;
 
-  if AValue is TGocciaIteratorValue then
-  begin
-    Result := TGocciaIteratorValue(AValue);
-    Exit;
-  end;
-
   IteratorHost := nil;
   IteratorReceiver := AValue;
   if AValue is TGocciaObjectValue then

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -66,6 +66,8 @@ type
 implementation
 
 uses
+  SysUtils,
+
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
@@ -76,6 +78,8 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.Iterator.Concrete,
+  Goccia.Values.IteratorSupport,
+  Goccia.Values.IteratorValue,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
@@ -169,33 +173,96 @@ end;
 
 procedure TGocciaMapValue.InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
 var
-  InitArg: TGocciaValue;
-  ArrValue: TGocciaArrayValue;
-  EntryArr: TGocciaArrayValue;
-  EntryObj: TGocciaObjectValue;
-  I: Integer;
+  InitArg, Adder, NextValue, Key, Value: TGocciaValue;
+  Iterator: TGocciaIteratorValue;
+  CallArgs: TGocciaArgumentsCollection;
+  Done: Boolean;
+  GC: TGarbageCollector;
+  WasSelfRooted, WasInitRooted, WasAdderRooted, WasIteratorRooted: Boolean;
+  WasNextRooted, WasKeyRooted, WasValueRooted: Boolean;
+
+  function AddRootIfNeeded(const AValue: TGocciaValue): Boolean;
+  begin
+    Result := Assigned(GC) and Assigned(AValue) and not GC.IsTempRoot(AValue);
+    if Result then
+      GC.AddTempRoot(AValue);
+  end;
+
+  procedure RemoveRootIfNeeded(const AValue: TGocciaValue; const AWasAdded: Boolean);
+  begin
+    if AWasAdded then
+      GC.RemoveTempRoot(AValue);
+  end;
+
 begin
   if AArguments.Length = 0 then
     Exit;
   InitArg := AArguments.GetElement(0);
-  if InitArg is TGocciaArrayValue then
-  begin
-    ArrValue := TGocciaArrayValue(InitArg);
-    for I := 0 to ArrValue.Elements.Count - 1 do
-    begin
-      if Assigned(ArrValue.Elements[I]) and (ArrValue.Elements[I] is TGocciaArrayValue) then
-      begin
-        EntryArr := TGocciaArrayValue(ArrValue.Elements[I]);
-        if EntryArr.Elements.Count >= 2 then
-          SetEntry(EntryArr.Elements[0], EntryArr.Elements[1]);
-      end
-      else if Assigned(ArrValue.Elements[I]) and
-              (ArrValue.Elements[I] is TGocciaObjectValue) then
-      begin
-        EntryObj := TGocciaObjectValue(ArrValue.Elements[I]);
-        SetEntry(EntryObj.GetProperty('0'), EntryObj.GetProperty('1'));
+  if (InitArg is TGocciaUndefinedLiteralValue) or
+     (InitArg is TGocciaNullLiteralValue) then
+    Exit;
+
+  GC := TGarbageCollector.Instance;
+  WasSelfRooted := AddRootIfNeeded(Self);
+  WasInitRooted := AddRootIfNeeded(InitArg);
+  try
+    Adder := GetProperty(PROP_SET);
+    if not Assigned(Adder) or not Adder.IsCallable then
+      ThrowTypeError(Format(SErrorValueNotFunction, [PROP_SET]), SSuggestMapThisType);
+
+    WasAdderRooted := AddRootIfNeeded(Adder);
+    try
+      Iterator := GetIteratorFromValue(InitArg);
+      if not Assigned(Iterator) then
+        ThrowTypeError(Format(SErrorMapConstructorNotIterable, [CONSTRUCTOR_MAP]), SSuggestNotIterable);
+
+      WasIteratorRooted := AddRootIfNeeded(Iterator);
+      try
+        NextValue := Iterator.DirectNext(Done);
+        while not Done do
+        begin
+          WasNextRooted := AddRootIfNeeded(NextValue);
+          try
+            try
+              if not (NextValue is TGocciaObjectValue) then
+                ThrowTypeError(SErrorMapConstructorEntryNotObject, SSuggestIteratorProtocol);
+
+              Key := TGocciaObjectValue(NextValue).GetProperty('0');
+              WasKeyRooted := AddRootIfNeeded(Key);
+              try
+                Value := TGocciaObjectValue(NextValue).GetProperty('1');
+                WasValueRooted := AddRootIfNeeded(Value);
+                try
+                  CallArgs := TGocciaArgumentsCollection.Create([Key, Value]);
+                  try
+                    InvokeCallable(Adder, CallArgs, Self);
+                  finally
+                    CallArgs.Free;
+                  end;
+                finally
+                  RemoveRootIfNeeded(Value, WasValueRooted);
+                end;
+              finally
+                RemoveRootIfNeeded(Key, WasKeyRooted);
+              end;
+            except
+              CloseIteratorPreservingError(Iterator);
+              raise;
+            end;
+          finally
+            RemoveRootIfNeeded(NextValue, WasNextRooted);
+          end;
+          NextValue := Iterator.DirectNext(Done);
+        end;
+      finally
+        RemoveRootIfNeeded(Iterator, WasIteratorRooted);
       end;
+    finally
+      RemoveRootIfNeeded(Adder, WasAdderRooted);
     end;
+  finally
+    RemoveRootIfNeeded(InitArg, WasInitRooted);
+    RemoveRootIfNeeded(Self, WasSelfRooted);
   end;
 end;
 

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -336,15 +336,15 @@ begin
   WasSelfRooted := AddRootIfNeeded(Self);
   WasInitRooted := AddRootIfNeeded(InitArg);
   try
-    Adder := GetProperty('add');
+    Adder := GetProperty(PROP_ADD);
     if not Assigned(Adder) or not Adder.IsCallable then
-      ThrowTypeError(Format(SErrorValueNotFunction, ['add']), SSuggestSetThisType);
+      ThrowTypeError(Format(SErrorValueNotFunction, [PROP_ADD]), SSuggestSetThisType);
 
     WasAdderRooted := AddRootIfNeeded(Adder);
     try
       Iterator := GetIteratorFromValue(InitArg);
       if not Assigned(Iterator) then
-        ThrowTypeError('Set constructor argument is not iterable');
+        ThrowTypeError(Format(SErrorMapConstructorNotIterable, [CONSTRUCTOR_SET]), SSuggestNotIterable);
 
       WasIteratorRooted := AddRootIfNeeded(Iterator);
       try

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -303,10 +303,27 @@ end;
 
 procedure TGocciaSetValue.InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection);
 var
-  InitArg: TGocciaValue;
+  InitArg, Adder, Item: TGocciaValue;
   Iterator: TGocciaIteratorValue;
-  Item: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
   Done: Boolean;
+  GC: TGarbageCollector;
+  WasSelfRooted, WasInitRooted, WasAdderRooted, WasIteratorRooted: Boolean;
+  WasItemRooted: Boolean;
+
+  function AddRootIfNeeded(const AValue: TGocciaValue): Boolean;
+  begin
+    Result := Assigned(GC) and Assigned(AValue) and not GC.IsTempRoot(AValue);
+    if Result then
+      GC.AddTempRoot(AValue);
+  end;
+
+  procedure RemoveRootIfNeeded(const AValue: TGocciaValue; const AWasAdded: Boolean);
+  begin
+    if AWasAdded then
+      GC.RemoveTempRoot(AValue);
+  end;
+
 begin
   if AArguments.Length = 0 then
     Exit;
@@ -315,19 +332,52 @@ begin
      (InitArg is TGocciaNullLiteralValue) then
     Exit;
 
-  Iterator := GetIteratorFromValue(InitArg);
-  if not Assigned(Iterator) then
-    ThrowTypeError('Set constructor argument is not iterable');
-
+  GC := TGarbageCollector.Instance;
+  WasSelfRooted := AddRootIfNeeded(Self);
+  WasInitRooted := AddRootIfNeeded(InitArg);
   try
-    repeat
-      Item := Iterator.DirectNext(Done);
-      if not Done then
-        AddItem(Item);
-    until Done;
-  except
-    CloseIteratorPreservingError(Iterator);
-    raise;
+    Adder := GetProperty('add');
+    if not Assigned(Adder) or not Adder.IsCallable then
+      ThrowTypeError(Format(SErrorValueNotFunction, ['add']), SSuggestSetThisType);
+
+    WasAdderRooted := AddRootIfNeeded(Adder);
+    try
+      Iterator := GetIteratorFromValue(InitArg);
+      if not Assigned(Iterator) then
+        ThrowTypeError('Set constructor argument is not iterable');
+
+      WasIteratorRooted := AddRootIfNeeded(Iterator);
+      try
+        Item := Iterator.DirectNext(Done);
+        while not Done do
+        begin
+          WasItemRooted := AddRootIfNeeded(Item);
+          try
+            try
+              CallArgs := TGocciaArgumentsCollection.Create([Item]);
+              try
+                InvokeCallable(Adder, CallArgs, Self);
+              finally
+                CallArgs.Free;
+              end;
+            except
+              CloseIteratorPreservingError(Iterator);
+              raise;
+            end;
+          finally
+            RemoveRootIfNeeded(Item, WasItemRooted);
+          end;
+          Item := Iterator.DirectNext(Done);
+        end;
+      finally
+        RemoveRootIfNeeded(Iterator, WasIteratorRooted);
+      end;
+    finally
+      RemoveRootIfNeeded(Adder, WasAdderRooted);
+    end;
+  finally
+    RemoveRootIfNeeded(InitArg, WasInitRooted);
+    RemoveRootIfNeeded(Self, WasSelfRooted);
   end;
 end;
 

--- a/source/units/Goccia.Values.WeakMapValue.pas
+++ b/source/units/Goccia.Values.WeakMapValue.pas
@@ -232,11 +232,11 @@ begin
 
       WasIteratorRooted := AddRootIfNeeded(Iterator);
       try
-        try
-          NextValue := Iterator.DirectNext(Done);
-          while not Done do
-          begin
-            WasNextRooted := AddRootIfNeeded(NextValue);
+        NextValue := Iterator.DirectNext(Done);
+        while not Done do
+        begin
+          WasNextRooted := AddRootIfNeeded(NextValue);
+          try
             try
               if not (NextValue is TGocciaObjectValue) then
                 ThrowTypeError(SErrorWeakMapConstructorEntryNotObject, SSuggestIteratorProtocol);
@@ -259,15 +259,14 @@ begin
               finally
                 RemoveRootIfNeeded(Key, WasKeyRooted);
               end;
-            finally
-              RemoveRootIfNeeded(NextValue, WasNextRooted);
+            except
+              CloseIteratorPreservingError(Iterator);
+              raise;
             end;
-            NextValue := Iterator.DirectNext(Done);
+          finally
+            RemoveRootIfNeeded(NextValue, WasNextRooted);
           end;
-        except
-          AcquireExceptionObject;
-          CloseIteratorPreservingError(Iterator);
-          raise;
+          NextValue := Iterator.DirectNext(Done);
         end;
       finally
         RemoveRootIfNeeded(Iterator, WasIteratorRooted);

--- a/source/units/Goccia.Values.WeakSetValue.pas
+++ b/source/units/Goccia.Values.WeakSetValue.pas
@@ -214,11 +214,11 @@ begin
 
       WasIteratorRooted := AddRootIfNeeded(Iterator);
       try
-        try
-          NextValue := Iterator.DirectNext(Done);
-          while not Done do
-          begin
-            WasNextRooted := AddRootIfNeeded(NextValue);
+        NextValue := Iterator.DirectNext(Done);
+        while not Done do
+        begin
+          WasNextRooted := AddRootIfNeeded(NextValue);
+          try
             try
               CallArgs := TGocciaArgumentsCollection.Create([NextValue]);
               try
@@ -226,15 +226,14 @@ begin
               finally
                 CallArgs.Free;
               end;
-            finally
-              RemoveRootIfNeeded(NextValue, WasNextRooted);
+            except
+              CloseIteratorPreservingError(Iterator);
+              raise;
             end;
-            NextValue := Iterator.DirectNext(Done);
+          finally
+            RemoveRootIfNeeded(NextValue, WasNextRooted);
           end;
-        except
-          AcquireExceptionObject;
-          CloseIteratorPreservingError(Iterator);
-          raise;
+          NextValue := Iterator.DirectNext(Done);
         end;
       finally
         RemoveRootIfNeeded(Iterator, WasIteratorRooted);

--- a/tests/built-ins/Map/constructor.js
+++ b/tests/built-ins/Map/constructor.js
@@ -88,3 +88,211 @@ test("Map.prototype.constructor is non-enumerable", () => {
   expect(desc.enumerable).toBe(false);
   expect(desc.configurable).toBe(true);
 });
+
+test("Map constructor rejects primitive iterator objects", () => {
+  const iterable = {
+    [Symbol.iterator]() {
+      return 1;
+    },
+  };
+
+  expect(() => new Map(iterable)).toThrow(TypeError);
+});
+
+test("Map constructor closes iterator when an entry is not an object", () => {
+  let closed = false;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: "not an object", done: false };
+        },
+        return() {
+          closed = true;
+          return {};
+        },
+      };
+    },
+  };
+
+  expect(() => new Map(iterable)).toThrow(TypeError);
+  expect(closed).toBe(true);
+});
+
+test("Map constructor closes iterator when entry key getter throws", () => {
+  const sentinel = new Error("key getter");
+  let closed = false;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return {
+            value: {
+              get 0() {
+                throw sentinel;
+              },
+            },
+            done: false,
+          };
+        },
+        return() {
+          closed = true;
+          return {};
+        },
+      };
+    },
+  };
+
+  try {
+    new Map(iterable);
+    throw new Error("expected Map constructor to throw");
+  } catch (error) {
+    expect(error).toBe(sentinel);
+  }
+  expect(closed).toBe(true);
+});
+
+test("Map constructor closes iterator when entry value getter throws", () => {
+  const sentinel = new Error("value getter");
+  let closed = false;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return {
+            value: {
+              0: "key",
+              get 1() {
+                throw sentinel;
+              },
+            },
+            done: false,
+          };
+        },
+        return() {
+          closed = true;
+          return {};
+        },
+      };
+    },
+  };
+
+  try {
+    new Map(iterable);
+    throw new Error("expected Map constructor to throw");
+  } catch (error) {
+    expect(error).toBe(sentinel);
+  }
+  expect(closed).toBe(true);
+});
+
+test("Map constructor closes iterator when subclass set throws and preserves original error", () => {
+  const sentinel = new Error("set failed");
+  let closed = false;
+  class ThrowingMap extends Map {
+    set() {
+      throw sentinel;
+    }
+  }
+
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: ["key", "value"], done: false };
+        },
+        return() {
+          closed = true;
+          throw new Error("return failed");
+        },
+      };
+    },
+  };
+
+  try {
+    new ThrowingMap(iterable);
+    throw new Error("expected Map constructor to throw");
+  } catch (error) {
+    expect(error).toBe(sentinel);
+  }
+  expect(closed).toBe(true);
+});
+
+test("Map constructor calls iterator next without arguments", () => {
+  let argumentCount = -1;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next(...args) {
+          argumentCount = args.length;
+          return { done: true };
+        },
+      };
+    },
+  };
+
+  new Map(iterable);
+  expect(argumentCount).toBe(0);
+});
+
+test("Map constructor does not close iterator when next throws", () => {
+  const sentinel = new Error("next failed");
+  let closed = false;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          throw sentinel;
+        },
+        return() {
+          closed = true;
+          return {};
+        },
+      };
+    },
+  };
+
+  try {
+    new Map(iterable);
+    throw new Error("expected Map constructor to throw");
+  } catch (error) {
+    expect(error).toBe(sentinel);
+  }
+  expect(closed).toBe(false);
+});
+
+test("Map constructor preserves primitive receiver for iterable lookup", () => {
+  let receiverType = "";
+  Object.defineProperty(Number.prototype, Symbol.iterator, {
+    configurable: true,
+    value() {
+      "use strict";
+      receiverType = typeof this;
+      return {
+        next() {
+          return { done: true };
+        },
+      };
+    },
+  });
+
+  try {
+    new Map(0);
+  } finally {
+    delete Number.prototype[Symbol.iterator];
+  }
+
+  expect(receiverType).toBe("number");
+});
+
+test("Map constructor observes native iterator @@iterator overrides", () => {
+  const iterator = [][Symbol.iterator]();
+  Object.defineProperty(iterator, Symbol.iterator, {
+    configurable: true,
+    value() {
+      return 1;
+    },
+  });
+
+  expect(() => new Map(iterator)).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/constructor.js
+++ b/tests/built-ins/Set/constructor.js
@@ -89,3 +89,73 @@ test("Set.prototype.constructor is non-enumerable", () => {
   expect(desc.enumerable).toBe(false);
   expect(desc.configurable).toBe(true);
 });
+
+test("Set constructor closes iterator when subclass add throws and preserves original error", () => {
+  const sentinel = new Error("add failed");
+  let closed = false;
+  class ThrowingSet extends Set {
+    add() {
+      throw sentinel;
+    }
+  }
+
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return { value: "value", done: false };
+        },
+        return() {
+          closed = true;
+          throw new Error("return failed");
+        },
+      };
+    },
+  };
+
+  try {
+    new ThrowingSet(iterable);
+    throw new Error("expected Set constructor to throw");
+  } catch (error) {
+    expect(error).toBe(sentinel);
+  }
+  expect(closed).toBe(true);
+});
+
+test("Set constructor does not close iterator when next throws", () => {
+  const sentinel = new Error("next failed");
+  let closed = false;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          throw sentinel;
+        },
+        return() {
+          closed = true;
+          return {};
+        },
+      };
+    },
+  };
+
+  try {
+    new Set(iterable);
+    throw new Error("expected Set constructor to throw");
+  } catch (error) {
+    expect(error).toBe(sentinel);
+  }
+  expect(closed).toBe(false);
+});
+
+test("Set constructor observes native iterator @@iterator overrides", () => {
+  const iterator = [][Symbol.iterator]();
+  Object.defineProperty(iterator, Symbol.iterator, {
+    configurable: true,
+    value() {
+      return 1;
+    },
+  });
+
+  expect(() => new Set(iterator)).toThrow(TypeError);
+});

--- a/tests/built-ins/WeakMap/constructor.js
+++ b/tests/built-ins/WeakMap/constructor.js
@@ -160,6 +160,44 @@ test("WeakMap constructor closes iterator on malformed entries", () => {
   expect(closed).toBe(true);
 });
 
+test("WeakMap constructor does not close iterator when next throws", () => {
+  const sentinel = new Error("next failed");
+  let closed = false;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          throw sentinel;
+        },
+        return() {
+          closed = true;
+          return {};
+        },
+      };
+    },
+  };
+
+  try {
+    new WeakMap(iterable);
+    throw new Error("expected WeakMap constructor to throw");
+  } catch (error) {
+    expect(error).toBe(sentinel);
+  }
+  expect(closed).toBe(false);
+});
+
+test("WeakMap constructor observes native iterator @@iterator overrides", () => {
+  const iterator = [][Symbol.iterator]();
+  Object.defineProperty(iterator, Symbol.iterator, {
+    configurable: true,
+    value() {
+      return 1;
+    },
+  });
+
+  expect(() => new WeakMap(iterator)).toThrow(TypeError);
+});
+
 test("WeakMap.prototype.constructor is WeakMap", () => {
   expect(WeakMap.prototype.constructor).toBe(WeakMap);
   expect(new WeakMap().constructor).toBe(WeakMap);

--- a/tests/built-ins/WeakSet/constructor.js
+++ b/tests/built-ins/WeakSet/constructor.js
@@ -129,6 +129,44 @@ test("WeakSet constructor closes iterator on abrupt completion", () => {
   expect(closed).toBe(true);
 });
 
+test("WeakSet constructor does not close iterator when next throws", () => {
+  const sentinel = new Error("next failed");
+  let closed = false;
+  const iterable = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          throw sentinel;
+        },
+        return() {
+          closed = true;
+          return {};
+        },
+      };
+    },
+  };
+
+  try {
+    new WeakSet(iterable);
+    throw new Error("expected WeakSet constructor to throw");
+  } catch (error) {
+    expect(error).toBe(sentinel);
+  }
+  expect(closed).toBe(false);
+});
+
+test("WeakSet constructor observes native iterator @@iterator overrides", () => {
+  const iterator = [][Symbol.iterator]();
+  Object.defineProperty(iterator, Symbol.iterator, {
+    configurable: true,
+    value() {
+      return 1;
+    },
+  });
+
+  expect(() => new WeakSet(iterator)).toThrow(TypeError);
+});
+
 test("WeakSet.prototype.constructor is WeakSet", () => {
   expect(WeakSet.prototype.constructor).toBe(WeakSet);
   expect(new WeakSet().constructor).toBe(WeakSet);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Align `Map(iterable)` with `AddEntriesFromIterable`: use the current `set` method, validate yielded entries, close iterators on entry/key/value/adder abrupt completions, and preserve the original error when `return()` also throws.
- Align sibling collection constructors where the same iterator boundary mattered: `Set` now uses the current `add` method, and `WeakMap`/`WeakSet` no longer close when `IteratorStepValue` itself fails.
- Reuse shared constructor diagnostics for the Set non-iterable branch and centralize the Set `add` property name through `PROP_ADD`.
- Remove the native-iterator fast path in `GetIteratorFromValue` so collection constructors observe overridden `@@iterator` on iterator objects.
- Add focused constructor regressions for Map, Set, WeakMap, and WeakSet.
- Refs #841; this intentionally does not close the issue because descriptor/alias work remains outside this constructor slice.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional validation:

- `./build.pas --clean testrunner && ./build/GocciaTestRunner tests && ./build/GocciaTestRunner tests --mode=bytecode && ./format.pas --check`
- `./build.pas loaderbare`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories built-ins --filter 'built-ins/Map/iterator-*' --mode bytecode --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories built-ins --filter 'built-ins/Map/iterator-*' --mode interpreted --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories built-ins --filter 'built-ins/Set/set-iterator-*' --mode bytecode --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories built-ins --filter 'built-ins/Set/set-iterator-*' --mode interpreted --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories built-ins --filter 'built-ins/WeakMap/iterator-*' --mode bytecode --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories built-ins --filter 'built-ins/WeakMap/iterator-*' --mode interpreted --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories built-ins --filter 'built-ins/WeakSet/iterator-*' --mode bytecode --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories built-ins --filter 'built-ins/WeakSet/iterator-*' --mode interpreted --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories staging --filter 'staging/sm/Map/constructor-iterator-close.js' --mode bytecode --jobs 4`
- `bun scripts/run_test262_suite.ts --suite-dir /private/tmp/goccia-test262-main --categories staging --filter 'staging/sm/Map/constructor-iterator-close.js' --mode interpreted --jobs 4`
- Review nit follow-up after merging latest `origin/main`: `./format.pas --check`
- Review nit follow-up after merging latest `origin/main`: `./build.pas --clean testrunner`
- Review nit follow-up after merging latest `origin/main`: `./build/GocciaTestRunner tests/built-ins/Set/constructor.js`
- Review nit follow-up after merging latest `origin/main`: `./build/GocciaTestRunner tests/built-ins/Set/constructor.js --mode=bytecode`
- Review nit follow-up after merging latest `origin/main`: `./build/GocciaTestRunner tests/built-ins/Set`
- Review nit follow-up after merging latest `origin/main`: `./build/GocciaTestRunner tests/built-ins/Set --mode=bytecode`
