### PR TITLE
fix(math): close Math gaps and follow-up regressions

### DIFF
--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -73,7 +73,7 @@ Implements the [ECMAScript Math object](https://developer.mozilla.org/en-US/docs
 |--------|-------------|
 | `Math.clamp(x, min, max)` | Clamp to range (Stage 2 [proposal-math-clamp](https://github.com/tc39/proposal-math-clamp)) |
 | `Math.f16round(x)` | Nearest 16-bit float |
-| `Math.sumPrecise(iterable)` | Precise sum via Kahan-Babuska-Neumaier compensated summation. Throws `TypeError` for non-iterable or non-number elements. Empty iterable returns `-0`. Mixed `±Infinity` returns `NaN`. |
+| `Math.sumPrecise(iterable)` | Precise sum via exact finite accumulation and final double rounding. Throws `TypeError` for non-iterable or non-number elements. Empty iterable returns `-0`. Mixed `±Infinity` returns `NaN`. |
 
 ### Data Formats (JSON, JSON5, YAML, JSONL, CSV, TSV, TOML)
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -662,7 +662,7 @@ Clamp a value to a range: `Math.clamp(value, min, max)`. See [proposal-math-clam
 
 ### Math.sumPrecise (ES2026)
 
-Precise summation of iterables using a compensated algorithm: `Math.sumPrecise(iterable)`. See [ES2026 §21.3.2.33](https://tc39.es/ecma262/#sec-math.sumprecise).
+Precise summation of iterables using exact finite accumulation and final double rounding: `Math.sumPrecise(iterable)`. See [ES2026 §21.3.2.33](https://tc39.es/ecma262/#sec-math.sumprecise).
 
 ### Map.prototype.getOrInsert (ES2026)
 

--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -7,6 +7,9 @@ interface
 uses
   IntlTypes;
 
+type
+  TIntlDateTimeFormatter = Pointer;
+
 function IntlICUAvailable: Boolean;
 
 function TryICUCanonicalizeLocale(const ATag: string; out ACanonical: string): Boolean;
@@ -43,6 +46,17 @@ function TryICUFormatDateTime(const ALocale: string; AMillis: Double;
   const AOptions: TIntlDateTimeFormatOptions; out AFormatted: string): Boolean;
 function TryICUFormatDateTimeToParts(const ALocale: string; AMillis: Double;
   const AOptions: TIntlDateTimeFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+function TryICUOpenDateTimeFormatter(const ALocale: string;
+  const AOptions: TIntlDateTimeFormatOptions;
+  out AFormatter: TIntlDateTimeFormatter): Boolean;
+procedure ICUCloseDateTimeFormatter(var AFormatter: TIntlDateTimeFormatter);
+function TryICUFormatDateTimeWithFormatter(
+  const AFormatter: TIntlDateTimeFormatter; AMillis: Double;
+  const AOptions: TIntlDateTimeFormatOptions; out AFormatted: string): Boolean;
+function TryICUFormatDateTimeToPartsWithFormatter(
+  const AFormatter: TIntlDateTimeFormatter; AMillis: Double;
+  const AOptions: TIntlDateTimeFormatOptions;
+  out AParts: TIntlFormatPartArray): Boolean;
 function TryICUFormatDateTimeRange(const ALocale: string; AStartMillis, AEndMillis: Double;
   const AOptions: TIntlDateTimeFormatOptions; out AFormatted: string): Boolean;
 function TryICUFormatDateTimeRangeToParts(const ALocale: string; AStartMillis, AEndMillis: Double;
@@ -3132,44 +3146,59 @@ begin
   Result := ICUSucceeded(Status) and Assigned(AFormatter);
 end;
 
-function TryICUFormatDateTime(const ALocale: string; AMillis: Double;
+function TryICUOpenDateTimeFormatter(const ALocale: string;
+  const AOptions: TIntlDateTimeFormatOptions;
+  out AFormatter: TIntlDateTimeFormatter): Boolean;
+begin
+  AFormatter := nil;
+  if not EnsureLoaded then
+    Exit(False);
+  Result := OpenDateFormatter(ALocale, AOptions, AFormatter);
+end;
+
+procedure ICUCloseDateTimeFormatter(var AFormatter: TIntlDateTimeFormatter);
+begin
+  if Assigned(AFormatter) then
+  begin
+    if Assigned(IntlFunctions.UdatClose) then
+      IntlFunctions.UdatClose(AFormatter);
+    AFormatter := nil;
+  end;
+end;
+
+function TryICUFormatDateTimeWithFormatter(
+  const AFormatter: TIntlDateTimeFormatter; AMillis: Double;
   const AOptions: TIntlDateTimeFormatOptions; out AFormatted: string): Boolean;
 var
   Status: TICUErrorCode;
-  Formatter: Pointer;
   Buffer: array[0..FORMAT_BUFFER_CAPACITY - 1] of WideChar;
   ResultLen: LongInt;
 begin
   Result := False;
   AFormatted := '';
 
-  if not EnsureLoaded then
+  if not Assigned(AFormatter) or not Assigned(IntlFunctions.UdatFormat) then
     Exit;
 
-  if not OpenDateFormatter(ALocale, AOptions, Formatter) then
+  FillChar(Buffer, SizeOf(Buffer), 0);
+  Status := ICU_SUCCESS;
+  ResultLen := IntlFunctions.UdatFormat(AFormatter, AMillis,
+    @Buffer[0], FORMAT_BUFFER_CAPACITY, nil, Status);
+  if not ICUSucceeded(Status) or (ResultLen <= 0) then
     Exit;
 
-  try
-    FillChar(Buffer, SizeOf(Buffer), 0);
-    Status := ICU_SUCCESS;
-    ResultLen := IntlFunctions.UdatFormat(Formatter, AMillis,
-      @Buffer[0], FORMAT_BUFFER_CAPACITY, nil, Status);
-    if not ICUSucceeded(Status) or (ResultLen <= 0) then
-      Exit;
-
-    AFormatted := UnicodeToString(Buffer, ResultLen);
-    AFormatted := PadTwoDigitHourFormatted(AFormatted, AOptions);
-    Result := True;
-  finally
-    IntlFunctions.UdatClose(Formatter);
-  end;
+  AFormatted := UnicodeToString(Buffer, ResultLen);
+  AFormatted := PadTwoDigitHourFormatted(AFormatted, AOptions);
+  Result := True;
 end;
 
-function TryICUFormatDateTimeToParts(const ALocale: string; AMillis: Double;
-  const AOptions: TIntlDateTimeFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+function TryICUFormatDateTimeToPartsWithFormatter(
+  const AFormatter: TIntlDateTimeFormatter; AMillis: Double;
+  const AOptions: TIntlDateTimeFormatOptions;
+  out AParts: TIntlFormatPartArray): Boolean;
 var
   Status: TICUErrorCode;
-  Formatter, Iterator: Pointer;
+  Iterator: Pointer;
   Buffer: array[0..FORMAT_BUFFER_CAPACITY - 1] of WideChar;
   ResultLen: LongInt;
   Spans: TICUFieldSpanArray;
@@ -3178,40 +3207,70 @@ begin
   Result := False;
   SetLength(AParts, 0);
 
-  if not EnsureLoaded or not Assigned(IntlFunctions.UdatFormatForFields) or
+  if not Assigned(AFormatter) or
+     not Assigned(IntlFunctions.UdatFormatForFields) or
      not Assigned(IntlFunctions.UfieldpositerOpen) or
      not Assigned(IntlFunctions.UfieldpositerClose) or
      not Assigned(IntlFunctions.UfieldpositerNext) then
     Exit;
 
-  if not OpenDateFormatter(ALocale, AOptions, Formatter) then
+  Status := ICU_SUCCESS;
+  Iterator := IntlFunctions.UfieldpositerOpen(Status);
+  if not ICUSucceeded(Status) or not Assigned(Iterator) then
     Exit;
-
   try
+    FillChar(Buffer, SizeOf(Buffer), 0);
     Status := ICU_SUCCESS;
-    Iterator := IntlFunctions.UfieldpositerOpen(Status);
-    if not ICUSucceeded(Status) or not Assigned(Iterator) then
+    ResultLen := IntlFunctions.UdatFormatForFields(AFormatter, AMillis,
+      @Buffer[0], FORMAT_BUFFER_CAPACITY, Iterator, Status);
+    if not ICUSucceeded(Status) or (ResultLen <= 0) then
       Exit;
-    try
-      FillChar(Buffer, SizeOf(Buffer), 0);
-      Status := ICU_SUCCESS;
-      ResultLen := IntlFunctions.UdatFormatForFields(Formatter, AMillis,
-        @Buffer[0], FORMAT_BUFFER_CAPACITY, Iterator, Status);
-      if not ICUSucceeded(Status) or (ResultLen <= 0) then
-        Exit;
 
-      UFormatted := UnicodeString(UnicodeToString(Buffer, ResultLen));
-      SetLength(Spans, 0);
-      CollectIteratorFieldSpans(Iterator, UFIELD_CATEGORY_DATE, Spans);
-      Result := BuildPartsFromFieldSpans(UFormatted, Spans,
-        UFIELD_CATEGORY_DATE, 0, DateFieldToPartType, AParts);
-      if Result then
-        PadTwoDigitHourParts(AParts, AOptions);
-    finally
-      IntlFunctions.UfieldpositerClose(Iterator);
-    end;
+    UFormatted := UnicodeString(UnicodeToString(Buffer, ResultLen));
+    SetLength(Spans, 0);
+    CollectIteratorFieldSpans(Iterator, UFIELD_CATEGORY_DATE, Spans);
+    Result := BuildPartsFromFieldSpans(UFormatted, Spans,
+      UFIELD_CATEGORY_DATE, 0, DateFieldToPartType, AParts);
+    if Result then
+      PadTwoDigitHourParts(AParts, AOptions);
   finally
-    IntlFunctions.UdatClose(Formatter);
+    IntlFunctions.UfieldpositerClose(Iterator);
+  end;
+end;
+
+function TryICUFormatDateTime(const ALocale: string; AMillis: Double;
+  const AOptions: TIntlDateTimeFormatOptions; out AFormatted: string): Boolean;
+var
+  Formatter: TIntlDateTimeFormatter;
+begin
+  if not TryICUOpenDateTimeFormatter(ALocale, AOptions, Formatter) then
+  begin
+    AFormatted := '';
+    Exit(False);
+  end;
+  try
+    Result := TryICUFormatDateTimeWithFormatter(Formatter, AMillis, AOptions,
+      AFormatted);
+  finally
+    ICUCloseDateTimeFormatter(Formatter);
+  end;
+end;
+
+function TryICUFormatDateTimeToParts(const ALocale: string; AMillis: Double;
+  const AOptions: TIntlDateTimeFormatOptions; out AParts: TIntlFormatPartArray): Boolean;
+var
+  Formatter: TIntlDateTimeFormatter;
+begin
+  if not TryICUOpenDateTimeFormatter(ALocale, AOptions, Formatter) then
+  begin
+    SetLength(AParts, 0);
+    Exit(False);
+  end;
+  try
+    Result := TryICUFormatDateTimeToPartsWithFormatter(Formatter, AMillis,
+      AOptions, AParts);
+  finally
+    ICUCloseDateTimeFormatter(Formatter);
   end;
 end;
 

--- a/source/units/Goccia.Builtins.Math.pas
+++ b/source/units/Goccia.Builtins.Math.pas
@@ -63,6 +63,9 @@ implementation
 
 uses
   Math,
+  SysUtils,
+
+  BigInteger,
 
   Goccia.Arguments.Converter,
   Goccia.Arguments.Validator,
@@ -78,12 +81,337 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.Iterator.Generic,
+  Goccia.Values.IteratorSupport,
   Goccia.Values.IteratorValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
 
+const
+  DOUBLE_SIGN_MASK = QWord($8000000000000000);
+  DOUBLE_EXP_MASK  = QWord($7FF0000000000000);
+  DOUBLE_FRAC_MASK = QWord($000FFFFFFFFFFFFF);
+  DOUBLE_HIDDEN_BIT = QWord($0010000000000000);
+  DOUBLE_EXP_BIAS = 1023;
+  DOUBLE_FRAC_BITS = 52;
+  DOUBLE_MIN_NORMAL_EXPONENT = -1022;
+  DOUBLE_MIN_SUBNORMAL_EXPONENT = -1074;
+  DOUBLE_MAX_EXPONENT = 1023;
+  DOUBLE_INTEGRAL_LIMIT = 4503599627370496.0; // 2^52
+
 threadvar
   FStaticMembers: TArray<TGocciaMemberDefinition>;
+
+{$IFDEF DARWIN}
+function LibMSinh(const AValue: Double): Double; cdecl; external name 'sinh';
+function LibMTanh(const AValue: Double): Double; cdecl; external name 'tanh';
+function LibMAsinh(const AValue: Double): Double; cdecl; external name 'asinh';
+function LibMAtanh(const AValue: Double): Double; cdecl; external name 'atanh';
+{$ENDIF}
+{$IFDEF LINUX}
+function LibMSinh(const AValue: Double): Double; cdecl; external 'm' name 'sinh';
+function LibMTanh(const AValue: Double): Double; cdecl; external 'm' name 'tanh';
+function LibMAsinh(const AValue: Double): Double; cdecl; external 'm' name 'asinh';
+function LibMAtanh(const AValue: Double): Double; cdecl; external 'm' name 'atanh';
+{$ENDIF}
+
+function IsFiniteIntegral(const AValue: Double): Boolean; inline;
+begin
+  Result := (not IsNan(AValue)) and (not IsInfinite(AValue)) and
+    ((Abs(AValue) >= DOUBLE_INTEGRAL_LIMIT) or (Frac(AValue) = 0));
+end;
+
+function CubeRootApprox(const AValue: Double): Double;
+var
+  AbsValue, Guess: Double;
+  I: Integer;
+begin
+  if AValue = 0 then
+    Exit(AValue);
+  AbsValue := Abs(AValue);
+  Guess := Power(AbsValue, 1.0 / 3.0);
+  for I := 0 to 2 do
+    Guess := (2.0 * Guess + AbsValue / (Guess * Guess)) / 3.0;
+  if AValue < 0 then
+    Result := -Guess
+  else
+    Result := Guess;
+end;
+
+function Expm1Approx(const AValue: Double): Double;
+var
+  Term: Double;
+  N: Integer;
+begin
+  if Abs(AValue) >= 0.5 then
+    Exit(Exp(AValue) - 1.0);
+  Result := AValue;
+  Term := AValue;
+  for N := 2 to 48 do
+  begin
+    Term := Term * AValue / N;
+    Result := Result + Term;
+    if Abs(Term) <= Abs(Result) * 1.0E-17 then
+      Break;
+  end;
+end;
+
+function Log1pApprox(const AValue: Double): Double;
+var
+  X2, X3, X4, X5, X6: Double;
+begin
+  if Abs(AValue) >= 1.0E-3 then
+    Exit(Ln(1.0 + AValue));
+  X2 := AValue * AValue;
+  X3 := X2 * AValue;
+  X4 := X3 * AValue;
+  X5 := X4 * AValue;
+  X6 := X5 * AValue;
+  Result := AValue - X2 / 2.0 + X3 / 3.0 - X4 / 4.0 +
+    X5 / 5.0 - X6 / 6.0;
+end;
+
+function AcoshApprox(const AValue: Double): Double;
+var
+  Delta: Double;
+  Root: Double;
+begin
+  Delta := AValue - 1.0;
+  if Delta = 0 then
+    Result := 0
+  else if Delta < 1.0E-3 then
+  begin
+    Root := Sqrt(2.0 * Delta);
+    Result := Root * (1.0 - Delta / 12.0 + 3.0 * Delta * Delta / 160.0 -
+      5.0 * Delta * Delta * Delta / 896.0);
+  end
+  else if AValue > 1.0E154 then
+    Result := Ln(AValue) + Ln(2.0)
+  else
+    Result := Ln(AValue + Sqrt(AValue - 1.0) * Sqrt(AValue + 1.0));
+end;
+
+function AsinhApprox(const AValue: Double): Double;
+var
+  AbsValue, Inner, Term, X2: Double;
+  N: Integer;
+begin
+  {$IFDEF DARWIN}
+  Exit(LibMAsinh(AValue));
+  {$ENDIF}
+  {$IFDEF LINUX}
+  Exit(LibMAsinh(AValue));
+  {$ENDIF}
+
+  if AValue = 0 then
+    Exit(AValue);
+  AbsValue := Abs(AValue);
+  if AbsValue < 0.5 then
+  begin
+    Result := AValue;
+    Term := AValue;
+    X2 := AValue * AValue;
+    for N := 1 to 80 do
+    begin
+      Term := -Term * X2 * Sqr(2 * N - 1) / ((2 * N) * (2 * N + 1));
+      Result := Result + Term;
+      if Abs(Term) <= Abs(Result) * 1.0E-17 then
+        Break;
+    end;
+    Exit;
+  end;
+  if AbsValue > 1.0E154 then
+    Inner := Ln(AbsValue) + Ln(2.0)
+  else
+    Inner := ArcSinh(AbsValue);
+  if AValue < 0 then
+    Result := -Inner
+  else
+    Result := Inner;
+end;
+
+function AtanhApprox(const AValue: Double): Double;
+var
+  X2, Term: Double;
+  Denominator: Integer;
+begin
+  {$IFDEF DARWIN}
+  Exit(LibMAtanh(AValue));
+  {$ENDIF}
+  {$IFDEF LINUX}
+  Exit(LibMAtanh(AValue));
+  {$ENDIF}
+
+  if AValue = 0 then
+    Exit(AValue);
+  if Abs(AValue) < 0.5 then
+  begin
+    Result := AValue;
+    Term := AValue;
+    X2 := AValue * AValue;
+    Denominator := 3;
+    while Denominator <= 161 do
+    begin
+      Term := Term * X2;
+      Result := Result + Term / Denominator;
+      if Abs(Term / Denominator) <= Abs(Result) * 1.0E-17 then
+        Break;
+      Inc(Denominator, 2);
+    end;
+    Exit;
+  end;
+  Result := ArcTanh(AValue);
+end;
+
+function TanhApprox(const AValue: Double): Double;
+var
+  E: Double;
+begin
+  {$IFDEF DARWIN}
+  Exit(LibMTanh(AValue));
+  {$ENDIF}
+  {$IFDEF LINUX}
+  Exit(LibMTanh(AValue));
+  {$ENDIF}
+
+  if AValue = 0 then
+    Exit(AValue);
+  if AValue > 20 then
+    Exit(1.0);
+  if AValue < -20 then
+    Exit(-1.0);
+  if Abs(AValue) < 0.25 then
+  begin
+    E := Expm1Approx(2.0 * AValue);
+    Exit(E / (E + 2.0));
+  end;
+  Result := Tanh(AValue);
+end;
+
+function SinhApprox(const AValue: Double): Double;
+var
+  Term, X2: Double;
+  N: Integer;
+begin
+  {$IFDEF DARWIN}
+  Exit(LibMSinh(AValue));
+  {$ENDIF}
+  {$IFDEF LINUX}
+  Exit(LibMSinh(AValue));
+  {$ENDIF}
+
+  if AValue = 0 then
+    Exit(AValue);
+  if Abs(AValue) >= 0.125 then
+    Exit(Sinh(AValue));
+  Result := AValue;
+  Term := AValue;
+  X2 := AValue * AValue;
+  for N := 1 to 24 do
+  begin
+    Term := Term * X2 / ((2 * N) * (2 * N + 1));
+    Result := Result + Term;
+    if Abs(Term) <= Abs(Result) * 1.0E-17 then
+      Break;
+  end;
+end;
+
+function DecomposeFiniteDouble(const AValue: Double; out AMantissa: TBigInteger;
+  out AExponent: Integer): Boolean;
+var
+  Bits, Fraction: QWord;
+  RawExponent: Integer;
+begin
+  Bits := PQWord(@AValue)^;
+  Fraction := Bits and DOUBLE_FRAC_MASK;
+  RawExponent := Integer((Bits and DOUBLE_EXP_MASK) shr DOUBLE_FRAC_BITS);
+  if RawExponent = 0 then
+  begin
+    if Fraction = 0 then
+      Exit(False);
+    AMantissa := TBigInteger.FromInt64(Int64(Fraction));
+    AExponent := DOUBLE_MIN_SUBNORMAL_EXPONENT;
+  end
+  else
+  begin
+    AMantissa := TBigInteger.FromInt64(Int64(DOUBLE_HIDDEN_BIT or Fraction));
+    AExponent := RawExponent - DOUBLE_EXP_BIAS - DOUBLE_FRAC_BITS;
+  end;
+  if (Bits and DOUBLE_SIGN_MASK) <> 0 then
+    AMantissa := AMantissa.Negate;
+  Result := True;
+end;
+
+function RoundShiftRightToEven(const AValue: TBigInteger;
+  const AShift: Integer): TBigInteger;
+var
+  Divisor, Quotient, Remainder, TwiceRemainder: TBigInteger;
+  Cmp: Integer;
+begin
+  if AShift <= 0 then
+    Exit(AValue.ShiftLeft(-AShift));
+  Quotient := AValue.ShiftRight(AShift);
+  Remainder := AValue.Subtract(Quotient.ShiftLeft(AShift));
+  if Remainder.IsZero then
+    Exit(Quotient);
+  Divisor := TBigInteger.One.ShiftLeft(AShift);
+  TwiceRemainder := Remainder.ShiftLeft(1);
+  Cmp := TwiceRemainder.Compare(Divisor);
+  if (Cmp > 0) or ((Cmp = 0) and Quotient.GetBit(0)) then
+    Quotient := Quotient.Add(TBigInteger.One);
+  Result := Quotient;
+end;
+
+function ExactScaledIntegerToDouble(const AValue: TBigInteger;
+  const AExponent: Integer): Double;
+var
+  Negative: Boolean;
+  Magnitude, Significand: TBigInteger;
+  Exponent, Shift: Integer;
+begin
+  if AValue.IsZero then
+    Exit(0.0);
+
+  Negative := AValue.IsNegative;
+  Magnitude := AValue.AbsValue;
+  Exponent := Magnitude.BitLength - 1 + AExponent;
+
+  if Exponent > DOUBLE_MAX_EXPONENT then
+  begin
+    if Negative then
+      Exit(NegInfinity);
+    Exit(Infinity);
+  end;
+
+  if Exponent >= DOUBLE_MIN_NORMAL_EXPONENT then
+  begin
+    Shift := Exponent - DOUBLE_FRAC_BITS - AExponent;
+    Significand := RoundShiftRightToEven(Magnitude, Shift);
+    if Significand.BitLength > DOUBLE_FRAC_BITS + 1 then
+    begin
+      Significand := Significand.ShiftRight(1);
+      Inc(Exponent);
+      if Exponent > DOUBLE_MAX_EXPONENT then
+      begin
+        if Negative then
+          Exit(NegInfinity);
+        Exit(Infinity);
+      end;
+    end;
+    Result := Ldexp(Significand.ToDouble, Exponent - DOUBLE_FRAC_BITS);
+  end
+  else
+  begin
+    Shift := DOUBLE_MIN_SUBNORMAL_EXPONENT - AExponent;
+    Significand := RoundShiftRightToEven(Magnitude, Shift);
+    if Significand.IsZero then
+      Result := 0.0
+    else
+      Result := Ldexp(Significand.ToDouble, DOUBLE_MIN_SUBNORMAL_EXPONENT);
+  end;
+
+  if Negative then
+    Result := -Result;
+end;
 
 procedure ClearThreadvarMembers;
 begin
@@ -166,8 +494,6 @@ function TGocciaMath.MathAbs(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.abs', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: If n is NaN, return NaN.
@@ -187,7 +513,6 @@ var
   NumberArg: TGocciaNumberLiteralValue;
   IntegralPart: Double;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.floor', ThrowError);
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := TGocciaArgumentConverter.GetNumber(AArgs, 0);
   // Step 2: If n is NaN, +∞𝔽, -∞𝔽, return n. Signed-zero is preserved
@@ -215,11 +540,11 @@ var
   NumberArg: TGocciaNumberLiteralValue;
   V: Double;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.ceil', ThrowError);
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := TGocciaArgumentConverter.GetNumber(AArgs, 0);
   // Step 2: If n is NaN, +∞𝔽, -∞𝔽, or an integral Number, return n.
-  if NumberArg.IsNaN or NumberArg.IsInfinite then
+  if NumberArg.IsNaN or NumberArg.IsInfinite or NumberArg.IsNegativeZero or
+     (NumberArg.Value = 0) or IsFiniteIntegral(NumberArg.Value) then
   begin
     Result := NumberArg;
     Exit;
@@ -240,11 +565,11 @@ function TGocciaMath.MathRound(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.round', ThrowError);
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: If n is NaN, +∞𝔽, -∞𝔽, or an integral Number, return n.
-  if NumberArg.IsNaN or NumberArg.IsInfinite then
+  if NumberArg.IsNaN or NumberArg.IsInfinite or NumberArg.IsNegativeZero or
+     (NumberArg.Value = 0) or IsFiniteIntegral(NumberArg.Value) then
   begin
     Result := NumberArg;
     Exit;
@@ -252,6 +577,8 @@ begin
   // Step 3: If n < +0𝔽 and n ≥ -0.5𝔽, return -0𝔽.
   if (NumberArg.Value < 0) and (NumberArg.Value >= -0.5) then
     Result := TGocciaNumberLiteralValue.NegativeZeroValue
+  else if (NumberArg.Value > 0) and (NumberArg.Value < 0.5) then
+    Result := TGocciaNumberLiteralValue.ZeroValue
   // Step 4: Return floor(n + 0.5).
   else
     Result := TGocciaNumberLiteralValue.Create(Floor(NumberArg.Value + 0.5));
@@ -262,6 +589,8 @@ function TGocciaMath.MathMax(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   I: Integer;
   MaxVal, NumVal: TGocciaNumberLiteralValue;
+  Coerced: array of TGocciaNumberLiteralValue;
+  HasNaN: Boolean;
 begin
   // Step 1: Let coerced be a new empty List.
   // Step 2: For each element arg of args, append ? ToNumber(arg) to coerced.
@@ -270,27 +599,27 @@ begin
     Result := TGocciaNumberLiteralValue.NegativeInfinityValue
   else
   begin
-    MaxVal := AArgs.GetElement(0).ToNumberLiteral;
-
-    // Step 4: If any element is NaN, return NaN.
-    if MaxVal.IsNaN then
+    SetLength(Coerced, AArgs.Length);
+    HasNaN := False;
+    for I := 0 to AArgs.Length - 1 do
     begin
-      Result := TGocciaNumberLiteralValue.NaNValue;
-      Exit;
+      Coerced[I] := AArgs.GetElement(I).ToNumberLiteral;
+      if Coerced[I].IsNaN then
+        HasNaN := True;
     end;
 
+    // Step 4: If any element is NaN, return NaN after all coercions.
+    if HasNaN then
+      Exit(TGocciaNumberLiteralValue.NaNValue);
+
     // Step 5: Return the largest value among the elements of coerced.
-    for I := 1 to AArgs.Length - 1 do
+    MaxVal := Coerced[0];
+    for I := 1 to High(Coerced) do
     begin
-      NumVal := AArgs.GetElement(I).ToNumberLiteral;
-
-      if NumVal.IsNaN then
-      begin
-        Result := TGocciaNumberLiteralValue.NaNValue;
-        Exit;
-      end;
-
-      if NumVal.IsGreaterThan(MaxVal).Value then
+      NumVal := Coerced[I];
+      if NumVal.IsGreaterThan(MaxVal).Value or
+         ((NumVal.Value = 0) and (not NumVal.IsNegativeZero) and
+          MaxVal.IsNegativeZero) then
         MaxVal := NumVal;
     end;
     Result := MaxVal;
@@ -302,6 +631,8 @@ function TGocciaMath.MathMin(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   I: Integer;
   MinVal, NumVal: TGocciaNumberLiteralValue;
+  Coerced: array of TGocciaNumberLiteralValue;
+  HasNaN: Boolean;
 begin
   // Step 1: Let coerced be a new empty List.
   // Step 2: For each element arg of args, append ? ToNumber(arg) to coerced.
@@ -310,27 +641,27 @@ begin
     Result := TGocciaNumberLiteralValue.InfinityValue
   else
   begin
-    MinVal := AArgs.GetElement(0).ToNumberLiteral;
-
-    // Step 4: If any element is NaN, return NaN.
-    if MinVal.IsNaN then
+    SetLength(Coerced, AArgs.Length);
+    HasNaN := False;
+    for I := 0 to AArgs.Length - 1 do
     begin
-      Result := TGocciaNumberLiteralValue.NaNValue;
-      Exit;
+      Coerced[I] := AArgs.GetElement(I).ToNumberLiteral;
+      if Coerced[I].IsNaN then
+        HasNaN := True;
     end;
 
+    // Step 4: If any element is NaN, return NaN after all coercions.
+    if HasNaN then
+      Exit(TGocciaNumberLiteralValue.NaNValue);
+
     // Step 5: Return the smallest value among the elements of coerced.
-    for I := 1 to AArgs.Length - 1 do
+    MinVal := Coerced[0];
+    for I := 1 to High(Coerced) do
     begin
-      NumVal := AArgs.GetElement(I).ToNumberLiteral;
-
-      if NumVal.IsNaN then
-      begin
-        Result := TGocciaNumberLiteralValue.NaNValue;
-        Exit;
-      end;
-
-      if NumVal.IsLessThan(MinVal).Value then
+      NumVal := Coerced[I];
+      if NumVal.IsLessThan(MinVal).Value or
+         (NumVal.IsNegativeZero and (MinVal.Value = 0) and
+          (not MinVal.IsNegativeZero)) then
         MinVal := NumVal;
     end;
     Result := MinVal;
@@ -345,7 +676,6 @@ var
   IntPart: Double;
   ExpIsOddInteger: Boolean;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Math.pow', ThrowError);
   Base := TGocciaArgumentConverter.GetNumber(AArgs, 0);
   Exponent := TGocciaArgumentConverter.GetNumber(AArgs, 1);
   B := Base.Value;
@@ -457,8 +787,6 @@ function TGocciaMath.MathSqrt(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sqrt', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: If n is NaN, return NaN.
@@ -527,8 +855,6 @@ function TGocciaMath.MathSign(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberLiteral: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sign', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberLiteral := AArgs.GetElement(0).ToNumberLiteral;
 
@@ -542,8 +868,12 @@ begin
   else if NumberLiteral.IsNegativeInfinity then
     Result := TGocciaNumberLiteralValue.Create(-1)
   // Step 5: If n < +0𝔽, return -1𝔽. If n > +0𝔽, return 1𝔽. Otherwise return n (±0).
+  else if NumberLiteral.Value = 0 then
+    Result := NumberLiteral
+  else if NumberLiteral.Value < 0 then
+    Result := TGocciaNumberLiteralValue.Create(-1)
   else
-    Result := TGocciaNumberLiteralValue.Create(Sign(NumberLiteral.Value));
+    Result := TGocciaNumberLiteralValue.OneValue;
 end;
 
 // §21.3.2.35 Math.trunc ( x )
@@ -551,8 +881,6 @@ function TGocciaMath.MathTrunc(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.trunc', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: If n is NaN, +∞𝔽, -∞𝔽, +0𝔽, or -0𝔽, return n.
@@ -562,6 +890,12 @@ begin
     Result := TGocciaNumberLiteralValue.InfinityValue
   else if NumberArg.IsNegativeInfinity then
     Result := TGocciaNumberLiteralValue.NegativeInfinityValue
+  else if NumberArg.IsNegativeZero or (NumberArg.Value = 0) then
+    Result := NumberArg
+  else if Abs(NumberArg.Value) >= DOUBLE_INTEGRAL_LIMIT then
+    Result := NumberArg
+  else if (NumberArg.Value < 0) and (NumberArg.Value > -1) then
+    Result := TGocciaNumberLiteralValue.NegativeZeroValue
   // Step 3: Return the integral Number nearest n in the direction of +0𝔽.
   else
     Result := TGocciaNumberLiteralValue.Create(Trunc(NumberArg.Value));
@@ -572,8 +906,6 @@ function TGocciaMath.MathExp(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberLiteral: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.exp', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberLiteral := AArgs.GetElement(0).ToNumberLiteral;
 
@@ -593,8 +925,6 @@ function TGocciaMath.MathLog(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.log', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for ln(n).
@@ -617,8 +947,6 @@ function TGocciaMath.MathLog10(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.log10', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for log10(n).
@@ -641,8 +969,6 @@ function TGocciaMath.MathSin(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sin', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for sin(n).
@@ -659,8 +985,6 @@ function TGocciaMath.MathCos(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.cos', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for cos(n).
@@ -677,8 +1001,6 @@ function TGocciaMath.MathTan(const AArgs: TGocciaArgumentsCollection; const AThi
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.tan', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for tan(n).
@@ -695,8 +1017,6 @@ function TGocciaMath.MathAcos(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.acos', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for acos(n).
@@ -716,8 +1036,6 @@ function TGocciaMath.MathAsin(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.asin', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for asin(n).
@@ -737,8 +1055,6 @@ function TGocciaMath.MathAtan(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.atan', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for atan(n).
@@ -759,8 +1075,6 @@ function TGocciaMath.MathAtan2(const AArgs: TGocciaArgumentsCollection; const AT
 var
   Y, X: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Math.atan2', ThrowError);
-
   // Step 1: Let ny be ? ToNumber(y).
   Y := TGocciaArgumentConverter.GetNumber(AArgs, 0);
   // Step 2: Let nx be ? ToNumber(x).
@@ -769,14 +1083,46 @@ begin
   // Step 3: Return the implementation-approximated Number value for atan2(ny, nx).
   if Y.IsNaN or X.IsNaN then
     Result := TGocciaNumberLiteralValue.NaNValue
+  else if Y.Value = 0 then
+  begin
+    if Y.IsNegativeZero then
+    begin
+      if X.IsNegativeZero or (X.Value < 0) or X.IsNegativeInfinity then
+        Result := TGocciaNumberLiteralValue.Create(-Pi)
+      else
+        Result := TGocciaNumberLiteralValue.NegativeZeroValue;
+    end
+    else if X.IsNegativeZero or (X.Value < 0) or X.IsNegativeInfinity then
+      Result := TGocciaNumberLiteralValue.Create(Pi)
+    else
+      Result := TGocciaNumberLiteralValue.ZeroValue;
+  end
   else if Y.IsInfinity and X.IsInfinity then
-    Result := TGocciaNumberLiteralValue.NaNValue
-  else if Y.IsNegativeInfinity and X.IsInfinity then
-    Result := TGocciaNumberLiteralValue.NaNValue
+    Result := TGocciaNumberLiteralValue.Create(Pi / 4)
   else if Y.IsInfinity and X.IsNegativeInfinity then
-    Result := TGocciaNumberLiteralValue.NaNValue
+    Result := TGocciaNumberLiteralValue.Create(3 * Pi / 4)
+  else if Y.IsInfinity then
+    Result := TGocciaNumberLiteralValue.Create(Pi / 2)
+  else if Y.IsNegativeInfinity and X.IsInfinity then
+    Result := TGocciaNumberLiteralValue.Create(-Pi / 4)
   else if Y.IsNegativeInfinity and X.IsNegativeInfinity then
-    Result := TGocciaNumberLiteralValue.NaNValue
+    Result := TGocciaNumberLiteralValue.Create(-3 * Pi / 4)
+  else if Y.IsNegativeInfinity then
+    Result := TGocciaNumberLiteralValue.Create(-Pi / 2)
+  else if X.IsInfinity then
+  begin
+    if Y.Value < 0 then
+      Result := TGocciaNumberLiteralValue.NegativeZeroValue
+    else
+      Result := TGocciaNumberLiteralValue.ZeroValue;
+  end
+  else if X.IsNegativeInfinity then
+  begin
+    if Y.Value < 0 then
+      Result := TGocciaNumberLiteralValue.Create(-Pi)
+    else
+      Result := TGocciaNumberLiteralValue.Create(Pi);
+  end
   else
     Result := TGocciaNumberLiteralValue.Create(ArcTan2(Y.Value, X.Value));
 end;
@@ -785,10 +1131,7 @@ end;
 function TGocciaMath.MathCbrt(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   NumberArg: TGocciaNumberLiteralValue;
-  SignVal: Double;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.cbrt', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for cbrt(n).
@@ -799,12 +1142,9 @@ begin
   else if NumberArg.IsNegativeInfinity then
     Result := TGocciaNumberLiteralValue.NegativeInfinityValue
   else if NumberArg.Value = 0.0 then
-    Result := TGocciaNumberLiteralValue.ZeroValue
+    Result := NumberArg
   else
-  begin
-    SignVal := Sign(NumberArg.Value);
-    Result := TGocciaNumberLiteralValue.Create(SignVal * Power(Abs(NumberArg.Value), 1.0 / 3.0));
-  end;
+    Result := TGocciaNumberLiteralValue.Create(CubeRootApprox(NumberArg.Value));
 end;
 
 // §21.3.2.13 Math.cosh ( x )
@@ -812,8 +1152,6 @@ function TGocciaMath.MathCosh(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.cosh', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for cosh(n).
@@ -830,8 +1168,6 @@ function TGocciaMath.MathSinh(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sinh', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for sinh(n).
@@ -841,8 +1177,10 @@ begin
     Result := TGocciaNumberLiteralValue.InfinityValue
   else if NumberArg.IsNegativeInfinity then
     Result := TGocciaNumberLiteralValue.NegativeInfinityValue
+  else if NumberArg.Value = 0 then
+    Result := NumberArg
   else
-    Result := TGocciaNumberLiteralValue.Create(Sinh(NumberArg.Value));
+    Result := TGocciaNumberLiteralValue.Create(SinhApprox(NumberArg.Value));
 end;
 
 // §21.3.2.34 Math.tanh ( x )
@@ -850,8 +1188,6 @@ function TGocciaMath.MathTanh(const AArgs: TGocciaArgumentsCollection; const ATh
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.tanh', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for tanh(n).
@@ -861,8 +1197,10 @@ begin
     Result := TGocciaNumberLiteralValue.OneValue
   else if NumberArg.IsNegativeInfinity then
     Result := TGocciaNumberLiteralValue.Create(-1)
+  else if NumberArg.Value = 0 then
+    Result := NumberArg
   else
-    Result := TGocciaNumberLiteralValue.Create(Tanh(NumberArg.Value));
+    Result := TGocciaNumberLiteralValue.Create(TanhApprox(NumberArg.Value));
 end;
 
 // §21.3.2.3 Math.acosh ( x )
@@ -870,8 +1208,6 @@ function TGocciaMath.MathAcosh(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.acosh', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for acosh(n).
@@ -885,7 +1221,7 @@ begin
   else if NumberArg.Value < 1.0 then
     Result := TGocciaNumberLiteralValue.NaNValue
   else
-    Result := TGocciaNumberLiteralValue.Create(ArcCosh(NumberArg.Value));
+    Result := TGocciaNumberLiteralValue.Create(AcoshApprox(NumberArg.Value));
 end;
 
 // §21.3.2.5 Math.asinh ( x )
@@ -893,8 +1229,6 @@ function TGocciaMath.MathAsinh(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.asinh', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for asinh(n).
@@ -905,7 +1239,7 @@ begin
   else if NumberArg.IsNegativeInfinity then
     Result := TGocciaNumberLiteralValue.NegativeInfinityValue
   else
-    Result := TGocciaNumberLiteralValue.Create(ArcSinh(NumberArg.Value));
+    Result := TGocciaNumberLiteralValue.Create(AsinhApprox(NumberArg.Value));
 end;
 
 // §21.3.2.7 Math.atanh ( x )
@@ -913,8 +1247,6 @@ function TGocciaMath.MathAtanh(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.atanh', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for atanh(n).
@@ -933,8 +1265,10 @@ begin
   // If n is -1𝔽, return -∞𝔽.
   else if NumberArg.Value = -1.0 then
     Result := TGocciaNumberLiteralValue.NegativeInfinityValue
+  else if NumberArg.Value = 0 then
+    Result := NumberArg
   else
-    Result := TGocciaNumberLiteralValue.Create(ArcTanh(NumberArg.Value));
+    Result := TGocciaNumberLiteralValue.Create(AtanhApprox(NumberArg.Value));
 end;
 
 // §21.3.2.15 Math.expm1 ( x )
@@ -942,8 +1276,6 @@ function TGocciaMath.MathExpm1(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.expm1', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for e^n - 1.
@@ -953,8 +1285,10 @@ begin
     Result := TGocciaNumberLiteralValue.Create(-1)
   else if NumberArg.IsInfinity then
     Result := TGocciaNumberLiteralValue.InfinityValue
+  else if NumberArg.Value = 0 then
+    Result := NumberArg
   else
-    Result := TGocciaNumberLiteralValue.Create(Exp(NumberArg.Value) - 1.0);
+    Result := TGocciaNumberLiteralValue.Create(Expm1Approx(NumberArg.Value));
 end;
 
 // ES2026 §21.3.2.17 Math.f16round ( x )
@@ -962,8 +1296,6 @@ function TGocciaMath.MathF16round(const AArgs: TGocciaArgumentsCollection; const
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.f16round', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: If n is NaN, return NaN. If n is ±∞ or ±0, return n.
@@ -973,6 +1305,8 @@ begin
     Result := TGocciaNumberLiteralValue.InfinityValue
   else if NumberArg.IsNegativeInfinity then
     Result := TGocciaNumberLiteralValue.NegativeInfinityValue
+  else if NumberArg.Value = 0 then
+    Result := NumberArg
   // Step 3: Return the result of rounding n to the nearest float16 value.
   else
     Result := TGocciaNumberLiteralValue.Create(Float16ToDouble(DoubleToFloat16(NumberArg.Value)));
@@ -984,8 +1318,6 @@ var
   NumberArg: TGocciaNumberLiteralValue;
   SingleVal: Single;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.fround', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: If n is NaN, return NaN. If n is ±∞, return n.
@@ -995,6 +1327,8 @@ begin
     Result := TGocciaNumberLiteralValue.InfinityValue
   else if NumberArg.IsNegativeInfinity then
     Result := TGocciaNumberLiteralValue.NegativeInfinityValue
+  else if NumberArg.Value = 0 then
+    Result := NumberArg
   // Step 3: Return the result of rounding n to the nearest float32 value.
   else
   begin
@@ -1041,26 +1375,22 @@ end;
 // §21.3.2.19 Math.imul ( x, y )
 function TGocciaMath.MathImul(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  X, Y: TGocciaNumberLiteralValue;
-  XInt, YInt: LongInt;
+  X, Y: Cardinal;
+  Product: UInt64;
+  SignedProduct: Int64;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 2, 'Math.imul', ThrowError);
-
-  X := TGocciaArgumentConverter.GetNumber(AArgs, 0);
-  Y := TGocciaArgumentConverter.GetNumber(AArgs, 1);
-
-  if X.IsNaN or Y.IsNaN then
-    Result := TGocciaNumberLiteralValue.ZeroValue
+  // Step 1: Let a be ? ToUint32(x).
+  X := ToUint32Value(AArgs.GetElement(0));
+  // Step 2: Let b be ? ToUint32(y).
+  Y := ToUint32Value(AArgs.GetElement(1));
+  // Step 3: Let product be (a x b) modulo 2^32.
+  Product := (UInt64(X) * UInt64(Y)) and UInt64($FFFFFFFF);
+  // Step 4: If product >= 2^31, return product - 2^32; otherwise return product.
+  if Product >= UInt64($80000000) then
+    SignedProduct := Int64(Product) - Int64($100000000)
   else
-  begin
-    // Step 1: Let a be ? ToUint32(x).
-    XInt := LongInt(Trunc(X.Value));
-    // Step 2: Let b be ? ToUint32(y).
-    YInt := LongInt(Trunc(Y.Value));
-    // Step 3: Let product be (a × b) modulo 2^32.
-    // Step 4: If product ≥ 2^31, return product - 2^32; otherwise return product.
-    Result := TGocciaNumberLiteralValue.Create(XInt * YInt);
-  end;
+    SignedProduct := Int64(Product);
+  Result := TGocciaNumberLiteralValue.Create(SignedProduct);
 end;
 
 // §21.3.2.22 Math.log1p ( x )
@@ -1068,8 +1398,6 @@ function TGocciaMath.MathLog1p(const AArgs: TGocciaArgumentsCollection; const AT
 var
   NumberArg: TGocciaNumberLiteralValue;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.log1p', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for ln(1 + n).
@@ -1085,17 +1413,19 @@ begin
   // If n < -1𝔽, return NaN.
   else if NumberArg.Value < -1.0 then
     Result := TGocciaNumberLiteralValue.NaNValue
+  else if NumberArg.Value = 0 then
+    Result := NumberArg
   else
-    Result := TGocciaNumberLiteralValue.Create(Ln(1.0 + NumberArg.Value));
+    Result := TGocciaNumberLiteralValue.Create(Log1pApprox(NumberArg.Value));
 end;
 
 // §21.3.2.23 Math.log2 ( x )
 function TGocciaMath.MathLog2(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   NumberArg: TGocciaNumberLiteralValue;
+  LogValue: Double;
+  RoundedLog: Integer;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.log2', ThrowError);
-
   // Step 1: Let n be ? ToNumber(x).
   NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 2: Return the implementation-approximated Number value for log2(n).
@@ -1110,57 +1440,57 @@ begin
   else if NumberArg.Value < 0 then
     Result := TGocciaNumberLiteralValue.NaNValue
   else
-    Result := TGocciaNumberLiteralValue.Create(Log2(NumberArg.Value));
+  begin
+    LogValue := Log2(NumberArg.Value);
+    RoundedLog := Round(LogValue);
+    if (RoundedLog > -1075) and (RoundedLog < 1024) and
+       (Power(2.0, RoundedLog) = NumberArg.Value) then
+      Result := TGocciaNumberLiteralValue.Create(RoundedLog)
+    else
+      Result := TGocciaNumberLiteralValue.Create(LogValue);
+  end;
 end;
 
 // §21.3.2.11 Math.clz32 ( x )
 function TGocciaMath.MathClz32(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
-  NumberArg: TGocciaNumberLiteralValue;
   Value: LongWord;
   Count: Integer;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.clz32', ThrowError);
-
-  NumberArg := AArgs.GetElement(0).ToNumberLiteral;
   // Step 1: Let n be ? ToUint32(x). NaN/±∞ coerce to 0, yielding 32.
-  if NumberArg.IsNaN or NumberArg.IsInfinity or NumberArg.IsNegativeInfinity then
-    Result := TGocciaNumberLiteralValue.Create(32)
+  Value := ToUint32Value(AArgs.GetElement(0));
+  if Value = 0 then
+    Count := 32
   else
   begin
-    Value := LongWord(Trunc(NumberArg.Value));
     // Step 2: Let p be the number of leading zero bits in the unsigned 32-bit
     // binary representation of n.
-    if Value = 0 then
-      Count := 32
-    else
+    Count := 0;
+    while (Value and $80000000) = 0 do
     begin
-      Count := 0;
-      while (Value and $80000000) = 0 do
-      begin
-        Inc(Count);
-        Value := Value shl 1;
-      end;
+      Inc(Count);
+      Value := Value shl 1;
     end;
-    // Step 3: Return 𝔽(p).
-    Result := TGocciaNumberLiteralValue.Create(Count);
   end;
+  // Step 3: Return 𝔽(p).
+  Result := TGocciaNumberLiteralValue.Create(Count);
 end;
 
 // TC39 proposal-math-sum §1 Math.sumPrecise(items)
 function TGocciaMath.MathSumPrecise(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
   procedure AccumulateValue(const AElement: TGocciaValue;
-    var ASum, ACompensation: Double;
-    var AHasPosInf, AHasNegInf, AHasNaN, AHasAnyValue: Boolean);
+    var AExactSum: TBigInteger; var ACommonExponent: Integer;
+    var AHasExactSum, AHasPosInf, AHasNegInf, AHasNaN,
+    AHasNonMinusZero: Boolean);
   var
     NumVal: TGocciaNumberLiteralValue;
-    T: Double;
+    Mantissa: TBigInteger;
+    Exponent: Integer;
   begin
     if not (AElement is TGocciaNumberLiteralValue) then
       Goccia.Values.ErrorHelper.ThrowTypeError(SErrorMathSumPreciseNotNumber, SSuggestNumberRange);
     NumVal := TGocciaNumberLiteralValue(AElement);
-    AHasAnyValue := True;
     if NumVal.IsNaN then
       AHasNaN := True
     else if NumVal.IsInfinity then
@@ -1169,93 +1499,69 @@ function TGocciaMath.MathSumPrecise(const AArgs: TGocciaArgumentsCollection; con
       AHasNegInf := True
     else
     begin
-      // Neumaier compensated summation
-      T := ASum + NumVal.Value;
-      if Abs(ASum) >= Abs(NumVal.Value) then
-        ACompensation := ACompensation + ((ASum - T) + NumVal.Value)
-      else
-        ACompensation := ACompensation + ((NumVal.Value - T) + ASum);
-      ASum := T;
+      if (NumVal.Value <> 0) or not NumVal.IsNegativeZero then
+        AHasNonMinusZero := True;
+      if DecomposeFiniteDouble(NumVal.Value, Mantissa, Exponent) then
+      begin
+        if not AHasExactSum then
+        begin
+          AExactSum := Mantissa;
+          ACommonExponent := Exponent;
+          AHasExactSum := True;
+        end
+        else
+        begin
+          if Exponent < ACommonExponent then
+          begin
+            AExactSum := AExactSum.ShiftLeft(ACommonExponent - Exponent);
+            ACommonExponent := Exponent;
+          end;
+          AExactSum := AExactSum.Add(Mantissa.ShiftLeft(Exponent - ACommonExponent));
+        end;
+      end;
     end;
   end;
 
 var
-  Iterable, IteratorMethod, IteratorObj, NextMethod, Element: TGocciaValue;
+  Iterable, Element: TGocciaValue;
   Iterator: TGocciaIteratorValue;
-  IterResult: TGocciaObjectValue;
-  ArrValue: TGocciaArrayValue;
-  CallArgs: TGocciaArgumentsCollection;
-  I: Integer;
-  Sum, Compensation: Double;
-  HasPosInf, HasNegInf, HasNaN, HasAnyValue: Boolean;
+  Done: Boolean;
+  ExactSum: TBigInteger;
+  CommonExponent: Integer;
+  Sum: Double;
+  HasExactSum, HasPosInf, HasNegInf, HasNaN, HasNonMinusZero: Boolean;
 begin
-  TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'Math.sumPrecise', ThrowError);
-
   Iterable := AArgs.GetElement(0);
 
-  Sum := 0.0;
-  Compensation := 0.0;
+  ExactSum := TBigInteger.Zero;
+  CommonExponent := 0;
+  HasExactSum := False;
   HasPosInf := False;
   HasNegInf := False;
   HasNaN := False;
-  HasAnyValue := False;
+  HasNonMinusZero := False;
 
-  // Fast path for arrays
-  if Iterable is TGocciaArrayValue then
-  begin
-    ArrValue := TGocciaArrayValue(Iterable);
-    for I := 0 to ArrValue.Elements.Count - 1 do
+  Iterator := GetIteratorFromValue(Iterable);
+  if not Assigned(Iterator) then
+    Goccia.Values.ErrorHelper.ThrowTypeError(SErrorMathSumPreciseNotIterable,
+      SSuggestNotIterable);
+
+  TGarbageCollector.Instance.AddTempRoot(Iterator);
+  try
+    Element := Iterator.DirectNext(Done);
+    while not Done do
     begin
-      Element := ArrValue.Elements[I];
-      if not Assigned(Element) then
-        Element := TGocciaUndefinedLiteralValue.UndefinedValue;
-      AccumulateValue(Element, Sum, Compensation, HasPosInf, HasNegInf, HasNaN, HasAnyValue);
-    end;
-  end
-  else
-  begin
-    // Resolve [Symbol.iterator] on the iterable
-    Iterator := nil;
-    if Iterable is TGocciaIteratorValue then
-      Iterator := TGocciaIteratorValue(Iterable)
-    else if Iterable is TGocciaObjectValue then
-    begin
-      IteratorMethod := TGocciaObjectValue(Iterable).GetSymbolProperty(TGocciaSymbolValue.WellKnownIterator);
-      if Assigned(IteratorMethod) and not (IteratorMethod is TGocciaUndefinedLiteralValue) and IteratorMethod.IsCallable then
-      begin
-        CallArgs := TGocciaArgumentsCollection.Create;
-        try
-          IteratorObj := InvokeCallable(IteratorMethod, CallArgs, Iterable);
-        finally
-          CallArgs.Free;
-        end;
-        if IteratorObj is TGocciaIteratorValue then
-          Iterator := TGocciaIteratorValue(IteratorObj)
-        else if IteratorObj is TGocciaObjectValue then
-        begin
-          NextMethod := IteratorObj.GetProperty(PROP_NEXT);
-          if Assigned(NextMethod) and not (NextMethod is TGocciaUndefinedLiteralValue) and NextMethod.IsCallable then
-            // Capture-once per ES2024 §7.4.2 GetIteratorDirect.
-            Iterator := CreateRootedGenericIterator(IteratorObj, NextMethod);
-        end;
+      try
+        AccumulateValue(Element, ExactSum, CommonExponent, HasExactSum,
+          HasPosInf, HasNegInf, HasNaN, HasNonMinusZero);
+      except
+        CloseIteratorPreservingError(Iterator);
+        raise;
       end;
+      Element := Iterator.DirectNext(Done);
     end;
-
-    if not Assigned(Iterator) then
-      Goccia.Values.ErrorHelper.ThrowTypeError(SErrorMathSumPreciseNotIterable, SSuggestNotIterable);
-
-    TGarbageCollector.Instance.AddTempRoot(Iterator);
-    try
-      IterResult := Iterator.AdvanceNext;
-      while not IterResult.GetProperty(PROP_DONE).ToBooleanLiteral.Value do
-      begin
-        Element := IterResult.GetProperty(PROP_VALUE);
-        AccumulateValue(Element, Sum, Compensation, HasPosInf, HasNegInf, HasNaN, HasAnyValue);
-        IterResult := Iterator.AdvanceNext;
-      end;
-    finally
-      TGarbageCollector.Instance.RemoveTempRoot(Iterator);
-    end;
+  finally
+    TGarbageCollector.Instance.RemoveTempRoot(Iterator);
   end;
 
   // Handle special cases per spec
@@ -1267,10 +1573,13 @@ begin
     Exit(TGocciaNumberLiteralValue.InfinityValue);
   if HasNegInf then
     Exit(TGocciaNumberLiteralValue.NegativeInfinityValue);
-  if not HasAnyValue then
+  if not HasNonMinusZero and not HasExactSum then
     Exit(TGocciaNumberLiteralValue.NegativeZeroValue);
 
-  Result := TGocciaNumberLiteralValue.Create(Sum + Compensation);
+  Sum := ExactScaledIntegerToDouble(ExactSum, CommonExponent);
+  if (Sum = 0) and not HasNonMinusZero then
+    Exit(TGocciaNumberLiteralValue.NegativeZeroValue);
+  Result := TGocciaNumberLiteralValue.Create(Sum);
 end;
 
 initialization

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -484,7 +484,8 @@ const
         '};'#10 +
         'const __GocciaDateTimeClip = (epochMilliseconds: any): number => {'#10 +
         '  const t: number = Math.trunc(Number(epochMilliseconds));'#10 +
-        '  return Number.isFinite(t) && Math.abs(t) <= dateTimeClipLimit ? t : NaN;'#10 +
+        '  if (!Number.isFinite(t) || Math.abs(t) > dateTimeClipLimit) return NaN;'#10 +
+        '  return t === 0 ? 0 : t;'#10 +
         '};'#10 +
         'const __GocciaDatePad = (value: number, length: number): string => {'#10 +
         '  return String(Math.abs(Math.trunc(value))).padStart(length, "0");'#10 +

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -588,8 +588,7 @@ const
         '  getUTCSeconds(): number { const z = Date.#utc(this); return z ? z.second : NaN; }'#10 +
         '  getUTCMilliseconds(): number { const z = Date.#utc(this); return z ? z.millisecond : NaN; }'#10 +
         '  static #clip(epochMilliseconds: number): number {'#10 +
-        '    const t = Math.trunc(epochMilliseconds);'#10 +
-        '    return Number.isFinite(t) && Math.abs(t) <= dateTimeClipLimit ? t : NaN;'#10 +
+        '    return __GocciaDateTimeClip(epochMilliseconds);'#10 +
         '  }'#10 +
         '  static #epochFromParts(year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, timeZone: string): number {'#10 +
         '    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day) ||'#10 +

--- a/source/units/Goccia.Values.IntlDateTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlDateTimeFormat.pas
@@ -38,11 +38,17 @@ type
     FResolvedOptions: TIntlDateTimeFormatOptions;
     FHasExplicitCoreOptions: Boolean;
     FBoundFormat: TGocciaValue;
+    FResolvedDateFormatter: Pointer;
 
     procedure InitializePrototype;
     procedure ReadOptions(const AOptions: TGocciaObjectValue);
+    function TryGetResolvedDateFormatter(out AFormatter: Pointer): Boolean;
+    function TryFormatResolvedDateTime(AMillis: Double; out AFormatted: string): Boolean;
+    function TryFormatResolvedDateTimeToParts(AMillis: Double;
+      out AParts: TIntlFormatPartArray): Boolean;
   public
     constructor Create(const ALocale: string; const AOptions: TGocciaObjectValue = nil);
+    destructor Destroy; override;
 
     function ToStringTag: string; override;
     procedure MarkReferences; override;
@@ -1791,8 +1797,11 @@ var
   EffectiveOptions: TIntlDateTimeFormatOptions;
   Input: TDateTimeFormattable;
   Parts: TIntlFormatPartArray;
+  FormatSucceeded: Boolean;
+  UseResolvedFormatter: Boolean;
 begin
   EffectiveOptions := ADTF.FResolvedOptions;
+  UseResolvedFormatter := False;
   Input := ToDateTimeFormattable(AValue);
   if IsTemporalDateTimeKind(Input.Kind) then
   begin
@@ -1814,12 +1823,21 @@ begin
       Millis := TimeClipMillis(Millis);
   end
   else
+  begin
     Millis := TimeClipMillis(Input.Millis);
+    UseResolvedFormatter := True;
+  end;
 
   if IsNan(Millis) then
     ThrowRangeError('Invalid time value');
 
-  if TryICUFormatDateTime(ADTF.FLocale, Millis, EffectiveOptions, Formatted) then
+  if UseResolvedFormatter then
+    FormatSucceeded := ADTF.TryFormatResolvedDateTime(Millis, Formatted)
+  else
+    FormatSucceeded := TryICUFormatDateTime(ADTF.FLocale, Millis,
+      EffectiveOptions, Formatted);
+
+  if FormatSucceeded then
   begin
     Formatted := AdjustProlepticGregorianYearEra(Formatted, Millis,
       EffectiveOptions);
@@ -2033,6 +2051,57 @@ begin
     FPrototype := GetIntlDateTimeFormatShared.Prototype;
 end;
 
+destructor TGocciaIntlDateTimeFormatValue.Destroy;
+begin
+  ICUCloseDateTimeFormatter(FResolvedDateFormatter);
+  inherited;
+end;
+
+function TGocciaIntlDateTimeFormatValue.TryGetResolvedDateFormatter(
+  out AFormatter: Pointer): Boolean;
+begin
+  if not Assigned(FResolvedDateFormatter) then
+    if not TryICUOpenDateTimeFormatter(FLocale, FResolvedOptions,
+      FResolvedDateFormatter) then
+    begin
+      AFormatter := nil;
+      Exit(False);
+    end;
+
+  AFormatter := FResolvedDateFormatter;
+  Result := True;
+end;
+
+function TGocciaIntlDateTimeFormatValue.TryFormatResolvedDateTime(
+  AMillis: Double; out AFormatted: string): Boolean;
+var
+  Formatter: Pointer;
+begin
+  if not TryGetResolvedDateFormatter(Formatter) then
+  begin
+    AFormatted := '';
+    Exit(False);
+  end;
+
+  Result := TryICUFormatDateTimeWithFormatter(Formatter, AMillis,
+    FResolvedOptions, AFormatted);
+end;
+
+function TGocciaIntlDateTimeFormatValue.TryFormatResolvedDateTimeToParts(
+  AMillis: Double; out AParts: TIntlFormatPartArray): Boolean;
+var
+  Formatter: Pointer;
+begin
+  if not TryGetResolvedDateFormatter(Formatter) then
+  begin
+    SetLength(AParts, 0);
+    Exit(False);
+  end;
+
+  Result := TryICUFormatDateTimeToPartsWithFormatter(Formatter, AMillis,
+    FResolvedOptions, AParts);
+end;
+
 function TGocciaIntlDateTimeFormatValue.ToStringTag: string;
 begin
   Result := 'Object';
@@ -2116,7 +2185,7 @@ begin
   if AArgs.GetElement(0) is TGocciaUndefinedLiteralValue then
   begin
     Millis := CurrentEpochMilliseconds;
-    if TryICUFormatDateTime(DTF.FLocale, Millis, DTF.FResolvedOptions, Formatted) then
+    if DTF.TryFormatResolvedDateTime(Millis, Formatted) then
     begin
       Formatted := AdjustProlepticGregorianYearEra(Formatted, Millis,
         DTF.FResolvedOptions);
@@ -2139,11 +2208,17 @@ var
   Parts: TIntlFormatPartArray;
   EffectiveOptions: TIntlDateTimeFormatOptions;
   Input: TDateTimeFormattable;
+  FormatSucceeded: Boolean;
+  UseResolvedFormatter: Boolean;
 begin
   DTF := AsDateTimeFormat(AThisValue, 'Intl.DateTimeFormat.prototype.formatToParts');
   EffectiveOptions := DTF.FResolvedOptions;
+  UseResolvedFormatter := False;
   if AArgs.GetElement(0) is TGocciaUndefinedLiteralValue then
-    Millis := CurrentEpochMilliseconds
+  begin
+    Millis := CurrentEpochMilliseconds;
+    UseResolvedFormatter := True;
+  end
   else
   begin
     Input := ToDateTimeFormattable(AArgs.GetElement(0));
@@ -2167,13 +2242,22 @@ begin
         Millis := TimeClipMillis(Millis);
     end
     else
+    begin
       Millis := TimeClipMillis(Input.Millis);
+      UseResolvedFormatter := True;
+    end;
 
     if IsNan(Millis) then
       ThrowRangeError('Invalid time value');
   end;
 
-  if TryICUFormatDateTimeToParts(DTF.FLocale, Millis, EffectiveOptions, Parts) then
+  if UseResolvedFormatter then
+    FormatSucceeded := DTF.TryFormatResolvedDateTimeToParts(Millis, Parts)
+  else
+    FormatSucceeded := TryICUFormatDateTimeToParts(DTF.FLocale, Millis,
+      EffectiveOptions, Parts);
+
+  if FormatSucceeded then
   begin
     AdjustLunisolarLeapMonthParts(Parts, Millis, EffectiveOptions);
     EnsureCopticEraPart(Parts, EffectiveOptions);

--- a/source/units/Goccia.Values.IntlDateTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlDateTimeFormat.pas
@@ -42,6 +42,7 @@ type
 
     procedure InitializePrototype;
     procedure ReadOptions(const AOptions: TGocciaObjectValue);
+    procedure SetResolvedTimeZone(const ATimeZone: string);
     function TryGetResolvedDateFormatter(out AFormatter: Pointer): Boolean;
     function TryFormatResolvedDateTime(AMillis: Double; out AFormatted: string): Boolean;
     function TryFormatResolvedDateTimeToParts(AMillis: Double;
@@ -1895,8 +1896,7 @@ begin
   begin
     ZDT := TGocciaTemporalZonedDateTimeValue(AValue);
     TimeZoneId := NormalizeDateTimeFormatTimeZone(ZDT.TimeZone);
-    DTF.FTimeZone := TimeZoneId;
-    DTF.FResolvedOptions.TimeZone := ICUDateTimeFormatTimeZone(TimeZoneId);
+    DTF.SetResolvedTimeZone(TimeZoneId);
   end;
 
   Result := FormatTemporalValueWithDateTimeFormat(DTF, AValue, True);
@@ -2055,6 +2055,20 @@ destructor TGocciaIntlDateTimeFormatValue.Destroy;
 begin
   ICUCloseDateTimeFormatter(FResolvedDateFormatter);
   inherited;
+end;
+
+procedure TGocciaIntlDateTimeFormatValue.SetResolvedTimeZone(
+  const ATimeZone: string);
+var
+  ICUTimeZone: string;
+begin
+  ICUTimeZone := ICUDateTimeFormatTimeZone(ATimeZone);
+  if (FTimeZone = ATimeZone) and (FResolvedOptions.TimeZone = ICUTimeZone) then
+    Exit;
+
+  ICUCloseDateTimeFormatter(FResolvedDateFormatter);
+  FTimeZone := ATimeZone;
+  FResolvedOptions.TimeZone := ICUTimeZone;
 end;
 
 function TGocciaIntlDateTimeFormatValue.TryGetResolvedDateFormatter(

--- a/tests/built-ins/Date/constructor.js
+++ b/tests/built-ins/Date/constructor.js
@@ -33,6 +33,11 @@ describe("Date constructor", () => {
     expect(d.getUTCDate()).toBe(1);
   });
 
+  test("new Date(ms) TimeClip canonicalizes negative zero", () => {
+    expect(Object.is(new Date(-0).getTime(), +0)).toBe(true);
+    expect(Object.is(new Date(-1.23e-15).valueOf(), +0)).toBe(true);
+  });
+
   test("Date instances allow own Symbol.toStringTag overrides", () => {
     const d = new Date(0);
     expect(Object.prototype.toString.call(d)).toBe("[object Date]");

--- a/tests/built-ins/Date/methods.js
+++ b/tests/built-ins/Date/methods.js
@@ -138,6 +138,14 @@ describe("Date methods", () => {
     expect(value.getUTCDate()).toBe(2);
   });
 
+  test("setTime() TimeClip canonicalizes negative zero", () => {
+    const value = new Date(1);
+    expect(Object.is(value.setTime(-0), +0)).toBe(true);
+    expect(Object.is(value.getTime(), +0)).toBe(true);
+    expect(Object.is(value.setTime(-1.23e-15), +0)).toBe(true);
+    expect(Object.is(value.valueOf(), +0)).toBe(true);
+  });
+
   test("multi-argument setters distinguish omitted fields from explicit undefined", () => {
     const base = Date.UTC(2024, 0, 2, 3, 4, 5, 6);
 

--- a/tests/built-ins/Math/atan2.js
+++ b/tests/built-ins/Math/atan2.js
@@ -8,3 +8,23 @@ test("Math.atan2", () => {
   expect(Math.atan2(1, 0)).toBe(Math.PI / 2);
   expect(Number.isNaN(Math.atan2(NaN, 1))).toBe(true);
 });
+
+test("Math.atan2 preserves signed zero for y", () => {
+  expect(Object.is(Math.atan2(-0, +0), -0)).toBe(true);
+  expect(Object.is(Math.atan2(-0, 1), -0)).toBe(true);
+  expect(Math.atan2(+0, -0)).toBe(Math.PI);
+  expect(Math.atan2(-0, -0)).toBe(-Math.PI);
+});
+
+test("Math.atan2 returns NaN for missing arguments", () => {
+  expect(Number.isNaN(Math.atan2(1))).toBe(true);
+});
+
+test("Math.atan2 handles infinity quadrants", () => {
+  expect(Math.atan2(Infinity, Infinity)).toBe(Math.PI / 4);
+  expect(Math.atan2(Infinity, -Infinity)).toBe((3 * Math.PI) / 4);
+  expect(Math.atan2(-Infinity, Infinity)).toBe(-Math.PI / 4);
+  expect(Math.atan2(-Infinity, -Infinity)).toBe((-3 * Math.PI) / 4);
+  expect(Object.is(Math.atan2(-1, Infinity), -0)).toBe(true);
+  expect(Math.atan2(1, -Infinity)).toBe(Math.PI);
+});

--- a/tests/built-ins/Math/f16round.js
+++ b/tests/built-ins/Math/f16round.js
@@ -7,6 +7,10 @@ describe("Math.f16round", () => {
     expect(Number.isNaN(Math.f16round(NaN))).toBe(true);
   });
 
+  test("returns NaN for missing input", () => {
+    expect(Number.isNaN(Math.f16round())).toBe(true);
+  });
+
   test("returns Infinity for Infinity", () => {
     expect(Math.f16round(Infinity)).toBe(Infinity);
   });

--- a/tests/built-ins/Math/hyperbolic.js
+++ b/tests/built-ins/Math/hyperbolic.js
@@ -6,27 +6,39 @@ describe("Math hyperbolic methods", () => {
 
   test("Math.sinh", () => {
     expect(Math.sinh(0)).toBe(0);
+    expect(Object.is(Math.sinh(-0), -0)).toBe(true);
     expect(Number.isNaN(Math.sinh(NaN))).toBe(true);
   });
 
   test("Math.tanh", () => {
     expect(Math.tanh(0)).toBe(0);
+    expect(Object.is(Math.tanh(-0), -0)).toBe(true);
     expect(Number.isNaN(Math.tanh(NaN))).toBe(true);
   });
 
   test("Math.acosh", () => {
     expect(Math.acosh(1)).toBe(0);
+    expect(Math.acosh(Number.MAX_VALUE)).toBeCloseTo(710.4758600739439, 12);
     expect(Number.isNaN(Math.acosh(0.5))).toBe(true);
     expect(Number.isNaN(Math.acosh(NaN))).toBe(true);
   });
 
   test("Math.asinh", () => {
     expect(Math.asinh(0)).toBe(0);
+    expect(Object.is(Math.asinh(-0), -0)).toBe(true);
     expect(Number.isNaN(Math.asinh(NaN))).toBe(true);
   });
 
   test("Math.atanh", () => {
     expect(Math.atanh(0)).toBe(0);
+    expect(Object.is(Math.atanh(-0), -0)).toBe(true);
     expect(Number.isNaN(Math.atanh(NaN))).toBe(true);
+  });
+
+  test("inverse hyperbolic roundtrips stay within the expected double", () => {
+    expect(Math.asinh(Math.sinh(-0.25))).toBe(-0.25);
+
+    const loopValue = -0.24999999999999967;
+    expect(Math.atanh(Math.tanh(loopValue))).toBe(loopValue);
   });
 });

--- a/tests/built-ins/Math/max.js
+++ b/tests/built-ins/Math/max.js
@@ -20,6 +20,24 @@ test("Math.max", () => {
   expect(Math.max(Infinity, -Infinity)).toBe(Infinity);
 });
 
+test("Math.max coerces all arguments before returning NaN", () => {
+  let calls = 0;
+  const coercible = {
+    valueOf: () => {
+      calls += 1;
+      return 1;
+    },
+  };
+
+  expect(Math.max(NaN, coercible)).toBeNaN();
+  expect(calls).toBe(1);
+});
+
+test("Math.max treats positive zero as greater than negative zero", () => {
+  expect(Object.is(Math.max(-0, +0), +0)).toBe(true);
+  expect(Object.is(Math.max(+0, -0), +0)).toBe(true);
+});
+
 test("Math.max has correct name and length", () => {
   expect(Math.max.name).toBe("max");
   expect(Math.max.length).toBe(2);

--- a/tests/built-ins/Math/min.js
+++ b/tests/built-ins/Math/min.js
@@ -18,6 +18,24 @@ test("Math.min", () => {
   expect(Math.min(-Infinity, Infinity)).toBe(-Infinity);
 });
 
+test("Math.min coerces all arguments before returning NaN", () => {
+  let calls = 0;
+  const coercible = {
+    valueOf: () => {
+      calls += 1;
+      return 1;
+    },
+  };
+
+  expect(Math.min(NaN, coercible)).toBeNaN();
+  expect(calls).toBe(1);
+});
+
+test("Math.min treats negative zero as less than positive zero", () => {
+  expect(Object.is(Math.min(+0, -0), -0)).toBe(true);
+  expect(Object.is(Math.min(-0, +0), -0)).toBe(true);
+});
+
 test("Math.min has correct name and length", () => {
   expect(Math.min.name).toBe("min");
   expect(Math.min.length).toBe(2);

--- a/tests/built-ins/Math/misc.js
+++ b/tests/built-ins/Math/misc.js
@@ -2,17 +2,21 @@ describe("Math miscellaneous methods", () => {
   test("Math.cbrt", () => {
     expect(Math.cbrt(27)).toBeCloseTo(3, 3);
     expect(Math.cbrt(0)).toBe(0);
+    expect(Object.is(Math.cbrt(-0), -0)).toBe(true);
     expect(Math.cbrt(-8)).toBeCloseTo(-2, 3);
     expect(Number.isNaN(Math.cbrt(NaN))).toBe(true);
   });
 
   test("Math.expm1", () => {
     expect(Math.expm1(0)).toBe(0);
+    expect(Object.is(Math.expm1(-0), -0)).toBe(true);
     expect(Number.isNaN(Math.expm1(NaN))).toBe(true);
   });
 
   test("Math.fround", () => {
     expect(Math.fround(0)).toBe(0);
+    expect(Object.is(Math.fround(-0), -0)).toBe(true);
+    expect(Number.isNaN(Math.fround())).toBe(true);
     expect(Number.isNaN(Math.fround(NaN))).toBe(true);
   });
 
@@ -29,10 +33,15 @@ describe("Math miscellaneous methods", () => {
     expect(Math.imul(2, 3)).toBe(6);
     expect(Math.imul(0, 5)).toBe(0);
     expect(Math.imul(-1, 5)).toBe(-5);
+    expect(Math.imul(0xffffffff, 5)).toBe(-5);
+    expect(Math.imul(0xffffffff, 0xffffffff)).toBe(1);
+    expect(Math.imul(0x40000000, 0x7fffffff)).toBe(-1073741824);
+    expect(Math.imul(0x80000000, 4)).toBe(0);
   });
 
   test("Math.log1p", () => {
     expect(Math.log1p(0)).toBe(0);
+    expect(Object.is(Math.log1p(-0), -0)).toBe(true);
     expect(Number.isNaN(Math.log1p(NaN))).toBe(true);
   });
 
@@ -46,5 +55,7 @@ describe("Math miscellaneous methods", () => {
   test("Math.clz32", () => {
     expect(Math.clz32(1)).toBe(31);
     expect(Math.clz32(0)).toBe(32);
+    expect(Math.clz32()).toBe(32);
+    expect(Math.clz32(4294967296)).toBe(32);
   });
 });

--- a/tests/built-ins/Math/rounding.js
+++ b/tests/built-ins/Math/rounding.js
@@ -23,7 +23,8 @@ test("Math.round, Math.floor, Math.ceil", () => {
 test("Math.round tie-breaking rounds up per spec", () => {
   expect(Math.round(0.5)).toBe(1);
   expect(Math.round(1.5)).toBe(2);
-  expect(Math.round(-0.5)).toBe(-0);
+  expect(Object.is(Math.round(-0.5), -0)).toBe(true);
+  expect(Object.is(Math.round(0.5 - Number.EPSILON / 4), +0)).toBe(true);
 });
 
 test("Math rounding with NaN and Infinity", () => {
@@ -39,6 +40,10 @@ test("Math rounding with zero", () => {
   expect(Math.round(0)).toBe(0);
   expect(Math.floor(0)).toBe(0);
   expect(Math.ceil(0)).toBe(0);
+  expect(Object.is(Math.round(-0), -0)).toBe(true);
+  expect(Object.is(Math.floor(-0), -0)).toBe(true);
+  expect(Object.is(Math.ceil(-0), -0)).toBe(true);
+  expect(Object.is(Math.ceil(-0.25), -0)).toBe(true);
 });
 
 test("Math rounding methods ignore extra arguments", () => {

--- a/tests/built-ins/Math/sign.js
+++ b/tests/built-ins/Math/sign.js
@@ -7,6 +7,7 @@ test("Math.sign", () => {
   expect(Math.sign(1)).toBe(1);
   expect(Math.sign(-1)).toBe(-1);
   expect(Math.sign(0)).toBeCloseTo(0);
+  expect(Object.is(Math.sign(-0), -0)).toBe(true);
   expect(Math.sign(NaN)).toBeNaN();
   expect(Math.sign(Infinity)).toBe(1);
   expect(Math.sign(-Infinity)).toBe(-1);

--- a/tests/built-ins/Math/sumPrecise.js
+++ b/tests/built-ins/Math/sumPrecise.js
@@ -53,12 +53,42 @@ describe.runIf(hasGoccia)("Math.sumPrecise", () => {
     expect(Math.sumPrecise(s)).toBe(6);
   });
 
+  test("uses the iterable protocol instead of array indexing", () => {
+    const values = [1, 2, 3];
+    let index = 0;
+    values[Symbol.iterator] = () => ({
+      next: () => {
+        index += 1;
+        if (index === 1) return { value: 4, done: false };
+        if (index === 2) return { value: 5, done: false };
+        return { value: undefined, done: true };
+      },
+    });
+
+    expect(Math.sumPrecise(values)).toBe(9);
+  });
+
   test("throws TypeError for non-number elements", () => {
     expect(() => Math.sumPrecise([1, "2", 3])).toThrow(TypeError);
     expect(() => Math.sumPrecise([true])).toThrow(TypeError);
     expect(() => Math.sumPrecise([null])).toThrow(TypeError);
     expect(() => Math.sumPrecise([undefined])).toThrow(TypeError);
     expect(() => Math.sumPrecise([{}])).toThrow(TypeError);
+  });
+
+  test("closes iterators when a non-number element throws", () => {
+    let closed = false;
+    const iterable = {};
+    iterable[Symbol.iterator] = () => ({
+      next: () => ({ value: "not a number", done: false }),
+      return: () => {
+        closed = true;
+        return {};
+      },
+    });
+
+    expect(() => Math.sumPrecise(iterable)).toThrow(TypeError);
+    expect(closed).toBe(true);
   });
 
   test("throws TypeError for non-iterable argument", () => {

--- a/tests/built-ins/Math/trunc.js
+++ b/tests/built-ins/Math/trunc.js
@@ -14,4 +14,7 @@ test("Math.trunc", () => {
   expect(Math.trunc(Infinity)).toBe(Infinity);
   expect(Math.trunc(-Infinity)).toBe(-Infinity);
   expect(Math.trunc(NaN)).toBeNaN();
+  expect(Object.is(Math.trunc(-0), -0)).toBe(true);
+  expect(Object.is(Math.trunc(-0.25), -0)).toBe(true);
+  expect(Math.trunc(Number.MAX_VALUE)).toBe(Number.MAX_VALUE);
 });

--- a/tests/built-ins/Temporal/ZonedDateTime/prototype/toLocaleString.js
+++ b/tests/built-ins/Temporal/ZonedDateTime/prototype/toLocaleString.js
@@ -1,0 +1,38 @@
+/*---
+description: Temporal.ZonedDateTime.prototype.toLocaleString
+features: [Temporal, Intl.DateTimeFormat]
+---*/
+
+const hasTemporalIntl = typeof Temporal !== "undefined" && typeof Intl !== "undefined";
+
+describe.runIf(hasTemporalIntl)("Temporal.ZonedDateTime.prototype.toLocaleString", () => {
+  test("uses the ZonedDateTime time zone", () => {
+    const zdt = new Temporal.ZonedDateTime(0n, "America/New_York");
+    const options = { hour: "numeric", minute: "numeric", timeZoneName: "short" };
+
+    const actual = zdt.toLocaleString("en-US", options);
+    const expected = new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "numeric",
+      timeZoneName: "short",
+      timeZone: "America/New_York",
+    }).format(0);
+    const utc = new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "numeric",
+      timeZoneName: "short",
+      timeZone: "UTC",
+    }).format(0);
+
+    expect(actual).toBe(expected);
+    expect(actual === utc).toBe(false);
+  });
+
+  test("rejects an explicit timeZone option", () => {
+    const zdt = new Temporal.ZonedDateTime(0n, "UTC");
+
+    expect(() => zdt.toLocaleString("en-US", { timeZone: "UTC" })).toThrow(
+      TypeError
+    );
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Close the remaining Math test262 gaps for issue #843, including missing-argument coercion, signed-zero preservation, integer conversion, hyperbolic approximation, and `atan2` quadrant edges.
- Rework `Math.sumPrecise` to use the iterator protocol, close iterators on abrupt element errors, and accumulate finite values exactly before final double rounding.
- Fix the Date shim's TimeClip handling so the corrected `Math.trunc(-tiny) === -0` behavior does not leak `-0` into `Date.prototype.getTime()` / `valueOf()` or `Date.prototype.setTime()`.
- Reuse the resolved `Intl.DateTimeFormat` ICU formatter to keep the Temporal `formatToParts` comparison test below timeout on Linux amd64, and invalidate that cache when `Temporal.ZonedDateTime.prototype.toLocaleString` applies the ZonedDateTime time zone.
- Update focused Math, Date, Intl/Temporal regressions, plus the `Math.sumPrecise` docs, to match the implementation.

Closes #843

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Verification run:

- `./build.pas --clean loaderbare testrunner`
- `./build.pas testrunner`
- `./build.pas loaderbare`
- `./build/GocciaTestRunner tests/built-ins/Math --no-progress --silent`
- `./build/GocciaTestRunner tests/built-ins/Math --mode=bytecode --no-progress --silent`
- `./build/GocciaTestRunner tests/built-ins/Date --no-progress --silent`
- `./build/GocciaTestRunner tests/built-ins/Date --mode=bytecode --no-progress --silent`
- `./build/GocciaTestRunner tests/built-ins/Intl`
- `./build/GocciaTestRunner tests/built-ins/Intl --mode=bytecode`
- `./build/GocciaTestRunner tests/built-ins/Temporal/ZonedDateTime`
- `./build/GocciaTestRunner tests/built-ins/Temporal/ZonedDateTime --mode=bytecode`
- `./build/GocciaTestRunner tests/built-ins/Temporal/ZonedDateTime/prototype/toLocaleString.js`
- `./build/GocciaTestRunner tests/built-ins/Temporal/ZonedDateTime/prototype/toLocaleString.js --mode=bytecode`
- `./build/GocciaTestRunner tests --no-progress --silent`
- `./build/GocciaTestRunner tests --mode=bytecode --no-progress --silent`
- `./format.pas --check`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-843.4Q3XvM --categories built-ins,staging --filter '**/Math/**' --mode bytecode --jobs 4 --timeout-ms 20000 --output /tmp/goccia-issue-843-math-results-final-post-review.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-date.E5wnq8 --categories built-ins --filter 'built-ins/Date/prototype/getTime/this-value-valid-date.js' --mode bytecode --jobs 1 --timeout-ms 20000 --output /tmp/goccia-date-gettime-fixed-bytecode.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-date.E5wnq8 --categories built-ins --filter 'built-ins/Date/prototype/getTime/this-value-valid-date.js' --mode interpreted --jobs 1 --timeout-ms 20000 --output /tmp/goccia-date-gettime-fixed-interpreted.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-date.E5wnq8 --categories built-ins --filter 'built-ins/Date/prototype/valueOf/S9.4_A3_T*.js' --mode bytecode --jobs 1 --timeout-ms 20000 --output /tmp/goccia-date-valueof-fixed-bytecode.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-date.E5wnq8 --categories built-ins --filter 'built-ins/Date/prototype/valueOf/S9.4_A3_T*.js' --mode interpreted --jobs 1 --timeout-ms 20000 --output /tmp/goccia-date-valueof-fixed-interpreted.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-date.E5wnq8 --categories built-ins --filter 'built-ins/Date/TimeClip_negative_zero.js' --mode bytecode --jobs 1 --timeout-ms 20000 --output /tmp/goccia-date-timeclip-fixed-bytecode.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-date.E5wnq8 --categories built-ins --filter 'built-ins/Date/TimeClip_negative_zero.js' --mode interpreted --jobs 1 --timeout-ms 20000 --output /tmp/goccia-date-timeclip-fixed-interpreted.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-843.4Q3XvM --categories built-ins --filter '**/Date/prototype/setTime/**' --mode bytecode --jobs 4 --timeout-ms 20000 --output /tmp/goccia-pr947-settime-test262-merged.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /tmp/goccia-test262-843.4Q3XvM --categories built-ins --filter '**/Date/TimeClip_negative_zero.js' --mode bytecode --jobs 4 --timeout-ms 20000 --output /tmp/goccia-pr947-timeclip-negative-zero-test262-merged.json`
- `TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 bun scripts/run_test262_suite.ts --suite-dir /Users/jstein/.cache/goccia-test262-64ff467c --categories intl402 --filter 'intl402/DateTimeFormat/prototype/formatToParts/compare-to-temporal.js' --mode bytecode --jobs 1 --timeout-ms 20000 --output /tmp/goccia-pr947-compare-to-temporal-bytecode-mac-cache-invalidation.json --verbose`
- `orb -m goccia-ci-amd64 bash -lc 'cd /Users/jstein/.codex/worktrees/38c8/GocciaScript && ./build.pas loaderbare && time TEST262_SUITE_SHA=64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1 ~/.bun/bin/bun scripts/run_test262_suite.ts --suite-dir /Users/jstein/.cache/goccia-test262-64ff467c --categories intl402 --filter "intl402/DateTimeFormat/prototype/formatToParts/compare-to-temporal.js" --mode bytecode --jobs 1 --timeout-ms 20000 --output /tmp/goccia-pr947-compare-to-temporal-bytecode-linux-amd64-cache-invalidation.json --verbose'`

Final Math slice: 357/357 passed, 0 failed, 0 wrapper-infra.
Final Date TimeClip regression slice: 4/4 passed in bytecode and interpreted modes, 0 failed, 0 wrapper-infra.
Review Date `setTime` slice: 11/11 passed in bytecode mode, 0 failed, 0 wrapper-infra.
Final Intl/Temporal focused suites: Intl 277/277 passed in both modes; Temporal/ZonedDateTime 66/66 passed in both modes.
Final `compare-to-temporal.js` timeout slice: passed on macOS in 3.1s and on OrbStack Linux amd64 in 4.6s harness / 5.2s real.
