### PR TITLE
feat(testing): add async mock helpers

### DIFF
--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -106,6 +106,10 @@ fn.mock.lastCall;   // ["a", "b"]
 // Configure behavior
 fn.mockReturnValue(42);              // All calls return 42
 fn.mockReturnValueOnce(1);           // Next call returns 1
+fn.mockResolvedValue(42);            // All calls return fresh fulfilled promises
+fn.mockResolvedValueOnce(1);         // Next call returns a fulfilled promise
+fn.mockRejectedValue(error);         // All calls return fresh rejected promises
+fn.mockRejectedValueOnce(error);     // Next call returns a rejected promise
 fn.mockImplementation((x) => x + 1); // Set implementation
 fn.mockImplementationOnce(() => 99);  // One-shot implementation
 
@@ -123,11 +127,10 @@ fn.getMockName();  // "myFn"
 
 **Priority order** when a mock is called:
 
-1. One-shot implementation (`mockImplementationOnce`) --- FIFO
-2. One-shot return value (`mockReturnValueOnce`) --- FIFO
-3. Permanent implementation (`mockImplementation`)
-4. Permanent return value (`mockReturnValue`)
-5. Return `undefined`
+1. One-shot queue (`mockImplementationOnce`, `mockReturnValueOnce`, `mockResolvedValueOnce`, or `mockRejectedValueOnce`) --- shared FIFO
+2. Permanent implementation (`mockImplementation`, `mockResolvedValue`, or `mockRejectedValue`)
+3. Permanent return value (`mockReturnValue`)
+4. Return `undefined`
 
 #### `spyOn(object, methodName)`
 
@@ -154,6 +157,7 @@ obj.greet("test");   // "hello test"
 ```javascript
 // Call tracking
 expect(fn).toHaveBeenCalled();
+expect(fn).toHaveBeenCalledOnce();
 expect(fn).toHaveBeenCalledTimes(3);
 expect(fn).toHaveBeenCalledWith(1, 2);        // Any call matched
 expect(fn).toHaveBeenLastCalledWith("last");   // Last call matched

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -137,6 +137,7 @@ type
 
     // Mock matchers
     function ToHaveBeenCalled(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ToHaveBeenCalledOnce(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ToHaveBeenCalledTimes(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ToHaveBeenCalledWith(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function ToHaveBeenLastCalledWith(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
@@ -894,6 +895,9 @@ begin
   // Mock matchers
   DefineProperty('toHaveBeenCalled', TGocciaPropertyDescriptorData.Create(
     TGocciaNativeFunctionValue.Create(ToHaveBeenCalled, 'toHaveBeenCalled', 0), [pfConfigurable, pfWritable]));
+  DefineProperty('toHaveBeenCalledOnce', TGocciaPropertyDescriptorData.Create(
+    TGocciaNativeFunctionValue.Create(ToHaveBeenCalledOnce,
+      'toHaveBeenCalledOnce', 0), [pfConfigurable, pfWritable]));
   DefineProperty('toHaveBeenCalledTimes', TGocciaPropertyDescriptorData.Create(
     TGocciaNativeFunctionValue.Create(ToHaveBeenCalledTimes, 'toHaveBeenCalledTimes', 1), [pfConfigurable, pfWritable]));
   DefineProperty('toHaveBeenCalledWith', TGocciaPropertyDescriptorData.Create(
@@ -2245,6 +2249,43 @@ begin
         Format('Expected mock to have been called %d time(s) but was called %d time(s)',
           [ExpectedTimes, MockFn.MockCalls.Count]));
   end;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaExpectationValue.ToHaveBeenCalledOnce(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  MockFn: TGocciaMockFunctionValue;
+  Matches: Boolean;
+begin
+  TGocciaArgumentValidator.RequireExactly(AArgs, 0, 'toHaveBeenCalledOnce',
+    TGocciaTestAssertions(FTestAssertions).ThrowError);
+
+  if not (FActualValue is TGocciaMockFunctionValue) then
+  begin
+    TGocciaTestAssertions(FTestAssertions).AssertionFailed(
+      'toHaveBeenCalledOnce', 'Value must be a mock or spy function');
+    Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+  end;
+
+  MockFn := TGocciaMockFunctionValue(FActualValue);
+  Matches := MockFn.MockCalls.Count = 1;
+  if FIsNegated then
+    Matches := not Matches;
+
+  if Matches then
+    TGocciaTestAssertions(FTestAssertions).AssertionPassed(
+      'toHaveBeenCalledOnce')
+  else if FIsNegated then
+    TGocciaTestAssertions(FTestAssertions).AssertionFailed(
+      'toHaveBeenCalledOnce',
+      'Expected mock not to have been called exactly once')
+  else
+    TGocciaTestAssertions(FTestAssertions).AssertionFailed(
+      'toHaveBeenCalledOnce', Format(
+        'Expected mock to have been called exactly once but was called %d time(s)',
+        [MockFn.MockCalls.Count]));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 

--- a/source/units/Goccia.Values.MockFunction.pas
+++ b/source/units/Goccia.Values.MockFunction.pas
@@ -62,6 +62,14 @@ type
       const AThisValue: TGocciaValue): TGocciaValue;
     function DoMockReturnValueOnce(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
+    function DoMockResolvedValue(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function DoMockResolvedValueOnce(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function DoMockRejectedValue(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function DoMockRejectedValueOnce(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
     function DoMockReset(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     function DoMockClear(const AArgs: TGocciaArgumentsCollection;
@@ -91,12 +99,77 @@ uses
   Goccia.GarbageCollector,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
-  Goccia.Values.NativeFunction;
+  Goccia.Values.NativeFunction,
+  Goccia.Values.PromiseValue;
+
+type
+  TGocciaMockPromiseFactoryValue = class(TGocciaFunctionBase)
+  private
+    FValue: TGocciaValue;
+    FReject: Boolean;
+  protected
+    function GetFunctionLength: Integer; override;
+    function GetFunctionName: string; override;
+  public
+    constructor Create(const AValue: TGocciaValue; const AReject: Boolean);
+    function Call(const AArguments: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue; override;
+    procedure MarkReferences; override;
+  end;
 
 const
   MOCK_DEFAULT_NAME = 'mock';
   RESULT_TYPE_RETURN = 'return';
   RESULT_TYPE_THROW = 'throw';
+
+{ TGocciaMockPromiseFactoryValue }
+
+constructor TGocciaMockPromiseFactoryValue.Create(const AValue: TGocciaValue;
+  const AReject: Boolean);
+begin
+  inherited Create;
+  FValue := AValue;
+  FReject := AReject;
+end;
+
+function TGocciaMockPromiseFactoryValue.GetFunctionLength: Integer;
+begin
+  Result := 0;
+end;
+
+function TGocciaMockPromiseFactoryValue.GetFunctionName: string;
+begin
+  Result := '';
+end;
+
+function TGocciaMockPromiseFactoryValue.Call(
+  const AArguments: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Promise: TGocciaPromiseValue;
+begin
+  Promise := TGocciaPromiseValue.Create;
+  if TGarbageCollector.Instance <> nil then
+    TGarbageCollector.Instance.AddTempRoot(Promise);
+  try
+    if FReject then
+      Promise.Reject(FValue)
+    else
+      Promise.Resolve(FValue);
+    Result := Promise;
+  finally
+    if TGarbageCollector.Instance <> nil then
+      TGarbageCollector.Instance.RemoveTempRoot(Promise);
+  end;
+end;
+
+procedure TGocciaMockPromiseFactoryValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FValue) then
+    FValue.MarkReferences;
+end;
 
 function ClonePropertyDescriptor(const ADescriptor: TGocciaPropertyDescriptor): TGocciaPropertyDescriptor;
 begin
@@ -188,6 +261,18 @@ begin
   DefineProperty('mockReturnValueOnce', TGocciaPropertyDescriptorData.Create(
     TGocciaNativeFunctionValue.Create(DoMockReturnValueOnce, 'mockReturnValueOnce', 1),
     [pfConfigurable, pfWritable]));
+  DefineProperty('mockResolvedValue', TGocciaPropertyDescriptorData.Create(
+    TGocciaNativeFunctionValue.Create(DoMockResolvedValue, 'mockResolvedValue', 1),
+    [pfConfigurable, pfWritable]));
+  DefineProperty('mockResolvedValueOnce', TGocciaPropertyDescriptorData.Create(
+    TGocciaNativeFunctionValue.Create(DoMockResolvedValueOnce,
+      'mockResolvedValueOnce', 1), [pfConfigurable, pfWritable]));
+  DefineProperty('mockRejectedValue', TGocciaPropertyDescriptorData.Create(
+    TGocciaNativeFunctionValue.Create(DoMockRejectedValue, 'mockRejectedValue', 1),
+    [pfConfigurable, pfWritable]));
+  DefineProperty('mockRejectedValueOnce', TGocciaPropertyDescriptorData.Create(
+    TGocciaNativeFunctionValue.Create(DoMockRejectedValueOnce,
+      'mockRejectedValueOnce', 1), [pfConfigurable, pfWritable]));
   DefineProperty('mockReset', TGocciaPropertyDescriptorData.Create(
     TGocciaNativeFunctionValue.Create(DoMockReset, 'mockReset', 0),
     [pfConfigurable, pfWritable]));
@@ -494,6 +579,52 @@ begin
   SetLength(FOnceIsImpl, Len + 1);
   FOnceIsImpl[Len] := False;
 
+  Result := Self;
+end;
+
+function TGocciaMockFunctionValue.DoMockResolvedValue(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  FImplementation := TGocciaMockPromiseFactoryValue.Create(
+    AArgs.GetElement(0), False);
+  Result := Self;
+end;
+
+function TGocciaMockFunctionValue.DoMockResolvedValueOnce(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Len: Integer;
+begin
+  FOnceQueue.Add(TGocciaMockPromiseFactoryValue.Create(
+    AArgs.GetElement(0), False));
+  Len := Length(FOnceIsImpl);
+  SetLength(FOnceIsImpl, Len + 1);
+  FOnceIsImpl[Len] := True;
+  Result := Self;
+end;
+
+function TGocciaMockFunctionValue.DoMockRejectedValue(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  FImplementation := TGocciaMockPromiseFactoryValue.Create(
+    AArgs.GetElement(0), True);
+  Result := Self;
+end;
+
+function TGocciaMockFunctionValue.DoMockRejectedValueOnce(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Len: Integer;
+begin
+  FOnceQueue.Add(TGocciaMockPromiseFactoryValue.Create(
+    AArgs.GetElement(0), True));
+  Len := Length(FOnceIsImpl);
+  SetLength(FOnceIsImpl, Len + 1);
+  FOnceIsImpl[Len] := True;
   Result := Self;
 end;
 

--- a/tests/built-ins/Goccia/expect/toHaveBeenCalledOnce.js
+++ b/tests/built-ins/Goccia/expect/toHaveBeenCalledOnce.js
@@ -1,0 +1,32 @@
+describe("toHaveBeenCalledOnce", () => {
+  test("passes for exactly one mock call", () => {
+    const fn = mock();
+    fn("value");
+
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  test("supports negation for zero and multiple calls", () => {
+    const fn = mock();
+    expect(fn).not.toHaveBeenCalledOnce();
+
+    fn();
+    fn();
+    expect(fn).not.toHaveBeenCalledOnce();
+  });
+
+  test("works with spies", () => {
+    const target = { run: () => "ok" };
+    const spy = spyOn(target, "run");
+
+    target.run();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  test("rejects unexpected arguments", () => {
+    const fn = mock();
+    fn();
+
+    expect(() => expect(fn).toHaveBeenCalledOnce("unexpected")).toThrow();
+  });
+});

--- a/tests/built-ins/Goccia/mockRejectedValue.js
+++ b/tests/built-ins/Goccia/mockRejectedValue.js
@@ -1,0 +1,28 @@
+describe("mockRejectedValue", () => {
+  test("returns a fresh rejected promise for every call", async () => {
+    const reason = { code: "E_MOCK" };
+    const fn = mock().mockRejectedValue(reason);
+    const first = fn();
+    const second = fn();
+
+    expect(first).not.toBe(second);
+    await expect(first).rejects.toBe(reason);
+    await expect(second).rejects.toBe(reason);
+  });
+
+  test("mockRejectedValueOnce shares the one-shot queue", async () => {
+    const fn = mock()
+      .mockResolvedValue("default")
+      .mockRejectedValueOnce("first rejection")
+      .mockResolvedValueOnce("one-shot success");
+
+    await expect(fn()).rejects.toBe("first rejection");
+    await expect(fn()).resolves.toBe("one-shot success");
+    await expect(fn()).resolves.toBe("default");
+  });
+
+  test("omitted values reject with undefined", async () => {
+    await expect(mock().mockRejectedValue()()).rejects.toBeUndefined();
+    await expect(mock().mockRejectedValueOnce()()).rejects.toBeUndefined();
+  });
+});

--- a/tests/built-ins/Goccia/mockResolvedValue.js
+++ b/tests/built-ins/Goccia/mockResolvedValue.js
@@ -1,0 +1,27 @@
+describe("mockResolvedValue", () => {
+  test("returns a fresh fulfilled promise for every call", async () => {
+    const fn = mock().mockResolvedValue(42);
+    const first = fn();
+    const second = fn();
+
+    expect(first).not.toBe(second);
+    await expect(first).resolves.toBe(42);
+    await expect(second).resolves.toBe(42);
+  });
+
+  test("mockResolvedValueOnce shares the one-shot queue", async () => {
+    const fn = mock()
+      .mockResolvedValue("default")
+      .mockResolvedValueOnce("first")
+      .mockReturnValueOnce("raw");
+
+    await expect(fn()).resolves.toBe("first");
+    expect(fn()).toBe("raw");
+    await expect(fn()).resolves.toBe("default");
+  });
+
+  test("omitted values resolve to undefined", async () => {
+    await expect(mock().mockResolvedValue()()).resolves.toBeUndefined();
+    await expect(mock().mockResolvedValueOnce()()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add mockResolvedValue, mockResolvedValueOnce, mockRejectedValue, and mockRejectedValueOnce with fresh promises per invocation and the existing shared one-shot FIFO.
- Add the Vitest-compatible toHaveBeenCalledOnce matcher for mocks and spies, including negation and arity validation.
- Document the new helpers and cover fulfilled, rejected, permanent, one-shot, chaining, omitted-value, mock, and spy behavior.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Validation performed:

- Focused interpreted and bytecode suites: 10/10 tests and 21 assertions passed in each mode
- Full interpreted suite: 11,682/11,682 tests passed
- Full bytecode suite: 11,682/11,682 tests passed
- Test structure: 1,446 files
- Pascal format, documentation links/symbols/length, truncation guards, Markdown lint, and pre-commit hooks