### PR TITLE
fix(collections): complete test262 conformance

### DIFF
--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -224,7 +224,7 @@ initialization
 
 `TGocciaSharedPrototype.Destroy` unpins both `FPrototype` and `FMethodHost`, so realm tear-down freeing the helper releases everything atomically — even before the next GC pass runs.
 
-Native classes whose default instance prototype lives in an owned realm slot override `TGocciaClassValue.IntrinsicPrototypeForRealm`. Their value unit exposes a matching `GetSharedPrototypeForRealm` lookup. `GetNativePrototypeFromConstructor` uses this virtual resolver when `newTarget.prototype` is not an object, so `GetPrototypeFromConstructor` falls back to the intrinsic from the **constructor's realm**, not whichever realm happens to be current. Keep this resolution in the native-class abstraction instead of adding constructor-name branches.
+Native classes whose default instance prototype lives in an owned realm slot opt in through `TGocciaClassValue.SupportsRealmIntrinsicPrototypeFallback` and override `IntrinsicPrototypeForRealm`. Their value unit exposes a matching `GetSharedPrototypeForRealm` lookup. `GetNativePrototypeFromConstructor` reads `newTarget.prototype` first, then uses this virtual resolver when the result is not an object, so `GetPrototypeFromConstructor` falls back to the intrinsic from the **constructor's realm**, not whichever realm happens to be current. Keep this resolution in the native-class abstraction instead of adding constructor-name branches.
 
 #### Stale-cache antipattern (do not do this)
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -141,6 +141,8 @@ end;
 
 Prototype **methods** take `(AArgs, AThisValue)`; use **`AThisValue`** for the real instance — **`Self`** is the method host singleton. For chaining (`Set.add`, `Map.set`), return **`AThisValue`**, not `Self`.
 
+When two standard properties must contain the **same function object**, declare the first method normally and register the later name with `AddPropertyAlias` or `AddSymbolAlias`. Aliases resolve an earlier data-property definition during `RegisterMemberDefinitions` and install its existing value with the requested descriptor flags. Do not register a second native callback: equivalent behavior is not enough for identity requirements such as `Set.prototype.keys === Set.prototype.values` or `Map.prototype[Symbol.iterator] === Map.prototype.entries`.
+
 ### Realm Ownership & Slot Registration
 
 Built-in prototypes are not module-level singletons; they live in a per-engine **realm** (`Goccia.Realm.pas`, `TGocciaRealm`). Each `TGocciaEngine` constructs its initial ECMA-262 Realm Record and frees it in `Destroy`, which unpins every prototype and cached template object the realm owns. The next engine on the same worker thread starts from pristine intrinsics — userland mutations of `Array.prototype`, including non-configurable property additions, do not leak across engine boundaries.
@@ -221,6 +223,8 @@ initialization
 ```
 
 `TGocciaSharedPrototype.Destroy` unpins both `FPrototype` and `FMethodHost`, so realm tear-down freeing the helper releases everything atomically — even before the next GC pass runs.
+
+Native classes whose default instance prototype lives in an owned realm slot override `TGocciaClassValue.IntrinsicPrototypeForRealm`. Their value unit exposes a matching `GetSharedPrototypeForRealm` lookup. `GetNativePrototypeFromConstructor` uses this virtual resolver when `newTarget.prototype` is not an object, so `GetPrototypeFromConstructor` falls back to the intrinsic from the **constructor's realm**, not whichever realm happens to be current. Keep this resolution in the native-class abstraction instead of adding constructor-name branches.
 
 #### Stale-cache antipattern (do not do this)
 

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -664,9 +664,8 @@ resourcestring
   SErrorSetClearNonSet = 'Set.prototype.clear called on non-Set object';
   SErrorSetForEachNonSet = 'Set.prototype.forEach called on non-Set object';
   SErrorSetValuesNonSet = 'Set.prototype.values called on non-Set object';
-  SErrorSetKeysNonSet = 'Set.prototype.keys called on non-Set object';
   SErrorSetEntriesNonSet = 'Set.prototype.entries called on non-Set object';
-  SErrorSetIteratorNonSet = 'Set.prototype[Symbol.iterator] called on non-Set object';
+  SErrorSetSizeNonSet = 'Set.prototype.size called on non-Set object';
   SErrorSetUnionNonSet = 'Set.prototype.union called on non-Set object';
   SErrorSetIntersectionNonSet = 'Set.prototype.intersection called on non-Set object';
   SErrorSetDifferenceNonSet = 'Set.prototype.difference called on non-Set object';
@@ -685,7 +684,7 @@ resourcestring
   SErrorMapKeysNonMap = 'Map.prototype.keys called on non-Map object';
   SErrorMapValuesNonMap = 'Map.prototype.values called on non-Map object';
   SErrorMapEntriesNonMap = 'Map.prototype.entries called on non-Map object';
-  SErrorMapIteratorNonMap = 'Map.prototype[Symbol.iterator] called on non-Map object';
+  SErrorMapSizeNonMap = 'Map.prototype.size called on non-Map object';
   SErrorMapGetOrInsertNonMap = 'Map.prototype.getOrInsert called on non-Map object';
   SErrorMapGetOrInsertComputedNonMap = 'Map.prototype.getOrInsertComputed called on non-Map object';
   SErrorMapConstructorEntryNotObject = 'Map constructor requires each entry to be an object';

--- a/source/units/Goccia.ObjectModel.Types.pas
+++ b/source/units/Goccia.ObjectModel.Types.pas
@@ -20,7 +20,9 @@ type
     gmkSymbolProperty,
     gmkSymbolMethod,
     gmkSymbolAccessor,
-    gmkDataProperty
+    gmkDataProperty,
+    gmkPropertyAlias,
+    gmkSymbolAlias
   );
 
   TGocciaMemberFlag = (
@@ -41,6 +43,7 @@ type
     PropertyFlags: TPropertyFlags;
     MemberFlags: TGocciaMemberFlags;
     DataValue: TGocciaValue;
+    AliasTargetName: string;
   end;
 
 implementation

--- a/source/units/Goccia.ObjectModel.pas
+++ b/source/units/Goccia.ObjectModel.pas
@@ -35,6 +35,8 @@ const
   gmkSymbolMethod = Goccia.ObjectModel.Types.gmkSymbolMethod;
   gmkSymbolAccessor = Goccia.ObjectModel.Types.gmkSymbolAccessor;
   gmkDataProperty = Goccia.ObjectModel.Types.gmkDataProperty;
+  gmkPropertyAlias = Goccia.ObjectModel.Types.gmkPropertyAlias;
+  gmkSymbolAlias = Goccia.ObjectModel.Types.gmkSymbolAlias;
   gmfNoFunctionPrototype = Goccia.ObjectModel.Types.gmfNoFunctionPrototype;
   gmfVariadic = Goccia.ObjectModel.Types.gmfVariadic;
   gmfNotConstructable = Goccia.ObjectModel.Types.gmfNotConstructable;
@@ -77,6 +79,12 @@ type
       const AValue: TGocciaValue; const AFlags: TPropertyFlags;
       const AKind: TGocciaMemberKind = gmkDataProperty;
       const AMemberFlags: TGocciaMemberFlags = []);
+    procedure AddPropertyAlias(const AExposedName, ATargetName: string;
+      const AFlags: TPropertyFlags;
+      const AMemberFlags: TGocciaMemberFlags = []);
+    procedure AddSymbolAlias(const ASymbol: TGocciaValue;
+      const ATargetName: string; const AFlags: TPropertyFlags;
+      const AMemberFlags: TGocciaMemberFlags = []);
     procedure AddPublishedGetter(const AInstanceClass: TClass;
       const APascalPropertyName, AExposedName: string;
       const AFlags: TPropertyFlags;
@@ -116,6 +124,11 @@ function DefineAccessor(const AExposedName: string;
 function DefineDataProperty(const AExposedName: string; const AValue: TGocciaValue;
   const AFlags: TPropertyFlags;
   const AKind: TGocciaMemberKind = gmkDataProperty): TGocciaMemberDefinition;
+function DefinePropertyAlias(const AExposedName, ATargetName: string;
+  const AFlags: TPropertyFlags): TGocciaMemberDefinition;
+function DefineSymbolAlias(const ASymbol: TGocciaValue;
+  const ATargetName: string;
+  const AFlags: TPropertyFlags): TGocciaMemberDefinition;
 function DefinePublishedGetter(const AInstanceClass: TClass;
   const APascalPropertyName, AExposedName: string; const AFlags: TPropertyFlags;
   const AKind: TGocciaMemberKind = gmkPrototypeGetter): TGocciaMemberDefinition;
@@ -181,6 +194,8 @@ begin
     gmkSymbolMethod: Result := 'symbol method';
     gmkSymbolAccessor: Result := 'symbol accessor';
     gmkDataProperty: Result := 'data property';
+    gmkPropertyAlias: Result := 'property alias';
+    gmkSymbolAlias: Result := 'symbol alias';
   else
     Result := 'member';
   end;
@@ -321,6 +336,7 @@ begin
   Result.PropertyFlags := [];
   Result.MemberFlags := [];
   Result.DataValue := nil;
+  Result.AliasTargetName := '';
   if AArity < 0 then
     Include(Result.MemberFlags, gmfVariadic);
 end;
@@ -365,6 +381,7 @@ begin
   Result.PropertyFlags := AFlags;
   Result.MemberFlags := [];
   Result.DataValue := nil;
+  Result.AliasTargetName := '';
 end;
 
 function DefineDataProperty(const AExposedName: string; const AValue: TGocciaValue;
@@ -380,6 +397,24 @@ begin
   Result.PropertyFlags := AFlags;
   Result.MemberFlags := [];
   Result.DataValue := AValue;
+  Result.AliasTargetName := '';
+end;
+
+function DefinePropertyAlias(const AExposedName, ATargetName: string;
+  const AFlags: TPropertyFlags): TGocciaMemberDefinition;
+begin
+  Result := DefineDataProperty(AExposedName, nil, AFlags,
+    gmkPropertyAlias);
+  Result.AliasTargetName := ATargetName;
+end;
+
+function DefineSymbolAlias(const ASymbol: TGocciaValue;
+  const ATargetName: string;
+  const AFlags: TPropertyFlags): TGocciaMemberDefinition;
+begin
+  Result := DefineDataProperty('', nil, AFlags, gmkSymbolAlias);
+  Result.Symbol := ASymbol;
+  Result.AliasTargetName := ATargetName;
 end;
 
 constructor TGocciaPublishedGetterHost.Create(const ATargetClass: TClass;
@@ -597,6 +632,28 @@ begin
   AddDefinition(Definition);
 end;
 
+procedure TGocciaMemberCollection.AddPropertyAlias(
+  const AExposedName, ATargetName: string; const AFlags: TPropertyFlags;
+  const AMemberFlags: TGocciaMemberFlags);
+var
+  Definition: TGocciaMemberDefinition;
+begin
+  Definition := DefinePropertyAlias(AExposedName, ATargetName, AFlags);
+  Definition.MemberFlags := Definition.MemberFlags + AMemberFlags;
+  AddDefinition(Definition);
+end;
+
+procedure TGocciaMemberCollection.AddSymbolAlias(const ASymbol: TGocciaValue;
+  const ATargetName: string; const AFlags: TPropertyFlags;
+  const AMemberFlags: TGocciaMemberFlags);
+var
+  Definition: TGocciaMemberDefinition;
+begin
+  Definition := DefineSymbolAlias(ASymbol, ATargetName, AFlags);
+  Definition.MemberFlags := Definition.MemberFlags + AMemberFlags;
+  AddDefinition(Definition);
+end;
+
 procedure TGocciaMemberCollection.AddPublishedGetter(
   const AInstanceClass: TClass;
   const APascalPropertyName, AExposedName: string;
@@ -662,6 +719,20 @@ begin
         raise EGocciaObjectModelError.CreateFmt(
           'Invalid %s "%s": symbol members require a symbol value',
           [KindToString(ADefinition.Kind), ADefinition.ExposedName]);
+    gmkPropertyAlias:
+      if ADefinition.AliasTargetName = '' then
+        raise EGocciaObjectModelError.CreateFmt(
+          'Invalid %s: alias target name must not be empty',
+          [KindToString(ADefinition.Kind)]);
+    gmkSymbolAlias:
+    begin
+      if not Assigned(ADefinition.Symbol) then
+        raise EGocciaObjectModelError.Create(
+          'Invalid symbol alias: symbol value must not be nil');
+      if ADefinition.AliasTargetName = '' then
+        raise EGocciaObjectModelError.Create(
+          'Invalid symbol alias: alias target name must not be empty');
+    end;
   end;
 end;
 
@@ -671,6 +742,8 @@ var
   I: Integer;
   Def: TGocciaMemberDefinition;
   GetterFn, SetterFn: TGocciaNativeFunctionValue;
+  AliasDescriptor: TGocciaPropertyDescriptor;
+  AliasValue: TGocciaValue;
   TargetObject: TGocciaObjectValue;
 begin
   if not (ATarget is TGocciaObjectValue) then
@@ -733,6 +806,24 @@ begin
       gmkDataProperty:
         TargetObject.DefineProperty(Def.ExposedName,
           TGocciaPropertyDescriptorData.Create(Def.DataValue, Def.PropertyFlags));
+      gmkPropertyAlias, gmkSymbolAlias:
+      begin
+        AliasDescriptor := TargetObject.GetOwnPropertyDescriptor(
+          Def.AliasTargetName);
+        if not (AliasDescriptor is TGocciaPropertyDescriptorData) then
+          raise EGocciaObjectModelError.CreateFmt(
+            'Cannot register %s: target "%s" is not an existing data property',
+            [KindToString(Def.Kind), Def.AliasTargetName]);
+        AliasValue := TGocciaPropertyDescriptorData(AliasDescriptor).Value;
+        if Def.Kind = gmkPropertyAlias then
+          TargetObject.DefineProperty(Def.ExposedName,
+            TGocciaPropertyDescriptorData.Create(AliasValue,
+              Def.PropertyFlags))
+        else
+          TargetObject.DefineSymbolProperty(TGocciaSymbolValue(Def.Symbol),
+            TGocciaPropertyDescriptorData.Create(AliasValue,
+              Def.PropertyFlags));
+      end;
     end;
   end;
 end;

--- a/source/units/Goccia.Realm.Test.pas
+++ b/source/units/Goccia.Realm.Test.pas
@@ -10,6 +10,7 @@ uses
   Goccia.GarbageCollector,
   Goccia.ExecutionContext,
   Goccia.Realm,
+  Goccia.SharedPrototype,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.Shape,
   TestingPascalLibrary,
@@ -63,6 +64,7 @@ type
     procedure TestSetOwnedSlotRoundtrip;
     procedure TestSetOwnedSlotReplacesPreviousAndFreesIt;
     procedure TestSetOwnedSlotSameValueIsNoOp;
+    procedure TestSharedPrototypeLookupRejectsMismatchedOwnedSlot;
     procedure TestDestructorFreesOwnedSlots;
     procedure TestDestructorUnpinsSlotObjects;
     procedure TestSlotIdGrowsArrayLazily;
@@ -92,6 +94,8 @@ begin
     TestSetOwnedSlotReplacesPreviousAndFreesIt);
   Test('SetOwnedSlot with the same value is a no-op',
     TestSetOwnedSlotSameValueIsNoOp);
+  Test('shared-prototype lookup rejects a mismatched owned-slot type',
+    TestSharedPrototypeLookupRejectsMismatchedOwnedSlot);
   Test('Destructor frees every owned slot', TestDestructorFreesOwnedSlots);
   Test('Destructor unpins slot objects so the GC can collect them',
     TestDestructorUnpinsSlotObjects);
@@ -267,6 +271,22 @@ begin
     Realm.Free;
   end;
   Expect<Integer>(GOwnedDestructorCount).ToBe(1);
+end;
+
+procedure TTestRealm.TestSharedPrototypeLookupRejectsMismatchedOwnedSlot;
+var
+  Realm: TGocciaRealm;
+  Slot: TGocciaRealmOwnedSlotId;
+begin
+  Slot := RegisterRealmOwnedSlot('test/owned/shared-prototype-mismatch');
+  Realm := TGocciaRealm.Create;
+  try
+    Realm.SetOwnedSlot(Slot, TCountingOwned.Create);
+    Expect<Boolean>(
+      GetSharedPrototypeFromOwnedSlot(Realm, Slot) = nil).ToBe(True);
+  finally
+    Realm.Free;
+  end;
 end;
 
 procedure TTestRealm.TestDestructorFreesOwnedSlots;

--- a/source/units/Goccia.SharedPrototype.pas
+++ b/source/units/Goccia.SharedPrototype.pas
@@ -5,6 +5,7 @@ unit Goccia.SharedPrototype;
 interface
 
 uses
+  Goccia.Realm,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
@@ -33,6 +34,9 @@ type
     property Prototype: TGocciaObjectValue read FPrototype;
   end;
 
+function GetSharedPrototypeFromOwnedSlot(const ARealm: TGocciaRealm;
+  const ASlotId: TGocciaRealmOwnedSlotId): TGocciaObjectValue;
+
 implementation
 
 uses
@@ -40,6 +44,19 @@ uses
   Goccia.GarbageCollector,
   Goccia.Values.ClassValue,
   Goccia.Values.ObjectPropertyDescriptor;
+
+function GetSharedPrototypeFromOwnedSlot(const ARealm: TGocciaRealm;
+  const ASlotId: TGocciaRealmOwnedSlotId): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(ASlotId));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
+end;
 
 constructor TGocciaSharedPrototype.Create(const AMethodHost: TGocciaValue);
 begin

--- a/source/units/Goccia.SharedPrototype.pas
+++ b/source/units/Goccia.SharedPrototype.pas
@@ -48,14 +48,14 @@ uses
 function GetSharedPrototypeFromOwnedSlot(const ARealm: TGocciaRealm;
   const ASlotId: TGocciaRealmOwnedSlotId): TGocciaObjectValue;
 var
-  Shared: TGocciaSharedPrototype;
+  Owned: TObject;
 begin
   Result := nil;
   if not Assigned(ARealm) then
     Exit;
-  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(ASlotId));
-  if Assigned(Shared) then
-    Result := Shared.Prototype;
+  Owned := ARealm.GetOwnedSlot(ASlotId);
+  if Owned is TGocciaSharedPrototype then
+    Result := TGocciaSharedPrototype(Owned).Prototype;
 end;
 
 constructor TGocciaSharedPrototype.Create(const AMethodHost: TGocciaValue);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -119,6 +119,8 @@ type
     procedure AppendOwnPrivateNames(const ANames: TStrings);
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; virtual;
     function NativeInstanceDefaultPrototype: TGocciaObjectValue; virtual;
+    function IntrinsicPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; virtual;
     function Instantiate(const AArguments: TGocciaArgumentsCollection;
       const ANewTarget: TGocciaValue = nil): TGocciaValue; virtual;
     function EstimatedInstancePropertyCapacity: Integer;
@@ -193,18 +195,26 @@ type
 
   TGocciaMapClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function IntrinsicPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; override;
   end;
 
   TGocciaSetClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function IntrinsicPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; override;
   end;
 
   TGocciaWeakMapClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function IntrinsicPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; override;
   end;
 
   TGocciaWeakSetClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function IntrinsicPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; override;
   end;
 
   TGocciaWeakRefClassValue = class(TGocciaClassValue)
@@ -548,11 +558,40 @@ function GetNativePrototypeFromConstructor(
   const ANativeClass: TGocciaClassValue;
   const ANewTarget: TGocciaValue;
   const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
+var
+  FallbackPrototype: TGocciaObjectValue;
+  FallbackRealm: TGocciaRealm;
+  ProtoValue: TGocciaValue;
 begin
+  FallbackRealm := GetFunctionRealm(ANewTarget);
+  FallbackPrototype := ANativeClass.IntrinsicPrototypeForRealm(FallbackRealm);
+  if Assigned(FallbackPrototype) then
+  begin
+    if ANewTarget is TGocciaObjectValue then
+      ProtoValue := TGocciaObjectValue(ANewTarget).GetProperty(PROP_PROTOTYPE)
+    else
+      ProtoValue := nil;
+    if ProtoValue is TGocciaObjectValue then
+      Exit(TGocciaObjectValue(ProtoValue));
+    Exit(FallbackPrototype);
+  end;
+
   if ANativeClass is TGocciaTypedArrayClassValue then
     Result := GetTypedArrayPrototypeFromConstructor(
       TGocciaTypedArrayClassValue(ANativeClass), ANewTarget,
       ACurrentRealmDefault)
+  else if ANativeClass is TGocciaArrayClassValue then
+    Result := GetArrayPrototypeFromConstructor(ANewTarget,
+      ACurrentRealmDefault)
+  else if ANativeClass is TGocciaStringClassValue then
+    Result := TGocciaStringClassValue(ANativeClass).
+      DefaultPrototypeForNewTarget(ANewTarget, ACurrentRealmDefault)
+  else if ANativeClass is TGocciaNumberClassValue then
+    Result := TGocciaNumberClassValue(ANativeClass).
+      DefaultPrototypeForNewTarget(ANewTarget, ACurrentRealmDefault)
+  else if ANativeClass is TGocciaBooleanClassValue then
+    Result := TGocciaBooleanClassValue(ANativeClass).
+      DefaultPrototypeForNewTarget(ANewTarget, ACurrentRealmDefault)
   else if ANativeClass is TGocciaFunctionConstructorClassValue then
     Result := FunctionObjectIntrinsicPrototypeFromConstructor(
       TGocciaFunctionConstructorClassValue(ANativeClass).DynamicKind,
@@ -1443,6 +1482,12 @@ begin
     Result := nil;
 end;
 
+function TGocciaClassValue.IntrinsicPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+begin
+  Result := nil;
+end;
+
 procedure TGocciaClassValue.ReplacePrototype(const APrototype: TGocciaObjectValue);
 begin
   FClassPrototype := APrototype;
@@ -1649,40 +1694,8 @@ begin
   if Assigned(ANewTarget) and not DelayNativePrototypeLookup then
   begin
     if Assigned(NativeClass) then
-    begin
-      if NativeClass is TGocciaTypedArrayClassValue then
-        InstancePrototype := GetTypedArrayPrototypeFromConstructor(
-          TGocciaTypedArrayClassValue(NativeClass), ANewTarget,
-          NativeIntrinsicPrototype)
-      else if NativeClass is TGocciaArrayClassValue then
-        InstancePrototype := GetArrayPrototypeFromConstructor(ANewTarget,
-          NativeIntrinsicPrototype)
-      else if NativeClass is TGocciaStringClassValue then
-        InstancePrototype := TGocciaStringClassValue(NativeClass).
-          DefaultPrototypeForNewTarget(ANewTarget, NativeIntrinsicPrototype)
-      else if NativeClass is TGocciaNumberClassValue then
-        InstancePrototype := TGocciaNumberClassValue(NativeClass).
-          DefaultPrototypeForNewTarget(ANewTarget, NativeIntrinsicPrototype)
-      else if NativeClass is TGocciaBooleanClassValue then
-        InstancePrototype := TGocciaBooleanClassValue(NativeClass).
-          DefaultPrototypeForNewTarget(ANewTarget, NativeIntrinsicPrototype)
-      else if NativeClass is TGocciaArrayBufferClassValue then
-        InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
-          NativeIntrinsicPrototype, CONSTRUCTOR_ARRAY_BUFFER)
-      else if NativeClass is TGocciaSharedArrayBufferClassValue then
-        InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
-          NativeIntrinsicPrototype, CONSTRUCTOR_SHARED_ARRAY_BUFFER)
-      else if NativeClass is TGocciaDataViewClassValue then
-        InstancePrototype := DefaultNativePrototypeForNewTarget(ANewTarget,
-          NativeIntrinsicPrototype, CONSTRUCTOR_DATA_VIEW)
-      else if NativeClass is TGocciaFunctionConstructorClassValue then
-        InstancePrototype := FunctionObjectIntrinsicPrototypeFromConstructor(
-          TGocciaFunctionConstructorClassValue(NativeClass).DynamicKind,
-          ANewTarget, NativeIntrinsicPrototype)
-      else
-        InstancePrototype := GetProtoFromConstructorWithIntrinsic(ANewTarget,
-          NativeIntrinsicPrototype);
-    end
+      InstancePrototype := GetNativePrototypeFromConstructor(NativeClass,
+        ANewTarget, NativeIntrinsicPrototype)
     else
       InstancePrototype := GetProtoFromConstructor(ANewTarget);
   end
@@ -2222,11 +2235,23 @@ begin
   Result := TGocciaMapValue.Create;
 end;
 
+function TGocciaMapClassValue.IntrinsicPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+begin
+  Result := TGocciaMapValue.GetSharedPrototypeForRealm(ARealm);
+end;
+
 { TGocciaSetClassValue }
 
 function TGocciaSetClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
 begin
   Result := TGocciaSetValue.Create;
+end;
+
+function TGocciaSetClassValue.IntrinsicPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+begin
+  Result := TGocciaSetValue.GetSharedPrototypeForRealm(ARealm);
 end;
 
 { TGocciaWeakMapClassValue }
@@ -2236,11 +2261,23 @@ begin
   Result := TGocciaWeakMapValue.Create;
 end;
 
+function TGocciaWeakMapClassValue.IntrinsicPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+begin
+  Result := TGocciaWeakMapValue.GetSharedPrototypeForRealm(ARealm);
+end;
+
 { TGocciaWeakSetClassValue }
 
 function TGocciaWeakSetClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
 begin
   Result := TGocciaWeakSetValue.Create;
+end;
+
+function TGocciaWeakSetClassValue.IntrinsicPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+begin
+  Result := TGocciaWeakSetValue.GetSharedPrototypeForRealm(ARealm);
 end;
 
 { TGocciaWeakRefClassValue }

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -119,6 +119,7 @@ type
     procedure AppendOwnPrivateNames(const ANames: TStrings);
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; virtual;
     function NativeInstanceDefaultPrototype: TGocciaObjectValue; virtual;
+    function SupportsRealmIntrinsicPrototypeFallback: Boolean; virtual;
     function IntrinsicPrototypeForRealm(
       const ARealm: TGocciaRealm): TGocciaObjectValue; virtual;
     function Instantiate(const AArguments: TGocciaArgumentsCollection;
@@ -195,24 +196,28 @@ type
 
   TGocciaMapClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function SupportsRealmIntrinsicPrototypeFallback: Boolean; override;
     function IntrinsicPrototypeForRealm(
       const ARealm: TGocciaRealm): TGocciaObjectValue; override;
   end;
 
   TGocciaSetClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function SupportsRealmIntrinsicPrototypeFallback: Boolean; override;
     function IntrinsicPrototypeForRealm(
       const ARealm: TGocciaRealm): TGocciaObjectValue; override;
   end;
 
   TGocciaWeakMapClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function SupportsRealmIntrinsicPrototypeFallback: Boolean; override;
     function IntrinsicPrototypeForRealm(
       const ARealm: TGocciaRealm): TGocciaObjectValue; override;
   end;
 
   TGocciaWeakSetClassValue = class(TGocciaClassValue)
     function CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue; override;
+    function SupportsRealmIntrinsicPrototypeFallback: Boolean; override;
     function IntrinsicPrototypeForRealm(
       const ARealm: TGocciaRealm): TGocciaObjectValue; override;
   end;
@@ -563,9 +568,7 @@ var
   FallbackRealm: TGocciaRealm;
   ProtoValue: TGocciaValue;
 begin
-  FallbackRealm := GetFunctionRealm(ANewTarget);
-  FallbackPrototype := ANativeClass.IntrinsicPrototypeForRealm(FallbackRealm);
-  if Assigned(FallbackPrototype) then
+  if ANativeClass.SupportsRealmIntrinsicPrototypeFallback then
   begin
     if ANewTarget is TGocciaObjectValue then
       ProtoValue := TGocciaObjectValue(ANewTarget).GetProperty(PROP_PROTOTYPE)
@@ -573,7 +576,12 @@ begin
       ProtoValue := nil;
     if ProtoValue is TGocciaObjectValue then
       Exit(TGocciaObjectValue(ProtoValue));
-    Exit(FallbackPrototype);
+
+    FallbackRealm := GetFunctionRealm(ANewTarget);
+    FallbackPrototype := ANativeClass.IntrinsicPrototypeForRealm(FallbackRealm);
+    if Assigned(FallbackPrototype) then
+      Exit(FallbackPrototype);
+    Exit(ACurrentRealmDefault);
   end;
 
   if ANativeClass is TGocciaTypedArrayClassValue then
@@ -1488,6 +1496,11 @@ begin
   Result := nil;
 end;
 
+function TGocciaClassValue.SupportsRealmIntrinsicPrototypeFallback: Boolean;
+begin
+  Result := False;
+end;
+
 procedure TGocciaClassValue.ReplacePrototype(const APrototype: TGocciaObjectValue);
 begin
   FClassPrototype := APrototype;
@@ -2241,6 +2254,11 @@ begin
   Result := TGocciaMapValue.GetSharedPrototypeForRealm(ARealm);
 end;
 
+function TGocciaMapClassValue.SupportsRealmIntrinsicPrototypeFallback: Boolean;
+begin
+  Result := True;
+end;
+
 { TGocciaSetClassValue }
 
 function TGocciaSetClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
@@ -2252,6 +2270,11 @@ function TGocciaSetClassValue.IntrinsicPrototypeForRealm(
   const ARealm: TGocciaRealm): TGocciaObjectValue;
 begin
   Result := TGocciaSetValue.GetSharedPrototypeForRealm(ARealm);
+end;
+
+function TGocciaSetClassValue.SupportsRealmIntrinsicPrototypeFallback: Boolean;
+begin
+  Result := True;
 end;
 
 { TGocciaWeakMapClassValue }
@@ -2267,6 +2290,11 @@ begin
   Result := TGocciaWeakMapValue.GetSharedPrototypeForRealm(ARealm);
 end;
 
+function TGocciaWeakMapClassValue.SupportsRealmIntrinsicPrototypeFallback: Boolean;
+begin
+  Result := True;
+end;
+
 { TGocciaWeakSetClassValue }
 
 function TGocciaWeakSetClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;
@@ -2278,6 +2306,11 @@ function TGocciaWeakSetClassValue.IntrinsicPrototypeForRealm(
   const ARealm: TGocciaRealm): TGocciaObjectValue;
 begin
   Result := TGocciaWeakSetValue.GetSharedPrototypeForRealm(ARealm);
+end;
+
+function TGocciaWeakSetClassValue.SupportsRealmIntrinsicPrototypeFallback: Boolean;
+begin
+  Result := True;
 end;
 
 { TGocciaWeakRefClassValue }

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -7,6 +7,7 @@ interface
 uses
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
@@ -28,7 +29,7 @@ type
     function MapKeys(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function MapValues(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function MapEntries(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-    function MapSymbolIterator(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function MapSize(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function MapGetOrInsert(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function MapGetOrInsertComputed(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     procedure InitializePrototype;
@@ -51,8 +52,6 @@ type
     procedure ReleaseIterator;
     function Count: Integer;
 
-    function GetProperty(const AName: string): TGocciaValue; override;
-    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToArray: TGocciaArrayValue;
     function ToStringTag: string; override;
     function BuiltinTagFallback: Boolean; override;
@@ -61,6 +60,8 @@ type
     procedure MarkReferences; override;
 
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function GetSharedPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; static;
   end;
 
 implementation
@@ -73,7 +74,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Realm,
   Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -131,13 +131,12 @@ begin
     Members.AddNamedMethod('keys', MapKeys, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('values', MapValues, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('entries', MapEntries, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddAccessor(PROP_SIZE, MapSize, nil, [pfConfigurable]);
     Members.AddNamedMethod('getOrInsert', MapGetOrInsert, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('getOrInsertComputed', MapGetOrInsertComputed, 2, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddSymbolMethod(
+    Members.AddSymbolAlias(
       TGocciaSymbolValue.WellKnownIterator,
-      '[Symbol.iterator]',
-      MapSymbolIterator,
-      0,
+      PROP_ENTRIES,
       [pfConfigurable, pfWritable]);
     Members.AddSymbolDataProperty(
       TGocciaSymbolValue.WellKnownToStringTag,
@@ -162,6 +161,19 @@ begin
   end;
   if Assigned(Shared) then
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+class function TGocciaMapValue.GetSharedPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GMapSharedSlot));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
 end;
 
 
@@ -314,19 +326,6 @@ end;
 function TGocciaMapValue.Count: Integer;
 begin
   Result := FStore.Count;
-end;
-
-function TGocciaMapValue.GetProperty(const AName: string): TGocciaValue;
-begin
-  Result := GetPropertyWithContext(AName, Self);
-end;
-
-function TGocciaMapValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
-begin
-  if AName = PROP_SIZE then
-    Result := TGocciaNumberLiteralValue.Create(FStore.Count)
-  else
-    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaMapValue.ToArray: TGocciaArrayValue;
@@ -563,18 +562,17 @@ begin
   Result := TGocciaMapIteratorValue.Create(AThisValue, mkEntries);
 end;
 
-// ES2026 §24.1.3.12 Map.prototype[@@iterator]()
-function TGocciaMapValue.MapSymbolIterator(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+// ES2026 §24.1.3.12 get Map.prototype.size
+function TGocciaMapValue.MapSize(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  // Step 1: Let M be the this value
-  // Steps 2-3: If M does not have a [[MapData]] internal slot, throw a TypeError
   if not (AThisValue is TGocciaMapValue) then
-    ThrowTypeError(SErrorMapIteratorNonMap, SSuggestMapThisType);
-  // Step 4: Return the result of calling Map.prototype.entries()
-  Result := TGocciaMapIteratorValue.Create(AThisValue, mkEntries);
+    ThrowTypeError(SErrorMapSizeNonMap, SSuggestMapThisType);
+  Result := TGocciaNumberLiteralValue.Create(
+    TGocciaMapValue(AThisValue).FStore.Count);
 end;
 
-// TC39 proposal-upsert §1.1 Map.prototype.getOrInsert(key, value)
+// ES2026 §24.1.3.7 Map.prototype.getOrInsert(key, value)
 function TGocciaMapValue.MapGetOrInsert(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   M: TGocciaMapValue;
@@ -588,6 +586,7 @@ begin
     MapKey := AArgs.GetElement(0)
   else
     MapKey := TGocciaUndefinedLiteralValue.UndefinedValue;
+  MapKey := TGocciaOrderedValueMap.CanonicalizeKey(MapKey);
 
   // Step 4: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
   //   If SameValueZero(p.[[Key]], key) is true, return p.[[Value]]
@@ -605,7 +604,7 @@ begin
   Result := DefaultValue;
 end;
 
-// TC39 proposal-upsert §1.2 Map.prototype.getOrInsertComputed(key, callbackfn)
+// ES2026 §24.1.3.8 Map.prototype.getOrInsertComputed(key, callback)
 function TGocciaMapValue.MapGetOrInsertComputed(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   M: TGocciaMapValue;
@@ -629,8 +628,10 @@ begin
     CallbackArg := TGocciaUndefinedLiteralValue.UndefinedValue;
   if not CallbackArg.IsCallable then
     ThrowTypeError(SErrorMapGetOrInsertComputedNotCallable, SSuggestMapCallbackRequired);
+  // Step 4: Set key to CanonicalizeKeyedCollectionKey(key)
+  MapKey := TGocciaOrderedValueMap.CanonicalizeKey(MapKey);
 
-  // Step 4: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+  // Step 5: For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
   //   If SameValueZero(p.[[Key]], key) is true, return p.[[Value]]
   if M.TryGetValue(MapKey, Existing) then
     Exit(Existing);
@@ -644,17 +645,17 @@ begin
   try
     CallArgs := TGocciaArgumentsCollection.Create([MapKey]);
     try
-      // Step 5: Let value be ? Call(callbackfn, undefined, « key »)
+      // Step 6: Let value be ? Call(callback, undefined, « key »)
       ComputedValue := InvokeCallable(CallbackArg, CallArgs,
         TGocciaUndefinedLiteralValue.UndefinedValue);
     finally
       CallArgs.Free;
     end;
 
-    // Step 6: Set key to CanonicalizeKeyedCollectionKey(key)
-    // Step 7: Append Record { [[Key]]: key, [[Value]]: value } to M.[[MapData]]
+    // Steps 7-10: Replace any callback-added value for the canonical key, or
+    // append a new entry when the key is still absent.
     M.SetEntry(MapKey, ComputedValue);
-    // Step 8: Return value
+    // Step 11: Return value
     Result := ComputedValue;
   finally
     RemoveTempRootIfNeeded(CallbackRoot);

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -165,15 +165,8 @@ end;
 
 class function TGocciaMapValue.GetSharedPrototypeForRealm(
   const ARealm: TGocciaRealm): TGocciaObjectValue;
-var
-  Shared: TGocciaSharedPrototype;
 begin
-  Result := nil;
-  if not Assigned(ARealm) then
-    Exit;
-  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GMapSharedSlot));
-  if Assigned(Shared) then
-    Result := Shared.Prototype;
+  Result := GetSharedPrototypeFromOwnedSlot(ARealm, GMapSharedSlot);
 end;
 
 

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -7,6 +7,7 @@ interface
 uses
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassValue,
@@ -27,9 +28,8 @@ type
     function SetClear(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function SetForEach(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function SetValues(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-    function SetKeys(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function SetEntries(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-    function SetSymbolIterator(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function SetSize(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function SetUnion(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function SetIntersection(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function SetDifference(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -48,18 +48,10 @@ type
 
     // Live, insertion-ordered cursor over active members. Seed ACursor with 0.
     function NextItem(var ACursor: Integer; out AValue: TGocciaValue): Boolean;
-    // Like NextItem, but stops at physical slot ALimit (captured via
-    // EntrySlotCount before a set operation that runs user callbacks), so
-    // members appended during a callback are not visited.
-    function NextItemBounded(var ACursor: Integer; ALimit: Integer;
-      out AValue: TGocciaValue): Boolean;
-    function EntrySlotCount: Integer;
     procedure RetainIterator;
     procedure ReleaseIterator;
     function Count: Integer;
 
-    function GetProperty(const AName: string): TGocciaValue; override;
-    function GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue; override;
     function ToArray: TGocciaArrayValue;
     function ToStringTag: string; override;
     function BuiltinTagFallback: Boolean; override;
@@ -68,6 +60,8 @@ type
     procedure MarkReferences; override;
 
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function GetSharedPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; static;
   end;
 
 implementation
@@ -80,7 +74,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Realm,
   Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
@@ -120,8 +113,8 @@ end;
 // snapshot because the spec (ES2026 §24.2.4.5) builds its result from a copy of
 // O.[[SetData]] taken before any `has` callback runs, so later mutations of the
 // receiver — including delete-then-readd — do not affect the result. The
-// live-iterating operations (intersection/isSubsetOf/isDisjointFrom) instead use
-// NextItemBounded over the original physical slots.
+// live-iterating operations (intersection/isSubsetOf/isDisjointFrom) instead
+// use NextItem so callback-appended members remain visible.
 function SnapshotSetItems(const ASet: TGocciaSetValue): TArray<TGocciaValue>;
 var
   Cursor, Count: Integer;
@@ -255,8 +248,10 @@ begin
     Members.AddNamedMethod('clear', SetClear, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('forEach', SetForEach, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('values', SetValues, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddNamedMethod('keys', SetKeys, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddPropertyAlias(PROP_KEYS, PROP_VALUES,
+      [pfConfigurable, pfWritable]);
     Members.AddNamedMethod('entries', SetEntries, 0, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddAccessor(PROP_SIZE, SetSize, nil, [pfConfigurable]);
     Members.AddNamedMethod('union', SetUnion, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('intersection', SetIntersection, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('difference', SetDifference, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
@@ -264,11 +259,9 @@ begin
     Members.AddNamedMethod('isSubsetOf', SetIsSubsetOf, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('isSupersetOf', SetIsSupersetOf, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     Members.AddNamedMethod('isDisjointFrom', SetIsDisjointFrom, 1, gmkPrototypeMethod, [gmfNoFunctionPrototype]);
-    Members.AddSymbolMethod(
+    Members.AddSymbolAlias(
       TGocciaSymbolValue.WellKnownIterator,
-      '[Symbol.iterator]',
-      SetSymbolIterator,
-      0,
+      PROP_VALUES,
       [pfConfigurable, pfWritable]);
     Members.AddSymbolDataProperty(
       TGocciaSymbolValue.WellKnownToStringTag,
@@ -293,6 +286,19 @@ begin
   end;
   if Assigned(Shared) then
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+class function TGocciaSetValue.GetSharedPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GSetSharedSlot));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
 end;
 
 destructor TGocciaSetValue.Destroy;
@@ -415,19 +421,6 @@ begin
   Result := FStore.NextEntry(ACursor, Key, AValue);
 end;
 
-function TGocciaSetValue.NextItemBounded(var ACursor: Integer; ALimit: Integer;
-  out AValue: TGocciaValue): Boolean;
-var
-  Key: TGocciaValue;
-begin
-  Result := FStore.NextEntryBounded(ACursor, ALimit, Key, AValue);
-end;
-
-function TGocciaSetValue.EntrySlotCount: Integer;
-begin
-  Result := FStore.EntrySlotCount;
-end;
-
 procedure TGocciaSetValue.RetainIterator;
 begin
   FStore.RetainIterator;
@@ -441,19 +434,6 @@ end;
 function TGocciaSetValue.Count: Integer;
 begin
   Result := FStore.Count;
-end;
-
-function TGocciaSetValue.GetProperty(const AName: string): TGocciaValue;
-begin
-  Result := GetPropertyWithContext(AName, Self);
-end;
-
-function TGocciaSetValue.GetPropertyWithContext(const AName: string; const AThisContext: TGocciaValue): TGocciaValue;
-begin
-  if AName = PROP_SIZE then
-    Result := TGocciaNumberLiteralValue.Create(FStore.Count)
-  else
-    Result := inherited GetPropertyWithContext(AName, AThisContext);
 end;
 
 function TGocciaSetValue.ToArray: TGocciaArrayValue;
@@ -633,17 +613,6 @@ begin
   Result := TGocciaSetIteratorValue.Create(AThisValue, skValues);
 end;
 
-// ES2026 §24.2.3.8 Set.prototype.keys()
-function TGocciaSetValue.SetKeys(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
-begin
-  // Step 1: This method is the same function as Set.prototype.values (per spec)
-  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
-  if not (AThisValue is TGocciaSetValue) then
-    ThrowTypeError(SErrorSetKeysNonSet, SSuggestSetThisType);
-  // Step 4: Return CreateSetIterator(S, value)
-  Result := TGocciaSetIteratorValue.Create(AThisValue, skValues);
-end;
-
 // ES2026 §24.2.3.5 Set.prototype.entries()
 function TGocciaSetValue.SetEntries(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 begin
@@ -655,17 +624,17 @@ begin
   Result := TGocciaSetIteratorValue.Create(AThisValue, skEntries);
 end;
 
-// ES2026 §24.2.3.11 Set.prototype[@@iterator]()
-function TGocciaSetValue.SetSymbolIterator(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+// ES2026 §24.2.4.14 get Set.prototype.size
+function TGocciaSetValue.SetSize(const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
 begin
-  // Step 1: This method is the same function as Set.prototype.values (per spec)
-  // Steps 2-3: If S does not have a [[SetData]] internal slot, throw a TypeError
   if not (AThisValue is TGocciaSetValue) then
-    ThrowTypeError(SErrorSetIteratorNonSet, SSuggestSetThisType);
-  Result := TGocciaSetIteratorValue.Create(AThisValue, skValues);
+    ThrowTypeError(SErrorSetSizeNonSet, SSuggestSetThisType);
+  Result := TGocciaNumberLiteralValue.Create(
+    TGocciaSetValue(AThisValue).FStore.Count);
 end;
 
-// ES2026 §24.2.3.12 Set.prototype.union(other)
+// ES2026 §24.2.4.16 Set.prototype.union(other)
 function TGocciaSetValue.SetUnion(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   ThisSet, ResultSet: TGocciaSetValue;
@@ -690,15 +659,17 @@ begin
   if Assigned(GC) and not WasResultRooted then
     GC.AddTempRoot(ResultSet);
   try
-    Cursor := 0;
-    while ThisSet.NextItem(Cursor, Item) do
-      ResultSet.AddItem(Item);
-    // Step 6: Let keysIter be GetIteratorFromSetLike(otherRec)
+    // Step 4: Acquire the iterator before copying O.[[SetData]]. Getting the
+    // iterator's next method may run user code that mutates O.
     Iterator := GetSetRecordKeysIterator(OtherRecord, 'union');
     WasIteratorRooted := Assigned(GC) and GC.IsTempRoot(Iterator);
     if Assigned(GC) and not WasIteratorRooted then
       GC.AddTempRoot(Iterator);
     try
+      // Step 5: Let resultSetData be a copy of O.[[SetData]].
+      Cursor := 0;
+      while ThisSet.NextItem(Cursor, Item) do
+        ResultSet.AddItem(Item);
       // Step 7: For each element nextValue from keysIter, do
       NextValue := Iterator.DirectNext(Done);
       while not Done do
@@ -722,7 +693,7 @@ begin
   end;
 end;
 
-// ES2026 §24.2.3.7 Set.prototype.intersection(other)
+// ES2026 §24.2.4.9 Set.prototype.intersection(other)
 function TGocciaSetValue.SetIntersection(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   ThisSet, ResultSet: TGocciaSetValue;
@@ -730,7 +701,7 @@ var
   Iterator: TGocciaIteratorValue;
   NextValue, Item: TGocciaValue;
   Done, WasResultRooted, WasIteratorRooted: Boolean;
-  Cursor, Limit: Integer;
+  Cursor: Integer;
   GC: TGarbageCollector;
 begin
   // Step 1: Let O be the this value
@@ -749,16 +720,13 @@ begin
   try
     if ThisSet.Count <= OtherRecord.Size then
     begin
-      // Step 6: For each element e of O.[[SetData]] present when the operation
-      // began. SetRecordHas runs user code that may mutate O; retain the store
-      // so physical slot indices stay stable, and bound iteration to the
-      // original slot count — appended members are not visited, deleted members
-      // are skipped, and a delete-then-readd lands past the bound (§24.2.4.6).
-      Limit := ThisSet.EntrySlotCount;
+      // Step 5: Re-read the live SetData length after each user callback.
+      // Retaining the store preserves physical indices while delete/re-add
+      // appends a new slot that must be visited by this iteration.
       ThisSet.RetainIterator;
       try
         Cursor := 0;
-        while ThisSet.NextItemBounded(Cursor, Limit, Item) do
+        while ThisSet.NextItem(Cursor, Item) do
           // Step 6a: If SetDataHas(otherRec, e) is true, append e
           if SetRecordHas(OtherRecord, Item) then
             ResultSet.AddItem(Item);
@@ -871,7 +839,7 @@ begin
   end;
 end;
 
-// ES2026 §24.2.3.9 Set.prototype.symmetricDifference(other)
+// ES2026 §24.2.4.15 Set.prototype.symmetricDifference(other)
 function TGocciaSetValue.SetSymmetricDifference(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   ThisSet, ResultSet: TGocciaSetValue;
@@ -896,16 +864,17 @@ begin
   if Assigned(GC) and not WasResultRooted then
     GC.AddTempRoot(ResultSet);
   try
-    Cursor := 0;
-    while ThisSet.NextItem(Cursor, Item) do
-      ResultSet.AddItem(Item);
-
-    // Step 7: Let keysIter be GetIteratorFromSetLike(otherRec)
+    // Step 4: Acquire the iterator before copying O.[[SetData]]. Getting the
+    // iterator's next method may run user code that mutates O.
     Iterator := GetSetRecordKeysIterator(OtherRecord, 'symmetricDifference');
     WasIteratorRooted := Assigned(GC) and GC.IsTempRoot(Iterator);
     if Assigned(GC) and not WasIteratorRooted then
       GC.AddTempRoot(Iterator);
     try
+      // Step 5: Let resultSetData be a copy of O.[[SetData]].
+      Cursor := 0;
+      while ThisSet.NextItem(Cursor, Item) do
+        ResultSet.AddItem(Item);
       // Step 8: For each element nextValue from keysIter, do
       NextValue := Iterator.DirectNext(Done);
       while not Done do
@@ -932,13 +901,13 @@ begin
   end;
 end;
 
-// ES2026 §24.2.3.8 Set.prototype.isSubsetOf(other)
+// ES2026 §24.2.4.11 Set.prototype.isSubsetOf(other)
 function TGocciaSetValue.SetIsSubsetOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   ThisSet: TGocciaSetValue;
   OtherRecord: TGocciaSetRecord;
   Item: TGocciaValue;
-  Cursor, Limit: Integer;
+  Cursor: Integer;
   IsSubset: Boolean;
 begin
   // Step 1: Let O be the this value
@@ -957,16 +926,13 @@ begin
   end;
 
   IsSubset := True;
-  // Step 6: For each element e of O.[[SetData]] present when the operation
-  // began. SetRecordHas runs user code that may mutate O; retain the store and
-  // bound iteration to the original slot count so appended members are not
-  // checked, deleted members are skipped, and a delete-then-readd lands past
-  // the bound (§24.2.3.8).
-  Limit := ThisSet.EntrySlotCount;
+  // Steps 5-7: Re-read the live SetData length after each user callback.
+  // Retaining the store preserves physical indices while newly appended
+  // members remain visible to the iteration.
   ThisSet.RetainIterator;
   try
     Cursor := 0;
-    while ThisSet.NextItemBounded(Cursor, Limit, Item) do
+    while ThisSet.NextItem(Cursor, Item) do
       // Step 6a: If SetDataHas(otherRec, e) is false, return false
       if not SetRecordHas(OtherRecord, Item) then
       begin
@@ -1038,7 +1004,7 @@ begin
   Result := TGocciaBooleanLiteralValue.TrueValue;
 end;
 
-// ES2026 §24.2.3.6 Set.prototype.isDisjointFrom(other)
+// ES2026 §24.2.4.8 Set.prototype.isDisjointFrom(other)
 function TGocciaSetValue.SetIsDisjointFrom(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   ThisSet: TGocciaSetValue;
@@ -1046,7 +1012,7 @@ var
   Iterator: TGocciaIteratorValue;
   NextValue, Item: TGocciaValue;
   Done, WasIteratorRooted, IsDisjoint: Boolean;
-  Cursor, Limit: Integer;
+  Cursor: Integer;
   GC: TGarbageCollector;
 begin
   // Step 1: Let O be the this value
@@ -1060,16 +1026,11 @@ begin
   if ThisSet.Count <= OtherRecord.Size then
   begin
     IsDisjoint := True;
-    // Step 5: For each element e of O.[[SetData]] present when the operation
-    // began. SetRecordHas runs user code that may mutate O; retain the store and
-    // bound iteration to the original slot count so appended elements are not
-    // checked, deleted elements are skipped, and a delete-then-readd lands past
-    // the bound (§24.2.3.6).
-    Limit := ThisSet.EntrySlotCount;
+    // Step 5: Re-read the live SetData length after each user callback.
     ThisSet.RetainIterator;
     try
       Cursor := 0;
-      while ThisSet.NextItemBounded(Cursor, Limit, Item) do
+      while ThisSet.NextItem(Cursor, Item) do
         // Step 5a: If SetDataHas(otherRec, e) is true, return false
         if SetRecordHas(OtherRecord, Item) then
         begin

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -290,15 +290,8 @@ end;
 
 class function TGocciaSetValue.GetSharedPrototypeForRealm(
   const ARealm: TGocciaRealm): TGocciaObjectValue;
-var
-  Shared: TGocciaSharedPrototype;
 begin
-  Result := nil;
-  if not Assigned(ARealm) then
-    Exit;
-  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GSetSharedSlot));
-  if Assigned(Shared) then
-    Result := Shared.Prototype;
+  Result := GetSharedPrototypeFromOwnedSlot(ARealm, GSetSharedSlot);
 end;
 
 destructor TGocciaSetValue.Destroy;

--- a/source/units/Goccia.Values.WeakMapValue.pas
+++ b/source/units/Goccia.Values.WeakMapValue.pas
@@ -151,15 +151,8 @@ end;
 
 class function TGocciaWeakMapValue.GetSharedPrototypeForRealm(
   const ARealm: TGocciaRealm): TGocciaObjectValue;
-var
-  Shared: TGocciaSharedPrototype;
 begin
-  Result := nil;
-  if not Assigned(ARealm) then
-    Exit;
-  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GWeakMapSharedSlot));
-  if Assigned(Shared) then
-    Result := Shared.Prototype;
+  Result := GetSharedPrototypeFromOwnedSlot(ARealm, GWeakMapSharedSlot);
 end;
 
 function TGocciaWeakMapValue.TryGetEntry(const AKey: TGocciaValue;

--- a/source/units/Goccia.Values.WeakMapValue.pas
+++ b/source/units/Goccia.Values.WeakMapValue.pas
@@ -9,6 +9,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ClassValue,
   Goccia.Values.ObjectValue,
@@ -46,6 +47,8 @@ type
     procedure SweepWeakReferences; override;
 
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function GetSharedPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; static;
 
     property Entries: TGocciaWeakMapStorage read FEntries;
   end;
@@ -60,7 +63,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Realm,
   Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.IteratorSupport,
@@ -145,6 +147,19 @@ begin
   end;
   if Assigned(Shared) then
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+class function TGocciaWeakMapValue.GetSharedPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GWeakMapSharedSlot));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
 end;
 
 function TGocciaWeakMapValue.TryGetEntry(const AKey: TGocciaValue;

--- a/source/units/Goccia.Values.WeakSetValue.pas
+++ b/source/units/Goccia.Values.WeakSetValue.pas
@@ -9,6 +9,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.ObjectModel,
+  Goccia.Realm,
   Goccia.SharedPrototype,
   Goccia.Values.ClassValue,
   Goccia.Values.ObjectValue,
@@ -41,6 +42,8 @@ type
     procedure SweepWeakReferences; override;
 
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function GetSharedPrototypeForRealm(
+      const ARealm: TGocciaRealm): TGocciaObjectValue; static;
 
     property Items: TGocciaWeakSetStorage read FItems;
   end;
@@ -55,7 +58,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.Realm,
   Goccia.Utils,
   Goccia.Values.ErrorHelper,
   Goccia.Values.IteratorSupport,
@@ -137,6 +139,19 @@ begin
   end;
   if Assigned(Shared) then
     ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+class function TGocciaWeakSetValue.GetSharedPrototypeForRealm(
+  const ARealm: TGocciaRealm): TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Result := nil;
+  if not Assigned(ARealm) then
+    Exit;
+  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GWeakSetSharedSlot));
+  if Assigned(Shared) then
+    Result := Shared.Prototype;
 end;
 
 function TGocciaWeakSetValue.ContainsValue(const AValue: TGocciaValue): Boolean;

--- a/source/units/Goccia.Values.WeakSetValue.pas
+++ b/source/units/Goccia.Values.WeakSetValue.pas
@@ -143,15 +143,8 @@ end;
 
 class function TGocciaWeakSetValue.GetSharedPrototypeForRealm(
   const ARealm: TGocciaRealm): TGocciaObjectValue;
-var
-  Shared: TGocciaSharedPrototype;
 begin
-  Result := nil;
-  if not Assigned(ARealm) then
-    Exit;
-  Shared := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GWeakSetSharedSlot));
-  if Assigned(Shared) then
-    Result := Shared.Prototype;
+  Result := GetSharedPrototypeFromOwnedSlot(ARealm, GWeakSetSharedSlot);
 end;
 
 function TGocciaWeakSetValue.ContainsValue(const AValue: TGocciaValue): Boolean;

--- a/tests/built-ins/Map/prototype/entries.js
+++ b/tests/built-ins/Map/prototype/entries.js
@@ -31,6 +31,7 @@ test("entries returns an iterator with next()", () => {
 });
 
 test("Map default iterator is entries", () => {
+  expect(Map.prototype[Symbol.iterator]).toBe(Map.prototype.entries);
   const map = new Map([["a", 1], ["b", 2]]);
   const iter = map[Symbol.iterator]();
   const first = iter.next().value;

--- a/tests/built-ins/Map/prototype/getOrInsertComputed.js
+++ b/tests/built-ins/Map/prototype/getOrInsertComputed.js
@@ -35,6 +35,17 @@ describe.runIf(hasGoccia)("Map.prototype.getOrInsertComputed", () => {
     expect(receivedKey).toBe("myKey");
   });
 
+  test("callback receives canonical positive zero", () => {
+    const map = new Map();
+    let receivedKey;
+    map.getOrInsertComputed(-0, (key) => {
+      receivedKey = key;
+      return "value";
+    });
+    expect(Object.is(receivedKey, 0)).toBe(true);
+    expect(Object.is(receivedKey, -0)).toBe(false);
+  });
+
   test("throws TypeError for non-callable callback", () => {
     const map = new Map();
     expect(() => map.getOrInsertComputed("key", "not a function")).toThrow(

--- a/tests/built-ins/Map/prototype/size.js
+++ b/tests/built-ins/Map/prototype/size.js
@@ -36,3 +36,20 @@ test("size is 0 after clear", () => {
   map.clear();
   expect(map.size).toBe(0);
 });
+
+test("size is a configurable non-enumerable prototype getter", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(Map.prototype, "size");
+  expect(typeof descriptor.get).toBe("function");
+  expect(descriptor.get.name).toBe("get size");
+  expect(descriptor.get.length).toBe(0);
+  expect(descriptor.set).toBe(undefined);
+  expect(descriptor.enumerable).toBe(false);
+  expect(descriptor.configurable).toBe(true);
+});
+
+test("size getter rejects values without Map data", () => {
+  const getter = Object.getOwnPropertyDescriptor(Map.prototype, "size").get;
+  expect(() => getter.call(Map.prototype)).toThrow(TypeError);
+  expect(() => getter.call(new Set())).toThrow(TypeError);
+  expect(() => getter.call(new WeakMap())).toThrow(TypeError);
+});

--- a/tests/built-ins/Reflect/construct/native-constructors.js
+++ b/tests/built-ins/Reflect/construct/native-constructors.js
@@ -144,6 +144,22 @@ describe("Reflect.construct with native ArrayBuffer constructor", () => {
   });
 });
 
+describe("Reflect.construct with native collection constructors", () => {
+  [Map, Set, WeakMap, WeakSet].forEach((Constructor) => {
+    test(`${Constructor.name} resolves the fallback realm after reading newTarget.prototype`, () => {
+      const revocable = Proxy.revocable(function () {}, {
+        get(target, property) {
+          expect(property).toBe("prototype");
+          revocable.revoke();
+          return null;
+        },
+      });
+
+      expect(() => Reflect.construct(Constructor, [], revocable.proxy)).toThrow(TypeError);
+    });
+  });
+});
+
 describe("Reflect.construct with Proxy forwarding newTarget", () => {
   test("Proxy with no construct trap forwards newTarget to native Error", () => {
     class Custom {}

--- a/tests/built-ins/Set/prototype/intersection.js
+++ b/tests/built-ins/Set/prototype/intersection.js
@@ -38,14 +38,16 @@ describe("Set.prototype.intersection", () => {
     expect(result.size).toBe(2);
   });
 
-  test("does not revisit a member deleted then re-added during a has callback", () => {
+  test("revisits a member deleted then re-added during a has callback", () => {
     const a = new Set([1, 2, 3]);
+    const seen = [];
     const setLike = {
       size: 5,
       has(value) {
-        if (value === 1) {
-          a.delete(3);
-          a.add(3);
+        seen.push(value);
+        if (value === 3) {
+          a.delete(2);
+          a.add(2);
         }
         return true;
       },
@@ -54,12 +56,11 @@ describe("Set.prototype.intersection", () => {
       },
     };
     const result = a.intersection(setLike);
-    // 3's original entry was emptied and the re-add is past the start-of-call
-    // bound, so it is not visited.
+    expect(seen).toEqual([1, 2, 3, 2]);
     expect(result.has(1)).toBe(true);
     expect(result.has(2)).toBe(true);
-    expect(result.has(3)).toBe(false);
-    expect(result.size).toBe(2);
+    expect(result.has(3)).toBe(true);
+    expect(result.size).toBe(3);
   });
 
   test("accepts set-like object", () => {

--- a/tests/built-ins/Set/prototype/isDisjointFrom.js
+++ b/tests/built-ins/Set/prototype/isDisjointFrom.js
@@ -50,6 +50,24 @@ describe("Set.prototype.isDisjointFrom", () => {
     expect(hasCalls).toBe(0);
   });
 
+  test("visits members appended by the set-like has callback", () => {
+    const receiver = new Set([1]);
+    const seen = [];
+    const setLike = {
+      size: 2,
+      has(value) {
+        seen.push(value);
+        if (value === 1) receiver.add(2);
+        return false;
+      },
+      keys() {
+        return [].values();
+      },
+    };
+    expect(receiver.isDisjointFrom(setLike)).toBe(true);
+    expect(seen).toEqual([1, 2]);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const isDisjointFrom = Set.prototype.isDisjointFrom;
     expect(() => isDisjointFrom.call(Set.prototype, new Set())).toThrow(TypeError);

--- a/tests/built-ins/Set/prototype/isSubsetOf.js
+++ b/tests/built-ins/Set/prototype/isSubsetOf.js
@@ -36,6 +36,27 @@ describe("Set.prototype.isSubsetOf", () => {
     expect(new Set([1, 4]).isSubsetOf(setLike)).toBe(false);
   });
 
+  test("visits members appended by the set-like has callback", () => {
+    const receiver = new Set([1, 2, 3]);
+    const additions = [4, 5];
+    const seen = [];
+    const setLike = {
+      size: 5,
+      has(value) {
+        seen.push(value);
+        receiver.delete(value);
+        if (additions.length > 0) receiver.add(additions.shift());
+        return true;
+      },
+      keys() {
+        return [].values();
+      },
+    };
+    expect(receiver.isSubsetOf(setLike)).toBe(true);
+    expect(seen).toEqual([1, 2, 3, 4, 5]);
+    expect(receiver.size).toBe(0);
+  });
+
   test("throws TypeError when called on non-Set", () => {
     const isSubsetOf = Set.prototype.isSubsetOf;
     expect(() => isSubsetOf.call(Set.prototype, new Set())).toThrow(TypeError);

--- a/tests/built-ins/Set/prototype/size.js
+++ b/tests/built-ins/Set/prototype/size.js
@@ -36,3 +36,19 @@ test("size is 0 after clear", () => {
   set.clear();
   expect(set.size).toBe(0);
 });
+
+test("size is a configurable non-enumerable prototype getter", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(Set.prototype, "size");
+  expect(typeof descriptor.get).toBe("function");
+  expect(descriptor.get.name).toBe("get size");
+  expect(descriptor.get.length).toBe(0);
+  expect(descriptor.set).toBe(undefined);
+  expect(descriptor.enumerable).toBe(false);
+  expect(descriptor.configurable).toBe(true);
+});
+
+test("size getter rejects values without Set data", () => {
+  const getter = Object.getOwnPropertyDescriptor(Set.prototype, "size").get;
+  expect(() => getter.call(Set.prototype)).toThrow(TypeError);
+  expect(() => getter.call(new Map())).toThrow(TypeError);
+});

--- a/tests/built-ins/Set/prototype/symmetricDifference.js
+++ b/tests/built-ins/Set/prototype/symmetricDifference.js
@@ -20,6 +20,26 @@ describe("Set.prototype.symmetricDifference", () => {
     expect(a.symmetricDifference(b).size).toBe(0);
   });
 
+  test("copies the receiver after acquiring the other keys iterator", () => {
+    const receiver = new Set([1, 2, 3]);
+    const setLike = {
+      size: 0,
+      has() {
+        return false;
+      },
+      keys() {
+        return {
+          get next() {
+            receiver.clear();
+            receiver.add(4);
+            return () => ({ done: true });
+          },
+        };
+      },
+    };
+    expect([...receiver.symmetricDifference(setLike)]).toEqual([4]);
+  });
+
   test("accepts set-like object", () => {
     const setLike = {
       size: 3,

--- a/tests/built-ins/Set/prototype/union.js
+++ b/tests/built-ins/Set/prototype/union.js
@@ -27,6 +27,26 @@ describe("Set.prototype.union", () => {
     expect(result.size).toBe(0);
   });
 
+  test("copies the receiver after acquiring the other keys iterator", () => {
+    const receiver = new Set([1, 2, 3]);
+    const setLike = {
+      size: 0,
+      has() {
+        return false;
+      },
+      keys() {
+        return {
+          get next() {
+            receiver.clear();
+            receiver.add(4);
+            return () => ({ done: true });
+          },
+        };
+      },
+    };
+    expect([...receiver.union(setLike)]).toEqual([4]);
+  });
+
   test("accepts set-like object", () => {
     const setLike = {
       size: "3",

--- a/tests/built-ins/Set/prototype/values.js
+++ b/tests/built-ins/Set/prototype/values.js
@@ -30,11 +30,13 @@ test("values returns an iterator with next()", () => {
 });
 
 test("keys is same as values for Set", () => {
+  expect(Set.prototype.keys).toBe(Set.prototype.values);
   const set = new Set([1, 2, 3]);
   expect([...set.keys()]).toEqual([1, 2, 3]);
 });
 
 test("Set default iterator is values", () => {
+  expect(Set.prototype[Symbol.iterator]).toBe(Set.prototype.values);
   const set = new Set([1, 2, 3]);
   const iter = set[Symbol.iterator]();
   expect(iter.next().value).toBe(1);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add generic object-model aliases and realm-aware native intrinsic prototype resolution so collection built-ins preserve required function identity and cross-realm constructor behavior.
- Centralize realm-owned shared-prototype lookup so Map, Set, WeakMap, and WeakSet use one nil-safe, type-checked helper.
- Preserve the specified `GetPrototypeFromConstructor` ordering by reading `newTarget.prototype` before resolving its fallback realm, including self-revoking proxy constructors.
- Expose real Map/Set size accessors, canonicalize Map insertion keys before callbacks, and align Set composition/predicate iteration with ES2026 mutation and iterator-acquisition semantics.
- Add focused regression coverage and document the reusable object-model patterns.
- Scope is limited to the six collection-owned test262 paths; incidental collection-name matches elsewhere are not included. No ADR was needed for these reversible extensions.
- Closes #841.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation performed:

- `./build.pas --clean tests` — all Pascal test programs built successfully
- `./build/Goccia.SharedPrototypeRealmReuse.Test` — 1/1 passed
- `./build/Goccia.Realm.Test` — 19/19 passed, including mismatched owned-slot type coverage
- `./build.pas --clean testrunner`
- `./build/GocciaTestRunner tests` — 11,288/11,288 tests passed
- `./build/GocciaTestRunner tests --mode=bytecode` — 11,288/11,288 tests passed
- Focused self-revoking `newTarget` regression for Map, Set, WeakMap, and WeakSet — 29/29 tests passed in both modes
- `./build.pas --clean loaderbare`
- Pinned test262 SHA `64ff467c0c1d60c077995bb7c5f93a9d8cc8ade1`: Map, Set, WeakMap, WeakSet, staging Map, and staging Set — 828/828 passed in interpreted mode and 828/828 passed in bytecode mode, with zero wrapper-infrastructure failures
- `./format.pas --check` — 381 files formatted
- Pre-commit documentation, truncation-guard, Pascal-format, and Markdown checks passed
