### PR TITLE
ci(awfy): compare PR AWFY against main

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,15 +58,17 @@ jobs:
       - name: Install FPC
         run: sudo apt-get update && sudo apt-get install fpc -qq > /dev/null
 
-      - name: Build benchmark runner (main base)
-        run: ./build.pas benchmarkrunner --prod
+      - name: Build benchmark runner and loader (main base)
+        run: ./build.pas --prod benchmarkrunner loader
 
-      - name: Upload main benchmark runner
+      - name: Upload main build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-main
           retention-days: 1
-          path: build/GocciaBenchmarkRunner
+          path: |
+            build/GocciaBenchmarkRunner
+            build/GocciaScriptLoader
 
   docs:
     runs-on: ubuntu-latest
@@ -362,9 +364,9 @@ jobs:
           path: profile-main/
 
   awfy-report:
-    needs: build
+    needs: [build, build-main]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash
@@ -389,8 +391,16 @@ jobs:
           name: build-pr
           path: build/
 
+      - name: Download main build
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: build-main
+          path: build-main/
+
       - name: Make binaries executable
-        run: chmod +x build/*
+        run: |
+          chmod +x build/*
+          chmod +x build-main/*
 
       - name: Read AWFY pin
         id: awfy-pin
@@ -418,6 +428,8 @@ jobs:
         run: |
           node scripts/awfy-ci-report.js \
             --awfy-dir awfy-suite/benchmarks/JavaScript \
+            --goccia-baseline build-main/GocciaScriptLoader \
+            --goccia-candidate build/GocciaScriptLoader \
             --output awfy-report.json
 
       - name: Upload AWFY report

--- a/docs/adr/0088-reject-broader-property-inline-caches.md
+++ b/docs/adr/0088-reject-broader-property-inline-caches.md
@@ -1,0 +1,81 @@
+# Reject broader property inline caches without AWFY transfer
+
+**Date:** 2026-07-06
+**Area:** `bytecode`, `performance`
+**Related:** [ADR 0065](0065-shape-lite-inline-cache-design.md), [ADR 0076](0076-same-runner-benchmark-comparison.md), [ADR 0081](0081-reject-value-caches-for-allocation-reduction.md), [ADR 0087](0087-awfy-cross-engine-benchmark-methodology.md)
+
+GocciaScript will not merge the July 2026 broader property-inline-cache spike
+for constant property access. The existing shape-lite own-property read cache
+remains in place, but the attempted expansion to broader read-side inline
+caches is rejected because it did not transfer from targeted probes to real
+AWFY rows. The project should not accept extra VM cache complexity when the best
+evidence is "same or slightly worse" on object-heavy programs.
+
+The investigated lane started from a real hotspot: targeted probes showed
+`propaccess-monomorphic`, `prop-polymorphic`, and `prop-megamorphic` far behind
+QuickJS, and object-heavy AWFY rows such as `Richards`, `DeltaBlue`, `Bounce`,
+and `Storage` were likely affected. The spike tested broader own-property
+read-side caching and a constant-key write cache while preserving ECMAScript
+semantics for accessors, proxies, deletion, prototype mutation, and descriptor
+changes.
+
+The combined implementation was unstable as a candidate. An initial interleaved
+10x AWFY run showed useful wins on `Richards`, `Bounce`, and `Storage`, but
+`DeltaBlue` regressed from 5.330 ms to 5.824 ms (**-9.27%**) with high
+coefficient of variation. A later 5x run still had `DeltaBlue` at **-1.87%**.
+A 30x rerun moved the combined patch positive on the selected rows, but with
+high variance on several rows, so the result was not strong enough to justify
+the broader cache shape by itself.
+
+Splitting the experiment identified the important boundary. The read-PIC-only
+variant produced a synthetic probe win on `prop-polymorphic`, but did not
+improve real AWFY rows:
+
+| Variant | Target | Baseline median | Candidate median | Result | Baseline CV | Candidate CV |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| read-PIC-only, 20x AWFY | `Richards` | 755.451 ms | 760.829 ms | **-0.71%** | 2.09% | 1.43% |
+| read-PIC-only, 20x AWFY | `DeltaBlue` | 3.421 ms | 3.453 ms | **-0.91%** | 9.03% | 9.47% |
+| read-PIC-only, 20x AWFY | `Bounce` | 16.164 ms | 16.086 ms | **+0.48%** | 2.19% | 1.68% |
+| read-PIC-only, 20x AWFY | `Storage` | 24.842 ms | 25.186 ms | **-1.38%** | 7.39% | 3.94% |
+| read-PIC-only, 20x probe | `propaccess-monomorphic` | 54.129 ms | 54.225 ms | **-0.18%** | 10.02% | 3.19% |
+| read-PIC-only, 20x probe | `prop-polymorphic` | 68.912 ms | 62.118 ms | **+9.86%** | 1.74% | 3.32% |
+| read-PIC-only, 20x probe | `prop-megamorphic` | 68.937 ms | 69.538 ms | **-0.87%** | 1.31% | 1.54% |
+| read-PIC-only, 20x probe | `method-call-fixed-arg` | 151.401 ms | 149.293 ms | **+1.39%** | 2.74% | 3.46% |
+
+That is the rejection reason: the read-side cache improved the synthetic
+polymorphic probe but was flat-to-negative on the AWFY programs it needed to
+help. This matches earlier rejected optimization lanes such as string interning
+and broad value caches: a local microbenchmark win is insufficient when the
+real workload result is neutral, negative, or too noisy for the complexity.
+
+A narrower write-IC-only split looked more promising, but it is not accepted by
+this ADR. It should be treated as a separate future candidate with its own
+implementation, semantic tests, and acceptance gate:
+
+| Variant | Target | Baseline median | Candidate median | Result | Baseline CV | Candidate CV |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| write-IC-only, 30x AWFY | `Richards` | 739.781 ms | 680.861 ms | **+7.96%** | 1.24% | 0.84% |
+| write-IC-only, 30x AWFY | `DeltaBlue` | 3.374 ms | 3.289 ms | **+2.52%** | 11.70% | 4.74% |
+| write-IC-only, 30x AWFY | `Bounce` | 16.056 ms | 15.189 ms | **+5.40%** | 3.25% | 3.05% |
+| write-IC-only, 30x AWFY | `Storage` | 24.792 ms | 24.025 ms | **+3.09%** | 2.14% | 2.28% |
+| write-IC-only, 20x probe | `propaccess-monomorphic` | 53.629 ms | 53.054 ms | **+1.07%** | 1.65% | 1.61% |
+| write-IC-only, 20x probe | `prop-polymorphic` | 68.291 ms | 68.490 ms | **-0.29%** | 13.39% | 1.53% |
+| write-IC-only, 20x probe | `prop-megamorphic` | 69.008 ms | 69.102 ms | **-0.14%** | 2.23% | 1.47% |
+| write-IC-only, 20x probe | `method-call-fixed-arg` | 149.220 ms | 149.153 ms | **+0.05%** | 1.35% | 1.13% |
+
+Future property-access optimization work should follow this rule:
+
+- split read ICs, write ICs, method-load cooperation, and computed-key caches
+  into independently measured patches;
+- require interleaved `--goccia-baseline` / `--goccia-candidate` AWFY runs, not
+  sequential batches;
+- require targeted probes to transfer to object-heavy AWFY rows before adding
+  VM cache state;
+- preserve the existing ECMAScript semantic exclusions for proxies, accessors,
+  private fields, descriptor changes, deletion, and prototype mutation;
+- treat probe-only wins as diagnostics, not merge criteria.
+
+The practical decision is to keep the existing monomorphic shape-lite read cache
+and reject the broader read-side PIC expansion until it shows real AWFY transfer.
+The write-only result can be reconsidered later, but only as a smaller,
+separately validated performance change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -97,3 +97,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0085 — Defer broad Annex B support before 1.0](0085-defer-annex-b-before-1-0.md)
 - [0086 — Parser errors for unsupported default syntax](0086-parser-errors-for-unsupported-default-syntax.md)
 - [0087 — AWFY cross-engine benchmark methodology](0087-awfy-cross-engine-benchmark-methodology.md)
+- [0088 — Reject broader property inline caches without AWFY transfer](0088-reject-broader-property-inline-caches.md)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -411,9 +411,10 @@ The normalized report records:
 
 Pull requests run an AWFY report lane from `.github/workflows/pr.yml`.
 The target set is recorded in `perf/awfy/manifest.json` under `ciReport`: all
-pinned AWFY benchmarks under the PR Goccia bytecode loader, the PR's `main`
-baseline loader, QuickJS, and the latest Node Current release resolved by
-`actions/setup-node` at workflow time, with five raw samples per engine.
+pinned AWFY benchmarks under the production-built PR Goccia bytecode loader, the
+production-built PR `main` baseline loader, QuickJS, and the latest Node Current
+release resolved by `actions/setup-node` at workflow time, with five raw samples
+per engine.
 Sampling is interleaved as target -> repetition -> engine, so every repetition
 runs the selected engines next to each other instead of collecting engine-sized
 batches. The workflow uploads the normalized JSON report and posts an

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -411,15 +411,16 @@ The normalized report records:
 
 Pull requests run an AWFY report lane from `.github/workflows/pr.yml`.
 The target set is recorded in `perf/awfy/manifest.json` under `ciReport`: all
-pinned AWFY benchmarks under Goccia bytecode, QuickJS, and the latest Node
-Current release resolved by `actions/setup-node` at workflow time, with five raw
-samples per engine. Sampling is interleaved as target -> repetition -> engine,
-so every repetition runs the selected engines next to each other instead of
-collecting engine-sized batches. The workflow uploads the normalized JSON report
-and posts an `AWFY Results` PR comment with medians; min/max/CV and raw samples
-stay in the `awfy-report` artifact. Diagnostic probes remain available through
-the same driver for focused engine work, but they are not mixed into the PR AWFY
-summary.
+pinned AWFY benchmarks under the PR Goccia bytecode loader, the PR's `main`
+baseline loader, QuickJS, and the latest Node Current release resolved by
+`actions/setup-node` at workflow time, with five raw samples per engine.
+Sampling is interleaved as target -> repetition -> engine, so every repetition
+runs the selected engines next to each other instead of collecting engine-sized
+batches. The workflow uploads the normalized JSON report and posts an
+`AWFY Results` PR comment with main/PR Goccia medians, the per-target PR-vs-main
+delta, and reference-engine medians; min/max/CV and raw samples stay in the
+`awfy-report` artifact. Diagnostic probes remain available through the same
+driver for focused engine work, but they are not mixed into the PR AWFY summary.
 
 AWFY rows with sub-0.5ms medians are useful for verifying that the benchmark
 runs consistently, but they are timer-floor sensitive. Before using one of those

--- a/scripts/awfy-ci-report.js
+++ b/scripts/awfy-ci-report.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const { spawnSync } = require('child_process');
+const { expandGocciaEngines } = require('./awfy-driver.js');
 
 const DEFAULT_MANIFEST = 'perf/awfy/manifest.json';
 const DEFAULT_OUTPUT = 'awfy-report.json';
@@ -79,18 +80,7 @@ function parsePositiveInteger(value, optionName) {
 
 function expectedEnginesForRun(options) {
   const requested = options.engines.split(',').map((engine) => engine.trim()).filter(Boolean);
-  const expected = [];
-
-  for (const engine of requested) {
-    if (engine === 'goccia' && (options.gocciaBaseline || options.gocciaCandidate)) {
-      if (options.gocciaBaseline) expected.push('goccia-baseline');
-      if (options.gocciaCandidate) expected.push('goccia-candidate');
-    } else {
-      expected.push(engine);
-    }
-  }
-
-  return expected;
+  return expandGocciaEngines(requested, options);
 }
 
 function reportConfig(manifest) {

--- a/scripts/awfy-ci-report.js
+++ b/scripts/awfy-ci-report.js
@@ -17,6 +17,10 @@ function usage() {
     '  --awfy-dir <path>    Path to are-we-fast-yet/benchmarks/JavaScript',
     '  --output <path>      Report path (default: awfy-report.json)',
     '  --engines <csv>      Engine order (default: goccia,qjs,node)',
+    '  --goccia-baseline <path>',
+    '                       Optional baseline Goccia binary, interleaved as goccia-baseline',
+    '  --goccia-candidate <path>',
+    '                       Optional candidate Goccia binary, interleaved as goccia-candidate',
     '  --timeout-ms <n>     Per-sample timeout (default: 300000)',
   ].join('\n');
 }
@@ -27,6 +31,8 @@ function parseArgs(argv) {
     awfyDir: '',
     output: DEFAULT_OUTPUT,
     engines: DEFAULT_ENGINES,
+    gocciaBaseline: '',
+    gocciaCandidate: '',
     timeoutMs: DEFAULT_TIMEOUT_MS,
   };
 
@@ -49,6 +55,10 @@ function parseArgs(argv) {
       options.output = nextValue();
     } else if (arg === '--engines' || arg.startsWith('--engines=')) {
       options.engines = nextValue();
+    } else if (arg === '--goccia-baseline' || arg.startsWith('--goccia-baseline=')) {
+      options.gocciaBaseline = nextValue();
+    } else if (arg === '--goccia-candidate' || arg.startsWith('--goccia-candidate=')) {
+      options.gocciaCandidate = nextValue();
     } else if (arg === '--timeout-ms' || arg.startsWith('--timeout-ms=')) {
       options.timeoutMs = parsePositiveInteger(nextValue(), '--timeout-ms');
     } else {
@@ -65,6 +75,22 @@ function parsePositiveInteger(value, optionName) {
     throw new Error(`${optionName} must be a positive integer, got ${value}`);
   }
   return parsed;
+}
+
+function expectedEnginesForRun(options) {
+  const requested = options.engines.split(',').map((engine) => engine.trim()).filter(Boolean);
+  const expected = [];
+
+  for (const engine of requested) {
+    if (engine === 'goccia' && (options.gocciaBaseline || options.gocciaCandidate)) {
+      if (options.gocciaBaseline) expected.push('goccia-baseline');
+      if (options.gocciaCandidate) expected.push('goccia-candidate');
+    } else {
+      expected.push(engine);
+    }
+  }
+
+  return expected;
 }
 
 function reportConfig(manifest) {
@@ -139,6 +165,8 @@ function runReport(options, manifest) {
   for (const probe of targetSpecs(config, 'probes')) {
     args.push('--probe', probe);
   }
+  if (options.gocciaBaseline) args.push('--goccia-baseline', options.gocciaBaseline);
+  if (options.gocciaCandidate) args.push('--goccia-candidate', options.gocciaCandidate);
   args.push(
     '--repetitions', String(repetitions),
     '--timeout-ms', String(options.timeoutMs),
@@ -152,7 +180,7 @@ function runReport(options, manifest) {
   }
 
   const report = JSON.parse(fs.readFileSync(options.output, 'utf8'));
-  const expectedEngines = options.engines.split(',').map((engine) => engine.trim()).filter(Boolean);
+  const expectedEngines = expectedEnginesForRun(options);
   validateReport(report, manifest, expectedEngines);
 }
 
@@ -179,6 +207,7 @@ if (require.main === module) {
 
 module.exports = {
   expectedEnginesForTarget,
+  expectedEnginesForRun,
   parseArgs,
   reportConfig,
   targetSpec,

--- a/scripts/awfy-comment.js
+++ b/scripts/awfy-comment.js
@@ -4,9 +4,12 @@ const fs = require('fs');
 
 const MARKER = '<!-- awfy-results -->';
 const LEGACY_MARKER = '<!-- awfy-smoke -->';
-const COMMENT_ENGINES = ['goccia', 'qjs', 'node'];
+const DEFAULT_COMMENT_ENGINES = ['goccia', 'qjs', 'node'];
+const COMPARISON_COMMENT_ENGINES = ['goccia-baseline', 'goccia-candidate', 'qjs', 'node'];
 const ENGINE_LABELS = {
   goccia: 'Goccia',
+  'goccia-baseline': 'Goccia main',
+  'goccia-candidate': 'Goccia PR',
   qjs: 'QuickJS',
   node: 'NodeJS',
 };
@@ -23,9 +26,24 @@ function plural(count, singular) {
   return `${count} ${singular}${count === 1 ? '' : 's'}`;
 }
 
-function targetStatus(target) {
+function reportHasGocciaComparison(report) {
+  const metadataEngines = report?.metadata?.engines || [];
+  if (metadataEngines.some((engine) => engine.name === 'goccia-baseline' || engine.name === 'goccia-candidate')) {
+    return true;
+  }
+  return (report?.targets || []).some((target) => {
+    const stats = target.summary?.engineStats || {};
+    return stats['goccia-baseline'] || stats['goccia-candidate'];
+  });
+}
+
+function commentEngines(report) {
+  return reportHasGocciaComparison(report) ? COMPARISON_COMMENT_ENGINES : DEFAULT_COMMENT_ENGINES;
+}
+
+function targetStatus(target, engines = DEFAULT_COMMENT_ENGINES) {
   const stats = target.summary?.engineStats || {};
-  const expectedEngines = target.kind === 'awfy' ? COMMENT_ENGINES : Object.keys(stats);
+  const expectedEngines = target.kind === 'awfy' ? engines : Object.keys(stats);
   const bad = [];
   for (const engine of expectedEngines) {
     const engineStats = stats[engine];
@@ -50,9 +68,9 @@ function targetStatus(target) {
   return 'pass';
 }
 
-function engineCells(target) {
+function engineCells(target, engines = DEFAULT_COMMENT_ENGINES) {
   const stats = target.summary?.engineStats || {};
-  return COMMENT_ENGINES.map((engine) => {
+  return engines.map((engine) => {
     const engineStats = stats[engine];
     if (!engineStats) return '-';
     if ((engineStats.ok || 0) === 0) return 'no ok sample';
@@ -82,7 +100,7 @@ function cleanEngineVersion(engine, version) {
 function engineLabels(report) {
   const labels = { ...ENGINE_LABELS };
   const metadata = report?.metadata?.engines || [];
-  for (const engine of COMMENT_ENGINES) {
+  for (const engine of Object.keys(ENGINE_LABELS)) {
     const version = cleanEngineVersion(
       engine,
       metadata.find((entry) => entry.name === engine)?.version,
@@ -92,14 +110,21 @@ function engineLabels(report) {
   return labels;
 }
 
-function buildGeomeanTable(geomean, labels = ENGINE_LABELS) {
+function deltaCell(target) {
+  const ratio = target.summary?.ratios?.['goccia-candidate_over_goccia-baseline'];
+  if (typeof ratio !== 'number' || !Number.isFinite(ratio) || ratio <= 0) return '-';
+  const delta = (1 - ratio) * 100;
+  return `${delta >= 0 ? '+' : ''}${delta.toFixed(2)}%`;
+}
+
+function buildGeomeanTable(geomean, labels = ENGINE_LABELS, engines = DEFAULT_COMMENT_ENGINES) {
   if (Object.keys(geomean).length === 0) return '';
 
   let body = '\n### Geomean Ratios\n\n';
-  body += `| Ratio (row / column) | ${labels.goccia} | ${labels.qjs} | ${labels.node} |\n`;
-  body += '|----------------------|--------|---------|------|\n';
-  for (const numerator of COMMENT_ENGINES) {
-    const cells = COMMENT_ENGINES.map((denominator) => ratioCell(geomean, numerator, denominator));
+  body += `| Ratio (row / column) | ${engines.map((engine) => labels[engine]).join(' | ')} |\n`;
+  body += `|----------------------|${engines.map(() => '--------').join('|')}|\n`;
+  for (const numerator of engines) {
+    const cells = engines.map((denominator) => ratioCell(geomean, numerator, denominator));
     body += `| ${ENGINE_LABELS[numerator]} | ${cells.join(' | ')} |\n`;
   }
   return body;
@@ -121,15 +146,23 @@ function reportSampleCount(report) {
 function buildAwfyReportComment(report) {
   let body = `${MARKER}\n## AWFY Results\n\n`;
   const labels = engineLabels(report);
+  const engines = commentEngines(report);
+  const hasComparison = reportHasGocciaComparison(report);
 
-  body += `| Target | Status | ${labels.goccia} | ${labels.qjs} | ${labels.node} |\n`;
-  body += '|--------|--------|--------|---------|------|\n';
+  body += `| Target | Status | ${engines.map((engine) => labels[engine]).join(' | ')}`;
+  if (hasComparison) body += ' | Δ PR vs main';
+  body += ' |\n';
+  body += `|--------|--------|${engines.map(() => '--------').join('|')}`;
+  if (hasComparison) body += '|-------------';
+  body += '|\n';
   for (const target of report.targets || []) {
-    const [goccia, qjs, node] = engineCells(target);
-    body += `| ${target.name} | ${targetStatus(target)} | ${goccia} | ${qjs} | ${node} |\n`;
+    const cells = engineCells(target, engines);
+    body += `| ${target.name} | ${targetStatus(target, engines)} | ${cells.join(' | ')}`;
+    if (hasComparison) body += ` | ${deltaCell(target)}`;
+    body += ' |\n';
   }
 
-  body += buildGeomeanTable(report.geomeanRatios || {}, labels);
+  body += buildGeomeanTable(report.geomeanRatios || {}, labels, engines);
 
   const awfyCount = (report.targets || []).filter((target) => target.kind === 'awfy').length;
   const probeCount = (report.targets || []).filter((target) => target.kind === 'probe').length;
@@ -139,6 +172,7 @@ function buildAwfyReportComment(report) {
   body += `\n<sub>${countParts.join(' plus ')}. `;
   if (sampleCount !== null) body += `Medians from ${plural(sampleCount, 'interleaved sample')} per engine; `;
   body += 'raw JSON includes min/max/CV and is attached as the `awfy-report` artifact. ';
+  if (hasComparison) body += 'Δ compares PR Goccia median against the same-runner main Goccia median. ';
   body += 'Rows below 0.5ms are timer-floor sensitive.</sub>\n';
   return body;
 }
@@ -181,6 +215,8 @@ module.exports = {
   buildAwfyReportComment,
   buildAwfySmokeComment: buildAwfyReportComment,
   cleanEngineVersion,
+  commentEngines,
+  deltaCell,
   engineLabels,
   LEGACY_MARKER,
   MARKER,

--- a/scripts/awfy-comment.js
+++ b/scripts/awfy-comment.js
@@ -110,22 +110,53 @@ function engineLabels(report) {
   return labels;
 }
 
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function formatDeltaPercent(delta) {
+  return `${delta >= 0 ? '+' : ''}${delta.toFixed(2)}%`;
+}
+
+function gocciaComparisonClassification(target) {
+  const stats = target.summary?.engineStats || {};
+  const baseline = stats['goccia-baseline'];
+  const candidate = stats['goccia-candidate'];
+  if (
+    !finiteNumber(baseline?.minMicros) ||
+    !finiteNumber(baseline?.maxMicros) ||
+    !finiteNumber(candidate?.minMicros) ||
+    !finiteNumber(candidate?.maxMicros)
+  ) {
+    return null;
+  }
+
+  if (candidate.maxMicros < baseline.minMicros) return 'improved';
+  if (candidate.minMicros > baseline.maxMicros) return 'regressed';
+  return 'unchanged';
+}
+
 function deltaCell(target) {
   const ratio = target.summary?.ratios?.['goccia-candidate_over_goccia-baseline'];
   if (typeof ratio !== 'number' || !Number.isFinite(ratio) || ratio <= 0) return '-';
   const delta = (1 - ratio) * 100;
-  return `${delta >= 0 ? '+' : ''}${delta.toFixed(2)}%`;
+  const formatted = formatDeltaPercent(delta);
+  const classification = gocciaComparisonClassification(target);
+  if (classification === 'improved') return `🟢 ${formatted}`;
+  if (classification === 'regressed') return `🔴 ${formatted}`;
+  if (classification === 'unchanged') return `~ overlap (${formatted})`;
+  return formatted;
 }
 
 function buildGeomeanTable(geomean, labels = ENGINE_LABELS, engines = DEFAULT_COMMENT_ENGINES) {
   if (Object.keys(geomean).length === 0) return '';
 
   let body = '\n### Geomean Ratios\n\n';
-  body += `| Ratio (row / column) | ${engines.map((engine) => labels[engine]).join(' | ')} |\n`;
+  body += `| Ratio (row / column) | ${engines.map((engine) => labels[engine] || ENGINE_LABELS[engine] || engine).join(' | ')} |\n`;
   body += `|----------------------|${engines.map(() => '--------').join('|')}|\n`;
   for (const numerator of engines) {
     const cells = engines.map((denominator) => ratioCell(geomean, numerator, denominator));
-    body += `| ${ENGINE_LABELS[numerator]} | ${cells.join(' | ')} |\n`;
+    body += `| ${labels[numerator] || ENGINE_LABELS[numerator] || numerator} | ${cells.join(' | ')} |\n`;
   }
   return body;
 }
@@ -172,7 +203,7 @@ function buildAwfyReportComment(report) {
   body += `\n<sub>${countParts.join(' plus ')}. `;
   if (sampleCount !== null) body += `Medians from ${plural(sampleCount, 'interleaved sample')} per engine; `;
   body += 'raw JSON includes min/max/CV and is attached as the `awfy-report` artifact. ';
-  if (hasComparison) body += 'Δ compares PR Goccia median against the same-runner main Goccia median. ';
+  if (hasComparison) body += 'Δ compares PR Goccia median against the same-runner main Goccia median; overlapping min/max ranges are treated as unchanged noise. ';
   body += 'Rows below 0.5ms are timer-floor sensitive.</sub>\n';
   return body;
 }

--- a/scripts/awfy-driver.js
+++ b/scripts/awfy-driver.js
@@ -297,14 +297,9 @@ function resolveEngines(options) {
     });
   };
 
-  for (const name of requested) {
+  for (const name of expandGocciaEngines(requested, options)) {
     if (name === 'goccia') {
-      if (options.gocciaBaseline || options.gocciaCandidate) {
-        if (options.gocciaBaseline) addGoccia('goccia-baseline', options.gocciaBaseline);
-        if (options.gocciaCandidate) addGoccia('goccia-candidate', options.gocciaCandidate);
-      } else {
-        addGoccia('goccia', options.goccia);
-      }
+      addGoccia('goccia', options.goccia);
     } else if (name === 'goccia-baseline') {
       if (!options.gocciaBaseline) throw new Error('--goccia-baseline is required for engine goccia-baseline');
       addGoccia('goccia-baseline', options.gocciaBaseline);
@@ -320,6 +315,19 @@ function resolveEngines(options) {
     }
   }
 
+  return engines;
+}
+
+function expandGocciaEngines(requested, options) {
+  const engines = [];
+  for (const name of requested) {
+    if (name === 'goccia' && (options.gocciaBaseline || options.gocciaCandidate)) {
+      if (options.gocciaBaseline) engines.push('goccia-baseline');
+      if (options.gocciaCandidate) engines.push('goccia-candidate');
+    } else {
+      engines.push(name);
+    }
+  }
   return engines;
 }
 
@@ -672,6 +680,7 @@ module.exports = {
   checksumAgreement,
   collectAwfyModules,
   coefficientOfVariation,
+  expandGocciaEngines,
   iqrFiltered,
   median,
   parseArgs,

--- a/scripts/test-awfy-driver.js
+++ b/scripts/test-awfy-driver.js
@@ -16,7 +16,12 @@ const {
   summarizeSamples,
 } = require('./awfy-driver.js');
 const { MARKER, buildAwfyReportComment, formatMicros } = require('./awfy-comment.js');
-const { reportConfig, targetSpecs, validateReport } = require('./awfy-ci-report.js');
+const {
+  expectedEnginesForRun,
+  reportConfig,
+  targetSpecs,
+  validateReport,
+} = require('./awfy-ci-report.js');
 
 let passed = 0;
 
@@ -241,6 +246,43 @@ console.log('awfy-driver: PR comment markdown...');
     geomeanRatios: {},
   });
   assert(missingEngineComment.includes('| NBody | engine issue: node | 1.00ms | 0.50ms | - |'), 'comment flags missing AWFY engine stats');
+
+  const comparisonComment = buildAwfyReportComment({
+    metadata: {
+      options: { repetitions: 5 },
+      engines: [
+        { name: 'goccia-baseline', version: '' },
+        { name: 'goccia-candidate', version: '' },
+        { name: 'qjs', version: 'QuickJS version 2026-06-04' },
+        { name: 'node', version: 'v26.4.0' },
+      ],
+    },
+    targets: [
+      {
+        name: 'NBody',
+        kind: 'awfy',
+        summary: {
+          checksumAgreement: { ok: true, checksums: ['verified'] },
+          engineStats: {
+            'goccia-baseline': { ok: 5, rawCount: 5, medianMicros: 1000 },
+            'goccia-candidate': { ok: 5, rawCount: 5, medianMicros: 900 },
+            qjs: { ok: 5, rawCount: 5, medianMicros: 500 },
+            node: { ok: 5, rawCount: 5, medianMicros: 250 },
+          },
+          ratios: {
+            'goccia-candidate_over_goccia-baseline': 0.9,
+          },
+        },
+      },
+    ],
+    geomeanRatios: {
+      'goccia-baseline_over_goccia-candidate': 1.111111111,
+      'goccia-candidate_over_goccia-baseline': 0.9,
+    },
+  });
+  assert(comparisonComment.includes('| Target | Status | Goccia main | Goccia PR | QuickJS 2026-06-04 | NodeJS v26.4.0 | Δ PR vs main |'), 'comparison comment shows main and PR Goccia columns');
+  assert(comparisonComment.includes('| NBody | pass | 1.00ms | 0.90ms | 0.50ms | 250.00µs | +10.00% |'), 'comparison comment renders per-target delta');
+  assert(comparisonComment.includes('Δ compares PR Goccia median against the same-runner main Goccia median'), 'comparison comment explains delta basis');
 }
 
 console.log('awfy-ci-report: manifest helpers...');
@@ -254,6 +296,15 @@ console.log('awfy-ci-report: manifest helpers...');
   };
   assertEqual(reportConfig(manifest).repetitions, 5, 'ci report config is preferred');
   assertEqual(targetSpecs(manifest.ciReport, 'benchmarks').join(','), 'NBody,CD:2', 'ci report target specs keep inner iterations');
+  assertEqual(
+    expectedEnginesForRun({
+      engines: 'goccia,qjs,node',
+      gocciaBaseline: 'main-loader',
+      gocciaCandidate: 'pr-loader',
+    }).join(','),
+    'goccia-baseline,goccia-candidate,qjs,node',
+    'ci report validation expands goccia into baseline/candidate engines',
+  );
 }
 
 console.log('awfy-ci-report: validation...');
@@ -275,6 +326,24 @@ console.log('awfy-ci-report: validation...');
     }],
   }, manifest, ['goccia', 'qjs', 'node']);
   assert(true, 'ci report validation accepts five clean samples');
+
+  validateReport({
+    metadata: { options: { repetitions: 5 } },
+    targets: [{
+      kind: 'awfy',
+      name: 'NBody',
+      summary: {
+        checksumAgreement: { ok: true, checksums: ['verified'] },
+        engineStats: {
+          'goccia-baseline': { ok: 5, rawCount: 5, medianMicros: 1000 },
+          'goccia-candidate': { ok: 5, rawCount: 5, medianMicros: 900 },
+          qjs: { ok: 5, rawCount: 5, medianMicros: 500 },
+          node: { ok: 5, rawCount: 5, medianMicros: 250 },
+        },
+      },
+    }],
+  }, manifest, ['goccia-baseline', 'goccia-candidate', 'qjs', 'node']);
+  assert(true, 'ci report validation accepts baseline/candidate Goccia samples');
 }
 
 console.log(`awfy-driver: ${passed} assertions passed.`);

--- a/scripts/test-awfy-driver.js
+++ b/scripts/test-awfy-driver.js
@@ -264,8 +264,24 @@ console.log('awfy-driver: PR comment markdown...');
         summary: {
           checksumAgreement: { ok: true, checksums: ['verified'] },
           engineStats: {
-            'goccia-baseline': { ok: 5, rawCount: 5, medianMicros: 1000 },
-            'goccia-candidate': { ok: 5, rawCount: 5, medianMicros: 900 },
+            'goccia-baseline': { ok: 5, rawCount: 5, medianMicros: 1000, minMicros: 990, maxMicros: 1010 },
+            'goccia-candidate': { ok: 5, rawCount: 5, medianMicros: 900, minMicros: 890, maxMicros: 910 },
+            qjs: { ok: 5, rawCount: 5, medianMicros: 500 },
+            node: { ok: 5, rawCount: 5, medianMicros: 250 },
+          },
+          ratios: {
+            'goccia-candidate_over_goccia-baseline': 0.9,
+          },
+        },
+      },
+      {
+        name: 'Noisy',
+        kind: 'awfy',
+        summary: {
+          checksumAgreement: { ok: true, checksums: ['verified'] },
+          engineStats: {
+            'goccia-baseline': { ok: 5, rawCount: 5, medianMicros: 1000, minMicros: 900, maxMicros: 1100 },
+            'goccia-candidate': { ok: 5, rawCount: 5, medianMicros: 900, minMicros: 850, maxMicros: 1050 },
             qjs: { ok: 5, rawCount: 5, medianMicros: 500 },
             node: { ok: 5, rawCount: 5, medianMicros: 250 },
           },
@@ -281,8 +297,13 @@ console.log('awfy-driver: PR comment markdown...');
     },
   });
   assert(comparisonComment.includes('| Target | Status | Goccia main | Goccia PR | QuickJS 2026-06-04 | NodeJS v26.4.0 | Δ PR vs main |'), 'comparison comment shows main and PR Goccia columns');
-  assert(comparisonComment.includes('| NBody | pass | 1.00ms | 0.90ms | 0.50ms | 250.00µs | +10.00% |'), 'comparison comment renders per-target delta');
-  assert(comparisonComment.includes('Δ compares PR Goccia median against the same-runner main Goccia median'), 'comparison comment explains delta basis');
+  assert(comparisonComment.includes('| NBody | pass | 1.00ms | 0.90ms | 0.50ms | 250.00µs | 🟢 +10.00% |'), 'comparison comment renders non-overlapping improvement delta');
+  assert(comparisonComment.includes('| Noisy | pass | 1.00ms | 0.90ms | 0.50ms | 250.00µs | ~ overlap (+10.00%) |'), 'comparison comment marks overlapping ranges as unchanged noise');
+  assert(comparisonComment.includes('| Goccia main | 1.000 | 1.111 | - | - |'), 'comparison geomean rows use main label');
+  assert(comparisonComment.includes('| Goccia PR | 0.900 | 1.000 | - | - |'), 'comparison geomean rows use PR label');
+  assert(comparisonComment.includes('| QuickJS 2026-06-04 | - | - | 1.000 | - |'), 'comparison geomean rows use versioned QuickJS label');
+  assert(comparisonComment.includes('| NodeJS v26.4.0 | - | - | - | 1.000 |'), 'comparison geomean rows use versioned Node label');
+  assert(comparisonComment.includes('Δ compares PR Goccia median against the same-runner main Goccia median; overlapping min/max ranges are treated as unchanged noise'), 'comparison comment explains delta basis and overlap classifier');
 }
 
 console.log('awfy-ci-report: manifest helpers...');


### PR DESCRIPTION
## Summary

- Add ADR 0088 documenting why the broader property inline cache spike is not being merged.
- Update the PR AWFY lane to build the PR's `main` baseline loader and run all pinned AWFY rows with `goccia-baseline` and `goccia-candidate` interleaved in the same driver run.
- Add `Goccia main`, `Goccia PR`, and per-target `Δ PR vs main` columns to the marked AWFY PR comment while preserving QuickJS and Node reference columns.
- Render PR-vs-main AWFY deltas with the benchmark-style min/max overlap buffer, use versioned labels consistently in geomean rows, and centralize Goccia baseline/candidate engine expansion.

Manual AWFY evidence posted to the PR comment:

- https://github.com/frostney/GocciaScript/pull/950#issuecomment-4897987325
- 14 pinned AWFY benchmarks, 5 interleaved samples per engine.
- Geomean PR-vs-main delta: `-0.27%` in this local run.
- After the overlap-buffer rendering fix, every per-row PR/main delta in that run is classified as `~ overlap (...)` noise rather than a significant improvement/regression.

## Testing

- [ ] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - N/A: no runtime semantics changed.
- [x] Updated documentation
  - `docs/adr/0088-reject-broader-property-inline-caches.md`
  - `docs/adr/README.md`
  - `docs/benchmarks.md`
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - N/A: no Pascal runtime code changed.
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Built production loaders for current `origin/main` and this PR branch.
  - Ran all configured AWFY rows with interleaved `goccia-baseline`, `goccia-candidate`, QuickJS, and Node samples.
  - Updated the AWFY PR comment with the noise-aware delta rendering from the saved full report.

Validation run:

- `./build.pas --clean --prod loader` in `/private/tmp/goccia-awfy-pr950/main-baseline`
- `./build.pas --clean --prod loader`
- `./build.pas --prod loader`
- `node scripts/test-awfy-driver.js`
- `node scripts/awfy-ci-report.js --awfy-dir /private/tmp/goccia-property-ic-evidence/perf-ic/are-we-fast-yet/benchmarks/JavaScript --goccia-baseline /private/tmp/goccia-awfy-pr950/main-baseline/build/GocciaScriptLoader --goccia-candidate build/GocciaScriptLoader --output /private/tmp/goccia-awfy-pr950/awfy-report.json`
- `node scripts/awfy-comment.js /private/tmp/goccia-awfy-pr950/awfy-report.json > /private/tmp/goccia-awfy-pr950/awfy-comment.md`
- `./format.pas --check`
- `git diff --check`
- `npx markdownlint-cli2 docs/benchmarks.md docs/adr/0088-reject-broader-property-inline-caches.md docs/adr/README.md`
- `npx tsx scripts/check-doc-symbols.ts`
- `npx tsx scripts/check-doc-length.ts`
- `npx tsx scripts/check-doc-links.ts`
- `npx tsx scripts/check-doc-duplication.ts`
