### PR TITLE
fix(coverage): exclude parallel runner warm-up

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2276,6 +2276,40 @@ console.log("Loader: coverage --output=json not corrupted...");
     if (!branchJson.includes('"branchMap":')) throw new Error('Branch JSON should contain "branchMap":');
     if (!branchJson.includes('"b":')) throw new Error('Branch JSON should contain "b":');
 
+    console.log("TestRunner: parallel coverage excludes internal warm-up sources...");
+    const parallelFirst = join(tmp, "parallel-coverage-a.js");
+    const parallelSecond = join(tmp, "parallel-coverage-b.js");
+    writeFileSync(parallelFirst, 'test("a", () => { expect(1).toBe(1); });\n');
+    writeFileSync(parallelSecond, 'test("b", () => { expect(2).toBe(2); });\n');
+    for (const mode of ["interpreted", "bytecode"]) {
+      const parallelJsonPath = join(tmp, `parallel-${mode}.json`);
+      const modeArgs = mode === "bytecode" ? ["--mode=bytecode"] : [];
+      const proc = Bun.spawnSync(
+        [
+          resolve(TESTRUNNER),
+          parallelFirst,
+          parallelSecond,
+          "--no-progress",
+          "--no-results",
+          "--jobs=2",
+          "--coverage",
+          "--coverage-format=json",
+          `--coverage-output=${parallelJsonPath}`,
+          ...modeArgs,
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      if (proc.exitCode !== 0)
+        throw new Error(`Parallel ${mode} coverage exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+      const parallelCoverage = JSON.parse(readFileSync(parallelJsonPath, "utf-8"));
+      if (Object.hasOwn(parallelCoverage, "<thread-init>"))
+        throw new Error(`Parallel ${mode} coverage should exclude internal <thread-init> source`);
+      for (const file of [parallelFirst, parallelSecond]) {
+        if (!Object.hasOwn(parallelCoverage, file))
+          throw new Error(`Parallel ${mode} coverage should retain user source ${file}`);
+      }
+    }
+
     console.log("Loader: JSX coverage source-map translation...");
     const jsxPath = join(tmp, "coverage-test.jsx");
     writeFileSync(

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -1292,6 +1292,8 @@ var
   EffectiveTimeoutMs: Integer;
   WatchdogMs: Integer;
   WorkerMemoryStats: TCLIJSONMemoryStats;
+  CoverageTracker: TGocciaCoverageTracker;
+  CoverageWasEnabled: Boolean;
 begin
   WorkerMemoryStats := DefaultCLIJSONMemoryStats;
   SetLength(WorkerData, AFiles.Count);
@@ -1311,12 +1313,27 @@ begin
     SetLength(WorkerData[I].FailedTestNames, 0);
   end;
 
-  // Force all shared prototypes to be initialised on the main thread
-  // before any worker thread starts, avoiding class-var race conditions.
-  if AnyFileConfigEnablesFlag(AFiles, EngineOptions.UnsafeFFI) then
-    EnsureSharedPrototypesInitialized(WarmUpRuntimeWithUnsafeFFI)
-  else
-    EnsureSharedPrototypesInitialized(WarmUpRuntime);
+  // Force all shared prototypes to be initialised on the main thread before
+  // any worker starts, avoiding class-var race conditions. This throwaway
+  // engine is runner infrastructure, so do not register its <thread-init>
+  // source in the user's coverage report. Preserve the tracker state instead
+  // of filtering by file name so a user source can never be hidden.
+  CoverageTracker := TGocciaCoverageTracker.Instance;
+  CoverageWasEnabled := False;
+  if Assigned(CoverageTracker) then
+  begin
+    CoverageWasEnabled := CoverageTracker.Enabled;
+    CoverageTracker.Enabled := False;
+  end;
+  try
+    if AnyFileConfigEnablesFlag(AFiles, EngineOptions.UnsafeFFI) then
+      EnsureSharedPrototypesInitialized(WarmUpRuntimeWithUnsafeFFI)
+    else
+      EnsureSharedPrototypesInitialized(WarmUpRuntime);
+  finally
+    if Assigned(CoverageTracker) then
+      CoverageTracker.Enabled := CoverageWasEnabled;
+  end;
 
   WallClockStart := GetNanoseconds;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Keep the main-thread `<thread-init>` warm-up engine out of parallel `GocciaTestRunner` coverage reports.
- Preserve and restore the coverage tracker around the internal warm-up instead of filtering report paths, so all user sources remain visible.
- Add CLI regressions for interpreted and bytecode `--jobs=2` JSON coverage that reject the internal pseudo-file and require both real input paths.
- Non-goal: change coverage collection or formatting for user-executed sources.

## Testing

- [x] Reproduced `<thread-init>` in interpreted and bytecode parallel JSON coverage before the fix
- [x] Verified the focused interpreted and bytecode parallel JSON coverage output excludes `<thread-init>` and retains both user files
- [x] Ran `bun run scripts/test-cli-apps.ts`
- [x] Ran `./build.pas testrunner`
- [x] Ran `./build/GocciaTestRunner tests` (11,672 passed)
- [x] Ran `./build/GocciaTestRunner tests --mode=bytecode` (11,672 passed)
- [x] Ran `./format.pas --check` (435 files checked)
- [ ] Updated documentation — not needed: this removes an internal runner artifact from existing coverage output
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (not needed; the change is runner orchestration covered through the real CLI)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change (not applicable to coverage report membership)
