### PR TITLE
feat(engine): add capability audit events

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,6 +50,14 @@ _Avoid_: Runtime, built-in surface, host surface.
 The engine-owned module that supplies JavaScript-observable time, time zone, and randomness. Hosts may inject its clock and RNG adapters; infrastructure timing is not part of the host environment.
 _Avoid_: Runtime surface, global clock, `TimingUtils` when referring to script-visible values.
 
+**Capability audit event**:
+A versioned structured host event emitted when source reaches a capability boundary. It records the capability kind, allow-or-deny decision, subject, reason, and active source location. The decision describes capability policy, not the eventual success of the requested operation.
+_Avoid_: Console log, operation result, security policy callback.
+
+**Capability audit sink**:
+The engine-owned host callback that receives capability audit events synchronously. Sink failures propagate and stop execution; CLI hosts provide a thread-safe JSONL sink through `--audit-log`.
+_Avoid_: Runtime extension, script-visible logger, best-effort telemetry.
+
 **Seed baseline**:
 An explicitly imported snapshot used to initialise a sandbox-visible filesystem. Top-level sandbox seeds copy from host paths or inline seed config entries; nested child sandbox seeds copy from the parent virtual filesystem or inline child entries. A seed baseline is not a live mount and does not make the source path ambiently available to running source.
 _Avoid_: Mount, host filesystem access.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ See [Core patterns](docs/core-patterns.md) and [Interpreter](docs/interpreter.md
 | [Embedding the Engine](docs/embedding.md) | Embedding GocciaScript in FreePascal applications |
 | [Virtual Module Configuration](docs/virtual-modules.md) | CLI, config-file, and embedding reference for host-supplied modules |
 | [Host Environment](docs/host-environment.md) | Injecting JavaScript-visible clock, time-zone, and random providers |
+| [Capability Audit Events](docs/capability-audit.md) | Structured host capability decisions, embedding sink, and CLI JSONL output |
 | [Testing](docs/testing.md) | Test organization, running tests, coverage, CI |
 | [Test Framework API](docs/testing-api.md) | Assertions, mocks, lifecycle hooks, async patterns |
 | [Benchmarks](docs/benchmarks.md) | Benchmark runner, output formats, writing benchmarks |

--- a/docs/adr/0097-engine-owned-capability-audit-seam.md
+++ b/docs/adr/0097-engine-owned-capability-audit-seam.md
@@ -1,0 +1,34 @@
+# Engine-owned capability audit seam
+
+**Date:** 2026-07-16
+**Area:** `engine`, `runtime`, `sandbox`, `cli`
+**Issue:** [#882](https://github.com/frostney/GocciaScript/issues/882)
+
+Capability observability uses one typed sink owned by `TGocciaEngine`.
+The engine constructs the versioned event, captures the active interpreter or
+bytecode call site, and delivers it synchronously. Runtime extensions and core
+built-ins receive only a narrow typed emitter callback, so fetch, FFI,
+Function construction, ShadowRealm construction, and sandbox filesystem paths
+do not depend on CLI logging or serialization.
+
+ShadowRealm child engines inherit the parent sink. Disabled `FFI` and
+`ShadowRealm` remain absent globals: auditing must not change JavaScript
+feature detection by installing throwing stubs. Their audit events therefore
+describe permitted use after installation; real deny gates such as the fetch
+allowlist and disabled Function construction report both decisions.
+
+The sandbox virtual filesystem remains engine-independent. It reports root
+clamping through a neutral callback, and the sandbox runtime translates that
+signal into one deny event per path normalization request. The existing
+clamped in-jail operation still proceeds, while ordinary filesystem activity
+does not create audit noise.
+
+CLI hosts expose `--audit-log=<path>` as a thread-safe UTF-8 JSONL sink.
+Opening and delivery are fail-closed: any file or host-sink exception aborts
+execution rather than silently producing an incomplete security record.
+Fetch events are emitted on the runtime thread before asynchronous HTTP work,
+so audit sinks are never called from fetch workers.
+
+This keeps capability policy at its existing boundaries, centralizes event
+shape and child-engine inheritance, and avoids a runtime service lookup or
+independent callback contract for every capability.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -106,3 +106,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0094 — Virtual modules use the ordinary module loader](0094-virtual-modules-use-the-module-loader.md)
 - [0095 — Custom bidirectional FFI ABI engine](0095-custom-bidirectional-ffi-abi-engine.md)
 - [0096 — Keep snapshot persistence behind a test-host adapter](0096-host-injected-snapshot-testing.md)
+- [0097 — Engine-owned capability audit seam](0097-engine-owned-capability-audit-seam.md)

--- a/docs/capability-audit.md
+++ b/docs/capability-audit.md
@@ -74,9 +74,11 @@ Engine.CapabilityAuditSink := HandleCapabilityAudit;
 Install the sink before executing source or attaching runtime capabilities.
 ShadowRealm child engines inherit the parent engine's sink.
 
-Sink exceptions propagate and stop execution. Hosts must treat delivery as
-part of the security contract: serialize concurrent calls when engines run on
-multiple threads, and do not swallow storage or transport failures.
+Sink exceptions propagate as `EGocciaCapabilityAuditDeliveryError` and stop
+execution. Script-level `try`/`catch` and promise rejection handlers cannot
+intercept delivery failures. Hosts must treat delivery as part of the security
+contract: serialize concurrent calls when engines run on multiple threads, and
+do not swallow storage or transport failures.
 
 ## CLI
 
@@ -91,4 +93,6 @@ All `TGocciaCLIApplication`-based hosts accept:
 
 The file is created before execution. Failure to open it or write an event is
 fatal. Writes are serialized, so batch hosts may safely combine events from
-`--jobs=N` workers into one JSONL stream.
+`--jobs=N` workers into one JSONL stream. `--log` and `--audit-log` must name
+different files; the CLI rejects equivalent expanded paths before opening
+either output.

--- a/docs/capability-audit.md
+++ b/docs/capability-audit.md
@@ -14,7 +14,7 @@ Every event has schema version `1` and these fields:
   "schemaVersion": 1,
   "kind": "fetch.host",
   "decision": "deny",
-  "subject": "https://blocked.example/path",
+  "subject": "blocked.example",
   "reason": "host is not in the allowed hosts list",
   "source": {
     "file": "app.js",
@@ -40,6 +40,9 @@ The current event kinds are:
 | `function.constructor` | Dynamic Function construction was allowed or denied |
 | `shadow-realm.construct` | An installed ShadowRealm constructor was invoked |
 | `sandbox.fs.path` | A sandbox path attempted to cross above the virtual root |
+
+`fetch.host` subjects contain only the checked host. URL user information,
+paths, and query parameters are not included in host-authorization events.
 
 Disabled `FFI` and `ShadowRealm` remain absent globals. Auditing does not
 install throwing stubs or alter feature detection. Their use events therefore

--- a/docs/capability-audit.md
+++ b/docs/capability-audit.md
@@ -1,0 +1,94 @@
+# Capability Audit Events
+
+GocciaScript can report structured events when source reaches a
+host-controlled capability boundary. Embedders install a sink on
+the `CapabilityAuditSink` property of `TGocciaEngine`; CLI hosts use
+`--audit-log=<path>` to write the same events as UTF-8 JSON Lines.
+
+## Event Contract
+
+Every event has schema version `1` and these fields:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "fetch.host",
+  "decision": "deny",
+  "subject": "https://blocked.example/path",
+  "reason": "host is not in the allowed hosts list",
+  "source": {
+    "file": "app.js",
+    "line": 12,
+    "column": 5
+  }
+}
+```
+
+`decision` records the capability decision, not whether the requested
+operation eventually succeeded. For example, `ffi.open` reports `allow` before
+the dynamic library is loaded; a missing library may still fail afterward.
+Line and column are `null` only when an event originates outside an active
+source call site.
+
+The current event kinds are:
+
+| Kind | Meaning |
+|------|---------|
+| `fetch.host` | Fetch host allowlist decision |
+| `fetch.dispatch` | An allowed fetch request reached the dispatch boundary |
+| `ffi.open` | An installed FFI runtime accepted a library-open attempt |
+| `function.constructor` | Dynamic Function construction was allowed or denied |
+| `shadow-realm.construct` | An installed ShadowRealm constructor was invoked |
+| `sandbox.fs.path` | A sandbox path attempted to cross above the virtual root |
+
+Disabled `FFI` and `ShadowRealm` remain absent globals. Auditing does not
+install throwing stubs or alter feature detection. Their use events therefore
+exist only when the host has installed those capabilities.
+
+Sandbox root escapes retain their existing behavior: the escape portion is
+denied and reported once for the path normalization request, while the
+resulting in-jail path remains clamped and the filesystem operation continues.
+Ordinary sandbox reads and writes do not generate events.
+
+Fetch authorization and dispatch events are emitted synchronously on the
+runtime thread. The HTTP worker does not call the sink.
+
+## Embedding
+
+The sink is a Pascal method callback:
+
+```pascal
+uses
+  Goccia.CapabilityAudit,
+  Goccia.Engine;
+
+procedure TMyHost.HandleCapabilityAudit(
+  const AEvent: TGocciaCapabilityAuditEvent);
+begin
+  WriteLn(AEvent.ToJSON);
+end;
+
+Engine.CapabilityAuditSink := HandleCapabilityAudit;
+```
+
+Install the sink before executing source or attaching runtime capabilities.
+ShadowRealm child engines inherit the parent engine's sink.
+
+Sink exceptions propagate and stop execution. Hosts must treat delivery as
+part of the security contract: serialize concurrent calls when engines run on
+multiple threads, and do not swallow storage or transport failures.
+
+## CLI
+
+All `TGocciaCLIApplication`-based hosts accept:
+
+```bash
+./build/GocciaScriptLoader app.js --audit-log=capabilities.jsonl
+./build/GocciaSandboxRunner /main.js \
+  --seed-config=sandbox.json \
+  --audit-log=capabilities.jsonl
+```
+
+The file is created before execution. Failure to open it or write an event is
+fatal. Writes are serialized, so batch hosts may safely combine events from
+`--jobs=N` workers into one JSONL stream.

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -120,6 +120,13 @@ function assertValidSourceMap(path: string): void {
   if (typeof map.mappings !== "string" || map.mappings.length === 0) throw new Error("Source map should have non-empty mappings");
 }
 
+function readJsonLines(path: string): any[] {
+  return readFileSync(path, "utf-8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
 function assertCommonJsonReport(json: any, label: string, expectedFileCount: number): void {
   if (json.fileName !== undefined) throw new Error(`${label} top-level fileName should be omitted`);
   if (typeof json.build?.version !== "string") throw new Error(`${label} build.version should be present`);
@@ -1854,6 +1861,98 @@ console.log("Loader: Promise.then drain (bytecode)...");
   if (proc.exitCode !== 0) throw new Error(`Loader Promise drain bytecode exited ${proc.exitCode}: ${proc.stderr.toString()}`);
   if (!proc.stdout.toString().includes("then-42"))
     throw new Error(`Loader Promise drain bytecode expected then-42, got: ${proc.stdout.toString()}`);
+}
+
+console.log("Loader: --audit-log records capability decisions with source locations...");
+{
+  const tmp = makeTmp();
+  try {
+    for (const mode of ["interpreted", "bytecode"] as const) {
+      const audit = join(tmp, `capabilities-${mode}.jsonl`);
+      const proc = Bun.spawnSync(
+        [
+          LOADER,
+          `--mode=${mode}`,
+          "--unsafe-ffi",
+          "--unsafe-shadowrealm",
+          `--audit-log=${audit}`,
+        ],
+        {
+          stdin: new TextEncoder().encode([
+            'try { Function("return 1")(); } catch (e) {}',
+            'try { FFI.open("./missing"); } catch (e) {}',
+            'new ShadowRealm().evaluate("new ShadowRealm(); 1");',
+            "",
+          ].join("\n")),
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      if (proc.exitCode !== 0)
+        throw new Error(`Loader audit ${mode} exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+      const events = readJsonLines(audit);
+      const expected = [
+        ["function.constructor", "deny", "Function", "<stdin>", 1],
+        ["ffi.open", "allow", "./missing", "<stdin>", 2],
+        ["shadow-realm.construct", "allow", "ShadowRealm", "<stdin>", 3],
+        ["shadow-realm.construct", "allow", "ShadowRealm", "<shadow-realm-eval>", 1],
+      ];
+      if (events.length !== expected.length)
+        throw new Error(`Loader audit ${mode} expected ${expected.length} events, got ${JSON.stringify(events)}`);
+      expected.forEach(([kind, decision, subject, file, line], index) => {
+        const event = events[index];
+        if (event.schemaVersion !== 1 ||
+            event.kind !== kind ||
+            event.decision !== decision ||
+            event.subject !== subject ||
+            event.source?.file !== file ||
+            event.source?.line !== line ||
+            typeof event.source?.column !== "number")
+          throw new Error(`Loader audit ${mode} event ${index} mismatch: ${JSON.stringify(event)}`);
+      });
+
+      const allowAudit = join(tmp, `function-allow-${mode}.jsonl`);
+      const allow = Bun.spawnSync(
+        [
+          LOADER,
+          `--mode=${mode}`,
+          "--unsafe-function-constructor",
+          `--audit-log=${allowAudit}`,
+        ],
+        {
+          stdin: new TextEncoder().encode('Function("return 1")();\n'),
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      if (allow.exitCode !== 0)
+        throw new Error(`Loader Function audit ${mode} exited ${allow.exitCode}: ${allow.stderr.toString()}`);
+      const allowEvents = readJsonLines(allowAudit);
+      if (allowEvents.length !== 1 ||
+          allowEvents[0].kind !== "function.constructor" ||
+          allowEvents[0].decision !== "allow" ||
+          allowEvents[0].source?.line !== 1)
+        throw new Error(`Loader Function allow audit ${mode} mismatch: ${JSON.stringify(allowEvents)}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("Loader: --audit-log fails closed when the output cannot be opened...");
+{
+  const tmp = makeTmp();
+  try {
+    const proc = Bun.spawnSync([LOADER, `--audit-log=${tmp}`], {
+      stdin: new TextEncoder().encode("1;\n"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (proc.exitCode === 0)
+      throw new Error("Loader audit log open failure should be fatal");
+  } finally {
+    clean(tmp);
+  }
 }
 
 // -- --global / --globals -------------------------------------------------------
@@ -4482,6 +4581,55 @@ console.log("SandboxRunner: seed config imports host paths relative to the confi
   }
 }
 
+console.log("SandboxRunner: --audit-log reports root escapes without changing clamped access...");
+{
+  const tmp = makeTmp();
+  try {
+    const seed = join(tmp, "audit-seed.json");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/main.js",
+          text: [
+            'import fs from "fs";',
+            'console.log(fs.readFileSync("../../secret.txt", "utf8"));',
+          ].join("\n"),
+        },
+        { path: "/secret.txt", text: "inside-jail" },
+      ],
+    }));
+
+    for (const mode of ["interpreted", "bytecode"] as const) {
+      const audit = join(tmp, `sandbox-audit-${mode}.jsonl`);
+      const proc = Bun.spawnSync(
+        [
+          SANDBOXRUNNER,
+          "/main.js",
+          `--seed-config=${seed}`,
+          "--source-type=module",
+          `--mode=${mode}`,
+          `--audit-log=${audit}`,
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      if (proc.exitCode !== 0)
+        throw new Error(`Sandbox audit ${mode} exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+      if (!containsLine(`\n${proc.stdout.toString()}`, "inside-jail"))
+        throw new Error(`Sandbox audit ${mode} changed clamped access: ${proc.stdout.toString()}`);
+      const events = readJsonLines(audit);
+      if (events.length !== 1 ||
+          events[0].kind !== "sandbox.fs.path" ||
+          events[0].decision !== "deny" ||
+          events[0].subject !== "../../secret.txt" ||
+          events[0].source?.file !== "/main.js" ||
+          events[0].source?.line !== 2)
+        throw new Error(`Sandbox audit ${mode} mismatch: ${JSON.stringify(events)}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
 console.log("SandboxRunner: seed directory rejects nested host symlink (no leak)...");
 {
   const tmp = makeTmp();
@@ -4662,9 +4810,21 @@ console.log("SandboxRunner: Windows directory junction seed is rejected (no leak
 
 console.log("Loader: --allowed-host blocks unlisted host...");
 {
-  const res = await $`echo 'fetch("http://blocked.test");' | ${LOADER} --allowed-host=example.com 2>&1`.nothrow();
-  if (res.exitCode === 0) throw new Error("Fetch to unlisted host should fail");
-  if (!res.text().includes("blocked.test")) throw new Error(`Error should mention blocked host, got: ${res.text()}`);
+  const tmp = makeTmp();
+  try {
+    const audit = join(tmp, "blocked-fetch-audit.jsonl");
+    const res = await $`echo 'fetch("http://blocked.test");' | ${LOADER} --allowed-host=example.com --audit-log=${audit} 2>&1`.nothrow();
+    if (res.exitCode === 0) throw new Error("Fetch to unlisted host should fail");
+    if (!res.text().includes("blocked.test")) throw new Error(`Error should mention blocked host, got: ${res.text()}`);
+    const events = readJsonLines(audit);
+    if (events.length !== 1 ||
+        events[0].kind !== "fetch.host" ||
+        events[0].decision !== "deny" ||
+        events[0].subject !== "http://blocked.test")
+      throw new Error(`Blocked fetch audit event mismatch: ${JSON.stringify(events)}`);
+  } finally {
+    clean(tmp);
+  }
 }
 
 console.log("Loader: no --allowed-host blocks all fetch...");
@@ -4684,14 +4844,27 @@ console.log("Loader: --allowed-host multiple hosts...");
 
 console.log("Loader: local fetch smoke with --allowed-host...");
 await withFetchTestServer(async (baseUrl) => {
-  const { exitCode, json, stderr } = await runLoaderJsonAsync(
-    `const response = await fetch("${baseUrl}/", { method: "HEAD" });\nresponse.status;\n`,
-    ["--compat-asi", "--allowed-host=127.0.0.1"],
-    { timeout: 10_000 },
-  );
-  if (exitCode !== 0) throw new Error(`Local fetch should exit 0, got ${exitCode}: ${stderr}`);
-  if (json.ok !== true) throw new Error(`Local fetch JSON ok should be true, got ${json.ok}`);
-  if (json.files?.[0]?.result !== 200) throw new Error(`Local fetch status should be 200, got ${json.files?.[0]?.result}`);
+  const tmp = makeTmp();
+  const audit = join(tmp, "fetch-audit.jsonl");
+  try {
+    const { exitCode, json, stderr } = await runLoaderJsonAsync(
+      `const response = await fetch("${baseUrl}/", { method: "HEAD" });\nresponse.status;\n`,
+      ["--compat-asi", "--allowed-host=127.0.0.1", `--audit-log=${audit}`],
+      { timeout: 10_000 },
+    );
+    if (exitCode !== 0) throw new Error(`Local fetch should exit 0, got ${exitCode}: ${stderr}`);
+    if (json.ok !== true) throw new Error(`Local fetch JSON ok should be true, got ${json.ok}`);
+    if (json.files?.[0]?.result !== 200) throw new Error(`Local fetch status should be 200, got ${json.files?.[0]?.result}`);
+    const events = readJsonLines(audit);
+    if (events.length !== 2 ||
+        events[0].kind !== "fetch.host" ||
+        events[0].decision !== "allow" ||
+        events[1].kind !== "fetch.dispatch" ||
+        events[1].decision !== "allow")
+      throw new Error(`Local fetch audit events mismatch: ${JSON.stringify(events)}`);
+  } finally {
+    clean(tmp);
+  }
 });
 
 // ============================================================================

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -1880,6 +1880,8 @@ console.log("Loader: --audit-log records capability decisions with source locati
         {
           stdin: new TextEncoder().encode([
             'try { Function("return 1")(); } catch (e) {}',
+            'const holder = { ctor: Function };',
+            'try { holder.ctor("return 1")(); } catch (e) {}',
             'try { FFI.open("./missing"); } catch (e) {}',
             'new ShadowRealm().evaluate("new ShadowRealm(); 1");',
             "",
@@ -1893,8 +1895,9 @@ console.log("Loader: --audit-log records capability decisions with source locati
       const events = readJsonLines(audit);
       const expected = [
         ["function.constructor", "deny", "Function", "<stdin>", 1],
-        ["ffi.open", "allow", "./missing", "<stdin>", 2],
-        ["shadow-realm.construct", "allow", "ShadowRealm", "<stdin>", 3],
+        ["function.constructor", "deny", "Function", "<stdin>", 3],
+        ["ffi.open", "allow", "./missing", "<stdin>", 4],
+        ["shadow-realm.construct", "allow", "ShadowRealm", "<stdin>", 5],
         ["shadow-realm.construct", "allow", "ShadowRealm", "<shadow-realm-eval>", 1],
       ];
       if (events.length !== expected.length)
@@ -1950,6 +1953,32 @@ console.log("Loader: --audit-log fails closed when the output cannot be opened..
     });
     if (proc.exitCode === 0)
       throw new Error("Loader audit log open failure should be fatal");
+  } finally {
+    clean(tmp);
+  }
+}
+
+console.log("Loader: --log and --audit-log reject the same output path...");
+{
+  const tmp = makeTmp();
+  try {
+    const shared = join(tmp, "combined.log");
+    const alias = `${tmp}/./combined.log`;
+    const proc = Bun.spawnSync(
+      [LOADER, `--log=${shared}`, `--audit-log=${alias}`],
+      {
+        stdin: new TextEncoder().encode('console.log("hello");\n'),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    if (proc.exitCode === 0)
+      throw new Error("Loader should reject colliding log output paths");
+    const diagnostic = proc.stdout.toString() + proc.stderr.toString();
+    if (!diagnostic.includes("must write to different files"))
+      throw new Error(`Loader collision error mismatch: ${diagnostic}`);
+    if (existsSync(shared))
+      throw new Error("Loader should validate colliding paths before opening either file");
   } finally {
     clean(tmp);
   }

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -4842,14 +4842,16 @@ console.log("Loader: --allowed-host blocks unlisted host...");
   const tmp = makeTmp();
   try {
     const audit = join(tmp, "blocked-fetch-audit.jsonl");
-    const res = await $`echo 'fetch("http://blocked.test");' | ${LOADER} --allowed-host=example.com --audit-log=${audit} 2>&1`.nothrow();
+    const res = await $`echo 'fetch("http://user:password@blocked.test/private?token=secret");' | ${LOADER} --allowed-host=example.com --audit-log=${audit} 2>&1`.nothrow();
     if (res.exitCode === 0) throw new Error("Fetch to unlisted host should fail");
     if (!res.text().includes("blocked.test")) throw new Error(`Error should mention blocked host, got: ${res.text()}`);
     const events = readJsonLines(audit);
     if (events.length !== 1 ||
         events[0].kind !== "fetch.host" ||
         events[0].decision !== "deny" ||
-        events[0].subject !== "http://blocked.test")
+        events[0].subject !== "blocked.test" ||
+        JSON.stringify(events).includes("password") ||
+        JSON.stringify(events).includes("token=secret"))
       throw new Error(`Blocked fetch audit event mismatch: ${JSON.stringify(events)}`);
   } finally {
     clean(tmp);
@@ -4888,6 +4890,7 @@ await withFetchTestServer(async (baseUrl) => {
     if (events.length !== 2 ||
         events[0].kind !== "fetch.host" ||
         events[0].decision !== "allow" ||
+        events[0].subject !== "127.0.0.1" ||
         events[1].kind !== "fetch.dispatch" ||
         events[1].decision !== "allow")
       throw new Error(`Local fetch audit events mismatch: ${JSON.stringify(events)}`);

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -13,6 +13,7 @@ uses
 
   Goccia.Application,
   Goccia.Builtins.GlobalShadowRealm,
+  Goccia.CapabilityAudit,
   Goccia.CLI.Options,
   Goccia.Engine,
   Goccia.Executor,
@@ -25,11 +26,15 @@ type
     FHelp: TFlagOption;
     FJobs: TIntegerOption;
     FLog: TStringOption;
+    FAuditLog: TStringOption;
     FMultifile: TFlagOption;
     FConfig: TStringOption;
     FLogFileHandle: TextFile;
     FLogLock: TRTLCriticalSection;
     FLogFileOpen: Boolean;
+    FAuditLogStream: TFileStream;
+    FAuditLogLock: TRTLCriticalSection;
+    FAuditLogOpen: Boolean;
     FEngineOptions: TGocciaEngineOptions;
     FCoverageOptions: TGocciaCoverageOptions;
     FProfilerOptions: TGocciaProfilerOptions;
@@ -42,6 +47,10 @@ type
     procedure ShutdownSingletons;
     procedure OpenLogFile;
     procedure CloseLogFile;
+    procedure OpenAuditLog;
+    procedure CloseAuditLog;
+    procedure HandleCapabilityAudit(
+      const AEvent: TGocciaCapabilityAuditEvent);
   protected
     procedure Configure; virtual; abstract;
     function UsageLine: string; virtual; abstract;
@@ -59,6 +68,7 @@ type
     function Add(const AOption: TOptionBase): TOptionBase;
     procedure ConfigureCreatedEngine(const AEngine: TGocciaEngine;
       const AFileConfig: TConfigEntryArray); virtual;
+    procedure ConfigureCapabilityAudit(const AEngine: TGocciaEngine);
     function ShouldApplyRootConfig(const APaths: TStringList;
       const AConfigPath: string; const AExplicitConfig: Boolean): Boolean; virtual;
     procedure HandleConsoleLog(const AMethod, ALine: string);
@@ -356,6 +366,7 @@ begin
   FHelp := nil;
   FJobs := nil;
   FLog := nil;
+  FAuditLog := nil;
   FMultifile := nil;
   FConfig := nil;
   FRootConfigPath := '';
@@ -363,10 +374,13 @@ begin
   // through SourceRegistry.Load never race on first-access creation.
   FSourceRegistry := TGocciaSourceRegistry.Create;
   FLogFileOpen := False;
+  FAuditLogStream := nil;
+  FAuditLogOpen := False;
 end;
 
 destructor TGocciaCLIApplication.Destroy;
 begin
+  CloseAuditLog;
   CloseLogFile;
   FOwnedOptions.Free;
   FEngineOptions.Free;
@@ -375,6 +389,7 @@ begin
   FHelp.Free;
   FJobs.Free;
   FLog.Free;
+  FAuditLog.Free;
   FMultifile.Free;
   FConfig.Free;
   FSourceRegistry.Free;
@@ -686,6 +701,13 @@ end;
 procedure TGocciaCLIApplication.ConfigureCreatedEngine(
   const AEngine: TGocciaEngine; const AFileConfig: TConfigEntryArray);
 begin
+end;
+
+procedure TGocciaCLIApplication.ConfigureCapabilityAudit(
+  const AEngine: TGocciaEngine);
+begin
+  if FAuditLogOpen then
+    AEngine.CapabilityAuditSink := HandleCapabilityAudit;
 end;
 
 procedure InjectModulesFromFileSystemModule(const AEngine: TGocciaEngine;
@@ -1053,6 +1075,7 @@ var
 begin
   Result := TGocciaEngine.Create(AFileName, ASource, AExecutor);
   try
+    ConfigureCapabilityAudit(Result);
     FileConfigPath := DiscoverFileConfigPath(AFileName);
     if FileConfigPath <> '' then
       FileConfig := ParseConfigFile(FileConfigPath)
@@ -1112,6 +1135,49 @@ begin
   finally
     FLogFileOpen := False;
     DoneCriticalSection(FLogLock);
+  end;
+end;
+
+procedure TGocciaCLIApplication.HandleCapabilityAudit(
+  const AEvent: TGocciaCapabilityAuditEvent);
+var
+  Line: RawByteString;
+begin
+  Line := RawByteString(UTF8Encode(AEvent.ToJSON + LineEnding));
+  EnterCriticalSection(FAuditLogLock);
+  try
+    if Length(Line) > 0 then
+      FAuditLogStream.WriteBuffer(Line[1], Length(Line));
+  finally
+    LeaveCriticalSection(FAuditLogLock);
+  end;
+end;
+
+procedure TGocciaCLIApplication.OpenAuditLog;
+begin
+  if FAuditLogOpen then
+    Exit;
+  InitCriticalSection(FAuditLogLock);
+  try
+    FAuditLogStream := TFileStream.Create(FAuditLog.Value, fmCreate);
+    FAuditLogOpen := True;
+  except
+    FAuditLogStream.Free;
+    FAuditLogStream := nil;
+    DoneCriticalSection(FAuditLogLock);
+    raise;
+  end;
+end;
+
+procedure TGocciaCLIApplication.CloseAuditLog;
+begin
+  if not FAuditLogOpen then
+    Exit;
+  try
+    FreeAndNil(FAuditLogStream);
+  finally
+    FAuditLogOpen := False;
+    DoneCriticalSection(FAuditLogLock);
   end;
 end;
 
@@ -1420,6 +1486,8 @@ begin
   FJobs.ShortName := 'j';
 
   FLog := TStringOption.Create('log', 'Write console output to a log file');
+  FAuditLog := TStringOption.Create('audit-log',
+    'Write capability audit events as JSON Lines');
 
   FMultifile := TFlagOption.Create('multifile',
     'Split each input (file or stdin) on "---" lines and run each ' +
@@ -1429,11 +1497,12 @@ begin
     'Path to a config file or a directory containing one (skips auto-discovery)');
 
   BuildAllOptions;
-  // Append --jobs, --log, --multifile and --config after BuildAllOptions so
+  // Append common application options after BuildAllOptions so
   // they appear in help
-  SetLength(FAllOptions, Length(FAllOptions) + 4);
-  FAllOptions[High(FAllOptions) - 3] := FJobs;
-  FAllOptions[High(FAllOptions) - 2] := FLog;
+  SetLength(FAllOptions, Length(FAllOptions) + 5);
+  FAllOptions[High(FAllOptions) - 4] := FJobs;
+  FAllOptions[High(FAllOptions) - 3] := FLog;
+  FAllOptions[High(FAllOptions) - 2] := FAuditLog;
   FAllOptions[High(FAllOptions) - 1] := FMultifile;
   FAllOptions[High(FAllOptions)] := FConfig;
 
@@ -1486,6 +1555,8 @@ begin
 
     if FLog.Present then
       OpenLogFile;
+    if FAuditLog.Present then
+      OpenAuditLog;
 
     InitializeSingletons;
     try
@@ -1493,6 +1564,7 @@ begin
       AfterExecute;
     finally
       ShutdownSingletons;
+      CloseAuditLog;
       CloseLogFile;
     end;
   finally

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -49,6 +49,7 @@ type
     procedure CloseLogFile;
     procedure OpenAuditLog;
     procedure CloseAuditLog;
+    procedure ValidateOutputPaths;
     procedure HandleCapabilityAudit(
       const AEvent: TGocciaCapabilityAuditEvent);
   protected
@@ -1181,6 +1182,25 @@ begin
   end;
 end;
 
+procedure TGocciaCLIApplication.ValidateOutputPaths;
+var
+  LogPath: string;
+  AuditPath: string;
+begin
+  if not FLog.Present or not FAuditLog.Present then
+    Exit;
+
+  LogPath := ExpandFileName(FLog.Value);
+  AuditPath := ExpandFileName(FAuditLog.Value);
+  {$IF DEFINED(DARWIN) OR DEFINED(WINDOWS)}
+  if SameText(LogPath, AuditPath) then
+  {$ELSE}
+  if LogPath = AuditPath then
+  {$ENDIF}
+    raise Exception.Create(
+      '--log and --audit-log must write to different files');
+end;
+
 procedure TGocciaCLIApplication.Validate;
 begin
   // Override point for subclasses
@@ -1552,6 +1572,7 @@ begin
       FRootConfigPath := '';
 
     Validate;
+    ValidateOutputPaths;
 
     if FLog.Present then
       OpenLogFile;

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -604,6 +604,7 @@ var
   EmptyConfig: TConfigEntryArray;
 begin
   EmptyConfig := EmptyConfigEntries;
+  ConfigureCapabilityAudit(AEngine);
   AEngine.SourceType := ResolveSourceTypeOption(EngineOptions.SourceType,
     EmptyConfig, AFileName);
   ApplyCompatibilityAndWarningFlags(AEngine, EngineOptions, EmptyConfig);

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -779,68 +779,71 @@ begin
   PreviousHostEnvironment := FCurrentHostEnvironment;
   FCurrentOutputLines := OutputLines;
   try
-    ConfigureSandboxResolver(Resolver);
-
-    if EngineOptions.Mode.Matches(emBytecode) then
-    begin
-      BytecodeExecutor := TGocciaBytecodeExecutor.Create;
-      BytecodeExecutor.GlobalBackedTopLevel := True;
-      Executor := BytecodeExecutor;
-    end
-    else
-    begin
-      InterpreterExecutor := TGocciaInterpreterExecutor.Create;
-      Executor := InterpreterExecutor;
-    end;
-
-    Engine := TGocciaEngine.Create(AEntryPath, Source, Resolver, Executor);
-    Engine.ModuleLoader.SetContentProvider(Provider, True);
-    Provider := nil;
-    ConfigureEngineForSandbox(Engine, AContext, AEntryPath,
-      PreviousHostEnvironment);
-    ApplyVirtualModulesToEngine(Engine, '');
-    FCurrentHostEnvironment := Engine.HostEnvironment;
-
     try
-      StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
-      StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
-      ScriptResult := Engine.Execute;
-      ExecutionRealm := CurrentRealm;
-      try
-        SetCurrentRealm(CloneRealm);
-        Result.ResultValue := CloneResultValue(ScriptResult.Result);
-      finally
-        SetCurrentRealm(ExecutionRealm);
-      end;
-      Result.Ok := True;
-      Result.ExitCode := 0;
-    finally
-      ClearExecutionTimeout;
-      ClearInstructionLimit;
-    end;
-  except
-    on E: EGocciaCapabilityAuditDeliveryError do
-      raise;
-    on E: TGocciaError do
-      Result.ErrorMessage := E.GetDetailedMessage(False);
-    on E: TGocciaThrowValue do
-      Result.ErrorMessage := FormatThrowDetail(E.Value, AEntryPath, Source,
-        False, E.Suggestion);
-    on E: Exception do
-      Result.ErrorMessage := E.Message;
-  end;
+      ConfigureSandboxResolver(Resolver);
 
-  Result.Output := OutputLines.Text;
-  if Result.ErrorMessage <> '' then
-    Result.ErrorOutput := Result.ErrorMessage + LineEnding;
-  Engine.Free;
-  Executor.Free;
-  Resolver.Free;
-  Provider.Free;
-  FCurrentHostEnvironment := PreviousHostEnvironment;
-  FCurrentOutputLines := PreviousOutputLines;
-  OutputLines.Free;
-  Source.Free;
+      if EngineOptions.Mode.Matches(emBytecode) then
+      begin
+        BytecodeExecutor := TGocciaBytecodeExecutor.Create;
+        BytecodeExecutor.GlobalBackedTopLevel := True;
+        Executor := BytecodeExecutor;
+      end
+      else
+      begin
+        InterpreterExecutor := TGocciaInterpreterExecutor.Create;
+        Executor := InterpreterExecutor;
+      end;
+
+      Engine := TGocciaEngine.Create(AEntryPath, Source, Resolver, Executor);
+      Engine.ModuleLoader.SetContentProvider(Provider, True);
+      Provider := nil;
+      ConfigureEngineForSandbox(Engine, AContext, AEntryPath,
+        PreviousHostEnvironment);
+      ApplyVirtualModulesToEngine(Engine, '');
+      FCurrentHostEnvironment := Engine.HostEnvironment;
+
+      try
+        StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
+        StartInstructionLimit(EngineOptions.MaxInstructions.ValueOr(0));
+        ScriptResult := Engine.Execute;
+        ExecutionRealm := CurrentRealm;
+        try
+          SetCurrentRealm(CloneRealm);
+          Result.ResultValue := CloneResultValue(ScriptResult.Result);
+        finally
+          SetCurrentRealm(ExecutionRealm);
+        end;
+        Result.Ok := True;
+        Result.ExitCode := 0;
+      finally
+        ClearExecutionTimeout;
+        ClearInstructionLimit;
+      end;
+    except
+      on E: EGocciaCapabilityAuditDeliveryError do
+        raise;
+      on E: TGocciaError do
+        Result.ErrorMessage := E.GetDetailedMessage(False);
+      on E: TGocciaThrowValue do
+        Result.ErrorMessage := FormatThrowDetail(E.Value, AEntryPath, Source,
+          False, E.Suggestion);
+      on E: Exception do
+        Result.ErrorMessage := E.Message;
+    end;
+
+    Result.Output := OutputLines.Text;
+    if Result.ErrorMessage <> '' then
+      Result.ErrorOutput := Result.ErrorMessage + LineEnding;
+  finally
+    Engine.Free;
+    Executor.Free;
+    Resolver.Free;
+    Provider.Free;
+    FCurrentHostEnvironment := PreviousHostEnvironment;
+    FCurrentOutputLines := PreviousOutputLines;
+    OutputLines.Free;
+    Source.Free;
+  end;
 end;
 
 function TSandboxRunnerApp.ExecuteSandboxPath(
@@ -857,31 +860,34 @@ begin
   Result.ExitCode := 1;
   ChildContext := TGocciaSandboxContext.Create;
   try
-    ChildContext.RunScriptCallback := ExecuteSandboxPath;
-    SeedNestedContext(AContext, ChildContext, AOptions);
-    ChildContext.CaptureBaseline;
-    Result := ExecuteSandboxPathInContext(ChildContext,
-      ChildContext.Fs.Normalize(AEntryPath));
-    if AOptions.IncludeDiff then
-    begin
-      Result.DiffRequested := True;
-      if AOptions.DiffFormat = 'unified' then
-        Result.Diff := ChildContext.DiffUnified(AOptions.DiffMetadata)
-      else
-        Result.Diff := ChildContext.DiffJson(AOptions.DiffMetadata);
+    try
+      ChildContext.RunScriptCallback := ExecuteSandboxPath;
+      SeedNestedContext(AContext, ChildContext, AOptions);
+      ChildContext.CaptureBaseline;
+      Result := ExecuteSandboxPathInContext(ChildContext,
+        ChildContext.Fs.Normalize(AEntryPath));
+      if AOptions.IncludeDiff then
+      begin
+        Result.DiffRequested := True;
+        if AOptions.DiffFormat = 'unified' then
+          Result.Diff := ChildContext.DiffUnified(AOptions.DiffMetadata)
+        else
+          Result.Diff := ChildContext.DiffJson(AOptions.DiffMetadata);
+      end;
+    except
+      on E: EGocciaCapabilityAuditDeliveryError do
+        raise;
+      on E: Exception do
+      begin
+        Result.Ok := False;
+        Result.ExitCode := 1;
+        Result.ErrorMessage := E.Message;
+        Result.ErrorOutput := E.Message + LineEnding;
+      end;
     end;
-  except
-    on E: EGocciaCapabilityAuditDeliveryError do
-      raise;
-    on E: Exception do
-    begin
-      Result.Ok := False;
-      Result.ExitCode := 1;
-      Result.ErrorMessage := E.Message;
-      Result.ErrorOutput := E.Message + LineEnding;
-    end;
+  finally
+    ChildContext.Free;
   end;
-  ChildContext.Free;
 end;
 
 procedure TSandboxRunnerApp.WriteDiffIfRequested;

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -16,6 +16,7 @@ uses
   Goccia.Application,
   Goccia.Builtins.Console,
   Goccia.Builtins.GlobalShadowRealm,
+  Goccia.CapabilityAudit,
   Goccia.CLI.Application,
   Goccia.CLI.Options,
   Goccia.Engine,
@@ -818,6 +819,8 @@ begin
       ClearInstructionLimit;
     end;
   except
+    on E: EGocciaCapabilityAuditDeliveryError do
+      raise;
     on E: TGocciaError do
       Result.ErrorMessage := E.GetDetailedMessage(False);
     on E: TGocciaThrowValue do
@@ -868,6 +871,8 @@ begin
         Result.Diff := ChildContext.DiffJson(AOptions.DiffMetadata);
     end;
   except
+    on E: EGocciaCapabilityAuditDeliveryError do
+      raise;
     on E: Exception do
     begin
       Result.Ok := False;

--- a/source/shared/SandboxVirtualFileSystem.Test.pas
+++ b/source/shared/SandboxVirtualFileSystem.Test.pas
@@ -26,8 +26,14 @@ type
   private
     FClock: TDeterministicSandboxClock;
     FFs: TSandboxVirtualFileSystem;
+    FClampCount: Integer;
+    FLastClampPath: string;
+    FLastClampBase: string;
+    FLastCanonicalPath: string;
     function TimeAt(const AMillisecond: Integer): TDateTime;
     procedure ExpectTime(const AActual, AExpected: TDateTime);
+    procedure HandleRootClamp(const APath, ABase,
+      ACanonicalPath: string);
   public
     procedure SetupTests; override;
     procedure BeforeEach; override;
@@ -39,6 +45,7 @@ type
     procedure TestSnapshotReadsDoNotAdvanceAccessTime;
     procedure TestDirectoryEntryChangesUpdateParentMetadata;
     procedure TestDefaultClockUsesUnixEpoch;
+    procedure TestRootClampCallback;
   end;
 
 function TDeterministicSandboxClock.Now: TDateTime;
@@ -59,6 +66,8 @@ begin
   Test('Directory entry changes update parent metadata',
     TestDirectoryEntryChangesUpdateParentMetadata);
   Test('Default clock tracks the Unix epoch', TestDefaultClockUsesUnixEpoch);
+  Test('Root clamp callback reports one attempted escape',
+    TestRootClampCallback);
 end;
 
 procedure TTestSandboxVirtualFileSystem.BeforeEach;
@@ -66,6 +75,10 @@ begin
   FClock := TDeterministicSandboxClock.Create;
   FClock.Value := TimeAt(0);
   FFs := TSandboxVirtualFileSystem.Create(0, FClock);
+  FClampCount := 0;
+  FLastClampPath := '';
+  FLastClampBase := '';
+  FLastCanonicalPath := '';
 end;
 
 procedure TTestSandboxVirtualFileSystem.AfterEach;
@@ -85,6 +98,15 @@ procedure TTestSandboxVirtualFileSystem.ExpectTime(const AActual,
   AExpected: TDateTime);
 begin
   Expect<Boolean>(AActual = AExpected).ToBe(True);
+end;
+
+procedure TTestSandboxVirtualFileSystem.HandleRootClamp(
+  const APath, ABase, ACanonicalPath: string);
+begin
+  Inc(FClampCount);
+  FLastClampPath := APath;
+  FLastClampBase := ABase;
+  FLastCanonicalPath := ACanonicalPath;
 end;
 
 procedure TTestSandboxVirtualFileSystem.TestTracksIndependentFileTimestamps;
@@ -247,6 +269,21 @@ begin
 
   Expect<Boolean>((ActualMilliseconds >= BeforeMilliseconds - 1) and
     (ActualMilliseconds <= AfterMilliseconds + 1)).ToBe(True);
+end;
+
+procedure TTestSandboxVirtualFileSystem.TestRootClampCallback;
+begin
+  FFs.RootClampCallback := HandleRootClamp;
+
+  Expect<string>(FFs.Normalize('/work/..')).ToBe('/');
+  Expect<Integer>(FClampCount).ToBe(0);
+
+  Expect<string>(FFs.Normalize('../../secret.txt', '/work')).ToBe(
+    '/secret.txt');
+  Expect<Integer>(FClampCount).ToBe(1);
+  Expect<string>(FLastClampPath).ToBe('../../secret.txt');
+  Expect<string>(FLastClampBase).ToBe('/work');
+  Expect<string>(FLastCanonicalPath).ToBe('/secret.txt');
 end;
 
 begin

--- a/source/shared/SandboxVirtualFileSystem.pas
+++ b/source/shared/SandboxVirtualFileSystem.pas
@@ -92,6 +92,9 @@ type
 
   TSandboxFsFile = class;
 
+  TSandboxRootClampCallback = procedure(const APath, ABase,
+    ACanonicalPath: string) of object;
+
   TSandboxVirtualFileSystem = class
   private
     FRoot: TSandboxFsNode;
@@ -99,6 +102,7 @@ type
     FUsedBytes: Int64;
     FNodeCount: Integer;
     FClock: TSandboxFsClock;
+    FRootClampCallback: TSandboxRootClampCallback;
     constructor CreateFork(const ASource: TSandboxVirtualFileSystem);
     function CurrentTime: TDateTime;
     function LookupNode(const ACanonicalPath: string): TSandboxFsNode;
@@ -166,6 +170,8 @@ type
     property QuotaBytes: Int64 read FQuotaBytes write FQuotaBytes;
     property UsedBytes: Int64 read FUsedBytes;
     property NodeCount: Integer read FNodeCount;
+    property RootClampCallback: TSandboxRootClampCallback
+      read FRootClampCallback write FRootClampCallback;
   end;
 
   TSandboxFsFile = class
@@ -416,6 +422,7 @@ var
   Segment: string;
   Start: Integer;
   Index: Integer;
+  ClampedAtRoot: Boolean;
 
   procedure PushSegment(const AValue: string);
   begin
@@ -424,7 +431,9 @@ var
     if AValue = '..' then
     begin
       if Segments.Count > 0 then
-        Segments.Delete(Segments.Count - 1);
+        Segments.Delete(Segments.Count - 1)
+      else
+        ClampedAtRoot := True;
       { at root, '..' clamps - the jail has no upstairs }
       Exit;
     end;
@@ -432,6 +441,7 @@ var
   end;
 
 begin
+  ClampedAtRoot := False;
   Path := NormalizeSandboxPathSeparators(APath);
   Base := NormalizeSandboxPathSeparators(ABase);
   if (Pos(#0, Path) > 0) or (Pos(#0, Base) > 0) then
@@ -460,6 +470,8 @@ begin
       Result := Result + PathSeparator + Segments[Index];
     if Result = '' then
       Result := PathSeparator;
+    if ClampedAtRoot and Assigned(FRootClampCallback) then
+      FRootClampCallback(APath, ABase, Result);
   finally
     Segments.Free;
   end;

--- a/source/units/Goccia.Builtins.GlobalFFI.pas
+++ b/source/units/Goccia.Builtins.GlobalFFI.pas
@@ -7,6 +7,7 @@ interface
 uses
   Goccia.Arguments.Collection,
   Goccia.Builtins.Base,
+  Goccia.CapabilityAudit,
   Goccia.Error.ThrowErrorCallback,
   Goccia.ObjectModel,
   Goccia.Scope,
@@ -14,6 +15,8 @@ uses
 
 type
   TGocciaGlobalFFI = class(TGocciaBuiltin)
+  private
+    FCapabilityAuditEmitter: TGocciaCapabilityAuditEmitter;
   published
     function FFIOpen(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function FFIStruct(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -23,7 +26,9 @@ type
     function FFINullptrGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function FFISuffixGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   public
-    constructor Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
+    constructor Create(const AName: string; const AScope: TGocciaScope;
+      const AThrowError: TGocciaThrowErrorCallback;
+      const ACapabilityAuditEmitter: TGocciaCapabilityAuditEmitter);
   end;
 
 implementation
@@ -61,11 +66,15 @@ const
   {$ENDIF}
   {$ENDIF}
 
-constructor TGocciaGlobalFFI.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
+constructor TGocciaGlobalFFI.Create(const AName: string;
+  const AScope: TGocciaScope;
+  const AThrowError: TGocciaThrowErrorCallback;
+  const ACapabilityAuditEmitter: TGocciaCapabilityAuditEmitter);
 var
   Members: TGocciaMemberCollection;
 begin
   inherited Create(AName, AScope, AThrowError);
+  FCapabilityAuditEmitter := ACapabilityAuditEmitter;
 
   Members := TGocciaMemberCollection.Create;
   try
@@ -130,6 +139,9 @@ begin
     ThrowTypeError(SErrorFFIOpenRequiresPath, SSuggestFFILibraryOpen);
 
   LibPath := AArgs.GetElement(0).ToStringLiteral.Value;
+  if Assigned(FCapabilityAuditEmitter) then
+    FCapabilityAuditEmitter(gckFFIOpen, gcdAllow, LibPath,
+      'FFI capability is enabled');
 
   try
     Handle := TGocciaFFILibraryHandle.Create(LibPath);

--- a/source/units/Goccia.Builtins.GlobalFetch.pas
+++ b/source/units/Goccia.Builtins.GlobalFetch.pas
@@ -140,7 +140,7 @@ begin
   if FAllowedHosts.Count = 0 then
   begin
     if Assigned(FCapabilityAuditEmitter) then
-      FCapabilityAuditEmitter(gckFetchHost, gcdDeny, AURLStr,
+      FCapabilityAuditEmitter(gckFetchHost, gcdDeny, Host,
         'no fetch hosts are allowed');
     ThrowTypeError(SErrorFetchNoAllowedHosts, SSuggestFetchAllowedHosts);
   end;
@@ -148,14 +148,14 @@ begin
   if FAllowedHosts.IndexOf(Host) < 0 then
   begin
     if Assigned(FCapabilityAuditEmitter) then
-      FCapabilityAuditEmitter(gckFetchHost, gcdDeny, AURLStr,
+      FCapabilityAuditEmitter(gckFetchHost, gcdDeny, Host,
         'host is not in the allowed hosts list');
     ThrowTypeError(Format(SErrorFetchHostNotAllowed, [Host]),
       SSuggestFetchAllowedHosts);
   end;
 
   if Assigned(FCapabilityAuditEmitter) then
-    FCapabilityAuditEmitter(gckFetchHost, gcdAllow, AURLStr,
+    FCapabilityAuditEmitter(gckFetchHost, gcdAllow, Host,
       'host is in the allowed hosts list');
 end;
 

--- a/source/units/Goccia.Builtins.GlobalFetch.pas
+++ b/source/units/Goccia.Builtins.GlobalFetch.pas
@@ -12,6 +12,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.Builtins.Base,
+  Goccia.CapabilityAudit,
   Goccia.Error.ThrowErrorCallback,
   Goccia.Scope,
   Goccia.Values.Primitives;
@@ -20,12 +21,14 @@ type
   TGocciaGlobalFetch = class(TGocciaBuiltin)
   private
     FAllowedHosts: TStringList;
+    FCapabilityAuditEmitter: TGocciaCapabilityAuditEmitter;
     function FetchCallback(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     procedure ValidateHost(const AURLStr: string);
   public
     constructor Create(const AName: string; const AScope: TGocciaScope;
-      const AThrowError: TGocciaThrowErrorCallback);
+      const AThrowError: TGocciaThrowErrorCallback;
+      const ACapabilityAuditEmitter: TGocciaCapabilityAuditEmitter);
     destructor Destroy; override;
 
     procedure SetAllowedHosts(const AHosts: TStrings);
@@ -100,10 +103,12 @@ end;
 
 constructor TGocciaGlobalFetch.Create(const AName: string;
   const AScope: TGocciaScope;
-  const AThrowError: TGocciaThrowErrorCallback);
+  const AThrowError: TGocciaThrowErrorCallback;
+  const ACapabilityAuditEmitter: TGocciaCapabilityAuditEmitter);
 begin
   inherited Create(AName, AScope, AThrowError);
 
+  FCapabilityAuditEmitter := ACapabilityAuditEmitter;
   FAllowedHosts := TStringList.Create;
   FAllowedHosts.CaseSensitive := False;
 
@@ -131,13 +136,27 @@ procedure TGocciaGlobalFetch.ValidateHost(const AURLStr: string);
 var
   Host: string;
 begin
-  if FAllowedHosts.Count = 0 then
-    ThrowTypeError(SErrorFetchNoAllowedHosts, SSuggestFetchAllowedHosts);
-
   Host := ExtractHostFromURL(AURLStr);
+  if FAllowedHosts.Count = 0 then
+  begin
+    if Assigned(FCapabilityAuditEmitter) then
+      FCapabilityAuditEmitter(gckFetchHost, gcdDeny, AURLStr,
+        'no fetch hosts are allowed');
+    ThrowTypeError(SErrorFetchNoAllowedHosts, SSuggestFetchAllowedHosts);
+  end;
+
   if FAllowedHosts.IndexOf(Host) < 0 then
+  begin
+    if Assigned(FCapabilityAuditEmitter) then
+      FCapabilityAuditEmitter(gckFetchHost, gcdDeny, AURLStr,
+        'host is not in the allowed hosts list');
     ThrowTypeError(Format(SErrorFetchHostNotAllowed, [Host]),
       SSuggestFetchAllowedHosts);
+  end;
+
+  if Assigned(FCapabilityAuditEmitter) then
+    FCapabilityAuditEmitter(gckFetchHost, gcdAllow, AURLStr,
+      'host is in the allowed hosts list');
 end;
 
 function TGocciaGlobalFetch.FetchCallback(
@@ -218,9 +237,12 @@ begin
 
   // Perform the request
   Promise := TGocciaPromiseValue.Create;
+  if not Assigned(TGocciaFetchManager.Instance) then
+    TGocciaFetchManager.Initialize;
+  if Assigned(FCapabilityAuditEmitter) then
+    FCapabilityAuditEmitter(gckFetchDispatch, gcdAllow, URLStr,
+      'fetch dispatch is allowed');
   try
-    if not Assigned(TGocciaFetchManager.Instance) then
-      TGocciaFetchManager.Initialize;
     TGocciaFetchManager.Instance.StartFetch(URLStr, Method, RequestHeaders,
       Promise);
   except

--- a/source/units/Goccia.Builtins.GlobalShadowRealm.pas
+++ b/source/units/Goccia.Builtins.GlobalShadowRealm.pas
@@ -38,6 +38,7 @@ uses
   Goccia.Arguments.Collection,
   Goccia.AST.Node,
   Goccia.AST.Statements,
+  Goccia.CapabilityAudit,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
@@ -198,6 +199,7 @@ begin
   FEngine := TGocciaEngine.Create('<shadow-realm>', FSource, FExecutor);
   FEngine.HostEnvironment.ConfigureAsChildOf(
     AParentEngine.HostEnvironment);
+  FEngine.ConfigureCapabilityAuditAsChildOf(AParentEngine);
   // Inherit the host's language surface so the child realm understands the
   // same syntax the host enabled (e.g. --compat-function), while staying a
   // fresh realm with its own intrinsics and global object.
@@ -458,6 +460,9 @@ begin
   // `new`; a non-hole `this` means a [[Call]] without new — throw a TypeError.
   if not (AThisValue is TGocciaHoleValue) then
     ThrowTypeError('Constructor ShadowRealm requires ''new''');
+
+  FEngine.EmitCapabilityAudit(gckShadowRealm, gcdAllow, 'ShadowRealm',
+    'ShadowRealm capability is enabled');
 
   // Steps 2-9: a fresh realm with its own global object and intrinsics.
   Child := TGocciaShadowRealmChildRealm.Create(FEngine);

--- a/source/units/Goccia.CapabilityAudit.Test.pas
+++ b/source/units/Goccia.CapabilityAudit.Test.pas
@@ -6,22 +6,48 @@ uses
   Classes,
   SysUtils,
 
+  SandboxVirtualFileSystem,
   TestingPascalLibrary,
 
   Goccia.CapabilityAudit,
   Goccia.Engine,
+  Goccia.Executor,
+  Goccia.Executor.Bytecode,
   Goccia.Executor.Interpreter,
+  Goccia.Modules,
+  Goccia.Runtime,
+  Goccia.RuntimeExtensions.Sandbox,
+  Goccia.Sandbox.Context,
   Goccia.TestSetup;
 
 type
   ECapabilityAuditSinkFailure = class(Exception);
 
+  TFailingRootClampRuntimeExtension = class(TGocciaRuntimeExtension)
+  private
+    FContext: TGocciaSandboxContext;
+    FPreviousRootClampCallback: TSandboxRootClampCallback;
+    procedure ReplacementRootClamp(const APath, ABase,
+      ACanonicalPath: string);
+  public
+    constructor Create(const AContext: TGocciaSandboxContext);
+    procedure Attach(const ARuntime: TGocciaRuntimeCore); override;
+    procedure Detach; override;
+  end;
+
   TCapabilityAuditTests = class(TTestSuite)
   private
+    FRootClampCount: Integer;
+    FSinkInvocationCount: Integer;
     procedure FailingSink(const AEvent: TGocciaCapabilityAuditEvent);
+    procedure RootClampSentinel(const APath, ABase,
+      ACanonicalPath: string);
     procedure TestSerializesStructuredEvent;
     procedure TestSerializesMissingCoordinatesAsNull;
     procedure TestSinkFailurePropagates;
+    procedure TestSandboxPromiseCannotCatchSinkFailure;
+    procedure TestFailedRuntimeInstallRestoresRootClampCallback;
+    procedure TestSandboxDetachRestoresExistingModules;
   public
     procedure SetupTests; override;
   end;
@@ -33,12 +59,53 @@ begin
   Test('Serializes unavailable coordinates as null',
     TestSerializesMissingCoordinatesAsNull);
   Test('Sink failures propagate to the host', TestSinkFailurePropagates);
+  Test('Sandbox promises cannot catch sink failures',
+    TestSandboxPromiseCannotCatchSinkFailure);
+  Test('Failed runtime installation restores the root clamp callback',
+    TestFailedRuntimeInstallRestoresRootClampCallback);
+  Test('Sandbox detach restores existing runtime modules',
+    TestSandboxDetachRestoresExistingModules);
+end;
+
+constructor TFailingRootClampRuntimeExtension.Create(
+  const AContext: TGocciaSandboxContext);
+begin
+  inherited Create;
+  FContext := AContext;
+end;
+
+procedure TFailingRootClampRuntimeExtension.Attach(
+  const ARuntime: TGocciaRuntimeCore);
+begin
+  inherited Attach(ARuntime);
+  FPreviousRootClampCallback := FContext.Fs.RootClampCallback;
+  FContext.Fs.RootClampCallback := ReplacementRootClamp;
+  raise Exception.Create('attachment failed');
+end;
+
+procedure TFailingRootClampRuntimeExtension.Detach;
+begin
+  FContext.Fs.RootClampCallback := FPreviousRootClampCallback;
+  FPreviousRootClampCallback := nil;
+  inherited;
+end;
+
+procedure TFailingRootClampRuntimeExtension.ReplacementRootClamp(
+  const APath, ABase, ACanonicalPath: string);
+begin
 end;
 
 procedure TCapabilityAuditTests.FailingSink(
   const AEvent: TGocciaCapabilityAuditEvent);
 begin
+  Inc(FSinkInvocationCount);
   raise ECapabilityAuditSinkFailure.Create(AEvent.Subject);
+end;
+
+procedure TCapabilityAuditTests.RootClampSentinel(
+  const APath, ABase, ACanonicalPath: string);
+begin
+  Inc(FRootClampCount);
 end;
 
 procedure TCapabilityAuditTests.TestSerializesStructuredEvent;
@@ -83,6 +150,7 @@ var
   Source: TStringList;
   Executor: TGocciaInterpreterExecutor;
   Engine: TGocciaEngine;
+  ErrorMessage: string;
   Raised: Boolean;
 begin
   Source := TStringList.Create;
@@ -90,17 +158,152 @@ begin
   Engine := TGocciaEngine.Create('audit-test.js', Source, Executor);
   try
     Engine.CapabilityAuditSink := FailingSink;
+    FSinkInvocationCount := 0;
+    ErrorMessage := '';
     Raised := False;
     try
       Engine.EmitCapabilityAudit(gckFFIOpen, gcdAllow, 'library',
         'enabled');
     except
-      on E: ECapabilityAuditSinkFailure do
+      on E: EGocciaCapabilityAuditDeliveryError do
+      begin
+        Raised := True;
+        ErrorMessage := E.Message;
+      end;
+    end;
+    Expect<Integer>(FSinkInvocationCount).ToBe(1);
+    Expect<Boolean>(Raised).ToBe(True);
+    Expect<Boolean>(Pos('library', ErrorMessage) > 0).ToBe(True);
+  finally
+    Engine.Free;
+    Executor.Free;
+    Source.Free;
+  end;
+end;
+
+procedure TCapabilityAuditTests.TestSandboxPromiseCannotCatchSinkFailure;
+  procedure RunWithExecutor(const AExecutor: TGocciaExecutor);
+  var
+    Source: TStringList;
+    Engine: TGocciaEngine;
+    Runtime: TGocciaRuntimeCore;
+    Context: TGocciaSandboxContext;
+    Raised: Boolean;
+  begin
+    Source := TStringList.Create;
+    Source.Text := 'import fs from "fs";' + LineEnding +
+      'try {' + LineEnding +
+      '  await fs.promises.readFile("../../missing.txt", "utf8");' +
+      LineEnding +
+      '} catch (e) {}';
+    Engine := TGocciaEngine.Create('/audit-promise-test.js', Source, AExecutor);
+    Context := TGocciaSandboxContext.Create;
+    try
+      Engine.SourceType := stModule;
+      Engine.CapabilityAuditSink := FailingSink;
+      FSinkInvocationCount := 0;
+      Runtime := AttachRuntime(Engine);
+      Runtime.Install(TGocciaSandboxRuntimeExtension.Create(Context));
+
+      Raised := False;
+      try
+        Engine.Execute;
+      except
+        on E: EGocciaCapabilityAuditDeliveryError do
+          Raised := True;
+      end;
+      Expect<Integer>(FSinkInvocationCount).ToBe(1);
+      Expect<Boolean>(Raised).ToBe(True);
+    finally
+      Engine.Free;
+      Context.Free;
+      AExecutor.Free;
+      Source.Free;
+    end;
+  end;
+begin
+  RunWithExecutor(TGocciaInterpreterExecutor.Create);
+  RunWithExecutor(TGocciaBytecodeExecutor.Create);
+end;
+
+procedure TCapabilityAuditTests.TestFailedRuntimeInstallRestoresRootClampCallback;
+var
+  Source: TStringList;
+  Executor: TGocciaInterpreterExecutor;
+  Engine: TGocciaEngine;
+  Runtime: TGocciaRuntimeCore;
+  Context: TGocciaSandboxContext;
+  NormalizedPath: string;
+  Raised: Boolean;
+begin
+  Source := TStringList.Create;
+  Executor := TGocciaInterpreterExecutor.Create;
+  Engine := TGocciaEngine.Create('audit-attach-test.js', Source, Executor);
+  Context := TGocciaSandboxContext.Create;
+  try
+    Runtime := AttachRuntime(Engine);
+    Context.Fs.RootClampCallback := RootClampSentinel;
+
+    Raised := False;
+    try
+      Runtime.Install(TFailingRootClampRuntimeExtension.Create(Context));
+    except
+      on E: Exception do
         Raised := True;
     end;
     Expect<Boolean>(Raised).ToBe(True);
+
+    FRootClampCount := 0;
+    NormalizedPath := Context.Fs.Normalize('../../probe', '/work');
+    Expect<string>(NormalizedPath).ToBe('/probe');
+    Expect<Integer>(FRootClampCount).ToBe(1);
   finally
     Engine.Free;
+    Context.Free;
+    Executor.Free;
+    Source.Free;
+  end;
+end;
+
+procedure TCapabilityAuditTests.TestSandboxDetachRestoresExistingModules;
+var
+  Source: TStringList;
+  Executor: TGocciaInterpreterExecutor;
+  Engine: TGocciaEngine;
+  Runtime: TGocciaRuntimeCore;
+  Context: TGocciaSandboxContext;
+  Extension: TGocciaSandboxRuntimeExtension;
+  ExistingFsModule: TGocciaModule;
+  ExistingGocciaModule: TGocciaModule;
+  CurrentModule: TGocciaModule;
+begin
+  Source := TStringList.Create;
+  Executor := TGocciaInterpreterExecutor.Create;
+  Engine := TGocciaEngine.Create('audit-detach-test.js', Source, Executor);
+  Context := TGocciaSandboxContext.Create;
+  ExistingFsModule := TGocciaModule.Create('existing-fs');
+  ExistingGocciaModule := TGocciaModule.Create('existing-goccia');
+  try
+    Runtime := AttachRuntime(Engine);
+    Engine.ModuleLoader.GlobalModules.Add('fs', ExistingFsModule);
+    Engine.ModuleLoader.GlobalModules.Add('goccia', ExistingGocciaModule);
+
+    Extension := TGocciaSandboxRuntimeExtension(Runtime.Install(
+      TGocciaSandboxRuntimeExtension.Create(Context)));
+    Extension.Detach;
+
+    Expect<Boolean>(Engine.ModuleLoader.GlobalModules.TryGetValue(
+      'fs', CurrentModule) and (CurrentModule = ExistingFsModule)).ToBe(True);
+    Expect<Boolean>(Engine.ModuleLoader.GlobalModules.TryGetValue(
+      'goccia', CurrentModule) and
+      (CurrentModule = ExistingGocciaModule)).ToBe(True);
+  finally
+    Engine.ModuleLoader.GlobalModules.Remove('goccia');
+    Engine.ModuleLoader.GlobalModules.Remove('fs');
+    Engine.Free;
+    ExistingGocciaModule.Free;
+    ExistingFsModule.Free;
+    Context.Free;
     Executor.Free;
     Source.Free;
   end;

--- a/source/units/Goccia.CapabilityAudit.Test.pas
+++ b/source/units/Goccia.CapabilityAudit.Test.pas
@@ -46,6 +46,7 @@ type
     procedure TestSerializesMissingCoordinatesAsNull;
     procedure TestSinkFailurePropagates;
     procedure TestSandboxPromiseCannotCatchSinkFailure;
+    procedure TestVMAsyncIteratorCannotCatchSinkFailure;
     procedure TestFailedRuntimeInstallRestoresRootClampCallback;
     procedure TestSandboxDetachRestoresExistingModules;
   public
@@ -61,6 +62,8 @@ begin
   Test('Sink failures propagate to the host', TestSinkFailurePropagates);
   Test('Sandbox promises cannot catch sink failures',
     TestSandboxPromiseCannotCatchSinkFailure);
+  Test('VM async iterators cannot catch sink failures',
+    TestVMAsyncIteratorCannotCatchSinkFailure);
   Test('Failed runtime installation restores the root clamp callback',
     TestFailedRuntimeInstallRestoresRootClampCallback);
   Test('Sandbox detach restores existing runtime modules',
@@ -224,6 +227,49 @@ procedure TCapabilityAuditTests.TestSandboxPromiseCannotCatchSinkFailure;
 begin
   RunWithExecutor(TGocciaInterpreterExecutor.Create);
   RunWithExecutor(TGocciaBytecodeExecutor.Create);
+end;
+
+procedure TCapabilityAuditTests.TestVMAsyncIteratorCannotCatchSinkFailure;
+var
+  Source: TStringList;
+  Executor: TGocciaBytecodeExecutor;
+  Engine: TGocciaEngine;
+  Raised: Boolean;
+begin
+  Source := TStringList.Create;
+  Source.Text := 'const iterable = {' + LineEnding +
+    '  [Symbol.iterator]: () => ({' + LineEnding +
+    '    next: () => {' + LineEnding +
+    '      Function("return 1");' + LineEnding +
+    '      return { done: true };' + LineEnding +
+    '    },' + LineEnding +
+    '  }),' + LineEnding +
+    '};' + LineEnding +
+    'try {' + LineEnding +
+    '  for await (const value of iterable) {}' + LineEnding +
+    '} catch (e) {}';
+  Executor := TGocciaBytecodeExecutor.Create;
+  Engine := TGocciaEngine.Create('/audit-async-iterator-test.js', Source,
+    Executor);
+  try
+    Engine.SourceType := stModule;
+    Engine.CapabilityAuditSink := FailingSink;
+    FSinkInvocationCount := 0;
+
+    Raised := False;
+    try
+      Engine.Execute;
+    except
+      on E: EGocciaCapabilityAuditDeliveryError do
+        Raised := True;
+    end;
+    Expect<Integer>(FSinkInvocationCount).ToBe(1);
+    Expect<Boolean>(Raised).ToBe(True);
+  finally
+    Engine.Free;
+    Executor.Free;
+    Source.Free;
+  end;
 end;
 
 procedure TCapabilityAuditTests.TestFailedRuntimeInstallRestoresRootClampCallback;

--- a/source/units/Goccia.CapabilityAudit.Test.pas
+++ b/source/units/Goccia.CapabilityAudit.Test.pas
@@ -1,0 +1,114 @@
+program Goccia.CapabilityAudit.Test;
+
+{$I Goccia.inc}
+
+uses
+  Classes,
+  SysUtils,
+
+  TestingPascalLibrary,
+
+  Goccia.CapabilityAudit,
+  Goccia.Engine,
+  Goccia.Executor.Interpreter,
+  Goccia.TestSetup;
+
+type
+  ECapabilityAuditSinkFailure = class(Exception);
+
+  TCapabilityAuditTests = class(TTestSuite)
+  private
+    procedure FailingSink(const AEvent: TGocciaCapabilityAuditEvent);
+    procedure TestSerializesStructuredEvent;
+    procedure TestSerializesMissingCoordinatesAsNull;
+    procedure TestSinkFailurePropagates;
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TCapabilityAuditTests.SetupTests;
+begin
+  Test('Serializes the versioned structured event',
+    TestSerializesStructuredEvent);
+  Test('Serializes unavailable coordinates as null',
+    TestSerializesMissingCoordinatesAsNull);
+  Test('Sink failures propagate to the host', TestSinkFailurePropagates);
+end;
+
+procedure TCapabilityAuditTests.FailingSink(
+  const AEvent: TGocciaCapabilityAuditEvent);
+begin
+  raise ECapabilityAuditSinkFailure.Create(AEvent.Subject);
+end;
+
+procedure TCapabilityAuditTests.TestSerializesStructuredEvent;
+var
+  AuditEvent: TGocciaCapabilityAuditEvent;
+begin
+  AuditEvent.Kind := gckFetchHost;
+  AuditEvent.Decision := gcdDeny;
+  AuditEvent.Subject := 'https://blocked.test/"quoted"';
+  AuditEvent.Reason := 'host is not allowed';
+  AuditEvent.Source.FilePath := 'app.js';
+  AuditEvent.Source.Line := 7;
+  AuditEvent.Source.Column := 3;
+
+  Expect<string>(AuditEvent.ToJSON).ToBe(
+    '{"schemaVersion":1,"kind":"fetch.host","decision":"deny",' +
+    '"subject":"https://blocked.test/\"quoted\"",' +
+    '"reason":"host is not allowed",' +
+    '"source":{"file":"app.js","line":7,"column":3}}');
+end;
+
+procedure TCapabilityAuditTests.TestSerializesMissingCoordinatesAsNull;
+var
+  AuditEvent: TGocciaCapabilityAuditEvent;
+begin
+  AuditEvent.Kind := gckShadowRealm;
+  AuditEvent.Decision := gcdAllow;
+  AuditEvent.Subject := 'ShadowRealm';
+  AuditEvent.Reason := 'enabled';
+  AuditEvent.Source.FilePath := '<shadow-realm>';
+  AuditEvent.Source.Line := 0;
+  AuditEvent.Source.Column := 0;
+
+  Expect<string>(AuditEvent.ToJSON).ToBe(
+    '{"schemaVersion":1,"kind":"shadow-realm.construct",' +
+    '"decision":"allow","subject":"ShadowRealm","reason":"enabled",' +
+    '"source":{"file":"<shadow-realm>","line":null,"column":null}}');
+end;
+
+procedure TCapabilityAuditTests.TestSinkFailurePropagates;
+var
+  Source: TStringList;
+  Executor: TGocciaInterpreterExecutor;
+  Engine: TGocciaEngine;
+  Raised: Boolean;
+begin
+  Source := TStringList.Create;
+  Executor := TGocciaInterpreterExecutor.Create;
+  Engine := TGocciaEngine.Create('audit-test.js', Source, Executor);
+  try
+    Engine.CapabilityAuditSink := FailingSink;
+    Raised := False;
+    try
+      Engine.EmitCapabilityAudit(gckFFIOpen, gcdAllow, 'library',
+        'enabled');
+    except
+      on E: ECapabilityAuditSinkFailure do
+        Raised := True;
+    end;
+    Expect<Boolean>(Raised).ToBe(True);
+  finally
+    Engine.Free;
+    Executor.Free;
+    Source.Free;
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(
+    TCapabilityAuditTests.Create('Capability Audit'));
+  TestRunnerProgram.Run;
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/units/Goccia.CapabilityAudit.pas
+++ b/source/units/Goccia.CapabilityAudit.pas
@@ -1,0 +1,108 @@
+unit Goccia.CapabilityAudit;
+
+{$I Goccia.inc}
+
+interface
+
+type
+  TGocciaCapabilityKind = (
+    gckFetchHost,
+    gckFetchDispatch,
+    gckFFIOpen,
+    gckFunctionConstructor,
+    gckShadowRealm,
+    gckSandboxFileSystem
+  );
+
+  TGocciaCapabilityDecision = (
+    gcdAllow,
+    gcdDeny
+  );
+
+  TGocciaCapabilityAuditSource = record
+    FilePath: string;
+    Line: Integer;
+    Column: Integer;
+  end;
+
+  TGocciaCapabilityAuditEvent = record
+    Kind: TGocciaCapabilityKind;
+    Decision: TGocciaCapabilityDecision;
+    Subject: string;
+    Reason: string;
+    Source: TGocciaCapabilityAuditSource;
+    function ToJSON: string;
+  end;
+
+  TGocciaCapabilityAuditSink = procedure(
+    const AEvent: TGocciaCapabilityAuditEvent) of object;
+
+  TGocciaCapabilityAuditEmitter = procedure(
+    const AKind: TGocciaCapabilityKind;
+    const ADecision: TGocciaCapabilityDecision;
+    const ASubject, AReason: string) of object;
+
+function CapabilityKindName(const AKind: TGocciaCapabilityKind): string;
+function CapabilityDecisionName(
+  const ADecision: TGocciaCapabilityDecision): string;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.JSON.Utils;
+
+function CapabilityKindName(const AKind: TGocciaCapabilityKind): string;
+begin
+  case AKind of
+    gckFetchHost:
+      Result := 'fetch.host';
+    gckFetchDispatch:
+      Result := 'fetch.dispatch';
+    gckFFIOpen:
+      Result := 'ffi.open';
+    gckFunctionConstructor:
+      Result := 'function.constructor';
+    gckShadowRealm:
+      Result := 'shadow-realm.construct';
+    gckSandboxFileSystem:
+      Result := 'sandbox.fs.path';
+  end;
+end;
+
+function CapabilityDecisionName(
+  const ADecision: TGocciaCapabilityDecision): string;
+begin
+  case ADecision of
+    gcdAllow:
+      Result := 'allow';
+    gcdDeny:
+      Result := 'deny';
+  end;
+end;
+
+function JSONIntegerOrNull(const AValue: Integer): string;
+begin
+  if AValue > 0 then
+    Result := IntToStr(AValue)
+  else
+    Result := 'null';
+end;
+
+function TGocciaCapabilityAuditEvent.ToJSON: string;
+begin
+  Result :=
+    '{"schemaVersion":1' +
+    ',"kind":' + QuoteJSONString(CapabilityKindName(Kind)) +
+    ',"decision":' + QuoteJSONString(CapabilityDecisionName(Decision)) +
+    ',"subject":' + QuoteJSONString(Subject) +
+    ',"reason":' + QuoteJSONString(Reason) +
+    ',"source":{' +
+      '"file":' + QuoteJSONString(Source.FilePath) +
+      ',"line":' + JSONIntegerOrNull(Source.Line) +
+      ',"column":' + JSONIntegerOrNull(Source.Column) +
+    '}}';
+end;
+
+end.

--- a/source/units/Goccia.CapabilityAudit.pas
+++ b/source/units/Goccia.CapabilityAudit.pas
@@ -4,7 +4,12 @@ unit Goccia.CapabilityAudit;
 
 interface
 
+uses
+  SysUtils;
+
 type
+  EGocciaCapabilityAuditDeliveryError = class(Exception);
+
   TGocciaCapabilityKind = (
     gckFetchHost,
     gckFetchDispatch,
@@ -49,8 +54,6 @@ function CapabilityDecisionName(
 implementation
 
 uses
-  SysUtils,
-
   Goccia.JSON.Utils;
 
 function CapabilityKindName(const AKind: TGocciaCapabilityKind): string;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -36,6 +36,7 @@ uses
   Goccia.Builtins.JSON,
   Goccia.Builtins.Math,
   Goccia.Builtins.Temporal,
+  Goccia.CapabilityAudit,
   Goccia.Constants,
   Goccia.Evaluator,
   Goccia.Evaluator.Context,
@@ -158,6 +159,7 @@ type
     FRetainedModules: Contnrs.TObjectList;
     FLazyThunks: Contnrs.TObjectList;
     FHostEnvironment: TGocciaHostEnvironment;
+    FCapabilityAuditSink: TGocciaCapabilityAuditSink;
 
     // Core language built-in objects
     FBuiltinMath: TGocciaMath;
@@ -270,6 +272,11 @@ type
 
     procedure AddAlias(const APattern, AReplacement: string);
     procedure SetAllowedFetchHosts(const AHosts: TStrings);
+    procedure EmitCapabilityAudit(const AKind: TGocciaCapabilityKind;
+      const ADecision: TGocciaCapabilityDecision;
+      const ASubject, AReason: string);
+    procedure ConfigureCapabilityAuditAsChildOf(
+      const AParent: TGocciaEngine);
     procedure InjectGlobal(const AKey: string; const AValue: TGocciaValue);
     procedure RegisterGlobal(const AName: string; const AValue: TGocciaValue);
     procedure RegisterLazyGlobal(const AName: string;
@@ -322,6 +329,8 @@ type
     property ModuleResolver: TGocciaModuleResolver read GetModuleResolver;
     property ModuleLoader: TGocciaModuleLoader read FModuleLoader;
     property HostEnvironment: TGocciaHostEnvironment read FHostEnvironment;
+    property CapabilityAuditSink: TGocciaCapabilityAuditSink
+      read FCapabilityAuditSink write FCapabilityAuditSink;
     property SourcePath: string read FSourcePath;
     property FunctionConstructor: TGocciaFunctionConstructorClassValue read FFunctionConstructor;
     property ObjectConstructor: TGocciaClassValue read FObjectConstructor;
@@ -378,6 +387,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Coverage,
   Goccia.Error,
+  Goccia.Execution.CallSite,
   Goccia.Executor.Bytecode,
   Goccia.Executor.Interpreter,
   Goccia.FileExtensions,
@@ -907,7 +917,10 @@ begin
   FExecutor.Initialize(FInterpreter.GlobalScope, FModuleLoader, AFileName);
 
   if Assigned(FFunctionConstructor) then
+  begin
     FFunctionConstructor.CompileDynamicFunction := CompileDynamicFunction;
+    FFunctionConstructor.CapabilityAuditEmitter := EmitCapabilityAudit;
+  end;
 end;
 
 destructor TGocciaEngine.Destroy;
@@ -1669,6 +1682,46 @@ var
 begin
   for I := 0 to FExtensions.Count - 1 do
     FExtensions[I].SetAllowedFetchHosts(AHosts);
+end;
+
+procedure TGocciaEngine.EmitCapabilityAudit(
+  const AKind: TGocciaCapabilityKind;
+  const ADecision: TGocciaCapabilityDecision;
+  const ASubject, AReason: string);
+var
+  AuditEvent: TGocciaCapabilityAuditEvent;
+  CallSite: TGocciaCallSite;
+begin
+  if not Assigned(FCapabilityAuditSink) then
+    Exit;
+
+  AuditEvent.Kind := AKind;
+  AuditEvent.Decision := ADecision;
+  AuditEvent.Subject := ASubject;
+  AuditEvent.Reason := AReason;
+  if CurrentGocciaCallSite(CallSite) then
+  begin
+    AuditEvent.Source.FilePath := CallSite.FilePath;
+    AuditEvent.Source.Line := CallSite.Line;
+    AuditEvent.Source.Column := CallSite.Column;
+  end
+  else
+  begin
+    AuditEvent.Source.FilePath := FSourcePath;
+    AuditEvent.Source.Line := 0;
+    AuditEvent.Source.Column := 0;
+  end;
+
+  FCapabilityAuditSink(AuditEvent);
+end;
+
+procedure TGocciaEngine.ConfigureCapabilityAuditAsChildOf(
+  const AParent: TGocciaEngine);
+begin
+  if Assigned(AParent) then
+    FCapabilityAuditSink := AParent.FCapabilityAuditSink
+  else
+    FCapabilityAuditSink := nil;
 end;
 
 procedure TGocciaEngine.WaitForRuntimeIdle;

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1712,7 +1712,15 @@ begin
     AuditEvent.Source.Column := 0;
   end;
 
-  FCapabilityAuditSink(AuditEvent);
+  try
+    FCapabilityAuditSink(AuditEvent);
+  except
+    on E: EGocciaCapabilityAuditDeliveryError do
+      raise;
+    on E: Exception do
+      raise EGocciaCapabilityAuditDeliveryError.Create(
+        'capability audit delivery failed: ' + E.Message);
+  end;
 end;
 
 procedure TGocciaEngine.ConfigureCapabilityAuditAsChildOf(

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -4394,7 +4394,10 @@ begin
         CheckStackDepth(TGocciaCallStack.Instance.Count);
       if Assigned(Callee) and Callee.IsCallable then
       begin
-        if Callee is TGocciaNativeFunctionValue then
+        if (Callee is TGocciaNativeFunctionValue) or
+           (Callee is TGocciaFunctionConstructorClassValue) or
+           (Callee is TGocciaBoundFunctionValue) or
+           (Callee is TGocciaProxyValue) then
         begin
           EnterGocciaCallSite(AContext.CurrentFilePath,
             ACallExpression.Line, ACallExpression.Column, PreviousCallSite);
@@ -8419,6 +8422,7 @@ var
   ReceiverPrototype: TGocciaObjectValue;
   ReceiverInstance: TGocciaObjectValue;
   Roots: TGocciaActiveRootFrame;
+  PreviousCallSite: TGocciaCallSite;
 begin
   Roots.Initialize;
   CheckExecutionTimeout;
@@ -8466,15 +8470,27 @@ begin
         CheckStackDepth(TGocciaCallStack.Instance.Count);
       if Callee is TGocciaProxyValue then
       begin
-        Result := TGocciaProxyValue(Callee).ConstructTrap(Arguments);
+        EnterGocciaCallSite(AContext.CurrentFilePath,
+          ANewExpression.Line, ANewExpression.Column, PreviousCallSite);
+        try
+          Result := TGocciaProxyValue(Callee).ConstructTrap(Arguments);
+        finally
+          LeaveGocciaCallSite(PreviousCallSite);
+        end
       end
       else if Callee is TGocciaClassValue then
       begin
-        if ShouldUseNativeClassInstantiation(TGocciaClassValue(Callee)) then
-          Result := TGocciaClassValue(Callee).Instantiate(Arguments)
-        else
-          Result := InstantiateClass(TGocciaClassValue(Callee), Arguments,
-            AContext);
+        EnterGocciaCallSite(AContext.CurrentFilePath,
+          ANewExpression.Line, ANewExpression.Column, PreviousCallSite);
+        try
+          if ShouldUseNativeClassInstantiation(TGocciaClassValue(Callee)) then
+            Result := TGocciaClassValue(Callee).Instantiate(Arguments)
+          else
+            Result := InstantiateClass(TGocciaClassValue(Callee), Arguments,
+              AContext);
+        finally
+          LeaveGocciaCallSite(PreviousCallSite);
+        end;
       end
       else if Callee is TGocciaNativeFunctionValue then
       begin
@@ -8484,8 +8500,14 @@ begin
               [TGocciaNativeFunctionValue(Callee).Name]),
             Format('''%s'' is not a constructor',
               [TGocciaNativeFunctionValue(Callee).Name]));
-        Result := TGocciaNativeFunctionValue(Callee).Construct(Arguments,
-          Callee);
+        EnterGocciaCallSite(AContext.CurrentFilePath,
+          ANewExpression.Line, ANewExpression.Column, PreviousCallSite);
+        try
+          Result := TGocciaNativeFunctionValue(Callee).Construct(Arguments,
+            Callee);
+        finally
+          LeaveGocciaCallSite(PreviousCallSite);
+        end;
       end
       else if Callee is TGocciaFunctionBase then
       begin
@@ -8521,11 +8543,17 @@ begin
           // InvokeConstructableWithReceiver merges bound args, dispatches to
           // the underlying target, and applies the spec return rules
           // (explicit Object return wins; otherwise the receiver).
-          Result := InvokeConstructableWithReceiver(FunctionCallee, Arguments,
-            ReceiverInstance, AContext);
+          EnterGocciaCallSite(AContext.CurrentFilePath,
+            ANewExpression.Line, ANewExpression.Column, PreviousCallSite);
+          try
+            Result := InvokeConstructableWithReceiver(FunctionCallee, Arguments,
+              ReceiverInstance, AContext);
+          finally
+            LeaveGocciaCallSite(PreviousCallSite);
+          end;
         finally
           TGarbageCollector.Instance.RemoveTempRoot(ReceiverInstance);
-        end;
+        end
       end
       else
       begin

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -193,6 +193,7 @@ uses
   Goccia.AST.BindingPatterns,
   Goccia.Bytecode.Chunk,
   Goccia.CallStack,
+  Goccia.CapabilityAudit,
   Goccia.Constants,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
@@ -7637,6 +7638,8 @@ var
         raise;
       on E: TGocciaInstructionLimitError do
         raise;
+      on E: EGocciaCapabilityAuditDeliveryError do
+        raise;
       on E: Exception do
       begin
         Result := TGocciaControlFlow.Normal(TGocciaUndefinedLiteralValue.UndefinedValue);
@@ -7700,6 +7703,8 @@ begin
       on E: TGocciaTimeoutError do
         raise;
       on E: TGocciaInstructionLimitError do
+        raise;
+      on E: EGocciaCapabilityAuditDeliveryError do
         raise;
       on E: Exception do
       begin

--- a/source/units/Goccia.Interpreter.pas
+++ b/source/units/Goccia.Interpreter.pas
@@ -109,6 +109,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.AST.Statements,
+  Goccia.CapabilityAudit,
   Goccia.Constants.ErrorNames,
   Goccia.Coverage,
   Goccia.GarbageCollector,
@@ -239,6 +240,8 @@ begin
     except
       on E: EGocciaAsyncAwaitSuspend do
         AttachAwait(E);
+      on E: EGocciaCapabilityAuditDeliveryError do
+        raise;
       on E: Exception do
         RejectWithException(E);
     end;

--- a/source/units/Goccia.Intrinsics.FunctionObjects.pas
+++ b/source/units/Goccia.Intrinsics.FunctionObjects.pas
@@ -241,6 +241,8 @@ begin
     FunctionConstructor := TGocciaFunctionConstructorClassValue(
       FunctionConstructorValue);
     Result.Enabled := FunctionConstructor.Enabled;
+    Result.CapabilityAuditEmitter :=
+      FunctionConstructor.CapabilityAuditEmitter;
     Result.CompileDynamicFunction := FunctionConstructor.CompileDynamicFunction;
   end;
 end;

--- a/source/units/Goccia.MicrotaskQueue.pas
+++ b/source/units/Goccia.MicrotaskQueue.pas
@@ -53,6 +53,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.Builtins.Atomics,
+  Goccia.CapabilityAudit,
   Goccia.Constants.ErrorNames,
   Goccia.Error,
   Goccia.GarbageCollector,
@@ -212,6 +213,8 @@ begin
         on E: TGocciaTimeoutError do
           raise;
         on E: TGocciaInstructionLimitError do
+          raise;
+        on E: EGocciaCapabilityAuditDeliveryError do
           raise;
         on E: Exception do
           ResolvingFunctions.RejectException(E);
@@ -383,6 +386,8 @@ begin
         on E: TGocciaTimeoutError do
           raise;
         on E: TGocciaInstructionLimitError do
+          raise;
+        on E: EGocciaCapabilityAuditDeliveryError do
           raise;
         on E: TGocciaTypeError do
           if Assigned(Promise) or Assigned(Capability) then

--- a/source/units/Goccia.Runtime.Test.pas
+++ b/source/units/Goccia.Runtime.Test.pas
@@ -14,10 +14,12 @@ uses
   Goccia.Modules,
   Goccia.Modules.Loader,
   Goccia.Modules.Resolver,
+  Goccia.Realm,
   Goccia.Runtime,
   Goccia.RuntimeExtensions.Console,
   Goccia.RuntimeExtensions.JSON5,
   Goccia.TestSetup,
+  Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
 type
@@ -25,6 +27,12 @@ type
   public
     function Resolve(const AModulePath,
       AImportingFilePath: string): string; override;
+  end;
+
+  TRollbackModuleRuntimeExtension = class(TGocciaRuntimeExtension)
+  public
+    procedure Attach(const ARuntime: TGocciaRuntimeCore); override;
+    procedure AddModuleExtensions(const AExtensions: TStrings); override;
   end;
 
   TRuntimeTests = class(TTestSuite)
@@ -42,6 +50,7 @@ type
     procedure TestGlobalModuleProviderUnregisterClearsLoadedModule;
     procedure TestRuntimeConstructorAcceptsExistingEngine;
     procedure TestRuntimeInstallIsIdempotent;
+    procedure TestRuntimeInstallRollsBackResolverExtensions;
     procedure TestRuntimePreservesResolverExtensions;
     procedure TestRuntimeModuleLoaderFallsBackToPreviousLoader;
     procedure TestRuntimeRunScriptFromFileLoadsFile;
@@ -58,6 +67,21 @@ begin
   Result := inherited Resolve(AModulePath, AImportingFilePath);
 end;
 
+procedure TRollbackModuleRuntimeExtension.Attach(
+  const ARuntime: TGocciaRuntimeCore);
+begin
+  inherited;
+  ARuntime.Engine.RegisterGlobal('resolverRollbackProbe',
+    TGocciaUndefinedLiteralValue.UndefinedValue);
+  TGocciaObjectValue(ARuntime.Engine.Realm.GlobalObject).PreventExtensions;
+end;
+
+procedure TRollbackModuleRuntimeExtension.AddModuleExtensions(
+  const AExtensions: TStrings);
+begin
+  AExtensions.Add('.rollback-test');
+end;
+
 procedure TRuntimeTests.SetupTests;
 begin
   Test('Engine rejects nil extension',
@@ -70,6 +94,8 @@ begin
     TestRuntimeConstructorAcceptsExistingEngine);
   Test('Runtime extension install is idempotent',
     TestRuntimeInstallIsIdempotent);
+  Test('Runtime extension install rolls back resolver extensions',
+    TestRuntimeInstallRollsBackResolverExtensions);
   Test('Runtime preserves resolver extensions',
     TestRuntimePreservesResolverExtensions);
   Test('Runtime module loader falls back to previous loader',
@@ -295,6 +321,52 @@ begin
       SecondExtension := Runtime.Install(TGocciaConsoleRuntimeExtension.Create);
 
       Expect<Boolean>(FirstExtension = SecondExtension).ToBe(True);
+    finally
+      Runtime.Free;
+      Engine.Free;
+      Source.Free;
+    end;
+  finally
+    Executor.Free;
+  end;
+end;
+
+procedure TRuntimeTests.TestRuntimeInstallRollsBackResolverExtensions;
+var
+  ContainsRollbackExtension: Boolean;
+  Engine: TGocciaEngine;
+  Executor: TGocciaInterpreterExecutor;
+  Extension: string;
+  Extensions: TModuleResolverExtensionArray;
+  Raised: Boolean;
+  Runtime: TGocciaRuntime;
+  Source: TStringList;
+begin
+  Source := CreateEmptySource;
+  Executor := TGocciaInterpreterExecutor.Create;
+  try
+    Engine := TGocciaEngine.Create('<runtime-test>', Source, Executor);
+    Runtime := nil;
+    try
+      Engine.Resolver.SetExtensions(['.custom']);
+      Runtime := TGocciaRuntime.Create(Engine);
+
+      Raised := False;
+      try
+        Runtime.Install(TRollbackModuleRuntimeExtension.Create);
+      except
+        on E: Exception do
+          Raised := True;
+      end;
+      Expect<Boolean>(Raised).ToBe(True);
+
+      Extensions := Engine.Resolver.GetExtensions;
+      ContainsRollbackExtension := False;
+      for Extension in Extensions do
+        if Extension = '.rollback-test' then
+          ContainsRollbackExtension := True;
+      Expect<Boolean>(ContainsRollbackExtension).ToBe(False);
+      Expect<string>(Extensions[0]).ToBe('.custom');
     finally
       Runtime.Free;
       Engine.Free;

--- a/source/units/Goccia.Runtime.Test.pas
+++ b/source/units/Goccia.Runtime.Test.pas
@@ -8,7 +8,9 @@ uses
 
   TestingPascalLibrary,
 
+  Goccia.Constants.PropertyNames,
   Goccia.Engine,
+  Goccia.Error.Messages,
   Goccia.Executor.Interpreter,
   Goccia.ModuleResolver,
   Goccia.Modules,
@@ -19,8 +21,12 @@ uses
   Goccia.RuntimeExtensions.Console,
   Goccia.RuntimeExtensions.JSON5,
   Goccia.TestSetup,
+  Goccia.Values.Error,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
+
+const
+  ROLLBACK_PROBE_NAME = 'resolverRollbackProbe';
 
 type
   TCustomRuntimeModuleResolver = class(TGocciaModuleResolver)
@@ -30,8 +36,11 @@ type
   end;
 
   TRollbackModuleRuntimeExtension = class(TGocciaRuntimeExtension)
+  private
+    FPreviousProbeValue: TGocciaValue;
   public
     procedure Attach(const ARuntime: TGocciaRuntimeCore); override;
+    procedure Detach; override;
     procedure AddModuleExtensions(const AExtensions: TStrings); override;
   end;
 
@@ -71,9 +80,19 @@ procedure TRollbackModuleRuntimeExtension.Attach(
   const ARuntime: TGocciaRuntimeCore);
 begin
   inherited;
-  ARuntime.Engine.RegisterGlobal('resolverRollbackProbe',
+  FPreviousProbeValue := ARuntime.Engine.Interpreter.GlobalScope.GetValue(
+    ROLLBACK_PROBE_NAME);
+  ARuntime.Engine.RegisterGlobal(ROLLBACK_PROBE_NAME,
     TGocciaUndefinedLiteralValue.UndefinedValue);
   TGocciaObjectValue(ARuntime.Engine.Realm.GlobalObject).PreventExtensions;
+end;
+
+procedure TRollbackModuleRuntimeExtension.Detach;
+begin
+  if Assigned(Runtime) then
+    Runtime.Engine.RegisterGlobal(ROLLBACK_PROBE_NAME, FPreviousProbeValue);
+  FPreviousProbeValue := nil;
+  inherited;
 end;
 
 procedure TRollbackModuleRuntimeExtension.AddModuleExtensions(
@@ -333,12 +352,14 @@ end;
 
 procedure TRuntimeTests.TestRuntimeInstallRollsBackResolverExtensions;
 var
-  ContainsRollbackExtension: Boolean;
+  BaselineExtensions: TModuleResolverExtensionArray;
   Engine: TGocciaEngine;
   Executor: TGocciaInterpreterExecutor;
-  Extension: string;
   Extensions: TModuleResolverExtensionArray;
-  Raised: Boolean;
+  I: Integer;
+  ProbeValue: TGocciaValue;
+  RaisedMessage: string;
+  RaisedExpectedException: Boolean;
   Runtime: TGocciaRuntime;
   Source: TStringList;
 begin
@@ -348,25 +369,39 @@ begin
     Engine := TGocciaEngine.Create('<runtime-test>', Source, Executor);
     Runtime := nil;
     try
+      Engine.RegisterGlobal(ROLLBACK_PROBE_NAME,
+        TGocciaBooleanLiteralValue.TrueValue);
       Engine.Resolver.SetExtensions(['.custom']);
       Runtime := TGocciaRuntime.Create(Engine);
+      BaselineExtensions := Engine.Resolver.GetExtensions;
 
-      Raised := False;
+      RaisedExpectedException := False;
+      RaisedMessage := '';
       try
         Runtime.Install(TRollbackModuleRuntimeExtension.Create);
       except
-        on E: Exception do
-          Raised := True;
+        on E: TGocciaThrowValue do
+        begin
+          RaisedExpectedException := True;
+          if E.Value is TGocciaObjectValue then
+            RaisedMessage := TGocciaObjectValue(E.Value)
+              .GetProperty(PROP_MESSAGE).ToStringLiteral.Value;
+        end;
       end;
-      Expect<Boolean>(Raised).ToBe(True);
+      Expect<Boolean>(RaisedExpectedException).ToBe(True);
+      Expect<string>(RaisedMessage).ToBe(Format(
+        SErrorCannotAddPropertyNotExtensible, [ROLLBACK_PROBE_NAME]));
 
       Extensions := Engine.Resolver.GetExtensions;
-      ContainsRollbackExtension := False;
-      for Extension in Extensions do
-        if Extension = '.rollback-test' then
-          ContainsRollbackExtension := True;
-      Expect<Boolean>(ContainsRollbackExtension).ToBe(False);
-      Expect<string>(Extensions[0]).ToBe('.custom');
+      Expect<Integer>(Length(Extensions)).ToBe(Length(BaselineExtensions));
+      for I := 0 to High(Extensions) do
+        Expect<string>(Extensions[I]).ToBe(BaselineExtensions[I]);
+      Expect<Boolean>(not Assigned(Runtime.FindRuntimeExtension(
+        TRollbackModuleRuntimeExtension))).ToBe(True);
+      ProbeValue := Engine.Interpreter.GlobalScope.GetValue(
+        ROLLBACK_PROBE_NAME);
+      Expect<Boolean>(ProbeValue =
+        TGocciaBooleanLiteralValue.TrueValue).ToBe(True);
     finally
       Runtime.Free;
       Engine.Free;

--- a/source/units/Goccia.Runtime.pas
+++ b/source/units/Goccia.Runtime.pas
@@ -352,7 +352,14 @@ begin
     FEngine.RefreshGlobalThis;
   except
     if Added then
+    begin
       FExtensions.Extract(AExtension);
+      try
+        RefreshModuleExtensions;
+      except
+        // Preserve the attachment or refresh failure that triggered cleanup.
+      end;
+    end;
     try
       AExtension.Detach;
     except

--- a/source/units/Goccia.Runtime.pas
+++ b/source/units/Goccia.Runtime.pas
@@ -352,9 +352,11 @@ begin
     FEngine.RefreshGlobalThis;
   except
     if Added then
-    begin
       FExtensions.Extract(AExtension);
+    try
       AExtension.Detach;
+    except
+      // Preserve the attachment or refresh failure that triggered cleanup.
     end;
     AExtension.Free;
     raise;

--- a/source/units/Goccia.RuntimeExtensions.FFI.pas
+++ b/source/units/Goccia.RuntimeExtensions.FFI.pas
@@ -26,7 +26,8 @@ procedure TGocciaFFIRuntimeExtension.Attach(const ARuntime: TGocciaRuntimeCore);
 begin
   inherited Attach(ARuntime);
   FBuiltinFFI := TGocciaGlobalFFI.Create(CONSTRUCTOR_FFI,
-    Runtime.Engine.Interpreter.GlobalScope, Runtime.Engine.ThrowError);
+    Runtime.Engine.Interpreter.GlobalScope, Runtime.Engine.ThrowError,
+    Runtime.Engine.EmitCapabilityAudit);
   Runtime.RegisterRuntimeGlobalName('FFI');
 end;
 

--- a/source/units/Goccia.RuntimeExtensions.Fetch.pas
+++ b/source/units/Goccia.RuntimeExtensions.Fetch.pas
@@ -56,7 +56,8 @@ begin
   inherited Attach(ARuntime);
   TGocciaFetchManager.Initialize;
   FBuiltinFetch := TGocciaGlobalFetch.Create('Fetch',
-    Runtime.Engine.Interpreter.GlobalScope, Runtime.Engine.ThrowError);
+    Runtime.Engine.Interpreter.GlobalScope, Runtime.Engine.ThrowError,
+    Runtime.Engine.EmitCapabilityAudit);
 
   if not Assigned(Runtime.Engine.ObjectConstructor) then
     Exit;

--- a/source/units/Goccia.RuntimeExtensions.Sandbox.pas
+++ b/source/units/Goccia.RuntimeExtensions.Sandbox.pas
@@ -19,8 +19,13 @@ type
   private
     FContext: TGocciaSandboxContext;
     FFsModule: TGocciaModule;
+    FFsModuleRegistered: Boolean;
     FGocciaModule: TGocciaModule;
+    FGocciaModuleRegistered: Boolean;
+    FPreviousFsModule: TGocciaModule;
+    FPreviousGocciaModule: TGocciaModule;
     FPreviousRootClampCallback: TSandboxRootClampCallback;
+    FRootClampInstalled: Boolean;
 
     procedure HandleRootClamp(const APath, ABase,
       ACanonicalPath: string);
@@ -283,6 +288,8 @@ begin
   except
     on E: TGocciaThrowValue do
       Result := RejectedPromise(E.Value);
+    on E: EGocciaCapabilityAuditDeliveryError do
+      raise;
     on E: Exception do
       Result := RejectedPromise(TGocciaStringLiteralValue.Create(E.Message));
   end;
@@ -648,6 +655,8 @@ begin
   except
     on E: TGocciaThrowValue do
       Result := RejectedPromise(E.Value);
+    on E: EGocciaCapabilityAuditDeliveryError do
+      raise;
     on E: Exception do
       Result := RejectedPromise(TGocciaStringLiteralValue.Create(E.Message));
   end;
@@ -666,6 +675,8 @@ begin
   except
     on E: TGocciaThrowValue do
       Result := RejectedPromise(E.Value);
+    on E: EGocciaCapabilityAuditDeliveryError do
+      raise;
     on E: Exception do
       Result := RejectedPromise(TGocciaStringLiteralValue.Create(E.Message));
   end;
@@ -690,6 +701,8 @@ begin
   except
     on E: TGocciaThrowValue do
       Result := RejectedPromise(E.Value);
+    on E: EGocciaCapabilityAuditDeliveryError do
+      raise;
     on E: Exception do
       Result := RejectedPromise(TGocciaStringLiteralValue.Create(E.Message));
   end;
@@ -882,8 +895,6 @@ var
   GocciaNamespace: TGocciaObjectValue;
 begin
   inherited Attach(ARuntime);
-  FPreviousRootClampCallback := FContext.Fs.RootClampCallback;
-  FContext.Fs.RootClampCallback := HandleRootClamp;
   FsNamespace := CreateFsNamespace;
   GocciaNamespace := CreateGocciaNamespace;
 
@@ -907,24 +918,57 @@ begin
   FFsModule.AddExportValue('copyFileSync',
     FsNamespace.GetProperty('copyFileSync'));
   FFsModule.AddExportValue('promises', FsNamespace.GetProperty('promises'));
+  if not Runtime.Engine.ModuleLoader.GlobalModules.TryGetValue(
+    'fs', FPreviousFsModule) then
+    FPreviousFsModule := nil;
   Runtime.Engine.ModuleLoader.GlobalModules.Add('fs', FFsModule);
+  FFsModuleRegistered := True;
 
   FGocciaModule := TGocciaModule.Create('goccia');
   FGocciaModule.AddExportValue(KEYWORD_DEFAULT, GocciaNamespace);
   FGocciaModule.AddExportValue('$', GocciaNamespace.GetProperty('$'));
   FGocciaModule.AddExportValue('runScript',
     GocciaNamespace.GetProperty('runScript'));
+  if not Runtime.Engine.ModuleLoader.GlobalModules.TryGetValue(
+    'goccia', FPreviousGocciaModule) then
+    FPreviousGocciaModule := nil;
   Runtime.Engine.ModuleLoader.GlobalModules.Add('goccia', FGocciaModule);
+  FGocciaModuleRegistered := True;
+
+  FPreviousRootClampCallback := FContext.Fs.RootClampCallback;
+  FContext.Fs.RootClampCallback := HandleRootClamp;
+  FRootClampInstalled := True;
 end;
 
 procedure TGocciaSandboxRuntimeExtension.Detach;
 begin
-  FContext.Fs.RootClampCallback := FPreviousRootClampCallback;
-  FPreviousRootClampCallback := nil;
+  if FRootClampInstalled then
+  begin
+    FContext.Fs.RootClampCallback := FPreviousRootClampCallback;
+    FPreviousRootClampCallback := nil;
+    FRootClampInstalled := False;
+  end;
   if Assigned(Runtime) and Assigned(Runtime.Engine) then
   begin
-    Runtime.Engine.ModuleLoader.GlobalModules.Remove('goccia');
-    Runtime.Engine.ModuleLoader.GlobalModules.Remove('fs');
+    if FGocciaModuleRegistered then
+    begin
+      if Assigned(FPreviousGocciaModule) then
+        Runtime.Engine.ModuleLoader.GlobalModules.Add(
+          'goccia', FPreviousGocciaModule)
+      else
+        Runtime.Engine.ModuleLoader.GlobalModules.Remove('goccia');
+      FPreviousGocciaModule := nil;
+      FGocciaModuleRegistered := False;
+    end;
+    if FFsModuleRegistered then
+    begin
+      if Assigned(FPreviousFsModule) then
+        Runtime.Engine.ModuleLoader.GlobalModules.Add('fs', FPreviousFsModule)
+      else
+        Runtime.Engine.ModuleLoader.GlobalModules.Remove('fs');
+      FPreviousFsModule := nil;
+      FFsModuleRegistered := False;
+    end;
   end;
   FGocciaModule.Free;
   FGocciaModule := nil;

--- a/source/units/Goccia.RuntimeExtensions.Sandbox.pas
+++ b/source/units/Goccia.RuntimeExtensions.Sandbox.pas
@@ -20,7 +20,10 @@ type
     FContext: TGocciaSandboxContext;
     FFsModule: TGocciaModule;
     FGocciaModule: TGocciaModule;
+    FPreviousRootClampCallback: TSandboxRootClampCallback;
 
+    procedure HandleRootClamp(const APath, ABase,
+      ACanonicalPath: string);
     function EnsureStatsPrototype: TGocciaObjectValue;
     function CreateStatsValue(const AStat: TSandboxFsStat): TGocciaValue;
     function CreateStatsDate(const AMilliseconds: Double): TGocciaValue;
@@ -100,6 +103,7 @@ uses
   base64,
   SandboxShell,
 
+  Goccia.CapabilityAudit,
   Goccia.JSON,
   Goccia.Keywords.Reserved,
   Goccia.Realm,
@@ -862,6 +866,15 @@ begin
   FContext := AContext;
 end;
 
+procedure TGocciaSandboxRuntimeExtension.HandleRootClamp(
+  const APath, ABase, ACanonicalPath: string);
+begin
+  if Assigned(Runtime) and Assigned(Runtime.Engine) then
+    Runtime.Engine.EmitCapabilityAudit(gckSandboxFileSystem, gcdDeny,
+      APath, Format('path from %s escaped the sandbox root and was clamped to %s',
+        [ABase, ACanonicalPath]));
+end;
+
 procedure TGocciaSandboxRuntimeExtension.Attach(
   const ARuntime: TGocciaRuntimeCore);
 var
@@ -869,6 +882,8 @@ var
   GocciaNamespace: TGocciaObjectValue;
 begin
   inherited Attach(ARuntime);
+  FPreviousRootClampCallback := FContext.Fs.RootClampCallback;
+  FContext.Fs.RootClampCallback := HandleRootClamp;
   FsNamespace := CreateFsNamespace;
   GocciaNamespace := CreateGocciaNamespace;
 
@@ -904,6 +919,8 @@ end;
 
 procedure TGocciaSandboxRuntimeExtension.Detach;
 begin
+  FContext.Fs.RootClampCallback := FPreviousRootClampCallback;
+  FPreviousRootClampCallback := nil;
   if Assigned(Runtime) and Assigned(Runtime.Engine) then
   begin
     Runtime.Engine.ModuleLoader.GlobalModules.Remove('goccia');

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -16023,7 +16023,10 @@ begin
           else
             for I := 0 to B - 1 do
               CallArgs.Add(GetRegister(A + 1 + I));
-          if GetRegister(A) is TGocciaNativeFunctionValue then
+          if (GetRegister(A) is TGocciaNativeFunctionValue) or
+             (GetRegister(A) is TGocciaFunctionConstructorClassValue) or
+             (GetRegister(A) is TGocciaBoundFunctionValue) or
+             (GetRegister(A) is TGocciaProxyValue) then
           begin
             EnterCurrentInstructionCallSite(PreviousCallSite);
             try

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -489,6 +489,7 @@ uses
   Goccia.AST.Node,
   Goccia.AST.Statements,
   Goccia.CallStack,
+  Goccia.CapabilityAudit,
   Goccia.Constants,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
@@ -3910,6 +3911,8 @@ begin
       raise;
     on E: TGocciaInstructionLimitError do
       raise;
+    on E: EGocciaCapabilityAuditDeliveryError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -3996,6 +3999,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: EGocciaCapabilityAuditDeliveryError do
       raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
@@ -4093,6 +4098,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: EGocciaCapabilityAuditDeliveryError do
       raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
@@ -5012,6 +5019,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: EGocciaCapabilityAuditDeliveryError do
       raise;
     on E: Exception do
       FPromise.Reject(CreateErrorObject(ERROR_NAME, E.Message));
@@ -16669,6 +16678,8 @@ begin
               raise;
             on E: TGocciaInstructionLimitError do
               raise;
+            on E: EGocciaCapabilityAuditDeliveryError do
+              raise;
             on E: Exception do
               DynImportPromise.Reject(
                 CreateErrorObject(ERROR_NAME, E.Message));
@@ -16740,6 +16751,8 @@ begin
             on E: TGocciaTimeoutError do
               raise;
             on E: TGocciaInstructionLimitError do
+              raise;
+            on E: EGocciaCapabilityAuditDeliveryError do
               raise;
             on E: Exception do
               DynImportPromise.Reject(
@@ -16863,6 +16876,8 @@ begin
             on E: TGocciaTimeoutError do
               raise;
             on E: TGocciaInstructionLimitError do
+              raise;
+            on E: EGocciaCapabilityAuditDeliveryError do
               raise;
             on E: Exception do
             begin

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -15758,7 +15758,10 @@ begin
           else
             for I := 0 to B - 1 do
               CallArgs.Add(GetRegister(A + 1 + I));
-          if GetRegister(A) is TGocciaNativeFunctionValue then
+          if (GetRegister(A) is TGocciaNativeFunctionValue) or
+             (GetRegister(A) is TGocciaFunctionConstructorClassValue) or
+             (GetRegister(A) is TGocciaBoundFunctionValue) or
+             (GetRegister(A) is TGocciaProxyValue) then
           begin
             EnterCurrentInstructionCallSite(PreviousCallSite);
             try
@@ -16055,7 +16058,12 @@ begin
           try
             for I := 0 to C - 1 do
               CallArgs.Add(GetRegister(B + 1 + I));
-            SetRegister(A, ConstructValue(GetRegister(B), CallArgs));
+            EnterCurrentInstructionCallSite(PreviousCallSite);
+            try
+              SetRegister(A, ConstructValue(GetRegister(B), CallArgs));
+            finally
+              LeaveGocciaCallSite(PreviousCallSite);
+            end;
           finally
             ReleaseArguments(CallArgs);
           end;
@@ -16081,7 +16089,12 @@ begin
           try
             for I := 0 to SpreadArray.Elements.Count - 1 do
               CallArgs.Add(SpreadArray.GetProperty(IntToStr(I)));
-            SetRegister(A, ConstructValue(GetRegister(B), CallArgs));
+            EnterCurrentInstructionCallSite(PreviousCallSite);
+            try
+              SetRegister(A, ConstructValue(GetRegister(B), CallArgs));
+            finally
+              LeaveGocciaCallSite(PreviousCallSite);
+            end;
           finally
             ReleaseArguments(CallArgs);
           end;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -12,6 +12,7 @@ uses
   Goccia.Arguments.Collection,
   Goccia.AST.Expressions,
   Goccia.AST.Node,
+  Goccia.CapabilityAudit,
   Goccia.Constants,
   Goccia.Realm,
   Goccia.Values.FunctionBase,
@@ -315,6 +316,7 @@ type
   TGocciaFunctionConstructorClassValue = class(TGocciaClassValue)
   private
     FEnabled: Boolean;
+    FCapabilityAuditEmitter: TGocciaCapabilityAuditEmitter;
     FCompileDynamicFunction: TGocciaCompileDynamicFunction;
     FDynamicKind: TGocciaDynamicFunctionKind;
     function BuildFunction(const AArguments: TGocciaArgumentsCollection): TGocciaFunctionBase;
@@ -327,6 +329,8 @@ type
     function GetClassLength: Integer; override;
 
     property Enabled: Boolean read FEnabled write FEnabled;
+    property CapabilityAuditEmitter: TGocciaCapabilityAuditEmitter
+      read FCapabilityAuditEmitter write FCapabilityAuditEmitter;
     property CompileDynamicFunction: TGocciaCompileDynamicFunction
       read FCompileDynamicFunction write FCompileDynamicFunction;
     property DynamicKind: TGocciaDynamicFunctionKind read FDynamicKind;
@@ -2539,6 +2543,7 @@ constructor TGocciaFunctionConstructorClassValue.Create(const AName: string;
 begin
   inherited Create(AName, ASuperClass);
   FEnabled := False;
+  FCapabilityAuditEmitter := nil;
   FCompileDynamicFunction := nil;
   FDynamicKind := ADynamicKind;
 end;
@@ -2554,8 +2559,17 @@ var
   PreviousRealm: TGocciaRealm;
 begin
   if not FEnabled then
+  begin
+    if Assigned(FCapabilityAuditEmitter) then
+      FCapabilityAuditEmitter(gckFunctionConstructor, gcdDeny, Name,
+        'dynamic code generation is disabled');
     ThrowTypeError('Dynamic code generation is disabled. ' +
       'Pass --unsafe-function-constructor to enable the Function constructor');
+  end;
+
+  if Assigned(FCapabilityAuditEmitter) then
+    FCapabilityAuditEmitter(gckFunctionConstructor, gcdAllow, Name,
+      'dynamic code generation is enabled');
 
   if not Assigned(FCompileDynamicFunction) then
     ThrowTypeError('Function constructor is not available in this environment');


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add an engine-owned, versioned capability-audit sink with source locations and a fail-closed `--audit-log` JSONL output for CLI hosts.
- Instrument fetch authorization and dispatch, `FFI.open`, dynamic Function construction, ShadowRealm construction (including child realms), and sandbox filesystem root-clamp attempts in both interpreter and bytecode execution.
- Keep audit delivery failures host-fatal across JavaScript `try`/`catch`, promises, VM adapters, microtasks, and sandbox result wrappers while guaranteeing sandbox lifecycle cleanup.
- Record only the authorized hostname in `fetch.host` events, excluding URL credentials, paths, and query parameters.
- Reject equivalent `--log` and `--audit-log` paths before opening either file, cover bytecode method-call source locations, and make runtime extension installation and sandbox module attachment transactional.
- Preserve the agreed boundaries: disabled FFI and ShadowRealm globals remain absent, sandbox escapes still clamp to the in-jail path, and audit sink or file failures abort execution.
- Closes #882.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - `./build/GocciaTestRunner tests --no-progress` (11,497 passed)
  - `./build/GocciaTestRunner tests --mode=bytecode --no-progress` (11,497 passed)
  - `bun run scripts/test-cli-apps.ts`
  - `bun run scripts/check-test-structure.ts`
- [x] Updated documentation
  - `./format.pas --check` (409 files)
  - documentation links, symbols, duplication, length, and markdown lint checks passed
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - `./build/Goccia.CapabilityAudit.Test` (7 passed)
  - `./build/Goccia.Runtime.Test` (9 passed)
  - clean builds passed for the sandbox runner, loader, test runner, bare loader, REPL, bundler, and benchmark runner
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change