### PR TITLE
fix(format): keep inline directives on declarations

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -38,6 +38,12 @@ Which sets:
 
 Overflow and range checks are **enabled** — correctness is prioritized over raw performance.
 
+Keep compiler-conditional routine directives on the declaration's final line:
+
+```pascal
+function NormalizeValue(const AValue: Double): Double; {$IFDEF FPC}inline;{$ENDIF}
+```
+
 ### Naming Conventions
 
 | Element | Convention | Example |

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -38,7 +38,8 @@ Which sets:
 
 Overflow and range checks are **enabled** — correctness is prioritized over raw performance.
 
-Keep compiler-conditional routine directives on the declaration's final line:
+Keep the entire compiler-conditional routine directive sequence on the
+declaration's final line:
 
 ```pascal
 function NormalizeValue(const AValue: Double): Double; {$IFDEF FPC}inline;{$ENDIF}

--- a/format.pas
+++ b/format.pas
@@ -931,24 +931,159 @@ end;
   Auto-Fix: Inline Compiler Directive Placement
   ═══════════════════════════════════════════════════════════════════════════ }
 
-function FixInlineDirectivePlacement(const ALines: TStringList): Boolean;
 const
-  InlineDirective = '{$IFDEF FPC}inline;{$ENDIF}';
+  CanonicalInlineDirective = '{$IFDEF FPC}inline;{$ENDIF}';
+  CompactInlineDirective = '{$IFDEFFPC}INLINE;{$ENDIF}';
+
+function CompactDirectiveText(const AText: string): string;
 var
-  I: Integer;
+  I, OutputIndex: Integer;
+begin
+  SetLength(Result, Length(AText));
+  OutputIndex := 0;
+  for I := 1 to Length(AText) do
+    if AText[I] > ' ' then
+    begin
+      Inc(OutputIndex);
+      Result[OutputIndex] := UpCase(AText[I]);
+    end;
+  SetLength(Result, OutputIndex);
+end;
+
+function IsInlineDirectivePrefix(const AText: string): Boolean;
+begin
+  Result := (Length(AText) <= Length(CompactInlineDirective)) and
+    SameText(AText, Copy(CompactInlineDirective, 1, Length(AText)));
+end;
+
+function TryFindInlineDirectiveSequence(const ALines: TStringList;
+  const AStartLine: Integer; out AStartColumn, AEndLine: Integer): Boolean;
+var
+  Column: Integer;
+  Candidate: string;
 begin
   Result := False;
-  I := 1;
+  for Column := 1 to Length(ALines[AStartLine]) do
+  begin
+    if ALines[AStartLine][Column] <> '{' then
+      Continue;
+
+    Candidate := CompactDirectiveText(Copy(ALines[AStartLine], Column,
+      Length(ALines[AStartLine])));
+    if not IsInlineDirectivePrefix(Candidate) then
+      Continue;
+
+    AEndLine := AStartLine;
+    while not SameText(Candidate, CompactInlineDirective) and
+      (AEndLine + 1 < ALines.Count) do
+    begin
+      Inc(AEndLine);
+      Candidate := Candidate + CompactDirectiveText(ALines[AEndLine]);
+      if not IsInlineDirectivePrefix(Candidate) then
+        Break;
+    end;
+
+    if SameText(Candidate, CompactInlineDirective) then
+    begin
+      AStartColumn := Column;
+      Exit(True);
+    end;
+  end;
+end;
+
+function FindRoutineDeclarationEnd(const ALines: TStringList;
+  const AStartLine: Integer): Integer;
+var
+  LineIndex, CharacterIndex, ParenthesisDepth: Integer;
+  StrippedLine: string;
+  InBlock: Boolean;
+begin
+  Result := -1;
+  ParenthesisDepth := 0;
+  InBlock := False;
+  for LineIndex := AStartLine to ALines.Count - 1 do
+  begin
+    StrippedLine := StripCodeLine(ALines[LineIndex], InBlock);
+    for CharacterIndex := 1 to Length(StrippedLine) do
+    begin
+      case StrippedLine[CharacterIndex] of
+        '(': Inc(ParenthesisDepth);
+        ')': Dec(ParenthesisDepth);
+        ';':
+          if ParenthesisDepth = 0 then
+            Exit(LineIndex);
+      end;
+    end;
+  end;
+end;
+
+function IsRoutineDeclarationEnd(const ALines: TStringList;
+  const ALine: Integer): Boolean;
+var
+  StartLine: Integer;
+begin
+  Result := False;
+  for StartLine := ALine downto 0 do
+    if IsFuncDeclStart(ALines[StartLine]) then
+    begin
+      Result := FindRoutineDeclarationEnd(ALines, StartLine) = ALine;
+      Exit;
+    end;
+end;
+
+function FixInlineDirectivePlacement(const ALines: TStringList): Boolean;
+var
+  I, StartColumn, EndLine, DeleteLine, DeclarationLine: Integer;
+  Prefix, FormattedLine: string;
+begin
+  Result := False;
+  I := 0;
   while I < ALines.Count do
   begin
-    if Trim(ALines[I]) = InlineDirective then
+    if not TryFindInlineDirectiveSequence(ALines, I, StartColumn, EndLine) then
     begin
-      ALines[I - 1] := TrimRight(ALines[I - 1]) + ' ' + InlineDirective;
-      ALines.Delete(I);
+      Inc(I);
+      Continue;
+    end;
+
+    Prefix := TrimRight(Copy(ALines[I], 1, StartColumn - 1));
+    if Prefix = '' then
+    begin
+      DeclarationLine := I - 1;
+      while (DeclarationLine >= 0) and
+        (Trim(ALines[DeclarationLine]) = '') do
+        Dec(DeclarationLine);
+      if (DeclarationLine < 0) or
+        not IsRoutineDeclarationEnd(ALines, DeclarationLine) then
+      begin
+        Inc(I);
+        Continue;
+      end;
+
+      ALines[DeclarationLine] := TrimRight(ALines[DeclarationLine]) + ' ' +
+        CanonicalInlineDirective;
+      for DeleteLine := EndLine downto DeclarationLine + 1 do
+        ALines.Delete(DeleteLine);
       Result := True;
+      I := DeclarationLine + 1;
     end
     else
+    begin
+      if not IsRoutineDeclarationEnd(ALines, I) then
+      begin
+        Inc(I);
+        Continue;
+      end;
+
+      FormattedLine := Prefix + ' ' + CanonicalInlineDirective;
+      if (ALines[I] <> FormattedLine) or (EndLine <> I) then
+        Result := True;
+      ALines[I] := FormattedLine;
+      if EndLine > I then
+        for DeleteLine := EndLine downto I + 1 do
+          ALines.Delete(DeleteLine);
       Inc(I);
+    end;
   end;
 end;
 

--- a/format.pas
+++ b/format.pas
@@ -935,19 +935,42 @@ const
   CanonicalInlineDirective = '{$IFDEF FPC}inline;{$ENDIF}';
   CompactInlineDirective = '{$IFDEFFPC}INLINE;{$ENDIF}';
 
-function CompactDirectiveText(const AText: string): string;
+function IsAfterLineComment(const ALine: string;
+  const AColumn: Integer): Boolean;
 var
-  I, OutputIndex: Integer;
+  I: Integer;
+  InString, InBlockComment: Boolean;
 begin
-  SetLength(Result, Length(AText));
-  OutputIndex := 0;
-  for I := 1 to Length(AText) do
-    if AText[I] > ' ' then
+  Result := False;
+  I := 1;
+  InString := False;
+  InBlockComment := False;
+  while (I < AColumn) and (I <= Length(ALine)) do
+  begin
+    if InString then
     begin
-      Inc(OutputIndex);
-      Result[OutputIndex] := UpCase(AText[I]);
-    end;
-  SetLength(Result, OutputIndex);
+      if ALine[I] = '''' then
+      begin
+        if (I < Length(ALine)) and (ALine[I + 1] = '''') then
+          Inc(I)
+        else
+          InString := False;
+      end;
+    end
+    else if InBlockComment then
+    begin
+      if ALine[I] = '}' then
+        InBlockComment := False;
+    end
+    else if ALine[I] = '''' then
+      InString := True
+    else if ALine[I] = '{' then
+      InBlockComment := True
+    else if (ALine[I] = '/') and (I < Length(ALine)) and
+      (ALine[I + 1] = '/') then
+      Exit(True);
+    Inc(I);
+  end;
 end;
 
 function IsInlineDirectivePrefix(const AText: string): Boolean;
@@ -957,9 +980,10 @@ begin
 end;
 
 function TryFindInlineDirectiveSequence(const ALines: TStringList;
-  const AStartLine: Integer; out AStartColumn, AEndLine: Integer): Boolean;
+  const AStartLine: Integer; out AStartColumn, AEndLine,
+  AEndColumn: Integer): Boolean;
 var
-  Column: Integer;
+  Column, LineIndex, CharacterIndex: Integer;
   Candidate: string;
 begin
   Result := False;
@@ -967,26 +991,36 @@ begin
   begin
     if ALines[AStartLine][Column] <> '{' then
       Continue;
-
-    Candidate := CompactDirectiveText(Copy(ALines[AStartLine], Column,
-      Length(ALines[AStartLine])));
-    if not IsInlineDirectivePrefix(Candidate) then
+    if IsAfterLineComment(ALines[AStartLine], Column) then
       Continue;
 
-    AEndLine := AStartLine;
-    while not SameText(Candidate, CompactInlineDirective) and
-      (AEndLine + 1 < ALines.Count) do
+    Candidate := '';
+    LineIndex := AStartLine;
+    CharacterIndex := Column;
+    while LineIndex < ALines.Count do
     begin
-      Inc(AEndLine);
-      Candidate := Candidate + CompactDirectiveText(ALines[AEndLine]);
+      while CharacterIndex <= Length(ALines[LineIndex]) do
+      begin
+        if ALines[LineIndex][CharacterIndex] > ' ' then
+        begin
+          Candidate := Candidate +
+            UpCase(ALines[LineIndex][CharacterIndex]);
+          if not IsInlineDirectivePrefix(Candidate) then
+            Break;
+          if SameText(Candidate, CompactInlineDirective) then
+          begin
+            AStartColumn := Column;
+            AEndLine := LineIndex;
+            AEndColumn := CharacterIndex;
+            Exit(True);
+          end;
+        end;
+        Inc(CharacterIndex);
+      end;
       if not IsInlineDirectivePrefix(Candidate) then
         Break;
-    end;
-
-    if SameText(Candidate, CompactInlineDirective) then
-    begin
-      AStartColumn := Column;
-      Exit(True);
+      Inc(LineIndex);
+      CharacterIndex := 1;
     end;
   end;
 end;
@@ -1033,20 +1067,23 @@ end;
 
 function FixInlineDirectivePlacement(const ALines: TStringList): Boolean;
 var
-  I, StartColumn, EndLine, DeleteLine, DeclarationLine: Integer;
-  Prefix, FormattedLine: string;
+  I, StartColumn, EndLine, EndColumn, DeleteLine, DeclarationLine: Integer;
+  Prefix, Suffix, FormattedLine: string;
 begin
   Result := False;
   I := 0;
   while I < ALines.Count do
   begin
-    if not TryFindInlineDirectiveSequence(ALines, I, StartColumn, EndLine) then
+    if not TryFindInlineDirectiveSequence(ALines, I, StartColumn, EndLine,
+      EndColumn) then
     begin
       Inc(I);
       Continue;
     end;
 
     Prefix := TrimRight(Copy(ALines[I], 1, StartColumn - 1));
+    Suffix := TrimRight(Copy(ALines[EndLine], EndColumn + 1,
+      Length(ALines[EndLine])));
     if Prefix = '' then
     begin
       DeclarationLine := I - 1;
@@ -1061,7 +1098,7 @@ begin
       end;
 
       ALines[DeclarationLine] := TrimRight(ALines[DeclarationLine]) + ' ' +
-        CanonicalInlineDirective;
+        CanonicalInlineDirective + Suffix;
       for DeleteLine := EndLine downto DeclarationLine + 1 do
         ALines.Delete(DeleteLine);
       Result := True;
@@ -1075,7 +1112,7 @@ begin
         Continue;
       end;
 
-      FormattedLine := Prefix + ' ' + CanonicalInlineDirective;
+      FormattedLine := Prefix + ' ' + CanonicalInlineDirective + Suffix;
       if (ALines[I] <> FormattedLine) or (EndLine <> I) then
         Result := True;
       ALines[I] := FormattedLine;

--- a/format.pas
+++ b/format.pas
@@ -928,6 +928,31 @@ begin
 end;
 
 { ═══════════════════════════════════════════════════════════════════════════
+  Auto-Fix: Inline Compiler Directive Placement
+  ═══════════════════════════════════════════════════════════════════════════ }
+
+function FixInlineDirectivePlacement(const ALines: TStringList): Boolean;
+const
+  InlineDirective = '{$IFDEF FPC}inline;{$ENDIF}';
+var
+  I: Integer;
+begin
+  Result := False;
+  I := 1;
+  while I < ALines.Count do
+  begin
+    if Trim(ALines[I]) = InlineDirective then
+    begin
+      ALines[I - 1] := TrimRight(ALines[I - 1]) + ' ' + InlineDirective;
+      ALines.Delete(I);
+      Result := True;
+    end
+    else
+      Inc(I);
+  end;
+end;
+
+{ ═══════════════════════════════════════════════════════════════════════════
   File Processing
   ═══════════════════════════════════════════════════════════════════════════ }
 
@@ -944,6 +969,7 @@ begin
     FormatUsesInLines(Lines, ResultLines);
     FixFuncNames(ResultLines);
     FixParamNames(ResultLines);
+    FixInlineDirectivePlacement(ResultLines);
     FixStraySpaces(ResultLines);
 
     if ResultLines.Text <> Lines.Text then

--- a/source/shared/BOM.pas
+++ b/source/shared/BOM.pas
@@ -16,14 +16,11 @@ const
   UTF8_BOM_BYTE_2 = $BB;
   UTF8_BOM_BYTE_3 = $BF;
 
-function HasByteOrderMark(const AText: string): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function HasByteOrderMark(const AText: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 function HasUTF8BOMBytes(const ABytes: TBytes;
-  const AStart, AEnd: Integer): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AStart, AEnd: Integer): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 function SkipByteOrderMark(const AText: string;
-  const AStart: Integer): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AStart: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/shared/BaseMap.pas
+++ b/source/shared/BaseMap.pas
@@ -46,11 +46,9 @@ type
       FMap: TBaseMap<TKey, TValue>;
       FIterState: Integer;
       FCurrent: TKeyValuePair;
-      function GetCurrent: TKeyValuePair;
-      {$IFDEF FPC}inline;{$ENDIF}
+      function GetCurrent: TKeyValuePair; {$IFDEF FPC}inline;{$ENDIF}
     public
-      function MoveNext: Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      function MoveNext: Boolean; {$IFDEF FPC}inline;{$ENDIF}
       property Current: TKeyValuePair read GetCurrent;
     end;
 
@@ -73,8 +71,7 @@ type
     function Remove(const AKey: TKey): Boolean; virtual; abstract;
     procedure Clear; virtual; abstract;
 
-    function GetEnumerator: TEnumerator;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetEnumerator: TEnumerator; {$IFDEF FPC}inline;{$ENDIF}
     function ToArray: TKeyValueArray;
     procedure ForEach(ACallback: TForEachCallback);
     function Keys: TKeyArray;

--- a/source/shared/BigInteger.pas
+++ b/source/shared/BigInteger.pas
@@ -19,8 +19,7 @@ type
     class procedure DivModMagnitudes(const AA, AB: TLimbArray;
       out AQuotient, ARemainder: TLimbArray); static;
   public
-    class function Zero: TBigInteger; static;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function Zero: TBigInteger; static; {$IFDEF FPC}inline;{$ENDIF}
     class function One: TBigInteger; static;
     class function NegativeOne: TBigInteger; static;
     class function FromInt64(const AValue: Int64): TBigInteger; static;
@@ -30,12 +29,9 @@ type
     class function FromBinaryString(const AValue: string): TBigInteger; static;
     class function FromOctalString(const AValue: string): TBigInteger; static;
 
-    function IsZero: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function IsNegative: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function IsPositive: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsZero: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function IsNegative: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function IsPositive: Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function IsOne: Boolean;
     function IsMinusOne: Boolean;
     function BitLength: Integer;

--- a/source/shared/CriticalSections.pas
+++ b/source/shared/CriticalSections.pas
@@ -20,24 +20,15 @@ type
   end;
   {$ENDIF}
 
-procedure CriticalSectionInit(var ASection: TGocciaCriticalSection);
-{$IFDEF FPC}inline;{$ENDIF}
-procedure CriticalSectionDone(var ASection: TGocciaCriticalSection);
-{$IFDEF FPC}inline;{$ENDIF}
-procedure CriticalSectionEnter(var ASection: TGocciaCriticalSection);
-{$IFDEF FPC}inline;{$ENDIF}
-procedure CriticalSectionLeave(var ASection: TGocciaCriticalSection);
-{$IFDEF FPC}inline;{$ENDIF}
-function GetGocciaThreadId: TThreadID;
-{$IFDEF FPC}inline;{$ENDIF}
-function AtomicIncrementInt32(var AValue: Integer): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
-function AtomicDecrementInt32(var AValue: Integer): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
-procedure ReadMemoryBarrier;
-{$IFDEF FPC}inline;{$ENDIF}
-procedure WriteMemoryBarrier;
-{$IFDEF FPC}inline;{$ENDIF}
+procedure CriticalSectionInit(var ASection: TGocciaCriticalSection); {$IFDEF FPC}inline;{$ENDIF}
+procedure CriticalSectionDone(var ASection: TGocciaCriticalSection); {$IFDEF FPC}inline;{$ENDIF}
+procedure CriticalSectionEnter(var ASection: TGocciaCriticalSection); {$IFDEF FPC}inline;{$ENDIF}
+procedure CriticalSectionLeave(var ASection: TGocciaCriticalSection); {$IFDEF FPC}inline;{$ENDIF}
+function GetGocciaThreadId: TThreadID; {$IFDEF FPC}inline;{$ENDIF}
+function AtomicIncrementInt32(var AValue: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
+function AtomicDecrementInt32(var AValue: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
+procedure ReadMemoryBarrier; {$IFDEF FPC}inline;{$ENDIF}
+procedure WriteMemoryBarrier; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/shared/EmbeddedResourceReader.pas
+++ b/source/shared/EmbeddedResourceReader.pas
@@ -32,8 +32,7 @@ type
     DataLength: Integer;
   end;
 
-function RCDATAResourceType: TEmbeddedResourceType;
-{$IFDEF FPC}inline;{$ENDIF}
+function RCDATAResourceType: TEmbeddedResourceType; {$IFDEF FPC}inline;{$ENDIF}
 function HasBytesAvailable(const ABuffer: TBytes; const AOffset, ALength: Integer): Boolean;
 function TryUInt32ToInteger(const AValue: UInt32; out AInteger: Integer): Boolean;
 function ReadUInt32LE(const ABuffer: TBytes; const AOffset: Integer): UInt32;

--- a/source/shared/HTTPClient.pas
+++ b/source/shared/HTTPClient.pas
@@ -281,8 +281,7 @@ end;
 // ---------------------------------------------------------------------------
 
 function SocketSend(const ASock: TSocket; const ABuf: Pointer;
-  const ALen: Integer): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ALen: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   {$IFDEF UNIX}
   Result := fpSend(ASock, ABuf, ALen, 0);
@@ -293,8 +292,7 @@ begin
 end;
 
 function SocketRecv(const ASock: TSocket; const ABuf: Pointer;
-  const ALen: Integer): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ALen: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   {$IFDEF UNIX}
   Result := fpRecv(ASock, ABuf, ALen, 0);
@@ -304,8 +302,7 @@ begin
   {$ENDIF}
 end;
 
-procedure SocketClose(const ASock: TSocket);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure SocketClose(const ASock: TSocket); {$IFDEF FPC}inline;{$ENDIF}
 begin
   {$IFDEF UNIX}
   CloseSocket(ASock);

--- a/source/shared/HashMap.pas
+++ b/source/shared/HashMap.pas
@@ -37,11 +37,9 @@ type
       FCapacity: Integer;
       FIndex: Integer;
       FCurrent: TBaseMap<TKey, TValue>.TKeyValuePair;
-      function GetCurrent: TBaseMap<TKey, TValue>.TKeyValuePair;
-      {$IFDEF FPC}inline;{$ENDIF}
+      function GetCurrent: TBaseMap<TKey, TValue>.TKeyValuePair; {$IFDEF FPC}inline;{$ENDIF}
     public
-      function MoveNext: Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      function MoveNext: Boolean; {$IFDEF FPC}inline;{$ENDIF}
       property Current: TBaseMap<TKey, TValue>.TKeyValuePair read GetCurrent;
     end;
 
@@ -54,13 +52,10 @@ type
     FCount: Integer;
     FCapacity: Integer;
 
-    class function HashKey(const AKey: TKey): Cardinal; static;
-    {$IFDEF FPC}inline;{$ENDIF}
-    class function KeysEqual(const A, B: TKey): Boolean; static;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function HashKey(const AKey: TKey): Cardinal; static; {$IFDEF FPC}inline;{$ENDIF}
+    class function KeysEqual(const A, B: TKey): Boolean; static; {$IFDEF FPC}inline;{$ENDIF}
 
-    function FindSlot(const AKey: TKey; AHash: Cardinal): Integer;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function FindSlot(const AKey: TKey; AHash: Cardinal): Integer; {$IFDEF FPC}inline;{$ENDIF}
     procedure Grow;
     procedure Reinsert(const ASlot: TSlot);
 
@@ -82,8 +77,7 @@ type
     function Remove(const AKey: TKey): Boolean; override;
     procedure Clear; override;
 
-    function GetEnumerator: TEnumerator;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetEnumerator: TEnumerator; {$IFDEF FPC}inline;{$ENDIF}
 
     property Capacity: Integer read FCapacity;
   end;

--- a/source/shared/IntlICU.pas
+++ b/source/shared/IntlICU.pas
@@ -873,8 +873,7 @@ begin
   Result := True;
 end;
 
-function BytePointer(const ABytes: TBytes): PAnsiChar;
-{$IFDEF FPC}inline;{$ENDIF}
+function BytePointer(const ABytes: TBytes): PAnsiChar; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Length(ABytes) = 0 then
     Result := nil
@@ -2211,8 +2210,7 @@ begin
     Result := ScaledInt / Scale;
 end;
 
-function CanonicalizeICUNumberFormatInput(AValue: Double): Double;
-{$IFDEF FPC}inline;{$ENDIF}
+function CanonicalizeICUNumberFormatInput(AValue: Double): Double; {$IFDEF FPC}inline;{$ENDIF}
 var
   Bits: UInt64;
 begin

--- a/source/shared/JSONParser.pas
+++ b/source/shared/JSONParser.pas
@@ -73,8 +73,7 @@ type
     function ParseObjectKey: string;
     function PeekCodePointSequence: string;
     function ReadCodePointSequence: string;
-    function Supports(const ACapability: TJSONParserCapability): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function Supports(const ACapability: TJSONParserCapability): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function TryMatchAdditionalWhitespace(out AByteLength: Integer): Boolean;
     function TryMatchLineTerminator(out AByteLength: Integer): Boolean;
     function TryParseAdditionalLiteral(const AIsNegative: Boolean): Boolean;
@@ -83,13 +82,10 @@ type
 
     procedure SkipWhitespace;
 
-    function PeekChar: Char;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function ReadChar: Char;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function PeekChar: Char; {$IFDEF FPC}inline;{$ENDIF}
+    function ReadChar: Char; {$IFDEF FPC}inline;{$ENDIF}
     function ExpectChar(const AExpected: Char): Boolean;
-    function IsAtEnd: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsAtEnd: Boolean; {$IFDEF FPC}inline;{$ENDIF}
     procedure RaiseParseError(const AMessage: string);
   protected
     function ParseString(const AQuote: Char): string; overload;

--- a/source/shared/NumberBits.pas
+++ b/source/shared/NumberBits.pas
@@ -9,16 +9,11 @@ const
   CANONICAL_FLOAT32_NAN_BITS: UInt32 = $7FC00000;
   CANONICAL_FLOAT64_NAN_BITS: UInt64 = $7FF8000000000000;
 
-function DoubleToBits(const AValue: Double): UInt64;
-{$IFDEF FPC}inline;{$ENDIF}
-function BitsToDouble(const ABits: UInt64): Double;
-{$IFDEF FPC}inline;{$ENDIF}
-function SingleToBits(const AValue: Single): UInt32;
-{$IFDEF FPC}inline;{$ENDIF}
-function BitsToSingle(const ABits: UInt32): Single;
-{$IFDEF FPC}inline;{$ENDIF}
-function IsNegativeZero(const AValue: Double): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function DoubleToBits(const AValue: Double): UInt64; {$IFDEF FPC}inline;{$ENDIF}
+function BitsToDouble(const ABits: UInt64): Double; {$IFDEF FPC}inline;{$ENDIF}
+function SingleToBits(const AValue: Single): UInt32; {$IFDEF FPC}inline;{$ENDIF}
+function BitsToSingle(const ABits: UInt32): Single; {$IFDEF FPC}inline;{$ENDIF}
+function IsNegativeZero(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/shared/NumericText.pas
+++ b/source/shared/NumericText.pas
@@ -200,20 +200,17 @@ begin
   Result := 1;
 end;
 
-function RyuPowerOfFiveBits(const AExponent: Integer): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function RyuPowerOfFiveBits(const AExponent: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (UInt32(AExponent) * UInt32(1217359) shr 19) + 1;
 end;
 
-function RyuLog10PowerOfTwo(const AExponent: Integer): UInt32;
-{$IFDEF FPC}inline;{$ENDIF}
+function RyuLog10PowerOfTwo(const AExponent: Integer): UInt32; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := UInt32(AExponent) * UInt32(78913) shr 18;
 end;
 
-function RyuLog10PowerOfFive(const AExponent: Integer): UInt32;
-{$IFDEF FPC}inline;{$ENDIF}
+function RyuLog10PowerOfFive(const AExponent: Integer): UInt32; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := UInt32(AExponent) * UInt32(732923) shr 20;
 end;
@@ -253,8 +250,7 @@ begin
 end;
 
 function RyuShiftRight128(const ALow, AHigh: UInt64;
-  const ADistance: Integer): UInt64;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ADistance: Integer): UInt64; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AHigh shl (64 - ADistance) or ALow shr ADistance;
 end;
@@ -366,15 +362,13 @@ begin
 end;
 
 function RyuIsMultipleOfPowerOfFive(const AValue: UInt64;
-  const APower: UInt32): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const APower: UInt32): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := RyuPowerOfFiveFactor(AValue) >= APower;
 end;
 
 function RyuIsMultipleOfPowerOfTwo(const AValue: UInt64;
-  const APower: UInt32): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const APower: UInt32): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AValue and ((UInt64(1) shl APower) - 1)) = 0;
 end;
@@ -671,8 +665,7 @@ begin
     Decimal.Exponent, Negative, Result);
 end;
 
-function SignedZero(const ANegative: Boolean): Double;
-{$IFDEF FPC}inline;{$ENDIF}
+function SignedZero(const ANegative: Boolean): Double; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if ANegative then
     Result := BitsToDouble(UInt64(1) shl 63)
@@ -680,8 +673,7 @@ begin
     Result := 0.0;
 end;
 
-function SignedInfinity(const ANegative: Boolean): Double;
-{$IFDEF FPC}inline;{$ENDIF}
+function SignedInfinity(const ANegative: Boolean): Double; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if ANegative then
     Result := BitsToDouble(UInt64($FFF0000000000000))
@@ -793,8 +785,7 @@ begin
   Result := True;
 end;
 
-function PowerOfFive(const AExponent: Integer): TBigInteger;
-{$IFDEF FPC}inline;{$ENDIF}
+function PowerOfFive(const AExponent: Integer): TBigInteger; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := TBigInteger.FromInt64(5).Power(
     TBigInteger.FromInt64(AExponent));

--- a/source/shared/OrderedMap.pas
+++ b/source/shared/OrderedMap.pas
@@ -44,11 +44,9 @@ type
       FEntryCount: Integer;
       FIndex: Integer;
       FCurrent: TBaseMap<TKey, TValue>.TKeyValuePair;
-      function GetCurrent: TBaseMap<TKey, TValue>.TKeyValuePair;
-      {$IFDEF FPC}inline;{$ENDIF}
+      function GetCurrent: TBaseMap<TKey, TValue>.TKeyValuePair; {$IFDEF FPC}inline;{$ENDIF}
     public
-      function MoveNext: Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      function MoveNext: Boolean; {$IFDEF FPC}inline;{$ENDIF}
       property Current: TBaseMap<TKey, TValue>.TKeyValuePair read GetCurrent;
     end;
 
@@ -98,8 +96,7 @@ type
     function Remove(const AKey: TKey): Boolean; override;
     procedure Clear; override;
 
-    function GetEnumerator: TEnumerator;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetEnumerator: TEnumerator; {$IFDEF FPC}inline;{$ENDIF}
     // Random-access lookup by active-entry position: O(AIndex), since it scans
     // active entries from the start. For sequential iteration use the enumerator
     // (`for Pair in Map do`); driving EntryAt from a `for I := 0 to Count - 1`

--- a/source/shared/OrderedStringMap.pas
+++ b/source/shared/OrderedStringMap.pas
@@ -39,11 +39,9 @@ type
       FEntryCount: Integer;
       FIndex: Integer;
       FCurrent: TBaseMap<string, TValue>.TKeyValuePair;
-      function GetCurrent: TBaseMap<string, TValue>.TKeyValuePair;
-      {$IFDEF FPC}inline;{$ENDIF}
+      function GetCurrent: TBaseMap<string, TValue>.TKeyValuePair; {$IFDEF FPC}inline;{$ENDIF}
     public
-      function MoveNext: Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      function MoveNext: Boolean; {$IFDEF FPC}inline;{$ENDIF}
       property Current: TBaseMap<string, TValue>.TKeyValuePair read GetCurrent;
     end;
 
@@ -71,16 +69,12 @@ type
     // still receive unique stamps; a stamp recorded against one map instance
     // can therefore never validate against a different instance that happens
     // to reuse the same address.
-    class function NextEntryVersion: Cardinal; static;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function NextEntryVersion: Cardinal; static; {$IFDEF FPC}inline;{$ENDIF}
 
-    class function HashKey(const AKey: string): Cardinal; static;
-    {$IFDEF FPC}inline;{$ENDIF}
-    class function KeysEqual(const A, B: string): Boolean; static;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function HashKey(const AKey: string): Cardinal; static; {$IFDEF FPC}inline;{$ENDIF}
+    class function KeysEqual(const A, B: string): Boolean; static; {$IFDEF FPC}inline;{$ENDIF}
 
-    function DeletedSlotsNeedCompaction: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function DeletedSlotsNeedCompaction: Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function FindBucket(const AKey: string; AHash: Cardinal;
       out ABucketIdx: Integer): Boolean;
     procedure Grow;
@@ -105,8 +99,7 @@ type
     function Remove(const AKey: string): Boolean; override;
     procedure Clear; override;
 
-    function GetEnumerator: TEnumerator;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetEnumerator: TEnumerator; {$IFDEF FPC}inline;{$ENDIF}
     // Random-access lookup by active-entry position: O(AIndex), since it scans
     // active entries from the start. For sequential iteration use the enumerator
     // (`for Pair in Map do`); driving EntryAt from a `for I := 0 to Count - 1`
@@ -115,15 +108,13 @@ type
 
     // Non-virtual live-entry count for hot validation paths (the Count
     // property dispatches through TBaseMap's virtual GetCount).
-    function CountFast: Integer;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function CountFast: Integer; {$IFDEF FPC}inline;{$ENDIF}
     // Entry-index access for version-validated inline caches: look up an
     // entry index once, then re-read its value directly while EntryVersion
     // is unchanged.
     function TryGetEntryIndex(const AKey: string; out AIndex: Integer): Boolean;
     function TryGetValueAtEntry(const AIndex: Integer;
-      out AValue: TValue): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      out AValue: TValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function KeyAtEntry(const AIndex: Integer): string;
 
     property Capacity: Integer read FBucketCount;

--- a/source/shared/StringBuffer.pas
+++ b/source/shared/StringBuffer.pas
@@ -13,19 +13,13 @@ type
     FData: UnicodeString;
     FLen: Integer;
     FCap: Integer;
-    function GetLength: Integer;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetLength: Integer; {$IFDEF FPC}inline;{$ENDIF}
   public
-    class function Create(const ACapacity: Integer = DEFAULT_CAPACITY): TStringBuffer; static;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure Append(const S: UnicodeString);
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure AppendChar(const C: WideChar);
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure Clear;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function ToString: UnicodeString;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function Create(const ACapacity: Integer = DEFAULT_CAPACITY): TStringBuffer; static; {$IFDEF FPC}inline;{$ENDIF}
+    procedure Append(const S: UnicodeString); {$IFDEF FPC}inline;{$ENDIF}
+    procedure AppendChar(const C: WideChar); {$IFDEF FPC}inline;{$ENDIF}
+    procedure Clear; {$IFDEF FPC}inline;{$ENDIF}
+    function ToString: UnicodeString; {$IFDEF FPC}inline;{$ENDIF}
     property Length: Integer read GetLength;
   end;
 

--- a/source/shared/TextEncoding.pas
+++ b/source/shared/TextEncoding.pas
@@ -42,8 +42,7 @@ begin
     Char($DC00 + (Supplementary and $3FF));
 end;
 
-function IsContinuationByte(const AByte: Byte): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsContinuationByte(const AByte: Byte): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AByte and $C0) = $80;
 end;
@@ -204,14 +203,12 @@ begin
   Result := Buffer.ToString;
 end;
 
-function IsHighSurrogate(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsHighSurrogate(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (Ord(AChar) >= $D800) and (Ord(AChar) <= $DBFF);
 end;
 
-function IsLowSurrogate(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsLowSurrogate(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (Ord(AChar) >= $DC00) and (Ord(AChar) <= $DFFF);
 end;

--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -33,8 +33,7 @@ function TryReadCodePointAt(const AText: string; const AIndex: Integer;
 function TryReadCodePointAtAllowSurrogates(const AText: string;
   const AIndex: Integer; out ACodePoint: Cardinal;
   out AByteLength: Integer): Boolean;
-function IsUnicodeSurrogateCodePoint(const ACodePoint: Cardinal): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsUnicodeSurrogateCodePoint(const ACodePoint: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 function IsECMAScriptWhitespaceCodePoint(const ACodePoint: Cardinal): Boolean;
 function TrimECMAScriptWhitespace(const AText: string): string;
 function TrimECMAScriptWhitespaceStart(const AText: string): string;
@@ -124,14 +123,12 @@ begin
   Result := FSourceTextValid;
 end;
 
-function IsHighSurrogateCodeUnit(const ACodeUnit: Cardinal): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsHighSurrogateCodeUnit(const ACodeUnit: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACodeUnit >= $D800) and (ACodeUnit <= $DBFF);
 end;
 
-function IsLowSurrogateCodeUnit(const ACodeUnit: Cardinal): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsLowSurrogateCodeUnit(const ACodeUnit: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACodeUnit >= $DC00) and (ACodeUnit <= $DFFF);
 end;

--- a/source/shared/TransportSecurity.pas
+++ b/source/shared/TransportSecurity.pas
@@ -125,8 +125,7 @@ begin
 end;
 
 function SocketSend(const ASock: TSocket; const ABuffer: Pointer;
-  const ALength: Integer): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ALength: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   {$IFDEF UNIX}
   Result := fpSend(ASock, ABuffer, ALength, 0);
@@ -137,8 +136,7 @@ begin
 end;
 
 function SocketReceive(const ASock: TSocket; const ABuffer: Pointer;
-  const ALength: Integer): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ALength: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   {$IFDEF UNIX}
   Result := fpRecv(ASock, ABuffer, ALength, 0);

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -935,8 +935,7 @@ begin
   end;
 end;
 
-function IsNullishAssignmentValue(const AValue: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsNullishAssignmentValue(const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := not Assigned(AValue) or
             (AValue is TGocciaUndefinedLiteralValue) or
@@ -966,8 +965,7 @@ begin
     TGocciaClassValue(Result).SetInferredName(AName);
 end;
 
-function NormalizeAssignmentValue(const AValue: TGocciaValue): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function NormalizeAssignmentValue(const AValue: TGocciaValue): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Assigned(AValue) then
     Result := AValue
@@ -2142,8 +2140,7 @@ begin
     Operator, AContext.OnError, Line, Column, AContext.NonStrictMode);
 end;
 
-function ToNumericValue(const AValue: TGocciaValue): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToNumericValue(const AValue: TGocciaValue): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ToPrimitive(AValue, tphNumber);
   if not (Result is TGocciaBigIntValue) then

--- a/source/units/Goccia.Arguments.Collection.pas
+++ b/source/units/Goccia.Arguments.Collection.pas
@@ -24,8 +24,7 @@ type
 
     // Collection operations
     function GetLength: Integer; virtual;
-    function IsEmpty: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsEmpty: Boolean; {$IFDEF FPC}inline;{$ENDIF}
     procedure Add(const AValue: TGocciaValue);
     procedure Clear;
     procedure EnsureCapacity(const ACapacity: Integer);

--- a/source/units/Goccia.Arithmetic.pas
+++ b/source/units/Goccia.Arithmetic.pas
@@ -25,29 +25,18 @@ function EvaluateBitwiseNot(const AOperand: TGocciaValue): TGocciaValue;
 function CompoundOperations(const ACurrentValue, ANewValue: TGocciaValue;
   const AOperator: TGocciaTokenType): TGocciaValue;
 
-function IsStrictEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function IsNotStrictEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function IsLooselyEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function IsNotLooselyEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function IsSameValue(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function IsSameValueZero(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsStrictEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function IsNotStrictEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function IsLooselyEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function IsNotLooselyEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function IsSameValue(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function IsSameValueZero(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
-function CompareStringValues(const ALeft, ARight: string): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
-function GreaterThan(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function GreaterThanOrEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function LessThan(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function LessThanOrEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function CompareStringValues(const ALeft, ARight: string): Integer; {$IFDEF FPC}inline;{$ENDIF}
+function GreaterThan(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function GreaterThanOrEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function LessThan(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function LessThanOrEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 
@@ -105,8 +94,7 @@ begin
 end;
 {$IFDEF PRODUCTION}{$Q-}{$ELSE}{$Q+}{$ENDIF}
 
-function NumberValue(const AValue: Double): TGocciaNumberLiteralValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function NumberValue(const AValue: Double): TGocciaNumberLiteralValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Math.IsNaN(AValue) then
     Exit(TGocciaNumberLiteralValue.NaNValue);
@@ -127,8 +115,7 @@ begin
   Result := TGocciaNumberLiteralValue.Create(AValue);
 end;
 
-function InfinityWithSign(const APositive: Boolean): TGocciaNumberLiteralValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function InfinityWithSign(const APositive: Boolean): TGocciaNumberLiteralValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if APositive then
     Result := TGocciaNumberLiteralValue.InfinityValue
@@ -137,16 +124,14 @@ begin
 end;
 
 // ES2026 §6.1.6.2 BigInt mixed-type arithmetic errors
-procedure CheckBigIntMixedTypes(const ALeft, ARight: TGocciaValue);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure CheckBigIntMixedTypes(const ALeft, ARight: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (ALeft is TGocciaBigIntValue) xor (ARight is TGocciaBigIntValue) then
     ThrowTypeError(SErrorBigIntMixedTypes, SSuggestBigIntNoMixedArithmetic);
 end;
 
 procedure ToPrimitiveOperands(const ALeft, ARight: TGocciaValue;
-  out APrimitiveLeft, APrimitiveRight: TGocciaValue);
-  {$IFDEF FPC}inline;{$ENDIF}
+  out APrimitiveLeft, APrimitiveRight: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 begin
   APrimitiveLeft := ToPrimitive(ALeft);
   if (TGarbageCollector.Instance <> nil) then
@@ -159,8 +144,7 @@ begin
   end;
 end;
 
-function ToNumericOperand(const AValue: TGocciaValue): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToNumericOperand(const AValue: TGocciaValue): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ToPrimitive(AValue, tphNumber);
   if Result is TGocciaSymbolValue then
@@ -171,8 +155,7 @@ begin
 end;
 
 function ToNumberPair(const ALeft, ARight: TGocciaValue;
-  out ALeftNum, ARightNum: TGocciaNumberLiteralValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  out ALeftNum, ARightNum: TGocciaNumberLiteralValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   CheckBigIntMixedTypes(ALeft, ARight);
   ALeftNum := TGocciaNumberLiteralValue(ALeft);
@@ -532,8 +515,7 @@ begin
 end;
 
 function NumberValuesEqual(const ALeft, ARight: TGocciaNumberLiteralValue;
-  const AKind: TGocciaNumberEqualityKind): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AKind: TGocciaNumberEqualityKind): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if ALeft.IsNaN or ARight.IsNaN then
   begin
@@ -560,8 +542,7 @@ begin
 end;
 
 function ValuesEqual(const ALeft, ARight: TGocciaValue;
-  const ANumberKind: TGocciaNumberEqualityKind): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ANumberKind: TGocciaNumberEqualityKind): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (ALeft is TGocciaUndefinedLiteralValue) and
      (ARight is TGocciaUndefinedLiteralValue) then
@@ -594,27 +575,23 @@ begin
 end;
 
 // ES2026 §7.2.14 IsStrictlyEqual(x, y)
-function IsStrictEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsStrictEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ValuesEqual(ALeft, ARight, nekStrict);
 end;
 
-function IsNotStrictEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsNotStrictEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := not IsStrictEqual(ALeft, ARight);
 end;
 
-function IsNullOrUndefined(const AValue: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsNullOrUndefined(const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AValue is TGocciaNullLiteralValue) or
     (AValue is TGocciaUndefinedLiteralValue);
 end;
 
-function IsLooseObjectComparablePrimitive(const AValue: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsLooseObjectComparablePrimitive(const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AValue is TGocciaStringLiteralValue) or
     (AValue is TGocciaNumberLiteralValue) or
@@ -626,15 +603,13 @@ function CompareBigIntAndNumber(const ABigInt: TGocciaBigIntValue;
   const ANumber: TGocciaNumberLiteralValue): Integer; forward;
 
 function BigIntNumberLooselyEqual(const ABigInt: TGocciaBigIntValue;
-  const ANumber: TGocciaNumberLiteralValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ANumber: TGocciaNumberLiteralValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := CompareBigIntAndNumber(ABigInt, ANumber) = RELATION_EQUAL;
 end;
 
 // ES2026 §7.2.13 IsLooselyEqual(x, y)
-function IsLooselyEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsLooselyEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   StringBigInt: TBigInteger;
 begin
@@ -700,28 +675,24 @@ begin
   Result := False;
 end;
 
-function IsNotLooselyEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsNotLooselyEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := not IsLooselyEqual(ALeft, ARight);
 end;
 
 // ES2026 §7.2.10 SameValue(x, y)
-function IsSameValue(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsSameValue(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ValuesEqual(ALeft, ARight, nekSameValue);
 end;
 
 // ES2026 §7.2.11 SameValueZero(x, y)
-function IsSameValueZero(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsSameValueZero(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ValuesEqual(ALeft, ARight, nekSameValueZero);
 end;
 
-function NormalizeRelation(const ACompare: Integer): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function NormalizeRelation(const ACompare: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if ACompare < 0 then
     Exit(RELATION_LESS);
@@ -730,8 +701,7 @@ begin
   Result := RELATION_EQUAL;
 end;
 
-function CompareNumberValues(const ALeftNum, ARightNum: TGocciaNumberLiteralValue): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function CompareNumberValues(const ALeftNum, ARightNum: TGocciaNumberLiteralValue): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if ALeftNum.IsNaN or ARightNum.IsNaN then
     Exit(RELATION_UNORDERED);
@@ -762,8 +732,7 @@ end;
 
 // ES2026 §7.2.14 IsLessThan(x, y, LeftFirst)
 function CompareBigIntAndNumber(const ABigInt: TGocciaBigIntValue;
-  const ANumber: TGocciaNumberLiteralValue): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ANumber: TGocciaNumberLiteralValue): Integer; {$IFDEF FPC}inline;{$ENDIF}
 var
   NumVal, FloorVal: Double;
   NumAsBigInt: TBigInteger;
@@ -841,8 +810,7 @@ begin
 end;
 
 // ES2026 §7.2.12 IsLessThan(x, y, LeftFirst), String comparison branch
-function CompareStringValues(const ALeft, ARight: string): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function CompareStringValues(const ALeft, ARight: string): Integer; {$IFDEF FPC}inline;{$ENDIF}
 var
   LeftByteIndex, RightByteIndex: Integer;
   LeftPendingLow, RightPendingLow: Integer;
@@ -874,8 +842,7 @@ begin
 end;
 
 function CompareBigIntAndString(const ABigInt: TGocciaBigIntValue;
-  const AString: TGocciaStringLiteralValue): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AString: TGocciaStringLiteralValue): Integer; {$IFDEF FPC}inline;{$ENDIF}
 var
   StringBigInt: TBigInteger;
 begin
@@ -884,8 +851,7 @@ begin
   Result := NormalizeRelation(ABigInt.Value.Compare(StringBigInt));
 end;
 
-function ToRelationalNumeric(const AValue: TGocciaValue): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToRelationalNumeric(const AValue: TGocciaValue): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if AValue is TGocciaBigIntValue then
     Exit(AValue);
@@ -894,8 +860,7 @@ begin
   Result := AValue.ToNumberLiteral;
 end;
 
-function CompareRelationalValues(const ALeft, ARight: TGocciaValue): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function CompareRelationalValues(const ALeft, ARight: TGocciaValue): Integer; {$IFDEF FPC}inline;{$ENDIF}
 var
   PrimLeft, PrimRight: TGocciaValue;
   NumericLeft, NumericRight: TGocciaValue;
@@ -959,20 +924,17 @@ begin
     TGocciaNumberLiteralValue(NumericRight));
 end;
 
-function LessThan(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function LessThan(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := CompareRelationalValues(ALeft, ARight) = RELATION_LESS;
 end;
 
-function GreaterThan(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function GreaterThan(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := CompareRelationalValues(ALeft, ARight) = RELATION_GREATER;
 end;
 
-function LessThanOrEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function LessThanOrEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Cmp: Integer;
 begin
@@ -980,8 +942,7 @@ begin
   Result := (Cmp = RELATION_LESS) or (Cmp = RELATION_EQUAL);
 end;
 
-function GreaterThanOrEqual(const ALeft, ARight: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function GreaterThanOrEqual(const ALeft, ARight: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Cmp: Integer;
 begin

--- a/source/units/Goccia.BinaryData.pas
+++ b/source/units/Goccia.BinaryData.pas
@@ -17,10 +17,8 @@ type
   );
 
 function BinaryBytesPerElement(const AKind: TGocciaBinaryElementKind): Integer;
-function BinaryIsFloatElement(const AKind: TGocciaBinaryElementKind): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function BinaryIsBigIntElement(const AKind: TGocciaBinaryElementKind): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function BinaryIsFloatElement(const AKind: TGocciaBinaryElementKind): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function BinaryIsBigIntElement(const AKind: TGocciaBinaryElementKind): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 function ReadBinaryNumberElement(const AData: TBytes; const AOffset: Integer;
   const AKind: TGocciaBinaryElementKind; const ALittleEndian: Boolean): Double;
@@ -43,14 +41,12 @@ uses
   Goccia.Float16,
   Goccia.NumberConversion;
 
-function UInt64BitsToInt64(const AValue: UInt64): Int64;
-{$IFDEF FPC}inline;{$ENDIF}
+function UInt64BitsToInt64(const AValue: UInt64): Int64; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Move(AValue, Result, SizeOf(Result));
 end;
 
-function Int64ToUInt64Bits(const AValue: Int64): UInt64;
-{$IFDEF FPC}inline;{$ENDIF}
+function Int64ToUInt64Bits(const AValue: Int64): UInt64; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Move(AValue, Result, SizeOf(Result));
 end;

--- a/source/units/Goccia.Builtins.GlobalRegExp.pas
+++ b/source/units/Goccia.Builtins.GlobalRegExp.pas
@@ -810,8 +810,7 @@ begin
 end;
 
 function IsECMAScriptWhiteSpaceOrLineTerminator(
-  const ACodePoint: Cardinal): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ACodePoint: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case ACodePoint of
     // ES2026 §12.2 White Space
@@ -846,8 +845,7 @@ begin
 end;
 
 function EncodeControlEscapeForRegExpEscape(const ACodePoint: Cardinal;
-  out AEscaped: string): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  out AEscaped: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := True;
   case ACodePoint of

--- a/source/units/Goccia.Builtins.Math.pas
+++ b/source/units/Goccia.Builtins.Math.pas
@@ -117,8 +117,7 @@ const
 threadvar
   FStaticMembers: TArray<TGocciaMemberDefinition>;
 
-function IsFiniteIntegral(const AValue: Double): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsFiniteIntegral(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (not IsNan(AValue)) and (not IsInfinite(AValue)) and
     ((Abs(AValue) >= DOUBLE_INTEGRAL_LIMIT) or (Frac(AValue) = 0));

--- a/source/units/Goccia.Builtins.Performance.pas
+++ b/source/units/Goccia.Builtins.Performance.pas
@@ -25,8 +25,7 @@ type
     FTimeOriginMonotonicNanoseconds: Int64;
     FHostEnvironment: TGocciaHostEnvironment;
 
-    function GetTimeOriginMilliseconds: Double;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetTimeOriginMilliseconds: Double; {$IFDEF FPC}inline;{$ENDIF}
   public
     constructor Create(const AHostEnvironment: TGocciaHostEnvironment);
 
@@ -72,8 +71,7 @@ var
 threadvar
   FPrototypeMethodHost: TGocciaPerformancePrototypeHost;
 
-function GetPerformanceShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetPerformanceShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GPerformanceSharedSlot))

--- a/source/units/Goccia.Builtins.Testing.Snapshots.pas
+++ b/source/units/Goccia.Builtins.Testing.Snapshots.pas
@@ -250,8 +250,7 @@ begin
   Result := False;
 end;
 
-function NaturalSortCode(const ACharacter: Char): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function NaturalSortCode(const ACharacter: Char): Integer; {$IFDEF FPC}inline;{$ENDIF}
 var
   CharacterCode: Integer;
 begin

--- a/source/units/Goccia.Bytecode.Chunk.pas
+++ b/source/units/Goccia.Bytecode.Chunk.pas
@@ -235,14 +235,11 @@ type
     function GetRegExpProgramCache(const ASlot: Integer): TObject;
     procedure SetRegExpProgramCache(const ASlot: Integer; const AValue: TObject);
     function GlobalReadCacheSlot(
-      const AConstIndex: Integer): PGocciaGlobalReadCacheEntry;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const AConstIndex: Integer): PGocciaGlobalReadCacheEntry; {$IFDEF FPC}inline;{$ENDIF}
     function PropertyReadCacheSlot(
-      const AConstIndex: Integer): PGocciaPropertyReadCacheEntry;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const AConstIndex: Integer): PGocciaPropertyReadCacheEntry; {$IFDEF FPC}inline;{$ENDIF}
     function ProtoReadCacheSlot(
-      const AConstIndex: Integer): PGocciaProtoReadCacheEntry;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const AConstIndex: Integer): PGocciaProtoReadCacheEntry; {$IFDEF FPC}inline;{$ENDIF}
     function AddFunction(const AFunction: TGocciaFunctionTemplate): UInt16;
     procedure AddUpvalueDescriptor(const AIsLocal: Boolean; const AIndex: UInt16;
       const AName: string = '');
@@ -252,17 +249,12 @@ type
     procedure AddExceptionHandler(const ATryStart, ATryEnd, ACatchTarget,
       AFinallyTarget: UInt32; const ACatchRegister: UInt16);
 
-    function GetInstruction(const AIndex: Integer): UInt32;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetConstant(const AIndex: Integer): TGocciaBytecodeConstant;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetInstruction(const AIndex: Integer): UInt32; {$IFDEF FPC}inline;{$ENDIF}
+    function GetConstant(const AIndex: Integer): TGocciaBytecodeConstant; {$IFDEF FPC}inline;{$ENDIF}
     function GetFunction(const AIndex: Integer): TGocciaFunctionTemplate;
-    function GetInstructionUnchecked(const AIndex: Integer): UInt32;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetConstantUnchecked(const AIndex: Integer): TGocciaBytecodeConstant;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetFunctionUnchecked(const AIndex: Integer): TGocciaFunctionTemplate;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetInstructionUnchecked(const AIndex: Integer): UInt32; {$IFDEF FPC}inline;{$ENDIF}
+    function GetConstantUnchecked(const AIndex: Integer): TGocciaBytecodeConstant; {$IFDEF FPC}inline;{$ENDIF}
+    function GetFunctionUnchecked(const AIndex: Integer): TGocciaFunctionTemplate; {$IFDEF FPC}inline;{$ENDIF}
     function GetUpvalueDescriptor(const AIndex: Integer): TGocciaUpvalueDescriptor;
     function GetDirectEvalEnvironment(
       const AIndex: Integer): TGocciaDirectEvalEnvironment;
@@ -336,8 +328,7 @@ begin
   end;
 end;
 
-function FloatBitsAreNaN(const AValue: Double): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function FloatBitsAreNaN(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Bits: UInt64;
 begin

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -419,31 +419,20 @@ type
     OP_CONSTRUCT_SPREAD = 226
   );
 
-function EncodeABC(const AOp: TGocciaOpCode; const A, B, C: UInt16): UInt64;
-{$IFDEF FPC}inline;{$ENDIF}
-function EncodeABx(const AOp: TGocciaOpCode; const A: UInt16; const ABx: UInt16): UInt64;
-{$IFDEF FPC}inline;{$ENDIF}
+function EncodeABC(const AOp: TGocciaOpCode; const A, B, C: UInt16): UInt64; {$IFDEF FPC}inline;{$ENDIF}
+function EncodeABx(const AOp: TGocciaOpCode; const A: UInt16; const ABx: UInt16): UInt64; {$IFDEF FPC}inline;{$ENDIF}
 function EncodeAsBx(const AOp: TGocciaOpCode; const A: UInt16;
-  const AAsBx: Int16): UInt64;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AAsBx: Int16): UInt64; {$IFDEF FPC}inline;{$ENDIF}
 function EncodeAx(const AOp: TGocciaOpCode;
-  const AAx: Int32): UInt64;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AAx: Int32): UInt64; {$IFDEF FPC}inline;{$ENDIF}
 
-function DecodeOp(const AInstruction: UInt32): UInt8;
-{$IFDEF FPC}inline;{$ENDIF}
-function DecodeA(const AInstruction: UInt32): UInt8;
-{$IFDEF FPC}inline;{$ENDIF}
-function DecodeB(const AInstruction: UInt32): UInt8;
-{$IFDEF FPC}inline;{$ENDIF}
-function DecodeC(const AInstruction: UInt32): UInt8;
-{$IFDEF FPC}inline;{$ENDIF}
-function DecodeBx(const AInstruction: UInt32): UInt16;
-{$IFDEF FPC}inline;{$ENDIF}
-function DecodesBx(const AInstruction: UInt32): Int16;
-{$IFDEF FPC}inline;{$ENDIF}
-function DecodeAx(const AInstruction: UInt32): Int32;
-{$IFDEF FPC}inline;{$ENDIF}
+function DecodeOp(const AInstruction: UInt32): UInt8; {$IFDEF FPC}inline;{$ENDIF}
+function DecodeA(const AInstruction: UInt32): UInt8; {$IFDEF FPC}inline;{$ENDIF}
+function DecodeB(const AInstruction: UInt32): UInt8; {$IFDEF FPC}inline;{$ENDIF}
+function DecodeC(const AInstruction: UInt32): UInt8; {$IFDEF FPC}inline;{$ENDIF}
+function DecodeBx(const AInstruction: UInt32): UInt16; {$IFDEF FPC}inline;{$ENDIF}
+function DecodesBx(const AInstruction: UInt32): Int16; {$IFDEF FPC}inline;{$ENDIF}
+function DecodeAx(const AInstruction: UInt32): Int32; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/units/Goccia.Compiler.ConstantFolding.pas
+++ b/source/units/Goccia.Compiler.ConstantFolding.pas
@@ -17,18 +17,15 @@ function TryEmitConstantExpression(const ACtx: TGocciaCompilationContext;
 procedure EmitCompileTimeValue(const ACtx: TGocciaCompilationContext;
   const AValue: TGocciaCompileTimeValue; const ADest: UInt16);
 function CompileTimeValueToBoolean(
-  const AValue: TGocciaCompileTimeValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaCompileTimeValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 function CompileTimeValueIsNullish(
-  const AValue: TGocciaCompileTimeValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaCompileTimeValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 function TryFoldBinary(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaBinaryExpression; const ADest: UInt16): Boolean;
 function TryFoldUnary(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaUnaryExpression; const ADest: UInt16): Boolean;
-function IsNegativeZeroFloat(const AValue: Double): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsNegativeZeroFloat(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 
@@ -54,21 +51,18 @@ uses
   Goccia.Values.Primitives;
 
 function CompileTimeValueToBoolean(
-  const AValue: TGocciaCompileTimeValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaCompileTimeValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := Goccia.Compiler.ConstantValue.CompileTimeValueToBoolean(AValue);
 end;
 
 function CompileTimeValueIsNullish(
-  const AValue: TGocciaCompileTimeValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaCompileTimeValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := Goccia.Compiler.ConstantValue.CompileTimeValueIsNullish(AValue);
 end;
 
-function IsNegativeZeroFloat(const AValue: Double): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsNegativeZeroFloat(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := IsNegativeZero(AValue);
 end;

--- a/source/units/Goccia.Compiler.ConstantValue.pas
+++ b/source/units/Goccia.Compiler.ConstantValue.pas
@@ -36,8 +36,7 @@ type
     PreserveCoverageShape: Boolean;
   end;
 
-function DefaultCompilerOptimizationOptions: TGocciaCompilerOptimizationOptions;
-{$IFDEF FPC}inline;{$ENDIF}
+function DefaultCompilerOptimizationOptions: TGocciaCompilerOptimizationOptions; {$IFDEF FPC}inline;{$ENDIF}
 
 function UnknownCompileTimeValue: TGocciaCompileTimeValue;
 function UndefinedCompileTimeValue: TGocciaCompileTimeValue;
@@ -50,19 +49,15 @@ function BigIntCompileTimeValue(const AValue: TBigInteger): TGocciaCompileTimeVa
 function TryCompileTimeValueFromLiteral(const AValue: TGocciaValue;
   out AConstant: TGocciaCompileTimeValue): Boolean;
 function CompileTimeValueToBoolean(const AValue: TGocciaCompileTimeValue): Boolean;
-function CompileTimeValueIsNullish(const AValue: TGocciaCompileTimeValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function CompileTimeValueIsNullish(const AValue: TGocciaCompileTimeValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 function CompileTimeValueToLocalType(
-  const AValue: TGocciaCompileTimeValue): TGocciaLocalType;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaCompileTimeValue): TGocciaLocalType; {$IFDEF FPC}inline;{$ENDIF}
 function CompileTimeValueToString(const AValue: TGocciaCompileTimeValue): string;
 function TryCompileTimeValueToNumber(const AValue: TGocciaCompileTimeValue;
   out ANumber: Double): Boolean;
 function CompileTimeValueIsNumber(const AValue: TGocciaCompileTimeValue;
-  const ANumber: Double): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
-function CompileTimeNumberIsNegativeZero(const AValue: Double): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+  const ANumber: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function CompileTimeNumberIsNegativeZero(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 
@@ -75,8 +70,7 @@ uses
   Goccia.Constants,
   Goccia.Values.BigIntValue;
 
-function DefaultCompilerOptimizationOptions: TGocciaCompilerOptimizationOptions;
-{$IFDEF FPC}inline;{$ENDIF}
+function DefaultCompilerOptimizationOptions: TGocciaCompilerOptimizationOptions; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result.EnableConstantFolding := True;
   Result.EnableConstPropagation := True;
@@ -163,8 +157,7 @@ begin
   end;
 end;
 
-function CompileTimeNumberIsNegativeZero(const AValue: Double): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function CompileTimeNumberIsNegativeZero(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := NumberBits.IsNegativeZero(AValue);
 end;
@@ -190,15 +183,13 @@ begin
 end;
 
 function CompileTimeValueIsNullish(
-  const AValue: TGocciaCompileTimeValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaCompileTimeValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AValue.Kind in [ctvkUndefined, ctvkNull];
 end;
 
 function CompileTimeValueToLocalType(
-  const AValue: TGocciaCompileTimeValue): TGocciaLocalType;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaCompileTimeValue): TGocciaLocalType; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case AValue.Kind of
     ctvkBoolean:
@@ -277,8 +268,7 @@ begin
 end;
 
 function CompileTimeValueIsNumber(const AValue: TGocciaCompileTimeValue;
-  const ANumber: Double): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ANumber: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AValue.Kind = ctvkNumber) and (not IsNaN(AValue.NumberValue)) and
     (AValue.NumberValue = ANumber);

--- a/source/units/Goccia.Compiler.Context.pas
+++ b/source/units/Goccia.Compiler.Context.pas
@@ -52,8 +52,7 @@ type
   end;
 
 function EmitInstruction(const ACtx: TGocciaCompilationContext;
-  const AInstruction: UInt64; const AForceWide: Boolean = False): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AInstruction: UInt64; const AForceWide: Boolean = False): Integer; {$IFDEF FPC}inline;{$ENDIF}
 procedure EmitLoadStringLiteral(const ACtx: TGocciaCompilationContext;
   const ADest: UInt16; const AValue: string);
 procedure EmitLineMapping(const ACtx: TGocciaCompilationContext;
@@ -71,11 +70,9 @@ function TokenTypeToRuntimeOp(
 function CompoundOpToRuntimeOp(
   const ATokenType: TGocciaTokenType): TGocciaOpCode;
 function IsShortCircuitAssignment(
-  const ATokenType: TGocciaTokenType): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ATokenType: TGocciaTokenType): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 function ShortCircuitJumpOp(
-  const ATokenType: TGocciaTokenType): TGocciaOpCode;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ATokenType: TGocciaTokenType): TGocciaOpCode; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -416,8 +416,7 @@ begin
 end;
 
 function ChildBodyIsStrictCode(const ACtx: TGocciaCompilationContext;
-  const ABody: TGocciaASTNode): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ABody: TGocciaASTNode): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (not ACtx.NonStrictMode) or
     (Assigned(ACtx.Template) and ACtx.Template.StrictCode) or
@@ -494,8 +493,7 @@ end;
 
 function ShouldIgnoreNonStrictImmutableLocalAssignment(
   const ACtx: TGocciaCompilationContext;
-  const ALocal: TGocciaCompilerLocal): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ALocal: TGocciaCompilerLocal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ACtx.NonStrictMode and ALocal.IsConst and
     ALocal.IsNonStrictImmutable;
@@ -503,8 +501,7 @@ end;
 
 function ShouldIgnoreNonStrictImmutableUpvalueAssignment(
   const ACtx: TGocciaCompilationContext;
-  const AUpvalue: TGocciaCompilerUpvalue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AUpvalue: TGocciaCompilerUpvalue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ACtx.NonStrictMode and AUpvalue.IsConst and
     AUpvalue.IsNonStrictImmutable;

--- a/source/units/Goccia.Compiler.TypeRules.pas
+++ b/source/units/Goccia.Compiler.TypeRules.pas
@@ -7,15 +7,12 @@ interface
 uses
   Goccia.Bytecode.Chunk;
 
-function TypesAreCompatible(const AProduced, AExpected: TGocciaLocalType): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function IsKnownNumeric(const AType: TGocciaLocalType): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function TypesAreCompatible(const AProduced, AExpected: TGocciaLocalType): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function IsKnownNumeric(const AType: TGocciaLocalType): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 
-function TypesAreCompatible(const AProduced, AExpected: TGocciaLocalType): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function TypesAreCompatible(const AProduced, AExpected: TGocciaLocalType): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if AProduced = sltUntyped then
     Exit(False);
@@ -26,8 +23,7 @@ begin
   Result := False;
 end;
 
-function IsKnownNumeric(const AType: TGocciaLocalType): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsKnownNumeric(const AType: TGocciaLocalType): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AType in [sltInteger, sltFloat];
 end;

--- a/source/units/Goccia.ControlFlow.pas
+++ b/source/units/Goccia.ControlFlow.pas
@@ -20,24 +20,16 @@ type
     FBits: NativeUInt;
     FTargetLabel: string;
     FReturnHasExpression: Boolean;
-    function GetKind: TGocciaControlFlowKind;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetValue: TGocciaValue;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetKind: TGocciaControlFlowKind; {$IFDEF FPC}inline;{$ENDIF}
+    function GetValue: TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
   public
-    class function Normal(const AValue: TGocciaValue): TGocciaControlFlow; static;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function Normal(const AValue: TGocciaValue): TGocciaControlFlow; static; {$IFDEF FPC}inline;{$ENDIF}
     class function Return(const AValue: TGocciaValue;
-      const AHasExpression: Boolean): TGocciaControlFlow; static;
-      {$IFDEF FPC}inline;{$ENDIF}
-    class function Empty: TGocciaControlFlow; static;
-    {$IFDEF FPC}inline;{$ENDIF}
-    class function Break(const ATargetLabel: string = ''; const AValue: TGocciaValue = nil): TGocciaControlFlow; static;
-    {$IFDEF FPC}inline;{$ENDIF}
-    class function Continue(const ATargetLabel: string = ''; const AValue: TGocciaValue = nil): TGocciaControlFlow; static;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function UpdateEmpty(const AValue: TGocciaValue): TGocciaControlFlow;
-    {$IFDEF FPC}inline;{$ENDIF}
+      const AHasExpression: Boolean): TGocciaControlFlow; static; {$IFDEF FPC}inline;{$ENDIF}
+    class function Empty: TGocciaControlFlow; static; {$IFDEF FPC}inline;{$ENDIF}
+    class function Break(const ATargetLabel: string = ''; const AValue: TGocciaValue = nil): TGocciaControlFlow; static; {$IFDEF FPC}inline;{$ENDIF}
+    class function Continue(const ATargetLabel: string = ''; const AValue: TGocciaValue = nil): TGocciaControlFlow; static; {$IFDEF FPC}inline;{$ENDIF}
+    function UpdateEmpty(const AValue: TGocciaValue): TGocciaControlFlow; {$IFDEF FPC}inline;{$ENDIF}
     property Kind: TGocciaControlFlowKind read GetKind;
     property Value: TGocciaValue read GetValue;
     property TargetLabel: string read FTargetLabel;

--- a/source/units/Goccia.Coverage.pas
+++ b/source/units/Goccia.Coverage.pas
@@ -38,8 +38,7 @@ type
     constructor Create(const AFileName: string; const AExecutableLines: Integer);
     destructor Destroy; override;
 
-    procedure RecordLineHit(const ALine: Integer);
-    {$IFDEF FPC}inline;{$ENDIF}
+    procedure RecordLineHit(const ALine: Integer); {$IFDEF FPC}inline;{$ENDIF}
     procedure RecordBranchHit(const ALine, AColumn, ABranchIndex: Integer);
     procedure EnsureBranchExists(const ALine, AColumn, ABranchIndex: Integer);
 
@@ -52,8 +51,7 @@ type
     property FileName: string read FFileName;
     property ExecutableLines: Integer read FExecutableLines;
     property Branches: TGocciaCoverageBranchList read FBranches;
-    function GetLineHitCount(const ALine: Integer): Integer;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetLineHitCount(const ALine: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
   end;
 
   TGocciaCoverageFileMap = TOrderedStringMap<TGocciaFileCoverage>;
@@ -81,8 +79,7 @@ type
     procedure RegisterSourceMap(const AFilePath: string;
       const ASourceMap: TGocciaSourceMap);
     procedure RecordLineHit(const AFilePath: string;
-      const ALine: Integer);
-      {$IFDEF FPC}inline;{$ENDIF}
+      const ALine: Integer); {$IFDEF FPC}inline;{$ENDIF}
     procedure RecordBranchHit(const AFilePath: string;
       const ALine, AColumn, ABranchIndex: Integer);
 

--- a/source/units/Goccia.Evaluator.TypeOperations.pas
+++ b/source/units/Goccia.Evaluator.TypeOperations.pas
@@ -12,8 +12,7 @@ uses
 type
   TIsObjectInstanceOfClassFunction = function(const AObj: TGocciaObjectValue; const AClassValue: TGocciaClassValue): Boolean;
 
-function EvaluateTypeof(const AOperand: TGocciaValue): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function EvaluateTypeof(const AOperand: TGocciaValue): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 function EvaluateInstanceof(const ALeft, ARight: TGocciaValue; const AIsObjectInstanceOfClass: TIsObjectInstanceOfClassFunction): TGocciaValue;
 function EvaluateInOperator(const ALeft, ARight: TGocciaValue): TGocciaValue;
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -258,8 +258,7 @@ function CollectDeclaredPrivateNames(
   const AContext: TGocciaEvaluationContext): TStringList; forward;
 
 function ShouldUseNativeClassInstantiation(
-  const AClassValue: TGocciaClassValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AClassValue: TGocciaClassValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AClassValue is TGocciaTypedArrayClassValue) or
     (AClassValue is TGocciaTypedArrayIntrinsicClassValue);
@@ -337,8 +336,7 @@ type
   TClassCallableEvalEntries = array of TClassCallableEvalEntry;
 
 function FunctionIntrinsicKind(const AIsAsync,
-  AIsGenerator: Boolean): TGocciaFunctionObjectIntrinsicKind;
-  {$IFDEF FPC}inline;{$ENDIF}
+  AIsGenerator: Boolean): TGocciaFunctionObjectIntrinsicKind; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if AIsAsync and AIsGenerator then
     Result := foikAsyncGenerator
@@ -457,8 +455,7 @@ begin
   end;
 end;
 
-procedure EnsureObjectPrototypeInitialized;
-{$IFDEF FPC}inline;{$ENDIF}
+procedure EnsureObjectPrototypeInitialized; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if TGocciaObjectValue.SharedObjectPrototype = nil then
     TGocciaObjectValue.InitializeSharedPrototype;
@@ -637,23 +634,20 @@ begin
   end;
 end;
 
-function UndefinedCompletionValue: TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function UndefinedCompletionValue: TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 procedure UpdateValueFromCompletion(const ACompletion: TGocciaControlFlow;
-  var AValue: TGocciaValue);
-  {$IFDEF FPC}inline;{$ENDIF}
+  var AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Assigned(ACompletion.Value) then
     AValue := ACompletion.Value;
 end;
 
 function NormalCompletionFromAbrupt(const ACompletion: TGocciaControlFlow;
-  const AValue: TGocciaValue): TGocciaControlFlow;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaValue): TGocciaControlFlow; {$IFDEF FPC}inline;{$ENDIF}
 var
   UpdatedCompletion: TGocciaControlFlow;
 begin
@@ -772,8 +766,7 @@ begin
 end;
 
 procedure AddValueRoot(var ARoots: TGocciaActiveRootFrame;
-  const AValue: TGocciaValue);
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Assigned(AValue) then
     ARoots.Add(AValue);
@@ -788,8 +781,7 @@ begin
     AddValueRoot(ARoots, AArguments.GetElement(I));
 end;
 
-procedure CollectInterpreterMemoryPressure(const AProtect: TGocciaValue);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure CollectInterpreterMemoryPressure(const AProtect: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 var
   GC: TGarbageCollector;
 begin
@@ -798,8 +790,7 @@ begin
     GC.CollectForMemoryPressure(AProtect);
 end;
 
-procedure QueueInterpreterResultHandoff(const AValue: TGocciaValue);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure QueueInterpreterResultHandoff(const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 var
   GC: TGarbageCollector;
 begin
@@ -808,8 +799,7 @@ begin
     GC.AddQueuedRoot(AValue);
 end;
 
-procedure ClearInterpreterResultHandoff(const AValue: TGocciaValue);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure ClearInterpreterResultHandoff(const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 var
   GC: TGarbageCollector;
 begin

--- a/source/units/Goccia.ExecutionContext.pas
+++ b/source/units/Goccia.ExecutionContext.pas
@@ -47,10 +47,8 @@ function CreateExecutionContext(const ARealm: TGocciaRealm;
   const AScriptOrModule: TObject = nil;
   const AFunctionValue: TGocciaValue = nil): TGocciaExecutionContext;
 
-function RunningExecutionContext: TGocciaExecutionContext;
-{$IFDEF FPC}inline;{$ENDIF}
-function HasRunningExecutionContext: Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function RunningExecutionContext: TGocciaExecutionContext; {$IFDEF FPC}inline;{$ENDIF}
+function HasRunningExecutionContext: Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/units/Goccia.FFI.Types.pas
+++ b/source/units/Goccia.FFI.Types.pas
@@ -63,15 +63,12 @@ type
       const AReturnType: TGocciaFFITypeDescriptor): TGocciaFFITypeDescriptor;
     procedure AddReference;
     procedure ReleaseReference;
-    function IsAggregate: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsAggregate: Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function ContainsUnion: Boolean;
     function FieldIndex(const AName: string): Integer;
-    function FieldCount: Integer;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function FieldCount: Integer; {$IFDEF FPC}inline;{$ENDIF}
     function FieldAt(const AIndex: Integer): TGocciaFFIFieldDescriptor;
-    function CallbackArgumentCount: Integer;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function CallbackArgumentCount: Integer; {$IFDEF FPC}inline;{$ENDIF}
     function CallbackArgumentAt(
       const AIndex: Integer): TGocciaFFITypeDescriptor;
     property Kind: TGocciaFFITypeKind read FKind;

--- a/source/units/Goccia.GarbageCollector.pas
+++ b/source/units/Goccia.GarbageCollector.pas
@@ -20,8 +20,7 @@ type
     procedure SetGCMarked(const AValue: Boolean);
   public
     procedure BeforeDestruction; override;
-    class procedure AdvanceMark; static;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class procedure AdvanceMark; static; {$IFDEF FPC}inline;{$ENDIF}
     procedure MarkReferences; virtual;
     function TraceWeakReferences: Boolean; virtual;
     procedure SweepWeakReferences; virtual;
@@ -46,8 +45,7 @@ type
   private
     FCount: Integer;
   public
-    procedure Initialize;
-    {$IFDEF FPC}inline;{$ENDIF}
+    procedure Initialize; {$IFDEF FPC}inline;{$ENDIF}
     procedure Add(const AObject: TGCManagedObject);
     procedure Clear;
   end;
@@ -90,8 +88,7 @@ type
     {$ENDIF}
 
     function GetManagedObjectCount: Integer;
-    function GetWatermark: Integer;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetWatermark: Integer; {$IFDEF FPC}inline;{$ENDIF}
     procedure ClearActiveRootEntries(const AObject: TGCManagedObject);
   protected
     procedure MarkRoots; virtual;
@@ -99,8 +96,7 @@ type
     procedure SweepWeakReferences;
     procedure SweepObjects;
   public
-    class function Instance: TGarbageCollector;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function Instance: TGarbageCollector; {$IFDEF FPC}inline;{$ENDIF}
     class procedure Initialize;
     class procedure Shutdown;
 
@@ -187,8 +183,7 @@ const
   MEMORY_PRESSURE_COLLECTION_MAX_RESERVE = 1024 * 1024;
 
 function DetectDefaultMaxBytes: Int64;
-procedure InitializeTempRoot(var ARoot: TGocciaTempRoot);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure InitializeTempRoot(var ARoot: TGocciaTempRoot); {$IFDEF FPC}inline;{$ENDIF}
 procedure AddTempRootIfNeeded(var ARoot: TGocciaTempRoot;
   const AObject: TGCManagedObject);
 procedure RemoveTempRootIfNeeded(var ARoot: TGocciaTempRoot);

--- a/source/units/Goccia.HostEnvironment.pas
+++ b/source/units/Goccia.HostEnvironment.pas
@@ -86,15 +86,11 @@ type
     procedure UseDeterministicProfile;
     procedure ConfigureAsChildOf(const AParent: TGocciaHostEnvironment);
 
-    function EpochNanoseconds: Int64;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function MonotonicNanoseconds: Int64;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function TimeZoneIdentifier: string;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function EpochNanoseconds: Int64; {$IFDEF FPC}inline;{$ENDIF}
+    function MonotonicNanoseconds: Int64; {$IFDEF FPC}inline;{$ENDIF}
+    function TimeZoneIdentifier: string; {$IFDEF FPC}inline;{$ENDIF}
     function ResolveTimeZoneIdentifier(const AFallback: string): string;
-    function RandomDouble: Double;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function RandomDouble: Double; {$IFDEF FPC}inline;{$ENDIF}
   end;
 
 implementation

--- a/source/units/Goccia.InstructionLimit.pas
+++ b/source/units/Goccia.InstructionLimit.pas
@@ -12,12 +12,9 @@ type
 
 procedure StartInstructionLimit(const AMaxInstructions: Int64);
 procedure ClearInstructionLimit;
-procedure IncrementInstructionCounter;
-{$IFDEF FPC}inline;{$ENDIF}
-procedure CheckInstructionLimit;
-{$IFDEF FPC}inline;{$ENDIF}
-procedure PollInstructionLimit;
-{$IFDEF FPC}inline;{$ENDIF}
+procedure IncrementInstructionCounter; {$IFDEF FPC}inline;{$ENDIF}
+procedure CheckInstructionLimit; {$IFDEF FPC}inline;{$ENDIF}
+procedure PollInstructionLimit; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 
@@ -37,23 +34,20 @@ begin
   GInstructionCount := 0;
 end;
 
-procedure IncrementInstructionCounter;
-{$IFDEF FPC}inline;{$ENDIF}
+procedure IncrementInstructionCounter; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if GMaxInstructions > 0 then
     Inc(GInstructionCount);
 end;
 
-procedure CheckInstructionLimit;
-{$IFDEF FPC}inline;{$ENDIF}
+procedure CheckInstructionLimit; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (GMaxInstructions > 0) and (GInstructionCount >= GMaxInstructions) then
     raise TGocciaInstructionLimitError.CreateFmt(
       'Execution exceeded instruction limit of %d', [GMaxInstructions]);
 end;
 
-procedure PollInstructionLimit;
-{$IFDEF FPC}inline;{$ENDIF}
+procedure PollInstructionLimit; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if GMaxInstructions > 0 then
   begin

--- a/source/units/Goccia.JSX.Transformer.pas
+++ b/source/units/Goccia.JSX.Transformer.pas
@@ -43,21 +43,15 @@ type
     FFileName: string;
     FJSXDepth: Integer;
 
-    function Peek: Char;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function PeekAt(const AOffset: Integer): Char;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function IsAtEnd: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure AdvanceInput;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function CurrentChar: Char;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function Peek: Char; {$IFDEF FPC}inline;{$ENDIF}
+    function PeekAt(const AOffset: Integer): Char; {$IFDEF FPC}inline;{$ENDIF}
+    function IsAtEnd: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    procedure AdvanceInput; {$IFDEF FPC}inline;{$ENDIF}
+    function CurrentChar: Char; {$IFDEF FPC}inline;{$ENDIF}
 
     procedure Emit(const AText: string);
     procedure EmitMapped(const AText: string; const ASourceLine, ASourceColumn: Integer);
-    procedure EmitChar(const AChar: Char);
-    {$IFDEF FPC}inline;{$ENDIF}
+    procedure EmitChar(const AChar: Char); {$IFDEF FPC}inline;{$ENDIF}
     procedure EmitNewline;
     procedure AddIdentityMapping;
 
@@ -73,10 +67,8 @@ type
 
     function IsJSXContext: Boolean;
     function IsJSXStart: Boolean;
-    function IsIdentifierStart(const AChar: Char): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function IsIdentifierPart(const AChar: Char): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsIdentifierStart(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function IsIdentifierPart(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
     procedure TransformJSXElement;
     function ReadJSXTagName: string;

--- a/source/units/Goccia.Keywords.Reserved.pas
+++ b/source/units/Goccia.Keywords.Reserved.pas
@@ -98,10 +98,8 @@ const
     KEYWORD_STATIC
   );
 
-function IsReservedKeyword(const AName: string): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function IsStrictModeReservedKeyword(const AName: string): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsReservedKeyword(const AName: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function IsStrictModeReservedKeyword(const AName: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/units/Goccia.Lexer.pas
+++ b/source/units/Goccia.Lexer.pas
@@ -51,16 +51,11 @@ type
     FScanTimeNanoseconds: Int64;
     function GetSourceLines: TStringList;
 
-    function IsAtEnd: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function Advance: Char;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function Peek: Char;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function PeekNext: Char;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function Match(const AExpected: Char): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsAtEnd: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function Advance: Char; {$IFDEF FPC}inline;{$ENDIF}
+    function Peek: Char; {$IFDEF FPC}inline;{$ENDIF}
+    function PeekNext: Char; {$IFDEF FPC}inline;{$ENDIF}
+    function Match(const AExpected: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function IsSourceIdentifierStartCodePoint(ACodePoint: Cardinal): Boolean;
     function IsSourceIdentifierPartCodePoint(ACodePoint: Cardinal): Boolean;
     function IsValidEscapedIdentifierText(const AText: string;
@@ -95,19 +90,14 @@ type
     procedure SkipComment;
     procedure SkipBlockComment;
     procedure SkipUntilLineTerminator;
-    function ConsumeWhitespaceCodePoint: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function IsLineTerminator: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function IsUnicodeLineTerminator: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function ConsumeLineTerminator: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function ConsumeWhitespaceCodePoint: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function IsLineTerminator: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function IsUnicodeLineTerminator: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function ConsumeLineTerminator: Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function ConsumeLineTerminatorBytes(out ABytes: string): Boolean;
     function AppendLineTerminator(var ASB, ARawSB: TStringBuffer): Boolean;
     function AppendTemplateLineContinuation(var ARawSB: TStringBuffer): Boolean;
-    procedure ConsumeUnicodeLineTerminator;
-    {$IFDEF FPC}inline;{$ENDIF}
+    procedure ConsumeUnicodeLineTerminator; {$IFDEF FPC}inline;{$ENDIF}
   public
     constructor Create(const ASource, AFileName: string);
     destructor Destroy; override;
@@ -274,8 +264,7 @@ begin
     ACodePoint := Cardinal(CodePointValue);
 end;
 
-function TryKeywordToken(const AText: string; out ATokenType: TGocciaTokenType): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function TryKeywordToken(const AText: string; out ATokenType: TGocciaTokenType): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Len: Integer;
   Range: TKeywordTokenLengthRange;
@@ -542,8 +531,7 @@ begin
 end;
 
 function TGocciaLexer.AppendTemplateLineContinuation(
-  var ARawSB: TStringBuffer): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  var ARawSB: TStringBuffer): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Bytes: string;
 begin
@@ -1470,8 +1458,7 @@ begin
 end;
 
 function LexicalGoalAllowsRegularExpression(
-  const ALexicalGoal: TGocciaLexicalGoal): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ALexicalGoal: TGocciaLexicalGoal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ALexicalGoal in [
     glgInputElementRegExp,
@@ -1481,8 +1468,7 @@ begin
 end;
 
 function LexicalGoalRequiresTemplateContinuation(
-  const ALexicalGoal: TGocciaLexicalGoal): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ALexicalGoal: TGocciaLexicalGoal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ALexicalGoal = glgInputElementTemplateTail;
 end;

--- a/source/units/Goccia.NumberExponentiation.pas
+++ b/source/units/Goccia.NumberExponentiation.pas
@@ -13,15 +13,13 @@ uses
 
   NumberBits;
 
-function IsOddIntegralNumber(const AValue: Double): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsOddIntegralNumber(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := not IsNan(AValue) and not IsInfinite(AValue) and
     (Frac(AValue) = 0.0) and (Frac(AValue / 2.0) <> 0.0);
 end;
 
-function CanonicalNaN: Double;
-{$IFDEF FPC}inline;{$ENDIF}
+function CanonicalNaN: Double; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := BitsToDouble(CANONICAL_FLOAT64_NAN_BITS);
 end;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -154,38 +154,27 @@ type
     function SourceSpanAtPosition(const ALine,
       AColumn: Integer): TGocciaSourceSpan;
 
-    function IsAtEnd: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function Peek: TGocciaToken;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsAtEnd: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function Peek: TGocciaToken; {$IFDEF FPC}inline;{$ENDIF}
     function PeekWithLexicalGoal(
-      const ALexicalGoal: TGocciaLexicalGoal): TGocciaToken;
-      {$IFDEF FPC}inline;{$ENDIF}
-    function Previous: TGocciaToken;
-    {$IFDEF FPC}inline;{$ENDIF}
+      const ALexicalGoal: TGocciaLexicalGoal): TGocciaToken; {$IFDEF FPC}inline;{$ENDIF}
+    function Previous: TGocciaToken; {$IFDEF FPC}inline;{$ENDIF}
     function Advance: TGocciaToken;
     function AdvanceWithLexicalGoal(
       const ALexicalGoal: TGocciaLexicalGoal): TGocciaToken;
-    function Check(const ATokenType: TGocciaTokenType): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function Check(const ATokenType: TGocciaTokenType): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function CheckWithLexicalGoal(const ATokenType: TGocciaTokenType;
-      const ALexicalGoal: TGocciaLexicalGoal): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
-    function CheckNext(const ATokenType: TGocciaTokenType): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+      const ALexicalGoal: TGocciaLexicalGoal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function CheckNext(const ATokenType: TGocciaTokenType): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function CheckNextWithLexicalGoal(const ATokenType: TGocciaTokenType;
-      const ALexicalGoal: TGocciaLexicalGoal): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const ALexicalGoal: TGocciaLexicalGoal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function CheckNextIdentifierBindingWithLexicalGoal(
-      const ALexicalGoal: TGocciaLexicalGoal): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const ALexicalGoal: TGocciaLexicalGoal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function IsAwaitOperandStart: Boolean;
     function Match(const ATokenTypes: array of TGocciaTokenType): Boolean; overload;
-    function Match(const ATokenType: TGocciaTokenType): Boolean; overload;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function Match(const ATokenType: TGocciaTokenType): Boolean; overload; {$IFDEF FPC}inline;{$ENDIF}
     function MatchWithLexicalGoal(const ATokenType: TGocciaTokenType;
-      const ALexicalGoal: TGocciaLexicalGoal): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const ALexicalGoal: TGocciaLexicalGoal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function Consume(const ATokenType: TGocciaTokenType; const AMessage: string): TGocciaToken; overload;
     function Consume(const ATokenType: TGocciaTokenType; const AMessage, ASuggestion: string): TGocciaToken; overload;
     procedure ConsumeSemicolonOrASI(const AMessage, ASuggestion: string);
@@ -230,8 +219,7 @@ type
     function MatchContextualKeyword(const AKeyword: string): Boolean;
     function MatchContextualKeywordWithLexicalGoal(const AKeyword: string;
       const ALexicalGoal: TGocciaLexicalGoal): Boolean;
-    function DefaultLexicalGoal: TGocciaLexicalGoal;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function DefaultLexicalGoal: TGocciaLexicalGoal; {$IFDEF FPC}inline;{$ENDIF}
 
     // Expression parsing (private)
     function Conditional: TGocciaExpression;
@@ -381,8 +369,7 @@ type
     function ParseExpressionUnchecked: TGocciaExpression;
     function Expression: TGocciaExpression;
     function AtEnd: Boolean;
-    function GetWarning(const AIndex: Integer): TGocciaParserWarning;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetWarning(const AIndex: Integer): TGocciaParserWarning; {$IFDEF FPC}inline;{$ENDIF}
     procedure ApplyOptions(const AOptions: TGocciaParserOptions);
     function Options: TGocciaParserOptions;
     property WarningCount: Integer read FWarningCount;

--- a/source/units/Goccia.Profiler.pas
+++ b/source/units/Goccia.Profiler.pas
@@ -68,22 +68,16 @@ type
 
     procedure ResetCounts;
 
-    procedure RecordOpcode(const AOp: UInt8);
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure RecordScalarHit;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure RecordScalarMiss;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure RecordAllocation;
-    {$IFDEF FPC}inline;{$ENDIF}
+    procedure RecordOpcode(const AOp: UInt8); {$IFDEF FPC}inline;{$ENDIF}
+    procedure RecordScalarHit; {$IFDEF FPC}inline;{$ENDIF}
+    procedure RecordScalarMiss; {$IFDEF FPC}inline;{$ENDIF}
+    procedure RecordAllocation; {$IFDEF FPC}inline;{$ENDIF}
     // Shape system saturation events (cold paths; see Goccia.Values.Shape):
     // an object layout hitting the transition depth limit, and a realm
     // shape table reaching capacity. Both degrade caching silently, so the
     // profiler is the diagnostic surface for them.
-    procedure RecordShapeDepthLimit;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure RecordShapeTableSaturation;
-    {$IFDEF FPC}inline;{$ENDIF}
+    procedure RecordShapeDepthLimit; {$IFDEF FPC}inline;{$ENDIF}
+    procedure RecordShapeTableSaturation; {$IFDEF FPC}inline;{$ENDIF}
 
     function RegisterTemplate(const AName, ASourceFile: string;
       const ALine: Integer): Integer;
@@ -92,12 +86,9 @@ type
     procedure PopFunction(const AProfileIndex: Integer;
       const ATimestamp: Int64);
 
-    function GetOpcodeCount(const AOp: UInt8): Int64;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetOpcodePairCount(const APrev, ACur: UInt8): Int64;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetFunctionProfile(const AIndex: Integer): TGocciaFunctionProfile;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetOpcodeCount(const AOp: UInt8): Int64; {$IFDEF FPC}inline;{$ENDIF}
+    function GetOpcodePairCount(const APrev, ACur: UInt8): Int64; {$IFDEF FPC}inline;{$ENDIF}
+    function GetFunctionProfile(const AIndex: Integer): TGocciaFunctionProfile; {$IFDEF FPC}inline;{$ENDIF}
 
     property Mode: TGocciaProfileMode read FMode write FMode;
     property Enabled: Boolean read FEnabled write FEnabled;

--- a/source/units/Goccia.Realm.pas
+++ b/source/units/Goccia.Realm.pas
@@ -114,8 +114,7 @@ function RegisterRealmOwnedSlot(const AName: string): TGocciaRealmOwnedSlotId;
 // engine is initialized.  Production code paths that rely on intrinsics
 // (value constructors, ExposePrototype, InitializePrototype, ...) require a
 // realm to be present.
-function CurrentRealm: TGocciaRealm;
-{$IFDEF FPC}inline;{$ENDIF}
+function CurrentRealm: TGocciaRealm; {$IFDEF FPC}inline;{$ENDIF}
 
 // Set by TGocciaEngine.Initialize and TGocciaEngine.ResetRealm.  Tests and
 // other host code generally should not call this directly.
@@ -189,8 +188,7 @@ begin
   end;
 end;
 
-function CurrentRealm: TGocciaRealm;
-{$IFDEF FPC}inline;{$ENDIF}
+function CurrentRealm: TGocciaRealm; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := GCurrentRealm;
 end;

--- a/source/units/Goccia.RegExp.Compiler.pas
+++ b/source/units/Goccia.RegExp.Compiler.pas
@@ -818,8 +818,7 @@ begin
 end;
 
 procedure IncludeStartCheckLatin1(var ACheck: TRegExpStartCheck;
-  ACodePoint: Cardinal);
-  {$IFDEF FPC}inline;{$ENDIF}
+  ACodePoint: Cardinal); {$IFDEF FPC}inline;{$ENDIF}
 begin
   ACheck.Latin1Bits[ACodePoint shr 5] :=
     ACheck.Latin1Bits[ACodePoint shr 5] or (UInt32(1) shl (ACodePoint and 31));
@@ -2951,8 +2950,7 @@ begin
   end;
 end;
 
-function IsQuantifierChar(C: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsQuantifierChar(C: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (C = '*') or (C = '+') or (C = '?') or (C = '{');
 end;

--- a/source/units/Goccia.RegExp.VM.pas
+++ b/source/units/Goccia.RegExp.VM.pas
@@ -88,15 +88,13 @@ begin
   AMemo.Count := 0;
 end;
 
-procedure MemoEnsureAllocated(var AMemo: TMemoTable);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure MemoEnsureAllocated(var AMemo: TMemoTable); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Length(AMemo.Entries) = 0 then
     SetLength(AMemo.Entries, MEMO_INITIAL_CAPACITY);
 end;
 
-function MemoHash(APC, APos, ACapacity: Integer): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function MemoHash(APC, APos, ACapacity: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 var
   H: Cardinal;
 begin
@@ -205,8 +203,7 @@ begin
 end;
 
 function CharClassContains(const AClass: TRegExpCharClass;
-  ACodePoint: Cardinal): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  ACodePoint: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Hi: Integer;
   Index: Integer;
@@ -252,8 +249,7 @@ begin
   Result := False;
 end;
 
-function IsBasicWordChar(ACodePoint: Cardinal): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsBasicWordChar(ACodePoint: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ((ACodePoint >= Ord('a')) and (ACodePoint <= Ord('z'))) or
             ((ACodePoint >= Ord('A')) and (ACodePoint <= Ord('Z'))) or
@@ -262,8 +258,7 @@ begin
 end;
 
 function IsWordChar(ACodePoint: Cardinal; AUnicodeAware,
-  AIgnoreCase: Boolean): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  AIgnoreCase: Boolean): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if IsBasicWordChar(ACodePoint) then
     Exit(True);
@@ -273,30 +268,26 @@ begin
     AUnicodeAware, AIgnoreCase));
 end;
 
-function IsLineTerminator(ACodePoint: Cardinal): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsLineTerminator(ACodePoint: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACodePoint = $0A) or (ACodePoint = $0D) or
             (ACodePoint = $2028) or (ACodePoint = $2029);
 end;
 
-function IsHighSurrogate(ACodeUnit: Cardinal): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsHighSurrogate(ACodeUnit: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACodeUnit >= HIGH_SURROGATE_START) and
     (ACodeUnit <= HIGH_SURROGATE_END);
 end;
 
-function IsLowSurrogate(ACodeUnit: Cardinal): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsLowSurrogate(ACodeUnit: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACodeUnit >= LOW_SURROGATE_START) and
     (ACodeUnit <= LOW_SURROGATE_END);
 end;
 
 function SurrogatePairToCodePoint(const AHighSurrogate,
-  ALowSurrogate: Cardinal): Cardinal;
-  {$IFDEF FPC}inline;{$ENDIF}
+  ALowSurrogate: Cardinal): Cardinal; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := $10000 + ((AHighSurrogate - HIGH_SURROGATE_START) shl 10) +
     (ALowSurrogate - LOW_SURROGATE_START);
@@ -357,8 +348,7 @@ end;
 
 function ReadInputCodePoint(const AInput: TRegExpInput; APos: Integer;
   const AUnicode: Boolean; out ACodePoint: Cardinal;
-  out AWidth: Integer): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  out AWidth: Integer): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   CodeUnit: Cardinal;
 begin
@@ -471,8 +461,7 @@ begin
 end;
 
 function StartCheckMatchesLatin1Unit(const ACheck: TRegExpStartCheck;
-  ACodeUnit: Cardinal): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  ACodeUnit: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACodeUnit <= $FF) and
     ((ACheck.Latin1Bits[ACodeUnit shr 5] and
@@ -1323,8 +1312,7 @@ threadvar
   GRegExpInputMemoValid: Boolean;
 
 function TryGetRegExpInputMemo(const AInput: string;
-  out ADecodedInput: TRegExpInput): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  out ADecodedInput: TRegExpInput): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := GRegExpInputMemoValid and
     (Pointer(AInput) = Pointer(GRegExpInputMemoStr));
@@ -1336,8 +1324,7 @@ begin
 end;
 
 procedure GetRegExpInput(const AInput: string;
-  out ADecodedInput: TRegExpInput);
-  {$IFDEF FPC}inline;{$ENDIF}
+  out ADecodedInput: TRegExpInput); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if TryGetRegExpInputMemo(AInput, ADecodedInput) then
     Exit;

--- a/source/units/Goccia.Scope.pas
+++ b/source/units/Goccia.Scope.pas
@@ -129,14 +129,11 @@ type
     // binding map's entry version.  TDZ still raises.  Returns False on any
     // stale cache so the caller can fall back to the named lookup.
     function TryGetLexicalValueAt(const AEntryIndex: Integer;
-      const AVersion: Cardinal; out AValue: TGocciaValue): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const AVersion: Cardinal; out AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function HasLexicalBindingAt(const AEntryIndex: Integer;
-      const AVersion: Cardinal): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const AVersion: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function IsGlobalBuiltInObjectBindingAt(const AEntryIndex: Integer;
-      const AVersion: Cardinal): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const AVersion: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     // Named lookup that reports the own-lexical entry index and map version
     // for inline caching.  AEntryIndex is -1 when the value was resolved
     // through the global this-object, var bindings, or the parent chain —
@@ -159,8 +156,7 @@ type
       const AColumn: Integer = 0); virtual;
     procedure ResolveAssignmentTarget(const AName: string;
       out AObjectBinding: TGocciaObjectValue; out AScopeBinding: TGocciaScope); virtual;
-    function ContainsOwnLexicalBinding(const AName: string): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function ContainsOwnLexicalBinding(const AName: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function IsBuiltInBinding(const AName: string): Boolean;
     function Contains(const AName: string): Boolean; virtual;
     function GetOwnBindingNames: TGocciaStringArray; virtual;

--- a/source/units/Goccia.Semver.pas
+++ b/source/units/Goccia.Semver.pas
@@ -178,27 +178,23 @@ begin
   Result.RTL := False;
 end;
 
-function IsDigit(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsDigit(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AChar >= '0') and (AChar <= '9');
 end;
 
-function IsAlpha(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsAlpha(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ((AChar >= 'a') and (AChar <= 'z')) or
     ((AChar >= 'A') and (AChar <= 'Z'));
 end;
 
-function IsAlphaNumericDash(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsAlphaNumericDash(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := IsDigit(AChar) or IsAlpha(AChar) or (AChar = '-');
 end;
 
-function IsWhitespace(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsWhitespace(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AChar = ' ') or (AChar = #9) or (AChar = #10) or
     (AChar = #13);

--- a/source/units/Goccia.Temporal.Calendar.pas
+++ b/source/units/Goccia.Temporal.Calendar.pas
@@ -321,8 +321,7 @@ threadvar
   DangiLunisolarYearOffsetValid: Boolean;
   DangiLunisolarYearOffset: Integer;
 
-function ICUSucceeded(const AStatus: TICUErrorCode): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function ICUSucceeded(const AStatus: TICUErrorCode): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AStatus <= ICU_SUCCESS;
 end;
@@ -950,20 +949,17 @@ begin
     Result := '';
 end;
 
-function IsLunisolarCalendar(const ACalendarId: string): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsLunisolarCalendar(const ACalendarId: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACalendarId = 'chinese') or (ACalendarId = 'dangi');
 end;
 
-function IsUnsupportedTemporalCalendarConversion(const ACalendarId: string): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsUnsupportedTemporalCalendarConversion(const ACalendarId: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACalendarId = 'islamic') or (ACalendarId = 'islamic-rgsa');
 end;
 
-function LunisolarCalendarCode(const ACalendarId: string): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function LunisolarCalendarCode(const ACalendarId: string): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if ACalendarId = 'chinese' then
     Result := 1
@@ -974,8 +970,7 @@ begin
 end;
 
 function LunisolarCacheIndex(const ACalendarCode, AYear, AMonth,
-  ADay: Integer): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  ADay: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 var
   Hash: Int64;
 begin
@@ -987,8 +982,7 @@ begin
 end;
 
 function LunisolarDateToISOIndex(const ACalendarCode, AYear, AMonth,
-  ADay: Integer; const AMatchMonthCode, AIsLeapMonth: Boolean): Integer;
-  {$IFDEF FPC}inline;{$ENDIF}
+  ADay: Integer; const AMatchMonthCode, AIsLeapMonth: Boolean): Integer; {$IFDEF FPC}inline;{$ENDIF}
 var
   LeapCode: Integer;
 begin

--- a/source/units/Goccia.Temporal.DurationMath.pas
+++ b/source/units/Goccia.Temporal.DurationMath.pas
@@ -29,14 +29,12 @@ const
   MAX_EPOCH_NANOSECONDS_DECIMAL = '8640000000000000000000';
   MAX_TIME_DURATION_DECIMAL = '9007199254740991999999999';
 
-function BigInt(const AValue: Int64): TBigInteger;
-{$IFDEF FPC}inline;{$ENDIF}
+function BigInt(const AValue: Int64): TBigInteger; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := TBigInteger.FromInt64(AValue);
 end;
 
-function BigIntFromDecimal(const AValue: string): TBigInteger;
-{$IFDEF FPC}inline;{$ENDIF}
+function BigIntFromDecimal(const AValue: string): TBigInteger; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := TBigInteger.FromDecimalString(AValue);
 end;

--- a/source/units/Goccia.Temporal.Utils.pas
+++ b/source/units/Goccia.Temporal.Utils.pas
@@ -85,8 +85,7 @@ function CoerceToISOInstant(const AStr: string; out ADate: TTemporalDateRecord;
 function CoerceToISOYearMonth(const AStr: string; out AYear, AMonth: Integer): Boolean;
 function CoerceToISOMonthDay(const AStr: string; out AMonth, ADay: Integer): Boolean;
 
-function CompareIntegers(const A, B: Integer): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function CompareIntegers(const A, B: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 function CompareDates(const AYear1, AMonth1, ADay1, AYear2, AMonth2, ADay2: Integer): Integer;
 function CompareTimes(const AHour1, AMinute1, ASecond1, AMs1, AUs1, ANs1,
   AHour2, AMinute2, ASecond2, AMs2, AUs2, ANs2: Integer): Integer;

--- a/source/units/Goccia.Terminal.Colors.pas
+++ b/source/units/Goccia.Terminal.Colors.pas
@@ -15,8 +15,7 @@ const
   ANSI_RESET = #27'[0m';
 
 function IsColorTerminal: Boolean;
-function Colorize(const AText, AColor: string; const AUseColor: Boolean): string;
-{$IFDEF FPC}inline;{$ENDIF}
+function Colorize(const AText, AColor: string; const AUseColor: Boolean): string; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/units/Goccia.ThreadCleanupRegistry.pas
+++ b/source/units/Goccia.ThreadCleanupRegistry.pas
@@ -85,8 +85,7 @@ begin
     GCleanups[I]();
 end;
 
-function CleanupProceduresEqual(const ALeft; const ARight): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function CleanupProceduresEqual(const ALeft; const ARight): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := CompareMem(@ALeft, @ARight, SizeOf(TGocciaThreadvarCleanupProc));
 end;

--- a/source/units/Goccia.URI.pas
+++ b/source/units/Goccia.URI.pas
@@ -91,8 +91,7 @@ begin
 end;
 
 { Percent-encode a single byte as %XX (uppercase hex). }
-function PercentEncodeByte(const AByte: Byte): string;
-{$IFDEF FPC}inline;{$ENDIF}
+function PercentEncodeByte(const AByte: Byte): string; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := '%' + HEX_DIGITS[(AByte shr 4) + 1] + HEX_DIGITS[(AByte and $0F) + 1];
 end;
@@ -123,8 +122,7 @@ begin
 end;
 
 { Returns True if ACodePoint is a UTF-16 surrogate (U+D800..U+DFFF). }
-function IsSurrogate(const ACodePoint: Integer): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsSurrogate(const ACodePoint: Integer): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACodePoint >= $D800) and (ACodePoint <= $DFFF);
 end;
@@ -162,15 +160,13 @@ begin
 end;
 
 { Returns True if C is an ASCII hex digit. }
-function IsASCIIHexDigit(const C: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsASCIIHexDigit(const C: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (C in ['0'..'9', 'A'..'F', 'a'..'f']);
 end;
 
 { Parse a hex digit character to its numeric value. }
-function HexVal(const C: Char): Byte;
-{$IFDEF FPC}inline;{$ENDIF}
+function HexVal(const C: Char): Byte; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case C of
     '0'..'9': Result := Ord(C) - Ord('0');

--- a/source/units/Goccia.URL.Parser.pas
+++ b/source/units/Goccia.URL.Parser.pas
@@ -75,39 +75,33 @@ uses
 // Character helpers
 // ---------------------------------------------------------------------------
 
-function IsASCIIAlpha(const C: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsASCIIAlpha(const C: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (C in ['A'..'Z', 'a'..'z']);
 end;
 
-function IsASCIIDigit(const C: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsASCIIDigit(const C: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (C in ['0'..'9']);
 end;
 
-function IsASCIIAlphanumeric(const C: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsASCIIAlphanumeric(const C: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (C in ['A'..'Z', 'a'..'z', '0'..'9']);
 end;
 
-function IsASCIIHexDigit(const C: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsASCIIHexDigit(const C: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (C in ['0'..'9', 'A'..'F', 'a'..'f']);
 end;
 
-function IsASCIIWhitespace(const C: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsASCIIWhitespace(const C: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   // ASCII tab, LF, CR, space
   Result := (C = #9) or (C = #10) or (C = #13) or (C = ' ');
 end;
 
-function ASCIILower(const C: Char): Char;
-{$IFDEF FPC}inline;{$ENDIF}
+function ASCIILower(const C: Char): Char; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if C in ['A'..'Z'] then
     Result := Chr(Ord(C) + 32)
@@ -125,8 +119,7 @@ begin
       Result[I] := Chr(Ord(Result[I]) + 32);
 end;
 
-function HexVal(const C: Char): Byte;
-{$IFDEF FPC}inline;{$ENDIF}
+function HexVal(const C: Char): Byte; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case C of
     '0'..'9': Result := Ord(C) - Ord('0');
@@ -145,8 +138,7 @@ const
   HEX_DIGITS = '0123456789ABCDEF';
 
 // §1.3.1 percent-encode after encoding
-function PercentEncode(const AByte: Byte): string;
-{$IFDEF FPC}inline;{$ENDIF}
+function PercentEncode(const AByte: Byte): string; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := '%' + HEX_DIGITS[(AByte shr 4) + 1] + HEX_DIGITS[(AByte and $0F) + 1];
 end;
@@ -179,46 +171,40 @@ end;
 // WHATWG URL Standard §4.1 Percent-encode sets
 
 // C0 percent-encode set: U+0000–U+001F and > U+007E
-function InC0PercentEncodeSet(const B: Byte): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function InC0PercentEncodeSet(const B: Byte): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (B < $21) or (B > $7E);
 end;
 
 // Fragment percent-encode set: C0 + {space U+0020, " U+0022, < U+003C, > U+003E, ` U+0060}
-function InFragmentPercentEncodeSet(const B: Byte): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function InFragmentPercentEncodeSet(const B: Byte): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := InC0PercentEncodeSet(B) or
             (B = $20) or (B = $22) or (B = $3C) or (B = $3E) or (B = $60);
 end;
 
 // Query percent-encode set: C0 + {space, ", #, <, >}
-function InQueryPercentEncodeSet(const B: Byte): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function InQueryPercentEncodeSet(const B: Byte): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := InC0PercentEncodeSet(B) or
             (B = $20) or (B = $22) or (B = $23) or (B = $3C) or (B = $3E);
 end;
 
 // Special-query percent-encode set: query + {'}
-function InSpecialQueryPercentEncodeSet(const B: Byte): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function InSpecialQueryPercentEncodeSet(const B: Byte): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := InQueryPercentEncodeSet(B) or (B = $27);
 end;
 
 // Path percent-encode set: query + {?, `, {, }}
-function InPathPercentEncodeSet(const B: Byte): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function InPathPercentEncodeSet(const B: Byte): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := InQueryPercentEncodeSet(B) or
             (B = $3F) or (B = $60) or (B = $7B) or (B = $7D);
 end;
 
 // Userinfo percent-encode set: path + {/, :, ;, =, @, [, \, ], ^, |}
-function InUserinfoPercentEncodeSet(const B: Byte): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function InUserinfoPercentEncodeSet(const B: Byte): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := InPathPercentEncodeSet(B) or
             (B = $2F) or (B = $3A) or (B = $3B) or (B = $3D) or
@@ -227,8 +213,7 @@ begin
 end;
 
 // application/x-www-form-urlencoded percent-encode set (for form data)
-function InFormPercentEncodeSet(const B: Byte): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function InFormPercentEncodeSet(const B: Byte): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   // Everything except: * - . 0-9 A-Z _ a-z
   Result := not (

--- a/source/units/Goccia.Utils.Arrays.pas
+++ b/source/units/Goccia.Utils.Arrays.pas
@@ -9,8 +9,7 @@ uses
   Goccia.Values.Primitives;
 
 // ES2026 §7.3.6 CreateDataPropertyOrThrow(O, P, V) for array indices.
-procedure ArrayCreateDataProperty(const AObject: TGocciaObjectValue; const AIndex: Integer; const AValue: TGocciaValue);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure ArrayCreateDataProperty(const AObject: TGocciaObjectValue; const AIndex: Integer; const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/units/Goccia.Utils.pas
+++ b/source/units/Goccia.Utils.pas
@@ -10,23 +10,19 @@ uses
 
 // Int64 -> Double widening that avoids FPC Delphi-mode bit-pattern casts and
 // Single-precision expression promotion on some targets.
-function Int64ToDouble(const AValue: Int64): Double;
-{$IFDEF FPC}inline;{$ENDIF}
+function Int64ToDouble(const AValue: Int64): Double; {$IFDEF FPC}inline;{$ENDIF}
 
 // ES2026 §7.1.6 ToIntegerOrInfinity — extract integer arg with default.
 // Returns Trunc(ToNumber(AArgs[AIndex])) or ADefault if index out of range.
-function ToIntegerFromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer = 0; const ADefault: Integer = 0): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToIntegerFromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer = 0; const ADefault: Integer = 0): Integer; {$IFDEF FPC}inline;{$ENDIF}
 
 // Value-level variant of ToIntegerFromArgs: ES2026 §7.1.6 ToIntegerOrInfinity
 // saturated to Integer.  NaN → 0, ±∞ and out-of-range doubles → ±MaxInt.
-function ToIntegerValue(const AValue: TGocciaValue): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToIntegerValue(const AValue: TGocciaValue): Integer; {$IFDEF FPC}inline;{$ENDIF}
 
 // ES2026 §7.1.22 ToLength saturated to Integer: NaN and values ≤ 0 → 0,
 // values ≥ MaxInt (incl. +∞) → MaxInt, else truncate.
-function ToLengthValue(const AValue: TGocciaValue): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToLengthValue(const AValue: TGocciaValue): Integer; {$IFDEF FPC}inline;{$ENDIF}
 
 // Temporal §13.21 ToIntegerWithTruncation: throws RangeError for NaN/±∞
 // (also matches ECMA-402 §9.2.15 DefaultNumberOption's rejection of
@@ -47,8 +43,7 @@ function ToIntegerWithTruncation64Value(const AValue: TGocciaValue): Int64;
 // treats NaN as 0, matching ToIntegerOrInfinity's behaviour for the inputs
 // these methods accept (no Infinity propagation needed — callers clamp by
 // length anyway).
-function ToInteger64FromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer = 0; const ADefault: Int64 = 0): Int64;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToInteger64FromArgs(const AArgs: TGocciaArgumentsCollection; const AIndex: Integer = 0; const ADefault: Int64 = 0): Int64; {$IFDEF FPC}inline;{$ENDIF}
 
 // ES2026 §7.1.7 ToInt32(argument)
 //   1. Let number be ? ToNumber(argument).
@@ -63,33 +58,27 @@ function ToInteger64FromArgs(const AArgs: TGocciaArgumentsCollection; const AInd
 // `(undefined & undefined)` evaluate to ~ -2^63 on Linux x86_64 CI while
 // passing 0 on macOS arm64 — see test262 language/expressions/bitwise-*
 // /S11.10.*_A3_T1.4.js for the regression cluster this fixes.
-function ToInt32Value(const AValue: TGocciaValue): Int32;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToInt32Value(const AValue: TGocciaValue): Int32; {$IFDEF FPC}inline;{$ENDIF}
 
 // ES2026 §7.1.8 ToUint32(argument)
-function ToUint32Value(const AValue: TGocciaValue): Cardinal;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToUint32Value(const AValue: TGocciaValue): Cardinal; {$IFDEF FPC}inline;{$ENDIF}
 
 // JS Number → Int64 for host/FFI marshaling: NaN/±∞ → 0, saturates at the
 // Int64 limits, otherwise truncates toward zero.
-function ToInt64Value(const AValue: TGocciaValue): Int64;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToInt64Value(const AValue: TGocciaValue): Int64; {$IFDEF FPC}inline;{$ENDIF}
 
 // ES2026 §7.1.10 ToUint16(argument)
 // NaN, ±0, ±∞ → 0; otherwise truncate and reduce modulo 2^16.
-function ToUint16Value(const AValue: TGocciaValue): Word;
-{$IFDEF FPC}inline;{$ENDIF}
+function ToUint16Value(const AValue: TGocciaValue): Word; {$IFDEF FPC}inline;{$ENDIF}
 
 // ES2026 relative index normalization (used by slice, splice, at, with, copyWithin, fill, etc.)
 // If ARelative < 0, returns max(ALength + ARelative, 0); else min(ARelative, ALength).
-function NormalizeRelativeIndex(const ARelative, ALength: Integer): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function NormalizeRelativeIndex(const ARelative, ALength: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 
 // ES2026 §7.3.14 Call(F, V, argumentsList) — safely invoke any callable value.
 // Dispatches through TGocciaFunctionBase.Call or TGocciaClassValue.Call based on runtime type.
 function InvokeCallable(const ACallable: TGocciaValue; const AArgs: TGocciaArgumentsCollection;
-  const AThisValue: TGocciaValue): TGocciaValue;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AThisValue: TGocciaValue): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 

--- a/source/units/Goccia.VM.Registers.pas
+++ b/source/units/Goccia.VM.Registers.pas
@@ -36,78 +36,57 @@ type
   PGocciaRegister = ^TGocciaRegister;
   TGocciaRegisterArray = array of TGocciaRegister;
 
-function RegisterUndefined: TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterNull: TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterHole: TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterBoolean(const AValue: Boolean): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterInt(const AValue: Int64): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterFloat(const AValue: Double): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterFromDouble(const AValue: Double): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterObject(const AValue: TGocciaValue): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function ValueToRegister(const AValue: TGocciaValue): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterToValue(const ARegister: TGocciaRegister): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterToDouble(const ARegister: TGocciaRegister): Double;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterToBoolean(const ARegister: TGocciaRegister): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-function RegisterIsNumericScalar(const ARegister: TGocciaRegister): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
-procedure MarkRegisterReferences(const ARegister: TGocciaRegister);
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterUndefined: TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterNull: TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterHole: TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterBoolean(const AValue: Boolean): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterInt(const AValue: Int64): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterFloat(const AValue: Double): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterFromDouble(const AValue: Double): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterObject(const AValue: TGocciaValue): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function ValueToRegister(const AValue: TGocciaValue): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterToValue(const ARegister: TGocciaRegister): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterToDouble(const ARegister: TGocciaRegister): Double; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterToBoolean(const ARegister: TGocciaRegister): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+function RegisterIsNumericScalar(const ARegister: TGocciaRegister): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+procedure MarkRegisterReferences(const ARegister: TGocciaRegister); {$IFDEF FPC}inline;{$ENDIF}
 
 implementation
 
-function RegisterUndefined: TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterUndefined: TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result.Kind := grkUndefined;
 end;
 
-function RegisterNull: TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterNull: TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result.Kind := grkNull;
 end;
 
-function RegisterHole: TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterHole: TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result.Kind := grkHole;
 end;
 
-function RegisterBoolean(const AValue: Boolean): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterBoolean(const AValue: Boolean): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result.Kind := grkBoolean;
   Result.BoolValue := AValue;
 end;
 
-function RegisterInt(const AValue: Int64): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterInt(const AValue: Int64): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result.Kind := grkInt;
   Result.IntValue := AValue;
 end;
 
-function RegisterFloat(const AValue: Double): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterFloat(const AValue: Double): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result.Kind := grkFloat;
   Result.FloatValue := AValue;
 end;
 
-function RegisterFromDouble(const AValue: Double): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterFromDouble(const AValue: Double): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   // Build a register directly from a raw Double without ever allocating a heap
   // TGocciaNumberLiteralValue. Mirrors the number branch of VMValueToRegisterFast:
@@ -129,15 +108,13 @@ begin
   Result := RegisterFloat(AValue);
 end;
 
-function RegisterObject(const AValue: TGocciaValue): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterObject(const AValue: TGocciaValue): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result.Kind := grkObject;
   Result.ObjectValue := AValue;
 end;
 
-function ValueToRegister(const AValue: TGocciaValue): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function ValueToRegister(const AValue: TGocciaValue): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if not Assigned(AValue) or (AValue is TGocciaUndefinedLiteralValue) then
     Exit(RegisterUndefined);
@@ -161,8 +138,7 @@ begin
   Result := RegisterObject(AValue);
 end;
 
-function RegisterToValue(const ARegister: TGocciaRegister): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterToValue(const ARegister: TGocciaRegister): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case ARegister.Kind of
     grkUndefined:
@@ -195,8 +171,7 @@ begin
   end;
 end;
 
-function RegisterToDouble(const ARegister: TGocciaRegister): Double;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterToDouble(const ARegister: TGocciaRegister): Double; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case ARegister.Kind of
     grkInt:
@@ -208,8 +183,7 @@ begin
   end;
 end;
 
-function RegisterToBoolean(const ARegister: TGocciaRegister): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterToBoolean(const ARegister: TGocciaRegister): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case ARegister.Kind of
     grkUndefined, grkNull, grkHole:
@@ -227,14 +201,12 @@ begin
   end;
 end;
 
-function RegisterIsNumericScalar(const ARegister: TGocciaRegister): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function RegisterIsNumericScalar(const ARegister: TGocciaRegister): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ARegister.Kind in [grkInt, grkFloat];
 end;
 
-procedure MarkRegisterReferences(const ARegister: TGocciaRegister);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure MarkRegisterReferences(const ARegister: TGocciaRegister); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (ARegister.Kind = grkObject) and Assigned(ARegister.ObjectValue) then
     ARegister.ObjectValue.MarkReferences;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -206,45 +206,32 @@ type
     procedure EnsureRegisterCapacity(const ACount: Integer);
     procedure EnsureLocalCapacity(const ACount: Integer);
     function GetLocalCell(const AIndex: Integer): TGocciaBytecodeCell;
-    function GetLocalRegister(const AIndex: Integer): TGocciaRegister;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetRegister(const AIndex: Integer): TGocciaValue;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetRegisterFast(const AIndex: Integer): TGocciaValue;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure SetRegister(const AIndex: Integer; const AValue: TGocciaValue);
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure SetRegisterFast(const AIndex: Integer; const AValue: TGocciaValue);
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure SetRegisterRaw(const AIndex: Integer; const AValue: TGocciaRegister);
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetLocalRegister(const AIndex: Integer): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
+    function GetRegister(const AIndex: Integer): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
+    function GetRegisterFast(const AIndex: Integer): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
+    procedure SetRegister(const AIndex: Integer; const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
+    procedure SetRegisterFast(const AIndex: Integer; const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
+    procedure SetRegisterRaw(const AIndex: Integer; const AValue: TGocciaRegister); {$IFDEF FPC}inline;{$ENDIF}
     procedure InstallFunctionPrototype(const AFunction: TGocciaObjectValue;
       const AKind: TGocciaFunctionObjectIntrinsicKind);
-    function GetLocal(const AIndex: Integer): TGocciaValue;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetLocalFast(const AIndex: Integer): TGocciaValue;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure SetLocal(const AIndex: Integer; const AValue: TGocciaValue);
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure SetLocalFast(const AIndex: Integer; const AValue: TGocciaValue);
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure SetLocalRaw(const AIndex: Integer; const AValue: TGocciaRegister);
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetLocal(const AIndex: Integer): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
+    function GetLocalFast(const AIndex: Integer): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
+    procedure SetLocal(const AIndex: Integer; const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
+    procedure SetLocalFast(const AIndex: Integer; const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
+    procedure SetLocalRaw(const AIndex: Integer; const AValue: TGocciaRegister); {$IFDEF FPC}inline;{$ENDIF}
     function MatchesNullishKind(const AValue: TGocciaValue; const AKind: UInt8): Boolean;
     function TryGetArrayIndex(const AKey: TGocciaValue; out AIndex: Integer): Boolean;
     function TryGetArrayIndexRegister(const AKey: TGocciaRegister;
       out AIndex: Integer): Boolean;
     function KeyToPropertyName(const AKey: TGocciaValue): string;
     function KeyToPropertyNameRegister(const AKey: TGocciaRegister): string;
-    function TryResolveObjectKey(const AKeyReg: TGocciaRegister; out AResolved: TGocciaValue): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function TryResolveObjectKey(const AKeyReg: TGocciaRegister; out AResolved: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     // Shared computed-property-access cores. AProbeArrayIndex preserves the
     // historical per-receiver cascades: array/string receivers probe for an
     // array index, class/object receivers do not.
     function ClassifyPropertyKey(const AKeyReg: TGocciaRegister;
       const AProbeArrayIndex: Boolean): TGocciaPropertyKey;
-    function PropertyKeyName(const AKey: TGocciaPropertyKey): string;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function PropertyKeyName(const AKey: TGocciaPropertyKey): string; {$IFDEF FPC}inline;{$ENDIF}
     // Register parameters are passed BY VALUE deliberately: callers pass
     // FRegisters[..] slots, and ClassifyPropertyKey can run user code
     // (ToPropertyKey -> toString) that grows and reallocates the register
@@ -638,8 +625,7 @@ type
   end;
 
 function BytecodeFunctionIntrinsicKind(const ATemplate: TGocciaFunctionTemplate):
-  TGocciaFunctionObjectIntrinsicKind;
-  {$IFDEF FPC}inline;{$ENDIF}
+  TGocciaFunctionObjectIntrinsicKind; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Assigned(ATemplate) and ATemplate.IsAsync and ATemplate.IsGenerator then
     Result := foikAsyncGenerator
@@ -653,8 +639,7 @@ end;
 
 function DirectEvalBindingIsNonStrictImmutable(
   const ABinding: TGocciaDirectEvalBindingInfo;
-  const ATemplate: TGocciaFunctionTemplate): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ATemplate: TGocciaFunctionTemplate): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := ABinding.IsConst and
     (ABinding.IsEvalSyntheticArguments or
@@ -662,8 +647,7 @@ begin
       (ATemplate.Name <> '') and (ABinding.Name = ATemplate.Name)));
 end;
 
-procedure EnsureVMObjectPrototypeInitialized;
-{$IFDEF FPC}inline;{$ENDIF}
+procedure EnsureVMObjectPrototypeInitialized; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if TGocciaObjectValue.SharedObjectPrototype = nil then
     TGocciaObjectValue.InitializeSharedPrototype;
@@ -1561,8 +1545,7 @@ begin
 end;
 
 function VMIsPrototypeInChain(const AObj: TGocciaObjectValue;
-  const ATargetProto: TGocciaObjectValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ATargetProto: TGocciaObjectValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   CurrentProto: TGocciaObjectValue;
 begin
@@ -1577,8 +1560,7 @@ begin
 end;
 
 function VMHasSymbolPropertyInChain(const AObject: TGocciaObjectValue;
-  const ASymbol: TGocciaSymbolValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ASymbol: TGocciaSymbolValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Current: TGocciaObjectValue;
 begin
@@ -1593,8 +1575,7 @@ begin
 end;
 
 function VMGetOwnDataDescriptorValue(const AObject: TGocciaObjectValue;
-  const AName: string; out AValue: TGocciaValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AName: string; out AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Descriptor: TGocciaPropertyDescriptor;
 begin
@@ -1613,8 +1594,7 @@ begin
 end;
 
 function VMTrySetOwnWritableDataProperty(const AObject: TGocciaObjectValue;
-  const AName: string; const AValue: TGocciaValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AName: string; const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Descriptor: TGocciaPropertyDescriptor;
 begin
@@ -1633,8 +1613,7 @@ end;
 
 function VMTryGetCachedGlobalOwnDataProperty(
   const AObject: TGocciaObjectValue; const AEntryIndex: Integer;
-  const AVersion: Cardinal; out AValue: TGocciaValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AVersion: Cardinal; out AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Descriptor: TGocciaPropertyDescriptor;
 begin
@@ -1655,8 +1634,7 @@ end;
 
 function VMTryGetGlobalOwnDataPropertyFillCache(
   const AObject: TGocciaObjectValue; const AName: string;
-  out AEntryIndex: Integer; out AVersion: Cardinal): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  out AEntryIndex: Integer; out AVersion: Cardinal): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Descriptor: TGocciaPropertyDescriptor;
 begin
@@ -1677,8 +1655,7 @@ const
   GLOBAL_READ_OBJECT_BINDING_BUILTIN = 2;
 
 function VMGlobalObjectBindingCacheStillPrecedes(
-  const AScope: TGocciaScope; const ACache: PGocciaGlobalReadCacheEntry): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AScope: TGocciaScope; const ACache: PGocciaGlobalReadCacheEntry): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case ACache^.ObjectBindingKind of
     GLOBAL_READ_OBJECT_BINDING_VAR:
@@ -1693,8 +1670,7 @@ begin
   end;
 end;
 
-function VMValueToRegisterFast(const AValue: TGocciaValue): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMValueToRegisterFast(const AValue: TGocciaValue): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 var
   NumberValue: Double;
 begin
@@ -1734,8 +1710,7 @@ end;
 // so the OP_GET_PROP_CONST inline cache may serve them without going
 // through their virtual GetProperty path. Exact-class checks exclude every
 // subclass with overridden lookup semantics (proxies, exotic objects).
-function VMPropertyReadCacheableReceiver(const AObject: TObject): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMPropertyReadCacheableReceiver(const AObject: TObject): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AObject.ClassType = TGocciaObjectValue) or
     (AObject.ClassType = TGocciaVMLiteralObjectValue) or
@@ -1753,8 +1728,7 @@ end;
 // (TOrderedStringMap.Add on an existing key).
 function VMTryGetCachedOwnDataProperty(const AObject: TGocciaObjectValue;
   const ACache: PGocciaPropertyReadCacheEntry;
-  out AValue: TGocciaValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  out AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Descriptor: TGocciaPropertyDescriptor;
 begin
@@ -1841,8 +1815,7 @@ end;
 // prefix shape's covered entries stay valid as the holder map grows, and
 // the descriptor is re-read by entry index on every hit.
 function VMHolderShapeMatches(const AObject: TGocciaObjectValue;
-  const ACachedShape: Pointer): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ACachedShape: Pointer): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := Pointer(
     TGocciaShapedPropertyMap(AObject.Properties).EnsureShape) = ACachedShape;
@@ -1853,8 +1826,7 @@ end;
 // EnsureShape keeps returning the same prefix pointer, so pointer equality
 // alone cannot prove a name is still absent.
 function VMAbsenceShapeMatches(const AObject: TGocciaObjectValue;
-  const ACachedShape: Pointer): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ACachedShape: Pointer): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Map: TGocciaShapedPropertyMap;
   LevelShape: TGocciaShape;
@@ -1985,8 +1957,7 @@ end;
 
 function VMFillProtoReadCache(const AReceiver: TGocciaObjectValue;
   const AName: string; const ACache: PGocciaProtoReadCacheEntry;
-  out AValue: TGocciaValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  out AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := VMFillProtoReadCacheCore(AReceiver, AName, ACache, AValue);
   // Every decline advances the streak so sites that can never use this
@@ -1999,8 +1970,7 @@ begin
 end;
 
 function VMGetOwnDataDescriptorRegister(const AObject: TGocciaObjectValue;
-  const AName: string; out AValue: TGocciaRegister): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AName: string; out AValue: TGocciaRegister): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Value: TGocciaValue;
 begin
@@ -2015,8 +1985,7 @@ begin
 end;
 
 function VMSetOwnWritableDataDescriptorValue(const AObject: TGocciaObjectValue;
-  const AName: string; const AValue: TGocciaValue): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AName: string; const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   Descriptor: TGocciaPropertyDescriptor;
 begin
@@ -2036,8 +2005,7 @@ end;
 
 // ES2026 §7.3.6 CreateDataPropertyOrThrow(O, P, V)
 procedure DefineDataPropertyOnObject(const ATarget: TGocciaObjectValue;
-  const AName: string; const AValue: TGocciaValue);
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AName: string; const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (ATarget is TGocciaVMLiteralObjectValue) and
      TGocciaVMLiteralObjectValue(ATarget)
@@ -2049,8 +2017,7 @@ end;
 
 // ES2026 §7.3.6 CreateDataPropertyOrThrow(O, P, V) — symbol variant
 procedure DefineSymbolDataPropertyOnObject(const ATarget: TGocciaObjectValue;
-  const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue);
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 begin
   ATarget.CreateDataPropertyOrThrow(ASymbol, AValue);
 end;
@@ -2230,8 +2197,7 @@ begin
   end;
 end;
 
-function VMNumberValue(const AValue: Double): TGocciaNumberLiteralValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMNumberValue(const AValue: Double): TGocciaNumberLiteralValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Math.IsNaN(AValue) then
     Exit(TGocciaNumberLiteralValue.NaNValue);
@@ -2252,8 +2218,7 @@ begin
   Result := TGocciaNumberLiteralValue.Create(AValue);
 end;
 
-function VMNumberRegister(const AValue: Double): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMNumberRegister(const AValue: Double): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Math.IsNaN(AValue) or Math.IsInfinite(AValue) then
     Exit(RegisterObject(VMNumberValue(AValue)));
@@ -2269,14 +2234,12 @@ begin
   Result := RegisterFloat(AValue);
 end;
 
-function VMModuloRegister(const ALeft, ARight: Double): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMModuloRegister(const ALeft, ARight: Double): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := VMNumberRegister(NumberRemainder(ALeft, ARight));
 end;
 
-function VMPowerRegister(const ALeft, ARight: Double): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMPowerRegister(const ALeft, ARight: Double): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := VMNumberRegister(NumberExponentiation(ALeft, ARight));
 end;
@@ -2286,8 +2249,7 @@ end;
 // Delegates to Goccia.Types.Enforcement.EnforceStrictType so the interpreter
 // and bytecode VM share a single enforcement implementation.
 procedure VMStrictTypeCheckRegisterValue(const AValue: TGocciaValue;
-  const AExpected: TGocciaLocalType);
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AExpected: TGocciaLocalType); {$IFDEF FPC}inline;{$ENDIF}
 begin
   EnforceStrictType(AValue, AExpected);
 end;
@@ -2297,8 +2259,7 @@ end;
 // NaN, Infinity, negative zero, or fractional results.
 // Uses implicit Double assignment (not Int64 * 1.0) to avoid AArch64 FPC 3.2.2
 // codegen bug where Int64 * 1.0 produces wrong results near LongInt boundaries.
-function VMIntResult(const AValue: Int64): TGocciaRegister;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMIntResult(const AValue: Int64): TGocciaRegister; {$IFDEF FPC}inline;{$ENDIF}
 var
   FloatValue: Double;
 begin
@@ -2312,8 +2273,7 @@ begin
 end;
 
 function VMRegisterToStringFast(
-  const AValue: TGocciaRegister): TGocciaStringLiteralValue;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: TGocciaRegister): TGocciaStringLiteralValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case AValue.Kind of
     grkUndefined:
@@ -2344,8 +2304,7 @@ begin
 end;
 
 function VMGlobalConstructor(const AScope: TGocciaScope;
-  const AName: string): TGocciaValue;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AName: string): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 var
   RootScope: TGocciaScope;
 begin
@@ -2359,21 +2318,18 @@ begin
     Result := nil;
 end;
 
-function VMGlobalObjectConstructor(const AScope: TGocciaScope): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMGlobalObjectConstructor(const AScope: TGocciaScope): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := VMGlobalConstructor(AScope, CONSTRUCTOR_OBJECT);
 end;
 
-function VMGlobalFunctionConstructor(const AScope: TGocciaScope): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function VMGlobalFunctionConstructor(const AScope: TGocciaScope): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := VMGlobalConstructor(AScope, CONSTRUCTOR_FUNCTION);
 end;
 
 function VMBuiltinConstructorMatchValue(const AMatcher, ASubject: TGocciaValue;
-  const AScope: TGocciaScope; out AMatches: Boolean): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AScope: TGocciaScope; out AMatches: Boolean): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 var
   ObjectConstructor, ArrayConstructor, StringConstructor, NumberConstructor,
     BooleanConstructor, FunctionConstructor, BigIntConstructor,
@@ -2440,8 +2396,7 @@ begin
 end;
 
 function VMInstanceOfValue(const ALeft, ARight,
-  AObjectConstructor, AFunctionConstructor: TGocciaValue): TGocciaValue;
-  {$IFDEF FPC}inline;{$ENDIF}
+  AObjectConstructor, AFunctionConstructor: TGocciaValue): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   // Keep bytecode in lockstep with interpreter semantics for ES2026
   // §13.10.2, including @@hasInstance and non-callable target errors.
@@ -7902,8 +7857,7 @@ begin
 end;
 
 function RegisterMatchesNullishKind(const AValue: TGocciaRegister;
-  const AKind: UInt8): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AKind: UInt8): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case AKind of
     GOCCIA_NULLISH_MATCH_ANY:
@@ -9735,15 +9689,13 @@ begin
 end;
 
 function HasDynamicVarBinding(const AScope: TGocciaScope;
-  const AName: string): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AName: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := Assigned(FindDynamicVarBindingScope(AScope, AName));
 end;
 
 function HasOwnDynamicVarBinding(const AScope: TGocciaScope;
-  const AName: string): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AName: string): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := Assigned(AScope) and
     (AScope.ContainsOwnVarBinding(AName) or

--- a/source/units/Goccia.Values.ArrayBufferValue.pas
+++ b/source/units/Goccia.Values.ArrayBufferValue.pas
@@ -93,8 +93,7 @@ uses
 var
   GArrayBufferSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetArrayBufferShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetArrayBufferShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GArrayBufferSharedSlot))

--- a/source/units/Goccia.Values.ArrayValue.pas
+++ b/source/units/Goccia.Values.ArrayValue.pas
@@ -19,16 +19,12 @@ type
     // Helper methods for reducing duplication
     function ValidateArrayMethodCall(const AMethodName: string; const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue; const ARequiresCallback: Boolean = True): TGocciaValue;
-    function IsArrayHole(const AElement: TGocciaValue): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsArrayHole(const AElement: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
-    procedure ThrowError(const AMessage: string; const AArgs: array of const); overload;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure ThrowError(const AMessage: string); overload;
-    {$IFDEF FPC}inline;{$ENDIF}
+    procedure ThrowError(const AMessage: string; const AArgs: array of const); overload; {$IFDEF FPC}inline;{$ENDIF}
+    procedure ThrowError(const AMessage: string); overload; {$IFDEF FPC}inline;{$ENDIF}
     procedure ThrowError(const AMessage: string; const AArgs: array of const;
-      const ASuggestion: string); overload;
-      {$IFDEF FPC}inline;{$ENDIF}
+      const ASuggestion: string); overload; {$IFDEF FPC}inline;{$ENDIF}
   protected
     FElements: TGocciaValueList;
     FLength: Int64;
@@ -160,8 +156,7 @@ var
   GArrayPrototypeSlot: TGocciaRealmSlotId;
   GArrayMethodHostSlot: TGocciaRealmSlotId;
 
-function GetSharedArrayPrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedArrayPrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GArrayPrototypeSlot))
@@ -230,8 +225,7 @@ type
 function CollectSparseIndicesInRange(const AObj: TGocciaObjectValue;
   const AStartInclusive, AEndExclusive: Int64): TArray<Int64>; forward;
 
-function GetArrayCallbackThisArg(const AArgs: TGocciaArgumentsCollection): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetArrayCallbackThisArg(const AArgs: TGocciaArgumentsCollection): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if AArgs.Length > 1 then
     Result := AArgs.GetElement(1)
@@ -242,8 +236,7 @@ end;
 function InvokeArrayCallback(const ACallback: TGocciaValue;
   const ATypedCallback: TGocciaFunctionBase;
   const ACallArgs: TGocciaArgumentsCollection;
-  const AThisArg: TGocciaValue): TGocciaValue;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AThisArg: TGocciaValue): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 var
   PreviousContinuation: TGocciaGeneratorContinuation;
   CallbackRoot, ThisRoot: TGocciaTempRoot;

--- a/source/units/Goccia.Values.AsymmetricMatcher.pas
+++ b/source/units/Goccia.Values.AsymmetricMatcher.pas
@@ -17,10 +17,8 @@ type
     FSample: TGocciaValue;
     FInverse: Boolean;
   protected
-    function ApplyInverse(const AResult: Boolean): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure SetSample(const AValue: TGocciaValue);
-    {$IFDEF FPC}inline;{$ENDIF}
+    function ApplyInverse(const AResult: Boolean): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    procedure SetSample(const AValue: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
   public
     constructor Create(const ASample: TGocciaValue;
       const AInverse: Boolean = False);

--- a/source/units/Goccia.Values.BigIntValue.pas
+++ b/source/units/Goccia.Values.BigIntValue.pas
@@ -136,8 +136,7 @@ begin
   SetLength(FPrototypeMembers, 0);
 end;
 
-function GetSharedBigIntPrimitivePrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedBigIntPrimitivePrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GBigIntPrimitivePrototypeSlot))

--- a/source/units/Goccia.Values.BooleanObjectValue.pas
+++ b/source/units/Goccia.Values.BooleanObjectValue.pas
@@ -50,8 +50,7 @@ var
   GBooleanPrototypeSlot: TGocciaRealmSlotId;
   GBooleanMethodHostSlot: TGocciaRealmSlotId;
 
-function GetSharedBooleanPrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedBooleanPrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GBooleanPrototypeSlot))

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -71,14 +71,10 @@ type
     FNameDeleted: Boolean;
     FLengthDeleted: Boolean;
     FSourceText: string;
-    function GetPropertyGetter(const AName: string): TGocciaFunctionBase;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetPropertySetter(const AName: string): TGocciaFunctionBase;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetStaticPropertyGetter(const AName: string): TGocciaFunctionBase;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetStaticPropertySetter(const AName: string): TGocciaFunctionBase;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetPropertyGetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
+    function GetPropertySetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
+    function GetStaticPropertyGetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
+    function GetStaticPropertySetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
     function GetPrivatePropertyGetter(const AName: string): TGocciaFunctionBase;
     function GetPrivatePropertySetter(const AName: string): TGocciaFunctionBase;
   public
@@ -357,8 +353,7 @@ type
     procedure SetPrivateProperty(const AName: string; const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue; const AThrowIfExists: Boolean = False);
     function TryGetRawPrivateProperty(const AKey: string; out AValue: TGocciaValue): Boolean;
     procedure SetRawPrivateProperty(const AKey: string; const AValue: TGocciaValue);
-    function IsInstanceOf(const AClass: TGocciaClassValue): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsInstanceOf(const AClass: TGocciaClassValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     procedure InitializeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); virtual;
     procedure FinalizeNativeFromArguments(const AArguments: TGocciaArgumentsCollection); virtual;
     procedure MarkReferences; override;

--- a/source/units/Goccia.Values.DataViewValue.pas
+++ b/source/units/Goccia.Values.DataViewValue.pas
@@ -33,8 +33,7 @@ type
     procedure InitializePrototype;
     procedure SyncBufferData;
     function IsDetachedBuffer: Boolean;
-    function IsAutoLength: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function IsAutoLength: Boolean; {$IFDEF FPC}inline;{$ENDIF}
     function IsViewOutOfBounds: Boolean;
     function GetViewByteLength: Integer;
     function GetBufferByteLength: Integer;
@@ -109,8 +108,7 @@ uses
 var
   GDataViewSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetDataViewShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetDataViewShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GDataViewSharedSlot))

--- a/source/units/Goccia.Values.FFILibrary.pas
+++ b/source/units/Goccia.Values.FFILibrary.pas
@@ -69,8 +69,7 @@ uses
 var
   GFFILibrarySharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetFFILibraryShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetFFILibraryShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GFFILibrarySharedSlot))

--- a/source/units/Goccia.Values.FFIPointer.pas
+++ b/source/units/Goccia.Values.FFIPointer.pas
@@ -63,8 +63,7 @@ var
   GFFIPointerSharedSlot: TGocciaRealmOwnedSlotId;
   GFFINullPointerSlot: TGocciaRealmSlotId;
 
-function GetFFIPointerShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetFFIPointerShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GFFIPointerSharedSlot))

--- a/source/units/Goccia.Values.FinalizationRegistryValue.pas
+++ b/source/units/Goccia.Values.FinalizationRegistryValue.pas
@@ -67,8 +67,7 @@ uses
 var
   GFinalizationRegistrySharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetFinalizationRegistryShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetFinalizationRegistryShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GFinalizationRegistrySharedSlot))

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -262,14 +262,12 @@ begin
   GFunctionConstructRedirectHook := AHook;
 end;
 
-function IsRegisteredProxyValue(const AValue: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsRegisteredProxyValue(const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := Assigned(GProxyPredicate) and GProxyPredicate(AValue);
 end;
 
-function GetSharedFunctionPrototype: TGocciaFunctionSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedFunctionPrototype: TGocciaFunctionSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaFunctionSharedPrototype(CurrentRealm.GetSlot(GFunctionPrototypeSlot))
@@ -474,8 +472,7 @@ begin
   end;
 end;
 
-function IsCallableForHasInstance(const AValue: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsCallableForHasInstance(const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AValue.IsCallable;
 end;

--- a/source/units/Goccia.Values.HeadersValue.pas
+++ b/source/units/Goccia.Values.HeadersValue.pas
@@ -86,8 +86,7 @@ uses
 var
   GHeadersSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetHeadersShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetHeadersShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GHeadersSharedSlot))

--- a/source/units/Goccia.Values.IntlCollator.pas
+++ b/source/units/Goccia.Values.IntlCollator.pas
@@ -69,8 +69,7 @@ type
     procedure MarkReferences; override;
   end;
 
-function GetIntlCollatorShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlCollatorShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlCollatorSharedSlot))

--- a/source/units/Goccia.Values.IntlDateTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlDateTimeFormat.pas
@@ -146,8 +146,7 @@ type
     Millisecond: Integer;
   end;
 
-function GetIntlDateTimeFormatShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlDateTimeFormatShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlDateTimeFormatSharedSlot))

--- a/source/units/Goccia.Values.IntlDisplayNames.pas
+++ b/source/units/Goccia.Values.IntlDisplayNames.pas
@@ -52,8 +52,7 @@ uses
 var
   GIntlDisplayNamesSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetIntlDisplayNamesShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlDisplayNamesShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlDisplayNamesSharedSlot))

--- a/source/units/Goccia.Values.IntlDurationFormat.pas
+++ b/source/units/Goccia.Values.IntlDurationFormat.pas
@@ -91,8 +91,7 @@ uses
 var
   GIntlDurationFormatSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetIntlDurationFormatShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlDurationFormatShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlDurationFormatSharedSlot))

--- a/source/units/Goccia.Values.IntlListFormat.pas
+++ b/source/units/Goccia.Values.IntlListFormat.pas
@@ -54,8 +54,7 @@ uses
 var
   GIntlListFormatSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetIntlListFormatShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlListFormatShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlListFormatSharedSlot))

--- a/source/units/Goccia.Values.IntlLocale.pas
+++ b/source/units/Goccia.Values.IntlLocale.pas
@@ -89,8 +89,7 @@ uses
 var
   GIntlLocaleSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetIntlLocaleShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlLocaleShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlLocaleSharedSlot))

--- a/source/units/Goccia.Values.IntlNumberFormat.pas
+++ b/source/units/Goccia.Values.IntlNumberFormat.pas
@@ -100,8 +100,7 @@ type
     procedure MarkReferences; override;
   end;
 
-function GetIntlNumberFormatShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlNumberFormatShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlNumberFormatSharedSlot))
@@ -268,8 +267,7 @@ begin
   Result := (SubtagLength >= 3) and (SubtagLength <= 8);
 end;
 
-function IsAsciiAlpha(const C: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsAsciiAlpha(const C: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (C in ['A'..'Z']) or (C in ['a'..'z']);
 end;

--- a/source/units/Goccia.Values.IntlPluralRules.pas
+++ b/source/units/Goccia.Values.IntlPluralRules.pas
@@ -62,8 +62,7 @@ var
 const
   FRENCH_COMPACT_PLURAL_MANY_THRESHOLD = 1000000;
 
-function GetIntlPluralRulesShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlPluralRulesShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlPluralRulesSharedSlot))

--- a/source/units/Goccia.Values.IntlRelativeTimeFormat.pas
+++ b/source/units/Goccia.Values.IntlRelativeTimeFormat.pas
@@ -56,8 +56,7 @@ uses
 var
   GIntlRelativeTimeFormatSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetIntlRelativeTimeFormatShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlRelativeTimeFormatShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlRelativeTimeFormatSharedSlot))

--- a/source/units/Goccia.Values.IntlSegmenter.pas
+++ b/source/units/Goccia.Values.IntlSegmenter.pas
@@ -106,8 +106,7 @@ begin
   SetLength(FSegmentIteratorPrototypeMembers, 0);
 end;
 
-function GetIntlSegmenterShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlSegmenterShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlSegmenterSharedSlot))
@@ -115,8 +114,7 @@ begin
     Result := nil;
 end;
 
-function GetIntlSegmentsShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlSegmentsShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlSegmentsSharedSlot))
@@ -124,8 +122,7 @@ begin
     Result := nil;
 end;
 
-function GetIntlSegmentIteratorShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIntlSegmentIteratorShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GIntlSegmentIteratorSharedSlot))

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -133,8 +133,7 @@ var
   GIteratorConstructorSlot: TGocciaRealmSlotId;
   GIteratorMethodHostSlot: TGocciaRealmSlotId;
 
-function GetSharedIteratorPrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedIteratorPrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GIteratorPrototypeSlot))
@@ -142,8 +141,7 @@ begin
     Result := nil;
 end;
 
-function GetSharedIteratorConstructor: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedIteratorConstructor: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GIteratorConstructorSlot))
@@ -151,8 +149,7 @@ begin
     Result := nil;
 end;
 
-function GetSharedIteratorHelperPrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedIteratorHelperPrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GIteratorHelperPrototypeSlot))
@@ -160,8 +157,7 @@ begin
     Result := nil;
 end;
 
-function GetSharedWrapForValidIteratorPrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedWrapForValidIteratorPrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(
@@ -173,8 +169,7 @@ end;
 // The per-realm method host (Self from InitializePrototype) that the helper,
 // constructor, and static methods bind to.  Populated by InitializePrototype,
 // which every entry point calls via EnsurePrototypeInitialized first. #892
-function GetIteratorMethodHost: TGocciaIteratorValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetIteratorMethodHost: TGocciaIteratorValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaIteratorValue(CurrentRealm.GetSlot(GIteratorMethodHostSlot))

--- a/source/units/Goccia.Values.MapValue.pas
+++ b/source/units/Goccia.Values.MapValue.pas
@@ -89,8 +89,7 @@ uses
 var
   GMapSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetMapShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetMapShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GMapSharedSlot))

--- a/source/units/Goccia.Values.NumberObjectValue.pas
+++ b/source/units/Goccia.Values.NumberObjectValue.pas
@@ -383,8 +383,7 @@ begin
   Result := Sign + Mantissa + 'e' + ExponentSign + IntToStr(Exponent);
 end;
 
-function GetSharedNumberPrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedNumberPrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GNumberPrototypeSlot))

--- a/source/units/Goccia.Values.ObjectPropertyDescriptor.pas
+++ b/source/units/Goccia.Values.ObjectPropertyDescriptor.pas
@@ -26,24 +26,15 @@ type
   private
     FFlags: TPropertyFlags;
     FFields: TPropertyDescriptorFields;
-    function GetEnumerable: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetConfigurable: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetWritable: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetHasEnumerableField: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetHasConfigurableField: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetHasWritableField: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetHasValue: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetHasGet: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetHasSet: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetEnumerable: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetConfigurable: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetWritable: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetHasEnumerableField: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetHasConfigurableField: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetHasWritableField: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetHasValue: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetHasGet: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetHasSet: Boolean; {$IFDEF FPC}inline;{$ENDIF}
   public
     constructor Create(const AFlags: TPropertyFlags;
       const AFields: TPropertyDescriptorFields);
@@ -104,8 +95,7 @@ type
     FGetter: TGocciaValue;
     FSetter: TGocciaValue;
 
-    function GetWritable: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetWritable: Boolean; {$IFDEF FPC}inline;{$ENDIF}
   public
     constructor Create(const AGetter: TGocciaValue; const ASetter: TGocciaValue; const AFlags: TPropertyFlags);
     constructor CreatePartial(const AGetter: TGocciaValue;

--- a/source/units/Goccia.Values.OrderedValueMap.Test.pas
+++ b/source/units/Goccia.Values.OrderedValueMap.Test.pas
@@ -75,14 +75,12 @@ begin
   Test('RetainIterator/ReleaseIterator track active count', TestIteratorRetainReleaseCounter);
 end;
 
-function Num(const AValue: Double): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function Num(const AValue: Double): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := TGocciaNumberLiteralValue.Create(AValue);
 end;
 
-function Str(const AValue: string): TGocciaValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function Str(const AValue: string): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := TGocciaStringLiteralValue.Create(AValue);
 end;

--- a/source/units/Goccia.Values.OrderedValueMap.pas
+++ b/source/units/Goccia.Values.OrderedValueMap.pas
@@ -47,8 +47,7 @@ type
     // keys()/values()/entries()/forEach observe +0. SameValueZero already
     // treats -0 and +0 as equal for lookup, so callers only need this for the
     // value that gets stored.
-    class function CanonicalizeKey(const AKey: TGocciaValue): TGocciaValue; static;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function CanonicalizeKey(const AKey: TGocciaValue): TGocciaValue; static; {$IFDEF FPC}inline;{$ENDIF}
 
     // Insert or in-place update (keeping the original insertion position),
     // canonicalizing the key first.
@@ -65,14 +64,11 @@ type
     // entries appended during iteration are visited and deleted (tombstoned)
     // entries are skipped, matching the spec [[MapData]] iteration model.
     function NextEntry(var ACursor: Integer;
-      out AKey, AValue: TGocciaValue): Boolean;
-      {$IFDEF FPC}inline;{$ENDIF}
+      out AKey, AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
     // Bracket a live iteration so compaction cannot renumber entries mid-walk.
-    procedure RetainIterator;
-    {$IFDEF FPC}inline;{$ENDIF}
-    procedure ReleaseIterator;
-    {$IFDEF FPC}inline;{$ENDIF}
+    procedure RetainIterator; {$IFDEF FPC}inline;{$ENDIF}
+    procedure ReleaseIterator; {$IFDEF FPC}inline;{$ENDIF}
 
     property ActiveIterators: Integer read FActiveIterators;
   end;

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -80,8 +80,7 @@ type
   public
     constructor Create(const AValue: Boolean);
 
-    class function FromBoolean(const AValue: Boolean): TGocciaBooleanLiteralValue; static;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function FromBoolean(const AValue: Boolean): TGocciaBooleanLiteralValue; static; {$IFDEF FPC}inline;{$ENDIF}
     class function TrueValue: TGocciaBooleanLiteralValue;
     class function FalseValue: TGocciaBooleanLiteralValue;
 
@@ -101,16 +100,11 @@ type
   private
     FValue: Double;
 
-    function GetIsNaN: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetIsNegativeZero: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetIsInfinity: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetIsNegativeInfinity: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    function GetIsInfinite: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function GetIsNaN: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetIsNegativeZero: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetIsInfinity: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetIsNegativeInfinity: Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    function GetIsInfinite: Boolean; {$IFDEF FPC}inline;{$ENDIF}
 
     class var FZeroValue: TGocciaNumberLiteralValue;
     class var FOneValue: TGocciaNumberLiteralValue;
@@ -416,8 +410,7 @@ begin
 end;
 
 class function TGocciaBooleanLiteralValue.FromBoolean(
-  const AValue: Boolean): TGocciaBooleanLiteralValue;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AValue: Boolean): TGocciaBooleanLiteralValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if AValue then
     Result := TrueValue

--- a/source/units/Goccia.Values.PromiseValue.pas
+++ b/source/units/Goccia.Values.PromiseValue.pas
@@ -122,8 +122,7 @@ var
   GPromiseDefaultConstructorSlot: TGocciaRealmSlotId;
 
 function GetPromiseSharedForRealm(
-  const ARealm: TGocciaRealm): TGocciaSharedPrototype;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ARealm: TGocciaRealm): TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Assigned(ARealm) then
     Result := TGocciaSharedPrototype(ARealm.GetOwnedSlot(GPromiseSharedSlot))
@@ -131,15 +130,13 @@ begin
     Result := nil;
 end;
 
-function GetPromiseShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetPromiseShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := GetPromiseSharedForRealm(CurrentRealm);
 end;
 
 function GetPromiseDefaultConstructorForRealm(
-  const ARealm: TGocciaRealm): TGocciaValue;
-  {$IFDEF FPC}inline;{$ENDIF}
+  const ARealm: TGocciaRealm): TGocciaValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Assigned(ARealm) then
     Result := TGocciaValue(ARealm.GetSlot(GPromiseDefaultConstructorSlot))
@@ -148,8 +145,7 @@ begin
 end;
 
 procedure SetPromiseDefaultConstructorForRealm(const ARealm: TGocciaRealm;
-  const AConstructor: TGocciaValue);
-  {$IFDEF FPC}inline;{$ENDIF}
+  const AConstructor: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if Assigned(ARealm) then
     ARealm.SetSlot(GPromiseDefaultConstructorSlot, AConstructor);

--- a/source/units/Goccia.Values.ResponseValue.pas
+++ b/source/units/Goccia.Values.ResponseValue.pas
@@ -96,8 +96,7 @@ uses
 var
   GResponseSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetResponseShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetResponseShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GResponseSharedSlot))

--- a/source/units/Goccia.Values.SetValue.pas
+++ b/source/units/Goccia.Values.SetValue.pas
@@ -96,8 +96,7 @@ type
 var
   GSetSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetSetShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSetShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GSetSharedSlot))

--- a/source/units/Goccia.Values.Shape.pas
+++ b/source/units/Goccia.Values.Shape.pas
@@ -99,8 +99,7 @@ type
     FOwnerRealmIdentity: TGocciaRealmIdentity;
     FShape: TGocciaShape;
     FShapeEntryCount: Integer;
-    function OwnerRealmIsCurrent: Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    function OwnerRealmIsCurrent: Boolean; {$IFDEF FPC}inline;{$ENDIF}
   public
     constructor Create; overload;
     constructor Create(AInitialCapacity: Integer); overload;
@@ -124,8 +123,7 @@ type
 
 // Process-wide immutable sentinel compared by identity only; never part of
 // any realm's transition tree.
-function DictionaryShapeSentinel: TGocciaShape;
-{$IFDEF FPC}inline;{$ENDIF}
+function DictionaryShapeSentinel: TGocciaShape; {$IFDEF FPC}inline;{$ENDIF}
 
 // The current realm's shape table, created on first use through the
 // realm-owned slot. nil when no realm is current (engine bootstrap edges);
@@ -141,8 +139,7 @@ var
   GShapeTableSlot: TGocciaRealmOwnedSlotId;
   GDictionaryShape: TGocciaShape;
 
-function DictionaryShapeSentinel: TGocciaShape;
-{$IFDEF FPC}inline;{$ENDIF}
+function DictionaryShapeSentinel: TGocciaShape; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := GDictionaryShape;
 end;

--- a/source/units/Goccia.Values.SharedArrayBufferValue.pas
+++ b/source/units/Goccia.Values.SharedArrayBufferValue.pas
@@ -76,8 +76,7 @@ uses
 var
   GSharedArrayBufferSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetSharedArrayBufferShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedArrayBufferShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GSharedArrayBufferSharedSlot))

--- a/source/units/Goccia.Values.StringObjectValue.pas
+++ b/source/units/Goccia.Values.StringObjectValue.pas
@@ -156,8 +156,7 @@ end;
 var
   GStringPrototypeSlot: TGocciaRealmSlotId;
 
-function GetSharedStringPrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedStringPrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GStringPrototypeSlot))

--- a/source/units/Goccia.Values.SymbolValue.pas
+++ b/source/units/Goccia.Values.SymbolValue.pas
@@ -113,8 +113,7 @@ var
 threadvar
   GNextSymbolId: Integer;
 
-function GetSharedSymbolPrototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetSharedSymbolPrototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GSymbolPrototypeSlot))

--- a/source/units/Goccia.Values.TemporalDuration.pas
+++ b/source/units/Goccia.Values.TemporalDuration.pas
@@ -177,8 +177,7 @@ type
     HasAny: Boolean;
   end;
 
-function GetTemporalDurationShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTemporalDurationShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTemporalDurationSharedSlot))
@@ -329,8 +328,7 @@ begin
     Result := NumberToBigInteger(AValue.ToNumberLiteral.Value);
 end;
 
-function BigIntUnit(const AValue: Int64): TBigInteger;
-{$IFDEF FPC}inline;{$ENDIF}
+function BigIntUnit(const AValue: Int64): TBigInteger; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := TBigInteger.FromInt64(AValue);
 end;
@@ -404,8 +402,7 @@ begin
     .Add(D.FWeeksBig.Multiply(BigIntUnit(7)).Multiply(BigIntUnit(NANOSECONDS_PER_DAY)));
 end;
 
-function IsDurationDigit(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsDurationDigit(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AChar >= '0') and (AChar <= '9');
 end;
@@ -1310,28 +1307,24 @@ begin
   Result := tuNanosecond;
 end;
 
-function IsDurationCalendarUnit(const AUnit: TTemporalUnit): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsDurationCalendarUnit(const AUnit: TTemporalUnit): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AUnit in [tuYear, tuMonth, tuWeek];
 end;
 
-function DurationHasCalendarUnits(const D: TGocciaTemporalDurationValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function DurationHasCalendarUnits(const D: TGocciaTemporalDurationValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (not D.FYearsBig.IsZero) or
             (not D.FMonthsBig.IsZero) or
             (not D.FWeeksBig.IsZero);
 end;
 
-function DurationHasDateUnits(const D: TGocciaTemporalDurationValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function DurationHasDateUnits(const D: TGocciaTemporalDurationValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := DurationHasCalendarUnits(D) or (not D.FDaysBig.IsZero);
 end;
 
-function DurationFieldsIdentical(const AOne, ATwo: TGocciaTemporalDurationValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function DurationFieldsIdentical(const AOne, ATwo: TGocciaTemporalDurationValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AOne.FYearsBig.Compare(ATwo.FYearsBig) = 0) and
             (AOne.FMonthsBig.Compare(ATwo.FMonthsBig) = 0) and
@@ -1345,8 +1338,7 @@ begin
             (AOne.FNanosecondsBig.Compare(ATwo.FNanosecondsBig) = 0);
 end;
 
-function IsDurationDateUnit(const AUnit: TTemporalUnit): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsDurationDateUnit(const AUnit: TTemporalUnit): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AUnit in [tuYear, tuMonth, tuWeek, tuDay];
 end;
@@ -2295,8 +2287,7 @@ begin
   end;
 end;
 
-function DurationIsUndefinedValue(const AValue: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function DurationIsUndefinedValue(const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue);
 end;
@@ -2306,8 +2297,7 @@ var
   I: Integer;
   L, R: Char;
 
-  function UpperASCII(const AChar: Char): Char;
-  {$IFDEF FPC}inline;{$ENDIF}
+  function UpperASCII(const AChar: Char): Char; {$IFDEF FPC}inline;{$ENDIF}
   begin
     if (AChar >= 'a') and (AChar <= 'z') then
       Result := Chr(Ord(AChar) - Ord('a') + Ord('A'))

--- a/source/units/Goccia.Values.TemporalInstant.pas
+++ b/source/units/Goccia.Values.TemporalInstant.pas
@@ -69,16 +69,14 @@ uses
 var
   GTemporalInstantSharedSlot: TGocciaRealmOwnedSlotId;
 
-function InstantEpochSecond(const AEpochMilliseconds: Int64): Int64;
-{$IFDEF FPC}inline;{$ENDIF}
+function InstantEpochSecond(const AEpochMilliseconds: Int64): Int64; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AEpochMilliseconds div 1000;
   if (AEpochMilliseconds < 0) and (AEpochMilliseconds mod 1000 <> 0) then
     Dec(Result);
 end;
 
-function GetTemporalInstantShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTemporalInstantShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTemporalInstantSharedSlot))
@@ -119,8 +117,7 @@ begin
   Result := AValue.ToInt64;
 end;
 
-function InstantIsASCIIDigit(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function InstantIsASCIIDigit(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AChar >= '0') and (AChar <= '9');
 end;

--- a/source/units/Goccia.Values.TemporalPlainDate.pas
+++ b/source/units/Goccia.Values.TemporalPlainDate.pas
@@ -107,8 +107,7 @@ begin
   SetLength(FPrototypeMembers, 0);
 end;
 
-function GetTemporalPlainDateShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTemporalPlainDateShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTemporalPlainDateSharedSlot))

--- a/source/units/Goccia.Values.TemporalPlainDateTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainDateTime.pas
@@ -118,8 +118,7 @@ uses
 var
   GTemporalPlainDateTimeSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetTemporalPlainDateTimeShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTemporalPlainDateTimeShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTemporalPlainDateTimeSharedSlot))
@@ -235,8 +234,7 @@ begin
       Copy(Result, SecondPos + 2, Length(Result) - SecondPos - 1);
 end;
 
-procedure ConstrainPlainDateTimeLeapSecond(var ASecond: Integer);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure ConstrainPlainDateTimeLeapSecond(var ASecond: Integer); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if ASecond = 60 then
     ASecond := 59;

--- a/source/units/Goccia.Values.TemporalPlainMonthDay.pas
+++ b/source/units/Goccia.Values.TemporalPlainMonthDay.pas
@@ -78,8 +78,7 @@ uses
 var
   GTemporalPlainMonthDaySharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetTemporalPlainMonthDayShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTemporalPlainMonthDayShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTemporalPlainMonthDaySharedSlot))

--- a/source/units/Goccia.Values.TemporalPlainTime.pas
+++ b/source/units/Goccia.Values.TemporalPlainTime.pas
@@ -82,8 +82,7 @@ uses
 var
   GTemporalPlainTimeSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetTemporalPlainTimeShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTemporalPlainTimeShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTemporalPlainTimeSharedSlot))

--- a/source/units/Goccia.Values.TemporalPlainYearMonth.pas
+++ b/source/units/Goccia.Values.TemporalPlainYearMonth.pas
@@ -82,8 +82,7 @@ uses
 var
   GTemporalPlainYearMonthSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetTemporalPlainYearMonthShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTemporalPlainYearMonthShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTemporalPlainYearMonthSharedSlot))

--- a/source/units/Goccia.Values.TemporalZonedDateTime.pas
+++ b/source/units/Goccia.Values.TemporalZonedDateTime.pas
@@ -121,8 +121,7 @@ uses
 var
   GTemporalZonedDateTimeSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetTemporalZonedDateTimeShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTemporalZonedDateTimeShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTemporalZonedDateTimeSharedSlot))
@@ -182,8 +181,7 @@ function FormatOffsetString(const AOffsetSeconds: Integer): string; forward;
 procedure SplitEpochNanoseconds(const AEpochNanoseconds: TBigInteger;
   out AEpochMilliseconds: Int64; out ASubMillisecondNanoseconds: Integer); forward;
 
-function EpochMillisecondsToSeconds(const AEpochMilliseconds: Int64): Int64;
-{$IFDEF FPC}inline;{$ENDIF}
+function EpochMillisecondsToSeconds(const AEpochMilliseconds: Int64): Int64; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := AEpochMilliseconds div MILLISECONDS_PER_SECOND;
   if (AEpochMilliseconds < 0) and
@@ -191,8 +189,7 @@ begin
     Dec(Result);
 end;
 
-function IsUndefinedValue(const AValue: TGocciaValue): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsUndefinedValue(const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue);
 end;
@@ -202,8 +199,7 @@ var
   I: Integer;
   LeftChar, RightChar: Char;
 
-  function UpperASCII(const AChar: Char): Char;
-  {$IFDEF FPC}inline;{$ENDIF}
+  function UpperASCII(const AChar: Char): Char; {$IFDEF FPC}inline;{$ENDIF}
   begin
     if (AChar >= 'a') and (AChar <= 'z') then
       Result := Chr(Ord(AChar) - Ord('a') + Ord('A'))
@@ -334,8 +330,7 @@ begin
   end;
 end;
 
-function IsASCIIDigit(const AChar: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsASCIIDigit(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (AChar >= '0') and (AChar <= '9');
 end;
@@ -1072,8 +1067,7 @@ begin
     TryParseISODateTimeWithOffset(Normalized, DateRec, TimeRec, OffsetSeconds, TimeZone);
 end;
 
-function ClampTemporalInteger(const AValue, AMin, AMax: Integer): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function ClampTemporalInteger(const AValue, AMin, AMax: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if AValue < AMin then
     Result := AMin
@@ -1084,8 +1078,7 @@ begin
 end;
 
 procedure ConstrainTemporalTimeFields(var AHour, AMinute, ASecond,
-  AMillisecond, AMicrosecond, ANanosecond: Integer);
-  {$IFDEF FPC}inline;{$ENDIF}
+  AMillisecond, AMicrosecond, ANanosecond: Integer); {$IFDEF FPC}inline;{$ENDIF}
 begin
   AHour := ClampTemporalInteger(AHour, 0, 23);
   AMinute := ClampTemporalInteger(AMinute, 0, 59);
@@ -1759,8 +1752,7 @@ var
   Whole, FractionNs: TBigInteger;
   Y, Mo, W, Da, H, Mi, S, Ms, Us, Ns: TBigInteger;
 
-  function IsDigit(const AChar: Char): Boolean;
-  {$IFDEF FPC}inline;{$ENDIF}
+  function IsDigit(const AChar: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
   begin
     Result := (AChar >= '0') and (AChar <= '9');
   end;

--- a/source/units/Goccia.Values.TextDecoderValue.pas
+++ b/source/units/Goccia.Values.TextDecoderValue.pas
@@ -67,8 +67,7 @@ uses
 var
   GTextDecoderSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetTextDecoderShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTextDecoderShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTextDecoderSharedSlot))

--- a/source/units/Goccia.Values.TextEncoderValue.pas
+++ b/source/units/Goccia.Values.TextEncoderValue.pas
@@ -64,8 +64,7 @@ begin
   SetLength(FPrototypeMembers, 0);
 end;
 
-function GetTextEncoderShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTextEncoderShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTextEncoderSharedSlot))

--- a/source/units/Goccia.Values.ToPrimitive.pas
+++ b/source/units/Goccia.Values.ToPrimitive.pas
@@ -61,8 +61,7 @@ threadvar
   GHintNumber: TGocciaStringLiteralValue;
   GHintDefault: TGocciaStringLiteralValue;
 
-procedure EnsureHintValue(var ASlot: TGocciaStringLiteralValue; const AValue: string);
-{$IFDEF FPC}inline;{$ENDIF}
+procedure EnsureHintValue(var ASlot: TGocciaStringLiteralValue; const AValue: string); {$IFDEF FPC}inline;{$ENDIF}
 begin
   if not Assigned(ASlot) then
   begin

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -87,10 +87,8 @@ type
     procedure MarkReferences; override;
 
     class function BytesPerElement(const AKind: TGocciaTypedArrayKind): Integer;
-    class function IsFloatKind(const AKind: TGocciaTypedArrayKind): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
-    class function IsBigIntKind(const AKind: TGocciaTypedArrayKind): Boolean;
-    {$IFDEF FPC}inline;{$ENDIF}
+    class function IsFloatKind(const AKind: TGocciaTypedArrayKind): Boolean; {$IFDEF FPC}inline;{$ENDIF}
+    class function IsBigIntKind(const AKind: TGocciaTypedArrayKind): Boolean; {$IFDEF FPC}inline;{$ENDIF}
     class function KindName(const AKind: TGocciaTypedArrayKind): string;
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
     class procedure SetSharedPrototypeParent(const AParent: TGocciaObjectValue);
@@ -246,8 +244,7 @@ type
     procedure MarkReferences; override;
   end;
 
-function GetTypedArrayShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetTypedArrayShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GTypedArraySharedSlot))
@@ -255,8 +252,7 @@ begin
     Result := nil;
 end;
 
-function GetUint8Prototype: TGocciaObjectValue;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetUint8Prototype: TGocciaObjectValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaObjectValue(CurrentRealm.GetSlot(GUint8PrototypeSlot))

--- a/source/units/Goccia.Values.URLSearchParamsValue.pas
+++ b/source/units/Goccia.Values.URLSearchParamsValue.pas
@@ -122,8 +122,7 @@ uses
 var
   GURLSearchParamsSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetURLSearchParamsShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetURLSearchParamsShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GURLSearchParamsSharedSlot))

--- a/source/units/Goccia.Values.URLValue.pas
+++ b/source/units/Goccia.Values.URLValue.pas
@@ -154,8 +154,7 @@ begin
   SetLength(FPrototypeMembers, 0);
 end;
 
-function GetURLShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetURLShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GURLSharedSlot))

--- a/source/units/Goccia.Values.Uint8ArrayEncoding.pas
+++ b/source/units/Goccia.Values.Uint8ArrayEncoding.pas
@@ -97,8 +97,7 @@ begin
   TablesInitialized := True;
 end;
 
-function IsAsciiWhitespace(const ACh: Char): Boolean;
-{$IFDEF FPC}inline;{$ENDIF}
+function IsAsciiWhitespace(const ACh: Char): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
   Result := (ACh = #9) or (ACh = #10) or (ACh = #12) or (ACh = #13) or (ACh = ' ');
 end;
@@ -188,8 +187,7 @@ end;
 
 { ---- Hex helpers ---- }
 
-function HexCharToNibble(const ACh: Char): Integer;
-{$IFDEF FPC}inline;{$ENDIF}
+function HexCharToNibble(const ACh: Char): Integer; {$IFDEF FPC}inline;{$ENDIF}
 begin
   case ACh of
     '0'..'9': Result := Ord(ACh) - Ord('0');

--- a/source/units/Goccia.Values.WeakMapValue.pas
+++ b/source/units/Goccia.Values.WeakMapValue.pas
@@ -75,8 +75,7 @@ uses
 var
   GWeakMapSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetWeakMapShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetWeakMapShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GWeakMapSharedSlot))

--- a/source/units/Goccia.Values.WeakRefValue.pas
+++ b/source/units/Goccia.Values.WeakRefValue.pas
@@ -53,8 +53,7 @@ uses
 var
   GWeakRefSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetWeakRefShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetWeakRefShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GWeakRefSharedSlot))

--- a/source/units/Goccia.Values.WeakSetValue.pas
+++ b/source/units/Goccia.Values.WeakSetValue.pas
@@ -70,8 +70,7 @@ uses
 var
   GWeakSetSharedSlot: TGocciaRealmOwnedSlotId;
 
-function GetWeakSetShared: TGocciaSharedPrototype;
-{$IFDEF FPC}inline;{$ENDIF}
+function GetWeakSetShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if (CurrentRealm <> nil) then
     Result := TGocciaSharedPrototype(CurrentRealm.GetOwnedSlot(GWeakSetSharedSlot))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Keep all 529 FPC-only `inline` directives introduced by #989 on the same line as their routine declarations.
- Parse the complete conditional structurally, tolerating whitespace, case, and line splits around `{$IFDEF FPC}`, `inline;`, and `{$ENDIF}` before emitting the canonical one-line form.
- Scope normalization to routine declarations so directive-shaped text in comments and strings remains untouched.
- Preserve trailing comments after real inline directives while ignoring directive-shaped text inside trailing comments.
- Document the complete compiler-conditional routine-directive convention.
- This is a formatting-only follow-up to #989; it does not change runtime or compiler semantics.

## Testing

- [x] Verified no regressions and confirmed the bugfix in end-to-end JavaScript/TypeScript tests
  - 1,442 files and 11,517 tests pass in interpreter mode.
  - 1,442 files and 11,517 tests pass in bytecode mode.
  - `./format.pas --check` passes for all 428 formatter inputs.
  - All-source stress checks normalize all 529 directives from whitespace-heavy and fully split forms back to the canonical declaration-line form.
  - Focused checks preserve directive-shaped text in comments and string literals, retain comments after real directives, and accept `//` inside default strings and block comments.
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the bugfix in native Pascal tests (not required; no AST, scope, evaluator, or value semantics changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change (not required; source tokens and runtime behavior are unchanged)
