### PR TITLE
feat(benchmarks): add AWFY cross-engine driver

### DIFF
--- a/.github/workflows/awfy-bump.yml
+++ b/.github/workflows/awfy-bump.yml
@@ -1,0 +1,64 @@
+name: AWFY weekly bump
+
+# Pulls the latest smarr/are-we-fast-yet master SHA, updates the shared
+# perf/awfy/manifest.json pin, and opens a PR. Merge once the benchmark
+# methodology smoke remains acceptable.
+#
+# Cadence: weekly (Mondays 07:00 UTC). Manual trigger available via
+# workflow_dispatch. See docs/benchmarks.md "Updating the AWFY pin".
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - id: latest
+        run: |
+          sha=$(gh api repos/smarr/are-we-fast-yet/commits/master --jq .sha)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "short=${sha:0:8}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update AWFY pin
+        run: bun scripts/awfy-bump-pin.ts ${{ steps.latest.outputs.sha }}
+
+      - id: changed
+        run: |
+          if git diff --quiet -- perf/awfy/manifest.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "AWFY already pinned to ${{ steps.latest.outputs.short }}; no PR to open."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update PR
+        if: steps.changed.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          branch: chore/awfy-bump
+          commit-message: "chore(awfy): bump pin to ${{ steps.latest.outputs.short }}"
+          title: "chore(awfy): bump pin to ${{ steps.latest.outputs.short }}"
+          body: |
+            Automated bump of the AWFY SHA pin to `${{ steps.latest.outputs.sha }}`.
+
+            Review with `node scripts/awfy-driver.js --list` and a selected
+            cross-engine smoke before merging if the corpus shape changed.
+
+            Cron: weekly, Mondays 07:00 UTC. See `.github/workflows/awfy-bump.yml`.
+          labels: |
+            performance
+            automated

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -415,15 +415,14 @@ jobs:
           args=()
           while IFS= read -r benchmark; do
             args+=(--benchmark "$benchmark")
-          done < <(node -e "const m = require('./perf/awfy/manifest.json'); for (const name of m.ciSmoke.benchmarks) console.log(name)")
+          done < <(node -e "const m = require('./perf/awfy/manifest.json'); const spec = (item) => typeof item === 'string' ? item : (item.innerIterations ? item.name + ':' + item.innerIterations : item.name); for (const item of m.ciSmoke.benchmarks) console.log(spec(item))")
           while IFS= read -r probe; do
             args+=(--probe "$probe")
-          done < <(node -e "const m = require('./perf/awfy/manifest.json'); for (const name of m.ciSmoke.probes) console.log(name)")
+          done < <(node -e "const m = require('./perf/awfy/manifest.json'); const spec = (item) => typeof item === 'string' ? item : (item.innerIterations ? item.name + ':' + item.innerIterations : item.name); for (const item of m.ciSmoke.probes) console.log(spec(item))")
 
           node scripts/awfy-driver.js \
             --awfy-dir awfy-suite/benchmarks/JavaScript \
             "${args[@]}" \
-            --inner-iterations 1 \
             --repetitions 1 \
             --timeout-ms 300000 \
             --engines goccia,qjs,node \
@@ -434,15 +433,22 @@ jobs:
           node <<'NODE'
           const fs = require('fs');
           const report = JSON.parse(fs.readFileSync('awfy-smoke.json', 'utf8'));
+          const expectedEngines = ['goccia', 'qjs', 'node'];
           const failures = [];
           for (const target of report.targets || []) {
             if (target.summary?.checksumAgreement?.ok === false) {
               failures.push(`${target.name}: checksum mismatch`);
             }
-            for (const [engine, stats] of Object.entries(target.summary?.engineStats || {})) {
+            for (const engine of expectedEngines) {
+              const stats = target.summary?.engineStats?.[engine];
+              if (!stats) {
+                failures.push(`${target.name}/${engine}: missing engine stats`);
+                continue;
+              }
               const nonOk = (stats.timeout || 0) + (stats.crash || 0) + (stats.oom || 0) +
                 (stats.verificationFailed || 0) + (stats.missingResult || 0);
-              if ((stats.ok || 0) === 0 || nonOk > 0) {
+              if ((stats.ok || 0) === 0 || (stats.rawCount || 0) === 0 ||
+                typeof stats.medianMicros !== 'number' || nonOk > 0) {
                 failures.push(`${target.name}/${engine}: ${JSON.stringify(stats)}`);
               }
             }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -361,6 +361,100 @@ jobs:
           if-no-files-found: ignore
           path: profile-main/
 
+  awfy-smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install QuickJS
+        run: sudo apt-get update && sudo apt-get install quickjs -qq > /dev/null
+
+      - name: Download build
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: build-pr
+          path: build/
+
+      - name: Make binaries executable
+        run: chmod +x build/*
+
+      - name: Read AWFY pin
+        id: awfy-pin
+        run: |
+          sha="$(node -e "const m = require('./perf/awfy/manifest.json'); process.stdout.write(m.awfy.commit)")"
+          if ! [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid AWFY pin in perf/awfy/manifest.json"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout AWFY corpus
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          repository: smarr/are-we-fast-yet
+          ref: ${{ steps.awfy-pin.outputs.sha }}
+          path: awfy-suite
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check AWFY driver helpers
+        run: node scripts/test-awfy-driver.js
+
+      - name: Run AWFY smoke
+        run: |
+          node scripts/awfy-driver.js \
+            --awfy-dir awfy-suite/benchmarks/JavaScript \
+            --benchmark NBody \
+            --probe generic-plus-scalars \
+            --inner-iterations 1 \
+            --repetitions 1 \
+            --timeout-ms 30000 \
+            --engines goccia,qjs,node \
+            --output awfy-smoke.json
+
+      - name: Check AWFY smoke outcomes
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const report = JSON.parse(fs.readFileSync('awfy-smoke.json', 'utf8'));
+          const failures = [];
+          for (const target of report.targets || []) {
+            if (target.summary?.checksumAgreement?.ok === false) {
+              failures.push(`${target.name}: checksum mismatch`);
+            }
+            for (const [engine, stats] of Object.entries(target.summary?.engineStats || {})) {
+              const nonOk = (stats.timeout || 0) + (stats.crash || 0) + (stats.oom || 0) +
+                (stats.verificationFailed || 0) + (stats.missingResult || 0);
+              if ((stats.ok || 0) === 0 || nonOk > 0) {
+                failures.push(`${target.name}/${engine}: ${JSON.stringify(stats)}`);
+              }
+            }
+          }
+          if (failures.length > 0) {
+            console.error(failures.join('\n'));
+            process.exit(1);
+          }
+          NODE
+
+      - name: Upload AWFY smoke
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: awfy-smoke
+          retention-days: 7
+          if-no-files-found: ignore
+          path: awfy-smoke.json
+
   cli:
     needs: build
     runs-on: ubuntu-latest
@@ -604,6 +698,61 @@ jobs:
 
             const marker = '<!-- benchmark-comparison -->';
             const body = marker + '\n' + inner;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  awfy-comment:
+    needs: awfy-smoke
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Download AWFY smoke
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        continue-on-error: true
+        with:
+          name: awfy-smoke
+
+      - name: Build AWFY comment markdown
+        run: node scripts/awfy-comment.js awfy-smoke.json > awfy-comment.md
+
+      - name: Post AWFY comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- awfy-smoke -->';
+            const body = fs.readFileSync('awfy-comment.md', 'utf8');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -388,7 +388,7 @@ jobs:
           tar -C "$RUNNER_TEMP" -xf "$archive"
           make -C "$RUNNER_TEMP/quickjs-$version" install PREFIX="$prefix" CONFIG_M32=
           echo "$prefix/bin" >> "$GITHUB_PATH"
-          "$prefix/bin/qjs" --help | head -1
+          "$prefix/bin/qjs" --eval 'print("QuickJS " + (1 + 2))'
 
       - name: Download build
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -412,13 +412,20 @@ jobs:
 
       - name: Run AWFY smoke
         run: |
+          args=()
+          while IFS= read -r benchmark; do
+            args+=(--benchmark "$benchmark")
+          done < <(node -e "const m = require('./perf/awfy/manifest.json'); for (const name of m.ciSmoke.benchmarks) console.log(name)")
+          while IFS= read -r probe; do
+            args+=(--probe "$probe")
+          done < <(node -e "const m = require('./perf/awfy/manifest.json'); for (const name of m.ciSmoke.probes) console.log(name)")
+
           node scripts/awfy-driver.js \
             --awfy-dir awfy-suite/benchmarks/JavaScript \
-            --benchmark NBody \
-            --probe generic-plus-scalars \
+            "${args[@]}" \
             --inner-iterations 1 \
             --repetitions 1 \
-            --timeout-ms 30000 \
+            --timeout-ms 300000 \
             --engines goccia,qjs,node \
             --output awfy-smoke.json
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -377,7 +377,18 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install QuickJS
-        run: sudo apt-get update && sudo apt-get install quickjs -qq > /dev/null
+        run: |
+          version="2026-06-04"
+          sha256="b376e839b322978313d929fd20663b11ba58b75df5a46c126dd19ea2fa70ad2a"
+          archive="$RUNNER_TEMP/quickjs-$version.tar.xz"
+          prefix="$RUNNER_TEMP/quickjs"
+
+          curl -fsSLo "$archive" "https://bellard.org/quickjs/quickjs-$version.tar.xz"
+          echo "$sha256  $archive" | shasum -a 256 --check
+          tar -C "$RUNNER_TEMP" -xf "$archive"
+          make -C "$RUNNER_TEMP/quickjs-$version" install PREFIX="$prefix" CONFIG_M32=
+          echo "$prefix/bin" >> "$GITHUB_PATH"
+          "$prefix/bin/qjs" --help | head -1
 
       - name: Download build
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7

--- a/docs/adr/0086-awfy-cross-engine-benchmark-methodology.md
+++ b/docs/adr/0086-awfy-cross-engine-benchmark-methodology.md
@@ -1,4 +1,4 @@
-# AWFY cross-engine handover methodology
+# AWFY cross-engine benchmark methodology
 
 **Date:** 2026-07-05
 **Area:** `benchmarking`, `tooling`
@@ -23,7 +23,7 @@ surface and report first-class failures for the rest. Per-benchmark bundles make
 each timeout, crash, OOM, parse failure, or checksum failure an explicit result
 instead of a reason the whole corpus disappears.
 
-Cross-engine timing claims from this lane must follow the handover protocol:
+Cross-engine timing claims from this lane must follow the benchmark protocol:
 production Goccia bytecode binaries, raw samples retained in JSON, medians plus
 IQR/min/max/CV, checksum/verification agreement across engines, and environment
 metadata for Goccia commit, FPC version, platform, architecture, reference-engine
@@ -36,18 +36,16 @@ may be rerun with `--profile=opcodes`, `--profile=functions`, or `--profile=all`
 for explanation.
 
 Pull-request CI runs a bounded smoke target set from `perf/awfy/manifest.json`:
-thirteen pinned AWFY benchmarks and one diagnostic probe under GocciaScript,
-QuickJS, and Node, surfaced as an `AWFY Smoke` PR comment. Full-corpus AWFY
-timing stays out of the PR gate until the remaining benchmarks are stable enough
-for that budget.
+all pinned AWFY benchmarks and one diagnostic probe under GocciaScript, QuickJS,
+and Node, surfaced as an `AWFY Smoke` PR comment.
 
 AWFY and web-tooling are roadmap-level proof, not the only gate for optimization
 work. The repo also keeps a small Goccia-owned diagnostic probe corpus under
-`perf/probes/` for the handover workstreams: dispatch preamble and loop floor (W1/W2), scalar `+` and
-`OP_TO_PRIMITIVE` pressure (W3), strict-types typed emission probes where syntax
-is Goccia-only (W4), call-path probes (W5), string/RegExp cliffs (W6), and the
-later typed-array boxing / inline-cache levers (#860/#861). Those probes use the
-same normalized driver/report schema but are not upstream AWFY benchmarks.
+`perf/probes/` for targeted engine surfaces: dispatch preamble and loop floor,
+scalar `+` and `OP_TO_PRIMITIVE` pressure, strict-types typed emission probes
+where syntax is Goccia-only, call-path probes, string/RegExp cliffs, and the
+later typed-array boxing / inline-cache levers (#860/#861). Those probes use
+the same normalized driver/report schema but are not upstream AWFY benchmarks.
 
 Consequences:
 

--- a/docs/adr/0086-awfy-cross-engine-handover-methodology.md
+++ b/docs/adr/0086-awfy-cross-engine-handover-methodology.md
@@ -35,6 +35,11 @@ remain separate from timing runs; selected AWFY outliers and diagnostic probes
 may be rerun with `--profile=opcodes`, `--profile=functions`, or `--profile=all`
 for explanation.
 
+Pull-request CI runs only a cheap smoke: one pinned AWFY benchmark and one
+diagnostic probe under GocciaScript, QuickJS, and Node, surfaced as an `AWFY
+Smoke` PR comment. Full-corpus AWFY timing stays out of the PR gate until the
+cost and stability are known.
+
 AWFY and web-tooling are roadmap-level proof, not the only gate for optimization
 work. The repo also keeps a small Goccia-owned diagnostic probe corpus under
 `perf/probes/` for the handover workstreams: dispatch preamble and loop floor (W1/W2), scalar `+` and

--- a/docs/adr/0086-awfy-cross-engine-handover-methodology.md
+++ b/docs/adr/0086-awfy-cross-engine-handover-methodology.md
@@ -1,0 +1,60 @@
+# AWFY cross-engine handover methodology
+
+**Date:** 2026-07-05
+**Area:** `benchmarking`, `tooling`
+**Issue:** [#856](https://github.com/frostney/GocciaScript/issues/856)
+**Related:** [#821](https://github.com/frostney/GocciaScript/issues/821), [#862](https://github.com/frostney/GocciaScript/issues/862), [ADR 0076](0076-same-runner-benchmark-comparison.md), [ADR 0081](0081-reject-value-caches-for-allocation-reduction.md)
+
+GocciaScript will use a repo-local AWFY adapter and cross-engine driver instead
+of pointing GocciaScript or QuickJS at upstream AWFY's Node-shaped JavaScript
+harness directly. Upstream AWFY remains the source of benchmark semantics and is
+recorded by repository SHA in `perf/awfy/manifest.json`, with weekly/manual
+pin-refresh PRs handled by `.github/workflows/awfy-bump.yml`. Each selected
+benchmark is bundled into a per-benchmark shell-portable entrypoint with a tiny
+`require` adapter and a `Date.now`-based timer. This keeps the benchmark source
+comparable across Node, QuickJS, and GocciaScript while avoiding Node-only
+globals such as `require`, `process.argv`, `process.hrtime`, and
+`process.stdout`.
+
+The adapter deliberately builds one benchmark entrypoint at a time. A monolithic
+bundle lets one parser or syntax issue in an unrelated benchmark block every
+other result, which is not useful when #856's job is to quantify the runnable
+surface and report first-class failures for the rest. Per-benchmark bundles make
+each timeout, crash, OOM, parse failure, or checksum failure an explicit result
+instead of a reason the whole corpus disappears.
+
+Cross-engine timing claims from this lane must follow the handover protocol:
+production Goccia bytecode binaries, raw samples retained in JSON, medians plus
+IQR/min/max/CV, checksum/verification agreement across engines, and environment
+metadata for Goccia commit, FPC version, platform, architecture, reference-engine
+versions, AWFY corpus SHA, and driver version. When comparing two Goccia
+binaries, the driver interleaves baseline and candidate samples per benchmark
+and repetition. Sequential baseline-then-candidate batches are not accepted for
+runtime claims, matching ADR 0081's drift guardrail. Profiler-backed Goccia runs
+remain separate from timing runs; selected AWFY outliers and diagnostic probes
+may be rerun with `--profile=opcodes`, `--profile=functions`, or `--profile=all`
+for explanation.
+
+AWFY and web-tooling are roadmap-level proof, not the only gate for optimization
+work. The repo also keeps a small Goccia-owned diagnostic probe corpus under
+`perf/probes/` for the handover workstreams: dispatch preamble and loop floor (W1/W2), scalar `+` and
+`OP_TO_PRIMITIVE` pressure (W3), strict-types typed emission probes where syntax
+is Goccia-only (W4), call-path probes (W5), string/RegExp cliffs (W6), and the
+later typed-array boxing / inline-cache levers (#860/#861). Those probes use the
+same normalized driver/report schema but are not upstream AWFY benchmarks.
+
+Consequences:
+
+- Issue #856 is complete only when AWFY JavaScript benchmarks run under
+  GocciaScript bytecode, QuickJS, and Node from the same driver with raw samples,
+  verification results, first-class failure outcomes, and reproducible metadata.
+- Issue #862 should use diagnostic probes as implementation gates and AWFY /
+  web-tooling as transfer proof for the worst measured hotspots.
+- Existing `GocciaBenchmarkRunner` remains the in-repo benchmark runner and CI PR
+  comparison surface. The AWFY driver is an external-shell comparison lane for
+  reference engines that do not provide Goccia's injected `suite`/`bench` API,
+  and its raw probes stay outside `benchmarks/` so CI does not mistake them for
+  runner-managed `suite()` files.
+- Strict-types probes are Goccia-only because type annotations are not portable
+  JavaScript syntax for Node or QuickJS; they are paired with untyped probes for
+  cross-engine context.

--- a/docs/adr/0086-awfy-cross-engine-handover-methodology.md
+++ b/docs/adr/0086-awfy-cross-engine-handover-methodology.md
@@ -35,10 +35,11 @@ remain separate from timing runs; selected AWFY outliers and diagnostic probes
 may be rerun with `--profile=opcodes`, `--profile=functions`, or `--profile=all`
 for explanation.
 
-Pull-request CI runs only a cheap smoke: one pinned AWFY benchmark and one
-diagnostic probe under GocciaScript, QuickJS, and Node, surfaced as an `AWFY
-Smoke` PR comment. Full-corpus AWFY timing stays out of the PR gate until the
-cost and stability are known.
+Pull-request CI runs a bounded smoke target set from `perf/awfy/manifest.json`:
+thirteen pinned AWFY benchmarks and one diagnostic probe under GocciaScript,
+QuickJS, and Node, surfaced as an `AWFY Smoke` PR comment. Full-corpus AWFY
+timing stays out of the PR gate until the remaining benchmarks are stable enough
+for that budget.
 
 AWFY and web-tooling are roadmap-level proof, not the only gate for optimization
 work. The repo also keeps a small Goccia-owned diagnostic probe corpus under

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,4 +95,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0083 — Migrate explicit per-thread cache clears into the thread-cleanup registry](0083-migrate-cache-clears-into-cleanup-registry.md)
 - [0084 — Realm-owned prototype method hosts and object-reference threadvar audit](0084-realm-owned-prototype-method-hosts.md)
 - [0085 — Defer broad Annex B support before 1.0](0085-defer-annex-b-before-1-0.md)
-- [0086 — AWFY cross-engine handover methodology](0086-awfy-cross-engine-handover-methodology.md)
+- [0086 — AWFY cross-engine benchmark methodology](0086-awfy-cross-engine-benchmark-methodology.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,3 +95,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0083 — Migrate explicit per-thread cache clears into the thread-cleanup registry](0083-migrate-cache-clears-into-cleanup-registry.md)
 - [0084 — Realm-owned prototype method hosts and object-reference threadvar audit](0084-realm-owned-prototype-method-hosts.md)
 - [0085 — Defer broad Annex B support before 1.0](0085-defer-annex-b-before-1-0.md)
+- [0086 — AWFY cross-engine handover methodology](0086-awfy-cross-engine-handover-methodology.md)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -362,6 +362,12 @@ The normalized report records:
 - Goccia commit, FPC version, platform, architecture, reference-engine versions,
   AWFY corpus SHA, and driver version
 
+Pull requests run a cheap AWFY smoke lane from `.github/workflows/pr.yml`: one
+pinned AWFY benchmark (`NBody`) and one diagnostic probe (`generic-plus-scalars`)
+under Goccia bytecode, QuickJS, and Node. The workflow uploads the normalized
+JSON report and posts an `AWFY Smoke` PR comment. This is a driver/corpus-shape
+guardrail only; it is not a full-corpus timing gate.
+
 When comparing two Goccia binaries, pass `--goccia-baseline` and
 `--goccia-candidate`; the driver interleaves baseline and candidate samples per
 target and repetition. Runtime claims for #862 should use this interleaved

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -362,11 +362,12 @@ The normalized report records:
 - Goccia commit, FPC version, platform, architecture, reference-engine versions,
   AWFY corpus SHA, and driver version
 
-Pull requests run a cheap AWFY smoke lane from `.github/workflows/pr.yml`: one
-pinned AWFY benchmark (`NBody`) and one diagnostic probe (`generic-plus-scalars`)
-under Goccia bytecode, QuickJS, and Node. The workflow uploads the normalized
-JSON report and posts an `AWFY Smoke` PR comment. This is a driver/corpus-shape
-guardrail only; it is not a full-corpus timing gate.
+Pull requests run a bounded AWFY smoke lane from `.github/workflows/pr.yml`.
+The target set is recorded in `perf/awfy/manifest.json` under `ciSmoke`: thirteen
+pinned AWFY benchmarks plus `generic-plus-scalars`, under Goccia bytecode,
+QuickJS, and Node. The workflow uploads the normalized JSON report and posts an
+`AWFY Smoke` PR comment. This is a driver/corpus-shape guardrail only; it is not
+a full-corpus timing gate.
 
 When comparing two Goccia binaries, pass `--goccia-baseline` and
 `--goccia-candidate`; the driver interleaves baseline and candidate samples per

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,6 +9,7 @@
 - **Profiler-backed runs** — Bytecode benchmark runs can emit opcode/function profiles with `--profile`, including deterministic single-run capture
 - **CI integration** — PR workflow posts benchmark comparison comments with range-overlap classification; main CI retains deterministic profile reports
 - **Environment tuning** — Calibration time, warmup iterations, and measurement rounds configurable via environment variables
+- **Cross-engine AWFY lane** — `scripts/awfy-driver.js` runs pinned AWFY and `perf/probes/` diagnostics under GocciaScript, QuickJS, and Node without mixing them into the `suite`/`bench` corpus
 
 GocciaScript includes a benchmark runner for measuring execution performance. Benchmarks live in the `benchmarks/` directory and use a `suite`/`bench` API.
 
@@ -296,3 +297,92 @@ The PR workflow (`.github/workflows/pr.yml`) builds the PR's base commit (`main`
 - The **overall PR summary** shows per-mode totals on separate lines with average percentage deltas
 - The comparison is **advisory** (comment-only, never merge-blocking)
 - 🟢 marks non-overlapping improvements, 🔴 marks non-overlapping regressions, `~ overlap` marks overlapping ranges, and 🆕 marks new benchmarks absent from the `main` build
+
+## AWFY Cross-Engine Lane
+
+The `benchmarks/` directory is reserved for `GocciaBenchmarkRunner` inputs that
+register `suite()` / `bench()` cases. Cross-engine AWFY and handover diagnostic
+probes live under `perf/` because they are plain shell-portable scripts driven by
+Node tooling, not benchmark-runner files. This keeps CI's recursive benchmark
+scan from treating diagnostic probes as missing `suite()` files.
+
+Use `scripts/awfy-driver.js` for #856/#862 investigation:
+
+```bash
+# List pinned AWFY benchmark names and Goccia-owned probes
+node scripts/awfy-driver.js --list
+
+# Smoke one AWFY benchmark from a local upstream checkout
+node scripts/awfy-driver.js \
+  --awfy-dir /path/to/are-we-fast-yet/benchmarks/JavaScript \
+  --benchmark NBody \
+  --inner-iterations 1 \
+  --repetitions 1 \
+  --engines goccia,qjs,node \
+  --output tmp/awfy-smoke.json
+
+# Smoke one diagnostic probe through the same normalized report schema
+node scripts/awfy-driver.js \
+  --probe generic-plus-scalars \
+  --inner-iterations 1000 \
+  --repetitions 1 \
+  --engines goccia,qjs,node \
+  --output tmp/probe-smoke.json
+```
+
+`perf/awfy/manifest.json` records the upstream AWFY repository, pinned commit,
+JavaScript corpus path, driver version, and diagnostic probe catalog. The driver
+generates per-benchmark portable AWFY bundles from the selected benchmark's
+CommonJS dependency graph instead of using upstream `harness.js` directly. That
+avoids Node-only globals (`require`, `process.argv`, `process.hrtime`,
+`process.stdout`) and prevents one unrelated benchmark parse failure from
+blocking every other benchmark.
+
+### Updating the AWFY Pin
+
+The AWFY corpus SHA is pinned in `perf/awfy/manifest.json`. A weekly workflow
+(`.github/workflows/awfy-bump.yml`) fetches the latest
+`smarr/are-we-fast-yet` `master` SHA, runs `bun scripts/awfy-bump-pin.ts`, and
+opens an automated PR when the manifest changes. The workflow no-ops when the
+pin is already current, matching the test262 and TOML suite bump pattern.
+
+Manual bump:
+
+```bash
+bun scripts/awfy-bump-pin.ts <40-hex-sha>
+```
+
+The normalized report records:
+
+- raw samples for every engine/target/repetition
+- medians, IQR-filtered medians, min/max, coefficient of variation, and
+  geomean pairwise ratios
+- checksum/verification results and cross-engine checksum agreement
+- timeout, crash, OOM, missing-result, and verification-failed outcomes
+- Goccia commit, FPC version, platform, architecture, reference-engine versions,
+  AWFY corpus SHA, and driver version
+
+When comparing two Goccia binaries, pass `--goccia-baseline` and
+`--goccia-candidate`; the driver interleaves baseline and candidate samples per
+target and repetition. Runtime claims for #862 should use this interleaved
+shape, not sequential baseline-then-candidate batches.
+
+Profiler-backed runs stay separate from timing. For selected Goccia outliers or
+diagnostic probes, add `--profile=opcodes|functions|all --profile-dir=<dir>` and
+run a dedicated diagnostic pass; do not mix profiled timings into ratio claims.
+
+### Issue Acceptance Criteria
+
+Issue #856 is complete when AWFY JavaScript benchmarks run under GocciaScript
+bytecode, QuickJS, and Node from the same driver; reports retain raw samples and
+derived statistics; verification/checksum results agree or fail explicitly;
+timeout, crash, and OOM are first-class outcomes; metadata is sufficient to
+reproduce the run; and at least one Goccia AWFY outlier can be rerun with
+opcode/function profiles attached.
+
+Issue #862 should use `perf/probes/` as implementation gates for dispatch,
+primitive lowering, call path, string/RegExp cliffs, typed-array call/return
+boxing, and inline-cache shape behavior. AWFY and web-tooling remain
+roadmap-level transfer proof. Allocation reductions are supporting evidence
+only; they do not prove a runtime win without interleaved timing movement and
+profile evidence for the mechanism.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -301,7 +301,7 @@ The PR workflow (`.github/workflows/pr.yml`) builds the PR's base commit (`main`
 ## AWFY Cross-Engine Lane
 
 The `benchmarks/` directory is reserved for `GocciaBenchmarkRunner` inputs that
-register `suite()` / `bench()` cases. Cross-engine AWFY and handover diagnostic
+register `suite()` / `bench()` cases. Cross-engine AWFY and diagnostic
 probes live under `perf/` because they are plain shell-portable scripts driven by
 Node tooling, not benchmark-runner files. This keeps CI's recursive benchmark
 scan from treating diagnostic probes as missing `suite()` files.
@@ -363,11 +363,10 @@ The normalized report records:
   AWFY corpus SHA, and driver version
 
 Pull requests run a bounded AWFY smoke lane from `.github/workflows/pr.yml`.
-The target set is recorded in `perf/awfy/manifest.json` under `ciSmoke`: thirteen
+The target set is recorded in `perf/awfy/manifest.json` under `ciSmoke`: all
 pinned AWFY benchmarks plus `generic-plus-scalars`, under Goccia bytecode,
 QuickJS, and Node. The workflow uploads the normalized JSON report and posts an
-`AWFY Smoke` PR comment. This is a driver/corpus-shape guardrail only; it is not
-a full-corpus timing gate.
+`AWFY Smoke` PR comment.
 
 When comparing two Goccia binaries, pass `--goccia-baseline` and
 `--goccia-candidate`; the driver interleaves baseline and candidate samples per

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,22 @@
+# Performance Handover Tooling
+
+## Executive Summary
+
+- `perf/awfy/manifest.json` pins the upstream AWFY JavaScript corpus version and
+  lists the Goccia-owned diagnostic probes.
+- `perf/probes/` contains plain portable probe scripts, not
+  `GocciaBenchmarkRunner` `suite()` / `bench()` files.
+- `scripts/awfy-driver.js` owns timing, interleaving, reference-engine commands,
+  checksum comparison, first-class failure outcomes, and normalized JSON output.
+- `scripts/awfy-bump-pin.ts` and `.github/workflows/awfy-bump.yml` keep the
+  AWFY corpus SHA refreshable through the same automated bump-PR pattern used
+  by the other pinned upstream suites.
+- Timing runs and Goccia profiler-backed diagnostic runs are separate by design.
+
+Use this directory for cross-engine performance handover work that needs Node,
+QuickJS, and GocciaScript to run the same script entrypoints. Use `benchmarks/`
+for the in-repo benchmark runner corpus.
+
+See [Benchmarks](../docs/benchmarks.md#awfy-cross-engine-lane) and
+[ADR 0086](../docs/adr/0086-awfy-cross-engine-handover-methodology.md) for the
+methodology and acceptance criteria.

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,4 +1,4 @@
-# Performance Handover Tooling
+# Cross-Engine Performance Tooling
 
 ## Executive Summary
 
@@ -13,10 +13,10 @@
   by the other pinned upstream suites.
 - Timing runs and Goccia profiler-backed diagnostic runs are separate by design.
 
-Use this directory for cross-engine performance handover work that needs Node,
-QuickJS, and GocciaScript to run the same script entrypoints. Use `benchmarks/`
-for the in-repo benchmark runner corpus.
+Use this directory for cross-engine performance work that needs Node, QuickJS,
+and GocciaScript to run the same script entrypoints. Use `benchmarks/` for the
+in-repo benchmark runner corpus.
 
 See [Benchmarks](../docs/benchmarks.md#awfy-cross-engine-lane) and
-[ADR 0086](../docs/adr/0086-awfy-cross-engine-handover-methodology.md) for the
+[ADR 0086](../docs/adr/0086-awfy-cross-engine-benchmark-methodology.md) for the
 methodology and acceptance criteria.

--- a/perf/awfy/manifest.json
+++ b/perf/awfy/manifest.json
@@ -29,6 +29,7 @@
   "ciSmoke": {
     "benchmarks": [
       "Bounce",
+      { "name": "CD", "innerIterations": 2 },
       "DeltaBlue",
       "Havlak",
       "Json",
@@ -42,128 +43,125 @@
       "Storage",
       "Towers"
     ],
-    "probes": ["generic-plus-scalars"],
-    "excludedBenchmarks": {
-      "CD": "Current portable bundle crashes before a normalized result under GocciaScript, QuickJS, and Node."
-    }
+    "probes": [{ "name": "generic-plus-scalars", "innerIterations": 1 }]
   },
   "diagnosticProbes": [
     {
       "name": "propaccess-monomorphic",
       "file": "perf/probes/propaccess-monomorphic.js",
-      "workstreams": ["W3", "W6"],
+      "focusAreas": ["property-access", "primitive-coercion", "scalar-plus"],
       "defaultInnerIterations": 40000,
       "tags": ["property-access", "op-to-primitive", "scalar-plus"]
     },
     {
       "name": "generic-plus-scalars",
       "file": "perf/probes/generic-plus-scalars.js",
-      "workstreams": ["W3"],
+      "focusAreas": ["scalar-plus"],
       "defaultInnerIterations": 200000,
       "tags": ["arithmetic", "scalar-plus"]
     },
     {
       "name": "loop-dispatch-floor",
       "file": "perf/probes/loop-dispatch-floor.js",
-      "workstreams": ["W1", "W2"],
+      "focusAreas": ["dispatch", "loop"],
       "defaultInnerIterations": 400000,
       "tags": ["dispatch", "loop"]
     },
     {
       "name": "nbody-minimal",
       "file": "perf/probes/nbody-minimal.js",
-      "workstreams": ["W2", "W3"],
+      "focusAreas": ["arithmetic", "loop"],
       "defaultInnerIterations": 2000,
       "tags": ["arithmetic", "loops"]
     },
     {
       "name": "fib-recursive",
       "file": "perf/probes/fib-recursive.js",
-      "workstreams": ["W5"],
+      "focusAreas": ["call-path", "recursion"],
       "defaultInnerIterations": 25,
       "tags": ["call", "recursion"]
     },
     {
       "name": "fixed-arg-call",
       "file": "perf/probes/fixed-arg-call.js",
-      "workstreams": ["W5"],
+      "focusAreas": ["call-path", "fixed-args"],
       "defaultInnerIterations": 100000,
       "tags": ["call", "fixed-args"]
     },
     {
       "name": "method-call-fixed-arg",
       "file": "perf/probes/method-call-fixed-arg.js",
-      "workstreams": ["W5", "W6"],
+      "focusAreas": ["call-path", "method-dispatch"],
       "defaultInnerIterations": 100000,
       "tags": ["call", "method"]
     },
     {
       "name": "sort-comparator",
       "file": "perf/probes/sort-comparator.js",
-      "workstreams": ["W5"],
+      "focusAreas": ["call-path", "array-sort"],
       "defaultInnerIterations": 2000,
       "tags": ["call", "array-sort"]
     },
     {
       "name": "bound-spread-apply",
       "file": "perf/probes/bound-spread-apply.js",
-      "workstreams": ["W5"],
+      "focusAreas": ["call-path", "bound", "spread", "apply"],
       "defaultInnerIterations": 50000,
       "tags": ["call", "bound", "spread", "apply"]
     },
     {
       "name": "string-append-30k",
       "file": "perf/probes/string-append-30k.js",
-      "workstreams": ["W6"],
+      "focusAreas": ["string", "append"],
       "defaultInnerIterations": 30000,
       "tags": ["string", "append"]
     },
     {
       "name": "string-builder-shaped",
       "file": "perf/probes/string-builder-shaped.js",
-      "workstreams": ["W6"],
+      "focusAreas": ["string", "join"],
       "defaultInnerIterations": 30000,
       "tags": ["string", "join"]
     },
     {
       "name": "regexp-corpus-build",
       "file": "perf/probes/regexp-corpus-build.js",
-      "workstreams": ["W6"],
+      "focusAreas": ["regexp", "string-corpus-build"],
       "defaultInnerIterations": 20000,
       "tags": ["regexp", "string-corpus-build"]
     },
     {
       "name": "regexp-exec-replace",
       "file": "perf/probes/regexp-exec-replace.js",
-      "workstreams": ["W6"],
+      "focusAreas": ["regexp", "string-corpus"],
       "defaultInnerIterations": 20000,
       "tags": ["regexp", "string-corpus"]
     },
     {
       "name": "typed-array-call-return",
       "file": "perf/probes/typed-array-call-return.js",
-      "workstreams": ["W5", "W6", "#860"],
+      "focusAreas": ["typed-array", "boxing", "call-return"],
       "defaultInnerIterations": 20000,
       "tags": ["typed-array", "boxing", "call-return"]
     },
     {
       "name": "prop-polymorphic",
       "file": "perf/probes/prop-polymorphic.js",
-      "workstreams": ["#861"],
+      "focusAreas": ["inline-cache", "polymorphic"],
       "defaultInnerIterations": 50000,
       "tags": ["inline-cache", "polymorphic"]
     },
     {
       "name": "prop-megamorphic",
       "file": "perf/probes/prop-megamorphic.js",
-      "workstreams": ["#861"],
+      "focusAreas": ["inline-cache", "megamorphic"],
       "defaultInnerIterations": 50000,
       "tags": ["inline-cache", "megamorphic"]
     },
     {
       "name": "strict-typed-arith",
       "file": "perf/probes/strict-typed-arith.js",
-      "workstreams": ["W4"],
+      "focusAreas": ["strict-types", "arithmetic"],
       "defaultInnerIterations": 100000,
       "engines": ["goccia", "goccia-baseline", "goccia-candidate"],
       "gocciaFlags": ["--strict-types"],
@@ -172,7 +170,7 @@
     {
       "name": "strict-typed-call",
       "file": "perf/probes/strict-typed-call.js",
-      "workstreams": ["W4", "W5"],
+      "focusAreas": ["strict-types", "call-path"],
       "defaultInnerIterations": 100000,
       "engines": ["goccia", "goccia-baseline", "goccia-candidate"],
       "gocciaFlags": ["--strict-types"],

--- a/perf/awfy/manifest.json
+++ b/perf/awfy/manifest.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": 1,
+  "awfy": {
+    "repository": "https://github.com/smarr/are-we-fast-yet",
+    "ref": "master",
+    "commit": "74306fec151070fd07157cefeacf19e7e0bcdc89",
+    "javascriptPath": "benchmarks/JavaScript",
+    "benchmarks": {
+      "Bounce": "bounce",
+      "CD": "cd",
+      "DeltaBlue": "deltablue",
+      "Havlak": "havlak",
+      "Json": "json",
+      "List": "list",
+      "Mandelbrot": "mandelbrot",
+      "NBody": "nbody",
+      "Permute": "permute",
+      "Queens": "queens",
+      "Richards": "richards",
+      "Sieve": "sieve",
+      "Storage": "storage",
+      "Towers": "towers"
+    }
+  },
+  "driver": {
+    "script": "scripts/awfy-driver.js",
+    "version": 1
+  },
+  "diagnosticProbes": [
+    {
+      "name": "propaccess-monomorphic",
+      "file": "perf/probes/propaccess-monomorphic.js",
+      "workstreams": ["W3", "W6"],
+      "defaultInnerIterations": 40000,
+      "tags": ["property-access", "op-to-primitive", "scalar-plus"]
+    },
+    {
+      "name": "generic-plus-scalars",
+      "file": "perf/probes/generic-plus-scalars.js",
+      "workstreams": ["W3"],
+      "defaultInnerIterations": 200000,
+      "tags": ["arithmetic", "scalar-plus"]
+    },
+    {
+      "name": "loop-dispatch-floor",
+      "file": "perf/probes/loop-dispatch-floor.js",
+      "workstreams": ["W1", "W2"],
+      "defaultInnerIterations": 400000,
+      "tags": ["dispatch", "loop"]
+    },
+    {
+      "name": "nbody-minimal",
+      "file": "perf/probes/nbody-minimal.js",
+      "workstreams": ["W2", "W3"],
+      "defaultInnerIterations": 2000,
+      "tags": ["arithmetic", "loops"]
+    },
+    {
+      "name": "fib-recursive",
+      "file": "perf/probes/fib-recursive.js",
+      "workstreams": ["W5"],
+      "defaultInnerIterations": 25,
+      "tags": ["call", "recursion"]
+    },
+    {
+      "name": "fixed-arg-call",
+      "file": "perf/probes/fixed-arg-call.js",
+      "workstreams": ["W5"],
+      "defaultInnerIterations": 100000,
+      "tags": ["call", "fixed-args"]
+    },
+    {
+      "name": "method-call-fixed-arg",
+      "file": "perf/probes/method-call-fixed-arg.js",
+      "workstreams": ["W5", "W6"],
+      "defaultInnerIterations": 100000,
+      "tags": ["call", "method"]
+    },
+    {
+      "name": "sort-comparator",
+      "file": "perf/probes/sort-comparator.js",
+      "workstreams": ["W5"],
+      "defaultInnerIterations": 2000,
+      "tags": ["call", "array-sort"]
+    },
+    {
+      "name": "bound-spread-apply",
+      "file": "perf/probes/bound-spread-apply.js",
+      "workstreams": ["W5"],
+      "defaultInnerIterations": 50000,
+      "tags": ["call", "bound", "spread", "apply"]
+    },
+    {
+      "name": "string-append-30k",
+      "file": "perf/probes/string-append-30k.js",
+      "workstreams": ["W6"],
+      "defaultInnerIterations": 30000,
+      "tags": ["string", "append"]
+    },
+    {
+      "name": "string-builder-shaped",
+      "file": "perf/probes/string-builder-shaped.js",
+      "workstreams": ["W6"],
+      "defaultInnerIterations": 30000,
+      "tags": ["string", "join"]
+    },
+    {
+      "name": "regexp-corpus-build",
+      "file": "perf/probes/regexp-corpus-build.js",
+      "workstreams": ["W6"],
+      "defaultInnerIterations": 20000,
+      "tags": ["regexp", "string-corpus-build"]
+    },
+    {
+      "name": "regexp-exec-replace",
+      "file": "perf/probes/regexp-exec-replace.js",
+      "workstreams": ["W6"],
+      "defaultInnerIterations": 20000,
+      "tags": ["regexp", "string-corpus"]
+    },
+    {
+      "name": "typed-array-call-return",
+      "file": "perf/probes/typed-array-call-return.js",
+      "workstreams": ["W5", "W6", "#860"],
+      "defaultInnerIterations": 20000,
+      "tags": ["typed-array", "boxing", "call-return"]
+    },
+    {
+      "name": "prop-polymorphic",
+      "file": "perf/probes/prop-polymorphic.js",
+      "workstreams": ["#861"],
+      "defaultInnerIterations": 50000,
+      "tags": ["inline-cache", "polymorphic"]
+    },
+    {
+      "name": "prop-megamorphic",
+      "file": "perf/probes/prop-megamorphic.js",
+      "workstreams": ["#861"],
+      "defaultInnerIterations": 50000,
+      "tags": ["inline-cache", "megamorphic"]
+    },
+    {
+      "name": "strict-typed-arith",
+      "file": "perf/probes/strict-typed-arith.js",
+      "workstreams": ["W4"],
+      "defaultInnerIterations": 100000,
+      "engines": ["goccia", "goccia-baseline", "goccia-candidate"],
+      "gocciaFlags": ["--strict-types"],
+      "tags": ["strict-types", "arithmetic"]
+    },
+    {
+      "name": "strict-typed-call",
+      "file": "perf/probes/strict-typed-call.js",
+      "workstreams": ["W4", "W5"],
+      "defaultInnerIterations": 100000,
+      "engines": ["goccia", "goccia-baseline", "goccia-candidate"],
+      "gocciaFlags": ["--strict-types"],
+      "tags": ["strict-types", "call"]
+    }
+  ]
+}

--- a/perf/awfy/manifest.json
+++ b/perf/awfy/manifest.json
@@ -26,6 +26,27 @@
     "script": "scripts/awfy-driver.js",
     "version": 1
   },
+  "ciSmoke": {
+    "benchmarks": [
+      "Bounce",
+      "DeltaBlue",
+      "Havlak",
+      "Json",
+      "List",
+      "Mandelbrot",
+      "NBody",
+      "Permute",
+      "Queens",
+      "Richards",
+      "Sieve",
+      "Storage",
+      "Towers"
+    ],
+    "probes": ["generic-plus-scalars"],
+    "excludedBenchmarks": {
+      "CD": "Current portable bundle crashes before a normalized result under GocciaScript, QuickJS, and Node."
+    }
+  },
   "diagnosticProbes": [
     {
       "name": "propaccess-monomorphic",

--- a/perf/probes/bound-spread-apply.js
+++ b/perf/probes/bound-spread-apply.js
@@ -1,0 +1,16 @@
+__gocciaRegisterProbe({
+  name: "bound-spread-apply",
+  run: (innerIterations) => {
+    const add3 = (a, b, c) => a + b + c;
+    const bound = add3.bind(null, 1);
+    const args = [2, 3];
+    let total = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      total = total + bound(...args);
+      total = total + add3.call(null, i & 7, 2, 3);
+      total = total + add3.apply(null, args);
+    }
+    return total | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/fib-recursive.js
+++ b/perf/probes/fib-recursive.js
@@ -1,0 +1,12 @@
+__gocciaRegisterProbe({
+  name: "fib-recursive",
+  run: (innerIterations) => {
+    const fib = (n) => n <= 1 ? n : fib(n - 1) + fib(n - 2);
+    let total = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      total = total + fib(20);
+    }
+    return total;
+  },
+  verify: (checksum, innerIterations) => checksum === 6765 * innerIterations,
+});

--- a/perf/probes/fixed-arg-call.js
+++ b/perf/probes/fixed-arg-call.js
@@ -1,0 +1,12 @@
+__gocciaRegisterProbe({
+  name: "fixed-arg-call",
+  run: (innerIterations) => {
+    const add3 = (a, b, c) => a + b + c;
+    let total = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      total = total + add3(i & 15, 7, 3);
+    }
+    return total | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/generic-plus-scalars.js
+++ b/perf/probes/generic-plus-scalars.js
@@ -1,0 +1,13 @@
+__gocciaRegisterProbe({
+  name: "generic-plus-scalars",
+  run: (innerIterations) => {
+    let total = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      const a = i % 97;
+      const b = (i + 17) % 89;
+      total = total + a + b + 0.5;
+    }
+    return total;
+  },
+  verify: (checksum) => checksum === checksum,
+});

--- a/perf/probes/loop-dispatch-floor.js
+++ b/perf/probes/loop-dispatch-floor.js
@@ -1,0 +1,17 @@
+__gocciaRegisterProbe({
+  name: "loop-dispatch-floor",
+  run: (innerIterations) => {
+    let x = 0;
+    let y = 1;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      x = x + y;
+      if ((x & 7) === 0) {
+        y = y + 1;
+      } else {
+        y = y ^ 3;
+      }
+    }
+    return (x ^ y) | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/method-call-fixed-arg.js
+++ b/perf/probes/method-call-fixed-arg.js
@@ -1,0 +1,17 @@
+__gocciaRegisterProbe({
+  name: "method-call-fixed-arg",
+  run: (innerIterations) => {
+    const accumulator = {
+      scale: 3,
+      add(a, b) {
+        return (a + b) * this.scale;
+      },
+    };
+    let total = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      total = total + accumulator.add(i & 31, 5);
+    }
+    return total | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/nbody-minimal.js
+++ b/perf/probes/nbody-minimal.js
@@ -1,0 +1,39 @@
+__gocciaRegisterProbe({
+  name: "nbody-minimal",
+  run: (innerIterations) => {
+    const bodies = [];
+    for (let i = 0; i < 5; i = i + 1) {
+      bodies.push({
+        x: i + 1,
+        y: i * 2 + 1,
+        z: i * 0.5 + 1,
+        vx: 0.1,
+        vy: 0.2,
+        vz: 0.05,
+        m: 1 + i * 0.1,
+      });
+    }
+    let e = 0;
+    for (let step = 0; step < innerIterations; step = step + 1) {
+      for (let i = 0; i < bodies.length; i = i + 1) {
+        const a = bodies[i];
+        for (let j = i + 1; j < bodies.length; j = j + 1) {
+          const b = bodies[j];
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const dz = a.z - b.z;
+          const d2 = dx * dx + dy * dy + dz * dz + 0.01;
+          const inv = 1 / Math.sqrt(d2);
+          e = e + (a.m * b.m) * inv;
+          a.vx = a.vx - dx * inv * 0.0001;
+          b.vx = b.vx + dx * inv * 0.0001;
+        }
+        a.x = a.x + a.vx * 0.001;
+        a.y = a.y + a.vy * 0.001;
+        a.z = a.z + a.vz * 0.001;
+      }
+    }
+    return e | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/prop-megamorphic.js
+++ b/perf/probes/prop-megamorphic.js
@@ -1,0 +1,18 @@
+__gocciaRegisterProbe({
+  name: "prop-megamorphic",
+  run: (innerIterations) => {
+    const values = [];
+    for (let i = 0; i < 32; i = i + 1) {
+      const o = { x: i, y: i * 2 };
+      o["pad" + i] = i;
+      values.push(o);
+    }
+    let total = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      const o = values[i & 31];
+      total = total + o.x + o.y;
+    }
+    return total | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/prop-polymorphic.js
+++ b/perf/probes/prop-polymorphic.js
@@ -1,0 +1,18 @@
+__gocciaRegisterProbe({
+  name: "prop-polymorphic",
+  run: (innerIterations) => {
+    const values = [
+      { x: 1, y: 2 },
+      { y: 3, x: 4 },
+      { x: 5, z: 1, y: 6 },
+      { z: 2, x: 7, y: 8 },
+    ];
+    let total = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      const o = values[i & 3];
+      total = total + o.x + o.y;
+    }
+    return total | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/propaccess-monomorphic.js
+++ b/perf/probes/propaccess-monomorphic.js
@@ -1,0 +1,13 @@
+__gocciaRegisterProbe({
+  name: "propaccess-monomorphic",
+  run: (innerIterations) => {
+    const o = { a: 1, b: 2, c: 3, d: 4 };
+    let s = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      o.a = o.a + 1;
+      s = s + o.a + o.b + o.c + o.d;
+    }
+    return s | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/regexp-corpus-build.js
+++ b/perf/probes/regexp-corpus-build.js
@@ -1,0 +1,11 @@
+__gocciaRegisterProbe({
+  name: "regexp-corpus-build",
+  run: (innerIterations) => {
+    let corpus = "";
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      corpus = corpus + "user" + i + "@example" + (i % 7) + ".com text " + i + "\n";
+    }
+    return corpus.length + ":" + corpus.charCodeAt(corpus.length - 2);
+  },
+  verify: (checksum) => typeof checksum === "string" && checksum.indexOf(":") > 0,
+});

--- a/perf/probes/regexp-exec-replace.js
+++ b/perf/probes/regexp-exec-replace.js
@@ -1,0 +1,20 @@
+__gocciaRegisterProbe({
+  name: "regexp-exec-replace",
+  run: (innerIterations) => {
+    let corpus = "";
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      corpus = corpus + "user" + i + "@example" + (i % 7) + ".com text " + i + "\n";
+    }
+    const re = /([a-z]+)(\d+)@example(\d)\.com/g;
+    let count = 0;
+    re.lastIndex = 0;
+    let match = re.exec(corpus);
+    while (match !== null) {
+      count = count + 1;
+      match = re.exec(corpus);
+    }
+    const replaced = corpus.replace(/text/g, "T");
+    return count + ":" + replaced.length;
+  },
+  verify: (checksum) => typeof checksum === "string" && checksum.indexOf(":") > 0,
+});

--- a/perf/probes/sort-comparator.js
+++ b/perf/probes/sort-comparator.js
@@ -1,0 +1,18 @@
+__gocciaRegisterProbe({
+  name: "sort-comparator",
+  run: (innerIterations) => {
+    let checksum = 0;
+    for (let r = 0; r < innerIterations; r = r + 1) {
+      const a = [];
+      let seed = 42 + r;
+      for (let i = 0; i < 80; i = i + 1) {
+        seed = (seed * 1103515245 + 12345) % 2147483648;
+        a.push(seed);
+      }
+      a.sort((x, y) => x - y);
+      checksum = (checksum + a[0] + a[a.length - 1]) | 0;
+    }
+    return checksum;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/perf/probes/strict-typed-arith.js
+++ b/perf/probes/strict-typed-arith.js
@@ -1,0 +1,12 @@
+__gocciaRegisterProbe({
+  name: "strict-typed-arith",
+  run: (innerIterations) => {
+    const add = (a: number, b: number): number => a + b;
+    let total: number = 0;
+    for (let i: number = 0; i < innerIterations; i = i + 1) {
+      total = add(total, (i % 31) + 0.25);
+    }
+    return total;
+  },
+  verify: (checksum) => checksum === checksum,
+});

--- a/perf/probes/strict-typed-call.js
+++ b/perf/probes/strict-typed-call.js
@@ -1,0 +1,12 @@
+__gocciaRegisterProbe({
+  name: "strict-typed-call",
+  run: (innerIterations) => {
+    const mix = (a: number, b: number, c: number): number => (a + b) * c;
+    let total: number = 0;
+    for (let i: number = 0; i < innerIterations; i = i + 1) {
+      total = total + mix(i % 13, 2, 3);
+    }
+    return total;
+  },
+  verify: (checksum) => checksum === checksum,
+});

--- a/perf/probes/string-append-30k.js
+++ b/perf/probes/string-append-30k.js
@@ -1,0 +1,15 @@
+__gocciaRegisterProbe({
+  name: "string-append-30k",
+  run: (innerIterations) => {
+    let s = "";
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      s = s + "chunk" + i + ";";
+    }
+    let h = 0;
+    for (let i = 0; i < s.length; i = i + 791) {
+      h = (h + s.charCodeAt(i)) | 0;
+    }
+    return s.length + ":" + h;
+  },
+  verify: (checksum) => typeof checksum === "string" && checksum.indexOf(":") > 0,
+});

--- a/perf/probes/string-builder-shaped.js
+++ b/perf/probes/string-builder-shaped.js
@@ -1,0 +1,18 @@
+__gocciaRegisterProbe({
+  name: "string-builder-shaped",
+  run: (innerIterations) => {
+    const chunks = [];
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      chunks.push("chunk");
+      chunks.push(String(i));
+      chunks.push(";");
+    }
+    const s = chunks.join("");
+    let h = 0;
+    for (let i = 0; i < s.length; i = i + 791) {
+      h = (h + s.charCodeAt(i)) | 0;
+    }
+    return s.length + ":" + h;
+  },
+  verify: (checksum) => typeof checksum === "string" && checksum.indexOf(":") > 0,
+});

--- a/perf/probes/typed-array-call-return.js
+++ b/perf/probes/typed-array-call-return.js
@@ -1,0 +1,17 @@
+__gocciaRegisterProbe({
+  name: "typed-array-call-return",
+  run: (innerIterations) => {
+    const values = new Int32Array(64);
+    for (let i = 0; i < values.length; i = i + 1) {
+      values[i] = i;
+    }
+    const read = (array, index) => array[index & 63];
+    const bump = (value) => value + 1;
+    let total = 0;
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      total = total + bump(read(values, i));
+    }
+    return total | 0;
+  },
+  verify: (checksum) => checksum === (checksum | 0),
+});

--- a/scripts/awfy-bump-pin.ts
+++ b/scripts/awfy-bump-pin.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+/**
+ * awfy-bump-pin.ts
+ *
+ * Update the AWFY corpus SHA pin used by the cross-engine benchmark driver.
+ * Invoked by the weekly `.github/workflows/awfy-bump.yml` cron job.
+ *
+ * Usage:
+ *   bun scripts/awfy-bump-pin.ts <new-sha> [manifest-path]
+ *
+ * Exits with status 0 and reports "no-op" when the pinned SHA already
+ * matches the argument. Exits non-zero only on argument, manifest, or I/O
+ * errors.
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const DEFAULT_TARGET = "perf/awfy/manifest.json";
+
+function main(argv: string[]): number {
+  if ((argv.length !== 1 && argv.length !== 2) || !SHA_RE.test(argv[0])) {
+    console.error("Usage: bun scripts/awfy-bump-pin.ts <40-hex-sha> [manifest-path]");
+    return 2;
+  }
+
+  const [newSha, target = DEFAULT_TARGET] = argv;
+
+  let text: string;
+  try {
+    text = readFileSync(target, "utf8");
+  } catch (err) {
+    console.error(`Failed to read ${target}: ${(err as Error).message}`);
+    return 1;
+  }
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(text);
+  } catch (err) {
+    console.error(`${target}: invalid JSON: ${(err as Error).message}`);
+    return 1;
+  }
+
+  const awfy = (manifest as { awfy?: { commit?: unknown } }).awfy;
+  const oldSha = awfy?.commit;
+  if (typeof oldSha !== "string" || !SHA_RE.test(oldSha)) {
+    console.error(`${target}: expected awfy.commit to be one 40-hex SHA`);
+    return 1;
+  }
+
+  if (oldSha === newSha) {
+    console.log(`${target}: already at ${newSha}`);
+    console.log(`No changes; pin already at ${newSha}.`);
+    return 0;
+  }
+
+  const commitRe = new RegExp(`("commit"\\s*:\\s*")${oldSha}(")`);
+  const updated = text.replace(commitRe, `$1${newSha}$2`);
+  if (updated === text) {
+    console.error(`${target}: could not rewrite awfy.commit`);
+    return 1;
+  }
+
+  writeFileSync(target, updated);
+  console.log(`${target}: bumped AWFY pin -> ${newSha}`);
+  return 0;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/scripts/awfy-comment.js
+++ b/scripts/awfy-comment.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const MARKER = '<!-- awfy-smoke -->';
+
+function formatMicros(value) {
+  if (typeof value !== 'number') return '-';
+  if (value >= 1000000) return `${(value / 1000000).toFixed(2)}s`;
+  if (value >= 1000) return `${(value / 1000).toFixed(2)}ms`;
+  return `${value.toFixed(2)}us`;
+}
+
+function targetOutcome(target) {
+  const stats = target.summary?.engineStats || {};
+  const bad = [];
+  for (const [engine, engineStats] of Object.entries(stats)) {
+    const ok = engineStats.ok || 0;
+    const failures =
+      (engineStats.timeout || 0) +
+      (engineStats.crash || 0) +
+      (engineStats.oom || 0) +
+      (engineStats.verificationFailed || 0) +
+      (engineStats.missingResult || 0);
+    if (ok === 0 || failures > 0) bad.push(engine);
+  }
+  if (target.summary?.checksumAgreement?.ok === false) bad.push('checksum');
+  return bad.length === 0 ? 'ok' : `check ${bad.join(', ')}`;
+}
+
+function engineCells(target) {
+  const stats = target.summary?.engineStats || {};
+  return ['goccia', 'qjs', 'node'].map((engine) => {
+    const engineStats = stats[engine];
+    if (!engineStats) return '-';
+    if ((engineStats.ok || 0) === 0) return 'no ok sample';
+    return formatMicros(engineStats.medianMicros);
+  });
+}
+
+function buildAwfySmokeComment(report) {
+  const awfy = report.metadata?.corpus?.awfy || {};
+  const shortSha = typeof awfy.commit === 'string' ? awfy.commit.slice(0, 8) : 'unknown';
+  const repo = awfy.repository || 'https://github.com/smarr/are-we-fast-yet';
+  const commitUrl = awfy.commit ? `${repo}/commit/${awfy.commit}` : repo;
+
+  let body = `${MARKER}\n## AWFY Smoke\n\n`;
+  body += `Pinned corpus: [\`${shortSha}\`](${commitUrl})  \n`;
+  body += `Driver version: ${report.metadata?.driver?.version ?? 'unknown'}  \n`;
+  body += `Generated: ${report.generatedAt ?? 'unknown'}\n\n`;
+
+  body += '| Target | Kind | Outcome | Checksum | Goccia | QuickJS | Node |\n';
+  body += '|--------|------|---------|----------|--------|---------|------|\n';
+  for (const target of report.targets || []) {
+    const [goccia, qjs, node] = engineCells(target);
+    const checksums = target.summary?.checksumAgreement?.checksums || [];
+    const checksum = target.summary?.checksumAgreement?.ok === false
+      ? `mismatch: ${checksums.join(', ')}`
+      : (checksums.join(', ') || '-');
+    body += `| ${target.name} | ${target.kind} | ${targetOutcome(target)} | ${checksum} | ${goccia} | ${qjs} | ${node} |\n`;
+  }
+
+  const geomean = report.geomeanRatios || {};
+  if (Object.keys(geomean).length > 0) {
+    body += '\n### Geomean Ratios\n\n';
+    body += '| Pair | Ratio |\n|------|-------|\n';
+    for (const [pair, ratio] of Object.entries(geomean).sort()) {
+      body += `| ${pair.replace(/_/g, ' ')} | ${Number(ratio).toFixed(3)} |\n`;
+    }
+  }
+
+  body += '\n<sub>Smoke only: one pinned AWFY benchmark plus one diagnostic probe. ';
+  body += 'Full-corpus AWFY timing remains a handover/manual or scheduled lane, not a PR gate.</sub>\n';
+  return body;
+}
+
+function unavailableComment(message) {
+  return [
+    MARKER,
+    '## AWFY Smoke',
+    '',
+    `_AWFY smoke results were not produced for this run: ${message}._`,
+    '',
+    '<sub>Smoke only. See the workflow run for the failing step.</sub>',
+    '',
+  ].join('\n');
+}
+
+function main(argv) {
+  const [fileName = 'awfy-smoke.json'] = argv;
+  if (!fs.existsSync(fileName)) {
+    process.stdout.write(unavailableComment(`${fileName} is missing`));
+    return 0;
+  }
+
+  try {
+    const report = JSON.parse(fs.readFileSync(fileName, 'utf8'));
+    process.stdout.write(buildAwfySmokeComment(report));
+    return 0;
+  } catch (error) {
+    process.stdout.write(unavailableComment(error.message));
+    return 0;
+  }
+}
+
+if (require.main === module) {
+  process.exitCode = main(process.argv.slice(2));
+}
+
+module.exports = {
+  MARKER,
+  buildAwfySmokeComment,
+  formatMicros,
+  targetOutcome,
+  unavailableComment,
+};

--- a/scripts/awfy-comment.js
+++ b/scripts/awfy-comment.js
@@ -43,15 +43,7 @@ function engineCells(target) {
 }
 
 function buildAwfySmokeComment(report) {
-  const awfy = report.metadata?.corpus?.awfy || {};
-  const shortSha = typeof awfy.commit === 'string' ? awfy.commit.slice(0, 8) : 'unknown';
-  const repo = awfy.repository || 'https://github.com/smarr/are-we-fast-yet';
-  const commitUrl = awfy.commit ? `${repo}/commit/${awfy.commit}` : repo;
-
   let body = `${MARKER}\n## AWFY Smoke\n\n`;
-  body += `Pinned corpus: [\`${shortSha}\`](${commitUrl})  \n`;
-  body += `Driver version: ${report.metadata?.driver?.version ?? 'unknown'}  \n`;
-  body += `Generated: ${report.generatedAt ?? 'unknown'}\n\n`;
 
   body += '| Target | Kind | Outcome | Checksum | Goccia | QuickJS | Node |\n';
   body += '|--------|------|---------|----------|--------|---------|------|\n';
@@ -75,8 +67,8 @@ function buildAwfySmokeComment(report) {
 
   const awfyCount = (report.targets || []).filter((target) => target.kind === 'awfy').length;
   const probeCount = (report.targets || []).filter((target) => target.kind === 'probe').length;
-  body += `\n<sub>Smoke only: ${plural(awfyCount, 'pinned AWFY benchmark')} plus ${plural(probeCount, 'diagnostic probe')}. `;
-  body += 'Full-corpus AWFY timing remains a handover/manual or scheduled lane, not a PR gate.</sub>\n';
+  body += `\n<sub>${plural(awfyCount, 'pinned AWFY benchmark')} plus ${plural(probeCount, 'diagnostic probe')}. `;
+  body += 'One PR sample per engine; raw JSON is attached as the `awfy-smoke` artifact.</sub>\n';
   return body;
 }
 

--- a/scripts/awfy-comment.js
+++ b/scripts/awfy-comment.js
@@ -11,6 +11,10 @@ function formatMicros(value) {
   return `${value.toFixed(2)}us`;
 }
 
+function plural(count, singular) {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`;
+}
+
 function targetOutcome(target) {
   const stats = target.summary?.engineStats || {};
   const bad = [];
@@ -69,7 +73,9 @@ function buildAwfySmokeComment(report) {
     }
   }
 
-  body += '\n<sub>Smoke only: one pinned AWFY benchmark plus one diagnostic probe. ';
+  const awfyCount = (report.targets || []).filter((target) => target.kind === 'awfy').length;
+  const probeCount = (report.targets || []).filter((target) => target.kind === 'probe').length;
+  body += `\n<sub>Smoke only: ${plural(awfyCount, 'pinned AWFY benchmark')} plus ${plural(probeCount, 'diagnostic probe')}. `;
   body += 'Full-corpus AWFY timing remains a handover/manual or scheduled lane, not a PR gate.</sub>\n';
   return body;
 }

--- a/scripts/awfy-driver.js
+++ b/scripts/awfy-driver.js
@@ -1,0 +1,664 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const DRIVER_VERSION = 1;
+const RESULT_MARKER = 'GOCCIA_AWFY_RESULT ';
+const DEFAULT_MANIFEST = path.join('perf', 'awfy', 'manifest.json');
+const DEFAULT_TIMEOUT_MS = 120000;
+const DEFAULT_REPETITIONS = 3;
+const DEFAULT_INNER_ITERATIONS = 1;
+const DEFAULT_GOCCIA_FLAGS = [
+  '--mode=bytecode',
+  '--compat-traditional-for-loop',
+  '--compat-while-loops',
+  '--compat-for-in-loop',
+  '--compat-function',
+];
+
+function usage() {
+  return [
+    'Usage: node scripts/awfy-driver.js [options]',
+    '',
+    'Targets:',
+    '  --benchmark <AWFY name>       Run an upstream AWFY JavaScript benchmark from --awfy-dir',
+    '  --probe <probe name>          Run a Goccia diagnostic probe from perf/probes',
+    '  --list                       List known AWFY benchmark names and probes',
+    '',
+    'Inputs and engines:',
+    '  --awfy-dir <path>             Path to are-we-fast-yet/benchmarks/JavaScript',
+    '  --manifest <path>             Manifest path (default: perf/awfy/manifest.json)',
+    '  --engines <csv>               Engine order (default: goccia,qjs,node)',
+    '  --goccia <path>               GocciaScriptLoader path (default: build/GocciaScriptLoader)',
+    '  --goccia-baseline <path>      Optional baseline Goccia binary, interleaved as goccia-baseline',
+    '  --goccia-candidate <path>     Optional candidate Goccia binary, interleaved as goccia-candidate',
+    '  --qjs <path>                  QuickJS shell path (default: qjs)',
+    '  --node <path>                 Node.js path (default: current node)',
+    '  --goccia-flag <flag>          Extra Goccia flag; repeatable',
+    '',
+    'Measurement:',
+    '  --repetitions <n>             Raw samples per engine/target (default: 3)',
+    '  --inner-iterations <n>        Override target inner iterations',
+    '  --timeout-ms <n>              Per-sample process timeout (default: 120000)',
+    '  --profile <mode>              Add Goccia --profile=opcodes|functions|all for diagnostic runs',
+    '  --profile-dir <path>          Directory for Goccia profile outputs',
+    '  --output <path>               Write normalized JSON report',
+    '  --keep-temp                   Keep generated portable JS bundles',
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const options = {
+    manifestPath: DEFAULT_MANIFEST,
+    awfyDir: '',
+    benchmarks: [],
+    probes: [],
+    engines: null,
+    goccia: path.join('build', 'GocciaScriptLoader'),
+    gocciaBaseline: '',
+    gocciaCandidate: '',
+    qjs: 'qjs',
+    node: process.execPath,
+    gocciaFlags: [],
+    repetitions: DEFAULT_REPETITIONS,
+    innerIterations: null,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    output: '',
+    profile: '',
+    profileDir: '',
+    keepTemp: false,
+    list: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const nextValue = () => {
+      if (arg.includes('=')) return arg.slice(arg.indexOf('=') + 1);
+      i += 1;
+      if (i >= argv.length) throw new Error(`Missing value for ${arg}`);
+      return argv[i];
+    };
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--list') {
+      options.list = true;
+    } else if (arg === '--keep-temp') {
+      options.keepTemp = true;
+    } else if (arg === '--manifest' || arg.startsWith('--manifest=')) {
+      options.manifestPath = nextValue();
+    } else if (arg === '--awfy-dir' || arg.startsWith('--awfy-dir=')) {
+      options.awfyDir = nextValue();
+    } else if (arg === '--benchmark' || arg.startsWith('--benchmark=')) {
+      options.benchmarks.push(nextValue());
+    } else if (arg === '--probe' || arg.startsWith('--probe=')) {
+      options.probes.push(nextValue());
+    } else if (arg === '--engines' || arg.startsWith('--engines=')) {
+      options.engines = nextValue().split(',').map((engine) => engine.trim()).filter(Boolean);
+    } else if (arg === '--goccia' || arg.startsWith('--goccia=')) {
+      options.goccia = nextValue();
+    } else if (arg === '--goccia-baseline' || arg.startsWith('--goccia-baseline=')) {
+      options.gocciaBaseline = nextValue();
+    } else if (arg === '--goccia-candidate' || arg.startsWith('--goccia-candidate=')) {
+      options.gocciaCandidate = nextValue();
+    } else if (arg === '--qjs' || arg.startsWith('--qjs=')) {
+      options.qjs = nextValue();
+    } else if (arg === '--node' || arg.startsWith('--node=')) {
+      options.node = nextValue();
+    } else if (arg === '--goccia-flag' || arg.startsWith('--goccia-flag=')) {
+      options.gocciaFlags.push(nextValue());
+    } else if (arg === '--repetitions' || arg.startsWith('--repetitions=')) {
+      options.repetitions = parsePositiveInteger(nextValue(), '--repetitions');
+    } else if (arg === '--inner-iterations' || arg.startsWith('--inner-iterations=')) {
+      options.innerIterations = parsePositiveInteger(nextValue(), '--inner-iterations');
+    } else if (arg === '--timeout-ms' || arg.startsWith('--timeout-ms=')) {
+      options.timeoutMs = parsePositiveInteger(nextValue(), '--timeout-ms');
+    } else if (arg === '--profile' || arg.startsWith('--profile=')) {
+      options.profile = nextValue();
+    } else if (arg === '--profile-dir' || arg.startsWith('--profile-dir=')) {
+      options.profileDir = nextValue();
+    } else if (arg === '--output' || arg.startsWith('--output=')) {
+      options.output = nextValue();
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function parsePositiveInteger(value, optionName) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`${optionName} must be a positive integer, got ${value}`);
+  }
+  return parsed;
+}
+
+function readJSON(fileName) {
+  return JSON.parse(fs.readFileSync(fileName, 'utf8'));
+}
+
+function normalizeModuleId(request) {
+  let normalized = request;
+  if (!normalized.startsWith('./')) normalized = `./${normalized}`;
+  normalized = path.posix.normalize(normalized);
+  if (!normalized.startsWith('./')) normalized = `./${normalized}`;
+  if (normalized.endsWith('.js')) normalized = normalized.slice(0, -3);
+  return normalized;
+}
+
+function collectAwfyModules(awfyDir, entryId) {
+  const modules = new Map();
+  const visit = (id) => {
+    const normalized = normalizeModuleId(id);
+    if (modules.has(normalized)) return;
+    const fileName = path.join(awfyDir, `${normalized.slice(2)}.js`);
+    const source = fs.readFileSync(fileName, 'utf8');
+    modules.set(normalized, source);
+
+    const requirePattern = /\brequire\(['"](\.\/[^'"]+)['"]\)/g;
+    let match = requirePattern.exec(source);
+    while (match) {
+      visit(match[1]);
+      match = requirePattern.exec(source);
+    }
+  };
+  visit(entryId);
+  return modules;
+}
+
+function buildAwfyBundle({ awfyDir, benchmarkName, moduleName, innerIterations }) {
+  const entryId = normalizeModuleId(moduleName);
+  const modules = collectAwfyModules(awfyDir, entryId);
+  const chunks = [
+    '"use strict";',
+    `const __awfyConfig = ${JSON.stringify({ benchmarkName, innerIterations })};`,
+    'const __awfyNowMicros = () => (typeof performance !== "undefined" && performance.now ? performance.now() * 1000 : Date.now() * 1000);',
+    'const process = { stdout: { write: (value) => { const text = String(value); if (text.length > 0) { const lines = text.split("\\n"); for (let i = 0; i < lines.length; i += 1) { if (lines[i].length > 0) console.log(lines[i]); } } } } };',
+    'const __modules = Object.create(null);',
+    'const __cache = Object.create(null);',
+    'const __define = (id, factory) => { __modules[id] = factory; };',
+    'const require = (id) => { const normalized = id.endsWith(".js") ? id.slice(0, -3) : id; const key = normalized.startsWith("./") ? normalized : "./" + normalized; if (__cache[key]) return __cache[key].exports; if (!__modules[key]) throw new Error("Missing AWFY module " + key); const module = { exports: {} }; __cache[key] = module; __modules[key](module, module.exports, require); return module.exports; };',
+  ];
+
+  for (const [id, source] of modules) {
+    chunks.push(`__define(${JSON.stringify(id)}, (module, exports, require) => {\n${source}\n});`);
+  }
+
+  chunks.push([
+    `const __suite = require(${JSON.stringify(entryId)});`,
+    'const __bench = __suite.newInstance();',
+    'const __started = __awfyNowMicros();',
+    'const __verificationPassed = __bench.innerBenchmarkLoop(__awfyConfig.innerIterations) === true;',
+    'const __durationMicros = __awfyNowMicros() - __started;',
+    'const __result = { kind: "awfy", name: __awfyConfig.benchmarkName, durationMicros: __durationMicros, checksum: __verificationPassed ? "verified" : "failed", verificationPassed: __verificationPassed, innerIterations: __awfyConfig.innerIterations };',
+    `console.log(${JSON.stringify(RESULT_MARKER)} + JSON.stringify(__result));`,
+    'if (!__verificationPassed) throw new Error("AWFY verification failed for " + __awfyConfig.benchmarkName);',
+  ].join('\n'));
+
+  return `${chunks.join('\n\n')}\n`;
+}
+
+function buildProbeBundle({ probe, innerIterations }) {
+  const source = fs.readFileSync(probe.file, 'utf8');
+  return [
+    '"use strict";',
+    `const __probeConfig = ${JSON.stringify({ name: probe.name, innerIterations })};`,
+    'const __probeNowMicros = () => (typeof performance !== "undefined" && performance.now ? performance.now() * 1000 : Date.now() * 1000);',
+    'let __probe = null;',
+    'const __gocciaRegisterProbe = (probe) => { __probe = probe; };',
+    source,
+    'if (__probe === null) throw new Error("Probe did not register itself: " + __probeConfig.name);',
+    'const __started = __probeNowMicros();',
+    'const __checksum = __probe.run(__probeConfig.innerIterations);',
+    'const __durationMicros = __probeNowMicros() - __started;',
+    'const __verificationPassed = __probe.verify ? (__probe.verify(__checksum, __probeConfig.innerIterations) === true) : true;',
+    'const __result = { kind: "probe", name: __probeConfig.name, durationMicros: __durationMicros, checksum: String(__checksum), verificationPassed: __verificationPassed, innerIterations: __probeConfig.innerIterations };',
+    `console.log(${JSON.stringify(RESULT_MARKER)} + JSON.stringify(__result));`,
+    'if (!__verificationPassed) throw new Error("Probe verification failed for " + __probeConfig.name);',
+    '',
+  ].join('\n');
+}
+
+function writeBundle(tempDir, target, source) {
+  const fileName = path.join(tempDir, `${target.kind}-${target.name}.js`);
+  fs.writeFileSync(fileName, source);
+  return fileName;
+}
+
+function resolveTargets(options, manifest) {
+  const targets = [];
+  const benchmarkMap = manifest.awfy?.benchmarks || {};
+  const probes = new Map((manifest.diagnosticProbes || []).map((probe) => [probe.name, probe]));
+
+  for (const benchmarkName of options.benchmarks) {
+    const moduleName = benchmarkMap[benchmarkName];
+    if (!moduleName) throw new Error(`Unknown AWFY benchmark: ${benchmarkName}`);
+    if (!options.awfyDir) throw new Error('--awfy-dir is required when --benchmark is used');
+    targets.push({
+      kind: 'awfy',
+      name: benchmarkName,
+      moduleName,
+      innerIterations: options.innerIterations || DEFAULT_INNER_ITERATIONS,
+      workstreams: ['#856'],
+      tags: ['awfy'],
+      source: `${options.awfyDir}/${moduleName}.js`,
+    });
+  }
+
+  for (const probeName of options.probes) {
+    const probe = probes.get(probeName);
+    if (!probe) throw new Error(`Unknown diagnostic probe: ${probeName}`);
+    targets.push({
+      kind: 'probe',
+      name: probe.name,
+      probe,
+      innerIterations: options.innerIterations || probe.defaultInnerIterations || DEFAULT_INNER_ITERATIONS,
+      workstreams: probe.workstreams || [],
+      tags: probe.tags || [],
+      source: probe.file,
+      engines: probe.engines || null,
+      gocciaFlags: probe.gocciaFlags || [],
+    });
+  }
+
+  return targets;
+}
+
+function resolveEngines(options) {
+  const requested = options.engines || ['goccia', 'qjs', 'node'];
+  const engines = [];
+
+  const addGoccia = (name, command) => {
+    engines.push({
+      name,
+      kind: 'goccia',
+      command,
+      baseArgs: DEFAULT_GOCCIA_FLAGS.concat(options.gocciaFlags),
+    });
+  };
+
+  for (const name of requested) {
+    if (name === 'goccia') {
+      if (options.gocciaBaseline || options.gocciaCandidate) {
+        if (options.gocciaBaseline) addGoccia('goccia-baseline', options.gocciaBaseline);
+        if (options.gocciaCandidate) addGoccia('goccia-candidate', options.gocciaCandidate);
+      } else {
+        addGoccia('goccia', options.goccia);
+      }
+    } else if (name === 'goccia-baseline') {
+      if (!options.gocciaBaseline) throw new Error('--goccia-baseline is required for engine goccia-baseline');
+      addGoccia('goccia-baseline', options.gocciaBaseline);
+    } else if (name === 'goccia-candidate') {
+      if (!options.gocciaCandidate) throw new Error('--goccia-candidate is required for engine goccia-candidate');
+      addGoccia('goccia-candidate', options.gocciaCandidate);
+    } else if (name === 'qjs') {
+      engines.push({ name: 'qjs', kind: 'qjs', command: options.qjs, baseArgs: [] });
+    } else if (name === 'node') {
+      engines.push({ name: 'node', kind: 'node', command: options.node, baseArgs: [] });
+    } else {
+      throw new Error(`Unknown engine: ${name}`);
+    }
+  }
+
+  return engines;
+}
+
+function engineAllowedForTarget(engine, target) {
+  if (!target.engines) return true;
+  return target.engines.includes(engine.name) || target.engines.includes(engine.kind);
+}
+
+function profileArgs(options, target, engine, repetition) {
+  if (!options.profile || engine.kind !== 'goccia') return [];
+  const args = [`--profile=${options.profile}`];
+  if (options.profileDir) {
+    fs.mkdirSync(options.profileDir, { recursive: true });
+    args.push(`--profile-output=${path.join(options.profileDir, `${target.name}-${engine.name}-${repetition}.json`)}`);
+  }
+  return args;
+}
+
+function runEngineSample({ engine, target, fileName, repetition, options }) {
+  const args = [];
+  if (engine.kind === 'goccia') {
+    args.push(fileName, ...engine.baseArgs, ...(target.gocciaFlags || []), ...profileArgs(options, target, engine, repetition));
+  } else {
+    args.push(...engine.baseArgs, fileName);
+  }
+
+  const startedAt = new Date().toISOString();
+  const proc = spawnSync(engine.command, args, {
+    encoding: 'utf8',
+    timeout: options.timeoutMs,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  const stdout = proc.stdout || '';
+  const stderr = proc.stderr || '';
+  const parsed = parseResult(stdout);
+  const outcome = classifyProcessOutcome(proc, parsed, stdout, stderr);
+
+  return {
+    engine: engine.name,
+    repetition,
+    startedAt,
+    outcome,
+    durationMicros: parsed?.durationMicros ?? null,
+    checksum: parsed?.checksum ?? null,
+    verificationPassed: parsed?.verificationPassed ?? false,
+    innerIterations: target.innerIterations,
+    exitCode: proc.status,
+    signal: proc.signal || null,
+    command: [engine.command, ...args],
+    stderr: outcome === 'ok' ? '' : stderr.slice(0, 4000),
+  };
+}
+
+function parseResult(stdout) {
+  const lines = stdout.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (line.startsWith(RESULT_MARKER)) {
+      return JSON.parse(line.slice(RESULT_MARKER.length));
+    }
+  }
+  return null;
+}
+
+function classifyProcessOutcome(proc, parsed, stdout, stderr) {
+  if (proc.error && proc.error.code === 'ETIMEDOUT') return 'timeout';
+  const combined = `${stdout}\n${stderr}`.toLowerCase();
+  if (combined.includes('out of memory') || combined.includes('oom') || proc.signal === 'SIGKILL') return 'oom';
+  if (!parsed) return proc.status === 0 ? 'missing-result' : 'crash';
+  if (!parsed.verificationPassed) return 'verification-failed';
+  if (proc.status !== 0) return 'crash';
+  return 'ok';
+}
+
+function median(values) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function iqrFiltered(values) {
+  if (values.length < 4) return [...values];
+  const sorted = [...values].sort((a, b) => a - b);
+  const q1 = sorted[Math.floor(sorted.length / 4)];
+  const q3 = sorted[Math.floor((sorted.length * 3) / 4)];
+  const iqr = q3 - q1;
+  if (iqr <= 0) return sorted;
+  const lower = q1 - 1.5 * iqr;
+  const upper = q3 + 1.5 * iqr;
+  return sorted.filter((value) => value >= lower && value <= upper);
+}
+
+function coefficientOfVariation(values) {
+  if (values.length === 0) return null;
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  if (mean === 0) return null;
+  const variance = values.reduce((sum, value) => sum + ((value - mean) * (value - mean)), 0) / values.length;
+  return (Math.sqrt(variance) / mean) * 100;
+}
+
+function summarizeSamples(samples) {
+  const values = samples
+    .filter((sample) => sample.outcome === 'ok' && typeof sample.durationMicros === 'number' && sample.durationMicros > 0)
+    .map((sample) => sample.durationMicros);
+  const filtered = iqrFiltered(values);
+  return {
+    ok: samples.filter((sample) => sample.outcome === 'ok').length,
+    timeout: samples.filter((sample) => sample.outcome === 'timeout').length,
+    crash: samples.filter((sample) => sample.outcome === 'crash').length,
+    oom: samples.filter((sample) => sample.outcome === 'oom').length,
+    verificationFailed: samples.filter((sample) => sample.outcome === 'verification-failed').length,
+    missingResult: samples.filter((sample) => sample.outcome === 'missing-result').length,
+    rawCount: values.length,
+    medianMicros: median(values),
+    iqrMedianMicros: median(filtered),
+    minMicros: values.length ? Math.min(...values) : null,
+    maxMicros: values.length ? Math.max(...values) : null,
+    coefficientOfVariation: coefficientOfVariation(values),
+  };
+}
+
+function checksumAgreement(samples) {
+  const checksums = new Set(samples
+    .filter((sample) => sample.outcome === 'ok')
+    .map((sample) => sample.checksum));
+  return {
+    ok: checksums.size <= 1,
+    checksums: [...checksums].sort(),
+  };
+}
+
+function buildTargetSummary(samples) {
+  const byEngine = new Map();
+  for (const sample of samples) {
+    if (!byEngine.has(sample.engine)) byEngine.set(sample.engine, []);
+    byEngine.get(sample.engine).push(sample);
+  }
+
+  const engineStats = {};
+  for (const [engine, engineSamples] of byEngine.entries()) {
+    engineStats[engine] = summarizeSamples(engineSamples);
+  }
+
+  const ratios = {};
+  const engines = Object.keys(engineStats);
+  for (const left of engines) {
+    for (const right of engines) {
+      if (left === right) continue;
+      const leftMedian = engineStats[left].medianMicros;
+      const rightMedian = engineStats[right].medianMicros;
+      if (leftMedian && rightMedian) {
+        ratios[`${left}_over_${right}`] = leftMedian / rightMedian;
+      }
+    }
+  }
+
+  return {
+    checksumAgreement: checksumAgreement(samples),
+    engineStats,
+    ratios,
+  };
+}
+
+function buildGeomeanRatios(targetReports) {
+  const buckets = new Map();
+  for (const target of targetReports) {
+    for (const [pair, ratio] of Object.entries(target.summary.ratios)) {
+      if (!Number.isFinite(ratio) || ratio <= 0) continue;
+      if (!buckets.has(pair)) buckets.set(pair, []);
+      buckets.get(pair).push(Math.log(ratio));
+    }
+  }
+
+  const result = {};
+  for (const [pair, logs] of buckets.entries()) {
+    result[pair] = Math.exp(logs.reduce((sum, value) => sum + value, 0) / logs.length);
+  }
+  return result;
+}
+
+function collectMetadata(options, manifest, engines) {
+  return {
+    driver: {
+      version: DRIVER_VERSION,
+      script: 'scripts/awfy-driver.js',
+    },
+    goccia: {
+      commit: commandText('git', ['rev-parse', 'HEAD']),
+      shortCommit: commandText('git', ['rev-parse', '--short', 'HEAD']),
+      status: commandText('git', ['status', '--short']),
+      buildMode: 'external-binary',
+      fpcVersion: commandText('fpc', ['-iV']),
+    },
+    platform: {
+      os: os.platform(),
+      release: os.release(),
+      arch: os.arch(),
+      cpus: os.cpus().length,
+    },
+    corpus: {
+      awfy: manifest.awfy || null,
+    },
+    engines: engines.map((engine) => ({
+      name: engine.name,
+      kind: engine.kind,
+      command: engine.command,
+      version: engineVersion(engine),
+    })),
+    options: {
+      repetitions: options.repetitions,
+      timeoutMs: options.timeoutMs,
+      profile: options.profile || null,
+      profileDir: options.profileDir || null,
+    },
+  };
+}
+
+function commandText(command, args) {
+  const proc = spawnSync(command, args, { encoding: 'utf8' });
+  if (proc.status !== 0) return '';
+  return (proc.stdout || '').trim();
+}
+
+function engineVersion(engine) {
+  if (engine.kind === 'node') return commandText(engine.command, ['--version']);
+  if (engine.kind === 'qjs') {
+    const proc = spawnSync(engine.command, ['-h'], { encoding: 'utf8' });
+    const output = `${proc.stdout || ''}${proc.stderr || ''}`.split(/\r?\n/)[0];
+    return output.trim();
+  }
+  const proc = spawnSync(engine.command, ['--version'], { encoding: 'utf8' });
+  if (proc.status === 0) return (proc.stdout || proc.stderr || '').trim();
+  return '';
+}
+
+function listTargets(manifest) {
+  const benchmarks = Object.keys(manifest.awfy?.benchmarks || {}).sort();
+  const probes = (manifest.diagnosticProbes || []).map((probe) => probe.name).sort();
+  console.log('AWFY benchmarks:');
+  for (const benchmark of benchmarks) console.log(`  ${benchmark}`);
+  console.log('\nDiagnostic probes:');
+  for (const probe of probes) console.log(`  ${probe}`);
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return 0;
+  }
+
+  const manifest = readJSON(options.manifestPath);
+  if (options.list) {
+    listTargets(manifest);
+    return 0;
+  }
+
+  const targets = resolveTargets(options, manifest);
+  if (targets.length === 0) {
+    throw new Error('No targets selected. Use --benchmark, --probe, or --list.');
+  }
+
+  const engines = resolveEngines(options);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'goccia-awfy-'));
+  const targetReports = [];
+
+  try {
+    for (const target of targets) {
+      const bundle = target.kind === 'awfy'
+        ? buildAwfyBundle({
+          awfyDir: options.awfyDir,
+          benchmarkName: target.name,
+          moduleName: target.moduleName,
+          innerIterations: target.innerIterations,
+        })
+        : buildProbeBundle({
+          probe: target.probe,
+          innerIterations: target.innerIterations,
+        });
+      const bundleFile = writeBundle(tempDir, target, bundle);
+      const samples = [];
+
+      for (let repetition = 0; repetition < options.repetitions; repetition += 1) {
+        for (const engine of engines) {
+          if (!engineAllowedForTarget(engine, target)) continue;
+          const sample = runEngineSample({
+            engine,
+            target,
+            fileName: bundleFile,
+            repetition,
+            options,
+          });
+          samples.push(sample);
+          console.error(`${target.name} ${engine.name} rep ${repetition + 1}/${options.repetitions}: ${sample.outcome}${sample.durationMicros ? ` ${sample.durationMicros}us` : ''}`);
+        }
+      }
+
+      targetReports.push({
+        kind: target.kind,
+        name: target.name,
+        source: target.source,
+        generatedBundle: options.keepTemp ? bundleFile : null,
+        workstreams: target.workstreams,
+        tags: target.tags,
+        innerIterations: target.innerIterations,
+        samples,
+        summary: buildTargetSummary(samples),
+      });
+    }
+  } finally {
+    if (!options.keepTemp) fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+
+  const report = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    metadata: collectMetadata(options, manifest, engines),
+    targets: targetReports,
+    geomeanRatios: buildGeomeanRatios(targetReports),
+  };
+
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.output) {
+    const outputDir = path.dirname(options.output);
+    if (outputDir && outputDir !== '.') fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(options.output, json);
+  } else {
+    process.stdout.write(json);
+  }
+
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  RESULT_MARKER,
+  buildAwfyBundle,
+  buildGeomeanRatios,
+  buildProbeBundle,
+  checksumAgreement,
+  collectAwfyModules,
+  coefficientOfVariation,
+  iqrFiltered,
+  median,
+  parseArgs,
+  parseResult,
+  summarizeSamples,
+};

--- a/scripts/awfy-driver.js
+++ b/scripts/awfy-driver.js
@@ -138,6 +138,17 @@ function parsePositiveInteger(value, optionName) {
   return parsed;
 }
 
+function parseTargetSpec(value, optionName) {
+  const marker = value.lastIndexOf(':');
+  if (marker <= 0) return { name: value, innerIterations: null };
+  const suffix = value.slice(marker + 1);
+  if (!/^[0-9]+$/.test(suffix)) return { name: value, innerIterations: null };
+  return {
+    name: value.slice(0, marker),
+    innerIterations: parsePositiveInteger(suffix, optionName),
+  };
+}
+
 function readJSON(fileName) {
   return JSON.parse(fs.readFileSync(fileName, 'utf8'));
 }
@@ -235,7 +246,9 @@ function resolveTargets(options, manifest) {
   const benchmarkMap = manifest.awfy?.benchmarks || {};
   const probes = new Map((manifest.diagnosticProbes || []).map((probe) => [probe.name, probe]));
 
-  for (const benchmarkName of options.benchmarks) {
+  for (const benchmarkSpec of options.benchmarks) {
+    const parsed = parseTargetSpec(benchmarkSpec, '--benchmark');
+    const benchmarkName = parsed.name;
     const moduleName = benchmarkMap[benchmarkName];
     if (!moduleName) throw new Error(`Unknown AWFY benchmark: ${benchmarkName}`);
     if (!options.awfyDir) throw new Error('--awfy-dir is required when --benchmark is used');
@@ -243,22 +256,24 @@ function resolveTargets(options, manifest) {
       kind: 'awfy',
       name: benchmarkName,
       moduleName,
-      innerIterations: options.innerIterations || DEFAULT_INNER_ITERATIONS,
-      workstreams: ['#856'],
+      innerIterations: options.innerIterations || parsed.innerIterations || DEFAULT_INNER_ITERATIONS,
+      focusAreas: ['awfy'],
       tags: ['awfy'],
       source: `${options.awfyDir}/${moduleName}.js`,
     });
   }
 
-  for (const probeName of options.probes) {
+  for (const probeSpec of options.probes) {
+    const parsed = parseTargetSpec(probeSpec, '--probe');
+    const probeName = parsed.name;
     const probe = probes.get(probeName);
     if (!probe) throw new Error(`Unknown diagnostic probe: ${probeName}`);
     targets.push({
       kind: 'probe',
       name: probe.name,
       probe,
-      innerIterations: options.innerIterations || probe.defaultInnerIterations || DEFAULT_INNER_ITERATIONS,
-      workstreams: probe.workstreams || [],
+      innerIterations: options.innerIterations || parsed.innerIterations || probe.defaultInnerIterations || DEFAULT_INNER_ITERATIONS,
+      focusAreas: probe.focusAreas || [],
       tags: probe.tags || [],
       source: probe.file,
       engines: probe.engines || null,
@@ -408,7 +423,7 @@ function coefficientOfVariation(values) {
 
 function summarizeSamples(samples) {
   const values = samples
-    .filter((sample) => sample.outcome === 'ok' && typeof sample.durationMicros === 'number' && sample.durationMicros > 0)
+    .filter((sample) => sample.outcome === 'ok' && typeof sample.durationMicros === 'number' && sample.durationMicros >= 0)
     .map((sample) => sample.durationMicros);
   const filtered = iqrFiltered(values);
   return {
@@ -608,7 +623,7 @@ function main(argv = process.argv.slice(2)) {
         name: target.name,
         source: target.source,
         generatedBundle: options.keepTemp ? bundleFile : null,
-        workstreams: target.workstreams,
+        focusAreas: target.focusAreas,
         tags: target.tags,
         innerIterations: target.innerIterations,
         samples,

--- a/scripts/test-awfy-driver.js
+++ b/scripts/test-awfy-driver.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const {
+  RESULT_MARKER,
+  buildAwfyBundle,
+  buildGeomeanRatios,
+  checksumAgreement,
+  median,
+  parseResult,
+  summarizeSamples,
+} = require('./awfy-driver.js');
+
+let passed = 0;
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+  passed += 1;
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`);
+  }
+  passed += 1;
+}
+
+console.log('awfy-driver: statistics...');
+{
+  assertEqual(median([3, 1, 2]), 2, 'median sorts odd-length values');
+  assertEqual(median([4, 1, 2, 3]), 2.5, 'median sorts even-length values');
+
+  const summary = summarizeSamples([
+    { outcome: 'ok', durationMicros: 100 },
+    { outcome: 'ok', durationMicros: 110 },
+    { outcome: 'timeout', durationMicros: null },
+  ]);
+  assertEqual(summary.ok, 2, 'summary counts ok samples');
+  assertEqual(summary.timeout, 1, 'summary counts timeout samples');
+  assertEqual(summary.medianMicros, 105, 'summary reports sample median');
+}
+
+console.log('awfy-driver: checksum agreement...');
+{
+  assert(checksumAgreement([
+    { outcome: 'ok', checksum: 'abc' },
+    { outcome: 'ok', checksum: 'abc' },
+    { outcome: 'crash', checksum: null },
+  ]).ok, 'matching checksums agree');
+
+  assert(!checksumAgreement([
+    { outcome: 'ok', checksum: 'abc' },
+    { outcome: 'ok', checksum: 'def' },
+  ]).ok, 'different checksums disagree');
+}
+
+console.log('awfy-driver: geomean ratios...');
+{
+  const ratios = buildGeomeanRatios([
+    { summary: { ratios: { goccia_over_qjs: 4 } } },
+    { summary: { ratios: { goccia_over_qjs: 9 } } },
+  ]);
+  assertEqual(Math.round(ratios.goccia_over_qjs * 1000) / 1000, 6, 'geomean ratio uses logs');
+}
+
+console.log('awfy-driver: portable AWFY bundle...');
+{
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'awfy-driver-test-'));
+  try {
+    fs.writeFileSync(path.join(tmp, 'benchmark.js'), [
+      'class Benchmark {',
+      '  innerBenchmarkLoop(innerIterations) {',
+      '    for (let i = 0; i < innerIterations; i += 1) {',
+      '      if (!this.verifyResult(this.benchmark())) return false;',
+      '    }',
+      '    return true;',
+      '  }',
+      '}',
+      'exports.Benchmark = Benchmark;',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(tmp, 'tiny.js'), [
+      "const { Benchmark } = require('./benchmark');",
+      'class Tiny extends Benchmark {',
+      '  benchmark() { return 42; }',
+      '  verifyResult(result) { return result === 42; }',
+      '}',
+      'exports.newInstance = () => new Tiny();',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(tmp, 'cd.js'), 'this is deliberately invalid if bundled\n');
+
+    const bundle = buildAwfyBundle({
+      awfyDir: tmp,
+      benchmarkName: 'Tiny',
+      moduleName: 'tiny',
+      innerIterations: 2,
+    });
+    assert(!bundle.includes('deliberately invalid'), 'bundle only includes selected dependency graph');
+
+    const bundleFile = path.join(tmp, 'bundle.js');
+    fs.writeFileSync(bundleFile, bundle);
+    const proc = spawnSync(process.execPath, [bundleFile], { encoding: 'utf8' });
+    assertEqual(proc.status, 0, `portable bundle exits cleanly: ${proc.stderr}`);
+    const parsed = parseResult(proc.stdout);
+    assert(parsed !== null, 'portable bundle emits normalized result');
+    assertEqual(parsed.name, 'Tiny', 'portable bundle names benchmark');
+    assertEqual(parsed.verificationPassed, true, 'portable bundle carries verification');
+    assert(proc.stdout.includes(RESULT_MARKER), 'portable bundle uses stable marker');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+console.log(`awfy-driver: ${passed} assertions passed.`);

--- a/scripts/test-awfy-driver.js
+++ b/scripts/test-awfy-driver.js
@@ -14,6 +14,7 @@ const {
   parseResult,
   summarizeSamples,
 } = require('./awfy-driver.js');
+const { MARKER, buildAwfySmokeComment } = require('./awfy-comment.js');
 
 let passed = 0;
 
@@ -114,6 +115,40 @@ console.log('awfy-driver: portable AWFY bundle...');
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
+}
+
+console.log('awfy-driver: PR comment markdown...');
+{
+  const comment = buildAwfySmokeComment({
+    generatedAt: '2026-07-05T00:00:00.000Z',
+    metadata: {
+      driver: { version: 1 },
+      corpus: {
+        awfy: {
+          repository: 'https://github.com/smarr/are-we-fast-yet',
+          commit: '1234567890abcdef1234567890abcdef12345678',
+        },
+      },
+    },
+    targets: [
+      {
+        name: 'NBody',
+        kind: 'awfy',
+        summary: {
+          checksumAgreement: { ok: true, checksums: ['verified'] },
+          engineStats: {
+            goccia: { ok: 1, medianMicros: 1000 },
+            qjs: { ok: 1, medianMicros: 500 },
+            node: { ok: 1, medianMicros: 250 },
+          },
+        },
+      },
+    ],
+    geomeanRatios: { goccia_over_qjs: 2 },
+  });
+  assert(comment.includes(MARKER), 'comment includes stable marker');
+  assert(comment.includes('NBody'), 'comment includes target name');
+  assert(comment.includes('goccia over qjs'), 'comment includes geomean ratio');
 }
 
 console.log(`awfy-driver: ${passed} assertions passed.`);

--- a/scripts/test-awfy-driver.js
+++ b/scripts/test-awfy-driver.js
@@ -43,6 +43,10 @@ console.log('awfy-driver: statistics...');
   assertEqual(summary.ok, 2, 'summary counts ok samples');
   assertEqual(summary.timeout, 1, 'summary counts timeout samples');
   assertEqual(summary.medianMicros, 105, 'summary reports sample median');
+
+  const zeroSummary = summarizeSamples([{ outcome: 'ok', durationMicros: 0 }]);
+  assertEqual(zeroSummary.rawCount, 1, 'summary keeps zero-duration samples visible');
+  assertEqual(zeroSummary.medianMicros, 0, 'summary reports zero-duration sample median');
 }
 
 console.log('awfy-driver: checksum agreement...');
@@ -150,6 +154,8 @@ console.log('awfy-driver: PR comment markdown...');
   assert(comment.includes('NBody'), 'comment includes target name');
   assert(comment.includes('goccia over qjs'), 'comment includes geomean ratio');
   assert(comment.includes('1 pinned AWFY benchmark'), 'comment summarizes AWFY count');
+  assert(!comment.includes('Pinned corpus:'), 'comment omits pin boilerplate');
+  assert(!comment.includes('Generated:'), 'comment omits generated timestamp boilerplate');
 }
 
 console.log(`awfy-driver: ${passed} assertions passed.`);

--- a/scripts/test-awfy-driver.js
+++ b/scripts/test-awfy-driver.js
@@ -149,6 +149,7 @@ console.log('awfy-driver: PR comment markdown...');
   assert(comment.includes(MARKER), 'comment includes stable marker');
   assert(comment.includes('NBody'), 'comment includes target name');
   assert(comment.includes('goccia over qjs'), 'comment includes geomean ratio');
+  assert(comment.includes('1 pinned AWFY benchmark'), 'comment summarizes AWFY count');
 }
 
 console.log(`awfy-driver: ${passed} assertions passed.`);


### PR DESCRIPTION
## Summary

- Add a repo-local AWFY cross-engine driver for GocciaScript bytecode, QuickJS, and Node using pinned upstream benchmark semantics.
- Add `perf/awfy/manifest.json`, a Goccia-owned diagnostic probe corpus, and ADR/docs for the #856/#862 benchmark methodology.
- Add `scripts/awfy-bump-pin.ts` plus `.github/workflows/awfy-bump.yml` so the AWFY SHA pin refreshes through the same automated bump-PR pattern as test262 and TOML.
- Add a pull-request AWFY lane and stable `AWFY Smoke` PR comment for the manifest-defined CI set: all 14 pinned AWFY benchmarks plus one diagnostic probe under Goccia, QuickJS, and Node.
- Pin the PR lane's QuickJS reference shell to official QuickJS `2026-06-04` so CI surfaces comparable QuickJS results instead of distro-package crashes.
- Part of #856; refs #821, #862, #860, #861. This does not close #856 because the issue still needs review of the collected methodology/results before it is considered done.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `node scripts/awfy-driver.js --list`
  - `node scripts/test-awfy-driver.js`
  - AWFY `NBody` smoke under Goccia bytecode, QuickJS, and Node
  - `generic-plus-scalars` probe smoke under Goccia bytecode, QuickJS, and Node
  - CI-shaped AWFY lane from `perf/awfy/manifest.json`: all 14 AWFY benchmarks plus `generic-plus-scalars:1`, `--repetitions 1`, `--timeout-ms 300000`, all engines passing; stricter engine-summary checker verified `goccia`, `qjs`, and `node` medians for every target
  - GitHub PR run `28752454777`: `awfy-smoke` and `awfy-comment` passed; the posted PR comment shows QuickJS values for every target
  - `bun scripts/awfy-bump-pin.ts 74306fec151070fd07157cefeacf19e7e0bcdc89`
  - temp-manifest AWFY pin rewrite smoke
  - `bun run scripts/test-benchmark-compare.ts`
  - `./build.pas --prod loader`
  - `./build.pas testrunner && ./build/GocciaTestRunner tests && ./build/GocciaTestRunner tests --mode=bytecode`
- [x] Updated documentation
  - `bun run scripts/check-doc-links.ts`
  - `bun run scripts/check-doc-length.ts`
  - `bun run scripts/check-doc-symbols.ts`
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - Not run; this PR does not change Pascal source.
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Added diagnostic probes, full pinned AWFY PR coverage, and a PR comment surface; timing claims remain benchmark-methodology output, not a benchmark-regression gate.
  - `./format.pas --check`
  - `git diff --check`
