### PR TITLE
chore(jetstream): bump pinned corpus

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -495,7 +495,7 @@ node scripts/jetstream-ci-report.js \
 ```
 
 `perf/jetstream/manifest.json` pins JetStream 3.0 commit
-`3967678fa8ab98d847ab33cf3728dba726fa854b`, driver version, process
+`b7babdf323e64e69bd2f6c376189c15825f5c73a`, driver version, process
 repetitions, and these six workloads: `hash-map`, `ai-astar`, `gaussian-blur`,
 `raytrace-public-class-fields`, `sync-fs`, and `lazy-collections`. The selection
 covers collections, control flow, numeric/array work, public class fields,

--- a/perf/jetstream/manifest.json
+++ b/perf/jetstream/manifest.json
@@ -3,7 +3,7 @@
   "jetStream": {
     "repository": "https://github.com/WebKit/JetStream",
     "ref": "main",
-    "commit": "3967678fa8ab98d847ab33cf3728dba726fa854b",
+    "commit": "b7babdf323e64e69bd2f6c376189c15825f5c73a",
     "release": "3.0",
     "benchmarks": {
       "hash-map": {


### PR DESCRIPTION
## Summary

- Advance the frozen JetStream 3 corpus pin to the current WebKit/JetStream `main` commit, `b7babdf323e64e69bd2f6c376189c15825f5c73a`.
- Update the operational benchmark documentation to match the manifest.
- Preserve ADR 0091's original SHA as historical decision context.

The upstream histories have diverged, but all six selected workload files are byte-identical at the old and new commits. This changes the retained corpus-SHA version boundary without changing the workload bytes.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional validation:

- verified the new full SHA is current WebKit/JetStream `main`
- verified all six selected file blob hashes match the old pin
- ran all six pinned workloads from a sparse checkout under Goccia; every sample reported `ok`
- `node scripts/test-jetstream-driver.js` — 41 assertions
- `./build.pas testrunner`
- `./build/GocciaTestRunner tests`
- `./build/GocciaTestRunner tests --mode=bytecode`
- `./format.pas --check`
- Markdown lint and all documentation checks