### PR TITLE
perf(compiler): avoid redundant this property moves

### DIFF
--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -121,6 +121,7 @@ Recent VM cleanup and optimization work has focused on reducing per-instruction 
 - use unchecked template access in the dispatch loop where bounds are already guaranteed
 - fuse `Number - Int16` as `OP_SUB_NUM_IMM` and conditional `Number <= Int16` as `OP_JUMP_IF_NUM_NOT_LTE_IMM` only when the compiler proves the source is an ECMAScript Number; these instructions remove literal-load and branch dispatches rather than merely replacing a generic arithmetic dispatch
 - retain a static named import's linked module namespace in its local/upvalue slot: `OP_IMPORT` scales with declarations, while repeated identifier reads use `OP_GET_IMPORT_BINDING` to dereference the cached live binding identity without repeating module-loader lookup
+- read standalone `this` properties directly from a non-captured local register, preserving the derived-constructor guard while avoiding a temporary-register move; captured, top-level, and method-call receiver paths retain their existing lowering
 - keep fast register access limited to proven hot/simple paths; local-slot and complex property paths should only move to fast access when they stay correct and measurably improve throughput
 - the register, local-cell, and argument window fills are GC-safety/correctness critical (the GC marks the whole live window): they are deliberately retained rather than trimmed
 

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -4639,6 +4639,9 @@ procedure CompileMember(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaMemberExpression; const ADest: UInt16);
 var
   ObjReg, IdxReg, BaseReg, SuperReg, KeyReg: UInt16;
+  LocalIdx: Integer;
+  ObjectRegisterAllocated: Boolean;
+  Local: TGocciaCompilerLocal;
   PropIdx: UInt16;
   EndJump, JumpIndex: Integer;
   NullishJumps: TGocciaCompilerJumpArray;
@@ -4688,10 +4691,28 @@ begin
     Exit;
   end;
 
-  ObjReg := ACtx.Scope.AllocateRegister;
   NullishJumpCount := 0;
-  CompileExpressionWithOptionalChainJumps(ACtx, AExpr.ObjectExpr, ObjReg,
-    NullishJumps, NullishJumpCount);
+  ObjectRegisterAllocated := True;
+  if AExpr.ObjectExpr is TGocciaThisExpression then
+  begin
+    LocalIdx := ACtx.Scope.ResolveLocal(KEYWORD_THIS);
+    if LocalIdx >= 0 then
+    begin
+      Local := ACtx.Scope.GetLocal(LocalIdx);
+      if not Local.IsCaptured then
+      begin
+        EmitDerivedThisInitializedCheck(ACtx);
+        ObjReg := Local.Slot;
+        ObjectRegisterAllocated := False;
+      end;
+    end;
+  end;
+  if ObjectRegisterAllocated then
+  begin
+    ObjReg := ACtx.Scope.AllocateRegister;
+    CompileExpressionWithOptionalChainJumps(ACtx, AExpr.ObjectExpr, ObjReg,
+      NullishJumps, NullishJumpCount);
+  end;
 
   if AExpr.Optional then
     AddOptionalChainJump(ACtx, NullishJumps, NullishJumpCount, ObjReg);
@@ -4715,7 +4736,8 @@ begin
     PatchJumpTarget(ACtx, EndJump);
   end;
 
-  ACtx.Scope.FreeRegister;
+  if ObjectRegisterAllocated then
+    ACtx.Scope.FreeRegister;
 end;
 
 procedure CompileConditional(const ACtx: TGocciaCompilationContext;

--- a/source/units/Goccia.Compiler.Test.pas
+++ b/source/units/Goccia.Compiler.Test.pas
@@ -74,6 +74,8 @@ type
     procedure TestCompileArithmetic;
     procedure TestCompileVariable;
     procedure TestCompileFunction;
+    procedure TestThisPropertyReadUsesLocalRegister;
+    procedure TestThisPropertyReadRetainsDerivedGuard;
     procedure TestStaticImportLoadsScaleWithDeclarations;
     procedure TestBinaryRoundTrip;
     procedure TestBinaryRoundTripClosedNumericSelfCall;
@@ -130,6 +132,10 @@ begin
   Test('Compile arithmetic', TestCompileArithmetic);
   Test('Compile variable', TestCompileVariable);
   Test('Compile function', TestCompileFunction);
+  Test('this property read uses local register',
+    TestThisPropertyReadUsesLocalRegister);
+  Test('this property read retains derived-constructor guard',
+    TestThisPropertyReadRetainsDerivedGuard);
   Test('Static import loads scale with declarations',
     TestStaticImportLoadsScaleWithDeclarations);
   Test('Binary round-trip', TestBinaryRoundTrip);
@@ -572,6 +578,55 @@ begin
   try
     Expect<Boolean>(Assigned(Module)).ToBe(True);
     Expect<Boolean>(Module.TopLevel.FunctionCount > 0).ToBe(True);
+  finally
+    Module.Free;
+  end;
+end;
+
+procedure TTestCompiler.TestThisPropertyReadUsesLocalRegister;
+var
+  Module: TGocciaBytecodeModule;
+  Func: TGocciaFunctionTemplate;
+begin
+  Module := CompileSource(
+    'const holder = {' +
+    '  value: 42,' +
+    '  read() { return this.value; }' +
+    '};');
+  try
+    Func := FindFunctionWithOp(Module.TopLevel, OP_GET_PROP_CONST);
+    Expect<Boolean>(Assigned(Func)).ToBe(True);
+    if Assigned(Func) then
+    begin
+      Expect<Integer>(CountOp(Func, OP_GET_PROP_CONST)).ToBe(1);
+      Expect<Integer>(CountOp(Func, OP_MOVE)).ToBe(0);
+    end;
+  finally
+    Module.Free;
+  end;
+end;
+
+procedure TTestCompiler.TestThisPropertyReadRetainsDerivedGuard;
+var
+  Module: TGocciaBytecodeModule;
+  Func: TGocciaFunctionTemplate;
+begin
+  Module := CompileSource(
+    'class Base {}' +
+    'class Derived extends Base {' +
+    '  constructor() {' +
+    '    this.value;' +
+    '    super();' +
+    '  }' +
+    '}');
+  try
+    Func := FindFunctionWithOp(Module.TopLevel, OP_GET_PROP_CONST);
+    Expect<Boolean>(Assigned(Func)).ToBe(True);
+    if Assigned(Func) then
+    begin
+      Expect<Boolean>(CountOp(Func, OP_JUMP_IF_TRUE) > 0).ToBe(True);
+      Expect<Boolean>(CountOp(Func, OP_THROW) > 0).ToBe(True);
+    end;
   finally
     Module.Free;
   end;


### PR DESCRIPTION
## Summary

- Read standalone `this` property receivers directly from their non-captured local register instead of copying them through a temporary.
- Preserve the derived-constructor initialization guard; captured, top-level, optional, wide-register, and method-call receiver paths retain their existing semantics and ownership.
- Reduce deterministic bytecode dispatch counts on affected AWFY workloads: Havlak 540,600,722 → 504,871,273 (-6.61%), Richards 11,617,813 → 10,668,357 (-8.17%), and DeltaBlue 38,790 → 36,427 (-6.09%).
- Related to #862; this does not close the umbrella throughput issue.

## Testing

- [x] Verified no regressions and confirmed the change in end-to-end JavaScript tests: `./build/GocciaTestRunner tests` and `./build/GocciaTestRunner tests --mode=bytecode` (1,454 files, 11,580 tests, 25,916 assertions in each mode)
- [x] Updated documentation in `docs/bytecode-vm.md`
- [x] Optional: Verified native Pascal compiler coverage (49/49), including direct-register lowering and retained derived-constructor guard emission
- [x] Optional: Verified benchmark coverage with same-runner amd64/FPC 3.2.2 production binaries and checksum agreement. In 30 order-controlled samples per workload, Richards median improved 864.831ms → 857.583ms (-0.84%) and DeltaBlue 5.678ms → 5.623ms (-0.98%); both engine orders favored the candidate. Five Havlak pairs were noisy (paired median +1.0%, independent medians -2.9%), so no Havlak wall-clock gain is claimed. CI-pinned QuickJS 2026-06-04 measured 4.11s median on Havlak.
- [x] `./format.pas --check`
- [x] Clean test-runner build and bundler smoke: `./build.pas --clean testrunner`, `./build.pas bundler`, `./build/GocciaBundler examples/basic.js --output=/tmp/goccia-862-basic.gbc`