### PR TITLE
fix(runtime): improve real-world library compatibility

### DIFF
--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -2143,7 +2143,7 @@ end;
 
 function ToNumericValue(const AValue: TGocciaValue): TGocciaValue; inline;
 begin
-  Result := ToPrimitive(AValue);
+  Result := ToPrimitive(AValue, tphNumber);
   if not (Result is TGocciaBigIntValue) then
     Result := Result.ToNumberLiteral;
 end;

--- a/source/units/Goccia.Arguments.Validator.pas
+++ b/source/units/Goccia.Arguments.Validator.pas
@@ -28,7 +28,9 @@ uses
 
 class procedure TGocciaArgumentValidator.RequireExactly(const ACollection: TGocciaArgumentsCollection; const AExpectedCount: Integer; const AFunctionName: string; const AThrowError: TGocciaThrowErrorCallback);
 begin
-  if ACollection.Length <> AExpectedCount then
+  // ECMAScript built-ins ignore extra arguments; this validator enforces the
+  // required positional count for historical fixed-arity call sites.
+  if ACollection.Length < AExpectedCount then
   begin
     if AExpectedCount = 0 then
       AThrowError(Format('%s expects no arguments but got %d', [AFunctionName, ACollection.Length]), 0, 0)
@@ -68,7 +70,14 @@ begin
   if (ACollection.Length < AMinCount) or (ACollection.Length > AMaxCount) then
   begin
     if AMinCount = AMaxCount then
-      RequireExactly(ACollection, AMinCount, AFunctionName, AThrowError)
+    begin
+      if AMinCount = 0 then
+        AThrowError(Format('%s expects no arguments but got %d', [AFunctionName, ACollection.Length]), 0, 0)
+      else if AMinCount = 1 then
+        AThrowError(Format('%s expects 1 argument but got %d', [AFunctionName, ACollection.Length]), 0, 0)
+      else
+        AThrowError(Format('%s expects %d arguments but got %d', [AFunctionName, AMinCount, ACollection.Length]), 0, 0);
+    end
     else
       AThrowError(Format('%s expects between %d and %d arguments but got %d', [AFunctionName, AMinCount, AMaxCount, ACollection.Length]), 0, 0);
   end;

--- a/source/units/Goccia.Arguments.Validator.pas
+++ b/source/units/Goccia.Arguments.Validator.pas
@@ -28,9 +28,7 @@ uses
 
 class procedure TGocciaArgumentValidator.RequireExactly(const ACollection: TGocciaArgumentsCollection; const AExpectedCount: Integer; const AFunctionName: string; const AThrowError: TGocciaThrowErrorCallback);
 begin
-  // ECMAScript built-ins ignore extra arguments; this validator enforces the
-  // required positional count for historical fixed-arity call sites.
-  if ACollection.Length < AExpectedCount then
+  if ACollection.Length <> AExpectedCount then
   begin
     if AExpectedCount = 0 then
       AThrowError(Format('%s expects no arguments but got %d', [AFunctionName, ACollection.Length]), 0, 0)
@@ -70,14 +68,7 @@ begin
   if (ACollection.Length < AMinCount) or (ACollection.Length > AMaxCount) then
   begin
     if AMinCount = AMaxCount then
-    begin
-      if AMinCount = 0 then
-        AThrowError(Format('%s expects no arguments but got %d', [AFunctionName, ACollection.Length]), 0, 0)
-      else if AMinCount = 1 then
-        AThrowError(Format('%s expects 1 argument but got %d', [AFunctionName, ACollection.Length]), 0, 0)
-      else
-        AThrowError(Format('%s expects %d arguments but got %d', [AFunctionName, AMinCount, ACollection.Length]), 0, 0);
-    end
+      RequireExactly(ACollection, AMinCount, AFunctionName, AThrowError)
     else
       AThrowError(Format('%s expects between %d and %d arguments but got %d', [AFunctionName, AMinCount, AMaxCount, ACollection.Length]), 0, 0);
   end;

--- a/source/units/Goccia.Arithmetic.pas
+++ b/source/units/Goccia.Arithmetic.pas
@@ -113,7 +113,7 @@ end;
 
 function ToNumericOperand(const AValue: TGocciaValue): TGocciaValue; inline;
 begin
-  Result := ToPrimitive(AValue);
+  Result := ToPrimitive(AValue, tphNumber);
   if Result is TGocciaSymbolValue then
     ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
   if Result is TGocciaBigIntValue then
@@ -538,7 +538,7 @@ function EvaluateBitwiseNot(const AOperand: TGocciaValue): TGocciaValue;
 var
   PrimOperand: TGocciaValue;
 begin
-  PrimOperand := ToPrimitive(AOperand);
+  PrimOperand := ToPrimitive(AOperand, tphNumber);
   if PrimOperand is TGocciaBigIntValue then
     Exit(TGocciaBigIntValue.Create(
       TGocciaBigIntValue(PrimOperand).Value.BitwiseNot));

--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -255,7 +255,7 @@ var
   Descriptor: TGocciaPropertyDescriptor;
   I: Integer;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.keys', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.keys', ThrowError);
 
   // Step 1: Let obj be ? ToObject(O)
   Obj := ToObject(AArgs.GetElement(0));
@@ -295,7 +295,7 @@ var
   Descriptor: TGocciaPropertyDescriptor;
   I: Integer;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.values', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.values', ThrowError);
 
   // Step 1: Let obj be ? ToObject(O)
   Obj := ToObject(AArgs.GetElement(0));
@@ -336,7 +336,7 @@ var
   Descriptor: TGocciaPropertyDescriptor;
   I: Integer;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.entries', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.entries', ThrowError);
 
   // Step 1: Let obj be ? ToObject(O)
   Obj := ToObject(AArgs.GetElement(0));
@@ -546,7 +546,7 @@ var
   PropertyName: string;
   KeyValue: TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.hasOwn', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Object.hasOwn', ThrowError);
 
   // Step 1: Let obj be ? ToObject(O)
   if AArgs.GetElement(0) is TGocciaClassValue then
@@ -617,7 +617,7 @@ var
   PropertyNames: TArray<string>;
   I: Integer;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.getOwnPropertyNames', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.getOwnPropertyNames', ThrowError);
 
   // Step 1: Let obj be ? ToObject(O)
   Obj := ToObject(AArgs.GetElement(0));
@@ -759,7 +759,7 @@ var
   SymbolKey: TGocciaSymbolValue;
   KeyValue: TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 3, 'Object.defineProperty', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 3, 'Object.defineProperty', ThrowError);
 
   // Step 1: If Type(O) is not Object, throw a TypeError exception
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
@@ -848,7 +848,7 @@ var
     end;
   end;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.defineProperties', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Object.defineProperties', ThrowError);
 
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
     ThrowTypeError(SErrorObjectDefinePropertiesCalledOnNonObject, SSuggestObjectArgType);
@@ -958,7 +958,7 @@ var
   Obj: TGocciaValue;
   TypedArray: TGocciaTypedArrayValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.freeze', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.freeze', ThrowError);
 
   Obj := AArgs.GetElement(0);
 
@@ -988,7 +988,7 @@ end;
 // ES2026 §20.1.2.13 Object.isFrozen(O)
 function TGocciaGlobalObject.ObjectIsFrozen(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.isFrozen', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.isFrozen', ThrowError);
 
   // Step 1: If Type(O) is not Object, return true
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
@@ -1111,7 +1111,7 @@ end;
 // ES2026 §20.1.2.20 Object.seal(O)
 function TGocciaGlobalObject.ObjectSeal(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.seal', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.seal', ThrowError);
 
   // Step 1: If Type(O) is not Object, return O
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
@@ -1129,7 +1129,7 @@ end;
 // ES2026 §20.1.2.15 Object.isSealed(O)
 function TGocciaGlobalObject.ObjectIsSealed(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.isSealed', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.isSealed', ThrowError);
 
   // Step 1: If Type(O) is not Object, return true
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
@@ -1164,7 +1164,7 @@ end;
 // ES2026 §20.1.2.14 Object.isExtensible(O)
 function TGocciaGlobalObject.ObjectIsExtensible(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Object.isExtensible', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Object.isExtensible', ThrowError);
 
   // Step 1: If Type(O) is not Object, return false
   if not (AArgs.GetElement(0) is TGocciaObjectValue) then
@@ -1305,7 +1305,7 @@ var
   I: Integer;
   ItemsRoot, IteratorRoot, CallbackRoot, ResultRoot: TGocciaTempRoot;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Object.groupBy', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Object.groupBy', ThrowError);
 
   Items := AArgs.GetElement(0);
   if not AArgs.GetElement(1).IsCallable then

--- a/source/units/Goccia.Builtins.Math.pas
+++ b/source/units/Goccia.Builtins.Math.pas
@@ -166,7 +166,7 @@ function TGocciaMath.MathAbs(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.abs', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.abs', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -187,7 +187,7 @@ var
   NumberArg: TGocciaNumberLiteralValue;
   IntegralPart: Double;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.floor', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.floor', ThrowError);
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := TGocciaArgumentConverter.GetNumber(AArgs, 0);
   // Step 2: If n is NaN, +∞𝔽, -∞𝔽, return n. Signed-zero is preserved
@@ -215,7 +215,7 @@ var
   NumberArg: TGocciaNumberLiteralValue;
   V: Double;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.ceil', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.ceil', ThrowError);
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := TGocciaArgumentConverter.GetNumber(AArgs, 0);
   // Step 2: If n is NaN, +∞𝔽, -∞𝔽, or an integral Number, return n.
@@ -240,7 +240,7 @@ function TGocciaMath.MathRound(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.round', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.round', ThrowError);
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: If n is NaN, +∞𝔽, -∞𝔽, or an integral Number, return n.
@@ -345,7 +345,7 @@ var
   IntPart: Double;
   ExpIsOddInteger: Boolean;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Math.pow', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Math.pow', ThrowError);
   Base := TGocciaArgumentConverter.GetNumber(AArgs, 0);
   Exponent := TGocciaArgumentConverter.GetNumber(AArgs, 1);
   B := Base.Value;
@@ -457,7 +457,7 @@ function TGocciaMath.MathSqrt(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.sqrt', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sqrt', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -480,7 +480,6 @@ end;
 // §21.3.2.27 Math.random ( )
 function TGocciaMath.MathRandom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  TGocciaArgumentValidator.RequireNone(AArgs, 'Math.random', ThrowError);
   // Step 1: Return a Number value with positive sign, ≥ +0𝔽 and < 1𝔽,
   // chosen randomly with approximately uniform distribution.
   Result := TGocciaNumberLiteralValue.Create(Random);
@@ -491,7 +490,7 @@ function TGocciaMath.MathClamp(const AArgs: TGocciaArgumentsCollection; const AT
 var
   Value, MinVal, MaxVal: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 3, 'Math.clamp', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 3, 'Math.clamp', ThrowError);
 
   // Step 1: Let x be ? ToNumber(x).
   Value := AArgs.GetElement(0).ToNumberLiteral;
@@ -528,7 +527,7 @@ function TGocciaMath.MathSign(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberLiteral: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.sign', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sign', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberLiteral := AArgs.GetElement(0).ToNumberLiteral;
@@ -552,7 +551,7 @@ function TGocciaMath.MathTrunc(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.trunc', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.trunc', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -573,7 +572,7 @@ function TGocciaMath.MathExp(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberLiteral: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.exp', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.exp', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberLiteral := AArgs.GetElement(0).ToNumberLiteral;
@@ -594,7 +593,7 @@ function TGocciaMath.MathLog(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.log', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.log', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -618,7 +617,7 @@ function TGocciaMath.MathLog10(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.log10', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.log10', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -642,7 +641,7 @@ function TGocciaMath.MathSin(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.sin', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sin', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -660,7 +659,7 @@ function TGocciaMath.MathCos(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.cos', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.cos', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -678,7 +677,7 @@ function TGocciaMath.MathTan(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.tan', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.tan', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -696,7 +695,7 @@ function TGocciaMath.MathAcos(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.acos', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.acos', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -717,7 +716,7 @@ function TGocciaMath.MathAsin(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.asin', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.asin', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -738,7 +737,7 @@ function TGocciaMath.MathAtan(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.atan', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.atan', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -760,7 +759,7 @@ function TGocciaMath.MathAtan2(const AArgs: TGocciaArgumentsCollection; const AT
 var
   Y, X: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Math.atan2', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Math.atan2', ThrowError);
 
   // Step 1: Let ny be ? ToNumber(y).
   Y := TGocciaArgumentConverter.GetNumber(AArgs, 0);
@@ -788,7 +787,7 @@ var
   NumberArg: TGocciaNumberLiteralValue;
   SignVal: Double;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.cbrt', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.cbrt', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -813,7 +812,7 @@ function TGocciaMath.MathCosh(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.cosh', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.cosh', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -831,7 +830,7 @@ function TGocciaMath.MathSinh(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.sinh', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sinh', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -851,7 +850,7 @@ function TGocciaMath.MathTanh(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.tanh', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.tanh', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -871,7 +870,7 @@ function TGocciaMath.MathAcosh(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.acosh', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.acosh', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -894,7 +893,7 @@ function TGocciaMath.MathAsinh(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.asinh', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.asinh', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -914,7 +913,7 @@ function TGocciaMath.MathAtanh(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.atanh', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.atanh', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -943,7 +942,7 @@ function TGocciaMath.MathExpm1(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.expm1', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.expm1', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -963,7 +962,7 @@ function TGocciaMath.MathF16round(const AArgs: TGocciaArgumentsCollection; const
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.f16round', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.f16round', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -985,7 +984,7 @@ var
   NumberArg: TGocciaNumberLiteralValue;
   SingleVal: Single;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.fround', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.fround', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -1045,7 +1044,7 @@ var
   X, Y: TGocciaNumberLiteralValue;
   XInt, YInt: LongInt;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Math.imul', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Math.imul', ThrowError);
 
   X := TGocciaArgumentConverter.GetNumber(AArgs, 0);
   Y := TGocciaArgumentConverter.GetNumber(AArgs, 1);
@@ -1069,7 +1068,7 @@ function TGocciaMath.MathLog1p(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.log1p', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.log1p', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -1095,7 +1094,7 @@ function TGocciaMath.MathLog2(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.log2', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.log2', ThrowError);
 
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
@@ -1121,7 +1120,7 @@ var
   Value: LongWord;
   Count: Integer;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.clz32', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.clz32', ThrowError);
 
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 1: Let n be ? ToUint32(x). NaN/±∞ coerce to 0, yielding 32.
@@ -1190,7 +1189,7 @@ var
   Sum, Compensation: Double;
   HasPosInf, HasNegInf, HasNaN, HasAnyValue: Boolean;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'Math.sumPrecise', ThrowError);
+  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sumPrecise', ThrowError);
 
   Iterable := AArgs.GetElement(0);
 

--- a/source/units/Goccia.Builtins.Math.pas
+++ b/source/units/Goccia.Builtins.Math.pas
@@ -1007,24 +1007,36 @@ end;
 // §21.3.2.18 Math.hypot ( ...args )
 function TGocciaMath.MathHypot(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  X, Y: TGocciaNumberLiteralValue;
+  Arg: TGocciaNumberLiteralValue;
+  Accumulator: Double;
+  HasNaN, HasInfinity: Boolean;
+  I: Integer;
 begin
-  TGocciaArgumentValidator.RequireExactly(AArgs, 2, 'Math.hypot', ThrowError);
-
   // Step 1: Let coerced be a new empty List.
   // Step 2: For each element arg of args, append ? ToNumber(arg) to coerced.
-  X := TGocciaArgumentConverter.GetNumber(AArgs, 0);
-  Y := TGocciaArgumentConverter.GetNumber(AArgs, 1);
+  Accumulator := 0;
+  HasNaN := False;
+  HasInfinity := False;
 
-  // Step 3: If any element is NaN, return NaN.
-  if X.IsNaN or Y.IsNaN then
-    Result := TGocciaNumberLiteralValue.NaNValue
-  // Step 4: If any element is ±∞, return +∞𝔽.
-  else if (X.IsInfinity or X.IsNegativeInfinity) or (Y.IsInfinity or Y.IsNegativeInfinity) then
-    Result := TGocciaNumberLiteralValue.InfinityValue
+  for I := 0 to AArgs.Length - 1 do
+  begin
+    Arg := TGocciaArgumentConverter.GetNumber(AArgs, I);
+    if Arg.IsNaN then
+      HasNaN := True
+    else if Arg.IsInfinity or Arg.IsNegativeInfinity then
+      HasInfinity := True
+    else
+      Accumulator := Hypot(Accumulator, Arg.Value);
+  end;
+
+  // Step 3: If any element is ±∞, return +∞𝔽.
+  if HasInfinity then
+    Exit(TGocciaNumberLiteralValue.InfinityValue);
+  // Step 4: If any element is NaN, return NaN.
+  if HasNaN then
+    Exit(TGocciaNumberLiteralValue.NaNValue);
   // Step 5: Return sqrt(sum of squares).
-  else
-    Result := TGocciaNumberLiteralValue.Create(Hypot(X.Value, Y.Value));
+  Result := TGocciaNumberLiteralValue.Create(Accumulator);
 end;
 
 // §21.3.2.19 Math.imul ( x, y )

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -3991,9 +3991,10 @@ var
   PathIdx, NameIdx: UInt16;
   Pair: TStringStringMap.TKeyValuePair;
   Slots: array of UInt8;
+  Captured: array of Boolean;
   Names: array of string;
   EncodedPath: string;
-  HasNamespace: Boolean;
+  HasNamespace, NamespaceCaptured: Boolean;
   I, Count: Integer;
 
   function ImportSlot(const AName: string): UInt8;
@@ -4016,10 +4017,26 @@ var
       ACtx.Scope.MarkImportBinding(LocalIdx, AStmt.Phase, EncodedPath,
         AExportName);
   end;
+
+  function ImportLocalIsCaptured(const AName: string): Boolean;
+  var
+    LocalIdx: Integer;
+  begin
+    LocalIdx := ACtx.Scope.ResolveLocal(AName);
+    Result := (LocalIdx >= 0) and ACtx.Scope.GetLocal(LocalIdx).IsCaptured;
+  end;
+
+  procedure SyncCapturedImportSlot(const ASlot: UInt8; const AIsCaptured: Boolean);
+  begin
+    if AIsCaptured then
+      EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, ASlot, UInt16(ASlot)));
+  end;
 begin
   HasNamespace := AStmt.NamespaceName <> '';
+  NamespaceCaptured := False;
   Count := AStmt.Imports.Count;
   SetLength(Slots, Count);
+  SetLength(Captured, Count);
   SetLength(Names, Count);
   EncodedPath := EncodeImportSpecifierAttribute(AStmt.ModulePath,
     AStmt.AttributeType);
@@ -4028,6 +4045,7 @@ begin
   begin
     NamespaceSlot := ImportSlot(AStmt.NamespaceName);
     MarkImportSlot(AStmt.NamespaceName, '');
+    NamespaceCaptured := ImportLocalIsCaptured(AStmt.NamespaceName);
   end;
 
   I := 0;
@@ -4039,6 +4057,7 @@ begin
       MarkImportSlot(Pair.Key, Pair.Value)
     else
       MarkImportSlot(Pair.Key, '');
+    Captured[I] := ImportLocalIsCaptured(Pair.Key);
     Inc(I);
   end;
 
@@ -4052,12 +4071,18 @@ begin
     EmitInstruction(ACtx, EncodeABx(OP_IMPORT, ModReg, PathIdx));
 
   if HasNamespace then
+  begin
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, NamespaceSlot, ModReg, 0));
+    SyncCapturedImportSlot(NamespaceSlot, NamespaceCaptured);
+  end;
 
   for I := 0 to Count - 1 do
   begin
     if AStmt.Phase = icpSource then
-      EmitInstruction(ACtx, EncodeABC(OP_MOVE, Slots[I], ModReg, 0))
+    begin
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, Slots[I], ModReg, 0));
+      SyncCapturedImportSlot(Slots[I], Captured[I]);
+    end
     else if AStmt.Phase <> icpEvaluation then
     begin
       NameIdx := ACtx.Template.AddConstantString(Names[I]);
@@ -4065,6 +4090,15 @@ begin
         raise Exception.Create('Constant pool overflow: import name index exceeds 255');
       EmitInstruction(ACtx, EncodeABC(OP_GET_PROP_CONST, Slots[I], ModReg,
         UInt8(NameIdx)));
+      SyncCapturedImportSlot(Slots[I], Captured[I]);
+    end
+    else if Captured[I] then
+    begin
+      EmitInstruction(ACtx, EncodeABC(OP_MOVE, Slots[I], ModReg, 0));
+      NameIdx := ACtx.Template.AddConstantString(Names[I]);
+      EmitInstruction(ACtx, EncodeABx(OP_GET_IMPORT_BINDING, Slots[I],
+        NameIdx));
+      SyncCapturedImportSlot(Slots[I], True);
     end;
   end;
 

--- a/source/units/Goccia.Compiler.pas
+++ b/source/units/Goccia.Compiler.pas
@@ -83,7 +83,8 @@ uses
   Goccia.Compiler.Expressions,
   Goccia.Compiler.PatternMatching,
   Goccia.Compiler.Statements,
-  Goccia.Keywords.Reserved;
+  Goccia.Keywords.Reserved,
+  Goccia.Modules;
 
 { TGocciaCompiler }
 
@@ -453,6 +454,8 @@ procedure PredeclareLexicalLocals(const ANode: TGocciaASTNode;
 var
   ImportDecl: TGocciaImportDeclaration;
   ImportPair: TStringStringMap.TKeyValuePair;
+  EncodedPath: string;
+  LocalIdx: Integer;
   VarDecl: TGocciaVariableDeclaration;
   DestructDecl: TGocciaDestructuringDeclaration;
 begin
@@ -516,12 +519,32 @@ begin
   else if ANode is TGocciaImportDeclaration then
   begin
     ImportDecl := TGocciaImportDeclaration(ANode);
+    EncodedPath := EncodeImportSpecifierAttribute(ImportDecl.ModulePath,
+      ImportDecl.AttributeType);
     if (ImportDecl.NamespaceName <> '') and
        (AScope.ResolveLocal(ImportDecl.NamespaceName) < 0) then
       AScope.DeclareLocal(ImportDecl.NamespaceName, True);
+    if ImportDecl.NamespaceName <> '' then
+    begin
+      LocalIdx := AScope.ResolveLocal(ImportDecl.NamespaceName);
+      if LocalIdx >= 0 then
+        AScope.MarkImportBinding(LocalIdx, ImportDecl.Phase, EncodedPath, '');
+    end;
     for ImportPair in ImportDecl.Imports do
+    begin
       if AScope.ResolveLocal(ImportPair.Key) < 0 then
         AScope.DeclareLocal(ImportPair.Key, True);
+      LocalIdx := AScope.ResolveLocal(ImportPair.Key);
+      if LocalIdx >= 0 then
+      begin
+        if ImportDecl.Phase = icpEvaluation then
+          AScope.MarkImportBinding(LocalIdx, ImportDecl.Phase, EncodedPath,
+            ImportPair.Value)
+        else
+          AScope.MarkImportBinding(LocalIdx, ImportDecl.Phase, EncodedPath,
+            '');
+      end;
+    end;
   end;
 end;
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -3530,7 +3530,7 @@ begin
         // their primitive and take the BigInt::unaryMinus path
         // instead of being silently coerced to NaN by the boxed
         // object's ToNumberLiteral.
-        Operand := ToPrimitive(Operand);
+        Operand := ToPrimitive(Operand, tphNumber);
         AddValueRoot(Roots, Operand);
         if Operand is TGocciaSymbolValue then
           ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);
@@ -3568,7 +3568,7 @@ begin
       // BigInt? throw).  Apply ToPrimitive here so boxed BigInts
       // surface the spec-mandated TypeError instead of silently
       // producing a number from the boxed object's coercion path.
-      Operand := ToPrimitive(Operand);
+      Operand := ToPrimitive(Operand, tphNumber);
       AddValueRoot(Roots, Operand);
       if Operand is TGocciaSymbolValue then
         ThrowTypeError(SErrorSymbolToNumber, SSuggestSymbolNoImplicitConversion);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -14360,7 +14360,7 @@ begin
           grkUndefined, grkHole:
             SetRegister(A, TGocciaNumberLiteralValue.NaNValue);
         else
-          LeftValue := ToPrimitive(GetRegisterFast(B));
+          LeftValue := ToPrimitive(GetRegisterFast(B), tphNumber);
           if LeftValue is TGocciaBigIntValue then
             SetRegister(A, TGocciaBigIntValue.Create(
               TGocciaBigIntValue(LeftValue).Value.Add(TBigInteger.One)))
@@ -14384,7 +14384,7 @@ begin
           grkUndefined, grkHole:
             SetRegister(A, TGocciaNumberLiteralValue.NaNValue);
         else
-          LeftValue := ToPrimitive(GetRegisterFast(B));
+          LeftValue := ToPrimitive(GetRegisterFast(B), tphNumber);
           if LeftValue is TGocciaBigIntValue then
             SetRegister(A, TGocciaBigIntValue.Create(
               TGocciaBigIntValue(LeftValue).Value.Subtract(TBigInteger.One)))
@@ -14448,7 +14448,7 @@ begin
             SetRegister(B, TGocciaNumberLiteralValue.NaNValue);
           end;
         else
-          LeftValue := ToPrimitive(GetRegisterFast(B));
+          LeftValue := ToPrimitive(GetRegisterFast(B), tphNumber);
           if LeftValue is TGocciaBigIntValue then
           begin
             SetRegisterFast(A, LeftValue);
@@ -14519,7 +14519,7 @@ begin
             SetRegister(B, TGocciaNumberLiteralValue.NaNValue);
           end;
         else
-          LeftValue := ToPrimitive(GetRegisterFast(B));
+          LeftValue := ToPrimitive(GetRegisterFast(B), tphNumber);
           if LeftValue is TGocciaBigIntValue then
           begin
             SetRegisterFast(A, LeftValue);
@@ -14618,7 +14618,7 @@ begin
           // (Object(1n)) unbox to their primitive and take the
           // BigInt::unaryMinus path; without it the box's
           // ToNumberLiteral coerces to NaN and we lose the BigInt.
-          LeftValue := ToPrimitive(GetRegisterFast(B));
+          LeftValue := ToPrimitive(GetRegisterFast(B), tphNumber);
           if LeftValue is TGocciaBigIntValue then
             SetRegister(A, TGocciaBigIntValue.Create(
               TGocciaBigIntValue(LeftValue).Value.Negate))
@@ -14914,7 +14914,7 @@ begin
           grkUndefined, grkHole:
             FRegisters[A] := RegisterObject(TGocciaNumberLiteralValue.NaNValue);
         else
-          LeftValue := ToPrimitive(GetRegisterFast(B));
+          LeftValue := ToPrimitive(GetRegisterFast(B), tphNumber);
           if LeftValue is TGocciaBigIntValue then
             SetRegisterFast(A, LeftValue)
           else

--- a/tests/built-ins/Array/prototype/map.js
+++ b/tests/built-ins/Array/prototype/map.js
@@ -129,3 +129,7 @@ test("map preserves trailing holes in sparse array", () => {
   expect(0 in result).toBe(true);
   expect(2 in result).toBe(false);
 });
+
+test("map can call standard built-ins that ignore extra callback arguments", () => {
+  expect([1.5, 2.7].map(Math.floor)).toEqual([1, 2]);
+});

--- a/tests/built-ins/Date/constructor.js
+++ b/tests/built-ins/Date/constructor.js
@@ -81,6 +81,15 @@ describe("Date constructor", () => {
     expect(Number(d)).toBe(0);
   });
 
+  test("Date numeric operators use the number primitive hint", () => {
+    const d = new Date(2026, 0, 1);
+    const time = d.valueOf();
+
+    expect(+d).toBe(time);
+    expect(d - 0).toBe(time);
+    expect(0 - d).toBe(-time);
+  });
+
   test("Date UTC string methods are present", () => {
     const d = new Date(0);
     expect(typeof Date.prototype.toUTCString).toBe("function");

--- a/tests/built-ins/Goccia/testing-library.js
+++ b/tests/built-ins/Goccia/testing-library.js
@@ -19,3 +19,16 @@ describe("toBeCloseTo -Infinity precision", () => {
     expect(0.1).toBeCloseTo(99999, -Infinity);
   });
 });
+
+describe("testing library arity validation", () => {
+  test("matchers reject extra arguments", () => {
+    expect(() => expect(1).toBe(1, "unexpected")).toThrow();
+  });
+
+  test("zero-argument matchers reject extra arguments", () => {
+    const fn = mock();
+    fn();
+
+    expect(() => expect(fn).toHaveBeenCalled("unexpected")).toThrow();
+  });
+});

--- a/tests/built-ins/Math/misc.js
+++ b/tests/built-ins/Math/misc.js
@@ -19,6 +19,9 @@ describe("Math miscellaneous methods", () => {
   test("Math.hypot", () => {
     expect(Math.hypot(3, 4)).toBe(5);
     expect(Math.hypot(0, 0)).toBe(0);
+    expect(Math.hypot()).toBe(0);
+    expect(Math.hypot(2, 3, 6)).toBe(7);
+    expect(Math.hypot(Infinity, NaN)).toBe(Infinity);
     expect(Number.isNaN(Math.hypot(NaN, 1))).toBe(true);
   });
 

--- a/tests/built-ins/Math/rounding.js
+++ b/tests/built-ins/Math/rounding.js
@@ -40,3 +40,9 @@ test("Math rounding with zero", () => {
   expect(Math.floor(0)).toBe(0);
   expect(Math.ceil(0)).toBe(0);
 });
+
+test("Math rounding methods ignore extra arguments", () => {
+  expect(Math.floor(1.9, "ignored", {})).toBe(1);
+  expect(Math.ceil(1.1, "ignored", {})).toBe(2);
+  expect(Math.round(1.4, "ignored", {})).toBe(1);
+});

--- a/tests/built-ins/Object/hasOwn.js
+++ b/tests/built-ins/Object/hasOwn.js
@@ -8,6 +8,11 @@ test("Object.hasOwn has the correct function length", () => {
   expect(Object.hasOwn.length).toBe(2);
 });
 
+test("Object.hasOwn ignores extra arguments", () => {
+  const obj = { name: "John" };
+  expect(Object.hasOwn(obj, "name", "ignored")).toBe(true);
+});
+
 test("Object.hasOwn with prototype", () => {
   const obj = Object.create({ name: "John" });
   expect(Object.hasOwn(obj, "name")).toBe(false);

--- a/tests/language/modules/hoisted-function-import-capture/goccia.json
+++ b/tests/language/modules/hoisted-function-import-capture/goccia.json
@@ -1,0 +1,4 @@
+{
+  "source-type": "module",
+  "compat-function": true
+}

--- a/tests/language/modules/hoisted-function-import-capture/helpers/words.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/words.js
@@ -1,0 +1,3 @@
+export function words(value) {
+  return value.split(" ").length;
+}

--- a/tests/language/modules/hoisted-function-import-capture/imported-binding.js
+++ b/tests/language/modules/hoisted-function-import-capture/imported-binding.js
@@ -3,11 +3,16 @@ description: Hoisted function declarations capture initialized imported bindings
 features: [modules, compat-function]
 ---*/
 
-import { words } from "./helpers/words.js";
+import { words, words as nonHoistedWords } from "./helpers/words.js";
 
 const arrow = (value) => words(value);
 const fnExpression = function (value) {
   return words(value);
+};
+
+const nonHoistedArrow = (value) => nonHoistedWords(value);
+const nonHoistedExpression = function (value) {
+  return nonHoistedWords(value);
 };
 
 function fnDeclaration(value) {
@@ -19,5 +24,10 @@ describe("hoisted function declarations capture imported bindings", () => {
     expect(arrow("a b")).toBe(2);
     expect(fnExpression("a b c")).toBe(3);
     expect(fnDeclaration("a b c d")).toBe(4);
+  });
+
+  test("non-hoisted closures capture imports without a hoisted declaration", () => {
+    expect(nonHoistedArrow("a b c d e")).toBe(5);
+    expect(nonHoistedExpression("a b c d e f")).toBe(6);
   });
 });

--- a/tests/language/modules/hoisted-function-import-capture/imported-binding.js
+++ b/tests/language/modules/hoisted-function-import-capture/imported-binding.js
@@ -1,0 +1,23 @@
+/*---
+description: Hoisted function declarations capture initialized imported bindings
+features: [modules, compat-function]
+---*/
+
+import { words } from "./helpers/words.js";
+
+const arrow = (value) => words(value);
+const fnExpression = function (value) {
+  return words(value);
+};
+
+function fnDeclaration(value) {
+  return words(value);
+}
+
+describe("hoisted function declarations capture imported bindings", () => {
+  test("function declarations read imports after module evaluation", () => {
+    expect(arrow("a b")).toBe(2);
+    expect(fnExpression("a b c")).toBe(3);
+    expect(fnDeclaration("a b c d")).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes three validated real-world compatibility gaps: numeric operators now pass the number hint to `ToPrimitive`, standard Object/Math built-ins enforce required arguments while ignoring extra JavaScript arguments, and bytecode import bindings are marked/initialized before hoisted function captures can observe holes.
- Keeps project-owned testing-library arity validation exact, with regressions for matcher and zero-argument matcher extra arguments.
- Makes `Math.hypot` truly variadic while preserving required-argument behavior for under-application.
- Adds focused regressions for Date numeric coercion, Math callback extra arguments, Object extra arguments, variadic `Math.hypot`, testing-library arity, bytecode hoisted function/import capture, and non-hoisted arrow/function-expression import capture without a hoisted declaration.
- Related to #769: this keeps the new default SyntaxError behavior intact while confirming warning recovery remains available.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build.pas testrunner`
  - `./build/GocciaTestRunner tests/language/modules/hoisted-function-import-capture --no-progress --exit-on-first-failure`
  - `./build/GocciaTestRunner tests/language/modules/hoisted-function-import-capture --mode=bytecode --no-progress --exit-on-first-failure`
  - Focused Date/Math/Array/Object/Goccia/module regression runs in interpreted and bytecode modes
  - `./build/GocciaTestRunner tests --no-progress --exit-on-first-failure`
  - `./build/GocciaTestRunner tests --mode=bytecode --no-progress --exit-on-first-failure`
  - #769 smoke: default unsupported `!=` exits with SyntaxError; `--warning-unsupported-features` recovers
  - es-toolkit smoke: clean SyntaxError without `--compat-loose-equality`; loads with `--compat-loose-equality`
- [ ] Updated documentation (not applicable; runtime compatibility is covered by regression tests)
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./build.pas tests`
  - `for t in build/*.Test; do "$t" || exit $?; done`
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Not run; this is a small correctness/compatibility fix outside benchmark-sensitive hot paths.
- [x] Format check
  - `./format.pas --check`