### PR TITLE
docs: sync release preparation claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,19 @@ modules, decorators, and proposal-compatible type syntax.
 
 ### Built-in Objects
 
-`console`, `Math`, `JSON`, `Object`, `Array`, `Number`, `String`, `RegExp`, `Symbol`, `Set`, `Map`, `WeakSet`, `WeakMap`, `Promise`, `Temporal`, `Iterator`, `Proxy`, `Reflect`, `ArrayBuffer`, `SharedArrayBuffer`, TypedArrays (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float16Array`, `Float32Array`, `Float64Array`, `BigInt64Array`, `BigUint64Array`) with ArrayBuffer and SharedArrayBuffer backing, `fetch`, `Headers`, `Response` ([WHATWG Fetch](https://fetch.spec.whatwg.org/) — GET/HEAD only), `AbortController`, `AbortSignal`, `URL`, `URLSearchParams`, `TextEncoder`, `TextDecoder`, plus error constructors (`Error`, `TypeError`, `ReferenceError`, `RangeError`, `DOMException`).
+Core built-ins include `Math`, `JSON`, `Object`, `Function`, `Array`, `Boolean`,
+`Number`, `BigInt`, `String`, `RegExp`, `Symbol`, `Set`, `Map`, `WeakSet`,
+`WeakMap`, `WeakRef`, `FinalizationRegistry`, `Promise`, `Temporal`, `Intl`,
+`Iterator`, `DisposableStack`, `AsyncDisposableStack`, `Proxy`, `Reflect`,
+`ArrayBuffer`, `SharedArrayBuffer`, `DataView`, `Atomics`, and TypedArrays
+(`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`,
+`Int32Array`, `Uint32Array`, `Float16Array`, `Float32Array`, `Float64Array`,
+`BigInt64Array`, `BigUint64Array`). The loader profile adds `console`,
+`performance`, `fetch`, `Headers`, `Response` ([WHATWG Fetch](https://fetch.spec.whatwg.org/) — GET/HEAD only),
+`AbortController`, `AbortSignal`, `URL`, `URLSearchParams`, `TextEncoder`, and
+`TextDecoder`. Error constructors include `Error`, `EvalError`, `TypeError`,
+`ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`,
+`SuppressedError`, and `DOMException`.
 
 Non-standard data-format APIs and SemVer are import-only Goccia runtime modules, not auto-installed globals: `goccia:csv`, `goccia:json5`, `goccia:jsonl`, `goccia:toml`, `goccia:tsv`, `goccia:yaml`, and `goccia:semver`. They expose named exports only; use `import * as CSV from "goccia:csv"` when you want the namespace-object shape. There is no default export.
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -352,7 +352,7 @@ The constructor-backed objects mirror the `node-semver` public fields and core i
 
 `encodeURI` / `decodeURI` / `encodeURIComponent` / `decodeURIComponent` follow the ECMA-262 URI handling specification. The shared encoding/decoding logic lives in `Goccia.URI.pas` and is also used by `import.meta.url` for file-path percent-encoding. Multi-byte Unicode characters are encoded as UTF-8 octets, each percent-encoded individually (e.g., `encodeURIComponent("中")` → `%E4%B8%AD`). Lone surrogates (U+D800–U+DFFF) throw `URIError`. Decoding validates UTF-8 well-formedness: overlong encodings, truncated sequences, and code points above U+10FFFF all throw `URIError`. `decodeURI` re-emits reserved characters as uppercase percent-encoded sequences even when the input uses lowercase hex digits (e.g., `%2f` → `%2F`).
 
-**Error constructors:** `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `DOMException`
+**Error constructors:** `Error`, `EvalError`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `SuppressedError`, `DOMException`
 
 **Prototype chain:** All error types follow the standard prototype hierarchy. `TypeError.prototype`, `RangeError.prototype`, etc. inherit from `Error.prototype`. Each error prototype has a `constructor` property pointing back to its constructor (e.g., `Error.prototype.constructor === Error`), so `new TypeError("x").constructor.name === "TypeError"`. `instanceof` checks and cross-type checks also work correctly: `new TypeError("msg") instanceof TypeError` is `true`, `new TypeError("msg") instanceof Error` is `true`, and `new TypeError("msg") instanceof RangeError` is `false`.
 

--- a/website/src/__tests__/positioning.test.ts
+++ b/website/src/__tests__/positioning.test.ts
@@ -26,7 +26,7 @@ describe("GocciaScript positioning", () => {
       /embedded in native applications/i,
     ]);
     expect(GOCCIASCRIPT_SUMMARY).toMatch(
-      /AI agents.+embedded in native applications/is,
+      /AI agents[\s\S]+embedded in native applications/i,
     );
   });
 


### PR DESCRIPTION
## Summary

- Sync the README built-in inventory with the globals actually registered by the core engine and loader runtime profile.
- Add the implemented `EvalError` and `SuppressedError` constructors to the built-in reference.
- Keep the website positioning assertion compatible with the repository's ES2017 TypeScript target.
- Record release-preparation follow-ups in #1070, #1071, and #1072.

This is the preparation PR only. It intentionally does not change the version, changelog, release branch, tag, or publishing state.

## Release preparation evidence

- Proposed next version from `git cliff --bumped-version`: `0.11.0`.
- Unreleased changelog preview is categorized under Performance, Website, Internal, Fixed, and Added, with no uncategorized `Other` entries.
- Latest retained main Test262 artifact (run 30980196951): 52,280 / 52,489 passing (99.602%), 196 failures, 13 timeouts.
- v0.10.0 Test262 artifact: 52,222 / 52,328 passing (99.797%), 95 failures, 11 timeouts.
- The six Iterator failures come from Test262 landing tc39/ecma262#3776 expectations before that normative PR is merged; tracked in #1070.
- CI-only staging timeout instability is tracked in #1071.
- CLDR 45.0 and Unicode 17 generated outputs reproduce exactly from their recorded inputs.
- The recorded `tzdata2026c` input is not byte-reproducible across ambient `zic` versions; the committed artifact was preserved and the toolchain fix is tracked in #1072.
- Lock-managed agent skills match a clean reinstall from their recorded sources.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Additional verification:

- `./build.pas testrunner`
- `./build/GocciaTestRunner tests` — 11,724 / 11,724 passed
- `./build/GocciaTestRunner tests --mode=bytecode` — 11,724 / 11,724 passed
- `./format.pas --check` — 437 files clean
- `cd website && bun test` — 170 / 170 passed
- `cd website && bun run lint`
- `cd website && bunx tsc --noEmit`
- `bun scripts/check-doc-links.ts` — 598 links, 0 broken
- `bun scripts/check-doc-symbols.ts` — 782 references valid
- `bun scripts/check-doc-duplication.ts` — 0 exact clones; 7 existing fuzzy warnings
- `bun scripts/check-doc-length.ts` — all 161 checked files within limits
