### PR TITLE
fix(modules): root relative CLI aliases

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -170,7 +170,7 @@ printf "name;" | ./build/GocciaScriptLoader --globals=context.toml --output=json
 # Load an explicit import map
 ./build/GocciaScriptLoader app.js --import-map=imports.json
 
-# Add one-off import-map-style aliases from the CLI
+# Add one-off import-map-style aliases from the CLI (relative targets use the invocation directory)
 ./build/GocciaScriptLoader app.js --alias @/=./src/ --alias config=./config/default.js
 
 # The same module-resolution and virtual-module flags are available on the shared CLI hosts.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -199,7 +199,7 @@ Engine.AddAlias('@/', 'src/');                       // prefix match
 Engine.AddAlias('@/components/', 'ui/lib/');         // more specific prefix
 ```
 
-For an embedded engine, the alias target is resolved relative to the resolver's base directory, which defaults to the entry file's directory. In the shared CLI hosts, relative `--alias` targets use the invocation directory, while aliases loaded from a configuration file use that configuration file's directory.
+For an embedded engine, the alias target is resolved relative to the resolver's base directory, which defaults to the entry file's directory. In the shared CLI hosts, relative `--alias` targets use the invocation directory, while aliases loaded from configuration use the active project configuration file's directory, including aliases inherited through `extends`.
 
 **Exact vs prefix matching:** A key without a trailing `/` is an exact match only. A key with a trailing `/` is a prefix match and appends the unmatched suffix to the target. This means `lodash` matches `import "lodash"` but not `import "lodash/fp"`, while `@/` matches `@/utils/math`.
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -199,7 +199,7 @@ Engine.AddAlias('@/', 'src/');                       // prefix match
 Engine.AddAlias('@/components/', 'ui/lib/');         // more specific prefix
 ```
 
-The alias target is resolved relative to the entry file's directory.
+For an embedded engine, the alias target is resolved relative to the resolver's base directory, which defaults to the entry file's directory. In the shared CLI hosts, relative `--alias` targets use the invocation directory, while aliases loaded from a configuration file use that configuration file's directory.
 
 **Exact vs prefix matching:** A key without a trailing `/` is an exact match only. A key with a trailing `/` is a prefix match and appends the unmatched suffix to the target. This means `lodash` matches `import "lodash"` but not `import "lodash/fp"`, while `@/` matches `@/utils/math`.
 

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2127,6 +2127,72 @@ console.log("Loader: ShadowRealm.importValue inherits the host module aliases...
   }
 }
 
+console.log("Loader: relative aliases use the invocation or config directory...");
+{
+  const tmp = makeTmp();
+  try {
+    const loader = resolve(LOADER);
+    const project = join(tmp, "project");
+    mkdirSync(join(project, "api-tests"), { recursive: true });
+    mkdirSync(join(project, "src"), { recursive: true });
+    writeFileSync(
+      join(project, "api-tests", "alias.test.js"),
+      [
+        'import { value } from "@/value";',
+        "console.log(value);",
+        'new ShadowRealm().importValue("@/value", "value")',
+        '  .then((childValue) => console.log("child-" + childValue));',
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(project, "src", "value.js"), 'export const value = "project-root";\n');
+
+    for (const mode of ["interpreted", "bytecode"] as const) {
+      const cliProc = Bun.spawnSync(
+        [
+          loader,
+          "api-tests/alias.test.js",
+          "--source-type=module",
+          `--mode=${mode}`,
+          "--unsafe-shadowrealm",
+          "--alias",
+          "@/=./src/",
+        ],
+        { cwd: project, stdout: "pipe", stderr: "pipe" },
+      );
+      if (cliProc.exitCode !== 0 ||
+          !containsLine(`\n${cliProc.stdout.toString()}`, "project-root") ||
+          !containsLine(`\n${cliProc.stdout.toString()}`, "child-project-root"))
+        throw new Error(
+          `Loader ${mode} relative CLI alias should resolve from the invocation directory: ` +
+          `${cliProc.stdout}${cliProc.stderr}`,
+        );
+    }
+
+    writeFileSync(
+      join(project, "goccia.json"),
+      JSON.stringify({
+        "source-type": "module",
+        "unsafe-shadowrealm": true,
+        alias: ["@/=./src/"],
+      }),
+    );
+    const configProc = Bun.spawnSync(
+      [loader, "project/api-tests/alias.test.js"],
+      { cwd: tmp, stdout: "pipe", stderr: "pipe" },
+    );
+    if (configProc.exitCode !== 0 ||
+        !containsLine(`\n${configProc.stdout.toString()}`, "project-root") ||
+        !containsLine(`\n${configProc.stdout.toString()}`, "child-project-root"))
+      throw new Error(
+        "Loader relative config alias should resolve from the config directory: " +
+        `${configProc.stdout}${configProc.stderr}`,
+      );
+  } finally {
+    clean(tmp);
+  }
+}
+
 console.log("Loader: --globals file...");
 {
   const tmp = makeTmp();

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2169,25 +2169,33 @@ console.log("Loader: relative aliases use the invocation or config directory..."
         );
     }
 
+    const baseConfigDirectory = join(tmp, "base-config");
+    mkdirSync(baseConfigDirectory, { recursive: true });
+    writeFileSync(
+      join(baseConfigDirectory, "goccia.json"),
+      JSON.stringify({ alias: ["@/=./src/"] }),
+    );
     writeFileSync(
       join(project, "goccia.json"),
       JSON.stringify({
+        extends: "../base-config/goccia.json",
         "source-type": "module",
         "unsafe-shadowrealm": true,
-        alias: ["@/=./src/"],
       }),
     );
-    const configProc = Bun.spawnSync(
-      [loader, "project/api-tests/alias.test.js"],
-      { cwd: tmp, stdout: "pipe", stderr: "pipe" },
-    );
-    if (configProc.exitCode !== 0 ||
-        !containsLine(`\n${configProc.stdout.toString()}`, "project-root") ||
-        !containsLine(`\n${configProc.stdout.toString()}`, "child-project-root"))
-      throw new Error(
-        "Loader relative config alias should resolve from the config directory: " +
-        `${configProc.stdout}${configProc.stderr}`,
+    for (const mode of ["interpreted", "bytecode"] as const) {
+      const configProc = Bun.spawnSync(
+        [loader, "project/api-tests/alias.test.js", `--mode=${mode}`],
+        { cwd: tmp, stdout: "pipe", stderr: "pipe" },
       );
+      if (configProc.exitCode !== 0 ||
+          !containsLine(`\n${configProc.stdout.toString()}`, "project-root") ||
+          !containsLine(`\n${configProc.stdout.toString()}`, "child-project-root"))
+        throw new Error(
+          `Loader ${mode} inherited relative config alias should resolve from ` +
+          `the active config directory: ${configProc.stdout}${configProc.stderr}`,
+        );
+    }
   } finally {
     clean(tmp);
   }

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -1077,6 +1077,7 @@ end;
 function TGocciaCLIApplication.CreateEngine(const AFileName: string;
   const ASource: TStringList; const AExecutor: TGocciaExecutor): TGocciaEngine;
 var
+  AliasBaseDirectory: string;
   FileConfig: TConfigEntryArray;
   FileConfigPath: string;
 begin
@@ -1090,8 +1091,14 @@ begin
       SetLength(FileConfig, 0);
     if Assigned(FEngineOptions) then
     begin
+      if FEngineOptions.Aliases.FromCommandLine or
+         (FRootConfigPath = '') then
+        AliasBaseDirectory := GetCurrentDir
+      else
+        AliasBaseDirectory := ExtractFilePath(FRootConfigPath);
       ConfigureModuleResolver(Result.Resolver, AFileName,
-        FEngineOptions.ImportMap.ValueOr(''), FEngineOptions.Aliases.Values);
+        FEngineOptions.ImportMap.ValueOr(''), FEngineOptions.Aliases.Values,
+        AliasBaseDirectory);
       if ResolveFlagOption(FEngineOptions.Deterministic, FileConfig) then
         Result.HostEnvironment.UseDeterministicProfile;
     end;

--- a/source/units/Goccia.Builtins.GlobalShadowRealm.pas
+++ b/source/units/Goccia.Builtins.GlobalShadowRealm.pas
@@ -225,6 +225,8 @@ begin
   FEngine.ModuleLoader.SetContentProvider(AParentEngine.ContentProvider, False);
   FEngine.ModuleLoader.CopyVirtualModulesFrom(AParentEngine.ModuleLoader);
   FEngine.ModuleLoader.Preprocessors := AParentEngine.Preprocessors;
+  FEngine.ModuleLoader.Resolver.BaseDirectory :=
+    AParentEngine.ModuleLoader.Resolver.BaseDirectory;
   for AliasPair in AParentEngine.ModuleLoader.Resolver.Aliases do
     FEngine.ModuleLoader.Resolver.AddAlias(AliasPair.Key, AliasPair.Value);
   // SetDefaultGlobalBindings installs `eval` on the realm global. GocciaScript

--- a/source/units/Goccia.Modules.Configuration.Test.pas
+++ b/source/units/Goccia.Modules.Configuration.Test.pas
@@ -28,6 +28,7 @@ type
     procedure TestConfigureModuleResolverPreservesUTF8ImportMap;
     procedure TestConfigureModuleResolverDiscoversProjectConfig;
     procedure TestConfigureModuleResolverAppliesInlineAliasAfterImportMap;
+    procedure TestConfigureModuleResolverResolvesInlineAliasFromExplicitBaseDirectory;
     procedure TestConfigureModuleResolverPrefersExplicitImportMap;
   protected
     procedure BeforeAll; override;
@@ -46,6 +47,8 @@ begin
     TestConfigureModuleResolverDiscoversProjectConfig);
   Test('ConfigureModuleResolver applies inline aliases after the import map',
     TestConfigureModuleResolverAppliesInlineAliasAfterImportMap);
+  Test('ConfigureModuleResolver resolves inline aliases from their explicit base directory',
+    TestConfigureModuleResolverResolvesInlineAliasFromExplicitBaseDirectory);
   Test('ConfigureModuleResolver prefers an explicit import map over discovered goccia.json',
     TestConfigureModuleResolverPrefersExplicitImportMap);
 end;
@@ -264,6 +267,36 @@ begin
 
   Expect<string>(ResolvedPath).ToBe(IncludeTrailingPathDelimiter(
     ProjectDirectory) + 'config' + PathDelim + 'override.js');
+end;
+
+procedure TModuleConfigurationTests.TestConfigureModuleResolverResolvesInlineAliasFromExplicitBaseDirectory;
+var
+  EntryPath, ProjectDirectory, ResolvedPath: string;
+  InlineAliases: TStringList;
+  Resolver: TGocciaModuleResolver;
+begin
+  ProjectDirectory := CreateTempDirectory;
+  EntryPath := IncludeTrailingPathDelimiter(ProjectDirectory) + 'api-tests' +
+    PathDelim + 'alias.test.js';
+
+  WriteTextFile(EntryPath, 'import { value } from "@/value";');
+  WriteTextFile(IncludeTrailingPathDelimiter(ProjectDirectory) + 'src' +
+    PathDelim + 'value.js', 'export const value = "project-root";');
+
+  InlineAliases := TStringList.Create;
+  Resolver := TGocciaModuleResolver.Create(ExtractFilePath(EntryPath));
+  try
+    InlineAliases.Add('@/=./src/');
+    ConfigureModuleResolver(Resolver, EntryPath, '', InlineAliases,
+      ProjectDirectory);
+    ResolvedPath := Resolver.Resolve('@/value', EntryPath);
+  finally
+    Resolver.Free;
+    InlineAliases.Free;
+  end;
+
+  Expect<string>(ResolvedPath).ToBe(IncludeTrailingPathDelimiter(
+    ProjectDirectory) + 'src' + PathDelim + 'value.js');
 end;
 
 procedure TModuleConfigurationTests.TestConfigureModuleResolverPrefersExplicitImportMap;

--- a/source/units/Goccia.Modules.Configuration.pas
+++ b/source/units/Goccia.Modules.Configuration.pas
@@ -11,7 +11,8 @@ uses
 
 procedure ConfigureModuleResolver(const AResolver: TGocciaModuleResolver;
   const AEntryFileName, AExplicitImportMapPath: string;
-  const AInlineAliases: TStrings);
+  const AInlineAliases: TStrings;
+  const AInlineAliasBaseDirectory: string = '');
 
 implementation
 
@@ -57,7 +58,8 @@ end;
 
 procedure ConfigureModuleResolver(const AResolver: TGocciaModuleResolver;
   const AEntryFileName, AExplicitImportMapPath: string;
-  const AInlineAliases: TStrings);
+  const AInlineAliases: TStrings;
+  const AInlineAliasBaseDirectory: string);
 var
   AliasPair: TModuleAliasPair;
   I: Integer;
@@ -77,6 +79,11 @@ begin
 
   if not Assigned(AInlineAliases) then
     Exit;
+
+  if (AInlineAliases.Count > 0) and
+     (AInlineAliasBaseDirectory <> '') then
+    AResolver.BaseDirectory := IncludeTrailingPathDelimiter(
+      ExpandHostFileName(AInlineAliasBaseDirectory));
 
   for I := 0 to AInlineAliases.Count - 1 do
   begin


### PR DESCRIPTION
## Summary

- Resolve relative command-line aliases from the CLI invocation directory instead of the importing file directory.
- Resolve config aliases from the active project configuration directory, including aliases inherited through extends.
- Preserve the configured alias base when ShadowRealm inherits module aliases.
- Keep embedded resolver defaults and import-map path normalization unchanged.

## Testing

- [x] Verified no regressions and confirmed the bugfix in the complete app-specific CLI harness, including interpreted, bytecode, cross-directory config inheritance, and ShadowRealm cases
- [x] Updated documentation
- [x] Verified all 1,456 JavaScript files and 11,672 tests in interpreted mode
- [x] Verified all 1,456 JavaScript files and 11,672 tests in bytecode mode
- [x] Verified all Pascal test programs build and the focused module-configuration suite passes 6/6
- [x] Verified formatting, test structure, trunc guards, Markdown lint, documentation links, symbols, duplication, and length checks
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change