### PR TITLE
fix(evaluator): bound lexical for-loop roots

### DIFF
--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -897,6 +897,23 @@ console.log("--max-memory (interpreter recursive expression pressure reclaims)..
   if ((json.memory?.gc?.collections ?? 0) <= 0) throw new Error(`Recursive expression pressure should report collections, got ${json.memory?.gc?.collections}`);
 }
 
+console.log("--max-memory (interpreter lexical for-loop roots stay bounded)...");
+{
+  const src = [
+    "for (let i = 0; i < 5000; i++) {",
+    "  if (i % 100 === 0) Goccia.gc();",
+    "}",
+    '"completed";',
+    "",
+  ].join("\n");
+  const { exitCode, json, stderr } = runLoaderJson(src, [
+    "--max-memory=300000",
+    "--compat-traditional-for-loop",
+  ], { timeout: 30_000 });
+  if (exitCode !== 0) throw new Error(`Interpreter lexical for-loop exit code should be 0, got ${exitCode}: ${JSON.stringify(json)}${stderr}`);
+  if (json.files?.[0]?.result !== "completed") throw new Error(`Interpreter lexical for-loop should complete, got ${json.files?.[0]?.result}`);
+}
+
 console.log("--max-memory (bytecode loop pressure reclaims)...");
 {
   const src = [

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -6207,6 +6207,14 @@ begin
               if IterBinding.TypeHint <> sltUntyped then
                 UpdateScope.SetOwnBindingTypeHint(Name, IterBinding.TypeHint);
             end;
+            { Binding transfer is complete, so the previous iteration scope is
+              no longer an active loop root. Reachable closures retain it
+              through their closure scope; the loop itself now needs only the
+              header and active update scope. }
+            LoopRoots.Clear;
+            if Assigned(HeaderScope) then
+              LoopRoots.Add(HeaderScope);
+            LoopRoots.Add(UpdateScope);
           end;
 
           if Assigned(ForState) then

--- a/tests/language/for-loop/gc-active-scope.js
+++ b/tests/language/for-loop/gc-active-scope.js
@@ -6,6 +6,42 @@ features: [compat-traditional-for-loop, Goccia.gc]
 const hasGoccia = typeof Goccia !== "undefined";
 
 describe.runIf(hasGoccia)("traditional for explicit GC", () => {
+  const measureLoopRetainedGrowth = (iterations) => {
+    Goccia.gc();
+    const baseline = Goccia.gc.bytesAllocated;
+    let retainedGrowth = 0;
+
+    for (let i = 0; i < iterations; i++) {
+      if (i === iterations - 1) {
+        Goccia.gc();
+        retainedGrowth = Goccia.gc.bytesAllocated - baseline;
+      }
+    }
+
+    return retainedGrowth;
+  };
+
+  const measureGeneratorLoopRetainedGrowth = (iterations) => {
+    const obj = {
+      *measure() {
+        Goccia.gc();
+        const baseline = Goccia.gc.bytesAllocated;
+        let retainedGrowth = 0;
+
+        for (let i = 0; i < iterations; i++) {
+          if (i === iterations - 1) {
+            Goccia.gc();
+            retainedGrowth = Goccia.gc.bytesAllocated - baseline;
+          }
+        }
+
+        return retainedGrowth;
+      },
+    };
+
+    return obj.measure().next().value;
+  };
+
   test("preserves the current lexical iteration binding across Goccia.gc", () => {
     const values = [];
 
@@ -15,5 +51,23 @@ describe.runIf(hasGoccia)("traditional for explicit GC", () => {
     }
 
     expect(values).toEqual([0, 1, 2]);
+  });
+
+  test("keeps retained growth bounded across ordinary lexical iterations", () => {
+    const shortGrowth = measureLoopRetainedGrowth(500);
+    const longGrowth = measureLoopRetainedGrowth(5000);
+
+    expect(Math.abs(longGrowth)).toBeLessThanOrEqual(
+      Math.max(Math.abs(shortGrowth) * 3, 1),
+    );
+  });
+
+  test("keeps retained growth bounded when a generator runs the loop in one resume", () => {
+    const shortGrowth = measureGeneratorLoopRetainedGrowth(500);
+    const longGrowth = measureGeneratorLoopRetainedGrowth(5000);
+
+    expect(Math.abs(longGrowth)).toBeLessThanOrEqual(
+      Math.max(Math.abs(shortGrowth) * 3, 1),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Release each obsolete lexical `for` iteration scope from the interpreter active-root frame immediately after its bindings are copied into the next update scope; retain only the header and currently active update scope.
- Preserve per-iteration closure identity and generator condition/body/update resumption because legitimately reachable scopes remain owned by closures or generator continuation state.
- Add relative bounded-growth regressions for ordinary loops and generators executing many iterations in one resume, plus a constrained `--max-memory=300000` CLI regression.
- Bytecode execution and the garbage-collector API are unchanged.

Closes #980

## Testing

- [x] Verified no regressions and confirmed the bugfix in end-to-end JavaScript tests
  - `./build.pas --clean`
  - `./build/GocciaTestRunner tests --no-progress` — 11,497/11,497 passed, 25,675 assertions
  - `./build/GocciaTestRunner tests --mode=bytecode --no-progress` — 11,497/11,497 passed, 25,675 assertions
  - `./build/GocciaTestRunner tests/language/for-loop --no-progress` — 93/93 passed, 176 assertions
  - `./build/GocciaTestRunner tests/language/for-loop --mode=bytecode --no-progress` — 93/93 passed, 176 assertions
  - `bun run scripts/test-cli.ts`
  - Exact 5,000-iteration ordinary and generator interpreter reproductions complete under `--max-memory=300000`
- [ ] Updated documentation
  - Not applicable: this fixes internal root lifetime without changing APIs, architecture, or documented behavior.
- [x] Optional: Verified no regressions and confirmed the bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - All 51 clean-built `build/*.Test` executables passed.
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change
  - Not applicable: the regression is covered by stable retained-growth and constrained-memory assertions rather than timing thresholds.
- `./format.pas --check` — 406 files formatted correctly
- `bun run scripts/check-test-structure.ts` — 1,428 files checked, 8 justified exceptions
- `git diff --check`

## Review

- Manual separate diff review completed because no `/review` skill is available in this checkout.
- No findings. Reviewed root ownership, closure reachability, generator continuation phases, error paths, scope boundaries, test stability, and issue acceptance criteria.