### PR TITLE
feat(benchmarks): add module microbench API

### DIFF
--- a/benchmarks/arraybuffer.js
+++ b/benchmarks/arraybuffer.js
@@ -2,104 +2,98 @@
 description: ArrayBuffer operation benchmarks
 ---*/
 
-suite("ArrayBuffer creation", () => {
-  bench("create ArrayBuffer(0)", {
-    run: () => {
-      const buf = new ArrayBuffer(0);
-    },
+import { bench, group } from "goccia:microbench";
+
+group("ArrayBuffer creation", () => {
+  bench("create ArrayBuffer(0)", () => {
+    const buf = new ArrayBuffer(0);
   });
 
-  bench("create ArrayBuffer(64)", {
-    run: () => {
-      const buf = new ArrayBuffer(64);
-    },
+  bench("create ArrayBuffer(64)", () => {
+    const buf = new ArrayBuffer(64);
   });
 
-  bench("create ArrayBuffer(1024)", {
-    run: () => {
-      const buf = new ArrayBuffer(1024);
-    },
+  bench("create ArrayBuffer(1024)", () => {
+    const buf = new ArrayBuffer(1024);
   });
 
-  bench("create ArrayBuffer(8192)", {
-    run: () => {
-      const buf = new ArrayBuffer(8192);
-    },
+  bench("create ArrayBuffer(8192)", () => {
+    const buf = new ArrayBuffer(8192);
   });
 });
 
-suite("ArrayBuffer.prototype.slice", () => {
-  bench("slice full buffer (64 bytes)", {
-    setup: () => new ArrayBuffer(64),
-    run: (buf) => {
+group("ArrayBuffer.prototype.slice", () => {
+  bench("slice full buffer (64 bytes)", ({ *setup() {
+    const buf = (() => new ArrayBuffer(64))();
+    yield () => {
       const sliced = buf.slice(0);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("slice half buffer (512 of 1024 bytes)", {
-    setup: () => new ArrayBuffer(1024),
-    run: (buf) => {
+  bench("slice half buffer (512 of 1024 bytes)", ({ *setup() {
+    const buf = (() => new ArrayBuffer(1024))();
+    yield () => {
       const sliced = buf.slice(0, 512);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("slice with negative indices", {
-    setup: () => new ArrayBuffer(256),
-    run: (buf) => {
+  bench("slice with negative indices", ({ *setup() {
+    const buf = (() => new ArrayBuffer(256))();
+    yield () => {
       const sliced = buf.slice(-128, -32);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("slice empty range", {
-    setup: () => new ArrayBuffer(1024),
-    run: (buf) => {
+  bench("slice empty range", ({ *setup() {
+    const buf = (() => new ArrayBuffer(1024))();
+    yield () => {
       const sliced = buf.slice(512, 512);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("ArrayBuffer property access", () => {
-  bench("byteLength access", {
-    setup: () => new ArrayBuffer(1024),
-    run: (buf) => {
+group("ArrayBuffer property access", () => {
+  bench("byteLength access", ({ *setup() {
+    const buf = (() => new ArrayBuffer(1024))();
+    yield () => {
       const len = buf.byteLength;
-    },
-  });
+    };
+  } }).setup);
 
-  bench("Symbol.toStringTag access", {
-    setup: () => new ArrayBuffer(64),
-    run: (buf) => {
+  bench("Symbol.toStringTag access", ({ *setup() {
+    const buf = (() => new ArrayBuffer(64))();
+    yield () => {
       const tag = buf[Symbol.toStringTag];
-    },
-  });
+    };
+  } }).setup);
 
-  bench("ArrayBuffer.isView", {
-    setup: () => new ArrayBuffer(64),
-    run: (buf) => {
+  bench("ArrayBuffer.isView", ({ *setup() {
+    const buf = (() => new ArrayBuffer(64))();
+    yield () => {
       const result = ArrayBuffer.isView(buf);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("structuredClone ArrayBuffer", () => {
-  bench("clone ArrayBuffer(64)", {
-    setup: () => new ArrayBuffer(64),
-    run: (buf) => {
+group("structuredClone ArrayBuffer", () => {
+  bench("clone ArrayBuffer(64)", ({ *setup() {
+    const buf = (() => new ArrayBuffer(64))();
+    yield () => {
       const clone = structuredClone(buf);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("clone ArrayBuffer(1024)", {
-    setup: () => new ArrayBuffer(1024),
-    run: (buf) => {
+  bench("clone ArrayBuffer(1024)", ({ *setup() {
+    const buf = (() => new ArrayBuffer(1024))();
+    yield () => {
       const clone = structuredClone(buf);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("clone ArrayBuffer inside object", {
-    setup: () => ({ buffer: new ArrayBuffer(256), name: "test" }),
-    run: (obj) => {
+  bench("clone ArrayBuffer inside object", ({ *setup() {
+    const obj = (() => ({ buffer: new ArrayBuffer(256), name: "test" }))();
+    yield () => {
       const clone = structuredClone(obj);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/arrays.js
+++ b/benchmarks/arrays.js
@@ -66,10 +66,12 @@ group("array transformation", () => {
 });
 
 group("nested callbacks", () => {
-  bench("map inside map (5x5)", () => {
-    const matrix = [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20], [21, 22, 23, 24, 25]];
-    const result = matrix.map((row) => row.map((x) => x * 2));
-  });
+  bench("map inside map (5x5)", ({ *setup() {
+    const matrix = (() => [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20], [21, 22, 23, 24, 25]])();
+    yield () => {
+      const result = matrix.map((row) => row.map((x) => x * 2));
+    };
+  } }).setup);
 
   bench("filter inside map (5x10)", ({ *setup() {
     const data = (() => Array.from({ length: 5 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)))();

--- a/benchmarks/arrays.js
+++ b/benchmarks/arrays.js
@@ -2,139 +2,115 @@
 description: Array operation benchmarks
 ---*/
 
-suite("array creation", () => {
-  bench("Array.from length 100", {
-    run: () => {
-      const arr = Array.from({ length: 100 }, (_, i) => i);
-    },
+import { bench, group } from "goccia:microbench";
+
+group("array creation", () => {
+  bench("Array.from length 100", () => {
+    const arr = Array.from({ length: 100 }, (_, i) => i);
   });
 
-  bench("Array.from 10 elements", {
-    run: () => {
-      const arr = Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    },
+  bench("Array.from 10 elements", () => {
+    const arr = Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   });
 
-  bench("Array.of 10 elements", {
-    run: () => {
-      const arr = Array.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    },
+  bench("Array.of 10 elements", () => {
+    const arr = Array.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   });
 
-  bench("spread into new array", {
-    run: () => {
-      const source = [1, 2, 3, 4, 5];
-      const copy = [...source, ...source];
-    },
+  bench("spread into new array", () => {
+    const source = [1, 2, 3, 4, 5];
+    const copy = [...source, ...source];
   });
 });
 
-suite("array iteration", () => {
+group("array iteration", () => {
   const arr50 = Array.from({ length: 50 }, (_, i) => i);
 
-  bench("map over 50 elements", {
-    run: () => {
-      const doubled = arr50.map((x) => x * 2);
-    },
+  bench("map over 50 elements", () => {
+    const doubled = arr50.map((x) => x * 2);
   });
 
-  bench("filter over 50 elements", {
-    run: () => {
-      const evens = arr50.filter((x) => x % 2 === 0);
-    },
+  bench("filter over 50 elements", () => {
+    const evens = arr50.filter((x) => x % 2 === 0);
   });
 
-  bench("reduce sum 50 elements", {
-    run: () => {
-      const sum = arr50.reduce((acc, x) => acc + x, 0);
-    },
+  bench("reduce sum 50 elements", () => {
+    const sum = arr50.reduce((acc, x) => acc + x, 0);
   });
 
-  bench("forEach over 50 elements", {
-    run: () => {
-      let count = 0;
-      arr50.forEach((x) => { count = count + 1; });
-    },
+  bench("forEach over 50 elements", () => {
+    let count = 0;
+    arr50.forEach((x) => { count = count + 1; });
   });
 
-  bench("find in 50 elements", {
-    run: () => {
-      const found = arr50.find((x) => x === 42);
-    },
+  bench("find in 50 elements", () => {
+    const found = arr50.find((x) => x === 42);
   });
 });
 
-suite("array transformation", () => {
-  bench("sort 20 elements", {
-    run: () => {
-      const arr = [15, 3, 8, 1, 19, 7, 12, 4, 17, 2, 11, 6, 14, 9, 20, 5, 16, 10, 13, 18];
-      const sorted = arr.toSorted((a, b) => a - b);
-    },
+group("array transformation", () => {
+  bench("sort 20 elements", () => {
+    const arr = [15, 3, 8, 1, 19, 7, 12, 4, 17, 2, 11, 6, 14, 9, 20, 5, 16, 10, 13, 18];
+    const sorted = arr.toSorted((a, b) => a - b);
   });
 
-  bench("flat nested array", {
-    run: () => {
-      const arr = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]];
-      const flat = arr.flat();
-    },
+  bench("flat nested array", () => {
+    const arr = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]];
+    const flat = arr.flat();
   });
 
-  bench("flatMap", {
-    run: () => {
-      const arr = [1, 2, 3, 4, 5];
-      const result = arr.flatMap((x) => [x, x * 2]);
-    },
+  bench("flatMap", () => {
+    const arr = [1, 2, 3, 4, 5];
+    const result = arr.flatMap((x) => [x, x * 2]);
   });
 });
 
-suite("nested callbacks", () => {
-  bench("map inside map (5x5)", {
-    run: () => {
-      const matrix = [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20], [21, 22, 23, 24, 25]];
-      const result = matrix.map((row) => row.map((x) => x * 2));
-    },
+group("nested callbacks", () => {
+  bench("map inside map (5x5)", () => {
+    const matrix = [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20], [21, 22, 23, 24, 25]];
+    const result = matrix.map((row) => row.map((x) => x * 2));
   });
 
-  bench("filter inside map (5x10)", {
-    setup: () => Array.from({ length: 5 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)),
-    run: (data) => {
+  bench("filter inside map (5x10)", ({ *setup() {
+    const data = (() => Array.from({ length: 5 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)))();
+    yield () => {
       const result = data.map((row) => row.filter((x) => x % 2 === 0));
-    },
-  });
+    };
+  } }).setup);
 
-  bench("reduce inside map (5x10)", {
-    setup: () => Array.from({ length: 5 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)),
-    run: (data) => {
+  bench("reduce inside map (5x10)", ({ *setup() {
+    const data = (() => Array.from({ length: 5 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)))();
+    yield () => {
       const sums = data.map((row) => row.reduce((a, b) => a + b, 0));
-    },
-  });
+    };
+  } }).setup);
 
-  bench("forEach inside forEach (5x10)", {
-    setup: () => Array.from({ length: 5 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)),
-    run: (matrix) => {
+  bench("forEach inside forEach (5x10)", ({ *setup() {
+    const matrix = (() => Array.from({ length: 5 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)))();
+    yield () => {
       let sum = 0;
       matrix.forEach((row) => { row.forEach((x) => { sum = sum + x; }); });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("find inside some (10x10)", {
-    setup: () => Array.from({ length: 10 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)),
-    run: (groups) => {
+  bench("find inside some (10x10)", ({ *setup() {
+    const groups = (() => Array.from({ length: 10 }, (_, i) => Array.from({ length: 10 }, (_, j) => i * 10 + j)))();
+    yield () => {
       const found = groups.some((g) => g.find((x) => x === 77) !== undefined);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("map+filter chain nested (5x20)", {
-    setup: () => Array.from({ length: 5 }, (_, i) => Array.from({ length: 20 }, (_, j) => i * 20 + j)),
-    run: (data) => {
+  bench("map+filter chain nested (5x20)", ({ *setup() {
+    const data = (() => Array.from({ length: 5 }, (_, i) => Array.from({ length: 20 }, (_, j) => i * 20 + j)))();
+    yield () => {
       const result = data.map((row) => row.map((x) => x * 3).filter((x) => x % 2 === 0));
-    },
-  });
+    };
+  } }).setup);
 
-  bench("reduce flatten (10x5)", {
-    setup: () => Array.from({ length: 10 }, (_, i) => Array.from({ length: 5 }, (_, j) => i * 5 + j)),
-    run: (matrix) => {
+  bench("reduce flatten (10x5)", ({ *setup() {
+    const matrix = (() => Array.from({ length: 10 }, (_, i) => Array.from({ length: 5 }, (_, j) => i * 5 + j)))();
+    yield () => {
       const flat = matrix.reduce((acc, row) => [...acc, ...row], []);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/async-await.js
+++ b/benchmarks/async-await.js
@@ -2,51 +2,41 @@
 description: async/await benchmarks
 ---*/
 
-suite("async/await", () => {
-  bench("single await", {
-    run: async () => {
+import { bench, group } from "goccia:microbench";
+
+group("async/await", () => {
+  bench("single await", async () => {
+    const val = await Promise.resolve(42);
+  });
+
+  bench("multiple awaits", async () => {
+    const a = await Promise.resolve(1);
+    const b = await Promise.resolve(2);
+    const c = await Promise.resolve(3);
+  });
+
+  bench("await non-Promise value", async () => {
+    const val = await 42;
+  });
+
+  bench("await with try/catch", async () => {
+    try {
       const val = await Promise.resolve(42);
-    },
+    } catch (e) {
+      // unreachable
+    }
   });
 
-  bench("multiple awaits", {
-    run: async () => {
-      const a = await Promise.resolve(1);
-      const b = await Promise.resolve(2);
-      const c = await Promise.resolve(3);
-    },
+  bench("await Promise.all", async () => {
+    const result = await Promise.all([
+      Promise.resolve(1),
+      Promise.resolve(2),
+      Promise.resolve(3)
+    ]);
   });
 
-  bench("await non-Promise value", {
-    run: async () => {
-      const val = await 42;
-    },
-  });
-
-  bench("await with try/catch", {
-    run: async () => {
-      try {
-        const val = await Promise.resolve(42);
-      } catch (e) {
-        // unreachable
-      }
-    },
-  });
-
-  bench("await Promise.all", {
-    run: async () => {
-      const result = await Promise.all([
-        Promise.resolve(1),
-        Promise.resolve(2),
-        Promise.resolve(3)
-      ]);
-    },
-  });
-
-  bench("nested async function call", {
-    run: async () => {
-      const inner = async () => await Promise.resolve(42);
-      const val = await inner();
-    },
+  bench("nested async function call", async () => {
+    const inner = async () => await Promise.resolve(42);
+    const val = await inner();
   });
 });

--- a/benchmarks/async-generators.js
+++ b/benchmarks/async-generators.js
@@ -2,7 +2,9 @@
 description: Async generator benchmarks
 ---*/
 
-suite("async generators", () => {
+import { bench, group } from "goccia:microbench";
+
+group("async generators", () => {
   const values = Array.from({ length: 25 }, (_, i) => i);
 
   const source = {
@@ -15,23 +17,19 @@ suite("async generators", () => {
     },
   };
 
-  bench("for-await-of over async generator", {
-    run: async () => {
-      let sum = 0;
-      for await (const value of source.values()) {
-        sum = sum + value;
-      }
-      return sum;
-    },
+  bench("for-await-of over async generator", async () => {
+    let sum = 0;
+    for await (const value of source.values()) {
+      sum = sum + value;
+    }
+    return sum;
   });
 
-  bench("async generator with await in body", {
-    run: async () => {
-      let sum = 0;
-      for await (const value of source.awaitedValues()) {
-        sum = sum + value;
-      }
-      return sum;
-    },
+  bench("async generator with await in body", async () => {
+    let sum = 0;
+    for await (const value of source.awaitedValues()) {
+      sum = sum + value;
+    }
+    return sum;
   });
 });

--- a/benchmarks/atomics.js
+++ b/benchmarks/atomics.js
@@ -2,65 +2,67 @@
 description: Atomics and SharedArrayBuffer operation benchmarks
 ---*/
 
-suite("Atomics integer operations", () => {
-  bench("load and store Int32Array", {
-    setup: () => new Int32Array(new SharedArrayBuffer(4)),
-    run: (view) => {
+import { bench, group } from "goccia:microbench";
+
+group("Atomics integer operations", () => {
+  bench("load and store Int32Array", ({ *setup() {
+    const view = (() => new Int32Array(new SharedArrayBuffer(4)))();
+    yield () => {
       Atomics.store(view, 0, 41);
       const value = Atomics.load(view, 0);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("read-modify-write Int32Array", {
-    setup: () => new Int32Array(new SharedArrayBuffer(4)),
-    run: (view) => {
+  bench("read-modify-write Int32Array", ({ *setup() {
+    const view = (() => new Int32Array(new SharedArrayBuffer(4)))();
+    yield () => {
       Atomics.add(view, 0, 1);
       Atomics.sub(view, 0, 1);
       Atomics.exchange(view, 0, 7);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("compareExchange hit and miss", {
-    setup: () => {
+  bench("compareExchange hit and miss", ({ *setup() {
+    const view = (() => {
       const view = new Int32Array(new SharedArrayBuffer(4));
       view[0] = 1;
       return view;
-    },
-    run: (view) => {
+    })();
+    yield () => {
       Atomics.compareExchange(view, 0, 1, 2);
       Atomics.compareExchange(view, 0, 1, 3);
       Atomics.compareExchange(view, 0, 2, 1);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Atomics wait and notify", () => {
-  bench("wait with zero timeout", {
-    setup: () => {
+group("Atomics wait and notify", () => {
+  bench("wait with zero timeout", ({ *setup() {
+    const view = (() => {
       const view = new Int32Array(new SharedArrayBuffer(4));
       view[0] = 1;
       return view;
-    },
-    run: (view) => {
+    })();
+    yield () => {
       const result = Atomics.wait(view, 0, 1, 0);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("waitAsync synchronous not-equal", {
-    setup: () => {
+  bench("waitAsync synchronous not-equal", ({ *setup() {
+    const view = (() => {
       const view = new Int32Array(new SharedArrayBuffer(4));
       view[0] = 1;
       return view;
-    },
-    run: (view) => {
+    })();
+    yield () => {
       const result = Atomics.waitAsync(view, 0, 2, 10);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("notify with no waiters", {
-    setup: () => new Int32Array(new SharedArrayBuffer(4)),
-    run: (view) => {
+  bench("notify with no waiters", ({ *setup() {
+    const view = (() => new Int32Array(new SharedArrayBuffer(4)))();
+    yield () => {
       const count = Atomics.notify(view, 0, 1);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/base64.js
+++ b/benchmarks/base64.js
@@ -2,6 +2,8 @@
 description: Base64 encoding and decoding benchmarks (btoa/atob)
 ---*/
 
+import { bench, group } from "goccia:microbench";
+
 const SHORT_ASCII = "Hello, World!";
 const MEDIUM_ASCII = "The quick brown fox jumps over the lazy dog. ".repeat(10);
 const LATIN1 = String.fromCharCode(0x00, 0x41, 0x80, 0xC0, 0xFF, 0xA9, 0xBE, 0x7F);
@@ -10,68 +12,48 @@ const SHORT_B64 = btoa(SHORT_ASCII);
 const MEDIUM_B64 = btoa(MEDIUM_ASCII);
 const LATIN1_B64 = btoa(LATIN1);
 
-suite("btoa", () => {
-  bench("short ASCII (13 chars)", {
-    run: () => {
-      btoa(SHORT_ASCII);
-    },
+group("btoa", () => {
+  bench("short ASCII (13 chars)", () => {
+    btoa(SHORT_ASCII);
   });
 
-  bench("medium ASCII (450 chars)", {
-    run: () => {
-      btoa(MEDIUM_ASCII);
-    },
+  bench("medium ASCII (450 chars)", () => {
+    btoa(MEDIUM_ASCII);
   });
 
-  bench("Latin-1 characters", {
-    run: () => {
-      btoa(LATIN1);
-    },
+  bench("Latin-1 characters", () => {
+    btoa(LATIN1);
   });
 });
 
-suite("atob", () => {
-  bench("short base64 (20 chars)", {
-    run: () => {
-      atob(SHORT_B64);
-    },
+group("atob", () => {
+  bench("short base64 (20 chars)", () => {
+    atob(SHORT_B64);
   });
 
-  bench("medium base64 (600 chars)", {
-    run: () => {
-      atob(MEDIUM_B64);
-    },
+  bench("medium base64 (600 chars)", () => {
+    atob(MEDIUM_B64);
   });
 
-  bench("Latin-1 output", {
-    run: () => {
-      atob(LATIN1_B64);
-    },
+  bench("Latin-1 output", () => {
+    atob(LATIN1_B64);
   });
 
-  bench("forgiving (no padding)", {
-    run: () => {
-      atob("SGVsbG8");
-    },
+  bench("forgiving (no padding)", () => {
+    atob("SGVsbG8");
   });
 
-  bench("with whitespace", {
-    run: () => {
-      atob("SGVs bG8s\nIFdv\tcmxk IQ==");
-    },
+  bench("with whitespace", () => {
+    atob("SGVs bG8s\nIFdv\tcmxk IQ==");
   });
 });
 
-suite("round-trip", () => {
-  bench("atob(btoa(short))", {
-    run: () => {
-      atob(btoa(SHORT_ASCII));
-    },
+group("round-trip", () => {
+  bench("atob(btoa(short))", () => {
+    atob(btoa(SHORT_ASCII));
   });
 
-  bench("atob(btoa(medium))", {
-    run: () => {
-      atob(btoa(MEDIUM_ASCII));
-    },
+  bench("atob(btoa(medium))", () => {
+    atob(btoa(MEDIUM_ASCII));
   });
 });

--- a/benchmarks/classes.js
+++ b/benchmarks/classes.js
@@ -2,464 +2,404 @@
 description: Class operation benchmarks
 ---*/
 
-suite("class instantiation", () => {
-  bench("simple class new", {
-    run: () => {
-      class Point {
-        constructor(x, y) {
-          this.x = x;
-          this.y = y;
-        }
+import { bench, group } from "goccia:microbench";
+
+group("class instantiation", () => {
+  bench("simple class new", () => {
+    class Point {
+      constructor(x, y) {
+        this.x = x;
+        this.y = y;
       }
-      const p = new Point(1, 2);
-    },
+    }
+    const p = new Point(1, 2);
   });
 
-  bench("class with defaults", {
-    run: () => {
-      class Config {
-        constructor(opts) {
-          this.host = opts.host;
-          this.port = opts.port;
-          this.debug = false;
-          this.retries = 3;
-        }
+  bench("class with defaults", () => {
+    class Config {
+      constructor(opts) {
+        this.host = opts.host;
+        this.port = opts.port;
+        this.debug = false;
+        this.retries = 3;
       }
-      const c = new Config({ host: "localhost", port: 8080 });
-    },
+    }
+    const c = new Config({ host: "localhost", port: 8080 });
   });
 
-  bench("50 instances via Array.from", {
-    run: () => {
-      class Item {
-        constructor(id) {
-          this.id = id;
-          this.active = true;
-        }
+  bench("50 instances via Array.from", () => {
+    class Item {
+      constructor(id) {
+        this.id = id;
+        this.active = true;
       }
-      const items = Array.from({ length: 50 }, (_, i) => new Item(i));
-    },
+    }
+    const items = Array.from({ length: 50 }, (_, i) => new Item(i));
   });
 });
 
-suite("method dispatch", () => {
-  bench("instance method call", {
-    run: () => {
-      class Counter {
-        constructor() { this.count = 0; }
-        increment() { this.count = this.count + 1; }
-        get value() { return this.count; }
-      }
-      const c = new Counter();
-      c.increment();
-      c.increment();
-      c.increment();
-      const v = c.value;
-    },
+group("method dispatch", () => {
+  bench("instance method call", () => {
+    class Counter {
+      constructor() { this.count = 0; }
+      increment() { this.count = this.count + 1; }
+      get value() { return this.count; }
+    }
+    const c = new Counter();
+    c.increment();
+    c.increment();
+    c.increment();
+    const v = c.value;
   });
 
-  bench("static method call", {
-    run: () => {
-      class MathHelper {
-        static square(x) { return x * x; }
-        static cube(x) { return x * x * x; }
-      }
-      const a = MathHelper.square(7);
-      const b = MathHelper.cube(3);
-    },
+  bench("static method call", () => {
+    class MathHelper {
+      static square(x) { return x * x; }
+      static cube(x) { return x * x * x; }
+    }
+    const a = MathHelper.square(7);
+    const b = MathHelper.cube(3);
   });
 });
 
-suite("inheritance", () => {
-  bench("single-level inheritance", {
-    run: () => {
-      class Shape {
-        constructor(name) { this.name = name; }
-        describe() { return this.name; }
+group("inheritance", () => {
+  bench("single-level inheritance", () => {
+    class Shape {
+      constructor(name) { this.name = name; }
+      describe() { return this.name; }
+    }
+    class Circle extends Shape {
+      constructor(radius) {
+        super("circle");
+        this.radius = radius;
       }
-      class Circle extends Shape {
-        constructor(radius) {
-          super("circle");
-          this.radius = radius;
+      area() { return 3.14159 * this.radius * this.radius; }
+    }
+    const c = new Circle(5);
+    const a = c.area();
+    const d = c.describe();
+  });
+
+  bench("two-level inheritance", () => {
+    class Animal {
+      constructor(name) { this.name = name; }
+      speak() { return this.name; }
+    }
+    class Dog extends Animal {
+      constructor(name, breed) {
+        super(name);
+        this.breed = breed;
+      }
+    }
+    class Poodle extends Dog {
+      constructor(name) {
+        super(name, "poodle");
+        this.groomed = false;
+      }
+    }
+    const p = new Poodle("Max");
+    const s = p.speak();
+  });
+});
+
+group("private fields", () => {
+  bench("private field access", () => {
+    class Wallet {
+      #balance = 0;
+      deposit(amount) { this.#balance = this.#balance + amount; }
+      get balance() { return this.#balance; }
+    }
+    const w = new Wallet();
+    w.deposit(100);
+    w.deposit(50);
+    const b = w.balance;
+  });
+
+  bench("private methods", () => {
+    class Validator {
+      #value;
+      constructor(v) { this.#value = v; }
+      #isPositive() { return this.#value > 0; }
+      validate() { return this.#isPositive(); }
+    }
+    const v = new Validator(42);
+    const ok = v.validate();
+  });
+});
+
+group("getters and setters", () => {
+  bench("getter/setter access", () => {
+    class Temperature {
+      constructor(c) { this.celsius = c; }
+      get fahrenheit() { return this.celsius * 9 / 5 + 32; }
+      set fahrenheit(f) { this.celsius = (f - 32) * 5 / 9; }
+    }
+    const t = new Temperature(100);
+    const f = t.fahrenheit;
+    t.fahrenheit = 72;
+  });
+});
+
+group("decorators: class", () => {
+  bench("class decorator (identity)", () => {
+    const noop = (cls, context) => cls;
+
+    @noop
+    class C {
+      value = 1;
+    }
+    const c = new C();
+  });
+
+  bench("class decorator (wrapping)", () => {
+    const wrap = (cls, context) => {
+      return class extends cls {
+        constructor(...args) {
+          super(...args);
+          this.wrapped = true;
         }
-        area() { return 3.14159 * this.radius * this.radius; }
-      }
-      const c = new Circle(5);
-      const a = c.area();
-      const d = c.describe();
-    },
-  });
+      };
+    };
 
-  bench("two-level inheritance", {
-    run: () => {
-      class Animal {
-        constructor(name) { this.name = name; }
-        speak() { return this.name; }
-      }
-      class Dog extends Animal {
-        constructor(name, breed) {
-          super(name);
-          this.breed = breed;
-        }
-      }
-      class Poodle extends Dog {
-        constructor(name) {
-          super(name, "poodle");
-          this.groomed = false;
-        }
-      }
-      const p = new Poodle("Max");
-      const s = p.speak();
-    },
+    @wrap
+    class C {
+      constructor() { this.x = 1; }
+    }
+    const c = new C();
   });
 });
 
-suite("private fields", () => {
-  bench("private field access", {
-    run: () => {
-      class Wallet {
-        #balance = 0;
-        deposit(amount) { this.#balance = this.#balance + amount; }
-        get balance() { return this.#balance; }
-      }
-      const w = new Wallet();
-      w.deposit(100);
-      w.deposit(50);
-      const b = w.balance;
-    },
-  });
+group("decorators: method", () => {
+  bench("identity method decorator", () => {
+    const noop = (method, context) => method;
 
-  bench("private methods", {
-    run: () => {
-      class Validator {
-        #value;
-        constructor(v) { this.#value = v; }
-        #isPositive() { return this.#value > 0; }
-        validate() { return this.#isPositive(); }
-      }
-      const v = new Validator(42);
-      const ok = v.validate();
-    },
-  });
-});
-
-suite("getters and setters", () => {
-  bench("getter/setter access", {
-    run: () => {
-      class Temperature {
-        constructor(c) { this.celsius = c; }
-        get fahrenheit() { return this.celsius * 9 / 5 + 32; }
-        set fahrenheit(f) { this.celsius = (f - 32) * 5 / 9; }
-      }
-      const t = new Temperature(100);
-      const f = t.fahrenheit;
-      t.fahrenheit = 72;
-    },
-  });
-});
-
-suite("decorators: class", () => {
-  bench("class decorator (identity)", {
-    run: () => {
-      const noop = (cls, context) => cls;
-
+    class C {
       @noop
-      class C {
-        value = 1;
-      }
-      const c = new C();
-    },
+      greet() { return "hello"; }
+    }
+    const c = new C();
+    const v = c.greet();
   });
 
-  bench("class decorator (wrapping)", {
-    run: () => {
-      const wrap = (cls, context) => {
-        return class extends cls {
-          constructor(...args) {
-            super(...args);
-            this.wrapped = true;
-          }
-        };
-      };
+  bench("wrapping method decorator", () => {
+    const logged = (method, context) => {
+      return (...args) => method(...args);
+    };
 
-      @wrap
-      class C {
-        constructor() { this.x = 1; }
-      }
-      const c = new C();
-    },
-  });
-});
-
-suite("decorators: method", () => {
-  bench("identity method decorator", {
-    run: () => {
-      const noop = (method, context) => method;
-
-      class C {
-        @noop
-        greet() { return "hello"; }
-      }
-      const c = new C();
-      const v = c.greet();
-    },
+    class C {
+      @logged
+      compute(x) { return x * 2; }
+    }
+    const c = new C();
+    const v = c.compute(5);
   });
 
-  bench("wrapping method decorator", {
-    run: () => {
-      const logged = (method, context) => {
-        return (...args) => method(...args);
-      };
+  bench("stacked method decorators (x3)", () => {
+    const d1 = (method, context) => method;
+    const d2 = (method, context) => method;
+    const d3 = (method, context) => method;
 
-      class C {
-        @logged
-        compute(x) { return x * 2; }
-      }
-      const c = new C();
-      const v = c.compute(5);
-    },
-  });
-
-  bench("stacked method decorators (x3)", {
-    run: () => {
-      const d1 = (method, context) => method;
-      const d2 = (method, context) => method;
-      const d3 = (method, context) => method;
-
-      class C {
-        @d1 @d2 @d3
-        run() { return 42; }
-      }
-      const c = new C();
-      const v = c.run();
-    },
+    class C {
+      @d1 @d2 @d3
+      run() { return 42; }
+    }
+    const c = new C();
+    const v = c.run();
   });
 });
 
-suite("decorators: field", () => {
-  bench("identity field decorator", {
-    run: () => {
-      const noop = (value, context) => {};
+group("decorators: field", () => {
+  bench("identity field decorator", () => {
+    const noop = (value, context) => {};
 
-      class C {
-        @noop
-        x = 10;
-      }
-      const c = new C();
-    },
+    class C {
+      @noop
+      x = 10;
+    }
+    const c = new C();
   });
 
-  bench("field initializer decorator", {
-    run: () => {
-      const double = (value, context) => {
-        return (initialValue) => initialValue * 2;
-      };
+  bench("field initializer decorator", () => {
+    const double = (value, context) => {
+      return (initialValue) => initialValue * 2;
+    };
 
-      class C {
-        @double
-        x = 5;
-      }
-      const c = new C();
-    },
+    class C {
+      @double
+      x = 5;
+    }
+    const c = new C();
   });
 });
 
-suite("decorators: getter/setter", () => {
-  bench("getter decorator (identity)", {
-    run: () => {
-      const noop = (getter, context) => getter;
+group("decorators: getter/setter", () => {
+  bench("getter decorator (identity)", () => {
+    const noop = (getter, context) => getter;
 
-      class C {
-        #val = 42;
-        @noop
-        get value() { return this.#val; }
-      }
-      const c = new C();
-      const v = c.value;
-    },
+    class C {
+      #val = 42;
+      @noop
+      get value() { return this.#val; }
+    }
+    const c = new C();
+    const v = c.value;
   });
 
-  bench("setter decorator (identity)", {
-    run: () => {
-      const noop = (setter, context) => setter;
+  bench("setter decorator (identity)", () => {
+    const noop = (setter, context) => setter;
 
-      class C {
-        #val = 0;
-        get value() { return this.#val; }
-        @noop
-        set value(v) { this.#val = v; }
-      }
-      const c = new C();
-      c.value = 99;
-      const v = c.value;
-    },
+    class C {
+      #val = 0;
+      get value() { return this.#val; }
+      @noop
+      set value(v) { this.#val = v; }
+    }
+    const c = new C();
+    c.value = 99;
+    const v = c.value;
   });
 });
 
-suite("decorators: static", () => {
-  bench("static method decorator", {
-    run: () => {
-      const noop = (method, context) => method;
+group("decorators: static", () => {
+  bench("static method decorator", () => {
+    const noop = (method, context) => method;
 
-      class C {
-        @noop
-        static compute(x) { return x + 1; }
-      }
-      const v = C.compute(10);
-    },
+    class C {
+      @noop
+      static compute(x) { return x + 1; }
+    }
+    const v = C.compute(10);
   });
 
-  bench("static field decorator", {
-    run: () => {
-      const noop = (value, context) => {};
+  bench("static field decorator", () => {
+    const noop = (value, context) => {};
 
-      class C {
-        @noop
-        static label = "hello";
-      }
-      const v = C.label;
-    },
+    class C {
+      @noop
+      static label = "hello";
+    }
+    const v = C.label;
   });
 });
 
-suite("decorators: private", () => {
-  bench("private method decorator", {
-    run: () => {
-      const noop = (method, context) => method;
+group("decorators: private", () => {
+  bench("private method decorator", () => {
+    const noop = (method, context) => method;
 
-      class C {
-        @noop
-        #compute(x) { return x * 3; }
-        run(x) { return this.#compute(x); }
-      }
-      const c = new C();
-      const v = c.run(7);
-    },
+    class C {
+      @noop
+      #compute(x) { return x * 3; }
+      run(x) { return this.#compute(x); }
+    }
+    const c = new C();
+    const v = c.run(7);
   });
 
-  bench("private field decorator", {
-    run: () => {
-      const noop = (value, context) => {};
+  bench("private field decorator", () => {
+    const noop = (value, context) => {};
 
-      class C {
-        @noop
-        #secret = 42;
-        get secret() { return this.#secret; }
-      }
-      const c = new C();
-      const v = c.secret;
-    },
+    class C {
+      @noop
+      #secret = 42;
+      get secret() { return this.#secret; }
+    }
+    const c = new C();
+    const v = c.secret;
   });
 });
 
-suite("decorators: auto-accessor", () => {
-  bench("plain auto-accessor (no decorator)", {
-    run: () => {
-      class C {
-        accessor name = "world";
-      }
-      const c = new C();
-      const v = c.name;
-      c.name = "updated";
-    },
+group("decorators: auto-accessor", () => {
+  bench("plain auto-accessor (no decorator)", () => {
+    class C {
+      accessor name = "world";
+    }
+    const c = new C();
+    const v = c.name;
+    c.name = "updated";
   });
 
-  bench("auto-accessor with decorator", {
-    run: () => {
-      const noop = (value, context) => value;
+  bench("auto-accessor with decorator", () => {
+    const noop = (value, context) => value;
 
-      class C {
-        @noop
-        accessor count = 0;
-      }
-      const c = new C();
-      const v = c.count;
-      c.count = 5;
-    },
+    class C {
+      @noop
+      accessor count = 0;
+    }
+    const c = new C();
+    const v = c.count;
+    c.count = 5;
   });
 });
 
-suite("decorators: metadata", () => {
-  bench("decorator writing metadata", {
-    run: () => {
-      const meta = (key, val) => (value, context) => {
-        context.metadata[key] = val;
-      };
+group("decorators: metadata", () => {
+  bench("decorator writing metadata", () => {
+    const meta = (key, val) => (value, context) => {
+      context.metadata[key] = val;
+    };
 
-      @meta("kind", "entity")
-      class C {
-        @meta("role", "id")
-        id = 1;
-      }
-      const m = C[Symbol.metadata];
-    },
+    @meta("kind", "entity")
+    class C {
+      @meta("role", "id")
+      id = 1;
+    }
+    const m = C[Symbol.metadata];
   });
 });
 
-suite("static getters and setters", () => {
-  bench("static getter read", {
-    run: () => {
-      class Config {
-        static get defaultPort() { return 8080; }
-        static get defaultHost() { return "localhost"; }
-      }
-      const p = Config.defaultPort;
-      const h = Config.defaultHost;
-    },
+group("static getters and setters", () => {
+  bench("static getter read", () => {
+    class Config {
+      static get defaultPort() { return 8080; }
+      static get defaultHost() { return "localhost"; }
+    }
+    const p = Config.defaultPort;
+    const h = Config.defaultHost;
   });
 
-  bench("static getter/setter pair", {
-    run: () => {
-      class Registry {
-        static _count = 0;
-        static get count() { return Registry._count; }
-        static set count(v) { Registry._count = v; }
-      }
-      Registry.count = 10;
-      const c = Registry.count;
-      Registry.count = c + 1;
-    },
+  bench("static getter/setter pair", () => {
+    class Registry {
+      static _count = 0;
+      static get count() { return Registry._count; }
+      static set count(v) { Registry._count = v; }
+    }
+    Registry.count = 10;
+    const c = Registry.count;
+    Registry.count = c + 1;
   });
 
-  bench("inherited static getter", {
-    run: () => {
-      class Base {
-        static get kind() { return "base"; }
-      }
-      class Child extends Base {}
-      class GrandChild extends Child {}
-      const a = Child.kind;
-      const b = GrandChild.kind;
-    },
+  bench("inherited static getter", () => {
+    class Base {
+      static get kind() { return "base"; }
+    }
+    class Child extends Base {}
+    class GrandChild extends Child {}
+    const a = Child.kind;
+    const b = GrandChild.kind;
   });
 
-  bench("inherited static setter", {
-    run: () => {
-      class Base {
-        static _val = 0;
-        static get val() { return Base._val; }
-        static set val(v) { Base._val = v; }
-      }
-      class Child extends Base {}
-      Child.val = 42;
-      const v = Child.val;
-    },
+  bench("inherited static setter", () => {
+    class Base {
+      static _val = 0;
+      static get val() { return Base._val; }
+      static set val(v) { Base._val = v; }
+    }
+    class Child extends Base {}
+    Child.val = 42;
+    const v = Child.val;
   });
 
-  bench("inherited static getter with this binding", {
-    run: () => {
-      class Base {
-        static _label = "Base";
-        static get label() { return this._label; }
-        static set label(v) { this._label = v; }
-      }
-      class Child extends Base {
-        static _label = "Child";
-      }
-      const baseLabel = Base.label;
-      const childLabel = Child.label;
-      Child.label = "Updated";
-      const updated = Child.label;
-    },
+  bench("inherited static getter with this binding", () => {
+    class Base {
+      static _label = "Base";
+      static get label() { return this._label; }
+      static set label(v) { this._label = v; }
+    }
+    class Child extends Base {
+      static _label = "Child";
+    }
+    const baseLabel = Base.label;
+    const childLabel = Child.label;
+    Child.label = "Updated";
+    const updated = Child.label;
   });
 });

--- a/benchmarks/closures.js
+++ b/benchmarks/closures.js
@@ -2,127 +2,107 @@
 description: Function and closure benchmarks
 ---*/
 
-suite("closure capture", () => {
-  bench("closure over single variable", {
-    run: () => {
-      const makeCounter = () => {
-        let count = 0;
-        return () => {
-          count = count + 1;
-          return count;
-        };
+import { bench, group } from "goccia:microbench";
+
+group("closure capture", () => {
+  bench("closure over single variable", () => {
+    const makeCounter = () => {
+      let count = 0;
+      return () => {
+        count = count + 1;
+        return count;
       };
-      const counter = makeCounter();
-      counter();
-      counter();
-      counter();
-    },
+    };
+    const counter = makeCounter();
+    counter();
+    counter();
+    counter();
   });
 
-  bench("closure over multiple variables", {
-    run: () => {
-      const makeAdder = (a, b, c) => {
-        return (x) => a + b + c + x;
-      };
-      const add = makeAdder(1, 2, 3);
-      const r1 = add(10);
-      const r2 = add(20);
-    },
+  bench("closure over multiple variables", () => {
+    const makeAdder = (a, b, c) => {
+      return (x) => a + b + c + x;
+    };
+    const add = makeAdder(1, 2, 3);
+    const r1 = add(10);
+    const r2 = add(20);
   });
 
-  bench("nested closures", {
-    run: () => {
-      const outer = (x) => {
-        return (y) => {
-          return (z) => x + y + z;
-        };
+  bench("nested closures", () => {
+    const outer = (x) => {
+      return (y) => {
+        return (z) => x + y + z;
       };
-      const f = outer(1)(2);
-      const r = f(3);
-    },
+    };
+    const f = outer(1)(2);
+    const r = f(3);
   });
 });
 
-suite("higher-order functions", () => {
-  bench("function as argument", {
-    run: () => {
-      const apply = (fn, x) => fn(x);
-      const double = (x) => x * 2;
-      const r1 = apply(double, 5);
-      const r2 = apply(double, 10);
-      const r3 = apply(double, 15);
-    },
+group("higher-order functions", () => {
+  bench("function as argument", () => {
+    const apply = (fn, x) => fn(x);
+    const double = (x) => x * 2;
+    const r1 = apply(double, 5);
+    const r2 = apply(double, 10);
+    const r3 = apply(double, 15);
   });
 
-  bench("function returning function", {
-    run: () => {
-      const multiplier = (factor) => (x) => x * factor;
-      const triple = multiplier(3);
-      const r1 = triple(1);
-      const r2 = triple(2);
-      const r3 = triple(3);
-    },
+  bench("function returning function", () => {
+    const multiplier = (factor) => (x) => x * factor;
+    const triple = multiplier(3);
+    const r1 = triple(1);
+    const r2 = triple(2);
+    const r3 = triple(3);
   });
 
-  bench("compose two functions", {
-    run: () => {
-      const compose = (f, g) => (x) => f(g(x));
-      const inc = (x) => x + 1;
-      const double = (x) => x * 2;
-      const incThenDouble = compose(double, inc);
-      const r1 = incThenDouble(3);
-      const r2 = incThenDouble(7);
-    },
+  bench("compose two functions", () => {
+    const compose = (f, g) => (x) => f(g(x));
+    const inc = (x) => x + 1;
+    const double = (x) => x * 2;
+    const incThenDouble = compose(double, inc);
+    const r1 = incThenDouble(3);
+    const r2 = incThenDouble(7);
   });
 });
 
-suite("call/apply/bind", () => {
-  bench("fn.call", {
-    run: () => {
-      const greet = (greeting) => greeting + " " + "world";
-      const r1 = greet.call(null, "hello");
-      const r2 = greet.call(null, "hi");
-    },
+group("call/apply/bind", () => {
+  bench("fn.call", () => {
+    const greet = (greeting) => greeting + " " + "world";
+    const r1 = greet.call(null, "hello");
+    const r2 = greet.call(null, "hi");
   });
 
-  bench("fn.apply", {
-    run: () => {
-      const sum = (a, b, c) => a + b + c;
-      const r1 = sum.apply(null, [1, 2, 3]);
-      const r2 = sum.apply(null, [4, 5, 6]);
-    },
+  bench("fn.apply", () => {
+    const sum = (a, b, c) => a + b + c;
+    const r1 = sum.apply(null, [1, 2, 3]);
+    const r2 = sum.apply(null, [4, 5, 6]);
   });
 
-  bench("fn.bind", {
-    run: () => {
-      const add = (a, b) => a + b;
-      const add5 = add.bind(null, 5);
-      const r1 = add5(10);
-      const r2 = add5(20);
-    },
+  bench("fn.bind", () => {
+    const add = (a, b) => a + b;
+    const add5 = add.bind(null, 5);
+    const r1 = add5(10);
+    const r2 = add5(20);
   });
 });
 
-suite("recursion", () => {
-  bench("recursive sum to 50", {
-    run: () => {
-      const sum = (n) => n <= 0 ? 0 : n + sum(n - 1);
-      const r = sum(50);
-    },
+group("recursion", () => {
+  bench("recursive sum to 50", () => {
+    const sum = (n) => n <= 0 ? 0 : n + sum(n - 1);
+    const r = sum(50);
   });
 
-  bench("recursive tree traversal", {
-    run: () => {
-      const node = (v, l, r) => ({ value: v, left: l, right: r });
-      const tree = node(1,
-        node(2, node(4, null, null), node(5, null, null)),
-        node(3, node(6, null, null), node(7, null, null))
-      );
-      const sumTree = (n) => {
-        if (n === null) { return 0; }
-        return n.value + sumTree(n.left) + sumTree(n.right);
-      };
-      const r = sumTree(tree);
-    },
+  bench("recursive tree traversal", () => {
+    const node = (v, l, r) => ({ value: v, left: l, right: r });
+    const tree = node(1,
+      node(2, node(4, null, null), node(5, null, null)),
+      node(3, node(6, null, null), node(7, null, null))
+    );
+    const sumTree = (n) => {
+      if (n === null) { return 0; }
+      return n.value + sumTree(n.left) + sumTree(n.right);
+    };
+    const r = sumTree(tree);
   });
 });

--- a/benchmarks/collections.js
+++ b/benchmarks/collections.js
@@ -2,114 +2,114 @@
 description: Set and Map collection benchmarks
 ---*/
 
-suite("Set operations", () => {
-  bench("add 50 elements", {
-    setup: () => Array.from({ length: 50 }, (_, i) => i),
-    run: (items) => {
+import { bench, group } from "goccia:microbench";
+
+group("Set operations", () => {
+  bench("add 50 elements", ({ *setup() {
+    const items = (() => Array.from({ length: 50 }, (_, i) => i))();
+    yield () => {
       const s = new Set();
       items.forEach((i) => { s.add(i); });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("has lookup (50 elements)", {
-    setup: () => new Set(Array.from({ length: 50 }, (_, i) => i)),
-    run: (s) => {
+  bench("has lookup (50 elements)", ({ *setup() {
+    const s = (() => new Set(Array.from({ length: 50 }, (_, i) => i)))();
+    yield () => {
       const a = s.has(0);
       const b = s.has(25);
       const c = s.has(49);
       const d = s.has(999);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("delete elements", {
-    setup: () => Array.from({ length: 20 }, (_, i) => i),
-    run: (items) => {
+  bench("delete elements", ({ *setup() {
+    const items = (() => Array.from({ length: 20 }, (_, i) => i))();
+    yield () => {
       const s = new Set(items);
       s.delete(0);
       s.delete(5);
       s.delete(10);
       s.delete(15);
       s.delete(19);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("forEach iteration", {
-    setup: () => new Set(Array.from({ length: 50 }, (_, i) => i)),
-    run: (s) => {
+  bench("forEach iteration", ({ *setup() {
+    const s = (() => new Set(Array.from({ length: 50 }, (_, i) => i)))();
+    yield () => {
       let sum = 0;
       s.forEach((v) => { sum = sum + v; });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("spread to array", {
-    setup: () => new Set(Array.from({ length: 30 }, (_, i) => i)),
-    run: (s) => {
+  bench("spread to array", ({ *setup() {
+    const s = (() => new Set(Array.from({ length: 30 }, (_, i) => i)))();
+    yield () => {
       const arr = [...s];
-    },
-  });
+    };
+  } }).setup);
 
-  bench("deduplicate array", {
-    run: () => {
-      const arr = [1, 2, 3, 1, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 8, 9, 8, 9, 10, 10];
-      const unique = [...new Set(arr)];
-    },
+  bench("deduplicate array", () => {
+    const arr = [1, 2, 3, 1, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 8, 9, 8, 9, 10, 10];
+    const unique = [...new Set(arr)];
   });
 });
 
-suite("Map operations", () => {
-  bench("set 50 entries", {
-    setup: () => Array.from({ length: 50 }, (_, i) => i),
-    run: (items) => {
+group("Map operations", () => {
+  bench("set 50 entries", ({ *setup() {
+    const items = (() => Array.from({ length: 50 }, (_, i) => i))();
+    yield () => {
       const m = new Map();
       items.forEach((i) => { m.set("key" + i, i); });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("get lookup (50 entries)", {
-    setup: () => new Map(Array.from({ length: 50 }, (_, i) => ["key" + i, i])),
-    run: (m) => {
+  bench("get lookup (50 entries)", ({ *setup() {
+    const m = (() => new Map(Array.from({ length: 50 }, (_, i) => ["key" + i, i])))();
+    yield () => {
       const a = m.get("key0");
       const b = m.get("key25");
       const c = m.get("key49");
       const d = m.get("missing");
-    },
-  });
+    };
+  } }).setup);
 
-  bench("has check", {
-    setup: () => new Map(Array.from({ length: 50 }, (_, i) => ["key" + i, i])),
-    run: (m) => {
+  bench("has check", ({ *setup() {
+    const m = (() => new Map(Array.from({ length: 50 }, (_, i) => ["key" + i, i])))();
+    yield () => {
       const a = m.has("key0");
       const b = m.has("key25");
       const c = m.has("missing");
-    },
-  });
+    };
+  } }).setup);
 
-  bench("delete entries", {
-    setup: () => Array.from({ length: 20 }, (_, i) => ["key" + i, i]),
-    run: (entries) => {
+  bench("delete entries", ({ *setup() {
+    const entries = (() => Array.from({ length: 20 }, (_, i) => ["key" + i, i]))();
+    yield () => {
       const m = new Map(entries);
       m.delete("key0");
       m.delete("key5");
       m.delete("key10");
       m.delete("key15");
       m.delete("key19");
-    },
-  });
+    };
+  } }).setup);
 
-  bench("forEach iteration", {
-    setup: () => new Map(Array.from({ length: 50 }, (_, i) => ["key" + i, i])),
-    run: (m) => {
+  bench("forEach iteration", ({ *setup() {
+    const m = (() => new Map(Array.from({ length: 50 }, (_, i) => ["key" + i, i])))();
+    yield () => {
       let sum = 0;
       m.forEach((v) => { sum = sum + v; });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("keys/values/entries", {
-    setup: () => new Map(Array.from({ length: 30 }, (_, i) => ["key" + i, i])),
-    run: (m) => {
+  bench("keys/values/entries", ({ *setup() {
+    const m = (() => new Map(Array.from({ length: 30 }, (_, i) => ["key" + i, i])))();
+    yield () => {
       const keys = [...m.keys()];
       const vals = [...m.values()];
       const ents = [...m.entries()];
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/csv.js
+++ b/benchmarks/csv.js
@@ -2,153 +2,149 @@
 description: CSV parse and stringify benchmarks
 ---*/
 
-suite("CSV.parse", () => {
-  bench("parse simple 3-column CSV", {
-    run: () => {
-      const result = CSV.parse("name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,Chicago");
-    },
+import { bench, group } from "goccia:microbench";
+
+group("CSV.parse", () => {
+  bench("parse simple 3-column CSV", () => {
+    const result = CSV.parse("name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,Chicago");
   });
 
-  bench("parse 10-row CSV", {
-    setup: () => {
+  bench("parse 10-row CSV", ({ *setup() {
+    const csv = (() => {
       const header = "id,name,email,score,active";
       const rows = Array.from({ length: 10 }, (_, i) =>
         i + ",user" + i + ",user" + i + "@test.com," + (i * 10) + ",true"
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (csv) => {
+    })();
+    yield () => {
       const result = CSV.parse(csv);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("parse 100-row CSV", {
-    setup: () => {
+  bench("parse 100-row CSV", ({ *setup() {
+    const csv = (() => {
       const header = "id,name,value";
       const rows = Array.from({ length: 100 }, (_, i) =>
         i + ",item" + i + "," + (i * 3.14)
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (csv) => {
+    })();
+    yield () => {
       const result = CSV.parse(csv);
-    },
+    };
+  } }).setup);
+
+  bench("parse CSV with quoted fields", () => {
+    const result = CSV.parse('name,address,note\n"Smith, John","123 Main St, Apt 4","He said ""hello"""');
   });
 
-  bench("parse CSV with quoted fields", {
-    run: () => {
-      const result = CSV.parse('name,address,note\n"Smith, John","123 Main St, Apt 4","He said ""hello"""');
-    },
-  });
-
-  bench("parse without headers (array of arrays)", {
-    setup: () => {
+  bench("parse without headers (array of arrays)", ({ *setup() {
+    const csv = (() => {
       return Array.from({ length: 50 }, (_, i) =>
         i + "," + (i * 2) + "," + (i * 3)
       ).join("\n");
-    },
-    run: (csv) => {
+    })();
+    yield () => {
       const result = CSV.parse(csv, { headers: false });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("parse with semicolon delimiter", {
-    setup: () => {
+  bench("parse with semicolon delimiter", ({ *setup() {
+    const csv = (() => {
       const header = "nom;prenom;age";
       const rows = Array.from({ length: 20 }, (_, i) =>
         "Nom" + i + ";Prenom" + i + ";" + (20 + i)
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (csv) => {
+    })();
+    yield () => {
       const result = CSV.parse(csv, { delimiter: ";" });
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("CSV.stringify", () => {
-  bench("stringify array of objects", {
-    setup: () => Array.from({ length: 10 }, (_, i) => ({
+group("CSV.stringify", () => {
+  bench("stringify array of objects", ({ *setup() {
+    const data = (() => Array.from({ length: 10 }, (_, i) => ({
       id: String(i),
       name: "user" + i,
       active: "true",
-    })),
-    run: (data) => {
+    })))();
+    yield () => {
       const s = CSV.stringify(data);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("stringify array of arrays", {
-    setup: () => Array.from({ length: 50 }, (_, i) => [
+  bench("stringify array of arrays", ({ *setup() {
+    const data = (() => Array.from({ length: 50 }, (_, i) => [
       String(i), "item" + i, String(i * 2),
-    ]),
-    run: (data) => {
+    ]))();
+    yield () => {
       const s = CSV.stringify(data, { headers: false });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("stringify with values needing escaping", {
-    setup: () => Array.from({ length: 10 }, (_, i) => ({
+  bench("stringify with values needing escaping", ({ *setup() {
+    const data = (() => Array.from({ length: 10 }, (_, i) => ({
       text: 'value with "quotes" and, commas',
       note: "line1\nline2",
-    })),
-    run: (data) => {
+    })))();
+    yield () => {
       const s = CSV.stringify(data);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("CSV.parse with reviver", () => {
-  bench("reviver converts numbers", {
-    setup: () => {
+group("CSV.parse with reviver", () => {
+  bench("reviver converts numbers", ({ *setup() {
+    const csv = (() => {
       const header = "a,b,c";
       const rows = Array.from({ length: 20 }, (_, i) =>
         (i * 1) + "," + (i * 2) + "," + (i * 3)
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (csv) => {
+    })();
+    yield () => {
       const result = CSV.parse(csv, {}, (key, value, ctx) => {
         const n = Number(value);
         return Number.isNaN(n) ? value : n;
       });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("reviver filters empty to null", {
-    run: () => {
-      const result = CSV.parse("a,b,c\n1,,3\n,2,\n,,", {}, (key, value, ctx) => {
-        if (!ctx.quoted && value === "") return null;
-        return value;
-      });
-    },
+  bench("reviver filters empty to null", () => {
+    const result = CSV.parse("a,b,c\n1,,3\n,2,\n,,", {}, (key, value, ctx) => {
+      if (!ctx.quoted && value === "") return null;
+      return value;
+    });
   });
 });
 
-suite("CSV roundtrip", () => {
-  bench("parse then stringify", {
-    setup: () => {
+group("CSV roundtrip", () => {
+  bench("parse then stringify", ({ *setup() {
+    const csv = (() => {
       const header = "id,name,score";
       const rows = Array.from({ length: 20 }, (_, i) =>
         i + ",user" + i + "," + (i * 10)
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (csv) => {
+    })();
+    yield () => {
       const parsed = CSV.parse(csv);
       const back = CSV.stringify(parsed);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("stringify then parse", {
-    setup: () => Array.from({ length: 20 }, (_, i) => ({
+  bench("stringify then parse", ({ *setup() {
+    const data = (() => Array.from({ length: 20 }, (_, i) => ({
       id: String(i),
       name: "item" + i,
       active: i % 2 === 0 ? "true" : "false",
-    })),
-    run: (data) => {
+    })))();
+    yield () => {
       const csv = CSV.stringify(data);
       const parsed = CSV.parse(csv);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/destructuring.js
+++ b/benchmarks/destructuring.js
@@ -2,171 +2,139 @@
 description: Destructuring benchmarks
 ---*/
 
-suite("array destructuring", () => {
-  bench("simple array destructuring", {
-    run: () => {
-      const arr = [1, 2, 3, 4, 5];
-      const [a, b, c, d, e] = arr;
-    },
+import { bench, group } from "goccia:microbench";
+
+group("array destructuring", () => {
+  bench("simple array destructuring", () => {
+    const arr = [1, 2, 3, 4, 5];
+    const [a, b, c, d, e] = arr;
   });
 
-  bench("with rest element", {
-    run: () => {
-      const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-      const [first, second, ...rest] = arr;
-    },
+  bench("with rest element", () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const [first, second, ...rest] = arr;
   });
 
-  bench("with defaults", {
-    run: () => {
-      const arr = [1, 2];
-      const [a, b, c = 3, d = 4, e = 5] = arr;
-    },
+  bench("with defaults", () => {
+    const arr = [1, 2];
+    const [a, b, c = 3, d = 4, e = 5] = arr;
   });
 
-  bench("skip elements", {
-    run: () => {
-      const arr = [1, 2, 3, 4, 5];
-      const [a, , c, , e] = arr;
-    },
+  bench("skip elements", () => {
+    const arr = [1, 2, 3, 4, 5];
+    const [a, , c, , e] = arr;
   });
 
-  bench("nested array destructuring", {
-    run: () => {
-      const arr = [[1, 2], [3, 4], [5, 6]];
-      const [[a, b], [c, d], [e, f]] = arr;
-    },
+  bench("nested array destructuring", () => {
+    const arr = [[1, 2], [3, 4], [5, 6]];
+    const [[a, b], [c, d], [e, f]] = arr;
   });
 
-  bench("swap variables", {
-    run: () => {
-      let a = 1;
-      let b = 2;
-      [a, b] = [b, a];
-    },
+  bench("swap variables", () => {
+    let a = 1;
+    let b = 2;
+    [a, b] = [b, a];
   });
 });
 
-suite("object destructuring", () => {
-  bench("simple object destructuring", {
-    run: () => {
-      const obj = { x: 1, y: 2, z: 3, w: 4 };
-      const { x, y, z, w } = obj;
-    },
+group("object destructuring", () => {
+  bench("simple object destructuring", () => {
+    const obj = { x: 1, y: 2, z: 3, w: 4 };
+    const { x, y, z, w } = obj;
   });
 
-  bench("with defaults", {
-    run: () => {
-      const obj = { x: 1 };
-      const { x, y = 2, z = 3, w = 4 } = obj;
-    },
+  bench("with defaults", () => {
+    const obj = { x: 1 };
+    const { x, y = 2, z = 3, w = 4 } = obj;
   });
 
-  bench("with renaming", {
-    run: () => {
-      const obj = { firstName: "Alice", lastName: "Smith", age: 30 };
-      const { firstName: first, lastName: last, age: years } = obj;
-    },
+  bench("with renaming", () => {
+    const obj = { firstName: "Alice", lastName: "Smith", age: 30 };
+    const { firstName: first, lastName: last, age: years } = obj;
   });
 
-  bench("nested object destructuring", {
-    run: () => {
-      const obj = {
-        user: { name: "Alice", address: { city: "NYC" } },
-        meta: { version: 1 }
-      };
-      const { user: { name, address: { city } }, meta: { version } } = obj;
-    },
+  bench("nested object destructuring", () => {
+    const obj = {
+      user: { name: "Alice", address: { city: "NYC" } },
+      meta: { version: 1 }
+    };
+    const { user: { name, address: { city } }, meta: { version } } = obj;
   });
 
-  bench("rest properties", {
-    run: () => {
-      const obj = { a: 1, b: 2, c: 3, d: 4, e: 5 };
-      const { a, b, ...rest } = obj;
-    },
+  bench("rest properties", () => {
+    const obj = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+    const { a, b, ...rest } = obj;
   });
 });
 
-suite("parameter destructuring", () => {
-  bench("object parameter", {
-    run: () => {
-      const process = ({ name, value, active = true }) => name + value;
-      const r1 = process({ name: "test", value: 42 });
-      const r2 = process({ name: "prod", value: 99, active: false });
-    },
+group("parameter destructuring", () => {
+  bench("object parameter", () => {
+    const process = ({ name, value, active = true }) => name + value;
+    const r1 = process({ name: "test", value: 42 });
+    const r2 = process({ name: "prod", value: 99, active: false });
   });
 
-  bench("array parameter", {
-    run: () => {
-      const sum = ([a, b, c]) => a + b + c;
-      const r1 = sum([1, 2, 3]);
-      const r2 = sum([4, 5, 6]);
-    },
+  bench("array parameter", () => {
+    const sum = ([a, b, c]) => a + b + c;
+    const r1 = sum([1, 2, 3]);
+    const r2 = sum([4, 5, 6]);
   });
 
-  bench("mixed destructuring in map", {
-    setup: () => Array.from({ length: 20 }, (_, i) => ({ id: i, value: i * 10 })),
-    run: (data) => {
+  bench("mixed destructuring in map", ({ *setup() {
+    const data = (() => Array.from({ length: 20 }, (_, i) => ({ id: i, value: i * 10 })))();
+    yield () => {
       const values = data.map(({ id, value }) => id + value);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("callback destructuring", () => {
-  bench("forEach with array destructuring", {
-    run: () => {
-      const pairs = [[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]];
-      let sum = 0;
-      pairs.forEach(([k, v]) => { sum = sum + k + v; });
-    },
+group("callback destructuring", () => {
+  bench("forEach with array destructuring", () => {
+    const pairs = [[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]];
+    let sum = 0;
+    pairs.forEach(([k, v]) => { sum = sum + k + v; });
   });
 
-  bench("map with array destructuring", {
-    run: () => {
-      const pairs = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]];
-      const sums = pairs.map(([a, b]) => a + b);
-    },
+  bench("map with array destructuring", () => {
+    const pairs = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]];
+    const sums = pairs.map(([a, b]) => a + b);
   });
 
-  bench("filter with array destructuring", {
-    run: () => {
-      const entries = [[1, 10], [2, 5], [3, 20], [4, 3], [5, 15]];
-      const big = entries.filter(([, val]) => val > 8);
-    },
+  bench("filter with array destructuring", () => {
+    const entries = [[1, 10], [2, 5], [3, 20], [4, 3], [5, 15]];
+    const big = entries.filter(([, val]) => val > 8);
   });
 
-  bench("reduce with array destructuring", {
-    run: () => {
-      const entries = [[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]];
-      const total = entries.reduce((acc, [, v]) => acc + v, 0);
-    },
+  bench("reduce with array destructuring", () => {
+    const entries = [[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]];
+    const total = entries.reduce((acc, [, v]) => acc + v, 0);
   });
 
-  bench("map with object destructuring", {
-    setup: () => Array.from({ length: 10 }, (_, i) => ({ id: i, name: "item", value: i * 10 })),
-    run: (items) => {
+  bench("map with object destructuring", ({ *setup() {
+    const items = (() => Array.from({ length: 10 }, (_, i) => ({ id: i, name: "item", value: i * 10 })))();
+    yield () => {
       const ids = items.map(({ id }) => id);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("map with nested destructuring", {
-    setup: () => Array.from({ length: 10 }, (_, i) => ({ user: { name: "u" + i }, score: i })),
-    run: (data) => {
+  bench("map with nested destructuring", ({ *setup() {
+    const data = (() => Array.from({ length: 10 }, (_, i) => ({ user: { name: "u" + i }, score: i })))();
+    yield () => {
       const names = data.map(({ user: { name } }) => name);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("map with rest in destructuring", {
-    setup: () => Array.from({ length: 10 }, (_, i) => [i, i + 1, i + 2, i + 3]),
-    run: (rows) => {
+  bench("map with rest in destructuring", ({ *setup() {
+    const rows = (() => Array.from({ length: 10 }, (_, i) => [i, i + 1, i + 2, i + 3]))();
+    yield () => {
       const firsts = rows.map(([first, ...rest]) => first + rest.length);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("map with defaults in destructuring", {
-    setup: () => Array.from({ length: 10 }, (_, i) => ({ x: i })),
-    run: (items) => {
+  bench("map with defaults in destructuring", ({ *setup() {
+    const items = (() => Array.from({ length: 10 }, (_, i) => ({ x: i })))();
+    yield () => {
       const ys = items.map(({ x, y = 0 }) => x + y);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/fibonacci.js
+++ b/benchmarks/fibonacci.js
@@ -2,100 +2,86 @@
 description: Fibonacci computation benchmarks
 ---*/
 
-suite("fibonacci", () => {
-  bench("recursive fib(15)", {
-    run: () => {
-      const fib = (n) => n <= 1 ? n : fib(n - 1) + fib(n - 2);
-      fib(15);
-    },
+import { bench, group } from "goccia:microbench";
+
+group("fibonacci", () => {
+  bench("recursive fib(15)", () => {
+    const fib = (n) => n <= 1 ? n : fib(n - 1) + fib(n - 2);
+    fib(15);
   });
 
-  bench("recursive fib(20)", {
-    run: () => {
-      const fib = (n) => n <= 1 ? n : fib(n - 1) + fib(n - 2);
-      fib(20);
-    },
+  bench("recursive fib(20)", () => {
+    const fib = (n) => n <= 1 ? n : fib(n - 1) + fib(n - 2);
+    fib(20);
   });
 
-  bench("recursive fib(15) typed", {
-    run: () => {
-      const fib = (n: number): number => n <= 1 ? n : fib(n - 1) + fib(n - 2);
-      fib(15);
-    },
+  bench("recursive fib(15) typed", () => {
+    const fib = (n: number): number => n <= 1 ? n : fib(n - 1) + fib(n - 2);
+    fib(15);
   });
 
-  bench("recursive fib(20) typed", {
-    run: () => {
-      const fib = (n: number): number => n <= 1 ? n : fib(n - 1) + fib(n - 2);
-      fib(20);
-    },
+  bench("recursive fib(20) typed", () => {
+    const fib = (n: number): number => n <= 1 ? n : fib(n - 1) + fib(n - 2);
+    fib(20);
   });
 
-  bench("iterative fib(20) via reduce", {
-    run: () => {
-      const fib = (n) => Array.from({ length: n }).reduce(
-        (acc) => [acc[1], acc[0] + acc[1]],
-        [0, 1]
-      )[0];
-      fib(20);
-    },
+  bench("iterative fib(20) via reduce", () => {
+    const fib = (n) => Array.from({ length: n }).reduce(
+      (acc) => [acc[1], acc[0] + acc[1]],
+      [0, 1]
+    )[0];
+    fib(20);
   });
 
-  bench("iterator fib(20)", {
-    run: () => {
-      const fibIter = {
-        [Symbol.iterator]() {
-          let a = 0;
-          let b = 1;
-          let count = 0;
-          return {
-            next() {
-              if (count >= 20) {
-                return { value: undefined, done: true };
-              }
-              const value = a;
-              const next = a + b;
-              a = b;
-              b = next;
-              count = count + 1;
-              return { value: value, done: false };
+  bench("iterator fib(20)", () => {
+    const fibIter = {
+      [Symbol.iterator]() {
+        let a = 0;
+        let b = 1;
+        let count = 0;
+        return {
+          next() {
+            if (count >= 20) {
+              return { value: undefined, done: true };
             }
-          };
-        }
-      };
-      const fibs = [...fibIter];
-    },
+            const value = a;
+            const next = a + b;
+            a = b;
+            b = next;
+            count = count + 1;
+            return { value: value, done: false };
+          }
+        };
+      }
+    };
+    const fibs = [...fibIter];
   });
 
-  bench("iterator fib(20) via Iterator.from + take", {
-    run: () => {
-      let a = 0;
-      let b = 1;
-      const fibs = Iterator.from({
-        next() {
-          const value = a;
-          const next = a + b;
-          a = b;
-          b = next;
-          return { value: value, done: false };
-        }
-      }).take(20).toArray();
-    },
+  bench("iterator fib(20) via Iterator.from + take", () => {
+    let a = 0;
+    let b = 1;
+    const fibs = Iterator.from({
+      next() {
+        const value = a;
+        const next = a + b;
+        a = b;
+        b = next;
+        return { value: value, done: false };
+      }
+    }).take(20).toArray();
   });
 
-  bench("iterator fib(20) last value via reduce", {
-    run: () => {
-      let a = 0;
-      let b = 1;
-      const last = Iterator.from({
-        next() {
-          const value = a;
-          const next = a + b;
-          a = b;
-          b = next;
-          return { value: value, done: false };
-        }
-      }).take(20).reduce((_, v) => v, 0);
-    },
+  bench("iterator fib(20) last value via reduce", () => {
+    let a = 0;
+    let b = 1;
+    const last = Iterator.from({
+      next() {
+        const value = a;
+        const next = a + b;
+        a = b;
+        b = next;
+        return { value: value, done: false };
+      }
+    }).take(20).reduce((_, v) => v, 0);
   });
 });

--- a/benchmarks/float16array.js
+++ b/benchmarks/float16array.js
@@ -2,6 +2,8 @@
 description: Float16Array operation benchmarks — IEEE 754 half-precision (binary16)
 ---*/
 
+import { bench, group } from "goccia:microbench";
+
 // Pre-populate test data
 const F16_100 = new Float16Array(100);
 const F16_1000 = new Float16Array(1000);
@@ -15,27 +17,21 @@ for (const i of Array(100).keys()) {
 }
 for (const i of Array(1000).keys()) F16_1000[i] = (i % 500) * 0.1;
 
-suite("Float16Array creation", () => {
-  bench("new Float16Array(0)", {
-    run: () => {
-      const ta = new Float16Array(0);
-    },
+group("Float16Array creation", () => {
+  bench("new Float16Array(0)", () => {
+    const ta = new Float16Array(0);
   });
 
-  bench("new Float16Array(100)", {
-    run: () => {
-      const ta = new Float16Array(100);
-    },
+  bench("new Float16Array(100)", () => {
+    const ta = new Float16Array(100);
   });
 
-  bench("new Float16Array(1000)", {
-    run: () => {
-      const ta = new Float16Array(1000);
-    },
+  bench("new Float16Array(1000)", () => {
+    const ta = new Float16Array(1000);
   });
 
-  bench("Float16Array.from([...100])", {
-    setup: () => {
+  bench("Float16Array.from([...100])", ({ *setup() {
+    const arr = (() => {
       const arr = [];
       let i = 0;
       for (const _ of Array(100).keys()) {
@@ -43,172 +39,158 @@ suite("Float16Array creation", () => {
         i = i + 1;
       }
       return arr;
-    },
-    run: (arr) => {
+    })();
+    yield () => {
       const ta = Float16Array.from(arr);
-    },
+    };
+  } }).setup);
+
+  bench("Float16Array.of(1.5, 2.5, 3.5, 4.5, 5.5)", () => {
+    const ta = Float16Array.of(1.5, 2.5, 3.5, 4.5, 5.5);
   });
 
-  bench("Float16Array.of(1.5, 2.5, 3.5, 4.5, 5.5)", {
-    run: () => {
-      const ta = Float16Array.of(1.5, 2.5, 3.5, 4.5, 5.5);
-    },
-  });
-
-  bench("new Float16Array(float64Array)", {
-    setup: () => {
+  bench("new Float16Array(float64Array)", ({ *setup() {
+    const f64 = (() => {
       const f64 = new Float64Array(100);
       for (const i of Array(100).keys()) f64[i] = i * 0.5;
       return f64;
-    },
-    run: (f64) => {
+    })();
+    yield () => {
       const f16 = new Float16Array(f64);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Float16Array element access", () => {
-  bench("sequential write 100 elements", {
-    setup: () => new Float16Array(100),
-    run: (ta) => {
+group("Float16Array element access", () => {
+  bench("sequential write 100 elements", ({ *setup() {
+    const ta = (() => new Float16Array(100))();
+    yield () => {
       let i = 0;
       for (const idx of Array(100).keys()) {
         ta[idx] = i * 0.5;
         i = i + 1;
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("sequential read 100 elements", {
-    setup: () => {
+  bench("sequential read 100 elements", ({ *setup() {
+    const ta = (() => {
       const ta = new Float16Array(100);
       ta.fill(1.5);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       let sum = 0;
       for (const idx of Array(100).keys()) {
         sum = sum + ta[idx];
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("write special values (NaN, Inf, -0)", {
-    setup: () => new Float16Array(6),
-    run: (ta) => {
+  bench("write special values (NaN, Inf, -0)", ({ *setup() {
+    const ta = (() => new Float16Array(6))();
+    yield () => {
       ta[0] = NaN;
       ta[1] = Infinity;
       ta[2] = -Infinity;
       ta[3] = -0;
       ta[4] = 65504;
       ta[5] = 5.960464477539063e-8;
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Float16Array vs Float32Array vs Float64Array — write 100", () => {
-  bench("Float16Array write", {
-    setup: () => new Float16Array(100),
-    run: (ta) => {
+group("Float16Array vs Float32Array vs Float64Array — write 100", () => {
+  bench("Float16Array write", ({ *setup() {
+    const ta = (() => new Float16Array(100))();
+    yield () => {
       let i = 0;
       for (const idx of Array(100).keys()) {
         ta[idx] = i * 1.5;
         i = i + 1;
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("Float32Array write", {
-    setup: () => new Float32Array(100),
-    run: (ta) => {
+  bench("Float32Array write", ({ *setup() {
+    const ta = (() => new Float32Array(100))();
+    yield () => {
       let i = 0;
       for (const idx of Array(100).keys()) {
         ta[idx] = i * 1.5;
         i = i + 1;
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("Float64Array write", {
-    setup: () => new Float64Array(100),
-    run: (ta) => {
+  bench("Float64Array write", ({ *setup() {
+    const ta = (() => new Float64Array(100))();
+    yield () => {
       let i = 0;
       for (const idx of Array(100).keys()) {
         ta[idx] = i * 1.5;
         i = i + 1;
       }
-    },
+    };
+  } }).setup);
+});
+
+group("Float16Array vs Float32Array vs Float64Array — read 100", () => {
+  bench("Float16Array read", () => {
+    let sum = 0;
+    for (const idx of Array(100).keys()) {
+      sum = sum + F16_100[idx];
+    }
+  });
+
+  bench("Float32Array read", () => {
+    let sum = 0;
+    for (const idx of Array(100).keys()) {
+      sum = sum + F32_100[idx];
+    }
+  });
+
+  bench("Float64Array read", () => {
+    let sum = 0;
+    for (const idx of Array(100).keys()) {
+      sum = sum + F64_100[idx];
+    }
   });
 });
 
-suite("Float16Array vs Float32Array vs Float64Array — read 100", () => {
-  bench("Float16Array read", {
-    run: () => {
-      let sum = 0;
-      for (const idx of Array(100).keys()) {
-        sum = sum + F16_100[idx];
-      }
-    },
-  });
-
-  bench("Float32Array read", {
-    run: () => {
-      let sum = 0;
-      for (const idx of Array(100).keys()) {
-        sum = sum + F32_100[idx];
-      }
-    },
-  });
-
-  bench("Float64Array read", {
-    run: () => {
-      let sum = 0;
-      for (const idx of Array(100).keys()) {
-        sum = sum + F64_100[idx];
-      }
-    },
-  });
-});
-
-suite("Float16Array methods", () => {
-  bench("fill(1.5)", {
-    setup: () => new Float16Array(1000),
-    run: (ta) => {
+group("Float16Array methods", () => {
+  bench("fill(1.5)", ({ *setup() {
+    const ta = (() => new Float16Array(1000))();
+    yield () => {
       ta.fill(1.5);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("slice()", {
-    setup: () => {
+  bench("slice()", ({ *setup() {
+    const ta = (() => {
       const ta = new Float16Array(100);
       ta.fill(1.5);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const sliced = ta.slice();
-    },
+    };
+  } }).setup);
+
+  bench("map(x => x * 2)", () => {
+    const mapped = F16_100.map((x) => x * 2);
   });
 
-  bench("map(x => x * 2)", {
-    run: () => {
-      const mapped = F16_100.map((x) => x * 2);
-    },
+  bench("filter(x => x > 25)", () => {
+    const filtered = F16_100.filter((x) => x > 25);
   });
 
-  bench("filter(x => x > 25)", {
-    run: () => {
-      const filtered = F16_100.filter((x) => x > 25);
-    },
+  bench("reduce (sum)", () => {
+    const sum = F16_100.reduce((acc, x) => acc + x, 0);
   });
 
-  bench("reduce (sum)", {
-    run: () => {
-      const sum = F16_100.reduce((acc, x) => acc + x, 0);
-    },
-  });
-
-  bench("sort()", {
-    setup: () => {
+  bench("sort()", ({ *setup() {
+    const ta = (() => {
       const ta = new Float16Array(100);
       let i = 100;
       for (const idx of Array(100).keys()) {
@@ -216,37 +198,33 @@ suite("Float16Array methods", () => {
         i = i - 1;
       }
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       ta.sort();
-    },
+    };
+  } }).setup);
+
+  bench("indexOf()", () => {
+    const idx = F16_100.indexOf(25);
   });
 
-  bench("indexOf()", {
-    run: () => {
-      const idx = F16_100.indexOf(25);
-    },
-  });
-
-  bench("reverse()", {
-    setup: () => {
+  bench("reverse()", ({ *setup() {
+    const ta = (() => {
       const ta = new Float16Array(100);
       ta.fill(1.5);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       ta.reverse();
-    },
+    };
+  } }).setup);
+
+  bench("toReversed()", () => {
+    const rev = F16_100.toReversed();
   });
 
-  bench("toReversed()", {
-    run: () => {
-      const rev = F16_100.toReversed();
-    },
-  });
-
-  bench("toSorted()", {
-    setup: () => {
+  bench("toSorted()", ({ *setup() {
+    const ta = (() => {
       const ta = new Float16Array(100);
       let i = 100;
       for (const idx of Array(100).keys()) {
@@ -254,78 +232,72 @@ suite("Float16Array methods", () => {
         i = i - 1;
       }
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const sorted = ta.toSorted();
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Float16Array buffer sharing", () => {
-  bench("create view over existing buffer", {
-    setup: () => new ArrayBuffer(200),
-    run: (buf) => {
+group("Float16Array buffer sharing", () => {
+  bench("create view over existing buffer", ({ *setup() {
+    const buf = (() => new ArrayBuffer(200))();
+    yield () => {
       const view = new Float16Array(buf);
-    },
+    };
+  } }).setup);
+
+  bench("subarray()", () => {
+    const sub = F16_100.subarray(10, 50);
   });
 
-  bench("subarray()", {
-    run: () => {
-      const sub = F16_100.subarray(10, 50);
-    },
-  });
-
-  bench("set() from array", {
-    setup: () => {
+  bench("set() from array", ({ *setup() {
+    const ctx = (() => {
       const ta = new Float16Array(100);
       const src = [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5];
       return { ta, src };
-    },
-    run: (ctx) => {
+    })();
+    yield () => {
       ctx.ta.set(ctx.src);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Float16Array iteration", () => {
-  bench("for-of loop", {
-    run: () => {
-      let sum = 0;
-      for (const v of F16_100) {
-        sum = sum + v;
-      }
-    },
+group("Float16Array iteration", () => {
+  bench("for-of loop", () => {
+    let sum = 0;
+    for (const v of F16_100) {
+      sum = sum + v;
+    }
   });
 
-  bench("spread into array", {
-    setup: () => {
+  bench("spread into array", ({ *setup() {
+    const ta = (() => {
       const ta = new Float16Array(50);
       ta.fill(1.5);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const arr = [...ta];
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Math.f16round", () => {
-  bench("f16round(1.337)", {
-    run: () => {
-      const r = Math.f16round(1.337);
-    },
+group("Math.f16round", () => {
+  bench("f16round(1.337)", () => {
+    const r = Math.f16round(1.337);
   });
 
-  bench("f16round over 100 values", {
-    setup: () => {
+  bench("f16round over 100 values", ({ *setup() {
+    const values = (() => {
       const values = [];
       for (const i of Array(100).keys()) values.push(i * 1.337);
       return values;
-    },
-    run: (values) => {
+    })();
+    yield () => {
       for (const v of values) {
         const r = Math.f16round(v);
       }
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/for-in/for-in.js
+++ b/benchmarks/for-in/for-in.js
@@ -2,7 +2,9 @@
 description: for...in enumeration and prototype-chain key dedup benchmarks
 ---*/
 
-suite("for...in", () => {
+import { bench, group } from "goccia:microbench";
+
+group("for...in", () => {
   // Build a `levels`-deep prototype chain where every level redeclares the
   // same `width` keys (plus one unique key per level). for...in must dedup
   // the shared keys down the chain, which stresses the key-dedup set.
@@ -21,29 +23,27 @@ suite("for...in", () => {
     return obj;
   }, {});
 
-  bench("for...in over 50 own keys", {
-    run: () => {
-      let count = 0;
-      for (const key in flat50) count = count + 1;
-      return count;
-    },
+  bench("for...in over 50 own keys", () => {
+    let count = 0;
+    for (const key in flat50) count = count + 1;
+    return count;
   });
 
-  bench("for...in over an 8-level chain of 50 shared keys", {
-    setup: () => buildChain(8, 50),
-    run: (obj) => {
+  bench("for...in over an 8-level chain of 50 shared keys", ({ *setup() {
+    const obj = (() => buildChain(8, 50))();
+    yield () => {
       let count = 0;
       for (const key in obj) count = count + 1;
       return count;
-    },
-  });
+    };
+  } }).setup);
 
-  bench("for...in over a 16-level chain of 100 shared keys", {
-    setup: () => buildChain(16, 100),
-    run: (obj) => {
+  bench("for...in over a 16-level chain of 100 shared keys", ({ *setup() {
+    const obj = (() => buildChain(16, 100))();
+    yield () => {
       let count = 0;
       for (const key in obj) count = count + 1;
       return count;
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/for-in/goccia.json
+++ b/benchmarks/for-in/goccia.json
@@ -1,3 +1,4 @@
 {
+  "source-type": "module",
   "compat-for-in-loop": true
 }

--- a/benchmarks/for-of.js
+++ b/benchmarks/for-of.js
@@ -2,74 +2,68 @@
 description: for...of benchmarks
 ---*/
 
-suite("for...of", () => {
+import { bench, group } from "goccia:microbench";
+
+group("for...of", () => {
   const smallArray = Array.from({ length: 10 }, (_, i) => i);
   const mediumArray = Array.from({ length: 100 }, (_, i) => i);
 
-  bench("for...of with 10-element array", {
-    run: () => {
-      let sum = 0;
-      for (const item of smallArray) {
-        sum = sum + item;
-      }
-    },
+  bench("for...of with 10-element array", () => {
+    let sum = 0;
+    for (const item of smallArray) {
+      sum = sum + item;
+    }
   });
 
-  bench("for...of with 100-element array", {
-    run: () => {
-      let sum = 0;
-      for (const item of mediumArray) {
-        sum = sum + item;
-      }
-    },
+  bench("for...of with 100-element array", () => {
+    let sum = 0;
+    for (const item of mediumArray) {
+      sum = sum + item;
+    }
   });
 
-  bench("for...of with string (10 chars)", {
-    run: () => {
-      const result = [];
-      for (const ch of "abcdefghij") {
-        result.push(ch);
-      }
-    },
+  bench("for...of with string (10 chars)", () => {
+    const result = [];
+    for (const ch of "abcdefghij") {
+      result.push(ch);
+    }
   });
 
-  bench("for...of with Set (10 elements)", {
-    setup: () => new Set(smallArray),
-    run: (s) => {
+  bench("for...of with Set (10 elements)", ({ *setup() {
+    const s = (() => new Set(smallArray))();
+    yield () => {
       let sum = 0;
       for (const item of s) {
         sum = sum + item;
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("for...of with Map entries (10 entries)", {
-    setup: () => new Map(smallArray.map((v) => [v, v * 2])),
-    run: (m) => {
+  bench("for...of with Map entries (10 entries)", ({ *setup() {
+    const m = (() => new Map(smallArray.map((v) => [v, v * 2])))();
+    yield () => {
       let sum = 0;
       for (const [k, v] of m) {
         sum = sum + k + v;
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("for...of with destructuring", {
-    setup: () => smallArray.map((v) => [v, v * 10]),
-    run: (pairs) => {
+  bench("for...of with destructuring", ({ *setup() {
+    const pairs = (() => smallArray.map((v) => [v, v * 10]))();
+    yield () => {
       let sum = 0;
       for (const [a, b] of pairs) {
         sum = sum + a + b;
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("for-await-of with sync array", {
-    run: async () => {
-      let sum = 0;
-      for await (const item of smallArray) {
-        sum = sum + item;
-      }
-      return sum;
-    },
+  bench("for-await-of with sync array", async () => {
+    let sum = 0;
+    for await (const item of smallArray) {
+      sum = sum + item;
+    }
+    return sum;
   });
 });

--- a/benchmarks/generators.js
+++ b/benchmarks/generators.js
@@ -2,7 +2,9 @@
 description: Generator benchmarks
 ---*/
 
-suite("generators", () => {
+import { bench, group } from "goccia:microbench";
+
+group("generators", () => {
   const values = Array.from({ length: 100 }, (_, i) => i);
 
   const makeObjectGenerator = () => ({
@@ -20,44 +22,44 @@ suite("generators", () => {
   const consumeNext = (iter, next, sum) =>
     next.done ? sum : consumeNext(iter, iter.next(), sum + next.value);
 
-  bench("manual next over object generator", {
-    setup: makeObjectGenerator,
-    run: (source) => {
+  bench("manual next over object generator", ({ *setup() {
+    const source = makeObjectGenerator();
+    yield () => {
       const iter = source.values();
       return consumeNext(iter, iter.next(), 0);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("for...of over object generator", {
-    setup: makeObjectGenerator,
-    run: (source) => {
+  bench("for...of over object generator", ({ *setup() {
+    const source = makeObjectGenerator();
+    yield () => {
       let sum = 0;
       for (const value of source.values()) {
         sum = sum + value;
       }
       return sum;
-    },
-  });
+    };
+  } }).setup);
 
-  bench("yield delegation", {
-    setup: makeObjectGenerator,
-    run: (source) => {
+  bench("yield delegation", ({ *setup() {
+    const source = makeObjectGenerator();
+    yield () => {
       let count = 0;
       for (const value of source.values()) {
         count = count + 1;
       }
       return count;
-    },
-  });
+    };
+  } }).setup);
 
-  bench("class generator method", {
-    setup: () => new GeneratorSource(),
-    run: (source) => {
+  bench("class generator method", ({ *setup() {
+    const source = (() => new GeneratorSource())();
+    yield () => {
       let sum = 0;
       for (const value of source.values()) {
         sum = sum + value;
       }
       return sum;
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/goccia.json
+++ b/benchmarks/goccia.json
@@ -1,0 +1,3 @@
+{
+  "source-type": "module"
+}

--- a/benchmarks/intl.js
+++ b/benchmarks/intl.js
@@ -2,39 +2,41 @@
 description: Intl operation benchmarks
 ---*/
 
-suite("Intl.NumberFormat", () => {
-  bench("format decimal", {
-    setup: () => new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }),
-    run: (format) => {
-      const result = format.format(1234567.89);
-    },
-  });
+import { bench, group } from "goccia:microbench";
 
-  bench("format currency", {
-    setup: () => new Intl.NumberFormat("de-DE", { style: "currency", currency: "EUR" }),
-    run: (format) => {
+group("Intl.NumberFormat", () => {
+  bench("format decimal", ({ *setup() {
+    const format = (() => new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }))();
+    yield () => {
       const result = format.format(1234567.89);
-    },
-  });
+    };
+  } }).setup);
+
+  bench("format currency", ({ *setup() {
+    const format = (() => new Intl.NumberFormat("de-DE", { style: "currency", currency: "EUR" }))();
+    yield () => {
+      const result = format.format(1234567.89);
+    };
+  } }).setup);
 });
 
-suite("Intl.DateTimeFormat", () => {
-  bench("format UTC date", {
-    setup: () => ({
+group("Intl.DateTimeFormat", () => {
+  bench("format UTC date", ({ *setup() {
+    const ctx = (() => ({
       format: new Intl.DateTimeFormat("en-US", {
         dateStyle: "medium",
         timeStyle: "short",
         timeZone: "UTC",
       }),
       date: new Date(1710510330000),
-    }),
-    run: (ctx) => {
+    }))();
+    yield () => {
       const result = ctx.format.format(ctx.date);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("formatRange UTC dates", {
-    setup: () => ({
+  bench("formatRange UTC dates", ({ *setup() {
+    const ctx = (() => ({
       format: new Intl.DateTimeFormat("en-US", {
         dateStyle: "medium",
         timeStyle: "short",
@@ -42,28 +44,28 @@ suite("Intl.DateTimeFormat", () => {
       }),
       start: new Date(1710510330000),
       end: new Date(1710513930000),
-    }),
-    run: (ctx) => {
+    }))();
+    yield () => {
       const result = ctx.format.formatRange(ctx.start, ctx.end);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Intl.Collator", () => {
-  bench("compare numeric strings", {
-    setup: () => new Intl.Collator("en", { numeric: true }),
-    run: (collator) => {
+group("Intl.Collator", () => {
+  bench("compare numeric strings", ({ *setup() {
+    const collator = (() => new Intl.Collator("en", { numeric: true }))();
+    yield () => {
       const result = collator.compare("item 9", "item 10");
-    },
-  });
+    };
+  } }).setup);
 
-  bench("sort short string list", {
-    setup: () => ({
+  bench("sort short string list", ({ *setup() {
+    const ctx = (() => ({
       collator: new Intl.Collator("en", { sensitivity: "base" }),
       values: ["zebra", "angstrom", "apple", "Algebra", "banana"],
-    }),
-    run: (ctx) => {
+    }))();
+    yield () => {
       const sorted = ctx.values.slice().sort(ctx.collator.compare);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/iterators.js
+++ b/benchmarks/iterators.js
@@ -2,426 +2,362 @@
 description: Iterator protocol and user-defined iterable benchmarks
 ---*/
 
-suite("user-defined iterator consumption", () => {
-  bench("Iterator.from({next}).toArray() — 20 elements", {
-    run: () => {
-      let i = 0;
-      const arr = Iterator.from({
-        next() {
-          if (i < 20) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).toArray();
-    },
+import { bench, group } from "goccia:microbench";
+
+group("user-defined iterator consumption", () => {
+  bench("Iterator.from({next}).toArray() — 20 elements", () => {
+    let i = 0;
+    const arr = Iterator.from({
+      next() {
+        if (i < 20) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).toArray();
   });
 
-  bench("Iterator.from({next}).toArray() — 50 elements", {
-    run: () => {
-      let i = 0;
-      const arr = Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).toArray();
-    },
+  bench("Iterator.from({next}).toArray() — 50 elements", () => {
+    let i = 0;
+    const arr = Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).toArray();
   });
 
-  bench("spread pre-wrapped iterator — 20 elements", {
-    run: () => {
-      let i = 0;
-      const iter = Iterator.from({
-        next() {
-          if (i < 20) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      });
-      const arr = [...iter];
-    },
+  bench("spread pre-wrapped iterator — 20 elements", () => {
+    let i = 0;
+    const iter = Iterator.from({
+      next() {
+        if (i < 20) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    });
+    const arr = [...iter];
   });
 
-  bench("Iterator.from({next}).forEach — 50 elements", {
-    run: () => {
-      let i = 0;
-      let sum = 0;
-      Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).forEach((v) => { sum = sum + v; });
-    },
+  bench("Iterator.from({next}).forEach — 50 elements", () => {
+    let i = 0;
+    let sum = 0;
+    Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).forEach((v) => { sum = sum + v; });
   });
 
-  bench("Iterator.from({next}).reduce — 50 elements", {
-    run: () => {
-      let i = 0;
-      const sum = Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).reduce((acc, v) => acc + v, 0);
-    },
+  bench("Iterator.from({next}).reduce — 50 elements", () => {
+    let i = 0;
+    const sum = Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).reduce((acc, v) => acc + v, 0);
   });
 });
 
-suite("Iterator.from", () => {
-  bench("wrap array iterator", {
-    run: () => {
-      const iter = Iterator.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-      const arr = iter.toArray();
-    },
+group("Iterator.from", () => {
+  bench("wrap array iterator", () => {
+    const iter = Iterator.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const arr = iter.toArray();
   });
 
-  bench("wrap plain {next()} object", {
-    run: () => {
-      let i = 0;
-      const iter = Iterator.from({
-        next() {
-          if (i < 30) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      });
-      const arr = iter.toArray();
-    },
+  bench("wrap plain {next()} object", () => {
+    let i = 0;
+    const iter = Iterator.from({
+      next() {
+        if (i < 30) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    });
+    const arr = iter.toArray();
   });
 });
 
-suite("iterator helpers — user-defined source", () => {
-  bench("map + toArray (50 elements)", {
-    run: () => {
-      let i = 0;
-      const arr = Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).map((x) => x * 2).toArray();
-    },
+group("iterator helpers — user-defined source", () => {
+  bench("map + toArray (50 elements)", () => {
+    let i = 0;
+    const arr = Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).map((x) => x * 2).toArray();
   });
 
-  bench("filter + toArray (50 elements)", {
-    run: () => {
-      let i = 0;
-      const arr = Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).filter((x) => x % 2 === 0).toArray();
-    },
+  bench("filter + toArray (50 elements)", () => {
+    let i = 0;
+    const arr = Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).filter((x) => x % 2 === 0).toArray();
   });
 
-  bench("take(10) + toArray (50 element source)", {
-    run: () => {
-      let i = 0;
-      const arr = Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).take(10).toArray();
-    },
+  bench("take(10) + toArray (50 element source)", () => {
+    let i = 0;
+    const arr = Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).take(10).toArray();
   });
 
-  bench("drop(40) + toArray (50 element source)", {
-    run: () => {
-      let i = 0;
-      const arr = Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).drop(40).toArray();
-    },
+  bench("drop(40) + toArray (50 element source)", () => {
+    let i = 0;
+    const arr = Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).drop(40).toArray();
   });
 
-  bench("chained map + filter + take (100 element source)", {
-    run: () => {
-      let i = 0;
-      const arr = Iterator.from({
-        next() {
-          if (i < 100) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).map((x) => x * 3)
-        .filter((x) => x % 2 === 0)
-        .take(10)
-        .toArray();
-    },
+  bench("chained map + filter + take (100 element source)", () => {
+    let i = 0;
+    const arr = Iterator.from({
+      next() {
+        if (i < 100) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).map((x) => x * 3)
+      .filter((x) => x % 2 === 0)
+      .take(10)
+      .toArray();
   });
 
-  bench("some + every (50 elements)", {
-    run: () => {
-      let i = 0;
-      const a = Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).some((x) => x > 40);
-      let j = 0;
-      const b = Iterator.from({
-        next() {
-          if (j < 50) { j = j + 1; return { value: j, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).every((x) => x < 100);
-    },
+  bench("some + every (50 elements)", () => {
+    let i = 0;
+    const a = Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).some((x) => x > 40);
+    let j = 0;
+    const b = Iterator.from({
+      next() {
+        if (j < 50) { j = j + 1; return { value: j, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).every((x) => x < 100);
   });
 
-  bench("find (50 elements)", {
-    run: () => {
-      let i = 0;
-      const found = Iterator.from({
-        next() {
-          if (i < 50) { i = i + 1; return { value: i, done: false }; }
-          return { value: undefined, done: true };
-        }
-      }).find((x) => x === 42);
-    },
+  bench("find (50 elements)", () => {
+    let i = 0;
+    const found = Iterator.from({
+      next() {
+        if (i < 50) { i = i + 1; return { value: i, done: false }; }
+        return { value: undefined, done: true };
+      }
+    }).find((x) => x === 42);
   });
 });
 
-suite("Iterator.concat", () => {
+group("Iterator.concat", () => {
   const arr10 = Array.from({ length: 10 }, (_, i) => i);
   const arr20 = Array.from({ length: 20 }, (_, i) => i);
 
-  bench("concat 2 arrays (10 + 10 elements)", {
-    run: () => {
-      const result = Iterator.concat(arr10, arr10).toArray();
-    },
+  bench("concat 2 arrays (10 + 10 elements)", () => {
+    const result = Iterator.concat(arr10, arr10).toArray();
   });
 
-  bench("concat 5 arrays (10 elements each)", {
-    run: () => {
-      const result = Iterator.concat(arr10, arr10, arr10, arr10, arr10).toArray();
-    },
+  bench("concat 5 arrays (10 elements each)", () => {
+    const result = Iterator.concat(arr10, arr10, arr10, arr10, arr10).toArray();
   });
 
-  bench("concat 2 arrays (20 + 20 elements)", {
-    run: () => {
-      const result = Iterator.concat(arr20, arr20).toArray();
-    },
+  bench("concat 2 arrays (20 + 20 elements)", () => {
+    const result = Iterator.concat(arr20, arr20).toArray();
   });
 
-  bench("concat + filter + toArray (20 + 20 elements)", {
-    run: () => {
-      const result = Iterator.concat(arr20, arr20)
-        .filter((x) => x % 2 === 0)
-        .toArray();
-    },
+  bench("concat + filter + toArray (20 + 20 elements)", () => {
+    const result = Iterator.concat(arr20, arr20)
+      .filter((x) => x % 2 === 0)
+      .toArray();
   });
 
-  bench("concat + map + take (20 + 20 elements, take 10)", {
-    run: () => {
-      const result = Iterator.concat(arr20, arr20)
-        .map((x) => x * 3)
-        .take(10)
-        .toArray();
-    },
+  bench("concat + map + take (20 + 20 elements, take 10)", () => {
+    const result = Iterator.concat(arr20, arr20)
+      .map((x) => x * 3)
+      .take(10)
+      .toArray();
   });
 
-  bench("concat Sets (15 + 15 elements)", {
-    setup: () => ({
+  bench("concat Sets (15 + 15 elements)", ({ *setup() {
+    const ctx = (() => ({
       a: new Set(Array.from({ length: 15 }, (_, i) => i)),
       b: new Set(Array.from({ length: 15 }, (_, i) => i + 15)),
-    }),
-    run: (ctx) => {
+    }))();
+    yield () => {
       const result = Iterator.concat(ctx.a, ctx.b).toArray();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("concat boxed strings (13 + 13 characters)", {
-    run: () => {
-      const result = Iterator.concat(Object("abcdefghijklm"), Object("nopqrstuvwxyz")).toArray();
-    },
+  bench("concat boxed strings (13 + 13 characters)", () => {
+    const result = Iterator.concat(Object("abcdefghijklm"), Object("nopqrstuvwxyz")).toArray();
   });
 });
 
-suite("Iterator.zip", () => {
+group("Iterator.zip", () => {
   const arr10 = Array.from({ length: 10 }, (_, i) => i);
   const arr20 = Array.from({ length: 20 }, (_, i) => i);
   const arr50 = Array.from({ length: 50 }, (_, i) => i);
 
-  bench("zip 2 arrays (10 + 10 elements)", {
-    run: () => {
-      const result = Iterator.zip([arr10, arr10]).toArray();
-    },
+  bench("zip 2 arrays (10 + 10 elements)", () => {
+    const result = Iterator.zip([arr10, arr10]).toArray();
   });
 
-  bench("zip 3 arrays (10 elements each)", {
-    run: () => {
-      const result = Iterator.zip([arr10, arr10, arr10]).toArray();
-    },
+  bench("zip 3 arrays (10 elements each)", () => {
+    const result = Iterator.zip([arr10, arr10, arr10]).toArray();
   });
 
-  bench("zip 2 arrays (20 + 20 elements)", {
-    run: () => {
-      const result = Iterator.zip([arr20, arr20]).toArray();
-    },
+  bench("zip 2 arrays (20 + 20 elements)", () => {
+    const result = Iterator.zip([arr20, arr20]).toArray();
   });
 
-  bench("zip 2 arrays (50 + 50 elements)", {
-    run: () => {
-      const result = Iterator.zip([arr50, arr50]).toArray();
-    },
+  bench("zip 2 arrays (50 + 50 elements)", () => {
+    const result = Iterator.zip([arr50, arr50]).toArray();
   });
 
-  bench("zip shortest mode (20 + 10 elements)", {
-    run: () => {
-      const result = Iterator.zip([arr20, arr10]).toArray();
-    },
+  bench("zip shortest mode (20 + 10 elements)", () => {
+    const result = Iterator.zip([arr20, arr10]).toArray();
   });
 
-  bench("zip longest mode (10 + 20 elements)", {
-    run: () => {
-      const result = Iterator.zip([arr10, arr20], { mode: "longest", padding: [0, 0] }).toArray();
-    },
+  bench("zip longest mode (10 + 20 elements)", () => {
+    const result = Iterator.zip([arr10, arr20], { mode: "longest", padding: [0, 0] }).toArray();
   });
 
-  bench("zip strict mode (20 + 20 elements)", {
-    run: () => {
-      const result = Iterator.zip([arr20, arr20], { mode: "strict" }).toArray();
-    },
+  bench("zip strict mode (20 + 20 elements)", () => {
+    const result = Iterator.zip([arr20, arr20], { mode: "strict" }).toArray();
   });
 
-  bench("zip + map + toArray (20 + 20 elements)", {
-    run: () => {
-      const result = Iterator.zip([arr20, arr20])
-        .map(([a, b]) => a + b)
-        .toArray();
-    },
+  bench("zip + map + toArray (20 + 20 elements)", () => {
+    const result = Iterator.zip([arr20, arr20])
+      .map(([a, b]) => a + b)
+      .toArray();
   });
 
-  bench("zip + filter + toArray (20 + 20 elements)", {
-    run: () => {
-      const result = Iterator.zip([arr20, arr20])
-        .filter(([a, b]) => a % 2 === 0)
-        .toArray();
-    },
+  bench("zip + filter + toArray (20 + 20 elements)", () => {
+    const result = Iterator.zip([arr20, arr20])
+      .filter(([a, b]) => a % 2 === 0)
+      .toArray();
   });
 
-  bench("zip Sets (15 + 15 elements)", {
-    setup: () => ({
+  bench("zip Sets (15 + 15 elements)", ({ *setup() {
+    const ctx = (() => ({
       a: new Set(Array.from({ length: 15 }, (_, i) => i)),
       b: new Set(Array.from({ length: 15 }, (_, i) => i + 15)),
-    }),
-    run: (ctx) => {
+    }))();
+    yield () => {
       const result = Iterator.zip([ctx.a, ctx.b]).toArray();
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Iterator.zipKeyed", () => {
-  bench("zipKeyed 2 keys (10 elements each)", {
-    setup: () => ({
+group("Iterator.zipKeyed", () => {
+  bench("zipKeyed 2 keys (10 elements each)", ({ *setup() {
+    const data = (() => ({
       x: Array.from({ length: 10 }, (_, i) => i),
       y: Array.from({ length: 10 }, (_, i) => i * 2),
-    }),
-    run: (data) => {
+    }))();
+    yield () => {
       const result = Iterator.zipKeyed(data).toArray();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("zipKeyed 3 keys (20 elements each)", {
-    setup: () => ({
+  bench("zipKeyed 3 keys (20 elements each)", ({ *setup() {
+    const data = (() => ({
       name: Array.from({ length: 20 }, (_, i) => "item" + i),
       value: Array.from({ length: 20 }, (_, i) => i * 10),
       flag: Array.from({ length: 20 }, (_, i) => i % 2 === 0),
-    }),
-    run: (data) => {
+    }))();
+    yield () => {
       const result = Iterator.zipKeyed(data).toArray();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("zipKeyed longest mode (10 + 20 elements)", {
-    setup: () => ({
+  bench("zipKeyed longest mode (10 + 20 elements)", ({ *setup() {
+    const data = (() => ({
       short: Array.from({ length: 10 }, (_, i) => i),
       long: Array.from({ length: 20 }, (_, i) => i),
-    }),
-    run: (data) => {
+    }))();
+    yield () => {
       const result = Iterator.zipKeyed(data, {
         mode: "longest",
         padding: { short: 0, long: 0 },
       }).toArray();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("zipKeyed strict mode (20 + 20 elements)", {
-    setup: () => ({
+  bench("zipKeyed strict mode (20 + 20 elements)", ({ *setup() {
+    const data = (() => ({
       a: Array.from({ length: 20 }, (_, i) => i),
       b: Array.from({ length: 20 }, (_, i) => i * 3),
-    }),
-    run: (data) => {
+    }))();
+    yield () => {
       const result = Iterator.zipKeyed(data, { mode: "strict" }).toArray();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("zipKeyed + filter + map (20 elements)", {
-    setup: () => ({
+  bench("zipKeyed + filter + map (20 elements)", ({ *setup() {
+    const data = (() => ({
       x: Array.from({ length: 20 }, (_, i) => i),
       y: Array.from({ length: 20 }, (_, i) => i * 5),
-    }),
-    run: (data) => {
+    }))();
+    yield () => {
       const result = Iterator.zipKeyed(data)
         .filter(({ x }) => x > 10)
         .map(({ x, y }) => x + y)
         .toArray();
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("built-in iterator helpers", () => {
+group("built-in iterator helpers", () => {
   const arr50 = Array.from({ length: 50 }, (_, i) => i);
 
-  bench("array.values().map().filter().toArray()", {
-    run: () => {
-      const result = arr50.values()
-        .map((x) => x * 2)
-        .filter((x) => x > 20)
-        .toArray();
-    },
+  bench("array.values().map().filter().toArray()", () => {
+    const result = arr50.values()
+      .map((x) => x * 2)
+      .filter((x) => x > 20)
+      .toArray();
   });
 
-  bench("array.values().take(5).toArray()", {
-    run: () => {
-      const result = arr50.values().take(5).toArray();
-    },
+  bench("array.values().take(5).toArray()", () => {
+    const result = arr50.values().take(5).toArray();
   });
 
-  bench("array.values().drop(45).toArray()", {
-    run: () => {
-      const result = arr50.values().drop(45).toArray();
-    },
+  bench("array.values().drop(45).toArray()", () => {
+    const result = arr50.values().drop(45).toArray();
   });
 
-  bench("map.entries() chained helpers", {
-    setup: () => new Map(Array.from({ length: 30 }, (_, i) => ["k" + i, i])),
-    run: (m) => {
+  bench("map.entries() chained helpers", ({ *setup() {
+    const m = (() => new Map(Array.from({ length: 30 }, (_, i) => ["k" + i, i])))();
+    yield () => {
       const result = m.entries()
         .filter(([k, v]) => v > 10)
         .map(([k, v]) => v * 2)
         .toArray();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("set.values() chained helpers", {
-    setup: () => new Set(Array.from({ length: 30 }, (_, i) => i)),
-    run: (s) => {
+  bench("set.values() chained helpers", ({ *setup() {
+    const s = (() => new Set(Array.from({ length: 30 }, (_, i) => i)))();
+    yield () => {
       const result = s.values()
         .filter((x) => x % 3 === 0)
         .map((x) => x * 10)
         .toArray();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("string iterator map + toArray", {
-    run: () => {
-      const result = "abcdefghijklmnopqrstuvwxyz"[Symbol.iterator]()
-        .map((ch) => ch.toUpperCase())
-        .toArray();
-    },
+  bench("string iterator map + toArray", () => {
+    const result = "abcdefghijklmnopqrstuvwxyz"[Symbol.iterator]()
+      .map((ch) => ch.toUpperCase())
+      .toArray();
   });
 });

--- a/benchmarks/json.js
+++ b/benchmarks/json.js
@@ -2,203 +2,169 @@
 description: JSON parse and stringify benchmarks
 ---*/
 
-suite("JSON.parse", () => {
-  bench("parse simple object", {
-    run: () => {
-      const obj = JSON.parse('{"name":"test","value":42,"active":true}');
-    },
+import { bench, group } from "goccia:microbench";
+
+group("JSON.parse", () => {
+  bench("parse simple object", () => {
+    const obj = JSON.parse('{"name":"test","value":42,"active":true}');
   });
 
-  bench("parse nested object", {
-    run: () => {
-      const obj = JSON.parse('{"user":{"name":"Alice","address":{"city":"NYC","zip":"10001"}},"score":95}');
-    },
+  bench("parse nested object", () => {
+    const obj = JSON.parse('{"user":{"name":"Alice","address":{"city":"NYC","zip":"10001"}},"score":95}');
   });
 
-  bench("parse array of objects", {
-    run: () => {
-      const arr = JSON.parse('[{"id":1,"name":"a"},{"id":2,"name":"b"},{"id":3,"name":"c"},{"id":4,"name":"d"},{"id":5,"name":"e"}]');
-    },
+  bench("parse array of objects", () => {
+    const arr = JSON.parse('[{"id":1,"name":"a"},{"id":2,"name":"b"},{"id":3,"name":"c"},{"id":4,"name":"d"},{"id":5,"name":"e"}]');
   });
 
-  bench("parse large flat object", {
-    run: () => {
-      const obj = JSON.parse('{"a":1,"b":2,"c":3,"d":4,"e":5,"f":6,"g":7,"h":8,"i":9,"j":10,"k":11,"l":12}');
-    },
+  bench("parse large flat object", () => {
+    const obj = JSON.parse('{"a":1,"b":2,"c":3,"d":4,"e":5,"f":6,"g":7,"h":8,"i":9,"j":10,"k":11,"l":12}');
   });
 
-  bench("parse mixed types", {
-    run: () => {
-      const obj = JSON.parse('{"str":"hello","num":3.14,"bool":true,"nil":null,"arr":[1,2,3],"obj":{"x":1}}');
-    },
+  bench("parse mixed types", () => {
+    const obj = JSON.parse('{"str":"hello","num":3.14,"bool":true,"nil":null,"arr":[1,2,3],"obj":{"x":1}}');
   });
 });
 
-suite("JSON.stringify", () => {
-  bench("stringify simple object", {
-    run: () => {
-      const s = JSON.stringify({ name: "test", value: 42, active: true });
-    },
+group("JSON.stringify", () => {
+  bench("stringify simple object", () => {
+    const s = JSON.stringify({ name: "test", value: 42, active: true });
   });
 
-  bench("stringify nested object", {
-    run: () => {
-      const s = JSON.stringify({
-        user: { name: "Alice", address: { city: "NYC", zip: "10001" } },
-        score: 95
-      });
-    },
+  bench("stringify nested object", () => {
+    const s = JSON.stringify({
+      user: { name: "Alice", address: { city: "NYC", zip: "10001" } },
+      score: 95
+    });
   });
 
-  bench("stringify array of objects", {
-    setup: () => Array.from({ length: 10 }, (_, i) => ({ id: i, name: "item" + i })),
-    run: (items) => {
+  bench("stringify array of objects", ({ *setup() {
+    const items = (() => Array.from({ length: 10 }, (_, i) => ({ id: i, name: "item" + i })))();
+    yield () => {
       const s = JSON.stringify(items);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("stringify mixed types", {
-    run: () => {
-      const s = JSON.stringify({
-        str: "hello",
-        num: 3.14,
-        bool: true,
-        nil: null,
-        arr: [1, 2, 3],
-        obj: { x: 1 }
-      });
-    },
+  bench("stringify mixed types", () => {
+    const s = JSON.stringify({
+      str: "hello",
+      num: 3.14,
+      bool: true,
+      nil: null,
+      arr: [1, 2, 3],
+      obj: { x: 1 }
+    });
   });
 });
 
-suite("JSON.parse with reviver", () => {
-  bench("reviver doubles numbers", {
-    run: () => {
-      const result = JSON.parse('{"a":1,"b":2,"c":3,"d":4,"e":5}', (key, value) => {
-        if (typeof value === "number") {
-          return value * 2;
-        }
-        return value;
-      });
-    },
+group("JSON.parse with reviver", () => {
+  bench("reviver doubles numbers", () => {
+    const result = JSON.parse('{"a":1,"b":2,"c":3,"d":4,"e":5}', (key, value) => {
+      if (typeof value === "number") {
+        return value * 2;
+      }
+      return value;
+    });
   });
 
-  bench("reviver filters properties", {
-    run: () => {
-      const result = JSON.parse('{"keep":1,"drop":2,"keep2":3,"drop2":4}', (key, value) => {
-        if (key.startsWith("drop")) {
-          return undefined;
-        }
-        return value;
-      });
-    },
+  bench("reviver filters properties", () => {
+    const result = JSON.parse('{"keep":1,"drop":2,"keep2":3,"drop2":4}', (key, value) => {
+      if (key.startsWith("drop")) {
+        return undefined;
+      }
+      return value;
+    });
   });
 
-  bench("reviver on nested object", {
-    run: () => {
-      const result = JSON.parse('{"user":{"name":"Alice","age":30},"score":95}', (key, value) => {
-        if (typeof value === "string") {
-          return value.toUpperCase();
-        }
-        return value;
-      });
-    },
+  bench("reviver on nested object", () => {
+    const result = JSON.parse('{"user":{"name":"Alice","age":30},"score":95}', (key, value) => {
+      if (typeof value === "string") {
+        return value.toUpperCase();
+      }
+      return value;
+    });
   });
 
-  bench("reviver on array", {
-    run: () => {
-      const result = JSON.parse('[1,2,3,4,5,6,7,8,9,10]', (key, value) => {
-        if (typeof value === "number") {
-          return value + 10;
-        }
-        return value;
-      });
-    },
+  bench("reviver on array", () => {
+    const result = JSON.parse('[1,2,3,4,5,6,7,8,9,10]', (key, value) => {
+      if (typeof value === "number") {
+        return value + 10;
+      }
+      return value;
+    });
   });
 });
 
-suite("JSON.stringify with replacer", () => {
-  bench("replacer function doubles numbers", {
-    run: () => {
-      const s = JSON.stringify({ a: 1, b: 2, c: 3, d: 4, e: 5 }, (key, value) => {
-        if (typeof value === "number") {
-          return value * 2;
-        }
-        return value;
-      });
-    },
+group("JSON.stringify with replacer", () => {
+  bench("replacer function doubles numbers", () => {
+    const s = JSON.stringify({ a: 1, b: 2, c: 3, d: 4, e: 5 }, (key, value) => {
+      if (typeof value === "number") {
+        return value * 2;
+      }
+      return value;
+    });
   });
 
-  bench("replacer function excludes properties", {
-    run: () => {
-      const s = JSON.stringify({ a: 1, secret: "hidden", b: 2, password: "nope" }, (key, value) => {
-        if (key === "secret" || key === "password") {
-          return undefined;
-        }
-        return value;
-      });
-    },
+  bench("replacer function excludes properties", () => {
+    const s = JSON.stringify({ a: 1, secret: "hidden", b: 2, password: "nope" }, (key, value) => {
+      if (key === "secret" || key === "password") {
+        return undefined;
+      }
+      return value;
+    });
   });
 
-  bench("array replacer (allowlist)", {
-    run: () => {
-      const s = JSON.stringify({ a: 1, b: 2, c: 3, d: 4, e: 5 }, ["a", "c", "e"]);
-    },
+  bench("array replacer (allowlist)", () => {
+    const s = JSON.stringify({ a: 1, b: 2, c: 3, d: 4, e: 5 }, ["a", "c", "e"]);
   });
 
-  bench("stringify with 2-space indent", {
-    run: () => {
-      const s = JSON.stringify({ name: "test", items: [1, 2, 3], nested: { x: 1 } }, null, 2);
-    },
+  bench("stringify with 2-space indent", () => {
+    const s = JSON.stringify({ name: "test", items: [1, 2, 3], nested: { x: 1 } }, null, 2);
   });
 
-  bench("stringify with tab indent", {
-    run: () => {
-      const s = JSON.stringify({ name: "test", items: [1, 2, 3], nested: { x: 1 } }, null, "\t");
-    },
+  bench("stringify with tab indent", () => {
+    const s = JSON.stringify({ name: "test", items: [1, 2, 3], nested: { x: 1 } }, null, "\t");
   });
 
-  bench("stringify deeply nested object with 2-space indent", {
-    setup: () =>
-      Array.from({ length: 50 }).reduce((acc) => ({ child: acc }), { leaf: true }),
-    run: (deep) => {
+  bench("stringify deeply nested object with 2-space indent", ({ *setup() {
+    const deep = (() =>
+      Array.from({ length: 50 }).reduce((acc) => ({ child: acc }), { leaf: true }))();
+    yield () => {
       const s = JSON.stringify(deep, null, 2);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("stringify deeply nested array with 2-space indent", {
-    setup: () => Array.from({ length: 50 }).reduce((acc) => [acc], [1]),
-    run: (deep) => {
+  bench("stringify deeply nested array with 2-space indent", ({ *setup() {
+    const deep = (() => Array.from({ length: 50 }).reduce((acc) => [acc], [1]))();
+    yield () => {
       const s = JSON.stringify(deep, null, 2);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("stringify very deeply nested object with 2-space indent", {
-    setup: () =>
-      Array.from({ length: 200 }).reduce((acc) => ({ child: acc }), { leaf: true }),
-    run: (deep) => {
+  bench("stringify very deeply nested object with 2-space indent", ({ *setup() {
+    const deep = (() =>
+      Array.from({ length: 200 }).reduce((acc) => ({ child: acc }), { leaf: true }))();
+    yield () => {
       const s = JSON.stringify(deep, null, 2);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("JSON roundtrip", () => {
-  bench("parse then stringify", {
-    run: () => {
-      const json = '{"users":[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}],"total":2}';
-      const obj = JSON.parse(json);
-      const back = JSON.stringify(obj);
-    },
+group("JSON roundtrip", () => {
+  bench("parse then stringify", () => {
+    const json = '{"users":[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}],"total":2}';
+    const obj = JSON.parse(json);
+    const back = JSON.stringify(obj);
   });
 
-  bench("stringify then parse", {
-    setup: () => ({
+  bench("stringify then parse", ({ *setup() {
+    const data = (() => ({
       items: Array.from({ length: 5 }, (_, i) => ({ id: i, active: i % 2 === 0 })),
       count: 5
-    }),
-    run: (data) => {
+    }))();
+    yield () => {
       const json = JSON.stringify(data);
       const obj = JSON.parse(json);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/jsx.jsx
+++ b/benchmarks/jsx.jsx
@@ -2,175 +2,135 @@
 description: JSX transformation and createElement benchmarks
 ---*/
 
+import { bench, group } from "goccia:microbench";
+
 const createElement = (tag, props, ...children) => ({ tag, props, children });
 const Fragment = Symbol("Fragment");
 
-suite("JSX element creation", () => {
-  bench("simple element", {
-    run: () => {
-      const el = <div>hello</div>;
-    },
+group("JSX element creation", () => {
+  bench("simple element", () => {
+    const el = <div>hello</div>;
   });
 
-  bench("self-closing element", {
-    run: () => {
-      const el = <br />;
-    },
+  bench("self-closing element", () => {
+    const el = <br />;
   });
 
-  bench("element with string attribute", {
-    run: () => {
-      const el = <div className="container"></div>;
-    },
+  bench("element with string attribute", () => {
+    const el = <div className="container"></div>;
   });
 
-  bench("element with multiple attributes", {
-    run: () => {
-      const el = <div id="main" className="active" tabIndex={0} role="button"></div>;
-    },
+  bench("element with multiple attributes", () => {
+    const el = <div id="main" className="active" tabIndex={0} role="button"></div>;
   });
 
-  bench("element with expression attribute", {
-    run: () => {
-      const count = 42;
-      const el = <span data-count={count + 1}></span>;
-    },
+  bench("element with expression attribute", () => {
+    const count = 42;
+    const el = <span data-count={count + 1}></span>;
   });
 });
 
-suite("JSX children", () => {
-  bench("text child", {
-    run: () => {
-      const el = <p>Hello World</p>;
-    },
+group("JSX children", () => {
+  bench("text child", () => {
+    const el = <p>Hello World</p>;
   });
 
-  bench("expression child", {
-    run: () => {
-      const name = "Alice";
-      const el = <p>{name}</p>;
-    },
+  bench("expression child", () => {
+    const name = "Alice";
+    const el = <p>{name}</p>;
   });
 
-  bench("mixed text and expression", {
-    run: () => {
-      const name = "Bob";
-      const el = <p>Hello {name}, welcome!</p>;
-    },
+  bench("mixed text and expression", () => {
+    const name = "Bob";
+    const el = <p>Hello {name}, welcome!</p>;
   });
 
-  bench("nested elements (3 levels)", {
-    run: () => {
-      const el = <div><section><p>deep</p></section></div>;
-    },
+  bench("nested elements (3 levels)", () => {
+    const el = <div><section><p>deep</p></section></div>;
   });
 
-  bench("sibling children", {
-    run: () => {
-      const el = <ul><li>one</li><li>two</li><li>three</li></ul>;
-    },
+  bench("sibling children", () => {
+    const el = <ul><li>one</li><li>two</li><li>three</li></ul>;
   });
 });
 
-suite("JSX components", () => {
-  bench("component element", {
-    run: () => {
-      const Button = (props) => props;
-      const el = <Button label="ok" />;
-    },
+group("JSX components", () => {
+  bench("component element", () => {
+    const Button = (props) => props;
+    const el = <Button label="ok" />;
   });
 
-  bench("component with children", {
-    run: () => {
-      const Card = (props) => props;
-      const el = <Card title="Test"><p>body</p></Card>;
-    },
+  bench("component with children", () => {
+    const Card = (props) => props;
+    const el = <Card title="Test"><p>body</p></Card>;
   });
 
-  bench("dotted component", {
-    run: () => {
-      const UI = { Button: (props) => props };
-      const el = <UI.Button variant="primary">Click</UI.Button>;
-    },
+  bench("dotted component", () => {
+    const UI = { Button: (props) => props };
+    const el = <UI.Button variant="primary">Click</UI.Button>;
   });
 });
 
-suite("JSX fragments", () => {
-  bench("empty fragment", {
-    run: () => {
-      const el = <></>;
-    },
+group("JSX fragments", () => {
+  bench("empty fragment", () => {
+    const el = <></>;
   });
 
-  bench("fragment with children", {
-    run: () => {
-      const el = <><span>a</span><span>b</span><span>c</span></>;
-    },
+  bench("fragment with children", () => {
+    const el = <><span>a</span><span>b</span><span>c</span></>;
   });
 });
 
-suite("JSX spread and shorthand", () => {
-  bench("spread attributes", {
-    run: () => {
-      const props = { id: "item", className: "active", role: "listitem" };
-      const el = <div {...props}></div>;
-    },
+group("JSX spread and shorthand", () => {
+  bench("spread attributes", () => {
+    const props = { id: "item", className: "active", role: "listitem" };
+    const el = <div {...props}></div>;
   });
 
-  bench("spread with overrides", {
-    run: () => {
-      const base = { className: "base", tabIndex: 0 };
-      const el = <div {...base} className="override" id="main"></div>;
-    },
+  bench("spread with overrides", () => {
+    const base = { className: "base", tabIndex: 0 };
+    const el = <div {...base} className="override" id="main"></div>;
   });
 
-  bench("shorthand props", {
-    run: () => {
-      const className = "active";
-      const id = "main";
-      const el = <div {className} {id}></div>;
-    },
+  bench("shorthand props", () => {
+    const className = "active";
+    const id = "main";
+    const el = <div {className} {id}></div>;
   });
 });
 
-suite("JSX complex trees", () => {
-  bench("nav bar structure", {
-    run: () => {
-      const el = (
-        <nav>
-          <ul>
-            <li><a href="/">Home</a></li>
-            <li><a href="/about">About</a></li>
-            <li><a href="/contact">Contact</a></li>
-          </ul>
-        </nav>
-      );
-    },
+group("JSX complex trees", () => {
+  bench("nav bar structure", () => {
+    const el = (
+      <nav>
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="/about">About</a></li>
+          <li><a href="/contact">Contact</a></li>
+        </ul>
+      </nav>
+    );
   });
 
-  bench("card component tree", {
-    run: () => {
-      const title = "Product";
-      const price = 29.99;
-      const el = (
-        <div className="card">
-          <div className="card-header">
-            <h2>{title}</h2>
-          </div>
-          <div className="card-body">
-            <p className="price">${price}</p>
-            <button className="btn">Add to cart</button>
-          </div>
+  bench("card component tree", () => {
+    const title = "Product";
+    const price = 29.99;
+    const el = (
+      <div className="card">
+        <div className="card-header">
+          <h2>{title}</h2>
         </div>
-      );
-    },
+        <div className="card-body">
+          <p className="price">${price}</p>
+          <button className="btn">Add to cart</button>
+        </div>
+      </div>
+    );
   });
 
-  bench("10 list items via Array.from", {
-    run: () => {
-      const items = Array.from({ length: 10 }, (_, i) => (
-        <li key={i} className="item">{i}</li>
-      ));
-    },
+  bench("10 list items via Array.from", () => {
+    const items = Array.from({ length: 10 }, (_, i) => (
+      <li key={i} className="item">{i}</li>
+    ));
   });
 });

--- a/benchmarks/modules.js
+++ b/benchmarks/modules.js
@@ -2,66 +2,50 @@
 description: Module import benchmarks
 ---*/
 
+import { bench, group } from "goccia:microbench";
+
 import { add, multiply, PI, greeting } from "./helpers/bench-module.js";
 import { name, version, debug, maxRetries, tags } from "./helpers/bench-config.json";
 
-suite("script module import", () => {
-  bench("call imported function", {
-    run: () => {
-      const r = add(2, 3);
-    },
+group("script module import", () => {
+  bench("call imported function", () => {
+    const r = add(2, 3);
   });
 
-  bench("call two imported functions", {
-    run: () => {
-      const r1 = add(2, 3);
-      const r2 = multiply(4, 5);
-    },
+  bench("call two imported functions", () => {
+    const r1 = add(2, 3);
+    const r2 = multiply(4, 5);
   });
 
-  bench("read imported constant", {
-    run: () => {
-      const r = PI;
-    },
+  bench("read imported constant", () => {
+    const r = PI;
   });
 
-  bench("read imported string", {
-    run: () => {
-      const r = greeting;
-    },
+  bench("read imported string", () => {
+    const r = greeting;
   });
 });
 
-suite("JSON module import", () => {
-  bench("read JSON string property", {
-    run: () => {
-      const r = name;
-    },
+group("JSON module import", () => {
+  bench("read JSON string property", () => {
+    const r = name;
   });
 
-  bench("read JSON number property", {
-    run: () => {
-      const r = maxRetries;
-    },
+  bench("read JSON number property", () => {
+    const r = maxRetries;
   });
 
-  bench("read JSON boolean property", {
-    run: () => {
-      const r = debug;
-    },
+  bench("read JSON boolean property", () => {
+    const r = debug;
   });
 
-  bench("read JSON array property", {
-    run: () => {
-      const r = tags;
-    },
+  bench("read JSON array property", () => {
+    const r = tags;
   });
 
-  bench("read multiple JSON properties", {
-    run: () => {
-      const r1 = name;
-      const r2 = version;
-      const r3 = maxRetries;
-    },
+  bench("read multiple JSON properties", () => {
+    const r1 = name;
+    const r2 = version;
+    const r3 = maxRetries;
   });
 });

--- a/benchmarks/numbers.js
+++ b/benchmarks/numbers.js
@@ -2,6 +2,8 @@
 description: Number operation benchmarks
 ---*/
 
+import { bench, group } from "goccia:microbench";
+
 // Hoisted so the bench measures FormatDouble's shortest-round-trip path rather
 // than the per-iteration cost of rebuilding the list and recomputing constants.
 const ToStringNonIntegerSamples = [
@@ -14,114 +16,90 @@ const ToStringNonIntegerSamples = [
   5.7016275775556e-8,
 ];
 
-suite("number creation", () => {
-  bench("integer arithmetic", {
-    run: () => {
-      const a = 42;
-      const b = 17;
-      const sum = a + b;
-      const diff = a - b;
-      const prod = a * b;
-      const quot = a / b;
-    },
+group("number creation", () => {
+  bench("integer arithmetic", () => {
+    const a = 42;
+    const b = 17;
+    const sum = a + b;
+    const diff = a - b;
+    const prod = a * b;
+    const quot = a / b;
   });
 
-  bench("floating point arithmetic", {
-    run: () => {
-      const a = 3.14159;
-      const b = 2.71828;
-      const sum = a + b;
-      const prod = a * b;
-      const quot = a / b;
-    },
+  bench("floating point arithmetic", () => {
+    const a = 3.14159;
+    const b = 2.71828;
+    const sum = a + b;
+    const prod = a * b;
+    const quot = a / b;
   });
 
-  bench("number coercion", {
-    run: () => {
-      const a = Number("42");
-      const b = Number("3.14");
-      const c = Number(true);
-      const d = Number(false);
-      const e = Number(null);
-    },
+  bench("number coercion", () => {
+    const a = Number("42");
+    const b = Number("3.14");
+    const c = Number(true);
+    const d = Number(false);
+    const e = Number(null);
   });
 });
 
-suite("number prototype methods", () => {
-  bench("toFixed", {
-    run: () => {
-      const num = 3.14159;
-      const a = num.toFixed(0);
-      const b = num.toFixed(2);
-      const c = num.toFixed(5);
-    },
+group("number prototype methods", () => {
+  bench("toFixed", () => {
+    const num = 3.14159;
+    const a = num.toFixed(0);
+    const b = num.toFixed(2);
+    const c = num.toFixed(5);
   });
 
-  bench("toString", {
-    run: () => {
-      const num = 255;
-      const a = num.toString();
-      const b = num.toString(16);
-      const c = num.toString(10);
-    },
+  bench("toString", () => {
+    const num = 255;
+    const a = num.toString();
+    const b = num.toString(16);
+    const c = num.toString(10);
   });
 
-  bench("toString non-integer (shortest round-trip)", {
-    run: () => {
-      let total = 0;
-      for (const x of ToStringNonIntegerSamples) total += x.toString().length;
-      return total;
-    },
+  bench("toString non-integer (shortest round-trip)", () => {
+    let total = 0;
+    for (const x of ToStringNonIntegerSamples) total += x.toString().length;
+    return total;
   });
 
-  bench("valueOf", {
-    run: () => {
-      const a = (42).valueOf();
-      const b = (3.14).valueOf();
-      const c = (0).valueOf();
-    },
+  bench("valueOf", () => {
+    const a = (42).valueOf();
+    const b = (3.14).valueOf();
+    const c = (0).valueOf();
   });
 
-  bench("toPrecision", {
-    run: () => {
-      const num = 123.456;
-      const a = num.toPrecision();
-      const b = num.toPrecision(4);
-      const c = num.toPrecision(2);
-    },
+  bench("toPrecision", () => {
+    const num = 123.456;
+    const a = num.toPrecision();
+    const b = num.toPrecision(4);
+    const c = num.toPrecision(2);
   });
 });
 
-suite("number static methods", () => {
-  bench("Number.isNaN", {
-    run: () => {
-      const a = Number.isNaN(NaN);
-      const b = Number.isNaN(42);
-      const c = Number.isNaN("hello");
-    },
+group("number static methods", () => {
+  bench("Number.isNaN", () => {
+    const a = Number.isNaN(NaN);
+    const b = Number.isNaN(42);
+    const c = Number.isNaN("hello");
   });
 
-  bench("Number.isFinite", {
-    run: () => {
-      const a = Number.isFinite(42);
-      const b = Number.isFinite(Infinity);
-      const c = Number.isFinite(NaN);
-    },
+  bench("Number.isFinite", () => {
+    const a = Number.isFinite(42);
+    const b = Number.isFinite(Infinity);
+    const c = Number.isFinite(NaN);
   });
 
-  bench("Number.isInteger", {
-    run: () => {
-      const a = Number.isInteger(42);
-      const b = Number.isInteger(3.14);
-      const c = Number.isInteger(0);
-    },
+  bench("Number.isInteger", () => {
+    const a = Number.isInteger(42);
+    const b = Number.isInteger(3.14);
+    const c = Number.isInteger(0);
   });
 
-  bench("Number.parseInt and parseFloat", {
-    run: () => {
-      const a = Number.parseInt("42");
-      const b = Number.parseFloat("3.14");
-      const c = Number.parseInt("ff", 16);
-    },
+  bench("Number.parseInt and parseFloat", () => {
+    const a = Number.parseInt("42");
+    const b = Number.parseFloat("3.14");
+    const c = Number.parseInt("ff", 16);
   });
 });

--- a/benchmarks/objects.js
+++ b/benchmarks/objects.js
@@ -2,57 +2,51 @@
 description: Object operation benchmarks
 ---*/
 
-suite("object creation", () => {
-  bench("create simple object", {
-    run: () => {
-      const obj = { x: 1, y: 2, z: 3 };
-    },
+import { bench, group } from "goccia:microbench";
+
+group("object creation", () => {
+  bench("create simple object", () => {
+    const obj = { x: 1, y: 2, z: 3 };
   });
 
-  bench("create nested object", {
-    run: () => {
-      const obj = {
-        name: "test",
-        data: { x: 1, y: 2 },
-        meta: { created: true, version: 1 }
-      };
-    },
+  bench("create nested object", () => {
+    const obj = {
+      name: "test",
+      data: { x: 1, y: 2 },
+      meta: { created: true, version: 1 }
+    };
   });
 
-  bench("create 50 objects via Array.from", {
-    run: () => {
-      const arr = Array.from({ length: 50 }, (_, i) => ({ id: i, name: "item" }));
-    },
+  bench("create 50 objects via Array.from", () => {
+    const arr = Array.from({ length: 50 }, (_, i) => ({ id: i, name: "item" }));
   });
 });
 
-suite("object access", () => {
-  bench("property read", {
-    setup: () => ({ a: 1, b: 2, c: 3, d: 4, e: 5 }),
-    run: (obj) => {
+group("object access", () => {
+  bench("property read", ({ *setup() {
+    const obj = (() => ({ a: 1, b: 2, c: 3, d: 4, e: 5 }))();
+    yield () => {
       const sum = obj.a + obj.b + obj.c + obj.d + obj.e;
-    },
-  });
+    };
+  } }).setup);
 
-  bench("Object.keys", {
-    setup: () => ({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 }),
-    run: (obj) => {
+  bench("Object.keys", ({ *setup() {
+    const obj = (() => ({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 }))();
+    yield () => {
       const keys = Object.keys(obj);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("Object.entries", {
-    setup: () => ({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 }),
-    run: (obj) => {
+  bench("Object.entries", ({ *setup() {
+    const obj = (() => ({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 }))();
+    yield () => {
       const entries = Object.entries(obj);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("spread operator", {
-    run: () => {
-      const a = { x: 1, y: 2 };
-      const b = { z: 3, w: 4 };
-      const merged = { ...a, ...b };
-    },
+  bench("spread operator", () => {
+    const a = { x: 1, y: 2 };
+    const b = { z: 3, w: 4 };
+    const merged = { ...a, ...b };
   });
 });

--- a/benchmarks/promises.js
+++ b/benchmarks/promises.js
@@ -2,117 +2,95 @@
 description: Promise operation benchmarks
 ---*/
 
-suite("promises", () => {
-  bench("Promise.resolve(value)", {
-    run: () => {
-      Promise.resolve(42);
-    },
+import { bench, group } from "goccia:microbench";
+
+group("promises", () => {
+  bench("Promise.resolve(value)", () => {
+    Promise.resolve(42);
   });
 
-  bench("new Promise(resolve => resolve(value))", {
-    run: () => {
-      new Promise((resolve) => resolve(42));
-    },
+  bench("new Promise(resolve => resolve(value))", () => {
+    new Promise((resolve) => resolve(42));
   });
 
-  bench("Promise.reject(reason)", {
-    run: () => {
-      Promise.reject("err");
-    },
+  bench("Promise.reject(reason)", () => {
+    Promise.reject("err");
   });
 
-  bench("resolve + then (1 handler)", {
-    run: () => {
-      Promise.resolve(1).then((v) => v + 1);
-    },
+  bench("resolve + then (1 handler)", () => {
+    Promise.resolve(1).then((v) => v + 1);
   });
 
-  bench("resolve + then chain (3 deep)", {
-    run: () => {
-      Promise.resolve(1)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1);
-    },
+  bench("resolve + then chain (3 deep)", () => {
+    Promise.resolve(1)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1);
   });
 
-  bench("resolve + then chain (10 deep)", {
-    run: () => {
-      Promise.resolve(0)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1)
-        .then((v) => v + 1);
-    },
+  bench("resolve + then chain (10 deep)", () => {
+    Promise.resolve(0)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1)
+      .then((v) => v + 1);
   });
 
-  bench("reject + catch + then", {
-    run: () => {
-      Promise.reject("error")
-        .catch((e) => "recovered")
-        .then((v) => v);
-    },
+  bench("reject + catch + then", () => {
+    Promise.reject("error")
+      .catch((e) => "recovered")
+      .then((v) => v);
   });
 
-  bench("resolve + finally + then", {
-    run: () => {
-      Promise.resolve(42)
-        .finally(() => {})
-        .then((v) => v);
-    },
+  bench("resolve + finally + then", () => {
+    Promise.resolve(42)
+      .finally(() => {})
+      .then((v) => v);
   });
 
-  bench("Promise.all (5 resolved)", {
-    run: () => {
-      Promise.all([
-        Promise.resolve(1),
-        Promise.resolve(2),
-        Promise.resolve(3),
-        Promise.resolve(4),
-        Promise.resolve(5)
-      ]);
-    },
+  bench("Promise.all (5 resolved)", () => {
+    Promise.all([
+      Promise.resolve(1),
+      Promise.resolve(2),
+      Promise.resolve(3),
+      Promise.resolve(4),
+      Promise.resolve(5)
+    ]);
   });
 
-  bench("Promise.race (5 resolved)", {
-    run: () => {
-      Promise.race([
-        Promise.resolve(1),
-        Promise.resolve(2),
-        Promise.resolve(3),
-        Promise.resolve(4),
-        Promise.resolve(5)
-      ]);
-    },
+  bench("Promise.race (5 resolved)", () => {
+    Promise.race([
+      Promise.resolve(1),
+      Promise.resolve(2),
+      Promise.resolve(3),
+      Promise.resolve(4),
+      Promise.resolve(5)
+    ]);
   });
 
-  bench("Promise.allSettled (5 mixed)", {
-    run: () => {
-      Promise.allSettled([
-        Promise.resolve(1),
-        Promise.reject("err"),
-        Promise.resolve(3),
-        Promise.reject("err2"),
-        Promise.resolve(5)
-      ]);
-    },
+  bench("Promise.allSettled (5 mixed)", () => {
+    Promise.allSettled([
+      Promise.resolve(1),
+      Promise.reject("err"),
+      Promise.resolve(3),
+      Promise.reject("err2"),
+      Promise.resolve(5)
+    ]);
   });
 
-  bench("Promise.any (5 mixed)", {
-    run: () => {
-      Promise.any([
-        Promise.reject("err1"),
-        Promise.resolve(2),
-        Promise.reject("err3"),
-        Promise.resolve(4),
-        Promise.resolve(5)
-      ]);
-    },
+  bench("Promise.any (5 mixed)", () => {
+    Promise.any([
+      Promise.reject("err1"),
+      Promise.resolve(2),
+      Promise.reject("err3"),
+      Promise.resolve(4),
+      Promise.resolve(5)
+    ]);
   });
 });

--- a/benchmarks/property-access.js
+++ b/benchmarks/property-access.js
@@ -2,11 +2,13 @@
 description: Cross-instance property access benchmarks (shape-sensitive patterns)
 ---*/
 
+import { bench, group } from "goccia:microbench";
+
 const INSTANCE_COUNT = 1000;
 
-suite("cross-instance field reads", () => {
-  bench("class instance fields across 1000 instances", {
-    setup: () => {
+group("cross-instance field reads", () => {
+  bench("class instance fields across 1000 instances", ({ *setup() {
+    const points = (() => {
       class Point {
         x;
         y;
@@ -16,29 +18,29 @@ suite("cross-instance field reads", () => {
         }
       }
       return Array.from({ length: INSTANCE_COUNT }, (_, i) => new Point(i, i * 2));
-    },
-    run: (points) => {
+    })();
+    yield () => {
       let sum = 0;
       for (const p of points) {
         sum += p.x + p.y;
       }
       return sum;
-    },
-  });
+    };
+  } }).setup);
 
-  bench("object literal fields across 1000 literals", {
-    setup: () => Array.from({ length: INSTANCE_COUNT }, (_, i) => ({ x: i, y: i * 2 })),
-    run: (objects) => {
+  bench("object literal fields across 1000 literals", ({ *setup() {
+    const objects = (() => Array.from({ length: INSTANCE_COUNT }, (_, i) => ({ x: i, y: i * 2 })))();
+    yield () => {
       let sum = 0;
       for (const o of objects) {
         sum += o.x + o.y;
       }
       return sum;
-    },
-  });
+    };
+  } }).setup);
 
-  bench("mixed-shape literals across 1000 literals", {
-    setup: () =>
+  bench("mixed-shape literals across 1000 literals", ({ *setup() {
+    const objects = (() =>
       Array.from({ length: INSTANCE_COUNT }, (_, i) => {
         switch (i % 4) {
           case 0:
@@ -50,20 +52,20 @@ suite("cross-instance field reads", () => {
           default:
             return { pad: true, x: i, y: i * 2 };
         }
-      }),
-    run: (objects) => {
+      }))();
+    yield () => {
       let sum = 0;
       for (const o of objects) {
         sum += o.x + o.y;
       }
       return sum;
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("cross-instance method dispatch", () => {
-  bench("own-class method across 1000 instances", {
-    setup: () => {
+group("cross-instance method dispatch", () => {
+  bench("own-class method across 1000 instances", ({ *setup() {
+    const points = (() => {
       class Point {
         x;
         y;
@@ -76,18 +78,18 @@ suite("cross-instance method dispatch", () => {
         }
       }
       return Array.from({ length: INSTANCE_COUNT }, (_, i) => new Point(i, i * 2));
-    },
-    run: (points) => {
+    })();
+    yield () => {
       let sum = 0;
       for (const p of points) {
         sum += p.norm();
       }
       return sum;
-    },
-  });
+    };
+  } }).setup);
 
-  bench("inherited method across 1000 instances", {
-    setup: () => {
+  bench("inherited method across 1000 instances", ({ *setup() {
+    const points = (() => {
       class Base {
         x;
         constructor(x) {
@@ -105,13 +107,13 @@ suite("cross-instance method dispatch", () => {
         }
       }
       return Array.from({ length: INSTANCE_COUNT }, (_, i) => new Derived(i, i * 2));
-    },
-    run: (points) => {
+    })();
+    yield () => {
       let sum = 0;
       for (const p of points) {
         sum += p.value();
       }
       return sum;
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/regexp.js
+++ b/benchmarks/regexp.js
@@ -2,94 +2,92 @@
 description: RegExp constructor, prototype, and string integration benchmarks
 ---*/
 
-suite("RegExp construction", () => {
-  bench("regex literal creation", {
-    run: () => {
-      const regex = /foo(bar)?/gi;
-    },
+import { bench, group } from "goccia:microbench";
+
+group("RegExp construction", () => {
+  bench("regex literal creation", () => {
+    const regex = /foo(bar)?/gi;
   });
 
-  bench("new RegExp(pattern, flags)", {
-    run: () => {
-      const regex = new RegExp("foo(bar)?", "gi");
-    },
+  bench("new RegExp(pattern, flags)", () => {
+    const regex = new RegExp("foo(bar)?", "gi");
   });
 
-  bench("RegExp(existingRegex) returns the same regex", {
-    setup: () => /foo(bar)?/gi,
-    run: (regex) => {
+  bench("RegExp(existingRegex) returns the same regex", ({ *setup() {
+    const regex = (() => /foo(bar)?/gi)();
+    yield () => {
       const result = RegExp(regex);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("RegExp prototype methods", () => {
-  bench("test() on a global regex", {
-    setup: () => ({
+group("RegExp prototype methods", () => {
+  bench("test() on a global regex", ({ *setup() {
+    const { regex, input } = (() => ({
       regex: /foo/g,
       input: "foo bar foo baz foo",
-    }),
-    run: ({ regex, input }) => {
+    }))();
+    yield () => {
       regex.lastIndex = 0;
       const matched = regex.test(input);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("exec() with capture groups", {
-    setup: () => ({
+  bench("exec() with capture groups", ({ *setup() {
+    const { regex, input } = (() => ({
       regex: /(foo)(bar)?/g,
       input: "foo foobar foo",
-    }),
-    run: ({ regex, input }) => {
+    }))();
+    yield () => {
       regex.lastIndex = 0;
       const match = regex.exec(input);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("toString()", {
-    setup: () => /foo(bar)?/gim,
-    run: (regex) => {
+  bench("toString()", ({ *setup() {
+    const regex = (() => /foo(bar)?/gim)();
+    yield () => {
       const value = regex.toString();
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("String integration with RegExp", () => {
-  bench("match() with global regex", {
-    setup: () => "foo bar foo baz foo",
-    run: (input) => {
+group("String integration with RegExp", () => {
+  bench("match() with global regex", ({ *setup() {
+    const input = (() => "foo bar foo baz foo")();
+    yield () => {
       const matches = input.match(/foo/g);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("matchAll() with capture groups", {
-    setup: () => "foo1 foo2 foo3",
-    run: (input) => {
+  bench("matchAll() with capture groups", ({ *setup() {
+    const input = (() => "foo1 foo2 foo3")();
+    yield () => {
       const results = [];
-      for (const match of input.matchAll(/(foo)(\d)/g)) {
+      for (const match of input.matchAll(/(foo)([0-9])/g)) {
         results.push(match[1]);
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("replace() with global regex", {
-    setup: () => "foo bar foo baz foo",
-    run: (input) => {
+  bench("replace() with global regex", ({ *setup() {
+    const input = (() => "foo bar foo baz foo")();
+    yield () => {
       const replaced = input.replace(/foo/g, "qux");
-    },
-  });
+    };
+  } }).setup);
 
-  bench("search() with regex", {
-    setup: () => "alpha beta gamma delta",
-    run: (input) => {
+  bench("search() with regex", ({ *setup() {
+    const input = (() => "alpha beta gamma delta")();
+    yield () => {
       const index = input.search(/gamma/);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("split() with regex separator", {
-    setup: () => "foo,bar;baz,qux",
-    run: (input) => {
+  bench("split() with regex separator", ({ *setup() {
+    const input = (() => "foo,bar;baz,qux")();
+    yield () => {
       const parts = input.split(/[;,]/);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/strings.js
+++ b/benchmarks/strings.js
@@ -2,153 +2,121 @@
 description: String operation benchmarks
 ---*/
 
-suite("string creation", () => {
-  bench("string concatenation", {
-    run: () => {
-      const result = "hello" + " " + "world" + "!" + " " + "foo" + " " + "bar";
-    },
+import { bench, group } from "goccia:microbench";
+
+group("string creation", () => {
+  bench("string concatenation", () => {
+    const result = "hello" + " " + "world" + "!" + " " + "foo" + " " + "bar";
   });
 
-  bench("template literal", {
-    run: () => {
-      const name = "world";
-      const greeting = `hello ${name}! welcome to ${name}`;
-    },
+  bench("template literal", () => {
+    const name = "world";
+    const greeting = `hello ${name}! welcome to ${name}`;
   });
 
-  bench("string repeat", {
-    run: () => {
-      const result = "abc".repeat(50);
-    },
+  bench("string repeat", () => {
+    const result = "abc".repeat(50);
   });
 });
 
-suite("string methods", () => {
-  bench("split and join", {
-    run: () => {
-      const str = "one,two,three,four,five,six,seven,eight,nine,ten";
-      const parts = str.split(",");
-      const joined = parts.join("-");
-    },
+group("string methods", () => {
+  bench("split and join", () => {
+    const str = "one,two,three,four,five,six,seven,eight,nine,ten";
+    const parts = str.split(",");
+    const joined = parts.join("-");
   });
 
-  bench("indexOf and includes", {
-    run: () => {
-      const str = "the quick brown fox jumps over the lazy dog";
-      const a = str.indexOf("fox");
-      const b = str.includes("lazy");
-      const c = str.indexOf("cat");
-    },
+  bench("indexOf and includes", () => {
+    const str = "the quick brown fox jumps over the lazy dog";
+    const a = str.indexOf("fox");
+    const b = str.includes("lazy");
+    const c = str.indexOf("cat");
   });
 
-  bench("toUpperCase and toLowerCase", {
-    run: () => {
-      const str = "Hello World From GocciaScript";
-      const upper = str.toUpperCase();
-      const lower = str.toLowerCase();
-    },
+  bench("toUpperCase and toLowerCase", () => {
+    const str = "Hello World From GocciaScript";
+    const upper = str.toUpperCase();
+    const lower = str.toLowerCase();
   });
 
-  bench("slice and substring", {
-    run: () => {
-      const str = "abcdefghijklmnopqrstuvwxyz";
-      const a = str.slice(5, 15);
-      const b = str.substring(10, 20);
-      const c = str.slice(-5);
-    },
+  bench("slice and substring", () => {
+    const str = "abcdefghijklmnopqrstuvwxyz";
+    const a = str.slice(5, 15);
+    const b = str.substring(10, 20);
+    const c = str.slice(-5);
   });
 
-  bench("trim operations", {
-    run: () => {
-      const str = "   hello world   ";
-      const a = str.trim();
-      const b = str.trimStart();
-      const c = str.trimEnd();
-    },
+  bench("trim operations", () => {
+    const str = "   hello world   ";
+    const a = str.trim();
+    const b = str.trimStart();
+    const c = str.trimEnd();
   });
 
-  bench("replace and replaceAll", {
-    run: () => {
-      const str = "foo bar foo baz foo";
-      const a = str.replace("foo", "qux");
-      const b = str.replaceAll("foo", "qux");
-    },
+  bench("replace and replaceAll", () => {
+    const str = "foo bar foo baz foo";
+    const a = str.replace("foo", "qux");
+    const b = str.replaceAll("foo", "qux");
   });
 
-  bench("startsWith and endsWith", {
-    run: () => {
-      const str = "hello world";
-      const a = str.startsWith("hello");
-      const b = str.endsWith("world");
-      const c = str.startsWith("world");
-      const d = str.endsWith("hello");
-    },
+  bench("startsWith and endsWith", () => {
+    const str = "hello world";
+    const a = str.startsWith("hello");
+    const b = str.endsWith("world");
+    const c = str.startsWith("world");
+    const d = str.endsWith("hello");
   });
 
-  bench("padStart and padEnd", {
-    run: () => {
-      const str = "42";
-      const a = str.padStart(8, "0");
-      const b = str.padEnd(8, ".");
-    },
+  bench("padStart and padEnd", () => {
+    const str = "42";
+    const a = str.padStart(8, "0");
+    const b = str.padEnd(8, ".");
   });
 });
 
-suite("tagged templates", () => {
+group("tagged templates", () => {
   // Baseline: identity tag — measures pure tag dispatch + template object construction cost
   const identity = (strings) => strings[0];
 
-  bench("identity tag, no substitutions", {
-    run: () => {
-      const result = identity`hello world`;
-    },
+  bench("identity tag, no substitutions", () => {
+    const result = identity`hello world`;
   });
 
   // Compare tag dispatch against equivalent plain function call
   const join = (strings, ...values) =>
     strings.reduce((acc, str, i) => acc + str + (values[i] !== undefined ? String(values[i]) : ""), "");
 
-  bench("tag with 1 substitution", {
-    run: () => {
-      const x = 42;
-      const result = join`value: ${x}`;
-    },
+  bench("tag with 1 substitution", () => {
+    const x = 42;
+    const result = join`value: ${x}`;
   });
 
-  bench("tag with 3 substitutions", {
-    run: () => {
-      const a = 1;
-      const b = 2;
-      const c = 3;
-      const result = join`${a} + ${b} = ${c}`;
-    },
+  bench("tag with 3 substitutions", () => {
+    const a = 1;
+    const b = 2;
+    const c = 3;
+    const result = join`${a} + ${b} = ${c}`;
   });
 
-  bench("tag with 6 substitutions", {
-    run: () => {
-      const a = 1;
-      const b = 2;
-      const c = 3;
-      const d = 4;
-      const e = 5;
-      const f = 6;
-      const result = join`${a}-${b}-${c}-${d}-${e}-${f}`;
-    },
+  bench("tag with 6 substitutions", () => {
+    const a = 1;
+    const b = 2;
+    const c = 3;
+    const d = 4;
+    const e = 5;
+    const f = 6;
+    const result = join`${a}-${b}-${c}-${d}-${e}-${f}`;
   });
 
   // String.raw: measures the built-in tag path
-  bench("String.raw, no substitutions", {
-    run: () => {
-      const result = String.raw`hello\nworld\ttab`;
-    },
+  bench("String.raw, no substitutions", () => {
+    const result = String.raw`hello\nworld\ttab`;
   });
 
-  bench("String.raw, 2 substitutions", {
-    run: () => {
-      const a = "foo";
-      const b = "bar";
-      const result = String.raw`prefix\t${a}\n${b}\tsuffix`;
-    },
+  bench("String.raw, 2 substitutions", () => {
+    const a = "foo";
+    const b = "bar";
+    const result = String.raw`prefix\t${a}\n${b}\tsuffix`;
   });
 
   // Accessing .raw inside tag — measures template object property access
@@ -156,10 +124,8 @@ suite("tagged templates", () => {
     strings.raw.reduce((acc, str, i) =>
       acc + str + (i < strings.raw.length - 1 ? "|" : ""), "");
 
-  bench("tag accessing .raw array", {
-    run: () => {
-      const result = rawJoin`line\none\ttwo\\three`;
-    },
+  bench("tag accessing .raw array", () => {
+    const result = rawJoin`line\none\ttwo\\three`;
   });
 
   // Method as tag — measures this-binding through member expression tag
@@ -172,11 +138,9 @@ suite("tagged templates", () => {
     },
   };
 
-  bench("method as tag (this binding)", {
-    run: () => {
-      const level = "info";
-      const msg = "started";
-      const result = formatter.tag`${level}: ${msg}`;
-    },
+  bench("method as tag (this binding)", () => {
+    const level = "info";
+    const msg = "started";
+    const result = formatter.tag`${level}: ${msg}`;
   });
 });

--- a/benchmarks/temporal.js
+++ b/benchmarks/temporal.js
@@ -2,55 +2,55 @@
 description: Temporal operation benchmarks
 ---*/
 
-suite("Temporal.PlainDate arithmetic", () => {
-  bench("PlainDate.add({ months: 1 })", {
-    setup: () => Temporal.PlainDate.from("2024-01-31"),
-    run: (date) => {
-      const next = date.add({ months: 1 });
-    },
-  });
+import { bench, group } from "goccia:microbench";
 
-  bench("PlainDate.until(..., { largestUnit: 'months' })", {
-    setup: () => ({
+group("Temporal.PlainDate arithmetic", () => {
+  bench("PlainDate.add({ months: 1 })", ({ *setup() {
+    const date = (() => Temporal.PlainDate.from("2024-01-31"))();
+    yield () => {
+      const next = date.add({ months: 1 });
+    };
+  } }).setup);
+
+  bench("PlainDate.until(..., { largestUnit: 'months' })", ({ *setup() {
+    const ctx = (() => ({
       start: Temporal.PlainDate.from("2024-01-01"),
       end: Temporal.PlainDate.from("2025-07-15"),
-    }),
-    run: (ctx) => {
+    }))();
+    yield () => {
       const duration = ctx.start.until(ctx.end, { largestUnit: "months" });
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Temporal.Duration balancing", () => {
-  bench("Duration.total days relative to PlainDate", {
-    setup: () => Temporal.Duration.from({ years: 1, months: 6, days: 3 }),
-    run: (duration) => {
+group("Temporal.Duration balancing", () => {
+  bench("Duration.total days relative to PlainDate", ({ *setup() {
+    const duration = (() => Temporal.Duration.from({ years: 1, months: 6, days: 3 }))();
+    yield () => {
       const days = duration.total({ unit: "days", relativeTo: "2024-01-01" });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("Duration.round to hours", {
-    setup: () => Temporal.Duration.from({ hours: 1, minutes: 45, seconds: 30 }),
-    run: (duration) => {
+  bench("Duration.round to hours", ({ *setup() {
+    const duration = (() => Temporal.Duration.from({ hours: 1, minutes: 45, seconds: 30 }))();
+    yield () => {
       const rounded = duration.round({ smallestUnit: "hours", roundingMode: "halfExpand" });
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("Temporal.ZonedDateTime", () => {
-  bench("ZonedDateTime.from named time zone", {
-    run: () => {
-      const zdt = Temporal.ZonedDateTime.from("2024-03-10T12:30:00-04:00[America/New_York]");
-    },
+group("Temporal.ZonedDateTime", () => {
+  bench("ZonedDateTime.from named time zone", () => {
+    const zdt = Temporal.ZonedDateTime.from("2024-03-10T12:30:00-04:00[America/New_York]");
   });
 
-  bench("ZonedDateTime.since across DST", {
-    setup: () => ({
+  bench("ZonedDateTime.since across DST", ({ *setup() {
+    const ctx = (() => ({
       start: Temporal.ZonedDateTime.from("2024-03-09T00:00:00-05:00[America/New_York]"),
       end: Temporal.ZonedDateTime.from("2024-03-10T12:30:00-04:00[America/New_York]"),
-    }),
-    run: (ctx) => {
+    }))();
+    yield () => {
       const duration = ctx.end.since(ctx.start, { largestUnit: "days" });
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/tsv.js
+++ b/benchmarks/tsv.js
@@ -2,109 +2,109 @@
 description: TSV parse and stringify benchmarks
 ---*/
 
-suite("TSV.parse", () => {
-  bench("parse simple 3-column TSV", {
-    run: () => {
-      const result = TSV.parse("name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\nCharlie\t35\tChicago");
-    },
+import { bench, group } from "goccia:microbench";
+
+group("TSV.parse", () => {
+  bench("parse simple 3-column TSV", () => {
+    const result = TSV.parse("name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\nCharlie\t35\tChicago");
   });
 
-  bench("parse 10-row TSV", {
-    setup: () => {
+  bench("parse 10-row TSV", ({ *setup() {
+    const tsv = (() => {
       const header = "id\tname\temail\tscore\tactive";
       const rows = Array.from({ length: 10 }, (_, i) =>
         i + "\tuser" + i + "\tuser" + i + "@test.com\t" + (i * 10) + "\ttrue"
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (tsv) => {
+    })();
+    yield () => {
       const result = TSV.parse(tsv);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("parse 100-row TSV", {
-    setup: () => {
+  bench("parse 100-row TSV", ({ *setup() {
+    const tsv = (() => {
       const header = "id\tname\tvalue";
       const rows = Array.from({ length: 100 }, (_, i) =>
         i + "\titem" + i + "\t" + (i * 3.14)
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (tsv) => {
+    })();
+    yield () => {
       const result = TSV.parse(tsv);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("parse TSV with backslash-escaped fields", {
-    setup: () => {
+  bench("parse TSV with backslash-escaped fields", ({ *setup() {
+    const tsv = (() => {
       const header = "path\tline";
       const rows = Array.from({ length: 20 }, (_, i) =>
         "C:\\\\Users\\\\test" + i + "\tline" + i + "\\nand more"
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (tsv) => {
+    })();
+    yield () => {
       const result = TSV.parse(tsv);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("parse without headers (array of arrays)", {
-    setup: () => {
+  bench("parse without headers (array of arrays)", ({ *setup() {
+    const tsv = (() => {
       return Array.from({ length: 50 }, (_, i) =>
         i + "\t" + (i * 2) + "\t" + (i * 3)
       ).join("\n");
-    },
-    run: (tsv) => {
+    })();
+    yield () => {
       const result = TSV.parse(tsv, { headers: false });
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("TSV.stringify", () => {
-  bench("stringify array of objects", {
-    setup: () => Array.from({ length: 10 }, (_, i) => ({
+group("TSV.stringify", () => {
+  bench("stringify array of objects", ({ *setup() {
+    const data = (() => Array.from({ length: 10 }, (_, i) => ({
       id: String(i),
       name: "user" + i,
       active: "true",
-    })),
-    run: (data) => {
+    })))();
+    yield () => {
       const s = TSV.stringify(data);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("stringify array of arrays", {
-    setup: () => Array.from({ length: 50 }, (_, i) => [
+  bench("stringify array of arrays", ({ *setup() {
+    const data = (() => Array.from({ length: 50 }, (_, i) => [
       String(i), "item" + i, String(i * 2),
-    ]),
-    run: (data) => {
+    ]))();
+    yield () => {
       const s = TSV.stringify(data, { headers: false });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("stringify with values needing escaping", {
-    setup: () => Array.from({ length: 10 }, (_, i) => ({
+  bench("stringify with values needing escaping", ({ *setup() {
+    const data = (() => Array.from({ length: 10 }, (_, i) => ({
       path: "C:\\Users\\test",
       note: "line1\nline2",
       tab: "col1\tcol2",
-    })),
-    run: (data) => {
+    })))();
+    yield () => {
       const s = TSV.stringify(data);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("TSV roundtrip", () => {
-  bench("parse then stringify", {
-    setup: () => {
+group("TSV roundtrip", () => {
+  bench("parse then stringify", ({ *setup() {
+    const tsv = (() => {
       const header = "id\tname\tscore";
       const rows = Array.from({ length: 20 }, (_, i) =>
         i + "\tuser" + i + "\t" + (i * 10)
       );
       return header + "\n" + rows.join("\n");
-    },
-    run: (tsv) => {
+    })();
+    yield () => {
       const parsed = TSV.parse(tsv);
       const back = TSV.stringify(parsed);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/typed-arrays.js
+++ b/benchmarks/typed-arrays.js
@@ -2,33 +2,27 @@
 description: TypedArray operation benchmarks
 ---*/
 
-suite("TypedArray creation", () => {
-  bench("new Int32Array(0)", {
-    run: () => {
-      const ta = new Int32Array(0);
-    },
+import { bench, group } from "goccia:microbench";
+
+group("TypedArray creation", () => {
+  bench("new Int32Array(0)", () => {
+    const ta = new Int32Array(0);
   });
 
-  bench("new Int32Array(100)", {
-    run: () => {
-      const ta = new Int32Array(100);
-    },
+  bench("new Int32Array(100)", () => {
+    const ta = new Int32Array(100);
   });
 
-  bench("new Int32Array(1000)", {
-    run: () => {
-      const ta = new Int32Array(1000);
-    },
+  bench("new Int32Array(1000)", () => {
+    const ta = new Int32Array(1000);
   });
 
-  bench("new Float64Array(100)", {
-    run: () => {
-      const ta = new Float64Array(100);
-    },
+  bench("new Float64Array(100)", () => {
+    const ta = new Float64Array(100);
   });
 
-  bench("Int32Array.from([...])", {
-    setup: () => {
+  bench("Int32Array.from([...])", ({ *setup() {
+    const arr = (() => {
       const arr = [];
       let i = 0;
       for (const _ of Array(100).keys()) {
@@ -36,89 +30,87 @@ suite("TypedArray creation", () => {
         i = i + 1;
       }
       return arr;
-    },
-    run: (arr) => {
+    })();
+    yield () => {
       const ta = Int32Array.from(arr);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("Int32Array.of(1, 2, 3, 4, 5)", {
-    run: () => {
-      const ta = Int32Array.of(1, 2, 3, 4, 5);
-    },
+  bench("Int32Array.of(1, 2, 3, 4, 5)", () => {
+    const ta = Int32Array.of(1, 2, 3, 4, 5);
   });
 });
 
-suite("TypedArray element access", () => {
-  bench("sequential write 100 elements", {
-    setup: () => new Int32Array(100),
-    run: (ta) => {
+group("TypedArray element access", () => {
+  bench("sequential write 100 elements", ({ *setup() {
+    const ta = (() => new Int32Array(100))();
+    yield () => {
       let i = 0;
       for (const idx of Array(100).keys()) {
         ta[idx] = i;
         i = i + 1;
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("sequential read 100 elements", {
-    setup: () => {
+  bench("sequential read 100 elements", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       ta.fill(42);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       let sum = 0;
       for (const idx of Array(100).keys()) {
         sum = sum + ta[idx];
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("Float64Array write 100 elements", {
-    setup: () => new Float64Array(100),
-    run: (ta) => {
+  bench("Float64Array write 100 elements", ({ *setup() {
+    const ta = (() => new Float64Array(100))();
+    yield () => {
       let i = 0;
       for (const idx of Array(100).keys()) {
         ta[idx] = i * 1.5;
         i = i + 1;
       }
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("TypedArray methods", () => {
-  bench("fill(42)", {
-    setup: () => new Int32Array(1000),
-    run: (ta) => {
+group("TypedArray methods", () => {
+  bench("fill(42)", ({ *setup() {
+    const ta = (() => new Int32Array(1000))();
+    yield () => {
       ta.fill(42);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("slice()", {
-    setup: () => {
+  bench("slice()", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       ta.fill(1);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const sliced = ta.slice();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("map(x => x * 2)", {
-    setup: () => {
+  bench("map(x => x * 2)", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       ta.fill(5);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const mapped = ta.map((x) => x * 2);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("filter(x => x > 50)", {
-    setup: () => {
+  bench("filter(x => x > 50)", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       let i = 0;
       for (const idx of Array(100).keys()) {
@@ -126,25 +118,25 @@ suite("TypedArray methods", () => {
         i = i + 1;
       }
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const filtered = ta.filter((x) => x > 50);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("reduce (sum)", {
-    setup: () => {
+  bench("reduce (sum)", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       ta.fill(1);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const sum = ta.reduce((acc, x) => acc + x, 0);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("sort()", {
-    setup: () => {
+  bench("sort()", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       let i = 100;
       for (const idx of Array(100).keys()) {
@@ -152,14 +144,14 @@ suite("TypedArray methods", () => {
         i = i - 1;
       }
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       ta.sort();
-    },
-  });
+    };
+  } }).setup);
 
-  bench("indexOf()", {
-    setup: () => {
+  bench("indexOf()", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       let i = 0;
       for (const idx of Array(100).keys()) {
@@ -167,78 +159,78 @@ suite("TypedArray methods", () => {
         i = i + 1;
       }
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const idx = ta.indexOf(50);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("reverse()", {
-    setup: () => {
+  bench("reverse()", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       ta.fill(1);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       ta.reverse();
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("TypedArray buffer sharing", () => {
-  bench("create view over existing buffer", {
-    setup: () => new ArrayBuffer(400),
-    run: (buf) => {
+group("TypedArray buffer sharing", () => {
+  bench("create view over existing buffer", ({ *setup() {
+    const buf = (() => new ArrayBuffer(400))();
+    yield () => {
       const view = new Int32Array(buf);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("subarray()", {
-    setup: () => {
+  bench("subarray()", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       ta.fill(42);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const sub = ta.subarray(10, 50);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("set() from array", {
-    setup: () => {
+  bench("set() from array", ({ *setup() {
+    const ctx = (() => {
       const ta = new Int32Array(100);
       const src = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
       return { ta, src };
-    },
-    run: (ctx) => {
+    })();
+    yield () => {
       ctx.ta.set(ctx.src);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("TypedArray iteration", () => {
-  bench("for-of loop", {
-    setup: () => {
+group("TypedArray iteration", () => {
+  bench("for-of loop", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(100);
       ta.fill(1);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       let sum = 0;
       for (const v of ta) {
         sum = sum + v;
       }
-    },
-  });
+    };
+  } }).setup);
 
-  bench("spread into array", {
-    setup: () => {
+  bench("spread into array", ({ *setup() {
+    const ta = (() => {
       const ta = new Int32Array(50);
       ta.fill(1);
       return ta;
-    },
-    run: (ta) => {
+    })();
+    yield () => {
       const arr = [...ta];
-    },
-  });
+    };
+  } }).setup);
 });

--- a/benchmarks/uint8array-encoding.js
+++ b/benchmarks/uint8array-encoding.js
@@ -2,6 +2,8 @@
 description: Uint8Array Base64 and Hex encoding/decoding benchmarks
 ---*/
 
+import { bench, group } from "goccia:microbench";
+
 const SHORT_BYTES = new Uint8Array([72, 101, 108, 108, 111]);
 const MEDIUM_BYTES = new Uint8Array(450);
 const LARGE_BYTES = new Uint8Array(4096);
@@ -18,124 +20,92 @@ const SHORT_HEX = SHORT_BYTES.toHex();
 const MEDIUM_HEX = MEDIUM_BYTES.toHex();
 const LARGE_HEX = LARGE_BYTES.toHex();
 
-suite("Uint8Array.prototype.toBase64", () => {
-  bench("short (5 bytes)", {
-    run: () => {
-      SHORT_BYTES.toBase64();
-    },
+group("Uint8Array.prototype.toBase64", () => {
+  bench("short (5 bytes)", () => {
+    SHORT_BYTES.toBase64();
   });
 
-  bench("medium (450 bytes)", {
-    run: () => {
-      MEDIUM_BYTES.toBase64();
-    },
+  bench("medium (450 bytes)", () => {
+    MEDIUM_BYTES.toBase64();
   });
 
-  bench("large (4096 bytes)", {
-    run: () => {
-      LARGE_BYTES.toBase64();
-    },
+  bench("large (4096 bytes)", () => {
+    LARGE_BYTES.toBase64();
   });
 
-  bench("base64url alphabet", {
-    run: () => {
-      MEDIUM_BYTES.toBase64({ alphabet: "base64url" });
-    },
+  bench("base64url alphabet", () => {
+    MEDIUM_BYTES.toBase64({ alphabet: "base64url" });
   });
 
-  bench("omitPadding", {
-    run: () => {
-      SHORT_BYTES.toBase64({ omitPadding: true });
-    },
+  bench("omitPadding", () => {
+    SHORT_BYTES.toBase64({ omitPadding: true });
   });
 });
 
-suite("Uint8Array.fromBase64", () => {
-  bench("short (8 chars)", {
-    run: () => {
-      Uint8Array.fromBase64(SHORT_B64);
-    },
+group("Uint8Array.fromBase64", () => {
+  bench("short (8 chars)", () => {
+    Uint8Array.fromBase64(SHORT_B64);
   });
 
-  bench("medium (600 chars)", {
-    run: () => {
-      Uint8Array.fromBase64(MEDIUM_B64);
-    },
+  bench("medium (600 chars)", () => {
+    Uint8Array.fromBase64(MEDIUM_B64);
   });
 
-  bench("large (5464 chars)", {
-    run: () => {
-      Uint8Array.fromBase64(LARGE_B64);
-    },
+  bench("large (5464 chars)", () => {
+    Uint8Array.fromBase64(LARGE_B64);
   });
 });
 
-suite("Uint8Array.prototype.toHex", () => {
-  bench("short (5 bytes)", {
-    run: () => {
-      SHORT_BYTES.toHex();
-    },
+group("Uint8Array.prototype.toHex", () => {
+  bench("short (5 bytes)", () => {
+    SHORT_BYTES.toHex();
   });
 
-  bench("medium (450 bytes)", {
-    run: () => {
-      MEDIUM_BYTES.toHex();
-    },
+  bench("medium (450 bytes)", () => {
+    MEDIUM_BYTES.toHex();
   });
 
-  bench("large (4096 bytes)", {
-    run: () => {
-      LARGE_BYTES.toHex();
-    },
+  bench("large (4096 bytes)", () => {
+    LARGE_BYTES.toHex();
   });
 });
 
-suite("Uint8Array.fromHex", () => {
-  bench("short (10 chars)", {
-    run: () => {
-      Uint8Array.fromHex(SHORT_HEX);
-    },
+group("Uint8Array.fromHex", () => {
+  bench("short (10 chars)", () => {
+    Uint8Array.fromHex(SHORT_HEX);
   });
 
-  bench("medium (900 chars)", {
-    run: () => {
-      Uint8Array.fromHex(MEDIUM_HEX);
-    },
+  bench("medium (900 chars)", () => {
+    Uint8Array.fromHex(MEDIUM_HEX);
   });
 
-  bench("large (8192 chars)", {
-    run: () => {
-      Uint8Array.fromHex(LARGE_HEX);
-    },
+  bench("large (8192 chars)", () => {
+    Uint8Array.fromHex(LARGE_HEX);
   });
 });
 
-suite("Uint8Array setFrom* (in-place)", () => {
-  bench("setFromBase64 (450 bytes)", {
-    setup: () => new Uint8Array(450),
-    run: (target) => {
+group("Uint8Array setFrom* (in-place)", () => {
+  bench("setFromBase64 (450 bytes)", ({ *setup() {
+    const target = (() => new Uint8Array(450))();
+    yield () => {
       target.setFromBase64(MEDIUM_B64);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("setFromHex (450 bytes)", {
-    setup: () => new Uint8Array(450),
-    run: (target) => {
+  bench("setFromHex (450 bytes)", ({ *setup() {
+    const target = (() => new Uint8Array(450))();
+    yield () => {
       target.setFromHex(MEDIUM_HEX);
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("round-trip", () => {
-  bench("toBase64 → fromBase64 (450 bytes)", {
-    run: () => {
-      Uint8Array.fromBase64(MEDIUM_BYTES.toBase64());
-    },
+group("round-trip", () => {
+  bench("toBase64 → fromBase64 (450 bytes)", () => {
+    Uint8Array.fromBase64(MEDIUM_BYTES.toBase64());
   });
 
-  bench("toHex → fromHex (450 bytes)", {
-    run: () => {
-      Uint8Array.fromHex(MEDIUM_BYTES.toHex());
-    },
+  bench("toHex → fromHex (450 bytes)", () => {
+    Uint8Array.fromHex(MEDIUM_BYTES.toHex());
   });
 });

--- a/benchmarks/weak-collections.js
+++ b/benchmarks/weak-collections.js
@@ -2,53 +2,55 @@
 description: WeakMap and WeakSet weak collection benchmarks
 ---*/
 
+import { bench, group } from "goccia:microbench";
+
 const makeObjectKeys = () => Array.from({ length: 50 }, (_, i) => ({ index: i }));
 const makeEntries = () => makeObjectKeys().map((key, i) => [key, { value: i }]);
 
-suite("WeakMap operations", () => {
-  bench("constructor from 50 entries", {
-    setup: makeEntries,
-    run: (entries) => {
+group("WeakMap operations", () => {
+  bench("constructor from 50 entries", ({ *setup() {
+    const entries = makeEntries();
+    yield () => {
       const map = new WeakMap(entries);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("set 50 object keys", {
-    setup: makeObjectKeys,
-    run: (keys) => {
+  bench("set 50 object keys", ({ *setup() {
+    const keys = makeObjectKeys();
+    yield () => {
       const map = new WeakMap();
       keys.forEach((key, i) => { map.set(key, i); });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("get lookups (50 entries)", {
-    setup: () => {
+  bench("get lookups (50 entries)", ({ *setup() {
+    const state = (() => {
       const entries = makeEntries();
       return { map: new WeakMap(entries), keys: entries.map((entry) => entry[0]) };
-    },
-    run: (state) => {
+    })();
+    yield () => {
       const a = state.map.get(state.keys[0]);
       const b = state.map.get(state.keys[25]);
       const c = state.map.get(state.keys[49]);
       const d = state.map.get({});
-    },
-  });
+    };
+  } }).setup);
 
-  bench("has checks (50 entries)", {
-    setup: () => {
+  bench("has checks (50 entries)", ({ *setup() {
+    const state = (() => {
       const entries = makeEntries();
       return { map: new WeakMap(entries), keys: entries.map((entry) => entry[0]) };
-    },
-    run: (state) => {
+    })();
+    yield () => {
       const a = state.map.has(state.keys[0]);
       const b = state.map.has(state.keys[25]);
       const c = state.map.has({});
-    },
-  });
+    };
+  } }).setup);
 
-  bench("delete entries", {
-    setup: makeObjectKeys,
-    run: (keys) => {
+  bench("delete entries", ({ *setup() {
+    const keys = makeObjectKeys();
+    yield () => {
       const map = new WeakMap();
       keys.forEach((key, i) => { map.set(key, i); });
       map.delete(keys[0]);
@@ -56,115 +58,115 @@ suite("WeakMap operations", () => {
       map.delete(keys[20]);
       map.delete(keys[30]);
       map.delete(keys[40]);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("non-registered symbol keys", {
-    setup: () => Array.from({ length: 20 }, (_, i) => Symbol("weak-map-" + i)),
-    run: (keys) => {
+  bench("non-registered symbol keys", ({ *setup() {
+    const keys = (() => Array.from({ length: 20 }, (_, i) => Symbol("weak-map-" + i)))();
+    yield () => {
       const map = new WeakMap();
       keys.forEach((key, i) => { map.set(key, i); });
       const value = map.get(keys[10]);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("getOrInsert", {
-    setup: makeObjectKeys,
-    run: (keys) => {
+  bench("getOrInsert", ({ *setup() {
+    const keys = makeObjectKeys();
+    yield () => {
       const map = new WeakMap();
       keys.forEach((key, i) => {
         const value = map.getOrInsert(key, i);
       });
       const existing = map.getOrInsert(keys[25], "existing");
-    },
-  });
+    };
+  } }).setup);
 
-  bench("getOrInsertComputed", {
-    setup: makeObjectKeys,
-    run: (keys) => {
+  bench("getOrInsertComputed", ({ *setup() {
+    const keys = makeObjectKeys();
+    yield () => {
       const map = new WeakMap();
       keys.forEach((key, i) => {
         const value = map.getOrInsertComputed(key, () => i);
       });
       const existing = map.getOrInsertComputed(keys[25], () => "existing");
-    },
-  });
+    };
+  } }).setup);
 
-  bench("forced gc live-key retention", {
-    setup: () => {
+  bench("forced gc live-key retention", ({ *setup() {
+    const state = (() => {
       const key = {};
       return { key, map: new WeakMap([[key, { value: 1 }]]) };
-    },
-    run: (state) => {
+    })();
+    yield () => {
       Array.from({ length: 20 }, (_, i) => i).forEach((i) => {
         state.map.set({ key: i }, { value: i });
       });
       Goccia.gc();
       const retained = state.map.get(state.key).value;
-    },
-  });
+    };
+  } }).setup);
 });
 
-suite("WeakSet operations", () => {
-  bench("constructor from 50 values", {
-    setup: makeObjectKeys,
-    run: (values) => {
+group("WeakSet operations", () => {
+  bench("constructor from 50 values", ({ *setup() {
+    const values = makeObjectKeys();
+    yield () => {
       const set = new WeakSet(values);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("add 50 object values", {
-    setup: makeObjectKeys,
-    run: (values) => {
+  bench("add 50 object values", ({ *setup() {
+    const values = makeObjectKeys();
+    yield () => {
       const set = new WeakSet();
       values.forEach((value) => { set.add(value); });
-    },
-  });
+    };
+  } }).setup);
 
-  bench("has checks (50 values)", {
-    setup: () => {
+  bench("has checks (50 values)", ({ *setup() {
+    const state = (() => {
       const values = makeObjectKeys();
       return { set: new WeakSet(values), values };
-    },
-    run: (state) => {
+    })();
+    yield () => {
       const a = state.set.has(state.values[0]);
       const b = state.set.has(state.values[25]);
       const c = state.set.has({});
-    },
-  });
+    };
+  } }).setup);
 
-  bench("delete values", {
-    setup: makeObjectKeys,
-    run: (values) => {
+  bench("delete values", ({ *setup() {
+    const values = makeObjectKeys();
+    yield () => {
       const set = new WeakSet(values);
       set.delete(values[0]);
       set.delete(values[10]);
       set.delete(values[20]);
       set.delete(values[30]);
       set.delete(values[40]);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("non-registered symbol values", {
-    setup: () => Array.from({ length: 20 }, (_, i) => Symbol("weak-set-" + i)),
-    run: (values) => {
+  bench("non-registered symbol values", ({ *setup() {
+    const values = (() => Array.from({ length: 20 }, (_, i) => Symbol("weak-set-" + i)))();
+    yield () => {
       const set = new WeakSet();
       values.forEach((value) => { set.add(value); });
       const present = set.has(values[10]);
-    },
-  });
+    };
+  } }).setup);
 
-  bench("forced gc pruning smoke", {
-    setup: () => {
+  bench("forced gc pruning smoke", ({ *setup() {
+    const state = (() => {
       const live = {};
       return { live, set: new WeakSet([live]) };
-    },
-    run: (state) => {
+    })();
+    yield () => {
       Array.from({ length: 20 }, (_, i) => i).forEach((i) => {
         state.set.add({ value: i });
       });
       Goccia.gc();
       const retained = state.set.has(state.live);
-    },
-  });
+    };
+  } }).setup);
 });

--- a/docs/adding-built-in-types.md
+++ b/docs/adding-built-in-types.md
@@ -545,21 +545,21 @@ Create `benchmarks/yourtype.js`:
 description: YourType operation benchmarks
 ---*/
 
-suite("YourType creation", () => {
-  bench("create YourType", {
-    run: () => {
-      const obj = new YourType();
-    },
+import { bench, group } from "goccia:microbench";
+
+group("YourType creation", () => {
+  bench("create YourType", () => {
+    const obj = new YourType();
   });
 });
 
-suite("YourType methods", () => {
-  bench("method call", {
-    setup: () => new YourType(),
-    run: (obj) => {
+group("YourType methods", () => {
+  bench("method call", ({ *setup() {
+    const obj = new YourType();
+    yield () => {
       obj.method();
-    },
-  });
+    };
+  } }).setup);
 });
 ```
 

--- a/docs/adr/0087-awfy-cross-engine-benchmark-methodology.md
+++ b/docs/adr/0087-awfy-cross-engine-benchmark-methodology.md
@@ -71,9 +71,9 @@ Consequences:
   web-tooling as transfer proof for the worst measured hotspots.
 - Existing `GocciaBenchmarkRunner` remains the in-repo benchmark runner and CI PR
   comparison surface. The AWFY driver is an external-shell comparison lane for
-  reference engines that do not provide Goccia's injected `suite`/`bench` API,
+  reference engines that do not provide Goccia's `"goccia:microbench"` API,
   and its raw probes stay outside `benchmarks/` so CI does not mistake them for
-  runner-managed `suite()` files.
+  runner-managed benchmark files.
 - Strict-types probes are Goccia-only because type annotations are not portable
   JavaScript syntax for Node or QuickJS; they are paired with untyped probes for
   cross-engine context.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,14 +4,14 @@
 
 ## Executive Summary
 
-- **`suite`/`bench` API** — `bench(name, { setup?, run, teardown? })` with auto-calibration, warmup, and IQR outlier filtering
+- **Module-only benchmark API** — Import `bench`, `group`, `run`, `summary`, and `boxplot` from `"goccia:microbench"`; no benchmark helpers are ambient globals
 - **Five output formats** — `console` (default), `text`, `csv`, `json`, `compact-json`; configurable via `--format` and `--output`
 - **Profiler-backed runs** — Bytecode benchmark runs can emit opcode/function profiles with `--profile`, including deterministic single-run capture
 - **CI integration** — PR workflow posts benchmark comparison comments with range-overlap classification; main CI retains deterministic profile reports
 - **Environment tuning** — Calibration time, warmup iterations, and measurement rounds configurable via environment variables
-- **Cross-engine AWFY lane** — `scripts/awfy-driver.js` runs pinned AWFY and `perf/probes/` diagnostics under GocciaScript, QuickJS, and Node without mixing them into the `suite`/`bench` corpus
+- **Cross-engine AWFY lane** — `scripts/awfy-driver.js` runs pinned AWFY and `perf/probes/` diagnostics under GocciaScript, QuickJS, and Node without mixing them into the benchmark-runner corpus
 
-GocciaScript includes a benchmark runner for measuring execution performance. Benchmarks live in the `benchmarks/` directory and use a `suite`/`bench` API.
+GocciaScript includes a benchmark runner for measuring execution performance. Benchmarks live in the `benchmarks/` directory and import the benchmark API from `"goccia:microbench"`.
 
 ## Running Benchmarks
 
@@ -26,8 +26,8 @@ GocciaScript includes a benchmark runner for measuring execution performance. Be
 ./build/GocciaBenchmarkRunner benchmarks/fibonacci.js
 
 # Run a benchmark from stdin
-printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/GocciaBenchmarkRunner
-printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/GocciaBenchmarkRunner - --mode=bytecode
+printf 'import { bench, group } from "goccia:microbench"; group("stdin", () => { bench("sum", () => 1 + 1); });\n' | ./build/GocciaBenchmarkRunner --source-type=module
+printf 'import { bench, group } from "goccia:microbench"; group("stdin", () => { bench("sum", () => 1 + 1); });\n' | ./build/GocciaBenchmarkRunner - --source-type=module --mode=bytecode
 
 # Run benchmarks with 2 parallel workers (default: CPU count)
 ./build/GocciaBenchmarkRunner benchmarks --jobs=2
@@ -53,7 +53,7 @@ The GocciaBenchmarkRunner supports five output formats via the `--format` option
 
 | Format | Description |
 |--------|-------------|
-| `console` (default) | Pretty-printed columnar output with suite headers, variance, setup/teardown times, and summary |
+| `console` (default) | Pretty-printed columnar output with group headers, variance, setup/teardown times, and summary |
 | `text` | Compact one-line-per-benchmark format with optional `setup=Xms teardown=Xms` suffixes |
 | `csv` | Standard CSV with header row (`file,suite,name,ops_per_sec,variance_percentage,mean_ms,iterations,setup_ms,teardown_ms,error`) |
 | `json` | Structured JSON with the common CLI envelope (`build`, aggregate `output`, `timing`, `memory`, `workers`) and a `files[]` array containing each `fileName`, per-file timing, and nested `benchmarks[]`, including `opsPerSec`, `variancePercentage`, `minOpsPerSec`, `maxOpsPerSec`, `setupMs`, and `teardownMs` |
@@ -83,10 +83,10 @@ allocation attribution:
 
 For deterministic CI signals, add `--profile-deterministic`. This skips warmup,
 calibration, and repeated measurement rounds, then runs each registered benchmark
-once through the existing `setup`/`run`/`teardown` path. If `--profile` is not
-provided, it defaults to `--profile=all`. The benchmark report remains
-structurally valid, but throughput fields are placeholders; use the profile JSON
-for deterministic comparisons.
+once through the same setup/measurement/teardown lifecycle used by normal
+benchmark runs. If `--profile` is not provided, it defaults to `--profile=all`.
+The benchmark report remains structurally valid, but throughput fields are
+placeholders; use the profile JSON for deterministic comparisons.
 
 ```bash
 ./build/GocciaBenchmarkRunner benchmarks/numbers.js \
@@ -119,48 +119,93 @@ GOCCIA_BENCH_CALIBRATION_MS=500 GOCCIA_BENCH_ROUNDS=15 ./build/GocciaBenchmarkRu
 
 ## Writing Benchmarks
 
-The `bench()` function takes a name and an options object with `setup`, `run`, and `teardown` fields:
+Import benchmark helpers from `"goccia:microbench"`:
 
 ```javascript
-suite("collections", () => {
-  bench("Set iteration", {
-    setup: () => new Set(Array.from({ length: 50 }, (_, i) => i)),
-    run: (s) => {
-      let sum = 0;
-      s.forEach((v) => { sum = sum + v; });
-    },
-    teardown: (s) => { s.clear(); },
-  });
+import { bench, group, summary, boxplot } from "goccia:microbench";
 
-  bench("simple computation", {
-    run: () => {
-      const result = 1 + 2 + 3;
+group("collections", () => {
+  const setIteration = {
+    *run() {
+      const set = new Set(Array.from({ length: 50 }, (_, i) => i));
+      try {
+        yield () => {
+          let sum = 0;
+          set.forEach((v) => { sum = sum + v; });
+        };
+      } finally {
+        set.clear();
+      }
     },
+  }.run;
+
+  bench("Set iteration", setIteration);
+
+  bench("simple computation", () => {
+    const result = 1 + 2 + 3;
+  });
+});
+
+summary(() => {
+  boxplot(() => {
+    group("numbers", () => {
+      bench("addition", () => 1 + 1);
+    });
   });
 });
 ```
 
 ### API
 
-- **`setup`** (optional): Called once before warmup. Its return value is passed as the first argument to `run` and `teardown`, even when that value is `undefined`.
-- **`run`** (required): The timed benchmark function. Called many times during warmup, calibration, and measurement.
-- **`teardown`** (optional): Called once after all measurement rounds complete. Receives the setup return value.
-- All three phases are independently timed and reported as `setupMs`, `teardownMs`, and the main `opsPerSec`/`meanMs` metrics.
+The primary benchmark form is `bench(name, fn)`, where `fn` is called many times during measurement. Generator callbacks provide setup and teardown without including that setup cost in the measured body:
+
+```javascript
+import { bench, group } from "goccia:microbench";
+
+group("collections", () => {
+  const setIteration = {
+    *run() {
+      const set = new Set(Array.from({ length: 50 }, (_, i) => i));
+      try {
+        yield () => {
+          let sum = 0;
+          set.forEach((v) => { sum = sum + v; });
+        };
+      } finally {
+        set.clear();
+      }
+    },
+  }.run;
+
+  bench("Set iteration", setIteration);
+
+  bench("simple computation", () => {
+    const result = 1 + 2 + 3;
+  });
+});
+```
+
+- Code before the generator's first `yield` is setup.
+- The yielded function is the timed benchmark body.
+- Cleanup that must run during generator close belongs in a `finally` block around the `yield`.
+- Setup and teardown are independently timed and reported as `setupMs`, `teardownMs`, and the main `opsPerSec`/`meanMs` metrics.
+- `summary(fn)` and `boxplot(fn)` are accepted output-shaping wrappers. Rich percentile and chart rendering belongs to issue #855, so today they should be treated as registration wrappers rather than a promise of additional report fields.
+- `run(opts?)` executes the currently registered benchmarks from script code. `GocciaBenchmarkRunner` also auto-runs registered benchmarks after loading a file, but a script-callable `run()` consumes the pending registry so the runner does not measure the same benchmarks twice.
 
 ### Data flow
 
 ```text
-setup() → [return value] → warmup(run × N) → calibrate(run × N) → measure(run × N × rounds) → teardown()
-   ↓                                                                    ↓                          ↓
- setupMs                                                        opsPerSec, meanMs, variance   teardownMs
+setup before yield → yielded run function → warmup/calibrate/measure → close generator
+        ↓                         ↓                                      ↓
+     setupMs             opsPerSec, meanMs, variance                 teardownMs
 ```
 
 ### Guidelines
 
-- Use `setup` to create data structures that the `run` function operates on. This isolates allocation cost from the operation being measured.
-- Use `teardown` for cleanup when the setup creates resources that should be explicitly released.
-- When the benchmark IS the creation (e.g., measuring `Array.from` speed), put everything in `run` with no `setup`.
-- The `run` function can be `async` for benchmarking async/await operations.
+- Use generator setup to create data structures that the yielded benchmark function operates on. This isolates allocation cost from the operation being measured.
+- Put cleanup in a generator `finally` block when setup creates resources that should be explicitly released.
+- When the benchmark IS the creation (e.g., measuring `Array.from` speed), use a plain benchmark function with no setup.
+- The benchmark function can be `async` for benchmarking async/await operations.
 
 ## How the GocciaBenchmarkRunner Works
 
@@ -169,15 +214,15 @@ The `GocciaBenchmarkRunner` program:
 1. Parses CLI inputs (`--format`, `--output`, and the benchmark path or stdin marker).
 2. Scans the provided path for `.js` files.
 3. For each file, creates a `TGocciaEngine`, attaches `TGocciaRuntimeCore`, applies the loader runtime profile, and installs the benchmark runtime extension.
-4. Loads and executes the source so benchmark files register their suites and benchmarks without running measurements from inside the script body.
+4. Loads and executes the source so benchmark files import `"goccia:microbench"` and register groups and benchmarks.
 5. Measures lex, parse, compile (bytecode mode), script execution, and benchmark execution phases separately with nanosecond precision via `TimingUtils.GetNanoseconds`.
-6. `suite()` calls execute immediately, registering `bench()` entries.
-7. After the script finishes, the runner invokes `runBenchmarks()` from Pascal to run each registered benchmark:
-   - **Setup:** Calls the `setup` function once (timed), caches the return value.
-   - **Warmup:** Configurable iterations to stabilize (default 5). The setup return value is passed to each call.
+6. `group()` calls execute immediately, registering nested `bench()` entries.
+7. After the script finishes, the runner auto-runs any benchmarks that were registered but not already consumed by a script-callable `run()`:
+   - **Setup:** Advances generator callbacks to their first `yield` (timed) when a benchmark uses generator-style setup.
+   - **Warmup:** Configurable iterations to stabilize (default 5). The yielded function or plain benchmark function is called for each iteration.
    - **Calibrate:** Scales batch size until it runs for at least the target calibration time (default 200ms). Uses nanosecond-resolution timing via `TimingUtils` (`clock_gettime(CLOCK_MONOTONIC)` on Unix/macOS, `QueryPerformanceCounter` on Windows).
    - **Measure:** Runs multiple measurement rounds (default 7). GC is disabled during measurement for identical behavior in both interpreter and bytecode modes. Between rounds, `CollectYoung` reclaims measurement garbage efficiently (pre-marks old objects, only traverses new allocations). After all rounds, IQR-based outlier filtering removes noise spikes before computing the coefficient of variation (CV%) and median values.
-   - **Teardown:** Calls the `teardown` function once (timed) after measurement completes.
+   - **Teardown:** Closes generator callbacks after measurement (timed), running `finally` cleanup when present.
 8. After each file completes, `GC.Collect` runs to reclaim memory between script executions.
 9. Collects all results into a `TBenchmarkReporter`, which renders the chosen output format.
 10. After rendering, checks for failures via `TBenchmarkReporter.HasFailures`. If any benchmark entry has a non-empty `Error` field or zero `OpsPerSec`/`MeanMs`, the process exits with code 1.
@@ -195,9 +240,11 @@ The non-zero exit code ensures CI pipelines fail when benchmarks crash or produc
 
 | Function | Description |
 |----------|-------------|
-| `suite(name, fn)` | Group benchmarks (like `describe` in tests). Executes `fn` immediately. |
-| `bench(name, { setup?, run, teardown? })` | Register a benchmark with optional setup/teardown. `run` is called many times during measurement; `setup` and `teardown` run once each and are independently timed. |
-| `runBenchmarks()` | Execute all registered benchmarks and return results. GocciaBenchmarkRunner calls this automatically after the benchmark file finishes registering suites. |
+| `bench(name, fn)` | Register a benchmark function. `fn` is called many times during measurement; generator callbacks use pre-yield setup, a yielded measured function, and `finally` cleanup on close. |
+| `group(name, fn)` | Group benchmarks (like `describe` in tests). Executes `fn` immediately. |
+| `run(opts?)` | Execute registered benchmarks from script code and return results. Calling `run()` prevents the runner's post-load auto-run from measuring the same registry again. |
+| `summary(fn)` | Accepted registration wrapper for summary-shaped output. Richer summary reporting is tracked in #855. |
+| `boxplot(fn)` | Accepted registration wrapper for boxplot-shaped output. Richer chart output is tracked in #855. |
 
 ## Available Benchmarks
 
@@ -301,10 +348,10 @@ The PR workflow (`.github/workflows/pr.yml`) builds the PR's base commit (`main`
 ## AWFY Cross-Engine Lane
 
 The `benchmarks/` directory is reserved for `GocciaBenchmarkRunner` inputs that
-register `suite()` / `bench()` cases. Cross-engine AWFY and diagnostic
+import `"goccia:microbench"` and register `group()` / `bench()` cases. Cross-engine AWFY and diagnostic
 probes live under `perf/` because they are plain shell-portable scripts driven by
 Node tooling, not benchmark-runner files. This keeps CI's recursive benchmark
-scan from treating diagnostic probes as missing `suite()` files.
+scan from treating diagnostic probes as missing benchmark-runner inputs.
 
 Use `scripts/awfy-driver.js` for #856/#862 investigation:
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -86,7 +86,7 @@ then diagnose the reported source line only if the same target still fails.
 ```bash
 ./build.pas loader && ./build/GocciaScriptLoader ./example.js
 printf "const x = 2 + 2; x;" | ./build/GocciaScriptLoader
-printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/GocciaBenchmarkRunner
+printf 'import { bench, group } from "goccia:microbench"; group("stdin", () => { bench("sum", () => 1 + 1); });\n' | ./build/GocciaBenchmarkRunner --source-type=module
 ```
 
 Both loaders are silent about the script's last evaluated value unless you pass `--print`. For local dev that's fine; for CI scripts and shell pipelines that previously parsed `Result: <value>` from the loader's stdout, pass `--print` and parse the bare value on the line after the timing banner — or switch to `--output=json` and read the `result` field, which is always populated regardless of `--print`.
@@ -214,7 +214,7 @@ printf '1;\n---\n2;\n---\n3;\n' | ./build/GocciaScriptLoader --multifile
 
 # Run benchmarks via bytecode VM
 ./build/GocciaBenchmarkRunner benchmarks --mode=bytecode
-printf 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n' | ./build/GocciaBenchmarkRunner - --mode=bytecode
+printf 'import { bench, group } from "goccia:microbench"; group("stdin", () => { bench("sum", () => 1 + 1); });\n' | ./build/GocciaBenchmarkRunner - --source-type=module --mode=bytecode
 ```
 
 ### `--multifile` (split a single input on `---` separators)

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -834,12 +834,14 @@ All matchers support `.not` negation: `expect(value).not.toBe(wrong)`.
 
 ### Benchmark (`Goccia.Builtins.Benchmark.pas`)
 
-Only available when `TGocciaBenchmarkRuntimeExtension` is installed in the runtime (used by the GocciaBenchmarkRunner). See [benchmarks.md](benchmarks.md) for usage, output formats, and CI integration.
+Only available when `TGocciaBenchmarkRuntimeExtension` is installed in the runtime (used by the GocciaBenchmarkRunner). The benchmark API is import-only from `"goccia:microbench"`; it does not install ambient `suite`, `bench`, or `runBenchmarks` globals. See [benchmarks.md](benchmarks.md) for usage, output formats, and CI integration.
 
 **Benchmark structure:**
 
 ```javascript
-suite("group name", () => {
+import { bench, group } from "goccia:microbench";
+
+group("group name", () => {
   bench("benchmark name", () => {
     // Code to benchmark — called many times during measurement
     someOperation();
@@ -851,11 +853,13 @@ suite("group name", () => {
 
 | Function | Description |
 |----------|-------------|
-| `suite(name, fn)` | Group benchmarks. Executes `fn` immediately to register `bench` entries. |
-| `bench(name, fn)` | Register a benchmark function. Called repeatedly during calibration and measurement. |
-| `runBenchmarks()` | Execute all registered benchmarks and return results. GocciaBenchmarkRunner calls this automatically after benchmark files register suites. |
+| `bench(name, fn)` | Register a benchmark function. Called repeatedly during calibration and measurement. Generator callbacks can provide setup around a yielded measured function, with `finally` cleanup on close. |
+| `group(name, fn)` | Group benchmarks. Executes `fn` immediately to register `bench` entries. |
+| `run(opts?)` | Execute registered benchmarks from script code. GocciaBenchmarkRunner also auto-runs registered benchmarks after loading a file, unless `run()` already consumed that registry. |
+| `summary(fn)` | Accepted registration wrapper for summary-shaped output. Richer summary reporting is tracked separately. |
+| `boxplot(fn)` | Accepted registration wrapper for boxplot-shaped output. Richer chart output is tracked separately. |
 
-**Result object** (returned by `runBenchmarks()`):
+**Result object** (returned by `run()`):
 
 Each benchmark result includes: `name`, `suite`, `opsPerSec`, `meanMs`, `iterations`, `totalMs`, `variancePercentage`, and optionally `error`.
 

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2242,6 +2242,42 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
       if (!profile.functions.some((fn: Record<string, unknown>) => typeof fn.allocations === "number"))
         throw new Error("Deterministic profile should include function allocation counts");
     }
+    const scriptRunProfileBench = join(tmp, "profile-deterministic-script-run.js");
+    const scriptRunProfileOut = join(tmp, "profile-script-run.json");
+    writeFileSync(scriptRunProfileBench, microbenchModuleWithExports("bench, group, run", [
+      "let count = 0;",
+      'group("profile-script-run", () => {',
+      '  bench("reruns deterministically", () => { count++; });',
+      "});",
+      "run();",
+    ]));
+    {
+      const proc = Bun.spawnSync(
+        [
+          resolve(BENCHRUNNER),
+          scriptRunProfileBench,
+          "--source-type=module",
+          "--profile-deterministic",
+          "--profile=all",
+          `--profile-output=${scriptRunProfileOut}`,
+          "--no-progress",
+          "--format=compact-json",
+        ],
+        { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
+      );
+      if (proc.exitCode !== 0) throw new Error(`Deterministic script-run profile benchmark exit ${proc.exitCode}: ${proc.stderr.toString()}`);
+      const report = JSON.parse(proc.stdout.toString());
+      const bench = report.files?.[0]?.benchmarks?.[0];
+      if (bench?.iterations !== 1)
+        throw new Error(`Deterministic script-run profile report should record one iteration, got ${bench?.iterations}`);
+    }
+    {
+      const profile = JSON.parse(readFileSync(scriptRunProfileOut, "utf-8"));
+      if (!Array.isArray(profile.opcodes) || profile.opcodes.length === 0)
+        throw new Error("Deterministic script-run profile should include opcode counts");
+      if (!Array.isArray(profile.functions) || profile.functions.length === 0)
+        throw new Error("Deterministic script-run profile should include function counts");
+    }
 
     console.log("BenchmarkRunner: file benchmark JSON output...");
     if (!fileJson.includes('"totalBenchmarks":')) throw new Error('JSON should contain totalBenchmarks');

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -146,6 +146,13 @@ function assertCommonJsonFile(file: any, label: string, fileName: string, ok = t
   if (ok && file.error !== null) throw new Error(`${label} error should be null`);
 }
 
+function assertPreservesBodyFailure(outputPath: string, label: string): void {
+  const json = JSON.parse(readFileSync(outputPath, "utf-8"));
+  const message = json.files?.[0]?.benchmarks?.[0]?.error;
+  if (typeof message !== "string" || !message.includes("body failure") || message.includes("cleanup failure"))
+    throw new Error(`${label} should preserve body failure, got ${JSON.stringify(message)}`);
+}
+
 // ============================================================================
 // GocciaScriptLoader
 // ============================================================================
@@ -2369,13 +2376,13 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     const cleanupFailOut = join(tmp, "benchmark-cleanup-fail.json");
     writeFileSync(cleanupFailBench, microbenchModule([
       'group("cleanup", () => {',
-      '  bench("body error wins", ({ *setup() {',
+      '  bench("body error wins", function* () {',
       "    try {",
       '      yield () => { throw new Error("body failure"); };',
       "    } finally {",
       '      throw new Error("cleanup failure");',
       "    }",
-      "  } }).setup);",
+      "  });",
       "});",
     ]));
     {
@@ -2386,10 +2393,7 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
       if (proc.exitCode === 0) throw new Error("Generator cleanup failure preservation benchmark should fail");
     }
     {
-      const json = JSON.parse(readFileSync(cleanupFailOut, "utf-8"));
-      const message = json.files?.[0]?.benchmarks?.[0]?.error;
-      if (typeof message !== "string" || !message.includes("body failure") || message.includes("cleanup failure"))
-        throw new Error(`Generator cleanup should preserve body failure, got ${JSON.stringify(message)}`);
+      assertPreservesBodyFailure(cleanupFailOut, "Generator cleanup");
     }
     console.log("BenchmarkRunner: deterministic generator cleanup preserves original benchmark failure...");
     const deterministicCleanupFailOut = join(tmp, "benchmark-cleanup-fail-deterministic.json");
@@ -2412,10 +2416,7 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
       if (proc.exitCode === 0) throw new Error("Deterministic generator cleanup failure preservation benchmark should fail");
     }
     {
-      const json = JSON.parse(readFileSync(deterministicCleanupFailOut, "utf-8"));
-      const message = json.files?.[0]?.benchmarks?.[0]?.error;
-      if (typeof message !== "string" || !message.includes("body failure") || message.includes("cleanup failure"))
-        throw new Error(`Deterministic generator cleanup should preserve body failure, got ${JSON.stringify(message)}`);
+      assertPreservesBodyFailure(deterministicCleanupFailOut, "Deterministic generator cleanup");
     }
 
     console.log("BenchmarkRunner: callback timeout is enforced...");

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -35,6 +35,16 @@ import { makeTmpFactory, clean } from "./test-cli/tmpdir";
 
 const makeTmp = makeTmpFactory("goccia-apps-");
 
+const MICROBENCH_MODULE_IMPORT = 'import { bench, group } from "goccia:microbench";';
+
+function microbenchModule(lines: string[]): string {
+  return [MICROBENCH_MODULE_IMPORT, ...lines, ""].join("\n");
+}
+
+function microbenchModuleWithExports(exports: string, lines: string[]): string {
+  return [`import { ${exports} } from "goccia:microbench";`, ...lines, ""].join("\n");
+}
+
 async function withFetchTestServer(
   callback: (baseUrl: string) => void | Promise<void>,
 ): Promise<void> {
@@ -2088,13 +2098,17 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
   } as Record<string, string>;
 
   try {
-    const stdinSource = 'suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n';
+    const stdinSource = microbenchModule([
+      'group("stdin", () => {',
+      '  bench("sum", () => 1 + 1);',
+      "});",
+    ]);
 
     console.log("BenchmarkRunner: file benchmark (interpreted)...");
     const fileOut = join(tmp, "file-interp.json");
     {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "benchmarks/fibonacci.js", "--no-progress", "--format=json", `--output=${fileOut}`],
+        [resolve(BENCHRUNNER), "benchmarks/fibonacci.js", "--source-type=module", "--no-progress", "--format=json", `--output=${fileOut}`],
         { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
       );
       if (proc.exitCode !== 0) throw new Error(`File benchmark exit ${proc.exitCode}: ${proc.stderr.toString()}`);
@@ -2121,7 +2135,7 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     const fileBcOut = join(tmp, "file-bc.json");
     {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "benchmarks/fibonacci.js", "--no-progress", "--format=json", `--output=${fileBcOut}`, "--mode=bytecode"],
+        [resolve(BENCHRUNNER), "benchmarks/fibonacci.js", "--source-type=module", "--no-progress", "--format=json", `--output=${fileBcOut}`, "--mode=bytecode"],
         { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
       );
       if (proc.exitCode !== 0) throw new Error(`Bytecode file benchmark exit ${proc.exitCode}: ${proc.stderr.toString()}`);
@@ -2142,29 +2156,69 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
       if (valid.length === 0) throw new Error("Bytecode benchmark JSON should contain at least one valid result");
     }
 
+    console.log("BenchmarkRunner: microbench API is module-only and accepts wrappers...");
+    const moduleOnlyOut = join(tmp, "module-only.json");
+    {
+      const moduleOnlySource = microbenchModuleWithExports(
+        "bench as microBench, group as microGroup, summary, boxplot",
+        [
+          'if (typeof bench !== "undefined") throw new Error("ambient bench should not exist");',
+          'if (typeof group !== "undefined") throw new Error("ambient group should not exist");',
+          'if (typeof suite !== "undefined") throw new Error("ambient suite should not exist");',
+          'if (typeof runBenchmarks !== "undefined") throw new Error("ambient runBenchmarks should not exist");',
+          "summary(() => {",
+          "  boxplot(() => {",
+          '    microGroup("module-only", () => {',
+          '      microBench("sum", () => 1 + 1);',
+          "    });",
+          "  });",
+          "});",
+        ],
+      );
+      const proc = Bun.spawnSync(
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${moduleOnlyOut}`],
+        {
+          stdin: new TextEncoder().encode(moduleOnlySource),
+          stdout: "pipe",
+          stderr: "pipe",
+          env: benchEnv,
+          timeout: 120_000,
+        },
+      );
+      if (proc.exitCode !== 0) throw new Error(`Module-only microbench API exit ${proc.exitCode}: ${proc.stderr.toString()}`);
+    }
+    {
+      const json = JSON.parse(readFileSync(moduleOnlyOut, "utf-8"));
+      if (json.files?.[0]?.benchmarks?.[0]?.name !== "sum")
+        throw new Error(`Module-only microbench JSON should contain benchmark name "sum", got: ${JSON.stringify(json.files?.[0]?.benchmarks)}`);
+      if (json.totalBenchmarks !== 1)
+        throw new Error(`Module-only microbench JSON should contain totalBenchmarks: 1, got ${json.totalBenchmarks}`);
+    }
+
     console.log("BenchmarkRunner: deterministic profile mode...");
     const profileBench = join(tmp, "profile-deterministic.js");
     const profileOut = join(tmp, "profile.json");
-    writeFileSync(profileBench, [
+    writeFileSync(profileBench, microbenchModule([
       'let count = 0;',
-      'suite("profile", () => {',
-      '  bench("runs once", {',
-      '    setup: () => ({ value: 1 }),',
-      '    run: async (state) => {',
-      '      count = count + await Promise.resolve(state.value);',
-      '    },',
-      '    teardown: () => {',
+      "const profiledBenchmark = {",
+      "  *run() {",
+      "    const state = { value: 1 };",
+      "    yield async () => {",
+      "      count = count + await Promise.resolve(state.value);",
+      "    };",
       '      if (count !== 1) { throw new Error("expected one deterministic run, got " + count); }',
-      '    },',
-      '  });',
-      '});',
-      '',
-    ].join("\n"));
+      "  },",
+      "}.run;",
+      'group("profile", () => {',
+      '  bench("runs once", profiledBenchmark);',
+      "});",
+    ]));
     {
       const proc = Bun.spawnSync(
         [
           resolve(BENCHRUNNER),
           profileBench,
+          "--source-type=module",
           "--profile-deterministic",
           "--profile=all",
           `--profile-output=${profileOut}`,
@@ -2196,11 +2250,11 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     const benchA = join(tmp, "bench-a.js");
     const benchB = join(tmp, "bench-b.js");
     const multiBenchOut = join(tmp, "bench-multi.json");
-    writeFileSync(benchA, 'suite("a", () => { bench("one", { run: () => 1 + 1 }); });\n');
-    writeFileSync(benchB, 'suite("b", () => { bench("two", { run: () => 2 + 2 }); });\n');
+    writeFileSync(benchA, microbenchModule(['group("a", () => { bench("one", () => 1 + 1); });']));
+    writeFileSync(benchB, microbenchModule(['group("b", () => { bench("two", () => 2 + 2); });']));
     {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), benchA, benchB, "--no-progress", "--jobs=2", "--format=json", `--output=${multiBenchOut}`],
+        [resolve(BENCHRUNNER), benchA, benchB, "--source-type=module", "--no-progress", "--jobs=2", "--format=json", `--output=${multiBenchOut}`],
         { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
       );
       if (proc.exitCode !== 0) throw new Error(`Multi-file benchmark JSON exit ${proc.exitCode}: ${proc.stderr.toString()}`);
@@ -2230,7 +2284,7 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     const compactBenchOut = join(tmp, "bench-compact.json");
     {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), benchA, benchB, "--no-progress", "--jobs=2", "--format=compact-json", `--output=${compactBenchOut}`],
+        [resolve(BENCHRUNNER), benchA, benchB, "--source-type=module", "--no-progress", "--jobs=2", "--format=compact-json", `--output=${compactBenchOut}`],
         { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
       );
       if (proc.exitCode !== 0) throw new Error(`Benchmark --format=compact-json exit ${proc.exitCode}: ${proc.stderr.toString()}`);
@@ -2259,10 +2313,10 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     console.log("BenchmarkRunner: benchmark failure JSON output...");
     const failBench = join(tmp, "benchmark-fail.js");
     const failOut = join(tmp, "benchmark-fail.json");
-    writeFileSync(failBench, 'suite("fail", () => { bench("boom", { run: () => { throw new Error("boom"); } }); });\n');
+    writeFileSync(failBench, microbenchModule(['group("fail", () => { bench("boom", () => { throw new Error("boom"); }); });']));
     {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), failBench, "--no-progress", "--format=json", `--output=${failOut}`],
+        [resolve(BENCHRUNNER), failBench, "--source-type=module", "--no-progress", "--format=json", `--output=${failOut}`],
         { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
       );
       if (proc.exitCode === 0) throw new Error("Failing benchmark JSON export should fail");
@@ -2277,14 +2331,13 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
 
     console.log("BenchmarkRunner: callback timeout is enforced...");
     {
-      const timeoutSource = [
-        'suite("limit", () => {',
-        '  bench("loop", { run: () => { while (true) {} } });',
+      const timeoutSource = microbenchModule([
+        'group("limit", () => {',
+        '  bench("loop", () => { while (true) {} });',
         "});",
-        "",
-      ].join("\n");
+      ]);
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "--no-progress", "--timeout=1"],
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--timeout=1"],
         {
           stdin: new TextEncoder().encode(timeoutSource),
           stdout: "pipe",
@@ -2300,7 +2353,7 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     const stdinOutPath = join(tmp, "stdin-interp.json");
     {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "--no-progress", "--format=json", `--output=${stdinOutPath}`],
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${stdinOutPath}`],
         {
           stdin: new TextEncoder().encode(stdinSource),
           stdout: "pipe",
@@ -2318,19 +2371,26 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
       if (json.totalBenchmarks !== 1) throw new Error(`Stdin JSON should contain totalBenchmarks: 1, got ${json.totalBenchmarks}`);
     }
 
-    console.log("BenchmarkRunner: registered callbacks survive repeated runs...");
+    console.log("BenchmarkRunner: script-callable run avoids auto-run double measurement...");
     const repeatedRunOutPath = join(tmp, "repeated-run.json");
     {
-      const repeatedRunSource = [
-        'suite("twice", () => {',
-        '  bench("sum", { run: () => 1 + 1 });',
+      const repeatedRunSource = microbenchModuleWithExports("bench, group, run", [
+        "let setupCount = 0;",
+        "const failsIfMeasuredTwice = {",
+        "  *run() {",
+        "    setupCount++;",
+        '    if (setupCount > 1) throw new Error("benchmark was measured more than once");',
+        "    yield () => 1 + 1;",
+        "  },",
+        "}.run;",
+        'group("twice", () => {',
+        '  bench("sum", failsIfMeasuredTwice);',
         "});",
-        "runBenchmarks();",
+        "run();",
         "Goccia.gc();",
-        "",
-      ].join("\n");
+      ]);
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "--no-progress", "--format=json", `--output=${repeatedRunOutPath}`],
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${repeatedRunOutPath}`],
         {
           stdin: new TextEncoder().encode(repeatedRunSource),
           stdout: "pipe",
@@ -2351,7 +2411,7 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     const stdinBcOutPath = join(tmp, "stdin-bc.json");
     {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "--no-progress", "--format=json", `--output=${stdinBcOutPath}`, "--mode=bytecode"],
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${stdinBcOutPath}`, "--mode=bytecode"],
         {
           stdin: new TextEncoder().encode(stdinSource),
           stdout: "pipe",
@@ -2372,21 +2432,18 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     console.log("BenchmarkRunner: async generator bytecode benchmark...");
     const asyncGeneratorBcOutPath = join(tmp, "async-generator-bc.json");
     {
-      const asyncGeneratorSource = [
-        'suite("async generator", () => {',
+      const asyncGeneratorSource = microbenchModule([
+        'group("async generator", () => {',
         "  const source = { async *values() { yield 1; yield 2; } };",
-        '  bench("consume", {',
-        "    run: async () => {",
+        '  bench("consume", async () => {',
         "      let sum = 0;",
         "      for await (const value of source.values()) sum = sum + value;",
         "      return sum;",
-        "    },",
         "  });",
         "});",
-        "",
-      ].join("\n");
+      ]);
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "--no-progress", "--format=json", `--output=${asyncGeneratorBcOutPath}`, "--mode=bytecode"],
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${asyncGeneratorBcOutPath}`, "--mode=bytecode"],
         {
           stdin: new TextEncoder().encode(asyncGeneratorSource),
           stdout: "pipe",
@@ -2410,7 +2467,7 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     const emptyBcOutPath = join(tmp, "empty-bc.json");
     {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "--no-progress", "--format=json", `--output=${emptyBcOutPath}`, "--mode=bytecode"],
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${emptyBcOutPath}`, "--mode=bytecode"],
         {
           stdin: new TextEncoder().encode("const value = 1;\n"),
           stdout: "pipe",
@@ -3377,11 +3434,11 @@ console.log("BenchmarkRunner: --multifile produces multiple file entries...");
     const file = join(tmp, "bench.js");
     writeFileSync(
       file,
-      'suite("A", () => { bench("a", { run: () => 1 + 1, iterations: 10, warmup: 0, repeats: 1 }); });\n' +
+      microbenchModule(['group("A", () => { bench("a", () => 1 + 1); });']) +
       "---\n" +
-      'suite("B", () => { bench("b", { run: () => 2 + 2, iterations: 10, warmup: 0, repeats: 1 }); });\n',
+      microbenchModule(['group("B", () => { bench("b", () => 2 + 2); });']),
     );
-    const proc = Bun.spawnSync([BENCHRUNNER, "--multifile", "--no-progress", "--format=json", file], {
+    const proc = Bun.spawnSync([BENCHRUNNER, "--multifile", "--source-type=module", "--no-progress", "--format=json", file], {
       stdout: "pipe",
       stderr: "pipe",
       env: benchEnv,

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2364,6 +2364,59 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
       if (file?.ok !== false) throw new Error(`Failing benchmark file should mark ok=false, got ${file?.ok}`);
       if (typeof file?.error?.message !== "string") throw new Error("Failing benchmark file should include shared error object");
     }
+    console.log("BenchmarkRunner: generator cleanup preserves original benchmark failure...");
+    const cleanupFailBench = join(tmp, "benchmark-cleanup-fail.js");
+    const cleanupFailOut = join(tmp, "benchmark-cleanup-fail.json");
+    writeFileSync(cleanupFailBench, microbenchModule([
+      'group("cleanup", () => {',
+      '  bench("body error wins", ({ *setup() {',
+      "    try {",
+      '      yield () => { throw new Error("body failure"); };',
+      "    } finally {",
+      '      throw new Error("cleanup failure");',
+      "    }",
+      "  } }).setup);",
+      "});",
+    ]));
+    {
+      const proc = Bun.spawnSync(
+        [resolve(BENCHRUNNER), cleanupFailBench, "--source-type=module", "--no-progress", "--format=json", `--output=${cleanupFailOut}`],
+        { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
+      );
+      if (proc.exitCode === 0) throw new Error("Generator cleanup failure preservation benchmark should fail");
+    }
+    {
+      const json = JSON.parse(readFileSync(cleanupFailOut, "utf-8"));
+      const message = json.files?.[0]?.benchmarks?.[0]?.error;
+      if (typeof message !== "string" || !message.includes("body failure") || message.includes("cleanup failure"))
+        throw new Error(`Generator cleanup should preserve body failure, got ${JSON.stringify(message)}`);
+    }
+    console.log("BenchmarkRunner: deterministic generator cleanup preserves original benchmark failure...");
+    const deterministicCleanupFailOut = join(tmp, "benchmark-cleanup-fail-deterministic.json");
+    const deterministicCleanupProfileOut = join(tmp, "benchmark-cleanup-fail-profile.json");
+    {
+      const proc = Bun.spawnSync(
+        [
+          resolve(BENCHRUNNER),
+          cleanupFailBench,
+          "--source-type=module",
+          "--profile-deterministic",
+          "--profile=all",
+          `--profile-output=${deterministicCleanupProfileOut}`,
+          "--no-progress",
+          "--format=json",
+          `--output=${deterministicCleanupFailOut}`,
+        ],
+        { stdout: "pipe", stderr: "pipe", env: benchEnv, timeout: 120_000 },
+      );
+      if (proc.exitCode === 0) throw new Error("Deterministic generator cleanup failure preservation benchmark should fail");
+    }
+    {
+      const json = JSON.parse(readFileSync(deterministicCleanupFailOut, "utf-8"));
+      const message = json.files?.[0]?.benchmarks?.[0]?.error;
+      if (typeof message !== "string" || !message.includes("body failure") || message.includes("cleanup failure"))
+        throw new Error(`Deterministic generator cleanup should preserve body failure, got ${JSON.stringify(message)}`);
+    }
 
     console.log("BenchmarkRunner: callback timeout is enforced...");
     {

--- a/scripts/test-cli-config.ts
+++ b/scripts/test-cli-config.ts
@@ -69,6 +69,15 @@ type CompatAcrossAppsCase = {
   benchNeedle: string;
 };
 
+function microbenchScript(lines: string[]): string {
+  return [
+    'import("goccia:microbench").then(({ bench, group }) => {',
+    ...lines.map((line) => `  ${line}`),
+    "});",
+    "",
+  ].join("\n");
+}
+
 async function runCompatAcrossAppsCase(testCase: CompatAcrossAppsCase): Promise<void> {
   const tmp = makeTmp();
   try {
@@ -421,13 +430,11 @@ console.log("Per-file ASI config across all apps...");
     );
     writeFileSync(
       join(asiDir, "bench.js"),
-      [
-        'suite("asi", () => {',
-        '  bench("sum", {',
-        "    run: () => 1 + 1",
-        "  })",
+      microbenchScript([
+        'group("asi", () => {',
+        '  bench("sum", () => 1 + 1)',
         "})",
-      ].join("\n") + "\n",
+      ]),
     );
 
     // Strict subdirectory (no config)
@@ -520,16 +527,14 @@ console.log("Per-file unsafe-ffi config across runtime apps...");
     );
     writeFileSync(
       join(tmp, "bench.js"),
-      [
-        'suite("unsafe-ffi", () => {',
-        '  bench("global", {',
-        "    run: () => {",
+      microbenchScript([
+        'group("unsafe-ffi", () => {',
+        '  bench("global", () => {',
         '      if (typeof FFI !== "object") throw new Error("FFI missing");',
         "      return FFI.suffix;",
-        "    },",
         "  });",
         "});",
-      ].join("\n") + "\n",
+      ]),
     );
 
     const loaderNoConfig = await $`${LOADER} --print ${join(noConfigDir, "test.js")} 2>&1`.text();
@@ -597,16 +602,14 @@ console.log("Per-file unsafe-ffi config across runtime apps...");
     for (const name of ["a", "b"]) {
       writeFileSync(
         join(parallelBenchDir, `${name}.js`),
-        [
-          `suite("unsafe-ffi-${name}", () => {`,
-          '  bench("global", {',
-          "    run: () => {",
+        microbenchScript([
+          `group("unsafe-ffi-${name}", () => {`,
+          '  bench("global", () => {',
           '      if (typeof FFI !== "object") throw new Error("FFI missing");',
           "      return FFI.suffix;",
-          "    },",
           "  });",
           "});",
-        ].join("\n") + "\n",
+        ]),
       );
     }
     const benchParallel = Bun.spawnSync(
@@ -653,14 +656,12 @@ for (const testCase of [
       "while (false) {}",
       'test("warning recovery", () => { expect(2 + 2).toBe(4); });',
     ].join("\n") + "\n",
-    benchSource: [
+    benchSource: microbenchScript([
       "while (false) {}",
-      'suite("warning", () => {',
-      '  bench("recovery", {',
-      "    run: () => 1 + 1,",
-      "  });",
+      'group("warning", () => {',
+      '  bench("recovery", () => 1 + 1);',
       "});",
-    ].join("\n") + "\n",
+    ]),
     benchNeedle: "warning",
   },
   {
@@ -676,14 +677,12 @@ for (const testCase of [
       "  });",
       "});",
     ].join("\n") + "\n",
-    benchSource: [
+    benchSource: microbenchScript([
       "var z = 1;",
-      'suite("var", () => {',
-      '  bench("add", {',
-      "    run: () => z + 1,",
-      "  });",
+      'group("var", () => {',
+      '  bench("add", () => z + 1);',
       "});",
-    ].join("\n") + "\n",
+    ]),
     benchNeedle: "var",
   },
   {
@@ -700,17 +699,15 @@ for (const testCase of [
       "  });",
       "});",
     ].join("\n") + "\n",
-    benchSource: [
-      'suite("for", () => {',
-      '  bench("count", {',
-      "    run: () => {",
+    benchSource: microbenchScript([
+      'group("for", () => {',
+      '  bench("count", () => {',
       "      let s = 0;",
       "      for (let i = 0; i < 10; i++) s += i;",
       "      return s;",
-      "    },",
       "  });",
       "});",
-    ].join("\n") + "\n",
+    ]),
     benchNeedle: "for",
   },
   {
@@ -731,10 +728,9 @@ for (const testCase of [
       "  });",
       "});",
     ].join("\n") + "\n",
-    benchSource: [
-      'suite("while", () => {',
-      '  bench("count", {',
-      "    run: () => {",
+    benchSource: microbenchScript([
+      'group("while", () => {',
+      '  bench("count", () => {',
       "      let s = 0;",
       "      let i = 0;",
       "      while (i < 10) {",
@@ -742,10 +738,9 @@ for (const testCase of [
       "        i++;",
       "      }",
       "      return s;",
-      "    },",
       "  });",
       "});",
-    ].join("\n") + "\n",
+    ]),
     benchNeedle: "while",
   },
   {
@@ -754,13 +749,11 @@ for (const testCase of [
     loaderSource: '"1" == 1;\n',
     loaderExpectedLine: "true",
     testRunnerSource: 'test("loose equality", () => { expect("1" == 1).toBe(true); });\n',
-    benchSource: [
-      'suite("loose", () => {',
-      '  bench("eq", {',
-      '    run: () => "1" == 1,',
-      "  });",
+    benchSource: microbenchScript([
+      'group("loose", () => {',
+      '  bench("eq", () => "1" == 1);',
       "});",
-    ].join("\n") + "\n",
+    ]),
     benchNeedle: "loose",
   },
   {
@@ -769,14 +762,12 @@ for (const testCase of [
     loaderSource: nonStrictSource,
     loaderExpectedLine: "7",
     testRunnerSource: nonStrictSource + 'test("nonstrict", () => { expect(f(1, 2)).toBe(7); });\n',
-    benchSource: [
+    benchSource: microbenchScript([
       nonStrictSource,
-      'suite("nonstrict", () => {',
-      '  bench("call", {',
-      "    run: () => f(1, 2),",
-      "  });",
+      'group("nonstrict", () => {',
+      '  bench("call", () => f(1, 2));',
       "});",
-    ].join("\n") + "\n",
+    ]),
     benchNeedle: "nonstrict",
   },
 ]) {
@@ -1394,14 +1385,12 @@ console.log("--config works on BenchmarkRunner...");
     writeFileSync(join(cfgDir, "goccia.toml"), 'compat-asi = true\n');
     writeFileSync(
       join(tmp, "bench.js"),
-      [
+      microbenchScript([
         // No semicolons — proves --config-supplied ASI is in effect.
-        'suite("config-flag", () => {',
-        '  bench("sum", {',
-        "    run: () => 1 + 1",
-        "  })",
+        'group("config-flag", () => {',
+        '  bench("sum", () => 1 + 1)',
         "})",
-      ].join("\n") + "\n",
+      ]),
     );
 
     const proc = Bun.spawnSync(

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -67,11 +67,11 @@ console.log("Stdin smoke (TestRunner)...");
 
 console.log("Stdin smoke (BenchmarkRunner)...");
 {
-  const src = `suite("stdin", () => { bench("sum", { run: () => 1 + 1 }); });\n`;
-  const out = await $`echo ${src} | ${BENCHRUNNER} --no-progress 2>&1`.text();
+  const src = `import { bench, group } from "goccia:microbench"; group("stdin", () => { bench("sum", () => 1 + 1); });\n`;
+  const out = await $`echo ${src} | ${BENCHRUNNER} --source-type=module --no-progress 2>&1`.text();
   if (!out.includes("sum")) throw new Error(`BenchmarkRunner stdin expected "sum" benchmark, got: ${out}`);
 
-  const outDash = await $`echo ${src} | ${BENCHRUNNER} - --no-progress 2>&1`.text();
+  const outDash = await $`echo ${src} | ${BENCHRUNNER} - --source-type=module --no-progress 2>&1`.text();
   if (!outDash.includes("sum")) throw new Error(`BenchmarkRunner stdin ("-" arg) expected "sum" benchmark, got: ${outDash}`);
 }
 

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -10,7 +10,6 @@ uses
   TimingUtils,
 
   Goccia.Application,
-  Goccia.Arguments.Collection,
   Goccia.Benchmark.Reporter,
   Goccia.Builtins.Benchmark,
   Goccia.Bytecode.Module,
@@ -285,24 +284,13 @@ function RunRegisteredBenchmarks(const AEngine: TGocciaEngine;
   const ADeterministicProfile: Boolean): TGocciaObjectValue;
 var
   Benchmark: TGocciaBenchmark;
-  EmptyArgs: TGocciaArgumentsCollection;
   Value: TGocciaValue;
 begin
   Benchmark := RuntimeBenchmark(AEngine);
   if not Assigned(Benchmark) then
     Exit(nil);
 
-  EmptyArgs := TGocciaArgumentsCollection.Create;
-  try
-    if ADeterministicProfile then
-      Value := Benchmark.RunDeterministicProfile(EmptyArgs,
-        TGocciaUndefinedLiteralValue.UndefinedValue)
-    else
-      Value := Benchmark.RunBenchmarks(EmptyArgs,
-        TGocciaUndefinedLiteralValue.UndefinedValue);
-  finally
-    EmptyArgs.Free;
-  end;
+  Value := Benchmark.RunForHost(ADeterministicProfile);
 
   if Value is TGocciaObjectValue then
     Result := TGocciaObjectValue(Value)

--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -120,6 +120,7 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.GeneratorValue,
+  Goccia.Values.IteratorSupport,
   Goccia.Values.NativeFunction,
   Goccia.Values.NativeFunctionCallback,
   Goccia.Values.PromiseValue,
@@ -747,17 +748,25 @@ begin
       Result.MeanMs := MeanRounds[FilteredStart + (FilteredCount div 2)];
       Result.MinOpsPerSec := OpsRounds[FilteredStart];
       Result.MaxOpsPerSec := OpsRounds[FilteredEnd];
-    finally
       if Assigned(GC) then
         GC.Enabled := WasGCEnabled;
       if Assigned(GeneratorIterator) then
       begin
         StartNanoseconds := GetNanoseconds;
-        GeneratorIterator.Close;
+        CloseIterator(GeneratorIterator);
         WaitForFetchIdle;
         Result.TeardownMs := (GetNanoseconds - StartNanoseconds) / 1000000;
         GeneratorIterator := nil;
       end;
+    except
+      if Assigned(GC) then
+        GC.Enabled := WasGCEnabled;
+      if Assigned(GeneratorIterator) then
+      begin
+        CloseIteratorPreservingError(GeneratorIterator);
+        GeneratorIterator := nil;
+      end;
+      raise;
     end;
   finally
     RunArgs.Free;
@@ -796,22 +805,29 @@ begin
   ActiveRoots.Add(ABenchCase.GeneratorFunction);
   RunArgs := TGocciaArgumentsCollection.CreateWithCapacity(1);
   try
-    if Assigned(ABenchCase.GeneratorFunction) then
-      RunFunction := CreateRunFunctionFromGenerator(ABenchCase, ActiveRoots,
-        GeneratorIterator);
+    try
+      if Assigned(ABenchCase.GeneratorFunction) then
+        RunFunction := CreateRunFunctionFromGenerator(ABenchCase, ActiveRoots,
+          GeneratorIterator);
 
-    InvokeBenchmarkFunction(RunFunction, SetupResult, RunArgs);
-    WaitForFetchIdle;
-
-    if Assigned(GeneratorIterator) then
-    begin
-      GeneratorIterator.Close;
+      InvokeBenchmarkFunction(RunFunction, SetupResult, RunArgs);
       WaitForFetchIdle;
-      GeneratorIterator := nil;
+
+      if Assigned(GeneratorIterator) then
+      begin
+        CloseIterator(GeneratorIterator);
+        WaitForFetchIdle;
+        GeneratorIterator := nil;
+      end;
+    except
+      if Assigned(GeneratorIterator) then
+      begin
+        CloseIteratorPreservingError(GeneratorIterator);
+        GeneratorIterator := nil;
+      end;
+      raise;
     end;
   finally
-    if Assigned(GeneratorIterator) then
-      GeneratorIterator.Close;
     RunArgs.Free;
     ActiveRoots.Clear;
   end;

--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -27,6 +27,8 @@ type
   TBenchmarkProgressEvent = procedure(const ASuiteName, ABenchName: string; const AIndex, ATotal: Integer) of object;
   TBenchmarkNotifyEvent = procedure of object;
 
+  TBenchmarkRunMode = (brmStandard, brmDeterministicProfile);
+
   TBenchmarkCase = class
   public
     Name: string;
@@ -62,6 +64,7 @@ type
     FOwnsNamespaceRoot: Boolean;
     FHasCompletedRun: Boolean;
     FLastRunResult: TGocciaObjectValue;
+    FLastRunMode: TBenchmarkRunMode;
     FOwnsLastRunRoot: Boolean;
     FOnProgress: TBenchmarkProgressEvent;
     FOnBeforeMeasurement: TBenchmarkNotifyEvent;
@@ -74,7 +77,8 @@ type
     function ExecuteWrapper(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     function IsGeneratorBenchmarkFunction(const AFunction: TGocciaFunctionBase): Boolean;
-    procedure StoreLastRunResult(const AResult: TGocciaObjectValue);
+    procedure StoreLastRunResult(const AResult: TGocciaObjectValue;
+      const AMode: TBenchmarkRunMode);
     procedure ClearLastRunResult;
     function RunSingleBenchmark(const ABenchCase: TBenchmarkCase): TBenchmarkResult;
     function RunSingleBenchmarkDeterministic(const ABenchCase: TBenchmarkCase): TBenchmarkResult;
@@ -223,6 +227,7 @@ begin
   FOwnsNamespaceRoot := False;
   FHasCompletedRun := False;
   FLastRunResult := nil;
+  FLastRunMode := brmStandard;
   FOwnsLastRunRoot := False;
 
   if Assigned(TGarbageCollector.Instance) then
@@ -305,13 +310,16 @@ begin
   FOwnsLastRunRoot := False;
   FHasCompletedRun := False;
   FLastRunResult := nil;
+  FLastRunMode := brmStandard;
 end;
 
-procedure TGocciaBenchmark.StoreLastRunResult(const AResult: TGocciaObjectValue);
+procedure TGocciaBenchmark.StoreLastRunResult(const AResult: TGocciaObjectValue;
+  const AMode: TBenchmarkRunMode);
 begin
   ClearLastRunResult;
   FLastRunResult := AResult;
   FHasCompletedRun := Assigned(AResult);
+  FLastRunMode := AMode;
   if FHasCompletedRun and Assigned(TGarbageCollector.Instance) then
   begin
     TGarbageCollector.Instance.AddRootObject(AResult);
@@ -820,7 +828,8 @@ var
   StartNanoseconds, TotalDurationNanoseconds: Int64;
   GC: TGarbageCollector;
 begin
-  if FHasCompletedRun and Assigned(FLastRunResult) then
+  if FHasCompletedRun and Assigned(FLastRunResult) and
+     (FLastRunMode = brmStandard) then
     Exit(FLastRunResult);
 
   StartNanoseconds := GetNanoseconds;
@@ -899,7 +908,7 @@ begin
       ResultObj.AssignProperty('results', ResultsArray);
       ResultObj.AssignProperty('durationNanoseconds', TGocciaNumberLiteralValue.Create(TotalDurationNanoseconds));
 
-      StoreLastRunResult(ResultObj);
+      StoreLastRunResult(ResultObj, brmStandard);
       Result := ResultObj;
     finally
       if Assigned(GC) then
@@ -925,7 +934,8 @@ var
   StartNanoseconds, TotalDurationNanoseconds: Int64;
   GC: TGarbageCollector;
 begin
-  if FHasCompletedRun and Assigned(FLastRunResult) then
+  if FHasCompletedRun and Assigned(FLastRunResult) and
+     (FLastRunMode = brmDeterministicProfile) then
     Exit(FLastRunResult);
 
   StartNanoseconds := GetNanoseconds;
@@ -1000,7 +1010,7 @@ begin
       ResultObj.AssignProperty('totalBenchmarks', TGocciaNumberLiteralValue.Create(FRegisteredBenchmarks.Count));
       ResultObj.AssignProperty('durationNanoseconds', TGocciaNumberLiteralValue.Create(TotalDurationNanoseconds));
       ResultObj.AssignProperty('results', ResultsArray);
-      StoreLastRunResult(ResultObj);
+      StoreLastRunResult(ResultObj, brmDeterministicProfile);
       Result := ResultObj;
     finally
       if Assigned(GC) then
@@ -1016,8 +1026,15 @@ function TGocciaBenchmark.RunForHost(
   const ADeterministicProfile: Boolean): TGocciaValue;
 var
   EmptyArgs: TGocciaArgumentsCollection;
+  RequestedMode: TBenchmarkRunMode;
 begin
-  if FHasCompletedRun and Assigned(FLastRunResult) then
+  if ADeterministicProfile then
+    RequestedMode := brmDeterministicProfile
+  else
+    RequestedMode := brmStandard;
+
+  if FHasCompletedRun and Assigned(FLastRunResult) and
+     (FLastRunMode = RequestedMode) then
     Exit(FLastRunResult);
 
   EmptyArgs := TGocciaArgumentsCollection.Create;

--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -13,8 +13,12 @@ uses
   Goccia.Arguments.Collection,
   Goccia.Builtins.Base,
   Goccia.Error.ThrowErrorCallback,
+  Goccia.GarbageCollector,
+  Goccia.Modules,
   Goccia.Scope,
   Goccia.Values.FunctionBase,
+  Goccia.Values.IteratorValue,
+  Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
 type
@@ -27,15 +31,12 @@ type
   public
     Name: string;
     SuiteName: string;
-    SetupFunction: TGocciaFunctionBase;
     RunFunction: TGocciaFunctionBase;
-    TeardownFunction: TGocciaFunctionBase;
+    GeneratorFunction: TGocciaFunctionBase;
     OwnsRunRoot: Boolean;
-    OwnsSetupRoot: Boolean;
-    OwnsTeardownRoot: Boolean;
+    OwnsGeneratorRoot: Boolean;
     constructor Create(const AName: string; const ARunFunction: TGocciaFunctionBase;
-      const ASuiteName: string; const ASetupFunction: TGocciaFunctionBase = nil;
-      const ATeardownFunction: TGocciaFunctionBase = nil);
+      const ASuiteName: string; const AGeneratorFunction: TGocciaFunctionBase = nil);
   end;
 
   TBenchmarkResult = record
@@ -57,12 +58,27 @@ type
     FRegisteredSuites: TStringList;
     FRegisteredBenchmarks: TObjectList<TBenchmarkCase>;
     FCurrentSuiteName: string;
+    FNamespaceObject: TGocciaObjectValue;
+    FOwnsNamespaceRoot: Boolean;
+    FHasCompletedRun: Boolean;
+    FLastRunResult: TGocciaObjectValue;
+    FOwnsLastRunRoot: Boolean;
     FOnProgress: TBenchmarkProgressEvent;
     FOnBeforeMeasurement: TBenchmarkNotifyEvent;
 
+    function CreateNamespaceObject: TGocciaObjectValue;
+    function CreateRunFunctionFromGenerator(
+      const ABenchCase: TBenchmarkCase;
+      var AActiveRoots: TGocciaActiveRootFrame;
+      out AGeneratorIterator: TGocciaIteratorValue): TGocciaFunctionBase;
+    function ExecuteWrapper(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function IsGeneratorBenchmarkFunction(const AFunction: TGocciaFunctionBase): Boolean;
+    procedure StoreLastRunResult(const AResult: TGocciaObjectValue);
+    procedure ClearLastRunResult;
     function RunSingleBenchmark(const ABenchCase: TBenchmarkCase): TBenchmarkResult;
     function RunSingleBenchmarkDeterministic(const ABenchCase: TBenchmarkCase): TBenchmarkResult;
-    function CalibrateIterations(const ABenchCase: TBenchmarkCase;
+    function CalibrateIterations(const ARunFunction: TGocciaFunctionBase;
       const ASetupResult: TGocciaValue;
       const ARunArgs: TGocciaArgumentsCollection): Int64;
     procedure UnrootRegisteredBenchmarks;
@@ -70,10 +86,15 @@ type
     constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
     destructor Destroy; override;
 
-    function Suite(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function CreateModule: TGocciaModule;
+    function Group(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function Bench(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function Run(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function RunBenchmarks(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function RunDeterministicProfile(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function RunForHost(const ADeterministicProfile: Boolean): TGocciaValue;
+    function Summary(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function Boxplot(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure ClearRegisteredBenchmarks;
 
     property OnProgress: TBenchmarkProgressEvent read FOnProgress write FOnProgress;
@@ -87,14 +108,18 @@ uses
   SysUtils,
 
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Detail,
   Goccia.FetchManager,
-  Goccia.GarbageCollector,
   Goccia.MicrotaskQueue,
   Goccia.Values.ArrayValue,
   Goccia.Values.Await,
+  Goccia.Values.Error,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.GeneratorValue,
   Goccia.Values.NativeFunction,
-  Goccia.Values.ObjectValue,
-  Goccia.Values.PromiseValue;
+  Goccia.Values.NativeFunctionCallback,
+  Goccia.Values.PromiseValue,
+  Goccia.VM.Exception;
 
 const
   DEFAULT_WARMUP_ITERATIONS = 5;
@@ -159,21 +184,30 @@ begin
   end;
 end;
 
+function BenchmarkExceptionMessage(const AException: Exception): string;
+begin
+  if AException is TGocciaThrowValue then
+    Exit(FormatThrowDetail(TGocciaThrowValue(AException).Value, '', nil, False,
+      TGocciaThrowValue(AException).Suggestion));
+  if AException is EGocciaBytecodeThrow then
+    Exit(FormatThrowDetail(EGocciaBytecodeThrow(AException).ThrownValue, '',
+      nil, False));
+  Result := AException.Message;
+end;
+
 { TBenchmarkCase }
 
-constructor TBenchmarkCase.Create(const AName: string; const ARunFunction: TGocciaFunctionBase;
-  const ASuiteName: string; const ASetupFunction: TGocciaFunctionBase;
-  const ATeardownFunction: TGocciaFunctionBase);
+constructor TBenchmarkCase.Create(const AName: string;
+  const ARunFunction: TGocciaFunctionBase; const ASuiteName: string;
+  const AGeneratorFunction: TGocciaFunctionBase);
 begin
   inherited Create;
   Name := AName;
   RunFunction := ARunFunction;
   SuiteName := ASuiteName;
-  SetupFunction := ASetupFunction;
-  TeardownFunction := ATeardownFunction;
+  GeneratorFunction := AGeneratorFunction;
   OwnsRunRoot := False;
-  OwnsSetupRoot := False;
-  OwnsTeardownRoot := False;
+  OwnsGeneratorRoot := False;
 end;
 
 { TGocciaBenchmark }
@@ -185,15 +219,58 @@ begin
   FRegisteredSuites := TStringList.Create;
   FRegisteredBenchmarks := TObjectList<TBenchmarkCase>.Create;
   FCurrentSuiteName := '';
+  FNamespaceObject := CreateNamespaceObject;
+  FOwnsNamespaceRoot := False;
+  FHasCompletedRun := False;
+  FLastRunResult := nil;
+  FOwnsLastRunRoot := False;
 
-  AScope.DefineLexicalBinding('suite', TGocciaNativeFunctionValue.Create(Suite, 'suite', 2), dtConst, True);
-  AScope.DefineLexicalBinding('bench', TGocciaNativeFunctionValue.Create(Bench, 'bench', 2), dtConst, True);
-  AScope.DefineLexicalBinding('runBenchmarks', TGocciaNativeFunctionValue.Create(RunBenchmarks, 'runBenchmarks', 0), dtConst, True);
+  if Assigned(TGarbageCollector.Instance) then
+  begin
+    TGarbageCollector.Instance.AddRootObject(FNamespaceObject);
+    FOwnsNamespaceRoot := True;
+  end;
+end;
+
+function AddBenchmarkFunction(const AObject: TGocciaObjectValue;
+  const AName: string; const ACallback: TGocciaNativeFunctionCallback;
+  const AArity: Integer): TGocciaNativeFunctionValue;
+begin
+  Result := TGocciaNativeFunctionValue.CreateWithoutPrototype(ACallback,
+    AName, AArity);
+  AObject.SetProperty(AName, Result);
+end;
+
+function TGocciaBenchmark.CreateNamespaceObject: TGocciaObjectValue;
+begin
+  Result := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype,
+    8);
+  AddBenchmarkFunction(Result, 'bench', Bench, 2);
+  AddBenchmarkFunction(Result, 'group', Group, 2);
+  AddBenchmarkFunction(Result, 'run', Run, 0);
+  AddBenchmarkFunction(Result, 'summary', Summary, 1);
+  AddBenchmarkFunction(Result, 'boxplot', Boxplot, 1);
+end;
+
+function TGocciaBenchmark.CreateModule: TGocciaModule;
+begin
+  Result := TGocciaModule.Create('goccia:microbench');
+  Result.AddExportValue('bench', FNamespaceObject.GetProperty('bench'));
+  Result.AddExportValue('group', FNamespaceObject.GetProperty('group'));
+  Result.AddExportValue('run', FNamespaceObject.GetProperty('run'));
+  Result.AddExportValue('summary', FNamespaceObject.GetProperty('summary'));
+  Result.AddExportValue('boxplot', FNamespaceObject.GetProperty('boxplot'));
+  Result.AddExportValue('default', FNamespaceObject);
 end;
 
 destructor TGocciaBenchmark.Destroy;
 begin
+  ClearLastRunResult;
   UnrootRegisteredBenchmarks;
+  if FOwnsNamespaceRoot and Assigned(TGarbageCollector.Instance) then
+    TGarbageCollector.Instance.RemoveRootObject(FNamespaceObject);
+  if not Assigned(TGarbageCollector.Instance) then
+    FNamespaceObject.Free;
   FRegisteredSuites.Free;
   FRegisteredBenchmarks.Free;
   inherited;
@@ -214,36 +291,104 @@ begin
     BenchCase := FRegisteredBenchmarks[I];
     if BenchCase.OwnsRunRoot then
       GC.RemoveTempRoot(BenchCase.RunFunction);
-    if BenchCase.OwnsSetupRoot then
-      GC.RemoveTempRoot(BenchCase.SetupFunction);
-    if BenchCase.OwnsTeardownRoot then
-      GC.RemoveTempRoot(BenchCase.TeardownFunction);
+    if BenchCase.OwnsGeneratorRoot then
+      GC.RemoveTempRoot(BenchCase.GeneratorFunction);
     BenchCase.OwnsRunRoot := False;
-    BenchCase.OwnsSetupRoot := False;
-    BenchCase.OwnsTeardownRoot := False;
+    BenchCase.OwnsGeneratorRoot := False;
+  end;
+end;
+
+procedure TGocciaBenchmark.ClearLastRunResult;
+begin
+  if FOwnsLastRunRoot and Assigned(TGarbageCollector.Instance) then
+    TGarbageCollector.Instance.RemoveRootObject(FLastRunResult);
+  FOwnsLastRunRoot := False;
+  FHasCompletedRun := False;
+  FLastRunResult := nil;
+end;
+
+procedure TGocciaBenchmark.StoreLastRunResult(const AResult: TGocciaObjectValue);
+begin
+  ClearLastRunResult;
+  FLastRunResult := AResult;
+  FHasCompletedRun := Assigned(AResult);
+  if FHasCompletedRun and Assigned(TGarbageCollector.Instance) then
+  begin
+    TGarbageCollector.Instance.AddRootObject(AResult);
+    FOwnsLastRunRoot := True;
   end;
 end;
 
 procedure TGocciaBenchmark.ClearRegisteredBenchmarks;
 begin
+  ClearLastRunResult;
   UnrootRegisteredBenchmarks;
   FRegisteredBenchmarks.Clear;
   FRegisteredSuites.Clear;
   FCurrentSuiteName := '';
 end;
 
-function TGocciaBenchmark.Suite(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+function TGocciaBenchmark.IsGeneratorBenchmarkFunction(
+  const AFunction: TGocciaFunctionBase): Boolean;
+var
+  ConstructorValue: TGocciaValue;
+  ConstructorName: TGocciaValue;
+begin
+  if (AFunction is TGocciaGeneratorFunctionValue) or
+     (AFunction is TGocciaGeneratorMethodValue) then
+    Exit(True);
+
+  ConstructorValue := AFunction.GetProperty(PROP_CONSTRUCTOR);
+  if ConstructorValue is TGocciaObjectValue then
+  begin
+    ConstructorName := TGocciaObjectValue(ConstructorValue).GetProperty(PROP_NAME);
+    Result := (ConstructorName is TGocciaStringLiteralValue) and
+      (TGocciaStringLiteralValue(ConstructorName).Value = 'GeneratorFunction');
+    Exit;
+  end;
+
+  Result := False;
+end;
+
+function TGocciaBenchmark.CreateRunFunctionFromGenerator(
+  const ABenchCase: TBenchmarkCase; var AActiveRoots: TGocciaActiveRootFrame;
+  out AGeneratorIterator: TGocciaIteratorValue): TGocciaFunctionBase;
+var
+  Done: Boolean;
+  GeneratorValue: TGocciaValue;
+  YieldedValue: TGocciaValue;
+begin
+  AGeneratorIterator := nil;
+  GeneratorValue := ABenchCase.GeneratorFunction.CallNoArgs(
+    TGocciaUndefinedLiteralValue.UndefinedValue);
+  if not (GeneratorValue is TGocciaIteratorValue) then
+    ThrowTypeError('bench generator callback must return a sync iterator');
+
+  AGeneratorIterator := TGocciaIteratorValue(GeneratorValue);
+  AActiveRoots.Add(AGeneratorIterator);
+  YieldedValue := AGeneratorIterator.DirectNext(Done);
+  WaitForFetchIdle;
+
+  if Done or not (YieldedValue is TGocciaFunctionBase) then
+    ThrowTypeError('bench generator callback must yield a function');
+
+  Result := TGocciaFunctionBase(YieldedValue);
+  AActiveRoots.Add(Result);
+end;
+
+function TGocciaBenchmark.Group(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   SuiteName: string;
   SuiteFunction: TGocciaFunctionBase;
-  EmptyArgs: TGocciaArgumentsCollection;
   PreviousSuiteName: string;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  if AArgs.Length < 2 then Exit;
-  if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then Exit;
-  if not (AArgs.GetElement(1) is TGocciaFunctionBase) then Exit;
+  if (AArgs.Length < 2) or
+     not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
+    ThrowTypeError('group requires a name string and callback');
+  if not (AArgs.GetElement(1) is TGocciaFunctionBase) then
+    ThrowTypeError('group requires a callback function');
 
   SuiteName := TGocciaStringLiteralValue(AArgs.GetElement(0)).Value;
   SuiteFunction := TGocciaFunctionBase(AArgs.GetElement(1));
@@ -259,61 +404,86 @@ begin
   end;
 end;
 
+function TGocciaBenchmark.ExecuteWrapper(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  WrapperFunction: TGocciaFunctionBase;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  if (AArgs.Length < 1) or not (AArgs.GetElement(0) is TGocciaFunctionBase) then
+    ThrowTypeError('benchmark wrapper requires a callback function');
+
+  WrapperFunction := TGocciaFunctionBase(AArgs.GetElement(0));
+  WrapperFunction.CallNoArgs(TGocciaUndefinedLiteralValue.UndefinedValue);
+end;
+
+function TGocciaBenchmark.Summary(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := ExecuteWrapper(AArgs, AThisValue);
+end;
+
+function TGocciaBenchmark.Boxplot(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := ExecuteWrapper(AArgs, AThisValue);
+end;
+
+function TGocciaBenchmark.Run(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RunBenchmarks(AArgs, AThisValue);
+end;
+
 function TGocciaBenchmark.Bench(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   BenchName: string;
-  OptionsObj: TGocciaObjectValue;
-  RunProp, SetupProp, TeardownProp: TGocciaValue;
-  RunFn, SetupFn, TeardownFn: TGocciaFunctionBase;
+  CallbackFn: TGocciaFunctionBase;
+  RunFn, GeneratorFn: TGocciaFunctionBase;
   BenchCase: TBenchmarkCase;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 
-  if AArgs.Length < 2 then Exit;
-  if not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then Exit;
-  if not (AArgs.GetElement(1) is TGocciaObjectValue) then Exit;
+  if (AArgs.Length < 2) or
+     not (AArgs.GetElement(0) is TGocciaStringLiteralValue) then
+    ThrowTypeError('bench requires a name string and callback');
+  if not (AArgs.GetElement(1) is TGocciaFunctionBase) then
+    ThrowTypeError('bench requires a callback function');
 
   BenchName := TGocciaStringLiteralValue(AArgs.GetElement(0)).Value;
-  OptionsObj := TGocciaObjectValue(AArgs.GetElement(1));
+  CallbackFn := TGocciaFunctionBase(AArgs.GetElement(1));
 
-  RunProp := OptionsObj.GetProperty('run');
-  if not Assigned(RunProp) or not (RunProp is TGocciaFunctionBase) then Exit;
-  RunFn := TGocciaFunctionBase(RunProp);
+  if IsGeneratorBenchmarkFunction(CallbackFn) then
+  begin
+    RunFn := nil;
+    GeneratorFn := CallbackFn;
+  end
+  else
+  begin
+    RunFn := CallbackFn;
+    GeneratorFn := nil;
+  end;
 
-  SetupFn := nil;
-  SetupProp := OptionsObj.GetProperty('setup');
-  if Assigned(SetupProp) and (SetupProp is TGocciaFunctionBase) then
-    SetupFn := TGocciaFunctionBase(SetupProp);
-
-  TeardownFn := nil;
-  TeardownProp := OptionsObj.GetProperty('teardown');
-  if Assigned(TeardownProp) and (TeardownProp is TGocciaFunctionBase) then
-    TeardownFn := TGocciaFunctionBase(TeardownProp);
-
-  BenchCase := TBenchmarkCase.Create(BenchName, RunFn, FCurrentSuiteName, SetupFn, TeardownFn);
+  BenchCase := TBenchmarkCase.Create(BenchName, RunFn, FCurrentSuiteName, GeneratorFn);
   if Assigned(TGarbageCollector.Instance) then
   begin
-    if not TGarbageCollector.Instance.IsTempRoot(RunFn) then
+    if Assigned(RunFn) and not TGarbageCollector.Instance.IsTempRoot(RunFn) then
     begin
       TGarbageCollector.Instance.AddTempRoot(RunFn);
       BenchCase.OwnsRunRoot := True;
     end;
-    if Assigned(SetupFn) and not TGarbageCollector.Instance.IsTempRoot(SetupFn) then
+    if Assigned(GeneratorFn) and not TGarbageCollector.Instance.IsTempRoot(GeneratorFn) then
     begin
-      TGarbageCollector.Instance.AddTempRoot(SetupFn);
-      BenchCase.OwnsSetupRoot := True;
-    end;
-    if Assigned(TeardownFn) and not TGarbageCollector.Instance.IsTempRoot(TeardownFn) then
-    begin
-      TGarbageCollector.Instance.AddTempRoot(TeardownFn);
-      BenchCase.OwnsTeardownRoot := True;
+      TGarbageCollector.Instance.AddTempRoot(GeneratorFn);
+      BenchCase.OwnsGeneratorRoot := True;
     end;
   end;
 
   FRegisteredBenchmarks.Add(BenchCase);
 end;
 
-function TGocciaBenchmark.CalibrateIterations(const ABenchCase: TBenchmarkCase;
+function TGocciaBenchmark.CalibrateIterations(const ARunFunction: TGocciaFunctionBase;
   const ASetupResult: TGocciaValue; const ARunArgs: TGocciaArgumentsCollection): Int64;
 var
   BatchSize: Int64;
@@ -326,12 +496,12 @@ begin
   while True do
   begin
     if Assigned(TGarbageCollector.Instance) then
-      TGarbageCollector.Instance.CollectIfNeeded(ABenchCase.RunFunction);
+      TGarbageCollector.Instance.CollectIfNeeded(ARunFunction);
     StartNanoseconds := GetNanoseconds;
     I := 0;
     while I < BatchSize do
     begin
-      InvokeBenchmarkFunction(ABenchCase.RunFunction, ASetupResult, ARunArgs);
+      InvokeBenchmarkFunction(ARunFunction, ASetupResult, ARunArgs);
       Inc(I);
     end;
     WaitForFetchIdle;
@@ -430,6 +600,8 @@ var
   MeasurementWatermark: Integer;
   RunArgs: TGocciaArgumentsCollection;
   ActiveRoots: TGocciaActiveRootFrame;
+  RunFunction: TGocciaFunctionBase;
+  GeneratorIterator: TGocciaIteratorValue;
 begin
   Result.Name := ABenchCase.Name;
   Result.SuiteName := ABenchCase.SuiteName;
@@ -444,25 +616,22 @@ begin
   GC := TGarbageCollector.Instance;
   WasGCEnabled := False;
   SetupResult := nil;
+  RunFunction := ABenchCase.RunFunction;
+  GeneratorIterator := nil;
   ActiveRoots.Initialize;
   ActiveRoots.Add(ABenchCase.RunFunction);
-  ActiveRoots.Add(ABenchCase.SetupFunction);
-  ActiveRoots.Add(ABenchCase.TeardownFunction);
+  ActiveRoots.Add(ABenchCase.GeneratorFunction);
   RunArgs := TGocciaArgumentsCollection.CreateWithCapacity(1);
   try
-    if Assigned(ABenchCase.SetupFunction) then
-    begin
-      StartNanoseconds := GetNanoseconds;
-      SetupResult := ABenchCase.SetupFunction.CallNoArgs(
-        TGocciaUndefinedLiteralValue.UndefinedValue);
-      WaitForFetchIdle;
-      Result.SetupMs := (GetNanoseconds - StartNanoseconds) / 1000000;
-
-      if Assigned(SetupResult) then
-        ActiveRoots.Add(SetupResult);
-    end;
-
     try
+      if Assigned(ABenchCase.GeneratorFunction) then
+      begin
+        StartNanoseconds := GetNanoseconds;
+        RunFunction := CreateRunFunctionFromGenerator(ABenchCase, ActiveRoots,
+          GeneratorIterator);
+        Result.SetupMs := (GetNanoseconds - StartNanoseconds) / 1000000;
+      end;
+
       if Assigned(GC) then
       begin
         WasGCEnabled := GC.Enabled;
@@ -473,10 +642,10 @@ begin
       end;
 
       for K := 1 to WARMUP_ITERATIONS do
-        InvokeBenchmarkFunction(ABenchCase.RunFunction, SetupResult, RunArgs);
+        InvokeBenchmarkFunction(RunFunction, SetupResult, RunArgs);
       WaitForFetchIdle;
 
-      Iterations := CalibrateIterations(ABenchCase, SetupResult, RunArgs);
+      Iterations := CalibrateIterations(RunFunction, SetupResult, RunArgs);
 
       if Assigned(GC) then
       begin
@@ -502,7 +671,7 @@ begin
         I := 0;
         while I < Iterations do
         begin
-          InvokeBenchmarkFunction(ABenchCase.RunFunction, SetupResult, RunArgs);
+          InvokeBenchmarkFunction(RunFunction, SetupResult, RunArgs);
           Inc(I);
         end;
         WaitForFetchIdle;
@@ -570,17 +739,17 @@ begin
       Result.MeanMs := MeanRounds[FilteredStart + (FilteredCount div 2)];
       Result.MinOpsPerSec := OpsRounds[FilteredStart];
       Result.MaxOpsPerSec := OpsRounds[FilteredEnd];
-
-      if Assigned(ABenchCase.TeardownFunction) then
-      begin
-        StartNanoseconds := GetNanoseconds;
-        InvokeBenchmarkFunction(ABenchCase.TeardownFunction, SetupResult, RunArgs);
-        WaitForFetchIdle;
-        Result.TeardownMs := (GetNanoseconds - StartNanoseconds) / 1000000;
-      end;
     finally
       if Assigned(GC) then
         GC.Enabled := WasGCEnabled;
+      if Assigned(GeneratorIterator) then
+      begin
+        StartNanoseconds := GetNanoseconds;
+        GeneratorIterator.Close;
+        WaitForFetchIdle;
+        Result.TeardownMs := (GetNanoseconds - StartNanoseconds) / 1000000;
+        GeneratorIterator := nil;
+      end;
     end;
   finally
     RunArgs.Free;
@@ -595,6 +764,8 @@ var
   RunArgs: TGocciaArgumentsCollection;
   GC: TGarbageCollector;
   ActiveRoots: TGocciaActiveRootFrame;
+  RunFunction: TGocciaFunctionBase;
+  GeneratorIterator: TGocciaIteratorValue;
 begin
   Result.Name := ABenchCase.Name;
   Result.SuiteName := ABenchCase.SuiteName;
@@ -610,30 +781,29 @@ begin
 
   GC := TGarbageCollector.Instance;
   SetupResult := nil;
+  RunFunction := ABenchCase.RunFunction;
+  GeneratorIterator := nil;
   ActiveRoots.Initialize;
   ActiveRoots.Add(ABenchCase.RunFunction);
-  ActiveRoots.Add(ABenchCase.SetupFunction);
-  ActiveRoots.Add(ABenchCase.TeardownFunction);
+  ActiveRoots.Add(ABenchCase.GeneratorFunction);
   RunArgs := TGocciaArgumentsCollection.CreateWithCapacity(1);
   try
-    if Assigned(ABenchCase.SetupFunction) then
-    begin
-      SetupResult := ABenchCase.SetupFunction.CallNoArgs(
-        TGocciaUndefinedLiteralValue.UndefinedValue);
-      WaitForFetchIdle;
-      if Assigned(SetupResult) then
-        ActiveRoots.Add(SetupResult);
-    end;
+    if Assigned(ABenchCase.GeneratorFunction) then
+      RunFunction := CreateRunFunctionFromGenerator(ABenchCase, ActiveRoots,
+        GeneratorIterator);
 
-    InvokeBenchmarkFunction(ABenchCase.RunFunction, SetupResult, RunArgs);
+    InvokeBenchmarkFunction(RunFunction, SetupResult, RunArgs);
     WaitForFetchIdle;
 
-    if Assigned(ABenchCase.TeardownFunction) then
+    if Assigned(GeneratorIterator) then
     begin
-      InvokeBenchmarkFunction(ABenchCase.TeardownFunction, SetupResult, RunArgs);
+      GeneratorIterator.Close;
       WaitForFetchIdle;
+      GeneratorIterator := nil;
     end;
   finally
+    if Assigned(GeneratorIterator) then
+      GeneratorIterator.Close;
     RunArgs.Free;
     ActiveRoots.Clear;
   end;
@@ -650,6 +820,9 @@ var
   StartNanoseconds, TotalDurationNanoseconds: Int64;
   GC: TGarbageCollector;
 begin
+  if FHasCompletedRun and Assigned(FLastRunResult) then
+    Exit(FLastRunResult);
+
   StartNanoseconds := GetNanoseconds;
   GC := TGarbageCollector.Instance;
 
@@ -703,7 +876,8 @@ begin
           try
             SingleResult.AssignProperty('name', TGocciaStringLiteralValue.Create(BenchCase.Name));
             SingleResult.AssignProperty('suite', TGocciaStringLiteralValue.Create(BenchCase.SuiteName));
-            SingleResult.AssignProperty('error', TGocciaStringLiteralValue.Create(E.Message));
+            SingleResult.AssignProperty('error',
+              TGocciaStringLiteralValue.Create(BenchmarkExceptionMessage(E)));
 
             ResultsArray.SetElement(ResultsArray.GetLength, SingleResult);
           finally
@@ -725,6 +899,7 @@ begin
       ResultObj.AssignProperty('results', ResultsArray);
       ResultObj.AssignProperty('durationNanoseconds', TGocciaNumberLiteralValue.Create(TotalDurationNanoseconds));
 
+      StoreLastRunResult(ResultObj);
       Result := ResultObj;
     finally
       if Assigned(GC) then
@@ -750,6 +925,9 @@ var
   StartNanoseconds, TotalDurationNanoseconds: Int64;
   GC: TGarbageCollector;
 begin
+  if FHasCompletedRun and Assigned(FLastRunResult) then
+    Exit(FLastRunResult);
+
   StartNanoseconds := GetNanoseconds;
   GC := TGarbageCollector.Instance;
 
@@ -803,7 +981,8 @@ begin
           try
             SingleResult.AssignProperty('name', TGocciaStringLiteralValue.Create(BenchCase.Name));
             SingleResult.AssignProperty('suite', TGocciaStringLiteralValue.Create(BenchCase.SuiteName));
-            SingleResult.AssignProperty('error', TGocciaStringLiteralValue.Create(E.Message));
+            SingleResult.AssignProperty('error',
+              TGocciaStringLiteralValue.Create(BenchmarkExceptionMessage(E)));
             ResultsArray.SetElement(ResultsArray.GetLength, SingleResult);
           finally
             if Assigned(GC) then
@@ -821,6 +1000,7 @@ begin
       ResultObj.AssignProperty('totalBenchmarks', TGocciaNumberLiteralValue.Create(FRegisteredBenchmarks.Count));
       ResultObj.AssignProperty('durationNanoseconds', TGocciaNumberLiteralValue.Create(TotalDurationNanoseconds));
       ResultObj.AssignProperty('results', ResultsArray);
+      StoreLastRunResult(ResultObj);
       Result := ResultObj;
     finally
       if Assigned(GC) then
@@ -829,6 +1009,27 @@ begin
   finally
     if Assigned(GC) and Assigned(ResultsArray) then
       GC.RemoveTempRoot(ResultsArray);
+  end;
+end;
+
+function TGocciaBenchmark.RunForHost(
+  const ADeterministicProfile: Boolean): TGocciaValue;
+var
+  EmptyArgs: TGocciaArgumentsCollection;
+begin
+  if FHasCompletedRun and Assigned(FLastRunResult) then
+    Exit(FLastRunResult);
+
+  EmptyArgs := TGocciaArgumentsCollection.Create;
+  try
+    if ADeterministicProfile then
+      Result := RunDeterministicProfile(EmptyArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue)
+    else
+      Result := RunBenchmarks(EmptyArgs,
+        TGocciaUndefinedLiteralValue.UndefinedValue);
+  finally
+    EmptyArgs.Free;
   end;
 end;
 

--- a/source/units/Goccia.RuntimeExtensions.Benchmark.pas
+++ b/source/units/Goccia.RuntimeExtensions.Benchmark.pas
@@ -6,12 +6,14 @@ interface
 
 uses
   Goccia.Builtins.Benchmark,
+  Goccia.Modules,
   Goccia.Runtime;
 
 type
   TGocciaBenchmarkRuntimeExtension = class(TGocciaRuntimeExtension)
   private
     FBuiltinBenchmark: TGocciaBenchmark;
+    FMicrobenchModule: TGocciaModule;
   public
     procedure Attach(const ARuntime: TGocciaRuntimeCore); override;
     procedure Detach; override;
@@ -27,11 +29,18 @@ begin
   inherited Attach(ARuntime);
   FBuiltinBenchmark := TGocciaBenchmark.Create('Benchmark',
     Runtime.Engine.Interpreter.GlobalScope, Runtime.Engine.ThrowError);
-  Runtime.RegisterRuntimeGlobalName('Benchmark');
+  FMicrobenchModule := FBuiltinBenchmark.CreateModule;
+  FMicrobenchModule.GetNamespaceObject;
+  Runtime.Engine.ModuleLoader.GlobalModules.Add('goccia:microbench',
+    FMicrobenchModule);
 end;
 
 procedure TGocciaBenchmarkRuntimeExtension.Detach;
 begin
+  if Assigned(Runtime) and Assigned(Runtime.Engine) then
+    Runtime.Engine.ModuleLoader.GlobalModules.Remove('goccia:microbench');
+  FMicrobenchModule.Free;
+  FMicrobenchModule := nil;
   FBuiltinBenchmark.Free;
   FBuiltinBenchmark := nil;
   inherited;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add the import-only `goccia:microbench` module with `bench`, `group`, `run`, `summary`, and `boxplot` exports, and remove ambient benchmark globals.
- Migrate the existing benchmark corpus to `bench(name, fn)` plus generator-style setup/cleanup around yielded benchmark bodies.
- Keep `summary`/`boxplot` as accepted registration wrappers for now; richer output remains a non-goal for this issue.
- Ensure script-callable `run()` returns the benchmark result, prevents same-mode host auto-run double measurement, and cannot mask the host `--profile-deterministic` pass with cached calibrated metrics.
- Preserve original benchmark failures when generator cleanup also throws, and align the nested array benchmark setup with its sibling nested-callback cases.
- Closes #854.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation run:

- `./build.pas benchmarkrunner`
- `bun scripts/test-cli-apps.ts`
- `./format.pas --check`
- `./build.pas testrunner && ./build/GocciaTestRunner tests && ./build/GocciaTestRunner tests --mode=bytecode`
- `GOCCIA_BENCH_WARMUP=0 GOCCIA_BENCH_CALIBRATION_MS=1 GOCCIA_BENCH_ROUNDS=1 ./build/GocciaBenchmarkRunner benchmarks --no-progress --format=compact-json --output=/tmp/goccia-bench-review-interp.json`
- `GOCCIA_BENCH_WARMUP=0 GOCCIA_BENCH_CALIBRATION_MS=1 GOCCIA_BENCH_ROUNDS=1 ./build/GocciaBenchmarkRunner benchmarks --mode=bytecode --no-progress --format=compact-json --output=/tmp/goccia-bench-review-bytecode.json`
- `git diff --check`
- `git diff --staged --check`
