### PR TITLE
test(coverage): handle Windows LCOV line endings

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2392,7 +2392,7 @@ console.log("Loader: coverage --output=json not corrupted...");
     const escapedFunctionNameLcovPath = join(tmp, "escaped-function-name.lcov");
     await $`${LOADER} --coverage --coverage-format=lcov --coverage-output=${escapedFunctionNameLcovPath} ${escapedFunctionNameSourcePath}`.quiet();
     const escapedFunctionNameLcov = readFileSync(escapedFunctionNameLcovPath, "utf-8");
-    const escapedFunctionRecords = escapedFunctionNameLcov.split("\n");
+    const escapedFunctionRecords = escapedFunctionNameLcov.split(/\r?\n/);
     if (!escapedFunctionRecords.some((line) => /^FN:\d+,line\\r\\nbreak$/.test(line)) ||
         !escapedFunctionRecords.includes("FNDA:1,line\\r\\nbreak")) {
       throw new Error("LCOV should escape carriage returns and newlines in function names");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Parse LCOV records with platform-neutral LF/CRLF handling in the CLI coverage regression.
- Restore both Windows CLI jobs without weakening the escaped-newline, literal-backslash, collision, or tracefile-injection assertions introduced by #1064.
- Non-goal: change production LCOV generation or formatting.

## Testing

- [x] Verified no regressions and confirmed the bugfix through `bun run scripts/test-cli-apps.ts`.
- [x] Ran a clean full build with `./build.pas --clean`.
- [x] Ran `./build/GocciaTestRunner tests --no-progress` (11,698 passed; 26,074 assertions).
- [x] Ran `./build/GocciaTestRunner tests --mode=bytecode --no-progress` (11,698 passed; 26,074 assertions).
- [x] Ran `./format.pas --check` (435 files checked).
- [x] Reproduced the Windows-only mismatch with a CRLF LCOV fixture and verified all original security assertions against the corrected split.
- [ ] Updated documentation — not needed: this changes only cross-platform parsing in a CLI regression.
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — not applicable: no Pascal source changed.
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — not applicable: no runtime behavior changed.
