### PR TITLE
feat(sandbox): track filesystem timestamps

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,10 @@ _Avoid_: Runtime, built-in surface, host surface.
 An explicitly imported snapshot used to initialise a sandbox-visible filesystem. Top-level sandbox seeds copy from host paths or inline seed config entries; nested child sandbox seeds copy from the parent virtual filesystem or inline child entries. A seed baseline is not a live mount and does not make the source path ambiently available to running source.
 _Avoid_: Mount, host filesystem access.
 
+**Metadata diff**:
+An opt-in sandbox diff dimension that reports timestamp changes independently from content and namespace changes. It compares a path's access, modification, change, and birth timestamps against the seed baseline without turning timestamp-only activity into a content modification.
+_Avoid_: Default diff, content diff.
+
 **Sandbox filesystem error**:
 A JavaScript `Error` reported by a sandbox runtime extension when a virtual filesystem operation fails. It carries a stable error code and operation/path context plus a target-appropriate numeric errno. It is shared by synchronous and promise APIs, and by callback APIs when installed.
 _Avoid_: Raw virtual filesystem exception, host filesystem error.

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -459,15 +459,15 @@ Nested scripts share the current sandbox filesystem unless child isolation is re
 const child = runScript("/child.js", {
   sandbox: true,
   seed: ["/child.js", { from: "/fixtures", to: "/fixtures" }],
-  diff: true
+  diffMetadata: true
 });
 
-const shellChild = await $`goccia --sandbox --seed /child.js --diff /child.js`.text();
+const shellChild = await $`goccia --sandbox --seed /child.js --diff-metadata /child.js`.text();
 ```
 
-Child seed entries are copied from the parent virtual filesystem, not the host filesystem. Child writes are discarded with the child VFS; request `diff: true` or shell `--diff` to inspect them.
+Child seed entries are copied from the parent virtual filesystem, not the host filesystem. Child writes are discarded with the child VFS; request `diff: true` or shell `--diff` to inspect them. Use nested `diffMetadata: true` or shell `--diff-metadata` to include timestamp changes; either form implies a diff.
 
-Diff output is explicit. `--diff` prints the diff after execution, `--diff-output=<host-path>` writes it to a host file, and `--diff-format=json|unified` selects the format. JSON is the default.
+Diff output is explicit. `--diff` prints the diff after execution, `--diff-output=<host-path>` writes it to a host file, and `--diff-format=json|unified` selects the format. JSON is the default. Metadata is omitted unless `--diff-metadata` is present. In JSON it appears as a separate `metadataChanges` array whose per-path `changes` object contains only changed `atimeMs`, `mtimeMs`, `ctimeMs`, and `birthtimeMs` fields; timestamp-only changes never appear as content modifications.
 
 ## Build Output
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -693,7 +693,7 @@ The `"fs"` module operates on the sandbox virtual filesystem. It follows a Node.
 | `fs.appendFileSync(path, data)` | Append UTF-8 string data or bytes from `Uint8Array` |
 | `fs.mkdirSync(path, options?)` | Create a directory; `{ recursive: true }` creates parents |
 | `fs.readdirSync(path)` | Return child names |
-| `fs.statSync(path)` | Return `{ path, name, type, size, mtimeMs, isFile(), isDirectory() }` |
+| `fs.statSync(path)` | Return a Stats snapshot with `path`, `name`, `type`, `size`, `atimeMs`, `mtimeMs`, `ctimeMs`, `birthtimeMs`, lazy Date accessors, and type predicates |
 | `fs.existsSync(path)` | Return whether a sandbox path exists |
 | `fs.rmSync(path, options?)` | Delete a file or directory; `{ recursive: true }` removes non-empty directories |
 | `fs.renameSync(from, to)` | Move or rename a sandbox path |
@@ -701,6 +701,19 @@ The `"fs"` module operates on the sandbox virtual filesystem. It follows a Node.
 | `fs.promises` | Promise-returning versions of the same operations |
 
 `readFileSync` returns a `Uint8Array` by default so binary seed entries can round-trip without text coercion.
+
+Stats snapshots expose `atime`, `mtime`, `ctime`, and `birthtime` as lazy Date
+accessors on a realm-owned shared prototype. Each access returns a fresh Date;
+the corresponding `*Ms` number remains part of the original snapshot.
+`isFile()` and `isDirectory()` report the virtual node kind, while
+`isSymbolicLink()` always returns `false` because the sandbox VFS does not
+support symbolic links.
+
+The VFS tracks the four timestamps independently. Reads advance access time;
+writes and truncation advance modification and change time; renames preserve
+access, modification, and birth time while advancing change time and affected
+directory metadata. Birth time is immutable. Copies receive fresh timestamps,
+while VFS forks used for baselines preserve the source timestamps.
 
 Filesystem failures are real JavaScript `Error` objects with Node-shaped
 `code`, `errno`, `path`, `syscall`, and optional `dest` metadata. Synchronous
@@ -741,6 +754,7 @@ const child = runScript("/child.js", {
     { path: "/data.bin", base64: "AQID" },
   ],
   diff: true,
+  diffMetadata: true,
   diffFormat: "json",
 });
 
@@ -748,7 +762,7 @@ console.log(child.stdout);
 console.log(child.diff);
 ```
 
-`seed` accepts one entry or an array. A string entry copies that parent-VFS path to the same child path. `{ from, to }` copies a parent file or directory into a child target path. When a file seed target ends in `/`, the file is copied under that directory with its source name. Inline `{ path, text }` and `{ path, base64 }` entries create child-only files.
+`seed` accepts one entry or an array. A string entry copies that parent-VFS path to the same child path. `{ from, to }` copies a parent file or directory into a child target path. When a file seed target ends in `/`, the file is copied under that directory with its source name. Inline `{ path, text }` and `{ path, base64 }` entries create child-only files. `diffMetadata: true` implies an isolated diff and adds timestamp changes as a separate metadata dimension; ordinary diffs remain content/namespace-only.
 
 The sandbox shell exposes the same child mode:
 
@@ -756,7 +770,7 @@ The sandbox shell exposes the same child mode:
 const out = await $`goccia --sandbox --seed /child.js --seed /lib=/lib --diff /child.js`.text();
 ```
 
-Shell `goccia` supports `--sandbox`, repeatable `--seed <from[=to]>` / `--seed=<from[=to]>`, `--diff`, and `--diff-format json|unified`. Child diffs are appended to command stdout only when `--diff` is present.
+Shell `goccia` supports `--sandbox`, repeatable `--seed <from[=to]>` / `--seed=<from[=to]>`, `--diff`, `--diff-metadata`, and `--diff-format json|unified`. `--diff-metadata` implies a diff. Child diffs are appended to command stdout only when a diff is requested.
 
 ### FFI (`Goccia.Builtins.GlobalFFI.pas`)
 

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -3247,6 +3247,11 @@ console.log("SandboxRunner: fs Stats expose realm-owned lazy Date metadata in ev
           path: "/main.js",
           text: [
             'import fs from "fs";',
+            'const intrinsicStat = fs.statSync("/tracked.txt");',
+            'globalThis.Date = class ReplacementDate { constructor() { this.replacement = true; } };',
+            'const intrinsicMtime = intrinsicStat.mtime;',
+            'const intrinsicDateValid = typeof intrinsicMtime.getTime === "function" && !Object.hasOwn(intrinsicMtime, "replacement");',
+            'globalThis.Date = Object.getPrototypeOf(intrinsicMtime).constructor;',
             'const syncStat = fs.statSync("/tracked.txt");',
             'const promiseStat = await fs.promises.stat("/tracked.txt");',
             'const checks = (stat) => {',
@@ -3279,6 +3284,7 @@ console.log("SandboxRunner: fs Stats expose realm-owned lazy Date metadata in ev
             'console.log("sync-stats:" + valid(syncStat));',
             'console.log("promise-stats:" + valid(promiseStat));',
             'console.log("shared-stats-prototype:" + (Object.getPrototypeOf(syncStat) === Object.getPrototypeOf(promiseStat)));',
+            'console.log("intrinsic-stats-date:" + intrinsicDateValid);',
           ].join("\n"),
         },
         { path: "/tracked.txt", text: "tracked" },
@@ -3296,7 +3302,12 @@ console.log("SandboxRunner: fs Stats expose realm-owned lazy Date metadata in ev
       const stdout = normalizeLineEndings(proc.stdout.toString());
       if (proc.exitCode !== 0)
         throw new Error(`SandboxRunner ${label} Stats run should exit 0, got ${proc.exitCode}: ${proc.stderr.toString()}`);
-      for (const expected of ["sync-stats:true", "promise-stats:true", "shared-stats-prototype:true"]) {
+      for (const expected of [
+        "sync-stats:true",
+        "promise-stats:true",
+        "shared-stats-prototype:true",
+        "intrinsic-stats-date:true",
+      ]) {
         if (!containsLine(`\n${stdout}`, expected))
           throw new Error(`SandboxRunner ${label} Stats stdout should include ${expected}, got: ${stdout}`);
       }

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -3223,11 +3223,139 @@ console.log("SandboxRunner: inline seeds, fs, $, runScript, and diffs...");
       if (!stdout.includes(expected))
         throw new Error(`SandboxRunner interpreter stdout should include ${JSON.stringify(expected)}, got: ${stdout}`);
     }
-    const changes = JSON.parse(readFileSync(diff, "utf-8")).changes;
+    const defaultDiff = JSON.parse(readFileSync(diff, "utf-8"));
+    const changes = defaultDiff.changes;
+    if ("metadataChanges" in defaultDiff)
+      throw new Error(`SandboxRunner default diff should omit metadataChanges, got ${JSON.stringify(defaultDiff)}`);
     if (!changes.some((c: any) => c.kind === "create" && c.path === "/hello.txt"))
       throw new Error(`SandboxRunner diff should include /hello.txt create, got ${JSON.stringify(changes)}`);
     if (!changes.some((c: any) => c.kind === "create" && c.path === "/child.out"))
       throw new Error(`SandboxRunner diff should include /child.out create, got ${JSON.stringify(changes)}`);
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("SandboxRunner: fs Stats expose realm-owned lazy Date metadata in every execution mode...");
+{
+  const tmp = makeTmp();
+  try {
+    const seed = join(tmp, "seed.json");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/main.js",
+          text: [
+            'import fs from "fs";',
+            'const syncStat = fs.statSync("/tracked.txt");',
+            'const promiseStat = await fs.promises.stat("/tracked.txt");',
+            'const checks = (stat) => {',
+            'const firstAtime = stat.atime;',
+            'const secondAtime = stat.atime;',
+            'return [',
+            '  stat.atime instanceof Date,',
+            '  stat.mtime instanceof Date,',
+            '  stat.ctime instanceof Date,',
+            '  stat.birthtime instanceof Date,',
+            '  stat.atime.getTime() === Math.trunc(stat.atimeMs + 0.5),',
+            '  stat.mtime.getTime() === Math.trunc(stat.mtimeMs + 0.5),',
+            '  stat.ctime.getTime() === Math.trunc(stat.ctimeMs + 0.5),',
+            '  stat.birthtime.getTime() === Math.trunc(stat.birthtimeMs + 0.5),',
+            '  typeof stat.atimeMs === "number",',
+            '  typeof stat.mtimeMs === "number",',
+            '  typeof stat.ctimeMs === "number",',
+            '  typeof stat.birthtimeMs === "number",',
+            '  stat.isFile(),',
+            '  !stat.isDirectory(),',
+            '  !stat.isSymbolicLink(),',
+            '  firstAtime !== secondAtime,',
+            '  !Object.hasOwn(stat, "atime"),',
+            '  !Object.hasOwn(stat, "isFile"),',
+            '];',
+            '};',
+            'const valid = (stat) => checks(stat).every(Boolean);',
+            'if (!valid(syncStat)) console.log("sync-checks:" + checks(syncStat).join(","));',
+            'if (!valid(promiseStat)) console.log("promise-checks:" + checks(promiseStat).join(","));',
+            'console.log("sync-stats:" + valid(syncStat));',
+            'console.log("promise-stats:" + valid(promiseStat));',
+            'console.log("shared-stats-prototype:" + (Object.getPrototypeOf(syncStat) === Object.getPrototypeOf(promiseStat)));',
+          ].join("\n"),
+        },
+        { path: "/tracked.txt", text: "tracked" },
+      ],
+    }));
+
+    for (const [label, extraArgs] of [
+      ["interpreter", []],
+      ["bytecode", ["--mode=bytecode"]],
+    ] as const) {
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed-config=${seed}`, "--source-type=module", ...extraArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const stdout = normalizeLineEndings(proc.stdout.toString());
+      if (proc.exitCode !== 0)
+        throw new Error(`SandboxRunner ${label} Stats run should exit 0, got ${proc.exitCode}: ${proc.stderr.toString()}`);
+      for (const expected of ["sync-stats:true", "promise-stats:true", "shared-stats-prototype:true"]) {
+        if (!containsLine(`\n${stdout}`, expected))
+          throw new Error(`SandboxRunner ${label} Stats stdout should include ${expected}, got: ${stdout}`);
+      }
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("SandboxRunner: metadata diffing is opt-in and separate from content changes...");
+{
+  const tmp = makeTmp();
+  try {
+    const seed = join(tmp, "seed.json");
+    const diff = join(tmp, "diff.json");
+    const unifiedDiff = join(tmp, "diff.patch");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/main.js",
+          text: [
+            'import fs from "fs";',
+            'for (const i of Array.from({ length: 10000 }, (_, index) => index)) { Math.sqrt(i); }',
+            'const text = fs.readFileSync("/tracked.txt", "utf8");',
+            'fs.writeFileSync("/tracked.txt", text);',
+          ].join("\n"),
+        },
+        { path: "/tracked.txt", text: "unchanged" },
+      ],
+    }));
+
+    const proc = Bun.spawnSync(
+      [SANDBOXRUNNER, "/main.js", `--seed-config=${seed}`, "--source-type=module", "--diff-metadata", `--diff-output=${diff}`],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (proc.exitCode !== 0)
+      throw new Error(`SandboxRunner metadata diff should exit 0, got ${proc.exitCode}: ${proc.stderr.toString()}`);
+    const parsed = JSON.parse(readFileSync(diff, "utf-8"));
+    if (parsed.changes.some((change: any) => change.path === "/tracked.txt"))
+      throw new Error(`Timestamp-only writes must not become content modifications, got ${JSON.stringify(parsed.changes)}`);
+    const tracked = parsed.metadataChanges.find((change: any) => change.path === "/tracked.txt");
+    if (!tracked)
+      throw new Error(`Metadata diff should include /tracked.txt, got ${JSON.stringify(parsed.metadataChanges)}`);
+    const fields = Object.keys(tracked.changes).sort();
+    if (JSON.stringify(fields) !== JSON.stringify(["atimeMs", "ctimeMs", "mtimeMs"]))
+      throw new Error(`Metadata diff should contain only changed timestamp fields, got ${JSON.stringify(tracked)}`);
+    if ("size" in tracked.changes || "type" in tracked.changes || "birthtimeMs" in tracked.changes)
+      throw new Error(`Metadata diff should not duplicate size/type or change birthtime, got ${JSON.stringify(tracked)}`);
+
+    const unifiedProc = Bun.spawnSync(
+      [SANDBOXRUNNER, "/main.js", `--seed-config=${seed}`, "--source-type=module", "--diff-metadata", "--diff-format=unified", `--diff-output=${unifiedDiff}`],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (unifiedProc.exitCode !== 0)
+      throw new Error(`SandboxRunner unified metadata diff should exit 0, got ${unifiedProc.exitCode}: ${unifiedProc.stderr.toString()}`);
+    const unified = readFileSync(unifiedDiff, "utf-8");
+    if (!unified.includes("@@ sandbox metadata changed /tracked.txt @@") ||
+        unified.includes("@@ sandbox file changed @@"))
+      throw new Error(`Unified metadata diff should keep timestamp-only changes separate, got: ${unified}`);
   } finally {
     clean(tmp);
   }
@@ -3542,15 +3670,19 @@ console.log("SandboxRunner: nested sandbox execution seeds from parent VFS witho
             '  diff: true,',
             '});',
             'const noWrite = runScript("/readonly.js", { sandbox: true, seed: ["/readonly.js"], diff: true, diffFormat: "unified" });',
+            'const metadataOnly = runScript("/metadata.js", { sandbox: true, seed: ["/metadata.js", "/metadata.txt"], diffMetadata: true });',
             'console.log(child.stdout.trim());',
             'console.log(child.diff.includes(\'"path": "/child-only.txt"\'));',
             'console.log(noWrite.diff === "");',
+            'console.log(JSON.parse(metadataOnly.diff).changes.length === 0);',
+            'console.log(JSON.parse(metadataOnly.diff).metadataChanges.some((change) => change.path === "/metadata.txt" && "ctimeMs" in change.changes && "mtimeMs" in change.changes));',
             'console.log(fs.existsSync("/child-only.txt"));',
             'console.log(fs.readFileSync("/parent.txt", "utf8"));',
-            'const shellChild = await $`goccia --sandbox --seed /child.js --seed /parent.txt --seed /parent.txt=/shell-out/ --diff /child.js`.text();',
+            'const shellChild = await $`goccia --sandbox --seed /child.js --seed /parent.txt --seed /parent.txt=/shell-out/ --diff-metadata /child.js`.text();',
             'console.log(shellChild.includes("parent-seed"));',
             'console.log(shellChild.includes("shell-out:parent-seed"));',
             'console.log(shellChild.includes(\'"path": "/child-only.txt"\'));',
+            'console.log(shellChild.includes(\'"metadataChanges"\'));',
             'console.log(fs.existsSync("/child-only.txt"));',
           ].join("\n"),
         },
@@ -3568,6 +3700,16 @@ console.log("SandboxRunner: nested sandbox execution seeds from parent VFS witho
           ].join("\n"),
         },
         { path: "/readonly.js", text: "1;" },
+        {
+          path: "/metadata.js",
+          text: [
+            'import fs from "fs";',
+            'for (const i of Array.from({ length: 10000 }, (_, index) => index)) { Math.sqrt(i); }',
+            'const text = fs.readFileSync("/metadata.txt", "utf8");',
+            'fs.writeFileSync("/metadata.txt", text);',
+          ].join("\n"),
+        },
+        { path: "/metadata.txt", text: "metadata" },
         { path: "/parent.txt", text: "parent-seed" },
       ],
     }));

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -3333,6 +3333,7 @@ console.log("SandboxRunner: metadata diffing is opt-in and separate from content
             'for (const i of Array.from({ length: 10000 }, (_, index) => index)) { Math.sqrt(i); }',
             'const text = fs.readFileSync("/tracked.txt", "utf8");',
             'fs.writeFileSync("/tracked.txt", text);',
+            'fs.mkdirSync("/created");',
           ].join("\n"),
         },
         { path: "/tracked.txt", text: "unchanged" },
@@ -3346,6 +3347,8 @@ console.log("SandboxRunner: metadata diffing is opt-in and separate from content
     if (proc.exitCode !== 0)
       throw new Error(`SandboxRunner metadata diff should exit 0, got ${proc.exitCode}: ${proc.stderr.toString()}`);
     const parsed = JSON.parse(readFileSync(diff, "utf-8"));
+    if (parsed.metadataChanges.some((change: any) => change.path === "/"))
+      throw new Error(`Metadata diff must not expose the implicit root, got ${JSON.stringify(parsed.metadataChanges)}`);
     if (parsed.changes.some((change: any) => change.path === "/tracked.txt"))
       throw new Error(`Timestamp-only writes must not become content modifications, got ${JSON.stringify(parsed.changes)}`);
     const tracked = parsed.metadataChanges.find((change: any) => change.path === "/tracked.txt");
@@ -3365,7 +3368,8 @@ console.log("SandboxRunner: metadata diffing is opt-in and separate from content
       throw new Error(`SandboxRunner unified metadata diff should exit 0, got ${unifiedProc.exitCode}: ${unifiedProc.stderr.toString()}`);
     const unified = readFileSync(unifiedDiff, "utf-8");
     if (!unified.includes("@@ sandbox metadata changed /tracked.txt @@") ||
-        unified.includes("@@ sandbox file changed @@"))
+        unified.includes("@@ sandbox file changed @@") ||
+        unified.includes("@@ sandbox metadata changed / @@"))
       throw new Error(`Unified metadata diff should keep timestamp-only changes separate, got: ${unified}`);
   } finally {
     clean(tmp);

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -52,6 +52,7 @@ type
     FSeedPaths: TRepeatableOption;
     FSeedConfigFiles: TRepeatableOption;
     FDiff: TFlagOption;
+    FDiffMetadata: TFlagOption;
     FDiffFormat: TStringOption;
     FDiffOutput: TStringOption;
     FPrint: TFlagOption;
@@ -203,6 +204,8 @@ begin
   FSeedConfigFiles := AddRepeatable('seed-config',
     'Import sandbox seed entries from a JSON configuration file');
   FDiff := AddFlag('diff', 'Print sandbox filesystem changes after execution');
+  FDiffMetadata := AddFlag('diff-metadata',
+    'Include timestamp changes in sandbox filesystem diffs');
   FDiffFormat := AddString('diff-format',
     'Diff format: json or unified (default: json)');
   FDiffOutput := AddString('diff-output', 'Write diff output to a host file');
@@ -836,9 +839,9 @@ begin
     begin
       Result.DiffRequested := True;
       if AOptions.DiffFormat = 'unified' then
-        Result.Diff := ChildContext.DiffUnified
+        Result.Diff := ChildContext.DiffUnified(AOptions.DiffMetadata)
       else
-        Result.Diff := ChildContext.DiffJson;
+        Result.Diff := ChildContext.DiffJson(AOptions.DiffMetadata);
     end;
   except
     on E: Exception do
@@ -857,12 +860,13 @@ var
   DiffText: string;
   OutFile: TextFile;
 begin
-  if not FDiff.Present and not FDiffOutput.Present then
+  if not FDiff.Present and not FDiffMetadata.Present and
+     not FDiffOutput.Present then
     Exit;
   if FDiffFormat.ValueOr('json') = 'unified' then
-    DiffText := FContext.DiffUnified
+    DiffText := FContext.DiffUnified(FDiffMetadata.Present)
   else
-    DiffText := FContext.DiffJson;
+    DiffText := FContext.DiffJson(FDiffMetadata.Present);
 
   if FDiffOutput.Present then
   begin

--- a/source/shared/SandboxVirtualFileSystem.Test.pas
+++ b/source/shared/SandboxVirtualFileSystem.Test.pas
@@ -14,9 +14,11 @@ uses
 type
   TDeterministicSandboxClock = class(TSandboxFsClock)
   private
+    FCallCount: Integer;
     FValue: TDateTime;
   public
     function Now: TDateTime; override;
+    property CallCount: Integer read FCallCount;
     property Value: TDateTime read FValue write FValue;
   end;
 
@@ -33,6 +35,7 @@ type
 
     procedure TestTracksIndependentFileTimestamps;
     procedure TestCopyRenameAndForkMetadata;
+    procedure TestForkDoesNotReadClock;
     procedure TestSnapshotReadsDoNotAdvanceAccessTime;
     procedure TestDirectoryEntryChangesUpdateParentMetadata;
     procedure TestDefaultClockUsesUnixEpoch;
@@ -40,6 +43,7 @@ type
 
 function TDeterministicSandboxClock.Now: TDateTime;
 begin
+  Inc(FCallCount);
   Result := FValue;
 end;
 
@@ -49,6 +53,7 @@ begin
     TestTracksIndependentFileTimestamps);
   Test('Copy, rename, and fork preserve their timestamp contracts',
     TestCopyRenameAndForkMetadata);
+  Test('Fork does not read the shared clock', TestForkDoesNotReadClock);
   Test('Snapshot reads do not advance access time',
     TestSnapshotReadsDoNotAdvanceAccessTime);
   Test('Directory entry changes update parent metadata',
@@ -168,6 +173,23 @@ begin
   ExpectTime(RenamedStat.ModifiedAt, SourceBefore.ModifiedAt);
   ExpectTime(RenamedStat.ChangedAt, TimeAt(40));
   ExpectTime(RenamedStat.BirthTime, SourceBefore.BirthTime);
+end;
+
+procedure TTestSandboxVirtualFileSystem.TestForkDoesNotReadClock;
+var
+  CallsBeforeFork: Integer;
+  Forked: TSandboxVirtualFileSystem;
+begin
+  FClock.Value := TimeAt(10);
+  FFs.WriteAllText('/source.txt', 'source');
+  CallsBeforeFork := FClock.CallCount;
+
+  Forked := FFs.Fork;
+  try
+    Expect<Integer>(FClock.CallCount).ToBe(CallsBeforeFork);
+  finally
+    Forked.Free;
+  end;
 end;
 
 procedure TTestSandboxVirtualFileSystem.TestSnapshotReadsDoNotAdvanceAccessTime;

--- a/source/shared/SandboxVirtualFileSystem.Test.pas
+++ b/source/shared/SandboxVirtualFileSystem.Test.pas
@@ -1,0 +1,236 @@
+program SandboxVirtualFileSystemTest;
+
+{$I Goccia.inc}
+
+uses
+  SysUtils,
+
+  SandboxVirtualFileSystem,
+  TestingPascalLibrary,
+  TimingUtils,
+
+  Goccia.TestSetup;
+
+type
+  TDeterministicSandboxClock = class(TSandboxFsClock)
+  private
+    FValue: TDateTime;
+  public
+    function Now: TDateTime; override;
+    property Value: TDateTime read FValue write FValue;
+  end;
+
+  TTestSandboxVirtualFileSystem = class(TTestSuite)
+  private
+    FClock: TDeterministicSandboxClock;
+    FFs: TSandboxVirtualFileSystem;
+    function TimeAt(const AMillisecond: Integer): TDateTime;
+    procedure ExpectTime(const AActual, AExpected: TDateTime);
+  public
+    procedure SetupTests; override;
+    procedure BeforeEach; override;
+    procedure AfterEach; override;
+
+    procedure TestTracksIndependentFileTimestamps;
+    procedure TestCopyRenameAndForkMetadata;
+    procedure TestSnapshotReadsDoNotAdvanceAccessTime;
+    procedure TestDirectoryEntryChangesUpdateParentMetadata;
+    procedure TestDefaultClockUsesUnixEpoch;
+  end;
+
+function TDeterministicSandboxClock.Now: TDateTime;
+begin
+  Result := FValue;
+end;
+
+procedure TTestSandboxVirtualFileSystem.SetupTests;
+begin
+  Test('Tracks independent file timestamps',
+    TestTracksIndependentFileTimestamps);
+  Test('Copy, rename, and fork preserve their timestamp contracts',
+    TestCopyRenameAndForkMetadata);
+  Test('Snapshot reads do not advance access time',
+    TestSnapshotReadsDoNotAdvanceAccessTime);
+  Test('Directory entry changes update parent metadata',
+    TestDirectoryEntryChangesUpdateParentMetadata);
+  Test('Default clock tracks the Unix epoch', TestDefaultClockUsesUnixEpoch);
+end;
+
+procedure TTestSandboxVirtualFileSystem.BeforeEach;
+begin
+  FClock := TDeterministicSandboxClock.Create;
+  FClock.Value := TimeAt(0);
+  FFs := TSandboxVirtualFileSystem.Create(0, FClock);
+end;
+
+procedure TTestSandboxVirtualFileSystem.AfterEach;
+begin
+  FFs.Free;
+  FClock.Free;
+end;
+
+function TTestSandboxVirtualFileSystem.TimeAt(
+  const AMillisecond: Integer): TDateTime;
+begin
+  Result := EncodeDate(2026, 1, 1) +
+    (AMillisecond / (24 * 60 * 60 * 1000));
+end;
+
+procedure TTestSandboxVirtualFileSystem.ExpectTime(const AActual,
+  AExpected: TDateTime);
+begin
+  Expect<Boolean>(AActual = AExpected).ToBe(True);
+end;
+
+procedure TTestSandboxVirtualFileSystem.TestTracksIndependentFileTimestamps;
+var
+  CreatedStat: TSandboxFsStat;
+  ReadStat: TSandboxFsStat;
+  WrittenStat: TSandboxFsStat;
+begin
+  FClock.Value := TimeAt(10);
+  FFs.WriteAllText('/file.txt', 'first');
+  CreatedStat := FFs.Stat('/file.txt');
+  ExpectTime(CreatedStat.AccessedAt, TimeAt(10));
+  ExpectTime(CreatedStat.ModifiedAt, TimeAt(10));
+  ExpectTime(CreatedStat.ChangedAt, TimeAt(10));
+  ExpectTime(CreatedStat.BirthTime, TimeAt(10));
+
+  FClock.Value := TimeAt(20);
+  Expect<string>(FFs.ReadAllText('/file.txt')).ToBe('first');
+  ReadStat := FFs.Stat('/file.txt');
+  ExpectTime(ReadStat.AccessedAt, TimeAt(20));
+  ExpectTime(ReadStat.ModifiedAt, TimeAt(10));
+  ExpectTime(ReadStat.ChangedAt, TimeAt(10));
+  ExpectTime(ReadStat.BirthTime, TimeAt(10));
+
+  FClock.Value := TimeAt(30);
+  FFs.WriteAllText('/file.txt', 'second');
+  WrittenStat := FFs.Stat('/file.txt');
+  ExpectTime(WrittenStat.AccessedAt, TimeAt(20));
+  ExpectTime(WrittenStat.ModifiedAt, TimeAt(30));
+  ExpectTime(WrittenStat.ChangedAt, TimeAt(30));
+  ExpectTime(WrittenStat.BirthTime, TimeAt(10));
+
+  FClock.Value := TimeAt(40);
+  WrittenStat := FFs.Stat('/file.txt');
+  ExpectTime(WrittenStat.AccessedAt, TimeAt(20));
+  ExpectTime(WrittenStat.ModifiedAt, TimeAt(30));
+  ExpectTime(WrittenStat.ChangedAt, TimeAt(30));
+  ExpectTime(WrittenStat.BirthTime, TimeAt(10));
+end;
+
+procedure TTestSandboxVirtualFileSystem.TestCopyRenameAndForkMetadata;
+var
+  SourceBefore: TSandboxFsStat;
+  SourceAfterCopy: TSandboxFsStat;
+  CopyStat: TSandboxFsStat;
+  RenamedStat: TSandboxFsStat;
+  ForkedStat: TSandboxFsStat;
+  Forked: TSandboxVirtualFileSystem;
+begin
+  FClock.Value := TimeAt(10);
+  FFs.WriteAllText('/source.txt', 'source');
+  FClock.Value := TimeAt(20);
+  FFs.ReadAllText('/source.txt');
+  SourceBefore := FFs.Stat('/source.txt');
+
+  Forked := FFs.Fork;
+  try
+    ForkedStat := Forked.Stat('/source.txt');
+    ExpectTime(ForkedStat.AccessedAt, SourceBefore.AccessedAt);
+    ExpectTime(ForkedStat.ModifiedAt, SourceBefore.ModifiedAt);
+    ExpectTime(ForkedStat.ChangedAt, SourceBefore.ChangedAt);
+    ExpectTime(ForkedStat.BirthTime, SourceBefore.BirthTime);
+  finally
+    Forked.Free;
+  end;
+
+  FClock.Value := TimeAt(30);
+  FFs.CopyPath('/source.txt', '/copy.txt');
+  SourceAfterCopy := FFs.Stat('/source.txt');
+  CopyStat := FFs.Stat('/copy.txt');
+  ExpectTime(SourceAfterCopy.AccessedAt, TimeAt(30));
+  ExpectTime(SourceAfterCopy.ModifiedAt, SourceBefore.ModifiedAt);
+  ExpectTime(SourceAfterCopy.BirthTime, SourceBefore.BirthTime);
+  ExpectTime(CopyStat.AccessedAt, TimeAt(30));
+  ExpectTime(CopyStat.ModifiedAt, TimeAt(30));
+  ExpectTime(CopyStat.ChangedAt, TimeAt(30));
+  ExpectTime(CopyStat.BirthTime, TimeAt(30));
+
+  FFs.CopyPath('/copy.txt', '/copy.txt');
+  Expect<string>(FFs.ReadAllText('/copy.txt')).ToBe('source');
+
+  FClock.Value := TimeAt(40);
+  FFs.MovePath('/source.txt', '/renamed.txt');
+  RenamedStat := FFs.Stat('/renamed.txt');
+  ExpectTime(RenamedStat.AccessedAt, TimeAt(30));
+  ExpectTime(RenamedStat.ModifiedAt, SourceBefore.ModifiedAt);
+  ExpectTime(RenamedStat.ChangedAt, TimeAt(40));
+  ExpectTime(RenamedStat.BirthTime, SourceBefore.BirthTime);
+end;
+
+procedure TTestSandboxVirtualFileSystem.TestSnapshotReadsDoNotAdvanceAccessTime;
+var
+  BeforeStat: TSandboxFsStat;
+  AfterStat: TSandboxFsStat;
+begin
+  FClock.Value := TimeAt(10);
+  FFs.WriteAllText('/file.txt', 'content');
+  BeforeStat := FFs.Stat('/file.txt');
+
+  FClock.Value := TimeAt(20);
+  Expect<string>(FFs.SnapshotReadAllText('/file.txt')).ToBe('content');
+  Expect<Integer>(Length(FFs.SnapshotReadAllBytes('/file.txt'))).ToBe(7);
+  Expect<Integer>(Length(FFs.SnapshotList('/'))).ToBe(1);
+  AfterStat := FFs.Stat('/file.txt');
+
+  ExpectTime(AfterStat.AccessedAt, BeforeStat.AccessedAt);
+  ExpectTime(FFs.Stat('/').AccessedAt, TimeAt(0));
+end;
+
+procedure TTestSandboxVirtualFileSystem.TestDirectoryEntryChangesUpdateParentMetadata;
+var
+  RootStat: TSandboxFsStat;
+begin
+  FClock.Value := TimeAt(10);
+  FFs.MakeDirectory('/directory');
+  RootStat := FFs.Stat('/');
+  ExpectTime(RootStat.ModifiedAt, TimeAt(10));
+  ExpectTime(RootStat.ChangedAt, TimeAt(10));
+
+  FClock.Value := TimeAt(20);
+  FFs.DeletePath('/directory');
+  RootStat := FFs.Stat('/');
+  ExpectTime(RootStat.ModifiedAt, TimeAt(20));
+  ExpectTime(RootStat.ChangedAt, TimeAt(20));
+end;
+
+procedure TTestSandboxVirtualFileSystem.TestDefaultClockUsesUnixEpoch;
+var
+  DefaultFs: TSandboxVirtualFileSystem;
+  BeforeMilliseconds: Int64;
+  AfterMilliseconds: Int64;
+  ActualMilliseconds: Double;
+begin
+  BeforeMilliseconds := GetEpochNanoseconds div 1000000;
+  DefaultFs := TSandboxVirtualFileSystem.Create;
+  try
+    ActualMilliseconds := SandboxDateTimeToUnixMilliseconds(
+      DefaultFs.Stat('/').BirthTime);
+  finally
+    DefaultFs.Free;
+  end;
+  AfterMilliseconds := GetEpochNanoseconds div 1000000;
+
+  Expect<Boolean>((ActualMilliseconds >= BeforeMilliseconds - 1) and
+    (ActualMilliseconds <= AfterMilliseconds + 1)).ToBe(True);
+end;
+
+begin
+  TestRunnerProgram.AddSuite(
+    TTestSandboxVirtualFileSystem.Create('SandboxVirtualFileSystem'));
+  TestRunnerProgram.Run;
+
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/shared/SandboxVirtualFileSystem.pas
+++ b/source/shared/SandboxVirtualFileSystem.pas
@@ -33,12 +33,22 @@ type
 
   TSandboxFsNodeKind = (nkFile, nkDirectory);
 
+  { Optional, non-owned clock used by the VFS.  Embedders can inject a
+    deterministic clock; nil selects the host wall clock. }
+  TSandboxFsClock = class
+  public
+    function Now: TDateTime; virtual; abstract;
+  end;
+
   TSandboxFsStat = record
     Path: string;
     Name: string;
     Kind: TSandboxFsNodeKind;
     Size: Int64;
+    AccessedAt: TDateTime;
     ModifiedAt: TDateTime;
+    ChangedAt: TDateTime;
+    BirthTime: TDateTime;
   end;
 
   TSandboxFsStatArray = array of TSandboxFsStat;
@@ -60,17 +70,23 @@ type
     FName: string;
     FKind: TSandboxFsNodeKind;
     FParent: TSandboxFsNode;
+    FAccessedAt: TDateTime;
     FModifiedAt: TDateTime;
+    FChangedAt: TDateTime;
+    FBirthTime: TDateTime;
     FData: TBytes;
     FSize: Int64;
     FOpenCount: Integer;
     FChildren: TStringList;
     function FullPath: string;
     function FindChild(const AName: string): TSandboxFsNode;
-    procedure AttachChild(const AChild: TSandboxFsNode);
-    procedure DetachChild(const AChild: TSandboxFsNode);
+    procedure AttachChild(const AChild: TSandboxFsNode;
+      const ATime: TDateTime);
+    procedure DetachChild(const AChild: TSandboxFsNode;
+      const ATime: TDateTime);
   public
-    constructor Create(const AName: string; const AKind: TSandboxFsNodeKind);
+    constructor Create(const AName: string; const AKind: TSandboxFsNodeKind;
+      const ATime: TDateTime);
     destructor Destroy; override;
   end;
 
@@ -82,6 +98,8 @@ type
     FQuotaBytes: Int64;
     FUsedBytes: Int64;
     FNodeCount: Integer;
+    FClock: TSandboxFsClock;
+    function CurrentTime: TDateTime;
     function LookupNode(const ACanonicalPath: string): TSandboxFsNode;
     function RequireNode(const APath: string): TSandboxFsNode;
     function RequireDirectory(const APath: string): TSandboxFsNode;
@@ -89,7 +107,10 @@ type
     function ResolveParent(const ACanonicalPath: string;
       out ALeafName: string): TSandboxFsNode;
     function StatOf(const ANode: TSandboxFsNode): TSandboxFsStat;
-    function CloneNode(const ASource: TSandboxFsNode): TSandboxFsNode;
+    function CloneNodePreservingMetadata(
+      const ASource: TSandboxFsNode): TSandboxFsNode;
+    function CloneNodeForCopy(const ASource: TSandboxFsNode;
+      const ATime: TDateTime): TSandboxFsNode;
     function SubtreeBytes(const ANode: TSandboxFsNode): Int64;
     function SubtreeNodes(const ANode: TSandboxFsNode): Integer;
     function SubtreeHasOpenHandles(const ANode: TSandboxFsNode): Boolean;
@@ -99,7 +120,8 @@ type
     procedure ValidateLeafName(const AName: string);
     function CreateFileNode(const ACanonicalPath: string): TSandboxFsNode;
   public
-    constructor Create(const AQuotaBytes: Int64 = 0);
+    constructor Create(const AQuotaBytes: Int64 = 0;
+      const AClock: TSandboxFsClock = nil);
     destructor Destroy; override;
 
     { Canonicalize APath against ABase ('/'-rooted). Collapses '.',
@@ -127,6 +149,11 @@ type
     procedure AppendAllText(const APath: string; const AText: string);
     function ReadAllBytes(const APath: string): TBytes;
     function ReadAllText(const APath: string): string;
+
+    { Non-observing reads for baselines, diffing, and diagnostics. }
+    function SnapshotList(const APath: string): TSandboxFsStatArray;
+    function SnapshotReadAllBytes(const APath: string): TBytes;
+    function SnapshotReadAllText(const APath: string): string;
 
     function Open(const APath: string;
       const AMode: TSandboxFsOpenMode): TSandboxFsFile;
@@ -172,13 +199,18 @@ type
 
 function SandboxFsKindName(const AKind: TSandboxFsNodeKind): string;
 function SandboxHumanBytes(const ABytes: Int64): string;
+function SandboxDateTimeToUnixMilliseconds(const AValue: TDateTime): Double;
 function NormalizeSandboxPathSeparators(const APath: string): string;
 
 implementation
 
+uses
+  TimingUtils;
+
 const
   PathSeparator = '/';
   AlternatePathSeparator = '\';
+  MillisecondsPerDay = 24 * 60 * 60 * 1000;
 
 function NormalizeSandboxPathSeparators(const APath: string): string;
 begin
@@ -214,6 +246,11 @@ begin
     Result := Format('%.1f %s', [Value, Units[UnitIndex]]);
 end;
 
+function SandboxDateTimeToUnixMilliseconds(const AValue: TDateTime): Double;
+begin
+  Result := (AValue - EncodeDate(1970, 1, 1)) * MillisecondsPerDay;
+end;
+
 function SplitPath(const ACanonicalPath: string): TStringArray;
 var
   Count: Integer;
@@ -240,12 +277,15 @@ end;
 { TSandboxFsNode }
 
 constructor TSandboxFsNode.Create(const AName: string;
-  const AKind: TSandboxFsNodeKind);
+  const AKind: TSandboxFsNodeKind; const ATime: TDateTime);
 begin
   inherited Create;
   FName := AName;
   FKind := AKind;
-  FModifiedAt := Now;
+  FAccessedAt := ATime;
+  FModifiedAt := ATime;
+  FChangedAt := ATime;
+  FBirthTime := ATime;
   if AKind = nkDirectory then
   begin
     FChildren := TStringList.Create;
@@ -288,32 +328,60 @@ begin
     Result := TSandboxFsNode(FChildren.Objects[Index]);
 end;
 
-procedure TSandboxFsNode.AttachChild(const AChild: TSandboxFsNode);
+procedure TSandboxFsNode.AttachChild(const AChild: TSandboxFsNode;
+  const ATime: TDateTime);
 begin
   FChildren.AddObject(AChild.FName, AChild);
   AChild.FParent := Self;
-  FModifiedAt := Now;
+  FModifiedAt := ATime;
+  FChangedAt := ATime;
 end;
 
-procedure TSandboxFsNode.DetachChild(const AChild: TSandboxFsNode);
+procedure TSandboxFsNode.DetachChild(const AChild: TSandboxFsNode;
+  const ATime: TDateTime);
 var
   Index: Integer;
 begin
   if FChildren.Find(AChild.FName, Index) then
     FChildren.Delete(Index);
   AChild.FParent := nil;
-  FModifiedAt := Now;
+  FModifiedAt := ATime;
+  FChangedAt := ATime;
 end;
 
 { TSandboxVirtualFileSystem }
 
-constructor TSandboxVirtualFileSystem.Create(const AQuotaBytes: Int64);
+constructor TSandboxVirtualFileSystem.Create(const AQuotaBytes: Int64;
+  const AClock: TSandboxFsClock);
 begin
   inherited Create;
-  FRoot := TSandboxFsNode.Create('', nkDirectory);
+  FClock := AClock;
+  FRoot := TSandboxFsNode.Create('', nkDirectory, CurrentTime);
   FQuotaBytes := AQuotaBytes;
   FUsedBytes := 0;
   FNodeCount := 0;
+end;
+
+function TSandboxVirtualFileSystem.CurrentTime: TDateTime;
+var
+  EpochNanoseconds: Int64;
+  EpochSeconds: Int64;
+  WholeDays: Int64;
+  SecondsOfDay: Int64;
+begin
+  if Assigned(FClock) then
+    Result := FClock.Now
+  else
+  begin
+    EpochNanoseconds := GetEpochNanoseconds;
+    EpochSeconds := EpochNanoseconds div 1000000000;
+    WholeDays := EpochSeconds div (24 * 60 * 60);
+    SecondsOfDay := EpochSeconds mod (24 * 60 * 60);
+    Result := EncodeDate(1970, 1, 1) + WholeDays +
+      (Double(SecondsOfDay) / Double(24 * 60 * 60)) +
+      (Double(EpochNanoseconds mod 1000000000) /
+        (Double(MillisecondsPerDay) * 1000000));
+  end;
 end;
 
 destructor TSandboxVirtualFileSystem.Destroy;
@@ -492,11 +560,13 @@ function TSandboxVirtualFileSystem.CreateFileNode(
 var
   Parent: TSandboxFsNode;
   LeafName: string;
+  Time: TDateTime;
 begin
   Parent := ResolveParent(ACanonicalPath, LeafName);
   ValidateLeafName(LeafName);
-  Result := TSandboxFsNode.Create(LeafName, nkFile);
-  Parent.AttachChild(Result);
+  Time := CurrentTime;
+  Result := TSandboxFsNode.Create(LeafName, nkFile, Time);
+  Parent.AttachChild(Result, Time);
   Inc(FNodeCount);
 end;
 
@@ -509,7 +579,10 @@ begin
     Result.Size := ANode.FSize
   else
     Result.Size := ANode.FChildren.Count;
+  Result.AccessedAt := ANode.FAccessedAt;
   Result.ModifiedAt := ANode.FModifiedAt;
+  Result.ChangedAt := ANode.FChangedAt;
+  Result.BirthTime := ANode.FBirthTime;
 end;
 
 function TSandboxVirtualFileSystem.Exists(const APath: string): Boolean;
@@ -545,6 +618,7 @@ var
 begin
   Result := nil;
   Node := RequireDirectory(APath);
+  Node.FAccessedAt := CurrentTime;
   SetLength(Result, Node.FChildren.Count);
   for Index := 0 to Node.FChildren.Count - 1 do
     Result[Index] := StatOf(TSandboxFsNode(Node.FChildren.Objects[Index]));
@@ -558,6 +632,7 @@ var
   Current: TSandboxFsNode;
   Next: TSandboxFsNode;
   Index: Integer;
+  Time: TDateTime;
 begin
   Canonical := Normalize(APath);
   if Canonical = PathSeparator then
@@ -581,8 +656,9 @@ begin
         raise ESandboxFsNotFound.CreateFmt(
           '%s: no such file or directory', [Canonical]);
       ValidateLeafName(Segments[Index]);
-      Next := TSandboxFsNode.Create(Segments[Index], nkDirectory);
-      Current.AttachChild(Next);
+      Time := CurrentTime;
+      Next := TSandboxFsNode.Create(Segments[Index], nkDirectory, Time);
+      Current.AttachChild(Next, Time);
       Inc(FNodeCount);
     end
     else if (Index = High(Segments)) and not ARecursive then
@@ -651,6 +727,7 @@ procedure TSandboxVirtualFileSystem.DeletePath(const APath: string;
   const ARecursive: Boolean);
 var
   Node: TSandboxFsNode;
+  Time: TDateTime;
 begin
   Node := RequireNode(APath);
   if Node = FRoot then
@@ -664,7 +741,8 @@ begin
       [Node.FullPath]);
   FUsedBytes := FUsedBytes - SubtreeBytes(Node);
   FNodeCount := FNodeCount - SubtreeNodes(Node);
-  Node.FParent.DetachChild(Node);
+  Time := CurrentTime;
+  Node.FParent.DetachChild(Node, Time);
   Node.Free;
 end;
 
@@ -675,6 +753,7 @@ var
   DestParent: TSandboxFsNode;
   DestCanonical: string;
   LeafName: string;
+  Time: TDateTime;
 begin
   SourceNode := RequireNode(ASource);
   if SourceNode = FRoot then
@@ -715,18 +794,21 @@ begin
         [DestNode.FullPath]);
   end;
 
-  SourceNode.FParent.DetachChild(SourceNode);
+  Time := CurrentTime;
+  SourceNode.FParent.DetachChild(SourceNode, Time);
   SourceNode.FName := LeafName;
-  DestParent.AttachChild(SourceNode);
+  SourceNode.FChangedAt := Time;
+  DestParent.AttachChild(SourceNode, Time);
 end;
 
-function TSandboxVirtualFileSystem.CloneNode(const ASource: TSandboxFsNode): TSandboxFsNode;
+function TSandboxVirtualFileSystem.CloneNodePreservingMetadata(
+  const ASource: TSandboxFsNode): TSandboxFsNode;
 var
   Index: Integer;
   Child: TSandboxFsNode;
 begin
-  Result := TSandboxFsNode.Create(ASource.FName, ASource.FKind);
-  Result.FModifiedAt := ASource.FModifiedAt;
+  Result := TSandboxFsNode.Create(ASource.FName, ASource.FKind,
+    ASource.FBirthTime);
   if ASource.FKind = nkFile then
   begin
     Result.FSize := ASource.FSize;
@@ -737,8 +819,37 @@ begin
   else
     for Index := 0 to ASource.FChildren.Count - 1 do
     begin
-      Child := CloneNode(TSandboxFsNode(ASource.FChildren.Objects[Index]));
-      Result.AttachChild(Child);
+      Child := CloneNodePreservingMetadata(
+        TSandboxFsNode(ASource.FChildren.Objects[Index]));
+      Result.AttachChild(Child, ASource.FModifiedAt);
+    end;
+  Result.FAccessedAt := ASource.FAccessedAt;
+  Result.FModifiedAt := ASource.FModifiedAt;
+  Result.FChangedAt := ASource.FChangedAt;
+  Result.FBirthTime := ASource.FBirthTime;
+end;
+
+function TSandboxVirtualFileSystem.CloneNodeForCopy(
+  const ASource: TSandboxFsNode; const ATime: TDateTime): TSandboxFsNode;
+var
+  Index: Integer;
+  Child: TSandboxFsNode;
+begin
+  ASource.FAccessedAt := ATime;
+  Result := TSandboxFsNode.Create(ASource.FName, ASource.FKind, ATime);
+  if ASource.FKind = nkFile then
+  begin
+    Result.FSize := ASource.FSize;
+    SetLength(Result.FData, ASource.FSize);
+    if ASource.FSize > 0 then
+      System.Move(ASource.FData[0], Result.FData[0], ASource.FSize);
+  end
+  else
+    for Index := 0 to ASource.FChildren.Count - 1 do
+    begin
+      Child := CloneNodeForCopy(
+        TSandboxFsNode(ASource.FChildren.Objects[Index]), ATime);
+      Result.AttachChild(Child, ATime);
     end;
 end;
 
@@ -751,6 +862,7 @@ var
   DestCanonical: string;
   LeafName: string;
   Clone: TSandboxFsNode;
+  Time: TDateTime;
 begin
   SourceNode := RequireNode(ASource);
   if (SourceNode.FKind = nkDirectory) and not ARecursive then
@@ -780,6 +892,8 @@ begin
 
   if Assigned(DestNode) then
   begin
+    if DestNode = SourceNode then
+      Exit;
     if (DestNode.FKind = nkFile) and (SourceNode.FKind = nkFile) then
       DeletePath(DestNode.FullPath)
     else
@@ -788,9 +902,10 @@ begin
   end;
 
   EnsureGrowth(SubtreeBytes(SourceNode));
-  Clone := CloneNode(SourceNode);
+  Time := CurrentTime;
+  Clone := CloneNodeForCopy(SourceNode, Time);
   Clone.FName := LeafName;
-  DestParent.AttachChild(Clone);
+  DestParent.AttachChild(Clone, Time);
   FUsedBytes := FUsedBytes + SubtreeBytes(Clone);
   FNodeCount := FNodeCount + SubtreeNodes(Clone);
 end;
@@ -799,11 +914,17 @@ procedure TSandboxVirtualFileSystem.Touch(const APath: string);
 var
   Canonical: string;
   Node: TSandboxFsNode;
+  Time: TDateTime;
 begin
   Canonical := Normalize(APath);
   Node := LookupNode(Canonical);
   if Assigned(Node) then
-    Node.FModifiedAt := Now
+  begin
+    Time := CurrentTime;
+    Node.FAccessedAt := Time;
+    Node.FModifiedAt := Time;
+    Node.FChangedAt := Time;
+  end
   else
     CreateFileNode(Canonical);
 end;
@@ -854,12 +975,51 @@ var
 begin
   Result := nil;
   Node := RequireFile(APath);
+  Node.FAccessedAt := CurrentTime;
   SetLength(Result, Node.FSize);
   if Node.FSize > 0 then
     System.Move(Node.FData[0], Result[0], Node.FSize);
 end;
 
 function TSandboxVirtualFileSystem.ReadAllText(const APath: string): string;
+var
+  Node: TSandboxFsNode;
+begin
+  Result := '';
+  Node := RequireFile(APath);
+  Node.FAccessedAt := CurrentTime;
+  SetLength(Result, Node.FSize);
+  if Node.FSize > 0 then
+    System.Move(Node.FData[0], Result[1], Node.FSize);
+end;
+
+function TSandboxVirtualFileSystem.SnapshotList(
+  const APath: string): TSandboxFsStatArray;
+var
+  Node: TSandboxFsNode;
+  Index: Integer;
+begin
+  Result := nil;
+  Node := RequireDirectory(APath);
+  SetLength(Result, Node.FChildren.Count);
+  for Index := 0 to Node.FChildren.Count - 1 do
+    Result[Index] := StatOf(TSandboxFsNode(Node.FChildren.Objects[Index]));
+end;
+
+function TSandboxVirtualFileSystem.SnapshotReadAllBytes(
+  const APath: string): TBytes;
+var
+  Node: TSandboxFsNode;
+begin
+  Result := nil;
+  Node := RequireFile(APath);
+  SetLength(Result, Node.FSize);
+  if Node.FSize > 0 then
+    System.Move(Node.FData[0], Result[0], Node.FSize);
+end;
+
+function TSandboxVirtualFileSystem.SnapshotReadAllText(
+  const APath: string): string;
 var
   Node: TSandboxFsNode;
 begin
@@ -896,9 +1056,9 @@ end;
 
 function TSandboxVirtualFileSystem.Fork: TSandboxVirtualFileSystem;
 begin
-  Result := TSandboxVirtualFileSystem.Create(FQuotaBytes);
+  Result := TSandboxVirtualFileSystem.Create(FQuotaBytes, FClock);
   Result.FRoot.Free;
-  Result.FRoot := CloneNode(FRoot);
+  Result.FRoot := CloneNodePreservingMetadata(FRoot);
   Result.FUsedBytes := FUsedBytes;
   Result.FNodeCount := FNodeCount;
 end;
@@ -918,6 +1078,8 @@ begin
     begin
       FFs.FUsedBytes := FFs.FUsedBytes - FNode.FSize;
       FNode.FSize := 0;
+      FNode.FModifiedAt := FFs.CurrentTime;
+      FNode.FChangedAt := FNode.FModifiedAt;
       FPosition := 0;
     end;
     omAppend:
@@ -963,6 +1125,7 @@ begin
     Exit(0);
   System.Move(FNode.FData[FPosition], ABuffer, Result);
   FPosition := FPosition + Result;
+  FNode.FAccessedAt := FFs.CurrentTime;
 end;
 
 function TSandboxFsFile.Write(const ABuffer;
@@ -981,7 +1144,8 @@ begin
     FFs.GrowFile(FNode, FPosition + ACount);
   System.Move(ABuffer, FNode.FData[FPosition], ACount);
   FPosition := FPosition + ACount;
-  FNode.FModifiedAt := Now;
+  FNode.FModifiedAt := FFs.CurrentTime;
+  FNode.FChangedAt := FNode.FModifiedAt;
   Result := ACount;
 end;
 
@@ -1018,7 +1182,8 @@ begin
   end;
   if FPosition > FNode.FSize then
     FPosition := FNode.FSize;
-  FNode.FModifiedAt := Now;
+  FNode.FModifiedAt := FFs.CurrentTime;
+  FNode.FChangedAt := FNode.FModifiedAt;
 end;
 
 function TSandboxFsFile.ReadText(const ACount: Integer): string;

--- a/source/shared/SandboxVirtualFileSystem.pas
+++ b/source/shared/SandboxVirtualFileSystem.pas
@@ -380,6 +380,8 @@ var
   EpochSeconds: Int64;
   WholeDays: Int64;
   SecondsOfDay: Int64;
+  SecondsOfDayValue: Double;
+  NanosecondRemainderValue: Double;
 begin
   if Assigned(FClock) then
     Result := FClock.Now
@@ -389,10 +391,12 @@ begin
     EpochSeconds := EpochNanoseconds div 1000000000;
     WholeDays := EpochSeconds div (24 * 60 * 60);
     SecondsOfDay := EpochSeconds mod (24 * 60 * 60);
+    SecondsOfDayValue := SecondsOfDay;
+    NanosecondRemainderValue := EpochNanoseconds mod 1000000000;
     Result := EncodeDate(1970, 1, 1) + WholeDays +
-      (Double(SecondsOfDay) / Double(24 * 60 * 60)) +
-      (Double(EpochNanoseconds mod 1000000000) /
-        (Double(MillisecondsPerDay) * 1000000));
+      (SecondsOfDayValue / (24 * 60 * 60)) +
+      (NanosecondRemainderValue /
+        (MillisecondsPerDay * 1000000));
   end;
 end;
 

--- a/source/shared/SandboxVirtualFileSystem.pas
+++ b/source/shared/SandboxVirtualFileSystem.pas
@@ -99,6 +99,7 @@ type
     FUsedBytes: Int64;
     FNodeCount: Integer;
     FClock: TSandboxFsClock;
+    constructor CreateFork(const ASource: TSandboxVirtualFileSystem);
     function CurrentTime: TDateTime;
     function LookupNode(const ACanonicalPath: string): TSandboxFsNode;
     function RequireNode(const APath: string): TSandboxFsNode;
@@ -360,6 +361,17 @@ begin
   FQuotaBytes := AQuotaBytes;
   FUsedBytes := 0;
   FNodeCount := 0;
+end;
+
+constructor TSandboxVirtualFileSystem.CreateFork(
+  const ASource: TSandboxVirtualFileSystem);
+begin
+  inherited Create;
+  FClock := ASource.FClock;
+  FRoot := CloneNodePreservingMetadata(ASource.FRoot);
+  FQuotaBytes := ASource.FQuotaBytes;
+  FUsedBytes := ASource.FUsedBytes;
+  FNodeCount := ASource.FNodeCount;
 end;
 
 function TSandboxVirtualFileSystem.CurrentTime: TDateTime;
@@ -1056,11 +1068,7 @@ end;
 
 function TSandboxVirtualFileSystem.Fork: TSandboxVirtualFileSystem;
 begin
-  Result := TSandboxVirtualFileSystem.Create(FQuotaBytes, FClock);
-  Result.FRoot.Free;
-  Result.FRoot := CloneNodePreservingMetadata(FRoot);
-  Result.FUsedBytes := FUsedBytes;
-  Result.FNodeCount := FNodeCount;
+  Result := TSandboxVirtualFileSystem.CreateFork(Self);
 end;
 
 { TSandboxFsFile }

--- a/source/units/Goccia.RuntimeExtensions.Sandbox.pas
+++ b/source/units/Goccia.RuntimeExtensions.Sandbox.pas
@@ -5,6 +5,8 @@ unit Goccia.RuntimeExtensions.Sandbox;
 interface
 
 uses
+  SandboxVirtualFileSystem,
+
   Goccia.Arguments.Collection,
   Goccia.Modules,
   Goccia.Runtime,
@@ -18,6 +20,24 @@ type
     FContext: TGocciaSandboxContext;
     FFsModule: TGocciaModule;
     FGocciaModule: TGocciaModule;
+
+    function EnsureStatsPrototype: TGocciaObjectValue;
+    function CreateStatsValue(const AStat: TSandboxFsStat): TGocciaValue;
+    function CreateStatsDate(const AMilliseconds: Double): TGocciaValue;
+    function StatsAtime(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StatsMtime(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StatsCtime(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StatsBirthtime(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StatsIsFile(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StatsIsDirectory(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StatsIsSymbolicLink(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
 
     function SandboxDollar(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -79,33 +99,33 @@ uses
 
   base64,
   SandboxShell,
-  SandboxVirtualFileSystem,
 
   Goccia.JSON,
   Goccia.Keywords.Reserved,
+  Goccia.Realm,
   Goccia.Sandbox.FileSystemErrors,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
   Goccia.Values.NativeFunction,
   Goccia.Values.NativeFunctionCallback,
+  Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.PromiseValue,
   Goccia.Values.TypedArrayValue;
-
-const
-  MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 
 type
   TGocciaSandboxStatValue = class(TGocciaObjectValue)
   private
     FKind: TSandboxFsNodeKind;
+    FAtimeMs: Double;
+    FMtimeMs: Double;
+    FCtimeMs: Double;
+    FBirthtimeMs: Double;
   public
-    constructor Create(const AStat: TSandboxFsStat);
-    function IsFile(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
-    function IsDirectory(const AArgs: TGocciaArgumentsCollection;
-      const AThisValue: TGocciaValue): TGocciaValue;
+    constructor Create(const APrototype: TGocciaObjectValue;
+      const AStat: TSandboxFsStat);
   end;
 
   TGocciaSandboxShellCommandValue = class(TGocciaObjectValue)
@@ -143,10 +163,8 @@ begin
   AObject.SetProperty(AName, Result);
 end;
 
-function DateTimeToUnixMilliseconds(const AValue: TDateTime): Double;
-begin
-  Result := (AValue - EncodeDate(1970, 1, 1)) * MILLISECONDS_PER_DAY;
-end;
+var
+  GSandboxStatsPrototypeSlot: TGocciaRealmSlotId;
 
 function FulfilledPromise(const AValue: TGocciaValue): TGocciaPromiseValue;
 begin
@@ -479,6 +497,12 @@ begin
     Result.IncludeDiff := True;
     Result.Isolated := True;
   end;
+  if ObjectBooleanProperty(OptionsObject, 'diffMetadata', AMethod) then
+  begin
+    Result.DiffMetadata := True;
+    Result.IncludeDiff := True;
+    Result.Isolated := True;
+  end;
 
   DiffFormat := ObjectStringProperty(OptionsObject, 'diffFormat', AMethod,
     False);
@@ -535,34 +559,24 @@ end;
 
 { TGocciaSandboxStatValue }
 
-constructor TGocciaSandboxStatValue.Create(const AStat: TSandboxFsStat);
+constructor TGocciaSandboxStatValue.Create(const APrototype: TGocciaObjectValue;
+  const AStat: TSandboxFsStat);
 begin
-  inherited Create(TGocciaObjectValue.SharedObjectPrototype, 8);
+  inherited Create(APrototype, 10);
   FKind := AStat.Kind;
+  FAtimeMs := SandboxDateTimeToUnixMilliseconds(AStat.AccessedAt);
+  FMtimeMs := SandboxDateTimeToUnixMilliseconds(AStat.ModifiedAt);
+  FCtimeMs := SandboxDateTimeToUnixMilliseconds(AStat.ChangedAt);
+  FBirthtimeMs := SandboxDateTimeToUnixMilliseconds(AStat.BirthTime);
   SetProperty('path', TGocciaStringLiteralValue.Create(AStat.Path));
   SetProperty('name', TGocciaStringLiteralValue.Create(AStat.Name));
   SetProperty('type', TGocciaStringLiteralValue.Create(
     SandboxFsKindName(AStat.Kind)));
   SetProperty('size', TGocciaNumberLiteralValue.Create(AStat.Size));
-  SetProperty('mtimeMs',
-    TGocciaNumberLiteralValue.Create(DateTimeToUnixMilliseconds(
-      AStat.ModifiedAt)));
-  AddNativeFunction(Self, 'isFile', IsFile, 0);
-  AddNativeFunction(Self, 'isDirectory', IsDirectory, 0);
-end;
-
-function TGocciaSandboxStatValue.IsFile(
-  const AArgs: TGocciaArgumentsCollection;
-  const AThisValue: TGocciaValue): TGocciaValue;
-begin
-  Result := TGocciaBooleanLiteralValue.Create(FKind = nkFile);
-end;
-
-function TGocciaSandboxStatValue.IsDirectory(
-  const AArgs: TGocciaArgumentsCollection;
-  const AThisValue: TGocciaValue): TGocciaValue;
-begin
-  Result := TGocciaBooleanLiteralValue.Create(FKind = nkDirectory);
+  SetProperty('atimeMs', TGocciaNumberLiteralValue.Create(FAtimeMs));
+  SetProperty('mtimeMs', TGocciaNumberLiteralValue.Create(FMtimeMs));
+  SetProperty('ctimeMs', TGocciaNumberLiteralValue.Create(FCtimeMs));
+  SetProperty('birthtimeMs', TGocciaNumberLiteralValue.Create(FBirthtimeMs));
 end;
 
 { TGocciaSandboxShellCommandValue }
@@ -693,6 +707,152 @@ begin
 end;
 
 { TGocciaSandboxRuntimeExtension }
+
+function RequireSandboxStatsReceiver(
+  const AThisValue: TGocciaValue): TGocciaSandboxStatValue;
+begin
+  if not (AThisValue is TGocciaSandboxStatValue) then
+  begin
+    ThrowTypeError('Stats method called on incompatible receiver');
+    Exit(nil);
+  end;
+  Result := TGocciaSandboxStatValue(AThisValue);
+end;
+
+function TGocciaSandboxRuntimeExtension.EnsureStatsPrototype:
+  TGocciaObjectValue;
+var
+  Realm: TGocciaRealm;
+
+  procedure DefineMethod(const AName: string;
+    const ACallback: TGocciaNativeFunctionCallback);
+  var
+    MethodValue: TGocciaNativeFunctionValue;
+  begin
+    MethodValue := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      ACallback, AName, 0);
+    Result.DefineProperty(AName, TGocciaPropertyDescriptorData.Create(
+      MethodValue, [pfWritable, pfConfigurable]));
+  end;
+
+  procedure DefineDateAccessor(const AName: string;
+    const ACallback: TGocciaNativeFunctionCallback);
+  var
+    Getter: TGocciaNativeFunctionValue;
+  begin
+    Getter := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      ACallback, 'get ' + AName, 0);
+    Result.DefineProperty(AName, TGocciaPropertyDescriptorAccessor.Create(
+      Getter, nil, [pfEnumerable, pfConfigurable]));
+  end;
+
+begin
+  Realm := CurrentRealm;
+  if not Assigned(Realm) then
+    raise Exception.Create('Sandbox Stats prototype requires an active realm');
+
+  Result := TGocciaObjectValue(
+    Realm.GetSlot(GSandboxStatsPrototypeSlot));
+  if Assigned(Result) then
+    Exit;
+
+  Result := TGocciaObjectValue.Create(
+    TGocciaObjectValue.GetSharedObjectPrototypeForRealm(Realm), 7);
+  DefineDateAccessor('atime', StatsAtime);
+  DefineDateAccessor('mtime', StatsMtime);
+  DefineDateAccessor('ctime', StatsCtime);
+  DefineDateAccessor('birthtime', StatsBirthtime);
+  DefineMethod('isFile', StatsIsFile);
+  DefineMethod('isDirectory', StatsIsDirectory);
+  DefineMethod('isSymbolicLink', StatsIsSymbolicLink);
+  Realm.SetSlot(GSandboxStatsPrototypeSlot, Result);
+end;
+
+function TGocciaSandboxRuntimeExtension.CreateStatsValue(
+  const AStat: TSandboxFsStat): TGocciaValue;
+begin
+  Result := TGocciaSandboxStatValue.Create(EnsureStatsPrototype, AStat);
+end;
+
+function TGocciaSandboxRuntimeExtension.CreateStatsDate(
+  const AMilliseconds: Double): TGocciaValue;
+var
+  DateConstructor: TGocciaValue;
+  Args: TGocciaArgumentsCollection;
+  Fraction: Double;
+  RoundedMilliseconds: Double;
+begin
+  DateConstructor := Runtime.Engine.Interpreter.GlobalScope.GetValue('Date');
+  Fraction := Frac(AMilliseconds);
+  RoundedMilliseconds := AMilliseconds - Fraction;
+  if Fraction >= 0.5 then
+    RoundedMilliseconds := RoundedMilliseconds + 1
+  else if Fraction < -0.5 then
+    RoundedMilliseconds := RoundedMilliseconds - 1;
+  Args := TGocciaArgumentsCollection.Create([
+    TGocciaNumberLiteralValue.Create(RoundedMilliseconds)]);
+  try
+    Result := ConstructValue(DateConstructor, Args, DateConstructor);
+  finally
+    Args.Free;
+  end;
+end;
+
+function TGocciaSandboxRuntimeExtension.StatsAtime(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := CreateStatsDate(
+    RequireSandboxStatsReceiver(AThisValue).FAtimeMs);
+end;
+
+function TGocciaSandboxRuntimeExtension.StatsMtime(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := CreateStatsDate(
+    RequireSandboxStatsReceiver(AThisValue).FMtimeMs);
+end;
+
+function TGocciaSandboxRuntimeExtension.StatsCtime(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := CreateStatsDate(
+    RequireSandboxStatsReceiver(AThisValue).FCtimeMs);
+end;
+
+function TGocciaSandboxRuntimeExtension.StatsBirthtime(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := CreateStatsDate(
+    RequireSandboxStatsReceiver(AThisValue).FBirthtimeMs);
+end;
+
+function TGocciaSandboxRuntimeExtension.StatsIsFile(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaBooleanLiteralValue.Create(
+    RequireSandboxStatsReceiver(AThisValue).FKind = nkFile);
+end;
+
+function TGocciaSandboxRuntimeExtension.StatsIsDirectory(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaBooleanLiteralValue.Create(
+    RequireSandboxStatsReceiver(AThisValue).FKind = nkDirectory);
+end;
+
+function TGocciaSandboxRuntimeExtension.StatsIsSymbolicLink(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  RequireSandboxStatsReceiver(AThisValue);
+  Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
 
 constructor TGocciaSandboxRuntimeExtension.Create(
   const AContext: TGocciaSandboxContext);
@@ -960,7 +1120,7 @@ var
 begin
   Path := RequireStringArg(AArgs, 0, 'fs.statSync');
   try
-    Result := TGocciaSandboxStatValue.Create(FContext.Fs.Stat(Path));
+    Result := CreateStatsValue(FContext.Fs.Stat(Path));
   except
     on E: ESandboxFsError do
       raise TGocciaThrowValue.Create(
@@ -1103,5 +1263,9 @@ function TGocciaSandboxRuntimeExtension.FsCopyFile(
 begin
   Result := RunValueAsPromise(FsCopyFileSync, AArgs, AThisValue);
 end;
+
+initialization
+  GSandboxStatsPrototypeSlot :=
+    RegisterRealmSlot('Sandbox.fs.Stats.prototype');
 
 end.

--- a/source/units/Goccia.RuntimeExtensions.Sandbox.pas
+++ b/source/units/Goccia.RuntimeExtensions.Sandbox.pas
@@ -104,6 +104,7 @@ uses
   Goccia.Keywords.Reserved,
   Goccia.Realm,
   Goccia.Sandbox.FileSystemErrors,
+  Goccia.Shims,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.Error,
@@ -782,7 +783,7 @@ var
   Fraction: Double;
   RoundedMilliseconds: Double;
 begin
-  DateConstructor := Runtime.Engine.Interpreter.GlobalScope.GetValue('Date');
+  DateConstructor := GetDateIntrinsic(Runtime.Engine.Interpreter);
   Fraction := Frac(AMilliseconds);
   RoundedMilliseconds := AMilliseconds - Fraction;
   if Fraction >= 0.5 then

--- a/source/units/Goccia.Sandbox.Context.pas
+++ b/source/units/Goccia.Sandbox.Context.pas
@@ -552,7 +552,7 @@ begin
         for I := 0 to CurrentPaths.Count - 1 do
         begin
           Path := CurrentPaths[I];
-          if not FBaseline.Exists(Path) then
+          if (Path = '/') or (not FBaseline.Exists(Path)) then
             Continue;
           CurrentStat := FFs.Stat(Path);
           BaselineStat := FBaseline.Stat(Path);
@@ -623,7 +623,7 @@ begin
       for I := 0 to CurrentPaths.Count - 1 do
       begin
         Path := CurrentPaths[I];
-        if not FBaseline.Exists(Path) then
+        if (Path = '/') or (not FBaseline.Exists(Path)) then
           Continue;
         CurrentStat := FFs.Stat(Path);
         BaselineStat := FBaseline.Stat(Path);

--- a/source/units/Goccia.Sandbox.Context.pas
+++ b/source/units/Goccia.Sandbox.Context.pas
@@ -38,6 +38,7 @@ type
     Isolated: Boolean;
     Seeds: TGocciaSandboxSeedSpecArray;
     IncludeDiff: Boolean;
+    DiffMetadata: Boolean;
     DiffFormat: string;
   end;
 
@@ -76,13 +77,19 @@ type
     function JsonEscape(const AValue: string): string;
     procedure AppendJsonChange(const ABuilder: TStrings; var AFirst: Boolean;
       const AKind, APath: string; const AOldBytes, ANewBytes: Int64);
+    procedure AppendJsonMetadataChange(const ABuilder: TStrings;
+      var AFirst: Boolean; const APath: string;
+      const ABaselineStat, ACurrentStat: TSandboxFsStat);
+    procedure AppendUnifiedMetadataChange(var AResult: string;
+      const APath: string; const ABaselineStat,
+      ACurrentStat: TSandboxFsStat);
   public
     constructor Create(const AQuotaBytes: Int64 = 0);
     destructor Destroy; override;
 
     procedure CaptureBaseline;
-    function DiffJson: string;
-    function DiffUnified: string;
+    function DiffJson(const AIncludeMetadata: Boolean = False): string;
+    function DiffUnified(const AIncludeMetadata: Boolean = False): string;
 
     property Fs: TSandboxVirtualFileSystem read FFs;
     property Baseline: TSandboxVirtualFileSystem read FBaseline;
@@ -105,6 +112,7 @@ begin
   Result.Isolated := False;
   Result.Seeds := nil;
   Result.IncludeDiff := False;
+  Result.DiffMetadata := False;
   Result.DiffFormat := 'json';
 end;
 
@@ -212,6 +220,12 @@ begin
       AOptions.IncludeDiff := True;
       AOptions.Isolated := True;
     end
+    else if Arg = '--diff-metadata' then
+    begin
+      AOptions.DiffMetadata := True;
+      AOptions.IncludeDiff := True;
+      AOptions.Isolated := True;
+    end
     else if Arg = '--seed' then
     begin
       Inc(Index);
@@ -316,7 +330,7 @@ begin
   if not AFs.IsDirectory(APath) then
     Exit;
 
-  Entries := AFs.List(APath);
+  Entries := AFs.SnapshotList(APath);
   for I := 0 to High(Entries) do
     CollectPaths(AFs, Entries[I].Path, APaths);
 end;
@@ -372,7 +386,91 @@ begin
   AFirst := False;
 end;
 
-function TGocciaSandboxContext.DiffJson: string;
+function TimestampMillisecondsText(const AValue: TDateTime): string;
+var
+  FormatSettings: TFormatSettings;
+begin
+  FormatSettings := DefaultFormatSettings;
+  FormatSettings.DecimalSeparator := '.';
+  Result := FloatToStr(SandboxDateTimeToUnixMilliseconds(AValue),
+    FormatSettings);
+end;
+
+procedure TGocciaSandboxContext.AppendJsonMetadataChange(
+  const ABuilder: TStrings; var AFirst: Boolean; const APath: string;
+  const ABaselineStat, ACurrentStat: TSandboxFsStat);
+var
+  Changes: string;
+  FirstField: Boolean;
+
+  procedure AppendTimestamp(const AName: string; const AOldValue,
+    ANewValue: TDateTime);
+  begin
+    if AOldValue = ANewValue then
+      Exit;
+    if not FirstField then
+      Changes := Changes + ', ';
+    Changes := Changes + '"' + AName + '": { "old": ' +
+      TimestampMillisecondsText(AOldValue) + ', "new": ' +
+      TimestampMillisecondsText(ANewValue) + ' }';
+    FirstField := False;
+  end;
+
+begin
+  Changes := '';
+  FirstField := True;
+  AppendTimestamp('atimeMs', ABaselineStat.AccessedAt,
+    ACurrentStat.AccessedAt);
+  AppendTimestamp('mtimeMs', ABaselineStat.ModifiedAt,
+    ACurrentStat.ModifiedAt);
+  AppendTimestamp('ctimeMs', ABaselineStat.ChangedAt,
+    ACurrentStat.ChangedAt);
+  AppendTimestamp('birthtimeMs', ABaselineStat.BirthTime,
+    ACurrentStat.BirthTime);
+  if FirstField then
+    Exit;
+
+  if not AFirst then
+    ABuilder[ABuilder.Count - 1] := ABuilder[ABuilder.Count - 1] + ',';
+  ABuilder.Add('    { "path": "' + JsonEscape(APath) +
+    '", "changes": { ' + Changes + ' } }');
+  AFirst := False;
+end;
+
+procedure TGocciaSandboxContext.AppendUnifiedMetadataChange(
+  var AResult: string; const APath: string; const ABaselineStat,
+  ACurrentStat: TSandboxFsStat);
+var
+  Changes: string;
+
+  procedure AppendTimestamp(const AName: string; const AOldValue,
+    ANewValue: TDateTime);
+  begin
+    if AOldValue = ANewValue then
+      Exit;
+    Changes := Changes + '-' + AName + ': ' +
+      TimestampMillisecondsText(AOldValue) + LineEnding;
+    Changes := Changes + '+' + AName + ': ' +
+      TimestampMillisecondsText(ANewValue) + LineEnding;
+  end;
+
+begin
+  Changes := '';
+  AppendTimestamp('atimeMs', ABaselineStat.AccessedAt,
+    ACurrentStat.AccessedAt);
+  AppendTimestamp('mtimeMs', ABaselineStat.ModifiedAt,
+    ACurrentStat.ModifiedAt);
+  AppendTimestamp('ctimeMs', ABaselineStat.ChangedAt,
+    ACurrentStat.ChangedAt);
+  AppendTimestamp('birthtimeMs', ABaselineStat.BirthTime,
+    ACurrentStat.BirthTime);
+  if Changes <> '' then
+    AResult := AResult + '@@ sandbox metadata changed ' + APath + ' @@' +
+      LineEnding + Changes;
+end;
+
+function TGocciaSandboxContext.DiffJson(
+  const AIncludeMetadata: Boolean): string;
 var
   Builder: TStringList;
   CurrentPaths: TStringList;
@@ -425,8 +523,8 @@ begin
 
       if CurrentStat.Kind = nkFile then
       begin
-        CurrentBytes := FFs.ReadAllBytes(Path);
-        BaselineBytes := FBaseline.ReadAllBytes(Path);
+        CurrentBytes := FFs.SnapshotReadAllBytes(Path);
+        BaselineBytes := FBaseline.SnapshotReadAllBytes(Path);
         if not BytesEqual(CurrentBytes, BaselineBytes) then
           AppendJsonChange(Builder, First, 'modify', Path,
             BytesLength(BaselineBytes), BytesLength(CurrentBytes));
@@ -445,6 +543,24 @@ begin
     end;
 
     Builder.Add('  ]');
+    if AIncludeMetadata then
+    begin
+      Builder[Builder.Count - 1] := Builder[Builder.Count - 1] + ',';
+      Builder.Add('  "metadataChanges": [');
+      First := True;
+      if Assigned(FBaseline) then
+        for I := 0 to CurrentPaths.Count - 1 do
+        begin
+          Path := CurrentPaths[I];
+          if not FBaseline.Exists(Path) then
+            Continue;
+          CurrentStat := FFs.Stat(Path);
+          BaselineStat := FBaseline.Stat(Path);
+          AppendJsonMetadataChange(Builder, First, Path, BaselineStat,
+            CurrentStat);
+        end;
+      Builder.Add('  ]');
+    end;
     Builder.Add('}');
     Result := Builder.Text;
   finally
@@ -454,12 +570,15 @@ begin
   end;
 end;
 
-function TGocciaSandboxContext.DiffUnified: string;
+function TGocciaSandboxContext.DiffUnified(
+  const AIncludeMetadata: Boolean): string;
 var
   CurrentPaths: TStringList;
   BaselinePaths: TStringList;
   I: Integer;
   Path: string;
+  CurrentStat: TSandboxFsStat;
+  BaselineStat: TSandboxFsStat;
 begin
   CurrentPaths := TStringList.Create;
   BaselinePaths := TStringList.Create;
@@ -476,14 +595,16 @@ begin
       if (Path = '/') or (not FFs.IsFile(Path)) then
         Continue;
       if Assigned(FBaseline) and FBaseline.IsFile(Path) and
-         BytesEqual(FBaseline.ReadAllBytes(Path), FFs.ReadAllBytes(Path)) then
+         BytesEqual(FBaseline.SnapshotReadAllBytes(Path),
+           FFs.SnapshotReadAllBytes(Path)) then
         Continue;
       Result := Result + '--- ' + Path + LineEnding;
       Result := Result + '+++ ' + Path + LineEnding;
       Result := Result + '@@ sandbox file changed @@' + LineEnding;
       if Assigned(FBaseline) and FBaseline.IsFile(Path) then
-        Result := Result + '-' + FBaseline.ReadAllText(Path) + LineEnding;
-      Result := Result + '+' + FFs.ReadAllText(Path) + LineEnding;
+        Result := Result + '-' + FBaseline.SnapshotReadAllText(Path) +
+          LineEnding;
+      Result := Result + '+' + FFs.SnapshotReadAllText(Path) + LineEnding;
     end;
 
     for I := 0 to BaselinePaths.Count - 1 do
@@ -494,8 +615,20 @@ begin
       Result := Result + '--- ' + Path + LineEnding;
       Result := Result + '+++ ' + Path + LineEnding;
       Result := Result + '@@ sandbox file deleted @@' + LineEnding;
-      Result := Result + '-' + FBaseline.ReadAllText(Path) + LineEnding;
+      Result := Result + '-' + FBaseline.SnapshotReadAllText(Path) +
+        LineEnding;
     end;
+
+    if AIncludeMetadata and Assigned(FBaseline) then
+      for I := 0 to CurrentPaths.Count - 1 do
+      begin
+        Path := CurrentPaths[I];
+        if not FBaseline.Exists(Path) then
+          Continue;
+        CurrentStat := FFs.Stat(Path);
+        BaselineStat := FBaseline.Stat(Path);
+        AppendUnifiedMetadataChange(Result, Path, BaselineStat, CurrentStat);
+      end;
   finally
     BaselinePaths.Free;
     CurrentPaths.Free;

--- a/source/units/Goccia.Shims.pas
+++ b/source/units/Goccia.Shims.pas
@@ -58,16 +58,24 @@ procedure RegisterDefaultShimNames(const AShims: TStringList);
 function LoadShimValue(const AInterpreter: TGocciaInterpreter;
   const AShim: TGocciaShimDefinition): TGocciaValue;
 
+{ Return the realm's original Date constructor without consulting the mutable
+  global property.  Materializes the Date shim on first use. }
+function GetDateIntrinsic(const AInterpreter: TGocciaInterpreter): TGocciaValue;
+
 implementation
 
 uses
+  SysUtils,
+
   Goccia.AST.Node,
   Goccia.Evaluator,
   Goccia.Evaluator.Context,
+  Goccia.Realm,
   Goccia.Scope,
   Goccia.SourcePipeline;
 
 const
+  DATE_SHIM_NAME = 'Date';
   DEFAULT_SHIMS: array[0..13] of TGocciaShimDefinition = (
     ( // WHATWG HTML spec §8.3 — legacy btoa(data) via Uint8Array.toBase64
       Name: 'btoa';
@@ -159,7 +167,7 @@ const
         ' Number.isFinite(Number(x));'
     ),
     ( // Legacy Date constructor via Temporal
-      Name: 'Date';
+      Name: DATE_SHIM_NAME;
       FileName: '<shim:Date>';
       Source:
         'const dateTimeClipLimit: number = 8.64e15;'#10 +
@@ -975,6 +983,9 @@ const
     )
   );
 
+var
+  GDateIntrinsicSlot: TGocciaRealmSlotId;
+
 function DefaultShimCount: Integer;
 begin
   Result := Length(DEFAULT_SHIMS);
@@ -996,6 +1007,7 @@ end;
 function LoadShimValue(const AInterpreter: TGocciaInterpreter;
   const AShim: TGocciaShimDefinition): TGocciaValue;
 var
+  CachedValue: TObject;
   ModuleParseResult: TGocciaSourcePipelineModuleResult;
   PipelineOptions: TGocciaSourcePipelineOptions;
   ProgramNode: TGocciaProgram;
@@ -1003,6 +1015,13 @@ var
   Context: TGocciaEvaluationContext;
   I: Integer;
 begin
+  if AShim.Name = DATE_SHIM_NAME then
+  begin
+    CachedValue := CurrentRealm.GetSlot(GDateIntrinsicSlot);
+    if CachedValue is TGocciaValue then
+      Exit(TGocciaValue(CachedValue));
+  end;
+
   PipelineOptions := TGocciaSourcePipeline.DefaultOptions;
   PipelineOptions.Preprocessors := [];
   PipelineOptions.Compatibility := [cfFunction];
@@ -1026,12 +1045,25 @@ begin
       for I := 0 to ProgramNode.Body.Count - 1 do
         EvaluateStatement(ProgramNode.Body[I], Context);
       Result := ModuleScope.GetValue(AShim.Name);
+      if AShim.Name = DATE_SHIM_NAME then
+        CurrentRealm.SetSlot(GDateIntrinsicSlot, Result);
     finally
       ProgramNode.Free;
     end;
   finally
     ModuleParseResult.Free;
   end;
+end;
+
+function GetDateIntrinsic(
+  const AInterpreter: TGocciaInterpreter): TGocciaValue;
+var
+  I: Integer;
+begin
+  for I := Low(DEFAULT_SHIMS) to High(DEFAULT_SHIMS) do
+    if DEFAULT_SHIMS[I].Name = DATE_SHIM_NAME then
+      Exit(LoadShimValue(AInterpreter, DEFAULT_SHIMS[I]));
+  raise Exception.Create('Date shim is not registered');
 end;
 
 function IsSideEffectShim(const AName: string): Boolean;
@@ -1054,5 +1086,8 @@ function TGocciaShimMaterializer.Materialize: TGocciaValue;
 begin
   Result := LoadShimValue(FInterpreter, FShim);
 end;
+
+initialization
+  GDateIntrinsicSlot := RegisterRealmSlot('%Date%');
 
 end.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Track independent access, modification, change, and birth timestamps in the sandbox VFS with an injectable non-owned clock and clock-neutral, metadata-preserving forks.
- Expose Node-shaped realm-owned Stats snapshots with numeric timestamp fields, lazy Date accessors bound to the realm's original Date intrinsic, and `isSymbolicLink()`.
- Add opt-in `--diff-metadata` / `diffMetadata: true` reporting as a separate metadata dimension while keeping default diffs content- and namespace-only.
- Keep real-time conversion safe on FPC 3.2.2 and omit the VFS's implicit root from JSON and unified metadata diffs.
- Update sandbox documentation and terminology. Symlinks remain unsupported, so `isSymbolicLink()` always returns `false`.
- Closes #870.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests (`bun scripts/test-cli-apps.ts`; interpreter and bytecode Stats coverage, intrinsic replacement coverage, and JSON/unified root-metadata omission)
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (`./build.pas tests`; all 46 test binaries passed, plus the focused default-clock Unix-epoch regression)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional verification: `./build/GocciaTestRunner tests`, `./build/GocciaTestRunner tests --mode=bytecode` (1,350 files / 11,305 tests per executor), `./format.pas --check`, `git diff --check`, and pre-commit source hooks.
