### PR TITLE
perf(json): recover UTF-16 parser hot paths

### DIFF
--- a/source/shared/JSONParser.Test.pas
+++ b/source/shared/JSONParser.Test.pas
@@ -55,6 +55,7 @@ type
     procedure TestParseStringBackslashEscape;
     procedure TestParseStringForwardSlashEscape;
     procedure TestParseStringQuoteEscape;
+    procedure TestParseStringUnicodeText;
     procedure TestParseStringUnicodeEscape;
     procedure TestParseStringSurrogatePair;
     procedure TestParseEmptyString;
@@ -71,6 +72,7 @@ type
     // Error cases: strict mode
     procedure TestErrorEmptyInput;
     procedure TestErrorTrailingGarbage;
+    procedure TestErrorUnescapedControlCharacter;
     procedure TestErrorUnterminatedString;
     procedure TestErrorUnterminatedObject;
     procedure TestErrorUnterminatedArray;
@@ -205,6 +207,7 @@ begin
   Test('Parse string with backslash escape', TestParseStringBackslashEscape);
   Test('Parse string with forward slash escape', TestParseStringForwardSlashEscape);
   Test('Parse string with quote escape', TestParseStringQuoteEscape);
+  Test('Parse unescaped Unicode string text', TestParseStringUnicodeText);
   Test('Parse string with unicode escape \u0041', TestParseStringUnicodeEscape);
   Test('Parse string with surrogate pair', TestParseStringSurrogatePair);
   Test('Parse empty string', TestParseEmptyString);
@@ -221,6 +224,7 @@ begin
   // Error cases: strict mode
   Test('Error on empty input', TestErrorEmptyInput);
   Test('Error on trailing garbage', TestErrorTrailingGarbage);
+  Test('Error on unescaped control character', TestErrorUnescapedControlCharacter);
   Test('Error on unterminated string', TestErrorUnterminatedString);
   Test('Error on unterminated object', TestErrorUnterminatedObject);
   Test('Error on unterminated array', TestErrorUnterminatedArray);
@@ -490,6 +494,22 @@ begin
   end;
 end;
 
+procedure TJSONParserTests.TestParseStringUnicodeText;
+var
+  Expected: string;
+  P: TRecordingJSONParser;
+begin
+  Expected := #$03BB#$D83D#$DE00;
+  P := TRecordingJSONParser.Create;
+  try
+    P.Parse('"' + Expected + '"');
+    Expect<Integer>(P.Events.Count).ToBe(1);
+    Expect<string>(P.Events[0]).ToBe('string:' + Expected);
+  finally
+    P.Free;
+  end;
+end;
+
 procedure TJSONParserTests.TestParseStringUnicodeEscape;
 var
   P: TRecordingJSONParser;
@@ -701,6 +721,26 @@ begin
     Raised := False;
     try
       P.Parse('42 extra');
+    except
+      on E: EJSONParseError do
+        Raised := True;
+    end;
+    Expect<Boolean>(Raised).ToBe(True);
+  finally
+    P.Free;
+  end;
+end;
+
+procedure TJSONParserTests.TestErrorUnescapedControlCharacter;
+var
+  P: TRecordingJSONParser;
+  Raised: Boolean;
+begin
+  P := TRecordingJSONParser.Create;
+  try
+    Raised := False;
+    try
+      P.Parse('"a' + #1 + 'b"');
     except
       on E: EJSONParseError do
         Raised := True;

--- a/source/shared/JSONParser.pas
+++ b/source/shared/JSONParser.pas
@@ -177,7 +177,8 @@ end;
 
 class function TAbstractJSONParser.IsASCIIDigit(const AChar: Char): Boolean;
 begin
-  Result := AChar in ['0'..'9'];
+  // FPC 3.2.2 lowers WideChar set membership through an ANSI conversion.
+  Result := (AChar >= '0') and (AChar <= '9');
 end;
 
 class function TAbstractJSONParser.IsASCIIHexDigit(const AChar: Char): Boolean;
@@ -515,7 +516,8 @@ begin
   DecimalPointSeen := False;
   ExponentSeen := False;
 
-  if PeekChar in ['-', '+'] then
+  // Keep ASCII WideChar checks direct for the same reason as IsASCIIDigit.
+  if (PeekChar = '-') or (PeekChar = '+') then
   begin
     SignText := ReadChar;
     if (SignText = '+') and not Supports(jpcAllowLeadingPlusSign) then
@@ -547,7 +549,7 @@ begin
     if not IsAtEnd and IsASCIIDigit(PeekChar) then
       RaiseParseError('Invalid number format');
   end
-  else if not IsAtEnd and (PeekChar in ['1'..'9']) then
+  else if not IsAtEnd and (PeekChar >= '1') and (PeekChar <= '9') then
   begin
     while not IsAtEnd and IsASCIIDigit(PeekChar) do
       NumStr := NumStr + ReadChar;
@@ -569,11 +571,11 @@ begin
         NumStr := NumStr + ReadChar;
   end;
 
-  if not IsAtEnd and (PeekChar in ['e', 'E']) then
+  if not IsAtEnd and ((PeekChar = 'e') or (PeekChar = 'E')) then
   begin
     ExponentSeen := True;
     NumStr := NumStr + ReadChar;
-    if not IsAtEnd and (PeekChar in ['+', '-']) then
+    if not IsAtEnd and ((PeekChar = '+') or (PeekChar = '-')) then
       NumStr := NumStr + ReadChar;
     if IsAtEnd or not IsASCIIDigit(PeekChar) then
       RaiseParseError('Invalid number format in exponent');

--- a/source/shared/JSONParser.pas
+++ b/source/shared/JSONParser.pas
@@ -122,6 +122,7 @@ implementation
 
 uses
   NumericText,
+  StringBuffer,
   TextEncoding,
   TextSemantics;
 
@@ -694,18 +695,36 @@ end;
 
 function TAbstractJSONParser.ParseString(const AQuote: Char): string;
 var
-  Text: string;
+  Buffer: TStringBuffer;
   Ch: Char;
+  StartPosition: Integer;
 begin
   ExpectChar(AQuote);
-  Text := '';
+
+  StartPosition := FPosition;
+  while FPosition <= FLength do
+  begin
+    Ch := FText[FPosition];
+    if Ch = AQuote then
+    begin
+      Result := Copy(FText, StartPosition, FPosition - StartPosition);
+      Inc(FPosition);
+      Exit;
+    end;
+    if (Ch = '\') or (Ord(Ch) < 32) then
+      Break;
+    Inc(FPosition);
+  end;
+  FPosition := StartPosition;
+
+  Buffer := TStringBuffer.Create;
 
   while not IsAtEnd do
   begin
     Ch := ReadChar;
     if Ch = AQuote then
     begin
-      Result := Text;
+      Result := Buffer.ToString;
       Exit;
     end;
 
@@ -720,36 +739,36 @@ begin
       Ch := ReadChar;
       case Ch of
         '"':
-          Text := Text + '"';
+          Buffer.AppendChar('"');
         '''':
           if Supports(jpcAllowExtendedStringEscapes) or (AQuote = '''') then
-            Text := Text + ''''
+            Buffer.AppendChar('''')
           else
             RaiseParseError('Invalid escape character: \' + Ch);
         '\':
-          Text := Text + '\';
+          Buffer.AppendChar('\');
         '/':
-          Text := Text + '/';
+          Buffer.AppendChar('/');
         'b':
-          Text := Text + #8;
+          Buffer.AppendChar(#8);
         'f':
-          Text := Text + #12;
+          Buffer.AppendChar(#12);
         'n':
-          Text := Text + #10;
+          Buffer.AppendChar(#10);
         'r':
-          Text := Text + #13;
+          Buffer.AppendChar(#13);
         't':
-          Text := Text + #9;
+          Buffer.AppendChar(#9);
         'u':
-          Text := Text + ParseUnicodeEscape;
+          Buffer.Append(ParseUnicodeEscape);
         'v':
           if Supports(jpcAllowExtendedStringEscapes) then
-            Text := Text + #11
+            Buffer.AppendChar(#11)
           else
             RaiseParseError('Invalid escape character: \' + Ch);
         'x':
           if Supports(jpcAllowExtendedStringEscapes) then
-            Text := Text + ParseHexEscape(2)
+            Buffer.Append(ParseHexEscape(2))
           else
             RaiseParseError('Invalid escape character: \' + Ch);
         '0':
@@ -758,7 +777,7 @@ begin
             begin
               if not IsAtEnd and IsASCIIDigit(PeekChar) then
                 RaiseParseError('Invalid escape character: \' + PeekChar);
-              Text := Text + #0;
+              Buffer.AppendChar(#0);
             end
             else
               RaiseParseError('Invalid escape character: \' + Ch);
@@ -770,7 +789,7 @@ begin
             RaiseParseError('Invalid escape character: \' + Ch);
       else
         if Supports(jpcAllowExtendedStringEscapes) then
-          Text := Text + Ch
+          Buffer.AppendChar(Ch)
         else
           RaiseParseError('Invalid escape character: \' + Ch);
       end;
@@ -780,7 +799,7 @@ begin
     else if Ord(Ch) < 32 then
       RaiseParseError('Unescaped control character in string')
     else
-      Text := Text + Ch;
+      Buffer.AppendChar(Ch);
   end;
 
   RaiseParseError('Unterminated string');


### PR DESCRIPTION
## Summary

- Scan ordinary unescaped JSON strings directly and copy the source slice once instead of growing a UnicodeString one character at a time.
- Keep escape and validation semantics on the existing parser path, using `TStringBuffer` for escaped strings.
- Replace number-parser WideChar set-membership checks with equivalent direct ASCII comparisons; FPC 3.2.2 otherwise lowers these checks through `fpc_uchar_to_char` and `iconv` on x86-64.
- Add focused native coverage for unescaped UTF-16 text and the control-character fallback boundary.
- Keep exact decimal conversion, structural UTF-16 overhead, and local-register/T4 work out of this PR because profiling identifies them as separate mechanisms.
- Related to #862.

## Testing

- [x] Verified no regressions in end-to-end JavaScript tests: `./build.pas --clean testrunner`, `./build/GocciaTestRunner tests`, and `./build/GocciaTestRunner tests --mode=bytecode` (1,442 files, 11,519 tests, 25,742 assertions in each mode).
- [x] Documentation not required: this changes internal parser mechanics without changing the public API or behavior.
- [x] Verified the native `JSONParser.Test` suite on macOS arm64 and Ubuntu x86-64 (54/54 passing on both).
- [x] Verified formatting with `./format.pas --check` (429 files).
- [x] Confirmed the performance recovery on Ubuntu 25.10 x86-64 with FPC 3.2.2 production bytecode binaries, QuickJS 2026-06-04, 15 interleaved samples per engine, matching checksums, and ADR 0087 IQR statistics.

### Measurements

Current `c477011e` versus the string fast path, IQR-filtered medians:

| Target | Main | Patched | Delta | Main CV | Patched CV |
|---|---:|---:|---:|---:|---:|
| JSON parse only | 120.614 ms | 91.533 ms | -24.11% | 10.05% | 4.14% |
| Reconstructed JSON roundtrip | 96.069 ms | 80.355 ms | -16.36% | 10.05% | 3.92% |
| Escaped-string parse control | 33.141 ms | 30.017 ms | -9.43% | 3.00% | 4.37% |
| JSON stringify control | 48.893 ms | 49.965 ms | +2.19% | 13.19% | 3.94% |

The string fix reduces parse-only retired instructions from 1,065,647,274 to 770,802,416 (-27.67%), branches from 145,668,284 to 107,413,247 (-26.26%), and branch mispredicts from 3,285,568 to 2,995,097 (-8.84%).

Same-commit string-patch versus direct-ASCII comparisons, IQR-filtered medians:

| Target | String patch | Combined | Delta | Baseline CV | Combined CV |
|---|---:|---:|---:|---:|---:|
| Integer-only JSON parse | 144.921 ms | 99.925 ms | -31.05% | 0.57% | 0.67% |
| Decimal-only JSON parse | 444.808 ms | 410.697 ms | -7.67% | 1.08% | 1.30% |
| JSON parse only | 82.775 ms | 78.898 ms | -4.68% | 0.92% | 0.89% |
| Reconstructed JSON roundtrip | 72.707 ms | 71.208 ms | -2.06% | 0.59% | 0.78% |
| Structure-only control | 162.627 ms | 163.723 ms | +0.67% | 1.84% | 0.76% |

Callgrind confirms the second mechanism: the integer-only probe falls from 398,062,860 to 271,508,200 retired instructions (-31.79%). Direct comparison with the pre-regression parent leaves integer parsing +9.34%, while exact decimal conversion remains +349.14% and structure-only parsing +40.64%; those residual gaps are not bundled into this PR.

Fresh CI same-runner `main` versus PR measurements confirm transfer to the repository benchmark suite:

| `benchmarks/json.js` | Interpreted | Bytecode |
|---|---:|---:|
| Parse simple object | +30.4% | +30.3% |
| Parse nested object | +33.5% | +36.7% |
| Parse array of objects | +28.2% | +24.8% |
| Parse large flat object | +29.4% | +30.5% |
| Parse then stringify | +14.5% | +24.0% |
| Stringify then parse | +21.3% | +23.3% |

The pinned AWFY `Json` row moves only +0.73%, confirming it is not a substitute for the missing audit kernel. All 49 PR checks pass, including test262 (52,219/52,328 pass, 99.8%, no new non-timeout failures).
