### PR TITLE
perf(vm): reduce dispatch loop overhead

### DIFF
--- a/source/units/Goccia.InstructionLimit.pas
+++ b/source/units/Goccia.InstructionLimit.pas
@@ -14,6 +14,7 @@ procedure StartInstructionLimit(const AMaxInstructions: Int64);
 procedure ClearInstructionLimit;
 procedure IncrementInstructionCounter; inline;
 procedure CheckInstructionLimit; inline;
+procedure PollInstructionLimit; inline;
 
 implementation
 
@@ -44,6 +45,17 @@ begin
   if (GMaxInstructions > 0) and (GInstructionCount >= GMaxInstructions) then
     raise TGocciaInstructionLimitError.CreateFmt(
       'Execution exceeded instruction limit of %d', [GMaxInstructions]);
+end;
+
+procedure PollInstructionLimit; inline;
+begin
+  if GMaxInstructions > 0 then
+  begin
+    if GInstructionCount >= GMaxInstructions then
+      raise TGocciaInstructionLimitError.CreateFmt(
+        'Execution exceeded instruction limit of %d', [GMaxInstructions]);
+    Inc(GInstructionCount);
+  end;
 end;
 
 end.

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -13233,41 +13233,42 @@ begin
     Running := True;
     while Running and (Frame.IP < Template.CodeCount) do
     begin
-      if (AStopAtIP >= 0) and (Frame.IP >= AStopAtIP) and
-         Assigned(AStopGenerator) then
-      begin
-        TGocciaBytecodeGeneratorObjectValue(AStopGenerator).
-          CaptureInitialContinuation(Frame, SavedHandlerCount, PrevCovLine,
-            Frame.IP);
-        Result := RegisterUndefined;
-        Exit;
-      end;
-
       try
-        CheckInstructionLimit;
-        Instruction := Template.GetInstructionUnchecked(Frame.IP);
-        Inc(Frame.IP);
-        IncrementInstructionCounter;
-
-        if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and
-           Assigned(Template.DebugInfo) then
+        while Running and (Frame.IP < Template.CodeCount) do
         begin
-          CovLine := Template.DebugInfo.GetLineForPC(Frame.IP - 1);
-          if (CovLine <> 0) and (CovLine <> PrevCovLine) then
+          if (AStopAtIP >= 0) and (Frame.IP >= AStopAtIP) and
+             Assigned(AStopGenerator) then
           begin
-            TGocciaCoverageTracker.Instance.RecordLineHit(
-              Template.DebugInfo.SourceFile, CovLine);
-            PrevCovLine := CovLine;
+            TGocciaBytecodeGeneratorObjectValue(AStopGenerator).
+              CaptureInitialContinuation(Frame, SavedHandlerCount, PrevCovLine,
+                Frame.IP);
+            Result := RegisterUndefined;
+            Exit;
           end;
-        end;
 
-        Op := DecodeOp(Instruction);
-        if FProfilingOpcodes then
-          TGocciaProfiler.Instance.RecordOpcode(Op);
-        A := DecodeA(Instruction);
-        B := DecodeB(Instruction);
-        C := DecodeC(Instruction);
-        case TGocciaOpCode(Op) of
+          PollInstructionLimit;
+          Instruction := Template.GetInstructionUnchecked(Frame.IP);
+          Inc(Frame.IP);
+
+          if FCoverageEnabled and Assigned(TGocciaCoverageTracker.Instance) and
+             Assigned(Template.DebugInfo) then
+          begin
+            CovLine := Template.DebugInfo.GetLineForPC(Frame.IP - 1);
+            if (CovLine <> 0) and (CovLine <> PrevCovLine) then
+            begin
+              TGocciaCoverageTracker.Instance.RecordLineHit(
+                Template.DebugInfo.SourceFile, CovLine);
+              PrevCovLine := CovLine;
+            end;
+          end;
+
+          Op := DecodeOp(Instruction);
+          if FProfilingOpcodes then
+            TGocciaProfiler.Instance.RecordOpcode(Op);
+          A := DecodeA(Instruction);
+          B := DecodeB(Instruction);
+          C := DecodeC(Instruction);
+          case TGocciaOpCode(Op) of
       OP_LOAD_CONST:
         // ES2026 §13.2.8.3: bckTemplateObject constants are lazily built and cached
         if Template.GetConstantUnchecked(DecodeBx(Instruction)).Kind = bckTemplateObject then
@@ -16506,6 +16507,7 @@ begin
       end;
         else
           raise Exception.CreateFmt('Unsupported Goccia VM opcode in minimal executor: %d', [Op]);
+        end;
         end;
       except
         on E: EGocciaBytecodeThrow do


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Reduce bytecode VM dispatch overhead by replacing the separate per-op instruction-limit check/counter calls with one inline `PollInstructionLimit` helper.
- Move the dispatch-loop exception guard out of the single-op body so the VM runs instructions until an exception needs `HandleExceptionUnwind`, preserving JS catch/finally behavior and bytecode compatibility.
- Non-goals: no opcode/compiler changes, no call ABI work, no property IC work, no arithmetic lowering, and no `.gbc` format/version change.
- No linked issue.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build/GocciaTestRunner tests --no-progress` — 11232/11232 passed
  - `./build/GocciaTestRunner tests --mode=bytecode --no-progress` — 11232/11232 passed
  - `bun scripts/test-cli.ts`
  - `bun scripts/test-cli-apps.ts`
- [ ] Updated documentation
  - Not applicable: no user-facing behavior, contributor workflow, or bytecode-format surface changed.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - Not applicable: no AST, scope, evaluator, or value-type semantics changed.
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - `./build.pas --clean --prod loader`
  - Updated-base AWFY interleaved baseline/candidate run, 5 reps, pinned AWFY SHA `74306fec151070fd07157cefeacf19e7e0bcdc89`
  - `loop-dispatch-floor`: candidate/baseline `0.758`, 24.2% faster
  - `generic-plus-scalars`: candidate/baseline `0.519`, 48.1% faster
  - `Sieve:50`: candidate/baseline `0.651`, 34.9% faster
  - focused geomean candidate/baseline `0.635`, 36.5% faster
  - local report: `/Users/jstein/.codex/worktrees/1d01/GocciaScript/tmp/awfy-validation-20260706-185809/awfy-focused.json`

Additional checks:

- `./build.pas testrunner benchmarkrunner loaderbare repl bundler sandboxrunner`
- `./format.pas --check`
- `git diff --check origin/main`