### PR TITLE
perf(regexp): avoid discarded match arrays

### DIFF
--- a/benchmarks/regexp.js
+++ b/benchmarks/regexp.js
@@ -60,6 +60,13 @@ group("String integration with RegExp", () => {
     };
   } }).setup);
 
+  bench("match() with many global results", ({ *setup() {
+    const input = (() => "foo ".repeat(256))();
+    yield () => {
+      const matches = input.match(/foo/g);
+    };
+  } }).setup);
+
   bench("matchAll() with capture groups", ({ *setup() {
     const input = (() => "foo1 foo2 foo3")();
     yield () => {
@@ -72,6 +79,13 @@ group("String integration with RegExp", () => {
 
   bench("replace() with global regex", ({ *setup() {
     const input = (() => "foo bar foo baz foo")();
+    yield () => {
+      const replaced = input.replace(/foo/g, "qux");
+    };
+  } }).setup);
+
+  bench("replace() with many global results", ({ *setup() {
+    const input = (() => "foo ".repeat(256))();
     yield () => {
       const replaced = input.replace(/foo/g, "qux");
     };

--- a/source/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/source/units/Goccia.Builtins.GlobalRegExp.pas
@@ -1264,7 +1264,7 @@ function TGocciaGlobalRegExp.RegExpSymbolMatch(
   const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 var
   Flags, Input, MatchString: string;
-  RegexValue: TGocciaObjectValue;
+  RegexValue, RetainedObject: TGocciaObjectValue;
   Match: TGocciaRegExpExecutionResult;
   MatchValue: TGocciaValue;
   ResultArray: TGocciaArrayValue;
@@ -1306,7 +1306,15 @@ begin
         Exit;
       end;
 
-      MatchString := Match.MatchedText;
+      RetainedObject := TGocciaObjectValue(Match.RetainedObject);
+      if Assigned(RetainedObject) then
+        TGarbageCollector.Instance.AddTempRoot(RetainedObject);
+      try
+        MatchString := Match.MatchedText;
+      finally
+        if Assigned(RetainedObject) then
+          TGarbageCollector.Instance.RemoveTempRoot(RetainedObject);
+      end;
       ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(MatchString));
       if MatchString = '' then
         AdvanceProtocolLastIndexAfterEmptyMatch(RegexValue, Input, IsUnicode);

--- a/source/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/source/units/Goccia.Builtins.GlobalRegExp.pas
@@ -1364,8 +1364,8 @@ var
   NamedCapturesValue, ReplaceValue, ReplacementValue: TGocciaValue;
   CaptureMatched, FunctionalReplace, Global, IsUnicode: Boolean;
   Match: TGocciaRegExpExecutionResult;
-  NamedCapturesObject, NamedCapturesRoot, RegexValue,
-  RetainedObject: TGocciaObjectValue;
+  NamedCapturesObject, RegexValue, RetainedObject: TGocciaObjectValue;
+  NamedCapturesRoot: TGocciaTempRoot;
   Results: TRegExpExecutionResults;
 begin
   RegexValue := RequireRegExpObjectReceiver(AThisValue,
@@ -1444,12 +1444,10 @@ begin
       end;
 
       NamedCapturesValue := Results[I].NamedCapturesValue;
-      NamedCapturesRoot := nil;
+      InitializeTempRoot(NamedCapturesRoot);
       if NamedCapturesValue is TGocciaObjectValue then
-      begin
-        NamedCapturesRoot := TGocciaObjectValue(NamedCapturesValue);
-        TGarbageCollector.Instance.AddTempRoot(NamedCapturesRoot);
-      end;
+        AddTempRootIfNeeded(NamedCapturesRoot,
+          TGocciaObjectValue(NamedCapturesValue));
       try
         if FunctionalReplace then
         begin
@@ -1480,8 +1478,7 @@ begin
             Matched, Input, Position, Captures, NamedCapturesObject);
         end;
       finally
-        if Assigned(NamedCapturesRoot) then
-          TGarbageCollector.Instance.RemoveTempRoot(NamedCapturesRoot);
+        RemoveTempRootIfNeeded(NamedCapturesRoot);
       end;
 
       if Position >= NextSourcePosition then

--- a/source/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/source/units/Goccia.Builtins.GlobalRegExp.pas
@@ -121,8 +121,11 @@ type
 
   TReplacementFragments = array of TReplacementFragment;
 
+  TRegExpExecutionResults = array of TGocciaRegExpExecutionResult;
+
 const
   INITIAL_REPLACEMENT_FRAGMENT_CAPACITY = 8;
+  INITIAL_REGEXP_EXECUTION_RESULT_CAPACITY = 8;
 
 var
   GRegExpPrototypeSlot: TGocciaRealmSlotId;
@@ -157,19 +160,6 @@ function GetRegexMatchElement(const AMatchArray: TGocciaObjectValue;
   const AIndex: Integer): TGocciaValue;
 begin
   Result := AMatchArray.GetProperty(IntToStr(AIndex));
-end;
-
-function ToIntegerOrInfinityClampedIndex(const AValue: TGocciaValue;
-  const AInputLength: Integer): Integer;
-var
-  Index: TGocciaNumberLiteralValue;
-begin
-  Index := AValue.ToNumberLiteral;
-  if Index.IsNaN or Index.IsNegativeInfinity or (Index.Value <= 0) then
-    Exit(0);
-  if Index.IsInfinity or (Index.Value >= AInputLength) then
-    Exit(AInputLength);
-  Result := Trunc(Index.Value);
 end;
 
 function RegExpSpeciesConstructor(const ARegExp: TGocciaObjectValue;
@@ -372,6 +362,25 @@ begin
     else
       NewCapacity := NewCapacity * 2;
   SetLength(AFragments, NewCapacity);
+end;
+
+procedure EnsureRegExpExecutionResultCapacity(
+  var AResults: TRegExpExecutionResults; const ARequiredCount: Integer);
+var
+  NewCapacity: Integer;
+begin
+  if Length(AResults) >= ARequiredCount then
+    Exit;
+
+  NewCapacity := Length(AResults);
+  if NewCapacity = 0 then
+    NewCapacity := INITIAL_REGEXP_EXECUTION_RESULT_CAPACITY;
+  while NewCapacity < ARequiredCount do
+    if NewCapacity > MaxInt div 2 then
+      NewCapacity := ARequiredCount
+    else
+      NewCapacity := NewCapacity * 2;
+  SetLength(AResults, NewCapacity);
 end;
 
 procedure AddReplacementTextFragment(var AFragments: TReplacementFragments;
@@ -1256,8 +1265,8 @@ function TGocciaGlobalRegExp.RegExpSymbolMatch(
 var
   Flags, Input, MatchString: string;
   RegexValue: TGocciaObjectValue;
+  Match: TGocciaRegExpExecutionResult;
   MatchValue: TGocciaValue;
-  MatchArray: TGocciaObjectValue;
   ResultArray: TGocciaArrayValue;
   MatchCount: Integer;
   IsUnicode: Boolean;
@@ -1288,7 +1297,7 @@ begin
     MatchCount := 0;
     while True do
     begin
-      if not MatchRegExpObjectOnce(RegexValue, Input, MatchValue) then
+      if not MatchRegExpObjectOnceResult(RegexValue, Input, Match) then
       begin
         if MatchCount = 0 then
           Result := TGocciaNullLiteralValue.NullValue
@@ -1297,8 +1306,7 @@ begin
         Exit;
       end;
 
-      MatchArray := TGocciaObjectValue(MatchValue);
-      MatchString := MatchArray.GetProperty('0').ToStringLiteral.Value;
+      MatchString := Match.MatchedText;
       ResultArray.Elements.Add(TGocciaStringLiteralValue.Create(MatchString));
       if MatchString = '' then
         AdvanceProtocolLastIndexAfterEmptyMatch(RegexValue, Input, IsUnicode);
@@ -1352,12 +1360,13 @@ var
   CallArgs: TGocciaArgumentsCollection;
   Captures: TRegexReplacementCaptures;
   CaptureNumber, CaptureCount, I, MatchLength, NextSourcePosition,
-  Position, ResultLength: Integer;
-  CaptureValue, MatchValue, NamedCapturesValue, ReplaceValue,
-  ReplacementValue: TGocciaValue;
-  FunctionalReplace, Global, IsUnicode: Boolean;
-  MatchArray, NamedCapturesObject, RegexValue: TGocciaObjectValue;
-  Results: TGocciaValueList;
+  Position, ResultCount, InputLength: Integer;
+  NamedCapturesValue, ReplaceValue, ReplacementValue: TGocciaValue;
+  CaptureMatched, FunctionalReplace, Global, IsUnicode: Boolean;
+  Match: TGocciaRegExpExecutionResult;
+  NamedCapturesObject, NamedCapturesRoot, RegexValue,
+  RetainedObject: TGocciaObjectValue;
+  Results: TRegExpExecutionResults;
 begin
   RegexValue := RequireRegExpObjectReceiver(AThisValue,
     'RegExp.prototype[Symbol.replace]');
@@ -1382,91 +1391,97 @@ begin
   if Global then
     RegexValue.SetProperty(PROP_LAST_INDEX, TGocciaNumberLiteralValue.Create(0));
 
-  Results := TGocciaValueList.Create(False);
+  ResultCount := 0;
   try
     while True do
     begin
-      if not MatchRegExpObjectOnce(RegexValue, Input, MatchValue) then
+      if not MatchRegExpObjectOnceResult(RegexValue, Input, Match) then
         Break;
 
-      Results.Add(MatchValue);
-      if MatchValue is TGocciaObjectValue then
-        TGarbageCollector.Instance.AddTempRoot(TGocciaObjectValue(MatchValue));
+      EnsureRegExpExecutionResultCapacity(Results, ResultCount + 1);
+      Results[ResultCount] := Match;
+      Inc(ResultCount);
+      RetainedObject := TGocciaObjectValue(Match.RetainedObject);
+      if Assigned(RetainedObject) then
+        TGarbageCollector.Instance.AddTempRoot(RetainedObject);
 
       if not Global then
         Break;
 
-      Matched := TGocciaObjectValue(MatchValue).GetProperty('0')
-        .ToStringLiteral.Value;
+      Matched := Match.MatchedText;
       if Matched = '' then
         AdvanceProtocolLastIndexAfterEmptyMatch(RegexValue, Input, IsUnicode);
     end;
 
     AccumulatedResult := '';
+    InputLength := UTF16CodeUnitLength(Input);
     NextSourcePosition := 0;
-    for I := 0 to Results.Count - 1 do
+    for I := 0 to ResultCount - 1 do
     begin
-      MatchArray := TGocciaObjectValue(Results[I]);
-      ResultLength := GetRegexMatchLength(MatchArray);
-      if ResultLength > 1 then
-        CaptureCount := ResultLength - 1
-      else
-        CaptureCount := 0;
+      CaptureCount := Results[I].CaptureCount;
 
-      Matched := MatchArray.GetProperty('0').ToStringLiteral.Value;
+      Matched := Results[I].MatchedText;
       MatchLength := UTF16CodeUnitLength(Matched);
-      Position := ToIntegerOrInfinityClampedIndex(
-        MatchArray.GetProperty(PROP_INDEX), UTF16CodeUnitLength(Input));
+      Position := Results[I].MatchIndex(InputLength);
 
       SetLength(Captures, CaptureCount);
       for CaptureNumber := 1 to CaptureCount do
       begin
-        CaptureValue := MatchArray.GetProperty(IntToStr(CaptureNumber));
-        if CaptureValue is TGocciaUndefinedLiteralValue then
+        Captures[CaptureNumber - 1].Text := Results[I].CaptureText(
+          CaptureNumber, CaptureMatched);
+        if not CaptureMatched then
         begin
           Captures[CaptureNumber - 1].Value :=
             TGocciaUndefinedLiteralValue.UndefinedValue;
-          Captures[CaptureNumber - 1].Text := '';
           Captures[CaptureNumber - 1].Matched := False;
         end
         else
         begin
-          Captures[CaptureNumber - 1].Text :=
-            CaptureValue.ToStringLiteral.Value;
           Captures[CaptureNumber - 1].Value :=
             TGocciaStringLiteralValue.Create(Captures[CaptureNumber - 1].Text);
           Captures[CaptureNumber - 1].Matched := True;
         end;
       end;
 
-      NamedCapturesValue := MatchArray.GetProperty(PROP_GROUPS);
-      if FunctionalReplace then
+      NamedCapturesValue := Results[I].NamedCapturesValue;
+      NamedCapturesRoot := nil;
+      if NamedCapturesValue is TGocciaObjectValue then
       begin
-        CallArgs := TGocciaArgumentsCollection.CreateWithCapacity(
-          CaptureCount + 4);
-        try
-          CallArgs.Add(TGocciaStringLiteralValue.Create(Matched));
-          for CaptureNumber := 0 to CaptureCount - 1 do
-            CallArgs.Add(Captures[CaptureNumber].Value);
-          CallArgs.Add(TGocciaNumberLiteralValue.Create(Position));
-          CallArgs.Add(TGocciaStringLiteralValue.Create(Input));
-          if not (NamedCapturesValue is TGocciaUndefinedLiteralValue) then
-            CallArgs.Add(NamedCapturesValue);
-          ReplacementValue := InvokeCallable(ReplaceValue, CallArgs,
-            TGocciaUndefinedLiteralValue.UndefinedValue);
-          ReplacementString := ReplacementValue.ToStringLiteral.Value;
-        finally
-          CallArgs.Free;
-        end;
-      end
-      else
-      begin
-        if NamedCapturesValue is TGocciaUndefinedLiteralValue then
-          NamedCapturesObject := nil
+        NamedCapturesRoot := TGocciaObjectValue(NamedCapturesValue);
+        TGarbageCollector.Instance.AddTempRoot(NamedCapturesRoot);
+      end;
+      try
+        if FunctionalReplace then
+        begin
+          CallArgs := TGocciaArgumentsCollection.CreateWithCapacity(
+            CaptureCount + 4);
+          try
+            CallArgs.Add(TGocciaStringLiteralValue.Create(Matched));
+            for CaptureNumber := 0 to CaptureCount - 1 do
+              CallArgs.Add(Captures[CaptureNumber].Value);
+            CallArgs.Add(TGocciaNumberLiteralValue.Create(Position));
+            CallArgs.Add(TGocciaStringLiteralValue.Create(Input));
+            if not (NamedCapturesValue is TGocciaUndefinedLiteralValue) then
+              CallArgs.Add(NamedCapturesValue);
+            ReplacementValue := InvokeCallable(ReplaceValue, CallArgs,
+              TGocciaUndefinedLiteralValue.UndefinedValue);
+            ReplacementString := ReplacementValue.ToStringLiteral.Value;
+          finally
+            CallArgs.Free;
+          end;
+        end
         else
-          NamedCapturesObject := ToObject(NamedCapturesValue);
-        ReplacementString := ExpandRegexReplacementString(ReplacementText,
-          Matched, Input, Position, Captures, NamedCapturesObject);
+        begin
+          if NamedCapturesValue is TGocciaUndefinedLiteralValue then
+            NamedCapturesObject := nil
+          else
+            NamedCapturesObject := ToObject(NamedCapturesValue);
+          ReplacementString := ExpandRegexReplacementString(ReplacementText,
+            Matched, Input, Position, Captures, NamedCapturesObject);
+        end;
+      finally
+        if Assigned(NamedCapturesRoot) then
+          TGarbageCollector.Instance.RemoveTempRoot(NamedCapturesRoot);
       end;
 
       if Position >= NextSourcePosition then
@@ -1479,20 +1494,22 @@ begin
       end;
     end;
 
-    if NextSourcePosition >= UTF16CodeUnitLength(Input) then
+    if NextSourcePosition >= InputLength then
       Result := TGocciaStringLiteralValue.Create(AccumulatedResult)
     else
     begin
       AppendReplacementFragment(AccumulatedResult,
         UTF16Substring(Input, NextSourcePosition,
-          UTF16CodeUnitLength(Input) - NextSourcePosition));
+          InputLength - NextSourcePosition));
       Result := TGocciaStringLiteralValue.Create(AccumulatedResult);
     end;
   finally
-    for I := 0 to Results.Count - 1 do
-      if Results[I] is TGocciaObjectValue then
-        TGarbageCollector.Instance.RemoveTempRoot(TGocciaObjectValue(Results[I]));
-    Results.Free;
+    for I := 0 to ResultCount - 1 do
+    begin
+      RetainedObject := TGocciaObjectValue(Results[I].RetainedObject);
+      if Assigned(RetainedObject) then
+        TGarbageCollector.Instance.RemoveTempRoot(RetainedObject);
+    end;
   end;
 end;
 

--- a/source/units/Goccia.RegExp.Runtime.pas
+++ b/source/units/Goccia.RegExp.Runtime.pas
@@ -8,6 +8,31 @@ uses
   Goccia.RegExp.Engine,
   Goccia.Values.Primitives;
 
+type
+  TGocciaRegExpExecutionResultKind = (rerkNative, rerkCustom);
+
+  TGocciaRegExpExecutionResult = record
+  private
+    FKind: TGocciaRegExpExecutionResultKind;
+    FInput: string;
+    FNativeMatch: TGocciaRegExpMatchResult;
+    FCustomMatch: TGocciaValue;
+  public
+    class function FromNative(const AInput: string;
+      const AMatch: TGocciaRegExpMatchResult): TGocciaRegExpExecutionResult;
+      static;
+    class function FromCustom(
+      const AMatch: TGocciaValue): TGocciaRegExpExecutionResult; static;
+    function Materialize: TGocciaValue;
+    function MatchedText: string;
+    function MatchIndex(const AInputLength: Integer): Integer;
+    function CaptureCount: Integer;
+    function CaptureText(const AIndex: Integer;
+      out AMatched: Boolean): string;
+    function NamedCapturesValue: TGocciaValue;
+    function RetainedObject: TGocciaValue;
+  end;
+
 function GetRegExpPrototype: TGocciaValue;
 function GetRegExpBuiltinExec: TGocciaValue;
 procedure SetRegExpPrototype(const APrototype: TGocciaValue);
@@ -25,6 +50,8 @@ function GetRegExpInternalSource(const AValue: TGocciaValue): string;
 function GetRegExpInternalFlags(const AValue: TGocciaValue): string;
 function MatchRegExpObjectOnce(const AValue: TGocciaValue; const AInput: string;
   out AMatchArray: TGocciaValue): Boolean;
+function MatchRegExpObjectOnceResult(const AValue: TGocciaValue;
+  const AInput: string; out AMatch: TGocciaRegExpExecutionResult): Boolean;
 function MatchRegExpBuiltinObjectOnce(const AValue: TGocciaValue;
   const AInput: string; out AMatchArray: TGocciaValue): Boolean;
 function MatchRegExpObject(const AValue: TGocciaValue; const AInput: string;
@@ -61,7 +88,8 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
-  Goccia.Values.SymbolValue;
+  Goccia.Values.SymbolValue,
+  Goccia.Values.ToObject;
 
 type
   TGocciaRegExpProgramData = class
@@ -149,6 +177,11 @@ end;
 
 function CreateRegExpObjectFromProgram(const APattern, AFlags: string;
   const ACompiledProgram: TRegExpProgram): TGocciaValue; forward;
+function MatchRegExpObjectResult(const AValue: TGocciaValue;
+  const AInput: string; const AStartIndex: Integer;
+  const ARequireStart, AUpdateLastIndex: Boolean;
+  out AMatch: TGocciaRegExpExecutionResult; out AMatchIndex, AMatchEnd,
+  ANextIndex: Integer; const AUseCustomExec: Boolean = True): Boolean; forward;
 
 function GetRegExpProgramData(const AValue: TGocciaValue): TGocciaRegExpProgramData;
 begin
@@ -313,13 +346,44 @@ begin
 end;
 
 // ES2026 §22.2.7.3 BuildMatchArray
+function BuildNamedGroupsValue(
+  const AMatchResult: TGocciaRegExpMatchResult): TGocciaValue;
+var
+  GroupsObject: TGocciaObjectValue;
+  GroupIndex: Integer;
+  I: Integer;
+begin
+  if Length(AMatchResult.NamedGroups) = 0 then
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+
+  GroupsObject := TGocciaObjectValue.Create(nil);
+  // ES2026: Two-pass approach for duplicate named capture groups.
+  // Pass 1: Initialize all unique names to undefined.
+  for I := 0 to High(AMatchResult.NamedGroups) do
+    GroupsObject.AssignProperty(AMatchResult.NamedGroups[I].Name,
+      TGocciaUndefinedLiteralValue.UndefinedValue);
+  // Pass 2: Overwrite with matched values. For duplicate names, only the
+  // participating group's value is set — non-participating duplicates are
+  // skipped, preserving the correct value regardless of iteration order.
+  for I := 0 to High(AMatchResult.NamedGroups) do
+  begin
+    GroupIndex := AMatchResult.NamedGroups[I].Index;
+    if (GroupIndex <= High(AMatchResult.Groups)) and
+       AMatchResult.Groups[GroupIndex].Matched then
+      GroupsObject.AssignProperty(AMatchResult.NamedGroups[I].Name,
+        TGocciaStringLiteralValue.Create(
+          AMatchResult.Groups[GroupIndex].Value));
+  end;
+  Result := GroupsObject;
+end;
+
 function BuildMatchArray(const AInput: string;
   const AMatchResult: TGocciaRegExpMatchResult): TGocciaObjectValue;
 var
   IndicesArray: TGocciaArrayValue;
   IndicesGroupsObject: TGocciaObjectValue;
   MatchArray: TGocciaArrayValue;
-  GroupsObject: TGocciaObjectValue;
+  GroupsValue: TGocciaValue;
   GroupIndex: Integer;
   I: Integer;
 
@@ -344,31 +408,8 @@ begin
     TGocciaNumberLiteralValue.Create(AMatchResult.MatchIndex));
   MatchArray.CreateDataPropertyOrThrow(PROP_INPUT,
     TGocciaStringLiteralValue.Create(AInput));
-  if Length(AMatchResult.NamedGroups) > 0 then
-  begin
-    GroupsObject := TGocciaObjectValue.Create(nil);
-    // ES2025: Two-pass approach for duplicate named capture groups.
-    // Pass 1: Initialize all unique names to undefined.
-    for I := 0 to High(AMatchResult.NamedGroups) do
-      GroupsObject.AssignProperty(AMatchResult.NamedGroups[I].Name,
-        TGocciaUndefinedLiteralValue.UndefinedValue);
-    // Pass 2: Overwrite with matched values. For duplicate names, only the
-    // participating group's value is set — non-participating duplicates are
-    // skipped, preserving the correct value regardless of iteration order.
-    for I := 0 to High(AMatchResult.NamedGroups) do
-    begin
-      GroupIndex := AMatchResult.NamedGroups[I].Index;
-      if (GroupIndex <= High(AMatchResult.Groups)) and
-         AMatchResult.Groups[GroupIndex].Matched then
-        GroupsObject.AssignProperty(AMatchResult.NamedGroups[I].Name,
-          TGocciaStringLiteralValue.Create(
-            AMatchResult.Groups[GroupIndex].Value));
-    end;
-    MatchArray.CreateDataPropertyOrThrow(PROP_GROUPS, GroupsObject);
-  end
-  else
-    MatchArray.CreateDataPropertyOrThrow(PROP_GROUPS,
-      TGocciaUndefinedLiteralValue.UndefinedValue);
+  GroupsValue := BuildNamedGroupsValue(AMatchResult);
+  MatchArray.CreateDataPropertyOrThrow(PROP_GROUPS, GroupsValue);
 
   if AMatchResult.HasIndices then
   begin
@@ -409,6 +450,107 @@ begin
   end;
 
   Result := MatchArray;
+end;
+
+class function TGocciaRegExpExecutionResult.FromNative(const AInput: string;
+  const AMatch: TGocciaRegExpMatchResult): TGocciaRegExpExecutionResult;
+begin
+  Result.FKind := rerkNative;
+  Result.FInput := AInput;
+  Result.FNativeMatch := AMatch;
+  Result.FCustomMatch := nil;
+end;
+
+class function TGocciaRegExpExecutionResult.FromCustom(
+  const AMatch: TGocciaValue): TGocciaRegExpExecutionResult;
+begin
+  Result.FKind := rerkCustom;
+  Result.FInput := '';
+  Result.FCustomMatch := AMatch;
+end;
+
+function TGocciaRegExpExecutionResult.Materialize: TGocciaValue;
+begin
+  if FKind = rerkCustom then
+    Exit(FCustomMatch);
+  Result := BuildMatchArray(FInput, FNativeMatch);
+end;
+
+function TGocciaRegExpExecutionResult.MatchedText: string;
+begin
+  if FKind = rerkCustom then
+    Exit(TGocciaObjectValue(FCustomMatch).GetProperty('0')
+      .ToStringLiteral.Value);
+  Result := FNativeMatch.Groups[0].Value;
+end;
+
+function TGocciaRegExpExecutionResult.MatchIndex(
+  const AInputLength: Integer): Integer;
+begin
+  if FKind = rerkCustom then
+    Exit(GetClampedIndexValue(
+      TGocciaObjectValue(FCustomMatch).GetProperty(PROP_INDEX),
+      AInputLength));
+  if FNativeMatch.MatchIndex <= 0 then
+    Exit(0);
+  if FNativeMatch.MatchIndex >= AInputLength then
+    Exit(AInputLength);
+  Result := FNativeMatch.MatchIndex;
+end;
+
+function TGocciaRegExpExecutionResult.CaptureCount: Integer;
+begin
+  if FKind = rerkCustom then
+  begin
+    Result := LengthOfArrayLike(TGocciaObjectValue(FCustomMatch));
+    if Result > 1 then
+      Dec(Result)
+    else
+      Result := 0;
+    Exit;
+  end;
+
+  Result := Length(FNativeMatch.Groups) - 1;
+  if Result < 0 then
+    Result := 0;
+end;
+
+function TGocciaRegExpExecutionResult.CaptureText(const AIndex: Integer;
+  out AMatched: Boolean): string;
+var
+  Value: TGocciaValue;
+begin
+  if FKind = rerkCustom then
+  begin
+    Value := TGocciaObjectValue(FCustomMatch).GetProperty(IntToStr(AIndex));
+    AMatched := not (Value is TGocciaUndefinedLiteralValue);
+    if AMatched then
+      Exit(Value.ToStringLiteral.Value);
+    Exit('');
+  end;
+
+  if (AIndex <= 0) or (AIndex > High(FNativeMatch.Groups)) or
+     not FNativeMatch.Groups[AIndex].Matched then
+  begin
+    AMatched := False;
+    Exit('');
+  end;
+  AMatched := True;
+  Result := FNativeMatch.Groups[AIndex].Value;
+end;
+
+function TGocciaRegExpExecutionResult.NamedCapturesValue: TGocciaValue;
+begin
+  if FKind = rerkCustom then
+    Exit(TGocciaObjectValue(FCustomMatch).GetProperty(PROP_GROUPS));
+  Result := BuildNamedGroupsValue(FNativeMatch);
+end;
+
+function TGocciaRegExpExecutionResult.RetainedObject: TGocciaValue;
+begin
+  if FKind = rerkCustom then
+    Exit(FCustomMatch);
+  Result := nil;
 end;
 
 function IsRegExpInstance(const AValue: TGocciaValue): Boolean;
@@ -531,25 +673,40 @@ end;
 function MatchRegExpObjectOnce(const AValue: TGocciaValue; const AInput: string;
   out AMatchArray: TGocciaValue): Boolean;
 var
-  Obj: TGocciaObjectValue;
+  Match: TGocciaRegExpExecutionResult;
+begin
+  Result := MatchRegExpObjectOnceResult(AValue, AInput, Match);
+  if Result then
+    AMatchArray := Match.Materialize
+  else
+    AMatchArray := nil;
+end;
+
+function MatchRegExpObjectOnceResult(const AValue: TGocciaValue;
+  const AInput: string; out AMatch: TGocciaRegExpExecutionResult): Boolean;
+var
+  CustomMatch: TGocciaValue;
   Flags: string;
   StartIndex, MatchIndex, MatchEnd, NextIndex: Integer;
   InputLength: Integer;
   LastIndex: Double;
   HandledCustomExec: Boolean;
 begin
-  Obj := TGocciaObjectValue(AValue);
   if not IsRegExpInstance(AValue) then
   begin
-    Result := MatchRegExpObject(AValue, AInput, 0, False, False, AMatchArray,
+    Result := MatchRegExpObjectResult(AValue, AInput, 0, False, False, AMatch,
       MatchIndex, MatchEnd, NextIndex);
     Exit;
   end;
 
-  Result := TryRunRegExpCustomExec(AValue, AInput, AMatchArray, MatchIndex,
+  Result := TryRunRegExpCustomExec(AValue, AInput, CustomMatch, MatchIndex,
     MatchEnd, NextIndex, HandledCustomExec);
   if HandledCustomExec then
+  begin
+    if Result then
+      AMatch := TGocciaRegExpExecutionResult.FromCustom(CustomMatch);
     Exit;
+  end;
 
   Flags := GetRegExpInternalFlags(AValue);
   LastIndex := GetRegExpLastIndexLength(AValue);
@@ -568,14 +725,15 @@ begin
   end
   else
     StartIndex := 0;
-  Result := MatchRegExpObject(AValue, AInput, StartIndex,
-    HasRegExpFlag(Flags, 'y'), True, AMatchArray, MatchIndex,
-    MatchEnd, NextIndex);
+  Result := MatchRegExpObjectResult(AValue, AInput, StartIndex,
+    HasRegExpFlag(Flags, 'y'), True, AMatch, MatchIndex,
+    MatchEnd, NextIndex, False);
 end;
 
 function MatchRegExpBuiltinObjectOnce(const AValue: TGocciaValue;
   const AInput: string; out AMatchArray: TGocciaValue): Boolean;
 var
+  Match: TGocciaRegExpExecutionResult;
   Flags: string;
   StartIndex, MatchIndex, MatchEnd, NextIndex: Integer;
   InputLength: Integer;
@@ -602,9 +760,13 @@ begin
   else
     StartIndex := 0;
 
-  Result := MatchRegExpObject(AValue, AInput, StartIndex,
-    HasRegExpFlag(Flags, 'y'), True, AMatchArray, MatchIndex,
+  Result := MatchRegExpObjectResult(AValue, AInput, StartIndex,
+    HasRegExpFlag(Flags, 'y'), True, Match, MatchIndex,
     MatchEnd, NextIndex, False);
+  if Result then
+    AMatchArray := Match.Materialize
+  else
+    AMatchArray := nil;
 end;
 
 function MatchRegExpObject(const AValue: TGocciaValue; const AInput: string;
@@ -612,6 +774,24 @@ function MatchRegExpObject(const AValue: TGocciaValue; const AInput: string;
   out AMatchArray: TGocciaValue; out AMatchIndex, AMatchEnd,
   ANextIndex: Integer; const AUseCustomExec: Boolean): Boolean;
 var
+  Match: TGocciaRegExpExecutionResult;
+begin
+  Result := MatchRegExpObjectResult(AValue, AInput, AStartIndex,
+    ARequireStart, AUpdateLastIndex, Match, AMatchIndex, AMatchEnd,
+    ANextIndex, AUseCustomExec);
+  if Result then
+    AMatchArray := Match.Materialize
+  else
+    AMatchArray := nil;
+end;
+
+function MatchRegExpObjectResult(const AValue: TGocciaValue;
+  const AInput: string; const AStartIndex: Integer;
+  const ARequireStart, AUpdateLastIndex: Boolean;
+  out AMatch: TGocciaRegExpExecutionResult; out AMatchIndex, AMatchEnd,
+  ANextIndex: Integer; const AUseCustomExec: Boolean): Boolean;
+var
+  CustomMatch: TGocciaValue;
   Obj: TGocciaObjectValue;
   HandledCustomExec: Boolean;
   MatchResult: TGocciaRegExpMatchResult;
@@ -621,10 +801,14 @@ begin
   Obj := TGocciaObjectValue(AValue);
   if AUseCustomExec then
   begin
-    Result := TryRunRegExpCustomExec(AValue, AInput, AMatchArray,
+    Result := TryRunRegExpCustomExec(AValue, AInput, CustomMatch,
       AMatchIndex, AMatchEnd, ANextIndex, HandledCustomExec);
     if HandledCustomExec then
+    begin
+      if Result then
+        AMatch := TGocciaRegExpExecutionResult.FromCustom(CustomMatch);
       Exit;
+    end;
   end;
 
   if not IsRegExpInstance(AValue) then
@@ -664,7 +848,6 @@ begin
   begin
     if ShouldUpdate then
       Obj.SetProperty(PROP_LAST_INDEX, TGocciaNumberLiteralValue.Create(0));
-    AMatchArray := nil;
     AMatchIndex := -1;
     AMatchEnd := -1;
     ANextIndex := -1;
@@ -674,7 +857,7 @@ begin
   AMatchIndex := MatchResult.MatchIndex;
   AMatchEnd := MatchResult.MatchEnd;
   ANextIndex := MatchResult.NextIndex;
-  AMatchArray := BuildMatchArray(AInput, MatchResult);
+  AMatch := TGocciaRegExpExecutionResult.FromNative(AInput, MatchResult);
   if ShouldUpdate then
     Obj.SetProperty(PROP_LAST_INDEX, TGocciaNumberLiteralValue.Create(AMatchEnd));
 end;

--- a/source/units/Goccia.RegExp.Runtime.pas
+++ b/source/units/Goccia.RegExp.Runtime.pas
@@ -14,16 +14,13 @@ type
   TGocciaRegExpExecutionResult = record
   private
     FKind: TGocciaRegExpExecutionResultKind;
-    FInput: string;
     FNativeMatch: TGocciaRegExpMatchResult;
     FCustomMatch: TGocciaValue;
   public
-    class function FromNative(const AInput: string;
-      const AMatch: TGocciaRegExpMatchResult): TGocciaRegExpExecutionResult;
-      static;
+    class function FromNative(const AMatch: TGocciaRegExpMatchResult):
+      TGocciaRegExpExecutionResult; static;
     class function FromCustom(
       const AMatch: TGocciaValue): TGocciaRegExpExecutionResult; static;
-    function Materialize: TGocciaValue;
     function MatchedText: string;
     function MatchIndex(const AInputLength: Integer): Integer;
     function CaptureCount: Integer;
@@ -177,6 +174,11 @@ end;
 
 function CreateRegExpObjectFromProgram(const APattern, AFlags: string;
   const ACompiledProgram: TRegExpProgram): TGocciaValue; forward;
+function MatchRegExpNativeObject(const AValue: TGocciaValue;
+  const AInput: string; const AStartIndex: Integer;
+  const ARequireStart, AUpdateLastIndex: Boolean;
+  out AMatchResult: TGocciaRegExpMatchResult; out AMatchIndex, AMatchEnd,
+  ANextIndex: Integer): Boolean; forward;
 function MatchRegExpObjectResult(const AValue: TGocciaValue;
   const AInput: string; const AStartIndex: Integer;
   const ARequireStart, AUpdateLastIndex: Boolean;
@@ -452,11 +454,10 @@ begin
   Result := MatchArray;
 end;
 
-class function TGocciaRegExpExecutionResult.FromNative(const AInput: string;
+class function TGocciaRegExpExecutionResult.FromNative(
   const AMatch: TGocciaRegExpMatchResult): TGocciaRegExpExecutionResult;
 begin
   Result.FKind := rerkNative;
-  Result.FInput := AInput;
   Result.FNativeMatch := AMatch;
   Result.FCustomMatch := nil;
 end;
@@ -465,15 +466,7 @@ class function TGocciaRegExpExecutionResult.FromCustom(
   const AMatch: TGocciaValue): TGocciaRegExpExecutionResult;
 begin
   Result.FKind := rerkCustom;
-  Result.FInput := '';
   Result.FCustomMatch := AMatch;
-end;
-
-function TGocciaRegExpExecutionResult.Materialize: TGocciaValue;
-begin
-  if FKind = rerkCustom then
-    Exit(FCustomMatch);
-  Result := BuildMatchArray(FInput, FNativeMatch);
 end;
 
 function TGocciaRegExpExecutionResult.MatchedText: string;
@@ -673,13 +666,44 @@ end;
 function MatchRegExpObjectOnce(const AValue: TGocciaValue; const AInput: string;
   out AMatchArray: TGocciaValue): Boolean;
 var
-  Match: TGocciaRegExpExecutionResult;
+  Flags: string;
+  StartIndex, MatchIndex, MatchEnd, NextIndex: Integer;
+  InputLength: Integer;
+  LastIndex: Double;
+  HandledCustomExec: Boolean;
 begin
-  Result := MatchRegExpObjectOnceResult(AValue, AInput, Match);
-  if Result then
-    AMatchArray := Match.Materialize
+  if not IsRegExpInstance(AValue) then
+  begin
+    Result := MatchRegExpObject(AValue, AInput, 0, False, False, AMatchArray,
+      MatchIndex, MatchEnd, NextIndex);
+    Exit;
+  end;
+
+  Result := TryRunRegExpCustomExec(AValue, AInput, AMatchArray, MatchIndex,
+    MatchEnd, NextIndex, HandledCustomExec);
+  if HandledCustomExec then
+    Exit;
+
+  Flags := GetRegExpInternalFlags(AValue);
+  LastIndex := GetRegExpLastIndexLength(AValue);
+  if HasRegExpFlag(Flags, 'g') or HasRegExpFlag(Flags, 'y') then
+  begin
+    InputLength := RegExpInputCodeUnitLength(AInput);
+    if LastIndex > InputLength then
+    begin
+      if InputLength < MaxInt then
+        StartIndex := InputLength + 1
+      else
+        StartIndex := MaxInt;
+    end
+    else
+      StartIndex := Trunc(LastIndex);
+  end
   else
-    AMatchArray := nil;
+    StartIndex := 0;
+  Result := MatchRegExpObject(AValue, AInput, StartIndex,
+    HasRegExpFlag(Flags, 'y'), True, AMatchArray, MatchIndex,
+    MatchEnd, NextIndex, False);
 end;
 
 function MatchRegExpObjectOnceResult(const AValue: TGocciaValue;
@@ -733,7 +757,6 @@ end;
 function MatchRegExpBuiltinObjectOnce(const AValue: TGocciaValue;
   const AInput: string; out AMatchArray: TGocciaValue): Boolean;
 var
-  Match: TGocciaRegExpExecutionResult;
   Flags: string;
   StartIndex, MatchIndex, MatchEnd, NextIndex: Integer;
   InputLength: Integer;
@@ -760,13 +783,9 @@ begin
   else
     StartIndex := 0;
 
-  Result := MatchRegExpObjectResult(AValue, AInput, StartIndex,
-    HasRegExpFlag(Flags, 'y'), True, Match, MatchIndex,
+  Result := MatchRegExpObject(AValue, AInput, StartIndex,
+    HasRegExpFlag(Flags, 'y'), True, AMatchArray, MatchIndex,
     MatchEnd, NextIndex, False);
-  if Result then
-    AMatchArray := Match.Materialize
-  else
-    AMatchArray := nil;
 end;
 
 function MatchRegExpObject(const AValue: TGocciaValue; const AInput: string;
@@ -774,13 +793,22 @@ function MatchRegExpObject(const AValue: TGocciaValue; const AInput: string;
   out AMatchArray: TGocciaValue; out AMatchIndex, AMatchEnd,
   ANextIndex: Integer; const AUseCustomExec: Boolean): Boolean;
 var
-  Match: TGocciaRegExpExecutionResult;
+  HandledCustomExec: Boolean;
+  MatchResult: TGocciaRegExpMatchResult;
 begin
-  Result := MatchRegExpObjectResult(AValue, AInput, AStartIndex,
-    ARequireStart, AUpdateLastIndex, Match, AMatchIndex, AMatchEnd,
-    ANextIndex, AUseCustomExec);
+  if AUseCustomExec then
+  begin
+    Result := TryRunRegExpCustomExec(AValue, AInput, AMatchArray,
+      AMatchIndex, AMatchEnd, ANextIndex, HandledCustomExec);
+    if HandledCustomExec then
+      Exit;
+  end;
+
+  Result := MatchRegExpNativeObject(AValue, AInput, AStartIndex,
+    ARequireStart, AUpdateLastIndex, MatchResult, AMatchIndex, AMatchEnd,
+    ANextIndex);
   if Result then
-    AMatchArray := Match.Materialize
+    AMatchArray := BuildMatchArray(AInput, MatchResult)
   else
     AMatchArray := nil;
 end;
@@ -792,13 +820,9 @@ function MatchRegExpObjectResult(const AValue: TGocciaValue;
   ANextIndex: Integer; const AUseCustomExec: Boolean): Boolean;
 var
   CustomMatch: TGocciaValue;
-  Obj: TGocciaObjectValue;
   HandledCustomExec: Boolean;
   MatchResult: TGocciaRegExpMatchResult;
-  ProgramData: TGocciaRegExpProgramData;
-  ShouldUpdate: Boolean;
 begin
-  Obj := TGocciaObjectValue(AValue);
   if AUseCustomExec then
   begin
     Result := TryRunRegExpCustomExec(AValue, AInput, CustomMatch,
@@ -811,9 +835,27 @@ begin
     end;
   end;
 
+  Result := MatchRegExpNativeObject(AValue, AInput, AStartIndex,
+    ARequireStart, AUpdateLastIndex, MatchResult, AMatchIndex, AMatchEnd,
+    ANextIndex);
+  if Result then
+    AMatch := TGocciaRegExpExecutionResult.FromNative(MatchResult);
+end;
+
+function MatchRegExpNativeObject(const AValue: TGocciaValue;
+  const AInput: string; const AStartIndex: Integer;
+  const ARequireStart, AUpdateLastIndex: Boolean;
+  out AMatchResult: TGocciaRegExpMatchResult; out AMatchIndex, AMatchEnd,
+  ANextIndex: Integer): Boolean;
+var
+  Obj: TGocciaObjectValue;
+  ProgramData: TGocciaRegExpProgramData;
+  ShouldUpdate: Boolean;
+begin
   if not IsRegExpInstance(AValue) then
     ThrowTypeError(SErrorRegExpExecNonRegExp);
 
+  Obj := TGocciaObjectValue(AValue);
   try
     if Obj.RegExpData is TGocciaRegExpProgramData then
     begin
@@ -825,7 +867,7 @@ begin
         AInput,
         AStartIndex,
         ARequireStart,
-        MatchResult);
+        AMatchResult);
     end
     else
       Result := ExecuteRegExp(
@@ -834,7 +876,7 @@ begin
         AInput,
         AStartIndex,
         ARequireStart,
-        MatchResult);
+        AMatchResult);
   except
     on E: ERegExpRuntimeError do
       ThrowError(E.Message);
@@ -854,10 +896,9 @@ begin
     Exit(False);
   end;
 
-  AMatchIndex := MatchResult.MatchIndex;
-  AMatchEnd := MatchResult.MatchEnd;
-  ANextIndex := MatchResult.NextIndex;
-  AMatch := TGocciaRegExpExecutionResult.FromNative(AInput, MatchResult);
+  AMatchIndex := AMatchResult.MatchIndex;
+  AMatchEnd := AMatchResult.MatchEnd;
+  ANextIndex := AMatchResult.NextIndex;
   if ShouldUpdate then
     Obj.SetProperty(PROP_LAST_INDEX, TGocciaNumberLiteralValue.Create(AMatchEnd));
 end;

--- a/source/units/Goccia.RegExp.Runtime.pas
+++ b/source/units/Goccia.RegExp.Runtime.pas
@@ -16,6 +16,7 @@ type
     FKind: TGocciaRegExpExecutionResultKind;
     FNativeMatch: TGocciaRegExpMatchResult;
     FCustomMatch: TGocciaValue;
+    function CustomProperty(const AName: string): TGocciaValue;
   public
     class function FromNative(const AMatch: TGocciaRegExpMatchResult):
       TGocciaRegExpExecutionResult; static;
@@ -469,11 +470,18 @@ begin
   Result.FCustomMatch := AMatch;
 end;
 
+function TGocciaRegExpExecutionResult.CustomProperty(
+  const AName: string): TGocciaValue;
+begin
+  Result := TGocciaObjectValue(FCustomMatch).GetProperty(AName);
+  if not Assigned(Result) then
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
 function TGocciaRegExpExecutionResult.MatchedText: string;
 begin
   if FKind = rerkCustom then
-    Exit(TGocciaObjectValue(FCustomMatch).GetProperty('0')
-      .ToStringLiteral.Value);
+    Exit(CustomProperty('0').ToStringLiteral.Value);
   Result := FNativeMatch.Groups[0].Value;
 end;
 
@@ -481,9 +489,7 @@ function TGocciaRegExpExecutionResult.MatchIndex(
   const AInputLength: Integer): Integer;
 begin
   if FKind = rerkCustom then
-    Exit(GetClampedIndexValue(
-      TGocciaObjectValue(FCustomMatch).GetProperty(PROP_INDEX),
-      AInputLength));
+    Exit(GetClampedIndexValue(CustomProperty(PROP_INDEX), AInputLength));
   if FNativeMatch.MatchIndex <= 0 then
     Exit(0);
   if FNativeMatch.MatchIndex >= AInputLength then
@@ -515,7 +521,7 @@ var
 begin
   if FKind = rerkCustom then
   begin
-    Value := TGocciaObjectValue(FCustomMatch).GetProperty(IntToStr(AIndex));
+    Value := CustomProperty(IntToStr(AIndex));
     AMatched := not (Value is TGocciaUndefinedLiteralValue);
     if AMatched then
       Exit(Value.ToStringLiteral.Value);
@@ -535,7 +541,7 @@ end;
 function TGocciaRegExpExecutionResult.NamedCapturesValue: TGocciaValue;
 begin
   if FKind = rerkCustom then
-    Exit(TGocciaObjectValue(FCustomMatch).GetProperty(PROP_GROUPS));
+    Exit(CustomProperty(PROP_GROUPS));
   Result := BuildNamedGroupsValue(FNativeMatch);
 end;
 

--- a/tests/built-ins/RegExp/prototype/symbol-match.js
+++ b/tests/built-ins/RegExp/prototype/symbol-match.js
@@ -88,6 +88,22 @@ test("Symbol.match does not coerce lastIndex after non-empty custom exec matches
   expect(regex[Symbol.match]("")).toEqual(["a non-empty string"]);
 });
 
+test("Symbol.match stringifies a missing custom result match as undefined", () => {
+  let calls = 0;
+  const protocol = {
+    flags: "g",
+    lastIndex: 0,
+    exec() {
+      if (calls++ === 0) {
+        return {};
+      }
+      return null;
+    },
+  };
+
+  expect(RegExp.prototype[Symbol.match].call(protocol, "")).toEqual(["undefined"]);
+});
+
 test("Symbol.match returns only matched strings for native global results", () => {
   expect(/(a)/dg[Symbol.match]("aba")).toEqual(["a", "a"]);
 });

--- a/tests/built-ins/RegExp/prototype/symbol-match.js
+++ b/tests/built-ins/RegExp/prototype/symbol-match.js
@@ -104,6 +104,27 @@ test("Symbol.match stringifies a missing custom result match as undefined", () =
   expect(RegExp.prototype[Symbol.match].call(protocol, "")).toEqual(["undefined"]);
 });
 
+test("Symbol.match retains custom results while reading matched text", () => {
+  let calls = 0;
+  const protocol = {
+    flags: "g",
+    lastIndex: 0,
+    exec() {
+      if (calls++ > 0) {
+        return null;
+      }
+      return {
+        get 0() {
+          Goccia.gc();
+          return "a";
+        },
+      };
+    },
+  };
+
+  expect(RegExp.prototype[Symbol.match].call(protocol, "")).toEqual(["a"]);
+});
+
 test("Symbol.match returns only matched strings for native global results", () => {
-  expect(/(a)/dg[Symbol.match]("aba")).toEqual(["a", "a"]);
+  expect(/a(b)/dg[Symbol.match]("abxab")).toEqual(["ab", "ab"]);
 });

--- a/tests/built-ins/RegExp/prototype/symbol-match.js
+++ b/tests/built-ins/RegExp/prototype/symbol-match.js
@@ -87,3 +87,7 @@ test("Symbol.match does not coerce lastIndex after non-empty custom exec matches
 
   expect(regex[Symbol.match]("")).toEqual(["a non-empty string"]);
 });
+
+test("Symbol.match returns only matched strings for native global results", () => {
+  expect(/(a)/dg[Symbol.match]("aba")).toEqual(["a", "a"]);
+});

--- a/tests/built-ins/RegExp/prototype/symbol-replace.js
+++ b/tests/built-ins/RegExp/prototype/symbol-replace.js
@@ -125,6 +125,27 @@ test("Symbol.replace retains custom exec results until replacement processing", 
   ]);
 });
 
+test("Symbol.replace normalizes missing custom result properties to undefined", () => {
+  let replacerArgs;
+  const protocol = {
+    flags: "",
+    lastIndex: 0,
+    exec() {
+      return { 0: "a", length: 2 };
+    },
+  };
+
+  expect(RegExp.prototype[Symbol.replace].call(
+    protocol,
+    "a",
+    (...args) => {
+      replacerArgs = args;
+      return "x";
+    },
+  )).toBe("x");
+  expect(replacerArgs).toEqual(["a", undefined, 0, "a"]);
+});
+
 test("Symbol.replace preserves retained results when groups aliases a later match", () => {
   let calls = 0;
   const protocol = {

--- a/tests/built-ins/RegExp/prototype/symbol-replace.js
+++ b/tests/built-ins/RegExp/prototype/symbol-replace.js
@@ -124,3 +124,52 @@ test("Symbol.replace retains custom exec results until replacement processing", 
     "groups",
   ]);
 });
+
+test("Symbol.replace preserves retained results when groups aliases a later match", () => {
+  let calls = 0;
+  const protocol = {
+    flags: "g",
+    lastIndex: 0,
+    pending: null,
+    exec(input) {
+      calls++;
+      if (calls === 1) {
+        this.pending = {
+          get length() {
+            return {
+              valueOf() {
+                Goccia.gc();
+                return 1;
+              },
+            };
+          },
+          0: "b",
+          index: 1,
+          groups: undefined,
+        };
+        this.lastIndex = 1;
+        return {
+          0: "a",
+          index: 0,
+          length: 1,
+          get groups() {
+            const result = protocol.pending;
+            protocol.pending = null;
+            return result;
+          },
+        };
+      }
+      if (calls === 2) {
+        this.lastIndex = 2;
+        return this.pending;
+      }
+      return null;
+    },
+  };
+
+  expect(RegExp.prototype[Symbol.replace].call(
+    protocol,
+    "ab",
+    "x",
+  )).toBe("xx");
+});

--- a/tests/built-ins/RegExp/prototype/symbol-replace.js
+++ b/tests/built-ins/RegExp/prototype/symbol-replace.js
@@ -68,3 +68,59 @@ test("Symbol.replace uses ToLength when advancing lastIndex after empty global m
     "set-lastIndex:1",
   ]);
 });
+
+test("Symbol.replace retains custom exec results until replacement processing", () => {
+  const log = [];
+  let calls = 0;
+  const match = {
+    get length() {
+      log.push("length");
+      return 2;
+    },
+    get 0() {
+      log.push("match");
+      return "b";
+    },
+    get 1() {
+      log.push("capture");
+      return "b";
+    },
+    get index() {
+      log.push("index");
+      return 1;
+    },
+    get groups() {
+      log.push("groups");
+      return undefined;
+    },
+  };
+  const protocol = {
+    flags: "g",
+    lastIndex: 0,
+    exec() {
+      calls++;
+      log.push("exec:" + calls);
+      if (calls === 1) {
+        this.lastIndex = 2;
+        return match;
+      }
+      return null;
+    },
+  };
+
+  expect(RegExp.prototype[Symbol.replace].call(
+    protocol,
+    "abc",
+    (matched, capture) => matched + capture,
+  )).toBe("abbc");
+  expect(log).toEqual([
+    "exec:1",
+    "match",
+    "exec:2",
+    "length",
+    "match",
+    "index",
+    "capture",
+    "groups",
+  ]);
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add a RegExp execution-result boundary that retains native engine match records and materializes ECMAScript match arrays only when the result is observable.
- Use the compact native path for global `@@match` and `@@replace`, while preserving custom `exec` objects and direct native-to-array materialization for `exec`, non-global match, search/split, and `matchAll` results.
- Preserve temporary-root ownership for retained custom results, including aliased `groups` values during replacement and custom matched-text getters during global matching, with explicit-GC regressions.
- Normalize absent custom `exec` result properties to ECMAScript `undefined` before matched-text, index, capture, and named-group processing.
- Add protocol-ordering regression coverage and high-cardinality RegExp benchmarks.
- Scope note: the issue's original `matchAll` optimization target is intentionally excluded because each iterator result is observable and must remain a full match array; the cited test262 cases were already passing on the current baseline.
- Direct 100,000-result profiles: global match allocations fell from 600,020 to 200,020 and profiled body time from 251.7 ms to 128.4 ms; global replace allocations fell from 600,022 to 100,022 and profiled body time from 3.76 s to 3.47 s.
- Latest same-runner benchmarks: many-result match improved by 110% interpreted and 122% bytecode; many-result replace improved by 67% and 80%. Regex `split()` is unchanged, with overlapping ranges (-0.7% interpreted, +0.7% bytecode).
- Visual evidence: not applicable; this is an internal engine/runtime change with no UI surface.

Closes #913

## Testing

- [x] Verified no regressions and confirmed the bugfix in end-to-end JavaScript tests: 11,445/11,445 pass in interpreted mode and 11,445/11,445 pass in bytecode mode.
- [x] Added explicit regressions for retained custom match results, absent custom result fields, and full-match versus capture selection.
- [x] Documentation impact assessed; no update is required because behavior and public APIs are unchanged.
- [ ] Optional: Native Pascal tests are not applicable; the changed behavior is exercised through the public JavaScript RegExp surface.
- [x] Verified benchmark coverage and latest same-runner comparison for high-cardinality global match and replace plus materializing RegExp callers.
- [x] Pinned test262 `RegExp.prototype[Symbol.match]`: 53/53 pass; `RegExp.prototype[Symbol.replace]`: 70/70 pass in interpreted and bytecode modes.
- [x] `./format.pas --check`
