### PR TITLE
test(math): allow portable hyperbolic approximations

### DIFF
--- a/tests/built-ins/Math/hyperbolic.js
+++ b/tests/built-ins/Math/hyperbolic.js
@@ -36,9 +36,9 @@ describe("Math hyperbolic methods", () => {
   });
 
   test("inverse hyperbolic roundtrips stay within the expected double", () => {
-    expect(Math.asinh(Math.sinh(-0.25))).toBe(-0.25);
+    expect(Math.asinh(Math.sinh(-0.25))).toBeCloseTo(-0.25, 15);
 
     const loopValue = -0.24999999999999967;
-    expect(Math.atanh(Math.tanh(loopValue))).toBe(loopValue);
+    expect(Math.atanh(Math.tanh(loopValue))).toBeCloseTo(loopValue, 15);
   });
 });


### PR DESCRIPTION
## Summary

- Replace exact equality in the inverse hyperbolic round-trip regression with the existing 15-decimal floating-point matcher.
- Preserve the regression inputs while matching ECMA-262 sections 21.3.2.5, 21.3.2.7, 21.3.2.32, and 21.3.2.36, which define these results as implementation-approximated.
- Fix the current main CI failures on x86_64-win64 and i386-win32; both observed errors were within 1.4e-16 of the expected result.
- Documentation is unchanged because this is a test portability correction with no runtime behavior change.

## Testing

- [x] Verified no regressions and confirmed the bugfix in end-to-end JavaScript tests
  - `./build.pas --clean testrunner`
  - `./build/GocciaTestRunner tests/built-ins/Math --no-progress --silent`
  - `./build/GocciaTestRunner tests/built-ins/Math --mode=bytecode --no-progress --silent`
  - `./build/GocciaTestRunner tests --no-progress --silent`
  - `./build/GocciaTestRunner tests --mode=bytecode --no-progress --silent`
  - `./format.pas --check`
  - Full manually dispatched [`CI` run](https://github.com/frostney/GocciaScript/actions/runs/29055419008): both `test (x86_64-win64, windows-latest)` and `test (i386-win32, windows-latest)` passed 11,247/11,247 tests with 24,610 assertions in interpreted and bytecode modes
- [x] Updated documentation (not applicable: no user-facing or contributor-facing behavior changed)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change