### PR TITLE
fix(jsx): guarantee transformer scan progress and positioned errors

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -419,7 +419,7 @@ Lowercase tags produce string tag names (`"div"`, `"span"`); uppercase tags are 
 
 **Custom factory:** The factory and fragment function names can be overridden per-file using pragma comments (`@jsxFactory`, `@jsxFragment`) at the top of the file, before any code.
 
-The transformer generates an internal source map for accurate error line/column reporting. JSX is enabled by default via `DefaultPreprocessors`; embedders can disable it with `Engine.Preprocessors := Engine.Preprocessors - [ppJSX]`.
+The transformer generates an internal source map for accurate error line/column reporting. JSX is enabled by default via `DefaultPreprocessors`; embedders can disable it with `Engine.Preprocessors := Engine.Preprocessors - [ppJSX]`. Opening-tag detection is a heuristic, so source that merely looks like JSX — a TypeScript type annotation such as `: <T>(x: T) => T`, for example — can start a JSX scan; when that scan stalls on a character no branch consumes, exceeds the nesting bound, or reaches the end of input inside an opening tag, the transformer reports a `SyntaxError` positioned in the original source rather than scanning on.
 
 ### Regular Expressions
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -413,7 +413,7 @@ const el = <div className="active">Hello {name}</div>;
 // Transformed to: createElement("div", { className: "active" }, "Hello ", name)
 ```
 
-**Supported syntax:** Elements, self-closing tags (`<br />`), fragments (`<>...</>`), string/expression/boolean attributes, spread attributes (`{...props}`), shorthand props (`<div {value} />` → `value={value}`), expression children (`{expr}`), nested JSX in expressions, dotted component names (`<Foo.Bar />`).
+**Supported syntax:** Elements, self-closing tags (`<br />`), fragments (`<>...</>`), string/expression/boolean attributes, spread attributes (`{...props}`), shorthand props (`<div {value} />` → `value={value}`), expression children (`{expr}`), nested JSX in expressions, dotted component names (`<Foo.Bar />`). Namespaced attribute names (`xlink:href`) and non-ASCII attribute names are **not** supported; both are reported as an unsupported-attribute-syntax `SyntaxError`.
 
 Lowercase tags produce string tag names (`"div"`, `"span"`); uppercase tags are passed as identifier references (component functions/classes).
 

--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -16,9 +16,15 @@ function assertSyntaxErrorInBothModes(
   source: string,
   desc: string,
   args: readonly string[] = [],
+  opts?: { timeout?: number; messageIncludes?: string },
 ): void {
-  assertSyntaxError(source, desc, [...args]);
-  assertSyntaxError(source, `${desc} (bytecode)`, [...args, "--mode=bytecode"]);
+  assertSyntaxError(source, desc, [...args], opts);
+  assertSyntaxError(
+    source,
+    `${desc} (bytecode)`,
+    [...args, "--mode=bytecode"],
+    opts,
+  );
 }
 
 // -- Error display (SyntaxError with caret and suggestion) ----------------------
@@ -787,6 +793,53 @@ console.log("Disabled-feature diagnostics with interpolated template literals...
     if (diagOut.includes("Unterminated template literal"))
       throw new Error(`${desc}: diagnostic should not mention an unterminated template literal, got: ${diagOut}`);
   }
+}
+
+// -- JSX preprocessor termination on non-JSX angle brackets ---------------------
+
+console.log("JSX preprocessor termination...");
+{
+  // Every case here must be proven to *terminate*: the JSX preprocessor scans
+  // source character by character, and a branch that consumes nothing used to
+  // spin forever at 100% CPU. A regression therefore hangs the loader instead
+  // of failing an assertion, so each run is bounded by an explicit timeout.
+  const JSX_SCAN_TIMEOUT_MS = 30_000;
+
+  const cases = [
+    {
+      desc: "type-parameter arrow after a function type annotation",
+      // `: <T>` looks like a JSX opening tag, so the children scan runs on the
+      // rest of the file and reaches `<T,` — where no attribute branch
+      // consumes the ','.
+      source: [
+        "const g: <T>(x: T) => T = (x) => x;",
+        "const w = <T,>(v: T): T => v;",
+        "",
+      ].join("\n"),
+      messageIncludes: "attribute list",
+    },
+    {
+      desc: "unterminated JSX opening tag",
+      source: 'const element = <div className="a"\n',
+      messageIncludes: "Unterminated opening tag",
+    },
+    {
+      desc: "mismatched JSX closing tag",
+      source: "const element = <div></span>;\n",
+      messageIncludes: "Expected closing tag",
+    },
+    {
+      desc: "JSX nesting beyond the depth bound",
+      source: `const element = ${"<a>".repeat(300)};\n`,
+      messageIncludes: "Nesting depth exceeded",
+    },
+  ] as const;
+
+  for (const { desc, source, messageIncludes } of cases)
+    assertSyntaxErrorInBothModes(source, desc, [], {
+      timeout: JSX_SCAN_TIMEOUT_MS,
+      messageIncludes,
+    });
 }
 
 console.log("\nAll test-cli-parser.ts tests passed.");

--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -16,7 +16,7 @@ function assertSyntaxErrorInBothModes(
   source: string,
   desc: string,
   args: readonly string[] = [],
-  opts?: { timeout?: number; messageIncludes?: string },
+  opts?: { timeout?: number; messageIncludes?: string; line?: number },
 ): void {
   assertSyntaxError(source, desc, [...args], opts);
   assertSyntaxError(
@@ -795,7 +795,7 @@ console.log("Disabled-feature diagnostics with interpolated template literals...
   }
 }
 
-// -- JSX preprocessor termination on non-JSX angle brackets ---------------------
+// -- JSX preprocessor termination and error positions --------------------------
 
 console.log("JSX preprocessor termination...");
 {
@@ -803,9 +803,17 @@ console.log("JSX preprocessor termination...");
   // source character by character, and a branch that consumes nothing used to
   // spin forever at 100% CPU. A regression therefore hangs the loader instead
   // of failing an assertion, so each run is bounded by an explicit timeout.
+  // Cases carrying `line` additionally pin where the error is reported, since
+  // nested attribute expressions are transformed from a copied slice whose
+  // positions have to be rebased onto the enclosing source.
   const JSX_SCAN_TIMEOUT_MS = 30_000;
 
-  const cases = [
+  const cases: readonly {
+    desc: string;
+    source: string;
+    messageIncludes: string;
+    line?: number;
+  }[] = [
     {
       desc: "type-parameter arrow after a function type annotation",
       // `: <T>` looks like a JSX opening tag, so the children scan runs on the
@@ -833,12 +841,52 @@ console.log("JSX preprocessor termination...");
       source: `const element = ${"<a>".repeat(300)};\n`,
       messageIncludes: "Nesting depth exceeded",
     },
-  ] as const;
+    {
+      desc: "error inside a nested attribute expression",
+      source: [
+        "const first = 1;",
+        "const element = <div a={<b></c>} />;",
+        "",
+      ].join("\n"),
+      messageIncludes: "Expected closing tag",
+      line: 2,
+    },
+    {
+      desc: "error inside a nested attribute expression starting on a later line",
+      source: [
+        "const first = 1;",
+        "const element = <div a={",
+        "  <b></c>",
+        "} />;",
+        "",
+      ].join("\n"),
+      messageIncludes: "Expected closing tag",
+      line: 3,
+    },
+    {
+      desc: "error on a later line of a nested attribute expression",
+      source: [
+        "const first = 1;",
+        "const element = <div a={<b>",
+        "</c>} />;",
+        "",
+      ].join("\n"),
+      messageIncludes: "Expected closing tag",
+      line: 3,
+    },
+    {
+      desc: "namespaced attribute name is reported as unsupported, not as non-JSX",
+      source: 'const element = <svg xlink:href="a" />;\n',
+      messageIncludes: "Unsupported attribute syntax",
+      line: 1,
+    },
+  ];
 
-  for (const { desc, source, messageIncludes } of cases)
+  for (const { desc, source, messageIncludes, line } of cases)
     assertSyntaxErrorInBothModes(source, desc, [], {
       timeout: JSX_SCAN_TIMEOUT_MS,
       messageIncludes,
+      line,
     });
 }
 

--- a/scripts/test-cli/assertions.ts
+++ b/scripts/test-cli/assertions.ts
@@ -38,6 +38,15 @@ export function runLoaderJson(
   );
   const stdout = proc.stdout.toString();
   const stderr = proc.stderr.toString();
+  // A killed process has no exit code. With `timeout` set this is the signal
+  // that the loader never terminated — report that directly instead of letting
+  // it surface as an unparseable-JSON failure.
+  if (proc.exitCode === null)
+    throw new Error(
+      `runLoaderJson: loader did not exit${
+        opts?.timeout != null ? ` within ${opts.timeout}ms` : ""
+      } (timed out)\nstderr: ${stderr}`,
+    );
   let json: any;
   try {
     json = JSON.parse(stdout);
@@ -55,13 +64,14 @@ export function runLoaderJson(
  * `opts.timeout` bounds the run — required for sources that must be proven to
  * terminate, where a regression hangs the process instead of failing an
  * assertion. `opts.messageIncludes` pins the diagnostic so an unrelated syntax
- * error cannot satisfy the assertion.
+ * error cannot satisfy the assertion, and `opts.line` pins the reported source
+ * line for errors whose position is itself the thing under test.
  */
 export function assertSyntaxError(
   source: string,
   desc: string,
   extraArgs?: string[],
-  opts?: { timeout?: number; messageIncludes?: string },
+  opts?: { timeout?: number; messageIncludes?: string; line?: number },
 ): void {
   const { exitCode, json } = runLoaderJson(source, extraArgs, opts);
   if (exitCode !== 1)
@@ -83,6 +93,10 @@ export function assertSyntaxError(
   )
     throw new Error(
       `${desc} should mention ${JSON.stringify(opts.messageIncludes)}, got ${JSON.stringify(json.error.message)}`,
+    );
+  if (opts?.line != null && json.error.line !== opts.line)
+    throw new Error(
+      `${desc} should be reported on line ${opts.line}, got line ${json.error.line}`,
     );
 }
 

--- a/scripts/test-cli/assertions.ts
+++ b/scripts/test-cli/assertions.ts
@@ -49,12 +49,21 @@ export function runLoaderJson(
   return { exitCode: proc.exitCode, json, stderr };
 }
 
+/**
+ * Asserts the loader rejects `source` with a positioned SyntaxError.
+ *
+ * `opts.timeout` bounds the run — required for sources that must be proven to
+ * terminate, where a regression hangs the process instead of failing an
+ * assertion. `opts.messageIncludes` pins the diagnostic so an unrelated syntax
+ * error cannot satisfy the assertion.
+ */
 export function assertSyntaxError(
   source: string,
   desc: string,
   extraArgs?: string[],
+  opts?: { timeout?: number; messageIncludes?: string },
 ): void {
-  const { exitCode, json } = runLoaderJson(source, extraArgs);
+  const { exitCode, json } = runLoaderJson(source, extraArgs, opts);
   if (exitCode !== 1)
     throw new Error(`${desc} should exit 1, but exited ${exitCode}`);
   if (json.ok !== false || json.error?.type !== "SyntaxError")
@@ -67,6 +76,13 @@ export function assertSyntaxError(
   )
     throw new Error(
       `${desc} should include numeric line and column, got line=${json.error.line} column=${json.error.column}`,
+    );
+  if (
+    opts?.messageIncludes != null &&
+    !String(json.error.message).includes(opts.messageIncludes)
+  )
+    throw new Error(
+      `${desc} should mention ${JSON.stringify(opts.messageIncludes)}, got ${JSON.stringify(json.error.message)}`,
     );
 }
 

--- a/source/units/Goccia.JSX.Transformer.pas
+++ b/source/units/Goccia.JSX.Transformer.pas
@@ -10,6 +10,7 @@ uses
 
   StringBuffer,
 
+  Goccia.Error,
   Goccia.Keywords.Contextual,
   Goccia.Keywords.Reserved,
   Goccia.SourceMap;
@@ -27,6 +28,7 @@ type
   private
     type
       TLastTokenKind = (ltkNone, ltkExpressionEnd, ltkOperator);
+      TScanContext = (scSource, scAttributes, scChildren, scExpression);
   private
     FSource: string;
     FPos: Integer;
@@ -51,7 +53,11 @@ type
 
     procedure RaiseJSXError(const AMessage: string);
     procedure RequireScanProgress(var AGuardPosition: Integer;
-      const AContext: string);
+      const AContext: TScanContext);
+    function ScanContextName(const AContext: TScanContext): string;
+    function IsUnsupportedAttributeChar(const AChar: Char): Boolean;
+    procedure RebaseNestedExpressionError(const AError: TGocciaError;
+      const ARawExpression: string; const AStartLine, AStartColumn: Integer);
 
     procedure Emit(const AText: string);
     procedure EmitMapped(const AText: string; const ASourceLine, ASourceColumn: Integer);
@@ -100,7 +106,6 @@ implementation
 uses
   TextSemantics,
 
-  Goccia.Error,
   Goccia.FileExtensions;
 
 const
@@ -220,6 +225,28 @@ begin
   raise TGocciaSyntaxError.Create(AMessage, FLine, FColumn, FFileName, nil);
 end;
 
+function TGocciaJSXTransformer.ScanContextName(
+  const AContext: TScanContext): string;
+begin
+  case AContext of
+    scAttributes: Result := JSX_CONTEXT_ATTRIBUTES;
+    scChildren: Result := JSX_CONTEXT_CHILDREN;
+    scExpression: Result := JSX_CONTEXT_EXPRESSION;
+  else
+    Result := JSX_CONTEXT_SOURCE;
+  end;
+end;
+
+// ':' opens a JSXNamespacedName (`xlink:href`) and bytes at or above #128 are
+// the lead bytes of a non-ASCII identifier. Both are legitimate JSX that this
+// transformer does not implement yet, so a stall on one is a missing feature
+// rather than evidence that the source was never JSX.
+function TGocciaJSXTransformer.IsUnsupportedAttributeChar(
+  const AChar: Char): Boolean;
+begin
+  Result := (AChar = ':') or (AChar >= #128);
+end;
+
 // Progress guard for the scanning loops. Each loop that can reach a character
 // none of its branches consume calls this once per iteration with its own guard
 // variable, initialised to 0 (FPos is 1-based, so the first iteration always
@@ -228,7 +255,7 @@ end;
 // enough to get here — and without the guard the loop spins forever at 100% CPU
 // instead of reporting the error.
 procedure TGocciaJSXTransformer.RequireScanProgress(var AGuardPosition: Integer;
-  const AContext: string);
+  const AContext: TScanContext);
 var
   Offender: string;
 begin
@@ -239,9 +266,46 @@ begin
   end;
 
   Offender := Peek;
-  RaiseJSXError(Format(
-    'JSX: Unexpected character "%s" in %s (likely runaway scan on non-JSX input)',
-    [Offender, AContext]));
+  if (AContext = scAttributes) and IsUnsupportedAttributeChar(Peek) then
+    RaiseJSXError(Format('JSX: Unsupported attribute syntax at "%s"',
+      [Offender]))
+  else
+    RaiseJSXError(Format(
+      'JSX: Unexpected character "%s" in %s (likely runaway scan on non-JSX input)',
+      [Offender, ScanContextName(AContext)]));
+end;
+
+// A nested attribute expression is transformed from a copied slice, so the
+// sub-transformer's positions are relative to that slice. Rebase them onto the
+// slice's position in this source before the error propagates — the slice's
+// leading whitespace is dropped by Trim, so it is skipped here too.
+procedure TGocciaJSXTransformer.RebaseNestedExpressionError(
+  const AError: TGocciaError; const ARawExpression: string;
+  const AStartLine, AStartColumn: Integer);
+var
+  Line, Column, I: Integer;
+begin
+  Line := AStartLine;
+  Column := AStartColumn;
+  I := 1;
+  while (I <= Length(ARawExpression)) and (ARawExpression[I] <= ' ') do
+  begin
+    if ARawExpression[I] = #10 then
+    begin
+      Inc(Line);
+      Column := 1;
+    end
+    else
+      Inc(Column);
+    Inc(I);
+  end;
+
+  // Only the slice's first line is column-shifted; every later line begins at
+  // column 1 in this source exactly as it does in the slice.
+  if AError.Line = 1 then
+    AError.TranslatePosition(Line, Column + AError.Column - 1, nil)
+  else
+    AError.TranslatePosition(Line + AError.Line - 1, AError.Column, nil);
 end;
 
 procedure TGocciaJSXTransformer.Emit(const AText: string);
@@ -839,10 +903,11 @@ var
   AttrName: string;
   Depth: Integer;
   ValueStart: Integer;
+  ValueLine, ValueColumn: Integer;
   I: Integer;
   GuardPosition: Integer;
   HasSpread: Boolean;
-  RawExpr: string;
+  RawExpr, RawSlice: string;
   SubResult: TGocciaJSXTransformResult;
 
   procedure FlushObjectAttrs;
@@ -868,7 +933,7 @@ begin
   GuardPosition := 0;
   while not IsAtEnd do
   begin
-    RequireScanProgress(GuardPosition, JSX_CONTEXT_ATTRIBUTES);
+    RequireScanProgress(GuardPosition, scAttributes);
     SkipWhitespace;
     if IsAtEnd or (CurrentChar = '>') or ((CurrentChar = '/') and (PeekAt(1) = '>')) then
       Break;
@@ -989,6 +1054,8 @@ begin
         AdvanceInput;
         Depth := 1;
         ValueStart := FPos;
+        ValueLine := FLine;
+        ValueColumn := FColumn;
         while not IsAtEnd and (Depth > 0) do
         begin
           if CurrentChar = '{' then
@@ -998,9 +1065,18 @@ begin
           if Depth > 0 then
             AdvanceInput;
         end;
-        RawExpr := Trim(Copy(FSource, ValueStart, FPos - ValueStart));
-        SubResult := TGocciaJSXTransformer.Transform(RawExpr, FFileName,
-          FFactoryName, FFragmentName);
+        RawSlice := Copy(FSource, ValueStart, FPos - ValueStart);
+        RawExpr := Trim(RawSlice);
+        try
+          SubResult := TGocciaJSXTransformer.Transform(RawExpr, FFileName,
+            FFactoryName, FFragmentName);
+        except
+          on E: TGocciaError do
+          begin
+            RebaseNestedExpressionError(E, RawSlice, ValueLine, ValueColumn);
+            raise;
+          end;
+        end;
         if Assigned(SubResult.SourceMap) then
           SubResult.SourceMap.Free;
         CurrentObjAttrs.Append(' ' + FormatPropertyKey(AttrName) + ': ' + SubResult.Source);
@@ -1045,7 +1121,7 @@ begin
   GuardPosition := 0;
   while not IsAtEnd do
   begin
-    RequireScanProgress(GuardPosition, JSX_CONTEXT_CHILDREN);
+    RequireScanProgress(GuardPosition, scChildren);
     if CurrentChar = '<' then
     begin
       if PeekAt(1) = '/' then
@@ -1122,7 +1198,7 @@ begin
   FLastTokenKind := ltkOperator;
   while not IsAtEnd do
   begin
-    RequireScanProgress(GuardPosition, JSX_CONTEXT_EXPRESSION);
+    RequireScanProgress(GuardPosition, scExpression);
     case CurrentChar of
       '{':
       begin
@@ -1435,7 +1511,7 @@ begin
   GuardPosition := 0;
   while not IsAtEnd do
   begin
-    RequireScanProgress(GuardPosition, JSX_CONTEXT_SOURCE);
+    RequireScanProgress(GuardPosition, scSource);
     C := CurrentChar;
 
     if (C = '/') and (PeekAt(1) = '/') then

--- a/source/units/Goccia.JSX.Transformer.pas
+++ b/source/units/Goccia.JSX.Transformer.pas
@@ -49,6 +49,10 @@ type
     procedure AdvanceInput; {$IFDEF FPC}inline;{$ENDIF}
     function CurrentChar: Char; {$IFDEF FPC}inline;{$ENDIF}
 
+    procedure RaiseJSXError(const AMessage: string);
+    procedure RequireScanProgress(var AGuardPosition: Integer;
+      const AContext: string);
+
     procedure Emit(const AText: string);
     procedure EmitMapped(const AText: string; const ASourceLine, ASourceColumn: Integer);
     procedure EmitChar(const AChar: Char); {$IFDEF FPC}inline;{$ENDIF}
@@ -86,6 +90,7 @@ type
     procedure TransformSource;
   public
     class function Transform(const ASource: string;
+      const AFileName: string = '';
       const AFactoryName: string = 'createElement';
       const AFragmentName: string = 'Fragment'): TGocciaJSXTransformResult;
   end;
@@ -95,6 +100,7 @@ implementation
 uses
   TextSemantics,
 
+  Goccia.Error,
   Goccia.FileExtensions;
 
 const
@@ -106,6 +112,13 @@ const
   // watchdog has to orphan the worker.
   MAX_JSX_DEPTH = 256;
 
+  // Scan contexts reported by RequireScanProgress, so a stalled loop names the
+  // construct it was scanning rather than a bare position.
+  JSX_CONTEXT_SOURCE = 'source';
+  JSX_CONTEXT_ATTRIBUTES = 'attribute list';
+  JSX_CONTEXT_CHILDREN = 'children';
+  JSX_CONTEXT_EXPRESSION = 'expression';
+
 procedure WarnIfJSXExtensionMismatch(const AFilePath: string);
 begin
   if not IsJSXNativeExtension(ExtractFileExt(AFilePath)) then
@@ -113,6 +126,7 @@ begin
 end;
 
 class function TGocciaJSXTransformer.Transform(const ASource: string;
+  const AFileName: string;
   const AFactoryName: string;
   const AFragmentName: string): TGocciaJSXTransformResult;
 var
@@ -120,6 +134,7 @@ var
 begin
   Transformer := TGocciaJSXTransformer.Create;
   try
+    Transformer.FFileName := AFileName;
     Transformer.FSource := ASource;
     Transformer.FPos := 1;
     Transformer.FLine := 1;
@@ -195,6 +210,38 @@ end;
 function TGocciaJSXTransformer.CurrentChar: Char;
 begin
   Result := FSource[FPos];
+end;
+
+// Every transformer diagnostic goes through here, so preprocessor failures
+// reach the host as ordinary positioned syntax errors instead of a bare
+// Exception the CLI can only print as "Error: <message>".
+procedure TGocciaJSXTransformer.RaiseJSXError(const AMessage: string);
+begin
+  raise TGocciaSyntaxError.Create(AMessage, FLine, FColumn, FFileName, nil);
+end;
+
+// Progress guard for the scanning loops. Each loop that can reach a character
+// none of its branches consume calls this once per iteration with its own guard
+// variable, initialised to 0 (FPos is 1-based, so the first iteration always
+// passes). A stalled FPos means the transformer is scanning input that only
+// looked like JSX — a TypeScript type annotation such as `: <T>(x: T) => T` is
+// enough to get here — and without the guard the loop spins forever at 100% CPU
+// instead of reporting the error.
+procedure TGocciaJSXTransformer.RequireScanProgress(var AGuardPosition: Integer;
+  const AContext: string);
+var
+  Offender: string;
+begin
+  if FPos > AGuardPosition then
+  begin
+    AGuardPosition := FPos;
+    Exit;
+  end;
+
+  Offender := Peek;
+  RaiseJSXError(Format(
+    'JSX: Unexpected character "%s" in %s (likely runaway scan on non-JSX input)',
+    [Offender, AContext]));
 end;
 
 procedure TGocciaJSXTransformer.Emit(const AText: string);
@@ -679,9 +726,9 @@ begin
   Inc(FJSXDepth);
   try
     if FJSXDepth > MAX_JSX_DEPTH then
-      raise Exception.CreateFmt(
-        'JSX nesting depth exceeded %d at line %d, column %d (likely runaway scan on non-JSX input)',
-        [MAX_JSX_DEPTH, FLine, FColumn]);
+      RaiseJSXError(Format(
+        'JSX: Nesting depth exceeded %d (likely runaway scan on non-JSX input)',
+        [MAX_JSX_DEPTH]));
 
     FHasJSX := True;
     StartLine := FLine;
@@ -767,6 +814,11 @@ begin
       FLastTokenKind := ltkExpressionEnd;
       Exit;
     end;
+
+    // Only reachable at end of input: EmitJSXAttributes stops at '>', '/>' or
+    // end of input, so falling through here means the opening tag was never
+    // closed. Report it instead of leaving an unbalanced factory call behind.
+    RaiseJSXError(Format('JSX: Unterminated opening tag <%s>', [TagName]));
   finally
     Dec(FJSXDepth);
   end;
@@ -788,6 +840,7 @@ var
   Depth: Integer;
   ValueStart: Integer;
   I: Integer;
+  GuardPosition: Integer;
   HasSpread: Boolean;
   RawExpr: string;
   SubResult: TGocciaJSXTransformResult;
@@ -812,8 +865,10 @@ begin
   SegmentCount := 0;
   AttrCount := 0;
   CurrentObjAttrs := TStringBuffer.Create;
+  GuardPosition := 0;
   while not IsAtEnd do
   begin
+    RequireScanProgress(GuardPosition, JSX_CONTEXT_ATTRIBUTES);
     SkipWhitespace;
     if IsAtEnd or (CurrentChar = '>') or ((CurrentChar = '/') and (PeekAt(1) = '>')) then
       Break;
@@ -944,7 +999,8 @@ begin
             AdvanceInput;
         end;
         RawExpr := Trim(Copy(FSource, ValueStart, FPos - ValueStart));
-        SubResult := TGocciaJSXTransformer.Transform(RawExpr, FFactoryName, FFragmentName);
+        SubResult := TGocciaJSXTransformer.Transform(RawExpr, FFileName,
+          FFactoryName, FFragmentName);
         if Assigned(SubResult.SourceMap) then
           SubResult.SourceMap.Free;
         CurrentObjAttrs.Append(' ' + FormatPropertyKey(AttrName) + ': ' + SubResult.Source);
@@ -984,9 +1040,12 @@ procedure TGocciaJSXTransformer.EmitJSXChildren(const ATagName: string);
 var
   Text: string;
   ChildStartLine, ChildStartColumn: Integer;
+  GuardPosition: Integer;
 begin
+  GuardPosition := 0;
   while not IsAtEnd do
   begin
+    RequireScanProgress(GuardPosition, JSX_CONTEXT_CHILDREN);
     if CurrentChar = '<' then
     begin
       if PeekAt(1) = '/' then
@@ -1054,13 +1113,16 @@ var
   Quote: Char;
   SavedTokenKind: TLastTokenKind;
   IdStart: Integer;
+  GuardPosition: Integer;
   Ident: string;
 begin
   Depth := 0;
+  GuardPosition := 0;
   SavedTokenKind := FLastTokenKind;
   FLastTokenKind := ltkOperator;
   while not IsAtEnd do
   begin
+    RequireScanProgress(GuardPosition, JSX_CONTEXT_EXPRESSION);
     case CurrentChar of
       '{':
       begin
@@ -1257,7 +1319,8 @@ begin
   if not IsAtEnd and (CurrentChar = '>') then
     AdvanceInput;
   if ClosingTag <> ATagName then
-    raise Exception.CreateFmt('JSX: Expected closing tag </%s> but found </%s> at line %d', [ATagName, ClosingTag, FLine]);
+    RaiseJSXError(Format('JSX: Expected closing tag </%s> but found </%s>',
+      [ATagName, ClosingTag]));
 end;
 
 procedure TGocciaJSXTransformer.ScanPragmas;
@@ -1366,10 +1429,13 @@ end;
 procedure TGocciaJSXTransformer.TransformSource;
 var
   C: Char;
+  GuardPosition: Integer;
 begin
   AddIdentityMapping;
+  GuardPosition := 0;
   while not IsAtEnd do
   begin
+    RequireScanProgress(GuardPosition, JSX_CONTEXT_SOURCE);
     C := CurrentChar;
 
     if (C = '/') and (PeekAt(1) = '/') then

--- a/source/units/Goccia.SourcePipeline.pas
+++ b/source/units/Goccia.SourcePipeline.pas
@@ -174,7 +174,7 @@ begin
     Result.Assign(ASource);
 end;
 
-function ApplyPreprocessors(const ASource: string;
+function ApplyPreprocessors(const ASource, AFileName: string;
   const AOptions: TGocciaSourcePipelineOptions;
   out ASourceMap: TGocciaSourceMap): string;
 var
@@ -185,7 +185,7 @@ begin
 
   if ppJSX in AOptions.Preprocessors then
   begin
-    JSXResult := TGocciaJSXTransformer.Transform(Result);
+    JSXResult := TGocciaJSXTransformer.Transform(Result, AFileName);
     Result := JSXResult.Source;
     ASourceMap := JSXResult.SourceMap;
   end;
@@ -513,7 +513,19 @@ begin
       SourceText := '';
     OriginalSourceText := SourceText;
 
-    SourceText := ApplyPreprocessors(SourceText, AOptions, PreprocessorSourceMap);
+    try
+      SourceText := ApplyPreprocessors(SourceText, AFileName, AOptions,
+        PreprocessorSourceMap);
+    except
+      on E: TGocciaError do
+      begin
+        // A preprocessor error is already positioned in the original source —
+        // no source map exists yet — so only the source context is missing for
+        // the caret display the parser errors below get for free.
+        E.TranslatePosition(E.Line, E.Column, ASource);
+        raise;
+      end;
+    end;
     Result.FSourceMap := PreprocessorSourceMap;
     if Assigned(Result.FSourceMap) then
     begin
@@ -738,7 +750,7 @@ begin
 
   OriginalSourceLines := CreateECMAScriptSourceLines(Source);
   try
-    Source := ApplyPreprocessors(Source, AOptions, SourceMap);
+    Source := ApplyPreprocessors(Source, AFileName, AOptions, SourceMap);
     try
       Lexer := TGocciaLexer.Create(Source, AFileName);
       try

--- a/source/units/Goccia.SourcePipeline.pas
+++ b/source/units/Goccia.SourcePipeline.pas
@@ -750,7 +750,18 @@ begin
 
   OriginalSourceLines := CreateECMAScriptSourceLines(Source);
   try
-    Source := ApplyPreprocessors(Source, AFileName, AOptions, SourceMap);
+    try
+      Source := ApplyPreprocessors(Source, AFileName, AOptions, SourceMap);
+    except
+      on E: TGocciaError do
+      begin
+        // A preprocessor error is positioned in the wrapper source, which is
+        // exactly what OriginalSourceLines holds — attach it so the caret
+        // display matches the coordinates the error already carries.
+        E.TranslatePosition(E.Line, E.Column, OriginalSourceLines);
+        raise;
+      end;
+    end;
     try
       Lexer := TGocciaLexer.Create(Source, AFileName);
       try


### PR DESCRIPTION
## Summary

- Fixes a DoS-class infinite loop: the JSX source preprocessor could spin forever at 100% CPU without consuming input when its attribute scanner met a non-attribute character (e.g. `,` in `<T,>` after a `: <T>` annotation put it in JSX-children mode) — before parsing, in both execution modes, unaffected by any timeout (handover finding F1).
- One centralized zero-progress guard now covers every transformer scan loop, and all transformer diagnostics surface as positioned `TGocciaSyntaxError` through the normal load-error path (caret display, JSON envelope, exit 1). Nested attribute sub-transform errors rebase onto the enclosing source position; namespaced-attribute JSX reports "unsupported" instead of "runaway".
- Non-goal: no change to the `IsJSXStart` heuristic or JSX semantics — TS type-syntax parsing is a later layer of this stack.

Part of the 0.11.0 adversarial-findings stacked-PR train (8 layers, each PR targets the layer below; merge bottom-up). Mini-spec: fix the differential-testing findings F1–F13/G4/G5 — JSX-transformer hang, toThrow semantics, Vitest matcher parity, coverage consistency, TS type-syntax gaps, AbortSignal events — and land the goccia-vs-bun differential battery harness as a CI gate, green at every layer.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full suite green in both modes; hang repro now errors in ~24ms; 4 line-pinned regression cases in `scripts/test-cli-parser.ts` (each fails against the pre-fix binary)
- [x] Updated documentation — `docs/language.md` (heuristic tag detection, namespaced-attribute limitation)
- [x] Optional: native Pascal tests — n/a (no AST/scope/evaluator/value-type changes)
- [ ] Optional: benchmark coverage — n/a (error paths only; the guard is a position comparison per loop iteration)

Review: fresh-context review passed ("ship"); its three error-reporting findings are fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
