### PR TITLE
feat(benchmarks): report percentile distributions

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -192,6 +192,7 @@ group("collections", () => {
 - `summary(fn)` creates a comparison scope. Its measured benchmarks are ordered by median invocation time and compared with the fastest member. The central ratio uses medians; the displayed range divides the competitor's p25/p75 by the fastest member's p75/p25. A range crossing `1.0x` is reported as inconclusive.
 - `boxplot(fn)` creates a visualization scope. Its measured benchmarks share an interquartile chart scale from the fastest observed sample through the slowest p99.
 - Nested `summary()` and `boxplot()` wrappers retain both memberships. Benchmarks outside a wrapper still receive percentile statistics and an individual interquartile bar, but do not participate in that scoped view.
+- Wrapper callbacks may be async; the wrapper waits for the returned promise before closing its reporting scope.
 - `run(opts?)` executes the currently registered benchmarks from script code. `GocciaBenchmarkRunner` also auto-runs registered benchmarks after loading a file, but a script-callable `run()` consumes the pending registry so the runner does not measure the same benchmarks twice.
 
 ### Data flow

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -5,7 +5,7 @@
 ## Executive Summary
 
 - **Module-only benchmark API** — Import `bench`, `group`, `run`, `summary`, and `boxplot` from `"goccia:microbench"`; no benchmark helpers are ambient globals
-- **Five output formats** — `console` (default), `text`, `csv`, `json`, `compact-json`; configurable via `--format` and `--output`
+- **Distribution-aware reports** — Five output formats report p75/p99/p999 and interquartile bars; scoped `boxplot()` and `summary()` wrappers add charts and uncertainty-aware comparisons, with reproducible statistics in structured output
 - **Profiler-backed runs** — Bytecode benchmark runs can emit opcode/function profiles with `--profile`, including deterministic single-run capture
 - **CI integration** — PR workflow posts benchmark comparison comments with range-overlap classification; main CI retains deterministic profile reports
 - **Environment tuning** — Calibration time, warmup iterations, and measurement rounds configurable via environment variables
@@ -53,10 +53,10 @@ The GocciaBenchmarkRunner supports five output formats via the `--format` option
 
 | Format | Description |
 |--------|-------------|
-| `console` (default) | Pretty-printed columnar output with group headers, variance, setup/teardown times, and summary |
-| `text` | Compact one-line-per-benchmark format with optional `setup=Xms teardown=Xms` suffixes |
-| `csv` | Standard CSV with header row (`file,suite,name,ops_per_sec,variance_percentage,mean_ms,iterations,setup_ms,teardown_ms,error`) |
-| `json` | Structured JSON with the common CLI envelope (`build`, aggregate `output`, `timing`, `memory`, `workers`) and a `files[]` array containing each `fileName`, per-file timing, and nested `benchmarks[]`, including `opsPerSec`, `variancePercentage`, `minOpsPerSec`, `maxOpsPerSec`, `setupMs`, and `teardownMs` |
+| `console` (default) | Pretty-printed output with group headers, throughput, variance, p75/p99/p999, per-benchmark interquartile bars, scoped boxplots, relative summaries, and setup/teardown times |
+| `text` | Compact one-line-per-benchmark output followed by any scoped boxplots and relative summaries |
+| `csv` | Scalar throughput and sample statistics, wrapper-scope identifiers, and derived relative-comparison fields |
+| `json` | Structured JSON with the common CLI envelope and per-benchmark throughput, sample statistics, wrapper scopes, and uncertainty-aware relative comparison data |
 | `compact-json` | Same structured JSON shape, omitting `build`, `memory`, `stdout`, and `stderr` for smaller machine-readable output |
 
 Use `--output=<file>` to write results to a file instead of stdout.
@@ -189,15 +189,17 @@ group("collections", () => {
 - The yielded function is the timed benchmark body.
 - Cleanup that must run during generator close belongs in a `finally` block around the `yield`.
 - Setup and teardown are independently timed and reported as `setupMs`, `teardownMs`, and the main `opsPerSec`/`meanMs` metrics.
-- `summary(fn)` and `boxplot(fn)` are accepted output-shaping wrappers. Rich percentile and chart rendering belongs to issue #855, so today they should be treated as registration wrappers rather than a promise of additional report fields.
+- `summary(fn)` creates a comparison scope. Its measured benchmarks are ordered by median invocation time and compared with the fastest member. The central ratio uses medians; the displayed range divides the competitor's p25/p75 by the fastest member's p75/p25. A range crossing `1.0x` is reported as inconclusive.
+- `boxplot(fn)` creates a visualization scope. Its measured benchmarks share an interquartile chart scale from the fastest observed sample through the slowest p99.
+- Nested `summary()` and `boxplot()` wrappers retain both memberships. Benchmarks outside a wrapper still receive percentile statistics and an individual interquartile bar, but do not participate in that scoped view.
 - `run(opts?)` executes the currently registered benchmarks from script code. `GocciaBenchmarkRunner` also auto-runs registered benchmarks after loading a file, but a script-callable `run()` consumes the pending registry so the runner does not measure the same benchmarks twice.
 
 ### Data flow
 
 ```text
-setup before yield → yielded run function → warmup/calibrate/measure → close generator
-        ↓                         ↓                                      ↓
-     setupMs             opsPerSec, meanMs, variance                 teardownMs
+setup before yield → yielded run function → warmup/calibrate → throughput rounds → bounded samples → close generator
+        ↓                         ↓                         ↓                  ↓                 ↓
+     setupMs                iterations          ops/sec, CV, range     percentiles       teardownMs
 ```
 
 ### Guidelines
@@ -222,6 +224,7 @@ The `GocciaBenchmarkRunner` program:
    - **Warmup:** Configurable iterations to stabilize (default 5). The yielded function or plain benchmark function is called for each iteration.
    - **Calibrate:** Scales batch size until it runs for at least the target calibration time (default 200ms). Uses nanosecond-resolution timing via `TimingUtils` (`clock_gettime(CLOCK_MONOTONIC)` on Unix/macOS, `QueryPerformanceCounter` on Windows).
    - **Measure:** Runs multiple measurement rounds (default 7). GC is disabled during measurement for identical behavior in both interpreter and bytecode modes. Between rounds, `CollectYoung` reclaims measurement garbage efficiently (pre-marks old objects, only traverses new allocations). After all rounds, IQR-based outlier filtering removes noise spikes before computing the coefficient of variation (CV%) and median values.
+   - **Sample:** Individually times at most 10,000 calibrated invocations. This separate pass leaves historical ops/sec and variance semantics unchanged and cannot add more invocations than calibration selected.
    - **Teardown:** Closes generator callbacks after measurement (timed), running `finally` cleanup when present.
 8. After each file completes, `GC.Collect` runs to reclaim memory between script executions.
 9. Collects all results into a `TBenchmarkReporter`, which renders the chosen output format.
@@ -243,8 +246,8 @@ The non-zero exit code ensures CI pipelines fail when benchmarks crash or produc
 | `bench(name, fn)` | Register a benchmark function. `fn` is called many times during measurement; generator callbacks use pre-yield setup, a yielded measured function, and `finally` cleanup on close. |
 | `group(name, fn)` | Group benchmarks (like `describe` in tests). Executes `fn` immediately. |
 | `run(opts?)` | Execute registered benchmarks from script code and return results. Calling `run()` prevents the runner's post-load auto-run from measuring the same registry again. |
-| `summary(fn)` | Accepted registration wrapper for summary-shaped output. Richer summary reporting is tracked in #855. |
-| `boxplot(fn)` | Accepted registration wrapper for boxplot-shaped output. Richer chart output is tracked in #855. |
+| `summary(fn)` | Register a comparison scope that reports median relative speed, a conservative interquartile ratio range, and inconclusive overlap. |
+| `boxplot(fn)` | Register a visualization scope whose benchmarks share an interquartile chart scale. |
 
 ## Available Benchmarks
 

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2241,7 +2241,10 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
         throw new Error(`Summary baseline should compare exactly to itself: ${JSON.stringify(baseline)}`);
       for (const benchmark of scopedBenchmarks) {
         if (benchmark === baseline) continue;
-        const expectedInconclusive = benchmark.relative.low <= 1 && benchmark.relative.high >= 1;
+        const { low, high } = benchmark.relative;
+        if (!Number.isFinite(low) || !Number.isFinite(high) || low > high)
+          throw new Error(`Summary relative bounds should be finite and ordered: ${JSON.stringify(benchmark)}`);
+        const expectedInconclusive = low <= 1 && high >= 1;
         if (benchmark.relative.inconclusive !== expectedInconclusive)
           throw new Error(`Summary overlap classification should match its range: ${JSON.stringify(benchmark)}`);
       }

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2165,25 +2165,31 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
 
     console.log("BenchmarkRunner: microbench API is module-only and accepts wrappers...");
     const moduleOnlyOut = join(tmp, "module-only.json");
-    {
-      const moduleOnlySource = microbenchModuleWithExports(
-        "bench as microBench, group as microGroup, summary, boxplot",
-        [
-          'if (typeof bench !== "undefined") throw new Error("ambient bench should not exist");',
-          'if (typeof group !== "undefined") throw new Error("ambient group should not exist");',
-          'if (typeof suite !== "undefined") throw new Error("ambient suite should not exist");',
-          'if (typeof runBenchmarks !== "undefined") throw new Error("ambient runBenchmarks should not exist");',
-          "summary(() => {",
-          "  boxplot(() => {",
-          '    microGroup("module-only", () => {',
-          '      microBench("sum", () => 1 + 1);',
-          "    });",
-          "  });",
-          "});",
-        ],
-      );
+    const moduleOnlyBytecodeOut = join(tmp, "module-only-bytecode.json");
+    const moduleOnlySource = microbenchModuleWithExports(
+      "bench as microBench, group as microGroup, summary, boxplot",
+      [
+        'if (typeof bench !== "undefined") throw new Error("ambient bench should not exist");',
+        'if (typeof group !== "undefined") throw new Error("ambient group should not exist");',
+        'if (typeof suite !== "undefined") throw new Error("ambient suite should not exist");',
+        'if (typeof runBenchmarks !== "undefined") throw new Error("ambient runBenchmarks should not exist");',
+        "summary(() => {",
+        "  boxplot(() => {",
+        '    microGroup("module-only", () => {',
+        '      microBench("sum", () => 1 + 1);',
+        '      microBench("array map", () => [1, 2, 3, 4].map((value) => value + 1));',
+        "    });",
+        "  });",
+        "});",
+        'microBench("outside wrappers", () => 2 + 2);',
+      ],
+    );
+    for (const run of [
+      { output: moduleOnlyOut, modeArguments: [] },
+      { output: moduleOnlyBytecodeOut, modeArguments: ["--mode=bytecode"] },
+    ]) {
       const proc = Bun.spawnSync(
-        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${moduleOnlyOut}`],
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${run.output}`, ...run.modeArguments],
         {
           stdin: new TextEncoder().encode(moduleOnlySource),
           stdout: "pipe",
@@ -2194,13 +2200,54 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
       );
       if (proc.exitCode !== 0) throw new Error(`Module-only microbench API exit ${proc.exitCode}: ${proc.stderr.toString()}`);
     }
-    {
-      const json = JSON.parse(readFileSync(moduleOnlyOut, "utf-8"));
+    for (const outputFile of [moduleOnlyOut, moduleOnlyBytecodeOut]) {
+      const json = JSON.parse(readFileSync(outputFile, "utf-8"));
       if (json.files?.[0]?.benchmarks?.[0]?.name !== "sum")
         throw new Error(`Module-only microbench JSON should contain benchmark name "sum", got: ${JSON.stringify(json.files?.[0]?.benchmarks)}`);
-      if (json.totalBenchmarks !== 1)
-        throw new Error(`Module-only microbench JSON should contain totalBenchmarks: 1, got ${json.totalBenchmarks}`);
+      if (json.totalBenchmarks !== 3)
+        throw new Error(`Module-only microbench JSON should contain totalBenchmarks: 3, got ${json.totalBenchmarks}`);
+      for (const benchmark of json.files[0].benchmarks) {
+        if (!(benchmark.sampleCount > 0 && benchmark.sampleCount <= benchmark.iterations && benchmark.sampleCount <= 10_000))
+          throw new Error(`Benchmark sampleCount should be bounded by calibrated iterations and the fixed cap: ${JSON.stringify(benchmark)}`);
+        if (!(benchmark.minSampleMs <= benchmark.p25Ms &&
+              benchmark.p25Ms <= benchmark.medianMs &&
+              benchmark.medianMs <= benchmark.p75Ms &&
+              benchmark.p75Ms <= benchmark.p99Ms &&
+              benchmark.p99Ms <= benchmark.p999Ms &&
+              benchmark.p999Ms <= benchmark.maxSampleMs))
+          throw new Error(`Benchmark percentiles should be ordered: ${JSON.stringify(benchmark)}`);
+        if (benchmark.name === "outside wrappers") {
+          if (benchmark.summaryScope !== null || benchmark.boxplotScope !== null || benchmark.relative !== null)
+            throw new Error(`Unwrapped benchmark should stay outside scoped views: ${JSON.stringify(benchmark)}`);
+        } else {
+          if (benchmark.summaryScope !== 1 || benchmark.boxplotScope !== 1)
+            throw new Error(`Benchmark wrapper scopes should be retained: ${JSON.stringify(benchmark)}`);
+          if (typeof benchmark.relative?.median !== "number" ||
+              typeof benchmark.relative?.low !== "number" ||
+              typeof benchmark.relative?.high !== "number" ||
+              typeof benchmark.relative?.inconclusive !== "boolean")
+            throw new Error(`Benchmark relative comparison should be structured: ${JSON.stringify(benchmark)}`);
+        }
+      }
+
     }
+
+    const consoleProc = Bun.spawnSync(
+      [resolve(BENCHRUNNER), "--source-type=module", "--no-progress"],
+      {
+        stdin: new TextEncoder().encode(moduleOnlySource),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: benchEnv,
+        timeout: 120_000,
+      },
+    );
+    if (consoleProc.exitCode !== 0)
+      throw new Error(`Module-only microbench console exit ${consoleProc.exitCode}: ${consoleProc.stderr.toString()}`);
+    const consoleOutput = consoleProc.stdout.toString();
+    for (const expected of ["p75", "p99", "p999", "boxplot", "summary", "fastest:"])
+      if (!consoleOutput.includes(expected))
+        throw new Error(`Module-only microbench console should contain ${expected}: ${consoleOutput}`);
 
     console.log("BenchmarkRunner: deterministic profile mode...");
     const profileBench = join(tmp, "profile-deterministic.js");

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2230,6 +2230,22 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
         }
       }
 
+      const scopedBenchmarks = json.files[0].benchmarks.filter(
+        (benchmark: Record<string, unknown>) => benchmark.summaryScope === 1,
+      );
+      const baseline = scopedBenchmarks.reduce(
+        (fastest: any, benchmark: any) => benchmark.medianMs < fastest.medianMs ? benchmark : fastest,
+      );
+      if (baseline.relative.median !== 1 || baseline.relative.low !== 1 ||
+          baseline.relative.high !== 1 || baseline.relative.inconclusive !== false)
+        throw new Error(`Summary baseline should compare exactly to itself: ${JSON.stringify(baseline)}`);
+      for (const benchmark of scopedBenchmarks) {
+        if (benchmark === baseline) continue;
+        const expectedInconclusive = benchmark.relative.low <= 1 && benchmark.relative.high >= 1;
+        if (benchmark.relative.inconclusive !== expectedInconclusive)
+          throw new Error(`Summary overlap classification should match its range: ${JSON.stringify(benchmark)}`);
+      }
+
     }
 
     const consoleProc = Bun.spawnSync(
@@ -2248,6 +2264,42 @@ console.log("TestRunner: --output=compact-json omits build, memory, stdout, stde
     for (const expected of ["p75", "p99", "p999", "boxplot", "summary", "fastest:"])
       if (!consoleOutput.includes(expected))
         throw new Error(`Module-only microbench console should contain ${expected}: ${consoleOutput}`);
+
+    console.log("BenchmarkRunner: async summary and boxplot callbacks retain scopes...");
+    const asyncScopeSource = microbenchModuleWithExports(
+      "bench, summary, boxplot",
+      [
+        "await boxplot(async () => {",
+        "  await Promise.resolve();",
+        "  await summary(async () => {",
+        "    await Promise.resolve();",
+        '    bench("async fast", () => 1 + 1);',
+        '    bench("async slow", () => [1, 2, 3, 4].map((value) => value + 1));',
+        "  });",
+        "});",
+      ],
+    );
+    for (const run of [
+      { output: join(tmp, "async-scopes.json"), modeArguments: [] },
+      { output: join(tmp, "async-scopes-bytecode.json"), modeArguments: ["--mode=bytecode"] },
+    ]) {
+      const proc = Bun.spawnSync(
+        [resolve(BENCHRUNNER), "--source-type=module", "--no-progress", "--format=json", `--output=${run.output}`, ...run.modeArguments],
+        {
+          stdin: new TextEncoder().encode(asyncScopeSource),
+          stdout: "pipe",
+          stderr: "pipe",
+          env: benchEnv,
+          timeout: 120_000,
+        },
+      );
+      if (proc.exitCode !== 0)
+        throw new Error(`Async microbench scopes exit ${proc.exitCode}: ${proc.stderr.toString()}`);
+      const benchmarks = JSON.parse(readFileSync(run.output, "utf-8")).files?.[0]?.benchmarks;
+      if (!Array.isArray(benchmarks) || benchmarks.length !== 2 ||
+          benchmarks.some((benchmark: any) => benchmark.summaryScope !== 1 || benchmark.boxplotScope !== 1))
+        throw new Error(`Async microbench callbacks should retain both scopes: ${JSON.stringify(benchmarks)}`);
+    }
 
     console.log("BenchmarkRunner: deterministic profile mode...");
     const profileBench = join(tmp, "profile-deterministic.js");

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -121,6 +121,8 @@ begin
 
         Entry.Suite := SingleResult.GetProperty('suite').ToStringLiteral.Value;
         Entry.Name := SingleResult.GetProperty(PROP_NAME).ToStringLiteral.Value;
+        Entry.SummaryScope := Round(SingleResult.GetProperty('summaryScope').ToNumberLiteral.Value);
+        Entry.BoxplotScope := Round(SingleResult.GetProperty('boxplotScope').ToNumberLiteral.Value);
 
         ErrorMsg := SingleResult.GetProperty('error').ToStringLiteral.Value;
         if ErrorMsg <> 'undefined' then
@@ -144,6 +146,14 @@ begin
           Entry.TeardownMs := SingleResult.GetProperty('teardownMs').ToNumberLiteral.Value;
           Entry.MinOpsPerSec := SingleResult.GetProperty('minOpsPerSec').ToNumberLiteral.Value;
           Entry.MaxOpsPerSec := SingleResult.GetProperty('maxOpsPerSec').ToNumberLiteral.Value;
+          Entry.SampleCount := Round(SingleResult.GetProperty('sampleCount').ToNumberLiteral.Value);
+          Entry.MinSampleMs := SingleResult.GetProperty('minSampleMs').ToNumberLiteral.Value;
+          Entry.P25Ms := SingleResult.GetProperty('p25Ms').ToNumberLiteral.Value;
+          Entry.MedianMs := SingleResult.GetProperty('medianMs').ToNumberLiteral.Value;
+          Entry.P75Ms := SingleResult.GetProperty('p75Ms').ToNumberLiteral.Value;
+          Entry.P99Ms := SingleResult.GetProperty('p99Ms').ToNumberLiteral.Value;
+          Entry.P999Ms := SingleResult.GetProperty('p999Ms').ToNumberLiteral.Value;
+          Entry.MaxSampleMs := SingleResult.GetProperty('maxSampleMs').ToNumberLiteral.Value;
         end;
 
         MutableFileResult.Entries[I] := Entry;

--- a/source/units/Goccia.Benchmark.Reporter.pas
+++ b/source/units/Goccia.Benchmark.Reporter.pas
@@ -201,8 +201,17 @@ begin
 end;
 
 procedure CalculateRelativeComparison(const AEntry, AFastest: TBenchmarkEntry;
-  out ARatio, ALowRatio, AHighRatio: Double; out AInconclusive: Boolean);
+  const AIsBaseline: Boolean; out ARatio, ALowRatio, AHighRatio: Double;
+  out AInconclusive: Boolean);
 begin
+  if AIsBaseline then
+  begin
+    ARatio := 1;
+    ALowRatio := 1;
+    AHighRatio := 1;
+    AInconclusive := False;
+    Exit;
+  end;
   ARatio := AEntry.MedianMs / AFastest.MedianMs;
   if (AFastest.P75Ms > 0) and (AFastest.P25Ms > 0) then
   begin
@@ -398,7 +407,7 @@ begin
         Continue;
 
       CalculateRelativeComparison(AFile.Entries[CandidateIndex],
-        AFile.Entries[FastestIndex], Ratio, LowRatio, HighRatio,
+        AFile.Entries[FastestIndex], False, Ratio, LowRatio, HighRatio,
         Inconclusive);
       if Inconclusive then
         FOutput.Add(SysUtils.Format(
@@ -630,10 +639,8 @@ begin
           if FastestIndex >= 0 then
           begin
             CalculateRelativeComparison(Entry,
-              FFiles[F].Entries[FastestIndex], Ratio, LowRatio, HighRatio,
-              Inconclusive);
-            if E = FastestIndex then
-              Inconclusive := False;
+              FFiles[F].Entries[FastestIndex], E = FastestIndex, Ratio,
+              LowRatio, HighRatio, Inconclusive);
             RelativeFields := SysUtils.Format('%.6f,%.6f,%.6f,%s',
               [Ratio, LowRatio, HighRatio,
                LowerCase(BoolToStr(Inconclusive, True))], CSVFormatSettings);
@@ -715,10 +722,8 @@ begin
         if FastestIndex >= 0 then
         begin
           CalculateRelativeComparison(Entry,
-            FFiles[F].Entries[FastestIndex], Ratio, LowRatio, HighRatio,
-            Inconclusive);
-          if E = FastestIndex then
-            Inconclusive := False;
+            FFiles[F].Entries[FastestIndex], E = FastestIndex, Ratio,
+            LowRatio, HighRatio, Inconclusive);
           RelativeJSON := SysUtils.Format(
             '{"median":%s,"low":%s,"high":%s,"inconclusive":%s}',
             [FormatJSONNumber(Ratio, JSONFormatSettings),

--- a/source/units/Goccia.Benchmark.Reporter.pas
+++ b/source/units/Goccia.Benchmark.Reporter.pas
@@ -21,6 +21,16 @@ type
     TeardownMs: Double;
     MinOpsPerSec: Double;
     MaxOpsPerSec: Double;
+    SampleCount: Integer;
+    MinSampleMs: Double;
+    P25Ms: Double;
+    MedianMs: Double;
+    P75Ms: Double;
+    P99Ms: Double;
+    P999Ms: Double;
+    MaxSampleMs: Double;
+    SummaryScope: Integer;
+    BoxplotScope: Integer;
     Error: string;
   end;
 
@@ -53,6 +63,8 @@ type
     procedure RenderText;
     procedure RenderCSV;
     procedure RenderJSON;
+    procedure RenderScopedViews(const AFile: TBenchmarkFileResult;
+      const AIndent: string);
 
     function GetFileResult(AIndex: Integer): TBenchmarkFileResult;
     function FormatOpsPerSec(const AOps: Double): string;
@@ -102,6 +114,107 @@ begin
   else
     Result := (AEntry.Error = '') and IsPositiveFinite(AEntry.OpsPerSec) and
       IsPositiveFinite(AEntry.MeanMs) and (AEntry.Iterations > 0);
+end;
+
+function FormatSampleTime(const AMilliseconds: Double): string;
+var
+  FormatSettings: TFormatSettings;
+begin
+  FormatSettings := DefaultFormatSettings;
+  FormatSettings.DecimalSeparator := '.';
+  if AMilliseconds < 0.001 then
+    Result := SysUtils.Format('%.2f ns', [AMilliseconds * 1000000],
+      FormatSettings)
+  else if AMilliseconds < 1 then
+    Result := SysUtils.Format('%.2f us', [AMilliseconds * 1000],
+      FormatSettings)
+  else
+    Result := SysUtils.Format('%.2f ms', [AMilliseconds], FormatSettings);
+end;
+
+function ScaleSample(const AValue, AMinimum, AMaximum: Double;
+  const AWidth: Integer): Integer;
+begin
+  if AMaximum <= AMinimum then
+    Exit(0);
+  Result := Round(((AValue - AMinimum) / (AMaximum - AMinimum)) *
+    (AWidth - 1));
+  if Result < 0 then
+    Result := 0
+  else if Result >= AWidth then
+    Result := AWidth - 1;
+end;
+
+function BuildInterquartileBar(const AEntry: TBenchmarkEntry;
+  const AMinimum, AMaximum: Double): string;
+const
+  BAR_WIDTH = 24;
+var
+  I, MinimumOffset, P25Offset, MedianOffset, P75Offset,
+    P99Offset: Integer;
+begin
+  Result := StringOfChar(' ', BAR_WIDTH);
+  MinimumOffset := ScaleSample(AEntry.MinSampleMs, AMinimum, AMaximum,
+    BAR_WIDTH) + 1;
+  P25Offset := ScaleSample(AEntry.P25Ms, AMinimum, AMaximum, BAR_WIDTH) + 1;
+  MedianOffset := ScaleSample(AEntry.MedianMs, AMinimum, AMaximum,
+    BAR_WIDTH) + 1;
+  P75Offset := ScaleSample(AEntry.P75Ms, AMinimum, AMaximum, BAR_WIDTH) + 1;
+  P99Offset := ScaleSample(AEntry.P99Ms, AMinimum, AMaximum, BAR_WIDTH) + 1;
+
+  for I := MinimumOffset to P99Offset do
+    Result[I] := '-';
+  for I := P25Offset to P75Offset do
+    Result[I] := '=';
+  Result[MinimumOffset] := '|';
+  Result[P99Offset] := '|';
+  if P25Offset = P75Offset then
+    Result[P25Offset] := '|'
+  else
+  begin
+    Result[P25Offset] := '[';
+    Result[P75Offset] := ']';
+    Result[MedianOffset] := '|';
+  end;
+end;
+
+function BenchmarkDisplayName(const AEntry: TBenchmarkEntry): string;
+begin
+  if AEntry.Suite = '' then
+    Result := AEntry.Name
+  else
+    Result := AEntry.Suite + ' > ' + AEntry.Name;
+end;
+
+function FindFastestSummaryEntry(const AFile: TBenchmarkFileResult;
+  const AScope: Integer): Integer;
+var
+  I: Integer;
+begin
+  Result := -1;
+  for I := 0 to Length(AFile.Entries) - 1 do
+    if (AFile.Entries[I].SummaryScope = AScope) and
+      (AFile.Entries[I].Error = '') and (AFile.Entries[I].MedianMs > 0) and
+      ((Result < 0) or
+       (AFile.Entries[I].MedianMs < AFile.Entries[Result].MedianMs)) then
+      Result := I;
+end;
+
+procedure CalculateRelativeComparison(const AEntry, AFastest: TBenchmarkEntry;
+  out ARatio, ALowRatio, AHighRatio: Double; out AInconclusive: Boolean);
+begin
+  ARatio := AEntry.MedianMs / AFastest.MedianMs;
+  if (AFastest.P75Ms > 0) and (AFastest.P25Ms > 0) then
+  begin
+    ALowRatio := AEntry.P25Ms / AFastest.P75Ms;
+    AHighRatio := AEntry.P75Ms / AFastest.P25Ms;
+  end
+  else
+  begin
+    ALowRatio := ARatio;
+    AHighRatio := ARatio;
+  end;
+  AInconclusive := (ALowRatio <= 1) and (AHighRatio >= 1);
 end;
 
 function FormatJSONNumber(const AValue: Double;
@@ -195,6 +308,112 @@ begin
   Result := TGocciaCSVStringifier.EscapeField(S, ',');
 end;
 
+procedure TBenchmarkReporter.RenderScopedViews(
+  const AFile: TBenchmarkFileResult; const AIndent: string);
+var
+  Scope, MaximumBoxplotScope, MaximumSummaryScope, I, Count, Rank,
+    CandidateIndex, FastestIndex: Integer;
+  MinimumSample, MaximumSample, Ratio, LowRatio, HighRatio: Double;
+  Inconclusive: Boolean;
+  Printed: array of Boolean;
+begin
+  MaximumBoxplotScope := 0;
+  MaximumSummaryScope := 0;
+  for I := 0 to Length(AFile.Entries) - 1 do
+  begin
+    if AFile.Entries[I].BoxplotScope > MaximumBoxplotScope then
+      MaximumBoxplotScope := AFile.Entries[I].BoxplotScope;
+    if AFile.Entries[I].SummaryScope > MaximumSummaryScope then
+      MaximumSummaryScope := AFile.Entries[I].SummaryScope;
+  end;
+
+  for Scope := 1 to MaximumBoxplotScope do
+  begin
+    Count := 0;
+    MinimumSample := MaxDouble;
+    MaximumSample := 0;
+    for I := 0 to Length(AFile.Entries) - 1 do
+      if (AFile.Entries[I].BoxplotScope = Scope) and
+        (AFile.Entries[I].Error = '') and
+        (AFile.Entries[I].SampleCount > 0) then
+      begin
+        Inc(Count);
+        if AFile.Entries[I].MinSampleMs < MinimumSample then
+          MinimumSample := AFile.Entries[I].MinSampleMs;
+        if AFile.Entries[I].P99Ms > MaximumSample then
+          MaximumSample := AFile.Entries[I].P99Ms;
+      end;
+    if Count = 0 then
+      Continue;
+
+    FOutput.Add('');
+    FOutput.Add(AIndent + 'boxplot');
+    for I := 0 to Length(AFile.Entries) - 1 do
+      if (AFile.Entries[I].BoxplotScope = Scope) and
+        (AFile.Entries[I].Error = '') and
+        (AFile.Entries[I].SampleCount > 0) then
+        FOutput.Add(SysUtils.Format('%s  %-30s %s',
+          [AIndent, BenchmarkDisplayName(AFile.Entries[I]),
+           BuildInterquartileBar(AFile.Entries[I], MinimumSample,
+             MaximumSample)]));
+    FOutput.Add(SysUtils.Format('%s  %s .. %s (p99)',
+      [AIndent, FormatSampleTime(MinimumSample),
+       FormatSampleTime(MaximumSample)]));
+  end;
+
+  for Scope := 1 to MaximumSummaryScope do
+  begin
+    Count := 0;
+    for I := 0 to Length(AFile.Entries) - 1 do
+      if (AFile.Entries[I].SummaryScope = Scope) and
+        (AFile.Entries[I].Error = '') and
+        (AFile.Entries[I].SampleCount > 0) then
+        Inc(Count);
+    if Count < 2 then
+      Continue;
+
+    FastestIndex := FindFastestSummaryEntry(AFile, Scope);
+    if FastestIndex < 0 then
+      Continue;
+    SetLength(Printed, Length(AFile.Entries));
+    FOutput.Add('');
+    FOutput.Add(AIndent + 'summary');
+    FOutput.Add(AIndent + '  fastest: ' +
+      BenchmarkDisplayName(AFile.Entries[FastestIndex]));
+    for Rank := 0 to Count - 1 do
+    begin
+      CandidateIndex := -1;
+      for I := 0 to Length(AFile.Entries) - 1 do
+        if not Printed[I] and (AFile.Entries[I].SummaryScope = Scope) and
+          (AFile.Entries[I].Error = '') and
+          (AFile.Entries[I].SampleCount > 0) and
+          ((CandidateIndex < 0) or
+           (AFile.Entries[I].MedianMs <
+            AFile.Entries[CandidateIndex].MedianMs)) then
+          CandidateIndex := I;
+      if CandidateIndex < 0 then
+        Break;
+      Printed[CandidateIndex] := True;
+      if CandidateIndex = FastestIndex then
+        Continue;
+
+      CalculateRelativeComparison(AFile.Entries[CandidateIndex],
+        AFile.Entries[FastestIndex], Ratio, LowRatio, HighRatio,
+        Inconclusive);
+      if Inconclusive then
+        FOutput.Add(SysUtils.Format(
+          '%s  %6.2fx median (%.2fx..%.2fx IQR; inconclusive)  %s',
+          [AIndent, Ratio, LowRatio, HighRatio,
+           BenchmarkDisplayName(AFile.Entries[CandidateIndex])]))
+      else
+        FOutput.Add(SysUtils.Format(
+          '%s  %6.2fx faster (%.2fx..%.2fx IQR)        %s',
+          [AIndent, Ratio, LowRatio, HighRatio,
+           BenchmarkDisplayName(AFile.Entries[CandidateIndex])]));
+    end;
+  end;
+end;
+
 procedure TBenchmarkReporter.Render(const AFormat: TBenchmarkReportFormat);
 begin
   FOutput.Clear;
@@ -261,6 +480,17 @@ begin
         FOutput.Add(SysUtils.Format('    %-30s  range: %s .. %s ops/sec',
           ['', FormatOpsPerSec(Entry.MinOpsPerSec), FormatOpsPerSec(Entry.MaxOpsPerSec)]));
 
+      if (Entry.Error = '') and (Entry.SampleCount > 0) then
+      begin
+        FOutput.Add(SysUtils.Format(
+          '    %-30s  p75 %9s  p99 %9s  p999 %9s  (%d samples)',
+          ['', FormatSampleTime(Entry.P75Ms), FormatSampleTime(Entry.P99Ms),
+           FormatSampleTime(Entry.P999Ms), Entry.SampleCount]));
+        FOutput.Add(SysUtils.Format('    %-30s  %s',
+          ['', BuildInterquartileBar(Entry, Entry.MinSampleMs,
+            Entry.P99Ms)]));
+      end;
+
       HasSetupTeardown := (Entry.SetupMs > 0) or (Entry.TeardownMs > 0);
       if HasSetupTeardown and (Entry.Error = '') then
       begin
@@ -272,6 +502,8 @@ begin
           FOutput.Add(SysUtils.Format('    %-30s  teardown: %.4fms', ['', Entry.TeardownMs]));
       end;
     end;
+
+    RenderScopedViews(FFiles[F], '  ');
 
     TotalBenchmarks := TotalBenchmarks + FFiles[F].TotalBenchmarks;
     TotalDurationNanoseconds := TotalDurationNanoseconds + FFiles[F].DurationNanoseconds;
@@ -326,10 +558,18 @@ begin
           Line := Line + SysUtils.Format(' setup=%.4fms', [Entry.SetupMs]);
         if Entry.TeardownMs > 0 then
           Line := Line + SysUtils.Format(' teardown=%.4fms', [Entry.TeardownMs]);
+        if Entry.SampleCount > 0 then
+          Line := Line + SysUtils.Format(
+            ' p75=%s p99=%s p999=%s samples=%d %s',
+            [FormatSampleTime(Entry.P75Ms), FormatSampleTime(Entry.P99Ms),
+             FormatSampleTime(Entry.P999Ms), Entry.SampleCount,
+             BuildInterquartileBar(Entry, Entry.MinSampleMs, Entry.P99Ms)]);
 
         FOutput.Add(Line);
       end;
     end;
+
+    RenderScopedViews(FFiles[F], '');
 
     TotalBenchmarks := TotalBenchmarks + FFiles[F].TotalBenchmarks;
     TotalDurationNanoseconds := TotalDurationNanoseconds + FFiles[F].DurationNanoseconds;
@@ -345,10 +585,20 @@ end;
 
 procedure TBenchmarkReporter.RenderCSV;
 var
-  F, E: Integer;
+  F, E, FastestIndex: Integer;
   Entry: TBenchmarkEntry;
+  SummaryScope, BoxplotScope, RelativeFields: string;
+  Ratio, LowRatio, HighRatio: Double;
+  Inconclusive: Boolean;
+  CSVFormatSettings: TFormatSettings;
 begin
-  FOutput.Add('file,suite,name,ops_per_sec,variance_percentage,mean_ms,iterations,setup_ms,teardown_ms,min_ops_per_sec,max_ops_per_sec,error');
+  CSVFormatSettings := DefaultFormatSettings;
+  CSVFormatSettings.DecimalSeparator := '.';
+  FOutput.Add('file,suite,name,ops_per_sec,variance_percentage,mean_ms,' +
+    'iterations,setup_ms,teardown_ms,min_ops_per_sec,max_ops_per_sec,' +
+    'sample_count,min_sample_ms,p25_ms,median_ms,p75_ms,p99_ms,p999_ms,' +
+    'max_sample_ms,summary_scope,boxplot_scope,relative_median,' +
+    'relative_low,relative_high,relative_inconclusive,error');
 
   for F := 0 to FFileCount - 1 do
   begin
@@ -356,23 +606,57 @@ begin
     begin
       Entry := FFiles[F].Entries[E];
 
-      if Entry.Error <> '' then
-        FOutput.Add(SysUtils.Format('%s,%s,%s,,,,,,,,,%s',
-          [EscapeCSVField(FFiles[F].FileName), EscapeCSVField(Entry.Suite),
-           EscapeCSVField(Entry.Name), EscapeCSVField(Entry.Error)]))
+      if Entry.SummaryScope > 0 then
+        SummaryScope := IntToStr(Entry.SummaryScope)
       else
-        FOutput.Add(SysUtils.Format('%s,%s,%s,%.6f,%.4f,%.6f,%d,%.6f,%.6f,%.6f,%.6f,',
+        SummaryScope := '';
+      if Entry.BoxplotScope > 0 then
+        BoxplotScope := IntToStr(Entry.BoxplotScope)
+      else
+        BoxplotScope := '';
+
+      if Entry.Error <> '' then
+        FOutput.Add(EscapeCSVField(FFiles[F].FileName) + ',' +
+          EscapeCSVField(Entry.Suite) + ',' + EscapeCSVField(Entry.Name) +
+          StringOfChar(',', 17) + SummaryScope + ',' + BoxplotScope +
+          StringOfChar(',', 5) + EscapeCSVField(Entry.Error))
+      else
+      begin
+        RelativeFields := ',,,';
+        if Entry.SummaryScope > 0 then
+        begin
+          FastestIndex := FindFastestSummaryEntry(FFiles[F],
+            Entry.SummaryScope);
+          if FastestIndex >= 0 then
+          begin
+            CalculateRelativeComparison(Entry,
+              FFiles[F].Entries[FastestIndex], Ratio, LowRatio, HighRatio,
+              Inconclusive);
+            if E = FastestIndex then
+              Inconclusive := False;
+            RelativeFields := SysUtils.Format('%.6f,%.6f,%.6f,%s',
+              [Ratio, LowRatio, HighRatio,
+               LowerCase(BoolToStr(Inconclusive, True))], CSVFormatSettings);
+          end;
+        end;
+        FOutput.Add(SysUtils.Format(
+          '%s,%s,%s,%.6f,%.4f,%.6f,%d,%.6f,%.6f,%.6f,%.6f,' +
+          '%d,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%s,%s,%s,',
           [EscapeCSVField(FFiles[F].FileName), EscapeCSVField(Entry.Suite),
            EscapeCSVField(Entry.Name), Entry.OpsPerSec, Entry.VariancePercentage,
            Entry.MeanMs, Entry.Iterations, Entry.SetupMs, Entry.TeardownMs,
-           Entry.MinOpsPerSec, Entry.MaxOpsPerSec]));
+           Entry.MinOpsPerSec, Entry.MaxOpsPerSec, Entry.SampleCount,
+           Entry.MinSampleMs, Entry.P25Ms, Entry.MedianMs, Entry.P75Ms,
+           Entry.P99Ms, Entry.P999Ms, Entry.MaxSampleMs, SummaryScope,
+           BoxplotScope, RelativeFields], CSVFormatSettings));
+      end;
     end;
   end;
 end;
 
 procedure TBenchmarkReporter.RenderJSON;
 var
-  F, E: Integer;
+  F, E, FastestIndex: Integer;
   Entry: TBenchmarkEntry;
   TotalBenchmarks: Integer;
   TotalDurationNanoseconds: Int64;
@@ -383,7 +667,10 @@ var
   FileOk: Boolean;
   ValidFileBenchmarkCount: Integer;
   FilesJSON, FileJSON, BenchmarksJSON, BenchmarkJSON, ExtraJSON: string;
-  FileErrorJSON, FileErrorMessage: string;
+  FileErrorJSON, FileErrorMessage, SummaryScopeJSON, BoxplotScopeJSON,
+    RelativeJSON: string;
+  Ratio, LowRatio, HighRatio: Double;
+  Inconclusive: Boolean;
 begin
   TotalBenchmarks := 0;
   TotalDurationNanoseconds := 0;
@@ -412,6 +699,35 @@ begin
     begin
       Entry := FFiles[F].Entries[E];
 
+      if Entry.SummaryScope > 0 then
+        SummaryScopeJSON := IntToStr(Entry.SummaryScope)
+      else
+        SummaryScopeJSON := 'null';
+      if Entry.BoxplotScope > 0 then
+        BoxplotScopeJSON := IntToStr(Entry.BoxplotScope)
+      else
+        BoxplotScopeJSON := 'null';
+      RelativeJSON := 'null';
+      if (Entry.Error = '') and (Entry.SummaryScope > 0) then
+      begin
+        FastestIndex := FindFastestSummaryEntry(FFiles[F],
+          Entry.SummaryScope);
+        if FastestIndex >= 0 then
+        begin
+          CalculateRelativeComparison(Entry,
+            FFiles[F].Entries[FastestIndex], Ratio, LowRatio, HighRatio,
+            Inconclusive);
+          if E = FastestIndex then
+            Inconclusive := False;
+          RelativeJSON := SysUtils.Format(
+            '{"median":%s,"low":%s,"high":%s,"inconclusive":%s}',
+            [FormatJSONNumber(Ratio, JSONFormatSettings),
+             FormatJSONNumber(LowRatio, JSONFormatSettings),
+             FormatJSONNumber(HighRatio, JSONFormatSettings),
+             LowerCase(BoolToStr(Inconclusive, True))]);
+        end;
+      end;
+
       if IsValidBenchmarkEntry(Entry, FFiles[F].DeterministicProfile) then
         Inc(ValidFileBenchmarkCount)
       else if FileOk then
@@ -428,8 +744,10 @@ begin
       if Entry.Error <> '' then
       begin
         BenchmarkJSON := SysUtils.Format(
-          '{"suite":"%s","name":"%s","error":"%s"}',
+          '{"suite":"%s","name":"%s","summaryScope":%s,' +
+          '"boxplotScope":%s,"error":"%s"}',
           [EscapeJSONString(Entry.Suite), EscapeJSONString(Entry.Name),
+           SummaryScopeJSON, BoxplotScopeJSON,
            EscapeJSONString(Entry.Error)])
       end
       else
@@ -437,7 +755,10 @@ begin
           '{"suite":"%s","name":"%s","opsPerSec":%s,' +
           '"variancePercentage":%s,"meanMs":%s,"iterations":%d,' +
           '"setupMs":%s,"teardownMs":%s,"minOpsPerSec":%s,' +
-          '"maxOpsPerSec":%s}',
+          '"maxOpsPerSec":%s,"sampleCount":%d,"minSampleMs":%s,' +
+          '"p25Ms":%s,"medianMs":%s,"p75Ms":%s,"p99Ms":%s,' +
+          '"p999Ms":%s,"maxSampleMs":%s,"summaryScope":%s,' +
+          '"boxplotScope":%s,"relative":%s}',
           [EscapeJSONString(Entry.Suite), EscapeJSONString(Entry.Name),
            FormatJSONNumber(Entry.OpsPerSec, JSONFormatSettings),
            FormatJSONPercentage(Entry.VariancePercentage, JSONFormatSettings),
@@ -445,7 +766,16 @@ begin
            FormatJSONNumber(Entry.SetupMs, JSONFormatSettings),
            FormatJSONNumber(Entry.TeardownMs, JSONFormatSettings),
            FormatJSONNumber(Entry.MinOpsPerSec, JSONFormatSettings),
-           FormatJSONNumber(Entry.MaxOpsPerSec, JSONFormatSettings)]);
+           FormatJSONNumber(Entry.MaxOpsPerSec, JSONFormatSettings),
+           Entry.SampleCount,
+           FormatJSONNumber(Entry.MinSampleMs, JSONFormatSettings),
+           FormatJSONNumber(Entry.P25Ms, JSONFormatSettings),
+           FormatJSONNumber(Entry.MedianMs, JSONFormatSettings),
+           FormatJSONNumber(Entry.P75Ms, JSONFormatSettings),
+           FormatJSONNumber(Entry.P99Ms, JSONFormatSettings),
+           FormatJSONNumber(Entry.P999Ms, JSONFormatSettings),
+           FormatJSONNumber(Entry.MaxSampleMs, JSONFormatSettings),
+           SummaryScopeJSON, BoxplotScopeJSON, RelativeJSON]);
 
       if BenchmarksJSON <> '' then
         BenchmarksJSON := BenchmarksJSON + ',';

--- a/source/units/Goccia.Benchmark.Reporter.pas
+++ b/source/units/Goccia.Benchmark.Reporter.pas
@@ -68,7 +68,6 @@ type
 
     function GetFileResult(AIndex: Integer): TBenchmarkFileResult;
     function FormatOpsPerSec(const AOps: Double): string;
-    function EscapeCSVField(const S: string): string;
   public
     constructor Create;
     destructor Destroy; override;
@@ -99,6 +98,36 @@ uses
 
   Goccia.CSV,
   Goccia.JSON.Utils;
+
+type
+  TBenchmarkCSVField = (bcfFile, bcfSuite, bcfName, bcfOpsPerSec,
+    bcfVariancePercentage, bcfMeanMs, bcfIterations, bcfSetupMs,
+    bcfTeardownMs, bcfMinOpsPerSec, bcfMaxOpsPerSec, bcfSampleCount,
+    bcfMinSampleMs, bcfP25Ms, bcfMedianMs, bcfP75Ms, bcfP99Ms, bcfP999Ms,
+    bcfMaxSampleMs, bcfSummaryScope, bcfBoxplotScope, bcfRelativeMedian,
+    bcfRelativeLow, bcfRelativeHigh, bcfRelativeInconclusive, bcfError);
+  TBenchmarkCSVFields = array[TBenchmarkCSVField] of string;
+
+const
+  BENCHMARK_CSV_HEADER: TBenchmarkCSVFields = ('file', 'suite', 'name',
+    'ops_per_sec', 'variance_percentage', 'mean_ms', 'iterations', 'setup_ms',
+    'teardown_ms', 'min_ops_per_sec', 'max_ops_per_sec', 'sample_count',
+    'min_sample_ms', 'p25_ms', 'median_ms', 'p75_ms', 'p99_ms', 'p999_ms',
+    'max_sample_ms', 'summary_scope', 'boxplot_scope', 'relative_median',
+    'relative_low', 'relative_high', 'relative_inconclusive', 'error');
+
+function JoinCSVFields(const AFields: TBenchmarkCSVFields): string;
+var
+  Field: TBenchmarkCSVField;
+begin
+  Result := '';
+  for Field := Low(TBenchmarkCSVField) to High(TBenchmarkCSVField) do
+  begin
+    if Field <> Low(TBenchmarkCSVField) then
+      Result := Result + ',';
+    Result := Result + TGocciaCSVStringifier.EscapeField(AFields[Field], ',');
+  end;
+end;
 
 function IsPositiveFinite(const AValue: Double): Boolean;
 begin
@@ -310,11 +339,6 @@ begin
       Result := Result + ',';
     Result := Result + S[I];
   end;
-end;
-
-function TBenchmarkReporter.EscapeCSVField(const S: string): string;
-begin
-  Result := TGocciaCSVStringifier.EscapeField(S, ',');
 end;
 
 procedure TBenchmarkReporter.RenderScopedViews(
@@ -596,18 +620,15 @@ procedure TBenchmarkReporter.RenderCSV;
 var
   F, E, FastestIndex: Integer;
   Entry: TBenchmarkEntry;
-  SummaryScope, BoxplotScope, RelativeFields: string;
+  Field: TBenchmarkCSVField;
+  Fields: TBenchmarkCSVFields;
   Ratio, LowRatio, HighRatio: Double;
   Inconclusive: Boolean;
   CSVFormatSettings: TFormatSettings;
 begin
   CSVFormatSettings := DefaultFormatSettings;
   CSVFormatSettings.DecimalSeparator := '.';
-  FOutput.Add('file,suite,name,ops_per_sec,variance_percentage,mean_ms,' +
-    'iterations,setup_ms,teardown_ms,min_ops_per_sec,max_ops_per_sec,' +
-    'sample_count,min_sample_ms,p25_ms,median_ms,p75_ms,p99_ms,p999_ms,' +
-    'max_sample_ms,summary_scope,boxplot_scope,relative_median,' +
-    'relative_low,relative_high,relative_inconclusive,error');
+  FOutput.Add(JoinCSVFields(BENCHMARK_CSV_HEADER));
 
   for F := 0 to FFileCount - 1 do
   begin
@@ -615,23 +636,50 @@ begin
     begin
       Entry := FFiles[F].Entries[E];
 
+      for Field := Low(TBenchmarkCSVField) to High(TBenchmarkCSVField) do
+        Fields[Field] := '';
+      Fields[bcfFile] := FFiles[F].FileName;
+      Fields[bcfSuite] := Entry.Suite;
+      Fields[bcfName] := Entry.Name;
       if Entry.SummaryScope > 0 then
-        SummaryScope := IntToStr(Entry.SummaryScope)
-      else
-        SummaryScope := '';
+        Fields[bcfSummaryScope] := IntToStr(Entry.SummaryScope);
       if Entry.BoxplotScope > 0 then
-        BoxplotScope := IntToStr(Entry.BoxplotScope)
-      else
-        BoxplotScope := '';
+        Fields[bcfBoxplotScope] := IntToStr(Entry.BoxplotScope);
 
       if Entry.Error <> '' then
-        FOutput.Add(EscapeCSVField(FFiles[F].FileName) + ',' +
-          EscapeCSVField(Entry.Suite) + ',' + EscapeCSVField(Entry.Name) +
-          StringOfChar(',', 17) + SummaryScope + ',' + BoxplotScope +
-          StringOfChar(',', 5) + EscapeCSVField(Entry.Error))
+        Fields[bcfError] := Entry.Error
       else
       begin
-        RelativeFields := ',,,';
+        Fields[bcfOpsPerSec] := SysUtils.Format('%.6f', [Entry.OpsPerSec],
+          CSVFormatSettings);
+        Fields[bcfVariancePercentage] := SysUtils.Format('%.4f',
+          [Entry.VariancePercentage], CSVFormatSettings);
+        Fields[bcfMeanMs] := SysUtils.Format('%.6f', [Entry.MeanMs],
+          CSVFormatSettings);
+        Fields[bcfIterations] := IntToStr(Entry.Iterations);
+        Fields[bcfSetupMs] := SysUtils.Format('%.6f', [Entry.SetupMs],
+          CSVFormatSettings);
+        Fields[bcfTeardownMs] := SysUtils.Format('%.6f', [Entry.TeardownMs],
+          CSVFormatSettings);
+        Fields[bcfMinOpsPerSec] := SysUtils.Format('%.6f',
+          [Entry.MinOpsPerSec], CSVFormatSettings);
+        Fields[bcfMaxOpsPerSec] := SysUtils.Format('%.6f',
+          [Entry.MaxOpsPerSec], CSVFormatSettings);
+        Fields[bcfSampleCount] := IntToStr(Entry.SampleCount);
+        Fields[bcfMinSampleMs] := SysUtils.Format('%.6f',
+          [Entry.MinSampleMs], CSVFormatSettings);
+        Fields[bcfP25Ms] := SysUtils.Format('%.6f', [Entry.P25Ms],
+          CSVFormatSettings);
+        Fields[bcfMedianMs] := SysUtils.Format('%.6f', [Entry.MedianMs],
+          CSVFormatSettings);
+        Fields[bcfP75Ms] := SysUtils.Format('%.6f', [Entry.P75Ms],
+          CSVFormatSettings);
+        Fields[bcfP99Ms] := SysUtils.Format('%.6f', [Entry.P99Ms],
+          CSVFormatSettings);
+        Fields[bcfP999Ms] := SysUtils.Format('%.6f', [Entry.P999Ms],
+          CSVFormatSettings);
+        Fields[bcfMaxSampleMs] := SysUtils.Format('%.6f',
+          [Entry.MaxSampleMs], CSVFormatSettings);
         if Entry.SummaryScope > 0 then
         begin
           FastestIndex := FindFastestSummaryEntry(FFiles[F],
@@ -641,22 +689,18 @@ begin
             CalculateRelativeComparison(Entry,
               FFiles[F].Entries[FastestIndex], E = FastestIndex, Ratio,
               LowRatio, HighRatio, Inconclusive);
-            RelativeFields := SysUtils.Format('%.6f,%.6f,%.6f,%s',
-              [Ratio, LowRatio, HighRatio,
-               LowerCase(BoolToStr(Inconclusive, True))], CSVFormatSettings);
+            Fields[bcfRelativeMedian] := SysUtils.Format('%.6f', [Ratio],
+              CSVFormatSettings);
+            Fields[bcfRelativeLow] := SysUtils.Format('%.6f', [LowRatio],
+              CSVFormatSettings);
+            Fields[bcfRelativeHigh] := SysUtils.Format('%.6f', [HighRatio],
+              CSVFormatSettings);
+            Fields[bcfRelativeInconclusive] := LowerCase(
+              BoolToStr(Inconclusive, True));
           end;
         end;
-        FOutput.Add(SysUtils.Format(
-          '%s,%s,%s,%.6f,%.4f,%.6f,%d,%.6f,%.6f,%.6f,%.6f,' +
-          '%d,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%s,%s,%s,',
-          [EscapeCSVField(FFiles[F].FileName), EscapeCSVField(Entry.Suite),
-           EscapeCSVField(Entry.Name), Entry.OpsPerSec, Entry.VariancePercentage,
-           Entry.MeanMs, Entry.Iterations, Entry.SetupMs, Entry.TeardownMs,
-           Entry.MinOpsPerSec, Entry.MaxOpsPerSec, Entry.SampleCount,
-           Entry.MinSampleMs, Entry.P25Ms, Entry.MedianMs, Entry.P75Ms,
-           Entry.P99Ms, Entry.P999Ms, Entry.MaxSampleMs, SummaryScope,
-           BoxplotScope, RelativeFields], CSVFormatSettings));
       end;
+      FOutput.Add(JoinCSVFields(Fields));
     end;
   end;
 end;

--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -188,17 +188,11 @@ begin
   if MEASUREMENT_ROUNDS < 1 then MEASUREMENT_ROUNDS := 1;
 end;
 
-function InvokeBenchmarkFunction(const AFunction: TGocciaFunctionBase;
-  const ASetupResult: TGocciaValue;
-  const ARunArgs: TGocciaArgumentsCollection): TGocciaValue;
+function AwaitBenchmarkResult(const AValue: TGocciaValue): TGocciaValue;
 var
   ThenMethod: TGocciaValue;
 begin
-  ARunArgs.Clear;
-  if Assigned(ASetupResult) then
-    ARunArgs.Add(ASetupResult);
-  Result := AFunction.CallPreparedArgs(ARunArgs,
-    TGocciaUndefinedLiteralValue.UndefinedValue);
+  Result := AValue;
   if Result is TGocciaPromiseValue then
     Result := AwaitValue(Result)
   else if Result is TGocciaObjectValue then
@@ -208,6 +202,17 @@ begin
        ThenMethod.IsCallable then
       Result := AwaitValue(Result);
   end;
+end;
+
+function InvokeBenchmarkFunction(const AFunction: TGocciaFunctionBase;
+  const ASetupResult: TGocciaValue;
+  const ARunArgs: TGocciaArgumentsCollection): TGocciaValue;
+begin
+  ARunArgs.Clear;
+  if Assigned(ASetupResult) then
+    ARunArgs.Add(ASetupResult);
+  Result := AwaitBenchmarkResult(AFunction.CallPreparedArgs(ARunArgs,
+    TGocciaUndefinedLiteralValue.UndefinedValue));
 end;
 
 function BenchmarkExceptionMessage(const AException: Exception): string;
@@ -485,13 +490,16 @@ function TGocciaBenchmark.ExecuteWrapper(
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   WrapperFunction: TGocciaFunctionBase;
+  WrapperResult: TGocciaValue;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if (AArgs.Length < 1) or not (AArgs.GetElement(0) is TGocciaFunctionBase) then
     ThrowTypeError('benchmark wrapper requires a callback function');
 
   WrapperFunction := TGocciaFunctionBase(AArgs.GetElement(0));
-  WrapperFunction.CallNoArgs(TGocciaUndefinedLiteralValue.UndefinedValue);
+  WrapperResult := WrapperFunction.CallNoArgs(
+    TGocciaUndefinedLiteralValue.UndefinedValue);
+  AwaitBenchmarkResult(WrapperResult);
 end;
 
 function TGocciaBenchmark.ExecuteScopedWrapper(
@@ -639,6 +647,33 @@ begin
     end;
     A[J + 1] := Temp;
   end;
+end;
+
+procedure QuickSortDoubles(var AValues: array of Double;
+  const ALow, AHigh: Integer);
+var
+  LowIndex, HighIndex: Integer;
+  Pivot, TemporaryValue: Double;
+begin
+  LowIndex := ALow;
+  HighIndex := AHigh;
+  Pivot := AValues[(ALow + AHigh) div 2];
+  repeat
+    while AValues[LowIndex] < Pivot do Inc(LowIndex);
+    while AValues[HighIndex] > Pivot do Dec(HighIndex);
+    if LowIndex <= HighIndex then
+    begin
+      TemporaryValue := AValues[LowIndex];
+      AValues[LowIndex] := AValues[HighIndex];
+      AValues[HighIndex] := TemporaryValue;
+      Inc(LowIndex);
+      Dec(HighIndex);
+    end;
+  until LowIndex > HighIndex;
+  if ALow < HighIndex then
+    QuickSortDoubles(AValues, ALow, HighIndex);
+  if LowIndex < AHigh then
+    QuickSortDoubles(AValues, LowIndex, AHigh);
 end;
 
 function PercentileValue(const ASorted: array of Double;
@@ -875,7 +910,8 @@ begin
         SampleDurations[K] := SampleDuration;
       end;
       WaitForFetchIdle;
-      InsertionSort(SampleDurations, SampleCount);
+      if SampleCount > 1 then
+        QuickSortDoubles(SampleDurations, 0, SampleCount - 1);
       Result.SampleCount := SampleCount;
       Result.MinSampleMs := PercentileValue(SampleDurations, SampleCount, 0);
       Result.P25Ms := PercentileValue(SampleDurations, SampleCount, 0.25);

--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -33,12 +33,15 @@ type
   public
     Name: string;
     SuiteName: string;
+    SummaryScope: Integer;
+    BoxplotScope: Integer;
     RunFunction: TGocciaFunctionBase;
     GeneratorFunction: TGocciaFunctionBase;
     OwnsRunRoot: Boolean;
     OwnsGeneratorRoot: Boolean;
     constructor Create(const AName: string; const ARunFunction: TGocciaFunctionBase;
-      const ASuiteName: string; const AGeneratorFunction: TGocciaFunctionBase = nil);
+      const ASuiteName: string; const ASummaryScope, ABoxplotScope: Integer;
+      const AGeneratorFunction: TGocciaFunctionBase = nil);
   end;
 
   TBenchmarkResult = record
@@ -53,6 +56,16 @@ type
     TeardownMs: Double;
     MinOpsPerSec: Double;
     MaxOpsPerSec: Double;
+    SampleCount: Integer;
+    MinSampleMs: Double;
+    P25Ms: Double;
+    MedianMs: Double;
+    P75Ms: Double;
+    P99Ms: Double;
+    P999Ms: Double;
+    MaxSampleMs: Double;
+    SummaryScope: Integer;
+    BoxplotScope: Integer;
   end;
 
   TGocciaBenchmark = class(TGocciaBuiltin)
@@ -60,6 +73,10 @@ type
     FRegisteredSuites: TStringList;
     FRegisteredBenchmarks: TObjectList<TBenchmarkCase>;
     FCurrentSuiteName: string;
+    FCurrentSummaryScope: Integer;
+    FCurrentBoxplotScope: Integer;
+    FNextSummaryScope: Integer;
+    FNextBoxplotScope: Integer;
     FNamespaceObject: TGocciaObjectValue;
     FOwnsNamespaceRoot: Boolean;
     FHasCompletedRun: Boolean;
@@ -76,6 +93,9 @@ type
       out AGeneratorIterator: TGocciaIteratorValue): TGocciaFunctionBase;
     function ExecuteWrapper(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
+    function ExecuteScopedWrapper(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue; var ACurrentScope,
+      ANextScope: Integer): TGocciaValue;
     function IsGeneratorBenchmarkFunction(const AFunction: TGocciaFunctionBase): Boolean;
     procedure StoreLastRunResult(const AResult: TGocciaObjectValue;
       const AMode: TBenchmarkRunMode);
@@ -132,6 +152,7 @@ const
   DEFAULT_CALIBRATION_BATCH = 5;
   DEFAULT_MEASUREMENT_ROUNDS = 7;
   MAX_MEASUREMENT_ROUNDS = 50;
+  MAX_PERCENTILE_SAMPLES = 10000;
   IQR_MULTIPLIER = 1.5;
 
 var
@@ -200,16 +221,54 @@ begin
   Result := AException.Message;
 end;
 
+procedure AssignBenchmarkScopeProperties(const AObject: TGocciaObjectValue;
+  const ASummaryScope, ABoxplotScope: Integer);
+begin
+  AObject.AssignProperty('summaryScope',
+    TGocciaNumberLiteralValue.Create(ASummaryScope));
+  AObject.AssignProperty('boxplotScope',
+    TGocciaNumberLiteralValue.Create(ABoxplotScope));
+end;
+
+procedure AssignBenchmarkResultProperties(const AObject: TGocciaObjectValue;
+  const AResult: TBenchmarkResult);
+begin
+  AObject.AssignProperty('name', TGocciaStringLiteralValue.Create(AResult.Name));
+  AObject.AssignProperty('suite', TGocciaStringLiteralValue.Create(AResult.SuiteName));
+  AObject.AssignProperty('opsPerSec', TGocciaNumberLiteralValue.Create(AResult.OpsPerSec));
+  AObject.AssignProperty('meanMs', TGocciaNumberLiteralValue.Create(AResult.MeanMs));
+  AObject.AssignProperty('iterations', TGocciaNumberLiteralValue.Create(AResult.Iterations));
+  AObject.AssignProperty('totalMs', TGocciaNumberLiteralValue.Create(AResult.TotalMs));
+  AObject.AssignProperty('variancePercentage', TGocciaNumberLiteralValue.Create(AResult.VariancePercentage));
+  AObject.AssignProperty('setupMs', TGocciaNumberLiteralValue.Create(AResult.SetupMs));
+  AObject.AssignProperty('teardownMs', TGocciaNumberLiteralValue.Create(AResult.TeardownMs));
+  AObject.AssignProperty('minOpsPerSec', TGocciaNumberLiteralValue.Create(AResult.MinOpsPerSec));
+  AObject.AssignProperty('maxOpsPerSec', TGocciaNumberLiteralValue.Create(AResult.MaxOpsPerSec));
+  AObject.AssignProperty('sampleCount', TGocciaNumberLiteralValue.Create(AResult.SampleCount));
+  AObject.AssignProperty('minSampleMs', TGocciaNumberLiteralValue.Create(AResult.MinSampleMs));
+  AObject.AssignProperty('p25Ms', TGocciaNumberLiteralValue.Create(AResult.P25Ms));
+  AObject.AssignProperty('medianMs', TGocciaNumberLiteralValue.Create(AResult.MedianMs));
+  AObject.AssignProperty('p75Ms', TGocciaNumberLiteralValue.Create(AResult.P75Ms));
+  AObject.AssignProperty('p99Ms', TGocciaNumberLiteralValue.Create(AResult.P99Ms));
+  AObject.AssignProperty('p999Ms', TGocciaNumberLiteralValue.Create(AResult.P999Ms));
+  AObject.AssignProperty('maxSampleMs', TGocciaNumberLiteralValue.Create(AResult.MaxSampleMs));
+  AssignBenchmarkScopeProperties(AObject, AResult.SummaryScope,
+    AResult.BoxplotScope);
+end;
+
 { TBenchmarkCase }
 
 constructor TBenchmarkCase.Create(const AName: string;
   const ARunFunction: TGocciaFunctionBase; const ASuiteName: string;
+  const ASummaryScope, ABoxplotScope: Integer;
   const AGeneratorFunction: TGocciaFunctionBase);
 begin
   inherited Create;
   Name := AName;
   RunFunction := ARunFunction;
   SuiteName := ASuiteName;
+  SummaryScope := ASummaryScope;
+  BoxplotScope := ABoxplotScope;
   GeneratorFunction := AGeneratorFunction;
   OwnsRunRoot := False;
   OwnsGeneratorRoot := False;
@@ -224,6 +283,10 @@ begin
   FRegisteredSuites := TStringList.Create;
   FRegisteredBenchmarks := TObjectList<TBenchmarkCase>.Create;
   FCurrentSuiteName := '';
+  FCurrentSummaryScope := 0;
+  FCurrentBoxplotScope := 0;
+  FNextSummaryScope := 0;
+  FNextBoxplotScope := 0;
   FNamespaceObject := CreateNamespaceObject;
   FOwnsNamespaceRoot := False;
   FHasCompletedRun := False;
@@ -335,6 +398,10 @@ begin
   FRegisteredBenchmarks.Clear;
   FRegisteredSuites.Clear;
   FCurrentSuiteName := '';
+  FCurrentSummaryScope := 0;
+  FCurrentBoxplotScope := 0;
+  FNextSummaryScope := 0;
+  FNextBoxplotScope := 0;
 end;
 
 function TGocciaBenchmark.IsGeneratorBenchmarkFunction(
@@ -427,16 +494,35 @@ begin
   WrapperFunction.CallNoArgs(TGocciaUndefinedLiteralValue.UndefinedValue);
 end;
 
+function TGocciaBenchmark.ExecuteScopedWrapper(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue; var ACurrentScope,
+  ANextScope: Integer): TGocciaValue;
+var
+  PreviousScope: Integer;
+begin
+  PreviousScope := ACurrentScope;
+  Inc(ANextScope);
+  ACurrentScope := ANextScope;
+  try
+    Result := ExecuteWrapper(AArgs, AThisValue);
+  finally
+    ACurrentScope := PreviousScope;
+  end;
+end;
+
 function TGocciaBenchmark.Summary(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := ExecuteWrapper(AArgs, AThisValue);
+  Result := ExecuteScopedWrapper(AArgs, AThisValue, FCurrentSummaryScope,
+    FNextSummaryScope);
 end;
 
 function TGocciaBenchmark.Boxplot(const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  Result := ExecuteWrapper(AArgs, AThisValue);
+  Result := ExecuteScopedWrapper(AArgs, AThisValue, FCurrentBoxplotScope,
+    FNextBoxplotScope);
 end;
 
 function TGocciaBenchmark.Run(const AArgs: TGocciaArgumentsCollection;
@@ -474,7 +560,8 @@ begin
     GeneratorFn := nil;
   end;
 
-  BenchCase := TBenchmarkCase.Create(BenchName, RunFn, FCurrentSuiteName, GeneratorFn);
+  BenchCase := TBenchmarkCase.Create(BenchName, RunFn, FCurrentSuiteName,
+    FCurrentSummaryScope, FCurrentBoxplotScope, GeneratorFn);
   if Assigned(TGarbageCollector.Instance) then
   begin
     if Assigned(RunFn) and not TGarbageCollector.Instance.IsTempRoot(RunFn) then
@@ -554,6 +641,17 @@ begin
   end;
 end;
 
+function PercentileValue(const ASorted: array of Double;
+  const ACount: Integer; const APercentile: Double): Double;
+var
+  PercentileIndex: Integer;
+begin
+  if ACount = 0 then
+    Exit(0);
+  PercentileIndex := Trunc(APercentile * (ACount - 1));
+  Result := ASorted[PercentileIndex] / 1000000;
+end;
+
 procedure FilterOutliersIQR(const ASorted: array of Double; const ACount: Integer;
   out AFilteredStart, AFilteredEnd: Integer);
 var
@@ -602,6 +700,10 @@ var
   I: Int64;
   Round, K: Integer;
   OpsRounds, MeanRounds: array of Double;
+  SampleDurations: array of Double;
+  SampleCount: Integer;
+  SampleStartNanoseconds, SampleDurationNanoseconds: Int64;
+  SampleDuration: Double;
   OpsMean, OpsVariance: Double;
   FilteredStart, FilteredEnd, FilteredCount: Integer;
   GC: TGarbageCollector;
@@ -618,6 +720,16 @@ begin
   Result.TeardownMs := 0;
   Result.MinOpsPerSec := 0;
   Result.MaxOpsPerSec := 0;
+  Result.SampleCount := 0;
+  Result.MinSampleMs := 0;
+  Result.P25Ms := 0;
+  Result.MedianMs := 0;
+  Result.P75Ms := 0;
+  Result.P99Ms := 0;
+  Result.P999Ms := 0;
+  Result.MaxSampleMs := 0;
+  Result.SummaryScope := ABenchCase.SummaryScope;
+  Result.BoxplotScope := ABenchCase.BoxplotScope;
 
   SetLength(OpsRounds, MEASUREMENT_ROUNDS);
   SetLength(MeanRounds, MEASUREMENT_ROUNDS);
@@ -748,6 +860,30 @@ begin
       Result.MeanMs := MeanRounds[FilteredStart + (FilteredCount div 2)];
       Result.MinOpsPerSec := OpsRounds[FilteredStart];
       Result.MaxOpsPerSec := OpsRounds[FilteredEnd];
+
+      if Iterations > MAX_PERCENTILE_SAMPLES then
+        SampleCount := MAX_PERCENTILE_SAMPLES
+      else
+        SampleCount := Iterations;
+      SetLength(SampleDurations, SampleCount);
+      for K := 0 to SampleCount - 1 do
+      begin
+        SampleStartNanoseconds := GetNanoseconds;
+        InvokeBenchmarkFunction(RunFunction, SetupResult, RunArgs);
+        SampleDurationNanoseconds := GetNanoseconds - SampleStartNanoseconds;
+        SampleDuration := SampleDurationNanoseconds;
+        SampleDurations[K] := SampleDuration;
+      end;
+      WaitForFetchIdle;
+      InsertionSort(SampleDurations, SampleCount);
+      Result.SampleCount := SampleCount;
+      Result.MinSampleMs := PercentileValue(SampleDurations, SampleCount, 0);
+      Result.P25Ms := PercentileValue(SampleDurations, SampleCount, 0.25);
+      Result.MedianMs := PercentileValue(SampleDurations, SampleCount, 0.5);
+      Result.P75Ms := PercentileValue(SampleDurations, SampleCount, 0.75);
+      Result.P99Ms := PercentileValue(SampleDurations, SampleCount, 0.99);
+      Result.P999Ms := PercentileValue(SampleDurations, SampleCount, 0.999);
+      Result.MaxSampleMs := PercentileValue(SampleDurations, SampleCount, 1);
       if Assigned(GC) then
         GC.Enabled := WasGCEnabled;
       if Assigned(GeneratorIterator) then
@@ -795,6 +931,16 @@ begin
   Result.TeardownMs := 0;
   Result.MinOpsPerSec := 0;
   Result.MaxOpsPerSec := 0;
+  Result.SampleCount := 0;
+  Result.MinSampleMs := 0;
+  Result.P25Ms := 0;
+  Result.MedianMs := 0;
+  Result.P75Ms := 0;
+  Result.P99Ms := 0;
+  Result.P999Ms := 0;
+  Result.MaxSampleMs := 0;
+  Result.SummaryScope := ABenchCase.SummaryScope;
+  Result.BoxplotScope := ABenchCase.BoxplotScope;
 
   GC := TGarbageCollector.Instance;
   SetupResult := nil;
@@ -871,17 +1017,7 @@ begin
         if Assigned(GC) then
           GC.AddTempRoot(SingleResult);
         try
-          SingleResult.AssignProperty('name', TGocciaStringLiteralValue.Create(BenchResult.Name));
-          SingleResult.AssignProperty('suite', TGocciaStringLiteralValue.Create(BenchResult.SuiteName));
-          SingleResult.AssignProperty('opsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.OpsPerSec));
-          SingleResult.AssignProperty('meanMs', TGocciaNumberLiteralValue.Create(BenchResult.MeanMs));
-          SingleResult.AssignProperty('iterations', TGocciaNumberLiteralValue.Create(BenchResult.Iterations));
-          SingleResult.AssignProperty('totalMs', TGocciaNumberLiteralValue.Create(BenchResult.TotalMs));
-          SingleResult.AssignProperty('variancePercentage', TGocciaNumberLiteralValue.Create(BenchResult.VariancePercentage));
-          SingleResult.AssignProperty('setupMs', TGocciaNumberLiteralValue.Create(BenchResult.SetupMs));
-          SingleResult.AssignProperty('teardownMs', TGocciaNumberLiteralValue.Create(BenchResult.TeardownMs));
-          SingleResult.AssignProperty('minOpsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.MinOpsPerSec));
-          SingleResult.AssignProperty('maxOpsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.MaxOpsPerSec));
+          AssignBenchmarkResultProperties(SingleResult, BenchResult);
 
           ResultsArray.SetElement(ResultsArray.GetLength, SingleResult);
         finally
@@ -901,6 +1037,8 @@ begin
           try
             SingleResult.AssignProperty('name', TGocciaStringLiteralValue.Create(BenchCase.Name));
             SingleResult.AssignProperty('suite', TGocciaStringLiteralValue.Create(BenchCase.SuiteName));
+            AssignBenchmarkScopeProperties(SingleResult,
+              BenchCase.SummaryScope, BenchCase.BoxplotScope);
             SingleResult.AssignProperty('error',
               TGocciaStringLiteralValue.Create(BenchmarkExceptionMessage(E)));
 
@@ -977,17 +1115,7 @@ begin
         if Assigned(GC) then
           GC.AddTempRoot(SingleResult);
         try
-          SingleResult.AssignProperty('name', TGocciaStringLiteralValue.Create(BenchResult.Name));
-          SingleResult.AssignProperty('suite', TGocciaStringLiteralValue.Create(BenchResult.SuiteName));
-          SingleResult.AssignProperty('opsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.OpsPerSec));
-          SingleResult.AssignProperty('meanMs', TGocciaNumberLiteralValue.Create(BenchResult.MeanMs));
-          SingleResult.AssignProperty('iterations', TGocciaNumberLiteralValue.Create(BenchResult.Iterations));
-          SingleResult.AssignProperty('totalMs', TGocciaNumberLiteralValue.Create(BenchResult.TotalMs));
-          SingleResult.AssignProperty('variancePercentage', TGocciaNumberLiteralValue.Create(BenchResult.VariancePercentage));
-          SingleResult.AssignProperty('setupMs', TGocciaNumberLiteralValue.Create(BenchResult.SetupMs));
-          SingleResult.AssignProperty('teardownMs', TGocciaNumberLiteralValue.Create(BenchResult.TeardownMs));
-          SingleResult.AssignProperty('minOpsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.MinOpsPerSec));
-          SingleResult.AssignProperty('maxOpsPerSec', TGocciaNumberLiteralValue.Create(BenchResult.MaxOpsPerSec));
+          AssignBenchmarkResultProperties(SingleResult, BenchResult);
 
           ResultsArray.SetElement(ResultsArray.GetLength, SingleResult);
         finally
@@ -1007,6 +1135,8 @@ begin
           try
             SingleResult.AssignProperty('name', TGocciaStringLiteralValue.Create(BenchCase.Name));
             SingleResult.AssignProperty('suite', TGocciaStringLiteralValue.Create(BenchCase.SuiteName));
+            AssignBenchmarkScopeProperties(SingleResult,
+              BenchCase.SummaryScope, BenchCase.BoxplotScope);
             SingleResult.AssignProperty('error',
               TGocciaStringLiteralValue.Create(BenchmarkExceptionMessage(E)));
             ResultsArray.SetElement(ResultsArray.GetLength, SingleResult);

--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -865,9 +865,6 @@ begin
            GC.ManagedObjectCount, GC.TotalCollected, GC.TotalCollections]));
       {$ENDIF}
 
-      if Assigned(GC) then
-        GC.Enabled := WasGCEnabled;
-
       InsertionSort(OpsRounds, MEASUREMENT_ROUNDS);
       InsertionSort(MeanRounds, MEASUREMENT_ROUNDS);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add a bounded invocation-level sampling pass that reports p75, p99, and p999 timings plus per-benchmark interquartile bars without changing the existing batched ops/sec and CV measurements.
- Make `boxplot()` and `summary()` real scoped reporting wrappers, including shared-scale charts and median relative-speed comparisons with conservative interquartile ranges and inconclusive-overlap classification.
- Preserve reproducibility across JSON, compact JSON, and CSV with scalar distribution statistics, wrapper scope identifiers, and derived relative comparisons; update benchmark documentation and interpreted/bytecode CLI coverage.
- Keep raw samples inside the measurement pass and cap sampling at the lower of calibrated iterations or 10,000 invocations, avoiding unbounded memory or report growth while meeting the mitata output baseline.
- Harden the reporting path with O(n log n) sorting for capped samples, GC disabled through percentile collection, async wrapper scope retention, finite/ordered relative-bound validation, exact `1.0x` baseline-relative fields, and typed 26-column CSV row construction through one escaping/join helper.
- Closes #855.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation run:

- `./build.pas benchmarkrunner`
- Direct CSV schema probe (26 fields for header, success, and error rows; comma/quote escaping and relative-column order verified)
- `./build.pas testrunner`
- `./build/GocciaTestRunner tests` (1,344 files, 11,251 tests and 24,643 assertions passed)
- `./build/GocciaTestRunner tests --mode=bytecode` (1,344 files, 11,251 tests and 24,643 assertions passed)
- `bun scripts/test-cli-apps.ts`
- `./format.pas --check`
- `git diff --check`
- `npx --yes markdownlint-cli2 docs/benchmarks.md`
- `npx --yes tsx scripts/check-doc-symbols.ts`
- `npx --yes tsx scripts/check-doc-duplication.ts` (warnings only; no exact clones)
- `npx --yes tsx scripts/check-doc-length.ts`
- `npx --yes tsx scripts/check-doc-links.ts`
