### PR TITLE
fix(engine): check nullish base before property-key coercion

### DIFF
--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -1840,8 +1840,14 @@ begin
   end;
 
   Obj := ObjectExpr.Evaluate(AContext);
-  PropertyValue := ToPropertyKey(PropertyExpression.Evaluate(AContext));
+  // ES2026 §13.3.3 stores the UNCONVERTED key in the Reference Record, and its
+  // NOTE calls out this exact form: for `a[b] = c`, ToPropertyKey is not performed
+  // until after evaluation of `c`. So evaluate the key expression, then the RHS,
+  // and only then apply §6.2.5.6 PutValue step 3.a (nullish base throws) followed
+  // by step 3.c (ToPropertyKey).
+  PropertyValue := PropertyExpression.Evaluate(AContext);
   Result := Value.Evaluate(AContext);
+  PropertyValue := ToPropertyKeyForBase(Obj, PropertyValue, True);
   if PropertyValue is TGocciaSymbolValue then
     AssignSymbolProperty(Obj, TGocciaSymbolValue(PropertyValue),
       Result, AContext.OnError, Line, Column, AContext.NonStrictMode)
@@ -2099,7 +2105,10 @@ begin
   end;
 
   Obj := ObjectExpr.Evaluate(AContext);
-  PropertyKeyValue := ToPropertyKey(PropertyExpression.Evaluate(AContext));
+  // ES2026 §13.15.2 compound assignment reads through §6.2.5.5 GetValue, whose
+  // step 3.a base check precedes the step 3.c ToPropertyKey conversion.
+  PropertyKeyValue := ToPropertyKeyForBase(Obj,
+    PropertyExpression.Evaluate(AContext));
   if PropertyKeyValue is TGocciaSymbolValue then
   begin
     CurrentValue := NormalizeAssignmentValue(ReadSymbolProperty(Obj,
@@ -2192,7 +2201,10 @@ begin
     Obj := MemberExpr.ObjectExpr.Evaluate(AContext);
     if MemberExpr.Computed then
     begin
-      PropertyKeyValue := ToPropertyKey(MemberExpr.PropertyExpression.Evaluate(AContext));
+      // ES2026 §13.4.2/§13.4.3 UpdateExpression reads via §6.2.5.5 GetValue, whose
+      // step 3.a base check precedes the step 3.c ToPropertyKey conversion.
+      PropertyKeyValue := ToPropertyKeyForBase(Obj,
+        MemberExpr.PropertyExpression.Evaluate(AContext));
       if (PropertyKeyValue is TGocciaSymbolValue) and ((Obj is TGocciaClassValue) or (Obj is TGocciaObjectValue)) then
       begin
         if Obj is TGocciaClassValue then

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -180,6 +180,13 @@ const
   COLLECTION_OP_TRY_ITERABLE_TO_ARRAY = 3;
   VALIDATE_OP_REQUIRE_OBJECT = 0;
   VALIDATE_OP_REQUIRE_ITERABLE = 1;
+  // Same nullish-base rejection as VALIDATE_OP_REQUIRE_OBJECT, but for a computed
+  // *member* base (`a[k]++`, `a[k] += v`, `a[k] ??= v`) rather than a destructuring
+  // pattern, so it reports the ES2026 §6.2.5.5 GetValue step 3.a "cannot read
+  // properties of null" wording instead of the destructuring wording. The C operand
+  // carries the key register, still holding the UNCOERCED key: this validate is
+  // emitted before OP_TO_PROPERTY_KEY precisely so step 3.a precedes step 3.c.
+  VALIDATE_OP_REQUIRE_OBJECT_FOR_MEMBER = 2;
   ITER_CLOSE_NORMAL = 0;
   ITER_CLOSE_PRESERVE_ERROR = 1;
   ITER_CLOSE_PRESERVE_UNLESS_GENERATOR_RETURN = 2;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -163,7 +163,10 @@ const
   //               Number subtraction and less-than-or-equal branches.
   //   v74 -> v75: added a direct scalar-frame self-call opcode for functions
   //               accepted by the closed-world numeric-call proof.
-  GOCCIA_FORMAT_VERSION = 75;
+  //   v75 -> v76: added the VALIDATE_OP_REQUIRE_OBJECT_FOR_MEMBER validation
+  //               mode, which rejects a nullish computed-member base before the
+  //               key is coerced and carries the key register in operand C.
+  GOCCIA_FORMAT_VERSION = 76;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -6365,7 +6365,7 @@ begin
     ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
     ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
     EmitInstruction(ACtx, EncodeABC(OP_VALIDATE_VALUE, ObjReg,
-      VALIDATE_OP_REQUIRE_OBJECT, 0));
+      VALIDATE_OP_REQUIRE_OBJECT_FOR_MEMBER, KeyReg));
     EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
     EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
     JumpIdx := EmitJumpInstruction(ACtx, ShortCircuitJumpOp(AExpr.Operator), CurReg);
@@ -6392,7 +6392,7 @@ begin
   ACtx.CompileExpression(AExpr.ObjectExpr, ObjReg);
   ACtx.CompileExpression(AExpr.PropertyExpression, KeyReg);
   EmitInstruction(ACtx, EncodeABC(OP_VALIDATE_VALUE, ObjReg,
-    VALIDATE_OP_REQUIRE_OBJECT, 0));
+    VALIDATE_OP_REQUIRE_OBJECT_FOR_MEMBER, KeyReg));
   EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
   EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
   ACtx.CompileExpression(AExpr.Value, ValReg);
@@ -6503,7 +6503,7 @@ begin
   ACtx.CompileExpression(AMember.ObjectExpr, ObjReg);
   ACtx.CompileExpression(AMember.PropertyExpression, KeyReg);
   EmitInstruction(ACtx, EncodeABC(OP_VALIDATE_VALUE, ObjReg,
-    VALIDATE_OP_REQUIRE_OBJECT, 0));
+    VALIDATE_OP_REQUIRE_OBJECT_FOR_MEMBER, KeyReg));
   EmitInstruction(ACtx, EncodeABC(OP_TO_PROPERTY_KEY, KeyReg, KeyReg, 0));
   EmitInstruction(ACtx, EncodeABC(OP_ARRAY_GET, CurReg, ObjReg, KeyReg));
   EmitIncrementStep(ACtx, AExpr, ADest, CurReg, AOp, ANumericOp,

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -4735,20 +4735,18 @@ begin
 
   // Determine the property name. ES2026 §7.1.19 ToPropertyKey on the
   // computed expression: symbols pass through; otherwise coerce via
-  // ToPrimitive(string) → ToString.
+  // ToPrimitive(string) → ToString. ToPropertyKeyForBase applies §6.2.5.5
+  // GetValue step 3.a first, so a nullish base throws a TypeError before the key
+  // is coerced (its toString/valueOf must not run).
   if AMemberExpression.Computed and Assigned(AMemberExpression.PropertyExpression) then
   begin
     PropertyValue := EvaluateExpression(AMemberExpression.PropertyExpression, AContext);
     AddValueRoot(Roots, PropertyValue);
-    PropertyKey := ToPropertyKey(PropertyValue);
+    PropertyKey := ToPropertyKeyForBase(Obj, PropertyValue);
     AddValueRoot(Roots, PropertyKey);
 
     if PropertyKey is TGocciaSymbolValue then
     begin
-      if (Obj is TGocciaNullLiteralValue) or (Obj is TGocciaUndefinedLiteralValue) then
-        ThrowTypeError(Format(SErrorCannotReadPropertiesOf, [Obj.ToStringLiteral.Value, 'Symbol()']),
-          SSuggestCheckNullBeforeAccess);
-
       if Obj is TGocciaClassValue then
       begin
         Result := TGocciaClassValue(Obj).GetSymbolProperty(TGocciaSymbolValue(PropertyKey));
@@ -11859,7 +11857,10 @@ begin
         AContext.NonStrictMode);
     pdrComputedProperty:
       begin
-        PropValue := ToPropertyKey(AReference.ComputedKeyValue);
+        // ES2026 §6.2.5.6 PutValue step 3.a before step 3.c: a nullish base
+        // throws a TypeError before the stored key value is coerced.
+        PropValue := ToPropertyKeyForBase(AReference.ObjectValue,
+          AReference.ComputedKeyValue, True);
         if PropValue is TGocciaSymbolValue then
           AssignSymbolProperty(AReference.ObjectValue,
             TGocciaSymbolValue(PropValue), AValue, AContext.OnError,
@@ -12208,8 +12209,11 @@ begin
   if MemberExpr.Computed then
   begin
     // ES2026 §13.5.1.2 PropertyDestructuringAssignmentEvaluation step 5:
-    // ToPropertyKey on the computed key.
-    PropValue := ToPropertyKey(EvaluateExpression(MemberExpr.PropertyExpression, AContext));
+    // ToPropertyKey on the computed key — but the store goes through §6.2.5.6
+    // PutValue, whose step 3.a base check precedes step 3.c, so a nullish base
+    // throws before the key is coerced.
+    PropValue := ToPropertyKeyForBase(Obj,
+      EvaluateExpression(MemberExpr.PropertyExpression, AContext), True);
     if PropValue is TGocciaSymbolValue then
       AssignSymbolProperty(Obj, TGocciaSymbolValue(PropValue), AValue,
         AContext.OnError, APattern.Line, APattern.Column,
@@ -12659,31 +12663,10 @@ begin
     begin
       PropertyKey := EvaluateExpression(MemberExpr.PropertyExpression, AContext);
 
-      if (ObjValue is TGocciaNullLiteralValue) or
-         (ObjValue is TGocciaUndefinedLiteralValue) then
-      begin
-        if PropertyKey is TGocciaSymbolValue then
-          ThrowTypeError(Format(SErrorCannotReadPropertiesOf,
-            [ObjValue.ToStringLiteral.Value,
-             TGocciaSymbolValue(PropertyKey).ToDisplayString.Value]),
-            SSuggestCheckNullBeforeAccess)
-        else if PropertyKey is TGocciaStringLiteralValue then
-          ThrowTypeError(Format(SErrorCannotReadPropertiesOf,
-            [ObjValue.ToStringLiteral.Value,
-             TGocciaStringLiteralValue(PropertyKey).Value]),
-            SSuggestCheckNullBeforeAccess)
-        else if PropertyKey is TGocciaNumberLiteralValue then
-          ThrowTypeError(Format(SErrorCannotReadPropertiesOf,
-            [ObjValue.ToStringLiteral.Value,
-             FormatDouble(TGocciaNumberLiteralValue(PropertyKey).Value)]),
-            SSuggestCheckNullBeforeAccess)
-        else
-          ThrowTypeError(Format(SErrorCannotReadPropertiesOf,
-            [ObjValue.ToStringLiteral.Value, '<computed>']),
-            SSuggestCheckNullBeforeAccess);
-      end;
-
-      PropertyKey := ToPropertyKey(PropertyKey);
+      // ES2026 §13.5.1.2 delete on a property reference resolves the base through
+      // ToObject before the key is converted, so the nullish-base TypeError wins
+      // over any key-coercion side effect.
+      PropertyKey := ToPropertyKeyForBase(ObjValue, PropertyKey);
       if PropertyKey is TGocciaSymbolValue then
       begin
         IsSymbolKey := True;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -279,6 +279,10 @@ type
     function ResolveDynamicUpvalueScope(const AIndex: Integer;
       const AName: string): TGocciaScope;
     function KeyDisplaySafe(const AKey: TGocciaRegister): string;
+    procedure ThrowNullishBasePropertyAccess(const ABaseKind: TGocciaRegisterKind;
+      const AKeyReg: TGocciaRegister; const AForWrite: Boolean);
+    procedure RequireCoercibleBaseRegister(const ABaseReg,
+      AKeyReg: TGocciaRegister; const AForWrite: Boolean); {$IFDEF FPC}inline;{$ENDIF}
     // ALimit semantics:
     //   ALimit < 0 → unbounded (drain until iterator returns done:true);
     //   ALimit = 0 → consume zero elements (used for `const [] = iter`);
@@ -8088,18 +8092,10 @@ var
   FastIndex: Integer;
   FastElement: Double;
 begin
-  // ES2026 §6.2.5.5 GetValue step 3.a: ToObject on the Reference Record's [[Base]]
-  // throws for null/undefined before step 3.c runs ToPropertyKey on the referenced
-  // name. KeyDisplaySafe names the key without invoking user code, which is
-  // required here precisely because the key has not been coerced yet.
+  // ES2026 §6.2.5.5 GetValue step 3.a runs before step 3.c ToPropertyKey.
   if (caoThrowOnNullUndefined in AOptions) and
-     (AObjReg.Kind = grkNull) then
-    ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull,
-      [KeyDisplaySafe(AKeyReg)]), SSuggestCheckNullBeforeAccess)
-  else if (caoThrowOnNullUndefined in AOptions) and
-          (AObjReg.Kind = grkUndefined) then
-    ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined,
-      [KeyDisplaySafe(AKeyReg)]), SSuggestCheckNullBeforeAccess)
+     (AObjReg.Kind in [grkNull, grkUndefined]) then
+    ThrowNullishBasePropertyAccess(AObjReg.Kind, AKeyReg, False)
   else if (AObjReg.Kind = grkObject) and
           (AObjReg.ObjectValue is TGocciaTypedArrayValue) and
           TryGetArrayIndexRegister(AKeyReg, FastIndex) and
@@ -8204,17 +8200,10 @@ var
   BoxedTarget: TGocciaObjectValue;
   FastIndex: Integer;
 begin
-  // ES2026 §6.2.5.6 PutValue step 3.a (ToObject on [[Base]]) precedes step 3.c
-  // (ToPropertyKey on [[ReferencedName]]), so a nullish target must throw before
-  // the key register is classified — ClassifyPropertyKey below can run a user
-  // toString/valueOf, and that side effect must not be observable here.
-  // KeyDisplaySafe names the key without coercing it.
-  if FRegisters[ATargetIndex].Kind = grkNull then
-    ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull,
-      [KeyDisplaySafe(AKeyReg)]), SSuggestCheckNullBeforeAccess)
-  else if FRegisters[ATargetIndex].Kind = grkUndefined then
-    ThrowTypeError(Format(SErrorCannotSetPropertiesOfUndefined,
-      [KeyDisplaySafe(AKeyReg)]), SSuggestCheckNullBeforeAccess);
+  // ES2026 §6.2.5.6 PutValue step 3.a precedes step 3.c, so a nullish target must
+  // throw before ClassifyPropertyKey below — that call can run a user
+  // toString/valueOf, and the side effect must not be observable here.
+  RequireCoercibleBaseRegister(FRegisters[ATargetIndex], AKeyReg, True);
 
   // Typed-array unboxed element write: a numeric-scalar value going to a valid
   // integer index stores directly, with no heap TGocciaNumberLiteralValue and no
@@ -8339,14 +8328,8 @@ var
   Deleted: Boolean;
   KeyName: string;
 begin
-  if AObjReg.Kind = grkNull then
-    ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull,
-      [KeyDisplaySafe(AKeyReg)]),
-      SSuggestCheckNullBeforeAccess)
-  else if AObjReg.Kind = grkUndefined then
-    ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined,
-      [KeyDisplaySafe(AKeyReg)]),
-      SSuggestCheckNullBeforeAccess)
+  if AObjReg.Kind in [grkNull, grkUndefined] then
+    ThrowNullishBasePropertyAccess(AObjReg.Kind, AKeyReg, False)
   else if (AObjReg.Kind = grkObject) and
           (AObjReg.ObjectValue is TGocciaObjectValue) then
   begin
@@ -8488,6 +8471,49 @@ begin
   else
     Result := '<computed>';
   end;
+end;
+
+// Throw path only. Kept out of RequireCoercibleBaseRegister — and deliberately
+// not inlined — so the managed string local and its implicit exception frame stay
+// off every computed member access.
+procedure TGocciaVM.ThrowNullishBasePropertyAccess(
+  const ABaseKind: TGocciaRegisterKind; const AKeyReg: TGocciaRegister;
+  const AForWrite: Boolean);
+var
+  KeyText: string;
+begin
+  // The key has not been coerced yet, so it must be named without invoking user
+  // code (ES2026 §6.2.5.5 GetValue step 3.a runs before step 3.c ToPropertyKey).
+  KeyText := KeyDisplaySafe(AKeyReg);
+  if AForWrite then
+  begin
+    if ABaseKind = grkNull then
+      ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, [KeyText]),
+        SSuggestCheckNullBeforeAccess)
+    else
+      ThrowTypeError(Format(SErrorCannotSetPropertiesOfUndefined, [KeyText]),
+        SSuggestCheckNullBeforeAccess);
+  end
+  else
+  begin
+    if ABaseKind = grkNull then
+      ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull, [KeyText]),
+        SSuggestCheckNullBeforeAccess)
+    else
+      ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined, [KeyText]),
+        SSuggestCheckNullBeforeAccess);
+  end;
+end;
+
+// ES2026 §6.2.5.5 GetValue step 3.a / §6.2.5.6 PutValue step 3.a: ToObject on the
+// Reference Record's [[Base]] throws a TypeError for null/undefined, and it does so
+// before step 3.c converts [[ReferencedName]] via ToPropertyKey. Pass AForWrite for
+// store targets so the message reads "cannot set properties".
+procedure TGocciaVM.RequireCoercibleBaseRegister(const ABaseReg,
+  AKeyReg: TGocciaRegister; const AForWrite: Boolean);
+begin
+  if ABaseReg.Kind in [grkNull, grkUndefined] then
+    ThrowNullishBasePropertyAccess(ABaseReg.Kind, AKeyReg, AForWrite);
 end;
 
 // IteratorClose for the raw-object form returned by GetIteratorValue
@@ -14918,12 +14944,7 @@ begin
         // base before SetIndexValueLoose classifies (and possibly coerces) the key.
         // Sloppy mode does not relax this — only the "assignment failed" case at
         // step 3.e is strict-only.
-        if FRegisters[A].Kind = grkNull then
-          ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull,
-            [KeyDisplaySafe(FRegisters[B])]), SSuggestCheckNullBeforeAccess)
-        else if FRegisters[A].Kind = grkUndefined then
-          ThrowTypeError(Format(SErrorCannotSetPropertiesOfUndefined,
-            [KeyDisplaySafe(FRegisters[B])]), SSuggestCheckNullBeforeAccess);
+        RequireCoercibleBaseRegister(FRegisters[A], FRegisters[B], True);
 
         RightValue := RegisterToValue(FRegisters[C]);
         TargetValue := GetRegister(A);
@@ -17230,17 +17251,9 @@ begin
             end;
 
           // ES2026 §6.2.5.5 GetValue step 3.a on a computed member base. C holds
-          // the key register, still uncoerced (this runs before OP_TO_PROPERTY_KEY),
-          // so KeyDisplaySafe names it without invoking user code.
+          // the key register, still uncoerced (this runs before OP_TO_PROPERTY_KEY).
           VALIDATE_OP_REQUIRE_OBJECT_FOR_MEMBER:
-            begin
-              if FRegisters[A].Kind = grkNull then
-                ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull,
-                  [KeyDisplaySafe(FRegisters[C])]), SSuggestCheckNullBeforeAccess)
-              else if FRegisters[A].Kind = grkUndefined then
-                ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined,
-                  [KeyDisplaySafe(FRegisters[C])]), SSuggestCheckNullBeforeAccess);
-            end;
+            RequireCoercibleBaseRegister(FRegisters[A], FRegisters[C], False);
 
           VALIDATE_OP_REQUIRE_ITERABLE:
             // Operand C is the iteration bound emitted by the compiler

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -8088,10 +8088,18 @@ var
   FastIndex: Integer;
   FastElement: Double;
 begin
+  // ES2026 §6.2.5.5 GetValue step 3.a: ToObject on the Reference Record's [[Base]]
+  // throws for null/undefined before step 3.c runs ToPropertyKey on the referenced
+  // name. KeyDisplaySafe names the key without invoking user code, which is
+  // required here precisely because the key has not been coerced yet.
   if (caoThrowOnNullUndefined in AOptions) and
-     (AObjReg.Kind in [grkUndefined, grkNull]) then
-    ThrowTypeError(SErrorCannotConvertNullOrUndefined,
-      SSuggestCheckNullBeforeAccess)
+     (AObjReg.Kind = grkNull) then
+    ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull,
+      [KeyDisplaySafe(AKeyReg)]), SSuggestCheckNullBeforeAccess)
+  else if (caoThrowOnNullUndefined in AOptions) and
+          (AObjReg.Kind = grkUndefined) then
+    ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined,
+      [KeyDisplaySafe(AKeyReg)]), SSuggestCheckNullBeforeAccess)
   else if (AObjReg.Kind = grkObject) and
           (AObjReg.ObjectValue is TGocciaTypedArrayValue) and
           TryGetArrayIndexRegister(AKeyReg, FastIndex) and
@@ -8196,6 +8204,18 @@ var
   BoxedTarget: TGocciaObjectValue;
   FastIndex: Integer;
 begin
+  // ES2026 §6.2.5.6 PutValue step 3.a (ToObject on [[Base]]) precedes step 3.c
+  // (ToPropertyKey on [[ReferencedName]]), so a nullish target must throw before
+  // the key register is classified — ClassifyPropertyKey below can run a user
+  // toString/valueOf, and that side effect must not be observable here.
+  // KeyDisplaySafe names the key without coercing it.
+  if FRegisters[ATargetIndex].Kind = grkNull then
+    ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull,
+      [KeyDisplaySafe(AKeyReg)]), SSuggestCheckNullBeforeAccess)
+  else if FRegisters[ATargetIndex].Kind = grkUndefined then
+    ThrowTypeError(Format(SErrorCannotSetPropertiesOfUndefined,
+      [KeyDisplaySafe(AKeyReg)]), SSuggestCheckNullBeforeAccess);
+
   // Typed-array unboxed element write: a numeric-scalar value going to a valid
   // integer index stores directly, with no heap TGocciaNumberLiteralValue and no
   // IntToStr index name. ToNumber on a Number is side-effect-free, so the spec's
@@ -14894,6 +14914,17 @@ begin
 
       OP_SET_INDEX_LOOSE:
       begin
+        // ES2026 §6.2.5.6 PutValue step 3.a precedes step 3.c: reject a nullish
+        // base before SetIndexValueLoose classifies (and possibly coerces) the key.
+        // Sloppy mode does not relax this — only the "assignment failed" case at
+        // step 3.e is strict-only.
+        if FRegisters[A].Kind = grkNull then
+          ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull,
+            [KeyDisplaySafe(FRegisters[B])]), SSuggestCheckNullBeforeAccess)
+        else if FRegisters[A].Kind = grkUndefined then
+          ThrowTypeError(Format(SErrorCannotSetPropertiesOfUndefined,
+            [KeyDisplaySafe(FRegisters[B])]), SSuggestCheckNullBeforeAccess);
+
         RightValue := RegisterToValue(FRegisters[C]);
         TargetValue := GetRegister(A);
         if (TargetValue is TGocciaClassValue) or
@@ -17196,6 +17227,19 @@ begin
               if FRegisters[A].Kind in [grkNull, grkUndefined] then
                 ThrowTypeError(Format(SErrorCannotDestructureNotObject, [RegisterToValue(FRegisters[A]).ToStringLiteral.Value]),
                   SSuggestDestructureRequiresObject);
+            end;
+
+          // ES2026 §6.2.5.5 GetValue step 3.a on a computed member base. C holds
+          // the key register, still uncoerced (this runs before OP_TO_PROPERTY_KEY),
+          // so KeyDisplaySafe names it without invoking user code.
+          VALIDATE_OP_REQUIRE_OBJECT_FOR_MEMBER:
+            begin
+              if FRegisters[A].Kind = grkNull then
+                ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull,
+                  [KeyDisplaySafe(FRegisters[C])]), SSuggestCheckNullBeforeAccess)
+              else if FRegisters[A].Kind = grkUndefined then
+                ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined,
+                  [KeyDisplaySafe(FRegisters[C])]), SSuggestCheckNullBeforeAccess);
             end;
 
           VALIDATE_OP_REQUIRE_ITERABLE:

--- a/source/units/Goccia.Values.ToPrimitive.pas
+++ b/source/units/Goccia.Values.ToPrimitive.pas
@@ -17,21 +17,12 @@ function ToPrimitive(const AValue: TGocciaValue; const AHint: TGocciaToPrimitive
 // else is coerced via ToString. Callers must check the returned type.
 function ToPropertyKey(const AValue: TGocciaValue): TGocciaValue;
 
-// ES2026 §6.2.5.5 GetValue step 3.a and §6.2.5.6 PutValue step 3.a perform
-// ToObject(_V_.[[Base]]) — which throws a *TypeError* for null/undefined — BEFORE
-// step 3.c converts _V_.[[ReferencedName]] with ToPropertyKey. Since §13.3.3
-// EvaluatePropertyAccessWithExpressionKey stores the *unconverted* key value in the
-// Reference Record, a nullish base must be rejected before the key expression's
-// result is coerced: a throwing or observable toString/valueOf on the key must not
-// run. Note that the key *expression* is still evaluated first (§13.3.3 step 1);
-// only the ToPropertyKey conversion is ordered after the base check.
-//
-// Every computed property access on a possibly-nullish base must therefore call
+// Every computed property access on a possibly-nullish base must call
 // ToPropertyKeyForBase rather than a bare ToPropertyKey. Pass AForWrite for store
-// targets (PutValue) so the message reads "cannot set properties" rather than
-// "cannot read properties".
+// targets so the message reads "cannot set properties" rather than "cannot read
+// properties".
 procedure RequireCoercibleBaseForPropertyAccess(const ABase, AUncoercedKey: TGocciaValue;
-  const AForWrite: Boolean = False);
+  const AForWrite: Boolean = False); {$IFDEF FPC}inline;{$ENDIF}
 function ToPropertyKeyForBase(const ABase, AUncoercedKey: TGocciaValue;
   const AForWrite: Boolean = False): TGocciaValue;
 
@@ -202,15 +193,14 @@ begin
     Result := '<computed>';
 end;
 
-procedure RequireCoercibleBaseForPropertyAccess(const ABase, AUncoercedKey: TGocciaValue;
+// Throw path only. Split out of RequireCoercibleBaseForPropertyAccess — and
+// deliberately not inlined — so the managed string local and the implicit
+// exception frame FPC emits for it stay off every computed member access.
+procedure ThrowNullishBasePropertyAccess(const ABase, AUncoercedKey: TGocciaValue;
   const AForWrite: Boolean);
 var
   KeyText: string;
 begin
-  if not ((ABase is TGocciaNullLiteralValue) or
-          (ABase is TGocciaUndefinedLiteralValue)) then
-    Exit;
-
   KeyText := DescribeUncoercedPropertyKey(AUncoercedKey);
   if AForWrite then
   begin
@@ -232,6 +222,26 @@ begin
   end;
 end;
 
+// ES2026 §6.2.5.5 GetValue step 3.a and §6.2.5.6 PutValue step 3.a perform
+// ToObject(_V_.[[Base]]) — which throws a *TypeError* for null/undefined — BEFORE
+// step 3.c converts _V_.[[ReferencedName]] with ToPropertyKey. Since §13.3.3
+// EvaluatePropertyAccessWithExpressionKey stores the *unconverted* key value in the
+// Reference Record, a nullish base must be rejected before the key expression's
+// result is coerced: a throwing or observable toString/valueOf on the key must not
+// run. The key *expression* is still evaluated first (§13.3.3 step 1); only the
+// ToPropertyKey conversion is ordered after the base check.
+//
+// Hot path: no managed locals here, so FPC emits no implicit exception frame.
+procedure RequireCoercibleBaseForPropertyAccess(const ABase, AUncoercedKey: TGocciaValue;
+  const AForWrite: Boolean);
+begin
+  if (ABase is TGocciaNullLiteralValue) or
+     (ABase is TGocciaUndefinedLiteralValue) then
+    ThrowNullishBasePropertyAccess(ABase, AUncoercedKey, AForWrite);
+end;
+
+// ES2026 §6.2.5.5 GetValue steps 3.a then 3.c (or §6.2.5.6 PutValue, same order):
+// reject a nullish base, then convert the referenced name with ToPropertyKey.
 function ToPropertyKeyForBase(const ABase, AUncoercedKey: TGocciaValue;
   const AForWrite: Boolean): TGocciaValue;
 begin

--- a/source/units/Goccia.Values.ToPrimitive.pas
+++ b/source/units/Goccia.Values.ToPrimitive.pas
@@ -17,9 +17,29 @@ function ToPrimitive(const AValue: TGocciaValue; const AHint: TGocciaToPrimitive
 // else is coerced via ToString. Callers must check the returned type.
 function ToPropertyKey(const AValue: TGocciaValue): TGocciaValue;
 
+// ES2026 §6.2.5.5 GetValue step 3.a and §6.2.5.6 PutValue step 3.a perform
+// ToObject(_V_.[[Base]]) — which throws a *TypeError* for null/undefined — BEFORE
+// step 3.c converts _V_.[[ReferencedName]] with ToPropertyKey. Since §13.3.3
+// EvaluatePropertyAccessWithExpressionKey stores the *unconverted* key value in the
+// Reference Record, a nullish base must be rejected before the key expression's
+// result is coerced: a throwing or observable toString/valueOf on the key must not
+// run. Note that the key *expression* is still evaluated first (§13.3.3 step 1);
+// only the ToPropertyKey conversion is ordered after the base check.
+//
+// Every computed property access on a possibly-nullish base must therefore call
+// ToPropertyKeyForBase rather than a bare ToPropertyKey. Pass AForWrite for store
+// targets (PutValue) so the message reads "cannot set properties" rather than
+// "cannot read properties".
+procedure RequireCoercibleBaseForPropertyAccess(const ABase, AUncoercedKey: TGocciaValue;
+  const AForWrite: Boolean = False);
+function ToPropertyKeyForBase(const ABase, AUncoercedKey: TGocciaValue;
+  const AForWrite: Boolean = False): TGocciaValue;
+
 implementation
 
 uses
+  SysUtils,
+
   Goccia.Arguments.Collection,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
@@ -165,6 +185,58 @@ begin
   // Step 3: Return ! ToString(key). Prim is a primitive here, so ToStringLiteral
   // on it cannot re-enter user code.
   Result := Prim.ToStringLiteral;
+end;
+
+// Name the key for the TypeError message without invoking user code. The whole
+// point of the base check is that ToPropertyKey has not run yet, so only keys that
+// are already primitives can be named exactly; object keys report '<computed>'.
+function DescribeUncoercedPropertyKey(const AKeyValue: TGocciaValue): string;
+begin
+  // Symbols are primitives but ToStringLiteral throws on them (ES2026 §7.1.17),
+  // so use the non-throwing description instead.
+  if AKeyValue is TGocciaSymbolValue then
+    Result := TGocciaSymbolValue(AKeyValue).ToDisplayString.Value
+  else if AKeyValue.IsPrimitive then
+    Result := AKeyValue.ToStringLiteral.Value
+  else
+    Result := '<computed>';
+end;
+
+procedure RequireCoercibleBaseForPropertyAccess(const ABase, AUncoercedKey: TGocciaValue;
+  const AForWrite: Boolean);
+var
+  KeyText: string;
+begin
+  if not ((ABase is TGocciaNullLiteralValue) or
+          (ABase is TGocciaUndefinedLiteralValue)) then
+    Exit;
+
+  KeyText := DescribeUncoercedPropertyKey(AUncoercedKey);
+  if AForWrite then
+  begin
+    if ABase is TGocciaNullLiteralValue then
+      ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, [KeyText]),
+        SSuggestCheckNullBeforeAccess)
+    else
+      ThrowTypeError(Format(SErrorCannotSetPropertiesOfUndefined, [KeyText]),
+        SSuggestCheckNullBeforeAccess);
+  end
+  else
+  begin
+    if ABase is TGocciaNullLiteralValue then
+      ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull, [KeyText]),
+        SSuggestCheckNullBeforeAccess)
+    else
+      ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined, [KeyText]),
+        SSuggestCheckNullBeforeAccess);
+  end;
+end;
+
+function ToPropertyKeyForBase(const ABase, AUncoercedKey: TGocciaValue;
+  const AForWrite: Boolean): TGocciaValue;
+begin
+  RequireCoercibleBaseForPropertyAccess(ABase, AUncoercedKey, AForWrite);
+  Result := ToPropertyKey(AUncoercedKey);
 end;
 
 end.

--- a/tests/language/expressions/member-access/nullish-base-before-key-coercion.js
+++ b/tests/language/expressions/member-access/nullish-base-before-key-coercion.js
@@ -1,0 +1,206 @@
+/*---
+description: A nullish base throws TypeError before the computed key is coerced to a property key
+esid: sec-evaluate-property-access-with-expression-key
+features: [optional-chaining, Symbol.toPrimitive]
+---*/
+
+// ES2026 §13.3.3 EvaluatePropertyAccessWithExpressionKey stores the *unconverted*
+// key value in the Reference Record. §6.2.5.5 GetValue and §6.2.5.6 PutValue then
+// run ToObject on the base (step 3.a) *before* ToPropertyKey on the referenced name
+// (step 3.c). So a nullish base must throw a TypeError before the key expression's
+// result is coerced, and the key's toString/valueOf must never run.
+//
+// These assertions use an explicit instanceof check rather than relying only on the
+// toThrow matcher, so they stay meaningful regardless of matcher strictness.
+
+const throwingKey = () => ({
+  toString() {
+    throw new Error("key side effect");
+  },
+});
+
+// Returns { error, coercions } without depending on toThrow.
+const capture = (fn) => {
+  let coercions = 0;
+  const key = {
+    toString() {
+      coercions++;
+      throw new Error("key side effect");
+    },
+  };
+  let error = null;
+  try {
+    fn(key);
+  } catch (e) {
+    error = e;
+  }
+  return { error, coercions };
+};
+
+test("computed read on a null base throws TypeError before coercing the key", () => {
+  const { error, coercions } = capture((key) => {
+    const base = null;
+    return base[key];
+  });
+
+  expect(error instanceof TypeError).toBe(true);
+  expect(coercions).toBe(0);
+});
+
+test("computed read on an undefined base throws TypeError before coercing the key", () => {
+  const { error, coercions } = capture((key) => {
+    const base = undefined;
+    return base[key];
+  });
+
+  expect(error instanceof TypeError).toBe(true);
+  expect(coercions).toBe(0);
+});
+
+test("postfix increment on a nullish base throws TypeError before coercing the key", () => {
+  const { error, coercions } = capture((key) => {
+    const base = null;
+    return base[key]++;
+  });
+
+  expect(error instanceof TypeError).toBe(true);
+  expect(coercions).toBe(0);
+});
+
+test("prefix decrement on a nullish base throws TypeError before coercing the key", () => {
+  const { error, coercions } = capture((key) => {
+    const base = undefined;
+    return --base[key];
+  });
+
+  expect(error instanceof TypeError).toBe(true);
+  expect(coercions).toBe(0);
+});
+
+test("computed store on a nullish base throws TypeError before coercing the key", () => {
+  const { error, coercions } = capture((key) => {
+    const base = null;
+    base[key] = 1;
+  });
+
+  expect(error instanceof TypeError).toBe(true);
+  expect(coercions).toBe(0);
+});
+
+test("compound assignment on a nullish base throws TypeError before coercing the key", () => {
+  const { error, coercions } = capture((key) => {
+    const base = null;
+    base[key] += 1;
+  });
+
+  expect(error instanceof TypeError).toBe(true);
+  expect(coercions).toBe(0);
+});
+
+test("destructuring into a nullish computed target throws TypeError before coercing the key", () => {
+  const { error, coercions } = capture((key) => {
+    const base = null;
+    [base[key]] = [1];
+  });
+
+  expect(error instanceof TypeError).toBe(true);
+  expect(coercions).toBe(0);
+});
+
+test("delete on a nullish base throws TypeError before coercing the key", () => {
+  const { error, coercions } = capture((key) => {
+    const base = null;
+    delete base[key];
+  });
+
+  expect(error instanceof TypeError).toBe(true);
+  expect(coercions).toBe(0);
+});
+
+test("optional chaining short-circuits without coercing the key", () => {
+  let coercions = 0;
+  const key = {
+    toString() {
+      coercions++;
+      return "a";
+    },
+  };
+  const base = null;
+
+  expect(base?.[key]).toBeUndefined();
+  expect(coercions).toBe(0);
+});
+
+test("the key expression still evaluates before the nullish base check", () => {
+  // §13.3.3 step 1 evaluates the key expression; only the ToPropertyKey
+  // conversion is ordered after the base check.
+  let evaluated = false;
+  const base = null;
+  let error = null;
+
+  try {
+    base[((evaluated = true), throwingKey())];
+  } catch (e) {
+    error = e;
+  }
+
+  expect(evaluated).toBe(true);
+  expect(error instanceof TypeError).toBe(true);
+});
+
+test("a non-nullish base still coerces the computed key", () => {
+  let coercions = 0;
+  const key = {
+    toString() {
+      coercions++;
+      return "a";
+    },
+  };
+
+  expect({ a: 1 }[key]).toBe(1);
+  expect(coercions).toBe(1);
+});
+
+test("a non-nullish base still surfaces a throwing key coercion", () => {
+  let error = null;
+  try {
+    ({})[throwingKey()];
+  } catch (e) {
+    error = e;
+  }
+
+  expect(error instanceof TypeError).toBe(false);
+  expect(error.message).toBe("key side effect");
+});
+
+test("assignment to a nullish computed target still evaluates the right-hand side first", () => {
+  // §13.3.3 NOTE: for `a[b] = c`, ToPropertyKey is not performed until after
+  // evaluation of `c`, and the §6.2.5.6 PutValue base check follows it. So the RHS
+  // runs even though the store then throws.
+  let rhsEvaluations = 0;
+  const base = null;
+  let error = null;
+
+  try {
+    base["a"] = (rhsEvaluations++, 1);
+  } catch (e) {
+    error = e;
+  }
+
+  expect(rhsEvaluations).toBe(1);
+  expect(error instanceof TypeError).toBe(true);
+});
+
+test("a symbol key on a nullish base throws TypeError without a property lookup", () => {
+  const key = Symbol("marker");
+  const base = null;
+  let error = null;
+
+  try {
+    base[key];
+  } catch (e) {
+    error = e;
+  }
+
+  expect(error instanceof TypeError).toBe(true);
+});

--- a/tests/language/expressions/member-access/nullish-base-before-key-coercion.js
+++ b/tests/language/expressions/member-access/nullish-base-before-key-coercion.js
@@ -191,6 +191,47 @@ test("assignment to a nullish computed target still evaluates the right-hand sid
   expect(error instanceof TypeError).toBe(true);
 });
 
+test("the nullish read message is the V8-shaped wording", () => {
+  // Pinned so wording regressions and interpreter/bytecode divergence both fail
+  // here rather than silently drifting; this file runs under both engines.
+  const { error } = capture((key) => {
+    const base = null;
+    return base[key];
+  });
+
+  expect(error.message).toBe(
+    "Cannot read properties of null (reading '<computed>')"
+  );
+});
+
+test("the nullish write message is the V8-shaped wording", () => {
+  const { error } = capture((key) => {
+    const base = undefined;
+    base[key] = 1;
+  });
+
+  expect(error.message).toBe(
+    "Cannot set properties of undefined (setting '<computed>')"
+  );
+});
+
+test("a non-nullish computed store evaluates the right-hand side before the key", () => {
+  // §13.3.3 NOTE: for `a[b] = c`, ToPropertyKey is deferred until after `c`.
+  const order = [];
+  const key = {
+    toString() {
+      order.push("key");
+      return "a";
+    },
+  };
+  const target = {};
+
+  target[key] = (order.push("rhs"), 1);
+
+  expect(order.join(",")).toBe("rhs,key");
+  expect(target.a).toBe(1);
+});
+
 test("a symbol key on a nullish base throws TypeError without a property lookup", () => {
   const key = Symbol("marker");
   const base = null;

--- a/tests/language/non-strict-mode/nullish-base-key-coercion.js
+++ b/tests/language/non-strict-mode/nullish-base-key-coercion.js
@@ -1,0 +1,120 @@
+/*---
+description: Non-strict computed writes on a nullish base still throw TypeError before coercing the key
+esid: sec-putvalue
+features: [compat-non-strict-mode]
+---*/
+
+// Sloppy mode relaxes only ES2026 §6.2.5.6 PutValue step 3.e (a *failed* assignment
+// throws only when [[Strict]] is true). Step 3.a — ToObject on the base — is
+// unconditional, and it runs before step 3.c converts the referenced name with
+// ToPropertyKey. So a nullish base must still throw a TypeError here, and the key's
+// toString must never run.
+//
+// This file exists to cover the sloppy-only store path (OP_SET_INDEX_LOOSE in the
+// bytecode VM), which the default strict test profile never reaches.
+
+const capture = (fn) => {
+  let coercions = 0;
+  const key = {
+    toString() {
+      coercions++;
+      throw new Error("key side effect");
+    },
+  };
+  let error = null;
+  try {
+    fn(key);
+  } catch (e) {
+    error = e;
+  }
+  return { error, coercions };
+};
+
+describe("non-strict nullish-base computed access", () => {
+  test("computed write on a null base throws TypeError before coercing the key", () => {
+    const { error, coercions } = capture((key) => {
+      const base = null;
+      base[key] = 1;
+    });
+
+    expect(error instanceof TypeError).toBe(true);
+    expect(coercions).toBe(0);
+  });
+
+  test("computed write on an undefined base throws TypeError before coercing the key", () => {
+    const { error, coercions } = capture((key) => {
+      const base = undefined;
+      base[key] = 1;
+    });
+
+    expect(error instanceof TypeError).toBe(true);
+    expect(coercions).toBe(0);
+  });
+
+  test("destructuring into a nullish computed target throws TypeError before coercing the key", () => {
+    const { error, coercions } = capture((key) => {
+      const base = null;
+      [base[key]] = [1];
+    });
+
+    expect(error instanceof TypeError).toBe(true);
+    expect(coercions).toBe(0);
+  });
+
+  test("computed read on a nullish base throws TypeError before coercing the key", () => {
+    const { error, coercions } = capture((key) => {
+      const base = null;
+      return base[key];
+    });
+
+    expect(error instanceof TypeError).toBe(true);
+    expect(coercions).toBe(0);
+  });
+
+  test("increment on a nullish base throws TypeError before coercing the key", () => {
+    const { error, coercions } = capture((key) => {
+      const base = null;
+      base[key]++;
+    });
+
+    expect(error instanceof TypeError).toBe(true);
+    expect(coercions).toBe(0);
+  });
+
+  test("compound assignment on a nullish base throws TypeError before coercing the key", () => {
+    const { error, coercions } = capture((key) => {
+      const base = undefined;
+      base[key] += 1;
+    });
+
+    expect(error instanceof TypeError).toBe(true);
+    expect(coercions).toBe(0);
+  });
+
+  test("the nullish write message names the operation and the base", () => {
+    const { error } = capture((key) => {
+      const base = null;
+      base[key] = 1;
+    });
+
+    expect(error.message).toBe(
+      "Cannot set properties of null (setting '<computed>')"
+    );
+  });
+
+  test("a non-nullish base still writes and still coerces the key", () => {
+    let coercions = 0;
+    const key = {
+      toString() {
+        coercions++;
+        return "a";
+      },
+    };
+    const target = {};
+
+    target[key] = 1;
+
+    expect(target.a).toBe(1);
+    expect(coercions).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Per ES2026 §13.3.3 / §6.2.5.5–6, member access on a nullish base must throw `TypeError` before the property key is coerced (no `toString`/`valueOf` side effects). The interpreter coerced the key first on reads, writes, updates, compound assignment, and destructuring targets; the bytecode VM shared the bug on computed store and destructuring-target store, and produced wrong messages elsewhere. Matches V8; JSC deviates on the write path and was treated as the outlier.
- Both engines route through a shared throw-free-fast-path helper; the VM's five hand-copied checks collapse into one; `GOCCIA_FORMAT_VERSION` bumps 75→76 for the new `OP_VALIDATE_VALUE` sub-opcode; RHS-before-throw ordering for assignments is preserved and pinned.
- Surfaced by this stack's toThrow layer: the old matcher's substring fallback (`Pos('Error','TypeError') > 0`) had been masking this bug in two existing tests.

Part of the 0.11.0 adversarial-findings stacked-PR train (8 layers, each PR targets the layer below; merge bottom-up). Mini-spec: fix the differential-testing findings F1–F13/G4/G5 — JSX-transformer hang, toThrow semantics, Vitest matcher parity, coverage consistency, TS type-syntax gaps, AbortSignal events — and land the goccia-vs-bun differential battery harness as a CI gate, green at every layer.

## Testing

- [x] End-to-end tests — full suite green both modes; 17 side-effect-counter tests (member-access) + 8 sloppy-mode tests under the non-strict profile (proven by temporarily reverting the guard: 4/8 fail without it); exact message wording pinned for both engines
- [x] Updated documentation — spec-clause annotations at the implementation bodies
- [x] Optional: native Pascal tests — bytecode format history entry; no golden files exist
- [ ] Optional: benchmarks — fast path deliberately restructured to avoid managed locals/implicit exception frames; not separately benchmarked

Review: fresh-context review "fix-first" findings (format-version bump, sloppy-mode coverage) plus all minors resolved in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
