### PR TITLE
ci(jetstream): automate weekly pin bumps

### DIFF
--- a/.github/workflows/jetstream-bump.yml
+++ b/.github/workflows/jetstream-bump.yml
@@ -1,0 +1,68 @@
+name: JetStream weekly bump
+
+# Pulls the latest WebKit/JetStream main SHA, updates the frozen corpus pin and
+# its current-reference documentation, and opens a PR. Merge once the complete
+# JetStream report remains acceptable.
+#
+# Cadence: weekly (Mondays 08:30 UTC). Manual trigger available via
+# workflow_dispatch.
+
+on:
+  schedule:
+    - cron: '30 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - id: latest
+        run: |
+          sha=$(gh api repos/WebKit/JetStream/commits/main --jq .sha)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "short=${sha:0:8}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update JetStream pin
+        env:
+          JETSTREAM_SHA: ${{ steps.latest.outputs.sha }}
+        run: |
+          bun scripts/jetstream-bump-pin.ts "$JETSTREAM_SHA"
+
+      - id: changed
+        run: |
+          if git diff --quiet -- perf/jetstream/manifest.json docs/benchmarks.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "JetStream is already pinned to ${{ steps.latest.outputs.short }}; no PR to open."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update PR
+        if: steps.changed.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          branch: chore/jetstream-bump
+          commit-message: "chore(jetstream): bump pin to ${{ steps.latest.outputs.short }}"
+          title: "chore(jetstream): bump pin to ${{ steps.latest.outputs.short }}"
+          body: |
+            Automated bump of the JetStream corpus SHA to `${{ steps.latest.outputs.sha }}`.
+
+            CI will run every frozen JetStream workload and publish the
+            cross-engine report. Review workload-source changes and the new
+            corpus-version boundary before merging.
+
+            Cron: weekly, Mondays 08:30 UTC. See `.github/workflows/jetstream-bump.yml`.
+          labels: |
+            performance
+            automated

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -503,6 +503,13 @@ generators, and iterators without requiring Wasm, DOM, workers, a host filesyste
 or a second copy of the Web Tooling lane. The private-field raytrace variant is
 excluded because it does not complete inside the diagnostic time budget.
 
+### Updating the JetStream Pin
+
+`.github/workflows/jetstream-bump.yml` checks WebKit/JetStream `main` weekly,
+updates the manifest and current pin reference with
+`scripts/jetstream-bump-pin.ts`, and opens an automated PR only when
+the SHA changes. PR CI runs the complete frozen subset before merge.
+
 The driver concatenates the listed upstream files unchanged into one generated
 shell entry per workload. The generic adapter supplies timing, deterministic
 randomness where the manifest requests it, and result serialization. Each suite

--- a/scripts/jetstream-bump-pin.ts
+++ b/scripts/jetstream-bump-pin.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+/**
+ * Update the JetStream corpus SHA in the benchmark manifest and current
+ * benchmark documentation.
+ *
+ * Usage:
+ *   bun scripts/jetstream-bump-pin.ts <new-sha> [manifest-path] [docs-path]
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const DEFAULT_MANIFEST = "perf/jetstream/manifest.json";
+const DEFAULT_DOCS = "docs/benchmarks.md";
+
+function readText(target: string): string {
+  try {
+    return readFileSync(target, "utf8");
+  } catch (error) {
+    throw new Error(`Failed to read ${target}: ${(error as Error).message}`);
+  }
+}
+
+function main(argv: string[]): number {
+  if (argv.length < 1 || argv.length > 3 || !SHA_RE.test(argv[0] ?? "")) {
+    console.error(
+      "Usage: bun scripts/jetstream-bump-pin.ts " +
+        "<40-hex-sha> [manifest-path] [docs-path]",
+    );
+    return 2;
+  }
+
+  const [newSha, manifestPath = DEFAULT_MANIFEST, docsPath = DEFAULT_DOCS] =
+    argv;
+
+  try {
+    const manifestText = readText(manifestPath);
+    const docsText = readText(docsPath);
+
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(manifestText);
+    } catch (error) {
+      throw new Error(
+        `${manifestPath}: invalid JSON: ${(error as Error).message}`,
+      );
+    }
+
+    const oldSha = (
+      manifest as { jetStream?: { commit?: unknown } }
+    ).jetStream?.commit;
+    if (typeof oldSha !== "string" || !SHA_RE.test(oldSha)) {
+      throw new Error(
+        `${manifestPath}: expected jetStream.commit to be one 40-hex SHA`,
+      );
+    }
+
+    if (!docsText.includes(oldSha)) {
+      throw new Error(`${docsPath}: expected current JetStream pin ${oldSha}`);
+    }
+    if (oldSha === newSha) {
+      console.log(`${manifestPath}: already at ${newSha}`);
+      return 0;
+    }
+
+    writeFileSync(manifestPath, manifestText.replace(oldSha, newSha));
+    writeFileSync(docsPath, docsText.replaceAll(oldSha, newSha));
+    console.log(`${manifestPath}: bumped JetStream pin -> ${newSha}`);
+    console.log(`${docsPath}: synchronized JetStream pin -> ${newSha}`);
+    return 0;
+  } catch (error) {
+    console.error((error as Error).message);
+    return 1;
+  }
+}
+
+process.exit(main(process.argv.slice(2)));


### PR DESCRIPTION
## Summary

- add a standalone weekly JetStream pin updater
- keep the manifest and its current documentation reference synchronized
- open a focused automated PR only when WebKit/JetStream main advances

## Testing

- [x] `actionlint .github/workflows/jetstream-bump.yml`
- [x] Live upstream no-op validation against WebKit/JetStream `main`
- [x] Updater changed-pin, repeat no-op, and invalid-input fixtures
- [x] `node scripts/test-jetstream-driver.js` (41 assertions)
- [x] `./format.pas --check`
- [x] Markdown lint, doc symbols, duplication, length, and links

The AWFY and Web Tooling update lanes remain separate workflows and PRs.