### PR TITLE
test(cli): make GC pressure check architecture-independent

### DIFF
--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -795,7 +795,9 @@ console.log("--max-memory (bytecode loop pressure reclaims)...");
   ].join("\n");
   const { exitCode, json, stderr } = runLoaderJson(src, [
     "--mode=bytecode",
-    "--max-memory=100000000",
+    // Keep the pressure threshold below both 32-bit and 64-bit allocation
+    // totals while leaving enough room for the loop's live object graph.
+    "--max-memory=20000000",
     "--compat-asi",
     "--compat-traditional-for-loop",
   ], { timeout: 30_000 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Calibrate the bytecode loop-pressure CLI test to a 20 MB heap limit so it triggers automatic collection on both 32-bit and 64-bit targets.
- Preserve the test's safety contract: the workload must complete with result `500000` and report at least one collection without exhausting the live heap.
- Keep the change limited to test calibration; the recurring Win32 failure predated the collection conformance merge and did not indicate a runtime GC regression.

## Testing

- [x] Verified no regressions and confirmed the bugfix in the complete CLI harness and both end-to-end JavaScript execution modes (11,288/11,288 tests passed in interpreter and bytecode modes)
- [ ] Updated documentation (not required for this test-only calibration)
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (not applicable; no Pascal source changed)
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change ([full manually dispatched CI passed](https://github.com/frostney/GocciaScript/actions/runs/29208368917), including Win32 interpreted and bytecode benchmark jobs)
