### PR TITLE
fix(bytecode): preserve module lexical captures

### DIFF
--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -2812,8 +2812,14 @@ begin
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, Slot, AValueReg, 0));
     if Local.IsCaptured then
       EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
-    EmitExportBindingUpdates(ACtx, Local.ExportNames,
-      Local.ExportNameCount, Slot);
+    // A linked module's persistent environment is initialized after the
+    // destructured value has been staged in its compiler local. Publishing an
+    // export first would initialize that environment binding too early, making
+    // the subsequent declaration look like a redeclaration. The enclosing
+    // export statement publishes the initialized binding immediately after.
+    if not (ACtx.PreinitializedTopLevelFunctions and Local.IsGlobalBacked) then
+      EmitExportBindingUpdates(ACtx, Local.ExportNames,
+        Local.ExportNameCount, Slot);
     Exit;
   end;
 

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -4238,6 +4238,7 @@ var
   BindingName: string;
   IsNamedDefaultFunction: Boolean;
   IsNamedDefaultClass: Boolean;
+  UsePreinitializedBinding: Boolean;
 begin
   BindingName := AStmt.LocalName;
   IsNamedDefaultFunction := (BindingName <> GOCCIA_DEFAULT_EXPORT_BINDING) and
@@ -4247,6 +4248,12 @@ begin
     (AStmt.Expression is TGocciaClassExpression) and
     (TGocciaClassExpression(AStmt.Expression).ClassDefinition.Name =
     BindingName);
+  // Only declaration-form default functions are instantiated during linking;
+  // assignment expressions initialize *default* during module evaluation.
+  UsePreinitializedBinding := AStmt.IsDirectDeclaration and
+    ACtx.PreinitializedTopLevelFunctions and
+    (ACtx.Scope.Depth = 0) and
+    (AStmt.Expression is TGocciaFunctionExpression);
   LocalIdx := ACtx.Scope.ResolveLocal(BindingName);
   if (LocalIdx >= 0) and
      (ACtx.Scope.GetLocal(LocalIdx).Depth = ACtx.Scope.Depth) then
@@ -4263,7 +4270,12 @@ begin
   end;
 
   FuncCount := ACtx.Template.FunctionCount;
-  if (AStmt.Expression is TGocciaClassExpression) and
+  if UsePreinitializedBinding then
+  begin
+    NameIdx := ACtx.Template.AddConstantString(BindingName);
+    EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, Slot, NameIdx));
+  end
+  else if (AStmt.Expression is TGocciaClassExpression) and
      (TGocciaClassExpression(AStmt.Expression).ClassDefinition.Name = '') then
     CompileClassExpression(ACtx,
       TGocciaClassExpression(AStmt.Expression).ClassDefinition, Slot,
@@ -4294,7 +4306,8 @@ begin
   if (LocalIdx >= 0) and ACtx.Scope.GetLocal(LocalIdx).IsCaptured then
     EmitInstruction(ACtx, EncodeABx(OP_SET_LOCAL, Slot, UInt16(Slot)));
 
-  if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) then
+  if ACtx.GlobalBackedTopLevel and (ACtx.Scope.Depth = 0) and
+     not UsePreinitializedBinding then
     EmitGlobalDefine(ACtx, Slot, BindingName,
       not (IsNamedDefaultFunction or IsNamedDefaultClass));
 

--- a/source/units/Goccia.Compiler.pas
+++ b/source/units/Goccia.Compiler.pas
@@ -1222,7 +1222,7 @@ begin
     if FGlobalBackedTopLevel then
       MarkTopLevelGlobalBackedLocals(FCurrentScope);
     Ctx := BuildContext;
-    if FGlobalBackedTopLevel then
+    if FGlobalBackedTopLevel and not FPreinitializedTopLevelFunctions then
       EmitGlobalLexicalPredeclarations(Ctx, FCurrentScope,
         PredeclaredLexicalStart);
     for PredeclaredLexicalIndex := PredeclaredLexicalStart to

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -1986,7 +1986,8 @@ begin
       if ExportDefaultDecl.IsDirectDeclaration and
          (ExportDefaultDecl.Expression is TGocciaFunctionExpression) then
       begin
-        Value := ExportDefaultDecl.Expression.Evaluate(AContext);
+        Value := EvaluateFunctionExpression(TGocciaFunctionExpression(
+          ExportDefaultDecl.Expression), AContext, False);
         if (Value is TGocciaFunctionValue) and
            (TGocciaFunctionValue(Value).Name = '') then
           TGocciaFunctionValue(Value).Name := KEYWORD_DEFAULT;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -57,7 +57,10 @@ function EvaluateObjectMethodDefinition(
 function EvaluateGetter(const AGetterExpression: TGocciaGetterExpression; const AContext: TGocciaEvaluationContext; const ASuperClass: TGocciaValue = nil; const AAsMethod: Boolean = False): TGocciaValue;
 function EvaluateSetter(const ASetterExpression: TGocciaSetterExpression; const AContext: TGocciaEvaluationContext; const ASuperClass: TGocciaValue = nil; const AAsMethod: Boolean = False): TGocciaValue;
 function EvaluateArrowFunction(const AArrowFunctionExpression: TGocciaArrowFunctionExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
-function EvaluateFunctionExpression(const AFunctionExpression: TGocciaFunctionExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateFunctionExpression(
+  const AFunctionExpression: TGocciaFunctionExpression;
+  const AContext: TGocciaEvaluationContext;
+  const ABindOwnName: Boolean = True): TGocciaValue;
 function EvaluateBlock(const ABlockStatement: TGocciaBlockStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 function EvaluateIf(const AIfStatement: TGocciaIfStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 function EvaluateTry(const ATryStatement: TGocciaTryStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
@@ -1112,7 +1115,7 @@ begin
   if not Assigned(FuncExpr) then
     Exit;
 
-  Value := FuncExpr.Evaluate(AContext);
+  Value := EvaluateFunctionExpression(FuncExpr, AContext, False);
   if (TGarbageCollector.Instance <> nil) then
     TGarbageCollector.Instance.AddTempRoot(Value);
   try
@@ -2951,7 +2954,8 @@ begin
     begin
       FuncDecl := FunctionsToInitialize[I];
       Name := FuncDecl.Name;
-      FunctionValue := FuncDecl.FunctionExpression.Evaluate(FunctionContext);
+      FunctionValue := EvaluateFunctionExpression(FuncDecl.FunctionExpression,
+        FunctionContext, False);
       if (TGarbageCollector.Instance <> nil) then
         TGarbageCollector.Instance.AddTempRoot(FunctionValue);
       try
@@ -7016,7 +7020,10 @@ begin
     TGocciaFunctionValue(Result).SourceText := AArrowFunctionExpression.SourceText;
 end;
 
-function EvaluateFunctionExpression(const AFunctionExpression: TGocciaFunctionExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
+function EvaluateFunctionExpression(
+  const AFunctionExpression: TGocciaFunctionExpression;
+  const AContext: TGocciaEvaluationContext;
+  const ABindOwnName: Boolean): TGocciaValue;
 var
   Statements: TObjectList<TGocciaASTNode>;
   ClosureScope: TGocciaScope;
@@ -7037,8 +7044,10 @@ begin
   end;
 
   // ES2026 §15.2.5: Named function expressions get an intermediate scope
-  // with a read-only binding of the function name visible inside the body
-  if AFunctionExpression.Name <> '' then
+  // with a read-only binding of the function name visible inside the body.
+  // Declaration instantiation passes False so the body resolves the mutable
+  // declaration binding in the enclosing environment instead.
+  if ABindOwnName and (AFunctionExpression.Name <> '') then
   begin
     NameScope := TGocciaFunctionNameScope.Create(AContext.Scope,
       AFunctionExpression.Name);

--- a/source/units/Goccia.Executor.Bytecode.pas
+++ b/source/units/Goccia.Executor.Bytecode.pas
@@ -121,7 +121,11 @@ begin
   AProgramConsumed := False;
   Compiler := TGocciaCompiler.Create(AContext.CurrentFilePath);
   try
-    Compiler.GlobalBackedTopLevel := False;
+    // ES2026 §16.2.1.7.3.1 InitializeEnvironment: module declarations
+    // live in the linked Module Environment Record. Keep bytecode top-level
+    // locals backed by that preinitialized scope so hoisted function objects
+    // created during linking observe later let/const initialization and writes.
+    Compiler.GlobalBackedTopLevel := True;
     Compiler.AsyncTopLevel := AProgram.HasTopLevelAwait;
     Compiler.PreinitializedTopLevelFunctions := True;
     Compiler.StrictTypes := FStrictTypes;

--- a/source/units/Goccia.Modules.Loader.pas
+++ b/source/units/Goccia.Modules.Loader.pas
@@ -1603,7 +1603,8 @@ var
           if ExportDefaultDecl.IsDirectDeclaration and
              (ExportDefaultDecl.Expression is TGocciaFunctionExpression) then
           begin
-            Value := ExportDefaultDecl.Expression.Evaluate(Context);
+            Value := EvaluateFunctionExpression(TGocciaFunctionExpression(
+              ExportDefaultDecl.Expression), Context, False);
             if (Value is TGocciaFunctionValue) and
                (TGocciaFunctionValue(Value).Name = '') then
               TGocciaFunctionValue(Value).Name := KEYWORD_DEFAULT;

--- a/tests/language/modules/hoisted-function-import-capture/helpers/module-default-declaration.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/module-default-declaration.js
@@ -1,0 +1,4 @@
+export default function mutableDefaultFunction() {
+  mutableDefaultFunction = "changed";
+  return "initial";
+}

--- a/tests/language/modules/hoisted-function-import-capture/helpers/module-lexical-bindings.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/module-lexical-bindings.js
@@ -1,0 +1,36 @@
+const constValue = "const-ready";
+let letValue = "let-ready";
+let reassignedLetValue;
+
+reassignedLetValue = "let-reassigned";
+
+export function readConst() {
+  return constValue;
+}
+
+export function readLet() {
+  return letValue;
+}
+
+export function readReassignedLet() {
+  return reassignedLetValue;
+}
+
+export function setLet(value) {
+  letValue = value;
+}
+
+function readViaExportList() {
+  return `${constValue}:${letValue}`;
+}
+
+export { readViaExportList };
+
+export const arrowReadsConst = () => constValue;
+export const expressionReadsLet = function () {
+  return letValue;
+};
+
+export default (function () {
+  return constValue;
+});

--- a/tests/language/modules/hoisted-function-import-capture/helpers/module-lexical-cycle-a.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/module-lexical-cycle-a.js
@@ -1,0 +1,12 @@
+import {
+  linkedFunctionMatches,
+  observedCycleRead,
+} from "./module-lexical-cycle-b.js";
+
+const cycleValue = "cycle-ready";
+
+export function readCycleValue() {
+  return cycleValue;
+}
+
+export { linkedFunctionMatches, observedCycleRead };

--- a/tests/language/modules/hoisted-function-import-capture/helpers/module-lexical-cycle-b.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/module-lexical-cycle-b.js
@@ -1,0 +1,16 @@
+import { readCycleValue } from "./module-lexical-cycle-a.js";
+
+const linkedReadCycleValue = readCycleValue;
+let observedCycleRead = "no error";
+
+try {
+  readCycleValue();
+} catch (error) {
+  observedCycleRead = error.name;
+}
+
+function linkedFunctionMatches() {
+  return linkedReadCycleValue === readCycleValue;
+}
+
+export { linkedFunctionMatches, observedCycleRead };

--- a/tests/language/modules/hoisted-function-import-capture/module-lexical-bindings.js
+++ b/tests/language/modules/hoisted-function-import-capture/module-lexical-bindings.js
@@ -1,0 +1,53 @@
+/*---
+description: Imported module functions capture initialized module lexical bindings
+features: [modules, compat-function]
+---*/
+
+import defaultExpressionReadsConst, {
+  arrowReadsConst,
+  expressionReadsLet,
+  readConst,
+  readLet,
+  readReassignedLet,
+  readViaExportList,
+  setLet,
+} from "./helpers/module-lexical-bindings.js";
+import mutableDefaultFunction from "./helpers/module-default-declaration.js";
+import {
+  linkedFunctionMatches,
+  observedCycleRead,
+  readCycleValue,
+} from "./helpers/module-lexical-cycle-a.js";
+
+describe("imported module functions capture module lexical bindings", () => {
+  test("directly exported functions read const and let bindings", () => {
+    expect(readConst()).toBe("const-ready");
+    expect(readLet()).toBe("let-ready");
+    expect(readReassignedLet()).toBe("let-reassigned");
+    setLet("let-updated");
+    expect(readLet()).toBe("let-updated");
+    setLet("let-ready");
+  });
+
+  test("functions exported through an export list read lexical bindings", () => {
+    expect(readViaExportList()).toBe("const-ready:let-ready");
+  });
+
+  test("arrow and function expression exports remain correct", () => {
+    expect(arrowReadsConst()).toBe("const-ready");
+    expect(expressionReadsLet()).toBe("let-ready");
+    expect(defaultExpressionReadsConst()).toBe("const-ready");
+    expect(defaultExpressionReadsConst.name).toBe("default");
+  });
+
+  test("named default declarations retain their mutable module binding", () => {
+    expect(mutableDefaultFunction()).toBe("initial");
+    expect(mutableDefaultFunction).toBe("changed");
+  });
+
+  test("cyclic reads preserve TDZ and initialize for later calls", () => {
+    expect(observedCycleRead).toBe("ReferenceError");
+    expect(readCycleValue()).toBe("cycle-ready");
+    expect(linkedFunctionMatches()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Execute bytecode module bodies against their already-linked module environment so hoisted function declarations observe later module-level let and const initialization and writes.
- Preserve link-time function identity, TDZ behavior in cycles, default-function exports, and destructured export initialization order.
- Distinguish link-instantiated default declarations from default assignment expressions, and give declaration-instantiated functions their mutable outer declaration binding rather than a named-expression self-binding.
- Add end-to-end coverage for direct exports, export lists, mutable and immutable bindings, arrows, function/default expressions, mutable named default declarations, and cyclic module graphs.
- Public language and documentation surfaces are unchanged.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
  - ./build/GocciaTestRunner tests --no-progress (11,677/11,677; 26,033 assertions)
  - ./build/GocciaTestRunner tests --mode=bytecode --no-progress (11,677/11,677; 26,033 assertions)
  - focused module lexical/default-binding regression in both modes (15/15; 28 assertions)
  - test262 language/module-code/** (599/599)
  - test262 language/expressions/dynamic-import/** (all 18 PR-regressed default-binding cases restored; one pre-existing steady-state failure remains)
- [ ] Updated documentation (not needed: this restores documented ECMAScript module semantics)
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
  - ./build.pas tests (all Pascal test targets built)
  - Goccia.Compiler.Test (50/50)
  - Goccia.VM.Test (14/14)
  - Goccia.Modules.ContentProvider.Test (15/15)
  - Goccia.Modules.Configuration.Test (5/5)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change (not applicable: correctness-only module initialization change)

Additional gates: ./build.pas --clean testrunner loaderbare; ./format.pas --check; bun run scripts/check-test-structure.ts; git diff --check; pre-commit hooks.